### PR TITLE
docs: aztec-nr doc comments

### DIFF
--- a/noir-projects/aztec-nr/README.md
+++ b/noir-projects/aztec-nr/README.md
@@ -17,19 +17,63 @@
 
 # Aztec.nr
 
-`Aztec-nr` is a [Noir](https://noir-lang.org) framework for smart contracts on [Aztec](aztec.network).
+`Aztec-nr` is a [Noir](https://noir-lang.org) framework for writing smart contracts on [Aztec](aztec.network).
 
-### Directory Structure
+## Noir vs Aztec.nr
+
+For those already used to ("Vanilla") Noir:
+
+| | Vanilla Noir | Aztec.nr |
+|---|---|---|
+| High-level distinction | A language for writing a provable program. | A library of helpful functions, state variables, and annotations, written in the Noir language. These can be imported and used like lego bricks, to create an Aztec smart contract. |
+| Can write Aztec smart contracts?  | No | Yes |
+| What language do I write my smart contract in? | n/a | You write your contract logic in Noir. It's just you'll be heavily using the imported annotations, structs and functions from this aztec-nr framework. So all of the logic relating to: declaring state variables; declaring functions; managing state; emitting events, will look clean and readable. The bodies of your functions will still be vanilla Noir. |
+| # programs (provable functions) | 1 program per Noir package | An entire collection of programs (smart contract functions), collected into a "contract" scope, that can operate on Aztec state. |
+| Can manage state variables?  | Not without basically re-writing all of Aztec.nr. | Yes - abstracts-away state management. (You don't need to design and implement your own state trees, for example -- you just plug into Aztec's state trees). |
+| How is a proof verified? | Pass the proof to a NoirJS verifier, or a Solidity verifier. | Send the proof to the Aztec network. |
+| Code compiles to... | ACIR | ACIR (for private functions), Brillig (for utility functions), AVM bytecode (for public functions) |
+| Public Inputs | Can be anything. | Behind-the-scenes, the public inputs rigidly adhere to the Aztec protocol spec. |
+
+A smart contract is essentially some persistent state variables, and a collection of functions which may edit those state variables. But it needs to be able to read and write data to the Aztec network, and the behind-the-scenes nature of how that works is very complex.
+
+Aztec.nr is a gigantic Noir library, which seeks to hide-away all of the complexities of interacting with Aztec. You get to import nice, intuitive types and functions, whilst behind the scenes Aztec.nr does a huge amount of complex stuff to convert your intentions into Aztec-compatible instructions.
+
+
+## Writing an Aztec smart contract with `aztec-nr`
+
+See [here](https://docs.aztec.network/developers/guides/smart_contracts) for more details.
+
+- Create a Noir project
+- Import `aztec-nr` as a dependency
+- Use the various annotations, state variables, and libraries of `aztec-nr` to write your smart contract.
+- See some example contracts [here](https://github.com/AztecProtocol/aztec-packages/tree/master/noir-projects/noir-contracts/contracts).
+
+
+## Directory Structure
+
+This noir workspace contains multiple packages. You can import these packages into your Noir project.
 
 ```
 .
-├── aztec               // The core of the aztec framework
-├── easy-private-state  // A library for easily creating private state
-├── safe-math           // A library for safe arithmetic
-└── value-note          // A library for storing arbitrary values
+└── aztec               // The main framework for writing Aztec smart contracts
+
+// Helpful types that are commonly used alongside the `aztec` library:
+├── uint-note           // An off-the-shelf Note struct, for storing a private u128
+├── value-note          // An off-the-shelf Note struct, for storing a private Field
+└── address-note        // An off-the-shelf Note struct, for storing a private AztecAddress
 ```
 
-## Installing Aztec-nr libraries
+> To be deprecated from the top-level workspace libraries:
+> `CompressedString`
+> `EasyPrivateUint`
+
+> To be relocated from the top-level workspace libraries:
+> `macro_compilation_failure_tests`
+
+
+## Importing `aztec-nr`
+
+To import `aztec-nr` into your own Aztec smart contract project, you'll need to add `aztec-nr` as a dependency inside your project's `Nargo.toml`:
 
 ```toml
 [package]
@@ -47,26 +91,108 @@ easy_private_state = { git = "https://github.com/AztecProtocol/aztec-nr", tag = 
 value_note = { git = "https://github.com/AztecProtocol/aztec-nr", tag = "master" , directory = "value-note" }
 ```
 
-## Prerequisites
+## Installation
 
-To use `Aztec.nr` you must have [Noir](https://noir-lang.org/) installed. Noir is a general purpose programming language for creating zero-knowledge-proofs. `Aztec.nr` supercharges the Noir language with Aztec Smart Contract capabilities.
+See the [Aztec Quickstart Guide](https://docs.aztec.network/developers/getting_started) to install all of the tools needed to write, test, deploy and execute Aztec smart contracts. This is a superset of the tooling needed to write a vanilla Noir program.
 
-### Quick Installation
+## Aztec State
 
-The fastest way to install is with [noirup](https://noir-lang.org/docs/getting_started/quick_start).
+Aztec has two kinds of state:
 
-To use `Aztec-nr` the `aztec` version of `Noir` is required (Note; this version is temporarily required if you would like to use `#[aztec()]` macros).
+- Public state
+- Private state
 
-Once noirup is installed, you can run the following:
+### Public State
 
-```bash
-noirup -v NARGO_VERSION_COMPATIBLE_WITH_YOUR_SANDBOX
-```
+Public state is similar to Ethereum smart contract state. Public state can be mutated by making calls to `#[public]` functions as part of a transaction.
 
-Replace `NARGO_VERSION_COMPATIBLE_WITH_YOUR_SANDBOX` with the version from the output of `aztec-cli get-node-info`:
+> The public functions of a transaction are executed by the current Proposer.
+> A Proposer is a node on the network with the temporary power to build blocks filled with transactions. This block-building power is randomly changed regularly between a set of Validators.
+> The transactions in a block are processed one-after-the-other, and the _public_ functions of each transaction are executed in a specific order.
 
-```bash
-aztec-cli get-node-info
-```
+The fact that public functions are executed _live_, one-after-the-other, means each public function has access to the entire "current" public state of the Aztec blockchain at the time it is executed.
 
-For more installation options, please view [Noir's getting started.](https://noir-lang.org/docs/getting_started/noir_installation)
+The general pattern for mutating _public_ state in a _public_ function is:
+- read the current state
+- mutate the state, however you wish
+- write the updated state
+
+`aztec-nr` exposes the following public state variables:
+
+- `PublicMutable`
+  - `write`
+  - `read`
+- `PublicImmutable`
+  - `initialize`
+  - `read`
+- `DelayedPublicMutable`
+  - In a public function:
+    - `schedule_value_change`
+    - `schedule_delay_change`
+    - `get_current_value` / `get_scheduled_value`
+    - `get_current_delay` / `get_scheduled_delay`
+  - In a private function:
+    - `get_current_value`
+
+See the relevant files for explanations of their properties, and when to use which.
+
+### Private State
+
+Private state is fundamentally different from Ethereum smart contract state.
+
+Private state can only be modified by a user who is _privy_ to that private state, to ensure that the user's secrets stay safe on their device. Any changes to private state are executed within `#[private]` functions.
+
+> Advanced: Each private function execution is proven to be correct with a zero-knowledge proof, which enables private data to be operated on without leaking that data. But generating a proof of a function execution takes slightly longer than conventional native execution of function.
+
+With these things in mind, it would be impractical for all users around the world to form an orderly queue to make changes to their own private state variables one-after-the-other, because sequentially executing and proving each private function would take too long. Throughput would be terrible.
+
+Instead, private functions are executed _asynchronously_, offchain. This enables each user to process any changes to _their own private state_, in their own time, on their own device. All users can do this in parallel.
+
+This asynchronicity has resulted in an unusual state model for Aztec private state.
+
+Whilst a user goes about executing some private functions offchain (on their own device), the _public_ state of the Aztec blockchain will continue to advance. This means as soon as a user commences private execution, their view of the chain will 'branch-off' from the current public view. A private function will not be able to read the "current" public state, because that state will have advanced, and it will not be able to immediately write to the "current" state of the chain, because the user is not the current Proposer.
+
+This is ok, as long as each private function only mutates _the user's own_ private state. Since nobody else _knows_ the user's private state (because it is private), there will be no collisions with the state modifications of any other functions being processed by other users at the same time.
+
+This state model is achieved with Notes and Nullifiers.
+
+A Note can be any custom struct of information, most likely some _private_ information.
+
+A Note can be stored onchain, and as such, a Note can represent a piece of private state.
+
+A single Note might represent the entirety of some private state, like a private NFT.
+
+Or a Note might be one of many notes that, when collected together, can be combined and interpreted to represent some private state. For example, a user's token balance might be made up of a collection of notes which, when collected together and summed, can be interpreted to represent the user's total token balance.
+
+It's a weird model, but `aztec-nr` provides some neat abstractions that seek to make this model intuitive to users.
+
+`aztec-nr` already offers some common off-the-shelf notes, e.g. to represent a private `u128` or a private `AztecAddress`. A user can also define their own note structs to store more-complex private information.
+
+`aztec-nr` then has a notion of "private state variables", which serve as a wrapper to enable notes to be written-to and read-from Aztec's private state tree.
+
+- `PrivateMutable`
+  - `initialize`
+  - `replace`
+  - `initialize_or_replace`
+  - `get_note`
+- `PrivateImmutable`
+  - `initialize`
+  - `get_note`
+- `PrivateSet`
+  - `insert`
+  - `remove`
+  - `pop_notes`
+  - `get_notes`
+
+See the relevant files for explanations of their properties, and when to use which.
+
+### Container state
+
+`aztec-nr` has the following containers within which state can be stored, if required:
+
+- `Map`
+
+
+
+
+

--- a/noir-projects/aztec-nr/aztec/src/context/private_context.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/private_context.nr
@@ -49,7 +49,122 @@ use dep::protocol_types::{
     utils::arrays::{ClaimedLengthArray, trimmed_array_length_hint},
 };
 
-// When finished, one can call .finish() to convert back to the abi
+/// # PrivateContext
+///
+/// The **main interface** between a #[private] function and the Aztec blockchain.
+///
+/// An instance of the PrivateContext is initialized automatically at the outset
+/// of every private function, within the #[private] macro, so you'll never
+/// need to consciously instantiate this yourself.
+///
+/// The instance is always named `context`, and it is always be available within
+/// the body of every #[private] function in your smart contract.
+///
+/// > For those used to "vanilla" Noir, it might be jarring to have access to
+/// > `context` without seeing a declaration `let context = PrivateContext::new(...)`
+/// > within the body of your function. This is just a consequence of using
+/// > macros to tidy-up verbose boilerplate. You can use `nargo expand` to
+/// > expand all macros, if you dare.
+///
+/// Typical usage for a smart contract developer will be to call getter
+/// methods of the PrivateContext.
+///
+/// _Pushing_ data and requests to the context is mostly handled within
+/// aztec-nr's own functions, so typically a smart contract developer won't
+/// need to call any setter methods directly.
+///
+/// > Advanced users might occasionally wish to push data to the context
+/// > directly for lower-level control. If you find yourself doing this, please
+/// > open an issue on GitHub to describe your use case: it might be that
+/// > new functionality should be added to aztec-nr.
+///
+/// ## Responsibilities
+/// - Exposes contextual data to a private function:
+///   - Data relating to how this private function was called.
+///     - msg_sender
+///     - this_address - (the contract address of the private function being
+///                      executed)
+///     - See `CallContext` for more data.
+///   - Data relating to the transaction in which this private function is
+///     being executed.
+///     - chain_id
+///     - version
+///     - gas_settings
+/// - Provides state access:
+///   - Access to the "Anchor block" header.
+///     Recall, a private function cannot read from the "current" block header,
+///     but must read from some historical block header, because as soon as
+///     private function execution begins (asynchronously, on a user's device),
+///     the public state of the chain (the "current state") will have progressed
+///     forward. We call this reference the "Anchor block".
+///     See `BlockHeader`.
+///   - Enables consumption of L1->L2 messages.
+/// - Enables calls to functions of other smart contracts:
+///   - Private function calls
+///   - Enqueueing of public function call requests
+///     (Since public functions are executed at a later time, by a block
+///     proposer, we say they are "enqueued").
+/// - Writes data to the blockchain:
+///   - New notes
+///   - New nullifiers
+///   - Private logs (for sending encrypted note contents or encrypted events)
+///   - New L2->L1 messages.
+/// - Provides args to the private function (handled by the #[private] macro).
+/// - Returns the return values of this private function (handled by the
+///   #[private] macro).
+/// - Makes Key Validation Requests.
+///   - Private functions are not allowed to see master secret keys, because we
+///     do not trust them. They are instead given "app-siloed" secret keys with
+///     a claim that they relate to a master public key. They can then request
+///     validation of this claim, by making a "key validation request" to the
+///     protocol's kernel circuits (which _are_ allowed to see certain master
+///     secret keys).
+///
+/// ## Advanced Responsibilities
+///
+/// - Ultimately, the PrivateContext is responsible for constructing the
+///   PrivateCircuitPublicInputs of the private function being executed.
+///   All private functions on Aztec must have public inputs which adhere
+///   to the rigid layout of the PrivateCircuitPublicInputs, in order to be
+///   compatible with the protocol's kernel circuits.
+///   A well-known misnomer:
+///   - "public inputs" contain both inputs and outputs of this function.
+///     - By "outputs" we mean a lot more side-effects than just the
+///       "return values" of the function.
+///   - Most of the so-called "public inputs" are kept _private_, and never leak
+///     to the outside world, because they are 'swallowed' by the protocol's
+///     kernel circuits before the tx is sent to the network. Only the
+///     following are exposed to the outside world:
+///     - New note_hashes
+///     - New nullifiers
+///     - New private logs
+///     - New L2->L1 messages
+///     - New enqueued public function call requests
+///     All the above-listed arrays of side-effects can be padded by the
+///     user's wallet (through instructions to the kernel circuits, via the
+///     PXE) to obscure their true lengths.
+///
+/// ## Syntax Justification
+///
+/// Both user-defined functions _and_ most functions in aztec-nr need access to
+/// the PrivateContext instance to read/write data. This is why you'll see the
+/// arguably-ugly pervasiveness of the "context" throughout your smart contract
+/// and the aztec-nr library.
+/// For example, `&mut context` is prevalent. In some languages, you can access
+/// and mutate a global variable (such as a PrivateContext instance) from a
+/// function without polluting the function's parameters. With Noir, a function
+/// must explicitly pass control of a mutable variable to another function, by
+/// reference. Since many functions in aztec-nr need to be able to push new data
+/// to the PrivateContext, they need to be handed a mutable reference _to_ the
+/// context as a parameter.
+/// For example, `Context` is prevalent as a generic parameter, to give better
+/// type safety at compile time. Many `aztec-nr` functions don't make sense if
+/// they're called in a particular runtime (private, public or utility), and so
+/// are intentionally only implemented over certain
+/// [Private|Public|Utility]Context structs. This gives smart contract
+/// developers a much faster feedback loop if they're making a mistake, as an
+/// error will be thrown by the LSP or when they compile their contract.
+///
 #[derive(Eq)]
 pub struct PrivateContext {
     // docs:start:private-context
@@ -117,38 +232,215 @@ impl PrivateContext {
         }
     }
 
+    /// Returns the contract address that initiated this function call.
+    ///
+    /// This is similar to `msg.sender` in Solidity (hence the name).
+    ///
+    /// Important Note: Since Aztec doesn't have a concept of an EoA (
+    /// Externally-owned Account), the msg_sender is "undefined" for the first
+    /// function call of every transaction. A value of `-1` is returned in such
+    /// cases.
+    /// The first function call of a tx is likely to be a call to the user's
+    /// account contract, so this quirk will most often be handled by account
+    /// contract developers.
+    ///
+    /// TODO(https://github.com/AztecProtocol/aztec-packages/issues/14025) - we
+    /// are considering making msg_sender: Option<AztecAddress>, since
+    /// a returned value of `Option:none` will be clearer to developers.
+    ///
+    /// # Returns
+    /// * `AztecAddress` - The address of the smart contract that called
+    ///   this function (be it an app contract or a user's account contract).
+    ///   Returns `-1` for the first function call of the tx.
+    ///
     pub fn msg_sender(self) -> AztecAddress {
         self.inputs.call_context.msg_sender
     }
 
+    /// Returns the contract address of the current function being executed.
+    ///
+    /// This is equivalent to `address(this)` in Solidity (hence the name).
+    /// Use this to identify the current contract's address, commonly needed for
+    /// access control or when interacting with other contracts.
+    ///
+    /// # Returns
+    /// * `AztecAddress` - The contract address of the current function being
+    ///                    executed.
+    ///
     pub fn this_address(self) -> AztecAddress {
         self.inputs.call_context.contract_address
     }
 
+    /// Returns the chain ID of the current network.
+    ///
+    /// This is similar to `block.chainid` in Solidity. Returns the unique
+    /// identifier for the blockchain network this transaction is executing on.
+    ///
+    /// Helps prevent cross-chain replay attacks. Useful if implementing
+    /// multi-chain contract logic.
+    ///
+    /// # Returns
+    /// * `Field` - The chain ID as a field element
+    ///
     pub fn chain_id(self) -> Field {
         self.inputs.tx_context.chain_id
     }
 
+    /// Returns the Aztec protocol version that this transaction is executing
+    /// under. Different versions may have different rules, opcodes, or
+    /// cryptographic primitives.
+    ///
+    /// This is similar to how Ethereum has different EVM versions.
+    ///
+    /// Useful for forward/backward compatibility checks
+    ///
+    /// Not to be confused with contract versions; this is the protocol version.
+    ///
+    /// # Returns
+    /// * `Field` - The protocol version as a field element
+    ///
     pub fn version(self) -> Field {
         self.inputs.tx_context.version
     }
 
+    /// Returns the gas settings for the current transaction.
+    ///
+    /// This provides information about gas limits and pricing for the
+    /// transaction, similar to `tx.gasprice` and gas limits in Ethereum.
+    /// However, Aztec has a more sophisticated gas model with separate
+    /// accounting for L2 computation and data availability (DA) costs.
+    ///
+    /// # Returns
+    /// * `GasSettings` - Struct containing gas limits and fee information
+    ///
     pub fn gas_settings(self) -> GasSettings {
         self.inputs.tx_context.gas_settings
     }
 
+    /// Returns the function selector of the currently executing function.
+    ///
+    /// Low-level function: Ordinarily, smart contract developers will not need
+    /// to access this.
+    ///
+    /// This is similar to `msg.sig` in Solidity, which returns the first 4
+    /// bytes of the function signature. In Aztec, the selector uniquely
+    /// identifies which function within the contract is being called.
+    ///
+    /// # Returns
+    /// * `FunctionSelector` - The 4-byte function identifier
+    ///
+    /// # Advanced
+    /// Only #[private] functions have a function selector as a protocol-
+    /// enshrined concept. The function selectors of private functions are
+    /// baked into the preimage of the contract address, and are used by the
+    /// protocol's kernel circuits to identify each private function and ensure
+    /// the correct one is being executed.
+    ///
+    /// Used internally for function dispatch and call verification.
+    ///
     pub fn selector(self) -> FunctionSelector {
         self.inputs.call_context.function_selector
     }
 
+    /// Returns the hash of the arguments passed to the current function.
+    ///
+    /// Very low-level function: You shouldn't need to call this. The #[private]
+    /// macro calls this, and it makes the arguments neatly available to the
+    /// body of your private function.
+    ///
+    /// # Returns
+    /// * `Field` - Hash of the function arguments
+    ///
+    /// # Advanced
+    /// * Arguments are hashed to reduce proof size and verification time
+    /// * Enables efficient argument passing in recursive function calls
+    /// * The hash can be used to retrieve the original arguments from the PXE.
+    ///
     pub fn get_args_hash(self) -> Field {
         self.args_hash
     }
 
+    /// Pushes a new note_hash to the Aztec blockchain's global Note Hash Tree
+    /// (a state tree).
+    ///
+    /// A note_hash is a commitment to a piece of private state.
+    ///
+    /// Low-level function: Ordinarily, smart contract developers will not need
+    /// to manually call this. Aztec-nr's state variables (see `../state_vars/`)
+    /// are designed to understand when to create and push new note hashes.
+    ///
+    /// # Arguments
+    /// * `note_hash` - The new note_hash.
+    ///
+    /// # Advanced
+    /// From here, the protocol's kernel circuits will take over and insert the
+    /// note_hash into the protocol's "note hash tree" (in the Base Rollup
+    /// circuit).
+    /// Before insertion, the protocol will:
+    /// - "Silo" the `note_hash` with the contract address of this function,
+    ///   to yield a `siloed_note_hash`. This prevents state collisions
+    ///   between different smart contracts.
+    /// - Ensure uniqueness of the `siloed_note_hash`, to prevent Faerie-Gold
+    ///   attacks, by hashing the `siloed_note_hash` with a unique value, to
+    ///   yield a `unique_siloed_note_hash` (see the protocol spec for more).
+    ///
+    /// In addition to calling this function, aztec-nr provides the contents
+    /// of the newly-created note to the PXE, via the `notify_created_note`
+    /// oracle.
+    ///
+    /// > Advanced users might occasionally wish to push data to the context
+    /// > directly for lower-level control. If you find yourself doing this,
+    /// > please open an issue on GitHub to describe your use case: it might be
+    /// > that new functionality should be added to aztec-nr.
+    ///
     pub fn push_note_hash(&mut self, note_hash: Field) {
         self.note_hashes.push(NoteHash { value: note_hash, counter: self.next_counter() });
     }
 
+    /// Pushes a new nullifier to the Aztec blockchain's global Nullifier Tree
+    /// (a state tree).
+    ///
+    /// See also: `push_nullifier_for_note_hash`.
+    ///
+    /// Low-level function: Ordinarily, smart contract developers will not need
+    /// to manually call this. Aztec-nr's state variables (see `../state_vars/`)
+    /// are designed to understand when to create and push new nullifiers.
+    ///
+    /// A nullifier can only be emitted once. Duplicate nullifier insertions are
+    /// rejected by the protocol.
+    ///
+    /// Generally, a nullifier is emitted to prevent an action from happening
+    /// more than once, in such a way that the action cannot be linked (by an
+    /// observer of the blockchain) to any earlier transactions.
+    ///
+    /// I.e. a nullifier is a random-looking, but deterministic record of a
+    /// private, one-time action, which does not leak what action has been
+    /// taken, and which preserves the property of "tx unlinkability".
+    ///
+    /// Usually, a nullifier will be emitted to "spend" a note (a piece of
+    /// private state), without revealing which specific note is being spent.
+    ///
+    /// (Important: in such cases, use the below `push_nullifier_for_note_hash`).
+    ///
+    /// Sometimes, a nullifier might be emitted completely unrelated to any
+    /// notes. Examples include initialization of a new contract; initialization
+    /// of a PrivateMutable, or signalling in Semaphore-like applications.
+    /// This `push_nullifier` function serves such use cases.
+    ///
+    /// # Arguments
+    /// * `nullifier`
+    ///
+    /// # Advanced
+    /// From here, the protocol's kernel circuits will take over and insert the
+    /// nullifier into the protocol's "nullifier tree" (in the Base Rollup
+    /// circuit).
+    /// Before insertion, the protocol will:
+    /// - "Silo" the `nullifier` with the contract address of this function,
+    ///   to yield a `siloed_nullifier`. This prevents state collisions
+    ///   between different smart contracts.
+    /// - Ensure the `siloed_nullifier` is unique (the nullifier tree is an
+    ///   indexed merkle tree which supports efficient non-membership proofs).
+    ///
     pub fn push_nullifier(&mut self, nullifier: Field) {
         notify_created_nullifier(nullifier);
         self.nullifiers.push(
@@ -156,6 +448,31 @@ impl PrivateContext {
         );
     }
 
+    /// Pushes a nullifier that corresponds to a specific note hash.
+    ///
+    /// Low-level function: Ordinarily, smart contract developers will not need
+    /// to manually call this. Aztec-nr's state variables (see `../state_vars/`)
+    /// are designed to understand when to create and push new nullifiers.
+    ///
+    /// This is a specialized version of `push_nullifier` that links a nullifier
+    /// to the specific note hash it's nullifying. This is the most common
+    /// usage pattern for nullifiers.
+    /// See `push_nullifier` for more explanation on nullifiers.
+    ///
+    /// # Arguments
+    /// * `nullifier`
+    /// * `nullified_note_hash` - The note hash of the note being nullified
+    ///
+    /// # Advanced
+    /// Important: usage of this function doesn't mean that the world will _see_
+    /// that this nullifier relates to the given nullified_note_hash (as that
+    /// would violate "tx unlinkability"); it simply informs the user's PXE
+    /// about the relationship (via `notify_nullified_note`). The PXE can then
+    /// use this information to feed hints to the kernel circuits for
+    /// "squashing" purposes: If a note is nullified during the same tx which
+    /// created it, we can "squash" (delete) the note and nullifier (and any
+    /// private logs associated with the note), to save on data emission costs.
+    ///
     pub fn push_nullifier_for_note_hash(&mut self, nullifier: Field, nullified_note_hash: Field) {
         let nullifier_counter = self.next_counter();
         notify_nullified_note(nullifier, nullified_note_hash, nullifier_counter);
@@ -168,23 +485,92 @@ impl PrivateContext {
         );
     }
 
-    // Returns the header of a block whose state is used during private execution (not the block the transaction is
-    // included in).
+    /// Returns the anchor block header - the historical block header that this
+    /// private function is reading from.
+    ///
+    /// A private function CANNOT read from the "current" block header,
+    /// but must read from some historical block header, because as soon as
+    /// private function execution begins (asynchronously, on a user's device),
+    /// the public state of the chain (the "current state") will have progressed
+    /// forward.
+    ///
+    /// # Returns
+    /// * `BlockHeader` - The anchor block header.
+    ///
+    /// # Advanced
+    /// * All private functions of a tx read from the same anchor block header.
+    /// * The protocol asserts that the `include_by_timestamp` of every tx
+    ///   is at most 24 hours beyond the timestamp of the tx's chosen anchor
+    ///   block header. This enables the network's nodes to safely prune old txs
+    ///   from the mempool. Therefore, the chosen block header _must_ be one
+    ///   from within the last 24 hours.
+    ///
     pub fn get_block_header(self) -> BlockHeader {
         self.historical_header
     }
 
-    // Returns the header of an arbitrary block whose block number is less than or equal to the block number
-    // of historical header.
+    /// Returns the header of any historical block at or before the anchor
+    /// block.
+    ///
+    /// This enables private contracts to access information from even older
+    /// blocks than the anchor block header.
+    ///
+    /// Useful for time-based contract logic that needs to compare against
+    /// multiple historical points.
+    ///
+    /// # Arguments
+    /// * `block_number` - The block number to retrieve (must be <= anchor
+    ///                    block number)
+    ///
+    /// # Returns
+    /// * `BlockHeader` - The header of the requested historical block
+    ///
+    /// # Advanced
+    /// This function uses an oracle to fetch block header data from the user's
+    /// PXE. Depending on how much blockchain data the user's PXE has been set
+    /// up to store, this might require a query from the PXE to another Aztec
+    /// node to get the data.
+    /// > This is generally true of all oracle getters (see `../oracle`).
+    ///
+    /// Each block header gets hashed and stored as a leaf in the protocol's
+    /// Archive Tree. In fact, the i-th block header gets stored at the i-th
+    /// leaf index of the Archive Tree. Behind the scenes, this
+    /// `get_block_header_at` function will add Archive Tree merkle-membership
+    /// constraints (~3k) to your smart contract function's circuit, to prove
+    /// existence of the block header in the Archive Tree.
+    ///
+    /// Note: we don't do any caching, so avoid making duplicate calls for the
+    /// same block header, because each call will add duplicate constraints.
+    ///
+    /// Calling this function is more expensive (constraint-wise) than getting
+    /// the anchor block header (via `get_block_header`). This is because the
+    /// anchor block's merkle membership proof is handled by Aztec's protocol
+    /// circuits, and is only performed once for the entire tx because all
+    /// private functions of a tx share a common anchor block header. Therefore,
+    /// the cost (constraint-wise) of calling `get_block_header` is effectively
+    /// free.
+    ///
     pub fn get_block_header_at(self, block_number: u32) -> BlockHeader {
         get_block_header_at(block_number, self)
     }
 
+    /// Sets the hash of the return values for this private function.
+    ///
+    /// Very low-level function: this is called by the #[private] macro.
+    ///
+    /// # Arguments
+    /// * `returns_hasher` - A hasher containing the return values to hash
+    ///
     pub fn set_return_hash(&mut self, returns_hasher: ArgsHasher) {
         self.return_hash = returns_hasher.hash();
         execution_cache::store(returns_hasher.fields, self.return_hash);
     }
 
+    /// Builds the PrivateCircuitPublicInputs for this private function, to
+    /// ensure compatibility with the protocol's kernel circuits.
+    ///
+    /// Very low-level function: This function is automatically called by the
+    /// #[private] macro.
     pub fn finish(self) -> PrivateCircuitPublicInputs {
         PrivateCircuitPublicInputs {
             call_context: self.inputs.call_context,
@@ -219,6 +605,19 @@ impl PrivateContext {
         }
     }
 
+    /// Designates this contract as the fee payer for the transaction.
+    ///
+    /// Unlike Ethereum, where the transaction sender always pays fees, Aztec
+    /// allows any contract to voluntarily pay transaction fees. This enables
+    /// patterns like sponsored transactions or fee abstraction where users
+    /// don't need to hold fee-juice themselves. (Fee juice is a fee-paying
+    /// asset for Aztec).
+    ///
+    /// Only one contract per transaction can declare itself as the fee payer,
+    /// and it must have sufficient fee-juice balance (>= the gas limits
+    /// specified in the TxContext) by the time we reach the public setup phase
+    /// of the tx.
+    ///
     pub fn set_as_fee_payer(&mut self) {
         dep::protocol_types::debug_log::debug_log_format(
             "Setting {0} as fee payer",
@@ -227,6 +626,34 @@ impl PrivateContext {
         self.is_fee_payer = true;
     }
 
+    /// Declares the end of the "setup phase" of this tx.
+    ///
+    /// Only one function per tx can declare the end of the setup phase.
+    ///
+    /// Niche function: Only wallet developers and paymaster contract developers
+    /// (aka Fee-payment contracts) will need to make use of this function.
+    ///
+    /// Aztec supports a three-phase execution model: setup, app logic, teardown.
+    /// The phases exist to enable a fee payer to take on the risk of paying
+    /// a transaction fee, safe in the knowledge that their payment (in whatever
+    /// token or method the user chooses) will succeed, regardless of whether
+    /// the app logic will succeed. The "setup" phase enables such a payment to
+    /// be made, because the setup phase _cannot revert_: a reverting function
+    /// within the setup phase would result in an invalid block which cannot
+    /// be proven. Any side-effects generated during that phase are guaranteed
+    /// to be inserted into Aztec's state trees (except for squashed notes &
+    /// nullifiers, of course).
+    ///
+    /// Even though the end of the setup phase is declared within a private
+    /// function, you might have noticed that _public_ functions can also
+    /// execute within the setup phase. This is because any public function
+    /// calls which were enqueued _within the setup phase_ by a private
+    /// function are considered part of the setup phase.
+    ///
+    /// # Advanced
+    /// * Sets the minimum revertible side effect counter of this tx to be the
+    /// PrivateContext's _current_ side effect counter.
+    ///
     pub fn end_setup(&mut self) {
         // dep::protocol_types::debug_log::debug_log_format(
         //     "Ending setup at counter {0}",
@@ -236,30 +663,230 @@ impl PrivateContext {
         notify_set_min_revertible_side_effect_counter(self.min_revertible_side_effect_counter);
     }
 
+    /// Sets a deadline (an "include-by timestamp") for when this transaction
+    /// must be included in a block.
+    ///
+    /// Other functions in this tx might call this setter with differing
+    /// values for the include-by timestamp. To ensure that all functions'
+    /// deadlines are met, the _minimum_ of all these include-by timestamps will
+    /// be exposed when this tx is submitted to the network.
+    ///
+    /// If the transaction is not included in a block by its include-by
+    /// timestamp, it becomes invalid and it will never be included.
+    ///
+    /// This expiry timestamp is publicly visible. See the "Advanced" section
+    /// for privacy concerns.
+    ///
+    /// # Arguments
+    /// * `include_by_timestamp` - Unix timestamp (seconds) deadline for inclusion.
+    ///                            The include-by timestamp of this tx will be
+    ///                            _at most_ the timestamp specified.
+    ///
+    /// # Advanced
+    /// * If multiple functions set differing `include_by_timestamp`s, the
+    ///   kernel circuits will set it to be the _minimum_ of the two. This
+    ///   ensures the tx expiry requirements of all functions in the tx are met.
+    /// * Rollup circuits will reject expired txs.
+    /// * The protocol enforces that all transactions must be included within
+    ///   24 hours of their chosen anchor block's timestamp, to enable safe
+    ///   mempool pruning.
+    /// * The DelayedPublicMutable design makes heavy use of this functionality,
+    ///   to enable private functions to read public state.
+    /// * A sophisticated Wallet should cleverly set an include-by timestamp
+    ///   to improve the privacy of the user and the network as a whole.
+    ///   For example, if a contract interaction sets include-by to some
+    ///   publicly-known value (e.g. the time when a contract upgrades), then
+    ///   the wallet might wish to set an even lower one to avoid revealing that
+    ///   this tx is interacting with said contract.
+    ///   Ideally, all wallets should standardise on an approach in order to
+    ///   provide users with a large anonymity set -- although the exact apprach
+    ///   will need to be discussed. Wallets that deviate from a standard might
+    ///   accidentally reveal which wallet each transaction originates from.
+    ///
     // docs:start:include-by-timestamp
     pub fn set_include_by_timestamp(&mut self, include_by_timestamp: u64) {
         // docs:end:include-by-timestamp
         self.include_by_timestamp = std::cmp::min(self.include_by_timestamp, include_by_timestamp);
     }
 
+    /// Makes a request to the protocol's kernel circuit to ensure a note_hash
+    /// actually exists.
+    ///
+    /// "Read requests" are used to prove that a note hash exists without
+    /// revealing which specific note was read.
+    ///
+    /// This can be used to prove existence of both settled notes (created in
+    /// prior transactions) and transient notes (created in the current
+    /// transaction).
+    /// If you need to prove existence of a settled note _at a specific block
+    /// number_, use `note_inclusion::prove_note_inclusion`.
+    ///
+    /// Low-level function. Ordinarily, smart contract developers will not need
+    /// to call this directly. Aztec-nr's state variables (see `../state_vars/`)
+    /// are designed to understand when to create and push new note_hash read
+    /// requests.
+    ///
+    /// # Arguments
+    /// * `note_hash` - The note hash to read and verify
+    ///
+    /// # Advanced
+    /// In "traditional" circuits for non-Aztec privacy applications, the merkle
+    /// membership proofs to check existence of a note are performed _within_
+    /// the application circuit.
+    ///
+    /// All Aztec private functions have access to the following constraint
+    /// optimisation:
+    /// In cases where the note being read was created earlier in the same tx,
+    /// the note wouldn't yet exist in the Note Hash Tree, so a hard-coded
+    /// merkle membership check which then gets ignored would be a waste of
+    /// constraints.
+    /// Instead, we can send read requests for all notes to the protocol's
+    /// kernel circuits, where we can conditionally assess which notes actually
+    /// need merkle membership proofs, and select an appropriately-sized
+    /// kernel circuit.
+    ///
+    /// For "settled notes" (which already existed in the Note Hash Tree of the
+    /// anchor block (i.e. before the tx began)), the kernel does a merkle
+    /// membership check.
+    ///
+    /// For "pending notes" (which were created earlier in _this_ tx), the
+    /// kernel will check that the note existed _before_ this read request was
+    /// made, by checking the side-effect counters of the note_hash and this
+    /// read request.
+    ///
+    /// This approach improves latency between writes and reads:
+    /// a function can read a note which was created earlier in the tx (rather
+    /// than performing the read in a later tx, after waiting for the earlier tx
+    /// to be included, to ensure the note is included in the tree).
+    ///
     pub fn push_note_hash_read_request(&mut self, note_hash: Field) {
         let side_effect = ReadRequest { value: note_hash, counter: self.next_counter() };
         self.note_hash_read_requests.push(side_effect);
     }
 
+    /// Requests to read a specific nullifier from the nullifier tree.
+    ///
+    /// Nullifier read requests are used to prove that a nullifier exists without
+    /// revealing which specific nullifier preimage was read.
+    ///
+    /// This can be used to prove existence of both settled nullifiers (created in
+    /// prior transactions) and transient nullifiers (created in the current
+    /// transaction).
+    /// If you need to prove existence of a settled nullifier _at a specific block
+    /// number_, use `nullifier_inclusion::prove_nullifier_inclusion`.
+    ///
+    /// Low-level function. Ordinarily, smart contract developers will not need
+    /// to call this directly. Aztec-nr's state variables (see `../state_vars/`)
+    /// are designed to understand when to create and push new nullifier read
+    /// requests.
+    ///
+    /// # Arguments
+    /// * `nullifier` - The nullifier to read and verify
+    ///
+    /// # Advanced
+    /// This approach improves latency between writes and reads:
+    /// a function can read a nullifier which was created earlier in the tx
+    /// (rather than performing the read in a later tx, after waiting for the
+    /// earlier tx to be included, to ensure the note is included in the tree).
+    ///
     pub fn push_nullifier_read_request(&mut self, nullifier: Field) {
         let request = ReadRequest { value: nullifier, counter: self.next_counter() };
         self.nullifier_read_requests.push(request);
     }
 
+    /// Requests the app-siloed nullifier secret key (nsk_app) for the given
+    /// (hashed) master nullifier public key (npk_m), from the user's PXE.
+    ///
+    /// Advanced function: Only needed if you're designing your own notes and/or
+    /// nullifiers.
+    ///
+    /// Contracts are not allowed to compute nullifiers for other contracts, as
+    /// that would let them read parts of their private state. Because of this,
+    /// a contract is only given an "app-siloed secret key", which is
+    /// constructed by hashing the user's master nullifier secret key with the
+    /// contract's address.
+    /// However, because contracts cannot be trusted with a user's master
+    /// nullifier secret key (because we don't know which contracts are honest
+    /// or malicious), the PXE refuses to provide any master secret keys to
+    /// any app smart contract function. This means app functions are unable to
+    /// prove that the derivation of an app-siloed nullifier secret key has been
+    /// computed correctly. Instead, an app function can request to the kernel
+    /// (via `request_nsk_app`) that it validates the siloed derivation, since
+    /// the kernel has been vetted to not leak any master secret keys.
+    ///
+    /// A common nullification scheme is to inject a nullifier secret key into
+    /// the preimage of a nullifier, to make the nullifier deterministic but
+    /// random-looking. This function enables that flow.
+    ///
+    /// # Arguments
+    /// * `npk_m_hash` - A hash of the master nullifier public key of the user
+    ///                  whose PXE is executing this function.
+    ///
+    /// # Returns
+    /// * The app-siloed nullifier secret key that corresponds to the given
+    ///   `npk_m_hash`.
+    ///
     pub fn request_nsk_app(&mut self, npk_m_hash: Field) -> Field {
         self.request_sk_app(npk_m_hash, NULLIFIER_INDEX)
     }
 
+    /// Requests the app-siloed nullifier secret key (nsk_app) for the given
+    /// (hashed) master nullifier public key (npk_m), from the user's PXE.
+    ///
+    /// See `request_nsk_app` and `request_sk_app` for more info.
+    ///
+    /// The intention of the "outgoing" keypair is to provide a second secret
+    /// key for all of a user's outgoing activity (i.e. for notes that a user
+    /// creates, as opposed to notes that a user receives from others). The
+    /// separation of incoming and outgoing data was a distinction made by
+    /// zcash, with the intention of enabling a user to optionally share with a
+    /// 3rd party a controlled view of only incoming or outgoing notes.
+    /// Similar functionality of sharing select data can be achieved with
+    /// offchain zero-knowledge proofs. It is up to an app developer whether
+    /// they choose to make use of a user's outgoing keypair within their
+    /// application logic, or instead simply use the same keypair (the address
+    /// keypair (which is effectively the same as the "incooming" keypair)) for
+    /// all incoming & outgoing messages to a user.
+    ///
+    /// Currently, all of the exposed encryption functions in aztec-nr ignore
+    /// the outgoing viewing keys, and instead encrypt all note logs and event
+    /// logs to a user's address public key.
+    ///
+    /// # Arguments
+    /// * `ovpk_m_hash` - Hash of the outgoing viewing public key master
+    ///
+    /// # Returns
+    /// * The application-specific outgoing viewing secret key
+    ///
     pub fn request_ovsk_app(&mut self, ovpk_m_hash: Field) -> Field {
         self.request_sk_app(ovpk_m_hash, OUTGOING_INDEX)
     }
 
+    /// Pushes a Key Validation Request to the kernel.
+    ///
+    /// Private functions are not allowed to see a user's master secret keys,
+    /// because we do not trust them. They are instead given "app-siloed" secret
+    /// keys with a claim that they relate to a master public key.
+    /// They can then request validation of this claim, by making a "key
+    /// validation request" to the protocol's kernel circuits (which _are_
+    /// allowed to see certain master secret keys).
+    ///
+    /// When a Key Validation Request tuple of (sk_app, Pk_m, app_address) is
+    /// submitted to the kernel, it will perform the following derivations
+    /// to validate the relationship between the claimed sk_app and the user's
+    /// Pk_m:
+    ///
+    ///       (sk_m) ----> * G ----> Pk_m
+    ///         |                     |
+    ///         v                       We use the kernel to prove this
+    ///  h(sk_m, app_address)         | sk_app-Pk_m relationship, because app
+    ///         |                       circuits must not be trusted to see sk_m.
+    ///         v                     |
+    ///      sk_app - -  - - - - - - -
+    ///
+    /// The function is named "request_" instead of "get_" to remind the user
+    /// that a Key Validation Request will be emitted to the kernel.
+    ///
     fn request_sk_app(&mut self, pk_m_hash: Field, key_index: Field) -> Field {
         let cached_request = self.last_key_validation_requests[key_index as u32].unwrap_or(
             KeyValidationRequest::empty(),
@@ -292,13 +919,69 @@ impl PrivateContext {
         }
     }
 
-    // docs:start:context_message_portal
+    /// Sends an "L2 -> L1 message" from this function (Aztec, L2) to a smart
+    /// contract on Ethereum (L1). L1 contracts which are designed to
+    /// send/receive messages to/from Aztec are called "Portal Contracts".
+    ///
+    /// Common use cases include withdrawals, cross-chain asset transfers, and
+    /// triggering L1 actions based on L2 state changes.
+    ///
+    /// The message will be inserted into an Aztec "Outbox" contract on L1,
+    /// when this transaction's block is proposed to L1.
+    /// Sending the message will not result in any immediate state changes in
+    /// the target portal contract. The message will need to be manually
+    /// consumed from the Outbox through a separate Ethereum transaction: a user
+    /// will need to call a function of the portal contract -- a function
+    /// specifically designed to make a call to the Outbox to consume the
+    /// message.
+    /// The message will only be available for consumption once the _epoch_
+    /// proof has been submitted. Given that there are multiple Aztec blocks
+    /// within an epoch, it might take some time for this epoch proof to be
+    /// submitted -- especially if the block was near the start of an epoch.
+    ///
+    /// # Arguments
+    /// * `recipient` - Ethereum address that will receive the message
+    /// * `content` - Message content (32 bytes as a Field element).
+    ///               This content has a very specific layout.
+    /// docs:start:context_message_portal
     pub fn message_portal(&mut self, recipient: EthAddress, content: Field) {
         // docs:end:context_message_portal
         let message = L2ToL1Message { recipient, content };
         self.l2_to_l1_msgs.push(message.count(self.next_counter()));
     }
 
+    /// Consumes a message sent from Ethereum (L1) to Aztec (L2).
+    ///
+    /// Common use cases include token bridging, cross-chain governance, and
+    /// triggering L2 actions based on L1 events.
+    ///
+    /// Use this function if you only want the message to ever be "referred to"
+    /// once. Once consumed using this method, the message cannot be consumed
+    /// again, because a nullifier is emitted.
+    /// If your use case wants for the message to be read unlimited times, then
+    /// you can always read any historic message from the L1-to-L2 messages tree;
+    /// messages never technically get deleted from that tree.
+    ///
+    /// The message will first be inserted into an Aztec "Inbox" smart contract
+    /// on L1.
+    /// Sending the message will not result in any immediate state changes in
+    /// the target L2 contract. The message will need to be manually
+    /// consumed by the target contract through a separate Aztec transaction.
+    /// The message will not be available for consumption immediately. Messages
+    /// get copied over from the L1 Inbox to L2 by the next Proposer in batches.
+    /// So you will need to wait until the messages are copied before you can
+    /// consume them.
+    ///
+    /// # Arguments
+    /// * `content` - The message content that was sent from L1
+    /// * `secret` - Secret value used for message privacy (if needed)
+    /// * `sender` - Ethereum address that sent the message
+    /// * `leaf_index` - Index of the message in the L1-to-L2 message tree
+    ///
+    /// # Advanced
+    /// Validates message existence in the L1-to-L2 message tree and nullifies
+    /// the message to prevent double-consumption.
+    ///
     // docs:start:context_consume_l1_to_l2_message
     // docs:start:consume_l1_to_l2_message
     pub fn consume_l1_to_l2_message(
@@ -325,6 +1008,65 @@ impl PrivateContext {
     }
     // docs:end:consume_l1_to_l2_message
 
+    /// Emits a private log (an array of Fields) that will be published to an
+    /// Ethereum blob.
+    ///
+    /// Private logs are intended for the broadcasting of ciphertexts: that is,
+    /// encrypted events or encrypted note contents.
+    /// Since the data in the logs is meant to be _encrypted_, private_logs are
+    /// broadcast to publicly-visible Ethereum blobs.
+    /// The intended recipients of such encrypted messages can then discover and
+    /// decrypt these encrypted logs using their viewing secret key.
+    /// (See `../messages/discovery` for more details).
+    ///
+    /// Important note: This function DOES NOT _do_ any encryption of the input
+    /// `log` fields. This function blindly publishes whatever input `log` data
+    /// is fed into it, so the caller of this function should have already
+    /// performed the encryption, and the `log` should be the result of that
+    /// encryption.
+    ///
+    /// The protocol does not dictate what encryption scheme should be used:
+    /// a smart contract developer can choose whatever encryption scheme they
+    /// like.
+    /// Aztec-nr includes some off-the-shelf encryption libraries that
+    /// developers might wish to use, for convenience. These libraries not only
+    /// encrypt a plaintext (to produce a ciphertext); they also prepend the
+    /// ciphertext with a `tag` and `ephemeral public key` for easier message
+    /// discovery. This is a very dense topic, and we will be writing more
+    /// libraries and docs soon.
+    ///
+    /// > Currently, AES128 CBC encryption is the main scheme included in
+    /// > aztec.nr.
+    /// > We are currently making significant changes to the interfaces of the
+    /// > encryption library.
+    ///
+    /// In some niche use cases, an app might be tempted to publish
+    /// _un-encrypted_ data via a private log, because _public logs_ are not
+    /// available to private functions. Be warned that emitting public data via
+    /// private logs is strongly discouraged, and is considered a "privacy
+    /// anti-pattern", because it reveals identifiable information about _which_
+    /// function has been executed. A tx which leaks such information does not
+    /// contribute to the privacy set of the network.
+    ///
+    /// * Unlike `emit_raw_note_log`, this log is not tied to any specific note
+    ///
+    /// # Arguments
+    /// * `log` - The log data that will be publicly broadcast (so make sure
+    ///           it's already been encrypted before you call this function).
+    ///   Private logs are bounded in size (PRIVATE_LOG_SIZE_IN_FIELDS), to
+    ///   encourage all logs from all smart contracts look identical.
+    /// * `length` - The actual length of the `log` (measured in number of
+    ///              Fields). Although the input log has a max size of
+    ///   PRIVATE_LOG_SIZE_IN_FIELDS, the latter values of the array might all
+    ///   be 0's for small logs. This `length` should reflect the trimmed length
+    ///   of the array. The protocol's kernel circuits can then append random
+    ///   fields as "padding" after the `length`, so that the logs of this
+    ///   smart contract look indistinguishable from (the same length as) the
+    ///   logs of all other applications. It's up to wallets how much padding
+    ///   to apply, so ideally all wallets should agree on standards for this.
+    ///
+    /// # Advanced
+    ///
     pub fn emit_private_log(&mut self, log: [Field; PRIVATE_LOG_SIZE_IN_FIELDS], length: u32) {
         let counter = self.next_counter();
         let private_log =
@@ -332,6 +1074,27 @@ impl PrivateContext {
         self.private_logs.push(private_log);
     }
 
+    // TODO: rename.
+    /// Emits a private log that is explicitly tied to a newly-emitted note_hash,
+    /// to convey to the kernel: "this log relates to this note".
+    ///
+    /// This linkage is important in case the note gets squashed (due to being
+    /// read later in this same tx), since we can then squash the log as well.
+    ///
+    /// See `emit_private_log` for more info about private log emission.
+    ///
+    /// # Arguments
+    /// * `log` - The log data as an array of Field elements
+    /// * `length` - The actual length of the `log` (measured in number of
+    ///              Fields).
+    /// * `note_hash_counter` - The side-effect counter that was assigned to the
+    ///                         new note_hash when it was pushed to this
+    //                          `PrivateContext`.
+    ///
+    /// Important: If your application logic requires the log to always be
+    /// emitted regardless of note squashing, consider using `emit_private_log`
+    /// instead, or emitting additional events.
+    ///
     pub fn emit_raw_note_log(
         &mut self,
         log: [Field; PRIVATE_LOG_SIZE_IN_FIELDS],
@@ -365,6 +1128,63 @@ impl PrivateContext {
         ));
     }
 
+    /// Calls a private function on another contract (or the same contract).
+    ///
+    /// Very low-level function.
+    ///
+    /// # Arguments
+    /// * `contract_address` - Address of the contract containing the function
+    /// * `function_selector` - 4-byte identifier of the function to call
+    /// * `args` - Array of arguments to pass to the called function
+    ///
+    /// # Returns
+    /// * `ReturnsHash` - Hash of the called function's return values. Use
+    ///   `.get_preimage()` to extract the actual return values.
+    ///
+    /// This enables contracts to interact with each other while maintaining
+    /// privacy. This "composability" of private contract functions is a key
+    /// feature of the Aztec network.
+    ///
+    /// If a user's transaction includes multiple private function calls, then
+    /// by the design of Aztec, the following information will remain private[1]:
+    /// - The function selectors and contract addresses of all private function
+    ///   calls will remain private, so an observer of the public mempool will
+    ///   not be able to look at a tx and deduce which private functions have
+    ///   been executed.
+    /// - The arguments and return values of all private function calls will
+    ///   remain private.
+    /// - The person who initiated the tx will remain private.
+    /// - The notes and nullifiers and private logs that are emitted by all
+    ///   private function calls will (if designed well) not leak any user
+    ///   secrets, nor leak which functions have been executed.
+    ///
+    /// [1] Caveats: Some of these privacy guarantees depend on how app
+    /// developers design their smart contracts. Some actions _can_ leak
+    /// information, such as:
+    /// - Calling an internal public function.
+    /// - Calling a public function and not setting msg_sender to Option::none
+    ///   (feature not built yet - see github).
+    /// - Calling any public function will always leak details about the nature
+    ///   of the transaction, so devs should be careful in their contract
+    ///   designs. If it can be done in a private function, then that will give
+    ///   the best privacy.
+    /// - Not padding the side-effects of a tx to some standardised, uniform
+    ///   size. The kernel circuits can take hints to pad side-effects, so a
+    ///   wallet should be able to request for a particular amount of padding.
+    ///   Wallets should ideally agree on some standard.
+    ///   - Padding should include:
+    ///     - Padding the lengths of note & nullifier arrays
+    ///     - Padding private logs with random fields, up to some standardised
+    ///       size.
+    /// See also: https://docs.aztec.network/developers/reference/considerations/privacy_considerations
+    ///
+    /// # Advanced
+    /// * The call is added to the private call stack and executed by kernel
+    ///   circuits after this function completes
+    /// * The called function can modify its own contract's private state
+    /// * Side effects from the called function are included in this transaction
+    /// * The call inherits the current transaction's context and gas limits
+    ///
     pub fn call_private_function<let ArgsCount: u32>(
         &mut self,
         contract_address: AztecAddress,
@@ -381,6 +1201,24 @@ impl PrivateContext {
         )
     }
 
+    /// Makes a read-only call to a private function on another contract.
+    ///
+    /// This is similar to Solidity's `staticcall`. The called function
+    /// cannot modify state or emit events. Any nested calls are constrained to
+    /// also be staticcalls.
+    ///
+    /// See `call_private_function` for more general info on private function
+    /// calls.
+    ///
+    /// # Arguments
+    /// * `contract_address` - Address of the contract to call
+    /// * `function_selector` - 4-byte identifier of the function to call
+    /// * `args` - Array of arguments to pass to the called function
+    ///
+    /// # Returns
+    /// * `ReturnsHash` - Hash of the called function's return values. Use
+    ///   `.get_preimage()` to extract the actual return values.
+    ///
     pub fn static_call_private_function<let ArgsCount: u32>(
         &mut self,
         contract_address: AztecAddress,
@@ -397,6 +1235,20 @@ impl PrivateContext {
         )
     }
 
+    /// Calls a private function that takes no arguments.
+    ///
+    /// This is a convenience function for calling private functions that don't
+    /// require any input parameters. It's equivalent to `call_private_function`
+    /// but slightly more efficient to use when no arguments are needed.
+    ///
+    /// # Arguments
+    /// * `contract_address` - Address of the contract containing the function
+    /// * `function_selector` - 4-byte identifier of the function to call
+    ///
+    /// # Returns
+    /// * `ReturnsHash` - Hash of the called function's return values. Use
+    ///   `.get_preimage()` to extract the actual return values.
+    ///
     pub fn call_private_function_no_args(
         &mut self,
         contract_address: AztecAddress,
@@ -405,6 +1257,19 @@ impl PrivateContext {
         self.call_private_function_with_args_hash(contract_address, function_selector, 0, false)
     }
 
+    /// Makes a read-only call to a private function which takes no arguments.
+    ///
+    /// This combines the optimisation of `call_private_function_no_args` with
+    /// the safety of `static_call_private_function`.
+    ///
+    /// # Arguments
+    /// * `contract_address` - Address of the contract containing the function
+    /// * `function_selector` - 4-byte identifier of the function to call
+    ///
+    /// # Returns
+    /// * `ReturnsHash` - Hash of the called function's return values. Use
+    ///   `.get_preimage()` to extract the actual return values.
+    ///
     pub fn static_call_private_function_no_args(
         &mut self,
         contract_address: AztecAddress,
@@ -413,6 +1278,21 @@ impl PrivateContext {
         self.call_private_function_with_args_hash(contract_address, function_selector, 0, true)
     }
 
+    /// Low-level private function call.
+    ///
+    /// This is the underlying implementation used by all other private function
+    /// call methods. Instead of taking raw arguments, it accepts a
+    /// hash of the arguments.
+    ///
+    /// # Arguments
+    /// * `contract_address` - Address of the contract containing the function
+    /// * `function_selector` - 4-byte identifier of the function to call
+    /// * `args_hash` - Pre-computed hash of the function arguments
+    /// * `is_static_call` - Whether this should be a read-only call
+    ///
+    /// # Returns
+    /// * `ReturnsHash` - Hash of the called function's return values
+    ///
     pub fn call_private_function_with_args_hash(
         &mut self,
         contract_address: AztecAddress,
@@ -464,10 +1344,39 @@ impl PrivateContext {
         //     > self.min_revertible_side_effect_counter {
         //     self.min_revertible_side_effect_counter = item.public_inputs.min_revertible_side_effect_counter;
         // }
-        self.side_effect_counter = end_side_effect_counter + 1;
+        self.side_effect_counter = end_side_effect_counter + 1; // TODO: call `next_counter` instead, for consistency
         ReturnsHash::new(returns_hash)
     }
 
+    /// Enqueues a call to a public function to be executed later.
+    ///
+    /// Unlike private functions which execute immediately on the user's device,
+    /// public function calls are "enqueued" and executed some time later by a
+    /// block proposer.
+    ///
+    /// This means a public function cannot return any values back to a private
+    /// function, because by the time the public function is being executed,
+    /// the private function which called it has already completed execution.
+    /// (In fact, the private function has been executed and proven, along with
+    /// all other private function calls of the user's tx. A single proof of the
+    /// tx has been submitted to the Aztec network, and some time later a
+    /// proposer has picked the tx up from the mempool and begun executing all
+    /// of the enqueued public functions).
+    ///
+    /// # Privacy warning
+    /// Enqueueing a public function call is an inherently leaky action.
+    /// Many interesting applications will require some interaction with public
+    /// state, but smart contract developers should try to use public function
+    /// calls sparingly, and carefully.
+    /// _Internal_ public function calls are especially leaky, because they
+    /// completely leak which private contract made the call.
+    /// See also: https://docs.aztec.network/developers/reference/considerations/privacy_considerations
+    ///
+    /// # Arguments
+    /// * `contract_address` - Address of the contract containing the function
+    /// * `function_selector` - 4-byte identifier of the function to call
+    /// * `args` - Array of arguments to pass to the public function
+    ///
     pub fn call_public_function<let ArgsCount: u32>(
         &mut self,
         contract_address: AztecAddress,
@@ -480,6 +1389,20 @@ impl PrivateContext {
         self.call_public_function_with_calldata_hash(contract_address, calldata_hash, false)
     }
 
+    /// Enqueues a read-only call to a public function.
+    ///
+    /// This is similar to Solidity's `staticcall`. The called function
+    /// cannot modify state or emit events. Any nested calls are constrained to
+    /// also be staticcalls.
+    ///
+    /// See also `call_public_function` for more important information about
+    /// making private -> public function calls.
+    ///
+    /// # Arguments
+    /// * `contract_address` - Address of the contract containing the function
+    /// * `function_selector` - 4-byte identifier of the function to call
+    /// * `args` - Array of arguments to pass to the public function
+    ///
     pub fn static_call_public_function<let ArgsCount: u32>(
         &mut self,
         contract_address: AztecAddress,
@@ -492,6 +1415,16 @@ impl PrivateContext {
         self.call_public_function_with_calldata_hash(contract_address, calldata_hash, true)
     }
 
+    /// Enqueues a call to a public function that takes no arguments.
+    ///
+    /// This is an optimisation for calling public functions that don't
+    /// take any input parameters. It's otherwise equivalent to
+    /// `call_public_function`.
+    ///
+    /// # Arguments
+    /// * `contract_address` - Address of the contract containing the function
+    /// * `function_selector` - 4-byte identifier of the function to call
+    ///
     pub fn call_public_function_no_args(
         &mut self,
         contract_address: AztecAddress,
@@ -501,6 +1434,15 @@ impl PrivateContext {
         self.call_public_function_with_calldata_hash(contract_address, calldata_hash, false)
     }
 
+    /// Enqueues a read-only call to a public function with no arguments.
+    ///
+    /// This combines the optimisation of `call_public_function_no_args` with
+    /// the safety of `static_call_public_function`.
+    ///
+    /// # Arguments
+    /// * `contract_address` - Address of the contract containing the function
+    /// * `function_selector` - 4-byte identifier of the function to call
+    ///
     pub fn static_call_public_function_no_args(
         &mut self,
         contract_address: AztecAddress,
@@ -510,6 +1452,21 @@ impl PrivateContext {
         self.call_public_function_with_calldata_hash(contract_address, calldata_hash, true)
     }
 
+    /// Low-level public function call.
+    ///
+    /// This is the underlying implementation used by all other public function
+    /// call methods. Instead of taking raw arguments, it accepts a
+    /// hash of the arguments.
+    ///
+    /// Advanced function: Most developers should use `call_public_function`
+    /// or `static_call_public_function` instead. This function is exposed for
+    /// performance optimization and advanced use cases.
+    ///
+    /// # Arguments
+    /// * `contract_address` - Address of the contract containing the function
+    /// * `calldata_hash` - Hash of the function calldata
+    /// * `is_static_call` - Whether this should be a read-only call
+    ///
     pub fn call_public_function_with_calldata_hash(
         &mut self,
         contract_address: AztecAddress,
@@ -537,6 +1494,30 @@ impl PrivateContext {
         self.public_call_requests.push(Counted::new(call_request, counter));
     }
 
+    /// Enqueues a public function call, and designates it to be the teardown
+    /// function for this tx. Only one teardown function call can be made by a
+    /// tx.
+    ///
+    /// Niche function: Only wallet developers and paymaster contract developers
+    /// (aka Fee-payment contracts) will need to make use of this function.
+    ///
+    /// Aztec supports a three-phase execution model: setup, app logic, teardown.
+    /// The phases exist to enable a fee payer to take on the risk of paying
+    /// a transaction fee, safe in the knowledge that their payment (in whatever
+    /// token or method the user chooses) will succeed, regardless of whether
+    /// the app logic will succeed. The "setup" phase ensures the fee payer
+    /// has sufficient balance to pay the proposer their fees.
+    /// The teardown phase is primarily intended to: calculate exactly
+    /// how much the user owes, based on gas consumption, and refund the user
+    /// any change.
+    ///
+    /// Note: in some cases, the cost of refunding the user (i.e. DA costs of
+    /// tx side-effects) might exceed the refund amount. For app logic with
+    /// fairly stable and predictable gas consumption, a material refund amount
+    /// is unlikely. For app logic with unpredictable gas consumption, a
+    /// refund might be important to the user (e.g. if a heft function reverts
+    /// very early). Wallet/FPC/Paymaster developers should be mindful of this.
+    ///
     pub fn set_public_teardown_function<let ArgsCount: u32>(
         &mut self,
         contract_address: AztecAddress,
@@ -549,6 +1530,21 @@ impl PrivateContext {
         self.set_public_teardown_function_with_calldata_hash(contract_address, calldata_hash, false)
     }
 
+    /// Low-level function to set the public teardown function.
+    ///
+    /// This is the underlying implementation for setting the teardown function
+    /// call that will execute at the end of the transaction. Instead of taking
+    /// raw arguments, it accepts a hash of the arguments.
+    ///
+    /// Advanced function: Most developers should use
+    /// `set_public_teardown_function` instead.
+    ///
+    /// # Arguments
+    /// * `contract_address` - Address of the contract containing the teardown
+    ///                        function
+    /// * `calldata_hash` - Hash of the function calldata
+    /// * `is_static_call` - Whether this should be a read-only call
+    ///
     pub fn set_public_teardown_function_with_calldata_hash(
         &mut self,
         contract_address: AztecAddress,
@@ -574,6 +1570,108 @@ impl PrivateContext {
         };
     }
 
+    /// Increments the side-effect counter.
+    ///
+    /// Very low-level function.
+    ///
+    /// # Advanced
+    ///
+    /// Every side-effect of a private function is given a "side-effect counter",
+    /// based on when it is created. This PrivateContext is in charge of
+    /// assigning the counters.
+    ///
+    /// The reason we have side-effect counters is complicated. Consider this
+    /// illustrative pseudocode of inter-contract function calls:
+    /// ```
+    /// contract A {
+    ///    let x = 5; // pseudocode for storage var x.
+    ///    fn a1 {
+    ///        read x; // value: 5, counter: 1.
+    ///        x = x + 1;
+    ///        write x; // value: 6, counter: 2.
+    ///
+    ///        B.b(); // start_counter: 2, end_counter: 4
+    ///
+    ///        read x; // value: 36, counter: 5.
+    ///        x = x + 1;
+    ///        write x; // value: 37, counter: 6.
+    ///    }
+    ///
+    ///    fn a2 {
+    ///        read x; // value: 6, counter: 3.
+    ///        x = x * x;
+    ///        write x; // value: 36, counter: 4.
+    ///    }
+    /// }
+    ///
+    /// contract B {
+    ///     fn b() {
+    ///         A.a2();
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// Suppose a1 is the first function called. The comments show the execution
+    /// counter of each side-effect, and what the new value of `x` is.
+    ///
+    /// These (private) functions are processed by Aztec's kernel circuits in an
+    /// order that is different from execution order:
+    /// All of A.a1 is proven before B.b is proven, before A.a2 is proven.
+    /// So when we're in the 2nd execution frame of A.a1 (after the call to
+    /// B.b), the circuit needs to justify why x went from being `6` to `36`.
+    /// But the circuit doesn't know why, and given the order of proving, the
+    /// kernel hasn't _seen_ a value of 36 get written yet.
+    /// The kernel needs to track big arrays of all side-effects of all
+    /// private functions in a tx. Then, as it recurses and processes B.b(), it
+    /// will eventually see a value of 36 get written.
+    ///
+    /// Suppose side-effect counters weren't exposed:
+    /// The kernel would only see this ordering (in order of proof verification):
+    /// [ A.a1.read, A.a1.write, A.a1.read, A.a1.write, A.a2.read, A.a2.write ]
+    /// [         5,          6,        36,         37,         6,         36 ]
+    /// The kernel wouldn't know _when_ B.b() was called within A.a1(), because
+    /// it can't see what's going on within an app circuit. So the kernel
+    /// wouldn't know that the ordering of reads and writes should actually be:
+    /// [ A.a1.read, A.a1.write, A.a2.read, A.a2.write, A.a1.read, A.a1.write ]
+    /// [         5,          6,        6,         36,         36,         37 ]
+    ///
+    /// And so, we introduced side-effect counters: every private function must
+    /// assign side-effect counters alongside every side-effect that it emits,
+    /// and also expose to the kernel the counters that it started and ended
+    /// with.
+    /// This gives the kernel enough information to arrange all side-effects in
+    /// the correct order.
+    /// It can then catch (for example) if a function tries to read state
+    /// before it has been written (e.g. if A.a2() maliciously tried to read
+    /// a value of x=37) (e.g. if A.a1() maliciously tried to read x=6).
+    ///
+    /// If a malicious app contract _lies_ and does not count correctly:
+    /// - It cannot lie about its start and end counters because the kernel
+    ///   will catch this.
+    /// - It _could_ lie about its intermediate counters:
+    ///   - 1. It could not increment its side-effects correctly
+    ///   - 2. It could label its side-effects with counters outside of its
+    ///        start and end counters' range.
+    ///   The kernel will catch 2.
+    ///   The kernel will not catch 1., but this would only cause corruption
+    ///   to the private state of the malicious contract, and not any other
+    ///   contracts (because a contract can only modify its own state). If
+    ///   a "good" contract is given _read access_ to a maliciously-counting
+    ///   contract (via an external getter function, or by reading historic
+    ///   state from the archive tree directly), and they then make state
+    ///   changes to their _own_ state accordingly, that could be dangerous.
+    ///   Developers should be mindful not to trust the claimed innards of
+    ///   external contracts unless they have audited/vetted the contracts
+    ///   including vetting the side-effect counter incrementation.
+    ///   This is a similar paradigm to Ethereum smart contract development:
+    ///   you must vet external contracts that your contract relies upon, and
+    ///   you must not make any presumptions about their claimed behaviour.
+    ///   (Hopefully if a contract imports a version of aztec-nr, we will get
+    ///   contract verification tooling that can validate the authenticity
+    ///   of the imported aztec-nr package, and hence infer that the side-
+    ///   effect counting will be correct, without having to re-audit such logic
+    ///   for every contract).
+    ///
     fn next_counter(&mut self) -> u32 {
         let counter = self.side_effect_counter;
         self.side_effect_counter += 1;

--- a/noir-projects/aztec-nr/aztec/src/context/public_context.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/public_context.nr
@@ -7,6 +7,67 @@ use dep::protocol_types::address::{AztecAddress, EthAddress};
 use dep::protocol_types::constants::MAX_U32_VALUE;
 use dep::protocol_types::traits::{Empty, FromField, Packable, Serialize, ToField};
 
+/// # PublicContext
+///
+/// The **main interface** between a #[public] function and the Aztec blockchain.
+///
+/// An instance of the PublicContext is initialized automatically at the outset
+/// of every public function, within the #[public] macro, so you'll never
+/// need to consciously instantiate this yourself.
+///
+/// The instance is always named `context`, and it will always be available
+/// within the body of every #[public] function in your smart contract.
+///
+/// Typical usage for a smart contract developer will be to call getter
+/// methods of the PublicContext.
+///
+/// _Pushing_ data and requests to the context is mostly handled within
+/// aztec-nr's own functions, so typically a smart contract developer won't
+/// need to call any setter methods directly.
+///
+/// ## Responsibilities
+/// - Exposes contextual data to a public function:
+///   - Data relating to how this public function was called:
+///     - msg_sender, this_address
+///   - Data relating to the current blockchain state:
+///     - timestamp, block_number, chain_id, version
+///   - Gas and fee information
+/// - Provides state access:
+///   - Read/write public storage (key-value mapping)
+///   - Check existence of notes and nullifiers
+///     (Some patterns use notes & nullifiers to store public (not private)
+///     information)
+///   - Enables consumption of L1->L2 messages.
+/// - Enables calls to other public smart contract functions:
+/// - Writes data to the blockchain:
+///   - Updates to public state variables
+///   - New public logs (for events)
+///   - New L2->L1 messages
+///   - New notes & nullifiers
+///     (E.g. pushing public info to notes/nullifiers, or for completing
+///     "partial notes")
+///
+/// ## Key Differences from Private Execution
+///
+/// Unlike private functions -- which are executed on the user's device and which
+/// can only reference historic state -- public functions are executed by a block
+/// proposer and are executed "live" on the _current_ tip of the chain.
+/// This means public functions can:
+/// - Read and write _current_ public state
+/// - Immediately see the effects of earlier transactions in the same block
+///
+/// Also, public functions are executed within a zkVM (the "AVM"), so that they
+/// can _revert_ whilst still ensuring payment to the proposer and prover.
+/// (Private functions cannot revert: they either succeed, or they cannot be
+/// included).
+///
+/// ## Optimising Public Functions
+///
+/// Using the AVM to execute public functions means they compile down to "AVM
+/// bytecode" instead of the ACIR that private functions (standalone circuits)
+/// compile to. Therefore the approach to optimising a public function is
+/// fundamentally different from optimising a public function.
+///
 pub struct PublicContext {
     pub args_hash: Option<Field>,
     pub compute_args_hash: fn() -> Field,
@@ -20,10 +81,27 @@ impl Eq for PublicContext {
 }
 
 impl PublicContext {
+    /// Creates a new PublicContext instance.
+    ///
+    /// Low-level function: This is called automatically by the #[public]
+    /// macro, so you shouldn't need to be called directly by smart contract
+    /// developers.
+    ///
+    /// # Arguments
+    /// * `compute_args_hash` - Function to compute the args_hash
+    ///
+    /// # Returns
+    /// * A new PublicContext instance
+    ///
     pub fn new(compute_args_hash: fn() -> Field) -> Self {
         PublicContext { args_hash: Option::none(), compute_args_hash }
     }
 
+    /// Emits a _public_ log that will be visible onchain to everyone.
+    ///
+    /// # Arguments
+    /// * `log` - The data to log, must implement Serialize trait
+    ///
     pub fn emit_public_log<T>(_self: &mut Self, log: T)
     where
         T: Serialize,
@@ -32,22 +110,109 @@ impl PublicContext {
         unsafe { emit_public_log(Serialize::serialize(log).as_slice()) };
     }
 
+    /// Checks if a given note hash exists in the note hash tree at a particular
+    /// leaf_index.
+    ///
+    /// # Arguments
+    /// * `note_hash` - The note hash to check for existence
+    /// * `leaf_index` - The index where the note hash should be located
+    ///
+    /// # Returns
+    /// * `bool` - True if the note hash exists at the specified index
+    ///
     pub fn note_hash_exists(_self: Self, note_hash: Field, leaf_index: u64) -> bool {
         // Safety: AVM opcodes are constrained by the AVM itself
         unsafe { note_hash_exists(note_hash, leaf_index) } == 1
     }
 
+    /// Checks if a specific L1-to-L2 message exists in the L1-to-L2 message
+    /// tree at a particular leaf index.
+    ///
+    /// Common use cases include token bridging, cross-chain governance, and
+    /// triggering L2 actions based on L1 events.
+    ///
+    /// This function should be called before attempting to consume an L1-to-L2
+    /// message.
+    ///
+    /// # Arguments
+    /// * `msg_hash` - Hash of the L1-to-L2 message to check
+    /// * `msg_leaf_index` - The index where the message should be located
+    ///
+    /// # Returns
+    /// * `bool` - True if the message exists at the specified index
+    ///
+    /// # Advanced
+    /// * Uses the AVM l1_to_l2_msg_exists opcode for tree lookup
+    /// * Messages are copied from L1 Inbox to L2 by block proposers
+    ///
     pub fn l1_to_l2_msg_exists(_self: Self, msg_hash: Field, msg_leaf_index: Field) -> bool {
         // Safety: AVM opcodes are constrained by the AVM itself
         // TODO(alvaro): Make l1l2msg leaf index a u64 upstream
         unsafe { l1_to_l2_msg_exists(msg_hash, msg_leaf_index as u64) } == 1
     }
 
+    /// Checks if a specific nullifier has been emitted by a given contract.
+    ///
+    /// Whilst nullifiers are primarily intended as a _privacy-preserving_
+    /// record of a one-time action, they can also be used to efficiently
+    /// record _public_ one-time actions too. An example is to check
+    /// whether a contract has been published: we emit a nullifier that is
+    /// deterministic, but whose preimage is _not_ private. This is more
+    /// efficient than using mutable storage, and can be done directly
+    /// from a private function.
+    ///
+    /// Nullifiers can be tested for non-existence in public, which is not the
+    /// case in private. Because private functions do not have access to
+    /// the tip of the blockchain (but only the anchor block they are built
+    /// at) they can only prove nullifier non-existence in the past. But between
+    /// an anchor block and the block in which a tx is included, the nullifier
+    /// might have been inserted into the nullifier tree by some other
+    /// transaction.
+    /// Public functions _do_ have access to the tip of the state, and so
+    /// this pattern is safe.
+    ///
+    /// # Arguments
+    /// * `unsiloed_nullifier` - The raw nullifier value (before siloing with
+    ///                          the contract address that emitted it).
+    /// * `address` - The claimed contract address that emitted the nullifier
+    ///
+    /// # Returns
+    /// * `bool` - True if the nullifier has been emitted by the specified contract
+    ///
     pub fn nullifier_exists(_self: Self, unsiloed_nullifier: Field, address: AztecAddress) -> bool {
         // Safety: AVM opcodes are constrained by the AVM itself
         unsafe { nullifier_exists(unsiloed_nullifier, address.to_field()) } == 1
     }
 
+    /// Consumes a message sent from Ethereum (L1) to Aztec (L2) -- effectively
+    /// marking it as "read".
+    ///
+    /// Use this function if you only want the message to ever be "referred to"
+    /// once. Once consumed using this method, the message cannot be consumed
+    /// again, because a nullifier is emitted.
+    /// If your use case wants for the message to be read unlimited times, then
+    /// you can always read any historic message from the L1-to-L2 messages tree,
+    /// using the `l1_to_l2_msg_exists` method. Messages never technically get
+    /// deleted from that tree.
+    ///
+    /// The message will first be inserted into an Aztec "Inbox" smart contract
+    /// on L1. It will not be available for consumption immediately. Messages
+    /// get copied-over from the L1 Inbox to L2 by the next Proposer in batches.
+    /// So you will need to wait until the messages are copied before you can
+    /// consume them.
+    ///
+    /// # Arguments
+    /// * `content` - The message content that was sent from L1
+    /// * `secret` - Secret value used for message privacy (if needed)
+    /// * `sender` - Ethereum address that sent the message
+    /// * `leaf_index` - Index of the message in the L1-to-L2 message tree
+    ///
+    /// # Advanced
+    /// * Validates message existence in the L1-to-L2 message tree
+    /// * Prevents double-consumption by emitting a nullifier
+    /// * Message hash is computed from all parameters + chain context
+    /// * Will revert if message doesn't exist or was already consumed
+    ///
     pub fn consume_l1_to_l2_message(
         &mut self,
         content: Field,
@@ -80,11 +245,48 @@ impl PublicContext {
         self.push_nullifier(nullifier);
     }
 
+    /// Sends an "L2 -> L1 message" from this function (Aztec, L2) to a smart
+    /// contract on Ethereum (L1). L1 contracts which are designed to
+    /// send/receive messages to/from Aztec are called "Portal Contracts".
+    ///
+    /// Common use cases include withdrawals, cross-chain asset transfers, and
+    /// triggering L1 actions based on L2 state changes.
+    ///
+    /// The message will be inserted into an Aztec "Outbox" contract on L1,
+    /// when this transaction's block is proposed to L1.
+    /// Sending the message will not result in any immediate state changes in
+    /// the target portal contract. The message will need to be manually
+    /// consumed from the Outbox through a separate Ethereum transaction: a user
+    /// will need to call a function of the portal contract -- a function
+    /// specifically designed to make a call to the Outbox to consume the
+    /// message.
+    /// The message will only be available for consumption once the _epoch_
+    /// proof has been submitted. Given that there are multiple Aztec blocks
+    /// within an epoch, it might take some time for this epoch proof to be
+    /// submitted -- especially if the block was near the start of an epoch.
+    ///
+    /// # Arguments
+    /// * `recipient` - Ethereum address that will receive the message
+    /// * `content` - Message content (32 bytes as a Field element)
+    ///
     pub fn message_portal(_self: &mut Self, recipient: EthAddress, content: Field) {
         // Safety: AVM opcodes are constrained by the AVM itself
         unsafe { send_l2_to_l1_msg(recipient, content) };
     }
 
+    /// Calls a public function on another contract.
+    ///
+    /// Will revert if the called function reverts or runs out of gas.
+    ///
+    /// # Arguments
+    /// * `contract_address` - Address of the contract to call
+    /// * `function_selector` - Function to call on the target contract
+    /// * `args` - Arguments to pass to the function
+    /// * `gas_opts` - An optional allocation of gas to the called function.
+    ///
+    /// # Returns
+    /// * `[Field]` - Return data from the called function
+    ///
     pub unconstrained fn call_public_function(
         _self: &mut Self,
         contract_address: AztecAddress,
@@ -111,6 +313,25 @@ impl PublicContext {
         result_data
     }
 
+    /// Makes a read-only call to a public function on another contract.
+    ///
+    /// This is similar to Solidity's `staticcall`. The called function
+    /// cannot modify state or emit events. Any nested calls are constrained to
+    /// also be staticcalls.
+    ///
+    /// Useful for querying data from other contracts safely.
+    ///
+    /// Will revert if the called function reverts or runs out of gas.
+    ///
+    /// # Arguments
+    /// * `contract_address` - Address of the contract to call
+    /// * `function_selector` - Function to call on the target contract
+    /// * `args` - Array of arguments to pass to the called function
+    /// * `gas_opts` - An optional allocation of gas to the called function.
+    ///
+    /// # Returns
+    /// * `[Field]` - Return data from the called function
+    ///
     pub unconstrained fn static_call_public_function(
         _self: &mut Self,
         contract_address: AztecAddress,
@@ -137,33 +358,142 @@ impl PublicContext {
         result_data
     }
 
+    /// Adds a new note hash to the Aztec blockchain's global Note Hash Tree.
+    ///
+    /// Notes are ordinarily constructed and emitted by _private_ functions, to
+    /// ensure that both the content of the note, and the contract that emitted
+    /// the note, stay private.
+    ///
+    /// There are however some useful patterns whereby a note needs to contain
+    /// _public_ data. The ability to push a new note_hash from a _public_
+    /// function means that notes can be injected with public data immediately
+    /// -- as soon as the public value is known. The slower alternative would
+    /// be to submit a follow-up transaction so that a private function can
+    /// inject the data. Both are possible on Aztec.
+    ///
+    /// Search "Partial Note" for a very common pattern which enables a note
+    /// to be "partially" populated with some data in a _private_ function, and
+    /// then later "completed" with some data in a public function.
+    ///
+    /// # Arguments
+    /// * `note_hash` - The hash of the note to add to the tree
+    ///
+    /// # Advanced
+    /// * The note hash will be siloed with the contract address by the protocol
+    ///
     pub fn push_note_hash(_self: &mut Self, note_hash: Field) {
         // Safety: AVM opcodes are constrained by the AVM itself
         unsafe { emit_note_hash(note_hash) };
     }
+
+    /// Adds a new nullifier to the Aztec blockchain's global Nullifier Tree.
+    ///
+    /// Whilst nullifiers are primarily intended as a _privacy-preserving_
+    /// record of a one-time action, they can also be used to efficiently
+    /// record _public_ one-time actions too. Hence why you're seeing this
+    /// function within the PublicContext.
+    /// An example is to check whether a contract has been published: we emit
+    /// a nullifier that is deterministic, but whose preimage is _not_ private.
+    ///
+    /// # Arguments
+    /// * `nullifier` - A unique field element that represents the consumed
+    ///   state
+    ///
+    /// # Advanced
+    /// * Nullifier is immediately added to the global nullifier tree
+    /// * Emitted nullifiers are immediately visible to all
+    ///   subsequent transactions in the same block
+    /// * Automatically siloed with the contract address by the protocol
+    /// * Used for preventing double-spending and ensuring one-time actions
+    ///
     pub fn push_nullifier(_self: &mut Self, nullifier: Field) {
         // Safety: AVM opcodes are constrained by the AVM itself
         unsafe { emit_nullifier(nullifier) };
     }
 
+    /// Returns the address of the current contract being executed.
+    ///
+    /// This is equivalent to `address(this)` in Solidity (hence the name).
+    /// Use this to identify the current contract's address, commonly needed for
+    /// access control or when interacting with other contracts.
+    ///
+    /// # Returns
+    /// * `AztecAddress` - The contract address of the current function being
+    ///                    executed.
+    ///
     pub fn this_address(_self: Self) -> AztecAddress {
         // Safety: AVM opcodes are constrained by the AVM itself
         unsafe {
             address()
         }
     }
+
+    /// Returns the contract address that initiated this function call.
+    ///
+    /// This is similar to `msg.sender` in Solidity (hence the name).
+    ///
+    /// Important Note: Since Aztec doesn't have a concept of an EoA (
+    /// Externally-owned Account), the msg_sender is "undefined" for the first
+    /// function call of every transaction. A value of `-1` is returned in such
+    /// cases, and is enforced by the protocol's kernel circuits.
+    /// The first function call of a tx is likely to be a call to the user's
+    /// account contract, so this quirk will most often be handled by account
+    /// contract developers.
+    ///
+    /// # Returns
+    /// * `AztecAddress` - The address of the account or contract that called
+    ///   this function
+    ///
+    /// # Examples
+    /// ```rust
+    /// #[aztec(public)]
+    /// fn transfer(context: &mut PublicContext, to: AztecAddress, amount: u64) {
+    ///     let sender = context.msg_sender();
+    ///     // Only the sender can transfer their own tokens
+    ///     assert(sender == get_token_owner(), "Unauthorized");
+    /// }
+    /// ```
+    ///
+    /// # Advanced
+    /// * Value is provided by the AVM sender opcode
+    /// * In nested calls, this is the immediate caller, not the original
+    ///   transaction sender
+    /// * Globally visible unlike private execution where it's contract-local
     pub fn msg_sender(_self: Self) -> AztecAddress {
         // Safety: AVM opcodes are constrained by the AVM itself
         unsafe {
             sender()
         }
     }
+
+    /// Returns the function selector of the currently-executing function.
+    ///
+    /// This is similar to `msg.sig` in Solidity, returning the first 4
+    /// bytes of the function signature.
+    ///
+    /// # Returns
+    /// * `FunctionSelector` - The 4-byte function identifier
+    ///
+    /// # Advanced
+    /// * Extracted from the first element of calldata
+    /// * Used internally for function dispatch in the AVM
+    ///
     pub fn selector(_self: Self) -> FunctionSelector {
         // The selector is the first element of the calldata when calling a public function through dispatch.
         // Safety: AVM opcodes are constrained by the AVM itself
         let raw_selector: [Field; 1] = unsafe { calldata_copy(0, 1) };
         FunctionSelector::from_field(raw_selector[0])
     }
+
+    /// Returns the hash of the arguments passed to the current function.
+    ///
+    /// Very low-level function: The #[public] macro uses this internally.
+    /// Smart contract developers typically won't need to access this
+    /// directly as arguments are automatically made available.
+    ///
+    /// # Returns
+    /// * `Field` - Hash of the function arguments
+    ///
     pub fn get_args_hash(mut self) -> Field {
         if !self.args_hash.is_some() {
             self.args_hash = Option::some((self.compute_args_hash)());
@@ -171,6 +501,29 @@ impl PublicContext {
 
         self.args_hash.unwrap_unchecked()
     }
+
+    /// Returns the "transaction fee" for the current transaction.
+    /// This is the final tx fee that will be deducted from the fee_payer's
+    /// "fee-juice" balance (in the protocol's Base Rollup circuit).
+    ///
+    /// # Returns
+    /// * `Field` - The actual, final cost of the transaction, taking into account:
+    ///             the actual gas used during the setup and app-logic phases,
+    ///             and the fixed amount of gas that's been allocated by the user
+    ///             for the teardown phase.
+    ///             I.e. effectiveL2FeePerGas * l2GasUsed + effectiveDAFeePerGas * daGasUsed
+    ///
+    /// This will return `0` during the "setup" and "app-logic" phases of
+    /// tx execution (because the final tx fee is not known at that time).
+    /// This will only return a nonzero value during the "teardown" phase of
+    /// execution, where the final tx fee can actually be computed.
+    ///
+    /// Regardless of _when_ this function is called during the teardown phase,
+    /// it will always return the same final tx fee value. The teardown phase
+    /// does not consume a variable amount of gas: it always consumes a
+    /// pre-allocated amount of gas, as specified by the user when they generate
+    /// their tx.
+    ///
     pub fn transaction_fee(_self: Self) -> Field {
         // Safety: AVM opcodes are constrained by the AVM itself
         unsafe {
@@ -178,36 +531,137 @@ impl PublicContext {
         }
     }
 
+    /// Returns the chain ID of the current network.
+    ///
+    /// This is similar to `block.chainid` in Solidity. Returns the unique
+    /// identifier for the blockchain network this transaction is executing on.
+    ///
+    /// Helps prevent cross-chain replay attacks. Useful if implementing
+    /// multi-chain contract logic.
+    ///
+    /// # Returns
+    /// * `Field` - The chain ID as a field element
+    ///
     pub fn chain_id(_self: Self) -> Field {
         // Safety: AVM opcodes are constrained by the AVM itself
         unsafe {
             chain_id()
         }
     }
+
+    /// Returns the Aztec protocol version that this transaction is executing
+    /// under. Different versions may have different rules, opcodes, or
+    /// cryptographic primitives.
+    ///
+    /// This is similar to how Ethereum has different EVM versions.
+    ///
+    /// Useful for forward/backward compatibility checks
+    ///
+    /// Not to be confused with contract versions; this is the protocol version.
+    ///
+    /// # Returns
+    /// * `Field` - The protocol version as a field element
+    ///
     pub fn version(_self: Self) -> Field {
         // Safety: AVM opcodes are constrained by the AVM itself
         unsafe {
             version()
         }
     }
+    /// Returns the current block number.
+    ///
+    /// This is similar to `block.number` in Solidity.
+    ///
+    /// Note: the current block number is only available within a public function
+    /// (as opposed to a private function).
+    ///
+    /// Note: the time intervals between blocks should not be relied upon as
+    /// being consistent:
+    /// - Timestamps of blocks fall within a range, rather than at exact regular
+    ///   intervals.
+    /// - Slots can be missed.
+    /// - Protocol upgrades can completely change the intervals between blocks
+    ///   (and indeed the current roadmap plans to reduce the time between
+    ///   blocks, eventually).
+    /// Use `context.timestamp()` for more-reliable time-based logic.
+    ///
+    /// # Returns
+    /// * `u32` - The current block number
+    ///
     pub fn block_number(_self: Self) -> u32 {
         // Safety: AVM opcodes are constrained by the AVM itself
         unsafe {
             block_number()
         }
     }
+
+    /// Returns the timestamp of the current block.
+    ///
+    /// This is similar to `block.timestamp` in Solidity.
+    ///
+    /// All functions of all transactions in a block share the exact same
+    /// timestamp (even though technically each transaction is executed
+    /// one-after-the-other).
+    ///
+    /// Important note: Timestamps of Aztec blocks are not at reliably-fixed
+    /// intervals. The proposer of the block has some flexibility to choose a
+    /// timestamp which is in a valid _range_: Obviously the timestamp of this
+    /// block must be strictly greater than that of the previous block, and must
+    /// must be less than the timestamp of whichever ethereum block the aztec
+    /// block is proposed to. Furthermore, if the timestamp is not deemed close
+    /// enough to the actual current time, the committee of validators will not
+    /// attest to the block.
+    ///
+    /// # Returns
+    /// * `u64` - Unix timestamp in seconds
+    ///
     pub fn timestamp(_self: Self) -> u64 {
         // Safety: AVM opcodes are constrained by the AVM itself
         unsafe {
             timestamp()
         }
     }
+
+    /// Returns the fee per unit of L2 gas for this transaction (aka the "L2 gas
+    /// price"), as chosen by the user.
+    ///
+    /// L2 gas covers the cost of executing public functions and handling
+    /// side-effects within the AVM.
+    ///
+    /// # Returns
+    /// * `u128` - Fee per unit of L2 gas
+    ///
+    /// Wallet developers should be mindful that the choice of gas price (which
+    /// is publicly visible) can leak information about the user, e.g.:
+    /// - which wallet software the user is using;
+    /// - the amount of time which has elapsed from the time the user's wallet
+    ///   chose a gas price (at the going rate), to the time of tx submission.
+    ///   This can give clues about the proving time, and hence the nature of
+    ///   the tx.
+    /// - the urgency of the transaction (which is kind of unavoidable, if the
+    ///   tx is indeed urgent).
+    /// - the wealth of the user.
+    /// - the exact user (if the gas price is explicitly chosen by the user to
+    ///   be some unique number like 0.123456789, or their favourite number).
+    /// Wallet devs might wish to consider fuzzing the choice of gas price.
+    ///
     pub fn base_fee_per_l2_gas(_self: Self) -> u128 {
         // Safety: AVM opcodes are constrained by the AVM itself
         unsafe {
             base_fee_per_l2_gas()
         }
     }
+
+    /// Returns the fee per unit of DA (Data Availability) gas (aka the "DA gas
+    /// price").
+    ///
+    /// DA gas covers the cost of making transaction data available on L1.
+    ///
+    /// See the warning in `fee_pre_l2_gas` for how gas prices can be leaky.
+    ///
+    /// # Returns
+    /// * `u128` - Fee per unit of DA gas
+    ///
     pub fn base_fee_per_da_gas(_self: Self) -> u128 {
         // Safety: AVM opcodes are constrained by the AVM itself
         unsafe {
@@ -215,23 +669,66 @@ impl PublicContext {
         }
     }
 
+    /// Returns the remaining L2 gas available for this transaction.
+    ///
+    /// Different AVM opcodes consume different amounts of gas.
+    ///
+    /// # Returns
+    /// * `u32` - Remaining L2 gas units
+    ///
     pub fn l2_gas_left(_self: Self) -> u32 {
         // Safety: AVM opcodes are constrained by the AVM itself
         unsafe {
             l2_gas_left()
         }
     }
+
+    /// Returns the remaining DA (Data Availability) gas available for this
+    /// transaction.
+    ///
+    /// DA gas is consumed when emitting data that needs to be made available
+    /// on L1, such as public logs or state updates.
+    /// All of the side-effects from the private part of the tx also consume
+    /// DA gas before execution of any public functions even begins.
+    ///
+    /// # Returns
+    /// * `u32` - Remaining DA gas units
+    ///
     pub fn da_gas_left(_self: Self) -> u32 {
         // Safety: AVM opcodes are constrained by the AVM itself
         unsafe {
             da_gas_left()
         }
     }
+
+    /// Checks if the current execution is within a staticcall context, where
+    /// no state changes or logs are allowed to be emitted (by this function
+    /// or any nested function calls).
+    ///
+    /// # Returns
+    /// * `bool` - True if in staticcall context, false otherwise
+    ///
     pub fn is_static_call(_self: Self) -> bool {
         // Safety: AVM opcodes are constrained by the AVM itself
         unsafe { is_static_call() } == 1
     }
 
+    /// Reads raw field values from public storage.
+    /// Reads N consecutive storage slots starting from the given slot.
+    ///
+    /// Very low-level function. Users should typically use the public state
+    /// variable abstractions to perform reads: PublicMutable & PublicImmutable.
+    ///
+    /// # Arguments
+    /// * `storage_slot` - The starting storage slot to read from
+    ///
+    /// # Returns
+    /// * `[Field; N]` - Array of N field values from consecutive storage slots
+    ///
+    /// # Generic Parameters
+    /// * `N` - the number of consecutive slots to return, starting from the
+    ///         `storage_slot`.
+    ///
     pub fn raw_storage_read<let N: u32>(_self: Self, storage_slot: Field) -> [Field; N] {
         let mut out = [0; N];
         for i in 0..N {
@@ -241,6 +738,20 @@ impl PublicContext {
         out
     }
 
+    /// Reads a typed value from public storage.
+    ///
+    /// Low-level function. Users should typically use the public state
+    /// variable abstractions to perform reads: PublicMutable & PublicImmutable.
+    ///
+    /// # Arguments
+    /// * `storage_slot` - The storage slot to read from
+    ///
+    /// # Returns
+    /// * `T` - The deserialized value from storage
+    ///
+    /// # Generic Parameters
+    /// * `T` - The type that the caller expects to read from the `storage_slot`.
+    ///
     pub fn storage_read<T>(self, storage_slot: Field) -> T
     where
         T: Packable,
@@ -248,6 +759,18 @@ impl PublicContext {
         T::unpack(self.raw_storage_read(storage_slot))
     }
 
+    /// Writes raw field values to public storage.
+    /// Writes to N consecutive storage slots starting from the given slot.
+    ///
+    /// Very low-level function. Users should typically use the public state
+    /// variable abstractions to perform writes: PublicMutable & PublicImmutable.
+    ///
+    /// Public storage writes take effect immediately.
+    ///
+    /// # Arguments
+    /// * `storage_slot` - The starting storage slot to write to
+    /// * `values` - Array of N Fields to write to storage
+    ///
     pub fn raw_storage_write<let N: u32>(_self: Self, storage_slot: Field, values: [Field; N]) {
         for i in 0..N {
             // Safety: AVM opcodes are constrained by the AVM itself
@@ -255,6 +778,18 @@ impl PublicContext {
         }
     }
 
+    /// Writes a typed value to public storage.
+    ///
+    /// Low-level function. Users should typically use the public state
+    /// variable abstractions to perform writes: PublicMutable & PublicImmutable.
+    ///
+    /// # Arguments
+    /// * `storage_slot` - The storage slot to write to
+    /// * `value` - The typed value to write to storage
+    ///
+    /// # Generic Parameters
+    /// * `T` - The type to write to storage.
+    ///
     pub fn storage_write<T>(self, storage_slot: Field, value: T)
     where
         T: Packable,
@@ -263,6 +798,7 @@ impl PublicContext {
     }
 }
 
+// TODO: consider putting this oracle code in its own file.
 // Unconstrained opcode wrappers (do not use directly).
 unconstrained fn address() -> AztecAddress {
     address_opcode()
@@ -393,6 +929,7 @@ impl Empty for PublicContext {
     }
 }
 
+// TODO: consider putting this oracle code in its own file.
 // AVM oracles (opcodes) follow, do not use directly.
 #[oracle(avmOpcodeAddress)]
 unconstrained fn address_opcode() -> AztecAddress {}

--- a/noir-projects/aztec-nr/aztec/src/state_vars/map.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/map.nr
@@ -1,7 +1,71 @@
 use crate::state_vars::storage::HasStorageSlot;
 use dep::protocol_types::{storage::map::derive_storage_slot_in_map, traits::ToField};
 
-// docs:start:map
+/// Map
+///
+/// A key-value storage container that maps keys to state variables, similar
+/// to Solidity mappings.
+///
+/// `Map` enables you to associate keys (like addresses or other identifiers)
+/// with state variables in your Aztec smart contract. This is conceptually
+/// similar to Solidity's `mapping(K => V)` syntax, where you can store and
+/// retrieve values by their associated keys.
+///
+/// You can declare a state variable contained within a Map in your contract's
+/// #[storage] struct.
+///
+/// For example, you might use
+/// `Map<AztecAddress, PrivateMutable<ValueNote, Context>, Context>` to track
+/// token balances for different users, similar to how you'd use
+/// `mapping(address => uint256)` in Solidity.
+///
+/// > Aside: the verbose `Context` in the declaration is a consequence of
+/// > leveraging Noir's regular syntax for generics to ensure that certain
+/// > state variable methods can only be called in some contexts (private,
+/// > public, utility).
+///
+/// The methods of Map are:
+/// - `at` (access state variable for a given key)
+/// (see the method's own doc comments for more info).
+///
+/// ## Generic Parameters
+/// - `K`: The key type (must implement `ToField` trait for hashing)
+/// - `V`: The value type:
+///   - any Aztec state variable:
+///     - `PublicMutable`
+///     - `PublicImmutable`
+///     - `PrivateMutable`
+///     - `PrivateImmutable`
+///     - `PrivateSet`
+///     - `DelayedPublicMutable`
+///     - `Map`
+/// - `Context`: The execution context (handles private/public function
+///   contexts)
+///
+/// ## Usage
+/// Maps are typically declared in your contract's #[storage] struct and
+/// accessed
+/// using the `at(key)` method to get the state variable for a specific key.
+/// The resulting state variable can then be read from or written to using its
+/// own methods.
+///
+/// ## Advanced
+/// Internally, `Map` uses a single base storage slot to represent the
+/// mapping
+/// itself, similar to Solidity's approach. Individual key-value pairs are
+/// stored at derived storage slots computed by hashing the base storage
+/// slot
+/// with the key using Poseidon2. This ensures:
+/// - No storage slot collisions between different keys
+/// - Uniform distribution of storage slots across the storage space
+/// - Compatibility with Aztec's storage tree structure
+/// - Gas-efficient storage access patterns similar to Solidity mappings
+///
+/// The storage slot derivation uses `derive_storage_slot_in_map(base_slot,
+/// key)` which computes `poseidon2_hash([base_slot, key.to_field()])`,
+/// ensuring cryptographically secure slot separation.
+///
+/// docs:start:map
 pub struct Map<K, V, Context> {
     context: Context,
     storage_slot: Field,
@@ -9,9 +73,11 @@ pub struct Map<K, V, Context> {
 }
 // docs:end:map
 
-// Map reserves a single storage slot regardless of what it stores because nothing is stored at said slot: it is only
-// used to derive the storage slots of nested state variables, which is expected to never result in collisions or slots
-// being close to one another due to these being hashes. This mirrors the strategy adopted by Solidity mappings.
+// Map reserves a single storage slot regardless of what it stores because
+// nothing is stored at said slot: it is only used to derive the storage slots
+// of nested state variables, which is expected to never result in collisions
+// or slots being close to one another due to these being hashes. This mirrors
+// the strategy adopted by Solidity mappings.
 impl<K, T, Context> HasStorageSlot<1> for Map<K, T, Context> {
     fn get_storage_slot(self) -> Field {
         self.storage_slot
@@ -19,6 +85,27 @@ impl<K, T, Context> HasStorageSlot<1> for Map<K, T, Context> {
 }
 
 impl<K, V, Context> Map<K, V, Context> {
+    /// Initializes a new Map state variable.
+    ///
+    /// This function is usually automatically called within the #[storage]
+    /// macro.
+    /// You typically don't need to call this directly when writing smart contracts.
+    ///
+    /// # Arguments
+    ///
+    /// * `context` - One of `PrivateContext`/`PublicContext`/`UtilityContext`.
+    ///               The Context determines which methods of this struct will
+    ///               be made available to the calling smart contract function.
+    /// * `storage_slot` - A unique identifier for this Map within the contract.
+    ///                    Usually, the #[storage] macro will determine an
+    ///                    appropriate storage_slot automatically. A smart
+    ///                    contract dev shouldn't have to worry about this, as
+    ///                    it's managed behind the scenes.
+    /// * `state_var_constructor` - A function that creates the value type (V)
+    ///                             given a context and storage slot. This is
+    ///                             typically the constructor of the state
+    ///                             variable type being stored in the Map.
+    ///
     // docs:start:new
     pub fn new(
         context: Context,
@@ -30,6 +117,38 @@ impl<K, V, Context> Map<K, V, Context> {
     }
     // docs:end:new
 
+    /// Returns the state variable associated with the given key.
+    ///
+    /// This is equivalent to accessing `mapping[key]` in Solidity. It returns
+    /// the state variable instance for the specified key, which can then be
+    /// used to read or write the value at that key.
+    ///
+    /// Unlike Solidity mappings which return the value directly, this returns
+    /// the state variable wrapper (like PrivateMutable, PublicMutable, etc.)
+    /// that you then call methods on to interact with the actual value.
+    ///
+    /// # Arguments
+    ///
+    /// * `key` - The key to look up in the map. Must implement the ToField
+    ///           trait (which most basic Noir & Aztec types do).
+    ///
+    /// # Returns
+    ///
+    /// * `V` - The state variable instance for this key. You can then call
+    ///         methods like `.read()`, `.write()`, `.get_note()`, etc. on this
+    ///         depending on the specific state variable type.
+    ///
+    /// # Example
+    ///
+    /// ```noir
+    /// // Get a user's balance (assuming PrivateMutable<ValueNote>)
+    /// let user_balance = storage.balances.at(user_address);
+    /// let current_note = user_balance.get_note();
+    ///
+    /// // Update the balance
+    /// user_balance.replace(new_note);
+    /// ```
+    ///
     // docs:start:at
     pub fn at(self, key: K) -> V
     where

--- a/noir-projects/aztec-nr/aztec/src/state_vars/private_immutable.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/private_immutable.nr
@@ -14,7 +14,49 @@ use crate::note::{
 use crate::oracle::notes::check_nullifier_exists;
 use crate::state_vars::storage::HasStorageSlot;
 
-// docs:start:struct
+/// PrivateImmutable
+///
+/// PrivateImmutable is a private state variable type for values that are set once
+/// and remain permanently unchanged.
+///
+/// You can declare a state variable of type PrivateImmutable within your contract's
+/// #[storage] struct:
+///
+/// E.g.:
+/// `your_variable: PrivateImmutable<YourNote, Context>`
+///
+/// The value is represented as a single note that persists for the lifetime of
+/// the state variable. Once initialized, this note is never nullified or replaced
+/// through the state variable interface - it can only be read.
+///
+/// The PrivateImmutable type facilitates: inserting the permanent note during
+/// initialization, and reading that note.
+///
+/// The methods of PrivateImmutable are:
+/// - `initialize`
+/// - `get_note`
+/// (see the methods' own doc comments for more info).
+///
+/// ## Example.
+///
+/// A contract's configuration parameters can be represented as a PrivateImmutable.
+/// Once set during contract deployment or initial setup, these parameters remain
+/// constant for the lifetime of the contract.
+///
+/// ## Privacy
+///
+/// PrivateImmutable has the same privacy properties as PrivateMutable (see
+/// PrivateMutable documentation), including the same privacy considerations
+/// regarding the initialization nullifier potentially leaking information about
+/// which storage slot was initialized.
+///
+/// # Generic Parameters:
+///
+/// * `Note` - A single note of this type will represent the PrivateImmutable's
+///            value at the given storage_slot.
+/// * `Context` - The execution context (PrivateContext or UtilityContext).
+///
+/// docs:start:struct
 pub struct PrivateImmutable<Note, Context> {
     context: Context,
     storage_slot: Field,
@@ -31,19 +73,58 @@ impl<T, Context> HasStorageSlot<1> for PrivateImmutable<T, Context> {
 }
 
 impl<Note, Context> PrivateImmutable<Note, Context> {
-    // docs:start:new
+    /// Initializes a new PrivateImmutable state variable.
+    ///
+    /// This function is usually automatically called within the #[storage] macro.
+    /// You typically don't need to call this directly when writing smart contracts.
+    ///
+    /// # Arguments
+    ///
+    /// * `context` - One of `PrivateContext`/`PublicContext`/`UtilityContext`. The
+    ///               Context determines which methods of this struct will be made
+    ///               available to the calling smart contract function.
+    /// * `storage_slot` - A unique identifier for this state variable within the
+    ///                    contract. The permanent note for this PrivateImmutable
+    ///                    state variable will have this `storage_slot`.
+    ///                    Usually, the #[storage] macro will determine an
+    ///                    appropriate storage_slot automatically. A smart contract
+    ///                    dev shouldn't have to worry about this, as it's managed
+    ///                    behind the scenes.
+    ///
+    /// docs:start:new
     pub fn new(context: Context, storage_slot: Field) -> Self {
         assert(storage_slot != 0, "Storage slot 0 not allowed. Storage slots must start from 1.");
         Self { context, storage_slot }
     }
     // docs:end:new
 
-    // The following computation is leaky, in that it doesn't hide the storage slot that has been initialized, nor does it hide the contract address of this contract.
-    // When this initialization nullifier is emitted, an observer could do a dictionary or rainbow attack to learn the preimage of this nullifier to deduce the storage slot and contract address.
-    // For some applications, leaking the details that a particular state variable of a particular contract has been initialized will be unacceptable.
-    // Under such circumstances, such application developers might wish to _not_ use this state variable type.
-    // This is especially dangerous for initial assignment to elements of a `Map<AztecAddress, PrivateImmutable>` type (for example), because the storage slot often also identifies an actor.
-    // e.g. the initial assignment to `my_map.at(msg.sender)` will leak: `msg.sender`, the fact that an element of `my_map` was assigned-to for the first time, and the contract_address.
+    /// Computes the nullifier that will be created when this PrivateImmutable is
+    /// initialized.
+    ///
+    /// This function is primarily used internally by the `initialize` method, but
+    /// may also be useful for contracts that need to check if a PrivateImmutable
+    /// has been initialized.
+    ///
+    /// **IMPORTANT PRIVACY CONSIDERATION:**
+    /// This computation has the same privacy implications as PrivateMutable's
+    /// initialization nullifier (see PrivateMutable documentation for detailed
+    /// explanation). The initialization nullifier can leak information about which
+    /// storage slot was initialized.
+    ///
+    /// See https://github.com/AztecProtocol/aztec-packages/issues/15568 for ideas to
+    /// improve this privacy footgun in future.
+    ///
+    /// # Returns
+    ///
+    /// * `Field` - The nullifier that will be emitted when this PrivateImmutable is
+    ///             initialized.
+    ///
+    /// # Advanced
+    ///
+    /// The computation uses the Poseidon2 hash function with a specific generator
+    /// index to hash the storage slot, creating a deterministic nullifier based on
+    /// the storage location.
+    ///
     pub fn compute_initialization_nullifier(self) -> Field {
         poseidon2_hash_with_separator(
             [self.storage_slot],
@@ -53,7 +134,42 @@ impl<Note, Context> PrivateImmutable<Note, Context> {
 }
 
 impl<Note> PrivateImmutable<Note, &mut PrivateContext> {
-    // docs:start:initialize
+    /// Initializes a PrivateImmutable state variable instance with a permanent note.
+    ///
+    /// This function inserts the single, permanent note for this state variable. It can
+    /// only be called once per PrivateImmutable. Subsequent calls will fail because
+    /// the initialization nullifier will already exist.
+    ///
+    /// Unlike PrivateMutable, this note will never be nullified or replaced through
+    /// the state variable interface - it persists for the lifetime of the state variable.
+    ///
+    /// # Arguments
+    ///
+    /// * `note` - The permanent note to store in this PrivateImmutable. This note
+    ///            contains the unchanging value of the state variable.
+    ///
+    /// # Returns
+    ///
+    /// * `NoteEmission<Note>` - A type-safe wrapper that requires you to decide
+    ///                          whether to encrypt and send the note to someone.
+    ///                          You can call `.emit()` on it to encrypt and log
+    ///                          the note, or `.discard()` to skip emission.
+    ///                          See NoteEmission for more details.
+    ///
+    /// # Advanced
+    ///
+    /// This function performs the following operations:
+    /// - Creates and emits an initialization nullifier to mark this storage slot
+    ///   as initialized. This prevents double-initialization.
+    /// - Inserts the provided note into the protocol's Note Hash Tree.
+    /// - Returns a NoteEmission type that allows the caller to decide how to encrypt
+    ///   and deliver the note to its intended recipient.
+    ///
+    /// The initialization nullifier is deterministically computed from the storage
+    /// slot and can leak privacy information (see `compute_initialization_nullifier`
+    /// documentation).
+    ///
+    /// docs:start:initialize
     pub fn initialize(self, note: Note) -> NoteEmission<Note>
     where
         Note: NoteType + NoteHash + Packable,
@@ -67,7 +183,28 @@ impl<Note> PrivateImmutable<Note, &mut PrivateContext> {
     }
     // docs:end:initialize
 
-    // docs:start:get_note
+    /// Reads the permanent note of a PrivateImmutable state variable instance.
+    ///
+    /// If this PrivateImmutable state variable has not yet been initialized,
+    /// no note will exist: the call will fail and the transaction will not
+    /// be provable.
+    ///
+    /// # Returns
+    ///
+    /// * `Note` - The permanent note stored in this PrivateImmutable.
+    ///
+    /// # Advanced
+    ///
+    /// This function performs the following operations:
+    /// - Retrieves the note from the PXE via an oracle call
+    /// - Validates that the note exists and belongs to this contract address and
+    ///   storage slot by pushing a read request to the context
+    /// - Returns the note content directly without nullification
+    ///
+    /// Since the note is immutable, there's no risk of reading stale data or
+    /// race conditions - the note never changes after initialization.
+    ///
+    /// docs:start:get_note
     pub fn get_note(self) -> Note
     where
         Note: NoteType + NoteHash + Packable,
@@ -87,15 +224,33 @@ impl<Note> PrivateImmutable<Note, UtilityContext>
 where
     Note: NoteType + NoteHash + Eq,
 {
-    // docs:start:is_initialized
+    /// Checks whether this PrivateImmutable has been initialized.
+    ///
+    /// # Returns
+    ///
+    /// * `bool` - `true` if the PrivateImmutable has been initialized (the initialization
+    ///            nullifier exists), `false` otherwise.
+    ///
+    /// docs:start:is_initialized
     pub unconstrained fn is_initialized(self) -> bool {
         let nullifier = self.compute_initialization_nullifier();
         check_nullifier_exists(nullifier)
     }
     // docs:end:is_initialized
 
-    // view_note does not actually use the context, but it calls oracles that are only available in private
-    // docs:start:view_note
+    /// Returns the permanent note in this PrivateImmutable without consuming it.
+    ///
+    /// This function is only available in a UtilityContext (unconstrained environment)
+    /// and is typically used for off-chain queries, view functions, or testing.
+    ///
+    /// Unlike the constrained `get_note()`, this function does not push read requests
+    /// or perform validation. It simply reads the note from the PXE's database.
+    ///
+    /// # Returns
+    ///
+    /// * `Note` - The permanent note stored in this PrivateImmutable.
+    ///
+    /// docs:start:view_note
     pub unconstrained fn view_note(self) -> Note
     where
         Note: Packable,

--- a/noir-projects/aztec-nr/aztec/src/state_vars/private_mutable.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/private_mutable.nr
@@ -15,7 +15,93 @@ use crate::note::retrieved_note::RetrievedNote;
 use crate::oracle::notes::check_nullifier_exists;
 use crate::state_vars::storage::HasStorageSlot;
 
-// docs:start:struct
+/// # PrivateMutable
+///
+/// PrivateMutable is a private state variable type, which enables you to read, mutate,
+/// and write private state within the #[private] functions of your smart contract.
+///
+/// You can declare a state variable of type PrivateMutable within your contract's
+/// #[storage] struct:
+///
+/// E.g.:
+/// `your_variable: PrivateMutable<YourNote, Context>`
+/// or:
+/// `your_mapping: Map<Field, PrivateMutable<YourNote, Context>>`
+///
+/// The 'current' value of a PrivateMutable state variable is represented as a
+/// _single_ note at any given time.
+///
+/// > More exactly, the 'current value' is the most recently inserted note that
+/// > has not yet been nullified.
+///
+/// This is conceptually similar to how a regular variable works in Ethereum:
+/// the state variable has exactly one value at any point in time. However, the
+/// underlying implementation differs significantly because of Aztec's private
+/// state model.
+///
+/// The PrivateMutable type operates over notes. A PrivateMutable state variable is
+/// initialized by inserting a very first note. Subsequently, the PrivateMutable
+/// can make changes to the state variable's value by nullifying the current note
+/// and inserting a replacement note.
+///
+/// The methods of PrivateMutable are:
+/// - `initialize`
+/// - `replace`
+/// - `initialize_or_replace`
+/// - `get_note`
+/// (see the methods' own doc comments for more info).
+///
+/// ## Example
+///
+/// A user's account nonce can be represented as a PrivateMutable<NonceNote>.
+/// The "current value" of the user's nonce is the value contained within the
+/// single not-yet-nullified note in this PrivateMutable.
+///
+/// When the nonce needs to be incremented, the current note gets nullified
+/// and a new note with the incremented nonce gets inserted. The new note then
+/// becomes the "current value" of the PrivateMutable state variable.
+///
+/// This is similar to how `uint256 nonce` would work in Solidity: there's always
+/// exactly one current value, and updating it overwrites the previous value.
+///
+/// ## When to choose PrivateMutable vs PrivateSet:
+///
+/// - Use PrivateMutable when you want exactly one note to represent the state
+///   variable's current value, similar to regular variables in Ethereum.
+/// - Use PrivateMutable when you want only the 'owner' of the private state to
+///   be able to make changes to it.
+/// - Use PrivateSet when you want multiple notes to collectively represent the
+///   state variable's current value (like a collection of token balance notes).
+/// - Use PrivateSet when you want to allow "other people" (beyond the owner) to
+///   insert notes into the state variable.
+///
+/// Only the 'owner' of a PrivateMutable state variable can mutate it, because
+/// every mutation requires nullifying the current note, and only the owner who
+/// knows the note's content can compute its nullifier.
+///
+/// ## Privacy
+///
+/// The methods of a PrivateMutable are only executable in a PrivateContext, and are
+/// designed to not leak anything about _which_ state variable was read/modified/
+/// initialized, to the outside world.
+///
+/// However, there is one important privacy consideration: the `initialize` method
+/// creates an "initialization nullifier" that can leak information about which
+/// storage slot was initialized. See the `initialize` method documentation for
+/// more details, and for a concrete example.
+///
+/// The design of the Note impacts the privacy of the state variable: the note
+/// should contain a `randomness` field so that, when hashed, the contents are
+/// private. The note's `compute_nullifier` method will also impact privacy when
+/// the note is nullified.
+///
+/// # Generic Parameters:
+///
+/// * `Note` - A single note of this type will represent the PrivateMutable's
+///            current value at the given storage_slot.
+/// * `Context` - The execution context (PrivateContext or UtilityContext).
+///
+/// docs:start:struct
 pub struct PrivateMutable<Note, Context> {
     context: Context,
     storage_slot: Field,
@@ -34,21 +120,53 @@ impl<T, Context> HasStorageSlot<1> for PrivateMutable<T, Context> {
 }
 
 impl<Note, Context> PrivateMutable<Note, Context> {
-    // docs:start:new
+    /// Initializes a new PrivateMutable state variable.
+    ///
+    /// This function is usually automatically called within the #[storage] macro.
+    /// You typically don't need to call this directly when writing smart contracts.
+    ///
+    /// # Arguments
+    ///
+    /// * `context` - One of `PrivateContext`/`PublicContext`/`UtilityContext`. The
+    ///               Context determines which methods of this struct will be made
+    ///               available to the calling smart contract function.
+    /// * `storage_slot` - A unique identifier for this state variable within the
+    ///                    contract. Every replacement note for this PrivateMutable
+    ///                    state variable will have the same `storage_slot`.
+    ///                    Usually, the #[storage] macro will determine an
+    ///                    appropriate storage_slot automatically. A smart contract
+    ///                    dev shouldn't have to worry about this, as it's managed
+    ///                    behind the scenes.
+    ///
+    /// docs:start:new
     pub fn new(context: Context, storage_slot: Field) -> Self {
         assert(storage_slot != 0, "Storage slot 0 not allowed. Storage slots must start from 1.");
         Self { context, storage_slot }
     }
     // docs:end:new
 
-    // The following computation is leaky, in that it doesn't hide the storage slot that has been initialized, nor does it hide the contract address of this contract.
-    // When this initialization nullifier is emitted, an observer could do a dictionary or rainbow attack to learn the preimage of this nullifier to deduce the storage slot and contract address.
-    // For some applications, leaking the details that a particular state variable of a particular contract has been initialized will be unacceptable.
-    // Under such circumstances, such application developers might wish to _not_ use this state variable type.
-    // This is especially dangerous for initial assignment to elements of a `Map<AztecAddress, PrivateMutable>` type (for example), because the storage slot often also identifies an actor. e.g.
-    // the initial assignment to `my_map.at(msg.sender)` will leak: `msg.sender`, the fact that an element of `my_map` was assigned-to for the first time, and the contract_address.
-    // Note: subsequent nullification of this state variable, via the `replace` method will not be leaky, if the `compute_nullifier()` method of the underlying note is designed to ensure privacy.
-    // For example, if the `compute_nullifier()` method injects the secret key of a note owner into the computed nullifier's preimage.
+    /// Computes the nullifier that will be created when this PrivateMutable is first
+    /// initialized.
+    ///
+    /// This function is primarily used internally by the `initialize` and
+    /// `initialize_or_replace` methods, but may also be useful for contracts that
+    /// need to check if a PrivateMutable has been initialized.
+    ///
+    /// ## Returns
+    ///
+    /// * `Field` - The nullifier that will be emitted when this PrivateMutable is
+    ///             first initialized.
+    ///
+    /// ## Advanced
+    ///
+    /// The computation uses the Poseidon2 hash function with a specific generator
+    /// index to hash the storage slot, creating a deterministic nullifier based on
+    /// the storage location.
+    ///
+    /// Note: Subsequent nullifications via the `replace` method will NOT be leaky
+    /// if the underlying note's `compute_nullifier()` method is designed to ensure privacy
+    /// (e.g., by incorporating the note owner's nullifier secret key into the nullifier preimage).
+    ///
     pub fn compute_initialization_nullifier(self) -> Field {
         poseidon2_hash_with_separator(
             [self.storage_slot],
@@ -61,6 +179,65 @@ impl<Note> PrivateMutable<Note, &mut PrivateContext>
 where
     Note: NoteType + NoteHash,
 {
+    /// Initializes a PrivateMutable state variable instance with its first note.
+    ///
+    /// This function creates the very first note for this state variable. It can
+    /// only be called once per PrivateMutable. Subsequent calls will fail because
+    /// the initialization nullifier will already exist.
+    ///
+    /// This is conceptually similar to setting an initial value for a variable in
+    /// Ethereum smart contracts, except that in Aztec the "value" is represented
+    /// as a private note.
+    ///
+    /// ## IMPORTANT PRIVACY CONSIDERATION
+    ///
+    /// This computation is leaky and can compromise privacy under certain
+    /// circumstances.
+    ///
+    /// When the initialization nullifier is emitted during this call, an observer
+    /// could perform a dictionary or rainbow attack to learn the storage slot and
+    /// contract address.
+    ///
+    /// For applications where revealing that a particular state variable has been
+    /// initialized is unacceptable, developers should consider alternative approaches
+    /// or avoid using PrivateMutable.
+    ///
+    /// This is especially dangerous for initial assignments to elements of a
+    /// `Map<AztecAddress, PrivateMutable>`, because the storage slot often identifies
+    /// a specific user. For example, `my_map.at(msg.sender).initialize(note)` will
+    /// leak:
+    /// - `msg.sender`;
+    /// - the fact that this map element was assigned for the first time;
+    /// - and the contract's address.
+    ///
+    /// See https://github.com/AztecProtocol/aztec-packages/issues/15568 for ideas to
+    /// improve this privacy footgun in future.
+    ///
+    /// ## Arguments
+    ///
+    /// * `note` - The initial note to store in this PrivateMutable. This note
+    ///            becomes the "current value" of the state variable.
+    ///
+    /// ## Returns
+    ///
+    /// * `NoteEmission<Note>` - A type-safe wrapper that requires you to decide
+    ///                          whether to encrypt and send the note to someone.
+    ///   You can call `.emit()` on it to encrypt and log the note, or `.discard()`
+    ///   to skip emission. See NoteEmission for more details.
+    ///
+    /// ## Advanced
+    ///
+    /// This function performs the following operations:
+    /// - Creates and emits an initialization nullifier to mark this storage slot
+    ///   as initialized. This prevents double-initialization.
+    /// - Inserts the provided note into the protocol's Note Hash Tree.
+    /// - Returns a NoteEmission type that allows the caller to decide how to encrypt
+    ///   and deliver the note to its intended recipient.
+    ///
+    /// The initialization nullifier is deterministically computed from the storage
+    /// slot and can leak privacy information (see `compute_initialization_nullifier`
+    /// documentation).
+    ///
     // docs:start:initialize
     pub fn initialize(self, note: Note) -> NoteEmission<Note>
     where
@@ -74,6 +251,46 @@ where
     }
     // docs:end:initialize
 
+    /// Replaces the current note of a PrivateMutable state variable with a new note.
+    ///
+    /// This function implements the typical "nullify-and-create" pattern for updating
+    /// private state in Aztec. It first retrieves the current note, nullifies it
+    /// (marking it as "spent"), and then inserts a `new_note` with the updated data.
+    ///
+    /// This is conceptually similar to updating a variable in Ethereum smart contracts,
+    /// except that in Aztec we achieve this by consuming the old note and creating a
+    /// new one.
+    ///
+    /// This function can only be called after the PrivateMutable has been initialized.
+    /// If called on an uninitialized PrivateMutable, it will fail because there is
+    /// no current note to replace.
+    ///
+    /// ## Arguments
+    ///
+    /// * `new_note` - The new note that will replace the current note. This becomes
+    ///                the new "current value" of the PrivateMutable.
+    ///
+    /// ## Returns
+    ///
+    /// * `NoteEmission<Note>` - A type-safe wrapper that requires you to decide
+    ///                          whether to encrypt and send the note to someone.
+    ///                          You can call `.emit()` on it to encrypt and log
+    ///                          the note, or `.discard()` to skip emission.
+    ///                          See NoteEmission documentation for more details.
+    ///
+    /// ## Advanced
+    ///
+    /// This function performs the following operations:
+    /// - Retrieves the current note from the PXE via an oracle call
+    /// - Validates that the current note exists and belongs to this storage slot
+    /// - Computes the nullifier for the current note and pushes it to the context
+    /// - Inserts the provided `new_note` into the Note Hash Tree
+    /// - Returns a NoteEmission type for the `new_note`, that allows the caller to
+    ///   decide how to encrypt and deliver this note to its intended recipient.
+    ///
+    /// The nullification of the previous note ensures that it cannot be used again,
+    /// maintaining the invariant that a PrivateMutable has exactly one current note.
+    ///
     // docs:start:replace
     pub fn replace(self, new_note: Note) -> NoteEmission<Note>
     where
@@ -94,6 +311,27 @@ where
     }
     // docs:end:replace
 
+    /// Initializes the PrivateMutable if it's uninitialized, or replaces the current
+    /// note if it's already initialized.
+    ///
+    /// This is a convenience function that automatically chooses between `initialize`
+    /// and `replace` based on whether the PrivateMutable has been previously initialized.
+    /// This is useful when you don't know the initialization state beforehand, such
+    /// as in functions that may be called multiple times.
+    ///
+    /// ## Arguments
+    ///
+    /// * `note` - The note to store. If initializing, this becomes the first note.
+    ///            If replacing, this becomes the new current note.
+    ///
+    /// ## Returns
+    ///
+    /// * `NoteEmission<Note>` - A type-safe wrapper that requires you to decide
+    ///                          whether to encrypt and send the note to someone.
+    ///                          You can call `.emit()` on it to encrypt and log
+    ///                          the note, or `.discard()` to skip emission.
+    ///                          See NoteEmission documentation for more details.
+    ///
     pub fn initialize_or_replace(self, note: Note) -> NoteEmission<Note>
     where
         Note: Packable,
@@ -119,7 +357,51 @@ where
         }
     }
 
-    // docs:start:get_note
+    /// Reads the current note of a PrivateMutable state variable instance.
+    ///
+    /// This function retrieves the current note, but with an important caveat: reading
+    /// a "current" note requires nullifying it to ensure that it is indeed current,
+    /// and that it and hasn't been nullified by some earlier transaction.
+    /// Having nullified the note, we then need to re-insert a new note with equal
+    /// value, so that this value remains available for future functions to read it
+    /// as "current".
+    ///
+    /// This is different from reading variables in Ethereum, where reading doesn't
+    /// modify the state. In Aztec's private state model, reading a "current" note
+    /// "consumes" it and creates a new note of equal value but with fresh
+    /// randomness.
+    ///
+    /// The returned note has the same content as the original but is actually the
+    /// newly-created note.
+    ///
+    /// ## Returns
+    ///
+    /// * `NoteEmission<Note>` - A type-safe wrapper containing the newly-created note.
+    ///                          You still need to decide whether to encrypt and send
+    ///                          the note to someone. You can call `.emit()` on it to
+    ///                          encrypt and log the note, or `.discard()` to skip
+    ///                          emission. See NoteEmission documentation for more details.
+    ///
+    /// ## Advanced
+    ///
+    /// This function performs the "nullify-and-recreate" pattern:
+    /// - Retrieves the current note from the PXE via an oracle call
+    /// - Validates that the note exists and belongs to this contract address and
+    ///   storage slot
+    /// - Nullifies the current note to ensure that it is indeed current
+    /// - Creates a new note with identical content but with fresh randomness
+    /// - Returns a NoteEmission for the new note
+    ///
+    /// This pattern ensures that:
+    /// - You're always reading the most up-to-date note
+    /// - Concurrent transactions can't create race conditions
+    /// - The note remains available for future reads (via the fresh copy)
+    ///
+    /// The kernel will inject a unique nonce into the newly-created note, which means
+    /// the new note will have a different nullifier, allowing it to be consumed in
+    /// the future.
+    ///
+    /// docs:start:get_note
     pub fn get_note(self) -> NoteEmission<Note>
     where
         Note: Packable,
@@ -141,12 +423,38 @@ impl<Note> PrivateMutable<Note, UtilityContext>
 where
     Note: NoteType + NoteHash + Eq,
 {
+    /// Checks whether this PrivateMutable has been initialized.
+    ///
+    /// Notice that this function is executable only within a UtilityContext, which
+    /// is an unconstrained environment on the user's local device.
+    ///
+    /// ## Returns
+    ///
+    /// * `bool` - `true` if the PrivateMutable has been initialized (the initialization
+    ///            nullifier exists), `false` otherwise.
+    ///
     pub unconstrained fn is_initialized(self) -> bool {
         let nullifier = self.compute_initialization_nullifier();
         check_nullifier_exists(nullifier)
     }
 
-    // docs:start:view_note
+    /// Returns the current note in this PrivateMutable without consuming it.
+    ///
+    /// This function is only available in a UtilityContext (unconstrained environment)
+    /// and is typically used for off-chain queries, view functions, or testing.
+    ///
+    /// Unlike `get_note()`, this function does NOT nullify and recreate the note.
+    /// It simply reads the current note from the PXE's database without modifying
+    /// the state. This makes it suitable for read-only operations.
+    ///
+    /// This is conceptually similar to view functions in Ethereum that don't modify
+    /// state.
+    ///
+    /// ## Returns
+    ///
+    /// * `Note` - The current note stored in this PrivateMutable.
+    ///
+    /// docs:start:view_note
     pub unconstrained fn view_note(self) -> Note
     where
         Note: Packable,

--- a/noir-projects/aztec-nr/aztec/src/state_vars/private_set.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/private_set.nr
@@ -18,24 +18,172 @@ use dep::protocol_types::{
 
 mod test;
 
-// docs:start:struct
+/// # PrivateSet
+///
+/// PrivateSet is a private state variable type, which enables you to read, mutate,
+/// and write private state within the #[private] functions of your smart contract.
+///
+/// You can declare a state variable of type PrivateSet within your contract's
+/// #[storage] struct:
+///
+/// E.g.:
+/// `your_variable: PrivateSet<YourNote, Context>`
+/// or:
+/// `your_mapping: Map<Field, PrivateSet<YourNote, Context>>`
+///
+/// The PrivateSet type operates over notes, by facilitating: the insertion
+/// of new notes, the reading of existing notes, and the nullification of existing
+/// notes.
+///
+/// The methods of PrivateSet are:
+/// - `insert`
+/// - `pop_notes`
+/// - `get_notes`
+/// - `remove`
+/// (see the methods' own doc comments for more info).
+///
+/// The "current value" of a PrivateSet state variable is represented as a
+/// _collection_ (or "Set") of multiple notes.
+///
+/// > More exactly, the 'current value' is the collection of all
+/// > _not-yet-nullified_ notes in the set.
+///
+///
+/// ## Example.
+///
+/// A user's token balance can be represented as a PrivateSet of multiple notes,
+/// where the note type contains a value.
+/// The "current value" of the user's token balance (the PrivateSet state variable)
+/// can be interpreted as the summation of the values contained within all
+/// not-yet-nullified notes (aka "current notes") in the PrivateSet.
+///
+/// This is similar to a physical wallet containing five $10 notes: the owner's
+/// wallet balance is the sum of all those $10 notes: $50.
+/// To spend $2, they can get one $10 note, nullify it, and insert one $8 note as
+/// change. Their new wallet balance will then be interpreted as the new summation: $48.
+///
+/// The interpretation doesn't always have to be a "summation of values". When
+/// `get_notes` is called, PrivateSet does not attempt to interpret the notes at all;
+/// it's up to the custom code of the smart contract to make an interpretation.
+///
+/// For example: a set of notes could instead represent a moving average; or a modal
+/// value; or some other single statistic. Or the set of notes might not be
+/// collapsible into a single statistic: it could be a disjoint collection of NFTs
+/// which are housed under the same "storage slot".
+///
+/// It's worth noting that a user can prove existence of _at least_ some subset
+/// of notes in a PrivateSet, but they cannot prove existence of _all_ notes
+/// in a PrivateSet.
+/// The physical wallet is a good example: a user can prove that there are five
+/// $10 notes in their wallet by furnishing those notes. But because we cannot
+/// _see_ the entirety of their wallet, they might have many more notes that
+/// they're choosing to not showing us.
+///
+/// ## When to choose PrivateSet vs PrivateMutable:
+///
+/// - If you want _someone else_ (other than the owner of the private state) to be
+///   able to make edits (insert notes).
+/// - If you don't want to leak the storage_slot being initialized (see the
+///   PrivateMutable file).
+/// - If you find yourself needing to re-initialize a PrivateMutable (see that file).
+///
+/// The 'current' value of a _PrivateMutable_ state variable is only ever represented
+/// by _one_ note at a time. To mutate the current value of a PrivateMutable, the
+/// current note always gets nullified, and a new, replacement note gets inserted.
+/// So if nullification is always required to mutate a PrivateMutable, that means
+/// only the 'owner' of a given PrivateMutable state variable can ever mutate it.
+/// For some use cases, this can be too limiting: A key feature of some smart contract
+/// functions is that _multiple people_ are able to mutate a particular state
+/// variable.
+///
+/// PrivateSet enables "other people" (other than the owner of the private state) to
+/// mutate the 'current' value, with some limitations:
+/// The 'owner' is still the only person with the ability to `remove` notes from the
+/// the set.
+/// "Other people" can `insert` notes into the set.
+///
+/// It's important to notice that the "owner" of a state variable is an abstract
+/// concept which will differ depending on the rules of a smart contract. When we
+/// talk about the "owner" in the context of these aztec-nr files, we tend to mean
+/// "the person who has the ability to nullify the state variable's notes".
+/// Notice that the state variable abstractions of aztec-nr do not know what an
+/// "owner" is: they delegate responsibility of understanding who the "owner" of a
+/// note is to the note itself, via a `compute_nullifier` call.
+///
+///
+/// ## Privacy
+///
+/// The methods of a PrivateSet are only executable in a PrivateContext, and are
+/// designed to not leak anything about _which_ state variable was read/modified/
+/// inserted, to the outside world.
+///
+/// The design of the Note does impact the privacy of the state variable: the note
+/// will need to contain a `randomness` field so that, when hashed, the contents of
+/// the note are private.
+/// > Note: we decided to explicitly require `randomness` in a note definition,
+/// > because we anticipated use cases where notes might also be used to store
+/// > certain _public_ state. We might roll-back that decision, so that users don't
+/// > need to worry about handling their own randomness when defining custom notes.
+///
+/// The design of the note's custom `compute_nullifier` method will also impact the
+/// privacy of the note at the time it is nullified. (Note: all Notes must implement
+/// `compute_nullifier` to be compatible with PrivateSet). See the docs.
+///
+///
+/// # Struct Fields:
+///
+/// * context - The execution context (PrivateContext or UtilityContext).
+/// * storage_slot -  All notes that "belong" to a given PrivateSet state variable
+///                   are augmented with a common `storage_slot` field, as a way of
+///   identifying which set they belong to. (Management of `storage_slot` is handled
+///   within the innards of the PrivateSet impl, so you shouldn't need to think about
+///   this any further).
+///
+///
+/// # Generic Parameters:
+///
+/// * `Note` - Many notes of this type will collectively form the PrivateSet at the
+///            given storage_slot.
+/// * `Context` - The execution context (PrivateContext or UtilityContext).
+///
+/// docs:start:struct
 pub struct PrivateSet<Note, Context> {
     pub context: Context,
     pub storage_slot: Field,
 }
 // docs:end:struct
 
-// Private storage slots are not really 'slots' but rather a value in the note hash preimage, so there is no notion of a
-// value spilling over multiple slots. For this reason PrivateSet (and all other private state variables) needs just one
-// slot to be reserved, regardless of what it stores.
 impl<T, Context> HasStorageSlot<1> for PrivateSet<T, Context> {
+    // Private storage slots are not really 'slots' but rather a value in the note
+    // hash preimage, so there is no notion of a value spilling over multiple slots.
+    // For this reason, PrivateSet (and all other private state variables) needs
+    // just one slot to be reserved, regardless of what it stores.
     fn get_storage_slot(self) -> Field {
         self.storage_slot
     }
 }
 
 impl<Note, Context> PrivateSet<Note, Context> {
-    // docs:start:new
+    /// Initializes a new PrivateSet state variable.
+    ///
+    /// This function is usually automatically called within the #[storage] macro.
+    /// You typically don't need to call this directly when writing smart contracts.
+    ///
+    ///
+    /// # Arguments
+    ///
+    /// * `context` - One of `PrivateContext`/`PublicContext`/`UtilityContext`. The
+    ///               Context determines which methods of this struct will be made
+    ///               available to the calling smart contract function.
+    /// * `storage_slot` - A unique identifier for this state variable within the
+    ///                    contract. All notes that "belong" to a given PrivateSet
+    ///                    state variable are augmented with a common `storage_slot`
+    ///                    field, as a way of identifying which set they belong to.
+    ///                    Usually, the #[storage] macro will determine an appropriate
+    ///                    storage_slot automatically. A smart contract dev shouldn't
+    ///                    have to worry about this, as it's managed behind the scenes.
+    ///
+    /// docs:start:new
     pub fn new(context: Context, storage_slot: Field) -> Self {
         assert(storage_slot != 0, "Storage slot 0 not allowed. Storage slots must start from 1.");
         PrivateSet { context, storage_slot }
@@ -47,7 +195,64 @@ impl<Note> PrivateSet<Note, &mut PrivateContext>
 where
     Note: NoteType + NoteHash + Eq,
 {
-    // docs:start:insert
+    /// Inserts a new `note` into the PrivateSet.
+    ///
+    /// # Arguments
+    ///
+    /// - `note` - A newly-created note that you would like to insert into this
+    ///            PrivateSet.
+    ///
+    /// # Returns
+    ///
+    /// - NoteEmission<Note> - A type-safe wrapper which makes it clear to the
+    ///                        smart contract dev that they now have a choice: they
+    ///   need to decide whether they would like to send the contents of the newly-
+    ///   created note to someone, or not. If they would like to, they have some
+    ///   further choices:
+    ///   - What kind of log to use? (Private log, or offchain log).
+    ///   - What kind of encryption scheme to use? (Currently only AES128 is supported)
+    ///   - Whether to _constrain_ delivery of the note, or not.
+    ///   At the moment, aztec-nr provides limited options.
+    ///   You can call `.emit()` on the returned type to encrypt and log the note, or
+    ///   `.discard()` to skip emission.
+    ///   See NoteEmission for more details.
+    ///   > Note: We're planning a _significant_ refactor of this syntax, to make the
+    ///     syntax of how to encrypt and deliver notes much clearer, and to make the
+    ///     default options much clearer to developers. We will also be enabling
+    ///     easier ways to customize your own note encryption options.
+    ///
+    /// # Advanced:
+    ///
+    /// Ultimately, this function inserts the `note` into the protocol's Note Hash
+    /// Tree.
+    /// Behind the scenes, we do the following:
+    /// - Augment the note with the `storage_slot` of this PrivateSet, to
+    ///   convey which set it belongs to.
+    /// - Augment the note with a `note_type_id`, so that it can be correctly filed-
+    ///   away when it is eventually discovered, decrypted, and processed by its
+    ///   intended recipient.
+    ///   (The note_type_id is usually allocated by the #[note] macro).
+    /// - Provide the contents of the (augmented) note to the PXE, so that it can
+    ///   store all notes created by the user executing this function.
+    ///   - The note is also kept in the PXE's memory during execution, in case this
+    ///     newly-created note gets _read_ in some later execution frame of this
+    ///     transaction. In such a case, we feed hints to the kernel to squash:
+    ///     the so-called "transient note", its note log (if applicable), and the
+    ///     nullifier that gets created by the reading function.
+    /// - Hash the (augmented) note into a single Field, via the note's own
+    ///   `compute_note_hash` method.
+    /// - Push the `note_hash` to the PrivateContext. From here, the protocol's
+    ///   kernel circuits will take over and insert the note_hash into the protocol's
+    ///   "note hash tree".
+    ///   - Before insertion, the protocol will:
+    ///     - "Silo" the `note_hash` with the `contract_address` of the calling
+    ///       function, to yield a `siloed_note_hash`. This prevents state collisions
+    ///       between different smart contracts.
+    ///     - Ensure uniqueness of the `siloed_note_hash`, to prevent Faerie-Gold
+    ///       attacks, by hashing the `siloed_note_hash` with a unique value, to
+    ///       yield a `unique_siloed_note_hash` (see the protocol spec for more).
+    ///
+    /// docs:start:insert
     pub fn insert(self, note: Note) -> NoteEmission<Note>
     where
         Note: Packable,
@@ -56,6 +261,82 @@ where
     }
     // docs:end:insert
 
+    /// Pops a collection of "current" notes (i.e. not-yet-nullified notes) which
+    /// belong to this PrivateSet.
+    ///
+    /// "Pop" indicates that, conceptually, the returned notes will get _permanently
+    /// removed_ (nullified) from the PrivateSet by this method.
+    ///
+    /// The act of nullifying convinces us that the returned notes are indeed
+    /// "current" (because if they can be nullified, it means they haven't been
+    /// nullified already, because a note can only be nullified once).
+    ///
+    /// This means that -- whilst the returned notes should be considered "current"
+    /// within the currently-executing execution frame of the tx -- they will be not
+    /// be considered "current" by any _later_ execution frame of this tx (or any
+    /// future tx).
+    ///
+    /// Notes will be selected from the PXE's database, via an oracle call, according
+    /// to the filtering `options` provided.
+    ///
+    /// # Arguments
+    ///
+    /// - `options` - See NoteGetterOptions. Enables the caller to specify the
+    ///               properties of the notes that must be returned by the oracle
+    ///               call to the PXE.
+    ///               The NoteGetterOptions are designed to contain functions which
+    ///               _constrain_ that the returned notes do indeed adhere to the
+    ///               specified options. Those functions are executed _within_ this
+    ///               `pop_notes` call.
+    ///
+    /// # Returns
+    ///
+    /// - BoundedVec<Note, MAX_NOTE_HASH_READ_REQUESTS_PER_CALL>
+    ///   - A vector of "current" notes, that have been constrained to satisfy the
+    ///     retrieval criteria specified by the given `options`.
+    ///
+    /// # Generic Parameters
+    ///
+    /// * `PreprocessorArgs` - See `NoteGetterOptions`.
+    /// * `FilterArgs` - See `NoteGetterOptions`.
+    /// * `M` - The length of the note (in Fields), when packed by the Packable trait.
+    ///
+    /// # Advanced:
+    ///
+    /// Reads the notes:
+    ///
+    /// - Gets notes from the PXE, via an oracle call, according to the filtering
+    ///   `options` provided.
+    /// - Constrains that the returned notes do indeed adhere to the `options`.
+    ///   (Note: the `options` contain _constrained_ functions that get invoked
+    ///   _within_ this function).
+    /// - Asserts that the notes do indeed belong to this calling function's
+    ///   `contract_address`, and to this PrivateSet's `storage_slot`.
+    /// - Computes the note_hash for each note, using the `storage_slot` and
+    ///   `contract_address` of this PrivateSet instance.
+    /// - Asserts that the note_hash does indeed exist:
+    ///   - For settled notes: makes a request to the kernel to perform a merkle
+    ///     membership check against the historical Note Hashes Tree that this tx
+    ///     is referencing.
+    ///   - For transient notes: makes a request to the kernel to ensure that the
+    ///     note was indeed emitted by some earlier execution frame of this tx.
+    ///
+    /// Nullifies the notes:
+    ///
+    /// - Computes the nullifier for each note.
+    ///   - (The nullifier computation differs depending on whether the note is
+    ///     settled or transient).
+    /// - Pushes the nullifiers to the PrivateContext. From here, the protocol's
+    ///   kernel circuits will take over and insert the nullifiers into the
+    ///   protocol's "nullifier tree".
+    ///   - Before insertion, the protocol will:
+    ///     - "Silo" each `nullifier` with the `contract_address` of the calling
+    ///       function, to yield a `siloed_nullifier`. This prevents nullifier
+    ///       collisions between different smart contracts.
+    ///     - Ensure that each `siloed_nullifier` does not already exist in the
+    ///       nullifier tree. The nullifier tree is an indexed merkle tree, which
+    ///       supports efficient non-membership proofs.
+    ///
     pub fn pop_notes<PreprocessorArgs, FilterArgs, let M: u32>(
         self,
         options: NoteGetterOptions<Note, M, PreprocessorArgs, FilterArgs>,
@@ -65,7 +346,7 @@ where
     {
         let (retrieved_notes, note_hashes) = get_notes(self.context, self.storage_slot, options);
         // We iterate in a range 0..options.limit instead of 0..notes.len() because options.limit is known at compile
-        // time and hence will result in less constraints when set to a lower value than
+        // time and hence will result in fewer constraints when set to a lower value than
         // MAX_NOTE_HASH_READ_REQUESTS_PER_CALL.
         for i in 0..options.limit {
             if i < retrieved_notes.len() {
@@ -82,8 +363,37 @@ where
         retrieved_notes.map(|retrieved_note| retrieved_note.note)
     }
 
-    /// Note that if you obtained the note via `get_notes` it's much better to use `pop_notes` as `pop_notes` results
-    /// in significantly less constrains due to avoiding an extra hash and read request check.
+    /// Permanently removes (conceptually) the given note from this PrivateSet,
+    /// by nullifying it.
+    ///
+    /// Note that if you obtained the note via `get_notes` it's much better to use
+    /// `pop_notes`, as `pop_notes` results in significantly fewer constraints,
+    /// due to avoiding an extra hash and read request check.
+    ///
+    /// # Arguments
+    ///
+    /// - `retrieved_note` - A note which -- earlier in the calling function's
+    ///                      execution -- has been retrieved from the PXE.
+    ///                      The `retrieved_note` is constrained to have been read
+    ///                      from the i
+    ///
+    /// # Returns
+    ///
+    /// - NoteEmission<Note> - A type-safe wrapper which makes it clear to the
+    ///                        smart contract dev that they now have a choice: they
+    ///   need to decide whether they would like to send the contents of the newly-
+    ///   created note to someone, or not. If they would like to, they have some
+    ///   further choices:
+    ///   - What kind of log to use? (Private log, or offchain log).
+    ///   - What kind of encryption scheme to use? (Currently only AES128 is supported)
+    ///   - Whether to _constrain_ delivery of the note, or not.
+    ///   At the moment, aztec-nr provides limited options.
+    ///   See NoteEmission for further details.
+    ///   > Note: We're planning a _significant_ refactor of this syntax, to make the
+    ///     syntax of how to encrypt and deliver notes much clearer, and to make the
+    ///     default options much clearer to developers. We will also be enabling
+    ///     easier ways to customize your own note encryption options.
+    ///
     pub fn remove(self, retrieved_note: RetrievedNote<Note>) {
         let note_hash = compute_note_hash_for_read_request(retrieved_note, self.storage_slot);
         let has_been_read =
@@ -93,8 +403,66 @@ where
         destroy_note_unsafe(self.context, retrieved_note, note_hash);
     }
 
-    /// Note that if you later on remove the note it's much better to use `pop_notes` as `pop_notes` results
-    /// in significantly less constrains due to avoiding 1 read request check.
+    /// Returns a collection of which belong to this PrivateSet.
+    ///
+    /// DANGER: the returned notes do not get nullified within this `get_notes`
+    /// function, and so they cannot necessarily be considered "current" notes.
+    /// I.e. you might be reading notes that have already been nullified. It is
+    /// this which distinguishes `get_notes` from `pop_notes`.
+    ///
+    /// Note that if you later on remove the note it's much better to use
+    /// `pop_notes` as `pop_notes` results in significantly fewer constrains
+    /// due to avoiding 1 read request check.
+    /// If you need for your app to see the notes before it can decide which to
+    /// nullify (which ideally would not be the case, and you'd be able to rely
+    /// on the filter and preprocessor to do this), then you have no resort but
+    /// to call `get_notes` and then `remove`.
+    ///
+    /// Notes will be selected from the PXE's database, via an oracle call, according
+    /// to the filtering `options` provided.
+    ///
+    /// # Arguments
+    ///
+    /// - `options` - See NoteGetterOptions. Enables the caller to specify the
+    ///               properties of the notes that must be returned by the oracle
+    ///               call to the PXE.
+    ///               The NoteGetterOptions are designed to contain functions which
+    ///               _constrain_ that the returned notes do indeed adhere to the
+    ///               specified options. Those functions are executed _within_ this
+    ///               `pop_notes` call.
+    ///
+    /// # Returns
+    ///
+    /// - BoundedVec<Note, MAX_NOTE_HASH_READ_REQUESTS_PER_CALL>
+    ///   - A vector of "current" notes, that have been constrained to satisfy the
+    ///     retrieval criteria specified by the given `options`.
+    ///
+    /// # Generic Parameters
+    ///
+    /// * `PreprocessorArgs` - See `NoteGetterOptions`.
+    /// * `FilterArgs` - See `NoteGetterOptions`.
+    /// * `M` - The length of the note (in Fields), when packed by the Packable trait.
+    ///
+    /// # Advanced:
+    ///
+    /// Reads the notes:
+    ///
+    /// - Gets notes from the PXE, via an oracle call, according to the filtering
+    ///   `options` provided.
+    /// - Constrains that the returned notes do indeed adhere to the `options`.
+    ///   (Note: the `options` contain _constrained_ functions that get invoked
+    ///   _within_ this function).
+    /// - Asserts that the notes do indeed belong to this calling function's
+    ///   `contract_address`, and to this PrivateSet's `storage_slot`.
+    /// - Computes the note_hash for each note, using the `storage_slot` and
+    ///   `contract_address` of this PrivateSet instance.
+    /// - Asserts that the note_hash does indeed exist:
+    ///   - For settled notes: makes a request to the kernel to perform a merkle
+    ///     membership check against the historical Note Hashes Tree that this tx
+    ///     is referencing.
+    ///   - For transient notes: makes a request to the kernel to ensure that the
+    ///     note was indeed emitted by some earlier execution frame of this tx.
+    ///
     pub fn get_notes<PreprocessorArgs, FilterArgs, let M: u32>(
         self,
         options: NoteGetterOptions<Note, M, PreprocessorArgs, FilterArgs>,
@@ -110,7 +478,19 @@ impl<Note> PrivateSet<Note, UtilityContext>
 where
     Note: NoteType + NoteHash + Eq,
 {
-    // docs:start:view_notes
+    /// Returns a collection of notes which belong to this PrivateSet, according
+    /// to the given selection `options`.
+    ///
+    /// Notice that this function is executable only within a UtilityContext, which
+    /// is an unconstrained environment on the user's local device.
+    ///
+    /// # Arguments
+    ///
+    /// - `options` - See NoteGetterOptions. Enables the caller to specify the
+    ///               properties of the notes that must be returned by the oracle
+    ///               call to the PXE.
+    ///
+    /// docs:start:view_notes
     pub unconstrained fn view_notes(
         self,
         options: NoteViewerOptions<Note, <Note as Packable>::N>,

--- a/noir-projects/aztec-nr/aztec/src/state_vars/public_immutable.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/public_immutable.nr
@@ -8,22 +8,46 @@ use protocol_types::{
     traits::Packable,
 };
 
-mod test;
-
-/// Stores an immutable value in public state which can be read from public, private and unconstrained execution
-/// contexts.
+/// # PublicImmutable
 ///
-/// Leverages `WithHash<T>` to enable efficient private reads of public storage. `WithHash` wrapper allows for
-/// efficient reads by verifying large values through a single hash check and then proving inclusion only of the hash
-/// in the public storage. This reduces the number of required tree inclusion proofs from O(M) to O(1).
+/// PublicImmutable is a public state variable type for values that are set once
+/// during initialization and remain permanently unchanged.
 ///
-/// This is valuable when T packs to multiple fields, as it maintains "almost constant" verification overhead
-/// regardless of the original data size.
+/// You can declare a state variable of type PublicImmutable within your contract's
+/// #[storage] struct:
 ///
-/// # Optimizing private reads in your contract
-/// Given that reading T from public immutable in private has "almost constant" constraints cost for different sizes
-/// of T it is recommended to group multiple values into a single struct when they are being read together. This can
-/// typically be some kind of configuration set up during contract initialization. E.g.:
+/// E.g.:
+/// `your_variable: PublicImmutable<T, Context>`
+///
+/// PublicImmutable stores an immutable value in public state which can be _read_
+/// from public, utility and even _private_ execution contexts.
+///
+/// The methods of PublicImmutable are:
+/// - `initialize`
+/// - `read`
+/// (see the methods' own doc comments for more info).
+///
+/// # Generic Parameters:
+///
+/// * `T` - The type of value stored (must implement Packable).
+/// * `Context` - The execution context (PublicContext, PrivateContext, or UtilityContext).
+///
+/// # Advanced
+///
+/// PublicImmutable leverages `WithHash<T>` to enable efficient private reads of
+/// public storage. The `WithHash` wrapper optimizes reads by hashing values that would
+/// be larger than a single field into a single field, then proving inclusion of only
+/// the hash in public storage.
+///
+/// This optimization is particularly valuable when T packs to multiple fields,
+/// as it maintains "almost constant" verification overhead regardless of the
+/// original data size.
+///
+/// ## Optimizing private reads in your contract
+/// Since reading T from public immutable storage in private contexts has "almost
+/// constant" constraint costs regardless of T's size, it's recommended to group
+/// multiple values into a single struct when they are to be read together. This is
+/// typically useful for configuration data set during contract initialization. E.g.:
 ///
 /// ```noir
 /// use dep::aztec::protocol_types::{address::AztecAddress, traits::Packable};
@@ -57,7 +81,23 @@ where
 }
 
 impl<T, Context> PublicImmutable<T, Context> {
-    // docs:start:public_immutable_struct_new
+    /// Initializes a new PublicImmutable state variable.
+    ///
+    /// This function is usually automatically called within the #[storage] macro.
+    /// You typically don't need to call this directly when writing smart contracts.
+    ///
+    /// # Arguments
+    ///
+    /// * `context` - One of `PublicContext`/`PrivateContext`/`UtilityContext`. The
+    ///               Context determines which methods of this struct will be made
+    ///               available to the calling smart contract function.
+    /// * `storage_slot` - A unique identifier for this state variable within the
+    ///                    contract. Usually, the #[storage] macro will determine an
+    ///                    appropriate storage_slot automatically. A smart contract
+    ///                    dev shouldn't have to worry about this, as it's managed
+    ///                    behind the scenes.
+    ///
+    /// docs:start:public_immutable_struct_new
     pub fn new(
         // Note: Passing the contexts to new(...) just to have an interface compatible with a Map.
         context: Context,
@@ -77,11 +117,27 @@ impl<T, Context> PublicImmutable<T, Context> {
 }
 
 impl<T> PublicImmutable<T, &mut PublicContext> {
-    /// Initializes the value.
+    /// Initializes a PublicImmutable state variable instance with a permanent value.
+    ///
+    /// This function sets the immutable value for this state variable. It can only
+    /// be called once per PublicImmutable. Subsequent calls will fail because the
+    /// initialization nullifier will already exist.
+    ///
+    /// # Arguments
+    /// * `value` - The permanent value to store in this PublicImmutable.
     ///
     /// # Panics
     /// Panics if the value is already initialized.
-    // docs:start:public_immutable_struct_write
+    ///
+    /// # Advanced
+    ///
+    /// This function performs the following operations:
+    /// - Creates and emits an initialization nullifier to mark this storage slot
+    ///   as initialized. This prevents double-initialization.
+    /// - Wraps the value in `WithHash<T>` for efficient private reads.
+    /// - Stores the wrapped value in Aztec's public data tree.
+    ///
+    /// docs:start:public_immutable_struct_write
     pub fn initialize(self, value: T)
     where
         T: Packable + Eq,
@@ -95,11 +151,25 @@ impl<T> PublicImmutable<T, &mut PublicContext> {
     }
     // docs:end:public_immutable_struct_write
 
-    /// Reads the value.
+    /// Reads the permanent value stored in this PublicImmutable state variable.
+    ///
+    /// # Returns
+    /// * `T` - The permanent value stored in this PublicImmutable.
     ///
     /// # Panics
     /// Panics if the value is not initialized.
-    // docs:start:public_immutable_struct_read
+    ///
+    /// # Advanced
+    ///
+    /// This function performs the following operations:
+    /// - Checks that the state variable has been initialized by verifying the
+    ///   initialization nullifier exists
+    /// - Reads the `WithHash<T>` wrapper from public storage
+    /// - Extracts and returns the original value T
+    ///
+    /// The function will panic if called on an uninitialized PublicImmutable.
+    ///
+    /// docs:start:public_immutable_struct_read
     pub fn read(self) -> T
     where
         T: Packable + Eq,
@@ -109,7 +179,21 @@ impl<T> PublicImmutable<T, &mut PublicContext> {
     }
     // docs:end:public_immutable_struct_read
 
-    /// Reads the value without checking if the value is initialized.
+    /// Reads the value stored in this PublicImmutable without checking if the value
+    /// is initialized.
+    ///
+    /// This function bypasses the initialization check and directly reads from
+    /// storage.
+    /// If the PublicImmutable has not been initialized, this will return a
+    /// zeroed value.
+    /// However, if the variable is _known_ to be initialized, this is cheaper
+    /// to call than `read`.
+    ///
+    /// # Returns
+    ///
+    /// * `T` - The value stored in this PublicImmutable, or empty/default values if
+    ///         uninitialized.
+    ///
     pub fn read_unsafe(self) -> T
     where
         T: Packable + Eq,
@@ -124,6 +208,15 @@ impl<T> PublicImmutable<T, &mut PublicContext> {
 }
 
 impl<T> PublicImmutable<T, UtilityContext> {
+    /// Reads the permanent value stored in this PublicImmutable state variable.
+    ///
+    /// Notice that this function is executable only within a UtilityContext, which
+    /// is an unconstrained environment on the user's local device.
+    ///
+    /// # Returns
+    ///
+    /// * `T` - The permanent value stored in this PublicImmutable.
+    ///
     pub unconstrained fn read(self) -> T
     where
         T: Packable + Eq,
@@ -134,6 +227,34 @@ impl<T> PublicImmutable<T, UtilityContext> {
 }
 
 impl<T> PublicImmutable<T, &mut PrivateContext> {
+    /// Reads the permanent value stored in this PublicImmutable from the anchor
+    /// block.
+    ///
+    /// Private functions execute asynchronously and offchain. When a user begins
+    /// private execution, their view of the chain 'branches off' from the current
+    /// public state, since public state continues to advance while they execute
+    /// privately. Therefore, private functions read from a historical snapshot of
+    /// public state rather than the current state.
+    ///
+    /// # Returns
+    ///
+    /// * `T` - The permanent value stored in this PublicImmutable at the historical
+    ///         block referenced by the private context.
+    ///
+    /// # Advanced
+    ///
+    /// This function performs a historical read using the block header from the private
+    /// context. The `WithHash` optimization is particularly valuable here because it
+    /// reduces the number of required inclusion proofs by proving membership of
+    /// only the hash instead of the full packed value.
+    ///
+    /// The historical read mechanism:
+    /// - Uses an oracle to obtain the value from the historical block
+    /// - Proves inclusion of the value's hash in the public data tree
+    /// - Proves that the root of this public data tree is correct, relative to the
+    ///   historical block header that is being referenced by this private function.
+    /// - Verifies that the oracle-provided value matches the stored hash
+    ///
     pub fn read(self) -> T
     where
         T: Packable + Eq,

--- a/noir-projects/aztec-nr/aztec/src/state_vars/public_mutable.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/public_mutable.nr
@@ -2,9 +2,42 @@ use crate::context::{PublicContext, UtilityContext};
 use crate::state_vars::storage::HasStorageSlot;
 use dep::protocol_types::traits::Packable;
 
-mod test;
-
-// docs:start:public_mutable_struct
+/// # PublicMutable
+///
+/// PublicMutable is a public state variable type for values that can be read
+/// and written within #[public] functions of your smart contract.
+///
+/// You can declare a state variable of type PublicMutable within your contract's
+/// #[storage] struct:
+///
+/// E.g.:
+/// `your_variable: PublicMutable<T, Context>`
+/// or:
+/// `your_mapping: Map<Field, PublicMutable<T, Context>>`
+///
+/// The methods of PublicMutable are:
+/// - `read`
+/// - `write`
+/// (see the methods' own doc comments for more info).
+///
+/// ## Example.
+///
+/// A voting contract's proposal count can be represented as a PublicMutable<u64>.
+/// The count can be read by anyone to see how many proposals exist, and incremented
+/// when new proposals are submitted.
+///
+/// # Generic Parameters:
+///
+/// * `T` - The type of value stored (must implement Packable).
+/// * `Context` - The execution context (PublicContext or UtilityContext).
+///
+/// # Advanced
+///
+/// Unlike private state variables which use notes, PublicMutable stores values
+/// directly in Aztec's public data tree. This enables direct read and write
+/// access to the current state during public function execution.
+///
+/// docs:start:public_mutable_struct
 pub struct PublicMutable<T, Context> {
     context: Context,
     storage_slot: Field,
@@ -21,7 +54,23 @@ where
 }
 
 impl<T, Context> PublicMutable<T, Context> {
-    // docs:start:public_mutable_struct_new
+    /// Initializes a new PublicMutable state variable.
+    ///
+    /// This function is usually automatically called within the #[storage] macro.
+    /// You typically don't need to call this directly when writing smart contracts.
+    ///
+    /// # Arguments
+    ///
+    /// * `context` - One of `PublicContext`/`UtilityContext`. The Context determines
+    ///               which methods of this struct will be made available to the calling
+    ///               smart contract function.
+    /// * `storage_slot` - A unique identifier for this state variable within the
+    ///                    contract. Usually, the #[storage] macro will determine an
+    ///                    appropriate storage_slot automatically. A smart contract
+    ///                    dev shouldn't have to worry about this, as it's managed
+    ///                    behind the scenes.
+    ///
+    /// docs:start:public_mutable_struct_new
     pub fn new(
         // Note: Passing the contexts to new(...) just to have an interface compatible with a Map.
         context: Context,
@@ -34,7 +83,13 @@ impl<T, Context> PublicMutable<T, Context> {
 }
 
 impl<T> PublicMutable<T, &mut PublicContext> {
-    // docs:start:public_mutable_struct_read
+    /// Reads the current value stored in this PublicMutable state variable.
+    ///
+    /// # Returns
+    ///
+    /// * `T` - The current value stored in this PublicMutable.
+    ///
+    /// docs:start:public_mutable_struct_read
     pub fn read(self) -> T
     where
         T: Packable,
@@ -43,7 +98,19 @@ impl<T> PublicMutable<T, &mut PublicContext> {
     }
     // docs:end:public_mutable_struct_read
 
-    // docs:start:public_mutable_struct_write
+    /// Writes a new value to this PublicMutable state variable.
+    ///
+    /// # Arguments
+    ///
+    /// * `value` - The new value to store in this PublicMutable.
+    ///
+    /// # Advanced
+    ///
+    /// This function updates the value stored in Aztec's public data tree.
+    /// The new value becomes immediately available to subsequent reads within
+    /// the same transaction.
+    ///
+    /// docs:start:public_mutable_struct_write
     pub fn write(self, value: T)
     where
         T: Packable,
@@ -54,6 +121,15 @@ impl<T> PublicMutable<T, &mut PublicContext> {
 }
 
 impl<T> PublicMutable<T, UtilityContext> {
+    /// Reads the current value stored in this PublicMutable state variable.
+    ///
+    /// Notice that this function is executable only within a UtilityContext, which
+    /// is an unconstrained environment on the user's local device.
+    ///
+    /// # Returns
+    ///
+    /// * `T` - The current value stored in this PublicMutable.
+    ///
     pub unconstrained fn read(self) -> T
     where
         T: Packable,

--- a/noir-projects/aztec-nr/compressed-string/src/compressed_string.nr
+++ b/noir-projects/aztec-nr/compressed-string/src/compressed_string.nr
@@ -1,15 +1,22 @@
 use dep::aztec::protocol_types::{traits::{Deserialize, Serialize}, utils::field::field_from_bytes};
 
-// The general Compressed String.
-// Compresses M bytes into N fields.
-// Can be used for longer strings that don't fit in a single field.
-// Each field can store 31 characters, so N should be M/31 rounded up.
+// TODO(https://github.com/AztecProtocol/aztec-packages/issues/15968): Kill, refactor and/or relocate this.
+
+/// Convenience struct for capturing a string of type `str<M>`, and converting it
+/// into other basic Noir types. Notably: converts to `[Field; N]` or `[u8; M]`.
+/// This particular conversion process tightly-packs the M bytes of the input `str`
+/// into 31-byte chunks, with each chunk being put into a field.
+/// Each field can store 31 characters, so N should be M/31 rounded up.
+/// Can be used for longer strings that don't fit into a single field.
 #[derive(Deserialize, Eq)]
 pub struct CompressedString<let N: u32, let M: u32> {
     value: [Field; N],
 }
 
 impl<let N: u32, let M: u32> CompressedString<N, M> {
+    // TODO: if we move this into the utils of aztecnr (as suggested by #15968),
+    // we can adopt its existing `fields_from_bytes` conversion function,
+    // instead of this duplicated logic here.
     pub fn from_string(input_string: str<M>) -> Self {
         let mut fields = [0; N];
         let byts = input_string.as_bytes();
@@ -31,6 +38,9 @@ impl<let N: u32, let M: u32> CompressedString<N, M> {
         Self { value: fields }
     }
 
+    // TODO: if we move this into the utils of aztecnr (as suggested by #15968),
+    // we can adopt its existing `bytes_from_fields` conversion function,
+    // instead of this duplicated logic here.
     pub fn to_bytes(self) -> [u8; M] {
         let mut result = [0; M];
         let mut w_index = 0 as u32;

--- a/noir-projects/aztec-nr/easy-private-state/src/easy_private_uint.nr
+++ b/noir-projects/aztec-nr/easy-private-state/src/easy_private_uint.nr
@@ -7,6 +7,16 @@ use dep::aztec::{
 };
 use dep::value_note::{balance_utils, filter::filter_notes_min_sum, value_note::ValueNote};
 
+/// @deprecated (soon) (https://github.com/AztecProtocol/aztec-packages/issues/15959) because:
+/// - Its functionality is a subset of `BalanceSet`
+/// - The "Easy" naming has been criticized.
+/// - It is not a wrapper around a Uint; bur rather around a Field.
+/// - It's weird to have a state variable be defined at the top-level of aztecnr,
+///   whilst all other state variables are defined _within_ aztecnr.
+///
+/// An example private state variable, representing a `Field` that can be:
+/// - Incremented by anyone
+/// - Decremented by the owner of the private state.
 pub struct EasyPrivateUint<Context> {
     context: Context,
     set: PrivateSet<ValueNote, Context>,
@@ -19,7 +29,6 @@ impl<Context> HasStorageSlot<1> for EasyPrivateUint<Context> {
     }
 }
 
-// Holds a note that can act similarly to an int.
 impl<Context> EasyPrivateUint<Context> {
     pub fn new(context: Context, storage_slot: Field) -> Self {
         EasyPrivateUint { context, set: PrivateSet::new(context, storage_slot) }


### PR DESCRIPTION
Adds considerable[1] doc comments to:
- State variables[2]
- PrivateContext
- PublicContext

**No code has been changed**

[1] The current docs are lacking a huge amount of important information. Eventually, we will write much better docs. Until then, I've put _a huge amount of detail_ in doc comments, to unblock smart contract devs immediately. Once the docs catch up in many months, we might consider removing some of the detail from these doc comments. (Although personally, I think big comments are fine).

[2] Except for SharedMutable, because I don't want to conflict with the big changes to naming of SharedMutable to DelayedPrivateMutable. 

Please be gentle with the review. People phrase explanations differently. These are how I would explain things. I won't reduce the size of comments for the sake of reducing the size of comments. :man-shrugging: 

**I haven't kept up with how we do releases. I've set the base branch to be `master`, as recommended by Sr Nico. Please correct me if that's wrong.**