### PR TITLE
chore: message_propagation.test should use mock gossip network

### DIFF
--- a/yarn-project/p2p/src/client/test/p2p_client.integration_message_propagation.test.ts
+++ b/yarn-project/p2p/src/client/test/p2p_client.integration_message_propagation.test.ts
@@ -29,7 +29,7 @@ import {
 } from '../../test-helpers/make-test-p2p-clients.js';
 import { MockGossipSubNetwork } from '../../test-helpers/mock-pubsub.js';
 
-const TEST_TIMEOUT = 120000;
+const TEST_TIMEOUT = 120_000;
 jest.setTimeout(TEST_TIMEOUT);
 
 describe('p2p client integration message propagation', () => {
@@ -200,7 +200,7 @@ describe('p2p client integration message propagation', () => {
       client3AttestationPromise.promise,
     ];
 
-    const messages = await retryUntil(() => collectIfReady(messagesPromise), 'all gossiped messages received', 10, 1);
+    const messages = await retryUntil(() => collectIfReady(messagesPromise), 'all gossiped messages received', 12, 0.5);
 
     expect(messages).toBeDefined();
     expect(client2HandleGossipedTxSpy).toHaveBeenCalled();
@@ -240,6 +240,7 @@ describe('p2p client integration message propagation', () => {
     async () => {
       // Create a set of nodes, client 1 will send a messages to other peers
       const numberOfNodes = 3;
+      const mockGossipSubNetwork = new MockGossipSubNetwork();
       // We start at rollup version 1
       const testConfig: MakeTestP2PClientOptions = {
         p2pBaseConfig: { ...p2pBaseConfig, rollupVersion: 1, p2pDisableStatusHandshake: true },
@@ -249,13 +250,14 @@ describe('p2p client integration message propagation', () => {
         mockWorldState: worldState,
         alwaysTrueVerifier: true,
         logger,
+        mockGossipSubNetwork,
       };
 
       const clientsAndConfig = await makeAndStartTestP2PClients(numberOfNodes, testConfig);
       const [client1, client2, client3] = clientsAndConfig;
 
       // Give the nodes time to discover each other
-      await retryUntil(async () => (await client1.client.getPeers()).length >= 2, 'peers discovered', 10, 0.5);
+      await retryUntil(async () => (await client1.client.getPeers()).length >= 2, 'peers discovered', 12, 0.5);
       logger.info(`Finished waiting for clients to discover each other`);
 
       // Assert that messages get propagated
@@ -287,7 +289,7 @@ describe('p2p client integration message propagation', () => {
 
       await startTestP2PClients(clients);
       // Give everyone time to connect again
-      await retryUntil(async () => (await client1.client.getPeers()).length >= 2, 'peers rediscovered', 10, 0.5);
+      await retryUntil(async () => (await client1.client.getPeers()).length >= 2, 'peers rediscovered', 12, 0.5);
       logger.info(`Finished waiting for clients to rediscover each other`);
 
       // Client 1 sends a tx a block proposal and an attestation and only client 2 should receive them, client 3 is now on a new version
@@ -346,8 +348,8 @@ describe('p2p client integration message propagation', () => {
               client2AttestationPromise.promise,
             ]),
           'client2 received all messages',
-          20,
-          1,
+          12,
+          0.5,
         );
 
         // We use Promise.any as no messages should be received

--- a/yarn-project/p2p/src/test-helpers/make-test-p2p-clients.ts
+++ b/yarn-project/p2p/src/test-helpers/make-test-p2p-clients.ts
@@ -149,7 +149,7 @@ export async function makeAndStartTestP2PClients(numberOfPeers: number, testConf
     clients.push(client);
   }
 
-  await Promise.all(clients.map(client => client.isReady()));
+  await retryUntil(() => clients.every(c => c.isReady()), 'p2p clients started', 10, 0.5);
   testConfig.logger?.info(`Created and started ${clients.length} P2P clients at ports ${ports.join(',')}`, {
     ports,
     peerEnrs,


### PR DESCRIPTION
This is yet another attempt at deflaking `p2p_client.integration_message_propagation.test.ts`. 

Reading the description of the test `'will propagate messages to peers at the same version'` more closely, I don't see any reason why this particular test, like the other one in the file (`'propagates messages using mocked gossip sub network'`), shouldn't use a mocked gossip sub network. 