### PR TITLE
chore: migrate txe tests to requiring the context check

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/context/returns_hash.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/returns_hash.nr
@@ -45,7 +45,7 @@ mod test {
 
     #[test]
     unconstrained fn retrieves_preimage() {
-        let mut env = TestEnvironment::_new();
+        let mut env = TestEnvironment::new();
         env.private_context(|_| {
             let value = MockStruct::new(4, 7);
             let serialized = value.serialize();
@@ -59,7 +59,7 @@ mod test {
 
     #[test]
     unconstrained fn retrieves_empty_preimage() {
-        let mut env = TestEnvironment::_new();
+        let mut env = TestEnvironment::new();
         env.private_context(|_| {
             let value = ();
             let serialized = [];

--- a/noir-projects/aztec-nr/aztec/src/keys/getters/test.nr
+++ b/noir-projects/aztec-nr/aztec/src/keys/getters/test.nr
@@ -1,21 +1,15 @@
 use crate::keys::getters::get_public_keys;
 
-use crate::test::helpers::{test_environment::TestEnvironment, txe_oracles, utils::TestAccount};
+use crate::test::helpers::test_environment::TestEnvironment;
 use dep::std::test::OracleMock;
 use protocol_types::traits::Serialize;
 
 global KEY_ORACLE_RESPONSE_LENGTH: u32 = 13; // 12 fields for the keys, one field for the partial address
 
-unconstrained fn setup() -> TestAccount {
-    let _ = TestEnvironment::new();
-    let account = txe_oracles::create_account(1);
-
-    account
-}
-
 #[test(should_fail_with = "Invalid public keys hint for address")]
-unconstrained fn test_get_public_keys_unknown() {
-    let account = setup();
+unconstrained fn get_public_keys_fails_with_bad_hint() {
+    let mut env = TestEnvironment::new();
+    let account = env.create_account(1);
 
     // Instead of querying for some unknown account, which would result in the oracle erroring out, we mock a bad oracle
     // response to check that the circuit properly checks the address derivation.
@@ -57,12 +51,14 @@ unconstrained fn test_get_public_keys_unknown() {
     let _ = OracleMock::mock("getPublicKeysAndPartialAddress")
         .returns(random_keys_and_partial_address.serialize())
         .times(1);
-    let _ = get_public_keys(account.address);
+    let _ = get_public_keys(account);
 }
 
 #[test]
-unconstrained fn test_get_public_keys_known() {
-    let account = setup();
+unconstrained fn get_public_keys_returns_keys_of_known_accounts() {
+    let mut env = TestEnvironment::new();
+    let account = env.create_account(1);
 
-    assert_eq(get_public_keys(account.address), account.keys);
+    // Key fetching requires oracles that are only available during private execution
+    env.private_context(|_| { let _ = get_public_keys(account); });
 }

--- a/noir-projects/aztec-nr/aztec/src/messages/encryption/aes128.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/encryption/aes128.nr
@@ -382,50 +382,55 @@ mod test {
     #[test]
     unconstrained fn encrypt_decrypt_log() {
         let mut env = TestEnvironment::new();
-        // Advance 1 block so we can read historic state from private
-        env.mine_block();
 
-        let plaintext = [1, 2, 3];
+        // Log decryption requires oracles that are only available during private execution
+        env.private_context(|_| {
+            let plaintext = [1, 2, 3];
 
-        let recipient = AztecAddress::from_field(
-            0x25afb798ea6d0b8c1618e50fdeafa463059415013d3b7c75d46abf5e242be70c,
-        );
+            let recipient = AztecAddress::from_field(
+                0x25afb798ea6d0b8c1618e50fdeafa463059415013d3b7c75d46abf5e242be70c,
+            );
 
-        // Mock random values for deterministic test
-        let eph_sk = 0x1358d15019d4639393d62b97e1588c095957ce74a1c32d6ec7d62fe6705d9538;
-        let _ = OracleMock::mock("getRandomField").returns(eph_sk).times(1);
+            // Mock random values for deterministic test
+            let eph_sk = 0x1358d15019d4639393d62b97e1588c095957ce74a1c32d6ec7d62fe6705d9538;
+            let _ = OracleMock::mock("getRandomField").returns(eph_sk).times(1);
 
-        let randomness = 0x0101010101010101010101010101010101010101010101010101010101010101;
-        let _ = OracleMock::mock("getRandomField").returns(randomness).times(1000000);
+            let randomness = 0x0101010101010101010101010101010101010101010101010101010101010101;
+            let _ = OracleMock::mock("getRandomField").returns(randomness).times(1000000);
 
-        let _ = OracleMock::mock("getIndexedTaggingSecretAsSender").returns(
-            IndexedTaggingSecret::deserialize([69420, 1337]),
-        );
-        let _ = OracleMock::mock("incrementAppTaggingSecretIndexAsSender").returns(());
+            let _ = OracleMock::mock("getIndexedTaggingSecretAsSender").returns(
+                IndexedTaggingSecret::deserialize([69420, 1337]),
+            );
+            let _ = OracleMock::mock("incrementAppTaggingSecretIndexAsSender").returns(());
 
-        // Encrypt the log
-        let encrypted_log = BoundedVec::from_array(AES128::encrypt_log(plaintext, recipient));
+            // Encrypt the log
+            let encrypted_log = BoundedVec::from_array(AES128::encrypt_log(plaintext, recipient));
 
-        // Mock shared secret for deterministic test
-        let shared_secret = derive_ecdh_shared_secret_using_aztec_address(
-            EmbeddedCurveScalar::from_field(eph_sk),
-            recipient,
-        );
-        let _ = OracleMock::mock("getSharedSecret").returns(shared_secret);
+            // Mock shared secret for deterministic test
+            let shared_secret = derive_ecdh_shared_secret_using_aztec_address(
+                EmbeddedCurveScalar::from_field(eph_sk),
+                recipient,
+            );
+            let _ = OracleMock::mock("getSharedSecret").returns(shared_secret);
 
-        // Decrypt the log
-        let decrypted = AES128::decrypt_log(encrypted_log, recipient);
+            // Decrypt the log
+            let decrypted = AES128::decrypt_log(encrypted_log, recipient);
 
-        // The decryption function spits out a BoundedVec because it's designed to work with logs with unknown length
-        // at compile time. For this reason we need to convert the original input to a BoundedVec.
-        let plaintext_bvec =
-            BoundedVec::<Field, PRIVATE_LOG_PLAINTEXT_SIZE_IN_FIELDS>::from_array(plaintext);
+            // The decryption function spits out a BoundedVec because it's designed to work with logs with unknown length
+            // at compile time. For this reason we need to convert the original input to a BoundedVec.
+            let plaintext_bvec =
+                BoundedVec::<Field, PRIVATE_LOG_PLAINTEXT_SIZE_IN_FIELDS>::from_array(plaintext);
 
-        // Verify decryption matches original plaintext
-        assert_eq(decrypted, plaintext_bvec, "Decrypted bytes should match original plaintext");
+            // Verify decryption matches original plaintext
+            assert_eq(
+                decrypted,
+                plaintext_bvec,
+                "Decrypted bytes should match original plaintext",
+            );
 
-        // The following is a workaround of "struct is never constructed" Noir compilation error (we only ever use
-        // static methods of the struct).
-        let _ = AES128 {};
+            // The following is a workaround of "struct is never constructed" Noir compilation error (we only ever use
+            // static methods of the struct).
+            let _ = AES128 {};
+        });
     }
 }

--- a/noir-projects/aztec-nr/aztec/src/note/note_getter/test.nr
+++ b/noir-projects/aztec-nr/aztec/src/note/note_getter/test.nr
@@ -37,7 +37,7 @@ where
 
 #[test]
 unconstrained fn processes_single_note() {
-    let mut env = TestEnvironment::_new();
+    let mut env = TestEnvironment::new();
 
     env.private_context(|context| {
         let mut notes_to_constrain = [Option::none(); _];
@@ -54,7 +54,7 @@ unconstrained fn processes_single_note() {
 
 #[test]
 unconstrained fn processes_many_notes() {
-    let mut env = TestEnvironment::_new();
+    let mut env = TestEnvironment::new();
 
     env.private_context(|context| {
         let mut notes_to_constrain = [Option::none(); _];
@@ -72,7 +72,7 @@ unconstrained fn processes_many_notes() {
 
 #[test]
 unconstrained fn collapses_notes_at_the_beginning_of_the_array() {
-    let mut env = TestEnvironment::_new();
+    let mut env = TestEnvironment::new();
 
     env.private_context(|context| {
         let mut opt_notes = [Option::none(); _];
@@ -101,7 +101,7 @@ unconstrained fn collapses_notes_at_the_beginning_of_the_array() {
 
 #[test]
 unconstrained fn can_return_zero_notes() {
-    let mut env = TestEnvironment::_new();
+    let mut env = TestEnvironment::new();
 
     env.private_context(|context| {
         let opt_notes: [Option<RetrievedNote<MockNote>>; _] = [Option::none(); _];
@@ -115,7 +115,7 @@ unconstrained fn can_return_zero_notes() {
 
 #[test(should_fail_with = "Got more notes than limit.")]
 unconstrained fn rejects_mote_notes_than_limit() {
-    let mut env = TestEnvironment::_new();
+    let mut env = TestEnvironment::new();
 
     env.private_context(|context| {
         let mut opt_notes: [Option<RetrievedNote<MockNote>>; _] = [Option::none(); _];
@@ -131,7 +131,7 @@ unconstrained fn rejects_mote_notes_than_limit() {
 
 #[test]
 unconstrained fn applies_filter_before_constraining() {
-    let mut env = TestEnvironment::_new();
+    let mut env = TestEnvironment::new();
 
     env.private_context(|context| {
         let mut notes_to_constrain = [Option::none(); _];
@@ -167,7 +167,7 @@ unconstrained fn applies_filter_before_constraining() {
 
 #[test(should_fail_with = "Note contract address mismatch.")]
 unconstrained fn rejects_mismatched_address() {
-    let mut env = TestEnvironment::_new();
+    let mut env = TestEnvironment::new();
 
     env.private_context(|context| {
         let note = MockNote::new(1).build_retrieved_note(); // We're not setting the right contract address
@@ -181,7 +181,7 @@ unconstrained fn rejects_mismatched_address() {
 
 #[test(should_fail_with = "Mismatch return note field.")]
 unconstrained fn rejects_mismatched_selector() {
-    let mut env = TestEnvironment::_new();
+    let mut env = TestEnvironment::new();
 
     env.private_context(|context| {
         let value = 10;
@@ -203,7 +203,7 @@ unconstrained fn rejects_mismatched_selector() {
 
 #[test(should_fail_with = "Return notes not sorted in descending order.")]
 unconstrained fn rejects_mismatched_desc_sort_order() {
-    let mut env = TestEnvironment::_new();
+    let mut env = TestEnvironment::new();
 
     env.private_context(|context| {
         let mut opt_notes = [Option::none(); _];
@@ -220,7 +220,7 @@ unconstrained fn rejects_mismatched_desc_sort_order() {
 
 #[test(should_fail_with = "Return notes not sorted in ascending order.")]
 unconstrained fn rejects_mismatched_asc_sort_order() {
-    let mut env = TestEnvironment::_new();
+    let mut env = TestEnvironment::new();
 
     env.private_context(|context| {
         let mut opt_notes = [Option::none(); _];

--- a/noir-projects/aztec-nr/aztec/src/oracle/capsules.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/capsules.nr
@@ -85,7 +85,7 @@ mod test {
 
     #[test]
     unconstrained fn stores_and_loads() {
-        let mut env = TestEnvironment::_new();
+        let mut env = TestEnvironment::new();
         env.private_context(|context| {
             let contract_address = context.this_address();
 
@@ -98,7 +98,7 @@ mod test {
 
     #[test]
     unconstrained fn store_overwrites() {
-        let mut env = TestEnvironment::_new();
+        let mut env = TestEnvironment::new();
         env.private_context(|context| {
             let contract_address = context.this_address();
 
@@ -114,7 +114,7 @@ mod test {
 
     #[test]
     unconstrained fn loads_empty_slot() {
-        let mut env = TestEnvironment::_new();
+        let mut env = TestEnvironment::new();
         env.private_context(|context| {
             let contract_address = context.this_address();
 
@@ -125,7 +125,7 @@ mod test {
 
     #[test]
     unconstrained fn deletes_stored_value() {
-        let mut env = TestEnvironment::_new();
+        let mut env = TestEnvironment::new();
         env.private_context(|context| {
             let contract_address = context.this_address();
 
@@ -140,7 +140,7 @@ mod test {
 
     #[test]
     unconstrained fn deletes_empty_slot() {
-        let mut env = TestEnvironment::_new();
+        let mut env = TestEnvironment::new();
         env.private_context(|context| {
             let contract_address = context.this_address();
 
@@ -152,7 +152,7 @@ mod test {
 
     #[test]
     unconstrained fn copies_non_overlapping_values() {
-        let mut env = TestEnvironment::_new();
+        let mut env = TestEnvironment::new();
         env.private_context(|context| {
             let contract_address = context.this_address();
 
@@ -174,7 +174,7 @@ mod test {
 
     #[test]
     unconstrained fn copies_overlapping_values_with_src_ahead() {
-        let mut env = TestEnvironment::_new();
+        let mut env = TestEnvironment::new();
         env.private_context(|context| {
             let contract_address = context.this_address();
 
@@ -201,7 +201,7 @@ mod test {
 
     #[test]
     unconstrained fn copies_overlapping_values_with_dst_ahead() {
-        let mut env = TestEnvironment::_new();
+        let mut env = TestEnvironment::new();
         env.private_context(|context| {
             let contract_address = context.this_address();
 
@@ -228,7 +228,7 @@ mod test {
 
     #[test(should_fail_with = "copy empty slot")]
     unconstrained fn cannot_copy_empty_values() {
-        let mut env = TestEnvironment::_new();
+        let mut env = TestEnvironment::new();
         env.private_context(|context| {
             let contract_address = context.this_address();
 
@@ -238,7 +238,7 @@ mod test {
 
     #[test(should_fail_with = "not allowed to access")]
     unconstrained fn cannot_store_other_contract() {
-        let mut env = TestEnvironment::_new();
+        let mut env = TestEnvironment::new();
         env.private_context(|context| {
             let contract_address = context.this_address();
             let other_contract_address = AztecAddress::from_field(contract_address.to_field() + 1);
@@ -250,7 +250,7 @@ mod test {
 
     #[test(should_fail_with = "not allowed to access")]
     unconstrained fn cannot_load_other_contract() {
-        let mut env = TestEnvironment::_new();
+        let mut env = TestEnvironment::new();
         env.private_context(|context| {
             let contract_address = context.this_address();
             let other_contract_address = AztecAddress::from_field(contract_address.to_field() + 1);
@@ -261,7 +261,7 @@ mod test {
 
     #[test(should_fail_with = "not allowed to access")]
     unconstrained fn cannot_delete_other_contract() {
-        let mut env = TestEnvironment::_new();
+        let mut env = TestEnvironment::new();
         env.private_context(|context| {
             let contract_address = context.this_address();
             let other_contract_address = AztecAddress::from_field(contract_address.to_field() + 1);
@@ -272,7 +272,7 @@ mod test {
 
     #[test(should_fail_with = "not allowed to access")]
     unconstrained fn cannot_copy_other_contract() {
-        let mut env = TestEnvironment::_new();
+        let mut env = TestEnvironment::new();
         env.private_context(|context| {
             let contract_address = context.this_address();
             let other_contract_address = AztecAddress::from_field(contract_address.to_field() + 1);

--- a/noir-projects/aztec-nr/aztec/src/state_vars/delayed_public_mutable/test.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/delayed_public_mutable/test.nr
@@ -35,7 +35,7 @@ unconstrained fn in_utility(
 
 #[test]
 unconstrained fn get_current_value_in_public_initial() {
-    let env = TestEnvironment::_new();
+    let env = TestEnvironment::new();
 
     env.public_context(|context| {
         let state_var = in_public(context);
@@ -45,7 +45,7 @@ unconstrained fn get_current_value_in_public_initial() {
 
 #[test]
 unconstrained fn get_scheduled_value_in_public() {
-    let mut env = TestEnvironment::_new();
+    let mut env = TestEnvironment::new();
 
     env.public_context(|context| {
         let state_var = in_public(context);
@@ -62,7 +62,7 @@ unconstrained fn get_scheduled_value_in_public() {
 
 #[test]
 unconstrained fn get_current_value_in_public_before_scheduled_change() {
-    let mut env = TestEnvironment::_new();
+    let mut env = TestEnvironment::new();
 
     let (original_value, timestamp_of_change) = env.public_context(|context| {
         let state_var = in_public(context);
@@ -90,7 +90,7 @@ unconstrained fn get_current_value_in_public_before_scheduled_change() {
 
 #[test]
 unconstrained fn get_current_value_in_public_at_scheduled_change() {
-    let mut env = TestEnvironment::_new();
+    let mut env = TestEnvironment::new();
 
     let (_, timestamp_of_change) = env.public_context(|context| {
         let state_var = in_public(context);
@@ -109,7 +109,7 @@ unconstrained fn get_current_value_in_public_at_scheduled_change() {
 
 #[test]
 unconstrained fn get_current_value_in_public_after_scheduled_change() {
-    let mut env = TestEnvironment::_new();
+    let mut env = TestEnvironment::new();
 
     let (_, timestamp_of_change) = env.public_context(|context| {
         let state_var = in_public(context);
@@ -129,7 +129,7 @@ unconstrained fn get_current_value_in_public_after_scheduled_change() {
 
 #[test]
 unconstrained fn get_current_delay_in_public_initial() {
-    let env = TestEnvironment::_new();
+    let env = TestEnvironment::new();
     env.public_context(|context| {
         let state_var = in_public(context);
         assert_eq(state_var.get_current_delay(), TEST_INITIAL_DELAY);
@@ -138,7 +138,7 @@ unconstrained fn get_current_delay_in_public_initial() {
 
 #[test]
 unconstrained fn get_scheduled_delay_in_public() {
-    let mut env = TestEnvironment::_new();
+    let mut env = TestEnvironment::new();
 
     env.public_context(|context| {
         let state_var = in_public(context);
@@ -154,7 +154,7 @@ unconstrained fn get_scheduled_delay_in_public() {
 
 #[test]
 unconstrained fn get_current_delay_in_public_before_scheduled_change() {
-    let mut env = TestEnvironment::_new();
+    let mut env = TestEnvironment::new();
 
     let (original_delay, timestamp_of_change) = env.public_context(|context| {
         let state_var = in_public(context);
@@ -182,7 +182,7 @@ unconstrained fn get_current_delay_in_public_before_scheduled_change() {
 
 #[test]
 unconstrained fn get_current_delay_in_public_at_scheduled_change() {
-    let mut env = TestEnvironment::_new();
+    let mut env = TestEnvironment::new();
 
     let (_, timestamp_of_change) = env.public_context(|context| {
         let state_var = in_public(context);
@@ -202,7 +202,7 @@ unconstrained fn get_current_delay_in_public_at_scheduled_change() {
 
 #[test]
 unconstrained fn get_current_delay_in_public_after_scheduled_change() {
-    let mut env = TestEnvironment::_new();
+    let mut env = TestEnvironment::new();
 
     let (_, timestamp_of_change) = env.public_context(|context| {
         let state_var = in_public(context);
@@ -222,7 +222,7 @@ unconstrained fn get_current_delay_in_public_after_scheduled_change() {
 
 #[test]
 unconstrained fn get_current_value_in_private_initial() {
-    let mut env = TestEnvironment::_new();
+    let mut env = TestEnvironment::new();
 
     env.private_context(|context| {
         let state_var = in_private(context);
@@ -237,7 +237,7 @@ unconstrained fn get_current_value_in_private_initial() {
 
 #[test]
 unconstrained fn get_current_value_in_private_before_change() {
-    let mut env = TestEnvironment::_new();
+    let mut env = TestEnvironment::new();
 
     let (_, timestamp_of_change) = env.public_context(|context| {
         let state_var = in_public(context);
@@ -257,7 +257,7 @@ unconstrained fn get_current_value_in_private_before_change() {
 
 #[test]
 unconstrained fn get_current_value_in_private_immediately_before_change() {
-    let mut env = TestEnvironment::_new();
+    let mut env = TestEnvironment::new();
 
     let (_, timestamp_of_change) = env.public_context(|context| {
         let state_var = in_public(context);
@@ -284,7 +284,7 @@ unconstrained fn get_current_value_in_private_immediately_before_change() {
 
 #[test]
 unconstrained fn get_current_value_in_private_at_change() {
-    let mut env = TestEnvironment::_new();
+    let mut env = TestEnvironment::new();
 
     let (_, timestamp_of_change) = env.public_context(|context| {
         let state_var = in_public(context);
@@ -312,7 +312,7 @@ unconstrained fn get_current_value_in_private_at_change() {
 
 #[test]
 unconstrained fn get_current_value_in_private_after_change() {
-    let mut env = TestEnvironment::_new();
+    let mut env = TestEnvironment::new();
 
     let (_, timestamp_of_change) = env.public_context(|context| {
         let state_var = in_public(context);
@@ -340,7 +340,7 @@ unconstrained fn get_current_value_in_private_after_change() {
 
 #[test]
 unconstrained fn get_current_value_in_private_with_non_initial_delay() {
-    let mut env = TestEnvironment::_new();
+    let mut env = TestEnvironment::new();
 
     let ((_, value_timestamp_of_change), (_, delay_timestamp_of_change)) = env
         .public_context(|context| {
@@ -368,7 +368,7 @@ unconstrained fn get_current_value_in_private_with_non_initial_delay() {
 
 #[test]
 unconstrained fn get_current_value_in_utility_initial() {
-    let mut env = TestEnvironment::_new();
+    let mut env = TestEnvironment::new();
     env.utility_context(|context| {
         let state_var = in_utility(context);
         assert_eq(state_var.get_current_value(), zeroed());
@@ -377,7 +377,7 @@ unconstrained fn get_current_value_in_utility_initial() {
 
 #[test]
 unconstrained fn get_current_value_in_utility_before_scheduled_change() {
-    let mut env = TestEnvironment::_new();
+    let mut env = TestEnvironment::new();
 
     let (_, timestamp_of_change) = env.public_context(|context| {
         let state_var = in_public(context);
@@ -400,7 +400,7 @@ unconstrained fn get_current_value_in_utility_before_scheduled_change() {
 
 #[test]
 unconstrained fn get_current_value_in_utility_at_scheduled_change() {
-    let mut env = TestEnvironment::_new();
+    let mut env = TestEnvironment::new();
 
     let (_, timestamp_of_change) = env.public_context(|context| {
         let state_var = in_public(context);
@@ -423,7 +423,7 @@ unconstrained fn get_current_value_in_utility_at_scheduled_change() {
 
 #[test]
 unconstrained fn get_current_value_in_utility_after_scheduled_change() {
-    let mut env = TestEnvironment::_new();
+    let mut env = TestEnvironment::new();
 
     let (_, timestamp_of_change) = env.public_context(|context| {
         let state_var = in_public(context);

--- a/noir-projects/aztec-nr/aztec/src/state_vars/private_mutable/test.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/private_mutable/test.nr
@@ -12,7 +12,7 @@ unconstrained fn in_private(
 
 #[test(should_fail_with = "Failed to get a note")]
 unconstrained fn get_uninitialized() {
-    let mut env = TestEnvironment::_new();
+    let mut env = TestEnvironment::new();
 
     env.private_context(|context| {
         let state_var = in_private(context);
@@ -22,7 +22,7 @@ unconstrained fn get_uninitialized() {
 
 #[test(should_fail_with = "Failed to get a note")]
 unconstrained fn replace_uninitialized() {
-    let mut env = TestEnvironment::_new();
+    let mut env = TestEnvironment::new();
 
     env.private_context(|context| {
         let state_var = in_private(context);
@@ -34,7 +34,7 @@ unconstrained fn replace_uninitialized() {
 
 #[test]
 unconstrained fn initialize() {
-    let mut env = TestEnvironment::_new();
+    let mut env = TestEnvironment::new();
 
     env.private_context(|context| {
         let state_var = in_private(context);
@@ -55,7 +55,7 @@ unconstrained fn initialize() {
 
 #[test]
 unconstrained fn initialize_and_get_pending() {
-    let mut env = TestEnvironment::_new();
+    let mut env = TestEnvironment::new();
 
     env.private_context(|context| {
         let state_var = in_private(context);
@@ -85,7 +85,7 @@ unconstrained fn initialize_and_get_pending() {
 
 #[test]
 unconstrained fn initialize_and_replace_pending() {
-    let mut env = TestEnvironment::_new();
+    let mut env = TestEnvironment::new();
 
     env.private_context(|context| {
         let state_var = in_private(context);
@@ -117,7 +117,7 @@ unconstrained fn initialize_and_replace_pending() {
 
 #[test]
 unconstrained fn initialize_or_replace_uninitialized() {
-    let mut env = TestEnvironment::_new();
+    let mut env = TestEnvironment::new();
 
     env.private_context(|context| {
         let state_var = in_private(context);
@@ -138,7 +138,7 @@ unconstrained fn initialize_or_replace_uninitialized() {
 
 #[test]
 unconstrained fn initialize_or_replace_initialized_pending() {
-    let mut env = TestEnvironment::_new();
+    let mut env = TestEnvironment::new();
 
     env.private_context(|context| {
         let state_var = in_private(context);

--- a/noir-projects/aztec-nr/aztec/src/state_vars/public_immutable/test.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/public_immutable/test.nr
@@ -21,7 +21,7 @@ fn in_utility(context: UtilityContext) -> PublicImmutable<MockStruct, UtilityCon
 
 #[test]
 unconstrained fn is_uninitialized_by_default() {
-    let mut env = TestEnvironment::_new();
+    let mut env = TestEnvironment::new();
 
     env.public_context(|context| {
         let state_var = in_public(context);
@@ -31,7 +31,7 @@ unconstrained fn is_uninitialized_by_default() {
 
 #[test]
 unconstrained fn initialize_uninitialized_same_tx() {
-    let mut env = TestEnvironment::_new();
+    let mut env = TestEnvironment::new();
 
     env.public_context(|context| {
         let state_var = in_public(context);
@@ -45,7 +45,7 @@ unconstrained fn initialize_uninitialized_same_tx() {
 
 #[test]
 unconstrained fn initialize_uninitialized_other_tx() {
-    let mut env = TestEnvironment::_new();
+    let mut env = TestEnvironment::new();
 
     env.public_context(|context| {
         let state_var = in_public(context);
@@ -62,7 +62,7 @@ unconstrained fn initialize_uninitialized_other_tx() {
 
 #[test(should_fail)]
 unconstrained fn initialize_already_initialized_same_tx() {
-    let mut env = TestEnvironment::_new();
+    let mut env = TestEnvironment::new();
 
     env.public_context(|context| {
         let state_var = in_public(context);
@@ -77,7 +77,7 @@ unconstrained fn initialize_already_initialized_same_tx() {
 
 #[test(should_fail)]
 unconstrained fn initialize_already_initialized_other_tx() {
-    let mut env = TestEnvironment::_new();
+    let mut env = TestEnvironment::new();
 
     env.public_context(|context| {
         let state_var = in_public(context);
@@ -94,7 +94,7 @@ unconstrained fn initialize_already_initialized_other_tx() {
 
 #[test(should_fail_with = "Trying to read from uninitialized PublicImmutable")]
 unconstrained fn read_uninitialized_public_fails() {
-    let mut env = TestEnvironment::_new();
+    let mut env = TestEnvironment::new();
 
     env.public_context(|context| {
         let state_var = in_public(context);
@@ -105,7 +105,7 @@ unconstrained fn read_uninitialized_public_fails() {
 // TODO(#15703): this test should be made to fail
 #[test]
 unconstrained fn read_uninitialized_private_returns_default() {
-    let mut env = TestEnvironment::_new();
+    let mut env = TestEnvironment::new();
 
     env.private_context(|context| {
         let state_var = in_private(context);
@@ -116,7 +116,7 @@ unconstrained fn read_uninitialized_private_returns_default() {
 // TODO(#15703): this test should be made to fail
 #[test]
 unconstrained fn read_uninitialized_utility_returns_default() {
-    let mut env = TestEnvironment::_new();
+    let mut env = TestEnvironment::new();
 
     env.utility_context(|context| {
         let state_var = in_utility(context);
@@ -126,7 +126,7 @@ unconstrained fn read_uninitialized_utility_returns_default() {
 
 #[test]
 unconstrained fn read_initialized_public_same_tx() {
-    let mut env = TestEnvironment::_new();
+    let mut env = TestEnvironment::new();
 
     env.public_context(|context| {
         let state_var = in_public(context);
@@ -139,7 +139,7 @@ unconstrained fn read_initialized_public_same_tx() {
 
 #[test]
 unconstrained fn read_initialized_public_other_tx() {
-    let mut env = TestEnvironment::_new();
+    let mut env = TestEnvironment::new();
     let value = MockStruct::new(5, 6);
 
     env.public_context(|context| {
@@ -155,7 +155,7 @@ unconstrained fn read_initialized_public_other_tx() {
 
 #[test]
 unconstrained fn read_initialized_private() {
-    let mut env = TestEnvironment::_new();
+    let mut env = TestEnvironment::new();
     let value = MockStruct::new(5, 6);
 
     env.public_context(|context| {
@@ -171,7 +171,7 @@ unconstrained fn read_initialized_private() {
 
 #[test]
 unconstrained fn read_initialized_utility() {
-    let mut env = TestEnvironment::_new();
+    let mut env = TestEnvironment::new();
     let value = MockStruct::new(5, 6);
 
     env.public_context(|context| {

--- a/noir-projects/aztec-nr/aztec/src/state_vars/public_mutable/test.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/public_mutable/test.nr
@@ -14,7 +14,7 @@ fn in_utility(context: UtilityContext) -> PublicMutable<MockStruct, UtilityConte
 
 #[test]
 unconstrained fn read_uninitialized_public_returns_zero() {
-    let mut env = TestEnvironment::_new();
+    let mut env = TestEnvironment::new();
 
     env.public_context(|context| {
         let state_var = in_public(context);
@@ -24,7 +24,7 @@ unconstrained fn read_uninitialized_public_returns_zero() {
 
 #[test]
 unconstrained fn read_uninitialized_utility_returns_default() {
-    let mut env = TestEnvironment::_new();
+    let mut env = TestEnvironment::new();
 
     env.utility_context(|context| {
         let state_var = in_utility(context);
@@ -34,7 +34,7 @@ unconstrained fn read_uninitialized_utility_returns_default() {
 
 #[test]
 unconstrained fn write_read_public_same_tx() {
-    let mut env = TestEnvironment::_new();
+    let mut env = TestEnvironment::new();
 
     env.public_context(|context| {
         let state_var = in_public(context);
@@ -47,7 +47,7 @@ unconstrained fn write_read_public_same_tx() {
 
 #[test]
 unconstrained fn write_read_public_other_tx() {
-    let mut env = TestEnvironment::_new();
+    let mut env = TestEnvironment::new();
 
     let value = MockStruct::new(5, 6);
 
@@ -64,7 +64,7 @@ unconstrained fn write_read_public_other_tx() {
 
 #[test]
 unconstrained fn write_read_utility() {
-    let mut env = TestEnvironment::_new();
+    let mut env = TestEnvironment::new();
     let value = MockStruct::new(5, 6);
 
     env.public_context(|context| {

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
@@ -47,10 +47,6 @@ impl PrivateContextOptions {
 
 impl TestEnvironment {
     pub unconstrained fn new() -> Self {
-        Self {}
-    }
-
-    pub unconstrained fn _new() -> Self {
         txe_oracles::enable_context_checks();
         Self {}
     }

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment/test.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment/test.nr
@@ -5,14 +5,14 @@ mod public_context;
 
 #[test(should_fail_with = "cannot be before next timestamp")]
 unconstrained fn set_next_block_timestamp_to_past_fails() {
-    let mut env = TestEnvironment::_new();
+    let mut env = TestEnvironment::new();
 
     env.set_next_block_timestamp(env.last_block_timestamp() - 1);
 }
 
 #[test]
 unconstrained fn set_next_block_timestamp_does_not_mine_a_block() {
-    let mut env = TestEnvironment::_new();
+    let mut env = TestEnvironment::new();
 
     let next_block_number_before = env.next_block_number();
     env.set_next_block_timestamp(env.last_block_timestamp() + 3600);
@@ -23,7 +23,7 @@ unconstrained fn set_next_block_timestamp_does_not_mine_a_block() {
 
 #[test]
 unconstrained fn set_next_block_timestamp_sets_next_manually_mined_block_timestamp() {
-    let mut env = TestEnvironment::_new();
+    let mut env = TestEnvironment::new();
 
     let expected_next_block_timestamp = env.last_block_timestamp() + 3600;
     env.set_next_block_timestamp(expected_next_block_timestamp);
@@ -34,7 +34,7 @@ unconstrained fn set_next_block_timestamp_sets_next_manually_mined_block_timesta
 
 #[test]
 unconstrained fn set_next_block_timestamp_sets_next_public_context_timestamp() {
-    let mut env = TestEnvironment::_new();
+    let mut env = TestEnvironment::new();
 
     let expected_next_block_timestamp = env.last_block_timestamp() + 3600;
     env.set_next_block_timestamp(expected_next_block_timestamp);
@@ -44,7 +44,7 @@ unconstrained fn set_next_block_timestamp_sets_next_public_context_timestamp() {
 
 #[test]
 unconstrained fn set_next_block_timestamp_sets_next_private_context_inclusion_block_timestamp() {
-    let mut env = TestEnvironment::_new();
+    let mut env = TestEnvironment::new();
 
     let last_block_timestamp = env.last_block_timestamp();
     let expected_next_block_timestamp = env.last_block_timestamp() + 3600;
@@ -62,7 +62,7 @@ unconstrained fn set_next_block_timestamp_sets_next_private_context_inclusion_bl
 
 #[test]
 unconstrained fn advance_next_block_timestamp_by_does_not_mine_a_block() {
-    let mut env = TestEnvironment::_new();
+    let mut env = TestEnvironment::new();
 
     let next_block_number_before = env.next_block_number();
     env.advance_next_block_timestamp_by(0);
@@ -73,7 +73,7 @@ unconstrained fn advance_next_block_timestamp_by_does_not_mine_a_block() {
 
 #[test]
 unconstrained fn advance_next_block_timestamp_by_sets_next_manually_mined_block_timestamp() {
-    let mut env = TestEnvironment::_new();
+    let mut env = TestEnvironment::new();
 
     let expected_next_block_timestamp = env.last_block_timestamp() + 3600;
     env.advance_next_block_timestamp_by(3600);
@@ -84,7 +84,7 @@ unconstrained fn advance_next_block_timestamp_by_sets_next_manually_mined_block_
 
 #[test]
 unconstrained fn advance_next_block_timestamp_by_sets_next_public_context_timestamp() {
-    let mut env = TestEnvironment::_new();
+    let mut env = TestEnvironment::new();
 
     let expected_next_block_timestamp = env.last_block_timestamp() + 3600;
     env.advance_next_block_timestamp_by(3600);
@@ -94,7 +94,7 @@ unconstrained fn advance_next_block_timestamp_by_sets_next_public_context_timest
 
 #[test]
 unconstrained fn mine_block_mines_a_block() {
-    let mut env = TestEnvironment::_new();
+    let mut env = TestEnvironment::new();
 
     let next_block_number_before = env.next_block_number();
     env.mine_block();
@@ -105,7 +105,7 @@ unconstrained fn mine_block_mines_a_block() {
 
 #[test]
 unconstrained fn mine_block_does_not_advance_the_timestamp() {
-    let mut env = TestEnvironment::_new();
+    let mut env = TestEnvironment::new();
 
     let previous_block_timestamp = env.last_block_timestamp();
     env.mine_block();
@@ -116,7 +116,7 @@ unconstrained fn mine_block_does_not_advance_the_timestamp() {
 
 #[test]
 unconstrained fn public_context_uses_next_block_number() {
-    let mut env = TestEnvironment::_new();
+    let mut env = TestEnvironment::new();
 
     let pending = env.next_block_number();
 
@@ -125,7 +125,7 @@ unconstrained fn public_context_uses_next_block_number() {
 
 #[test]
 unconstrained fn public_context_advances_block_number() {
-    let mut env = TestEnvironment::_new();
+    let mut env = TestEnvironment::new();
 
     let first_block_number = env.public_context(|context| context.block_number());
     let second_block_number = env.public_context(|context| context.block_number());
@@ -135,7 +135,7 @@ unconstrained fn public_context_advances_block_number() {
 
 #[test]
 unconstrained fn public_context_does_not_advance_the_timestamp() {
-    let mut env = TestEnvironment::_new();
+    let mut env = TestEnvironment::new();
 
     let first_timestamp = env.public_context(|context| context.timestamp());
     let second_timestamp = env.public_context(|context| context.timestamp());
@@ -155,7 +155,7 @@ unconstrained fn public_context_repeats_contract_address() {
 
 #[test]
 unconstrained fn private_context_uses_last_block_number() {
-    let mut env = TestEnvironment::_new();
+    let mut env = TestEnvironment::new();
 
     let last_block_number = env.last_block_number();
 
@@ -166,7 +166,7 @@ unconstrained fn private_context_uses_last_block_number() {
 
 #[test]
 unconstrained fn private_context_advances_block_number() {
-    let mut env = TestEnvironment::_new();
+    let mut env = TestEnvironment::new();
 
     let first_block_number =
         env.private_context(|context| context.get_block_header().global_variables.block_number);
@@ -178,7 +178,7 @@ unconstrained fn private_context_advances_block_number() {
 
 #[test]
 unconstrained fn private_context_does_not_advance_the_timestamp() {
-    let mut env = TestEnvironment::_new();
+    let mut env = TestEnvironment::new();
 
     env.private_context(|_| {});
     let first_timestamp = env.last_block_timestamp();

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment/test/private_context.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment/test/private_context.nr
@@ -3,7 +3,7 @@ use protocol_types::{address::AztecAddress, traits::FromField};
 
 #[test]
 unconstrained fn at_sets_contract_address() {
-    let mut env = TestEnvironment::_new();
+    let mut env = TestEnvironment::new();
     let contract_address = AztecAddress::from_field(17);
 
     env.private_context_at(contract_address, |context| {
@@ -13,7 +13,7 @@ unconstrained fn at_sets_contract_address() {
 
 #[test]
 unconstrained fn opts_sets_contract_address_and_historical_block_number() {
-    let mut env = TestEnvironment::_new();
+    let mut env = TestEnvironment::new();
 
     env.mine_block();
     let historical_block_number = env.last_block_number() - 1;

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment/test/public_context.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment/test/public_context.nr
@@ -12,7 +12,7 @@ global nullifier: Field = 9;
 
 #[test]
 unconstrained fn at_sets_contract_address() {
-    let mut env = TestEnvironment::_new();
+    let mut env = TestEnvironment::new();
     let contract_address = AztecAddress::from_field(17);
 
     env.public_context_at(contract_address, |context| {
@@ -22,7 +22,7 @@ unconstrained fn at_sets_contract_address() {
 
 #[test]
 unconstrained fn default_storage_value() {
-    let mut env = TestEnvironment::_new();
+    let mut env = TestEnvironment::new();
 
     env.public_context(|context| {
         assert_eq(context.storage_read::<MockStruct>(storage_slot), zeroed());
@@ -31,7 +31,7 @@ unconstrained fn default_storage_value() {
 
 #[test]
 unconstrained fn storage_write_in_same_context() {
-    let mut env = TestEnvironment::_new();
+    let mut env = TestEnvironment::new();
 
     env.public_context(|context| {
         context.storage_write(storage_slot, value);
@@ -41,7 +41,7 @@ unconstrained fn storage_write_in_same_context() {
 
 #[test]
 unconstrained fn storage_write_in_future_context() {
-    let mut env = TestEnvironment::_new();
+    let mut env = TestEnvironment::new();
 
     env.public_context(|context| { context.storage_write(storage_slot, value); });
 
@@ -50,7 +50,7 @@ unconstrained fn storage_write_in_future_context() {
 
 #[test]
 unconstrained fn storage_multiple_writes_in_same_context() {
-    let mut env = TestEnvironment::_new();
+    let mut env = TestEnvironment::new();
 
     env.public_context(|context| {
         context.storage_write(storage_slot, value);
@@ -62,7 +62,7 @@ unconstrained fn storage_multiple_writes_in_same_context() {
 
 #[test]
 unconstrained fn storage_multiple_writes_in_future_context() {
-    let mut env = TestEnvironment::_new();
+    let mut env = TestEnvironment::new();
 
     env.public_context(|context| { context.storage_write(storage_slot, value); });
 
@@ -74,7 +74,7 @@ unconstrained fn storage_multiple_writes_in_future_context() {
 
 #[test]
 unconstrained fn read_nonexistent_nullifier() {
-    let mut env = TestEnvironment::_new();
+    let mut env = TestEnvironment::new();
 
     env.public_context(|context| {
         assert(!context.nullifier_exists(nullifier, context.this_address()));
@@ -83,7 +83,7 @@ unconstrained fn read_nonexistent_nullifier() {
 
 #[test]
 unconstrained fn read_public_nullifier_same_context() {
-    let mut env = TestEnvironment::_new();
+    let mut env = TestEnvironment::new();
 
     env.public_context(|context| {
         context.push_nullifier(nullifier);
@@ -93,7 +93,7 @@ unconstrained fn read_public_nullifier_same_context() {
 
 #[test]
 unconstrained fn read_public_nullifier_other_context() {
-    let mut env = TestEnvironment::_new();
+    let mut env = TestEnvironment::new();
 
     env.public_context(|context| { context.push_nullifier(nullifier); });
 
@@ -104,7 +104,7 @@ unconstrained fn read_public_nullifier_other_context() {
 
 #[test]
 unconstrained fn read_private_nullifier() {
-    let mut env = TestEnvironment::_new();
+    let mut env = TestEnvironment::new();
 
     env.private_context(|context| { context.push_nullifier(nullifier); });
 

--- a/noir-projects/noir-contracts/contracts/app/nft_contract/src/test/utils.nr
+++ b/noir-projects/noir-contracts/contracts/app/nft_contract/src/test/utils.nr
@@ -1,8 +1,7 @@
 use crate::NFT;
 use aztec::{
-    oracle::{execution::get_contract_address, notes::set_sender_for_tags},
-    protocol_types::address::AztecAddress,
-    test::helpers::{test_environment::TestEnvironment, txe_oracles},
+    oracle::notes::set_sender_for_tags, protocol_types::address::AztecAddress,
+    test::helpers::test_environment::TestEnvironment,
 };
 
 pub unconstrained fn setup(


### PR DESCRIPTION
This one is not very interesting, I just had to update some callsites that manually called oracles.