### PR TITLE
feat!: improve txe deploy API

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
@@ -10,7 +10,7 @@ use crate::{
     },
     hash::hash_args,
     oracle::{execution::{get_block_number, get_timestamp}, execution_cache},
-    test::helpers::{txe_oracles, utils::Deployer},
+    test::helpers::{txe_oracles, utils::ContractDeployment},
 };
 
 use super::txe_oracles::public_call_new_flow;
@@ -34,13 +34,15 @@ impl Counter {
 }
 
 pub struct TestEnvironment {
-    // The secrets to be used for light and contract account creation. By keeping track of the last used secret we can
-    // issue new ones automatically without requiring the user to provide different ones. Additionally, having the
-    // secrets be deterministic for each set of accounts and all concurrent tests results in TXE being able to maximize
-    // cache usage and not have to recompute account addresses and contract artifacts, which are relatively expensive
-    // operations.
+    // The secrets to be used for light and contract account creation, as well as contract deployments. By keeping track
+    // of the last used secret we can issue new ones automatically without requiring the user to provide different ones.
+    //
+    // Additionally, having the secrets be deterministic for each set of accounts and all concurrent tests results in
+    // TXE being able to maximize cache usage and not have to recompute account addresses and contract artifacts, which
+    // are relatively expensive operations.
     light_account_secret: Counter,
     contract_account_secret: Counter,
+    contract_deployment_secret: Counter,
 }
 
 pub struct CallResult<T> {
@@ -71,12 +73,20 @@ impl PrivateContextOptions {
 
 impl TestEnvironment {
     pub unconstrained fn new() -> Self {
-        Self { light_account_secret: Counter::new(), contract_account_secret: Counter::new() }
+        Self {
+            light_account_secret: Counter::new(),
+            contract_account_secret: Counter::new(),
+            contract_deployment_secret: Counter::new(),
+        }
     }
 
     pub unconstrained fn _new() -> Self {
         txe_oracles::enable_context_checks();
-        Self { light_account_secret: Counter::new(), contract_account_secret: Counter::new() }
+        Self {
+            light_account_secret: Counter::new(),
+            contract_account_secret: Counter::new(),
+            contract_deployment_secret: Counter::new(),
+        }
     }
 
     /// EXPERIMENTAL FEATURE - NOT MEANT FOR EXTERNAL USE
@@ -331,16 +341,54 @@ impl TestEnvironment {
         test_account.address
     }
 
-    pub unconstrained fn deploy<let N: u32, let M: u32>(
-        self: Self,
-        path: str<N>,
-        name: str<M>,
-    ) -> Deployer<N, M> {
-        Deployer { env: self, path, name, secret: 0 }
-    }
-
-    pub unconstrained fn deploy_self<let M: u32>(self: Self, name: str<M>) -> Deployer<0, M> {
-        Deployer { env: self, path: "", name, secret: 0 }
+    /// Prepares a contract for deployment, so that its private, public and utility functions can be called. The
+    /// contract **must be already compiled** before tests are run, and **must be recompiled if changed** for the tests
+    /// to deploy the updated version.
+    ///
+    /// In order to finalize the deployment, the proper initializer function must be specified via one of the associated
+    /// methods. For more information on how to specify the path and initialization, read the sections below.
+    ///
+    /// ### Path
+    /// Contracts can be deployed from either the same crate as the test, from a different crate in the same workspace,
+    /// or from an altogether independent crate.
+    ///
+    /// If deploying contracts from the same crate as the test, just refer to it by its name:
+    /// ```noir
+    /// TestEnvironment::new().deploy("MyContract");
+    /// ```
+    ///
+    /// If deploying contracts from a different crate in the same workspace, use `@crate_name/contract_name`:
+    /// ```noir
+    /// TestEnvironment::new().deploy("@my_contract_crate/MyContract");
+    /// ```
+    ///
+    /// If deploying contracts from a crate not in the workspace, use `path_to_crate/contract_name`, with the crate path
+    /// relative to the current workspace:
+    /// ```noir
+    /// TestEnvironment::new().deploy("../my_other_crate/MyContract");
+    /// ```
+    ///
+    /// ### Initialization
+    /// If no initializer function needs to be called, use `without_initializer`:
+    /// ```noir
+    /// let my_contract = TestEnvironment::new().deploy("MyContract").without_initializer();
+    /// ```
+    ///
+    /// For private initializers, use `with_private_initializer`:
+    /// ```noir
+    /// let my_contract = TestEnvironment::new().deploy("MyContract").with_private_initializer(
+    ///   PrivateInitContract::interface().private_init_fn(init_args)
+    /// );
+    /// ```
+    ///
+    /// For public initializers, use `with_public_initializer`:
+    /// ```noir
+    /// let my_contract = TestEnvironment::new().deploy("MyContract").with_public_initializer(
+    ///   PublicInitContract::interface().public_init_fn(init_args)
+    /// );
+    /// ```
+    pub unconstrained fn deploy<let N: u32>(&mut self, path: str<N>) -> ContractDeployment<N> {
+        ContractDeployment { env: *self, path, secret: self.contract_deployment_secret.next() }
     }
 
     pub unconstrained fn call_private<T, let M: u32>(

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment/test.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment/test.nr
@@ -1,6 +1,7 @@
 use crate::test::helpers::test_environment::TestEnvironment;
 
 mod accounts;
+mod deployment;
 mod private_context;
 mod public_context;
 

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment/test/deployment.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment/test/deployment.nr
@@ -1,0 +1,17 @@
+use crate::test::helpers::test_environment::TestEnvironment;
+
+#[test]
+unconstrained fn deploy_does_not_repeat_addresses() {
+    let mut env = TestEnvironment::new();
+
+    // Ideally we'd not rely so much on relative paths and external crates for this test - the Test contract should
+    // perhaps be moved to the aztec-nr workspace, but we currently have all contracts in the same workspace to simplify
+    // the scripts that build and test them.
+    let first_contract = env.deploy("../noir-contracts/@test_contract/Test").without_initializer();
+    let second_contract = env.deploy("../noir-contracts/@test_contract/Test").without_initializer();
+
+    // Note that Test _does_ have an initializer, we're not invoking it and then testing calling contract functions
+    // because contracts depend on aztec-nr, and so by importing a contract we'd be creating a circular dependency. This
+    // at least does test that the basics of the deployment mechanism work.
+    assert(first_contract != second_contract);
+}

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/txe_oracles.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/txe_oracles.nr
@@ -10,14 +10,13 @@ use protocol_types::{
     utils::reader::Reader,
 };
 
-pub unconstrained fn deploy<let N: u32, let M: u32, let P: u32>(
+pub unconstrained fn deploy<let N: u32, let P: u32>(
     path: str<N>,
-    name: str<M>,
     initializer: str<P>,
     args: [Field],
     secret: Field,
 ) -> ContractInstance {
-    let instance_fields = deploy_oracle(path, name, initializer, args, secret);
+    let instance_fields = deploy_oracle(path, initializer, args, secret);
     ContractInstance::deserialize(instance_fields)
 }
 
@@ -96,9 +95,8 @@ pub unconstrained fn get_private_context_inputs(
 ) -> PrivateContextInputs {}
 
 #[oracle(deploy)]
-pub unconstrained fn deploy_oracle<let N: u32, let M: u32, let P: u32>(
+pub unconstrained fn deploy_oracle<let N: u32, let P: u32>(
     path: str<N>,
-    name: str<M>,
     initializer: str<P>,
     args: [Field],
     secret: Field,

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/utils.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/utils.nr
@@ -4,37 +4,52 @@ use crate::{
 };
 use protocol_types::{
     address::AztecAddress,
-    contract_instance::ContractInstance,
     public_keys::PublicKeys,
     traits::{Deserialize, Serialize},
 };
 use std::meta::derive;
 
-pub struct Deployer<let N: u32, let M: u32> {
+pub struct ContractDeployment<let N: u32> {
     pub env: TestEnvironment,
     pub path: str<N>,
-    pub name: str<M>,
     pub secret: Field,
 }
 
-impl<let N: u32, let M: u32> Deployer<N, M> {
+impl<let N: u32> ContractDeployment<N> {
+    /// Finalizes a contract deployment prepared via `TestEnvironment::deploy` by calling a private initializer function
+    /// from the `from` account.
+    ///
+    /// The `initializer_call` is created by calling the intended private initializer function inside the contract's
+    /// `interface()` with its arguments:
+    /// ```noir
+    /// contract MyContract {
+    ///   #[private]
+    ///   #[initializer]
+    ///   fn init_fn(owner: AztecAddress) { ... }
+    /// }
+    ///
+    /// #[test]
+    /// unconstrained fn test_deployment() {
+    ///   let contract_address = TestEnvironment::new().deploy("MyContract").with_private_initializer(
+    ///     MyContract::interface().init_fn(owner)
+    ///   );
+    /// }
     pub unconstrained fn with_private_initializer<T, let P: u32>(
         self,
         from: AztecAddress,
-        call_interface: PrivateCallInterface<P, T>,
-    ) -> ContractInstance
+        initializer_call: PrivateCallInterface<P, T>,
+    ) -> AztecAddress
     where
         T: Deserialize,
     {
         let instance = txe_oracles::deploy(
             self.path,
-            self.name,
-            call_interface.get_name(),
-            call_interface.get_args(),
+            initializer_call.get_name(),
+            initializer_call.get_args(),
             self.secret,
         );
 
-        // call_interface does not actually have the target_contract value set - it is created with the helper
+        // initializer_call does not actually have the target_contract value set - it is created with the helper
         // `interface` function created by `generate_contract_interface` in the aztec macros - it represents a call to
         // a contract at an unknown address. Now that we've deployed the contract We can crate a new call interface with
         // the address and perform the call.
@@ -43,33 +58,50 @@ impl<let N: u32, let M: u32> Deployer<N, M> {
             from,
             PrivateCallInterface::new(
                 instance.to_address(),
-                call_interface.get_selector(),
-                call_interface.get_name(),
-                call_interface.get_args(),
-                call_interface.get_is_static(),
+                initializer_call.get_selector(),
+                initializer_call.get_name(),
+                initializer_call.get_args(),
+                initializer_call.get_is_static(),
             ),
         );
 
-        instance
+        instance.to_address()
     }
 
+    /// Finalizes a contract deployment prepared via `TestEnvironment::deploy` by calling a public initializer function
+    /// from the `from` account.
+    ///
+    /// The `initializer_call` is created by calling the intended public initializer function inside the contract's
+    /// `interface()` with its arguments:
+    /// ```noir
+    /// contract MyContract {
+    ///   #[public]
+    ///   #[initializer]
+    ///   fn init_fn(owner: AztecAddress) { ... }
+    /// }
+    ///
+    /// #[test]
+    /// unconstrained fn test_deployment() {
+    ///   let contract_address = TestEnvironment::new().deploy("MyContract").with_public_initializer(
+    ///     MyContract::interface().init_fn(owner)
+    ///   );
+    /// }
     pub unconstrained fn with_public_initializer<let P: u32, T>(
         self,
         from: AztecAddress,
-        call_interface: PublicCallInterface<P, T>,
-    ) -> ContractInstance
+        initializer_call: PublicCallInterface<P, T>,
+    ) -> AztecAddress
     where
         T: Deserialize,
     {
         let instance = txe_oracles::deploy(
             self.path,
-            self.name,
-            call_interface.get_name(),
-            call_interface.get_args(),
+            initializer_call.get_name(),
+            initializer_call.get_args(),
             self.secret,
         );
 
-        // call_interface does not actually have the target_contract value set - it is created with the helper
+        // initializer_call does not actually have the target_contract value set - it is created with the helper
         // `interface` function created by `generate_contract_interface` in the aztec macros - it represents a call to
         // a contract at an unknown address. Now that we've deployed the contract We can crate a new call interface with
         // the address and perform the call.
@@ -78,18 +110,23 @@ impl<let N: u32, let M: u32> Deployer<N, M> {
             from,
             PublicCallInterface::new(
                 instance.to_address(),
-                call_interface.get_selector(),
-                call_interface.get_name(),
-                call_interface.get_args(),
-                call_interface.get_is_static(),
+                initializer_call.get_selector(),
+                initializer_call.get_name(),
+                initializer_call.get_args(),
+                initializer_call.get_is_static(),
             ),
         );
 
-        instance
+        instance.to_address()
     }
 
-    pub unconstrained fn without_initializer(self) -> ContractInstance {
-        txe_oracles::deploy(self.path, self.name, "", &[], self.secret)
+    /// Finalizes a contract deployment prepared via `TestEnvironment::deploy` without calling any initializer function.
+    ///
+    /// Note that initializers cannot be manually called once this function returns, since the contract address itself
+    /// contains a commitment to the lack of initialization arguments as per the protocol rules. Initializers can only
+    /// be invoked by using the `with_private_initializer` or `with_public_initializer` functions.
+    pub unconstrained fn without_initializer(self) -> AztecAddress {
+        txe_oracles::deploy(self.path, "", &[], self.secret).to_address()
     }
 }
 

--- a/noir-projects/noir-contracts/contracts/app/auth_contract/src/test.nr
+++ b/noir-projects/noir-contracts/contracts/app/auth_contract/src/test.nr
@@ -13,9 +13,8 @@ unconstrained fn setup() -> (TestEnvironment, AztecAddress, AztecAddress, AztecA
 
     let initializer_call_interface = Auth::interface().constructor(admin);
 
-    let auth_contract =
-        env.deploy_self("Auth").with_public_initializer(admin, initializer_call_interface);
-    let auth_contract_address = auth_contract.to_address();
+    let auth_contract_address =
+        env.deploy("Auth").with_public_initializer(admin, initializer_call_interface);
 
     (env, auth_contract_address, admin, to_authorize, other)
 }

--- a/noir-projects/noir-contracts/contracts/app/easy_private_voting_contract/src/test/utils.nr
+++ b/noir-projects/noir-contracts/contracts/app/easy_private_voting_contract/src/test/utils.nr
@@ -10,11 +10,9 @@ pub unconstrained fn setup() -> (TestEnvironment, AztecAddress, AztecAddress) {
     let admin = env.create_light_account();
 
     let initializer_call_interface = EasyPrivateVoting::interface().constructor(admin);
-    let voting_contract = env.deploy_self("EasyPrivateVoting").with_public_initializer(
-        admin,
-        initializer_call_interface,
-    );
+    let voting_contract_address =
+        env.deploy("EasyPrivateVoting").with_public_initializer(admin, initializer_call_interface);
 
     env.mine_block();
-    (env, voting_contract.to_address(), admin)
+    (env, voting_contract_address, admin)
 }

--- a/noir-projects/noir-contracts/contracts/app/nft_contract/src/test/utils.nr
+++ b/noir-projects/noir-contracts/contracts/app/nft_contract/src/test/utils.nr
@@ -31,9 +31,8 @@ pub unconstrained fn setup(
         "TestNFT000000000000000000000000",
         "TN00000000000000000000000000000",
     );
-    let nft_contract =
-        env.deploy_self("NFT").with_public_initializer(owner, initializer_call_interface);
-    let nft_contract_address = nft_contract.to_address();
+    let nft_contract_address =
+        env.deploy("NFT").with_public_initializer(owner, initializer_call_interface);
 
     (env, nft_contract_address, owner, recipient)
 }

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/test/transfer_to_public.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/test/transfer_to_public.nr
@@ -10,8 +10,6 @@ unconstrained fn transfer_to_public_on_behalf_of_self() {
     let (env, token_contract_address, owner, _, mint_amount) =
         utils::setup_and_mint_to_private(/* with_account_contracts */ false);
 
-    // foo
-
     let transfer_to_public_amount = mint_amount / (10 as u128);
     let _ = env.call_private(
         owner,

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/test/transfer_to_public.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/test/transfer_to_public.nr
@@ -10,6 +10,8 @@ unconstrained fn transfer_to_public_on_behalf_of_self() {
     let (env, token_contract_address, owner, _, mint_amount) =
         utils::setup_and_mint_to_private(/* with_account_contracts */ false);
 
+    // foo
+
     let transfer_to_public_amount = mint_amount / (10 as u128);
     let _ = env.call_private(
         owner,

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/test/utils.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/test/utils.nr
@@ -32,9 +32,8 @@ pub unconstrained fn setup(
         "TT00000000000000000000000000000",
         18,
     );
-    let token_contract =
-        env.deploy_self("Token").with_public_initializer(owner, initializer_call_interface);
-    let token_contract_address = token_contract.to_address();
+    let token_contract_address =
+        env.deploy("Token").with_public_initializer(owner, initializer_call_interface);
     env.mine_block();
     (env, token_contract_address, owner, recipient)
 }

--- a/noir-projects/noir-contracts/contracts/protocol/router_contract/src/test.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/router_contract/src/test.nr
@@ -10,10 +10,9 @@ use aztec::utils::comparison::Comparator;
 
 #[test]
 unconstrained fn check_block_number() {
-    let env = TestEnvironment::new();
+    let mut env = TestEnvironment::new();
 
-    let router_contract = env.deploy_self("Router").without_initializer();
-    let router_contract_address = router_contract.to_address();
+    let router_contract_address = env.deploy("Router").without_initializer();
     let router = Router::at(router_contract_address);
 
     let expected_next_block_number = env.next_block_number();
@@ -25,10 +24,9 @@ unconstrained fn check_block_number() {
 
 #[test(should_fail)] // should_fail_with = "Block number mismatch."
 unconstrained fn check_block_number_fail() {
-    let env = TestEnvironment::new();
+    let mut env = TestEnvironment::new();
 
-    let router_contract = env.deploy_self("Router").without_initializer();
-    let router_contract_address = router_contract.to_address();
+    let router_contract_address = env.deploy("Router").without_initializer();
     let router = Router::at(router_contract_address);
 
     let expected_next_block_number = env.next_block_number();
@@ -40,10 +38,9 @@ unconstrained fn check_block_number_fail() {
 
 #[test]
 unconstrained fn check_timestamp() {
-    let env = TestEnvironment::new();
+    let mut env = TestEnvironment::new();
 
-    let router_contract = env.deploy_self("Router").without_initializer();
-    let router_contract_address = router_contract.to_address();
+    let router_contract_address = env.deploy("Router").without_initializer();
     let router = Router::at(router_contract_address);
 
     let expected_next_block_timestamp = env.last_block_timestamp() + 100;
@@ -56,10 +53,9 @@ unconstrained fn check_timestamp() {
 
 #[test(should_fail)] // should_fail_with = "Timestamp mismatch."
 unconstrained fn check_timestamp_fail() {
-    let env = TestEnvironment::new();
+    let mut env = TestEnvironment::new();
 
-    let router_contract = env.deploy_self("Router").without_initializer();
-    let router_contract_address = router_contract.to_address();
+    let router_contract_address = env.deploy("Router").without_initializer();
     let router = Router::at(router_contract_address);
 
     let expected_next_block_timestamp = env.last_block_timestamp() + 100;

--- a/noir-projects/noir-contracts/contracts/test/counter_contract/src/test.nr
+++ b/noir-projects/noir-contracts/contracts/test/counter_contract/src/test.nr
@@ -16,7 +16,6 @@ pub unconstrained fn setup(initial_value: Field) -> (TestEnvironment, AztecAddre
 
     // Deploy contract and initialize
     let initializer = Counter::interface().initialize(initial_value as u64, owner);
-    let counter_contract = env.deploy_self("Counter").with_private_initializer(owner, initializer);
-    let contract_address = counter_contract.to_address();
+    let contract_address = env.deploy("Counter").with_private_initializer(owner, initializer);
     (env, contract_address, owner)
 }

--- a/noir-projects/noir-contracts/contracts/test/parent_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/parent_contract/src/main.nr
@@ -269,12 +269,10 @@ pub contract Parent {
         let owner = env.create_light_account();
 
         // Deploy parent contract
-        let parent_contract = env.deploy_self("Parent").without_initializer();
-        let parent_contract_address = parent_contract.to_address();
+        let parent_contract_address = env.deploy("Parent").without_initializer();
 
         // Deploy child contract
-        let child_contract = env.deploy("./@child_contract", "Child").without_initializer();
-        let child_contract_address = child_contract.to_address();
+        let child_contract_address = env.deploy("@child_contract/Child").without_initializer();
 
         // The 'from' param is irrelevant in all tests below.
         let from = owner;

--- a/noir-projects/noir-contracts/contracts/test/public_immutable_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/public_immutable_contract/src/main.nr
@@ -34,11 +34,11 @@ mod tests {
 
     unconstrained fn setup() -> (TestEnvironment, AztecAddress) {
         // Setup test environment
-        let env = TestEnvironment::new();
+        let mut env = TestEnvironment::new();
 
         // Deploy contract without initialization
         let contract_address =
-            env.deploy_self("PublicImmutableContract").without_initializer().to_address();
+            env.deploy("PublicImmutableContract").without_initializer().to_address();
 
         (env, contract_address)
     }

--- a/noir-projects/noir-contracts/contracts/test/public_immutable_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/public_immutable_contract/src/main.nr
@@ -37,8 +37,7 @@ mod tests {
         let mut env = TestEnvironment::new();
 
         // Deploy contract without initialization
-        let contract_address =
-            env.deploy("PublicImmutableContract").without_initializer().to_address();
+        let contract_address = env.deploy("PublicImmutableContract").without_initializer();
 
         (env, contract_address)
     }

--- a/noir-projects/noir-contracts/contracts/test/test_contract/src/test/deployment_proofs.nr
+++ b/noir-projects/noir-contracts/contracts/test/test_contract/src/test/deployment_proofs.nr
@@ -27,8 +27,7 @@ pub unconstrained fn setup() -> (TestEnvironment, AztecAddress, AztecAddress) {
 
     // Deploy contract and initialize
     let initializer = Test::interface().initialize();
-    let test_contract = env.deploy_self("Test").with_private_initializer(owner, initializer);
-    let contract_address = test_contract.to_address();
+    let contract_address = env.deploy("Test").with_private_initializer(owner, initializer);
 
     // We sanity check that the initialization block was the last one
     assert_eq(env.last_block_number(), CONTRACT_INITIALIZED_AT);

--- a/noir-projects/noir-contracts/contracts/test/test_contract/src/test/note_delivery.nr
+++ b/noir-projects/noir-contracts/contracts/test/test_contract/src/test/note_delivery.nr
@@ -13,9 +13,8 @@ pub unconstrained fn setup() -> (TestEnvironment, AztecAddress, AztecAddress, Az
     let sender = env.create_light_account();
     let recipient = env.create_light_account();
 
-    let test_contract =
-        env.deploy_self("Test").with_private_initializer(sender, Test::interface().initialize());
-    let contract_address = test_contract.to_address();
+    let contract_address =
+        env.deploy("Test").with_private_initializer(sender, Test::interface().initialize());
 
     (env, contract_address, sender, recipient)
 }


### PR DESCRIPTION
Built on top of https://github.com/AztecProtocol/aztec-packages/pull/16007 as I'm reusing the counters from there.

We can now have multiple deployments of the same contract class since we'll assign them different secrets (we also could've specified a salt, but this also works _and_ it gives us unique secrets, so it seems more convenient). I also merged `deploy` and `deploy_self` by using `path` a bit more to parse the string - we'll need to make this more robust in the future to avoid having TXE crash when it doesn't find the file and instead return a reasonable error, but it works for now. I also changed the return value to be the address, since we never care about the full instance (and we can retrieve it if needed).