### PR TITLE
chore: save memory in trace blocks when gate selectors are known to be all zero

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -57,9 +57,9 @@
       "name": "Debug BB API Test",
       "type": "lldb",
       "request": "launch",
-      "program": "${workspaceFolder}/barretenberg/cpp/build-debug/bin/api_tests",
+      "program": "${workspaceFolder}/barretenberg/cpp/build-debug-no-avm/bin/api_tests",
       "args": ["--gtest_filter=ClientIVCAPITests.ProveAndVerifyFileBasedFlow"],
-      "cwd": "${workspaceFolder}/barretenberg/cpp/build-debug",
+      "cwd": "${workspaceFolder}/barretenberg/cpp/build-debug-no-avm",
       "initCommands": [
         "command script import ${workspaceFolder}/barretenberg/cpp/scripts/lldb_format.py"
       ],

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -48,7 +48,7 @@
       "type": "lldb",
       "request": "launch",
       "program": "${workspaceFolder}/barretenberg/cpp/build-debug-no-avm/bin/boomerang_value_detection_tests",
-      "args": ["--gtest_filter=boomerang_ultra_circuit_constructor.test_graph_for_arithmetic_gates"],
+      "args": ["--gtest_filter=BoomerangGoblinRecursiveVerifierTests.graph_description_basic"],
       "initCommands": [
         "command script import ${workspaceFolder}/barretenberg/cpp/scripts/lldb_format.py"
       ],

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -44,11 +44,11 @@
       ],
     },
     {
-      "name": "Debug Commitment Schemes Tests",
+      "name": "Debug test_graph_for_arithmetic_gates",
       "type": "lldb",
       "request": "launch",
-      "program": "${workspaceFolder}/barretenberg/cpp/build-debug/bin/commitment_schemes_tests",
-      "args": [],
+      "program": "${workspaceFolder}/barretenberg/cpp/build-debug-no-avm/bin/boomerang_value_detection_tests",
+      "args": ["--gtest_filter=boomerang_ultra_circuit_constructor.test_graph_for_arithmetic_gates"],
       "initCommands": [
         "command script import ${workspaceFolder}/barretenberg/cpp/scripts/lldb_format.py"
       ],

--- a/barretenberg/cpp/src/barretenberg/honk/execution_trace/execution_trace_block.hpp
+++ b/barretenberg/cpp/src/barretenberg/honk/execution_trace/execution_trace_block.hpp
@@ -219,7 +219,6 @@ template <typename FF, size_t NUM_WIRES_> class ExecutionTraceBlock {
     uint32_t fixed_size = 0; // Fixed size for use in structured trace
 
     virtual RefVector<Selector<FF>> get_selectors() = 0;
-    virtual RefVector<const Selector<FF>> get_selectors() const = 0;
 
     void populate_wires(const uint32_t& idx_1, const uint32_t& idx_2, const uint32_t& idx_3, const uint32_t& idx_4)
     {
@@ -244,13 +243,6 @@ template <typename FF, size_t NUM_WIRES_> class ExecutionTraceBlock {
     Selector<FF>& q_2() { return non_gate_selectors[3]; };
     Selector<FF>& q_3() { return non_gate_selectors[4]; };
     Selector<FF>& q_4() { return non_gate_selectors[5]; };
-
-    const Selector<FF>& q_m() const { return non_gate_selectors[0]; };
-    const Selector<FF>& q_c() const { return non_gate_selectors[1]; };
-    const Selector<FF>& q_1() const { return non_gate_selectors[2]; };
-    const Selector<FF>& q_2() const { return non_gate_selectors[3]; };
-    const Selector<FF>& q_3() const { return non_gate_selectors[4]; };
-    const Selector<FF>& q_4() const { return non_gate_selectors[5]; };
 
   protected:
     std::array<SlabVectorSelector<FF>, 6> non_gate_selectors;

--- a/barretenberg/cpp/src/barretenberg/honk/execution_trace/execution_trace_block.hpp
+++ b/barretenberg/cpp/src/barretenberg/honk/execution_trace/execution_trace_block.hpp
@@ -54,7 +54,7 @@ template <typename FF> class ZeroSelector : public Selector<FF> {
     using Selector<FF>::emplace_back;
     void emplace_back(int i) override
     {
-        BB_ASSERT_EQ(i, 0);
+        BB_ASSERT_EQ(i, 0, "emplace_back non-zero to ZeroSelector is not allowed");
         size_++;
     }
     void push_back(const FF& value) override

--- a/barretenberg/cpp/src/barretenberg/honk/execution_trace/execution_trace_block.hpp
+++ b/barretenberg/cpp/src/barretenberg/honk/execution_trace/execution_trace_block.hpp
@@ -87,21 +87,15 @@ template <typename FF> class ZeroSelector : public Selector<FF> {
     const FF& operator[](size_t index) const override
     {
         BB_ASSERT_LT(index, size_);
-        ASSERT(zero.is_zero());
         return zero;
     };
-    const FF& back() const override
-    {
-        ASSERT(zero.is_zero());
-        return zero;
-    }
+    const FF& back() const override { return zero; }
 
     size_t size() const override { return size_; }
     bool empty() const override { return size_ == 0; }
 
     std::vector<uint8_t> to_buffer() const override
     {
-        ASSERT(zero.is_zero());
         using serialize::write;
         std::vector<uint8_t> buf;
         for (size_t i = 0; i < size_; i++) {

--- a/barretenberg/cpp/src/barretenberg/honk/execution_trace/execution_trace_block.hpp
+++ b/barretenberg/cpp/src/barretenberg/honk/execution_trace/execution_trace_block.hpp
@@ -58,7 +58,7 @@ template <typename FF> class ZeroSelector : public Selector<FF> {
     using Selector<FF>::emplace_back;
     void emplace_back(int value) override
     {
-        BB_ASSERT_EQ(value, 0, "emplace_back non-zero to ZeroSelector is not allowed");
+        BB_ASSERT_EQ(value, 0, "Calling ZeroSelector::emplace_back with a non zero value.");
         size_++;
     }
     void push_back(const FF& value) override
@@ -68,12 +68,13 @@ template <typename FF> class ZeroSelector : public Selector<FF> {
     }
     void set_back(int value) override
     {
-        BB_ASSERT_EQ(value, 0, "emplace_back non-zero to ZeroSelector is not allowed");
+        BB_ASSERT_EQ(value, 0, "Calling ZeroSelector::set_back with a non zero value.");
+        BB_ASSERT_GT(size_, 0U);
     }
     void set(size_t idx, int value) override
     {
         BB_ASSERT_LT(idx, size_);
-        BB_ASSERT_EQ(value, 0, "set non-zero to ZeroSelector is not allowed");
+        BB_ASSERT_EQ(value, 0, "Calling ZeroSelector::set with a non zero value.");
     }
     void set(size_t idx, const FF& value) override
     {

--- a/barretenberg/cpp/src/barretenberg/honk/execution_trace/execution_trace_usage_tracker.hpp
+++ b/barretenberg/cpp/src/barretenberg/honk/execution_trace/execution_trace_usage_tracker.hpp
@@ -22,7 +22,6 @@ namespace bb {
 struct ExecutionTraceUsageTracker {
     using Range = std::pair<size_t, size_t>;
     using Builder = MegaCircuitBuilder;
-    using MegaTraceActiveRanges = MegaTraceBlockData<Range>;
     using MegaTraceFixedBlockSizes = MegaExecutionTraceBlocks;
 
     TraceStructure max_sizes;             // max utilization of each block

--- a/barretenberg/cpp/src/barretenberg/honk/execution_trace/mega_execution_trace.hpp
+++ b/barretenberg/cpp/src/barretenberg/honk/execution_trace/mega_execution_trace.hpp
@@ -157,7 +157,7 @@ class MegaTraceBlock : public ExecutionTraceBlock<fr, /*NUM_WIRES_ */ 4> {
      */
     void resize_additional(size_t new_size) { q_busread().resize(new_size); };
 
-  protected:
+  private:
     std::array<ZeroSelector<fr>, 9> zero_selectors;
 };
 
@@ -168,7 +168,7 @@ class MegaTraceBusReadBlock : public MegaTraceBlock {
     SelectorType& q_busread() override { return gate_selector; }
     const SelectorType& q_busread() const override { return gate_selector; }
 
-  protected:
+  private:
     SlabVectorSelector<fr> gate_selector;
 };
 
@@ -177,7 +177,7 @@ class MegaTraceLookupBlock : public MegaTraceBlock {
     SelectorType& q_lookup_type() override { return gate_selector; }
     const SelectorType& q_lookup_type() const override { return gate_selector; }
 
-  protected:
+  private:
     SlabVectorSelector<fr> gate_selector;
 };
 
@@ -186,7 +186,7 @@ class MegaTraceArithmeticBlock : public MegaTraceBlock {
     SelectorType& q_arith() override { return gate_selector; }
     const SelectorType& q_arith() const override { return gate_selector; }
 
-  protected:
+  private:
     SlabVectorSelector<fr> gate_selector;
 };
 
@@ -195,7 +195,7 @@ class MegaTraceDeltaRangeBlock : public MegaTraceBlock {
     SelectorType& q_delta_range() override { return gate_selector; }
     const SelectorType& q_delta_range() const override { return gate_selector; }
 
-  protected:
+  private:
     SlabVectorSelector<fr> gate_selector;
 };
 
@@ -204,7 +204,7 @@ class MegaTraceEllipticBlock : public MegaTraceBlock {
     SelectorType& q_elliptic() override { return gate_selector; }
     const SelectorType& q_elliptic() const override { return gate_selector; }
 
-  protected:
+  private:
     SlabVectorSelector<fr> gate_selector;
 };
 
@@ -213,7 +213,7 @@ class MegaTraceMemoryBlock : public MegaTraceBlock {
     SelectorType& q_memory() override { return gate_selector; }
     const SelectorType& q_memory() const override { return gate_selector; }
 
-  protected:
+  private:
     SlabVectorSelector<fr> gate_selector;
 };
 
@@ -222,7 +222,7 @@ class MegaTraceNonNativeFieldBlock : public MegaTraceBlock {
     SelectorType& q_nnf() override { return gate_selector; }
     const SelectorType& q_nnf() const override { return gate_selector; }
 
-  protected:
+  private:
     SlabVectorSelector<fr> gate_selector;
 };
 
@@ -231,7 +231,7 @@ class MegaTracePoseidon2ExternalBlock : public MegaTraceBlock {
     SelectorType& q_poseidon2_external() override { return gate_selector; }
     const SelectorType& q_poseidon2_external() const override { return gate_selector; }
 
-  protected:
+  private:
     SlabVectorSelector<fr> gate_selector;
 };
 
@@ -240,7 +240,7 @@ class MegaTracePoseidon2InternalBlock : public MegaTraceBlock {
     SelectorType& q_poseidon2_internal() override { return gate_selector; }
     const SelectorType& q_poseidon2_internal() const override { return gate_selector; }
 
-  protected:
+  private:
     SlabVectorSelector<fr> gate_selector;
 };
 
@@ -264,7 +264,7 @@ class MegaTraceOverflowBlock : public MegaTraceBlock {
     const SelectorType& q_poseidon2_external() const override { return gate_selectors[6]; }
     const SelectorType& q_poseidon2_internal() const override { return gate_selectors[7]; }
 
-  protected:
+  private:
     std::array<SlabVectorSelector<fr>, 8> gate_selectors;
 };
 

--- a/barretenberg/cpp/src/barretenberg/honk/execution_trace/mega_execution_trace.hpp
+++ b/barretenberg/cpp/src/barretenberg/honk/execution_trace/mega_execution_trace.hpp
@@ -90,8 +90,9 @@ struct TraceSettings {
     size_t dyadic_size() const { return numeric::round_up_power_2(size()); }
 };
 
-class MegaTraceBlock : public ExecutionTraceBlock<fr, /*NUM_WIRES_ */ 4, /*NUM_SELECTORS_*/ 15> {
-    using SelectorType = ExecutionTraceBlock<fr, 4, 15>::SelectorType;
+class MegaTraceBlock
+    : public ExecutionTraceBlock<fr, /*NUM_WIRES_ */ 4, /*NUM_NON_ZERO_SELECTORS_*/ 15, /*NUM_ZERO_SELECTORS_=*/0> {
+    using SelectorType = ExecutionTraceBlock<fr, 4, 15, 0>::NonZeroSelectorType;
 
   public:
     void populate_wires(const uint32_t& idx_1, const uint32_t& idx_2, const uint32_t& idx_3, const uint32_t& idx_4)
@@ -111,21 +112,21 @@ class MegaTraceBlock : public ExecutionTraceBlock<fr, /*NUM_WIRES_ */ 4, /*NUM_S
     auto& w_o() { return std::get<2>(this->wires); };
     auto& w_4() { return std::get<3>(this->wires); };
 
-    auto& q_m() { return this->selectors[0]; };
-    auto& q_c() { return this->selectors[1]; };
-    auto& q_1() { return this->selectors[2]; };
-    auto& q_2() { return this->selectors[3]; };
-    auto& q_3() { return this->selectors[4]; };
-    auto& q_4() { return this->selectors[5]; };
-    auto& q_busread() { return this->selectors[6]; };
-    auto& q_lookup_type() { return this->selectors[7]; };
-    auto& q_arith() { return this->selectors[8]; };
-    auto& q_delta_range() { return this->selectors[9]; };
-    auto& q_elliptic() { return this->selectors[10]; };
-    auto& q_memory() { return this->selectors[11]; };
-    auto& q_nnf() { return this->selectors[12]; };
-    auto& q_poseidon2_external() { return this->selectors[13]; };
-    auto& q_poseidon2_internal() { return this->selectors[14]; };
+    auto& q_m() { return this->non_zero_selectors[0]; };
+    auto& q_c() { return this->non_zero_selectors[1]; };
+    auto& q_1() { return this->non_zero_selectors[2]; };
+    auto& q_2() { return this->non_zero_selectors[3]; };
+    auto& q_3() { return this->non_zero_selectors[4]; };
+    auto& q_4() { return this->non_zero_selectors[5]; };
+    auto& q_busread() { return this->non_zero_selectors[6]; };
+    auto& q_lookup_type() { return this->non_zero_selectors[7]; };
+    auto& q_arith() { return this->non_zero_selectors[8]; };
+    auto& q_delta_range() { return this->non_zero_selectors[9]; };
+    auto& q_elliptic() { return this->non_zero_selectors[10]; };
+    auto& q_memory() { return this->non_zero_selectors[11]; };
+    auto& q_nnf() { return this->non_zero_selectors[12]; };
+    auto& q_poseidon2_external() { return this->non_zero_selectors[13]; };
+    auto& q_poseidon2_internal() { return this->non_zero_selectors[14]; };
 
     RefVector<SelectorType> get_gate_selectors()
     {
@@ -165,7 +166,8 @@ class MegaExecutionTraceBlocks : public MegaTraceBlockData<MegaTraceBlock> {
      */
 
     static constexpr size_t NUM_WIRES = MegaTraceBlock::NUM_WIRES;
-    static constexpr size_t NUM_SELECTORS = MegaTraceBlock::NUM_SELECTORS;
+    static constexpr size_t NUM_NON_ZERO_SELECTORS = MegaTraceBlock::NUM_NON_ZERO_SELECTORS;
+    static constexpr size_t NUM_ZERO_SELECTORS = MegaTraceBlock::NUM_ZERO_SELECTORS;
 
     using FF = fr;
 

--- a/barretenberg/cpp/src/barretenberg/honk/execution_trace/mega_execution_trace.hpp
+++ b/barretenberg/cpp/src/barretenberg/honk/execution_trace/mega_execution_trace.hpp
@@ -12,6 +12,7 @@
 #include "barretenberg/flavor/flavor_concepts.hpp"
 #include "barretenberg/honk/execution_trace/execution_trace_block.hpp"
 #include "barretenberg/numeric/bitop/get_msb.hpp"
+#include <cstdint>
 
 namespace bb {
 
@@ -61,8 +62,36 @@ template <typename T> struct MegaTraceBlockData {
         };
     }
 
+    bool operator==(const MegaTraceBlockData& other) const = default;
+};
+
+struct TraceStructure {
+    uint32_t ecc_op;
+    uint32_t busread;
+    uint32_t lookup;
+    uint32_t pub_inputs;
+    uint32_t arithmetic;
+    uint32_t delta_range;
+    uint32_t elliptic;
+    uint32_t memory;
+    uint32_t nnf;
+    uint32_t poseidon2_external;
+    uint32_t poseidon2_internal;
+    uint32_t overflow; // block gates of arbitrary type that overflow their designated block
+
+    auto get()
+    {
+        return RefArray{ ecc_op,   busread, lookup, pub_inputs,         arithmetic,         delta_range,
+                         elliptic, memory,  nnf,    poseidon2_external, poseidon2_internal, overflow };
+    }
+
+    auto get() const
+    {
+        return RefArray{ ecc_op,   busread, lookup, pub_inputs,         arithmetic,         delta_range,
+                         elliptic, memory,  nnf,    poseidon2_external, poseidon2_internal, overflow };
+    }
+
     size_t size() const
-        requires std::same_as<T, uint32_t>
     {
         size_t result{ 0 };
         for (const auto& block_size : get()) {
@@ -70,11 +99,7 @@ template <typename T> struct MegaTraceBlockData {
         }
         return static_cast<size_t>(result);
     }
-
-    bool operator==(const MegaTraceBlockData& other) const = default;
 };
-
-using TraceStructure = MegaTraceBlockData<uint32_t>;
 
 struct TraceSettings {
     std::optional<TraceStructure> structure;
@@ -184,6 +209,104 @@ class MegaTraceBlock : public ExecutionTraceBlock<fr, /*NUM_WIRES_ */ 4> {
   protected:
     std::array<ZeroSelector<fr>, 9> zero_selectors;
 };
+
+// class MegaTracePublicInputBlock : public MegaTraceBlock {};
+
+// class MegaTraceLookupBlock : public MegaTraceBlock {
+//   public:
+//     SelectorType& q_lookup_type() override { return gate_selector; }
+//     const SelectorType& q_lookup_type() const override { return gate_selector; }
+
+//   protected:
+//     SlabVectorSelector<fr> gate_selector;
+// };
+
+// class MegaTraceArithmeticBlock : public MegaTraceBlock {
+//   public:
+//     SelectorType& q_arith() override { return gate_selector; }
+//     const SelectorType& q_arith() const override { return gate_selector; }
+
+//   protected:
+//     SlabVectorSelector<fr> gate_selector;
+// };
+
+// class MegaTraceDeltaRangeBlock : public MegaTraceBlock {
+//   public:
+//     SelectorType& q_delta_range() override { return gate_selector; }
+//     const SelectorType& q_delta_range() const override { return gate_selector; }
+
+//   protected:
+//     SlabVectorSelector<fr> gate_selector;
+// };
+
+// class MegaTraceEllipticBlock : public MegaTraceBlock {
+//   public:
+//     SelectorType& q_elliptic() override { return gate_selector; }
+//     const SelectorType& q_elliptic() const override { return gate_selector; }
+
+//   protected:
+//     SlabVectorSelector<fr> gate_selector;
+// };
+
+// class MegaTraceMemoryBlock : public MegaTraceBlock {
+//   public:
+//     SelectorType& q_memory() override { return gate_selector; }
+//     const SelectorType& q_memory() const override { return gate_selector; }
+
+//   protected:
+//     SlabVectorSelector<fr> gate_selector;
+// };
+
+// class MegaTraceNonNativeFieldBlock : public MegaTraceBlock {
+//   public:
+//     SelectorType& q_nnf() override { return gate_selector; }
+//     const SelectorType& q_nnf() const override { return gate_selector; }
+
+//   protected:
+//     SlabVectorSelector<fr> gate_selector;
+// };
+
+// class MegaTracePoseidon2ExternalBlock : public MegaTraceBlock {
+//   public:
+//     SelectorType& q_poseidon2_external() override { return gate_selector; }
+//     const SelectorType& q_poseidon2_external() const override { return gate_selector; }
+
+//   protected:
+//     SlabVectorSelector<fr> gate_selector;
+// };
+
+// class MegaTracePoseidon2InternalBlock : public MegaTraceBlock {
+//   public:
+//     SelectorType& q_poseidon2_internal() override { return gate_selector; }
+//     const SelectorType& q_poseidon2_internal() const override { return gate_selector; }
+
+//   protected:
+//     SlabVectorSelector<fr> gate_selector;
+// };
+
+// class MegaTraceOverflowBlock : public MegaTraceBlock {
+//   public:
+//     SelectorType& q_lookup_type() override { return gate_selectors[0]; };
+//     SelectorType& q_arith() override { return gate_selectors[1]; }
+//     SelectorType& q_delta_range() override { return gate_selectors[2]; }
+//     SelectorType& q_elliptic() override { return gate_selectors[3]; }
+//     SelectorType& q_memory() override { return gate_selectors[4]; }
+//     SelectorType& q_nnf() override { return gate_selectors[5]; }
+//     SelectorType& q_poseidon2_external() override { return gate_selectors[6]; }
+//     SelectorType& q_poseidon2_internal() override { return gate_selectors[7]; }
+
+//     const SelectorType& q_lookup_type() const override { return gate_selectors[0]; };
+//     const SelectorType& q_arith() const override { return gate_selectors[1]; }
+//     const SelectorType& q_delta_range() const override { return gate_selectors[2]; }
+//     const SelectorType& q_elliptic() const override { return gate_selectors[3]; }
+//     const SelectorType& q_memory() const override { return gate_selectors[4]; }
+//     const SelectorType& q_nnf() const override { return gate_selectors[5]; }
+//     const SelectorType& q_poseidon2_external() const override { return gate_selectors[6]; }
+//     const SelectorType& q_poseidon2_internal() const override { return gate_selectors[7]; }
+
+//   protected:
+//     std::array<SlabVectorSelector<fr>, 8> gate_selectors;
+// };
 
 class MegaExecutionTraceBlocks : public MegaTraceBlockData<MegaTraceBlock> {
   public:

--- a/barretenberg/cpp/src/barretenberg/honk/execution_trace/mega_execution_trace.hpp
+++ b/barretenberg/cpp/src/barretenberg/honk/execution_trace/mega_execution_trace.hpp
@@ -329,10 +329,9 @@ struct MegaTraceBlockData {
 
     auto get_gate_blocks() const
     {
-        return RefArray(std::array<const MegaTraceBlock*, 10>{
+        return RefArray(std::array<const MegaTraceBlock*, 9>{
             &busread,
             &lookup,
-            &pub_inputs,
             &arithmetic,
             &delta_range,
             &elliptic,

--- a/barretenberg/cpp/src/barretenberg/honk/execution_trace/mega_execution_trace.hpp
+++ b/barretenberg/cpp/src/barretenberg/honk/execution_trace/mega_execution_trace.hpp
@@ -90,43 +90,29 @@ struct TraceSettings {
     size_t dyadic_size() const { return numeric::round_up_power_2(size()); }
 };
 
-class MegaTraceBlock
-    : public ExecutionTraceBlock<fr, /*NUM_WIRES_ */ 4, /*NUM_NON_ZERO_SELECTORS_*/ 15, /*NUM_ZERO_SELECTORS_=*/0> {
-    using SelectorType = ExecutionTraceBlock<fr, 4, 15, 0>::NonZeroSelectorType;
+class MegaTraceBlock : public ExecutionTraceBlock<fr, /*NUM_WIRES_ */ 4> {
+    using SelectorType = Selector<fr>;
 
   public:
-    void populate_wires(const uint32_t& idx_1, const uint32_t& idx_2, const uint32_t& idx_3, const uint32_t& idx_4)
-    {
-#ifdef CHECK_CIRCUIT_STACKTRACES
-        this->stack_traces.populate();
-#endif
-        this->tracy_gate();
-        this->wires[0].emplace_back(idx_1);
-        this->wires[1].emplace_back(idx_2);
-        this->wires[2].emplace_back(idx_3);
-        this->wires[3].emplace_back(idx_4);
-    }
+    SelectorType& q_busread() { return this->zero_selectors[0]; };
+    SelectorType& q_lookup_type() { return this->zero_selectors[1]; };
+    SelectorType& q_arith() { return this->zero_selectors[2]; };
+    SelectorType& q_delta_range() { return this->zero_selectors[3]; };
+    SelectorType& q_elliptic() { return this->zero_selectors[4]; };
+    SelectorType& q_memory() { return this->zero_selectors[5]; };
+    SelectorType& q_nnf() { return this->zero_selectors[6]; };
+    SelectorType& q_poseidon2_external() { return this->zero_selectors[7]; };
+    SelectorType& q_poseidon2_internal() { return this->zero_selectors[8]; };
 
-    auto& w_l() { return std::get<0>(this->wires); };
-    auto& w_r() { return std::get<1>(this->wires); };
-    auto& w_o() { return std::get<2>(this->wires); };
-    auto& w_4() { return std::get<3>(this->wires); };
-
-    auto& q_m() { return this->non_zero_selectors[0]; };
-    auto& q_c() { return this->non_zero_selectors[1]; };
-    auto& q_1() { return this->non_zero_selectors[2]; };
-    auto& q_2() { return this->non_zero_selectors[3]; };
-    auto& q_3() { return this->non_zero_selectors[4]; };
-    auto& q_4() { return this->non_zero_selectors[5]; };
-    auto& q_busread() { return this->non_zero_selectors[6]; };
-    auto& q_lookup_type() { return this->non_zero_selectors[7]; };
-    auto& q_arith() { return this->non_zero_selectors[8]; };
-    auto& q_delta_range() { return this->non_zero_selectors[9]; };
-    auto& q_elliptic() { return this->non_zero_selectors[10]; };
-    auto& q_memory() { return this->non_zero_selectors[11]; };
-    auto& q_nnf() { return this->non_zero_selectors[12]; };
-    auto& q_poseidon2_external() { return this->non_zero_selectors[13]; };
-    auto& q_poseidon2_internal() { return this->non_zero_selectors[14]; };
+    const SelectorType& q_busread() const { return this->zero_selectors[0]; };
+    const SelectorType& q_lookup_type() const { return this->zero_selectors[1]; };
+    const SelectorType& q_arith() const { return this->zero_selectors[2]; };
+    const SelectorType& q_delta_range() const { return this->zero_selectors[3]; };
+    const SelectorType& q_elliptic() const { return this->zero_selectors[4]; };
+    const SelectorType& q_memory() const { return this->zero_selectors[5]; };
+    const SelectorType& q_nnf() const { return this->zero_selectors[6]; };
+    const SelectorType& q_poseidon2_external() const { return this->zero_selectors[7]; };
+    const SelectorType& q_poseidon2_internal() const { return this->zero_selectors[8]; };
 
     RefVector<SelectorType> get_gate_selectors()
     {
@@ -134,6 +120,48 @@ class MegaTraceBlock
             q_busread(),     q_lookup_type(),        q_arith(),
             q_delta_range(), q_elliptic(),           q_memory(),
             q_nnf(),         q_poseidon2_external(), q_poseidon2_internal(),
+        };
+    }
+
+    RefVector<Selector<fr>> get_selectors() override
+    {
+        return RefVector{
+            q_m(),
+            q_c(),
+            q_1(),
+            q_2(),
+            q_3(),
+            q_4(),
+            q_busread(),
+            q_lookup_type(),
+            q_arith(),
+            q_delta_range(),
+            q_elliptic(),
+            q_memory(),
+            q_nnf(),
+            q_poseidon2_external(),
+            q_poseidon2_internal(),
+        };
+    }
+
+    RefVector<const Selector<fr>> get_selectors() const override
+    {
+        return RefVector{
+            q_m(),
+            q_c(),
+            q_1(),
+            q_2(),
+            q_3(),
+            q_4(),
+            q_busread(),
+            q_lookup_type(),
+            q_arith(),
+            q_delta_range(),
+            q_elliptic(),
+            q_memory(),
+            q_nnf(),
+            q_poseidon2_external(),
+            q_poseidon2_internal(),
         };
     }
 
@@ -152,6 +180,9 @@ class MegaTraceBlock
      * @param new_size
      */
     void resize_additional(size_t new_size) { q_busread().resize(new_size); };
+
+  protected:
+    std::array<ZeroSelector<fr>, 9> zero_selectors;
 };
 
 class MegaExecutionTraceBlocks : public MegaTraceBlockData<MegaTraceBlock> {
@@ -166,8 +197,6 @@ class MegaExecutionTraceBlocks : public MegaTraceBlockData<MegaTraceBlock> {
      */
 
     static constexpr size_t NUM_WIRES = MegaTraceBlock::NUM_WIRES;
-    static constexpr size_t NUM_NON_ZERO_SELECTORS = MegaTraceBlock::NUM_NON_ZERO_SELECTORS;
-    static constexpr size_t NUM_ZERO_SELECTORS = MegaTraceBlock::NUM_ZERO_SELECTORS;
 
     using FF = fr;
 

--- a/barretenberg/cpp/src/barretenberg/honk/execution_trace/mega_execution_trace.hpp
+++ b/barretenberg/cpp/src/barretenberg/honk/execution_trace/mega_execution_trace.hpp
@@ -120,27 +120,6 @@ class MegaTraceBlock : public ExecutionTraceBlock<fr, /*NUM_WIRES_ */ 4> {
         };
     }
 
-    RefVector<const Selector<fr>> get_selectors() const override
-    {
-        return RefVector{
-            q_m(),
-            q_c(),
-            q_1(),
-            q_2(),
-            q_3(),
-            q_4(),
-            q_busread(),
-            q_lookup_type(),
-            q_arith(),
-            q_delta_range(),
-            q_elliptic(),
-            q_memory(),
-            q_nnf(),
-            q_poseidon2_external(),
-            q_poseidon2_internal(),
-        };
-    }
-
     /**
      * @brief Add zeros to all selectors which are not part of the conventional Ultra arithmetization
      * @details Facilitates reuse of Ultra gate construction functions in arithmetizations which extend the
@@ -166,7 +145,6 @@ class MegaTracePublicInputBlock : public MegaTraceBlock {};
 class MegaTraceBusReadBlock : public MegaTraceBlock {
   public:
     SelectorType& q_busread() override { return gate_selector; }
-    const SelectorType& q_busread() const override { return gate_selector; }
 
   private:
     SlabVectorSelector<fr> gate_selector;
@@ -175,7 +153,6 @@ class MegaTraceBusReadBlock : public MegaTraceBlock {
 class MegaTraceLookupBlock : public MegaTraceBlock {
   public:
     SelectorType& q_lookup_type() override { return gate_selector; }
-    const SelectorType& q_lookup_type() const override { return gate_selector; }
 
   private:
     SlabVectorSelector<fr> gate_selector;
@@ -184,7 +161,6 @@ class MegaTraceLookupBlock : public MegaTraceBlock {
 class MegaTraceArithmeticBlock : public MegaTraceBlock {
   public:
     SelectorType& q_arith() override { return gate_selector; }
-    const SelectorType& q_arith() const override { return gate_selector; }
 
   private:
     SlabVectorSelector<fr> gate_selector;
@@ -193,7 +169,6 @@ class MegaTraceArithmeticBlock : public MegaTraceBlock {
 class MegaTraceDeltaRangeBlock : public MegaTraceBlock {
   public:
     SelectorType& q_delta_range() override { return gate_selector; }
-    const SelectorType& q_delta_range() const override { return gate_selector; }
 
   private:
     SlabVectorSelector<fr> gate_selector;
@@ -202,7 +177,6 @@ class MegaTraceDeltaRangeBlock : public MegaTraceBlock {
 class MegaTraceEllipticBlock : public MegaTraceBlock {
   public:
     SelectorType& q_elliptic() override { return gate_selector; }
-    const SelectorType& q_elliptic() const override { return gate_selector; }
 
   private:
     SlabVectorSelector<fr> gate_selector;
@@ -211,7 +185,6 @@ class MegaTraceEllipticBlock : public MegaTraceBlock {
 class MegaTraceMemoryBlock : public MegaTraceBlock {
   public:
     SelectorType& q_memory() override { return gate_selector; }
-    const SelectorType& q_memory() const override { return gate_selector; }
 
   private:
     SlabVectorSelector<fr> gate_selector;
@@ -220,7 +193,6 @@ class MegaTraceMemoryBlock : public MegaTraceBlock {
 class MegaTraceNonNativeFieldBlock : public MegaTraceBlock {
   public:
     SelectorType& q_nnf() override { return gate_selector; }
-    const SelectorType& q_nnf() const override { return gate_selector; }
 
   private:
     SlabVectorSelector<fr> gate_selector;
@@ -229,7 +201,6 @@ class MegaTraceNonNativeFieldBlock : public MegaTraceBlock {
 class MegaTracePoseidon2ExternalBlock : public MegaTraceBlock {
   public:
     SelectorType& q_poseidon2_external() override { return gate_selector; }
-    const SelectorType& q_poseidon2_external() const override { return gate_selector; }
 
   private:
     SlabVectorSelector<fr> gate_selector;
@@ -238,7 +209,6 @@ class MegaTracePoseidon2ExternalBlock : public MegaTraceBlock {
 class MegaTracePoseidon2InternalBlock : public MegaTraceBlock {
   public:
     SelectorType& q_poseidon2_internal() override { return gate_selector; }
-    const SelectorType& q_poseidon2_internal() const override { return gate_selector; }
 
   private:
     SlabVectorSelector<fr> gate_selector;
@@ -254,15 +224,6 @@ class MegaTraceOverflowBlock : public MegaTraceBlock {
     SelectorType& q_nnf() override { return gate_selectors[5]; }
     SelectorType& q_poseidon2_external() override { return gate_selectors[6]; }
     SelectorType& q_poseidon2_internal() override { return gate_selectors[7]; }
-
-    const SelectorType& q_lookup_type() const override { return gate_selectors[0]; };
-    const SelectorType& q_arith() const override { return gate_selectors[1]; }
-    const SelectorType& q_delta_range() const override { return gate_selectors[2]; }
-    const SelectorType& q_elliptic() const override { return gate_selectors[3]; }
-    const SelectorType& q_memory() const override { return gate_selectors[4]; }
-    const SelectorType& q_nnf() const override { return gate_selectors[5]; }
-    const SelectorType& q_poseidon2_external() const override { return gate_selectors[6]; }
-    const SelectorType& q_poseidon2_internal() const override { return gate_selectors[7]; }
 
   private:
     std::array<SlabVectorSelector<fr>, 8> gate_selectors;

--- a/barretenberg/cpp/src/barretenberg/honk/execution_trace/ultra_execution_trace.hpp
+++ b/barretenberg/cpp/src/barretenberg/honk/execution_trace/ultra_execution_trace.hpp
@@ -14,100 +14,63 @@
 
 namespace bb {
 
-class UltraTraceBlock
-    : public ExecutionTraceBlock<fr, /*NUM_WIRES_ */ 4, /*NUM_NON_ZERO_SELECTORS_*/ 7, /*NUM_ZERO_SELECTORS_*/ 8> {
+class UltraTraceBlock : public ExecutionTraceBlock<fr, 4> {
   public:
-    void populate_wires(const uint32_t& idx_1, const uint32_t& idx_2, const uint32_t& idx_3, const uint32_t& idx_4)
+    Selector<fr>& q_lookup_type() { return zero_selectors[0]; };
+    Selector<fr>& q_arith() { return zero_selectors[1]; }
+    Selector<fr>& q_delta_range() { return zero_selectors[2]; }
+    Selector<fr>& q_elliptic() { return zero_selectors[3]; }
+    Selector<fr>& q_memory() { return zero_selectors[4]; }
+    Selector<fr>& q_nnf() { return zero_selectors[5]; }
+    Selector<fr>& q_poseidon2_external() { return zero_selectors[6]; }
+    Selector<fr>& q_poseidon2_internal() { return zero_selectors[7]; }
+
+    const Selector<fr>& q_lookup_type() const { return zero_selectors[0]; };
+    const Selector<fr>& q_arith() const { return zero_selectors[1]; }
+    const Selector<fr>& q_delta_range() const { return zero_selectors[2]; }
+    const Selector<fr>& q_elliptic() const { return zero_selectors[3]; }
+    const Selector<fr>& q_memory() const { return zero_selectors[4]; }
+    const Selector<fr>& q_nnf() const { return zero_selectors[5]; }
+    const Selector<fr>& q_poseidon2_external() const { return zero_selectors[6]; }
+    const Selector<fr>& q_poseidon2_internal() const { return zero_selectors[7]; }
+
+    RefVector<Selector<fr>> get_selectors() override
     {
-#ifdef CHECK_CIRCUIT_STACKTRACES
-        this->stack_traces.populate();
-#endif
-        this->tracy_gate();
-        this->wires[0].emplace_back(idx_1);
-        this->wires[1].emplace_back(idx_2);
-        this->wires[2].emplace_back(idx_3);
-        this->wires[3].emplace_back(idx_4);
+        return RefVector{ q_m(),
+                          q_c(),
+                          q_1(),
+                          q_2(),
+                          q_3(),
+                          q_4(),
+                          q_lookup_type(),
+                          q_arith(),
+                          q_delta_range(),
+                          q_elliptic(),
+                          q_memory(),
+                          q_nnf(),
+                          q_poseidon2_external(),
+                          q_poseidon2_internal() };
+    }
+    RefVector<const Selector<fr>> get_selectors() const override
+    {
+        return RefVector{ q_m(),
+                          q_c(),
+                          q_1(),
+                          q_2(),
+                          q_3(),
+                          q_4(),
+                          q_lookup_type(),
+                          q_arith(),
+                          q_delta_range(),
+                          q_elliptic(),
+                          q_memory(),
+                          q_nnf(),
+                          q_poseidon2_external(),
+                          q_poseidon2_internal() };
     }
 
-    auto& w_l() { return std::get<0>(this->wires); };
-    auto& w_r() { return std::get<1>(this->wires); };
-    auto& w_o() { return std::get<2>(this->wires); };
-    auto& w_4() { return std::get<3>(this->wires); };
-
-    SlabVectorSelector<fr>& q_m() { return non_zero_selectors[0]; };
-    SlabVectorSelector<fr>& q_c() { return non_zero_selectors[1]; };
-    SlabVectorSelector<fr>& q_1() { return non_zero_selectors[2]; };
-    SlabVectorSelector<fr>& q_2() { return non_zero_selectors[3]; };
-    SlabVectorSelector<fr>& q_3() { return non_zero_selectors[4]; };
-    SlabVectorSelector<fr>& q_4() { return non_zero_selectors[5]; };
-
-    enum class Type {
-        LOOKUP_TYPE,
-        ARITHMETIC,
-        DELTA_RANGE,
-        ELLIPTIC,
-        MEMORY,
-        NON_NATIVE_FIELD,
-        POSEIDON2_EXTERNAL,
-        POSEIDON2_INTERNAL,
-    } type;
-
-    Selector<fr>& q_lookup_type()
-    {
-        if (type == Type::LOOKUP_TYPE) {
-            return non_zero_selectors[6];
-        }
-        return zero_selectors[0];
-    };
-    Selector<fr>& q_arith()
-    {
-        if (type == Type::ARITHMETIC) {
-            return non_zero_selectors[6];
-        }
-        return zero_selectors[1];
-    }
-    Selector<fr>& q_delta_range()
-    {
-        if (type == Type::DELTA_RANGE) {
-            return non_zero_selectors[6];
-        }
-        return zero_selectors[2];
-    }
-    Selector<fr>& q_elliptic()
-    {
-        if (type == Type::ELLIPTIC) {
-            return non_zero_selectors[6];
-        }
-        return zero_selectors[3];
-    }
-    Selector<fr>& q_memory()
-    {
-        if (type == Type::MEMORY) {
-            return non_zero_selectors[6];
-        }
-        return zero_selectors[4];
-    }
-    Selector<fr>& q_nnf()
-    {
-        if (type == Type::NON_NATIVE_FIELD) {
-            return non_zero_selectors[6];
-        }
-        return zero_selectors[5];
-    }
-    Selector<fr>& q_poseidon2_external()
-    {
-        if (type == Type::POSEIDON2_EXTERNAL) {
-            return non_zero_selectors[6];
-        }
-        return zero_selectors[6];
-    }
-    Selector<fr>& q_poseidon2_internal()
-    {
-        if (type == Type::POSEIDON2_INTERNAL) {
-            return non_zero_selectors[6];
-        }
-        return zero_selectors[7];
-    }
+  protected:
+    std::array<ZeroSelector<fr>, 8> zero_selectors;
 };
 
 /**
@@ -151,8 +114,6 @@ class UltraExecutionTraceBlocks : public UltraTraceBlockData {
 
   public:
     static constexpr size_t NUM_WIRES = UltraTraceBlock::NUM_WIRES;
-    static constexpr size_t NUM_NON_ZERO_SELECTORS = UltraTraceBlock::NUM_NON_ZERO_SELECTORS;
-    static constexpr size_t NUM_ZERO_SELECTORS = UltraTraceBlock::NUM_ZERO_SELECTORS;
     using FF = fr;
 
     bool has_overflow = false;
@@ -199,7 +160,7 @@ class UltraExecutionTraceBlocks : public UltraTraceBlockData {
     size_t get_structured_dyadic_size()
     {
         size_t total_size = 1; // start at 1 because the 0th row is unused for selectors for Honk
-        for (auto block : this->get()) {
+        for (auto& block : this->get()) {
             total_size += block.get_fixed_size();
         }
 

--- a/barretenberg/cpp/src/barretenberg/honk/execution_trace/ultra_execution_trace.hpp
+++ b/barretenberg/cpp/src/barretenberg/honk/execution_trace/ultra_execution_trace.hpp
@@ -69,7 +69,7 @@ class UltraTraceBlock : public ExecutionTraceBlock<fr, 4> {
                           q_poseidon2_internal() };
     }
 
-  protected:
+  private:
     std::array<ZeroSelector<fr>, 8> zero_selectors;
 };
 
@@ -80,7 +80,7 @@ class UltraTraceLookupBlock : public UltraTraceBlock {
     SelectorType& q_lookup_type() override { return gate_selector; }
     const SelectorType& q_lookup_type() const override { return gate_selector; }
 
-  protected:
+  private:
     SlabVectorSelector<fr> gate_selector;
 };
 
@@ -89,7 +89,7 @@ class UltraTraceArithmeticBlock : public UltraTraceBlock {
     SelectorType& q_arith() override { return gate_selector; }
     const SelectorType& q_arith() const override { return gate_selector; }
 
-  protected:
+  private:
     SlabVectorSelector<fr> gate_selector;
 };
 
@@ -98,7 +98,7 @@ class UltraTraceDeltaRangeBlock : public UltraTraceBlock {
     SelectorType& q_delta_range() override { return gate_selector; }
     const SelectorType& q_delta_range() const override { return gate_selector; }
 
-  protected:
+  private:
     SlabVectorSelector<fr> gate_selector;
 };
 
@@ -107,7 +107,7 @@ class UltraTraceEllipticBlock : public UltraTraceBlock {
     SelectorType& q_elliptic() override { return gate_selector; }
     const SelectorType& q_elliptic() const override { return gate_selector; }
 
-  protected:
+  private:
     SlabVectorSelector<fr> gate_selector;
 };
 
@@ -116,7 +116,7 @@ class UltraTraceMemoryBlock : public UltraTraceBlock {
     SelectorType& q_memory() override { return gate_selector; }
     const SelectorType& q_memory() const override { return gate_selector; }
 
-  protected:
+  private:
     SlabVectorSelector<fr> gate_selector;
 };
 
@@ -125,7 +125,7 @@ class UltraTraceNonNativeFieldBlock : public UltraTraceBlock {
     SelectorType& q_nnf() override { return gate_selector; }
     const SelectorType& q_nnf() const override { return gate_selector; }
 
-  protected:
+  private:
     SlabVectorSelector<fr> gate_selector;
 };
 
@@ -134,7 +134,7 @@ class UltraTracePoseidon2ExternalBlock : public UltraTraceBlock {
     SelectorType& q_poseidon2_external() override { return gate_selector; }
     const SelectorType& q_poseidon2_external() const override { return gate_selector; }
 
-  protected:
+  private:
     SlabVectorSelector<fr> gate_selector;
 };
 
@@ -143,7 +143,7 @@ class UltraTracePoseidon2InternalBlock : public UltraTraceBlock {
     SelectorType& q_poseidon2_internal() override { return gate_selector; }
     const SelectorType& q_poseidon2_internal() const override { return gate_selector; }
 
-  protected:
+  private:
     SlabVectorSelector<fr> gate_selector;
 };
 
@@ -167,7 +167,7 @@ class UltraTraceOverflowBlock : public UltraTraceBlock {
     const SelectorType& q_poseidon2_external() const override { return gate_selectors[6]; }
     const SelectorType& q_poseidon2_internal() const override { return gate_selectors[7]; }
 
-  protected:
+  private:
     std::array<SlabVectorSelector<fr>, 8> gate_selectors;
 };
 

--- a/barretenberg/cpp/src/barretenberg/honk/execution_trace/ultra_execution_trace.hpp
+++ b/barretenberg/cpp/src/barretenberg/honk/execution_trace/ultra_execution_trace.hpp
@@ -8,6 +8,7 @@
 
 #include "barretenberg/common/ref_vector.hpp"
 #include "barretenberg/common/throw_or_abort.hpp"
+#include "barretenberg/ecc/curves/bn254/fr.hpp"
 #include "barretenberg/honk/execution_trace/execution_trace_block.hpp"
 #include "barretenberg/numeric/bitop/get_msb.hpp"
 
@@ -55,9 +56,7 @@ template <typename T> struct UltraTraceBlockData {
     bool operator==(const UltraTraceBlockData& other) const = default;
 };
 
-class UltraTraceBlock : public ExecutionTraceBlock<fr, /*NUM_WIRES_ */ 4, /*NUM_SELECTORS_*/ 14> {
-    using SelectorType = ExecutionTraceBlock<fr, 4, 14>::SelectorType;
-
+class UltraTraceBlock : public ExecutionTraceBlock<fr, /*NUM_WIRES_ */ 4, /*NUM_SELECTORS_*/ 7> {
   public:
     void populate_wires(const uint32_t& idx_1, const uint32_t& idx_2, const uint32_t& idx_3, const uint32_t& idx_4)
     {
@@ -76,20 +75,80 @@ class UltraTraceBlock : public ExecutionTraceBlock<fr, /*NUM_WIRES_ */ 4, /*NUM_
     auto& w_o() { return std::get<2>(this->wires); };
     auto& w_4() { return std::get<3>(this->wires); };
 
-    auto& q_m() { return this->selectors[0]; };
-    auto& q_c() { return this->selectors[1]; };
-    auto& q_1() { return this->selectors[2]; };
-    auto& q_2() { return this->selectors[3]; };
-    auto& q_3() { return this->selectors[4]; };
-    auto& q_4() { return this->selectors[5]; };
-    auto& q_lookup_type() { return this->selectors[6]; };
-    auto& q_arith() { return this->selectors[7]; };
-    auto& q_delta_range() { return this->selectors[8]; };
-    auto& q_elliptic() { return this->selectors[9]; };
-    auto& q_memory() { return this->selectors[10]; };
-    auto& q_nnf() { return this->selectors[11]; };
-    auto& q_poseidon2_external() { return this->selectors[12]; };
-    auto& q_poseidon2_internal() { return this->selectors[13]; };
+    SlabVectorSelector<fr>& q_m() { return this->selectors[0]; };
+    SlabVectorSelector<fr>& q_c() { return this->selectors[1]; };
+    SlabVectorSelector<fr>& q_1() { return this->selectors[2]; };
+    SlabVectorSelector<fr>& q_2() { return this->selectors[3]; };
+    SlabVectorSelector<fr>& q_3() { return this->selectors[4]; };
+    SlabVectorSelector<fr>& q_4() { return this->selectors[5]; };
+
+    enum class Type {
+        LOOKUP_TYPE,
+        ARITHMETIC,
+        DELTA_RANGE,
+        ELLIPTIC,
+        MEMORY,
+        NON_NATIVE_FIELD,
+        POSEIDON2_EXTERNAL,
+        POSEIDON2_INTERNAL,
+    } type;
+
+    Selector<fr>& q_lookup_type()
+    {
+        if (type == Type::LOOKUP_TYPE) {
+            return this->selectors[6];
+        }
+        return zero_selector;
+    };
+    Selector<fr>& q_arith()
+    {
+        if (type == Type::ARITHMETIC) {
+            return this->selectors[6];
+        }
+        return zero_selector;
+    }
+    Selector<fr>& q_delta_range()
+    {
+        if (type == Type::DELTA_RANGE) {
+            return this->selectors[6];
+        }
+        return zero_selector;
+    }
+    Selector<fr>& q_elliptic()
+    {
+        if (type == Type::ELLIPTIC) {
+            return this->selectors[6];
+        }
+        return zero_selector;
+    }
+    Selector<fr>& q_memory()
+    {
+        if (type == Type::MEMORY) {
+            return this->selectors[6];
+        }
+        return zero_selector;
+    }
+    Selector<fr>& q_nnf()
+    {
+        if (type == Type::NON_NATIVE_FIELD) {
+            return this->selectors[6];
+        }
+        return zero_selector;
+    }
+    Selector<fr>& q_poseidon2_external()
+    {
+        if (type == Type::POSEIDON2_EXTERNAL) {
+            return this->selectors[6];
+        }
+        return zero_selector;
+    }
+    Selector<fr>& q_poseidon2_internal()
+    {
+        if (type == Type::POSEIDON2_INTERNAL) {
+            return this->selectors[6];
+        }
+        return zero_selector;
+    }
 };
 
 class UltraExecutionTraceBlocks : public UltraTraceBlockData<UltraTraceBlock> {

--- a/barretenberg/cpp/src/barretenberg/honk/execution_trace/ultra_execution_trace.hpp
+++ b/barretenberg/cpp/src/barretenberg/honk/execution_trace/ultra_execution_trace.hpp
@@ -16,23 +16,23 @@ namespace bb {
 
 class UltraTraceBlock : public ExecutionTraceBlock<fr, 4> {
   public:
-    Selector<fr>& q_lookup_type() { return zero_selectors[0]; };
-    Selector<fr>& q_arith() { return zero_selectors[1]; }
-    Selector<fr>& q_delta_range() { return zero_selectors[2]; }
-    Selector<fr>& q_elliptic() { return zero_selectors[3]; }
-    Selector<fr>& q_memory() { return zero_selectors[4]; }
-    Selector<fr>& q_nnf() { return zero_selectors[5]; }
-    Selector<fr>& q_poseidon2_external() { return zero_selectors[6]; }
-    Selector<fr>& q_poseidon2_internal() { return zero_selectors[7]; }
+    virtual Selector<fr>& q_lookup_type() { return zero_selectors[0]; };
+    virtual Selector<fr>& q_arith() { return zero_selectors[1]; }
+    virtual Selector<fr>& q_delta_range() { return zero_selectors[2]; }
+    virtual Selector<fr>& q_elliptic() { return zero_selectors[3]; }
+    virtual Selector<fr>& q_memory() { return zero_selectors[4]; }
+    virtual Selector<fr>& q_nnf() { return zero_selectors[5]; }
+    virtual Selector<fr>& q_poseidon2_external() { return zero_selectors[6]; }
+    virtual Selector<fr>& q_poseidon2_internal() { return zero_selectors[7]; }
 
-    const Selector<fr>& q_lookup_type() const { return zero_selectors[0]; };
-    const Selector<fr>& q_arith() const { return zero_selectors[1]; }
-    const Selector<fr>& q_delta_range() const { return zero_selectors[2]; }
-    const Selector<fr>& q_elliptic() const { return zero_selectors[3]; }
-    const Selector<fr>& q_memory() const { return zero_selectors[4]; }
-    const Selector<fr>& q_nnf() const { return zero_selectors[5]; }
-    const Selector<fr>& q_poseidon2_external() const { return zero_selectors[6]; }
-    const Selector<fr>& q_poseidon2_internal() const { return zero_selectors[7]; }
+    virtual const Selector<fr>& q_lookup_type() const { return zero_selectors[0]; };
+    virtual const Selector<fr>& q_arith() const { return zero_selectors[1]; }
+    virtual const Selector<fr>& q_delta_range() const { return zero_selectors[2]; }
+    virtual const Selector<fr>& q_elliptic() const { return zero_selectors[3]; }
+    virtual const Selector<fr>& q_memory() const { return zero_selectors[4]; }
+    virtual const Selector<fr>& q_nnf() const { return zero_selectors[5]; }
+    virtual const Selector<fr>& q_poseidon2_external() const { return zero_selectors[6]; }
+    virtual const Selector<fr>& q_poseidon2_internal() const { return zero_selectors[7]; }
 
     RefVector<Selector<fr>> get_selectors() override
     {
@@ -73,38 +73,159 @@ class UltraTraceBlock : public ExecutionTraceBlock<fr, 4> {
     std::array<ZeroSelector<fr>, 8> zero_selectors;
 };
 
+class UltraTracePublicInputBlock : public UltraTraceBlock {};
+
+class UltraTraceLookupBlock : public UltraTraceBlock {
+  public:
+    SelectorType& q_lookup_type() override { return gate_selector; }
+    const SelectorType& q_lookup_type() const override { return gate_selector; }
+
+  protected:
+    SlabVectorSelector<fr> gate_selector;
+};
+
+class UltraTraceArithmeticBlock : public UltraTraceBlock {
+  public:
+    SelectorType& q_arith() override { return gate_selector; }
+    const SelectorType& q_arith() const override { return gate_selector; }
+
+  protected:
+    SlabVectorSelector<fr> gate_selector;
+};
+
+class UltraTraceDeltaRangeBlock : public UltraTraceBlock {
+  public:
+    SelectorType& q_delta_range() override { return gate_selector; }
+    const SelectorType& q_delta_range() const override { return gate_selector; }
+
+  protected:
+    SlabVectorSelector<fr> gate_selector;
+};
+
+class UltraTraceEllipticBlock : public UltraTraceBlock {
+  public:
+    SelectorType& q_elliptic() override { return gate_selector; }
+    const SelectorType& q_elliptic() const override { return gate_selector; }
+
+  protected:
+    SlabVectorSelector<fr> gate_selector;
+};
+
+class UltraTraceMemoryBlock : public UltraTraceBlock {
+  public:
+    SelectorType& q_memory() override { return gate_selector; }
+    const SelectorType& q_memory() const override { return gate_selector; }
+
+  protected:
+    SlabVectorSelector<fr> gate_selector;
+};
+
+class UltraTraceNonNativeFieldBlock : public UltraTraceBlock {
+  public:
+    SelectorType& q_nnf() override { return gate_selector; }
+    const SelectorType& q_nnf() const override { return gate_selector; }
+
+  protected:
+    SlabVectorSelector<fr> gate_selector;
+};
+
+class UltraTracePoseidon2ExternalBlock : public UltraTraceBlock {
+  public:
+    SelectorType& q_poseidon2_external() override { return gate_selector; }
+    const SelectorType& q_poseidon2_external() const override { return gate_selector; }
+
+  protected:
+    SlabVectorSelector<fr> gate_selector;
+};
+
+class UltraTracePoseidon2InternalBlock : public UltraTraceBlock {
+  public:
+    SelectorType& q_poseidon2_internal() override { return gate_selector; }
+    const SelectorType& q_poseidon2_internal() const override { return gate_selector; }
+
+  protected:
+    SlabVectorSelector<fr> gate_selector;
+};
+
+class UltraTraceOverflowBlock : public UltraTraceBlock {
+  public:
+    SelectorType& q_lookup_type() override { return gate_selectors[0]; };
+    SelectorType& q_arith() override { return gate_selectors[1]; }
+    SelectorType& q_delta_range() override { return gate_selectors[2]; }
+    SelectorType& q_elliptic() override { return gate_selectors[3]; }
+    SelectorType& q_memory() override { return gate_selectors[4]; }
+    SelectorType& q_nnf() override { return gate_selectors[5]; }
+    SelectorType& q_poseidon2_external() override { return gate_selectors[6]; }
+    SelectorType& q_poseidon2_internal() override { return gate_selectors[7]; }
+
+    const SelectorType& q_lookup_type() const override { return gate_selectors[0]; };
+    const SelectorType& q_arith() const override { return gate_selectors[1]; }
+    const SelectorType& q_delta_range() const override { return gate_selectors[2]; }
+    const SelectorType& q_elliptic() const override { return gate_selectors[3]; }
+    const SelectorType& q_memory() const override { return gate_selectors[4]; }
+    const SelectorType& q_nnf() const override { return gate_selectors[5]; }
+    const SelectorType& q_poseidon2_external() const override { return gate_selectors[6]; }
+    const SelectorType& q_poseidon2_internal() const override { return gate_selectors[7]; }
+
+  protected:
+    std::array<SlabVectorSelector<fr>, 8> gate_selectors;
+};
+
 /**
  * @brief Defines the circuit block types for the Ultra arithmetization
  */
 struct UltraTraceBlockData {
-    UltraTraceBlock pub_inputs; // Has to be the first block
-    UltraTraceBlock lookup;
-    UltraTraceBlock arithmetic;
-    UltraTraceBlock delta_range;
-    UltraTraceBlock elliptic;
-    UltraTraceBlock memory;
-    UltraTraceBlock nnf;
-    UltraTraceBlock poseidon2_external;
-    UltraTraceBlock poseidon2_internal;
-    UltraTraceBlock overflow;
+    UltraTracePublicInputBlock pub_inputs; // Has to be the first block
+    UltraTraceLookupBlock lookup;
+    UltraTraceArithmeticBlock arithmetic;
+    UltraTraceDeltaRangeBlock delta_range;
+    UltraTraceEllipticBlock elliptic;
+    UltraTraceMemoryBlock memory;
+    UltraTraceNonNativeFieldBlock nnf;
+    UltraTracePoseidon2ExternalBlock poseidon2_external;
+    UltraTracePoseidon2InternalBlock poseidon2_internal;
+    UltraTraceOverflowBlock overflow;
 
     auto get()
     {
-        return RefArray{ pub_inputs, lookup, arithmetic,         delta_range,        elliptic,
-                         memory,     nnf,    poseidon2_external, poseidon2_internal, overflow };
+        return RefArray(std::array<UltraTraceBlock*, 10>{ &pub_inputs,
+                                                          &lookup,
+                                                          &arithmetic,
+                                                          &delta_range,
+                                                          &elliptic,
+                                                          &memory,
+                                                          &nnf,
+                                                          &poseidon2_external,
+                                                          &poseidon2_internal,
+                                                          &overflow });
     }
 
     auto get() const
     {
-        return RefArray{ pub_inputs, lookup, arithmetic,         delta_range,        elliptic,
-                         memory,     nnf,    poseidon2_external, poseidon2_internal, overflow };
+        return RefArray(std::array<const UltraTraceBlock*, 10>{ &pub_inputs,
+                                                                &lookup,
+                                                                &arithmetic,
+                                                                &delta_range,
+                                                                &elliptic,
+                                                                &memory,
+                                                                &nnf,
+                                                                &poseidon2_external,
+                                                                &poseidon2_internal,
+                                                                &overflow });
     }
 
     auto get_gate_blocks() const
     {
-        return RefArray{
-            lookup, arithmetic, delta_range, elliptic, memory, nnf, poseidon2_external, poseidon2_internal
-        };
+        return RefArray(std::array<const UltraTraceBlock*, 8>{
+            &lookup,
+            &arithmetic,
+            &delta_range,
+            &elliptic,
+            &memory,
+            &nnf,
+            &poseidon2_external,
+            &poseidon2_internal,
+        });
     }
 
     bool operator==(const UltraTraceBlockData& other) const = default;

--- a/barretenberg/cpp/src/barretenberg/honk/execution_trace/ultra_execution_trace.hpp
+++ b/barretenberg/cpp/src/barretenberg/honk/execution_trace/ultra_execution_trace.hpp
@@ -25,33 +25,7 @@ class UltraTraceBlock : public ExecutionTraceBlock<fr, 4> {
     virtual Selector<fr>& q_poseidon2_external() { return zero_selectors[6]; }
     virtual Selector<fr>& q_poseidon2_internal() { return zero_selectors[7]; }
 
-    virtual const Selector<fr>& q_lookup_type() const { return zero_selectors[0]; };
-    virtual const Selector<fr>& q_arith() const { return zero_selectors[1]; }
-    virtual const Selector<fr>& q_delta_range() const { return zero_selectors[2]; }
-    virtual const Selector<fr>& q_elliptic() const { return zero_selectors[3]; }
-    virtual const Selector<fr>& q_memory() const { return zero_selectors[4]; }
-    virtual const Selector<fr>& q_nnf() const { return zero_selectors[5]; }
-    virtual const Selector<fr>& q_poseidon2_external() const { return zero_selectors[6]; }
-    virtual const Selector<fr>& q_poseidon2_internal() const { return zero_selectors[7]; }
-
     RefVector<Selector<fr>> get_selectors() override
-    {
-        return RefVector{ q_m(),
-                          q_c(),
-                          q_1(),
-                          q_2(),
-                          q_3(),
-                          q_4(),
-                          q_lookup_type(),
-                          q_arith(),
-                          q_delta_range(),
-                          q_elliptic(),
-                          q_memory(),
-                          q_nnf(),
-                          q_poseidon2_external(),
-                          q_poseidon2_internal() };
-    }
-    RefVector<const Selector<fr>> get_selectors() const override
     {
         return RefVector{ q_m(),
                           q_c(),
@@ -78,7 +52,6 @@ class UltraTracePublicInputBlock : public UltraTraceBlock {};
 class UltraTraceLookupBlock : public UltraTraceBlock {
   public:
     SelectorType& q_lookup_type() override { return gate_selector; }
-    const SelectorType& q_lookup_type() const override { return gate_selector; }
 
   private:
     SlabVectorSelector<fr> gate_selector;
@@ -87,7 +60,6 @@ class UltraTraceLookupBlock : public UltraTraceBlock {
 class UltraTraceArithmeticBlock : public UltraTraceBlock {
   public:
     SelectorType& q_arith() override { return gate_selector; }
-    const SelectorType& q_arith() const override { return gate_selector; }
 
   private:
     SlabVectorSelector<fr> gate_selector;
@@ -96,7 +68,6 @@ class UltraTraceArithmeticBlock : public UltraTraceBlock {
 class UltraTraceDeltaRangeBlock : public UltraTraceBlock {
   public:
     SelectorType& q_delta_range() override { return gate_selector; }
-    const SelectorType& q_delta_range() const override { return gate_selector; }
 
   private:
     SlabVectorSelector<fr> gate_selector;
@@ -105,7 +76,6 @@ class UltraTraceDeltaRangeBlock : public UltraTraceBlock {
 class UltraTraceEllipticBlock : public UltraTraceBlock {
   public:
     SelectorType& q_elliptic() override { return gate_selector; }
-    const SelectorType& q_elliptic() const override { return gate_selector; }
 
   private:
     SlabVectorSelector<fr> gate_selector;
@@ -114,7 +84,6 @@ class UltraTraceEllipticBlock : public UltraTraceBlock {
 class UltraTraceMemoryBlock : public UltraTraceBlock {
   public:
     SelectorType& q_memory() override { return gate_selector; }
-    const SelectorType& q_memory() const override { return gate_selector; }
 
   private:
     SlabVectorSelector<fr> gate_selector;
@@ -123,7 +92,6 @@ class UltraTraceMemoryBlock : public UltraTraceBlock {
 class UltraTraceNonNativeFieldBlock : public UltraTraceBlock {
   public:
     SelectorType& q_nnf() override { return gate_selector; }
-    const SelectorType& q_nnf() const override { return gate_selector; }
 
   private:
     SlabVectorSelector<fr> gate_selector;
@@ -132,7 +100,6 @@ class UltraTraceNonNativeFieldBlock : public UltraTraceBlock {
 class UltraTracePoseidon2ExternalBlock : public UltraTraceBlock {
   public:
     SelectorType& q_poseidon2_external() override { return gate_selector; }
-    const SelectorType& q_poseidon2_external() const override { return gate_selector; }
 
   private:
     SlabVectorSelector<fr> gate_selector;
@@ -141,7 +108,6 @@ class UltraTracePoseidon2ExternalBlock : public UltraTraceBlock {
 class UltraTracePoseidon2InternalBlock : public UltraTraceBlock {
   public:
     SelectorType& q_poseidon2_internal() override { return gate_selector; }
-    const SelectorType& q_poseidon2_internal() const override { return gate_selector; }
 
   private:
     SlabVectorSelector<fr> gate_selector;
@@ -157,15 +123,6 @@ class UltraTraceOverflowBlock : public UltraTraceBlock {
     SelectorType& q_nnf() override { return gate_selectors[5]; }
     SelectorType& q_poseidon2_external() override { return gate_selectors[6]; }
     SelectorType& q_poseidon2_internal() override { return gate_selectors[7]; }
-
-    const SelectorType& q_lookup_type() const override { return gate_selectors[0]; };
-    const SelectorType& q_arith() const override { return gate_selectors[1]; }
-    const SelectorType& q_delta_range() const override { return gate_selectors[2]; }
-    const SelectorType& q_elliptic() const override { return gate_selectors[3]; }
-    const SelectorType& q_memory() const override { return gate_selectors[4]; }
-    const SelectorType& q_nnf() const override { return gate_selectors[5]; }
-    const SelectorType& q_poseidon2_external() const override { return gate_selectors[6]; }
-    const SelectorType& q_poseidon2_internal() const override { return gate_selectors[7]; }
 
   private:
     std::array<SlabVectorSelector<fr>, 8> gate_selectors;

--- a/barretenberg/cpp/src/barretenberg/honk/execution_trace/ultra_execution_trace.hpp
+++ b/barretenberg/cpp/src/barretenberg/honk/execution_trace/ultra_execution_trace.hpp
@@ -90,12 +90,6 @@ class UltraTraceBlock : public ExecutionTraceBlock<fr, /*NUM_WIRES_ */ 4, /*NUM_
     auto& q_nnf() { return this->selectors[11]; };
     auto& q_poseidon2_external() { return this->selectors[12]; };
     auto& q_poseidon2_internal() { return this->selectors[13]; };
-
-    RefVector<SelectorType> get_gate_selectors()
-    {
-        return { q_lookup_type(), q_arith(), q_delta_range(),        q_elliptic(),
-                 q_memory(),      q_nnf(),   q_poseidon2_external(), q_poseidon2_internal() };
-    }
 };
 
 class UltraExecutionTraceBlocks : public UltraTraceBlockData<UltraTraceBlock> {

--- a/barretenberg/cpp/src/barretenberg/honk/execution_trace/ultra_execution_trace.hpp
+++ b/barretenberg/cpp/src/barretenberg/honk/execution_trace/ultra_execution_trace.hpp
@@ -56,7 +56,8 @@ template <typename T> struct UltraTraceBlockData {
     bool operator==(const UltraTraceBlockData& other) const = default;
 };
 
-class UltraTraceBlock : public ExecutionTraceBlock<fr, /*NUM_WIRES_ */ 4, /*NUM_SELECTORS_*/ 7> {
+class UltraTraceBlock
+    : public ExecutionTraceBlock<fr, /*NUM_WIRES_ */ 4, /*NUM_NON_ZERO_SELECTORS_*/ 7, /*NUM_ZERO_SELECTORS_*/ 8> {
   public:
     void populate_wires(const uint32_t& idx_1, const uint32_t& idx_2, const uint32_t& idx_3, const uint32_t& idx_4)
     {
@@ -75,12 +76,12 @@ class UltraTraceBlock : public ExecutionTraceBlock<fr, /*NUM_WIRES_ */ 4, /*NUM_
     auto& w_o() { return std::get<2>(this->wires); };
     auto& w_4() { return std::get<3>(this->wires); };
 
-    SlabVectorSelector<fr>& q_m() { return this->selectors[0]; };
-    SlabVectorSelector<fr>& q_c() { return this->selectors[1]; };
-    SlabVectorSelector<fr>& q_1() { return this->selectors[2]; };
-    SlabVectorSelector<fr>& q_2() { return this->selectors[3]; };
-    SlabVectorSelector<fr>& q_3() { return this->selectors[4]; };
-    SlabVectorSelector<fr>& q_4() { return this->selectors[5]; };
+    SlabVectorSelector<fr>& q_m() { return non_zero_selectors[0]; };
+    SlabVectorSelector<fr>& q_c() { return non_zero_selectors[1]; };
+    SlabVectorSelector<fr>& q_1() { return non_zero_selectors[2]; };
+    SlabVectorSelector<fr>& q_2() { return non_zero_selectors[3]; };
+    SlabVectorSelector<fr>& q_3() { return non_zero_selectors[4]; };
+    SlabVectorSelector<fr>& q_4() { return non_zero_selectors[5]; };
 
     enum class Type {
         LOOKUP_TYPE,
@@ -96,58 +97,58 @@ class UltraTraceBlock : public ExecutionTraceBlock<fr, /*NUM_WIRES_ */ 4, /*NUM_
     Selector<fr>& q_lookup_type()
     {
         if (type == Type::LOOKUP_TYPE) {
-            return this->selectors[6];
+            return non_zero_selectors[6];
         }
-        return zero_selector;
+        return zero_selectors[0];
     };
     Selector<fr>& q_arith()
     {
         if (type == Type::ARITHMETIC) {
-            return this->selectors[6];
+            return non_zero_selectors[6];
         }
-        return zero_selector;
+        return zero_selectors[1];
     }
     Selector<fr>& q_delta_range()
     {
         if (type == Type::DELTA_RANGE) {
-            return this->selectors[6];
+            return non_zero_selectors[6];
         }
-        return zero_selector;
+        return zero_selectors[2];
     }
     Selector<fr>& q_elliptic()
     {
         if (type == Type::ELLIPTIC) {
-            return this->selectors[6];
+            return non_zero_selectors[6];
         }
-        return zero_selector;
+        return zero_selectors[3];
     }
     Selector<fr>& q_memory()
     {
         if (type == Type::MEMORY) {
-            return this->selectors[6];
+            return non_zero_selectors[6];
         }
-        return zero_selector;
+        return zero_selectors[4];
     }
     Selector<fr>& q_nnf()
     {
         if (type == Type::NON_NATIVE_FIELD) {
-            return this->selectors[6];
+            return non_zero_selectors[6];
         }
-        return zero_selector;
+        return zero_selectors[5];
     }
     Selector<fr>& q_poseidon2_external()
     {
         if (type == Type::POSEIDON2_EXTERNAL) {
-            return this->selectors[6];
+            return non_zero_selectors[6];
         }
-        return zero_selector;
+        return zero_selectors[6];
     }
     Selector<fr>& q_poseidon2_internal()
     {
         if (type == Type::POSEIDON2_INTERNAL) {
-            return this->selectors[6];
+            return non_zero_selectors[6];
         }
-        return zero_selector;
+        return zero_selectors[7];
     }
 };
 
@@ -155,7 +156,8 @@ class UltraExecutionTraceBlocks : public UltraTraceBlockData<UltraTraceBlock> {
 
   public:
     static constexpr size_t NUM_WIRES = UltraTraceBlock::NUM_WIRES;
-    static constexpr size_t NUM_SELECTORS = UltraTraceBlock::NUM_SELECTORS;
+    static constexpr size_t NUM_NON_ZERO_SELECTORS = UltraTraceBlock::NUM_NON_ZERO_SELECTORS;
+    static constexpr size_t NUM_ZERO_SELECTORS = UltraTraceBlock::NUM_ZERO_SELECTORS;
     using FF = fr;
 
     bool has_overflow = false;

--- a/barretenberg/cpp/src/barretenberg/honk/execution_trace/ultra_execution_trace.hpp
+++ b/barretenberg/cpp/src/barretenberg/honk/execution_trace/ultra_execution_trace.hpp
@@ -14,48 +14,6 @@
 
 namespace bb {
 
-/**
- * @brief Defines the circuit block types for the Ultra arithmetization
- * @note Its useful to define this as a template since it is used to actually store gate data (T = UltraTraceBlock)
- * but also to store corresponding block sizes (T = uint32_t) for the structured trace or dynamic block size
- * tracking in ClientIvc.
- *
- * @tparam T
- */
-template <typename T> struct UltraTraceBlockData {
-    T pub_inputs; // Has to be the first block
-    T lookup;
-    T arithmetic;
-    T delta_range;
-    T elliptic;
-    T memory;
-    T nnf;
-    T poseidon2_external;
-    T poseidon2_internal;
-    T overflow;
-
-    auto get()
-    {
-        return RefArray{ pub_inputs, lookup, arithmetic,         delta_range,        elliptic,
-                         memory,     nnf,    poseidon2_external, poseidon2_internal, overflow };
-    }
-
-    auto get() const
-    {
-        return RefArray{ pub_inputs, lookup, arithmetic,         delta_range,        elliptic,
-                         memory,     nnf,    poseidon2_external, poseidon2_internal, overflow };
-    }
-
-    auto get_gate_blocks() const
-    {
-        return RefArray{
-            lookup, arithmetic, delta_range, elliptic, memory, nnf, poseidon2_external, poseidon2_internal
-        };
-    }
-
-    bool operator==(const UltraTraceBlockData& other) const = default;
-};
-
 class UltraTraceBlock
     : public ExecutionTraceBlock<fr, /*NUM_WIRES_ */ 4, /*NUM_NON_ZERO_SELECTORS_*/ 7, /*NUM_ZERO_SELECTORS_*/ 8> {
   public:
@@ -152,7 +110,44 @@ class UltraTraceBlock
     }
 };
 
-class UltraExecutionTraceBlocks : public UltraTraceBlockData<UltraTraceBlock> {
+/**
+ * @brief Defines the circuit block types for the Ultra arithmetization
+ */
+struct UltraTraceBlockData {
+    UltraTraceBlock pub_inputs; // Has to be the first block
+    UltraTraceBlock lookup;
+    UltraTraceBlock arithmetic;
+    UltraTraceBlock delta_range;
+    UltraTraceBlock elliptic;
+    UltraTraceBlock memory;
+    UltraTraceBlock nnf;
+    UltraTraceBlock poseidon2_external;
+    UltraTraceBlock poseidon2_internal;
+    UltraTraceBlock overflow;
+
+    auto get()
+    {
+        return RefArray{ pub_inputs, lookup, arithmetic,         delta_range,        elliptic,
+                         memory,     nnf,    poseidon2_external, poseidon2_internal, overflow };
+    }
+
+    auto get() const
+    {
+        return RefArray{ pub_inputs, lookup, arithmetic,         delta_range,        elliptic,
+                         memory,     nnf,    poseidon2_external, poseidon2_internal, overflow };
+    }
+
+    auto get_gate_blocks() const
+    {
+        return RefArray{
+            lookup, arithmetic, delta_range, elliptic, memory, nnf, poseidon2_external, poseidon2_internal
+        };
+    }
+
+    bool operator==(const UltraTraceBlockData& other) const = default;
+};
+
+class UltraExecutionTraceBlocks : public UltraTraceBlockData {
 
   public:
     static constexpr size_t NUM_WIRES = UltraTraceBlock::NUM_WIRES;

--- a/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/ultra_verification_keys_comparator.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/ultra_verification_keys_comparator.hpp
@@ -32,9 +32,9 @@ static void compare_ultra_blocks_and_verification_keys(
 
     size_t block_idx = 0;
     for (auto [block_0, block_1] : zip_view(blocks[0].get(), blocks[1].get())) {
-        BB_ASSERT_EQ(block_0.non_zero_selectors.size(), block_1.non_zero_selectors.size());
+        BB_ASSERT_EQ(block_0.get_selectors().size(), block_1.get_selectors().size());
         size_t selector_idx = 0;
-        for (auto [p_10, p_11] : zip_view(block_0.non_zero_selectors, block_1.non_zero_selectors)) {
+        for (auto [p_10, p_11] : zip_view(block_0.get_selectors(), block_1.get_selectors())) {
             check_eq(p_10, p_11, block_idx, selector_idx);
             selector_idx++;
         }

--- a/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/ultra_verification_keys_comparator.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/ultra_verification_keys_comparator.hpp
@@ -32,9 +32,9 @@ static void compare_ultra_blocks_and_verification_keys(
 
     size_t block_idx = 0;
     for (auto [block_0, block_1] : zip_view(blocks[0].get(), blocks[1].get())) {
-        BB_ASSERT_EQ(block_0.selectors.size(), block_1.selectors.size());
+        BB_ASSERT_EQ(block_0.non_zero_selectors.size(), block_1.non_zero_selectors.size());
         size_t selector_idx = 0;
-        for (auto [p_10, p_11] : zip_view(block_0.selectors, block_1.selectors)) {
+        for (auto [p_10, p_11] : zip_view(block_0.non_zero_selectors, block_1.non_zero_selectors)) {
             check_eq(p_10, p_11, block_idx, selector_idx);
             selector_idx++;
         }

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/mega_circuit_builder.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/mega_circuit_builder.cpp
@@ -168,12 +168,18 @@ template <typename FF> ecc_op_tuple MegaCircuitBuilder_<FF>::populate_ecc_op_wir
     op_tuple.z_2 = this->add_variable(ultra_op.z_2);
 
     this->blocks.ecc_op.populate_wires(op_tuple.op, op_tuple.x_lo, op_tuple.x_hi, op_tuple.y_lo);
-    for (auto& selector : this->blocks.ecc_op.selectors) {
+    for (auto& selector : this->blocks.ecc_op.non_zero_selectors) {
+        selector.emplace_back(0);
+    }
+    for (auto& selector : this->blocks.ecc_op.zero_selectors) {
         selector.emplace_back(0);
     }
 
     this->blocks.ecc_op.populate_wires(this->zero_idx, op_tuple.y_hi, op_tuple.z_1, op_tuple.z_2);
-    for (auto& selector : this->blocks.ecc_op.selectors) {
+    for (auto& selector : this->blocks.ecc_op.non_zero_selectors) {
+        selector.emplace_back(0);
+    }
+    for (auto& selector : this->blocks.ecc_op.zero_selectors) {
         selector.emplace_back(0);
     }
 

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/mega_circuit_builder.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/mega_circuit_builder.cpp
@@ -168,18 +168,12 @@ template <typename FF> ecc_op_tuple MegaCircuitBuilder_<FF>::populate_ecc_op_wir
     op_tuple.z_2 = this->add_variable(ultra_op.z_2);
 
     this->blocks.ecc_op.populate_wires(op_tuple.op, op_tuple.x_lo, op_tuple.x_hi, op_tuple.y_lo);
-    for (auto& selector : this->blocks.ecc_op.non_zero_selectors) {
-        selector.emplace_back(0);
-    }
-    for (auto& selector : this->blocks.ecc_op.zero_selectors) {
+    for (auto& selector : this->blocks.ecc_op.get_selectors()) {
         selector.emplace_back(0);
     }
 
     this->blocks.ecc_op.populate_wires(this->zero_idx, op_tuple.y_hi, op_tuple.z_1, op_tuple.z_2);
-    for (auto& selector : this->blocks.ecc_op.non_zero_selectors) {
-        selector.emplace_back(0);
-    }
-    for (auto& selector : this->blocks.ecc_op.zero_selectors) {
+    for (auto& selector : this->blocks.ecc_op.get_selectors()) {
         selector.emplace_back(0);
     }
 

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.cpp
@@ -1950,7 +1950,10 @@ template <typename ExecutionTrace> void UltraCircuitBuilder_<ExecutionTrace>::po
     for (const auto& idx : this->public_inputs()) {
         // first two wires get a copy of the public inputs
         blocks.pub_inputs.populate_wires(idx, idx, this->zero_idx, this->zero_idx);
-        for (auto& selector : this->blocks.pub_inputs.selectors) {
+        for (auto& selector : this->blocks.pub_inputs.non_zero_selectors) {
+            selector.emplace_back(0);
+        }
+        for (auto& selector : this->blocks.pub_inputs.zero_selectors) {
             selector.emplace_back(0);
         }
     }
@@ -2509,7 +2512,8 @@ template <typename ExecutionTrace> uint256_t UltraCircuitBuilder_<ExecutionTrace
 
     // Hash the selectors, the wires, and the variable index array (which captures information about copy constraints)
     for (auto& block : blocks.get()) {
-        std::for_each(block.selectors.begin(), block.selectors.end(), convert_and_insert_selectors);
+        std::for_each(block.non_zero_selectors.begin(), block.non_zero_selectors.end(), convert_and_insert_selectors);
+        std::for_each(block.zero_selectors.begin(), block.zero_selectors.end(), convert_and_insert_selectors);
         std::for_each(block.wires.begin(), block.wires.end(), convert_and_insert_vectors);
     }
     convert_and_insert_vectors(circuit.real_variable_index);

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.cpp
@@ -2498,17 +2498,21 @@ template <typename ExecutionTrace> uint256_t UltraCircuitBuilder_<ExecutionTrace
     circuit.finalize_circuit(/*ensure_nonzero=*/false);
 
     std::vector<uint8_t> to_hash;
-    const auto convert_and_insert = [&to_hash](auto& vector) {
-        std::vector<uint8_t> buffer = to_buffer(vector);
+    const auto convert_and_insert_selectors = [&to_hash](auto& selector) {
+        std::vector<uint8_t> buffer = selector.to_buffer();
+        to_hash.insert(to_hash.end(), buffer.begin(), buffer.end());
+    };
+    const auto convert_and_insert_vectors = [&to_hash](auto& wire) {
+        std::vector<uint8_t> buffer = to_buffer(wire);
         to_hash.insert(to_hash.end(), buffer.begin(), buffer.end());
     };
 
     // Hash the selectors, the wires, and the variable index array (which captures information about copy constraints)
     for (auto& block : blocks.get()) {
-        std::for_each(block.selectors.begin(), block.selectors.end(), convert_and_insert);
-        std::for_each(block.wires.begin(), block.wires.end(), convert_and_insert);
+        std::for_each(block.selectors.begin(), block.selectors.end(), convert_and_insert_selectors);
+        std::for_each(block.wires.begin(), block.wires.end(), convert_and_insert_vectors);
     }
-    convert_and_insert(circuit.real_variable_index);
+    convert_and_insert_vectors(circuit.real_variable_index);
 
     return from_buffer<uint256_t>(crypto::sha256(to_hash));
 }

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.cpp
@@ -653,8 +653,8 @@ void UltraCircuitBuilder_<ExecutionTrace>::create_ecc_add_gate(const ecc_add_gat
     }
 
     if (can_fuse_into_previous_gate) {
-        block.q_1()[block.size() - 1] = in.sign_coefficient;
-        block.q_elliptic()[block.size() - 1] = 1;
+        block.q_1().set(block.size() - 1, in.sign_coefficient);
+        block.q_elliptic().set(block.size() - 1, 1);
     } else {
         block.populate_wires(this->zero_idx, in.x1, in.y1, this->zero_idx);
         block.q_3().emplace_back(0);
@@ -714,8 +714,8 @@ void UltraCircuitBuilder_<ExecutionTrace>::create_ecc_dbl_gate(const ecc_dbl_gat
     }
 
     if (can_fuse_into_previous_gate) {
-        block.q_elliptic()[block.size() - 1] = 1;
-        block.q_m()[block.size() - 1] = 1;
+        block.q_elliptic().set(block.size() - 1, 1);
+        block.q_m().set(block.size() - 1, 1);
     } else {
         block.populate_wires(this->zero_idx, in.x1, in.y1, this->zero_idx);
         block.q_elliptic().emplace_back(1);

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.hpp
@@ -799,8 +799,6 @@ class UltraCircuitBuilder_ : public CircuitBuilderBase<typename ExecutionTrace_:
     void create_poseidon2_external_gate(const poseidon2_external_gate_<FF>& in);
     void create_poseidon2_internal_gate(const poseidon2_internal_gate_<FF>& in);
 
-    uint256_t hash_circuit() const;
-
     msgpack::sbuffer export_circuit() override;
 };
 using UltraCircuitBuilder = UltraCircuitBuilder_<UltraExecutionTraceBlocks>;

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.hpp
@@ -331,9 +331,12 @@ class UltraCircuitBuilder_ : public CircuitBuilderBase<typename ExecutionTrace_:
         // do nothing
 #else
         for (auto& block : blocks.get()) {
-            size_t nominal_size = block.selectors[0].size();
-            for (size_t idx = 1; idx < block.selectors.size(); ++idx) {
-                ASSERT_DEBUG(block.selectors[idx].size() == nominal_size);
+            size_t nominal_size = block.non_zero_selectors[0].size();
+            for (size_t idx = 1; idx < block.non_zero_selectors.size(); ++idx) {
+                ASSERT_DEBUG(block.non_zero_selectors[idx].size() == nominal_size);
+            }
+            for (auto& selector : block.zero_selectors) {
+                ASSERT_DEBUG(selector.size() == nominal_size);
             }
         }
 

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.hpp
@@ -679,7 +679,40 @@ class UltraCircuitBuilder_ : public CircuitBuilderBase<typename ExecutionTrace_:
         const uint32_t variable_index,
         const size_t num_bits,
         std::string const& msg = "decompose_into_default_range_better_for_oddlimbnum");
-    void create_dummy_gate(auto& block, const uint32_t&, const uint32_t&, const uint32_t&, const uint32_t&);
+
+    /**
+     * @brief Create a gate with no constraints but with possibly non-trivial wire values
+     * @details A dummy gate can be used to provide wire values to be accessed via shifts by the gate that proceeds it.
+     * The dummy gate itself does not have to satisfy any constraints (all selectors are zero).
+     *
+     * @tparam ExecutionTrace
+     * @param block Execution trace block into which the dummy gate is to be placed
+     */
+    void create_dummy_gate(
+        auto& block, const uint32_t& idx_1, const uint32_t& idx_2, const uint32_t& idx_3, const uint32_t& idx_4)
+    {
+        block.populate_wires(idx_1, idx_2, idx_3, idx_4);
+        block.q_m().emplace_back(0);
+        block.q_1().emplace_back(0);
+        block.q_2().emplace_back(0);
+        block.q_3().emplace_back(0);
+        block.q_c().emplace_back(0);
+        block.q_arith().emplace_back(0);
+        block.q_4().emplace_back(0);
+        block.q_delta_range().emplace_back(0);
+        block.q_elliptic().emplace_back(0);
+        block.q_lookup_type().emplace_back(0);
+        block.q_memory().emplace_back(0);
+        block.q_nnf().emplace_back(0);
+        block.q_poseidon2_external().emplace_back(0);
+        block.q_poseidon2_internal().emplace_back(0);
+
+        if constexpr (HasAdditionalSelectors<ExecutionTrace>) {
+            block.pad_additional();
+        }
+        check_selector_length_consistency();
+        ++this->num_gates;
+    }
     void create_dummy_constraints(const std::vector<uint32_t>& variable_index);
     void create_sort_constraint(const std::vector<uint32_t>& variable_index);
     void create_sort_constraint_with_edges(const std::vector<uint32_t>& variable_index, const FF&, const FF&);

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.hpp
@@ -48,7 +48,6 @@ class UltraCircuitBuilder_ : public CircuitBuilderBase<typename ExecutionTrace_:
     static constexpr size_t NUM_WIRES = ExecutionTrace::NUM_WIRES;
     // Keeping NUM_WIRES, at least temporarily, for backward compatibility
     static constexpr size_t program_width = ExecutionTrace::NUM_WIRES;
-    static constexpr size_t num_selectors = ExecutionTrace::NUM_SELECTORS;
 
     static constexpr std::string_view NAME_STRING = "UltraCircuitBuilder";
     static constexpr CircuitType CIRCUIT_TYPE = CircuitType::ULTRA;

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.hpp
@@ -332,7 +332,7 @@ class UltraCircuitBuilder_ : public CircuitBuilderBase<typename ExecutionTrace_:
 #else
         for (auto& block : blocks.get()) {
             const auto& block_selectors = block.get_selectors();
-            size_t nominal_size = block_selectors.size();
+            size_t nominal_size = block_selectors[0].size();
             for (size_t idx = 1; idx < block_selectors.size(); ++idx) {
                 ASSERT_DEBUG(block_selectors[idx].size() == nominal_size);
             }

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.hpp
@@ -331,12 +331,10 @@ class UltraCircuitBuilder_ : public CircuitBuilderBase<typename ExecutionTrace_:
         // do nothing
 #else
         for (auto& block : blocks.get()) {
-            size_t nominal_size = block.non_zero_selectors[0].size();
-            for (size_t idx = 1; idx < block.non_zero_selectors.size(); ++idx) {
-                ASSERT_DEBUG(block.non_zero_selectors[idx].size() == nominal_size);
-            }
-            for (auto& selector : block.zero_selectors) {
-                ASSERT_DEBUG(selector.size() == nominal_size);
+            const auto& block_selectors = block.get_selectors();
+            size_t nominal_size = block_selectors.size();
+            for (size_t idx = 1; idx < block_selectors.size(); ++idx) {
+                ASSERT_DEBUG(block_selectors[idx].size() == nominal_size);
             }
         }
 

--- a/barretenberg/cpp/src/barretenberg/trace_to_polynomials/trace_to_polynomials.cpp
+++ b/barretenberg/cpp/src/barretenberg/trace_to_polynomials/trace_to_polynomials.cpp
@@ -80,18 +80,11 @@ std::vector<CyclicPermutation> TraceToPolynomials<Flavor>::populate_wires_and_se
             }
         }
 
+        RefVector<Selector<FF>> block_selectors = block.get_selectors();
         // Insert the selector values for this block into the selector polynomials at the correct offset
         // TODO(https://github.com/AztecProtocol/barretenberg/issues/398): implicit arithmetization/flavor consistency
-        for (size_t selector_idx = 0; selector_idx < NUM_NON_ZERO_SELECTORS; selector_idx++) {
-            auto& selector = block.non_zero_selectors[selector_idx];
-            for (size_t row_idx = 0; row_idx < block_size; ++row_idx) {
-                size_t trace_row_idx = row_idx + offset;
-                selectors[selector_idx].set_if_valid_index(trace_row_idx, selector[row_idx]);
-            }
-        }
-        for (size_t selector_idx = NUM_NON_ZERO_SELECTORS; selector_idx < NUM_NON_ZERO_SELECTORS + NUM_ZERO_SELECTORS;
-             selector_idx++) {
-            auto& selector = block.zero_selectors[selector_idx];
+        for (size_t selector_idx = 0; selector_idx < block_selectors.size(); selector_idx++) {
+            auto& selector = block_selectors[selector_idx];
             for (size_t row_idx = 0; row_idx < block_size; ++row_idx) {
                 size_t trace_row_idx = row_idx + offset;
                 selectors[selector_idx].set_if_valid_index(trace_row_idx, selector[row_idx]);

--- a/barretenberg/cpp/src/barretenberg/trace_to_polynomials/trace_to_polynomials.cpp
+++ b/barretenberg/cpp/src/barretenberg/trace_to_polynomials/trace_to_polynomials.cpp
@@ -82,8 +82,16 @@ std::vector<CyclicPermutation> TraceToPolynomials<Flavor>::populate_wires_and_se
 
         // Insert the selector values for this block into the selector polynomials at the correct offset
         // TODO(https://github.com/AztecProtocol/barretenberg/issues/398): implicit arithmetization/flavor consistency
-        for (size_t selector_idx = 0; selector_idx < NUM_SELECTORS; selector_idx++) {
-            auto& selector = block.selectors[selector_idx];
+        for (size_t selector_idx = 0; selector_idx < NUM_NON_ZERO_SELECTORS; selector_idx++) {
+            auto& selector = block.non_zero_selectors[selector_idx];
+            for (size_t row_idx = 0; row_idx < block_size; ++row_idx) {
+                size_t trace_row_idx = row_idx + offset;
+                selectors[selector_idx].set_if_valid_index(trace_row_idx, selector[row_idx]);
+            }
+        }
+        for (size_t selector_idx = NUM_NON_ZERO_SELECTORS; selector_idx < NUM_NON_ZERO_SELECTORS + NUM_ZERO_SELECTORS;
+             selector_idx++) {
+            auto& selector = block.zero_selectors[selector_idx];
             for (size_t row_idx = 0; row_idx < block_size; ++row_idx) {
                 size_t trace_row_idx = row_idx + offset;
                 selectors[selector_idx].set_if_valid_index(trace_row_idx, selector[row_idx]);

--- a/barretenberg/cpp/src/barretenberg/trace_to_polynomials/trace_to_polynomials.cpp
+++ b/barretenberg/cpp/src/barretenberg/trace_to_polynomials/trace_to_polynomials.cpp
@@ -50,7 +50,7 @@ std::vector<CyclicPermutation> TraceToPolynomials<Flavor>::populate_wires_and_se
     copy_cycles.resize(builder.get_num_variables()); // at most one copy cycle per variable
 
     RefArray<Polynomial, NUM_WIRES> wires = polynomials.get_wires();
-    RefArray<Polynomial, NUM_SELECTORS> selectors = polynomials.get_selectors();
+    auto selectors = polynomials.get_selectors();
 
     // For each block in the trace, populate wire polys, copy cycles and selector polys
     for (auto& block : builder.blocks.get()) {

--- a/barretenberg/cpp/src/barretenberg/trace_to_polynomials/trace_to_polynomials.hpp
+++ b/barretenberg/cpp/src/barretenberg/trace_to_polynomials/trace_to_polynomials.hpp
@@ -23,7 +23,8 @@ template <class Flavor> class TraceToPolynomials {
   public:
     static constexpr size_t NUM_WIRES = Builder::NUM_WIRES;
 
-    static constexpr size_t NUM_SELECTORS = Builder::ExecutionTrace::NUM_SELECTORS;
+    static constexpr size_t NUM_NON_ZERO_SELECTORS = Builder::ExecutionTrace::NUM_NON_ZERO_SELECTORS;
+    static constexpr size_t NUM_ZERO_SELECTORS = Builder::ExecutionTrace::NUM_ZERO_SELECTORS;
 
     /**
      * @brief Given a circuit, populate a proving key with wire polys, selector polys, and sigma/id polys

--- a/barretenberg/cpp/src/barretenberg/trace_to_polynomials/trace_to_polynomials.hpp
+++ b/barretenberg/cpp/src/barretenberg/trace_to_polynomials/trace_to_polynomials.hpp
@@ -23,9 +23,6 @@ template <class Flavor> class TraceToPolynomials {
   public:
     static constexpr size_t NUM_WIRES = Builder::NUM_WIRES;
 
-    static constexpr size_t NUM_NON_ZERO_SELECTORS = Builder::ExecutionTrace::NUM_NON_ZERO_SELECTORS;
-    static constexpr size_t NUM_ZERO_SELECTORS = Builder::ExecutionTrace::NUM_ZERO_SELECTORS;
-
     /**
      * @brief Given a circuit, populate a proving key with wire polys, selector polys, and sigma/id polys
      * @note By default, this method constructs an exectution trace that is sorted by gate type. Optionally, it

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/decider_proving_key.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/decider_proving_key.cpp
@@ -321,7 +321,7 @@ void DeciderProvingKey_<Flavor>::move_structured_trace_overflow_to_overflow_bloc
             // ensures it can be read into by the previous gate but does not itself try to read into the next gate.
             for (auto& selector : block.get_gate_selectors()) {
                 BB_ASSERT_EQ(selector.empty(), false);
-                selector.back() = 0;
+                selector.set_back(0);
             }
         }
     }

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/decider_proving_key.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/decider_proving_key.cpp
@@ -311,14 +311,7 @@ void DeciderProvingKey_<Flavor>::move_structured_trace_overflow_to_overflow_bloc
                 }
                 wire.resize(fixed_block_size); // shrink the main block to its max capacity
             }
-            for (auto [selector, overflow_selector] :
-                 zip_view(block.non_zero_selectors, overflow_block.non_zero_selectors)) {
-                for (size_t i = overflow_start; i < overflow_end; ++i) {
-                    overflow_selector.push_back(selector[i]);
-                }
-                selector.resize(fixed_block_size); // shrink the main block to its max capacity
-            }
-            for (auto [selector, overflow_selector] : zip_view(block.zero_selectors, overflow_block.zero_selectors)) {
+            for (auto [selector, overflow_selector] : zip_view(block.get_selectors(), overflow_block.get_selectors())) {
                 for (size_t i = overflow_start; i < overflow_end; ++i) {
                     overflow_selector.push_back(selector[i]);
                 }

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/decider_proving_key.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/decider_proving_key.cpp
@@ -311,7 +311,14 @@ void DeciderProvingKey_<Flavor>::move_structured_trace_overflow_to_overflow_bloc
                 }
                 wire.resize(fixed_block_size); // shrink the main block to its max capacity
             }
-            for (auto [selector, overflow_selector] : zip_view(block.selectors, overflow_block.selectors)) {
+            for (auto [selector, overflow_selector] :
+                 zip_view(block.non_zero_selectors, overflow_block.non_zero_selectors)) {
+                for (size_t i = overflow_start; i < overflow_end; ++i) {
+                    overflow_selector.push_back(selector[i]);
+                }
+                selector.resize(fixed_block_size); // shrink the main block to its max capacity
+            }
+            for (auto [selector, overflow_selector] : zip_view(block.zero_selectors, overflow_block.zero_selectors)) {
                 for (size_t i = overflow_start; i < overflow_end; ++i) {
                     overflow_selector.push_back(selector[i]);
                 }


### PR DESCRIPTION
Most `ExecutionTraceBlock` except the overflow block is restricted to a certain type of gates. The other gate selectors are always zero so we don't need to store them explicitly. Not storing them can save us about 400MB memory.

I felt it was the easiest to represent the selectors that will be zero by a new class of selector `ZeroSelector`, which is always zero and uses constant memory. This way, the call sites that populate or read the selectors only need minimum change.

Each selector in the block is of an abstract type `Selector`, and they can be either `ZeroSelector` or `SlabVectorSelector` depending on which derived class the blocks belong to. 

For the bigger picture, see https://hackmd.io/7wcdcdLtQGy95qg7xMFH9A.

Benchmarks:

Testing the memory limit by running `CPUS=16 MEM=Xg ~/aztec-packages/ci3/docker_isolate "BB_SLOW_LOW_MEMORY=1 ./build/bin/ultra_honk_bench --benchmark_filter='construct_proof_ultrahonk_power_of_2/21$'"` with gradually smaller `X`. On this branch, `X` can be as low as ~1.3, whereas on the merge-train, `X` can only go as low as ~1.7. This confirms the 400MB memory improvement.

