### PR TITLE
feat(avm): tx execution context

### DIFF
--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/concrete_dbs.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/concrete_dbs.cpp
@@ -285,4 +285,9 @@ void MerkleDB::revert_checkpoint()
     }
 }
 
+uint32_t MerkleDB::get_checkpoint_id() const
+{
+    return raw_merkle_db.get_checkpoint_id();
+}
+
 } // namespace bb::avm2::simulation

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/concrete_dbs.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/concrete_dbs.hpp
@@ -63,6 +63,7 @@ class MerkleDB final : public HighLevelMerkleDBInterface {
     void create_checkpoint() override;
     void commit_checkpoint() override;
     void revert_checkpoint() override;
+    uint32_t get_checkpoint_id() const override;
 
     // Constrained.
     FF storage_read(const AztecAddress& contract_address, const FF& slot) const override;

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/context.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/context.hpp
@@ -74,6 +74,8 @@ class ContextInterface {
 
     virtual Gas gas_left() const = 0;
 
+    virtual uint32_t get_checkpoint_id_at_creation() const = 0;
+
     // Events
     virtual ContextEvent serialize_context_event() = 0;
 };
@@ -95,6 +97,7 @@ class BaseContext : public ContextInterface {
                 HighLevelMerkleDBInterface& merkle_db,
                 WrittenPublicDataSlotsTreeCheckInterface& written_public_data_slots_tree)
         : merkle_db(merkle_db)
+        , checkpoint_id_at_creation(merkle_db.get_checkpoint_id())
         , written_public_data_slots_tree(written_public_data_slots_tree)
         , address(address)
         , msg_sender(msg_sender)
@@ -156,11 +159,14 @@ class BaseContext : public ContextInterface {
 
     void set_gas_used(Gas gas_used) override { this->gas_used = gas_used; }
 
+    uint32_t get_checkpoint_id_at_creation() const override { return checkpoint_id_at_creation; }
+
     // Input / Output
     std::vector<FF> get_returndata(uint32_t rd_offset, uint32_t rd_copy_size) override;
 
   protected:
     HighLevelMerkleDBInterface& merkle_db;
+    uint32_t checkpoint_id_at_creation; // DB id when the context was created.
     WrittenPublicDataSlotsTreeCheckInterface& written_public_data_slots_tree;
 
   private:

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/context_provider.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/context_provider.cpp
@@ -14,6 +14,7 @@ std::unique_ptr<ContextInterface> ContextProvider::make_nested_context(AztecAddr
                                                                        bool is_static,
                                                                        Gas gas_limit)
 {
+    merkle_db.create_checkpoint(); // Fork DB just like in TS.
     uint32_t context_id = next_context_id++;
     return std::make_unique<NestedContext>(
         context_id,

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/events/tx_context_event.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/events/tx_context_event.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "barretenberg/vm2/common/aztec_types.hpp"
+
+namespace bb::avm2::simulation {
+
+struct TxContextEvent {
+    // Gas
+    Gas gas_used;
+    Gas gas_limit;
+
+    // Tree State
+    TreeStates tree_states;
+    AppendOnlyTreeSnapshot written_public_data_slots_tree_snapshot;
+};
+
+} // namespace bb::avm2::simulation

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/events/tx_events.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/events/tx_events.hpp
@@ -5,13 +5,12 @@
 
 #include "barretenberg/vm2/common/aztec_types.hpp"
 #include "barretenberg/vm2/common/field.hpp"
+#include "barretenberg/vm2/simulation/events/tx_context_event.hpp"
 
 namespace bb::avm2::simulation {
 
 struct TxStartupEvent {
-    Gas tx_gas_limit;
-    Gas private_gas_used;
-    TreeStates tree_state;
+    TxContextEvent state;
 };
 
 struct EnqueuedCallEvent {
@@ -20,8 +19,6 @@ struct EnqueuedCallEvent {
     FF transaction_fee;
     bool is_static;
     FF calldata_hash;
-    Gas prev_gas_used;
-    Gas gas_used;
     Gas gas_limit;
     bool success;
 };
@@ -49,12 +46,9 @@ using TxPhaseEventType =
 
 struct TxPhaseEvent {
     TransactionPhase phase;
-    TreeStates prev_tree_state;
-    TreeStates next_tree_state;
-    // TODO: Add written public data slots tree snapshot, ideally via a TxContextEvent
-
+    TxContextEvent state_before;
+    TxContextEvent state_after;
     bool reverted;
-
     TxPhaseEventType event;
 };
 

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/execution.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/execution.hpp
@@ -175,6 +175,7 @@ class Execution : public ExecutionInterface {
 
     void handle_enter_call(ContextInterface& parent_context, std::unique_ptr<ContextInterface> child_context);
     void handle_exit_call();
+    void handle_exceptional_halt(ContextInterface& context);
 
     // TODO(#13683): This is leaking circuit implementation details. We should have a better way to do this.
     // Setters for inputs and output for gadgets/subtraces. These are used for register allocation.

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/lib/db_interfaces.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/lib/db_interfaces.hpp
@@ -65,6 +65,9 @@ class LowLevelMerkleDBInterface {
     virtual void create_checkpoint() = 0;
     virtual void commit_checkpoint() = 0;
     virtual void revert_checkpoint() = 0;
+    // Returns the id of the current checkpoint.
+    // This is a unique id for the lifetime of the db.
+    virtual uint32_t get_checkpoint_id() const = 0;
 };
 
 // High level access to a merkle db. In general these will be constrained.
@@ -95,6 +98,7 @@ class HighLevelMerkleDBInterface {
     virtual void create_checkpoint() = 0;
     virtual void commit_checkpoint() = 0;
     virtual void revert_checkpoint() = 0;
+    virtual uint32_t get_checkpoint_id() const = 0;
 
     virtual LowLevelMerkleDBInterface& as_unconstrained() const = 0;
 };

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/lib/raw_data_dbs.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/lib/raw_data_dbs.cpp
@@ -604,4 +604,9 @@ AppendLeafResult HintedRawMerkleDB::appendLeafInternal(world_state::MerkleTreeId
     return { .root = tree_info.root, .path = get_sibling_path(tree_id, tree_info.nextAvailableLeafIndex) };
 }
 
+uint32_t HintedRawMerkleDB::get_checkpoint_id() const
+{
+    return checkpoint_stack.top();
+}
+
 } // namespace bb::avm2::simulation

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/lib/raw_data_dbs.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/lib/raw_data_dbs.hpp
@@ -61,6 +61,7 @@ class HintedRawMerkleDB final : public LowLevelMerkleDBInterface {
     void create_checkpoint() override;
     void commit_checkpoint() override;
     void revert_checkpoint() override;
+    uint32_t get_checkpoint_id() const override;
 
   private:
     TreeSnapshots tree_roots;

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/testing/mock_context.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/testing/mock_context.hpp
@@ -65,6 +65,8 @@ class MockContext : public ContextInterface {
 
     MOCK_METHOD(Gas, gas_left, (), (const, override));
 
+    MOCK_METHOD(uint32_t, get_checkpoint_id_at_creation, (), (const, override));
+
     // Event Emitting
     MOCK_METHOD(ContextEvent, serialize_context_event, (), (override));
 };

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/testing/mock_dbs.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/testing/mock_dbs.hpp
@@ -57,6 +57,7 @@ class MockLowLevelMerkleDB : public LowLevelMerkleDBInterface {
     MOCK_METHOD(void, create_checkpoint, (), (override));
     MOCK_METHOD(void, commit_checkpoint, (), (override));
     MOCK_METHOD(void, revert_checkpoint, (), (override));
+    MOCK_METHOD(uint32_t, get_checkpoint_id, (), (const, override));
 };
 
 class MockHighLevelMerkleDB : public HighLevelMerkleDBInterface {
@@ -85,6 +86,7 @@ class MockHighLevelMerkleDB : public HighLevelMerkleDBInterface {
     MOCK_METHOD(void, create_checkpoint, (), (override));
     MOCK_METHOD(void, commit_checkpoint, (), (override));
     MOCK_METHOD(void, revert_checkpoint, (), (override));
+    MOCK_METHOD(uint32_t, get_checkpoint_id, (), (const, override));
 
     MOCK_METHOD(LowLevelMerkleDBInterface&, as_unconstrained, (), (const, override));
 };

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/tx_context.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/tx_context.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "barretenberg/vm2/common/aztec_types.hpp"
+#include "barretenberg/vm2/simulation/events/tx_context_event.hpp"
+#include "barretenberg/vm2/simulation/lib/db_interfaces.hpp"
+#include "barretenberg/vm2/simulation/written_public_data_slots_tree_check.hpp"
+
+namespace bb::avm2::simulation {
+
+struct TxContext {
+    HighLevelMerkleDBInterface& merkle_db;
+    WrittenPublicDataSlotsTreeCheckInterface& written_public_data_slots_tree;
+    Gas gas_used = { 0, 0 };
+
+    TxContextEvent serialize_tx_context_event() const
+    {
+        return {
+            .gas_used = gas_used,
+            .tree_states = merkle_db.get_tree_state(),
+            .written_public_data_slots_tree_snapshot = written_public_data_slots_tree.snapshot(),
+        };
+    }
+};
+
+} // namespace bb::avm2::simulation

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/tx_execution.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/tx_execution.cpp
@@ -7,31 +7,31 @@
 #include "barretenberg/vm2/common/aztec_constants.hpp"
 #include "barretenberg/vm2/common/aztec_types.hpp"
 #include "barretenberg/vm2/simulation/context.hpp"
+#include "barretenberg/vm2/simulation/events/tx_context_event.hpp"
 #include "barretenberg/vm2/simulation/events/tx_events.hpp"
+#include "barretenberg/vm2/simulation/tx_context.hpp"
 
 namespace bb::avm2::simulation {
 
 void TxExecution::emit_public_call_request(const PublicCallRequestWithCalldata& call,
                                            TransactionPhase phase,
                                            const FF& transaction_fee,
-                                           const ExecutionResult& result,
-                                           TreeStates&& prev_tree_state,
-                                           Gas prev_gas,
-                                           Gas gas_limit)
+                                           bool success,
+                                           const Gas& gas_limit,
+                                           const TxContextEvent& state_before,
+                                           const TxContextEvent& state_after)
 {
     events.emit(TxPhaseEvent{ .phase = phase,
-                              .prev_tree_state = std::move(prev_tree_state),
-                              .next_tree_state = merkle_db.get_tree_state(),
+                              .state_before = state_before,
+                              .state_after = state_after,
                               .event = EnqueuedCallEvent{
                                   .msg_sender = call.request.msgSender,
                                   .contract_address = call.request.contractAddress,
                                   .transaction_fee = transaction_fee,
                                   .is_static = call.request.isStaticCall,
                                   .calldata_hash = call.request.calldataHash,
-                                  .prev_gas_used = prev_gas,
-                                  .gas_used = result.gas_used,
                                   .gas_limit = gas_limit,
-                                  .success = result.success,
+                                  .success = success,
                               } });
 }
 
@@ -45,12 +45,10 @@ void TxExecution::emit_public_call_request(const PublicCallRequestWithCalldata& 
 void TxExecution::simulate(const Tx& tx)
 {
     Gas gas_limit = tx.gasSettings.gasLimits;
-    Gas gas_used = tx.gasUsedByPrivate;
+    tx_context.gas_used = tx.gasUsedByPrivate;
 
     events.emit(TxStartupEvent{
-        .tx_gas_limit = gas_limit,
-        .private_gas_used = gas_used,
-        .tree_state = merkle_db.get_tree_state(),
+        .state = tx_context.serialize_tx_context_event(),
     });
 
     info("Simulating tx ",
@@ -68,23 +66,24 @@ void TxExecution::simulate(const Tx& tx)
     // Setup.
     for (const auto& call : tx.setupEnqueuedCalls) {
         info("[SETUP] Executing enqueued call to ", call.request.contractAddress);
-        TreeStates prev_tree_state = merkle_db.get_tree_state();
+        TxContextEvent state_before = tx_context.serialize_tx_context_event();
         auto context = context_provider.make_enqueued_context(call.request.contractAddress,
                                                               call.request.msgSender,
                                                               /*transaction_fee=*/FF(0),
                                                               call.calldata,
                                                               call.request.isStaticCall,
                                                               gas_limit,
-                                                              gas_used);
+                                                              tx_context.gas_used);
         ExecutionResult result = call_execution.execute(std::move(context));
+        tx_context.gas_used = result.gas_used;
         emit_public_call_request(call,
                                  TransactionPhase::SETUP,
                                  /*transaction_fee=*/FF(0),
-                                 result,
-                                 std::move(prev_tree_state),
-                                 gas_used,
-                                 gas_limit);
-        gas_used = result.gas_used;
+                                 result.success,
+                                 gas_limit,
+                                 state_before,
+                                 tx_context.serialize_tx_context_event());
+        tx_context.gas_used = result.gas_used;
     }
 
     // The checkpoint we should go back to if anything from now on reverts.
@@ -97,24 +96,23 @@ void TxExecution::simulate(const Tx& tx)
         // App logic.
         for (const auto& call : tx.appLogicEnqueuedCalls) {
             info("[APP_LOGIC] Executing enqueued call to ", call.request.contractAddress);
-            TreeStates prev_tree_state = merkle_db.get_tree_state();
+            TxContextEvent state_before = tx_context.serialize_tx_context_event();
             auto context = context_provider.make_enqueued_context(call.request.contractAddress,
                                                                   call.request.msgSender,
                                                                   /*transaction_fee=*/FF(0),
                                                                   call.calldata,
                                                                   call.request.isStaticCall,
                                                                   gas_limit,
-                                                                  gas_used);
+                                                                  tx_context.gas_used);
             ExecutionResult result = call_execution.execute(std::move(context));
+            tx_context.gas_used = result.gas_used;
             emit_public_call_request(call,
                                      TransactionPhase::APP_LOGIC,
                                      /*transaction_fee=*/FF(0),
-                                     result,
-                                     std::move(prev_tree_state),
-                                     gas_used,
-                                     gas_limit);
-            gas_used = result.gas_used;
-
+                                     result.success,
+                                     gas_limit,
+                                     state_before,
+                                     tx_context.serialize_tx_context_event());
             if (!result.success) {
                 throw std::runtime_error(
                     format("[APP_LOGIC] Enqueued call to ", call.request.contractAddress, " failed"));
@@ -135,29 +133,33 @@ void TxExecution::simulate(const Tx& tx)
     // Compute the transaction fee here so it can be passed to teardown
     uint128_t fee_per_da_gas = tx.effectiveGasFees.feePerDaGas;
     uint128_t fee_per_l2_gas = tx.effectiveGasFees.feePerL2Gas;
-    FF fee = FF(fee_per_da_gas) * FF(gas_used.daGas) + FF(fee_per_l2_gas) * FF(gas_used.l2Gas);
+    FF fee = FF(fee_per_da_gas) * FF(tx_context.gas_used.daGas) + FF(fee_per_l2_gas) * FF(tx_context.gas_used.l2Gas);
 
     // Teardown.
     try {
         if (tx.teardownEnqueuedCall) {
             info("[TEARDOWN] Executing enqueued call to ", tx.teardownEnqueuedCall->request.contractAddress);
-            TreeStates prev_tree_state = merkle_db.get_tree_state();
+            // Reset gas for teardown since it is tracked separately.
+            tx_context.gas_used = { 0, 0 };
+            TxContextEvent state_before = tx_context.serialize_tx_context_event();
             auto context = context_provider.make_enqueued_context(tx.teardownEnqueuedCall->request.contractAddress,
                                                                   tx.teardownEnqueuedCall->request.msgSender,
                                                                   fee,
                                                                   tx.teardownEnqueuedCall->calldata,
                                                                   tx.teardownEnqueuedCall->request.isStaticCall,
+                                                                  // Teardown has its own gas limit and usage.
                                                                   tx.gasSettings.teardownGasLimits,
                                                                   Gas{ 0, 0 });
             ExecutionResult result = call_execution.execute(std::move(context));
             // Check what to do here for GAS
             emit_public_call_request(*tx.teardownEnqueuedCall,
+                                     // TODO(dbanks12): This should be TEARDOWN.
                                      TransactionPhase::APP_LOGIC,
                                      fee,
-                                     result,
-                                     std::move(prev_tree_state),
-                                     Gas{ 0, 0 }, // Reset for teardown since it is tracked separately
-                                     tx.gasSettings.teardownGasLimits);
+                                     result.success,
+                                     tx.gasSettings.teardownGasLimits,
+                                     state_before,
+                                     tx_context.serialize_tx_context_event());
             if (!result.success) {
                 throw std::runtime_error(format(
                     "[TEARDOWN] Enqueued call to ", tx.teardownEnqueuedCall->request.contractAddress, " failed"));
@@ -175,9 +177,115 @@ void TxExecution::simulate(const Tx& tx)
     }
 
     // Fee payment
-    TreeStates prev_tree_state = merkle_db.get_tree_state();
+    pay_fee(tx.feePayer, fee, fee_per_da_gas, fee_per_l2_gas);
+}
 
-    FF fee_payer = tx.feePayer;
+// TODO: How to increment the context id here?
+// This function inserts the non-revertible accumulated data into the Merkle DB.
+// It might error if the limits for number of allowable inserts are exceeded, but this result in an unprovable tx
+void TxExecution::insert_non_revertibles(const Tx& tx)
+{
+    info("[NON_REVERTIBLE] Inserting ",
+         tx.nonRevertibleAccumulatedData.nullifiers.size(),
+         " nullifiers, ",
+         tx.nonRevertibleAccumulatedData.noteHashes.size(),
+         " note hashes, and ",
+         tx.nonRevertibleAccumulatedData.l2ToL1Messages.size(),
+         " L2 to L1 messages for tx ",
+         tx.hash);
+
+    TxContextEvent state_before = tx_context.serialize_tx_context_event();
+    // 1. Write the already siloed nullifiers.
+    for (const auto& nullifier : tx.nonRevertibleAccumulatedData.nullifiers) {
+        // TODO: handle the error case
+        merkle_db.siloed_nullifier_write(nullifier);
+        TxContextEvent state_after = tx_context.serialize_tx_context_event();
+        events.emit(TxPhaseEvent{ .phase = TransactionPhase::NR_NULLIFIER_INSERTION,
+                                  .state_before = state_before,
+                                  .state_after = state_after,
+                                  .event = PrivateAppendTreeEvent{ .leaf_value = nullifier } });
+        state_before = state_after;
+    }
+
+    // 2. Write already unique note hashes.
+    for (const auto& unique_note_hash : tx.nonRevertibleAccumulatedData.noteHashes) {
+        merkle_db.unique_note_hash_write(unique_note_hash);
+        TxContextEvent state_after = tx_context.serialize_tx_context_event();
+        events.emit(TxPhaseEvent{ .phase = TransactionPhase::NR_NOTE_INSERTION,
+                                  .state_before = state_before,
+                                  .state_after = state_after,
+                                  .event = PrivateAppendTreeEvent{ .leaf_value = unique_note_hash } });
+        state_before = state_after;
+    }
+
+    // 3. Write l2_l1 messages
+    for (const auto& l2_to_l1_msg : tx.nonRevertibleAccumulatedData.l2ToL1Messages) {
+        // Tree state does not change when writing L2 to L1 messages.
+        TxContextEvent state_after = tx_context.serialize_tx_context_event();
+        events.emit(TxPhaseEvent{ .phase = TransactionPhase::NR_L2_TO_L1_MESSAGE,
+                                  .state_before = state_before,
+                                  .state_after = state_after,
+                                  .event = PrivateEmitL2L1MessageEvent{ .scoped_msg = l2_to_l1_msg } });
+        state_before = state_after;
+    }
+}
+
+// TODO: Error Handling
+void TxExecution::insert_revertibles(const Tx& tx)
+{
+    info("[REVERTIBLE] Inserting ",
+         tx.revertibleAccumulatedData.nullifiers.size(),
+         " nullifiers, ",
+         tx.revertibleAccumulatedData.noteHashes.size(),
+         " note hashes, and ",
+         tx.revertibleAccumulatedData.l2ToL1Messages.size(),
+         " L2 to L1 messages for tx ",
+         tx.hash);
+
+    TxContextEvent state_before = tx_context.serialize_tx_context_event();
+    // 1. Write the already siloed nullifiers.
+    for (const auto& siloed_nullifier : tx.revertibleAccumulatedData.nullifiers) {
+        // TODO: handle the error case
+        merkle_db.siloed_nullifier_write(siloed_nullifier);
+
+        TxContextEvent state_after = tx_context.serialize_tx_context_event();
+        events.emit(TxPhaseEvent{ .phase = TransactionPhase::R_NULLIFIER_INSERTION,
+                                  .state_before = state_before,
+                                  .state_after = state_after,
+                                  .event = PrivateAppendTreeEvent{ .leaf_value = siloed_nullifier } });
+        state_before = state_after;
+    }
+
+    // 2. Write the siloed non uniqued note hashes
+    for (const auto& siloed_note_hash : tx.revertibleAccumulatedData.noteHashes) {
+        merkle_db.siloed_note_hash_write(siloed_note_hash);
+
+        TxContextEvent state_after = tx_context.serialize_tx_context_event();
+        events.emit(TxPhaseEvent{ .phase = TransactionPhase::R_NOTE_INSERTION,
+                                  .state_before = state_before,
+                                  .state_after = state_after,
+                                  .event = PrivateAppendTreeEvent{ .leaf_value = siloed_note_hash } });
+        state_before = state_after;
+    }
+
+    // 3. Write L2 to L1 messages.
+    for (const auto& l2_to_l1_msg : tx.revertibleAccumulatedData.l2ToL1Messages) {
+        // Tree state does not change when writing L2 to L1 messages.
+        TxContextEvent state_after = tx_context.serialize_tx_context_event();
+        events.emit(TxPhaseEvent{ .phase = TransactionPhase::R_L2_TO_L1_MESSAGE,
+                                  .state_before = state_before,
+                                  .state_after = state_after,
+                                  .event = PrivateEmitL2L1MessageEvent{ .scoped_msg = l2_to_l1_msg } });
+        state_before = state_after;
+    }
+}
+
+void TxExecution::pay_fee(const FF& fee_payer,
+                          const FF& fee,
+                          const uint128_t& fee_per_da_gas,
+                          const uint128_t& fee_per_l2_gas)
+{
+    TxContextEvent state_before = tx_context.serialize_tx_context_event();
 
     FF fee_juice_balance_slot = poseidon2.hash({ FEE_JUICE_BALANCES_SLOT, fee_payer });
 
@@ -194,8 +302,8 @@ void TxExecution::simulate(const Tx& tx)
     // merkle_db.storage_write(FEE_JUICE_ADDRESS, fee_juice_balance_slot, fee_payer_balance - fee, true);
 
     events.emit(TxPhaseEvent{ .phase = TransactionPhase::COLLECT_GAS_FEES,
-                              .prev_tree_state = prev_tree_state,
-                              .next_tree_state = merkle_db.get_tree_state(),
+                              .state_before = state_before,
+                              .state_after = tx_context.serialize_tx_context_event(),
                               .event = CollectGasFeeEvent{
                                   .effective_fee_per_da_gas = fee_per_da_gas,
                                   .effective_fee_per_l2_gas = fee_per_l2_gas,
@@ -204,104 +312,6 @@ void TxExecution::simulate(const Tx& tx)
                                   .fee_juice_balance_slot = fee_juice_balance_slot,
                                   .fee = fee,
                               } });
-}
-
-// TODO: How to increment the context id here?
-// This function inserts the non-revertible accumulated data into the Merkle DB.
-// It might error if the limits for number of allowable inserts are exceeded, but this result in an unprovable tx
-void TxExecution::insert_non_revertibles(const Tx& tx)
-{
-    info("[NON_REVERTIBLE] Inserting ",
-         tx.nonRevertibleAccumulatedData.nullifiers.size(),
-         " nullifiers, ",
-         tx.nonRevertibleAccumulatedData.noteHashes.size(),
-         " note hashes, and ",
-         tx.nonRevertibleAccumulatedData.l2ToL1Messages.size(),
-         " L2 to L1 messages for tx ",
-         tx.hash);
-    auto prev_tree_state = merkle_db.get_tree_state();
-    // 1. Write the already siloed nullifiers.
-    for (const auto& nullifier : tx.nonRevertibleAccumulatedData.nullifiers) {
-        // TODO: handle the error case
-        merkle_db.siloed_nullifier_write(nullifier);
-
-        auto next_tree_state = merkle_db.get_tree_state();
-        events.emit(TxPhaseEvent{ .phase = TransactionPhase::NR_NULLIFIER_INSERTION,
-                                  .prev_tree_state = prev_tree_state,
-                                  .next_tree_state = next_tree_state,
-                                  .event = PrivateAppendTreeEvent{ .leaf_value = nullifier } });
-        prev_tree_state = next_tree_state;
-    }
-
-    // 2. Write already unique note hashes.
-    for (const auto& unique_note_hash : tx.nonRevertibleAccumulatedData.noteHashes) {
-        merkle_db.unique_note_hash_write(unique_note_hash);
-
-        auto next_tree_state = merkle_db.get_tree_state();
-        events.emit(TxPhaseEvent{ .phase = TransactionPhase::NR_NOTE_INSERTION,
-                                  .prev_tree_state = prev_tree_state,
-                                  .next_tree_state = next_tree_state,
-                                  .event = PrivateAppendTreeEvent{ .leaf_value = unique_note_hash } });
-        prev_tree_state = next_tree_state;
-    }
-
-    // 3. Write l2_l1 messages
-    for (const auto& l2_to_l1_msg : tx.nonRevertibleAccumulatedData.l2ToL1Messages) {
-        // Tree state does not change when writing L2 to L1 messages.
-        auto tree_state = merkle_db.get_tree_state();
-        events.emit(TxPhaseEvent{ .phase = TransactionPhase::NR_L2_TO_L1_MESSAGE,
-                                  .prev_tree_state = tree_state,
-                                  .next_tree_state = tree_state,
-                                  .event = PrivateEmitL2L1MessageEvent{ .scoped_msg = l2_to_l1_msg } });
-    }
-}
-
-// TODO: Error Handling
-void TxExecution::insert_revertibles(const Tx& tx)
-{
-    info("[REVERTIBLE] Inserting ",
-         tx.revertibleAccumulatedData.nullifiers.size(),
-         " nullifiers, ",
-         tx.revertibleAccumulatedData.noteHashes.size(),
-         " note hashes, and ",
-         tx.revertibleAccumulatedData.l2ToL1Messages.size(),
-         " L2 to L1 messages for tx ",
-         tx.hash);
-    auto prev_tree_state = merkle_db.get_tree_state();
-    // 1. Write the already siloed nullifiers.
-    for (const auto& siloed_nullifier : tx.revertibleAccumulatedData.nullifiers) {
-        // TODO: handle the error case
-        merkle_db.siloed_nullifier_write(siloed_nullifier);
-
-        auto next_tree_state = merkle_db.get_tree_state();
-        events.emit(TxPhaseEvent{ .phase = TransactionPhase::R_NULLIFIER_INSERTION,
-                                  .prev_tree_state = prev_tree_state,
-                                  .next_tree_state = next_tree_state,
-                                  .event = PrivateAppendTreeEvent{ .leaf_value = siloed_nullifier } });
-        prev_tree_state = next_tree_state;
-    }
-
-    // 2. Write the siloed non uniqued note hashes
-    for (const auto& siloed_note_hash : tx.revertibleAccumulatedData.noteHashes) {
-        merkle_db.siloed_note_hash_write(siloed_note_hash);
-
-        auto next_tree_state = merkle_db.get_tree_state();
-        events.emit(TxPhaseEvent{ .phase = TransactionPhase::R_NOTE_INSERTION,
-                                  .prev_tree_state = prev_tree_state,
-                                  .next_tree_state = next_tree_state,
-                                  .event = PrivateAppendTreeEvent{ .leaf_value = siloed_note_hash } });
-        prev_tree_state = next_tree_state;
-    }
-
-    // 3. Write L2 to L1 messages.
-    for (const auto& l2_to_l1_msg : tx.revertibleAccumulatedData.l2ToL1Messages) {
-        // Tree state does not change when writing L2 to L1 messages.
-        auto tree_state = merkle_db.get_tree_state();
-        events.emit(TxPhaseEvent{ .phase = TransactionPhase::R_L2_TO_L1_MESSAGE,
-                                  .prev_tree_state = tree_state,
-                                  .next_tree_state = tree_state,
-                                  .event = PrivateEmitL2L1MessageEvent{ .scoped_msg = l2_to_l1_msg } });
-    }
 }
 
 } // namespace bb::avm2::simulation

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/tx_execution.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/tx_execution.hpp
@@ -9,16 +9,18 @@
 #include "barretenberg/vm2/simulation/execution.hpp"
 #include "barretenberg/vm2/simulation/lib/db_interfaces.hpp"
 #include "barretenberg/vm2/simulation/nullifier_tree_check.hpp"
+#include "barretenberg/vm2/simulation/tx_context.hpp"
+#include "barretenberg/vm2/simulation/written_public_data_slots_tree_check.hpp"
 
 namespace bb::avm2::simulation {
 
 // In charge of executing a transaction.
 class TxExecution final {
   public:
-    // FIXME: mekle db here should only be temporary, we should access via context.
     TxExecution(ExecutionInterface& call_execution,
                 ContextProviderInterface& context_provider,
                 HighLevelMerkleDBInterface& merkle_db,
+                WrittenPublicDataSlotsTreeCheckInterface& written_public_data_slots_tree,
                 FieldGreaterThanInterface& field_gt,
                 Poseidon2Interface& poseidon2,
                 EventEmitterInterface<TxEvent>& event_emitter)
@@ -28,6 +30,7 @@ class TxExecution final {
         , field_gt(field_gt)
         , poseidon2(poseidon2)
         , events(event_emitter)
+        , tx_context(merkle_db, written_public_data_slots_tree)
     {}
 
     void simulate(const Tx& tx);
@@ -35,11 +38,12 @@ class TxExecution final {
   private:
     ExecutionInterface& call_execution;
     ContextProviderInterface& context_provider;
-    // More things need to be lifted into the tx execution??
     HighLevelMerkleDBInterface& merkle_db;
     FieldGreaterThanInterface& field_gt;
     Poseidon2Interface& poseidon2;
     EventEmitterInterface<TxEvent>& events;
+
+    TxContext tx_context;
 
     // This function can throw if there is a nullifier collision.
     void insert_non_revertibles(const Tx& tx);
@@ -48,10 +52,11 @@ class TxExecution final {
     void emit_public_call_request(const PublicCallRequestWithCalldata& call,
                                   TransactionPhase phase,
                                   const FF& transaction_fee,
-                                  const ExecutionResult& result,
-                                  TreeStates&& prev_tree_state,
-                                  Gas prev_gas,
-                                  Gas gas_limit);
+                                  bool success,
+                                  const Gas& gas_limit,
+                                  const TxContextEvent& state_before,
+                                  const TxContextEvent& state_after);
+    void pay_fee(const FF& fee_payer, const FF& fee, const uint128_t& fee_per_da_gas, const uint128_t& fee_per_l2_gas);
 };
 
 } // namespace bb::avm2::simulation

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/tx_execution.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/tx_execution.test.cpp
@@ -6,6 +6,7 @@
 #include "barretenberg/vm2/simulation/testing/mock_field_gt.hpp"
 #include "barretenberg/vm2/simulation/testing/mock_memory.hpp"
 #include "barretenberg/vm2/simulation/testing/mock_poseidon2.hpp"
+#include "barretenberg/vm2/simulation/testing/mock_written_public_data_slots_tree_check.hpp"
 #include "barretenberg/vm2/testing/fixtures.hpp"
 
 #include <gmock/gmock.h>
@@ -27,8 +28,14 @@ class TxExecutionTest : public ::testing::Test {
     NiceMock<MockExecution> execution;
     NiceMock<MockFieldGreaterThan> field_gt;
     NiceMock<MockPoseidon2> poseidon2;
-    TxExecution tx_execution =
-        TxExecution(execution, context_provider, merkle_db, field_gt, poseidon2, tx_event_emitter);
+    NiceMock<MockWrittenPublicDataSlotsTreeCheck> written_public_data_slots_tree_check;
+    TxExecution tx_execution = TxExecution(execution,
+                                           context_provider,
+                                           merkle_db,
+                                           written_public_data_slots_tree_check,
+                                           field_gt,
+                                           poseidon2,
+                                           tx_event_emitter);
 };
 
 TEST_F(TxExecutionTest, simulateTx)

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation_helper.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation_helper.cpp
@@ -211,7 +211,13 @@ template <typename S> EventsContainer AvmSimulationHelper::simulate_with_setting
                         greater_than,
                         get_contract_instance,
                         merkle_db);
-    TxExecution tx_execution(execution, context_provider, merkle_db, field_gt, poseidon2, tx_event_emitter);
+    TxExecution tx_execution(execution,
+                             context_provider,
+                             merkle_db,
+                             written_public_data_slots_tree_check,
+                             field_gt,
+                             poseidon2,
+                             tx_event_emitter);
 
     tx_execution.simulate(hints.tx);
 

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/tx_trace.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/tx_trace.test.cpp
@@ -31,15 +31,16 @@ TEST(TxTraceGenTest, EnqueuedCallEvent)
     auto calldata_hash = FF::random_element();
 
     simulation::TxStartupEvent startup_event = {
-        .tx_gas_limit = { 1000, 2000 },
-        .private_gas_used = { 500, 1000 },
-        .tree_state = {},
+        .state = { .gas_used = { 500, 1000 },
+                   .gas_limit = { 1000, 2000 },
+                   .tree_states = {},
+                   .written_public_data_slots_tree_snapshot = {} },
     };
 
     simulation::TxPhaseEvent tx_event = {
         .phase = TransactionPhase::SETUP,
-        .prev_tree_state = {},
-        .next_tree_state = {},
+        .state_before = {},
+        .state_after = {},
         .reverted = false,
         .event =
             simulation::EnqueuedCallEvent{
@@ -47,9 +48,6 @@ TEST(TxTraceGenTest, EnqueuedCallEvent)
                 .contract_address = contract_address,
                 .is_static = false,
                 .calldata_hash = calldata_hash,
-                .prev_gas_used = {},
-                .gas_used = {},
-                .gas_limit = {},
                 .success = true,
             },
     };
@@ -103,14 +101,15 @@ TEST(TxTraceGenTest, CollectFeeEvent)
     auto fee = effective_fee_per_da_gas * prev_da_gas_used + effective_fee_per_l2_gas * prev_l2_gas_used;
 
     simulation::TxStartupEvent startup_event = {
-        .tx_gas_limit = { 1000, 2000 },
-        .private_gas_used = { 500, 1000 },
-        .tree_state = {},
+        .state = { .gas_used = { 500, 1000 },
+                   .gas_limit = { 1000, 2000 },
+                   .tree_states = {},
+                   .written_public_data_slots_tree_snapshot = {} },
     };
 
     simulation::TxPhaseEvent tx_event = { .phase = TransactionPhase::COLLECT_GAS_FEES,
-                                          .prev_tree_state = {},
-                                          .next_tree_state = {},
+                                          .state_before = {},
+                                          .state_after = {},
                                           .reverted = false,
                                           .event = simulation::CollectGasFeeEvent{
                                               .effective_fee_per_da_gas =


### PR DESCRIPTION
# Introduce TxContext to track transaction state

This PR introduces a `TxContext` structure to track transaction state, including gas usage and tree states. 

Since at the TX level we only need ONE level of checkpointing, I chose to avoid building something that can support multiple levels (like in Execution).

I introduced the "written public data tree" into this context, but I have not wired it up anywhere in PIL or trace generation. TODOs were added. 

I could've gone fancier with the dependency injection, maybe have a tx context provider, but this time I chose simplicity.

I chose to always serialize all of the before and after state, and to include gas there. I don't like that gas has to be manually updated from the result of an enqueued call... but that was already there, I just didn't make it any better.

I'm hoping for functionality here, and not necessarily the best design. We can refactor later, but feel free to leave comments!