### PR TITLE
chore: slash veto e2e test

### DIFF
--- a/l1-contracts/src/core/RollupCore.sol
+++ b/l1-contracts/src/core/RollupCore.sol
@@ -74,6 +74,7 @@ contract RollupCore is EIP712("Aztec Rollup", "1"), Ownable, IStakingCore, IVali
 
     Timestamp exitDelay = Timestamp.wrap(_config.exitDelaySeconds);
     ISlasher slasher = ExtRollupLib3.deploySlasher(
+      address(this),
       _config.slashingQuorum,
       _config.slashingRoundSize,
       _config.slashingLifetimeInRounds,

--- a/l1-contracts/src/core/libraries/rollup/ExtRollupLib3.sol
+++ b/l1-contracts/src/core/libraries/rollup/ExtRollupLib3.sol
@@ -18,6 +18,7 @@ library ExtRollupLib3 {
   }
 
   function deploySlasher(
+    address _rollup,
     uint256 _slashingQuorum,
     uint256 _slashingRoundSize,
     uint256 _slashingLifetimeInRounds,
@@ -25,7 +26,12 @@ library ExtRollupLib3 {
     address _slashingVetoer
   ) external returns (ISlasher) {
     Slasher slasher = new Slasher(
-      _slashingQuorum, _slashingRoundSize, _slashingLifetimeInRounds, _slashingExecutionDelayInRounds, _slashingVetoer
+      _rollup,
+      _slashingQuorum,
+      _slashingRoundSize,
+      _slashingLifetimeInRounds,
+      _slashingExecutionDelayInRounds,
+      _slashingVetoer
     );
     return ISlasher(address(slasher));
   }

--- a/l1-contracts/src/core/slashing/Slasher.sol
+++ b/l1-contracts/src/core/slashing/Slasher.sol
@@ -18,14 +18,14 @@ contract Slasher is ISlasher {
   error Slasher__PayloadVetoed(address payload);
 
   constructor(
+    address _rollup,
     uint256 _quorumSize,
     uint256 _roundSize,
     uint256 _lifetimeInRounds,
     uint256 _executionDelayInRounds,
     address _vetoer
   ) {
-    PROPOSER =
-      new SlashingProposer(msg.sender, this, _quorumSize, _roundSize, _lifetimeInRounds, _executionDelayInRounds);
+    PROPOSER = new SlashingProposer(_rollup, this, _quorumSize, _roundSize, _lifetimeInRounds, _executionDelayInRounds);
     VETOER = _vetoer;
   }
 

--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -1097,6 +1097,7 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, Traceable {
     const newConfig = { ...this.config, ...config };
     this.sequencer?.updateSequencerConfig(config);
     this.slasherClient?.updateConfig(config);
+    this.validatorsSentinel?.updateConfig(config);
     // this.blockBuilder.updateConfig(config); // TODO: Spyros has a PR to add the builder to `this`, so we can do this
     await this.p2pClient.updateP2PConfig(config);
 

--- a/yarn-project/aztec-node/src/sentinel/sentinel.ts
+++ b/yarn-project/aztec-node/src/sentinel/sentinel.ts
@@ -60,6 +60,10 @@ export class Sentinel extends (EventEmitter as new () => WatcherEmitter) impleme
     this.runningPromise = new RunningPromise(this.work.bind(this), logger, interval);
   }
 
+  public updateConfig(config: Partial<SlasherConfig>) {
+    this.config = { ...this.config, ...config };
+  }
+
   public async start() {
     await this.init();
     this.runningPromise.start();

--- a/yarn-project/end-to-end/src/e2e_p2p/slash_veto_demo.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/slash_veto_demo.test.ts
@@ -1,0 +1,240 @@
+import type { AztecNodeService } from '@aztec/aztec-node';
+import { createLogger, retryUntil } from '@aztec/aztec.js';
+import { type ExtendedViemWalletClient, L1Deployer, RollupContract, SlasherArtifact } from '@aztec/ethereum';
+import { GSEAbi } from '@aztec/l1-artifacts/GSEAbi';
+import { RollupAbi } from '@aztec/l1-artifacts/RollupAbi';
+import { SlasherAbi } from '@aztec/l1-artifacts/SlasherAbi';
+
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { getContract } from 'viem';
+import { privateKeyToAccount } from 'viem/accounts';
+
+import { createNodes } from '../fixtures/setup_p2p_test.js';
+import { P2PNetworkTest } from './p2p_network.js';
+
+const debugLogger = createLogger('e2e:spartan-test:slash-veto-demo');
+
+const NUM_NODES = 4;
+const NUM_VALIDATORS = NUM_NODES + 1; // We create an extra validator, who will not have a running node
+const BOOT_NODE_UDP_PORT = 4500;
+const EPOCH_DURATION = 4;
+const SLASHING_QUORUM = 3;
+const SLASHING_ROUND_SIZE = 5;
+const AZTEC_SLOT_DURATION = 12;
+const ETHEREUM_SLOT_DURATION = 6;
+const LIFETIME_IN_ROUNDS = 2;
+const EXECUTION_DELAY_IN_ROUNDS = 1;
+const DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'slash-veto-demo-'));
+
+// const config = setupEnvironment(process.env) as K8sGCloudConfig;
+
+describe('veto slash', () => {
+  let t: P2PNetworkTest;
+  let nodes: AztecNodeService[];
+  let slashingAmount: bigint;
+  let additionalNode: AztecNodeService | undefined;
+  let rollup: RollupContract;
+
+  beforeEach(async () => {
+    t = await P2PNetworkTest.create({
+      testName: 'e2e_p2p_slash_veto_demo',
+      numberOfNodes: 0,
+      numberOfValidators: NUM_VALIDATORS,
+      basePort: BOOT_NODE_UDP_PORT,
+      startProverNode: true,
+      initialConfig: {
+        aztecSlotDuration: AZTEC_SLOT_DURATION,
+        ethereumSlotDuration: ETHEREUM_SLOT_DURATION,
+        aztecProofSubmissionEpochs: 1024, // effectively do not reorg
+        listenAddress: '127.0.0.1',
+        minTxsPerBlock: 0,
+        aztecEpochDuration: EPOCH_DURATION,
+        validatorReexecute: false,
+        sentinelEnabled: true,
+        slashingQuorum: SLASHING_QUORUM,
+        slashingRoundSize: SLASHING_ROUND_SIZE,
+        slashInactivityCreateTargetPercentage: 0.5,
+        slashInactivitySignalTargetPercentage: 0.1,
+        slashProposerRoundPollingIntervalSeconds: 1,
+      },
+    });
+
+    await t.applyBaseSnapshots();
+    await t.setup();
+
+    ({ rollup } = await t.getContracts());
+    // slash amount is just below the ejection threshold
+    slashingAmount = (await rollup.getActivationThreshold()) - (await rollup.getEjectionThreshold()) - 1n;
+
+    nodes = await createNodes(
+      t.ctx.aztecNodeConfig,
+      t.ctx.dateProvider,
+      t.bootstrapNodeEnr,
+      NUM_NODES, // Note we do not create the last validator yet, so it shows as offline
+      BOOT_NODE_UDP_PORT,
+      t.prefilledPublicData,
+
+      DATA_DIR,
+    );
+    for (const node of nodes) {
+      await node.setConfig({
+        slashInactivityEnabled: true,
+        slashInactivityCreatePenalty: slashingAmount,
+        slashInactivityMaxPenalty: slashingAmount,
+      });
+    }
+    await t.removeInitialNode();
+
+    t.logger.info(`Setup complete`, { validators: t.validators });
+  });
+
+  afterEach(async () => {
+    await t.stopNodes(nodes);
+    if (additionalNode !== undefined) {
+      await t.stopNodes([additionalNode]);
+    }
+    await t.teardown();
+    for (let i = 0; i < NUM_NODES; i++) {
+      fs.rmSync(`${DATA_DIR}-${i}`, { recursive: true, force: true, maxRetries: 3 });
+    }
+  });
+
+  async function deployNewSlasher(deployerClient: ExtendedViemWalletClient) {
+    const deployer = new L1Deployer(deployerClient, 42, undefined, false, undefined, undefined);
+    const args = [
+      rollup.address,
+      SLASHING_QUORUM,
+      SLASHING_ROUND_SIZE,
+      LIFETIME_IN_ROUNDS, // lifetime in rounds
+      EXECUTION_DELAY_IN_ROUNDS, // execution delay in rounds
+      deployerClient.account.address, // vetoer
+    ] as const;
+    debugLogger.info(`\n\ndeploying slasher with args: ${JSON.stringify(args)}\n\n`);
+    const slashFactoryAddress = await deployer.deploy(SlasherArtifact, args);
+    await deployer.waitForDeployments();
+    return slashFactoryAddress;
+  }
+
+  it.each([true, false])(
+    'sets the new slasher and shouldVeto=%s',
+    async (shouldVeto: boolean) => {
+      const l1Client = t.ctx.deployL1ContractsValues.l1Client;
+      const newSlasherAddress = await deployNewSlasher(l1Client);
+      debugLogger.info(`\n\nnewSlasherAddress: ${newSlasherAddress}\n\n`);
+      const rollupRaw = getContract({
+        address: rollup.address,
+        abi: RollupAbi,
+        client: l1Client,
+      });
+      const tx = await rollupRaw.write.setSlasher([newSlasherAddress.toString()]);
+      const receipt = await l1Client.waitForTransactionReceipt({ hash: tx });
+      expect(receipt.status).toEqual('success');
+      const slasherAddress = await rollup.getSlasher();
+      expect(slasherAddress.toLowerCase()).toEqual(newSlasherAddress.toString().toLowerCase());
+      debugLogger.info(`\n\nnew slasher address: ${slasherAddress}\n\n`);
+      const slasher = getContract({
+        address: slasherAddress,
+        abi: SlasherAbi,
+        client: t.ctx.deployL1ContractsValues.l1Client,
+      });
+      const slasherVetoer = await slasher.read.VETOER();
+      debugLogger.info(`\n\nnew slasher vetoer: ${slasherVetoer}\n\n`);
+      expect(slasherVetoer).toEqual(l1Client.account.address);
+
+      const slashingProposer = await rollup.getSlashingProposer();
+
+      const awaitSubmittableRound = new Promise<{ payload: `0x${string}`; round: bigint }>(resolve => {
+        slashingProposer.listenToSubmittablePayloads(args => {
+          resolve(args);
+        });
+      });
+
+      // Add diagnostic logging while waiting
+      const startTime = Date.now();
+      debugLogger.info('Waiting for submittable round...');
+
+      const diagnosticInterval = setInterval(() => {
+        void (async () => {
+          try {
+            const currentRound = await slashingProposer.getCurrentRound();
+            const roundInfo = await slashingProposer.getRoundInfo(rollup.address, currentRound);
+            debugLogger.info(`\n\ncurrentRound: ${currentRound}\n\n`);
+            debugLogger.info(`\n\npayloadWithMostSignals: ${roundInfo.payloadWithMostSignals}\n\n`);
+
+            const signals = await slashingProposer.getPayloadSignals(
+              rollup.address,
+              currentRound,
+              roundInfo.payloadWithMostSignals,
+            );
+            debugLogger.info(`\n\nsignals: ${signals}\n\n`);
+          } catch (error) {
+            debugLogger.error(`Error getting diagnostic info: ${error}`);
+          }
+        })();
+      }, AZTEC_SLOT_DURATION * 1000); // Log every slot
+
+      const submittableRound = await awaitSubmittableRound;
+      clearInterval(diagnosticInterval);
+
+      const totalTime = ((Date.now() - startTime) / 1000).toFixed(1);
+      debugLogger.info(`✅ Received submittable round after ${totalTime}s`);
+      debugLogger.info(`\n\nsubmittableRound: ${submittableRound.round}\n\n`);
+      debugLogger.info(`\n\nsubmittablePayload: ${submittableRound.payload}\n\n`);
+
+      await retryUntil(async () => {
+        const currentRound = await slashingProposer.getCurrentRound();
+        return currentRound > submittableRound.round;
+      });
+
+      const attesterPrivateKey = t.attesterPrivateKeys[t.attesterPrivateKeys.length - 1];
+      const attester = privateKeyToAccount(attesterPrivateKey);
+      const gseAddress = await rollup.getGSE();
+      const gse = getContract({
+        address: gseAddress,
+        abi: GSEAbi,
+        client: t.ctx.deployL1ContractsValues.l1Client,
+      });
+      const badAttesterInitialBalance = await gse.read.effectiveBalanceOf([rollup.address, attester.address]);
+      debugLogger.info(`\n\nbadAttesterInitialBalance: ${badAttesterInitialBalance}\n\n`);
+
+      const gseOwnerAddress = await gse.read.owner();
+      debugLogger.info(`\n\ngseOwnerAddress: ${gseOwnerAddress}\n\n`);
+
+      if (shouldVeto) {
+        const slasher = getContract({
+          address: await rollup.getSlasher(),
+          abi: SlasherAbi,
+          client: t.ctx.deployL1ContractsValues.l1Client,
+        });
+        const tx = await slasher.write.vetoPayload([submittableRound.payload]);
+        const receipt = await t.ctx.deployL1ContractsValues.l1Client.waitForTransactionReceipt({ hash: tx });
+        debugLogger.info(`\n\nvetoPayload tx receipt: ${receipt.status}\n\n`);
+      }
+
+      const awaitPayloadSubmitted = new Promise<{ round: bigint; payload: `0x${string}` }>(resolve => {
+        slashingProposer.listenToPayloadSubmitted(args => {
+          resolve(args);
+        });
+      });
+      const awaitPayloadExpiredPromise = retryUntil(async () => {
+        const currentRound = await slashingProposer.getCurrentRound();
+        return currentRound > submittableRound.round + BigInt(LIFETIME_IN_ROUNDS);
+      });
+
+      const payloadExecutedOrExpired = await Promise.race([awaitPayloadSubmitted, awaitPayloadExpiredPromise]);
+      const badAttesterFinalBalance = await gse.read.effectiveBalanceOf([rollup.address, attester.address]);
+      if (shouldVeto) {
+        expect(payloadExecutedOrExpired).toBe(true);
+        expect(badAttesterFinalBalance).toBe(badAttesterInitialBalance);
+      } else {
+        expect((payloadExecutedOrExpired as { round: bigint; payload: `0x${string}` }).round).toBe(
+          submittableRound.round,
+        );
+        expect(badAttesterFinalBalance).toBe(badAttesterInitialBalance - slashingAmount);
+      }
+    },
+    1000 * 60 * 10,
+  );
+});

--- a/yarn-project/end-to-end/src/e2e_p2p/slash_veto_demo.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/slash_veto_demo.test.ts
@@ -23,9 +23,9 @@ const ETHEREUM_SLOT_DURATION = 6;
 const AZTEC_SLOT_DURATION = 12;
 const EPOCH_DURATION = 4;
 // how many l2 slots make up a slashing round
-const SLASHING_ROUND_SIZE = 9;
+const SLASHING_ROUND_SIZE = 5;
 // how many block builders must signal for a single payload in a single round for it to be executable
-const SLASHING_QUORUM = 5;
+const SLASHING_QUORUM = 3;
 // an attester must not attest to 50% of proven blocks over an epoch to warrant a slash payload being created
 const SLASH_INACTIVITY_CREATE_TARGET_PERCENTAGE = 0.5;
 // an attester must not attest to 10% of proven blocks over an epoch to agree with a slash
@@ -43,7 +43,7 @@ describe('veto slash', () => {
   let additionalNode: AztecNodeService | undefined;
   let rollup: RollupContract;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     t = await P2PNetworkTest.create({
       testName: 'e2e_p2p_slash_veto_demo',
       numberOfNodes: 0,
@@ -100,7 +100,7 @@ describe('veto slash', () => {
     t.logger.info(`Setup complete`, { validators: t.validators });
   });
 
-  afterEach(async () => {
+  afterAll(async () => {
     await t.stopNodes(nodes);
     if (additionalNode !== undefined) {
       await t.stopNodes([additionalNode]);
@@ -133,7 +133,7 @@ describe('veto slash', () => {
     return slashFactoryAddress;
   }
 
-  it.each([false])(
+  it.each([false, true])(
     'sets the new slasher and shouldVeto=%s',
     async (shouldVeto: boolean) => {
       //################################//

--- a/yarn-project/end-to-end/src/e2e_p2p/slash_veto_demo.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/slash_veto_demo.test.ts
@@ -133,7 +133,7 @@ describe('veto slash', () => {
     return slashFactoryAddress;
   }
 
-  it.each([false, true])(
+  it.each([true])(
     'sets the new slasher and shouldVeto=%s',
     async (shouldVeto: boolean) => {
       //################################//

--- a/yarn-project/end-to-end/src/spartan/utils.ts
+++ b/yarn-project/end-to-end/src/spartan/utils.ts
@@ -462,10 +462,12 @@ export function applyValidatorKill({
   namespace,
   spartanDir,
   logger,
+  values,
 }: {
   namespace: string;
   spartanDir: string;
   logger: Logger;
+  values?: Record<string, string | number>;
 }) {
   return installChaosMeshChart({
     instanceName: 'validator-kill',
@@ -473,6 +475,7 @@ export function applyValidatorKill({
     valuesFile: 'validator-kill.yaml',
     helmChartDir: getChartDir(spartanDir, 'aztec-chaos-scenarios'),
     logger,
+    values,
   });
 }
 

--- a/yarn-project/ethereum/src/contracts/rollup.ts
+++ b/yarn-project/ethereum/src/contracts/rollup.ts
@@ -235,6 +235,10 @@ export class RollupContract {
     return this.rollup.read.getSlasher();
   }
 
+  getOwner() {
+    return this.rollup.read.owner();
+  }
+
   public async getSlashingProposerAddress() {
     const slasherAddress = await this.getSlasher();
     const slasher = getContract({
@@ -702,5 +706,21 @@ export class RollupContract {
         args: [proposalId],
       }),
     });
+  }
+
+  public listenToSlasherChanged(callback: (args: { oldSlasher: `0x${string}`; newSlasher: `0x${string}` }) => unknown) {
+    return this.rollup.watchEvent.SlasherUpdated(
+      {},
+      {
+        onLogs: logs => {
+          for (const log of logs) {
+            const args = log.args;
+            if (args.oldSlasher && args.newSlasher) {
+              callback(args as { oldSlasher: `0x${string}`; newSlasher: `0x${string}` });
+            }
+          }
+        },
+      },
+    );
   }
 }

--- a/yarn-project/ethereum/src/contracts/rollup.ts
+++ b/yarn-project/ethereum/src/contracts/rollup.ts
@@ -147,7 +147,6 @@ export class RollupContract {
     return this.rollup;
   }
 
-  @memoize
   public async getSlashingProposer() {
     const slasherAddress = await this.rollup.read.getSlasher();
     const slasher = getContract({ address: slasherAddress, abi: SlasherAbi, client: this.client });

--- a/yarn-project/ethereum/src/contracts/slashing_proposer.ts
+++ b/yarn-project/ethereum/src/contracts/slashing_proposer.ts
@@ -56,6 +56,10 @@ export class SlashingProposerContract extends EventEmitter implements IEmpireBas
     return this.proposer.read.EXECUTION_DELAY_IN_ROUNDS();
   }
 
+  public getCurrentRound() {
+    return this.proposer.read.getCurrentRound();
+  }
+
   public computeRound(slot: bigint): Promise<bigint> {
     return this.proposer.read.computeRound([slot]);
   }

--- a/yarn-project/ethereum/src/l1_artifacts.ts
+++ b/yarn-project/ethereum/src/l1_artifacts.ts
@@ -40,6 +40,8 @@ import {
   RollupLinkReferences,
   SlashFactoryAbi,
   SlashFactoryBytecode,
+  SlasherAbi,
+  SlasherBytecode,
   StakingAssetHandlerAbi,
   StakingAssetHandlerBytecode,
   TestERC20Abi,
@@ -139,6 +141,12 @@ export const GovernanceArtifact = {
   name: 'Governance',
   contractAbi: GovernanceAbi,
   contractBytecode: GovernanceBytecode as Hex,
+};
+
+export const SlasherArtifact = {
+  name: 'Slasher',
+  contractAbi: SlasherAbi,
+  contractBytecode: SlasherBytecode as Hex,
 };
 
 export const SlashFactoryArtifact = {

--- a/yarn-project/sequencer-client/src/publisher/sequencer-publisher.ts
+++ b/yarn-project/sequencer-client/src/publisher/sequencer-publisher.ts
@@ -101,14 +101,11 @@ export class SequencerPublisher {
   private interrupted = false;
   private metrics: SequencerPublisherMetrics;
   public epochCache: EpochCache;
-  private dateProvider: DateProvider;
 
   protected governanceLog = createLogger('sequencer:publisher:governance');
-  protected governanceProposerAddress?: EthAddress;
   private governancePayload: EthAddress = EthAddress.ZERO;
 
   protected slashingLog = createLogger('sequencer:publisher:slashing');
-  protected slashingProposerAddress?: EthAddress;
   private getSlashPayload?: GetSlashPayloadCallBack = undefined;
 
   private myLastSignals: Record<SignalType, bigint> = {
@@ -153,7 +150,6 @@ export class SequencerPublisher {
   ) {
     this.ethereumSlotDuration = BigInt(config.ethereumSlotDuration);
     this.epochCache = deps.epochCache;
-    this.dateProvider = deps.dateProvider;
 
     this.blobSinkClient =
       deps.blobSinkClient ?? createBlobSinkClient(config, { logger: createLogger('sequencer:blob-sink:client') });
@@ -166,6 +162,12 @@ export class SequencerPublisher {
 
     this.govProposerContract = deps.governanceProposerContract;
     this.slashingProposerContract = deps.slashingProposerContract;
+
+    this.rollupContract.listenToSlasherChanged(async () => {
+      this.log.info('Slashing proposer changed');
+      const newSlashingProposer = await this.rollupContract.getSlashingProposer();
+      this.slashingProposerContract = newSlashingProposer;
+    });
   }
 
   public getRollupContract(): RollupContract {
@@ -591,14 +593,14 @@ export class SequencerPublisher {
         const logData = { ...result, slotNumber, round, payload: payload.toString() };
         if (!success) {
           this.log.error(
-            `Voting in [${action}] for ${payload} at slot ${slotNumber} in round ${round} failed`,
+            `Signaling in [${action}] for ${payload} at slot ${slotNumber} in round ${round} failed`,
             logData,
           );
           this.myLastSignals[signalType] = cachedLastVote;
           return false;
         } else {
           this.log.info(
-            `Voting in [${action}] for ${payload} at slot ${slotNumber} in round ${round} succeeded`,
+            `Signaling in [${action}] for ${payload} at slot ${slotNumber} in round ${round} succeeded`,
             logData,
           );
           return true;


### PR DESCRIPTION
Update slasher to take the rollup as an arg, rather than assume it is `msg.sender`. This allows easy creation of new slashers after rollup deployment.

**Key Changes:**
- **Contract Updates**: Modified `RollupCore`, `ExtRollupLib3`, and `Slasher` constructors to accept and pass the rollup address parameter. 
- **Dynamic Slasher Updates**: Added event listeners in `SequencerPublisher` and `SlasherClient` to handle slasher contract changes at runtime
- **New Integration Test**: Added comprehensive end-to-end test `slash_veto_demo.test.ts` to validate slashing and veto functionality
- **Enhanced Contracts**: Added new methods and event listeners to `RollupContract` and `SlashingProposerContract` for better monitoring
