### PR TITLE
chore: audit ECCVM transcript relation

### DIFF
--- a/barretenberg/cpp/src/barretenberg/eccvm/eccvm_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/eccvm/eccvm_flavor.hpp
@@ -1052,7 +1052,7 @@ class ECCVMFlavor {
         //    lookups i.e. `polynomials.msm_accumulator_x[last_edge_idx] will change z_perm[last_edge_idx - 1] and
         //    z_perm_shift[last_edge_idx - 1]
         //
-        // 3. The value of `transcript_mul` can be non-zero at the end of a long MSM of points-at-infinity, which will
+        // 3. The value of `transcript_mul` can be non-zero at the end of an MSM of points-at-infinity, which will
         //    cause `full_msm_count` to be non-zero while `transcript_msm_count` vanishes.
         //
         // 4. For similar reasons, we must add that `transcript_op==0`.

--- a/barretenberg/cpp/src/barretenberg/relations/ecc_vm/ecc_set_relation.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/ecc_vm/ecc_set_relation.hpp
@@ -26,7 +26,7 @@ template <typename FF_> class ECCVMSetRelationImpl {
     template <typename AllEntities> inline static bool skip(const AllEntities& in)
     {
         // If z_perm == z_perm_shift, this implies that none of the wire values for the present input are involved in
-        // non-trivial copy constraints. The value of `transcript_mul` can be non-zero at the end of a long MSM of
+        // non-trivial copy constraints. The value of `transcript_mul` can be non-zero at the end of an MSM of
         // points-at-infinity, which will cause `full_msm_count` to be non-zero while `transcript_msm_count` vanishes.
         // Therefore, we add this as a skip condition.
         return (in.z_perm - in.z_perm_shift).is_zero() && in.transcript_mul.is_zero() && in.lagrange_last.is_zero();

--- a/barretenberg/cpp/src/barretenberg/relations/ecc_vm/ecc_transcript_relation.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/ecc_vm/ecc_transcript_relation.hpp
@@ -36,8 +36,8 @@ template <typename FF_> class ECCVMTranscriptRelationImpl {
   public:
     using FF = FF_;
 
-    static constexpr std::array<size_t, 25> SUBRELATION_PARTIAL_LENGTHS{
-        8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8,
+    static constexpr std::array<size_t, 26> SUBRELATION_PARTIAL_LENGTHS{
+        8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8,
     };
 
     template <typename ContainerOverSubrelations, typename AllEntities, typename Parameters>

--- a/barretenberg/cpp/src/barretenberg/relations/ecc_vm/ecc_transcript_relation.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/ecc_vm/ecc_transcript_relation.hpp
@@ -36,8 +36,8 @@ template <typename FF_> class ECCVMTranscriptRelationImpl {
   public:
     using FF = FF_;
 
-    static constexpr std::array<size_t, 26> SUBRELATION_PARTIAL_LENGTHS{
-        8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8,
+    static constexpr std::array<size_t, 25> SUBRELATION_PARTIAL_LENGTHS{
+        8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8,
     };
 
     template <typename ContainerOverSubrelations, typename AllEntities, typename Parameters>

--- a/barretenberg/cpp/src/barretenberg/relations/ecc_vm/ecc_transcript_relation_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/ecc_vm/ecc_transcript_relation_impl.hpp
@@ -55,48 +55,48 @@ void ECCVMTranscriptRelationImpl<FF>::accumulate(ContainerOverSubrelations& accu
         static const Accumulator oy(qy);
         return std::array<Accumulator, 2>{ ox, oy };
     };
-    auto z1 = View(in.transcript_z1);
-    auto z2 = View(in.transcript_z2);
-    auto z1_zero = View(in.transcript_z1zero);
-    auto z2_zero = View(in.transcript_z2zero);
-    auto op = View(in.transcript_op);
-    auto q_add = View(in.transcript_add);
-    auto q_mul = View(in.transcript_mul);
-    auto q_mul_shift = View(in.transcript_mul_shift);
-    auto q_eq = View(in.transcript_eq);
-    auto msm_transition = View(in.transcript_msm_transition);
-    auto msm_count = View(in.transcript_msm_count);
-    auto msm_count_shift = View(in.transcript_msm_count_shift);
-    auto pc = View(in.transcript_pc);
-    auto pc_shift = View(in.transcript_pc_shift);
-    auto transcript_accumulator_x_shift = View(in.transcript_accumulator_x_shift);
-    auto transcript_accumulator_y_shift = View(in.transcript_accumulator_y_shift);
-    auto transcript_accumulator_x = View(in.transcript_accumulator_x);
-    auto transcript_accumulator_y = View(in.transcript_accumulator_y);
-    auto msm_count_zero_at_transition = View(in.transcript_msm_count_zero_at_transition);
-    auto msm_count_at_transition_inverse = View(in.transcript_msm_count_at_transition_inverse);
-    auto transcript_msm_x = View(in.transcript_msm_intermediate_x);
-    auto transcript_msm_y = View(in.transcript_msm_intermediate_y);
-    auto transcript_Px = View(in.transcript_Px);
-    auto transcript_Py = View(in.transcript_Py);
-    auto is_accumulator_empty = -View(in.transcript_accumulator_not_empty) + 1;
-    auto lagrange_first = View(in.lagrange_first);
-    auto lagrange_last = View(in.lagrange_last);
-    auto is_accumulator_empty_shift = -View(in.transcript_accumulator_not_empty_shift) + 1;
-    auto q_reset_accumulator = View(in.transcript_reset_accumulator);
-    auto lagrange_second = View(in.lagrange_second);
-    auto transcript_Pinfinity = View(in.transcript_base_infinity);
-    auto transcript_Px_inverse = View(in.transcript_base_x_inverse);
-    auto transcript_Py_inverse = View(in.transcript_base_y_inverse);
-    auto transcript_add_x_equal = View(in.transcript_add_x_equal);
-    auto transcript_add_y_equal = View(in.transcript_add_y_equal);
-    auto transcript_add_lambda = View(in.transcript_add_lambda);
-    auto transcript_msm_infinity = View(in.transcript_msm_infinity);
+    const auto z1 = View(in.transcript_z1);
+    const auto z2 = View(in.transcript_z2);
+    const auto z1_zero = View(in.transcript_z1zero);
+    const auto z2_zero = View(in.transcript_z2zero);
+    const auto op = View(in.transcript_op);
+    const auto q_add = View(in.transcript_add);
+    const auto q_mul = View(in.transcript_mul);
+    const auto q_mul_shift = View(in.transcript_mul_shift);
+    const auto q_eq = View(in.transcript_eq);
+    const auto msm_transition = View(in.transcript_msm_transition);
+    const auto msm_count = View(in.transcript_msm_count);
+    const auto msm_count_shift = View(in.transcript_msm_count_shift);
+    const auto pc = View(in.transcript_pc);
+    const auto pc_shift = View(in.transcript_pc_shift);
+    const auto transcript_accumulator_x_shift = View(in.transcript_accumulator_x_shift);
+    const auto transcript_accumulator_y_shift = View(in.transcript_accumulator_y_shift);
+    const auto transcript_accumulator_x = View(in.transcript_accumulator_x);
+    const auto transcript_accumulator_y = View(in.transcript_accumulator_y);
+    const auto msm_count_zero_at_transition = View(in.transcript_msm_count_zero_at_transition);
+    const auto msm_count_at_transition_inverse = View(in.transcript_msm_count_at_transition_inverse);
+    const auto transcript_msm_x = View(in.transcript_msm_intermediate_x);
+    const auto transcript_msm_y = View(in.transcript_msm_intermediate_y);
+    const auto transcript_Px = View(in.transcript_Px);
+    const auto transcript_Py = View(in.transcript_Py);
+    const auto is_accumulator_empty = -View(in.transcript_accumulator_not_empty) + 1;
+    const auto lagrange_first = View(in.lagrange_first);
+    const auto lagrange_last = View(in.lagrange_last);
+    const auto is_accumulator_empty_shift = -View(in.transcript_accumulator_not_empty_shift) + 1;
+    const auto q_reset_accumulator = View(in.transcript_reset_accumulator);
+    const auto lagrange_second = View(in.lagrange_second);
+    const auto transcript_Pinfinity = View(in.transcript_base_infinity);
+    const auto transcript_Px_inverse = View(in.transcript_base_x_inverse);
+    const auto transcript_Py_inverse = View(in.transcript_base_y_inverse);
+    const auto transcript_add_x_equal = View(in.transcript_add_x_equal);
+    const auto transcript_add_y_equal = View(in.transcript_add_y_equal);
+    const auto transcript_add_lambda = View(in.transcript_add_lambda);
+    const auto transcript_msm_infinity = View(in.transcript_msm_infinity);
 
-    auto is_not_first_row = (-lagrange_first + 1);
-    auto is_not_last_row = (-lagrange_last + 1);
-    auto is_not_first_or_last_row = (-lagrange_first + -lagrange_last + 1);
-    auto is_not_infinity = (-transcript_Pinfinity + 1);
+    const auto is_not_first_row = (-lagrange_first + 1);
+    const auto is_not_last_row = (-lagrange_last + 1);
+    const auto is_not_first_or_last_row = (-lagrange_first + -lagrange_last + 1);
+    const auto is_not_infinity = (-transcript_Pinfinity + 1);
     /**
      * @brief Validate correctness of z1_zero, z2_zero.
      * If z1_zero = 0 and operation is a MUL, we will write a scalar mul instruction into our multiplication table.
@@ -166,7 +166,7 @@ void ECCVMTranscriptRelationImpl<FF>::accumulate(ContainerOverSubrelations& accu
     auto msm_count_zero_at_transition_check = msm_count_zero_at_transition * msm_count_total;
     msm_count_zero_at_transition_check +=
         (msm_count_total * msm_count_at_transition_inverse - 1) * (-msm_count_zero_at_transition + 1); // degree 4
-    // forces that `msm_count_zero_at_transition` to have the following property at a syntactic transition: if
+    // forces `msm_count_zero_at_transition` to have the following property at a syntactic transition: if
     // `msm_count_zero_at_transition == 1`, then `msm_count_total == 0`. else if `msm_count_zero_at_transition == 0`,
     // then `msm_count_total != 0` and is in fact the inverse of `msm_count_at_transition_inverse` (which is a witness
     // column).

--- a/barretenberg/cpp/src/barretenberg/relations/ecc_vm/ecc_transcript_relation_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/ecc_vm/ecc_transcript_relation_impl.hpp
@@ -231,12 +231,15 @@ void ECCVMTranscriptRelationImpl<FF>::accumulate(ContainerOverSubrelations& accu
 
     /**
      * @brief Boundary conditions.
-     * The first "content" row is the _second_ row of the table. We demand that the following values are present:
-     * is_accumulator_empty = 1
-     * msm_count = 0
+     * The first "content" row is the _second_ row of the table.
+     *
+     * We demand that the following values are present in this first content row:
+     * `is_accumulator_empty == 1`; and
+     * `msm_count == 0`.
+     * We also demand that `pc == 0` at the last row.
      */
-    std::get<11>(accumulator) += lagrange_second * (-is_accumulator_empty + 1) * scaling_factor; // degree 2
-    std::get<12>(accumulator) += lagrange_second * msm_count * scaling_factor;                   // degree 2
+    std::get<11>(accumulator) += lagrange_second * (-is_accumulator_empty + 1) * scaling_factor;      // degree 2
+    std::get<12>(accumulator) += (lagrange_second * msm_count + lagrange_last * pc) * scaling_factor; // degree 2
 
     /**
      * @brief On-curve validation checks.
@@ -506,14 +509,6 @@ void ECCVMTranscriptRelationImpl<FF>::accumulate(ContainerOverSubrelations& accu
         auto y_constant = transcript_add_y_equal - 1;
         auto transcript_add_y_equal_check_relation = (y_diff * y_product + y_constant) * any_add_is_active;
         std::get<24>(accumulator) += transcript_add_y_equal_check_relation * scaling_factor; // degree 5
-
-        /**
-         * @brief check that the last `pc` is 0
-         *
-         * our `pc` is non-increasing for optimization reasons. therefore our boundary condition for `pc` is that the
-         * last row has value 0.
-         */
-        std::get<25>(accumulator) += lagrange_last * pc * scaling_factor;
     }
 }
 } // namespace bb


### PR DESCRIPTION
Audit of the transcript relations in the ECCVM.

Only two content changes: the `pc` wasn't constrained to be zero at the last row and there was some confusing (to me!) logic re: `msm_count` that I simplified.

The rest is comments.