### PR TITLE
chore: simplify `uint` logic by removing `witness_status`

### DIFF
--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/uint/arithmetic.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/uint/arithmetic.cpp
@@ -48,7 +48,7 @@ uint<Builder, Native> uint<Builder, Native>::operator+(const uint& other) const
 
     uint<Builder, Native> result(ctx);
     result.witness_index = gate.c;
-    result.witness_status = WitnessStatus::WEAK_NORMALIZED;
+    result.normalize();
 
     return result;
 }
@@ -94,7 +94,7 @@ uint<Builder, Native> uint<Builder, Native>::operator-(const uint& other) const
 
     uint<Builder, Native> result(ctx);
     result.witness_index = gate.c;
-    result.witness_status = WitnessStatus::WEAK_NORMALIZED;
+    result.normalize();
 
     return result;
 }
@@ -139,9 +139,8 @@ uint<Builder, Native> uint<Builder, Native>::operator*(const uint& other) const
     ctx->decompose_into_default_range(gate.d, width);
 
     uint<Builder, Native> result(ctx);
-    result.accumulators = constrain_accumulators(ctx, gate.c);
     result.witness_index = gate.c;
-    result.witness_status = WitnessStatus::OK;
+    result.normalize();
 
     return result;
 }
@@ -248,13 +247,11 @@ std::pair<uint<Builder, Native>, uint<Builder, Native>> uint<Builder, Native>::d
     ctx->decompose_into_default_range(delta_idx, width);
     uint<Builder, Native> quotient(ctx);
     quotient.witness_index = quotient_idx;
-    quotient.accumulators = constrain_accumulators(ctx, quotient.witness_index);
-    quotient.witness_status = WitnessStatus::OK;
+    quotient.normalize();
 
     uint<Builder, Native> remainder(ctx);
     remainder.witness_index = remainder_idx;
-    remainder.accumulators = constrain_accumulators(ctx, remainder.witness_index);
-    remainder.witness_status = WitnessStatus::OK;
+    remainder.normalize();
 
     return std::make_pair(quotient, remainder);
 }

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/uint/uint.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/uint/uint.cpp
@@ -183,15 +183,11 @@ template <typename Builder, typename Native> uint256_t uint<Builder, Native>::ge
     if (!context || is_constant()) {
         return additive_constant;
     }
-    return (uint256_t(context->get_variable(witness_index))) & MASK;
-}
 
-template <typename Builder, typename Native> uint256_t uint<Builder, Native>::get_unbounded_value() const
-{
-    if (!context || is_constant()) {
-        return additive_constant;
-    }
-    return (uint256_t(context->get_variable(witness_index)));
+    const uint256_t witness_value = context->get_variable(witness_index);
+    ASSERT(witness_value.get_msb() < width, "uint::get_value(): witness value exceeds type width");
+
+    return witness_value & MASK;
 }
 
 template <typename Builder, typename Native> bool_t<Builder> uint<Builder, Native>::at(const size_t bit_index) const

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/uint/uint.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/uint/uint.cpp
@@ -84,10 +84,8 @@ uint<Builder, Native>::uint(const byte_array<Builder>& other)
         witness_index = accumulator.witness_index;
     }
 
-    // Constrain the accumulators
-    if (witness_index != IS_CONSTANT) {
-        accumulators = constrain_accumulators(context, witness_index);
-    }
+    // We need to constrain the accumulators, so we normalize here.
+    normalize();
 }
 
 template <typename Builder, typename Native>
@@ -117,10 +115,8 @@ uint<Builder, Native>::uint(Builder* parent_context, const std::vector<bool_t<Bu
         witness_index = accumulator.witness_index;
     }
 
