### PR TITLE
test: restore testenv tests and add some more

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
@@ -13,6 +13,8 @@ use crate::{
     test::helpers::{txe_oracles, utils::ContractDeployment},
 };
 
+mod test;
+
 struct Counter {
     next_value: Field,
 }

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment/test.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment/test.nr
@@ -117,6 +117,35 @@ unconstrained fn mine_block_does_not_advance_the_timestamp() {
 }
 
 #[test]
+unconstrained fn mine_block_at_mines_a_block() {
+    let env = TestEnvironment::_new();
+
+    let next_block_number_before = env.next_block_number();
+    env.mine_block_at(env.last_block_timestamp() + 1);
+    let next_block_number_after = env.next_block_number();
+
+    assert_eq(next_block_number_after, next_block_number_before + 1);
+}
+
+#[test]
+unconstrained fn mine_block_at_sets_the_block_timestamp() {
+    let env = TestEnvironment::_new();
+
+    let expected_block_timestamp = env.last_block_timestamp() + 3600 * 24 * 30; // Advance a month
+    env.mine_block_at(expected_block_timestamp);
+
+    assert_eq(env.last_block_timestamp(), expected_block_timestamp);
+}
+
+#[test(should_fail_with = "Cannot go back in time")]
+unconstrained fn mine_block_at_fails_with_past_timestamps() {
+    let env = TestEnvironment::_new();
+
+    let expected_block_timestamp = env.last_block_timestamp() - 1;
+    env.mine_block_at(expected_block_timestamp);
+}
+
+#[test]
 unconstrained fn public_context_uses_next_block_number() {
     let env = TestEnvironment::_new();
 


### PR DESCRIPTION
This restores the testenv tests accidentally deleted in https://github.com/AztecProtocol/aztec-packages/pull/16061, and adds some `mine_block_at` tests, which we lacked.