### PR TITLE
fix: re-enable proving on ARM

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -416,6 +416,7 @@ case "$cmd" in
     export CI=1
     export USE_TEST_CACHE=1
     export CI_FULL=0
+    export ACCEPT_DISABLED_AVM_VK_TREE_ROOT=1
     build
     test
     ;;
@@ -423,6 +424,7 @@ case "$cmd" in
     export CI=1
     export USE_TEST_CACHE=0
     export CI_FULL=1
+    export ACCEPT_DISABLED_AVM_VK_TREE_ROOT=1
     build
     test
     bench

--- a/yarn-project/aztec/src/cli/cmds/start_prover_agent.ts
+++ b/yarn-project/aztec/src/cli/cmds/start_prover_agent.ts
@@ -28,12 +28,6 @@ export async function startProverAgent(
     process.exit(1);
   }
 
-  // Check if running on ARM and fast-fail if so.
-  if (process.arch.startsWith('arm')) {
-    userLog(`Prover agent is not supported on ARM architecture (detected: ${process.arch}). Exiting.`);
-    process.exit(1);
-  }
-
   const config = {
     ...getProverNodeAgentConfigFromEnv(), // get default config from env
     ...extractRelevantOptions<ProverAgentConfig>(options, proverAgentConfigMappings, 'proverAgent'), // override with command line options

--- a/yarn-project/aztec/src/cli/cmds/start_prover_node.ts
+++ b/yarn-project/aztec/src/cli/cmds/start_prover_node.ts
@@ -35,12 +35,6 @@ export async function startProverNode(
     process.exit(1);
   }
 
-  // Check if running on ARM and fast-fail if so.
-  if (process.arch.startsWith('arm')) {
-    userLog(`Prover node is not supported on ARM architecture (detected: ${process.arch}). Exiting.`);
-    process.exit(1);
-  }
-
   let proverConfig = {
     ...getProverNodeConfigFromEnv(), // get default config from env
     ...extractRelevantOptions<ProverNodeConfig>(options, proverNodeConfigMappings, 'proverNode'), // override with command line options

--- a/yarn-project/aztec/src/testnet_compatibility.test.ts
+++ b/yarn-project/aztec/src/testnet_compatibility.test.ts
@@ -11,9 +11,16 @@ import { getGenesisValues } from '@aztec/world-state/testing';
  */
 describe('Testnet compatibility', () => {
   it('has expected VK tree root', () => {
-    expect(getVKTreeRoot()).toEqual(
-      Fr.fromHexString('0x20f10f409ad7fb68d015f2e0bc0fefabc7b305c5ccd6ae14d9034ccdfa460824'),
-    );
+    const expectedRoots = [Fr.fromHexString('0x1a5079b513266d78cf61cc98914d568e800982d8b2b9fe79c90f47ce27ffa2ec')];
+
+    if (process.env.ACCEPT_DISABLED_AVM_VK_TREE_ROOT === '1') {
+      expectedRoots.push(
+        //  Accept the VK tree root when the AVM is disabled (the AVM is only enabled on ARM release builds because of build times).
+        Fr.fromHexString('0x19e3d93ad6369e960f28fdda0da5110129c2db67f49445d8406001eab1a1ae6a'),
+      );
+    }
+
+    expect(expectedRoots).toContainEqual(getVKTreeRoot());
   });
   it('has expected Protocol Contracts tree root', () => {
     expect(protocolContractTreeRoot).toEqual(


### PR DESCRIPTION
This PR re-enables running the prover-node and prover-agents on ARM machines.