### PR TITLE
chore: final manual trait impl. nukings

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/utils/with_hash.nr
+++ b/noir-projects/aztec-nr/aztec/src/utils/with_hash.nr
@@ -86,6 +86,11 @@ where
     }
 }
 
+// Note: I don't derive Packable on `WithHash` because `derive_serialize` function does not support setting "N = M"
+// as I do here 3 lines below. This could be worked around by placing the "where" clause directly on the `WithHash`
+// struct, but Jake mentioned that the syntax is not expected to be supported at least until Noir 1.0.
+// Relevant discussion on Slack:
+// https://aztecprotocol.slack.com/archives/C04QF64EDNV/p1752593876160699?thread_ts=1752589887.955379&cid=C04QF64EDNV
 impl<T, let M: u32> Packable for WithHash<T, M>
 where
     T: Packable<N = M>,

--- a/noir-projects/aztec-nr/compressed-string/src/compressed_string.nr
+++ b/noir-projects/aztec-nr/compressed-string/src/compressed_string.nr
@@ -4,7 +4,7 @@ use dep::aztec::protocol_types::{traits::{Deserialize, Serialize}, utils::field:
 // Compresses M bytes into N fields.
 // Can be used for longer strings that don't fit in a single field.
 // Each field can store 31 characters, so N should be M/31 rounded up.
-#[derive(Deserialize, Eq, Serialize)]
+#[derive(Deserialize, Eq)]
 pub struct CompressedString<let N: u32, let M: u32> {
     value: [Field; N],
 }
@@ -44,6 +44,17 @@ impl<let N: u32, let M: u32> CompressedString<N, M> {
             }
         }
         result
+    }
+}
+
+// TODO: Replace this with the derived version. Not done yet as this uncovered a bug in the AVM. See the discussion
+// below for more details:
+// https://aztecprotocol.slack.com/archives/C02M7VC7TN0/p1754463522334449
+impl<let N: u32, let M: u32> Serialize for CompressedString<N, M> {
+    let N: u32 = N;
+
+    fn serialize(self) -> [Field; Self::N] {
+        self.value
     }
 }
 

--- a/noir-projects/aztec-nr/compressed-string/src/compressed_string.nr
+++ b/noir-projects/aztec-nr/compressed-string/src/compressed_string.nr
@@ -4,6 +4,7 @@ use dep::aztec::protocol_types::{traits::{Deserialize, Serialize}, utils::field:
 // Compresses M bytes into N fields.
 // Can be used for longer strings that don't fit in a single field.
 // Each field can store 31 characters, so N should be M/31 rounded up.
+#[derive(Deserialize, Eq, Serialize)]
 pub struct CompressedString<let N: u32, let M: u32> {
     value: [Field; N],
 }
@@ -43,28 +44,6 @@ impl<let N: u32, let M: u32> CompressedString<N, M> {
             }
         }
         result
-    }
-}
-
-impl<let N: u32, let M: u32> Eq for CompressedString<N, M> {
-    fn eq(self, other: CompressedString<N, M>) -> bool {
-        self.value == other.value
-    }
-}
-
-impl<let N: u32, let M: u32> Serialize for CompressedString<N, M> {
-    let N: u32 = N;
-
-    fn serialize(self) -> [Field; Self::N] {
-        self.value
-    }
-}
-
-impl<let N: u32, let M: u32> Deserialize for CompressedString<N, M> {
-    let N: u32 = N;
-
-    fn deserialize(input: [Field; Self::N]) -> Self {
-        Self { value: input }
     }
 }
 

--- a/noir-projects/noir-contracts/contracts/test/test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/test_contract/src/main.nr
@@ -441,32 +441,11 @@ pub contract Test {
         }
     }
 
