### PR TITLE
feat!: commence call interface unification

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/context/call_interfaces.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/call_interfaces.nr
@@ -63,8 +63,10 @@ where
             self.args_hash,
             false,
         );
-        let returns: T = returns_hash.get_preimage();
-        returns
+
+        // If T is () (i.e. if the function does not return anything) then `get_preimage` will constrain that the
+        // returns hash is empty as per the protocol rules.
+        returns_hash.get_preimage()
     }
 
     pub fn view(self, context: &mut PrivateContext) -> T {
@@ -75,93 +77,13 @@ where
             self.args_hash,
             true,
         );
+        // If T is () (i.e. if the function does not return anything) then `get_preimage` will constrain that the
+        // returns hash is empty as per the protocol rules.
         returns_hash.get_preimage()
     }
 }
 
 impl<let M: u32, T> CallInterface<M> for PrivateCallInterface<M, T> {
-    fn get_args(self) -> [Field] {
-        self.args
-    }
-
-    fn get_selector(self) -> FunctionSelector {
-        self.selector
-    }
-
-    fn get_name(self) -> str<M> {
-        self.name
-    }
-
-    fn get_contract_address(self) -> AztecAddress {
-        self.target_contract
-    }
-
-    fn get_is_static(self) -> bool {
-        self.is_static
-    }
-}
-
-// PrivateVoidCallInterface
-
-pub struct PrivateVoidCallInterface<let M: u32, T> {
-    target_contract: AztecAddress,
-    selector: FunctionSelector,
-    name: str<M>,
-    args_hash: Field,
-    args: [Field],
-    return_type: (), // Unit type () indicates this interface is for functions that return nothing (void)
-    is_static: bool,
-}
-
-impl<let M: u32, T> PrivateVoidCallInterface<M, T>
-where
-    T: Deserialize,
-{
-    pub fn new(
-        target_contract: AztecAddress,
-        selector: FunctionSelector,
-        name: str<M>,
-        args: [Field],
-        is_static: bool,
-    ) -> Self {
-        let args_hash = hash_args(args);
-        Self {
-            target_contract,
-            selector,
-            name,
-            args_hash,
-            args,
-            return_type: std::mem::zeroed(),
-            is_static,
-        }
-    }
-
-    pub fn call(self, context: &mut PrivateContext) {
-        execution_cache::store(self.args, self.args_hash);
-        context
-            .call_private_function_with_args_hash(
-                self.target_contract,
-                self.selector,
-                self.args_hash,
-                false,
-            )
-            .assert_empty();
-    }
-
-    pub fn view(self, context: &mut PrivateContext) {
-        execution_cache::store(self.args, self.args_hash);
-        context
-            .call_private_function_with_args_hash(
-                self.target_contract,
-                self.selector,
-                self.args_hash,
-                true,
-            )
-            .assert_empty();
-    }
-}
-
-impl<let M: u32, T> CallInterface<M> for PrivateVoidCallInterface<M, T> {
     fn get_args(self) -> [Field] {
         self.args
     }
@@ -251,72 +173,6 @@ impl<let M: u32, T> CallInterface<M> for PrivateStaticCallInterface<M, T> {
     }
 }
 
-// PrivateStaticVoidCallInterface
-
-pub struct PrivateStaticVoidCallInterface<let M: u32, T> {
-    target_contract: AztecAddress,
-    selector: FunctionSelector,
-    name: str<M>,
-    args_hash: Field,
-    args: [Field],
-    return_type: (), // Unit type () indicates this interface is for functions that return nothing (void)
-    is_static: bool,
-}
-
-impl<let M: u32, T> PrivateStaticVoidCallInterface<M, T> {
-    pub fn new(
-        target_contract: AztecAddress,
-        selector: FunctionSelector,
-        name: str<M>,
-        args: [Field],
-    ) -> Self {
-        let args_hash = hash_args(args);
-        Self {
-            target_contract,
-            selector,
-            name,
-            args_hash,
-            args,
-            return_type: std::mem::zeroed(),
-            is_static: true,
-        }
-    }
-
-    pub fn view(self, context: &mut PrivateContext) {
-        execution_cache::store(self.args, self.args_hash);
-        context
-            .call_private_function_with_args_hash(
-                self.target_contract,
-                self.selector,
-                self.args_hash,
-                true,
-            )
-            .assert_empty();
-    }
-}
-
-impl<let M: u32, T> CallInterface<M> for PrivateStaticVoidCallInterface<M, T> {
-    fn get_args(self) -> [Field] {
-        self.args
-    }
-
-    fn get_selector(self) -> FunctionSelector {
-        self.selector
-    }
-
-    fn get_name(self) -> str<M> {
-        self.name
-    }
-
-    fn get_contract_address(self) -> AztecAddress {
-        self.target_contract
-    }
-
-    fn get_is_static(self) -> bool {
-        self.is_static
-    }
-}
-
 // PublicCallInterface
 
 pub struct PublicCallInterface<let M: u32, T> {
@@ -363,6 +219,8 @@ where
             self.args,
             self.gas_opts,
         );
+        // If T is () (i.e. if the function does not return anything) then `as_array` will constrain that `returns` has
+        // a length of 0 (since that is ()'s deserialization length).
         Deserialize::deserialize(returns.as_array())
     }
 
@@ -373,6 +231,8 @@ where
             self.args,
             self.gas_opts,
         );
+        // If T is () (i.e. if the function does not return anything) then `as_array` will constrain that `returns` has
+        // a length of 0 (since that is ()'s deserialization length).
         Deserialize::deserialize(returns.as_array())
     }
 
@@ -402,120 +262,6 @@ where
 }
 
 impl<let M: u32, T> CallInterface<M> for PublicCallInterface<M, T> {
-    fn get_args(self) -> [Field] {
-        self.args
-    }
-
-    fn get_selector(self) -> FunctionSelector {
-        self.selector
-    }
-
-    fn get_name(self) -> str<M> {
-        self.name
-    }
-
-    fn get_contract_address(self) -> AztecAddress {
-        self.target_contract
-    }
-
-    fn get_is_static(self) -> bool {
-        self.is_static
-    }
-}
-
-// PublicVoidCallInterface
-
-pub struct PublicVoidCallInterface<let M: u32, T> {
-    target_contract: AztecAddress,
-    selector: FunctionSelector,
-    name: str<M>,
-    args: [Field],
-    return_type: (), // Unit type () indicates this interface is for functions that return nothing (void)
-    is_static: bool,
-    gas_opts: GasOpts,
-}
-
-impl<let M: u32, T> PublicVoidCallInterface<M, T> {
-    pub fn new(
-        target_contract: AztecAddress,
-        selector: FunctionSelector,
-        name: str<M>,
-        args: [Field],
-        is_static: bool,
-    ) -> Self {
-        Self {
-            target_contract,
-            selector,
-            name,
-            args,
-            return_type: std::mem::zeroed(),
-            is_static,
-            gas_opts: GasOpts::default(),
-        }
-    }
-
-    pub fn with_gas(self: &mut Self, gas_opts: GasOpts) -> &mut Self {
-        self.gas_opts = gas_opts;
-        self
-    }
-
-    pub unconstrained fn call(self, context: &mut PublicContext) {
-        let returns = context.call_public_function(
-            self.target_contract,
-            self.selector,
-            self.args,
-            self.gas_opts,
-        );
-        assert(returns.len() == 0);
-    }
-
-    pub unconstrained fn view(self, context: &mut PublicContext) {
-        let returns = context.static_call_public_function(
-            self.target_contract,
-            self.selector,
-            self.args,
-            self.gas_opts,
-        );
-        assert(returns.len() == 0);
-    }
-
-    pub fn enqueue(self, context: &mut PrivateContext) {
-        let calldata = self.args.push_front(self.selector.to_field());
-        let calldata_hash = hash_calldata(calldata);
-        execution_cache::store(calldata, calldata_hash);
-        context.call_public_function_with_calldata_hash(
-            self.target_contract,
-            calldata_hash,
-            /*static=*/
-            false,
-        )
-    }
-
-    pub fn enqueue_view(self, context: &mut PrivateContext) {
-        let calldata = self.args.push_front(self.selector.to_field());
-        let calldata_hash = hash_calldata(calldata);
-        execution_cache::store(calldata, calldata_hash);
-        context.call_public_function_with_calldata_hash(
-            self.target_contract,
-            calldata_hash,
-            /*static=*/
-            true,
-        )
-    }
-
-    pub fn set_as_teardown(self, context: &mut PrivateContext) {
-        let calldata = self.args.push_front(self.selector.to_field());
-        let calldata_hash = hash_calldata(calldata);
-        execution_cache::store(calldata, calldata_hash);
-        context.set_public_teardown_function_with_calldata_hash(
-            self.target_contract,
-            calldata_hash,
-            false,
-        )
-    }
-}
-
-impl<let M: u32, T> CallInterface<M> for PublicVoidCallInterface<M, T> {
     fn get_args(self) -> [Field] {
         self.args
     }
@@ -620,86 +366,6 @@ impl<let M: u32, T> CallInterface<M> for PublicStaticCallInterface<M, T> {
     }
 }
 
-// PublicStaticVoidCallInterface
-
-pub struct PublicStaticVoidCallInterface<let M: u32, T> {
-    target_contract: AztecAddress,
-    selector: FunctionSelector,
-    name: str<M>,
-    args: [Field],
-    return_type: (), // Unit type () indicates this interface is for functions that return nothing (void)
-    is_static: bool,
-    gas_opts: GasOpts,
-}
-
-impl<let M: u32, T> PublicStaticVoidCallInterface<M, T> {
-    pub fn new(
-        target_contract: AztecAddress,
-        selector: FunctionSelector,
-        name: str<M>,
-        args: [Field],
-    ) -> Self {
-        Self {
-            target_contract,
-            selector,
-            name,
-            args,
-            return_type: std::mem::zeroed(),
-            is_static: true,
-            gas_opts: GasOpts::default(),
-        }
-    }
-
-    pub fn with_gas(self: &mut Self, gas_opts: GasOpts) -> &mut Self {
-        self.gas_opts = gas_opts;
-        self
-    }
-
-    pub unconstrained fn view(self, context: &mut PublicContext) {
-        let returns = context.static_call_public_function(
-            self.target_contract,
-            self.selector,
-            self.args,
-            self.gas_opts,
-        );
-        assert(returns.len() == 0);
-    }
-
-    pub fn enqueue_view(self, context: &mut PrivateContext) {
-        let calldata = self.args.push_front(self.selector.to_field());
-        let calldata_hash = hash_calldata(calldata);
-        execution_cache::store(calldata, calldata_hash);
-        context.call_public_function_with_calldata_hash(
-            self.target_contract,
-            calldata_hash,
-            /*static=*/
-            true,
-        )
-    }
-}
-
-impl<let M: u32, T> CallInterface<M> for PublicStaticVoidCallInterface<M, T> {
-    fn get_args(self) -> [Field] {
-        self.args
-    }
-
-    fn get_selector(self) -> FunctionSelector {
-        self.selector
-    }
-
-    fn get_name(self) -> str<M> {
-        self.name
-    }
-
-    fn get_contract_address(self) -> AztecAddress {
-        self.target_contract
-    }
-
-    fn get_is_static(self) -> bool {
-        self.is_static
-    }
-}
-
 // UtilityCallInterface
 
 pub struct UtilityCallInterface<let M: u32, T> {
@@ -761,67 +427,6 @@ impl<let M: u32, T> UtilityCallInterface<M, T> {
     }
 }
 
