### PR TITLE
chore: separate hashing from fiat-shamir

### DIFF
--- a/barretenberg/cpp/src/barretenberg/eccvm/eccvm_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/eccvm/eccvm_flavor.hpp
@@ -841,8 +841,8 @@ class ECCVMFlavor {
          * @param transcript
          * @returns The hash of the verification key
          */
-        fr add_hash_to_transcript([[maybe_unused]] const std::string& domain_separator,
-                                  [[maybe_unused]] Transcript& transcript) const override
+        fr hash_through_transcript([[maybe_unused]] const std::string& domain_separator,
+                                   [[maybe_unused]] Transcript& transcript) const override
         {
             throw_or_abort("Not intended to be used because vk is hardcoded in circuit.");
         }

--- a/barretenberg/cpp/src/barretenberg/flavor/flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/flavor.hpp
@@ -205,7 +205,7 @@ class NativeVerificationKey_ : public PrecomputedCommitments {
     }
 
     /**
-     * @brief Adds the verification key hash to the transcript and returns the hash.
+     * @brief Hashes the vk using the transcript's independent buffer and returns the hash.
      * @details Needed to make sure the Origin Tag system works. We need to set the origin tags of the VK witnesses in
      * the transcript. If we instead did the hashing outside of the transcript and submitted just the hash, only the
      * origin tag of the hash would be set properly. We want to avoid backpropagating origin tags to the actual VK
@@ -216,7 +216,8 @@ class NativeVerificationKey_ : public PrecomputedCommitments {
      * @param transcript
      * @returns The hash of the verification key
      */
-    virtual fr add_hash_to_transcript(const std::string& domain_separator, Transcript& transcript) const
+    virtual typename Transcript::DataType hash_through_transcript(const std::string& domain_separator,
+                                                                  Transcript& transcript) const
     {
         transcript.add_to_independent_hash_buffer(domain_separator + "vk_log_circuit_size", this->log_circuit_size);
         transcript.add_to_independent_hash_buffer(domain_separator + "vk_num_public_inputs", this->num_public_inputs);
@@ -226,10 +227,8 @@ class NativeVerificationKey_ : public PrecomputedCommitments {
             transcript.add_to_independent_hash_buffer(domain_separator + "vk_commitment", commitment);
         }
 
-        fr vk_hash = transcript.hash_independent_buffer();
-        transcript.add_to_hash_buffer(domain_separator + "vk_hash", vk_hash);
-        return vk_hash;
-    };
+        return transcript.hash_independent_buffer();
+    }
 };
 
 /**
@@ -299,7 +298,7 @@ class StdlibVerificationKey_ : public PrecomputedCommitments {
     }
 
     /**
-     * @brief Adds the verification key hash to the transcript and returns the hash.
+     * @brief Hashes the vk using the transcript's independent buffer and returns the hash.
      * @details Needed to make sure the Origin Tag system works. We need to set the origin tags of the VK witnesses in
      * the transcript. If we instead did the hashing outside of the transcript and submitted just the hash, only the
      * origin tag of the hash would be set properly. We want to avoid backpropagating origin tags to the actual VK
@@ -310,7 +309,7 @@ class StdlibVerificationKey_ : public PrecomputedCommitments {
      * @param transcript
      * @returns The hash of the verification key
      */
