### PR TITLE
chore: Removes hack to delete all txs in failed epoch

### DIFF
--- a/yarn-project/end-to-end/src/e2e_block_building.test.ts
+++ b/yarn-project/end-to-end/src/e2e_block_building.test.ts
@@ -524,9 +524,7 @@ describe('e2e_block_building', () => {
     });
   });
 
-  // Due to #13723, this test is disabled.
-  // TODO: bring back once fixed: #13770
-  describe.skip('reorgs', () => {
+  describe('reorgs', () => {
     let contract: StatefulTestContract;
     let cheatCodes: CheatCodes;
     let ownerAddress: AztecAddress;
@@ -572,8 +570,9 @@ describe('e2e_block_building', () => {
       expect(await contract.methods.summed_values(ownerAddress).simulate()).toEqual(51n);
 
       logger.info('Advancing past the proof submission window');
+
       await cheatCodes.rollup.advanceToEpoch(
-        getProofSubmissionDeadlineEpoch(0n, {
+        getProofSubmissionDeadlineEpoch(2n, {
           proofSubmissionEpochs: 1,
         }),
       );

--- a/yarn-project/p2p/src/client/p2p_client.test.ts
+++ b/yarn-project/p2p/src/client/p2p_client.test.ts
@@ -277,34 +277,6 @@ describe('P2P Client', () => {
   });
 
   describe('Chain prunes', () => {
-    it('deletes transactions mined in pruned blocks', async () => {
-      client = createClient();
-      blockSource.setProvenBlockNumber(0);
-      await client.start();
-
-      // Create two transactions:
-      // 1. A transaction mined in block 95 (which will be pruned)
-      // 2. A transaction mined in block 90 (which will remain)
-      const txMinedInPrunedBlock = await mockTx();
-      const txMinedInKeptBlock = await mockTx();
-
-      // Mock the mined transactions
-      txPool.getMinedTxHashes.mockResolvedValue([
-        [txMinedInPrunedBlock.getTxHash(), 95],
-        [txMinedInKeptBlock.getTxHash(), 90],
-      ]);
-
-      txPool.getAllTxs.mockResolvedValue([txMinedInPrunedBlock, txMinedInKeptBlock]);
-
-      // Prune the chain back to block 90
-      blockSource.removeBlocks(10);
-      await client.sync();
-
-      // Verify only the transaction mined in the pruned block is deleted
-      expect(txPool.deleteTxs).toHaveBeenCalledWith([txMinedInPrunedBlock.getTxHash()]);
-      await client.stop();
-    });
-
     it('moves the tips on a chain reorg', async () => {
       blockSource.setProvenBlockNumber(0);
       await client.start();
@@ -361,9 +333,7 @@ describe('P2P Client', () => {
       await client.stop();
     });
 
-    // NOTE: skipping as we currently delete all mined txs within the epoch when pruning
-    // TODO: bring back once fixed: #13770
-    it.skip('moves mined and valid txs back to the pending set', async () => {
+    it('moves mined and valid txs back to the pending set', async () => {
       client = createClient();
       blockSource.setProvenBlockNumber(0);
       await client.start();

--- a/yarn-project/p2p/src/client/p2p_client.ts
+++ b/yarn-project/p2p/src/client/p2p_client.ts
@@ -778,15 +778,8 @@ export class P2PClient<T extends P2PClientType = P2PClientType.Full>
    * @param latestBlock - The block number the chain was pruned to.
    */
   private async handlePruneL2Blocks(latestBlock: number): Promise<void> {
-    // NOTE: temporary fix for alphanet, deleting ALL txs that were in the epoch from the pool #13723
-    // TODO: undo once fixed: #13770
     const txsToDelete = new Map<string, TxHash>();
     const minedTxs = await this.txPool.getMinedTxHashes();
-    for (const [txHash, blockNumber] of minedTxs) {
-      if (blockNumber > latestBlock) {
-        txsToDelete.set(txHash.toString(), txHash);
-      }
-    }
 
     // Find transactions that reference pruned blocks in their historical header
     for (const tx of await this.txPool.getAllTxs()) {
@@ -811,17 +804,15 @@ export class P2PClient<T extends P2PClientType = P2PClientType.Full>
     // NOTE: we can't move _all_ txs back to pending because the tx pool could keep hold of mined txs for longer
     // (see this.keepProvenTxsFor)
 
-    // NOTE: given current fix for alphanet, the code below is redundant as all these txs will be deleted.
-    // TODO: bring back once fixed: #13770
-    // const txsToMoveToPending: TxHash[] = [];
-    // for (const [txHash, blockNumber] of minedTxs) {
-    //   if (blockNumber > latestBlock) {
-    //     txsToMoveToPending.push(txHash);
-    //   }
-    // }
+    const txsToMoveToPending: TxHash[] = [];
+    for (const [txHash, blockNumber] of minedTxs) {
+      if (blockNumber > latestBlock) {
+        txsToMoveToPending.push(txHash);
+      }
+    }
 
-    // this.log.info(`Moving ${txsToMoveToPending.length} mined txs back to pending`);
-    // await this.txPool.markMinedAsPending(txsToMoveToPending);
+    this.log.info(`Moving ${txsToMoveToPending.length} mined txs back to pending`);
+    await this.txPool.markMinedAsPending(txsToMoveToPending);
 
     await this.synchedLatestBlockNumber.set(latestBlock);
     // no need to update block hashes, as they will be updated as new blocks are added


### PR DESCRIPTION
At the launch of alpha testnet, we put in a temporary hack to delete all txs in a pruned epoch, not just those that were made invalid. This removes the hack.

See #13770 
