### PR TITLE
feat: Add Single Validator RPC Method for Historical Data Retrieval

### DIFF
--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -1125,7 +1125,11 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, Traceable {
     return this.validatorsSentinel?.computeStats() ?? Promise.resolve({ stats: {}, slotWindow: 0 });
   }
 
-  public getValidatorStats(validatorAddress: string, fromSlot?: bigint, toSlot?: bigint): Promise<SingleValidatorStats | undefined> {
+  public getValidatorStats(
+    validatorAddress: EthAddress,
+    fromSlot?: bigint,
+    toSlot?: bigint,
+  ): Promise<SingleValidatorStats | undefined> {
     return this.validatorsSentinel?.getValidatorStats(validatorAddress, fromSlot, toSlot) ?? Promise.resolve(undefined);
   }
 

--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -95,7 +95,7 @@ import {
   type TxValidationResult,
 } from '@aztec/stdlib/tx';
 import { getPackageVersion } from '@aztec/stdlib/update-checker';
-import type { ValidatorsStats } from '@aztec/stdlib/validators';
+import type { SingleValidatorStats, ValidatorsStats } from '@aztec/stdlib/validators';
 import {
   Attributes,
   type TelemetryClient,
@@ -1123,6 +1123,10 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, Traceable {
 
   public getValidatorsStats(): Promise<ValidatorsStats> {
     return this.validatorsSentinel?.computeStats() ?? Promise.resolve({ stats: {}, slotWindow: 0 });
+  }
+
+  public getValidatorStats(validatorAddress: string, fromSlot?: bigint, toSlot?: bigint): Promise<SingleValidatorStats | undefined> {
+    return this.validatorsSentinel?.getValidatorStats(validatorAddress, fromSlot, toSlot) ?? Promise.resolve(undefined);
   }
 
   public async startSnapshotUpload(location: string): Promise<void> {

--- a/yarn-project/aztec-node/src/sentinel/sentinel.test.ts
+++ b/yarn-project/aztec-node/src/sentinel/sentinel.test.ts
@@ -278,6 +278,102 @@ describe('sentinel', () => {
         const result = await sentinel.getValidatorStats(validator, 1n, 6n);
         expect(result).toBeUndefined();
       });
+
+      it('should return expected mocked data structure', async () => {
+        const mockHistory: ValidatorStatusHistory = [
+          { slot: 1n, status: 'block-mined' },
+          { slot: 2n, status: 'attestation-sent' },
+        ];
+        const mockProvenPerformance = [
+          { epoch: 1n, missed: 2, total: 10 },
+          { epoch: 2n, missed: 1, total: 8 },
+        ];
+
+        jest.spyOn(store, 'getHistory').mockResolvedValue(mockHistory);
+        jest.spyOn(store, 'getProvenPerformance').mockResolvedValue(mockProvenPerformance);
+        jest.spyOn(sentinel, 'computeStatsForValidator').mockReturnValue({
+          address: validator,
+          totalSlots: 2,
+          missedProposals: { count: 0, currentStreak: 0, rate: 0 },
+          missedAttestations: { count: 0, currentStreak: 0, rate: 0 },
+          history: mockHistory,
+        });
+
+        const result = await sentinel.getValidatorStats(validator, 1n, 6n);
+
+        expect(result).toEqual({
+          validator: {
+            address: validator,
+            totalSlots: 2,
+            missedProposals: { count: 0, currentStreak: 0, rate: 0 },
+            missedAttestations: { count: 0, currentStreak: 0, rate: 0 },
+            history: mockHistory,
+          },
+          allTimeProvenPerformance: mockProvenPerformance,
+          lastProcessedSlot: sentinel.getLastProcessedSlot(),
+          initialSlot: sentinel.getInitialSlot(),
+          slotWindow: 10,
+        });
+      });
+
+      it('should call computeStatsForValidator with correct parameters', async () => {
+        const mockHistory: ValidatorStatusHistory = [{ slot: 5n, status: 'block-mined' }];
+        jest.spyOn(store, 'getHistory').mockResolvedValue(mockHistory);
+        jest.spyOn(store, 'getProvenPerformance').mockResolvedValue([]);
+        const computeStatsSpy = jest.spyOn(sentinel, 'computeStatsForValidator').mockReturnValue({
+          address: validator,
+          totalSlots: 1,
+          missedProposals: { count: 0, currentStreak: 0, rate: 0 },
+          missedAttestations: { count: 0, currentStreak: 0, rate: 0 },
+          history: mockHistory,
+        });
+
+        await sentinel.getValidatorStats(validator, 3n, 8n);
+
+        expect(computeStatsSpy).toHaveBeenCalledWith(validator.toString(), mockHistory, 3n, 8n);
+      });
+
+      it('should use default slot range when not provided', async () => {
+        const mockHistory: ValidatorStatusHistory = [{ slot: 5n, status: 'block-mined' }];
+        jest.spyOn(store, 'getHistory').mockResolvedValue(mockHistory);
+        jest.spyOn(store, 'getProvenPerformance').mockResolvedValue([]);
+        const computeStatsSpy = jest.spyOn(sentinel, 'computeStatsForValidator').mockReturnValue({
+          address: validator,
+          totalSlots: 1,
+          missedProposals: { count: 0, currentStreak: 0, rate: 0 },
+          missedAttestations: { count: 0, currentStreak: 0, rate: 0 },
+          history: mockHistory,
+        });
+
+        await sentinel.getValidatorStats(validator);
+
+        expect(computeStatsSpy).toHaveBeenCalledWith(validator.toString(), mockHistory, slot - BigInt(10), slot);
+      });
+
+      it('should return proven performance data from store', async () => {
+        const mockHistory: ValidatorStatusHistory = [{ slot: 1n, status: 'block-mined' }];
+        const mockProvenPerformance = [
+          { epoch: 5n, missed: 3, total: 12 },
+          { epoch: 6n, missed: 0, total: 15 },
+        ];
+
+        jest.spyOn(store, 'getHistory').mockResolvedValue(mockHistory);
+        const getProvenPerformanceSpy = jest
+          .spyOn(store, 'getProvenPerformance')
+          .mockResolvedValue(mockProvenPerformance);
+        jest.spyOn(sentinel, 'computeStatsForValidator').mockReturnValue({
+          address: validator,
+          totalSlots: 1,
+          missedProposals: { count: 0, currentStreak: 0, rate: 0 },
+          missedAttestations: { count: 0, currentStreak: 0, rate: 0 },
+          history: mockHistory,
+        });
+
+        const result = await sentinel.getValidatorStats(validator);
+
+        expect(getProvenPerformanceSpy).toHaveBeenCalledWith(validator);
+        expect(result?.allTimeProvenPerformance).toEqual(mockProvenPerformance);
+      });
     });
   });
 
