### PR TITLE
chore: removing unnecessary lowercase conversion (fixes latex) + some nits

### DIFF
--- a/barretenberg/cpp/docs/Doxyfile
+++ b/barretenberg/cpp/docs/Doxyfile
@@ -610,7 +610,7 @@ INTERNAL_DOCS = NO
 # Possible values are: SYSTEM, NO and YES.
 # The default value is: SYSTEM.
 
-CASE_SENSE_NAMES = YES
+CASE_SENSE_NAMES = NO
 
 # If the HIDE_SCOPE_NAMES tag is set to NO then doxygen will show members with
 # their full class and namespace scopes in the documentation. If set to YES, the

--- a/barretenberg/docs/docs/index.md
+++ b/barretenberg/docs/docs/index.md
@@ -5,7 +5,6 @@ Barretenberg is a C++ library that implements various Zero-Knowledge Succinct No
 ## Key Features
 
 - **Multiple Proof Systems**: Supports several zkSNARK implementations including:
-  - **UltraPlonk**: A legacy version of PLONK
   - **UltraHonk**: A newer, more efficient PLONKish proving system
   - **ClientIVC**: A proving scheme optimized for [Aztec](https://aztec.network) client-side smart contract execution
 
@@ -51,7 +50,7 @@ A versioning tool allowing to install arbitrary versions of Barretenberg, as wel
 The `bb` command line interface is the primary way to interact with Barretenberg directly. It provides commands for operations such as:
 
 - Proving and verifying circuits
-- Generating verification keys 
+- Generating verification keys
 - Creating Solidity verifiers for on-chain verification
 - Executing and verifying recursive proofs
 
@@ -66,7 +65,6 @@ bb.js is a TypeScript library that wraps the Barretenberg C++ implementation via
 UltraHonk is an advanced proof system that offers improvements over the legacy UltraPlonk:
 
 - More efficient proving times
-- Smaller proof sizes
 - Reduced memory usage
 - Enhanced recursive proving capabilities
 

--- a/barretenberg/docs/scripts/build_docs.sh
+++ b/barretenberg/docs/scripts/build_docs.sh
@@ -21,45 +21,10 @@ mkdir -p "../docs/static/api"
 if [ -d "docs/build" ]; then
   # First, clean the destination to avoid any leftover files
   rm -rf ../docs/static/api/*
-  
+
   # Copy the built documentation
   cp -R docs/build/* ../docs/static/api/
-  
-  # Convert all filenames to lowercase to avoid case-sensitivity issues
-  echo "Converting filenames to lowercase to avoid case-sensitivity issues..."
-  cd ../docs/static/api
-  
-  # Find all files and rename them to lowercase
-  find . -depth -name "*" | while read file; do
-    dir=$(dirname "$file")
-    base=$(basename "$file")
-    lower=$(echo "$base" | tr '[:upper:]' '[:lower:]')
-    if [ "$base" != "$lower" ]; then
-      # If file with lowercase name already exists, remove the uppercase version
-      if [ -e "$dir/$lower" ]; then
-        echo "Removing duplicate file: $file (keeping lowercase version)"
-        rm -f "$file"
-      else
-        echo "Renaming: $file -> $dir/$lower"
-        mv "$file" "$dir/$lower"
-      fi
-    fi
-  done
-  
-  # Update all HTML file references to use lowercase names
-  echo "Updating HTML file references to use lowercase names..."
-  find . -name "*.html" -type f | while read htmlfile; do
-    # Use a temporary file for safe in-place editing
-    temp_file=$(mktemp)
-    
-    # Update href and src attributes to use lowercase
-    sed -E 's/href="([^"]*[A-Z][^"]*)"/href="\L\1"/g; s/src="([^"]*[A-Z][^"]*)"/src="\L\1"/g' "$htmlfile" > "$temp_file"
-    
-    # Replace original file with updated content
-    mv "$temp_file" "$htmlfile"
-  done
-  
-  cd - > /dev/null
+
 else
   echo "Error: docs/build directory not found!"
   exit 1


### PR DESCRIPTION
There was this leftover thing from my experiments serving the doxygen page on docusaurus. It was breaking LaTeX when served directly (as it is now).

This fixes it.