### PR TITLE
refactor: minor oracles cleanup

### DIFF
--- a/yarn-project/pxe/src/contract_function_simulator/oracle/oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/oracle.ts
@@ -201,10 +201,9 @@ export class Oracle {
     return [witness.map(toACVMField)];
   }
 
-  // TODO(benesjan): This doesn't map to the underlying oracle name which is just ugly.
   async utilityGetPublicKeysAndPartialAddress([address]: ACVMField[]): Promise<ACVMField[][]> {
     const parsedAddress = AztecAddress.fromField(Fr.fromString(address));
-    const { publicKeys, partialAddress } = await this.typedOracle.utilityGetCompleteAddress(parsedAddress);
+    const { publicKeys, partialAddress } = await this.typedOracle.utilityGetPublicKeysAndPartialAddress(parsedAddress);
 
     return [[...publicKeys.toFields(), partialAddress].map(toACVMField)];
   }

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/typed_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/typed_oracle.ts
@@ -2,8 +2,9 @@ import type { L1_TO_L2_MSG_TREE_HEIGHT } from '@aztec/constants';
 import { Fr, Point } from '@aztec/foundation/fields';
 import type { FunctionSelector, NoteSelector } from '@aztec/stdlib/abi';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
-import type { CompleteAddress, ContractInstance } from '@aztec/stdlib/contract';
+import type { ContractInstance, PartialAddress } from '@aztec/stdlib/contract';
 import type { KeyValidationRequest } from '@aztec/stdlib/kernel';
+import type { PublicKeys } from '@aztec/stdlib/keys';
 import type { ContractClassLog, IndexedTaggingSecret } from '@aztec/stdlib/logs';
 import type { Note, NoteStatus } from '@aztec/stdlib/note';
 import { UtilityContext } from '@aztec/stdlib/oracle';
@@ -115,8 +116,10 @@ export abstract class TypedOracle {
     return Promise.reject(new OracleMethodNotAvailableError('utilityGetBlockHeader'));
   }
 
-  utilityGetCompleteAddress(_account: AztecAddress): Promise<CompleteAddress> {
-    return Promise.reject(new OracleMethodNotAvailableError('utilityGetCompleteAddress'));
+  utilityGetPublicKeysAndPartialAddress(
+    _account: AztecAddress,
+  ): Promise<{ publicKeys: PublicKeys; partialAddress: PartialAddress }> {
+    return Promise.reject(new OracleMethodNotAvailableError('utilityGetPublicKeysAndPartialAddress'));
   }
 
   utilityGetAuthWitness(_messageHash: Fr): Promise<Fr[] | undefined> {

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
@@ -3,9 +3,10 @@ import { Fr, Point } from '@aztec/foundation/fields';
 import { applyStringFormatting, createLogger } from '@aztec/foundation/log';
 import type { AuthWitness } from '@aztec/stdlib/auth-witness';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
-import type { CompleteAddress, ContractInstance } from '@aztec/stdlib/contract';
+import type { ContractInstance, PartialAddress } from '@aztec/stdlib/contract';
 import { siloNullifier } from '@aztec/stdlib/hash';
 import type { KeyValidationRequest } from '@aztec/stdlib/kernel';
+import type { PublicKeys } from '@aztec/stdlib/keys';
 import { IndexedTaggingSecret } from '@aztec/stdlib/logs';
 import type { NoteStatus } from '@aztec/stdlib/note';
 import { UtilityContext } from '@aztec/stdlib/oracle';
@@ -142,13 +143,18 @@ export class UtilityExecutionOracle extends TypedOracle {
   }
 
   /**
-   * Retrieve the complete address associated to a given address.
+   * Retrieve the public keys and partial address associated to a given address.
    * @param account - The account address.
-   * @returns A complete address associated with the input address.
-   * @throws An error if the account is not registered in the database.
+   * @returns The public keys and partial address associated with the input address.
    */
-  public override utilityGetCompleteAddress(account: AztecAddress): Promise<CompleteAddress> {
-    return this.executionDataProvider.getCompleteAddress(account);
+  public override async utilityGetPublicKeysAndPartialAddress(
+    account: AztecAddress,
+  ): Promise<{ publicKeys: PublicKeys; partialAddress: PartialAddress }> {
+    const completeAddress = await this.executionDataProvider.getCompleteAddress(account);
+    return {
+      publicKeys: completeAddress.publicKeys,
+      partialAddress: completeAddress.partialAddress,
+    };
   }
 
   /**

--- a/yarn-project/txe/src/oracle/txe_oracle.ts
+++ b/yarn-project/txe/src/oracle/txe_oracle.ts
@@ -438,7 +438,7 @@ export class TXE {
     return this.stateMachine.archiver.getBlockHeader(blockNumber);
   }
 
-  utilityGetCompleteAddress(account: AztecAddress) {
+  utilityGetPublicKeysAndPartialAddress(account: AztecAddress) {
     return Promise.resolve(this.accountDataProvider.getAccount(account));
   }
 
@@ -966,8 +966,7 @@ export class TXE {
 
     const noteCache = new ExecutionNoteCache(this.getTxRequestHash());
 
-    // TODO(benesjan): Fix stale 'context' name.
-    const context = new PrivateExecutionOracle(
+    const privateExecutionOracle = new PrivateExecutionOracle(
       argsHash,
       txContext,
       callContext,
@@ -992,7 +991,7 @@ export class TXE {
       from,
     );
 
-    context.privateStoreInExecutionCache(args, argsHash);
+    privateExecutionOracle.privateStoreInExecutionCache(args, argsHash);
 
     // Note: This is a slight modification of simulator.run without any of the checks. Maybe we should modify simulator.run with a boolean value to skip checks.
     let result: PrivateExecutionResult;
@@ -1000,7 +999,7 @@ export class TXE {
     try {
       executionResult = await executePrivateFunction(
         this.simulator,
-        context,
+        privateExecutionOracle,
         artifact,
         targetContractAddress,
         functionSelector,
@@ -1016,7 +1015,7 @@ export class TXE {
       );
       const publicFunctionsCalldata = await Promise.all(
         publicCallRequests.map(async r => {
-          const calldata = await context.privateLoadFromExecutionCache(r.calldataHash);
+          const calldata = await privateExecutionOracle.privateLoadFromExecutionCache(r.calldataHash);
           return new HashedValues(calldata, r.calldataHash);
         }),
       );

--- a/yarn-project/txe/src/txe_service/txe_service.ts
+++ b/yarn-project/txe/src/txe_service/txe_service.ts
@@ -488,7 +488,7 @@ export class TXEService {
     }
 
     const parsedAddress = addressFromSingle(address);
-    const { publicKeys, partialAddress } = await this.txe.utilityGetCompleteAddress(parsedAddress);
+    const { publicKeys, partialAddress } = await this.txe.utilityGetPublicKeysAndPartialAddress(parsedAddress);
     return toForeignCallResult([toArray([...publicKeys.toFields(), partialAddress])]);
   }
 


### PR DESCRIPTION
When working on the PR down the stack I've stumbled upon a couple minor code quality issues:
1. In the `Oracle` class we had `utilityGetPublicKeysAndPartialAddress` oracle but the handler in `TypedOracle` was called `utilityGetCompleteAddress` and it returned full complete address instead of just the public keys and the partial address. Since for the rest of the oracles the name and return value always matches this was confusing.
2. Updated a stale variable name in `TXE`.