### PR TITLE
chore: don't warn on exceeded rate limits

### DIFF
--- a/yarn-project/p2p/src/services/reqresp/reqresp.test.ts
+++ b/yarn-project/p2p/src/services/reqresp/reqresp.test.ts
@@ -124,7 +124,7 @@ describe('ReqResp', () => {
     await startNodes(nodes);
 
     // Spy on the logger to make sure the error message is logged
-    const loggerSpy = jest.spyOn((nodes[1].req as any).logger, 'warn');
+    const loggerSpy = jest.spyOn((nodes[1].req as any).logger, 'verbose');
 
     await sleep(500);
     await connectToPeers(nodes);

--- a/yarn-project/p2p/src/services/reqresp/reqresp.ts
+++ b/yarn-project/p2p/src/services/reqresp/reqresp.ts
@@ -534,7 +534,7 @@ export class ReqResp implements ReqRespInterface {
     }
 
     // Do not punish if we are stopping the service
-    if (e instanceof AbortError) {
+    if (e && (e instanceof AbortError || e.code === 'ABORT_ERR')) {
       this.logger.debug(`Request aborted: ${e.message}`, logTags);
       return undefined;
     }

--- a/yarn-project/p2p/src/services/reqresp/reqresp.ts
+++ b/yarn-project/p2p/src/services/reqresp/reqresp.ts
@@ -653,7 +653,7 @@ export class ReqResp implements ReqRespInterface {
       // Store a reference to from this for the async generator
       const rateLimitStatus = this.rateLimiter.allow(protocol, connection.remotePeer);
       if (rateLimitStatus != RateLimitStatus.Allowed) {
-        this.logger.warn(
+        this.logger.verbose(
           `Rate limit exceeded ${prettyPrintRateLimitStatus(rateLimitStatus)} for ${protocol} from ${
             connection.remotePeer
           }`,
@@ -689,7 +689,11 @@ export class ReqResp implements ReqRespInterface {
         stream,
       );
     } catch (e: any) {
-      this.logger.warn('Reqresp response error: ', e);
+      let level: 'warn' | 'debug' = 'warn';
+      if (e && e instanceof ReqRespStatusError && e.status === ReqRespStatus.RATE_LIMIT_EXCEEDED) {
+        level = 'debug';
+      }
+      this.logger[level](`Reqresp response error: ${String(e)}`, e);
       this.metrics.recordResponseError(protocol);
 
       // If we receive a known error, we use the error status in the response chunk, otherwise we categorize as unknown


### PR DESCRIPTION
Log rate limit errors at the debug (instead of warning) level. This PR is opened aganist master because the case has changed significantly in next.