### PR TITLE
fix: Prove block that consumes an L1toL2 msg added on the same L1 block

### DIFF
--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_proof_public_cross_chain.test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_proof_public_cross_chain.test.ts
@@ -1,0 +1,82 @@
+import { Fr, type Logger, generateClaimSecret, retryUntil } from '@aztec/aztec.js';
+import { EthAddress } from '@aztec/foundation/eth-address';
+import { TestContract } from '@aztec/noir-test-contracts.js/Test';
+
+import { jest } from '@jest/globals';
+
+import { sendL1ToL2Message } from '../fixtures/l1_to_l2_messaging.js';
+import type { EndToEndContext } from '../fixtures/utils.js';
+import { EpochsTestContext } from './epochs_test.js';
+
+jest.setTimeout(1000 * 60 * 10);
+
+// Proves an epoch that contains txs with public function calls that consume L1 to L2 messages
+// Regression for this issue https://aztecprotocol.slack.com/archives/C085C1942HG/p1754400213976059
+describe('e2e_epochs/epochs_proof_public_cross_chain', () => {
+  let context: EndToEndContext;
+  let logger: Logger;
+
+  let test: EpochsTestContext;
+
+  beforeEach(async () => {
+    test = await EpochsTestContext.setup({ numberOfAccounts: 1, minTxsPerBlock: 1, disableAnvilTestWatcher: true });
+    ({ context, logger } = test);
+  });
+
+  afterEach(async () => {
+    jest.restoreAllMocks();
+    await test.teardown();
+  });
+
+  it('submits proof with a tx with public l1-to-l2 message claim', async () => {
+    // Deploy a contract that consumes L1 to L2 messages
+    await context.aztecNodeAdmin!.setConfig({ minTxsPerBlock: 0 });
+    logger.warn(`Deploying test contract`);
+    const testContract = await TestContract.deploy(context.wallet).send({ from: context.accounts[0] }).deployed();
+    logger.warn(`Test contract deployed at ${testContract.address}`);
+
+    // Send an l1 to l2 message to be consumed from the contract
+    const [secret, secretHash] = await generateClaimSecret();
+    const message = { recipient: testContract.address, content: Fr.random(), secretHash };
+    logger.warn(`Sending L1 to L2 message ${message.content.toString()} to be consumed by ${testContract.address}`);
+    const { msgHash, globalLeafIndex } = await sendL1ToL2Message(message, context.deployL1ContractsValues);
+
+    logger.warn(`Waiting for message ${msgHash} with index ${globalLeafIndex} to be synced`);
+    await retryUntil(
+      () => context.aztecNode.isL1ToL2MessageSynced(msgHash),
+      'message sync',
+      test.L2_SLOT_DURATION_IN_S * 4,
+    );
+
+    // And we consume the message using the test contract. It's important that we don't wait for the membership witness
+    // to be available, since we want to test the scenario where the message becomes available on the same block the tx lands.
+    logger.warn(`Consuming message ${message.content.toString()} from the contract at ${testContract.address}`);
+    const txReceipt = await testContract.methods
+      .consume_message_from_arbitrary_sender_public(
+        message.content,
+        secret,
+        EthAddress.fromString(context.deployL1ContractsValues.l1Client.account.address),
+        globalLeafIndex.toBigInt(),
+      )
+      .send({ from: context.accounts[0] })
+      .wait();
+    expect(txReceipt.blockNumber).toBeGreaterThan(0);
+
+    // Wait until a proof lands for the transaction
+    logger.warn(`Waiting for proof for tx ${txReceipt.txHash} mined at ${txReceipt.blockNumber!}`);
+    await retryUntil(
+      async () => {
+        const provenBlockNumber = await context.aztecNode.getProvenBlockNumber();
+        logger.info(`Proven block number is ${provenBlockNumber}`);
+        return provenBlockNumber >= txReceipt.blockNumber!;
+      },
+      'Proof has been submitted',
+      test.L2_SLOT_DURATION_IN_S * test.epochDuration * 3,
+    );
+
+    const provenBlockNumber = await context.aztecNode.getProvenBlockNumber();
+    expect(provenBlockNumber).toBeGreaterThanOrEqual(txReceipt.blockNumber!);
+
+    logger.info(`Test succeeded`);
+  });
+});

--- a/yarn-project/prover-node/src/job/epoch-proving-job.ts
+++ b/yarn-project/prover-node/src/job/epoch-proving-job.ts
@@ -1,5 +1,8 @@
 import { BatchedBlob, Blob } from '@aztec/blob-lib';
+import { NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP } from '@aztec/constants';
 import { asyncPool } from '@aztec/foundation/async-pool';
+import { padArrayEnd } from '@aztec/foundation/collection';
+import { Fr } from '@aztec/foundation/fields';
 import { createLogger } from '@aztec/foundation/log';
 import { RunningPromise, promiseWithResolvers } from '@aztec/foundation/promise';
 import { Timer } from '@aztec/foundation/timer';
@@ -11,6 +14,7 @@ import {
   EpochProvingJobTerminalState,
   type ForkMerkleTreeOperations,
 } from '@aztec/stdlib/interfaces/server';
+import { MerkleTreeId } from '@aztec/stdlib/trees';
 import type { ProcessedTx, Tx } from '@aztec/stdlib/tx';
 import { Attributes, type Traceable, type Tracer, trackSpan } from '@aztec/telemetry-client';
 
@@ -151,7 +155,7 @@ export class EpochProvingJob implements Traceable {
         await this.prover.startNewBlock(globalVariables, l1ToL2Messages, previousHeader);
 
         // Process public fns
-        const db = await this.dbProvider.fork(block.number - 1);
+        const db = await this.createFork(block.number - 1, l1ToL2Messages);
         const publicProcessor = this.publicProcessorFactory.create(db, globalVariables, true);
         const processed = await this.processTxs(publicProcessor, txs);
         await this.prover.addTxs(processed);
@@ -210,6 +214,26 @@ export class EpochProvingJob implements Traceable {
       await this.prover.stop();
       resolve();
     }
+  }
+
+  /**
+   * Create a new db fork for tx processing, inserting all L1 to L2.
+   * REFACTOR: The prover already spawns a db fork of its own for each block, so we may be able to do away with just one fork.
+   */
+  private async createFork(blockNumber: number, l1ToL2Messages: Fr[]) {
+    const db = await this.dbProvider.fork(blockNumber);
+    const l1ToL2MessagesPadded = padArrayEnd(
+      l1ToL2Messages,
+      Fr.ZERO,
+      NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP,
+      'Too many L1 to L2 messages',
+    );
+    this.log.verbose(`Creating fork at ${blockNumber} with ${l1ToL2Messages.length} L1 to L2 messages`, {
+      blockNumber,
+      l1ToL2Messages: l1ToL2MessagesPadded.map(m => m.toString()),
+    });
+    await db.appendLeaves(MerkleTreeId.L1_TO_L2_MESSAGE_TREE, l1ToL2MessagesPadded);
+    return db;
   }
 
   private progressState(state: EpochProvingJobState) {


### PR DESCRIPTION
Failing with:

```
[17:17:31.957] ERROR: prover-client:proving-agent:prover-node Job id=1:BLOCK_ROOT_ROLLUP:dc30b45467db22799e62c39ebfe75b324984a6ca77f20a55be730e5e4eca5f42 type=SINGLE_TX_BLOCK_ROOT_ROLLUP failed err=Circuit execution failed: last_l1_to_l2 in constants does not match the value in the previous block header retry=false: Error: Circuit execution failed: last_l1_to_l2 in constants does not match the value in the previous block header
```