### PR TITLE
chore(docs): Add separator to netlify build command

### DIFF
--- a/barretenberg/docs/netlify.toml
+++ b/barretenberg/docs/netlify.toml
@@ -1,6 +1,6 @@
 [build]
   # Only build if changes are made in the docs directory
-  ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF barretenberg/docs"
+  ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF -- barretenberg/docs"
 
 # Redirect root to /docs
 [[redirects]]

--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -1,6 +1,6 @@
 [build]
   # Only build if changes are made in the docs directory
-  ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF docs"
+  ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF -- docs"
 
 [[redirects]]
     from = "/guides/smart_contracts/writing_contracts/initializers"


### PR DESCRIPTION
Netlify is building bb docs on every PR, likely due to an error in the `ignore` command. this is an attempt to fix that