### PR TITLE
chore: assert poseidon hashes only witnesses

### DIFF
--- a/barretenberg/cpp/src/barretenberg/boomerang_value_detection/graph_description_poseidon2s_permutation.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/boomerang_value_detection/graph_description_poseidon2s_permutation.test.cpp
@@ -84,37 +84,6 @@ void test_poseidon2s_circuit(size_t num_inputs = 5)
 }
 
 /**
- * @brief Test graph description for poseidon2 hash with byte array input
- *
- * The result should be one connected component, and only output variables must be in one gate
- *
- * @param num_inputs Number of random bytes to generate
- */
-void test_poseidon2s_hash_byte_array(size_t num_inputs = 5)
-{
-    Builder builder;
-
-    std::vector<uint8_t> input;
-    input.reserve(num_inputs);
-    for (size_t i = 0; i < num_inputs; ++i) {
-        input.push_back(engine.get_random_uint8());
-    }
-
-    byte_array_ct circuit_input(&builder, input);
-    auto result = stdlib::poseidon2<Builder>::hash_buffer(builder, circuit_input);
-    auto graph = StaticAnalyzer(builder);
-    auto connected_components = graph.find_connected_components();
-    EXPECT_EQ(connected_components.size(), 1);
-    auto variables_in_one_gate = graph.show_variables_in_one_gate(builder);
-    std::unordered_set<uint32_t> outputs{
-        result.witness_index, result.witness_index + 1, result.witness_index + 2, result.witness_index + 3
-    };
-    for (const auto& elem : variables_in_one_gate) {
-        EXPECT_EQ(outputs.contains(elem), true);
-    }
-}
-
-/**
  * @brief Test graph description for repeated poseidon2 hash operations
  *
  * The result should be one connected component with repeated hashing of pairs,
@@ -232,16 +201,6 @@ TEST(boomerang_poseidon2s, test_graph_for_poseidon2s)
 TEST(boomerang_poseidon2s, test_graph_for_poseidon2s_for_one_input_size)
 {
     test_poseidon2s_circuit();
-}
-
-/**
- * @brief Test graph for poseidon2s hash with byte arrays of varying sizes
- */
-TEST(boomerang_poseidon2s, test_graph_for_poseidon2s_hash_byte_array)
-{
-    for (size_t num_inputs = 6; num_inputs < 100; num_inputs++) {
-        test_poseidon2s_hash_byte_array(num_inputs);
-    }
 }
 
 /**

--- a/barretenberg/cpp/src/barretenberg/crypto/poseidon2/poseidon2.cpp
+++ b/barretenberg/cpp/src/barretenberg/crypto/poseidon2/poseidon2.cpp
@@ -16,38 +16,5 @@ typename Poseidon2<Params>::FF Poseidon2<Params>::hash(const std::vector<typenam
     return Sponge::hash_internal(input);
 }
 
-/**
- * @brief Hashes vector of bytes by chunking it into 31 byte field elements and calling hash()
- * @details Slice function cuts out the required number of bytes from the byte vector
- */
-template <typename Params>
-typename Poseidon2<Params>::FF Poseidon2<Params>::hash_buffer(const std::vector<uint8_t>& input)
-{
-    const size_t num_bytes = input.size();
-    const size_t bytes_per_element = 31;
-    size_t num_elements = static_cast<size_t>(num_bytes % bytes_per_element != 0) + (num_bytes / bytes_per_element);
-
-    const auto slice = [](const std::vector<uint8_t>& data, const size_t start, const size_t slice_size) {
-        uint256_t result(0);
-        for (size_t i = 0; i < slice_size; ++i) {
-            result = (result << uint256_t(8));
-            result += uint256_t(data[i + start]);
-        }
-        return FF(result);
-    };
-
-    std::vector<FF> converted;
-    for (size_t i = 0; i < num_elements - 1; ++i) {
-        size_t bytes_to_slice = bytes_per_element;
-        FF element = slice(input, i * bytes_per_element, bytes_to_slice);
-        converted.emplace_back(element);
-    }
-    size_t bytes_to_slice = num_bytes - ((num_elements - 1) * bytes_per_element);
-    FF element = slice(input, (num_elements - 1) * bytes_per_element, bytes_to_slice);
-    converted.emplace_back(element);
-
-    return hash(converted);
-}
-
 template class Poseidon2<Poseidon2Bn254ScalarFieldParams>;
 } // namespace bb::crypto

