### PR TITLE
feat: a minimal fixed offset append merge

### DIFF
--- a/barretenberg/cpp/src/barretenberg/op_queue/ecc_op_queue.hpp
+++ b/barretenberg/cpp/src/barretenberg/op_queue/ecc_op_queue.hpp
@@ -63,10 +63,10 @@ class ECCOpQueue {
         ultra_ops_table.create_new_subtable();
     }
 
-    void merge(MergeSettings settings = MergeSettings::PREPEND)
+    void merge(MergeSettings settings = MergeSettings::PREPEND, std::optional<size_t> ultra_fixed_offset = std::nullopt)
     {
         eccvm_ops_table.merge(settings);
-        ultra_ops_table.merge(settings);
+        ultra_ops_table.merge(settings, ultra_fixed_offset);
     }
 
     // Construct polynomials corresponding to the columns of the full aggregate ultra ecc ops table

--- a/barretenberg/cpp/src/barretenberg/op_queue/ecc_ops_table.hpp
+++ b/barretenberg/cpp/src/barretenberg/op_queue/ecc_ops_table.hpp
@@ -259,14 +259,14 @@ class UltraEccOpsTable {
         if (settings == MergeSettings::APPEND) {
             // All appends are treated as fixed-location for ultra ops
             ASSERT(!has_fixed_append, "Can only perform fixed-location append once");
-            fixed_append_offset = offset; // May be nullopt, which means append right after prepended tables
+            // Set fixed location at which to append ultra ops. If nullopt --> append right after prepended tables
+            fixed_append_offset = offset;
             has_fixed_append = true;
-            // Still merge normally, but we'll handle the placement specially during column construction
             table.merge(settings);
             current_subtable_idx = table.num_subtables() - 1;
-        } else {
+        } else { // MergeSettings::PREPEND
             table.merge(settings);
-            current_subtable_idx = settings == MergeSettings::PREPEND ? 0 : table.num_subtables() - 1;
+            current_subtable_idx = 0;
         }
     }
 

--- a/barretenberg/cpp/src/barretenberg/op_queue/ecc_ops_table.hpp
+++ b/barretenberg/cpp/src/barretenberg/op_queue/ecc_ops_table.hpp
@@ -280,12 +280,12 @@ class UltraEccOpsTable {
         if (has_fixed_append) {
             // Handle fixed-location append: prepended tables first, then appended table at fixed offset
             return construct_column_polynomials_with_fixed_append(poly_size);
-        } else {
-            // Normal case: all subtables in order
-            const size_t subtable_start_idx = 0; // include all subtables
-            const size_t subtable_end_idx = table.num_subtables();
-            return construct_column_polynomials_from_subtables(poly_size, subtable_start_idx, subtable_end_idx);
         }
+
+        // Normal case: all subtables in order
+        const size_t subtable_start_idx = 0; // include all subtables
+        const size_t subtable_end_idx = table.num_subtables();
+        return construct_column_polynomials_from_subtables(poly_size, subtable_start_idx, subtable_end_idx);
     }
 
     // Construct the columns of the previous full ultra ecc ops table
@@ -298,8 +298,8 @@ class UltraEccOpsTable {
         return construct_column_polynomials_from_subtables(poly_size, subtable_start_idx, subtable_end_idx);
     }
 
