### PR TITLE
feat(avm): execution context reverts

### DIFF
--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/concrete_dbs.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/concrete_dbs.cpp
@@ -285,4 +285,9 @@ void MerkleDB::revert_checkpoint()
     }
 }
 
+uint32_t MerkleDB::get_checkpoint_id() const
+{
+    return raw_merkle_db.get_checkpoint_id();
+}
+
 } // namespace bb::avm2::simulation

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/concrete_dbs.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/concrete_dbs.hpp
@@ -63,6 +63,7 @@ class MerkleDB final : public HighLevelMerkleDBInterface {
     void create_checkpoint() override;
     void commit_checkpoint() override;
     void revert_checkpoint() override;
+    uint32_t get_checkpoint_id() const override;
 
     // Constrained.
     FF storage_read(const AztecAddress& contract_address, const FF& slot) const override;

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/context.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/context.hpp
@@ -74,6 +74,8 @@ class ContextInterface {
 
     virtual Gas gas_left() const = 0;
 
+    virtual uint32_t get_checkpoint_id_at_creation() const = 0;
+
     // Events
     virtual ContextEvent serialize_context_event() = 0;
 };
@@ -95,6 +97,7 @@ class BaseContext : public ContextInterface {
                 HighLevelMerkleDBInterface& merkle_db,
                 WrittenPublicDataSlotsTreeCheckInterface& written_public_data_slots_tree)
         : merkle_db(merkle_db)
+        , checkpoint_id_at_creation(merkle_db.get_checkpoint_id())
         , written_public_data_slots_tree(written_public_data_slots_tree)
         , address(address)
         , msg_sender(msg_sender)
@@ -156,11 +159,14 @@ class BaseContext : public ContextInterface {
 
     void set_gas_used(Gas gas_used) override { this->gas_used = gas_used; }
 
+    uint32_t get_checkpoint_id_at_creation() const override { return checkpoint_id_at_creation; }
+
     // Input / Output
     std::vector<FF> get_returndata(uint32_t rd_offset, uint32_t rd_copy_size) override;
 
   protected:
     HighLevelMerkleDBInterface& merkle_db;
+    uint32_t checkpoint_id_at_creation; // DB id when the context was created.
     WrittenPublicDataSlotsTreeCheckInterface& written_public_data_slots_tree;
 
   private:

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/context_provider.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/context_provider.cpp
@@ -14,6 +14,7 @@ std::unique_ptr<ContextInterface> ContextProvider::make_nested_context(AztecAddr
                                                                        bool is_static,
                                                                        Gas gas_limit)
 {
+    merkle_db.create_checkpoint(); // Fork DB just like in TS.
     uint32_t context_id = next_context_id++;
     return std::make_unique<NestedContext>(
         context_id,

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/execution.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/execution.hpp
@@ -175,6 +175,7 @@ class Execution : public ExecutionInterface {
 
     void handle_enter_call(ContextInterface& parent_context, std::unique_ptr<ContextInterface> child_context);
     void handle_exit_call();
+    void handle_exceptional_halt(ContextInterface& context);
 
     // TODO(#13683): This is leaking circuit implementation details. We should have a better way to do this.
     // Setters for inputs and output for gadgets/subtraces. These are used for register allocation.

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/lib/db_interfaces.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/lib/db_interfaces.hpp
@@ -65,6 +65,9 @@ class LowLevelMerkleDBInterface {
     virtual void create_checkpoint() = 0;
     virtual void commit_checkpoint() = 0;
     virtual void revert_checkpoint() = 0;
+    // Returns the id of the current checkpoint.
+    // This is a unique id for the lifetime of the db.
+    virtual uint32_t get_checkpoint_id() const = 0;
 };
 
 // High level access to a merkle db. In general these will be constrained.
@@ -95,6 +98,7 @@ class HighLevelMerkleDBInterface {
     virtual void create_checkpoint() = 0;
     virtual void commit_checkpoint() = 0;
     virtual void revert_checkpoint() = 0;
+    virtual uint32_t get_checkpoint_id() const = 0;
 
     virtual LowLevelMerkleDBInterface& as_unconstrained() const = 0;
 };

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/lib/raw_data_dbs.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/lib/raw_data_dbs.cpp
@@ -604,4 +604,9 @@ AppendLeafResult HintedRawMerkleDB::appendLeafInternal(world_state::MerkleTreeId
     return { .root = tree_info.root, .path = get_sibling_path(tree_id, tree_info.nextAvailableLeafIndex) };
 }
 
+uint32_t HintedRawMerkleDB::get_checkpoint_id() const
+{
+    return checkpoint_stack.top();
+}
+
 } // namespace bb::avm2::simulation

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/lib/raw_data_dbs.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/lib/raw_data_dbs.hpp
@@ -61,6 +61,7 @@ class HintedRawMerkleDB final : public LowLevelMerkleDBInterface {
     void create_checkpoint() override;
     void commit_checkpoint() override;
     void revert_checkpoint() override;
+    uint32_t get_checkpoint_id() const override;
 
   private:
     TreeSnapshots tree_roots;

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/testing/mock_context.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/testing/mock_context.hpp
@@ -65,6 +65,8 @@ class MockContext : public ContextInterface {
 
     MOCK_METHOD(Gas, gas_left, (), (const, override));
 
+    MOCK_METHOD(uint32_t, get_checkpoint_id_at_creation, (), (const, override));
+
     // Event Emitting
     MOCK_METHOD(ContextEvent, serialize_context_event, (), (override));
 };

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/testing/mock_dbs.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/testing/mock_dbs.hpp
@@ -57,6 +57,7 @@ class MockLowLevelMerkleDB : public LowLevelMerkleDBInterface {
     MOCK_METHOD(void, create_checkpoint, (), (override));
     MOCK_METHOD(void, commit_checkpoint, (), (override));
     MOCK_METHOD(void, revert_checkpoint, (), (override));
+    MOCK_METHOD(uint32_t, get_checkpoint_id, (), (const, override));
 };
 
 class MockHighLevelMerkleDB : public HighLevelMerkleDBInterface {
@@ -85,6 +86,7 @@ class MockHighLevelMerkleDB : public HighLevelMerkleDBInterface {
     MOCK_METHOD(void, create_checkpoint, (), (override));
     MOCK_METHOD(void, commit_checkpoint, (), (override));
     MOCK_METHOD(void, revert_checkpoint, (), (override));
+    MOCK_METHOD(uint32_t, get_checkpoint_id, (), (const, override));
 
     MOCK_METHOD(LowLevelMerkleDBInterface&, as_unconstrained, (), (const, override));
 };


### PR DESCRIPTION
### TL;DR

Implemented proper database checkpointing for nested contract calls in the VM2 simulation.

I took the easy way out for now and did not introduce an `ExternalCallManager` (we do have an Internal one). We can reconsider later at cleanup stage, but hopefully this is functional.

### What changed?

- Added `get_checkpoint_id()` method to `MerkleDB` and related interfaces to track database state
- Modified `ContextProvider` to create a checkpoint when making a nested context
- Added checkpoint ID tracking in `BaseContext` to ensure proper DB state management
- Refactored exception handling in `Execution` class with a new `handle_exceptional_halt` method
- Implemented proper DB checkpoint commit/revert logic in `handle_exit_call` based on execution success
