### PR TITLE
fix: throw when making Fr from negatives

### DIFF
--- a/yarn-project/foundation/src/fields/fields.ts
+++ b/yarn-project/foundation/src/fields/fields.ts
@@ -60,6 +60,8 @@ abstract class BaseField {
       this.asBigInt = BigInt(value);
       if (this.asBigInt >= this.modulus()) {
         throw new Error(`Value 0x${this.asBigInt.toString(16)} is greater or equal to field modulus.`);
+      } else if (this.asBigInt < 0n) {
+        throw new Error(`Value 0x${this.asBigInt.toString(16)} is negative.`);
       }
     } else if (value instanceof BaseField) {
       this.asBuffer = value.asBuffer;


### PR DESCRIPTION
Hopefully we can use this to find out what is trying to make `Fr(-1)`