### PR TITLE
fix: addressing remaining visibility warnings

### DIFF
--- a/noir-projects/aztec-nr/aztec/Nargo.toml
+++ b/noir-projects/aztec-nr/aztec/Nargo.toml
@@ -6,5 +6,5 @@ type = "lib"
 
 [dependencies]
 protocol_types = { path = "../../noir-protocol-circuits/crates/types" }
-sha256 = { tag = "v0.1.2", git = "https://github.com/noir-lang/sha256" }
+sha256 = { tag = "v0.1.4", git = "https://github.com/noir-lang/sha256" }
 poseidon = { tag = "v0.1.1", git = "https://github.com/noir-lang/poseidon" }

--- a/noir-projects/aztec-nr/aztec/src/lib.nr
+++ b/noir-projects/aztec-nr/aztec/src/lib.nr
@@ -1,11 +1,11 @@
-mod context;
+pub mod context;
 mod publish_contract_instance;
 mod hash;
 mod history;
-mod keys;
+pub mod keys;
 mod messaging;
-mod note;
-mod oracle;
+pub mod note;
+pub mod oracle;
 mod state_vars;
 mod capsules;
 mod event;
@@ -13,6 +13,6 @@ pub mod messages;
 pub use dep::protocol_types;
 mod utils;
 mod authwit;
-mod macros;
+pub mod macros;
 
 mod test;

--- a/noir-projects/noir-contracts/contracts/account/ecdsa_k_account_contract/Nargo.toml
+++ b/noir-projects/noir-contracts/contracts/account/ecdsa_k_account_contract/Nargo.toml
@@ -7,4 +7,4 @@ type = "contract"
 [dependencies]
 aztec = { path = "../../../../aztec-nr/aztec" }
 ecdsa_public_key_note = { path = "../../libs/ecdsa_public_key_note" }
-sha256 = { tag = "v0.1.2", git = "https://github.com/noir-lang/sha256" }
+sha256 = { tag = "v0.1.4", git = "https://github.com/noir-lang/sha256" }

--- a/noir-projects/noir-contracts/contracts/account/ecdsa_r_account_contract/Nargo.toml
+++ b/noir-projects/noir-contracts/contracts/account/ecdsa_r_account_contract/Nargo.toml
@@ -7,4 +7,4 @@ type = "contract"
 [dependencies]
 aztec = { path = "../../../../aztec-nr/aztec" }
 ecdsa_public_key_note = { path = "../../libs/ecdsa_public_key_note" }
-sha256 = { tag = "v0.1.2", git = "https://github.com/noir-lang/sha256" }
+sha256 = { tag = "v0.1.4", git = "https://github.com/noir-lang/sha256" }

--- a/noir-projects/noir-contracts/contracts/app/card_game_contract/Nargo.toml
+++ b/noir-projects/noir-contracts/contracts/app/card_game_contract/Nargo.toml
@@ -7,4 +7,4 @@ type = "contract"
 [dependencies]
 aztec = { path = "../../../../aztec-nr/aztec" }
 value_note = { path = "../../../../aztec-nr/value-note" }
-sha256 = { tag = "v0.1.2", git = "https://github.com/noir-lang/sha256" }
+sha256 = { tag = "v0.1.4", git = "https://github.com/noir-lang/sha256" }

--- a/noir-projects/noir-contracts/contracts/test/avm_gadgets_test_contract/Nargo.toml
+++ b/noir-projects/noir-contracts/contracts/test/avm_gadgets_test_contract/Nargo.toml
@@ -7,5 +7,5 @@ type = "contract"
 [dependencies]
 aztec = { path = "../../../../aztec-nr/aztec" }
 keccak256 = { tag = "v0.1.0", git = "https://github.com/noir-lang/keccak256" }
-sha256 = { tag = "v0.1.2", git = "https://github.com/noir-lang/sha256" }
+sha256 = { tag = "v0.1.4", git = "https://github.com/noir-lang/sha256" }
 poseidon = { tag= "v0.1.1", git = "https://github.com/noir-lang/poseidon" }

--- a/noir-projects/noir-contracts/contracts/test/avm_test_contract/Nargo.toml
+++ b/noir-projects/noir-contracts/contracts/test/avm_test_contract/Nargo.toml
@@ -7,6 +7,6 @@ type = "contract"
 [dependencies]
 aztec = { path = "../../../../aztec-nr/aztec" }
 compressed_string = { path = "../../../../aztec-nr/compressed-string" }
-sha256 = { tag = "v0.1.2", git = "https://github.com/noir-lang/sha256" }
+sha256 = { tag = "v0.1.4", git = "https://github.com/noir-lang/sha256" }
 keccak256 = { tag = "v0.1.0", git = "https://github.com/noir-lang/keccak256" }
 poseidon = { tag= "v0.1.1", git = "https://github.com/noir-lang/poseidon" }

--- a/noir-projects/noir-contracts/contracts/test/benchmarking_contract/Nargo.toml
+++ b/noir-projects/noir-contracts/contracts/test/benchmarking_contract/Nargo.toml
@@ -7,4 +7,4 @@ type = "contract"
 [dependencies]
 aztec = { path = "../../../../aztec-nr/aztec" }
 value_note = { path = "../../../../aztec-nr/value-note" }
-sha256 = { tag = "v0.1.2", git = "https://github.com/noir-lang/sha256" }
+sha256 = { tag = "v0.1.4", git = "https://github.com/noir-lang/sha256" }

--- a/noir-projects/noir-protocol-circuits/crates/types/Nargo.toml
+++ b/noir-projects/noir-protocol-circuits/crates/types/Nargo.toml
@@ -5,5 +5,5 @@ authors = [""]
 compiler_version = ">=0.18.0"
 
 [dependencies]
-sha256 = { tag = "v0.1.3", git = "https://github.com/noir-lang/sha256" }
+sha256 = { tag = "v0.1.4", git = "https://github.com/noir-lang/sha256" }
 poseidon = { tag = "v0.1.1", git = "https://github.com/noir-lang/poseidon" }


### PR DESCRIPTION
Needed to do the following to resolve remaining visibility issue that currently blocks [Noir sync](https://github.com/AztecProtocol/aztec-packages/pull/15899):
- Exposed a few modules from `Aztec.nr` as in the  it's prohibited to access private modules.
- Updated https://github.com/noir-lang/sha256 dependency as an older version had a visibility issue present.