+    #[derive(Serialize)]
     pub struct DeepStruct {
         pub a_field: Field,
         pub a_bool: bool,
         pub a_note: DummyNote,
         pub many_notes: [DummyNote; 3],
-    }
-
-    // Serializing using "canonical" form.
-    // 1. Everything that fits in a field, *becomes* a Field
-    // 2. Strings become arrays of bytes (no strings here)
-    // 4. Arrays become arrays of Fields following rules 2 and 3 (no arrays here)
-    // 5. Structs become arrays of Fields, with every item defined in the same order as they are in Noir code, following rules 2, 3, 4 and 5 (recursive)
-    impl Serialize for DeepStruct {
-        let N: u32 = 10;
-
-        fn serialize(self) -> [Field; Self::N] {
-            let mut result = [0; Self::N];
-            result[0] = self.a_field;
-            result[1] = self.a_bool as Field;
-            result[2] = self.a_note.amount;
-            result[3] = self.a_note.secret_hash;
-            for i in 0..3 {
-                result[4 + i * 2] = self.many_notes[i].amount;
-                result[5 + i * 2] = self.many_notes[i].secret_hash;
-            }
-            result
-        }
     }
 }

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/previous_kernel_validator.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/previous_kernel_validator.nr
@@ -3,7 +3,6 @@ mod previous_kernel_validator_hints;
 use dep::types::{
     abis::{private_kernel_data::PrivateKernelData, side_effect::{Ordered, OrderedValue}},
     address::AztecAddress,
-    proof::traits::Verifiable,
     traits::Empty,
 };
 

--- a/noir-projects/noir-protocol-circuits/crates/types/src/proof/verification_key.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/proof/verification_key.nr
@@ -2,7 +2,7 @@ use crate::{
     constants::{
         AVM_VERIFICATION_KEY_LENGTH_IN_FIELDS, MEGA_VK_LENGTH_IN_FIELDS, ULTRA_VK_LENGTH_IN_FIELDS,
     },
-    traits::{Deserialize, Empty, Serialize},
+    traits::Empty,
 };
 use std::meta::derive;
 
