### PR TITLE
feat!: remove return data struct from testenv

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/test/helpers/authwit.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/authwit.nr
@@ -48,7 +48,7 @@ where
         compute_inner_authwit_hash([caller.to_field(), selector.to_field(), args_hash]);
     let message_hash = compute_authwit_message_hash(target, chain_id, version, inner_hash);
 
-    let _ = env.call_public(
+    env.call_public(
         on_behalf_of,
         PublicCallInterface::<_, ()>::new(
             CANONICAL_AUTH_REGISTRY_ADDRESS,

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
@@ -45,11 +45,6 @@ pub struct TestEnvironment {
     contract_deployment_secret: Counter,
 }
 
-pub struct CallResult<T> {
-    pub return_value: T,
-    pub tx_hash: Field,
-}
-
 pub struct PrivateContextOptions {
     contract_address: Option<AztecAddress>,
     historical_block_number: Option<u32>,
@@ -395,14 +390,14 @@ impl TestEnvironment {
         _self: Self,
         from: AztecAddress,
         call_interface: PrivateCallInterface<M, T>,
-    ) -> CallResult<T>
+    ) -> T
     where
         T: Deserialize,
     {
         let args = call_interface.get_args();
         let args_hash = hash_args(args);
 
-        let (_end_side_effect_counter, returns_hash, tx_hash) = txe_oracles::private_call_new_flow(
+        let (_, returns_hash, _) = txe_oracles::private_call_new_flow(
             from,
             call_interface.get_contract_address(),
             call_interface.get_selector(),
@@ -411,8 +406,7 @@ impl TestEnvironment {
             call_interface.get_is_static(),
         );
 
-        let returns: T = ReturnsHash::new(returns_hash).get_preimage();
-        CallResult { return_value: returns, tx_hash }
+        ReturnsHash::new(returns_hash).get_preimage()
     }
 
     pub unconstrained fn view_private<T, let M: u32>(
@@ -425,7 +419,7 @@ impl TestEnvironment {
         let args = call_interface.get_args();
         let args_hash = hash_args(args);
 
-        let (_end_side_effect_counter, returns_hash, _) = txe_oracles::private_call_new_flow(
+        let (_, returns_hash, _) = txe_oracles::private_call_new_flow(
             std::mem::zeroed(), // The 'from' address is currently not manually set
             call_interface.get_contract_address(),
             call_interface.get_selector(),
@@ -434,8 +428,7 @@ impl TestEnvironment {
             call_interface.get_is_static(),
         );
 
-        let returns: T = ReturnsHash::new(returns_hash).get_preimage();
-        returns
+        ReturnsHash::new(returns_hash).get_preimage()
     }
 
     pub unconstrained fn simulate_utility<T, let M: u32>(
@@ -455,19 +448,18 @@ impl TestEnvironment {
             args_hash,
         );
 
-        let returns: T = ReturnsHash::new(returns_hash).get_preimage();
-        returns
+        ReturnsHash::new(returns_hash).get_preimage()
     }
 
     pub unconstrained fn call_public<T, let M: u32>(
         _self: Self,
         from: AztecAddress,
         call_interface: PublicCallInterface<M, T>,
-    ) -> CallResult<T>
+    ) -> T
     where
         T: Deserialize,
     {
-        let (returns_hash, tx_hash) = public_call_new_flow(
+        let (returns_hash, _) = public_call_new_flow(
             from,
             call_interface.get_contract_address(),
             call_interface.get_selector(),
@@ -476,8 +468,7 @@ impl TestEnvironment {
         );
 
         // This shouldn't be using ReturnsHash, but I don't think CalldataHash is right either in this context
-        let returns: T = ReturnsHash::new(returns_hash).get_preimage();
-        CallResult { return_value: returns, tx_hash }
+        ReturnsHash::new(returns_hash).get_preimage()
     }
 
     pub unconstrained fn view_public<T, let M: u32>(

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment/test/accounts.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment/test/accounts.nr
@@ -60,18 +60,16 @@ unconstrained fn light_accounts_fail_on_private_authwit_checks() {
     let inner_hash = 13;
     let caller = AztecAddress::zero();
 
-    let _: Field = env
-        .call_private(
-            caller,
-            PrivateCallInterface::new(
-                light_account,
-                comptime { FunctionSelector::from_signature("verify_private_authwit(Field)") },
-                "verify_private_authwit",
-                [inner_hash],
-                true,
-            ),
-        )
-        .return_value;
+    env.call_private(
+        caller,
+        PrivateCallInterface::new(
+            light_account,
+            comptime { FunctionSelector::from_signature("verify_private_authwit(Field)") },
+            "verify_private_authwit",
+            [inner_hash],
+            true,
+        ),
+    );
 }
 
 #[test(should_fail_with = "Unknown auth witness")]
@@ -82,18 +80,16 @@ unconstrained fn contract_accounts_reject_invalid_private_authwits() {
     let inner_hash = 13;
     let caller = AztecAddress::zero();
 
-    let _: Field = env
-        .call_private(
-            caller,
-            PrivateCallInterface::new(
-                contract_account,
-                comptime { FunctionSelector::from_signature("verify_private_authwit(Field)") },
-                "verify_private_authwit",
-                [inner_hash],
-                true,
-            ),
-        )
-        .return_value;
+    env.call_private(
+        caller,
+        PrivateCallInterface::new(
+            contract_account,
+            comptime { FunctionSelector::from_signature("verify_private_authwit(Field)") },
+            "verify_private_authwit",
+            [inner_hash],
+            true,
+        ),
+    );
 }
 
 #[test]
@@ -114,17 +110,15 @@ unconstrained fn contract_accounts_accept_valid_private_authwits() {
         txe_oracles::add_authwit(contract_account, message_hash);
     });
 
-    let result = env
-        .call_private(
-            caller,
-            PrivateCallInterface::new(
-                contract_account,
-                comptime { FunctionSelector::from_signature("verify_private_authwit(Field)") },
-                "verify_private_authwit",
-                [inner_hash],
-                true,
-            ),
-        )
-        .return_value;
+    let result = env.call_private(
+        caller,
+        PrivateCallInterface::new(
+            contract_account,
+            comptime { FunctionSelector::from_signature("verify_private_authwit(Field)") },
+            "verify_private_authwit",
+            [inner_hash],
+            true,
+        ),
+    );
     assert_eq(result, IS_VALID_SELECTOR);
 }

--- a/noir-projects/noir-contracts/contracts/app/auth_contract/src/test.nr
+++ b/noir-projects/noir-contracts/contracts/app/auth_contract/src/test.nr
@@ -32,7 +32,7 @@ unconstrained fn non_admin_cannot_set_unauthorized() {
     let (env, auth_contract_address, _, _, other) = setup();
     let auth = Auth::at(auth_contract_address);
 
-    let _ = env.call_public(other, auth.set_authorized(other));
+    env.call_public(other, auth.set_authorized(other));
 }
 
 #[test]
@@ -40,7 +40,7 @@ unconstrained fn admin_can_schedule_set_authorized() {
     let (env, auth_contract_address, admin, to_authorize, _) = setup();
     let auth = Auth::at(auth_contract_address);
 
-    let _ = env.call_public(admin, auth.set_authorized(to_authorize));
+    env.call_public(admin, auth.set_authorized(to_authorize));
 
     let (scheduled_authorized, timestamp_of_change) =
         env.view_public(auth.get_scheduled_authorized());
@@ -53,7 +53,7 @@ unconstrained fn scheduled_authorized_is_not_immediately_effective() {
     let (env, auth_contract_address, admin, to_authorize, _) = setup();
     let auth = Auth::at(auth_contract_address);
 
-    let _ = env.call_public(admin, auth.set_authorized(to_authorize));
+    env.call_public(admin, auth.set_authorized(to_authorize));
     let (_, timestamp_of_change) = env.view_public(auth.get_scheduled_authorized());
 
     env.set_next_block_timestamp(timestamp_of_change - 1);
@@ -65,7 +65,7 @@ unconstrained fn scheduled_authorized_becomes_effective_after_delay() {
     let (env, auth_contract_address, admin, to_authorize, _) = setup();
     let auth = Auth::at(auth_contract_address);
 
-    let _ = env.call_public(admin, auth.set_authorized(to_authorize));
+    env.call_public(admin, auth.set_authorized(to_authorize));
     let (_, timestamp_of_change) = env.view_public(auth.get_scheduled_authorized());
 
     env.mine_block_at(timestamp_of_change);
@@ -73,5 +73,5 @@ unconstrained fn scheduled_authorized_becomes_effective_after_delay() {
     assert_eq(env.view_public(auth.get_authorized()), to_authorize);
     assert_eq(env.view_private(auth.get_authorized_in_private()), to_authorize);
 
-    let _ = env.call_private(to_authorize, auth.do_private_authorized_thing());
+    env.call_private(to_authorize, auth.do_private_authorized_thing());
 }

--- a/noir-projects/noir-contracts/contracts/app/easy_private_voting_contract/src/test/first.nr
+++ b/noir-projects/noir-contracts/contracts/app/easy_private_voting_contract/src/test/first.nr
@@ -27,7 +27,7 @@ unconstrained fn test_check_vote_status() {
 unconstrained fn test_end_vote() {
     let (env, voting_contract_address, admin) = utils::setup();
 
-    let _ = env.call_public(admin, EasyPrivateVoting::at(voting_contract_address).end_vote());
+    env.call_public(admin, EasyPrivateVoting::at(voting_contract_address).end_vote());
 
     env.public_context_at(voting_contract_address, |context| {
         let vote_ended = context.storage_read(EasyPrivateVoting::storage_layout().vote_ended.slot);
@@ -40,7 +40,7 @@ unconstrained fn test_fail_end_vote_by_non_admin() {
     let (mut env, voting_contract_address, _) = utils::setup();
     let alice = env.create_light_account();
 
-    let _ = env.call_public(alice, EasyPrivateVoting::at(voting_contract_address).end_vote());
+    env.call_public(alice, EasyPrivateVoting::at(voting_contract_address).end_vote());
 }
 
 #[test]
@@ -49,10 +49,7 @@ unconstrained fn test_cast_vote() {
     let alice = env.create_light_account();
 
     let candidate = 1;
-    let _ = env.call_private(
-        alice,
-        EasyPrivateVoting::at(voting_contract_address).cast_vote(candidate),
-    );
+    env.call_private(alice, EasyPrivateVoting::at(voting_contract_address).cast_vote(candidate));
 
     env.public_context_at(voting_contract_address, |context| {
         let vote_count = context.storage_read(derive_storage_slot_in_map(
@@ -71,10 +68,7 @@ unconstrained fn test_cast_vote_with_separate_accounts() {
 
     let candidate = 101;
 
-    let _ = env.call_private(
-        alice,
-        EasyPrivateVoting::at(voting_contract_address).cast_vote(candidate),
-    );
+    env.call_private(alice, EasyPrivateVoting::at(voting_contract_address).cast_vote(candidate));
 
     let _ =
         env.call_private(bob, EasyPrivateVoting::at(voting_contract_address).cast_vote(candidate));
@@ -95,13 +89,7 @@ unconstrained fn test_fail_vote_twice() {
 
     let candidate = 101;
 
-    let _ = env.call_private(
-        alice,
-        EasyPrivateVoting::at(voting_contract_address).cast_vote(candidate),
-    );
+    env.call_private(alice, EasyPrivateVoting::at(voting_contract_address).cast_vote(candidate));
 
-    let _ = env.call_private(
-        alice,
-        EasyPrivateVoting::at(voting_contract_address).cast_vote(candidate),
-    );
+    env.call_private(alice, EasyPrivateVoting::at(voting_contract_address).cast_vote(candidate));
 }

--- a/noir-projects/noir-contracts/contracts/app/nft_contract/src/test/access_control.nr
+++ b/noir-projects/noir-contracts/contracts/app/nft_contract/src/test/access_control.nr
@@ -11,18 +11,18 @@ unconstrained fn access_control() {
     let nft = NFT::at(nft_contract_address);
 
     // Set a new admin
-    let _ = env.call_public(owner, nft.set_admin(new_admin));
+    env.call_public(owner, nft.set_admin(new_admin));
     assert_eq(env.view_public(nft.get_admin()), new_admin.to_field());
 
     // Check new admin is not a minter
     assert(!env.view_public(nft.is_minter(new_admin)));
 
     // Set new admin as minter
-    let _ = env.call_public(new_admin, nft.set_minter(new_admin, true));
+    env.call_public(new_admin, nft.set_minter(new_admin, true));
     assert(env.view_public(nft.is_minter(new_admin)));
 
     // Revoke minter as admin
-    let _ = env.call_public(new_admin, nft.set_minter(new_admin, false));
+    env.call_public(new_admin, nft.set_minter(new_admin, false));
     assert(!env.view_public(nft.is_minter(new_admin)));
 }
 
@@ -33,7 +33,7 @@ unconstrained fn set_admin_requires_admin_caller() {
 
     let nft = NFT::at(nft_contract_address);
 
-    let _ = env.call_public(other, nft.set_admin(other));
+    env.call_public(other, nft.set_admin(other));
 }
 
 #[test(should_fail)]
@@ -43,5 +43,5 @@ unconstrained fn set_minter_requires_admin_caller() {
 
     let nft = NFT::at(nft_contract_address);
 
-    let _ = env.call_public(other, nft.set_minter(other, true));
+    env.call_public(other, nft.set_minter(other, true));
 }

--- a/noir-projects/noir-contracts/contracts/app/nft_contract/src/test/minting.nr
+++ b/noir-projects/noir-contracts/contracts/app/nft_contract/src/test/minting.nr
@@ -8,7 +8,7 @@ unconstrained fn mint_success() {
     let (env, nft_contract_address, owner, _) = utils::setup(/* with_account_contracts */ false);
 
     let token_id = 10000;
-    let _ = env.call_public(owner, NFT::at(nft_contract_address).mint(owner, token_id));
+    env.call_public(owner, NFT::at(nft_contract_address).mint(owner, token_id));
 
     utils::assert_owns_public_nft(env, nft_contract_address, owner, token_id);
 }
@@ -19,7 +19,7 @@ unconstrained fn mint_as_non_minter_fails() {
     let (env, nft_contract_address, owner, other) = utils::setup(/* with_account_contracts */ false);
 
     let token_id = 10000;
-    let _ = env.call_public(other, NFT::at(nft_contract_address).mint(owner, token_id));
+    env.call_public(other, NFT::at(nft_contract_address).mint(owner, token_id));
 }
 
 #[test(should_fail)] // should_fail_with="NFT not minted"
@@ -28,7 +28,7 @@ unconstrained fn mint_twice_fails() {
     let (env, nft_contract_address, owner, _) = utils::setup(/* with_account_contracts */ false);
 
     let token_id = 10000;
-    let _ = env.call_public(owner, NFT::at(nft_contract_address).mint(owner, token_id));
+    env.call_public(owner, NFT::at(nft_contract_address).mint(owner, token_id));
 
     env.utility_context_at(nft_contract_address, |context| {
         let nft_exists_slot = NFT::storage_layout().nft_exists.slot;
@@ -36,7 +36,7 @@ unconstrained fn mint_twice_fails() {
         assert(context.storage_read(nft_slot));
     });
 
-    let _ = env.call_public(owner, NFT::at(nft_contract_address).mint(owner, token_id));
+    env.call_public(owner, NFT::at(nft_contract_address).mint(owner, token_id));
 }
 
 #[test(should_fail)]
@@ -44,5 +44,5 @@ unconstrained fn mint_id_0_fails() {
     // Setup without account contracts. We are not using authwits here, so dummy accounts are enough
     let (env, nft_contract_address, owner, _) = utils::setup(/* with_account_contracts */ false);
 
-    let _ = env.call_public(owner, NFT::at(nft_contract_address).mint(owner, 0));
+    env.call_public(owner, NFT::at(nft_contract_address).mint(owner, 0));
 }

--- a/noir-projects/noir-contracts/contracts/app/nft_contract/src/test/transfer_in_private.nr
+++ b/noir-projects/noir-contracts/contracts/app/nft_contract/src/test/transfer_in_private.nr
@@ -11,7 +11,7 @@ unconstrained fn transfer_in_private() {
         utils::setup_mint_and_transfer_to_private(/* with_account_contracts */ false);
 
     // Transfer the NFT to the recipient
-    let _ = env.call_private(
+    env.call_private(
         sender,
         NFT::at(nft_contract_address).transfer_in_private(sender, recipient, token_id, 0),
     );
@@ -27,7 +27,7 @@ unconstrained fn transfer_in_private_to_self() {
         utils::setup_mint_and_transfer_to_private(/* with_account_contracts */ false);
 
     // Transfer the NFT back to the owner
-    let _ = env.call_private(
+    env.call_private(
         owner,
         NFT::at(nft_contract_address).transfer_in_private(owner, owner, token_id, 0),
     );
@@ -44,7 +44,7 @@ unconstrained fn transfer_in_private_to_non_deployed_account() {
     let not_deployed = env.create_light_account();
 
     // Transfer the NFT to the recipient
-    let _ = env.call_private(
+    env.call_private(
         sender,
         NFT::at(nft_contract_address).transfer_in_private(sender, not_deployed, token_id, 0),
     );
@@ -65,7 +65,7 @@ unconstrained fn transfer_in_private_on_behalf_of_other() {
     add_private_authwit_from_call_interface(sender, recipient, transfer_in_private_call_interface);
 
     // Transfer the NFT to the recipient
-    let _ = env.call_private(recipient, transfer_in_private_call_interface);
+    env.call_private(recipient, transfer_in_private_call_interface);
 
     // Recipient should be the private NFT owner
     utils::assert_owns_private_nft(env, nft_contract_address, recipient, token_id);
@@ -77,7 +77,7 @@ unconstrained fn transfer_in_private_failure_not_an_owner() {
     let (env, nft_contract_address, owner, not_owner, token_id) =
         utils::setup_mint_and_transfer_to_private(/* with_account_contracts */ false);
 
-    let _ = env.call_private(
+    env.call_private(
         not_owner,
         NFT::at(nft_contract_address).transfer_in_private(not_owner, owner, token_id, 0),
     );
@@ -95,7 +95,7 @@ unconstrained fn transfer_in_private_failure_on_behalf_of_self_non_zero_nonce() 
     let token_id = random();
 
     // Try transferring the NFT
-    let _ = env.call_private(
+    env.call_private(
         sender,
         NFT::at(nft_contract_address).transfer_in_private(sender, recipient, token_id, 1),
     );
@@ -113,7 +113,7 @@ unconstrained fn transfer_in_private_failure_on_behalf_of_other_without_approval
     let token_id = random();
 
     // Try transferring the NFT
-    let _ = env.call_private(
+    env.call_private(
         recipient,
         NFT::at(nft_contract_address).transfer_in_private(sender, recipient, token_id, 1),
     );
@@ -139,5 +139,5 @@ unconstrained fn transfer_in_private_failure_on_behalf_of_other_wrong_caller() {
     );
 
     // Try transferring the NFT
-    let _ = env.call_private(recipient, transfer_in_private_from_call_interface);
+    env.call_private(recipient, transfer_in_private_from_call_interface);
 }

--- a/noir-projects/noir-contracts/contracts/app/nft_contract/src/test/transfer_in_public.nr
+++ b/noir-projects/noir-contracts/contracts/app/nft_contract/src/test/transfer_in_public.nr
@@ -9,7 +9,7 @@ unconstrained fn transfer_in_public() {
         utils::setup_and_mint(/* with_account_contracts */ false);
 
     // Transfer the NFT
-    let _ = env.call_public(
+    env.call_public(
         sender,
         NFT::at(nft_contract_address).transfer_in_public(sender, recipient, token_id, 0),
     );
@@ -24,10 +24,7 @@ unconstrained fn transfer_in_public_to_self() {
         utils::setup_and_mint(/* with_account_contracts */ false);
 
     // Transfer the NFT
-    let _ = env.call_public(
-        user,
-        NFT::at(nft_contract_address).transfer_in_public(user, user, token_id, 0),
-    );
+    env.call_public(user, NFT::at(nft_contract_address).transfer_in_public(user, user, token_id, 0));
 
     // Check the user stayed the public owner
     utils::assert_owns_public_nft(env, nft_contract_address, user, token_id);
@@ -49,7 +46,7 @@ unconstrained fn transfer_in_public_on_behalf_of_other() {
     );
 
     // Transfer the NFT
-    let _ = env.call_public(recipient, transfer_in_public_from_call_interface);
+    env.call_public(recipient, transfer_in_public_from_call_interface);
 
     // Check the is recipient is the new public owner
     utils::assert_owns_public_nft(env, nft_contract_address, recipient, token_id);
@@ -64,7 +61,7 @@ unconstrained fn transfer_in_public_failure_on_behalf_of_self_non_zero_nonce() {
         utils::setup(/* with_account_contracts */ false);
 
     let token_id = 1;
-    let _ = env.call_public(
+    env.call_public(
         sender,
         NFT::at(nft_contract_address).transfer_in_public(sender, recipient, token_id, 1),
     );
@@ -77,7 +74,7 @@ unconstrained fn transfer_in_public_non_existent_nft() {
         utils::setup(/* with_account_contracts */ false);
 
     let token_id = 1;
-    let _ = env.call_public(
+    env.call_public(
         sender,
         NFT::at(nft_contract_address).transfer_in_public(sender, recipient, token_id, 0),
     );
@@ -89,7 +86,7 @@ unconstrained fn transfer_in_public_failure_on_behalf_of_other_without_approval(
     let (env, nft_contract_address, sender, recipient, token_id) =
         utils::setup_and_mint(/* with_account_contracts */ true);
 
-    let _ = env.call_public(
+    env.call_public(
         recipient,
         NFT::at(nft_contract_address).transfer_in_public(sender, recipient, token_id, 0),
     );
@@ -110,5 +107,5 @@ unconstrained fn transfer_in_public_failure_on_behalf_of_other_wrong_caller() {
     );
 
     // Try to transfer tokens
-    let _ = env.call_public(recipient, transfer_in_public_from_call_interface);
+    env.call_public(recipient, transfer_in_public_from_call_interface);
 }

--- a/noir-projects/noir-contracts/contracts/app/nft_contract/src/test/transfer_to_private.nr
+++ b/noir-projects/noir-contracts/contracts/app/nft_contract/src/test/transfer_to_private.nr
@@ -29,15 +29,13 @@ unconstrained fn transfer_to_private_external_orchestration() {
         utils::setup_and_mint(/* with_account_contracts */ false);
 
     // We prepare the transfer
-    let partial_note = env
-        .call_private(
-            owner,
-            NFT::at(nft_contract_address).prepare_private_balance_increase(recipient),
-        )
-        .return_value;
+    let partial_note = env.call_private(
+        owner,
+        NFT::at(nft_contract_address).prepare_private_balance_increase(recipient),
+    );
 
     // Finalize the transfer of the NFT (message sender owns the NFT in public)
-    let _ = env.call_public(
+    env.call_public(
         owner,
         NFT::at(nft_contract_address).finalize_transfer_to_private(token_id, partial_note),
     );
@@ -60,7 +58,7 @@ unconstrained fn transfer_to_private_transfer_not_prepared() {
     let partial_note = PartialNFTNote::deserialize([commitment]);
 
     // Try finalizing the transfer without preparing it
-    let _ = env.call_public(
+    env.call_public(
         owner,
         NFT::at(nft_contract_address).finalize_transfer_to_private(token_id, partial_note),
     );
@@ -75,15 +73,13 @@ unconstrained fn transfer_to_private_failure_not_an_owner() {
     // (For this specific test we could set a random value for the commitment and not do the call to `prepare...`
     // as the NFT owner check is before we use the value but that would made the test less robust against changes
     // in the contract.)
-    let partial_note = env
-        .call_private(
-            owner,
-            NFT::at(nft_contract_address).prepare_private_balance_increase(not_owner),
-        )
-        .return_value;
+    let partial_note = env.call_private(
+        owner,
+        NFT::at(nft_contract_address).prepare_private_balance_increase(not_owner),
+    );
 
     // Try transferring someone else's public NFT
-    let _ = env.call_public(
+    env.call_public(
         not_owner,
         NFT::at(nft_contract_address).finalize_transfer_to_private(token_id, partial_note),
     );
@@ -99,16 +95,14 @@ unconstrained fn incorrect_completer_cannot_complete_partial_note() {
     let completer = env.create_light_account();
 
     // We prepare the partial note as a completer.
-    let partial_note = env
-        .call_private(
-            completer,
-            NFT::at(nft_contract_address).prepare_private_balance_increase(recipient),
-        )
-        .return_value;
+    let partial_note = env.call_private(
+        completer,
+        NFT::at(nft_contract_address).prepare_private_balance_increase(recipient),
+    );
 
     // Now we try to complete the partial note as another completer. Note that the caller here is the owner of the token
     // we're transferring - this is so that we pass the owner check and fail on the partial note completer check.
-    let _ = env.call_public(
+    env.call_public(
         owner,
         NFT::at(nft_contract_address).finalize_transfer_to_private(token_id, partial_note),
     );

--- a/noir-projects/noir-contracts/contracts/app/nft_contract/src/test/transfer_to_public.nr
+++ b/noir-projects/noir-contracts/contracts/app/nft_contract/src/test/transfer_to_public.nr
@@ -10,7 +10,7 @@ unconstrained fn transfer_to_public() {
     let (env, nft_contract_address, sender, recipient, token_id) =
         utils::setup_mint_and_transfer_to_private(/* with_account_contracts */ false);
 
-    let _ = env.call_private(
+    env.call_private(
         sender,
         NFT::at(nft_contract_address).transfer_to_public(sender, recipient, token_id, 0),
     );
@@ -25,10 +25,7 @@ unconstrained fn transfer_to_public_to_self() {
     let (env, nft_contract_address, user, _, token_id) =
         utils::setup_mint_and_transfer_to_private(/* with_account_contracts */ false);
 
-    let _ = env.call_private(
-        user,
-        NFT::at(nft_contract_address).transfer_to_public(user, user, token_id, 0),
-    );
+    env.call_private(user, NFT::at(nft_contract_address).transfer_to_public(user, user, token_id, 0));
 
     // Check the user stayed the public owner
     utils::assert_owns_public_nft(env, nft_contract_address, user, token_id);
@@ -44,7 +41,7 @@ unconstrained fn transfer_to_public_on_behalf_of_other() {
     add_private_authwit_from_call_interface(sender, recipient, transfer_to_public_call_interface);
 
     // transfer_to_public the NFT
-    let _ = env.call_private(recipient, transfer_to_public_call_interface);
+    env.call_private(recipient, transfer_to_public_call_interface);
 
     // Recipient should be the public owner
     utils::assert_owns_public_nft(env, nft_contract_address, recipient, token_id);
@@ -56,7 +53,7 @@ unconstrained fn transfer_to_public_failure_not_an_owner() {
     let (env, nft_contract_address, _, not_owner, token_id) =
         utils::setup_mint_and_transfer_to_private(/* with_account_contracts */ false);
 
-    let _ = env.call_private(
+    env.call_private(
         not_owner,
         NFT::at(nft_contract_address).transfer_to_public(not_owner, not_owner, token_id, 0),
     );
@@ -68,7 +65,7 @@ unconstrained fn transfer_to_public_failure_on_behalf_of_self_non_zero_nonce() {
     let (env, nft_contract_address, user, _, token_id) =
         utils::setup_mint_and_transfer_to_private(/* with_account_contracts */ false);
 
-    let _ = env.call_private(
+    env.call_private(
         user,
         NFT::at(nft_contract_address).transfer_to_public(user, user, token_id, random()),
     );
@@ -84,7 +81,7 @@ unconstrained fn transfer_to_public_failure_on_behalf_of_other_invalid_designate
     add_private_authwit_from_call_interface(sender, sender, transfer_to_public_call_interface);
 
     // transfer_to_public the NFT
-    let _ = env.call_private(recipient, transfer_to_public_call_interface);
+    env.call_private(recipient, transfer_to_public_call_interface);
 }
 
 #[test(should_fail_with = "Unknown auth witness for message hash")]
@@ -93,7 +90,7 @@ unconstrained fn transfer_to_public_failure_on_behalf_of_other_no_approval() {
         utils::setup_mint_and_transfer_to_private(/* with_account_contracts */ true);
 
     // transfer_to_public the NFT
-    let _ = env.call_private(
+    env.call_private(
         recipient,
         NFT::at(nft_contract_address).transfer_to_public(sender, recipient, token_id, 0),
     );

--- a/noir-projects/noir-contracts/contracts/app/nft_contract/src/test/utils.nr
+++ b/noir-projects/noir-contracts/contracts/app/nft_contract/src/test/utils.nr
@@ -44,7 +44,7 @@ pub unconstrained fn setup_and_mint(
     let (env, nft_contract_address, owner, recipient) = setup(with_account_contracts);
     let minted_token_id = 615;
 
-    let _ = env.call_public(owner, NFT::at(nft_contract_address).mint(owner, minted_token_id));
+    env.call_public(owner, NFT::at(nft_contract_address).mint(owner, minted_token_id));
 
     (env, nft_contract_address, owner, recipient, minted_token_id)
 }
@@ -56,7 +56,7 @@ pub unconstrained fn setup_mint_and_transfer_to_private(
         setup_and_mint(with_account_contracts);
 
     // We transfer the public NFT to private.
-    let _ = env.call_private(
+    env.call_private(
         owner,
         NFT::at(nft_contract_address).transfer_to_private(owner, minted_token_id),
     );

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/test/access_control.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/test/access_control.nr
@@ -11,18 +11,18 @@ unconstrained fn access_control() {
     let token = Token::at(token_contract_address);
 
     // Set a new admin
-    let _ = env.call_public(owner, token.set_admin(new_admin));
+    env.call_public(owner, token.set_admin(new_admin));
     assert_eq(env.view_public(token.get_admin()), new_admin.to_field());
 
     // Check new admin is not a minter
     assert(!env.view_public(token.is_minter(new_admin)));
 
     // Set new admin as minter
-    let _ = env.call_public(new_admin, token.set_minter(new_admin, true));
+    env.call_public(new_admin, token.set_minter(new_admin, true));
     assert(env.view_public(token.is_minter(new_admin)));
 
     // Revoke minter as admin
-    let _ = env.call_public(new_admin, token.set_minter(new_admin, false));
+    env.call_public(new_admin, token.set_minter(new_admin, false));
     assert(!env.view_public(token.is_minter(new_admin)));
 }
 
@@ -33,7 +33,7 @@ unconstrained fn set_admin_requires_admin_caller() {
 
     let token = Token::at(token_contract_address);
 
-    let _ = env.call_public(other, token.set_admin(other));
+    env.call_public(other, token.set_admin(other));
 }
 
 #[test(should_fail)]
@@ -43,5 +43,5 @@ unconstrained fn set_minter_requires_admin_caller() {
 
     let token = Token::at(token_contract_address);
 
-    let _ = env.call_public(other, token.set_minter(other, true));
+    env.call_public(other, token.set_minter(other, true));
 }

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/test/burn_private.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/test/burn_private.nr
@@ -11,10 +11,7 @@ unconstrained fn burn_private_on_behalf_of_self() {
     let burn_amount = mint_amount / (10 as u128);
 
     // Burn less than balance
-    let _ = env.call_private(
-        owner,
-        Token::at(token_contract_address).burn_private(owner, burn_amount, 0),
-    );
+    env.call_private(owner, Token::at(token_contract_address).burn_private(owner, burn_amount, 0));
     utils::check_private_balance(
         env,
         token_contract_address,
@@ -34,7 +31,7 @@ unconstrained fn burn_private_on_behalf_of_other() {
         Token::at(token_contract_address).burn_private(owner, burn_amount, AUTHWIT_NONCE);
     add_private_authwit_from_call_interface(owner, recipient, burn_call_interface);
     // Burn tokens
-    let _ = env.call_private(recipient, burn_call_interface);
+    env.call_private(recipient, burn_call_interface);
     utils::check_private_balance(
         env,
         token_contract_address,
@@ -50,10 +47,7 @@ unconstrained fn burn_private_failure_more_than_balance() {
 
     // Burn more than balance
     let burn_amount = mint_amount * (10 as u128);
-    let _ = env.call_private(
-        owner,
-        Token::at(token_contract_address).burn_private(owner, burn_amount, 0),
-    );
+    env.call_private(owner, Token::at(token_contract_address).burn_private(owner, burn_amount, 0));
 }
 
 #[test(should_fail_with = "Assertion failed: Invalid authwit nonce. When 'from' and 'msg_sender' are the same, 'authwit_nonce' must be zero")]
@@ -62,10 +56,7 @@ unconstrained fn burn_private_failure_on_behalf_of_self_non_zero_nonce() {
         utils::setup_and_mint_to_public(/* with_account_contracts */ false);
 
     let burn_amount = mint_amount;
-    let _ = env.call_private(
-        owner,
-        Token::at(token_contract_address).burn_private(owner, burn_amount, 1),
-    );
+    env.call_private(owner, Token::at(token_contract_address).burn_private(owner, burn_amount, 1));
 }
 
 #[test(should_fail_with = "Balance too low")]
@@ -80,7 +71,7 @@ unconstrained fn burn_private_failure_on_behalf_of_other_more_than_balance() {
         Token::at(token_contract_address).burn_private(owner, burn_amount, AUTHWIT_NONCE);
     add_private_authwit_from_call_interface(owner, recipient, burn_call_interface);
 
-    let _ = env.call_private(recipient, burn_call_interface);
+    env.call_private(recipient, burn_call_interface);
 }
 
 #[test(should_fail_with = "Unknown auth witness for message hash")]
@@ -94,7 +85,7 @@ unconstrained fn burn_private_failure_on_behalf_of_other_without_approval() {
     let burn_call_interface =
         Token::at(token_contract_address).burn_private(owner, burn_amount, AUTHWIT_NONCE);
 
-    let _ = env.call_private(recipient, burn_call_interface);
+    env.call_private(recipient, burn_call_interface);
 }
 
 #[test(should_fail_with = "Unknown auth witness for message hash")]
@@ -109,5 +100,5 @@ unconstrained fn burn_private_failure_on_behalf_of_other_wrong_designated_caller
         Token::at(token_contract_address).burn_private(owner, burn_amount, AUTHWIT_NONCE);
     add_private_authwit_from_call_interface(owner, owner, burn_call_interface);
 
-    let _ = env.call_private(recipient, burn_call_interface);
+    env.call_private(recipient, burn_call_interface);
 }

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/test/burn_public.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/test/burn_public.nr
@@ -9,10 +9,7 @@ unconstrained fn burn_public_success() {
     let burn_amount = mint_amount / (10 as u128);
 
     // Burn less than balance
-    let _ = env.call_public(
-        owner,
-        Token::at(token_contract_address).burn_public(owner, burn_amount, 0),
-    );
+    env.call_public(owner, Token::at(token_contract_address).burn_public(owner, burn_amount, 0));
     utils::check_public_balance(
         env,
         token_contract_address,
@@ -33,7 +30,7 @@ unconstrained fn burn_public_on_behalf_of_other() {
     add_public_authwit_from_call_interface(env, owner, recipient, burn_call_interface);
 
     // Burn tokens
-    let _ = env.call_public(recipient, burn_call_interface);
+    env.call_public(recipient, burn_call_interface);
 
     utils::check_public_balance(
         env,
@@ -51,10 +48,7 @@ unconstrained fn burn_public_failure_more_than_balance() {
     // Burn more than balance
     let burn_amount = mint_amount * (10 as u128);
     // Try to burn
-    let _ = env.call_public(
-        owner,
-        Token::at(token_contract_address).burn_public(owner, burn_amount, 0),
-    );
+    env.call_public(owner, Token::at(token_contract_address).burn_public(owner, burn_amount, 0));
 }
 
 #[test(should_fail)] // should_fail_with = "Assertion failed: Invalid authwit nonce. When 'from' and 'msg_sender' are the same, 'authwit_nonce' must be zero"
@@ -65,7 +59,7 @@ unconstrained fn burn_public_failure_on_behalf_of_self_non_zero_nonce() {
     // Burn on behalf of self with non-zero nonce
     let burn_amount = mint_amount / (10 as u128);
     // Try to burn
-    let _ = env.call_public(
+    env.call_public(
         owner,
         Token::at(token_contract_address).burn_public(owner, burn_amount, random()),
     );
@@ -81,7 +75,7 @@ unconstrained fn burn_public_failure_on_behalf_of_other_without_approval() {
     let burn_call_interface =
         Token::at(token_contract_address).burn_public(owner, burn_amount, random());
 
-    let _ = env.call_public(recipient, burn_call_interface);
+    env.call_public(recipient, burn_call_interface);
 }
 
 #[test(should_fail)] // should_fail_with = "unauthorized"
@@ -95,5 +89,5 @@ unconstrained fn burn_public_failure_on_behalf_of_other_wrong_caller() {
         Token::at(token_contract_address).burn_public(owner, burn_amount, random());
     add_public_authwit_from_call_interface(env, owner, owner, burn_call_interface);
 
-    let _ = env.call_public(recipient, burn_call_interface);
+    env.call_public(recipient, burn_call_interface);
 }

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/test/mint_to_public.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/test/mint_to_public.nr
@@ -6,10 +6,7 @@ unconstrained fn mint_to_public_success() {
     let (env, token_contract_address, owner, _) = utils::setup(/* with_account_contracts */ false);
 
     let mint_amount = 10_000 as u128;
-    let _ = env.call_public(
-        owner,
-        Token::at(token_contract_address).mint_to_public(owner, mint_amount),
-    );
+    env.call_public(owner, Token::at(token_contract_address).mint_to_public(owner, mint_amount));
 
     utils::check_public_balance(env, token_contract_address, owner, mint_amount);
 
@@ -25,7 +22,7 @@ unconstrained fn mint_as_non_minter() {
 
     // As non-minter
     let mint_amount = 10_000 as u128;
-    let _ = env.call_public(
+    env.call_public(
         recipient,
         Token::at(token_contract_address).mint_to_public(recipient, mint_amount),
     );
@@ -41,11 +38,8 @@ unconstrained fn mint_overflow() {
     let amount_until_overflow = 1000 as u128;
     let mint_amount = (2.pow_32(128) - amount_until_overflow as Field) as u128;
 
-    let _ = env.call_public(
-        owner,
-        Token::at(token_contract_address).mint_to_public(recipient, mint_amount),
-    );
-    let _ = env.call_public(
+    env.call_public(owner, Token::at(token_contract_address).mint_to_public(recipient, mint_amount));
+    env.call_public(
         owner,
         Token::at(token_contract_address).mint_to_public(recipient, amount_until_overflow),
     );

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/test/transfer.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/test/transfer.nr
@@ -10,10 +10,7 @@ unconstrained fn transfer_private() {
     // docs:start:txe_test_transfer_private
     // Transfer tokens
     let transfer_amount = 1000 as u128;
-    let _ = env.call_private(
-        owner,
-        Token::at(token_contract_address).transfer(recipient, transfer_amount),
-    );
+    env.call_private(owner, Token::at(token_contract_address).transfer(recipient, transfer_amount));
     // docs:end:txe_test_transfer_private
     // Check balances
     utils::check_private_balance(
@@ -48,7 +45,7 @@ unconstrained fn transfer_private_to_non_deployed_account() {
 
     // Transfer tokens
     let transfer_amount = 1000 as u128;
-    let _ = env.call_private(
+    env.call_private(
         owner,
         Token::at(token_contract_address).transfer(not_deployed, transfer_amount),
     );
@@ -70,8 +67,5 @@ unconstrained fn transfer_private_failure_more_than_balance() {
         utils::setup_and_mint_to_private(/* with_account_contracts */ false);
     // Transfer tokens
     let transfer_amount = mint_amount + (1 as u128);
-    let _ = env.call_private(
-        owner,
-        Token::at(token_contract_address).transfer(recipient, transfer_amount),
-    );
+    env.call_private(owner, Token::at(token_contract_address).transfer(recipient, transfer_amount));
 }

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/test/transfer_in_private.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/test/transfer_in_private.nr
@@ -14,7 +14,7 @@ unconstrained fn transfer_private_on_behalf_of_other() {
         Token::at(token_contract_address).transfer_in_private(owner, recipient, transfer_amount, 1);
     add_private_authwit_from_call_interface(owner, recipient, transfer_private_from_call_interface);
     // Transfer tokens
-    let _ = env.call_private(recipient, transfer_private_from_call_interface);
+    env.call_private(recipient, transfer_private_from_call_interface);
     // docs:end:private_authwit
     // Check balances
     utils::check_private_balance(
@@ -38,7 +38,7 @@ unconstrained fn transfer_private_failure_on_behalf_of_self_non_zero_nonce() {
         Token::at(token_contract_address).transfer_in_private(owner, recipient, transfer_amount, 1);
     add_private_authwit_from_call_interface(owner, recipient, transfer_private_from_call_interface);
     // Transfer tokens
-    let _ = env.call_private(owner, transfer_private_from_call_interface);
+    env.call_private(owner, transfer_private_from_call_interface);
 }
 // docs:end:fail_with_message
 
@@ -53,7 +53,7 @@ unconstrained fn transfer_private_failure_on_behalf_of_more_than_balance() {
         Token::at(token_contract_address).transfer_in_private(owner, recipient, transfer_amount, 1);
     add_private_authwit_from_call_interface(owner, recipient, transfer_private_from_call_interface);
     // Transfer tokens
-    let _ = env.call_private(recipient, transfer_private_from_call_interface);
+    env.call_private(recipient, transfer_private_from_call_interface);
 }
 
 #[test(should_fail_with = "Unknown auth witness for message hash")]
@@ -66,7 +66,7 @@ unconstrained fn transfer_private_failure_on_behalf_of_other_without_approval() 
     let transfer_private_from_call_interface =
         Token::at(token_contract_address).transfer_in_private(owner, recipient, transfer_amount, 1);
     // Transfer tokens
-    let _ = env.call_private(recipient, transfer_private_from_call_interface);
+    env.call_private(recipient, transfer_private_from_call_interface);
 }
 
 #[test(should_fail_with = "Unknown auth witness for message hash")]
@@ -80,5 +80,5 @@ unconstrained fn transfer_private_failure_on_behalf_of_other_wrong_caller() {
         Token::at(token_contract_address).transfer_in_private(owner, recipient, transfer_amount, 1);
     add_private_authwit_from_call_interface(owner, owner, transfer_private_from_call_interface);
     // Transfer tokens
-    let _ = env.call_private(recipient, transfer_private_from_call_interface);
+    env.call_private(recipient, transfer_private_from_call_interface);
 }

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/test/transfer_in_public.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/test/transfer_in_public.nr
@@ -9,7 +9,7 @@ unconstrained fn public_transfer() {
         utils::setup_and_mint_to_public(/* with_account_contracts */ false);
     // Transfer tokens
     let transfer_amount = mint_amount / (10 as u128);
-    let _ = env.call_public(
+    env.call_public(
         owner,
         Token::at(token_contract_address).transfer_in_public(owner, recipient, transfer_amount, 0),
     );
@@ -32,7 +32,7 @@ unconstrained fn public_transfer_to_self() {
     // Transfer tokens
     let transfer_amount = mint_amount / (10 as u128);
     // docs:start:call_public
-    let _ = env.call_public(
+    env.call_public(
         owner,
         Token::at(token_contract_address).transfer_in_public(owner, owner, transfer_amount, 0),
     );
@@ -56,7 +56,7 @@ unconstrained fn public_transfer_on_behalf_of_other() {
         public_transfer_in_private_call_interface,
     );
     // Transfer tokens
-    let _ = env.call_public(recipient, public_transfer_in_private_call_interface);
+    env.call_public(recipient, public_transfer_in_private_call_interface);
     // Check balances
     utils::check_public_balance(
         env,
@@ -77,7 +77,7 @@ unconstrained fn public_transfer_failure_more_than_balance() {
     let public_transfer_call_interface =
         Token::at(token_contract_address).transfer_in_public(owner, recipient, transfer_amount, 0);
     // Try to transfer tokens
-    let _ = env.call_public(owner, public_transfer_call_interface);
+    env.call_public(owner, public_transfer_call_interface);
 }
 
 #[test(should_fail)] // should_fail_with = "Assertion failed: Invalid authwit nonce. When 'from' and 'msg_sender' are the same, 'authwit_nonce' must be zero"
@@ -91,7 +91,7 @@ unconstrained fn public_transfer_failure_on_behalf_of_self_non_zero_nonce() {
         Token::at(token_contract_address).transfer_in_public(owner, recipient, transfer_amount, 1);
     add_public_authwit_from_call_interface(env, owner, recipient, public_transfer_call_interface);
     // Try to transfer tokens
-    let _ = env.call_public(owner, public_transfer_call_interface);
+    env.call_public(owner, public_transfer_call_interface);
 }
 
 #[test(should_fail)] // should_fail_with = "unauthorized"
@@ -104,7 +104,7 @@ unconstrained fn public_transfer_failure_on_behalf_of_other_without_approval() {
         Token::at(token_contract_address).transfer_in_public(owner, recipient, transfer_amount, 1);
 
     // Try to transfer tokens
-    let _ = env.call_public(recipient, public_transfer_in_private_call_interface);
+    env.call_public(recipient, public_transfer_in_private_call_interface);
 }
 
 #[test(should_fail)] // should_fail_with = "Assertion failed: attempt to subtract with overflow"
@@ -125,7 +125,7 @@ unconstrained fn public_transfer_failure_on_behalf_of_other_more_than_balance() 
     // docs:end:public_authwit
 
     // Try to transfer tokens
-    let _ = env.call_public(recipient, public_transfer_in_private_call_interface);
+    env.call_public(recipient, public_transfer_in_private_call_interface);
 }
 
 #[test(should_fail)] // should_fail_with = "unauthorized"
@@ -144,5 +144,5 @@ unconstrained fn public_transfer_failure_on_behalf_of_other_wrong_caller() {
     );
 
     // Try to transfer tokens
-    let _ = env.call_public(recipient, public_transfer_in_private_call_interface);
+    env.call_public(recipient, public_transfer_in_private_call_interface);
 }

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/test/transfer_to_private.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/test/transfer_to_private.nr
@@ -27,15 +27,13 @@ unconstrained fn transfer_to_private_external_orchestration() {
         utils::setup_and_mint_to_public(/* with_account_contracts */ false);
 
     // We prepare the transfer
-    let partial_uint_note = env
-        .call_private(
-            owner,
-            Token::at(token_contract_address).prepare_private_balance_increase(recipient),
-        )
-        .return_value;
+    let partial_uint_note = env.call_private(
+        owner,
+        Token::at(token_contract_address).prepare_private_balance_increase(recipient),
+    );
 
     // Finalize the transfer of the tokens (message sender owns the tokens in public)
-    let _ = env.call_public(
+    env.call_public(
         owner,
         Token::at(token_contract_address).finalize_transfer_to_private(amount, partial_uint_note),
     );
@@ -53,14 +51,12 @@ unconstrained fn transfer_to_private_from_private_external_orchestration() {
         utils::setup_and_mint_to_private(/* with_account_contracts */ false);
 
     // We prepare the transfer
-    let partial_uint_note = env
-        .call_private(
-            owner,
-            Token::at(token_contract_address).prepare_private_balance_increase(recipient),
-        )
-        .return_value;
+    let partial_uint_note = env.call_private(
+        owner,
+        Token::at(token_contract_address).prepare_private_balance_increase(recipient),
+    );
     // Finalize the transfer of the tokens (message sender owns the tokens in public)
-    let _ = env.call_private(
+    env.call_private(
         owner,
         Token::at(token_contract_address).finalize_transfer_to_private_from_private(
             owner,
@@ -88,7 +84,7 @@ unconstrained fn transfer_to_private_transfer_not_prepared() {
     let partial_uint_note = PartialUintNote::deserialize([commitment]);
 
     // Try finalizing the transfer without preparing it
-    let _ = env.call_public(
+    env.call_public(
         owner,
         Token::at(token_contract_address).finalize_transfer_to_private(amount, partial_uint_note),
     );
@@ -103,15 +99,13 @@ unconstrained fn transfer_to_private_failure_not_an_owner() {
     // (For this specific test we could set a random value for the commitment and not do the call to `prepare...`
     // as the token balance check is before we use the value but that would made the test less robust against changes
     // in the contract.)
-    let partial_uint_note = env
-        .call_private(
-            owner,
-            Token::at(token_contract_address).prepare_private_balance_increase(not_owner),
-        )
-        .return_value;
+    let partial_uint_note = env.call_private(
+        owner,
+        Token::at(token_contract_address).prepare_private_balance_increase(not_owner),
+    );
 
     // Try transferring someone else's token balance
-    let _ = env.call_public(
+    env.call_public(
         not_owner,
         Token::at(token_contract_address).finalize_transfer_to_private(amount, partial_uint_note),
     );
@@ -127,16 +121,14 @@ unconstrained fn incorrect_completer_cannot_complete_partial_note() {
     let completer = env.create_light_account();
 
     // We prepare the partial note as a completer
-    let partial_uint_note = env
-        .call_private(
-            completer,
-            Token::at(token_contract_address).prepare_private_balance_increase(recipient),
-        )
-        .return_value;
+    let partial_uint_note = env.call_private(
+        completer,
+        Token::at(token_contract_address).prepare_private_balance_increase(recipient),
+    );
 
     // Now we try to complete the partial note as another completer. Note that the caller here owns the tokens - this is
     // so that we pass the balance check and fail on the partial note completer check.
-    let _ = env.call_public(
+    env.call_public(
         owner,
         Token::at(token_contract_address).finalize_transfer_to_private(amount, partial_uint_note),
     );

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/test/transfer_to_public.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/test/transfer_to_public.nr
@@ -11,7 +11,7 @@ unconstrained fn transfer_to_public_on_behalf_of_self() {
         utils::setup_and_mint_to_private(/* with_account_contracts */ false);
 
     let transfer_to_public_amount = mint_amount / (10 as u128);
-    let _ = env.call_private(
+    env.call_private(
         owner,
         Token::at(token_contract_address).transfer_to_public(
             owner,
@@ -48,7 +48,7 @@ unconstrained fn transfer_to_public_on_behalf_of_other() {
     );
     add_private_authwit_from_call_interface(owner, recipient, transfer_to_public_call_interface);
     // transfer_to_public tokens
-    let _ = env.call_private(recipient, transfer_to_public_call_interface);
+    env.call_private(recipient, transfer_to_public_call_interface);
     utils::check_private_balance(
         env,
         token_contract_address,
@@ -70,7 +70,7 @@ unconstrained fn transfer_to_public_failure_more_than_balance() {
         utils::setup_and_mint_to_private(/* with_account_contracts */ false);
 
     let transfer_to_public_amount = mint_amount + (1 as u128);
-    let _ = env.call_private(
+    env.call_private(
         owner,
         Token::at(token_contract_address).transfer_to_public(
             owner,
@@ -88,7 +88,7 @@ unconstrained fn transfer_to_public_failure_on_behalf_of_self_non_zero_nonce() {
         utils::setup_and_mint_to_private(/* with_account_contracts */ false);
 
     let transfer_to_public_amount = mint_amount + (1 as u128);
-    let _ = env.call_private(
+    env.call_private(
         owner,
         Token::at(token_contract_address).transfer_to_public(
             owner,
@@ -114,7 +114,7 @@ unconstrained fn transfer_to_public_failure_on_behalf_of_other_more_than_balance
     add_private_authwit_from_call_interface(owner, recipient, transfer_to_public_call_interface);
 
     // transfer_to_public tokens
-    let _ = env.call_private(recipient, transfer_to_public_call_interface);
+    env.call_private(recipient, transfer_to_public_call_interface);
 }
 
 #[test(should_fail_with = "Unknown auth witness for message hash")]
@@ -132,7 +132,7 @@ unconstrained fn transfer_to_public_failure_on_behalf_of_other_invalid_designate
     add_private_authwit_from_call_interface(owner, owner, transfer_to_public_call_interface);
 
     // transfer_to_public tokens
-    let _ = env.call_private(recipient, transfer_to_public_call_interface);
+    env.call_private(recipient, transfer_to_public_call_interface);
 }
 
 #[test(should_fail_with = "Unknown auth witness for message hash")]
@@ -149,5 +149,5 @@ unconstrained fn transfer_to_public_failure_on_behalf_of_other_no_approval() {
     );
 
     // transfer_to_public tokens
-    let _ = env.call_private(recipient, transfer_to_public_call_interface);
+    env.call_private(recipient, transfer_to_public_call_interface);
 }

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/test/transfer_to_public_and_prepare_private_balance_increase.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/test/transfer_to_public_and_prepare_private_balance_increase.nr
@@ -35,7 +35,7 @@ unconstrained fn transfer_to_public_and_prepare_private_balance_increase_and_fin
     );
 
     // Impersonate the AMM and initiate the transfer
-    let partial_note = env.call_private(amm_contract, transfer_call_interface).return_value;
+    let partial_note = env.call_private(amm_contract, transfer_call_interface);
 
     // Check balances before the partial note is finalized
     utils::check_private_balance(
@@ -50,7 +50,7 @@ unconstrained fn transfer_to_public_and_prepare_private_balance_increase_and_fin
     // --> this should send the `change_amount` from AMM's public balance to liquidity provider's private balance
     let change_amount = deposit_amount / (2 as u128);
 
-    let _ = env.call_public(
+    env.call_public(
         amm_contract,
         Token::at(token_contract_address).finalize_transfer_to_private(change_amount, partial_note),
     );
@@ -112,14 +112,15 @@ unconstrained fn transfer_to_public_and_prepare_private_balance_increase_failure
         utils::setup_and_mint_to_private(/* with_account_contracts */ true);
 
     let transfer_amount = mint_amount / (10 as u128);
-    let transfer_call_interface = Token::at(token_contract_address)
-        .transfer_to_public_and_prepare_private_balance_increase(
+
+    // Try executing transfer without approval
+    let _ = env.call_private(
+        recipient,
+        Token::at(token_contract_address).transfer_to_public_and_prepare_private_balance_increase(
             sender,
             recipient,
             transfer_amount,
             1,
-        );
-
-    // Try executing transfer without approval
-    let _ = env.call_private(recipient, transfer_call_interface);
+        ),
+    );
 }

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/test/utils.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/test/utils.nr
@@ -46,10 +46,7 @@ pub unconstrained fn setup_and_mint_to_public(
     let mint_amount = 10000 as u128;
 
     // Mint some tokens
-    let _ = env.call_public(
-        owner,
-        Token::at(token_contract_address).mint_to_public(owner, mint_amount),
-    );
+    env.call_public(owner, Token::at(token_contract_address).mint_to_public(owner, mint_amount));
 
     (env, token_contract_address, owner, recipient, mint_amount)
 }
@@ -62,10 +59,7 @@ pub unconstrained fn setup_and_mint_amount_to_private(
     let (env, token_contract_address, owner, recipient) = setup(with_account_contracts);
 
     // Mint some tokens
-    let _ = env.call_private(
-        owner,
-        Token::at(token_contract_address).mint_to_private(owner, mint_amount),
-    );
+    env.call_private(owner, Token::at(token_contract_address).mint_to_private(owner, mint_amount));
 
     (env, token_contract_address, owner, recipient, mint_amount)
 }

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/types/balance_set.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/types/balance_set.nr
@@ -157,13 +157,13 @@ mod test {
 
         // The owner mints two notes for the recipient
         let first_note_value = note_values[0];
-        let _ = env.call_private(
+        env.call_private(
             owner,
             Token::at(token_contract_address).mint_to_private(recipient, first_note_value),
         );
 
         let second_note_value = note_values[1];
-        let _ = env.call_private(
+        env.call_private(
             owner,
             Token::at(token_contract_address).mint_to_private(recipient, second_note_value),
         );

--- a/noir-projects/noir-contracts/contracts/protocol/router_contract/src/test.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/router_contract/src/test.nr
@@ -16,7 +16,7 @@ unconstrained fn check_block_number() {
     let router = Router::at(router_contract_address);
 
     let expected_next_block_number = env.next_block_number();
-    let _ = env.call_private(
+    env.call_private(
         AztecAddress::empty(),
         router.check_block_number(Comparator.LT, expected_next_block_number + 1),
     );
@@ -30,7 +30,7 @@ unconstrained fn check_block_number_fail() {
     let router = Router::at(router_contract_address);
 
     let expected_next_block_number = env.next_block_number();
-    let _ = env.call_private(
+    env.call_private(
         AztecAddress::empty(),
         router.check_block_number(Comparator.LT, expected_next_block_number),
     );
@@ -45,7 +45,7 @@ unconstrained fn check_timestamp() {
 
     let expected_next_block_timestamp = env.last_block_timestamp() + 100;
     env.set_next_block_timestamp(expected_next_block_timestamp);
-    let _ = env.call_private(
+    env.call_private(
         AztecAddress::empty(),
         router.check_timestamp(Comparator.LT, expected_next_block_timestamp + 1),
     );
@@ -60,7 +60,7 @@ unconstrained fn check_timestamp_fail() {
 
     let expected_next_block_timestamp = env.last_block_timestamp() + 100;
     env.set_next_block_timestamp(expected_next_block_timestamp);
-    let _ = env.call_private(
+    env.call_private(
         AztecAddress::empty(),
         router.check_timestamp(Comparator.LT, expected_next_block_timestamp),
     );

--- a/noir-projects/noir-contracts/contracts/test/counter_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/counter_contract/src/main.nr
@@ -117,7 +117,7 @@ pub contract Counter {
         // docs:end:txe_test_read_notes
 
         // Increment the counter
-        let _ = env.call_private(owner, Counter::at(contract_address).increment(owner));
+        env.call_private(owner, Counter::at(contract_address).increment(owner));
 
         let incremented_counter =
             env.simulate_utility(Counter::at(contract_address)._experimental_get_counter(owner));
@@ -139,7 +139,7 @@ pub contract Counter {
             env.simulate_utility(Counter::at(contract_address)._experimental_get_counter(owner));
         assert(initial_note_value == initial_value);
 
-        let _ = env.call_private(owner, Counter::at(contract_address).increment_twice(owner));
+        env.call_private(owner, Counter::at(contract_address).increment_twice(owner));
 
         assert_eq(
             env.simulate_utility(Counter::at(contract_address)._experimental_get_counter(owner)),
@@ -153,7 +153,7 @@ pub contract Counter {
             7,
         );
 
-        let _ = env.call_private(owner, Counter::at(contract_address).decrement(owner));
+        env.call_private(owner, Counter::at(contract_address).decrement(owner));
         assert_eq(
             env.simulate_utility(Counter::at(contract_address)._experimental_get_counter(owner)),
             6,

--- a/noir-projects/noir-contracts/contracts/test/parent_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/parent_contract/src/main.nr
@@ -279,42 +279,32 @@ pub contract Parent {
 
         // Set value in child through parent
         let value_to_set = 7;
-        let result = env
-            .call_private(
-                from,
-                Parent::at(parent_contract_address).private_call(
-                    child_contract_address,
-                    comptime {
-                        FunctionSelector::from_signature("private_set_value(Field,(Field))")
-                    },
-                    [value_to_set, owner.to_field()],
-                ),
-            )
-            .return_value;
+        let result = env.call_private(
+            from,
+            Parent::at(parent_contract_address).private_call(
+                child_contract_address,
+                comptime { FunctionSelector::from_signature("private_set_value(Field,(Field))") },
+                [value_to_set, owner.to_field()],
+            ),
+        );
         assert(result == value_to_set);
 
         // Read the stored value in the note.
-        let note_value = env
-            .call_private(
-                from,
-                Child::at(child_contract_address).private_get_value(value_to_set, owner),
-            )
-            .return_value;
+        let note_value = env.call_private(
+            from,
+            Child::at(child_contract_address).private_get_value(value_to_set, owner),
+        );
         assert(note_value == value_to_set);
 
         // Get value from child through parent
-        let read_result = env
-            .call_private(
-                from,
-                Parent::at(parent_contract_address).private_call(
-                    child_contract_address,
-                    comptime {
-                        FunctionSelector::from_signature("private_get_value(Field,(Field))")
-                    },
-                    [7, owner.to_field()],
-                ),
-            )
-            .return_value;
+        let read_result = env.call_private(
+            from,
+            Parent::at(parent_contract_address).private_call(
+                child_contract_address,
+                comptime { FunctionSelector::from_signature("private_get_value(Field,(Field))") },
+                [7, owner.to_field()],
+            ),
+        );
         assert(note_value == read_result);
     }
 }

--- a/noir-projects/noir-contracts/contracts/test/public_immutable_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/public_immutable_contract/src/main.nr
@@ -49,14 +49,13 @@ mod tests {
 
         // set x to 10
         let x = 10;
-        let _ = env.call_public(contract_address, test_contract.initialize_value(x));
+        env.call_public(contract_address, test_contract.initialize_value(x));
 
         // We advance block to commit state and have the nullifier available for reading.
         env.mine_block();
 
         // Read value and verify it matches
-        let result = env.call_public(contract_address, test_contract.read_value());
-        assert(result.return_value == x);
+        assert_eq(env.call_public(contract_address, test_contract.read_value()), x);
     }
 
     #[test(should_fail)] // should_fail_with = "Trying to read from uninitialized PublicImmutable"
@@ -75,10 +74,12 @@ mod tests {
         let (env, contract_address) = setup();
 
         // Try to read uninitialized value - this should return 0 as it is the default public storage value
-        let result = env.call_public(
-            contract_address,
-            PublicImmutableContract::at(contract_address).read_value_unsafe(),
+        assert_eq(
+            env.call_public(
+                contract_address,
+                PublicImmutableContract::at(contract_address).read_value_unsafe(),
+            ),
+            0,
         );
-        assert(result.return_value == 0);
     }
 }

--- a/noir-projects/noir-contracts/contracts/test/test_contract/src/test/note_delivery.nr
+++ b/noir-projects/noir-contracts/contracts/test/test_contract/src/test/note_delivery.nr
@@ -25,15 +25,16 @@ unconstrained fn create_note_private_only_tx_and_read_in_private() {
     let test_contract = Test::at(contract_address);
 
     let make_tx_hybrid = false;
-    let _ = env.call_private(
+    env.call_private(
         sender,
         test_contract.call_create_note(VALUE, recipient, STORAGE_SLOT, make_tx_hybrid),
     );
 
     // The 'from' param is irrelevant in this case
-    let retrieved = env
-        .call_private(recipient, test_contract.call_get_notes(STORAGE_SLOT, ACTIVE_OR_NULLIFIED))
-        .return_value;
+    let retrieved = env.call_private(
+        recipient,
+        test_contract.call_get_notes(STORAGE_SLOT, ACTIVE_OR_NULLIFIED),
+    );
     assert_eq(retrieved, VALUE);
 }
 
@@ -43,7 +44,7 @@ unconstrained fn create_note_private_only_tx_and_read_in_utility() {
     let test_contract = Test::at(contract_address);
 
     let make_tx_hybrid = false;
-    let _ = env.call_private(
+    env.call_private(
         sender,
         test_contract.call_create_note(VALUE, recipient, STORAGE_SLOT, make_tx_hybrid),
     );
@@ -61,15 +62,16 @@ unconstrained fn create_note_hybrid_tx_and_read_in_private() {
     let test_contract = Test::at(contract_address);
 
     let make_tx_hybrid = true;
-    let _ = env.call_private(
+    env.call_private(
         sender,
         test_contract.call_create_note(VALUE, recipient, STORAGE_SLOT, make_tx_hybrid),
     );
 
     // The 'from' param is irrelevant in this case
-    let retrieved = env
-        .call_private(recipient, test_contract.call_get_notes(STORAGE_SLOT, ACTIVE_OR_NULLIFIED))
-        .return_value;
+    let retrieved = env.call_private(
+        recipient,
+        test_contract.call_get_notes(STORAGE_SLOT, ACTIVE_OR_NULLIFIED),
+    );
     assert_eq(retrieved, VALUE);
 }
 
@@ -79,7 +81,7 @@ unconstrained fn create_note_hybrid_tx_and_read_in_utility() {
     let test_contract = Test::at(contract_address);
 
     let make_tx_hybrid = true;
-    let _ = env.call_private(
+    env.call_private(
         sender,
         test_contract.call_create_note(VALUE, recipient, STORAGE_SLOT, make_tx_hybrid),
     );
@@ -96,15 +98,16 @@ unconstrained fn create_partial_note_in_one_tx_and_read_in_private() {
     let (env, contract_address, sender, recipient) = setup();
     let test_contract = Test::at(contract_address);
 
-    let _ = env.call_private(
+    env.call_private(
         sender,
         test_contract.call_create_and_complete_partial_note(recipient, STORAGE_SLOT, VALUE),
     );
 
     // The 'from' param is irrelevant in this case
-    let retrieved = env
-        .call_private(recipient, test_contract.call_get_notes(STORAGE_SLOT, ACTIVE_OR_NULLIFIED))
-        .return_value;
+    let retrieved = env.call_private(
+        recipient,
+        test_contract.call_get_notes(STORAGE_SLOT, ACTIVE_OR_NULLIFIED),
+    );
     assert_eq(retrieved, VALUE);
 }
 
@@ -113,7 +116,7 @@ unconstrained fn create_partial_note_in_one_tx_and_read_in_utility() {
     let (env, contract_address, sender, recipient) = setup();
     let test_contract = Test::at(contract_address);
 
-    let _ = env.call_private(
+    env.call_private(
         sender,
         test_contract.call_create_and_complete_partial_note(recipient, STORAGE_SLOT, VALUE),
     );
@@ -130,16 +133,16 @@ unconstrained fn create_partial_note_in_two_txs_and_read_in_private() {
     let (env, contract_address, sender, recipient) = setup();
     let test_contract = Test::at(contract_address);
 
-    let partial_note = env
-        .call_private(sender, test_contract.call_create_partial_note(recipient, STORAGE_SLOT))
-        .return_value;
+    let partial_note =
+        env.call_private(sender, test_contract.call_create_partial_note(recipient, STORAGE_SLOT));
 
-    let _ = env.call_public(sender, test_contract.call_complete_partial_note(partial_note, VALUE));
+    env.call_public(sender, test_contract.call_complete_partial_note(partial_note, VALUE));
 
     // The 'from' param is irrelevant in this case
-    let retrieved = env
-        .call_private(recipient, test_contract.call_get_notes(STORAGE_SLOT, ACTIVE_OR_NULLIFIED))
-        .return_value;
+    let retrieved = env.call_private(
+        recipient,
+        test_contract.call_get_notes(STORAGE_SLOT, ACTIVE_OR_NULLIFIED),
+    );
     assert_eq(retrieved, VALUE);
 }
 
@@ -148,11 +151,10 @@ unconstrained fn create_partial_note_in_two_txs_and_read_in_utility() {
     let (env, contract_address, sender, recipient) = setup();
     let test_contract = Test::at(contract_address);
 
-    let partial_note = env
-        .call_private(sender, test_contract.call_create_partial_note(recipient, STORAGE_SLOT))
-        .return_value;
+    let partial_note =
+        env.call_private(sender, test_contract.call_create_partial_note(recipient, STORAGE_SLOT));
 
-    let _ = env.call_public(sender, test_contract.call_complete_partial_note(partial_note, VALUE));
+    env.call_public(sender, test_contract.call_complete_partial_note(partial_note, VALUE));
 
     let retrieved = env.simulate_utility(test_contract._experimental_call_view_notes(
         STORAGE_SLOT,


### PR DESCRIPTION
Its existence only allowed for retrieving the tx hash, which we've never used (and we'll have a method for the last tx hash soon anyway), and forced all callsites to handle a return value. This was a bit of a no brainer.