### PR TITLE
chore(docs): fixing docs previews

### DIFF
--- a/barretenberg/docs/netlify.toml
+++ b/barretenberg/docs/netlify.toml
@@ -1,6 +1,6 @@
 [build]
   # Only build if changes are made in the docs directory
-  ignore = "git diff --quiet origin/next HEAD -- barretenberg/docs"
+  ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF"
 
 # Redirect root to /docs
 [[redirects]]

--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -1,6 +1,6 @@
 [build]
   # Only build if changes are made in the docs directory
-  ignore = "git diff --quiet origin/next HEAD -- docs"
+  ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF"
 
 [[redirects]]
     from = "/guides/smart_contracts/writing_contracts/initializers"


### PR DESCRIPTION
Fixing docs previews for real. The issue was that we were specifying a path when it wasn't needed, since the netlify.toml is already in the folder where the check needs to be made.
