### PR TITLE
chore: Attempt to deflake p2p_message_propagation

### DIFF
--- a/yarn-project/p2p/src/client/test/p2p_client.integration_message_propagation.test.ts
+++ b/yarn-project/p2p/src/client/test/p2p_client.integration_message_propagation.test.ts
@@ -80,13 +80,13 @@ describe('p2p client integration message propagation', () => {
   });
 
   afterEach(async () => {
-    jest.restoreAllMocks();
-    jest.resetAllMocks();
-    jest.clearAllMocks();
-
     logger.info(`Tearing down state for ${expect.getState().currentTestName}`);
     await shutdown(clients);
     logger.info('Shut down p2p clients');
+
+    jest.restoreAllMocks();
+    jest.resetAllMocks();
+    jest.clearAllMocks();
 
     clients = [];
   });
@@ -191,16 +191,17 @@ describe('p2p client integration message propagation', () => {
     await (client1 as any).p2pService.broadcastAttestation(attestation);
 
     // Clients 2 and 3 should receive all messages
-    const messagesPromise = Promise.all([
+    const messagesPromise = [
       client2TxPromise.promise,
       client3TxPromise.promise,
       client2ProposalPromise.promise,
       client3ProposalPromise.promise,
       client2AttestationPromise.promise,
       client3AttestationPromise.promise,
-    ]);
+    ];
 
-    const messages = await Promise.race([messagesPromise, sleep(6000).then(() => undefined)]);
+    const messages = await retryUntil(() => collectIfReady(messagesPromise), 'all gossiped messages received', 20, 1);
+
     expect(messages).toBeDefined();
     expect(client2HandleGossipedTxSpy).toHaveBeenCalled();
     expect(client2HandleGossipedProposalSpy).toHaveBeenCalled();
@@ -221,6 +222,14 @@ describe('p2p client integration message propagation', () => {
     }
   };
 
+  const collectIfReady = async (promises: Promise<any>[]) => {
+    const settled = await Promise.allSettled(promises);
+    if (settled.every(s => s.status === 'fulfilled')) {
+      return settled.map(s => (s as PromiseFulfilledResult<any>).value);
+    }
+    return undefined;
+  };
+
   // Test creates 3 nodes. Node 1 sends all message types to others.
   // Test confirms that nodes 2 and 3 receive all messages.
   // Then nodes 2 and 3 are restarted, node 3 is restarted at a new version
@@ -233,7 +242,7 @@ describe('p2p client integration message propagation', () => {
       const numberOfNodes = 3;
       // We start at rollup version 1
       const testConfig: MakeTestP2PClientOptions = {
-        p2pBaseConfig: { ...p2pBaseConfig, rollupVersion: 1 },
+        p2pBaseConfig: { ...p2pBaseConfig, rollupVersion: 1, p2pDisableStatusHandshake: true },
         mockAttestationPool: attestationPool,
         mockTxPool: txPool,
         mockEpochCache: epochCache,
@@ -248,11 +257,6 @@ describe('p2p client integration message propagation', () => {
         (c as any).client.p2pService.peerManager.exchangeStatusHandshake = jest.fn().mockImplementation(() => {});
       }
       const [client1, client2, client3] = clientsAndConfig;
-
-      //Disable handshake because it makes this test flaky
-      clientsAndConfig.forEach((c: any) => {
-        c.client.p2pService.peerManager.exchangeStatusHandshake = jest.fn().mockImplementation(() => {});
-      });
 
       // Give the nodes time to discover each other
       await retryUntil(async () => (await client1.client.getPeers()).length >= 2, 'peers discovered', 10, 0.5);
@@ -284,11 +288,6 @@ describe('p2p client integration message propagation', () => {
       });
 
       const clients = [newClient2, newClient3];
-
-      //Disable handshake because it makes this test flaky
-      clients.forEach((c: any) => {
-        c.p2pService.peerManager.exchangeStatusHandshake = jest.fn().mockImplementation(() => {});
-      });
 
       await startTestP2PClients(clients);
       // Give everyone time to connect again
@@ -343,22 +342,22 @@ describe('p2p client integration message propagation', () => {
         await (client1.client as any).p2pService.broadcastAttestation(attestation);
 
         // Only client 2 should receive the messages
-        const client2MessagesPromises = Promise.all([
-          client2TxPromise.promise,
-          client2ProposalPromise.promise,
-          client2AttestationPromise.promise,
-        ]);
+        const client2Messages = await retryUntil(
+          () =>
+            collectIfReady([
+              client2TxPromise.promise,
+              client2ProposalPromise.promise,
+              client2AttestationPromise.promise,
+            ]),
+          'client2 received all messages',
+          20,
+          1,
+        );
 
         // We use Promise.any as no messages should be received
-        const client3MessagesPromises = Promise.any([
-          client3TxPromise.promise,
-          client3ProposalPromise.promise,
-          client3AttestationPromise.promise,
-        ]);
-
-        const [client2Messages, client3Messages] = await Promise.all([
-          Promise.race([client2MessagesPromises, sleep(6000).then(() => undefined)]),
-          Promise.race([client3MessagesPromises, sleep(6000).then(() => undefined)]),
+        const client3Messages = await Promise.race([
+          Promise.any([client3TxPromise.promise, client3ProposalPromise.promise, client3AttestationPromise.promise]),
+          sleep(6_000).then(() => undefined),
         ]);
 
         // We expect that all messages were received by client 2


### PR DESCRIPTION
This PR attempts to deflake `p2p_client.integration_message_propagation.test.ts`
I say attempt because I'm unable to reproduce this locally, no matter how hard I try. This is why I assume it could be a timing issue (my machine being faster than CI, and messages are propagated faster).

I have noticed on the CI errors when this test is executed, and as far as I can tell, these are artifacts of not mocking everything properly, but I didn't want to waste time on this because, these same errors appear to me locally and we have had the same errors in the past, meaning they don't seem to affect if the test will pass or not. 