### PR TITLE
chore: update get sample seed

### DIFF
--- a/l1-contracts/src/core/RollupCore.sol
+++ b/l1-contracts/src/core/RollupCore.sol
@@ -526,8 +526,8 @@ contract RollupCore is EIP712("Aztec Rollup", "1"), Ownable, IStakingCore, IVali
    *      `ExtRollupLib.propose(...)` -> `ProposeLib.propose(...)` -> `ValidatorSelectionLib.setupEpoch(...)`).
    *
    *      If there are missed proposals then setupEpoch does not get called automatically. Since the next committee
-   *      selection is computed based on the latest stored seed and the epoch number, we would only fail to get a
-   *      fresh seed if:
+   *      selection is computed based on the stored randao and the epoch number, failing to update the randao stored
+   *      will keep the committee predictable longer into the future. We would only fail to get a fresh randao if:
    *      1. All the proposals in the epoch were missed
    *      2. Nobody called setupEpoch on the Rollup contract
    *
@@ -540,13 +540,13 @@ contract RollupCore is EIP712("Aztec Rollup", "1"), Ownable, IStakingCore, IVali
   }
 
   /**
-   * @notice Captures the seed for validator selection in the next epoch
-   * @dev Can be called by anyone. Takes a snapshot of the current state to ensure
-   *      unpredictable but deterministic validator selection. Automatically called
-   *      from setupEpoch.
+   * @notice Captures the randao for future validator selection
+   * @dev Can be called by anyone. Takes a snapshot of the current randao to ensure unpredictable but deterministic
+   *      validator selection. Automatically called from setupEpoch. Can be used as a cheaper alternative to
+   *      `setupEpoch` to update the randao checkpoints.
    */
