### PR TITLE
fix: Fix incorrect switch inside the field fuzzer

### DIFF
--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/field/field.fuzzer.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/field/field.fuzzer.hpp
@@ -916,7 +916,7 @@ template <typename Builder> class FieldBase {
         {
             (void)builder;
 
-            switch (VarianceRNG.next() % 9) {
+            switch (VarianceRNG.next() % 8) {
             case 0:
 #ifdef FUZZING_SHOW_INFORMATION
                 std::cout << "Construct via field_t" << std::endl;


### PR DESCRIPTION
This pr fixes a faulty `switch` statement in `stdlib_primitives_field_fuzzer`