### PR TITLE
feat: add method existence check in TXEDispatcher

### DIFF
--- a/yarn-project/txe/src/index.ts
+++ b/yarn-project/txe/src/index.ts
@@ -227,6 +227,18 @@ class TXEDispatcher {
     }
 
     const txeService = TXESessions.get(sessionId);
+
+    // Check if the function exists on the txeService before calling it
+    if (typeof (txeService as any)[functionName] !== 'function') {
+      const availableMethods = Object.getOwnPropertyNames(Object.getPrototypeOf(txeService))
+        .filter(name => typeof (txeService as any)[name] === 'function' && name !== 'constructor')
+        .sort();
+
+      throw new Error(
+        `TXE function '${functionName}' is not available. ` + `Available methods: ${availableMethods.join(', ')}`,
+      );
+    }
+
     const response = await (txeService as any)[functionName](...inputs);
     return response;
   }


### PR DESCRIPTION
Implemented a check to verify if the requested function exists on the `txeService` before invocation. If the function is not available, an error is thrown listing the available methods, enhancing error handling and user feedback.

This what the error looked like before when the oracle function didn't exist:

<img width="1560" height="112" alt="image" src="https://github.com/user-attachments/assets/655d344f-9d2a-4959-bea8-f1d4b3e7b856" />

This is what it looks like now:

<img width="1596" height="728" alt="image" src="https://github.com/user-attachments/assets/7af9cc1d-7c3a-4175-bfc2-1fe7227d008b" />
