### PR TITLE
chore: bump rollup_ivc_integration.test.ts jest timeout

### DIFF
--- a/yarn-project/ivc-integration/src/rollup_ivc_integration.test.ts
+++ b/yarn-project/ivc-integration/src/rollup_ivc_integration.test.ts
@@ -37,7 +37,7 @@ import {
 
 /* eslint-disable camelcase */
 
-jest.setTimeout(120_000);
+jest.setTimeout(150_000);
 
 const logger = createLogger('ivc-integration:test:rollup-native');
 


### PR DESCRIPTION
Bumped jest timeout from 120s to 150s. 