### PR TITLE
chore: uint audit part 2

### DIFF
--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/field/field.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/field/field.test.cpp
@@ -1309,7 +1309,10 @@ template <typename Builder> class stdlib_field : public testing::Test {
     static void test_origin_tag_consistency()
     {
         Builder builder = Builder();
-        auto a = field_ct(witness_ct(&builder, bb::fr::random_element()));
+        // Randomly generate a and b (a must ≤ 252 bits)
+        uint256_t a_val =
+            uint256_t(bb::fr::random_element()) & ((uint256_t(1) << grumpkin::MAX_NO_WRAP_INTEGER_BIT_LENGTH) - 1);
+        auto a = field_ct(witness_ct(&builder, a_val));
         auto b = field_ct(witness_ct(&builder, bb::fr::random_element()));
         EXPECT_TRUE(a.get_origin_tag().is_empty());
         EXPECT_TRUE(b.get_origin_tag().is_empty());

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/uint/arithmetic.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/uint/arithmetic.cpp
@@ -1,5 +1,5 @@
 // === AUDIT STATUS ===
-// internal:    { status: not started, auditors: [], date: YYYY-MM-DD }
+// internal:    { status: done, auditors: [suyash], date: 2025-07-23 }
 // external_1:  { status: not started, auditors: [], date: YYYY-MM-DD }
 // external_2:  { status: not started, auditors: [], date: YYYY-MM-DD }
 // =====================

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/uint/arithmetic.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/uint/arithmetic.cpp
@@ -18,6 +18,7 @@ uint<Builder, Native> uint<Builder, Native>::operator+(const uint& other) const
 
     ASSERT(context == other.context || (context != nullptr && other.context == nullptr) ||
            (context == nullptr && other.context != nullptr));
+
     Builder* ctx = (context == nullptr) ? other.context : context;
 
     if (is_constant() && other.is_constant()) {
@@ -25,6 +26,13 @@ uint<Builder, Native> uint<Builder, Native>::operator+(const uint& other) const
     }
 
     // N.B. We assume that additive_constant is nonzero ONLY if value is constant
+    if (!is_constant()) {
+        BB_ASSERT_EQ(additive_constant, 0ULL, "uint::operator+ expected additive_constant to be zero");
+    }
+    if (!other.is_constant()) {
+        BB_ASSERT_EQ(other.additive_constant, 0ULL, "uint::operator+ expected other.additive_constant to be zero");
+    }
+
     const uint256_t lhs = get_value();
     const uint256_t rhs = other.get_value();
     const uint256_t constants = (additive_constant + other.additive_constant) & MASK;
@@ -67,6 +75,13 @@ uint<Builder, Native> uint<Builder, Native>::operator-(const uint& other) const
     }
 
     // N.B. We assume that additive_constant is nonzero ONLY if value is constant
+    if (!is_constant()) {
+        BB_ASSERT_EQ(additive_constant, 0ULL, "uint::operator- expected additive_constant to be zero");
+    }
+    if (!other.is_constant()) {
+        BB_ASSERT_EQ(other.additive_constant, 0ULL, "uint::operator- expected other.additive_constant to be zero");
+    }
+
     const uint32_t lhs_idx = is_constant() ? ctx->zero_idx : witness_index;
     const uint32_t rhs_idx = other.is_constant() ? ctx->zero_idx : other.witness_index;
 
@@ -102,6 +117,9 @@ uint<Builder, Native> uint<Builder, Native>::operator-(const uint& other) const
 template <typename Builder, typename Native>
 uint<Builder, Native> uint<Builder, Native>::operator*(const uint& other) const
 {
+    ASSERT(context == other.context || (context != nullptr && other.context == nullptr) ||
+           (context == nullptr && other.context != nullptr));
+
     Builder* ctx = (context == nullptr) ? other.context : context;
 
     if (is_constant() && other.is_constant()) {
@@ -109,6 +127,14 @@ uint<Builder, Native> uint<Builder, Native>::operator*(const uint& other) const
     }
     if (is_constant() && !other.is_constant()) {
         return other * (*this);
+    }
+
+    // N.B. We assume that additive_constant is nonzero ONLY if value is constant
+    if (!is_constant()) {
+        BB_ASSERT_EQ(additive_constant, 0ULL, "uint::operator* expected additive_constant to be zero");
+    }
+    if (!other.is_constant()) {
+        BB_ASSERT_EQ(other.additive_constant, 0ULL, "uint::operator* expected other.additive_constant to be zero");
     }
 
     const uint32_t rhs_idx = other.is_constant() ? ctx->zero_idx : other.witness_index;

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/uint/arithmetic.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/uint/arithmetic.cpp
@@ -209,14 +209,17 @@ std::pair<uint<Builder, Native>, uint<Builder, Native>> uint<Builder, Native>::d
     Builder* ctx = (context == nullptr) ? other.context : context;
 
     // We want to force the divisor to be non-zero, as this is an error state
-    field_t<Builder>(other).assert_is_not_zero("uint_arithmetic: divide by zero!");
+    static_cast<field_t<Builder>>(other).assert_is_not_zero("uint_arithmetic: divide by zero!");
 
     // If both are constants, we can compute the quotient and remainder directly
     if (is_constant() && other.is_constant()) {
         const uint<Builder, Native> remainder(ctx, additive_constant % other.additive_constant);
         const uint<Builder, Native> quotient(ctx, additive_constant / other.additive_constant);
         return std::make_pair(quotient, remainder);
-    } else if (witness_index == other.witness_index) {
+    }
+
+    // If the divisor and dividend are the same witness, we can return a quotient of 1 and a remainder of 0.
+    if (witness_index == other.witness_index) {
         const uint<Builder, Native> remainder(context, 0);
         const uint<Builder, Native> quotient(context, 1);
         return std::make_pair(quotient, remainder);

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/uint/arithmetic.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/uint/arithmetic.cpp
@@ -209,15 +209,9 @@ std::pair<uint<Builder, Native>, uint<Builder, Native>> uint<Builder, Native>::d
     Builder* ctx = (context == nullptr) ? other.context : context;
 
     // We want to force the divisor to be non-zero, as this is an error state
-    if (other.is_constant() && other.get_value() == 0) {
-        // TODO: should have an actual error handler!
-        const uint32_t one = ctx->add_variable(FF::one());
-        ctx->assert_equal_constant(one, FF::zero(), "plookup_arithmetic: divide by zero!");
-    } else if (!other.is_constant()) {
-        const bool_t<Builder> is_divisor_zero = field_t<Builder>(other).is_zero();
-        ctx->assert_equal_constant(is_divisor_zero.witness_index, FF::zero(), "plookup_arithmetic: divide by zero!");
-    }
+    field_t<Builder>(other).assert_is_not_zero("uint_arithmetic: divide by zero!");
 
+    // If both are constants, we can compute the quotient and remainder directly
     if (is_constant() && other.is_constant()) {
         const uint<Builder, Native> remainder(ctx, additive_constant % other.additive_constant);
         const uint<Builder, Native> quotient(ctx, additive_constant / other.additive_constant);

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/uint/arithmetic.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/uint/arithmetic.cpp
@@ -87,7 +87,7 @@ uint<Builder, Native> uint<Builder, Native>::operator-(const uint& other) const
 
     const uint256_t lhs = get_value();
     const uint256_t rhs = other.get_value();
-    const uint256_t constant_term = (additive_constant - other.additive_constant);
+    const uint256_t constant_term = CIRCUIT_UINT_MAX_PLUS_ONE + (additive_constant - other.additive_constant);
 
     const uint256_t difference = CIRCUIT_UINT_MAX_PLUS_ONE + lhs - rhs;
     const uint256_t overflow = difference >> width;
@@ -102,7 +102,7 @@ uint<Builder, Native> uint<Builder, Native>::operator-(const uint& other) const
         FF::neg_one(),
         FF::neg_one(),
         -FF(CIRCUIT_UINT_MAX_PLUS_ONE),
-        CIRCUIT_UINT_MAX_PLUS_ONE + constant_term,
+        constant_term,
     };
 
     ctx->create_balanced_add_gate(gate);

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/uint/comparison.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/uint/comparison.cpp
@@ -1,5 +1,5 @@
 // === AUDIT STATUS ===
-// internal:    { status: not started, auditors: [], date: YYYY-MM-DD }
+// internal:    { status: done, auditors: [suyash], date: 2025-07-23 }
 // external_1:  { status: not started, auditors: [], date: YYYY-MM-DD }
 // external_2:  { status: not started, auditors: [], date: YYYY-MM-DD }
 // =====================

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/uint/logic.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/uint/logic.cpp
@@ -1,5 +1,5 @@
 // === AUDIT STATUS ===
-// internal:    { status: not started, auditors: [], date: YYYY-MM-DD }
+// internal:    { status: done, auditors: [suyash], date: 2025-07-23 }
 // external_1:  { status: not started, auditors: [], date: YYYY-MM-DD }
 // external_2:  { status: not started, auditors: [], date: YYYY-MM-DD }
 // =====================

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/uint/uint.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/uint/uint.cpp
@@ -1,5 +1,5 @@
 // === AUDIT STATUS ===
-// internal:    { status: not started, auditors: [], date: YYYY-MM-DD }
+// internal:    { status: done, auditors: [suyash], date: 2025-07-23 }
 // external_1:  { status: not started, auditors: [], date: YYYY-MM-DD }
 // external_2:  { status: not started, auditors: [], date: YYYY-MM-DD }
 // =====================

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/uint/uint.fuzzer.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/uint/uint.fuzzer.hpp
@@ -359,30 +359,6 @@ template <typename Builder> class UintFuzzBase {
                 return static_cast<T>(v >> bits);
             }
         }
-        template <class T> static T get_bit(const T v, const size_t bit)
-        {
-            if (bit >= sizeof(T) * 8) {
-                return 0;
-            } else {
-                return (v & (uint64_t(1) << bit)) ? 1 : 0;
-            }
-        }
-        template <class T> static std::vector<bool_t> to_bit_vector(const T& v)
-        {
-            std::vector<bool_t> bits;
-            for (size_t i = 0; i < v.get_width(); i++) {
-                bits.push_back(at<>(v, i));
-            }
-            return bits;
-        }
-        template <class T> static std::array<bool_t, T::width> to_bit_array(const T& v)
-        {
-            std::array<bool_t, T::width> bits;
-            for (size_t i = 0; i < T::width; i++) {
-                bits[i] = at<>(v, i);
-            }
-            return bits;
-        }
         template <class T> static uint256_t get_value(const T& v)
         {
             const auto ret = v.get_value();
@@ -827,7 +803,7 @@ template <typename Builder> class UintFuzzBase {
         /* Explicit re-instantiation using the various constructors */
         ExecutionHandler set(Builder* builder) const
         {
-            switch (VarianceRNG.next() % 7) {
+            switch (VarianceRNG.next() % 5) {
             case 0:
                 return ExecutionHandler(this->ref,
                                         Uint(uint_8_t(this->uint.v8),
@@ -853,18 +829,6 @@ template <typename Builder> class UintFuzzBase {
                                              uint_32_t(this->to_byte_array(this->uint.v32)),
                                              uint_64_t(this->to_byte_array(this->uint.v64))));
             case 4:
-                return ExecutionHandler(this->ref,
-                                        Uint(uint_8_t(builder, this->to_bit_vector(this->uint.v8)),
-                                             uint_16_t(builder, this->to_bit_vector(this->uint.v16)),
-                                             uint_32_t(builder, this->to_bit_vector(this->uint.v32)),
-                                             uint_64_t(builder, this->to_bit_vector(this->uint.v64))));
-            case 5:
-                return ExecutionHandler(this->ref,
-                                        Uint(uint_8_t(builder, this->to_bit_array(this->uint.v8)),
-                                             uint_16_t(builder, this->to_bit_array(this->uint.v16)),
-                                             uint_32_t(builder, this->to_bit_array(this->uint.v32)),
-                                             uint_64_t(builder, this->to_bit_array(this->uint.v64))));
-            case 6:
                 return ExecutionHandler(this->ref,
                                         Uint(uint_8_t(builder, this->ref.v8),
                                              uint_16_t(builder, this->ref.v16),

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/uint/uint.fuzzer.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/uint/uint.fuzzer.hpp
@@ -69,7 +69,6 @@ template <typename Builder> class UintFuzzBase {
             AND,
             OR,
             XOR,
-            GET_BIT,
             SHL,
             SHR,
             ROL,
@@ -140,7 +139,6 @@ template <typename Builder> class UintFuzzBase {
                 out = static_cast<uint8_t>(rng.next() & 0xff);
                 return { .id = instruction_opcode, .arguments.threeArgs = { .in1 = in1, .in2 = in2, .out = out } };
                 break;
-            case OPCODE::GET_BIT:
             case OPCODE::SHL:
             case OPCODE::SHR:
             case OPCODE::ROL:
@@ -204,7 +202,6 @@ template <typename Builder> class UintFuzzBase {
                 PUT_RANDOM_BYTE_IF_LUCKY(instruction.arguments.threeArgs.in2)
                 PUT_RANDOM_BYTE_IF_LUCKY(instruction.arguments.threeArgs.out)
                 break;
-            case OPCODE::GET_BIT:
             case OPCODE::SHL:
             case OPCODE::SHR:
             case OPCODE::ROL:
@@ -241,7 +238,6 @@ template <typename Builder> class UintFuzzBase {
         static constexpr size_t AND = 3;
         static constexpr size_t OR = 3;
         static constexpr size_t XOR = 3;
-        static constexpr size_t GET_BIT = 10;
         static constexpr size_t SHL = 10;
         static constexpr size_t SHR = 10;
         static constexpr size_t ROL = 10;
@@ -276,9 +272,8 @@ template <typename Builder> class UintFuzzBase {
                 return { .id = static_cast<typename Instruction::OPCODE>(opcode),
                          .arguments.threeArgs = { .in1 = *Data, .in2 = *(Data + 1), .out = *(Data + 2) } };
             }
-            if constexpr (opcode == Instruction::OPCODE::GET_BIT || opcode == Instruction::OPCODE::SHL ||
-                          opcode == Instruction::OPCODE::SHR || opcode == Instruction::OPCODE::ROL ||
-                          opcode == Instruction::OPCODE::ROR) {
+            if constexpr (opcode == Instruction::OPCODE::SHL || opcode == Instruction::OPCODE::SHR ||
+                          opcode == Instruction::OPCODE::ROL || opcode == Instruction::OPCODE::ROR) {
                 return Instruction{ .id = static_cast<typename Instruction::OPCODE>(opcode),
                                     .arguments.bitArgs = { .in = *Data, .out = *(Data + 1), .bit = *(Data + 2) } };
             }
@@ -320,8 +315,7 @@ template <typename Builder> class UintFuzzBase {
                 *(Data + 2) = instruction.arguments.threeArgs.in2;
                 *(Data + 3) = instruction.arguments.threeArgs.out;
             }
-            if constexpr (instruction_opcode == Instruction::OPCODE::GET_BIT ||
-                          instruction_opcode == Instruction::OPCODE::SHL ||
+            if constexpr (instruction_opcode == Instruction::OPCODE::SHL ||
                           instruction_opcode == Instruction::OPCODE::SHR ||
                           instruction_opcode == Instruction::OPCODE::ROL ||
                           instruction_opcode == Instruction::OPCODE::ROR) {
@@ -372,24 +366,6 @@ template <typename Builder> class UintFuzzBase {
             } else {
                 return (v & (uint64_t(1) << bit)) ? 1 : 0;
             }
-        }
-        /* wrapper for uint::at which ensures the context of
-         * the return value has been set
-         */
-        template <class T> static bool_t at(const T& v, const size_t bit_index)
-        {
-            const auto ret = v.at(bit_index);
-
-            if (ret.get_context() != v.get_context()) {
-                std::cerr << "Context of return bool_t not set" << std::endl;
-                abort();
-            }
-
-            return ret;
-        }
-        template <class T> static T get_bit(Builder* builder, const T& v, const size_t bit)
-        {
-            return T(builder, std::vector<bool_t>{ at<>(v, bit) });
         }
         template <class T> static std::vector<bool_t> to_bit_vector(const T& v)
         {
@@ -760,17 +736,6 @@ template <typename Builder> class UintFuzzBase {
             default:
                 abort();
             }
-        }
-        ExecutionHandler get_bit(Builder* builder, const size_t bit) const
-        {
-            return ExecutionHandler(Reference(this->get_bit<uint8_t>(this->ref.v8, bit),
-                                              this->get_bit<uint16_t>(this->ref.v16, bit),
-                                              this->get_bit<uint32_t>(this->ref.v32, bit),
-                                              this->get_bit<uint64_t>(this->ref.v64, bit)),
-                                    Uint(this->get_bit<uint_8_t>(builder, this->uint.v8, bit),
-                                         this->get_bit<uint_16_t>(builder, this->uint.v16, bit),
-                                         this->get_bit<uint_32_t>(builder, this->uint.v32, bit),
-                                         this->get_bit<uint_64_t>(builder, this->uint.v64, bit)));
         }
         ExecutionHandler shl(const size_t bits) const
         {
@@ -1156,34 +1121,6 @@ template <typename Builder> class UintFuzzBase {
 
             ExecutionHandler result;
             result = stack[first_index] ^ stack[second_index];
-            // If the output index is larger than the number of elements in stack, append
-            if (output_index >= stack.size()) {
-                stack.push_back(result);
-            } else {
-                stack[output_index] = result;
-            }
-            return 0;
-        };
-        /**
-         * @brief Execute the GET_BIT instruction
-         *
-         * @param builder
-         * @param stack
-         * @param instruction
-         * @return if everything is ok, 1 if we should stop execution, since an expected error was encountered
-         */
-        static inline size_t execute_GET_BIT(Builder* builder,
-                                             std::vector<ExecutionHandler>& stack,
-                                             Instruction& instruction)
-        {
-            if (stack.size() == 0) {
-                return 1;
-            }
-            size_t first_index = instruction.arguments.bitArgs.in % stack.size();
-            size_t output_index = instruction.arguments.bitArgs.out;
-            const uint8_t bit = instruction.arguments.bitArgs.bit;
-            ExecutionHandler result;
-            result = stack[first_index].get_bit(builder, bit);
             // If the output index is larger than the number of elements in stack, append
             if (output_index >= stack.size()) {
                 stack.push_back(result);

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/uint/uint.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/uint/uint.hpp
@@ -1,5 +1,5 @@
 // === AUDIT STATUS ===
-// internal:    { status: not started, auditors: [], date: YYYY-MM-DD }
+// internal:    { status: done, auditors: [suyash], date: 2025-07-23 }
 // external_1:  { status: not started, auditors: [], date: YYYY-MM-DD }
 // external_2:  { status: not started, auditors: [], date: YYYY-MM-DD }
 // =====================
@@ -50,12 +50,14 @@ template <typename Builder, typename Native> class uint {
     explicit operator byte_array<Builder>() const;
     explicit operator field_t<Builder>() const;
 
+    // Arithmetic operations
     uint operator+(const uint& other) const;
     uint operator-(const uint& other) const;
     uint operator*(const uint& other) const;
     uint operator/(const uint& other) const;
     uint operator%(const uint& other) const;
 
+    // Bitwise operations
     uint operator&(const uint& other) const;
     uint operator^(const uint& other) const;
     uint operator|(const uint& other) const;
@@ -69,6 +71,7 @@ template <typename Builder, typename Native> class uint {
     uint ror(const uint256_t target_rotation) const { return ror(static_cast<size_t>(target_rotation.data[0])); }
     uint rol(const uint256_t target_rotation) const { return rol(static_cast<size_t>(target_rotation.data[0])); }
 
+    // Comparison operations
     bool_t<Builder> operator>(const uint& other) const;
     bool_t<Builder> operator<(const uint& other) const;
     bool_t<Builder> operator>=(const uint& other) const;
@@ -77,6 +80,7 @@ template <typename Builder, typename Native> class uint {
     bool_t<Builder> operator!=(const uint& other) const;
     bool_t<Builder> operator!() const;
 
+    // Assignment operators
     uint operator+=(const uint& other)
     {
         *this = operator+(other);
@@ -130,6 +134,7 @@ template <typename Builder, typename Native> class uint {
         return *this;
     }
 
+    // Helper functions
     uint normalize() const;
 
     uint256_t get_value() const;
@@ -151,6 +156,8 @@ template <typename Builder, typename Native> class uint {
     mutable uint256_t additive_constant;
 
     // N.B. Not an accumulator! Contains 6-bit slices of input
+    // `accumulators` are used to store 6-bit slices of the value of the uint. This is done to
+    // range-constrain the uint by constraining individual slices.
     mutable std::vector<uint32_t> accumulators;
     mutable uint32_t witness_index;
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/uint/uint.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/uint/uint.hpp
@@ -137,8 +137,6 @@ template <typename Builder, typename Native> class uint {
     bool is_constant() const { return witness_index == IS_CONSTANT; }
     Builder* get_context() const { return context; }
 
-    bool_t<Builder> at(const size_t bit_index) const;
-
     size_t get_width() const { return width; }
 
     uint32_t get_witness_index() const { return witness_index; }

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/uint/uint.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/uint/uint.test.cpp
@@ -189,8 +189,6 @@ template <typename TestType> class stdlib_uint : public testing::Test {
                                 witness_ct(&builder, true),
                             });
 
-        EXPECT_EQ(a.at(0).get_value(), false);
-        EXPECT_EQ(a.at(7).get_value(), true);
         EXPECT_EQ(static_cast<uint32_t>(a.get_value()), 128U);
     }
 
@@ -1730,39 +1728,6 @@ template <typename TestType> class stdlib_uint : public testing::Test {
         bool proof_result = CircuitChecker::check(builder);
         EXPECT_EQ(proof_result, true);
     }
-
-    /**
-     * @brief Test the function uint_ct::at used to extract bits.
-     */
-    static void test_at()
-    {
-        Builder builder = Builder();
-
-        const auto bit_test = [&builder](const bool is_constant) {
-            // construct a sum of uint_ct's, where at least one is a constant,
-            // and validate its correctness bitwise
-            uint_native const_a = get_random();
-            uint_native a_val = get_random();
-            uint_native c_val = const_a + a_val;
-            uint_ct a = is_constant ? uint_ct(&builder, a_val) : witness_ct(&builder, a_val);
-            uint_ct a_shift = uint_ct(&builder, const_a);
-            uint_ct c = a + a_shift;
-            for (size_t i = 0; i < uint_native_width; ++i) {
-                bool_ct result = c.at(i);
-                bool expected = (((c_val >> i) & 1UL) == 1UL) ? true : false;
-                EXPECT_EQ(result.get_value(), expected);
-                EXPECT_EQ(result.get_context(), c.get_context());
-            }
-        };
-
-        bit_test(false);
-        bit_test(true);
-
-        printf("builder gates = %zu\n", builder.get_estimated_num_finalized_gates());
-
-        bool proof_result = CircuitChecker::check(builder);
-        EXPECT_EQ(proof_result, true);
-    }
 };
 
 // Define the test types for all combinations
@@ -1937,8 +1902,4 @@ TYPED_TEST(stdlib_uint, test_ror)
 TYPED_TEST(stdlib_uint, test_rol)
 {
     TestFixture::test_rol();
-}
-TYPED_TEST(stdlib_uint, test_at)
-{
-    TestFixture::test_at();
 }

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/uint/uint.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/uint/uint.test.cpp
@@ -1033,6 +1033,13 @@ template <typename TestType> class stdlib_uint : public testing::Test {
             uint_ct b_shift = uint_ct(&builder, const_b);
             uint_ct c = a + a_shift;
             uint_ct d = b + b_shift;
+
+            // If both dividend and divisor are constants and divisor is zero, we expect an exception to be thrown.
+            if (divisor_zero && (lhs_constant && rhs_constant)) {
+                EXPECT_THROW_OR_ABORT(c / d, "divide by zero with constant dividend and divisor");
+                return;
+            }
+
             uint_ct e = c / d;
             e = e.normalize();
 


### PR DESCRIPTION
### 🧾 Audit Context

Remainder audit of `uint`.

### 🛠️ Changes Made

- Removed `at` function as it has a bug. The bug is explained [here](https://github.com/AztecProtocol/aztec-packages/blob/3941e2f537a5257f4d19c0e018a73ab687151024/barretenberg/cpp/src/barretenberg/stdlib/primitives/uint/uint.cpp#L244-L249).
- Added assertions and minor comments.
- No circuit changes.

### ✅ Checklist

- [x] Audited all methods of the relevant module/class
- [x] Audited the interface of the module/class with other (relevant) components
- [x] Documented existing functionality and any changes made (as per Doxygen requirements)
- [x] Resolved and/or closed all issues/TODOs pertaining to the audited files
- [x] Confirmed and documented any security or other issues found (if applicable)
- [x] Verified that tests cover all critical paths (and added tests if necessary)
- [x] Updated audit tracking for the files audited (check the start of each file you audited)

### 📌 Notes for Reviewers

NA
