### PR TITLE
feat: specialised ZeroSelector to save memory on selectors known to be zero

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -44,11 +44,11 @@
       ],
     },
     {
-      "name": "Debug Commitment Schemes Tests",
+      "name": "Debug test_graph_for_arithmetic_gates",
       "type": "lldb",
       "request": "launch",
-      "program": "${workspaceFolder}/barretenberg/cpp/build-debug/bin/commitment_schemes_tests",
-      "args": [],
+      "program": "${workspaceFolder}/barretenberg/cpp/build-debug-no-avm/bin/boomerang_value_detection_tests",
+      "args": ["--gtest_filter=BoomerangGoblinRecursiveVerifierTests.graph_description_basic"],
       "initCommands": [
         "command script import ${workspaceFolder}/barretenberg/cpp/scripts/lldb_format.py"
       ],
@@ -57,9 +57,9 @@
       "name": "Debug BB API Test",
       "type": "lldb",
       "request": "launch",
-      "program": "${workspaceFolder}/barretenberg/cpp/build-debug/bin/api_tests",
+      "program": "${workspaceFolder}/barretenberg/cpp/build-debug-no-avm/bin/api_tests",
       "args": ["--gtest_filter=ClientIVCAPITests.ProveAndVerifyFileBasedFlow"],
-      "cwd": "${workspaceFolder}/barretenberg/cpp/build-debug",
+      "cwd": "${workspaceFolder}/barretenberg/cpp/build-debug-no-avm",
       "initCommands": [
         "command script import ${workspaceFolder}/barretenberg/cpp/scripts/lldb_format.py"
       ],

--- a/barretenberg/cpp/src/barretenberg/honk/execution_trace/execution_trace_block.hpp
+++ b/barretenberg/cpp/src/barretenberg/honk/execution_trace/execution_trace_block.hpp
@@ -8,6 +8,8 @@
 #include "barretenberg/common/assert.hpp"
 #include "barretenberg/common/mem.hpp"
 #include "barretenberg/common/ref_array.hpp"
+#include "barretenberg/common/ref_vector.hpp"
+#include "barretenberg/common/serialize.hpp"
 #include "barretenberg/common/slab_allocator.hpp"
 #include "barretenberg/common/throw_or_abort.hpp"
 #include <cstddef>
@@ -36,21 +38,203 @@ struct StackTraces {
 #endif
 
 /**
+ * @brief Abstract interface for a generic selector.
+ * @details A selector holds field elements that represent gate enable signals in circuit constraints.
+ *          This interface defines basic operations required for concrete selector implementations.
+ *
+ * @tparam FF The finite field element type.
+ */
+template <typename FF> class Selector {
+  public:
+    Selector() = default;
+    virtual ~Selector() = default;
+
+    // Delete copy/move to avoid object slicing and unintended behavior
+    Selector(const Selector&) = default;
+    Selector& operator=(const Selector&) = default;
+    Selector(Selector&&) = delete;
+    Selector& operator=(Selector&&) = delete;
+
+    /**
+     * @brief Append a field element to the selector.
+     * @param value Field element to append.
+     */
+    void emplace_back(const FF& value) { push_back(value); }
+
+    /**
+     * @brief Append an integer value to the selector.
+     * @param value Must be convertible to FF.
+     */
+    virtual void emplace_back(int value) = 0;
+
+    /**
+     * @brief Push a field element to the selector.
+     * @param value Field element to add.
+     */
+    virtual void push_back(const FF& value) = 0;
+
+    /**
+     * @brief Resize the selector.
+     * @param new_size The new size.
+     */
+    virtual void resize(size_t new_size) = 0;
+
+    /**
+     * @brief Get value at specified index.
+     * @param index Index of the element.
+     * @return Reference to the field element at index.
+     */
+    virtual const FF& operator[](size_t index) const = 0;
+
+    /**
+     * @brief Get the last value in the selector.
+     * @return Reference to the last field element.
+     */
+    virtual const FF& back() const = 0;
+
+    /**
+     * @brief Get the number of elements.
+     */
+    virtual size_t size() const = 0;
+
+    /**
+     * @brief Check if the selector is empty.
+     */
+    virtual bool empty() const = 0;
+
+    /**
+     * @brief Set the value at index using integer.
+     * @param idx Index.
+     * @param value Integer value.
+     */
+    virtual void set(size_t idx, int value) = 0;
+
+    /**
+     * @brief Set the last value using integer.
+     * @param value Integer value.
+     */
+    virtual void set_back(int value) = 0;
+
+    /**
+     * @brief Set the value at index using a field element.
+     * @param idx Index.
+     * @param value Field element.
+     */
+    virtual void set(size_t idx, const FF& value) = 0;
+};
+
+/**
+ * @brief Selector specialization that only allows zeros.
+ * @details Efficient representation for selectors that are guaranteed to be zero everywhere.
+ *
+ * @tparam FF The finite field element type.
+ */
+template <typename FF> class ZeroSelector : public Selector<FF> {
+  public:
+    using Selector<FF>::emplace_back;
+
+    void emplace_back(int value) override
+    {
+        BB_ASSERT_EQ(value, 0, "Calling ZeroSelector::emplace_back with a non zero value.");
+        size_++;
+    }
+
+    void push_back(const FF& value) override
+    {
+        ASSERT(value.is_zero());
+        size_++;
+    }
+
+    void set_back(int value) override
+    {
+        BB_ASSERT_EQ(value, 0, "Calling ZeroSelector::set_back with a non zero value.");
+        BB_ASSERT_GT(size_, 0U);
+    }
+
+    void set(size_t idx, int value) override
+    {
+        BB_ASSERT_LT(idx, size_);
+        BB_ASSERT_EQ(value, 0, "Calling ZeroSelector::set with a non zero value.");
+    }
+
+    void set(size_t idx, const FF& value) override
+    {
+        BB_ASSERT_LT(idx, size_);
+        ASSERT(value.is_zero());
+        size_++;
+    }
+
+    void resize(size_t new_size) override { size_ = new_size; }
+
+    bool operator==(const ZeroSelector& other) const { return size_ == other.size(); }
+
+    const FF& operator[](size_t index) const override
+    {
+        BB_ASSERT_LT(index, size_);
+        return zero;
+    }
+
+    const FF& back() const override { return zero; }
+
+    size_t size() const override { return size_; }
+
+    bool empty() const override { return size_ == 0; }
+
+  private:
+    static constexpr FF zero = 0;
+    size_t size_ = 0;
+};
+
+/**
+ * @brief Selector backed by a slab allocator vector.
+ * @details Allows dynamic values with fast memory allocation from slabs.
+ *
+ * @tparam FF The finite field element type.
+ */
+template <typename FF> class SlabVectorSelector : public Selector<FF> {
+  public:
+    using Selector<FF>::emplace_back;
+
+    void emplace_back(int i) override { data.emplace_back(i); }
+    void push_back(const FF& value) override { data.push_back(value); }
+    void set_back(int value) override { data.back() = value; }
+    void set(size_t idx, int i) override { data[idx] = i; }
+    void set(size_t idx, const FF& value) override { data[idx] = value; }
+    void resize(size_t new_size) override { data.resize(new_size); }
+
+    bool operator==(const SlabVectorSelector& other) const { return data == other.data; }
+
+    const FF& operator[](size_t i) const override { return data[i]; }
+    const FF& back() const override { return data.back(); }
+
+    size_t size() const override { return data.size(); }
+    bool empty() const override { return data.empty(); }
+
+  private:
+    SlabVector<FF> data;
+};
+
+/**
  * @brief Basic structure for storing gate data in a builder
  *
  * @tparam FF
  * @tparam NUM_WIRES
- * @tparam NUM_SELECTORS
  */
-template <typename FF, size_t NUM_WIRES_, size_t NUM_SELECTORS_> class ExecutionTraceBlock {
+template <typename FF, size_t NUM_WIRES_> class ExecutionTraceBlock {
   public:
     static constexpr size_t NUM_WIRES = NUM_WIRES_;
-    static constexpr size_t NUM_SELECTORS = NUM_SELECTORS_;
 
-    using SelectorType = SlabVector<FF>;
+    using SelectorType = Selector<FF>;
     using WireType = SlabVector<uint32_t>;
-    using Selectors = std::array<SelectorType, NUM_SELECTORS>;
     using Wires = std::array<WireType, NUM_WIRES>;
+
+    ExecutionTraceBlock() = default;
+    ExecutionTraceBlock(const ExecutionTraceBlock&) = default;
+    ExecutionTraceBlock& operator=(const ExecutionTraceBlock&) = default;
+    ExecutionTraceBlock(ExecutionTraceBlock&&) noexcept = default;
+    ExecutionTraceBlock& operator=(ExecutionTraceBlock&&) noexcept = default;
+
+    virtual ~ExecutionTraceBlock() = default;
 
 #ifdef CHECK_CIRCUIT_STACKTRACES
     // If enabled, we keep slow stack traces to be able to correlate gates with code locations where they were added
@@ -69,8 +253,7 @@ template <typename FF, size_t NUM_WIRES_, size_t NUM_SELECTORS_> class Execution
 #endif
     }
 
-    Wires wires; // vectors of indices into a witness variables array
-    Selectors selectors;
+    Wires wires;                                                   // vectors of indices into a witness variables array
     uint32_t trace_offset_ = std::numeric_limits<uint32_t>::max(); // where this block starts in the trace
 
     uint32_t trace_offset() const
@@ -88,7 +271,7 @@ template <typename FF, size_t NUM_WIRES_, size_t NUM_SELECTORS_> class Execution
         for (auto& w : wires) {
             w.reserve(size_hint);
         }
-        for (auto& p : selectors) {
+        for (auto& p : get_selectors()) {
             p.reserve(size_hint);
         }
 #ifdef CHECK_CIRCUIT_STACKTRACES
@@ -114,6 +297,35 @@ template <typename FF, size_t NUM_WIRES_, size_t NUM_SELECTORS_> class Execution
     }
 #endif
     uint32_t fixed_size = 0; // Fixed size for use in structured trace
+
+    virtual RefVector<Selector<FF>> get_selectors() = 0;
+
+    void populate_wires(const uint32_t& idx_1, const uint32_t& idx_2, const uint32_t& idx_3, const uint32_t& idx_4)
+    {
+#ifdef CHECK_CIRCUIT_STACKTRACES
+        this->stack_traces.populate();
+#endif
+        this->tracy_gate();
+        this->wires[0].emplace_back(idx_1);
+        this->wires[1].emplace_back(idx_2);
+        this->wires[2].emplace_back(idx_3);
+        this->wires[3].emplace_back(idx_4);
+    }
+
+    auto& w_l() { return std::get<0>(this->wires); };
+    auto& w_r() { return std::get<1>(this->wires); };
+    auto& w_o() { return std::get<2>(this->wires); };
+    auto& w_4() { return std::get<3>(this->wires); };
+
+    Selector<FF>& q_m() { return non_gate_selectors[0]; };
+    Selector<FF>& q_c() { return non_gate_selectors[1]; };
+    Selector<FF>& q_1() { return non_gate_selectors[2]; };
+    Selector<FF>& q_2() { return non_gate_selectors[3]; };
+    Selector<FF>& q_3() { return non_gate_selectors[4]; };
+    Selector<FF>& q_4() { return non_gate_selectors[5]; };
+
+  protected:
+    std::array<SlabVectorSelector<FF>, 6> non_gate_selectors;
 };
 
 } // namespace bb

--- a/barretenberg/cpp/src/barretenberg/honk/execution_trace/execution_trace_usage_tracker.hpp
+++ b/barretenberg/cpp/src/barretenberg/honk/execution_trace/execution_trace_usage_tracker.hpp
@@ -22,7 +22,6 @@ namespace bb {
 struct ExecutionTraceUsageTracker {
     using Range = std::pair<size_t, size_t>;
     using Builder = MegaCircuitBuilder;
-    using MegaTraceActiveRanges = MegaTraceBlockData<Range>;
     using MegaTraceFixedBlockSizes = MegaExecutionTraceBlocks;
 
     TraceStructure max_sizes;             // max utilization of each block

--- a/barretenberg/cpp/src/barretenberg/honk/execution_trace/mega_execution_trace.hpp
+++ b/barretenberg/cpp/src/barretenberg/honk/execution_trace/mega_execution_trace.hpp
@@ -216,17 +216,18 @@ class MegaTracePoseidon2InternalBlock : public MegaTraceBlock {
 
 class MegaTraceOverflowBlock : public MegaTraceBlock {
   public:
-    SelectorType& q_lookup_type() override { return gate_selectors[0]; };
-    SelectorType& q_arith() override { return gate_selectors[1]; }
-    SelectorType& q_delta_range() override { return gate_selectors[2]; }
-    SelectorType& q_elliptic() override { return gate_selectors[3]; }
-    SelectorType& q_memory() override { return gate_selectors[4]; }
-    SelectorType& q_nnf() override { return gate_selectors[5]; }
-    SelectorType& q_poseidon2_external() override { return gate_selectors[6]; }
-    SelectorType& q_poseidon2_internal() override { return gate_selectors[7]; }
+    SelectorType& q_busread() override { return gate_selectors[0]; };
+    SelectorType& q_lookup_type() override { return gate_selectors[1]; };
+    SelectorType& q_arith() override { return gate_selectors[2]; }
+    SelectorType& q_delta_range() override { return gate_selectors[3]; }
+    SelectorType& q_elliptic() override { return gate_selectors[4]; }
+    SelectorType& q_memory() override { return gate_selectors[5]; }
+    SelectorType& q_nnf() override { return gate_selectors[6]; }
+    SelectorType& q_poseidon2_external() override { return gate_selectors[7]; }
+    SelectorType& q_poseidon2_internal() override { return gate_selectors[8]; }
 
   private:
-    std::array<SlabVectorSelector<fr>, 8> gate_selectors;
+    std::array<SlabVectorSelector<fr>, 9> gate_selectors;
 };
 
 /**

--- a/barretenberg/cpp/src/barretenberg/honk/execution_trace/mega_execution_trace.hpp
+++ b/barretenberg/cpp/src/barretenberg/honk/execution_trace/mega_execution_trace.hpp
@@ -12,35 +12,23 @@
 #include "barretenberg/flavor/flavor_concepts.hpp"
 #include "barretenberg/honk/execution_trace/execution_trace_block.hpp"
 #include "barretenberg/numeric/bitop/get_msb.hpp"
+#include <cstdint>
 
 namespace bb {
 
-/**
- * @brief A container indexed by the types of the blocks in the execution trace.
- *
- * @details We instantiate this both to contain the actual gates of an execution trace, and also to describe different
- * trace structures (i.e., sets of capacities for each block type, which we use to optimize the folding prover).
- * Note: the ecc_op block has to be the first in the execution trace to not break the Goblin functionality.
- */
-template <typename T> struct MegaTraceBlockData {
-    T ecc_op;
-    T busread;
-    T lookup;
-    T pub_inputs;
-    T arithmetic;
-    T delta_range;
-    T elliptic;
-    T memory;
-    T nnf;
-    T poseidon2_external;
-    T poseidon2_internal;
-    T overflow; // block gates of arbitrary type that overflow their designated block
-
-    std::vector<std::string_view> get_labels() const
-    {
-        return { "ecc_op",   "busread", "lookup", "pub_inputs",         "arithmetic",         "delta_range",
-                 "elliptic", "memory",  "nnf",    "poseidon2_external", "poseidon2_internal", "overflow" };
-    }
+struct TraceStructure {
+    uint32_t ecc_op;
+    uint32_t busread;
+    uint32_t lookup;
+    uint32_t pub_inputs;
+    uint32_t arithmetic;
+    uint32_t delta_range;
+    uint32_t elliptic;
+    uint32_t memory;
+    uint32_t nnf;
+    uint32_t poseidon2_external;
+    uint32_t poseidon2_internal;
+    uint32_t overflow; // block gates of arbitrary type that overflow their designated block
 
     auto get()
     {
@@ -54,15 +42,7 @@ template <typename T> struct MegaTraceBlockData {
                          elliptic, memory,  nnf,    poseidon2_external, poseidon2_internal, overflow };
     }
 
-    auto get_gate_blocks() const
-    {
-        return RefArray{
-            busread, lookup, arithmetic, delta_range, elliptic, memory, nnf, poseidon2_external, poseidon2_internal,
-        };
-    }
-
     size_t size() const
-        requires std::same_as<T, uint32_t>
     {
         size_t result{ 0 };
         for (const auto& block_size : get()) {
@@ -70,11 +50,7 @@ template <typename T> struct MegaTraceBlockData {
         }
         return static_cast<size_t>(result);
     }
-
-    bool operator==(const MegaTraceBlockData& other) const = default;
 };
-
-using TraceStructure = MegaTraceBlockData<uint32_t>;
 
 struct TraceSettings {
     std::optional<TraceStructure> structure;
@@ -90,42 +66,29 @@ struct TraceSettings {
     size_t dyadic_size() const { return numeric::round_up_power_2(size()); }
 };
 
-class MegaTraceBlock : public ExecutionTraceBlock<fr, /*NUM_WIRES_ */ 4, /*NUM_SELECTORS_*/ 15> {
-    using SelectorType = ExecutionTraceBlock<fr, 4, 15>::SelectorType;
-
+class MegaTraceBlock : public ExecutionTraceBlock<fr, /*NUM_WIRES_ */ 4> {
   public:
-    void populate_wires(const uint32_t& idx_1, const uint32_t& idx_2, const uint32_t& idx_3, const uint32_t& idx_4)
-    {
-#ifdef CHECK_CIRCUIT_STACKTRACES
-        this->stack_traces.populate();
-#endif
-        this->tracy_gate();
-        this->wires[0].emplace_back(idx_1);
-        this->wires[1].emplace_back(idx_2);
-        this->wires[2].emplace_back(idx_3);
-        this->wires[3].emplace_back(idx_4);
-    }
+    using SelectorType = Selector<fr>;
 
-    auto& w_l() { return std::get<0>(this->wires); };
-    auto& w_r() { return std::get<1>(this->wires); };
-    auto& w_o() { return std::get<2>(this->wires); };
-    auto& w_4() { return std::get<3>(this->wires); };
+    virtual SelectorType& q_busread() { return this->zero_selectors[0]; };
+    virtual SelectorType& q_lookup_type() { return this->zero_selectors[1]; };
+    virtual SelectorType& q_arith() { return this->zero_selectors[2]; };
+    virtual SelectorType& q_delta_range() { return this->zero_selectors[3]; };
+    virtual SelectorType& q_elliptic() { return this->zero_selectors[4]; };
+    virtual SelectorType& q_memory() { return this->zero_selectors[5]; };
+    virtual SelectorType& q_nnf() { return this->zero_selectors[6]; };
+    virtual SelectorType& q_poseidon2_external() { return this->zero_selectors[7]; };
+    virtual SelectorType& q_poseidon2_internal() { return this->zero_selectors[8]; };
 
-    auto& q_m() { return this->selectors[0]; };
-    auto& q_c() { return this->selectors[1]; };
-    auto& q_1() { return this->selectors[2]; };
-    auto& q_2() { return this->selectors[3]; };
-    auto& q_3() { return this->selectors[4]; };
-    auto& q_4() { return this->selectors[5]; };
-    auto& q_busread() { return this->selectors[6]; };
-    auto& q_lookup_type() { return this->selectors[7]; };
-    auto& q_arith() { return this->selectors[8]; };
-    auto& q_delta_range() { return this->selectors[9]; };
-    auto& q_elliptic() { return this->selectors[10]; };
-    auto& q_memory() { return this->selectors[11]; };
-    auto& q_nnf() { return this->selectors[12]; };
-    auto& q_poseidon2_external() { return this->selectors[13]; };
-    auto& q_poseidon2_internal() { return this->selectors[14]; };
+    virtual const SelectorType& q_busread() const { return this->zero_selectors[0]; };
+    virtual const SelectorType& q_lookup_type() const { return this->zero_selectors[1]; };
+    virtual const SelectorType& q_arith() const { return this->zero_selectors[2]; };
+    virtual const SelectorType& q_delta_range() const { return this->zero_selectors[3]; };
+    virtual const SelectorType& q_elliptic() const { return this->zero_selectors[4]; };
+    virtual const SelectorType& q_memory() const { return this->zero_selectors[5]; };
+    virtual const SelectorType& q_nnf() const { return this->zero_selectors[6]; };
+    virtual const SelectorType& q_poseidon2_external() const { return this->zero_selectors[7]; };
+    virtual const SelectorType& q_poseidon2_internal() const { return this->zero_selectors[8]; };
 
     RefVector<SelectorType> get_gate_selectors()
     {
@@ -133,6 +96,27 @@ class MegaTraceBlock : public ExecutionTraceBlock<fr, /*NUM_WIRES_ */ 4, /*NUM_S
             q_busread(),     q_lookup_type(),        q_arith(),
             q_delta_range(), q_elliptic(),           q_memory(),
             q_nnf(),         q_poseidon2_external(), q_poseidon2_internal(),
+        };
+    }
+
+    RefVector<Selector<fr>> get_selectors() override
+    {
+        return RefVector{
+            q_m(),
+            q_c(),
+            q_1(),
+            q_2(),
+            q_3(),
+            q_4(),
+            q_busread(),
+            q_lookup_type(),
+            q_arith(),
+            q_delta_range(),
+            q_elliptic(),
+            q_memory(),
+            q_nnf(),
+            q_poseidon2_external(),
+            q_poseidon2_internal(),
         };
     }
 
@@ -151,9 +135,178 @@ class MegaTraceBlock : public ExecutionTraceBlock<fr, /*NUM_WIRES_ */ 4, /*NUM_S
      * @param new_size
      */
     void resize_additional(size_t new_size) { q_busread().resize(new_size); };
+
+  private:
+    std::array<ZeroSelector<fr>, 9> zero_selectors;
 };
 
-class MegaExecutionTraceBlocks : public MegaTraceBlockData<MegaTraceBlock> {
+class MegaTracePublicInputBlock : public MegaTraceBlock {};
+
+class MegaTraceBusReadBlock : public MegaTraceBlock {
+  public:
+    SelectorType& q_busread() override { return gate_selector; }
+
+  private:
+    SlabVectorSelector<fr> gate_selector;
+};
+
+class MegaTraceLookupBlock : public MegaTraceBlock {
+  public:
+    SelectorType& q_lookup_type() override { return gate_selector; }
+
+  private:
+    SlabVectorSelector<fr> gate_selector;
+};
+
+class MegaTraceArithmeticBlock : public MegaTraceBlock {
+  public:
+    SelectorType& q_arith() override { return gate_selector; }
+
+  private:
+    SlabVectorSelector<fr> gate_selector;
+};
+
+class MegaTraceDeltaRangeBlock : public MegaTraceBlock {
+  public:
+    SelectorType& q_delta_range() override { return gate_selector; }
+
+  private:
+    SlabVectorSelector<fr> gate_selector;
+};
+
+class MegaTraceEllipticBlock : public MegaTraceBlock {
+  public:
+    SelectorType& q_elliptic() override { return gate_selector; }
+
+  private:
+    SlabVectorSelector<fr> gate_selector;
+};
+
+class MegaTraceMemoryBlock : public MegaTraceBlock {
+  public:
+    SelectorType& q_memory() override { return gate_selector; }
+
+  private:
+    SlabVectorSelector<fr> gate_selector;
+};
+
+class MegaTraceNonNativeFieldBlock : public MegaTraceBlock {
+  public:
+    SelectorType& q_nnf() override { return gate_selector; }
+
+  private:
+    SlabVectorSelector<fr> gate_selector;
+};
+
+class MegaTracePoseidon2ExternalBlock : public MegaTraceBlock {
+  public:
+    SelectorType& q_poseidon2_external() override { return gate_selector; }
+
+  private:
+    SlabVectorSelector<fr> gate_selector;
+};
+
+class MegaTracePoseidon2InternalBlock : public MegaTraceBlock {
+  public:
+    SelectorType& q_poseidon2_internal() override { return gate_selector; }
+
+  private:
+    SlabVectorSelector<fr> gate_selector;
+};
+
+class MegaTraceOverflowBlock : public MegaTraceBlock {
+  public:
+    SelectorType& q_lookup_type() override { return gate_selectors[0]; };
+    SelectorType& q_arith() override { return gate_selectors[1]; }
+    SelectorType& q_delta_range() override { return gate_selectors[2]; }
+    SelectorType& q_elliptic() override { return gate_selectors[3]; }
+    SelectorType& q_memory() override { return gate_selectors[4]; }
+    SelectorType& q_nnf() override { return gate_selectors[5]; }
+    SelectorType& q_poseidon2_external() override { return gate_selectors[6]; }
+    SelectorType& q_poseidon2_internal() override { return gate_selectors[7]; }
+
+  private:
+    std::array<SlabVectorSelector<fr>, 8> gate_selectors;
+};
+
+/**
+ * @brief A container indexed by the types of the blocks in the execution trace.
+ *
+ * @details We instantiate this both to contain the actual gates of an execution trace, and also to describe different
+ * trace structures (i.e., sets of capacities for each block type, which we use to optimize the folding prover).
+ * Note: the ecc_op block has to be the first in the execution trace to not break the Goblin functionality.
+ */
+struct MegaTraceBlockData {
+    MegaTraceBlock ecc_op;
+    MegaTraceBusReadBlock busread;
+    MegaTraceLookupBlock lookup;
+    MegaTracePublicInputBlock pub_inputs;
+    MegaTraceArithmeticBlock arithmetic;
+    MegaTraceDeltaRangeBlock delta_range;
+    MegaTraceEllipticBlock elliptic;
+    MegaTraceMemoryBlock memory;
+    MegaTraceNonNativeFieldBlock nnf;
+    MegaTracePoseidon2ExternalBlock poseidon2_external;
+    MegaTracePoseidon2InternalBlock poseidon2_internal;
+    MegaTraceOverflowBlock overflow; // block gates of arbitrary type that overflow their designated block
+
+    std::vector<std::string_view> get_labels() const
+    {
+        return { "ecc_op",   "busread", "lookup", "pub_inputs",         "arithmetic",         "delta_range",
+                 "elliptic", "memory",  "nnf",    "poseidon2_external", "poseidon2_internal", "overflow" };
+    }
+
+    auto get()
+    {
+        return RefArray(std::array<MegaTraceBlock*, 12>{ &ecc_op,
+                                                         &busread,
+                                                         &lookup,
+                                                         &pub_inputs,
+                                                         &arithmetic,
+                                                         &delta_range,
+                                                         &elliptic,
+                                                         &memory,
+                                                         &nnf,
+                                                         &poseidon2_external,
+                                                         &poseidon2_internal,
+                                                         &overflow });
+    }
+
+    auto get() const
+    {
+        return RefArray(std::array<const MegaTraceBlock*, 12>{ &ecc_op,
+                                                               &busread,
+                                                               &lookup,
+                                                               &pub_inputs,
+                                                               &arithmetic,
+                                                               &delta_range,
+                                                               &elliptic,
+                                                               &memory,
+                                                               &nnf,
+                                                               &poseidon2_external,
+                                                               &poseidon2_internal,
+                                                               &overflow });
+    }
+
+    auto get_gate_blocks() const
+    {
+        return RefArray(std::array<const MegaTraceBlock*, 9>{
+            &busread,
+            &lookup,
+            &arithmetic,
+            &delta_range,
+            &elliptic,
+            &memory,
+            &nnf,
+            &poseidon2_external,
+            &poseidon2_internal,
+        });
+    }
+
+    bool operator==(const MegaTraceBlockData& other) const = default;
+};
+
+class MegaExecutionTraceBlocks : public MegaTraceBlockData {
   public:
     /**
      * @brief Defines the circuit block types for the Mega arithmetization
@@ -165,7 +318,6 @@ class MegaExecutionTraceBlocks : public MegaTraceBlockData<MegaTraceBlock> {
      */
 
     static constexpr size_t NUM_WIRES = MegaTraceBlock::NUM_WIRES;
-    static constexpr size_t NUM_SELECTORS = MegaTraceBlock::NUM_SELECTORS;
 
     using FF = fr;
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/ultra_verification_keys_comparator.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/ultra_verification_keys_comparator.hpp
@@ -32,9 +32,9 @@ static void compare_ultra_blocks_and_verification_keys(
 
     size_t block_idx = 0;
     for (auto [block_0, block_1] : zip_view(blocks[0].get(), blocks[1].get())) {
-        BB_ASSERT_EQ(block_0.selectors.size(), block_1.selectors.size());
+        BB_ASSERT_EQ(block_0.get_selectors().size(), block_1.get_selectors().size());
         size_t selector_idx = 0;
-        for (auto [p_10, p_11] : zip_view(block_0.selectors, block_1.selectors)) {
+        for (auto [p_10, p_11] : zip_view(block_0.get_selectors(), block_1.get_selectors())) {
             check_eq(p_10, p_11, block_idx, selector_idx);
             selector_idx++;
         }

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/mega_circuit_builder.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/mega_circuit_builder.cpp
@@ -168,12 +168,12 @@ template <typename FF> ecc_op_tuple MegaCircuitBuilder_<FF>::populate_ecc_op_wir
     op_tuple.z_2 = this->add_variable(ultra_op.z_2);
 
     this->blocks.ecc_op.populate_wires(op_tuple.op, op_tuple.x_lo, op_tuple.x_hi, op_tuple.y_lo);
-    for (auto& selector : this->blocks.ecc_op.selectors) {
+    for (auto& selector : this->blocks.ecc_op.get_selectors()) {
         selector.emplace_back(0);
     }
 
     this->blocks.ecc_op.populate_wires(this->zero_idx, op_tuple.y_hi, op_tuple.z_1, op_tuple.z_2);
-    for (auto& selector : this->blocks.ecc_op.selectors) {
+    for (auto& selector : this->blocks.ecc_op.get_selectors()) {
         selector.emplace_back(0);
     }
 

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.hpp
@@ -48,7 +48,6 @@ class UltraCircuitBuilder_ : public CircuitBuilderBase<typename ExecutionTrace_:
     static constexpr size_t NUM_WIRES = ExecutionTrace::NUM_WIRES;
     // Keeping NUM_WIRES, at least temporarily, for backward compatibility
     static constexpr size_t program_width = ExecutionTrace::NUM_WIRES;
-    static constexpr size_t num_selectors = ExecutionTrace::NUM_SELECTORS;
 
     static constexpr std::string_view NAME_STRING = "UltraCircuitBuilder";
     static constexpr CircuitType CIRCUIT_TYPE = CircuitType::ULTRA;
@@ -332,9 +331,10 @@ class UltraCircuitBuilder_ : public CircuitBuilderBase<typename ExecutionTrace_:
         // do nothing
 #else
         for (auto& block : blocks.get()) {
-            size_t nominal_size = block.selectors[0].size();
-            for (size_t idx = 1; idx < block.selectors.size(); ++idx) {
-                ASSERT_DEBUG(block.selectors[idx].size() == nominal_size);
+            const auto& block_selectors = block.get_selectors();
+            size_t nominal_size = block_selectors[0].size();
+            for (size_t idx = 1; idx < block_selectors.size(); ++idx) {
+                ASSERT_DEBUG(block_selectors[idx].size() == nominal_size);
             }
         }
 
@@ -677,7 +677,40 @@ class UltraCircuitBuilder_ : public CircuitBuilderBase<typename ExecutionTrace_:
         const uint32_t variable_index,
         const size_t num_bits,
         std::string const& msg = "decompose_into_default_range_better_for_oddlimbnum");
-    void create_dummy_gate(auto& block, const uint32_t&, const uint32_t&, const uint32_t&, const uint32_t&);
+
+    /**
+     * @brief Create a gate with no constraints but with possibly non-trivial wire values
+     * @details A dummy gate can be used to provide wire values to be accessed via shifts by the gate that proceeds it.
+     * The dummy gate itself does not have to satisfy any constraints (all selectors are zero).
+     *
+     * @tparam ExecutionTrace
+     * @param block Execution trace block into which the dummy gate is to be placed
+     */
+    void create_dummy_gate(
+        auto& block, const uint32_t& idx_1, const uint32_t& idx_2, const uint32_t& idx_3, const uint32_t& idx_4)
+    {
+        block.populate_wires(idx_1, idx_2, idx_3, idx_4);
+        block.q_m().emplace_back(0);
+        block.q_1().emplace_back(0);
+        block.q_2().emplace_back(0);
+        block.q_3().emplace_back(0);
+        block.q_c().emplace_back(0);
+        block.q_arith().emplace_back(0);
+        block.q_4().emplace_back(0);
+        block.q_delta_range().emplace_back(0);
+        block.q_elliptic().emplace_back(0);
+        block.q_lookup_type().emplace_back(0);
+        block.q_memory().emplace_back(0);
+        block.q_nnf().emplace_back(0);
+        block.q_poseidon2_external().emplace_back(0);
+        block.q_poseidon2_internal().emplace_back(0);
+
+        if constexpr (HasAdditionalSelectors<ExecutionTrace>) {
+            block.pad_additional();
+        }
+        check_selector_length_consistency();
+        ++this->num_gates;
+    }
     void create_dummy_constraints(const std::vector<uint32_t>& variable_index);
     void create_sort_constraint(const std::vector<uint32_t>& variable_index);
     void create_sort_constraint_with_edges(const std::vector<uint32_t>& variable_index, const FF&, const FF&);
@@ -765,8 +798,6 @@ class UltraCircuitBuilder_ : public CircuitBuilderBase<typename ExecutionTrace_:
 
     void create_poseidon2_external_gate(const poseidon2_external_gate_<FF>& in);
     void create_poseidon2_internal_gate(const poseidon2_internal_gate_<FF>& in);
-
-    uint256_t hash_circuit() const;
 
     msgpack::sbuffer export_circuit() override;
 };

--- a/barretenberg/cpp/src/barretenberg/trace_to_polynomials/trace_to_polynomials.cpp
+++ b/barretenberg/cpp/src/barretenberg/trace_to_polynomials/trace_to_polynomials.cpp
@@ -50,7 +50,7 @@ std::vector<CyclicPermutation> TraceToPolynomials<Flavor>::populate_wires_and_se
     copy_cycles.resize(builder.get_num_variables()); // at most one copy cycle per variable
 
     RefArray<Polynomial, NUM_WIRES> wires = polynomials.get_wires();
-    RefArray<Polynomial, NUM_SELECTORS> selectors = polynomials.get_selectors();
+    auto selectors = polynomials.get_selectors();
 
     // For each block in the trace, populate wire polys, copy cycles and selector polys
     for (auto& block : builder.blocks.get()) {
@@ -80,10 +80,11 @@ std::vector<CyclicPermutation> TraceToPolynomials<Flavor>::populate_wires_and_se
             }
         }
 
+        RefVector<Selector<FF>> block_selectors = block.get_selectors();
         // Insert the selector values for this block into the selector polynomials at the correct offset
         // TODO(https://github.com/AztecProtocol/barretenberg/issues/398): implicit arithmetization/flavor consistency
-        for (size_t selector_idx = 0; selector_idx < NUM_SELECTORS; selector_idx++) {
-            auto& selector = block.selectors[selector_idx];
+        for (size_t selector_idx = 0; selector_idx < block_selectors.size(); selector_idx++) {
+            auto& selector = block_selectors[selector_idx];
             for (size_t row_idx = 0; row_idx < block_size; ++row_idx) {
                 size_t trace_row_idx = row_idx + offset;
                 selectors[selector_idx].set_if_valid_index(trace_row_idx, selector[row_idx]);

--- a/barretenberg/cpp/src/barretenberg/trace_to_polynomials/trace_to_polynomials.hpp
+++ b/barretenberg/cpp/src/barretenberg/trace_to_polynomials/trace_to_polynomials.hpp
@@ -23,8 +23,6 @@ template <class Flavor> class TraceToPolynomials {
   public:
     static constexpr size_t NUM_WIRES = Builder::NUM_WIRES;
 
-    static constexpr size_t NUM_SELECTORS = Builder::ExecutionTrace::NUM_SELECTORS;
-
     /**
      * @brief Given a circuit, populate a proving key with wire polys, selector polys, and sigma/id polys
      * @note By default, this method constructs an exectution trace that is sorted by gate type. Optionally, it

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/decider_proving_key.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/decider_proving_key.cpp
@@ -311,7 +311,7 @@ void DeciderProvingKey_<Flavor>::move_structured_trace_overflow_to_overflow_bloc
                 }
                 wire.resize(fixed_block_size); // shrink the main block to its max capacity
             }
-            for (auto [selector, overflow_selector] : zip_view(block.selectors, overflow_block.selectors)) {
+            for (auto [selector, overflow_selector] : zip_view(block.get_selectors(), overflow_block.get_selectors())) {
                 for (size_t i = overflow_start; i < overflow_end; ++i) {
                     overflow_selector.push_back(selector[i]);
                 }
@@ -321,7 +321,7 @@ void DeciderProvingKey_<Flavor>::move_structured_trace_overflow_to_overflow_bloc
             // ensures it can be read into by the previous gate but does not itself try to read into the next gate.
             for (auto& selector : block.get_gate_selectors()) {
                 BB_ASSERT_EQ(selector.empty(), false);
-                selector.back() = 0;
+                selector.set_back(0);
             }
         }
     }


### PR DESCRIPTION
This is a reland of https://github.com/AztecProtocol/aztec-packages/pull/16044 with a minor fix https://github.com/AztecProtocol/aztec-packages/pull/16141/commits/7e9b998c7e2ad94f6d6aab7fb161d8766ea6c633.

Original description:

Most ExecutionTraceBlock except the overflow block is restricted to a certain type of gates. The other gate selectors are always zero so we don't need to store them explicitly. Not storing them can save us about 400MB memory.

I felt it was the easiest to represent the selectors that will be zero by a new class of selector ZeroSelector, which is always zero and uses constant memory. This way, the call sites that populate or read the selectors only need minimum change.

Each selector in the block is of an abstract type Selector, and they can be either ZeroSelector or SlabVectorSelector depending on which derived class the blocks belong to.

For the bigger picture, see https://hackmd.io/7wcdcdLtQGy95qg7xMFH9A.

Benchmarks:

Testing the memory limit by running CPUS=16 MEM=Xg ~/aztec-packages/ci3/docker_isolate "BB_SLOW_LOW_MEMORY=1 ./build/bin/ultra_honk_bench --benchmark_filter='construct_proof_ultrahonk_power_of_2/21$'" with gradually smaller X. On this branch, X can be as low as ~1.3, whereas on the merge-train, X can only go as low as ~1.7. This confirms the 400MB memory improvement.