### PR TITLE
chore!: Remove recovery byte from ecdsa signature in stdlib + add documentation

### DIFF
--- a/barretenberg/cpp/scripts/test_civc_standalone_vks_havent_changed.sh
+++ b/barretenberg/cpp/scripts/test_civc_standalone_vks_havent_changed.sh
@@ -11,7 +11,7 @@ cd ..
 # - Generate a hash for versioning: sha256sum bb-civc-inputs.tar.gz
 # - Upload the compressed results: aws s3 cp bb-civc-inputs.tar.gz s3://aztec-ci-artifacts/protocol/bb-civc-inputs-[hash(0:8)].tar.gz
 # Note: In case of the "Test suite failed to run ... Unexpected token 'with' " error, need to run: docker pull aztecprotocol/build:3.0
-pinned_short_hash="251cc432"
+pinned_short_hash="93eaa5ec"
 pinned_civc_inputs_url="https://aztec-ci-artifacts.s3.us-east-2.amazonaws.com/protocol/bb-civc-inputs-${pinned_short_hash}.tar.gz"
 
 function compress_and_upload {

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/ecdsa_secp256k1.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/ecdsa_secp256k1.cpp
@@ -60,11 +60,9 @@ void create_ecdsa_k1_verify_constraints(Builder& builder,
 
     std::vector<uint8_t> rr(new_sig.r.begin(), new_sig.r.end());
     std::vector<uint8_t> ss(new_sig.s.begin(), new_sig.s.end());
-    std::vector<uint8_t> vv = { new_sig.v };
 
     stdlib::ecdsa_signature<Builder> sig{ stdlib::byte_array<Builder>(&builder, rr),
-                                          stdlib::byte_array<Builder>(&builder, ss),
-                                          stdlib::byte_array<Builder>(&builder, vv) };
+                                          stdlib::byte_array<Builder>(&builder, ss) };
 
     pub_key_x_fq.assert_is_in_field();
     pub_key_y_fq.assert_is_in_field();

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/ecdsa_secp256r1.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/ecdsa_secp256r1.cpp
@@ -58,11 +58,9 @@ void create_ecdsa_r1_verify_constraints(Builder& builder,
 
     std::vector<uint8_t> rr(new_sig.r.begin(), new_sig.r.end());
     std::vector<uint8_t> ss(new_sig.s.begin(), new_sig.s.end());
-    std::vector<uint8_t> vv = { new_sig.v };
 
     stdlib::ecdsa_signature<Builder> sig{ stdlib::byte_array<Builder>(&builder, rr),
-                                          stdlib::byte_array<Builder>(&builder, ss),
-                                          stdlib::byte_array<Builder>(&builder, vv) };
+                                          stdlib::byte_array<Builder>(&builder, ss) };
 
     pub_key_x_fq.assert_is_in_field();
     pub_key_y_fq.assert_is_in_field();

--- a/barretenberg/cpp/src/barretenberg/solidity_helpers/circuits/ecdsa_circuit.hpp
+++ b/barretenberg/cpp/src/barretenberg/solidity_helpers/circuits/ecdsa_circuit.hpp
@@ -67,12 +67,10 @@ class EcdsaCircuit {
 
         std::vector<uint8_t> rr(signature.r.begin(), signature.r.end());
         std::vector<uint8_t> ss(signature.s.begin(), signature.s.end());
-        std::vector<uint8_t> vv = { signature.v };
 
         // IN CIRCUIT: create a witness with the sig in our circuit
         stdlib::ecdsa_signature<Builder> sig{ typename curve::byte_array_ct(&builder, rr),
-                                              typename curve::byte_array_ct(&builder, ss),
-                                              typename curve::byte_array_ct(&builder, vv) };
+                                              typename curve::byte_array_ct(&builder, ss) };
 
         // IN CIRCUIT: verify the signature
         typename curve::bool_ct signature_result = stdlib::ecdsa_verify_signature<Builder,

--- a/barretenberg/cpp/src/barretenberg/stdlib/encryption/ecdsa/ecdsa.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/encryption/ecdsa/ecdsa.hpp
@@ -14,7 +14,6 @@ namespace bb::stdlib {
 template <typename Builder> struct ecdsa_signature {
     stdlib::byte_array<Builder> r;
     stdlib::byte_array<Builder> s;
-    stdlib::byte_array<Builder> v; // v is single byte (byte_array of size 1)
 };
 
 template <typename Builder, typename Curve, typename Fq, typename Fr, typename G1>

--- a/barretenberg/cpp/src/barretenberg/stdlib/encryption/ecdsa/ecdsa.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/encryption/ecdsa/ecdsa.test.cpp
@@ -36,11 +36,11 @@ TEST(stdlib_ecdsa, verify_signature)
 
     std::vector<uint8_t> rr(signature.r.begin(), signature.r.end());
     std::vector<uint8_t> ss(signature.s.begin(), signature.s.end());
-    std::vector<uint8_t> vv = { signature.v };
 
-    stdlib::ecdsa_signature<Builder> sig{ curve_::byte_array_ct(&builder, rr),
-                                          curve_::byte_array_ct(&builder, ss),
-                                          curve_::byte_array_ct(&builder, vv) };
+    stdlib::ecdsa_signature<Builder> sig{
+        curve_::byte_array_ct(&builder, rr),
+        curve_::byte_array_ct(&builder, ss),
+    };
 
     curve_::byte_array_ct message(&builder, message_string);
 
@@ -81,11 +81,8 @@ TEST(stdlib_ecdsa, verify_r1_signature)
 
     std::vector<uint8_t> rr(signature.r.begin(), signature.r.end());
     std::vector<uint8_t> ss(signature.s.begin(), signature.s.end());
-    std::vector<uint8_t> vv = { signature.v };
 
-    stdlib::ecdsa_signature<Builder> sig{ curveR1::byte_array_ct(&builder, rr),
-                                          curveR1::byte_array_ct(&builder, ss),
-                                          curveR1::byte_array_ct(&builder, vv) };
+    stdlib::ecdsa_signature<Builder> sig{ curveR1::byte_array_ct(&builder, rr), curveR1::byte_array_ct(&builder, ss) };
 
     curveR1::byte_array_ct message(&builder, message_string);
 
@@ -127,13 +124,8 @@ TEST(stdlib_ecdsa, ecdsa_verify_signature_noassert_succeed)
 
     std::vector<uint8_t> rr(signature.r.begin(), signature.r.end());
     std::vector<uint8_t> ss(signature.s.begin(), signature.s.end());
-    std::vector<uint8_t> vv = { signature.v };
 
-    stdlib::ecdsa_signature<Builder> sig{
-        curve_::byte_array_ct(&builder, rr),
-        curve_::byte_array_ct(&builder, ss),
-        curve_::byte_array_ct(&builder, vv),
-    };
+    stdlib::ecdsa_signature<Builder> sig{ curve_::byte_array_ct(&builder, rr), curve_::byte_array_ct(&builder, ss) };
 
     curve_::byte_array_ct message(&builder, message_string);
 
@@ -184,11 +176,8 @@ TEST(stdlib_ecdsa, ecdsa_verify_signature_noassert_fail)
 
     std::vector<uint8_t> rr(signature.r.begin(), signature.r.end());
     std::vector<uint8_t> ss(signature.s.begin(), signature.s.end());
-    std::vector<uint8_t> vv = { 27 }; // Use a valid recovery id
 
-    stdlib::ecdsa_signature<Builder> sig{ curve_::byte_array_ct(&builder, rr),
-                                          curve_::byte_array_ct(&builder, ss),
-                                          curve_::byte_array_ct(&builder, vv) };
+    stdlib::ecdsa_signature<Builder> sig{ curve_::byte_array_ct(&builder, rr), curve_::byte_array_ct(&builder, ss) };
 
     curve_::byte_array_ct message(&builder, message_string);
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/encryption/ecdsa/ecdsa_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/encryption/ecdsa/ecdsa_impl.hpp
@@ -11,32 +11,6 @@
 #include "barretenberg/stdlib/hash/sha256/sha256.hpp"
 #include "barretenberg/stdlib/primitives/curves/secp256k1.hpp"
 
-/**
- * Fix the following notation:
- *  1. \$E\$ is an elliptic curve over the base field \$\mathbb{F}_q\$.
- *  2. \$G\$ is a generator of the group of points of \$E\$, the order of \$G\$ is \$n\$.
- *  3. \$a \in \mathbb{F}_n^{\ast}$ is a private key, and \$P := aG\$ is the associated public key
- *  4. \$\mathcal{H}\$ is a hash function
- *
- * Given a message \$m\$, a couple \$(r,s)\$ is a valid signature for the message \$m\$ with respect to the public key
- * \$P\$ if:
- *  1. \$P\$ is a point on \$E\$
- *  2. \$0 < r < n\$
- *  3. \$0 < s < (n+1) / 2\$
- *  4. Define \$e := \mathcal{H}(m) mod n$ and \$Q := e s^{-1} G + r s^{-1} P \$
- *  5. \$Q\$ is not the point at infinity AND \$Q_x = r mod n\$ (note that \$Q_x \in \mathbb{F}_q\$)
- *
- * @note The requirement of step 2. is to avoid transaction malleability: if \$(r,s)\$ is a valid signature for message
- * \$m\$ and public key \$P\$, so is \$(r,n-s)\$. We protect against malleability by enforcing that \$s\$ is always the
- * lowest of the two possible values.
- *
- * @note In Ethereum signatures contain also a recovery byte \$v\$ which is used to recover the public key for which
- * the signature is to be validated. As we receive the public key as part of the inputs to the verification function, we
- * do not handle the recovery byte. The signature which is the input to the verification function is given by \$(r,s)\$.
- * The users of the verification function should handle the recovery byte if that is in their interest.
- *
- */
-
 namespace bb::stdlib {
 
 namespace {
@@ -45,6 +19,29 @@ auto& engine = numeric::get_debug_randomness();
 
 /**
  * @brief Verify ECDSA signature. Produces unsatisfiable constraints if signature fails
+ *
+ * @details Fix the following notation:
+ *  1. \f$E\f$ is an elliptic curve over the base field \f$\mathbb{F}_q\f$.
+ *  2. \f$G\f$ is a generator of the group of points of \f$E\f$, the order of \f$G\f$ is \f$n\f$.
+ *  3. \f$a \in \mathbb{F}_n^{\ast}\f$ is a private key, and \f$P := aG\f$ is the associated public key
+ *  4. \f$\mathbf{H}\f$ is a hash function
+ *
+ * Given a message \f$m\f$, a couple \f$(r,s)\f$ is a valid signature for the message \f$m\f$ with respect to the public
+ * key \f$P\f$ if:
+ *  1. \f$P\f$ is a point on \f$E\f$
+ *  2. \f$0 < r < n\f$
+ *  3. \f$0 < s < (n+1) / 2\f$
+ *  4. Define \f$e := \mathbf{H}(m) \mod n\f$ and \f$Q := e s^{-1} G + r s^{-1} P \f$
+ *  5. \f$Q\f$ is not the point at infinity AND \f$Q_x = r \mod n\f$ (note that \f$Q_x \in \mathbb{F}_q\f$)
+ *
+ * @note The requirement of step 2. is to avoid transaction malleability: if \f$(r,s)\f$ is a valid signature for
+ * message \f$m\f$ and public key \f$P\f$, so is \f$(r,n-s)\f$. We protect against malleability by enforcing that
+ * \f$s\f$ is always the lowest of the two possible values.
+ *
+ * @note In Ethereum signatures contain also a recovery byte \$v\$ which is used to recover the public key for which
+ * the signature is to be validated. As we receive the public key as part of the inputs to the verification function, we
+ * do not handle the recovery byte. The signature which is the input to the verification function is given by \$(r,s)\$.
+ * The users of the verification function should handle the recovery byte if that is in their interest.
  *
  * @tparam Builder
  * @tparam Curve

--- a/barretenberg/cpp/src/barretenberg/stdlib/encryption/ecdsa/ecdsa_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/encryption/ecdsa/ecdsa_impl.hpp
@@ -20,10 +20,11 @@
  *
  * Given a message \$m\$, a couple \$(r,s)\$ is a valid signature for the message \$m\$ with respect to the public key
  * \$P\$ if:
- *  1. \$0 < r < n\$
- *  2. \$0 < s < (n+1) / 2\$
- *  3. Define \$e := \mathcal{H}(m) mod n$ and \$Q := e s^{-1} G + r s^{-1} P \$
- *  4. \$Q\$ is not the point at infinity AND \$Q_x = r mod n\$ (note that \$Q_x \in \mathbb{F}_q\$)
+ *  1. \$P\$ is a point on \$E\$
+ *  2. \$0 < r < n\$
+ *  3. \$0 < s < (n+1) / 2\$
+ *  4. Define \$e := \mathcal{H}(m) mod n$ and \$Q := e s^{-1} G + r s^{-1} P \$
+ *  5. \$Q\$ is not the point at infinity AND \$Q_x = r mod n\$ (note that \$Q_x \in \mathbb{F}_q\$)
  *
  * @note The requirement of step 2. is to avoid transaction malleability: if \$(r,s)\$ is a valid signature for message
  * \$m\$ and public key \$P\$, so is \$(r,n-s)\$. We protect against malleability by enforcing that \$s\$ is always the

--- a/barretenberg/cpp/src/barretenberg/stdlib/encryption/ecdsa/ecdsa_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/encryption/ecdsa/ecdsa_impl.hpp
@@ -37,38 +37,6 @@ bool_t<Builder> ecdsa_verify_signature(const stdlib::byte_array<Builder>& messag
 {
     Builder* ctx = message.get_context() ? message.get_context() : public_key.x.context;
 
-    BB_ASSERT_EQ(sig.v.size(), 1ULL, "ecdsa: v must be a single byte");
-
-    /**
-     * Check if recovery id v is either 27 ot 28.
-     *
-     * The v in an (r, s, v) ecdsa signature is the 8-bit recovery id s.t. v ∈ {0, 1, 2, 3}.
-     * It is used to recover signing public key from an ecdsa signature. In practice, the value
-     * of v is offset by 27 following the convention from the original bitcoin whitepaper.
-     *
-     * The value of v depends on the point R = (x, y) s.t. r = x % |Fr|
-     * 0: y is even  &&  x < |Fr| (x = r)
-     * 1: y is odd   &&  x < |Fr| (x = r)
-     * 2: y is even  &&  |Fr| <= x < |Fq| (x = r + |Fr|)
-     * 3: y is odd   &&  |Fr| <= x < |Fq| (x = r + |Fr|)
-     *
-     * It is highly unlikely for x be be in [|Fr|, |Fq|) for the secp256k1 curve because:
-     * P(|Fr| <= x < |Fq|) = 1 - |Fr|/|Fq| ≈ 0.
-     * Therefore, it is reasonable to assume that the value of v will always be 0 or 1
-     * (i.e. 27 or 28 with offset). In fact, the ethereum yellow paper [1] only allows v to be 27 or 28
-     * and considers signatures with v ∈ {29, 30} to be non-standard.
-     *
-     * TODO(Suyash): EIP-155 allows v > 35 to ensure different v on different chains.
-     * Do we need to consider that in our circuits?
-     *
-     * References:
-     * [1] Ethereum yellow paper, Appendix E: https://ethereum.github.io/yellowpaper/paper.pdf
-     * [2] EIP-155: https://eips.ethereum.org/EIPS/eip-155
-     *
-     */
-    // Note: This check is also present in the _noassert variation of this method.
-    sig.v[0].assert_is_in_set({ field_t<Builder>(27), field_t<Builder>(28) }, "ecdsa: signature is non-standard");
-
     stdlib::byte_array<Builder> hashed_message =
         static_cast<stdlib::byte_array<Builder>>(stdlib::SHA256<Builder>::hash(message));
 
@@ -149,8 +117,6 @@ bool_t<Builder> ecdsa_verify_signature_prehashed_message_noassert(const stdlib::
 {
     Builder* ctx = hashed_message.get_context() ? hashed_message.get_context() : public_key.x.context;
 
-    BB_ASSERT_EQ(sig.v.size(), 1ULL, "ecdsa: v must be a single byte");
-
     Fr z(hashed_message);
     z.assert_is_in_field();
 
@@ -205,8 +171,6 @@ bool_t<Builder> ecdsa_verify_signature_prehashed_message_noassert(const stdlib::
     output &= result_mod_r.binary_basis_limbs[3].element == (r.binary_basis_limbs[3].element);
     output &= result_mod_r.prime_basis_limb == (r.prime_basis_limb);
 
-    sig.v[0].assert_is_in_set({ field_t<Builder>(27), field_t<Builder>(28) }, "ecdsa: signature is non-standard");
-
     return output;
 }
 
@@ -241,13 +205,11 @@ template <typename Builder> void generate_ecdsa_verification_test_circuit(Builde
 
         std::vector<uint8_t> rr(signature.r.begin(), signature.r.end());
         std::vector<uint8_t> ss(signature.s.begin(), signature.s.end());
-        std::vector<uint8_t> vv = { signature.v };
 
         typename curve::g1_bigfr_ct public_key = curve::g1_bigfr_ct::from_witness(&builder, account.public_key);
 
         stdlib::ecdsa_signature<Builder> sig{ typename curve::byte_array_ct(&builder, rr),
-                                              typename curve::byte_array_ct(&builder, ss),
-                                              typename curve::byte_array_ct(&builder, vv) };
+                                              typename curve::byte_array_ct(&builder, ss) };
 
         typename curve::byte_array_ct message(&builder, message_string);
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/encryption/ecdsa/ecdsa_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/encryption/ecdsa/ecdsa_impl.hpp
@@ -11,6 +11,31 @@
 #include "barretenberg/stdlib/hash/sha256/sha256.hpp"
 #include "barretenberg/stdlib/primitives/curves/secp256k1.hpp"
 
+/**
+ * Fix the following notation:
+ *  1. \$E\$ is an elliptic curve over the base field \$\mathbb{F}_q\$.
+ *  2. \$G\$ is a generator of the group of points of \$E\$, the order of \$G\$ is \$n\$.
+ *  3. \$a \in \mathbb{F}_n^{\ast}$ is a private key, and \$P := aG\$ is the associated public key
+ *  4. \$\mathcal{H}\$ is a hash function
+ *
+ * Given a message \$m\$, a couple \$(r,s)\$ is a valid signature for the message \$m\$ with respect to the public key
+ * \$P\$ if:
+ *  1. \$0 < r < n\$
+ *  2. \$0 < s < (n+1) / 2\$
+ *  3. Define \$e := \mathcal{H}(m) mod n$ and \$Q := e s^{-1} G + r s^{-1} P \$
+ *  4. \$Q\$ is not the point at infinity AND \$Q_x = r mod n\$ (note that \$Q_x \in \mathbb{F}_q\$)
+ *
+ * @note The requirement of step 2. is to avoid transaction malleability: if \$(r,s)\$ is a valid signature for message
+ * \$m\$ and public key \$P\$, so is \$(r,n-s)\$. We protect against malleability by enforcing that \$s\$ is always the
+ * lowest of the two possible values.
+ *
+ * @note In Ethereum signatures contain also a recovery byte \$v\$ which is used to recover the public key for which
+ * the signature is to be validated. As we receive the public key as part of the inputs to the verification function, we
+ * do not handle the recovery byte. The signature which is the input to the verification function is given by \$(r,s)\$.
+ * The users of the verification function should handle the recovery byte if that is in their interest.
+ *
+ */
+
 namespace bb::stdlib {
 
 namespace {


### PR DESCRIPTION
Audit part 2: remove the recovery byte from ecdsa signatures in stdlib + add documentation.

ECDSA signatures are composed of two integers `r` and `s`. Ethereum adds a recovery byte to avoid sending public keys as well as signatures: the public key for which the signature is supposed to be validated can be extracted from the signature and the recovery byte. In circuit we do not handle the recovery byte because we are already given the public key.

This PR removes the recovery byte from ecdsa signatures in stdlib (note: the recovery byte is still present in the native generation of an ECDSA signature).

We also add documentation explaining the constraints imposed by the verification circuit.