### PR TITLE
chore: Clean up public input propagation in `acir_format`

### DIFF
--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_format.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_format.cpp
@@ -35,10 +35,15 @@ template class DSLBigInts<UltraCircuitBuilder>;
 template class DSLBigInts<MegaCircuitBuilder>;
 
 template <typename Builder>
-void handle_IPA_accumulation(Builder& builder,
-                             const std::vector<OpeningClaim<stdlib::grumpkin<Builder>>>& nested_ipa_claims,
-                             const std::vector<stdlib::Proof<Builder>>& nested_ipa_proofs,
-                             bool is_root_rollup);
+void perform_full_IPA_verification(Builder& builder,
+                                   const std::vector<OpeningClaim<stdlib::grumpkin<Builder>>>& nested_ipa_claims,
+                                   const std::vector<stdlib::Proof<Builder>>& nested_ipa_proofs);
+
+template <typename Builder>
+std::pair<OpeningClaim<stdlib::grumpkin<Builder>>, HonkProof> handle_IPA_accumulation(
+    Builder& builder,
+    const std::vector<OpeningClaim<stdlib::grumpkin<Builder>>>& nested_ipa_claims,
+    const std::vector<stdlib::Proof<Builder>>& nested_ipa_proofs);
 
 template <typename Builder> struct HonkRecursionConstraintsOutput {
     using PairingPoints = stdlib::recursion::PairingPoints<Builder>;
@@ -46,6 +51,40 @@ template <typename Builder> struct HonkRecursionConstraintsOutput {
     std::vector<OpeningClaim<stdlib::grumpkin<Builder>>> nested_ipa_claims;
     std::vector<stdlib::Proof<Builder>> nested_ipa_proofs;
     bool is_root_rollup = false;
+
+    void update(HonkRecursionConstraintOutput<Builder>& other, bool has_ipa_data)
+    {
+        // Update points accumulator
+        if (this->points_accumulator.has_data) {
+            this->points_accumulator.aggregate(other.points_accumulator);
+        } else {
+            this->points_accumulator = other.points_accumulator;
+        }
+
+        if (has_ipa_data) {
+            // Update ipa proofs and claims
+            this->nested_ipa_proofs.push_back(other.ipa_proof);
+            this->nested_ipa_claims.push_back(other.ipa_claim);
+        }
+    }
+
+    void update(HonkRecursionConstraintsOutput<Builder>& other, bool has_ipa_data)
+    {
+        // Update points accumulator
+        if (this->points_accumulator.has_data) {
+            this->points_accumulator.aggregate(other.points_accumulator);
+        } else {
+            this->points_accumulator = other.points_accumulator;
+        }
+
+        if (has_ipa_data) {
+            // Update ipa proofs and claims
+            this->nested_ipa_proofs.insert(
+                this->nested_ipa_proofs.end(), other.nested_ipa_proofs.begin(), other.nested_ipa_proofs.end());
+            this->nested_ipa_claims.insert(
+                this->nested_ipa_claims.end(), other.nested_ipa_claims.begin(), other.nested_ipa_claims.end());
+        }
+    }
 };
 
 template <typename Builder>
@@ -258,79 +297,133 @@ void build_constraints(Builder& builder, AcirProgram& program, const ProgramMeta
     }
 
     // RecursionConstraints
+    bool has_honk_recursion_constraints = !constraint_system.honk_recursion_constraints.empty();
+    bool has_avm_recursion_constraints = !constraint_system.avm_recursion_constraints.empty();
+    bool has_ivc_recursion_constraints = !constraint_system.ivc_recursion_constraints.empty();
+
     if constexpr (IsMegaBuilder<Builder>) {
-        if (!constraint_system.honk_recursion_constraints.empty()) {
-            HonkRecursionConstraintsOutput<Builder> output = process_honk_recursion_constraints(
-                builder, constraint_system, has_valid_witness_assignments, gate_counter);
-            output.points_accumulator.set_public();
-        }
-        if (!constraint_system.avm_recursion_constraints.empty()) {
+        // We shouldn't have both honk recursion constraints and ivc recursion constraints.
+        BB_ASSERT_EQ(!has_honk_recursion_constraints || !has_ivc_recursion_constraints,
+                     true,
+                     "Invalid circuit: both honk and ivc recursion constraints present.");
+
+        // AVM constraints are not handled when using MegaBuilder
+        if (has_avm_recursion_constraints) {
             info("WARNING: this circuit contains unhandled avm_recursion_constraints!");
         }
-        if (!constraint_system.ivc_recursion_constraints.empty()) {
+
+        if (has_honk_recursion_constraints) {
+            HonkRecursionConstraintsOutput<Builder> output = process_honk_recursion_constraints(
+                builder, constraint_system, has_valid_witness_assignments, gate_counter);
+
+            // Propagate pairing points
+            stdlib::recursion::honk::DefaultIO<Builder> inputs;
+            inputs.pairing_inputs = output.points_accumulator;
+            inputs.set_public();
+        } else if (has_ivc_recursion_constraints) {
             process_ivc_recursion_constraints(
                 builder, constraint_system, metadata.ivc, has_valid_witness_assignments, gate_counter);
-        }
-
-        // We shouldn't have both honk recursion constraints and ivc recursion constraints.
-        ASSERT(constraint_system.honk_recursion_constraints.empty() ||
-                   constraint_system.ivc_recursion_constraints.empty(),
-               "Invalid circuit: both honk and ivc recursion constraints present.");
-        // If its an app circuit that has no recursion constraints, add default pairing points to public inputs.
-        if (constraint_system.honk_recursion_constraints.empty() &&
-            constraint_system.ivc_recursion_constraints.empty()) {
+        } else {
+            // If its an app circuit that has no recursion constraints, add default pairing points to public inputs.
             stdlib::recursion::honk::AppIO::add_default(builder);
         }
     } else {
-        HonkRecursionConstraintsOutput<Builder> honk_output =
-            process_honk_recursion_constraints(builder, constraint_system, has_valid_witness_assignments, gate_counter);
+        BB_ASSERT_EQ(has_ivc_recursion_constraints,
+                     true,
+                     "Invalid circuit: ivc recursion constraints are present with UltraBuilder.");
+        BB_ASSERT_EQ(has_honk_recursion_constraints || !has_avm_recursion_constraints,
+                     true,
+                     "Invalid circuit: avm constraints are present but honk constraints are not.");
+
+        // Container for data to be propagated
+        HonkRecursionConstraintsOutput<Builder> honk_output;
+
+        if (has_honk_recursion_constraints) {
+            honk_output = process_honk_recursion_constraints(
+                builder, constraint_system, has_valid_witness_assignments, gate_counter);
+        }
 
 #ifndef DISABLE_AZTEC_VM
-        HonkRecursionConstraintsOutput<Builder> avm_output =
-            process_avm_recursion_constraints(builder, constraint_system, has_valid_witness_assignments, gate_counter);
+        HonkRecursionConstraintsOutput<Builder> avm_output;
 
-        // This is a little annoying, but we should probably be explicit about these things so that its obvious how the
-        // pairing points are being aggregated.
-        if (honk_output.points_accumulator.has_data) {
-            if (avm_output.points_accumulator.has_data) {
-                honk_output.points_accumulator.aggregate(avm_output.points_accumulator);
-            }
-        } else {
-            if (avm_output.points_accumulator.has_data) {
-                honk_output.points_accumulator = avm_output.points_accumulator;
-            }
+        if (has_avm_recursion_constraints) {
+            avm_output = process_avm_recursion_constraints(
+                builder, constraint_system, has_valid_witness_assignments, gate_counter);
+
+            // Update honk_output: append (potentially 0) ipa claims and proofs.
+            // If honk output has points accumulator, aggregate it with the one coming from the avm. Otherwise, override
+            // it with the avm's one.
+            honk_output.update(avm_output, /*has_ipa_data=*/!avm_output.nested_ipa_claims.empty());
         }
-        // Append the (potentially 0) ipa claims and proofs to honk_output
-        honk_output.nested_ipa_claims.insert(honk_output.nested_ipa_claims.end(),
-                                             avm_output.nested_ipa_claims.begin(),
-                                             avm_output.nested_ipa_claims.end());
-        honk_output.nested_ipa_proofs.insert(honk_output.nested_ipa_proofs.end(),
-                                             avm_output.nested_ipa_proofs.begin(),
-                                             avm_output.nested_ipa_proofs.end());
 #endif
-        // If the circuit has either honk or avm recursion constraints, add the aggregation object. Otherwise, add a
-        // default one if the circuit is recursive and honk_recursion is true.
-        if (!constraint_system.honk_recursion_constraints.empty() ||
-            !constraint_system.avm_recursion_constraints.empty()) {
-            ASSERT(metadata.honk_recursion != 0);
-            honk_output.points_accumulator.set_public();
-        } else if (metadata.honk_recursion != 0) {
-            // Make sure the verification key records the public input indices of the
-            // final recursion output.
-            PairingPoints::add_default_to_public_inputs(builder);
-        }
 
-        // Accumulate the IPA claims and set it to be public inputs
-        // Either we're proving with RollupHonk (honk_recursion=2) or its the root rollup.
-        if (metadata.honk_recursion == 2 || honk_output.is_root_rollup) {
-            handle_IPA_accumulation(
-                builder, honk_output.nested_ipa_claims, honk_output.nested_ipa_proofs, honk_output.is_root_rollup);
+        // Handle IPA
+        if (honk_output.is_root_rollup) {
+            perform_full_IPA_verification(builder, honk_output.nested_ipa_claims, honk_output.nested_ipa_proofs);
+        } else if (metadata.honk_recursion == 2) {
+            auto [ipa_claim, ipa_proof] =
+                handle_IPA_accumulation(builder, honk_output.nested_ipa_claims, honk_output.nested_ipa_proofs);
+
+            // Set proof
+            builder.ipa_proof = ipa_proof;
+
+            // IO
+            bb::stdlib::recursion::honk::RollupIO inputs;
+            inputs.pairing_inputs = (has_honk_recursion_constraints || has_avm_recursion_constraints)
+                                        ? honk_output.points_accumulator
+                                        : PairingPoints::default_pairing_points(builder);
+            inputs.ipa_claim = ipa_claim;
+            inputs.set_public();
         } else {
             // We shouldn't accidentally have IPA proofs otherwise.
             BB_ASSERT_EQ(
                 honk_output.nested_ipa_proofs.size(), static_cast<size_t>(0), "IPA proofs present when not expected.");
+
+            // If it is a recursive circuit, propagate pairing points
+            if (metadata.honk_recursion == 1) {
+                // IO
+                bb::stdlib::recursion::honk::DefaultIO<Builder> inputs;
+                inputs.pairing_inputs = (has_honk_recursion_constraints || has_avm_recursion_constraints)
+                                            ? honk_output.points_accumulator
+                                            : PairingPoints::default_pairing_points(builder);
+                inputs.set_public();
+            }
         }
     }
+} // namespace acir_format
+
+/**
+ * @brief Perform full recursive IPA verification
+ *
+ * @tparam Builder
+ * @param builder
+ * @param nested_ipa_claims
+ * @param nested_ipa_proofs
+ */
+template <typename Builder>
+void perform_full_IPA_verification(Builder& builder,
+                                   const std::vector<OpeningClaim<stdlib::grumpkin<Builder>>>& nested_ipa_claims,
+                                   const std::vector<stdlib::Proof<Builder>>& nested_ipa_proofs)
+{
+    using StdlibTranscript = bb::stdlib::recursion::honk::UltraStdlibTranscript;
+
+    BB_ASSERT_EQ(
+        nested_ipa_claims.size(), nested_ipa_proofs.size(), "Mismatched number of nested IPA claims and proofs.");
+    BB_ASSERT_EQ(nested_ipa_claims.size(), 2U, "Root rollup must have two nested IPA claims.");
+
+    OpeningClaim<stdlib::grumpkin<Builder>> final_ipa_claim;
+    HonkProof final_ipa_proof;
+
+    auto [ipa_claim, ipa_proof] = handle_IPA_accumulation(builder, nested_ipa_claims, nested_ipa_proofs);
+
+    // IPA verification
+    VerifierCommitmentKey<stdlib::grumpkin<Builder>> verifier_commitment_key(
+        &builder, 1 << CONST_ECCVM_LOG_N, VerifierCommitmentKey<curve::Grumpkin>(1 << CONST_ECCVM_LOG_N));
+
+    auto accumulated_ipa_transcript = std::make_shared<StdlibTranscript>();
+    accumulated_ipa_transcript->load_proof(stdlib::Proof<Builder>(builder, ipa_proof));
+    IPA<stdlib::grumpkin<Builder>>::full_verify_recursive(
+        verifier_commitment_key, ipa_claim, accumulated_ipa_transcript);
 }
 
 /**
@@ -340,21 +433,19 @@ void build_constraints(Builder& builder, AcirProgram& program, const ProgramMeta
  * @param builder
  * @param nested_ipa_claims
  * @param nested_ipa_proofs
- * @param is_root_rollup
  */
 template <typename Builder>
-void handle_IPA_accumulation(Builder& builder,
-                             const std::vector<OpeningClaim<stdlib::grumpkin<Builder>>>& nested_ipa_claims,
-                             const std::vector<stdlib::Proof<Builder>>& nested_ipa_proofs,
-                             bool is_root_rollup)
+std::pair<OpeningClaim<stdlib::grumpkin<Builder>>, HonkProof> handle_IPA_accumulation(
+    Builder& builder,
+    const std::vector<OpeningClaim<stdlib::grumpkin<Builder>>>& nested_ipa_claims,
+    const std::vector<stdlib::Proof<Builder>>& nested_ipa_proofs)
 {
     BB_ASSERT_EQ(
         nested_ipa_claims.size(), nested_ipa_proofs.size(), "Mismatched number of nested IPA claims and proofs.");
+
     OpeningClaim<stdlib::grumpkin<Builder>> final_ipa_claim;
     HonkProof final_ipa_proof;
-    if (is_root_rollup) {
-        BB_ASSERT_EQ(nested_ipa_claims.size(), 2U, "Root rollup must have two nested IPA claims.");
-    }
+
     if (nested_ipa_claims.size() == 2) {
         // If we have two claims, accumulate.
         CommitmentKey<curve::Grumpkin> commitment_key(1 << CONST_ECCVM_LOG_N);
@@ -366,26 +457,16 @@ void handle_IPA_accumulation(Builder& builder,
         ipa_transcript_2->load_proof(nested_ipa_proofs[1]);
         auto [ipa_claim, ipa_proof] = IPA<stdlib::grumpkin<Builder>>::accumulate(
             commitment_key, ipa_transcript_1, nested_ipa_claims[0], ipa_transcript_2, nested_ipa_claims[1]);
-        // If this is the root rollup, do full IPA verification
-        if (is_root_rollup) {
-            VerifierCommitmentKey<stdlib::grumpkin<Builder>> verifier_commitment_key(
-                &builder, 1 << CONST_ECCVM_LOG_N, VerifierCommitmentKey<curve::Grumpkin>(1 << CONST_ECCVM_LOG_N));
-            // do full IPA verification
-            auto accumulated_ipa_transcript = std::make_shared<StdlibTranscript>();
-            accumulated_ipa_transcript->load_proof(stdlib::Proof<Builder>(builder, ipa_proof));
-            IPA<stdlib::grumpkin<Builder>>::full_verify_recursive(
-                verifier_commitment_key, ipa_claim, accumulated_ipa_transcript);
-        } else {
-            final_ipa_claim = ipa_claim;
-            final_ipa_proof = ipa_proof;
-        }
+
+        final_ipa_claim = ipa_claim;
+        final_ipa_proof = ipa_proof;
     } else if (nested_ipa_claims.size() == 1) {
         // If we have one claim, just forward it along.
         final_ipa_claim = nested_ipa_claims[0];
         // This conversion looks suspicious but there's no need to make this an output of the circuit since
         // its a proof that will be checked anyway.
         final_ipa_proof = nested_ipa_proofs[0].get_value();
-    } else if (nested_ipa_claims.size() == 0) {
+    } else if (nested_ipa_claims.empty()) {
         // If we don't have any claims, we may need to inject a fake one if we're proving with
         // UltraRollupHonk, indicated by the manual setting of the honk_recursion metadata to 2.
         info("Proving with UltraRollupHonk but no IPA claims exist.");
@@ -398,15 +479,11 @@ void handle_IPA_accumulation(Builder& builder,
         // We don't support and shouldn't expect to support circuits with 3+ IPA recursive verifiers.
         throw_or_abort("Too many nested IPA claims to accumulate");
     }
-    // If we aren't in the root rollup, we should have an output IPA proof.
-    if (!is_root_rollup) {
-        BB_ASSERT_EQ(final_ipa_proof.size(), IPA_PROOF_LENGTH);
-        // Propagate the IPA claim via the public inputs of the outer circuit
-        // TODO(https://github.com/AztecProtocol/barretenberg/issues/1306): Determine the right
-        // location/entity to handle this IPA data propagation.
-        final_ipa_claim.set_public();
-        builder.ipa_proof = final_ipa_proof;
-    }
+
+    BB_ASSERT_EQ(final_ipa_proof.size(), IPA_PROOF_LENGTH);
+
+    // Return the IPA claim and proof
+    return { final_ipa_claim, final_ipa_proof };
 }
 
 template <typename Builder>
@@ -420,45 +497,30 @@ process_honk_recursion_constraints(Builder& builder,
     // Add recursion constraints
     size_t idx = 0;
     for (auto& constraint : constraint_system.honk_recursion_constraints) {
+        HonkRecursionConstraintOutput<Builder> honk_recursion_constraint;
+
         if (constraint.proof_type == HONK_ZK) {
-            auto honk_recursion_constraint = create_honk_recursion_constraints<UltraZKRecursiveFlavor_<Builder>>(
+            honk_recursion_constraint = create_honk_recursion_constraints<UltraZKRecursiveFlavor_<Builder>>(
                 builder, constraint, has_valid_witness_assignments);
-
-            if (output.points_accumulator.has_data) {
-                output.points_accumulator.aggregate(honk_recursion_constraint.points_accumulator);
-            } else {
-                output.points_accumulator = honk_recursion_constraint.points_accumulator;
-            }
-
         } else if (constraint.proof_type == HONK) {
-            auto honk_recursion_constraint = create_honk_recursion_constraints<UltraRecursiveFlavor_<Builder>>(
+            honk_recursion_constraint = create_honk_recursion_constraints<UltraRecursiveFlavor_<Builder>>(
                 builder, constraint, has_valid_witness_assignments);
-            if (output.points_accumulator.has_data) {
-                output.points_accumulator.aggregate(honk_recursion_constraint.points_accumulator);
-            } else {
-                output.points_accumulator = honk_recursion_constraint.points_accumulator;
-            }
         } else if (constraint.proof_type == ROLLUP_HONK || constraint.proof_type == ROOT_ROLLUP_HONK) {
             if constexpr (!IsUltraBuilder<Builder>) {
                 throw_or_abort("Rollup Honk proof type not supported on MegaBuilder");
             } else {
-                if (constraint.proof_type == ROOT_ROLLUP_HONK) {
-                    output.is_root_rollup = true;
-                }
-                auto honk_recursion_constraint =
-                    create_honk_recursion_constraints<UltraRollupRecursiveFlavor_<Builder>>(
-                        builder, constraint, has_valid_witness_assignments);
-                if (output.points_accumulator.has_data) {
-                    output.points_accumulator.aggregate(honk_recursion_constraint.points_accumulator);
-                } else {
-                    output.points_accumulator = honk_recursion_constraint.points_accumulator;
-                }
-                output.nested_ipa_claims.push_back(honk_recursion_constraint.ipa_claim);
-                output.nested_ipa_proofs.push_back(honk_recursion_constraint.ipa_proof);
+                honk_recursion_constraint = create_honk_recursion_constraints<UltraRollupRecursiveFlavor_<Builder>>(
+                    builder, constraint, has_valid_witness_assignments);
             }
         } else {
             throw_or_abort("Invalid Honk proof type");
         }
+
+        // Update output
+        output.update(honk_recursion_constraint,
+                      /*has_ipa_data=*/constraint.proof_type == ROLLUP_HONK ||
+                          constraint.proof_type == ROOT_ROLLUP_HONK);
+        output.is_root_rollup &= constraint.proof_type == ROOT_ROLLUP_HONK;
 
         gate_counter.track_diff(constraint_system.gates_per_opcode,
                                 constraint_system.original_opcode_indices.honk_recursion_constraints.at(idx++));
@@ -549,17 +611,11 @@ process_avm_recursion_constraints(Builder& builder,
     // Add recursion constraints
     size_t idx = 0;
     for (auto& constraint : constraint_system.avm_recursion_constraints) {
-        // TODO(https://github.com/AztecProtocol/barretenberg/issues/1303): Utilize the version of this method that
-        // employs the Goblinized AVM recursive verifier.
         HonkRecursionConstraintOutput<Builder> avm2_recursion_output =
             create_avm2_recursion_constraints_goblin(builder, constraint, has_valid_witness_assignments);
-        if (output.points_accumulator.has_data) {
-            output.points_accumulator.aggregate(avm2_recursion_output.points_accumulator);
-        } else {
-            output.points_accumulator = avm2_recursion_output.points_accumulator;
-        }
-        output.nested_ipa_claims.push_back(avm2_recursion_output.ipa_claim);
-        output.nested_ipa_proofs.push_back(avm2_recursion_output.ipa_proof);
+
+        // Update the output
+        output.update(avm2_recursion_output, /*has_ipa_data=*/true);
 
         gate_counter.track_diff(constraint_system.gates_per_opcode,
                                 constraint_system.original_opcode_indices.avm_recursion_constraints.at(idx++));

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_format.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_format.cpp
@@ -517,7 +517,7 @@ process_honk_recursion_constraints(Builder& builder,
         output.update(honk_recursion_constraint,
                       /*has_ipa_data=*/constraint.proof_type == ROLLUP_HONK ||
                           constraint.proof_type == ROOT_ROLLUP_HONK);
-        output.is_root_rollup &= constraint.proof_type == ROOT_ROLLUP_HONK;
+        output.is_root_rollup = constraint.proof_type == ROOT_ROLLUP_HONK;
 
         gate_counter.track_diff(constraint_system.gates_per_opcode,
                                 constraint_system.original_opcode_indices.honk_recursion_constraints.at(idx++));

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_format.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_format.cpp
@@ -408,9 +408,6 @@ void perform_full_IPA_verification(Builder& builder,
         nested_ipa_claims.size(), nested_ipa_proofs.size(), "Mismatched number of nested IPA claims and proofs.");
     BB_ASSERT_EQ(nested_ipa_claims.size(), 2U, "Root rollup must have two nested IPA claims.");
 
-    OpeningClaim<stdlib::grumpkin<Builder>> final_ipa_claim;
-    HonkProof final_ipa_proof;
-
     auto [ipa_claim, ipa_proof] = handle_IPA_accumulation(builder, nested_ipa_claims, nested_ipa_proofs);
 
     // IPA verification

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_format.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_format.cpp
@@ -328,11 +328,12 @@ void build_constraints(Builder& builder, AcirProgram& program, const ProgramMeta
             stdlib::recursion::honk::AppIO::add_default(builder);
         }
     } else {
+        bool is_recursive_circuit = metadata.honk_recursion != 0;
         BB_ASSERT_EQ(has_ivc_recursion_constraints,
                      false,
                      "Invalid circuit: ivc recursion constraints are present with UltraBuilder.");
-        BB_ASSERT_EQ(has_honk_recursion_constraints || has_avm_recursion_constraints,
-                     metadata.honk_recursion != 0,
+        BB_ASSERT_EQ(!(has_honk_recursion_constraints || has_avm_recursion_constraints) || is_recursive_circuit,
+                     true,
                      "Invalid circuit: honk or avm recursion constraints present but the circuit is not recursive.");
 
         // Container for data to be propagated

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_format.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_format.cpp
@@ -329,11 +329,8 @@ void build_constraints(Builder& builder, AcirProgram& program, const ProgramMeta
         }
     } else {
         BB_ASSERT_EQ(has_ivc_recursion_constraints,
-                     true,
+                     false,
                      "Invalid circuit: ivc recursion constraints are present with UltraBuilder.");
-        BB_ASSERT_EQ(has_honk_recursion_constraints || !has_avm_recursion_constraints,
-                     true,
-                     "Invalid circuit: avm constraints are present but honk constraints are not.");
 
         // Container for data to be propagated
         HonkRecursionConstraintsOutput<Builder> honk_output;

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/pairing_points.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/pairing_points.hpp
@@ -141,6 +141,33 @@ template <typename Builder_> struct PairingPoints {
     }
 
     /**
+     * @brief Generate default pairing points
+     *
+     * @param builder
+     */
+    static PairingPoints default_pairing_points(Builder& builder)
+    {
+        using field =
+            std::conditional_t<IsMegaBuilder<Builder>, goblin_field<Builder>, bigfield<Builder, bb::Bn254FqParams>>;
+
+        // TODO(https://github.com/AztecProtocol/barretenberg/issues/911): These are pairing points
+        // extracted from a valid proof. This is a workaround because we can't represent the point at
+        // infinity in biggroup yet.
+        field x0(fq("0x031e97a575e9d05a107acb64952ecab75c020998797da7842ab5d6d1986846cf"));
+        field y0(fq("0x178cbf4206471d722669117f9758a4c410db10a01750aebb5666547acf8bd5a4"));
+        field x1(fq("0x0f94656a2ca489889939f81e9c74027fd51009034b3357f0e91b8a11e7842c38"));
+        field y1(fq("0x1b52c2020d7464a0c80c0da527a08193fe27776f50224bd6fb128b46c1ddb67f"));
+
+        Group P0(x0, y0);
+        Group P1(x1, y1);
+
+        P0.convert_constant_to_fixed_witness(&builder);
+        P1.convert_constant_to_fixed_witness(&builder);
+
+        return { P0, P1 };
+    }
+
+    /**
      * @brief Adds default public inputs to the builder.
      * @details This should cost exactly 20 gates because there's 4 bigfield elements and each have 5 total
      * witnesses including the prime limb.
@@ -149,26 +176,10 @@ template <typename Builder_> struct PairingPoints {
      */
     static void add_default_to_public_inputs(Builder& builder)
     {
-        // TODO(https://github.com/AztecProtocol/barretenberg/issues/911): These are pairing points extracted from a
-        // valid proof. This is a workaround because we can't represent the point at infinity in biggroup yet.
-        bigfield<Builder, bb::Bn254FqParams> x0(
-            fq("0x031e97a575e9d05a107acb64952ecab75c020998797da7842ab5d6d1986846cf"));
-        bigfield<Builder, bb::Bn254FqParams> y0(
-            fq("0x178cbf4206471d722669117f9758a4c410db10a01750aebb5666547acf8bd5a4"));
-        bigfield<Builder, bb::Bn254FqParams> x1(
-            fq("0x0f94656a2ca489889939f81e9c74027fd51009034b3357f0e91b8a11e7842c38"));
-        bigfield<Builder, bb::Bn254FqParams> y1(
-            fq("0x1b52c2020d7464a0c80c0da527a08193fe27776f50224bd6fb128b46c1ddb67f"));
+        auto [P0, P1, _] = default_pairing_points(builder);
 
-        x0.convert_constant_to_fixed_witness(&builder);
-        y0.convert_constant_to_fixed_witness(&builder);
-        x1.convert_constant_to_fixed_witness(&builder);
-        y1.convert_constant_to_fixed_witness(&builder);
-
-        x0.set_public();
-        y0.set_public();
-        x1.set_public();
-        y1.set_public();
+        P0.set_public();
+        P1.set_public();
     }
 };
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/pairing_points.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/pairing_points.hpp
@@ -141,33 +141,6 @@ template <typename Builder_> struct PairingPoints {
     }
 
     /**
-     * @brief Generate default pairing points
-     *
-     * @param builder
-     */
-    static PairingPoints default_pairing_points(Builder& builder)
-    {
-        using field =
-            std::conditional_t<IsMegaBuilder<Builder>, goblin_field<Builder>, bigfield<Builder, bb::Bn254FqParams>>;
-
-        // TODO(https://github.com/AztecProtocol/barretenberg/issues/911): These are pairing points
-        // extracted from a valid proof. This is a workaround because we can't represent the point at
-        // infinity in biggroup yet.
-        field x0(fq("0x031e97a575e9d05a107acb64952ecab75c020998797da7842ab5d6d1986846cf"));
-        field y0(fq("0x178cbf4206471d722669117f9758a4c410db10a01750aebb5666547acf8bd5a4"));
-        field x1(fq("0x0f94656a2ca489889939f81e9c74027fd51009034b3357f0e91b8a11e7842c38"));
-        field y1(fq("0x1b52c2020d7464a0c80c0da527a08193fe27776f50224bd6fb128b46c1ddb67f"));
-
-        Group P0(x0, y0);
-        Group P1(x1, y1);
-
-        P0.convert_constant_to_fixed_witness(&builder);
-        P1.convert_constant_to_fixed_witness(&builder);
-
-        return { P0, P1 };
-    }
-
-    /**
      * @brief Adds default public inputs to the builder.
      * @details This should cost exactly 20 gates because there's 4 bigfield elements and each have 5 total
      * witnesses including the prime limb.
@@ -176,10 +149,26 @@ template <typename Builder_> struct PairingPoints {
      */
     static void add_default_to_public_inputs(Builder& builder)
     {
-        auto [P0, P1, _] = default_pairing_points(builder);
+        // TODO(https://github.com/AztecProtocol/barretenberg/issues/911): These are pairing points extracted from a
+        // valid proof. This is a workaround because we can't represent the point at infinity in biggroup yet.
+        bigfield<Builder, bb::Bn254FqParams> x0(
+            fq("0x031e97a575e9d05a107acb64952ecab75c020998797da7842ab5d6d1986846cf"));
+        bigfield<Builder, bb::Bn254FqParams> y0(
+            fq("0x178cbf4206471d722669117f9758a4c410db10a01750aebb5666547acf8bd5a4"));
+        bigfield<Builder, bb::Bn254FqParams> x1(
+            fq("0x0f94656a2ca489889939f81e9c74027fd51009034b3357f0e91b8a11e7842c38"));
+        bigfield<Builder, bb::Bn254FqParams> y1(
+            fq("0x1b52c2020d7464a0c80c0da527a08193fe27776f50224bd6fb128b46c1ddb67f"));
 
-        P0.set_public();
-        P1.set_public();
+        x0.convert_constant_to_fixed_witness(&builder);
+        y0.convert_constant_to_fixed_witness(&builder);
+        x1.convert_constant_to_fixed_witness(&builder);
+        y1.convert_constant_to_fixed_witness(&builder);
+
+        x0.set_public();
+        y0.set_public();
+        x1.set_public();
+        y1.set_public();
     }
 };
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/special_public_inputs/special_public_inputs.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/special_public_inputs/special_public_inputs.hpp
@@ -117,17 +117,17 @@ class KernelIO {
      */
     static void add_default(Builder& builder)
     {
-        PairingInputs::add_default_to_public_inputs(builder);
-        G1 kernel_return_data = DataBusDepot<Builder>::construct_default_commitment(builder);
-        kernel_return_data.set_public();
-        G1 app_return_data = DataBusDepot<Builder>::construct_default_commitment(builder);
-        app_return_data.set_public();
-        TableCommitments ecc_op_tables;
-        for (auto& table_commitment : ecc_op_tables) {
+        KernelIO inputs;
+
+        inputs.pairing_inputs = PairingInputs::default_pairing_points(builder);
+        inputs.kernel_return_data = DataBusDepot<Builder>::construct_default_commitment(builder);
+        inputs.app_return_data = DataBusDepot<Builder>::construct_default_commitment(builder);
+        for (auto& table_commitment : inputs.ecc_op_tables) {
             table_commitment = G1(DEFAULT_ECC_COMMITMENT);
             table_commitment.convert_constant_to_fixed_witness(&builder);
-            table_commitment.set_public();
         }
+
+        inputs.set_public();
     };
 };
 
@@ -177,7 +177,13 @@ template <typename Builder> class DefaultIO {
      * @brief Add default public inputs when they are not present
      *
      */
-    static void add_default(Builder& builder) { PairingInputs::add_default_to_public_inputs(builder); };
+    static void add_default(Builder& builder)
+    {
+        DefaultIO<Builder> inputs;
+        inputs.pairing_inputs = PairingInputs::default_pairing_points(builder);
+
+        inputs.set_public();
+    };
 };
 
 /**
@@ -304,10 +310,12 @@ template <class Builder_> class HidingKernelIO {
      */
     static void add_default(Builder& builder)
     {
-        PairingInputs::add_default_to_public_inputs(builder);
-        for (auto& table_commitment : default_ecc_op_tables(builder)) {
-            table_commitment.set_public();
-        }
+        HidingKernelIO<Builder> inputs;
+
+        inputs.pairing_inputs = PairingInputs::default_pairing_points(builder);
+        inputs.ecc_op_tables = default_ecc_op_tables(builder);
+
+        inputs.set_public();
     };
 };
 
@@ -364,10 +372,16 @@ class RollupIO {
      */
     static void add_default(Builder& builder)
     {
-        PairingInputs::add_default_to_public_inputs(builder);
+        RollupIO inputs;
         auto [stdlib_opening_claim, ipa_proof] = IPA<grumpkin<Builder>>::create_fake_ipa_claim_and_proof(builder);
-        stdlib_opening_claim.set_public();
+
+        // Add IPA proof
         builder.ipa_proof = ipa_proof;
+
+        inputs.pairing_inputs = PairingInputs::default_pairing_points(builder);
+        inputs.ipa_claim = stdlib_opening_claim;
+
+        inputs.set_public();
     };
 };
 


### PR DESCRIPTION
This PR restructures how we propagate public inputs in `acir_format`. There is no change to the circuits/vks, the code is only restructured to make it simpler too read.

This PR is in preparation for the introduction of recursive ClientIVC verification in noir, as the new structure of the code will make it easier to propagate the public inputs that come from recursive ClientIVC verification.