### PR TITLE
test: migrate all tests off-of env.private()

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/history/note_inclusion/test.nr
+++ b/noir-projects/aztec-nr/aztec/src/history/note_inclusion/test.nr
@@ -1,22 +1,31 @@
 use crate::history::{note_inclusion::ProveNoteInclusion, test};
 
-// In this test, we create a note and prove its inclusion in the block of its creation.
+use crate::test::helpers::test_environment::PrivateContextOptions;
+
 #[test]
-unconstrained fn note_inclusion() {
+unconstrained fn succeeds_on_blocks_after_note_creation() {
     let (env, retrieved_note) = test::create_note();
 
-    let context = &mut env.private_at(test::NOTE_CREATED_AT);
-
-    // docs:start:prove_note_inclusion
-    context.historical_header.prove_note_inclusion(retrieved_note, test::NOTE_STORAGE_SLOT);
-    // docs:end:prove_note_inclusion
+    env.private_context_opts(
+        PrivateContextOptions::new().at_historical_block_number(test::NOTE_CREATED_AT),
+        |context| {
+            // docs:start:prove_note_inclusion
+            let header = context.historical_header;
+            header.prove_note_inclusion(retrieved_note, test::NOTE_STORAGE_SLOT);
+            // docs:end:prove_note_inclusion
+        },
+    );
 }
 
-// In this test, we create a note and fail to prove its inclusion in the block before its creation.
 #[test(should_fail_with = "not found in NOTE_HASH_TREE at block 1")]
-unconstrained fn note_inclusion_fails() {
+unconstrained fn fails_on_blocks_before_note_creation() {
     let (env, retrieved_note) = test::create_note();
 
-    let context = &mut env.private_at(test::NOTE_CREATED_AT - 1);
-    context.historical_header.prove_note_inclusion(retrieved_note, test::NOTE_STORAGE_SLOT);
+    env.private_context_opts(
+        PrivateContextOptions::new().at_historical_block_number(test::NOTE_CREATED_AT - 1),
+        |context| {
+            let header = context.historical_header;
+            header.prove_note_inclusion(retrieved_note, test::NOTE_STORAGE_SLOT);
+        },
+    );
 }

--- a/noir-projects/aztec-nr/aztec/src/history/note_validity/test.nr
+++ b/noir-projects/aztec-nr/aztec/src/history/note_validity/test.nr
@@ -1,38 +1,45 @@
 use crate::history::note_validity::ProveNoteValidity;
 use crate::history::test;
 
-// In these tests, we create a note in one block and nullify it in the next.
+use crate::test::helpers::test_environment::PrivateContextOptions;
 
-// In this test, we fail to prove the note's validity in the block before its creation. It fails the validity check due to
-// non-inclusion of the note in the block before its creation.
 #[test(should_fail_with = "not found in NOTE_HASH_TREE at block 1")]
-unconstrained fn note_not_valid_due_to_non_inclusion() {
+unconstrained fn fails_on_blocks_before_note_creation() {
     let (env, retrieved_note) = test::create_note_and_nullify_it();
 
-    let context = &mut env.private_at(test::NOTE_CREATED_AT - 1);
-
-    context.historical_header.prove_note_validity(retrieved_note, test::NOTE_STORAGE_SLOT, context);
+    env.private_context_opts(
+        PrivateContextOptions::new().at_historical_block_number(test::NOTE_CREATED_AT - 1),
+        |context| {
+            let header = context.historical_header;
+            header.prove_note_validity(retrieved_note, test::NOTE_STORAGE_SLOT, context);
+        },
+    );
 }
 
-// In this test, we prove the note's validity in the block at its creation, and before its nullification. It succeeds
-// because it is included and not nullified at the block specified.
 #[test]
-unconstrained fn note_is_valid() {
+unconstrained fn succeeds_on_blocks_after_creation_and_before_nullification() {
     let (env, retrieved_note) = test::create_note_and_nullify_it();
 
-    let context = &mut env.private_at(test::NOTE_CREATED_AT);
-
-    // docs:start:prove_note_validity
-    context.historical_header.prove_note_validity(retrieved_note, test::NOTE_STORAGE_SLOT, context);
-    // docs:end:prove_note_validity
+    env.private_context_opts(
+        PrivateContextOptions::new().at_historical_block_number(test::NOTE_CREATED_AT),
+        |context| {
+            // docs:start:prove_note_validity
+            let header = context.historical_header;
+            header.prove_note_validity(retrieved_note, test::NOTE_STORAGE_SLOT, context);
+            // docs:end:prove_note_validity
+        },
+    );
 }
 
-// In this test, we fail to prove the note's validity in the block at its nullification. It fails the validity check due to
-// its nullifier being included in the state at one block after it was created.
 #[test(should_fail_with = "Proving nullifier non-inclusion failed")]
-unconstrained fn note_not_valid_due_to_nullification() {
+unconstrained fn fails_on_blocks_after_note_nullification() {
     let (env, retrieved_note) = test::create_note_and_nullify_it();
 
-    let context = &mut env.private_at(test::NOTE_NULLIFIED_AT);
-    context.historical_header.prove_note_validity(retrieved_note, test::NOTE_STORAGE_SLOT, context);
+    env.private_context_opts(
+        PrivateContextOptions::new().at_historical_block_number(test::NOTE_NULLIFIED_AT),
+        |context| {
+            let header = context.historical_header;
+            header.prove_note_validity(retrieved_note, test::NOTE_STORAGE_SLOT, context);
+        },
+    );
 }

--- a/noir-projects/aztec-nr/aztec/src/history/nullifier_inclusion/test.nr
+++ b/noir-projects/aztec-nr/aztec/src/history/nullifier_inclusion/test.nr
@@ -1,72 +1,71 @@
 use crate::history::{nullifier_inclusion::{ProveNoteIsNullified, ProveNullifierInclusion}, test};
 use crate::oracle::{notes::notify_created_nullifier, random::random};
-use crate::test::helpers::test_environment::TestEnvironment;
+use crate::test::helpers::test_environment::{PrivateContextOptions, TestEnvironment};
 use dep::protocol_types::{
     constants::GENERATOR_INDEX__OUTER_NULLIFIER, hash::poseidon2_hash_with_separator,
     traits::ToField,
 };
 
-// In these tests, we create a note in one block and nullify it in the next.
-
-// In this test, we prove the presence of the note's nullifier in state at the block it was nullified in.
 #[test]
-unconstrained fn note_is_nullified() {
+unconstrained fn note_is_nullified_succeeds_on_blocks_after_note_nullification() {
     let (env, retrieved_note) = test::create_note_and_nullify_it();
 
-    let context = &mut env.private_at(test::NOTE_NULLIFIED_AT);
-
-    context.historical_header.prove_note_is_nullified(
-        retrieved_note,
-        test::NOTE_STORAGE_SLOT,
-        context,
+    env.private_context_opts(
+        PrivateContextOptions::new().at_historical_block_number(test::NOTE_NULLIFIED_AT),
+        |context| {
+            let header = context.historical_header;
+            header.prove_note_is_nullified(retrieved_note, test::NOTE_STORAGE_SLOT, context);
+        },
     );
 }
 
-// In this test, we fail to prove the presence of the note's nullifier in state at the block before it was nullified.
 #[test(should_fail_with = "Nullifier membership witness not found at block 2.")]
-unconstrained fn note_is_not_nullified() {
+unconstrained fn note_is_nullified_fails_on_blocks_before_note_nullification() {
     let (env, retrieved_note) = test::create_note_and_nullify_it();
 
-    let context = &mut env.private_at(test::NOTE_NULLIFIED_AT - 1);
-
-    context.historical_header.prove_note_is_nullified(
-        retrieved_note,
-        test::NOTE_STORAGE_SLOT,
-        context,
+    env.private_context_opts(
+        PrivateContextOptions::new().at_historical_block_number(test::NOTE_NULLIFIED_AT - 1),
+        |context| {
+            let header = context.historical_header;
+            header.prove_note_is_nullified(retrieved_note, test::NOTE_STORAGE_SLOT, context);
+        },
     );
 }
 
-// In this test, we create a nullifier and confirm that it was siloed and added to state.
 #[test]
-unconstrained fn nullifier_inclusion() {
+unconstrained fn prove_nullifier_inclusion_succeeds_on_blocks_after_nullifier_creation() {
     let mut env = TestEnvironment::new();
 
-    let unsiloed_nullifier = 42069;
+    let siloed_nullifier = env.private_context(|context| {
+        let unsiloed_nullifier = 42069;
+        notify_created_nullifier(unsiloed_nullifier);
 
-    // We need to create the siloed nullifier so we can check for its inclusion in state.
-    let siloed_nullifier = poseidon2_hash_with_separator(
-        [env.contract_address().to_field(), unsiloed_nullifier],
-        GENERATOR_INDEX__OUTER_NULLIFIER,
+        // We need to compute the siloed nullifier so we can check for its inclusion in state.
+        poseidon2_hash_with_separator(
+            [context.this_address().to_field(), unsiloed_nullifier],
+            GENERATOR_INDEX__OUTER_NULLIFIER,
+        )
+    });
+
+    let nullifier_created_at = env.last_block_number();
+
+    env.private_context_opts(
+        PrivateContextOptions::new().at_historical_block_number(nullifier_created_at),
+        |context| {
+            // docs:start:prove_nullifier_inclusion
+            let header = context.historical_header;
+            header.prove_nullifier_inclusion(siloed_nullifier);
+            // docs:end:prove_nullifier_inclusion
+        },
     );
-
-    notify_created_nullifier(unsiloed_nullifier);
-
-    let nullifier_created_at = env.next_block_number();
-
-    env.mine_block();
-
-    let context = &mut env.private_at(nullifier_created_at);
-
-    // docs:start:prove_nullifier_inclusion
-    context.historical_header.prove_nullifier_inclusion(siloed_nullifier);
-    // docs:end:prove_nullifier_inclusion
 }
 
-// In this test, we fail to prove the inclusion of an arbitrary nullifier in state.
 #[test(should_fail_with = "Nullifier membership witness not found")]
-unconstrained fn nullifier_inclusion_fails() {
+unconstrained fn prove_nullifier_inclusion_fails_on_blocks_before_nullifier_creation() {
     let mut env = TestEnvironment::new();
 
-    let context = &mut env.private();
-    context.historical_header.prove_nullifier_inclusion(random());
+    env.private_context(|context| {
+        let header = context.historical_header;
+        header.prove_nullifier_inclusion(random());
+    });
 }

--- a/noir-projects/aztec-nr/aztec/src/history/nullifier_non_inclusion/test.nr
+++ b/noir-projects/aztec-nr/aztec/src/history/nullifier_non_inclusion/test.nr
@@ -3,72 +3,70 @@ use crate::history::{
     test,
 };
 use crate::oracle::{notes::notify_created_nullifier, random::random};
-use crate::test::helpers::test_environment::TestEnvironment;
+use crate::test::helpers::test_environment::{PrivateContextOptions, TestEnvironment};
 use dep::protocol_types::{
     constants::GENERATOR_INDEX__OUTER_NULLIFIER, hash::poseidon2_hash_with_separator,
     traits::ToField,
 };
 
-// In these tests, we create a note in one block and nullify it in the next.
-
-// In this test, we prove the absence of the note's nullifier in state at the block before it was nullified.
 #[test]
-unconstrained fn note_not_nullified() {
+unconstrained fn note_not_nullified_succeeds_in_blocks_before_note_nullification() {
     let (env, retrieved_note) = test::create_note_and_nullify_it();
 
-    let context = &mut env.private_at(test::NOTE_NULLIFIED_AT - 1);
-
-    context.historical_header.prove_note_not_nullified(
-        retrieved_note,
-        test::NOTE_STORAGE_SLOT,
-        context,
+    env.private_context_opts(
+        PrivateContextOptions::new().at_historical_block_number(test::NOTE_NULLIFIED_AT - 1),
+        |context| {
+            let header = context.historical_header;
+            header.prove_note_not_nullified(retrieved_note, test::NOTE_STORAGE_SLOT, context);
+        },
     );
 }
 
-// In this test, we fail prove the absence of the note's nullifier in state at the block it was nullified in.
 #[test(should_fail_with = "Proving nullifier non-inclusion failed")]
-unconstrained fn note_not_nullified_fails() {
+unconstrained fn note_not_nullified_fails_in_blocks_after_note_nullification_fails() {
     let (env, retrieved_note) = test::create_note_and_nullify_it();
 
-    let context = &mut env.private_at(test::NOTE_NULLIFIED_AT);
-    context.historical_header.prove_note_not_nullified(
-        retrieved_note,
-        test::NOTE_STORAGE_SLOT,
-        context,
+    env.private_context_opts(
+        PrivateContextOptions::new().at_historical_block_number(test::NOTE_NULLIFIED_AT),
+        |context| {
+            let header = context.historical_header;
+            header.prove_note_not_nullified(retrieved_note, test::NOTE_STORAGE_SLOT, context);
+        },
     );
 }
 
-// In this test, we prove the absence of an arbitrary nullifier in state.
 #[test]
-unconstrained fn nullifier_non_inclusion() {
+unconstrained fn nullifier_non_inclusion_succeeds_in_blocks_before_nullifier_creation() {
     let mut env = TestEnvironment::new();
 
-    let context = &mut env.private();
-
-    context.historical_header.prove_nullifier_non_inclusion(random());
+    env.private_context(|context| {
+        let header = context.historical_header;
+        header.prove_nullifier_non_inclusion(random());
+    });
 }
 
-// In this test, we create a nullifier and fail to prove its absence in state (we are checking the
-// siloed version of it because that is what is actually pushed to state).
 #[test(should_fail_with = "Proving nullifier non-inclusion failed")]
-unconstrained fn nullifier_non_inclusion_fails() {
+unconstrained fn nullifier_non_inclusion_fails_in_blocks_after_nullifier_creation() {
     let mut env = TestEnvironment::new();
 
-    let unsiloed_nullifier = 42069;
+    let siloed_nullifier = env.private_context(|context| {
+        let unsiloed_nullifier = 42069;
+        notify_created_nullifier(unsiloed_nullifier);
 
-    // We need to create the siloed nullifier so we can check for its inclusion in state.
-    let siloed_nullifier = poseidon2_hash_with_separator(
-        [env.contract_address().to_field(), unsiloed_nullifier],
-        GENERATOR_INDEX__OUTER_NULLIFIER,
+        // We need to compute the siloed nullifier so we can check for its inclusion in state.
+        poseidon2_hash_with_separator(
+            [context.this_address().to_field(), unsiloed_nullifier],
+            GENERATOR_INDEX__OUTER_NULLIFIER,
+        )
+    });
+
+    let nullifier_created_at = env.last_block_number();
+
+    env.private_context_opts(
+        PrivateContextOptions::new().at_historical_block_number(nullifier_created_at),
+        |context| {
+            let header = context.historical_header;
+            header.prove_nullifier_non_inclusion(siloed_nullifier);
+        },
     );
-
-    notify_created_nullifier(unsiloed_nullifier);
-
-    let nullifier_created_at = env.next_block_number();
-
-    env.mine_block();
-
-    let context = &mut env.private_at(nullifier_created_at);
-
-    context.historical_header.prove_nullifier_non_inclusion(siloed_nullifier);
 }

--- a/noir-projects/aztec-nr/aztec/src/history/test.nr
+++ b/noir-projects/aztec-nr/aztec/src/history/test.nr
@@ -1,9 +1,6 @@
-use crate::{
-    note::{
-        lifecycle::{create_note as lifecycle_create_note, destroy_note},
-        note_metadata::NoteMetadata,
-    },
-    oracle::execution::get_contract_address,
+use crate::note::{
+    lifecycle::{create_note as lifecycle_create_note, destroy_note},
+    note_metadata::NoteMetadata,
 };
 use crate::note::retrieved_note::RetrievedNote;
 use crate::test::{helpers::test_environment::TestEnvironment, mocks::mock_note::MockNote};
@@ -12,45 +9,41 @@ pub(crate) global NOTE_STORAGE_SLOT: Field = 420;
 pub(crate) global NOTE_CREATED_AT: u32 = 2;
 pub(crate) global NOTE_NULLIFIED_AT: u32 = 3;
 
-// We create a note in block 2.
 pub(crate) unconstrained fn create_note() -> (&mut TestEnvironment, RetrievedNote<MockNote>) {
     let mut env = TestEnvironment::new();
-    let context = &mut env.private();
 
-    // We sanity check that we are building block 2, thus block 2 is where the note will be added.
-    assert_eq(env.next_block_number(), NOTE_CREATED_AT);
+    // We create a note in block NOTE_CREATED_AT
+    let retrieved_note = env.private_context(|context| {
+        let contract_address = context.this_address();
 
-    let contract_address = get_contract_address();
+        // The test environment doesn't yet supporting delivering settled notes, so we hardcode the nonce we know the
+        // note will have if emitted as the only note in block NOTE_CREATED_AT.
+        let retrieved_note = MockNote::new(69)
+            .contract_address(contract_address)
+            .note_metadata(NoteMetadata::from_raw_data(
+                false,
+                0x256c00025f88d92eb518176c67c9d619b876e7261ef3ef5879fac1cf3b5acab2,
+            ))
+            .build_retrieved_note();
 
-    let retrieved_note = MockNote::new(69)
-        .contract_address(contract_address)
-        .note_metadata(NoteMetadata::from_raw_data(
-            false,
-            0x256c00025f88d92eb518176c67c9d619b876e7261ef3ef5879fac1cf3b5acab2,
-        ))
-        .build_retrieved_note();
+        let _ = lifecycle_create_note(context, NOTE_STORAGE_SLOT, retrieved_note.note);
 
-    let _ = lifecycle_create_note(context, NOTE_STORAGE_SLOT, retrieved_note.note);
+        retrieved_note
+    });
 
-    // TODO(#12226): FIX
-    // context.push_note_hash(retrieved_note.note.compute_note_hash(15));
-    env.mine_block();
+    // Verify the note was inserted in the correct block
+    assert_eq(env.last_block_number(), NOTE_CREATED_AT);
 
     (&mut env, retrieved_note)
 }
 
-// We create a note at block 2 and nullify it in the next block.
 pub(crate) unconstrained fn create_note_and_nullify_it() -> (&mut TestEnvironment, RetrievedNote<MockNote>) {
     let (env, retrieved_note) = create_note();
 
-    let context = &mut env.private();
+    env.private_context(|context| { destroy_note(context, retrieved_note, NOTE_STORAGE_SLOT); });
 
-    // We sanity check that we are building block 3, thus block 3 is where the note will be nullified.
-    assert_eq(env.next_block_number(), NOTE_NULLIFIED_AT);
-
-    destroy_note(context, retrieved_note, NOTE_STORAGE_SLOT);
-
-    env.mine_block();
+    // Verify the note was nullified in the correct block
+    assert_eq(env.last_block_number(), NOTE_NULLIFIED_AT);
 
     (env, retrieved_note)
 }


### PR DESCRIPTION
I thought migrating these would require that we support delivering settled notes to PXE in a test, but I ended up relying on the same hack as the current tests (hardcoding the precomputed nonce) and managed to complete the migration. These will be refactored once we add those capabilities, but there's no need to do it now. 

With this, there are no longer any calls to `env.private()` or `env.public()`.