-// UtilityVoidCallInterface
-
-pub struct UtilityVoidCallInterface<let M: u32, T> {
-    target_contract: AztecAddress,
-    selector: FunctionSelector,
-    name: str<M>,
-    args_hash: Field,
-    args: [Field],
-    return_type: T,
-}
-
-impl<let M: u32, T> CallInterface<M> for UtilityVoidCallInterface<M, T> {
-    fn get_args(self) -> [Field] {
-        self.args
-    }
-
-    fn get_selector(self) -> FunctionSelector {
-        self.selector
-    }
-
-    fn get_name(self) -> str<M> {
-        self.name
-    }
-
-    fn get_contract_address(self) -> AztecAddress {
-        self.target_contract
-    }
-
-    fn get_is_static(self) -> bool {
-        false
-    }
-}
-
-impl<let M: u32, T> UtilityVoidCallInterface<M, T> {
-    pub fn new(
-        target_contract: AztecAddress,
-        selector: FunctionSelector,
-        name: str<M>,
-        args: [Field],
-    ) -> Self {
-        let args_hash = hash_args(args);
-        Self { target_contract, selector, name, args_hash, args, return_type: std::mem::zeroed() }
-    }
-
-    pub fn get_args(self) -> [Field] {
-        self.args
-    }
-
-    pub fn get_selector(self) -> FunctionSelector {
-        self.selector
-    }
-
-    pub fn get_name(self) -> str<M> {
-        self.name
-    }
-
-    pub fn get_contract_address(self) -> AztecAddress {
-        self.target_contract
-    }
-}
-
 pub trait TXEPublicCallInterface<T> {
     unconstrained fn call_with_txe(self, from: AztecAddress) -> (T, Field);
 }
@@ -845,25 +450,6 @@ where
     }
 }
 
-impl<let M: u32, T> TXEPublicCallInterface<T> for PublicVoidCallInterface<M, T>
-where
-    T: Deserialize,
-{
-    unconstrained fn call_with_txe(self, from: AztecAddress) -> (T, Field) {
-        let (returns_hash, tx_hash) = txe_oracles::public_call_new_flow(
-            from,
-            self.target_contract,
-            self.selector,
-            self.args,
-            self.is_static,
-        );
-
-        let returns = ReturnsHash::new(returns_hash).get_preimage_and_assert_empty();
-
-        (returns, tx_hash)
-    }
-}
-
 impl<let M: u32, T> TXEPublicCallInterface<T> for PublicStaticCallInterface<M, T>
 where
     T: Deserialize,
@@ -878,25 +464,6 @@ where
         );
 
         let returns = ReturnsHash::new(returns_hash).get_preimage();
-
-        (returns, tx_hash)
-    }
-}
-
-impl<let M: u32, T> TXEPublicCallInterface<T> for PublicStaticVoidCallInterface<M, T>
-where
-    T: Deserialize,
-{
-    unconstrained fn call_with_txe(self, from: AztecAddress) -> (T, Field) {
-        let (returns_hash, tx_hash) = txe_oracles::public_call_new_flow(
-            from,
-            self.target_contract,
-            self.selector,
-            self.args,
-            self.is_static,
-        );
-
-        let returns = ReturnsHash::new(returns_hash).get_preimage_and_assert_empty();
 
         (returns, tx_hash)
     }
@@ -929,30 +496,6 @@ where
     }
 }
 
-impl<let M: u32, T> TXEPrivateCallInterface<T> for PrivateVoidCallInterface<M, T>
-where
-    T: Deserialize,
-{
-    unconstrained fn call_with_txe(self, from: AztecAddress) -> (T, Field) {
-        let args = self.get_args();
-        let args_hash = hash_args(args);
-        execution_cache::store(args, args_hash);
-
-        let (_end_side_effect_counter, returns_hash, tx_hash) = txe_oracles::private_call_new_flow(
-            from,
-            self.get_contract_address(),
-            self.get_selector(),
-            args,
-            args_hash,
-            self.get_is_static(),
-        );
-
-        let returns = ReturnsHash::new(returns_hash).get_preimage_and_assert_empty();
-
-        (returns, tx_hash)
-    }
-}
-
 impl<let M: u32, T> TXEPrivateCallInterface<T> for PrivateStaticCallInterface<M, T>
 where
     T: Deserialize,
@@ -972,30 +515,6 @@ where
         );
 
         let returns = ReturnsHash::new(returns_hash).get_preimage();
-
-        (returns, tx_hash)
-    }
-}
-
-impl<let M: u32, T> TXEPrivateCallInterface<T> for PrivateStaticVoidCallInterface<M, T>
-where
-    T: Deserialize,
-{
-    unconstrained fn call_with_txe(self, from: AztecAddress) -> (T, Field) {
-        let args = self.get_args();
-        let args_hash = hash_args(args);
-        execution_cache::store(args, args_hash);
-
-        let (_, returns_hash, tx_hash) = txe_oracles::private_call_new_flow(
-            from,
-            self.get_contract_address(),
-            self.get_selector(),
-            args,
-            args_hash,
-            self.get_is_static(),
-        );
-
-        let returns = ReturnsHash::new(returns_hash).get_preimage_and_assert_empty();
 
         (returns, tx_hash)
     }
@@ -1021,26 +540,6 @@ where
         );
 
         let returns: T = ReturnsHash::new(returns_hash).get_preimage();
-        returns
-    }
-}
-
-impl<let M: u32, T> TXEUtilityCallInterface<T> for UtilityVoidCallInterface<M, T>
-where
-    T: Deserialize,
-{
-    unconstrained fn call_with_txe(self) -> T {
-        let args = self.get_args();
-        let args_hash = hash_args(args);
-        execution_cache::store(args, args_hash);
-
-        let returns_hash = crate::oracle::simulate_utility_function::simulate_utility_function(
-            self.get_contract_address(),
-            self.get_selector(),
-            args_hash,
-        );
-
-        let returns = ReturnsHash::new(returns_hash).get_preimage_and_assert_empty();
         returns
     }
 }

--- a/noir-projects/aztec-nr/aztec/src/context/call_interfaces.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/call_interfaces.nr
@@ -259,6 +259,17 @@ where
             true,
         )
     }
+
+    pub fn set_as_teardown(self, context: &mut PrivateContext) {
+        let calldata = self.args.push_front(self.selector.to_field());
+        let calldata_hash = hash_calldata(calldata);
+        execution_cache::store(calldata, calldata_hash);
+        context.set_public_teardown_function_with_calldata_hash(
+            self.target_contract,
+            calldata_hash,
+            false,
+        )
+    }
 }
 
 impl<let M: u32, T> CallInterface<M> for PublicCallInterface<M, T> {

--- a/noir-projects/aztec-nr/aztec/src/context/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/mod.nr
@@ -10,9 +10,8 @@ pub mod call_interfaces;
 pub mod gas;
 
 pub use call_interfaces::{
-    PrivateCallInterface, PrivateStaticCallInterface, PrivateStaticVoidCallInterface,
-    PrivateVoidCallInterface, PublicCallInterface, PublicStaticCallInterface,
-    PublicStaticVoidCallInterface, PublicVoidCallInterface, UtilityCallInterface,
+    PrivateCallInterface, PrivateStaticCallInterface, PublicCallInterface,
+    PublicStaticCallInterface, UtilityCallInterface,
 };
 pub use private_context::PrivateContext;
 pub use public_context::PublicContext;

--- a/noir-projects/aztec-nr/aztec/src/context/returns_hash.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/returns_hash.nr
@@ -1,6 +1,13 @@
 use crate::{hash::hash_args_array, oracle::execution_cache};
 use dep::protocol_types::traits::Deserialize;
 
+/// A hash that represents a private contract function call's return value. Call `get_preimage` to get the underlying
+/// value.
+///
+/// The kernels don't process the actual return values but instead their hashes, so it is up to contracts to populate
+/// oracles with the preimages of these hashes on return to make them available to their callers.
+///
+/// Public calls don't utilize this mechanism since the AVM does process the full return values.
 pub struct ReturnsHash {
     hash: Field,
 }
@@ -10,16 +17,7 @@ impl ReturnsHash {
         ReturnsHash { hash }
     }
 
-    pub fn assert_empty(self) {
-        assert_eq(self.hash, 0);
-    }
-
-    pub fn raw(self) -> Field {
-        self.hash
-    }
-
-    /// This is only used during private execution, since in public it is the VM itself that keeps track of return
-    /// values.
+    /// Fetches the underlying return value from an oracle, constraining that it corresponds to the return data hash.
     pub fn get_preimage<T>(self) -> T
     where
         T: Deserialize,
@@ -30,18 +28,6 @@ impl ReturnsHash {
         // with a zero hash), correctly constraining `self.hash`.
         let preimage = unsafe { execution_cache::load(self.hash) };
         assert_eq(self.hash, hash_args_array(preimage), "Preimage mismatch");
-
-        Deserialize::deserialize(preimage)
-    }
-
-    pub fn get_preimage_and_assert_empty<T>(self) -> T
-    where
-        T: Deserialize,
-    {
-        // Safety: We verify that the value returned by `load` is the preimage of `hash`, fully constraining it.
-        let preimage = unsafe { execution_cache::load(self.hash) };
-        assert_eq(self.hash, hash_args_array(preimage));
-        assert_eq(self.hash, 0);
 
         Deserialize::deserialize(preimage)
     }

--- a/noir-projects/aztec-nr/aztec/src/context/returns_hash.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/returns_hash.nr
@@ -24,9 +24,12 @@ impl ReturnsHash {
     where
         T: Deserialize,
     {
-        // Safety: We verify that the value returned by `load` is the preimage of `hash`, fully constraining it.
+        // Safety: We verify that the value returned by `load` is the preimage of `hash`, fully constraining it. If `T`
+        // is `()`, then `preimage` must be an array of length 0 (since that is `()`'s deserialization length).
+        // `hash_args_array` handles empty arrays following the protocol rules (i.e. an empty args array is signaled
+        // with a zero hash), correctly constraining `self.hash`.
         let preimage = unsafe { execution_cache::load(self.hash) };
-        assert_eq(self.hash, hash_args_array(preimage));
+        assert_eq(self.hash, hash_args_array(preimage), "Preimage mismatch");
 
         Deserialize::deserialize(preimage)
     }
@@ -42,4 +45,69 @@ impl ReturnsHash {
 
         Deserialize::deserialize(preimage)
     }
+}
+
+mod test {
+    use crate::{
+        hash::hash_args_array,
+        oracle::execution_cache,
+        test::{helpers::test_environment::TestEnvironment, mocks::mock_struct::MockStruct},
+    };
+    use super::ReturnsHash;
+    use protocol_types::traits::Serialize;
+    use std::test::OracleMock;
+
+    #[test]
+    unconstrained fn retrieves_preimage() {
+        let mut env = TestEnvironment::_new();
+        env.private_context(|_| {
+            let value = MockStruct::new(4, 7);
+            let serialized = value.serialize();
+
+            let hash = hash_args_array(serialized);
+            execution_cache::store(serialized, hash);
+
+            assert_eq(ReturnsHash::new(hash).get_preimage(), value);
+        });
+    }
+
+    #[test]
+    unconstrained fn retrieves_empty_preimage() {
+        let mut env = TestEnvironment::_new();
+        env.private_context(|_| {
+            let value = ();
+            let serialized = [];
+
+            let hash = hash_args_array(serialized);
+            execution_cache::store(serialized, hash);
+
+            assert_eq(ReturnsHash::new(hash).get_preimage(), value);
+        });
+    }
+
+    #[test(should_fail_with = "Preimage mismatch")]
+    unconstrained fn rejects_bad_preimage() {
+        let value = MockStruct::new(4, 7);
+        let serialized = value.serialize();
+
+        let mut bad_serialized = serialized;
+        bad_serialized[0] += 1;
+
+        let hash = hash_args_array(serialized);
+
+        let _ = OracleMock::mock("loadFromExecutionCache").returns(bad_serialized);
+        assert_eq(ReturnsHash::new(hash).get_preimage(), value);
+    }
+
+    // This test passes due to a Noir bug.
+    // #[test(should_fail_with="Preimage mismatch")]
+    // unconstrained fn rejects_bad_empty_preimage() {
+    //     let value = ();
+    //     let serialized = [];
+
+    //     let hash = hash_args_array(serialized);
+
+    //     let _ = OracleMock::mock("loadFromExecutionCache").returns([1]);
+    //     assert_eq(ReturnsHash::new(hash).get_preimage(), value);
+    // }
 }

--- a/noir-projects/aztec-nr/aztec/src/macros/functions/call_interface_stubs.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/functions/call_interface_stubs.nr
@@ -17,42 +17,21 @@ comptime global SERIALIZED_ARGS_NAME: Quoted = quote { serialized_args };
 
 pub comptime fn stub_fn(f: FunctionDefinition) -> Quoted {
     let is_static_call = is_fn_view(f);
-    let is_void = f.return_type() == type_of(());
 
     if is_fn_private(f) {
         if is_static_call {
-            if is_void {
-                create_private_static_void_stub(f)
-            } else {
-                create_private_static_stub(f)
-            }
+            create_private_static_stub(f)
         } else {
-            if is_void {
-                create_private_void_stub(f)
-            } else {
-                create_private_stub(f)
-            }
+            create_private_stub(f)
         }
     } else if is_fn_public(f) {
         if is_static_call {
-            if is_void {
-                create_public_static_void_stub(f)
-            } else {
-                create_public_static_stub(f)
-            }
+            create_public_static_stub(f)
         } else {
-            if is_void {
-                create_public_void_stub(f)
-            } else {
-                create_public_stub(f)
-            }
+            create_public_stub(f)
         }
     } else {
-        if is_void {
-            create_utility_void_stub(f)
-        } else {
-            create_utility_stub(f)
-        }
+        create_utility_stub(f)
     }
 }
 
@@ -146,43 +125,6 @@ comptime fn create_private_static_stub(f: FunctionDefinition) -> Quoted {
     }
 }
 
