### PR TITLE
feat: Change sampling algorithm to use feistel permutations

### DIFF
--- a/l1-contracts/src/core/libraries/crypto/SampleLib.sol
+++ b/l1-contracts/src/core/libraries/crypto/SampleLib.sol
@@ -3,22 +3,13 @@
 pragma solidity >=0.8.27;
 
 import {Errors} from "@aztec/core/libraries/Errors.sol";
-import {SlotDerivation} from "@oz/utils/SlotDerivation.sol";
-import {TransientSlot} from "@oz/utils/TransientSlot.sol";
 
 /**
  * @title   SampleLib
  * @author  Anaxandridas II
- * @notice  A tiny library to draw committee indices using a sample without replacement algorithm.
+ * @notice  A tiny library to draw committee indices using a sample without replacement algorithm based on Feistel permutations.
  */
 library SampleLib {
-  using SlotDerivation for string;
-  using SlotDerivation for bytes32;
-  using TransientSlot for *;
-
-  // Namespace for transient storage keys used within this library
-  string private constant OVERRIDE_NAMESPACE = "Aztec.SampleLib.Override";
-
   /**
    * Compute Committee
    *
@@ -32,6 +23,7 @@ library SampleLib {
    */
   function computeCommittee(uint256 _committeeSize, uint256 _indexCount, uint256 _seed)
     internal
+    pure
     returns (uint256[] memory)
   {
     require(
@@ -43,52 +35,8 @@ library SampleLib {
       return new uint256[](0);
     }
 
-    uint256[] memory sampledIndices = new uint256[](_committeeSize);
-
-    uint256 upperLimit = _indexCount - 1;
-
-    for (uint256 index = 0; index < _committeeSize; index++) {
-      uint256 sampledIndex = computeSampleIndex(index, upperLimit + 1, _seed);
-
-      // Get index, or its swapped override
-      sampledIndices[index] = getValue(sampledIndex);
-      if (upperLimit > 0) {
-        // Swap with the last index
-        setOverrideValue(sampledIndex, getValue(upperLimit));
-        // Decrement the upper limit
-        upperLimit--;
-      }
-    }
-
-    // Clear transient storage.
-    // Note that we are cleaing the `sampleIndicies` and do not keep track of a separate list of
-    // `sampleIndex` that was written to. The reasoning being that we are only overwriting for
-    // duplicate cases, so `sampleIndicies` isa superset of the `sampleIndex` that have been drawn
-    // (due to account for duplicates). Thereby clearing the `sampleIndicies` clears all.
-    // Due to the cost of `tstore` and `tload` it is cheaper just to overwrite it all, than checking
-    // if there is even anything to override.
-    for (uint256 i = 0; i < _committeeSize; i++) {
-      setOverrideValue(sampledIndices[i], 0);
-    }
-
-    return sampledIndices;
-  }
-
-  function setOverrideValue(uint256 _index, uint256 _value) internal {
-    OVERRIDE_NAMESPACE.erc7201Slot().deriveMapping(_index).asUint256().tstore(_value);
-  }
-
-  function getValue(uint256 _index) internal view returns (uint256) {
-    uint256 overrideValue = getOverrideValue(_index);
-    if (overrideValue != 0) {
-      return overrideValue;
-    }
-
-    return _index;
-  }
-
-  function getOverrideValue(uint256 _index) internal view returns (uint256) {
-    return OVERRIDE_NAMESPACE.erc7201Slot().deriveMapping(_index).asUint256().tload();
+    // Use optimized batch Feistel computation
+    return computeCommitteeBatch(_committeeSize, _indexCount, _seed);
   }
 
   /**
@@ -111,5 +59,134 @@ library SampleLib {
     }
 
     return uint256(keccak256(abi.encodePacked(_seed, _index))) % _indexCount;
+  }
+
+  /**
+   * @notice  Compute a single committee member at a specific index in O(1) time
+   *          without allowing duplicates using a Feistel network permutation
+   *
+   * @param _index - The index in the committee (0 to _committeeSize-1)
+   * @param _committeeSize - The size of the committee
+   * @param _indexCount - The total number of validators to sample from
+   * @param _seed - The seed for randomization
+   *
+   * @return The validator index for the committee position
+   */
+  function computeCommitteeMemberAtIndex(
+    uint256 _index,
+    uint256 _committeeSize,
+    uint256 _indexCount,
+    uint256 _seed
+  ) internal pure returns (uint256) {
+    require(_index < _committeeSize, Errors.SampleLib__IndexOutOfBounds(_index, _committeeSize));
+    require(
+      _committeeSize <= _indexCount,
+      Errors.SampleLib__SampleLargerThanIndex(_committeeSize, _indexCount)
+    );
+
+    // Use a Feistel network to create a permutation of [0, _indexCount)
+    uint256 permutedIndex = feistelPermute(_index, _indexCount, _seed);
+
+    // Cycle walking: keep applying the permutation until we get a value < _indexCount
+    // This handles non-power-of-2 sizes
+    while (permutedIndex >= _indexCount) {
+      permutedIndex = feistelPermute(permutedIndex, _indexCount, _seed);
+    }
+
+    return permutedIndex;
+  }
+
+  /**
+   * @notice  Optimized batch computation of committee members using Feistel network
+   *          Computes all indices simultaneously with shared pre-computation
+   *
+   * @param _committeeSize - The size of the committee
+   * @param _indexCount - The total number of validators to sample from
+   * @param _seed - The seed for randomization
+   *
+   * @return The array of validator indices for the committee
+   */
+  function computeCommitteeBatch(uint256 _committeeSize, uint256 _indexCount, uint256 _seed)
+    internal
+    pure
+    returns (uint256[] memory)
+  {
+    uint256[] memory indices = new uint256[](_committeeSize);
+
+    // Pre-compute constants for Feistel network
+    uint256 size = 1;
+    uint256 bits = 0;
+    while (size < _indexCount) {
+      size <<= 1;
+      bits++;
+    }
+
+    uint256 halfBits = (bits + 1) / 2;
+    uint256 mask = (1 << halfBits) - 1;
+
+    // Process all committee members
+    for (uint256 i = 0; i < _committeeSize; i++) {
+      uint256 permuted = i;
+
+      // Apply Feistel rounds
+      do {
+        uint256 left = permuted >> halfBits;
+        uint256 right = permuted & mask;
+
+        // 4 rounds of Feistel
+        for (uint256 round = 0; round < 4; round++) {
+          uint256 newLeft = right;
+          uint256 f = uint256(keccak256(abi.encodePacked(_seed, round, right))) & mask;
+          right = left ^ f;
+          left = newLeft;
+        }
+
+        permuted = (left << halfBits) | right;
+      } while (permuted >= _indexCount); // Cycle walking for non-power-of-2 domains
+
+      indices[i] = permuted;
+    }
+
+    return indices;
+  }
+
+  /**
+   * @notice  Feistel network implementation for creating a bijective mapping
+   *          Guarantees no collisions within the domain
+   *
+   * @param _input - The input value to permute
+   * @param _max - The maximum value (exclusive) in the domain
+   * @param _seed - The seed for the permutation
+   *
+   * @return The permuted value
+   */
+  function feistelPermute(uint256 _input, uint256 _max, uint256 _seed)
+    internal
+    pure
+    returns (uint256)
+  {
+    // Find next power of 2 >= _max for balanced Feistel
+    uint256 size = 1;
+    uint256 bits = 0;
+    while (size < _max) {
+      size <<= 1;
+      bits++;
+    }
+
+    uint256 halfBits = (bits + 1) / 2;
+    uint256 mask = (1 << halfBits) - 1;
+
+    uint256 left = _input >> halfBits;
+    uint256 right = _input & mask;
+
+    // 4 rounds provides good mixing for cryptographic permutation
+    for (uint256 round = 0; round < 4; round++) {
+      uint256 newLeft = right;
+      uint256 f = uint256(keccak256(abi.encodePacked(_seed, round, right))) & mask;
+      right = left ^ f;
+      left = newLeft;
+    }
+
+    return (left << halfBits) | right;
   }
 }

--- a/l1-contracts/test/RollupGetters.t.sol
+++ b/l1-contracts/test/RollupGetters.t.sol
@@ -78,6 +78,15 @@ contract RollupShouldBeGetters is ValidatorSelectionTestBase {
     assertEq(committeeSize, expectedSize, "invalid getCommitteeCommittmentAt size");
     assertNotEq(committeeCommitment, bytes32(0), "invalid committee commitment");
 
+    // Check for no duplicates in each committee
+    for (uint256 i = 0; i < expectedSize; i++) {
+      for (uint256 j = i + 1; j < expectedSize; j++) {
+        assertNotEq(committee[i], committee[j], "duplicate found in getEpochCommittee");
+        assertNotEq(committee2[i], committee2[j], "duplicate found in getCommitteeAt");
+        assertNotEq(committee3[i], committee3[j], "duplicate found in getCurrentEpochCommittee");
+      }
+    }
+
     (, bytes32[] memory writes) = vm.accesses(address(rollup));
     assertEq(writes.length, 0, "No writes should be done");
   }


### PR DESCRIPTION
Feistel permutations remove the need for auxiliary storage for tracking replacements, and most importantly, allow us to compute a given index permutation in constant time, which allows us to get the proposer for a given committee without having to compute all indices.

Props to Claude for the idea and implementation.

Builds on #15813

Median propose cost is `306000`.