### PR TITLE
fix: fix grammatical mistakes in getting_started.md

### DIFF
--- a/docs/docs/developers/getting_started.md
+++ b/docs/docs/developers/getting_started.md
@@ -8,8 +8,8 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 Get started on your local environment using the sandbox. If you'd rather jump into testnet, read the [getting started on testnet guide](./guides/getting_started_on_testnet.md).
-     
-The Sandbox is an local development Aztec network running fully on your machine, and interacting with a development Ethereum node. You can develop and deploy on it just like on a testnet or mainnet (when the time comes). The sandbox makes it faster and easier to develop and test your Aztec applications.
+
+The Sandbox is a local development Aztec network running fully on your machine, and interacting with a development Ethereum node. You can develop and deploy on it just like on a testnet or mainnet (when the time comes). The sandbox makes it faster and easier to develop and test your Aztec applications.
 
 What's included in the sandbox:
 
@@ -18,7 +18,7 @@ What's included in the sandbox:
 - A set of test accounts with some test tokens to pay fees
 - Development tools to compile contracts and interact with the network (`aztec-nargo` and `aztec-wallet`)
 
-All of this comes packages in a Docker container to make it easy to install and run.
+All of this comes packaged in a Docker container to make it easy to install and run.
 
 This guide will teach you how to install the Aztec sandbox, run it using the Aztec CLI, and interact with contracts using the wallet CLI. To jump right into the testnet instead, click the `Testnet` tab.
 


### PR DESCRIPTION
The PR fixes two grammatical mistakes in the [getting started page](https://docs.aztec.network/developers/getting_started) in the build section of the documentation.

changes made:

- "an local" -> "a local"
- "comes packages in a Docker container" -> "comes packaged in a docker container"