### PR TITLE
chore: Ensure proving job txs are sorted

### DIFF
--- a/yarn-project/prover-node/src/job/epoch-proving-job-data.test.ts
+++ b/yarn-project/prover-node/src/job/epoch-proving-job-data.test.ts
@@ -11,10 +11,13 @@ import {
 
 describe('EpochProvingJobData', () => {
   it('serializes and deserializes', async () => {
+    const txArray = times(8, () => Tx.random());
+    const txs = new Map<string, Tx>(txArray.map(tx => [tx.getTxHash().toString(), tx]));
+
     const jobData: EpochProvingJobData = {
       epochNumber: 3n,
       blocks: await timesAsync(4, i => L2Block.random(i + 1)),
-      txs: times(8, () => Tx.random()),
+      txs,
       l1ToL2Messages: {
         0: [Fr.random(), Fr.random()],
         1: [Fr.random()],

--- a/yarn-project/prover-node/src/job/epoch-proving-job.test.ts
+++ b/yarn-project/prover-node/src/job/epoch-proving-job.test.ts
@@ -49,9 +49,11 @@ describe('epoch-proving-job', () => {
 
   // Subject factory
   const createJob = (opts: { deadline?: Date; parallelBlockLimit?: number } = {}) => {
+    const txsMap = new Map<string, Tx>(txs.map(tx => [tx.getTxHash().toString(), tx]));
+
     const data: EpochProvingJobData = {
       blocks,
-      txs,
+      txs: txsMap,
       epochNumber: BigInt(epochNumber),
       l1ToL2Messages: fromEntries(blocks.map(b => [b.number, []])),
       previousBlockHeader: initialHeader,

--- a/yarn-project/prover-node/src/job/epoch-proving-job.ts
+++ b/yarn-project/prover-node/src/job/epoch-proving-job.ts
@@ -125,7 +125,7 @@ export class EpochProvingJob implements Traceable {
 
       const finalBlobBatchingChallenges = await BatchedBlob.precomputeBatchedBlobChallenges(allBlobs);
       this.prover.startNewEpoch(epochNumber, fromBlock, epochSizeBlocks, finalBlobBatchingChallenges);
-      await this.prover.startTubeCircuits(this.txs);
+      await this.prover.startTubeCircuits(Array.from(this.txs.values()));
 
       await asyncPool(this.config.parallelBlockLimit ?? 32, this.blocks, async block => {
         this.checkState();
@@ -307,7 +307,7 @@ export class EpochProvingJob implements Traceable {
   }
 
   private getTxs(block: L2Block): Tx[] {
-    return block.body.txEffects.map(txEffect => this.txs.find(tx => tx.getTxHash().equals(txEffect.txHash))!);
+    return block.body.txEffects.map(txEffect => this.txs.get(txEffect.txHash.toString())!);
   }
 
   private getL1ToL2Messages(block: L2Block) {

--- a/yarn-project/prover-node/src/job/epoch-proving-job.ts
+++ b/yarn-project/prover-node/src/job/epoch-proving-job.ts
@@ -307,11 +307,7 @@ export class EpochProvingJob implements Traceable {
   }
 
   private getTxs(block: L2Block): Tx[] {
-    const txHashes = block.body.txEffects.map(tx => tx.txHash.toBigInt());
-    const txsAndHashes = this.txs.map(tx => ({ tx, hash: tx.getTxHash() }));
-    return txsAndHashes
-      .filter(txAndHash => txHashes.includes(txAndHash.hash.toBigInt()))
-      .map(txAndHash => txAndHash.tx);
+    return block.body.txEffects.map(txEffect => this.txs.find(tx => tx.getTxHash().equals(txEffect.txHash))!);
   }
 
   private getL1ToL2Messages(block: L2Block) {

--- a/yarn-project/prover-node/src/prover-node.ts
+++ b/yarn-project/prover-node/src/prover-node.ts
@@ -24,6 +24,7 @@ import {
 } from '@aztec/stdlib/interfaces/server';
 import type { L1ToL2MessageSource } from '@aztec/stdlib/messaging';
 import type { P2PClientType } from '@aztec/stdlib/p2p';
+import type { Tx } from '@aztec/stdlib/tx';
 import {
   Attributes,
   L1Metrics,
@@ -303,7 +304,8 @@ export class ProverNode implements EpochMonitorHandler, ProverNodeApi, Traceable
   @trackSpan('ProverNode.gatherEpochData', epochNumber => ({ [Attributes.EPOCH_NUMBER]: Number(epochNumber) }))
   private async gatherEpochData(epochNumber: bigint): Promise<EpochProvingJobData> {
     const blocks = await this.gatherBlocks(epochNumber);
-    const txs = await this.gatherTxs(epochNumber, blocks);
+    const txArray = await this.gatherTxs(epochNumber, blocks);
+    const txs = new Map<string, Tx>(txArray.map(tx => [tx.getTxHash().toString(), tx]));
     const l1ToL2Messages = await this.gatherMessages(epochNumber, blocks);
     const previousBlockHeader = await this.gatherPreviousBlockHeader(epochNumber, blocks[0]);
     const [lastBlock] = await this.l2BlockSource.getPublishedBlocks(blocks.at(-1)!.number, 1);


### PR DESCRIPTION
The txs loaded in the epoch proving job implicitly relied on the txs being provided in the same order as they are in the block. However, if tx-collection returned them out of order, then the proving job would try processing them out of order.

This change ensures the txs are always processed in order.
