### PR TITLE
fix: delete tar generated by test-vk-havent-changed script

### DIFF
--- a/barretenberg/cpp/scripts/test_civc_standalone_vks_havent_changed.sh
+++ b/barretenberg/cpp/scripts/test_civc_standalone_vks_havent_changed.sh
@@ -53,7 +53,7 @@ if [[ "${1:-}" == "--update_inputs" ]]; then
 fi
 
 export inputs_tmp_dir=$(mktemp -d)
-trap 'rm -rf "$inputs_tmp_dir"' EXIT SIGINT
+trap 'rm -rf "$inputs_tmp_dir" bb-civc-inputs.tar.gz' EXIT SIGINT
 
 curl -s -f "$pinned_civc_inputs_url" | tar -xzf - -C "$inputs_tmp_dir" &>/dev/null
 


### PR DESCRIPTION
The tar is not supposed to be checked in https://github.com/AztecProtocol/aztec-packages/pull/15953/commits/50a1bd3e24e412bcf1f4a374a2d81519a7331606#r2229436867
