### PR TITLE
fix: Propose before voting in multicall (#15920)

### DIFF
--- a/.test_patterns.yml
+++ b/.test_patterns.yml
@@ -84,10 +84,6 @@ tests:
       - *tom
 
   # e2e tests skipped
-  - regex: "src/e2e_sequencer/gov_proposal"
-    skip: true
-    owners:
-      - *lasse
   - regex: "testbench/port_change.test.ts"
     skip: true
     owners:

--- a/yarn-project/end-to-end/src/e2e_sequencer/gov_proposal.test.ts
+++ b/yarn-project/end-to-end/src/e2e_sequencer/gov_proposal.test.ts
@@ -1,50 +1,63 @@
-import { EthAddress, type Logger, type PXE, type Wallet } from '@aztec/aztec.js';
+import { EthAddress, Fr, type Logger, type Wallet } from '@aztec/aztec.js';
 import { CheatCodes } from '@aztec/aztec.js/testing';
 import {
   type DeployL1ContractsReturnType,
   GovernanceProposerContract,
   RollupContract,
   deployL1Contract,
-  getL1ContractsConfigEnvVars,
 } from '@aztec/ethereum';
+import { times } from '@aztec/foundation/collection';
+import { SecretValue } from '@aztec/foundation/config';
+import { bufferToHex } from '@aztec/foundation/string';
+import type { TestDateProvider } from '@aztec/foundation/timer';
 import { NewGovernanceProposerPayloadAbi } from '@aztec/l1-artifacts/NewGovernanceProposerPayloadAbi';
 import { NewGovernanceProposerPayloadBytecode } from '@aztec/l1-artifacts/NewGovernanceProposerPayloadBytecode';
-import type { PXEService } from '@aztec/pxe/server';
+import { TestContract } from '@aztec/noir-test-contracts.js/Test';
 import type { AztecNodeAdmin } from '@aztec/stdlib/interfaces/client';
 
 import { privateKeyToAccount } from 'viem/accounts';
 
 import { getPrivateKeyFromIndex, setup } from '../fixtures/utils.js';
-import { submitTxsTo } from '../shared/submit-transactions.js';
+
+const ETHEREUM_SLOT_DURATION = 8;
+const AZTEC_SLOT_DURATION = 16;
+const TXS_PER_BLOCK = 1;
+const ROUND_SIZE = 2;
+const QUORUM_SIZE = 2;
+const COMMITTEE_SIZE = 48;
 
 describe('e2e_gov_proposal', () => {
   let logger: Logger;
   let teardown: () => Promise<void>;
   let wallet: Wallet;
-  let pxe: PXE;
   let aztecNodeAdmin: AztecNodeAdmin | undefined;
   let deployL1ContractsValues: DeployL1ContractsReturnType;
-  let aztecSlotDuration: number;
   let cheatCodes: CheatCodes;
-  beforeEach(async () => {
-    const privateKey = `0x${getPrivateKeyFromIndex(0)!.toString('hex')}` as `0x${string}`;
-    const account = privateKeyToAccount(privateKey);
-    const initialValidators = [
-      {
-        attester: EthAddress.fromString(account.address),
-        withdrawer: EthAddress.fromString(account.address),
-        privateKey,
-      },
-    ];
-    const { ethereumSlotDuration, aztecSlotDuration: _aztecSlotDuration } = getL1ContractsConfigEnvVars();
-    aztecSlotDuration = _aztecSlotDuration;
+  let dateProvider: TestDateProvider | undefined;
 
-    ({ teardown, logger, wallet, pxe, aztecNodeAdmin, deployL1ContractsValues, cheatCodes } = await setup(1, {
-      initialValidators,
-      ethereumSlotDuration,
+  beforeEach(async () => {
+    const validatorOffset = 10;
+    const validators = times(COMMITTEE_SIZE, i => {
+      const privateKey = bufferToHex(getPrivateKeyFromIndex(i + validatorOffset)!);
+      const account = privateKeyToAccount(privateKey);
+      const address = EthAddress.fromString(account.address);
+      return { attester: address, withdrawer: address, privateKey };
+    });
+
+    ({ teardown, logger, wallet, aztecNodeAdmin, deployL1ContractsValues, cheatCodes, dateProvider } = await setup(1, {
+      anvilAccounts: 100,
+      aztecTargetCommitteeSize: 48,
+      initialValidators: validators,
+      validatorPrivateKeys: new SecretValue(validators.map(v => v.privateKey)), // sequencer runs with all validator keys
+      governanceProposerRoundSize: ROUND_SIZE,
+      governanceProposerQuorum: QUORUM_SIZE,
+      ethereumSlotDuration: ETHEREUM_SLOT_DURATION,
+      aztecSlotDuration: AZTEC_SLOT_DURATION,
+      aztecProofSubmissionEpochs: 128, // no pruning
       salt: 420,
-      minTxsPerBlock: 8,
+      minTxsPerBlock: TXS_PER_BLOCK,
       enforceTimeTable: true,
+      automineL1Setup: true, // speed up setup
     }));
   }, 3 * 60000);
 
@@ -53,32 +66,49 @@ describe('e2e_gov_proposal', () => {
   it(
     'should build/propose blocks while voting',
     async () => {
+      const { l1Client, l1ContractAddresses } = deployL1ContractsValues;
+      const { registryAddress, rollupAddress, gseAddress, governanceProposerAddress } = l1ContractAddresses;
+      const rollup = new RollupContract(l1Client, rollupAddress.toString());
+      const governanceProposer = new GovernanceProposerContract(l1Client, governanceProposerAddress.toString());
+
       const { address: newGovernanceProposerAddress } = await deployL1Contract(
-        deployL1ContractsValues.l1Client,
+        l1Client,
         NewGovernanceProposerPayloadAbi,
         NewGovernanceProposerPayloadBytecode,
-        [deployL1ContractsValues.l1ContractAddresses.registryAddress.toString()],
+        [registryAddress.toString(), gseAddress!.toString()],
         '0x2a', // salt
       );
+
+      // Deploy a test contract to send msgs via the outbox, since this increases
+      // gas cost of a proposal, which has triggered oog errors in the past.
+      const testContract = await TestContract.deploy(wallet).send().deployed();
+
+      await cheatCodes.rollup.advanceToEpoch(2n, { updateDateProvider: dateProvider });
+
       await aztecNodeAdmin!.setConfig({
         governanceProposerPayload: newGovernanceProposerAddress,
+        maxTxsPerBlock: TXS_PER_BLOCK,
       });
-      const rollup = new RollupContract(
-        deployL1ContractsValues.l1Client,
-        deployL1ContractsValues.l1ContractAddresses.rollupAddress.toString(),
-      );
-      const governanceProposer = new GovernanceProposerContract(
-        deployL1ContractsValues.l1Client,
-        deployL1ContractsValues.l1ContractAddresses.governanceProposerAddress.toString(),
-      );
 
       const roundDuration = await governanceProposer.getRoundSize();
+      expect(roundDuration).toEqual(BigInt(ROUND_SIZE));
       const slot = await rollup.getSlotNumber();
       const round = await governanceProposer.computeRound(slot);
       const nextRoundBeginsAtSlot = (slot / roundDuration) * roundDuration + roundDuration;
       const nextRoundBeginsAtTimestamp = await rollup.getTimestampForSlot(nextRoundBeginsAtSlot);
-      logger.info(`Warping to round ${round + 1n} at slot ${nextRoundBeginsAtSlot}`);
-      await cheatCodes.eth.warp(Number(nextRoundBeginsAtTimestamp));
+
+      logger.warn(`Warping to round ${round + 1n} at slot ${nextRoundBeginsAtSlot}`, {
+        nextRoundBeginsAtSlot,
+        nextRoundBeginsAtTimestamp,
+        roundDuration,
+        slot,
+        round,
+      });
+
+      await cheatCodes.eth.warp(Number(nextRoundBeginsAtTimestamp), {
+        resetBlockInterval: true,
+        updateDateProvider: dateProvider,
+      });
 
       // Now we submit a bunch of transactions to the PXE.
       // We know that this will last at least as long as the round duration,
@@ -86,21 +116,26 @@ describe('e2e_gov_proposal', () => {
       // Simultaneously, we should be voting for the proposal in every slot.
 
       for (let i = 0; i < roundDuration; i++) {
-        const txs = await submitTxsTo(pxe as PXEService, 8, wallet, logger);
+        const txs = times(TXS_PER_BLOCK, () =>
+          testContract.methods
+            .create_l2_to_l1_message_arbitrary_recipient_private(Fr.random(), EthAddress.random())
+            .send(),
+        );
         await Promise.all(
           txs.map(async (tx, j) => {
             logger.info(`Waiting for tx ${i}-${j}: ${await tx.getTxHash()} to be mined`);
-            return tx.wait({ timeout: 2 * aztecSlotDuration + 2 });
+            return tx.wait({ timeout: 2 * AZTEC_SLOT_DURATION + 2 });
           }),
         );
       }
 
+      logger.warn('All transactions submitted and mined');
       const votes = await governanceProposer.getProposalVotes(
-        deployL1ContractsValues.l1ContractAddresses.rollupAddress.toString(),
+        rollupAddress.toString(),
         round + 1n,
         newGovernanceProposerAddress.toString(),
       );
-      expect(votes).toEqual(roundDuration);
+      expect(votes).toBeGreaterThan(0n);
     },
     1000 * 60 * 5,
   );

--- a/yarn-project/end-to-end/src/fixtures/utils.ts
+++ b/yarn-project/end-to-end/src/fixtures/utils.ts
@@ -306,6 +306,8 @@ export type SetupOptions = {
   disableAnvilTestWatcher?: boolean;
   /** Whether to enable anvil automine during deployment of L1 contracts (consider defaulting this to true). */
   automineL1Setup?: boolean;
+  /** How many accounts to seed and unlock in anvil. */
+  anvilAccounts?: number;
 } & Partial<AztecNodeConfig>;
 
 /** Context for an end-to-end test as returned by the `setup` function */
@@ -397,7 +399,7 @@ export async function setup(
         );
       }
 
-      const res = await startAnvil({ l1BlockTime: opts.ethereumSlotDuration });
+      const res = await startAnvil({ l1BlockTime: opts.ethereumSlotDuration, accounts: opts.anvilAccounts });
       anvil = res.anvil;
       config.l1RpcUrls = [res.rpcUrl];
     }

--- a/yarn-project/ethereum/src/test/start_anvil.ts
+++ b/yarn-project/ethereum/src/test/start_anvil.ts
@@ -12,6 +12,7 @@ export async function startAnvil(
     port?: number;
     l1BlockTime?: number;
     captureMethodCalls?: boolean;
+    accounts?: number;
   } = {},
 ): Promise<{ anvil: Anvil; methodCalls?: string[]; rpcUrl: string; stop: () => Promise<void> }> {
   const anvilBinary = resolve(dirname(fileURLToPath(import.meta.url)), '../../', 'scripts/anvil_kill_wrapper.sh');
@@ -29,6 +30,7 @@ export async function startAnvil(
         port: opts.port ?? 8545,
         blockTime: opts.l1BlockTime,
         stopTimeout: 1000,
+        accounts: opts.accounts ?? 20,
       });
 
       // Listen to the anvil output to get the port.

--- a/yarn-project/sequencer-client/src/publisher/sequencer-publisher.test.ts
+++ b/yarn-project/sequencer-client/src/publisher/sequencer-publisher.test.ts
@@ -263,10 +263,6 @@ describe('SequencerPublisher', () => {
     expect(forwardSpy).toHaveBeenCalledWith(
       [
         {
-          to: mockRollupAddress,
-          data: encodeFunctionData({ abi: RollupAbi, functionName: 'propose', args }),
-        },
-        {
           to: mockGovernanceProposerAddress,
           data: encodeFunctionData({
             abi: EmpireBaseAbi,
@@ -274,17 +270,22 @@ describe('SequencerPublisher', () => {
             args: [govPayload.toString(), voteSig.toViemSignature()],
           }),
         },
+        {
+          to: mockRollupAddress,
+          data: encodeFunctionData({ abi: RollupAbi, functionName: 'propose', args }),
+        },
       ],
       l1TxUtils,
-      // vote + val + (val * 20n) / 100n
       {
-        gasLimit: SequencerPublisher.VOTE_GAS_GUESS + 1_000_000n + GAS_GUESS + ((1_000_000n + GAS_GUESS) * 20n) / 100n,
+        gasLimit: expect.any(BigInt),
         txTimeoutAt: undefined,
       },
       { blobs: expectedBlobs.map(b => b.data), kzg },
       mockRollupAddress,
       expect.anything(), // the logger
     );
+
+    expect(forwardSpy.mock.calls[0][2]?.gasLimit).toBeGreaterThan(2_000_000n);
   });
 
   it('errors if forwarder tx fails', async () => {

--- a/yarn-project/validator-client/src/validator.ts
+++ b/yarn-project/validator-client/src/validator.ts
@@ -130,8 +130,8 @@ export class ValidatorClient extends (EventEmitter as new () => WatcherEmitter) 
         const committeeSet = new Set(committee.map(v => v.toString()));
         const inCommittee = me.filter(a => committeeSet.has(a.toString()));
         if (inCommittee.length > 0) {
-          inCommittee.forEach(a =>
-            this.log.info(`Validator ${a.toString()} is on the validator committee for epoch ${epoch}`),
+          this.log.info(
+            `Validators ${inCommittee.map(a => a.toString()).join(',')} are on the validator committee for epoch ${epoch}`,
           );
         } else {
           this.log.verbose(


### PR DESCRIPTION
Backport for #15920

Attempt at fixing the OOG we've been seeing on adversarial testnet when sequencers try to vote and propose at the same time.

- Reenables the gov-proposal test, which tested this case and had been disabled for months.
- Bumps the number of validators in the test to 48 (all in the same node though) and includes outbox msgs to try and reproduce the oog. I failed though: I had to manually tweak the `VOTE_GAS_GUESS` to ridiculously low values to reproduce the oog.
- Changes the sequencer publisher so it always calls `propose` first, so the committee is pre-stored in transient storage. It's unclear to me if this will still be the case after all the work in delayed signatures.
- Bumps the vote gas guess to 800k, since we've seen that votes were taking 700k gas in sepolia.