### PR TITLE
make aes128 methods static

### DIFF
--- a/yarn-project/foundation/src/crypto/aes128/index.test.ts
+++ b/yarn-project/foundation/src/crypto/aes128/index.test.ts
@@ -3,11 +3,6 @@ import { createCipheriv, createDecipheriv, randomBytes } from 'crypto';
 import { Aes128 } from './index.js';
 
 describe('aes128', () => {
-  let aes128!: Aes128;
-
-  beforeAll(() => {
-    aes128 = new Aes128();
-  });
 
   // PKCS#7 padding
   const pad = (data: Buffer): Buffer => {
@@ -37,7 +32,7 @@ describe('aes128', () => {
     cipher.setAutoPadding(false);
     const expected = Buffer.concat([cipher.update(paddedData), cipher.final()]);
 
-    const result: Buffer = await aes128.encryptBufferCBC(data, iv, key);
+    const result: Buffer = await Aes128.encryptBufferCBC(data, iv, key);
 
     expect(result).toEqual(expected);
   });
@@ -57,7 +52,7 @@ describe('aes128', () => {
     decipher.setAutoPadding(false);
     const expected = removePadding(Buffer.concat([decipher.update(ciphertext), decipher.final()]));
 
-    const result: Buffer = await aes128.decryptBufferCBC(ciphertext, iv, key);
+    const result: Buffer = await Aes128.decryptBufferCBC(ciphertext, iv, key);
 
     expect(result).toEqual(expected);
   });

--- a/yarn-project/foundation/src/crypto/aes128/index.ts
+++ b/yarn-project/foundation/src/crypto/aes128/index.ts
@@ -13,7 +13,7 @@ export class Aes128 {
    * @param key - Key to encrypt with.
    * @returns Encrypted data.
    */
-  public async encryptBufferCBC(data: Uint8Array, iv: Uint8Array, key: Uint8Array) {
+  public static async encryptBufferCBC(data: Uint8Array, iv: Uint8Array, key: Uint8Array) {
     const rawLength = data.length;
     const numPaddingBytes = 16 - (rawLength % 16);
     const paddingBuffer = Buffer.alloc(numPaddingBytes);
@@ -36,7 +36,7 @@ export class Aes128 {
    * @param key - Key to decrypt with.
    * @returns Decrypted data.
    */
-  public async decryptBufferCBCKeepPadding(data: Uint8Array, iv: Uint8Array, key: Uint8Array): Promise<Buffer> {
+  public static async decryptBufferCBCKeepPadding(data: Uint8Array, iv: Uint8Array, key: Uint8Array): Promise<Buffer> {
     const api = await BarretenbergSync.initSingleton(process.env.BB_WASM_PATH);
     const paddedBuffer = Buffer.from(
       api.aesDecryptBufferCbc(new RawBuffer(data), new RawBuffer(iv), new RawBuffer(key), data.length),
@@ -51,7 +51,7 @@ export class Aes128 {
    * @param key - Key to decrypt with.
    * @returns Decrypted data.
    */
-  public async decryptBufferCBC(data: Uint8Array, iv: Uint8Array, key: Uint8Array) {
+  public static async decryptBufferCBC(data: Uint8Array, iv: Uint8Array, key: Uint8Array) {
     const paddedBuffer = await this.decryptBufferCBCKeepPadding(data, iv, key);
     const paddingToRemove = paddedBuffer[paddedBuffer.length - 1];
     return paddedBuffer.subarray(0, paddedBuffer.length - paddingToRemove);


### PR DESCRIPTION
### 🧾 Audit Context

All Aes128 methods can be static, which makes users of Aes128 writing more concise and clean code.

### 🛠️ Changes Made

change all methods in Aes128 to static

### ✅ Checklist

- [x] Audited all methods of the relevant module/class
- [x] Audited the interface of the module/class with other (relevant) components
- [ ] Documented existing functionality and any changes made (as per Doxygen requirements)
- [ ] Resolved and/or closed all issues/TODOs pertaining to the audited files
- [x] Confirmed and documented any security or other issues found (if applicable)
- [x] Verified that tests cover all critical paths (and added tests if necessary)
- [x] Updated audit tracking for the files audited (check the start of each file you audited)

### 📌 Notes for Reviewers