-    virtual FF add_hash_to_transcript(const std::string& domain_separator, Transcript& transcript) const
+    virtual FF hash_through_transcript(const std::string& domain_separator, Transcript& transcript) const
     {
         transcript.add_to_independent_hash_buffer(domain_separator + "vk_log_circuit_size", this->log_circuit_size);
         transcript.add_to_independent_hash_buffer(domain_separator + "vk_num_public_inputs", this->num_public_inputs);
@@ -318,10 +317,8 @@ class StdlibVerificationKey_ : public PrecomputedCommitments {
         for (const Commitment& commitment : this->get_all()) {
             transcript.add_to_independent_hash_buffer(domain_separator + "vk_commitment", commitment);
         }
-        FF vk_hash = transcript.hash_independent_buffer();
-        transcript.add_to_hash_buffer(domain_separator + "vk_hash", vk_hash);
-        return vk_hash;
-    };
+        return transcript.hash_independent_buffer();
+    }
 };
 
 template <typename FF, typename VerificationKey> class VKAndHash_ {

--- a/barretenberg/cpp/src/barretenberg/flavor/native_verification_key.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/native_verification_key.test.cpp
@@ -61,7 +61,7 @@ TYPED_TEST_SUITE(NativeVerificationKeyTests, FlavorTypes);
 
 /**
  * @brief Checks that the hash produced from calling to_field_elements and then add_to_independent_hash_buffer is the
- * same as the hash() call and also the same as the add_hash_to_transcript.
+ * same as the hash() call and also the same as the hash_through_transcript.
  *
  */
 TYPED_TEST(NativeVerificationKeyTests, VKHashingConsistency)
@@ -79,15 +79,15 @@ TYPED_TEST(NativeVerificationKeyTests, VKHashingConsistency)
     for (const auto& field_element : vk_field_elements) {
         transcript.add_to_independent_hash_buffer("vk_element", field_element);
     }
-    fr vkey_hash_1 = transcript.hash_independent_buffer();
+    fr vk_hash_1 = transcript.hash_independent_buffer();
     // Second method of hashing: using hash().
-    fr vkey_hash_2 = vk.hash();
-    EXPECT_EQ(vkey_hash_1, vkey_hash_2);
+    fr vk_hash_2 = vk.hash();
+    EXPECT_EQ(vk_hash_1, vk_hash_2);
     if constexpr (!IsAnyOf<Flavor, ECCVMFlavor, TranslatorFlavor>) {
-        // Third method of hashing: using add_hash_to_transcript.
+        // Third method of hashing: using hash_through_transcript.
         typename Flavor::Transcript transcript_2;
-        fr vkey_hash_3 = vk.add_hash_to_transcript("", transcript_2);
-        EXPECT_EQ(vkey_hash_2, vkey_hash_3);
+        fr vk_hash_3 = vk.hash_through_transcript("", transcript_2);
+        EXPECT_EQ(vk_hash_2, vk_hash_3);
     }
 }
 

--- a/barretenberg/cpp/src/barretenberg/flavor/stdlib_verification_key.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/stdlib_verification_key.test.cpp
@@ -41,7 +41,7 @@ TYPED_TEST_SUITE(StdlibVerificationKeyTests, FlavorTypes);
 
 /**
  * @brief Checks that the hash produced from calling to_field_elements and then add_to_independent_hash_buffer is the
- * same as the hash() call and also the same as the add_hash_to_transcript.
+ * same as the hash() call and also the same as the hash_through_transcript.
  *
  */
 TYPED_TEST(StdlibVerificationKeyTests, VKHashingConsistency)
@@ -77,14 +77,14 @@ TYPED_TEST(StdlibVerificationKeyTests, VKHashingConsistency)
     for (const auto& field_element : vk_field_elements) {
         transcript.add_to_independent_hash_buffer("vk_element", field_element);
     }
-    FF vkey_hash_1 = transcript.hash_independent_buffer();
+    FF vk_hash_1 = transcript.hash_independent_buffer();
     // Second method of hashing: using hash().
-    FF vkey_hash_2 = vk.hash(outer_builder);
-    EXPECT_EQ(vkey_hash_1.get_value(), vkey_hash_2.get_value());
-    // Third method of hashing: using add_hash_to_transcript.
+    FF vk_hash_2 = vk.hash(outer_builder);
+    EXPECT_EQ(vk_hash_1.get_value(), vk_hash_2.get_value());
+    // Third method of hashing: using hash_through_transcript.
     if constexpr (!IsAnyOf<Flavor, TranslatorRecursiveFlavor, ECCVMRecursiveFlavor>) {
         StdlibTranscript transcript_2;
-        FF vkey_hash_3 = vk.add_hash_to_transcript("", transcript_2);
-        EXPECT_EQ(vkey_hash_2.get_value(), vkey_hash_3.get_value());
+        FF vk_hash_3 = vk.hash_through_transcript("", transcript_2);
+        EXPECT_EQ(vk_hash_2.get_value(), vk_hash_3.get_value());
     }
 }

