### PR TITLE
refactor: ignition propose savings

### DIFF
--- a/l1-contracts/gas_benchmark.md
+++ b/l1-contracts/gas_benchmark.md
@@ -6,7 +6,7 @@
 
 | Parameter             | Value |
 |-----------------------|-------|
-| Slot Duration         |    60 |
+| Slot Duration         |   192 |
 | Epoch Duration        |    48 |
 | Target Committee Size |    24 |
 | Mana Target           |     0 |
@@ -16,24 +16,24 @@
 
 | Function             | Avg Gas | Max Gas | Calldata Size | Calldata Gas |
 |----------------------|---------|---------|---------------|--------------|
-| propose              | 192,119 | 207,397 |         1,060 |       16,960 |
+| propose              | 152,610 | 169,137 |         1,060 |       16,960 |
 | submitEpochRootProof | 813,442 | 834,067 |         3,812 |       60,992 |
 | setupEpoch           |  40,849 | 108,446 |             - |            - |
 
-**Avg Gas Cost per Second**: 3,781.1 gas/second
-*Epoch duration*: 0h 48m 0s
+**Avg Gas Cost per Second**: 975.8 gas/second
+*Epoch duration*: 2h 33m 36s
 
 ### Validators (IGNITION)
 
 | Function             | Avg Gas | Max Gas | Calldata Size | Calldata Gas |
 |----------------------|---------|---------|---------------|--------------|
-| propose              | 250,072 | 265,515 |         2,852 |       45,632 |
-| submitEpochRootProof | 923,880 | 944,511 |         5,092 |       81,472 |
-| aggregate3           | 297,537 | 316,779 |             - |            - |
+| propose              | 210,546 | 227,246 |         2,852 |       45,632 |
+| submitEpochRootProof | 923,838 | 944,451 |         5,092 |       81,472 |
+| aggregate3           | 258,011 | 281,827 |             - |            - |
 | setupEpoch           |  48,233 | 354,577 |             - |            - |
 
-**Avg Gas Cost per Second**: 4,826.2 gas/second
-*Epoch duration*: 0h 48m 0s
+**Avg Gas Cost per Second**: 1,302.3 gas/second
+*Epoch duration*: 2h 33m 36s
 
 
 ## Alpha
@@ -52,22 +52,22 @@
 
 | Function             | Avg Gas | Max Gas | Calldata Size | Calldata Gas |
 |----------------------|---------|---------|---------------|--------------|
-| propose              | 230,021 | 246,987 |         1,060 |       16,960 |
+| propose              | 230,565 | 247,531 |         1,060 |       16,960 |
 | submitEpochRootProof | 686,752 | 725,612 |         3,812 |       60,992 |
 | setupEpoch           |  42,024 | 110,967 |             - |            - |
 
-**Avg Gas Cost per Second**: 7,618.2 gas/second
+**Avg Gas Cost per Second**: 7,633.3 gas/second
 *Epoch duration*: 0h 19m 12s
 
 ### Validators (Alpha)
 
 | Function             | Avg Gas | Max Gas | Calldata Size | Calldata Gas |
 |----------------------|---------|---------|---------------|--------------|
-| propose              | 337,105 | 355,679 |         4,580 |       73,280 |
+| propose              | 337,661 | 356,235 |         4,580 |       73,280 |
 | submitEpochRootProof | 894,446 | 932,423 |         6,308 |      100,928 |
-| aggregate3           | 389,549 | 411,347 |             - |            - |
+| aggregate3           | 390,106 | 411,903 |             - |            - |
 | setupEpoch           |  61,573 | 599,674 |             - |            - |
 
-**Avg Gas Cost per Second**: 10,970.3 gas/second
+**Avg Gas Cost per Second**: 10,985.8 gas/second
 *Epoch duration*: 0h 19m 12s
 