-    // Construct the columns of the current ultra ecc ops subtable which is either the first or the last one depening on
-    // whether it has been prepended or appended
+    // Construct the columns of the current ultra ecc ops subtable which is either the first or the last one
+    // depening on whether it has been prepended or appended
     ColumnPolynomials construct_current_ultra_ops_subtable_columns() const
     {
         const size_t poly_size = current_ultra_subtable_size();

--- a/barretenberg/cpp/src/barretenberg/op_queue/ecc_ops_table.hpp
+++ b/barretenberg/cpp/src/barretenberg/op_queue/ecc_ops_table.hpp
@@ -230,17 +230,44 @@ class UltraEccOpsTable {
     size_t current_subtable_idx = 0; // index of the current subtable being constructed
     UltraOpsTable table;
 
+    // For fixed-location append functionality (ultra ops only)
+    std::optional<size_t> fixed_append_offset;
+    bool has_fixed_append = false;
+
   public:
     size_t size() const { return table.size(); }
-    size_t ultra_table_size() const { return table.size() * NUM_ROWS_PER_OP; }
+    size_t ultra_table_size() const
+    {
+        size_t base_size = table.size() * NUM_ROWS_PER_OP;
+        if (has_fixed_append && fixed_append_offset.has_value()) {
+            // Include zeros gap and final subtable at fixed location
+            size_t last_subtable_size = 0;
+            if (!table.get().empty()) {
+                // The last subtable in deque is the fixed-location one
+                last_subtable_size = table.get().back().size() * NUM_ROWS_PER_OP;
+            }
+            return std::max(base_size, fixed_append_offset.value() + last_subtable_size);
+        }
+        return base_size;
+    }
     size_t current_ultra_subtable_size() const { return table.get()[current_subtable_idx].size() * NUM_ROWS_PER_OP; }
     size_t previous_ultra_table_size() const { return (ultra_table_size() - current_ultra_subtable_size()); }
     void create_new_subtable(size_t size_hint = 0) { table.create_new_subtable(size_hint); }
     void push(const UltraOp& op) { table.push(op); }
-    void merge(MergeSettings settings = MergeSettings::PREPEND)
+    void merge(MergeSettings settings = MergeSettings::PREPEND, std::optional<size_t> offset = std::nullopt)
     {
-        table.merge(settings);
-        current_subtable_idx = settings == MergeSettings::PREPEND ? 0 : table.num_subtables() - 1;
+        if (settings == MergeSettings::APPEND) {
+            // All appends are treated as fixed-location for ultra ops
+            ASSERT(!has_fixed_append, "Can only perform fixed-location append once");
+            fixed_append_offset = offset; // May be nullopt, which means append right after prepended tables
+            has_fixed_append = true;
+            // Still merge normally, but we'll handle the placement specially during column construction
+            table.merge(settings);
+            current_subtable_idx = table.num_subtables() - 1;
+        } else {
+            table.merge(settings);
+            current_subtable_idx = settings == MergeSettings::PREPEND ? 0 : table.num_subtables() - 1;
+        }
     }
 
     std::vector<UltraOp> get_reconstructed() const { return table.get_reconstructed(); }
@@ -249,16 +276,21 @@ class UltraEccOpsTable {
     ColumnPolynomials construct_table_columns() const
     {
         const size_t poly_size = ultra_table_size();
-        const size_t subtable_start_idx = 0; // include all subtables
-        const size_t subtable_end_idx = table.num_subtables();
 
-        return construct_column_polynomials_from_subtables(poly_size, subtable_start_idx, subtable_end_idx);
+        if (has_fixed_append) {
+            // Handle fixed-location append: prepended tables first, then appended table at fixed offset
+            return construct_column_polynomials_with_fixed_append(poly_size);
+        } else {
+            // Normal case: all subtables in order
+            const size_t subtable_start_idx = 0; // include all subtables
+            const size_t subtable_end_idx = table.num_subtables();
+            return construct_column_polynomials_from_subtables(poly_size, subtable_start_idx, subtable_end_idx);
+        }
     }
 
     // Construct the columns of the previous full ultra ecc ops table
     ColumnPolynomials construct_previous_table_columns() const
     {
-
         const size_t poly_size = previous_ultra_table_size();
         const size_t subtable_start_idx = current_subtable_idx == 0 ? 1 : 0;
         const size_t subtable_end_idx = current_subtable_idx == 0 ? table.num_subtables() : table.num_subtables() - 1;
@@ -279,6 +311,60 @@ class UltraEccOpsTable {
 
   private:
     /**
+     * @brief Write a single UltraOp to the column polynomials at the given position
+     * @details Each op is written across 2 rows (NUM_ROWS_PER_OP)
+     * @param column_polynomials The column polynomials to write to
+     * @param op The operation to write
+     * @param row_idx The starting row index (will write to row_idx and row_idx+1)
+     */
+    static void write_op_to_polynomials(ColumnPolynomials& column_polynomials, const UltraOp& op, const size_t row_idx)
+    {
+        column_polynomials[0].at(row_idx) = !op.op_code.is_random_op ? op.op_code.value() : op.op_code.random_value_1;
+        column_polynomials[1].at(row_idx) = op.x_lo;
+        column_polynomials[2].at(row_idx) = op.x_hi;
+        column_polynomials[3].at(row_idx) = op.y_lo;
+        column_polynomials[0].at(row_idx + 1) = !op.op_code.is_random_op ? 0 : op.op_code.random_value_2;
+        column_polynomials[1].at(row_idx + 1) = op.y_hi;
+        column_polynomials[2].at(row_idx + 1) = op.z_1;
+        column_polynomials[3].at(row_idx + 1) = op.z_2;
+    }
+
+    /**
+     * @brief Construct polynomials with fixed-location append
+     * @details Process prepended subtables first, then place the appended subtable at the fixed offset
+     */
+    ColumnPolynomials construct_column_polynomials_with_fixed_append(const size_t poly_size) const
+    {
+        ColumnPolynomials column_polynomials;
+        for (auto& poly : column_polynomials) {
+            poly = Polynomial<Fr>(poly_size); // Initialized to zeros
+        }
+
+        // Process all prepended subtables (all except last)
+        size_t i = 0;
+        for (size_t subtable_idx = 0; subtable_idx < table.num_subtables() - 1; ++subtable_idx) {
+            const auto& subtable = table.get()[subtable_idx];
+            for (const auto& op : subtable) {
+                write_op_to_polynomials(column_polynomials, op, i);
+                i += NUM_ROWS_PER_OP;
+            }
+        }
+
+        // Place the appended subtable at the fixed offset
+        size_t append_position = fixed_append_offset.value_or(i);
+        const auto& appended_subtable = table.get()[table.num_subtables() - 1];
+
+        size_t j = append_position;
+        for (const auto& op : appended_subtable) {
+            write_op_to_polynomials(column_polynomials, op, j);
+            j += NUM_ROWS_PER_OP;
+        }
+
+        // Any gap between prepended tables and appended table remains zeros (from initialization)
+        return column_polynomials;
+    }
+
+    /**
      * @brief Construct polynomials corresponding to the columns of the reconstructed ultra ops table for the given
      * range of subtables
      * TODO(https://github.com/AztecProtocol/barretenberg/issues/1267): multithread this functionality
@@ -297,17 +383,8 @@ class UltraEccOpsTable {
         for (size_t subtable_idx = subtable_start_idx; subtable_idx < subtable_end_idx; ++subtable_idx) {
             const auto& subtable = table.get()[subtable_idx];
             for (const auto& op : subtable) {
-                column_polynomials[0].at(i) = !op.op_code.is_random_op ? op.op_code.value() : op.op_code.random_value_1;
-                column_polynomials[1].at(i) = op.x_lo;
-                column_polynomials[2].at(i) = op.x_hi;
-                column_polynomials[3].at(i) = op.y_lo;
-                i++;
-                column_polynomials[0].at(i) = !op.op_code.is_random_op ? 0 : op.op_code.random_value_2;
-                // only the first 'op' field is utilized
-                column_polynomials[1].at(i) = op.y_hi;
-                column_polynomials[2].at(i) = op.z_1;
-                column_polynomials[3].at(i) = op.z_2;
-                i++;
+                write_op_to_polynomials(column_polynomials, op, i);
+                i += NUM_ROWS_PER_OP;
             }
         }
         return column_polynomials;

--- a/barretenberg/cpp/src/barretenberg/op_queue/ecc_ops_table.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/op_queue/ecc_ops_table.test.cpp
@@ -196,6 +196,141 @@ TEST(EccOpsTableTest, UltraOpsPrependThenAppend)
     }
 }
 
+TEST(EccOpsTableTest, UltraOpsFixedLocationAppendNoGap)
+{
+    using Fr = fr;
+    using TableGenerator = EccOpsTableTest::UltraOpTableGenerator;
+
+    // Construct sets of ultra ops
+    const size_t NUM_SUBTABLES = 3;
+    std::vector<size_t> subtable_op_counts = { 4, 2, 7 };
+
+    TableGenerator table_generator;
+    auto subtables = table_generator.generate_subtables(NUM_SUBTABLES, subtable_op_counts);
+
+    // Construct the concatenated table with fixed-location append (no explicit offset)
+    UltraEccOpsTable ultra_ops_table;
+    std::array<MergeSettings, NUM_SUBTABLES> merge_settings = { MergeSettings::PREPEND,
+                                                                MergeSettings::PREPEND,
+                                                                MergeSettings::APPEND };
+
+    for (size_t i = 0; i < NUM_SUBTABLES; ++i) {
+        ultra_ops_table.create_new_subtable();
+        for (const auto& op : subtables[i]) {
+            ultra_ops_table.push(op);
+        }
+
+        // For APPEND (last subtable), don't provide an offset (default to right after prepended tables)
+        ultra_ops_table.merge(merge_settings[i]);
+    }
+
+    // Expected order: subtable[1], subtable[0], subtable[2] (no gap)
+    std::vector<std::vector<UltraOp>> ordered_subtables = { subtables[1], subtables[0], subtables[2] };
+
+    // Construct the mock ultra ops table
+    EccOpsTableTest::MockUltraOpsTable expected_ultra_ops_table(ordered_subtables);
+
+    // Check that the ultra ops table has the correct size
+    auto expected_num_ops = std::accumulate(subtable_op_counts.begin(), subtable_op_counts.end(), size_t(0));
+    EXPECT_EQ(ultra_ops_table.size(), expected_num_ops);
+
+    // Construct polynomials corresponding to the columns of the ultra ops table
+    std::array<Polynomial<Fr>, 4> ultra_ops_table_polynomials = ultra_ops_table.construct_table_columns();
+
+    // Check that the ultra ops table matches the expected table
+    for (auto [expected_column, poly] : zip_view(expected_ultra_ops_table.columns, ultra_ops_table_polynomials)) {
+        for (auto [expected_value, value] : zip_view(expected_column, poly.coeffs())) {
+            EXPECT_EQ(expected_value, value);
+        }
+    }
+}
+
+TEST(EccOpsTableTest, UltraOpsFixedLocationAppendWithGap)
+{
+    using Fr = fr;
+    using TableGenerator = EccOpsTableTest::UltraOpTableGenerator;
+
+    const size_t ULTRA_ROWS_PER_OP = UltraEccOpsTable::NUM_ROWS_PER_OP;
+
+    // Construct sets of ultra ops
+    const size_t NUM_SUBTABLES = 3;
+    std::vector<size_t> subtable_op_counts = { 4, 2, 7 };
+
+    TableGenerator table_generator;
+    auto subtables = table_generator.generate_subtables(NUM_SUBTABLES, subtable_op_counts);
+
+    // Construct the concatenated table with fixed-location append at specific offset
+    UltraEccOpsTable ultra_ops_table;
+    std::array<MergeSettings, NUM_SUBTABLES> merge_settings = { MergeSettings::PREPEND,
+                                                                MergeSettings::PREPEND,
+                                                                MergeSettings::APPEND };
+
+    // Define a fixed offset at which to append the table (must be greater than the total size of the prepended tables)
+    const size_t fixed_offset = 20;
+    const size_t prepended_size = (subtable_op_counts[0] + subtable_op_counts[1]) * ULTRA_ROWS_PER_OP;
+    ASSERT(fixed_offset > prepended_size);
+
+    // Construct the ultra ops table
+    for (size_t i = 0; i < NUM_SUBTABLES; ++i) {
+        ultra_ops_table.create_new_subtable();
+        for (const auto& op : subtables[i]) {
+            ultra_ops_table.push(op);
+        }
+
+        // For APPEND (last subtable), provide a fixed offset
+        if (merge_settings[i] == MergeSettings::APPEND) {
+            ultra_ops_table.merge(merge_settings[i], fixed_offset);
+        } else {
+            ultra_ops_table.merge(merge_settings[i]);
+        }
+    }
+
+    // Check that the ultra ops table has the correct total size (gap is not present in raw ops table)
+    auto expected_num_ops = std::accumulate(subtable_op_counts.begin(), subtable_op_counts.end(), size_t(0));
+    EXPECT_EQ(ultra_ops_table.size(), expected_num_ops);
+
+    // Check that the polynomials have the correct size (including gap)
+    size_t expected_poly_size = fixed_offset + (subtable_op_counts[2] * ULTRA_ROWS_PER_OP);
+    EXPECT_EQ(ultra_ops_table.ultra_table_size(), expected_poly_size);
+
+    // Construct polynomials corresponding to the columns of the ultra ops table
+    std::array<Polynomial<Fr>, 4> ultra_ops_table_polynomials = ultra_ops_table.construct_table_columns();
+
+    // Verify each polynomial has the expected size
+    for (const auto& poly : ultra_ops_table_polynomials) {
+        EXPECT_EQ(poly.size(), expected_poly_size);
+    }
+
+    // Construct expected table with zeros in the gap
+    // Order: subtable[1], subtable[0], zeros, subtable[2]
+    std::vector<std::vector<UltraOp>> ordered_subtables = { subtables[1], subtables[0] };
+    EccOpsTableTest::MockUltraOpsTable expected_prepended_table(ordered_subtables);
+
+    // Check prepended subtables are at the beginning
+    for (auto [ultra_op_poly, expected_poly] :
+         zip_view(ultra_ops_table_polynomials, expected_prepended_table.columns)) {
+        for (size_t row = 0; row < prepended_size; ++row) {
+            EXPECT_EQ(ultra_op_poly.at(row), expected_poly[row]);
+        }
+    }
+
+    // Check gap from offset to appended subtable is filled with zeros
+    for (auto ultra_op_poly : ultra_ops_table_polynomials) {
+        for (size_t row = prepended_size; row < fixed_offset; ++row) {
+            EXPECT_EQ(ultra_op_poly.at(row), Fr::zero());
+        }
+    }
+
+    // Check appended subtable is at the fixed offset
+    std::vector<std::vector<UltraOp>> appended_subtables = { subtables[2] };
+    EccOpsTableTest::MockUltraOpsTable expected_appended_table(appended_subtables);
+    for (auto [ultra_op_poly, expected_poly] : zip_view(ultra_ops_table_polynomials, expected_appended_table.columns)) {
+        for (size_t row = 0; row < subtable_op_counts[2] * ULTRA_ROWS_PER_OP; ++row) {
+            EXPECT_EQ(ultra_op_poly.at(fixed_offset + row), expected_poly[row]);
+        }
+    }
+}
+
 // Ensure EccvmOpsTable correctly constructs a concatenated table from successively prepended subtables
 TEST(EccOpsTableTest, EccvmOpsTable)
 {


### PR DESCRIPTION
Implements a not very flexible but just what we need "fixed offset" append merge in the ops table logic. Allows for concatenating the ultra ops subtable at a fixed location as is needed for merge ZK.