### PR TITLE
feat: enable keystore config in k8s

### DIFF
--- a/spartan/aztec-network/templates/prover-node.yaml
+++ b/spartan/aztec-network/templates/prover-node.yaml
@@ -98,6 +98,10 @@ spec:
             - name: prover-node-data
               mountPath: {{ .Values.proverNode.dataDir }}
           env:
+            {{- if .Values.web3signer.enabled }}
+            - name: WEB3_SIGNER_URL
+              value: "http://{{ include "aztec-network.fullname" . }}-web3signer.{{ .Release.Namespace }}.svc.cluster.local:9000/"
+            {{- end }}
             - name: BOOTSTRAP_NODES
               value: "{{ .Values.aztec.bootstrapENRs }}"
             - name: REGISTRY_CONTRACT_ADDRESS

--- a/spartan/aztec-network/templates/web3signer.yaml
+++ b/spartan/aztec-network/templates/web3signer.yaml
@@ -67,6 +67,14 @@ spec:
               privateKey: "$pk"
               EOF
               done
+
+              prover_publisher=$(cast wallet private-key "$MNEMONIC" --mnemonic-index {{ .Values.aztec.proverKeyIndexStart }})
+              cat >> "$KS_FILE" <<EOF
+              ---
+              type: file-raw
+              keyType: SECP256K1
+              privateKey: "$prover_publisher"
+              EOF
           env:
             - name: MNEMONIC
               value: {{ .Values.aztec.l1DeploymentMnemonic | quote }}


### PR DESCRIPTION
This PR configures validators and provers in rc-1 deployment using the keystore spec.

~**DO NOT MERGE** until #16272 is merged. This PR was opened separately in order to avoid conflicts with next~ 
Added a flag that can be turned on after #16272 is merged