### PR TITLE
feat: fix AVM circuit size

### DIFF
--- a/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.cpp
+++ b/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.cpp
@@ -28,7 +28,6 @@ ClientIVC::ClientIVC(size_t num_circuits, TraceSettings trace_settings)
     size_t commitment_key_size =
         std::max(trace_settings.dyadic_size(), 1UL << TranslatorFlavor::CONST_TRANSLATOR_LOG_N);
     info("BN254 commitment key size: ", commitment_key_size);
-    // TODO(https://github.com/AztecProtocol/barretenberg/issues/1420): pass commitment keys by value
     bn254_commitment_key = CommitmentKey<curve::BN254>(commitment_key_size);
 }
 
@@ -458,7 +457,6 @@ void ClientIVC::accumulate(ClientCircuit& circuit, const std::shared_ptr<MegaVer
     // If the current circuit overflows past the current size of the commitment key, reinitialize accordingly.
     // TODO(https://github.com/AztecProtocol/barretenberg/issues/1319)
     if (proving_key->dyadic_size() > bn254_commitment_key.dyadic_size) {
-        // TODO(https://github.com/AztecProtocol/barretenberg/issues/1420): pass commitment keys by value
         bn254_commitment_key = CommitmentKey<curve::BN254>(proving_key->dyadic_size());
         goblin.commitment_key = bn254_commitment_key;
     }

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/circuit_builder_base_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/circuit_builder_base_impl.hpp
@@ -236,8 +236,8 @@ template <typename FF_> void CircuitBuilderBase<FF_>::failure(std::string msg)
 {
 #ifndef FUZZING_DISABLE_WARNINGS
     if (!has_dummy_witnesses) {
-        // We have a builder failure when we have real witnesses which is a mistake.
-        info("(Experimental) WARNING: Builder failure when we have real witnesses!"); // not a catch-all error
+        // Not a catch-all error log. We have a builder failure when we have real witnesses which is a mistake.
+        info("(Experimental) WARNING: Builder failure when we have real witnesses! Ignore if writing vk.");
     }
 #endif
     _failed = true;

--- a/barretenberg/cpp/src/barretenberg/sumcheck/sumcheck.hpp
+++ b/barretenberg/cpp/src/barretenberg/sumcheck/sumcheck.hpp
@@ -322,7 +322,6 @@ template <typename Flavor> class SumcheckProver {
         CommitmentKey ck;
 
         if constexpr (IsGrumpkinFlavor<Flavor>) {
-            // TODO(https://github.com/AztecProtocol/barretenberg/issues/1420): pass commitment keys by value
             ck = CommitmentKey(BATCHED_RELATION_PARTIAL_LENGTH);
             // Compute the vector {0, 1, \ldots, BATCHED_RELATION_PARTIAL_LENGTH-1} needed to transform the round
             // univariates from Lagrange to monomial basis

--- a/barretenberg/cpp/src/barretenberg/vm2/common/constants.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/common/constants.hpp
@@ -6,7 +6,8 @@
 
 namespace bb::avm2 {
 
-constexpr uint32_t CIRCUIT_SUBGROUP_SIZE = 1 << 21;
+constexpr size_t MAX_AVM_TRACE_LOG_SIZE = 21;
+constexpr size_t MAX_AVM_TRACE_SIZE = 1 << MAX_AVM_TRACE_LOG_SIZE;
 
 // Also used for op_id in the circuit trace
 enum class BitwiseOperation : uint8_t {

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/polynomials.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/polynomials.cpp
@@ -29,7 +29,7 @@ AvmProver::ProverPolynomials compute_polynomials(tracegen::TraceContainer& trace
 
                            poly = AvmProver::Polynomial(
                                /*memory size*/ allocated_size,
-                               /*largest possible index*/ CIRCUIT_SUBGROUP_SIZE,
+                               /*largest possible index*/ MAX_AVM_TRACE_SIZE, // TODO(#16660): use real size?
                                /*make shiftable with offset*/ 1);
                        }
                    }));
@@ -55,7 +55,7 @@ AvmProver::ProverPolynomials compute_polynomials(tracegen::TraceContainer& trace
                            // WARNING! Column-Polynomials order matters!
                            Column col = static_cast<Column>(i);
                            const auto num_rows = trace.get_column_rows(col);
-                           poly = AvmProver::Polynomial::create_non_parallel_zero_init(num_rows, CIRCUIT_SUBGROUP_SIZE);
+                           poly = AvmProver::Polynomial::create_non_parallel_zero_init(num_rows, MAX_AVM_TRACE_SIZE);
                        });
                    }));
 

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/prover.cpp
@@ -9,6 +9,7 @@
 #include "barretenberg/honk/proof_system/logderivative_library.hpp"
 #include "barretenberg/relations/permutation_relation.hpp"
 #include "barretenberg/sumcheck/sumcheck.hpp"