--- a/barretenberg/cpp/src/barretenberg/flavor/ultra_keccak_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/ultra_keccak_flavor.hpp
@@ -93,25 +93,6 @@ class UltraKeccakFlavor : public bb::UltraFlavor {
             }
         }
 
-        /**
-         * @brief Adds the verification key witnesses directly to the transcript.
-         * @details Needed to make sure the Origin Tag system works. See the base class function for
-         * more details.
-         *
-         * @param domain_separator
-         * @param transcript
-         *
-         * @returns The hash of the verification key
-         */
-        fr add_hash_to_transcript(const std::string& domain_separator, Transcript& transcript) const override
-        {
-            // This hash contains a hash of the entire vk - including all of the elements
-            const fr hash = this->hash();
-
-            transcript.add_to_hash_buffer(domain_separator + "vk_hash", hash);
-            return hash;
-        }
-
         // Don't statically check for object completeness.
         using MSGPACK_NO_STATIC_CHECK = std::true_type;
 

--- a/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover_impl.hpp
@@ -37,7 +37,8 @@ void ProtogalaxyProver_<Flavor, NUM_KEYS>::run_oink_prover_on_each_incomplete_ke
         run_oink_prover_on_one_incomplete_key(key, verifier_accum, domain_separator);
     } else {
         // Fiat-Shamir the verifier accumulator
-        FF accum_hash = verifier_accum->add_hash_to_transcript("", *transcript);
+        FF accum_hash = verifier_accum->hash_through_transcript(domain_separator + '_', *transcript);
+        transcript->add_to_hash_buffer(domain_separator + "_accum_hash", accum_hash);
         info("Accumulator hash in PG prover: ", accum_hash);
     }
 

--- a/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_verifier.cpp
@@ -25,7 +25,8 @@ void ProtogalaxyVerifier_<DeciderVerificationKeys>::run_oink_verifier_on_each_in
         key->gate_challenges = std::vector<FF>(CONST_PG_LOG_N, 0);
     } else {
         // Fiat-Shamir the verifier accumulator
-        FF accum_hash = key->add_hash_to_transcript("", *transcript);
+        FF accum_hash = key->hash_through_transcript(domain_separator + '_', *transcript);
+        transcript->add_to_hash_buffer(domain_separator + "_accum_hash", accum_hash);
         info("Accumulator hash in PG verifier: ", accum_hash);
     }
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/eccvm_verifier/eccvm_recursive_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/eccvm_verifier/eccvm_recursive_flavor.hpp
@@ -146,8 +146,8 @@ class ECCVMRecursiveFlavor {
          * @param domain_separator
          * @param transcript
          */
-        FF add_hash_to_transcript([[maybe_unused]] const std::string& domain_separator,
-                                  [[maybe_unused]] Transcript& transcript) const override
+        FF hash_through_transcript([[maybe_unused]] const std::string& domain_separator,
+                                   [[maybe_unused]] Transcript& transcript) const override
         {
             throw_or_abort("Not intended to be used because vk is hardcoded in circuit.");
         }

--- a/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/oink_recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/oink_recursive_verifier.cpp
@@ -50,11 +50,12 @@ template <typename Flavor> void OinkRecursiveVerifier_<Flavor>::verify()
     WitnessCommitments commitments;
     CommitmentLabels labels;
 
-    FF vkey_hash = decider_vk->vk_and_hash->vk->add_hash_to_transcript(domain_separator, *transcript);
-    vinfo("vk hash in Oink recursive verifier: ", vkey_hash);
+    FF vk_hash = decider_vk->vk_and_hash->vk->hash_through_transcript(domain_separator, *transcript);
+    transcript->add_to_hash_buffer(domain_separator + "vk_hash", vk_hash);
+    vinfo("vk hash in Oink recursive verifier: ", vk_hash);
     vinfo("expected vk hash: ", decider_vk->vk_and_hash->hash);
     // Check that the vk hash matches the hash of the verification key
-    decider_vk->vk_and_hash->hash.assert_equal(vkey_hash);
+    decider_vk->vk_and_hash->hash.assert_equal(vk_hash);
 
     size_t num_public_inputs =
         static_cast<size_t>(static_cast<uint32_t>(decider_vk->vk_and_hash->vk->num_public_inputs.get_value()));

--- a/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/protogalaxy_recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/protogalaxy_recursive_verifier.cpp
@@ -29,7 +29,8 @@ void ProtogalaxyRecursiveVerifier_<DeciderVerificationKeys>::run_oink_verifier_o
         // Fiat-Shamir the accumulator.
         // TODO(https://github.com/AztecProtocol/barretenberg/issues/1390): assert_equal on accumulator hash with public
         // input hash.
-        FF accum_hash = key->add_hash_to_transcript("", *transcript);
+        FF accum_hash = key->hash_through_transcript(domain_separator + '_', *transcript);
+        transcript->add_to_hash_buffer(domain_separator + "_accum_hash", accum_hash);
         info("Accumulator hash in PG rec verifier: ", accum_hash);
     }
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/recursive_decider_verification_key.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/recursive_decider_verification_key.hpp
@@ -145,7 +145,7 @@ template <IsRecursiveFlavor Flavor> class RecursiveDeciderVerificationKey_ {
         return decider_vk;
     }
 
