### PR TITLE
chore: deflake timeout after block mined

### DIFF
--- a/yarn-project/ethereum/src/l1_tx_utils.test.ts
+++ b/yarn-project/ethereum/src/l1_tx_utils.test.ts
@@ -505,12 +505,12 @@ describe('L1TxUtils', () => {
       const tx = await gasUtils.sendTransaction(txRequest);
       const monitorPromise = gasUtils.monitorTransaction(txRequest, tx.txHash, tx, { txTimeoutAt });
 
-      await sleep(1000);
+      await sleep(100);
       await cheatCodes.dropTransaction(tx.txHash);
       await cheatCodes.setNextBlockTimestamp(txTimeoutAt);
       await cheatCodes.mine();
       await expect(monitorPromise).rejects.toThrow(/timed out/);
-      expect(dateProvider.now() - now).toBeGreaterThanOrEqual(990);
+      expect(dateProvider.now() - now).toBeGreaterThanOrEqual(90);
     }, 20_000);
 
     it('attempts to cancel timed out transactions', async () => {


### PR DESCRIPTION
## Overview

Test always fails if this sleep is increased past 1 second, so in some cases on congested ci machine it takes longer, reducing the sleep to be less than the next block timestamp solves it

logic is - increasing number makes it happen, so decreasing number good
