### PR TITLE
chore: toggle whether or not we use multithreaded or row-skipping compute_univariate

### DIFF
--- a/barretenberg/cpp/src/barretenberg/sumcheck/sumcheck.hpp
+++ b/barretenberg/cpp/src/barretenberg/sumcheck/sumcheck.hpp
@@ -232,7 +232,7 @@ template <typename Flavor, const size_t virtual_log_n = CONST_PROOF_SIZE_LOG_N> 
         // In the first round, we compute the first univariate polynomial and populate the book-keeping table of
         // #partially_evaluated_polynomials, which has \f$ n/2 \f$ rows and \f$ N \f$ columns.
         auto round_univariate =
-            round.compute_univariate_with_row_skipping(full_polynomials, relation_parameters, gate_separators, alphas);
+            round.compute_univariate(full_polynomials, relation_parameters, gate_separators, alphas);
         // Initialize the partially evaluated polynomials which will be used in the following rounds.
         // This will use the information in the structured full polynomials to save memory if possible.
         partially_evaluated_polynomials = PartiallyEvaluatedMultivariates(full_polynomials, multivariate_n);
@@ -256,8 +256,8 @@ template <typename Flavor, const size_t virtual_log_n = CONST_PROOF_SIZE_LOG_N> 
             PROFILE_THIS_NAME("sumcheck loop");
 
             // Write the round univariate to the transcript
-            round_univariate = round.compute_univariate_with_row_skipping(
-                partially_evaluated_polynomials, relation_parameters, gate_separators, alphas);
+            round_univariate =
+                round.compute_univariate(partially_evaluated_polynomials, relation_parameters, gate_separators, alphas);
             // Place evaluations of Sumcheck Round Univariate in the transcript
             transcript->send_to_verifier("Sumcheck:univariate_" + std::to_string(round_idx), round_univariate);
             FF round_challenge = transcript->template get_challenge<FF>("Sumcheck:u_" + std::to_string(round_idx));
@@ -327,7 +327,7 @@ template <typename Flavor, const size_t virtual_log_n = CONST_PROOF_SIZE_LOG_N> 
                                                                  zk_sumcheck_data,
                                                                  row_disabling_polynomial);
         auto round_univariate =
-            round.compute_univariate_with_row_skipping(full_polynomials, relation_parameters, gate_separators, alphas);
+            round.compute_univariate(full_polynomials, relation_parameters, gate_separators, alphas);
         round_univariate += hiding_univariate;
 
         // Initialize the partially evaluated polynomials which will be used in the following rounds.
@@ -374,8 +374,8 @@ template <typename Flavor, const size_t virtual_log_n = CONST_PROOF_SIZE_LOG_N> 
                                                                 alphas,
                                                                 zk_sumcheck_data,
                                                                 row_disabling_polynomial);
