### PR TITLE
chore: remove call machinery from txe 

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
@@ -289,15 +289,15 @@ impl TestEnvironment {
     }
 
     pub unconstrained fn deploy<let N: u32, let M: u32>(
-        _self: Self,
+        self: Self,
         path: str<N>,
         name: str<M>,
     ) -> Deployer<N, M> {
-        Deployer { path, name, secret: 0 }
+        Deployer { env: self, path, name, secret: 0 }
     }
 
-    pub unconstrained fn deploy_self<let M: u32>(_self: Self, name: str<M>) -> Deployer<0, M> {
-        Deployer { path: "", name, secret: 0 }
+    pub unconstrained fn deploy_self<let M: u32>(self: Self, name: str<M>) -> Deployer<0, M> {
+        Deployer { env: self, path: "", name, secret: 0 }
     }
 
     pub unconstrained fn call_private<T, let M: u32>(

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/utils.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/utils.nr
@@ -1,8 +1,6 @@
 use crate::{
-    context::{call_interfaces::CallInterface, gas::GasOpts, PrivateContext, PublicContext},
-    hash::hash_args,
-    oracle::execution_cache,
-    test::helpers::txe_oracles,
+    context::call_interfaces::{CallInterface, PrivateCallInterface, PublicCallInterface},
+    test::helpers::{test_environment::TestEnvironment, txe_oracles},
 };
 use protocol_types::{
     address::AztecAddress,
@@ -13,94 +11,19 @@ use protocol_types::{
 use std::meta::derive;
 
 pub struct Deployer<let N: u32, let M: u32> {
+    pub env: TestEnvironment,
     pub path: str<N>,
     pub name: str<M>,
     pub secret: Field,
 }
 
 impl<let N: u32, let M: u32> Deployer<N, M> {
-    pub unconstrained fn with_private_initializer<C, let P: u32>(
+    pub unconstrained fn with_private_initializer<T, let P: u32>(
         self,
         from: AztecAddress,
-        call_interface: C,
+        call_interface: PrivateCallInterface<P, T>,
     ) -> ContractInstance
     where
-        C: CallInterface<P>,
-    {
-        let instance = txe_oracles::deploy(
-            self.path,
-            self.name,
-            call_interface.get_name(),
-            call_interface.get_args(),
-            self.secret,
-        );
-
-        let inputs = txe_oracles::get_private_context_inputs(Option::none());
-        let mut private_context = PrivateContext::new(inputs, 0);
-        let args = call_interface.get_args();
-        let args_hash = if args.len() > 0 { hash_args(args) } else { 0 };
-        execution_cache::store(args, args_hash);
-
-        let previous_contract_address = txe_oracles::get_contract_address();
-        txe_oracles::set_contract_address(from);
-
-        let _ = private_context.call_private_function_with_args_hash(
-            instance.to_address(),
-            call_interface.get_selector(),
-            args_hash,
-            call_interface.get_is_static(),
-        );
-
-        txe_oracles::set_contract_address(previous_contract_address);
-
-        txe_oracles::advance_blocks_by(1);
-
-        instance
-    }
-
-    pub unconstrained fn with_public_void_initializer<let P: u32, C>(
-        self,
-        from: AztecAddress,
-        call_interface: C,
-    ) -> ContractInstance
-    where
-        C: CallInterface<P>,
-    {
-        let instance = txe_oracles::deploy(
-            self.path,
-            self.name,
-            call_interface.get_name(),
-            call_interface.get_args(),
-            self.secret,
-        );
-
-        let mut public_context = PublicContext::new(|| panic(f"Provide args hash manually"));
-
-        let previous_contract_address = txe_oracles::get_contract_address();
-        txe_oracles::set_contract_address(from);
-
-        let results = public_context.call_public_function(
-            instance.to_address(),
-            call_interface.get_selector(),
-            call_interface.get_args(),
-            GasOpts::default(),
-        );
-        assert(results.len() == 0);
-
-        txe_oracles::set_contract_address(previous_contract_address);
-
-        txe_oracles::advance_blocks_by(1);
-
-        instance
-    }
-
-    pub unconstrained fn with_public_initializer<let P: u32, T, C>(
-        self,
-        from: AztecAddress,
-        call_interface: C,
-    ) -> ContractInstance
-    where
-        C: CallInterface<P>,
         T: Deserialize,
     {
         let instance = txe_oracles::deploy(
@@ -111,20 +34,56 @@ impl<let N: u32, let M: u32> Deployer<N, M> {
             self.secret,
         );
 
-        let mut public_context = PublicContext::new(|| panic(f"Provide args hash manually"));
-
-        let previous_contract_address = txe_oracles::get_contract_address();
-        txe_oracles::set_contract_address(from);
-
-        let _ = public_context.call_public_function(
-            instance.to_address(),
-            call_interface.get_selector(),
-            call_interface.get_args(),
-            GasOpts::default(),
+        // call_interface does not actually have the target_contract value set - it is created with the helper
+        // `interface` function created by `generate_contract_interface` in the aztec macros - it represents a call to
+        // a contract at an unknown address. Now that we've deployed the contract We can crate a new call interface with
+        // the address and perform the call.
+        // We probably want to introduce an intermediate struct to represent this, if we're going to keep this API.
+        let _ = self.env.call_private::<T, _>(
+            from,
+            PrivateCallInterface::new(
+                instance.to_address(),
+                call_interface.get_selector(),
+                call_interface.get_name(),
+                call_interface.get_args(),
+                call_interface.get_is_static(),
+            ),
         );
-        txe_oracles::set_contract_address(previous_contract_address);
 
-        txe_oracles::advance_blocks_by(1);
+        instance
+    }
+
+    pub unconstrained fn with_public_initializer<let P: u32, T>(
+        self,
+        from: AztecAddress,
+        call_interface: PublicCallInterface<P, T>,
+    ) -> ContractInstance
+    where
+        T: Deserialize,
+    {
+        let instance = txe_oracles::deploy(
+            self.path,
+            self.name,
+            call_interface.get_name(),
+            call_interface.get_args(),
+            self.secret,
+        );
+
+        // call_interface does not actually have the target_contract value set - it is created with the helper
+        // `interface` function created by `generate_contract_interface` in the aztec macros - it represents a call to
+        // a contract at an unknown address. Now that we've deployed the contract We can crate a new call interface with
+        // the address and perform the call.
+        // We probably want to introduce an intermediate struct to represent this, if we're going to keep this API.
+        let _ = self.env.call_public::<T, _>(
+            from,
+            PublicCallInterface::new(
+                instance.to_address(),
+                call_interface.get_selector(),
+                call_interface.get_name(),
+                call_interface.get_args(),
+                call_interface.get_is_static(),
+            ),
+        );
 
         instance
     }

--- a/noir-projects/noir-contracts/contracts/app/auth_contract/src/test.nr
+++ b/noir-projects/noir-contracts/contracts/app/auth_contract/src/test.nr
@@ -14,7 +14,7 @@ unconstrained fn setup() -> (&mut TestEnvironment, AztecAddress, AztecAddress, A
     let initializer_call_interface = Auth::interface().constructor(admin);
 
     let auth_contract =
-        env.deploy_self("Auth").with_public_void_initializer(admin, initializer_call_interface);
+        env.deploy_self("Auth").with_public_initializer(admin, initializer_call_interface);
     let auth_contract_address = auth_contract.to_address();
 
     (&mut env, auth_contract_address, admin, to_authorize, other)

--- a/noir-projects/noir-contracts/contracts/app/easy_private_voting_contract/src/test/utils.nr
+++ b/noir-projects/noir-contracts/contracts/app/easy_private_voting_contract/src/test/utils.nr
@@ -10,7 +10,7 @@ pub unconstrained fn setup() -> (&mut TestEnvironment, AztecAddress, AztecAddres
     let admin = env.create_account(1);
 
     let initializer_call_interface = EasyPrivateVoting::interface().constructor(admin);
-    let voting_contract = env.deploy_self("EasyPrivateVoting").with_public_void_initializer(
+    let voting_contract = env.deploy_self("EasyPrivateVoting").with_public_initializer(
         admin,
         initializer_call_interface,
     );

--- a/noir-projects/noir-contracts/contracts/app/nft_contract/src/test/utils.nr
+++ b/noir-projects/noir-contracts/contracts/app/nft_contract/src/test/utils.nr
@@ -33,7 +33,7 @@ pub unconstrained fn setup(
         "TN00000000000000000000000000000",
     );
     let nft_contract =
-        env.deploy_self("NFT").with_public_void_initializer(owner, initializer_call_interface);
+        env.deploy_self("NFT").with_public_initializer(owner, initializer_call_interface);
     let nft_contract_address = nft_contract.to_address();
 
     (&mut env, nft_contract_address, owner, recipient)

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/test/utils.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/test/utils.nr
@@ -33,7 +33,7 @@ pub unconstrained fn setup(
         18,
     );
     let token_contract =
-        env.deploy_self("Token").with_public_void_initializer(owner, initializer_call_interface);
+        env.deploy_self("Token").with_public_initializer(owner, initializer_call_interface);
     let token_contract_address = token_contract.to_address();
     env.mine_block();
     (&mut env, token_contract_address, owner, recipient)

--- a/yarn-project/txe/src/oracle/txe_oracle.ts
+++ b/yarn-project/txe/src/oracle/txe_oracle.ts
@@ -14,7 +14,7 @@ import { padArrayEnd } from '@aztec/foundation/collection';
 import { Aes128, Schnorr, poseidon2Hash } from '@aztec/foundation/crypto';
 import { Fr, Point } from '@aztec/foundation/fields';
 import { type Logger, applyStringFormatting } from '@aztec/foundation/log';
-import { TestDateProvider, Timer } from '@aztec/foundation/timer';
+import { TestDateProvider } from '@aztec/foundation/timer';
 import { KeyStore } from '@aztec/key-store';
 import type { AztecAsyncKVStore } from '@aztec/kv-store';
 import type { ProtocolContract } from '@aztec/protocol-contracts';
@@ -35,10 +35,8 @@ import {
   type NoteData,
   Oracle,
   PrivateExecutionOracle,
-  type TypedOracle,
   UtilityExecutionOracle,
   executePrivateFunction,
-  extractPrivateCircuitPublicInputs,
   generateSimulatedProvingResult,
   pickNotes,
 } from '@aztec/pxe/simulator';
@@ -90,7 +88,6 @@ import { deriveKeys } from '@aztec/stdlib/keys';
 import { ContractClassLog, IndexedTaggingSecret, PrivateLog, type PublicLog } from '@aztec/stdlib/logs';
 import type { NoteStatus } from '@aztec/stdlib/note';
 import { ClientIvcProof } from '@aztec/stdlib/proofs';
-import type { CircuitWitnessGenerationStats } from '@aztec/stdlib/stats';
 import {
   makeAppendOnlyTreeSnapshot,
   makeContentCommitment,
@@ -130,7 +127,7 @@ import { TXEAccountDataProvider } from '../util/txe_account_data_provider.js';
 import { TXEContractDataProvider } from '../util/txe_contract_data_provider.js';
 import { TXEPublicContractDataSource } from '../util/txe_public_contract_data_source.js';
 
-export class TXE implements TypedOracle {
+export class TXE {
   private blockNumber = 1;
   private timestamp = GENESIS_TIMESTAMP;
 
@@ -138,9 +135,6 @@ export class TXE implements TypedOracle {
   private msgSender: AztecAddress;
   private functionSelector = FunctionSelector.fromField(new Fr(0));
   private isStaticCall = false;
-  // Return/revert data of the latest nested call.
-  private nestedCallReturndata: Fr[] = [];
-  private nestedCallSuccess: boolean = false;
 
   private pxeOracleInterface: PXEOracleInterface;
 
@@ -871,82 +865,6 @@ export class TXE implements TypedOracle {
     }
   }
 
-  async callPrivateFunction(
-    targetContractAddress: AztecAddress,
-    functionSelector: FunctionSelector,
-    argsHash: Fr,
-    sideEffectCounter: number,
-    isStaticCall: boolean,
-  ) {
-    this.logger.verbose(
-      `Executing external function ${await this.getDebugFunctionName(
-        targetContractAddress,
-        functionSelector,
-      )}@${targetContractAddress} isStaticCall=${isStaticCall}`,
-    );
-
-    // Store and modify env
-    const currentContractAddress = this.contractAddress;
-    const currentMessageSender = this.msgSender;
-    const currentFunctionSelector = FunctionSelector.fromField(this.functionSelector.toField());
-    this.setMsgSender(this.contractAddress);
-    this.setContractAddress(targetContractAddress);
-    this.setFunctionSelector(functionSelector);
-
-    const artifact = await this.contractDataProvider.getFunctionArtifact(targetContractAddress, functionSelector);
-    if (!artifact) {
-      throw new Error(`Artifact not found when calling private function. Contract address: ${targetContractAddress}.`);
-    }
-
-    const initialWitness = await this.getInitialWitness(artifact, argsHash, sideEffectCounter, isStaticCall);
-    const acvmCallback = new Oracle(this);
-    const timer = new Timer();
-    const acirExecutionResult = await this.simulator
-      .executeUserCircuit(initialWitness, artifact, acvmCallback.toACIRCallback())
-      .catch((err: Error) => {
-        err.message = resolveAssertionMessageFromError(err, artifact);
-
-        const execError = new ExecutionError(
-          err.message,
-          {
-            contractAddress: targetContractAddress,
-            functionSelector,
-          },
-          extractCallStack(err, artifact.debug),
-          { cause: err },
-        );
-        this.logger.debug(`Error executing private function ${targetContractAddress}:${functionSelector}`);
-        throw createSimulationError(execError);
-      });
-    const duration = timer.ms();
-    const publicInputs = extractPrivateCircuitPublicInputs(artifact, acirExecutionResult.partialWitness);
-
-    const initialWitnessSize = witnessMapToFields(initialWitness).length * Fr.SIZE_IN_BYTES;
-    this.logger.debug(`Ran external function ${targetContractAddress.toString()}:${functionSelector}`, {
-      circuitName: 'app-circuit',
-      duration,
-      eventName: 'circuit-witness-generation',
-      inputSize: initialWitnessSize,
-      outputSize: publicInputs.toBuffer().length,
-      appCircuitName: 'noname',
-    } satisfies CircuitWitnessGenerationStats);
-
-    // Apply side effects
-    const endSideEffectCounter = publicInputs.endSideEffectCounter;
-    this.sideEffectCounter = endSideEffectCounter.toNumber() + 1;
-
-    await this.addPrivateLogs(
-      targetContractAddress,
-      publicInputs.privateLogs.getActiveItems().map(privateLog => privateLog.log),
-    );
-
-    this.setContractAddress(currentContractAddress);
-    this.setMsgSender(currentMessageSender);
-    this.setFunctionSelector(currentFunctionSelector);
-
-    return { endSideEffectCounter, returnsHash: publicInputs.returnsHash };
-  }
-
   async getInitialWitness(abi: FunctionAbi, argsHash: Fr, sideEffectCounter: number, isStaticCall: boolean) {
     const argumentsSize = countArgumentsSize(abi);
 
@@ -1178,62 +1096,6 @@ export class TXE implements TypedOracle {
       logRetrievalRequestsArrayBaseSlot,
       logRetrievalResponsesArrayBaseSlot,
     );
-  }
-
-  // AVM oracles
-
-  async avmOpcodeCall(
-    targetContractAddress: AztecAddress,
-    calldata: Fr[],
-    isStaticCall: boolean,
-  ): Promise<PublicTxResult> {
-    // Store and modify env
-    const currentContractAddress = this.contractAddress;
-    const currentMessageSender = this.msgSender;
-    this.setMsgSender(this.contractAddress);
-    this.setContractAddress(targetContractAddress);
-
-    const executionResult = await this.executePublicFunction(
-      calldata,
-      /* msgSender */ currentContractAddress,
-      targetContractAddress,
-      isStaticCall,
-    );
-    // Save return/revert data for later.
-    this.nestedCallReturndata = executionResult.processedPhases[0]!.returnValues[0].values!;
-    this.nestedCallSuccess = executionResult.revertCode.isOK();
-
-    // Apply side effects
-    if (executionResult.revertCode.isOK()) {
-      const sideEffects = executionResult.avmProvingRequest.inputs.publicInputs.accumulatedData;
-      const publicDataWrites = sideEffects.publicDataWrites.filter(s => !s.isEmpty());
-      const noteHashes = sideEffects.noteHashes.filter(s => !s.isEmpty());
-      const { usedTxRequestHashForNonces } = this.noteCache.finish();
-      const firstNullifier = usedTxRequestHashForNonces
-        ? this.getTxRequestHash()
-        : this.noteCache.getAllNullifiers()[0];
-      const nullifiers = sideEffects.nullifiers.filter(s => !s.isEmpty()).filter(s => !s.equals(firstNullifier));
-      await this.addPublicDataWrites(publicDataWrites);
-      this.addUniqueNoteHashesFromPublic(noteHashes);
-      this.addSiloedNullifiersFromPublic(nullifiers);
-    }
-
-    this.setContractAddress(currentContractAddress);
-    this.setMsgSender(currentMessageSender);
-
-    return executionResult;
-  }
-
-  avmOpcodeSuccessCopy(): boolean {
-    return this.nestedCallSuccess;
-  }
-
-  avmOpcodeReturndataSize(): number {
-    return this.nestedCallReturndata.length;
-  }
-
-  avmOpcodeReturndataCopy(rdOffset: number, copySize: number): Fr[] {
-    return this.nestedCallReturndata.slice(rdOffset, rdOffset + copySize);
   }
 
   async avmOpcodeNullifierExists(innerNullifier: Fr, targetAddress: AztecAddress): Promise<boolean> {


### PR DESCRIPTION
And here we finally delete all of the machinery required to process private and public calls inline, (i.e. the old `call_iface.call(context)`, which we don't do anymore. I am not entirely sure if this will pass CI in it's current state, but detecting usage of this feature is a bit hard unfortunately so this is a good way of seeing what fails.

Built on top of https://github.com/AztecProtocol/aztec-packages/pull/15934, merge that first.