-    // Constrain the accumulators
-    if (witness_index != IS_CONSTANT) {
-        accumulators = constrain_accumulators(context, witness_index);
-    }
+    // We need to constrain the accumulators, so we normalize here.
+    normalize();
 }
 
 template <typename Builder, typename Native>

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/uint/uint.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/uint/uint.hpp
@@ -105,10 +105,7 @@ template <typename Builder, typename Native> class uint {
   protected:
     Builder* context;
 
-    enum WitnessStatus { OK, NOT_NORMALIZED, WEAK_NORMALIZED };
-
     mutable uint256_t additive_constant;
-    mutable WitnessStatus witness_status;
 
     // N.B. Not an accumulator! Contains 6-bit slices of input
     mutable std::vector<uint32_t> accumulators;

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/uint/uint.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/uint/uint.hpp
@@ -100,7 +100,6 @@ template <typename Builder, typename Native> class uint {
     uint256_t get_additive_constant() const { return additive_constant; }
 
     std::vector<uint32_t> get_accumulators() const { return accumulators; }
-    uint256_t get_unbounded_value() const;
 
   protected:
     Builder* context;

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.cpp
@@ -510,18 +510,11 @@ void UltraCircuitBuilder_<ExecutionTrace>::create_balanced_add_gate(const add_qu
     }
     check_selector_length_consistency();
     ++this->num_gates;
-    // Why 3? TODO: return to this
-    // The purpose of this gate is to do enable lazy 32-bit addition.
-    // Consider a + b = c mod 2^32
-    // We want the 4th wire to represent the quotient:
-    // w1 + w2 = w4 * 2^32 + w3
-    // If we allow this overflow 'flag' to range from 0 to 3, instead of 0 to 1,
-    // we can get away with chaining a few addition operations together with basic add gates,
-    // before having to use this gate.
-    // (N.B. a larger value would be better, the value '3' is for Turbo backwards compatibility.
-    // In Turbo this method uses a custom gate,
-    // where we were limited to a 2-bit range check by the degree of the custom gate identity.
-    create_new_range_constraint(in.d, 3);
+
+    // Range constrain the 4-th wire to {0, 1}. Since the inputs being added never exceed (2^x - 1)
+    // during uintx arithmetic, we can safely use a 1-bit range check here. In other words, we do not
+    // allow lazy uintx addition.
+    create_new_range_constraint(in.d, 1);
 }
 /**
  * @brief Create a multiplication gate with q_m * a * b + q_3 * c + q_const = 0


### PR DESCRIPTION
TLDR: `uint` arithmetic operators `+` and `-` had a coding error and as a result, we weren't actually supporting lazy arithmetic over integers. This PR simplifies the `uint` class to now allow any "unbounded" values.

#### The Issue 

In the current `uint` class, we allow "unbounded" values, for example, a `uint32_ct` can contain a value > 32 bits. This was done to allow lazy arithmetic before such values were "normalized". This is because a call to `normalize()` is expensive: it decomposes the value in 12-bit slices and range-constrains each slice. 

In practice though, the addition and subtraction operator actually didn't allow any overflow due to a coding error. 
On adding two $\textsf{uint}x$ values $a$ and $b$ (where $x \in [8, 16, 32, 64]$), we currently do:

https://github.com/AztecProtocol/aztec-packages/blob/5c2c217a2f1b05ae226a16ee19a99079dbba8fec/barretenberg/cpp/src/barretenberg/stdlib/primitives/uint/arithmetic.cpp#L27-L47

Assume $a, b$ are both witnesses, the `create_balanced_add_gate` creates the following constraint:

$$a + b = q \cdot \textcolor{grey}{2^x} + r$$

where the quotient $q$ and remainder $r$ are computed as:

$$q := \frac{(a \textsf{ mod } 2^x) + (b \textsf{ mod } 2^x)}{2^x}, \quad r := \left((a \textsf{ mod } 2^x) + (b \textsf{ mod } 2^x)\right) \textsf{ mod } 2^x.$$

In other words, the quotient and remainder are computed from the "truncated" values of $a$ and $b$ when it should have been from the "unbounded" values. Effectively, this means we are not actually supporting lazy arithmetic (i.e., arithmetic operations expect inputs to be "normalized"). I wrote a test [here](https://github.com/AztecProtocol/aztec-packages/blob/ace0afdb4fb773cfc50af92930ecb94993ab72a5/barretenberg/cpp/src/barretenberg/stdlib/primitives/uint/uint.test.cpp#L243-L271) that fails when, ideally, it should have passed. This confirmed the coding error.

#### Solution(s)

One way to fix this is to actually use `get_unbounded_value()` in place of `get_value()` (on lines 27 and 28 in `operator+` above). But we never really were using the benefits of lazy addition (because of this silly error). So we decided its better to remove functionality related to "unbounded" uint values. 

Thus, we remove the `witness_status` member of the `uint` class as it tracks if a `uint` needs to be "normalized". As a consequence, we now need to "normalize" in every constructor where we weren't constraining the accumulators (i.e., `byte_array` and `std::vector<bool_t>`). Further, in `operator+` and `operator-` we normalize the result. Also, removed the `get_unbounded_value()` as it isn't being used anywhere. 