### PR TITLE
chore: Add custom eslint rule to prevent non-primitive collections

### DIFF
--- a/yarn-project/ethereum/src/test/chain_monitor.ts
+++ b/yarn-project/ethereum/src/test/chain_monitor.ts
@@ -19,6 +19,7 @@ export class ChainMonitor extends EventEmitter<ChainMonitorEventMap> {
   private readonly l1Client: ViemClient;
   private inbox: InboxContract | undefined;
   private handle: NodeJS.Timeout | undefined;
+  // eslint-disable-next-line aztec-custom/no-non-primitive-in-collections
   private running: Set<Promise<void>> = new Set();
 
   /** Current L1 block number */

--- a/yarn-project/foundation/eslint-rules/no-non-primitive-in-collections.js
+++ b/yarn-project/foundation/eslint-rules/no-non-primitive-in-collections.js
@@ -1,0 +1,239 @@
+// @ts-check
+import * as ts from 'typescript';
+
+/**
+ * @fileoverview Rule to disallow non-primitive types in Set<T> and Map<T, ...> collections
+ */
+
+/** @type {import('eslint').Rule.RuleModule} */
+export default {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Disallow non-primitive types in Set<T> and Map<T, ...> collections',
+      category: 'Best Practices',
+      recommended: true,
+    },
+    messages: {
+      nonPrimitiveInSet: 'Set should only be used with primitive types. Found Set<{{type}}>',
+      nonPrimitiveInMapKey: 'Map keys should only be primitive types. Found Map<{{type}}, ...>',
+    },
+    schema: [],
+  },
+
+  create(context) {
+    // Get TypeScript type services
+    let parserServices = null;
+    let checker = null;
+
+    try {
+      // @ts-expect-error parserServices might not be defined in all contexts
+      parserServices =
+        context.parserServices || context.sourceCode?.parserServices || context.getSourceCode()?.parserServices;
+
+      if (parserServices?.program && parserServices?.esTreeNodeToTSNodeMap) {
+        checker = parserServices.program.getTypeChecker();
+      }
+    } catch (e) {
+      // TypeScript services not available, fall back to AST-only checking
+    }
+
+    /**
+     * Check if a TypeScript type is allowed (using type checker)
+     */
+    function isAllowedTypeWithChecker(tsType) {
+      if (!tsType) return false;
+
+      // Check for primitive types
+      const flags = tsType.getFlags();
+      const primitiveFlags =
+        ts.TypeFlags.String |
+        ts.TypeFlags.Number |
+        ts.TypeFlags.BigInt |
+        ts.TypeFlags.Boolean |
+        ts.TypeFlags.Undefined |
+        ts.TypeFlags.Null |
+        ts.TypeFlags.ESSymbol |
+        ts.TypeFlags.Any |
+        ts.TypeFlags.Unknown |
+        ts.TypeFlags.Never |
+        ts.TypeFlags.Void;
+
+      if (flags & primitiveFlags) {
+        return true;
+      }
+
+      // Check for literal types (string literals, number literals, etc.)
+      if (flags & ts.TypeFlags.Literal) {
+        return true;
+      }
+
+      // Check for enums
+      if (flags & ts.TypeFlags.Enum) {
+        return true;
+      }
+
+      // Check for enum literal types
+      if (flags & ts.TypeFlags.EnumLiteral) {
+        return true;
+      }
+
+      // Check for type parameters (generics)
+      if (flags & ts.TypeFlags.TypeParameter) {
+        return true;
+      }
+
+      // Check for union types - all members must be allowed
+      if (flags & ts.TypeFlags.Union) {
+        if (tsType.isUnion && tsType.isUnion()) {
+          return tsType.types.every(t => isAllowedTypeWithChecker(t));
+        }
+      }
+
+      return false;
+    }
+
+    /**
+     * Fallback: Check if a type node represents a primitive type (AST-only)
+     * This is only used if TypeScript type checker is not available
+     */
+    function isPrimitiveTypeNodeFallback(typeNode) {
+      if (!typeNode) return false;
+
+      switch (typeNode.type) {
+        case 'TSStringKeyword':
+        case 'TSNumberKeyword':
+        case 'TSBigIntKeyword':
+        case 'TSBooleanKeyword':
+        case 'TSSymbolKeyword':
+        case 'TSUndefinedKeyword':
+        case 'TSNullKeyword':
+        case 'TSAnyKeyword':
+        case 'TSUnknownKeyword':
+        case 'TSVoidKeyword':
+        case 'TSNeverKeyword':
+          return true;
+
+        case 'TSTypeParameter':
+          return true;
+
+        case 'TSLiteralType':
+        case 'TSTemplateLiteralType':
+          return true;
+
+        case 'TSUnionType':
+          return typeNode.types.every(t => isPrimitiveTypeNodeFallback(t));
+
+        case 'TSTypeReference':
+          if (typeNode.typeName && typeNode.typeName.type === 'Identifier') {
+            const name = typeNode.typeName.name;
+
+            // Single uppercase letters (type parameters)
+            if (name.length === 1 && name === name.toUpperCase()) {
+              return true;
+            }
+
+            // Basic primitive type names
+            const primitives = ['string', 'number', 'bigint', 'boolean', 'symbol', 'undefined', 'null'];
+            if (primitives.includes(name)) {
+              return true;
+            }
+          }
+          return false;
+
+        default:
+          return false;
+      }
+    }
+
+    /**
+     * Get a readable type name from a type node
+     */
+    function getTypeName(typeNode) {
+      if (!typeNode) return 'unknown';
+
+      try {
+        const sourceCode = context.getSourceCode();
+        return sourceCode.getText(typeNode);
+      } catch (e) {
+        return 'unknown';
+      }
+    }
+
+    return {
+      TSTypeReference(node) {
+        if (!node.typeName || node.typeName.type !== 'Identifier') {
+          return;
+        }
+
+        const typeName = node.typeName.name;
+
+        // Check for Set<T>
+        if (typeName === 'Set' && node.typeArguments?.params?.length > 0) {
+          const typeParam = node.typeArguments.params[0];
+          let isAllowed = false;
+          let typeStr = getTypeName(typeParam);
+
+          // Use type checker if available
+          if (checker && parserServices) {
+            try {
+              const tsNode = parserServices.esTreeNodeToTSNodeMap.get(typeParam);
+              const tsType = checker.getTypeAtLocation(tsNode);
+              isAllowed = isAllowedTypeWithChecker(tsType);
+              typeStr = checker.typeToString(tsType);
+            } catch (e) {
+              // Fall back to AST checking
+              isAllowed = isPrimitiveTypeNodeFallback(typeParam);
+            }
+          } else {
+            // Use AST-only checking as fallback
+            isAllowed = isPrimitiveTypeNodeFallback(typeParam);
+          }
+
+          if (!isAllowed) {
+            context.report({
+              node,
+              messageId: 'nonPrimitiveInSet',
+              data: {
+                type: typeStr,
+              },
+            });
+          }
+        }
+
+        // Check for Map<K, V>
+        if (typeName === 'Map' && node.typeArguments?.params?.length > 0) {
+          const keyTypeParam = node.typeArguments.params[0];
+          let isAllowed = false;
+          let typeStr = getTypeName(keyTypeParam);
+
+          // Use type checker if available
+          if (checker && parserServices) {
+            try {
+              const tsNode = parserServices.esTreeNodeToTSNodeMap.get(keyTypeParam);
+              const tsType = checker.getTypeAtLocation(tsNode);
+              isAllowed = isAllowedTypeWithChecker(tsType);
+              typeStr = checker.typeToString(tsType);
+            } catch (e) {
+              // Fall back to AST checking
+              isAllowed = isPrimitiveTypeNodeFallback(keyTypeParam);
+            }
+          } else {
+            // Use AST-only checking as fallback
+            isAllowed = isPrimitiveTypeNodeFallback(keyTypeParam);
+          }
+
+          if (!isAllowed) {
+            context.report({
+              node,
+              messageId: 'nonPrimitiveInMapKey',
+              data: {
+                type: typeStr,
+              },
+            });
+          }
+        }
+      },
+    };
+  },
+};

