### PR TITLE
refactor: ignition proof submission savings

### DIFF
--- a/l1-contracts/gas_benchmark.md
+++ b/l1-contracts/gas_benchmark.md
@@ -16,23 +16,23 @@
 
 | Function             | Avg Gas | Max Gas | Calldata Size | Calldata Gas |
 |----------------------|---------|---------|---------------|--------------|
-| propose              | 152,610 | 169,137 |         1,060 |       16,960 |
-| submitEpochRootProof | 813,442 | 834,067 |         3,812 |       60,992 |
+| propose              | 152,658 | 169,185 |         1,060 |       16,960 |
+| submitEpochRootProof | 569,593 | 592,809 |         3,812 |       60,992 |
 | setupEpoch           |  40,850 | 108,458 |             - |            - |
 
-**Avg Gas Cost per Second**: 975.8 gas/second
+**Avg Gas Cost per Second**: 923.1 gas/second
 *Epoch duration*: 2h 33m 36s
 
 ### Validators (IGNITION)
 
 | Function             | Avg Gas | Max Gas | Calldata Size | Calldata Gas |
 |----------------------|---------|---------|---------------|--------------|
-| propose              | 210,546 | 227,246 |         2,852 |       45,632 |
-| submitEpochRootProof | 923,838 | 944,451 |         5,092 |       81,472 |
-| aggregate3           | 258,011 | 281,827 |             - |            - |
+| propose              | 210,594 | 227,294 |         2,852 |       45,632 |
+| submitEpochRootProof | 679,989 | 703,193 |         5,092 |       81,472 |
+| aggregate3           | 258,059 | 281,875 |             - |            - |
 | setupEpoch           |  47,418 | 327,409 |             - |            - |
 
-**Avg Gas Cost per Second**: 1,302.2 gas/second
+**Avg Gas Cost per Second**: 1,249.6 gas/second
 *Epoch duration*: 2h 33m 36s
 
 
@@ -52,22 +52,22 @@
 
 | Function             | Avg Gas | Max Gas | Calldata Size | Calldata Gas |
 |----------------------|---------|---------|---------------|--------------|
-| propose              | 230,565 | 247,531 |         1,060 |       16,960 |
-| submitEpochRootProof | 686,752 | 725,612 |         3,812 |       60,992 |
+| propose              | 230,613 | 247,579 |         1,060 |       16,960 |
+| submitEpochRootProof | 689,254 | 728,109 |         3,812 |       60,992 |
 | setupEpoch           |  42,025 | 110,979 |             - |            - |
 
-**Avg Gas Cost per Second**: 7,633.3 gas/second
+**Avg Gas Cost per Second**: 7,639.0 gas/second
 *Epoch duration*: 0h 19m 12s
 
 ### Validators (Alpha)
 
 | Function             | Avg Gas | Max Gas | Calldata Size | Calldata Gas |
 |----------------------|---------|---------|---------------|--------------|
-| propose              | 337,661 | 356,235 |         4,580 |       73,280 |
-| submitEpochRootProof | 894,446 | 932,423 |         6,308 |      100,928 |
-| aggregate3           | 390,107 | 411,903 |             - |            - |
+| propose              | 337,709 | 356,283 |         4,580 |       73,280 |
+| submitEpochRootProof | 896,948 | 934,920 |         6,308 |      100,928 |
+| aggregate3           | 390,155 | 411,951 |             - |            - |
 | setupEpoch           |  59,398 | 545,314 |             - |            - |
 
-**Avg Gas Cost per Second**: 10,983.9 gas/second
+**Avg Gas Cost per Second**: 10,989.6 gas/second
 *Epoch duration*: 0h 19m 12s
 

