### PR TITLE
fix: pass &self to slot_at instead of self

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/capsules/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/capsules/mod.nr
@@ -112,7 +112,7 @@ impl<T> CapsuleArray<T> {
         }
     }
 
-    unconstrained fn slot_at(self, index: u32) -> Field {
+    unconstrained fn slot_at(&self, index: u32) -> Field {
         // Elements are stored immediately after the base slot, so we add 1 to it to compute the slot for the first
         // element.
         self.base_slot + 1 + index as Field


### PR DESCRIPTION
Changed `slot_at` to take `&self` instead of consuming `self`.

This avoids unnecessary moves and aligns with its read-only usage. Cleaner and safer — no behavior change.

