### PR TITLE
chore: use granular imports for txe

### DIFF
--- a/yarn-project/txe/src/bin/index.ts
+++ b/yarn-project/txe/src/bin/index.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S node --no-warnings
-import { createLogger } from '@aztec/aztec.js';
 import { startHttpRpcServer } from '@aztec/foundation/json-rpc/server';
+import { createLogger } from '@aztec/foundation/log';
 
 import { createTXERpcServer } from '../index.js';
 

--- a/yarn-project/txe/src/index.ts
+++ b/yarn-project/txe/src/index.ts
@@ -1,19 +1,15 @@
 import { SchnorrAccountContractArtifact } from '@aztec/accounts/schnorr';
-import {
-  AztecAddress,
-  type ContractInstanceWithAddress,
-  Fr,
-  type NoirCompiledContract,
-  PublicKeys,
-  deriveKeys,
-  getContractInstanceFromInstantiationParams,
-  loadContractArtifact,
-} from '@aztec/aztec.js';
+import { Fr } from '@aztec/foundation/fields';
 import { createSafeJsonRpcServer } from '@aztec/foundation/json-rpc/server';
 import type { Logger } from '@aztec/foundation/log';
 import { type ProtocolContract, protocolContractNames } from '@aztec/protocol-contracts';
 import { BundledProtocolContractsProvider } from '@aztec/protocol-contracts/providers/bundle';
+import { loadContractArtifact } from '@aztec/stdlib/abi';
+import { AztecAddress } from '@aztec/stdlib/aztec-address';
+import { type ContractInstanceWithAddress, getContractInstanceFromInstantiationParams } from '@aztec/stdlib/contract';
 import { computeArtifactHash } from '@aztec/stdlib/contract';
+import { PublicKeys, deriveKeys } from '@aztec/stdlib/keys';
+import type { NoirCompiledContract } from '@aztec/stdlib/noir';
 import type { ApiSchemaFor, ZodFor } from '@aztec/stdlib/schemas';
 
 import { createHash } from 'crypto';

--- a/yarn-project/txe/src/oracle/txe_oracle.ts
+++ b/yarn-project/txe/src/oracle/txe_oracle.ts
@@ -1,4 +1,3 @@
-import { type AztecNode, Body, L2Block, Note } from '@aztec/aztec.js';
 import {
   DEFAULT_GAS_LIMIT,
   DEFAULT_TEARDOWN_GAS_LIMIT,
@@ -61,6 +60,7 @@ import {
 import { AuthWitness } from '@aztec/stdlib/auth-witness';
 import { PublicDataWrite } from '@aztec/stdlib/avm';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
+import { Body, L2Block } from '@aztec/stdlib/block';
 import type { ContractInstance, ContractInstanceWithAddress } from '@aztec/stdlib/contract';
 import { Gas, GasFees, GasSettings } from '@aztec/stdlib/gas';
 import {
@@ -72,7 +72,7 @@ import {
   siloNoteHash,
   siloNullifier,
 } from '@aztec/stdlib/hash';
-import type { MerkleTreeReadOperations, MerkleTreeWriteOperations } from '@aztec/stdlib/interfaces/server';
+import type { AztecNode, MerkleTreeReadOperations, MerkleTreeWriteOperations } from '@aztec/stdlib/interfaces/server';
 import {
   type KeyValidationRequest,
   PartialPrivateTailPublicInputsForPublic,
@@ -82,6 +82,7 @@ import {
   PublicCallRequest,
 } from '@aztec/stdlib/kernel';
 import { ContractClassLog, IndexedTaggingSecret, PrivateLog, type PublicLog } from '@aztec/stdlib/logs';
+import { Note } from '@aztec/stdlib/note';
 import type { NoteStatus } from '@aztec/stdlib/note';
 import { ClientIvcProof } from '@aztec/stdlib/proofs';
 import {
@@ -1029,7 +1030,7 @@ export class TXE {
 
     const contractsDB = new PublicContractsDB(new TXEPublicContractDataSource(this));
     const guardedMerkleTrees = new GuardedMerkleTreeOperations(this.baseFork);
-    const simulator = new PublicTxSimulator(guardedMerkleTrees, contractsDB, globals, true, true);
+    const simulator = new PublicTxSimulator(guardedMerkleTrees, contractsDB, globals, true, true, true);
     const processor = new PublicProcessor(globals, guardedMerkleTrees, contractsDB, simulator, new TestDateProvider());
 
     const tx = await Tx.create({

--- a/yarn-project/txe/src/txe_service/txe_service.ts
+++ b/yarn-project/txe/src/txe_service/txe_service.ts
@@ -1,11 +1,11 @@
-import { type ContractInstanceWithAddress, Fr, Point } from '@aztec/aztec.js';
 import { CONTRACT_INSTANCE_REGISTRY_CONTRACT_ADDRESS } from '@aztec/constants';
+import { Fr, Point } from '@aztec/foundation/fields';
 import type { Logger } from '@aztec/foundation/log';
 import { openTmpStore } from '@aztec/kv-store/lmdb-v2';
 import type { ProtocolContract } from '@aztec/protocol-contracts';
 import { type ContractArtifact, FunctionSelector, NoteSelector } from '@aztec/stdlib/abi';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
-import { computePartialAddress } from '@aztec/stdlib/contract';
+import { type ContractInstanceWithAddress, computePartialAddress } from '@aztec/stdlib/contract';
 import { MerkleTreeId } from '@aztec/stdlib/trees';
 
 import { TXE } from '../oracle/txe_oracle.js';

--- a/yarn-project/txe/src/util/txe_contract_data_provider.ts
+++ b/yarn-project/txe/src/util/txe_contract_data_provider.ts
@@ -1,5 +1,6 @@
-import { type ContractArtifact, Fr } from '@aztec/aztec.js';
+import { Fr } from '@aztec/foundation/fields';
 import { ContractDataProvider } from '@aztec/pxe/server';
+import type { ContractArtifact } from '@aztec/stdlib/abi';
 
 export type ContractArtifactWithHash = ContractArtifact & { artifactHash: Fr };
 


### PR DESCRIPTION
This doesn't quite fix the startup time issue, but it helps us get closer to addressing it.