### PR TITLE
chore!: Nuke flushTxs

### DIFF
--- a/yarn-project/aztec-node/src/aztec-node/server.test.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.test.ts
@@ -15,7 +15,6 @@ import type { L2BlockSource } from '@aztec/stdlib/block';
 import type { ContractDataSource } from '@aztec/stdlib/contract';
 import { EmptyL1RollupConstants } from '@aztec/stdlib/epoch-helpers';
 import { GasFees } from '@aztec/stdlib/gas';
-import type { AztecNode } from '@aztec/stdlib/interfaces/client';
 import type { L2LogsSource, MerkleTreeReadOperations, WorldStateSynchronizer } from '@aztec/stdlib/interfaces/server';
 import type { L1ToL2MessageSource } from '@aztec/stdlib/messaging';
 import { mockTx } from '@aztec/stdlib/testing';
@@ -56,9 +55,10 @@ describe('aztec node', () => {
   let merkleTreeOps: MockProxy<MerkleTreeReadOperations>;
   let l2BlockSource: MockProxy<L2BlockSource>;
   let lastBlockNumber: number;
-  let node: AztecNode;
+  let node: AztecNodeService;
   let feePayer: AztecAddress;
   let epochCache: EpochCache;
+  let nodeConfig: AztecNodeConfig;
 
   const chainId = new Fr(12345);
   const rollupVersion = new Fr(1);
@@ -131,7 +131,20 @@ describe('aztec node', () => {
     // all txs use the same allowed FPC class
     const contractSource = mock<ContractDataSource>();
 
-    const aztecNodeConfig: AztecNodeConfig = getConfigEnvVars();
+    const nodeConfigFromEnvVars: AztecNodeConfig = getConfigEnvVars();
+    nodeConfig = {
+      ...nodeConfigFromEnvVars,
+      l1Contracts: {
+        ...nodeConfigFromEnvVars.l1Contracts,
+        rollupAddress: EthAddress.ZERO,
+        registryAddress: EthAddress.ZERO,
+        inboxAddress: EthAddress.ZERO,
+        outboxAddress: EthAddress.ZERO,
+      },
+    };
+
+    // Inject a spurious config value to test that the config is correctly picked up
+    (nodeConfig as any).nonExistingConfig = 'foo';
 
     // We never request any info from the rollup contract here, since only the `getEpochAndSlotInNextL1Slot` method
     // on the epoch cache is used so a simple mock will suffice.
@@ -140,16 +153,7 @@ describe('aztec node', () => {
     epochCache = new EpochCache(rollupContract, 0n, undefined, 0n, EmptyL1RollupConstants, new MockDateProvider());
 
     node = new AztecNodeService(
-      {
-        ...aztecNodeConfig,
-        l1Contracts: {
-          ...aztecNodeConfig.l1Contracts,
-          rollupAddress: EthAddress.ZERO,
-          registryAddress: EthAddress.ZERO,
-          inboxAddress: EthAddress.ZERO,
-          outboxAddress: EthAddress.ZERO,
-        },
-      },
+      nodeConfig,
       p2p,
       l2BlockSource,
       l2LogsSource,
@@ -254,6 +258,14 @@ describe('aztec node', () => {
   });
 
   describe('getters', () => {
+    describe('config', () => {
+      it('returns the correct config', async () => {
+        const config = await node.getConfig();
+        expect(config.maxTxPoolSize).toEqual(nodeConfig.maxTxPoolSize);
+        expect('nonExistingConfig' in config).toBe(false);
+      });
+    });
+
     describe('node info', () => {
       it('returns the correct node version', async () => {
         const releasePleaseVersionFile = readFileSync(

--- a/yarn-project/bot/src/factory.ts
+++ b/yarn-project/bot/src/factory.ts
@@ -128,10 +128,8 @@ export class BotFactory {
       const sentTx = account.deploy({ fee: { paymentMethod } });
       const txHash = await sentTx.getTxHash();
       // docs:end:claim_and_deploy
-      this.log.info(`Sent tx with hash ${txHash.toString()}`);
-      await this.tryFlushTxs();
-      this.log.verbose('Waiting for account deployment to settle');
-      await sentTx.wait({ timeout: this.config.txMinedWaitSeconds });
+      this.log.info(`Sent tx for account deployment with hash ${txHash.toString()}`);
+      await this.withNoMinTxsPerBlock(() => sentTx.wait({ timeout: this.config.txMinedWaitSeconds }));
       this.log.info(`Account deployed at ${address}`);
       return wallet;
     }
@@ -186,10 +184,8 @@ export class BotFactory {
       this.log.info(`Deploying token contract at ${address.toString()}`);
       const sentTx = deploy.send(deployOpts);
       const txHash = await sentTx.getTxHash();
-      this.log.info(`Sent tx with hash ${txHash.toString()}`);
-      await this.tryFlushTxs();
-      this.log.verbose('Waiting for token setup to settle');
-      return sentTx.deployed({ timeout: this.config.txMinedWaitSeconds });
+      this.log.info(`Sent tx for token setup with hash ${txHash.toString()}`);
+      return this.withNoMinTxsPerBlock(() => sentTx.deployed({ timeout: this.config.txMinedWaitSeconds }));
     }
   }
 
@@ -315,10 +311,8 @@ export class BotFactory {
       this.log.info(`Deploying contract ${name} at ${address.toString()}`);
       const sentTx = deploy.send(deployOpts);
       const txHash = await sentTx.getTxHash();
-      this.log.info(`Sent tx with hash ${txHash.toString()}`);
-      await this.tryFlushTxs();
-      this.log.verbose(`Waiting for contract ${name} setup to settle`);
-      return sentTx.deployed({ timeout: this.config.txMinedWaitSeconds });
+      this.log.info(`Sent contract ${name} setup tx with hash ${txHash.toString()}`);
+      return this.withNoMinTxsPerBlock(() => sentTx.deployed({ timeout: this.config.txMinedWaitSeconds }));
     }
   }
 
@@ -358,10 +352,8 @@ export class BotFactory {
     }
     const sentTx = new BatchCall(token.wallet, calls).send();
     const txHash = await sentTx.getTxHash();
-    this.log.info(`Sent tx with hash ${txHash.toString()}`);
-    await this.tryFlushTxs();
-    this.log.verbose('Waiting for token mint to settle');
-    await sentTx.wait({ timeout: this.config.txMinedWaitSeconds });
+    this.log.info(`Sent token mint tx with hash ${txHash.toString()}`);
+    await this.withNoMinTxsPerBlock(() => sentTx.wait({ timeout: this.config.txMinedWaitSeconds }));
   }
 
   private async bridgeL1FeeJuice(recipient: AztecAddress) {
@@ -396,20 +388,23 @@ export class BotFactory {
     return claim;
   }
 
-  private async advanceL2Block() {
-    const initialBlockNumber = await this.node!.getBlockNumber();
-    await this.tryFlushTxs();
-    await retryUntil(async () => (await this.node!.getBlockNumber()) >= initialBlockNumber + 1);
+  private async withNoMinTxsPerBlock<T>(fn: () => Promise<T>): Promise<T> {
+    if (!this.nodeAdmin || !this.config.flushSetupTransactions) {
+      return fn();
+    }
+    const { minTxsPerBlock } = await this.nodeAdmin.getConfig();
+    await this.nodeAdmin.setConfig({ minTxsPerBlock: 0 });
+    try {
+      return await fn();
+    } finally {
+      await this.nodeAdmin.setConfig({ minTxsPerBlock });
+    }
   }
 
-  private async tryFlushTxs() {
-    if (this.config.flushSetupTransactions) {
-      this.log.verbose('Flushing transactions');
-      try {
-        await this.nodeAdmin!.flushTxs();
-      } catch (err) {
-        this.log.error(`Failed to flush transactions: ${err}`);
-      }
-    }
+  private async advanceL2Block() {
+    await this.withNoMinTxsPerBlock(async () => {
+      const initialBlockNumber = await this.node!.getBlockNumber();
+      await retryUntil(async () => (await this.node!.getBlockNumber()) >= initialBlockNumber + 1);
+    });
   }
 }

--- a/yarn-project/end-to-end/src/shared/gas_portal_test_harness.ts
+++ b/yarn-project/end-to-end/src/shared/gas_portal_test_harness.ts
@@ -180,8 +180,18 @@ export class GasBridgingTestHarness implements IGasBridgingTestHarness {
 
   private async advanceL2Block() {
     const initialBlockNumber = await this.aztecNode.getBlockNumber();
-    await this.aztecNodeAdmin?.flushTxs();
+
+    let minTxsPerBlock = undefined;
+    if (this.aztecNodeAdmin) {
+      ({ minTxsPerBlock } = await this.aztecNodeAdmin.getConfig());
+      await this.aztecNodeAdmin.setConfig({ minTxsPerBlock: 0 }); // Set to 0 to ensure we can advance the block
+    }
+
     await retryUntil(async () => (await this.aztecNode.getBlockNumber()) >= initialBlockNumber + 1);
+
+    if (this.aztecNodeAdmin && minTxsPerBlock !== undefined) {
+      await this.aztecNodeAdmin.setConfig({ minTxsPerBlock });
+    }
   }
 }
 // docs:end:cross_chain_test_harness

--- a/yarn-project/end-to-end/src/spartan/setup_test_wallets.ts
+++ b/yarn-project/end-to-end/src/spartan/setup_test_wallets.ts
@@ -168,8 +168,18 @@ async function bridgeL1FeeJuice(
 
 async function advanceL2Block(node: AztecNode, nodeAdmin?: AztecNodeAdmin) {
   const initialBlockNumber = await node.getBlockNumber();
-  await nodeAdmin?.flushTxs();
+
+  let minTxsPerBlock = undefined;
+  if (nodeAdmin) {
+    ({ minTxsPerBlock } = await nodeAdmin.getConfig());
+    await nodeAdmin.setConfig({ minTxsPerBlock: 0 }); // Set to 0 to ensure we can advance the block
+  }
+
   await retryUntil(async () => (await node.getBlockNumber()) >= initialBlockNumber + 1);
+
+  if (nodeAdmin && minTxsPerBlock !== undefined) {
+    await nodeAdmin.setConfig({ minTxsPerBlock });
+  }
 }
 
 async function deployTokenAndMint(

--- a/yarn-project/foundation/src/collection/object.ts
+++ b/yarn-project/foundation/src/collection/object.ts
@@ -51,6 +51,11 @@ export function omit<T extends object>(object: T, ...props: string[]): Partial<T
   return obj;
 }
 
+/** Equivalent to Object.keys but preserves types. */
+export function getKeys<T extends object>(obj: T): (keyof T)[] {
+  return Object.keys(obj) as (keyof T)[];
+}
+
 /** Equivalent to Object.entries but preserves types. */
 export function getEntries<T extends Record<PropertyKey, unknown>>(obj: T): { [K in keyof T]: [K, T[K]] }[keyof T][] {
   // See https://stackoverflow.com/a/76176570

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
@@ -428,42 +428,6 @@ describe('sequencer', () => {
     expectPublisherProposeL2Block([]);
   });
 
-  it('builds a block that contains less than the minimum number of transactions once flushed', async () => {
-    const txs = await timesParallel(8, i => makeTx(i * 0x10000));
-
-    sequencer.updateConfig({ minTxsPerBlock: 4 });
-
-    // block is not built with 0 txs
-    mockPendingTxs([]);
-    await sequencer.doRealWork();
-    expect(blockBuilder.buildBlock).toHaveBeenCalledTimes(0);
-
-    // block is not built with 3 txs
-    mockPendingTxs(txs.slice(0, 3));
-    await sequencer.doRealWork();
-    expect(blockBuilder.buildBlock).toHaveBeenCalledTimes(0);
-
-    // flush the sequencer and it should build a block
-    sequencer.flush();
-
-    // block is built with 3 txs
-    const postFlushTxs = txs.slice(0, 3);
-    mockPendingTxs(postFlushTxs);
-    block = await makeBlock(postFlushTxs);
-    const postFlushTxHashes = await Promise.all(postFlushTxs.map(tx => tx.getTxHash()));
-
-    await sequencer.doRealWork();
-    expect(blockBuilder.buildBlock).toHaveBeenCalledTimes(1);
-    expect(blockBuilder.buildBlock).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.anything(),
-      globalVariables,
-      expect.anything(),
-    );
-
-    expectPublisherProposeL2Block(postFlushTxHashes);
-  });
-
   it('settles on the chain tip before it starts building a block', async () => {
     // this test simulates a synch happening right after the sequencer starts building a block
     // simulate every component being synched

--- a/yarn-project/stdlib/src/interfaces/aztec-node-admin.test.ts
+++ b/yarn-project/stdlib/src/interfaces/aztec-node-admin.test.ts
@@ -26,12 +26,16 @@ describe('AztecNodeAdminApiSchema', () => {
     expect([...tested].sort()).toEqual(all.sort());
   });
 
-  it('setConfig', async () => {
-    await context.client.setConfig({ coinbase: EthAddress.random() });
+  it('getConfig', async () => {
+    const config = await context.client.getConfig();
+    expect(config).toMatchObject({
+      coinbase: expect.any(EthAddress),
+      maxTxPoolSize: expect.any(Number),
+    });
   });
 
-  it('flushTxs', async () => {
-    await context.client.flushTxs();
+  it('setConfig', async () => {
+    await context.client.setConfig({ coinbase: EthAddress.random() });
   });
 
   it('startSnapshotUpload', async () => {
@@ -57,8 +61,16 @@ class MockAztecNodeAdmin implements AztecNodeAdmin {
     expect(config.coinbase).toBeInstanceOf(EthAddress);
     return Promise.resolve();
   }
-  flushTxs(): Promise<void> {
-    return Promise.resolve();
+  getConfig(): Promise<SequencerConfig & ProverConfig & { maxTxPoolSize: number }> {
+    return Promise.resolve({
+      realProofs: false,
+      proverTestDelayType: 'fixed',
+      proverTestDelayMs: 100,
+      proverTestDelayFactor: 1,
+      proverAgentCount: 1,
+      coinbase: EthAddress.random(),
+      maxTxPoolSize: 1000,
+    });
   }
   startSnapshotUpload(_location: string): Promise<void> {
     return Promise.resolve();

--- a/yarn-project/stdlib/src/interfaces/aztec-node-admin.ts
+++ b/yarn-project/stdlib/src/interfaces/aztec-node-admin.ts
@@ -12,16 +12,15 @@ import { type ProverConfig, ProverConfigSchema } from './prover-client.js';
  */
 export interface AztecNodeAdmin {
   /**
+   * Retrieves the configuration of this node.
+   */
+  getConfig(): Promise<AztecNodeAdminConfig>;
+
+  /**
    * Updates the configuration of this node.
    * @param config - Updated configuration to be merged with the current one.
    */
-  setConfig(config: Partial<SequencerConfig & ProverConfig & { maxTxPoolSize: number }>): Promise<void>;
-
-  /**
-   * Forces the next block to be built bypassing all time and pending checks.
-   * Useful for testing.
-   */
-  flushTxs(): Promise<void>;
+  setConfig(config: Partial<AztecNodeAdminConfig>): Promise<void>;
 
   /**
    * Pauses syncing, creates a backup of archiver and world-state databases, and uploads them. Returns immediately.
@@ -43,16 +42,15 @@ export interface AztecNodeAdmin {
   resumeSync(): Promise<void>;
 }
 
+export type AztecNodeAdminConfig = SequencerConfig & ProverConfig & { maxTxPoolSize: number };
+
+export const AztecNodeAdminConfigSchema = SequencerConfigSchema.merge(ProverConfigSchema).merge(
+  z.object({ maxTxPoolSize: z.number() }),
+);
+
 export const AztecNodeAdminApiSchema: ApiSchemaFor<AztecNodeAdmin> = {
-  setConfig: z
-    .function()
-    .args(
-      SequencerConfigSchema.merge(ProverConfigSchema)
-        .merge(z.object({ maxTxPoolSize: z.number() }))
-        .partial(),
-    )
-    .returns(z.void()),
-  flushTxs: z.function().returns(z.void()),
+  getConfig: z.function().returns(AztecNodeAdminConfigSchema),
+  setConfig: z.function().args(AztecNodeAdminConfigSchema.partial()).returns(z.void()),
   startSnapshotUpload: z.function().args(z.string()).returns(z.void()),
   rollbackTo: z.function().args(z.number()).returns(z.void()),
   pauseSync: z.function().returns(z.void()),

--- a/yarn-project/stdlib/src/interfaces/aztec-node.test.ts
+++ b/yarn-project/stdlib/src/interfaces/aztec-node.test.ts
@@ -686,9 +686,6 @@ class MockAztecNode implements AztecNode {
     };
     return instance;
   }
-  flushTxs(): Promise<void> {
-    return Promise.resolve();
-  }
   getEncodedEnr(): Promise<string | undefined> {
     return Promise.resolve('enr:-');
   }


### PR DESCRIPTION
Removes the flushTxs method in favor of setting minTxsPerBlock to zero until the given condition is reached. We are not using this method in production at all, just for testing. And it was flaky due to race conditions: see [this run](http://ci.aztec-labs.com/7354b98827d088ca) where a cross chain tx caused the entire test to time out since no blocks were built, as the flushing failed, and the test got stuck in `Not enough txs to build block`.

This change required adding a `getConfig` method so we could fetch the original value for minTxsPerBlock so we could restore it afterwards.