### PR TITLE
feat: restore txe public sim errors

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/state_vars/public_immutable/test.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/public_immutable/test.nr
@@ -60,7 +60,7 @@ unconstrained fn initialize_uninitialized_other_tx() {
     });
 }
 
-#[test(should_fail)]
+#[test(should_fail_with = "Duplicate")]
 unconstrained fn initialize_already_initialized_same_tx() {
     let env = TestEnvironment::_new();
 
@@ -75,7 +75,7 @@ unconstrained fn initialize_already_initialized_same_tx() {
     });
 }
 
-#[test(should_fail)]
+#[test(should_fail_with = "already present")]
 unconstrained fn initialize_already_initialized_other_tx() {
     let env = TestEnvironment::_new();
 

--- a/noir-projects/noir-contracts/contracts/app/auth_contract/src/test.nr
+++ b/noir-projects/noir-contracts/contracts/app/auth_contract/src/test.nr
@@ -28,12 +28,20 @@ unconstrained fn authorized_initially_unset() {
     assert_eq(env.view_public(auth.get_authorized()), std::mem::zeroed());
 }
 
-#[test(should_fail)]
+#[test(should_fail_with = "caller is not admin")]
 unconstrained fn non_admin_cannot_set_unauthorized() {
     let (env, auth_contract_address, _, _, other) = setup();
     let auth = Auth::at(auth_contract_address);
 
     let _ = env.call_public(other, auth.set_authorized(other));
+}
+
+#[test(should_fail_with = "caller is not authorized")]
+unconstrained fn non_authorized_cannot_do_authorized_thing() {
+    let (env, auth_contract_address, _, _, other) = setup();
+    let auth = Auth::at(auth_contract_address);
+
+    let _ = env.call_private(other, auth.do_private_authorized_thing());
 }
 
 #[test]

--- a/noir-projects/noir-contracts/contracts/app/easy_private_voting_contract/src/test/first.nr
+++ b/noir-projects/noir-contracts/contracts/app/easy_private_voting_contract/src/test/first.nr
@@ -35,7 +35,7 @@ unconstrained fn test_end_vote() {
     });
 }
 
-#[test(should_fail)]
+#[test(should_fail_with = "Only admin can end votes")]
 unconstrained fn test_fail_end_vote_by_non_admin() {
     let (env, voting_contract_address, _) = utils::setup();
     let alice = env.create_account(2);
@@ -88,7 +88,7 @@ unconstrained fn test_cast_vote_with_separate_accounts() {
     });
 }
 
