### PR TITLE
fix: remove `--proposer-eoa` as its no longer a supported flag

### DIFF
--- a/docs/docs/the_aztec_network/guides/run_nodes/how_to_run_sequencer.md
+++ b/docs/docs/the_aztec_network/guides/run_nodes/how_to_run_sequencer.md
@@ -114,8 +114,7 @@ aztec add-l1-validator --staking-asset-handler=0xF739D03e98e23A7B65940848aBA8921
   --l1-rpc-urls $ETHEREUM_HOSTS \
   --l1-chain-id 11155111 \
   --private-key "0x<hex value>" \
-  --attester "0x<eth address>" \
-  --proposer-eoa "0x<eth address>"
+  --attester "0x<eth address>"
 ```
 
 **Tip**: Use `aztec help add-l1-validator` for further parameter details.


### PR DESCRIPTION
--proposer-eoa is no longer a supported flag according to latest --help?

```sh
aztec add-l1-validator --help
Usage: aztec add-l1-validator [options]

Adds a validator to the L1 rollup contract.

Options:
  --l1-rpc-urls <string>             List of Ethereum host URLs. Chain identifiers localhost and testnet can be used (comma separated) (default: ["http://host.docker.internal:8545"], env: ETHEREUM_HOSTS)
  -pk, --private-key <string>        The private key to use sending the transaction
  -m, --mnemonic <string>            The mnemonic to use sending the transaction (default: "test test test test test test test test test test test junk")
  -c, --l1-chain-id <number>         Chain ID of the ethereum host (default: 31337, env: L1_CHAIN_ID)
  --attester <address>               ethereum address of the attester
  --staking-asset-handler <address>  ethereum address of the staking asset handler
  --proof <buffer>                   The proof to use for the attestation
  --merkle-proof <string>            The merkle proof to use for the attestation (comma separated list of 32 byte buffers)
  -h, --help                         display help for command
```

Please read [contributing guidelines](CONTRIBUTING.md) and remove this line.

For audit-related pull requests, please use the [audit PR template](?expand=1&template=audit.md).