--- a/barretenberg/cpp/src/barretenberg/crypto/poseidon2/poseidon2.hpp
+++ b/barretenberg/cpp/src/barretenberg/crypto/poseidon2/poseidon2.hpp
@@ -23,11 +23,6 @@ template <typename Params> class Poseidon2 {
      * @brief Hashes a vector of field elements
      */
     static FF hash(const std::vector<FF>& input);
-    /**
-     * @brief Hashes vector of bytes by chunking it into 31 byte field elements and calling hash()
-     * @details Slice function cuts out the required number of bytes from the byte vector
-     */
-    static FF hash_buffer(const std::vector<uint8_t>& input);
 };
 
 extern template class Poseidon2<Poseidon2Bn254ScalarFieldParams>;

--- a/barretenberg/cpp/src/barretenberg/crypto/poseidon2/poseidon2.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/crypto/poseidon2/poseidon2.test.cpp
@@ -45,22 +45,3 @@ TEST(Poseidon2, HashConsistencyCheck)
 
     EXPECT_EQ(result, expected);
 }
-
-TEST(Poseidon2, HashBufferConsistencyCheck)
-{
-    // 31 byte inputs because hash_buffer slicing is only injective with 31 bytes, as it slices 31 bytes for each field
-    // element
-    fr a(std::string("00000b615c4d3e2fa0b1c2d3e4f56789fedcba9876543210abcdef0123456789"));
-
-    // takes field element and converts it to 32 bytes
-    auto input_vec = to_buffer(a);
-    bb::fr result1 = crypto::Poseidon2<crypto::Poseidon2Bn254ScalarFieldParams>::hash_buffer(input_vec);
-    input_vec.erase(input_vec.begin()); // erase first byte since we want 31 bytes
-    fr result2 = crypto::Poseidon2<crypto::Poseidon2Bn254ScalarFieldParams>::hash_buffer(input_vec);
-
-    std::vector<fr> input{ a };
-    auto expected = crypto::Poseidon2<crypto::Poseidon2Bn254ScalarFieldParams>::hash(input);
-
-    EXPECT_NE(result1, expected);
-    EXPECT_EQ(result2, expected);
-}

--- a/barretenberg/cpp/src/barretenberg/stdlib/hash/poseidon2/poseidon2.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/hash/poseidon2/poseidon2.cpp
@@ -23,28 +23,6 @@ template <typename C> field_t<C> poseidon2<C>::hash(C& builder, const std::vecto
     return Sponge::hash_internal(builder, inputs);
 }
 
-/**
- * @brief Hash a byte_array.
- */
-template <typename C> field_t<C> poseidon2<C>::hash_buffer(C& builder, const stdlib::byte_array<C>& input)
-{
-    const size_t num_bytes = input.size();
-    const size_t bytes_per_element = 31; // 31 bytes in a fr element
-    size_t num_elements = static_cast<size_t>(num_bytes % bytes_per_element != 0) + (num_bytes / bytes_per_element);
-
-    std::vector<field_ct> elements;
-    for (size_t i = 0; i < num_elements; ++i) {
-        size_t bytes_to_slice = 0;
-        if (i == num_elements - 1) {
-            bytes_to_slice = num_bytes - (i * bytes_per_element);
-        } else {
-            bytes_to_slice = bytes_per_element;
-        }
-        auto element = static_cast<field_ct>(input.slice(i * bytes_per_element, bytes_to_slice));
-        elements.emplace_back(element);
-    }
-    return hash(builder, elements);
-}
 template class poseidon2<bb::MegaCircuitBuilder>;
 template class poseidon2<bb::UltraCircuitBuilder>;
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/hash/poseidon2/sponge/sponge.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/hash/poseidon2/sponge/sponge.hpp
@@ -155,6 +155,7 @@ template <size_t rate, size_t capacity, size_t t, typename Permutation, typename
         FieldSponge sponge(builder, iv);
 
         for (size_t i = 0; i < in_len; ++i) {
+            BB_ASSERT_EQ(input[i].witness_index == IS_CONSTANT, false, "Sponge inputs should not be stdlib constants.");
             sponge.absorb(input[i]);
         }
 


### PR DESCRIPTION
Closes https://github.com/AztecProtocol/barretenberg/issues/1413.

Adds assert to sponge that ensures we only hash witnesses. Removes unused hash_buffer functions from poseidon2.