-#[test(should_fail)]
+#[test(should_fail_with = "already exists")]
 unconstrained fn test_fail_vote_twice() {
     let (env, voting_contract_address, _) = utils::setup();
     let alice = env.create_account(2);

--- a/noir-projects/noir-contracts/contracts/app/nft_contract/src/test/access_control.nr
+++ b/noir-projects/noir-contracts/contracts/app/nft_contract/src/test/access_control.nr
@@ -26,7 +26,7 @@ unconstrained fn access_control() {
     assert(!env.view_public(nft.is_minter(new_admin)));
 }
 
-#[test(should_fail)]
+#[test(should_fail_with = "caller is not an admin")]
 unconstrained fn set_admin_requires_admin_caller() {
     // Setup without account contracts. We are not using authwits here, so dummy accounts are enough
     let (env, nft_contract_address, _, other) = utils::setup(/* with_account_contracts */ false);
@@ -36,7 +36,7 @@ unconstrained fn set_admin_requires_admin_caller() {
     let _ = env.call_public(other, nft.set_admin(other));
 }
 
-#[test(should_fail)]
+#[test(should_fail_with = "caller is not an admin")]
 unconstrained fn set_minter_requires_admin_caller() {
     // Setup without account contracts. We are not using authwits here, so dummy accounts are enough
     let (env, nft_contract_address, _, other) = utils::setup(/* with_account_contracts */ false);

--- a/noir-projects/noir-contracts/contracts/app/nft_contract/src/test/minting.nr
+++ b/noir-projects/noir-contracts/contracts/app/nft_contract/src/test/minting.nr
@@ -22,7 +22,7 @@ unconstrained fn mint_as_non_minter_fails() {
     let _ = env.call_public(other, NFT::at(nft_contract_address).mint(owner, token_id));
 }
 
-#[test(should_fail_with = "NFT not minted")]
+#[test(should_fail_with = "token already exists")]
 unconstrained fn mint_twice_fails() {
     // Setup without account contracts. We are not using authwits here, so dummy accounts are enough
     let (env, nft_contract_address, owner, _) = utils::setup(/* with_account_contracts */ false);

--- a/noir-projects/noir-contracts/contracts/app/nft_contract/src/test/minting.nr
+++ b/noir-projects/noir-contracts/contracts/app/nft_contract/src/test/minting.nr
@@ -13,7 +13,7 @@ unconstrained fn mint_success() {
     utils::assert_owns_public_nft(env, nft_contract_address, owner, token_id);
 }
 
-#[test(should_fail)] // should_fail_with="NFT minted by non-minter"
+#[test(should_fail_with = "NFT minted by non-minter")]
 unconstrained fn mint_as_non_minter_fails() {
     // Setup without account contracts. We are not using authwits here, so dummy accounts are enough
     let (env, nft_contract_address, owner, other) = utils::setup(/* with_account_contracts */ false);
@@ -22,7 +22,7 @@ unconstrained fn mint_as_non_minter_fails() {
     let _ = env.call_public(other, NFT::at(nft_contract_address).mint(owner, token_id));
 }
 
-#[test(should_fail)] // should_fail_with="NFT not minted"
+#[test(should_fail_with = "NFT not minted")]
 unconstrained fn mint_twice_fails() {
     // Setup without account contracts. We are not using authwits here, so dummy accounts are enough
     let (env, nft_contract_address, owner, _) = utils::setup(/* with_account_contracts */ false);
@@ -39,7 +39,7 @@ unconstrained fn mint_twice_fails() {
     let _ = env.call_public(owner, NFT::at(nft_contract_address).mint(owner, token_id));
 }
 
-#[test(should_fail)]
+#[test(should_fail_with = "zero token ID not supported")]
 unconstrained fn mint_id_0_fails() {
     // Setup without account contracts. We are not using authwits here, so dummy accounts are enough
     let (env, nft_contract_address, owner, _) = utils::setup(/* with_account_contracts */ false);

--- a/noir-projects/noir-contracts/contracts/app/nft_contract/src/test/minting.nr
+++ b/noir-projects/noir-contracts/contracts/app/nft_contract/src/test/minting.nr
@@ -13,7 +13,7 @@ unconstrained fn mint_success() {
     utils::assert_owns_public_nft(env, nft_contract_address, owner, token_id);
 }
 
-#[test(should_fail_with = "NFT minted by non-minter")]
+#[test(should_fail_with = "caller is not a minter")]
 unconstrained fn mint_as_non_minter_fails() {
     // Setup without account contracts. We are not using authwits here, so dummy accounts are enough
     let (env, nft_contract_address, owner, other) = utils::setup(/* with_account_contracts */ false);

--- a/noir-projects/noir-contracts/contracts/app/nft_contract/src/test/transfer_in_public.nr
+++ b/noir-projects/noir-contracts/contracts/app/nft_contract/src/test/transfer_in_public.nr
@@ -55,7 +55,7 @@ unconstrained fn transfer_in_public_on_behalf_of_other() {
     utils::assert_owns_public_nft(env, nft_contract_address, recipient, token_id);
 }
 
-#[test(should_fail)] // should_fail_with = "Assertion failed: Invalid authwit nonce. When 'from' and 'msg_sender' are the same, 'authwit_nonce' must be zero"
+#[test(should_fail_with = "Assertion failed: Invalid authwit nonce. When 'from' and 'msg_sender' are the same, 'authwit_nonce' must be zero")]
 unconstrained fn transfer_in_public_failure_on_behalf_of_self_non_zero_nonce() {
     // Setup without account contracts. We are not using authwits here, so dummy accounts are enough.
     // The authwit check is in the beginning so we don't need to waste time on minting the NFT and transferring
@@ -70,7 +70,7 @@ unconstrained fn transfer_in_public_failure_on_behalf_of_self_non_zero_nonce() {
     );
 }
 
-#[test(should_fail)] // should_fail_with = "invalid owner"
+#[test(should_fail_with = "invalid owner")]
 unconstrained fn transfer_in_public_non_existent_nft() {
     // Setup without account contracts. We are not using authwits here, so dummy accounts are enough
     let (env, nft_contract_address, sender, recipient) =
@@ -83,7 +83,7 @@ unconstrained fn transfer_in_public_non_existent_nft() {
     );
 }
 
-#[test(should_fail)] // should_fail_with = "unauthorized"
+#[test(should_fail_with = "unauthorized")]
 unconstrained fn transfer_in_public_failure_on_behalf_of_other_without_approval() {
     // Setup with account contracts. Slower since we actually deploy them, but needed for authwits.
     let (env, nft_contract_address, sender, recipient, token_id) =
@@ -95,7 +95,7 @@ unconstrained fn transfer_in_public_failure_on_behalf_of_other_without_approval(
     );
 }
 
-#[test(should_fail)] // should_fail_with = "unauthorized"
+#[test(should_fail_with = "unauthorized")]
 unconstrained fn transfer_in_public_failure_on_behalf_of_other_wrong_caller() {
     // Setup with account contracts. Slower since we actually deploy them, but needed for authwits.
     let (env, nft_contract_address, sender, recipient, token_id) =

--- a/noir-projects/noir-contracts/contracts/app/nft_contract/src/test/transfer_to_private.nr
+++ b/noir-projects/noir-contracts/contracts/app/nft_contract/src/test/transfer_to_private.nr
@@ -49,7 +49,7 @@ unconstrained fn transfer_to_private_external_orchestration() {
     utils::assert_owns_public_nft(env, nft_contract_address, AztecAddress::zero(), token_id);
 }
 
-#[test(should_fail)] // should_fail_with = "Invalid partial note or completer"
+#[test(should_fail_with = "Invalid partial note or completer")]
 unconstrained fn transfer_to_private_transfer_not_prepared() {
     // Setup without account contracts. We are not using authwits here, so dummy accounts are enough
     let (env, nft_contract_address, owner, _, token_id) =
@@ -66,7 +66,7 @@ unconstrained fn transfer_to_private_transfer_not_prepared() {
     );
 }
 
-#[test(should_fail)] // should_fail_with = "invalid NFT owner"
+#[test(should_fail_with = "invalid NFT owner")]
 unconstrained fn transfer_to_private_failure_not_an_owner() {
     // Setup without account contracts. We are not using authwits here, so dummy accounts are enough
     let (env, nft_contract_address, owner, not_owner, token_id) =
@@ -89,7 +89,7 @@ unconstrained fn transfer_to_private_failure_not_an_owner() {
     );
 }
 
-#[test(should_fail)] // should_fail_with = "Invalid partial note or completer"
+#[test(should_fail_with = "Invalid partial note or completer")]
 unconstrained fn incorrect_completer_cannot_complete_partial_note() {
     // Setup without account contracts. We are not using authwits here, so dummy accounts are enough.
     let (env, nft_contract_address, owner, recipient, token_id) =

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/test/access_control.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/test/access_control.nr
@@ -26,7 +26,7 @@ unconstrained fn access_control() {
     assert(!env.view_public(token.is_minter(new_admin)));
 }
 
-#[test(should_fail)]
+#[test(should_fail_with = "caller is not admin")]
 unconstrained fn set_admin_requires_admin_caller() {
     // Setup without account contracts. We are not using authwits here, so dummy accounts are enough
     let (env, token_contract_address, _, other) = utils::setup(/* with_account_contracts */ false);
@@ -36,7 +36,7 @@ unconstrained fn set_admin_requires_admin_caller() {
     let _ = env.call_public(other, token.set_admin(other));
 }
 
-#[test(should_fail)]
+#[test(should_fail_with = "caller is not admin")]
 unconstrained fn set_minter_requires_admin_caller() {
     // Setup without account contracts. We are not using authwits here, so dummy accounts are enough
     let (env, token_contract_address, _, other) = utils::setup(/* with_account_contracts */ false);

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/test/burn_public.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/test/burn_public.nr
@@ -43,7 +43,7 @@ unconstrained fn burn_public_on_behalf_of_other() {
     );
 }
 
-#[test(should_fail)] // should_fail_with = "Assertion failed: attempt to subtract with overflow"
+#[test(should_fail_with = "Assertion failed: attempt to subtract with overflow")]
 unconstrained fn burn_public_failure_more_than_balance() {
     let (env, token_contract_address, owner, _, mint_amount) =
         utils::setup_and_mint_to_public(/* with_account_contracts */ false);
@@ -57,7 +57,7 @@ unconstrained fn burn_public_failure_more_than_balance() {
     );
 }
 
-#[test(should_fail)] // should_fail_with = "Assertion failed: Invalid authwit nonce. When 'from' and 'msg_sender' are the same, 'authwit_nonce' must be zero"
+#[test(should_fail_with = "Assertion failed: Invalid authwit nonce. When 'from' and 'msg_sender' are the same, 'authwit_nonce' must be zero")]
 unconstrained fn burn_public_failure_on_behalf_of_self_non_zero_nonce() {
     let (env, token_contract_address, owner, _, mint_amount) =
         utils::setup_and_mint_to_public(/* with_account_contracts */ false);
@@ -71,7 +71,7 @@ unconstrained fn burn_public_failure_on_behalf_of_self_non_zero_nonce() {
     );
 }
 
-#[test(should_fail)] // should_fail_with = "unauthorized"
+#[test(should_fail_with = "unauthorized")]
 unconstrained fn burn_public_failure_on_behalf_of_other_without_approval() {
     let (env, token_contract_address, owner, recipient, mint_amount) =
         utils::setup_and_mint_to_public(/* with_account_contracts */ true);
@@ -84,7 +84,7 @@ unconstrained fn burn_public_failure_on_behalf_of_other_without_approval() {
     let _ = env.call_public(recipient, burn_call_interface);
 }
 
-#[test(should_fail)] // should_fail_with = "unauthorized"
+#[test(should_fail_with = "unauthorized")]
 unconstrained fn burn_public_failure_on_behalf_of_other_wrong_caller() {
     let (env, token_contract_address, owner, recipient, mint_amount) =
         utils::setup_and_mint_to_public(/* with_account_contracts */ true);

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/test/mint_to_public.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/test/mint_to_public.nr
@@ -17,7 +17,7 @@ unconstrained fn mint_to_public_success() {
     assert(total_supply == mint_amount);
 }
 
-#[test(should_fail)]
+#[test(should_fail_with = "caller is not minter")]
 unconstrained fn mint_as_non_minter() {
     // Setup without account contracts. We are not using authwits here, so dummy accounts are enough
     let (env, token_contract_address, _, recipient) =

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/test/transfer_in_public.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/test/transfer_in_public.nr
@@ -67,7 +67,7 @@ unconstrained fn public_transfer_on_behalf_of_other() {
     utils::check_public_balance(env, token_contract_address, recipient, transfer_amount);
 }
 
-#[test(should_fail)] // should_fail_with = "Assertion failed: attempt to subtract with overflow"
+#[test(should_fail_with = "Assertion failed: attempt to subtract with overflow")]
 unconstrained fn public_transfer_failure_more_than_balance() {
     // Setup without account contracts. We are not using authwits here, so dummy accounts are enough
     let (env, token_contract_address, owner, recipient, mint_amount) =
@@ -80,7 +80,7 @@ unconstrained fn public_transfer_failure_more_than_balance() {
     let _ = env.call_public(owner, public_transfer_call_interface);
 }
 
-#[test(should_fail)] // should_fail_with = "Assertion failed: Invalid authwit nonce. When 'from' and 'msg_sender' are the same, 'authwit_nonce' must be zero"
+#[test(should_fail_with = "Assertion failed: Invalid authwit nonce. When 'from' and 'msg_sender' are the same, 'authwit_nonce' must be zero")]
 unconstrained fn public_transfer_failure_on_behalf_of_self_non_zero_nonce() {
     // Setup without account contracts. We are not using authwits here, so dummy accounts are enough
     let (env, token_contract_address, owner, recipient, mint_amount) =
@@ -94,7 +94,7 @@ unconstrained fn public_transfer_failure_on_behalf_of_self_non_zero_nonce() {
     let _ = env.call_public(owner, public_transfer_call_interface);
 }
 
-#[test(should_fail)] // should_fail_with = "unauthorized"
+#[test(should_fail_with = "unauthorized")]
 unconstrained fn public_transfer_failure_on_behalf_of_other_without_approval() {
     // Setup with account contracts. Slower since we actually deploy them, but needed for authwits.
     let (env, token_contract_address, owner, recipient, mint_amount) =
@@ -107,7 +107,7 @@ unconstrained fn public_transfer_failure_on_behalf_of_other_without_approval() {
     let _ = env.call_public(recipient, public_transfer_in_private_call_interface);
 }
 
-#[test(should_fail)] // should_fail_with = "Assertion failed: attempt to subtract with overflow"
+#[test(should_fail_with = "Assertion failed: attempt to subtract with overflow")]
 unconstrained fn public_transfer_failure_on_behalf_of_other_more_than_balance() {
     // Setup with account contracts. Slower since we actually deploy them, but needed for authwits.
     let (env, token_contract_address, owner, recipient, mint_amount) =
@@ -128,7 +128,7 @@ unconstrained fn public_transfer_failure_on_behalf_of_other_more_than_balance() 
     let _ = env.call_public(recipient, public_transfer_in_private_call_interface);
 }
 
-#[test(should_fail)] // should_fail_with = "unauthorized"
+#[test(should_fail_with = "unauthorized")]
 unconstrained fn public_transfer_failure_on_behalf_of_other_wrong_caller() {
     // Setup with account contracts. Slower since we actually deploy them, but needed for authwits.
     let (env, token_contract_address, owner, recipient, mint_amount) =

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/test/transfer_to_private.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/test/transfer_to_private.nr
@@ -75,7 +75,7 @@ unconstrained fn transfer_to_private_from_private_external_orchestration() {
     utils::check_private_balance(env, token_contract_address, owner, 0);
 }
 
-#[test(should_fail)] // should_fail_with = "Invalid partial note or completer"
+#[test(should_fail_with = "Invalid partial note or completer")]
 unconstrained fn transfer_to_private_transfer_not_prepared() {
     // Setup without account contracts. We are not using authwits here, so dummy accounts are enough
     let (env, token_contract_address, owner, _, amount) =
@@ -94,7 +94,7 @@ unconstrained fn transfer_to_private_transfer_not_prepared() {
     );
 }
 
-#[test(should_fail)] // should_fail_with = "Assertion failed: attempt to subtract with overflow"
+#[test(should_fail_with = "Assertion failed: attempt to subtract with overflow")]
 unconstrained fn transfer_to_private_failure_not_an_owner() {
     // Setup without account contracts. We are not using authwits here, so dummy accounts are enough
     let (env, token_contract_address, owner, not_owner, amount) =
@@ -117,7 +117,7 @@ unconstrained fn transfer_to_private_failure_not_an_owner() {
     );
 }
 
-#[test(should_fail)] // should_fail_with = "Invalid partial note or completer"
+#[test(should_fail_with = "Invalid partial note or completer")]
 unconstrained fn incorrect_completer_cannot_complete_partial_note() {
     // Setup without account contracts. We are not using authwits here, so dummy accounts are enough.
     let (env, token_contract_address, owner, recipient, amount) =

--- a/noir-projects/noir-contracts/contracts/protocol/router_contract/src/test.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/router_contract/src/test.nr
@@ -23,7 +23,7 @@ unconstrained fn check_block_number() {
     );
 }
 
-#[test(should_fail)] // should_fail_with = "Block number mismatch."
+#[test(should_fail_with = "Block number mismatch.")]
 unconstrained fn check_block_number_fail() {
     let env = TestEnvironment::new();
 
@@ -54,7 +54,7 @@ unconstrained fn check_timestamp() {
     );
 }
 
-#[test(should_fail)] // should_fail_with = "Timestamp mismatch."
+#[test(should_fail_with = "Timestamp mismatch.")]
 unconstrained fn check_timestamp_fail() {
     let env = TestEnvironment::new();
 

--- a/noir-projects/noir-contracts/contracts/test/public_immutable_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/public_immutable_contract/src/main.nr
@@ -60,7 +60,7 @@ mod tests {
         assert(result.return_value == x);
     }
 
-    #[test(should_fail)] // should_fail_with = "Trying to read from uninitialized PublicImmutable"
+    #[test(should_fail_with = "Trying to read from uninitialized PublicImmutable")]
     unconstrained fn reading_uninitialized_immutable_fails() {
         let (env, contract_address) = setup();
 


### PR DESCRIPTION
These had been removed due to me not investigating why there were gone. After looking into things I learned that the public processor only deals with contract code and not the full artifact, and as such is unable to interpret a reverted call. We therefore do this in the TXE oracle using the `enrich` functions, which do access the full artifact and convert the revert reason selector into a proper message. I also added error strings for contract tests that lacked them