### PR TITLE
feat: inlining more of serialization methods

### DIFF
--- a/noir-projects/noir-contracts/contracts/app/token_blacklist_contract/src/types/roles.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_blacklist_contract/src/types/roles.nr
@@ -15,6 +15,7 @@ pub struct UserFlags {
 impl Packable for UserFlags {
     let N: u32 = 1;
 
+    #[inline_always]
     fn pack(self) -> [Field; Self::N] {
         let mut value: u64 = 0;
 
@@ -33,6 +34,7 @@ impl Packable for UserFlags {
         [value.to_field()]
     }
 
+    #[inline_always]
     fn unpack(fields: [Field; Self::N]) -> Self {
         let value: u64 = fields[0] as u64;
         let is_admin = value & ADMIN_FLAG == ADMIN_FLAG;

--- a/noir-projects/noir-protocol-circuits/crates/types/src/meta/mod.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/meta/mod.nr
@@ -491,10 +491,12 @@ pub comptime fn derive_packable(s: TypeDefinition) -> Quoted {
         {
             let N: u32 = $right_hand_side_of_definition_of_n;
 
+            #[inline_always]
             fn pack(self) -> [Field; Self::N] {
                 $pack_function_body
             }
 
+            #[inline_always]
             fn unpack(packed: [Field; Self::N]) -> Self {
                 $unpack_function_body
             }

--- a/noir-projects/noir-protocol-circuits/crates/types/src/type_packing.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/type_packing.nr
@@ -15,10 +15,12 @@ global I64_PACKED_LEN: u32 = 1;
 impl Packable for bool {
     let N: u32 = BOOL_PACKED_LEN;
 
+    #[inline_always]
     fn pack(self) -> [Field; Self::N] {
         [self as Field]
     }
 
+    #[inline_always]
     fn unpack(fields: [Field; Self::N]) -> bool {
         (fields[0] as u1) != 0
     }
@@ -27,10 +29,12 @@ impl Packable for bool {
 impl Packable for u8 {
     let N: u32 = U8_PACKED_LEN;
 
+    #[inline_always]
     fn pack(self) -> [Field; Self::N] {
         [self as Field]
     }
 
+    #[inline_always]
     fn unpack(fields: [Field; Self::N]) -> Self {
         fields[0] as u8
     }
@@ -39,10 +43,12 @@ impl Packable for u8 {
 impl Packable for u16 {
     let N: u32 = U16_PACKED_LEN;
 
+    #[inline_always]
     fn pack(self) -> [Field; Self::N] {
         [self as Field]
     }
 
+    #[inline_always]
     fn unpack(fields: [Field; Self::N]) -> Self {
         fields[0] as u16
     }
@@ -51,10 +57,12 @@ impl Packable for u16 {
 impl Packable for u32 {
     let N: u32 = U32_PACKED_LEN;
 
+    #[inline_always]
     fn pack(self) -> [Field; Self::N] {
         [self as Field]
     }
 
+    #[inline_always]
     fn unpack(fields: [Field; Self::N]) -> Self {
         fields[0] as u32
     }
@@ -63,10 +71,12 @@ impl Packable for u32 {
 impl Packable for u64 {
     let N: u32 = U64_PACKED_LEN;
 
+    #[inline_always]
     fn pack(self) -> [Field; Self::N] {
         [self as Field]
     }
 
+    #[inline_always]
     fn unpack(fields: [Field; Self::N]) -> Self {
         fields[0] as u64
     }
@@ -75,10 +85,12 @@ impl Packable for u64 {
 impl Packable for u128 {
     let N: u32 = U128_PACKED_LEN;
 
+    #[inline_always]
     fn pack(self) -> [Field; Self::N] {
         [self as Field]
     }
 
+    #[inline_always]
     fn unpack(fields: [Field; Self::N]) -> Self {
         fields[0] as u128
     }
@@ -87,10 +99,12 @@ impl Packable for u128 {
 impl Packable for Field {
     let N: u32 = FIELD_PACKED_LEN;
 
+    #[inline_always]
     fn pack(self) -> [Field; Self::N] {
         [self]
     }
 
+    #[inline_always]
     fn unpack(fields: [Field; Self::N]) -> Self {
         fields[0]
     }
@@ -99,10 +113,12 @@ impl Packable for Field {
 impl Packable for i8 {
     let N: u32 = I8_PACKED_LEN;
 
+    #[inline_always]
     fn pack(self) -> [Field; Self::N] {
         [self as u8 as Field]
     }
 
+    #[inline_always]
     fn unpack(fields: [Field; Self::N]) -> Self {
         fields[0] as u8 as i8
     }
@@ -111,10 +127,12 @@ impl Packable for i8 {
 impl Packable for i16 {
     let N: u32 = I16_PACKED_LEN;
 
+    #[inline_always]
     fn pack(self) -> [Field; Self::N] {
         [self as u16 as Field]
     }
 
+    #[inline_always]
     fn unpack(fields: [Field; Self::N]) -> Self {
         fields[0] as u16 as i16
     }
@@ -123,10 +141,12 @@ impl Packable for i16 {
 impl Packable for i32 {
     let N: u32 = I32_PACKED_LEN;
 
+    #[inline_always]
     fn pack(self) -> [Field; Self::N] {
         [self as u32 as Field]
     }
 
+    #[inline_always]
     fn unpack(fields: [Field; Self::N]) -> Self {
         fields[0] as u32 as i32
     }
@@ -135,10 +155,12 @@ impl Packable for i32 {
 impl Packable for i64 {
     let N: u32 = I64_PACKED_LEN;
 
+    #[inline_always]
     fn pack(self) -> [Field; Self::N] {
         [self as u64 as Field]
     }
 
+    #[inline_always]
     fn unpack(fields: [Field; Self::N]) -> Self {
         fields[0] as u64 as i64
     }
@@ -150,6 +172,7 @@ where
 {
     let N: u32 = M * <T as Packable>::N;
 
+    #[inline_always]
     fn pack(self) -> [Field; Self::N] {
         let mut result: [Field; Self::N] = std::mem::zeroed();
         for i in 0..M {
@@ -161,6 +184,7 @@ where
         result
     }
 
+    #[inline_always]
     fn unpack(fields: [Field; Self::N]) -> Self {
         let mut reader = crate::utils::reader::Reader::new(fields);
         let mut result: [T; M] = std::mem::zeroed();

--- a/noir-projects/noir-protocol-circuits/crates/types/src/type_serialization.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/type_serialization.nr
@@ -15,6 +15,7 @@ global I64_SERIALIZED_LEN: u32 = 1;
 impl Serialize for bool {
     let N: u32 = BOOL_SERIALIZED_LEN;
 
+    #[inline_always]
     fn serialize(self) -> [Field; Self::N] {
         [self as Field]
     }
@@ -23,6 +24,7 @@ impl Serialize for bool {
 impl Deserialize for bool {
     let N: u32 = BOOL_SERIALIZED_LEN;
 
+    #[inline_always]
     fn deserialize(fields: [Field; Self::N]) -> bool {
         fields[0] != 0
     }
@@ -31,6 +33,7 @@ impl Deserialize for bool {
 impl Serialize for u8 {
     let N: u32 = U8_SERIALIZED_LEN;
 
+    #[inline_always]
     fn serialize(self) -> [Field; Self::N] {
         [self as Field]
     }
@@ -39,6 +42,7 @@ impl Serialize for u8 {
 impl Deserialize for u8 {
     let N: u32 = U8_SERIALIZED_LEN;
 
+    #[inline_always]
     fn deserialize(fields: [Field; Self::N]) -> Self {
         fields[0] as u8
     }
@@ -47,6 +51,7 @@ impl Deserialize for u8 {
 impl Serialize for u16 {
     let N: u32 = U16_SERIALIZED_LEN;
 
+    #[inline_always]
     fn serialize(self) -> [Field; Self::N] {
         [self as Field]
     }
@@ -55,6 +60,7 @@ impl Serialize for u16 {
 impl Deserialize for u16 {
     let N: u32 = U16_SERIALIZED_LEN;
 
+    #[inline_always]
     fn deserialize(fields: [Field; Self::N]) -> Self {
         fields[0] as u16
     }
@@ -63,6 +69,7 @@ impl Deserialize for u16 {
 impl Serialize for u32 {
     let N: u32 = U32_SERIALIZED_LEN;
 
+    #[inline_always]
     fn serialize(self) -> [Field; Self::N] {
         [self as Field]
     }
@@ -71,6 +78,7 @@ impl Serialize for u32 {
 impl Deserialize for u32 {
     let N: u32 = U32_SERIALIZED_LEN;
 
+    #[inline_always]
     fn deserialize(fields: [Field; Self::N]) -> Self {
         fields[0] as u32
     }
@@ -79,6 +87,7 @@ impl Deserialize for u32 {
 impl Serialize for u64 {
     let N: u32 = U64_SERIALIZED_LEN;
 
+    #[inline_always]
     fn serialize(self) -> [Field; Self::N] {
         [self as Field]
     }
@@ -87,6 +96,7 @@ impl Serialize for u64 {
 impl Deserialize for u64 {
     let N: u32 = U64_SERIALIZED_LEN;
 
+    #[inline_always]
     fn deserialize(fields: [Field; Self::N]) -> Self {
         fields[0] as u64
     }
@@ -95,6 +105,7 @@ impl Deserialize for u64 {
 impl Serialize for u128 {
     let N: u32 = U128_SERIALIZED_LEN;
 
+    #[inline_always]
     fn serialize(self) -> [Field; Self::N] {
         [self as Field]
     }
@@ -103,6 +114,7 @@ impl Serialize for u128 {
 impl Deserialize for u128 {
     let N: u32 = U128_SERIALIZED_LEN;
 
+    #[inline_always]
     fn deserialize(fields: [Field; Self::N]) -> Self {
         fields[0] as u128
     }
@@ -111,6 +123,7 @@ impl Deserialize for u128 {
 impl Serialize for Field {
     let N: u32 = FIELD_SERIALIZED_LEN;
 
+    #[inline_always]
     fn serialize(self) -> [Field; Self::N] {
         [self]
     }
@@ -119,6 +132,7 @@ impl Serialize for Field {
 impl Deserialize for Field {
     let N: u32 = FIELD_SERIALIZED_LEN;
 
+    #[inline_always]
     fn deserialize(fields: [Field; Self::N]) -> Self {
         fields[0]
     }
@@ -127,6 +141,7 @@ impl Deserialize for Field {
 impl Serialize for i8 {
     let N: u32 = I8_SERIALIZED_LEN;
 
+    #[inline_always]
     fn serialize(self) -> [Field; Self::N] {
         [self as u8 as Field]
     }
@@ -135,6 +150,7 @@ impl Serialize for i8 {
 impl Deserialize for i8 {
     let N: u32 = I8_SERIALIZED_LEN;
 
+    #[inline_always]
     fn deserialize(fields: [Field; Self::N]) -> Self {
         fields[0] as u8 as i8
     }
@@ -143,6 +159,7 @@ impl Deserialize for i8 {
 impl Serialize for i16 {
     let N: u32 = I16_SERIALIZED_LEN;
 
+    #[inline_always]
     fn serialize(self) -> [Field; Self::N] {
         [self as u16 as Field]
     }
@@ -151,6 +168,7 @@ impl Serialize for i16 {
 impl Deserialize for i16 {
     let N: u32 = I16_SERIALIZED_LEN;
 
+    #[inline_always]
     fn deserialize(fields: [Field; Self::N]) -> Self {
         fields[0] as u16 as i16
     }
@@ -159,6 +177,7 @@ impl Deserialize for i16 {
 impl Serialize for i32 {
     let N: u32 = I32_SERIALIZED_LEN;
 
+    #[inline_always]
     fn serialize(self) -> [Field; Self::N] {
         [self as u32 as Field]
     }
@@ -167,6 +186,7 @@ impl Serialize for i32 {
 impl Deserialize for i32 {
     let N: u32 = I32_SERIALIZED_LEN;
 
+    #[inline_always]
     fn deserialize(fields: [Field; Self::N]) -> Self {
         fields[0] as u32 as i32
     }
@@ -175,6 +195,7 @@ impl Deserialize for i32 {
 impl Serialize for i64 {
     let N: u32 = I64_SERIALIZED_LEN;
 
+    #[inline_always]
     fn serialize(self) -> [Field; Self::N] {
         [self as u64 as Field]
     }
@@ -183,6 +204,7 @@ impl Serialize for i64 {
 impl Deserialize for i64 {
     let N: u32 = I64_SERIALIZED_LEN;
 
+    #[inline_always]
     fn deserialize(fields: [Field; Self::N]) -> Self {
         fields[0] as u64 as i64
     }
@@ -194,6 +216,7 @@ where
 {
     let N: u32 = <T as Serialize>::N * M;
 
+    #[inline_always]
     fn serialize(self) -> [Field; Self::N] {
         let mut result: [Field; _] = std::mem::zeroed();
         for i in 0..M {
@@ -212,6 +235,7 @@ where
 {
     let N: u32 = <T as Deserialize>::N * M;
 
+    #[inline_always]
     fn deserialize(fields: [Field; Self::N]) -> Self {
         let mut reader = crate::utils::reader::Reader::new(fields);
         let mut result: [T; M] = std::mem::zeroed();
@@ -225,6 +249,7 @@ where
 {
     let N: u32 = <T as Serialize>::N + 1;
 
+    #[inline_always]
     fn serialize(self) -> [Field; Self::N] {
         let mut result: [Field; Self::N] = std::mem::zeroed();
 
@@ -245,6 +270,7 @@ where
 {
     let N: u32 = <T as Deserialize>::N + 1;
 
+    #[inline_always]
     fn deserialize(fields: [Field; Self::N]) -> Self {
         if fields[0] == 1 {
             let mut value_fields = [0; <T as Deserialize>::N];


### PR DESCRIPTION
I assume `#[inline_always]` was not placed on these methods by accident in https://github.com/AztecProtocol/aztec-packages/pull/14369 hence I am doing that here.