### PR TITLE
fix: `Aztec.nr` type parameters naming inconsistencies

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/context/private_context.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/private_context.nr
@@ -365,11 +365,11 @@ impl PrivateContext {
         ));
     }
 
-    pub fn call_private_function<let ARGS_COUNT: u32>(
+    pub fn call_private_function<let ArgsCount: u32>(
         &mut self,
         contract_address: AztecAddress,
         function_selector: FunctionSelector,
-        args: [Field; ARGS_COUNT],
+        args: [Field; ArgsCount],
     ) -> ReturnsHash {
         let args_hash = hash_args_array(args);
         execution_cache::store(args, args_hash);
@@ -381,11 +381,11 @@ impl PrivateContext {
         )
     }
 
-    pub fn static_call_private_function<let ARGS_COUNT: u32>(
+    pub fn static_call_private_function<let ArgsCount: u32>(
         &mut self,
         contract_address: AztecAddress,
         function_selector: FunctionSelector,
-        args: [Field; ARGS_COUNT],
+        args: [Field; ArgsCount],
     ) -> ReturnsHash {
         let args_hash = hash_args_array(args);
         execution_cache::store(args, args_hash);
@@ -468,11 +468,11 @@ impl PrivateContext {
         ReturnsHash::new(returns_hash)
     }
 
-    pub fn call_public_function<let ARGS_COUNT: u32>(
+    pub fn call_public_function<let ArgsCount: u32>(
         &mut self,
         contract_address: AztecAddress,
         function_selector: FunctionSelector,
-        args: [Field; ARGS_COUNT],
+        args: [Field; ArgsCount],
     ) {
         let calldata = [function_selector.to_field()].concat(args);
         let calldata_hash = hash_calldata_array(calldata);
@@ -480,11 +480,11 @@ impl PrivateContext {
         self.call_public_function_with_calldata_hash(contract_address, calldata_hash, false)
     }
 
-    pub fn static_call_public_function<let ARGS_COUNT: u32>(
+    pub fn static_call_public_function<let ArgsCount: u32>(
         &mut self,
         contract_address: AztecAddress,
         function_selector: FunctionSelector,
-        args: [Field; ARGS_COUNT],
+        args: [Field; ArgsCount],
     ) {
         let calldata = [function_selector.to_field()].concat(args);
         let calldata_hash = hash_calldata_array(calldata);
@@ -537,11 +537,11 @@ impl PrivateContext {
         self.public_call_requests.push(Counted::new(call_request, counter));
     }
 
-    pub fn set_public_teardown_function<let ARGS_COUNT: u32>(
+    pub fn set_public_teardown_function<let ArgsCount: u32>(
         &mut self,
         contract_address: AztecAddress,
         function_selector: FunctionSelector,
-        args: [Field; ARGS_COUNT],
+        args: [Field; ArgsCount],
     ) {
         let calldata = [function_selector.to_field()].concat(args);
         let calldata_hash = hash_calldata_array(calldata);

--- a/noir-projects/aztec-nr/aztec/src/messages/encryption/aes128.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/encryption/aes128.nr
@@ -158,8 +158,8 @@ pub fn derive_aes_symmetric_key_and_iv_from_ecdh_shared_secret_using_poseidon2_u
 pub struct AES128 {}
 
 impl LogEncryption for AES128 {
-    fn encrypt_log<let PLAINTEXT_LEN: u32>(
-        plaintext: [Field; PLAINTEXT_LEN],
+    fn encrypt_log<let PlaintextLen: u32>(
+        plaintext: [Field; PlaintextLen],
         recipient: AztecAddress,
     ) -> [Field; PRIVATE_LOG_CIPHERTEXT_LEN] {
         // AES 128 operates on bytes, not fields, so we need to convert the fields to bytes.
@@ -208,7 +208,7 @@ impl LogEncryption for AES128 {
         //      = |full_pt| + 16 - (|full_pt| - 16 * (|full_pt| // 16))
         //      = 16 + 16 * (|full_pt| // 16)
         //      = 16 * (1 + |full_pt| // 16)
-        assert(ciphertext_bytes.len() == 16 * (1 + (PLAINTEXT_LEN * 32) / 16));
+        assert(ciphertext_bytes.len() == 16 * (1 + (PlaintextLen * 32) / 16));
 
         // *****************************************************************************
         // Compute the header ciphertext
@@ -233,12 +233,12 @@ impl LogEncryption for AES128 {
         // *****************************************************************************
 
         let mut log_bytes_padding_to_mult_31 =
-            get_arr_of_size__log_bytes_padding__from_PT::<PLAINTEXT_LEN * 32>();
+            get_arr_of_size__log_bytes_padding__from_PT::<PlaintextLen * 32>();
         // Safety: this randomness won't be constrained to be random. It's in the
         // interest of the executor of this fn to encrypt with random bytes.
         log_bytes_padding_to_mult_31 = unsafe { get_random_bytes() };
 
-        let mut log_bytes = get_arr_of_size__log_bytes__from_PT::<PLAINTEXT_LEN * 32>();
+        let mut log_bytes = get_arr_of_size__log_bytes__from_PT::<PlaintextLen * 32>();
 
         assert(
             log_bytes.len() % 31 == 0,

--- a/noir-projects/aztec-nr/aztec/src/messages/encryption/log_encryption.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/encryption/log_encryption.nr
@@ -40,8 +40,8 @@ pub trait LogEncryption {
     ///
     /// # Returns
     /// Fixed-size array of encrypted Field elements representing the private log
-    fn encrypt_log<let PLAINTEXT_LEN: u32>(
-        plaintext: [Field; PLAINTEXT_LEN],
+    fn encrypt_log<let PlaintextLen: u32>(
+        plaintext: [Field; PlaintextLen],
         recipient: AztecAddress,
     ) -> [Field; PRIVATE_LOG_CIPHERTEXT_LEN];
 

--- a/noir-projects/aztec-nr/aztec/src/messages/logs/arithmetic_generics_utils.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/logs/arithmetic_generics_utils.nr
@@ -6,38 +6,38 @@ use crate::messages::encryption::log_encryption::HEADER_CIPHERTEXT_SIZE_IN_BYTES
 
 // In this section, instead of initialising arrays with very complicated generic
 // arithmetic, such as:
-// let my_arr: [u8; (((PT + (16 - (PT % 16))) + (HEADER_CIPHERTEXT_SIZE_IN_BYTES + 1)) + ((((((PT + (16 - (PT % 16))) + (HEADER_CIPHERTEXT_SIZE_IN_BYTES + 1)) + 30) / 31) * 31) - ((PT + (16 - (PT % 16))) + (HEADER_CIPHERTEXT_SIZE_IN_BYTES + 1))))] = [0; (((PT + (16 - (PT % 16))) + (HEADER_CIPHERTEXT_SIZE_IN_BYTES + 1)) + ((((((PT + (16 - (PT % 16))) + (HEADER_CIPHERTEXT_SIZE_IN_BYTES + 1)) + 30) / 31) * 31) - ((PT + (16 - (PT % 16))) + (HEADER_CIPHERTEXT_SIZE_IN_BYTES + 1))))];
+// let my_arr: [u8; (((Pt + (16 - (Pt % 16))) + (HEADER_CIPHERTEXT_SIZE_IN_BYTES + 1)) + ((((((Pt + (16 - (Pt % 16))) + (HEADER_CIPHERTEXT_SIZE_IN_BYTES + 1)) + 30) / 31) * 31) - ((Pt + (16 - (Pt % 16))) + (HEADER_CIPHERTEXT_SIZE_IN_BYTES + 1))))] = [0; (((Pt + (16 - (Pt % 16))) + (HEADER_CIPHERTEXT_SIZE_IN_BYTES + 1)) + ((((((Pt + (16 - (Pt % 16))) + (HEADER_CIPHERTEXT_SIZE_IN_BYTES + 1)) + 30) / 31) * 31) - ((Pt + (16 - (Pt % 16))) + (HEADER_CIPHERTEXT_SIZE_IN_BYTES + 1))))];
 //... we instead do the arithmetic a little bit at a time, so that the computation
 // can be audited and understood. Now, we can't do arithmetic on generics in the body
 // of a function, so we abusing functions in the following way:
 
 // |full_pt| = |pt| = (N * 32) + 64
-fn get_arr_of_size__full_plaintext<let PT: u32>() -> [u8; PT] {
-    [0; PT]
+fn get_arr_of_size__full_plaintext<let Pt: u32>() -> [u8; Pt] {
+    [0; Pt]
 }
 
 // |pt_aes_padding| = 16 - (|full_pt| % 16)
-fn get_arr_of_size__plaintext_aes_padding<let FULL_PT: u32>(
-    _full_pt: [u8; FULL_PT],
-) -> [u8; 16 - (FULL_PT % 16)] {
-    [0; 16 - (FULL_PT % 16)]
+fn get_arr_of_size__plaintext_aes_padding<let FullPt: u32>(
+    _full_pt: [u8; FullPt],
+) -> [u8; 16 - (FullPt % 16)] {
+    [0; 16 - (FullPt % 16)]
 }
 
 // |ct| = |full_pt| + |pt_aes_padding|
-fn get_arr_of_size__ciphertext<let FULL_PT: u32, let PT_AES_PADDING: u32>(
-    _full_pt: [u8; FULL_PT],
-    _pt_aes_padding: [u8; PT_AES_PADDING],
-) -> [u8; FULL_PT + PT_AES_PADDING] {
-    [0; FULL_PT + PT_AES_PADDING]
+fn get_arr_of_size__ciphertext<let FullPt: u32, let PtAesPadding: u32>(
+    _full_pt: [u8; FullPt],
+    _pt_aes_padding: [u8; PtAesPadding],
+) -> [u8; FullPt + PtAesPadding] {
+    [0; FullPt + PtAesPadding]
 }
 
 // Ok, so we have the following bytes:
 // eph_pk_sign, header_ciphertext, ciphertext:
 // Let lbwop = 1 + HEADER_CIPHERTEXT_SIZE_IN_BYTES + |ct| // aka log bytes without padding
-fn get_arr_of_size__log_bytes_without_padding<let CT: u32>(
-    _ct: [u8; CT],
-) -> [u8; 1 + HEADER_CIPHERTEXT_SIZE_IN_BYTES + CT] {
-    [0; 1 + HEADER_CIPHERTEXT_SIZE_IN_BYTES + CT]
+fn get_arr_of_size__log_bytes_without_padding<let Ct: u32>(
+    _ct: [u8; Ct],
+) -> [u8; 1 + HEADER_CIPHERTEXT_SIZE_IN_BYTES + Ct] {
+    [0; 1 + HEADER_CIPHERTEXT_SIZE_IN_BYTES + Ct]
 }
 
 // Recall:
@@ -47,10 +47,10 @@ fn get_arr_of_size__log_bytes_without_padding<let CT: u32>(
 // p = 31 * ceil(lbwop / 31) - lbwop
 //   = 31 * ((lbwop + 30) // 31) - lbwop
 //     (because ceil(x / y) = (x + y - 1) // y ).
-fn get_arr_of_size__log_bytes_padding<let LBWOP: u32>(
-    _lbwop: [u8; LBWOP],
-) -> [u8; (31 * ((LBWOP + 30) / 31)) - LBWOP] {
-    [0; (31 * ((LBWOP + 30) / 31)) - LBWOP]
+fn get_arr_of_size__log_bytes_padding<let Lbwop: u32>(
+    _lbwop: [u8; Lbwop],
+) -> [u8; (31 * ((Lbwop + 30) / 31)) - Lbwop] {
+    [0; (31 * ((Lbwop + 30) / 31)) - Lbwop]
 }
 
 // |log_bytes| = 1 + HEADER_CIPHERTEXT_SIZE_IN_BYTES + |ct| + p // aka log bytes (with padding)
@@ -66,9 +66,9 @@ fn get_arr_of_size__log_bytes<let LBWOP: u32, let P: u32>(
 
 // The return type is pasted from the LSP's expectation, because it was too difficult
 // to match its weird way of doing algebra. It doesn't know all rules of arithmetic.
-// PT is the plaintext length.
-pub(crate) fn get_arr_of_size__log_bytes_padding__from_PT<let PT: u32>() -> [u8; ((((((PT + (16 - (PT % 16))) + HEADER_CIPHERTEXT_SIZE_IN_BYTES + 1) + 30) / 31) * 31) - ((PT + (16 - (PT % 16))) + HEADER_CIPHERTEXT_SIZE_IN_BYTES + 1))] {
-    let full_pt = get_arr_of_size__full_plaintext::<PT>();
+// Pt is the plaintext length.
+pub(crate) fn get_arr_of_size__log_bytes_padding__from_PT<let Pt: u32>() -> [u8; ((((((Pt + (16 - (Pt % 16))) + HEADER_CIPHERTEXT_SIZE_IN_BYTES + 1) + 30) / 31) * 31) - ((Pt + (16 - (Pt % 16))) + HEADER_CIPHERTEXT_SIZE_IN_BYTES + 1))] {
+    let full_pt = get_arr_of_size__full_plaintext::<Pt>();
     let pt_aes_padding = get_arr_of_size__plaintext_aes_padding(full_pt);
     let ct = get_arr_of_size__ciphertext(full_pt, pt_aes_padding);
     let lbwop = get_arr_of_size__log_bytes_without_padding(ct);
@@ -78,8 +78,8 @@ pub(crate) fn get_arr_of_size__log_bytes_padding__from_PT<let PT: u32>() -> [u8;
 
 // The return type is pasted from the LSP's expectation, because it was too difficult
 // to match its weird way of doing algebra. It doesn't know all rules of arithmetic.
-pub(crate) fn get_arr_of_size__log_bytes__from_PT<let PT: u32>() -> [u8; (((PT + (16 - (PT % 16))) + HEADER_CIPHERTEXT_SIZE_IN_BYTES + 1) + ((((((PT + (16 - (PT % 16))) + HEADER_CIPHERTEXT_SIZE_IN_BYTES + 1) + 30) / 31) * 31) - ((PT + (16 - (PT % 16))) + HEADER_CIPHERTEXT_SIZE_IN_BYTES + 1)))] {
-    let full_pt = get_arr_of_size__full_plaintext::<PT>();
+pub(crate) fn get_arr_of_size__log_bytes__from_PT<let Pt: u32>() -> [u8; (((Pt + (16 - (Pt % 16))) + HEADER_CIPHERTEXT_SIZE_IN_BYTES + 1) + ((((((Pt + (16 - (Pt % 16))) + HEADER_CIPHERTEXT_SIZE_IN_BYTES + 1) + 30) / 31) * 31) - ((Pt + (16 - (Pt % 16))) + HEADER_CIPHERTEXT_SIZE_IN_BYTES + 1)))] {
+    let full_pt = get_arr_of_size__full_plaintext::<Pt>();
     let pt_aes_padding = get_arr_of_size__plaintext_aes_padding(full_pt);
     let ct = get_arr_of_size__ciphertext(full_pt, pt_aes_padding);
     let lbwop = get_arr_of_size__log_bytes_without_padding(ct);

--- a/noir-projects/aztec-nr/aztec/src/note/note_getter.nr
+++ b/noir-projects/aztec-nr/aztec/src/note/note_getter.nr
@@ -108,10 +108,10 @@ where
 /// or _valid_ - this typically requires also emitting the note's nullifier to prove that it had not been emitted
 /// before. Because of this, calling this function directly from end-user applications should be discouraged, and safe
 /// abstractions such as aztec-nr's state variables should be used instead.
-pub fn get_notes<Note, let M: u32, PREPROCESSOR_ARGS, FILTER_ARGS>(
+pub fn get_notes<Note, let M: u32, PreprocessorArgs, FilterArgs>(
     context: &mut PrivateContext,
     storage_slot: Field,
-    options: NoteGetterOptions<Note, M, PREPROCESSOR_ARGS, FILTER_ARGS>,
+    options: NoteGetterOptions<Note, M, PreprocessorArgs, FilterArgs>,
     ) -> (BoundedVec<RetrievedNote<Note>, MAX_NOTE_HASH_READ_REQUESTS_PER_CALL>, BoundedVec<Field, MAX_NOTE_HASH_READ_REQUESTS_PER_CALL>)
 where
     Note: NoteType + NoteHash + Eq + Packable<N = M>,
@@ -124,19 +124,19 @@ where
     constrain_get_notes_internal(context, storage_slot, opt_notes, options)
 }
 
-unconstrained fn apply_preprocessor<Note, PREPROCESSOR_ARGS>(
+unconstrained fn apply_preprocessor<Note, PreprocessorArgs>(
     notes: [Option<Note>; MAX_NOTE_HASH_READ_REQUESTS_PER_CALL],
-    preprocessor: fn([Option<Note>; MAX_NOTE_HASH_READ_REQUESTS_PER_CALL], PREPROCESSOR_ARGS) -> [Option<Note>; MAX_NOTE_HASH_READ_REQUESTS_PER_CALL],
-    preprocessor_args: PREPROCESSOR_ARGS,
+    preprocessor: fn([Option<Note>; MAX_NOTE_HASH_READ_REQUESTS_PER_CALL], PreprocessorArgs) -> [Option<Note>; MAX_NOTE_HASH_READ_REQUESTS_PER_CALL],
+    preprocessor_args: PreprocessorArgs,
 ) -> [Option<Note>; MAX_NOTE_HASH_READ_REQUESTS_PER_CALL] {
     preprocessor(notes, preprocessor_args)
 }
 
-fn constrain_get_notes_internal<Note, let M: u32, PREPROCESSOR_ARGS, FILTER_ARGS>(
+fn constrain_get_notes_internal<Note, let M: u32, PreprocessorArgs, FilterArgs>(
     context: &mut PrivateContext,
     storage_slot: Field,
     opt_notes: [Option<RetrievedNote<Note>>; MAX_NOTE_HASH_READ_REQUESTS_PER_CALL],
-    options: NoteGetterOptions<Note, M, PREPROCESSOR_ARGS, FILTER_ARGS>,
+    options: NoteGetterOptions<Note, M, PreprocessorArgs, FilterArgs>,
     ) -> (BoundedVec<RetrievedNote<Note>, MAX_NOTE_HASH_READ_REQUESTS_PER_CALL>, BoundedVec<Field, MAX_NOTE_HASH_READ_REQUESTS_PER_CALL>)
 where
     Note: NoteType + NoteHash + Eq + Packable<N = M>,
@@ -213,9 +213,9 @@ where
     opt_notes[0].expect(f"Failed to get a note") // Notice: we don't allow dummies to be returned from get_note (singular).
 }
 
-unconstrained fn get_notes_internal<Note, let M: u32, PREPROCESSOR_ARGS, FILTER_ARGS>(
+unconstrained fn get_notes_internal<Note, let M: u32, PreprocessorArgs, FilterArgs>(
     storage_slot: Field,
-    options: NoteGetterOptions<Note, M, PREPROCESSOR_ARGS, FILTER_ARGS>,
+    options: NoteGetterOptions<Note, M, PreprocessorArgs, FilterArgs>,
 ) -> [Option<RetrievedNote<Note>>; MAX_NOTE_HASH_READ_REQUESTS_PER_CALL]
 where
     Note: NoteType + Packable<N = M>,

--- a/noir-projects/aztec-nr/aztec/src/note/note_getter_options.nr
+++ b/noir-projects/aztec-nr/aztec/src/note/note_getter_options.nr
@@ -63,17 +63,17 @@ fn return_all_notes<Note>(
 }
 
 // docs:start:NoteGetterOptions
-pub struct NoteGetterOptions<Note, let N: u32, PREPROCESSOR_ARGS, FILTER_ARGS> {
+pub struct NoteGetterOptions<Note, let N: u32, PreprocessorArgs, FilterArgs> {
     pub selects: BoundedVec<Option<Select>, N>,
     pub sorts: BoundedVec<Option<Sort>, N>,
     pub limit: u32,
     pub offset: u32,
     // Preprocessor and filter functions are used to filter notes. The preprocessor is applied before the filter and
     // unlike filter it is applied in an unconstrained context.
-    pub preprocessor: fn([Option<RetrievedNote<Note>>; MAX_NOTE_HASH_READ_REQUESTS_PER_CALL], PREPROCESSOR_ARGS) -> [Option<RetrievedNote<Note>>; MAX_NOTE_HASH_READ_REQUESTS_PER_CALL],
-    pub preprocessor_args: PREPROCESSOR_ARGS,
-    pub filter: fn([Option<RetrievedNote<Note>>; MAX_NOTE_HASH_READ_REQUESTS_PER_CALL], FILTER_ARGS) -> [Option<RetrievedNote<Note>>; MAX_NOTE_HASH_READ_REQUESTS_PER_CALL],
-    pub filter_args: FILTER_ARGS,
+    pub preprocessor: fn([Option<RetrievedNote<Note>>; MAX_NOTE_HASH_READ_REQUESTS_PER_CALL], PreprocessorArgs) -> [Option<RetrievedNote<Note>>; MAX_NOTE_HASH_READ_REQUESTS_PER_CALL],
+    pub preprocessor_args: PreprocessorArgs,
+    pub filter: fn([Option<RetrievedNote<Note>>; MAX_NOTE_HASH_READ_REQUESTS_PER_CALL], FilterArgs) -> [Option<RetrievedNote<Note>>; MAX_NOTE_HASH_READ_REQUESTS_PER_CALL],
+    pub filter_args: FilterArgs,
     pub status: u8,
 }
 // docs:end:NoteGetterOptions
@@ -84,7 +84,7 @@ pub struct NoteGetterOptions<Note, let N: u32, PREPROCESSOR_ARGS, FILTER_ARGS> {
 // `selects` to specify fields, `sorts` to establish sorting criteria, `offset` to skip items, and `limit` to cap
 // the result size.
 // And finally, a custom preprocessor and filter to refine the outcome further.
-impl<Note, let N: u32, PREPROCESSOR_ARGS, FILTER_ARGS> NoteGetterOptions<Note, N, PREPROCESSOR_ARGS, FILTER_ARGS> {
+impl<Note, let N: u32, PreprocessorArgs, FilterArgs> NoteGetterOptions<Note, N, PreprocessorArgs, FilterArgs> {
     // This method adds a `Select` criterion to the options.
     // It takes a property_selector indicating which field to select,
     // a value representing the specific value to match in that field, and
@@ -155,7 +155,7 @@ where
     }
 }
 
-impl<Note, let M: u32, PREPROCESSOR_ARGS> NoteGetterOptions<Note, M, PREPROCESSOR_ARGS, Field>
+impl<Note, let M: u32, PreprocessorArgs> NoteGetterOptions<Note, M, PreprocessorArgs, Field>
 where
     Note: NoteType + Packable<N = M>,
 {
@@ -163,8 +163,8 @@ where
     // the database and preprocessor_args as its parameters.
     // `preprocessor_args` allows you to provide additional data or context to the custom preprocessor.
     pub fn with_preprocessor(
-        preprocessor: fn([Option<RetrievedNote<Note>>; MAX_NOTE_HASH_READ_REQUESTS_PER_CALL], PREPROCESSOR_ARGS) -> [Option<RetrievedNote<Note>>; MAX_NOTE_HASH_READ_REQUESTS_PER_CALL],
-        preprocessor_args: PREPROCESSOR_ARGS,
+        preprocessor: fn([Option<RetrievedNote<Note>>; MAX_NOTE_HASH_READ_REQUESTS_PER_CALL], PreprocessorArgs) -> [Option<RetrievedNote<Note>>; MAX_NOTE_HASH_READ_REQUESTS_PER_CALL],
+        preprocessor_args: PreprocessorArgs,
     ) -> Self {
         Self {
             selects: BoundedVec::new(),
@@ -180,7 +180,7 @@ where
     }
 }
 
-impl<Note, let M: u32, FILTER_ARGS> NoteGetterOptions<Note, M, Field, FILTER_ARGS>
+impl<Note, let M: u32, FilterArgs> NoteGetterOptions<Note, M, Field, FilterArgs>
 where
     Note: NoteType + Packable<N = M>,
 {
@@ -188,8 +188,8 @@ where
     // the notes returned from the database and filter_args as its parameters.
     // `filter_args` allows you to provide additional data or context to the custom filter.
     pub fn with_filter(
-        filter: fn([Option<RetrievedNote<Note>>; MAX_NOTE_HASH_READ_REQUESTS_PER_CALL], FILTER_ARGS) -> [Option<RetrievedNote<Note>>; MAX_NOTE_HASH_READ_REQUESTS_PER_CALL],
-        filter_args: FILTER_ARGS,
+        filter: fn([Option<RetrievedNote<Note>>; MAX_NOTE_HASH_READ_REQUESTS_PER_CALL], FilterArgs) -> [Option<RetrievedNote<Note>>; MAX_NOTE_HASH_READ_REQUESTS_PER_CALL],
+        filter_args: FilterArgs,
     ) -> Self {
         Self {
             selects: BoundedVec::new(),

--- a/noir-projects/aztec-nr/aztec/src/note/retrieved_note.nr
+++ b/noir-projects/aztec-nr/aztec/src/note/retrieved_note.nr
@@ -9,17 +9,17 @@ pub global RETRIEVED_NOTE_OVERHEAD: u32 = 1 + 2;
 /// A container of a note and the metadata required to prove its existence, regardless of whether the note is
 /// pending (created in the current transaction) or settled (created in a previous transaction).
 #[derive(Eq)]
-pub struct RetrievedNote<NOTE> {
-    pub note: NOTE,
+pub struct RetrievedNote<Note> {
+    pub note: Note,
     pub contract_address: AztecAddress,
     pub metadata: NoteMetadata,
 }
 
-impl<NOTE> Serialize for RetrievedNote<NOTE>
+impl<Note> Serialize for RetrievedNote<Note>
 where
-    NOTE: Serialize,
+    Note: Serialize,
 {
-    let N: u32 = <NOTE as Serialize>::N + RETRIEVED_NOTE_OVERHEAD;
+    let N: u32 = <Note as Serialize>::N + RETRIEVED_NOTE_OVERHEAD;
 
     fn serialize(self) -> [Field; Self::N] {
         self.note.serialize().concat([self.contract_address.to_field()]).concat(self
@@ -30,18 +30,18 @@ where
 
 // This function is not part of the Packable trait implementation because in the case of the retrieved note, the pack
 // functionality resides in TS (oracle.ts and txe_service.ts).
-pub fn unpack_retrieved_note<NOTE, let M: u32>(
+pub fn unpack_retrieved_note<Note, let M: u32>(
     packed_retrieved_note: [Field; M + RETRIEVED_NOTE_OVERHEAD],
-) -> RetrievedNote<NOTE>
+) -> RetrievedNote<Note>
 where
-    NOTE: Packable<N = M>,
+    Note: Packable<N = M>,
 {
     let contract_address = AztecAddress::from_field(packed_retrieved_note[0]);
     let note_nonce = packed_retrieved_note[1];
     let nonzero_note_hash_counter = (packed_retrieved_note[2] as u1) != 0;
 
     let packed_note = subarray(packed_retrieved_note, RETRIEVED_NOTE_OVERHEAD);
-    let note = NOTE::unpack(packed_note);
+    let note = Note::unpack(packed_note);
 
     RetrievedNote {
         note,

--- a/noir-projects/aztec-nr/aztec/src/oracle/notes.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/notes.nr
@@ -83,7 +83,7 @@ unconstrained fn notify_created_nullifier_oracle_wrapper(nullifier: Field) {
 unconstrained fn notify_created_nullifier_oracle(_nullifier: Field) {}
 
 #[oracle(getNotes)]
-unconstrained fn get_notes_oracle<let NOTE_PCKD_LEN: u32, let M: u32, let MAX_NOTES: u32>(
+unconstrained fn get_notes_oracle<let NotePckdLen: u32, let M: u32, let MaxNotes: u32>(
     _storage_slot: Field,
     _num_selects: u8,
     _select_by_indexes: [u8; M],
@@ -100,12 +100,12 @@ unconstrained fn get_notes_oracle<let NOTE_PCKD_LEN: u32, let M: u32, let MAX_NO
     _status: u8,
     // This is always set to MAX_NOTES. We need to pass it to TS in order to correctly construct the BoundedVec
     _max_notes: u32,
-    // This is always set to NOTE_PCKD_LEN + RETRIEVED_NOTE_OVERHEAD. We need to pass it to TS in order to be able to
+    // This is always set to NotePckdLen + RETRIEVED_NOTE_OVERHEAD. We need to pass it to TS in order to be able to
     // correctly construct the BoundedVec there.
     _packed_retrieved_note_length: u32,
-) -> BoundedVec<[Field; NOTE_PCKD_LEN + RETRIEVED_NOTE_OVERHEAD], MAX_NOTES> {}
+) -> BoundedVec<[Field; NotePckdLen + RETRIEVED_NOTE_OVERHEAD], MaxNotes> {}
 
-pub unconstrained fn get_notes<Note, let NOTE_PCKD_LEN: u32, let M: u32, let MAX_NOTES: u32>(
+pub unconstrained fn get_notes<Note, let NotePckdLen: u32, let M: u32, let MaxNotes: u32>(
     storage_slot: Field,
     num_selects: u8,
     select_by_indexes: [u8; M],
@@ -120,30 +120,31 @@ pub unconstrained fn get_notes<Note, let NOTE_PCKD_LEN: u32, let M: u32, let MAX
     limit: u32,
     offset: u32,
     status: u8,
-) -> [Option<RetrievedNote<Note>>; MAX_NOTES]
+) -> [Option<RetrievedNote<Note>>; MaxNotes]
 where
-    Note: NoteType + Packable<N = NOTE_PCKD_LEN>,
+    Note: NoteType + Packable<N = NotePckdLen>,
 {
-    let packed_retrieved_notes: BoundedVec<[Field; NOTE_PCKD_LEN + RETRIEVED_NOTE_OVERHEAD], MAX_NOTES> = get_notes_oracle(
-        storage_slot,
-        num_selects,
-        select_by_indexes,
-        select_by_offsets,
-        select_by_lengths,
-        select_values,
-        select_comparators,
-        sort_by_indexes,
-        sort_by_offsets,
-        sort_by_lengths,
-        sort_order,
-        limit,
-        offset,
-        status,
-        MAX_NOTES,
-        NOTE_PCKD_LEN + RETRIEVED_NOTE_OVERHEAD,
-    );
+    let packed_retrieved_notes: BoundedVec<[Field; NotePckdLen + RETRIEVED_NOTE_OVERHEAD], MaxNotes>
+         = get_notes_oracle(
+            storage_slot,
+            num_selects,
+            select_by_indexes,
+            select_by_offsets,
+            select_by_lengths,
+            select_values,
+            select_comparators,
+            sort_by_indexes,
+            sort_by_offsets,
+            sort_by_lengths,
+            sort_order,
+            limit,
+            offset,
+            status,
+            MaxNotes,
+            NotePckdLen + RETRIEVED_NOTE_OVERHEAD,
+        );
 
-    let mut notes = BoundedVec::<_, MAX_NOTES>::new();
+    let mut notes = BoundedVec::<_, MaxNotes>::new();
     for i in 0..packed_retrieved_notes.len() {
         let retrieved_note = unpack_retrieved_note(packed_retrieved_notes.get(i));
         notes.push(retrieved_note);
@@ -166,7 +167,7 @@ where
     // functions we could use BoundedVec return value as there the optimization does not matter since it is applied in
     // an unconstrained context. We, however, use the same return value type to be able to use the same function as
     // both a preprocessor and a filter.
-    let mut notes_array = [Option::none(); MAX_NOTES];
+    let mut notes_array = [Option::none(); MaxNotes];
     for i in 0..notes.len() {
         if i < notes.len() {
             notes_array[i] = Option::some(notes.get_unchecked(i));

--- a/noir-projects/aztec-nr/aztec/src/state_vars/delayed_public_mutable.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/delayed_public_mutable.nr
@@ -16,16 +16,16 @@ use crate::{
 
 mod test;
 
-pub struct DelayedPublicMutable<T, let INITIAL_DELAY: u64, Context> {
+pub struct DelayedPublicMutable<T, let InitialDelay: u64, Context> {
     context: Context,
     storage_slot: Field,
 }
 
 // This will make the Aztec macros require that T implements the Packable and Eq traits, and allocate `M` storage
 // slots to this state variable.
-impl<T, let INITIAL_DELAY: u64, Context, let M: u32> HasStorageSlot<M> for DelayedPublicMutable<T, INITIAL_DELAY, Context>
+impl<T, let InitialDelay: u64, Context, let M: u32> HasStorageSlot<M> for DelayedPublicMutable<T, InitialDelay, Context>
 where
-    WithHash<DelayedPublicMutableValues<T, INITIAL_DELAY>, _>: Packable<N = M>,
+    WithHash<DelayedPublicMutableValues<T, InitialDelay>, _>: Packable<N = M>,
 {
     fn get_storage_slot(self) -> Field {
         self.storage_slot
@@ -41,16 +41,16 @@ where
 // the value is not changed immediately but rather a value change is scheduled to happen in the future after some delay
 // measured in seconds. Reads in private are only valid as long as they are included in a block with a timestamp not
 // too far into the future, so that they can guarantee the value will not have possibly changed by then (because of the
-// delay). The delay for changing a value is initially equal to INITIAL_DELAY, but can be changed by calling
+// delay). The delay for changing a value is initially equal to InitialDelay, but can be changed by calling
 // `schedule_delay_change`.
-impl<T, let INITIAL_DELAY: u64, Context> DelayedPublicMutable<T, INITIAL_DELAY, Context> {
+impl<T, let InitialDelay: u64, Context> DelayedPublicMutable<T, InitialDelay, Context> {
     pub fn new(context: Context, storage_slot: Field) -> Self {
         assert(storage_slot != 0, "Storage slot 0 not allowed. Storage slots must start from 1.");
         Self { context, storage_slot }
     }
 }
 
-impl<T, let INITIAL_DELAY: u64> DelayedPublicMutable<T, INITIAL_DELAY, &mut PublicContext>
+impl<T, let InitialDelay: u64> DelayedPublicMutable<T, InitialDelay, &mut PublicContext>
 where
     T: Eq,
 {
@@ -142,7 +142,7 @@ where
         unpack_value_change::<T, <T as Packable>::N>(packed)
     }
 
-    fn read_delay_change(self) -> ScheduledDelayChange<INITIAL_DELAY>
+    fn read_delay_change(self) -> ScheduledDelayChange<InitialDelay>
     where
         T: Packable,
     {
@@ -153,13 +153,13 @@ where
         // We don't read ScheduledDelayChange directly by having it implement Packable because ScheduledValueChange
         // and ScheduledDelayChange are packed together (sdc and svc.timestamp_of_change are stored in the same slot).
         let packed = self.context.storage_read(self.storage_slot);
-        unpack_delay_change::<INITIAL_DELAY>(packed)
+        unpack_delay_change::<InitialDelay>(packed)
     }
 
     fn write(
         self,
         value_change: ScheduledValueChange<T>,
-        delay_change: ScheduledDelayChange<INITIAL_DELAY>,
+        delay_change: ScheduledDelayChange<InitialDelay>,
     )
     where
         T: Packable,
@@ -177,7 +177,7 @@ where
     }
 }
 
-impl<T, let INITIAL_DELAY: u64> DelayedPublicMutable<T, INITIAL_DELAY, &mut PrivateContext>
+impl<T, let InitialDelay: u64> DelayedPublicMutable<T, InitialDelay, &mut PrivateContext>
 where
     T: Eq,
 {
@@ -215,7 +215,7 @@ where
 
     fn historical_read_from_public_storage(
         self,
-    ) -> (ScheduledValueChange<T>, ScheduledDelayChange<INITIAL_DELAY>, u64)
+    ) -> (ScheduledValueChange<T>, ScheduledDelayChange<InitialDelay>, u64)
     where
         T: Packable,
     {
@@ -224,14 +224,14 @@ where
 
         let historical_timestamp = header.global_variables.timestamp;
 
-        let values: DelayedPublicMutableValues<T, INITIAL_DELAY> =
+        let values: DelayedPublicMutableValues<T, InitialDelay> =
             WithHash::historical_public_storage_read(header, address, self.storage_slot);
 
         (values.svc, values.sdc, historical_timestamp)
     }
 }
 
-impl<T, let INITIAL_DELAY: u64> DelayedPublicMutable<T, INITIAL_DELAY, UtilityContext>
+impl<T, let InitialDelay: u64> DelayedPublicMutable<T, InitialDelay, UtilityContext>
 where
     T: Eq,
 {
@@ -239,7 +239,7 @@ where
     where
         T: Packable,
     {
-        let dpmv: DelayedPublicMutableValues<T, INITIAL_DELAY> =
+        let dpmv: DelayedPublicMutableValues<T, InitialDelay> =
             WithHash::utility_public_storage_read(self.context, self.storage_slot);
 
         let current_timestamp = self.context.timestamp();

--- a/noir-projects/aztec-nr/aztec/src/state_vars/private_set.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/private_set.nr
@@ -56,9 +56,9 @@ where
     }
     // docs:end:insert
 
-    pub fn pop_notes<PREPROCESSOR_ARGS, FILTER_ARGS, let M: u32>(
+    pub fn pop_notes<PreprocessorArgs, FilterArgs, let M: u32>(
         self,
-        options: NoteGetterOptions<Note, M, PREPROCESSOR_ARGS, FILTER_ARGS>,
+        options: NoteGetterOptions<Note, M, PreprocessorArgs, FilterArgs>,
     ) -> BoundedVec<Note, MAX_NOTE_HASH_READ_REQUESTS_PER_CALL>
     where
         Note: Packable<N = M>,
@@ -95,9 +95,9 @@ where
 
     /// Note that if you later on remove the note it's much better to use `pop_notes` as `pop_notes` results
     /// in significantly less constrains due to avoiding 1 read request check.
-    pub fn get_notes<PREPROCESSOR_ARGS, FILTER_ARGS, let M: u32>(
+    pub fn get_notes<PreprocessorArgs, FilterArgs, let M: u32>(
         self,
-        options: NoteGetterOptions<Note, M, PREPROCESSOR_ARGS, FILTER_ARGS>,
+        options: NoteGetterOptions<Note, M, PreprocessorArgs, FilterArgs>,
     ) -> BoundedVec<RetrievedNote<Note>, MAX_NOTE_HASH_READ_REQUESTS_PER_CALL>
     where
         Note: Packable<N = M>,

--- a/noir-projects/aztec-nr/aztec/src/utils/array/append.nr
+++ b/noir-projects/aztec-nr/aztec/src/utils/array/append.nr
@@ -1,10 +1,9 @@
-/// Appends two `BoundedVec`s together, returning one that contains all of the elements of the first one followed by all
-/// of the elements of the second one. The resulting `BoundedVec` can have any arbitrary maximum length, but it must be
+/// Appends the elements of the second `BoundedVec` to the end of the first one. The resulting `BoundedVec` can have any arbitrary maximum length, but it must be
 /// large enough to fit all of the elements of both the first and second vectors.
-pub fn append<T, let A_LEN: u32, let B_LEN: u32, let DST_LEN: u32>(
-    a: BoundedVec<T, A_LEN>,
-    b: BoundedVec<T, B_LEN>,
-) -> BoundedVec<T, DST_LEN> {
+pub fn append<T, let ALen: u32, let BLen: u32, let DstLen: u32>(
+    a: BoundedVec<T, ALen>,
+    b: BoundedVec<T, BLen>,
+) -> BoundedVec<T, DstLen> {
     let mut dst = BoundedVec::new();
 
     dst.extend_from_bounded_vec(a);

--- a/noir-projects/aztec-nr/aztec/src/utils/array/subarray.nr
+++ b/noir-projects/aztec-nr/aztec/src/utils/array/subarray.nr
@@ -24,7 +24,7 @@ mod test {
 
     #[test]
     unconstrained fn subarray_into_empty() {
-        // In all of these cases we're setting DST_LEN to be 0, so we always get back an emtpy array.
+        // In all of these cases we're setting DstLen to be 0, so we always get back an empty array.
         assert_eq(subarray::<Field, _, _>([], 0), []);
         assert_eq(subarray([1, 2, 3, 4, 5], 0), []);
         assert_eq(subarray([1, 2, 3, 4, 5], 2), []);
@@ -45,7 +45,7 @@ mod test {
         assert_eq(subarray([1, 2, 3, 4, 5], 1), [2]);
     }
 
-    #[test(should_fail_with = "DST_LEN too large for offset")]
+    #[test(should_fail_with = "DstLen too large for offset")]
     unconstrained fn subarray_offset_too_large() {
         // With an offset of 1 we can only request up to 4 elements
         let _: [_; 5] = subarray([1, 2, 3, 4, 5], 1);

--- a/noir-projects/aztec-nr/aztec/src/utils/array/subarray.nr
+++ b/noir-projects/aztec-nr/aztec/src/utils/array/subarray.nr
@@ -1,4 +1,4 @@
-/// Returns `DST_LEN` elements from a source array, starting at `offset`. `DST_LEN` must not be larger than the number
+/// Returns `DstLen` elements from a source array, starting at `offset`. `DstLen` must not be larger than the number
 /// of elements past `offset`.
 ///
 /// Examples:
@@ -8,14 +8,11 @@
 ///
 /// let bar: [Field; 5] = subarray([1, 2, 3, 4, 5], 2); // fails - we can't return 5 elements since only 3 remain
 /// ```
-pub fn subarray<T, let SRC_LEN: u32, let DST_LEN: u32>(
-    src: [T; SRC_LEN],
-    offset: u32,
-) -> [T; DST_LEN] {
-    assert(offset + DST_LEN <= SRC_LEN, "DST_LEN too large for offset");
+pub fn subarray<T, let SrcLen: u32, let DstLen: u32>(src: [T; SrcLen], offset: u32) -> [T; DstLen] {
+    assert(offset + DstLen <= SrcLen, "DstLen too large for offset");
 
-    let mut dst: [T; DST_LEN] = std::mem::zeroed();
-    for i in 0..DST_LEN {
+    let mut dst: [T; DstLen] = std::mem::zeroed();
+    for i in 0..DstLen {
         dst[i] = src[i + offset];
     }
 

--- a/noir-projects/aztec-nr/aztec/src/utils/array/subbvec.nr
+++ b/noir-projects/aztec-nr/aztec/src/utils/array/subbvec.nr
@@ -1,11 +1,11 @@
 use crate::utils::array;
 
-/// Returns `DST_MAX_LEN` elements from a source BoundedVec, starting at `offset`. `offset` must not be larger than the
-/// original length, and `DST_LEN` must not be larger than the total number of elements past `offset` (including the
+/// Returns `DstMaxLen` elements from a source BoundedVec, starting at `offset`. `offset` must not be larger than the
+/// original length, and `DstLen` must not be larger than the total number of elements past `offset` (including the
 /// zeroed elements past `len()`).
 ///
 /// Only elements at the beginning of the vector can be removed: it is not possible to also remove elements at the end
-/// of the vector by passing a value for `DST_LEN` that is smaller than `len() - offset`.
+/// of the vector by passing a value for `DstLen` that is smaller than `len() - offset`.
 ///
 /// Examples:
 /// ```
@@ -15,10 +15,10 @@ use crate::utils::array;
 /// let bar: BoundedVec<_, 1> = subbvec(foo, 2); // fails - we can't return just 1 element since 3 remain
 /// let baz: BoundedVec<_, 10> = subbvec(foo, 3); // fails - we can't return 10 elements since only 7 remain
 /// ```
-pub fn subbvec<T, let SRC_MAX_LEN: u32, let DST_MAX_LEN: u32>(
-    bvec: BoundedVec<T, SRC_MAX_LEN>,
+pub fn subbvec<T, let SrcMaxLen: u32, let DstMaxLen: u32>(
+    bvec: BoundedVec<T, SrcMaxLen>,
     offset: u32,
-) -> BoundedVec<T, DST_MAX_LEN> {
+) -> BoundedVec<T, DstMaxLen> {
     // from_parts_unchecked does not verify that the elements past len are zeroed, but that is not an issue in our case
     // because we're constructing the new storage array as a subarray of the original one (which should have zeroed
     // storage past len), guaranteeing correctness. This is because `subarray` does not allow extending arrays past

--- a/noir-projects/aztec-nr/aztec/src/utils/array/subbvec.nr
+++ b/noir-projects/aztec-nr/aztec/src/utils/array/subbvec.nr
@@ -73,7 +73,7 @@ mod test {
         let _: BoundedVec<_, 1> = subbvec(bvec, 2);
     }
 
-    #[test(should_fail_with = "DST_LEN too large for offset")]
+    #[test(should_fail_with = "DstLen too large for offset")]
     unconstrained fn subbvec_dst_len_causes_enlarge() {
         let bvec = BoundedVec::<_, 10>::from_array([1, 2, 3, 4, 5]);
 
@@ -81,7 +81,7 @@ mod test {
         let _: BoundedVec<_, 11> = subbvec(bvec, 0);
     }
 
-    #[test(should_fail_with = "DST_LEN too large for offset")]
+    #[test(should_fail_with = "DstLen too large for offset")]
     unconstrained fn subbvec_dst_len_too_large_for_offset() {
         let bvec = BoundedVec::<_, 10>::from_array([1, 2, 3, 4, 5]);
 

--- a/noir-projects/noir-protocol-circuits/crates/reset-kernel-lib/src/note_hash_read_request_reset.nr
+++ b/noir-projects/noir-protocol-circuits/crates/reset-kernel-lib/src/note_hash_read_request_reset.nr
@@ -39,10 +39,10 @@ impl SettledReadHint<NOTE_HASH_TREE_HEIGHT, NoteHashLeafPreimage> for NoteHashSe
     }
 }
 
-pub struct NoteHashReadRequestHints<let PENDING_READ_HINTS_LEN: u32, let SETTLED_READ_HINTS_LEN: u32> {
+pub struct NoteHashReadRequestHints<let PendingReadHintsLen: u32, let SettledReadHintsLen: u32> {
     pub read_request_actions: [ReadRequestAction; MAX_NOTE_HASH_READ_REQUESTS_PER_TX],
-    pub pending_read_hints: [PendingReadHint; PENDING_READ_HINTS_LEN],
-    pub settled_read_hints: [NoteHashSettledReadHint; SETTLED_READ_HINTS_LEN],
+    pub pending_read_hints: [PendingReadHint; PendingReadHintsLen],
+    pub settled_read_hints: [NoteHashSettledReadHint; SettledReadHintsLen],
 }
 
 mod tests {
@@ -66,14 +66,14 @@ mod tests {
     };
     use types::utils::arrays::ClaimedLengthArray;
 
-    struct TestBuilder<let READ_REQUEST_LEN: u32, let PENDING_VALUE_LEN: u32, let PENDING_READ_HINTS_LEN: u32, let SETTLED_READ_HINTS_LEN: u32> {
+    struct TestBuilder<let ReadRequestLen: u32, let PendingValueLen: u32, let PendingReadHintsLen: u32, let SettledReadHintsLen: u32> {
         contract_address: AztecAddress,
-        read_requests: ClaimedLengthArray<ScopedReadRequest, READ_REQUEST_LEN>,
-        read_request_actions: [ReadRequestAction; READ_REQUEST_LEN],
-        pending_values: ClaimedLengthArray<ScopedNoteHash, PENDING_VALUE_LEN>,
-        pending_read_hints: [PendingReadHint; PENDING_READ_HINTS_LEN],
+        read_requests: ClaimedLengthArray<ScopedReadRequest, ReadRequestLen>,
+        read_request_actions: [ReadRequestAction; ReadRequestLen],
+        pending_values: ClaimedLengthArray<ScopedNoteHash, PendingValueLen>,
+        pending_read_hints: [PendingReadHint; PendingReadHintsLen],
         pending_read_amount: u32,
-        leaf_preimages: [NoteHashLeafPreimage; SETTLED_READ_HINTS_LEN],
+        leaf_preimages: [NoteHashLeafPreimage; SettledReadHintsLen],
         settled_read_amount: u32,
     }
 
@@ -145,7 +145,7 @@ mod tests {
         }
     }
 
-    impl<let READ_REQUEST_LEN: u32, let PENDING_VALUE_LEN: u32, let PENDING_READ_HINTS_LEN: u32, let SETTLED_READ_HINTS_LEN: u32> TestBuilder<READ_REQUEST_LEN, PENDING_VALUE_LEN, PENDING_READ_HINTS_LEN, SETTLED_READ_HINTS_LEN> {
+    impl<let ReadRequestLen: u32, let PendingValueLen: u32, let PendingReadHintsLen: u32, let SettledReadHintsLen: u32> TestBuilder<ReadRequestLen, PendingValueLen, PendingReadHintsLen, SettledReadHintsLen> {
         fn build_tree(
             self,
         ) -> NonEmptyMerkleTree<2, NOTE_HASH_TREE_HEIGHT, NOTE_HASH_TREE_HEIGHT - 1, 1> {
@@ -183,7 +183,7 @@ mod tests {
 
         pub unconstrained fn get_propagated_read_requests(
             self,
-        ) -> ClaimedLengthArray<ScopedReadRequest, READ_REQUEST_LEN> {
+        ) -> ClaimedLengthArray<ScopedReadRequest, ReadRequestLen> {
             get_propagated_read_requests(self.read_requests, self.read_request_actions)
         }
 

--- a/noir-projects/noir-protocol-circuits/crates/reset-kernel-lib/src/nullifier_read_request_reset.nr
+++ b/noir-projects/noir-protocol-circuits/crates/reset-kernel-lib/src/nullifier_read_request_reset.nr
@@ -39,10 +39,10 @@ impl SettledReadHint<NULLIFIER_TREE_HEIGHT, NullifierLeafPreimage> for Nullifier
     }
 }
 
-pub struct NullifierReadRequestHints<let PENDING_READ_HINTS_LEN: u32, let SETTLED_READ_HINTS_LEN: u32> {
+pub struct NullifierReadRequestHints<let PendingReadHintsLen: u32, let SettledReadHintsLen: u32> {
     pub read_request_actions: [ReadRequestAction; MAX_NULLIFIER_READ_REQUESTS_PER_TX],
-    pub pending_read_hints: [PendingReadHint; PENDING_READ_HINTS_LEN],
-    pub settled_read_hints: [NullifierSettledReadHint; SETTLED_READ_HINTS_LEN],
+    pub pending_read_hints: [PendingReadHint; PendingReadHintsLen],
+    pub settled_read_hints: [NullifierSettledReadHint; SettledReadHintsLen],
 }
 
 mod tests {
@@ -66,13 +66,13 @@ mod tests {
     };
     use types::utils::arrays::ClaimedLengthArray;
 
-    struct TestBuilder<let READ_REQUEST_LEN: u32, let PENDING_VALUE_LEN: u32, let PENDING_READ_HINTS_LEN: u32, let SETTLED_READ_HINTS_LEN: u32> {
-        read_requests: ClaimedLengthArray<ScopedReadRequest, READ_REQUEST_LEN>,
-        read_request_actions: [ReadRequestAction; READ_REQUEST_LEN],
-        pending_values: ClaimedLengthArray<ScopedNullifier, PENDING_VALUE_LEN>,
-        pending_read_hints: [PendingReadHint; PENDING_READ_HINTS_LEN],
+    struct TestBuilder<let ReadRequestLen: u32, let PendingValueLen: u32, let PendingReadHintsLen: u32, let SettledReadHintsLen: u32> {
+        read_requests: ClaimedLengthArray<ScopedReadRequest, ReadRequestLen>,
+        read_request_actions: [ReadRequestAction; ReadRequestLen],
+        pending_values: ClaimedLengthArray<ScopedNullifier, PendingValueLen>,
+        pending_read_hints: [PendingReadHint; PendingReadHintsLen],
         pending_read_amount: u32,
-        leaf_preimages: [NullifierLeafPreimage; SETTLED_READ_HINTS_LEN],
+        leaf_preimages: [NullifierLeafPreimage; SettledReadHintsLen],
         settled_read_amount: u32,
     }
 
@@ -150,7 +150,7 @@ mod tests {
         }
     }
 
-    impl<let READ_REQUEST_LEN: u32, let PENDING_VALUE_LEN: u32, let PENDING_READ_HINTS_LEN: u32, let SETTLED_READ_HINTS_LEN: u32> TestBuilder<READ_REQUEST_LEN, PENDING_VALUE_LEN, PENDING_READ_HINTS_LEN, SETTLED_READ_HINTS_LEN> {
+    impl<let ReadRequestLen: u32, let PendingValueLen: u32, let PendingReadHintsLen: u32, let SettledReadHintsLen: u32> TestBuilder<ReadRequestLen, PendingValueLen, PendingReadHintsLen, SettledReadHintsLen> {
         fn build_tree(
             self,
         ) -> NonEmptyMerkleTree<2, NULLIFIER_TREE_HEIGHT, NULLIFIER_TREE_HEIGHT - 1, 1> {
@@ -188,7 +188,7 @@ mod tests {
 
         pub unconstrained fn get_propagated_read_requests(
             self,
-        ) -> ClaimedLengthArray<ScopedReadRequest, READ_REQUEST_LEN> {
+        ) -> ClaimedLengthArray<ScopedReadRequest, ReadRequestLen> {
             get_propagated_read_requests(self.read_requests, self.read_request_actions)
         }
 

--- a/noir-projects/noir-protocol-circuits/crates/reset-kernel-lib/src/reset/key_validation_request.nr
+++ b/noir-projects/noir-protocol-circuits/crates/reset-kernel-lib/src/reset/key_validation_request.nr
@@ -48,11 +48,11 @@ fn verify_key_validation_request(
 
 // `key_validation_amount` is a known constant at compile time. For all such reset variant
 // amounts, the constant is defined in the main.nr files and passed down to this function.
-pub fn verify_reset_key_validation_requests<let REQUESTS_LEN: u32, let HINTS_LEN: u32>(
-    key_validation_requests: ClaimedLengthArray<ScopedKeyValidationRequestAndGenerator, REQUESTS_LEN>,
-    hints: [KeyValidationHint; HINTS_LEN],
+pub fn verify_reset_key_validation_requests<let RequestsLen: u32, let HintsLen: u32>(
+    key_validation_requests: ClaimedLengthArray<ScopedKeyValidationRequestAndGenerator, RequestsLen>,
+    hints: [KeyValidationHint; HintsLen],
     key_validation_amount: u32,
-    propagated_requests: ClaimedLengthArray<ScopedKeyValidationRequestAndGenerator, REQUESTS_LEN>,
+    propagated_requests: ClaimedLengthArray<ScopedKeyValidationRequestAndGenerator, RequestsLen>,
 ) {
     if key_validation_amount == 0 {
         assert_eq(
@@ -63,11 +63,11 @@ pub fn verify_reset_key_validation_requests<let REQUESTS_LEN: u32, let HINTS_LEN
     } else {
         assert_eq(
             key_validation_amount,
-            HINTS_LEN,
+            HintsLen,
             "key_validation_amount should be the same as the number of hints",
         );
 
-        for i in 0..HINTS_LEN {
+        for i in 0..HintsLen {
             let hint = hints[i];
             let request = key_validation_requests.array[i];
             if i < key_validation_requests.length {
@@ -87,9 +87,9 @@ pub fn verify_reset_key_validation_requests<let REQUESTS_LEN: u32, let HINTS_LEN
             "Incorrect unverified key validation requests claimed length",
         );
 
-        for i in HINTS_LEN..REQUESTS_LEN {
+        for i in HintsLen..RequestsLen {
             let unverified_request = key_validation_requests.array[i];
-            let to_index = i - HINTS_LEN;
+            let to_index = i - HintsLen;
             let propagated_request = propagated_requests.array[to_index];
             assert_eq(
                 propagated_request,
@@ -142,11 +142,11 @@ mod tests {
     };
     use std::embedded_curve_ops::fixed_base_scalar_mul as derive_public_key;
 
-    struct TestBuilder<let REQUESTS_LEN: u32, let HINTS_LEN: u32> {
-        key_validation_requests: ClaimedLengthArray<ScopedKeyValidationRequestAndGenerator, REQUESTS_LEN>,
-        hints: BoundedVec<KeyValidationHint, HINTS_LEN>,
+    struct TestBuilder<let RequestsLen: u32, let HintsLen: u32> {
+        key_validation_requests: ClaimedLengthArray<ScopedKeyValidationRequestAndGenerator, RequestsLen>,
+        hints: BoundedVec<KeyValidationHint, HintsLen>,
         key_validation_amount: u32,
-        propagated_requests: ClaimedLengthArray<ScopedKeyValidationRequestAndGenerator, REQUESTS_LEN>,
+        propagated_requests: ClaimedLengthArray<ScopedKeyValidationRequestAndGenerator, RequestsLen>,
     }
 
     impl TestBuilder<6, 2> {
@@ -197,12 +197,12 @@ mod tests {
         }
     }
 
-    impl<let REQUESTS_LEN: u32, let HINTS_LEN: u32> TestBuilder<REQUESTS_LEN, HINTS_LEN> {
+    impl<let RequestsLen: u32, let HintsLen: u32> TestBuilder<RequestsLen, HintsLen> {
         pub fn empty() -> Self {
             Self {
                 key_validation_requests: ClaimedLengthArray::empty(),
                 hints: BoundedVec::new(),
-                key_validation_amount: HINTS_LEN,
+                key_validation_amount: HintsLen,
                 propagated_requests: ClaimedLengthArray::empty(),
             }
         }
@@ -236,7 +236,7 @@ mod tests {
 
         pub fn get_propagated_key_validation_requests(
             self,
-        ) -> ClaimedLengthArray<ScopedKeyValidationRequestAndGenerator, REQUESTS_LEN> {
+        ) -> ClaimedLengthArray<ScopedKeyValidationRequestAndGenerator, RequestsLen> {
             // Safety: This is only used in tests.
             unsafe {
                 get_propagated_key_validation_requests(

--- a/noir-projects/noir-protocol-circuits/crates/reset-kernel-lib/src/reset/read_request.nr
+++ b/noir-projects/noir-protocol-circuits/crates/reset-kernel-lib/src/reset/read_request.nr
@@ -61,11 +61,11 @@ impl PendingReadHint {
     }
 }
 
-pub trait SettledReadHint<let TREE_HEIGHT: u32, LEAF_PREIMAGE>
+pub trait SettledReadHint<let TreeHeight: u32, LEAF_PREIMAGE>
 where
     LEAF_PREIMAGE: LeafPreimage,
 {
-    fn membership_witness(self) -> MembershipWitness<TREE_HEIGHT>;
+    fn membership_witness(self) -> MembershipWitness<TreeHeight>;
     fn leaf_preimage(self) -> LEAF_PREIMAGE;
     fn skip(read_request_len: u32) -> Self;
 }
@@ -74,19 +74,19 @@ where
 // More info here:
 // - https://discourse.aztec.network/t/to-read-or-not-to-read/178
 // - https://discourse.aztec.network/t/spending-notes-which-havent-yet-been-inserted/180
-fn validate_pending_read_requests<let READ_REQUEST_LEN: u32, T, let PENDING_VALUE_LEN: u32, let PENDING_READ_HINTS_LEN: u32>(
-    read_requests: ClaimedLengthArray<ScopedReadRequest, READ_REQUEST_LEN>,
-    pending_values: ClaimedLengthArray<T, PENDING_VALUE_LEN>,
-    hints: [PendingReadHint; PENDING_READ_HINTS_LEN],
+fn validate_pending_read_requests<let ReadRequestLen: u32, T, let PendingValueLen: u32, let PendingReadHintsLen: u32>(
+    read_requests: ClaimedLengthArray<ScopedReadRequest, ReadRequestLen>,
+    pending_values: ClaimedLengthArray<T, PendingValueLen>,
+    hints: [PendingReadHint; PendingReadHintsLen],
 )
 where
     T: Readable<ScopedReadRequest>,
 {
-    for i in 0..PENDING_READ_HINTS_LEN {
+    for i in 0..PendingReadHintsLen {
         let hint = hints[i];
         let read_request_index = hint.read_request_index;
         let pending_value_index = hint.pending_value_index;
-        if read_request_index != READ_REQUEST_LEN {
+        if read_request_index != ReadRequestLen {
             assert(
                 pending_value_index < pending_values.length,
                 "Cannot read a pending value beyond claimed length",
@@ -100,19 +100,19 @@ where
 
 // Validate read requests against the historical tree root, for reading settled notes.
 // Use their membership witnesses to do so.
-fn validate_settled_read_requests<let READ_REQUEST_LEN: u32, let SETTLED_READ_HINTS_LEN: u32, H, let TREE_HEIGHT: u32, LEAF_PREIMAGE>(
-    read_requests: ClaimedLengthArray<ScopedReadRequest, READ_REQUEST_LEN>,
-    hints: [H; SETTLED_READ_HINTS_LEN],
+fn validate_settled_read_requests<let ReadRequestLen: u32, let SettledReadHintsLen: u32, H, let TreeHeight: u32, LEAF_PREIMAGE>(
+    read_requests: ClaimedLengthArray<ScopedReadRequest, ReadRequestLen>,
+    hints: [H; SettledReadHintsLen],
     tree_root: Field,
 )
 where
-    H: SettledReadHint<TREE_HEIGHT, LEAF_PREIMAGE> + ReadValueHint,
+    H: SettledReadHint<TreeHeight, LEAF_PREIMAGE> + ReadValueHint,
     LEAF_PREIMAGE: LeafPreimage + Readable<ScopedReadRequest>,
 {
-    for i in 0..SETTLED_READ_HINTS_LEN {
+    for i in 0..SettledReadHintsLen {
         let hint = hints[i];
         let read_request_index = hint.read_request_index();
-        if read_request_index != READ_REQUEST_LEN {
+        if read_request_index != ReadRequestLen {
             let read_request = read_requests.array[read_request_index];
             let leaf_preimage = hint.leaf_preimage();
             leaf_preimage.assert_match_read_request(read_request);
@@ -124,19 +124,19 @@ where
     }
 }
 
-fn verify_propagated_read_requests<let READ_REQUEST_LEN: u32, let PENDING_READ_HINTS_LEN: u32, T, let SETTLED_READ_HINTS_LEN: u32, S>(
-    read_requests: ClaimedLengthArray<ScopedReadRequest, READ_REQUEST_LEN>,
-    read_request_actions: [ReadRequestAction; READ_REQUEST_LEN],
-    pending_read_hints: [T; PENDING_READ_HINTS_LEN],
-    settled_read_hints: [S; SETTLED_READ_HINTS_LEN],
-    propagated_read_requests: ClaimedLengthArray<ScopedReadRequest, READ_REQUEST_LEN>,
+fn verify_propagated_read_requests<let ReadRequestLen: u32, let PendingReadHintsLen: u32, T, let SettledReadHintsLen: u32, S>(
+    read_requests: ClaimedLengthArray<ScopedReadRequest, ReadRequestLen>,
+    read_request_actions: [ReadRequestAction; ReadRequestLen],
+    pending_read_hints: [T; PendingReadHintsLen],
+    settled_read_hints: [S; SettledReadHintsLen],
+    propagated_read_requests: ClaimedLengthArray<ScopedReadRequest, ReadRequestLen>,
 )
 where
     T: ReadValueHint,
     S: ReadValueHint,
 {
     let mut num_propagated = 0;
-    for i in 0..READ_REQUEST_LEN {
+    for i in 0..ReadRequestLen {
         let read_request = read_requests.array[i];
         let status = read_request_actions[i];
         if status.action == ReadRequestActions.READ_AS_PENDING {
@@ -196,20 +196,20 @@ where
 // and `settled_read_amount` the same as `SETTLED_READ_HINTS_LEN`.
 // We created two variables because an array is not allowed to be empty (zero length). In the case a reset circuit skips
 // the read request verification, the array will contain empty items, and the [pending|settled]_read_amount will be zero.
-pub fn verify_reset_read_requests<let READ_REQUEST_LEN: u32, P, let PENDING_VALUE_LEN: u32, let PENDING_READ_HINTS_LEN: u32, let SETTLED_READ_HINTS_LEN: u32, H, let TREE_HEIGHT: u32, LEAF_PREIMAGE>(
-    read_requests: ClaimedLengthArray<ScopedReadRequest, READ_REQUEST_LEN>,
-    pending_values: ClaimedLengthArray<P, PENDING_VALUE_LEN>,
-    read_request_actions: [ReadRequestAction; READ_REQUEST_LEN],
-    pending_read_hints: [PendingReadHint; PENDING_READ_HINTS_LEN],
+pub fn verify_reset_read_requests<let ReadRequestLen: u32, P, let PendingValueLen: u32, let PendingReadHintsLen: u32, let SettledReadHintsLen: u32, H, let TreeHeight: u32, LEAF_PREIMAGE>(
+    read_requests: ClaimedLengthArray<ScopedReadRequest, ReadRequestLen>,
+    pending_values: ClaimedLengthArray<P, PendingValueLen>,
+    read_request_actions: [ReadRequestAction; ReadRequestLen],
+    pending_read_hints: [PendingReadHint; PendingReadHintsLen],
     pending_read_amount: u32,
-    settled_read_hints: [H; SETTLED_READ_HINTS_LEN],
+    settled_read_hints: [H; SettledReadHintsLen],
     settled_read_amount: u32,
     tree_root: Field,
-    propagated_read_requests: ClaimedLengthArray<ScopedReadRequest, READ_REQUEST_LEN>,
+    propagated_read_requests: ClaimedLengthArray<ScopedReadRequest, ReadRequestLen>,
 )
 where
     P: Readable<ScopedReadRequest>,
-    H: SettledReadHint<TREE_HEIGHT, LEAF_PREIMAGE> + ReadValueHint,
+    H: SettledReadHint<TreeHeight, LEAF_PREIMAGE> + ReadValueHint,
     LEAF_PREIMAGE: LeafPreimage + Readable<ScopedReadRequest>,
 {
     if pending_read_amount != 0 {
@@ -219,7 +219,7 @@ where
         // making it impossible to skip propagating a read request by referring to a hint that's not used.
         assert_eq(
             pending_read_amount,
-            PENDING_READ_HINTS_LEN,
+            PendingReadHintsLen,
             "pending_read_amount should be the same as the number of pending read hints",
         );
         validate_pending_read_requests(read_requests, pending_values, pending_read_hints);
@@ -227,10 +227,10 @@ where
         // Ensure all index hints are set to READ_REQUEST_LEN.
         // This guarantees that the hints cannot be used in verify_propagated_read_requests
         // to skip propagating a read request by referencing a valid read_request_index.
-        for i in 0..PENDING_READ_HINTS_LEN {
+        for i in 0..PendingReadHintsLen {
             assert_eq(
                 pending_read_hints[i].read_request_index(),
-                READ_REQUEST_LEN,
+                ReadRequestLen,
                 "Unused pending read hint should not point to a read request",
             );
         }
@@ -243,7 +243,7 @@ where
         // making it impossible to skip propagating a read request by referring to a hint that's not used.
         assert_eq(
             settled_read_amount,
-            SETTLED_READ_HINTS_LEN,
+            SettledReadHintsLen,
             "settled_read_amount should be the same as the number of settled read hints",
         );
         validate_settled_read_requests(read_requests, settled_read_hints, tree_root);
@@ -251,10 +251,10 @@ where
         // Ensure all index hints are set to READ_REQUEST_LEN.
         // This guarantees that the hints cannot be used in verify_propagated_read_requests
         // to skip propagating a read request by referencing a valid read_request_index.
-        for i in 0..SETTLED_READ_HINTS_LEN {
+        for i in 0..SettledReadHintsLen {
             assert_eq(
                 settled_read_hints[i].read_request_index(),
-                READ_REQUEST_LEN,
+                ReadRequestLen,
                 "Unused settled read hint should not point to a read request",
             );
         }
@@ -269,10 +269,10 @@ where
     );
 }
 
-pub unconstrained fn get_propagated_read_requests<let READ_REQUEST_LEN: u32>(
-    read_requests: ClaimedLengthArray<ScopedReadRequest, READ_REQUEST_LEN>,
-    read_request_actions: [ReadRequestAction; READ_REQUEST_LEN],
-) -> ClaimedLengthArray<ScopedReadRequest, READ_REQUEST_LEN> {
+pub unconstrained fn get_propagated_read_requests<let ReadRequestLen: u32>(
+    read_requests: ClaimedLengthArray<ScopedReadRequest, ReadRequestLen>,
+    read_request_actions: [ReadRequestAction; ReadRequestLen],
+) -> ClaimedLengthArray<ScopedReadRequest, ReadRequestLen> {
     let mut propagated_read_requests = ClaimedLengthArray::empty();
     for i in 0..read_requests.length {
         let read_request = read_requests.array[i];
@@ -288,7 +288,7 @@ pub unconstrained fn get_propagated_read_requests<let READ_REQUEST_LEN: u32>(
     // If not all read requests are propagated, we must still copy the first item beyond the claimed length into the
     // propagated array to prevent incorrect equality assertions in verify_propagated_read_requests.
     // See the implementation of verify_propagated_read_requests for more details.
-    if read_requests.length != READ_REQUEST_LEN {
+    if read_requests.length != ReadRequestLen {
         let num_propagated = propagated_read_requests.length;
         propagated_read_requests.array[num_propagated] = read_requests.array[read_requests.length];
     }
@@ -402,13 +402,13 @@ mod tests {
             TestSettledReadPartialHint { read_request_index: read_request_len, leaf_index: 0 }
         }
     }
-    struct TestBuilder<let READ_REQUEST_LEN: u32, let PENDING_VALUE_LEN: u32, let PENDING_READ_HINTS_LEN: u32, let SETTLED_READ_HINTS_LEN: u32> {
-        read_requests: ClaimedLengthArray<ScopedReadRequest, READ_REQUEST_LEN>,
-        read_request_actions: [ReadRequestAction; READ_REQUEST_LEN],
-        pending_values: ClaimedLengthArray<TestValue, PENDING_VALUE_LEN>,
-        pending_read_hints: [PendingReadHint; PENDING_READ_HINTS_LEN],
-        settled_read_partial_hints: [TestSettledReadPartialHint; SETTLED_READ_HINTS_LEN],
-        leaf_preimages: [TestLeafPreimage; SETTLED_READ_HINTS_LEN],
+    struct TestBuilder<let ReadRequestLen: u32, let PendingValueLen: u32, let PendingReadHintsLen: u32, let SettledReadHintsLen: u32> {
+        read_requests: ClaimedLengthArray<ScopedReadRequest, ReadRequestLen>,
+        read_request_actions: [ReadRequestAction; ReadRequestLen],
+        pending_values: ClaimedLengthArray<TestValue, PendingValueLen>,
+        pending_read_hints: [PendingReadHint; PendingReadHintsLen],
+        settled_read_partial_hints: [TestSettledReadPartialHint; SettledReadHintsLen],
+        leaf_preimages: [TestLeafPreimage; SettledReadHintsLen],
         pending_read_amount: u32,
         settled_read_amount: u32,
     }
@@ -484,7 +484,7 @@ mod tests {
         }
     }
 
-    impl<let READ_REQUEST_LEN: u32, let PENDING_VALUE_LEN: u32, let PENDING_READ_HINTS_LEN: u32, let SETTLED_READ_HINTS_LEN: u32> TestBuilder<READ_REQUEST_LEN, PENDING_VALUE_LEN, PENDING_READ_HINTS_LEN, SETTLED_READ_HINTS_LEN> {
+    impl<let ReadRequestLen: u32, let PendingValueLen: u32, let PendingReadHintsLen: u32, let SettledReadHintsLen: u32> TestBuilder<ReadRequestLen, PendingValueLen, PendingReadHintsLen, SettledReadHintsLen> {
         fn build_tree(self) -> NonEmptyMerkleTree<2, 3, 2, 1> {
             NonEmptyMerkleTree::new(
                 [self.leaf_preimages[0].as_leaf(), self.leaf_preimages[1].as_leaf()],
@@ -494,13 +494,11 @@ mod tests {
             )
         }
 
-        pub fn get_settled_read_hints(
-            self,
-        ) -> ([TestSettledReadHint; SETTLED_READ_HINTS_LEN], Field) {
+        pub fn get_settled_read_hints(self) -> ([TestSettledReadHint; SettledReadHintsLen], Field) {
             let tree = self.build_tree();
 
             let hints = self.settled_read_partial_hints.map(|hint| {
-                let membership_witness = if hint.read_request_index != READ_REQUEST_LEN {
+                let membership_witness = if hint.read_request_index != ReadRequestLen {
                     MembershipWitness {
                         leaf_index: hint.leaf_index as Field,
                         sibling_path: tree.get_sibling_path(hint.leaf_index),
@@ -509,7 +507,7 @@ mod tests {
                     MembershipWitness::empty()
                 };
 
-                let leaf_preimage = if hint.read_request_index != READ_REQUEST_LEN {
+                let leaf_preimage = if hint.read_request_index != ReadRequestLen {
                     self.leaf_preimages[hint.leaf_index]
                 } else {
                     TestLeafPreimage::empty()
@@ -554,13 +552,13 @@ mod tests {
                     .unwrap()
             };
             self.settled_read_partial_hints[hint_index] =
-                TestSettledReadPartialHint::skip(READ_REQUEST_LEN);
+                TestSettledReadPartialHint::skip(ReadRequestLen);
             self.read_request_actions[read_request_index] = ReadRequestAction::set_as_skip();
         }
 
         pub fn get_propagated_read_requests(
             self,
-        ) -> ClaimedLengthArray<ScopedReadRequest, READ_REQUEST_LEN> {
+        ) -> ClaimedLengthArray<ScopedReadRequest, ReadRequestLen> {
             // Safety: this is only used in tests.
             unsafe {
                 get_propagated_read_requests(self.read_requests, self.read_request_actions)
@@ -582,7 +580,7 @@ mod tests {
 
         pub fn validate_settled_read_requests_with_hints(
             self,
-            settled_hints: [TestSettledReadHint; SETTLED_READ_HINTS_LEN],
+            settled_hints: [TestSettledReadHint; SettledReadHintsLen],
             tree_root: Field,
         ) {
             validate_settled_read_requests(self.read_requests, settled_hints, tree_root);
@@ -590,7 +588,7 @@ mod tests {
 
         pub fn verify_with_propagated_read_requests(
             self,
-            propagated_read_requests: ClaimedLengthArray<ScopedReadRequest, READ_REQUEST_LEN>,
+            propagated_read_requests: ClaimedLengthArray<ScopedReadRequest, ReadRequestLen>,
         ) {
             let (settled_hints, tree_root) = self.get_settled_read_hints();
             verify_reset_read_requests(

--- a/noir-projects/noir-protocol-circuits/crates/reset-kernel-lib/src/reset/transient_data.nr
+++ b/noir-projects/noir-protocol-circuits/crates/reset-kernel-lib/src/reset/transient_data.nr
@@ -24,20 +24,20 @@ use validate_transient_data_squashing_hints::validate_transient_data_squashing_h
 ///
 /// This function checks that note hashes, nullifiers, and logs are squashed correctly according to user-provided hints
 /// and expectations. It allows some transient data to be intentionally preserved across iterations when needed.
-pub fn validate_squashed_transient_data<let NOTE_HASHES_LEN: u32, let NULLIFIERS_LEN: u32, let LOGS_LEN: u32, let SQUASHING_HINTS_LEN: u32>(
-    note_hashes: ClaimedLengthArray<ScopedNoteHash, NOTE_HASHES_LEN>,
-    nullifiers: ClaimedLengthArray<ScopedNullifier, NULLIFIERS_LEN>,
-    logs: ClaimedLengthArray<Scoped<PrivateLogData>, LOGS_LEN>,
-    expected_kept_note_hashes: ClaimedLengthArray<ScopedNoteHash, NOTE_HASHES_LEN>,
-    expected_kept_nullifiers: ClaimedLengthArray<ScopedNullifier, NULLIFIERS_LEN>,
-    expected_kept_logs: ClaimedLengthArray<Scoped<PrivateLogData>, LOGS_LEN>,
+pub fn validate_squashed_transient_data<let NoteHashesLen: u32, let NullifiersLen: u32, let LogsLen: u32, let SquashingHintsLen: u32>(
+    note_hashes: ClaimedLengthArray<ScopedNoteHash, NoteHashesLen>,
+    nullifiers: ClaimedLengthArray<ScopedNullifier, NullifiersLen>,
+    logs: ClaimedLengthArray<Scoped<PrivateLogData>, LogsLen>,
+    expected_kept_note_hashes: ClaimedLengthArray<ScopedNoteHash, NoteHashesLen>,
+    expected_kept_nullifiers: ClaimedLengthArray<ScopedNullifier, NullifiersLen>,
+    expected_kept_logs: ClaimedLengthArray<Scoped<PrivateLogData>, LogsLen>,
     min_revertible_side_effect_counter: u32,
     // Hints provided by the user to specify what to squash.
     // These are not derived automatically in this function like other hints, because the user can choose to not squash
     // a pair even if it's squashable. Sometimes the transient data might be useful in later iterations. For example, a
     // note hash must be kept to be used for a note hash read request created in a later iteration, and can only be
     // squashed after the read request is validated.
-    transient_data_squashing_hints: [TransientDataSquashingHint; SQUASHING_HINTS_LEN],
+    transient_data_squashing_hints: [TransientDataSquashingHint; SquashingHintsLen],
 ) {
     // Safety: The hints are verified below by validate_squashed_transient_data_with_derived_hints.
     let derived_hints = unsafe {
@@ -69,16 +69,16 @@ pub fn validate_squashed_transient_data<let NOTE_HASHES_LEN: u32, let NULLIFIERS
 /// - Squashing hints are well-formed: active hints must reference unique and in-bounds note hash and nullifier indices.
 /// - Note hashes and nullifiers are squashed or kept appropriately.
 /// - Private logs are squashed or propagated, and note logs are correctly linked to the note hashes.
-fn validate_squashed_transient_data_with_derived_hints<let NOTE_HASHES_LEN: u32, let NULLIFIERS_LEN: u32, let LOGS_LEN: u32, let SQUASHING_HINTS_LEN: u32>(
-    note_hashes: ClaimedLengthArray<ScopedNoteHash, NOTE_HASHES_LEN>,
-    nullifiers: ClaimedLengthArray<ScopedNullifier, NULLIFIERS_LEN>,
-    logs: ClaimedLengthArray<Scoped<PrivateLogData>, LOGS_LEN>,
-    expected_kept_note_hashes: ClaimedLengthArray<ScopedNoteHash, NOTE_HASHES_LEN>,
-    expected_kept_nullifiers: ClaimedLengthArray<ScopedNullifier, NULLIFIERS_LEN>,
-    expected_kept_logs: ClaimedLengthArray<Scoped<PrivateLogData>, LOGS_LEN>,
+fn validate_squashed_transient_data_with_derived_hints<let NoteHashesLen: u32, let NullifiersLen: u32, let LogsLen: u32, let SquashingHintsLen: u32>(
+    note_hashes: ClaimedLengthArray<ScopedNoteHash, NoteHashesLen>,
+    nullifiers: ClaimedLengthArray<ScopedNullifier, NullifiersLen>,
+    logs: ClaimedLengthArray<Scoped<PrivateLogData>, LogsLen>,
+    expected_kept_note_hashes: ClaimedLengthArray<ScopedNoteHash, NoteHashesLen>,
+    expected_kept_nullifiers: ClaimedLengthArray<ScopedNullifier, NullifiersLen>,
+    expected_kept_logs: ClaimedLengthArray<Scoped<PrivateLogData>, LogsLen>,
     min_revertible_side_effect_counter: u32,
-    transient_data_squashing_hints: [TransientDataSquashingHint; SQUASHING_HINTS_LEN],
-    derived_hints: DerivedHints<SQUASHING_HINTS_LEN, NOTE_HASHES_LEN, NULLIFIERS_LEN, LOGS_LEN>,
+    transient_data_squashing_hints: [TransientDataSquashingHint; SquashingHintsLen],
+    derived_hints: DerivedHints<SquashingHintsLen, NoteHashesLen, NullifiersLen, LogsLen>,
 ) {
     validate_transient_data_squashing_hints(
         note_hashes,
@@ -140,15 +140,15 @@ pub(crate) mod tests {
         )
     }
 
-    pub struct TransientDataFixtureBuilder<let NOTE_HASHES_LEN: u32, let NULLIFIERS_LEN: u32, let LOGS_LEN: u32, let SQUASHING_HINTS_LEN: u32> {
-        pub note_hashes: ClaimedLengthArray<ScopedNoteHash, NOTE_HASHES_LEN>,
-        pub nullifiers: ClaimedLengthArray<ScopedNullifier, NULLIFIERS_LEN>,
-        pub logs: ClaimedLengthArray<Scoped<PrivateLogData>, LOGS_LEN>,
-        pub expected_kept_note_hashes: ClaimedLengthArray<ScopedNoteHash, NOTE_HASHES_LEN>,
-        pub expected_kept_nullifiers: ClaimedLengthArray<ScopedNullifier, NULLIFIERS_LEN>,
-        pub expected_kept_logs: ClaimedLengthArray<Scoped<PrivateLogData>, LOGS_LEN>,
+    pub struct TransientDataFixtureBuilder<let NoteHashesLen: u32, let NullifiersLen: u32, let LogsLen: u32, let SquashingHintsLen: u32> {
+        pub note_hashes: ClaimedLengthArray<ScopedNoteHash, NoteHashesLen>,
+        pub nullifiers: ClaimedLengthArray<ScopedNullifier, NullifiersLen>,
+        pub logs: ClaimedLengthArray<Scoped<PrivateLogData>, LogsLen>,
+        pub expected_kept_note_hashes: ClaimedLengthArray<ScopedNoteHash, NoteHashesLen>,
+        pub expected_kept_nullifiers: ClaimedLengthArray<ScopedNullifier, NullifiersLen>,
+        pub expected_kept_logs: ClaimedLengthArray<Scoped<PrivateLogData>, LogsLen>,
         pub min_revertible_side_effect_counter: u32,
-        pub transient_data_squashing_hints: [TransientDataSquashingHint; SQUASHING_HINTS_LEN],
+        pub transient_data_squashing_hints: [TransientDataSquashingHint; SquashingHintsLen],
         num_transient_data_squashing_hints: u32,
     }
 
@@ -159,7 +159,7 @@ pub(crate) mod tests {
         }
     }
 
-    impl<let NOTE_HASHES_LEN: u32, let NULLIFIERS_LEN: u32, let LOGS_LEN: u32, let SQUASHING_HINTS_LEN: u32> TransientDataFixtureBuilder<NOTE_HASHES_LEN, NULLIFIERS_LEN, LOGS_LEN, SQUASHING_HINTS_LEN> {
+    impl<let NoteHashesLen: u32, let NullifiersLen: u32, let LogsLen: u32, let SquashingHintsLen: u32> TransientDataFixtureBuilder<NoteHashesLen, NullifiersLen, LogsLen, SquashingHintsLen> {
         pub fn empty() -> Self {
             TransientDataFixtureBuilder {
                 note_hashes: ClaimedLengthArray::empty(),
@@ -170,8 +170,8 @@ pub(crate) mod tests {
                 expected_kept_logs: ClaimedLengthArray::empty(),
                 min_revertible_side_effect_counter: 0,
                 transient_data_squashing_hints: [
-                    TransientDataSquashingHint::skip(NOTE_HASHES_LEN, NULLIFIERS_LEN);
-                         SQUASHING_HINTS_LEN
+                    TransientDataSquashingHint::skip(NoteHashesLen, NullifiersLen);
+                         SquashingHintsLen
                     ],
                 num_transient_data_squashing_hints: 0,
             }
@@ -220,12 +220,12 @@ pub(crate) mod tests {
         }
 
         pub fn get_skip_index_hint(_self: Self) -> TransientDataSquashingHint {
-            TransientDataSquashingHint::skip(NOTE_HASHES_LEN, NULLIFIERS_LEN)
+            TransientDataSquashingHint::skip(NoteHashesLen, NullifiersLen)
         }
 
         pub fn build_derived_hints(
             self,
-        ) -> DerivedHints<SQUASHING_HINTS_LEN, NOTE_HASHES_LEN, NULLIFIERS_LEN, LOGS_LEN> {
+        ) -> DerivedHints<SquashingHintsLen, NoteHashesLen, NullifiersLen, LogsLen> {
             // Safety: This is only used in tests.
             unsafe {
                 build_derived_hints(
@@ -253,7 +253,7 @@ pub(crate) mod tests {
 
         pub fn validate_with_derived_hints(
             self,
-            derived_hints: DerivedHints<SQUASHING_HINTS_LEN, NOTE_HASHES_LEN, NULLIFIERS_LEN, LOGS_LEN>,
+            derived_hints: DerivedHints<SquashingHintsLen, NoteHashesLen, NullifiersLen, LogsLen>,
         ) {
             validate_squashed_transient_data_with_derived_hints(
                 self.note_hashes,

--- a/noir-projects/noir-protocol-circuits/crates/reset-kernel-lib/src/reset/transient_data/derived_hints.nr
+++ b/noir-projects/noir-protocol-circuits/crates/reset-kernel-lib/src/reset/transient_data/derived_hints.nr
@@ -18,18 +18,18 @@ use dep::types::{
     utils::arrays::{ClaimedLengthArray, SortedTuple},
 };
 
-pub struct DerivedHints<let SQUASHING_HINTS_LEN: u32, let NOTE_HASHES_LEN: u32, let NULLIFIERS_LEN: u32, let LOGS_LEN: u32> {
+pub struct DerivedHints<let SquashingHintsLen: u32, let NoteHashesLen: u32, let NullifiersLen: u32, let LogsLen: u32> {
     /// The number of squashing hints that can be used to squash note hashes and nullifiers.
     pub num_active_squashing_hints: u32,
     /// The nullifier indices extracted from the squashing hints, sorted in ascending order.
-    pub nullifier_index_sorted_tuples: [SortedTuple<u32>; SQUASHING_HINTS_LEN],
+    pub nullifier_index_sorted_tuples: [SortedTuple<u32>; SquashingHintsLen],
     /// A boolean array indicating which note hashes are to be squashed.
-    pub note_hash_squash_flags: [bool; NOTE_HASHES_LEN],
+    pub note_hash_squash_flags: [bool; NoteHashesLen],
     /// A boolean array indicating which nullifiers are to be squashed.
-    pub nullifier_squash_flags: [bool; NULLIFIERS_LEN],
+    pub nullifier_squash_flags: [bool; NullifiersLen],
     /// For each note log, identifies the index of its linked note hash, either in the `kept_note_hashes` array, or in
     /// the `transient_data_squashing_hints` array if squashed.
-    pub note_log_linked_source_indices: [NoteLogLinkedSourceIndices; LOGS_LEN],
+    pub note_log_linked_source_indices: [NoteLogLinkedSourceIndices; LogsLen],
 }
 
 /// Constructs all derived hints needed to apply transient data squashing logic.
@@ -37,13 +37,13 @@ pub struct DerivedHints<let SQUASHING_HINTS_LEN: u32, let NOTE_HASHES_LEN: u32, 
 /// Given the same input parameters, this function will deterministically return the same derived hints.
 /// Any mismatch in derived hints will cause the verification to fail.
 /// An attacker cannot manipulate the hints to bypass the verification process.
-pub unconstrained fn build_derived_hints<let NOTE_HASHES_LEN: u32, let NULLIFIERS_LEN: u32, let LOGS_LEN: u32, let SQUASHING_HINTS_LEN: u32>(
-    note_hashes: ClaimedLengthArray<ScopedNoteHash, NOTE_HASHES_LEN>,
-    nullifiers: ClaimedLengthArray<ScopedNullifier, NULLIFIERS_LEN>,
-    logs: ClaimedLengthArray<Scoped<PrivateLogData>, LOGS_LEN>,
-    expected_kept_note_hashes: ClaimedLengthArray<ScopedNoteHash, NOTE_HASHES_LEN>,
-    transient_data_squashing_hints: [TransientDataSquashingHint; SQUASHING_HINTS_LEN],
-) -> DerivedHints<SQUASHING_HINTS_LEN, NOTE_HASHES_LEN, NULLIFIERS_LEN, LOGS_LEN> {
+pub unconstrained fn build_derived_hints<let NoteHashesLen: u32, let NullifiersLen: u32, let LogsLen: u32, let SquashingHintsLen: u32>(
+    note_hashes: ClaimedLengthArray<ScopedNoteHash, NoteHashesLen>,
+    nullifiers: ClaimedLengthArray<ScopedNullifier, NullifiersLen>,
+    logs: ClaimedLengthArray<Scoped<PrivateLogData>, LogsLen>,
+    expected_kept_note_hashes: ClaimedLengthArray<ScopedNoteHash, NoteHashesLen>,
+    transient_data_squashing_hints: [TransientDataSquashingHint; SquashingHintsLen],
+) -> DerivedHints<SquashingHintsLen, NoteHashesLen, NullifiersLen, LogsLen> {
     let num_active_squashing_hints =
         get_num_active_squashing_hints(transient_data_squashing_hints, nullifiers);
 

--- a/noir-projects/noir-protocol-circuits/crates/reset-kernel-lib/src/reset/transient_data/derived_hints/note_log_linked_source_indices.nr
+++ b/noir-projects/noir-protocol-circuits/crates/reset-kernel-lib/src/reset/transient_data/derived_hints/note_log_linked_source_indices.nr
@@ -28,17 +28,17 @@ pub struct NoteLogLinkedSourceIndices {
 ///
 /// @returns An array of `NoteLogLinkedSourceIndices` where each entry corresponds to a log in `logs` and describes the
 /// origin of its possible linked note hash (may be in `kept_note_hashes` or in `transient_data_squashing_hints`).
-pub unconstrained fn build_note_log_linked_source_indices<let LOGS_LEN: u32, let NOTE_HASHES_LEN: u32, let SQUASHING_HINTS_LEN: u32>(
-    logs: ClaimedLengthArray<Scoped<PrivateLogData>, LOGS_LEN>,
-    note_hashes: ClaimedLengthArray<ScopedNoteHash, NOTE_HASHES_LEN>,
-    kept_note_hashes: ClaimedLengthArray<ScopedNoteHash, NOTE_HASHES_LEN>,
-    transient_data_squashing_hints: [TransientDataSquashingHint; SQUASHING_HINTS_LEN],
-) -> [NoteLogLinkedSourceIndices; LOGS_LEN] {
+pub unconstrained fn build_note_log_linked_source_indices<let LogsLen: u32, let NoteHashesLen: u32, let SquashingHintsLen: u32>(
+    logs: ClaimedLengthArray<Scoped<PrivateLogData>, LogsLen>,
+    note_hashes: ClaimedLengthArray<ScopedNoteHash, NoteHashesLen>,
+    kept_note_hashes: ClaimedLengthArray<ScopedNoteHash, NoteHashesLen>,
+    transient_data_squashing_hints: [TransientDataSquashingHint; SquashingHintsLen],
+) -> [NoteLogLinkedSourceIndices; LogsLen] {
     let mut linked_source_indices = [
         NoteLogLinkedSourceIndices {
             transient_data_squashing_hint_index: 0,
             kept_note_hash_index: 0,
-        }; LOGS_LEN
+        }; LogsLen
     ];
 
     for i in 0..logs.length {

--- a/noir-projects/noir-protocol-circuits/crates/reset-kernel-lib/src/reset/transient_data/derived_hints/nullifier_index_sorted_tuples.nr
+++ b/noir-projects/noir-protocol-circuits/crates/reset-kernel-lib/src/reset/transient_data/derived_hints/nullifier_index_sorted_tuples.nr
@@ -7,9 +7,9 @@ use types::utils::arrays::{get_sorted_tuple, SortedTuple};
 /// and its original position in the `transient_data_squashing_hints` array.
 ///
 /// The array is sorted in ascending order by nullifier index.
-pub unconstrained fn build_nullifier_index_sorted_tuples<let SQUASHING_HINTS_LEN: u32>(
-    transient_data_squashing_hints: [TransientDataSquashingHint; SQUASHING_HINTS_LEN],
-) -> [SortedTuple<u32>; SQUASHING_HINTS_LEN] {
+pub unconstrained fn build_nullifier_index_sorted_tuples<let SquashingHintsLen: u32>(
+    transient_data_squashing_hints: [TransientDataSquashingHint; SquashingHintsLen],
+) -> [SortedTuple<u32>; SquashingHintsLen] {
     let nullifier_indices = transient_data_squashing_hints.map(|hint| hint.nullifier_index);
     get_sorted_tuple(nullifier_indices, |a, b| a < b)
 }

--- a/noir-projects/noir-protocol-circuits/crates/reset-kernel-lib/src/reset/transient_data/derived_hints/num_active_squashing_hints.nr
+++ b/noir-projects/noir-protocol-circuits/crates/reset-kernel-lib/src/reset/transient_data/derived_hints/num_active_squashing_hints.nr
@@ -7,12 +7,12 @@ use dep::types::{
 /// Returns the number of active hints in the `transient_data_squashing_hints` array.
 /// Only the first `num_active_squashing_hints` entries in the array are used to squash (note hash, nullifier) pairs.
 /// Remaining entries are considered inactive and will be ignored.
-pub unconstrained fn get_num_active_squashing_hints<let SQUASHING_HINTS_LEN: u32, let NULLIFIERS_LEN: u32>(
-    transient_data_squashing_hints: [TransientDataSquashingHint; SQUASHING_HINTS_LEN],
-    _nullifiers: ClaimedLengthArray<ScopedNullifier, NULLIFIERS_LEN>,
+pub unconstrained fn get_num_active_squashing_hints<let SquashingHintsLen: u32, let NullifiersLen: u32>(
+    transient_data_squashing_hints: [TransientDataSquashingHint; SquashingHintsLen],
+    _nullifiers: ClaimedLengthArray<ScopedNullifier, NullifiersLen>,
 ) -> u32 {
     find_first_index(
         transient_data_squashing_hints,
-        |hint| hint.nullifier_index == NULLIFIERS_LEN,
+        |hint| hint.nullifier_index == NullifiersLen,
     )
 }

--- a/noir-projects/noir-protocol-circuits/crates/reset-kernel-lib/src/reset/transient_data/derived_hints/squash_flags.nr
+++ b/noir-projects/noir-protocol-circuits/crates/reset-kernel-lib/src/reset/transient_data/derived_hints/squash_flags.nr
@@ -2,11 +2,11 @@ use crate::reset::transient_data::transient_data_squashing_hint::TransientDataSq
 
 /// Constructs a boolean flag array indicating which note hashes are to be squashed.
 /// For each active squashing hint, sets the flag at the corresponding `note_hash_index` to `true`.
-pub unconstrained fn build_note_hash_squash_flags<let SQUASHING_HINTS_LEN: u32, let NOTE_HASHES_LEN: u32>(
-    transient_data_squashing_hints: [TransientDataSquashingHint; SQUASHING_HINTS_LEN],
+pub unconstrained fn build_note_hash_squash_flags<let SquashingHintsLen: u32, let NoteHashesLen: u32>(
+    transient_data_squashing_hints: [TransientDataSquashingHint; SquashingHintsLen],
     num_active_squashing_hints: u32,
-) -> [bool; NOTE_HASHES_LEN] {
-    let mut hints = [false; NOTE_HASHES_LEN];
+) -> [bool; NoteHashesLen] {
+    let mut hints = [false; NoteHashesLen];
     for i in 0..num_active_squashing_hints {
         let note_hash_index = transient_data_squashing_hints[i].note_hash_index;
         hints[note_hash_index] = true;
@@ -16,11 +16,11 @@ pub unconstrained fn build_note_hash_squash_flags<let SQUASHING_HINTS_LEN: u32, 
 
 /// Constructs a boolean flag array indicating which nullifiers are to be squashed.
 /// For each active squashing hint, sets the flag at the corresponding `nullifier_index` to `true`.
-pub unconstrained fn build_nullifier_squash_flags<let SQUASHING_HINTS_LEN: u32, let NULLIFIERS_LEN: u32>(
-    transient_data_squashing_hints: [TransientDataSquashingHint; SQUASHING_HINTS_LEN],
+pub unconstrained fn build_nullifier_squash_flags<let SquashingHintsLen: u32, let NullifiersLen: u32>(
+    transient_data_squashing_hints: [TransientDataSquashingHint; SquashingHintsLen],
     num_active_squashing_hints: u32,
-) -> [bool; NULLIFIERS_LEN] {
-    let mut hints = [false; NULLIFIERS_LEN];
+) -> [bool; NullifiersLen] {
+    let mut hints = [false; NullifiersLen];
     for i in 0..num_active_squashing_hints {
         let nullifier_index = transient_data_squashing_hints[i].nullifier_index;
         hints[nullifier_index] = true;

--- a/noir-projects/noir-protocol-circuits/crates/reset-kernel-lib/src/reset/transient_data/utils/squash_transient_data.nr
+++ b/noir-projects/noir-protocol-circuits/crates/reset-kernel-lib/src/reset/transient_data/utils/squash_transient_data.nr
@@ -24,15 +24,15 @@ use dep::types::{
 /// All non-note logs are retained. A note log is retained **only** if it's linked to a note hash that is not squashed.
 ///
 /// @returns Updated `note_hashes`, `nullifiers`, and `logs` arrays with the squashable elements removed.
-pub unconstrained fn squash_transient_data<let NOTE_HASHES_LEN: u32, let NULLIFIERS_LEN: u32, let LOGS_LEN: u32, let SQUASHING_HINTS_LEN: u32>(
-    note_hashes: ClaimedLengthArray<ScopedNoteHash, NOTE_HASHES_LEN>,
-    nullifiers: ClaimedLengthArray<ScopedNullifier, NULLIFIERS_LEN>,
-    logs: ClaimedLengthArray<Scoped<PrivateLogData>, LOGS_LEN>,
-    transient_data_squashing_hints: [TransientDataSquashingHint; SQUASHING_HINTS_LEN],
-    ) -> (ClaimedLengthArray<ScopedNoteHash, NOTE_HASHES_LEN>, ClaimedLengthArray<ScopedNullifier, NULLIFIERS_LEN>, ClaimedLengthArray<Scoped<PrivateLogData>, LOGS_LEN>) {
+pub unconstrained fn squash_transient_data<let NoteHashesLen: u32, let NullifiersLen: u32, let LogsLen: u32, let SquashingHintsLen: u32>(
+    note_hashes: ClaimedLengthArray<ScopedNoteHash, NoteHashesLen>,
+    nullifiers: ClaimedLengthArray<ScopedNullifier, NullifiersLen>,
+    logs: ClaimedLengthArray<Scoped<PrivateLogData>, LogsLen>,
+    transient_data_squashing_hints: [TransientDataSquashingHint; SquashingHintsLen],
+    ) -> (ClaimedLengthArray<ScopedNoteHash, NoteHashesLen>, ClaimedLengthArray<ScopedNullifier, NullifiersLen>, ClaimedLengthArray<Scoped<PrivateLogData>, LogsLen>) {
     // Create a flag for each note hash and nullifier, indicating whether it is squashed.
-    let mut note_hash_squash_flags = [false; NOTE_HASHES_LEN];
-    let mut nullifier_squash_flags = [false; NULLIFIERS_LEN];
+    let mut note_hash_squash_flags = [false; NoteHashesLen];
+    let mut nullifier_squash_flags = [false; NullifiersLen];
     let num_active_squashing_hints =
         get_num_active_squashing_hints(transient_data_squashing_hints, nullifiers);
     for i in 0..num_active_squashing_hints {
@@ -42,7 +42,7 @@ pub unconstrained fn squash_transient_data<let NOTE_HASHES_LEN: u32, let NULLIFI
     }
 
     // Propagate note hashes that are not squashed:
-    let mut kept_note_hashes: ClaimedLengthArray<ScopedNoteHash, NOTE_HASHES_LEN> =
+    let mut kept_note_hashes: ClaimedLengthArray<ScopedNoteHash, NoteHashesLen> =
         ClaimedLengthArray::empty();
     for i in 0..note_hashes.length {
         if !note_hash_squash_flags[i] {
@@ -51,7 +51,7 @@ pub unconstrained fn squash_transient_data<let NOTE_HASHES_LEN: u32, let NULLIFI
     }
 
     // Propagate nullifiers that are not squashed:
-    let mut kept_nullifiers: ClaimedLengthArray<ScopedNullifier, NULLIFIERS_LEN> =
+    let mut kept_nullifiers: ClaimedLengthArray<ScopedNullifier, NullifiersLen> =
         ClaimedLengthArray::empty();
     for i in 0..nullifiers.length {
         if !nullifier_squash_flags[i] {
@@ -59,7 +59,7 @@ pub unconstrained fn squash_transient_data<let NOTE_HASHES_LEN: u32, let NULLIFI
         }
     }
 
-    let mut kept_logs: ClaimedLengthArray<Scoped<PrivateLogData>, LOGS_LEN> =
+    let mut kept_logs: ClaimedLengthArray<Scoped<PrivateLogData>, LogsLen> =
         ClaimedLengthArray::empty();
     for i in 0..logs.length {
         let log = logs.array[i];

--- a/noir-projects/noir-protocol-circuits/crates/reset-kernel-lib/src/reset/transient_data/validate_log_squashing.nr
+++ b/noir-projects/noir-protocol-circuits/crates/reset-kernel-lib/src/reset/transient_data/validate_log_squashing.nr
@@ -26,20 +26,20 @@ fn is_log_linked_to_note_hash(log: Scoped<PrivateLogData>, note_hash: ScopedNote
 /// - Correct linkage between logs and their note hashes.
 /// - Correct usage of squashing hints.
 /// - Both the log and the note hash must be revertible or non-revertible.
-pub fn validate_log_squashing<let LOGS_LEN: u32, let SQUASHING_HINTS_LEN: u32, let NOTE_HASHES_LEN: u32>(
-    logs: ClaimedLengthArray<Scoped<PrivateLogData>, LOGS_LEN>,
-    note_hashes: ClaimedLengthArray<ScopedNoteHash, NOTE_HASHES_LEN>,
-    expected_kept_logs: ClaimedLengthArray<Scoped<PrivateLogData>, LOGS_LEN>,
-    expected_kept_note_hashes: ClaimedLengthArray<ScopedNoteHash, NOTE_HASHES_LEN>,
+pub fn validate_log_squashing<let LogsLen: u32, let SquashingHintsLen: u32, let NoteHashesLen: u32>(
+    logs: ClaimedLengthArray<Scoped<PrivateLogData>, LogsLen>,
+    note_hashes: ClaimedLengthArray<ScopedNoteHash, NoteHashesLen>,
+    expected_kept_logs: ClaimedLengthArray<Scoped<PrivateLogData>, LogsLen>,
+    expected_kept_note_hashes: ClaimedLengthArray<ScopedNoteHash, NoteHashesLen>,
     min_revertible_side_effect_counter: u32,
-    transient_data_squashing_hints: [TransientDataSquashingHint; SQUASHING_HINTS_LEN],
-    note_log_linked_source_indices: [NoteLogLinkedSourceIndices; LOGS_LEN],
+    transient_data_squashing_hints: [TransientDataSquashingHint; SquashingHintsLen],
+    note_log_linked_source_indices: [NoteLogLinkedSourceIndices; LogsLen],
 ) {
     // This loop determines whether each log should be:
     // - kept and propagated forward, or
     // - squashed along with its associated note hash.
     let mut kept_logs_counter = 0;
-    for i in 0..LOGS_LEN {
+    for i in 0..LogsLen {
         let log = logs.array[i];
         let linked_source_indices = note_log_linked_source_indices[i];
 
@@ -89,7 +89,7 @@ pub fn validate_log_squashing<let LOGS_LEN: u32, let SQUASHING_HINTS_LEN: u32, l
             );
             // We can be sure that `hinted_squashed_note_hash` is squashed because its index appears in
             // `transient_data_squashing_hints`, which is iterated over earlier. And each `note_hash_index` beyond
-            // `num_active_squashing_hints` is set to `NOTE_HASHES_LEN` and would overflow the note hashes array.
+            // `num_active_squashing_hints` is set to `NoteHashesLen` and would overflow the note hashes array.
             //
             // No need to check that `squashed_note_hash_index` is within the claimed length; that check is already
             // done when the hint is used to squash the note hash.
@@ -126,7 +126,7 @@ pub fn validate_log_squashing<let LOGS_LEN: u32, let SQUASHING_HINTS_LEN: u32, l
     // Note: We can't directly compare `expected_kept_logs.length` with `kept_logs_counter`, because the counter
     // includes logs beyond the claimed length.
     // Instead, we calculate how many logs were squashed, and derive the expected kept array length.
-    let num_squashed_logs = LOGS_LEN - kept_logs_counter;
+    let num_squashed_logs = LogsLen - kept_logs_counter;
     assert_eq(
         expected_kept_logs.length,
         logs.length - num_squashed_logs,

--- a/noir-projects/noir-protocol-circuits/crates/reset-kernel-lib/src/reset/transient_data/validate_log_squashing.nr
+++ b/noir-projects/noir-protocol-circuits/crates/reset-kernel-lib/src/reset/transient_data/validate_log_squashing.nr
@@ -491,7 +491,7 @@ mod tests {
         builder.validate_with_derived_hints(derived_hints);
     }
 
-    #[test(should_fail_with = "Unused note hash index hint must be set to NOTE_HASHES_LEN")]
+    #[test(should_fail_with = "Unused note hash index hint must be set to NoteHashesLen")]
     fn fails_squashed_log_linked_to_fake_note_hash() {
         let mut builder = TransientDataFixtureBuilder::new();
 

--- a/noir-projects/noir-protocol-circuits/crates/reset-kernel-lib/src/reset/transient_data/validate_note_hash_nullifier_squashing.nr
+++ b/noir-projects/noir-protocol-circuits/crates/reset-kernel-lib/src/reset/transient_data/validate_note_hash_nullifier_squashing.nr
@@ -14,16 +14,16 @@ use validate_squashable_note_hash_nullifier_pair::validate_squashable_note_hash_
 ///
 /// It assumes that the uniqueness and bounds of the hinted indices have already been validated (which is done in
 /// `validate_transient_data_squashing_hints.nr`).
-pub fn validate_note_hash_nullifier_squashing<let NOTE_HASHES_LEN: u32, let NULLIFIERS_LEN: u32, let SQUASHING_HINTS_LEN: u32>(
-    note_hashes: ClaimedLengthArray<ScopedNoteHash, NOTE_HASHES_LEN>,
-    nullifiers: ClaimedLengthArray<ScopedNullifier, NULLIFIERS_LEN>,
-    expected_kept_note_hashes: ClaimedLengthArray<ScopedNoteHash, NOTE_HASHES_LEN>,
-    expected_kept_nullifiers: ClaimedLengthArray<ScopedNullifier, NULLIFIERS_LEN>,
+pub fn validate_note_hash_nullifier_squashing<let NoteHashesLen: u32, let NullifiersLen: u32, let SquashingHintsLen: u32>(
+    note_hashes: ClaimedLengthArray<ScopedNoteHash, NoteHashesLen>,
+    nullifiers: ClaimedLengthArray<ScopedNullifier, NullifiersLen>,
+    expected_kept_note_hashes: ClaimedLengthArray<ScopedNoteHash, NoteHashesLen>,
+    expected_kept_nullifiers: ClaimedLengthArray<ScopedNullifier, NullifiersLen>,
     min_revertible_side_effect_counter: u32,
-    transient_data_squashing_hints: [TransientDataSquashingHint; SQUASHING_HINTS_LEN],
+    transient_data_squashing_hints: [TransientDataSquashingHint; SquashingHintsLen],
     num_active_squashing_hints: u32,
-    note_hash_squash_flags: [bool; NOTE_HASHES_LEN],
-    nullifier_squash_flags: [bool; NULLIFIERS_LEN],
+    note_hash_squash_flags: [bool; NoteHashesLen],
+    nullifier_squash_flags: [bool; NullifiersLen],
 ) {
     // This loop iterates over the hints `transient_data_squashing_hints` and validates that each (note hash, nullifier)
     // pair is eligible to be squashed.
@@ -31,7 +31,7 @@ pub fn validate_note_hash_nullifier_squashing<let NOTE_HASHES_LEN: u32, let NULL
     // We iterate over the hints directly (rather than the full note hashes or nullifiers arrays) so that the circuit
     // size can be optimized according to the number of squashable pairs needed.
     let mut is_active_hint = true;
-    for i in 0..SQUASHING_HINTS_LEN {
+    for i in 0..SquashingHintsLen {
         let hint = transient_data_squashing_hints[i];
 
         // Determine if the hint can be used.
@@ -72,7 +72,7 @@ pub fn validate_note_hash_nullifier_squashing<let NOTE_HASHES_LEN: u32, let NULL
     // it is squashed. Here we propagate the note hashes whose flags are `false`, and check that they match the expected
     // kept note hashes.
     let mut kept_note_hashes_counter = 0;
-    for i in 0..NOTE_HASHES_LEN {
+    for i in 0..NoteHashesLen {
         if !note_hash_squash_flags[i] {
             assert_eq(
                 expected_kept_note_hashes.array[kept_note_hashes_counter],
@@ -86,7 +86,7 @@ pub fn validate_note_hash_nullifier_squashing<let NOTE_HASHES_LEN: u32, let NULL
     // than it should be, and the below check will fail.
     assert_eq(
         kept_note_hashes_counter + num_squashed_pairs,
-        NOTE_HASHES_LEN,
+        NoteHashesLen,
         "Wrong number of note hashes removed",
     );
     // Ensure that the length of the kept note hashes array is correct.
@@ -103,7 +103,7 @@ pub fn validate_note_hash_nullifier_squashing<let NOTE_HASHES_LEN: u32, let NULL
     // it is squashed. Here we propagate the nullifiers whose flags are `false`, and check that they match the expected
     // kept nullifiers.
     let mut kept_nullifiers_counter = 0;
-    for i in 0..NULLIFIERS_LEN {
+    for i in 0..NullifiersLen {
         if !nullifier_squash_flags[i] {
             assert_eq(
                 expected_kept_nullifiers.array[kept_nullifiers_counter],
@@ -117,7 +117,7 @@ pub fn validate_note_hash_nullifier_squashing<let NOTE_HASHES_LEN: u32, let NULL
     // than it should be, and the below check will fail.
     assert_eq(
         kept_nullifiers_counter + num_squashed_pairs,
-        NULLIFIERS_LEN,
+        NullifiersLen,
         "Wrong number of nullifiers removed",
     );
     // Ensure that the length of the kept nullifiers array is correct.

--- a/noir-projects/noir-protocol-circuits/crates/reset-kernel-lib/src/reset/transient_data/validate_transient_data_squashing_hints.nr
+++ b/noir-projects/noir-protocol-circuits/crates/reset-kernel-lib/src/reset/transient_data/validate_transient_data_squashing_hints.nr
@@ -18,16 +18,16 @@ use types::{
 ///
 /// The validation against the claimed lengths prevent malicious users from faking a note hash or nullifier beyond the
 /// claimed length to justify squashing a nullifier or note hash that should be kept.
-pub fn validate_transient_data_squashing_hints<let NOTE_HASHES_LEN: u32, let NULLIFIERS_LEN: u32, let SQUASHING_HINTS_LEN: u32>(
-    note_hashes: ClaimedLengthArray<ScopedNoteHash, NOTE_HASHES_LEN>,
-    nullifiers: ClaimedLengthArray<ScopedNullifier, NULLIFIERS_LEN>,
-    transient_data_squashing_hints: [TransientDataSquashingHint; SQUASHING_HINTS_LEN],
+pub fn validate_transient_data_squashing_hints<let NoteHashesLen: u32, let NullifiersLen: u32, let SquashingHintsLen: u32>(
+    note_hashes: ClaimedLengthArray<ScopedNoteHash, NoteHashesLen>,
+    nullifiers: ClaimedLengthArray<ScopedNullifier, NullifiersLen>,
+    transient_data_squashing_hints: [TransientDataSquashingHint; SquashingHintsLen],
     num_active_squashing_hints: u32,
     // Sorted values of nullifier indices (with original indices) used to validate uniqueness.
-    nullifier_index_sorted_tuples: [SortedTuple<u32>; SQUASHING_HINTS_LEN],
+    nullifier_index_sorted_tuples: [SortedTuple<u32>; SquashingHintsLen],
 ) {
     let mut is_active_hint = true;
-    for i in 0..SQUASHING_HINTS_LEN {
+    for i in 0..SquashingHintsLen {
         let hint = transient_data_squashing_hints[i];
         let nullifier_index_sorted_tuple = nullifier_index_sorted_tuples[i];
 
@@ -78,8 +78,8 @@ pub fn validate_transient_data_squashing_hints<let NOTE_HASHES_LEN: u32, let NUL
             // fake note hash beyond the claimed length.
             assert_eq(
                 hint.note_hash_index,
-                NOTE_HASHES_LEN,
-                "Unused note hash index hint must be set to NOTE_HASHES_LEN",
+                NoteHashesLen,
+                "Unused note hash index hint must be set to NoteHashesLen",
             );
 
             // === Nullifier index uniqueness check: Step 3 ===
@@ -87,8 +87,8 @@ pub fn validate_transient_data_squashing_hints<let NOTE_HASHES_LEN: u32, let NUL
             // That would allow a duplicate nullifier index in an active hint to slip through undetected.
             assert_eq(
                 hint.nullifier_index,
-                NULLIFIERS_LEN,
-                "Unused nullifier index hint must be set to NULLIFIERS_LEN",
+                NullifiersLen,
+                "Unused nullifier index hint must be set to NullifiersLen",
             );
         }
     }

--- a/noir-projects/noir-protocol-circuits/crates/reset-kernel-lib/src/reset/transient_data/validate_transient_data_squashing_hints.nr
+++ b/noir-projects/noir-protocol-circuits/crates/reset-kernel-lib/src/reset/transient_data/validate_transient_data_squashing_hints.nr
@@ -174,7 +174,7 @@ mod tests {
         builder.validate_with_derived_hints(derived_hints);
     }
 
-    #[test(should_fail_with = "Unused note hash index hint must be set to NOTE_HASHES_LEN")]
+    #[test(should_fail_with = "Unused note hash index hint must be set to NoteHashesLen")]
     fn fails_note_hash_squashed_by_inactive_hint() {
         let mut builder = TransientDataFixtureBuilder::new();
 
@@ -270,7 +270,7 @@ mod tests {
         builder.validate_with_derived_hints(derived_hints);
     }
 
-    #[test(should_fail_with = "Unused nullifier index hint must be set to NULLIFIERS_LEN")]
+    #[test(should_fail_with = "Unused nullifier index hint must be set to NullifiersLen")]
     fn fails_nullifier_squashed_by_inactive_hint() {
         let mut builder = TransientDataFixtureBuilder::new();
 

--- a/noir-projects/noir-protocol-circuits/crates/reset-kernel-lib/src/tests/note_hash_read_request_hints_builder.nr
+++ b/noir-projects/noir-protocol-circuits/crates/reset-kernel-lib/src/tests/note_hash_read_request_hints_builder.nr
@@ -4,24 +4,24 @@ use crate::{
 };
 use dep::types::{constants::MAX_NOTE_HASH_READ_REQUESTS_PER_TX, traits::Empty};
 
-pub struct NoteHashReadRequestHintsBuilder<let PENDING_HINTS_LEN: u32, let SETTLED_HINTS_LEN: u32> {
+pub struct NoteHashReadRequestHintsBuilder<let PendingHintsLen: u32, let SettledHintsLen: u32> {
     pub read_request_actions: [ReadRequestAction; MAX_NOTE_HASH_READ_REQUESTS_PER_TX],
-    pub pending_read_hints: BoundedVec<PendingReadHint, PENDING_HINTS_LEN>,
-    pub settled_read_hints: BoundedVec<NoteHashSettledReadHint, SETTLED_HINTS_LEN>,
+    pub pending_read_hints: BoundedVec<PendingReadHint, PendingHintsLen>,
+    pub settled_read_hints: BoundedVec<NoteHashSettledReadHint, SettledHintsLen>,
 }
 
-impl<let PENDING_HINTS_LEN: u32, let SETTLED_HINTS_LEN: u32> NoteHashReadRequestHintsBuilder<PENDING_HINTS_LEN, SETTLED_HINTS_LEN> {
+impl<let PendingHintsLen: u32, let SettledHintsLen: u32> NoteHashReadRequestHintsBuilder<PendingHintsLen, SettledHintsLen> {
     pub fn new() -> Self {
         NoteHashReadRequestHintsBuilder {
             read_request_actions: [ReadRequestAction::empty(); MAX_NOTE_HASH_READ_REQUESTS_PER_TX],
             pending_read_hints: BoundedVec::from_parts_unchecked(
-                [PendingReadHint::skip(MAX_NOTE_HASH_READ_REQUESTS_PER_TX); PENDING_HINTS_LEN],
+                [PendingReadHint::skip(MAX_NOTE_HASH_READ_REQUESTS_PER_TX); PendingHintsLen],
                 0,
             ),
             settled_read_hints: BoundedVec::from_parts_unchecked(
                 [
                     NoteHashSettledReadHint::skip(MAX_NOTE_HASH_READ_REQUESTS_PER_TX);
-                         SETTLED_HINTS_LEN
+                         SettledHintsLen
                     ],
                 0,
             ),
@@ -36,7 +36,7 @@ impl<let PENDING_HINTS_LEN: u32, let SETTLED_HINTS_LEN: u32> NoteHashReadRequest
             ReadRequestAction::set_as_pending(hint_index);
     }
 
-    pub fn to_hints(self) -> NoteHashReadRequestHints<PENDING_HINTS_LEN, SETTLED_HINTS_LEN> {
+    pub fn to_hints(self) -> NoteHashReadRequestHints<PendingHintsLen, SettledHintsLen> {
         NoteHashReadRequestHints {
             read_request_actions: self.read_request_actions,
             pending_read_hints: self.pending_read_hints.storage(),

--- a/noir-projects/noir-protocol-circuits/crates/reset-kernel-lib/src/tests/nullifier_read_request_hints_builder.nr
+++ b/noir-projects/noir-protocol-circuits/crates/reset-kernel-lib/src/tests/nullifier_read_request_hints_builder.nr
@@ -4,24 +4,24 @@ use crate::{
 };
 use dep::types::{constants::MAX_NULLIFIER_READ_REQUESTS_PER_TX, traits::Empty};
 
-pub struct NullifierReadRequestHintsBuilder<let PENDING_HINTS_LEN: u32, let SETTLED_HINTS_LEN: u32> {
+pub struct NullifierReadRequestHintsBuilder<let PendingHintsLen: u32, let SettledHintsLen: u32> {
     pub read_request_actions: [ReadRequestAction; MAX_NULLIFIER_READ_REQUESTS_PER_TX],
-    pub pending_read_hints: BoundedVec<PendingReadHint, PENDING_HINTS_LEN>,
-    pub settled_read_hints: BoundedVec<NullifierSettledReadHint, SETTLED_HINTS_LEN>,
+    pub pending_read_hints: BoundedVec<PendingReadHint, PendingHintsLen>,
+    pub settled_read_hints: BoundedVec<NullifierSettledReadHint, SettledHintsLen>,
 }
 
-impl<let PENDING_HINTS_LEN: u32, let SETTLED_HINTS_LEN: u32> NullifierReadRequestHintsBuilder<PENDING_HINTS_LEN, SETTLED_HINTS_LEN> {
+impl<let PendingHintsLen: u32, let SettledHintsLen: u32> NullifierReadRequestHintsBuilder<PendingHintsLen, SettledHintsLen> {
     pub fn new() -> Self {
         NullifierReadRequestHintsBuilder {
             read_request_actions: [ReadRequestAction::empty(); MAX_NULLIFIER_READ_REQUESTS_PER_TX],
             pending_read_hints: BoundedVec::from_parts_unchecked(
-                [PendingReadHint::skip(MAX_NULLIFIER_READ_REQUESTS_PER_TX); PENDING_HINTS_LEN],
+                [PendingReadHint::skip(MAX_NULLIFIER_READ_REQUESTS_PER_TX); PendingHintsLen],
                 0,
             ),
             settled_read_hints: BoundedVec::from_parts_unchecked(
                 [
                     NullifierSettledReadHint::skip(MAX_NULLIFIER_READ_REQUESTS_PER_TX);
-                         SETTLED_HINTS_LEN
+                         SettledHintsLen
                     ],
                 0,
             ),
@@ -36,7 +36,7 @@ impl<let PENDING_HINTS_LEN: u32, let SETTLED_HINTS_LEN: u32> NullifierReadReques
             ReadRequestAction::set_as_pending(hint_index);
     }
 
-    pub fn to_hints(self) -> NullifierReadRequestHints<PENDING_HINTS_LEN, SETTLED_HINTS_LEN> {
+    pub fn to_hints(self) -> NullifierReadRequestHints<PendingHintsLen, SettledHintsLen> {
         NullifierReadRequestHints {
             read_request_actions: self.read_request_actions,
             pending_read_hints: self.pending_read_hints.storage(),

--- a/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays.nr
@@ -47,12 +47,12 @@ use super::for_loop::{for_i_in_0_, for_i_only_in_0_};
 //**********************************************************************************
 
 // TODO: Consider making this a part of the noir stdlib.
-pub fn subarray<let SRC_LEN: u32, let DST_LEN: u32>(
-    src: [Field; SRC_LEN],
+pub fn subarray<let SrcLen: u32, let DstLen: u32>(
+    src: [Field; SrcLen],
     offset: u32,
-) -> [Field; DST_LEN] {
-    let mut dst: [Field; DST_LEN] = std::mem::zeroed();
-    for i in 0..DST_LEN {
+) -> [Field; DstLen] {
+    let mut dst: [Field; DstLen] = std::mem::zeroed();
+    for i in 0..DstLen {
         dst[i] = src[i + offset];
     }
 


### PR DESCRIPTION
Fixes #16013

Mike bothered me with that issue but he is pardoned because I promised him to try to run AI agent on this task. It actually worked well. Just took a bit of time for the AI to process it and had to dump the compilation output with errors into the agent a few times. In this case I would actually prefer if the agent was even more agentic as always allowing it to proceed slowed it all down.