### PR TITLE
feat!: add test env note discovery

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/macros/aztec.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/aztec.nr
@@ -276,7 +276,7 @@ comptime fn generate_process_message() -> Quoted {
             message_ciphertext: BoundedVec<Field, aztec::messages::encoding::MESSAGE_CIPHERTEXT_LEN>,
             message_context: aztec::messages::processing::message_context::MessageContext,
         ) {
-            aztec::messages::discovery::process_message::do_process_message(
+            aztec::messages::discovery::process_message::process_message_ciphertext(
                 context.this_address(),
                 _compute_note_hash_and_nullifier,
                 message_ciphertext,

--- a/noir-projects/aztec-nr/aztec/src/messages/discovery/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/discovery/mod.nr
@@ -8,7 +8,9 @@ pub mod process_message;
 
 use crate::{
     messages::{
-        discovery::{private_notes::MAX_NOTE_PACKED_LEN, process_message::do_process_message},
+        discovery::{
+            private_notes::MAX_NOTE_PACKED_LEN, process_message::process_message_ciphertext,
+        },
         processing::{
             get_private_logs, pending_tagged_log::PendingTaggedLog,
             validate_enqueued_notes_and_events,
@@ -59,7 +61,7 @@ pub struct NoteHashAndNullifier {
 ///     };
 /// }
 /// ```
-type ComputeNoteHashAndNullifier<Env> = unconstrained fn[Env](/* packed_note */BoundedVec<Field, MAX_NOTE_PACKED_LEN>, /* storage_slot */ Field, /* note_type_id */ Field, /* contract_address */ AztecAddress, /* note nonce */ Field) -> Option<NoteHashAndNullifier>;
+pub type ComputeNoteHashAndNullifier<Env> = unconstrained fn[Env](/* packed_note */BoundedVec<Field, MAX_NOTE_PACKED_LEN>, /* storage_slot */ Field, /* note_type_id */ Field, /* contract_address */ AztecAddress, /* note nonce */ Field) -> Option<NoteHashAndNullifier>;
 
 /// Performs the message discovery process, in which private logs are downloaded and inspected to find new private
 /// notes, partial notes and events, etc., and pending partial notes are processed to search for their completion logs.
@@ -88,7 +90,7 @@ pub unconstrained fn discover_new_messages<Env>(
         // We remove the tag from the pending tagged log and process the message ciphertext contained in it.
         let message_ciphertext = array::subbvec(pending_tagged_log.log, 1);
 
-        do_process_message(
+        process_message_ciphertext(
             contract_address,
             compute_note_hash_and_nullifier,
             message_ciphertext,

--- a/noir-projects/aztec-nr/aztec/src/messages/discovery/process_message.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/discovery/process_message.nr
@@ -3,7 +3,7 @@ use crate::messages::{
         ComputeNoteHashAndNullifier, partial_notes::process_partial_note_private_msg,
         private_events::process_private_event_msg, private_notes::process_private_note_msg,
     },
-    encoding::{decode_message, MESSAGE_CIPHERTEXT_LEN},
+    encoding::{decode_message, MESSAGE_CIPHERTEXT_LEN, MESSAGE_PLAINTEXT_LEN},
     encryption::{aes128::AES128, log_encryption::LogEncryption},
     msg_type::{
         PARTIAL_NOTE_PRIVATE_MSG_TYPE_ID, PRIVATE_EVENT_MSG_TYPE_ID, PRIVATE_NOTE_MSG_TYPE_ID,
@@ -25,19 +25,31 @@ use protocol_types::{address::AztecAddress, debug_log::{debug_log, debug_log_for
 ///
 /// Events are processed by computing an event commitment from the serialized event data and its randomness field, then
 /// enqueueing the event data and commitment for validation.
-pub unconstrained fn do_process_message<Env>(
+pub unconstrained fn process_message_ciphertext<Env>(
     contract_address: AztecAddress,
     compute_note_hash_and_nullifier: ComputeNoteHashAndNullifier<Env>,
     message_ciphertext: BoundedVec<Field, MESSAGE_CIPHERTEXT_LEN>,
     message_context: MessageContext,
 ) {
-    let message = AES128::decrypt_log(message_ciphertext, message_context.recipient);
+    process_message_plaintext(
+        contract_address,
+        compute_note_hash_and_nullifier,
+        AES128::decrypt_log(message_ciphertext, message_context.recipient),
+        message_context,
+    );
+}
 
+pub unconstrained fn process_message_plaintext<Env>(
+    contract_address: AztecAddress,
+    compute_note_hash_and_nullifier: ComputeNoteHashAndNullifier<Env>,
+    message_plaintext: BoundedVec<Field, MESSAGE_PLAINTEXT_LEN>,
+    message_context: MessageContext,
+) {
     // The first thing to do after decrypting the message is to determine what type of message we're processing. We
     // have 3 message types: private notes, partial notes and events.
 
     // We decode the message to obtain the message type id, metadata and content.
-    let (msg_type_id, msg_metadata, msg_content) = decode_message(message);
+    let (msg_type_id, msg_metadata, msg_content) = decode_message(message_plaintext);
 
     if msg_type_id == PRIVATE_NOTE_MSG_TYPE_ID {
         debug_log("Processing private note msg");

--- a/noir-projects/aztec-nr/aztec/src/messages/logs/note.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/logs/note.nr
@@ -3,43 +3,36 @@ use crate::{
         encoding::encode_message,
         encryption::{aes128::AES128, log_encryption::LogEncryption},
         logs::utils::prefix_with_tag,
-        msg_type::PARTIAL_NOTE_PRIVATE_MSG_TYPE_ID,
+        msg_type::{PARTIAL_NOTE_PRIVATE_MSG_TYPE_ID, PRIVATE_NOTE_MSG_TYPE_ID},
     },
     note::note_interface::NoteType,
 };
 use protocol_types::{
-    address::AztecAddress,
-    constants::{PRIVATE_LOG_CIPHERTEXT_LEN, PRIVATE_LOG_SIZE_IN_FIELDS},
-    traits::Packable,
+    address::AztecAddress, constants::PRIVATE_LOG_SIZE_IN_FIELDS, traits::Packable,
 };
 
 // TODO(#16881): once partial notes support emission via an offchain message we will most likely want to remove this.
-pub fn compute_partial_note_log<Note>(
-    note: Note,
+pub fn compute_partial_note_private_content_log<PartialNotePrivateContent>(
+    partial_note_private_content: PartialNotePrivateContent,
     storage_slot: Field,
     recipient: AztecAddress,
 ) -> [Field; PRIVATE_LOG_SIZE_IN_FIELDS]
 where
-    Note: NoteType + Packable,
+    PartialNotePrivateContent: NoteType + Packable,
 {
-    let ciphertext = compute_note_message_ciphertext(
-        note,
+    let message_plaintext = partial_note_private_content_to_message_plaintext(
+        partial_note_private_content,
         storage_slot,
-        recipient,
-        PARTIAL_NOTE_PRIVATE_MSG_TYPE_ID,
     );
+    let message_ciphertext = AES128::encrypt_log(message_plaintext, recipient);
 
-    let log = prefix_with_tag(ciphertext, recipient);
-
-    log
+    prefix_with_tag(message_ciphertext, recipient)
 }
 
-pub fn compute_note_message_ciphertext<Note>(
+pub fn private_note_to_message_plaintext<Note>(
     note: Note,
     storage_slot: Field,
-    recipient: AztecAddress,
-    msg_type: u64,
-) -> [Field; PRIVATE_LOG_CIPHERTEXT_LEN]
+) -> [Field; <Note as Packable>::N + 2]
 where
     Note: NoteType + Packable,
 {
@@ -53,7 +46,29 @@ where
     }
 
     // Notes use the note type id for metadata
-    let plaintext = encode_message(msg_type, Note::get_id() as u64, msg_content);
+    encode_message(PRIVATE_NOTE_MSG_TYPE_ID, Note::get_id() as u64, msg_content)
+}
 
-    AES128::encrypt_log(plaintext, recipient)
+pub fn partial_note_private_content_to_message_plaintext<PartialNotePrivateContent>(
+    partial_note_private_content: PartialNotePrivateContent,
+    storage_slot: Field,
+) -> [Field; <PartialNotePrivateContent as Packable>::N + 2]
+where
+    PartialNotePrivateContent: NoteType + Packable,
+{
+    let packed_private_content = partial_note_private_content.pack();
+
+    // A partial note message's content is the storage slot followed by the packed private content representation
+    let mut msg_content = [0; 1 + <PartialNotePrivateContent as Packable>::N];
+    msg_content[0] = storage_slot;
+    for i in 0..packed_private_content.len() {
+        msg_content[1 + i] = packed_private_content[i];
+    }
+
+    encode_message(
+        PARTIAL_NOTE_PRIVATE_MSG_TYPE_ID,
+        // Notes use the note type id for metadata
+        PartialNotePrivateContent::get_id() as u64,
+        msg_content,
+    )
 }

--- a/noir-projects/aztec-nr/aztec/src/note/note_emission.nr
+++ b/noir-projects/aztec-nr/aztec/src/note/note_emission.nr
@@ -1,9 +1,9 @@
 use crate::{
     context::PrivateContext,
     messages::{
-        logs::{note::compute_note_message_ciphertext, utils::prefix_with_tag},
+        encryption::{aes128::AES128, log_encryption::LogEncryption},
+        logs::{note::private_note_to_message_plaintext, utils::prefix_with_tag},
         message_delivery::MessageDelivery,
-        msg_type::PRIVATE_NOTE_MSG_TYPE_ID,
         offchain_messages::emit_offchain_message,
     },
     note::note_interface::NoteType,
@@ -52,11 +52,9 @@ where
 
         let ciphertext = remove_constraints_if(
             !constrained_encryption,
-            || compute_note_message_ciphertext(
-                self.note,
-                self.storage_slot,
+            || AES128::encrypt_log(
+                private_note_to_message_plaintext(self.note, self.storage_slot),
                 recipient,
-                PRIVATE_NOTE_MSG_TYPE_ID,
             ),
         );
 

--- a/noir-projects/aztec-nr/aztec/src/note/note_getter.nr
+++ b/noir-projects/aztec-nr/aztec/src/note/note_getter.nr
@@ -81,7 +81,7 @@ where
 {
     // Safety: Constraining that we got a valid note from the oracle is fairly straightforward: all we need to do
     // is check that the metadata is correct, and that the note exists.
-    let retrieved_note = unsafe { get_note_internal::<Note>(storage_slot) };
+    let retrieved_note = unsafe { view_note::<Note>(storage_slot) };
 
     // For settled notes, the contract address is implicitly checked since the hash returned from
     // `compute_note_hash_for_read_request` is siloed and kernels verify the siloing during note read request
@@ -189,7 +189,7 @@ where
     (notes, note_hashes)
 }
 
-unconstrained fn get_note_internal<Note>(storage_slot: Field) -> RetrievedNote<Note>
+pub unconstrained fn view_note<Note>(storage_slot: Field) -> RetrievedNote<Note>
 where
     Note: NoteType + Packable,
 {
@@ -210,7 +210,7 @@ where
         NoteStatus.ACTIVE,
     );
 
-    opt_notes[0].expect(f"Failed to get a note") // Notice: we don't allow dummies to be returned from get_note (singular).
+    opt_notes[0].expect(f"Failed to get a note")
 }
 
 unconstrained fn get_notes_internal<Note, let M: u32, PreprocessorArgs, FilterArgs>(

--- a/noir-projects/aztec-nr/aztec/src/note/note_getter/test.nr
+++ b/noir-projects/aztec-nr/aztec/src/note/note_getter/test.nr
@@ -37,7 +37,7 @@ where
 }
 
 #[test]
-unconstrained fn processes_single_note() {
+unconstrained fn constrain_get_notes_processes_single_note() {
     let env = TestEnvironment::new();
 
     env.private_context(|context| {
@@ -55,7 +55,7 @@ unconstrained fn processes_single_note() {
 }
 
 #[test]
-unconstrained fn processes_many_notes() {
+unconstrained fn constrain_get_notes_processes_many_notes() {
     let env = TestEnvironment::new();
 
     env.private_context(|context| {
@@ -75,7 +75,7 @@ unconstrained fn processes_many_notes() {
 }
 
 #[test]
-unconstrained fn collapses_notes_at_the_beginning_of_the_array() {
+unconstrained fn constrain_get_notes_collapses_notes_at_the_beginning_of_the_array() {
     let env = TestEnvironment::new();
 
     env.private_context(|context| {
@@ -106,7 +106,7 @@ unconstrained fn collapses_notes_at_the_beginning_of_the_array() {
 }
 
 #[test]
-unconstrained fn can_return_zero_notes() {
+unconstrained fn constrain_get_notes_can_return_zero_notes() {
     let env = TestEnvironment::new();
 
     env.private_context(|context| {
@@ -120,7 +120,7 @@ unconstrained fn can_return_zero_notes() {
 }
 
 #[test(should_fail_with = "Got more notes than limit.")]
-unconstrained fn rejects_mote_notes_than_limit() {
+unconstrained fn constrain_get_notes_rejects_mote_notes_than_limit() {
     let env = TestEnvironment::new();
 
     env.private_context(|context| {
@@ -138,7 +138,7 @@ unconstrained fn rejects_mote_notes_than_limit() {
 }
 
 #[test]
-unconstrained fn applies_filter_before_constraining() {
+unconstrained fn constrain_get_notes_applies_filter_before_constraining() {
     let env = TestEnvironment::new();
 
     env.private_context(|context| {
@@ -175,7 +175,7 @@ unconstrained fn applies_filter_before_constraining() {
 }
 
 #[test(should_fail_with = "Note contract address mismatch.")]
-unconstrained fn rejects_mismatched_address() {
+unconstrained fn constrain_get_notes_rejects_mismatched_address() {
     let env = TestEnvironment::new();
 
     env.private_context(|context| {
@@ -189,7 +189,7 @@ unconstrained fn rejects_mismatched_address() {
 }
 
 #[test(should_fail_with = "Mismatch return note field.")]
-unconstrained fn rejects_mismatched_selector() {
+unconstrained fn constrain_get_notes_rejects_mismatched_selector() {
     let env = TestEnvironment::new();
 
     env.private_context(|context| {
@@ -211,7 +211,7 @@ unconstrained fn rejects_mismatched_selector() {
 }
 
 #[test(should_fail_with = "Return notes not sorted in descending order.")]
-unconstrained fn rejects_mismatched_desc_sort_order() {
+unconstrained fn constrain_get_notes_rejects_mismatched_desc_sort_order() {
     let env = TestEnvironment::new();
 
     env.private_context(|context| {
@@ -229,7 +229,7 @@ unconstrained fn rejects_mismatched_desc_sort_order() {
 }
 
 #[test(should_fail_with = "Return notes not sorted in ascending order.")]
-unconstrained fn rejects_mismatched_asc_sort_order() {
+unconstrained fn constrain_get_notes_rejects_mismatched_asc_sort_order() {
     let env = TestEnvironment::new();
 
     env.private_context(|context| {

--- a/noir-projects/aztec-nr/aztec/src/state_vars/private_mutable.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/private_mutable.nr
@@ -7,13 +7,14 @@ use crate::context::{PrivateContext, UtilityContext};
 use crate::note::{
     lifecycle::{create_note, destroy_note_unsafe},
     note_emission::NoteEmission,
-    note_getter::{get_note, view_notes},
+    note_getter::{get_note, view_note},
     note_interface::{NoteHash, NoteType},
-    note_viewer_options::NoteViewerOptions,
 };
 use crate::note::retrieved_note::RetrievedNote;
 use crate::oracle::notes::check_nullifier_exists;
 use crate::state_vars::storage::HasStorageSlot;
+
+mod test;
 
 /// # PrivateMutable
 ///
@@ -107,8 +108,6 @@ pub struct PrivateMutable<Note, Context> {
     storage_slot: Field,
 }
 // docs:end:struct
-
-mod test;
 
 // Private storage slots are not really 'slots' but rather a value in the note hash preimage, so there is no notion of a
 // value spilling over multiple slots. For this reason PrivateMutable (and all other private state variables) needs just
@@ -465,8 +464,7 @@ where
     where
         Note: Packable,
     {
-        let mut options = NoteViewerOptions::<Note, <Note as Packable>::N>::new();
-        view_notes(self.storage_slot, options.set_limit(1)).get(0)
+        view_note(self.storage_slot).note
     }
     // docs:end:view_note
 }

--- a/noir-projects/aztec-nr/aztec/src/state_vars/private_mutable/test.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/private_mutable/test.nr
@@ -1,4 +1,4 @@
-use crate::{context::PrivateContext, state_vars::private_mutable::PrivateMutable};
+use crate::{context::{PrivateContext, UtilityContext}, state_vars::private_mutable::PrivateMutable};
 use crate::test::{helpers::test_environment::TestEnvironment, mocks::mock_note::MockNote};
 
 global STORAGE_SLOT: Field = 17;
@@ -7,6 +7,10 @@ global VALUE: Field = 23;
 unconstrained fn in_private(
     context: &mut PrivateContext,
 ) -> PrivateMutable<MockNote, &mut PrivateContext> {
+    PrivateMutable::new(context, STORAGE_SLOT)
+}
+
+unconstrained fn in_utility(context: UtilityContext) -> PrivateMutable<MockNote, UtilityContext> {
     PrivateMutable::new(context, STORAGE_SLOT)
 }
 
@@ -21,6 +25,16 @@ unconstrained fn get_uninitialized() {
 }
 
 #[test(should_fail_with = "Failed to get a note")]
+unconstrained fn view_uninitialized() {
+    let env = TestEnvironment::new();
+
+    env.utility_context(|context| {
+        let state_var = in_utility(context);
+        let _ = state_var.view_note();
+    });
+}
+
+#[test(should_fail_with = "Failed to get a note")]
 unconstrained fn replace_uninitialized() {
     let env = TestEnvironment::new();
 
@@ -31,59 +45,6 @@ unconstrained fn replace_uninitialized() {
             let note = MockNote::new(VALUE).build_note();
             note
         });
-    });
-}
-
-// Named function to use as a callback for replace
-fn plus_one(note: MockNote) -> MockNote {
-    MockNote::new(note.value + 1).build_note()
-}
-
-#[test]
-unconstrained fn test_replace_plus_one() {
-    let env = TestEnvironment::new();
-
-    env.private_context(|context| {
-        let mut state_var = in_private(context);
-
-        // Initialize with a known value
-        let INIT_VALUE: Field = 7;
-        let EXPECTED_VALUE: Field = 8;
-        let initial_note = MockNote::new(INIT_VALUE).build_note();
-        let _ = state_var.initialize(initial_note);
-
-        // run read_and_replace with helper function
-        let emission = state_var.replace(plus_one);
-
-        // emission should contain new note with value 8
-        let expected_note = MockNote::new(EXPECTED_VALUE).build_note();
-        assert_eq(emission.note, expected_note);
-    });
-}
-
-#[test]
-unconstrained fn test_replace_capture_variable() {
-    let env = TestEnvironment::new();
-
-    env.private_context(|context| {
-        let mut state_var = in_private(context);
-
-        // Initialize with a known value
-        let INIT_VALUE: Field = 10;
-        let initial_note = MockNote::new(INIT_VALUE).build_note();
-        let _ = state_var.initialize(initial_note);
-
-        // Local variable to capture
-        let x: Field = 5;
-
-        // Use a closure to increment the note by x
-        let emission = state_var.replace(|note| MockNote::new(note.value + x).build_note());
-
-        // Expected value is initial + x
-        let expected_value: Field = INIT_VALUE + x;
-        let expected_note = MockNote::new(expected_value).build_note();
-
-        assert_eq(emission.note, expected_note);
     });
 }
 
@@ -123,10 +84,10 @@ unconstrained fn initialize_and_get_pending() {
         let nullifiers_pre_get = context.nullifiers.len();
         let note_hash_read_requests_pre_get = context.note_hash_read_requests.len();
 
-        let emission = state_var.get_note();
+        let get_emission = state_var.get_note();
 
-        assert_eq(emission.note, note);
-        assert_eq(emission.storage_slot, STORAGE_SLOT);
+        assert_eq(get_emission.note, note);
+        assert_eq(get_emission.storage_slot, STORAGE_SLOT);
 
         // Reading a PrivateMutable results in:
         // - a read request for the read value
@@ -135,6 +96,59 @@ unconstrained fn initialize_and_get_pending() {
         assert_eq(context.note_hash_read_requests.len(), note_hash_read_requests_pre_get + 1);
         assert_eq(context.nullifiers.len(), nullifiers_pre_get + 1);
         assert_eq(context.note_hashes.len(), note_hashes_pre_get + 1);
+    });
+}
+
+#[test]
+unconstrained fn initialize_and_get_settled() {
+    let env = TestEnvironment::new();
+
+    let note = MockNote::new(VALUE).build_note();
+
+    let init_emission = env.private_context(|context| {
+        let state_var = in_private(context);
+
+        state_var.initialize(note)
+    });
+
+    env.discover_note(init_emission);
+
+    env.private_context(|context| {
+        let state_var = in_private(context);
+
+        let get_emission = state_var.get_note();
+
+        assert_eq(get_emission.note, note);
+        assert_eq(get_emission.storage_slot, STORAGE_SLOT);
+
+        // Reading a PrivateMutable results in:
+        // - a read request for the read value
+        // - a nullifier for the read note
+        // - a new note for the recreation of the read value
+        assert_eq(context.note_hash_read_requests.len(), 1);
+        assert_eq(context.nullifiers.len(), 1);
+        assert_eq(context.note_hashes.len(), 1);
+    });
+}
+
+#[test]
+unconstrained fn initialize_and_view_settled() {
+    let env = TestEnvironment::new();
+
+    let note = MockNote::new(VALUE).build_note();
+
+    let init_emission = env.private_context(|context| {
+        let state_var = in_private(context);
+
+        state_var.initialize(note)
+    });
+
+    env.discover_note(init_emission);
+
+    env.utility_context(|context| {
+        let state_var = in_utility(context);
+
+        assert_eq(state_var.view_note(), note);
     });
 }
 
@@ -154,13 +168,15 @@ unconstrained fn initialize_and_replace_pending() {
         let note_hashes_pre_replace = context.note_hashes.len();
 
         let replacement_value = VALUE + 1;
+        let replacement_note = MockNote::new(replacement_value).build_note();
+        let replace_emission = state_var.replace(|current_note| {
+            assert_eq(current_note, note);
 
-        let emission =
-            state_var.replace(|_old_note| MockNote::new(replacement_value).build_note());
+            replacement_note
+        });
 
-        let expected_note = MockNote::new(replacement_value).build_note();
-        assert_eq(emission.note, expected_note);
-        assert_eq(emission.storage_slot, STORAGE_SLOT);
+        assert_eq(replace_emission.note, replacement_note);
+        assert_eq(replace_emission.storage_slot, STORAGE_SLOT);
 
         // Replacing a PrivateMutable results in:
         // - a read request for the read value
@@ -173,6 +189,43 @@ unconstrained fn initialize_and_replace_pending() {
 }
 
 #[test]
+unconstrained fn initialize_and_replace_settled() {
+    let env = TestEnvironment::new();
+
+    let note = MockNote::new(VALUE).build_note();
+
+    let init_emission = env.private_context(|context| {
+        let state_var = in_private(context);
+
+        state_var.initialize(note)
+    });
+
+    env.discover_note(init_emission);
+
+    env.private_context(|context| {
+        let state_var = in_private(context);
+
+        let replacement_value = VALUE + 1;
+        let replacement_note = MockNote::new(replacement_value).build_note();
+        let replace_emission = state_var.replace(|current_note| {
+            assert_eq(current_note, note);
+            replacement_note
+        });
+
+        assert_eq(replace_emission.note, replacement_note);
+        assert_eq(replace_emission.storage_slot, STORAGE_SLOT);
+
+        // Replacing a PrivateMutable results in:
+        // - a read request for the read value
+        // - a nullifier for the read note
+        // - a new note for the replacement note
+        assert_eq(context.note_hash_read_requests.len(), 1);
+        assert_eq(context.nullifiers.len(), 1);
+        assert_eq(context.note_hashes.len(), 1);
+    });
+}
+
+#[test]
 unconstrained fn initialize_or_replace_uninitialized() {
     let env = TestEnvironment::new();
 
@@ -181,8 +234,8 @@ unconstrained fn initialize_or_replace_uninitialized() {
 
         let init_note = MockNote::new(VALUE).build_note();
 
-        let emission = state_var.initialize_or_replace(init_note, |_old_note: MockNote| {
-            panic(f"Unexpected call to replacement closure") // This should not be called
+        let emission = state_var.initialize_or_replace(init_note, |_: MockNote| {
+            panic(f"") // This should not be called
         });
 
         assert_eq(emission.note, init_note);
@@ -200,7 +253,7 @@ unconstrained fn initialize_or_replace_uninitialized() {
 // #[test]
 // unconstrained fn initialize_or_replace_initialized_pending() {
 //     let env = TestEnvironment::new();
-
+//
 //     env.private_context(|context| {
 //         let state_var = in_private(context);
 
@@ -226,3 +279,46 @@ unconstrained fn initialize_or_replace_uninitialized() {
 //         assert_eq(context.note_hashes.len(), note_hashes_pre_replace + 1);
 //     });
 // }
+
+#[test]
+unconstrained fn initialize_or_replace_initialized_settled() {
+    let env = TestEnvironment::new();
+
+    let note = MockNote::new(VALUE).build_note();
+
+    let init_emission = env.private_context(|context| {
+        let state_var = in_private(context);
+
+        state_var.initialize(note)
+    });
+
+    env.discover_note(init_emission);
+
+    env.private_context(|context| {
+        let state_var = in_private(context);
+
+        let note_hash_read_requests_pre_replace = context.note_hash_read_requests.len();
+        let nullifiers_pre_replace = context.nullifiers.len();
+        let note_hashes_pre_replace = context.note_hashes.len();
+
+        let replacement_value = VALUE + 1;
+        let replacement_note = MockNote::new(replacement_value).build_note();
+        let emission = state_var.initialize_or_replace(std::mem::zeroed(), |current_note| {
+            assert_eq(current_note, note);
+            replacement_note
+        });
+
+        assert_eq(emission.note, replacement_note);
+        assert_eq(emission.storage_slot, STORAGE_SLOT);
+
+        // Replacing a PrivateMutable results in:
+        // - a read request for the read value
+        // - a nullifier for the read note
+        // - a new note for the replacement note
+        // This would only succeed if the variable had already been initialized, as otherwise the read request would
+        // fail.
+        assert_eq(context.note_hash_read_requests.len(), note_hash_read_requests_pre_replace + 1);
+        assert_eq(context.nullifiers.len(), nullifiers_pre_replace + 1);
+        assert_eq(context.note_hashes.len(), note_hashes_pre_replace + 1);
+    });
+}

--- a/noir-projects/aztec-nr/aztec/src/state_vars/private_set/test.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/private_set/test.nr
@@ -89,6 +89,62 @@ unconstrained fn insert_and_get_pending() {
 }
 
 #[test]
+unconstrained fn insert_and_get_settled() {
+    let env = TestEnvironment::new();
+
+    let note = MockNote::new(VALUE).build_note();
+
+    let emission = env.private_context(|context| {
+        let state_var = in_private(context);
+
+        state_var.insert(note)
+    });
+
+    env.discover_note(emission);
+
+    env.private_context(|context| {
+        let state_var = in_private(context);
+
+        let notes = state_var.get_notes(NoteGetterOptions::new());
+
+        assert_eq(notes.len(), 1);
+
+        // get_notes returns the notes, but does *not* nullify them
+        assert_eq(state_var.context.note_hash_read_requests.len(), 1);
+        assert_eq(state_var.context.nullifiers.len(), 0);
+
+        // Instead we get RetrievedNotes, which can be later used for nullification
+        let retrieved_note = notes.get(0);
+        assert(retrieved_note.metadata.is_settled());
+        assert_eq(retrieved_note.note, note);
+    });
+}
+
+#[test]
+unconstrained fn insert_and_view_settled() {
+    let env = TestEnvironment::new();
+
+    let note = MockNote::new(VALUE).build_note();
+
+    let emission = env.private_context(|context| {
+        let state_var = in_private(context);
+
+        state_var.insert(note)
+    });
+
+    env.discover_note(emission);
+
+    env.utility_context(|context| {
+        let state_var = in_utility(context);
+
+        let notes = state_var.view_notes(NoteViewerOptions::new());
+
+        assert_eq(notes.len(), 1);
+        assert_eq(notes.get(0), note);
+    });
+}
+
+#[test]
 unconstrained fn insert_and_pop_pending() {
     let env = TestEnvironment::new();
 
@@ -97,6 +153,34 @@ unconstrained fn insert_and_pop_pending() {
 
         let note = MockNote::new(VALUE).build_note();
         let _ = state_var.insert(note);
+
+        let notes = state_var.pop_notes(NoteGetterOptions::new());
+
+        assert_eq(notes.len(), 1);
+        assert_eq(notes.get(0), note);
+
+        // pop_notes returns the notes *and* nullifies them
+        assert_eq(state_var.context.note_hash_read_requests.len(), 1);
+        assert_eq(state_var.context.nullifiers.len(), 1);
+    });
+}
+
+#[test]
+unconstrained fn insert_and_pop_settled() {
+    let env = TestEnvironment::new();
+
+    let note = MockNote::new(VALUE).build_note();
+
+    let emission = env.private_context(|context| {
+        let state_var = in_private(context);
+
+        state_var.insert(note)
+    });
+
+    env.discover_note(emission);
+
+    env.private_context(|context| {
+        let state_var = in_private(context);
 
         let notes = state_var.pop_notes(NoteGetterOptions::new());
 
@@ -129,6 +213,31 @@ unconstrained fn insert_and_remove_pending() {
 }
 
 #[test]
+unconstrained fn insert_and_remove_settled() {
+    let env = TestEnvironment::new();
+
+    let note = MockNote::new(VALUE).build_note();
+
+    let emission = env.private_context(|context| {
+        let state_var = in_private(context);
+        state_var.insert(note)
+    });
+
+    env.discover_note(emission);
+
+    env.private_context(|context| {
+        let state_var = in_private(context);
+
+        let retrieved = state_var.get_notes(NoteGetterOptions::new());
+
+        state_var.remove(retrieved.get(0));
+
+        // remove nullifies the note
+        assert_eq(state_var.context.nullifiers.len(), 1);
+    });
+}
+
+#[test]
 unconstrained fn insert_pop_and_read_again_pending() {
     let env = TestEnvironment::new();
 
@@ -147,6 +256,31 @@ unconstrained fn insert_pop_and_read_again_pending() {
 }
 
 #[test]
+unconstrained fn insert_pop_and_read_again_settled() {
+    let env = TestEnvironment::new();
+
+    let note = MockNote::new(VALUE).build_note();
+
+    let emission = env.private_context(|context| {
+        let state_var = in_private(context);
+
+        state_var.insert(note)
+    });
+
+    env.discover_note(emission);
+
+    env.private_context(|context| {
+        let state_var = in_private(context);
+
+        let _ = state_var.pop_notes(NoteGetterOptions::new());
+
+        // Now that we've deleted the note, the oracle should know this and not return them any more.
+        assert_eq(state_var.pop_notes(NoteGetterOptions::new()).len(), 0);
+        assert_eq(state_var.get_notes(NoteGetterOptions::new()).len(), 0);
+    });
+}
+
+#[test]
 unconstrained fn insert_remove_and_read_again_pending() {
     let env = TestEnvironment::new();
 
@@ -155,6 +289,32 @@ unconstrained fn insert_remove_and_read_again_pending() {
 
         let note = MockNote::new(VALUE).build_note();
         let _ = state_var.insert(note);
+
+        let retrieved = state_var.get_notes(NoteGetterOptions::new());
+        state_var.remove(retrieved.get(0));
+
+        // Now that we've deleted the notes, the oracle should know this and not return them any more.
+        assert_eq(state_var.pop_notes(NoteGetterOptions::new()).len(), 0);
+        assert_eq(state_var.get_notes(NoteGetterOptions::new()).len(), 0);
+    });
+}
+
+#[test]
+unconstrained fn insert_remove_and_read_again_settled() {
+    let env = TestEnvironment::new();
+
+    let note = MockNote::new(VALUE).build_note();
+
+    let emission = env.private_context(|context| {
+        let state_var = in_private(context);
+
+        state_var.insert(note)
+    });
+
+    env.discover_note(emission);
+
+    env.private_context(|context| {
+        let state_var = in_private(context);
 
         let retrieved = state_var.get_notes(NoteGetterOptions::new());
         state_var.remove(retrieved.get(0));

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
@@ -1,5 +1,7 @@
 use protocol_types::{
-    abis::function_selector::FunctionSelector, address::AztecAddress, traits::Deserialize,
+    abis::function_selector::FunctionSelector,
+    address::AztecAddress,
+    traits::{Deserialize, Packable},
 };
 
 use crate::{
@@ -9,8 +11,24 @@ use crate::{
         UtilityCallInterface, UtilityContext,
     },
     hash::hash_args,
+    messages::{
+        discovery::{
+            ComputeNoteHashAndNullifier, NoteHashAndNullifier,
+            process_message::process_message_plaintext,
+        },
+        logs::note::private_note_to_message_plaintext,
+        processing::{message_context::MessageContext, validate_enqueued_notes_and_events},
+    },
+    note::{
+        note_emission::NoteEmission,
+        note_interface::{NoteHash, NoteType},
+        note_metadata::SettledNoteMetadata,
+        retrieved_note::RetrievedNote,
+        utils::compute_note_hash_for_nullify,
+    },
     oracle::version::assert_compatible_oracle_version,
     test::helpers::{txe_oracles, utils::ContractDeployment},
+    utils::array::subarray,
 };
 
 mod test;
@@ -99,6 +117,18 @@ impl PrivateContextOptions {
     }
 }
 
+struct PublicContextOptions {
+    contract_address: Option<AztecAddress>,
+}
+
+struct UtilityContextOptions {
+    contract_address: Option<AztecAddress>,
+}
+
+struct NoteDiscoveryOptions {
+    contract_address: Option<AztecAddress>,
+}
+
 impl TestEnvironment {
     /// Creates a new `TestEnvironment`. This function should only be called once per test.
     pub unconstrained fn new() -> Self {
@@ -142,27 +172,28 @@ impl TestEnvironment {
     /// });
     /// ```
     pub unconstrained fn public_context<Env, T>(
-        _self: Self,
+        self: Self,
         f: fn[Env](&mut PublicContext) -> T,
     ) -> T {
-        txe_oracles::set_public_txe_context(Option::none());
-
-        let mut context = PublicContext::new(|| 0);
-        let ret_value = f(&mut context);
-
-        txe_oracles::set_top_level_txe_context();
-
-        ret_value
+        self.public_context_opts(PublicContextOptions { contract_address: Option::none() }, f)
     }
 
     /// Variant of `public_context` which allows specifying the contract address in which the public context will
     /// execute, which will affect note and nullifier siloing, storage access, etc.
     pub unconstrained fn public_context_at<Env, T>(
-        _self: Self,
+        self: Self,
         addr: AztecAddress,
         f: fn[Env](&mut PublicContext) -> T,
     ) -> T {
-        txe_oracles::set_public_txe_context(Option::some(addr));
+        self.public_context_opts(PublicContextOptions { contract_address: Option::some(addr) }, f)
+    }
+
+    unconstrained fn public_context_opts<Env, T>(
+        _self: Self,
+        opts: PublicContextOptions,
+        f: fn[Env](&mut PublicContext) -> T,
+    ) -> T {
+        txe_oracles::set_public_txe_context(opts.contract_address);
 
         let mut context = PublicContext::new(|| 0);
         let ret_value = f(&mut context);
@@ -206,38 +237,32 @@ impl TestEnvironment {
     /// });
     /// ```
     pub unconstrained fn private_context<Env, T>(
-        _self: Self,
+        self: Self,
         f: fn[Env](&mut PrivateContext) -> T,
     ) -> T {
-        let mut context = PrivateContext::new(
-            txe_oracles::set_private_txe_context(Option::none(), Option::none()),
-            0,
-        );
-
-        let ret_value = f(&mut context);
-
-        txe_oracles::set_top_level_txe_context();
-
-        ret_value
+        self.private_context_opts(
+            PrivateContextOptions {
+                contract_address: Option::none(),
+                historical_block_number: Option::none(),
+            },
+            f,
+        )
     }
 
     /// Variant of `private_context` which allows specifying the contract address in which the private context will
     /// execute, which will affect note and nullifier siloing, storage access, etc.
     pub unconstrained fn private_context_at<Env, T>(
-        _self: Self,
+        self: Self,
         addr: AztecAddress,
         f: fn[Env](&mut PrivateContext) -> T,
     ) -> T {
-        let mut context = PrivateContext::new(
-            txe_oracles::set_private_txe_context(Option::some(addr), Option::none()),
-            0,
-        );
-
-        let ret_value = f(&mut context);
-
-        txe_oracles::set_top_level_txe_context();
-
-        ret_value
+        self.private_context_opts(
+            PrivateContextOptions {
+                contract_address: Option::some(addr),
+                historical_block_number: Option::none(),
+            },
+            f,
+        )
     }
 
     /// Variant of `private_context` which allows specifying multiple configuration values via `PrivateContextOptions`.
@@ -287,26 +312,26 @@ impl TestEnvironment {
     ///   state_var.view_note()
     /// });
     /// ```
-    pub unconstrained fn utility_context<Env, T>(
-        _self: Self,
-        f: fn[Env](UtilityContext) -> T,
-    ) -> T {
-        txe_oracles::set_utility_txe_context(Option::none());
-        let context = UtilityContext::new();
-        let ret_value = f(context);
-        txe_oracles::set_top_level_txe_context();
-
-        ret_value
+    pub unconstrained fn utility_context<Env, T>(self: Self, f: fn[Env](UtilityContext) -> T) -> T {
+        self.utility_context_opts(UtilityContextOptions { contract_address: Option::none() }, f)
     }
 
     /// Variant of `utility_context` which allows specifying the contract address in which the utility context will
     /// execute, which will affect note and storage access.
     pub unconstrained fn utility_context_at<Env, T>(
-        _self: Self,
+        self: Self,
         addr: AztecAddress,
         f: fn[Env](UtilityContext) -> T,
     ) -> T {
-        txe_oracles::set_utility_txe_context(Option::some(addr));
+        self.utility_context_opts(UtilityContextOptions { contract_address: Option::some(addr) }, f)
+    }
+
+    unconstrained fn utility_context_opts<Env, T>(
+        _self: Self,
+        opts: UtilityContextOptions,
+        f: fn[Env](UtilityContext) -> T,
+    ) -> T {
+        txe_oracles::set_utility_txe_context(opts.contract_address);
         let context = UtilityContext::new();
         let ret_value = f(context);
         txe_oracles::set_top_level_txe_context();
@@ -608,5 +633,143 @@ impl TestEnvironment {
         );
 
         T::deserialize(serialized_return_values)
+    }
+
+    /// Discovers a note wrapped in a `NoteEmission` value, which is expected to have been created in the last
+    /// transaction (typically via `private_context()`) so that it can be retrieved in later transactions. This mimics
+    /// the normal note discovery process that takes places automatically in contracts.
+    ///
+    /// `NoteEmission` values are typically returned by aztec-nr state variables that create notes and need to notify a
+    /// recipient of their existence. Instead of going through the message encoding, encryption and emission that would
+    /// regularly take place in a contract, `discover_note` simply takes the `NoteEmission` and processes it as needed
+    /// to discover the underlying note.
+    ///
+    /// See `discover_note_at` for a variant that allows specifying the contract address the note belongs to.
+    ///
+    /// ### Sample usage
+    ///
+    /// The most common way to invoke this function is to obtain an emission created during the execution of a
+    /// `private_context`:
+    ///
+    /// ```noir
+    /// let emission = env.private_context(|context| create_note(context, storage_slot, note));
+    ///
+    /// env.discover_note(emission);
+    ///
+    /// env.private_context(|context| { let (retrieved_note, _) = get_note::<MockNote>(context, storage_slot); });
+    /// ```
+    pub unconstrained fn discover_note<Note>(self: Self, emission: NoteEmission<Note>)
+    where
+        Note: Packable + NoteType + NoteHash,
+    {
+        self.discover_note_opts(NoteDiscoveryOptions { contract_address: Option::none() }, emission);
+    }
+
+    /// Variant of `discover_note` which allows specifying the contract address the note belongs to, which is required
+    /// when the note was not emitted in the default address used by `private_context`.
+    ///
+    /// ```noir
+    /// let emission = env.private_context_at(contract_address, |context| {
+    ///     create_note(context, storage_slot, note)
+    /// });
+    ///
+    /// env.discover_note_at(contract_address, emission);
+    ///
+    /// env.private_context_at(contract_address, |context| {
+    ///     let (retrieved_note, _) = get_note::<MockNote>(context, storage_slot);
+    /// });
+    /// ```
+    pub unconstrained fn discover_note_at<Note>(
+        self: Self,
+        addr: AztecAddress,
+        emission: NoteEmission<Note>,
+    )
+    where
+        Note: Packable + NoteType + NoteHash,
+    {
+        self.discover_note_opts(
+            NoteDiscoveryOptions { contract_address: Option::some(addr) },
+            emission,
+        );
+    }
+
+    unconstrained fn discover_note_opts<Note>(
+        self: Self,
+        opts: NoteDiscoveryOptions,
+        emission: NoteEmission<Note>,
+    )
+    where
+        Note: Packable + NoteType + NoteHash,
+    {
+        // This function will emulate the message discovery and processing that would happen in a real contract, based
+        // on a message created from the received note emission.
+
+        // First we produce the message itself. We skip encryption/decryption since we're not interested in that here.
+        // Note that we need to convert the fixed-size array produced by the encoding functions into a BoundedVec, which
+        // is what the decoding functions expect (because they are built to manage protocol logs, which are arbitrarily
+        // sized).
+        let message_plaintext = BoundedVec::from_array(private_note_to_message_plaintext(
+            emission.note,
+            emission.storage_slot,
+        ));
+
+        // Then we fetch the transaction effects from the latest transaction, in which the note from the emission is
+        // expected to have been created. In a real contract this data would have either been supplied by the
+        // `process_message` caller, of retrieved along with the message from a tagged log.
+        let (tx_hash, unique_note_hashes_in_tx, nullifiers_in_tx) =
+            txe_oracles::get_last_tx_effects();
+
+        // Real messages would also have a recipient, a concept which does not translate to anything in
+        // `TestEnvironment` since it works with a single PXE with global scopes. We therefore simply set the zero
+        // address as the recipient, which PXE accepts as a note scope despite this not being a registered account.
+        let recipient = AztecAddress::zero();
+
+        let message_context = MessageContext {
+            tx_hash,
+            unique_note_hashes_in_tx,
+            first_nullifier_in_tx: nullifiers_in_tx.get(0),
+            recipient,
+        };
+
+        // We also need to provide an implementation for the `compute_note_hash_and_nullifier` function, which would
+        // typically be created by the macros for the different notes in a given contract. Here we build one specialized
+        // for `Note`.
+        let compute_note_hash_and_nullifier: ComputeNoteHashAndNullifier<_> = |packed_note, storage_slot, note_type_id, contract_address, note_nonce| {
+            assert_eq(note_type_id, Note::get_id());
+            assert_eq(packed_note.len(), <Note as Packable>::N);
+
+            let note = Note::unpack(subarray(packed_note.storage(), 0));
+
+            let note_hash = note.compute_note_hash(storage_slot);
+            let note_hash_for_nullify = compute_note_hash_for_nullify(
+                RetrievedNote {
+                    note,
+                    contract_address,
+                    metadata: SettledNoteMetadata::new(note_nonce).into(),
+                },
+                storage_slot,
+            );
+
+            let inner_nullifier = note.compute_nullifier_unconstrained(note_hash_for_nullify);
+
+            Option::some(NoteHashAndNullifier { note_hash, inner_nullifier })
+        };
+
+        // Both private and utility functions perform message processing and note discovery. We do it in an utility
+        // context here as that one is more lightweight and does not create new blocks, which also allows for
+        // `discover_notes` to be called repeatedly with multiple emissions from the same transaction.
+        self.utility_context_opts(
+            UtilityContextOptions { contract_address: opts.contract_address },
+            |context| {
+                process_message_plaintext(
+                    context.this_address(),
+                    compute_note_hash_and_nullifier,
+                    message_plaintext,
+                    message_context,
+                );
+
+                validate_enqueued_notes_and_events(context.this_address());
+            },
+        );
     }
 }

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment/test.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment/test.nr
@@ -5,6 +5,7 @@ mod accounts;
 mod deployment;
 mod private_context;
 mod public_context;
+mod notes;
 
 #[test(should_fail_with = "cannot be before next timestamp")]
 unconstrained fn set_next_block_timestamp_to_past_fails() {

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment/test/notes.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment/test/notes.nr
@@ -1,0 +1,399 @@
+use crate::note::{
+    lifecycle::{create_note, destroy_note_unsafe},
+    note_getter::{get_note, get_notes, view_note, view_notes},
+    note_getter_options::NoteGetterOptions,
+    note_viewer_options::NoteViewerOptions,
+};
+use crate::test::{helpers::test_environment::TestEnvironment, mocks::mock_note::MockNote};
+use protocol_types::{address::AztecAddress, traits::FromField};
+
+global VALUE: Field = 7;
+global CONTRACT_ADDRESS: AztecAddress = AztecAddress::from_field(12);
+global STORAGE_SLOT: Field = 13;
+
+#[test(should_fail_with = "Failed to get a note")]
+unconstrained fn get_nonexistent_note_fails() {
+    let env = TestEnvironment::new();
+
+    env.private_context(|context| { let _ = get_note::<MockNote>(context, STORAGE_SLOT); });
+}
+
+#[test(should_fail_with = "Failed to get a note")]
+unconstrained fn view_nonexistent_note_fails() {
+    let env = TestEnvironment::new();
+
+    env.private_context(|_| { let _ = view_note::<MockNote>(STORAGE_SLOT); });
+}
+
+#[test]
+unconstrained fn get_transient_note() {
+    let env = TestEnvironment::new();
+
+    env.private_context(|context| {
+        let note = MockNote::new(VALUE).build_note();
+        let _ = create_note(context, STORAGE_SLOT, note);
+        let (retrieved_note, _) = get_note::<MockNote>(context, STORAGE_SLOT);
+
+        assert_eq(retrieved_note.note, note);
+    });
+}
+
+#[test(should_fail_with = "Failed to get a note")]
+unconstrained fn get_undiscovered_settled_note_fails() {
+    let env = TestEnvironment::new();
+
+    let note = MockNote::new(VALUE).build_note();
+
+    env.private_context(|context| { let _ = create_note(context, STORAGE_SLOT, note); });
+
+    env.private_context(|context| { let _ = get_note::<MockNote>(context, STORAGE_SLOT); });
+}
+
+#[test(should_fail_with = "Failed to get a note")]
+unconstrained fn view_undiscovered_settled_note_fails() {
+    let env = TestEnvironment::new();
+
+    let note = MockNote::new(VALUE).build_note();
+
+    env.private_context(|context| { let _ = create_note(context, STORAGE_SLOT, note); });
+
+    env.utility_context(|_| { let _ = view_note::<MockNote>(STORAGE_SLOT); });
+}
+
+#[test]
+unconstrained fn get_discovered_settled_note() {
+    let env = TestEnvironment::new();
+
+    let note = MockNote::new(VALUE).build_note();
+
+    let emission = env.private_context(|context| create_note(context, STORAGE_SLOT, note));
+
+    env.discover_note(emission);
+
+    env.private_context(|context| {
+        let (retrieved_note, _) = get_note::<MockNote>(context, STORAGE_SLOT);
+
+        assert_eq(retrieved_note.note, note);
+    });
+}
+
+#[test]
+unconstrained fn view_discovered_settled_note() {
+    let env = TestEnvironment::new();
+
+    let note = MockNote::new(VALUE).build_note();
+
+    let emission = env.private_context(|context| create_note(context, STORAGE_SLOT, note));
+
+    env.discover_note(emission);
+
+    env.utility_context(|_| {
+        let retrieved_note = view_note::<MockNote>(STORAGE_SLOT);
+
+        assert_eq(retrieved_note.note, note);
+    });
+}
+
+#[test]
+unconstrained fn get_multiple_discovered_settled_notes() {
+    let env = TestEnvironment::new();
+
+    let note = MockNote::new(VALUE).build_note();
+    let other_note = MockNote::new(VALUE + 1).build_note();
+
+    let (emission, other_emission) = env.private_context(|context| {
+        (create_note(context, STORAGE_SLOT, note), create_note(context, STORAGE_SLOT, other_note))
+    });
+
+    env.discover_note(emission);
+    env.discover_note(other_emission);
+
+    env.private_context(|context| {
+        let (notes, _) = get_notes(context, STORAGE_SLOT, NoteGetterOptions::new());
+
+        assert_eq(notes.len(), 2);
+        assert_eq(notes.get(0).note, note);
+        assert_eq(notes.get(1).note, other_note);
+    });
+}
+
+#[test]
+unconstrained fn view_multiple_discovered_settled_notes() {
+    let env = TestEnvironment::new();
+
+    let note = MockNote::new(VALUE).build_note();
+    let other_note = MockNote::new(VALUE + 1).build_note();
+
+    let (emission, other_emission) = env.private_context(|context| {
+        (create_note(context, STORAGE_SLOT, note), create_note(context, STORAGE_SLOT, other_note))
+    });
+
+    env.discover_note(emission);
+    env.discover_note(other_emission);
+
+    env.utility_context(|_| {
+        let notes = view_notes(STORAGE_SLOT, NoteViewerOptions::new());
+
+        assert_eq(notes.len(), 2);
+        assert_eq(notes.get(0), note);
+        assert_eq(notes.get(1), other_note);
+    });
+}
+
+#[test(should_fail_with = "Failed to get a note")]
+unconstrained fn get_at_other_contract_discovered_settled_note_fails() {
+    let env = TestEnvironment::new();
+
+    let note = MockNote::new(VALUE).build_note();
+
+    let emission = env.private_context(|context| create_note(context, STORAGE_SLOT, note));
+
+    env.discover_note(emission);
+
+    env.private_context_at(CONTRACT_ADDRESS, |context| {
+        let (_, _) = get_note::<MockNote>(context, STORAGE_SLOT);
+    });
+}
+
+#[test(should_fail_with = "Failed to get a note")]
+unconstrained fn view_at_other_contract_discovered_settled_note_fails() {
+    let env = TestEnvironment::new();
+
+    let note = MockNote::new(VALUE).build_note();
+
+    let emission = env.private_context(|context| create_note(context, STORAGE_SLOT, note));
+
+    env.discover_note(emission);
+
+    env.utility_context_at(CONTRACT_ADDRESS, |_| { let _ = view_note::<MockNote>(STORAGE_SLOT); });
+}
+
+#[test(should_fail_with = "Failed to get a note")]
+unconstrained fn get_discovered_at_other_contract_settled_note_fails() {
+    let env = TestEnvironment::new();
+
+    let note = MockNote::new(VALUE).build_note();
+
+    let emission = env.private_context(|context| create_note(context, STORAGE_SLOT, note));
+
+    env.discover_note_at(CONTRACT_ADDRESS, emission);
+
+    env.private_context(|context| { let _ = get_note::<MockNote>(context, STORAGE_SLOT); });
+}
+
+#[test(should_fail_with = "Failed to get a note")]
+unconstrained fn view_discovered_at_other_contract_settled_note_fails() {
+    let env = TestEnvironment::new();
+
+    let note = MockNote::new(VALUE).build_note();
+
+    let emission = env.private_context(|context| create_note(context, STORAGE_SLOT, note));
+
+    env.discover_note_at(CONTRACT_ADDRESS, emission);
+
+    env.utility_context(|_| { let _ = view_note::<MockNote>(STORAGE_SLOT); });
+}
+
+#[test(should_fail_with = "Failed to get a note")]
+unconstrained fn get_discovered_settled_note_at_other_contract_fails() {
+    let env = TestEnvironment::new();
+
+    let note = MockNote::new(VALUE).build_note();
+
+    let emission = env.private_context_at(CONTRACT_ADDRESS, |context| {
+        create_note(context, STORAGE_SLOT, note)
+    });
+
+    env.discover_note(emission);
+
+    env.private_context_at(CONTRACT_ADDRESS, |context| {
+        let _ = get_note::<MockNote>(context, STORAGE_SLOT);
+    });
+}
+
+#[test(should_fail_with = "Failed to get a note")]
+unconstrained fn view_discovered_settled_note_at_other_contract_fails() {
+    let env = TestEnvironment::new();
+
+    let note = MockNote::new(VALUE).build_note();
+
+    let emission = env.private_context_at(CONTRACT_ADDRESS, |context| {
+        create_note(context, STORAGE_SLOT, note)
+    });
+
+    env.discover_note(emission);
+
+    env.utility_context_at(CONTRACT_ADDRESS, |_| { let _ = view_note::<MockNote>(STORAGE_SLOT); });
+}
+
+#[test]
+unconstrained fn get_discovered_at_other_contract_settled_note_at_other_contract() {
+    let env = TestEnvironment::new();
+
+    let note = MockNote::new(VALUE).build_note();
+
+    let emission = env.private_context_at(CONTRACT_ADDRESS, |context| {
+        create_note(context, STORAGE_SLOT, note)
+    });
+
+    env.discover_note_at(CONTRACT_ADDRESS, emission);
+
+    env.private_context_at(CONTRACT_ADDRESS, |context| {
+        let (retrieved_note, _) = get_note::<MockNote>(context, STORAGE_SLOT);
+
+        assert_eq(retrieved_note.note, note);
+    });
+}
+
+#[test]
+unconstrained fn view_discovered_at_other_contract_settled_note_at_other_contract() {
+    let env = TestEnvironment::new();
+
+    let note = MockNote::new(VALUE).build_note();
+
+    let emission = env.private_context_at(CONTRACT_ADDRESS, |context| {
+        create_note(context, STORAGE_SLOT, note)
+    });
+
+    env.discover_note_at(CONTRACT_ADDRESS, emission);
+
+    env.utility_context_at(CONTRACT_ADDRESS, |_| {
+        let retrieved_note = view_note::<MockNote>(STORAGE_SLOT);
+
+        assert_eq(retrieved_note.note, note);
+    });
+}
+
+#[test(should_fail_with = "Failed to get a note")]
+unconstrained fn get_squashed_note_fails() {
+    let env = TestEnvironment::new();
+
+    let note = MockNote::new(VALUE).build_note();
+
+    env.private_context(|context| {
+        let _ = create_note(context, STORAGE_SLOT, note);
+
+        // The aztec-nr API makes it so that in order to destroy the note we need to read it, because we need to know
+        // its note hash (either transient or settled). Conceptually this also forces the application to prove that the
+        // note does exist, and that it's not simply emitting a random nullifier.
+        let (retrieved_note, note_hash_for_read_request) =
+            get_note::<MockNote>(context, STORAGE_SLOT);
+        destroy_note_unsafe(context, retrieved_note, note_hash_for_read_request);
+
+        let (_, _) = get_note::<MockNote>(context, STORAGE_SLOT);
+    });
+}
+
+#[test(should_fail_with = "Failed to get a note")]
+unconstrained fn get_settled_squashed_note_fails() {
+    let env = TestEnvironment::new();
+
+    let note = MockNote::new(VALUE).build_note();
+
+    let emission = env.private_context(|context| {
+        let emission = create_note(context, STORAGE_SLOT, note);
+
+        // The aztec-nr API makes it so that in order to destroy the note we need to read it, because we need to know
+        // its note hash (either transient or settled). Conceptually this also forces the application to prove that the
+        // note does exist, and that it's not simply emitting a random nullifier.
+        let (retrieved_note, note_hash_for_read_request) =
+            get_note::<MockNote>(context, STORAGE_SLOT);
+        destroy_note_unsafe(context, retrieved_note, note_hash_for_read_request);
+
+        emission
+    });
+
+    env.discover_note(emission);
+
+    env.private_context(|context| { let (_, _) = get_note::<MockNote>(context, STORAGE_SLOT); });
+}
+
+#[test(should_fail_with = "Failed to get a note")]
+unconstrained fn view_settled_squashed_note_fails() {
+    let env = TestEnvironment::new();
+
+    let note = MockNote::new(VALUE).build_note();
+
+    let emission = env.private_context(|context| {
+        let emission = create_note(context, STORAGE_SLOT, note);
+
+        // The aztec-nr API makes it so that in order to destroy the note we need to read it, because we need to know
+        // its note hash (either transient or settled). Conceptually this also forces the application to prove that the
+        // note does exist, and that it's not simply emitting a random nullifier.
+        let (retrieved_note, note_hash_for_read_request) =
+            get_note::<MockNote>(context, STORAGE_SLOT);
+        destroy_note_unsafe(context, retrieved_note, note_hash_for_read_request);
+
+        emission
+    });
+
+    env.discover_note(emission);
+
+    env.utility_context(|_| { let _ = view_note::<MockNote>(STORAGE_SLOT); });
+}
+
+#[test(should_fail_with = "Failed to get a note")]
+unconstrained fn get_settled_note_with_transient_nullifier_note_fails() {
+    let env = TestEnvironment::new();
+
+    let note = MockNote::new(VALUE).build_note();
+
+    let emission = env.private_context(|context| create_note(context, STORAGE_SLOT, note));
+
+    env.discover_note(emission);
+
+    env.private_context(|context| {
+        // The aztec-nr API makes it so that in order to destroy the note we need to read it, because we need to know
+        // its note hash (either transient or settled). Conceptually this also forces the application to prove that the
+        // note does exist, and that it's not simply emitting a random nullifier.
+        let (retrieved_note, note_hash_for_read_request) =
+            get_note::<MockNote>(context, STORAGE_SLOT);
+        destroy_note_unsafe(context, retrieved_note, note_hash_for_read_request);
+
+        let (_, _) = get_note::<MockNote>(context, STORAGE_SLOT);
+    });
+}
+
+#[test(should_fail_with = "Failed to get a note")]
+unconstrained fn get_settled_note_with_settled_nullifier_note_fails() {
+    let env = TestEnvironment::new();
+
+    let note = MockNote::new(VALUE).build_note();
+
+    let emission = env.private_context(|context| create_note(context, STORAGE_SLOT, note));
+
+    env.discover_note(emission);
+
+    env.private_context(|context| {
+        // The aztec-nr API makes it so that in order to destroy the note we need to read it, because we need to know
+        // its note hash (either transient or settled). Conceptually this also forces the application to prove that the
+        // note does exist, and that it's not simply emitting a random nullifier.
+        let (retrieved_note, note_hash_for_read_request) =
+            get_note::<MockNote>(context, STORAGE_SLOT);
+        destroy_note_unsafe(context, retrieved_note, note_hash_for_read_request);
+    });
+
+    env.private_context(|context| { let (_, _) = get_note::<MockNote>(context, STORAGE_SLOT); });
+}
+
+#[test(should_fail_with = "Failed to get a note")]
+unconstrained fn view_settled_note_with_settled_nullifier_note_fails() {
+    let env = TestEnvironment::new();
+
+    let note = MockNote::new(VALUE).build_note();
+
+    let emission = env.private_context(|context| create_note(context, STORAGE_SLOT, note));
+
+    env.discover_note(emission);
+
+    env.private_context(|context| {
+        // The aztec-nr API makes it so that in order to destroy the note we need to read it, because we need to know
+        // its note hash (either transient or settled). Conceptually this also forces the application to prove that the
+        // note does exist, and that it's not simply emitting a random nullifier.
+        let (retrieved_note, note_hash_for_read_request) =
+            get_note::<MockNote>(context, STORAGE_SLOT);
+        destroy_note_unsafe(context, retrieved_note, note_hash_for_read_request);
+    });
+
+    env.utility_context(|_| { let _ = view_note::<MockNote>(STORAGE_SLOT); });
+}

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/txe_oracles.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/txe_oracles.nr
@@ -3,7 +3,7 @@ use crate::{context::inputs::PrivateContextInputs, test::helpers::utils::TestAcc
 use protocol_types::{
     abis::function_selector::FunctionSelector,
     address::AztecAddress,
-    constants::CONTRACT_INSTANCE_LENGTH,
+    constants::{CONTRACT_INSTANCE_LENGTH, MAX_NOTE_HASHES_PER_TX, MAX_NULLIFIERS_PER_TX},
     contract_instance::ContractInstance,
     traits::{Deserialize, ToField},
 };
@@ -44,7 +44,6 @@ pub unconstrained fn public_call_new_flow<let N: u32>(
     is_static_call: bool,
 ) -> [Field; N] {
     let calldata = args.push_front(function_selector.to_field());
-
     public_call_new_flow_oracle(from, contract_address, calldata, is_static_call)
 }
 
@@ -64,6 +63,9 @@ pub unconstrained fn get_next_block_timestamp() -> u64 {}
 
 #[oracle(txeGetLastBlockTimestamp)]
 pub unconstrained fn get_last_block_timestamp() -> u64 {}
+
+#[oracle(txeGetLastTxEffects)]
+pub unconstrained fn get_last_tx_effects() -> (Field, BoundedVec<Field, MAX_NOTE_HASHES_PER_TX>, BoundedVec<Field, MAX_NULLIFIERS_PER_TX>) {}
 
 #[oracle(txeAdvanceBlocksBy)]
 pub unconstrained fn advance_blocks_by(blocks: u32) {}

--- a/noir-projects/aztec-nr/uint-note/src/uint_note.nr
+++ b/noir-projects/aztec-nr/uint-note/src/uint_note.nr
@@ -144,14 +144,14 @@ impl UintNote {
         //  - the commitment is already public information, so we're not revealing anything else
         //  - we don't need to create any additional information, private or public, for the tag
         //  - other contracts cannot impersonate us and emit logs with the same tag due to public log siloing
-        let private_log_content = PrivateUintPartialNotePrivateLogContent {
-            owner,
-            randomness,
-            public_log_tag: commitment,
-        };
+        let private_log_content =
+            UintPartialNotePrivateLogContent { owner, randomness, public_log_tag: commitment };
 
-        let encrypted_log =
-            note::compute_partial_note_log(private_log_content, storage_slot, recipient);
+        let encrypted_log = note::compute_partial_note_private_content_log(
+            private_log_content,
+            storage_slot,
+            recipient,
+        );
         // Regardless of the original content size, the log is padded with random bytes up to
         // `PRIVATE_LOG_SIZE_IN_FIELDS` to prevent leaking information about the actual size.
         let length = encrypted_log.len();
@@ -190,7 +190,7 @@ impl UintPartialNotePrivateContent {
 }
 
 #[derive(Packable)]
-struct PrivateUintPartialNotePrivateLogContent {
+struct UintPartialNotePrivateLogContent {
     // The ordering of these fields is important given that it must:
     //   a) match that of UintNote, and
     //   b) have the public log tag at the beginning
@@ -200,7 +200,7 @@ struct PrivateUintPartialNotePrivateLogContent {
     randomness: Field,
 }
 
-impl NoteType for PrivateUintPartialNotePrivateLogContent {
+impl NoteType for UintPartialNotePrivateLogContent {
     fn get_id() -> Field {
         UintNote::get_id()
     }
@@ -328,8 +328,7 @@ impl FromField for PartialUintNote {
 
 mod test {
     use super::{
-        PartialUintNote, PrivateUintPartialNotePrivateLogContent, UintNote,
-        UintPartialNotePrivateContent,
+        PartialUintNote, UintNote, UintPartialNotePrivateContent, UintPartialNotePrivateLogContent,
     };
     use dep::aztec::{
         note::note_interface::NoteHash,
@@ -372,11 +371,8 @@ mod test {
         let partial_note_private_content = UintPartialNotePrivateContent { owner, randomness };
         let commitment = partial_note_private_content.compute_partial_commitment(storage_slot);
 
-        let private_log_content = PrivateUintPartialNotePrivateLogContent {
-            owner,
-            randomness,
-            public_log_tag: commitment,
-        };
+        let private_log_content =
+            UintPartialNotePrivateLogContent { owner, randomness, public_log_tag: commitment };
         // The following is a misuse of the `deserialize` function, but this is just a test and it's better than
         // letting devs manually construct it when they shouldn't be able to.
         let partial_note = PartialUintNote::deserialize([commitment]);

--- a/noir-projects/noir-contracts/contracts/app/nft_contract/src/types/nft_note.nr
+++ b/noir-projects/noir-contracts/contracts/app/nft_contract/src/types/nft_note.nr
@@ -140,14 +140,14 @@ impl NFTNote {
         //  - the commitment is already public information, so we're not revealing anything else
         //  - we don't need to create any additional information, private or public, for the tag
         //  - other contracts cannot impersonate us and emit logs with the same tag due to public log siloing
-        let private_log_content = PrivateNFTPartialNotePrivateLogContent {
-            owner,
-            randomness,
-            public_log_tag: commitment,
-        };
+        let private_log_content =
+            NFTPartialNotePrivateLogContent { owner, randomness, public_log_tag: commitment };
 
-        let encrypted_log =
-            note::compute_partial_note_log(private_log_content, storage_slot, recipient);
+        let encrypted_log = note::compute_partial_note_private_content_log(
+            private_log_content,
+            storage_slot,
+            recipient,
+        );
         // Regardless of the original content size, the log is padded with random bytes up to
         // `PRIVATE_LOG_SIZE_IN_FIELDS` to prevent leaking information about the actual size.
         let length = encrypted_log.len();
@@ -186,7 +186,7 @@ impl NFTPartialNotePrivateContent {
 }
 
 #[derive(Packable)]
-struct PrivateNFTPartialNotePrivateLogContent {
+struct NFTPartialNotePrivateLogContent {
     // The ordering of these fields is important given that it must:
     //   a) match that of NFTNote, and
     //   b) have the public log tag at the beginning
@@ -196,7 +196,7 @@ struct PrivateNFTPartialNotePrivateLogContent {
     randomness: Field,
 }
 
-impl NoteType for PrivateNFTPartialNotePrivateLogContent {
+impl NoteType for NFTPartialNotePrivateLogContent {
     fn get_id() -> Field {
         NFTNote::get_id()
     }
@@ -266,8 +266,7 @@ impl PartialNFTNote {
 
 mod test {
     use super::{
-        NFTNote, NFTPartialNotePrivateContent, PartialNFTNote,
-        PrivateNFTPartialNotePrivateLogContent,
+        NFTNote, NFTPartialNotePrivateContent, NFTPartialNotePrivateLogContent, PartialNFTNote,
     };
     use dep::aztec::{
         note::note_interface::NoteHash,
@@ -310,11 +309,8 @@ mod test {
         let partial_note_private_content = NFTPartialNotePrivateContent { owner, randomness };
         let commitment = partial_note_private_content.compute_partial_commitment(storage_slot);
 
-        let private_log_content = PrivateNFTPartialNotePrivateLogContent {
-            owner,
-            randomness,
-            public_log_tag: commitment,
-        };
+        let private_log_content =
+            NFTPartialNotePrivateLogContent { owner, randomness, public_log_tag: commitment };
         // The following is a misuse of the `deserialize` function, but this is just a test and it's better than
         // letting devs manually construct it when they shouldn't be able to.
         let partial_note = PartialNFTNote::deserialize([commitment]);

--- a/yarn-project/pxe/src/contract_function_simulator/pxe_oracle_interface.test.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/pxe_oracle_interface.test.ts
@@ -913,12 +913,10 @@ describe('PXEOracleInterface', () => {
 
     it('should search for notes from all accounts', async () => {
       // Add multiple accounts to keystore
-      const numAccounts = 3;
-
       await keyStore.addAccount(Fr.random(), Fr.random());
       await keyStore.addAccount(Fr.random(), Fr.random());
 
-      expect(await keyStore.getAccounts()).toHaveLength(numAccounts);
+      expect(await keyStore.getAccounts()).toHaveLength(3);
 
       // Spy on the noteDataProvider.getNotesSpy
       const getNotesSpy = jest.spyOn(noteDataProvider, 'getNotes');
@@ -926,14 +924,11 @@ describe('PXEOracleInterface', () => {
       // Call the function under test
       await pxeOracleInterface.removeNullifiedNotes(contractAddress);
 
-      // Verify removeNullifiedNotes was called once for each account
-      expect(getNotesSpy).toHaveBeenCalledTimes(numAccounts);
+      // Verify removeNullifiedNotes was called once for all accounts
+      expect(getNotesSpy).toHaveBeenCalledTimes(1);
 
-      // Verify getNotes was called with the correct contract address and recipient for each account
-      const accounts = await keyStore.getAccounts();
-      accounts.forEach(recipient => {
-        expect(getNotesSpy).toHaveBeenCalledWith(expect.objectContaining({ contractAddress, recipient }));
-      });
+      // Verify getNotes was called with the correct contract address
+      expect(getNotesSpy).toHaveBeenCalledWith(expect.objectContaining({ contractAddress }));
     });
   });
 

--- a/yarn-project/pxe/src/contract_function_simulator/pxe_oracle_interface.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/pxe_oracle_interface.ts
@@ -714,7 +714,7 @@ export class PXEOracleInterface implements ExecutionDataProvider {
 
     if (nullifierIndex !== undefined) {
       const { data: _, ...blockHashAndNum } = nullifierIndex;
-      await this.noteDataProvider.removeNullifiedNotes([{ data: siloedNullifier, ...blockHashAndNum }], recipient);
+      await this.noteDataProvider.removeNullifiedNotes([{ data: siloedNullifier, ...blockHashAndNum }]);
 
       this.log.verbose(`Removed just-added note`, {
         contract: contractAddress,
@@ -895,51 +895,48 @@ export class PXEOracleInterface implements ExecutionDataProvider {
     // available, even for non-archive nodes.
     const syncedBlockNumber = await this.syncDataProvider.getBlockNumber();
 
-    for (const recipient of await this.keyStore.getAccounts()) {
-      const currentNotesForRecipient = await this.noteDataProvider.getNotes({ contractAddress, recipient });
+    const contractNotes = await this.noteDataProvider.getNotes({ contractAddress });
 
-      if (currentNotesForRecipient.length === 0) {
-        // Save a call to the node if there are no notes for the recipient
-        continue;
-      }
-
-      const nullifiersToCheck = currentNotesForRecipient.map(note => note.siloedNullifier);
-      const nullifierBatches = nullifiersToCheck.reduce(
-        (acc, nullifier) => {
-          if (acc[acc.length - 1].length < MAX_RPC_LEN) {
-            acc[acc.length - 1].push(nullifier);
-          } else {
-            acc.push([nullifier]);
-          }
-          return acc;
-        },
-        [[]] as Fr[][],
-      );
-      const nullifierIndexes = (
-        await Promise.all(
-          nullifierBatches.map(batch =>
-            this.aztecNode.findLeavesIndexes(syncedBlockNumber, MerkleTreeId.NULLIFIER_TREE, batch),
-          ),
-        )
-      ).flat();
-
-      const foundNullifiers = nullifiersToCheck
-        .map((nullifier, i) => {
-          if (nullifierIndexes[i] !== undefined) {
-            return { ...nullifierIndexes[i], ...{ data: nullifier } } as InBlock<Fr>;
-          }
-        })
-        .filter(nullifier => nullifier !== undefined) as InBlock<Fr>[];
-
-      const nullifiedNotes = await this.noteDataProvider.removeNullifiedNotes(foundNullifiers, recipient);
-      nullifiedNotes.forEach(noteDao => {
-        this.log.verbose(`Removed note for contract ${noteDao.contractAddress} at slot ${noteDao.storageSlot}`, {
-          contract: noteDao.contractAddress,
-          slot: noteDao.storageSlot,
-          nullifier: noteDao.siloedNullifier.toString(),
-        });
-      });
+    if (contractNotes.length === 0) {
+      return;
     }
+
+    const nullifiersToCheck = contractNotes.map(note => note.siloedNullifier);
+    const nullifierBatches = nullifiersToCheck.reduce(
+      (acc, nullifier) => {
+        if (acc[acc.length - 1].length < MAX_RPC_LEN) {
+          acc[acc.length - 1].push(nullifier);
+        } else {
+          acc.push([nullifier]);
+        }
+        return acc;
+      },
+      [[]] as Fr[][],
+    );
+    const nullifierIndexes = (
+      await Promise.all(
+        nullifierBatches.map(batch =>
+          this.aztecNode.findLeavesIndexes(syncedBlockNumber, MerkleTreeId.NULLIFIER_TREE, batch),
+        ),
+      )
+    ).flat();
+
+    const foundNullifiers = nullifiersToCheck
+      .map((nullifier, i) => {
+        if (nullifierIndexes[i] !== undefined) {
+          return { ...nullifierIndexes[i], ...{ data: nullifier } } as InBlock<Fr>;
+        }
+      })
+      .filter(nullifier => nullifier !== undefined) as InBlock<Fr>[];
+
+    const nullifiedNotes = await this.noteDataProvider.removeNullifiedNotes(foundNullifiers);
+    nullifiedNotes.forEach(noteDao => {
+      this.log.verbose(`Removed note for contract ${noteDao.contractAddress} at slot ${noteDao.storageSlot}`, {
+        contract: noteDao.contractAddress,
+        slot: noteDao.storageSlot,
+        nullifier: noteDao.siloedNullifier.toString(),
+      });
+    });
   }
 
   storeCapsule(contractAddress: AztecAddress, slot: Fr, capsule: Fr[]): Promise<void> {

--- a/yarn-project/pxe/src/storage/note_data_provider/note_data_provider.test.ts
+++ b/yarn-project/pxe/src/storage/note_data_provider/note_data_provider.test.ts
@@ -116,16 +116,13 @@ describe('NoteDataProvider', () => {
   it.each(filteringTests)('retrieves nullified notes', async (getFilter, getExpected) => {
     await noteDataProvider.addNotes(notes);
 
-    // Nullify all notes and use the same filter as other test cases
-    for (const recipient of recipients) {
-      const notesToNullify = notes.filter(note => note.recipient.equals(recipient));
-      const nullifiers = notesToNullify.map(note => ({
-        data: note.siloedNullifier,
-        l2BlockNumber: note.l2BlockNumber,
-        l2BlockHash: L2BlockHash.fromString(note.l2BlockHash),
-      }));
-      await expect(noteDataProvider.removeNullifiedNotes(nullifiers, recipient)).resolves.toEqual(notesToNullify);
-    }
+    // Nullify all notes
+    const nullifiers = notes.map(note => ({
+      data: note.siloedNullifier,
+      l2BlockNumber: note.l2BlockNumber,
+      l2BlockHash: L2BlockHash.fromString(note.l2BlockHash),
+    }));
+    await expect(noteDataProvider.removeNullifiedNotes(nullifiers)).resolves.toEqual(notes);
     const filter = await getFilter();
     const returnedNotes = await noteDataProvider.getNotes({ ...filter, status: NoteStatus.ACTIVE_OR_NULLIFIED });
     const expected = await getExpected();
@@ -140,9 +137,7 @@ describe('NoteDataProvider', () => {
       l2BlockNumber: note.l2BlockNumber,
       l2BlockHash: L2BlockHash.fromString(note.l2BlockHash),
     }));
-    await expect(noteDataProvider.removeNullifiedNotes(nullifiers, notesToNullify[0].recipient)).resolves.toEqual(
-      notesToNullify,
-    );
+    await expect(noteDataProvider.removeNullifiedNotes(nullifiers)).resolves.toEqual(notesToNullify);
 
     const actualNotesWithDefault = await getNotesForAllContracts({});
     const actualNotesWithActive = await getNotesForAllContracts({ status: NoteStatus.ACTIVE });
@@ -160,9 +155,7 @@ describe('NoteDataProvider', () => {
       l2BlockNumber: 99,
       l2BlockHash: L2BlockHash.random(),
     }));
-    await expect(noteDataProvider.removeNullifiedNotes(nullifiers, notesToNullify[0].recipient)).resolves.toEqual(
-      notesToNullify,
-    );
+    await expect(noteDataProvider.removeNullifiedNotes(nullifiers)).resolves.toEqual(notesToNullify);
     await expect(noteDataProvider.unnullifyNotesAfter(98)).resolves.toEqual(undefined);
 
     const result = await getNotesForAllContracts({ status: NoteStatus.ACTIVE, recipient: recipients[0] });
@@ -179,9 +172,7 @@ describe('NoteDataProvider', () => {
       l2BlockNumber: note.l2BlockNumber,
       l2BlockHash: L2BlockHash.fromString(note.l2BlockHash),
     }));
-    await expect(noteDataProvider.removeNullifiedNotes(nullifiers, notesToNullify[0].recipient)).resolves.toEqual(
-      notesToNullify,
-    );
+    await expect(noteDataProvider.removeNullifiedNotes(nullifiers)).resolves.toEqual(notesToNullify);
 
     const result = await getNotesForAllContracts({
       status: NoteStatus.ACTIVE_OR_NULLIFIED,
@@ -231,16 +222,13 @@ describe('NoteDataProvider', () => {
       }),
     ).resolves.toEqual([notes[0]]);
     await expect(
-      noteDataProvider.removeNullifiedNotes(
-        [
-          {
-            data: notes[0].siloedNullifier,
-            l2BlockHash: L2BlockHash.fromString(notes[0].l2BlockHash),
-            l2BlockNumber: notes[0].l2BlockNumber,
-          },
-        ],
-        recipients[0],
-      ),
+      noteDataProvider.removeNullifiedNotes([
+        {
+          data: notes[0].siloedNullifier,
+          l2BlockHash: L2BlockHash.fromString(notes[0].l2BlockHash),
+          l2BlockNumber: notes[0].l2BlockNumber,
+        },
+      ]),
     ).resolves.toEqual([notes[0]]);
 
     await expect(

--- a/yarn-project/pxe/src/storage/note_data_provider/note_data_provider.ts
+++ b/yarn-project/pxe/src/storage/note_data_provider/note_data_provider.ts
@@ -270,7 +270,7 @@ export class NoteDataProvider implements DataProvider {
     return result;
   }
 
-  removeNullifiedNotes(nullifiers: InBlock<Fr>[], recipient: AztecAddress): Promise<NoteDao[]> {
+  removeNullifiedNotes(nullifiers: InBlock<Fr>[]): Promise<NoteDao[]> {
     if (nullifiers.length === 0) {
       return Promise.resolve([]);
     }
@@ -292,9 +292,6 @@ export class NoteDataProvider implements DataProvider {
         }
         const noteScopes = (await toArray(this.#notesToScope.getValuesAsync(noteIndex))) ?? [];
         const note = NoteDao.fromBuffer(noteBuffer);
-        if (!note.recipient.equals(recipient)) {
-          throw new Error("Tried to nullify someone else's note");
-        }
 
         nullifiedNotes.push(note);
 

--- a/yarn-project/txe/src/oracle/txe_oracle_top_level_context.ts
+++ b/yarn-project/txe/src/oracle/txe_oracle_top_level_context.ts
@@ -154,6 +154,19 @@ export class TXEOracleTopLevelContext extends TXETypedOracle {
     return (await this.stateMachine.node.getBlockHeader('latest'))!.globalVariables.timestamp;
   }
 
+  override async txeGetLastTxEffects() {
+    const block = await this.stateMachine.archiver.getBlock('latest');
+
+    if (block!.body.txEffects.length != 1) {
+      // Note that calls like env.mine() will result in blocks with no transactions, hitting this
+      throw new Error(`Expected a single transaction in the last block, found ${block!.body.txEffects.length}`);
+    }
+
+    const txEffects = block!.body.txEffects[0];
+
+    return { txHash: txEffects.txHash, noteHashes: txEffects.noteHashes, nullifiers: txEffects.nullifiers };
+  }
+
   override async txeAdvanceBlocksBy(blocks: number) {
     this.logger.debug(`time traveling ${blocks} blocks`);
 

--- a/yarn-project/txe/src/oracle/txe_typed_oracle.ts
+++ b/yarn-project/txe/src/oracle/txe_typed_oracle.ts
@@ -1,4 +1,4 @@
-import type { CompleteAddress, ContractArtifact, ContractInstanceWithAddress } from '@aztec/aztec.js';
+import type { CompleteAddress, ContractArtifact, ContractInstanceWithAddress, TxHash } from '@aztec/aztec.js';
 import type { Fr } from '@aztec/foundation/fields';
 import { TypedOracle } from '@aztec/pxe/simulator';
 import type { FunctionSelector } from '@aztec/stdlib/abi';
@@ -99,6 +99,14 @@ export class TXETypedOracle extends TypedOracle {
 
   txeGetLastBlockTimestamp(): Promise<bigint> {
     throw new OracleMethodNotAvailableError(this.className, 'txeGetLastBlockTimestamp');
+  }
+
+  txeGetLastTxEffects(): Promise<{
+    txHash: TxHash;
+    noteHashes: Fr[];
+    nullifiers: Fr[];
+  }> {
+    throw new OracleMethodNotAvailableError(this.className, 'txeGetLastTxEffects');
   }
 
   storageWrite(_startStorageSlot: Fr, _values: Fr[]): Promise<Fr[]> {

--- a/yarn-project/txe/src/state_machine/archiver.ts
+++ b/yarn-project/txe/src/state_machine/archiver.ts
@@ -63,8 +63,8 @@ export class TXEArchiver extends ArchiverStoreHelper implements L2BlockSource {
    * @param number - The block number to return (inclusive).
    * @returns The requested L2 block.
    */
-  public getBlock(number: number): Promise<L2Block | undefined> {
-    return this.getPublishedBlock(number).then(block => block?.block);
+  public getBlock(number: number | 'latest'): Promise<L2Block | undefined> {
+    return this.getPublishedBlock(number != 'latest' ? number : -1).then(block => block?.block);
   }
 
   /**

--- a/yarn-project/txe/src/txe_service/txe_service.ts
+++ b/yarn-project/txe/src/txe_service/txe_service.ts
@@ -1,4 +1,5 @@
 import { type ContractInstanceWithAddress, Fr, Point } from '@aztec/aztec.js';
+import { MAX_NOTE_HASHES_PER_TX, MAX_NULLIFIERS_PER_TX } from '@aztec/constants';
 import { packAsRetrievedNote } from '@aztec/pxe/simulator';
 import { type ContractArtifact, FunctionSelector, NoteSelector } from '@aztec/stdlib/abi';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
@@ -193,6 +194,16 @@ export class TXEService {
     const timestamp = await this.oracleHandler.txeGetLastBlockTimestamp();
 
     return toForeignCallResult([toSingle(new Fr(timestamp))]);
+  }
+
+  async txeGetLastTxEffects() {
+    const { txHash, noteHashes, nullifiers } = await this.oracleHandler.txeGetLastTxEffects();
+
+    return toForeignCallResult([
+      toSingle(txHash.hash),
+      ...arrayToBoundedVec(toArray(noteHashes), MAX_NOTE_HASHES_PER_TX),
+      ...arrayToBoundedVec(toArray(nullifiers), MAX_NULLIFIERS_PER_TX),
+    ]);
   }
 
   // Since the argument is a slice, noir automatically adds a length field to oracle call.

--- a/yarn-project/txe/src/txe_session.ts
+++ b/yarn-project/txe/src/txe_session.ts
@@ -252,7 +252,7 @@ export class TXESession implements TXESessionStateHandler {
       contractAddress ?? DEFAULT_ADDRESS,
     );
 
-    this.oracleHandler = new TXE(
+    this.oracleHandler = await TXE.create(
       contractAddress ?? DEFAULT_ADDRESS,
       this.pxeOracleInterface,
       await this.stateMachine.synchronizer.nativeWorldStateService.fork(),
@@ -274,7 +274,7 @@ export class TXESession implements TXESessionStateHandler {
     // all the way to the tip of the chain.
     const latestBlock = await this.stateMachine.node.getBlockHeader('latest');
 
-    this.oracleHandler = new TXE(
+    this.oracleHandler = await TXE.create(
       contractAddress ?? DEFAULT_ADDRESS,
       this.pxeOracleInterface,
       await this.stateMachine.synchronizer.nativeWorldStateService.fork(),


### PR DESCRIPTION
This adds `TestEnvironment::discover_note`, which is needed to emulate the note discovery that happens in real contracts for notes created in a `TestEnvironment::pirvate_context`. With this we can now extend our testing of note-based state variables, as well as properly tests constructs such as `DelayedPrivateMutable`.

I introduced some minor adjustments to the internals of the message encoding functions to better reuse those capabitilies. These are part of a larger set of changes we'll likely want to introduce as we unify and improve the note and event emission APIs.

edit: I also added some tests for note destruction and checking that we do not return those notes, both in transient and settled scenarios. I'm only testing private context and not utility context to keep the number of tests here small, but we should later expand these, perhaps with some more organization of the internals of the note getter API.

Interestingly, I had to pseudo introduce the notion of 'syncing' and how it relates to nullified note discovery (#12553) here, since  direct context usage does not run the autogenerated note discovery code. This resulted in some findings, notably the note data provider being a bit annoying about requiring knowledge of the recipient of the notes that were being nullified, seemingly for no good reason. I had to remove all of that because `env::discover_note` sets the zero address as the recipient as none are assumed to exist, and so when looking up notes we'd want to check for nullification we'd find none since our PXE had no accounts. This now searches _all_ notes in scope, regardless of who their recipient is.