### PR TITLE
chore: prover node resolves validator IP addresses

### DIFF
--- a/spartan/aztec-node/scripts/resolve-node-hosts.sh
+++ b/spartan/aztec-node/scripts/resolve-node-hosts.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -eu
+
+# resolves headless service to the backing pods. Useful for the prover nodes to collect txs
+node -e '
+const dns = require("dns").promises;
+const net = require("net");
+(async () => {
+  const ips = [];
+  for (const arg of process.argv.slice(1)) {
+    try {
+      if (net.isIP(arg) !== 0) {
+        ips.push(arg);
+      } else {
+        ips.push(...await dns.resolve4(arg));
+      }
+    } catch (err) {}
+  }
+  console.log(ips.map(ip => `http://${ip}:8080`).join(","))
+})()' $@

--- a/spartan/aztec-prover-stack/values.yaml
+++ b/spartan/aztec-prover-stack/values.yaml
@@ -28,6 +28,7 @@ node:
 
     preStartScript: |
       source /scripts/get-private-key.sh
+      export TX_COLLECTION_NODE_RPC_URLS=$(bash /scripts/resolve-node-hosts.sh $NODE_HOSTS)
 
     startCmd:
       - --prover-node

--- a/spartan/terraform/deploy-testnet/main.tf
+++ b/spartan/terraform/deploy-testnet/main.tf
@@ -185,6 +185,11 @@ resource "helm_release" "prover" {
   ]
 
   set {
+    name  = "node.node.env.NODE_HOSTS"
+    value = "${var.RELEASE_PREFIX}-validator-headless.${var.NAMESPACE}.svc.cluster.local"
+  }
+
+  set {
     name  = "global.aztecImage.repository"
     value = split(":", var.AZTEC_DOCKER_IMAGE)[0] # e.g. aztecprotocol/aztec
   }


### PR DESCRIPTION
This PR adds a script for the prover node to resolve the headless service domain for validators. This can be used for prover coordination.