### PR TITLE
chore(docs): removing check for netlify siteid

### DIFF
--- a/barretenberg/docs/bootstrap.sh
+++ b/barretenberg/docs/bootstrap.sh
@@ -34,9 +34,11 @@ function build_and_deploy {
   if [ "${CI:-0}" -eq 1 ] && [ "$(arch)" == "amd64" ]; then
     if [ "$REF_NAME" == "next" ]; then
       echo_header "deploying to production"
+      denoise "yarn install && yarn build"
       do_or_dryrun yarn netlify deploy --site barretenberg --prod
     else
       echo_header "deploying preview for branch: $REF_NAME"
+      denoise "yarn install && yarn build"
       do_or_dryrun yarn netlify deploy --site barretenberg
     fi
   else

--- a/barretenberg/docs/bootstrap.sh
+++ b/barretenberg/docs/bootstrap.sh
@@ -32,12 +32,6 @@ function build_and_deploy {
   fi
 
   if [ "${CI:-0}" -eq 1 ] && [ "$(arch)" == "amd64" ]; then
-    if [ -z "${NETLIFY_SITE_ID:-}" ] || [ -z "${NETLIFY_AUTH_TOKEN:-}" ]; then
-      echo "No netlify credentials available, skipping."
-      return
-    fi
-
-    # Deploy to prod if on the main branch (next)
     if [ "$REF_NAME" == "next" ]; then
       echo_header "deploying to production"
       do_or_dryrun yarn netlify deploy --site barretenberg --prod


### PR DESCRIPTION
This check is unneeded as the netlify cli will just fail if the authtoken doesn't exist (Aztec docs don't have it either)