### PR TITLE
fix: Specify announce address to libp2p address manager

### DIFF
--- a/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
+++ b/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
@@ -324,6 +324,7 @@ export class LibP2PService<T extends P2PClientType = P2PClientType.Full> extends
       services: {
         identify: identify({
           protocolPrefix: 'aztec',
+          runOnConnectionOpen: false,
         }),
         pubsub: gossipsub({
           directPeers,

--- a/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
+++ b/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
@@ -258,12 +258,14 @@ export class LibP2PService<T extends P2PClientType = P2PClientType.Full> extends
       )
     ).filter(peer => peer !== undefined);
 
+    const announceTcpMultiaddr = config.p2pIp ? [convertToMultiaddr(config.p2pIp, p2pPort, 'tcp')] : [];
+
     const node = await createLibp2p({
       start: false,
       peerId,
       addresses: {
         listen: [bindAddrTcp],
-        announce: [], // announce is handled by the peer discovery service
+        announce: announceTcpMultiaddr,
       },
       transports: [
         tcp({
@@ -324,7 +326,7 @@ export class LibP2PService<T extends P2PClientType = P2PClientType.Full> extends
       services: {
         identify: identify({
           protocolPrefix: 'aztec',
-          runOnConnectionOpen: false,
+          runOnConnectionOpen: true,
         }),
         pubsub: gossipsub({
           directPeers,


### PR DESCRIPTION
This PR adds the announce address (the node's publicly dialable address) to the address manager when starting libp2p. This has the effect that the identify protocol will use this address when communicating to other peers what it should be dialed on.

