### PR TITLE
chore: expanding macros on /dev version of the docs

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -53,7 +53,7 @@ const config = {
       /** @type {import('@docusaurus/preset-classic').Options} */
       {
         docs: {
-          path: "docs",
+          path: "processed-docs",
           sidebarPath: "./sidebars.js",
           editUrl: (params) => {
             return (


### PR DESCRIPTION
Was building off the `docs/docs` folder which meant the macros weren't expanding. 

The versioned versions were, because they expanded when they were cut