-comptime fn create_private_void_stub(f: FunctionDefinition) -> Quoted {
-    let (fn_name, fn_parameters_list, serialized_args_slice_construction, fn_name_str, fn_name_len, fn_selector) =
-        create_stub_base(f);
-
-    quote {
-        pub fn $fn_name(self, $fn_parameters_list) -> dep::aztec::context::call_interfaces::PrivateVoidCallInterface<$fn_name_len, ()> {
-            $serialized_args_slice_construction
-            let selector = $FROM_FIELD($fn_selector);
-            dep::aztec::context::call_interfaces::PrivateVoidCallInterface::new(
-                self.target_contract,
-                selector,
-                $fn_name_str,
-                $SERIALIZED_ARGS_NAME,
-                false
-            )
-        }
-    }
-}
-
-comptime fn create_private_static_void_stub(f: FunctionDefinition) -> Quoted {
-    let (fn_name, fn_parameters_list, serialized_args_slice_construction, fn_name_str, fn_name_len, fn_selector) =
-        create_stub_base(f);
-
-    quote {
-        pub fn $fn_name(self, $fn_parameters_list) -> dep::aztec::context::call_interfaces::PrivateStaticVoidCallInterface<$fn_name_len, ()> {
-            $serialized_args_slice_construction
-            let selector = $FROM_FIELD($fn_selector);
-            dep::aztec::context::call_interfaces::PrivateStaticVoidCallInterface::new(
-                self.target_contract,
-                selector,
-                $fn_name_str,
-                serialized_args
-            )
-        }
-    }
-}
-
 comptime fn create_public_stub(f: FunctionDefinition) -> Quoted {
     let (fn_name, fn_parameters_list, serialized_args_slice_construction, fn_name_str, fn_name_len, fn_selector) =
         create_stub_base(f);
@@ -222,43 +164,6 @@ comptime fn create_public_static_stub(f: FunctionDefinition) -> Quoted {
     }
 }
 
