### PR TITLE
chore: change how virtual_log_n is set in sumcheck

### DIFF
--- a/barretenberg/cpp/src/barretenberg/eccvm/eccvm.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/eccvm/eccvm.test.cpp
@@ -202,7 +202,7 @@ TEST_F(ECCVMTests, CommittedSumcheck)
     prover_transcript = std::make_shared<Transcript>();
 
     // Run Sumcheck on the ECCVM Prover polynomials
-    using SumcheckProver = SumcheckProver<ECCVMFlavor, CONST_ECCVM_LOG_N>;
+    using SumcheckProver = SumcheckProver<ECCVMFlavor>;
     SumcheckProver sumcheck_prover(pk->circuit_size,
                                    pk->polynomials,
                                    prover_transcript,
@@ -219,7 +219,7 @@ TEST_F(ECCVMTests, CommittedSumcheck)
     verifier_transcript->load_proof(prover_transcript->export_proof());
 
     // Execute Sumcheck Verifier
-    SumcheckVerifier<Flavor, CONST_ECCVM_LOG_N> sumcheck_verifier(verifier_transcript, alpha, CONST_ECCVM_LOG_N);
+    SumcheckVerifier<Flavor> sumcheck_verifier(verifier_transcript, alpha, CONST_ECCVM_LOG_N);
     SumcheckOutput<ECCVMFlavor> verifier_output = sumcheck_verifier.verify(relation_parameters, gate_challenges);
 
     // Evaluate prover's round univariates at corresponding challenges and compare them with the claimed evaluations

--- a/barretenberg/cpp/src/barretenberg/eccvm/eccvm.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/eccvm/eccvm.test.cpp
@@ -203,8 +203,13 @@ TEST_F(ECCVMTests, CommittedSumcheck)
 
     // Run Sumcheck on the ECCVM Prover polynomials
     using SumcheckProver = SumcheckProver<ECCVMFlavor, CONST_ECCVM_LOG_N>;
-    SumcheckProver sumcheck_prover(
-        pk->circuit_size, pk->polynomials, prover_transcript, alpha, gate_challenges, relation_parameters);
+    SumcheckProver sumcheck_prover(pk->circuit_size,
+                                   pk->polynomials,
+                                   prover_transcript,
+                                   alpha,
+                                   gate_challenges,
+                                   relation_parameters,
+                                   CONST_ECCVM_LOG_N);
 
     ZKData zk_sumcheck_data = ZKData(CONST_ECCVM_LOG_N, prover_transcript);
 
@@ -214,7 +219,7 @@ TEST_F(ECCVMTests, CommittedSumcheck)
     verifier_transcript->load_proof(prover_transcript->export_proof());
 
     // Execute Sumcheck Verifier
-    SumcheckVerifier<Flavor, CONST_ECCVM_LOG_N> sumcheck_verifier(verifier_transcript, alpha);
+    SumcheckVerifier<Flavor, CONST_ECCVM_LOG_N> sumcheck_verifier(verifier_transcript, alpha, CONST_ECCVM_LOG_N);
     SumcheckOutput<ECCVMFlavor> verifier_output = sumcheck_verifier.verify(relation_parameters, gate_challenges);
 
     // Evaluate prover's round univariates at corresponding challenges and compare them with the claimed evaluations

--- a/barretenberg/cpp/src/barretenberg/eccvm/eccvm_prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/eccvm/eccvm_prover.cpp
@@ -139,7 +139,13 @@ void ECCVMProver::execute_relation_check_rounds()
         gate_challenges[idx] = transcript->template get_challenge<FF>("Sumcheck:gate_challenge_" + std::to_string(idx));
     }
 
-    Sumcheck sumcheck(key->circuit_size, key->polynomials, transcript, alpha, gate_challenges, relation_parameters);
+    Sumcheck sumcheck(key->circuit_size,
+                      key->polynomials,
+                      transcript,
+                      alpha,
+                      gate_challenges,
+                      relation_parameters,
+                      CONST_ECCVM_LOG_N);
 
     zk_sumcheck_data = ZKData(key->log_circuit_size, transcript, key->commitment_key);
 

