### PR TITLE
feat: add web3signer to testnet releases

### DIFF
--- a/spartan/aztec-keystore/Chart.yaml
+++ b/spartan/aztec-keystore/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+name: aztec-mnemonic
+description: This chart derives private keys and addresses from a mnemonic
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+

--- a/spartan/aztec-keystore/templates/_helpers.tpl
+++ b/spartan/aztec-keystore/templates/_helpers.tpl
@@ -1,0 +1,7 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "aztec-keystore.serviceAccountName" -}}
+{{- .Values.serviceAccount.name | default (printf "%s-%s" .Release.Name "keystore") }}
+{{- end }}
+

--- a/spartan/aztec-keystore/templates/batchjob.yaml
+++ b/spartan/aztec-keystore/templates/batchjob.yaml
@@ -1,0 +1,100 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Release.Name }}-derive-accounts
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": hook-succeeded
+spec:
+  template:
+    spec:
+      serviceAccountName: {{ include "aztec-keystore.serviceAccountName" . }}
+      restartPolicy: OnFailure
+      volumes:
+        - name: shared
+          emptyDir: {}
+        {{- if .Values.mnemonic.fromSecret.name }}
+        - name: mnemonic
+          secret:
+            secretName: {{ .Values.mnemonic.fromSecret.name }}
+            items:
+              - key: {{ .Values.mnemonic.fromSecret.key | default "mnemonic" }}
+                path: mnemonic
+        {{- end }}
+      initContainers:
+        - name: derive
+          image: {{ printf "%s:%s" .Values.global.aztecImage.repository .Values.global.aztecImage.tag }}
+          imagePullPolicy: {{ .Values.global.aztecImage.pullPolicy }}
+          command:
+            - /bin/bash
+            - -c
+            - |
+              set -euo pipefail
+              NODES="{{ .Values.attesters.nodeCount }}"
+              ATTESTERS_PER_NODE="{{ .Values.attesters.attestersPerNode }}"
+              KEY_INDEX_START="{{ .Values.attesters.mnemonicStartIndex }}"
+
+              {{- if .Values.mnemonic.fromSecret.name }}
+              MNEMONIC="/mnemonic/mnemonic"
+              {{- else }}
+              MNEMONIC="{{ .Values.mnemonic.value }}"
+              {{- end }}
+
+              for ((i=0;i<NODES;i++)); do
+                KS_FILE=/shared/attesters/keystores/node_$i.yaml
+                ADDR_FILE=/shared/attesters/addresses/node_$i
+
+                mkdir -p $(dirname $KS_FILE) $(dirname $ADDR_FILE)
+
+                truncate -s 0 "$ADDR_FILE"
+                truncate -s 0 "$KS_FILE"
+
+                for ((j=0;j<ATTESTERS_PER_NODE;j++)); do
+                  idx=$((KEY_INDEX_START + ATTESTERS_PER_NODE * i + j))
+                  pk="$(cast wallet private-key --mnemonic "$MNEMONIC" --mnemonic-index "$idx")"
+                  addr="$(cast wallet address --private-key $pk)"
+
+                  [[ $j -gt 0 ]] && echo '---' >> "$KS_FILE"
+                  printf 'type: file-raw\nkeyType: SECP256K1\nprivateKey: %s\n' "$pk" >> "$KS_FILE"
+
+                  [[ $j -gt 0 ]] && printf ',' >> "$ADDR_FILE"
+                  printf '%s' "$addr" >> "$ADDR_FILE"
+                done
+
+                echo "Generated config for attesters on node $i"
+              done
+          volumeMounts:
+            - name: shared
+              mountPath: /shared
+            {{- if .Values.mnemonic.fromSecret.name }}
+            - name: mnemonic
+              mountPath: /mnemonic
+            {{- end }}
+      containers:
+        - name: publish
+          image: {{ printf "%s:%s" .Values.global.kubectlImage.repository .Values.global.kubectlImage.tag }}
+          imagePullPolicy: {{ .Values.global.kubectlImage.pullPolicy }}
+          env:
+            - name: K8S_NAMESPACE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          command:
+            - /bin/bash
+            - -c
+            - |
+              set -euo pipefail
+
+              ATTESTER_KEYSTORE_SECRET_NAME="{{ .Values.attesters.keyStoreSecret.name | default (printf "%s-%s" .Release.Name "attester-keystores") }}"
+
+              kubectl -n "$K8S_NAMESPACE_NAME" create secret generic "$ATTESTER_KEYSTORE_SECRET_NAME" \
+                --from-file /shared/attesters/keystores \
+                --dry-run=client -o yaml | kubectl apply -f -
+
+              ATTESTER_ADDRESS_CM_NAME="{{ .Values.attesters.addressConfigMap.name | default (printf "%s-%s" .Release.Name "attester-addresses") }}"
+              kubectl -n "$K8S_NAMESPACE_NAME" create configmap "$ATTESTER_ADDRESS_CM_NAME" \
+                --from-file /shared/attesters/addresses \
+                --dry-run=client -o yaml | kubectl apply -f -
+          volumeMounts:
+            - name: shared
+              mountPath: /shared

