### PR TITLE
chore(avm): setup bench with univariates

### DIFF
--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/benchmark/relations_acc.bench.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/benchmark/relations_acc.bench.cpp
@@ -5,10 +5,10 @@
 #include <tuple>
 
 #include "barretenberg/common/constexpr_utils.hpp"
+#include "barretenberg/polynomials/univariate.hpp"
 #include "barretenberg/relations/relation_parameters.hpp"
 #include "barretenberg/vm2/common/field.hpp"
 #include "barretenberg/vm2/constraining/flavor.hpp"
-#include "barretenberg/vm2/constraining/full_row.hpp"
 #include "barretenberg/vm2/generated/columns.hpp"
 
 using namespace benchmark;
@@ -16,14 +16,59 @@ using namespace bb::avm2;
 
 namespace {
 
-AvmFullRow get_random_row()
+// Using a row of MAX_PARTIAL_RELATION_LENGTH univariates is a better approximation of what proving does.
+// Benchmarking with this would then take into account any gains via the use of Accumulator::View.
+// However, compilation time for the benchmark becomes as long as for prover.cpp.
+#ifdef AVM_USE_UNIVARIATES
+
+struct FakeUnivariateAllEntities {
+    static constexpr size_t MAX_PARTIAL_RELATION_LENGTH = AvmFlavor::MAX_PARTIAL_RELATION_LENGTH;
+    using DataType = bb::Univariate<FF, MAX_PARTIAL_RELATION_LENGTH>;
+
+    DataType fixed_random_value;
+
+    FakeUnivariateAllEntities(const DataType& fixed_random_value)
+        : fixed_random_value(fixed_random_value)
+    {}
+    const DataType& get(ColumnAndShifts) const { return fixed_random_value; }
+};
+
+FakeUnivariateAllEntities get_random_row()
 {
-    AvmFullRow row;
-    for (size_t i = 0; i < NUM_COLUMNS_WITH_SHIFTS; i++) {
-        row.get(static_cast<ColumnAndShifts>(i)) = FF::random_element();
-    }
-    return row;
+    return FakeUnivariateAllEntities(FakeUnivariateAllEntities::DataType::random_element());
 }
+
+template <typename Relation> auto allocate_result()
+{
+    return typename Relation::SumcheckTupleOfUnivariatesOverSubrelations{};
+}
+
+// Otherwise, we use a fake row of FFs, which is closer to what check-circuit does.
+// This disregards any gains via the use of Accumulator::View.
+#else
+
+struct FakeAvmFullRow {
+    using DataType = FF;
+
+    FakeAvmFullRow(const FF& fixed_random_value)
+        : fixed_random_value(fixed_random_value)
+    {}
+    const FF& get(ColumnAndShifts) const { return fixed_random_value; }
+
+    FF fixed_random_value;
+};
+
+FakeAvmFullRow get_random_row()
+{
+    return FakeAvmFullRow(FF::random_element());
+}
+
+template <typename Relation> auto allocate_result()
+{
+    return typename Relation::SumcheckArrayOfValuesOverSubrelations{};
+}
+
+#endif // AVM_USE_UNIVARIATES
 
 bb::RelationParameters<FF> get_params()
 {
@@ -45,7 +90,7 @@ template <typename Relation> void BM_accumulate_relation(State& state)
     auto params = get_params();
     FF scaling_factor = 1;
 
-    typename Relation::SumcheckArrayOfValuesOverSubrelations result{};
+    auto result = allocate_result<Relation>();
 
     for (auto _ : state) {
         Relation::accumulate(result, row, params, scaling_factor);


### PR DESCRIPTION
Setting it up for later when we properly use `::View`.