--- a/l1-contracts/gas_benchmark_results.json
+++ b/l1-contracts/gas_benchmark_results.json
@@ -3,10 +3,10 @@
     "no_validators": {
       "propose": {
         "calls": 100,
-        "min": 149582,
-        "mean": 152610,
-        "median": 152392,
-        "max": 169137,
+        "min": 149630,
+        "mean": 152658,
+        "median": 152440,
+        "max": 169185,
         "calldata_size": 1060,
         "calldata_gas": 16960
       },
@@ -19,10 +19,10 @@
       },
       "submitEpochRootProof": {
         "calls": 2,
-        "min": 792817,
-        "mean": 813442,
-        "median": 813442,
-        "max": 834067,
+        "min": 546378,
+        "mean": 569593,
+        "median": 569593,
+        "max": 592809,
         "calldata_size": 3812,
         "calldata_gas": 60992
       }
@@ -30,10 +30,10 @@
     "validators": {
       "propose": {
         "calls": 100,
-        "min": 204044,
-        "mean": 210546,
-        "median": 209888,
-        "max": 227246,
+        "min": 204092,
+        "mean": 210594,
+        "median": 209936,
+        "max": 227294,
         "calldata_size": 2852,
         "calldata_gas": 45632
       },
@@ -46,19 +46,19 @@
       },
       "submitEpochRootProof": {
         "calls": 2,
-        "min": 903225,
-        "mean": 923838,
-        "median": 923838,
-        "max": 944451,
+        "min": 656786,
+        "mean": 679989,
+        "median": 679989,
+        "max": 703193,
         "calldata_size": 5092,
         "calldata_gas": 81472
       },
       "aggregate3": {
         "calls": 100,
-        "min": 247366,
-        "mean": 258011,
-        "median": 255716,
-        "max": 281827
+        "min": 247414,
+        "mean": 258059,
+        "median": 255764,
+        "max": 281875
       }
     }
   },
@@ -66,10 +66,10 @@
     "no_validators": {
       "propose": {
         "calls": 100,
-        "min": 221595,
-        "mean": 230565,
-        "median": 229850,
-        "max": 247531,
+        "min": 221643,
+        "mean": 230613,
+        "median": 229898,
+        "max": 247579,
         "calldata_size": 1060,
         "calldata_gas": 16960
       },
@@ -82,10 +82,10 @@
       },
       "submitEpochRootProof": {
         "calls": 3,
-        "min": 667274,
-        "mean": 686752,
-        "median": 667370,
-        "max": 725612,
+        "min": 669779,
+        "mean": 689254,
+        "median": 669875,
+        "max": 728109,
         "calldata_size": 3812,
         "calldata_gas": 60992
       }
@@ -93,10 +93,10 @@
     "validators": {
       "propose": {
         "calls": 100,
-        "min": 323242,
-        "mean": 337661,
-        "median": 337308,
-        "max": 356235,
+        "min": 323290,
+        "mean": 337709,
+        "median": 337356,
+        "max": 356283,
         "calldata_size": 4580,
         "calldata_gas": 73280
       },
@@ -109,19 +109,19 @@
       },
       "submitEpochRootProof": {
         "calls": 3,
-        "min": 874205,
-        "mean": 894446,
-        "median": 876710,
-        "max": 932423,
+        "min": 876710,
+        "mean": 896948,
+        "median": 879215,
+        "max": 934920,
         "calldata_size": 6308,
         "calldata_gas": 100928
       },
       "aggregate3": {
         "calls": 100,
-        "min": 366627,
-        "mean": 390107,
-        "median": 389508,
-        "max": 411903
+        "min": 366675,
+        "mean": 390155,
+        "median": 389556,
+        "max": 411951
       }
     }
   }

--- a/l1-contracts/src/core/libraries/rollup/FeeLib.sol
+++ b/l1-contracts/src/core/libraries/rollup/FeeLib.sol
@@ -252,6 +252,11 @@ library FeeLib {
     });
   }
 
+  function isTxsEnabled() internal view returns (bool) {
+    // If the target is 0, the limit is 0. And no transactions can enter
+    return getManaTarget() > 0;
+  }
+
   function getManaTarget() internal view returns (uint256) {
     return getStorage().config.getManaTarget();
   }

