### PR TITLE
chore: backport 16220

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -387,6 +387,7 @@ case "$cmd" in
     export CI=1
     export USE_TEST_CACHE=1
     export CI_FULL=0
+    export ACCEPT_DISABLED_AVM_VK_TREE_ROOT=1
     build
     test
     ;;
@@ -394,6 +395,7 @@ case "$cmd" in
     export CI=1
     export USE_TEST_CACHE=0
     export CI_FULL=1
+    export ACCEPT_DISABLED_AVM_VK_TREE_ROOT=1
     build
     test
     bench

--- a/yarn-project/aztec/src/cli/cmds/start_prover_agent.ts
+++ b/yarn-project/aztec/src/cli/cmds/start_prover_agent.ts
@@ -28,12 +28,6 @@ export async function startProverAgent(
     process.exit(1);
   }
 
-  // Check if running on ARM and fast-fail if so.
-  if (process.arch.startsWith('arm')) {
-    userLog(`Prover agent is not supported on ARM architecture (detected: ${process.arch}). Exiting.`);
-    process.exit(1);
-  }
-
   const config = {
     ...getProverNodeAgentConfigFromEnv(), // get default config from env
     ...extractRelevantOptions<ProverAgentConfig>(options, proverAgentConfigMappings, 'proverAgent'), // override with command line options

--- a/yarn-project/aztec/src/cli/cmds/start_prover_node.ts
+++ b/yarn-project/aztec/src/cli/cmds/start_prover_node.ts
@@ -35,12 +35,6 @@ export async function startProverNode(
     process.exit(1);
   }
 
-  // Check if running on ARM and fast-fail if so.
-  if (process.arch.startsWith('arm')) {
-    userLog(`Prover node is not supported on ARM architecture (detected: ${process.arch}). Exiting.`);
-    process.exit(1);
-  }
-
   let proverConfig = {
     ...getProverNodeConfigFromEnv(), // get default config from env
     ...extractRelevantOptions<ProverNodeConfig>(options, proverNodeConfigMappings, 'proverNode'), // override with command line options

--- a/yarn-project/aztec/src/test/testnet_compatibility.test.ts
+++ b/yarn-project/aztec/src/test/testnet_compatibility.test.ts
@@ -11,10 +11,15 @@ import { getGenesisValues } from '@aztec/world-state/testing';
  */
 describe('Testnet compatibility', () => {
   it('has expected VK tree root', () => {
-    const expectedRoots = [
-      Fr.fromHexString('0x1a5079b513266d78cf61cc98914d568e800982d8b2b9fe79c90f47ce27ffa2ec'),
-      Fr.fromHexString('0x19e3d93ad6369e960f28fdda0da5110129c2db67f49445d8406001eab1a1ae6a'), // the AVM is disabled on ARM and that leads to a different VK tree root. Not ideal but we don't support proving on ARM for now.
-    ];
+    const expectedRoots = [Fr.fromHexString('0x1a5079b513266d78cf61cc98914d568e800982d8b2b9fe79c90f47ce27ffa2ec')];
+
+    if (process.env.ACCEPT_DISABLED_AVM_VK_TREE_ROOT === '1') {
+      expectedRoots.push(
+        //  Accept the VK tree root when the AVM is disabled (the AVM is only enabled on ARM release builds because of build times).
+        Fr.fromHexString('0x19e3d93ad6369e960f28fdda0da5110129c2db67f49445d8406001eab1a1ae6a'),
+      );
+    }
+
     expect(expectedRoots).toContainEqual(getVKTreeRoot());
   });
   it('has expected Protocol Contracts tree root', () => {


### PR DESCRIPTION
This PR re-enables running the prover-node and prover-agents on ARM machines.
Backport #16220 
