### PR TITLE
refactor: pythonise benchmark file generation

### DIFF
--- a/l1-contracts/bootstrap.sh
+++ b/l1-contracts/bootstrap.sh
@@ -145,106 +145,32 @@ function bench_cmds {
 function bench {
   rm -rf bench-out && mkdir -p bench-out
 
-  # Run the gas benchmark to generate the markdown file
+  # Run the gas benchmark to generate the markdown file and JSON results
   gas_benchmark
 
-  # Extract gas values from gas_benchmark.md and create JSON output
-  awk '
-  function trim(s) {
-    sub(/^[ \t]+/, "", s);
-    sub(/[ \t]+$/, "", s);
-    return s;
-  }
-  BEGIN {
-    print "[";
-    first = 1;
-  }
-  /^[a-zA-Z]/ {
-    if ($1 != "Function" && $1 != "-------------------------") {
-      # Split the line into columns and clean them
-      n = split($0, cols, "|");
-      for (i = 1; i <= n; i++) {
-        cols[i] = trim(cols[i]);
-      }
-
-      # Only process Max rows
-      if (cols[2] == "Max") {
-        # Get the function name
-        func_name = cols[1];
-
-        # Define our cases with their column numbers
-        cases["no_validators"] = 3;
-        cases["100_validators"] = 4;
-        cases["100_validators_slashing"] = 5;
-        cases["overhead"] = 6;
-
-        for (case_name in cases) {
-          col = cases[case_name];
-
-          # Filter: only include aggregate3 functions with 100_validators_slashing, and vice versa
-          has_aggregate3 = index(tolower(func_name), "aggregate3") > 0;
-          is_slashing_case = (case_name == "100_validators_slashing");
-
-          # Skip if aggregate3 function but not slashing case, or slashing case but not aggregate3 function
-          if ((has_aggregate3 && !is_slashing_case) || (is_slashing_case && !has_aggregate3)) {
-            continue;
-          }
-
-
-          # Rename aggregate3 to proposeAndVote in function name
-          display_func_name = func_name;
-          if (has_aggregate3) {
-            gsub(/aggregate3/, "proposeAndVote", display_func_name);
-          }
-
-          if (match(cols[col], /([0-9]+)[ ]*\(([0-9.]+)\)/)) {
-            # Extract the raw gas value (first number)
-            match(cols[col], /[0-9]+/);
-            raw_gas = substr(cols[col], RSTART, RLENGTH);
-
-            # Extract the per tx value
-            match(cols[col], /\(([0-9.]+)\)/);
-            per_tx = substr(cols[col], RSTART+1, RLENGTH-2);
-
-            if (!first) print ",";
-            first = 0;
-
-            # Output raw gas value
-            print "  {";
-            print "    \"name\": \"" display_func_name " (" case_name ")\",";
-            print "    \"value\": " raw_gas ",";
-            print "    \"unit\": \"gas\"";
-            print "  },";
-
-            # Output per tx value
-            print "  {";
-            print "    \"name\": \"" display_func_name " (" case_name ") per l2 tx\",";
-            print "    \"value\": " per_tx ",";
-            print "    \"unit\": \"gas\"";
-            print "  }";
-          }
-        }
-      }
-    }
-  }
-  END {
-    print "]";
-  }' gas_benchmark.md > ./bench-out/l1-gas.bench.json
+  # Use Python script to generate the benchmark JSON from gas_benchmark_results.json
+  python3 scripts/generate_benchmark_json.py
 }
 
 function gas_benchmark {
   check=${1:-"no"}
 
-  validator_costs
+  echo_header "l1-contracts gas benchmark"
+  forge --version
 
-  diff gas_benchmark.new.md gas_benchmark.md > gas_benchmark.diff || true
+  # Run the new Python benchmarking script
+  echo "Running gas benchmarks..."
+  python3 scripts/gas_benchmarks.py
 
-  if [ -s gas_benchmark.diff -a "$check" = "check" ]; then
-    cat gas_benchmark.diff
-    echo "Gas benchmark has changed. Please check the diffs above, then run './bootstrap.sh gas_benchmark' to update the gas benchmark."
-    exit 1
+  # The script generates gas_benchmark.md directly
+  # Check if it differs from the committed version
+  if [ "$check" = "check" ]; then
+    if ! git diff --quiet gas_benchmark.md; then
+      git diff gas_benchmark.md
+      echo "Gas benchmark has changed. Please check the diffs above, then run './bootstrap.sh gas_benchmark' to update the gas benchmark."
+      exit 1
+    fi
   fi
-  mv gas_benchmark.new.md gas_benchmark.md
 }
 
 function validator_costs {
@@ -256,7 +182,8 @@ function validator_costs {
     --match-contract "BenchmarkRollupTest" \
     --match-test "test_no_validators" \
     --fuzz-seed 42 \
-    > no_validators.tmp
+    --json \
+    > no_validators.json
 
   # Run test with 100 validators
   echo "Running test with 100 validators..."
@@ -264,7 +191,8 @@ function validator_costs {
     --match-contract "BenchmarkRollupTest" \
     --match-test "test_100_validators" \
     --fuzz-seed 42 \
-    > with_validators.tmp
+    --json \
+    > 100_validators.json
 
   # Run test with 100 validators and slashing
   echo "Running test with 100 validators and slashing..."
@@ -272,113 +200,12 @@ function validator_costs {
     --match-contract "BenchmarkRollupTest" \
     --match-test "test_100_slashing_validators" \
     --fuzz-seed 42 \
-    > with_slashing_validators.tmp
+    --json \
+    > 100_validators_slashing.json
 
-  file_no="no_validators.tmp"          # without validators
-  file_yes="with_validators.tmp"       # with    validators
-  file_yes_slashing="with_slashing_validators.tmp"       # with    validators and slashing
-  report="gas_benchmark.new.md"        # will be overwritten each run
-
-  # keep ONLY these functions, in this order
-  wanted_funcs="propose setupEpoch submitEpochRootProof aggregate3"
-
-  # one label per numeric column (use | to separate)
-  labels='Min|Avg|Median|Max|# Calls'
-
-  awk -v keep="$wanted_funcs" -v lbl="$labels" \
-      -v f_no="$file_no" -v f_yes="$file_yes" -v f_yes_slashing="$file_yes_slashing" '
-  function trim(s){gsub(/^[[:space:]]+|[[:space:]]+$/,"",s); return s}
-  #   cell(raw [, scaled])
-  #   If you call it with ONE argument, you get the raw value only.
-  #   If you call it with TWO arguments, you get  "raw (scaled)"  padded to 22.
-  function cell(raw, scaled,   s) {
-      # Was a second parameter supplied?
-      if ( scaled == "" )                 # argument omitted → print raw only
-          return sprintf("%22d", raw)
-
-      s = sprintf("%10d (%.2f)", raw, scaled)
-      return sprintf("%-22s", s)          # left-pad / truncate to 22 chars
-  }
-
-  BEGIN{
-      # ---------------- wanted functions & labels (unchanged) ---------------
-      nf = split(keep, F, /[[:space:]]+/)
-      for (i = 1; i <= nf; i++) { order[i] = F[i]; want[F[i]] }
-      split(lbl, L, /\|/);   nLab = length(L)
-
-      # ---------------- fixed-width formats ---------------------------------
-      # header row
-      hdr = "%-24s | %-7s | %22s | %23s | %22s | %12s\n"
-      sep = "-------------------------+---------+------------------------+-------------------------+------------------------+-----------------"
-      # data row (the three %22s will already be fully padded strings)
-      row = "%-24s | %-7s | %22s | %23s | %22s | %10.2f%%\n"
-
-      printf hdr, "Function", "Metric",
-                  "No Validators (gas/tx)", "100 Validators (gas/tx)", "Δ Gas (gas/tx)", "% Overhead"
-      print  sep
-
-      FS="|"; OFS=""
-  }
-  # ---------- first file: without validators ----------------------------------
-  FNR==NR {
-      if($0 !~ /^\|/) next
-      split($0, C)                      # C[1] "", C[2] fn, C[3..] numbers
-      fn = trim(C[2])
-      if(!(fn in want)) next
-      for(i=3; i<=NF-1; i++) base[fn,i] = trim(C[i]) + 0
-      cols[fn] = NF - 3                 # remember how many numeric cols
-      next
-  }
-  # ---------- second file: with validators ------------------------------------
-  {
-      if($0 !~ /^\|/) next
-      split($0, C)
-      fn = trim(C[2])
-      if(!(fn in want)) next
-      for(i=3; i<=NF-1; i++) with[fn,i] = trim(C[i]) + 0
-      cols[fn] = NF - 3
-  }
-  # ---------- third file: with validators and slashing --------------------------
-  {
-      if($0 !~ /^\|/) next
-      split($0, C)
-      fn = trim(C[2])
-      if(!(fn in want)) next
-      for(i=3; i<=NF-1; i++) with_slashing[fn,i] = trim(C[i]) + 0
-      cols[fn] = NF - 3
-  }
-  # ---------- emit table -------------------------------------------------------
-  END{
-      for (k = 1; k <= nf; k++) {
-          fn = order[k]
-          div = (fn == "propose" || fn == "aggregate3" ? 360 : 11520)   # change 11520→720 if desired
-
-          for (j = 1; j <= cols[fn]; j++) {
-              idx    = j + 2
-              metric = L[j]
-              a      = base[fn,idx] + 0
-              b      = with[fn,idx] + 0
-              diff   = b - a
-              pct    = (a ? diff * 100.0 / a : 0)
-
-              if (metric == "# Calls") {
-                  c1 = cell(a)
-                  c2 = cell(b)
-                  c3 = cell(diff)
-              } else {
-                  c1 = cell(a,   a/div)
-                  c2 = cell(b,   b/div)
-                  c3 = cell(diff,diff/div)
-              }
-              printf row, fn, metric, c1, c2, c3, pct
-          }
-          print sep
-      }
-  }
-  ' "$file_no" "$file_yes" "$file_yes_slashing" > "$report"
-
-  # Clean up temporary files
-  rm no_validators.tmp with_validators.tmp with_slashing_validators.tmp
+  # Use Python script to process the JSON files
+  echo "Processing gas reports with Python script..."
+  python3 scripts/process_gas_reports.py no_validators.json 100_validators.json 100_validators_slashing.json
 }
 
 # First argument is a branch name (e.g. master, or the latest version e.g. 1.2.3) to push to the head of.

--- a/l1-contracts/gas_benchmark.md
+++ b/l1-contracts/gas_benchmark.md
@@ -1,26 +1,71 @@
-Function                 | Metric  | No Validators (gas/tx) | 100 Validators (gas/tx) |        Δ Gas (gas/tx) |   % Overhead
--------------------------+---------+------------------------+-------------------------+------------------------+-----------------
-propose                  | Min     |     209098 (580.83)    |      409354 (1137.09)   |     200256 (556.27)    |      95.77%
-propose                  | Avg     |     219044 (608.46)    |      419428 (1165.08)   |     200384 (556.62)    |      91.48%
-propose                  | Median  |     219084 (608.57)    |      419290 (1164.69)   |     200206 (556.13)    |      91.38%
-propose                  | Max     |     235034 (652.87)    |      435649 (1210.14)   |     200615 (557.26)    |      85.36%
-propose                  | # Calls |                    100 |                     100 |                      0 |       0.00%
--------------------------+---------+------------------------+-------------------------+------------------------+-----------------
-setupEpoch               | Min     |      37790 (3.28)      |       37790 (3.28)      |          0 (0.00)      |       0.00%
-setupEpoch               | Avg     |      41912 (3.64)      |       61658 (5.35)      |      19746 (1.71)      |      47.11%
-setupEpoch               | Median  |      39790 (3.45)      |       39790 (3.45)      |          0 (0.00)      |       0.00%
-setupEpoch               | Max     |     106381 (9.23)      |      600014 (52.08)     |     493633 (42.85)     |     464.02%
-setupEpoch               | # Calls |                    100 |                     100 |                      0 |       0.00%
--------------------------+---------+------------------------+-------------------------+------------------------+-----------------
-submitEpochRootProof     | Min     |     654650 (56.83)     |      654650 (56.83)     |          0 (0.00)      |       0.00%
-submitEpochRootProof     | Avg     |     674114 (58.52)     |      674114 (58.52)     |          0 (0.00)      |       0.00%
-submitEpochRootProof     | Median  |     654746 (56.84)     |      654746 (56.84)     |          0 (0.00)      |       0.00%
-submitEpochRootProof     | Max     |     712946 (61.89)     |      712946 (61.89)     |          0 (0.00)      |       0.00%
-submitEpochRootProof     | # Calls |                      3 |                       3 |                      0 |       0.00%
--------------------------+---------+------------------------+-------------------------+------------------------+-----------------
-aggregate3               | Min     |          0 (0.00)      |      454945 (1263.74)   |     454945 (1263.74)   |       0.00%
-aggregate3               | Avg     |          0 (0.00)      |      471529 (1309.80)   |     471529 (1309.80)   |       0.00%
-aggregate3               | Median  |          0 (0.00)      |      472537 (1312.60)   |     472537 (1312.60)   |       0.00%
-aggregate3               | Max     |          0 (0.00)      |      495790 (1377.19)   |     495790 (1377.19)   |       0.00%
-aggregate3               | # Calls |                      0 |                     100 |                    100 |       0.00%
--------------------------+---------+------------------------+-------------------------+------------------------+-----------------
+# Gas Benchmark Report
+
+## IGNITION
+
+### Configuration
+
+| Parameter             | Value |
+|-----------------------|-------|
+| Slot Duration         |    60 |
+| Epoch Duration        |    48 |
+| Target Committee Size |    24 |
+| Mana Target           |     0 |
+
+### No Validators (IGNITION)
+
+| Function             |     Avg |     Max |
+|----------------------|---------|---------|
+| propose              | 180,182 | 195,380 |
+| setupEpoch           |  40,785 | 103,864 |
+| submitEpochRootProof | 799,356 | 819,960 |
+
+**Avg Gas Cost per Second**: 3,294.7 gas/second
+*(Epoch duration: 0h 48m 0s)*
+
+### Validators (IGNITION)
+
+| Function             |     Avg |     Max |
+|----------------------|---------|---------|
+| propose              | 284,434 | 300,076 |
+| setupEpoch           |  48,311 | 354,729 |
+| submitEpochRootProof | 799,356 | 819,960 |
+| aggregate3           | 331,654 | 351,870 |
+
+**Avg Gas Cost per Second**: 5,034.9 gas/second
+*(Epoch duration: 0h 48m 0s)*
+
+
+## Alpha
+
+### Configuration
+
+| Parameter             |       Value |
+|-----------------------|-------------|
+| Slot Duration         |          36 |
+| Epoch Duration        |          32 |
+| Target Committee Size |          48 |
+| Mana Target           | 100,000,000 |
+
+### No Validators (Alpha)
+
+| Function             |     Avg |     Max |
+|----------------------|---------|---------|
+| propose              | 219,022 | 235,012 |
+| setupEpoch           |  41,912 | 106,381 |
+| submitEpochRootProof | 671,999 | 710,831 |
+
+**Gas Cost per Second**: 6,703.7 gas/second
+*(Epoch duration: 0h 19m 12s)*
+
+### Validators (Alpha)
+
+| Function             |     Avg |     Max |
+|----------------------|---------|---------|
+| propose              | 419,406 | 435,627 |
+| setupEpoch           |  61,658 | 600,014 |
+| submitEpochRootProof | 671,999 | 710,831 |
+| aggregate3           | 471,485 | 495,734 |
+
+**Gas Cost per Second**: 12,287.0 gas/second
+*(Epoch duration: 0h 19m 12s)*
+

--- a/l1-contracts/gas_benchmark.md
+++ b/l1-contracts/gas_benchmark.md
@@ -10,6 +10,7 @@
 | Epoch Duration        |    48 |
 | Target Committee Size |    24 |
 | Mana Target           |     0 |
+| Proofs per Epoch      |  2.00 |
 
 ### No Validators (IGNITION)
 
@@ -19,8 +20,8 @@
 | setupEpoch           |  40,785 | 103,864 |
 | submitEpochRootProof | 799,356 | 819,960 |
 
-**Avg Gas Cost per Second**: 3,294.7 gas/second
-*(Epoch duration: 0h 48m 0s)*
+**Avg Gas Cost per Second**: 3,572.3 gas/second
+*Epoch duration*: 0h 48m 0s
 
 ### Validators (IGNITION)
 
@@ -31,8 +32,8 @@
 | submitEpochRootProof | 799,356 | 819,960 |
 | aggregate3           | 331,654 | 351,870 |
 
-**Avg Gas Cost per Second**: 5,034.9 gas/second
-*(Epoch duration: 0h 48m 0s)*
+**Avg Gas Cost per Second**: 5,312.4 gas/second
+*Epoch duration*: 0h 48m 0s
 
 
 ## Alpha
@@ -45,6 +46,7 @@
 | Epoch Duration        |          32 |
 | Target Committee Size |          48 |
 | Mana Target           | 100,000,000 |
+| Proofs per Epoch      |        2.00 |
 
 ### No Validators (Alpha)
 
@@ -54,8 +56,8 @@
 | setupEpoch           |  41,912 | 106,381 |
 | submitEpochRootProof | 671,999 | 710,831 |
 
-**Gas Cost per Second**: 6,703.7 gas/second
-*(Epoch duration: 0h 19m 12s)*
+**Avg Gas Cost per Second**: 7,287.0 gas/second
+*Epoch duration*: 0h 19m 12s
 
 ### Validators (Alpha)
 
@@ -66,6 +68,6 @@
 | submitEpochRootProof | 671,999 | 710,831 |
 | aggregate3           | 471,485 | 495,734 |
 
-**Gas Cost per Second**: 12,287.0 gas/second
-*(Epoch duration: 0h 19m 12s)*
+**Avg Gas Cost per Second**: 12,870.4 gas/second
+*Epoch duration*: 0h 19m 12s
 

--- a/l1-contracts/gas_benchmark_results.json
+++ b/l1-contracts/gas_benchmark_results.json
@@ -1,0 +1,112 @@
+{
+  "ignition": {
+    "no_validators": {
+      "propose": {
+        "calls": 100,
+        "min": 172938,
+        "mean": 180182,
+        "median": 179484,
+        "max": 195380
+      },
+      "setupEpoch": {
+        "calls": 100,
+        "min": 37790,
+        "mean": 40785,
+        "median": 39790,
+        "max": 103864
+      },
+      "submitEpochRootProof": {
+        "calls": 2,
+        "min": 778752,
+        "mean": 799356,
+        "median": 799356,
+        "max": 819960
+      }
+    },
+    "validators": {
+      "propose": {
+        "calls": 100,
+        "min": 277179,
+        "mean": 284434,
+        "median": 283725,
+        "max": 300076
+      },
+      "setupEpoch": {
+        "calls": 100,
+        "min": 37790,
+        "mean": 48311,
+        "median": 39790,
+        "max": 354729
+      },
+      "submitEpochRootProof": {
+        "calls": 2,
+        "min": 778752,
+        "mean": 799356,
+        "median": 799356,
+        "max": 819960
+      },
+      "aggregate3": {
+        "calls": 100,
+        "min": 324429,
+        "mean": 331654,
+        "median": 326830,
+        "max": 351870
+      }
+    }
+  },
+  "alpha": {
+    "no_validators": {
+      "propose": {
+        "calls": 100,
+        "min": 209076,
+        "mean": 219022,
+        "median": 219062,
+        "max": 235012
+      },
+      "setupEpoch": {
+        "calls": 100,
+        "min": 37790,
+        "mean": 41912,
+        "median": 39790,
+        "max": 106381
+      },
+      "submitEpochRootProof": {
+        "calls": 3,
+        "min": 652535,
+        "mean": 671999,
+        "median": 652631,
+        "max": 710831
+      }
+    },
+    "validators": {
+      "propose": {
+        "calls": 100,
+        "min": 409332,
+        "mean": 419406,
+        "median": 419268,
+        "max": 435627
+      },
+      "setupEpoch": {
+        "calls": 100,
+        "min": 37790,
+        "mean": 61658,
+        "median": 39790,
+        "max": 600014
+      },
+      "submitEpochRootProof": {
+        "calls": 3,
+        "min": 652535,
+        "mean": 671999,
+        "median": 652631,
+        "max": 710831
+      },
+      "aggregate3": {
+        "calls": 100,
+        "min": 454901,
+        "mean": 471485,
+        "median": 472493,
+        "max": 495734
+      }
+    }
+  }
+}

--- a/l1-contracts/scripts/gas_benchmarks.py
+++ b/l1-contracts/scripts/gas_benchmarks.py
@@ -1,0 +1,586 @@
+#!/usr/bin/env python3
+"""
+Configuration-based gas benchmarking script for l1-contracts.
+Runs forge tests directly and generates human-readable reports.
+"""
+
+import json
+import os
+import subprocess
+from typing import Dict, List, Any
+
+
+# Configuration for different benchmark scenarios
+BENCHMARK_CONFIGS = {
+    "no_validators": {
+        "name": "No Validators",
+        "tests": [
+            {
+                "command": [
+                    "forge",
+                    "test",
+                    "--match-contract",
+                    "BenchmarkRollupTest",
+                    "--match-test",
+                    "test_no_validators",
+                    "--fuzz-seed",
+                    "42",
+                    "--json",
+                ],
+                "priority": 1,
+            }
+        ],
+        "focus_functions": ["propose", "setupEpoch", "submitEpochRootProof"],
+        "tx_divisor": {
+            "propose": 360,
+            "setupEpoch": 11520,
+            "submitEpochRootProof": 11520,
+        },
+    },
+    "validators": {
+        "name": "Validators",
+        "tests": [
+            {
+                "command": [
+                    "forge",
+                    "test",
+                    "--match-contract",
+                    "BenchmarkRollupTest",
+                    "--match-test",
+                    "test_100_validators",
+                    "--fuzz-seed",
+                    "42",
+                    "--json",
+                ],
+                "priority": 1,
+            },
+            {
+                "command": [
+                    "forge",
+                    "test",
+                    "--match-contract",
+                    "BenchmarkRollupTest",
+                    "--match-test",
+                    "test_100_slashing_validators",
+                    "--fuzz-seed",
+                    "42",
+                    "--json",
+                ],
+                "priority": 2,  # Lower priority - only use if function not in priority 1
+            },
+        ],
+        "focus_functions": [
+            "propose",
+            "setupEpoch",
+            "submitEpochRootProof",
+            "aggregate3",
+        ],
+        "tx_divisor": {
+            "propose": 360,
+            "setupEpoch": 11520,
+            "submitEpochRootProof": 11520,
+            "aggregate3": 360,
+        },
+    },
+}
+
+
+def run_forge_test(command: List[str], ignition: bool = False) -> Dict[str, Any]:
+    """Run a forge test command and return the JSON output."""
+    print(f"Running: {' '.join(command)}")
+    print(f"IGNITION environment variable set to: {ignition}")
+
+    # Add FORGE_GAS_REPORT environment variable
+    env = os.environ.copy()
+    env["FORGE_GAS_REPORT"] = "true"
+
+    # Set IGNITION environment variable based on config
+    env["IGNITION"] = "true" if ignition else "false"
+
+    try:
+        result = subprocess.run(
+            command, capture_output=True, text=True, check=True, env=env
+        )
+        return json.loads(result.stdout)
+    except subprocess.CalledProcessError as e:
+        print(f"Error running forge test: {e}")
+        print(f"stderr: {e.stderr}")
+        return {}
+    except json.JSONDecodeError as e:
+        print(f"Error parsing JSON output: {e}")
+        return {}
+
+
+def extract_config(ignition: bool = False) -> Dict[str, int]:
+    """Run the test_log_config test to extract configuration values."""
+    print(f"Extracting configuration for IGNITION={ignition}")
+
+    command = [
+        "forge",
+        "test",
+        "--match-contract",
+        "BenchmarkRollupTest",
+        "--match-test",
+        "test_log_config",
+        "--fuzz-seed",
+        "42",
+        "-vv",
+        "--json",
+    ]
+
+    # Add IGNITION environment variable but NOT FORGE_GAS_REPORT
+    env = os.environ.copy()
+    env["IGNITION"] = "true" if ignition else "false"
+    # Remove FORGE_GAS_REPORT if it exists to get decoded_logs
+    env.pop("FORGE_GAS_REPORT", None)
+
+    try:
+        result = subprocess.run(
+            command, capture_output=True, text=True, check=True, env=env
+        )
+
+        output = json.loads(result.stdout)
+
+        # Extract config from decoded_logs
+        config = {}
+        for contract_data in output.values():
+            if isinstance(contract_data, dict) and "test_results" in contract_data:
+                for test_name, test_data in contract_data["test_results"].items():
+                    if "test_log_config" in test_name and "decoded_logs" in test_data:
+                        # Parse decoded logs like ["SLOT_DURATION: 60", "EPOCH_DURATION: 48", ...]
+                        for log in test_data["decoded_logs"]:
+                            if ":" in log:
+                                parts = log.split(":", 1)
+                                if len(parts) == 2:
+                                    key = parts[0].strip()
+                                    value = parts[1].strip()
+                                    try:
+                                        config[key] = int(value)
+                                    except ValueError:
+                                        # Skip if not a number
+                                        pass
+
+        return config
+    except Exception as e:
+        print(f"Error extracting config: {e}")
+        return {}
+
+
+def extract_gas_data_from_forge_output(
+    forge_output: Any, target_functions: List[str]
+) -> Dict[str, Dict]:
+    """Extract gas data for specific functions from forge JSON output."""
+    function_data = {}
+
+    # Handle different forge output formats
+    # The output might be a list of contracts or a dict
+    if isinstance(forge_output, list):
+        # Iterate through contracts in the list
+        for contract_entry in forge_output:
+            if (
+                not isinstance(contract_entry, dict)
+                or "functions" not in contract_entry
+            ):
+                continue
+
+            # Look for our target functions
+            for func_name, gas_stats in contract_entry["functions"].items():
+                for target in target_functions:
+                    if target in func_name:
+                        function_data[target] = gas_stats
+                        break
+
+    elif isinstance(forge_output, dict):
+        # Navigate through forge's JSON structure
+        for contract_data in forge_output.values():
+            if not isinstance(contract_data, dict):
+                continue
+
+            # Look for gas reports in the contract data
+            if "test_results" in contract_data:
+                for test_data in contract_data["test_results"].values():
+                    if "gas_report" in test_data:
+                        for functions in test_data["gas_report"].values():
+                            for func_name, gas_stats in functions.items():
+                                # Check if this matches any target function
+                                for target in target_functions:
+                                    if target in func_name:
+                                        function_data[target] = gas_stats
+                                        break
+
+            # Also check if gas data is at contract level
+            if "functions" in contract_data:
+                for func_name, gas_stats in contract_data["functions"].items():
+                    for target in target_functions:
+                        if target in func_name:
+                            function_data[target] = gas_stats
+                            break
+
+    return function_data
+
+
+def merge_gas_data_with_priority(
+    data_list: List[Dict[str, Dict]], priorities: List[int]
+) -> Dict[str, Dict]:
+    """
+    Merge gas data from multiple sources based on priority.
+    Lower priority number = higher precedence.
+    """
+    merged = {}
+
+    # Sort by priority (ascending)
+    sorted_data = sorted(zip(data_list, priorities), key=lambda x: x[1])
+
+    for data, _ in sorted_data:
+        for func_name, gas_stats in data.items():
+            if func_name not in merged:
+                merged[func_name] = gas_stats
+
+    return merged
+
+
+def run_benchmark_config(
+    config: Dict[str, Any], ignition: bool = False
+) -> Dict[str, Dict]:
+    """Run all tests for a configuration and return merged gas data."""
+    all_gas_data = []
+    priorities = []
+
+    for test in config["tests"]:
+        # Run the forge test with ignition parameter
+        forge_output = run_forge_test(test["command"], ignition)
+
+        # Extract gas data
+        gas_data = extract_gas_data_from_forge_output(
+            forge_output, config["focus_functions"]
+        )
+
+        all_gas_data.append(gas_data)
+        priorities.append(test["priority"])
+
+    # Merge results based on priority
+    return merge_gas_data_with_priority(all_gas_data, priorities)
+
+
+def seconds_to_hms(seconds: int) -> str:
+    """Convert seconds to hours:minutes:seconds format."""
+    hours = seconds // 3600
+    minutes = (seconds % 3600) // 60
+    secs = seconds % 60
+    return f"{hours}h {minutes}m {secs}s"
+
+
+def generate_markdown_report(
+    ignition_results: Dict[str, Dict[str, Dict]],
+    alpha_results: Dict[str, Dict[str, Dict]],
+    ignition_config: Dict[str, int],
+    alpha_config: Dict[str, int],
+    output_file: str = "gas_benchmark.md",
+):
+    """Generate a human-readable markdown report from benchmark results."""
+    lines = []
+
+    # Sort functions in desired order
+    function_order = ["propose", "setupEpoch", "submitEpochRootProof", "aggregate3"]
+
+    # Add header
+    lines.append("# Gas Benchmark Report\n")
+
+    # First, add all IGNITION results
+    lines.append("## IGNITION\n")
+
+    # Add IGNITION configuration
+    if ignition_config:
+        lines.append("### Configuration\n")
+
+        # Define the configuration parameters to display
+        config_params = [
+            ("Slot Duration", ignition_config.get("SLOT_DURATION", "N/A")),
+            ("Epoch Duration", ignition_config.get("EPOCH_DURATION", "N/A")),
+            (
+                "Target Committee Size",
+                ignition_config.get("TARGET_COMMITTEE_SIZE", "N/A"),
+            ),
+            ("Mana Target", f"{ignition_config.get('MANA_TARGET', 0):,}"),
+        ]
+
+        # Calculate column widths
+        param_col_width = max(
+            len("Parameter"), max(len(param[0]) for param in config_params)
+        )
+        value_col_width = max(
+            len("Value"), max(len(str(param[1])) for param in config_params)
+        )
+
+        # Table header with proper spacing
+        header = f"| {'Parameter':<{param_col_width}} | {'Value':>{value_col_width}} |"
+        separator = f"|{'-' * (param_col_width + 2)}|{'-' * (value_col_width + 2)}|"
+
+        lines.append(header)
+        lines.append(separator)
+
+        # Add data rows with proper spacing
+        for param_name, param_value in config_params:
+            row = f"| {param_name:<{param_col_width}} | {param_value:>{value_col_width}} |"
+            lines.append(row)
+
+        lines.append("")
+
+    for config_name, gas_data in ignition_results.items():
+        config_display_name = BENCHMARK_CONFIGS[config_name]["name"]
+        lines.append(f"### {config_display_name} (IGNITION)\n")
+
+        # Get functions for this config in the desired order
+        config_functions = [f for f in function_order if f in gas_data]
+
+        if not config_functions:
+            lines.append("*No gas data available*\n")
+            continue
+
+        # Calculate column widths for proper alignment
+        func_col_width = max(len("Function"), max(len(f) for f in config_functions))
+        avg_col_width = max(
+            len("Avg"),
+            max(len(f"{gas_data[f].get('mean', 0):,}") for f in config_functions),
+        )
+        max_col_width = max(
+            len("Max"),
+            max(len(f"{gas_data[f].get('max', 0):,}") for f in config_functions),
+        )
+
+        # Table header with proper spacing
+        header = f"| {'Function':<{func_col_width}} | {'Avg':>{avg_col_width}} | {'Max':>{max_col_width}} |"
+        separator = f"|{'-' * (func_col_width + 2)}|{'-' * (avg_col_width + 2)}|{'-' * (max_col_width + 2)}|"
+
+        lines.append(header)
+        lines.append(separator)
+
+        # Add data rows with proper spacing
+        for func_name in config_functions:
+            func_data = gas_data[func_name]
+            avg_value = func_data.get("mean", 0)
+            max_value = func_data.get("max", 0)
+
+            row = f"| {func_name:<{func_col_width}} | {avg_value:>{avg_col_width},} | {max_value:>{max_col_width},} |"
+            lines.append(row)
+
+        lines.append("")  # Empty line between tables
+
+        # Calculate and add gas cost per second for IGNITION mode
+        if (
+            all(
+                func in gas_data
+                for func in ["setupEpoch", "propose", "submitEpochRootProof"]
+            )
+            and ignition_config
+        ):
+            slot_duration = ignition_config.get("SLOT_DURATION", 1)
+            epoch_duration = ignition_config.get("EPOCH_DURATION", 1)
+
+            # Get average gas values
+            setup_epoch_gas = gas_data["setupEpoch"].get("mean", 0)
+            propose_gas = gas_data["propose"].get("mean", 0)
+            submit_proof_gas = gas_data["submitEpochRootProof"].get("mean", 0)
+
+            # Calculate gas cost per second
+            total_epoch_gas = (
+                setup_epoch_gas + (propose_gas * epoch_duration) + submit_proof_gas
+            )
+            epoch_duration_seconds = slot_duration * epoch_duration
+            gas_per_second = (
+                total_epoch_gas / epoch_duration_seconds
+                if epoch_duration_seconds > 0
+                else 0
+            )
+
+            lines.append(
+                f"**Avg Gas Cost per Second**: {gas_per_second:,.1f} gas/second"
+            )
+            lines.append(
+                f"*(Epoch duration: {seconds_to_hms(epoch_duration_seconds)})*"
+            )
+            lines.append("")
+
+    # Then, add all Alpha results
+    lines.append("\n## Alpha\n")
+
+    # Add Alpha configuration
+    if alpha_config:
+        lines.append("### Configuration\n")
+
+        # Define the configuration parameters to display
+        config_params = [
+            ("Slot Duration", alpha_config.get("SLOT_DURATION", "N/A")),
+            ("Epoch Duration", alpha_config.get("EPOCH_DURATION", "N/A")),
+            ("Target Committee Size", alpha_config.get("TARGET_COMMITTEE_SIZE", "N/A")),
+            ("Mana Target", f"{alpha_config.get('MANA_TARGET', 0):,}"),
+        ]
+
+        # Calculate column widths
+        param_col_width = max(
+            len("Parameter"), max(len(param[0]) for param in config_params)
+        )
+        value_col_width = max(
+            len("Value"), max(len(str(param[1])) for param in config_params)
+        )
+
+        # Table header with proper spacing
+        header = f"| {'Parameter':<{param_col_width}} | {'Value':>{value_col_width}} |"
+        separator = f"|{'-' * (param_col_width + 2)}|{'-' * (value_col_width + 2)}|"
+
+        lines.append(header)
+        lines.append(separator)
+
+        # Add data rows with proper spacing
+        for param_name, param_value in config_params:
+            row = f"| {param_name:<{param_col_width}} | {param_value:>{value_col_width}} |"
+            lines.append(row)
+
+        lines.append("")
+
+    for config_name, gas_data in alpha_results.items():
+        config_display_name = BENCHMARK_CONFIGS[config_name]["name"]
+        lines.append(f"### {config_display_name} (Alpha)\n")
+
+        # Get functions for this config in the desired order
+        config_functions = [f for f in function_order if f in gas_data]
+
+        if not config_functions:
+            lines.append("*No gas data available*\n")
+            continue
+
+        # Calculate column widths for proper alignment
+        func_col_width = max(len("Function"), max(len(f) for f in config_functions))
+        avg_col_width = max(
+            len("Avg"),
+            max(len(f"{gas_data[f].get('mean', 0):,}") for f in config_functions),
+        )
+        max_col_width = max(
+            len("Max"),
+            max(len(f"{gas_data[f].get('max', 0):,}") for f in config_functions),
+        )
+
+        # Table header with proper spacing
+        header = f"| {'Function':<{func_col_width}} | {'Avg':>{avg_col_width}} | {'Max':>{max_col_width}} |"
+        separator = f"|{'-' * (func_col_width + 2)}|{'-' * (avg_col_width + 2)}|{'-' * (max_col_width + 2)}|"
+
+        lines.append(header)
+        lines.append(separator)
+
+        # Add data rows with proper spacing
+        for func_name in config_functions:
+            func_data = gas_data[func_name]
+            avg_value = func_data.get("mean", 0)
+            max_value = func_data.get("max", 0)
+
+            row = f"| {func_name:<{func_col_width}} | {avg_value:>{avg_col_width},} | {max_value:>{max_col_width},} |"
+            lines.append(row)
+
+        lines.append("")  # Empty line between tables
+
+        # Calculate and add gas cost per second for Alpha mode
+        if (
+            all(
+                func in gas_data
+                for func in ["setupEpoch", "propose", "submitEpochRootProof"]
+            )
+            and alpha_config
+        ):
+            slot_duration = alpha_config.get("SLOT_DURATION", 1)
+            epoch_duration = alpha_config.get("EPOCH_DURATION", 1)
+
+            # Get average gas values
+            setup_epoch_gas = gas_data["setupEpoch"].get("mean", 0)
+            propose_gas = gas_data["propose"].get("mean", 0)
+            submit_proof_gas = gas_data["submitEpochRootProof"].get("mean", 0)
+
+            # Calculate gas cost per second
+            total_epoch_gas = (
+                setup_epoch_gas + (propose_gas * epoch_duration) + submit_proof_gas
+            )
+            epoch_duration_seconds = slot_duration * epoch_duration
+            gas_per_second = (
+                total_epoch_gas / epoch_duration_seconds
+                if epoch_duration_seconds > 0
+                else 0
+            )
+
+            lines.append(f"**Gas Cost per Second**: {gas_per_second:,.1f} gas/second")
+            lines.append(
+                f"*(Epoch duration: {seconds_to_hms(epoch_duration_seconds)})*"
+            )
+            lines.append("")
+
+    # Write to file
+    with open(output_file, "w") as f:
+        f.write("\n".join(lines) + "\n")
+
+    print(f"\nMarkdown report saved to: {output_file}")
+
+
+def main():
+    """Main entry point."""
+
+    # Run benchmarks for each configuration with both IGNITION modes
+    ignition_results = {}
+    alpha_results = {}
+
+    # Extract configurations
+    print("Extracting configurations...")
+    ignition_config = extract_config(ignition=True)
+    alpha_config = extract_config(ignition=False)
+
+    # First, run all configurations with IGNITION=true
+    print(f"\n{'='*60}")
+    print("Running benchmarks with IGNITION=true")
+    print(f"{'='*60}")
+
+    for config_name, config in BENCHMARK_CONFIGS.items():
+        print(f"\n{'='*60}")
+        print(f"Running benchmark: {config['name']} (IGNITION)")
+        print(f"{'='*60}")
+
+        gas_data = run_benchmark_config(config, ignition=True)
+        ignition_results[config_name] = gas_data
+
+        # Show summary
+        print(f"\nExtracted gas data for {config['name']} (IGNITION):")
+        for func_name, data in gas_data.items():
+            print(
+                f"  - {func_name}: max={data.get('max', 'N/A'):,}, mean={data.get('mean', 'N/A'):,}"
+            )
+
+    # Then, run all configurations with IGNITION=false (Alpha)
+    print(f"\n\n{'='*60}")
+    print("Running benchmarks with IGNITION=false (Alpha)")
+    print(f"{'='*60}")
+
+    for config_name, config in BENCHMARK_CONFIGS.items():
+        print(f"\n{'='*60}")
+        print(f"Running benchmark: {config['name']} (Alpha)")
+        print(f"{'='*60}")
+
+        gas_data = run_benchmark_config(config, ignition=False)
+        alpha_results[config_name] = gas_data
+
+        # Show summary
+        print(f"\nExtracted gas data for {config['name']} (Alpha):")
+        for func_name, data in gas_data.items():
+            print(
+                f"  - {func_name}: max={data.get('max', 'N/A'):,}, mean={data.get('mean', 'N/A'):,}"
+            )
+
+    # Save raw results
+    all_results = {"ignition": ignition_results, "alpha": alpha_results}
+    with open("gas_benchmark_results.json", "w") as f:
+        json.dump(all_results, f, indent=2)
+    print(f"\nRaw results saved to: gas_benchmark_results.json")
+
+    # Generate markdown report
+    generate_markdown_report(
+        ignition_results, alpha_results, ignition_config, alpha_config
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/l1-contracts/scripts/gas_benchmarks.py
+++ b/l1-contracts/scripts/gas_benchmarks.py
@@ -302,6 +302,10 @@ def generate_markdown_report(
                 ignition_config.get("TARGET_COMMITTEE_SIZE", "N/A"),
             ),
             ("Mana Target", f"{ignition_config.get('MANA_TARGET', 0):,}"),
+            (
+                "Proofs per Epoch",
+                f"{ignition_config.get('PROOFS_PER_EPOCH', 200) / 100:.2f}",
+            ),
         ]
 
         # Calculate column widths
@@ -376,6 +380,9 @@ def generate_markdown_report(
         ):
             slot_duration = ignition_config.get("SLOT_DURATION", 1)
             epoch_duration = ignition_config.get("EPOCH_DURATION", 1)
+            proofs_per_epoch = (
+                ignition_config.get("PROOFS_PER_EPOCH", 200) / 100
+            )  # Convert from e2 to decimal
 
             # Get average gas values
             setup_epoch_gas = gas_data["setupEpoch"].get("mean", 0)
@@ -384,7 +391,9 @@ def generate_markdown_report(
 
             # Calculate gas cost per second
             total_epoch_gas = (
-                setup_epoch_gas + (propose_gas * epoch_duration) + submit_proof_gas
+                setup_epoch_gas
+                + (propose_gas * epoch_duration)
+                + (submit_proof_gas * proofs_per_epoch)
             )
             epoch_duration_seconds = slot_duration * epoch_duration
             gas_per_second = (
@@ -396,9 +405,7 @@ def generate_markdown_report(
             lines.append(
                 f"**Avg Gas Cost per Second**: {gas_per_second:,.1f} gas/second"
             )
-            lines.append(
-                f"*(Epoch duration: {seconds_to_hms(epoch_duration_seconds)})*"
-            )
+            lines.append(f"*Epoch duration*: {seconds_to_hms(epoch_duration_seconds)}")
             lines.append("")
 
     # Then, add all Alpha results
@@ -414,6 +421,10 @@ def generate_markdown_report(
             ("Epoch Duration", alpha_config.get("EPOCH_DURATION", "N/A")),
             ("Target Committee Size", alpha_config.get("TARGET_COMMITTEE_SIZE", "N/A")),
             ("Mana Target", f"{alpha_config.get('MANA_TARGET', 0):,}"),
+            (
+                "Proofs per Epoch",
+                f"{alpha_config.get('PROOFS_PER_EPOCH', 200) / 100:.2f}",
+            ),
         ]
 
         # Calculate column widths
@@ -488,6 +499,9 @@ def generate_markdown_report(
         ):
             slot_duration = alpha_config.get("SLOT_DURATION", 1)
             epoch_duration = alpha_config.get("EPOCH_DURATION", 1)
+            proofs_per_epoch = (
+                alpha_config.get("PROOFS_PER_EPOCH", 200) / 100
+            )  # Convert from e2 to decimal
 
             # Get average gas values
             setup_epoch_gas = gas_data["setupEpoch"].get("mean", 0)
@@ -496,7 +510,9 @@ def generate_markdown_report(
 
             # Calculate gas cost per second
             total_epoch_gas = (
-                setup_epoch_gas + (propose_gas * epoch_duration) + submit_proof_gas
+                setup_epoch_gas
+                + (propose_gas * epoch_duration)
+                + (submit_proof_gas * proofs_per_epoch)
             )
             epoch_duration_seconds = slot_duration * epoch_duration
             gas_per_second = (
@@ -505,10 +521,11 @@ def generate_markdown_report(
                 else 0
             )
 
-            lines.append(f"**Gas Cost per Second**: {gas_per_second:,.1f} gas/second")
             lines.append(
-                f"*(Epoch duration: {seconds_to_hms(epoch_duration_seconds)})*"
+                f"**Avg Gas Cost per Second**: {gas_per_second:,.1f} gas/second"
             )
+            lines.append(f"*Epoch duration*: {seconds_to_hms(epoch_duration_seconds)}")
+
             lines.append("")
 
     # Write to file

--- a/l1-contracts/scripts/generate_benchmark_json.py
+++ b/l1-contracts/scripts/generate_benchmark_json.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""
+Generate a flat benchmark JSON file from gas_benchmark_results.json
+This replaces the awk script in bootstrap.sh
+"""
+
+import json
+import sys
+from typing import Dict, List, Any
+
+
+def load_gas_results(filepath: str = "gas_benchmark_results.json") -> Dict[str, Any]:
+    """Load the gas benchmark results from JSON file."""
+    try:
+        with open(filepath, "r") as f:
+            return json.load(f)
+    except FileNotFoundError:
+        print(f"Error: Could not find {filepath}")
+        sys.exit(1)
+    except json.JSONDecodeError as e:
+        print(f"Error parsing JSON: {e}")
+        sys.exit(1)
+
+
+def load_config(mode: str) -> Dict[str, int]:
+    """Load configuration for a specific mode from the test contract."""
+    import subprocess
+    
+    command = [
+        "forge",
+        "test",
+        "--match-contract",
+        "BenchmarkRollupTest",
+        "--match-test",
+        "test_log_config",
+        "--fuzz-seed",
+        "42",
+        "-vv",
+        "--json",
+    ]
+    
+    env = subprocess.os.environ.copy()
+    env["IGNITION"] = "true" if mode == "ignition" else "false"
+    env.pop("FORGE_GAS_REPORT", None)
+    
+    try:
+        result = subprocess.run(
+            command, capture_output=True, text=True, check=True, env=env
+        )
+        
+        output = json.loads(result.stdout)
+        
+        # Extract config from decoded_logs
+        config = {}
+        for contract_data in output.values():
+            if isinstance(contract_data, dict) and "test_results" in contract_data:
+                for test_name, test_data in contract_data["test_results"].items():
+                    if "test_log_config" in test_name and "decoded_logs" in test_data:
+                        for log in test_data["decoded_logs"]:
+                            if ":" in log:
+                                parts = log.split(":", 1)
+                                if len(parts) == 2:
+                                    key = parts[0].strip()
+                                    value = parts[1].strip()
+                                    try:
+                                        config[key] = int(value)
+                                    except ValueError:
+                                        pass
+        
+        return config
+    except Exception as e:
+        print(f"Warning: Could not extract config for {mode}: {e}")
+        return {}
+
+
+def generate_flat_benchmark_list(gas_results: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Convert the nested gas results into a flat list of benchmark entries."""
+    benchmark_list = []
+    
+    # Load configurations
+    alpha_config = load_config("alpha")
+    ignition_config = load_config("ignition")
+    
+    # Process both ignition and alpha results
+    for mode, mode_results in gas_results.items():
+        for config_name, config_data in mode_results.items():
+            for function_name, gas_stats in config_data.items():
+                # Rename aggregate3 to proposeAndVote for consistency
+                display_function_name = function_name
+                if function_name == "aggregate3":
+                    display_function_name = "proposeAndVote"
+                
+                # Create the benchmark entry using mean value
+                benchmark_entry = {
+                    "name": f"{mode}/{config_name}/{display_function_name}",
+                    "value": gas_stats.get("mean", 0),
+                    "unit": "gas"
+                }
+                benchmark_list.append(benchmark_entry)
+            
+            # Add gas cost per second for all configurations
+            if all(func in config_data for func in ["setupEpoch", "propose", "submitEpochRootProof"]):
+                config = alpha_config if mode == "alpha" else ignition_config
+                if config:
+                    slot_duration = config.get("SLOT_DURATION", 36 if mode == "alpha" else 60)
+                    epoch_duration = config.get("EPOCH_DURATION", 32 if mode == "alpha" else 48)
+                    
+                    # Get average gas values
+                    setup_epoch_gas = config_data["setupEpoch"].get("mean", 0)
+                    propose_gas = config_data["propose"].get("mean", 0)
+                    submit_proof_gas = config_data["submitEpochRootProof"].get("mean", 0)
+                    
+                    # Calculate gas cost per second
+                    total_epoch_gas = setup_epoch_gas + (propose_gas * epoch_duration) + submit_proof_gas
+                    epoch_duration_seconds = slot_duration * epoch_duration
+                    gas_per_second = total_epoch_gas / epoch_duration_seconds if epoch_duration_seconds > 0 else 0
+                    
+                    # Add gas per second benchmark entry
+                    benchmark_entry = {
+                        "name": f"{mode}/{config_name}/gasPerSecond",
+                        "value": round(gas_per_second, 1),
+                        "unit": "gas/second"
+                    }
+                    benchmark_list.append(benchmark_entry)
+    
+    return benchmark_list
+
+
+def save_benchmark_json(benchmark_list: List[Dict[str, Any]], output_file: str = "bench-out/l1-gas.bench.json"):
+    """Save the benchmark list to JSON file."""
+    # Ensure the output directory exists
+    import os
+    output_dir = os.path.dirname(output_file)
+    if output_dir and not os.path.exists(output_dir):
+        os.makedirs(output_dir)
+    
+    with open(output_file, "w") as f:
+        json.dump(benchmark_list, f, indent=2)
+    print(f"Benchmark JSON saved to: {output_file}")
+
+
+def main():
+    """Main entry point."""
+    # Load gas results
+    gas_results = load_gas_results()
+    
+    # Generate flat benchmark list
+    benchmark_list = generate_flat_benchmark_list(gas_results)
+    
+    # Sort the list by name for consistency
+    benchmark_list.sort(key=lambda x: x["name"])
+    
+    # Save to JSON file
+    save_benchmark_json(benchmark_list)
+    
+    # Print summary
+    print(f"Generated {len(benchmark_list)} benchmark entries")
+    
+    # Optionally print the results
+    if "--print" in sys.argv:
+        print("\nBenchmark entries:")
+        for entry in benchmark_list:
+            print(f"  {entry['name']}: {entry['value']:,} {entry['unit']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/l1-contracts/scripts/generate_benchmark_json.py
+++ b/l1-contracts/scripts/generate_benchmark_json.py
@@ -104,6 +104,7 @@ def generate_flat_benchmark_list(gas_results: Dict[str, Any]) -> List[Dict[str, 
                 if config:
                     slot_duration = config.get("SLOT_DURATION", 36 if mode == "alpha" else 60)
                     epoch_duration = config.get("EPOCH_DURATION", 32 if mode == "alpha" else 48)
+                    proofs_per_epoch = config.get("PROOFS_PER_EPOCH", 200) / 100  # Convert from e2 to decimal
                     
                     # Get average gas values
                     setup_epoch_gas = config_data["setupEpoch"].get("mean", 0)
@@ -111,7 +112,7 @@ def generate_flat_benchmark_list(gas_results: Dict[str, Any]) -> List[Dict[str, 
                     submit_proof_gas = config_data["submitEpochRootProof"].get("mean", 0)
                     
                     # Calculate gas cost per second
-                    total_epoch_gas = setup_epoch_gas + (propose_gas * epoch_duration) + submit_proof_gas
+                    total_epoch_gas = setup_epoch_gas + (propose_gas * epoch_duration) + (submit_proof_gas * proofs_per_epoch)
                     epoch_duration_seconds = slot_duration * epoch_duration
                     gas_per_second = total_epoch_gas / epoch_duration_seconds if epoch_duration_seconds > 0 else 0
                     

--- a/l1-contracts/test/benchmark/happy.t.sol
+++ b/l1-contracts/test/benchmark/happy.t.sol
@@ -122,6 +122,7 @@ contract BenchmarkRollupTest is FeeModelTestPoints, DecoderBase {
   uint256 internal EPOCH_DURATION;
   uint256 internal MANA_TARGET;
   uint256 internal TARGET_COMMITTEE_SIZE;
+  uint256 internal PROOFS_PER_EPOCH; // given as e2, for simple decimals, e.g., 200 = 2.00
   uint256 internal VOTING_ROUND_SIZE = 500;
 
   Rollup internal rollup;
@@ -189,6 +190,7 @@ contract BenchmarkRollupTest is FeeModelTestPoints, DecoderBase {
       EPOCH_DURATION = 48;
       MANA_TARGET = 0;
       TARGET_COMMITTEE_SIZE = 24;
+      PROOFS_PER_EPOCH = 200; // 2.00
     } else {
       full = load("single_tx_block_1");
 
@@ -196,6 +198,7 @@ contract BenchmarkRollupTest is FeeModelTestPoints, DecoderBase {
       EPOCH_DURATION = 32;
       MANA_TARGET = 1e8;
       TARGET_COMMITTEE_SIZE = 48;
+      PROOFS_PER_EPOCH = 200; // 2.00
     }
 
     FeeLib.initialize(MANA_TARGET, EthValue.wrap(100));
@@ -212,6 +215,7 @@ contract BenchmarkRollupTest is FeeModelTestPoints, DecoderBase {
     emit log_named_uint("EPOCH_DURATION", EPOCH_DURATION);
     emit log_named_uint("MANA_TARGET", MANA_TARGET);
     emit log_named_uint("TARGET_COMMITTEE_SIZE", TARGET_COMMITTEE_SIZE);
+    emit log_named_uint("PROOFS_PER_EPOCH", PROOFS_PER_EPOCH);
   }
 
   function test_no_validators() public prepare(0, true) {


### PR DESCRIPTION
Altering the solidity benchmark file generation such that it is simpler to follow by not using `awk` but also making it a bit more elaborate to produce results for both ignition and alpha configurations in one go, making it simpler to get an idea of the "real" costs and not "the costs that the benchmark config have". The configuration is added to the markdown file, and the gas per second is also added to both benchmark and markdown doc. 

I tried to group the benchmarks into different configs so they hopefully are easier to jump around in at the benchmark page.

Updated the l1 metadata loaded in benchmark slightly to better accomedate longer l2 block times without running out of data.