--- a/spartan/aztec-keystore/templates/rbac.yaml
+++ b/spartan/aztec-keystore/templates/rbac.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "aztec-keystore.serviceAccountName" . }}-role
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps","secrets"]
+    verbs: ["get", "create","update","patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "aztec-keystore.serviceAccountName" . }}-role-binding
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "aztec-keystore.serviceAccountName" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "aztec-keystore.serviceAccountName" . }}-role
+{{- end }}

--- a/spartan/aztec-keystore/templates/serviceaccount.yaml
+++ b/spartan/aztec-keystore/templates/serviceaccount.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "aztec-keystore.serviceAccountName" . }}
+  annotations:
+{{- toYaml .Values.serviceAccount.annotations | nindent 4 }}
+{{- end }}
+

--- a/spartan/aztec-keystore/values.yaml
+++ b/spartan/aztec-keystore/values.yaml
@@ -1,0 +1,35 @@
+global:
+  aztecImage:
+    repository: aztecprotocol/aztec
+    tag: latest
+    pullPolicy: Always
+  kubectlImage:
+    repository: bitnami/kubectl
+    tag: 1.33.4
+    pullPolicy: Always
+
+mnemonic:
+  value: ""
+  fromSecret:
+    name: ""
+    key: mnemonic
+
+
+attesters:
+  attestersPerNode: 1
+  nodeCount: 1
+  mnemonicStartIndex: 2000
+  keyStoreSecret:
+    create: true
+    name: "" # if empty name will be generated based on Release.Name
+  addressConfigMap:
+    create: true
+    name: "" # if empty name will be generated based on Release.Name
+
+# TODO: add publisher key support
+
+serviceAccount:
+  create: true
+  name: "" # leave empty to generate a name based on Release.Name
+  annotations: {}
+

--- a/spartan/aztec-node/templates/_pod-template.yaml
+++ b/spartan/aztec-node/templates/_pod-template.yaml
@@ -114,9 +114,8 @@ spec:
           mountPath: /shared
         - name: scripts
           mountPath: /scripts/
-        {{- if .Values.node.configMap.extraScriptsEnabled }}
-        - name: extra-scripts
-          mountPath: /extra-scripts/
+        {{- if .Values.node.extraVolumeMounts }}
+        {{- toYaml .Values.node.extraVolumeMounts | nindent 8 }}
         {{- end }}
         {{- if .Values.node.secret.filesEnabled }}
         - name: secrets
@@ -241,15 +240,13 @@ spec:
     - name: scripts
       configMap:
         name: {{ include "chart.fullname" . }}-scripts
-    {{- if .Values.node.configMap.extraScriptsEnabled }}
-    - name: extra-scripts
-      configMap:
-        name: {{ include "chart.fullname" . }}-extra-scripts
+    {{- if .Values.node.extraVolumes }}
+    {{- toYaml .Values.node.extraVolumes | nindent 4 }}
     {{- end }}
     {{- if .Values.node.secret.filesEnabled }}
     - name: config
       secret:
-        secretName: name: {{ include "chart.fullname" . }}-files
+        secretName: {{ include "chart.fullname" . }}-files
     {{- end }}
     {{- if .Values.persistence.enabled }}
     {{- if .Values.persistence.existingClaim }}

--- a/spartan/aztec-node/values.yaml
+++ b/spartan/aztec-node/values.yaml
@@ -81,9 +81,11 @@ node:
     configMapEnabled: false
     secretEnabled: false
 
+  extraVolumes: []
+  extraVolumeMounts: []
+
   configMap:
     envEnabled: false
-    extraScriptsEnabled: false
 
   secret:
     envEnabled: false

--- a/spartan/terraform/deploy-staging-testnet/values/staging-testnet-validator.yaml
+++ b/spartan/terraform/deploy-staging-testnet/values/staging-testnet-validator.yaml
@@ -33,8 +33,6 @@ validator:
   node:
     logLevel: "debug; info: aztec:simulator, json-rpc"
     preStartScript: |
-      source /scripts/get-private-key.sh
-
       until curl --silent --head --fail "${BOOT_NODE_HOST}/status" > /dev/null; do
         echo "Waiting for boot node..."
         sleep 1