-            round_univariate = round.compute_univariate_with_row_skipping(
-                partially_evaluated_polynomials, relation_parameters, gate_separators, alphas);
+            round_univariate =
+                round.compute_univariate(partially_evaluated_polynomials, relation_parameters, gate_separators, alphas);
             round_univariate += hiding_univariate;
 
             if constexpr (!IsGrumpkinFlavor<Flavor>) {

--- a/barretenberg/cpp/src/barretenberg/sumcheck/sumcheck_round.hpp
+++ b/barretenberg/cpp/src/barretenberg/sumcheck/sumcheck_round.hpp
@@ -91,8 +91,7 @@ template <typename Flavor> class SumcheckProverRound {
         // Initialize univariate accumulators to 0
         Utils::zero_univariates(univariate_accumulators);
     }
-    // TODO(https://github.com/AztecProtocol/barretenberg/issues/1484): should we get rid of this function, given
-    // `compute_univariates_with_row_skipping()`?
+
     /**
      * @brief  To compute the round univariate in Round \f$i\f$, the prover first computes the values of Honk
      polynomials \f$ P_1,\ldots, P_N \f$ at the points of the form \f$ (u_0,\ldots, u_{i-1}, k, \vec \ell)\f$ for \f$
@@ -140,9 +139,25 @@ template <typename Flavor> class SumcheckProverRound {
             }
         }
     }
-
     /**
-     * @brief Non-ZK version: Return the evaluations of the univariate round polynomials \f$ \tilde{S}_{i} (X_{i}) \f$
+     * @brief Return the evaluations of the univariate round polynomials. Toggles between multi-threaded computation
+     * (designed with the AVM in mind) and a version which intelligently allows from row-skipped functionality
+     */
+    template <typename ProverPolynomialsOrPartiallyEvaluatedMultivariates>
+    SumcheckRoundUnivariate compute_univariate(ProverPolynomialsOrPartiallyEvaluatedMultivariates& polynomials,
+                                               const bb::RelationParameters<FF>& relation_parameters,
+                                               const bb::GateSeparatorPolynomial<FF>& gate_separators,
+                                               const SubrelationSeparators& alphas)
+    {
+        if constexpr (specifiesUnivariateChunks<Flavor>) {
+            return compute_univariate_multithreaded(polynomials, relation_parameters, gate_separators, alphas);
+        }
+        return compute_univariate_with_row_skipping(polynomials, relation_parameters, gate_separators, alphas);
+    }
+    // TODO(https://github.com/AztecProtocol/barretenberg/issues/1484): should we more intelligently incorporate the two
+    // `compute_univariate` types of functions?
+    /**
+     * @brief Return the evaluations of the univariate round polynomials \f$ \tilde{S}_{i} (X_{i}) \f$
      at \f$ X_{i } = 0,\ldots, D \f$. Most likely, \f$ D \f$ is around  \f$ 12 \f$. At the
      * end, reset all
      * univariate accumulators to be zero.
@@ -164,10 +179,11 @@ template <typename Flavor> class SumcheckProverRound {
      method \ref extend_and_batch_univariates "extend and batch univariates".
      */
     template <typename ProverPolynomialsOrPartiallyEvaluatedMultivariates>
-    SumcheckRoundUnivariate compute_univariate(ProverPolynomialsOrPartiallyEvaluatedMultivariates& polynomials,
-                                               const bb::RelationParameters<FF>& relation_parameters,
-                                               const bb::GateSeparatorPolynomial<FF>& gate_separators,
-                                               const SubrelationSeparators& alphas)
+    SumcheckRoundUnivariate compute_univariate_multithreaded(
+        ProverPolynomialsOrPartiallyEvaluatedMultivariates& polynomials,
+        const bb::RelationParameters<FF>& relation_parameters,
+        const bb::GateSeparatorPolynomial<FF>& gate_separators,
+        const SubrelationSeparators& alphas)
     {
         PROFILE_THIS_NAME("compute_univariate");
 

--- a/barretenberg/cpp/src/barretenberg/sumcheck/sumcheck_round.hpp
+++ b/barretenberg/cpp/src/barretenberg/sumcheck/sumcheck_round.hpp
@@ -140,7 +140,7 @@ template <typename Flavor> class SumcheckProverRound {
         }
     }
     /**
-     * @brief Return the evaluations of the univariate round polynomials. Toggles between multi-threaded computation
+     * @brief Return the evaluations of the univariate round polynomials. Toggles between chunked computation
      * (designed with the AVM in mind) and a version which intelligently allows from row-skipped functionality
      */
     template <typename ProverPolynomialsOrPartiallyEvaluatedMultivariates>
@@ -150,7 +150,7 @@ template <typename Flavor> class SumcheckProverRound {
                                                const SubrelationSeparators& alphas)
     {
         if constexpr (specifiesUnivariateChunks<Flavor>) {
-            return compute_univariate_multithreaded(polynomials, relation_parameters, gate_separators, alphas);
+            return compute_univariate_with_chunking(polynomials, relation_parameters, gate_separators, alphas);
         }
         return compute_univariate_with_row_skipping(polynomials, relation_parameters, gate_separators, alphas);
     }
@@ -179,13 +179,13 @@ template <typename Flavor> class SumcheckProverRound {
      method \ref extend_and_batch_univariates "extend and batch univariates".
      */
     template <typename ProverPolynomialsOrPartiallyEvaluatedMultivariates>
-    SumcheckRoundUnivariate compute_univariate_multithreaded(
+    SumcheckRoundUnivariate compute_univariate_with_chunking(
         ProverPolynomialsOrPartiallyEvaluatedMultivariates& polynomials,
         const bb::RelationParameters<FF>& relation_parameters,
         const bb::GateSeparatorPolynomial<FF>& gate_separators,
         const SubrelationSeparators& alphas)
     {
-        PROFILE_THIS_NAME("compute_univariate");
+        PROFILE_THIS_NAME("compute_univariate_with_chunking");
 
         // Determine number of threads for multithreading.
         // Note: Multithreading is "on" for every round but we reduce the number of threads from the max available based


### PR DESCRIPTION
In [14272](https://github.com/AztecProtocol/aztec-packages/pull/14272) and [15841](https://github.com/AztecProtocol/aztec-packages/pull/15841), a row-skipping functionality was incorporated in the process of computing the round univariates in sumcheck. This passed over a multithreaded implementation, which was tailor-made for the AVM, causing a performance hit for the AVM.

We combine these two to maintain the AVM performance.