+#include "barretenberg/vm2/common/constants.hpp"
 #include "barretenberg/vm2/tooling/stats.hpp"
 
 namespace bb::avm2 {
@@ -107,7 +108,7 @@ void AvmProver::execute_relation_check_rounds()
 
     // Generate gate challenges
     std::vector<FF> gate_challenges =
-        transcript->template get_powers_of_challenge<FF>("Sumcheck:gate_challenge", CONST_PROOF_SIZE_LOG_N);
+        transcript->template get_powers_of_challenge<FF>("Sumcheck:gate_challenge", key->log_circuit_size);
 
     Sumcheck sumcheck(key->circuit_size,
                       prover_polynomials,
@@ -115,7 +116,7 @@ void AvmProver::execute_relation_check_rounds()
                       alpha,
                       gate_challenges,
                       relation_parameters,
-                      CONST_PROOF_SIZE_LOG_N);
+                      key->log_circuit_size);
 
     sumcheck_output = sumcheck.prove();
 }

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/recursion/recursive_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/recursion/recursive_flavor.hpp
@@ -63,11 +63,9 @@ class AvmRecursiveFlavor {
     class VerificationKey
         : public StdlibVerificationKey_<CircuitBuilder, NativeFlavor::PrecomputedEntities<Commitment>> {
       public:
+        size_t log_fixed_circuit_size = MAX_AVM_TRACE_LOG_SIZE;
         VerificationKey(CircuitBuilder* builder, const std::shared_ptr<NativeVerificationKey>& native_key)
         {
-            this->log_circuit_size = FF::from_witness(builder, native_key->log_circuit_size);
-            this->num_public_inputs = FF::from_witness(builder, native_key->num_public_inputs);
-
             for (auto [native_comm, comm] : zip_view(native_key->get_all(), this->get_all())) {
                 comm = Commitment::from_witness(builder, native_comm);
             }
@@ -82,15 +80,7 @@ class AvmRecursiveFlavor {
         VerificationKey(CircuitBuilder& builder, std::span<const FF> elements)
         {
             size_t num_frs_read = 0;
-            size_t num_frs_FF = stdlib::field_conversion::calc_num_bn254_frs<CircuitBuilder, FF>();
             size_t num_frs_Comm = stdlib::field_conversion::calc_num_bn254_frs<CircuitBuilder, Commitment>();
-
-            this->log_circuit_size = stdlib::field_conversion::convert_from_bn254_frs<CircuitBuilder, FF>(
-                builder, elements.subspan(num_frs_read, num_frs_FF));
-            num_frs_read += num_frs_FF;
-            this->num_public_inputs = stdlib::field_conversion::convert_from_bn254_frs<CircuitBuilder, FF>(
-                builder, elements.subspan(num_frs_read, num_frs_FF));
-            num_frs_read += num_frs_FF;
 
             for (Commitment& comm : this->get_all()) {
                 comm = stdlib::field_conversion::convert_from_bn254_frs<CircuitBuilder, Commitment>(

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/verifier.cpp
@@ -30,7 +30,7 @@ using FF = AvmFlavor::FF;
 // Evaluate the given public input column over the multivariate challenge points
 inline FF AvmVerifier::evaluate_public_input_column(const std::vector<FF>& points, std::vector<FF> challenges)
 {
-    Polynomial<FF> polynomial(points, 1UL << CONST_PROOF_SIZE_LOG_N);
+    Polynomial<FF> polynomial(points, (1 << key->log_circuit_size));
     return polynomial.evaluate_mle(challenges);
 }
 
@@ -76,16 +76,16 @@ bool AvmVerifier::verify_proof(const HonkProof& proof, const std::vector<std::ve
     }
 
     // Execute Sumcheck Verifier
-    std::vector<FF> padding_indicator_array(CONST_PROOF_SIZE_LOG_N, 1);
+    std::vector<FF> padding_indicator_array(key->log_circuit_size, 1);
 
     // Multiply each linearly independent subrelation contribution by `alpha^i` for i = 0, ..., NUM_SUBRELATIONS - 1.
     const FF alpha = transcript->template get_challenge<FF>("Sumcheck:alpha");
 
-    SumcheckVerifier<Flavor> sumcheck(transcript, alpha, CONST_PROOF_SIZE_LOG_N);
+    SumcheckVerifier<Flavor> sumcheck(transcript, alpha, key->log_circuit_size);
 
     // Get the gate challenges for sumcheck computation
     std::vector<FF> gate_challenges =
-        transcript->template get_powers_of_challenge<FF>("Sumcheck:gate_challenge", CONST_PROOF_SIZE_LOG_N);
+        transcript->template get_powers_of_challenge<FF>("Sumcheck:gate_challenge", key->log_circuit_size);
 
     SumcheckOutput<Flavor> output = sumcheck.verify(relation_parameters, gate_challenges, padding_indicator_array);
 

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/precomputed_trace.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/precomputed_trace.hpp
@@ -11,7 +11,7 @@ namespace bb::avm2::tracegen {
 // See precomputed.pil.
 class PrecomputedTraceBuilder final {
   public:
-    void process_misc(TraceContainer& trace, const uint32_t num_rows = CIRCUIT_SUBGROUP_SIZE);
+    void process_misc(TraceContainer& trace, const uint32_t num_rows = MAX_AVM_TRACE_SIZE);
     void process_bitwise(TraceContainer& trace);
     void process_sel_range_8(TraceContainer& trace);
     void process_sel_range_16(TraceContainer& trace);

--- a/yarn-project/bb-prover/src/prover/proof_utils.ts
+++ b/yarn-project/bb-prover/src/prover/proof_utils.ts
@@ -80,7 +80,7 @@ export async function readProofAsFields<PROOF_LENGTH extends number>(
   // This buffer will have the form: [binary public inputs, binary proof]
   const binaryProofWithPublicInputs = Buffer.concat([binaryPublicInputs, binaryProof]);
   logger.debug(
-    `Circuit path: ${filePath}, complete proof length: ${json.length}, num public inputs: ${numPublicInputs}, circuit size: ${vkData.circuitSize}, is recursive: ${vkData.isRecursive}, raw length: ${binaryProofWithPublicInputs.length}`,
+    `Circuit path: ${filePath}, complete proof length: ${json.length}, num public inputs: ${numPublicInputs}, circuit size: ${vkData.circuitSize}, raw length: ${binaryProofWithPublicInputs.length}`,
   );
   assert(
     binaryProofWithPublicInputs.length == numPublicInputs * 32 + proofLength * 32,

--- a/yarn-project/bb-prover/src/verification_key/verification_key_data.ts
+++ b/yarn-project/bb-prover/src/verification_key/verification_key_data.ts
@@ -43,6 +43,7 @@ export async function extractAvmVkData(vkDirectoryPath: string): Promise<Verific
     Array(AVM_V2_VERIFICATION_KEY_LENGTH_IN_FIELDS_PADDED - fieldsArray.length).fill(new Fr(0)),
   );
   const vkAsFields = await VerificationKeyAsFields.fromKey(fieldsArrayPadded);
+  // TODO(#16644): We should have a different type for AVM verification keys since we don't have circuit size or num public inputs in AVM VKs.
   const vk = new VerificationKeyData(vkAsFields, rawBinary);
   return vk;
 }

--- a/yarn-project/stdlib/src/vks/verification_key.ts
+++ b/yarn-project/stdlib/src/vks/verification_key.ts
@@ -80,7 +80,6 @@ export class CommitmentMap {
 // TODO: find better home for these constants
 export const CIRCUIT_SIZE_INDEX = 0;
 export const CIRCUIT_PUBLIC_INPUTS_INDEX = 1;
-export const CIRCUIT_RECURSIVE_INDEX = 3;
 
 /**
  * Provides a 'fields' representation of a circuit's verification key
@@ -102,10 +101,6 @@ export class VerificationKeyAsFields {
 
   public get circuitSize() {
     return Number(this.key[CIRCUIT_SIZE_INDEX]);
-  }
-
-  public get isRecursive() {
-    return this.key[CIRCUIT_RECURSIVE_INDEX].equals(Fr.ONE);
   }
 
   static get schema() {
@@ -269,10 +264,6 @@ export class VerificationKeyData {
 
   public get circuitSize() {
     return this.keyAsFields.circuitSize;
-  }
-
-  public get isRecursive() {
-    return this.keyAsFields.isRecursive;
   }
 
   static empty() {


### PR DESCRIPTION
Remove circuit size and num_public_inputs from AVM. Use the fixed AVM size everywhere.