### PR TITLE
refactor!: new note emission API

### DIFF
--- a/boxes/boxes/react/src/contracts/src/main.nr
+++ b/boxes/boxes/react/src/contracts/src/main.nr
@@ -1,14 +1,14 @@
-use dep::aztec::macros::aztec;
+use aztec::macros::aztec;
 
 #[aztec]
 contract BoxReact {
-    use dep::aztec::{
-        messages::logs::note::encode_and_encrypt_note,
+    use aztec::{
+        event::event_interface::MessageDelivery,
         macros::{functions::{initializer, private, utility}, storage::storage},
         protocol_types::address::AztecAddress,
         state_vars::{Map, PrivateMutable},
     };
-    use dep::value_note::value_note::ValueNote;
+    use value_note::value_note::ValueNote;
 
     #[storage]
     struct Storage<Context> {
@@ -21,10 +21,11 @@ contract BoxReact {
         let numbers = storage.numbers;
         let new_number = ValueNote::new(number, owner);
 
-        numbers.at(owner).initialize(new_number).emit(encode_and_encrypt_note(
+        numbers.at(owner).initialize(new_number).emit(
             &mut context,
             owner,
-        ));
+            MessageDelivery.CONSTRAINED_ONCHAIN,
+        );
     }
 
     #[private]
@@ -32,10 +33,11 @@ contract BoxReact {
         let numbers = storage.numbers;
         let new_number = ValueNote::new(number, owner);
 
-        numbers.at(owner).replace(new_number).emit(encode_and_encrypt_note(
+        numbers.at(owner).replace(new_number).emit(
             &mut context,
             owner,
-        ));
+            MessageDelivery.CONSTRAINED_ONCHAIN,
+        );
     }
 
     #[utility]

--- a/boxes/boxes/vite/src/contracts/src/main.nr
+++ b/boxes/boxes/vite/src/contracts/src/main.nr
@@ -1,14 +1,14 @@
-use dep::aztec::macros::aztec;
+use aztec::macros::aztec;
 
 #[aztec]
 contract BoxReact {
-    use dep::aztec::{
-        messages::logs::note::encode_and_encrypt_note,
+    use aztec::{
+        event::event_interface::MessageDelivery,
         macros::{functions::{initializer, private, utility}, storage::storage},
         protocol_types::address::AztecAddress,
         state_vars::{Map, PrivateMutable},
     };
-    use dep::value_note::value_note::ValueNote;
+    use value_note::value_note::ValueNote;
 
     #[storage]
     struct Storage<Context> {
@@ -21,10 +21,11 @@ contract BoxReact {
         let numbers = storage.numbers;
         let mut new_number = ValueNote::new(number, owner);
 
-        numbers.at(owner).initialize(new_number).emit(encode_and_encrypt_note(
+        numbers.at(owner).initialize(new_number).emit(
             &mut context,
             owner,
-        ));
+            MessageDelivery.CONSTRAINED_ONCHAIN,
+        );
     }
 
     #[private]
@@ -32,10 +33,11 @@ contract BoxReact {
         let numbers = storage.numbers;
         let mut new_number = ValueNote::new(number, owner);
 
-        numbers.at(owner).replace(new_number).emit(encode_and_encrypt_note(
+        numbers.at(owner).replace(new_number).emit(
             &mut context,
             owner,
-        ));
+            MessageDelivery.CONSTRAINED_ONCHAIN,
+        );
     }
 
     #[utility]

--- a/noir-projects/aztec-nr/aztec/src/event/event_interface.nr
+++ b/noir-projects/aztec-nr/aztec/src/event/event_interface.nr
@@ -40,6 +40,7 @@ use dep::protocol_types::{
 /// over unconstrained encryption and is slower to prove (requiring more constraints).
 ///
 /// There are three available delivery modes described below.
+// TODO(#16771): This is now used by notes as well. Move it.
 pub struct MessageDeliveryEnum {
     /// 1. Constrained On-chain
     /// - Uses constrained encryption and in the future constrained tagging (issue #14565) with on-chain delivery

--- a/noir-projects/aztec-nr/aztec/src/messages/logs/note.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/logs/note.nr
@@ -1,5 +1,6 @@
 use crate::{
     context::PrivateContext,
+    event::event_interface::MessageDelivery,
     messages::{
         encoding::encode_message,
         encryption::{aes128::AES128, log_encryption::LogEncryption},
@@ -8,7 +9,7 @@ use crate::{
         offchain_messages::emit_offchain_message,
     },
     note::{note_emission::NoteEmission, note_interface::NoteType},
-    utils::{array::subarray::subarray, remove_constraints::remove_constraints},
+    utils::remove_constraints::remove_constraints_if,
 };
 use protocol_types::{
     abis::note_hash::NoteHash,
@@ -25,17 +26,6 @@ fn assert_note_exists(context: PrivateContext, note_hash_counter: u32) {
     assert(note_exists, "Can only emit a note log for an existing note.");
 }
 
-pub fn compute_note_log<Note>(
-    note: Note,
-    storage_slot: Field,
-    recipient: AztecAddress,
-) -> [Field; PRIVATE_LOG_SIZE_IN_FIELDS]
-where
-    Note: NoteType + Packable,
-{
-    compute_log(note, storage_slot, recipient, PRIVATE_NOTE_MSG_TYPE_ID)
-}
-
 pub fn compute_partial_note_log<Note>(
     note: Note,
     storage_slot: Field,
@@ -44,20 +34,24 @@ pub fn compute_partial_note_log<Note>(
 where
     Note: NoteType + Packable,
 {
-    compute_log(
+    let ciphertext = compute_ciphertext(
         note,
         storage_slot,
         recipient,
         PARTIAL_NOTE_PRIVATE_MSG_TYPE_ID,
-    )
+    );
+
+    let log = prefix_with_tag(ciphertext, recipient);
+
+    log
 }
 
-fn compute_log<Note>(
+fn compute_ciphertext<Note>(
     note: Note,
     storage_slot: Field,
     recipient: AztecAddress,
     msg_type: u64,
-) -> [Field; PRIVATE_LOG_SIZE_IN_FIELDS]
+) -> [Field; PRIVATE_LOG_CIPHERTEXT_LEN]
 where
     Note: NoteType + Packable,
 {
@@ -73,98 +67,58 @@ where
     // Notes use the note type id for metadata
     let plaintext = encode_message(msg_type, Note::get_id() as u64, msg_content);
 
-    let ciphertext = AES128::encrypt_log(plaintext, recipient);
-
-    let log = prefix_with_tag(ciphertext, recipient);
-
-    log
+    AES128::encrypt_log(plaintext, recipient)
 }
 
-/// Sends an encrypted message to `recipient` with the content of the note, which they will discover when processing
-/// private logs.
-pub fn encode_and_encrypt_note<Note>(
-    context: &mut PrivateContext,
-    recipient: AztecAddress,
-) -> fn[(&mut PrivateContext, AztecAddress)](NoteEmission<Note>) -> ()
-where
-    Note: NoteType + Packable,
-{
-    |e: NoteEmission<Note>| {
-        let note = e.note;
-        let storage_slot = e.storage_slot;
-        let note_hash_counter = e.note_hash_counter;
-        assert_note_exists(*context, note_hash_counter);
-
-        let encrypted_log = compute_note_log(note, storage_slot, recipient);
-        // Regardless of the original note size `N, the log is padded with random bytes up to
-        // `PRIVATE_LOG_SIZE_IN_FIELDS` to prevent leaking information about the actual size.
-        let length = encrypted_log.len();
-        context.emit_raw_note_log(encrypted_log, length, note_hash_counter);
-    }
-}
-
-/// Same as `encode_and_encrypt_note`, except encryption is unconstrained. This means that the sender is free to make
-/// the log contents be whatever they wish, potentially resulting in scenarios in which the recipient is unable to
-/// decrypt and process the payload, **leading to the note being lost**.
+/// Emits a note that can be delivered either via private logs or offchain messages, with configurable encryption and
+/// tagging constraints.
 ///
-/// Only use this function in scenarios where the recipient not receiving the note is an acceptable outcome.
-pub fn encode_and_encrypt_note_unconstrained<Note>(
+/// # Arguments
+/// * `note_emission` - The note emission to emit
+/// * `context` - The private context to emit the note in
+/// * `recipient` - The address that should receive this note
+/// * `delivery_mode` - Controls encryption, tagging, and delivery constraints. Must be a compile-time constant.
+///   See `MessageDeliveryEnum` for details on the available modes.
+pub fn emit_note<Note>(
+    note_emission: NoteEmission<Note>,
     context: &mut PrivateContext,
     recipient: AztecAddress,
-) -> fn[(&mut PrivateContext, AztecAddress)](NoteEmission<Note>) -> ()
+    delivery_mode: u8,
+)
 where
     Note: NoteType + Packable,
 {
-    |e: NoteEmission<Note>| {
-        let note = e.note;
-        let storage_slot = e.storage_slot;
-        let note_hash_counter = e.note_hash_counter;
+    // This function relies on `delivery_mode` being a constant in order to reduce circuit constraints when unconstrained
+    // usage is requested. If `delivery_mode` were a runtime value then performance would suffer.
+    assert_constant(delivery_mode);
 
-        assert_note_exists(*context, note_hash_counter);
+    let note = note_emission.note;
+    let storage_slot = note_emission.storage_slot;
+    let note_hash_counter = note_emission.note_hash_counter;
 
-        // Safety: this function does not constrain the encryption of the log, as explained on its description.
-        let encrypted_log =
-            unsafe { remove_constraints(|| compute_note_log(note, storage_slot, recipient)) };
+    assert_note_exists(*context, note_hash_counter);
+
+    // The following maps out the 3 dimensions across which we configure message delivery.
+    let constrained_encryption = delivery_mode == MessageDelivery.CONSTRAINED_ONCHAIN;
+    let emit_as_offchain_message = delivery_mode == MessageDelivery.UNCONSTRAINED_OFFCHAIN;
+    // TODO(#14565): Add constrained tagging
+    let _constrained_tagging = delivery_mode == MessageDelivery.CONSTRAINED_ONCHAIN;
+
+    let ciphertext = remove_constraints_if(
+        !constrained_encryption,
+        || compute_ciphertext(note, storage_slot, recipient, PRIVATE_NOTE_MSG_TYPE_ID),
+    );
+
+    if emit_as_offchain_message {
+        emit_offchain_message(ciphertext, recipient);
+    } else {
+        // Safety: Currently unsafe. See description of CONSTRAINED_ONCHAIN in MessageDeliveryEnum.
+        // TODO(#14565): Implement proper constrained tag prefixing to make this truly CONSTRAINED_ONCHAIN
+        let log_content = prefix_with_tag(ciphertext, recipient);
+
         // Regardless of the original note size `N`, the log is padded with random bytes up to
         // `PRIVATE_LOG_SIZE_IN_FIELDS` to prevent leaking information about the actual size.
-        let length = encrypted_log.len();
-        context.emit_raw_note_log(encrypted_log, length, note_hash_counter);
-    }
-}
-
-/// Same as `encode_and_encrypt_note_unconstrained`, except the note is emitted as an offchain message instead of a
-/// private log.
-///
-/// Like `encode_and_encrypt_note_unconstrained`, this function uses unconstrained encryption. The sender can set any
-/// message contents, potentially preventing recipient decryption and resulting in note loss. Since offchain messages
-/// inherently lack delivery guarantees, constrained encryption provides no benefit and is not offered.
-///
-/// While delivery is not guaranteed, message integrity is still protected via cryptographic commitments in the note
-/// hash tree. For guaranteed delivery, use `encode_and_encrypt_note` with private logs instead. See
-/// `messages::offchain_message::emit_offchain_message` for more details on delivery guarantees.
-pub fn encode_and_encrypt_note_and_emit_as_offchain_message<Note>(
-    context: &mut PrivateContext,
-    recipient: AztecAddress,
-) -> fn[(&mut PrivateContext, AztecAddress)](NoteEmission<Note>) -> ()
-where
-    Note: NoteType + Packable,
-{
-    |e: NoteEmission<Note>| {
-        let note = e.note;
-        let storage_slot = e.storage_slot;
-        let note_hash_counter = e.note_hash_counter;
-
-        assert_note_exists(*context, note_hash_counter);
-
-        // Safety: this function does not constrain the encryption of the log, as explained on its description.
-        let encrypted_log =
-            unsafe { remove_constraints(|| compute_note_log(note, storage_slot, recipient)) };
-
-        // Remove the tag from the log
-        // TODO: This is a tech debt. We should refactor this file such that the log is by default computed without
-        // the tag.
-        let message_ciphertext: [_; PRIVATE_LOG_CIPHERTEXT_LEN] = subarray(encrypted_log, 1);
-
-        emit_offchain_message(message_ciphertext, recipient);
+        let length = log_content.len();
+        context.emit_raw_note_log(log_content, length, note_hash_counter);
     }
 }

--- a/noir-projects/aztec-nr/aztec/src/note/note_emission.nr
+++ b/noir-projects/aztec-nr/aztec/src/note/note_emission.nr
@@ -1,3 +1,8 @@
+use crate::{
+    context::PrivateContext, messages::logs::note::emit_note, note::note_interface::NoteType,
+};
+use protocol_types::{address::AztecAddress, traits::Packable};
+
 /**
  * A note emission struct containing the information required for emitting a note.
  * The exact `emit` logic is passed in by the application code
@@ -8,13 +13,16 @@ pub struct NoteEmission<Note> {
     pub note_hash_counter: u32, // a note_hash_counter of 0 means settled
 }
 
-impl<Note> NoteEmission<Note> {
+impl<Note> NoteEmission<Note>
+where
+    Note: NoteType + Packable,
+{
     pub fn new(note: Note, storage_slot: Field, note_hash_counter: u32) -> Self {
         Self { note, storage_slot, note_hash_counter }
     }
 
-    pub fn emit<Env>(self, _emit: fn[Env](Self) -> ()) {
-        _emit(self);
+    pub fn emit(self, context: &mut PrivateContext, recipient: AztecAddress, delivery_mode: u8) {
+        emit_note(self, context, recipient, delivery_mode);
     }
 
     pub fn discard(_self: Self) {}
@@ -32,14 +40,17 @@ pub struct OuterNoteEmission<Note> {
     pub emission: Option<NoteEmission<Note>>,
 }
 
-impl<Note> OuterNoteEmission<Note> {
+impl<Note> OuterNoteEmission<Note>
+where
+    Note: NoteType + Packable,
+{
     pub fn new(emission: Option<NoteEmission<Note>>) -> Self {
         Self { emission }
     }
 
-    pub fn emit<Env>(self, _emit: fn[Env](NoteEmission<Note>) -> ()) {
+    pub fn emit(self, context: &mut PrivateContext, recipient: AztecAddress, delivery_mode: u8) {
         if self.emission.is_some() {
-            _emit(self.emission.unwrap());
+            self.emission.unwrap_unchecked().emit(context, recipient, delivery_mode);
         }
     }
 

--- a/noir-projects/aztec-nr/easy-private-state/src/easy_private_uint.nr
+++ b/noir-projects/aztec-nr/easy-private-state/src/easy_private_uint.nr
@@ -1,11 +1,11 @@
-use dep::aztec::{
+use aztec::{
     context::{PrivateContext, UtilityContext},
-    messages::logs::note::encode_and_encrypt_note,
+    event::event_interface::MessageDelivery,
     note::note_getter_options::NoteGetterOptions,
     protocol_types::address::AztecAddress,
     state_vars::{PrivateSet, storage::HasStorageSlot},
 };
-use dep::value_note::{balance_utils, filter::filter_notes_min_sum, value_note::ValueNote};
+use value_note::{balance_utils, filter::filter_notes_min_sum, value_note::ValueNote};
 
 /// @deprecated (soon) (https://github.com/AztecProtocol/aztec-packages/issues/15959) because:
 /// - Its functionality is a subset of `BalanceSet`
@@ -43,7 +43,7 @@ impl EasyPrivateUint<&mut PrivateContext> {
 
         // Insert the new note to the owner's set of notes.
         // docs:start:insert
-        self.set.insert(addend_note).emit(encode_and_encrypt_note(self.context, owner));
+        self.set.insert(addend_note).emit(self.context, owner, MessageDelivery.CONSTRAINED_ONCHAIN);
         // docs:end:insert
     }
 
@@ -67,7 +67,7 @@ impl EasyPrivateUint<&mut PrivateContext> {
         // Creates change note for the owner.
         let result_value = minuend - subtrahend;
         let result_note = ValueNote::new(result_value as Field, owner);
-        self.set.insert(result_note).emit(encode_and_encrypt_note(self.context, owner));
+        self.set.insert(result_note).emit(self.context, owner, MessageDelivery.CONSTRAINED_ONCHAIN);
     }
 }
 

--- a/noir-projects/aztec-nr/value-note/src/utils.nr
+++ b/noir-projects/aztec-nr/value-note/src/utils.nr
@@ -2,7 +2,7 @@ use crate::{filter::filter_notes_min_sum, value_note::ValueNote};
 
 use aztec::{
     context::PrivateContext,
-    messages::logs::note::encode_and_encrypt_note,
+    event::event_interface::MessageDelivery,
     note::{note_getter_options::{NoteGetterOptions, SortOrder}, note_interface::NoteProperties},
     protocol_types::{address::AztecAddress, traits::Packable},
     state_vars::PrivateSet,
@@ -33,7 +33,7 @@ pub fn increment(
     let note = ValueNote::new(amount, recipient);
     // Insert the new note to the owner's set of notes and emit the log if value is non-zero.
     // TODO: consider how to give devs choice over this `encode_and_encrypt_note` function. At the moment, it's hard-coded as one of many potential strategies.
-    balance.insert(note).emit(encode_and_encrypt_note(balance.context, recipient));
+    balance.insert(note).emit(balance.context, recipient, MessageDelivery.CONSTRAINED_ONCHAIN);
 }
 
 // Find some of the `owner`'s notes whose values add up to the `amount`.

--- a/noir-projects/noir-contracts/contracts/account/ecdsa_k_account_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/account/ecdsa_k_account_contract/src/main.nr
@@ -7,8 +7,8 @@ pub contract EcdsaKAccount {
     use dep::aztec::{
         authwit::{account::AccountActions, entrypoint::{app::AppPayload, fee::FeePayload}},
         context::PrivateContext,
+        event::event_interface::MessageDelivery,
         macros::{functions::{initializer, noinitcheck, private, view}, storage::storage},
-        messages::logs::note::encode_and_encrypt_note,
         oracle::{auth_witness::get_auth_witness, notes::{get_sender_for_tags, set_sender_for_tags}},
         state_vars::PrivateImmutable,
     };
@@ -40,10 +40,11 @@ pub contract EcdsaKAccount {
 
         // Safety: Comment from above applies here as well.
         unsafe { set_sender_for_tags(this) };
-        storage.signing_public_key.initialize(pub_key_note).emit(encode_and_encrypt_note(
+        storage.signing_public_key.initialize(pub_key_note).emit(
             &mut context,
             this,
-        ));
+            MessageDelivery.CONSTRAINED_ONCHAIN,
+        );
         // Safety: Comment from above applies here as well.
         unsafe { set_sender_for_tags(original_sender) };
     }

--- a/noir-projects/noir-contracts/contracts/account/ecdsa_r_account_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/account/ecdsa_r_account_contract/src/main.nr
@@ -6,8 +6,8 @@ pub contract EcdsaRAccount {
     use dep::aztec::{
         authwit::{account::AccountActions, entrypoint::{app::AppPayload, fee::FeePayload}},
         context::PrivateContext,
+        event::event_interface::MessageDelivery,
         macros::{functions::{initializer, noinitcheck, private, view}, storage::storage},
-        messages::logs::note::encode_and_encrypt_note,
         oracle::{auth_witness::get_auth_witness, notes::{get_sender_for_tags, set_sender_for_tags}},
         state_vars::PrivateImmutable,
     };
@@ -39,10 +39,11 @@ pub contract EcdsaRAccount {
 
         // Safety: Comment from above applies here as well.
         unsafe { set_sender_for_tags(this) };
-        storage.signing_public_key.initialize(pub_key_note).emit(encode_and_encrypt_note(
+        storage.signing_public_key.initialize(pub_key_note).emit(
             &mut context,
             this,
-        ));
+            MessageDelivery.CONSTRAINED_ONCHAIN,
+        );
         // Safety: Comment from above applies here as well.
         unsafe { set_sender_for_tags(original_sender) };
     }

--- a/noir-projects/noir-contracts/contracts/account/schnorr_account_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/account/schnorr_account_contract/src/main.nr
@@ -13,9 +13,9 @@ pub contract SchnorrAccount {
             entrypoint::{app::AppPayload, fee::FeePayload},
         },
         context::PrivateContext,
+        event::event_interface::MessageDelivery,
         hash::compute_siloed_nullifier,
         macros::{functions::{initializer, noinitcheck, private, utility, view}, storage::storage},
-        messages::logs::note::encode_and_encrypt_note,
         oracle::{
             auth_witness::get_auth_witness,
             get_nullifier_membership_witness::get_low_nullifier_membership_witness,
@@ -54,10 +54,11 @@ pub contract SchnorrAccount {
 
         // Safety: Comment from above applies here as well.
         unsafe { set_sender_for_tags(this) };
-        storage.signing_public_key.initialize(pub_key_note).emit(encode_and_encrypt_note(
+        storage.signing_public_key.initialize(pub_key_note).emit(
             &mut context,
             this,
-        ));
+            MessageDelivery.CONSTRAINED_ONCHAIN,
+        );
         // Safety: Comment from above applies here as well.
         unsafe { set_sender_for_tags(original_sender) };
     }

--- a/noir-projects/noir-contracts/contracts/app/app_subscription_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/app_subscription_contract/src/main.nr
@@ -44,8 +44,8 @@ pub contract AppSubscription {
 
     use aztec::{
         authwit::auth::assert_current_call_valid_authwit,
+        event::event_interface::MessageDelivery,
         macros::{functions::{initializer, private, public, utility}, storage::storage},
-        messages::logs::note::encode_and_encrypt_note,
         oracle::notes::set_sender_for_tags,
         protocol_types::{address::AztecAddress, constants::MAX_FIELD_VALUE, traits::ToField},
         state_vars::{Map, PrivateMutable, PublicImmutable},
@@ -84,10 +84,11 @@ pub contract AppSubscription {
 
         note.remaining_txs -= 1;
 
-        storage.subscriptions.at(user_address).replace(note).emit(encode_and_encrypt_note(
+        storage.subscriptions.at(user_address).replace(note).emit(
             &mut context,
             user_address,
-        ));
+            MessageDelivery.CONSTRAINED_ONCHAIN,
+        );
 
         context.set_as_fee_payer();
 
@@ -155,7 +156,9 @@ pub contract AppSubscription {
 
         let subscription_note = SubscriptionNote::new(subscriber, expiry_block_number, tx_count);
         storage.subscriptions.at(subscriber).initialize_or_replace(subscription_note).emit(
-            encode_and_encrypt_note(&mut context, subscriber),
+            &mut context,
+            subscriber,
+            MessageDelivery.CONSTRAINED_ONCHAIN,
         );
     }
 

--- a/noir-projects/noir-contracts/contracts/app/card_game_contract/src/cards.nr
+++ b/noir-projects/noir-contracts/contracts/app/card_game_contract/src/cards.nr
@@ -1,16 +1,11 @@
-use dep::aztec::{
-    context::PrivateContext,
-    note::{
-        note_getter_options::NoteGetterOptions, note_viewer_options::NoteViewerOptions,
-        retrieved_note::RetrievedNote,
-    },
-};
-
-use dep::aztec::{
-    context::UtilityContext,
+use aztec::{
+    context::{PrivateContext, UtilityContext},
+    event::event_interface::MessageDelivery,
     keys::getters::get_public_keys,
-    messages::logs::note::encode_and_encrypt_note,
-    note::constants::MAX_NOTES_PER_PAGE,
+    note::{
+        constants::MAX_NOTES_PER_PAGE, note_getter_options::NoteGetterOptions,
+        note_viewer_options::NoteViewerOptions, retrieved_note::RetrievedNote,
+    },
     protocol_types::{
         address::AztecAddress,
         constants::MAX_NOTE_HASH_READ_REQUESTS_PER_CALL,
@@ -18,8 +13,8 @@ use dep::aztec::{
     },
     state_vars::{PrivateSet, storage::HasStorageSlot},
 };
-use dep::value_note::value_note::ValueNote;
 use std::meta::derive;
+use value_note::value_note::ValueNote;
 
 #[derive(Packable, Serialize)]
 pub struct Card {
@@ -121,7 +116,11 @@ impl Deck<&mut PrivateContext> {
         let mut inserted_cards = &[];
         for card in cards {
             let card_note = CardNote::from_card(card, owner);
-            self.set.insert(card_note.note).emit(encode_and_encrypt_note(self.set.context, owner));
+            self.set.insert(card_note.note).emit(
+                self.set.context,
+                owner,
+                MessageDelivery.CONSTRAINED_ONCHAIN,
+            );
             inserted_cards = inserted_cards.push_back(card_note);
         }
 

--- a/noir-projects/noir-contracts/contracts/app/crowdfunding_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/crowdfunding_contract/src/main.nr
@@ -1,28 +1,27 @@
 // docs:start:empty-contract
 mod config;
 
-use dep::aztec::macros::aztec;
+use aztec::macros::aztec;
 
 #[aztec]
 pub contract Crowdfunding {
     // docs:end:empty-contract
     // docs:start:all-deps
     use crate::config::Config;
-    use dep::aztec::{
-        event::event_interface::emit_event_in_public,
+    use aztec::{
+        event::event_interface::{emit_event_in_public, MessageDelivery},
         macros::{
             events::event,
             functions::{initializer, internal, private, public},
             storage::storage,
         },
-        messages::logs::note::encode_and_encrypt_note,
         protocol_types::address::AztecAddress,
         state_vars::{PrivateSet, PublicImmutable},
         utils::comparison::Comparator,
     };
-    use dep::uint_note::uint_note::UintNote;
     use router::utils::privately_check_timestamp;
     use token::Token;
+    use uint_note::uint_note::UintNote;
     // docs:end:all-deps
 
     // docs:start:withdrawal-processed-event
@@ -78,7 +77,11 @@ pub contract Crowdfunding {
         // contract by proving that the hash of this note exists in the note hash tree.
         let note = UintNote::new(amount, donor);
 
-        storage.donation_receipts.insert(note).emit(encode_and_encrypt_note(&mut context, donor));
+        storage.donation_receipts.insert(note).emit(
+            &mut context,
+            donor,
+            MessageDelivery.CONSTRAINED_ONCHAIN,
+        );
     }
     // docs:end:donate
 

--- a/noir-projects/noir-contracts/contracts/app/escrow_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/escrow_contract/src/main.nr
@@ -1,18 +1,19 @@
 // Sample escrow contract that stores a balance of a private token on behalf of an owner.
-use dep::aztec::macros::aztec;
+use aztec::macros::aztec;
 
 #[aztec]
 pub contract Escrow {
-    use dep::aztec::{
+    use aztec::{
+        event::event_interface::MessageDelivery,
         macros::{functions::{initializer, private}, storage::storage},
-        messages::logs::note::encode_and_encrypt_note,
+        protocol_types::address::AztecAddress,
+        state_vars::PrivateImmutable,
     };
-    use dep::aztec::{protocol_types::address::AztecAddress, state_vars::PrivateImmutable};
 
     // docs:start:addressnote_import
-    use dep::address_note::address_note::AddressNote;
+    use address_note::address_note::AddressNote;
     // docs:end:addressnote_import
-    use dep::token::Token;
+    use token::Token;
 
     #[storage]
     struct Storage<Context> {
@@ -26,7 +27,7 @@ pub contract Escrow {
         // docs:start:addressnote_new
         let note = AddressNote::new(owner, owner);
         // docs:end:addressnote_new
-        storage.owner.initialize(note).emit(encode_and_encrypt_note(&mut context, owner));
+        storage.owner.initialize(note).emit(&mut context, owner, MessageDelivery.CONSTRAINED_ONCHAIN);
     }
 
     // docs:start:withdraw

--- a/noir-projects/noir-contracts/contracts/app/nft_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/nft_contract/src/main.nr
@@ -12,11 +12,11 @@ pub contract NFT {
     use aztec::{
         authwit::auth::compute_authwit_nullifier,
         context::{PrivateContext, PublicContext},
+        event::event_interface::MessageDelivery,
         macros::{
             functions::{authorize_once, initializer, internal, private, public, utility, view},
             storage::storage,
         },
-        messages::logs::note::encode_and_encrypt_note,
         note::{
             constants::MAX_NOTES_PER_PAGE, note_getter_options::NoteGetterOptions,
             note_interface::NoteProperties, note_viewer_options::NoteViewerOptions,
@@ -302,7 +302,7 @@ pub contract NFT {
 
         let new_note = NFTNote::new(token_id, to);
 
-        nfts.at(to).insert(new_note).emit(encode_and_encrypt_note(&mut context, to));
+        nfts.at(to).insert(new_note).emit(&mut context, to, MessageDelivery.CONSTRAINED_ONCHAIN);
     }
     // docs:end:transfer_in_private
 

--- a/noir-projects/noir-contracts/contracts/app/simple_token_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/simple_token_contract/src/main.nr
@@ -1,6 +1,6 @@
 mod types;
 
-use dep::aztec::macros::aztec;
+use aztec::macros::aztec;
 
 // Minimal token contract. Do not use
 // For demonstration purposes in playground only
@@ -10,9 +10,9 @@ use dep::aztec::macros::aztec;
 pub contract SimpleToken {
     use std::ops::{Add, Sub};
 
-    use dep::compressed_string::FieldCompressedString;
+    use compressed_string::FieldCompressedString;
 
-    use dep::aztec::{
+    use aztec::{
         authwit::auth::compute_authwit_nullifier,
         context::{PrivateCallInterface, PrivateContext, PublicContext},
         event::event_interface::{emit_event_in_private, MessageDelivery},
@@ -21,12 +21,11 @@ pub contract SimpleToken {
             functions::{authorize_once, initializer, internal, private, public, utility, view},
             storage::storage,
         },
-        messages::logs::note::{encode_and_encrypt_note, encode_and_encrypt_note_unconstrained},
         protocol_types::address::AztecAddress,
         state_vars::{Map, PublicImmutable, PublicMutable},
     };
 
-    use dep::uint_note::uint_note::{PartialUintNote, UintNote};
+    use uint_note::uint_note::{PartialUintNote, UintNote};
 
     use crate::types::balance_set::BalanceSet;
 
@@ -127,7 +126,11 @@ pub contract SimpleToken {
         amount: u128,
         authwit_nonce: Field,
     ) {
-        storage.balances.at(from).sub(from, amount).emit(encode_and_encrypt_note(&mut context, from));
+        storage.balances.at(from).sub(from, amount).emit(
+            &mut context,
+            from,
+            MessageDelivery.CONSTRAINED_ONCHAIN,
+        );
         SimpleToken::at(context.this_address())._increase_public_balance(to, amount).enqueue(
             &mut context,
         );
@@ -144,14 +147,16 @@ pub contract SimpleToken {
             amount,
             INITIAL_TRANSFER_CALL_MAX_NOTES,
         );
-        storage.balances.at(from).add(from, change).emit(encode_and_encrypt_note_unconstrained(
+        storage.balances.at(from).add(from, change).emit(
             &mut context,
             from,
-        ));
-        storage.balances.at(to).add(to, amount).emit(encode_and_encrypt_note_unconstrained(
+            MessageDelivery.UNCONSTRAINED_ONCHAIN,
+        );
+        storage.balances.at(to).add(to, amount).emit(
             &mut context,
             to,
-        ));
+            MessageDelivery.UNCONSTRAINED_ONCHAIN,
+        );
 
         emit_event_in_private(
             Transfer { from, to, amount },
@@ -164,7 +169,11 @@ pub contract SimpleToken {
     #[authorize_once("from", "authwit_nonce")]
     #[private]
     fn burn_private(from: AztecAddress, amount: u128, authwit_nonce: Field) {
-        storage.balances.at(from).sub(from, amount).emit(encode_and_encrypt_note(&mut context, from));
+        storage.balances.at(from).sub(from, amount).emit(
+            &mut context,
+            from,
+            MessageDelivery.CONSTRAINED_ONCHAIN,
+        );
         SimpleToken::at(context.this_address())._reduce_total_supply(amount).enqueue(&mut context);
     }
 

--- a/noir-projects/noir-contracts/contracts/app/token_blacklist_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_blacklist_contract/src/main.nr
@@ -1,6 +1,6 @@
 mod types;
 
-use dep::aztec::macros::aztec;
+use aztec::macros::aztec;
 
 // NOTE: This contract is stale and is kept around only as a reference of how to implement a blacklist.
 // Don't take into consideration the interface of this contract. The TransparentNote "shield" flow is
@@ -18,15 +18,13 @@ use dep::aztec::macros::aztec;
 pub contract TokenBlacklist {
     // Libs
     use aztec::{
+        event::event_interface::MessageDelivery,
         hash::compute_secret_hash,
         macros::{
             functions::{authorize_once, initializer, internal, private, public, utility, view},
             storage::storage,
         },
-        messages::{
-            discovery::private_notes::attempt_note_discovery,
-            logs::note::{encode_and_encrypt_note, encode_and_encrypt_note_unconstrained},
-        },
+        messages::discovery::private_notes::attempt_note_discovery,
         note::{
             note_getter_options::NoteGetterOptions,
             note_interface::{NoteHash, NoteProperties, NoteType},
@@ -192,7 +190,7 @@ pub contract TokenBlacklist {
         assert(notes.len() == 1, "note not popped");
 
         // Add the token note to user's balances set
-        storage.balances.add(to, amount).emit(encode_and_encrypt_note(&mut context, to));
+        storage.balances.add(to, amount).emit(&mut context, to, MessageDelivery.CONSTRAINED_ONCHAIN);
     }
 
     #[authorize_once("from", "authwit_nonce")]
@@ -203,7 +201,11 @@ pub contract TokenBlacklist {
         let to_roles = storage.roles.at(to).get_current_value();
         assert(!to_roles.is_blacklisted, "Blacklisted: Recipient");
 
-        storage.balances.sub(from, amount).emit(encode_and_encrypt_note(&mut context, from));
+        storage.balances.sub(from, amount).emit(
+            &mut context,
+            from,
+            MessageDelivery.CONSTRAINED_ONCHAIN,
+        );
 
         TokenBlacklist::at(context.this_address())._increase_public_balance(to, amount).enqueue(
             &mut context,
@@ -219,14 +221,16 @@ pub contract TokenBlacklist {
         let to_roles = storage.roles.at(to).get_current_value();
         assert(!to_roles.is_blacklisted, "Blacklisted: Recipient");
 
-        storage.balances.sub(from, amount).emit(encode_and_encrypt_note_unconstrained(
+        storage.balances.sub(from, amount).emit(
             &mut context,
             from,
-        ));
-        storage.balances.add(to, amount).emit(encode_and_encrypt_note_unconstrained(
+            MessageDelivery.UNCONSTRAINED_ONCHAIN,
+        );
+        storage.balances.add(to, amount).emit(
             &mut context,
             to,
-        ));
+            MessageDelivery.UNCONSTRAINED_ONCHAIN,
+        );
     }
 
     #[authorize_once("from", "authwit_nonce")]
@@ -235,7 +239,11 @@ pub contract TokenBlacklist {
         let from_roles = storage.roles.at(from).get_current_value();
         assert(!from_roles.is_blacklisted, "Blacklisted: Sender");
 
-        storage.balances.sub(from, amount).emit(encode_and_encrypt_note(&mut context, from));
+        storage.balances.sub(from, amount).emit(
+            &mut context,
+            from,
+            MessageDelivery.CONSTRAINED_ONCHAIN,
+        );
 
         TokenBlacklist::at(context.this_address())._reduce_total_supply(amount).enqueue(&mut context);
     }

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/main.nr
@@ -26,7 +26,6 @@ pub contract Token {
             functions::{authorize_once, initializer, internal, private, public, utility, view},
             storage::storage,
         },
-        messages::logs::note::{encode_and_encrypt_note, encode_and_encrypt_note_unconstrained},
         state_vars::{Map, PublicImmutable, PublicMutable},
     };
 
@@ -235,7 +234,11 @@ pub contract Token {
         amount: u128,
         authwit_nonce: Field,
     ) {
-        storage.balances.at(from).sub(from, amount).emit(encode_and_encrypt_note(&mut context, from));
+        storage.balances.at(from).sub(from, amount).emit(
+            &mut context,
+            from,
+            MessageDelivery.CONSTRAINED_ONCHAIN,
+        );
         Token::at(context.this_address())._increase_public_balance(to, amount).enqueue(&mut context);
     }
     // docs:end:transfer_to_public
@@ -262,7 +265,11 @@ pub contract Token {
         amount: u128,
         authwit_nonce: Field,
     ) -> PartialUintNote {
-        storage.balances.at(from).sub(from, amount).emit(encode_and_encrypt_note(&mut context, from));
+        storage.balances.at(from).sub(from, amount).emit(
+            &mut context,
+            from,
+            MessageDelivery.CONSTRAINED_ONCHAIN,
+        );
         Token::at(context.this_address())._increase_public_balance(to, amount).enqueue(&mut context);
 
         // We prepare the private balance increase (the partial note for the change).
@@ -287,14 +294,16 @@ pub contract Token {
             amount,
             INITIAL_TRANSFER_CALL_MAX_NOTES,
         );
-        storage.balances.at(from).add(from, change).emit(encode_and_encrypt_note_unconstrained(
+        storage.balances.at(from).add(from, change).emit(
             &mut context,
             from,
-        ));
-        storage.balances.at(to).add(to, amount).emit(encode_and_encrypt_note_unconstrained(
+            MessageDelivery.UNCONSTRAINED_ONCHAIN,
+        );
+        storage.balances.at(to).add(to, amount).emit(
             &mut context,
             to,
-        ));
+            MessageDelivery.UNCONSTRAINED_ONCHAIN,
+        );
 
         // We don't constrain encryption of the note log in `transfer` (unlike in `transfer_in_private`) because the transfer
         // function is only designed to be used in situations where the event is not strictly necessary (e.g. payment to
@@ -385,9 +394,17 @@ pub contract Token {
         authwit_nonce: Field,
     ) {
         // docs:start:increase_private_balance
-        storage.balances.at(from).sub(from, amount).emit(encode_and_encrypt_note(&mut context, from));
+        storage.balances.at(from).sub(from, amount).emit(
+            &mut context,
+            from,
+            MessageDelivery.CONSTRAINED_ONCHAIN,
+        );
         // docs:end:increase_private_balance
-        storage.balances.at(to).add(to, amount).emit(encode_and_encrypt_note(&mut context, to));
+        storage.balances.at(to).add(to, amount).emit(
+            &mut context,
+            to,
+            MessageDelivery.CONSTRAINED_ONCHAIN,
+        );
     }
     // docs:end:transfer_in_private
 
@@ -395,7 +412,11 @@ pub contract Token {
     #[authorize_once("from", "authwit_nonce")]
     #[private]
     fn burn_private(from: AztecAddress, amount: u128, authwit_nonce: Field) {
-        storage.balances.at(from).sub(from, amount).emit(encode_and_encrypt_note(&mut context, from));
+        storage.balances.at(from).sub(from, amount).emit(
+            &mut context,
+            from,
+            MessageDelivery.CONSTRAINED_ONCHAIN,
+        );
         Token::at(context.this_address())._reduce_total_supply(amount).enqueue(&mut context);
     }
     // docs:end:burn_private
@@ -492,7 +513,11 @@ pub contract Token {
         authwit_nonce: Field,
     ) {
         // First we subtract the `amount` from the private balance of `from`
-        storage.balances.at(from).sub(from, amount).emit(encode_and_encrypt_note(&mut context, from));
+        storage.balances.at(from).sub(from, amount).emit(
+            &mut context,
+            from,
+            MessageDelivery.CONSTRAINED_ONCHAIN,
+        );
 
         partial_note.complete_from_private(&mut context, context.msg_sender(), amount);
     }

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/types/balance_set.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/types/balance_set.nr
@@ -73,7 +73,7 @@ impl BalanceSet<&mut PrivateContext> {
     pub fn sub(self: Self, owner: AztecAddress, amount: u128) -> OuterNoteEmission<UintNote> {
         let subtracted = self.try_sub(amount, MAX_NOTE_HASH_READ_REQUESTS_PER_CALL);
 
-        // try_sub may have substracted more or less than amount. We must ensure that we subtracted at least as much as
+        // try_sub may have subtracted more or less than amount. We must ensure that we subtracted at least as much as
         // we needed, and then create a new note for the owner for the change (if any).
         assert(subtracted >= amount, "Balance too low");
         self.add(owner, subtracted - amount)

--- a/noir-projects/noir-contracts/contracts/docs/docs_example_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/docs/docs_example_contract/src/main.nr
@@ -9,8 +9,8 @@ pub contract DocsExample {
     // how to import dependencies defined in your workspace
     use aztec::{
         context::PrivateContext,
+        event::event_interface::MessageDelivery,
         macros::{functions::{private, public, utility}, storage::{storage, storage_no_init}},
-        messages::logs::note::encode_and_encrypt_note,
         note::{note_interface::NoteProperties, note_viewer_options::NoteViewerOptions},
         protocol_types::{address::AztecAddress, traits::Hash},
         state_vars::{
@@ -101,10 +101,11 @@ pub contract DocsExample {
     fn initialize_private_immutable(points: u8) {
         let new_card = CardNote::new(points, context.msg_sender());
 
-        storage.private_immutable.initialize(new_card).emit(encode_and_encrypt_note(
+        storage.private_immutable.initialize(new_card).emit(
             &mut context,
             context.msg_sender(),
-        ));
+            MessageDelivery.CONSTRAINED_ONCHAIN,
+        );
     }
     // docs:end:initialize-private-mutable
 
@@ -127,10 +128,11 @@ pub contract DocsExample {
         let new_card = CardNote::new(points, context.msg_sender());
 
         // docs:start:state_vars-PrivateMutableReplace
-        storage.legendary_card.replace(new_card).emit(encode_and_encrypt_note(
+        storage.legendary_card.replace(new_card).emit(
             &mut context,
             context.msg_sender(),
-        ));
+            MessageDelivery.CONSTRAINED_ONCHAIN,
+        );
         // docs:end:state_vars-PrivateMutableReplace
     }
 

--- a/noir-projects/noir-contracts/contracts/test/child_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/child_contract/src/main.nr
@@ -6,8 +6,8 @@ pub contract Child {
     use dep::aztec::protocol_types::address::AztecAddress;
 
     use dep::aztec::{
+        event::event_interface::MessageDelivery,
         macros::{functions::{internal, private, public}, storage::storage},
-        messages::logs::note::encode_and_encrypt_note,
         note::{note_getter_options::NoteGetterOptions, note_interface::NoteProperties},
         state_vars::{Map, PrivateSet, PublicMutable},
         utils::comparison::Comparator,
@@ -62,10 +62,11 @@ pub contract Child {
         let note = ValueNote::new(new_value, owner);
         // docs:end:valuenote_new
 
-        storage.a_map_with_private_values.at(owner).insert(note).emit(encode_and_encrypt_note(
+        storage.a_map_with_private_values.at(owner).insert(note).emit(
             &mut context,
             owner,
-        ));
+            MessageDelivery.CONSTRAINED_ONCHAIN,
+        );
         new_value
     }
 

--- a/noir-projects/noir-contracts/contracts/test/no_constructor_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/no_constructor_contract/src/main.nr
@@ -5,8 +5,8 @@ use aztec::macros::aztec;
 #[aztec]
 pub contract NoConstructor {
     use aztec::{
+        event::event_interface::MessageDelivery,
         macros::{functions::{private, public, utility}, storage::storage},
-        messages::logs::note::encode_and_encrypt_note,
         state_vars::PrivateMutable,
     };
 
@@ -29,10 +29,11 @@ pub contract NoConstructor {
     fn initialize_private_mutable(value: Field) {
         let note = ValueNote::new(value, context.msg_sender());
 
-        storage.private_mutable.initialize(note).emit(encode_and_encrypt_note(
+        storage.private_mutable.initialize(note).emit(
             &mut context,
             context.msg_sender(),
-        ));
+            MessageDelivery.CONSTRAINED_ONCHAIN,
+        );
     }
 
     /// Helper function used to test that call to `initialize_private_mutable` was successful or not yet performed.

--- a/noir-projects/noir-contracts/contracts/test/note_getter_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/note_getter_contract/src/main.nr
@@ -5,7 +5,7 @@ use aztec::macros::aztec;
 pub contract NoteGetter {
     use aztec::{
         // Core functionality
-        messages::logs::note::encode_and_encrypt_note,
+        event::event_interface::MessageDelivery,
         note::note_interface::NoteProperties,
         // Macros
         macros::{functions::{private, utility}, storage::storage},
@@ -24,7 +24,11 @@ pub contract NoteGetter {
     fn insert_note(value: Field) {
         let note = ValueNote::new(value, context.msg_sender());
 
-        storage.set.insert(note).emit(encode_and_encrypt_note(&mut context, context.msg_sender()));
+        storage.set.insert(note).emit(
+            &mut context,
+            context.msg_sender(),
+            MessageDelivery.CONSTRAINED_ONCHAIN,
+        );
     }
 
     #[utility]

--- a/noir-projects/noir-contracts/contracts/test/offchain_effect_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/offchain_effect_contract/src/main.nr
@@ -6,7 +6,6 @@ contract OffchainEffect {
     use aztec::{
         event::event_interface::{emit_event_in_private, MessageDelivery},
         macros::{events::event, functions::{private, utility}, storage::storage},
-        messages::logs::note::encode_and_encrypt_note_and_emit_as_offchain_message,
         note::note_viewer_options::NoteViewerOptions,
         oracle::offchain_effect::emit_offchain_effect,
         protocol_types::{address::AztecAddress, traits::Serialize},
@@ -64,10 +63,9 @@ contract OffchainEffect {
         let note = UintNote::new(value, owner);
 
         storage.balances.at(owner).insert(note).emit(
-            encode_and_encrypt_note_and_emit_as_offchain_message(
-                &mut context,
-                context.msg_sender(),
-            ),
+            &mut context,
+            context.msg_sender(),
+            MessageDelivery.UNCONSTRAINED_OFFCHAIN,
         );
     }
 

--- a/noir-projects/noir-contracts/contracts/test/pending_note_hashes_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/pending_note_hashes_contract/src/main.nr
@@ -9,8 +9,8 @@ pub contract PendingNoteHashes {
     // Libs
     use aztec::{
         context::PrivateContext,
+        event::event_interface::MessageDelivery,
         macros::{functions::private, storage::storage},
-        messages::logs::note::encode_and_encrypt_note,
         note::{note_emission::NoteEmission, note_getter_options::NoteGetterOptions},
         protocol_types::{
             abis::function_selector::FunctionSelector,
@@ -44,7 +44,7 @@ pub contract PendingNoteHashes {
         let note = ValueNote::new(amount, owner);
 
         // Insert note
-        owner_balance.insert(note).emit(encode_and_encrypt_note(&mut context, owner));
+        owner_balance.insert(note).emit(&mut context, owner, MessageDelivery.CONSTRAINED_ONCHAIN);
 
         let options = NoteGetterOptions::with_filter(filter_notes_min_sum, amount);
         // get note inserted above
@@ -87,7 +87,7 @@ pub contract PendingNoteHashes {
         let note = ValueNote::new(amount, owner);
 
         // Insert note
-        owner_balance.insert(note).emit(encode_and_encrypt_note(&mut context, owner));
+        owner_balance.insert(note).emit(&mut context, owner, MessageDelivery.CONSTRAINED_ONCHAIN);
     }
 
     // Nested/inner function to create and insert a note
@@ -103,7 +103,7 @@ pub contract PendingNoteHashes {
         let note = ValueNote::unpack([amount.to_field(), owner.to_field(), randomness.to_field()]);
 
         // Insert note
-        owner_balance.insert(note).emit(encode_and_encrypt_note(&mut context, owner));
+        owner_balance.insert(note).emit(&mut context, owner, MessageDelivery.CONSTRAINED_ONCHAIN);
     }
 
     // Nested/inner function to create and insert a note
@@ -117,10 +117,10 @@ pub contract PendingNoteHashes {
         // Insert note
         let emission = owner_balance.insert(note);
 
-        emission.emit(encode_and_encrypt_note(&mut context, owner));
+        emission.emit(&mut context, owner, MessageDelivery.CONSTRAINED_ONCHAIN);
 
         // Emit note again
-        emission.emit(encode_and_encrypt_note(&mut context, owner));
+        emission.emit(&mut context, owner, MessageDelivery.CONSTRAINED_ONCHAIN);
     }
 
     // Nested/inner function to get a note and confirm it matches the expected value
@@ -335,7 +335,7 @@ pub contract PendingNoteHashes {
         let good_note = ValueNote::new(10, owner);
         // Insert good note with real log
         let good_note_emission = owner_balance.insert(good_note);
-        good_note_emission.emit(encode_and_encrypt_note(&mut context, owner));
+        good_note_emission.emit(&mut context, owner, MessageDelivery.CONSTRAINED_ONCHAIN);
 
         // We will emit a note log with an incorrect preimage to ensure the pxe throws
         // This note has not been inserted...
@@ -346,7 +346,7 @@ pub contract PendingNoteHashes {
             good_note_emission.note_hash_counter,
         );
 
-        bad_note_emission.emit(encode_and_encrypt_note(&mut context, owner));
+        bad_note_emission.emit(&mut context, owner, MessageDelivery.CONSTRAINED_ONCHAIN);
     }
 
     #[contract_library_method]
@@ -359,7 +359,7 @@ pub contract PendingNoteHashes {
 
         for i in 0..max_notes_per_call() {
             let note = ValueNote::new(i as Field, owner);
-            owner_balance.insert(note).emit(encode_and_encrypt_note(context, owner));
+            owner_balance.insert(note).emit(context, owner, MessageDelivery.CONSTRAINED_ONCHAIN);
         }
     }
 
@@ -367,7 +367,7 @@ pub contract PendingNoteHashes {
     fn destroy_max_notes(owner: AztecAddress, storage: Storage<&mut PrivateContext>) {
         let owner_balance = storage.balances.at(owner);
         // Note that we're relying on PXE actually returning the notes, we're not constraining that any specific
-        // numer of notes are deleted.
+        // number of notes are deleted.
         let _ = owner_balance.pop_notes(NoteGetterOptions::new());
     }
 

--- a/noir-projects/noir-contracts/contracts/test/spam_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/spam_contract/src/main.nr
@@ -1,14 +1,13 @@
 mod types;
 
-use dep::aztec::macros::aztec;
+use aztec::macros::aztec;
 
-// A contract used for testing a random hodgepodge of small features from simulator and end-to-end tests.
 #[aztec]
 pub contract Spam {
 
-    use dep::aztec::{
+    use aztec::{
+        event::event_interface::MessageDelivery,
         macros::{functions::{internal, private, public}, storage::storage},
-        messages::logs::note::encode_and_encrypt_note_unconstrained,
         protocol_types::{
             address::AztecAddress,
             constants::{
@@ -35,7 +34,9 @@ pub contract Spam {
 
         for _ in 0..MAX_NOTE_HASHES_PER_CALL {
             storage.balances.at(caller).add(caller, amount).emit(
-                encode_and_encrypt_note_unconstrained(&mut context, caller),
+                &mut context,
+                caller,
+                MessageDelivery.UNCONSTRAINED_ONCHAIN,
             );
         }
 

--- a/noir-projects/noir-contracts/contracts/test/state_vars_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/state_vars_contract/src/main.nr
@@ -4,8 +4,8 @@ use aztec::macros::aztec;
 #[aztec]
 pub contract StateVars {
     use aztec::{
+        event::event_interface::MessageDelivery,
         macros::{functions::{private, public, utility, view}, storage::{storage, storage_no_init}},
-        messages::logs::note::encode_and_encrypt_note,
         protocol_types::{address::AztecAddress, traits::{Deserialize, Packable, Serialize}},
         state_vars::{PrivateImmutable, PrivateMutable, PublicImmutable, PublicMutable},
     };
@@ -101,30 +101,33 @@ pub contract StateVars {
     fn initialize_private_immutable(randomness: Field, value: Field) {
         let new_note = ValueNote::new(value, context.msg_sender());
 
-        storage.private_immutable.initialize(new_note).emit(encode_and_encrypt_note(
+        storage.private_immutable.initialize(new_note).emit(
             &mut context,
             context.msg_sender(),
-        ));
+            MessageDelivery.CONSTRAINED_ONCHAIN,
+        );
     }
 
     #[private]
     fn initialize_private(randomness: Field, value: Field) {
         let private_mutable = ValueNote::new(value, context.msg_sender());
 
-        storage.private_mutable.initialize(private_mutable).emit(encode_and_encrypt_note(
+        storage.private_mutable.initialize(private_mutable).emit(
             &mut context,
             context.msg_sender(),
-        ));
+            MessageDelivery.CONSTRAINED_ONCHAIN,
+        );
     }
 
     #[private]
     fn update_private_mutable(randomness: Field, value: Field) {
         let new_note = ValueNote::new(value, context.msg_sender());
 
-        storage.private_mutable.replace(new_note).emit(encode_and_encrypt_note(
+        storage.private_mutable.replace(new_note).emit(
             &mut context,
             context.msg_sender(),
-        ));
+            MessageDelivery.CONSTRAINED_ONCHAIN,
+        );
     }
 
     #[private]
@@ -139,10 +142,11 @@ pub contract StateVars {
         let new_note = ValueNote::new(new_value, context.msg_sender());
 
         // Replace existing note with new note
-        storage.private_mutable.replace(new_note).emit(encode_and_encrypt_note(
+        storage.private_mutable.replace(new_note).emit(
             &mut context,
             context.msg_sender(),
-        ));
+            MessageDelivery.CONSTRAINED_ONCHAIN,
+        );
     }
 
     #[utility]

--- a/noir-projects/noir-contracts/contracts/test/static_child_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/static_child_contract/src/main.nr
@@ -4,8 +4,8 @@ use dep::aztec::macros::aztec;
 #[aztec]
 pub contract StaticChild {
     use dep::aztec::{
+        event::event_interface::MessageDelivery,
         macros::{functions::{private, public, view}, storage::storage},
-        messages::logs::note::encode_and_encrypt_note,
         note::note_getter_options::NoteGetterOptions,
         protocol_types::address::AztecAddress,
         state_vars::{PrivateSet, PublicMutable},
@@ -46,7 +46,11 @@ pub contract StaticChild {
     #[view]
     fn private_illegal_set_value(new_value: Field, owner: AztecAddress) -> Field {
         let note = ValueNote::new(new_value, owner);
-        storage.a_private_value.insert(note).emit(encode_and_encrypt_note(&mut context, owner));
+        storage.a_private_value.insert(note).emit(
+            &mut context,
+            owner,
+            MessageDelivery.CONSTRAINED_ONCHAIN,
+        );
         new_value
     }
 
@@ -55,7 +59,11 @@ pub contract StaticChild {
     fn private_set_value(new_value: Field, owner: AztecAddress, sender: AztecAddress) -> Field {
         let note = ValueNote::new(new_value, owner);
 
-        storage.a_private_value.insert(note).emit(encode_and_encrypt_note(&mut context, owner));
+        storage.a_private_value.insert(note).emit(
+            &mut context,
+            owner,
+            MessageDelivery.CONSTRAINED_ONCHAIN,
+        );
         new_value
     }
 

--- a/noir-projects/noir-contracts/contracts/test/test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/test_contract/src/main.nr
@@ -2,7 +2,7 @@ mod test;
 mod test_note;
 
 // A contract used for testing a random hodgepodge of small features from simulator and end-to-end tests.
-use dep::aztec::macros::aztec;
+use aztec::macros::aztec;
 
 // DEPRECATED: This contract is deprecated. If you want to test new features, create a simple new contract used
 // to test only that one feature. See NoConstructor contract for example.
@@ -11,44 +11,47 @@ pub contract Test {
     // Note: If you import a new kind of note you will most likely need to update the test_note_type_id test
     // as the note type ids of current notes might have changed.
 
-    use dep::aztec::messages::logs::note::encode_and_encrypt_note;
-    use dep::aztec::{
-        note::{note_getter_options::NoteGetterOptions, note_viewer_options::NoteViewerOptions},
+    use aztec::{
+        // Note related imports
+        note::{
+            constants::MAX_NOTES_PER_PAGE,
+            lifecycle::{create_note, destroy_note_unsafe},
+            note_getter::{get_notes, view_notes},
+            note_getter_options::{NoteGetterOptions, NoteStatus},
+            note_viewer_options::NoteViewerOptions,
+            retrieved_note::RetrievedNote,
+        },
+        // State variable types
         state_vars::{
             DelayedPublicMutable, Map, PrivateImmutable, PrivateMutable, PrivateSet,
             PublicImmutable,
         },
-    };
-
-    use dep::aztec::protocol_types::{
-        abis::function_selector::FunctionSelector,
-        address::{AztecAddress, EthAddress},
-        constants::{MAX_NOTE_HASH_READ_REQUESTS_PER_CALL, PRIVATE_LOG_SIZE_IN_FIELDS},
-        traits::{Hash, Packable, Serialize},
-    };
-
-    use dep::aztec::keys::getters::get_public_keys;
-    use dep::aztec::note::constants::MAX_NOTES_PER_PAGE;
-
-    use dep::aztec::{
+        // Protocol types and constants
+        protocol_types::{
+            abis::function_selector::FunctionSelector,
+            address::{AztecAddress, EthAddress},
+            constants::{MAX_NOTE_HASH_READ_REQUESTS_PER_CALL, PRIVATE_LOG_SIZE_IN_FIELDS},
+            traits::{Hash, Packable, Serialize},
+        },
+        // Event related
         event::event_interface::{emit_event_in_private, MessageDelivery},
+        // Hashing
         hash::{ArgsHasher, pedersen_hash},
+        // History and inclusion proofs
         history::note_inclusion::ProveNoteInclusion,
+        // Key management
+        keys::getters::get_public_keys,
+        // Macros
         macros::{
             events::event,
             functions::{initializer, internal, noinitcheck, private, public, utility},
             storage::storage,
         },
-        note::{
-            lifecycle::{create_note, destroy_note_unsafe},
-            note_getter::{get_notes, view_notes},
-            note_getter_options::NoteStatus,
-            retrieved_note::RetrievedNote,
-        },
+        // Contract instance management
         publish_contract_instance::publish_contract_instance_for_public_execution,
     };
-    use dep::token_portal_content_hash_lib::get_mint_to_private_content_hash;
     use std::meta::derive;
+    use token_portal_content_hash_lib::get_mint_to_private_content_hash;
 
     // We are importing different kinds of notes to test the note type ids
     use crate::test_note::TestNote;
@@ -137,10 +140,11 @@ pub contract Test {
     ) {
         // docs:start:create_note
         let note = UintNote::new(value, owner);
-        create_note(&mut context, storage_slot, note).emit(encode_and_encrypt_note(
+        create_note(&mut context, storage_slot, note).emit(
             &mut context,
             owner,
-        ));
+            MessageDelivery.CONSTRAINED_ONCHAIN,
+        );
         // docs:end:create_note
 
         if make_tx_hybrid {

--- a/noir-projects/noir-contracts/contracts/test/updatable_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/updatable_contract/src/main.nr
@@ -1,14 +1,16 @@
-use dep::aztec::macros::aztec;
+use aztec::macros::aztec;
 
 /// A contract that can be updated to a new contract class. Used to test contract updates in e2e_contract_updates.test.ts.
 #[aztec]
 contract Updatable {
-    use aztec::macros::{functions::{initializer, private, public, utility}, storage::storage};
-    use aztec::messages::logs::note::encode_and_encrypt_note;
-    use aztec::state_vars::{PrivateMutable, PublicMutable};
-
-    use aztec::protocol_types::{
-        constants::CONTRACT_INSTANCE_REGISTRY_CONTRACT_ADDRESS, contract_class_id::ContractClassId,
+    use aztec::{
+        event::event_interface::MessageDelivery,
+        macros::{functions::{initializer, private, public, utility}, storage::storage},
+        protocol_types::{
+            constants::CONTRACT_INSTANCE_REGISTRY_CONTRACT_ADDRESS,
+            contract_class_id::ContractClassId,
+        },
+        state_vars::{PrivateMutable, PublicMutable},
     };
     use contract_instance_registry::ContractInstanceRegistry;
     use value_note::value_note::ValueNote;
@@ -24,10 +26,11 @@ contract Updatable {
     fn initialize(initial_value: Field) {
         let owner = context.msg_sender();
         let new_value = ValueNote::new(initial_value, owner);
-        storage.private_value.initialize(new_value).emit(encode_and_encrypt_note(
+        storage.private_value.initialize(new_value).emit(
             &mut context,
             owner,
-        ));
+            MessageDelivery.CONSTRAINED_ONCHAIN,
+        );
         Updatable::at(context.this_address()).set_public_value(initial_value).enqueue(&mut context);
     }
 

--- a/noir-projects/noir-contracts/contracts/test/updated_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/updated_contract/src/main.nr
@@ -1,13 +1,14 @@
-use dep::aztec::macros::aztec;
+use aztec::macros::aztec;
 
 /// A contract to whose contract class the `Updatable` contract is updated to in `e2e_contract_updates.test.ts`.
 #[aztec]
 contract Updated {
-    use aztec::macros::{functions::{private, public, utility}, storage::storage};
-    use aztec::messages::logs::note::encode_and_encrypt_note;
-    use aztec::state_vars::{PrivateMutable, PublicMutable};
-
-    use aztec::protocol_types::constants::CONTRACT_INSTANCE_REGISTRY_CONTRACT_ADDRESS;
+    use aztec::{
+        event::event_interface::MessageDelivery,
+        macros::{functions::{private, public, utility}, storage::storage},
+        protocol_types::constants::CONTRACT_INSTANCE_REGISTRY_CONTRACT_ADDRESS,
+        state_vars::{PrivateMutable, PublicMutable},
+    };
     use contract_instance_registry::ContractInstanceRegistry;
     use value_note::value_note::ValueNote;
 
@@ -26,7 +27,11 @@ contract Updated {
     fn set_private_value() {
         let owner = context.msg_sender();
         let new_note = ValueNote::new(27, owner);
-        storage.private_value.replace(new_note).emit(encode_and_encrypt_note(&mut context, owner));
+        storage.private_value.replace(new_note).emit(
+            &mut context,
+            owner,
+            MessageDelivery.CONSTRAINED_ONCHAIN,
+        );
     }
 
     #[public]


### PR DESCRIPTION
Refactoring note emission API to use the recently introduced `MessageDelivery` global var.

```diff
- note_emission.emit(encode_and_encrypt_note(&mut context, from));
+ note_emission.emit(&mut context, from, MessageDelivery.CONSTRAINED_ONCHAIN);
```

```diff
- note_emission.emit(encode_and_encrypt_note_unconstrained(&mut context, from));
+ note_emission.emit(&mut context, from, MessageDelivery.UNCONSTRAINED_ONCHAIN);
```

```diff
- note_emission.emit(encode_and_encrypt_note_and_emit_as_offchain_message(&mut context, context.msg_sender());
+ note_emission.emit(&mut context, context.msg_sender(), MessageDelivery.UNCONSTRAINED_OFFCHAIN);
```

## Followup work

### Achieving final imports
Would give the highest priority to tackling [this issue](https://github.com/AztecProtocol/aztec-packages/issues/16771) because the import of `MessageDelivery` affects contract code and we don't want to force devs to do 2 annoying migrations. Plan on tackling that right after this PR is merged.

## Random thoughts that came to my mind while implementing this

### Consider renaming `OuterNoteEmission`
I would consider renaming `OuterNoteEmission` to `MaybeNoteEmission` because `OuterNoteEmission` is not really descriptive (it being outer feels like an implementation detail and not something you want to communicate to the struct consumer). But devs don't really get exposed to this that much so possibly doesn't matter much.

### `noteEmission.discard(...)`
I've also noticed that the discard method on the note emission structs is not ever used in our codebase. I feel like notes might be too important to ever be discarded so would revisit whether having the func makes sense.

### Emitting partial notes as offchain message
None of our partial notes implementations support emission via an offchain message.

## On using AI
In this PR there was a lot of repetitive changes in the contracts and I realized that if I write nice migration notes first then I can use that as an input to the prompt. This made the AI output flawless.