### PR TITLE
chore: Package inputs to Merge verifier into a single struct

### DIFF
--- a/barretenberg/cpp/src/barretenberg/boomerang_value_detection/graph_description_goblin.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/boomerang_value_detection/graph_description_goblin.test.cpp
@@ -23,17 +23,16 @@ class BoomerangGoblinRecursiveVerifierTests : public testing::Test {
     using OuterDeciderProvingKey = DeciderProvingKey_<OuterFlavor>;
 
     using Commitment = MergeVerifier::Commitment;
-    using TableCommitment = MergeVerifier::TableCommitments;
+    using MergeCommitments = MergeVerifier::InputCommitments;
     using RecursiveCommitment = GoblinRecursiveVerifier::MergeVerifier::Commitment;
-    using RecursiveTableCommitment = GoblinRecursiveVerifier::MergeVerifier::TableCommitments;
+    using RecursiveMergeCommitments = GoblinRecursiveVerifier::MergeVerifier::InputCommitments;
 
     static void SetUpTestSuite() { bb::srs::init_file_crs_factory(bb::srs::bb_crs_path()); }
 
     struct ProverOutput {
         GoblinProof proof;
         Goblin::VerificationKey verifier_input;
-        TableCommitment t_commitments;
-        TableCommitment T_prev_commitments;
+        MergeCommitments merge_commitments;
     };
 
     /**
@@ -60,21 +59,19 @@ class BoomerangGoblinRecursiveVerifierTests : public testing::Test {
         GoblinMockCircuits::construct_simple_circuit(builder);
         goblin_final.op_queue->merge();
         // Subtable values and commitments - needed for (Recursive)MergeVerifier
-        TableCommitment t_commitments;
-        TableCommitment T_prev_commitments;
+        MergeCommitments merge_commitments;
         auto t_current = goblin_final.op_queue->construct_current_ultra_ops_subtable_columns();
         auto T_prev = goblin_final.op_queue->construct_previous_ultra_ops_table_columns();
         CommitmentKey<curve::BN254> pcs_commitment_key(goblin_final.op_queue->get_ultra_ops_table_num_rows());
         for (size_t idx = 0; idx < MegaFlavor::NUM_WIRES; idx++) {
-            t_commitments[idx] = pcs_commitment_key.commit(t_current[idx]);
-            T_prev_commitments[idx] = pcs_commitment_key.commit(T_prev[idx]);
+            merge_commitments.t_commitments[idx] = pcs_commitment_key.commit(t_current[idx]);
+            merge_commitments.T_prev_commitments[idx] = pcs_commitment_key.commit(T_prev[idx]);
         }
 
         // Output is a goblin proof plus ECCVM/Translator verification keys
         return { goblin_final.prove(),
                  { std::make_shared<ECCVMVK>(), std::make_shared<TranslatorVK>() },
-                 t_commitments,
-                 T_prev_commitments };
+                 merge_commitments };
     }
 };
 
@@ -84,21 +81,21 @@ class BoomerangGoblinRecursiveVerifierTests : public testing::Test {
  */
 TEST_F(BoomerangGoblinRecursiveVerifierTests, graph_description_basic)
 {
-    auto [proof, verifier_input, t_commitments, T_prev_commitments] = create_goblin_prover_output();
+    auto [proof, verifier_input, merge_commitments] = create_goblin_prover_output();
 
     Builder builder;
 
     // Merge commitments
-    RecursiveTableCommitment recursive_t_commitments;
-    RecursiveTableCommitment recursive_T_prev_commitments;
+    RecursiveMergeCommitments recursive_merge_commitments;
     for (size_t idx = 0; idx < MegaFlavor::NUM_WIRES; idx++) {
-        recursive_t_commitments[idx] = RecursiveCommitment::from_witness(&builder, t_commitments[idx]);
-        recursive_T_prev_commitments[idx] = RecursiveCommitment::from_witness(&builder, T_prev_commitments[idx]);
+        recursive_merge_commitments.t_commitments[idx] =
+            RecursiveCommitment::from_witness(&builder, merge_commitments.t_commitments[idx]);
+        recursive_merge_commitments.T_prev_commitments[idx] =
+            RecursiveCommitment::from_witness(&builder, merge_commitments.T_prev_commitments[idx]);
     }
 
     GoblinRecursiveVerifier verifier{ &builder, verifier_input };
-    GoblinRecursiveVerifierOutput output =
-        verifier.verify(proof, recursive_t_commitments, recursive_T_prev_commitments);
+    GoblinRecursiveVerifierOutput output = verifier.verify(proof, recursive_merge_commitments);
     output.points_accumulator.set_public();
     // Construct and verify a proof for the Goblin Recursive Verifier circuit
     {

--- a/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.cpp
+++ b/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.cpp
@@ -98,15 +98,15 @@ std::pair<ClientIVC::PairingPoints, ClientIVC::TableCommitments> ClientIVC::
         const TableCommitments& T_prev_commitments,
         const std::shared_ptr<RecursiveTranscript>& accumulation_recursive_transcript)
 {
+    using MergeCommitments = Goblin::MergeRecursiveVerifier::InputCommitments;
+
     // Witness commitments and public inputs corresponding to the incoming instance
     WitnessCommitments witness_commitments;
     std::vector<StdlibFF> public_inputs;
 
-    // Commitments to the previous status of the op_queue, to be finalized according to the recursive verification we
-    // are performing
-    // TODO(https://github.com/AztecProtocol/barretenberg/issues/1492): Change Merge verifier API and improve the name
-    // of the following variable.
-    TableCommitments finalised_T_prev_commitments = T_prev_commitments;
+    // Input commitments to be passed to the merge recursive verification
+    MergeCommitments merge_commitments;
+    merge_commitments.T_prev_commitments = T_prev_commitments;
 
     switch (verifier_inputs.type) {
     case QUEUE_TYPE::PG: {
@@ -146,7 +146,7 @@ std::pair<ClientIVC::PairingPoints, ClientIVC::TableCommitments> ClientIVC::
         public_inputs = std::move(verifier.public_inputs);
 
         // T_prev = 0 in the first recursive verification
-        finalised_T_prev_commitments = HidingKernelIO::empty_ecc_op_tables(circuit);
+        merge_commitments.T_prev_commitments = HidingKernelIO::empty_ecc_op_tables(circuit);
 
         break;
     }
@@ -173,7 +173,7 @@ std::pair<ClientIVC::PairingPoints, ClientIVC::TableCommitments> ClientIVC::
         // T_prev is read by the public input of the previous kernel K_{i-1} at the beginning of the recursive
         // verification of of the folding of K_{i-1} (kernel), A_{i,1} (app), .., A_{i, n} (app). This verification
         // happens in K_{i}
-        finalised_T_prev_commitments = kernel_input.ecc_op_tables;
+        merge_commitments.T_prev_commitments = kernel_input.ecc_op_tables;
 
         // Perform databus consistency checks
         kernel_input.kernel_return_data.assert_equal(witness_commitments.calldata);
@@ -192,11 +192,11 @@ std::pair<ClientIVC::PairingPoints, ClientIVC::TableCommitments> ClientIVC::
     }
 
     // Extract the commitments to the subtable corresponding to the incoming circuit
-    TableCommitments t_commitments = witness_commitments.get_ecc_op_wires().get_copy();
+    merge_commitments.t_commitments = witness_commitments.get_ecc_op_wires().get_copy();
 
     // Recursively verify the corresponding merge proof
-    auto [pairing_points, merged_table_commitments] = goblin.recursively_verify_merge(
-        circuit, t_commitments, finalised_T_prev_commitments, accumulation_recursive_transcript);
+    auto [pairing_points, merged_table_commitments] =
+        goblin.recursively_verify_merge(circuit, merge_commitments, accumulation_recursive_transcript);
 
     pairing_points.aggregate(nested_pairing_points);
 
@@ -381,6 +381,8 @@ std::pair<ClientIVC::PairingPoints, ClientIVC::TableCommitments> ClientIVC::comp
     const std::shared_ptr<RecursiveVKAndHash>& stdlib_vk_and_hash,
     ClientCircuit& circuit)
 {
+    using MergeCommitments = Goblin::MergeRecursiveVerifier::InputCommitments;
+
     // Shared transcript between PG and Merge
     // TODO(https://github.com/AztecProtocol/barretenberg/issues/1453): Investigate whether Decider/PG/Merge need to
     // share a transcript
@@ -421,13 +423,13 @@ std::pair<ClientIVC::PairingPoints, ClientIVC::TableCommitments> ClientIVC::comp
     kernel_input.app_return_data.assert_equal(witness_commitments.secondary_calldata);
 
     // Extract the commitments to the subtable corresponding to the incoming circuit
-    TableCommitments t_commitments = witness_commitments.get_ecc_op_wires().get_copy();
+    MergeCommitments merge_commitments;
+    merge_commitments.t_commitments = witness_commitments.get_ecc_op_wires().get_copy();
+    merge_commitments.T_prev_commitments = std::move(
+        kernel_input.ecc_op_tables); // Commitment to the status of the op_queue before folding the tail kernel
     // Perform recursive verification of the last merge proof
-    auto [points_accumulator, merged_table_commitments] = goblin.recursively_verify_merge(
-        circuit,
-        t_commitments,
-        kernel_input.ecc_op_tables, // Commitment to the status of the op_queue before folding the tail kernel
-        pg_merge_transcript);
+    auto [points_accumulator, merged_table_commitments] =
+        goblin.recursively_verify_merge(circuit, merge_commitments, pg_merge_transcript);
 
     points_accumulator.aggregate(kernel_input.pairing_inputs);
 
@@ -509,6 +511,7 @@ ClientIVC::Proof ClientIVC::prove()
 
 bool ClientIVC::verify(const Proof& proof, const VerificationKey& vk)
 {
+    using TableCommitments = Goblin::TableCommitments;
     // Create a transcript to be shared by MegaZK-, Merge-, ECCVM-, and Translator- Verifiers.
     std::shared_ptr<Goblin::Transcript> civc_verifier_transcript = std::make_shared<Goblin::Transcript>();
     // Verify the hiding circuit proof
@@ -517,12 +520,11 @@ bool ClientIVC::verify(const Proof& proof, const VerificationKey& vk)
     vinfo("Mega verified: ", mega_verified);
 
     // Extract the commitments to the subtable corresponding to the incoming circuit
-    MergeVerifier::TableCommitments t_commitments =
-        verifier.verification_key->witness_commitments.get_ecc_op_wires().get_copy();
+    TableCommitments t_commitments = verifier.verification_key->witness_commitments.get_ecc_op_wires().get_copy();
 
     // Goblin verification (final merge, eccvm, translator)
     bool goblin_verified =
-        Goblin::verify(proof.goblin_proof, t_commitments, T_prev_commitments, civc_verifier_transcript);
+        Goblin::verify(proof.goblin_proof, { t_commitments, T_prev_commitments }, civc_verifier_transcript);
     vinfo("Goblin verified: ", goblin_verified);
 
     // TODO(https://github.com/AztecProtocol/barretenberg/issues/1396): State tracking in CIVC verifiers.

--- a/barretenberg/cpp/src/barretenberg/goblin/goblin.cpp
+++ b/barretenberg/cpp/src/barretenberg/goblin/goblin.cpp
@@ -76,8 +76,7 @@ GoblinProof Goblin::prove()
 
 std::pair<Goblin::PairingPoints, Goblin::RecursiveTableCommitments> Goblin::recursively_verify_merge(
     MegaBuilder& builder,
-    const RecursiveTableCommitments& t_commitments,
-    const RecursiveTableCommitments& T_prev_commitments,
+    const RecursiveMergeCommitments& merge_commitments,
     const std::shared_ptr<RecursiveTranscript>& transcript)
 {
     ASSERT(!merge_verification_queue.empty());
@@ -87,7 +86,7 @@ std::pair<Goblin::PairingPoints, Goblin::RecursiveTableCommitments> Goblin::recu
 
     MergeRecursiveVerifier merge_verifier{ &builder, MergeSettings::PREPEND, transcript };
     auto [pairing_points, merged_table_commitments] =
-        merge_verifier.verify_proof(stdlib_merge_proof, t_commitments, T_prev_commitments);
+        merge_verifier.verify_proof(stdlib_merge_proof, merge_commitments);
 
     merge_verification_queue.pop_front(); // remove the processed proof from the queue
 
@@ -95,13 +94,11 @@ std::pair<Goblin::PairingPoints, Goblin::RecursiveTableCommitments> Goblin::recu
 }
 
 bool Goblin::verify(const GoblinProof& proof,
-                    const TableCommitments& t_commitments,
-                    const TableCommitments& T_prev_commitments,
+                    const MergeCommitments& merge_commitments,
                     const std::shared_ptr<Transcript>& transcript)
 {
     MergeVerifier merge_verifier(MergeSettings::PREPEND, transcript);
-    auto [merge_verified, merged_table_commitments] =
-        merge_verifier.verify_proof(proof.merge_proof, t_commitments, T_prev_commitments);
+    auto [merge_verified, merged_table_commitments] = merge_verifier.verify_proof(proof.merge_proof, merge_commitments);
 
     ECCVMVerifier eccvm_verifier(transcript);
     bool eccvm_verified = eccvm_verifier.verify_proof(proof.eccvm_proof);

--- a/barretenberg/cpp/src/barretenberg/goblin/goblin.hpp
+++ b/barretenberg/cpp/src/barretenberg/goblin/goblin.hpp
@@ -96,10 +96,7 @@ class Goblin {
      * @details Proofs are verified in a FIFO manner
      *
      * @param builder The circuit in which the recursive verification will be performed.
-     * @param inputs_commitments Commitments used by the verifier to run the verification algorithm. They contain the
-     * subtable commitments data, containing the commitments to t_j read from the transcript by the PG verifier with
-     * which the Merge verifier shares a transcript, and the commitments to the full op_queue table after the previous
-     * iteration of merge
+     * @param inputs_commitments The commitment used by the Merge verifier
      * @param transcript The transcript to be passed to the MergeRecursiveVerifier.
      * @return Pair of PairingPoints and commitments to the merged tables as read from the proof by the Merge verifier
      */
@@ -112,10 +109,7 @@ class Goblin {
      * @brief Verify a full Goblin proof (ECCVM, Translator, merge)
      *
      * @param proof
-     * @param inputs_commitments Commitments used by the verifier to run the verification algorithm. They contain the
-     * subtable commitments data, containing the commitments to t_j read from the transcript by the PG verifier with
-     * which the Merge verifier shares a transcript, and the commitments to the full op_queue table after the previous
-     * iteration of merge
+     * @param inputs_commitments The commitments used by the Merge verifier
      * @param merged_table_commitment The commitment to the merged table as read from the proof
      * @param transcript
      *

--- a/barretenberg/cpp/src/barretenberg/goblin/goblin.hpp
+++ b/barretenberg/cpp/src/barretenberg/goblin/goblin.hpp
@@ -40,6 +40,8 @@ class Goblin {
     using PairingPoints = MergeRecursiveVerifier::PairingPoints;
     using TableCommitments = MergeVerifier::TableCommitments;
     using RecursiveTableCommitments = MergeRecursiveVerifier::TableCommitments;
+    using MergeCommitments = MergeVerifier::InputCommitments;
+    using RecursiveMergeCommitments = MergeRecursiveVerifier::InputCommitments;
     using RecursiveCommitment = MergeRecursiveVerifier::Commitment;
     using RecursiveTranscript = bb::BaseTranscript<bb::stdlib::recursion::honk::StdlibTranscriptParams<MegaBuilder>>;
 
@@ -94,25 +96,26 @@ class Goblin {
      * @details Proofs are verified in a FIFO manner
      *
      * @param builder The circuit in which the recursive verification will be performed.
-     * @param subtable_commitments The subtable commitments data, containing the commitments to t_j read from the
-     * transcript by the PG verifier with which the Merge verifier shares a transcript
-     * @param T_prev_commitments The full op_queue table commitments after the previous iteration of merge
+     * @param inputs_commitments Commitments used by the verifier to run the verification algorithm. They contain the
+     * subtable commitments data, containing the commitments to t_j read from the transcript by the PG verifier with
+     * which the Merge verifier shares a transcript, and the commitments to the full op_queue table after the previous
+     * iteration of merge
      * @param transcript The transcript to be passed to the MergeRecursiveVerifier.
      * @return Pair of PairingPoints and commitments to the merged tables as read from the proof by the Merge verifier
      */
     std::pair<PairingPoints, RecursiveTableCommitments> recursively_verify_merge(
         MegaBuilder& builder,
-        const RecursiveTableCommitments& t_commitments,
-        const RecursiveTableCommitments& T_prev_commitments,
+        const RecursiveMergeCommitments& merge_commitments,
         const std::shared_ptr<RecursiveTranscript>& transcript);
 
     /**
      * @brief Verify a full Goblin proof (ECCVM, Translator, merge)
      *
      * @param proof
-     * @param subtable_commitments The subtable commitments data, containing the commitments to t_j read from the
-     * transcript by the PG verifier with which the Merge verifier shares a transcript
-     * @param T_prev_commitments The full op_queue table commitments after the previous iteration of merge
+     * @param inputs_commitments Commitments used by the verifier to run the verification algorithm. They contain the
+     * subtable commitments data, containing the commitments to t_j read from the transcript by the PG verifier with
+     * which the Merge verifier shares a transcript, and the commitments to the full op_queue table after the previous
+     * iteration of merge
      * @param merged_table_commitment The commitment to the merged table as read from the proof
      * @param transcript
      *
@@ -120,8 +123,7 @@ class Goblin {
      * verifier
      */
     static bool verify(const GoblinProof& proof,
-                       const TableCommitments& t_commitments,
-                       const TableCommitments& T_prev_commitments,
+                       const MergeCommitments& merge_commitments,
                        const std::shared_ptr<Transcript>& transcript);
 };
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/client_ivc_verifier/client_ivc_recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/client_ivc_verifier/client_ivc_recursive_verifier.cpp
@@ -27,12 +27,12 @@ ClientIVCRecursiveVerifier::Output ClientIVCRecursiveVerifier::verify(const Stdl
 
     // Perform Goblin recursive verification
     GoblinVerificationKey goblin_verification_key{};
-    MergeCommitments merge_commitments;
-    merge_commitments.t_commitments = verifier.key->witness_commitments.get_ecc_op_wires()
-                                          .get_copy(); // Commitments to subtables added by the hiding kernel
-    merge_commitments.T_prev_commitments = std::move(
-        mega_output
-            .ecc_op_tables); // Commitments to the state of the ecc op_queue as computed insided the hiding kernel
+    MergeCommitments merge_commitments{
+        .t_commitments = verifier.key->witness_commitments.get_ecc_op_wires()
+                             .get_copy(), // Commitments to subtables added by the hiding kernel
+        .T_prev_commitments = std::move(mega_output.ecc_op_tables) // Commitments to the state of the ecc op_queue as
+                                                                   // computed insided the hiding kernel
+    };
     GoblinVerifier goblin_verifier{ builder.get(), goblin_verification_key, civc_rec_verifier_transcript };
     GoblinRecursiveVerifierOutput output = goblin_verifier.verify(proof.goblin_proof, merge_commitments);
     output.points_accumulator.aggregate(mega_output.points_accumulator);

--- a/barretenberg/cpp/src/barretenberg/stdlib/client_ivc_verifier/client_ivc_recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/client_ivc_verifier/client_ivc_recursive_verifier.cpp
@@ -16,7 +16,7 @@ namespace bb::stdlib::recursion::honk {
  */
 ClientIVCRecursiveVerifier::Output ClientIVCRecursiveVerifier::verify(const StdlibProof& proof)
 {
-    using TableCommitments = GoblinVerifier::MergeVerifier::TableCommitments;
+    using MergeCommitments = GoblinVerifier::MergeVerifier::InputCommitments;
     std::shared_ptr<Transcript> civc_rec_verifier_transcript(std::make_shared<Transcript>());
     // Construct stdlib Mega verification key
     auto stdlib_mega_vk_and_hash = std::make_shared<RecursiveVKAndHash>(*builder, ivc_verification_key.mega);
@@ -27,14 +27,14 @@ ClientIVCRecursiveVerifier::Output ClientIVCRecursiveVerifier::verify(const Stdl
 
     // Perform Goblin recursive verification
     GoblinVerificationKey goblin_verification_key{};
-    TableCommitments t_commitments = verifier.key->witness_commitments.get_ecc_op_wires()
-                                         .get_copy(); // Commitments to subtables added by the hiding kernel
+    MergeCommitments merge_commitments;
+    merge_commitments.t_commitments = verifier.key->witness_commitments.get_ecc_op_wires()
+                                          .get_copy(); // Commitments to subtables added by the hiding kernel
+    merge_commitments.T_prev_commitments = std::move(
+        mega_output
+            .ecc_op_tables); // Commitments to the state of the ecc op_queue as computed insided the hiding kernel
     GoblinVerifier goblin_verifier{ builder.get(), goblin_verification_key, civc_rec_verifier_transcript };
-    GoblinRecursiveVerifierOutput output = goblin_verifier.verify(
-        proof.goblin_proof,
-        t_commitments,
-        mega_output.ecc_op_tables // Commitments to the state of the ecc op_queue as computed insided the hiding kernel
-    );
+    GoblinRecursiveVerifierOutput output = goblin_verifier.verify(proof.goblin_proof, merge_commitments);
     output.points_accumulator.aggregate(mega_output.points_accumulator);
     // TODO(https://github.com/AztecProtocol/barretenberg/issues/1396): State tracking in CIVC verifiers
     return { output };

--- a/barretenberg/cpp/src/barretenberg/stdlib/goblin_verifier/goblin_recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/goblin_verifier/goblin_recursive_verifier.cpp
@@ -16,11 +16,10 @@ namespace bb::stdlib::recursion::honk {
  *
  */
 GoblinRecursiveVerifierOutput GoblinRecursiveVerifier::verify(const GoblinProof& proof,
-                                                              const TableCommitments& t_commitments,
-                                                              const TableCommitments& T_prev_commitments)
+                                                              const MergeCommitments& merge_commitments)
 {
     StdlibProof stdlib_proof(*builder, proof);
-    return verify(stdlib_proof, t_commitments, T_prev_commitments);
+    return verify(stdlib_proof, merge_commitments);
 }
 
 /**
@@ -30,16 +29,13 @@ GoblinRecursiveVerifierOutput GoblinRecursiveVerifier::verify(const GoblinProof&
  * @param t_commitments The commitments to the subtable for the merge being verified
  *
  */
-// TODO(https://github.com/AztecProtocol/barretenberg/issues/1492): Modify Merge verifier API and package inputs in a
-// single struct
 GoblinRecursiveVerifierOutput GoblinRecursiveVerifier::verify(const StdlibProof& proof,
-                                                              const TableCommitments& t_commitments,
-                                                              const TableCommitments& T_prev_commitments)
+                                                              const MergeCommitments& merge_commitments)
 {
     // Verify the final merge step
     MergeVerifier merge_verifier{ builder, MergeSettings::PREPEND, transcript };
     auto [merge_pairing_points, merged_table_commitments] =
-        merge_verifier.verify_proof(proof.merge_proof, t_commitments, T_prev_commitments);
+        merge_verifier.verify_proof(proof.merge_proof, merge_commitments);
 
     // Run the ECCVM recursive verifier
     ECCVMVerifier eccvm_verifier{ builder, verification_keys.eccvm_verification_key, transcript };

--- a/barretenberg/cpp/src/barretenberg/stdlib/goblin_verifier/goblin_recursive_verifier.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/goblin_verifier/goblin_recursive_verifier.hpp
@@ -15,9 +15,7 @@ namespace bb::stdlib::recursion::honk {
 struct GoblinRecursiveVerifierOutput {
     using Builder = UltraCircuitBuilder;
     using Curve = grumpkin<Builder>;
-    using Transcript = bb::BaseTranscript<bb::stdlib::recursion::honk::StdlibTranscriptParams<Builder>>;
     using PairingAccumulator = PairingPoints<Builder>;
-    using TableCommitments = goblin::MergeRecursiveVerifier_<Builder>::TableCommitments;
     PairingAccumulator points_accumulator;
     OpeningClaim<Curve> opening_claim;
     stdlib::Proof<Builder> ipa_proof;
@@ -40,7 +38,7 @@ class GoblinRecursiveVerifier {
     using VerificationKey = Goblin::VerificationKey;
 
     // Merge commitments
-    using TableCommitments = MergeVerifier::TableCommitments;
+    using MergeCommitments = MergeVerifier::InputCommitments;
 
     struct StdlibProof {
         using StdlibHonkProof = bb::stdlib::Proof<Builder>;
@@ -66,9 +64,9 @@ class GoblinRecursiveVerifier {
         , transcript(transcript){};
 
     [[nodiscard("IPA claim and Pairing points should be accumulated")]] GoblinRecursiveVerifierOutput verify(
-        const GoblinProof&, const TableCommitments& t_commitments, const TableCommitments& T_prev_commitments);
+        const GoblinProof&, const MergeCommitments& merge_commitments);
     [[nodiscard("IPA claim and Pairing points should be accumulated")]] GoblinRecursiveVerifierOutput verify(
-        const StdlibProof&, const TableCommitments& t_commitments, const TableCommitments& T_prev_commitments);
+        const StdlibProof&, const MergeCommitments& merge_commitments);
 
   private:
     Builder* builder;

--- a/barretenberg/cpp/src/barretenberg/stdlib/goblin_verifier/goblin_recursive_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/goblin_verifier/goblin_recursive_verifier.test.cpp
@@ -23,18 +23,16 @@ class GoblinRecursiveVerifierTests : public testing::Test {
 
     using Commitment = MergeVerifier::Commitment;
     using RecursiveCommitment = GoblinRecursiveVerifier::MergeVerifier::Commitment;
-    using TableCommitments = MergeVerifier::TableCommitments;
-    using RecursiveTableCommitments = GoblinRecursiveVerifier::MergeVerifier::TableCommitments;
+    using MergeCommitments = MergeVerifier::InputCommitments;
+    using RecursiveMergeCommitments = GoblinRecursiveVerifier::MergeVerifier::InputCommitments;
 
     static void SetUpTestSuite() { bb::srs::init_file_crs_factory(bb::srs::bb_crs_path()); }
 
     struct ProverOutput {
         GoblinProof proof;
         Goblin::VerificationKey verifier_input;
-        TableCommitments t_commitments;
-        TableCommitments T_prev_commitments;
-        RecursiveTableCommitments recursive_t_commitments;
-        RecursiveTableCommitments recursive_T_prev_commitments;
+        MergeCommitments merge_commitments;
+        RecursiveMergeCommitments recursive_merge_commitments;
     };
 
     /**
@@ -63,30 +61,30 @@ class GoblinRecursiveVerifierTests : public testing::Test {
         goblin_final.op_queue->merge();
 
         // Subtable values and commitments - needed for (Recursive)MergeVerifier
-        TableCommitments t_commitments;
-        TableCommitments T_prev_commitments;
+        MergeCommitments merge_commitments;
         auto t_current = goblin_final.op_queue->construct_current_ultra_ops_subtable_columns();
         auto T_prev = goblin_final.op_queue->construct_previous_ultra_ops_table_columns();
         CommitmentKey<curve::BN254> pcs_commitment_key(goblin_final.op_queue->get_ultra_ops_table_num_rows());
         for (size_t idx = 0; idx < MegaFlavor::NUM_WIRES; idx++) {
-            t_commitments[idx] = pcs_commitment_key.commit(t_current[idx]);
-            T_prev_commitments[idx] = pcs_commitment_key.commit(T_prev[idx]);
+            merge_commitments.t_commitments[idx] = pcs_commitment_key.commit(t_current[idx]);
+            merge_commitments.T_prev_commitments[idx] = pcs_commitment_key.commit(T_prev[idx]);
         }
 
-        RecursiveTableCommitments recursive_t_commitments;
-        RecursiveTableCommitments recursive_T_prev_commitments;
+        RecursiveMergeCommitments recursive_merge_commitments;
         if (outer_builder != nullptr) {
             for (size_t idx = 0; idx < MegaFlavor::NUM_WIRES; idx++) {
-                recursive_t_commitments[idx] = RecursiveCommitment::from_witness(outer_builder, t_commitments[idx]);
-                recursive_T_prev_commitments[idx] =
-                    RecursiveCommitment::from_witness(outer_builder, T_prev_commitments[idx]);
+                recursive_merge_commitments.t_commitments[idx] =
+                    RecursiveCommitment::from_witness(outer_builder, merge_commitments.t_commitments[idx]);
+                recursive_merge_commitments.T_prev_commitments[idx] =
+                    RecursiveCommitment::from_witness(outer_builder, merge_commitments.T_prev_commitments[idx]);
             }
         }
 
         // Output is a goblin proof plus ECCVM/Translator verification keys
-        return { goblin_final.prove(),    { std::make_shared<ECCVMVK>(), std::make_shared<TranslatorVK>() },
-                 t_commitments,           T_prev_commitments,
-                 recursive_t_commitments, recursive_T_prev_commitments };
+        return { goblin_final.prove(),
+                 { std::make_shared<ECCVMVK>(), std::make_shared<TranslatorVK>() },
+                 merge_commitments,
+                 recursive_merge_commitments };
     }
 };
 
@@ -96,16 +94,11 @@ class GoblinRecursiveVerifierTests : public testing::Test {
  */
 TEST_F(GoblinRecursiveVerifierTests, NativeVerification)
 {
-    auto [proof,
-          verifier_input,
-          t_commitments,
-          T_prev_commitments,
-          _recursive_t_commitments,
-          _recursive_T_prev_commitments] = create_goblin_prover_output();
+    auto [proof, verifier_input, merge_commitments, _] = create_goblin_prover_output();
 
     std::shared_ptr<Goblin::Transcript> verifier_transcript = std::make_shared<Goblin::Transcript>();
 
-    EXPECT_TRUE(Goblin::verify(proof, t_commitments, T_prev_commitments, verifier_transcript));
+    EXPECT_TRUE(Goblin::verify(proof, merge_commitments, verifier_transcript));
 }
 
 /**
@@ -116,16 +109,11 @@ TEST_F(GoblinRecursiveVerifierTests, Basic)
 {
     Builder builder;
 
-    auto [proof,
-          verifier_input,
-          t_commitments,
-          T_prev_commitments,
-          recursive_t_commitments,
-          recursive_T_prev_commitments] = create_goblin_prover_output(&builder);
+    auto [proof, verifier_input, merge_commitments, recursive_merge_commitments] =
+        create_goblin_prover_output(&builder);
 
     GoblinRecursiveVerifier verifier{ &builder, verifier_input };
-    GoblinRecursiveVerifierOutput output =
-        verifier.verify(proof, recursive_t_commitments, recursive_T_prev_commitments);
+    GoblinRecursiveVerifierOutput output = verifier.verify(proof, recursive_merge_commitments);
     output.points_accumulator.set_public();
 
     info("Recursive Verifier: num gates = ", builder.num_gates);
@@ -155,16 +143,11 @@ TEST_F(GoblinRecursiveVerifierTests, IndependentVKHash)
         -> std::tuple<typename Builder::ExecutionTrace, std::shared_ptr<OuterFlavor::VerificationKey>> {
         Builder builder;
 
-        auto [proof,
-              verifier_input,
-              t_commitments,
-              T_prev_commitments,
-              recursive_t_commitments,
-              recursive_T_prev_commitments] = create_goblin_prover_output(&builder, inner_size);
+        auto [proof, verifier_input, merge_commitments, recursive_merge_commitments] =
+            create_goblin_prover_output(&builder, inner_size);
 
         GoblinRecursiveVerifier verifier{ &builder, verifier_input };
-        GoblinRecursiveVerifierOutput output =
-            verifier.verify(proof, recursive_t_commitments, recursive_T_prev_commitments);
+        GoblinRecursiveVerifierOutput output = verifier.verify(proof, recursive_merge_commitments);
         output.points_accumulator.set_public();
 
         info("Recursive Verifier: num gates = ", builder.num_gates);
@@ -193,12 +176,8 @@ TEST_F(GoblinRecursiveVerifierTests, ECCVMFailure)
 {
     Builder builder;
 
-    auto [proof,
-          verifier_input,
-          t_commitments,
-          T_prev_commitments,
-          recursive_t_commitments,
-          recursive_T_prev_commitments] = create_goblin_prover_output(&builder);
+    auto [proof, verifier_input, merge_commitments, recursive_merge_commitments] =
+        create_goblin_prover_output(&builder);
 
     // Tamper with the ECCVM proof
     for (auto& val : proof.eccvm_proof.pre_ipa_proof) {
@@ -209,8 +188,7 @@ TEST_F(GoblinRecursiveVerifierTests, ECCVMFailure)
     }
 
     GoblinRecursiveVerifier verifier{ &builder, verifier_input };
-    GoblinRecursiveVerifierOutput goblin_rec_verifier_output =
-        verifier.verify(proof, recursive_t_commitments, recursive_T_prev_commitments);
+    GoblinRecursiveVerifierOutput goblin_rec_verifier_output = verifier.verify(proof, recursive_merge_commitments);
 
     srs::init_file_crs_factory(bb::srs::bb_crs_path());
     auto crs_factory = srs::get_grumpkin_crs_factory();
@@ -231,12 +209,7 @@ TEST_F(GoblinRecursiveVerifierTests, ECCVMFailure)
  */
 TEST_F(GoblinRecursiveVerifierTests, TranslatorFailure)
 {
-    auto [proof,
-          verifier_input,
-          t_commitments,
-          T_prev_commitments,
-          _recursive_t_commitments,
-          _recursive_T_prev_commitments] = create_goblin_prover_output();
+    auto [proof, verifier_input, merge_commitments, _] = create_goblin_prover_output();
 
     // Tamper with the Translator proof preamble
     {
@@ -250,16 +223,16 @@ TEST_F(GoblinRecursiveVerifierTests, TranslatorFailure)
 
         Builder builder;
 
-        RecursiveTableCommitments recursive_t_commitments;
-        RecursiveTableCommitments recursive_T_prev_commitments;
+        RecursiveMergeCommitments recursive_merge_commitments;
         for (size_t idx = 0; idx < MegaFlavor::NUM_WIRES; idx++) {
-            recursive_t_commitments[idx] = RecursiveCommitment::from_witness(&builder, t_commitments[idx]);
-            recursive_T_prev_commitments[idx] = RecursiveCommitment::from_witness(&builder, T_prev_commitments[idx]);
+            recursive_merge_commitments.t_commitments[idx] =
+                RecursiveCommitment::from_witness(&builder, merge_commitments.t_commitments[idx]);
+            recursive_merge_commitments.T_prev_commitments[idx] =
+                RecursiveCommitment::from_witness(&builder, merge_commitments.T_prev_commitments[idx]);
         }
 
         GoblinRecursiveVerifier verifier{ &builder, verifier_input };
-        [[maybe_unused]] auto goblin_rec_verifier_output =
-            verifier.verify(tampered_proof, recursive_t_commitments, recursive_T_prev_commitments);
+        [[maybe_unused]] auto goblin_rec_verifier_output = verifier.verify(tampered_proof, recursive_merge_commitments);
         EXPECT_FALSE(CircuitChecker::check(builder));
     }
     // Tamper with the Translator proof non-preamble values
@@ -277,16 +250,16 @@ TEST_F(GoblinRecursiveVerifierTests, TranslatorFailure)
 
         Builder builder;
 
-        RecursiveTableCommitments recursive_t_commitments;
-        RecursiveTableCommitments recursive_T_prev_commitments;
+        RecursiveMergeCommitments recursive_merge_commitments;
         for (size_t idx = 0; idx < MegaFlavor::NUM_WIRES; idx++) {
-            recursive_t_commitments[idx] = RecursiveCommitment::from_witness(&builder, t_commitments[idx]);
-            recursive_T_prev_commitments[idx] = RecursiveCommitment::from_witness(&builder, T_prev_commitments[idx]);
+            recursive_merge_commitments.t_commitments[idx] =
+                RecursiveCommitment::from_witness(&builder, merge_commitments.t_commitments[idx]);
+            recursive_merge_commitments.T_prev_commitments[idx] =
+                RecursiveCommitment::from_witness(&builder, merge_commitments.T_prev_commitments[idx]);
         }
 
         GoblinRecursiveVerifier verifier{ &builder, verifier_input };
-        [[maybe_unused]] auto goblin_rec_verifier_output =
-            verifier.verify(tampered_proof, recursive_t_commitments, recursive_T_prev_commitments);
+        [[maybe_unused]] auto goblin_rec_verifier_output = verifier.verify(tampered_proof, recursive_merge_commitments);
         EXPECT_FALSE(CircuitChecker::check(builder));
     }
 }
@@ -299,12 +272,8 @@ TEST_F(GoblinRecursiveVerifierTests, TranslationEvaluationsFailure)
 {
     Builder builder;
 
-    auto [proof,
-          verifier_input,
-          t_commitments,
-          T_prev_commitments,
-          recursive_t_commitments,
-          recursive_T_prev_commitments] = create_goblin_prover_output(&builder);
+    auto [proof, verifier_input, merge_commitments, recursive_merge_commitments] =
+        create_goblin_prover_output(&builder);
 
     // Tamper with the evaluation of `op` witness. The index is computed manually.
     // TODO(https://github.com/AztecProtocol/barretenberg/issues/1298):
@@ -313,8 +282,7 @@ TEST_F(GoblinRecursiveVerifierTests, TranslationEvaluationsFailure)
     proof.eccvm_proof.pre_ipa_proof[op_limb_index] += 1;
 
     GoblinRecursiveVerifier verifier{ &builder, verifier_input };
-    [[maybe_unused]] auto goblin_rec_verifier_output =
-        verifier.verify(proof, recursive_t_commitments, recursive_T_prev_commitments);
+    [[maybe_unused]] auto goblin_rec_verifier_output = verifier.verify(proof, recursive_merge_commitments);
 
     EXPECT_FALSE(CircuitChecker::check(builder));
 }
@@ -333,17 +301,13 @@ TEST_F(GoblinRecursiveVerifierTests, TranslatorMergeConsistencyFailure)
 
         Builder builder;
 
-        auto [proof,
-              verifier_input,
-              t_commitments,
-              T_prev_commitments,
-              recursive_t_commitments,
-              recursive_T_prev_commitments] = create_goblin_prover_output(&builder);
+        auto [proof, verifier_input, merge_commitments, recursive_merge_commitments] =
+            create_goblin_prover_output(&builder);
 
         std::shared_ptr<Goblin::Transcript> verifier_transcript = std::make_shared<Goblin::Transcript>();
 
         // Check natively that the proof is correct.
-        EXPECT_TRUE(Goblin::verify(proof, t_commitments, T_prev_commitments, verifier_transcript));
+        EXPECT_TRUE(Goblin::verify(proof, merge_commitments, verifier_transcript));
 
         // TODO(https://github.com/AztecProtocol/barretenberg/issues/1298):
         // Better recursion testing - create more flexible proof tampering tests.
@@ -370,8 +334,7 @@ TEST_F(GoblinRecursiveVerifierTests, TranslatorMergeConsistencyFailure)
         // Construct and check the Goblin Recursive Verifier circuit
 
         GoblinRecursiveVerifier verifier{ &builder, verifier_input };
-        [[maybe_unused]] auto goblin_rec_verifier_output =
-            verifier.verify(proof, recursive_t_commitments, recursive_T_prev_commitments);
+        [[maybe_unused]] auto goblin_rec_verifier_output = verifier.verify(proof, recursive_merge_commitments);
 
         EXPECT_FALSE(CircuitChecker::check(builder));
     }

--- a/barretenberg/cpp/src/barretenberg/stdlib/merge_verifier/merge_recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/merge_verifier/merge_recursive_verifier.cpp
@@ -71,7 +71,7 @@ template <typename CircuitBuilder>
 std::pair<typename MergeRecursiveVerifier_<CircuitBuilder>::PairingPoints,
           typename MergeRecursiveVerifier_<CircuitBuilder>::TableCommitments>
 MergeRecursiveVerifier_<CircuitBuilder>::verify_proof(const stdlib::Proof<CircuitBuilder>& proof,
-                                                      const TableCommitments& t_commitments)
+                                                      const InputCommitments& input_commitments)
 {
     using Claims = typename ShplonkVerifier_<Curve>::LinearCombinationOfClaims;
 
@@ -86,8 +86,9 @@ MergeRecursiveVerifier_<CircuitBuilder>::verify_proof(const stdlib::Proof<Circui
     for (size_t idx = 0; idx < NUM_WIRES; ++idx) {
         // TODO(https://github.com/AztecProtocol/barretenberg/issues/1473): remove receiving commitment to T_prev
         auto T_prev_commitment = transcript->template receive_from_prover<Commitment>("T_PREV_" + std::to_string(idx));
-        auto left_table = settings == MergeSettings::PREPEND ? t_commitments[idx] : T_prev_commitment;
-        auto right_table = settings == MergeSettings::PREPEND ? T_prev_commitment : t_commitments[idx];
+        auto left_table = settings == MergeSettings::PREPEND ? input_commitments.t_commitments[idx] : T_prev_commitment;
+        auto right_table =
+            settings == MergeSettings::PREPEND ? T_prev_commitment : input_commitments.t_commitments[idx];
 
         table_commitments.emplace_back(left_table);
         table_commitments.emplace_back(right_table);

--- a/barretenberg/cpp/src/barretenberg/stdlib/merge_verifier/merge_recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/merge_verifier/merge_recursive_verifier.cpp
@@ -62,9 +62,10 @@ MergeRecursiveVerifier_<CircuitBuilder>::MergeRecursiveVerifier_(CircuitBuilder*
  * @param proof
  * @param subtable_commitments The subtable commitments data, containing the commitments to t_j read from the transcript
  * by the PG verifier with which the Merge verifier shares a transcript
- * @param t_commitments The subtable commitments data, containing the commitments to t_j read from the transcript
- * by the PG verifier with which the Merge verifier shares a transcript
- * @param T_prev_commitments The full op_queue table commitments after the previous iteration of merge
+ * @param inputs_commitments Commitments used by the verifier to run the verification algorithm. They contain the
+ * subtable commitments data, containing the commitments to t_j read from the transcript by the PG verifier with which
+ * the Merge verifier shares a transcript, and the commitments to the full op_queue table after the previous iteration
+ * of merge
  * @return std::pair<PairingPoints, TableCommitments> Pair of the pairing inputs for final verification and the
  * commitments to the merged tables as read from the proof
  */

--- a/barretenberg/cpp/src/barretenberg/stdlib/merge_verifier/merge_recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/merge_verifier/merge_recursive_verifier.cpp
@@ -60,12 +60,7 @@ MergeRecursiveVerifier_<CircuitBuilder>::MergeRecursiveVerifier_(CircuitBuilder*
  *
  * @tparam CircuitBuilder
  * @param proof
- * @param subtable_commitments The subtable commitments data, containing the commitments to t_j read from the transcript
- * by the PG verifier with which the Merge verifier shares a transcript
- * @param inputs_commitments Commitments used by the verifier to run the verification algorithm. They contain the
- * subtable commitments data, containing the commitments to t_j read from the transcript by the PG verifier with which
- * the Merge verifier shares a transcript, and the commitments to the full op_queue table after the previous iteration
- * of merge
+ * @param inputs_commitments The commitments used by the Merge verifier
  * @return std::pair<PairingPoints, TableCommitments> Pair of the pairing inputs for final verification and the
  * commitments to the merged tables as read from the proof
  */

--- a/barretenberg/cpp/src/barretenberg/stdlib/merge_verifier/merge_recursive_verifier.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/merge_verifier/merge_recursive_verifier.hpp
@@ -32,7 +32,12 @@ template <typename CircuitBuilder> class MergeRecursiveVerifier_ {
     static constexpr size_t NUM_WIRES = MegaExecutionTraceBlocks::NUM_WIRES;
     using TableCommitments = std::array<Commitment, NUM_WIRES>; // Commitments to the subtables and the merged table
 
-    // Commitments used by the Merge verifier to perfom merge verification
+    /**
+     * Commitments used by the verifier to run the verification algorithm. They contain:
+     *  - `t_commitments`: the subtable commitments data, containing the commitments to t_j read from the transcript by
+     *     the PG verifier with which the Merge verifier shares a transcript
+     *  - `T_prev_commitments`: the commitments to the full op_queue table after the previous iteration of merge
+     */
     struct InputCommitments {
         TableCommitments t_commitments;
         TableCommitments T_prev_commitments;

--- a/barretenberg/cpp/src/barretenberg/stdlib/merge_verifier/merge_recursive_verifier.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/merge_verifier/merge_recursive_verifier.hpp
@@ -32,12 +32,17 @@ template <typename CircuitBuilder> class MergeRecursiveVerifier_ {
     static constexpr size_t NUM_WIRES = MegaExecutionTraceBlocks::NUM_WIRES;
     using TableCommitments = std::array<Commitment, NUM_WIRES>; // Commitments to the subtables and the merged table
 
+    struct InputCommitments {
+        TableCommitments t_commitments;
+        TableCommitments T_prev_commitments;
+    };
+
     explicit MergeRecursiveVerifier_(CircuitBuilder* builder,
                                      const MergeSettings settings = MergeSettings::PREPEND,
                                      const std::shared_ptr<Transcript>& transcript = std::make_shared<Transcript>());
 
     [[nodiscard("Pairing points should be accumulated")]] std::pair<PairingPoints, TableCommitments> verify_proof(
-        const stdlib::Proof<CircuitBuilder>& proof, const TableCommitments& t_commitments);
+        const stdlib::Proof<CircuitBuilder>& proof, const InputCommitments& input_commitments);
 };
 
 } // namespace bb::stdlib::recursion::goblin

--- a/barretenberg/cpp/src/barretenberg/stdlib/merge_verifier/merge_recursive_verifier.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/merge_verifier/merge_recursive_verifier.hpp
@@ -32,6 +32,7 @@ template <typename CircuitBuilder> class MergeRecursiveVerifier_ {
     static constexpr size_t NUM_WIRES = MegaExecutionTraceBlocks::NUM_WIRES;
     using TableCommitments = std::array<Commitment, NUM_WIRES>; // Commitments to the subtables and the merged table
 
+    // Commitments used by the Merge verifier to perfom merge verification
     struct InputCommitments {
         TableCommitments t_commitments;
         TableCommitments T_prev_commitments;

--- a/barretenberg/cpp/src/barretenberg/stdlib/merge_verifier/merge_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/merge_verifier/merge_verifier.test.cpp
@@ -23,6 +23,7 @@ template <class RecursiveBuilder> class RecursiveMergeVerifierTest : public test
     // Types for recursive verifier circuit
     using RecursiveMergeVerifier = MergeRecursiveVerifier_<RecursiveBuilder>;
     using RecursiveTableCommitments = MergeRecursiveVerifier_<RecursiveBuilder>::TableCommitments;
+    using RecursiveMergeCommitments = MergeRecursiveVerifier_<RecursiveBuilder>::InputCommitments;
 
     // Define types relevant for inner circuit
     using InnerFlavor = MegaFlavor;
@@ -35,6 +36,7 @@ template <class RecursiveBuilder> class RecursiveMergeVerifierTest : public test
     using VerifierCommitmentKey = bb::VerifierCommitmentKey<curve::BN254>;
     using MergeProof = MergeProver::MergeProof;
     using TableCommitments = MergeVerifier::TableCommitments;
+    using MergeCommitments = MergeVerifier::InputCommitments;
 
     enum class TamperProofMode { None, Shift, MCommitment, LEval };
 
@@ -86,19 +88,17 @@ template <class RecursiveBuilder> class RecursiveMergeVerifierTest : public test
         tamper_with_proof(merge_proof, tampering_mode);
 
         // Subtable values and commitments - needed for (Recursive)MergeVerifier
-        TableCommitments t_commitments;
-        TableCommitments T_prev_commitments;
-        RecursiveTableCommitments recursive_t_commitments;
-        RecursiveTableCommitments recursive_T_prev_commitments;
+        MergeCommitments merge_commitments;
+        RecursiveMergeCommitments recursive_merge_commitments;
         auto t_current = op_queue->construct_current_ultra_ops_subtable_columns();
         auto T_prev = op_queue->construct_previous_ultra_ops_table_columns();
         for (size_t idx = 0; idx < InnerFlavor::NUM_WIRES; idx++) {
-            t_commitments[idx] = merge_prover.pcs_commitment_key.commit(t_current[idx]);
-            T_prev_commitments[idx] = merge_prover.pcs_commitment_key.commit(T_prev[idx]);
-            recursive_t_commitments[idx] =
-                RecursiveMergeVerifier::Commitment::from_witness(&outer_circuit, t_commitments[idx]);
-            recursive_T_prev_commitments[idx] =
-                RecursiveMergeVerifier::Commitment::from_witness(&outer_circuit, T_prev_commitments[idx]);
+            merge_commitments.t_commitments[idx] = merge_prover.pcs_commitment_key.commit(t_current[idx]);
+            merge_commitments.T_prev_commitments[idx] = merge_prover.pcs_commitment_key.commit(T_prev[idx]);
+            recursive_merge_commitments.t_commitments[idx] =
+                RecursiveMergeVerifier::Commitment::from_witness(&outer_circuit, merge_commitments.t_commitments[idx]);
+            recursive_merge_commitments.T_prev_commitments[idx] = RecursiveMergeVerifier::Commitment::from_witness(
+                &outer_circuit, recursive_merge_commitments.T_prev_commitments[idx]);
         }
 
         // Create a recursive merge verification circuit for the merge proof
@@ -106,7 +106,7 @@ template <class RecursiveBuilder> class RecursiveMergeVerifierTest : public test
         verifier.transcript->enable_manifest();
         const stdlib::Proof<RecursiveBuilder> stdlib_merge_proof(outer_circuit, merge_proof);
         auto [pairing_points, recursive_merged_table_commitments] =
-            verifier.verify_proof(stdlib_merge_proof, recursive_t_commitments, recursive_T_prev_commitments);
+            verifier.verify_proof(stdlib_merge_proof, recursive_merge_commitments);
 
         // Check for a failure flag in the recursive verifier circuit
         EXPECT_EQ(outer_circuit.failed(), !expected) << outer_circuit.err();
@@ -115,8 +115,7 @@ template <class RecursiveBuilder> class RecursiveMergeVerifierTest : public test
         // verifier and check that the result agrees.
         MergeVerifier native_verifier{ settings };
         native_verifier.transcript->enable_manifest();
-        auto [verified_native, merged_table_commitments] =
-            native_verifier.verify_proof(merge_proof, t_commitments, T_prev_commitments);
+        auto [verified_native, merged_table_commitments] = native_verifier.verify_proof(merge_proof, merge_commitments);
         VerifierCommitmentKey pcs_verification_key;
         bool verified_recursive =
             pcs_verification_key.pairing_check(pairing_points.P0.get_value(), pairing_points.P1.get_value());

--- a/barretenberg/cpp/src/barretenberg/stdlib/merge_verifier/merge_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/merge_verifier/merge_verifier.test.cpp
@@ -98,7 +98,7 @@ template <class RecursiveBuilder> class RecursiveMergeVerifierTest : public test
             recursive_merge_commitments.t_commitments[idx] =
                 RecursiveMergeVerifier::Commitment::from_witness(&outer_circuit, merge_commitments.t_commitments[idx]);
             recursive_merge_commitments.T_prev_commitments[idx] = RecursiveMergeVerifier::Commitment::from_witness(
-                &outer_circuit, recursive_merge_commitments.T_prev_commitments[idx]);
+                &outer_circuit, merge_commitments.T_prev_commitments[idx]);
         }
 
         // Create a recursive merge verification circuit for the merge proof

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/mega_honk.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/mega_honk.test.cpp
@@ -83,16 +83,15 @@ template <typename Flavor> class MegaHonkTests : public ::testing::Test {
         auto merge_proof = merge_prover.construct_proof();
 
         // Construct Merge commitments
-        MergeVerifier::TableCommitments t_commitments;
-        MergeVerifier::TableCommitments T_prev_commitments;
+        MergeVerifier::InputCommitments merge_commitments;
         auto t_current = op_queue->construct_current_ultra_ops_subtable_columns();
         auto T_prev = op_queue->construct_previous_ultra_ops_table_columns();
         for (size_t idx = 0; idx < Flavor::NUM_WIRES; idx++) {
-            t_commitments[idx] = merge_prover.pcs_commitment_key.commit(t_current[idx]);
-            T_prev_commitments[idx] = merge_prover.pcs_commitment_key.commit(T_prev[idx]);
+            merge_commitments.t_commitments[idx] = merge_prover.pcs_commitment_key.commit(t_current[idx]);
+            merge_commitments.T_prev_commitments[idx] = merge_prover.pcs_commitment_key.commit(T_prev[idx]);
         }
 
-        auto [verified, _] = merge_verifier.verify_proof(merge_proof, t_commitments, T_prev_commitments);
+        auto [verified, _] = merge_verifier.verify_proof(merge_proof, merge_commitments);
 
         return verified;
     }

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/merge_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/merge_verifier.cpp
@@ -61,7 +61,7 @@ MergeVerifier::MergeVerifier(const MergeSettings settings, const std::shared_ptr
  * read from the proof
  */
 std::pair<bool, typename MergeVerifier::TableCommitments> MergeVerifier::verify_proof(
-    const HonkProof& proof, const TableCommitments& t_commitments)
+    const HonkProof& proof, const InputCommitments& input_commitments)
 {
     using Claims = typename ShplonkVerifier_<Curve>::LinearCombinationOfClaims;
 
@@ -76,8 +76,9 @@ std::pair<bool, typename MergeVerifier::TableCommitments> MergeVerifier::verify_
     for (size_t idx = 0; idx < NUM_WIRES; ++idx) {
         // TODO(https://github.com/AztecProtocol/barretenberg/issues/1473): remove receiving commitment to T_prev
         auto T_prev_commitment = transcript->template receive_from_prover<Commitment>("T_PREV_" + std::to_string(idx));
-        auto left_table = settings == MergeSettings::PREPEND ? t_commitments[idx] : T_prev_commitment;
-        auto right_table = settings == MergeSettings::PREPEND ? T_prev_commitment : t_commitments[idx];
+        auto left_table = settings == MergeSettings::PREPEND ? input_commitments.t_commitments[idx] : T_prev_commitment;
+        auto right_table =
+            settings == MergeSettings::PREPEND ? T_prev_commitment : input_commitments.t_commitments[idx];
 
         table_commitments.emplace_back(left_table);
         table_commitments.emplace_back(right_table);

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/merge_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/merge_verifier.cpp
@@ -55,10 +55,7 @@ MergeVerifier::MergeVerifier(const MergeSettings settings, const std::shared_ptr
  * - \f$l_j = T_{prev,j}, r_j = t_j, m_j = T_j\f$ if we are appending the subtable
  *
  * @param proof
- * @param inputs_commitments Commitments used by the verifier to run the verification algorithm. They contain the
- * subtable commitments data, containing the commitments to t_j read from the transcript by the PG verifier with which
- * the Merge verifier shares a transcript, and the commitments to the full op_queue table after the previous iteration
- * of merge
+ * @param inputs_commitments The commitments used by the Merge verifier
  * @return std::pair<bool, TableCommitments> Pair of verification result and the commitments to the merged tables as
  * read from the proof
  */

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/merge_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/merge_verifier.cpp
@@ -55,9 +55,10 @@ MergeVerifier::MergeVerifier(const MergeSettings settings, const std::shared_ptr
  * - \f$l_j = T_{prev,j}, r_j = t_j, m_j = T_j\f$ if we are appending the subtable
  *
  * @param proof
- * @param t_commitments The subtable commitments data, containing the commitments to t_j read from the transcript
- * by the PG verifier with which the Merge verifier shares a transcript
- * @param T_prev_commitments The full op_queue table commitments after the previous iteration of merge
+ * @param inputs_commitments Commitments used by the verifier to run the verification algorithm. They contain the
+ * subtable commitments data, containing the commitments to t_j read from the transcript by the PG verifier with which
+ * the Merge verifier shares a transcript, and the commitments to the full op_queue table after the previous iteration
+ * of merge
  * @return std::pair<bool, TableCommitments> Pair of verification result and the commitments to the merged tables as
  * read from the proof
  */

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/merge_verifier.hpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/merge_verifier.hpp
@@ -34,12 +34,17 @@ class MergeVerifier {
     using Commitment = typename Curve::AffineElement;
     using TableCommitments = std::array<Commitment, NUM_WIRES>; // Commitments to the subtables and the merged table
 
+    struct InputCommitments {
+        TableCommitments t_commitments;
+        TableCommitments T_prev_commitments;
+    };
+
     std::shared_ptr<Transcript> transcript;
     MergeSettings settings;
 
     explicit MergeVerifier(const MergeSettings settings = MergeSettings::PREPEND,
                            const std::shared_ptr<Transcript>& transcript = std::make_shared<Transcript>());
-    std::pair<bool, TableCommitments> verify_proof(const HonkProof& proof, const TableCommitments& t_commitments);
+    std::pair<bool, TableCommitments> verify_proof(const HonkProof& proof, const InputCommitments& input_commitments);
 };
 
 } // namespace bb

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/merge_verifier.hpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/merge_verifier.hpp
@@ -34,6 +34,7 @@ class MergeVerifier {
     using Commitment = typename Curve::AffineElement;
     using TableCommitments = std::array<Commitment, NUM_WIRES>; // Commitments to the subtables and the merged table
 
+    // Commitments used by the Merge verifier to perfom merge verification
     struct InputCommitments {
         TableCommitments t_commitments;
         TableCommitments T_prev_commitments;

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/merge_verifier.hpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/merge_verifier.hpp
@@ -34,7 +34,12 @@ class MergeVerifier {
     using Commitment = typename Curve::AffineElement;
     using TableCommitments = std::array<Commitment, NUM_WIRES>; // Commitments to the subtables and the merged table
 
-    // Commitments used by the Merge verifier to perfom merge verification
+    /**
+     * Commitments used by the verifier to run the verification algorithm. They contain:
+     *  - `t_commitments`: the subtable commitments data, containing the commitments to t_j read from the transcript by
+     *     the PG verifier with which the Merge verifier shares a transcript
+     *  - `T_prev_commitments`: the commitments to the full op_queue table after the previous iteration of merge
+     */
     struct InputCommitments {
         TableCommitments t_commitments;
         TableCommitments T_prev_commitments;

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/recursion/goblin_avm_recursive_verifier.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/recursion/goblin_avm_recursive_verifier.hpp
@@ -220,9 +220,9 @@ class AvmGoblinRecursiveVerifier {
         inputs.pairing_inputs = points_accumulator;
         // TODO(https://github.com/AztecProtocol/barretenberg/issues/1489): Can we avoid paying for these public inputs
         // given that they are not used?
-        inputs.ecc_op_tables = IO<MegaBuilder>::default_ecc_op_tables(
-            mega_builder); // There is only one layer of Goblin, so the verifier will set T_prev
-                           // to the empty table and disregard this value
+        inputs.ecc_op_tables =
+            IO::default_ecc_op_tables(mega_builder); // There is only one layer of Goblin, so the verifier will set
+                                                     // T_prev to the empty table and disregard this value
         inputs.set_public();
 
         // All prover components share a single transcript

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/recursion/goblin_avm_recursive_verifier.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/recursion/goblin_avm_recursive_verifier.hpp
@@ -117,7 +117,7 @@ class AvmGoblinRecursiveVerifier {
         using MegaRecursiveVerifier = stdlib::recursion::honk::UltraRecursiveVerifier_<MegaRecursiveFlavor>;
         using GoblinRecursiveVerifier = stdlib::recursion::honk::GoblinRecursiveVerifier;
         using GoblinRecursiveVerifierOutput = stdlib::recursion::honk::GoblinRecursiveVerifierOutput;
-        using TableCommitments = GoblinRecursiveVerifier::MergeVerifier::TableCommitments;
+        using MergeCommitments = GoblinRecursiveVerifier::MergeVerifier::InputCommitments;
         using FF = MegaRecursiveFlavor::FF;
 
         // Construct hash buffer containing the AVM proof, public inputs, and VK
@@ -138,13 +138,14 @@ class AvmGoblinRecursiveVerifier {
         auto mega_verifier_output = mega_verifier.verify_proof(mega_proof);
 
         // Recursively verify the goblin proof\pi_G in the Ultra circuit
-        TableCommitments t_commitments = mega_verifier.key->witness_commitments.get_ecc_op_wires().get_copy();
-        TableCommitments T_prev_commitments =
+        MergeCommitments merge_commitments;
+        merge_commitments.t_commitments = mega_verifier.key->witness_commitments.get_ecc_op_wires().get_copy();
+        merge_commitments.T_prev_commitments =
             stdlib::recursion::honk::HidingKernelIO<UltraBuilder>::empty_ecc_op_tables(
                 ultra_builder); // Empty ecc op tables because there is only one layer of Goblin
         GoblinRecursiveVerifier goblin_verifier{ &ultra_builder, inner_output.goblin_vk, transcript };
         GoblinRecursiveVerifierOutput goblin_verifier_output =
-            goblin_verifier.verify(inner_output.goblin_proof, t_commitments, T_prev_commitments);
+            goblin_verifier.verify(inner_output.goblin_proof, merge_commitments);
         goblin_verifier_output.points_accumulator.aggregate(mega_verifier_output.points_accumulator);
 
         // Validate the consistency of the AVM2 verifier inputs {\pi, pub_inputs, VK}_{AVM2} between the inner (Mega)


### PR DESCRIPTION
We package the inputs to the Merge verifier (two at the moment: `t_commitments` and `T_prev_commitments`) into a single struct to reduce the number of function arguments and prevent incorrect ordering of the arguments.

This PR closes https://github.com/AztecProtocol/barretenberg/issues/1492.