### PR TITLE
chore: fixing noir warnings

### DIFF
--- a/noir-projects/aztec-nr/address-note/src/address_note.nr
+++ b/noir-projects/aztec-nr/address-note/src/address_note.nr
@@ -22,5 +22,9 @@ impl AddressNote {
         let randomness = unsafe { random() };
         AddressNote { address, owner, randomness }
     }
+
+    pub fn get_address(self) -> AztecAddress {
+        self.address
+    }
 }
 // docs:end:address_note_def

--- a/noir-projects/aztec-nr/aztec/src/context/private_context.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/private_context.nr
@@ -550,7 +550,9 @@ impl PrivateContext {
         };
     }
 
-    fn next_counter(&mut self) -> u32 {
+    // This function got exposed publicly to be able to access it in ContractClassRegistry.
+    // TODO: Should we introduce an abstraction such that accessing this externally is not needed?
+    pub fn next_counter(&mut self) -> u32 {
         let counter = self.side_effect_counter;
         self.side_effect_counter += 1;
         counter

--- a/noir-projects/aztec-nr/aztec/src/context/private_context.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/private_context.nr
@@ -551,7 +551,8 @@ impl PrivateContext {
     }
 
     // This function got exposed publicly to be able to access it in ContractClassRegistry.
-    // TODO: Should we introduce an abstraction such that accessing this externally is not needed?
+    // TODO(#15980): Implement a method for pushing contract class log hashes to the context and un-expose this
+    // function.
     pub fn next_counter(&mut self) -> u32 {
         let counter = self.side_effect_counter;
         self.side_effect_counter += 1;

--- a/noir-projects/aztec-nr/aztec/src/context/public_context.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/public_context.nr
@@ -321,7 +321,10 @@ unconstrained fn l1_to_l2_msg_exists(msg_hash: Field, msg_leaf_index: u64) -> u1
 unconstrained fn send_l2_to_l1_msg(recipient: EthAddress, content: Field) {
     send_l2_to_l1_msg_opcode(recipient, content)
 }
-unconstrained fn call(
+
+// This function is temporarily exposed publicly to be able to test it in AVMTest contract.
+// TODO: Refactor tests to keep this implementation detail private within the crate.
+pub unconstrained fn call(
     l2_gas_allocation: u32,
     da_gas_allocation: u32,
     address: AztecAddress,
@@ -344,15 +347,22 @@ pub unconstrained fn calldata_copy<let N: u32>(cdoffset: u32, copy_size: u32) ->
 }
 
 // `success_copy` is placed immediately after the CALL opcode to get the success value
-unconstrained fn success_copy() -> bool {
+//
+// This function is temporarily exposed publicly to be able to test it in AVMTest contract.
+// TODO: Refactor tests to keep this implementation detail private within the crate.
+pub unconstrained fn success_copy() -> bool {
     success_copy_opcode()
 }
 
-unconstrained fn returndata_size() -> u32 {
+// This function is temporarily exposed publicly to be able to test it in AVMTest contract.
+// TODO: Refactor tests to keep this implementation detail private within the crate.
+pub unconstrained fn returndata_size() -> u32 {
     returndata_size_opcode()
 }
 
-unconstrained fn returndata_copy(rdoffset: u32, copy_size: u32) -> [Field] {
+// This function is temporarily exposed publicly to be able to test it in AVMTest contract.
+// TODO: Refactor tests to keep this implementation detail private within the crate.
+pub unconstrained fn returndata_copy(rdoffset: u32, copy_size: u32) -> [Field] {
     returndata_copy_opcode(rdoffset, copy_size)
 }
 
@@ -364,7 +374,10 @@ pub unconstrained fn avm_return(returndata: [Field]) {
 // to do rethrows, where the revert data is the same as the original revert data.
 // For normal reverts, use Noir's `assert` which, on top of reverting, will also add
 // an error selector to the revert data.
-unconstrained fn avm_revert(revertdata: [Field]) {
+//
+// This function is temporarily exposed publicly to be able to test it in AVMTest contract.
+// TODO: Refactor tests to keep this implementation detail private within the crate.
+pub unconstrained fn avm_revert(revertdata: [Field]) {
     revert_opcode(revertdata)
 }
 

--- a/noir-projects/aztec-nr/aztec/src/context/public_context.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/public_context.nr
@@ -323,7 +323,7 @@ unconstrained fn send_l2_to_l1_msg(recipient: EthAddress, content: Field) {
 }
 
 // This function is temporarily exposed publicly to be able to test it in AVMTest contract.
-// TODO: Refactor tests to keep this implementation detail private within the crate.
+// TODO(#15980): Refactor tests to keep this implementation detail private within the crate.
 pub unconstrained fn call(
     l2_gas_allocation: u32,
     da_gas_allocation: u32,

--- a/noir-projects/aztec-nr/aztec/src/macros/functions/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/functions/mod.nr
@@ -1,7 +1,7 @@
 pub(crate) mod abi_export;
 pub(crate) mod call_interface_stubs;
-// Note: The following was exported out of the crate only because it's tested by the StatefulTest contract. This is not
-// great and ideally we would just test it within this crate.
+// TODO: Move initialization_utils out of this crate
+// See https://github.com/AztecProtocol/aztec-packages/pull/15856#discussion_r2229134689 for more details
 pub mod initialization_utils;
 pub(crate) mod stub_registry;
 pub(crate) mod auth_registry;

--- a/noir-projects/aztec-nr/aztec/src/macros/functions/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/functions/mod.nr
@@ -1,6 +1,8 @@
 pub(crate) mod abi_export;
 pub(crate) mod call_interface_stubs;
-pub(crate) mod initialization_utils;
+// Note: The following was exported out of the crate only because it's tested by the StatefulTest contract. This is not
+// great and ideally we would just test it within this crate.
+pub mod initialization_utils;
 pub(crate) mod stub_registry;
 pub(crate) mod auth_registry;
 pub(crate) mod utils;

--- a/noir-projects/aztec-nr/aztec/src/note/note_emission.nr
+++ b/noir-projects/aztec-nr/aztec/src/note/note_emission.nr
@@ -29,7 +29,7 @@ impl<Note> NoteEmission<Note> {
  * a change note in a token's transfer function only when there is "change" left).
  */
 pub struct OuterNoteEmission<Note> {
-    emission: Option<NoteEmission<Note>>,
+    pub emission: Option<NoteEmission<Note>>,
 }
 
 impl<Note> OuterNoteEmission<Note> {

--- a/noir-projects/aztec-nr/aztec/src/test/mocks/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/mocks/mod.nr
@@ -1,2 +1,2 @@
-pub(crate) mod mock_note;
-pub(crate) mod mock_struct;
+pub mod mock_note;
+pub mod mock_struct;

--- a/noir-projects/aztec-nr/aztec/src/test/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/mod.nr
@@ -1,2 +1,2 @@
 pub mod helpers;
-pub(crate) mod mocks;
+pub mod mocks;

--- a/noir-projects/aztec-nr/easy-private-state/src/easy_private_uint.nr
+++ b/noir-projects/aztec-nr/easy-private-state/src/easy_private_uint.nr
@@ -1,11 +1,11 @@
 use dep::aztec::{
-    context::PrivateContext,
+    context::{PrivateContext, UtilityContext},
     messages::logs::note::encode_and_encrypt_note,
     note::note_getter_options::NoteGetterOptions,
     protocol_types::address::AztecAddress,
     state_vars::{PrivateSet, storage::HasStorageSlot},
 };
-use dep::value_note::{filter::filter_notes_min_sum, value_note::ValueNote};
+use dep::value_note::{balance_utils, filter::filter_notes_min_sum, value_note::ValueNote};
 
 pub struct EasyPrivateUint<Context> {
     context: Context,
@@ -59,5 +59,11 @@ impl EasyPrivateUint<&mut PrivateContext> {
         let result_value = minuend - subtrahend;
         let result_note = ValueNote::new(result_value as Field, owner);
         self.set.insert(result_note).emit(encode_and_encrypt_note(self.context, owner));
+    }
+}
+
+impl EasyPrivateUint<UtilityContext> {
+    pub unconstrained fn value(self) -> Field {
+        balance_utils::get_balance(self.set)
     }
 }

--- a/noir-projects/aztec-nr/easy-private-state/src/easy_private_uint.nr
+++ b/noir-projects/aztec-nr/easy-private-state/src/easy_private_uint.nr
@@ -63,7 +63,7 @@ impl EasyPrivateUint<&mut PrivateContext> {
 }
 
 impl EasyPrivateUint<UtilityContext> {
-    pub unconstrained fn value(self) -> Field {
+    pub unconstrained fn get_value(self) -> Field {
         balance_utils::get_balance(self.set)
     }
 }

--- a/noir-projects/aztec-nr/uint-note/src/uint_note.nr
+++ b/noir-projects/aztec-nr/uint-note/src/uint_note.nr
@@ -212,7 +212,7 @@ impl NoteType for PrivateUintPartialNotePrivateLogContent {
 /// of course that its value is known).
 #[derive(Packable, Serialize, Deserialize, Eq)]
 pub struct PartialUintNote {
-    pub commitment: Field,
+    commitment: Field,
 }
 
 global NOTE_COMPLETION_LOG_LENGTH: u32 = 2;
@@ -333,7 +333,7 @@ mod test {
     };
     use dep::aztec::{
         note::note_interface::NoteHash,
-        protocol_types::{address::AztecAddress, traits::{FromField, Packable}},
+        protocol_types::{address::AztecAddress, traits::{Deserialize, FromField, Packable}},
         utils::array::subarray,
     };
 
@@ -377,7 +377,9 @@ mod test {
             randomness,
             public_log_tag: commitment,
         };
-        let partial_note = PartialUintNote { commitment };
+        // The following is a misuse of the `deserialize` function, but this is just a test and it's better than
+        // letting devs manually construct it when they shouldn't be able to.
+        let partial_note = PartialUintNote::deserialize([commitment]);
 
         // The first field of the partial note private content is the public completion log tag, so it should match the
         // first field of the public log.

--- a/noir-projects/aztec-nr/uint-note/src/uint_note.nr
+++ b/noir-projects/aztec-nr/uint-note/src/uint_note.nr
@@ -104,6 +104,10 @@ impl UintNote {
         self.value
     }
 
+    pub fn get_owner(self) -> AztecAddress {
+        self.owner
+    }
+
     /// Creates a partial note that will hide the owner and storage slot but not the value, since the note will be later
     /// completed in public. This is a powerful technique for scenarios in which the value cannot be known in private
     /// (e.g. because it depends on some public state, such as a DEX).

--- a/noir-projects/aztec-nr/uint-note/src/uint_note.nr
+++ b/noir-projects/aztec-nr/uint-note/src/uint_note.nr
@@ -212,7 +212,7 @@ impl NoteType for PrivateUintPartialNotePrivateLogContent {
 /// of course that its value is known).
 #[derive(Packable, Serialize, Deserialize, Eq)]
 pub struct PartialUintNote {
-    commitment: Field,
+    pub commitment: Field,
 }
 
 global NOTE_COMPLETION_LOG_LENGTH: u32 = 2;

--- a/noir-projects/aztec-nr/value-note/src/lib.nr
+++ b/noir-projects/aztec-nr/value-note/src/lib.nr
@@ -1,4 +1,4 @@
-mod balance_utils;
+pub mod balance_utils;
 mod filter;
 mod utils;
 mod value_note;

--- a/noir-projects/noir-contracts/contracts/account/schnorr_account_contract/src/public_key_note.nr
+++ b/noir-projects/noir-contracts/contracts/account/schnorr_account_contract/src/public_key_note.nr
@@ -5,9 +5,9 @@ use aztec::{macros::notes::note, protocol_types::{address::AztecAddress, traits:
 #[derive(Eq, Packable)]
 #[note]
 pub struct PublicKeyNote {
-    x: Field,
-    y: Field,
-    owner: AztecAddress,
+    pub x: Field,
+    pub y: Field,
+    pub owner: AztecAddress,
 }
 
 impl PublicKeyNote {

--- a/noir-projects/noir-contracts/contracts/account/schnorr_single_key_account_contract/src/auth_oracle.nr
+++ b/noir-projects/noir-contracts/contracts/account/schnorr_single_key_account_contract/src/auth_oracle.nr
@@ -6,9 +6,9 @@ use std::meta::derive;
 
 #[derive(Deserialize)]
 pub struct AuthWitness {
-    keys: PublicKeys,
-    signature: [u8; 64],
-    partial_address: PartialAddress,
+    pub keys: PublicKeys,
+    pub signature: [u8; 64],
+    pub partial_address: PartialAddress,
 }
 
 pub unconstrained fn get_auth_witness(message_hash: Field) -> AuthWitness {

--- a/noir-projects/noir-contracts/contracts/app/app_subscription_contract/src/dapp_payload.nr
+++ b/noir-projects/noir-contracts/contracts/app/app_subscription_contract/src/dapp_payload.nr
@@ -47,7 +47,7 @@ impl DAppPayload {
 
     // Executes all private and public calls
     // docs:start:entrypoint-execute-calls
-    fn execute_calls(self, context: &mut PrivateContext, target_address: AztecAddress) {
+    pub fn execute_calls(self, context: &mut PrivateContext, target_address: AztecAddress) {
         for i in 0..DAPP_MAX_CALLS {
             let call = self.function_calls[i];
             // whitelist the calls that the user can do only go to the expected Dapp contract

--- a/noir-projects/noir-contracts/contracts/app/app_subscription_contract/src/subscription_note.nr
+++ b/noir-projects/noir-contracts/contracts/app/app_subscription_contract/src/subscription_note.nr
@@ -8,8 +8,8 @@ use aztec::{
 #[note]
 pub struct SubscriptionNote {
     owner: AztecAddress,
-    expiry_block_number: u32,
-    remaining_txs: u32,
+    pub expiry_block_number: u32,
+    pub remaining_txs: u32,
     // Randomness of the note to protect against note hash preimage attacks
     randomness: Field,
 }

--- a/noir-projects/noir-contracts/contracts/app/card_game_contract/src/cards.nr
+++ b/noir-projects/noir-contracts/contracts/app/card_game_contract/src/cards.nr
@@ -140,9 +140,7 @@ impl Deck<UtilityContext> {
         let mut options = NoteViewerOptions::new();
         let notes = self.set.view_notes(options.set_offset(offset));
 
-        let cards = notes.map(|note| Card::from_field(note.value()));
-
-        cards
+        notes.map(|note| Card::from_field(note.value()))
     }
 }
 

--- a/noir-projects/noir-contracts/contracts/app/card_game_contract/src/cards.nr
+++ b/noir-projects/noir-contracts/contracts/app/card_game_contract/src/cards.nr
@@ -24,8 +24,8 @@ use std::meta::derive;
 #[derive(Packable, Serialize)]
 pub struct Card {
     // We use u32s since u16s are unsupported
-    strength: u32,
-    points: u32,
+    pub strength: u32,
+    pub points: u32,
 }
 
 impl FromField for Card {
@@ -68,7 +68,7 @@ impl CardNote {
     }
 
     pub fn from_note(note: ValueNote) -> CardNote {
-        CardNote { card: Card::from_field(note.value), note }
+        CardNote { card: Card::from_field(note.value()), note }
     }
 }
 
@@ -140,13 +140,7 @@ impl Deck<UtilityContext> {
         let mut options = NoteViewerOptions::new();
         let notes = self.set.view_notes(options.set_offset(offset));
 
-        // TODO: ideally we'd do let cards = notes.map(|note| Cards::from_field(note.value));
-        // see https://github.com/noir-lang/noir/pull/5250
-        let mut cards = BoundedVec::new();
-        cards.len = notes.len();
-        for i in 0..notes.len() {
-            cards.storage[i] = Card::from_field(notes.get_unchecked(i).value);
-        }
+        let cards = notes.map(|note| Card::from_field(note.value()));
 
         cards
     }

--- a/noir-projects/noir-contracts/contracts/app/card_game_contract/src/game.nr
+++ b/noir-projects/noir-contracts/contracts/app/card_game_contract/src/game.nr
@@ -7,9 +7,9 @@ global NUMBER_OF_CARDS_DECK: u32 = 2;
 
 #[derive(Deserialize, Eq, Packable)]
 pub struct PlayerEntry {
-    address: AztecAddress,
-    deck_strength: u32,
-    points: u64,
+    pub address: AztecAddress,
+    pub deck_strength: u32,
+    pub points: u64,
 }
 
 impl PlayerEntry {
@@ -18,15 +18,15 @@ impl PlayerEntry {
     }
 }
 
-global PLAYABLE_CARDS: u32 = 4;
+pub global PLAYABLE_CARDS: u32 = 4;
 
 #[derive(Packable)]
 pub struct Game {
     players: [PlayerEntry; NUMBER_OF_PLAYERS],
-    rounds_cards: [Card; PLAYABLE_CARDS],
+    pub rounds_cards: [Card; PLAYABLE_CARDS],
     started: bool,
     finished: bool,
-    claimed: bool,
+    pub claimed: bool,
     current_player: u32,
     current_round: u32,
 }

--- a/noir-projects/noir-contracts/contracts/app/claim_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/claim_contract/src/main.nr
@@ -41,7 +41,7 @@ pub contract Claim {
             "Note does not correspond to the target contract",
         );
         assert_eq(
-            proof_retrieved_note.note.owner,
+            proof_retrieved_note.note.get_owner(),
             context.msg_sender(),
             "Note does not belong to the sender",
         );
@@ -67,7 +67,7 @@ pub contract Claim {
 
         // 4) Finally we mint the reward token to the sender of the transaction
         Token::at(storage.reward_token.read())
-            .mint_to_public(recipient, proof_retrieved_note.note.value)
+            .mint_to_public(recipient, proof_retrieved_note.note.get_value())
             .enqueue(&mut context);
     }
 }

--- a/noir-projects/noir-contracts/contracts/app/easy_private_token_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/easy_private_token_contract/src/main.nr
@@ -43,7 +43,7 @@ pub contract EasyPrivateToken {
     // Helper function to get the balance of a user.
     #[utility]
     unconstrained fn get_balance(owner: AztecAddress) -> Field {
-        storage.balances.at(owner).value()
+        storage.balances.at(owner).get_value()
     }
 }
 // docs:end:easy_private_token_contract

--- a/noir-projects/noir-contracts/contracts/app/easy_private_token_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/easy_private_token_contract/src/main.nr
@@ -6,7 +6,6 @@ pub contract EasyPrivateToken {
     use dep::aztec::macros::{functions::{initializer, private, utility}, storage::storage};
     use dep::aztec::{protocol_types::address::AztecAddress, state_vars::Map};
     use dep::easy_private_state::EasyPrivateUint;
-    use dep::value_note::balance_utils;
 
     #[storage]
     struct Storage<Context> {
@@ -44,10 +43,7 @@ pub contract EasyPrivateToken {
     // Helper function to get the balance of a user.
     #[utility]
     unconstrained fn get_balance(owner: AztecAddress) -> Field {
-        let balances = storage.balances;
-
-        // Return the sum of all notes in the set.
-        balance_utils::get_balance(balances.at(owner).set)
+        storage.balances.at(owner).value()
     }
 }
 // docs:end:easy_private_token_contract

--- a/noir-projects/noir-contracts/contracts/app/escrow_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/escrow_contract/src/main.nr
@@ -35,7 +35,7 @@ pub contract Escrow {
         let sender = context.msg_sender();
 
         let note = storage.owner.get_note();
-        assert(note.address == sender);
+        assert(note.get_address() == sender);
         // docs:start:call_function
         Token::at(token).transfer(recipient, amount).call(&mut context);
         // docs:end:call_function

--- a/noir-projects/noir-contracts/contracts/app/lending_contract/src/asset.nr
+++ b/noir-projects/noir-contracts/contracts/app/lending_contract/src/asset.nr
@@ -11,8 +11,8 @@ use std::meta::derive;
 /// up rewriting all the values.
 #[derive(Deserialize, Packable, Serialize)]
 pub struct Asset {
-    interest_accumulator: u128,
-    last_updated_ts: u64,
-    loan_to_value: u128,
-    oracle: AztecAddress,
+    pub interest_accumulator: u128,
+    pub last_updated_ts: u64,
+    pub loan_to_value: u128,
+    pub oracle: AztecAddress,
 }

--- a/noir-projects/noir-contracts/contracts/app/lending_contract/src/helpers.nr
+++ b/noir-projects/noir-contracts/contracts/app/lending_contract/src/helpers.nr
@@ -33,8 +33,8 @@ pub fn covered_by_collateral(
 }
 
 pub struct DebtReturn {
-    debt_value: u128,
-    static_debt: u128,
+    pub debt_value: u128,
+    pub static_debt: u128,
 }
 
 fn div_up(a: u128, b: u128) -> u128 {

--- a/noir-projects/noir-contracts/contracts/app/lending_contract/src/interest_math.nr
+++ b/noir-projects/noir-contracts/contracts/app/lending_contract/src/interest_math.nr
@@ -1,4 +1,4 @@
-use std::ops::{Add, Div, Mul, Sub};
+use std::ops::{Add, Div, Mul};
 
 // Binomial approximation of exponential
 // using lower than desired precisions for everything due to u128 limit

--- a/noir-projects/noir-contracts/contracts/app/lending_contract/src/position.nr
+++ b/noir-projects/noir-contracts/contracts/app/lending_contract/src/position.nr
@@ -3,7 +3,7 @@ use std::meta::derive;
 
 #[derive(Serialize, Deserialize)]
 pub struct Position {
-    collateral: u128,
-    static_debt: u128,
-    debt: u128,
+    pub collateral: u128,
+    pub static_debt: u128,
+    pub debt: u128,
 }

--- a/noir-projects/noir-contracts/contracts/app/nft_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/nft_contract/src/main.nr
@@ -13,7 +13,6 @@ pub contract NFT {
         authwit::auth::compute_authwit_nullifier,
         context::{PrivateContext, PublicContext},
         macros::{
-            events::event,
             functions::{authorize_once, initializer, internal, private, public, utility, view},
             storage::storage,
         },
@@ -32,12 +31,12 @@ pub contract NFT {
 
     // TODO(#8467): Rename this to Transfer - calling this NFTTransfer to avoid export conflict with the Transfer event
     // in the Token contract.
-    #[event]
-    struct NFTTransfer {
-        from: AztecAddress,
-        to: AztecAddress,
-        token_id: Field,
-    }
+    // #[event]
+    // struct NFTTransfer {
+    //     from: AztecAddress,
+    //     to: AztecAddress,
+    //     token_id: Field,
+    // }
 
     // docs:start:storage_struct
     #[storage]
@@ -357,7 +356,7 @@ pub contract NFT {
         let mut owned_nft_ids = [0; MAX_NOTES_PER_PAGE];
         for i in 0..options.limit {
             if i < notes.len() {
-                owned_nft_ids[i] = notes.get_unchecked(i).token_id;
+                owned_nft_ids[i] = notes.get_unchecked(i).get_token_id();
             }
         }
 

--- a/noir-projects/noir-contracts/contracts/app/nft_contract/src/test/transfer_to_private.nr
+++ b/noir-projects/noir-contracts/contracts/app/nft_contract/src/test/transfer_to_private.nr
@@ -1,5 +1,5 @@
 use crate::{NFT, test::utils, types::nft_note::PartialNFTNote};
-use aztec::{oracle::random::random, protocol_types::address::AztecAddress};
+use aztec::{oracle::random::random, protocol_types::{address::AztecAddress, traits::Deserialize}};
 
 /// Internal orchestration means that the calls to `prepare_private_balance_increase`
 /// and `finalize_transfer_to_private` are done by the NFT contract itself.
@@ -56,7 +56,8 @@ unconstrained fn transfer_to_private_transfer_not_prepared() {
         utils::setup_and_mint(/* with_account_contracts */ false);
 
     // Transfer was not prepared so we can use random value for the partial note
-    let partial_note = PartialNFTNote { commitment: random() };
+    let commitment = random();
+    let partial_note = PartialNFTNote::deserialize([commitment]);
 
     // Try finalizing the transfer without preparing it
     let _ = env.call_public(

--- a/noir-projects/noir-contracts/contracts/app/nft_contract/src/test/transfer_to_private.nr
+++ b/noir-projects/noir-contracts/contracts/app/nft_contract/src/test/transfer_to_private.nr
@@ -1,8 +1,5 @@
 use crate::{NFT, test::utils, types::nft_note::PartialNFTNote};
-use dep::aztec::{
-    oracle::random::random,
-    protocol_types::{address::AztecAddress, traits::FromField},
-};
+use aztec::{oracle::random::random, protocol_types::address::AztecAddress};
 
 /// Internal orchestration means that the calls to `prepare_private_balance_increase`
 /// and `finalize_transfer_to_private` are done by the NFT contract itself.
@@ -59,8 +56,7 @@ unconstrained fn transfer_to_private_transfer_not_prepared() {
         utils::setup_and_mint(/* with_account_contracts */ false);
 
     // Transfer was not prepared so we can use random value for the partial note
-    let commitment = random();
-    let partial_note = PartialNFTNote::from_field(commitment);
+    let partial_note = PartialNFTNote { commitment: random() };
 
     // Try finalizing the transfer without preparing it
     let _ = env.call_public(

--- a/noir-projects/noir-contracts/contracts/app/nft_contract/src/test/transfer_to_private.nr
+++ b/noir-projects/noir-contracts/contracts/app/nft_contract/src/test/transfer_to_private.nr
@@ -1,5 +1,8 @@
 use crate::{NFT, test::utils, types::nft_note::PartialNFTNote};
-use dep::aztec::{oracle::random::random, protocol_types::address::AztecAddress};
+use dep::aztec::{
+    oracle::random::random,
+    protocol_types::{address::AztecAddress, traits::FromField},
+};
 
 /// Internal orchestration means that the calls to `prepare_private_balance_increase`
 /// and `finalize_transfer_to_private` are done by the NFT contract itself.
@@ -56,7 +59,8 @@ unconstrained fn transfer_to_private_transfer_not_prepared() {
         utils::setup_and_mint(/* with_account_contracts */ false);
 
     // Transfer was not prepared so we can use random value for the partial note
-    let partial_note = PartialNFTNote { commitment: random() };
+    let commitment = random();
+    let partial_note = PartialNFTNote::from_field(commitment);
 
     // Try finalizing the transfer without preparing it
     let _ = env.call_public(

--- a/noir-projects/noir-contracts/contracts/app/nft_contract/src/test/utils.nr
+++ b/noir-projects/noir-contracts/contracts/app/nft_contract/src/test/utils.nr
@@ -1,8 +1,7 @@
 use crate::NFT;
 use aztec::{
-    oracle::{execution::get_contract_address, notes::set_sender_for_tags},
-    protocol_types::address::AztecAddress,
-    test::helpers::{test_environment::TestEnvironment, txe_oracles},
+    oracle::notes::set_sender_for_tags, protocol_types::address::AztecAddress,
+    test::helpers::test_environment::TestEnvironment,
 };
 
 pub unconstrained fn setup(

--- a/noir-projects/noir-contracts/contracts/app/nft_contract/src/types/nft_note.nr
+++ b/noir-projects/noir-contracts/contracts/app/nft_contract/src/types/nft_note.nr
@@ -208,7 +208,7 @@ impl NoteType for PrivateNFTPartialNotePrivateLogContent {
 /// of course that its token id is known).
 #[derive(Packable, Serialize, Deserialize)]
 pub struct PartialNFTNote {
-    commitment: Field,
+    pub commitment: Field,
 }
 
 impl PartialNFTNote {

--- a/noir-projects/noir-contracts/contracts/app/nft_contract/src/types/nft_note.nr
+++ b/noir-projects/noir-contracts/contracts/app/nft_contract/src/types/nft_note.nr
@@ -208,7 +208,7 @@ impl NoteType for PrivateNFTPartialNotePrivateLogContent {
 /// of course that its token id is known).
 #[derive(Packable, Serialize, Deserialize)]
 pub struct PartialNFTNote {
-    pub commitment: Field,
+    commitment: Field,
 }
 
 impl PartialNFTNote {
@@ -271,7 +271,7 @@ mod test {
     };
     use dep::aztec::{
         note::note_interface::NoteHash,
-        protocol_types::{address::AztecAddress, traits::{FromField, Packable}},
+        protocol_types::{address::AztecAddress, traits::{Deserialize, FromField, Packable}},
         utils::array::subarray,
     };
 
@@ -315,7 +315,9 @@ mod test {
             randomness,
             public_log_tag: commitment,
         };
-        let partial_note = PartialNFTNote { commitment };
+        // The following is a misuse of the `deserialize` function, but this is just a test and it's better than
+        // letting devs manually construct it when they shouldn't be able to.
+        let partial_note = PartialNFTNote::deserialize([commitment]);
 
         // The first field of the partial note private content is the public completion log tag, so it should match the
         // first field of the public log.

--- a/noir-projects/noir-contracts/contracts/app/price_feed_contract/src/asset.nr
+++ b/noir-projects/noir-contracts/contracts/app/price_feed_contract/src/asset.nr
@@ -3,5 +3,5 @@ use std::meta::derive;
 
 #[derive(Deserialize, Packable, Serialize)]
 pub struct Asset {
-    price: u128,
+    pub price: u128,
 }

--- a/noir-projects/noir-contracts/contracts/app/token_blacklist_contract/src/types/mod.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_blacklist_contract/src/types/mod.nr
@@ -1,4 +1,4 @@
 mod transparent_note;
 mod balances_map;
-mod token_note;
+pub(crate) mod token_note;
 mod roles;

--- a/noir-projects/noir-contracts/contracts/app/token_blacklist_contract/src/types/mod.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_blacklist_contract/src/types/mod.nr
@@ -1,4 +1,4 @@
-mod transparent_note;
-mod balances_map;
+pub(crate) mod transparent_note;
+pub(crate) mod balances_map;
 pub(crate) mod token_note;
-mod roles;
+pub(crate) mod roles;

--- a/noir-projects/noir-contracts/contracts/app/token_blacklist_contract/src/types/roles.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_blacklist_contract/src/types/roles.nr
@@ -1,4 +1,4 @@
-use dep::aztec::protocol_types::traits::{Deserialize, FromField, Packable, Serialize, ToField};
+use dep::aztec::protocol_types::traits::{Deserialize, Packable, Serialize, ToField};
 use std::meta::derive;
 
 global ADMIN_FLAG: u64 = 1;
@@ -7,9 +7,9 @@ global BLACKLIST_FLAG: u64 = 4;
 
 #[derive(Deserialize, Eq, Serialize)]
 pub struct UserFlags {
-    is_admin: bool,
-    is_minter: bool,
-    is_blacklisted: bool,
+    pub is_admin: bool,
+    pub is_minter: bool,
+    pub is_blacklisted: bool,
 }
 
 impl Packable for UserFlags {

--- a/noir-projects/noir-contracts/contracts/app/token_blacklist_contract/src/types/token_note.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_blacklist_contract/src/types/token_note.nr
@@ -4,7 +4,7 @@ use aztec::{
     protocol_types::{address::AztecAddress, traits::Packable},
 };
 
-trait OwnedNote {
+pub trait OwnedNote {
     fn new(amount: u128, owner: AztecAddress) -> Self;
     fn get_amount(self) -> u128;
 }

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/test/burn_public.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/test/burn_public.nr
@@ -9,7 +9,10 @@ unconstrained fn burn_public_success() {
     let burn_amount = mint_amount / (10 as u128);
 
     // Burn less than balance
-    env.call_public(owner, Token::at(token_contract_address).burn_public(owner, burn_amount, 0));
+    let _ = env.call_public(
+        owner,
+        Token::at(token_contract_address).burn_public(owner, burn_amount, 0),
+    );
     utils::check_public_balance(
         env,
         token_contract_address,

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/test/transfer_to_private.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/test/transfer_to_private.nr
@@ -1,5 +1,5 @@
 use crate::{test::utils, Token};
-use dep::aztec::oracle::random::random;
+use dep::aztec::{oracle::random::random, protocol_types::traits::Deserialize};
 use dep::uint_note::uint_note::PartialUintNote;
 
 /// Internal orchestration means that the calls to `prepare_private_balance_increase`
@@ -82,7 +82,10 @@ unconstrained fn transfer_to_private_transfer_not_prepared() {
         utils::setup_and_mint_to_public(/* with_account_contracts */ false);
 
     // Transfer was not prepared so we can use random value for the partial note
-    let partial_uint_note = PartialUintNote { commitment: random() };
+    // The following is a misuse of the `deserialize` function, but this is just a test and it's better than
+    // letting devs manually construct it when they shouldn't be able to.
+    let commitment = random();
+    let partial_uint_note = PartialUintNote::deserialize([commitment]);
 
     // Try finalizing the transfer without preparing it
     let _ = env.call_public(

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/test/transfer_to_private.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/test/transfer_to_private.nr
@@ -1,5 +1,5 @@
 use crate::{test::utils, Token};
-use aztec::{oracle::random::random, protocol_types::traits::FromField};
+use aztec::oracle::random::random;
 use uint_note::uint_note::PartialUintNote;
 
 /// Internal orchestration means that the calls to `prepare_private_balance_increase`
@@ -82,9 +82,7 @@ unconstrained fn transfer_to_private_transfer_not_prepared() {
         utils::setup_and_mint_to_public(/* with_account_contracts */ false);
 
     // Transfer was not prepared so we can use random value for the partial note
-    let commitment = random();
-    // We use `from_field` because the PartialUintNote's commitment field is private. Don't judge. It's just a test.
-    let partial_uint_note = PartialUintNote::from_field(commitment);
+    let partial_uint_note = PartialUintNote { commitment: random() };
 
     // Try finalizing the transfer without preparing it
     let _ = env.call_public(

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/test/transfer_to_private.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/test/transfer_to_private.nr
@@ -1,6 +1,6 @@
 use crate::{test::utils, Token};
-use aztec::oracle::random::random;
-use uint_note::uint_note::PartialUintNote;
+use dep::aztec::oracle::random::random;
+use dep::uint_note::uint_note::PartialUintNote;
 
 /// Internal orchestration means that the calls to `prepare_private_balance_increase`
 /// and `finalize_transfer_to_private` are done by the TOKEN contract itself.

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/test/transfer_to_private.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/test/transfer_to_private.nr
@@ -1,6 +1,6 @@
 use crate::{test::utils, Token};
-use dep::aztec::oracle::random::random;
-use dep::uint_note::uint_note::PartialUintNote;
+use aztec::{oracle::random::random, protocol_types::traits::FromField};
+use uint_note::uint_note::PartialUintNote;
 
 /// Internal orchestration means that the calls to `prepare_private_balance_increase`
 /// and `finalize_transfer_to_private` are done by the TOKEN contract itself.
@@ -82,7 +82,9 @@ unconstrained fn transfer_to_private_transfer_not_prepared() {
         utils::setup_and_mint_to_public(/* with_account_contracts */ false);
 
     // Transfer was not prepared so we can use random value for the partial note
-    let partial_uint_note = PartialUintNote { commitment: random() };
+    let commitment = random();
+    // We use `from_field` because the PartialUintNote's commitment field is private. Don't judge. It's just a test.
+    let partial_uint_note = PartialUintNote::from_field(commitment);
 
     // Try finalizing the transfer without preparing it
     let _ = env.call_public(

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/types/balance_set.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/types/balance_set.nr
@@ -195,7 +195,7 @@ mod test {
 
             let note =
                 recipient_balance_set.sub(recipient, smaller_note_value).emission.unwrap().note;
-            assert_eq(note.value, larger_note_value - smaller_note_value);
+            assert_eq(note.get_value(), larger_note_value - smaller_note_value);
         });
     }
 }

--- a/noir-projects/noir-contracts/contracts/app/uniswap_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/uniswap_contract/src/main.nr
@@ -55,7 +55,7 @@ pub contract Uniswap {
         secret_hash_for_L1_to_l2_message: Field,
         caller_on_L1: EthAddress,
         // nonce for someone to call swap on sender's behalf
-        nonce_for_swap_approval: Field,
+        _nonce_for_swap_approval: Field,
     ) {
         if (!sender.eq(context.msg_sender())) {
             assert_current_call_valid_authwit_public(&mut context, sender);

--- a/noir-projects/noir-contracts/contracts/docs/docs_example_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/docs/docs_example_contract/src/main.nr
@@ -98,8 +98,8 @@ pub contract DocsExample {
 
     // docs:start:initialize-private-mutable
     #[private]
-    fn initialize_private_immutable(randomness: Field, points: u8) {
-        let new_card = CardNote::new(points, randomness, context.msg_sender());
+    fn initialize_private_immutable(points: u8) {
+        let new_card = CardNote::new(points, context.msg_sender());
 
         storage.private_immutable.initialize(new_card).emit(encode_and_encrypt_note(
             &mut context,
@@ -123,8 +123,8 @@ pub contract DocsExample {
         // docs:start:state_vars-PrivateMutableGet
         let card = storage.legendary_card.get_note().note;
         // docs:end:state_vars-PrivateMutableGet
-        let points = card.points + 1;
-        let new_card = CardNote::new(points, card.randomness, context.msg_sender());
+        let points = card.get_points() + 1;
+        let new_card = CardNote::new(points, context.msg_sender());
 
         // docs:start:state_vars-PrivateMutableReplace
         storage.legendary_card.replace(new_card).emit(encode_and_encrypt_note(

--- a/noir-projects/noir-contracts/contracts/docs/docs_example_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/docs/docs_example_contract/src/main.nr
@@ -163,7 +163,7 @@ pub contract DocsExample {
     // contract library method to avoid compilation error.
     #[contract_library_method]
     // docs:start:simple_macro_example_expanded
-    fn simple_macro_example_expanded(
+    pub fn simple_macro_example_expanded(
         // ************************************************************
         // The private context inputs are made available to the circuit by the kernel
         // docs:start:context-example-inputs

--- a/noir-projects/noir-contracts/contracts/docs/docs_example_contract/src/options.nr
+++ b/noir-projects/noir-contracts/contracts/docs/docs_example_contract/src/options.nr
@@ -52,7 +52,7 @@ pub fn filter_min_points(
     let mut selected_cards = [Option::none(); MAX_NOTE_HASH_READ_REQUESTS_PER_CALL];
     let mut num_selected = 0;
     for i in 0..cards.len() {
-        if cards[i].is_some() & cards[i].unwrap_unchecked().note.points >= min_points {
+        if cards[i].is_some() & cards[i].unwrap_unchecked().note.get_points() >= min_points {
             selected_cards[num_selected] = cards[i];
             num_selected += 1;
         }

--- a/noir-projects/noir-contracts/contracts/docs/docs_example_contract/src/types.nr
+++ b/noir-projects/noir-contracts/contracts/docs/docs_example_contract/src/types.nr
@@ -1,2 +1,2 @@
-mod card_note;
-mod leader;
+pub(crate) mod card_note;
+pub(crate) mod leader;

--- a/noir-projects/noir-contracts/contracts/docs/docs_example_contract/src/types/card_note.nr
+++ b/noir-projects/noir-contracts/contracts/docs/docs_example_contract/src/types/card_note.nr
@@ -1,5 +1,6 @@
 use aztec::{
     macros::notes::note,
+    oracle::random::random,
     protocol_types::{address::AztecAddress, traits::{Deserialize, Packable, Serialize}},
 };
 
@@ -17,7 +18,17 @@ pub struct CardNote {
 // docs:end:state_vars-CardNote
 
 impl CardNote {
-    pub fn new(points: u8, randomness: Field, owner: AztecAddress) -> Self {
+    pub fn new(points: u8, owner: AztecAddress) -> Self {
+        // Safety: We use the randomness to preserve the privacy of the note recipient by preventing brute-forcing,
+        // so a malicious sender could use non-random values to make the note less private. But they already know
+        // the full note pre-image anyway, and so the recipient already trusts them to not disclose this
+        // information. We can therefore assume that the sender will cooperate in the random value generation.
+        let randomness = unsafe { random() };
+
         CardNote { points, randomness, owner }
+    }
+
+    pub fn get_points(self) -> u8 {
+        self.points
     }
 }

--- a/noir-projects/noir-contracts/contracts/docs/docs_example_contract/src/types/leader.nr
+++ b/noir-projects/noir-contracts/contracts/docs/docs_example_contract/src/types/leader.nr
@@ -4,6 +4,6 @@ use std::meta::derive;
 // Shows how to create a custom struct in Public
 #[derive(Deserialize, Eq, Packable, Serialize)]
 pub struct Leader {
-    account: AztecAddress,
-    points: u8,
+    pub account: AztecAddress,
+    pub points: u8,
 }

--- a/noir-projects/noir-contracts/contracts/protocol/contract_class_registry/src/events/class_published.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/contract_class_registry/src/events/class_published.nr
@@ -5,15 +5,15 @@ use dep::aztec::protocol_types::{
 use dep::aztec::protocol_types::traits::ToField;
 
 pub struct ContractClassPublished {
-    contract_class_id: ContractClassId,
-    version: Field,
-    artifact_hash: Field,
-    private_functions_root: Field,
-    packed_public_bytecode: [Field; MAX_PACKED_PUBLIC_BYTECODE_SIZE_IN_FIELDS],
+    pub contract_class_id: ContractClassId,
+    pub version: Field,
+    pub artifact_hash: Field,
+    pub private_functions_root: Field,
+    pub packed_public_bytecode: [Field; MAX_PACKED_PUBLIC_BYTECODE_SIZE_IN_FIELDS],
 }
 
 impl ContractClassPublished {
-    fn serialize_non_standard(
+    pub fn serialize_non_standard(
         self: Self,
     ) -> [Field; MAX_PACKED_PUBLIC_BYTECODE_SIZE_IN_FIELDS + 5] {
         let mut packed = [0; MAX_PACKED_PUBLIC_BYTECODE_SIZE_IN_FIELDS + 5];

--- a/noir-projects/noir-contracts/contracts/protocol/contract_class_registry/src/events/mod.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/contract_class_registry/src/events/mod.nr
@@ -1,3 +1,3 @@
-mod class_published;
-mod private_function_broadcasted;
-mod utility_function_broadcasted;
+pub(crate) mod class_published;
+pub(crate) mod private_function_broadcasted;
+pub(crate) mod utility_function_broadcasted;

--- a/noir-projects/noir-contracts/contracts/protocol/contract_class_registry/src/events/private_function_broadcasted.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/contract_class_registry/src/events/private_function_broadcasted.nr
@@ -14,29 +14,29 @@ use std::meta::derive;
 
 #[derive(Serialize)]
 pub struct InnerPrivateFunction {
-    selector: FunctionSelector,
-    metadata_hash: Field,
-    vk_hash: Field,
+    pub selector: FunctionSelector,
+    pub metadata_hash: Field,
+    pub vk_hash: Field,
 }
 
 #[derive(Serialize)]
 pub struct PrivateFunction {
-    selector: FunctionSelector,
-    metadata_hash: Field,
-    vk_hash: Field,
-    bytecode: [Field; MAX_PACKED_BYTECODE_SIZE_PER_PRIVATE_FUNCTION_IN_FIELDS],
+    pub selector: FunctionSelector,
+    pub metadata_hash: Field,
+    pub vk_hash: Field,
+    pub bytecode: [Field; MAX_PACKED_BYTECODE_SIZE_PER_PRIVATE_FUNCTION_IN_FIELDS],
 }
 
 // #[event]
 pub struct ClassPrivateFunctionBroadcasted {
-    contract_class_id: ContractClassId,
-    artifact_metadata_hash: Field,
-    utility_functions_artifact_tree_root: Field,
-    private_function_tree_sibling_path: [Field; FUNCTION_TREE_HEIGHT],
-    private_function_tree_leaf_index: Field,
-    artifact_function_tree_sibling_path: [Field; ARTIFACT_FUNCTION_TREE_MAX_HEIGHT],
-    artifact_function_tree_leaf_index: Field,
-    function: PrivateFunction,
+    pub contract_class_id: ContractClassId,
+    pub artifact_metadata_hash: Field,
+    pub utility_functions_artifact_tree_root: Field,
+    pub private_function_tree_sibling_path: [Field; FUNCTION_TREE_HEIGHT],
+    pub private_function_tree_leaf_index: Field,
+    pub artifact_function_tree_sibling_path: [Field; ARTIFACT_FUNCTION_TREE_MAX_HEIGHT],
+    pub artifact_function_tree_leaf_index: Field,
+    pub function: PrivateFunction,
 }
 
 impl ClassPrivateFunctionBroadcasted {

--- a/noir-projects/noir-contracts/contracts/protocol/contract_class_registry/src/events/private_function_broadcasted.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/contract_class_registry/src/events/private_function_broadcasted.nr
@@ -40,7 +40,7 @@ pub struct ClassPrivateFunctionBroadcasted {
 }
 
 impl ClassPrivateFunctionBroadcasted {
-    fn serialize_non_standard(
+    pub fn serialize_non_standard(
         self: Self,
     ) -> [Field; MAX_PACKED_BYTECODE_SIZE_PER_PRIVATE_FUNCTION_IN_FIELDS + CLASS_REGISTRY_PRIVATE_FUNCTION_BROADCASTED_ADDITIONAL_FIELDS] {
         let mut packed = [

--- a/noir-projects/noir-contracts/contracts/protocol/contract_class_registry/src/events/utility_function_broadcasted.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/contract_class_registry/src/events/utility_function_broadcasted.nr
@@ -14,29 +14,29 @@ use std::meta::derive;
 
 #[derive(Serialize)]
 pub struct InnerUtilityFunction {
-    selector: FunctionSelector,
-    metadata_hash: Field,
+    pub selector: FunctionSelector,
+    pub metadata_hash: Field,
 }
 
 #[derive(Serialize)]
 pub struct UtilityFunction {
-    selector: FunctionSelector,
-    metadata_hash: Field,
-    bytecode: [Field; MAX_PACKED_BYTECODE_SIZE_PER_UTILITY_FUNCTION_IN_FIELDS],
+    pub selector: FunctionSelector,
+    pub metadata_hash: Field,
+    pub bytecode: [Field; MAX_PACKED_BYTECODE_SIZE_PER_UTILITY_FUNCTION_IN_FIELDS],
 }
 
 // #[event]
 pub struct ClassUtilityFunctionBroadcasted {
-    contract_class_id: ContractClassId,
-    artifact_metadata_hash: Field,
-    private_functions_artifact_tree_root: Field,
-    artifact_function_tree_sibling_path: [Field; ARTIFACT_FUNCTION_TREE_MAX_HEIGHT],
-    artifact_function_tree_leaf_index: Field,
-    function: UtilityFunction,
+    pub contract_class_id: ContractClassId,
+    pub artifact_metadata_hash: Field,
+    pub private_functions_artifact_tree_root: Field,
+    pub artifact_function_tree_sibling_path: [Field; ARTIFACT_FUNCTION_TREE_MAX_HEIGHT],
+    pub artifact_function_tree_leaf_index: Field,
+    pub function: UtilityFunction,
 }
 
 impl ClassUtilityFunctionBroadcasted {
-    fn serialize_non_standard(
+    pub fn serialize_non_standard(
         self: Self,
     ) -> [Field; MAX_PACKED_BYTECODE_SIZE_PER_UTILITY_FUNCTION_IN_FIELDS + CLASS_REGISTRY_UTILITY_FUNCTION_BROADCASTED_ADDITIONAL_FIELDS] {
         let mut packed = [

--- a/noir-projects/noir-contracts/contracts/test/avm_gadgets_test_contract/Nargo.toml
+++ b/noir-projects/noir-contracts/contracts/test/avm_gadgets_test_contract/Nargo.toml
@@ -8,3 +8,4 @@ type = "contract"
 aztec = { path = "../../../../aztec-nr/aztec" }
 keccak256 = { tag = "v0.1.0", git = "https://github.com/noir-lang/keccak256" }
 sha256 = { tag = "v0.1.2", git = "https://github.com/noir-lang/sha256" }
+poseidon = { tag= "v0.1.1", git = "https://github.com/noir-lang/poseidon" }

--- a/noir-projects/noir-contracts/contracts/test/avm_gadgets_test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/avm_gadgets_test_contract/src/main.nr
@@ -11,12 +11,12 @@ contract AvmGadgetsTest {
 
     #[public]
     fn keccak_f1600(data: [u64; 25]) -> [u64; 25] {
-        std::hash::keccak::keccakf1600(data)
+        std::hash::keccakf1600(data)
     }
 
     #[public]
     fn poseidon2_hash(data: [Field; 10]) -> Field {
-        std::hash::poseidon2::Poseidon2::hash(data, data.len())
+        poseidon::poseidon2::Poseidon2::hash(data, data.len())
     }
 
     #[public]

--- a/noir-projects/noir-contracts/contracts/test/avm_test_contract/Nargo.toml
+++ b/noir-projects/noir-contracts/contracts/test/avm_test_contract/Nargo.toml
@@ -9,3 +9,4 @@ aztec = { path = "../../../../aztec-nr/aztec" }
 compressed_string = { path = "../../../../aztec-nr/compressed-string" }
 sha256 = { tag = "v0.1.2", git = "https://github.com/noir-lang/sha256" }
 keccak256 = { tag = "v0.1.0", git = "https://github.com/noir-lang/keccak256" }
+poseidon = { tag= "v0.1.1", git = "https://github.com/noir-lang/poseidon" }

--- a/noir-projects/noir-contracts/contracts/test/avm_test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/avm_test_contract/src/main.nr
@@ -32,6 +32,7 @@ pub contract AvmTest {
     };
     use dep::aztec::state_vars::Map;
     use dep::aztec::state_vars::PublicMutable;
+    use dep::aztec::state_vars::storage::HasStorageSlot;
     use dep::compressed_string::CompressedString;
     use aztec::protocol_types::traits::Serialize;
     use std::embedded_curve_ops::{EmbeddedCurvePoint, multi_scalar_mul};
@@ -85,7 +86,7 @@ pub contract AvmTest {
     fn set_storage_map(to: AztecAddress, amount: u32) -> Field {
         storage.map.at(to).write(amount);
         // returns storage slot for key
-        derive_storage_slot_in_map(storage.map.storage_slot, to)
+        derive_storage_slot_in_map(storage.map.get_storage_slot(), to)
     }
 
     #[public]
@@ -93,7 +94,7 @@ pub contract AvmTest {
         let new_balance = storage.map.at(to).read().add(amount);
         storage.map.at(to).write(new_balance);
         // returns storage slot for key
-        derive_storage_slot_in_map(storage.map.storage_slot, to)
+        derive_storage_slot_in_map(storage.map.get_storage_slot(), to)
     }
 
     #[public]
@@ -307,7 +308,7 @@ pub contract AvmTest {
 
     #[public]
     fn returndata_copy_oracle() {
-        AvmTest::at(context.this_address()).return_oracle().call(&mut context);
+        let _ = AvmTest::at(context.this_address()).return_oracle().call(&mut context);
         let returndatasize = dep::aztec::context::public_context::returndata_size();
         let returndata = dep::aztec::context::public_context::returndata_copy(0, returndatasize);
         assert(returndata == &[1, 2, 3], "Returndata copy failed");

--- a/noir-projects/noir-contracts/contracts/test/avm_test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/avm_test_contract/src/main.nr
@@ -669,7 +669,7 @@ pub contract AvmTest {
         dep::aztec::oracle::debug_log::debug_log("sha256_hash");
         let _ = sha256::sha256_var(args_u8, args_u8.len() as u64);
         dep::aztec::oracle::debug_log::debug_log("poseidon2_hash");
-        let _ = std::hash::poseidon2::Poseidon2::hash(args_field, args_field.len());
+        let _ = poseidon::poseidon2::Poseidon2::hash(args_field, args_field.len());
         dep::aztec::oracle::debug_log::debug_log("pedersen_hash");
         let _ = std::hash::pedersen_hash(args_field);
         dep::aztec::oracle::debug_log::debug_log("pedersen_hash_with_index");

--- a/noir-projects/noir-contracts/contracts/test/avm_test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/avm_test_contract/src/main.nr
@@ -253,7 +253,7 @@ pub contract AvmTest {
 
     #[public]
     fn external_call_to_divide_by_zero() {
-        AvmTest::at(context.this_address()).divide_by_zero().call(&mut context);
+        let _ = AvmTest::at(context.this_address()).divide_by_zero().call(&mut context);
     }
 
     #[public]
@@ -618,7 +618,7 @@ pub contract AvmTest {
 
     // function with large array as calldata (for benchmarking call interface macros)
     #[public]
-    fn fn_w_large_calldata(arr: [Field; 300]) -> pub Field {
+    fn fn_w_large_calldata(_arr: [Field; 300]) -> pub Field {
         // do nothing and return...
         5
     }

--- a/noir-projects/noir-contracts/contracts/test/avm_test_contract/src/note.nr
+++ b/noir-projects/noir-contracts/contracts/test/avm_test_contract/src/note.nr
@@ -3,6 +3,6 @@ use std::meta::derive;
 
 #[derive(Deserialize, Packable, Serialize)]
 pub struct Note {
-    a: Field,
-    b: Field,
+    pub a: Field,
+    pub b: Field,
 }

--- a/noir-projects/noir-contracts/contracts/test/benchmarking_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/benchmarking_contract/src/main.nr
@@ -40,7 +40,7 @@ pub contract Benchmarking {
         let mut getter_options = NoteGetterOptions::new();
         let notes = owner_notes.pop_notes(getter_options.set_limit(1).set_offset(index));
         let note = notes.get(0);
-        increment(owner_notes, note.value, owner);
+        increment(owner_notes, note.value(), owner);
     }
 
     // Reads and writes to public storage and enqueues a call to another public function.

--- a/noir-projects/noir-contracts/contracts/test/child_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/child_contract/src/main.nr
@@ -74,7 +74,7 @@ pub contract Child {
         let mut options = NoteGetterOptions::new();
         options = options.select(ValueNote::properties().value, Comparator.EQ, amount).set_limit(1);
         let retrieved_notes = storage.a_map_with_private_values.at(owner).get_notes(options);
-        retrieved_notes.get(0).note.value
+        retrieved_notes.get(0).note.value()
     }
 
     // Increments `current_value` by `new_value`

--- a/noir-projects/noir-contracts/contracts/test/counter_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/counter_contract/src/main.nr
@@ -12,7 +12,7 @@ pub contract Counter {
         state_vars::Map,
     };
     use easy_private_state::EasyPrivateUint;
-    use value_note::{balance_utils, value_note::ValueNote};
+    use value_note::balance_utils;
     // docs:end:imports
 
     // docs:start:storage_struct

--- a/noir-projects/noir-contracts/contracts/test/counter_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/counter_contract/src/main.nr
@@ -8,11 +8,11 @@ pub contract Counter {
     // docs:start:imports
     use aztec::{
         macros::{functions::{initializer, private, public, utility}, storage::storage},
+        oracle::debug_log::debug_log_format,
         protocol_types::{address::AztecAddress, traits::ToField},
         state_vars::Map,
     };
     use easy_private_state::EasyPrivateUint;
-    use value_note::balance_utils;
     // docs:end:imports
 
     // docs:start:storage_struct
@@ -35,12 +35,7 @@ pub contract Counter {
     // docs:start:increment
     #[private]
     fn increment(owner: AztecAddress) {
-        unsafe {
-            dep::aztec::oracle::debug_log::debug_log_format(
-                "Incrementing counter for owner {0}",
-                [owner.to_field()],
-            );
-        }
+        debug_log_format("Incrementing counter for owner {0}", [owner.to_field()]);
 
         Counter::at(context.this_address()).emit_in_public(12345).enqueue(&mut context);
 
@@ -51,12 +46,10 @@ pub contract Counter {
 
     #[private]
     fn increment_twice(owner: AztecAddress) {
-        unsafe {
-            dep::aztec::oracle::debug_log::debug_log_format(
-                "Incrementing counter twice for owner {0}",
-                [owner.to_field()],
-            );
-        }
+        debug_log_format(
+            "Incrementing counter twice for owner {0}",
+            [owner.to_field()],
+        );
         let counters = storage.counters;
         counters.at(owner).add(1, owner);
         counters.at(owner).add(1, owner);
@@ -64,12 +57,10 @@ pub contract Counter {
 
     #[private]
     fn increment_and_decrement(owner: AztecAddress) {
-        unsafe {
-            dep::aztec::oracle::debug_log::debug_log_format(
-                "Incrementing and decrementing counter for owner {0}",
-                [owner.to_field()],
-            );
-        }
+        debug_log_format(
+            "Incrementing and decrementing counter for owner {0}",
+            [owner.to_field()],
+        );
         let counters = storage.counters;
         counters.at(owner).add(1, owner);
         counters.at(owner).sub(1, owner);
@@ -77,12 +68,7 @@ pub contract Counter {
 
     #[private]
     fn decrement(owner: AztecAddress) {
-        unsafe {
-            dep::aztec::oracle::debug_log::debug_log_format(
-                "Decrementing counter for owner {0}",
-                [owner.to_field()],
-            );
-        }
+        debug_log_format("Decrementing counter for owner {0}", [owner.to_field()]);
         let counters = storage.counters;
         counters.at(owner).sub(1, owner);
     }
@@ -90,18 +76,12 @@ pub contract Counter {
     // docs:start:get_counter
     #[utility]
     unconstrained fn get_counter(owner: AztecAddress) -> Field {
-        let counters = storage.counters;
-        balance_utils::get_balance(counters.at(owner).set)
+        storage.counters.at(owner).get_value()
     }
 
     #[private]
     fn increment_self_and_other(other_counter: AztecAddress, owner: AztecAddress) {
-        unsafe {
-            dep::aztec::oracle::debug_log::debug_log_format(
-                "Incrementing counter for other {0}",
-                [owner.to_field()],
-            );
-        }
+        debug_log_format("Incrementing counter for other {0}", [owner.to_field()]);
 
         let counters = storage.counters;
         counters.at(owner).add(1, owner);

--- a/noir-projects/noir-contracts/contracts/test/parent_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/parent_contract/src/main.nr
@@ -267,7 +267,6 @@ pub contract Parent {
     unconstrained fn test_private_call() {
         let mut env = TestEnvironment::new();
         let owner = env.create_account(1);
-        let sender = env.create_account(7097070);
 
         // Deploy parent contract
         let parent_contract = env.deploy_self("Parent").without_initializer();

--- a/noir-projects/noir-contracts/contracts/test/pending_note_hashes_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/pending_note_hashes_contract/src/main.nr
@@ -2,26 +2,25 @@
 // read (eventually even nullified) in the same TX. This contract
 // also contains some "bad" test cases to ensure that notes cannot
 // be read/nullified before their creation etc.
-use dep::aztec::macros::aztec;
+use aztec::macros::aztec;
 
 #[aztec]
 pub contract PendingNoteHashes {
     // Libs
-    use dep::aztec::{
+    use aztec::{
         context::PrivateContext,
-        note::note_getter_options::NoteGetterOptions,
+        macros::{functions::private, storage::storage},
+        messages::logs::note::encode_and_encrypt_note,
+        note::{note_emission::NoteEmission, note_getter_options::NoteGetterOptions},
+        protocol_types::{
+            abis::function_selector::FunctionSelector,
+            address::AztecAddress,
+            constants::{MAX_NOTE_HASH_READ_REQUESTS_PER_CALL, MAX_NOTE_HASHES_PER_CALL},
+            traits::{Packable, ToField},
+        },
         state_vars::{Map, PrivateSet},
     };
-    use dep::aztec::macros::{functions::private, storage::storage};
-    use dep::aztec::messages::logs::note::encode_and_encrypt_note;
-    use dep::aztec::note::note_emission::NoteEmission;
-    use dep::aztec::protocol_types::constants::{
-        MAX_NOTE_HASH_READ_REQUESTS_PER_CALL, MAX_NOTE_HASHES_PER_CALL,
-    };
-    use dep::value_note::{filter::filter_notes_min_sum, value_note::ValueNote};
-    use aztec::protocol_types::{
-        abis::function_selector::FunctionSelector, address::AztecAddress, traits::ToField,
-    };
+    use value_note::{filter::filter_notes_min_sum, value_note::ValueNote};
 
     #[storage]
     struct Storage<Context> {
@@ -52,10 +51,10 @@ pub contract PendingNoteHashes {
         let notes = owner_balance.pop_notes(options);
 
         let note0 = notes.get(0);
-        assert(note.value == note0.value);
+        assert(note.value() == note0.value());
         assert(notes.len() == 1);
 
-        note0.value
+        note0.value()
     }
 
     // Confirm cannot access note hashes inserted later in same function
@@ -98,8 +97,10 @@ pub contract PendingNoteHashes {
     fn insert_note_static_randomness(amount: Field, owner: AztecAddress, sender: AztecAddress) {
         let owner_balance = storage.balances.at(owner);
 
-        let mut note = ValueNote::new(amount, owner);
-        note.randomness = 2;
+        let randomness = 2;
+        // Note that the following is severely misusing the Packable trait as we should never be messing with internal
+        // encoding. This is brittle but I don't care.
+        let note = ValueNote::unpack([amount.to_field(), owner.to_field(), randomness.to_field()]);
 
         // Insert note
         owner_balance.insert(note).emit(encode_and_encrypt_note(&mut context, owner));
@@ -131,7 +132,7 @@ pub contract PendingNoteHashes {
         options = options.set_limit(1);
         let note = owner_balance.pop_notes(options).get(0);
 
-        assert(expected_value == note.value);
+        assert(expected_value == note.value());
         expected_value
     }
 
@@ -297,7 +298,7 @@ pub contract PendingNoteHashes {
         sender: AztecAddress,
         how_many_recursions: u64,
     ) {
-        create_max_notes(owner, sender, storage, &mut context);
+        create_max_notes(owner, storage, &mut context);
 
         PendingNoteHashes::at(context.this_address())
             .recursively_destroy_and_create_notes(owner, sender, how_many_recursions)
@@ -313,7 +314,7 @@ pub contract PendingNoteHashes {
         assert(executions_left > 0);
 
         destroy_max_notes(owner, storage);
-        create_max_notes(owner, sender, storage, &mut context);
+        create_max_notes(owner, storage, &mut context);
 
         let executions_left = executions_left - 1;
 
@@ -351,7 +352,6 @@ pub contract PendingNoteHashes {
     #[contract_library_method]
     fn create_max_notes(
         owner: AztecAddress,
-        sender: AztecAddress,
         storage: Storage<&mut PrivateContext>,
         context: &mut PrivateContext,
     ) {

--- a/noir-projects/noir-contracts/contracts/test/state_vars_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/state_vars_contract/src/main.nr
@@ -133,7 +133,7 @@ pub contract StateVars {
         let current = storage.private_mutable.get_note().note;
 
         // Increment value by 1
-        let new_value = current.value + 1;
+        let new_value = current.value() + 1;
 
         // Create new note with incremented value
         let new_note = ValueNote::new(new_value, context.msg_sender());

--- a/noir-projects/noir-contracts/contracts/test/static_child_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/static_child_contract/src/main.nr
@@ -69,7 +69,7 @@ pub contract StaticChild {
             .select(ValueNote::properties().owner, Comparator.EQ, owner)
             .set_limit(1);
         let retrieved_notes = storage.a_private_value.get_notes(options);
-        retrieved_notes.get(0).note.value
+        retrieved_notes.get(0).note.value()
     }
 
     // Increments `current_value` by `new_value`

--- a/noir-projects/noir-contracts/contracts/test/static_parent_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/static_parent_contract/src/main.nr
@@ -3,7 +3,7 @@ use dep::aztec::macros::aztec;
 
 #[aztec]
 pub contract StaticParent {
-    use dep::aztec::{context::gas::GasOpts, macros::functions::{private, public, view}};
+    use dep::aztec::{context::gas::GasOpts, macros::functions::{private, public}};
     use dep::aztec::protocol_types::{
         abis::function_selector::FunctionSelector, address::AztecAddress,
     };

--- a/noir-projects/noir-contracts/contracts/test/test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/test_contract/src/main.nr
@@ -196,7 +196,7 @@ pub contract Test {
             get_notes(&mut context, storage_slot, options);
         // docs:end:get_note_from_pxe
 
-        retrieved_notes.get(0).note.value
+        retrieved_notes.get(0).note.get_value()
     }
 
     #[private]
@@ -209,7 +209,7 @@ pub contract Test {
         let (retrieved_notes, _): (BoundedVec<RetrievedNote<UintNote>, MAX_NOTE_HASH_READ_REQUESTS_PER_CALL>, BoundedVec<Field, MAX_NOTE_HASH_READ_REQUESTS_PER_CALL>) =
             get_notes(&mut context, storage_slot, options);
 
-        [retrieved_notes.get(0).note.value, retrieved_notes.get(1).note.value]
+        [retrieved_notes.get(0).note.get_value(), retrieved_notes.get(1).note.get_value()]
     }
 
     #[utility]
@@ -221,7 +221,7 @@ pub contract Test {
 
         let notes: BoundedVec<UintNote, MAX_NOTES_PER_PAGE> = view_notes(storage_slot, options);
 
-        notes.get(0).value
+        notes.get(0).get_value()
     }
 
     #[utility]
@@ -236,7 +236,7 @@ pub contract Test {
 
         let notes: BoundedVec<UintNote, MAX_NOTES_PER_PAGE> = view_notes(storage_slot, options);
 
-        [notes.get(0).value, notes.get(1).value]
+        [notes.get(0).get_value(), notes.get(1).get_value()]
     }
 
     #[private]

--- a/noir-projects/noir-contracts/contracts/test/test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/test_contract/src/main.nr
@@ -46,7 +46,6 @@ pub contract Test {
             retrieved_note::RetrievedNote,
         },
         publish_contract_instance::publish_contract_instance_for_public_execution,
-        test::mocks::mock_struct::MockStruct,
     };
     use dep::token_portal_content_hash_lib::get_mint_to_private_content_hash;
     use std::meta::derive;
@@ -428,8 +427,8 @@ pub contract Test {
 
     #[derive(Serialize)]
     pub struct DummyNote {
-        amount: Field,
-        secret_hash: Field,
+        pub amount: Field,
+        pub secret_hash: Field,
     }
 
     impl DummyNote {
@@ -443,10 +442,10 @@ pub contract Test {
     }
 
     pub struct DeepStruct {
-        a_field: Field,
-        a_bool: bool,
-        a_note: DummyNote,
-        many_notes: [DummyNote; 3],
+        pub a_field: Field,
+        pub a_bool: bool,
+        pub a_note: DummyNote,
+        pub many_notes: [DummyNote; 3],
     }
 
     // Serializing using "canonical" form.

--- a/noir-projects/noir-contracts/contracts/test/updatable_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/updatable_contract/src/main.nr
@@ -59,7 +59,7 @@ contract Updatable {
 
     #[utility]
     unconstrained fn get_private_value() -> Field {
-        storage.private_value.view_note().value
+        storage.private_value.view_note().value()
     }
 
     #[utility]

--- a/noir-projects/noir-contracts/contracts/test/updated_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/updated_contract/src/main.nr
@@ -38,7 +38,7 @@ contract Updated {
 
     #[utility]
     unconstrained fn get_private_value() -> Field {
-        storage.private_value.view_note().value
+        storage.private_value.view_note().value()
     }
 
     #[utility]

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/base/components/public_tube_data_validator.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/base/components/public_tube_data_validator.nr
@@ -22,7 +22,7 @@ fn assert_eq_array_and_length<T, let N: u32, let M: u32>(
     name: str<M>,
 )
 where
-    T: Eq + Empty,
+    T: Empty,
 {
     assert_eq(array_from_tube, array_from_avm, f"{name} mismatch between tube and avm");
 

--- a/noir-projects/noir-protocol-circuits/crates/types/src/tests/types.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/tests/types.nr
@@ -48,15 +48,6 @@ impl Empty for TestCombinedValue {
     }
 }
 
-pub(crate) fn sum_two_values(from: TestTwoValues) -> TestValue {
-    TestValue { value: from.value_1 + from.value_2, counter: from.counter }
-}
-
-pub(crate) fn assert_summed_from_two_values(from: TestTwoValues, to: TestValue) -> () {
-    assert(from.value_1 + from.value_2 == to.value);
-    assert(from.counter == to.counter);
-}
-
 pub(crate) fn combine_two_values(from: TestTwoValues) -> TestCombinedValue {
     TestCombinedValue { value: from.value_1 + from.value_2 }
 }

--- a/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays/assert_sorted_transformed_padded_array.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays/assert_sorted_transformed_padded_array.nr
@@ -96,7 +96,7 @@ where
     // assert(original_array_length <= capped_size, "capped_size does not cover all non-empty items");
     // We need the padding_length, so instead of doing the above assertion, we do this:
     // This will fail if original_array_length > capped_size, because u32 cannot underflow.
-    // let padding_length = capped_size - original_array_length;
+    let _padding_length = capped_size - original_array_length;
 
     let mut should_be_padded = false;
     for i in 0..N {

--- a/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays/assert_sorted_transformed_padded_array.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays/assert_sorted_transformed_padded_array.nr
@@ -96,7 +96,7 @@ where
     // assert(original_array_length <= capped_size, "capped_size does not cover all non-empty items");
     // We need the padding_length, so instead of doing the above assertion, we do this:
     // This will fail if original_array_length > capped_size, because u32 cannot underflow.
-    let padding_length = capped_size - original_array_length;
+    // let padding_length = capped_size - original_array_length;
 
     let mut should_be_padded = false;
     for i in 0..N {

--- a/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays/assert_split_transformed_padded_arrays.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays/assert_split_transformed_padded_arrays.nr
@@ -442,7 +442,8 @@ mod tests {
     fn assert_split_transformed_padded_arrays_with_hint__first_after_split_index_too_small_fails() {
         let mut builder = TestBuilder::new();
 
-        builder.first_after_split_index._value -= 1;
+        builder.first_after_split_index =
+            Option::some(builder.first_after_split_index.unwrap() - 1);
 
         builder.execute_with_hint();
     }
@@ -451,7 +452,8 @@ mod tests {
     fn assert_split_transformed_padded_arrays_with_hint__first_after_split_index_too_large_fails() {
         let mut builder = TestBuilder::new();
 
-        builder.first_after_split_index._value += 1;
+        builder.first_after_split_index =
+            Option::some(builder.first_after_split_index.unwrap() + 1);
 
         builder.execute_with_hint();
     }
@@ -460,7 +462,7 @@ mod tests {
     fn assert_split_transformed_padded_arrays_with_hint__first_padded_index_too_small_fails() {
         let mut builder = TestBuilder::new();
 
-        builder.first_padded_index._value -= 1;
+        builder.first_padded_index = Option::some(builder.first_padded_index.unwrap() - 1);
 
         builder.execute_with_hint();
     }
@@ -469,7 +471,7 @@ mod tests {
     fn assert_split_transformed_padded_arrays_with_hint__first_padded_index_too_large_fails() {
         let mut builder = TestBuilder::new();
 
-        builder.first_padded_index._value += 1;
+        builder.first_padded_index = Option::some(builder.first_padded_index.unwrap() + 1);
 
         builder.execute_with_hint();
     }


### PR DESCRIPTION
Fixing the vast majority of compiler warnings in `noir-projects`.

Tackling this now as incoming Noir release will disallow accessing of private fields and private functionality.

These warnings are remaining:

<img width="1128" height="523" alt="image" src="https://github.com/user-attachments/assets/a9372a2b-ce93-41f3-9a4b-ffa96b60ba5f" />

The first one is impractical to fix, the 2nd, 3rd and 4th I am not sure how to fix and the last one I plan on making the AVM team fix.