### PR TITLE
chore: fix critical security vulnerability in Docker socket permissions

### DIFF
--- a/aztec-up/scripts/run_test.sh
+++ b/aztec-up/scripts/run_test.sh
@@ -23,7 +23,7 @@ docker save aztecprotocol/aztec:latest | docker exec -i $1 \
       sleep 3
       cat /tmp/dockerd.log
     done
-    chmod 777 /var/run/docker.sock
+    chown root:ubuntu /var/run/docker.sock && chmod 660 /var/run/docker.sock
     echo 'Loading image...'
     docker load
   "


### PR DESCRIPTION


## Description

**Critical security fix**: Replace unsafe `chmod 777` on Docker socket with proper group-based permissions in `aztec-up/scripts/run_test.sh`.

## What was changed

- **Before**: `chmod 777 /var/run/docker.sock` (world-writable, dangerous)
- **After**: `chown root:ubuntu /var/run/docker.sock && chmod 660 /var/run/docker.sock` (group-based access)

## Why this matters

The previous `chmod 777` gave any process in the container full control over the Docker daemon, creating a serious privilege escalation risk. The new approach maintains functionality while restricting access to the `ubuntu` group only.

