### PR TITLE
fix: don't fwd ssh agent unless running the cli-wallet

### DIFF
--- a/aztec-up/bin/.aztec-run
+++ b/aztec-up/bin/.aztec-run
@@ -83,7 +83,7 @@ done
 arg_volume_mounts="-v $HOME:$HOME -v cache:/cache"
 
 # If we have an ssh agent running, mount it into container, or if on mac, forward it with socat.
-if [ -n "${SSH_AUTH_SOCK:-}" ]; then
+if [[ "${FORWARD_SSH_AGENT:-0}" == 1 && -n "${SSH_AUTH_SOCK:-}" ]]; then
   # warn "SSH_AUTH_SOCK is set to ${SSH_AUTH_SOCK:-}. Attempting to enable SSH agent forwarding..."
 
   if [ "$uname" == "Darwin" ]; then

--- a/aztec-up/bin/aztec
+++ b/aztec-up/bin/aztec
@@ -163,7 +163,9 @@ case ${1:-} in
 
       RESTART_CODES="1 78 79"  # ERROR, ROLLUP_UPGRADE, VERSION_UPGRADE
 
-      echo "Starting supervised Aztec application..."
+      if [ "$SUPERVISED" == "1" ]; then
+        echo "Starting supervised Aztec application..."
+      fi
       set +e
       while true; do
         $(dirname $0)/.aztec-run aztec-start \

--- a/aztec-up/bin/aztec-wallet
+++ b/aztec-up/bin/aztec-wallet
@@ -6,4 +6,6 @@ export ENV_VARS_TO_INJECT="SSH_AUTH_SOCK PXE_PROVER LOG_LEVEL"
 # Appends 8 char hex to avoid container name clashes
 export CONTAINER_NAME=aztec-wallet-$(printf "%08x" $((RANDOM * RANDOM)))
 
+export FORWARD_SSH_AGENT=1
+
 exec $(dirname $0)/.aztec-run aztec-wallet /usr/src/yarn-project/cli-wallet/wallet-entrypoint.sh "$@"


### PR DESCRIPTION
Some fixes for the `aztec` bash wrapper

Fix #14146 