-  function setupSeedSnapshotForNextEpoch() public override(IValidatorSelectionCore) {
-    ExtRollupLib2.setupSeedSnapshotForNextEpoch();
+  function checkpointRandao() public override(IValidatorSelectionCore) {
+    ExtRollupLib2.checkpointRandao();
   }
 
   /**

--- a/l1-contracts/src/core/interfaces/IValidatorSelection.sol
+++ b/l1-contracts/src/core/interfaces/IValidatorSelection.sol
@@ -9,14 +9,14 @@ import {Checkpoints} from "@oz/utils/structs/Checkpoints.sol";
 struct ValidatorSelectionStorage {
   // A mapping to snapshots of the validator set
   mapping(Epoch => bytes32 committeeCommitment) committeeCommitments;
-  // Checkpointed map of epoch -> sample seed
-  Checkpoints.Trace224 seeds;
+  // Checkpointed map of epoch -> randao value
+  Checkpoints.Trace224 randaos;
   uint256 targetCommitteeSize;
 }
 
 interface IValidatorSelectionCore {
   function setupEpoch() external;
-  function setupSeedSnapshotForNextEpoch() external;
+  function checkpointRandao() external;
 }
 
 interface IValidatorSelection is IValidatorSelectionCore, IEmperor {

--- a/l1-contracts/src/core/libraries/rollup/ExtRollupLib2.sol
+++ b/l1-contracts/src/core/libraries/rollup/ExtRollupLib2.sol
@@ -71,9 +71,9 @@ library ExtRollupLib2 {
     ValidatorSelectionLib.setupEpoch(currentEpoch);
   }
 
-  function setupSeedSnapshotForNextEpoch() external {
+  function checkpointRandao() external {
     Epoch currentEpoch = Timestamp.wrap(block.timestamp).epochFromTimestamp();
-    ValidatorSelectionLib.setSampleSeedForNextEpoch(currentEpoch);
+    ValidatorSelectionLib.checkpointRandao(currentEpoch);
   }
 
   function updateStakingQueueConfig(StakingQueueConfig memory _config) external {

--- a/l1-contracts/src/core/libraries/rollup/ValidatorSelectionLib.sol
+++ b/l1-contracts/src/core/libraries/rollup/ValidatorSelectionLib.sol
@@ -60,8 +60,8 @@ import {TransientSlot} from "@oz/utils/TransientSlot.sol";
  *      4. Seed Management:
  *         - Sample seeds determine committee and proposer selection for each epoch
  *         - Seeds use prevrandao from L1 blocks combined with epoch number for unpredictability
- *         - Seeds are set 2 epochs in advance to prevent last-minute manipulation and provide L1-reorg resistance
- *         - First two epochs use maximum seed values (type(uint224).max) for bootstrap (this results in the committee
+ *         - Prevrandao are set 2 epochs in advance to prevent last-minute manipulation and provide L1-reorg resistance
+ *         - First two epochs use randao values (type(uint224).max) for bootstrap (this results in the committee
  *           being predictable in the first 2 epochs which is considered acceptable when bootstrapping the network)
  *
  *      5. Caching and Optimization:
@@ -134,9 +134,8 @@ library ValidatorSelectionLib {
     ValidatorSelectionStorage storage store = getStorage();
     store.targetCommitteeSize = _targetCommitteeSize;
 
-    // Set the sample seed for the first 2 epochs to max
-    store.seeds.push(0, type(uint224).max);
-    store.seeds.push(1, type(uint224).max);
+    // Set the initial randao
+    store.randaos.push(0, uint224(block.prevrandao));
   }
 
   /**
@@ -155,11 +154,11 @@ library ValidatorSelectionLib {
 
     //################ Seeds ################
     // Get the sample seed for this current epoch.
-    uint224 sampleSeed = getSampleSeed(_epochNumber);
+    uint256 sampleSeed = getSampleSeed(_epochNumber);
 
-    // Set the sample seed for the next epoch if required
+    // Checkpoint randao for future sampling if required
     // function handles the case where it is already set
-    setSampleSeedForNextEpoch(_epochNumber);
+    checkpointRandao(_epochNumber);
 
     //################ Committee ################
     // If the committee is not set for this epoch, we need to sample it
@@ -228,7 +227,7 @@ library ValidatorSelectionLib {
       }
 
       // Get the proposer from the committee based on the epoch, slot, and sample seed
-      uint224 sampleSeed = getSampleSeed(_epochNumber);
+      uint256 sampleSeed = getSampleSeed(_epochNumber);
       proposerIndex = computeProposerIndex(_epochNumber, _slot, sampleSeed, committeeSize);
       proposer = committee[proposerIndex];
 
@@ -384,7 +383,7 @@ library ValidatorSelectionLib {
 
     Epoch epochNumber = _slot.epochFromSlot();
 
-    uint224 sampleSeed = getSampleSeed(epochNumber);
+    uint256 sampleSeed = getSampleSeed(epochNumber);
     (uint32 ts, uint256[] memory indices) = sampleValidatorsIndices(epochNumber, sampleSeed);
     uint256 committeeSize = indices.length;
     if (committeeSize == 0) {
@@ -402,7 +401,7 @@ library ValidatorSelectionLib {
    * @param _seed The cryptographic seed for sampling randomness
    * @return The array of validator addresses selected for the committee
    */
-  function sampleValidators(Epoch _epoch, uint224 _seed) internal returns (address[] memory) {
+  function sampleValidators(Epoch _epoch, uint256 _seed) internal returns (address[] memory) {
     (uint32 ts, uint256[] memory indices) = sampleValidatorsIndices(_epoch, _seed);
     return StakingLib.getAttestersFromIndicesAtTime(Timestamp.wrap(ts), indices);
   }
@@ -415,7 +414,7 @@ library ValidatorSelectionLib {
    * @return The array of committee member addresses for the epoch
    */
   function getCommitteeAt(Epoch _epochNumber) internal returns (address[] memory) {
-    uint224 seed = getSampleSeed(_epochNumber);
+    uint256 seed = getSampleSeed(_epochNumber);
     return sampleValidators(_epochNumber, seed);
   }
 
@@ -444,41 +443,34 @@ library ValidatorSelectionLib {
   }
 
   /**
-   * @notice Sets the sample seed for the epoch two epochs in the future
-   * @dev Calls setSampleSeedForEpoch with _epoch + 2 to maintain the two-epoch advance requirement.
-   *      This ensures randomness seeds are set well in advance to prevent manipulation.
-   * @param _epoch The current epoch (seed will be set for _epoch + 2)
+   * @notice Checkpoints randao value for future usage
+   * @dev Checks if already stored before computing and storing the randao value.
+   *      Offset the epoch by 2 to maintain the two-epoch advance requirement.
+   *      This ensures randomness are set well in advance to prevent manipulation.
+   * @param _epoch The current epoch (randao will be set for _epoch + 2)
+   *       Passed to reduce recomputation
    */
-  function setSampleSeedForNextEpoch(Epoch _epoch) internal {
-    setSampleSeedForEpoch(_epoch + Epoch.wrap(2));
-  }
-
-  /**
-   * @notice Sets the sample seed for a specific epoch if not already set
-   * @dev Checks if the seed is already stored before computing and storing a new one.
-   *      Uses computeNextSeed() to generate cryptographically secure randomness.
-   * @param _epoch The epoch to set the sample seed for
-   */
-  function setSampleSeedForEpoch(Epoch _epoch) internal {
+  function checkpointRandao(Epoch _epoch) internal {
     ValidatorSelectionStorage storage store = getStorage();
-    uint32 epoch = Epoch.unwrap(_epoch).toUint32();
+
+    // Compute the offset
+    uint32 epoch = Epoch.unwrap(_epoch).toUint32() + 2;
 
     // Check if the latest checkpoint is for the next epoch
-    // It should be impossible that zero epoch snapshots exist, as in the genesis state we push the first sample seed
+    // It should be impossible that zero epoch snapshots exist, as in the genesis state we push the first values
     // into the store
-    (, uint32 mostRecentSeedEpoch,) = store.seeds.latestCheckpoint();
+    (, uint32 mostRecentEpoch,) = store.randaos.latestCheckpoint();
 
-    // If the sample seed for the next epoch is already set, we can skip the computation
-    if (mostRecentSeedEpoch == epoch) {
+    // If the randao for the next epoch is already set, we can skip the computation
+    if (mostRecentEpoch == epoch) {
       return;
     }
 
-    // If the most recently stored seed is less than the epoch we are querying, then we need to compute its seed for
+    // If the most recently stored epoch is less than the epoch we are querying, then we need to store randao for
     // later use
-    if (mostRecentSeedEpoch < epoch) {
-      // Compute the sample seed for the next epoch
-      uint224 nextSeed = computeNextSeed(_epoch);
-      store.seeds.push(epoch, nextSeed);
+    if (mostRecentEpoch < epoch) {
+      // Truncate the randao to be used for future sampling.
+      store.randaos.push(epoch, uint224(block.prevrandao));
     }
   }
 
@@ -558,15 +550,14 @@ library ValidatorSelectionLib {
 
   /**
    * @notice Gets the cryptographic sample seed for an epoch
-   * @dev Retrieves the seed from the checkpointed seeds mapping using upperLookup.
-   *      The seed is computed as keccak256(epoch, block.prevrandao) during epoch setup.
-   *      Never called for epoch 0 or future epochs - only for current/past epochs.
+   * @dev Retrieves the randao from the checkpointed randaos mapping using upperLookup.
+   *      Then computes the sample seed using keccak256(epoch, randao)
    * @param _epoch The epoch to get the sample seed for
-   * @return The 224-bit sample seed used for validator selection randomness
+   * @return The sample seed used for validator selection randomness
    */
-  function getSampleSeed(Epoch _epoch) internal view returns (uint224) {
+  function getSampleSeed(Epoch _epoch) internal view returns (uint256) {
     ValidatorSelectionStorage storage store = getStorage();
-    return store.seeds.upperLookup(Epoch.unwrap(_epoch).toUint32());
+    return uint256(keccak256(abi.encode(_epoch, store.randaos.upperLookup(Epoch.unwrap(_epoch).toUint32()))));
   }
 
   /**
@@ -607,7 +598,7 @@ library ValidatorSelectionLib {
    * @return indices Array of validator indices selected for the committee
    * @custom:reverts Errors.ValidatorSelection__InsufficientCommitteeSize if not enough validators available
    */
-  function sampleValidatorsIndices(Epoch _epoch, uint224 _seed) private returns (uint32, uint256[] memory) {
+  function sampleValidatorsIndices(Epoch _epoch, uint256 _seed) private returns (uint32, uint256[] memory) {
     ValidatorSelectionStorage storage store = getStorage();
     uint32 ts = epochToSampleTime(_epoch);
     uint256 validatorSetSize = StakingLib.getAttesterCountAtTime(Timestamp.wrap(ts));
@@ -623,18 +614,6 @@ library ValidatorSelectionLib {
     }
 
     return (ts, SampleLib.computeCommittee(targetCommitteeSize, validatorSetSize, _seed));
-  }
-
-  /**
-   * @notice Computes the cryptographic seed for an epoch using L1 randomness
-   * @dev Combines epoch number with block.prevrandao to create unpredictable but deterministic seed.
-   *      Including epoch prevents foundry testing issues where prevrandao might be zero.
-   * @param _epoch The epoch to compute the seed for
-   * @return The computed 224-bit seed (truncated from 256-bit keccak output)
-   */
-  function computeNextSeed(Epoch _epoch) private view returns (uint224) {
-    // Allow for unsafe (lossy) downcast as we do not care if we loose bits
-    return uint224(uint256(keccak256(abi.encode(_epoch, block.prevrandao))));
   }
 
   /**

--- a/l1-contracts/test/validator-selection/ValidatorSelection.t.sol
+++ b/l1-contracts/test/validator-selection/ValidatorSelection.t.sol
@@ -136,9 +136,10 @@ contract ValidatorSelectionTest is ValidatorSelectionTestBase {
     assertEq(expectedProposer, actualProposer, "Invalid proposer");
   }
 
-  function testCommitteeForNonSetupEpoch(uint8 _epochsToJump) public setup(4, 4) progressEpochs(2) {
+  function testCommitteeForNonSetupEpoch() public setup(8, 4) progressEpochs(2) {
     Epoch pre = rollup.getCurrentEpoch();
-    vm.warp(block.timestamp + uint256(_epochsToJump) * rollup.getEpochDuration() * rollup.getSlotDuration());
+    // Jump 8 epochs into the future to ensure that it haven't been setup.
+    vm.warp(block.timestamp + 8 * rollup.getEpochDuration() * rollup.getSlotDuration());
 
     Epoch post = rollup.getCurrentEpoch();
 
@@ -151,8 +152,8 @@ contract ValidatorSelectionTest is ValidatorSelectionTestBase {
     assertEq(preCommittee.length, expectedSize, "Invalid committee size");
     assertEq(postCommittee.length, expectedSize, "Invalid committee size");
 
-    // Elements in the committee should be the same
-    assertEq(preCommittee, postCommittee, "Committee elements have changed");
+    // Elements in the committee should **not** be the same, as the epoch is mixed into the seed
+    assertNotEq(preCommittee, postCommittee, "Committee elements have not changed");
   }
 
   function testStableCommittee(uint8 _timeToJump) public setup(4, 4) progressEpochs(2) {

--- a/l1-contracts/test/validator-selection/setupEpoch.t.sol
+++ b/l1-contracts/test/validator-selection/setupEpoch.t.sol
@@ -16,6 +16,10 @@ contract SetupEpochTest is ValidatorSelectionTestBase {
   using Checkpoints for Checkpoints.Trace224;
   using stdStorage for StdStorage;
 
+  function computeSampleSeed(uint256 _epoch, uint256 _randao) internal pure returns (uint256) {
+    return uint256(keccak256(abi.encode(_epoch, _randao)));
+  }
+
   function test_WhenTheRollupDoesNotHaveTheTargetCommitteeSize() external setup(0, 48) {
     // it should not allow setting up any epoch
     // it should have the always seed set to max
@@ -27,22 +31,25 @@ contract SetupEpochTest is ValidatorSelectionTestBase {
     );
     rollup.setupEpoch();
 
+    // The foundry randao values are by default 0. So we lock it in here to easily use later.
+    uint256 randao = 0;
+
     // Read the sample seed for epoch 0 through the rollup contract
     uint256 sampleSeed = IValidatorSelection(address(rollup)).getCurrentSampleSeed();
-    assertEq(sampleSeed, type(uint224).max, "Sample seed for epoch0 should be max in genesis state");
+    assertEq(sampleSeed, computeSampleSeed(0, randao), "invalid sample seed for epoch0");
 
     // Read the sample seed for epoch 1 through the rollup contract
     Timestamp epoch1Timestamp =
       Timestamp.wrap(block.timestamp + TestConstants.AZTEC_EPOCH_DURATION * TestConstants.AZTEC_SLOT_DURATION);
     uint256 epoch1Seed = IValidatorSelection(address(rollup)).getSampleSeedAt(epoch1Timestamp);
-    assertEq(epoch1Seed, type(uint224).max, "Sample seed for epoch1 should be max in genesis state");
+    assertEq(epoch1Seed, computeSampleSeed(1, randao), "invalid sample seed for epoch1");
 
     // Read the sample seed for epoch 2 through the rollup contract
     Timestamp epoch2Timestamp =
       Timestamp.wrap(block.timestamp + 2 * TestConstants.AZTEC_EPOCH_DURATION * TestConstants.AZTEC_SLOT_DURATION);
     assertTrue(
-      IValidatorSelection(address(rollup)).getSampleSeedAt(epoch2Timestamp) == type(uint224).max,
-      "Epoch 2 seed should be max"
+      IValidatorSelection(address(rollup)).getSampleSeedAt(epoch2Timestamp) == computeSampleSeed(2, randao),
+      "invalid sample seed for epoch2"
     );
 
     // Advance into epoch 2
@@ -51,8 +58,8 @@ contract SetupEpochTest is ValidatorSelectionTestBase {
     // Read the sample seed for epoch 2 now that we are in epoch 2, it should not change
     assertEq(
       IValidatorSelection(address(rollup)).getCurrentSampleSeed(),
-      type(uint224).max,
-      "Epoch 2 seed should remain the same when re-reading"
+      computeSampleSeed(2, randao),
+      "sample seed for epoch 2 should remain the same when re-reading"
     );
 
     // Call setupEpoch again, from the current epoch it should not change the sample seed
@@ -63,18 +70,12 @@ contract SetupEpochTest is ValidatorSelectionTestBase {
     );
     rollup.setupEpoch();
 
-    assertEq(
-      IValidatorSelection(address(rollup)).getCurrentSampleSeed(),
-      type(uint224).max,
-      "Epoch 2 seed should not change when calling setupEpoch"
-    );
-
     // Seed for the epoch 4 should be set
     Timestamp epoch4Timestamp =
       Timestamp.wrap(block.timestamp + 2 * TestConstants.AZTEC_EPOCH_DURATION * TestConstants.AZTEC_SLOT_DURATION);
     assertTrue(
-      IValidatorSelection(address(rollup)).getSampleSeedAt(epoch4Timestamp) == type(uint224).max,
-      "Epoch 4 seed should be max"
+      IValidatorSelection(address(rollup)).getSampleSeedAt(epoch4Timestamp) == computeSampleSeed(4, randao),
+      "invalid sample seed for epoch4"
     );
   }
 
@@ -84,9 +85,9 @@ contract SetupEpochTest is ValidatorSelectionTestBase {
 
   function test_WhenTheSampleSeedHasBeenSet() external setup(4, 4) whenTheRollupHasTheTargetCommitteeSize {
     // it should not change the sample seed
-    // it should be calculate the same committee when looking into the past
-    // it should not change the commitee even when validators are added or removed
-    // it should not change the next seed
+    // it should calculate the same committee when looking into the past
+    // it should not change the committee even when validators are added or removed
+    // it should not change the next randao, but sample-seed should be updated
 
     Timestamp epoch2Timestamp =
       Timestamp.wrap(block.timestamp + 2 * TestConstants.AZTEC_EPOCH_DURATION * TestConstants.AZTEC_SLOT_DURATION);
@@ -97,7 +98,7 @@ contract SetupEpochTest is ValidatorSelectionTestBase {
 
     // Check that the initial epoch seed is set
     uint256 initialEpochSeed = IValidatorSelection(address(rollup)).getSampleSeedAt(Timestamp.wrap(block.timestamp));
-    assertEq(initialEpochSeed, type(uint224).max, "Sample seed for initial epoch should be max");
+    assertEq(initialEpochSeed, computeSampleSeed(2, block.prevrandao), "Sample seed for initial epoch should be max");
 
     // Get the initial committee
     address[] memory initialCommittee = IValidatorSelection(address(rollup)).getCurrentEpochCommittee();
@@ -150,6 +151,10 @@ contract SetupEpochTest is ValidatorSelectionTestBase {
 
     vm.warp(Timestamp.unwrap(epoch2Timestamp));
 
+    uint256 randaoFrom2 = uint224(uint256(keccak256("make da fake randao")));
+    vm.prevrandao(randaoFrom2);
+    assertEq(block.prevrandao, randaoFrom2, "prevrandao should be the same as the randao from 2");
+
     // it should use the most recent sample seed
     rollup.setupEpoch();
 
@@ -157,14 +162,14 @@ contract SetupEpochTest is ValidatorSelectionTestBase {
     uint256 nextEpochTimestamp =
       block.timestamp + 2 * TestConstants.AZTEC_EPOCH_DURATION * TestConstants.AZTEC_SLOT_DURATION;
     uint256 nextEpochSeed = IValidatorSelection(address(rollup)).getSampleSeedAt(Timestamp.wrap(nextEpochTimestamp));
-    assertGt(nextEpochSeed, 0, "Sample seed should be set for the next epoch");
+    assertEq(nextEpochSeed, computeSampleSeed(4, randaoFrom2), "1 invalid sample seed for next epoch");
 
     // Jump into the future, looking back, the returned sample seed should be the same for the next range of epochs
     uint256 savedTimestamp = block.timestamp;
     vm.warp(savedTimestamp + 2 * (TestConstants.AZTEC_EPOCH_DURATION * TestConstants.AZTEC_SLOT_DURATION));
 
     uint256 sampleSeedAfterJump = IValidatorSelection(address(rollup)).getCurrentSampleSeed();
-    assertEq(sampleSeedAfterJump, nextEpochSeed, "Sample seed should be the same");
+    assertEq(sampleSeedAfterJump, nextEpochSeed, "2 Sample seed should be the same");
 
     // Add some validators
     addNumberOfValidators(420_422, 2);
@@ -172,22 +177,29 @@ contract SetupEpochTest is ValidatorSelectionTestBase {
     // Jump further into the future
     vm.warp(savedTimestamp + 4 * (TestConstants.AZTEC_EPOCH_DURATION * TestConstants.AZTEC_SLOT_DURATION));
 
-    // Check that the sample seed has not changed
+    // Check that the sample seed has changed
     assertEq(
-      IValidatorSelection(address(rollup)).getCurrentSampleSeed(), nextEpochSeed, "Sample seed should not change"
+      IValidatorSelection(address(rollup)).getCurrentSampleSeed(),
+      computeSampleSeed(6, randaoFrom2),
+      "3 sample seed haven't changed"
     );
 
-    // Call setupEpoch, the sample seed should not change
+    // Call setupEpoch, the sample seed should not change even though the randao value will change
+    uint256 randaoFrom8 = 1234;
+    vm.prevrandao(randaoFrom8);
     rollup.setupEpoch();
     assertEq(
-      IValidatorSelection(address(rollup)).getCurrentSampleSeed(), nextEpochSeed, "Sample seed should not change"
+      IValidatorSelection(address(rollup)).getCurrentSampleSeed(),
+      computeSampleSeed(6, randaoFrom2),
+      "4 Sample seed should not change"
     );
 
     // The sample seed for the next epoch should have changed
     uint256 nextEpochTimestamp2 =
       block.timestamp + 2 * TestConstants.AZTEC_EPOCH_DURATION * TestConstants.AZTEC_SLOT_DURATION;
     uint256 nextEpochSeed2 = IValidatorSelection(address(rollup)).getSampleSeedAt(Timestamp.wrap(nextEpochTimestamp2));
-    assertNotEq(nextEpochSeed2, nextEpochSeed, "Sample seed for the next epoch should have changed");
+    assertEq(nextEpochSeed2, computeSampleSeed(8, randaoFrom8), "5 invalid sample seed for next epoch");
+    assertNotEq(nextEpochSeed2, nextEpochSeed, "5 Sample seed for the next epoch should have changed");
   }
 
   function test_WhenNewSampleSeedsAreAdded() external whenItHasBeenALongTimeSinceTheLastSampleSeedWasSet {

--- a/l1-contracts/test/validator-selection/setupSampleSeed.t.sol
+++ b/l1-contracts/test/validator-selection/setupSampleSeed.t.sol
@@ -20,7 +20,7 @@ contract SetupSampleSeedTest is ValidatorSelectionTestBase {
     vm.warp(
       block.timestamp + (_epochToTest - 1) * TestConstants.AZTEC_EPOCH_DURATION * TestConstants.AZTEC_SLOT_DURATION
     );
-    rollup.setupSeedSnapshotForNextEpoch();
+    rollup.checkpointRandao();
 
     // The sample seed should have been updated
     uint256 newSampleSeed = rollup.getSampleSeedAt(Timestamp.wrap(block.timestamp + timejump));

--- a/yarn-project/cli/src/cmds/l1/trigger_seed_snapshot.ts
+++ b/yarn-project/cli/src/cmds/l1/trigger_seed_snapshot.ts
@@ -24,7 +24,7 @@ export async function triggerSeedSnapshot({
   });
 
   log('Triggering seed snapshot for next epoch');
-  const txHash = await rollup.write.setupSeedSnapshotForNextEpoch();
+  const txHash = await rollup.write.checkpointRandao();
   log(`Sent! | Seed snapshot setup for next epoch | tx hash: ${txHash}`);
   const receipt = await client.waitForTransactionReceipt({ hash: txHash });
   log(`Done! | Seed snapshot setup for next epoch | tx hash: ${txHash} | status: ${receipt.status}`);


### PR DESCRIPTION
Updating the sample logic such that we store only the truncated randao values in the checkpoints and then at retrieval time computes the sample seed using the epoch as well.

Means that we don't have the "stale seed" issue to the same degree, but still allowing checkpointing the randao.