### PR TITLE
fix!: public call interaces do not returndatacopy if size is 0

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/context/public_context.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/public_context.nr
@@ -305,7 +305,12 @@ impl PublicContext {
         // Use success_copy to determine whether the call succeeded
         let success = success_copy();
 
-        let result_data = returndata_copy(0, returndata_size());
+        let rd_size = returndata_size();
+        let mut result_data: [Field] = [];
+        if rd_size > 0 {
+            // If there is return data, copy it
+            result_data = returndata_copy(0, rd_size);
+        }
         if !success {
             // Rethrow the revert data.
             avm_revert(result_data);
@@ -350,7 +355,12 @@ impl PublicContext {
         // Use success_copy to determine whether the call succeeded
         let success = success_copy();
 
-        let result_data = returndata_copy(0, returndata_size());
+        let rd_size = returndata_size();
+        let mut result_data: [Field] = [];
+        if rd_size > 0 {
+            // If there is return data, copy it
+            result_data = returndata_copy(0, rd_size);
+        }
         if !success {
             // Rethrow the revert data.
             avm_revert(result_data);


### PR DESCRIPTION
At the moment, the AVM circuit cannot handle rdcopy of size 0. I'm not sure if this changeset makes sense. Either way we need to either exceptionally halt in rdcopy if size is 0, or properly handle it in the circuit.