### PR TITLE
chore!: Merge two ecdsa verification functions

### DIFF
--- a/barretenberg/cpp/scripts/test_civc_standalone_vks_havent_changed.sh
+++ b/barretenberg/cpp/scripts/test_civc_standalone_vks_havent_changed.sh
@@ -11,7 +11,7 @@ cd ..
 # - Generate a hash for versioning: sha256sum bb-civc-inputs.tar.gz
 # - Upload the compressed results: aws s3 cp bb-civc-inputs.tar.gz s3://aztec-ci-artifacts/protocol/bb-civc-inputs-[hash(0:8)].tar.gz
 # Note: In case of the "Test suite failed to run ... Unexpected token 'with' " error, need to run: docker pull aztecprotocol/build:3.0
-pinned_short_hash="4de9f109"
+pinned_short_hash="869efec4"
 pinned_civc_inputs_url="https://aztec-ci-artifacts.s3.us-east-2.amazonaws.com/protocol/bb-civc-inputs-${pinned_short_hash}.tar.gz"
 
 function compress_and_upload {

--- a/barretenberg/cpp/scripts/test_civc_standalone_vks_havent_changed.sh
+++ b/barretenberg/cpp/scripts/test_civc_standalone_vks_havent_changed.sh
@@ -11,7 +11,7 @@ cd ..
 # - Generate a hash for versioning: sha256sum bb-civc-inputs.tar.gz
 # - Upload the compressed results: aws s3 cp bb-civc-inputs.tar.gz s3://aztec-ci-artifacts/protocol/bb-civc-inputs-[hash(0:8)].tar.gz
 # Note: In case of the "Test suite failed to run ... Unexpected token 'with' " error, need to run: docker pull aztecprotocol/build:3.0
-pinned_short_hash="6784e210"
+pinned_short_hash="430c0215"
 pinned_civc_inputs_url="https://aztec-ci-artifacts.s3.us-east-2.amazonaws.com/protocol/bb-civc-inputs-${pinned_short_hash}.tar.gz"
 
 function compress_and_upload {

--- a/barretenberg/cpp/scripts/test_civc_standalone_vks_havent_changed.sh
+++ b/barretenberg/cpp/scripts/test_civc_standalone_vks_havent_changed.sh
@@ -11,7 +11,7 @@ cd ..
 # - Generate a hash for versioning: sha256sum bb-civc-inputs.tar.gz
 # - Upload the compressed results: aws s3 cp bb-civc-inputs.tar.gz s3://aztec-ci-artifacts/protocol/bb-civc-inputs-[hash(0:8)].tar.gz
 # Note: In case of the "Test suite failed to run ... Unexpected token 'with' " error, need to run: docker pull aztecprotocol/build:3.0
-pinned_short_hash="dba43b65"
+pinned_short_hash="6784e210"
 pinned_civc_inputs_url="https://aztec-ci-artifacts.s3.us-east-2.amazonaws.com/protocol/bb-civc-inputs-${pinned_short_hash}.tar.gz"
 
 function compress_and_upload {

--- a/barretenberg/cpp/scripts/test_civc_standalone_vks_havent_changed.sh
+++ b/barretenberg/cpp/scripts/test_civc_standalone_vks_havent_changed.sh
@@ -11,7 +11,7 @@ cd ..
 # - Generate a hash for versioning: sha256sum bb-civc-inputs.tar.gz
 # - Upload the compressed results: aws s3 cp bb-civc-inputs.tar.gz s3://aztec-ci-artifacts/protocol/bb-civc-inputs-[hash(0:8)].tar.gz
 # Note: In case of the "Test suite failed to run ... Unexpected token 'with' " error, need to run: docker pull aztecprotocol/build:3.0
-pinned_short_hash="430c0215"
+pinned_short_hash="4de9f109"
 pinned_civc_inputs_url="https://aztec-ci-artifacts.s3.us-east-2.amazonaws.com/protocol/bb-civc-inputs-${pinned_short_hash}.tar.gz"
 
 function compress_and_upload {

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/ecdsa_secp256k1.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/ecdsa_secp256k1.cpp
@@ -51,7 +51,7 @@ void create_ecdsa_k1_verify_constraints(Builder& builder,
 
     auto new_sig = ecdsa_convert_signature(builder, input.signature);
 
-    byte_array_ct message = ecdsa_array_of_bytes_to_byte_array(builder, input.hashed_message);
+    byte_array_ct hashed_message = ecdsa_array_of_bytes_to_byte_array(builder, input.hashed_message);
     auto pub_key_x_byte_arr = ecdsa_array_of_bytes_to_byte_array(builder, input.pub_x_indices);
     auto pub_key_y_byte_arr = ecdsa_array_of_bytes_to_byte_array(builder, input.pub_y_indices);
 
@@ -74,16 +74,15 @@ void create_ecdsa_k1_verify_constraints(Builder& builder,
         pub_key_y_byte_arr[i].assert_equal(field_ct::from_witness_index(&builder, input.pub_y_indices[i]));
     }
     for (size_t i = 0; i < input.hashed_message.size(); ++i) {
-        message[i].assert_equal(field_ct::from_witness_index(&builder, input.hashed_message[i]));
+        hashed_message[i].assert_equal(field_ct::from_witness_index(&builder, input.hashed_message[i]));
     }
 
     bool_ct signature_result =
-        stdlib::ecdsa_verify_signature_prehashed_message_noassert<Builder,
-                                                                  secp256k1_ct,
-                                                                  typename secp256k1_ct::fq_ct,
-                                                                  typename secp256k1_ct::bigfr_ct,
-                                                                  typename secp256k1_ct::g1_bigfr_ct>(
-            message, public_key, sig);
+        stdlib::ecdsa_verify_signature<Builder,
+                                       secp256k1_ct,
+                                       typename secp256k1_ct::fq_ct,
+                                       typename secp256k1_ct::bigfr_ct,
+                                       typename secp256k1_ct::g1_bigfr_ct>(hashed_message, public_key, sig);
     bool_ct signature_result_normalized = signature_result.normalize();
     builder.assert_equal(signature_result_normalized.witness_index, input.result);
 }

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/ecdsa_secp256r1.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/ecdsa_secp256r1.cpp
@@ -49,7 +49,7 @@ void create_ecdsa_r1_verify_constraints(Builder& builder,
 
     auto new_sig = ecdsa_convert_signature(builder, input.signature);
 
-    byte_array_ct message = ecdsa_array_of_bytes_to_byte_array(builder, input.hashed_message);
+    byte_array_ct hashed_message = ecdsa_array_of_bytes_to_byte_array(builder, input.hashed_message);
     auto pub_key_x_byte_arr = ecdsa_array_of_bytes_to_byte_array(builder, input.pub_x_indices);
     auto pub_key_y_byte_arr = ecdsa_array_of_bytes_to_byte_array(builder, input.pub_y_indices);
 
@@ -72,16 +72,15 @@ void create_ecdsa_r1_verify_constraints(Builder& builder,
         pub_key_y_byte_arr[i].assert_equal(field_ct::from_witness_index(&builder, input.pub_y_indices[i]));
     }
     for (size_t i = 0; i < input.hashed_message.size(); ++i) {
-        message[i].assert_equal(field_ct::from_witness_index(&builder, input.hashed_message[i]));
+        hashed_message[i].assert_equal(field_ct::from_witness_index(&builder, input.hashed_message[i]));
     }
 
     bool_ct signature_result =
-        stdlib::ecdsa_verify_signature_prehashed_message_noassert<Builder,
-                                                                  secp256r1_ct,
-                                                                  typename secp256r1_ct::fq_ct,
-                                                                  typename secp256r1_ct::bigfr_ct,
-                                                                  typename secp256r1_ct::g1_bigfr_ct>(
-            message, public_key, sig);
+        stdlib::ecdsa_verify_signature<Builder,
+                                       secp256r1_ct,
+                                       typename secp256r1_ct::fq_ct,
+                                       typename secp256r1_ct::bigfr_ct,
+                                       typename secp256r1_ct::g1_bigfr_ct>(hashed_message, public_key, sig);
     bool_ct signature_result_normalized = signature_result.normalize();
     builder.assert_equal(signature_result_normalized.witness_index, input.result);
 }

--- a/barretenberg/cpp/src/barretenberg/solidity_helpers/circuits/ecdsa_circuit.hpp
+++ b/barretenberg/cpp/src/barretenberg/solidity_helpers/circuits/ecdsa_circuit.hpp
@@ -75,20 +75,22 @@ class EcdsaCircuit {
         stdlib::ecdsa_signature<Builder> sig{ typename curve::byte_array_ct(&builder, rr),
                                               typename curve::byte_array_ct(&builder, ss) };
 
+        stdlib::byte_array<Builder> hashed_message =
+            static_cast<stdlib::byte_array<Builder>>(stdlib::SHA256<Builder>::hash(input_buffer));
+
         // IN CIRCUIT: verify the signature
         typename curve::bool_ct signature_result = stdlib::ecdsa_verify_signature<Builder,
                                                                                   curve,
                                                                                   typename curve::fq_ct,
                                                                                   typename curve::bigfr_ct,
                                                                                   typename curve::g1_bigfr_ct>(
-            // input_buffer, public_key, sig);
-            input_buffer,
+            // hashed_message, public_key, sig);
+            hashed_message,
             public_key,
             sig);
 
-        // Assert the signature is true, we hash the message inside the verify sig stdlib call
-        bool_ct is_true = bool_ct(true);
-        signature_result.must_imply(is_true, "signature verification failed");
+        // Assert the signature is true
+        signature_result.assert_equal(bool_ct(true));
 
         return builder;
     }

--- a/barretenberg/cpp/src/barretenberg/stdlib/encryption/ecdsa/ecdsa.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/encryption/ecdsa/ecdsa.hpp
@@ -25,10 +25,6 @@ template <typename Builder> struct ecdsa_signature {
             return s.get_context();
         }
 
-        if (v.get_context() != nullptr) {
-            return v.get_context();
-        }
-
         return nullptr;
     }
 };

--- a/barretenberg/cpp/src/barretenberg/stdlib/encryption/ecdsa/ecdsa.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/encryption/ecdsa/ecdsa.hpp
@@ -38,6 +38,12 @@ bool_t<Builder> ecdsa_verify_signature(const stdlib::byte_array<Builder>& hashed
                                        const G1& public_key,
                                        const ecdsa_signature<Builder>& sig);
 
+template <typename Builder, typename Curve, typename Fq, typename Fr, typename G1>
+void validate_inputs(const stdlib::byte_array<Builder>& hashed_message,
+                     const G1& public_key,
+                     const ecdsa_signature<Builder>& sig,
+                     const G1& scalar_mul_result);
+
 template <typename Builder> void generate_ecdsa_verification_test_circuit(Builder& builder, size_t num_iterations);
 
 } // namespace bb::stdlib

--- a/barretenberg/cpp/src/barretenberg/stdlib/encryption/ecdsa/ecdsa.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/encryption/ecdsa/ecdsa.hpp
@@ -41,8 +41,7 @@ bool_t<Builder> ecdsa_verify_signature(const stdlib::byte_array<Builder>& hashed
 template <typename Builder, typename Curve, typename Fq, typename Fr, typename G1>
 void validate_inputs(const stdlib::byte_array<Builder>& hashed_message,
                      const G1& public_key,
-                     const ecdsa_signature<Builder>& sig,
-                     const G1& scalar_mul_result);
+                     const ecdsa_signature<Builder>& sig);
 
 template <typename Builder> void generate_ecdsa_verification_test_circuit(Builder& builder, size_t num_iterations);
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/encryption/ecdsa/ecdsa.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/encryption/ecdsa/ecdsa.hpp
@@ -14,17 +14,29 @@ namespace bb::stdlib {
 template <typename Builder> struct ecdsa_signature {
     stdlib::byte_array<Builder> r;
     stdlib::byte_array<Builder> s;
+
+    Builder* get_context() const
+    {
+        if (r.get_context() != nullptr) {
+            return r.get_context();
+        }
+
+        if (s.get_context() != nullptr) {
+            return s.get_context();
+        }
+
+        if (v.get_context() != nullptr) {
+            return v.get_context();
+        }
+
+        return nullptr;
+    }
 };
 
 template <typename Builder, typename Curve, typename Fq, typename Fr, typename G1>
-bool_t<Builder> ecdsa_verify_signature(const stdlib::byte_array<Builder>& message,
+bool_t<Builder> ecdsa_verify_signature(const stdlib::byte_array<Builder>& hashed_message,
                                        const G1& public_key,
                                        const ecdsa_signature<Builder>& sig);
-
-template <typename Builder, typename Curve, typename Fq, typename Fr, typename G1>
-bool_t<Builder> ecdsa_verify_signature_prehashed_message_noassert(const stdlib::byte_array<Builder>& hashed_message,
-                                                                  const G1& public_key,
-                                                                  const ecdsa_signature<Builder>& sig);
 
 template <typename Builder> void generate_ecdsa_verification_test_circuit(Builder& builder, size_t num_iterations);
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/encryption/ecdsa/ecdsa.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/encryption/ecdsa/ecdsa.test.cpp
@@ -7,198 +7,122 @@
 #include "barretenberg/common/test.hpp"
 #include "ecdsa.hpp"
 
+#include <gtest/gtest.h>
+
 using namespace bb;
 using namespace bb::crypto;
 
-using Builder = UltraCircuitBuilder;
-using curve_ = stdlib::secp256k1<Builder>;
-using curveR1 = stdlib::secp256r1<Builder>;
+template <class Curve> class EcdsaTests : public ::testing::Test {
+  public:
+    using Builder = Curve::Builder;
 
-TEST(stdlib_ecdsa, verify_signature)
-{
-    Builder builder = Builder();
+    // Native Types
+    using FrNative = Curve::fr;
+    using FqNative = Curve::fq;
+    using G1Native = Curve::g1;
 
-    // whaaablaghaaglerijgeriij
-    std::string message_string = "Instructions unclear, ask again later.";
+    // Stdlib types
+    using Fr = Curve::bigfr_ct;
+    using Fq = Curve::fq_ct;
+    using G1 = Curve::g1_bigfr_ct;
 
-    ecdsa_key_pair<curve_::fr, curve_::g1> account;
-    account.private_key = curve_::fr::random_element();
-    account.public_key = curve_::g1::one * account.private_key;
-
-    ecdsa_signature signature =
-        ecdsa_construct_signature<Sha256Hasher, curve_::fq, curve_::fr, curve_::g1>(message_string, account);
-
-    bool first_result = ecdsa_verify_signature<Sha256Hasher, curve_::fq, curve_::fr, curve_::g1>(
-        message_string, account.public_key, signature);
-    EXPECT_EQ(first_result, true);
-
-    curve_::g1_bigfr_ct public_key = curve_::g1_bigfr_ct::from_witness(&builder, account.public_key);
-
-    std::vector<uint8_t> rr(signature.r.begin(), signature.r.end());
-    std::vector<uint8_t> ss(signature.s.begin(), signature.s.end());
-
-    stdlib::ecdsa_signature<Builder> sig{
-        curve_::byte_array_ct(&builder, rr),
-        curve_::byte_array_ct(&builder, ss),
+    struct StdlibEcdsaData {
+        stdlib::byte_array<Builder> message;
+        G1 public_key;
+        stdlib::ecdsa_signature<Builder> sig;
     };
 
-    curve_::byte_array_ct message(&builder, message_string);
+    std::pair<ecdsa_key_pair<FrNative, G1Native>, ecdsa_signature> generate_dummy_ecdsa_data(std::string message_string,
+                                                                                             bool tamper_with_signature)
+    {
+        ecdsa_key_pair<FrNative, G1Native> account;
+        account.private_key = FrNative::random_element();
+        account.public_key = G1Native::one * account.private_key;
 
-    curve_::bool_ct signature_result =
-        stdlib::ecdsa_verify_signature<Builder, curve_, curve_::fq_ct, curve_::bigfr_ct, curve_::g1_bigfr_ct>(
-            message, public_key, sig);
+        ecdsa_signature signature =
+            ecdsa_construct_signature<Sha256Hasher, FqNative, FrNative, G1Native>(message_string, account);
 
-    EXPECT_EQ(signature_result.get_value(), true);
+        if (tamper_with_signature) {
+            signature.r[1] += 1;
+        }
 
-    std::cerr << "num gates = " << builder.get_estimated_num_finalized_gates() << std::endl;
-    benchmark_info(Builder::NAME_STRING,
-                   "ECDSA",
-                   "Signature Verification Test",
-                   "Gate Count",
-                   builder.get_estimated_num_finalized_gates());
-    bool proof_result = CircuitChecker::check(builder);
-    EXPECT_EQ(proof_result, true);
+        return { account, signature };
+    }
+
+    StdlibEcdsaData create_stdlib_ecdsa_data(Builder& builder,
+                                             std::string message_string,
+                                             ecdsa_key_pair<FrNative, G1Native>& account,
+                                             ecdsa_signature& signature)
+    {
+        stdlib::byte_array<Builder> message(&builder, message_string);
+
+        G1 pub_key = G1::from_witness(&builder, account.public_key);
+
+        std::vector<uint8_t> rr(signature.r.begin(), signature.r.end());
+        std::vector<uint8_t> ss(signature.s.begin(), signature.s.end());
+        std::vector<uint8_t> vv = { signature.v };
+
+        stdlib::ecdsa_signature<Builder> sig{ stdlib::byte_array<Builder>(&builder, rr),
+                                              stdlib::byte_array<Builder>(&builder, ss),
+                                              stdlib::byte_array<Builder>(&builder, vv) };
+
+        return { message, pub_key, sig };
+    }
+
+    void test_verify_signature(bool tamper_with_signature)
+    {
+        // whaaablaghaaglerijgeriij
+        std::string message_string = "Instructions unclear, ask again later.";
+
+        auto [account, signature] =
+            generate_dummy_ecdsa_data(message_string, /*tamper_with_signature=*/tamper_with_signature);
+
+        // Natively verify the signature
+        bool native_verification = ecdsa_verify_signature<Sha256Hasher, FqNative, FrNative, G1Native>(
+            message_string, account.public_key, signature);
+        EXPECT_EQ(native_verification, !tamper_with_signature);
+
+        // Create ECDSA verification circuit
+        Builder builder;
+
+        auto [message, public_key, sig] = create_stdlib_ecdsa_data(builder, message_string, account, signature);
+
+        // Compute H(m)
+        stdlib::byte_array<Builder> hashed_message =
+            static_cast<stdlib::byte_array<Builder>>(stdlib::SHA256<Builder>::hash(message));
+
+        // Verify signature
+        stdlib::bool_t<Builder> signature_result =
+            stdlib::ecdsa_verify_signature<Builder, Curve, Fq, Fr, G1>(hashed_message, public_key, sig);
+
+        // Enforce verification passed successfully
+        signature_result.assert_equal(stdlib::bool_t<Builder>(true));
+
+        EXPECT_EQ(signature_result.get_value(), !tamper_with_signature);
+
+        std::cerr << "num gates = " << builder.get_estimated_num_finalized_gates() << std::endl;
+        benchmark_info(Builder::NAME_STRING,
+                       "ECDSA",
+                       "Signature Verification Test",
+                       "Gate Count",
+                       builder.get_estimated_num_finalized_gates());
+        bool proof_result = CircuitChecker::check(builder);
+        EXPECT_EQ(proof_result, !tamper_with_signature);
+    }
+};
+
+using Curves = testing::Types<stdlib::secp256k1<UltraCircuitBuilder>,
+                              stdlib::secp256r1<UltraCircuitBuilder>>; // TODO(federicobarbacovi): Is
+                                                                       // UltraCircuitBuilder a valid assumption?
+
+TYPED_TEST_SUITE(EcdsaTests, Curves);
+
+TYPED_TEST(EcdsaTests, VerifySignature)
+{
+    TestFixture::test_verify_signature(/*tamper_with_signature=*/false);
 }
 
-TEST(stdlib_ecdsa, verify_r1_signature)
+TYPED_TEST(EcdsaTests, VerifySignatureFails)
 {
-    Builder builder = Builder();
-
-    std::string message_string = "Instructions unclear, ask again later.";
-
-    ecdsa_key_pair<curveR1::fr, curveR1::g1> account;
-    account.private_key = curveR1::fr::random_element();
-    account.public_key = curveR1::g1::one * account.private_key;
-
-    ecdsa_signature signature =
-        ecdsa_construct_signature<Sha256Hasher, curveR1::fq, curveR1::fr, curveR1::g1>(message_string, account);
-
-    bool first_result = ecdsa_verify_signature<Sha256Hasher, curveR1::fq, curveR1::fr, curveR1::g1>(
-        message_string, account.public_key, signature);
-    EXPECT_EQ(first_result, true);
-
-    curveR1::g1_bigfr_ct public_key = curveR1::g1_bigfr_ct::from_witness(&builder, account.public_key);
-
-    std::vector<uint8_t> rr(signature.r.begin(), signature.r.end());
-    std::vector<uint8_t> ss(signature.s.begin(), signature.s.end());
-
-    stdlib::ecdsa_signature<Builder> sig{ curveR1::byte_array_ct(&builder, rr), curveR1::byte_array_ct(&builder, ss) };
-
-    curveR1::byte_array_ct message(&builder, message_string);
-
-    curveR1::bool_ct signature_result =
-        stdlib::ecdsa_verify_signature<Builder, curveR1, curveR1::fq_ct, curveR1::bigfr_ct, curveR1::g1_bigfr_ct>(
-            message, public_key, sig);
-
-    EXPECT_EQ(signature_result.get_value(), true);
-
-    std::cerr << "num gates = " << builder.get_estimated_num_finalized_gates() << std::endl;
-    benchmark_info(Builder::NAME_STRING,
-                   "ECDSA",
-                   "Signature Verification Test",
-                   "Gate Count",
-                   builder.get_estimated_num_finalized_gates());
-    bool proof_result = CircuitChecker::check(builder);
-    EXPECT_EQ(proof_result, true);
-}
-
-TEST(stdlib_ecdsa, ecdsa_verify_signature_noassert_succeed)
-{
-    Builder builder = Builder();
-
-    // whaaablaghaaglerijgeriij
-    std::string message_string = "Instructions unclear, ask again later.";
-
-    ecdsa_key_pair<curve_::fr, curve_::g1> account;
-    account.private_key = curve_::fr::random_element();
-    account.public_key = curve_::g1::one * account.private_key;
-
-    ecdsa_signature signature =
-        ecdsa_construct_signature<Sha256Hasher, curve_::fq, curve_::fr, curve_::g1>(message_string, account);
-
-    bool first_result = ecdsa_verify_signature<Sha256Hasher, curve_::fq, curve_::fr, curve_::g1>(
-        message_string, account.public_key, signature);
-    EXPECT_EQ(first_result, true);
-
-    curve_::g1_bigfr_ct public_key = curve_::g1_bigfr_ct::from_witness(&builder, account.public_key);
-
-    std::vector<uint8_t> rr(signature.r.begin(), signature.r.end());
-    std::vector<uint8_t> ss(signature.s.begin(), signature.s.end());
-
-    stdlib::ecdsa_signature<Builder> sig{ curve_::byte_array_ct(&builder, rr), curve_::byte_array_ct(&builder, ss) };
-
-    curve_::byte_array_ct message(&builder, message_string);
-
-    stdlib::byte_array<Builder> hashed_message =
-        static_cast<stdlib::byte_array<Builder>>(stdlib::SHA256<Builder>::hash(message));
-
-    curve_::bool_ct signature_result =
-        stdlib::ecdsa_verify_signature_prehashed_message_noassert<Builder,
-                                                                  curve_,
-                                                                  curve_::fq_ct,
-                                                                  curve_::bigfr_ct,
-                                                                  curve_::g1_bigfr_ct>(hashed_message, public_key, sig);
-
-    EXPECT_EQ(signature_result.get_value(), true);
-
-    std::cerr << "num gates = " << builder.get_estimated_num_finalized_gates() << std::endl;
-    benchmark_info(Builder::NAME_STRING,
-                   "ECDSA",
-                   "Signature Verification Test",
-                   "Gate Count",
-                   builder.get_estimated_num_finalized_gates());
-    bool proof_result = CircuitChecker::check(builder);
-    EXPECT_EQ(proof_result, true);
-}
-
-TEST(stdlib_ecdsa, ecdsa_verify_signature_noassert_fail)
-{
-    Builder builder = Builder();
-
-    // whaaablaghaaglerijgeriij
-    std::string message_string = "Instructions unclear, ask again later.";
-
-    ecdsa_key_pair<curve_::fr, curve_::g1> account;
-    account.private_key = curve_::fr::random_element();
-    account.public_key = curve_::g1::one * account.private_key;
-
-    ecdsa_signature signature =
-        ecdsa_construct_signature<Sha256Hasher, curve_::fq, curve_::fr, curve_::g1>(message_string, account);
-
-    // tamper w. signature to make fail
-    signature.r[0] += 1;
-
-    bool first_result = ecdsa_verify_signature<Sha256Hasher, curve_::fq, curve_::fr, curve_::g1>(
-        message_string, account.public_key, signature);
-    EXPECT_EQ(first_result, false);
-
-    curve_::g1_bigfr_ct public_key = curve_::g1_bigfr_ct::from_witness(&builder, account.public_key);
-
-    std::vector<uint8_t> rr(signature.r.begin(), signature.r.end());
-    std::vector<uint8_t> ss(signature.s.begin(), signature.s.end());
-
-    stdlib::ecdsa_signature<Builder> sig{ curve_::byte_array_ct(&builder, rr), curve_::byte_array_ct(&builder, ss) };
-
-    curve_::byte_array_ct message(&builder, message_string);
-
-    stdlib::byte_array<Builder> hashed_message =
-        static_cast<stdlib::byte_array<Builder>>(stdlib::SHA256<Builder>::hash(message));
-
-    curve_::bool_ct signature_result =
-        stdlib::ecdsa_verify_signature_prehashed_message_noassert<Builder,
-                                                                  curve_,
-                                                                  curve_::fq_ct,
-                                                                  curve_::bigfr_ct,
-                                                                  curve_::g1_bigfr_ct>(hashed_message, public_key, sig);
-
-    EXPECT_EQ(signature_result.get_value(), false);
-
-    std::cerr << "num gates = " << builder.get_estimated_num_finalized_gates() << std::endl;
-    benchmark_info(Builder::NAME_STRING,
-                   "ECDSA",
-                   "Signature Verification Test",
-                   "Gate Count",
-                   builder.get_estimated_num_finalized_gates());
-    bool proof_result = CircuitChecker::check(builder);
-    EXPECT_EQ(proof_result, true);
+    TestFixture::test_verify_signature(/*tamper_with_signature=*/true);
 }

--- a/barretenberg/cpp/src/barretenberg/stdlib/encryption/ecdsa/ecdsa.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/encryption/ecdsa/ecdsa.test.cpp
@@ -63,8 +63,7 @@ template <class Curve> class EcdsaTests : public ::testing::Test {
         std::vector<uint8_t> vv = { signature.v };
 
         stdlib::ecdsa_signature<Builder> sig{ stdlib::byte_array<Builder>(&builder, rr),
-                                              stdlib::byte_array<Builder>(&builder, ss),
-                                              stdlib::byte_array<Builder>(&builder, vv) };
+                                              stdlib::byte_array<Builder>(&builder, ss) };
 
         return { message, pub_key, sig };
     }

--- a/barretenberg/cpp/src/barretenberg/stdlib/encryption/ecdsa/ecdsa_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/encryption/ecdsa/ecdsa_impl.hpp
@@ -201,6 +201,10 @@ bool_t<Builder> ecdsa_verify_signature(const stdlib::byte_array<Builder>& hashed
                                                         result.x.binary_basis_limbs[1].element,
                                                         result.x.binary_basis_limbs[2].element,
                                                         result.x.binary_basis_limbs[3].element);
+    // Copy maximum limb values from Fq to Fr: this is needed by the subtraction happening in the == operator
+    for (size_t idx = 0; idx < 4; idx++) {
+        result_x_mod_r.binary_basis_limbs[idx].maximum_value = result.x.binary_basis_limbs[idx].element;
+    }
 
     // Check result.x = r mod n
     bool_t<Builder> is_signature_valid = result_x_mod_r == r;

--- a/barretenberg/cpp/src/barretenberg/stdlib/encryption/ecdsa/ecdsa_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/encryption/ecdsa/ecdsa_impl.hpp
@@ -88,9 +88,10 @@ void validate_inputs(const stdlib::byte_array<Builder>& hashed_message,
  *  2. \f$0 < r < n\f$
  *  3. \f$0 < s < (n+1) / 2\f$
  *  4. Define \f$e := \mathbf{H}(m) \mod n\f$ and \f$Q := e s^{-1} G + r s^{-1} P \f$
- *  5. \f$Q\f$ is not the point at infinity AND \f$Q_x = r \mod n\f$ (note that \f$Q_x \in \mathbb{F}_q\f$)
+ *  5. \f$Q\f$ is not the point at infinity
+ *  6. \f$Q_x = r \mod n\f$ (note that \f$Q_x \in \mathbb{F}_q\f$)
  *
- * @note The requirement of step 2. is to avoid transaction malleability: if \f$(r,s)\f$ is a valid signature for
+ * @note The requirement of step 2. is to avoid signature malleability: if \f$(r,s)\f$ is a valid signature for
  * message \f$m\f$ and public key \f$P\f$, so is \f$(r,n-s)\f$. We protect against malleability by enforcing that
  * \f$s\f$ is always the lowest of the two possible values.
  *

--- a/barretenberg/cpp/src/barretenberg/stdlib/encryption/ecdsa/ecdsa_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/encryption/ecdsa/ecdsa_impl.hpp
@@ -261,8 +261,13 @@ template <typename Builder> void generate_ecdsa_verification_test_circuit(Builde
 
         byte_array<Builder> message(&builder, message_string);
 
+        // Compute H(m)
+        stdlib::byte_array<Builder> hashed_message =
+            static_cast<stdlib::byte_array<Builder>>(stdlib::SHA256<Builder>::hash(message));
+
         // Verify ecdsa signature
-        bool_t<Builder> result = stdlib::ecdsa_verify_signature<Builder, Curve, Fq, Fr, G1>(message, public_key, sig);
+        bool_t<Builder> result =
+            stdlib::ecdsa_verify_signature<Builder, Curve, Fq, Fr, G1>(hashed_message, public_key, sig);
         result.assert_equal(bool_t<Builder>(true));
     }
 }

--- a/barretenberg/cpp/src/barretenberg/stdlib/encryption/ecdsa/ecdsa_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/encryption/ecdsa/ecdsa_impl.hpp
@@ -181,7 +181,7 @@ template <typename Builder> void generate_ecdsa_verification_test_circuit(Builde
                                            typename curve::fq_ct,
                                            typename curve::bigfr_ct,
                                            typename curve::g1_bigfr_ct>(message, public_key, sig);
-        result.assert_equal(curve::bool_ct(true));
+        result.assert_equal(typename curve::bool_ct(true));
     }
 }
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/encryption/ecdsa/ecdsa_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/encryption/ecdsa/ecdsa_impl.hpp
@@ -203,7 +203,7 @@ bool_t<Builder> ecdsa_verify_signature(const stdlib::byte_array<Builder>& hashed
                                                         result.x.binary_basis_limbs[3].element);
     // Copy maximum limb values from Fq to Fr: this is needed by the subtraction happening in the == operator
     for (size_t idx = 0; idx < 4; idx++) {
-        result_x_mod_r.binary_basis_limbs[idx].maximum_value = result.x.binary_basis_limbs[idx].element;
+        result_x_mod_r.binary_basis_limbs[idx].maximum_value = result.x.binary_basis_limbs[idx].maximum_value;
     }
 
     // Check result.x = r mod n

--- a/barretenberg/cpp/src/barretenberg/stdlib/encryption/ecdsa/ecdsa_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/encryption/ecdsa/ecdsa_impl.hpp
@@ -238,7 +238,7 @@ template <typename Builder> void generate_ecdsa_verification_test_circuit(Builde
 
     std::string message_string = "Instructions unclear, ask again later.";
 
-    crypto::ecdsa_key_pair<fr, g1> account;
+    crypto::ecdsa_key_pair<FrNative, G1Native> account;
     for (size_t i = 0; i < num_iterations; i++) {
         // Generate unique signature for each iteration
         account.private_key = FrNative::random_element(&engine);

--- a/barretenberg/cpp/src/barretenberg/stdlib/encryption/ecdsa/ecdsa_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/encryption/ecdsa/ecdsa_impl.hpp
@@ -154,7 +154,7 @@ bool_t<Builder> ecdsa_verify_signature(const stdlib::byte_array<Builder>& hashed
 
     // Turn the hashed message into an element of Fr
     // The assertion means that an honest prover has a small probability of not being able to generate a valid proof if
-    // H(m) > n. Enforcing this condition introduces a small number of gates, and ensures that signatures cannot be
+    // H(m) >= n. Enforcing this condition introduces a small number of gates, and ensures that signatures cannot be
     // forged by finding a collision of H modulo n. While finding such a collision is supposed to be hard even modulo n,
     // we protect against this case with this cheap check.
     Fr z(hashed_message);

--- a/barretenberg/cpp/src/barretenberg/stdlib/encryption/ecdsa/ecdsa_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/encryption/ecdsa/ecdsa_impl.hpp
@@ -114,9 +114,9 @@ void validate_inputs(const stdlib::byte_array<Builder>& hashed_message,
  * @note The circuit introduces constraints for the following assertions:
  *          1. \$P\$ is on the curve
  *          2. \$H(m) < n\$
- *          2. \$0 < r < n\$
- *          3. \$0 < s < (n+1)/2\$
- *          4. \$Q := H(m) s^{-1} G + r s^{-1} P\$ is not the point at infinity
+ *          3. \$0 < r < n\$
+ *          4. \$0 < s < (n+1)/2\$
+ *          5. \$Q := H(m) s^{-1} G + r s^{-1} P\$ is not the point at infinity
  * Therefore, if the witnesses passed to this function do not satisfy these constraints, the resulting circuit
  * will be unsatisfied. If a user wants to use the verification inside a in-circuit branch, then they need to supply
  * valid data for \$P, r, s\$, even though \$(r,s)\$ doesn't need to be a valid signature.

--- a/barretenberg/cpp/src/barretenberg/stdlib/encryption/ecdsa/ecdsa_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/encryption/ecdsa/ecdsa_impl.hpp
@@ -195,7 +195,8 @@ bool_t<Builder> ecdsa_verify_signature(const stdlib::byte_array<Builder>& hashed
     Fr result_x_mod_r = Fr::unsafe_construct_from_limbs(result.x.binary_basis_limbs[0].element,
                                                         result.x.binary_basis_limbs[1].element,
                                                         result.x.binary_basis_limbs[2].element,
-                                                        result.x.binary_basis_limbs[3].element);
+                                                        result.x.binary_basis_limbs[3].element,
+                                                        /*can_overflow=*/true);
 
     // Check result.x = r mod n
     bool_t<Builder> is_signature_valid = result_x_mod_r == r;

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/curves/secp256r1.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/curves/secp256r1.hpp
@@ -17,20 +17,20 @@ namespace bb::stdlib {
 template <typename CircuitType> struct secp256r1 {
     static constexpr bb::CurveType type = bb::CurveType::SECP256R1;
 
-    typedef bb::secp256r1::fq fq;
-    typedef bb::secp256r1::fr fr;
-    typedef bb::secp256r1::g1 g1;
+    using fq = bb::secp256r1::fq;
+    using fr = bb::secp256r1::fr;
+    using g1 = bb::secp256r1::g1;
 
-    typedef CircuitType Builder;
-    typedef witness_t<Builder> witness_ct;
-    typedef public_witness_t<Builder> public_witness_ct;
-    typedef field_t<Builder> fr_ct;
-    typedef byte_array<Builder> byte_array_ct;
-    typedef bool_t<Builder> bool_ct;
+    using Builder = CircuitType;
+    using witness_ct = witness_t<Builder>;
+    using public_witness_ct = public_witness_t<Builder>;
+    using fr_ct = field_t<Builder>;
+    using byte_array_ct = byte_array<Builder>;
+    using bool_ct = bool_t<Builder>;
 
-    typedef bigfield<Builder, typename bb::secp256r1::FqParams> fq_ct;
-    typedef bigfield<Builder, typename bb::secp256r1::FrParams> bigfr_ct;
-    typedef element<Builder, fq_ct, fr_ct, g1> g1_ct;
-    typedef element<Builder, fq_ct, bigfr_ct, g1> g1_bigfr_ct;
+    using fq_ct = bigfield<Builder, typename bb::secp256r1::FqParams>;
+    using bigfr_ct = bigfield<Builder, typename bb::secp256r1::FrParams>;
+    using g1_ct = element<Builder, fq_ct, fr_ct, g1>;
+    using g1_bigfr_ct = element<Builder, fq_ct, bigfr_ct, g1>;
 };
 } // namespace bb::stdlib


### PR DESCRIPTION
Audit part 3: merge the two verification functions into one and restructuring.

* We merge the remaining two ecdsa verification functions into one. The difference between the two was that one was computing the result of ECDSA signature verification _and_ enforcing the verification to be successful, while the other was simply computing the result of ECDSA signature verification. We maintain only the function that performs the verification but doesn't enforce the verification to be successful. The rationale is that in Noir we expose signature verification, but we always receive the supposed result: `true` or `false`, and then we verify that the signature verification resulted in the expected result.
* We restructure the signature verification function to make the constraints clearer.
* We restructure testing to use `gtest`. This is in preparation of more thorough testing to be introduced in a follow-up PR.