### PR TITLE
chore: Removed unused functions from ecdsa stdlib

### DIFF
--- a/barretenberg/cpp/src/barretenberg/stdlib/encryption/ecdsa/ecdsa.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/encryption/ecdsa/ecdsa.hpp
@@ -23,30 +23,9 @@ bool_t<Builder> ecdsa_verify_signature(const stdlib::byte_array<Builder>& messag
                                        const ecdsa_signature<Builder>& sig);
 
 template <typename Builder, typename Curve, typename Fq, typename Fr, typename G1>
-bool_t<Builder> ecdsa_verify_signature_noassert(const stdlib::byte_array<Builder>& message,
-                                                const G1& public_key,
-                                                const ecdsa_signature<Builder>& sig);
-
-template <typename Builder, typename Curve, typename Fq, typename Fr, typename G1>
 bool_t<Builder> ecdsa_verify_signature_prehashed_message_noassert(const stdlib::byte_array<Builder>& hashed_message,
                                                                   const G1& public_key,
                                                                   const ecdsa_signature<Builder>& sig);
-
-template <typename Builder>
-static ecdsa_signature<Builder> ecdsa_from_witness(Builder* ctx, const crypto::ecdsa_signature& input)
-{
-    std::vector<uint8_t> r_vec(std::begin(input.r), std::end(input.r));
-    std::vector<uint8_t> s_vec(std::begin(input.s), std::end(input.s));
-    std::vector<uint8_t> v_vec = { input.v }; // Create single-element vector for v
-    stdlib::byte_array<Builder> r(ctx, r_vec);
-    stdlib::byte_array<Builder> s(ctx, s_vec);
-    stdlib::byte_array<Builder> v(ctx, v_vec); // v is now a byte_array with size 1
-    ecdsa_signature<Builder> out;
-    out.r = r;
-    out.s = s;
-    out.v = v;
-    return out;
-}
 
 template <typename Builder> void generate_ecdsa_verification_test_circuit(Builder& builder, size_t num_iterations);
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/encryption/ecdsa/ecdsa.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/encryption/ecdsa/ecdsa.test.cpp
@@ -137,9 +137,15 @@ TEST(stdlib_ecdsa, ecdsa_verify_signature_noassert_succeed)
 
     curve_::byte_array_ct message(&builder, message_string);
 
+    stdlib::byte_array<Builder> hashed_message =
+        static_cast<stdlib::byte_array<Builder>>(stdlib::SHA256<Builder>::hash(message));
+
     curve_::bool_ct signature_result =
-        stdlib::ecdsa_verify_signature_noassert<Builder, curve_, curve_::fq_ct, curve_::bigfr_ct, curve_::g1_bigfr_ct>(
-            message, public_key, sig);
+        stdlib::ecdsa_verify_signature_prehashed_message_noassert<Builder,
+                                                                  curve_,
+                                                                  curve_::fq_ct,
+                                                                  curve_::bigfr_ct,
+                                                                  curve_::g1_bigfr_ct>(hashed_message, public_key, sig);
 
     EXPECT_EQ(signature_result.get_value(), true);
 
@@ -186,9 +192,15 @@ TEST(stdlib_ecdsa, ecdsa_verify_signature_noassert_fail)
 
     curve_::byte_array_ct message(&builder, message_string);
 
+    stdlib::byte_array<Builder> hashed_message =
+        static_cast<stdlib::byte_array<Builder>>(stdlib::SHA256<Builder>::hash(message));
+
     curve_::bool_ct signature_result =
-        stdlib::ecdsa_verify_signature_noassert<Builder, curve_, curve_::fq_ct, curve_::bigfr_ct, curve_::g1_bigfr_ct>(
-            message, public_key, sig);
+        stdlib::ecdsa_verify_signature_prehashed_message_noassert<Builder,
+                                                                  curve_,
+                                                                  curve_::fq_ct,
+                                                                  curve_::bigfr_ct,
+                                                                  curve_::g1_bigfr_ct>(hashed_message, public_key, sig);
 
     EXPECT_EQ(signature_result.get_value(), false);
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/encryption/ecdsa/ecdsa_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/encryption/ecdsa/ecdsa_impl.hpp
@@ -211,31 +211,6 @@ bool_t<Builder> ecdsa_verify_signature_prehashed_message_noassert(const stdlib::
 }
 
 /**
- * @brief Verify ECDSA signature. Returns 0 if signature fails (i.e. does not produce unsatisfiable constraints)
- *
- * @tparam Builder
- * @tparam Curve
- * @tparam Fq
- * @tparam Fr
- * @tparam G1
- * @param message
- * @param public_key
- * @param sig
- * @return bool_t<Builder>
- */
-template <typename Builder, typename Curve, typename Fq, typename Fr, typename G1>
-bool_t<Builder> ecdsa_verify_signature_noassert(const stdlib::byte_array<Builder>& message,
-                                                const G1& public_key,
-                                                const ecdsa_signature<Builder>& sig)
-{
-    stdlib::byte_array<Builder> hashed_message =
-        static_cast<stdlib::byte_array<Builder>>(stdlib::SHA256<Builder>::hash(message));
-
-    return ecdsa_verify_signature_prehashed_message_noassert<Builder, Curve, Fq, Fr, G1>(
-        hashed_message, public_key, sig);
-}
-
-/**
  * @brief Generate a simple ecdsa verification circuit for testing purposes
  *
  * @tparam Builder


### PR DESCRIPTION
Audit part 1: remove unused functions from ecdsa stdlib