### PR TITLE
chore: Address epochs_first_slot test flake

### DIFF
--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_first_slot.test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_first_slot.test.ts
@@ -56,6 +56,7 @@ describe('e2e_epochs/epochs_first_slot', () => {
       maxTxsPerBlock: 1,
       attestationPropagationTime: 0.5,
       maxL1TxInclusionTimeIntoSlot: 0,
+      archiverPollingIntervalMS: 200,
     });
 
     ({ context, logger } = test);

--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_proof_fails.test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_proof_fails.test.ts
@@ -34,7 +34,7 @@ describe('e2e_epochs/epochs_proof_fails', () => {
   beforeEach(async () => {
     // Bumping the epoch duration to 5 because otherwise it takes a full epoch before the actual test starts,
     // which means the prover node is attempting to prove before we setup the mocks.
-    test = await EpochsTestContext.setup({ aztecEpochDuration: 5 });
+    test = await EpochsTestContext.setup({ ethereumSlotDuration: 8, aztecEpochDuration: 5 });
     ({ proverDelayer, sequencerDelayer, context, l1Client, rollup, constants, logger, monitor } = test);
     ({ L1_BLOCK_TIME_IN_S, L2_SLOT_DURATION_IN_S } = test);
   });

--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_simple_block_building.test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_simple_block_building.test.ts
@@ -87,8 +87,8 @@ describe('e2e_epochs/epochs_simple_block_building', () => {
     logger.warn(`Started all sequencers`);
 
     // Wait until all txs are mined
-    const timeout = test.L2_SLOT_DURATION_IN_S * (TX_COUNT * 2 + 1) * 1000;
-    await executeTimeout(() => Promise.all(sentTxs.map(tx => tx.wait())), timeout);
+    const timeout = test.L2_SLOT_DURATION_IN_S * (TX_COUNT * 2 + 1);
+    await executeTimeout(() => Promise.all(sentTxs.map(tx => tx.wait({ timeout }))), timeout * 1000);
     logger.warn(`All txs have been mined`);
 
     // Expect no failures from sequencers during block building.

--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_test.ts
@@ -45,6 +45,7 @@ import {
 export const WORLD_STATE_BLOCK_HISTORY = 2;
 export const WORLD_STATE_BLOCK_CHECK_INTERVAL = 50;
 export const ARCHIVER_POLL_INTERVAL = 50;
+export const DEFAULT_L1_BLOCK_TIME = process.env.CI ? 12 : 8;
 
 export type EpochsTestOpts = Partial<SetupOptions> & { numberOfAccounts?: number };
 
@@ -86,7 +87,9 @@ export class EpochsTestContext {
   }
 
   public static getSlotDurations(opts: EpochsTestOpts = {}) {
-    const envEthereumSlotDuration = process.env.L1_BLOCK_TIME ? parseInt(process.env.L1_BLOCK_TIME) : 8;
+    const envEthereumSlotDuration = process.env.L1_BLOCK_TIME
+      ? parseInt(process.env.L1_BLOCK_TIME)
+      : DEFAULT_L1_BLOCK_TIME;
     const ethereumSlotDuration = opts.ethereumSlotDuration ?? envEthereumSlotDuration;
     const aztecSlotDuration = opts.aztecSlotDuration ?? ethereumSlotDuration * 2;
     const aztecEpochDuration = opts.aztecEpochDuration ?? 4;


### PR DESCRIPTION
The test was failing due to the nodes taking too much time to sync the previous block, so the next slot was skipped. This PR increases the L1 slot time when running on CI so we give more time to the nodes to sync.

See logs in [this run](http://ci.aztec-labs.com/9f639f745e2de9b3):

```
18:20:57 [18:20:57.104] INFO: sequencer:publisher:7 Published L2 block to L1 rollup contract {"sender":"0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266","transactionHash":"0xf7108f97a444644a2c37b2b6e6d68b68c4d3fe5757e7fabc3d2e75bd401d5929","calldataSize":1636,"calldataGas":14140,"txCount":1,"blockNumber":43,"blockTimestamp":1754333260,"privateLogCount":16,"publicLogCount":0,"contractClassLogCount":0,"contractClassLogSize":0,"type":"eip4844","status":"success","cumulativeGasUsed":431509,"logs":[{"address":"0xa5ce51e6d78888b12b63ab4b9676d9d8c7b196d4","blockHash":"0x66835f4d7cfe0f4c85fb90d9d9c7f088e7f1786d61919ed3a19d3693f7cefa5b","blockNumber":43,"blockTimestamp":"0x68910054","data":"0x","logIndex":0,"removed":false,"topics":["0x47e13ec4cc37e31e3a4f25115640068ffbe4bee53b32f0953fa593388e69fc0f","0x0000000000000000000000000000000000000000000000000000000000000002","0x0000000000000000000000000000000000000000000000000000000000000000"],"transactionHash":"0xf7108f97a444644a2c37b2b6e6d68b68c4d3fe5757e7fabc3d2e75bd401d5929","transactionIndex":0},{"address":"0x4cec0930966ceb5e10cefa1668c1d63c369e78aa","blockHash":"0x66835f4d7cfe0f4c85fb90d9d9c7f088e7f1786d61919ed3a19d3693f7cefa5b","blockNumber":43,"blockTimestamp":"0x68910054","data":"0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000001018cb7ecaf910e1fd4c9944f682c75e94d629fb307c44596494eb6f582ae006f","logIndex":1,"removed":false,"topics":["0x9ad613a7ff46b97e0f732b31118d43f39c9ca017bed1efe739b70b0625383589","0x0000000000000000000000000000000000000000000000000000000000000002","0x23cdb117fabeb43cc8fc26477fb8787919965e601ba1cd1805679195d3015f05"],"transactionHash":"0xf7108f97a444644a2c37b2b6e6d68b68c4d3fe5757e7fabc3d2e75bd401d5929","transactionIndex":0}],"logsBloom":"0x04000000020000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008000000000010040000000000000000000000000000000000000000000000000000008020000000000000000000808000010000200000010000000000000000000000000000000000000000000000000000000000000000000000000000800000000000000400000080100000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000020000000100000010000000000000000000000000000008000000000000000000000","transactionIndex":0,"blockHash":"0x66835f4d7cfe0f4c85fb90d9d9c7f088e7f1786d61919ed3a19d3693f7cefa5b","gasUsed":431509,"effectiveGasPrice":1205285546,"blobGasUsed":131072,"blobGasPrice":1,"from":"0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266","to":"0xca11bde05977b3631167028862be2a173976ca11","contractAddress":null}
18:20:57 [18:20:57.176] INFO: e2e:e2e_epochs:epochs_first_slot L1 block 43 mined at 18:47:48 with new L2 block 2 for epoch 3 {"currentTimestamp":1754333268,"l1Timestamp":1754333268,"l1BlockNumber":43,"l2SlotNumber":96,"l2Epoch":3,"l2BlockNumber":2,"l2ProvenBlockNumber":0,"totalL2Messages":0}
18:20:58 [18:20:58.430] INFO: archiver:4 Downloaded L2 block 2 {"blockHash":"0x21f0c179bbfd9a55b7d42b6f17a060b04c2985238c98b348529182404db799a6","blockNumber":2,"txCount":1,"globalVariables":{"blockNumber":2,"chainId":31337,"coinbase":"0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266","feePerDaGas":0,"feePerL2Gas":5450,"feeRecipient":"0x0000000000000000000000000000000000000000000000000000000000000000","slotNumber":96,"timestamp":1754333260,"version":2613743393},"archiveRoot":"0x23cdb117fabeb43cc8fc26477fb8787919965e601ba1cd1805679195d3015f05","archiveNextLeafIndex":3}
18:20:58 [18:20:58.842] INFO: archiver:3 Downloaded L2 block 2 {"blockHash":"0x21f0c179bbfd9a55b7d42b6f17a060b04c2985238c98b348529182404db799a6","blockNumber":2,"txCount":1,"globalVariables":{"blockNumber":2,"chainId":31337,"coinbase":"0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266","feePerDaGas":0,"feePerL2Gas":5450,"feeRecipient":"0x0000000000000000000000000000000000000000000000000000000000000000","slotNumber":96,"timestamp":1754333260,"version":2613743393},"archiveRoot":"0x23cdb117fabeb43cc8fc26477fb8787919965e601ba1cd1805679195d3015f05","archiveNextLeafIndex":3}
18:20:58 [18:20:58.844] INFO: world_state:4 World state updated with L2 block 2 {"eventName":"l2-block-handled","duration":48.388959000003524,"unfinalisedBlockNumber":2,"finalisedBlockNumber":0,"oldestHistoricBlock":1,"txCount":1,"blockNumber":2,"blockTimestamp":1754333260,"privateLogCount":16,"publicLogCount":0,"contractClassLogCount":0,"contractClassLogSize":0}
18:20:59 [18:20:59.027] INFO: archiver:5 Downloaded L2 block 2 {"blockHash":"0x21f0c179bbfd9a55b7d42b6f17a060b04c2985238c98b348529182404db799a6","blockNumber":2,"txCount":1,"globalVariables":{"blockNumber":2,"chainId":31337,"coinbase":"0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266","feePerDaGas":0,"feePerL2Gas":5450,"feeRecipient":"0x0000000000000000000000000000000000000000000000000000000000000000","slotNumber":96,"timestamp":1754333260,"version":2613743393},"archiveRoot":"0x23cdb117fabeb43cc8fc26477fb8787919965e601ba1cd1805679195d3015f05","archiveNextLeafIndex":3}
18:20:59 [18:20:59.209] INFO: archiver:7 Downloaded L2 block 2 {"blockHash":"0x21f0c179bbfd9a55b7d42b6f17a060b04c2985238c98b348529182404db799a6","blockNumber":2,"txCount":1,"globalVariables":{"blockNumber":2,"chainId":31337,"coinbase":"0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266","feePerDaGas":0,"feePerL2Gas":5450,"feeRecipient":"0x0000000000000000000000000000000000000000000000000000000000000000","slotNumber":96,"timestamp":1754333260,"version":2613743393},"archiveRoot":"0x23cdb117fabeb43cc8fc26477fb8787919965e601ba1cd1805679195d3015f05","archiveNextLeafIndex":3}
18:20:59 [18:20:59.385] INFO: archiver:9 Downloaded L2 block 2 {"blockHash":"0x21f0c179bbfd9a55b7d42b6f17a060b04c2985238c98b348529182404db799a6","blockNumber":2,"txCount":1,"globalVariables":{"blockNumber":2,"chainId":31337,"coinbase":"0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266","feePerDaGas":0,"feePerL2Gas":5450,"feeRecipient":"0x0000000000000000000000000000000000000000000000000000000000000000","slotNumber":96,"timestamp":1754333260,"version":2613743393},"archiveRoot":"0x23cdb117fabeb43cc8fc26477fb8787919965e601ba1cd1805679195d3015f05","archiveNextLeafIndex":3}
18:20:59 [18:20:59.386] INFO: archiver:8 Downloaded L2 block 2 {"blockHash":"0x21f0c179bbfd9a55b7d42b6f17a060b04c2985238c98b348529182404db799a6","blockNumber":2,"txCount":1,"globalVariables":{"blockNumber":2,"chainId":31337,"coinbase":"0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266","feePerDaGas":0,"feePerL2Gas":5450,"feeRecipient":"0x0000000000000000000000000000000000000000000000000000000000000000","slotNumber":96,"timestamp":1754333260,"version":2613743393},"archiveRoot":"0x23cdb117fabeb43cc8fc26477fb8787919965e601ba1cd1805679195d3015f05","archiveNextLeafIndex":3}
18:20:59 [18:20:59.493] INFO: archiver:2 Downloaded L2 block 2 {"blockHash":"0x21f0c179bbfd9a55b7d42b6f17a060b04c2985238c98b348529182404db799a6","blockNumber":2,"txCount":1,"globalVariables":{"blockNumber":2,"chainId":31337,"coinbase":"0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266","feePerDaGas":0,"feePerL2Gas":5450,"feeRecipient":"0x0000000000000000000000000000000000000000000000000000000000000000","slotNumber":96,"timestamp":1754333260,"version":2613743393},"archiveRoot":"0x23cdb117fabeb43cc8fc26477fb8787919965e601ba1cd1805679195d3015f05","archiveNextLeafIndex":3}
18:20:59 [18:20:59.587] INFO: archiver Downloaded L2 block 2 {"blockHash":"0x21f0c179bbfd9a55b7d42b6f17a060b04c2985238c98b348529182404db799a6","blockNumber":2,"txCount":1,"globalVariables":{"blockNumber":2,"chainId":31337,"coinbase":"0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266","feePerDaGas":0,"feePerL2Gas":5450,"feeRecipient":"0x0000000000000000000000000000000000000000000000000000000000000000","slotNumber":96,"timestamp":1754333260,"version":2613743393},"archiveRoot":"0x23cdb117fabeb43cc8fc26477fb8787919965e601ba1cd1805679195d3015f05","archiveNextLeafIndex":3}
18:20:59 [18:20:59.588] INFO: archiver:6 Downloaded L2 block 2 {"blockHash":"0x21f0c179bbfd9a55b7d42b6f17a060b04c2985238c98b348529182404db799a6","blockNumber":2,"txCount":1,"globalVariables":{"blockNumber":2,"chainId":31337,"coinbase":"0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266","feePerDaGas":0,"feePerL2Gas":5450,"feeRecipient":"0x0000000000000000000000000000000000000000000000000000000000000000","slotNumber":96,"timestamp":1754333260,"version":2613743393},"archiveRoot":"0x23cdb117fabeb43cc8fc26477fb8787919965e601ba1cd1805679195d3015f05","archiveNextLeafIndex":3}
18:20:59 [18:20:59.666] INFO: world_state:3 World state updated with L2 block 2 {"eventName":"l2-block-handled","duration":61.86037799999758,"unfinalisedBlockNumber":2,"finalisedBlockNumber":0,"oldestHistoricBlock":1,"txCount":1,"blockNumber":2,"blockTimestamp":1754333260,"privateLogCount":16,"publicLogCount":0,"contractClassLogCount":0,"contractClassLogSize":0}
18:20:59 [18:20:59.693] INFO: world_state:5 World state updated with L2 block 2 {"eventName":"l2-block-handled","duration":35.80771599999571,"unfinalisedBlockNumber":2,"finalisedBlockNumber":0,"oldestHistoricBlock":1,"txCount":1,"blockNumber":2,"blockTimestamp":1754333260,"privateLogCount":16,"publicLogCount":0,"contractClassLogCount":0,"contractClassLogSize":0}
18:20:59 [18:20:59.775] INFO: world_state:9 World state updated with L2 block 2 {"eventName":"l2-block-handled","duration":40.56559699999343,"unfinalisedBlockNumber":2,"finalisedBlockNumber":0,"oldestHistoricBlock":1,"txCount":1,"blockNumber":2,"blockTimestamp":1754333260,"privateLogCount":16,"publicLogCount":0,"contractClassLogCount":0,"contractClassLogSize":0}
18:20:59 [18:20:59.778] INFO: world_state:8 World state updated with L2 block 2 {"eventName":"l2-block-handled","duration":41.86338999999862,"unfinalisedBlockNumber":2,"finalisedBlockNumber":0,"oldestHistoricBlock":1,"txCount":1,"blockNumber":2,"blockTimestamp":1754333260,"privateLogCount":16,"publicLogCount":0,"contractClassLogCount":0,"contractClassLogSize":0}
18:20:59 [18:20:59.781] INFO: world_state:7 World state updated with L2 block 2 {"eventName":"l2-block-handled","duration":42.46742899999663,"unfinalisedBlockNumber":2,"finalisedBlockNumber":0,"oldestHistoricBlock":1,"txCount":1,"blockNumber":2,"blockTimestamp":1754333260,"privateLogCount":16,"publicLogCount":0,"contractClassLogCount":0,"contractClassLogSize":0}
18:20:59 [18:20:59.828] INFO: world_state World state updated with L2 block 2 {"eventName":"l2-block-handled","duration":17.69535999999789,"unfinalisedBlockNumber":2,"finalisedBlockNumber":0,"oldestHistoricBlock":1,"txCount":1,"blockNumber":2,"blockTimestamp":1754333260,"privateLogCount":16,"publicLogCount":0,"contractClassLogCount":0,"contractClassLogSize":0}
18:20:59 [18:20:59.829] INFO: world_state:2 World state updated with L2 block 2 {"eventName":"l2-block-handled","duration":16.739633000004687,"unfinalisedBlockNumber":2,"finalisedBlockNumber":0,"oldestHistoricBlock":1,"txCount":1,"blockNumber":2,"blockTimestamp":1754333260,"privateLogCount":16,"publicLogCount":0,"contractClassLogCount":0,"contractClassLogSize":0}
18:20:59 [18:20:59.879] INFO: world_state:6 World state updated with L2 block 2 {"eventName":"l2-block-handled","duration":21.955271999991965,"unfinalisedBlockNumber":2,"finalisedBlockNumber":0,"oldestHistoricBlock":1,"txCount":1,"blockNumber":2,"blockTimestamp":1754333260,"privateLogCount":16,"publicLogCount":0,"contractClassLogCount":0,"contractClassLogSize":0}
18:20:59 [18:20:59.884] VERBOSE: p2p:4 Synched to latest block 2
18:20:59 [18:20:59.973] VERBOSE: p2p:3 Synched to latest block 2
18:20:59 [18:20:59.976] VERBOSE: p2p:5 Synched to latest block 2
18:21:00 [18:21:00.005] VERBOSE: p2p:9 Synched to latest block 2
18:21:00 [18:21:00.006] VERBOSE: p2p:7 Synched to latest block 2
18:21:00 [18:21:00.007] VERBOSE: p2p:8 Synched to latest block 2
18:21:00 [18:21:00.549] VERBOSE: p2p:6 Synched to latest block 2
18:21:00 [18:21:00.549] VERBOSE: p2p Synched to latest block 2
18:21:00 [18:21:00.550] VERBOSE: p2p:2 Synched to latest block 2
18:21:00 [18:21:00.635] WARN: sequencer:2 Too far into slot for INITIALIZING_PROPOSAL (time into slot 3.675s greater than 3s allowance)
18:21:01 [18:21:01.175] WARN: sequencer:2 Too far into slot for INITIALIZING_PROPOSAL (time into slot 4.215s greater than 3s allowance)
```