### PR TITLE
docs: `create_fn_abi_export` function

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/macros/functions/abi_export.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/functions/abi_export.nr
@@ -1,5 +1,34 @@
 use std::meta::type_of;
 
+/// Creates ABI structs for a function to expose its interface.
+///
+/// # Important
+/// This function needs to be run before transformations modifying the signature of the target function `f` are applied
+/// (e.g. transform_private).
+///
+/// # Overview
+/// This function takes a FunctionDefinition and generates two structs:
+/// 1. A parameters struct containing all the function parameters
+/// 2. An ABI struct containing the parameters struct and return type (if any)
+///
+/// # Example
+/// Given a function:
+/// ```noir
+/// fn increment(owner: AztecAddress) -> Field { ... }
+/// ```
+///
+/// It generates:
+/// ```noir
+/// pub struct increment_parameters {
+///     pub owner: AztecAddress
+/// }
+///
+/// #[abi(functions)]
+/// pub struct increment_abi {
+///     parameters: increment_parameters,
+///     return_type: Field
+/// }
+/// ```
 pub(crate) comptime fn create_fn_abi_export(f: FunctionDefinition) -> Quoted {
     let name = f.name();
     let mut parameters =
@@ -21,8 +50,7 @@ pub(crate) comptime fn create_fn_abi_export(f: FunctionDefinition) -> Quoted {
 
     let abi_struct_name = f"{name}_abi".quoted_contents();
 
-    let result = quote {
-
+    quote {
         $parameters
 
         #[abi(functions)]
@@ -30,6 +58,5 @@ pub(crate) comptime fn create_fn_abi_export(f: FunctionDefinition) -> Quoted {
             parameters: $parameters_struct_name,
             $return_type
         }
-    };
-    result
+    }
 }

--- a/noir-projects/aztec-nr/aztec/src/macros/functions/abi_export.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/functions/abi_export.nr
@@ -31,9 +31,11 @@ use std::meta::type_of;
 /// ```
 ///
 /// ## The #[abi(functions)] Attribute
-/// The `#[abi(functions)]` attribute marks this struct to be included in the contract ABI's `outputs.functions` array.
-/// This array contains the function signatures with their original parameter and return types, before any
-/// transformations by macros are applied. This allows the toolchain to know the original function interfaces.
+/// The `#[abi(functions)]` attribute marks this struct for inclusion in the contract ABI's `outputs.functions` array.
+/// This array preserves the original function signatures, including parameters and return types, before any macro
+/// transformations are applied. This preservation is crucial because macro processing alters the actual return type
+/// of contract functions to `PrivateCircuitPublicInputs`, which differs from the developer's originally specified
+/// return type. Our toolchain requires access to these original signatures.
 pub(crate) comptime fn create_fn_abi_export(f: FunctionDefinition) -> Quoted {
     let name = f.name();
     let mut parameters =

--- a/noir-projects/aztec-nr/aztec/src/macros/functions/abi_export.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/functions/abi_export.nr
@@ -11,7 +11,7 @@ use std::meta::type_of;
 /// 1. A parameters struct containing all the function parameters
 /// 2. An ABI struct containing the parameters struct and return type (if any)
 ///
-/// # Example
+/// ## Example
 /// Given a function:
 /// ```noir
 /// fn increment(owner: AztecAddress) -> Field { ... }
@@ -29,6 +29,10 @@ use std::meta::type_of;
 ///     return_type: Field
 /// }
 /// ```
+///
+/// ## The #[abi(functions)] Attribute
+/// The `#[abi(functions)]` is a custom attribute that is then used by the toolchain to generate the contract ABI.
+/// TODO: Is this responsible for the `abi` item in the function artifact?
 pub(crate) comptime fn create_fn_abi_export(f: FunctionDefinition) -> Quoted {
     let name = f.name();
     let mut parameters =

--- a/noir-projects/aztec-nr/aztec/src/macros/functions/abi_export.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/functions/abi_export.nr
@@ -31,8 +31,9 @@ use std::meta::type_of;
 /// ```
 ///
 /// ## The #[abi(functions)] Attribute
-/// The `#[abi(functions)]` is a custom attribute that is then used by the toolchain to generate the contract ABI.
-/// TODO: Is this responsible for the `abi` item in the function artifact?
+/// The `#[abi(functions)]` attribute marks this struct to be included in the contract ABI's `outputs.functions` array.
+/// This array contains the function signatures with their original parameter and return types, before any
+/// transformations by macros are applied. This allows the toolchain to know the original function interfaces.
 pub(crate) comptime fn create_fn_abi_export(f: FunctionDefinition) -> Quoted {
     let name = f.name();
     let mut parameters =


### PR DESCRIPTION
Documenting this function as it should have been documented in the first place.

[This bug](https://github.com/AztecProtocol/aztec-packages/pull/16149#issuecomment-3143443819) motivated me to do it.