### PR TITLE
fix: replace “amount” with “token_id” in Update nft_contract.md

### DIFF
--- a/docs/docs/developers/tutorials/codealong/contract_tutorials/nft_contract.md
+++ b/docs/docs/developers/tutorials/codealong/contract_tutorials/nft_contract.md
@@ -219,11 +219,11 @@ This public function checks that the `token_id` is not 0 and does not already ex
 
 #include_code transfer_in_public /noir-projects/noir-contracts/contracts/app/nft_contract/src/main.nr rust
 
-##### Authorizing token spends (via authwits)
+##### Authorizing token transfers (via authwits)
 
-If the `msg_sender` is **NOT** the same as the account to debit from, the function checks that the account has authorized the `msg_sender` contract to debit tokens on its behalf. This check is done by computing the function selector that needs to be authorized, computing the hash of the message that the account contract has approved. This is a hash of the contract that is approved to spend (`context.msg_sender`), the token contract that can be spent from (`context.this_address()`), the `selector`, the account to spend from (`from`), the `amount` and a `nonce` to prevent multiple spends. This hash is passed to `assert_inner_hash_valid_authwit_public` to ensure that the Account Contract has approved tokens to be spent on it's behalf.
+If the `msg_sender` is **NOT** the same as the account to debit from, the function checks that the account has authorized the `msg_sender` contract to transfer the token on its behalf. This check is done by computing the function selector that needs to be authorized, computing the hash of the message that the account contract has approved. This is a hash of the contract that is approved to act (`context.msg_sender`), the token contract involved (`context.this_address()`), the `selector`, the account to transfer from (`from`), the **`token_id`**, and a `nonce` to prevent multiple uses. This hash is passed to `assert_inner_hash_valid_authwit_public` to ensure that the Account Contract has approved this transfer.
 
-If the `msg_sender` is the same as the account to debit from, the authorization check is bypassed and the function proceeds to update the public owner.
+If the `msg_sender` is the same as the account to transfer from, the authorization check is bypassed and the function proceeds to update the public owner.
 
 #### `finalize_transfer_to_private`
 


### PR DESCRIPTION

Summary
Fix a semantic error in the NFT contract tutorial: the authwit paragraph describes signing an amount, which is correct for fungible tokens but wrong for NFTs. For ERC-721, approvals/authorizations must be tied to a specific token_id (or a blanket operator approval), not an amount.

Changes
In the “Authorizing token spends (via authwits)” subsection under transfer_in_public:

Replace references to “spend/debit tokens” with “transfer the token” (NFT-accurate wording).

Replace amount with token_id in the list of fields included in the signed/hashed message.

Keep the rest of the flow unchanged.

Rationale
ERC-721 doesn’t have quantities; actions are for a specific tokenid.

Binding the signature to token_id prevents misuse/replay on a different NFT and matches developer expectations from transferFrom(from, to, tokenId) / approve(spender, tokenId).

Risk/Impact
Docs-only change; no code behavior altered.
Reduces reader confusion and prevents incorrect implementations derived from the tutorial.