@@ -10,32 +10,6 @@ use std::meta::derive;
 pub struct VerificationKey<let N: u32> {
     pub key: [Field; N],
     pub hash: Field,
-}
-
-impl<let M: u32> Serialize for VerificationKey<M> {
-    let N: u32 = M + 1;
-
-    fn serialize(self) -> [Field; Self::N] {
-        let mut fields = [0; Self::N];
-        for i in 0..M {
-            fields[i] = self.key[i];
-        }
-        fields[M] = self.hash;
-        fields
-    }
-}
-
-impl<let M: u32> Deserialize for VerificationKey<M> {
-    let N: u32 = M + 1;
-
-    fn deserialize(fields: [Field; Self::N]) -> Self {
-        let mut key = VerificationKey::empty();
-        for i in 0..M {
-            key.key[i] = fields[i];
-        }
-        key.hash = fields[M];
-        key
-    }
 }
 
 impl<let M: u32> Empty for VerificationKey<M> {

--- a/noir-projects/noir-protocol-circuits/crates/types/src/proof/verification_key.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/proof/verification_key.nr
@@ -2,7 +2,7 @@ use crate::{
     constants::{
         AVM_VERIFICATION_KEY_LENGTH_IN_FIELDS, MEGA_VK_LENGTH_IN_FIELDS, ULTRA_VK_LENGTH_IN_FIELDS,
     },
-    traits::Empty,
+    traits::{Deserialize, Empty, Serialize},
 };
 use std::meta::derive;
 
@@ -12,18 +12,23 @@ pub struct VerificationKey<let N: u32> {
     pub hash: Field,
 }
 
-// Intrinsic Noir serialization format is not used here so we don't implement `Serialize` and `Deserialize` traits.
-impl<let M: u32> VerificationKey<M> {
-    fn serialize_non_standard(self) -> [Field; M + 1] {
-        let mut fields = [0; M + 1];
+impl<let M: u32> Serialize for VerificationKey<M> {
+    let N: u32 = M + 1;
+
+    fn serialize(self) -> [Field; Self::N] {
+        let mut fields = [0; Self::N];
         for i in 0..M {
             fields[i] = self.key[i];
         }
         fields[M] = self.hash;
         fields
     }
+}
 
-    fn deserialize_non_standard(fields: [Field; M + 1]) -> Self {
+impl<let M: u32> Deserialize for VerificationKey<M> {
+    let N: u32 = M + 1;
+
+    fn deserialize(fields: [Field; Self::N]) -> Self {
         let mut key = VerificationKey::empty();
         for i in 0..M {
             key.key[i] = fields[i];

--- a/noir-projects/noir-protocol-circuits/crates/types/src/proof/verification_key.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/proof/verification_key.nr
@@ -2,14 +2,35 @@ use crate::{
     constants::{
         AVM_VERIFICATION_KEY_LENGTH_IN_FIELDS, MEGA_VK_LENGTH_IN_FIELDS, ULTRA_VK_LENGTH_IN_FIELDS,
     },
-    traits::{Deserialize, Empty, Serialize},
+    traits::Empty,
 };
 use std::meta::derive;
 
-#[derive(Deserialize, Eq, Serialize)]
+#[derive(Eq)]
 pub struct VerificationKey<let N: u32> {
     pub key: [Field; N],
     pub hash: Field,
+}
+
+// Intrinsic Noir serialization format is not used here so we don't implement `Serialize` and `Deserialize` traits.
+impl<let M: u32> VerificationKey<M> {
+    fn serialize_non_standard(self) -> [Field; M + 1] {
+        let mut fields = [0; M + 1];
+        for i in 0..M {
+            fields[i] = self.key[i];
+        }
+        fields[M] = self.hash;
+        fields
+    }
+
+    fn deserialize_non_standard(fields: [Field; M + 1]) -> Self {
+        let mut key = VerificationKey::empty();
+        for i in 0..M {
+            key.key[i] = fields[i];
+        }
+        key.hash = fields[M];
+        key
+    }
 }
 
 impl<let M: u32> Empty for VerificationKey<M> {

--- a/noir-projects/noir-protocol-circuits/crates/types/src/proof/verification_key.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/proof/verification_key.nr
@@ -6,36 +6,10 @@ use crate::{
 };
 use std::meta::derive;
 
-#[derive(Eq)]
+#[derive(Deserialize, Eq, Serialize)]
 pub struct VerificationKey<let N: u32> {
     pub key: [Field; N],
     pub hash: Field,
-}
-
-impl<let M: u32> Serialize for VerificationKey<M> {
-    let N: u32 = M + 1;
-
-    fn serialize(self) -> [Field; Self::N] {
-        let mut fields = [0; Self::N];
-        for i in 0..M {
-            fields[i] = self.key[i];
-        }
-        fields[M] = self.hash;
-        fields
-    }
-}
-
-impl<let M: u32> Deserialize for VerificationKey<M> {
-    let N: u32 = M + 1;
-
-    fn deserialize(fields: [Field; Self::N]) -> Self {
-        let mut key = VerificationKey::empty();
-        for i in 0..M {
-            key.key[i] = fields[i];
-        }
-        key.hash = fields[M];
-        key
-    }
 }
 
 impl<let M: u32> Empty for VerificationKey<M> {

--- a/noir-projects/noir-protocol-circuits/crates/types/src/traits.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/traits.nr
@@ -364,7 +364,7 @@ impl<let M: u32> Serialize for str<M> {
 /// - +1 is for storing the length
 ///
 /// # Note
-/// Not deriving this because it's not supported to call derive_serialize on a "remote" struct (and it will never
+/// Not deriving this because it's not supported to call derive_deserialize on a "remote" struct (and it will never
 /// be supported).
 impl<T, let M: u32> Deserialize for BoundedVec<T, M>
 where

--- a/noir-projects/noir-protocol-circuits/crates/types/src/traits.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/traits.nr
@@ -362,6 +362,10 @@ impl<let M: u32> Serialize for str<M> {
 /// - T::N is the number of Fields needed to deserialize one item
 /// - M is the maximum length of the BoundedVec
 /// - +1 is for storing the length
+///
+/// # Note
+/// Not deriving this because it's not supported to call derive_serialize on a "remote" struct (and it will never
+/// be supported).
 impl<T, let M: u32> Deserialize for BoundedVec<T, M>
 where
     T: Deserialize,
@@ -401,6 +405,8 @@ impl Deserialize for () {
     }
 }
 
+// Note: Not deriving this because it's not supported to call derive_serialize on a "remote" struct (and it will never
+// be supported).
 impl<T, let M: u32> Serialize for BoundedVec<T, M>
 where
     T: Serialize,

--- a/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays.nr
@@ -339,6 +339,7 @@ where
 /// Validation must include:
 /// - Asserting all items to the LHS of the length are nonempty (dense).
 /// - Asserting all items to the RHS of the length are empty.
+#[derive(Deserialize, Serialize)]
 pub struct ClaimedLengthArray<T, let N: u32> {
     pub array: [T; N],
     pub length: u32,
@@ -437,82 +438,6 @@ where
 {
     fn empty() -> Self {
         Self { array: [T::empty(); N], length: 0 }
-    }
-}
-
-/// Deserialize implementation for ClaimedLengthArray<T,M>
-///
-/// The serialized format is:
-/// - First M*N fields contain the serialized array elements, where N is the serialized length of type T
-/// - The last field contains the length of the array
-///
-/// For example, if T serializes to 2 fields and M=3 (max length), the format would be:
-/// [T1_field1, T1_field2, T2_field1, T2_field2, T3_field1, T3_field2, length]
-///
-/// The total serialized length is M*N + 1 fields, where:
-/// - M is the max length of the array
-/// - N is the serialized length of type T
-/// - +1 is for the length field
-impl<T, let M: u32> Deserialize for ClaimedLengthArray<T, M>
-where
-    T: Deserialize + Empty,
-{
-    let N: u32 = <T as Deserialize>::N * M + 1;
-
-    #[inline_always]
-    fn deserialize(fields: [Field; Self::N]) -> Self {
-        let mut new_arr: Self = Self::empty();
-
-        // Length is stored in the last field as we need to match intrinsic Noir serialization and the `len` struct
-        // field is after `storage` struct field.
-        let len = fields[<T as Deserialize>::N * M] as u32;
-
-        let mut within_length = true;
-        for i in 0..M {
-            if i == len {
-                within_length = false;
-            }
-
-            if within_length {
-                let mut nested_fields = [0; <T as Deserialize>::N];
-                for j in 0..<T as Deserialize>::N {
-                    nested_fields[j] = fields[i * <T as Deserialize>::N + j];
-                }
-
-                let item = T::deserialize(nested_fields);
-
-                new_arr.push(item);
-            }
-        }
-
-        assert(len == new_arr.length);
-
-        new_arr
-    }
-}
-
-impl<T, let M: u32> Serialize for ClaimedLengthArray<T, M>
-where
-    T: Serialize,
-{
-    let N: u32 = <T as Serialize>::N * M + 1;
-
-    #[inline_always]
-    fn serialize(self) -> [Field; Self::N] {
-        let mut fields = [0; Self::N];
-
-        for i in 0..M {
-            let serialized_item = self.array[i].serialize();
-
-            for j in 0..<T as Serialize>::N {
-                fields[i * <T as Serialize>::N + j] = serialized_item[j];
-            }
-        }
-
-        // Length is stored in the last field.
-        fields[<T as Serialize>::N * M] = self.length as Field;
-
-        fields
     }
 }
 


### PR DESCRIPTION
A non-controversial PR that just nuked the remaining manual implementations. Once this PR is merged then the auto-derivation is used basically everywhere where possible.