--- a/l1-contracts/gas_benchmark_results.json
+++ b/l1-contracts/gas_benchmark_results.json
@@ -3,10 +3,10 @@
     "no_validators": {
       "propose": {
         "calls": 100,
-        "min": 184955,
-        "mean": 192119,
-        "median": 191501,
-        "max": 207397,
+        "min": 149582,
+        "mean": 152610,
+        "median": 152392,
+        "max": 169137,
         "calldata_size": 1060,
         "calldata_gas": 16960
       },
@@ -30,10 +30,10 @@
     "validators": {
       "propose": {
         "calls": 100,
-        "min": 240190,
-        "mean": 250072,
-        "median": 250717,
-        "max": 265515,
+        "min": 204044,
+        "mean": 210546,
+        "median": 209888,
+        "max": 227246,
         "calldata_size": 2852,
         "calldata_gas": 45632
       },
@@ -46,19 +46,19 @@
       },
       "submitEpochRootProof": {
         "calls": 2,
-        "min": 903249,
-        "mean": 923880,
-        "median": 923880,
-        "max": 944511,
+        "min": 903225,
+        "mean": 923838,
+        "median": 923838,
+        "max": 944451,
         "calldata_size": 5092,
         "calldata_gas": 81472
       },
       "aggregate3": {
         "calls": 100,
-        "min": 285659,
-        "mean": 297537,
-        "median": 294826,
-        "max": 316779
+        "min": 247366,
+        "mean": 258011,
+        "median": 255716,
+        "max": 281827
       }
     }
   },
@@ -66,10 +66,10 @@
     "no_validators": {
       "propose": {
         "calls": 100,
-        "min": 221051,
-        "mean": 230021,
-        "median": 229305,
-        "max": 246987,
+        "min": 221595,
+        "mean": 230565,
+        "median": 229850,
+        "max": 247531,
         "calldata_size": 1060,
         "calldata_gas": 16960
       },
@@ -93,10 +93,10 @@
     "validators": {
       "propose": {
         "calls": 100,
-        "min": 322686,
-        "mean": 337105,
-        "median": 336752,
-        "max": 355679,
+        "min": 323242,
+        "mean": 337661,
+        "median": 337308,
+        "max": 356235,
         "calldata_size": 4580,
         "calldata_gas": 73280
       },
@@ -118,10 +118,10 @@
       },
       "aggregate3": {
         "calls": 100,
-        "min": 366071,
-        "mean": 389549,
-        "median": 388952,
-        "max": 411347
+        "min": 366627,
+        "mean": 390106,
+        "median": 389508,
+        "max": 411903
       }
     }
   }

