### PR TITLE
archiver: pad timestamp/logIndex in ContractInstanceStore update keys for numeric ordering

### DIFF
--- a/yarn-project/archiver/src/archiver/kv_archiver_store/contract_instance_store.ts
+++ b/yarn-project/archiver/src/archiver/kv_archiver_store/contract_instance_store.ts
@@ -9,7 +9,19 @@ import {
 } from '@aztec/stdlib/contract';
 import type { UInt64 } from '@aztec/stdlib/types';
 
-type ContractInstanceUpdateKey = [string, string] | [string, string, number];
+type ContractInstanceUpdateKey = [string, string] | [string, string, string];
+
+// Fixed-width paddings to preserve numeric ordering when keys are serialized as strings
+const U64_DECIMAL_WIDTH = 20; // max 18446744073709551615
+const LOG_INDEX_WIDTH = 10; // supports up to 9,999,999,999 entries per timestamp
+
+function padUInt64Decimal(value: bigint): string {
+  return value.toString().padStart(U64_DECIMAL_WIDTH, '0');
+}
+
+function padLogIndex(value: number): string {
+  return value.toString().padStart(LOG_INDEX_WIDTH, '0');
+}
 
 /**
  * LMDB implementation of the ArchiverDataStore interface.
@@ -43,10 +55,11 @@ export class ContractInstanceStore {
   }
 
   getUpdateKey(contractAddress: AztecAddress, timestamp: UInt64, logIndex?: number): ContractInstanceUpdateKey {
+    const ts = padUInt64Decimal(timestamp);
     if (logIndex === undefined) {
-      return [contractAddress.toString(), timestamp.toString()];
+      return [contractAddress.toString(), ts];
     } else {
-      return [contractAddress.toString(), timestamp.toString(), logIndex];
+      return [contractAddress.toString(), ts, padLogIndex(logIndex)];
     }
   }
 


### PR DESCRIPTION
Replace stringified timestamp with a fixed-width, zero-padded decimal string (20 digits) and logIndex with a 10-digit zero-padded string when composing #contractInstanceUpdates keys.
Update ContractInstanceUpdateKey to [string, string] | [string, string, string].
Ensure range scans return the latest update at or before a given timestamp across both LMDB and IndexedDB backends by preserving numeric ordering in key serialization.
Note: existing data written with the old key format will need migration if present; logic change is backward-incompatible for mixed key formats.