### PR TITLE
fix!: use unique leaf id to nullify consumed l2ToL1Msg

### DIFF
--- a/l1-contracts/src/core/interfaces/messagebridge/IOutbox.sol
+++ b/l1-contracts/src/core/interfaces/messagebridge/IOutbox.sol
@@ -16,7 +16,7 @@ interface IOutbox {
     uint256 indexed l2BlockNumber,
     bytes32 indexed root,
     bytes32 indexed messageHash,
-    uint256 leafIndex
+    uint256 leafId
   );
 
   // docs:start:outbox_insert
@@ -53,12 +53,12 @@ interface IOutbox {
 
   // docs:start:outbox_has_message_been_consumed_at_block_and_index
   /**
-   * @notice Checks to see if an index of the L2 to L1 message tree for a specific block has been consumed
+   * @notice Checks to see if an L2 to L1 message in a specific block has been consumed
    * @dev - This function does not throw. Out-of-bounds access is considered valid, but will always return false
-   * @param _l2BlockNumber - The block number specifying the block that contains the index of the message we want to check
-   * @param _leafIndex - The index of the message inside the merkle tree
+   * @param _l2BlockNumber - The block number specifying the block that contains the message we want to check
+   * @param _leafId - The unique id of the message leaf
    */
-  function hasMessageBeenConsumedAtBlockAndIndex(uint256 _l2BlockNumber, uint256 _leafIndex)
+  function hasMessageBeenConsumedAtBlock(uint256 _l2BlockNumber, uint256 _leafId)
     external
     view
     returns (bool);

--- a/l1-contracts/src/core/interfaces/messagebridge/IOutbox.sol
+++ b/l1-contracts/src/core/interfaces/messagebridge/IOutbox.sol
@@ -13,10 +13,7 @@ import {DataStructures} from "../../libraries/DataStructures.sol";
 interface IOutbox {
   event RootAdded(uint256 indexed l2BlockNumber, bytes32 indexed root);
   event MessageConsumed(
-    uint256 indexed l2BlockNumber,
-    bytes32 indexed root,
-    bytes32 indexed messageHash,
-    uint256 leafId
+    uint256 indexed l2BlockNumber, bytes32 indexed root, bytes32 indexed messageHash, uint256 leafId
   );
 
   // docs:start:outbox_insert

--- a/l1-contracts/src/core/messagebridge/Outbox.sol
+++ b/l1-contracts/src/core/messagebridge/Outbox.sol
@@ -92,37 +92,38 @@ contract Outbox is IOutbox {
 
     require(blockRoot != bytes32(0), Errors.Outbox__NothingToConsumeAtBlock(_l2BlockNumber));
 
+    uint256 leafId = (1 << (_path.length)) + _leafIndex;
+
     require(
-      !rootData.nullified.get(_leafIndex),
-      Errors.Outbox__AlreadyNullified(_l2BlockNumber, _leafIndex)
+      !rootData.nullified.get(leafId), Errors.Outbox__AlreadyNullified(_l2BlockNumber, leafId)
     );
 
     bytes32 messageHash = _message.sha256ToField();
 
     MerkleLib.verifyMembership(_path, messageHash, _leafIndex, blockRoot);
 
-    rootData.nullified.set(_leafIndex);
+    rootData.nullified.set(leafId);
 
-    emit MessageConsumed(_l2BlockNumber, blockRoot, messageHash, _leafIndex);
+    emit MessageConsumed(_l2BlockNumber, blockRoot, messageHash, leafId);
   }
 
   /**
-   * @notice Checks to see if an index of the L2 to L1 message tree for a specific block has been consumed
+   * @notice Checks to see if an L2 to L1 message in a specific block has been consumed
    *
    * @dev - This function does not throw. Out-of-bounds access is considered valid, but will always return false
    *
-   * @param _l2BlockNumber - The block number specifying the block that contains the index of the message we want to check
-   * @param _leafIndex - The index of the message inside the merkle tree
+   * @param _l2BlockNumber - The block number specifying the block that contains the message we want to check
+   * @param _leafId - The unique id of the message leaf
    *
    * @return bool - True if the message has been consumed, false otherwise
    */
-  function hasMessageBeenConsumedAtBlockAndIndex(uint256 _l2BlockNumber, uint256 _leafIndex)
+  function hasMessageBeenConsumedAtBlock(uint256 _l2BlockNumber, uint256 _leafId)
     external
     view
     override(IOutbox)
     returns (bool)
   {
-    return roots[_l2BlockNumber].nullified.get(_leafIndex);
+    return roots[_l2BlockNumber].nullified.get(_leafId);
   }
 
   /**

--- a/l1-contracts/src/core/messagebridge/Outbox.sol
+++ b/l1-contracts/src/core/messagebridge/Outbox.sol
@@ -92,7 +92,7 @@ contract Outbox is IOutbox {
 
     require(blockRoot != bytes32(0), Errors.Outbox__NothingToConsumeAtBlock(_l2BlockNumber));
 
-    uint256 leafId = (1 << (_path.length)) + _leafIndex;
+    uint256 leafId = (1 << _path.length) + _leafIndex;
 
     require(
       !rootData.nullified.get(leafId), Errors.Outbox__AlreadyNullified(_l2BlockNumber, leafId)

--- a/l1-contracts/test/Outbox.t.sol
+++ b/l1-contracts/test/Outbox.t.sol
@@ -155,7 +155,7 @@ contract OutboxTest is Test {
     outbox.insert(1, root);
 
     uint256 leafIndex = 0;
-    uint256 leafId = 2 ** DEFAULT_TREE_HEIGHT;
+    uint256 leafId = 2 ** DEFAULT_TREE_HEIGHT + leafIndex;
     (bytes32[] memory path,) = tree.computeSiblingPath(leafIndex);
     outbox.consume(fakeMessage, 1, leafIndex, path);
 
@@ -243,7 +243,7 @@ contract OutboxTest is Test {
     outbox.insert(1, root);
 
     uint256 leafIndex = 0;
-    uint256 leafId = 2 ** DEFAULT_TREE_HEIGHT;
+    uint256 leafId = 2 ** DEFAULT_TREE_HEIGHT + leafIndex;
     (bytes32[] memory path,) = tree.computeSiblingPath(leafIndex);
 
     bool statusBeforeConsumption = outbox.hasMessageBeenConsumedAtBlock(1, leafId);

--- a/l1-contracts/test/Outbox.t.sol
+++ b/l1-contracts/test/Outbox.t.sol
@@ -40,14 +40,18 @@ contract OutboxTest is Test {
     merkleTestUtil = new MerkleTestUtil();
   }
 
-  function _fakeMessage(address _recipient) internal view returns (DataStructures.L2ToL1Msg memory) {
+  function _fakeMessage(address _recipient, uint256 _content)
+    internal
+    view
+    returns (DataStructures.L2ToL1Msg memory)
+  {
     return DataStructures.L2ToL1Msg({
       sender: DataStructures.L2Actor({
         actor: 0x2000000000000000000000000000000000000000000000000000000000000000,
         version: AZTEC_VERSION
       }),
       recipient: DataStructures.L1Actor({actor: _recipient, chainId: block.chainid}),
-      content: 0x3000000000000000000000000000000000000000000000000000000000000000
+      content: bytes32(_content)
     });
   }
 
@@ -92,7 +96,7 @@ contract OutboxTest is Test {
   }
 
   function testRevertIfConsumingMessageBelongingToOther() public {
-    DataStructures.L2ToL1Msg memory fakeMessage = _fakeMessage(address(this));
+    DataStructures.L2ToL1Msg memory fakeMessage = _fakeMessage(address(this), 123);
 
     (bytes32[] memory path,) = zeroedTree.computeSiblingPath(0);
 
@@ -104,7 +108,7 @@ contract OutboxTest is Test {
   }
 
   function testRevertIfConsumingMessageWithInvalidChainId() public {
-    DataStructures.L2ToL1Msg memory fakeMessage = _fakeMessage(address(this));
+    DataStructures.L2ToL1Msg memory fakeMessage = _fakeMessage(address(this), 123);
 
     (bytes32[] memory path,) = zeroedTree.computeSiblingPath(0);
 
@@ -115,7 +119,7 @@ contract OutboxTest is Test {
   }
 
   function testRevertIfVersionMismatch() public {
-    DataStructures.L2ToL1Msg memory message = _fakeMessage(address(this));
+    DataStructures.L2ToL1Msg memory message = _fakeMessage(address(this), 123);
     (bytes32[] memory path,) = zeroedTree.computeSiblingPath(0);
 
     message.sender.version = AZTEC_VERSION + 1;
@@ -129,7 +133,7 @@ contract OutboxTest is Test {
 
   function testRevertIfNothingInsertedAtBlockNumber() public {
     uint256 blockNumber = 1;
-    DataStructures.L2ToL1Msg memory fakeMessage = _fakeMessage(address(this));
+    DataStructures.L2ToL1Msg memory fakeMessage = _fakeMessage(address(this), 123);
 
     (bytes32[] memory path,) = zeroedTree.computeSiblingPath(0);
 
@@ -140,7 +144,7 @@ contract OutboxTest is Test {
   }
 
   function testRevertIfTryingToConsumeSameMessage() public {
-    DataStructures.L2ToL1Msg memory fakeMessage = _fakeMessage(address(this));
+    DataStructures.L2ToL1Msg memory fakeMessage = _fakeMessage(address(this), 123);
     bytes32 leaf = fakeMessage.sha256ToField();
 
     NaiveMerkle tree = new NaiveMerkle(DEFAULT_TREE_HEIGHT);
@@ -150,14 +154,17 @@ contract OutboxTest is Test {
     vm.prank(ROLLUP_CONTRACT);
     outbox.insert(1, root);
 
-    (bytes32[] memory path,) = tree.computeSiblingPath(0);
-    outbox.consume(fakeMessage, 1, 0, path);
-    vm.expectRevert(abi.encodeWithSelector(Errors.Outbox__AlreadyNullified.selector, 1, 0));
-    outbox.consume(fakeMessage, 1, 0, path);
+    uint256 leafIndex = 0;
+    uint256 leafId = 2 ** DEFAULT_TREE_HEIGHT;
+    (bytes32[] memory path,) = tree.computeSiblingPath(leafIndex);
+    outbox.consume(fakeMessage, 1, leafIndex, path);
+
+    vm.expectRevert(abi.encodeWithSelector(Errors.Outbox__AlreadyNullified.selector, 1, leafId));
+    outbox.consume(fakeMessage, 1, leafIndex, path);
   }
 
   function testRevertIfPathHeightMismatch() public {
-    DataStructures.L2ToL1Msg memory fakeMessage = _fakeMessage(address(this));
+    DataStructures.L2ToL1Msg memory fakeMessage = _fakeMessage(address(this), 123);
     bytes32 leaf = fakeMessage.sha256ToField();
 
     NaiveMerkle tree = new NaiveMerkle(DEFAULT_TREE_HEIGHT);
@@ -179,7 +186,7 @@ contract OutboxTest is Test {
   }
 
   function testRevertIfTryingToConsumeMessageNotInTree() public {
-    DataStructures.L2ToL1Msg memory fakeMessage = _fakeMessage(address(this));
+    DataStructures.L2ToL1Msg memory fakeMessage = _fakeMessage(address(this), 123);
     bytes32 leaf = fakeMessage.sha256ToField();
     fakeMessage.content = bytes32(uint256(42069));
     bytes32 modifiedLeaf = fakeMessage.sha256ToField();
@@ -208,7 +215,7 @@ contract OutboxTest is Test {
   function testRevertIfConsumingFromTreeNotProven() public {
     FakeRollup(ROLLUP_CONTRACT).setProvenBlockNum(0);
 
-    DataStructures.L2ToL1Msg memory fakeMessage = _fakeMessage(address(this));
+    DataStructures.L2ToL1Msg memory fakeMessage = _fakeMessage(address(this), 123);
     bytes32 leaf = fakeMessage.sha256ToField();
 
     NaiveMerkle tree = new NaiveMerkle(DEFAULT_TREE_HEIGHT);
@@ -219,16 +226,13 @@ contract OutboxTest is Test {
     outbox.insert(1, root);
 
     (bytes32[] memory path,) = tree.computeSiblingPath(0);
-
-    bool statusBeforeConsumption = outbox.hasMessageBeenConsumedAtBlockAndIndex(1, 0);
-    assertEq(abi.encode(0), abi.encode(statusBeforeConsumption));
 
     vm.expectRevert(abi.encodeWithSelector(Errors.Outbox__BlockNotProven.selector, 1));
     outbox.consume(fakeMessage, 1, 0, path);
   }
 
   function testValidInsertAndConsume() public {
-    DataStructures.L2ToL1Msg memory fakeMessage = _fakeMessage(address(this));
+    DataStructures.L2ToL1Msg memory fakeMessage = _fakeMessage(address(this), 123);
     bytes32 leaf = fakeMessage.sha256ToField();
 
     NaiveMerkle tree = new NaiveMerkle(DEFAULT_TREE_HEIGHT);
@@ -238,16 +242,18 @@ contract OutboxTest is Test {
     vm.prank(ROLLUP_CONTRACT);
     outbox.insert(1, root);
 
-    (bytes32[] memory path,) = tree.computeSiblingPath(0);
+    uint256 leafIndex = 0;
+    uint256 leafId = 2 ** DEFAULT_TREE_HEIGHT;
+    (bytes32[] memory path,) = tree.computeSiblingPath(leafIndex);
 
-    bool statusBeforeConsumption = outbox.hasMessageBeenConsumedAtBlockAndIndex(1, 0);
+    bool statusBeforeConsumption = outbox.hasMessageBeenConsumedAtBlock(1, leafId);
     assertEq(abi.encode(0), abi.encode(statusBeforeConsumption));
 
     vm.expectEmit(true, true, true, true, address(outbox));
-    emit IOutbox.MessageConsumed(1, root, leaf, 0);
-    outbox.consume(fakeMessage, 1, 0, path);
+    emit IOutbox.MessageConsumed(1, root, leaf, leafId);
+    outbox.consume(fakeMessage, 1, leafIndex, path);
 
-    bool statusAfterConsumption = outbox.hasMessageBeenConsumedAtBlockAndIndex(1, 0);
+    bool statusAfterConsumption = outbox.hasMessageBeenConsumedAtBlock(1, leafId);
     assertEq(abi.encode(1), abi.encode(statusAfterConsumption));
   }
 
@@ -267,7 +273,7 @@ contract OutboxTest is Test {
     NaiveMerkle tree = new NaiveMerkle(treeHeight);
 
     for (uint256 i = 0; i < numberOfMessages; i++) {
-      DataStructures.L2ToL1Msg memory fakeMessage = _fakeMessage(_recipients[i]);
+      DataStructures.L2ToL1Msg memory fakeMessage = _fakeMessage(_recipients[i], 123);
       messages[i] = fakeMessage;
       bytes32 modifiedLeaf = fakeMessage.sha256ToField();
 
@@ -283,16 +289,17 @@ contract OutboxTest is Test {
 
     for (uint256 i = 0; i < numberOfMessages; i++) {
       (bytes32[] memory path, bytes32 leaf) = tree.computeSiblingPath(i);
+      uint256 leafId = 2 ** treeHeight + i;
 
       vm.expectEmit(true, true, true, true, address(outbox));
-      emit IOutbox.MessageConsumed(blockNumber, root, leaf, i);
+      emit IOutbox.MessageConsumed(blockNumber, root, leaf, leafId);
       vm.prank(_recipients[i]);
       outbox.consume(messages[i], blockNumber, i, path);
     }
   }
 
-  function testCheckOutOfBoundsStatus(uint256 _blockNumber, uint256 _leafIndex) public view {
-    bool outOfBounds = outbox.hasMessageBeenConsumedAtBlockAndIndex(_blockNumber, _leafIndex);
+  function testCheckOutOfBoundsStatus(uint256 _blockNumber, uint256 _leafId) public view {
+    bool outOfBounds = outbox.hasMessageBeenConsumedAtBlock(_blockNumber, _leafId);
     assertFalse(outOfBounds);
   }
 
@@ -312,6 +319,295 @@ contract OutboxTest is Test {
     {
       bytes32 actualRoot = outbox.getRootData(2);
       assertEq(bytes32(0), actualRoot);
+    }
+  }
+
+  function testConsumeOneOutHashAsRoot() public {
+    DataStructures.L2ToL1Msg memory fakeMessage = _fakeMessage(address(this), 123);
+    bytes32 leaf = fakeMessage.sha256ToField();
+
+    // There's only 1 message in the entire block, so the root is the leaf.
+    bytes32 root = leaf;
+
+    vm.prank(ROLLUP_CONTRACT);
+    outbox.insert(1, leaf);
+
+    uint256 leafIndex = 0;
+    uint256 leafId = 1;
+
+    bool statusBeforeConsumption = outbox.hasMessageBeenConsumedAtBlock(1, leafId);
+    assertEq(abi.encode(0), abi.encode(statusBeforeConsumption));
+
+    vm.expectEmit(true, true, true, true, address(outbox));
+    emit IOutbox.MessageConsumed(1, root, leaf, leafId);
+    bytes32[] memory path = new bytes32[](0);
+    outbox.consume(fakeMessage, 1, leafIndex, path);
+
+    bool statusAfterConsumption = outbox.hasMessageBeenConsumedAtBlock(1, leafId);
+    assertEq(abi.encode(1), abi.encode(statusAfterConsumption));
+  }
+
+  function testConsumeMessagesInWonkyTree() public {
+    DataStructures.L2ToL1Msg[] memory fakeMessages = new DataStructures.L2ToL1Msg[](3);
+    bytes32[] memory leaves = new bytes32[](3);
+    for (uint256 i = 0; i < 3; i++) {
+      fakeMessages[i] = _fakeMessage(address(this), i);
+      leaves[i] = fakeMessages[i].sha256ToField();
+    }
+    uint256 blockNumber = 1;
+
+    // Build a wonky tree of 3 txs. Each tx has 1 message, so the txOutHash equals the only leaf.
+    //    outHash
+    //     /   \
+    //    .   tx2
+    //  /   \
+    // tx0 tx1
+
+    // First, build the left subtree with 2 leaves.
+    // subtreeRoot
+    //  /  \
+    // tx0 tx1
+    NaiveMerkle subtree = new NaiveMerkle(1);
+    subtree.insertLeaf(leaves[0]);
+    subtree.insertLeaf(leaves[1]);
+    bytes32 subtreeRoot = subtree.computeRoot();
+
+    // Then, build the top tree with the subtree root and the last leaf.
+    //      outHash
+    //   /          \
+    // subtreeRoot tx2
+    NaiveMerkle topTree = new NaiveMerkle(1);
+    topTree.insertLeaf(subtreeRoot);
+    topTree.insertLeaf(leaves[2]);
+    bytes32 root = topTree.computeRoot();
+
+    vm.prank(ROLLUP_CONTRACT);
+    outbox.insert(blockNumber, root);
+
+    // Consume the message of tx0.
+    {
+      uint256 msgIndex = 0;
+      uint256 leafIndex = 0;
+      uint256 leafId = 2 ** 2;
+      bytes32[] memory path = new bytes32[](2);
+      {
+        (bytes32[] memory subtreePath,) = subtree.computeSiblingPath(0);
+        (bytes32[] memory topTreePath,) = topTree.computeSiblingPath(0);
+        path[0] = subtreePath[0];
+        path[1] = topTreePath[0];
+      }
+      outbox.consume(fakeMessages[msgIndex], blockNumber, leafIndex, path);
+
+      vm.expectRevert(
+        abi.encodeWithSelector(Errors.Outbox__AlreadyNullified.selector, blockNumber, leafId)
+      );
+      outbox.consume(fakeMessages[msgIndex], blockNumber, leafIndex, path);
+    }
+
+    // Consume the message of tx1.
+    {
+      uint256 msgIndex = 1;
+      uint256 leafIndex = 1;
+      uint256 leafId = 2 ** 2 + 1;
+      bytes32[] memory path = new bytes32[](2);
+      {
+        (bytes32[] memory subtreePath,) = subtree.computeSiblingPath(1);
+        (bytes32[] memory topTreePath,) = topTree.computeSiblingPath(0);
+        path[0] = subtreePath[0];
+        path[1] = topTreePath[0];
+      }
+      outbox.consume(fakeMessages[msgIndex], blockNumber, leafIndex, path);
+
+      vm.expectRevert(
+        abi.encodeWithSelector(Errors.Outbox__AlreadyNullified.selector, blockNumber, leafId)
+      );
+      outbox.consume(fakeMessages[msgIndex], blockNumber, leafIndex, path);
+    }
+
+    // Consume the message of tx2.
+    {
+      uint256 msgIndex = 2;
+      uint256 leafIndex = 1;
+      uint256 leafId = 2 ** 1 + 1;
+      (bytes32[] memory path,) = topTree.computeSiblingPath(1);
+      outbox.consume(fakeMessages[msgIndex], blockNumber, leafIndex, path);
+
+      vm.expectRevert(
+        abi.encodeWithSelector(Errors.Outbox__AlreadyNullified.selector, blockNumber, leafId)
+      );
+      outbox.consume(fakeMessages[msgIndex], blockNumber, leafIndex, path);
+    }
+  }
+
+  function testConsumeMessagesInWonkyWonkyTree() public {
+    // Test with a wonky tree of 3 txs:
+    // - tx0 has 1 message.
+    // - tx1 has 3 messages.
+    // - tx2 has 3 messages.
+
+    DataStructures.L2ToL1Msg[] memory fakeMessages = new DataStructures.L2ToL1Msg[](7);
+    bytes32[] memory leaves = new bytes32[](7);
+    for (uint256 i = 0; i < 7; i++) {
+      fakeMessages[i] = _fakeMessage(address(this), i);
+      leaves[i] = fakeMessages[i].sha256ToField();
+    }
+    uint256 blockNumber = 1;
+
+    bytes32[] memory txOutHashes = new bytes32[](3);
+
+    // tx0 has 1 message, the message leaf is the root.
+    txOutHashes[0] = leaves[0];
+
+    // Build the subtree of tx1 with 3 message.
+    bytes32 tx1SubtreeRoot;
+    {
+      NaiveMerkle subtree = new NaiveMerkle(1);
+      subtree.insertLeaf(leaves[1]);
+      subtree.insertLeaf(leaves[2]);
+      tx1SubtreeRoot = subtree.computeRoot();
+      NaiveMerkle topTree = new NaiveMerkle(1);
+      topTree.insertLeaf(tx1SubtreeRoot);
+      topTree.insertLeaf(leaves[3]);
+      txOutHashes[1] = topTree.computeRoot();
+    }
+
+    // Build the subtree of tx2 with 3 messages.
+    bytes32 tx2SubtreeRoot;
+    {
+      NaiveMerkle tx2Subtree = new NaiveMerkle(1);
+      NaiveMerkle tx2TopTree = new NaiveMerkle(1);
+      tx2Subtree.insertLeaf(leaves[4]);
+      tx2Subtree.insertLeaf(leaves[5]);
+      tx2SubtreeRoot = tx2Subtree.computeRoot();
+      tx2TopTree.insertLeaf(tx2SubtreeRoot);
+      tx2TopTree.insertLeaf(leaves[6]);
+      txOutHashes[2] = tx2TopTree.computeRoot();
+    }
+
+    // Build a wonky tree of 3 txs.
+    //    outHash
+    //     /  \
+    //    .   tx2
+    //  /  \
+    // tx0 tx1
+
+    // First, build the left subtree with 2 txOutHashes.
+    // subtreeRoot
+    //  /  \
+    // tx0 tx1
+    bytes32 subtreeRoot;
+    {
+      NaiveMerkle subtree = new NaiveMerkle(1);
+      subtree.insertLeaf(txOutHashes[0]);
+      subtree.insertLeaf(txOutHashes[1]);
+      subtreeRoot = subtree.computeRoot();
+    }
+
+    // Then, build the top tree with the subtree root and the last txOutHash.
+    //      outHash
+    //    /        \
+    // subtreeRoot tx2
+    {
+      NaiveMerkle topTree = new NaiveMerkle(1);
+      topTree.insertLeaf(subtreeRoot);
+      topTree.insertLeaf(txOutHashes[2]);
+      bytes32 root = topTree.computeRoot();
+
+      vm.prank(ROLLUP_CONTRACT);
+      outbox.insert(blockNumber, root);
+    }
+
+    // Consume messages[0] in tx0.
+    {
+      //    outHash
+      //     /  \
+      //    .   tx2
+      //   /  \
+      //  m0  tx1
+      uint256 msgIndex = 0;
+      uint256 leafIndex = 0;
+      uint256 leafId = 2 ** 2;
+      bytes32[] memory path = new bytes32[](2);
+      path[0] = txOutHashes[1];
+      path[1] = txOutHashes[2];
+      outbox.consume(fakeMessages[msgIndex], blockNumber, leafIndex, path);
+
+      vm.expectRevert(
+        abi.encodeWithSelector(Errors.Outbox__AlreadyNullified.selector, blockNumber, leafId)
+      );
+      outbox.consume(fakeMessages[msgIndex], blockNumber, leafIndex, path);
+    }
+
+    // Consume messages[2] in tx1.
+    {
+      //    outHash
+      //     /  \
+      //    .   tx2
+      //   /  \
+      // tx0  tx1
+      //      / \
+      //    .   m3
+      //   / \
+      //  m1 m2
+      uint256 msgIndex = 2;
+      uint256 leafIndex = 5; // Leaf at index 5 in a balanced tree of height 4.
+      uint256 leafId = 2 ** 4 + leafIndex;
+      bytes32[] memory path = new bytes32[](4);
+      path[0] = leaves[1];
+      path[1] = leaves[3];
+      path[2] = txOutHashes[0];
+      path[3] = txOutHashes[2];
+      outbox.consume(fakeMessages[msgIndex], blockNumber, leafIndex, path);
+
+      vm.expectRevert(
+        abi.encodeWithSelector(Errors.Outbox__AlreadyNullified.selector, blockNumber, leafId)
+      );
+      outbox.consume(fakeMessages[msgIndex], blockNumber, leafIndex, path);
+    }
+
+    // Consume messages[4] in tx2.
+    {
+      //    outHash
+      //     /  \
+      //    .   tx2
+      //        /  \
+      //       .   m6
+      //     /  \
+      //    m4 m5
+      uint256 msgIndex = 4;
+      uint256 leafIndex = 4; // Leaf at index 4 in a balanced tree of height 3.
+      uint256 leafId = 2 ** 3 + leafIndex;
+      bytes32[] memory path = new bytes32[](3);
+      path[0] = leaves[5];
+      path[1] = leaves[6];
+      path[2] = subtreeRoot;
+      outbox.consume(fakeMessages[msgIndex], blockNumber, leafIndex, path);
+
+      vm.expectRevert(
+        abi.encodeWithSelector(Errors.Outbox__AlreadyNullified.selector, blockNumber, leafId)
+      );
+      outbox.consume(fakeMessages[msgIndex], blockNumber, leafIndex, path);
+    }
+
+    // Consume messages[6] in tx2.
+    {
+      //    outHash
+      //     /  \
+      //    .   tx2
+      //        /  \
+      //       .   m6
+      uint256 msgIndex = 6;
+      uint256 leafIndex = 3; // Leaf at index 3 in a balanced tree of height 2.
+      uint256 leafId = 2 ** 2 + leafIndex;
+      bytes32[] memory path = new bytes32[](2);
+      path[0] = tx2SubtreeRoot;
+      path[1] = subtreeRoot;
+      outbox.consume(fakeMessages[msgIndex], blockNumber, leafIndex, path);
+
+      vm.expectRevert(
+        abi.encodeWithSelector(Errors.Outbox__AlreadyNullified.selector, blockNumber, leafId)
+      );
+      outbox.consume(fakeMessages[msgIndex], blockNumber, leafIndex, path);
     }
   }
 }

--- a/l1-contracts/test/portals/TokenPortal.t.sol
+++ b/l1-contracts/test/portals/TokenPortal.t.sol
@@ -284,9 +284,12 @@ contract TokenPortalTest is Test {
     (bytes32 l2ToL1Message, bytes32[] memory siblingPath, bytes32 treeRoot) =
       _addWithdrawMessageInOutbox(address(this), l2BlockNumber);
 
+    uint256 leafIndex = 0;
+    uint256 leafId = 2 ** siblingPath.length;
+
     vm.expectEmit(true, true, true, true);
-    emit IOutbox.MessageConsumed(l2BlockNumber, treeRoot, l2ToL1Message, 0);
-    tokenPortal.withdraw(recipient, withdrawAmount, true, l2BlockNumber, 0, siblingPath);
+    emit IOutbox.MessageConsumed(l2BlockNumber, treeRoot, l2ToL1Message, leafId);
+    tokenPortal.withdraw(recipient, withdrawAmount, true, l2BlockNumber, leafIndex, siblingPath);
 
     // Should have received 654 RNA tokens
     assertEq(testERC20.balanceOf(recipient), withdrawAmount);

--- a/l1-contracts/test/portals/TokenPortal.t.sol
+++ b/l1-contracts/test/portals/TokenPortal.t.sol
@@ -235,19 +235,22 @@ contract TokenPortalTest is Test {
       _addWithdrawMessageInOutbox(address(0), l2BlockNumber);
     assertEq(testERC20.balanceOf(recipient), 0);
 
+    uint256 leafIndex = 0;
+    uint256 leafId = 2 ** siblingPath.length;
+
     vm.startPrank(_caller);
     vm.expectEmit(true, true, true, true);
-    emit IOutbox.MessageConsumed(l2BlockNumber, treeRoot, l2ToL1Message, 0);
-    tokenPortal.withdraw(recipient, withdrawAmount, false, l2BlockNumber, 0, siblingPath);
+    emit IOutbox.MessageConsumed(l2BlockNumber, treeRoot, l2ToL1Message, leafId);
+    tokenPortal.withdraw(recipient, withdrawAmount, false, l2BlockNumber, leafIndex, siblingPath);
 
     // Should have received 654 RNA tokens
     assertEq(testERC20.balanceOf(recipient), withdrawAmount);
 
     // Should not be able to withdraw again
     vm.expectRevert(
-      abi.encodeWithSelector(Errors.Outbox__AlreadyNullified.selector, l2BlockNumber, 0)
+      abi.encodeWithSelector(Errors.Outbox__AlreadyNullified.selector, l2BlockNumber, leafId)
     );
-    tokenPortal.withdraw(recipient, withdrawAmount, false, l2BlockNumber, 0, siblingPath);
+    tokenPortal.withdraw(recipient, withdrawAmount, false, l2BlockNumber, leafIndex, siblingPath);
     vm.stopPrank();
   }
 

--- a/l1-contracts/test/portals/TokenPortal.t.sol
+++ b/l1-contracts/test/portals/TokenPortal.t.sol
@@ -236,7 +236,7 @@ contract TokenPortalTest is Test {
     assertEq(testERC20.balanceOf(recipient), 0);
 
     uint256 leafIndex = 0;
-    uint256 leafId = 2 ** siblingPath.length;
+    uint256 leafId = 2 ** siblingPath.length + leafIndex;
 
     vm.startPrank(_caller);
     vm.expectEmit(true, true, true, true);
@@ -285,7 +285,7 @@ contract TokenPortalTest is Test {
       _addWithdrawMessageInOutbox(address(this), l2BlockNumber);
 
     uint256 leafIndex = 0;
-    uint256 leafId = 2 ** siblingPath.length;
+    uint256 leafId = 2 ** siblingPath.length + leafIndex;
 
     vm.expectEmit(true, true, true, true);
     emit IOutbox.MessageConsumed(l2BlockNumber, treeRoot, l2ToL1Message, leafId);

--- a/l1-contracts/test/portals/UniswapPortal.t.sol
+++ b/l1-contracts/test/portals/UniswapPortal.t.sol
@@ -397,9 +397,9 @@ contract UniswapPortalTest is Test {
     assertEq(DAI.balanceOf(address(daiTokenPortal)), 0);
     // there should be some weth in the weth portal
     assertGt(WETH9.balanceOf(address(wethTokenPortal)), 0);
-    // there the message should be nullified at index 0 and 1
-    assertTrue(outbox.hasMessageBeenConsumedAtBlockAndIndex(l2BlockNumber, 0));
-    assertTrue(outbox.hasMessageBeenConsumedAtBlockAndIndex(l2BlockNumber, 1));
+    // there the messages should be nullified
+    assertTrue(outbox.hasMessageBeenConsumedAtBlock(l2BlockNumber, 1 << withdrawSiblingPath.length));
+    assertTrue(outbox.hasMessageBeenConsumedAtBlock(l2BlockNumber, 1 << swapSiblingPath.length + 1));
   }
 
   function testSwapCalledByAnyoneIfDesignatedCallerNotSet(address _caller) public {
@@ -443,9 +443,9 @@ contract UniswapPortalTest is Test {
     assertEq(DAI.balanceOf(address(daiTokenPortal)), 0);
     // there should be some weth in the weth portal
     assertGt(WETH9.balanceOf(address(wethTokenPortal)), 0);
-    // there should be no message in the outbox:
-    assertTrue(outbox.hasMessageBeenConsumedAtBlockAndIndex(l2BlockNumber, 0));
-    assertTrue(outbox.hasMessageBeenConsumedAtBlockAndIndex(l2BlockNumber, 1));
+    // there the messages should be nullified
+    assertTrue(outbox.hasMessageBeenConsumedAtBlock(l2BlockNumber, 1 << withdrawSiblingPath.length));
+    assertTrue(outbox.hasMessageBeenConsumedAtBlock(l2BlockNumber, 1 << swapSiblingPath.length + 1));
   }
 
   function testRevertIfSwapWithDesignatedCallerCalledByWrongCaller(address _caller) public {

--- a/yarn-project/aztec.js/src/ethereum/portal_manager.ts
+++ b/yarn-project/aztec.js/src/ethereum/portal_manager.ts
@@ -13,6 +13,7 @@ import { TokenPortalAbi } from '@aztec/l1-artifacts/TokenPortalAbi';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
 import { computeL2ToL1MessageHash, computeSecretHash } from '@aztec/stdlib/hash';
 import type { PXE } from '@aztec/stdlib/interfaces/client';
+import { getL2ToL1MessageLeafId } from '@aztec/stdlib/messaging';
 
 import { type Hex, getContract, toFunctionSelector } from 'viem';
 
@@ -400,9 +401,12 @@ export class L1TokenPortalManager extends L1ToL2TokenPortalManager {
       `Sending L1 tx to consume message at block ${blockNumber} index ${messageIndex} to withdraw ${amount}`,
     );
 
-    const isConsumedBefore = await this.outbox.read.hasMessageBeenConsumedAtBlockAndIndex([blockNumber, messageIndex]);
+    const messageLeafId = getL2ToL1MessageLeafId({ l2MessageIndex: messageIndex, siblingPath });
+    const isConsumedBefore = await this.outbox.read.hasMessageBeenConsumedAtBlock([blockNumber, messageLeafId]);
     if (isConsumedBefore) {
-      throw new Error(`L1 to L2 message at block ${blockNumber} index ${messageIndex} has already been consumed`);
+      throw new Error(
+        `L1 to L2 message at block ${blockNumber} index ${messageIndex} height ${siblingPath.pathSize} has already been consumed`,
+      );
     }
 
     // Call function on L1 contract to consume the message
@@ -419,9 +423,11 @@ export class L1TokenPortalManager extends L1ToL2TokenPortalManager {
       hash: await this.extendedClient.writeContract(withdrawRequest),
     });
 
-    const isConsumedAfter = await this.outbox.read.hasMessageBeenConsumedAtBlockAndIndex([blockNumber, messageIndex]);
+    const isConsumedAfter = await this.outbox.read.hasMessageBeenConsumedAtBlock([blockNumber, messageLeafId]);
     if (!isConsumedAfter) {
-      throw new Error(`L1 to L2 message at block ${blockNumber} index ${messageIndex} not consumed after withdrawal`);
+      throw new Error(
+        `L1 to L2 message at block ${blockNumber} index ${messageIndex} height ${siblingPath.pathSize} not consumed after withdrawal`,
+      );
     }
   }
 

--- a/yarn-project/end-to-end/src/e2e_p2p/add_rollup.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/add_rollup.test.ts
@@ -27,7 +27,7 @@ import { TestContract } from '@aztec/noir-test-contracts.js/Test';
 import { protocolContractTreeRoot } from '@aztec/protocol-contracts';
 import { createPXEService, getPXEServiceConfig } from '@aztec/pxe/server';
 import { computeL2ToL1MessageHash } from '@aztec/stdlib/hash';
-import { computeL2ToL1MembershipWitness } from '@aztec/stdlib/messaging';
+import { computeL2ToL1MembershipWitness, getL2ToL1MessageLeafId } from '@aztec/stdlib/messaging';
 import { getGenesisValues } from '@aztec/world-state/testing';
 
 import { jest } from '@jest/globals';
@@ -309,6 +309,7 @@ describe('e2e_p2p_add_rollup', () => {
         });
 
         const l2ToL1MessageResult = await computeL2ToL1MembershipWitness(node, l2OutgoingReceipt!.blockNumber, leaf);
+        const leafId = getL2ToL1MessageLeafId(l2ToL1MessageResult!);
 
         // We need to mark things as proven
         const cheatcodes = RollupCheatCodes.create(l1RpcUrls, l1ContractAddresses);
@@ -352,13 +353,13 @@ describe('e2e_p2p_add_rollup', () => {
             l2BlockNumber: bigint;
             root: `0x${string}`;
             messageHash: `0x${string}`;
-            leafIndex: bigint;
+            leafId: bigint;
           };
         };
 
-        // We check that MessageConsumed event was emitted with the expected message hash and leaf index
+        // We check that MessageConsumed event was emitted with the expected message hash and leaf id
         expect(topics.args.messageHash).toStrictEqual(leaf.toString());
-        expect(topics.args.leafIndex).toStrictEqual(BigInt(0));
+        expect(topics.args.leafId).toStrictEqual(leafId);
       }
     };
 

--- a/yarn-project/stdlib/src/messaging/l2_to_l1_membership.ts
+++ b/yarn-project/stdlib/src/messaging/l2_to_l1_membership.ts
@@ -111,3 +111,7 @@ export async function computeL2ToL1MembershipWitness(
     siblingPath: new SiblingPath(combinedPath.length, combinedPath),
   };
 }
+
+export function getL2ToL1MessageLeafId(membershipWitness: L2ToL1MembershipWitness): bigint {
+  return 2n ** BigInt(membershipWitness.siblingPath.pathSize) + membershipWitness.l2MessageIndex;
+}


### PR DESCRIPTION
#16027