### PR TITLE
fix: Fix AVM massive mem consumption.

### DIFF
--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/flavor.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/flavor.cpp
@@ -3,6 +3,28 @@
 
 namespace bb::avm2 {
 
+// Define the Relations type only in this compilation unit
+using Relations = AvmFlavor::Relations_<AvmFlavorSettings::FF>;
+
+// Verify that the hardcoded constants in the header match the actual computed values
+static_assert(AvmFlavor::NUM_SUBRELATIONS == compute_number_of_subrelations<Relations>(),
+              "NUM_SUBRELATIONS mismatch! Update the value in flavor.hpp");
+static_assert(AvmFlavor::MAX_PARTIAL_RELATION_LENGTH == compute_max_partial_relation_length<Relations>(),
+              "MAX_PARTIAL_RELATION_LENGTH mismatch! Update the value in flavor.hpp");
+static_assert(AvmFlavor::NUM_RELATIONS == std::tuple_size_v<Relations>,
+              "NUM_RELATIONS mismatch! Update the value in flavor.hpp");
+static_assert(AvmFlavor::BATCHED_RELATION_PARTIAL_LENGTH == AvmFlavor::MAX_PARTIAL_RELATION_LENGTH + 1,
+              "BATCHED_RELATION_PARTIAL_LENGTH mismatch!");
+static_assert(AvmFlavor::MAX_PARTIAL_RELATION_LENGTH < 8, "MAX_PARTIAL_RELATION_LENGTH must be less than 8");
+
+// Define the type aliases that depend on Relations here where it's already instantiated
+// These are used internally by the flavor implementation but not exposed in the header
+// to avoid instantiating all relations in every compilation unit
+namespace {
+using SumcheckTupleOfTuplesOfUnivariates = decltype(create_sumcheck_tuple_of_tuples_of_univariates<Relations>());
+using TupleOfArraysOfValues = decltype(create_tuple_of_arrays_of_values<Relations>());
+} // namespace
+
 AvmFlavor::ProverPolynomials::ProverPolynomials(ProvingKey& proving_key)
 {
     for (auto [prover_poly, key_poly] : zip_view(this->get_unshifted(), proving_key.get_all())) {

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/flavor.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/flavor.cpp
@@ -13,8 +13,6 @@ static_assert(AvmFlavor::MAX_PARTIAL_RELATION_LENGTH == compute_max_partial_rela
               "MAX_PARTIAL_RELATION_LENGTH mismatch! Update the value in flavor.hpp");
 static_assert(AvmFlavor::NUM_RELATIONS == std::tuple_size_v<Relations>,
               "NUM_RELATIONS mismatch! Update the value in flavor.hpp");
-static_assert(AvmFlavor::BATCHED_RELATION_PARTIAL_LENGTH == AvmFlavor::MAX_PARTIAL_RELATION_LENGTH + 1,
-              "BATCHED_RELATION_PARTIAL_LENGTH mismatch!");
 static_assert(AvmFlavor::MAX_PARTIAL_RELATION_LENGTH < 8, "MAX_PARTIAL_RELATION_LENGTH must be less than 8");
 
 // Define the type aliases that depend on Relations here where it's already instantiated

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/flavor.hpp
@@ -78,23 +78,23 @@ class AvmFlavor {
     // Need to be templated for recursive verifier
     template <typename FF_> using Relations_ = tuple_cat_t<MainRelations_<FF_>, LookupRelations_<FF_>>;
 
-    static constexpr size_t NUM_SUBRELATIONS = 2221;         // Will be verified in flavor.cpp
-    static constexpr size_t MAX_PARTIAL_RELATION_LENGTH = 7; // Will be verified in flavor.cpp
-    static constexpr size_t NUM_RELATIONS = 413;             // Will be verified in flavor.cpp
-    static constexpr size_t BATCHED_RELATION_PARTIAL_LENGTH = MAX_PARTIAL_RELATION_LENGTH + 1;
-
-    // SubrelationSeparators only depends on constants, so it's safe to define
-    using SubrelationSeparators = std::array<FF, NUM_SUBRELATIONS - 1>;
-
-    // MEMORY OPTIMIZATION: These type aliases cause instantiation of all 413 relations.
-    // To avoid this in test files, we only define them when actually needed.
-    // Files that need these (prover.cpp, verifier.cpp) should define AVM_FLAVOR_NEED_SUMCHECK_TYPES
+    // MEMORY OPTIMIZATION: These type aliases cause instantiation of all relations.
+    // To avoid this in files that don't need them, e.g. tests, we only define them when actually needed.
+    // Files that need these e.g. prover.cpp, verifier.cpp, should define AVM_FLAVOR_NEED_SUMCHECK_TYPES
     // before including this header.
 #ifdef AVM_FLAVOR_NEED_SUMCHECK_TYPES
     using Relations = Relations_<FF>;
     using SumcheckTupleOfTuplesOfUnivariates = decltype(create_sumcheck_tuple_of_tuples_of_univariates<Relations>());
     using TupleOfArraysOfValues = decltype(create_tuple_of_arrays_of_values<Relations>());
 #endif
+
+    // These are hardcoded here and checked by explicit instantiation in flavor.cpp.
+    // Reduces compilation time/mem massively for many cpp units as we don't need to instantiate all the relations.
+    static constexpr size_t NUM_SUBRELATIONS = 2288;
+    static constexpr size_t MAX_PARTIAL_RELATION_LENGTH = 7;
+    static constexpr size_t NUM_RELATIONS = 416;
+    static constexpr size_t BATCHED_RELATION_PARTIAL_LENGTH = MAX_PARTIAL_RELATION_LENGTH + 1;
+    using SubrelationSeparators = std::array<FF, NUM_SUBRELATIONS - 1>;
 
     static constexpr bool has_zero_row = true;
 

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/flavor.hpp
@@ -77,24 +77,24 @@ class AvmFlavor {
 
     // Need to be templated for recursive verifier
     template <typename FF_> using Relations_ = tuple_cat_t<MainRelations_<FF_>, LookupRelations_<FF_>>;
-    using Relations = Relations_<FF>;
 
-    static constexpr size_t NUM_SUBRELATIONS = compute_number_of_subrelations<Relations>();
+    static constexpr size_t NUM_SUBRELATIONS = 2221;         // Will be verified in flavor.cpp
+    static constexpr size_t MAX_PARTIAL_RELATION_LENGTH = 7; // Will be verified in flavor.cpp
+    static constexpr size_t NUM_RELATIONS = 413;             // Will be verified in flavor.cpp
+    static constexpr size_t BATCHED_RELATION_PARTIAL_LENGTH = MAX_PARTIAL_RELATION_LENGTH + 1;
 
+    // SubrelationSeparators only depends on constants, so it's safe to define
     using SubrelationSeparators = std::array<FF, NUM_SUBRELATIONS - 1>;
 
-    static constexpr size_t MAX_PARTIAL_RELATION_LENGTH = compute_max_partial_relation_length<Relations>();
-
-    static_assert(MAX_PARTIAL_RELATION_LENGTH < 8, "MAX_PARTIAL_RELATION_LENGTH must be less than 8");
-
-    // BATCHED_RELATION_PARTIAL_LENGTH = algebraic degree of sumcheck relation *after* multiplying by the `pow_zeta`
-    // random polynomial e.g. For \sum(x) [A(x) * B(x) + C(x)] * PowZeta(X), relation length = 2 and random relation
-    // length = 3
-    static constexpr size_t BATCHED_RELATION_PARTIAL_LENGTH = MAX_PARTIAL_RELATION_LENGTH + 1;
-    static constexpr size_t NUM_RELATIONS = std::tuple_size_v<Relations>;
-
+    // MEMORY OPTIMIZATION: These type aliases cause instantiation of all 413 relations.
+    // To avoid this in test files, we only define them when actually needed.
+    // Files that need these (prover.cpp, verifier.cpp) should define AVM_FLAVOR_NEED_SUMCHECK_TYPES
+    // before including this header.
+#ifdef AVM_FLAVOR_NEED_SUMCHECK_TYPES
+    using Relations = Relations_<FF>;
     using SumcheckTupleOfTuplesOfUnivariates = decltype(create_sumcheck_tuple_of_tuples_of_univariates<Relations>());
     using TupleOfArraysOfValues = decltype(create_tuple_of_arrays_of_values<Relations>());
+#endif
 
     static constexpr bool has_zero_row = true;
 

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/prover.cpp
@@ -1,3 +1,5 @@
+// Enable sumcheck types that cause heavy template instantiation
+#define AVM_FLAVOR_NEED_SUMCHECK_TYPES
 #include "barretenberg/vm2/constraining/prover.hpp"
 
 #include "barretenberg/commitment_schemes/claim.hpp"

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/verifier.cpp
@@ -1,3 +1,5 @@
+// Enable sumcheck types that cause heavy template instantiation
+#define AVM_FLAVOR_NEED_SUMCHECK_TYPES
 #include "barretenberg/vm2/constraining/verifier.hpp"
 
 #include "barretenberg/commitment_schemes/shplonk/shplemini.hpp"


### PR DESCRIPTION
This line:
```
using Relations = Relations_<FF>;
```
In `flavor.hpp` effectively instantiates the entire set of relations, in every cpp file that directly or indirectly includes this header.
This is kind of a hack, but reduces that instantiation only to files that actually need it. It does this in two ways:
* We hardcode values such as `NUM_SUBRELATIONS` in the header rather than computing them from an instantiation. These hardcoded values are checked at compile time when compiling `flavor.cpp`. Will require developers to adjust the values as they make changes.
* We define `AVM_FLAVOR_NEED_SUMCHECK_TYPES=1` in cpp files that actually need `SumcheckTupleOfTuplesOfUnivariates`. e.g. prover/verififier.cpp. Many test files do not this.

This is hacky but it works. I think the root issue is that we have this overaggregated flavor class that could perhaps be aggregated from parts broken down further and only have the required parts imported where needed.

I don't know if possible. That's a bigger job I'm not pursuing...

This reduces peak sysbox memory usage during bb build with avm from 250g to about 80gb.