--- a/l1-contracts/src/core/libraries/rollup/ProposeLib.sol
+++ b/l1-contracts/src/core/libraries/rollup/ProposeLib.sol
@@ -48,7 +48,7 @@ struct InterimProposeValues {
   bytes32 payloadDigest;
   Epoch currentEpoch;
   bool isFirstBlockOfEpoch;
-  bool isIgnition;
+  bool isTxsEnabled;
 }
 
 /**
@@ -98,8 +98,8 @@ library ProposeLib {
     }
     InterimProposeValues memory v;
 
-    v.isIgnition = FeeLib.getManaTarget() == 0;
-    if (!v.isIgnition) {
+    v.isTxsEnabled = FeeLib.isTxsEnabled();
+    if (v.isTxsEnabled) {
       // Since ignition have no TX's, we need not waste gas updating pricing oracle.
       FeeLib.updateL1GasFeeOracle();
     }
@@ -116,7 +116,7 @@ library ProposeLib {
     ValidatorSelectionLib.setupEpoch(v.currentEpoch);
 
     ManaBaseFeeComponents memory components;
-    if (!v.isIgnition) {
+    if (v.isTxsEnabled) {
       // Since ignition have no TX's, we need not waste gas computing the fee components
       components = getManaBaseFeeComponentsAt(Timestamp.wrap(block.timestamp), true);
     }
@@ -158,7 +158,7 @@ library ProposeLib {
     );
 
     FeeHeader memory feeHeader;
-    if (!v.isIgnition) {
+    if (v.isTxsEnabled) {
       // Since ignition have no TX's, we need not waste gas deriving the fee header
       feeHeader = FeeLib.computeFeeHeader(
         blockNumber,
@@ -186,7 +186,7 @@ library ProposeLib {
       })
     );
 
-    if (!v.isIgnition) {
+    if (v.isTxsEnabled) {
       // Since ignition will have no transactions there will be no method to consume or output message.
       // Therefore we can ignore it as long as mana target is zero.
       // Since the inbox is async, it must enforce its own check to not try to insert if ignition.

--- a/l1-contracts/test/ignition.t.sol
+++ b/l1-contracts/test/ignition.t.sol
@@ -18,6 +18,7 @@ import {Errors} from "@aztec/core/libraries/Errors.sol";
 import {RollupBase, IInstance} from "./base/RollupBase.sol";
 import {RollupBuilder} from "./builder/RollupBuilder.sol";
 import {TimeCheater} from "./staking/TimeCheater.sol";
+import {Bps, BpsLib} from "@aztec/core/libraries/rollup/RewardLib.sol";
 // solhint-disable comprehensive-interface
 
 /**
@@ -84,7 +85,32 @@ contract IgnitionTest is RollupBase {
   }
 
   function test_emptyBlock() public setUpFor("empty_block_1") {
+    assertEq(rollup.getFeeAsset().balanceOf(address(rollup)), 0);
+
     _proposeBlock("empty_block_1", 1, 0);
+
+    _proveBlocks("empty_block_", 1, 1, address(0xbeef));
+
+    // The block rewards should have accumulated
+    assertEq(
+      rollup.getFeeAsset().balanceOf(address(rollup)),
+      rollup.getBlockReward(),
+      "no block rewards collected"
+    );
+
+    uint256 blockReward = rollup.getBlockReward();
+    Bps bps = rollup.getRewardConfig().sequencerBps;
+    uint256 sequencerReward = BpsLib.mul(blockReward, bps);
+
+    address coinbase = address(bytes20("sequencer"));
+    assertEq(
+      rollup.getSequencerRewards(coinbase), sequencerReward, "sequencer reward not collected"
+    );
+    assertEq(
+      rollup.getCollectiveProverRewardsForEpoch(Epoch.wrap(0)),
+      blockReward - sequencerReward,
+      "prover reward not collected"
+    );
   }
 
   function test_RevertNonEmptyBlock() public setUpFor("empty_block_1") {


### PR DESCRIPTION
Similar to #16064 we can get easy savings for the proof submission by simply skipping all the stuff with fees when we are in ignition and it have no effect.