### PR TITLE
chore: Add test to check that inner vk in Goblin Avm Recursive verifier can be constructed without a witness

### DIFF
--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_format.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_format.cpp
@@ -542,8 +542,6 @@ process_avm_recursion_constraints(Builder& builder,
     // Add recursion constraints
     size_t idx = 0;
     for (auto& constraint : constraint_system.avm_recursion_constraints) {
-        // TODO(https://github.com/AztecProtocol/barretenberg/issues/1303): Utilize the version of this method that
-        // employs the Goblinized AVM recursive verifier.
         HonkRecursionConstraintOutput<Builder> avm2_recursion_output =
             create_avm2_recursion_constraints_goblin(builder, constraint, has_valid_witness_assignments);
         if (output.points_accumulator.has_data) {

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/avm2_recursion_constraint.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/avm2_recursion_constraint.cpp
@@ -9,6 +9,7 @@
 #include "avm2_recursion_constraint.hpp"
 
 #include "barretenberg/constants.hpp"
+#include "barretenberg/dsl/acir_format/avm2_recursion_constraint_mock.hpp"
 #include "barretenberg/dsl/acir_format/proof_surgeon.hpp"
 #include "barretenberg/flavor/flavor.hpp"
 #include "barretenberg/flavor/ultra_flavor.hpp"
@@ -28,121 +29,6 @@ using namespace bb;
 using field_ct = stdlib::field_t<Builder>;
 using bn254 = stdlib::bn254<Builder>;
 using PairingPoints = bb::stdlib::recursion::PairingPoints<Builder>;
-
-namespace {
-/**
- * @brief Creates a dummy vkey and proof object.
- * @details Populates the key and proof vectors with dummy values in the write_vk case when we do not have a valid
- * witness. The bulk of the logic is setting up certain values correctly like the circuit size, aggregation object, and
- * commitments.
- *
- * @param builder
- * @param proof_size Size of proof with NO public inputs
- * @param public_inputs_size Total size of public inputs including aggregation object
- * @param key_fields
- * @param proof_fields
- */
-void create_dummy_vkey_and_proof(Builder& builder,
-                                 [[maybe_unused]] size_t proof_size,
-                                 size_t public_inputs_size,
-                                 const std::vector<field_ct>& key_fields,
-                                 const std::vector<field_ct>& proof_fields)
-{
-    using Flavor = avm2::AvmFlavor;
-
-    // Relevant source for proof layout: AvmFlavor::Transcript::serialize_full_transcript()
-    // TODO(#13390): Revive this assertion (and remove the >= 0 one) once we freeze the number of colums in AVM.
-    // assert((proof_size - Flavor::NUM_WITNESS_ENTITIES * Flavor::NUM_FRS_COM -
-    //         (Flavor::NUM_ALL_ENTITIES + 1) * Flavor::NUM_FRS_FR - Flavor::NUM_FRS_COM) %
-    //            (Flavor::NUM_FRS_COM + Flavor::NUM_FRS_FR * (Flavor::BATCHED_RELATION_PARTIAL_LENGTH + 1)) ==
-    //        0);
-
-    // Derivation of circuit size based on the proof
-    // TODO#13390): Revive the following code once we freeze the number of colums in AVM.
-    // const auto log_circuit_size =
-    //     (proof_size - Flavor::NUM_WITNESS_ENTITIES * Flavor::NUM_FRS_COM -
-    //      (Flavor::NUM_ALL_ENTITIES + 1) * Flavor::NUM_FRS_FR - Flavor::NUM_FRS_COM) /
-    //     (Flavor::NUM_FRS_COM + Flavor::NUM_FRS_FR * (Flavor::BATCHED_RELATION_PARTIAL_LENGTH + 1));
-    const auto log_circuit_size = CONST_PROOF_SIZE_LOG_N;
-
-    // First key field is log circuit size
-    builder.set_variable(key_fields[0].witness_index, log_circuit_size);
-    // Second key field is number of public inputs
-    builder.set_variable(key_fields[1].witness_index, public_inputs_size);
-
-    size_t offset = 2;
-    for (size_t i = 0; i < Flavor::NUM_PRECOMPUTED_ENTITIES; ++i) {
-        auto comm = curve::BN254::AffineElement::one() * fr::random_element();
-        auto frs = field_conversion::convert_to_bn254_frs(comm);
-        builder.set_variable(key_fields[offset].witness_index, frs[0]);
-        builder.set_variable(key_fields[offset + 1].witness_index, frs[1]);
-        builder.set_variable(key_fields[offset + 2].witness_index, frs[2]);
-        builder.set_variable(key_fields[offset + 3].witness_index, frs[3]);
-        offset += 4;
-    }
-
-    // This routine is adding some placeholders for avm proof and avm vk in the case where witnesses are not present.
-    // TODO(#14234)[Unconditional PIs validation]: Remove next line and use offset == 0 for subsequent line.
-    builder.set_variable(proof_fields[0].witness_index, 1);
-    builder.set_variable(proof_fields[1].witness_index, 1 << log_circuit_size);
-    offset = 2; // TODO(#14234)[Unconditional PIs validation]: reset offset = 1
-
-    // Witness Commitments
-    for (size_t i = 0; i < Flavor::NUM_WITNESS_ENTITIES; i++) {
-        auto comm = curve::BN254::AffineElement::one() * fr::random_element();
-        auto frs = field_conversion::convert_to_bn254_frs(comm);
-        builder.set_variable(proof_fields[offset].witness_index, frs[0]);
-        builder.set_variable(proof_fields[offset + 1].witness_index, frs[1]);
-        builder.set_variable(proof_fields[offset + 2].witness_index, frs[2]);
-        builder.set_variable(proof_fields[offset + 3].witness_index, frs[3]);
-        offset += 4;
-    }
-
-    // now the univariates
-    for (size_t i = 0; i < CONST_PROOF_SIZE_LOG_N * Flavor::BATCHED_RELATION_PARTIAL_LENGTH; i++) {
-        builder.set_variable(proof_fields[offset].witness_index, fr::random_element());
-        offset++;
-    }
-
-    // now the sumcheck evaluations
-    for (size_t i = 0; i < Flavor::NUM_ALL_ENTITIES; i++) {
-        builder.set_variable(proof_fields[offset].witness_index, fr::random_element());
-        offset++;
-    }
-
-    // now the gemini fold commitments which are CONST_PROOF_SIZE_LOG_N - 1
-    for (size_t i = 1; i < CONST_PROOF_SIZE_LOG_N; i++) {
-        auto comm = curve::BN254::AffineElement::one() * fr::random_element();
-        auto frs = field_conversion::convert_to_bn254_frs(comm);
-        builder.set_variable(proof_fields[offset].witness_index, frs[0]);
-        builder.set_variable(proof_fields[offset + 1].witness_index, frs[1]);
-        builder.set_variable(proof_fields[offset + 2].witness_index, frs[2]);
-        builder.set_variable(proof_fields[offset + 3].witness_index, frs[3]);
-        offset += 4;
-    }
-
-    // the gemini fold evaluations which are CONST_PROOF_SIZE_LOG_N
-    for (size_t i = 0; i < CONST_PROOF_SIZE_LOG_N; i++) {
-        builder.set_variable(proof_fields[offset].witness_index, fr::random_element());
-        offset++;
-    }
-
-    // lastly the shplonk batched quotient commitment and kzg quotient commitment
-    for (size_t i = 0; i < 2; i++) {
-        auto comm = curve::BN254::AffineElement::one() * fr::random_element();
-        auto frs = field_conversion::convert_to_bn254_frs(comm);
-        builder.set_variable(proof_fields[offset].witness_index, frs[0]);
-        builder.set_variable(proof_fields[offset + 1].witness_index, frs[1]);
-        builder.set_variable(proof_fields[offset + 2].witness_index, frs[2]);
-        builder.set_variable(proof_fields[offset + 3].witness_index, frs[3]);
-        offset += 4;
-    }
-
-    // TODO(#13390): Revive the following assertion once we freeze the number of colums in AVM.
-    // ASSERT(offset == proof_size);
-}
-
-} // namespace
 
 /**
  * @brief Add constraints associated with recursive verification of an AVM2 proof using Goblin

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/avm2_recursion_constraint_mock.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/avm2_recursion_constraint_mock.cpp
@@ -1,0 +1,112 @@
+#ifndef DISABLE_AZTEC_VM
+
+#include "barretenberg/dsl/acir_format/avm2_recursion_constraint_mock.hpp"
+#include "barretenberg/vm2/common/constants.hpp"
+#include "barretenberg/vm2/constraining/flavor.hpp"
+
+#include <cstddef>
+
+namespace acir_format {
+
+void create_dummy_vkey_and_proof(Builder& builder,
+                                 [[maybe_unused]] size_t proof_size,
+                                 size_t public_inputs_size,
+                                 const std::vector<field_ct>& key_fields,
+                                 const std::vector<field_ct>& proof_fields)
+{
+    using Flavor = avm2::AvmFlavor;
+
+    // Relevant source for proof layout: AvmFlavor::Transcript::serialize_full_transcript()
+    // TODO(#13390): Revive this assertion (and remove the >= 0 one) once we freeze the number of colums in AVM.
+    // assert((proof_size - Flavor::NUM_WITNESS_ENTITIES * Flavor::NUM_FRS_COM -
+    //         (Flavor::NUM_ALL_ENTITIES + 1) * Flavor::NUM_FRS_FR - Flavor::NUM_FRS_COM) %
+    //            (Flavor::NUM_FRS_COM + Flavor::NUM_FRS_FR * (Flavor::BATCHED_RELATION_PARTIAL_LENGTH + 1)) ==
+    //        0);
+
+    // Derivation of circuit size based on the proof
+    // TODO#13390): Revive the following code once we freeze the number of colums in AVM.
+    // const auto log_circuit_size =
+    //     (proof_size - Flavor::NUM_WITNESS_ENTITIES * Flavor::NUM_FRS_COM -
+    //      (Flavor::NUM_ALL_ENTITIES + 1) * Flavor::NUM_FRS_FR - Flavor::NUM_FRS_COM) /
+    //     (Flavor::NUM_FRS_COM + Flavor::NUM_FRS_FR * (Flavor::BATCHED_RELATION_PARTIAL_LENGTH + 1));
+    const auto log_circuit_size = numeric::get_msb(avm2::CIRCUIT_SUBGROUP_SIZE);
+
+    // First key field is log circuit size
+    builder.set_variable(key_fields[0].witness_index, log_circuit_size);
+    // Second key field is number of public inputs
+    builder.set_variable(key_fields[1].witness_index, public_inputs_size);
+
+    size_t offset = 2;
+    for (size_t i = 0; i < Flavor::NUM_PRECOMPUTED_ENTITIES; ++i) {
+        auto comm = curve::BN254::AffineElement::one() * fr::random_element();
+        auto frs = field_conversion::convert_to_bn254_frs(comm);
+        builder.set_variable(key_fields[offset].witness_index, frs[0]);
+        builder.set_variable(key_fields[offset + 1].witness_index, frs[1]);
+        builder.set_variable(key_fields[offset + 2].witness_index, frs[2]);
+        builder.set_variable(key_fields[offset + 3].witness_index, frs[3]);
+        offset += 4;
+    }
+
+    // This routine is adding some placeholders for avm proof and avm vk in the case where witnesses are not present.
+    // TODO(#14234)[Unconditional PIs validation]: Remove next line and use offset == 0 for subsequent line.
+    builder.set_variable(proof_fields[0].witness_index, 0);
+    builder.set_variable(proof_fields[1].witness_index, 1 << log_circuit_size);
+    offset = 2; // TODO(#14234)[Unconditional PIs validation]: reset offset = 1
+
+    // Witness Commitments
+    for (size_t i = 0; i < Flavor::NUM_WITNESS_ENTITIES; i++) {
+        auto comm = curve::BN254::AffineElement::one() * fr::random_element();
+        auto frs = field_conversion::convert_to_bn254_frs(comm);
+        builder.set_variable(proof_fields[offset].witness_index, frs[0]);
+        builder.set_variable(proof_fields[offset + 1].witness_index, frs[1]);
+        builder.set_variable(proof_fields[offset + 2].witness_index, frs[2]);
+        builder.set_variable(proof_fields[offset + 3].witness_index, frs[3]);
+        offset += 4;
+    }
+
+    // now the univariates
+    for (size_t i = 0; i < CONST_PROOF_SIZE_LOG_N * Flavor::BATCHED_RELATION_PARTIAL_LENGTH; i++) {
+        builder.set_variable(proof_fields[offset].witness_index, fr::random_element());
+        offset++;
+    }
+
+    // now the sumcheck evaluations
+    for (size_t i = 0; i < Flavor::NUM_ALL_ENTITIES; i++) {
+        builder.set_variable(proof_fields[offset].witness_index, fr::random_element());
+        offset++;
+    }
+
+    // now the gemini fold commitments which are CONST_PROOF_SIZE_LOG_N - 1
+    for (size_t i = 1; i < CONST_PROOF_SIZE_LOG_N; i++) {
+        auto comm = curve::BN254::AffineElement::one() * fr::random_element();
+        auto frs = field_conversion::convert_to_bn254_frs(comm);
+        builder.set_variable(proof_fields[offset].witness_index, frs[0]);
+        builder.set_variable(proof_fields[offset + 1].witness_index, frs[1]);
+        builder.set_variable(proof_fields[offset + 2].witness_index, frs[2]);
+        builder.set_variable(proof_fields[offset + 3].witness_index, frs[3]);
+        offset += 4;
+    }
+
+    // the gemini fold evaluations which are CONST_PROOF_SIZE_LOG_N
+    for (size_t i = 0; i < CONST_PROOF_SIZE_LOG_N; i++) {
+        builder.set_variable(proof_fields[offset].witness_index, fr::random_element());
+        offset++;
+    }
+
+    // lastly the shplonk batched quotient commitment and kzg quotient commitment
+    for (size_t i = 0; i < 2; i++) {
+        auto comm = curve::BN254::AffineElement::one() * fr::random_element();
+        auto frs = field_conversion::convert_to_bn254_frs(comm);
+        builder.set_variable(proof_fields[offset].witness_index, frs[0]);
+        builder.set_variable(proof_fields[offset + 1].witness_index, frs[1]);
+        builder.set_variable(proof_fields[offset + 2].witness_index, frs[2]);
+        builder.set_variable(proof_fields[offset + 3].witness_index, frs[3]);
+        offset += 4;
+    }
+
+    // TODO(#13390): Revive the following assertion once we freeze the number of colums in AVM.
+    // ASSERT(offset == proof_size);
+}
+
+} // namespace acir_format
+#endif // DISABLE_AZTEC_VM

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/avm2_recursion_constraint_mock.hpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/avm2_recursion_constraint_mock.hpp
@@ -1,0 +1,31 @@
+#ifndef DISABLE_AZTEC_VM
+
+#include "barretenberg/dsl/acir_format/ecdsa_secp256k1.hpp"
+#include "barretenberg/stdlib/primitives/field/field.hpp"
+#include <cstddef>
+
+namespace acir_format {
+
+using namespace bb;
+using field_ct = stdlib::field_t<Builder>;
+
+/**
+ * @brief Creates a dummy vkey and proof object.
+ * @details Populates the key and proof vectors with dummy values in the write_vk case when we do not have a valid
+ * witness. The bulk of the logic is setting up certain values correctly like the circuit size, aggregation object, and
+ * commitments.
+ *
+ * @param builder
+ * @param proof_size Size of proof with NO public inputs
+ * @param public_inputs_size Total size of public inputs including aggregation object
+ * @param key_fields
+ * @param proof_fields
+ */
+void create_dummy_vkey_and_proof(Builder& builder,
+                                 [[maybe_unused]] size_t proof_size,
+                                 size_t public_inputs_size,
+                                 const std::vector<field_ct>& key_fields,
+                                 const std::vector<field_ct>& proof_fields);
+
+} // namespace acir_format
+#endif // DISABLE_AZTEC_VM

--- a/barretenberg/cpp/src/barretenberg/flavor/mega_recursive_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/mega_recursive_flavor.hpp
@@ -179,6 +179,20 @@ template <typename BuilderType> class MegaRecursiveFlavor_ {
             }
             return VerificationKey(builder, vk_fields);
         }
+
+        /**
+         * @brief Fixes witnesses of VK to be constants.
+         *
+         */
+        void fix_witness()
+        {
+            this->log_circuit_size.fix_witness();
+            this->num_public_inputs.fix_witness();
+            this->pub_inputs_offset.fix_witness();
+            for (Commitment& commitment : this->get_all()) {
+                commitment.fix_witness();
+            }
+        }
     };
 
     /**

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/recursion/goblin_avm_recursive_verifier.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/recursion/goblin_avm_recursive_verifier.hpp
@@ -130,8 +130,10 @@ class AvmGoblinRecursiveVerifier {
         // Recursively verify the Mega proof \pi_M in the Ultra circuit
         // All verifier components share a single transcript
         auto transcript = std::make_shared<MegaRecursiveFlavor::Transcript>();
-        // TODO(https://github.com/AztecProtocol/barretenberg/issues/1305): Mega + Goblin VKs must be circuit constants.
         auto mega_vk_and_hash = std::make_shared<MegaRecursiveVKAndHash>(ultra_builder, inner_output.mega_vk);
+        // Fix the inner mega vk and vk hash to be constants in the outer circuit.
+        mega_vk_and_hash->vk->fix_witness();
+        mega_vk_and_hash->hash.fix_witness();
         MegaRecursiveVerifier mega_verifier(&ultra_builder, mega_vk_and_hash, transcript);
         stdlib::Proof<UltraBuilder> mega_proof(ultra_builder, inner_output.mega_proof);
         auto mega_verifier_output = mega_verifier.verify_proof(mega_proof);

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/recursion/recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/recursion/recursive_verifier.cpp
@@ -66,7 +66,6 @@ AvmRecursiveVerifier::PairingPoints AvmRecursiveVerifier::verify_proof(
     return verify_proof(stdlib_proof, public_inputs_ct);
 }
 
-// TODO(#991): (see https://github.com/AztecProtocol/barretenberg/issues/991)
 // TODO(#14234)[Unconditional PIs validation]: rename stdlib_proof_with_pi_flag to stdlib_proof
 AvmRecursiveVerifier::PairingPoints AvmRecursiveVerifier::verify_proof(
     const stdlib::Proof<Builder>& stdlib_proof_with_pi_flag, const std::vector<std::vector<FF>>& public_inputs)


### PR DESCRIPTION
* Move key and proof mocking logic to their own file
* Define new test to check that the vk of the inner circuit in the Goblin Avm Recursive Verifier can be constructed without a witness