### PR TITLE
chore: try to deflake p2p_integration tests

### DIFF
--- a/yarn-project/p2p/src/client/test/p2p_client.integration_block_txs.test.ts
+++ b/yarn-project/p2p/src/client/test/p2p_client.integration_block_txs.test.ts
@@ -99,13 +99,13 @@ describe('p2p client integration block txs protocol ', () => {
   });
 
   afterEach(async () => {
-    jest.restoreAllMocks();
-    jest.resetAllMocks();
-    jest.clearAllMocks();
-
     logger.info(`Tearing down state for ${expect.getState().currentTestName}`);
     await shutdown(clients);
     logger.info('Shut down p2p clients');
+
+    jest.restoreAllMocks();
+    jest.resetAllMocks();
+    jest.clearAllMocks();
 
     clients = [];
   });

--- a/yarn-project/p2p/src/client/test/p2p_client.integration_message_propagation.test.ts
+++ b/yarn-project/p2p/src/client/test/p2p_client.integration_message_propagation.test.ts
@@ -200,7 +200,7 @@ describe('p2p client integration message propagation', () => {
       client3AttestationPromise.promise,
     ];
 
-    const messages = await retryUntil(() => collectIfReady(messagesPromise), 'all gossiped messages received', 20, 1);
+    const messages = await retryUntil(() => collectIfReady(messagesPromise), 'all gossiped messages received', 10, 1);
 
     expect(messages).toBeDefined();
     expect(client2HandleGossipedTxSpy).toHaveBeenCalled();
@@ -252,10 +252,6 @@ describe('p2p client integration message propagation', () => {
       };
 
       const clientsAndConfig = await makeAndStartTestP2PClients(numberOfNodes, testConfig);
-      //Disable handshake because it makes this test flaky
-      for (const c of clientsAndConfig) {
-        (c as any).client.p2pService.peerManager.exchangeStatusHandshake = jest.fn().mockImplementation(() => {});
-      }
       const [client1, client2, client3] = clientsAndConfig;
 
       // Give the nodes time to discover each other

--- a/yarn-project/p2p/src/client/test/p2p_client.integration_message_propagation.test.ts
+++ b/yarn-project/p2p/src/client/test/p2p_client.integration_message_propagation.test.ts
@@ -80,13 +80,13 @@ describe('p2p client integration message propagation', () => {
   });
 
   afterEach(async () => {
-    jest.restoreAllMocks();
-    jest.resetAllMocks();
-    jest.clearAllMocks();
-
     logger.info(`Tearing down state for ${expect.getState().currentTestName}`);
     await shutdown(clients);
     logger.info('Shut down p2p clients');
+
+    jest.restoreAllMocks();
+    jest.resetAllMocks();
+    jest.clearAllMocks();
 
     clients = [];
   });
@@ -191,16 +191,17 @@ describe('p2p client integration message propagation', () => {
     await (client1 as any).p2pService.broadcastAttestation(attestation);
 
     // Clients 2 and 3 should receive all messages
-    const messagesPromise = Promise.all([
+    const messagesPromise = [
       client2TxPromise.promise,
       client3TxPromise.promise,
       client2ProposalPromise.promise,
       client3ProposalPromise.promise,
       client2AttestationPromise.promise,
       client3AttestationPromise.promise,
-    ]);
+    ];
 
-    const messages = await Promise.race([messagesPromise, sleep(6000).then(() => undefined)]);
+    const messages = await retryUntil(() => collectIfReady(messagesPromise), 'all gossiped messages received', 20, 1);
+
     expect(messages).toBeDefined();
     expect(client2HandleGossipedTxSpy).toHaveBeenCalled();
     expect(client2HandleGossipedProposalSpy).toHaveBeenCalled();
@@ -221,6 +222,14 @@ describe('p2p client integration message propagation', () => {
     }
   };
 
+  const collectIfReady = async (promises: Promise<any>[]) => {
+    const settled = await Promise.allSettled(promises);
+    if (settled.every(s => s.status === 'fulfilled')) {
+      return settled.map(s => (s as PromiseFulfilledResult<any>).value);
+    }
+    return undefined;
+  };
+
   // Test creates 3 nodes. Node 1 sends all message types to others.
   // Test confirms that nodes 2 and 3 receive all messages.
   // Then nodes 2 and 3 are restarted, node 3 is restarted at a new version
@@ -233,7 +242,7 @@ describe('p2p client integration message propagation', () => {
       const numberOfNodes = 3;
       // We start at rollup version 1
       const testConfig: MakeTestP2PClientOptions = {
-        p2pBaseConfig: { ...p2pBaseConfig, rollupVersion: 1 },
+        p2pBaseConfig: { ...p2pBaseConfig, rollupVersion: 1, p2pDisableStatusHandshake: true },
         mockAttestationPool: attestationPool,
         mockTxPool: txPool,
         mockEpochCache: epochCache,
@@ -248,11 +257,6 @@ describe('p2p client integration message propagation', () => {
         (c as any).client.p2pService.peerManager.exchangeStatusHandshake = jest.fn().mockImplementation(() => {});
       }
       const [client1, client2, client3] = clientsAndConfig;
-
-      //Disable handshake because it makes this test flaky
-      clientsAndConfig.forEach((c: any) => {
-        c.client.p2pService.peerManager.exchangeStatusHandshake = jest.fn().mockImplementation(() => {});
-      });
 
       // Give the nodes time to discover each other
       await retryUntil(async () => (await client1.client.getPeers()).length >= 2, 'peers discovered', 10, 0.5);
@@ -284,11 +288,6 @@ describe('p2p client integration message propagation', () => {
       });
 
       const clients = [newClient2, newClient3];
-
-      //Disable handshake because it makes this test flaky
-      clients.forEach((c: any) => {
-        c.p2pService.peerManager.exchangeStatusHandshake = jest.fn().mockImplementation(() => {});
-      });
 
       await startTestP2PClients(clients);
       // Give everyone time to connect again
@@ -343,22 +342,22 @@ describe('p2p client integration message propagation', () => {
         await (client1.client as any).p2pService.broadcastAttestation(attestation);
 
         // Only client 2 should receive the messages
-        const client2MessagesPromises = Promise.all([
-          client2TxPromise.promise,
-          client2ProposalPromise.promise,
-          client2AttestationPromise.promise,
-        ]);
+        const client2Messages = await retryUntil(
+          () =>
+            collectIfReady([
+              client2TxPromise.promise,
+              client2ProposalPromise.promise,
+              client2AttestationPromise.promise,
+            ]),
+          'client2 received all messages',
+          20,
+          1,
+        );
 
         // We use Promise.any as no messages should be received
-        const client3MessagesPromises = Promise.any([
-          client3TxPromise.promise,
-          client3ProposalPromise.promise,
-          client3AttestationPromise.promise,
-        ]);
-
-        const [client2Messages, client3Messages] = await Promise.all([
-          Promise.race([client2MessagesPromises, sleep(6000).then(() => undefined)]),
-          Promise.race([client3MessagesPromises, sleep(6000).then(() => undefined)]),
+        const client3Messages = await Promise.race([
+          Promise.any([client3TxPromise.promise, client3ProposalPromise.promise, client3AttestationPromise.promise]),
+          sleep(6_000).then(() => undefined),
         ]);
 
         // We expect that all messages were received by client 2

--- a/yarn-project/p2p/src/client/test/p2p_client.integration_txs.test.ts
+++ b/yarn-project/p2p/src/client/test/p2p_client.integration_txs.test.ts
@@ -72,13 +72,13 @@ describe('p2p client integration', () => {
   });
 
   afterEach(async () => {
-    jest.restoreAllMocks();
-    jest.resetAllMocks();
-    jest.clearAllMocks();
-
     logger.info(`Tearing down state for ${expect.getState().currentTestName}`);
     await shutdown(clients);
     logger.info('Shut down p2p clients');
+
+    jest.restoreAllMocks();
+    jest.resetAllMocks();
+    jest.clearAllMocks();
 
     clients = [];
   });

--- a/yarn-project/p2p/src/test-helpers/make-test-p2p-clients.ts
+++ b/yarn-project/p2p/src/test-helpers/make-test-p2p-clients.ts
@@ -2,6 +2,7 @@ import { MockL2BlockSource } from '@aztec/archiver/test';
 import type { EpochCache } from '@aztec/epoch-cache';
 import { SecretValue } from '@aztec/foundation/config';
 import { type Logger, createLogger } from '@aztec/foundation/log';
+import { retryUntil } from '@aztec/foundation/retry';
 import { sleep } from '@aztec/foundation/sleep';
 import type { DataStoreConfig } from '@aztec/kv-store/config';
 import { openTmpStore } from '@aztec/kv-store/lmdb-v2';
@@ -207,5 +208,5 @@ export async function makeTestP2PClients(numberOfPeers: number, testConfig: Make
 
 export async function startTestP2PClients(clients: P2PClient[]) {
   await Promise.all(clients.map(c => c.start()));
-  await Promise.all(clients.map(c => c.isReady()));
+  await retryUntil(() => clients.every(c => c.isReady()), 'p2p clients started', 10, 0.5);
 }


### PR DESCRIPTION
I'm basically reopening https://github.com/AztecProtocol/aztec-packages/pull/15878. 
I don't believe this will deflake message propagation tests, but it should make status handshake tests less brittle. 