### PR TITLE
feat: Add Single Validator RPC Method for Historical Data Retrieval

### DIFF
--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -95,7 +95,7 @@ import {
   type TxValidationResult,
 } from '@aztec/stdlib/tx';
 import { getPackageVersion } from '@aztec/stdlib/update-checker';
-import type { ValidatorsStats } from '@aztec/stdlib/validators';
+import type { SingleValidatorStats, ValidatorsStats } from '@aztec/stdlib/validators';
 import {
   Attributes,
   type TelemetryClient,
@@ -1123,6 +1123,14 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, Traceable {
 
   public getValidatorsStats(): Promise<ValidatorsStats> {
     return this.validatorsSentinel?.computeStats() ?? Promise.resolve({ stats: {}, slotWindow: 0 });
+  }
+
+  public getValidatorStats(
+    validatorAddress: EthAddress,
+    fromSlot?: bigint,
+    toSlot?: bigint,
+  ): Promise<SingleValidatorStats | undefined> {
+    return this.validatorsSentinel?.getValidatorStats(validatorAddress, fromSlot, toSlot) ?? Promise.resolve(undefined);
   }
 
   public async startSnapshotUpload(location: string): Promise<void> {

--- a/yarn-project/aztec-node/src/sentinel/store.ts
+++ b/yarn-project/aztec-node/src/sentinel/store.ts
@@ -101,7 +101,7 @@ export class SentinelStore {
     return histories;
   }
 
-  private async getHistory(address: EthAddress): Promise<ValidatorStatusHistory | undefined> {
+  public async getHistory(address: EthAddress): Promise<ValidatorStatusHistory | undefined> {
     const data = await this.historyMap.getAsync(address.toString());
     return data && this.deserializeHistory(data);
   }

--- a/yarn-project/stdlib/src/interfaces/aztec-node.test.ts
+++ b/yarn-project/stdlib/src/interfaces/aztec-node.test.ts
@@ -51,7 +51,7 @@ import { TxEffect } from '../tx/tx_effect.js';
 import { TxHash } from '../tx/tx_hash.js';
 import { TxReceipt } from '../tx/tx_receipt.js';
 import type { TxValidationResult } from '../tx/validator/tx_validator.js';
-import type { ValidatorsStats } from '../validators/types.js';
+import type { SingleValidatorStats, ValidatorsStats } from '../validators/types.js';
 import { MAX_RPC_LEN } from './api_limit.js';
 import { type AztecNode, AztecNodeApiSchema } from './aztec-node.js';
 import type { SequencerConfig } from './configs.js';
@@ -367,6 +367,51 @@ describe('AztecNodeApiSchema', () => {
     expect(response).toEqual(handler.validatorStats);
   });
 
+  it('getValidatorStats', async () => {
+    const validatorAddress = EthAddress.random();
+    handler.singleValidatorStats = {
+      validator: {
+        address: validatorAddress,
+        totalSlots: 5,
+        missedAttestations: { currentStreak: 0, count: 0 },
+        missedProposals: { currentStreak: 0, count: 0 },
+        history: [{ slot: 1n, status: 'block-mined' }],
+      },
+      allTimeProvenPerformance: [],
+      lastProcessedSlot: 10n,
+      initialSlot: 1n,
+      slotWindow: 100,
+    };
+
+    const response = await context.client.getValidatorStats(validatorAddress);
+    expect(response).toEqual(handler.singleValidatorStats);
+  });
+
+  it('getValidatorStats(non-existent)', async () => {
+    const response = await context.client.getValidatorStats(EthAddress.random());
+    expect(response).toBeUndefined();
+  });
+
+  it('getValidatorStats(with-time-range)', async () => {
+    const validatorAddress = EthAddress.random();
+    handler.singleValidatorStats = {
+      validator: {
+        address: validatorAddress,
+        totalSlots: 3,
+        missedAttestations: { currentStreak: 0, count: 0 },
+        missedProposals: { currentStreak: 0, count: 0 },
+        history: [{ slot: 5n, status: 'attestation-sent' }],
+      },
+      allTimeProvenPerformance: [],
+      lastProcessedSlot: 10n,
+      initialSlot: 5n,
+      slotWindow: 5,
+    };
+
+    const response = await context.client.getValidatorStats(validatorAddress, 5n, 10n);
+    expect(response).toEqual(handler.singleValidatorStats);
+  });
+
   it('simulatePublicCalls', async () => {
     const response = await context.client.simulatePublicCalls(Tx.random());
     expect(response).toBeInstanceOf(PublicSimulationOutput);
@@ -419,6 +464,7 @@ describe('AztecNodeApiSchema', () => {
 
 class MockAztecNode implements AztecNode {
   public validatorStats: ValidatorsStats | undefined;
+  public singleValidatorStats: SingleValidatorStats | undefined;
 
   constructor(private artifact: ContractArtifact) {}
 
@@ -654,6 +700,20 @@ class MockAztecNode implements AztecNode {
   }
   getValidatorsStats(): Promise<ValidatorsStats> {
     return Promise.resolve(this.validatorStats!);
+  }
+  getValidatorStats(
+    validatorAddress: EthAddress,
+    fromSlot?: bigint,
+    toSlot?: bigint,
+  ): Promise<SingleValidatorStats | undefined> {
+    expect(validatorAddress).toBeInstanceOf(EthAddress);
+    if (fromSlot !== undefined) {
+      expect(typeof fromSlot).toBe('bigint');
+    }
+    if (toSlot !== undefined) {
+      expect(typeof toSlot).toBe('bigint');
+    }
+    return Promise.resolve(this.singleValidatorStats);
   }
   simulatePublicCalls(tx: Tx, _enforceFeePayment = false): Promise<PublicSimulationOutput> {
     expect(tx).toBeInstanceOf(Tx);

--- a/yarn-project/stdlib/src/interfaces/aztec-node.ts
+++ b/yarn-project/stdlib/src/interfaces/aztec-node.ts
@@ -7,6 +7,7 @@ import {
   PUBLIC_DATA_TREE_HEIGHT,
 } from '@aztec/constants';
 import { type L1ContractAddresses, L1ContractAddressesSchema } from '@aztec/ethereum/l1-contract-addresses';
+import type { EthAddress } from '@aztec/foundation/eth-address';
 import type { Fr } from '@aztec/foundation/fields';
 import { createSafeJsonRpcClient, makeFetch } from '@aztec/foundation/json-rpc/client';
 import { MembershipWitness, SiblingPath } from '@aztec/foundation/trees';
@@ -48,8 +49,8 @@ import {
   TxValidationResultSchema,
   indexedTxSchema,
 } from '../tx/index.js';
-import { ValidatorsStatsSchema } from '../validators/schemas.js';
-import type { ValidatorsStats } from '../validators/types.js';
+import { SingleValidatorStatsSchema, ValidatorsStatsSchema } from '../validators/schemas.js';
+import type { SingleValidatorStats, ValidatorsStats } from '../validators/types.js';
 import { type ComponentsVersions, getVersioningResponseHandler } from '../versioning/index.js';
 import { MAX_RPC_BLOCKS_LEN, MAX_RPC_LEN, MAX_RPC_TXS_LEN } from './api_limit.js';
 import {
@@ -397,6 +398,13 @@ export interface AztecNode
   /** Returns stats for validators if enabled. */
   getValidatorsStats(): Promise<ValidatorsStats>;
 
+  /** Returns stats for a single validator if enabled. */
+  getValidatorStats(
+    validatorAddress: EthAddress,
+    fromSlot?: bigint,
+    toSlot?: bigint,
+  ): Promise<SingleValidatorStats | undefined>;
+
   /**
    * Simulates the public part of a transaction with the current state.
    * This currently just checks that the transaction execution succeeds.
@@ -576,6 +584,11 @@ export const AztecNodeApiSchema: ApiSchemaFor<AztecNode> = {
   getBlockHeader: z.function().args(optional(L2BlockNumberSchema)).returns(BlockHeader.schema.optional()),
 
   getValidatorsStats: z.function().returns(ValidatorsStatsSchema),
+
+  getValidatorStats: z
+    .function()
+    .args(schemas.EthAddress, optional(schemas.BigInt), optional(schemas.BigInt))
+    .returns(SingleValidatorStatsSchema.optional()),
 
   simulatePublicCalls: z.function().args(Tx.schema, optional(z.boolean())).returns(PublicSimulationOutput.schema),
 

--- a/yarn-project/stdlib/src/validators/schemas.ts
+++ b/yarn-project/stdlib/src/validators/schemas.ts
@@ -2,7 +2,13 @@ import { type ZodFor, schemas } from '@aztec/foundation/schemas';
 
 import { z } from 'zod';
 
-import type { ValidatorStats, ValidatorStatusHistory, ValidatorStatusInSlot, ValidatorsStats } from './types.js';
+import type {
+  SingleValidatorStats,
+  ValidatorStats,
+  ValidatorStatusHistory,
+  ValidatorStatusInSlot,
+  ValidatorsStats,
+} from './types.js';
 
 export const ValidatorStatusInSlotSchema = z.enum([
   'block-mined',
@@ -51,3 +57,17 @@ export const ValidatorsStatsSchema = z.object({
   initialSlot: schemas.BigInt.optional(),
   slotWindow: schemas.Integer,
 }) satisfies ZodFor<ValidatorsStats>;
+
+export const SingleValidatorStatsSchema = z.object({
+  validator: ValidatorStatsSchema,
+  allTimeProvenPerformance: z.array(
+    z.object({
+      missed: schemas.Integer,
+      total: schemas.Integer,
+      epoch: schemas.BigInt,
+    }),
+  ),
+  lastProcessedSlot: schemas.BigInt.optional(),
+  initialSlot: schemas.BigInt.optional(),
+  slotWindow: schemas.Integer,
+}) satisfies ZodFor<SingleValidatorStats>;

--- a/yarn-project/stdlib/src/validators/types.ts
+++ b/yarn-project/stdlib/src/validators/types.ts
@@ -37,3 +37,11 @@ export type ValidatorsStats = {
 };
 
 export type ValidatorsEpochPerformance = Record<`0x${string}`, { missed: number; total: number }>;
+
+export type SingleValidatorStats = {
+  validator: ValidatorStats;
+  allTimeProvenPerformance: { missed: number; total: number; epoch: bigint }[];
+  lastProcessedSlot?: bigint;
+  initialSlot?: bigint;
+  slotWindow: number;
+};


### PR DESCRIPTION
This is a squash of #16177 by @StoneMac65, since the external PR and the squash check seem to be causing issues with CI. Until we fix the underlying issue, let's see if we can get this merged via this PR.