### PR TITLE
chore: only stop testing env on x86

### DIFF
--- a/spartan/bootstrap.sh
+++ b/spartan/bootstrap.sh
@@ -91,7 +91,7 @@ function start_env {
 }
 
 function stop_env {
-  if [ "$CI_NIGHTLY" -eq 1 ]; then
+  if [ "$CI_NIGHTLY" -eq 1 ] && [ "$(arch)" != "arm64" ]; then
     NIGHTLY_NS=nightly-$(date -u +%Y%m%d)
     echo "Uninstalling test network in namespace $NIGHTLY_NS"
     ./scripts/cleanup_k8s.sh "$NIGHTLY_NS" "$NIGHTLY_NS"


### PR DESCRIPTION
We only run nightly tests on x86 right now so the testing env is not setup on ARM.