### PR TITLE
chore: mark p2p message_propagation test as flake

### DIFF
--- a/.test_patterns.yml
+++ b/.test_patterns.yml
@@ -212,7 +212,8 @@ tests:
     error_regex: "✕ should stop after max retry attempts"
     owners:
       - *sean
-  - regex: "p2p/src/client/p2p_client/test/" 
+  - regex: "p2p/src/client/test/p2p_client.integration_message_propagation.test.ts" 
+    error_regex: "will propagate messages to peers at the same version"
     owners:
       - *palla
   - regex: "yarn-project/kv-store"


### PR DESCRIPTION
My original idea was to mark all `p2p_client/test/` as flakes, but the regex was wrong, given [this test](http://ci.aztec-labs.com/9999d8b5cb8e4c93) is marked as failed instead of flaked.
Since only `message_propagation` test seems to be failing, I'm only marking it as flaky.