### PR TITLE
fix: Updated req/resp timeouts

### DIFF
--- a/yarn-project/p2p/src/services/reqresp/config.ts
+++ b/yarn-project/p2p/src/services/reqresp/config.ts
@@ -1,7 +1,7 @@
 import { type ConfigMapping, booleanConfigHelper, numberConfigHelper } from '@aztec/foundation/config';
 
 export const DEFAULT_INDIVIDUAL_REQUEST_TIMEOUT_MS = 10_000;
-export const DEFAULT_OVERALL_REQUEST_TIMEOUT_MS = 20_000;
+export const DEFAULT_OVERALL_REQUEST_TIMEOUT_MS = 10_000; // Not currently used
 export const DEFAULT_REQRESP_DIAL_TIMEOUT_MS = 5_000;
 export const DEFAULT_OPTIMISTIC_NEGOTIATION = false;
 

--- a/yarn-project/p2p/src/services/reqresp/config.ts
+++ b/yarn-project/p2p/src/services/reqresp/config.ts
@@ -1,8 +1,8 @@
 import { type ConfigMapping, booleanConfigHelper, numberConfigHelper } from '@aztec/foundation/config';
 
-export const DEFAULT_INDIVIDUAL_REQUEST_TIMEOUT_MS = 2000;
-export const DEFAULT_OVERALL_REQUEST_TIMEOUT_MS = 4000;
-export const DEFAULT_REQRESP_DIAL_TIMEOUT_MS = 1000;
+export const DEFAULT_INDIVIDUAL_REQUEST_TIMEOUT_MS = 10_000;
+export const DEFAULT_OVERALL_REQUEST_TIMEOUT_MS = 20_000;
+export const DEFAULT_REQRESP_DIAL_TIMEOUT_MS = 5_000;
 export const DEFAULT_OPTIMISTIC_NEGOTIATION = false;
 
 // For use in tests.

--- a/yarn-project/p2p/src/services/reqresp/reqresp.ts
+++ b/yarn-project/p2p/src/services/reqresp/reqresp.ts
@@ -62,7 +62,6 @@ import { ReqRespStatus, ReqRespStatusError, parseStatusChunk, prettyPrintReqResp
  * see: https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/p2p-interface.md#the-reqresp-domain
  */
 export class ReqResp implements ReqRespInterface {
-  private overallRequestTimeoutMs: number = DEFAULT_OVERALL_REQUEST_TIMEOUT_MS;
   private individualRequestTimeoutMs: number = DEFAULT_INDIVIDUAL_REQUEST_TIMEOUT_MS;
   private dialTimeoutMs: number = DEFAULT_REQRESP_DIAL_TIMEOUT_MS;
 
@@ -102,10 +101,6 @@ export class ReqResp implements ReqRespInterface {
   }
 
   public updateConfig(config: Partial<P2PReqRespConfig>): void {
-    if (typeof config.overallRequestTimeoutMs === 'number') {
-      this.overallRequestTimeoutMs = config.overallRequestTimeoutMs;
-    }
-
     if (typeof config.individualRequestTimeoutMs === 'number') {
       this.individualRequestTimeoutMs = config.individualRequestTimeoutMs;
     }

--- a/yarn-project/p2p/src/services/reqresp/reqresp.ts
+++ b/yarn-project/p2p/src/services/reqresp/reqresp.ts
@@ -20,7 +20,6 @@ import { SnappyTransform } from '../encoding.js';
 import type { PeerScoring } from '../peer-manager/peer_scoring.js';
 import {
   DEFAULT_INDIVIDUAL_REQUEST_TIMEOUT_MS,
-  DEFAULT_OVERALL_REQUEST_TIMEOUT_MS,
   DEFAULT_REQRESP_DIAL_TIMEOUT_MS,
   type P2PReqRespConfig,
 } from './config.js';


### PR DESCRIPTION
This PR updates the default req/resp timeouts to be more in line with Ethereum's values and increase the likelihood of hadshakes successes.
