### PR TITLE
fix: Correct active range for databus

### DIFF
--- a/barretenberg/cpp/scripts/test_civc_standalone_vks_havent_changed.sh
+++ b/barretenberg/cpp/scripts/test_civc_standalone_vks_havent_changed.sh
@@ -11,7 +11,7 @@ cd ..
 # - Generate a hash for versioning: sha256sum bb-civc-inputs.tar.gz
 # - Upload the compressed results: aws s3 cp bb-civc-inputs.tar.gz s3://aztec-ci-artifacts/protocol/bb-civc-inputs-[hash(0:8)].tar.gz
 # Note: In case of the "Test suite failed to run ... Unexpected token 'with' " error, need to run: docker pull aztecprotocol/build:3.0
-pinned_short_hash="1710c0ac"
+pinned_short_hash="0413d627"
 pinned_civc_inputs_url="https://aztec-ci-artifacts.s3.us-east-2.amazonaws.com/protocol/bb-civc-inputs-${pinned_short_hash}.tar.gz"
 
 function compress_and_upload {

--- a/barretenberg/cpp/src/barretenberg/honk/execution_trace/execution_trace_usage_tracker.hpp
+++ b/barretenberg/cpp/src/barretenberg/honk/execution_trace/execution_trace_usage_tracker.hpp
@@ -102,7 +102,7 @@ struct ExecutionTraceUsageTracker {
         // The active range for lookup-style blocks consists of two components: (1) rows containing the lookup/read
         // gates and (2) rows containing the table data itself. The Mega arithmetization contains two such blocks:
         // conventional lookups (lookup block) and the databus (busread block). Here we add the ranges corresponding
-        // to the "table" data for these two blocks.
+        // to the "table" data for these two blocks. The corresponding gate ranges were added above.
         size_t databus_data_start = 0; // Databus column data starts at idx 0
         size_t databus_data_end = databus_data_start + max_databus_size;
         active_ranges.push_back(Range{ databus_data_start, databus_data_end }); // region where databus contains data

--- a/barretenberg/cpp/src/barretenberg/honk/execution_trace/execution_trace_usage_tracker.hpp
+++ b/barretenberg/cpp/src/barretenberg/honk/execution_trace/execution_trace_usage_tracker.hpp
@@ -99,7 +99,10 @@ struct ExecutionTraceUsageTracker {
             active_ranges.push_back(Range{ start_idx, end_idx });
         }
 
-        // The active ranges must also include the rows where the actual databus and lookup table data are stored.
+        // The active range for lookup-style blocks consists of two components: (1) rows containing the lookup/read
+        // gates and (2) rows containing the table data itself. The Mega arithmetization contains two such blocks:
+        // conventional lookups (lookup block) and the databus (busread block). Here we add the ranges corresponding
+        // to the "table" data for these two blocks.
         size_t databus_data_start = 0; // Databus column data starts at idx 0
         size_t databus_data_end = databus_data_start + max_databus_size;
         active_ranges.push_back(Range{ databus_data_start, databus_data_end }); // region where databus contains data

--- a/barretenberg/cpp/src/barretenberg/honk/execution_trace/execution_trace_usage_tracker.hpp
+++ b/barretenberg/cpp/src/barretenberg/honk/execution_trace/execution_trace_usage_tracker.hpp
@@ -108,22 +108,9 @@ struct ExecutionTraceUsageTracker {
         active_ranges.push_back(Range{ databus_data_start, databus_data_end }); // region where databus contains data
 
         // Note: start of table data is aligned with start of the lookup gates block
-        size_t lookups_start = fixed_sizes.lookup.trace_offset();
-        size_t lookups_end = lookups_start + std::max(max_tables_size, static_cast<size_t>(max_sizes.lookup));
-        active_ranges.emplace_back(Range{ lookups_start, lookups_end });
-    }
-
-    // Check whether an index is contained within the active ranges (or previous active ranges; needed for perturbator)
-    bool check_is_active(const size_t idx, bool use_prev_accumulator = false)
-    {
-        // If structured trace is not in use, assume the whole trace is active
-        if (!trace_settings.structure) {
-            return true;
-        }
-        std::vector<Range> ranges_to_check = use_prev_accumulator ? previous_active_ranges : active_ranges;
-        return std::any_of(ranges_to_check.begin(), ranges_to_check.end(), [idx](const auto& range) {
-            return idx >= range.first && idx < range.second;
-        });
+        size_t tables_start = fixed_sizes.lookup.trace_offset();
+        size_t tables_end = tables_start + max_tables_size;
+        active_ranges.emplace_back(Range{ tables_start, tables_end }); // region where table data is stored
     }
 
     void print()

--- a/barretenberg/cpp/src/barretenberg/honk/execution_trace/execution_trace_usage_tracker.hpp
+++ b/barretenberg/cpp/src/barretenberg/honk/execution_trace/execution_trace_usage_tracker.hpp
@@ -100,12 +100,9 @@ struct ExecutionTraceUsageTracker {
         }
 
         // The active ranges must also include the rows where the actual databus and lookup table data are stored.
-        // (Note: lookup tables are constructed from the beginning of the lookup block ; databus data is constructed at
-        // the start of the trace).
-
-        // TODO(https://github.com/AztecProtocol/barretenberg/issues/1152): should be able to use simply Range{ 0,
-        // max_databus_size } but this breaks for certain choices of num_threads. It should also be possible to have the
-        // lookup table data be Range{lookup_start, max_tables_size} but that also breaks.
+        size_t databus_data_start = 0; // Databus column data starts at idx 0
+        size_t databus_data_end = databus_data_start + max_databus_size;
+        active_ranges.push_back(Range{ databus_data_start, databus_data_end }); // region where databus contains data
         size_t lookups_start = fixed_sizes.lookup.trace_offset();
         size_t lookups_end = lookups_start + std::max(max_tables_size, static_cast<size_t>(max_sizes.lookup));
         active_ranges.emplace_back(Range{ lookups_start, lookups_end });

--- a/barretenberg/cpp/src/barretenberg/honk/execution_trace/execution_trace_usage_tracker.hpp
+++ b/barretenberg/cpp/src/barretenberg/honk/execution_trace/execution_trace_usage_tracker.hpp
@@ -106,9 +106,6 @@ struct ExecutionTraceUsageTracker {
         // TODO(https://github.com/AztecProtocol/barretenberg/issues/1152): should be able to use simply Range{ 0,
         // max_databus_size } but this breaks for certain choices of num_threads. It should also be possible to have the
         // lookup table data be Range{lookup_start, max_tables_size} but that also breaks.
-        size_t databus_end =
-            std::max(max_databus_size, static_cast<size_t>(fixed_sizes.busread.trace_offset() + max_sizes.busread));
-        active_ranges.push_back(Range{ 0, databus_end });
         size_t lookups_start = fixed_sizes.lookup.trace_offset();
         size_t lookups_end = lookups_start + std::max(max_tables_size, static_cast<size_t>(max_sizes.lookup));
         active_ranges.emplace_back(Range{ lookups_start, lookups_end });

--- a/barretenberg/cpp/src/barretenberg/honk/execution_trace/execution_trace_usage_tracker.hpp
+++ b/barretenberg/cpp/src/barretenberg/honk/execution_trace/execution_trace_usage_tracker.hpp
@@ -103,9 +103,24 @@ struct ExecutionTraceUsageTracker {
         size_t databus_data_start = 0; // Databus column data starts at idx 0
         size_t databus_data_end = databus_data_start + max_databus_size;
         active_ranges.push_back(Range{ databus_data_start, databus_data_end }); // region where databus contains data
+
+        // Note: start of table data is aligned with start of the lookup gates block
         size_t lookups_start = fixed_sizes.lookup.trace_offset();
         size_t lookups_end = lookups_start + std::max(max_tables_size, static_cast<size_t>(max_sizes.lookup));
         active_ranges.emplace_back(Range{ lookups_start, lookups_end });
+    }
+
+    // Check whether an index is contained within the active ranges (or previous active ranges; needed for perturbator)
+    bool check_is_active(const size_t idx, bool use_prev_accumulator = false)
+    {
+        // If structured trace is not in use, assume the whole trace is active
+        if (!trace_settings.structure) {
+            return true;
+        }
+        std::vector<Range> ranges_to_check = use_prev_accumulator ? previous_active_ranges : active_ranges;
+        return std::any_of(ranges_to_check.begin(), ranges_to_check.end(), [idx](const auto& range) {
+            return idx >= range.first && idx < range.second;
+        });
     }
 
     void print()

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/decider_proving_key.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/decider_proving_key.cpp
@@ -160,16 +160,20 @@ void DeciderProvingKey_<Flavor>::allocate_databus_polynomials(const Circuit& cir
     polynomials.return_data_read_counts = Polynomial(MAX_DATABUS_SIZE, dyadic_size());
     polynomials.return_data_read_tags = Polynomial(MAX_DATABUS_SIZE, dyadic_size());
 
-    polynomials.databus_id = Polynomial(MAX_DATABUS_SIZE, dyadic_size());
-
     // Allocate log derivative lookup argument inverse polynomials
     const size_t q_busread_end =
         circuit.blocks.busread.trace_offset() + circuit.blocks.busread.get_fixed_size(is_structured);
-    polynomials.calldata_inverses = Polynomial(std::max(circuit.get_calldata().size(), q_busread_end), dyadic_size());
+    const size_t calldata_size = circuit.get_calldata().size();
+    const size_t secondary_calldata_size = circuit.get_secondary_calldata().size();
+    const size_t return_data_size = circuit.get_return_data().size();
+
+    polynomials.databus_id = Polynomial(
+        std::max({ calldata_size, secondary_calldata_size, return_data_size, q_busread_end }), dyadic_size());
+
+    polynomials.calldata_inverses = Polynomial(std::max(calldata_size, q_busread_end), dyadic_size());
     polynomials.secondary_calldata_inverses =
-        Polynomial(std::max(circuit.get_secondary_calldata().size(), q_busread_end), dyadic_size());
-    polynomials.return_data_inverses =
-        Polynomial(std::max(circuit.get_return_data().size(), q_busread_end), dyadic_size());
+        Polynomial(std::max(secondary_calldata_size, q_busread_end), dyadic_size());
+    polynomials.return_data_inverses = Polynomial(std::max(return_data_size, q_busread_end), dyadic_size());
 }
 
 /**


### PR DESCRIPTION
Update the "active range" tracker to use the correct ranges for the databus data and lookup table data. Previously they were being constructed to include a redundant subset of the trace, potentially leading to execution of the relations on rows where it isn't necessary.

Closes https://github.com/AztecProtocol/barretenberg/issues/1152