### PR TITLE
fix: double RAM to arm64 runners

### DIFF
--- a/ci3/aws_request_instance
+++ b/ci3/aws_request_instance
@@ -17,7 +17,7 @@ instance_types_amd64=(
 )
 
 instance_types_arm64=(
-  m7g
+  r7g
 )
 
 # Declare an associative array to map CPU counts to instance type suffixes.


### PR DESCRIPTION
avm build was running out of the 256GB of ram