### PR TITLE
refactor: add unsafe and prime for recency

### DIFF
--- a/l1-contracts/gas_benchmark.md
+++ b/l1-contracts/gas_benchmark.md
@@ -18,7 +18,7 @@
 |----------------------|---------|---------|---------------|--------------|
 | propose              | 152,610 | 169,137 |         1,060 |       16,960 |
 | submitEpochRootProof | 813,442 | 834,067 |         3,812 |       60,992 |
-| setupEpoch           |  40,849 | 108,446 |             - |            - |
+| setupEpoch           |  40,850 | 108,458 |             - |            - |
 
 **Avg Gas Cost per Second**: 975.8 gas/second
 *Epoch duration*: 2h 33m 36s
@@ -30,9 +30,9 @@
 | propose              | 210,546 | 227,246 |         2,852 |       45,632 |
 | submitEpochRootProof | 923,838 | 944,451 |         5,092 |       81,472 |
 | aggregate3           | 258,011 | 281,827 |             - |            - |
-| setupEpoch           |  48,233 | 354,577 |             - |            - |
+| setupEpoch           |  47,418 | 327,409 |             - |            - |
 
-**Avg Gas Cost per Second**: 1,302.3 gas/second
+**Avg Gas Cost per Second**: 1,302.2 gas/second
 *Epoch duration*: 2h 33m 36s
 
 
@@ -54,7 +54,7 @@
 |----------------------|---------|---------|---------------|--------------|
 | propose              | 230,565 | 247,531 |         1,060 |       16,960 |
 | submitEpochRootProof | 686,752 | 725,612 |         3,812 |       60,992 |
-| setupEpoch           |  42,024 | 110,967 |             - |            - |
+| setupEpoch           |  42,025 | 110,979 |             - |            - |
 
 **Avg Gas Cost per Second**: 7,633.3 gas/second
 *Epoch duration*: 0h 19m 12s
@@ -65,9 +65,9 @@
 |----------------------|---------|---------|---------------|--------------|
 | propose              | 337,661 | 356,235 |         4,580 |       73,280 |
 | submitEpochRootProof | 894,446 | 932,423 |         6,308 |      100,928 |
-| aggregate3           | 390,106 | 411,903 |             - |            - |
-| setupEpoch           |  61,573 | 599,674 |             - |            - |
+| aggregate3           | 390,107 | 411,903 |             - |            - |
+| setupEpoch           |  59,398 | 545,314 |             - |            - |
 
-**Avg Gas Cost per Second**: 10,985.8 gas/second
+**Avg Gas Cost per Second**: 10,983.9 gas/second
 *Epoch duration*: 0h 19m 12s
 

