### PR TITLE
chore: making docs previews only happen on changes to docs folder

### DIFF
--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -1,3 +1,7 @@
+[build]
+  # Only build if changes are made in the docs directory
+  ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF docs"
+
 [[redirects]]
     from = "/guides/smart_contracts/writing_contracts/initializers"
     to = "/developers/guides/smart_contracts/writing_contracts/initializers"


### PR DESCRIPTION
According to the netlify docs about this [here](https://docs.netlify.com/build/configure-builds/ignore-builds/) 