### PR TITLE
chore: Always push blobs to sink

### DIFF
--- a/yarn-project/blob-sink/src/blobstore/blob_store_test_suite.ts
+++ b/yarn-project/blob-sink/src/blobstore/blob_store_test_suite.ts
@@ -11,19 +11,19 @@ export function describeBlobStore(getBlobStore: () => Promise<BlobStore>) {
     blobStore = await getBlobStore();
   });
 
-  it('should store and retrieve a blob', async () => {
+  it('should store and retrieve a blob by hash', async () => {
     // Create a test blob with random fields
     const testFields = [Fr.random(), Fr.random(), Fr.random()];
     const blob = await Blob.fromFields(testFields);
-    const blockId = '0x12345';
     const blobWithIndex = new BlobWithIndex(blob, 0);
+    const blobHash = blob.getEthVersionedBlobHash();
 
     // Store the blob
-    await blobStore.addBlobSidecars(blockId, [blobWithIndex]);
+    await blobStore.addBlobs([blobWithIndex]);
 
-    // Retrieve the blob
-    const retrievedBlobs = await blobStore.getBlobSidecars(blockId);
-    const [retrievedBlob] = retrievedBlobs!;
+    // Retrieve the blob by hash
+    const retrievedBlobs = await blobStore.getBlobsByHashes([blobHash]);
+    const [retrievedBlob] = retrievedBlobs;
 
     // Verify the blob was retrieved and matches
     expect(retrievedBlob).toBeDefined();
@@ -31,112 +31,109 @@ export function describeBlobStore(getBlobStore: () => Promise<BlobStore>) {
     expect(retrievedBlob.blob.commitment.toString('hex')).toBe(blob.commitment.toString('hex'));
   });
 
-  it('Should allow requesting a specific index of blob', async () => {
-    const testFields = [Fr.random(), Fr.random(), Fr.random()];
-    const blob = await Blob.fromFields(testFields);
-    const blockId = '0x12345';
-    const blobWithIndex = new BlobWithIndex(blob, 0);
-    const blobWithIndex2 = new BlobWithIndex(blob, 1);
-
-    await blobStore.addBlobSidecars(blockId, [blobWithIndex, blobWithIndex2]);
-
-    const retrievedBlobs = await blobStore.getBlobSidecars(blockId, [0]);
-    const [retrievedBlob] = retrievedBlobs!;
-
-    expect(retrievedBlob.blob.fieldsHash.toString()).toBe(blob.fieldsHash.toString());
-    expect(retrievedBlob.blob.commitment.toString('hex')).toBe(blob.commitment.toString('hex'));
-
-    const retrievedBlobs2 = await blobStore.getBlobSidecars(blockId, [1]);
-    const [retrievedBlob2] = retrievedBlobs2!;
-
-    expect(retrievedBlob2.blob.fieldsHash.toString()).toBe(blob.fieldsHash.toString());
-    expect(retrievedBlob2.blob.commitment.toString('hex')).toBe(blob.commitment.toString('hex'));
-  });
-
-  it('Differentiate between blockHash and slot', async () => {
-    const testFields = [Fr.random(), Fr.random(), Fr.random()];
-    const testFieldsSlot = [Fr.random(), Fr.random(), Fr.random()];
-    const blob = await Blob.fromFields(testFields);
-    const blobSlot = await Blob.fromFields(testFieldsSlot);
-    const blockId = '0x12345';
-    const slot = '12345';
-    const blobWithIndex = new BlobWithIndex(blob, 0);
-    const blobWithIndexSlot = new BlobWithIndex(blobSlot, 0);
-
-    await blobStore.addBlobSidecars(blockId, [blobWithIndex]);
-    await blobStore.addBlobSidecars(slot, [blobWithIndexSlot]);
-
-    const retrievedBlobs = await blobStore.getBlobSidecars(blockId, [0]);
-    const [retrievedBlob] = retrievedBlobs!;
-
-    expect(retrievedBlob.blob.fieldsHash.toString()).toBe(blob.fieldsHash.toString());
-    expect(retrievedBlob.blob.commitment.toString('hex')).toBe(blob.commitment.toString('hex'));
-
-    const retrievedBlobs2 = await blobStore.getBlobSidecars(slot, [0]);
-    const [retrievedBlob2] = retrievedBlobs2!;
-
-    expect(retrievedBlob2.blob.fieldsHash.toString()).toBe(blobSlot.fieldsHash.toString());
-    expect(retrievedBlob2.blob.commitment.toString('hex')).toBe(blobSlot.commitment.toString('hex'));
-  });
-
-  it('should return undefined for non-existent blob', async () => {
-    const nonExistentBlob = await blobStore.getBlobSidecars('999999');
-    expect(nonExistentBlob).toBeUndefined();
-  });
-
-  it('should handle multiple blobs with different block IDs', async () => {
+  it('should handle multiple blobs stored and retrieved by their hashes', async () => {
     // Create two different blobs
     const blob1 = await Blob.fromFields([Fr.random(), Fr.random()]);
     const blob2 = await Blob.fromFields([Fr.random(), Fr.random(), Fr.random()]);
     const blobWithIndex1 = new BlobWithIndex(blob1, 0);
-    const blobWithIndex2 = new BlobWithIndex(blob2, 0);
+    const blobWithIndex2 = new BlobWithIndex(blob2, 1);
+
+    const blobHash1 = blob1.getEthVersionedBlobHash();
+    const blobHash2 = blob2.getEthVersionedBlobHash();
 
     // Store both blobs
-    await blobStore.addBlobSidecars('1', [blobWithIndex1]);
-    await blobStore.addBlobSidecars('2', [blobWithIndex2]);
+    await blobStore.addBlobs([blobWithIndex1, blobWithIndex2]);
 
     // Retrieve and verify both blobs
-    const retrieved1 = await blobStore.getBlobSidecars('1');
-    const retrieved2 = await blobStore.getBlobSidecars('2');
-    const [retrievedBlob1] = retrieved1!;
-    const [retrievedBlob2] = retrieved2!;
+    const retrievedBlobs = await blobStore.getBlobsByHashes([blobHash1, blobHash2]);
 
-    expect(retrievedBlob1.blob.commitment.toString('hex')).toBe(blob1.commitment.toString('hex'));
-    expect(retrievedBlob2.blob.commitment.toString('hex')).toBe(blob2.commitment.toString('hex'));
+    expect(retrievedBlobs.length).toBe(2);
+    expect(retrievedBlobs[0].blob.commitment.toString('hex')).toBe(blob1.commitment.toString('hex'));
+    expect(retrievedBlobs[1].blob.commitment.toString('hex')).toBe(blob2.commitment.toString('hex'));
   });
 
-  it('should overwrite blob when using same block ID', async () => {
-    // Create two different blobs
-    const originalBlob = await Blob.fromFields([Fr.random()]);
-    const newBlob = await Blob.fromFields([Fr.random(), Fr.random()]);
-    const blockId = '1';
-    const originalBlobWithIndex = new BlobWithIndex(originalBlob, 0);
-    const newBlobWithIndex = new BlobWithIndex(newBlob, 0);
+  it('should return empty array for non-existent blob hash', async () => {
+    // Create a random hash that doesn't exist
+    const nonExistentHash = Buffer.alloc(32);
+    nonExistentHash.fill(0xff);
 
-    // Store original blob
-    await blobStore.addBlobSidecars(blockId, [originalBlobWithIndex]);
-
-    // Overwrite with new blob
-    await blobStore.addBlobSidecars(blockId, [newBlobWithIndex]);
-
-    // Retrieve and verify it's the new blob
-    const retrievedBlobs = await blobStore.getBlobSidecars(blockId);
-    const [retrievedBlob] = retrievedBlobs!;
-    expect(retrievedBlob.blob.commitment.toString('hex')).toBe(newBlob.commitment.toString('hex'));
-    expect(retrievedBlob.blob.commitment.toString('hex')).not.toBe(originalBlob.commitment.toString('hex'));
+    const retrievedBlobs = await blobStore.getBlobsByHashes([nonExistentHash]);
+    expect(retrievedBlobs).toEqual([]);
   });
 
-  it('should handle multiple blobs with the same block ID', async () => {
+  it('should handle storing blobs with different indices', async () => {
+    // Create blobs with different indices
     const blob1 = await Blob.fromFields([Fr.random()]);
     const blob2 = await Blob.fromFields([Fr.random()]);
     const blobWithIndex1 = new BlobWithIndex(blob1, 0);
-    const blobWithIndex2 = new BlobWithIndex(blob2, 0);
+    const blobWithIndex2 = new BlobWithIndex(blob2, 1);
 
-    await blobStore.addBlobSidecars('1', [blobWithIndex1, blobWithIndex2]);
-    const retrievedBlobs = await blobStore.getBlobSidecars('1');
-    const [retrievedBlob1, retrievedBlob2] = retrievedBlobs!;
+    await blobStore.addBlobs([blobWithIndex1, blobWithIndex2]);
 
-    expect(retrievedBlob1.blob.commitment.toString('hex')).toBe(blob1.commitment.toString('hex'));
-    expect(retrievedBlob2.blob.commitment.toString('hex')).toBe(blob2.commitment.toString('hex'));
+    const blobHash1 = blob1.getEthVersionedBlobHash();
+    const blobHash2 = blob2.getEthVersionedBlobHash();
+
+    const retrievedBlobs = await blobStore.getBlobsByHashes([blobHash1, blobHash2]);
+
+    expect(retrievedBlobs[0].index).toBe(0);
+    expect(retrievedBlobs[1].index).toBe(1);
+  });
+
+  it('should handle retrieving subset of stored blobs', async () => {
+    // Store multiple blobs
+    const blob1 = await Blob.fromFields([Fr.random()]);
+    const blob2 = await Blob.fromFields([Fr.random()]);
+    const blob3 = await Blob.fromFields([Fr.random()]);
+
+    await blobStore.addBlobs([new BlobWithIndex(blob1, 0), new BlobWithIndex(blob2, 1), new BlobWithIndex(blob3, 2)]);
+
+    // Retrieve only some of them
+    const blobHash1 = blob1.getEthVersionedBlobHash();
+    const blobHash3 = blob3.getEthVersionedBlobHash();
+
+    const retrievedBlobs = await blobStore.getBlobsByHashes([blobHash1, blobHash3]);
+
+    expect(retrievedBlobs.length).toBe(2);
+    expect(retrievedBlobs[0].blob.commitment.toString('hex')).toBe(blob1.commitment.toString('hex'));
+    expect(retrievedBlobs[1].blob.commitment.toString('hex')).toBe(blob3.commitment.toString('hex'));
+  });
+
+  it('should handle duplicate blob hashes in request', async () => {
+    const blob = await Blob.fromFields([Fr.random()]);
+    const blobWithIndex = new BlobWithIndex(blob, 0);
+    const blobHash = blob.getEthVersionedBlobHash();
+
+    await blobStore.addBlobs([blobWithIndex]);
+
+    // Request the same blob hash multiple times
+    const retrievedBlobs = await blobStore.getBlobsByHashes([blobHash, blobHash]);
+
+    // Implementation may return duplicates or deduplicate - both are valid
+    expect(retrievedBlobs.length).toBeGreaterThanOrEqual(1);
+    expect(retrievedBlobs[0].blob.commitment.toString('hex')).toBe(blob.commitment.toString('hex'));
+  });
+
+  it('should overwrite blob when storing with same hash', async () => {
+    // Create two blobs that will have the same hash (same content)
+    const fields = [Fr.random(), Fr.random()];
+    const blob1 = await Blob.fromFields(fields);
+    const blob2 = await Blob.fromFields(fields);
+
+    // Store with different indices
+    const blobWithIndex1 = new BlobWithIndex(blob1, 0);
+    const blobWithIndex2 = new BlobWithIndex(blob2, 5);
+
+    const blobHash = blob1.getEthVersionedBlobHash();
+
+    // Store first blob
+    await blobStore.addBlobs([blobWithIndex1]);
+
+    // Overwrite with second blob (same hash, different index)
+    await blobStore.addBlobs([blobWithIndex2]);
+
+    // Retrieve and verify it's the second blob (with index 5)
+    const retrievedBlobs = await blobStore.getBlobsByHashes([blobHash]);
+    expect(retrievedBlobs.length).toBe(1);
+    expect(retrievedBlobs[0].index).toBe(5);
   });
 }

--- a/yarn-project/blob-sink/src/blobstore/interface.ts
+++ b/yarn-project/blob-sink/src/blobstore/interface.ts
@@ -2,11 +2,11 @@ import type { BlobWithIndex } from '../types/index.js';
 
 export interface BlobStore {
   /**
-   * Get a blob by block id
+   * Get blobs by their hashes
    */
-  getBlobSidecars: (blockId: string, indices?: number[]) => Promise<BlobWithIndex[] | undefined>;
+  getBlobsByHashes: (blobHashes: Buffer[]) => Promise<BlobWithIndex[]>;
   /**
-   * Add a blob to the store
+   * Add blobs to the store, indexed by their hashes
    */
-  addBlobSidecars: (blockId: string, blobSidecars: BlobWithIndex[]) => Promise<void>;
+  addBlobs: (blobs: BlobWithIndex[]) => Promise<void>;
 }

--- a/yarn-project/blob-sink/src/client/interface.ts
+++ b/yarn-project/blob-sink/src/client/interface.ts
@@ -3,7 +3,9 @@ import type { Blob } from '@aztec/blob-lib';
 import type { BlobWithIndex } from '../types/blob_with_index.js';
 
 export interface BlobSinkClientInterface {
-  sendBlobsToBlobSink(blockId: string, blobs: Blob[]): Promise<boolean>;
+  /** Sends the given blobs to a sink, to be indexed by blob hash. */
+  sendBlobsToBlobSink(blobs: Blob[]): Promise<boolean>;
+  /** Fetches the given blob sidecars by block, hash, and indices. */
   getBlobSidecar(blockId: string, blobHashes?: Buffer[], indices?: number[]): Promise<BlobWithIndex[]>;
   /** Tests all configured blob sources and logs whether they are reachable or not. */
   testSources(): Promise<void>;

--- a/yarn-project/blob-sink/src/client/local.test.ts
+++ b/yarn-project/blob-sink/src/client/local.test.ts
@@ -1,6 +1,6 @@
 import { MemoryBlobStore } from '../blobstore/memory_blob_store.js';
-import { runBlobSinkClientTests } from './blob-sink-client-tests.js';
 import { LocalBlobSinkClient } from './local.js';
+import { runBlobSinkClientTests } from './tests.js';
 
 describe('LocalBlobSinkClient', () => {
   runBlobSinkClientTests(() => {

--- a/yarn-project/blob-sink/src/client/local.ts
+++ b/yarn-project/blob-sink/src/client/local.ts
@@ -15,22 +15,13 @@ export class LocalBlobSinkClient implements BlobSinkClientInterface {
     return Promise.resolve();
   }
 
-  public async sendBlobsToBlobSink(blockId: string, blobs: Blob[]): Promise<boolean> {
-    await this.blobStore.addBlobSidecars(
-      blockId,
-      blobs.map((blob, index) => new BlobWithIndex(blob, index)),
-    );
+  public async sendBlobsToBlobSink(blobs: Blob[]): Promise<boolean> {
+    const blobsWithIndex = blobs.map((blob, index) => new BlobWithIndex(blob, index));
+    await this.blobStore.addBlobs(blobsWithIndex);
     return true;
   }
 
-  public async getBlobSidecar(blockId: string, blobHashes: Buffer[], indices?: number[]): Promise<BlobWithIndex[]> {
-    const blobSidecars = await this.blobStore.getBlobSidecars(blockId, indices);
-    if (!blobSidecars) {
-      return [];
-    }
-    return blobSidecars.filter(blob => {
-      const blobHash = blob.blob.getEthVersionedBlobHash();
-      return blobHashes.some(hash => hash.equals(blobHash));
-    });
+  public getBlobSidecar(_blockId: string, blobHashes: Buffer[]): Promise<BlobWithIndex[]> {
+    return this.blobStore.getBlobsByHashes(blobHashes);
   }
 }

--- a/yarn-project/blob-sink/src/client/tests.ts
+++ b/yarn-project/blob-sink/src/client/tests.ts
@@ -1,5 +1,7 @@
 import { makeEncodedBlob } from '@aztec/blob-lib/testing';
 
+import type { Hex } from 'viem';
+
 import type { BlobSinkClientInterface } from './interface.js';
 
 /**
@@ -10,10 +12,12 @@ import type { BlobSinkClientInterface } from './interface.js';
 export function runBlobSinkClientTests(
   createClient: () => Promise<{ client: BlobSinkClientInterface; cleanup: () => Promise<void> }>,
 ) {
+  let blockId: Hex;
   let client: BlobSinkClientInterface;
   let cleanup: () => Promise<void>;
 
   beforeEach(async () => {
+    blockId = '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef';
     const setup = await createClient();
     client = setup.client;
     cleanup = setup.cleanup;
@@ -23,13 +27,11 @@ export function runBlobSinkClientTests(
     await cleanup();
   });
 
-  it('should send and retrieve blobs', async () => {
+  it('should send and retrieve blobs by hash', async () => {
     const blob = await makeEncodedBlob(3);
     const blobHash = blob.getEthVersionedBlobHash();
-    const blockId = '0x1234';
 
-    const success = await client.sendBlobsToBlobSink(blockId, [blob]);
-    expect(success).toBe(true);
+    await client.sendBlobsToBlobSink([blob]);
 
     const retrievedBlobs = await client.getBlobSidecar(blockId, [blobHash]);
     expect(retrievedBlobs).toHaveLength(1);
@@ -40,10 +42,8 @@ export function runBlobSinkClientTests(
   it('should handle multiple blobs', async () => {
     const blobs = await Promise.all([makeEncodedBlob(2), makeEncodedBlob(2), makeEncodedBlob(2)]);
     const blobHashes = blobs.map(blob => blob.getEthVersionedBlobHash());
-    const blockId = '0x5678';
 
-    const success = await client.sendBlobsToBlobSink(blockId, blobs);
-    expect(success).toBe(true);
+    await client.sendBlobsToBlobSink(blobs);
 
     const retrievedBlobs = await client.getBlobSidecar(blockId, blobHashes);
     expect(retrievedBlobs).toHaveLength(3);
@@ -52,17 +52,42 @@ export function runBlobSinkClientTests(
       expect(retrievedBlobs[i].blob.fieldsHash.toString()).toBe(blobs[i].fieldsHash.toString());
       expect(retrievedBlobs[i].blob.commitment.toString('hex')).toBe(blobs[i].commitment.toString('hex'));
     }
-
-    // Can request blobs by index
-    const retrievedBlobsByIndex = await client.getBlobSidecar(blockId, blobHashes, [0, 2]);
-    expect(retrievedBlobsByIndex).toHaveLength(2);
-    expect(retrievedBlobsByIndex[0].blob.fieldsHash.toString()).toBe(blobs[0].fieldsHash.toString());
-    expect(retrievedBlobsByIndex[1].blob.fieldsHash.toString()).toBe(blobs[2].fieldsHash.toString());
   });
 
-  it('should return empty array for non-existent block', async () => {
-    const blockId = '0xnonexistent';
-    const retrievedBlobs = await client.getBlobSidecar(blockId, [Buffer.from([0x0])]);
+  it('should handle retrieving subset of blobs', async () => {
+    const blobs = await Promise.all([makeEncodedBlob(2), makeEncodedBlob(2), makeEncodedBlob(2)]);
+    const blobHashes = blobs.map(blob => blob.getEthVersionedBlobHash());
+
+    await client.sendBlobsToBlobSink(blobs);
+
+    // Retrieve only first and third blob
+    const retrievedBlobs = await client.getBlobSidecar(blockId, [blobHashes[0], blobHashes[2]]);
+    expect(retrievedBlobs).toHaveLength(2);
+    expect(retrievedBlobs[0].blob.fieldsHash.toString()).toBe(blobs[0].fieldsHash.toString());
+    expect(retrievedBlobs[1].blob.fieldsHash.toString()).toBe(blobs[2].fieldsHash.toString());
+  });
+
+  it('should return empty array for non-existent blob hash', async () => {
+    const nonExistentHash = Buffer.alloc(32);
+    nonExistentHash.fill(0xff);
+
+    const retrievedBlobs = await client.getBlobSidecar(blockId, [nonExistentHash]);
     expect(retrievedBlobs).toEqual([]);
+  });
+
+  it('should preserve blob indices', async () => {
+    const blob1 = await makeEncodedBlob(2);
+    const blob2 = await makeEncodedBlob(2);
+    const blobs = [blob1, blob2];
+    const blobHashes = blobs.map(blob => blob.getEthVersionedBlobHash());
+
+    await client.sendBlobsToBlobSink(blobs);
+
+    const retrievedBlobs = await client.getBlobSidecar(blockId, blobHashes);
+    expect(retrievedBlobs).toHaveLength(2);
+
+    // Indices should be assigned sequentially based on the order they were sent
+    expect(retrievedBlobs[0].index).toBe(0);
+    expect(retrievedBlobs[1].index).toBe(1);
   });
 }

--- a/yarn-project/blob-sink/src/server/factory.ts
+++ b/yarn-project/blob-sink/src/server/factory.ts
@@ -1,11 +1,7 @@
-import { getPublicClient } from '@aztec/ethereum';
-import { createLogger } from '@aztec/foundation/log';
 import type { AztecAsyncKVStore } from '@aztec/kv-store';
 import { createStore } from '@aztec/kv-store/lmdb-v2';
 import type { TelemetryClient } from '@aztec/telemetry-client';
 
-import { hasRemoteBlobSinkSources } from '../client/config.js';
-import { HttpBlobSinkClient } from '../client/http.js';
 import type { BlobSinkConfig } from './config.js';
 import { BlobSinkServer } from './server.js';
 
@@ -31,14 +27,6 @@ export async function createBlobSinkServer(
   telemetry?: TelemetryClient,
 ): Promise<BlobSinkServer> {
   const store = await getDataStore(config);
-  const blobClient = hasRemoteBlobSinkSources(config)
-    ? new HttpBlobSinkClient(config, {
-        onBlobDeserializationError: 'trace',
-        logger: createLogger('blob-sink:server:http'),
-      })
-    : undefined;
-  const { l1ChainId, l1RpcUrls } = config;
-  const l1PublicClient = l1ChainId && l1RpcUrls ? getPublicClient({ l1ChainId, l1RpcUrls }) : undefined;
 
-  return new BlobSinkServer(config, store, blobClient, l1PublicClient, telemetry);
+  return new BlobSinkServer(config, store, telemetry);
 }

--- a/yarn-project/blob-sink/src/server/server.test.ts
+++ b/yarn-project/blob-sink/src/server/server.test.ts
@@ -1,30 +1,18 @@
 import { Blob } from '@aztec/blob-lib';
 import { makeEncodedBlob } from '@aztec/blob-lib/testing';
-import type { L2BlockProposedEvent, ViemPublicClient } from '@aztec/ethereum';
-import { bufferToHex, hexToBuffer } from '@aztec/foundation/string';
-import { fileURLToPath } from '@aztec/foundation/url';
 
-import { readFile } from 'fs/promises';
-import { type MockProxy, mock } from 'jest-mock-extended';
-import { join } from 'path';
 import request from 'supertest';
 
-import { BlobscanBlockResponseSchema } from '../archive/blobscan_archive_client.js';
-import type { BlobArchiveClient } from '../archive/interface.js';
-import { HttpBlobSinkClient } from '../client/http.js';
 import type { BlobSinkClientInterface } from '../client/interface.js';
 import { outboundTransform } from '../encoding/index.js';
-import { BlobWithIndex } from '../types/blob_with_index.js';
 import type { BlobSinkConfig } from './config.js';
 import { BlobSinkServer } from './server.js';
 
 describe('BlobSinkService', () => {
   let service: BlobSinkServer;
 
-  const startServer = async (
-    config: Partial<BlobSinkConfig & { httpClient: BlobSinkClientInterface; l1Client: ViemPublicClient }> = {},
-  ) => {
-    service = new BlobSinkServer({ ...config, port: 0 }, undefined, config.httpClient, config.l1Client);
+  const startServer = async (config: Partial<BlobSinkConfig & { httpClient: BlobSinkClientInterface }> = {}) => {
+    service = new BlobSinkServer({ ...config, port: 0 }, undefined);
     await service.start();
   };
 
@@ -41,23 +29,21 @@ describe('BlobSinkService', () => {
     });
   });
 
-  describe('store', () => {
-    const blockId = '0x1234';
-
+  describe('store and retrieve', () => {
     let blob: Blob;
     let blob2: Blob;
+    let blobHashes: string[];
 
     beforeEach(async () => {
       await startServer();
 
       blob = await makeEncodedBlob(3);
       blob2 = await makeEncodedBlob(3);
-      // Post the blob
+
+      // Post the blobs using new API
       const postResponse = await request(service.getApp())
-        .post('/blob_sidecar')
+        .post('/blobs')
         .send({
-          // eslint-disable-next-line camelcase
-          block_id: blockId,
           blobs: [
             {
               index: 0,
@@ -71,16 +57,20 @@ describe('BlobSinkService', () => {
         });
 
       expect(postResponse.status).toBe(200);
+      expect(postResponse.body.blobHashes).toHaveLength(2);
+      blobHashes = postResponse.body.blobHashes;
     });
 
-    it('should retrieve the blob', async () => {
-      // Retrieve the blob
-      const getResponse = await request(service.getApp()).get(`/eth/v1/beacon/blob_sidecars/${blockId}`);
+    it('should retrieve blobs by hash', async () => {
+      // Retrieve the blobs using their hashes
+      const getResponse = await request(service.getApp()).get(`/blobs?blobHashes=${blobHashes.join(',')}`);
 
       expect(getResponse.status).toBe(200);
 
       // Convert the response blob back to a Blob object and verify it matches
       const retrievedBlobs = getResponse.body.data;
+      expect(retrievedBlobs).toHaveLength(2);
+
       const retrievedBlob = await Blob.fromEncodedBlobBuffer(Buffer.from(retrievedBlobs[0].blob.slice(2), 'hex'));
       const retrievedBlob2 = await Blob.fromEncodedBlobBuffer(Buffer.from(retrievedBlobs[1].blob.slice(2), 'hex'));
 
@@ -93,172 +83,79 @@ describe('BlobSinkService', () => {
       expect(retrievedBlob2.evaluate().proof.toString('hex')).toBe(blob2.evaluate().proof.toString('hex'));
     });
 
-    it('should retrieve specific indicies', async () => {
-      // We can also request specific indicies
-      const getWithIndicies = await request(service.getApp()).get(
-        `/eth/v1/beacon/blob_sidecars/${blockId}?indices=0,1`,
-      );
+    it('should retrieve specific blob by single hash', async () => {
+      // We can also request a single blob by its hash
+      const getResponse = await request(service.getApp()).get(`/blobs?blobHashes=${blobHashes[1]}`);
 
-      expect(getWithIndicies.status).toBe(200);
-      expect(getWithIndicies.body.data.length).toBe(2);
+      expect(getResponse.status).toBe(200);
+      expect(getResponse.body.data.length).toBe(1);
 
-      const retrievedBlobs = getWithIndicies.body.data;
-      const retrievedBlob = await Blob.fromEncodedBlobBuffer(Buffer.from(retrievedBlobs[0].blob.slice(2), 'hex'));
-      const retrievedBlob2 = await Blob.fromEncodedBlobBuffer(Buffer.from(retrievedBlobs[1].blob.slice(2), 'hex'));
-      expect(retrievedBlob.fieldsHash.toString()).toBe(blob.fieldsHash.toString());
-      expect(retrievedBlob.commitment.toString('hex')).toBe(blob.commitment.toString('hex'));
-      expect(retrievedBlob.evaluate().proof.toString('hex')).toBe(blob.evaluate().proof.toString('hex'));
-
-      expect(retrievedBlob2.fieldsHash.toString()).toBe(blob2.fieldsHash.toString());
-      expect(retrievedBlob2.commitment.toString('hex')).toBe(blob2.commitment.toString('hex'));
-      expect(retrievedBlob2.evaluate().proof.toString('hex')).toBe(blob2.evaluate().proof.toString('hex'));
-    });
-
-    it('should retrieve a single index', async () => {
-      const getWithIndicies = await request(service.getApp()).get(`/eth/v1/beacon/blob_sidecars/${blockId}?indices=1`);
-
-      expect(getWithIndicies.status).toBe(200);
-      expect(getWithIndicies.body.data.length).toBe(1);
-
-      const retrievedBlobs = getWithIndicies.body.data;
+      const retrievedBlobs = getResponse.body.data;
       const retrievedBlob = await Blob.fromEncodedBlobBuffer(Buffer.from(retrievedBlobs[0].blob.slice(2), 'hex'));
       expect(retrievedBlob.fieldsHash.toString()).toBe(blob2.fieldsHash.toString());
       expect(retrievedBlob.commitment.toString('hex')).toBe(blob2.commitment.toString('hex'));
       expect(retrievedBlob.evaluate().proof.toString('hex')).toBe(blob2.evaluate().proof.toString('hex'));
+    });
+
+    it('should retrieve first blob by its hash', async () => {
+      const getResponse = await request(service.getApp()).get(`/blobs?blobHashes=${blobHashes[0]}`);
+
+      expect(getResponse.status).toBe(200);
+      expect(getResponse.body.data.length).toBe(1);
+
+      const retrievedBlobs = getResponse.body.data;
+      const retrievedBlob = await Blob.fromEncodedBlobBuffer(Buffer.from(retrievedBlobs[0].blob.slice(2), 'hex'));
+      expect(retrievedBlob.fieldsHash.toString()).toBe(blob.fieldsHash.toString());
+      expect(retrievedBlob.commitment.toString('hex')).toBe(blob.commitment.toString('hex'));
+      expect(retrievedBlob.evaluate().proof.toString('hex')).toBe(blob.evaluate().proof.toString('hex'));
     });
   });
 
   describe('errors', () => {
     beforeEach(() => startServer());
 
-    it('should return an error if invalid indicies are provided', async () => {
-      const blockId = '0x1234';
-
-      const response = await request(service.getApp()).get(`/eth/v1/beacon/blob_sidecars/${blockId}?indices=word`);
+    it('should return an error if blobHashes parameter is missing', async () => {
+      const response = await request(service.getApp()).get('/blobs');
       expect(response.status).toBe(400);
-      expect(response.body.error).toBe('Invalid indices parameter');
+      expect(response.body.error).toBe('Missing or invalid blobHashes query parameter');
     });
 
-    it('should return an error if the block ID is invalid (POST)', async () => {
-      const response = await request(service.getApp()).post('/blob_sidecar').send({
-        // eslint-disable-next-line camelcase
-        block_id: undefined,
+    it('should return an error if invalid blob hash format is provided', async () => {
+      const response = await request(service.getApp()).get('/blobs?blobHashes=invalid-hash');
+      expect(response.status).toBe(400);
+      expect(response.body.error).toBe('Invalid blob hash: invalid-hash');
+    });
+
+    it('should return an error if blobs parameter is missing (POST)', async () => {
+      const response = await request(service.getApp()).post('/blobs').send({});
+
+      expect(response.status).toBe(400);
+      expect(response.body.error).toBe('Invalid blob data');
+    });
+
+    it('should return an error if blobs parameter is not an array (POST)', async () => {
+      const response = await request(service.getApp()).post('/blobs').send({
+        blobs: 'not-an-array',
       });
 
       expect(response.status).toBe(400);
+      expect(response.body.error).toBe('Invalid blob data');
     });
 
-    it('should return an error if the block ID is invalid (GET)', async () => {
-      const response = await request(service.getApp()).get('/eth/v1/beacon/blob_sidecars/invalid-id');
-
-      expect(response.status).toBe(400);
-    });
-
-    it('should return 404 for non-existent blob', async () => {
-      const response = await request(service.getApp()).get('/eth/v1/beacon/blob_sidecars/0x999999');
+    it('should return 404 for non-existent blob hashes', async () => {
+      const nonExistentHash = '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef';
+      const response = await request(service.getApp()).get(`/blobs?blobHashes=${nonExistentHash}`);
 
       expect(response.status).toBe(404);
+      expect(response.body.error).toBe('No blobs found');
     });
 
-    it('should reject negative block IDs', async () => {
-      const response = await request(service.getApp()).get('/eth/v1/beacon/blob_sidecars/-123');
+    it('should reject blob hashes that are too short', async () => {
+      const shortHash = '0x1234';
+      const response = await request(service.getApp()).get(`/blobs?blobHashes=${shortHash}`);
 
       expect(response.status).toBe(400);
-      expect(response.body.error).toBe('Invalid block_id parameter');
-    });
-  });
-
-  describe('with l1 client', () => {
-    let l1Client: MockProxy<ViemPublicClient>;
-    let blob: Blob;
-    let blob2: Blob;
-
-    const blockId = '0x1234';
-
-    beforeEach(async () => {
-      blob = await makeEncodedBlob(3);
-      blob2 = await makeEncodedBlob(3);
-      l1Client = mock<ViemPublicClient>();
-      l1Client.getContractEvents.mockResolvedValue([
-        {
-          args: {
-            versionedBlobHashes: [bufferToHex(blob.getEthVersionedBlobHash())],
-            archive: '0x5678',
-            blockNumber: 1234n,
-          } satisfies L2BlockProposedEvent,
-        } as any,
-      ]);
-
-      await startServer({ l1Client });
-    });
-
-    afterEach(() => {
-      expect(l1Client.getContractEvents).toHaveBeenCalledTimes(1);
-      expect(l1Client.getContractEvents).toHaveBeenCalledWith(expect.objectContaining({ blockHash: blockId }));
-    });
-
-    it('should accept blobs emitted by rollup contract', async () => {
-      const postResponse = await request(service.getApp())
-        .post('/blob_sidecar')
-        .send({
-          // eslint-disable-next-line camelcase
-          block_id: blockId,
-          blobs: [{ index: 0, blob: outboundTransform(blob.toBuffer()) }],
-        });
-
-      expect(postResponse.status).toBe(200);
-    });
-
-    it('should reject blobs not emitted by rollup contract', async () => {
-      const postResponse = await request(service.getApp())
-        .post('/blob_sidecar')
-        .send({
-          // eslint-disable-next-line camelcase
-          block_id: blockId,
-          blobs: [
-            { index: 0, blob: outboundTransform(blob.toBuffer()) },
-            { index: 1, blob: outboundTransform(blob2.toBuffer()) },
-          ],
-        });
-
-      expect(postResponse.status).toBe(400);
-    });
-  });
-
-  describe('with archive', () => {
-    let archiveClient: MockProxy<BlobArchiveClient>;
-
-    beforeEach(async () => {
-      archiveClient = mock<BlobArchiveClient>();
-      const httpClient = new HttpBlobSinkClient({}, { archiveClient });
-      await startServer({ httpClient });
-    });
-
-    it('should retrieve the blob from archive and store locally', async () => {
-      // Actual blockId from Sepolia with an Aztec tx, corresponds to blobscan_get_block.json fixture
-      const blockId = '0x7d81980a40426c40544f0f729ada953be406730b877b5865d6cdc35cc8f9c84e';
-      const dataPath = join(fileURLToPath(import.meta.url), '../..', 'archive/fixtures', 'blobscan_get_block.json');
-      const expectedBlobJsons = BlobscanBlockResponseSchema.parse(JSON.parse(await readFile(dataPath, 'utf-8')));
-      archiveClient.getBlobsFromBlock.mockResolvedValue(expectedBlobJsons);
-
-      const getResponse = await request(service.getApp()).get(`/eth/v1/beacon/blob_sidecars/${blockId}`);
-      expect(getResponse.status).toBe(200);
-
-      // Even though the block has two blobs, only one is of interest to us
-      expect(getResponse.body.data.length).toBe(1);
-      const expectedBlobWithIndex = new BlobWithIndex(await Blob.fromJson(expectedBlobJsons[0]), 0);
-      const retrievedBlobWithIndex = new BlobWithIndex(
-        await Blob.fromEncodedBlobBuffer(hexToBuffer(getResponse.body.data[0].blob)),
-        getResponse.body.data[0].index,
-      );
-      expect(retrievedBlobWithIndex.toJSON()).toEqual(expectedBlobWithIndex.toJSON());
-
-      // Re-fetching should not hit the archive client again
-      const getResponse2 = await request(service.getApp()).get(`/eth/v1/beacon/blob_sidecars/${blockId}`);
-      expect(getResponse2.status).toBe(200);
-      expect(getResponse2.body.data.length).toBe(1);
-
-      expect(archiveClient.getBlobsFromBlock).toHaveBeenCalledTimes(1);
+      expect(response.body.error).toBe(`Invalid blob hash: ${shortHash}`);
     });
   });
 });

--- a/yarn-project/blob-sink/src/types/api.ts
+++ b/yarn-project/blob-sink/src/types/api.ts
@@ -2,7 +2,6 @@ import type { Hex } from 'viem';
 import { z } from 'zod';
 
 export interface PostBlobSidecarRequest {
-  block_id: string;
   blobs: Array<{
     index: number;
     blob: {

--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_l1_reorgs.test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_l1_reorgs.test.ts
@@ -255,7 +255,7 @@ describe('e2e_epochs/epochs_l1_reorgs', () => {
       logger.warn(`Sending blobs to blob sink`);
       const blobs = await getBlobs(l2BlockTx);
       const blobSinkClient = createBlobSinkClient(context.config);
-      await blobSinkClient.sendBlobsToBlobSink(txReceipt.blockHash, blobs);
+      await blobSinkClient.sendBlobsToBlobSink(blobs);
 
       // And wait for the node to see the new block
       await retryUntil(() => node.getBlockNumber().then(b => b === L2_BLOCK_NUMBER), 'node sync', 5, 0.1);

--- a/yarn-project/ethereum/src/queries.ts
+++ b/yarn-project/ethereum/src/queries.ts
@@ -1,7 +1,4 @@
 import type { EthAddress } from '@aztec/foundation/eth-address';
-import { RollupAbi } from '@aztec/l1-artifacts/RollupAbi';
-
-import type { Hex } from 'viem';
 
 import type { L1ContractsConfig } from './config.js';
 import { ReadOnlyGovernanceContract } from './contracts/governance.js';
@@ -85,26 +82,4 @@ export async function getL1ContractsConfig(
     genesisArchiveTreeRoot,
     exitDelaySeconds: Number(exitDelay),
   };
-}
-
-export type L2BlockProposedEvent = {
-  versionedBlobHashes: readonly Hex[];
-  archive: Hex;
-  blockNumber: bigint;
-};
-
-export async function getL2BlockProposalEvents(
-  client: ViemPublicClient,
-  blockId: Hex,
-  rollupAddress?: EthAddress,
-): Promise<L2BlockProposedEvent[]> {
-  return (
-    await client.getContractEvents({
-      abi: RollupAbi,
-      address: rollupAddress?.toString(),
-      blockHash: blockId,
-      eventName: 'L2BlockProposed',
-      strict: true,
-    })
-  ).map(log => log.args);
 }


### PR DESCRIPTION
I've hit the `Unable to get blob sidecar` flake [again](http://ci.aztec-labs.com/4af041ccf096ff33) even after [the fix](https://github.com/AztecProtocol/aztec-packages/pull/15800) (see the issue description for a detailed overview of what the underlying problem is). The issue seems to be coming from the Anvil test watcher this time, since it's updating the wall time at the same time the tx is perceived as failed.

So, this time I'm addressing the symptom instead of the cause. This PR changes the sequencer publisher so it **always** publishes blob data to the sink, instead of waiting for its success. 

However, the blob sink required the block in which the tx was mined in order to accept the blob, as it indexed blobs by block. So this PR also changes the blob sink to just index blobs by hash and not block. 

However, the blob sink server required the block in order to fall back to consensus to fetch the blobs on a miss (see first item in https://github.com/AztecProtocol/aztec-packages/pull/13542). That feature had been introduced so the blob sink could serve blobs in situations where not all nodes pushed to the sink, such as testnet, but that setup has been deprecated as confirmed by @alexghr. So this PR also removes the blob sink server fallback on a miss.