### PR TITLE
chore: remove `HasPlookup` from remaining places

### DIFF
--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/circuit_builders/circuit_builders.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/circuit_builders/circuit_builders.hpp
@@ -13,9 +13,6 @@
 #include "barretenberg/stdlib_circuit_builders/ultra_circuit_builder.hpp"
 
 template <typename T>
-concept HasPlookup = bb::IsAnyOf<T, bb::UltraCircuitBuilder, bb::MegaCircuitBuilder>;
-
-template <typename T>
 concept IsUltraBuilder = bb::IsAnyOf<T, bb::UltraCircuitBuilder>;
 template <typename T>
 concept IsMegaBuilder = bb::IsAnyOf<T, bb::MegaCircuitBuilder>;

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/logic/logic.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/logic/logic.test.cpp
@@ -122,27 +122,25 @@ TYPED_TEST(LogicTest, DifferentWitnessSameResult)
 
     STDLIB_TYPE_ALIASES
     auto builder = Builder();
-    if (HasPlookup<Builder>) {
-        uint256_t a = 3758096391;
-        uint256_t b = 2147483649;
-        field_ct x = witness_ct(&builder, uint256_t(a));
-        field_ct y = witness_ct(&builder, uint256_t(b));
+    uint256_t a = 3758096391;
+    uint256_t b = 2147483649;
+    field_ct x = witness_ct(&builder, uint256_t(a));
+    field_ct y = witness_ct(&builder, uint256_t(b));
 
-        uint256_t xor_expected = a ^ b;
-        const std::function<std::pair<uint256_t, uint256_t>(uint256_t, uint256_t, size_t)>& get_bad_chunk =
-            [](uint256_t left, uint256_t right, size_t chunk_size) {
-                (void)left;
-                (void)right;
-                (void)chunk_size;
-                auto left_chunk = uint256_t(2684354565);
-                auto right_chunk = uint256_t(3221225475);
-                return std::make_pair(left_chunk, right_chunk);
-            };
+    uint256_t xor_expected = a ^ b;
+    const std::function<std::pair<uint256_t, uint256_t>(uint256_t, uint256_t, size_t)>& get_bad_chunk =
+        [](uint256_t left, uint256_t right, size_t chunk_size) {
+            (void)left;
+            (void)right;
+            (void)chunk_size;
+            auto left_chunk = uint256_t(2684354565);
+            auto right_chunk = uint256_t(3221225475);
+            return std::make_pair(left_chunk, right_chunk);
+        };
 
-        field_ct xor_result = stdlib::logic<Builder>::create_logic_constraint(x, y, 32, true, get_bad_chunk);
-        EXPECT_EQ(uint256_t(xor_result.get_value()), xor_expected);
+    field_ct xor_result = stdlib::logic<Builder>::create_logic_constraint(x, y, 32, true, get_bad_chunk);
+    EXPECT_EQ(uint256_t(xor_result.get_value()), xor_expected);
 
-        bool result = CircuitChecker::check(builder);
-        EXPECT_EQ(result, false);
-    }
+    bool result = CircuitChecker::check(builder);
+    EXPECT_EQ(result, false);
 }

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/dynamic_array.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/dynamic_array.cpp
@@ -31,7 +31,6 @@ DynamicArray<Builder>::DynamicArray(Builder* builder, const size_t maximum_size)
     , _max_size(maximum_size)
     , _length(0)
 {
-    static_assert(HasPlookup<Builder>);
     ASSERT(_context != nullptr);
     _inner_table = ram_table(_context, maximum_size);
     // Initialize the ram table with all zeroes

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/ram_table.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/ram_table.cpp
@@ -22,7 +22,6 @@ namespace bb::stdlib {
  */
 template <typename Builder> ram_table<Builder>::ram_table(Builder* builder, const size_t table_size)
 {
-    static_assert(HasPlookup<Builder>);
     _context = builder;
     _length = table_size;
     _index_initialized.resize(table_size);
@@ -44,7 +43,6 @@ template <typename Builder> ram_table<Builder>::ram_table(Builder* builder, cons
  */
 template <typename Builder> ram_table<Builder>::ram_table(const std::vector<field_pt>& table_entries)
 {
-    static_assert(HasPlookup<Builder>);
     // get the builder _context
     for (const auto& entry : table_entries) {
         if (entry.get_context() != nullptr) {

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/rom_table.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/rom_table.cpp
@@ -15,7 +15,6 @@ namespace bb::stdlib {
 
 template <typename Builder> rom_table<Builder>::rom_table(const std::vector<field_pt>& table_entries)
 {
-    static_assert(HasPlookup<Builder>);
     // get the builder context
     for (const auto& entry : table_entries) {
         if (entry.get_context() != nullptr) {

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/twin_rom_table.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/twin_rom_table.cpp
@@ -16,7 +16,6 @@ namespace bb::stdlib {
 template <typename Builder>
 twin_rom_table<Builder>::twin_rom_table(const std::vector<std::array<field_pt, 2>>& table_entries)
 {
-    static_assert(HasPlookup<Builder>);
     // get the builder context
     for (const auto& entry : table_entries) {
         if (entry[0].get_context() != nullptr) {


### PR DESCRIPTION
Removed last few traces of `HasPlookup` as we now only support `Ultra` and `Mega` circuit builders in stdlib and beyond.
