### PR TITLE
chore: Removed pruning of the duplicate connections

### DIFF
--- a/yarn-project/p2p/src/services/peer-manager/peer_manager.test.ts
+++ b/yarn-project/p2p/src/services/peer-manager/peer_manager.test.ts
@@ -415,40 +415,6 @@ describe('PeerManager', () => {
       expect(mockLibP2PNode.hangUp).toHaveBeenCalledTimes(2);
     });
 
-    it('should disconnect from duplicate peers during heartbeat', async () => {
-      // Create a peer that will have duplicate connections
-      const peerId = await createSecp256k1PeerId();
-
-      // Create mock connections with different timestamps to simulate connections opened at different times
-      const oldestConnection = {
-        remotePeer: peerId,
-        timeline: { open: 1000 },
-        close: jest.fn(),
-      };
-      const duplicateConnection1 = {
-        remotePeer: peerId,
-        timeline: { open: 2000 },
-        close: jest.fn(),
-      };
-      const duplicateConnection2 = {
-        remotePeer: peerId,
-        timeline: { open: 3000 },
-        close: jest.fn(),
-      };
-      mockLibP2PNode.getConnections.mockReturnValue([duplicateConnection1, oldestConnection, duplicateConnection2]);
-
-      // Trigger heartbeat which should call pruneDuplicatePeers
-      await peerManager.heartbeat();
-
-      await sleep(100);
-
-      // Verify that the duplicate connections were closed
-      expect(duplicateConnection1.close).toHaveBeenCalled();
-      expect(duplicateConnection2.close).toHaveBeenCalled();
-      // Verify that the oldest connection was not closed
-      expect(oldestConnection.close).not.toHaveBeenCalled();
-    });
-
     it('should properly clean up peers on stop', async () => {
       mockLibP2PNode.getPeers.mockReturnValue([await createSecp256k1PeerId(), await createSecp256k1PeerId()]);
 
@@ -691,9 +657,6 @@ describe('PeerManager', () => {
       // Mock the pruneUnhealthyPeers method to return the connections unchanged
       // This ensures prioritizePeers gets the correct connections
       jest.spyOn(peerManager as any, 'pruneUnhealthyPeers').mockImplementation(connections => connections);
-
-      // Mock the pruneDuplicatePeers method to return the connections unchanged
-      jest.spyOn(peerManager as any, 'pruneDuplicatePeers').mockImplementation(connections => connections);
 
       // Trigger heartbeat which should call prioritizePeers
       await peerManager.heartbeat();


### PR DESCRIPTION
Removes pruning of "duplicate" peer connections. 
Libp2p manages this, but more importantly, it's perfectly fine to have multiple connections per peer. ([source](https://discuss.libp2p.io/t/random-walk-peer-discovery-adds-connections-to-same-peer/584))
Finally, choosing the most recent ones to remove seems somewhat arbitrary (i.e., why not prune the oldest).

With this change, the preferred gossip test hasn't flaked for me using `grind` at all.