### PR TITLE
chore: invert check

### DIFF
--- a/noir-projects/aztec-nr/bootstrap.sh
+++ b/noir-projects/aztec-nr/bootstrap.sh
@@ -44,7 +44,7 @@ function format {
 }
 
 function release {
-  if semver check $REF_NAME; then
+  if ! semver check $REF_NAME; then
     echo_stderr "Release tag must be a valid semver version. Found: $REF_NAME"
     exit 1
   fi


### PR DESCRIPTION
Looks like this condition should have been inverted. [Nightly CI logs](https://github.com/AztecProtocol/aztec-packages/actions/runs/16712826743/job/47300588722)

```
03:18:35 + case "$cmd" in
03:18:35 + release
03:18:35 + semver check v1.0.0-nightly.20250804
03:18:35 + echo_stderr 'Release tag must be a valid semver version. Found: v1.0.0-nightly.20250804'
03:18:35 + echo Release tag must be a valid semver version. Found: v1.0.0-nightly.20250804
03:18:35 Release tag must be a valid semver version. Found: v1.0.0-nightly.20250804
03:18:35 + exit 1
```