### PR TITLE
chore(ci): remove `retry` from `aztec-up/scripts/run_test.sh`

### DIFF
--- a/aztec-up/scripts/run_test.sh
+++ b/aztec-up/scripts/run_test.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 trap 'docker rm -f $1 &>/dev/null' SIGINT SIGTERM EXIT
 docker rm -f $1 &>/dev/null || true
-retry docker pull aztecprotocol/dind
+docker pull aztecprotocol/dind
 docker run --rm \
   -d \
   --privileged \


### PR DESCRIPTION
This PR removes usage of `retry` from `aztec-up/scripts/run_test.sh` as this just causes the script to fail as `retry` is not defined.

I've spoken with Adam about this and he asked for me to help revert this change while he's on holiday.