--- a/yarn-project/foundation/eslint-rules/no-non-primitive-in-collections.js
+++ b/yarn-project/foundation/eslint-rules/no-non-primitive-in-collections.js
@@ -68,6 +68,16 @@ export default {
         return true;
       }
 
+      // Check for template literal types (e.g., `0x${string}`)
+      if (flags & ts.TypeFlags.TemplateLiteral) {
+        return true;
+      }
+
+      // Check for string mapping types (template literal patterns)
+      if (flags & ts.TypeFlags.StringMapping) {
+        return true;
+      }
+
       // Check for enums
       if (flags & ts.TypeFlags.Enum) {
         return true;

--- a/yarn-project/foundation/eslint.config.js
+++ b/yarn-project/foundation/eslint.config.js
@@ -8,6 +8,8 @@ import { globalIgnores } from 'eslint/config';
 import globals from 'globals';
 import tseslint from 'typescript-eslint';
 
+import noNonPrimitiveInCollections from './eslint-rules/no-non-primitive-in-collections.js';
+
 export default [
   globalIgnores([
     '**/node_modules/**',
@@ -47,6 +49,11 @@ export default [
       tsdoc,
       'no-only-tests': noOnlyTests,
       importPlugin,
+      'aztec-custom': {
+        rules: {
+          'no-non-primitive-in-collections': noNonPrimitiveInCollections,
+        },
+      },
     },
     rules: {
       // Disabled rules
@@ -106,6 +113,7 @@ export default [
       'import/no-extraneous-dependencies': 'error',
       // this unfortunately doesn't block `fit` and `fdescribe`
       'no-only-tests/no-only-tests': ['error'],
+      'aztec-custom/no-non-primitive-in-collections': 'error',
     },
   }),
   {

--- a/yarn-project/foundation/src/async-pool/index.ts
+++ b/yarn-project/foundation/src/async-pool/index.ts
@@ -29,6 +29,7 @@
 export function asyncPool<T, R>(poolLimit: number, iterable: T[], iteratorFn: (item: T, iterable: T[]) => Promise<R>) {
   let i = 0;
   const ret: Promise<R>[] = [];
+  // eslint-disable-next-line aztec-custom/no-non-primitive-in-collections
   const executing: Set<Promise<R>> = new Set();
   const enqueue = (): Promise<any> => {
     if (i === iterable.length) {

--- a/yarn-project/p2p/src/services/reqresp/connection-sampler/connection_sampler.test.ts
+++ b/yarn-project/p2p/src/services/reqresp/connection-sampler/connection_sampler.test.ts
@@ -8,7 +8,7 @@ import { type MockProxy, mock } from 'jest-mock-extended';
 import { ConnectionSampler, type RandomSampler } from './connection_sampler.js';
 
 describe('ConnectionSampler', () => {
-  let sampler: ConnectionSampler;
+  let sampler: TestConnectionSampler;
   let mockLibp2p: any;
   let peers: PeerId[];
   let excluding: Map<string, boolean>;
@@ -27,7 +27,7 @@ describe('ConnectionSampler', () => {
     mockRandomSampler = mock<RandomSampler>();
     mockRandomSampler.random.mockReturnValue(0);
 
-    sampler = new ConnectionSampler(mockLibp2p, mockRandomSampler, undefined, { cleanupIntervalMs: 500 });
+    sampler = new TestConnectionSampler(mockLibp2p, mockRandomSampler, undefined, { cleanupIntervalMs: 500 });
     excluding = new Map();
   });
 
@@ -40,8 +40,8 @@ describe('ConnectionSampler', () => {
       id,
       status: 'open',
       metadata: {},
-      close: jest.fn().mockImplementation(() => Promise.resolve()),
-    }) as Partial<Stream>;
+      close: jest.fn<Stream['close']>().mockImplementation(() => Promise.resolve()) as () => Promise<void>,
+    }) as Stream;
 
   describe('getPeer', () => {
     it('returns a random peer from the list', () => {
@@ -98,15 +98,15 @@ describe('ConnectionSampler', () => {
       expect(stream).toBe(mockStream);
 
       // Verify internal state
-      expect((sampler as any).activeConnectionsCount.get(peers[0])).toBe(1);
-      expect((sampler as any).streams.has(mockStream)).toBe(true);
+      expect(sampler.activeConnectionsCount.get(peers[0].toString())).toBe(1);
+      expect(sampler.streams.has(mockStream)).toBe(true);
 
       // Close connection
       await sampler.close(stream);
 
       // Verify cleanup
-      expect((sampler as any).activeConnectionsCount.get(peers[0])).toBe(0);
-      expect((sampler as any).streams.has(mockStream)).toBe(false);
+      expect(sampler.activeConnectionsCount.get(peers[0].toString())).toBe(0);
+      expect(sampler.streams.has(mockStream)).toBe(false);
       expect(mockStream.close).toHaveBeenCalled();
     });
 
@@ -119,13 +119,13 @@ describe('ConnectionSampler', () => {
       await sampler.dialProtocol(peers[0], 'test');
       await sampler.dialProtocol(peers[0], 'test');
 
-      expect((sampler as any).activeConnectionsCount.get(peers[0])).toBe(2);
+      expect(sampler.activeConnectionsCount.get(peers[0].toString())).toBe(2);
 
       await sampler.close(mockStream1 as Stream);
-      expect((sampler as any).activeConnectionsCount.get(peers[0])).toBe(1);
+      expect(sampler.activeConnectionsCount.get(peers[0].toString())).toBe(1);
 
       await sampler.close(mockStream2 as Stream);
-      expect((sampler as any).activeConnectionsCount.get(peers[0])).toBe(0);
+      expect(sampler.activeConnectionsCount.get(peers[0].toString())).toBe(0);
     });
 
     it('handles errors during connection close', async () => {
@@ -137,8 +137,8 @@ describe('ConnectionSampler', () => {
       await sampler.close(mockStream as Stream);
 
       // Should still clean up internal state even if close fails
-      expect((sampler as any).activeConnectionsCount.get(peers[0])).toBe(0);
-      expect((sampler as any).streams.has(mockStream)).toBe(false);
+      expect(sampler.activeConnectionsCount.get(peers[0].toString())).toBe(0);
+      expect(sampler.streams.has(mockStream)).toBe(false);
     });
 
     it('does not accidentally close a stream for another peer', async () => {
@@ -167,13 +167,13 @@ describe('ConnectionSampler', () => {
       await sampler.dialProtocol(peers[0], 'test');
 
       // Manually set activeConnectionsCount to 0 to simulate lost accounting
-      (sampler as any).activeConnectionsCount.set(peers[0], 0);
+      sampler.activeConnectionsCount.set(peers[0].toString(), 0);
 
       // Trigger cleanup
       await sleep(600);
 
       expect(mockStream.close).toHaveBeenCalled();
-      expect((sampler as any).streams.has(mockStream)).toBe(false);
+      expect(sampler.streams.has(mockStream)).toBe(false);
     });
 
     it('properly cleans up on stop', async () => {
@@ -189,7 +189,7 @@ describe('ConnectionSampler', () => {
 
       expect(mockStream1.close).toHaveBeenCalled();
       expect(mockStream2.close).toHaveBeenCalled();
-      expect((sampler as any).streams.size).toBe(0);
+      expect(sampler.streams.size).toBe(0);
     });
   });
 
@@ -206,7 +206,7 @@ describe('ConnectionSampler', () => {
 
       mockRandomSampler = mock<RandomSampler>();
       mockRandomSampler.random.mockReturnValue(0);
-      sampler = new ConnectionSampler(mockLibp2p, mockRandomSampler, undefined, { cleanupIntervalMs: 1000 });
+      sampler = new TestConnectionSampler(mockLibp2p, mockRandomSampler, undefined, { cleanupIntervalMs: 1000 });
     });
 
     it('should only return samples as many peers as available', () => {
@@ -223,8 +223,8 @@ describe('ConnectionSampler', () => {
         .mockReturnValue(0);
 
       // Set up some peers with active connections
-      sampler['activeConnectionsCount'].set(peers[3], 1);
-      sampler['activeConnectionsCount'].set(peers[4], 2);
+      sampler['activeConnectionsCount'].set(peers[3].toString(), 1);
+      sampler['activeConnectionsCount'].set(peers[4].toString(), 2);
 
       // Sample 3 peers
       const sampledPeers = sampler.samplePeersBatch(3);
@@ -241,10 +241,10 @@ describe('ConnectionSampler', () => {
 
     it('falls back to peers with connections when needed', () => {
       // Set up most peers with active connections
-      sampler['activeConnectionsCount'].set(peers[1], 1);
-      sampler['activeConnectionsCount'].set(peers[2], 1);
-      sampler['activeConnectionsCount'].set(peers[3], 1);
-      sampler['activeConnectionsCount'].set(peers[4], 1);
+      sampler['activeConnectionsCount'].set(peers[1].toString(), 1);
+      sampler['activeConnectionsCount'].set(peers[2].toString(), 1);
+      sampler['activeConnectionsCount'].set(peers[3].toString(), 1);
+      sampler['activeConnectionsCount'].set(peers[4].toString(), 1);
 
       mockRandomSampler.random.mockReturnValue(0); // Always pick first available peer
 
@@ -258,7 +258,7 @@ describe('ConnectionSampler', () => {
 
     it('handles case when all peers have active connections', () => {
       // Set up all peers with active connections
-      peers.forEach(peer => sampler['activeConnectionsCount'].set(peer, 1));
+      peers.forEach(peer => sampler['activeConnectionsCount'].set(peer.toString(), 1));
 
       mockRandomSampler.random.mockReturnValue(0); // Always pick first available peer
 
@@ -298,3 +298,9 @@ describe('ConnectionSampler', () => {
     });
   });
 });
+
+class TestConnectionSampler extends ConnectionSampler {
+  declare activeConnectionsCount: Map<string, number>;
+  // eslint-disable-next-line aztec-custom/no-non-primitive-in-collections
+  declare streams: Set<Stream>;
+}

--- a/yarn-project/p2p/src/services/tx_collection/fast_tx_collection.ts
+++ b/yarn-project/p2p/src/services/tx_collection/fast_tx_collection.ts
@@ -19,7 +19,7 @@ import type { TxCollectionSink } from './tx_collection_sink.js';
 import type { TxSource } from './tx_source.js';
 
 export class FastTxCollection {
-  /** Fast collection requests */
+  // eslint-disable-next-line aztec-custom/no-non-primitive-in-collections
   protected requests: Set<FastCollectionRequest> = new Set();
 
   constructor(

--- a/yarn-project/p2p/src/services/tx_collection/tx_collection.test.ts
+++ b/yarn-project/p2p/src/services/tx_collection/tx_collection.test.ts
@@ -482,6 +482,7 @@ describe('TxCollection', () => {
 });
 
 class TestFastTxCollection extends FastTxCollection {
+  // eslint-disable-next-line aztec-custom/no-non-primitive-in-collections
   declare requests: Set<FastCollectionRequest>;
   declare collectFast: (
     request: FastCollectionRequest,

--- a/yarn-project/pxe/src/pxe_service/error_enriching.ts
+++ b/yarn-project/pxe/src/pxe_service/error_enriching.ts
@@ -19,6 +19,7 @@ export async function enrichSimulationError(
   // Maps contract addresses to the set of function selectors that were in error.
   // Map and Set do reference equality for their keys instead of value equality, so we store the string
   // representation to get e.g. different contract address objects with the same address value to match.
+  // eslint-disable-next-line aztec-custom/no-non-primitive-in-collections
   const mentionedFunctions: Map<string, Set<FunctionSelector>> = new Map();
 
   err.getCallStack().forEach(({ contractAddress, functionSelector }) => {


### PR DESCRIPTION
Adds a custom (Claude-written) eslint rule to guard against Map and Set instances created with non-primitive keys. This should help guard against bugs like [this one](https://github.com/AztecProtocol/aztec-packages/pull/16006/files#diff-88ca6c7e70feff3a05a9fd509027696db8b7f17434dd226bcadb3b8496d36a4dL90).

Also updates the connection sampler to NOT index active connection count by peer id. I haven't been able to confirm whether this was indeed a bug or not, but fixed it just in case.
