### PR TITLE
chore: remove redundant word in comment

### DIFF
--- a/yarn-project/bb-prover/src/avm_proving_tests/avm_contract_class_limits.test.ts
+++ b/yarn-project/bb-prover/src/avm_proving_tests/avm_contract_class_limits.test.ts
@@ -38,7 +38,7 @@ describe('AVM WitGen & Circuit – check circuit - contract class limits', () =>
         .map(instance => instance.address)
         .slice(0, MAX_PUBLIC_CALLS_TO_UNIQUE_CONTRACT_CLASS_IDS);
 
-      // include the first contract again again at the end to ensure that we can call it even after the limit is reached
+      // include the first contract again at the end to ensure that we can call it even after the limit is reached
       instanceAddresses.push(instanceAddresses[0]);
 
       // include another contract address that reuses a class ID to ensure that we can call it even after the limit is reached

--- a/yarn-project/simulator/src/public/avm/apps_tests/avm_test.test.ts
+++ b/yarn-project/simulator/src/public/avm/apps_tests/avm_test.test.ts
@@ -55,7 +55,7 @@ describe('AVM simulator apps tests: AvmTestContract', () => {
       .map(instance => instance.address)
       .slice(0, MAX_PUBLIC_CALLS_TO_UNIQUE_CONTRACT_CLASS_IDS);
 
-    // include the first contract again again at the end to ensure that we can call it even after the limit is reached
+    // include the first contract again at the end to ensure that we can call it even after the limit is reached
     instanceAddresses.push(instanceAddresses[0]);
 
     // include another contract address that reuses a class ID to ensure that we can call it even after the limit is reached

--- a/yarn-project/stdlib/src/tx/tx_execution_request.ts
+++ b/yarn-project/stdlib/src/tx/tx_execution_request.ts
@@ -81,7 +81,7 @@ export class TxExecutionRequest {
       this.origin,
       this.firstCallArgsHash,
       this.txContext,
-      // Entrypoints must be private as as defined by the protocol.
+      // Entrypoints must be private as defined by the protocol.
       new FunctionData(this.functionSelector, true /* isPrivate */),
       this.salt,
     );


### PR DESCRIPTION
 remove redundant word in comment