-comptime fn create_public_void_stub(f: FunctionDefinition) -> Quoted {
-    let (fn_name, fn_parameters_list, serialized_args_slice_construction, fn_name_str, fn_name_len, fn_selector) =
-        create_stub_base(f);
-
-    quote {
-        pub fn $fn_name(self, $fn_parameters_list) -> dep::aztec::context::call_interfaces::PublicVoidCallInterface<$fn_name_len, ()> {
-            $serialized_args_slice_construction
-            let selector = $FROM_FIELD($fn_selector);
-            dep::aztec::context::call_interfaces::PublicVoidCallInterface::new(
-                self.target_contract,
-                selector,
-                $fn_name_str,
-                $SERIALIZED_ARGS_NAME,
-                false
-            )
-        }
-    }
-}
-
-comptime fn create_public_static_void_stub(f: FunctionDefinition) -> Quoted {
-    let (fn_name, fn_parameters_list, serialized_args_slice_construction, fn_name_str, fn_name_len, fn_selector) =
-        create_stub_base(f);
-
-    quote {
-        pub fn $fn_name(self, $fn_parameters_list) -> dep::aztec::context::call_interfaces::PublicStaticVoidCallInterface<$fn_name_len, ()> {
-            $serialized_args_slice_construction
-            let selector = $FROM_FIELD($fn_selector);
-            dep::aztec::context::call_interfaces::PublicStaticVoidCallInterface::new(
-                self.target_contract,
-                selector,
-                $fn_name_str,
-                serialized_args
-            )
-        }
-    }
-}
-
 comptime fn create_utility_stub(f: FunctionDefinition) -> Quoted {
     let (fn_name, fn_parameters_list, serialized_args_slice_construction, fn_name_str, fn_name_len, fn_selector) =
         create_stub_base(f);
@@ -272,27 +177,6 @@ comptime fn create_utility_stub(f: FunctionDefinition) -> Quoted {
             $serialized_args_slice_construction
             let selector = $FROM_FIELD($fn_selector);
             dep::aztec::context::call_interfaces::UtilityCallInterface::new(
-                self.target_contract,
-                selector,
-                $fn_name_str,
-                $SERIALIZED_ARGS_NAME,
-            )
-        }
-    }
-}
-
-comptime fn create_utility_void_stub(f: FunctionDefinition) -> Quoted {
-    let (fn_name, fn_parameters_list, serialized_args_slice_construction, fn_name_str, fn_name_len, fn_selector) =
-        create_stub_base(f);
-
-    // This is here because utility function call interfaces can only be used within TXe tests.
-    let modified_fn_name = f"_experimental_{fn_name}".quoted_contents();
-
-    quote {
-        pub fn $modified_fn_name(self, $fn_parameters_list) -> dep::aztec::context::call_interfaces::UtilityVoidCallInterface<$fn_name_len, ()> {
-            $serialized_args_slice_construction
-            let selector = $FROM_FIELD($fn_selector);
-            dep::aztec::context::call_interfaces::UtilityVoidCallInterface::new(
                 self.target_contract,
                 selector,
                 $fn_name_str,

--- a/noir-projects/aztec-nr/aztec/src/macros/functions/call_interface_stubs.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/functions/call_interface_stubs.nr
@@ -1,7 +1,7 @@
 use crate::macros::utils::{
     add_to_field_array, AsStrQuote, compute_fn_selector, is_fn_private, is_fn_public, is_fn_view,
 };
-use std::meta::{type_of, unquote};
+use std::meta::unquote;
 
 comptime global FROM_FIELD: TypedExpr = {
     let from_field_trait = quote { protocol_types::traits::FromField }.as_trait_constraint();

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/authwit.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/authwit.nr
@@ -1,6 +1,6 @@
 use crate::{
     authwit::auth::{compute_authwit_message_hash, compute_inner_authwit_hash},
-    context::call_interfaces::{CallInterface, PublicVoidCallInterface},
+    context::call_interfaces::{CallInterface, PublicCallInterface},
     hash::hash_args,
     oracle::execution::{get_chain_id, get_version},
     test::helpers::{test_environment::TestEnvironment, txe_oracles},
@@ -48,9 +48,9 @@ where
         compute_inner_authwit_hash([caller.to_field(), selector.to_field(), args_hash]);
     let message_hash = compute_authwit_message_hash(target, chain_id, version, inner_hash);
 
-    let _ = env.call_public_void(
+    let _ = env.call_public(
         on_behalf_of,
-        PublicVoidCallInterface::<_, ()>::new(
+        PublicCallInterface::<_, ()>::new(
             CANONICAL_AUTH_REGISTRY_ADDRESS,
             comptime { FunctionSelector::from_signature("set_authorized(Field,bool)") },
             "set_authorized",

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
@@ -472,23 +472,6 @@ impl TestEnvironment {
         returns
     }
 
-    pub unconstrained fn simulate_void_utility<T, let M: u32>(
-        _self: Self,
-        call_interface: UtilityCallInterface<M, T>,
-    ) {
-        let args = call_interface.get_args();
-        let args_hash = hash_args(args);
-        execution_cache::store(args, args_hash);
-
-        let returns_hash = crate::oracle::simulate_utility_function::simulate_utility_function(
-            call_interface.get_contract_address(),
-            call_interface.get_selector(),
-            args_hash,
-        );
-
-        ReturnsHash::new(returns_hash).assert_empty();
-    }
-
     pub unconstrained fn call_public<T, let M: u32>(
         _self: Self,
         from: AztecAddress,

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
@@ -13,11 +13,9 @@ use crate::{
         PrivateCallInterface,
         PrivateContext,
         PrivateStaticCallInterface,
-        PrivateVoidCallInterface,
         PublicCallInterface,
         PublicContext,
         PublicStaticCallInterface,
-        PublicVoidCallInterface,
         ReturnsHash,
         UtilityCallInterface,
         UtilityContext,
@@ -429,29 +427,6 @@ impl TestEnvironment {
         CallResult { return_value: returns, tx_hash }
     }
 
-    pub unconstrained fn call_private_void<let M: u32, T>(
-        _self: Self,
-        from: AztecAddress,
-        call_interface: PrivateVoidCallInterface<M, T>,
-    ) -> CallResult<()> {
-        let args = call_interface.get_args();
-        let args_hash = hash_args(args);
-        execution_cache::store(args, args_hash);
-
-        let (_end_side_effect_counter, returns_hash, tx_hash) = txe_oracles::private_call_new_flow(
-            from,
-            call_interface.get_contract_address(),
-            call_interface.get_selector(),
-            args,
-            args_hash,
-            call_interface.get_is_static(),
-        );
-
-        ReturnsHash::new(returns_hash).assert_empty();
-
-        CallResult { return_value: (), tx_hash }
-    }
-
     pub unconstrained fn view_private<T, let M: u32>(
         _self: Self,
         from: AztecAddress,
@@ -533,24 +508,6 @@ impl TestEnvironment {
         // This shouldn't be using ReturnsHash, but I don't think CalldataHash is right either in this context
         let returns: T = ReturnsHash::new(returns_hash).get_preimage();
         CallResult { return_value: returns, tx_hash }
-    }
-
-    pub unconstrained fn call_public_void<T, let M: u32>(
-        _self: Self,
-        from: AztecAddress,
-        call_interface: PublicVoidCallInterface<M, T>,
-    ) -> CallResult<()> {
-        let (returns_hash, tx_hash) = public_call_new_flow(
-            from,
-            call_interface.get_contract_address(),
-            call_interface.get_selector(),
-            call_interface.get_args(),
-            false,
-        );
-
-        ReturnsHash::new(returns_hash).assert_empty();
-
-        CallResult { return_value: (), tx_hash }
     }
 
     pub unconstrained fn view_public<T, let M: u32>(

--- a/noir-projects/noir-contracts/contracts/app/auth_contract/src/test/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/auth_contract/src/test/main.nr
@@ -25,10 +25,8 @@ unconstrained fn main() {
     let expected_timestamp_of_first_change = GENESIS_TIMESTAMP + Auth::CHANGE_AUTHORIZED_DELAY;
 
     let admin_sets_authorized = || {
-        let _ = env.call_public_void(
-            admin,
-            Auth::at(auth_contract_address).set_authorized(to_authorize),
-        );
+        let _ =
+            env.call_public(admin, Auth::at(auth_contract_address).set_authorized(to_authorize));
 
         let (scheduled_authorized, timestamp_of_change) =
             env.view_public(Auth::at(auth_contract_address).get_scheduled_authorized());
@@ -58,7 +56,7 @@ unconstrained fn main() {
         );
         assert_eq(authorized_in_private_again, to_authorize);
 
-        let _ = env.call_private_void(
+        let _ = env.call_private(
             to_authorize,
             Auth::at(auth_contract_address).do_private_authorized_thing(),
         );
@@ -69,7 +67,7 @@ unconstrained fn main() {
         expected_timestamp_of_first_change + Auth::CHANGE_AUTHORIZED_DELAY;
 
     let authorize_other = || {
-        let _ = env.call_public_void(admin, Auth::at(auth_contract_address).set_authorized(other));
+        let _ = env.call_public(admin, Auth::at(auth_contract_address).set_authorized(other));
 
         let (scheduled_authorized, timestamp_of_change) =
             env.view_public(Auth::at(auth_contract_address).get_scheduled_authorized());
@@ -82,7 +80,7 @@ unconstrained fn main() {
             env.view_public(Auth::at(auth_contract_address).get_authorized());
         assert_eq(authorized, to_authorize);
 
-        let _ = env.call_private_void(
+        let _ = env.call_private(
             to_authorize,
             Auth::at(auth_contract_address).do_private_authorized_thing(),
         );
@@ -110,10 +108,8 @@ unconstrained fn main() {
 
         env.assert_private_call_fails(Auth::at(auth_contract_address).do_private_authorized_thing());
 
-        let _ = env.call_private_void(
-            other,
-            Auth::at(auth_contract_address).do_private_authorized_thing(),
-        );
+        let _ =
+            env.call_private(other, Auth::at(auth_contract_address).do_private_authorized_thing());
     };
     authorized_becomes_effective_after_delay_again();
 }

--- a/noir-projects/noir-contracts/contracts/app/easy_private_voting_contract/src/test/first.nr
+++ b/noir-projects/noir-contracts/contracts/app/easy_private_voting_contract/src/test/first.nr
@@ -27,7 +27,7 @@ unconstrained fn test_check_vote_status() {
 unconstrained fn test_end_vote() {
     let (env, voting_contract_address, admin) = utils::setup();
 
-    let _ = env.call_public_void(admin, EasyPrivateVoting::at(voting_contract_address).end_vote());
+    let _ = env.call_public(admin, EasyPrivateVoting::at(voting_contract_address).end_vote());
 
     env.public_context_at(voting_contract_address, |context| {
         let vote_ended = context.storage_read(EasyPrivateVoting::storage_layout().vote_ended.slot);
@@ -40,7 +40,7 @@ unconstrained fn test_fail_end_vote_by_non_admin() {
     let (env, voting_contract_address, _) = utils::setup();
     let alice = env.create_account(2);
 
-    let _ = env.call_public_void(alice, EasyPrivateVoting::at(voting_contract_address).end_vote());
+    let _ = env.call_public(alice, EasyPrivateVoting::at(voting_contract_address).end_vote());
 }
 
 #[test]
@@ -49,7 +49,7 @@ unconstrained fn test_cast_vote() {
     let alice = env.create_account(2);
 
     let candidate = 1;
-    let _ = env.call_private_void(
+    let _ = env.call_private(
         alice,
         EasyPrivateVoting::at(voting_contract_address).cast_vote(candidate),
     );
@@ -71,15 +71,13 @@ unconstrained fn test_cast_vote_with_separate_accounts() {
 
     let candidate = 101;
 
-    let _ = env.call_private_void(
+    let _ = env.call_private(
         alice,
         EasyPrivateVoting::at(voting_contract_address).cast_vote(candidate),
     );
 
-    let _ = env.call_private_void(
-        bob,
-        EasyPrivateVoting::at(voting_contract_address).cast_vote(candidate),
-    );
+    let _ =
+        env.call_private(bob, EasyPrivateVoting::at(voting_contract_address).cast_vote(candidate));
 
     env.public_context_at(voting_contract_address, |context| {
         let vote_count = context.storage_read(derive_storage_slot_in_map(
@@ -97,12 +95,12 @@ unconstrained fn test_fail_vote_twice() {
 
     let candidate = 101;
 
-    let _ = env.call_private_void(
+    let _ = env.call_private(
         alice,
         EasyPrivateVoting::at(voting_contract_address).cast_vote(candidate),
     );
 
-    let _ = env.call_private_void(
+    let _ = env.call_private(
         alice,
         EasyPrivateVoting::at(voting_contract_address).cast_vote(candidate),
     );

--- a/noir-projects/noir-contracts/contracts/app/nft_contract/src/test/access_control.nr
+++ b/noir-projects/noir-contracts/contracts/app/nft_contract/src/test/access_control.nr
@@ -11,18 +11,18 @@ unconstrained fn access_control() {
     let nft = NFT::at(nft_contract_address);
 
     // Set a new admin
-    let _ = env.call_public_void(owner, nft.set_admin(new_admin));
+    let _ = env.call_public(owner, nft.set_admin(new_admin));
     assert_eq(env.view_public(nft.get_admin()), new_admin.to_field());
 
     // Check new admin is not a minter
     assert(!env.view_public(nft.is_minter(new_admin)));
 
     // Set new admin as minter
-    let _ = env.call_public_void(new_admin, nft.set_minter(new_admin, true));
+    let _ = env.call_public(new_admin, nft.set_minter(new_admin, true));
     assert(env.view_public(nft.is_minter(new_admin)));
 
     // Revoke minter as admin
-    let _ = env.call_public_void(new_admin, nft.set_minter(new_admin, false));
+    let _ = env.call_public(new_admin, nft.set_minter(new_admin, false));
     assert(!env.view_public(nft.is_minter(new_admin)));
 }
 
@@ -33,7 +33,7 @@ unconstrained fn set_admin_requires_admin_caller() {
 
     let nft = NFT::at(nft_contract_address);
 
-    let _ = env.call_public_void(other, nft.set_admin(other));
+    let _ = env.call_public(other, nft.set_admin(other));
 }
 
 #[test(should_fail)]
@@ -43,5 +43,5 @@ unconstrained fn set_minter_requires_admin_caller() {
 
     let nft = NFT::at(nft_contract_address);
 
-    let _ = env.call_public_void(other, nft.set_minter(other, true));
+    let _ = env.call_public(other, nft.set_minter(other, true));
 }

--- a/noir-projects/noir-contracts/contracts/app/nft_contract/src/test/minting.nr
+++ b/noir-projects/noir-contracts/contracts/app/nft_contract/src/test/minting.nr
@@ -8,7 +8,7 @@ unconstrained fn mint_success() {
     let (env, nft_contract_address, owner, _) = utils::setup(/* with_account_contracts */ false);
 
     let token_id = 10000;
-    let _ = env.call_public_void(owner, NFT::at(nft_contract_address).mint(owner, token_id));
+    let _ = env.call_public(owner, NFT::at(nft_contract_address).mint(owner, token_id));
 
     utils::assert_owns_public_nft(env, nft_contract_address, owner, token_id);
 }
@@ -19,7 +19,7 @@ unconstrained fn mint_as_non_minter_fails() {
     let (env, nft_contract_address, owner, other) = utils::setup(/* with_account_contracts */ false);
 
     let token_id = 10000;
-    let _ = env.call_public_void(other, NFT::at(nft_contract_address).mint(owner, token_id));
+    let _ = env.call_public(other, NFT::at(nft_contract_address).mint(owner, token_id));
 }
 
 #[test(should_fail)] // should_fail_with="NFT not minted"
@@ -28,7 +28,7 @@ unconstrained fn mint_twice_fails() {
     let (env, nft_contract_address, owner, _) = utils::setup(/* with_account_contracts */ false);
 
     let token_id = 10000;
-    let _ = env.call_public_void(owner, NFT::at(nft_contract_address).mint(owner, token_id));
+    let _ = env.call_public(owner, NFT::at(nft_contract_address).mint(owner, token_id));
 
     env.utility_context_at(nft_contract_address, |context| {
         let nft_exists_slot = NFT::storage_layout().nft_exists.slot;
@@ -36,7 +36,7 @@ unconstrained fn mint_twice_fails() {
         assert(context.storage_read(nft_slot));
     });
 
-    let _ = env.call_public_void(owner, NFT::at(nft_contract_address).mint(owner, token_id));
+    let _ = env.call_public(owner, NFT::at(nft_contract_address).mint(owner, token_id));
 }
 
 #[test(should_fail)]
@@ -44,5 +44,5 @@ unconstrained fn mint_id_0_fails() {
     // Setup without account contracts. We are not using authwits here, so dummy accounts are enough
     let (env, nft_contract_address, owner, _) = utils::setup(/* with_account_contracts */ false);
 
-    let _ = env.call_public_void(owner, NFT::at(nft_contract_address).mint(owner, 0));
+    let _ = env.call_public(owner, NFT::at(nft_contract_address).mint(owner, 0));
 }

--- a/noir-projects/noir-contracts/contracts/app/nft_contract/src/test/transfer_in_private.nr
+++ b/noir-projects/noir-contracts/contracts/app/nft_contract/src/test/transfer_in_private.nr
@@ -12,7 +12,7 @@ unconstrained fn transfer_in_private() {
         utils::setup_mint_and_transfer_to_private(/* with_account_contracts */ false);
 
     // Transfer the NFT to the recipient
-    let _ = env.call_private_void(
+    let _ = env.call_private(
         sender,
         NFT::at(nft_contract_address).transfer_in_private(sender, recipient, token_id, 0),
     );
@@ -28,7 +28,7 @@ unconstrained fn transfer_in_private_to_self() {
         utils::setup_mint_and_transfer_to_private(/* with_account_contracts */ false);
 
     // Transfer the NFT back to the owner
-    let _ = env.call_private_void(
+    let _ = env.call_private(
         owner,
         NFT::at(nft_contract_address).transfer_in_private(owner, owner, token_id, 0),
     );
@@ -45,7 +45,7 @@ unconstrained fn transfer_in_private_to_non_deployed_account() {
     let not_deployed = txe_oracles::create_account(999);
 
     // Transfer the NFT to the recipient
-    let _ = env.call_private_void(
+    let _ = env.call_private(
         sender,
         NFT::at(nft_contract_address).transfer_in_private(sender, not_deployed.address, token_id, 0),
     );
@@ -66,7 +66,7 @@ unconstrained fn transfer_in_private_on_behalf_of_other() {
     add_private_authwit_from_call_interface(sender, recipient, transfer_in_private_call_interface);
 
     // Transfer the NFT to the recipient
-    let _ = env.call_private_void(recipient, transfer_in_private_call_interface);
+    let _ = env.call_private(recipient, transfer_in_private_call_interface);
 
     // Recipient should be the private NFT owner
     utils::assert_owns_private_nft(env, nft_contract_address, recipient, token_id);
@@ -78,7 +78,7 @@ unconstrained fn transfer_in_private_failure_not_an_owner() {
     let (env, nft_contract_address, owner, not_owner, token_id) =
         utils::setup_mint_and_transfer_to_private(/* with_account_contracts */ false);
 
-    let _ = env.call_private_void(
+    let _ = env.call_private(
         not_owner,
         NFT::at(nft_contract_address).transfer_in_private(not_owner, owner, token_id, 0),
     );
@@ -96,7 +96,7 @@ unconstrained fn transfer_in_private_failure_on_behalf_of_self_non_zero_nonce() 
     let token_id = random();
 
     // Try transferring the NFT
-    let _ = env.call_private_void(
+    let _ = env.call_private(
         sender,
         NFT::at(nft_contract_address).transfer_in_private(sender, recipient, token_id, 1),
     );
@@ -114,7 +114,7 @@ unconstrained fn transfer_in_private_failure_on_behalf_of_other_without_approval
     let token_id = random();
 
     // Try transferring the NFT
-    let _ = env.call_private_void(
+    let _ = env.call_private(
         recipient,
         NFT::at(nft_contract_address).transfer_in_private(sender, recipient, token_id, 1),
     );
@@ -140,5 +140,5 @@ unconstrained fn transfer_in_private_failure_on_behalf_of_other_wrong_caller() {
     );
 
     // Try transferring the NFT
-    let _ = env.call_private_void(recipient, transfer_in_private_from_call_interface);
+    let _ = env.call_private(recipient, transfer_in_private_from_call_interface);
 }

--- a/noir-projects/noir-contracts/contracts/app/nft_contract/src/test/transfer_in_public.nr
+++ b/noir-projects/noir-contracts/contracts/app/nft_contract/src/test/transfer_in_public.nr
@@ -9,7 +9,7 @@ unconstrained fn transfer_in_public() {
         utils::setup_and_mint(/* with_account_contracts */ false);
 
     // Transfer the NFT
-    let _ = env.call_public_void(
+    let _ = env.call_public(
         sender,
         NFT::at(nft_contract_address).transfer_in_public(sender, recipient, token_id, 0),
     );
@@ -24,7 +24,7 @@ unconstrained fn transfer_in_public_to_self() {
         utils::setup_and_mint(/* with_account_contracts */ false);
 
     // Transfer the NFT
-    let _ = env.call_public_void(
+    let _ = env.call_public(
         user,
         NFT::at(nft_contract_address).transfer_in_public(user, user, token_id, 0),
     );
@@ -49,7 +49,7 @@ unconstrained fn transfer_in_public_on_behalf_of_other() {
     );
 
     // Transfer the NFT
-    let _ = env.call_public_void(recipient, transfer_in_public_from_call_interface);
+    let _ = env.call_public(recipient, transfer_in_public_from_call_interface);
 
     // Check the is recipient is the new public owner
     utils::assert_owns_public_nft(env, nft_contract_address, recipient, token_id);
@@ -64,7 +64,7 @@ unconstrained fn transfer_in_public_failure_on_behalf_of_self_non_zero_nonce() {
         utils::setup(/* with_account_contracts */ false);
 
     let token_id = 1;
-    let _ = env.call_public_void(
+    let _ = env.call_public(
         sender,
         NFT::at(nft_contract_address).transfer_in_public(sender, recipient, token_id, 1),
     );
@@ -77,7 +77,7 @@ unconstrained fn transfer_in_public_non_existent_nft() {
         utils::setup(/* with_account_contracts */ false);
 
     let token_id = 1;
-    let _ = env.call_public_void(
+    let _ = env.call_public(
         sender,
         NFT::at(nft_contract_address).transfer_in_public(sender, recipient, token_id, 0),
     );
@@ -89,7 +89,7 @@ unconstrained fn transfer_in_public_failure_on_behalf_of_other_without_approval(
     let (env, nft_contract_address, sender, recipient, token_id) =
         utils::setup_and_mint(/* with_account_contracts */ true);
 
-    let _ = env.call_public_void(
+    let _ = env.call_public(
         recipient,
         NFT::at(nft_contract_address).transfer_in_public(sender, recipient, token_id, 0),
     );
@@ -110,5 +110,5 @@ unconstrained fn transfer_in_public_failure_on_behalf_of_other_wrong_caller() {
     );
 
     // Try to transfer tokens
-    let _ = env.call_public_void(recipient, transfer_in_public_from_call_interface);
+    let _ = env.call_public(recipient, transfer_in_public_from_call_interface);
 }

--- a/noir-projects/noir-contracts/contracts/app/nft_contract/src/test/transfer_to_private.nr
+++ b/noir-projects/noir-contracts/contracts/app/nft_contract/src/test/transfer_to_private.nr
@@ -37,7 +37,7 @@ unconstrained fn transfer_to_private_external_orchestration() {
         .return_value;
 
     // Finalize the transfer of the NFT (message sender owns the NFT in public)
-    let _ = env.call_public_void(
+    let _ = env.call_public(
         owner,
         NFT::at(nft_contract_address).finalize_transfer_to_private(token_id, partial_note),
     );
@@ -59,7 +59,7 @@ unconstrained fn transfer_to_private_transfer_not_prepared() {
     let partial_note = PartialNFTNote { commitment: random() };
 
     // Try finalizing the transfer without preparing it
-    let _ = env.call_public_void(
+    let _ = env.call_public(
         owner,
         NFT::at(nft_contract_address).finalize_transfer_to_private(token_id, partial_note),
     );
@@ -82,7 +82,7 @@ unconstrained fn transfer_to_private_failure_not_an_owner() {
         .return_value;
 
     // Try transferring someone else's public NFT
-    let _ = env.call_public_void(
+    let _ = env.call_public(
         not_owner,
         NFT::at(nft_contract_address).finalize_transfer_to_private(token_id, partial_note),
     );
@@ -107,7 +107,7 @@ unconstrained fn incorrect_completer_cannot_complete_partial_note() {
 
     // Now we try to complete the partial note as another completer. Note that the caller here is the owner of the token
     // we're transferring - this is so that we pass the owner check and fail on the partial note completer check.
-    let _ = env.call_public_void(
+    let _ = env.call_public(
         owner,
         NFT::at(nft_contract_address).finalize_transfer_to_private(token_id, partial_note),
     );

--- a/noir-projects/noir-contracts/contracts/app/nft_contract/src/test/transfer_to_public.nr
+++ b/noir-projects/noir-contracts/contracts/app/nft_contract/src/test/transfer_to_public.nr
@@ -10,7 +10,7 @@ unconstrained fn transfer_to_public() {
     let (env, nft_contract_address, sender, recipient, token_id) =
         utils::setup_mint_and_transfer_to_private(/* with_account_contracts */ false);
 
-    let _ = env.call_private_void(
+    let _ = env.call_private(
         sender,
         NFT::at(nft_contract_address).transfer_to_public(sender, recipient, token_id, 0),
     );
@@ -25,7 +25,7 @@ unconstrained fn transfer_to_public_to_self() {
     let (env, nft_contract_address, user, _, token_id) =
         utils::setup_mint_and_transfer_to_private(/* with_account_contracts */ false);
 
-    let _ = env.call_private_void(
+    let _ = env.call_private(
         user,
         NFT::at(nft_contract_address).transfer_to_public(user, user, token_id, 0),
     );
@@ -44,7 +44,7 @@ unconstrained fn transfer_to_public_on_behalf_of_other() {
     add_private_authwit_from_call_interface(sender, recipient, transfer_to_public_call_interface);
 
     // transfer_to_public the NFT
-    let _ = env.call_private_void(recipient, transfer_to_public_call_interface);
+    let _ = env.call_private(recipient, transfer_to_public_call_interface);
 
     // Recipient should be the public owner
     utils::assert_owns_public_nft(env, nft_contract_address, recipient, token_id);
@@ -56,7 +56,7 @@ unconstrained fn transfer_to_public_failure_not_an_owner() {
     let (env, nft_contract_address, _, not_owner, token_id) =
         utils::setup_mint_and_transfer_to_private(/* with_account_contracts */ false);
 
-    let _ = env.call_private_void(
+    let _ = env.call_private(
         not_owner,
         NFT::at(nft_contract_address).transfer_to_public(not_owner, not_owner, token_id, 0),
     );
@@ -68,7 +68,7 @@ unconstrained fn transfer_to_public_failure_on_behalf_of_self_non_zero_nonce() {
     let (env, nft_contract_address, user, _, token_id) =
         utils::setup_mint_and_transfer_to_private(/* with_account_contracts */ false);
 
-    let _ = env.call_private_void(
+    let _ = env.call_private(
         user,
         NFT::at(nft_contract_address).transfer_to_public(user, user, token_id, random()),
     );
@@ -84,7 +84,7 @@ unconstrained fn transfer_to_public_failure_on_behalf_of_other_invalid_designate
     add_private_authwit_from_call_interface(sender, sender, transfer_to_public_call_interface);
 
     // transfer_to_public the NFT
-    let _ = env.call_private_void(recipient, transfer_to_public_call_interface);
+    let _ = env.call_private(recipient, transfer_to_public_call_interface);
 }
 
 #[test(should_fail_with = "Unknown auth witness for message hash")]
@@ -93,7 +93,7 @@ unconstrained fn transfer_to_public_failure_on_behalf_of_other_no_approval() {
         utils::setup_mint_and_transfer_to_private(/* with_account_contracts */ true);
 
     // transfer_to_public the NFT
-    let _ = env.call_private_void(
+    let _ = env.call_private(
         recipient,
         NFT::at(nft_contract_address).transfer_to_public(sender, recipient, token_id, 0),
     );

--- a/noir-projects/noir-contracts/contracts/app/nft_contract/src/test/utils.nr
+++ b/noir-projects/noir-contracts/contracts/app/nft_contract/src/test/utils.nr
@@ -46,7 +46,7 @@ pub unconstrained fn setup_and_mint(
     let (env, nft_contract_address, owner, recipient) = setup(with_account_contracts);
     let minted_token_id = 615;
 
-    let _ = env.call_public_void(owner, NFT::at(nft_contract_address).mint(owner, minted_token_id));
+    let _ = env.call_public(owner, NFT::at(nft_contract_address).mint(owner, minted_token_id));
 
     (env, nft_contract_address, owner, recipient, minted_token_id)
 }
@@ -58,7 +58,7 @@ pub unconstrained fn setup_mint_and_transfer_to_private(
         setup_and_mint(with_account_contracts);
 
     // We transfer the public NFT to private.
-    let _ = env.call_private_void(
+    let _ = env.call_private(
         owner,
         NFT::at(nft_contract_address).transfer_to_private(owner, minted_token_id),
     );

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/test/access_control.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/test/access_control.nr
@@ -11,18 +11,18 @@ unconstrained fn access_control() {
     let token = Token::at(token_contract_address);
 
     // Set a new admin
-    let _ = env.call_public_void(owner, token.set_admin(new_admin));
+    let _ = env.call_public(owner, token.set_admin(new_admin));
     assert_eq(env.view_public(token.get_admin()), new_admin.to_field());
 
     // Check new admin is not a minter
     assert(!env.view_public(token.is_minter(new_admin)));
 
     // Set new admin as minter
-    let _ = env.call_public_void(new_admin, token.set_minter(new_admin, true));
+    let _ = env.call_public(new_admin, token.set_minter(new_admin, true));
     assert(env.view_public(token.is_minter(new_admin)));
 
     // Revoke minter as admin
-    let _ = env.call_public_void(new_admin, token.set_minter(new_admin, false));
+    let _ = env.call_public(new_admin, token.set_minter(new_admin, false));
     assert(!env.view_public(token.is_minter(new_admin)));
 }
 
@@ -33,7 +33,7 @@ unconstrained fn set_admin_requires_admin_caller() {
 
     let token = Token::at(token_contract_address);
 
-    let _ = env.call_public_void(other, token.set_admin(other));
+    let _ = env.call_public(other, token.set_admin(other));
 }
 
 #[test(should_fail)]
@@ -43,5 +43,5 @@ unconstrained fn set_minter_requires_admin_caller() {
 
     let token = Token::at(token_contract_address);
 
-    let _ = env.call_public_void(other, token.set_minter(other, true));
+    let _ = env.call_public(other, token.set_minter(other, true));
 }

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/test/burn_private.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/test/burn_private.nr
@@ -11,7 +11,7 @@ unconstrained fn burn_private_on_behalf_of_self() {
     let burn_amount = mint_amount / (10 as u128);
 
     // Burn less than balance
-    let _ = env.call_private_void(
+    let _ = env.call_private(
         owner,
         Token::at(token_contract_address).burn_private(owner, burn_amount, 0),
     );
@@ -34,7 +34,7 @@ unconstrained fn burn_private_on_behalf_of_other() {
         Token::at(token_contract_address).burn_private(owner, burn_amount, AUTHWIT_NONCE);
     add_private_authwit_from_call_interface(owner, recipient, burn_call_interface);
     // Burn tokens
-    let _ = env.call_private_void(recipient, burn_call_interface);
+    let _ = env.call_private(recipient, burn_call_interface);
     utils::check_private_balance(
         env,
         token_contract_address,
@@ -50,7 +50,7 @@ unconstrained fn burn_private_failure_more_than_balance() {
 
     // Burn more than balance
     let burn_amount = mint_amount * (10 as u128);
-    let _ = env.call_private_void(
+    let _ = env.call_private(
         owner,
         Token::at(token_contract_address).burn_private(owner, burn_amount, 0),
     );
@@ -62,7 +62,7 @@ unconstrained fn burn_private_failure_on_behalf_of_self_non_zero_nonce() {
         utils::setup_and_mint_to_public(/* with_account_contracts */ false);
 
     let burn_amount = mint_amount;
-    let _ = env.call_private_void(
+    let _ = env.call_private(
         owner,
         Token::at(token_contract_address).burn_private(owner, burn_amount, 1),
     );
@@ -80,7 +80,7 @@ unconstrained fn burn_private_failure_on_behalf_of_other_more_than_balance() {
         Token::at(token_contract_address).burn_private(owner, burn_amount, AUTHWIT_NONCE);
     add_private_authwit_from_call_interface(owner, recipient, burn_call_interface);
     // Impersonate recipient to perform the call
-    let _ = env.call_private_void(recipient, burn_call_interface);
+    let _ = env.call_private(recipient, burn_call_interface);
 }
 
 #[test(should_fail_with = "Unknown auth witness for message hash")]
@@ -94,7 +94,7 @@ unconstrained fn burn_private_failure_on_behalf_of_other_without_approval() {
     let burn_call_interface =
         Token::at(token_contract_address).burn_private(owner, burn_amount, AUTHWIT_NONCE);
     // Impersonate recipient to perform the call
-    let _ = env.call_private_void(recipient, burn_call_interface);
+    let _ = env.call_private(recipient, burn_call_interface);
 }
 
 #[test(should_fail_with = "Unknown auth witness for message hash")]
@@ -109,5 +109,5 @@ unconstrained fn burn_private_failure_on_behalf_of_other_wrong_designated_caller
         Token::at(token_contract_address).burn_private(owner, burn_amount, AUTHWIT_NONCE);
     add_private_authwit_from_call_interface(owner, owner, burn_call_interface);
     // Impersonate recipient to perform the call
-    let _ = env.call_private_void(recipient, burn_call_interface);
+    let _ = env.call_private(recipient, burn_call_interface);
 }

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/test/burn_public.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/test/burn_public.nr
@@ -9,7 +9,7 @@ unconstrained fn burn_public_success() {
     let burn_amount = mint_amount / (10 as u128);
 
     // Burn less than balance
-    env.call_public_void(owner, Token::at(token_contract_address).burn_public(owner, burn_amount, 0));
+    env.call_public(owner, Token::at(token_contract_address).burn_public(owner, burn_amount, 0));
     utils::check_public_balance(
         env,
         token_contract_address,
@@ -30,7 +30,7 @@ unconstrained fn burn_public_on_behalf_of_other() {
     add_public_authwit_from_call_interface(env, owner, recipient, burn_call_interface);
 
     // Burn tokens
-    let _ = env.call_public_void(recipient, burn_call_interface);
+    let _ = env.call_public(recipient, burn_call_interface);
 
     utils::check_public_balance(
         env,
@@ -48,7 +48,7 @@ unconstrained fn burn_public_failure_more_than_balance() {
     // Burn more than balance
     let burn_amount = mint_amount * (10 as u128);
     // Try to burn
-    let _ = env.call_public_void(
+    let _ = env.call_public(
         owner,
         Token::at(token_contract_address).burn_public(owner, burn_amount, 0),
     );
@@ -62,7 +62,7 @@ unconstrained fn burn_public_failure_on_behalf_of_self_non_zero_nonce() {
     // Burn on behalf of self with non-zero nonce
     let burn_amount = mint_amount / (10 as u128);
     // Try to burn
-    let _ = env.call_public_void(
+    let _ = env.call_public(
         owner,
         Token::at(token_contract_address).burn_public(owner, burn_amount, random()),
     );
@@ -78,7 +78,7 @@ unconstrained fn burn_public_failure_on_behalf_of_other_without_approval() {
     let burn_call_interface =
         Token::at(token_contract_address).burn_public(owner, burn_amount, random());
 
-    let _ = env.call_public_void(recipient, burn_call_interface);
+    let _ = env.call_public(recipient, burn_call_interface);
 }
 
 #[test(should_fail)] // should_fail_with = "unauthorized"
@@ -92,5 +92,5 @@ unconstrained fn burn_public_failure_on_behalf_of_other_wrong_caller() {
         Token::at(token_contract_address).burn_public(owner, burn_amount, random());
     add_public_authwit_from_call_interface(env, owner, owner, burn_call_interface);
 
-    let _ = env.call_public_void(recipient, burn_call_interface);
+    let _ = env.call_public(recipient, burn_call_interface);
 }

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/test/mint_to_public.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/test/mint_to_public.nr
@@ -6,7 +6,7 @@ unconstrained fn mint_to_public_success() {
     let (env, token_contract_address, owner, _) = utils::setup(/* with_account_contracts */ false);
 
     let mint_amount = 10_000 as u128;
-    let _ = env.call_public_void(
+    let _ = env.call_public(
         owner,
         Token::at(token_contract_address).mint_to_public(owner, mint_amount),
     );
@@ -25,7 +25,7 @@ unconstrained fn mint_as_non_minter() {
 
     // As non-minter
     let mint_amount = 10_000 as u128;
-    let _ = env.call_public_void(
+    let _ = env.call_public(
         recipient,
         Token::at(token_contract_address).mint_to_public(recipient, mint_amount),
     );
@@ -41,11 +41,11 @@ unconstrained fn mint_overflow() {
     let amount_until_overflow = 1000 as u128;
     let mint_amount = (2.pow_32(128) - amount_until_overflow as Field) as u128;
 
-    let _ = env.call_public_void(
+    let _ = env.call_public(
         owner,
         Token::at(token_contract_address).mint_to_public(recipient, mint_amount),
     );
-    let _ = env.call_public_void(
+    let _ = env.call_public(
         owner,
         Token::at(token_contract_address).mint_to_public(recipient, amount_until_overflow),
     );

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/test/transfer.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/test/transfer.nr
@@ -10,7 +10,7 @@ unconstrained fn transfer_private() {
     // docs:start:txe_test_transfer_private
     // Transfer tokens
     let transfer_amount = 1000 as u128;
-    let _ = env.call_private_void(
+    let _ = env.call_private(
         owner,
         Token::at(token_contract_address).transfer(recipient, transfer_amount),
     );
@@ -32,10 +32,8 @@ unconstrained fn transfer_private_to_self() {
         utils::setup_and_mint_to_private(/* with_account_contracts */ false);
     // Transfer tokens
     let transfer_amount = 1000 as u128;
-    let _ = env.call_private_void(
-        owner,
-        Token::at(token_contract_address).transfer(owner, transfer_amount),
-    );
+    let _ =
+        env.call_private(owner, Token::at(token_contract_address).transfer(owner, transfer_amount));
 
     // Check balances
     utils::check_private_balance(env, token_contract_address, owner, mint_amount);
@@ -50,7 +48,7 @@ unconstrained fn transfer_private_to_non_deployed_account() {
 
     // Transfer tokens
     let transfer_amount = 1000 as u128;
-    let _ = env.call_private_void(
+    let _ = env.call_private(
         owner,
         Token::at(token_contract_address).transfer(not_deployed, transfer_amount),
     );
@@ -72,7 +70,7 @@ unconstrained fn transfer_private_failure_more_than_balance() {
         utils::setup_and_mint_to_private(/* with_account_contracts */ false);
     // Transfer tokens
     let transfer_amount = mint_amount + (1 as u128);
-    let _ = env.call_private_void(
+    let _ = env.call_private(
         owner,
         Token::at(token_contract_address).transfer(recipient, transfer_amount),
     );

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/test/transfer_in_private.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/test/transfer_in_private.nr
@@ -14,7 +14,7 @@ unconstrained fn transfer_private_on_behalf_of_other() {
         Token::at(token_contract_address).transfer_in_private(owner, recipient, transfer_amount, 1);
     add_private_authwit_from_call_interface(owner, recipient, transfer_private_from_call_interface);
     // Transfer tokens
-    let _ = env.call_private_void(recipient, transfer_private_from_call_interface);
+    let _ = env.call_private(recipient, transfer_private_from_call_interface);
     // docs:end:private_authwit
     // Check balances
     utils::check_private_balance(
@@ -38,7 +38,7 @@ unconstrained fn transfer_private_failure_on_behalf_of_self_non_zero_nonce() {
         Token::at(token_contract_address).transfer_in_private(owner, recipient, transfer_amount, 1);
     add_private_authwit_from_call_interface(owner, recipient, transfer_private_from_call_interface);
     // Transfer tokens
-    let _ = env.call_private_void(owner, transfer_private_from_call_interface);
+    let _ = env.call_private(owner, transfer_private_from_call_interface);
 }
 // docs:end:fail_with_message
 
@@ -53,7 +53,7 @@ unconstrained fn transfer_private_failure_on_behalf_of_more_than_balance() {
         Token::at(token_contract_address).transfer_in_private(owner, recipient, transfer_amount, 1);
     add_private_authwit_from_call_interface(owner, recipient, transfer_private_from_call_interface);
     // Transfer tokens
-    let _ = env.call_private_void(recipient, transfer_private_from_call_interface);
+    let _ = env.call_private(recipient, transfer_private_from_call_interface);
 }
 
 #[test(should_fail_with = "Unknown auth witness for message hash")]
@@ -66,7 +66,7 @@ unconstrained fn transfer_private_failure_on_behalf_of_other_without_approval() 
     let transfer_private_from_call_interface =
         Token::at(token_contract_address).transfer_in_private(owner, recipient, transfer_amount, 1);
     // Transfer tokens
-    let _ = env.call_private_void(recipient, transfer_private_from_call_interface);
+    let _ = env.call_private(recipient, transfer_private_from_call_interface);
 }
 
 #[test(should_fail_with = "Unknown auth witness for message hash")]
@@ -80,5 +80,5 @@ unconstrained fn transfer_private_failure_on_behalf_of_other_wrong_caller() {
         Token::at(token_contract_address).transfer_in_private(owner, recipient, transfer_amount, 1);
     add_private_authwit_from_call_interface(owner, owner, transfer_private_from_call_interface);
     // Transfer tokens
-    let _ = env.call_private_void(recipient, transfer_private_from_call_interface);
+    let _ = env.call_private(recipient, transfer_private_from_call_interface);
 }

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/test/transfer_in_public.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/test/transfer_in_public.nr
@@ -9,7 +9,7 @@ unconstrained fn public_transfer() {
         utils::setup_and_mint_to_public(/* with_account_contracts */ false);
     // Transfer tokens
     let transfer_amount = mint_amount / (10 as u128);
-    let _ = env.call_public_void(
+    let _ = env.call_public(
         owner,
         Token::at(token_contract_address).transfer_in_public(owner, recipient, transfer_amount, 0),
     );
@@ -32,7 +32,7 @@ unconstrained fn public_transfer_to_self() {
     // Transfer tokens
     let transfer_amount = mint_amount / (10 as u128);
     // docs:start:call_public
-    let _ = env.call_public_void(
+    let _ = env.call_public(
         owner,
         Token::at(token_contract_address).transfer_in_public(owner, owner, transfer_amount, 0),
     );
@@ -56,7 +56,7 @@ unconstrained fn public_transfer_on_behalf_of_other() {
         public_transfer_in_private_call_interface,
     );
     // Transfer tokens
-    let _ = env.call_public_void(recipient, public_transfer_in_private_call_interface);
+    let _ = env.call_public(recipient, public_transfer_in_private_call_interface);
     // Check balances
     utils::check_public_balance(
         env,
@@ -77,7 +77,7 @@ unconstrained fn public_transfer_failure_more_than_balance() {
     let public_transfer_call_interface =
         Token::at(token_contract_address).transfer_in_public(owner, recipient, transfer_amount, 0);
     // Try to transfer tokens
-    let _ = env.call_public_void(owner, public_transfer_call_interface);
+    let _ = env.call_public(owner, public_transfer_call_interface);
 }
 
 #[test(should_fail)] // should_fail_with = "Assertion failed: Invalid authwit nonce. When 'from' and 'msg_sender' are the same, 'authwit_nonce' must be zero"
@@ -91,7 +91,7 @@ unconstrained fn public_transfer_failure_on_behalf_of_self_non_zero_nonce() {
         Token::at(token_contract_address).transfer_in_public(owner, recipient, transfer_amount, 1);
     add_public_authwit_from_call_interface(env, owner, recipient, public_transfer_call_interface);
     // Try to transfer tokens
-    let _ = env.call_public_void(owner, public_transfer_call_interface);
+    let _ = env.call_public(owner, public_transfer_call_interface);
 }
 
 #[test(should_fail)] // should_fail_with = "unauthorized"
@@ -104,7 +104,7 @@ unconstrained fn public_transfer_failure_on_behalf_of_other_without_approval() {
         Token::at(token_contract_address).transfer_in_public(owner, recipient, transfer_amount, 1);
 
     // Try to transfer tokens
-    let _ = env.call_public_void(recipient, public_transfer_in_private_call_interface);
+    let _ = env.call_public(recipient, public_transfer_in_private_call_interface);
 }
 
 #[test(should_fail)] // should_fail_with = "Assertion failed: attempt to subtract with overflow"
@@ -125,7 +125,7 @@ unconstrained fn public_transfer_failure_on_behalf_of_other_more_than_balance() 
     // docs:end:public_authwit
 
     // Try to transfer tokens
-    let _ = env.call_public_void(recipient, public_transfer_in_private_call_interface);
+    let _ = env.call_public(recipient, public_transfer_in_private_call_interface);
 }
 
 #[test(should_fail)] // should_fail_with = "unauthorized"
@@ -144,5 +144,5 @@ unconstrained fn public_transfer_failure_on_behalf_of_other_wrong_caller() {
     );
 
     // Try to transfer tokens
-    let _ = env.call_public_void(recipient, public_transfer_in_private_call_interface);
+    let _ = env.call_public(recipient, public_transfer_in_private_call_interface);
 }

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/test/transfer_to_private.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/test/transfer_to_private.nr
@@ -35,7 +35,7 @@ unconstrained fn transfer_to_private_external_orchestration() {
         .return_value;
 
     // Finalize the transfer of the tokens (message sender owns the tokens in public)
-    let _ = env.call_public_void(
+    let _ = env.call_public(
         owner,
         Token::at(token_contract_address).finalize_transfer_to_private(amount, partial_uint_note),
     );
@@ -60,7 +60,7 @@ unconstrained fn transfer_to_private_from_private_external_orchestration() {
         )
         .return_value;
     // Finalize the transfer of the tokens (message sender owns the tokens in public)
-    let _ = env.call_private_void(
+    let _ = env.call_private(
         owner,
         Token::at(token_contract_address).finalize_transfer_to_private_from_private(
             owner,
@@ -85,7 +85,7 @@ unconstrained fn transfer_to_private_transfer_not_prepared() {
     let partial_uint_note = PartialUintNote { commitment: random() };
 
     // Try finalizing the transfer without preparing it
-    let _ = env.call_public_void(
+    let _ = env.call_public(
         owner,
         Token::at(token_contract_address).finalize_transfer_to_private(amount, partial_uint_note),
     );
@@ -108,7 +108,7 @@ unconstrained fn transfer_to_private_failure_not_an_owner() {
         .return_value;
 
     // Try transferring someone else's token balance
-    let _ = env.call_public_void(
+    let _ = env.call_public(
         not_owner,
         Token::at(token_contract_address).finalize_transfer_to_private(amount, partial_uint_note),
     );
@@ -133,7 +133,7 @@ unconstrained fn incorrect_completer_cannot_complete_partial_note() {
 
     // Now we try to complete the partial note as another completer. Note that the caller here owns the tokens - this is
     // so that we pass the balance check and fail on the partial note completer check.
-    let _ = env.call_public_void(
+    let _ = env.call_public(
         owner,
         Token::at(token_contract_address).finalize_transfer_to_private(amount, partial_uint_note),
     );

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/test/transfer_to_public.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/test/transfer_to_public.nr
@@ -11,7 +11,7 @@ unconstrained fn transfer_to_public_on_behalf_of_self() {
         utils::setup_and_mint_to_private(/* with_account_contracts */ false);
 
     let transfer_to_public_amount = mint_amount / (10 as u128);
-    let _ = env.call_private_void(
+    let _ = env.call_private(
         owner,
         Token::at(token_contract_address).transfer_to_public(
             owner,
@@ -48,7 +48,7 @@ unconstrained fn transfer_to_public_on_behalf_of_other() {
     );
     add_private_authwit_from_call_interface(owner, recipient, transfer_to_public_call_interface);
     // transfer_to_public tokens
-    let _ = env.call_private_void(recipient, transfer_to_public_call_interface);
+    let _ = env.call_private(recipient, transfer_to_public_call_interface);
     utils::check_private_balance(
         env,
         token_contract_address,
@@ -70,7 +70,7 @@ unconstrained fn transfer_to_public_failure_more_than_balance() {
         utils::setup_and_mint_to_private(/* with_account_contracts */ false);
 
     let transfer_to_public_amount = mint_amount + (1 as u128);
-    let _ = env.call_private_void(
+    let _ = env.call_private(
         owner,
         Token::at(token_contract_address).transfer_to_public(
             owner,
@@ -88,7 +88,7 @@ unconstrained fn transfer_to_public_failure_on_behalf_of_self_non_zero_nonce() {
         utils::setup_and_mint_to_private(/* with_account_contracts */ false);
 
     let transfer_to_public_amount = mint_amount + (1 as u128);
-    let _ = env.call_private_void(
+    let _ = env.call_private(
         owner,
         Token::at(token_contract_address).transfer_to_public(
             owner,
@@ -114,7 +114,7 @@ unconstrained fn transfer_to_public_failure_on_behalf_of_other_more_than_balance
     add_private_authwit_from_call_interface(owner, recipient, transfer_to_public_call_interface);
 
     // transfer_to_public tokens
-    let _ = env.call_private_void(recipient, transfer_to_public_call_interface);
+    let _ = env.call_private(recipient, transfer_to_public_call_interface);
 }
 
 #[test(should_fail_with = "Unknown auth witness for message hash")]
@@ -132,7 +132,7 @@ unconstrained fn transfer_to_public_failure_on_behalf_of_other_invalid_designate
     add_private_authwit_from_call_interface(owner, owner, transfer_to_public_call_interface);
 
     // transfer_to_public tokens
-    let _ = env.call_private_void(recipient, transfer_to_public_call_interface);
+    let _ = env.call_private(recipient, transfer_to_public_call_interface);
 }
 
 #[test(should_fail_with = "Unknown auth witness for message hash")]
@@ -149,5 +149,5 @@ unconstrained fn transfer_to_public_failure_on_behalf_of_other_no_approval() {
     );
 
     // transfer_to_public tokens
-    let _ = env.call_private_void(recipient, transfer_to_public_call_interface);
+    let _ = env.call_private(recipient, transfer_to_public_call_interface);
 }

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/test/transfer_to_public_and_prepare_private_balance_increase.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/test/transfer_to_public_and_prepare_private_balance_increase.nr
@@ -50,7 +50,7 @@ unconstrained fn transfer_to_public_and_prepare_private_balance_increase_and_fin
     // --> this should send the `change_amount` from AMM's public balance to liquidity provider's private balance
     let change_amount = deposit_amount / (2 as u128);
 
-    let _ = env.call_public_void(
+    let _ = env.call_public(
         amm_contract,
         Token::at(token_contract_address).finalize_transfer_to_private(change_amount, partial_note),
     );

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/test/utils.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/test/utils.nr
@@ -56,7 +56,7 @@ pub unconstrained fn setup_and_mint_to_public(
     let mint_amount = 10000 as u128;
 
     // Mint some tokens
-    let _ = env.call_public_void(
+    let _ = env.call_public(
         owner,
         Token::at(token_contract_address).mint_to_public(owner, mint_amount),
     );
@@ -72,7 +72,7 @@ pub unconstrained fn setup_and_mint_amount_to_private(
     let (env, token_contract_address, owner, recipient) = setup(with_account_contracts);
 
     // Mint some tokens
-    let _ = env.call_private_void(
+    let _ = env.call_private(
         owner,
         Token::at(token_contract_address).mint_to_private(owner, mint_amount),
     );

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/types/balance_set.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/types/balance_set.nr
@@ -157,13 +157,13 @@ mod test {
 
         // The owner mints two notes for the recipient
         let first_note_value = note_values[0];
-        let _ = env.call_private_void(
+        let _ = env.call_private(
             owner,
             Token::at(token_contract_address).mint_to_private(recipient, first_note_value),
         );
 
         let second_note_value = note_values[1];
-        let _ = env.call_private_void(
+        let _ = env.call_private(
             owner,
             Token::at(token_contract_address).mint_to_private(recipient, second_note_value),
         );

--- a/noir-projects/noir-contracts/contracts/protocol/router_contract/src/test.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/router_contract/src/test.nr
@@ -17,7 +17,7 @@ unconstrained fn check_block_number() {
     let router = Router::at(router_contract_address);
 
     let expected_next_block_number = env.next_block_number();
-    let _ = env.call_private_void(
+    let _ = env.call_private(
         AztecAddress::empty(),
         router.check_block_number(Comparator.LT, expected_next_block_number + 1),
     );
@@ -32,7 +32,7 @@ unconstrained fn check_block_number_fail() {
     let router = Router::at(router_contract_address);
 
     let expected_next_block_number = env.next_block_number();
-    let _ = env.call_private_void(
+    let _ = env.call_private(
         AztecAddress::empty(),
         router.check_block_number(Comparator.LT, expected_next_block_number),
     );
@@ -48,7 +48,7 @@ unconstrained fn check_timestamp() {
 
     let expected_next_block_timestamp = env.last_block_timestamp() + 100;
     env.set_next_block_timestamp(expected_next_block_timestamp);
-    let _ = env.call_private_void(
+    let _ = env.call_private(
         AztecAddress::empty(),
         router.check_timestamp(Comparator.LT, expected_next_block_timestamp + 1),
     );
@@ -64,7 +64,7 @@ unconstrained fn check_timestamp_fail() {
 
     let expected_next_block_timestamp = env.last_block_timestamp() + 100;
     env.set_next_block_timestamp(expected_next_block_timestamp);
-    let _ = env.call_private_void(
+    let _ = env.call_private(
         AztecAddress::empty(),
         router.check_timestamp(Comparator.LT, expected_next_block_timestamp),
     );

--- a/noir-projects/noir-contracts/contracts/test/counter_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/counter_contract/src/main.nr
@@ -137,7 +137,7 @@ pub contract Counter {
         // docs:end:txe_test_read_notes
 
         // Increment the counter
-        let _ = env.call_private_void(owner, Counter::at(contract_address).increment(owner));
+        let _ = env.call_private(owner, Counter::at(contract_address).increment(owner));
 
         let incremented_counter =
             env.simulate_utility(Counter::at(contract_address)._experimental_get_counter(owner));
@@ -159,23 +159,21 @@ pub contract Counter {
             env.simulate_utility(Counter::at(contract_address)._experimental_get_counter(owner));
         assert(initial_note_value == initial_value);
 
-        let _ = env.call_private_void(owner, Counter::at(contract_address).increment_twice(owner));
+        let _ = env.call_private(owner, Counter::at(contract_address).increment_twice(owner));
 
         assert_eq(
             env.simulate_utility(Counter::at(contract_address)._experimental_get_counter(owner)),
             7,
         );
 
-        let _ = env.call_private_void(
-            owner,
-            Counter::at(contract_address).increment_and_decrement(owner),
-        );
+        let _ =
+            env.call_private(owner, Counter::at(contract_address).increment_and_decrement(owner));
         assert_eq(
             env.simulate_utility(Counter::at(contract_address)._experimental_get_counter(owner)),
             7,
         );
 
-        let _ = env.call_private_void(owner, Counter::at(contract_address).decrement(owner));
+        let _ = env.call_private(owner, Counter::at(contract_address).decrement(owner));
         assert_eq(
             env.simulate_utility(Counter::at(contract_address)._experimental_get_counter(owner)),
             6,

--- a/noir-projects/noir-contracts/contracts/test/public_immutable_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/public_immutable_contract/src/main.nr
@@ -50,7 +50,7 @@ mod tests {
 
         // set x to 10
         let x = 10;
-        let _ = env.call_public_void(contract_address, test_contract.initialize_value(x));
+        let _ = env.call_public(contract_address, test_contract.initialize_value(x));
 
         // We advance block to commit state and have the nullifier available for reading.
         env.mine_block();

--- a/noir-projects/noir-contracts/contracts/test/test_contract/src/test/note_delivery.nr
+++ b/noir-projects/noir-contracts/contracts/test/test_contract/src/test/note_delivery.nr
@@ -26,7 +26,7 @@ unconstrained fn create_note_private_only_tx_and_read_in_private() {
     let test_contract = Test::at(contract_address);
 
     let make_tx_hybrid = false;
-    let _ = env.call_private_void(
+    let _ = env.call_private(
         sender,
         test_contract.call_create_note(VALUE, recipient, STORAGE_SLOT, make_tx_hybrid),
     );
@@ -44,7 +44,7 @@ unconstrained fn create_note_private_only_tx_and_read_in_utility() {
     let test_contract = Test::at(contract_address);
 
     let make_tx_hybrid = false;
-    let _ = env.call_private_void(
+    let _ = env.call_private(
         sender,
         test_contract.call_create_note(VALUE, recipient, STORAGE_SLOT, make_tx_hybrid),
     );
@@ -62,7 +62,7 @@ unconstrained fn create_note_hybrid_tx_and_read_in_private() {
     let test_contract = Test::at(contract_address);
 
     let make_tx_hybrid = true;
-    let _ = env.call_private_void(
+    let _ = env.call_private(
         sender,
         test_contract.call_create_note(VALUE, recipient, STORAGE_SLOT, make_tx_hybrid),
     );
@@ -80,7 +80,7 @@ unconstrained fn create_note_hybrid_tx_and_read_in_utility() {
     let test_contract = Test::at(contract_address);
 
     let make_tx_hybrid = true;
-    let _ = env.call_private_void(
+    let _ = env.call_private(
         sender,
         test_contract.call_create_note(VALUE, recipient, STORAGE_SLOT, make_tx_hybrid),
     );
@@ -97,7 +97,7 @@ unconstrained fn create_partial_note_in_one_tx_and_read_in_private() {
     let (env, contract_address, sender, recipient) = setup();
     let test_contract = Test::at(contract_address);
 
-    let _ = env.call_private_void(
+    let _ = env.call_private(
         sender,
         test_contract.call_create_and_complete_partial_note(recipient, STORAGE_SLOT, VALUE),
     );
@@ -114,7 +114,7 @@ unconstrained fn create_partial_note_in_one_tx_and_read_in_utility() {
     let (env, contract_address, sender, recipient) = setup();
     let test_contract = Test::at(contract_address);
 
-    let _ = env.call_private_void(
+    let _ = env.call_private(
         sender,
         test_contract.call_create_and_complete_partial_note(recipient, STORAGE_SLOT, VALUE),
     );
@@ -135,8 +135,7 @@ unconstrained fn create_partial_note_in_two_txs_and_read_in_private() {
         .call_private(sender, test_contract.call_create_partial_note(recipient, STORAGE_SLOT))
         .return_value;
 
-    let _ =
-        env.call_public_void(sender, test_contract.call_complete_partial_note(partial_note, VALUE));
+    let _ = env.call_public(sender, test_contract.call_complete_partial_note(partial_note, VALUE));
 
     // The 'from' param is irrelevant in this case
     let retrieved = env
@@ -154,8 +153,7 @@ unconstrained fn create_partial_note_in_two_txs_and_read_in_utility() {
         .call_private(sender, test_contract.call_create_partial_note(recipient, STORAGE_SLOT))
         .return_value;
 
-    let _ =
-        env.call_public_void(sender, test_contract.call_complete_partial_note(partial_note, VALUE));
+    let _ = env.call_public(sender, test_contract.call_complete_partial_note(partial_note, VALUE));
 
     let retrieved = env.simulate_utility(test_contract._experimental_call_view_notes(
         STORAGE_SLOT,

--- a/noir-projects/noir-contracts/contracts/test/txe_test_contract/src/test.nr
+++ b/noir-projects/noir-contracts/contracts/test/txe_test_contract/src/test.nr
@@ -42,7 +42,7 @@ unconstrained fn new_calling_flow_increment_self_and_other() {
         env.deploy_self("TXETest").with_private_initializer(owner, initializer2);
     let contract_address2 = counter_contract2.to_address();
 
-    let _ = env.call_private_void(
+    let _ = env.call_private(
         owner,
         TXETest::at(contract_address).increment_self_and_other(contract_address2, owner),
     );
@@ -80,7 +80,7 @@ unconstrained fn new_calling_flow_increment_with_new_call_flow() {
     let initial_value: u64 = 2;
     let (mut env, contract_address, owner) = setup(initial_value);
 
-    let _ = env.call_private_void(owner, TXETest::at(contract_address).increment(owner));
+    let _ = env.call_private(owner, TXETest::at(contract_address).increment(owner));
 
     env.impersonate(contract_address);
 

--- a/yarn-project/end-to-end/src/e2e_static_calls.test.ts
+++ b/yarn-project/end-to-end/src/e2e_static_calls.test.ts
@@ -11,15 +11,16 @@ describe('e2e_static_calls', () => {
   let childContract: StaticChildContract;
   let teardown: () => Promise<void>;
   let owner: AztecAddress;
+  let sender: AztecAddress;
 
   beforeAll(async () => {
     ({ teardown, wallet } = await setup());
     owner = wallet.getCompleteAddress().address;
-    parentContract = await StaticParentContract.deploy(wallet).send().deployed();
+    (sender = owner), (parentContract = await StaticParentContract.deploy(wallet).send().deployed());
     childContract = await StaticChildContract.deploy(wallet).send().deployed();
 
     // We create a note in the set, such that later reads doesn't fail due to get_notes returning 0 notes
-    await childContract.methods.private_set_value(42n, owner).send().wait();
+    await childContract.methods.private_set_value(42n, owner, sender).send().wait();
   });
 
   afterAll(() => teardown());
@@ -118,9 +119,10 @@ describe('e2e_static_calls', () => {
     it('fails when performing illegal private to private static calls', async () => {
       await expect(
         parentContract.methods
-          .private_static_call(childContract.address, await childContract.methods.private_set_value.selector(), [
+          .private_static_call_3_args(childContract.address, await childContract.methods.private_set_value.selector(), [
             42n,
             owner,
+            sender,
           ])
           .send()
           .wait(),
@@ -142,10 +144,11 @@ describe('e2e_static_calls', () => {
     it('fails when performing illegal (nested) private to private static calls', async () => {
       await expect(
         parentContract.methods
-          .private_nested_static_call(childContract.address, await childContract.methods.private_set_value.selector(), [
-            42n,
-            owner,
-          ])
+          .private_nested_static_call_3_args(
+            childContract.address,
+            await childContract.methods.private_set_value.selector(),
+            [42n, owner, sender],
+          )
           .send()
           .wait(),
       ).rejects.toThrow(STATIC_CALL_STATE_MODIFICATION_ERROR);


### PR DESCRIPTION
You can just do things. In this case, delete ~700 lines and end up with a net improvement.

This deletes all of the `Void` variants of the call interfaces, in turn deleting the `call_<>_void` variants, nicely unifying the testing experience - we now just `call_public` or `call_private` without worrying about return types. I also simplified `ReturnsHash` a bit since it had three ways of achieving the same simple tasks, and added some tests and clarifying comments about how the `()` case is handled.

There's lots more to improve on the `CallInterfaces`, and many more removals to be done, but this initial pass is worth doing separately because it directly improves `TestEnvironment`'s API.