### PR TITLE
chore: remove databus non-issue

### DIFF
--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/databus/databus.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/databus/databus.hpp
@@ -80,8 +80,6 @@ template <typename Builder> class databus {
  * default commitment value. We set the same value for the missing return data herein so that the commitments agree
  * and the corresponding consistency check will be satisfied in the kernel in which it's performed.
  *
- * TODO(https://github.com/AztecProtocol/barretenberg/issues/1138): scrutinize the use of a default value for
- * consistency of default databus commitments.
  * @tparam Builder
  */
 template <class Builder> class DataBusDepot {

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/field/field_conversion.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/field/field_conversion.hpp
@@ -168,6 +168,7 @@ template <typename Builder, typename T> std::vector<fr<Builder>> convert_to_bn25
     } else if constexpr (IsAnyOf<T, goblin_field<Builder>>) {
         return convert_goblin_fr_to_bn254_frs(val);
     } else if constexpr (IsAnyOf<T, bn254_element<Builder>>) {
+        // TODO(https://github.com/AztecProtocol/barretenberg/issues/1527): Consider handling point at infinity.
         using BaseField = bn254_element<Builder>::BaseField;
         auto fr_vec_x = convert_to_bn254_frs<Builder, BaseField>(val.x);
         auto fr_vec_y = convert_to_bn254_frs<Builder, BaseField>(val.y);

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/databus.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/databus.hpp
@@ -23,8 +23,9 @@ constexpr uint32_t PROPAGATED_DATABUS_COMMITMENTS_SIZE = PROPAGATED_DATABUS_COMM
  */
 struct BusVector {
 
-    // TODO(https://github.com/AztecProtocol/barretenberg/issues/1138): A default value added to every databus column to
-    // avoid the point at infinity commitment and to ensure the validity of the databus commitment consistency checks.
+    // A default value added to every databus column to avoid the point at infinity commitment and to ensure the
+    // validity of the databus commitment consistency checks. Note: in principle we could allow point at infinity
+    // default commitment but there is precedent for avoiding this by default.
     static constexpr bb::fr DEFAULT_VALUE = 25;
 
     /**

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/mega_circuit_builder.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/mega_circuit_builder.cpp
@@ -42,7 +42,6 @@ template <typename FF> void MegaCircuitBuilder_<FF>::add_mega_gates_to_ensure_al
 {
     // Add a single default value to all databus columns. Note: This value must be equal across all columns in order for
     // inter-circuit databus commitment checks to pass in IVC settings.
-    // TODO(https://github.com/AztecProtocol/barretenberg/issues/1138): Consider default value.
 
     // Create an arbitrary calldata read gate
     add_public_calldata(this->add_variable(BusVector::DEFAULT_VALUE));    // add one entry in calldata


### PR DESCRIPTION
Removes outdated [issue](https://github.com/AztecProtocol/barretenberg/issues/1138) that does not actually pose any problem. In particular, there is no problem with adding a default value to all databus columns and using the resulting commitment as the default for "unused" databus columns in circuits. This follows the pattern we use more generally to avoid all points at infinity by adding "default" gates in the circuit builders. This is not strictly necessary but is convenient. 

Adds an issue in the `field_conversion` library to determine whether there is a need to add support for serialization of points at infinity which is currently missing. 