@@ -469,5 +565,17 @@ class TestSentinel extends Sentinel {
 
   public override updateProvenPerformance(epoch: bigint, performance: ValidatorsEpochPerformance) {
     return super.updateProvenPerformance(epoch, performance);
+  }
+
+  public override getValidatorStats(validatorAddress: EthAddress, fromSlot?: bigint, toSlot?: bigint) {
+    return super.getValidatorStats(validatorAddress, fromSlot, toSlot);
+  }
+
+  public getLastProcessedSlot() {
+    return this.lastProcessedSlot;
+  }
+
+  public getInitialSlot() {
+    return this.initialSlot;
   }
 }

--- a/yarn-project/aztec-node/src/sentinel/store.ts
+++ b/yarn-project/aztec-node/src/sentinel/store.ts
@@ -101,7 +101,7 @@ export class SentinelStore {
     return histories;
   }
 
-  private async getHistory(address: EthAddress): Promise<ValidatorStatusHistory | undefined> {
+  public async getHistory(address: EthAddress): Promise<ValidatorStatusHistory | undefined> {
     const data = await this.historyMap.getAsync(address.toString());
     return data && this.deserializeHistory(data);
   }

--- a/yarn-project/stdlib/src/interfaces/aztec-node.test.ts
+++ b/yarn-project/stdlib/src/interfaces/aztec-node.test.ts
@@ -51,7 +51,7 @@ import { TxEffect } from '../tx/tx_effect.js';
 import { TxHash } from '../tx/tx_hash.js';
 import { TxReceipt } from '../tx/tx_receipt.js';
 import type { TxValidationResult } from '../tx/validator/tx_validator.js';
-import type { ValidatorsStats } from '../validators/types.js';
+import type { SingleValidatorStats, ValidatorsStats } from '../validators/types.js';
 import { MAX_RPC_LEN } from './api_limit.js';
 import { type AztecNode, AztecNodeApiSchema } from './aztec-node.js';
 import type { SequencerConfig } from './configs.js';
@@ -654,6 +654,9 @@ class MockAztecNode implements AztecNode {
   }
   getValidatorsStats(): Promise<ValidatorsStats> {
     return Promise.resolve(this.validatorStats!);
+  }
+  getValidatorStats(_validatorAddress: string, _fromSlot?: bigint, _toSlot?: bigint): Promise<SingleValidatorStats | undefined> {
+    return Promise.resolve(undefined);
   }
   simulatePublicCalls(tx: Tx, _enforceFeePayment = false): Promise<PublicSimulationOutput> {
     expect(tx).toBeInstanceOf(Tx);

--- a/yarn-project/stdlib/src/interfaces/aztec-node.test.ts
+++ b/yarn-project/stdlib/src/interfaces/aztec-node.test.ts
@@ -368,48 +368,48 @@ describe('AztecNodeApiSchema', () => {
   });
 
   it('getValidatorStats', async () => {
-      const validatorAddress = EthAddress.random();
-      handler.singleValidatorStats = {
-          validator: {
-              address: validatorAddress,
-              totalSlots: 5,
-              missedAttestations: { currentStreak: 0, count: 0 },
-              missedProposals: { currentStreak: 0, count: 0 },
-              history: [{ slot: 1n, status: 'block-mined' }],
-          },
-          provenPerformance: [],
-          lastProcessedSlot: 10n,
-          initialSlot: 1n,
-          slotWindow: 100,
-      };
+    const validatorAddress = EthAddress.random();
+    handler.singleValidatorStats = {
+      validator: {
+        address: validatorAddress,
+        totalSlots: 5,
+        missedAttestations: { currentStreak: 0, count: 0 },
+        missedProposals: { currentStreak: 0, count: 0 },
+        history: [{ slot: 1n, status: 'block-mined' }],
+      },
+      allTimeProvenPerformance: [],
+      lastProcessedSlot: 10n,
+      initialSlot: 1n,
+      slotWindow: 100,
+    };
 
-      const response = await context.client.getValidatorStats(validatorAddress.toString());
-      expect(response).toEqual(handler.singleValidatorStats);
+    const response = await context.client.getValidatorStats(validatorAddress);
+    expect(response).toEqual(handler.singleValidatorStats);
   });
 
   it('getValidatorStats(non-existent)', async () => {
-      const response = await context.client.getValidatorStats(EthAddress.random().toString());
-      expect(response).toBeUndefined();
+    const response = await context.client.getValidatorStats(EthAddress.random());
+    expect(response).toBeUndefined();
   });
 
   it('getValidatorStats(with-time-range)', async () => {
-      const validatorAddress = EthAddress.random();
-      handler.singleValidatorStats = {
-          validator: {
-              address: validatorAddress,
-              totalSlots: 3,
-              missedAttestations: { currentStreak: 0, count: 0 },
-              missedProposals: { currentStreak: 0, count: 0 },
-              history: [{ slot: 5n, status: 'attestation-sent' }],
-          },
-          provenPerformance: [],
-          lastProcessedSlot: 10n,
-          initialSlot: 5n,
-          slotWindow: 5,
-      };
+    const validatorAddress = EthAddress.random();
+    handler.singleValidatorStats = {
+      validator: {
+        address: validatorAddress,
+        totalSlots: 3,
+        missedAttestations: { currentStreak: 0, count: 0 },
+        missedProposals: { currentStreak: 0, count: 0 },
+        history: [{ slot: 5n, status: 'attestation-sent' }],
+      },
+      allTimeProvenPerformance: [],
+      lastProcessedSlot: 10n,
+      initialSlot: 5n,
+      slotWindow: 5,
+    };
 
-      const response = await context.client.getValidatorStats(validatorAddress.toString(), 5n, 10n);
-      expect(response).toEqual(handler.singleValidatorStats);
+    const response = await context.client.getValidatorStats(validatorAddress, 5n, 10n);
+    expect(response).toEqual(handler.singleValidatorStats);
   });
 
   it('simulatePublicCalls', async () => {
@@ -701,15 +701,19 @@ class MockAztecNode implements AztecNode {
   getValidatorsStats(): Promise<ValidatorsStats> {
     return Promise.resolve(this.validatorStats!);
   }
-  getValidatorStats(validatorAddress: string, fromSlot?: bigint, toSlot?: bigint): Promise<SingleValidatorStats | undefined> {
-      expect(typeof validatorAddress).toBe('string');
-      if (fromSlot !== undefined) {
-        expect(typeof fromSlot).toBe('bigint');
-      }
-      if (toSlot !== undefined) {
-        expect(typeof toSlot).toBe('bigint');
-      }
-      return Promise.resolve(this.singleValidatorStats);
+  getValidatorStats(
+    validatorAddress: EthAddress,
+    fromSlot?: bigint,
+    toSlot?: bigint,
+  ): Promise<SingleValidatorStats | undefined> {
+    expect(validatorAddress).toBeInstanceOf(EthAddress);
+    if (fromSlot !== undefined) {
+      expect(typeof fromSlot).toBe('bigint');
+    }
+    if (toSlot !== undefined) {
+      expect(typeof toSlot).toBe('bigint');
+    }
+    return Promise.resolve(this.singleValidatorStats);
   }
   simulatePublicCalls(tx: Tx, _enforceFeePayment = false): Promise<PublicSimulationOutput> {
     expect(tx).toBeInstanceOf(Tx);

--- a/yarn-project/stdlib/src/interfaces/aztec-node.ts
+++ b/yarn-project/stdlib/src/interfaces/aztec-node.ts
@@ -48,8 +48,8 @@ import {
   TxValidationResultSchema,
   indexedTxSchema,
 } from '../tx/index.js';
-import { ValidatorsStatsSchema } from '../validators/schemas.js';
-import type { ValidatorsStats } from '../validators/types.js';
+import { SingleValidatorStatsSchema, ValidatorsStatsSchema } from '../validators/schemas.js';
+import type { SingleValidatorStats, ValidatorsStats } from '../validators/types.js';
 import { type ComponentsVersions, getVersioningResponseHandler } from '../versioning/index.js';
 import { MAX_RPC_BLOCKS_LEN, MAX_RPC_LEN, MAX_RPC_TXS_LEN } from './api_limit.js';
 import {
@@ -397,6 +397,9 @@ export interface AztecNode
   /** Returns stats for validators if enabled. */
   getValidatorsStats(): Promise<ValidatorsStats>;
 
+  /** Returns stats for a single validator if enabled. */
+  getValidatorStats(validatorAddress: string, fromSlot?: bigint, toSlot?: bigint): Promise<SingleValidatorStats | undefined>;
+
   /**
    * Simulates the public part of a transaction with the current state.
    * This currently just checks that the transaction execution succeeds.
@@ -576,6 +579,11 @@ export const AztecNodeApiSchema: ApiSchemaFor<AztecNode> = {
   getBlockHeader: z.function().args(optional(L2BlockNumberSchema)).returns(BlockHeader.schema.optional()),
 
   getValidatorsStats: z.function().returns(ValidatorsStatsSchema),
+
+  getValidatorStats: z
+    .function()
+    .args(z.string(), optional(schemas.BigInt), optional(schemas.BigInt))
+    .returns(SingleValidatorStatsSchema.optional()),
 
   simulatePublicCalls: z.function().args(Tx.schema, optional(z.boolean())).returns(PublicSimulationOutput.schema),
 

--- a/yarn-project/stdlib/src/interfaces/aztec-node.ts
+++ b/yarn-project/stdlib/src/interfaces/aztec-node.ts
@@ -7,6 +7,7 @@ import {
   PUBLIC_DATA_TREE_HEIGHT,
 } from '@aztec/constants';
 import { type L1ContractAddresses, L1ContractAddressesSchema } from '@aztec/ethereum/l1-contract-addresses';
+import type { EthAddress } from '@aztec/foundation/eth-address';
 import type { Fr } from '@aztec/foundation/fields';
 import { createSafeJsonRpcClient, makeFetch } from '@aztec/foundation/json-rpc/client';
 import { MembershipWitness, SiblingPath } from '@aztec/foundation/trees';
@@ -398,7 +399,11 @@ export interface AztecNode
   getValidatorsStats(): Promise<ValidatorsStats>;
 
   /** Returns stats for a single validator if enabled. */
-  getValidatorStats(validatorAddress: string, fromSlot?: bigint, toSlot?: bigint): Promise<SingleValidatorStats | undefined>;
+  getValidatorStats(
+    validatorAddress: EthAddress,
+    fromSlot?: bigint,
+    toSlot?: bigint,
+  ): Promise<SingleValidatorStats | undefined>;
 
   /**
    * Simulates the public part of a transaction with the current state.
@@ -582,7 +587,7 @@ export const AztecNodeApiSchema: ApiSchemaFor<AztecNode> = {
 
   getValidatorStats: z
     .function()
-    .args(z.string(), optional(schemas.BigInt), optional(schemas.BigInt))
+    .args(schemas.EthAddress, optional(schemas.BigInt), optional(schemas.BigInt))
     .returns(SingleValidatorStatsSchema.optional()),
 
   simulatePublicCalls: z.function().args(Tx.schema, optional(z.boolean())).returns(PublicSimulationOutput.schema),

--- a/yarn-project/stdlib/src/validators/schemas.ts
+++ b/yarn-project/stdlib/src/validators/schemas.ts
@@ -2,7 +2,13 @@ import { type ZodFor, schemas } from '@aztec/foundation/schemas';
 
 import { z } from 'zod';
 
-import type { SingleValidatorStats, ValidatorStats, ValidatorStatusHistory, ValidatorStatusInSlot, ValidatorsStats } from './types.js';
+import type {
+  SingleValidatorStats,
+  ValidatorStats,
+  ValidatorStatusHistory,
+  ValidatorStatusInSlot,
+  ValidatorsStats,
+} from './types.js';
 
 export const ValidatorStatusInSlotSchema = z.enum([
   'block-mined',
@@ -54,11 +60,13 @@ export const ValidatorsStatsSchema = z.object({
 
 export const SingleValidatorStatsSchema = z.object({
   validator: ValidatorStatsSchema,
-  provenPerformance: z.array(z.object({
-    missed: schemas.Integer,
-    total: schemas.Integer,
-    epoch: schemas.BigInt,
-  })),
+  allTimeProvenPerformance: z.array(
+    z.object({
+      missed: schemas.Integer,
+      total: schemas.Integer,
+      epoch: schemas.BigInt,
+    }),
+  ),
   lastProcessedSlot: schemas.BigInt.optional(),
   initialSlot: schemas.BigInt.optional(),
   slotWindow: schemas.Integer,

--- a/yarn-project/stdlib/src/validators/schemas.ts
+++ b/yarn-project/stdlib/src/validators/schemas.ts
@@ -2,7 +2,7 @@ import { type ZodFor, schemas } from '@aztec/foundation/schemas';
 
 import { z } from 'zod';
 
-import type { ValidatorStats, ValidatorStatusHistory, ValidatorStatusInSlot, ValidatorsStats } from './types.js';
+import type { SingleValidatorStats, ValidatorStats, ValidatorStatusHistory, ValidatorStatusInSlot, ValidatorsStats } from './types.js';
 
 export const ValidatorStatusInSlotSchema = z.enum([
   'block-mined',
@@ -51,3 +51,15 @@ export const ValidatorsStatsSchema = z.object({
   initialSlot: schemas.BigInt.optional(),
   slotWindow: schemas.Integer,
 }) satisfies ZodFor<ValidatorsStats>;
+
+export const SingleValidatorStatsSchema = z.object({
+  validator: ValidatorStatsSchema,
+  provenPerformance: z.array(z.object({
+    missed: schemas.Integer,
+    total: schemas.Integer,
+    epoch: schemas.BigInt,
+  })),
+  lastProcessedSlot: schemas.BigInt.optional(),
+  initialSlot: schemas.BigInt.optional(),
+  slotWindow: schemas.Integer,
+}) satisfies ZodFor<SingleValidatorStats>;

--- a/yarn-project/stdlib/src/validators/types.ts
+++ b/yarn-project/stdlib/src/validators/types.ts
@@ -40,7 +40,7 @@ export type ValidatorsEpochPerformance = Record<`0x${string}`, { missed: number;
 
 export type SingleValidatorStats = {
   validator: ValidatorStats;
-  provenPerformance: { missed: number; total: number; epoch: bigint }[];
+  allTimeProvenPerformance: { missed: number; total: number; epoch: bigint }[];
   lastProcessedSlot?: bigint;
   initialSlot?: bigint;
   slotWindow: number;

--- a/yarn-project/stdlib/src/validators/types.ts
+++ b/yarn-project/stdlib/src/validators/types.ts
@@ -37,3 +37,11 @@ export type ValidatorsStats = {
 };
 
 export type ValidatorsEpochPerformance = Record<`0x${string}`, { missed: number; total: number }>;
+
+export type SingleValidatorStats = {
+  validator: ValidatorStats;
+  provenPerformance: { missed: number; total: number; epoch: bigint }[];
+  lastProcessedSlot?: bigint;
+  initialSlot?: bigint;
+  slotWindow: number;
+};


### PR DESCRIPTION
# Summary

This PR adds a new RPC method `getValidatorStats` to retrieve historical data and performance for a single validator instead of all validators, addressing the need for more efficient validator monitoring as discussed on Discord. Prior to this implementation, retrieving validator performance data required calling `getValidatorsStats`, which returns data for ALL validators.

This PR introduces a targeted approach that:

- Reduces data transfer and processing overhead by 99%+
- Enables focused validator monitoring with ~2-5KB responses
- Supports historical data analysis with optional time range filtering
- Prepares the foundation for future archival functionality

## Core Implementation

1. **New Types & Schemas** (`yarn-project/stdlib/src/validators/`)
   - Added `SingleValidatorStats` type for single validator response
   - Added corresponding Zod schema for validation

2. **RPC Interface** (`yarn-project/stdlib/src/interfaces/aztec-node.ts`)
   - Added `getValidatorStats` method to `AztecNode` interface
   - Added schema definition with optional slot range parameters

3. **Sentinel Implementation** (`yarn-project/aztec-node/src/sentinel/`)
   - Made `SentinelStore.getHistory()` public for single validator access
   - Added `computeStatsForSingleValidator()` method to `Sentinel` class
   - Implemented slot range filtering for historical data analysis

4. **Node Service** (`yarn-project/aztec-node/src/aztec-node/server.ts`)
   - Added RPC endpoint implementation that delegates to Sentinel

## API Details

**Method**: `getValidatorStats`
**Namespace**: `node_getValidatorStats` (in sandbox)

**Parameters**:
- `validatorAddress` (string): The validator's Ethereum address
- `fromSlot` (optional bigint): Start slot for filtering historical data
- `toSlot` (optional bigint): End slot for filtering historical data

**Returns**: `SingleValidatorStats | undefined`

**Response Structure**:
```typescript
{
  validator: ValidatorStats,           // Current validator statistics
  provenPerformance: Array<{           // Historical proven performance
    missed: number,
    total: number,
    epoch: bigint
  }>,
  lastProcessedSlot?: bigint,          // Last processed slot
  initialSlot?: bigint,                // Initial tracking slot
  slotWindow: number                   // Size of tracking window
}
```

## Usage Examples

### Get all data for a validator

```bash
curl -X POST http://localhost:8080 \
  -H "Content-Type: application/json" \
  -d '{"jsonrpc":"2.0","method":"node_getValidatorStats","params":["0x1234..."],"id":1}'
```

### Get data for specific slot range

```bash
curl -X POST http://localhost:8080 \
  -H "Content-Type: application/json" \
  -d '{"jsonrpc":"2.0","method":"node_getValidatorStats","params":["0x1234...", "100", "200"],"id":1}'
```

## Testing

### Development Testing

- **Tag v1.2.0**: Tested and validated against Aztec v1.2.0 tag
- **Current testnet**: Successfully tested on live Aztec testnet
- **Integration tests**: Validated with real validator data and various scenarios

### Docker Image Available

A testnet-compatible version is available for testing:
```bash
docker pull stonemac65/sentinel:v1.2.0
```

### Real Test Server Example on Current Testnet

**Request:**
```bash
curl -X POST http://localhost:8080 \
  -H "Content-Type: application/json" \
  -d '{"jsonrpc": "2.0", "method": "node_getValidatorStats", "params": ["0x2ccf122e8953fd81b547ccb4f27d6dfa13907b03", "24300", "24400"], "id": 1}'
```

**Result for real validator:**
```json
{
  "jsonrpc":"2.0",
  "id":1,
  "result":{
    "validator":{
      "address":"0x2ccf122e8953fd81b547ccb4f27d6dfa13907b03",
      "lastAttestation":{
        "timestamp":"1753965252",
        "slot":"24400",
        "date":"2025-07-31T12:34:12.000Z"
      },
      "totalSlots":14,
      "missedProposals":{"currentStreak":0,"count":0},
      "missedAttestations":{"currentStreak":0,"rate":0,"count":0},
      "history":[
        {"slot":"24385","status":"attestation-sent"},
        {"slot":"24386","status":"attestation-sent"},
        {"slot":"24387","status":"attestation-sent"},
        {"slot":"24388","status":"attestation-sent"},
        {"slot":"24389","status":"attestation-sent"},
        {"slot":"24390","status":"attestation-sent"},
        {"slot":"24391","status":"attestation-sent"},
        {"slot":"24392","status":"attestation-sent"},
        {"slot":"24393","status":"attestation-sent"},
        {"slot":"24394","status":"attestation-sent"},
        {"slot":"24395","status":"attestation-sent"},
        {"slot":"24397","status":"attestation-sent"},
        {"slot":"24399","status":"attestation-sent"},
        {"slot":"24400","status":"attestation-sent"}
      ]
    },
    "provenPerformance":[
      {"epoch":"762","missed":0,"total":23},
      {"epoch":"792","missed":0,"total":14},
      {"epoch":"817","missed":0,"total":14},
      {"epoch":"870","missed":0,"total":20},
      {"epoch":"896","missed":0,"total":21},
      {"epoch":"920","missed":0,"total":25},
      {"epoch":"965","missed":0,"total":21},
      {"epoch":"990","missed":0,"total":24}
    ],
    "lastProcessedSlot":"32040",
    "initialSlot":"24383",
    "slotWindow":960000
  }
}
```
