### PR TITLE
test: Orderbook TXE tests

### DIFF
--- a/noir-projects/noir-contracts/contracts/app/amm_contract/src/test/test.nr
+++ b/noir-projects/noir-contracts/contracts/app/amm_contract/src/test/test.nr
@@ -9,9 +9,6 @@ global AUTHWIT_NONCE: Field = 1;
 global DEFAULT_AMOUNT_0_MIN: u128 = 0;
 global DEFAULT_AMOUNT_1_MIN: u128 = 0;
 
-// Note: Ideally this test would be split into 2 separate test cases - one for order creation and one for order
-// fulfillment, with the second test running on the state from the first test. Since this feature is not currently
-// supported, combining them into a single comprehensive test is the best approach.
 #[test]
 unconstrained fn add_liquidity_twice_and_remove_liquidity() {
     let (mut env, amm_address, token0_address, token1_address, liquidity_token_address, minter) =

--- a/noir-projects/noir-contracts/contracts/app/orderbook_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/orderbook_contract/src/main.nr
@@ -1,5 +1,6 @@
 mod config;
 mod order;
+mod test;
 
 use aztec::macros::aztec;
 
@@ -97,7 +98,7 @@ pub contract Orderbook {
         let maker_partial_note =
             Token::at(ask_token).prepare_private_balance_increase(maker).call(&mut context);
 
-        // We use the partial note's as the order ID. Because partial notes emit a nullifier when created they are
+        // We use the partial note as the order ID. Because partial notes emit a nullifier when created they are
         // unique, and so this guarantees that our order IDs are also unique without having to keep track of past
         // ones.
         let order_id = maker_partial_note.to_field();

--- a/noir-projects/noir-contracts/contracts/app/orderbook_contract/src/test/mod.nr
+++ b/noir-projects/noir-contracts/contracts/app/orderbook_contract/src/test/mod.nr
@@ -1,0 +1,2 @@
+mod test;
+pub(crate) mod utils;

--- a/noir-projects/noir-contracts/contracts/app/orderbook_contract/src/test/test.nr
+++ b/noir-projects/noir-contracts/contracts/app/orderbook_contract/src/test/test.nr
@@ -1,0 +1,190 @@
+use crate::{Orderbook, test::utils::setup};
+use aztec::{
+    protocol_types::{address::AztecAddress, traits::FromField},
+    test::helpers::authwit::add_private_authwit_from_call_interface,
+};
+use token::Token;
+use uint_note::uint_note::PartialUintNote;
+
+global BID_AMOUNT: u128 = 1000;
+global ASK_AMOUNT: u128 = 2000;
+global CREATE_ORDER_AUTHWIT_NONCE: Field = 1;
+global FULFILL_ORDER_AUTHWIT_NONCE: Field = 2;
+
+/// Checks the full flow of creating an order and fulfilling it.
+#[test]
+unconstrained fn full_flow() {
+    let (mut env, orderbook_address, token0_address, token1_address, minter) = setup();
+
+    // We create a contract account (as opposed to a light account) for the maker and taker to be able to use authwits.
+    let maker = env.create_contract_account();
+    let taker = env.create_contract_account();
+
+    let token0 = Token::at(token0_address);
+    let token1 = Token::at(token1_address);
+    let orderbook = Orderbook::at(orderbook_address);
+
+    // Mint tokens to maker and taker
+    env.call_private(minter, token0.mint_to_private(maker, BID_AMOUNT));
+    env.call_private(minter, token1.mint_to_private(taker, ASK_AMOUNT));
+
+    // ORDER CREATION
+    let transfer_call_interface =
+        token0.transfer_to_public(maker, orderbook_address, BID_AMOUNT, CREATE_ORDER_AUTHWIT_NONCE);
+    add_private_authwit_from_call_interface(maker, orderbook_address, transfer_call_interface);
+
+    let order_id = env.call_private(
+        maker,
+        orderbook.create_order(
+            token0_address,
+            token1_address,
+            BID_AMOUNT,
+            ASK_AMOUNT,
+            CREATE_ORDER_AUTHWIT_NONCE,
+        ),
+    );
+
+    // Get order and verify it's active
+    let (order, is_fulfilled) = env.simulate_utility(orderbook.get_order(order_id));
+
+    assert_eq(order.bid_amount, BID_AMOUNT);
+    assert_eq(order.ask_amount, ASK_AMOUNT);
+    assert_eq(order.bid_token_is_zero, true); // token0 -> token1
+    assert_eq(is_fulfilled, false);
+
+    // Verify that all maker's tokens were transferred to orderbook's public balance
+    assert_eq(env.view_public(token0.balance_of_public(orderbook_address)), BID_AMOUNT);
+    assert_eq(env.simulate_utility(token0.balance_of_private(maker)), 0);
+
+    // ORDER FULFILLMENT
+
+    // Convert order_id back to PartialUintNote as the orderbook does and then create authwit for taker to transfer ask
+    // tokens.
+    let maker_partial_note = PartialUintNote::from_field(order_id);
+    let fulfill_transfer_call_interface = token1.finalize_transfer_to_private_from_private(
+        taker,
+        maker_partial_note,
+        ASK_AMOUNT,
+        FULFILL_ORDER_AUTHWIT_NONCE,
+    );
+    add_private_authwit_from_call_interface(
+        taker,
+        orderbook_address,
+        fulfill_transfer_call_interface,
+    );
+
+    env.call_private(taker, orderbook.fulfill_order(order_id, FULFILL_ORDER_AUTHWIT_NONCE));
+
+    // Verify final balances
+    assert_eq(env.simulate_utility(token0.balance_of_private(maker)), 0);
+    assert_eq(env.simulate_utility(token1.balance_of_private(maker)), ASK_AMOUNT);
+    assert_eq(env.simulate_utility(token0.balance_of_private(taker)), BID_AMOUNT);
+    assert_eq(env.simulate_utility(token1.balance_of_private(taker)), 0);
+
+    // Get order and verify it's fulfilled
+    let (order, is_fulfilled) = env.simulate_utility(orderbook.get_order(order_id));
+
+    assert_eq(order.bid_amount, BID_AMOUNT);
+    assert_eq(order.ask_amount, ASK_AMOUNT);
+    assert_eq(order.bid_token_is_zero, true); // token0 -> token1
+    assert_eq(is_fulfilled, true);
+}
+
+#[test(should_fail_with = "ZERO_BID_AMOUNT")]
+unconstrained fn create_order_zero_bid_amount() {
+    let (mut env, orderbook_address, token0_address, token1_address, _minter) = setup();
+
+    let orderbook = Orderbook::at(orderbook_address);
+    let maker = env.create_light_account();
+
+    let _ = env.call_private(
+        maker,
+        orderbook.create_order(
+            token0_address,
+            token1_address,
+            0,
+            ASK_AMOUNT,
+            CREATE_ORDER_AUTHWIT_NONCE,
+        ),
+    );
+}
+
+#[test(should_fail_with = "ZERO_ASK_AMOUNT")]
+unconstrained fn create_order_zero_ask_amount() {
+    let (mut env, orderbook_address, token0_address, token1_address, _minter) = setup();
+
+    let maker = env.create_light_account();
+    let orderbook = Orderbook::at(orderbook_address);
+
+    let _ = env.call_private(
+        maker,
+        orderbook.create_order(
+            token0_address,
+            token1_address,
+            BID_AMOUNT,
+            0,
+            CREATE_ORDER_AUTHWIT_NONCE,
+        ),
+    );
+}
+
+#[test(should_fail_with = "BID_TOKEN_IS_INVALID")]
+unconstrained fn create_order_invalid_bid_token() {
+    let (mut env, orderbook_address, _token0_address, token1_address, _minter) = setup();
+
+    let maker = env.create_light_account();
+    let orderbook = Orderbook::at(orderbook_address);
+
+    let invalid_token = AztecAddress::from_field(999);
+
+    let _ = env.call_private(
+        maker,
+        orderbook.create_order(
+            invalid_token,
+            token1_address,
+            BID_AMOUNT,
+            ASK_AMOUNT,
+            CREATE_ORDER_AUTHWIT_NONCE,
+        ),
+    );
+}
+
+#[test(should_fail_with = "ASK_TOKEN_IS_INVALID")]
+unconstrained fn create_order_invalid_ask_token() {
+    let (mut env, orderbook_address, token0_address, _token1_address, _minter) = setup();
+
+    let maker = env.create_light_account();
+    let orderbook = Orderbook::at(orderbook_address);
+
+    let invalid_token = AztecAddress::from_field(999);
+
+    let _ = env.call_private(
+        maker,
+        orderbook.create_order(
+            token0_address,
+            invalid_token,
+            BID_AMOUNT,
+            ASK_AMOUNT,
+            CREATE_ORDER_AUTHWIT_NONCE,
+        ),
+    );
+}
+
+#[test(should_fail_with = "SAME_TOKEN_TRADE")]
+unconstrained fn create_order_same_tokens() {
+    let (mut env, orderbook_address, token0_address, _token1_address, _minter) = setup();
+
+    let maker = env.create_light_account();
+    let orderbook = Orderbook::at(orderbook_address);
+
+    let _ = env.call_private(
+        maker,
+        orderbook.create_order(
+            token0_address,
+            token0_address,
+            BID_AMOUNT,
+            ASK_AMOUNT,
+            CREATE_ORDER_AUTHWIT_NONCE,
+        ),
+    );
+}

--- a/noir-projects/noir-contracts/contracts/app/orderbook_contract/src/test/utils.nr
+++ b/noir-projects/noir-contracts/contracts/app/orderbook_contract/src/test/utils.nr
@@ -1,0 +1,44 @@
+use crate::Orderbook;
+use aztec::{
+    protocol_types::address::AztecAddress, test::helpers::test_environment::TestEnvironment,
+};
+use token::Token;
+
+// Sets up test env with orderbook with two tokens and a minter account.
+// TODO(#16560): Make it possible to return a contract instance directly from setup func
+pub(crate) unconstrained fn setup() -> (TestEnvironment, AztecAddress, AztecAddress, AztecAddress, AztecAddress) {
+    let mut env = TestEnvironment::new();
+
+    // Setup admin account
+    let admin = env.create_light_account();
+
+    // Deploy tokens
+    let token0_initializer = Token::interface().constructor(
+        admin,
+        "Token00000000000000000000000000",
+        "TK00000000000000000000000000000",
+        18,
+    );
+    let token0_address =
+        env.deploy("@token_contract/Token").with_public_initializer(admin, token0_initializer);
+
+    let token1_initializer = Token::interface().constructor(
+        admin,
+        "Token11111111111111111111111111",
+        "TK11111111111111111111111111111",
+        18,
+    );
+    let token1_address =
+        env.deploy("@token_contract/Token").with_public_initializer(admin, token1_initializer);
+
+    // Deploy orderbook contract
+    let orderbook_initializer = Orderbook::interface().constructor(token0_address, token1_address);
+    let orderbook_address =
+        env.deploy("Orderbook").with_public_initializer(admin, orderbook_initializer);
+
+    // The admin has the minter role. Since we only care about the minting capability in the tests, we return the admin
+    // address as 'minter' rather than 'admin'.
+    let minter = admin;
+
+    (env, orderbook_address, token0_address, token1_address, minter)
+}

--- a/yarn-project/end-to-end/src/e2e_orderbook.test.ts
+++ b/yarn-project/end-to-end/src/e2e_orderbook.test.ts
@@ -9,9 +9,10 @@ import { setup } from './fixtures/utils.js';
 
 const TIMEOUT = 120_000;
 
-// TODO(#14525): Write thorough Orderbook tests. Currently we test only a happy path here because we will migrate these
-// tests to TXE once TXE 2.0 is ready. Didn't write it in TXE now as there is no way to obtain public events and all of
-// TXE will be rewritten soon.
+// Unhappy path tests are written only in Noir.
+//
+// We keep this test around because it's the only TS test where we have async completion of a partial note (partial
+// note created in one tx and completed in another).
 describe('Orderbook', () => {
   jest.setTimeout(TIMEOUT);
 


### PR DESCRIPTION
Fixes #14525 

We didn't have the Orderbook thoroughly tested as when I implemented it TXE was not yet reasonable. Now it's reasonable so I decided to tackle this. Since AI is known to be good at tests I decided to gave it a try.

## AI experiment
This was the prompt + well curated the context window by opening the relevant tabs in Cursor:

> write the orderbook tests in noir-projects/noir-contracts/contracts/app/orderbook_contract/src/test.nr
> 
> note that the Orderbook contract accepts 2 token contracts on the input so you will need to deploy those first. Use the setup and setup and mint functionality from noir-projects/noir-contracts/contracts/app/token_contract/src/test/utils.nr.
> 
> From the orderbook you want to test the setup order and create order functions. There is also already a yarn-project/end-to-end/src/e2e_orderbook.test.ts test but that is written in TypeScript and noit Noir and it tests only the happy path. In the Noir tests I would also like to test unhappy paths. See tests in noir-projects/noir-contracts/contracts/app/token_contract/src/test/transfer_in_private.nr for inspiration on how to structure the Noir tests.

Overall it managed to implement it all. The only thing I need to help it with is that it didn't understand that it needs to refer the `token_contract` crate when deploying:

```diff
env.deploy("Token")
env.deploy("@token_contract/Token")
```

Would say this was caused by us not having enough examples and me not putting that into a context window.

Other than this it managed to resolve on its own one other issue (tried to mint with an account with token minter permissions).

The only other thing I did is that I nuked quite a few tests it did because it was for example testing that a function call fails when it doesn't have token transfer authwit provided. Felt like this is sufficient to have only in the token tests.

### Update on AI
Code quality was not great and had to redo quite a lot of stuff. That could be improved though if we had a proper reference (plenty of the style issues were present in the rest of our codebase).