-    FF add_hash_to_transcript(const std::string& domain_separator, Transcript& transcript) const
+    FF hash_through_transcript(const std::string& domain_separator, Transcript& transcript) const
     {
         transcript.add_to_independent_hash_buffer(domain_separator + "decider_vk_log_circuit_size",
                                                   this->vk_and_hash->vk->log_circuit_size);
@@ -177,9 +177,7 @@ template <IsRecursiveFlavor Flavor> class RecursiveDeciderVerificationKey_ {
         transcript.add_to_independent_hash_buffer(domain_separator + "decider_vk_gate_challenges",
                                                   this->gate_challenges);
 
-        FF decider_vk_hash = transcript.hash_independent_buffer();
-        transcript.add_to_hash_buffer(domain_separator + "decider_vk_hash", decider_vk_hash);
-        return decider_vk_hash;
+        return transcript.hash_independent_buffer();
     }
 };
 } // namespace bb::stdlib::recursion::honk

--- a/barretenberg/cpp/src/barretenberg/stdlib/translator_vm_verifier/translator_recursive_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/translator_vm_verifier/translator_recursive_flavor.hpp
@@ -146,8 +146,8 @@ class TranslatorRecursiveFlavor {
          * @param domain_separator
          * @param transcript
          */
-        FF add_hash_to_transcript([[maybe_unused]] const std::string& domain_separator,
-                                  [[maybe_unused]] Transcript& transcript) const override
+        FF hash_through_transcript([[maybe_unused]] const std::string& domain_separator,
+                                   [[maybe_unused]] Transcript& transcript) const override
         {
             throw_or_abort("Not intended to be used because vk is hardcoded in circuit.");
         }

--- a/barretenberg/cpp/src/barretenberg/translator_vm/translator_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/translator_flavor.hpp
@@ -806,8 +806,8 @@ class TranslatorFlavor {
          * @param domain_separator
          * @param transcript
          */
-        fr add_hash_to_transcript([[maybe_unused]] const std::string& domain_separator,
-                                  [[maybe_unused]] Transcript& transcript) const override
+        fr hash_through_transcript([[maybe_unused]] const std::string& domain_separator,
+                                   [[maybe_unused]] Transcript& transcript) const override
         {
             throw_or_abort("Not intended to be used because vk is hardcoded in circuit.");
         }

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/decider_verification_key.hpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/decider_verification_key.hpp
@@ -46,7 +46,7 @@ template <IsUltraOrMegaHonk Flavor> class DeciderVerificationKey_ {
         : vk(vk)
     {}
 
-    FF add_hash_to_transcript(const std::string& domain_separator, Transcript& transcript) const
+    FF hash_through_transcript(const std::string& domain_separator, Transcript& transcript) const
     {
         transcript.add_to_independent_hash_buffer(domain_separator + "decider_vk_log_circuit_size",
                                                   this->vk->log_circuit_size);
@@ -78,9 +78,7 @@ template <IsUltraOrMegaHonk Flavor> class DeciderVerificationKey_ {
         transcript.add_to_independent_hash_buffer(domain_separator + "decider_vk_gate_challenges",
                                                   this->gate_challenges);
 
-        FF decider_vk_hash = transcript.hash_independent_buffer();
-        transcript.add_to_hash_buffer(domain_separator + "decider_vk_hash", decider_vk_hash);
-        return decider_vk_hash;
+        return transcript.hash_independent_buffer();
     }
 
     MSGPACK_FIELDS(vk, relation_parameters, alphas, is_complete, gate_challenges, target_sum, witness_commitments);

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/oink_prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/oink_prover.cpp
@@ -87,8 +87,9 @@ template <IsUltraOrMegaHonk Flavor> typename OinkProver<Flavor>::Proof OinkProve
 template <IsUltraOrMegaHonk Flavor> void OinkProver<Flavor>::execute_preamble_round()
 {
     PROFILE_THIS_NAME("OinkProver::execute_preamble_round");
-    fr vkey_hash = honk_vk->add_hash_to_transcript(domain_separator, *transcript);
-    vinfo("vk hash in Oink prover: ", vkey_hash);
+    fr vk_hash = honk_vk->hash_through_transcript(domain_separator, *transcript);
+    transcript->add_to_hash_buffer(domain_separator + "vk_hash", vk_hash);
+    vinfo("vk hash in Oink prover: ", vk_hash);
 
     for (size_t i = 0; i < proving_key->num_public_inputs(); ++i) {
         auto public_input_i = proving_key->public_inputs[i];

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/oink_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/oink_verifier.cpp
@@ -46,8 +46,9 @@ template <IsUltraOrMegaHonk Flavor> void OinkVerifier<Flavor>::verify()
  */
 template <IsUltraOrMegaHonk Flavor> void OinkVerifier<Flavor>::execute_preamble_round()
 {
-    FF vkey_hash = verification_key->vk->add_hash_to_transcript(domain_separator, *transcript);
-    vinfo("vk hash in Oink verifier: ", vkey_hash);
+    FF vk_hash = verification_key->vk->hash_through_transcript(domain_separator, *transcript);
+    transcript->add_to_hash_buffer(domain_separator + "vk_hash", vk_hash);
+    vinfo("vk hash in Oink verifier: ", vk_hash);
 
     for (size_t i = 0; i < verification_key->vk->num_public_inputs; ++i) {
         auto public_input_i =

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/flavor.hpp
@@ -274,7 +274,7 @@ class AvmFlavor {
         std::vector<fr> to_field_elements() const override;
 
         /**
-         * @brief Adds the verification key hash to the transcript and returns the hash.
+         * @brief Hashes the vk using the transcript's independent buffer and returns the hash.
          * @details Needed to make sure the Origin Tag system works. See the base class function for
          * more details.
          *
@@ -282,8 +282,8 @@ class AvmFlavor {
          * @param transcript
          * @returns The hash of the verification key
          */
-        fr add_hash_to_transcript([[maybe_unused]] const std::string& domain_separator,
-                                  [[maybe_unused]] Transcript& transcript) const override
+        fr hash_through_transcript([[maybe_unused]] const std::string& domain_separator,
+                                   [[maybe_unused]] Transcript& transcript) const override
         {
             // TODO(https://github.com/AztecProtocol/barretenberg/issues/1466): Implement this function.
             throw_or_abort("Not implemented yet!");

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/recursion/recursive_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/recursion/recursive_flavor.hpp
@@ -102,8 +102,8 @@ class AvmRecursiveFlavor {
 
         // TODO(https://github.com/AztecProtocol/barretenberg/issues/1466): Implement these functions.
         std::vector<FF> to_field_elements() const override { throw_or_abort("Not implemented yet!"); }
-        FF add_hash_to_transcript([[maybe_unused]] const std::string& domain_separator,
-                                  [[maybe_unused]] Transcript& transcript) const override
+        FF hash_through_transcript([[maybe_unused]] const std::string& domain_separator,
+                                   [[maybe_unused]] Transcript& transcript) const override
         {
             throw_or_abort("Not implemented yet!");
         }


### PR DESCRIPTION
Removes the fiat-shamiring from the add_hash_to_transcript function. Renames add_hash_to_transcript to hash_through_transcript.