--- a/l1-contracts/gas_benchmark_results.json
+++ b/l1-contracts/gas_benchmark_results.json
@@ -13,9 +13,9 @@
       "setupEpoch": {
         "calls": 100,
         "min": 37714,
-        "mean": 40849,
+        "mean": 40850,
         "median": 39714,
-        "max": 108446
+        "max": 108458
       },
       "submitEpochRootProof": {
         "calls": 2,
@@ -40,9 +40,9 @@
       "setupEpoch": {
         "calls": 100,
         "min": 37714,
-        "mean": 48233,
+        "mean": 47418,
         "median": 39714,
-        "max": 354577
+        "max": 327409
       },
       "submitEpochRootProof": {
         "calls": 2,
@@ -76,9 +76,9 @@
       "setupEpoch": {
         "calls": 100,
         "min": 37714,
-        "mean": 42024,
+        "mean": 42025,
         "median": 39714,
-        "max": 110967
+        "max": 110979
       },
       "submitEpochRootProof": {
         "calls": 3,
@@ -103,9 +103,9 @@
       "setupEpoch": {
         "calls": 100,
         "min": 37714,
-        "mean": 61573,
+        "mean": 59398,
         "median": 39714,
-        "max": 599674
+        "max": 545314
       },
       "submitEpochRootProof": {
         "calls": 3,
@@ -119,7 +119,7 @@
       "aggregate3": {
         "calls": 100,
         "min": 366627,
-        "mean": 390106,
+        "mean": 390107,
         "median": 389508,
         "max": 411903
       }

--- a/l1-contracts/src/governance/GSE.sol
+++ b/l1-contracts/src/governance/GSE.sol
@@ -813,9 +813,10 @@ contract GSE is IGSE, GSECore {
       require(index < totalSize, Errors.GSE__OutOfBounds(index, totalSize));
 
       if (index < storeSize) {
-        attesters[i] = instanceStore.attesters.getAddressFromIndexAtTimestamp(index, ts);
+        attesters[i] = instanceStore.attesters.unsafeGetRecentAddressFromIndexAtTimestamp(index, ts);
       } else if (isLatestRollup) {
-        attesters[i] = bonusStore.attesters.getAddressFromIndexAtTimestamp(index - storeSize, ts);
+        attesters[i] =
+          bonusStore.attesters.unsafeGetRecentAddressFromIndexAtTimestamp(index - storeSize, ts);
       } else {
         revert Errors.GSE__FatalError("SHOULD NEVER HAPPEN");
       }

--- a/l1-contracts/src/governance/libraries/AddressSnapshotLib.sol
+++ b/l1-contracts/src/governance/libraries/AddressSnapshotLib.sol
@@ -173,6 +173,27 @@ library AddressSnapshotLib {
   }
 
   /**
+   * @notice Gets the address at a specific index and timestamp
+   *
+   * @dev     The caller MUST have ensure that `_index` < `size`
+   *          at the `_timestamp` provided.
+   * @dev     Primed for recent checkpoints in the address history.
+   *
+   * @param _self The storage reference to the set
+   * @param _index The index to query
+   * @param _timestamp The timestamp to query
+   * @return address The address at the given index and timestamp
+   */
+  function unsafeGetRecentAddressFromIndexAtTimestamp(
+    SnapshottedAddressSet storage _self,
+    uint256 _index,
+    uint32 _timestamp
+  ) internal view returns (address) {
+    uint224 addr = _self.indexToAddressHistory[_index].upperLookupRecent(_timestamp);
+    return address(addr.toUint160());
+  }
+
+  /**
    * @notice Gets the current size of the set
    * @param _self The storage reference to the set
    * @return uint256 The number of addresses in the set

--- a/l1-contracts/test/validator-selection/ValidatorSelectionBase.sol
+++ b/l1-contracts/test/validator-selection/ValidatorSelectionBase.sol
@@ -28,6 +28,7 @@ import {StakingQueueConfig} from "@aztec/core/libraries/compressed-data/StakingQ
 
 import {TimeCheater} from "../staking/TimeCheater.sol";
 import {stdStorage, StdStorage} from "forge-std/Test.sol";
+import {Math} from "@oz/utils/math/Math.sol";
 // solhint-disable comprehensive-interface
 
 /**
@@ -92,7 +93,7 @@ contract ValidatorSelectionTestBase is DecoderBase {
     }
 
     StakingQueueConfig memory stakingQueueConfig = TestConstants.getStakingQueueConfig();
-    stakingQueueConfig.normalFlushSizeMin = _validatorCount;
+    stakingQueueConfig.normalFlushSizeMin = Math.max(_validatorCount, 1);
 
     RollupBuilder builder = new RollupBuilder(address(this)).setStakingQueueConfig(
       stakingQueueConfig


### PR DESCRIPTION
Addresses a cost issue in the GSE that unnecessarily re-computed the `size` when fetching values forthe committee. Also primes the fetching of committee for recent values, as it is more likely than not that the address to be retrieved will be in a recent insertion.

Adds 2 new tests to check that the cost of the committee computation does not grow unexpectedly fast.

---

Should be considered if the recency bias should also be applied to the fetching of the size from the GSE.