### PR TITLE
chore: prohibiting compilation warnings in `noir-projects/noir-contracts`

### DIFF
--- a/noir-projects/noir-contracts/bootstrap.sh
+++ b/noir-projects/noir-contracts/bootstrap.sh
@@ -148,15 +148,12 @@ function compile {
   local json_path="./target/$filename"
   contract_hash=$(get_contract_hash $1)
   if ! cache_download contract-$contract_hash.tar.gz; then
-    if [ "${VERBOSE:-0}" -eq 0 ]; then
-      local args="--silence-warnings"
-    fi
-    $NARGO compile ${args:-} --package $contract --inliner-aggressiveness 0 --pedantic-solving
+    $NARGO compile --package $contract --inliner-aggressiveness 0 --pedantic-solving --deny-warnings
     $TRANSPILER $json_path $json_path
     cache_upload contract-$contract_hash.tar.gz $json_path
   fi
 
-  # We segregate equivalent vk's created by processs_function. This was done to narrow down potential edge cases with identical VKs
+  # We segregate equivalent vk's created by process_function. This was done to narrow down potential edge cases with identical VKs
   # reading from cache at the same time. Create this folder up-front.
   mkdir -p $tmp_dir/$contract_hash
 

--- a/noir-projects/noir-contracts/contracts/docs/docs_example_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/docs/docs_example_contract/src/main.nr
@@ -189,7 +189,8 @@ pub contract DocsExample {
         let mut context = PrivateContext::new(inputs, args_hasher.hash());
         // docs:end:context-example-context
         // docs:start:storage-example-context
-        let mut storage = Storage::init(&mut context);
+        // The following is prefixed with an underscore just to avoid a warning about unused variable.
+        let mut _storage = Storage::init(&mut context);
         // docs:end:storage-example-context
         // ************************************************************
         // Our actual program

--- a/noir-projects/noir-protocol-circuits/bootstrap.sh
+++ b/noir-projects/noir-protocol-circuits/bootstrap.sh
@@ -55,7 +55,7 @@ function compile {
     SECONDS=0
     rm -f $json_path
     # TODO(#10754): Remove --skip-brillig-constraints-check
-    local compile_cmd="$NARGO compile --package $name --skip-brillig-constraints-check --deny-warnings"
+    local compile_cmd="$NARGO compile --package $name --skip-brillig-constraints-check"
     echo_stderr "$compile_cmd"
     dump_fail "$compile_cmd"
     echo_stderr "Compilation complete for: $name (${SECONDS}s)"

--- a/noir-projects/noir-protocol-circuits/bootstrap.sh
+++ b/noir-projects/noir-protocol-circuits/bootstrap.sh
@@ -55,7 +55,7 @@ function compile {
     SECONDS=0
     rm -f $json_path
     # TODO(#10754): Remove --skip-brillig-constraints-check
-    local compile_cmd="$NARGO compile --package $name --skip-brillig-constraints-check"
+    local compile_cmd="$NARGO compile --package $name --skip-brillig-constraints-check --deny-warnings"
     echo_stderr "$compile_cmd"
     dump_fail "$compile_cmd"
     echo_stderr "Compilation complete for: $name (${SECONDS}s)"

--- a/noir-projects/noir-protocol-circuits/crates/ts-types/src/main.nr
+++ b/noir-projects/noir-protocol-circuits/crates/ts-types/src/main.nr
@@ -19,20 +19,18 @@ use dep::types::{
 // This is a temporary workaround to make the noir codegen generate the ts type definitions for the following structs.
 // Remove this file once this issue is fixed: https://github.com/noir-lang/noir/issues/9026
 fn main(
-    note_hash: NoteHash,
-    scoped_note_hash: ScopedNoteHash,
-    nullifier: Nullifier,
-    scoped_nullifier: ScopedNullifier,
-    private_log_data: PrivateLogData,
-    log_hash: LogHash,
-    private_call_request: PrivateCallRequest,
-    public_call_request: PublicCallRequest,
-    read_request: ReadRequest,
-    scoped_read_request: ScopedReadRequest,
-    key_validation_request: KeyValidationRequestAndGenerator,
-    scoped_key_validation_request: ScopedKeyValidationRequestAndGenerator,
-    l2_to_l1_message: L2ToL1Message,
-    counted: Counted<u32>,
-) -> pub u32 {
-    0
-}
+    _note_hash: NoteHash,
+    _scoped_note_hash: ScopedNoteHash,
+    _nullifier: Nullifier,
+    _scoped_nullifier: ScopedNullifier,
+    _private_log_data: PrivateLogData,
+    _log_hash: LogHash,
+    _private_call_request: PrivateCallRequest,
+    _public_call_request: PublicCallRequest,
+    _read_request: ReadRequest,
+    _scoped_read_request: ScopedReadRequest,
+    _key_validation_request: KeyValidationRequestAndGenerator,
+    _scoped_key_validation_request: ScopedKeyValidationRequestAndGenerator,
+    _l2_to_l1_message: L2ToL1Message,
+    _counted: Counted<u32>,
+) {}


### PR DESCRIPTION
With all the Noir compilation warnings now being fixed in `noir-projects` I am prohibiting warnings to ensure that warnings will not sneak back in.

**Update**: Unfortunately got the CI to pass only because the protocol circuits were obtained from cache. When building it without cache I got warnings described in [this issue](https://github.com/noir-lang/noir/issues/9359). Since that noir issue will take a while to tackle I will still allow warnings in protocol circuits and merge this PR now.