### PR TITLE
fix: address 142

### DIFF
--- a/l1-contracts/src/governance/RewardDistributor.sol
+++ b/l1-contracts/src/governance/RewardDistributor.sol
@@ -5,6 +5,7 @@ pragma solidity >=0.8.27;
 import {IRegistry} from "@aztec/governance/interfaces/IRegistry.sol";
 import {IRewardDistributor} from "@aztec/governance/interfaces/IRewardDistributor.sol";
 import {Errors} from "@aztec/governance/libraries/Errors.sol";
+import {Ownable} from "@oz/access/Ownable.sol";
 import {IERC20} from "@oz/token/ERC20/IERC20.sol";
 import {SafeERC20} from "@oz/token/ERC20/utils/SafeERC20.sol";
 
@@ -26,6 +27,12 @@ contract RewardDistributor is IRewardDistributor {
   function claim(address _to, uint256 _amount) external override(IRewardDistributor) {
     require(msg.sender == canonicalRollup(), Errors.RewardDistributor__InvalidCaller(msg.sender, canonicalRollup()));
     ASSET.safeTransfer(_to, _amount);
+  }
+
+  function recover(address _asset, address _to, uint256 _amount) external override(IRewardDistributor) {
+    address owner = Ownable(address(REGISTRY)).owner();
+    require(msg.sender == owner, Errors.RewardDistributor__InvalidCaller(msg.sender, owner));
+    IERC20(_asset).safeTransfer(_to, _amount);
   }
 
   function canonicalRollup() public view override(IRewardDistributor) returns (address) {

--- a/l1-contracts/src/governance/interfaces/IRewardDistributor.sol
+++ b/l1-contracts/src/governance/interfaces/IRewardDistributor.sol
@@ -3,5 +3,6 @@ pragma solidity >=0.8.27;
 
 interface IRewardDistributor {
   function claim(address _to, uint256 _amount) external;
+  function recover(address _asset, address _to, uint256 _amount) external;
   function canonicalRollup() external view returns (address);
 }

--- a/l1-contracts/test/benchmark/happy.t.sol
+++ b/l1-contracts/test/benchmark/happy.t.sol
@@ -95,6 +95,8 @@ contract FakeCanonical is IRewardDistributor {
   }
 
   function updateRegistry(IRegistry _registry) external {}
+
+  function recover(address _asset, address _to, uint256 _amount) external {}
 }
 
 contract BenchmarkRollupTest is FeeModelTestPoints, DecoderBase {

--- a/l1-contracts/test/compression/PreHeating.t.sol
+++ b/l1-contracts/test/compression/PreHeating.t.sol
@@ -92,6 +92,8 @@ contract FakeCanonical is IRewardDistributor {
   }
 
   function updateRegistry(IRegistry _registry) external {}
+
+  function recover(address _asset, address _to, uint256 _amount) external {}
 }
 
 /**

--- a/l1-contracts/test/governance/reward-distributor/recover.t.sol
+++ b/l1-contracts/test/governance/reward-distributor/recover.t.sol
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.27;
+
+import {RewardDistributorBase} from "./Base.t.sol";
+
+import {Errors} from "@aztec/governance/libraries/Errors.sol";
+import {Ownable} from "@oz/access/Ownable.sol";
+import {TestERC20} from "@aztec/mock/TestERC20.sol";
+
+contract RecoverTest is RewardDistributorBase {
+  address internal caller;
+
+  function test_WhenCallerIsNotOwner(address _caller) external {
+    // it reverts
+    address owner = Ownable(address(registry)).owner();
+    vm.assume(_caller != owner);
+
+    vm.expectRevert(abi.encodeWithSelector(Errors.RewardDistributor__InvalidCaller.selector, _caller, owner));
+    vm.prank(_caller);
+    rewardDistributor.recover(address(token), _caller, 1e18);
+  }
+
+  modifier whenCallerIsOwner() {
+    caller = Ownable(address(registry)).owner();
+    _;
+  }
+
+  function test_GivenBalanceGt0(uint256 _balance, uint256 _amount) external whenCallerIsOwner {
+    // it transfers the requested amount
+
+    uint256 balance = bound(_balance, 1, type(uint256).max);
+    uint256 amount = bound(_amount, 1, balance);
+    token.mint(address(rewardDistributor), balance);
+
+    uint256 callerBalance = token.balanceOf(caller);
+    vm.prank(caller);
+    rewardDistributor.recover(address(token), caller, amount);
+
+    assertEq(token.balanceOf(caller), callerBalance + amount);
+    assertEq(token.balanceOf(address(rewardDistributor)), balance - amount);
+
+    TestERC20 token2 = new TestERC20("Token2", "T2", address(this));
+    token2.mint(address(rewardDistributor), balance);
+
+    vm.prank(caller);
+    rewardDistributor.recover(address(token2), caller, amount);
+    assertEq(token2.balanceOf(caller), amount);
+    assertEq(token2.balanceOf(address(rewardDistributor)), balance - amount);
+  }
+}


### PR DESCRIPTION
Currently the rollup don't need to have the registry in its config, and if it did and were to be updatable seems like it poses the same issue. 

I think the sanest solution here will be to take the alternative route and ensure that governance can simple claw back the funds. However, I don't think that gov need to be constrained on where they can put them for the simple reason that they already have the power of the issuer, so they could already make funds if they wanted to.