--- a/barretenberg/cpp/src/barretenberg/eccvm/eccvm_prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/eccvm/eccvm_prover.cpp
@@ -128,7 +128,7 @@ void ECCVMProver::execute_grand_product_computation_round()
 void ECCVMProver::execute_relation_check_rounds()
 {
 
-    using Sumcheck = SumcheckProver<Flavor, CONST_ECCVM_LOG_N>;
+    using Sumcheck = SumcheckProver<Flavor>;
 
     // Each linearly independent subrelation contribution is multiplied by `alpha^i`, where
     //  i = 0, ..., NUM_SUBRELATIONS- 1.

--- a/barretenberg/cpp/src/barretenberg/eccvm/eccvm_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/eccvm/eccvm_verifier.cpp
@@ -63,7 +63,7 @@ bool ECCVMVerifier::verify_proof(const ECCVMProof& proof)
     const FF alpha = transcript->template get_challenge<FF>("Sumcheck:alpha");
 
     // Execute Sumcheck Verifier
-    SumcheckVerifier<Flavor, CONST_ECCVM_LOG_N> sumcheck(transcript, alpha, CONST_ECCVM_LOG_N);
+    SumcheckVerifier<Flavor> sumcheck(transcript, alpha, CONST_ECCVM_LOG_N);
 
     std::vector<FF> gate_challenges(CONST_ECCVM_LOG_N);
     for (size_t idx = 0; idx < gate_challenges.size(); idx++) {

--- a/barretenberg/cpp/src/barretenberg/eccvm/eccvm_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/eccvm/eccvm_verifier.cpp
@@ -63,7 +63,7 @@ bool ECCVMVerifier::verify_proof(const ECCVMProof& proof)
     const FF alpha = transcript->template get_challenge<FF>("Sumcheck:alpha");
 
     // Execute Sumcheck Verifier
-    SumcheckVerifier<Flavor, CONST_ECCVM_LOG_N> sumcheck(transcript, alpha);
+    SumcheckVerifier<Flavor, CONST_ECCVM_LOG_N> sumcheck(transcript, alpha, CONST_ECCVM_LOG_N);
 
     std::vector<FF> gate_challenges(CONST_ECCVM_LOG_N);
     for (size_t idx = 0; idx < gate_challenges.size(); idx++) {

--- a/barretenberg/cpp/src/barretenberg/polynomials/row_disabling_polynomial.hpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/row_disabling_polynomial.hpp
@@ -187,13 +187,12 @@ template <typename FF> struct RowDisablingPolynomial {
      * @param multivariate_challenge Sumcheck evaluation challenge
      * @param padding_indicator_array An array with first log_n entries equal to 1, and the remaining entries are 0.
      */
-    template <size_t virtual_log_n>
     static FF evaluate_at_challenge(std::span<FF> multivariate_challenge,
-                                    const std::array<FF, virtual_log_n>& padding_indicator_array)
+                                    const std::vector<FF>& padding_indicator_array)
     {
         FF evaluation_at_multivariate_challenge{ 1 };
 
-        for (size_t idx = 2; idx < virtual_log_n; idx++) {
+        for (size_t idx = 2; idx < padding_indicator_array.size(); idx++) {
             const FF& indicator = padding_indicator_array[idx];
             evaluation_at_multivariate_challenge *= FF{ 1 } - indicator + indicator * multivariate_challenge[idx];
         }

--- a/barretenberg/cpp/src/barretenberg/stdlib/eccvm_verifier/eccvm_recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/eccvm_verifier/eccvm_recursive_verifier.cpp
@@ -91,7 +91,7 @@ ECCVMRecursiveVerifier::IpaClaimAndProof ECCVMRecursiveVerifier::verify_proof(co
     // Each linearly independent subrelation contribution is multiplied by `alpha^i`, where
     //  i = 0, ..., NUM_SUBRELATIONS- 1.
     const FF alpha = transcript->template get_challenge<FF>("Sumcheck:alpha");
-    Sumcheck sumcheck(transcript, alpha);
+    Sumcheck sumcheck(transcript, alpha, CONST_ECCVM_LOG_N);
 
     std::vector<FF> gate_challenges(CONST_ECCVM_LOG_N);
     for (size_t idx = 0; idx < gate_challenges.size(); idx++) {

--- a/barretenberg/cpp/src/barretenberg/stdlib/eccvm_verifier/eccvm_recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/eccvm_verifier/eccvm_recursive_verifier.cpp
@@ -51,7 +51,7 @@ ECCVMRecursiveVerifier::IpaClaimAndProof ECCVMRecursiveVerifier::verify_proof(co
     using OpeningClaim = OpeningClaim<Curve>;
     using ClaimBatcher = ClaimBatcher_<Curve>;
     using ClaimBatch = ClaimBatcher::Batch;
-    using Sumcheck = SumcheckVerifier<Flavor, CONST_ECCVM_LOG_N>;
+    using Sumcheck = SumcheckVerifier<Flavor>;
 
     RelationParameters<FF> relation_parameters;
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/decider_recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/decider_recursive_verifier.cpp
@@ -48,7 +48,7 @@ DeciderRecursiveVerifier_<Flavor>::PairingPoints DeciderRecursiveVerifier_<Flavo
     const auto padding_indicator_array =
         compute_padding_indicator_array<Curve, CONST_PROOF_SIZE_LOG_N>(accumulator->vk_and_hash->vk->log_circuit_size);
 
-    Sumcheck sumcheck(transcript, accumulator->alphas, accumulator->target_sum);
+    Sumcheck sumcheck(transcript, accumulator->alphas, CONST_PROOF_SIZE_LOG_N, accumulator->target_sum);
     SumcheckOutput<Flavor> output =
         sumcheck.verify(accumulator->relation_parameters, accumulator->gate_challenges, padding_indicator_array);
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/ultra_recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/ultra_recursive_verifier.cpp
@@ -106,7 +106,7 @@ UltraRecursiveVerifier_<Flavor>::Output UltraRecursiveVerifier_<Flavor>::verify_
     const auto padding_indicator_array =
         compute_padding_indicator_array<Curve, CONST_PROOF_SIZE_LOG_N>(key->vk_and_hash->vk->log_circuit_size);
 
-    Sumcheck sumcheck(transcript, key->alphas);
+    Sumcheck sumcheck(transcript, key->alphas, CONST_PROOF_SIZE_LOG_N);
 
     // Receive commitments to Libra masking polynomials
     std::array<Commitment, NUM_LIBRA_COMMITMENTS> libra_commitments = {};

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/padding_indicator_array/padding_indicator_array.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/padding_indicator_array/padding_indicator_array.hpp
@@ -35,15 +35,15 @@ namespace bb::stdlib {
  * \f$ [b_0(x-1), \ldots, b_{N-1}(x-1)] \f$ only depends on \f$ N \f$ adding ~\f$ 4\cdot N \f$ gates to the circuit.
  *
  */
-template <typename Curve, size_t virtual_log_n>
-static std::array<typename Curve::ScalarField, virtual_log_n> compute_padding_indicator_array(
+template <typename Curve, size_t virtual_log_n = CONST_PROOF_SIZE_LOG_N>
+static std::vector<typename Curve::ScalarField> compute_padding_indicator_array(
     const typename Curve::ScalarField& log_n)
 {
     using Fr = typename Curve::ScalarField;
     // Create a domain of size `virtual_log_n` and compute Lagrange denominators
     using Data = BarycentricDataRunTime<Fr, virtual_log_n, /*num_evals=*/1>;
 
-    std::array<Fr, virtual_log_n> result{};
+    std::vector<Fr> result(virtual_log_n);
     // 1) Build prefix products:
     //    prefix[i] = ∏_{m=0..(i-1)} (x - 1 - big_domain[m]), with prefix[0] = 1.
     std::vector<Fr> prefix(virtual_log_n, Fr{ 1 });
@@ -81,27 +81,30 @@ static std::array<typename Curve::ScalarField, virtual_log_n> compute_padding_in
     return result;
 }
 
-/**
- * @brief Given a witness `n` and a padding indicator array computed from `log_n`, check in-circuit that the latter is
- * indded the logarithm of `n`.
- *
- * @details It is crucial that `log_n` is constrained to be in range [1, virtual_log_n], as it forces the first `log_n`
- * entries of `padding_indicator_array` to be equal to 1 and the rest of the entries to be equal to 0. This implies that
- * `n` can be reconstructed by incrementing each entry in the array and taking their product.
- *
- * @tparam Fr
- * @tparam virtual_log_n
- * @param padding_indicator_array
- * @param n expected = 2^(log_n)
- */
-template <typename Fr, size_t virtual_log_n>
-static void constrain_log_circuit_size(const std::array<Fr, virtual_log_n>& padding_indicator_array, const Fr& n)
-{
-    Fr accumulated_circuit_size{ 1 };
-    for (auto& indicator : padding_indicator_array) {
-        accumulated_circuit_size *= indicator + Fr{ 1 };
-    };
+// /**
+//  * @brief Given a witness `n` and a padding indicator array computed from `log_n`, check in-circuit that the latter
+//  is
+//  * indded the logarithm of `n`.
+//  *
+//  * @details It is crucial that `log_n` is constrained to be in range [1, virtual_log_n], as it forces the first
+//  `log_n`
+//  * entries of `padding_indicator_array` to be equal to 1 and the rest of the entries to be equal to 0. This implies
+//  that
+//  * `n` can be reconstructed by incrementing each entry in the array and taking their product.
+//  *
+//  * @tparam Fr
+//  * @tparam virtual_log_n
+//  * @param padding_indicator_array
+//  * @param n expected = 2^(log_n)
+//  */
+// template <typename Fr, size_t virtual_log_n>
+// static void constrain_log_circuit_size(const std::array<Fr, virtual_log_n>& padding_indicator_array, const Fr& n)
+// {
+//     Fr accumulated_circuit_size{ 1 };
+//     for (auto& indicator : padding_indicator_array) {
+//         accumulated_circuit_size *= indicator + Fr{ 1 };
+//     };
 
-    n.assert_equal(accumulated_circuit_size);
-}
+//     n.assert_equal(accumulated_circuit_size);
+// }
 } // namespace bb::stdlib

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/padding_indicator_array/padding_indicator_array.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/padding_indicator_array/padding_indicator_array.hpp
@@ -80,31 +80,4 @@ static std::vector<typename Curve::ScalarField> compute_padding_indicator_array(
 
     return result;
 }
-
-// /**
-//  * @brief Given a witness `n` and a padding indicator array computed from `log_n`, check in-circuit that the latter
-//  is
-//  * indded the logarithm of `n`.
-//  *
-//  * @details It is crucial that `log_n` is constrained to be in range [1, virtual_log_n], as it forces the first
-//  `log_n`
-//  * entries of `padding_indicator_array` to be equal to 1 and the rest of the entries to be equal to 0. This implies
-//  that
-//  * `n` can be reconstructed by incrementing each entry in the array and taking their product.
-//  *
-//  * @tparam Fr
-//  * @tparam virtual_log_n
-//  * @param padding_indicator_array
-//  * @param n expected = 2^(log_n)
-//  */
-// template <typename Fr, size_t virtual_log_n>
-// static void constrain_log_circuit_size(const std::array<Fr, virtual_log_n>& padding_indicator_array, const Fr& n)
-// {
-//     Fr accumulated_circuit_size{ 1 };
-//     for (auto& indicator : padding_indicator_array) {
-//         accumulated_circuit_size *= indicator + Fr{ 1 };
-//     };
-
-//     n.assert_equal(accumulated_circuit_size);
-// }
 } // namespace bb::stdlib

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/padding_indicator_array/padding_indicator_array.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/padding_indicator_array/padding_indicator_array.test.cpp
@@ -37,10 +37,7 @@ template <typename Param> class PaddingIndicatorArrayTest : public testing::Test
             // Check that the sum of indicators is indeed x
             Fr sum_of_indicators = std::accumulate(result.begin(), result.end(), Fr{ 0 });
             EXPECT_TRUE((sum_of_indicators == x).get_value());
-            // Create a witness = 2^idx
-            Fr exponent = Fr::from_witness(&builder, 1 << idx);
-            // Using the indicator values, compute 2^idx in-circuit.
-            stdlib::constrain_log_circuit_size(result, exponent);
+
             // Check the correctness of the circuit
             EXPECT_TRUE(CircuitChecker::check(builder));
         }
@@ -96,12 +93,7 @@ template <typename Param> class PaddingIndicatorArrayTest : public testing::Test
             Fr x = Fr::from_witness(&builder, scalar_raw);
             auto result = compute_padding_indicator_array<Curve, domain_size>(x);
 
-            size_t gate_count = builder.get_estimated_num_finalized_gates();
-            // Create a witness = 2^(idx)
-            Fr exponent = Fr::from_witness(&builder, 1UL << scalar_raw);
-            // Using the indicator values, compute 2^idx in-circuit.
-            stdlib::constrain_log_circuit_size(result, exponent);
-            return gate_count;
+            return builder.get_estimated_num_finalized_gates();
         };
 
         // Valid input: x in [1, domain_size - 1]
@@ -113,30 +105,6 @@ template <typename Param> class PaddingIndicatorArrayTest : public testing::Test
         size_t gates_random = get_gate_count(random_scalar);
 
         EXPECT_EQ(gates_in_range, gates_random);
-    }
-
-    void test_log_constraint_failure()
-    {
-        for (size_t idx = 1; idx <= domain_size; idx++) {
-            Builder builder;
-            Fr x = Fr::from_witness(&builder, idx);
-
-            auto result = compute_padding_indicator_array<Curve, domain_size>(x);
-            EXPECT_TRUE(result[idx - 1].get_value() == 1);
-
-            info("num gates = ", builder.get_estimated_num_finalized_gates());
-            // Check that the sum of indicators is indeed x
-            Fr sum_of_indicators = std::accumulate(result.begin(), result.end(), Fr{ 0 });
-            EXPECT_TRUE((sum_of_indicators == x).get_value());
-            // Check the correctness of the circuit
-            EXPECT_TRUE(CircuitChecker::check(builder));
-            // Create a witness = 2^idx
-            Fr exponent = Fr::from_witness(&builder, (1 << idx) + 1);
-            // Using the indicator values, compute tampered "2^idx" in-circuit.
-            stdlib::constrain_log_circuit_size(result, exponent);
-            // Circuit check must fail as 2^(log_n) != n
-            EXPECT_FALSE(CircuitChecker::check(builder));
-        }
     }
 };
 
@@ -162,9 +130,5 @@ TYPED_TEST(PaddingIndicatorArrayTest, TestValueNotInrange)
 TYPED_TEST(PaddingIndicatorArrayTest, TestGateCountIndependence)
 {
     TestFixture::test_gate_count_independence();
-}
-TYPED_TEST(PaddingIndicatorArrayTest, TestLogConstraintFailure)
-{
-    TestFixture::test_log_constraint_failure();
 }
 } // namespace

--- a/barretenberg/cpp/src/barretenberg/stdlib/translator_vm_verifier/translator_recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/translator_vm_verifier/translator_recursive_verifier.cpp
@@ -91,7 +91,7 @@ TranslatorRecursiveVerifier::PairingPoints TranslatorRecursiveVerifier::verify_p
                                                                                      const BF& evaluation_input_x,
                                                                                      const BF& batching_challenge_v)
 {
-    using Sumcheck = ::bb::SumcheckVerifier<Flavor, TranslatorFlavor::CONST_TRANSLATOR_LOG_N>;
+    using Sumcheck = ::bb::SumcheckVerifier<Flavor>;
     using PCS = Flavor::PCS;
     using Curve = Flavor::Curve;
     using Shplemini = ::bb::ShpleminiVerifier_<Curve>;

--- a/barretenberg/cpp/src/barretenberg/stdlib/translator_vm_verifier/translator_recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/translator_vm_verifier/translator_recursive_verifier.cpp
@@ -140,7 +140,7 @@ TranslatorRecursiveVerifier::PairingPoints TranslatorRecursiveVerifier::verify_p
     //  i = 0, ..., NUM_SUBRELATIONS- 1.
     const FF alpha = transcript->template get_challenge<FF>("Sumcheck:alpha");
 
-    Sumcheck sumcheck(transcript, alpha);
+    Sumcheck sumcheck(transcript, alpha, TranslatorFlavor::CONST_TRANSLATOR_LOG_N);
 
     std::vector<FF> gate_challenges(TranslatorFlavor::CONST_TRANSLATOR_LOG_N);
     for (size_t idx = 0; idx < gate_challenges.size(); idx++) {
@@ -153,7 +153,7 @@ TranslatorRecursiveVerifier::PairingPoints TranslatorRecursiveVerifier::verify_p
     FF one{ 1 };
     one.convert_constant_to_fixed_witness(builder);
 
-    std::array<FF, TranslatorFlavor::CONST_TRANSLATOR_LOG_N> padding_indicator_array;
+    std::vector<FF> padding_indicator_array(TranslatorFlavor::CONST_TRANSLATOR_LOG_N);
     std::ranges::fill(padding_indicator_array, one);
 
     auto sumcheck_output = sumcheck.verify(relation_parameters, gate_challenges, padding_indicator_array);

--- a/barretenberg/cpp/src/barretenberg/sumcheck/partial_evaluation.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/sumcheck/partial_evaluation.test.cpp
@@ -66,7 +66,7 @@ TYPED_TEST(PartialEvaluationTests, TwoRoundsSpecial)
     SubrelationSeparators alpha{ 1 };
     std::vector<FF> gate_challenges{ 1, 1 };
 
-    SumcheckProver<Flavor, multivariate_d> sumcheck(
+    SumcheckProver<Flavor> sumcheck(
         multivariate_n, full_polynomials, transcript, alpha, gate_challenges, {}, multivariate_d);
 
     FF round_challenge_0 = { 0x6c7301b49d85a46c, 0x44311531e39c64f6, 0xb13d66d8d6c1a24c, 0x04410c360230a295 };
@@ -113,7 +113,7 @@ TYPED_TEST(PartialEvaluationTests, TwoRoundsGeneric)
     full_polynomials.q_m = f0;
     std::vector<FF> gate_challenges{ 1, 1 };
 
-    SumcheckProver<Flavor, multivariate_d> sumcheck(
+    SumcheckProver<Flavor> sumcheck(
         multivariate_n, full_polynomials, transcript, alpha, gate_challenges, {}, multivariate_d);
 
     FF round_challenge_0 = FF::random_element();
@@ -185,7 +185,7 @@ TYPED_TEST(PartialEvaluationTests, ThreeRoundsSpecial)
 
     std::vector<FF> gate_challenges{ 1, 1, 1 };
 
-    SumcheckProver<Flavor, multivariate_d> sumcheck(
+    SumcheckProver<Flavor> sumcheck(
         multivariate_n, full_polynomials, transcript, alpha, gate_challenges, {}, multivariate_d);
 
     FF round_challenge_0 = 1;
@@ -247,7 +247,7 @@ TYPED_TEST(PartialEvaluationTests, ThreeRoundsGeneric)
     SubrelationSeparators alpha{ 1 };
     std::vector<FF> gate_challenges{ 1, 1, 1 };
 
-    SumcheckProver<Flavor, multivariate_d> sumcheck(
+    SumcheckProver<Flavor> sumcheck(
         multivariate_n, full_polynomials, transcript, alpha, gate_challenges, {}, multivariate_d);
 
     FF round_challenge_0 = FF::random_element();
@@ -322,7 +322,7 @@ TYPED_TEST(PartialEvaluationTests, ThreeRoundsGenericMultiplePolys)
     SubrelationSeparators alpha{ 1 };
     std::vector<FF> gate_challenges{ 1, 1, 1 };
 
-    SumcheckProver<Flavor, multivariate_d> sumcheck(
+    SumcheckProver<Flavor> sumcheck(
         multivariate_n, full_polynomials, transcript, alpha, gate_challenges, {}, multivariate_d);
 
     std::array<FF, 3> expected_q1;

--- a/barretenberg/cpp/src/barretenberg/sumcheck/partial_evaluation.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/sumcheck/partial_evaluation.test.cpp
@@ -67,7 +67,7 @@ TYPED_TEST(PartialEvaluationTests, TwoRoundsSpecial)
     std::vector<FF> gate_challenges{ 1, 1 };
 
     SumcheckProver<Flavor, multivariate_d> sumcheck(
-        multivariate_n, full_polynomials, transcript, alpha, gate_challenges, {});
+        multivariate_n, full_polynomials, transcript, alpha, gate_challenges, {}, multivariate_d);
 
     FF round_challenge_0 = { 0x6c7301b49d85a46c, 0x44311531e39c64f6, 0xb13d66d8d6c1a24c, 0x04410c360230a295 };
     round_challenge_0.self_to_montgomery_form();
@@ -114,7 +114,7 @@ TYPED_TEST(PartialEvaluationTests, TwoRoundsGeneric)
     std::vector<FF> gate_challenges{ 1, 1 };
 
     SumcheckProver<Flavor, multivariate_d> sumcheck(
-        multivariate_n, full_polynomials, transcript, alpha, gate_challenges, {});
+        multivariate_n, full_polynomials, transcript, alpha, gate_challenges, {}, multivariate_d);
 
     FF round_challenge_0 = FF::random_element();
     FF expected_lo = v00 * (FF(1) - round_challenge_0) + v10 * round_challenge_0;
@@ -186,7 +186,7 @@ TYPED_TEST(PartialEvaluationTests, ThreeRoundsSpecial)
     std::vector<FF> gate_challenges{ 1, 1, 1 };
 
     SumcheckProver<Flavor, multivariate_d> sumcheck(
-        multivariate_n, full_polynomials, transcript, alpha, gate_challenges, {});
+        multivariate_n, full_polynomials, transcript, alpha, gate_challenges, {}, multivariate_d);
 
     FF round_challenge_0 = 1;
     FF expected_q1 = v000 * (FF(1) - round_challenge_0) + v100 * round_challenge_0; // 2
@@ -248,7 +248,7 @@ TYPED_TEST(PartialEvaluationTests, ThreeRoundsGeneric)
     std::vector<FF> gate_challenges{ 1, 1, 1 };
 
     SumcheckProver<Flavor, multivariate_d> sumcheck(
-        multivariate_n, full_polynomials, transcript, alpha, gate_challenges, {});
+        multivariate_n, full_polynomials, transcript, alpha, gate_challenges, {}, multivariate_d);
 
     FF round_challenge_0 = FF::random_element();
     FF expected_q1 = v000 * (FF(1) - round_challenge_0) + v100 * round_challenge_0;
@@ -323,7 +323,7 @@ TYPED_TEST(PartialEvaluationTests, ThreeRoundsGenericMultiplePolys)
     std::vector<FF> gate_challenges{ 1, 1, 1 };
 
     SumcheckProver<Flavor, multivariate_d> sumcheck(
-        multivariate_n, full_polynomials, transcript, alpha, gate_challenges, {});
+        multivariate_n, full_polynomials, transcript, alpha, gate_challenges, {}, multivariate_d);
 
     std::array<FF, 3> expected_q1;
     std::array<FF, 3> expected_q2;

--- a/barretenberg/cpp/src/barretenberg/sumcheck/sumcheck.hpp
+++ b/barretenberg/cpp/src/barretenberg/sumcheck/sumcheck.hpp
@@ -162,7 +162,8 @@ template <typename Flavor> class SumcheckProver {
     // Contains various challenges, such as `beta` and `gamma` used in the Grand Product argument.
     bb::RelationParameters<FF> relation_parameters;
 
-    size_t real_log_n;
+    // Determines the number of rounds in the sumcheck (may include padding rounds, i.e. >= multivariate_d).
+    size_t virtual_log_n;
 
     std::vector<FF> multivariate_challenge;
 
@@ -192,7 +193,7 @@ template <typename Flavor> class SumcheckProver {
                    const SubrelationSeparators& relation_separator,
                    const std::vector<FF>& gate_challenges,
                    const RelationParameters<FF>& relation_parameters,
-                   const size_t real_log_n)
+                   const size_t virtual_log_n)
         : multivariate_n(multivariate_n)
         , multivariate_d(numeric::get_msb(multivariate_n))
         , full_polynomials(prover_polynomials)
@@ -201,7 +202,7 @@ template <typename Flavor> class SumcheckProver {
         , alphas(relation_separator)
         , gate_challenges(gate_challenges)
         , relation_parameters(relation_parameters)
-        , real_log_n(real_log_n){};
+        , virtual_log_n(virtual_log_n){};
 
     // SumcheckProver constructor for the Flavors that generate a single challeng `alpha` and use its powers as
     // subrelation seperator challenges.
@@ -211,7 +212,7 @@ template <typename Flavor> class SumcheckProver {
                    const FF& alpha,
                    const std::vector<FF>& gate_challenges,
                    const RelationParameters<FF>& relation_parameters,
-                   const size_t real_log_n)
+                   const size_t virtual_log_n)
         : multivariate_n(multivariate_n)
         , multivariate_d(numeric::get_msb(multivariate_n))
         , full_polynomials(prover_polynomials)
@@ -220,7 +221,7 @@ template <typename Flavor> class SumcheckProver {
         , alphas(initialize_relation_separator<FF, Flavor::NUM_SUBRELATIONS - 1>(alpha))
         , gate_challenges(gate_challenges)
         , relation_parameters(relation_parameters)
-        , real_log_n(real_log_n){};
+        , virtual_log_n(virtual_log_n){};
     /**
      * @brief Non-ZK version: Compute round univariate, place it in transcript, compute challenge, partially evaluate.
      * Repeat until final round, then get full evaluations of prover polynomials, and place them in transcript.
@@ -234,7 +235,7 @@ template <typename Flavor> class SumcheckProver {
         // on the boolean hypercube.
         GateSeparatorPolynomial<FF> gate_separators(gate_challenges, multivariate_d);
 
-        multivariate_challenge.reserve(real_log_n);
+        multivariate_challenge.reserve(virtual_log_n);
         // In the first round, we compute the first univariate polynomial and populate the book-keeping table of
         // #partially_evaluated_polynomials, which has \f$ n/2 \f$ rows and \f$ N \f$ columns.
         auto round_univariate =
@@ -275,9 +276,9 @@ template <typename Flavor> class SumcheckProver {
         }
         vinfo("completed ", multivariate_d, " rounds of sumcheck");
 
-        // Zero univariates are used to pad the proof to the fixed size real_log_n.
+        // Zero univariates are used to pad the proof to the fixed size virtual_log_n.
         auto zero_univariate = bb::Univariate<FF, Flavor::BATCHED_RELATION_PARTIAL_LENGTH>::zero();
-        for (size_t idx = multivariate_d; idx < real_log_n; idx++) {
+        for (size_t idx = multivariate_d; idx < virtual_log_n; idx++) {
             transcript->send_to_verifier("Sumcheck:univariate_" + std::to_string(idx), zero_univariate);
             FF round_challenge = transcript->template get_challenge<FF>("Sumcheck:u_" + std::to_string(idx));
             multivariate_challenge.emplace_back(round_challenge);
@@ -412,9 +413,9 @@ template <typename Flavor> class SumcheckProver {
         }
         vinfo("completed ", multivariate_d, " rounds of sumcheck");
 
-        // Zero univariates are used to pad the proof to the fixed size real_log_n.
+        // Zero univariates are used to pad the proof to the fixed size virtual_log_n.
         auto zero_univariate = bb::Univariate<FF, Flavor::BATCHED_RELATION_PARTIAL_LENGTH>::zero();
-        for (size_t idx = multivariate_d; idx < real_log_n; idx++) {
+        for (size_t idx = multivariate_d; idx < virtual_log_n; idx++) {
             transcript->send_to_verifier("Sumcheck:univariate_" + std::to_string(idx), zero_univariate);
 
             FF round_challenge = transcript->template get_challenge<FF>("Sumcheck:u_" + std::to_string(idx));
@@ -658,7 +659,8 @@ template <typename Flavor> class SumcheckVerifier {
     std::shared_ptr<Transcript> transcript;
     SumcheckVerifierRound<Flavor> round;
 
-    size_t real_log_n;
+    // Determines number of rounds in the sumcheck (may include padding rounds)
+    size_t virtual_log_n;
 
     // An array of size NUM_SUBRELATIONS-1 containing challenges or consecutive powers of a single challenge that
     // separate linearly independent subrelation.
@@ -674,20 +676,20 @@ template <typename Flavor> class SumcheckVerifier {
 
     explicit SumcheckVerifier(std::shared_ptr<Transcript> transcript,
                               SubrelationSeparators& relation_separator,
-                              size_t real_log_n,
+                              size_t virtual_log_n,
                               FF target_sum = 0)
         : transcript(std::move(transcript))
         , round(target_sum)
-        , real_log_n(real_log_n)
+        , virtual_log_n(virtual_log_n)
         , alphas(relation_separator){};
 
     explicit SumcheckVerifier(std::shared_ptr<Transcript> transcript,
                               const FF& alpha,
-                              size_t real_log_n,
+                              size_t virtual_log_n,
                               FF target_sum = 0)
         : transcript(std::move(transcript))
         , round(target_sum)
-        , real_log_n(real_log_n)
+        , virtual_log_n(virtual_log_n)
         , alphas(initialize_relation_separator<FF, Flavor::NUM_SUBRELATIONS - 1>(alpha)){};
     /**
      * @brief Extract round univariate, check sum, generate challenge, compute next target sum..., repeat until
@@ -725,8 +727,8 @@ template <typename Flavor> class SumcheckVerifier {
         }
 
         std::vector<FF> multivariate_challenge;
-        multivariate_challenge.reserve(real_log_n);
-        for (size_t round_idx = 0; round_idx < real_log_n; round_idx++) {
+        multivariate_challenge.reserve(virtual_log_n);
+        for (size_t round_idx = 0; round_idx < virtual_log_n; round_idx++) {
             // Obtain the round univariate from the transcript
             std::string round_univariate_label = "Sumcheck:univariate_" + std::to_string(round_idx);
             round_univariate =
@@ -818,12 +820,12 @@ template <typename Flavor> class SumcheckVerifier {
         const FF libra_challenge = transcript->template get_challenge<FF>("Libra:Challenge");
 
         std::vector<FF> multivariate_challenge;
-        multivariate_challenge.reserve(real_log_n);
+        multivariate_challenge.reserve(virtual_log_n);
         // if Flavor has ZK, the target total sum is corrected by Libra total sum multiplied by the Libra
         // challenge
         round.target_total_sum = libra_total_sum * libra_challenge;
 
-        for (size_t round_idx = 0; round_idx < real_log_n; round_idx++) {
+        for (size_t round_idx = 0; round_idx < virtual_log_n; round_idx++) {
             // Obtain the round univariate from the transcript
             const std::string round_univariate_comm_label = "Sumcheck:univariate_comm_" + std::to_string(round_idx);
             const std::string univariate_eval_label_0 = "Sumcheck:univariate_" + std::to_string(round_idx) + "_eval_0";
@@ -863,7 +865,7 @@ template <typename Flavor> class SumcheckVerifier {
         // Compute the evaluations of the polynomial (1 - \sum L_i) where the sum is for i corresponding to the rows
         // where all sumcheck relations are disabled
         full_honk_purported_value *=
-            RowDisablingPolynomial<FF>::evaluate_at_challenge(multivariate_challenge, real_log_n);
+            RowDisablingPolynomial<FF>::evaluate_at_challenge(multivariate_challenge, virtual_log_n);
 
         // Extract claimed evaluations of Libra univariates and compute their sum multiplied by the Libra challenge
         const FF libra_evaluation = transcript->template receive_from_prover<FF>("Libra:claimed_evaluation");
@@ -873,7 +875,7 @@ template <typename Flavor> class SumcheckVerifier {
 
         // Populate claimed evaluations of Sumcheck Round Univariates at the round challenges. These will be
         // checked as a part of Shplemini.
-        for (size_t round_idx = 1; round_idx < real_log_n; round_idx++) {
+        for (size_t round_idx = 1; round_idx < virtual_log_n; round_idx++) {
             round_univariate_evaluations[round_idx - 1][2] =
                 round_univariate_evaluations[round_idx][0] + round_univariate_evaluations[round_idx][1];
         };
@@ -898,7 +900,7 @@ template <typename Flavor> class SumcheckVerifier {
             verified = (first_sumcheck_round_evaluations_sum == round.target_total_sum);
         }
 
-        round_univariate_evaluations[real_log_n - 1][2] = full_honk_purported_value;
+        round_univariate_evaluations[virtual_log_n - 1][2] = full_honk_purported_value;
 
         //! [Final Verification Step]
         // For ZK Flavors: the evaluations of Libra univariates are included in the Sumcheck Output

--- a/barretenberg/cpp/src/barretenberg/sumcheck/sumcheck.hpp
+++ b/barretenberg/cpp/src/barretenberg/sumcheck/sumcheck.hpp
@@ -120,7 +120,7 @@ transcript. These operations are taken care of by \ref bb::BaseTranscript "Trans
 ## Output
 The Sumcheck output is specified by \ref bb::SumcheckOutput< Flavor >.
  */
-template <typename Flavor, const size_t virtual_log_n = CONST_PROOF_SIZE_LOG_N> class SumcheckProver {
+template <typename Flavor> class SumcheckProver {
   public:
     using FF = typename Flavor::FF;
     // PartiallyEvaluatedMultivariates OR ProverPolynomials
@@ -626,7 +626,7 @@ u_{d-1})\right)\f}
   \snippet cpp/src/barretenberg/sumcheck/sumcheck.hpp Final Verification Step
 
  */
-template <typename Flavor, size_t virtual_log_n = CONST_PROOF_SIZE_LOG_N> class SumcheckVerifier {
+template <typename Flavor> class SumcheckVerifier {
 
   public:
     using Utils = bb::RelationUtils<Flavor>;

--- a/barretenberg/cpp/src/barretenberg/sumcheck/sumcheck.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/sumcheck/sumcheck.test.cpp
@@ -66,7 +66,8 @@ template <typename Flavor> class SumcheckTests : public ::testing::Test {
                 transcript->template get_challenge<FF>("Sumcheck:gate_challenge_" + std::to_string(idx));
         }
 
-        SumcheckProver<Flavor> sumcheck(multivariate_n, full_polynomials, transcript, alpha, gate_challenges, {});
+        SumcheckProver<Flavor> sumcheck(
+            multivariate_n, full_polynomials, transcript, alpha, gate_challenges, {}, CONST_PROOF_SIZE_LOG_N);
 
         auto output = sumcheck.prove();
 
@@ -142,7 +143,8 @@ template <typename Flavor> class SumcheckTests : public ::testing::Test {
                 transcript->template get_challenge<FF>("Sumcheck:gate_challenge_" + std::to_string(idx));
         }
 
-        SumcheckProver<Flavor> sumcheck(multivariate_n, full_polynomials, transcript, alpha, gate_challenges, {});
+        SumcheckProver<Flavor> sumcheck(
+            multivariate_n, full_polynomials, transcript, alpha, gate_challenges, {}, CONST_PROOF_SIZE_LOG_N);
 
         SumcheckOutput<Flavor> output;
 
@@ -261,7 +263,8 @@ template <typename Flavor> class SumcheckTests : public ::testing::Test {
                                                                prover_transcript,
                                                                prover_alpha,
                                                                prover_gate_challenges,
-                                                               relation_parameters);
+                                                               relation_parameters,
+                                                               multivariate_d);
 
         SumcheckOutput<Flavor> output;
         if constexpr (Flavor::HasZK) {
@@ -278,14 +281,15 @@ template <typename Flavor> class SumcheckTests : public ::testing::Test {
             verifier_alpha[idx] =
                 verifier_transcript->template get_challenge<FF>("Sumcheck:alpha_" + std::to_string(idx));
         }
-        auto sumcheck_verifier = SumcheckVerifier<Flavor, multivariate_d>(verifier_transcript, verifier_alpha);
+        auto sumcheck_verifier =
+            SumcheckVerifier<Flavor, multivariate_d>(verifier_transcript, verifier_alpha, multivariate_d);
 
         std::vector<FF> verifier_gate_challenges(multivariate_d);
         for (size_t idx = 0; idx < multivariate_d; idx++) {
             verifier_gate_challenges[idx] =
                 verifier_transcript->template get_challenge<FF>("Sumcheck:gate_challenge_" + std::to_string(idx));
         }
-        std::array<FF, multivariate_d> padding_indicator_array;
+        std::vector<FF> padding_indicator_array(multivariate_d);
         std::ranges::fill(padding_indicator_array, FF{ 1 });
         auto verifier_output =
             sumcheck_verifier.verify(relation_parameters, verifier_gate_challenges, padding_indicator_array);
@@ -359,7 +363,8 @@ template <typename Flavor> class SumcheckTests : public ::testing::Test {
                                                                prover_transcript,
                                                                prover_alpha,
                                                                prover_gate_challenges,
-                                                               relation_parameters);
+                                                               relation_parameters,
+                                                               multivariate_d);
 
         SumcheckOutput<Flavor> output;
         if constexpr (Flavor::HasZK) {
@@ -377,7 +382,7 @@ template <typename Flavor> class SumcheckTests : public ::testing::Test {
             verifier_alpha[idx] =
                 verifier_transcript->template get_challenge<FF>("Sumcheck:alpha_" + std::to_string(idx));
         }
-        SumcheckVerifier<Flavor, multivariate_d> sumcheck_verifier(verifier_transcript, verifier_alpha);
+        SumcheckVerifier<Flavor, multivariate_d> sumcheck_verifier(verifier_transcript, verifier_alpha, multivariate_d);
 
         std::vector<FF> verifier_gate_challenges(multivariate_d);
         for (size_t idx = 0; idx < multivariate_d; idx++) {
@@ -385,7 +390,7 @@ template <typename Flavor> class SumcheckTests : public ::testing::Test {
                 verifier_transcript->template get_challenge<FF>("Sumcheck:gate_challenge_" + std::to_string(idx));
         }
 
-        std::array<FF, multivariate_d> padding_indicator_array;
+        std::vector<FF> padding_indicator_array(multivariate_d);
         std::ranges::fill(padding_indicator_array, FF{ 1 });
         auto verifier_output =
             sumcheck_verifier.verify(relation_parameters, verifier_gate_challenges, padding_indicator_array);

--- a/barretenberg/cpp/src/barretenberg/sumcheck/sumcheck.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/sumcheck/sumcheck.test.cpp
@@ -258,13 +258,13 @@ template <typename Flavor> class SumcheckTests : public ::testing::Test {
                 prover_transcript->template get_challenge<FF>("Sumcheck:gate_challenge_" + std::to_string(idx));
         }
 
-        SumcheckProver<Flavor, multivariate_d> sumcheck_prover(multivariate_n,
-                                                               full_polynomials,
-                                                               prover_transcript,
-                                                               prover_alpha,
-                                                               prover_gate_challenges,
-                                                               relation_parameters,
-                                                               multivariate_d);
+        SumcheckProver<Flavor> sumcheck_prover(multivariate_n,
+                                               full_polynomials,
+                                               prover_transcript,
+                                               prover_alpha,
+                                               prover_gate_challenges,
+                                               relation_parameters,
+                                               multivariate_d);
 
         SumcheckOutput<Flavor> output;
         if constexpr (Flavor::HasZK) {
@@ -281,8 +281,7 @@ template <typename Flavor> class SumcheckTests : public ::testing::Test {
             verifier_alpha[idx] =
                 verifier_transcript->template get_challenge<FF>("Sumcheck:alpha_" + std::to_string(idx));
         }
-        auto sumcheck_verifier =
-            SumcheckVerifier<Flavor, multivariate_d>(verifier_transcript, verifier_alpha, multivariate_d);
+        auto sumcheck_verifier = SumcheckVerifier<Flavor>(verifier_transcript, verifier_alpha, multivariate_d);
 
         std::vector<FF> verifier_gate_challenges(multivariate_d);
         for (size_t idx = 0; idx < multivariate_d; idx++) {
@@ -358,13 +357,13 @@ template <typename Flavor> class SumcheckTests : public ::testing::Test {
                 prover_transcript->template get_challenge<FF>("Sumcheck:gate_challenge_" + std::to_string(idx));
         }
 
-        SumcheckProver<Flavor, multivariate_d> sumcheck_prover(multivariate_n,
-                                                               full_polynomials,
-                                                               prover_transcript,
-                                                               prover_alpha,
-                                                               prover_gate_challenges,
-                                                               relation_parameters,
-                                                               multivariate_d);
+        SumcheckProver<Flavor> sumcheck_prover(multivariate_n,
+                                               full_polynomials,
+                                               prover_transcript,
+                                               prover_alpha,
+                                               prover_gate_challenges,
+                                               relation_parameters,
+                                               multivariate_d);
 
         SumcheckOutput<Flavor> output;
         if constexpr (Flavor::HasZK) {
@@ -382,7 +381,7 @@ template <typename Flavor> class SumcheckTests : public ::testing::Test {
             verifier_alpha[idx] =
                 verifier_transcript->template get_challenge<FF>("Sumcheck:alpha_" + std::to_string(idx));
         }
-        SumcheckVerifier<Flavor, multivariate_d> sumcheck_verifier(verifier_transcript, verifier_alpha, multivariate_d);
+        SumcheckVerifier<Flavor> sumcheck_verifier(verifier_transcript, verifier_alpha, multivariate_d);
 
         std::vector<FF> verifier_gate_challenges(multivariate_d);
         for (size_t idx = 0; idx < multivariate_d; idx++) {

--- a/barretenberg/cpp/src/barretenberg/translator_vm/translator_prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/translator_prover.cpp
@@ -150,8 +150,13 @@ void TranslatorProver::execute_relation_check_rounds()
 
     const size_t circuit_size = key->proving_key->circuit_size;
 
-    Sumcheck sumcheck(
-        circuit_size, key->proving_key->polynomials, transcript, alpha, gate_challenges, relation_parameters);
+    Sumcheck sumcheck(circuit_size,
+                      key->proving_key->polynomials,
+                      transcript,
+                      alpha,
+                      gate_challenges,
+                      relation_parameters,
+                      Flavor::CONST_TRANSLATOR_LOG_N);
 
     const size_t log_subgroup_size = static_cast<size_t>(numeric::get_msb(Flavor::Curve::SUBGROUP_SIZE));
     // Create a temporary commitment key that is only used to initialise the ZKSumcheckData

--- a/barretenberg/cpp/src/barretenberg/translator_vm/translator_prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/translator_prover.cpp
@@ -137,7 +137,7 @@ void TranslatorProver::execute_grand_product_computation_round()
  */
 void TranslatorProver::execute_relation_check_rounds()
 {
-    using Sumcheck = SumcheckProver<Flavor, Flavor::CONST_TRANSLATOR_LOG_N>;
+    using Sumcheck = SumcheckProver<Flavor>;
 
     // Each linearly independent subrelation contribution is multiplied by `alpha^i`, where
     //  i = 0, ..., NUM_SUBRELATIONS- 1.

--- a/barretenberg/cpp/src/barretenberg/translator_vm/translator_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/translator_verifier.cpp
@@ -67,7 +67,7 @@ bool TranslatorVerifier::verify_proof(const HonkProof& proof,
     using ClaimBatcher = ClaimBatcher_<Curve>;
     using ClaimBatch = ClaimBatcher::Batch;
     using InterleavedBatch = ClaimBatcher::InterleavedBatch;
-    using Sumcheck = SumcheckVerifier<Flavor, Flavor::CONST_TRANSLATOR_LOG_N>;
+    using Sumcheck = SumcheckVerifier<Flavor>;
     using VerifierCommitmentKey = typename Flavor::VerifierCommitmentKey;
 
     // Load the proof produced by the translator prover

--- a/barretenberg/cpp/src/barretenberg/translator_vm/translator_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/translator_verifier.cpp
@@ -107,7 +107,7 @@ bool TranslatorVerifier::verify_proof(const HonkProof& proof,
     const FF alpha = transcript->template get_challenge<FF>("Sumcheck:alpha");
 
     // Execute Sumcheck Verifier
-    Sumcheck sumcheck(transcript, alpha);
+    Sumcheck sumcheck(transcript, alpha, Flavor::CONST_TRANSLATOR_LOG_N);
 
     std::vector<FF> gate_challenges(Flavor::CONST_TRANSLATOR_LOG_N);
     for (size_t idx = 0; idx < gate_challenges.size(); idx++) {
@@ -118,7 +118,7 @@ bool TranslatorVerifier::verify_proof(const HonkProof& proof,
     std::array<Commitment, NUM_LIBRA_COMMITMENTS> libra_commitments = {};
     libra_commitments[0] = transcript->template receive_from_prover<Commitment>("Libra:concatenation_commitment");
 
-    std::array<FF, TranslatorFlavor::CONST_TRANSLATOR_LOG_N> padding_indicator_array;
+    std::vector<FF> padding_indicator_array(Flavor::CONST_TRANSLATOR_LOG_N);
     std::ranges::fill(padding_indicator_array, FF{ 1 });
 
     auto sumcheck_output = sumcheck.verify(relation_parameters, gate_challenges, padding_indicator_array);

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/decider_prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/decider_prover.cpp
@@ -40,7 +40,8 @@ template <IsUltraOrMegaHonk Flavor> void DeciderProver_<Flavor>::execute_relatio
                       transcript,
                       proving_key->alphas,
                       proving_key->gate_challenges,
-                      proving_key->relation_parameters);
+                      proving_key->relation_parameters,
+                      CONST_PROOF_SIZE_LOG_N);
     {
 
         PROFILE_THIS_NAME("sumcheck.prove");

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/decider_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/decider_verifier.cpp
@@ -48,13 +48,13 @@ template <typename Flavor> typename DeciderVerifier_<Flavor>::Output DeciderVeri
 
     const size_t log_circuit_size = static_cast<size_t>(accumulator->vk->log_circuit_size);
 
-    std::array<FF, CONST_PROOF_SIZE_LOG_N> padding_indicator_array;
+    std::vector<FF> padding_indicator_array(CONST_PROOF_SIZE_LOG_N);
 
     for (size_t idx = 0; idx < CONST_PROOF_SIZE_LOG_N; idx++) {
         padding_indicator_array[idx] = (idx < log_circuit_size) ? FF{ 1 } : FF{ 0 };
     }
 
-    SumcheckVerifier<Flavor> sumcheck(transcript, accumulator->alphas, accumulator->target_sum);
+    SumcheckVerifier<Flavor> sumcheck(transcript, accumulator->alphas, CONST_PROOF_SIZE_LOG_N, accumulator->target_sum);
     // For MegaZKFlavor: receive commitments to Libra masking polynomials
     std::array<Commitment, NUM_LIBRA_COMMITMENTS> libra_commitments = {};
     if constexpr (Flavor::HasZK) {

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/sumcheck.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/sumcheck.test.cpp
@@ -173,7 +173,8 @@ TEST_F(SumcheckTestsRealCircuit, Ultra)
                                            prover_transcript,
                                            prover_alphas,
                                            prover_gate_challenges,
-                                           decider_pk->relation_parameters);
+                                           decider_pk->relation_parameters,
+                                           CONST_PROOF_SIZE_LOG_N);
 
     auto prover_output = sumcheck_prover.prove();
 
@@ -183,14 +184,14 @@ TEST_F(SumcheckTestsRealCircuit, Ultra)
     for (size_t idx = 0; idx < verifier_alphas.size(); idx++) {
         verifier_alphas[idx] = verifier_transcript->template get_challenge<FF>("Sumcheck:alpha_" + std::to_string(idx));
     }
-    SumcheckVerifier<Flavor> sumcheck_verifier(verifier_transcript, verifier_alphas);
+    SumcheckVerifier<Flavor> sumcheck_verifier(verifier_transcript, verifier_alphas, CONST_PROOF_SIZE_LOG_N);
 
     std::vector<FF> verifier_gate_challenges(log_circuit_size);
     for (size_t idx = 0; idx < log_circuit_size; idx++) {
         verifier_gate_challenges[idx] =
             verifier_transcript->template get_challenge<FF>("Sumcheck:gate_challenge_" + std::to_string(idx));
     }
-    std::array<FF, CONST_PROOF_SIZE_LOG_N> padding_indicator_array;
+    std::vector<FF> padding_indicator_array(CONST_PROOF_SIZE_LOG_N);
     for (size_t idx = 0; idx < padding_indicator_array.size(); idx++) {
         padding_indicator_array[idx] = (idx < log_circuit_size) ? FF{ 1 } : FF{ 0 };
     }

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/prover.cpp
@@ -106,7 +106,13 @@ void AvmProver::execute_relation_check_rounds()
         gate_challenges[idx] = transcript->template get_challenge<FF>("Sumcheck:gate_challenge_" + std::to_string(idx));
     }
 
-    Sumcheck sumcheck(key->circuit_size, prover_polynomials, transcript, alpha, gate_challenges, relation_parameters);
+    Sumcheck sumcheck(key->circuit_size,
+                      prover_polynomials,
+                      transcript,
+                      alpha,
+                      gate_challenges,
+                      relation_parameters,
+                      CONST_PROOF_SIZE_LOG_N);
 
     sumcheck_output = sumcheck.prove();
 }

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/recursion/recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/recursion/recursive_verifier.cpp
@@ -121,7 +121,7 @@ AvmRecursiveVerifier::PairingPoints AvmRecursiveVerifier::verify_proof(
     // Multiply each linearly independent subrelation contribution by `alpha^i` for i = 0, ..., NUM_SUBRELATIONS - 1.
     const FF alpha = transcript->template get_challenge<FF>("Sumcheck:alpha");
 
-    SumcheckVerifier<Flavor> sumcheck(transcript, alpha);
+    SumcheckVerifier<Flavor> sumcheck(transcript, alpha, CONST_PROOF_SIZE_LOG_N);
 
     auto gate_challenges = std::vector<FF>(log_circuit_size);
     for (size_t idx = 0; idx < log_circuit_size; idx++) {

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/verifier.cpp
@@ -81,7 +81,7 @@ bool AvmVerifier::verify_proof(const HonkProof& proof, const std::vector<std::ve
     // Execute Sumcheck Verifier
     const size_t log_circuit_size = numeric::get_msb(circuit_size);
 
-    std::array<FF, CONST_PROOF_SIZE_LOG_N> padding_indicator_array;
+    std::vector<FF> padding_indicator_array(CONST_PROOF_SIZE_LOG_N);
 
     for (size_t idx = 0; idx < CONST_PROOF_SIZE_LOG_N; idx++) {
         padding_indicator_array[idx] = (idx < log_circuit_size) ? FF{ 1 } : FF{ 0 };

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/verifier.cpp
@@ -90,7 +90,7 @@ bool AvmVerifier::verify_proof(const HonkProof& proof, const std::vector<std::ve
     // Multiply each linearly independent subrelation contribution by `alpha^i` for i = 0, ..., NUM_SUBRELATIONS - 1.
     const FF alpha = transcript->template get_challenge<FF>("Sumcheck:alpha");
 
-    SumcheckVerifier<Flavor> sumcheck(transcript, alpha);
+    SumcheckVerifier<Flavor> sumcheck(transcript, alpha, CONST_PROOF_SIZE_LOG_N);
 
     auto gate_challenges = std::vector<FF>(log_circuit_size);
     for (size_t idx = 0; idx < log_circuit_size; idx++) {


### PR DESCRIPTION
Set `virtual_log_n` in sumcheck based on an input parameter rather than a template parameter. This allows setting the value at runtime (i.e. when the value is not known at compile time) which is useful for removing the padding rounds from the solidity verifier.