### PR TITLE
feat(avm): AVM proving benchmarks

### DIFF
--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/prover.cpp
@@ -66,7 +66,7 @@ void AvmProver::execute_log_derivative_inverse_round()
     bb::constexpr_for<0, std::tuple_size_v<Flavor::LookupRelations>, 1>([&]<size_t relation_idx>() {
         using Relation = std::tuple_element_t<relation_idx, Flavor::LookupRelations>;
         tasks.push_back([&]() {
-            AVM_TRACK_TIME(std::string("prove/execute_log_derivative_inverse_round/") + std::string(Relation::NAME),
+            AVM_TRACK_TIME(std::string("prove/log_derivative_inverse_round/") + std::string(Relation::NAME),
                            (compute_logderivative_inverse<FF, Relation>(
                                prover_polynomials, relation_parameters, key->circuit_size)));
         });
@@ -137,20 +137,20 @@ HonkProof AvmProver::construct_proof()
     execute_preamble_round();
 
     // Compute wire commitments.
-    AVM_TRACK_TIME("prove/execute_wire_commitments_round", execute_wire_commitments_round());
+    AVM_TRACK_TIME("prove/wire_commitments_round", execute_wire_commitments_round());
 
     // Compute log derivative inverses.
-    AVM_TRACK_TIME("prove/execute_log_derivative_inverse_round", execute_log_derivative_inverse_round());
+    AVM_TRACK_TIME("prove/log_derivative_inverse_round", execute_log_derivative_inverse_round());
 
     // Compute commitments to logderivative inverse polynomials.
-    AVM_TRACK_TIME("prove/execute_log_derivative_inverse_commitments_round",
+    AVM_TRACK_TIME("prove/log_derivative_inverse_commitments_round",
                    execute_log_derivative_inverse_commitments_round());
 
     // Run sumcheck subprotocol.
-    AVM_TRACK_TIME("prove/execute_relation_check_rounds", execute_relation_check_rounds());
+    AVM_TRACK_TIME("prove/sumcheck", execute_relation_check_rounds());
 
     // Execute PCS.
-    AVM_TRACK_TIME("prove/execute_pcs_rounds", execute_pcs_rounds());
+    AVM_TRACK_TIME("prove/pcs_rounds", execute_pcs_rounds());
 
     return export_proof();
 }

--- a/yarn-project/bb-prover/src/avm_proving_tests/avm_bulk.test.ts
+++ b/yarn-project/bb-prover/src/avm_proving_tests/avm_bulk.test.ts
@@ -17,14 +17,13 @@ describe('AVM bulk test', () => {
   let tester: AvmProvingTester;
   const logger = createLogger('avm-bulk-test');
 
-  beforeAll(async () => {
+  beforeEach(async () => {
     tester = await AvmProvingTester.new(/*checkCircuitOnly=*/ false, /*globals=*/ defaultGlobals(), metrics);
     avmTestContractInstance = await tester.registerAndDeployContract(
       /*constructorArgs=*/ [],
       /*deployer=*/ AztecAddress.fromNumber(420),
       AvmTestContractArtifact,
     );
-    tester.setMetricsPrefix('bb-prover');
   });
 
   afterAll(() => {

--- a/yarn-project/bb-prover/src/avm_proving_tests/avm_proving_tester.ts
+++ b/yarn-project/bb-prover/src/avm_proving_tests/avm_proving_tester.ts
@@ -150,7 +150,7 @@ export class AvmProvingTester extends PublicTxSimulationTester {
     });
 
     // Hack to make labels match.
-    const txLabelWithCount = `${txLabel}/0`;
+    const txLabelWithCount = `${txLabel}/${this.txCount - 1}`;
     // I need to cast because TS doesnt realize metrics is protected not private.
     (this as any).metrics?.recordProverMetrics(txLabelWithCount, {
       proverSimulationStepMs: times['simulation/all'],

--- a/yarn-project/bb-prover/src/avm_proving_tests/avm_proving_tester.ts
+++ b/yarn-project/bb-prover/src/avm_proving_tests/avm_proving_tester.ts
@@ -1,7 +1,9 @@
+import type { LogFn, LogLevel, Logger } from '@aztec/foundation/log';
 import {
   PublicTxSimulationTester,
   SimpleContractDataSource,
   type TestEnqueuedCall,
+  type TestExecutorMetrics,
   type TestPrivateInsertions,
 } from '@aztec/simulator/public/fixtures';
 import { type AvmCircuitInputs, AvmCircuitPublicInputs } from '@aztec/stdlib/avm';
@@ -25,6 +27,65 @@ import {
 
 const BB_PATH = path.resolve('../../barretenberg/cpp/build/bin/bb');
 
+// An InterceptingLogger that records all log messages and forwards them to a wrapped logger.
+class InterceptingLogger implements Logger {
+  public readonly logs: string[] = [];
+  public level: LogLevel;
+  public module: string;
+
+  private logger: Logger;
+
+  constructor(logger: Logger) {
+    this.logger = logger;
+    this.level = logger.level;
+    this.module = logger.module;
+  }
+
+  isLevelEnabled(level: LogLevel): boolean {
+    return this.logger.isLevelEnabled(level);
+  }
+
+  createChild(_childModule: string): Logger {
+    throw new Error('Not implemented');
+  }
+
+  private intercept(level: LogLevel, msg: string, ...args: any[]) {
+    this.logs.push(...msg.split('\n'));
+    // Forward to the wrapped logger
+    (this.logger[level] as LogFn)(msg, ...args);
+  }
+
+  // Log methods for each level
+  silent(msg: string, ...args: any[]) {
+    this.intercept('silent', msg, ...args);
+  }
+  fatal(msg: string, ...args: any[]) {
+    this.intercept('fatal', msg, ...args);
+  }
+  warn(msg: string, ...args: any[]) {
+    this.intercept('warn', msg, ...args);
+  }
+  info(msg: string, ...args: any[]) {
+    this.intercept('info', msg, ...args);
+  }
+  verbose(msg: string, ...args: any[]) {
+    this.intercept('verbose', msg, ...args);
+  }
+  debug(msg: string, ...args: any[]) {
+    this.intercept('debug', msg, ...args);
+  }
+  trace(msg: string, ...args: any[]) {
+    this.intercept('trace', msg, ...args);
+  }
+
+  // Error log function can be string or Error
+  error(err: Error | string, ...args: any[]) {
+    const msg = typeof err === 'string' ? err : err.message;
+    this.logs.push(msg);
+    this.logger.error(msg, err, ...args);
+  }
+}
+
 export class AvmProvingTester extends PublicTxSimulationTester {
   constructor(
     private bbWorkingDirectory: string,
@@ -32,31 +93,78 @@ export class AvmProvingTester extends PublicTxSimulationTester {
     contractDataSource: SimpleContractDataSource,
     merkleTrees: MerkleTreeWriteOperations,
     globals?: GlobalVariables,
+    metrics?: TestExecutorMetrics,
   ) {
-    super(merkleTrees, contractDataSource, globals);
+    super(merkleTrees, contractDataSource, globals, metrics);
   }
 
-  static async new(checkCircuitOnly: boolean = false, globals?: GlobalVariables) {
+  static async new(checkCircuitOnly: boolean = false, globals?: GlobalVariables, metrics?: TestExecutorMetrics) {
     const bbWorkingDirectory = await fs.mkdtemp(path.join(tmpdir(), 'bb-'));
 
     const contractDataSource = new SimpleContractDataSource();
     const merkleTrees = await (await NativeWorldStateService.tmp()).fork();
-    return new AvmProvingTester(bbWorkingDirectory, checkCircuitOnly, contractDataSource, merkleTrees, globals);
+    return new AvmProvingTester(
+      bbWorkingDirectory,
+      checkCircuitOnly,
+      contractDataSource,
+      merkleTrees,
+      globals,
+      metrics,
+    );
   }
 
-  async prove(avmCircuitInputs: AvmCircuitInputs): Promise<BBResult> {
+  async prove(avmCircuitInputs: AvmCircuitInputs, txLabel: string = 'unlabeledTx'): Promise<BBResult> {
+    const interceptingLogger = new InterceptingLogger(this.logger);
+
     // Then we prove.
     const proofRes = await generateAvmProof(
       BB_PATH,
       this.bbWorkingDirectory,
       avmCircuitInputs,
-      this.logger,
+      interceptingLogger,
       this.checkCircuitOnly,
     );
     if (proofRes.status === BB_RESULT.FAILURE) {
       this.logger.error(`Proof generation failed: ${proofRes.reason}`);
     }
     expect(proofRes.status).toEqual(BB_RESULT.SUCCESS);
+
+    // Parse the logs into a structured format.
+    const logs = interceptingLogger.logs;
+    // const traceSizes: { name: string; size: number }[] = [];
+    // logs.forEach(log => {
+    //   const match = log.match(/\b(\w+): (\d+) \(~2/);
+    //   if (match) {
+    //     traceSizes.push({
+    //       name: match[1],
+    //       size: parseInt(match[2]),
+    //     });
+    //   }
+    // });
+    const times: { [key: string]: number } = {};
+    logs.forEach(log => {
+      const match = log.match(/\b([\w/]+)_ms: (\d+)/);
+      if (match) {
+        times[match[1]] = parseInt(match[2]);
+      }
+    });
+
+    // Hack to make labels match.
+    const txLabelWithCount = `${txLabel}/0`;
+    // I need to cast because TS doesnt realize metrics is protected not private.
+    (this as any).metrics?.recordProverMetrics(txLabelWithCount, {
+      proverSimulationStepMs: times['simulation/all'],
+      proverProvingStepMs: times['proving/all'],
+      proverTraceGenerationStepMs: times['tracegen/all'],
+      traceGenerationInteractionsMs: times['tracegen/interactions'],
+      traceGenerationTracesMs: times['tracegen/traces'],
+      provingSumcheckMs: times['prove/sumcheck'],
+      provingPcsMs: times['prove/pcs_rounds'],
+      provingLogDerivativeInverseMs: times['prove/log_derivative_inverse_round'],
+      provingLogDerivativeInverseCommitmentsMs: times['prove/log_derivative_inverse_commitments_round'],
+      provingWireCommitmentsMs: times['prove/wire_commitments_round'],
+    });
+
     return proofRes as BBSuccess;
   }
 
@@ -77,8 +185,8 @@ export class AvmProvingTester extends PublicTxSimulationTester {
     );
   }
 
-  public async proveVerify(avmCircuitInputs: AvmCircuitInputs) {
-    const provingRes = await this.prove(avmCircuitInputs);
+  public async proveVerify(avmCircuitInputs: AvmCircuitInputs, txLabel: string = 'unlabeledTx') {
+    const provingRes = await this.prove(avmCircuitInputs, txLabel);
     expect(provingRes.status).toEqual(BB_RESULT.SUCCESS);
 
     const verificationRes = await this.verify(provingRes as BBSuccess, avmCircuitInputs.publicInputs);
@@ -93,21 +201,37 @@ export class AvmProvingTester extends PublicTxSimulationTester {
     expectRevert: boolean | undefined,
     feePayer = sender,
     privateInsertions?: TestPrivateInsertions,
+    txLabel: string = 'unlabeledTx',
   ) {
-    const simRes = await this.simulateTx(sender, setupCalls, appCalls, teardownCall, feePayer, privateInsertions);
+    const simRes = await this.simulateTx(
+      sender,
+      setupCalls,
+      appCalls,
+      teardownCall,
+      feePayer,
+      privateInsertions,
+      txLabel,
+    );
     expect(simRes.revertCode.isOK()).toBe(expectRevert ? false : true);
 
     const avmCircuitInputs = simRes.avmProvingRequest.inputs;
-    await this.proveVerify(avmCircuitInputs);
+    await this.proveVerify(avmCircuitInputs, txLabel);
   }
 
-  public async simProveVerifyAppLogic(appCall: TestEnqueuedCall, expectRevert?: boolean) {
+  public async simProveVerifyAppLogic(
+    appCall: TestEnqueuedCall,
+    expectRevert?: boolean,
+    txLabel: string = 'unlabeledTx',
+  ) {
     await this.simProveVerify(
       /*sender=*/ AztecAddress.fromNumber(42),
       /*setupCalls=*/ [],
       [appCall],
       undefined,
       expectRevert,
+      /*feePayer=*/ undefined,
+      /*privateInsertions=*/ undefined,
+      txLabel,
     );
   }
 }

--- a/yarn-project/bootstrap.sh
+++ b/yarn-project/bootstrap.sh
@@ -171,6 +171,7 @@ function bench_cmds {
   echo "$hash BENCH_OUTPUT=bench-out/tx_pool.bench.json yarn-project/scripts/run_test.sh p2p/src/mem_pools/tx_pool/tx_pool_bench.test.ts"
   echo "$hash BENCH_OUTPUT=bench-out/tx.bench.json yarn-project/scripts/run_test.sh stdlib/src/tx/tx_bench.test.ts"
   echo "$hash:ISOLATE=1:CPUS=10:MEM=16g:LOG_LEVEL=silent BENCH_OUTPUT=bench-out/proving_broker.bench.json yarn-project/scripts/run_test.sh prover-client/src/test/proving_broker_testbench.test.ts"
+  echo "$hash:ISOLATE=1:CPUS=16:MEM=16g BENCH_OUTPUT=bench-out/avm_bulk_test.bench.json yarn-project/scripts/run_test.sh bb-prover/src/avm_proving_tests/avm_bulk.test.ts"
 }
 
 function release_packages {

--- a/yarn-project/foundation/src/log/index.ts
+++ b/yarn-project/foundation/src/log/index.ts
@@ -3,3 +3,4 @@ export * from './libp2p_logger.js';
 export * from './log_fn.js';
 export * from './noir_debug_log_util.js';
 export * from './pino-logger.js';
+export * from './log-levels.js';

--- a/yarn-project/simulator/src/public/executor_metrics.ts
+++ b/yarn-project/simulator/src/public/executor_metrics.ts
@@ -112,10 +112,6 @@ export class ExecutorMetrics implements ExecutorMetricsInterface {
     });
   }
 
-  recordTxHashComputation(durationMs: number) {
-    this.txHashing.record(Math.ceil(durationMs));
-  }
-
   recordPrivateEffectsInsertion(durationUs: number, type: 'revertible' | 'non-revertible') {
     this.privateEffectsInsertions.record(Math.ceil(durationUs), {
       [Attributes.REVERTIBILITY]: type,

--- a/yarn-project/simulator/src/public/executor_metrics_interface.ts
+++ b/yarn-project/simulator/src/public/executor_metrics_interface.ts
@@ -10,6 +10,5 @@ export interface ExecutorMetricsInterface {
     manaUsed: number,
     totalInstructionsExecuted: number,
   ): void;
-  recordTxHashComputation(durationMs: number): void;
   recordPrivateEffectsInsertion(durationUs: number, type: 'revertible' | 'non-revertible'): void;
 }

--- a/yarn-project/simulator/src/public/fixtures/index.ts
+++ b/yarn-project/simulator/src/public/fixtures/index.ts
@@ -2,3 +2,4 @@ export * from './public_tx_simulation_tester.js';
 export * from './utils.js';
 export * from './simple_contract_data_source.js';
 export { readAvmMinimalPublicTxInputsFromFile, createAvmMinimalPublicTx } from './minimal_public_tx.js';
+export { TestExecutorMetrics } from '../test_executor_metrics.js';

--- a/yarn-project/simulator/src/public/fixtures/public_tx_simulation_tester.ts
+++ b/yarn-project/simulator/src/public/fixtures/public_tx_simulation_tester.ts
@@ -39,7 +39,7 @@ export type TestEnqueuedCall = {
  * transactions.
  */
 export class PublicTxSimulationTester extends BaseAvmSimulationTester {
-  private txCount = 0;
+  protected txCount: number = 0;
   private simulator: MeasuredPublicTxSimulator;
   private metricsPrefix?: string;
 
@@ -83,7 +83,7 @@ export class PublicTxSimulationTester extends BaseAvmSimulationTester {
     teardownCall?: TestEnqueuedCall,
     feePayer: AztecAddress = sender,
     /* need some unique first nullifier for note-nonce computations */
-    privateInsertions: TestPrivateInsertions = { nonRevertible: { nullifiers: [new Fr(420000 + this.txCount++)] } },
+    privateInsertions: TestPrivateInsertions = { nonRevertible: { nullifiers: [new Fr(420000 + this.txCount)] } },
   ): Promise<Tx> {
     const setupCallRequests = await asyncMap(setupCalls, call =>
       this.#createPubicCallRequestForCall(call, call.sender ?? sender),
@@ -95,6 +95,7 @@ export class PublicTxSimulationTester extends BaseAvmSimulationTester {
       ? await this.#createPubicCallRequestForCall(teardownCall, teardownCall.sender ?? sender)
       : undefined;
 
+    this.txCount++;
     return createTxForPublicCalls(
       privateInsertions,
       setupCallRequests,
@@ -120,7 +121,7 @@ export class PublicTxSimulationTester extends BaseAvmSimulationTester {
 
     await this.setFeePayerBalance(feePayer);
 
-    const txLabelWithCount = `${txLabel}/${this.txCount}`;
+    const txLabelWithCount = `${txLabel}/${this.txCount - 1}`;
     const fullTxLabel = this.metricsPrefix ? `${this.metricsPrefix}/${txLabelWithCount}` : txLabelWithCount;
 
     const avmResult = await this.simulator.simulate(tx, fullTxLabel);

--- a/yarn-project/simulator/src/public/fixtures/public_tx_simulation_tester.ts
+++ b/yarn-project/simulator/src/public/fixtures/public_tx_simulation_tester.ts
@@ -120,7 +120,7 @@ export class PublicTxSimulationTester extends BaseAvmSimulationTester {
 
     await this.setFeePayerBalance(feePayer);
 
-    const txLabelWithCount = `${txLabel}/${this.txCount - 1}`;
+    const txLabelWithCount = `${txLabel}/${this.txCount}`;
     const fullTxLabel = this.metricsPrefix ? `${this.metricsPrefix}/${txLabelWithCount}` : txLabelWithCount;
 
     const avmResult = await this.simulator.simulate(tx, fullTxLabel);

--- a/yarn-project/simulator/src/public/public_tx_simulator/measured_public_tx_simulator.ts
+++ b/yarn-project/simulator/src/public/public_tx_simulator/measured_public_tx_simulator.ts
@@ -39,13 +39,6 @@ export class MeasuredPublicTxSimulator extends PublicTxSimulator {
     return avmResult;
   }
 
-  protected override computeTxHash(tx: Tx) {
-    const timer = new Timer();
-    const txHash = super.computeTxHash(tx);
-    this.metrics.recordTxHashComputation(timer.ms());
-    return txHash;
-  }
-
   protected override async insertNonRevertiblesFromPrivate(context: PublicTxContext, tx: Tx) {
     const timer = new Timer();
     await super.insertNonRevertiblesFromPrivate(context, tx);

--- a/yarn-project/simulator/src/public/test_executor_metrics.ts
+++ b/yarn-project/simulator/src/public/test_executor_metrics.ts
@@ -16,14 +16,26 @@ export interface PublicEnqueuedCallMetrics {
 }
 
 export interface PublicTxMetrics {
+  // TS simulation
   totalDurationMs: number;
   manaUsed: number;
   totalInstructionsExecuted: number;
-  txHashMs: number | undefined;
   nonRevertiblePrivateInsertionsUs: number | undefined;
   revertiblePrivateInsertionsUs: number | undefined;
   enqueuedCalls: PublicEnqueuedCallMetrics[];
   revertedCode: RevertCode | undefined;
+  // Proving
+  proverSimulationStepMs: number | undefined;
+  proverProvingStepMs: number | undefined;
+  proverTraceGenerationStepMs: number | undefined;
+  // Proving (detail)
+  traceGenerationInteractionsMs: number | undefined;
+  traceGenerationTracesMs: number | undefined;
+  provingSumcheckMs: number | undefined;
+  provingPcsMs: number | undefined;
+  provingLogDerivativeInverseMs: number | undefined;
+  provingLogDerivativeInverseCommitmentsMs: number | undefined;
+  provingWireCommitmentsMs: number | undefined;
 }
 
 const NUM_SPACES = 4;
@@ -40,7 +52,31 @@ export enum PublicTxMetricsFilter {
   TOTALS,
   DURATIONS,
   INSTRUCTIONS,
+  PROVING,
 }
+
+const EMPTY_TX_METRICS: PublicTxMetrics = {
+  // TS simulation
+  totalDurationMs: 0,
+  manaUsed: 0,
+  totalInstructionsExecuted: 0,
+  nonRevertiblePrivateInsertionsUs: undefined,
+  revertiblePrivateInsertionsUs: undefined,
+  enqueuedCalls: [],
+  revertedCode: undefined,
+  // Proving
+  proverSimulationStepMs: undefined,
+  proverProvingStepMs: undefined,
+  proverTraceGenerationStepMs: undefined,
+  // Proving (detail)
+  traceGenerationInteractionsMs: undefined,
+  traceGenerationTracesMs: undefined,
+  provingSumcheckMs: undefined,
+  provingPcsMs: undefined,
+  provingLogDerivativeInverseMs: undefined,
+  provingLogDerivativeInverseCommitmentsMs: undefined,
+  provingWireCommitmentsMs: undefined,
+};
 
 export class TestExecutorMetrics implements ExecutorMetricsInterface {
   private logger: Logger;
@@ -56,16 +92,7 @@ export class TestExecutorMetrics implements ExecutorMetricsInterface {
   startRecordingTxSimulation(txLabel: string) {
     assert(!this.currentTxLabel, 'Cannot start recording tx simulation when another is live');
     assert(!this.txMetrics.has(txLabel), 'Cannot start recording metrics for tx with duplicate label');
-    this.txMetrics.set(txLabel, {
-      totalDurationMs: 0,
-      manaUsed: 0,
-      totalInstructionsExecuted: 0,
-      txHashMs: undefined,
-      nonRevertiblePrivateInsertionsUs: undefined,
-      revertiblePrivateInsertionsUs: undefined,
-      enqueuedCalls: [],
-      revertedCode: undefined,
-    });
+    this.txMetrics.set(txLabel, EMPTY_TX_METRICS);
     this.currentTxLabel = txLabel;
     this.txTimer = new Timer();
   }
@@ -124,13 +151,6 @@ export class TestExecutorMetrics implements ExecutorMetricsInterface {
     });
   }
 
-  recordTxHashComputation(durationMs: number) {
-    assert(this.currentTxLabel, 'Cannot record tx hash computation time when no tx is live');
-    const txMetrics = this.txMetrics.get(this.currentTxLabel)!;
-    assert(txMetrics.txHashMs === undefined, 'Cannot RE-record tx hash computation time');
-    txMetrics.txHashMs = durationMs;
-  }
-
   recordPrivateEffectsInsertion(durationUs: number, type: 'revertible' | 'non-revertible') {
     assert(this.currentTxLabel, 'Cannot record private effects insertion when no tx is live');
     const txMetrics = this.txMetrics.get(this.currentTxLabel)!;
@@ -146,6 +166,18 @@ export class TestExecutorMetrics implements ExecutorMetricsInterface {
         'Cannot RE-record non-revertible insertions of private effects',
       );
       txMetrics.nonRevertiblePrivateInsertionsUs = durationUs;
+    }
+  }
+
+  recordProverMetrics(txLabel: string, metrics: Partial<PublicTxMetrics>) {
+    if (!this.txMetrics.has(txLabel)) {
+      this.txMetrics.set(txLabel, EMPTY_TX_METRICS);
+    }
+    const txMetrics = this.txMetrics.get(txLabel)!;
+    for (const [key, value] of Object.entries(metrics)) {
+      if (key in txMetrics) {
+        txMetrics[key as keyof PublicTxMetrics] = value as any;
+      }
     }
   }
 
@@ -181,10 +213,22 @@ export class TestExecutorMetrics implements ExecutorMetricsInterface {
         pretty += `${INDENT0}Total instructions executed: ${fmtNum(txMetrics.totalInstructionsExecuted)}\n`;
       }
       if (filter === PublicTxMetricsFilter.DURATIONS || filter === PublicTxMetricsFilter.ALL) {
-        pretty += `${INDENT0}Tx hash computation: ${fmtNum(txMetrics.txHashMs!, 'ms')}\n`;
         pretty += `${INDENT0}Private insertions:\n`;
         pretty += `${INDENT1}Non-revertible: ${fmtNum(txMetrics.nonRevertiblePrivateInsertionsUs! / 1_000, 'ms')}\n`;
         pretty += `${INDENT1}Revertible: ${fmtNum(txMetrics.revertiblePrivateInsertionsUs! / 1_000, 'ms')}\n`;
+      }
+      if (filter === PublicTxMetricsFilter.PROVING || filter === PublicTxMetricsFilter.ALL) {
+        pretty += `${INDENT0}Proving:\n`;
+        pretty += `${INDENT1}Simulation: ${fmtNum(txMetrics.proverSimulationStepMs!, 'ms')}\n`;
+        pretty += `${INDENT1}Proving: ${fmtNum(txMetrics.proverProvingStepMs!, 'ms')}\n`;
+        pretty += `${INDENT1}Trace generation: ${fmtNum(txMetrics.proverTraceGenerationStepMs!, 'ms')}\n`;
+        pretty += `${INDENT1}Trace generation interactions: ${fmtNum(txMetrics.traceGenerationInteractionsMs!, 'ms')}\n`;
+        pretty += `${INDENT1}Trace generation traces: ${fmtNum(txMetrics.traceGenerationTracesMs!, 'ms')}\n`;
+        pretty += `${INDENT1}Sumcheck: ${fmtNum(txMetrics.provingSumcheckMs!, 'ms')}\n`;
+        pretty += `${INDENT1}PCS: ${fmtNum(txMetrics.provingPcsMs!, 'ms')}\n`;
+        pretty += `${INDENT1}Log derivative inverse: ${fmtNum(txMetrics.provingLogDerivativeInverseMs!, 'ms')}\n`;
+        pretty += `${INDENT1}Log derivative inverse commitments: ${fmtNum(txMetrics.provingLogDerivativeInverseCommitmentsMs!, 'ms')}\n`;
+        pretty += `${INDENT1}Wire commitments: ${fmtNum(txMetrics.provingWireCommitmentsMs!, 'ms')}\n`;
       }
       if (filter !== PublicTxMetricsFilter.TOTALS) {
         // totals exclude enqueued calls
@@ -227,43 +271,103 @@ export class TestExecutorMetrics implements ExecutorMetricsInterface {
   }
 
   toGithubActionBenchmarkJSON(indent = 2) {
+    const metricsInfo = {
+      totalInstructionsExecuted: {
+        name: 'totalInstructionsExecuted',
+        unit: '#instructions',
+        category: PublicTxMetricsFilter.INSTRUCTIONS,
+      },
+      totalDurationMs: {
+        name: 'totalDurationMs',
+        unit: 'ms',
+        category: PublicTxMetricsFilter.DURATIONS,
+      },
+      manaUsed: {
+        name: 'manaUsed',
+        unit: 'mana',
+        category: PublicTxMetricsFilter.TOTALS,
+      },
+      nonRevertiblePrivateInsertionsUs: {
+        name: 'nonRevertiblePrivateInsertionsUs',
+        unit: 'us',
+        category: PublicTxMetricsFilter.DURATIONS,
+      },
+      revertiblePrivateInsertionsUs: {
+        name: 'revertiblePrivateInsertionsUs',
+        unit: 'us',
+        category: PublicTxMetricsFilter.DURATIONS,
+      },
+      proverSimulationStepMs: {
+        name: 'proverSimulationStepMs',
+        unit: 'ms',
+        category: PublicTxMetricsFilter.PROVING,
+      },
+      proverProvingStepMs: {
+        name: 'proverProvingStepMs',
+        unit: 'ms',
+        category: PublicTxMetricsFilter.PROVING,
+      },
+      proverTraceGenerationStepMs: {
+        name: 'proverTraceGenerationStepMs',
+        unit: 'ms',
+        category: PublicTxMetricsFilter.PROVING,
+      },
+      traceGenerationInteractionsMs: {
+        name: 'traceGenerationInteractionsMs',
+        unit: 'ms',
+        category: PublicTxMetricsFilter.PROVING,
+      },
+      traceGenerationTracesMs: {
+        name: 'traceGenerationTracesMs',
+        unit: 'ms',
+        category: PublicTxMetricsFilter.PROVING,
+      },
+      provingSumcheckMs: {
+        name: 'provingSumcheckMs',
+        unit: 'ms',
+        category: PublicTxMetricsFilter.PROVING,
+      },
+      provingPcsMs: {
+        name: 'provingPcsMs',
+        unit: 'ms',
+        category: PublicTxMetricsFilter.PROVING,
+      },
+      provingLogDerivativeInverseMs: {
+        name: 'provingLogDerivativeInverseMs',
+        unit: 'ms',
+        category: PublicTxMetricsFilter.PROVING,
+      },
+      provingLogDerivativeInverseCommitmentsMs: {
+        name: 'provingLogDerivativeInverseCommitmentsMs',
+        unit: 'ms',
+        category: PublicTxMetricsFilter.PROVING,
+      },
+      provingWireCommitmentsMs: {
+        name: 'provingWireCommitmentsMs',
+        unit: 'ms',
+        category: PublicTxMetricsFilter.PROVING,
+      },
+    };
+
     const data = [];
     for (const [txLabel, txMetrics] of this.txMetrics.entries()) {
-      data.push({
-        name: `${txLabel}/totalInstructionsExecuted`,
-        value: txMetrics.totalInstructionsExecuted,
-        unit: '#instructions',
-      });
-      data.push({
-        name: `${txLabel}/totalDurationMs`,
-        value: txMetrics.totalDurationMs,
-        unit: 'ms',
-      });
-      data.push({
-        name: `${txLabel}/manaUsed`,
-        value: txMetrics.manaUsed,
-        unit: 'mana',
-      });
-      data.push({
-        name: `${txLabel}/txHashMs`,
-        value: txMetrics.txHashMs,
-        unit: 'ms',
-      });
-      data.push({
-        name: `${txLabel}/nonRevertiblePrivateInsertionsUs`,
-        value: txMetrics.nonRevertiblePrivateInsertionsUs,
-        unit: 'us',
-      });
-      data.push({
-        name: `${txLabel}/revertiblePrivateInsertionsUs`,
-        value: txMetrics.revertiblePrivateInsertionsUs,
-        unit: 'us',
-      });
+      for (const [key, value] of Object.entries(txMetrics)) {
+        if (value !== undefined && key in metricsInfo) {
+          data.push({
+            name: `${txLabel}/${metricsInfo[key as keyof typeof metricsInfo].name}`,
+            value: value,
+            unit: metricsInfo[key as keyof typeof metricsInfo].unit,
+          });
+        }
+      }
     }
     return JSON.stringify(data, null, indent);
   }
 }
 
 function fmtNum(num: number, unit?: string) {
+  if (num === undefined) {
+    return 'undefined';
+  }
   return `\`${num.toLocaleString()}${unit ? ` ${unit}` : ''}\``;
 }


### PR DESCRIPTION
* Modified AvmProvingTester to be able to set some metrics. They are parsed from the BB stdout.
* Modified avm bulk test to output the metrics. The metrics will be just outputted in text mode when running the testing version of the test.
* Added a new bench to bootstrap, this will re-run the test and output the metrics in JSON format.

Also removes `txHashMs` since it's always 0 now.

```
[
  {
    "name": "bulk_test/0/totalDurationMs",
    "value": 559.5237900000011,
    "unit": "ms"
  },
  {
    "name": "bulk_test/0/manaUsed",
    "value": 450025,
    "unit": "mana"
  },
  {
    "name": "bulk_test/0/totalInstructionsExecuted",
    "value": 25937,
    "unit": "#instructions"
  },
  {
    "name": "bulk_test/0/nonRevertiblePrivateInsertionsUs",
    "value": 15210.878999999295,
    "unit": "us"
  },
  {
    "name": "bulk_test/0/revertiblePrivateInsertionsUs",
    "value": 18985.63700000068,
    "unit": "us"
  },
  {
    "name": "bulk_test/0/proverSimulationStepMs",
    "value": 198,
    "unit": "ms"
  },
  {
    "name": "bulk_test/0/proverProvingStepMs",
    "value": 23457,
    "unit": "ms"
  },
  {
    "name": "bulk_test/0/proverTraceGenerationStepMs",
    "value": 2982,
    "unit": "ms"
  },
  {
    "name": "bulk_test/0/traceGenerationInteractionsMs",
    "value": 752,
    "unit": "ms"
  },
  {
    "name": "bulk_test/0/traceGenerationTracesMs",
    "value": 2213,
    "unit": "ms"
  },
  {
    "name": "bulk_test/0/provingSumcheckMs",
    "value": 5432,
    "unit": "ms"
  },
  {
    "name": "bulk_test/0/provingPcsMs",
    "value": 3711,
    "unit": "ms"
  },
  {
    "name": "bulk_test/0/provingLogDerivativeInverseMs",
    "value": 471,
    "unit": "ms"
  },
  {
    "name": "bulk_test/0/provingLogDerivativeInverseCommitmentsMs",
    "value": 3136,
    "unit": "ms"
  },
  {
    "name": "bulk_test/0/provingWireCommitmentsMs",
    "value": 7981,
    "unit": "ms"
  }
]
```