### PR TITLE
fix: return type typo in get_authorized_delay

### DIFF
--- a/noir-projects/noir-contracts/contracts/app/auth_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/auth_contract/src/main.nr
@@ -59,7 +59,7 @@ pub contract Auth {
 
     #[public]
     #[view]
-    fn get_authorized_delay() -> pub u64 {
+    fn get_authorized_delay() -> u64 {
         storage.authorized.get_current_delay()
     }
 


### PR DESCRIPTION
Removed stray pub from the return type of get_authorized_delay in noir-projects/noir-contracts/contracts/app/auth_contract/src/main.nr. This resolves a syntax error and aligns the signature with visibility attributes. No behavioral changes.