### PR TITLE
chore: Introduce `GoblinAvmIO` and add templated version of `verify_proof` to `UltraRecursiveVerifier` 

### DIFF
--- a/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.cpp
+++ b/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.cpp
@@ -148,7 +148,7 @@ std::pair<ClientIVC::PairingPoints, ClientIVC::TableCommitments> ClientIVC::
         public_inputs = std::move(verifier.public_inputs);
 
         // T_prev = 0 in the first recursive verification
-        merge_commitments.T_prev_commitments = HidingKernelIO::empty_ecc_op_tables(circuit);
+        merge_commitments.T_prev_commitments = stdlib::recursion::honk::empty_ecc_op_tables(circuit);
 
         break;
     }

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_format.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_format.cpp
@@ -421,24 +421,22 @@ process_honk_recursion_constraints(Builder& builder,
     size_t idx = 0;
     for (auto& constraint : constraint_system.honk_recursion_constraints) {
         if (constraint.proof_type == HONK_ZK) {
-            auto [pairing_points, _ipa_claim, _ipa_proof, _ecc_op_tables] =
-                create_honk_recursion_constraints<UltraZKRecursiveFlavor_<Builder>>(
-                    builder, constraint, has_valid_witness_assignments);
+            auto honk_recursion_constraint = create_honk_recursion_constraints<UltraZKRecursiveFlavor_<Builder>>(
+                builder, constraint, has_valid_witness_assignments);
 
             if (output.points_accumulator.has_data) {
-                output.points_accumulator.aggregate(pairing_points);
+                output.points_accumulator.aggregate(honk_recursion_constraint.pairing_points);
             } else {
-                output.points_accumulator = pairing_points;
+                output.points_accumulator = honk_recursion_constraint.pairing_points;
             }
 
         } else if (constraint.proof_type == HONK) {
-            auto [pairing_points, _ipa_claim, _ipa_proof, _ecc_op_tables] =
-                create_honk_recursion_constraints<UltraRecursiveFlavor_<Builder>>(
-                    builder, constraint, has_valid_witness_assignments);
+            auto honk_recursion_constraint = create_honk_recursion_constraints<UltraRecursiveFlavor_<Builder>>(
+                builder, constraint, has_valid_witness_assignments);
             if (output.points_accumulator.has_data) {
-                output.points_accumulator.aggregate(pairing_points);
+                output.points_accumulator.aggregate(honk_recursion_constraintpairing_points);
             } else {
-                output.points_accumulator = pairing_points;
+                output.points_accumulator = honk_recursion_constraint.pairing_points;
             }
         } else if (constraint.proof_type == ROLLUP_HONK || constraint.proof_type == ROOT_ROLLUP_HONK) {
             if constexpr (!IsUltraBuilder<Builder>) {
@@ -447,16 +445,16 @@ process_honk_recursion_constraints(Builder& builder,
                 if (constraint.proof_type == ROOT_ROLLUP_HONK) {
                     output.is_root_rollup = true;
                 }
-                auto [pairing_points, ipa_claim, ipa_proof, _ecc_op_tables] =
+                auto honk_recursion_constraint =
                     create_honk_recursion_constraints<UltraRollupRecursiveFlavor_<Builder>>(
                         builder, constraint, has_valid_witness_assignments);
                 if (output.points_accumulator.has_data) {
-                    output.points_accumulator.aggregate(pairing_points);
+                    output.points_accumulator.aggregate(honk_recursion_constraint.pairing_points);
                 } else {
-                    output.points_accumulator = pairing_points;
+                    output.points_accumulator = honk_recursion_constraint.pairing_points;
                 }
-                output.nested_ipa_claims.push_back(ipa_claim);
-                output.nested_ipa_proofs.push_back(ipa_proof);
+                output.nested_ipa_claims.push_back(honk_recursion_constraint.ipa_claim);
+                output.nested_ipa_proofs.push_back(honk_recursion_constraint.ipa_proof);
             }
         } else {
             throw_or_abort("Invalid Honk proof type");

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_format.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_format.cpp
@@ -425,18 +425,18 @@ process_honk_recursion_constraints(Builder& builder,
                 builder, constraint, has_valid_witness_assignments);
 
             if (output.points_accumulator.has_data) {
-                output.points_accumulator.aggregate(honk_recursion_constraint.pairing_points);
+                output.points_accumulator.aggregate(honk_recursion_constraint.points_accumulator);
             } else {
-                output.points_accumulator = honk_recursion_constraint.pairing_points;
+                output.points_accumulator = honk_recursion_constraint.points_accumulator;
             }
 
         } else if (constraint.proof_type == HONK) {
             auto honk_recursion_constraint = create_honk_recursion_constraints<UltraRecursiveFlavor_<Builder>>(
                 builder, constraint, has_valid_witness_assignments);
             if (output.points_accumulator.has_data) {
-                output.points_accumulator.aggregate(honk_recursion_constraint.pairing_points);
+                output.points_accumulator.aggregate(honk_recursion_constraint.points_accumulator);
             } else {
-                output.points_accumulator = honk_recursion_constraint.pairing_points;
+                output.points_accumulator = honk_recursion_constraint.points_accumulator;
             }
         } else if (constraint.proof_type == ROLLUP_HONK || constraint.proof_type == ROOT_ROLLUP_HONK) {
             if constexpr (!IsUltraBuilder<Builder>) {
@@ -449,9 +449,9 @@ process_honk_recursion_constraints(Builder& builder,
                     create_honk_recursion_constraints<UltraRollupRecursiveFlavor_<Builder>>(
                         builder, constraint, has_valid_witness_assignments);
                 if (output.points_accumulator.has_data) {
-                    output.points_accumulator.aggregate(honk_recursion_constraint.pairing_points);
+                    output.points_accumulator.aggregate(honk_recursion_constraint.points_accumulator);
                 } else {
-                    output.points_accumulator = honk_recursion_constraint.pairing_points;
+                    output.points_accumulator = honk_recursion_constraint.points_accumulator;
                 }
                 output.nested_ipa_claims.push_back(honk_recursion_constraint.ipa_claim);
                 output.nested_ipa_proofs.push_back(honk_recursion_constraint.ipa_proof);

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_format.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_format.cpp
@@ -434,7 +434,7 @@ process_honk_recursion_constraints(Builder& builder,
             auto honk_recursion_constraint = create_honk_recursion_constraints<UltraRecursiveFlavor_<Builder>>(
                 builder, constraint, has_valid_witness_assignments);
             if (output.points_accumulator.has_data) {
-                output.points_accumulator.aggregate(honk_recursion_constraintpairing_points);
+                output.points_accumulator.aggregate(honk_recursion_constraint.pairing_points);
             } else {
                 output.points_accumulator = honk_recursion_constraint.pairing_points;
             }

--- a/barretenberg/cpp/src/barretenberg/honk/types/public_inputs_type.hpp
+++ b/barretenberg/cpp/src/barretenberg/honk/types/public_inputs_type.hpp
@@ -67,4 +67,7 @@ static constexpr std::size_t HIDING_KERNEL_PUBLIC_INPUTS_SIZE =
 static constexpr std::size_t ROLLUP_PUBLIC_INPUTS_SIZE =
     /*pairing_inputs*/ PAIRING_POINTS_SIZE + /*ipa_claim*/ GRUMPKIN_OPENING_CLAIM_SIZE;
 
+// Number of bb::fr elements used to represent the public inputs of the inner circuit in the GoblinAvmRecursiveVerifier
+static constexpr std::size_t GOBLIN_AVM_PUBLIC_INPUTS_SIZE = FR_PUBLIC_INPUTS_SIZE + PAIRING_POINTS_SIZE;
+
 } // namespace bb

--- a/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/ultra_recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/ultra_recursive_verifier.cpp
@@ -199,7 +199,7 @@ template UltraRecursiveVerifier_<bb::MegaZKRecursiveFlavor_<UltraCircuitBuilder>
 // GoblinAvm specialization
 template UltraRecursiveVerifier_<bb::MegaRecursiveFlavor_<UltraCircuitBuilder>>::Output UltraRecursiveVerifier_<
     bb::MegaRecursiveFlavor_<UltraCircuitBuilder>>::
-    verify_proof<HidingKernelIO<UltraCircuitBuilder>>(
+    verify_proof<GoblinAvmIO<UltraCircuitBuilder>>(
         const UltraRecursiveVerifier_<bb::MegaRecursiveFlavor_<UltraCircuitBuilder>>::StdlibProof& proof);
 
 } // namespace bb::stdlib::recursion::honk

--- a/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/ultra_recursive_verifier.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/ultra_recursive_verifier.hpp
@@ -29,7 +29,7 @@ template <typename Builder> struct UltraRecursiveVerifierOutput {
     OpeningClaim<grumpkin<Builder>> ipa_claim;
     stdlib::Proof<Builder> ipa_proof;
     std::array<G1, Builder::NUM_WIRES> ecc_op_tables; // Ecc op tables' commitments as extracted from the public inputs
-    // of the HidingKernel, only for ClientIVC
+                                                      // of the HidingKernel, only for ClientIVC
     FF mega_hash; // The hash of public inputs and VK of the inner circuit in the GoblinAvmRecursiveVerifier
 
     UltraRecursiveVerifierOutput() = default;

--- a/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/ultra_recursive_verifier.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/ultra_recursive_verifier.hpp
@@ -29,7 +29,8 @@ template <typename Builder> struct UltraRecursiveVerifierOutput {
     OpeningClaim<grumpkin<Builder>> ipa_claim;
     stdlib::Proof<Builder> ipa_proof;
     std::array<G1, Builder::NUM_WIRES> ecc_op_tables; // Ecc op tables' commitments as extracted from the public inputs
-                                                      // of the HidingKernel, only for MegaFlavor
+    // of the HidingKernel, only for ClientIVC
+    FF mega_hash; // The hash of public inputs and VK of the inner circuit in the GoblinAvmRecursiveVerifier
 
     UltraRecursiveVerifierOutput() = default;
 
@@ -41,6 +42,8 @@ template <typename Builder> struct UltraRecursiveVerifierOutput {
             ipa_claim = inputs.ipa_claim;
         } else if constexpr (std::is_same_v<IO, HidingKernelIO<Builder>>) {
             ecc_op_tables = inputs.ecc_op_tables;
+        } else if constexpr (std::is_same_v<IO, GoblinAvmIO<Builder>>) {
+            mega_hash = inputs.mega_hash;
         } else if constexpr (!std::is_same_v<IO, DefaultIO<Builder>>) {
             throw_or_abort("Invalid public input type.");
         }

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/field/field.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/field/field.hpp
@@ -14,8 +14,12 @@
 namespace bb::stdlib {
 
 template <typename Builder> class bool_t;
-template <typename Builder> class field_t {
+template <typename Builder_> class field_t {
   public:
+    using Builder = Builder_;
+
+    static constexpr size_t PUBLIC_INPUTS_SIZE = FR_PUBLIC_INPUTS_SIZE;
+
     mutable Builder* context = nullptr;
 
     /**
@@ -369,6 +373,11 @@ template <typename Builder> class field_t {
         auto result = field_t(witness_t<Builder>(ctx, input));
         result.set_free_witness_tag();
         return result;
+    }
+
+    static field_t reconstruct_from_public(const std::span<const field_t, PUBLIC_INPUTS_SIZE>& limbs)
+    {
+        return limbs[0];
     }
 
     /**

--- a/barretenberg/cpp/src/barretenberg/stdlib/special_public_inputs/special_public_inputs.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/special_public_inputs/special_public_inputs.hpp
@@ -165,6 +165,53 @@ template <typename Builder> class DefaultIO {
 using AppIO = DefaultIO<MegaCircuitBuilder>; // app IO is always Mega
 
 /**
+ * @brief The data that is propagated on the public inputs of the inner GoblinAvmRecursiveVerifier circuit
+ */
+template <typename Builder> class GoblinAvmIO {
+  public:
+    using Curve = stdlib::bn254<Builder>; // curve is always bn254
+    using FF = Curve::ScalarField;
+    using PairingInputs = stdlib::recursion::PairingPoints<Builder>;
+
+    using PublicFF = stdlib::PublicInputComponent<FF>;
+    using PublicPairingPoints = stdlib::PublicInputComponent<PairingInputs>;
+
+    FF mega_inputs_hash;
+    PairingInputs pairing_inputs;
+
+    // Total size of the IO public inputs
+    static constexpr size_t PUBLIC_INPUTS_SIZE = GOBLIN_AVM_PUBLIC_INPUTS_SIZE;
+
+    /**
+     * @brief Reconstructs the IO components from a public inputs array.
+     *
+     * @param public_inputs Public inputs array containing the serialized kernel public inputs.
+     */
+    void reconstruct_from_public(const std::vector<FF>& public_inputs)
+    {
+        // Assumes that the GoblinAvm-io public inputs are at the end of the public_inputs vector
+        uint32_t index = static_cast<uint32_t>(public_inputs.size() - PUBLIC_INPUTS_SIZE);
+        mega_inputs_hash = PublicFF::reconstruct(public_inputs, PublicComponentKey{ index });
+        index += FF::PUBLIC_INPUTS_SIZE;
+        pairing_inputs = PublicPairingPoints::reconstruct(public_inputs, PublicComponentKey{ index });
+    }
+
+    /**
+     * @brief Set each IO component to be a public input of the underlying circuit.
+     *
+     */
+    void set_public()
+    {
+        mega_inputs_hash.set_public();
+        pairing_inputs.set_public();
+
+        // Finalize the public inputs to ensure no more public inputs can be added hereafter.
+        Builder* builder = pairing_inputs.P0.get_context();
+        builder->finalize_public_inputs();
+    }
+};
+
+/**
  * @brief Manages the data that is propagated on the public inputs of a hiding kernel circuit
  */
 template <class Builder_> class HidingKernelIO {

--- a/barretenberg/cpp/src/barretenberg/stdlib/special_public_inputs/special_public_inputs.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/special_public_inputs/special_public_inputs.hpp
@@ -176,7 +176,7 @@ template <typename Builder> class GoblinAvmIO {
     using PublicFF = stdlib::PublicInputComponent<FF>;
     using PublicPairingPoints = stdlib::PublicInputComponent<PairingInputs>;
 
-    FF mega_inputs_hash;
+    FF mega_hash;
     PairingInputs pairing_inputs;
 
     // Total size of the IO public inputs
@@ -191,7 +191,7 @@ template <typename Builder> class GoblinAvmIO {
     {
         // Assumes that the GoblinAvm-io public inputs are at the end of the public_inputs vector
         uint32_t index = static_cast<uint32_t>(public_inputs.size() - PUBLIC_INPUTS_SIZE);
-        mega_inputs_hash = PublicFF::reconstruct(public_inputs, PublicComponentKey{ index });
+        mega_hash = PublicFF::reconstruct(public_inputs, PublicComponentKey{ index });
         index += FF::PUBLIC_INPUTS_SIZE;
         pairing_inputs = PublicPairingPoints::reconstruct(public_inputs, PublicComponentKey{ index });
     }
@@ -202,7 +202,7 @@ template <typename Builder> class GoblinAvmIO {
      */
     void set_public()
     {
-        mega_inputs_hash.set_public();
+        mega_hash.set_public();
         pairing_inputs.set_public();
 
         // Finalize the public inputs to ensure no more public inputs can be added hereafter.

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/recursion/goblin_avm_recursive_verifier.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/recursion/goblin_avm_recursive_verifier.hpp
@@ -119,7 +119,7 @@ class AvmGoblinRecursiveVerifier {
         using GoblinRecursiveVerifierOutput = stdlib::recursion::honk::GoblinRecursiveVerifierOutput;
         using MergeCommitments = GoblinRecursiveVerifier::MergeVerifier::InputCommitments;
         using FF = MegaRecursiveFlavor::FF;
-        using IO = stdlib::recursion::honk::HidingKernelIO<UltraBuilder>;
+        using IO = stdlib::recursion::honk::GoblinAvmIO<UltraBuilder>;
 
         // Construct hash buffer containing the AVM proof, public inputs, and VK
         std::vector<FF> hash_buffer;
@@ -141,8 +141,8 @@ class AvmGoblinRecursiveVerifier {
         // Recursively verify the goblin proof\pi_G in the Ultra circuit
         MergeCommitments merge_commitments{
             .t_commitments = mega_verifier.key->witness_commitments.get_ecc_op_wires().get_copy(),
-            .T_prev_commitments =
-                IO::empty_ecc_op_tables(ultra_builder) // Empty ecc op tables because there is only one layer of Goblin
+            .T_prev_commitments = stdlib::recursion::honk::empty_ecc_op_tables(
+                ultra_builder) // Empty ecc op tables because there is only one layer of Goblin
         };
         GoblinRecursiveVerifier goblin_verifier{ &ultra_builder, inner_output.goblin_vk, transcript };
         GoblinRecursiveVerifierOutput goblin_verifier_output =
@@ -152,7 +152,7 @@ class AvmGoblinRecursiveVerifier {
         // Validate the consistency of the AVM2 verifier inputs {\pi, pub_inputs, VK}_{AVM2} between the inner (Mega)
         // circuit and the outer (Ultra) by asserting equality on the independently computed hashes of this data.
         const FF ultra_hash = stdlib::poseidon2<UltraBuilder>::hash(ultra_builder, hash_buffer);
-        mega_proof[inner_output.mega_hash_public_input_index].assert_equal(ultra_hash);
+        mega_verifier_output.mega_hash.assert_equal(ultra_hash);
 
         // Return ipa proof, ipa claim and output aggregation object produced from verifying the Mega + Goblin proofs
         RecursiveAvmGoblinOutput output;
@@ -177,7 +177,7 @@ class AvmGoblinRecursiveVerifier {
         using TranslatorVK = Goblin::TranslatorVerificationKey;
         using MegaVerificationKey = MegaFlavor::VerificationKey;
         using FF = AvmRecursiveFlavor::FF;
-        using IO = stdlib::recursion::honk::HidingKernelIO<MegaBuilder>;
+        using IO = stdlib::recursion::honk::GoblinAvmIO<MegaBuilder>;
 
         // Instantiate Mega builder for the inner circuit (AVM2 proof recursive verifier)
         Goblin goblin;
@@ -206,9 +206,7 @@ class AvmGoblinRecursiveVerifier {
         std::vector<FF> key_fields = convert_stdlib_ultra_to_stdlib_mega(outer_key_fields);
 
         // Compute the hash and set it public
-        const FF mega_input_hash = stdlib::poseidon2<MegaBuilder>::hash(mega_builder, mega_hash_buffer);
-        const size_t mega_hash_public_input_index = mega_builder.num_public_inputs();
-        mega_input_hash.set_public(); // Add the hash result to the public inputs
+        const FF mega_hash = stdlib::poseidon2<MegaBuilder>::hash(mega_builder, mega_hash_buffer);
 
         // Construct a Mega-arithmetized AVM2 recursive verifier circuit
         auto stdlib_key = std::make_shared<AvmRecursiveVerificationKey>(mega_builder, std::span<FF>(key_fields));
@@ -217,12 +215,8 @@ class AvmGoblinRecursiveVerifier {
 
         // Public inputs
         IO inputs;
+        inputs.mega_hash = mega_hash;
         inputs.pairing_inputs = points_accumulator;
-        // TODO(https://github.com/AztecProtocol/barretenberg/issues/1489): Can we avoid paying for these public inputs
-        // given that they are not used?
-        inputs.ecc_op_tables =
-            IO::default_ecc_op_tables(mega_builder); // There is only one layer of Goblin, so the verifier will set
-                                                     // T_prev to the empty table and disregard this value
         inputs.set_public();
 
         // All prover components share a single transcript

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/recursion/goblin_avm_recursive_verifier.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/recursion/goblin_avm_recursive_verifier.hpp
@@ -61,7 +61,6 @@ class AvmGoblinRecursiveVerifier {
         GoblinProof goblin_proof;                             // \pi_G
         std::shared_ptr<MegaFlavor::VerificationKey> mega_vk; // VK_M
         Goblin::VerificationKey goblin_vk;                    // VK_G
-        size_t mega_hash_public_input_index;                  // Index of hash h_M in the Mega proof opub inputs
     };
 
     std::vector<UltraFF> outer_key_fields;
@@ -239,7 +238,6 @@ class AvmGoblinRecursiveVerifier {
             .goblin_proof = goblin_proof,
             .mega_vk = mega_vk,
             .goblin_vk = goblin_vk,
-            .mega_hash_public_input_index = mega_hash_public_input_index,
         };
     }
 };


### PR DESCRIPTION
We standardise the usage of public inputs in the `GoblinAvmRecursiveVerifier` by introducing a class `GoblinAvmIO` that has two members: the hash of the mega inputs, and the pairing inputs.