### PR TITLE
chore(rollup): coinbase | prover rewards not limited to sender

### DIFF
--- a/l1-contracts/src/core/RollupCore.sol
+++ b/l1-contracts/src/core/RollupCore.sol
@@ -342,29 +342,29 @@ contract RollupCore is EIP712("Aztec Rollup", "1"), Ownable, IStakingCore, IVali
   /**
    * @notice Claims accumulated rewards for a sequencer (block proposer)
    * @dev Rewards must be enabled via isRewardsClaimable. Transfers all accumulated rewards to the recipient.
-   * @param _recipient The address to receive the rewards
+   * @param _coinbase The address that has accumulated the rewards - rewards are sent to this address
    * @return The amount of rewards claimed
    */
-  function claimSequencerRewards(address _recipient) external override(IRollupCore) returns (uint256) {
+  function claimSequencerRewards(address _coinbase) external override(IRollupCore) returns (uint256) {
     require(isRewardsClaimable, Errors.Rollup__RewardsNotClaimable());
-    return RewardLib.claimSequencerRewards(_recipient);
+    return RewardLib.claimSequencerRewards(_coinbase);
   }
 
   /**
    * @notice Claims prover rewards for specified epochs
    * @dev Rewards must be enabled. Provers earn rewards for successfully proving epoch transitions.
    *      Each epoch can only be claimed once per prover.
-   * @param _recipient The address to receive the rewards
+   * @param _coinbase The address that has accumulated the rewards - rewards are sent to this address
    * @param _epochs Array of epochs to claim rewards for
    * @return The total amount of rewards claimed
    */
-  function claimProverRewards(address _recipient, Epoch[] memory _epochs)
+  function claimProverRewards(address _coinbase, Epoch[] memory _epochs)
     external
     override(IRollupCore)
     returns (uint256)
   {
     require(isRewardsClaimable, Errors.Rollup__RewardsNotClaimable());
-    return RewardLib.claimProverRewards(_recipient, _epochs);
+    return RewardLib.claimProverRewards(_coinbase, _epochs);
   }
 
   /**

--- a/l1-contracts/src/core/libraries/rollup/RewardLib.sol
+++ b/l1-contracts/src/core/libraries/rollup/RewardLib.sol
@@ -81,18 +81,18 @@ library RewardLib {
     rewardStorage.config = _config;
   }
 
-  function claimSequencerRewards(address _recipient) internal returns (uint256) {
+  function claimSequencerRewards(address _sequencer) internal returns (uint256) {
     RewardStorage storage rewardStorage = getStorage();
 
     RollupStore storage rollupStore = STFLib.getStorage();
-    uint256 amount = rewardStorage.sequencerRewards[msg.sender];
-    rewardStorage.sequencerRewards[msg.sender] = 0;
-    rollupStore.config.feeAsset.transfer(_recipient, amount);
+    uint256 amount = rewardStorage.sequencerRewards[_sequencer];
+    rewardStorage.sequencerRewards[_sequencer] = 0;
+    rollupStore.config.feeAsset.transfer(_sequencer, amount);
 
     return amount;
   }
 
-  function claimProverRewards(address _recipient, Epoch[] memory _epochs) internal returns (uint256) {
+  function claimProverRewards(address _prover, Epoch[] memory _epochs) internal returns (uint256) {
     Epoch currentEpoch = Timestamp.wrap(block.timestamp).epochFromTimestamp();
     RollupStore storage rollupStore = STFLib.getStorage();
 
@@ -106,20 +106,20 @@ library RewardLib {
       );
 
       require(
-        !rewardStorage.proverClaimed[msg.sender].get(Epoch.unwrap(_epochs[i])),
-        Errors.Rollup__AlreadyClaimed(msg.sender, _epochs[i])
+        !rewardStorage.proverClaimed[_prover].get(Epoch.unwrap(_epochs[i])),
+        Errors.Rollup__AlreadyClaimed(_prover, _epochs[i])
       );
-      rewardStorage.proverClaimed[msg.sender].set(Epoch.unwrap(_epochs[i]));
+      rewardStorage.proverClaimed[_prover].set(Epoch.unwrap(_epochs[i]));
 
       EpochRewards storage e = rewardStorage.epochRewards[_epochs[i]];
       SubEpochRewards storage se = e.subEpoch[e.longestProvenLength];
-      uint256 shares = se.shares[msg.sender];
+      uint256 shares = se.shares[_prover];
       if (shares > 0) {
         accumulatedRewards += (shares * e.rewards / se.summedShares);
       }
     }
 
-    rollupStore.config.feeAsset.transfer(_recipient, accumulatedRewards);
+    rollupStore.config.feeAsset.transfer(_prover, accumulatedRewards);
 
     return accumulatedRewards;
   }

--- a/l1-contracts/test/MultiProof.t.sol
+++ b/l1-contracts/test/MultiProof.t.sol
@@ -159,10 +159,10 @@ contract MultiProofTest is RollupBase {
     {
       uint256 sequencerRewards = rollup.getSequencerRewards(sequencer);
       assertGt(sequencerRewards, 0, "Sequencer rewards is zero");
-      vm.prank(sequencer);
       uint256 sequencerRewardsClaimed = rollup.claimSequencerRewards(sequencer);
       assertEq(sequencerRewardsClaimed, sequencerRewards, "Sequencer rewards not claimed");
       assertEq(rollup.getSequencerRewards(sequencer), 0, "Sequencer rewards not zeroed");
+      assertEq(testERC20.balanceOf(sequencer), sequencerRewards, "Sequencer rewards not transferred");
     }
 
     Epoch[] memory epochs = new Epoch[](1);
@@ -180,18 +180,16 @@ contract MultiProofTest is RollupBase {
       Epoch deadline = TimeLib.toDeadlineEpoch(epochs[0]);
 
       vm.expectRevert(abi.encodeWithSelector(Errors.Rollup__NotPastDeadline.selector, deadline, Epoch.wrap(0)));
-      vm.prank(bob);
       rollup.claimProverRewards(bob, epochs);
 
       vm.warp(Timestamp.unwrap(rollup.getTimestampForSlot(deadline.toSlots())));
-      vm.prank(bob);
       uint256 bobRewardsClaimed = rollup.claimProverRewards(bob, epochs);
+      assertEq(testERC20.balanceOf(bob), bobRewardsClaimed, "Bob rewards not transferred");
 
       assertEq(bobRewardsClaimed, bobRewards, "Bob rewards not claimed");
       assertEq(rollup.getSpecificProverRewardsForEpoch(Epoch.wrap(0), bob), 0, "Bob rewards not zeroed");
 
       vm.expectRevert(abi.encodeWithSelector(Errors.Rollup__AlreadyClaimed.selector, bob, Epoch.wrap(0)));
-      vm.prank(bob);
       rollup.claimProverRewards(bob, epochs);
     }
   }


### PR DESCRIPTION
## Overview

Allow coinbase rewards to be claimable by anyone, but they always go to the coinbase
Enables support for split contracts as rewards