@@ -42,6 +40,19 @@ validator:
       echo "Boot node is ready!"
 
       export BOOTSTRAP_NODES=$(curl -X POST --data '{"method": "bootstrap_getEncodedEnr"}' $BOOT_NODE_HOST | jq -r .result)
+
+      source /scripts/get-private-key.sh
+
+      # TODO: renable this code once staging has web3signer support
+      #if [[ -n "$WEB3_SIGNER_URL" ]]; then
+      #  POD_INDEX=$(echo $K8S_POD_NAME | awk -F'-' '{print $NF}')
+      #  KEY_INDEX=$((POD_INDEX * VALIDATORS_PER_NODE))
+      #  PUBLISHER_INDEX=$((KEY_INDEX_START + KEY_INDEX))
+      #  export L1_PRIVATE_KEY=$(cast wallet private-key --mnemonic "$MNEMONIC" --mnemonic-index $PUBLISHER_INDEX)
+      #  export WEB3_SIGNER_ADDRESSES="$(cat /addresses/node_$POD_INDEX)"
+      #else
+      #  source /scripts/get-private-key.sh
+      #fi
 
     env:
       SPONSORED_FPC: true

--- a/spartan/terraform/deploy-testnet/values/testnet-validator.yaml
+++ b/spartan/terraform/deploy-testnet/values/testnet-validator.yaml
@@ -34,6 +34,20 @@ validator:
           namespaceSelector: {}
 
   node:
+    preStartScript: |
+      source /scripts/get-private-key.sh
+
+      # TODO: renable this code once staging has web3signer support
+      #if [[ -n "$WEB3_SIGNER_URL" ]]; then
+      #  POD_INDEX=$(echo $K8S_POD_NAME | awk -F'-' '{print $NF}')
+      #  KEY_INDEX=$((POD_INDEX * VALIDATORS_PER_NODE))
+      #  PUBLISHER_INDEX=$((KEY_INDEX_START + KEY_INDEX))
+      #  export L1_PRIVATE_KEY=$(cast wallet private-key --mnemonic "$MNEMONIC" --mnemonic-index $PUBLISHER_INDEX)
+      #  export WEB3_SIGNER_ADDRESSES="$(cat /addresses/node_$POD_INDEX)"
+      #else
+      #  source /scripts/get-private-key.sh
+      #fi
+
     env:
       L1_FIXED_PRIORITY_FEE_PER_GAS: 3
       L1_TX_MONITOR_CANCEL_TX_ON_TIMEOUT: false

--- a/spartan/terraform/modules/web3signer/main.tf
+++ b/spartan/terraform/modules/web3signer/main.tf
@@ -1,0 +1,80 @@
+resource "helm_release" "keystore_setup" {
+  name             = "${var.RELEASE_NAME}-setup"
+  repository       = "../../"
+  chart            = "aztec-keystore"
+  namespace        = var.NAMESPACE
+  create_namespace = true
+  upgrade_install  = true
+
+  values = [
+    yamlencode({
+      global = {
+        aztecImage = {
+          repository = split(":", var.AZTEC_DOCKER_IMAGE)[0]
+          tag        = split(":", var.AZTEC_DOCKER_IMAGE)[1]
+        }
+        kubectlImage = {
+          repository = split(":", var.KUBECTL_DOCKER_IMAGE)[0]
+          tag        = split(":", var.KUBECTL_DOCKER_IMAGE)[1]
+        }
+      }
+      mnemonic = {
+        value = var.MNEMONIC
+      }
+      attesters = {
+        attestersPerNode   = var.ATTESTERS_PER_NODE
+        nodeCount          = var.NODE_COUNT
+        mnemonicStartIndex = var.MNEMONIC_INDEX_START
+        keyStoreSecret = {
+          create = true
+          name   = "${var.RELEASE_NAME}-keystore"
+        }
+
+        addressConfigMap = {
+          create = true
+          name   = var.ADDRESS_CONFIGMAP_NAME
+        }
+      }
+    })
+  ]
+
+  timeout       = 300
+  wait          = false
+  wait_for_jobs = false
+}
+
+resource "helm_release" "web3signer" {
+  name             = "${var.RELEASE_NAME}-signer"
+  repository       = "https://ethpandaops.github.io/ethereum-helm-charts"
+  chart            = "web3signer"
+  version          = "1.0.6"
+  namespace        = var.NAMESPACE
+  create_namespace = true
+  upgrade_install  = true
+
+  values = [
+    file("${path.module}/values/web3signer.yaml"),
+    yamlencode({
+      chainId = var.CHAIN_ID
+      image = {
+        repository = split(":", var.WEB3SIGNER_DOCKER_IMAGE)[0]
+        tag        = split(":", var.WEB3SIGNER_DOCKER_IMAGE)[1]
+      }
+      extraVolumes = [{
+        name = "keystore"
+        secret = {
+          secretName = "${var.RELEASE_NAME}-keystore"
+        }
+      }]
+      extraVolumeMounts = [{
+        name      = "keystore"
+        mountPath = "/keystore"
+      }]
+      keystorePath = "/keystore"
+    })
+  ]
+
+  timeout       = 300
+  wait          = false
+  wait_for_jobs = false
+}

