### PR TITLE
chore: libp2p services better start

### DIFF
--- a/yarn-project/p2p/src/client/test/p2p_client.integration_status_handshake.test.ts
+++ b/yarn-project/p2p/src/client/test/p2p_client.integration_status_handshake.test.ts
@@ -109,9 +109,13 @@ describe('p2p client integration status handshake', () => {
   });
 
   it('should disconnect client when it returns status with wrong version', async () => {
+    const TEST_HEARTBEAT_INTERVAL = 2000; // 2 seconds
     clients = (
       await makeTestP2PClients(NUMBER_OF_PEERS, {
-        p2pBaseConfig,
+        p2pBaseConfig: {
+          ...p2pBaseConfig,
+          peerCheckIntervalMS: TEST_HEARTBEAT_INTERVAL,
+        },
         mockAttestationPool: attestationPool,
         mockTxPool: txPool,
         mockEpochCache: epochCache,
@@ -129,6 +133,9 @@ describe('p2p client integration status handshake', () => {
     await startTestP2PClients(clients);
     await retryUntil(async () => (await client1.getPeers()).length == 1, 'peers discovered', 10, 0.5);
     logger.info(`Finished waiting for clients to connect`);
+
+    // We sleep for 3 intervals to make sure disconnect happened
+    await sleep(3 * TEST_HEARTBEAT_INTERVAL);
 
     for (const handshakeSpy of statusHandshakeSpies) {
       expect(handshakeSpy).toHaveBeenCalled();


### PR DESCRIPTION
Improves the `start` procedure in libp2p_service.
I have noticed the following errors in  some tests:

```
    SUBPROTOCOL: /aztec/req/block_txs/0.1.0
     CodeError: protocol selection failed
        at Module.select (/workspaces/aztec-packages/yarn-project/node_modules/@libp2p/multistream-select/src/select.ts:116:9)
        at processTicksAndRejections (node:internal/process/task_queues:105:5)
        at ConnectionImpl.newStream [as _newStream] (/workspaces/aztec-packages/yarn-project/node_modules/libp2p/src/upgrader.ts:462:15)
        at ConnectionImpl.newStream (/workspaces/aztec-packages/yarn-project/node_modules/libp2p/src/connection/index.ts:134:20)
        at /workspaces/aztec-packages/yarn-project/foundation/dest/queue/serial_queue.js:58:33
        at FifoMemoryQueue.process (/workspaces/aztec-packages/yarn-project/foundation/dest/queue/base_memory_queue.js:110:17) {
      code: 'ERR_UNSUPPORTED_PROTOCOL',
      props: {}
    }
```

This indicates that subprotocols were not registered in time. After applying this fix, I've noticed that, e.g., `preferred_gossip` is not failing anymore 