--- a/l1-contracts/src/core/libraries/Errors.sol
+++ b/l1-contracts/src/core/libraries/Errors.sol
@@ -25,6 +25,7 @@ library Errors {
   error Inbox__ContentTooLarge(bytes32 content); // 0x47452014
   error Inbox__SecretHashTooLarge(bytes32 secretHash); // 0xecde7e2c
   error Inbox__MustBuildBeforeConsume(); // 0xc4901999
+  error Inbox__Ignition();
 
   // Outbox
   error Outbox__Unauthorized(); // 0x2c9490c2

--- a/l1-contracts/src/core/libraries/rollup/ProposeLib.sol
+++ b/l1-contracts/src/core/libraries/rollup/ProposeLib.sol
@@ -48,6 +48,7 @@ struct InterimProposeValues {
   bytes32 payloadDigest;
   Epoch currentEpoch;
   bool isFirstBlockOfEpoch;
+  bool isIgnition;
 }
 
 /**
@@ -95,9 +96,13 @@ library ProposeLib {
     if (STFLib.canPruneAtTime(Timestamp.wrap(block.timestamp))) {
       STFLib.prune();
     }
-    FeeLib.updateL1GasFeeOracle();
-
     InterimProposeValues memory v;
+
+    v.isIgnition = FeeLib.getManaTarget() == 0;
+    if (!v.isIgnition) {
+      // Since ignition have no TX's, we need not waste gas updating pricing oracle.
+      FeeLib.updateL1GasFeeOracle();
+    }
 
     // TODO(#13430): The below blobsHashesCommitment known as blobsHash elsewhere in the code. The name is confusingly similar to blobCommitmentsHash,
     // see comment in BlobLib.sol -> validateBlobs().
@@ -110,8 +115,11 @@ library ProposeLib {
     v.currentEpoch = Timestamp.wrap(block.timestamp).epochFromTimestamp();
     ValidatorSelectionLib.setupEpoch(v.currentEpoch);
 
-    ManaBaseFeeComponents memory components =
-      getManaBaseFeeComponentsAt(Timestamp.wrap(block.timestamp), true);
+    ManaBaseFeeComponents memory components;
+    if (!v.isIgnition) {
+      // Since ignition have no TX's, we need not waste gas computing the fee components
+      components = getManaBaseFeeComponentsAt(Timestamp.wrap(block.timestamp), true);
+    }
 
     v.payloadDigest = digest(
       ProposePayload({
@@ -149,13 +157,17 @@ library ProposeLib {
       STFLib.getBlobCommitmentsHash(blockNumber - 1), v.blobCommitments, v.isFirstBlockOfEpoch
     );
 
-    FeeHeader memory feeHeader = FeeLib.computeFeeHeader(
-      blockNumber,
-      _args.oracleInput.feeAssetPriceModifier,
-      header.totalManaUsed,
-      components.congestionCost,
-      components.proverCost
-    );
+    FeeHeader memory feeHeader;
+    if (!v.isIgnition) {
+      // Since ignition have no TX's, we need not waste gas deriving the fee header
+      feeHeader = FeeLib.computeFeeHeader(
+        blockNumber,
+        _args.oracleInput.feeAssetPriceModifier,
+        header.totalManaUsed,
+        components.congestionCost,
+        components.proverCost
+      );
+    }
 
     // Compute attestationsHash from the attestations
     v.attestationsHash = keccak256(abi.encode(_attestations));
@@ -174,14 +186,20 @@ library ProposeLib {
       })
     );
 
-    // @note  The block number here will always be >=1 as the genesis block is at 0
-    v.inHash = rollupStore.config.inbox.consume(blockNumber);
-    require(
-      header.contentCommitment.inHash == v.inHash,
-      Errors.Rollup__InvalidInHash(v.inHash, header.contentCommitment.inHash)
-    );
+    if (!v.isIgnition) {
+      // Since ignition will have no transactions there will be no method to consume or output message.
+      // Therefore we can ignore it as long as mana target is zero.
+      // Since the inbox is async, it must enforce its own check to not try to insert if ignition.
 
-    rollupStore.config.outbox.insert(blockNumber, header.contentCommitment.outHash);
+      // @note  The block number here will always be >=1 as the genesis block is at 0
+      v.inHash = rollupStore.config.inbox.consume(blockNumber);
+      require(
+        header.contentCommitment.inHash == v.inHash,
+        Errors.Rollup__InvalidInHash(v.inHash, header.contentCommitment.inHash)
+      );
+
+      rollupStore.config.outbox.insert(blockNumber, header.contentCommitment.outHash);
+    }
 
     emit IRollupCore.L2BlockProposed(blockNumber, _args.archive, v.blobHashes);
   }

--- a/l1-contracts/src/core/messagebridge/Inbox.sol
+++ b/l1-contracts/src/core/messagebridge/Inbox.sol
@@ -85,6 +85,7 @@ contract Inbox is IInbox {
       uint256(_secretHash) <= Constants.MAX_FIELD_VALUE,
       Errors.Inbox__SecretHashTooLarge(_secretHash)
     );
+    require(IRollup(ROLLUP).getManaTarget() > 0, Errors.Inbox__Ignition());
 
     // Is this the best way to read a packed struct into local variables in a single SLOAD
     // without having to use assembly and manual unpacking?

--- a/l1-contracts/test/Inbox.t.sol
+++ b/l1-contracts/test/Inbox.t.sol
@@ -26,6 +26,8 @@ contract InboxTest is Test {
   uint256 internal blockNumber = Constants.INITIAL_L2_BLOCK_NUM;
   bytes32 internal emptyTreeRoot;
 
+  uint256 internal manaTarget = 1e8;
+
   function setUp() public {
     address rollup = address(this);
     IERC20 feeAsset = new TestERC20("Fee Asset", "FA", address(this));
@@ -44,6 +46,10 @@ contract InboxTest is Test {
       secretHash: 0x3000000000000000000000000000000000000000000000000000000000000000,
       index: 0x01
     });
+  }
+
+  function getManaTarget() public view returns (uint256) {
+    return manaTarget;
   }
 
   function _divideAndRoundUp(uint256 a, uint256 b) internal pure returns (uint256) {
@@ -76,6 +82,13 @@ contract InboxTest is Test {
   modifier checkInvariant() {
     _;
     assertLt(blockNumber, inbox.getInProgress());
+  }
+
+  function testRevertIfIgnition() public {
+    manaTarget = 0;
+
+    vm.expectRevert(Errors.Inbox__Ignition.selector);
+    inbox.sendL2Message(DataStructures.L2Actor({actor: 0, version: version}), 0, 0);
   }
 
   function testRevertIfNotConsumingFromRollup() public {

--- a/l1-contracts/test/base/RollupBase.sol
+++ b/l1-contracts/test/base/RollupBase.sol
@@ -255,6 +255,11 @@ contract RollupBase is DecoderBase {
   }
 
   function _populateInbox(address _sender, bytes32 _recipient, bytes32[] memory _contents) internal {
+    if (rollup.getManaTarget() == 0) {
+      // If we are in ignition, we cannot populate the inbox.
+      return;
+    }
+
     inbox = Inbox(address(rollup.getInbox()));
     uint256 version = rollup.getVersion();
 

--- a/l1-contracts/test/benchmark/happy.t.sol
+++ b/l1-contracts/test/benchmark/happy.t.sol
@@ -191,7 +191,7 @@ contract BenchmarkRollupTest is FeeModelTestPoints, DecoderBase {
     if (vm.envOr("IGNITION", false)) {
       full = load("empty_block_1");
 
-      SLOT_DURATION = 60;
+      SLOT_DURATION = 16 * 12;
       EPOCH_DURATION = 48;
       MANA_TARGET = 0;
       TARGET_COMMITTEE_SIZE = 24;


### PR DESCRIPTION
Given that ignition do not have transactions, there are a plethora of computation that can be completely skipped during the `propose` in order to reduce the gas costs.

- Need not update the gas oracle
- Need not compute the fees components
- Need not derive the fee header (since it is only used in fee computation, which is useless without txs)
- Need not fetch messages from inbox (because it will be impossible to consume)
- Need not insert messages into the outbox (because there will never be a message)

Note that since messages are inserted into the inbox independently from block production, we will add another check in the inbox to ensure that messages will not be inserted into a rollup that would not be able to consume them, e.g., revert if mana limit is 0.

## IGNITION

### Configuration

| Parameter             | Value |
|-----------------------|-------|
| Slot Duration         |   192 |
| Epoch Duration        |    48 |
| Target Committee Size |    24 |
| Mana Target           |     0 |
| Proofs per Epoch      |  2.00 |

### No Validators (IGNITION)

| Function             | Avg Gas | Max Gas | Calldata Size | Calldata Gas |
|----------------------|---------|---------|---------------|--------------|
| propose              | 152,610 | 169,137 |         1,060 |       16,960 |
| submitEpochRootProof | 813,442 | 834,067 |         3,812 |       60,992 |
| setupEpoch           |  40,849 | 108,446 |             - |            - |

**Avg Gas Cost per Second**: 975.8 gas/second
*Epoch duration*: 2h 33m 36s

### Validators (IGNITION)

| Function             | Avg Gas | Max Gas | Calldata Size | Calldata Gas |
|----------------------|---------|---------|---------------|--------------|
| propose              | 210,546 | 227,246 |         2,852 |       45,632 |
| submitEpochRootProof | 923,838 | 944,451 |         5,092 |       81,472 |
| aggregate3           | 258,011 | 281,827 |             - |            - |
| setupEpoch           |  48,233 | 354,577 |             - |            - |

**Avg Gas Cost per Second**: 1,302.3 gas/second
*Epoch duration*: 2h 33m 36s