--- a/spartan/terraform/modules/web3signer/outputs.tf
+++ b/spartan/terraform/modules/web3signer/outputs.tf
@@ -1,0 +1,9 @@
+output "web3signer_url" {
+  description = "URL to access the web3signer instance"
+  value       = "http://${var.RELEASE_NAME}-web3signer.${var.NAMESPACE}.svc.cluster.local:9000"
+}
+
+output "addresses_configmap_name" {
+  description = "ConfigMap name containing the published addresses"
+  value       = var.ADDRESS_CONFIGMAP_NAME
+}

--- a/spartan/terraform/modules/web3signer/values/web3signer.yaml
+++ b/spartan/terraform/modules/web3signer/values/web3signer.yaml
@@ -1,0 +1,26 @@
+replicas: 1
+
+image:
+  pullPolicy: Always
+
+slashingprotectiondb:
+  enabled: false
+
+customCommand:
+  - /bin/bash
+  - -c
+  - |
+    /opt/web3signer/bin/web3signer --config-file /data/config.yaml eth1 
+
+extraEnv:
+  - name: K8S_NAMESPACE_NAME
+    valueFrom:
+      fieldRef:
+        fieldPath: metadata.namespace
+
+config: |
+  data-path: "/data"
+  http-host-allowlist: "{{ .Release.Name }}-web3signer.{{ .Release.Namespace }}.svc.cluster.local"
+  key-store-path: {{ .Values.keystorePath }}
+  eth1.chain-id: {{ .Values.chainId }}
+

--- a/spartan/terraform/modules/web3signer/variables.tf
+++ b/spartan/terraform/modules/web3signer/variables.tf
@@ -1,0 +1,62 @@
+variable "NAMESPACE" {
+  description = "The namespace to deploy the signer into"
+  type        = string
+}
+
+variable "RELEASE_NAME" {
+  description = "The name of the release"
+  type        = string
+  default     = "signer"
+}
+
+variable "CHAIN_ID" {
+  description = "The chain ID of the target network"
+  type        = string
+}
+
+# TODO: switch to passing mnemonic by secret name (instead of value)
+# mount secret directly into pod through secret store CSI driver
+# https://cloud.google.com/secret-manager/docs/secret-manager-managed-csi-component
+variable "MNEMONIC" {
+  description = "The mnemonic to use for this deployment"
+  type        = string
+  sensitive   = true
+}
+
+variable "ADDRESS_CONFIGMAP_NAME" {
+  description = "Name of the ConfigMap where the addresses will be published"
+  type        = string
+}
+
+variable "ATTESTERS_PER_NODE" {
+  description = "Number of attester keys to derive"
+  type        = number
+}
+
+variable "NODE_COUNT" {
+  description = "Number of attester keys to derive"
+  type        = number
+}
+
+variable "MNEMONIC_INDEX_START" {
+  description = "Mnemonic index start for key derivation"
+  type        = number
+}
+
+variable "AZTEC_DOCKER_IMAGE" {
+  description = "The Aztec image to deploy"
+  type        = string
+  default     = "aztecprotocol/aztec:latest"
+}
+
+variable "WEB3SIGNER_DOCKER_IMAGE" {
+  description = "The web3signer image to use"
+  type        = string
+  default     = "consensys/web3signer:25.3.0"
+}
+
+variable "KUBECTL_DOCKER_IMAGE" {
+  description = "The kubectl image to use"
+  type        = string
+  default     = "bitnami/kubectl:1.33.4"
+}


### PR DESCRIPTION
This PR deploys an instance of web3signer to testnet and staging testnet.

`aztec-keystore` is a new Helm chart meant to derive all the private keys and addresses needed for an aztec deployment. It currently only derives the attester keys and it will be extended to support publisher private keys as well. The chart runs a batchjob at install and upgrade time that (securely) reads the mnemonic and creates a Secret containing all the private keys and a ConfigMap containing all the addresses (grouped by node).

The web3signer installation then mounts the Secret containing the keystores into memory while the attesters mount the ConfigMap and source the appropriate file (depending on their `POD_INDEX`)

Fix #16180

