### PR TITLE
feat: Mocking for translator and eccvm proofs

### DIFF
--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/avm2_recursion_constraint.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/avm2_recursion_constraint.cpp
@@ -50,6 +50,8 @@ void create_dummy_vkey_and_proof(Builder& builder,
                                  const std::vector<field_ct>& key_fields,
                                  const std::vector<field_ct>& proof_fields)
 {
+    // TODO(https://github.com/AztecProtocol/barretenberg/issues/1514): restructure this function to use functions from
+    // mock_verifier_inputs
     using Flavor = avm2::AvmFlavor;
 
     // Relevant source for proof layout: AvmFlavor::Transcript::serialize_full_transcript()

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/honk_recursion_constraint.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/honk_recursion_constraint.cpp
@@ -7,6 +7,7 @@
 #include "honk_recursion_constraint.hpp"
 #include "barretenberg/common/assert.hpp"
 #include "barretenberg/constants.hpp"
+#include "barretenberg/dsl/acir_format/mock_verifier_inputs.hpp"
 #include "barretenberg/flavor/flavor.hpp"
 #include "barretenberg/flavor/ultra_recursive_flavor.hpp"
 #include "barretenberg/flavor/ultra_rollup_recursive_flavor.hpp"
@@ -54,150 +55,37 @@ void create_dummy_vkey_and_proof(typename Flavor::CircuitBuilder& builder,
 {
     using Builder = typename Flavor::CircuitBuilder;
     using NativeFlavor = typename Flavor::NativeFlavor;
-
-    static constexpr size_t IPA_CLAIM_SIZE = stdlib::recursion::honk::RollupIO::IpaClaim::PUBLIC_INPUTS_SIZE;
+    using IO = std::conditional_t<HasIPAAccumulator<Flavor>,
+                                  stdlib::recursion::honk::RollupIO,
+                                  stdlib::recursion::honk::DefaultIO<Builder>>;
 
     // Set vkey->circuit_size correctly based on the proof size
     BB_ASSERT_EQ(proof_size, NativeFlavor::PROOF_LENGTH_WITHOUT_PUB_INPUTS());
-    // a lambda that adds dummy commitments (libra and gemini)
-    auto set_dummy_commitment = [&](size_t& offset) {
-        auto comm = curve::BN254::AffineElement::one() * fr::random_element();
-        auto frs = field_conversion::convert_to_bn254_frs(comm);
-        builder.set_variable(proof_fields[offset].witness_index, frs[0]);
-        builder.set_variable(proof_fields[offset + 1].witness_index, frs[1]);
-        builder.set_variable(proof_fields[offset + 2].witness_index, frs[2]);
-        builder.set_variable(proof_fields[offset + 3].witness_index, frs[3]);
-        offset += 4;
-    };
 
-    auto set_dummy_evaluation = [&](size_t& offset) {
-        builder.set_variable(proof_fields[offset].witness_index, fr::random_element());
-        offset++;
-    };
-
-    // Note: this computation should always result in log_circuit_size = CONST_PROOF_SIZE_LOG_N
-    auto log_circuit_size = CONST_PROOF_SIZE_LOG_N;
-    size_t offset = 0;
-    // First key field is circuit size
-    builder.set_variable(key_fields[offset++].witness_index, 1 << log_circuit_size);
-    // Second key field is number of public inputs
-    builder.set_variable(key_fields[offset++].witness_index, public_inputs_size);
-    // Third key field is the pub inputs offset
+    size_t num_inner_public_inputs = public_inputs_size - IO::PUBLIC_INPUTS_SIZE;
     uint32_t pub_inputs_offset = NativeFlavor::has_zero_row ? 1 : 0;
-    builder.set_variable(key_fields[offset++].witness_index, pub_inputs_offset);
-    size_t num_inner_public_inputs = HasIPAAccumulator<Flavor> ? public_inputs_size - bb::RollupIO::PUBLIC_INPUTS_SIZE
-                                                               : public_inputs_size - bb::DefaultIO::PUBLIC_INPUTS_SIZE;
 
-    for (size_t i = 0; i < Flavor::NUM_PRECOMPUTED_ENTITIES; ++i) {
-        set_dummy_commitment(offset);
-    }
+    // Generate mock honk vk
+    // Note: log_circuit_size = CONST_PROOF_SIZE_LOG_N
+    auto honk_vk = create_mock_honk_vk<typename Flavor::NativeFlavor, IO>(
+        1 << CONST_PROOF_SIZE_LOG_N, pub_inputs_offset, num_inner_public_inputs);
 
-    offset = 0; // Reset offset for parsing proof fields
+    size_t offset = 0;
 
-    // the inner public inputs
-    for (size_t i = 0; i < num_inner_public_inputs; i++) {
-        set_dummy_evaluation(offset);
-    }
-
-    // Get some values for a valid aggregation object and use them here to avoid divide by 0 or other issues.
-    std::array<fr, PairingPoints<Builder>::PUBLIC_INPUTS_SIZE> dummy_pairing_points_values =
-        PairingPoints<Builder>::construct_dummy();
-    for (size_t i = 0; i < PairingPoints<Builder>::PUBLIC_INPUTS_SIZE; i++) {
-        builder.set_variable(proof_fields[offset].witness_index, dummy_pairing_points_values[i]);
+    // Set honk vk in builder
+    for (auto& proof_element : honk_vk->to_field_elements()) {
+        builder.set_variable(key_fields[offset].witness_index, proof_element);
         offset++;
     }
 
-    // IPA claim
-    // TODO(https://github.com/AztecProtocol/barretenberg/issues/1392): Don't use random elements here.
-    if constexpr (HasIPAAccumulator<Flavor>) {
-        for (size_t i = 0; i < IPA_CLAIM_SIZE; i++) {
-            set_dummy_evaluation(offset);
-        }
-    }
+    // Generate dummy honk proof
+    bb::HonkProof honk_proof = create_mock_honk_proof<typename Flavor::NativeFlavor, IO>(num_inner_public_inputs);
 
-    // first NUM_WITNESS_ENTITIES witness commitments
-    for (size_t i = 0; i < Flavor::NUM_WITNESS_ENTITIES; i++) {
-        set_dummy_commitment(offset);
-    }
-
-    if constexpr (Flavor::HasZK) {
-        // Libra concatenation commitment
-        set_dummy_commitment(offset);
-        // libra sum
-        set_dummy_evaluation(offset);
-    }
-
-    // now the univariates, which can just be 0s (8*CONST_PROOF_SIZE_LOG_N Frs, where 8 is the maximum relation
-    // degree)
-    for (size_t i = 0; i < CONST_PROOF_SIZE_LOG_N * Flavor::BATCHED_RELATION_PARTIAL_LENGTH; i++) {
-        set_dummy_evaluation(offset);
-    }
-
-    // now the sumcheck evaluations, which is just 44 0s
-    for (size_t i = 0; i < Flavor::NUM_ALL_ENTITIES; i++) {
-        set_dummy_evaluation(offset);
-    }
-
-    if constexpr (Flavor::HasZK) {
-        // Libra claimed evaluation
-        set_dummy_evaluation(offset);
-        // Libra grand sum commitment
-
-        set_dummy_commitment(offset);
-        // Libra quotient commitment
-        set_dummy_commitment(offset);
-        // Gemini masking commitment
-        set_dummy_commitment(offset);
-        // Gemini masking evaluation
-        set_dummy_evaluation(offset);
-    }
-
-    // now the gemini fold commitments which are CONST_PROOF_SIZE_LOG_N - 1
-    for (size_t i = 1; i < CONST_PROOF_SIZE_LOG_N; i++) {
-        set_dummy_commitment(offset);
-    }
-
-    // the gemini fold evaluations which are also CONST_PROOF_SIZE_LOG_N
-    for (size_t i = 1; i <= CONST_PROOF_SIZE_LOG_N; i++) {
-        set_dummy_evaluation(offset);
-    }
-
-    if constexpr (Flavor::HasZK) {
-        // NUM_SMALL_IPA_EVALUATIONS libra evals
-        for (size_t i = 0; i < NUM_SMALL_IPA_EVALUATIONS; i++) {
-            set_dummy_evaluation(offset);
-        }
-    }
-
-    // lastly the shplonk batched quotient commitment and kzg quotient commitment
-    for (size_t i = 0; i < 2; i++) {
-        set_dummy_commitment(offset);
-    }
-    // IPA Proof
-    if constexpr (HasIPAAccumulator<Flavor>) {
-
-        // Ls and Rs
-        for (size_t i = 0; i < static_cast<size_t>(2) * CONST_ECCVM_LOG_N; i++) {
-            auto comm = curve::Grumpkin::AffineElement::one() * fq::random_element();
-            auto frs = field_conversion::convert_to_bn254_frs(comm);
-            builder.set_variable(proof_fields[offset].witness_index, frs[0]);
-            builder.set_variable(proof_fields[offset + 1].witness_index, frs[1]);
-            offset += 2;
-        }
-
-        // G_zero
-        auto G_zero = curve::Grumpkin::AffineElement::one() * fq::random_element();
-        auto G_zero_frs = field_conversion::convert_to_bn254_frs(G_zero);
-        builder.set_variable(proof_fields[offset].witness_index, G_zero_frs[0]);
-        builder.set_variable(proof_fields[offset + 1].witness_index, G_zero_frs[1]);
-        offset += 2;
-
-        // a_zero
-        auto a_zero = fq::random_element();
-        auto a_zero_frs = field_conversion::convert_to_bn254_frs(a_zero);
-        builder.set_variable(proof_fields[offset].witness_index, a_zero_frs[0]);
-        builder.set_variable(proof_fields[offset + 1].witness_index, a_zero_frs[1]);
-        offset += 2;
+    offset = 0;
+    // Set honk proof in builder
+    for (auto& proof_element : honk_proof) {
+        builder.set_variable(proof_fields[offset].witness_index, proof_element);
+        offset++;
     }
 
     BB_ASSERT_EQ(offset, proof_size + public_inputs_size);

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/honk_recursion_constraint.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/honk_recursion_constraint.cpp
@@ -73,8 +73,8 @@ void create_dummy_vkey_and_proof(typename Flavor::CircuitBuilder& builder,
     size_t offset = 0;
 
     // Set honk vk in builder
-    for (auto& proof_element : honk_vk->to_field_elements()) {
-        builder.set_variable(key_fields[offset].witness_index, proof_element);
+    for (auto& vk_element : honk_vk->to_field_elements()) {
+        builder.set_variable(key_fields[offset].witness_index, vk_element);
         offset++;
     }
 

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/ivc_recursion_constraint.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/ivc_recursion_constraint.test.cpp
@@ -256,15 +256,6 @@ class IvcRecursionConstraintTest : public ::testing::Test {
 };
 
 /**
- * @brief Check that the size of a mock merge proof matches expectation
- */
-TEST_F(IvcRecursionConstraintTest, MockMergeProofSize)
-{
-    Goblin::MergeProof merge_proof = create_mock_merge_proof();
-    EXPECT_EQ(merge_proof.size(), MERGE_PROOF_SIZE);
-}
-
-/**
  * @brief Test IVC accumulation of a one app and one kernel; The kernel includes a recursive oink verification for the
  * app, specified via an ACIR RecursionConstraint.
  */

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/mock_verifier_inputs.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/mock_verifier_inputs.cpp
@@ -190,6 +190,222 @@ Goblin::MergeProof create_mock_merge_proof()
 }
 
 /**
+ * @brief Create a mock pre-ipa proof which has the correct structure but is not necessarily valid
+ *
+ * @return HonkProof
+ */
+HonkProof create_mock_pre_ipa_proof()
+{
+    using FF = ECCVMFlavor::FF;
+    HonkProof proof;
+
+    // 1. NUM_WITNESS_ENTITIES commitments
+    for (size_t idx = 0; idx < ECCVMFlavor::NUM_WITNESS_ENTITIES; idx++) {
+        proof.emplace_back(FF::random_element());
+    }
+
+    // 2. Libra concatenation commitment
+    populate_field_elements_for_mock_commitments(proof, /*num_commitments*/ 1);
+
+    // 3. Libra sum
+    proof.emplace_back(FF::random_element());
+
+    // 4. Sumcheck univariates commitments
+    populate_field_elements_for_mock_commitments(proof, /*num_commitments=*/CONST_ECCVM_LOG_N);
+
+    // 5. Sumcheck univariate evaluations
+    for (size_t idx = 0; idx < 2 * CONST_ECCVM_LOG_N; idx++) {
+        proof.emplace_back(FF::random_element());
+    }
+
+    // 6. ALL_ENTITIES sumcheck evaluations
+    for (size_t idx = 0; idx < ECCVMFlavor::NUM_ALL_ENTITIES; idx++) {
+        proof.emplace_back(FF::random_element());
+    }
+
+    // 7. Libra evaluation
+    proof.emplace_back(FF::random_element());
+
+    // 8. Libra grand sum commitment
+    populate_field_elements_for_mock_commitments(proof, /*num_commitments=*/CONST_ECCVM_LOG_N);
+
+    // 9. Libra quotient commitment
+    populate_field_elements_for_mock_commitments(proof, /*num_commitments=*/CONST_ECCVM_LOG_N);
+
+    // 10. Gemini masking commitment
+    populate_field_elements_for_mock_commitments(proof, /*num_commitments=*/CONST_ECCVM_LOG_N);
+
+    // 11. Gemini masking evaluations
+    proof.emplace_back(FF::random_element());
+
+    // 12. Gemini fold commitments
+    populate_field_elements_for_mock_commitments(proof, /*num_commitments=*/CONST_ECCVM_LOG_N - 1);
+
+    // 13. Gemini evaluations
+    for (size_t idx = 0; idx < CONST_ECCVM_LOG_N; idx++) {
+        proof.emplace_back(FF::random_element());
+    }
+
+    // 14. NUM_SMALL_IPA_EVALUATIONS libra evals
+    for (size_t idx = 0; idx < NUM_SMALL_IPA_EVALUATIONS; idx++) {
+        proof.emplace_back(FF::random_element());
+    }
+
+    // 15. Shplonk
+    populate_field_elements_for_mock_commitments(proof, /*num_commitments=*/1);
+
+    // 16. Translator concatenated masking term commitment
+    populate_field_elements_for_mock_commitments(proof, /*num_commitments=*/1);
+
+    // 17. Translator op evaluation
+    proof.emplace_back(FF::random_element());
+
+    // 18. Translator Px evaluation
+    proof.emplace_back(FF::random_element());
+
+    // 19. Translator Py evaluation
+    proof.emplace_back(FF::random_element());
+
+    // 20. Translator z1 evaluation
+    proof.emplace_back(FF::random_element());
+
+    // 21. Translator z2 evaluation
+    proof.emplace_back(FF::random_element());
+
+    // 22. Translator concatenated masking term evaluation
+    proof.emplace_back(FF::random_element());
+
+    // 23. Translator grand sum commitment
+    populate_field_elements_for_mock_commitments(proof, /*num_commitments=*/1);
+
+    // 24. Translator quotient commitment
+    populate_field_elements_for_mock_commitments(proof, /*num_commitments=*/1);
+
+    // 25. Translator concatenation evaluation
+    proof.emplace_back(FF::random_element());
+
+    // 26. Translator grand sum shift evaluation
+    proof.emplace_back(FF::random_element());
+
+    // 27. Translator grand sum evaluation
+    proof.emplace_back(FF::random_element());
+
+    // 28. Translator quotient evaluation
+    proof.emplace_back(FF::random_element());
+
+    // 29. Shplonk
+    populate_field_elements_for_mock_commitments(proof, /*num_commitments=*/1);
+
+    BB_ASSERT_EQ(proof.size(), ECCVMFlavor::PROOF_LENGTH_WITHOUT_PUB_INPUTS - IPA_PROOF_LENGTH);
+
+    return proof;
+}
+
+/**
+ * @brief Create a mock ipa proof which has the correct structure but is not necessarily valid
+ *
+ * @return HonkProof
+ */
+HonkProof create_mock_ipa_proof()
+{
+    HonkProof proof;
+
+    // Commitments to L and R for CONST_ECCVM_LOG_N round
+    populate_field_elements_for_mock_commitments(proof, /*num_commitments=*/2 * CONST_ECCVM_LOG_N);
+
+    // Commitment to G_0
+    populate_field_elements_for_mock_commitments(proof, /*num_commitments=*/1);
+
+    // a_0 evaluation
+    proof.emplace_back(fr::random_element());
+
+    BB_ASSERT_EQ(proof.size(), IPA_PROOF_LENGTH);
+
+    return proof;
+}
+
+/**
+ * @brief Create a mock translator proof which has the correct structure but is not necessarily valid
+ *
+ * @return HonkProof
+ */
+HonkProof create_mock_translator_proof()
+{
+    using FF = TranslatorFlavor::FF;
+
+    HonkProof proof;
+
+    // 1. Accumulated result
+    proof.emplace_back(FF::random_element());
+
+    // 1. NUM_WITNESS_ENTITIES commitments
+    populate_field_elements_for_mock_commitments(proof, /*num_commitments=*/TranslatorFlavor::NUM_WITNESS_ENTITIES);
+
+    // 2. Libra concatenation commitment
+    populate_field_elements_for_mock_commitments(proof, /*num_commitments=*/1);
+
+    // 3. Libra sum
+    proof.emplace_back(FF::random_element());
+
+    // 4. sumcheck univariates
+    for (size_t idx = 0;
+         idx < TranslatorFlavor::CONST_TRANSLATOR_LOG_N * TranslatorFlavor::BATCHED_RELATION_PARTIAL_LENGTH;
+         idx++) {
+        proof.emplace_back(FF::random_element());
+    }
+
+    // 5. NUM_ALL_ENTITIES sumcheck evaluations
+    for (size_t idx = 0; idx < TranslatorFlavor::NUM_ALL_ENTITIES; idx++) {
+        proof.emplace_back(FF::random_element());
+    }
+
+    // 6. Libra claimed evaluation
+    proof.emplace_back(FF::random_element());
+
+    // 7. Libra grand sum commitment
+    populate_field_elements_for_mock_commitments(proof, /*num_commitments=*/1);
+
+    // 8. Libra quotient commitment
+    populate_field_elements_for_mock_commitments(proof, /*num_commitments=*/1);
+
+    // 9. Gemini masking commitment
+    populate_field_elements_for_mock_commitments(proof, /*num_commitments=*/1);
+
+    // 10. Gemini masking evaluation
+    proof.emplace_back(FF::random_element());
+
+    // 11. CONST_TRANSLATOR_LOG_N - 1 Gemini fold commitments
+    populate_field_elements_for_mock_commitments(proof,
+                                                 /*num_commitments=*/TranslatorFlavor::CONST_TRANSLATOR_LOG_N - 1);
+
+    // 12. CONST_TRANSLATOR_LOG_N Gemini evaluations
+    for (size_t idx = 0; idx < TranslatorFlavor::CONST_TRANSLATOR_LOG_N; idx++) {
+        proof.emplace_back(FF::random_element());
+    }
+
+    // 13. Gemini P pos evaluation
+    proof.emplace_back(FF::random_element());
+
+    // 14. Gemini P neg evaluation
+    proof.emplace_back(FF::random_element());
+
+    // 15. NUM_SMALL_IPA_EVALUATIONS libra evals
+    for (size_t idx = 0; idx < NUM_SMALL_IPA_EVALUATIONS; idx++) {
+        proof.emplace_back(FF::random_element());
+    }
+
+    // 16. Shplonk
+    populate_field_elements_for_mock_commitments(proof, /*num_commitments=*/1);
+
+    // 17. KZG
+    populate_field_elements_for_mock_commitments(proof, /*num_commitments=*/1);
+
+    BB_ASSERT_EQ(proof.size(), TranslatorFlavor::PROOF_LENGTH_WITHOUT_PUB_INPUTS);
+
+    return proof;
+}
+
+/**
  * @brief Create a mock MegaHonk VK that has the correct structure
  *
  */

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/mock_verifier_inputs.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/mock_verifier_inputs.cpp
@@ -204,7 +204,7 @@ Goblin::MergeProof create_mock_merge_proof()
     Goblin::MergeProof proof;
     proof.reserve(MERGE_PROOF_SIZE);
 
-    uint32_t mock_shift_size = 5;
+    uint32_t mock_shift_size = 5; // Must be smaller than 32, otherwise pow raises an error
 
     // Populate mock shift size
     populate_field_elements(proof, 1, /*value=*/mock_shift_size);

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/mock_verifier_inputs.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/mock_verifier_inputs.cpp
@@ -92,57 +92,67 @@ template <typename Flavor, class PublicInputs> HonkProof create_mock_oink_proof(
  */
 template <typename Flavor> HonkProof create_mock_decider_proof(const size_t const_proof_log_n)
 {
+    using FF = Flavor::FF;
+    using Curve = Flavor::Curve;
     HonkProof proof;
 
     if constexpr (Flavor::HasZK) {
         // Libra concatenation commitment
-        populate_field_elements_for_mock_commitments(proof, 1);
+        populate_field_elements_for_mock_commitments<Curve>(proof, 1);
 
         // Libra sum
-        populate_field_elements(proof, 1);
+        populate_field_elements<FF>(proof, 1);
     }
 
     // Sumcheck univariates
     const size_t TOTAL_SIZE_SUMCHECK_UNIVARIATES = const_proof_log_n * Flavor::BATCHED_RELATION_PARTIAL_LENGTH;
-    populate_field_elements(proof, TOTAL_SIZE_SUMCHECK_UNIVARIATES);
+    populate_field_elements<FF>(proof, TOTAL_SIZE_SUMCHECK_UNIVARIATES);
 
     // Sumcheck multilinear evaluations
-    populate_field_elements(proof, Flavor::NUM_ALL_ENTITIES);
+    populate_field_elements<FF>(proof, Flavor::NUM_ALL_ENTITIES);
 
     if constexpr (Flavor::HasZK) {
         // Libra claimed evaluation
-        populate_field_elements(proof, 1);
+        populate_field_elements<FF>(proof, 1);
 
         // Libra grand sum commitment
-        populate_field_elements_for_mock_commitments(proof, 1);
+        populate_field_elements_for_mock_commitments<Curve>(proof, 1);
 
         // Libra quotient commitment
-        populate_field_elements_for_mock_commitments(proof, 1);
+        populate_field_elements_for_mock_commitments<Curve>(proof, 1);
 
         // Gemini masking commitment
-        populate_field_elements_for_mock_commitments(proof, 1);
+        populate_field_elements_for_mock_commitments<Curve>(proof, 1);
 
         // Gemini masking evaluation
-        populate_field_elements(proof, 1);
+        populate_field_elements<FF>(proof, 1);
     }
 
     // Gemini fold commitments
     const size_t NUM_GEMINI_FOLD_COMMITMENTS = const_proof_log_n - 1;
-    populate_field_elements_for_mock_commitments(proof, NUM_GEMINI_FOLD_COMMITMENTS);
+    populate_field_elements_for_mock_commitments<Curve>(proof, NUM_GEMINI_FOLD_COMMITMENTS);
 
     // Gemini fold evaluations
     const size_t NUM_GEMINI_FOLD_EVALUATIONS = const_proof_log_n;
-    populate_field_elements(proof, NUM_GEMINI_FOLD_EVALUATIONS);
+    populate_field_elements<FF>(proof, NUM_GEMINI_FOLD_EVALUATIONS);
+
+    if constexpr (std::is_same_v<Flavor, TranslatorFlavor>) {
+        // Gemini P pos evaluation
+        populate_field_elements<FF>(proof, 1);
+
+        // Gemini P neg evaluation
+        populate_field_elements<FF>(proof, 1);
+    }
 
     if constexpr (Flavor::HasZK) {
         // NUM_SMALL_IPA_EVALUATIONS libra evals
-        populate_field_elements(proof, NUM_SMALL_IPA_EVALUATIONS);
+        populate_field_elements<FF>(proof, NUM_SMALL_IPA_EVALUATIONS);
     }
 
     // Shplonk batched quotient commitment
-    populate_field_elements_for_mock_commitments(proof, /*num_commitments=*/1);
+    populate_field_elements_for_mock_commitments<Curve>(proof, /*num_commitments=*/1);
     // KZG quotient commitment
-    populate_field_elements_for_mock_commitments(proof, /*num_commitments=*/1);
+    populate_field_elements_for_mock_commitments<Curve>(proof, /*num_commitments=*/1);
 
     return proof;
 }

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/mock_verifier_inputs.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/mock_verifier_inputs.cpp
@@ -245,11 +245,11 @@ HonkProof create_mock_pre_ipa_proof()
     // 3. Libra sum
     populate_field_elements<FF>(proof, 1);
 
-    // 4. Sumcheck univariates commitments
-    populate_field_elements_for_mock_commitments<curve::Grumpkin>(proof, /*num_commitments=*/CONST_ECCVM_LOG_N);
-
-    // 5. Sumcheck univariate evaluations
-    populate_field_elements<FF>(proof, CONST_ECCVM_LOG_N + CONST_ECCVM_LOG_N);
+    // 4. Sumcheck univariates commitments + 5. Sumcheck univariate evaluations
+    for (size_t idx = 0; idx < CONST_ECCVM_LOG_N; idx++) {
+        populate_field_elements_for_mock_commitments<curve::Grumpkin>(proof, /*num_commitments=*/1);
+        populate_field_elements<FF>(proof, /*num_elements=*/2);
+    }
 
     // 6. ALL_ENTITIES sumcheck evaluations
     populate_field_elements<FF>(proof, ECCVMFlavor::NUM_ALL_ENTITIES);

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/mock_verifier_inputs.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/mock_verifier_inputs.cpp
@@ -27,12 +27,29 @@ using namespace bb;
  * @param fields field buffer to append mock commitment values to
  * @param num_commitments number of mock commitments to append
  */
+template <class Curve = curve::BN254>
 void populate_field_elements_for_mock_commitments(std::vector<fr>& fields, const size_t& num_commitments)
 {
-    auto mock_commitment = curve::BN254::AffineElement::one();
+    auto mock_commitment = Curve::AffineElement::one();
     std::vector<fr> mock_commitment_frs = field_conversion::convert_to_bn254_frs(mock_commitment);
     for (size_t i = 0; i < num_commitments; ++i) {
         for (const fr& val : mock_commitment_frs) {
+            fields.emplace_back(val);
+        }
+    }
+}
+
+/**
+ * @brief Helper to populate a field buffer with some number of field elements
+ *
+ * @param fields field buffer to append field elements to
+ * @param num_commitments number of mock commitments to append
+ */
+template <class FF = curve::BN254::ScalarField>
+void populate_field_elements(std::vector<fr>& fields, const size_t& num_elements)
+{
+    for (size_t i = 0; i < num_elements; ++i) {
+        for (auto& val : field_conversion::convert_to_bn254_frs(FF::random_element())) {
             fields.emplace_back(val);
         }
     }
@@ -200,101 +217,91 @@ HonkProof create_mock_pre_ipa_proof()
     HonkProof proof;
 
     // 1. NUM_WITNESS_ENTITIES commitments
-    for (size_t idx = 0; idx < ECCVMFlavor::NUM_WITNESS_ENTITIES; idx++) {
-        proof.emplace_back(FF::random_element());
-    }
+    populate_field_elements_for_mock_commitments<curve::Grumpkin>(proof, ECCVMFlavor::NUM_WITNESS_ENTITIES);
 
     // 2. Libra concatenation commitment
-    populate_field_elements_for_mock_commitments(proof, /*num_commitments*/ 1);
+    populate_field_elements_for_mock_commitments<curve::Grumpkin>(proof, /*num_commitments*/ 1);
 
     // 3. Libra sum
-    proof.emplace_back(FF::random_element());
+    populate_field_elements<FF>(proof, 1);
 
     // 4. Sumcheck univariates commitments
-    populate_field_elements_for_mock_commitments(proof, /*num_commitments=*/CONST_ECCVM_LOG_N);
+    populate_field_elements_for_mock_commitments<curve::Grumpkin>(proof, /*num_commitments=*/CONST_ECCVM_LOG_N);
 
     // 5. Sumcheck univariate evaluations
-    for (size_t idx = 0; idx < 2 * CONST_ECCVM_LOG_N; idx++) {
-        proof.emplace_back(FF::random_element());
-    }
+    populate_field_elements<FF>(proof, CONST_ECCVM_LOG_N + CONST_ECCVM_LOG_N);
 
     // 6. ALL_ENTITIES sumcheck evaluations
-    for (size_t idx = 0; idx < ECCVMFlavor::NUM_ALL_ENTITIES; idx++) {
-        proof.emplace_back(FF::random_element());
-    }
+    populate_field_elements<FF>(proof, ECCVMFlavor::NUM_ALL_ENTITIES);
 
     // 7. Libra evaluation
-    proof.emplace_back(FF::random_element());
+    populate_field_elements<FF>(proof, 1);
 
     // 8. Libra grand sum commitment
-    populate_field_elements_for_mock_commitments(proof, /*num_commitments=*/CONST_ECCVM_LOG_N);
+    populate_field_elements_for_mock_commitments<curve::Grumpkin>(proof, /*num_commitments=*/1);
 
     // 9. Libra quotient commitment
-    populate_field_elements_for_mock_commitments(proof, /*num_commitments=*/CONST_ECCVM_LOG_N);
+    populate_field_elements_for_mock_commitments<curve::Grumpkin>(proof, /*num_commitments=*/1);
 
     // 10. Gemini masking commitment
-    populate_field_elements_for_mock_commitments(proof, /*num_commitments=*/CONST_ECCVM_LOG_N);
+    populate_field_elements_for_mock_commitments<curve::Grumpkin>(proof, /*num_commitments=*/1);
 
     // 11. Gemini masking evaluations
-    proof.emplace_back(FF::random_element());
+    populate_field_elements<FF>(proof, 1);
 
     // 12. Gemini fold commitments
-    populate_field_elements_for_mock_commitments(proof, /*num_commitments=*/CONST_ECCVM_LOG_N - 1);
+    populate_field_elements_for_mock_commitments<curve::Grumpkin>(proof, /*num_commitments=*/CONST_ECCVM_LOG_N - 1);
 
     // 13. Gemini evaluations
-    for (size_t idx = 0; idx < CONST_ECCVM_LOG_N; idx++) {
-        proof.emplace_back(FF::random_element());
-    }
+    populate_field_elements<FF>(proof, CONST_ECCVM_LOG_N);
 
     // 14. NUM_SMALL_IPA_EVALUATIONS libra evals
-    for (size_t idx = 0; idx < NUM_SMALL_IPA_EVALUATIONS; idx++) {
-        proof.emplace_back(FF::random_element());
-    }
+    populate_field_elements<FF>(proof, NUM_SMALL_IPA_EVALUATIONS);
 
     // 15. Shplonk
-    populate_field_elements_for_mock_commitments(proof, /*num_commitments=*/1);
+    populate_field_elements_for_mock_commitments<curve::Grumpkin>(proof, /*num_commitments=*/1);
 
     // 16. Translator concatenated masking term commitment
-    populate_field_elements_for_mock_commitments(proof, /*num_commitments=*/1);
+    populate_field_elements_for_mock_commitments<curve::Grumpkin>(proof, /*num_commitments=*/1);
 
     // 17. Translator op evaluation
-    proof.emplace_back(FF::random_element());
+    populate_field_elements<FF>(proof, 1);
 
     // 18. Translator Px evaluation
-    proof.emplace_back(FF::random_element());
+    populate_field_elements<FF>(proof, 1);
 
     // 19. Translator Py evaluation
-    proof.emplace_back(FF::random_element());
+    populate_field_elements<FF>(proof, 1);
 
     // 20. Translator z1 evaluation
-    proof.emplace_back(FF::random_element());
+    populate_field_elements<FF>(proof, 1);
 
     // 21. Translator z2 evaluation
-    proof.emplace_back(FF::random_element());
+    populate_field_elements<FF>(proof, 1);
 
     // 22. Translator concatenated masking term evaluation
-    proof.emplace_back(FF::random_element());
+    populate_field_elements<FF>(proof, 1);
 
     // 23. Translator grand sum commitment
-    populate_field_elements_for_mock_commitments(proof, /*num_commitments=*/1);
+    populate_field_elements_for_mock_commitments<curve::Grumpkin>(proof, /*num_commitments=*/1);
 
     // 24. Translator quotient commitment
-    populate_field_elements_for_mock_commitments(proof, /*num_commitments=*/1);
+    populate_field_elements_for_mock_commitments<curve::Grumpkin>(proof, /*num_commitments=*/1);
 
     // 25. Translator concatenation evaluation
-    proof.emplace_back(FF::random_element());
+    populate_field_elements<FF>(proof, 1);
 
     // 26. Translator grand sum shift evaluation
-    proof.emplace_back(FF::random_element());
+    populate_field_elements<FF>(proof, 1);
 
     // 27. Translator grand sum evaluation
-    proof.emplace_back(FF::random_element());
+    populate_field_elements<FF>(proof, 1);
 
     // 28. Translator quotient evaluation
-    proof.emplace_back(FF::random_element());
+    populate_field_elements<FF>(proof, 1);
 
     // 29. Shplonk
-    populate_field_elements_for_mock_commitments(proof, /*num_commitments=*/1);
+    populate_field_elements_for_mock_commitments<curve::Grumpkin>(proof, /*num_commitments=*/1);
 
     BB_ASSERT_EQ(proof.size(), ECCVMFlavor::PROOF_LENGTH_WITHOUT_PUB_INPUTS - IPA_PROOF_LENGTH);
 
@@ -311,12 +318,14 @@ HonkProof create_mock_ipa_proof()
     HonkProof proof;
 
     // Commitments to L and R for CONST_ECCVM_LOG_N round
-    populate_field_elements_for_mock_commitments(proof, /*num_commitments=*/2 * CONST_ECCVM_LOG_N);
+    populate_field_elements_for_mock_commitments<curve::Grumpkin>(
+        proof, /*num_commitments=*/CONST_ECCVM_LOG_N + CONST_ECCVM_LOG_N);
 
     // Commitment to G_0
-    populate_field_elements_for_mock_commitments(proof, /*num_commitments=*/1);
+    populate_field_elements_for_mock_commitments<curve::Grumpkin>(proof, /*num_commitments=*/1);
 
-    // a_0 evaluation
+    // a_0 evaluation (a_0 is in the base field of BN254)
+    proof.emplace_back(fr::random_element());
     proof.emplace_back(fr::random_element());
 
     BB_ASSERT_EQ(proof.size(), IPA_PROOF_LENGTH);
@@ -332,73 +341,68 @@ HonkProof create_mock_ipa_proof()
 HonkProof create_mock_translator_proof()
 {
     using FF = TranslatorFlavor::FF;
+    using BF = TranslatorFlavor::BF;
+    using Curve = TranslatorFlavor::Curve;
 
     HonkProof proof;
 
     // 1. Accumulated result
-    proof.emplace_back(FF::random_element());
+    populate_field_elements<BF>(proof, 1);
 
     // 1. NUM_WITNESS_ENTITIES commitments
-    populate_field_elements_for_mock_commitments(proof, /*num_commitments=*/TranslatorFlavor::NUM_WITNESS_ENTITIES);
+    populate_field_elements_for_mock_commitments<Curve>(proof,
+                                                        /*num_commitments=*/TranslatorFlavor::NUM_WITNESS_ENTITIES - 4);
 
     // 2. Libra concatenation commitment
-    populate_field_elements_for_mock_commitments(proof, /*num_commitments=*/1);
+    populate_field_elements_for_mock_commitments<Curve>(proof, /*num_commitments=*/1);
 
     // 3. Libra sum
-    proof.emplace_back(FF::random_element());
+    populate_field_elements<FF>(proof, 1);
 
     // 4. sumcheck univariates
-    for (size_t idx = 0;
-         idx < TranslatorFlavor::CONST_TRANSLATOR_LOG_N * TranslatorFlavor::BATCHED_RELATION_PARTIAL_LENGTH;
-         idx++) {
-        proof.emplace_back(FF::random_element());
-    }
+    populate_field_elements<FF>(
+        proof, TranslatorFlavor::CONST_TRANSLATOR_LOG_N * TranslatorFlavor::BATCHED_RELATION_PARTIAL_LENGTH);
 
     // 5. NUM_ALL_ENTITIES sumcheck evaluations
-    for (size_t idx = 0; idx < TranslatorFlavor::NUM_ALL_ENTITIES; idx++) {
-        proof.emplace_back(FF::random_element());
-    }
+    populate_field_elements<FF>(proof, TranslatorFlavor::NUM_ALL_ENTITIES);
 
     // 6. Libra claimed evaluation
-    proof.emplace_back(FF::random_element());
+    populate_field_elements<FF>(proof, 1);
 
     // 7. Libra grand sum commitment
-    populate_field_elements_for_mock_commitments(proof, /*num_commitments=*/1);
+    populate_field_elements_for_mock_commitments<Curve>(proof, /*num_commitments=*/1);
 
     // 8. Libra quotient commitment
-    populate_field_elements_for_mock_commitments(proof, /*num_commitments=*/1);
+    populate_field_elements_for_mock_commitments<Curve>(proof, /*num_commitments=*/1);
 
     // 9. Gemini masking commitment
-    populate_field_elements_for_mock_commitments(proof, /*num_commitments=*/1);
+    populate_field_elements_for_mock_commitments<Curve>(proof, /*num_commitments=*/1);
 
     // 10. Gemini masking evaluation
-    proof.emplace_back(FF::random_element());
+    populate_field_elements<FF>(proof, 1);
 
     // 11. CONST_TRANSLATOR_LOG_N - 1 Gemini fold commitments
-    populate_field_elements_for_mock_commitments(proof,
-                                                 /*num_commitments=*/TranslatorFlavor::CONST_TRANSLATOR_LOG_N - 1);
+    populate_field_elements_for_mock_commitments<Curve>(proof,
+                                                        /*num_commitments=*/TranslatorFlavor::CONST_TRANSLATOR_LOG_N -
+                                                            1);
 
     // 12. CONST_TRANSLATOR_LOG_N Gemini evaluations
-    for (size_t idx = 0; idx < TranslatorFlavor::CONST_TRANSLATOR_LOG_N; idx++) {
-        proof.emplace_back(FF::random_element());
-    }
+    populate_field_elements<FF>(proof, TranslatorFlavor::CONST_TRANSLATOR_LOG_N);
 
     // 13. Gemini P pos evaluation
-    proof.emplace_back(FF::random_element());
+    populate_field_elements<FF>(proof, 1);
 
     // 14. Gemini P neg evaluation
-    proof.emplace_back(FF::random_element());
+    populate_field_elements<FF>(proof, 1);
 
     // 15. NUM_SMALL_IPA_EVALUATIONS libra evals
-    for (size_t idx = 0; idx < NUM_SMALL_IPA_EVALUATIONS; idx++) {
-        proof.emplace_back(FF::random_element());
-    }
+    populate_field_elements<FF>(proof, NUM_SMALL_IPA_EVALUATIONS);
 
     // 16. Shplonk
-    populate_field_elements_for_mock_commitments(proof, /*num_commitments=*/1);
+    populate_field_elements_for_mock_commitments<Curve>(proof, /*num_commitments=*/1);
 
     // 17. KZG
-    populate_field_elements_for_mock_commitments(proof, /*num_commitments=*/1);
+    populate_field_elements_for_mock_commitments<Curve>(proof, /*num_commitments=*/1);
 
     BB_ASSERT_EQ(proof.size(), TranslatorFlavor::PROOF_LENGTH_WITHOUT_PUB_INPUTS);
 

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/mock_verifier_inputs.hpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/mock_verifier_inputs.hpp
@@ -14,9 +14,11 @@
 
 namespace acir_format {
 
-template <typename Flavor, class PublicInputs> bb::HonkProof create_mock_oink_proof();
+template <typename Flavor, class PublicInputs>
+bb::HonkProof create_mock_oink_proof(const size_t inner_public_inputs_size = 0);
 template <typename Flavor> bb::HonkProof create_mock_decider_proof();
-template <typename Flavor, class PublicInputs> bb::HonkProof create_mock_honk_proof();
+template <typename Flavor, class PublicInputs>
+bb::HonkProof create_mock_honk_proof(const size_t inner_public_inputs_size = 0);
 template <typename Flavor, class PublicInputs> bb::HonkProof create_mock_pg_proof();
 bb::Goblin::MergeProof create_mock_merge_proof();
 bb::HonkProof create_mock_pre_ipa_proof();
@@ -25,7 +27,8 @@ bb::HonkProof create_mock_translator_proof();
 
 template <typename Flavor, class PublicInputs>
 std::shared_ptr<typename Flavor::VerificationKey> create_mock_honk_vk(const size_t dyadic_size,
-                                                                      const size_t pub_inputs_offset);
+                                                                      const size_t pub_inputs_offset,
+                                                                      const size_t inner_public_inputs_size = 0);
 template <typename Flavor> std::shared_ptr<bb::DeciderVerificationKey_<Flavor>> create_mock_decider_vk();
 
 } // namespace acir_format

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/mock_verifier_inputs.hpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/mock_verifier_inputs.hpp
@@ -16,7 +16,8 @@ namespace acir_format {
 
 template <typename Flavor, class PublicInputs>
 bb::HonkProof create_mock_oink_proof(const size_t inner_public_inputs_size = 0);
-template <typename Flavor> bb::HonkProof create_mock_decider_proof();
+template <typename Flavor>
+bb::HonkProof create_mock_decider_proof(const size_t const_proof_log_n = bb::CONST_PROOF_SIZE_LOG_N);
 template <typename Flavor, class PublicInputs>
 bb::HonkProof create_mock_honk_proof(const size_t inner_public_inputs_size = 0);
 template <typename Flavor, class PublicInputs> bb::HonkProof create_mock_pg_proof();

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/mock_verifier_inputs.hpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/mock_verifier_inputs.hpp
@@ -19,6 +19,9 @@ template <typename Flavor> bb::HonkProof create_mock_decider_proof();
 template <typename Flavor, class PublicInputs> bb::HonkProof create_mock_honk_proof();
 template <typename Flavor, class PublicInputs> bb::HonkProof create_mock_pg_proof();
 bb::Goblin::MergeProof create_mock_merge_proof();
+bb::HonkProof create_mock_pre_ipa_proof();
+bb::HonkProof create_mock_ipa_proof();
+bb::HonkProof create_mock_translator_proof();
 
 template <typename Flavor, class PublicInputs>
 std::shared_ptr<typename Flavor::VerificationKey> create_mock_honk_vk(const size_t dyadic_size,

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/mock_verifier_inputs.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/mock_verifier_inputs.test.cpp
@@ -32,6 +32,33 @@ TEST(MockVerifierInputsTest, MockMergeProofSize)
 }
 
 /**
+ * @brief Check that the size of a mock pre-ipa proof matches expectation
+ */
+TEST(MockVerifierInputsTest, MockPreIpaProofSize)
+{
+    HonkProof pre_ipa_proof = create_mock_pre_ipa_proof();
+    EXPECT_EQ(pre_ipa_proof.size(), ECCVMFlavor::PROOF_LENGTH_WITHOUT_PUB_INPUTS - IPA_PROOF_LENGTH);
+}
+
+/**
+ * @brief Check that the size of a mock ipa proof matches expectation
+ */
+TEST(MockVerifierInputsTest, MockIPAProofSize)
+{
+    HonkProof ipa_proof = create_mock_ipa_proof();
+    EXPECT_EQ(ipa_proof.size(), IPA_PROOF_LENGTH);
+}
+
+/**
+ * @brief Check that the size of a mock translator proof matches expectation
+ */
+TEST(MockVerifierInputsTest, MockTranslatorProofSize)
+{
+    HonkProof translator_proof = create_mock_translator_proof();
+    EXPECT_EQ(translator_proof.size(), TranslatorFlavor::PROOF_LENGTH_WITHOUT_PUB_INPUTS);
+}
+
+/**
  * @brief Check that the size of a mock Oink proof matches expectation for MegaFlavor
  *
  */

--- a/barretenberg/cpp/src/barretenberg/stdlib/special_public_inputs/special_public_inputs.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/special_public_inputs/special_public_inputs.hpp
@@ -135,8 +135,9 @@ class KernelIO {
  * @brief Manages the data that is propagated on the public inputs of an application/function circuit
  *
  */
-template <typename Builder> class DefaultIO {
+template <typename Builder_> class DefaultIO {
   public:
+    using Builder = Builder_;
     using Curve = stdlib::bn254<Builder>; // curve is always bn254
     using FF = Curve::ScalarField;
     using PairingInputs = stdlib::recursion::PairingPoints<Builder>;


### PR DESCRIPTION
* Define methods to mock proofs for translator and eccvm
* Restructure functions to create dummy vk and proofs in recursion constraints so that they use the functions from `mock_verifier_inputs` (this avoids code duplication)

This PR is mostly in preparation for transitioning the tube in noir. We need to mock translator and eccvm proofs to mock ClientIVC proofs.