### PR TITLE
feat(avm): skippable check-circuit

### DIFF
--- a/barretenberg/cpp/src/barretenberg/vm2/avm_api.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/avm_api.cpp
@@ -45,7 +45,7 @@ bool AvmAPI::check_circuit(const AvmAPI::ProvingInputs& inputs)
     info("Generating trace...");
     AvmTraceGenHelper tracegen_helper;
     tracegen::TraceContainer trace;
-    tracegen_helper.fill_trace_columns(trace, std::move(events), inputs.publicInputs);
+    AVM_TRACK_TIME("tracegen/all", tracegen_helper.fill_trace_columns(trace, std::move(events), inputs.publicInputs));
 
     // Go into interactive debug mode if requested.
     if (getenv("AVM_DEBUG") != nullptr) {
@@ -53,7 +53,7 @@ bool AvmAPI::check_circuit(const AvmAPI::ProvingInputs& inputs)
         debugger.run();
     }
 
-    tracegen_helper.fill_trace_interactions(trace);
+    AVM_TRACK_TIME("tracegen/all", tracegen_helper.fill_trace_interactions(trace));
 
     // Check circuit.
     info("Checking circuit...");

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/check_circuit.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/check_circuit.hpp
@@ -8,6 +8,6 @@ namespace bb::avm2::constraining {
 
 // This is a version of check circuit that runs on the prover polynomials.
 // It is the closest to "real proving" that we can get without actually running the prover.
-void run_check_circuit(AvmFlavor::ProverPolynomials& polys, size_t num_rows);
+void run_check_circuit(AvmFlavor::ProverPolynomials& polys, size_t num_rows, bool skippable_enabled = true);
 
 } // namespace bb::avm2::constraining

--- a/barretenberg/cpp/src/barretenberg/vm2/proving_helper.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/proving_helper.cpp
@@ -89,12 +89,18 @@ bool AvmProvingHelper::check_circuit(tracegen::TraceContainer&& trace)
     // PLUS one extra row to catch any possible errors in the empty remainder
     // of the circuit.
     const size_t num_rows = trace.get_num_rows_without_clk() + 1;
-    info("Running check circuit over ", num_rows, " rows.");
+    const bool skippable_enabled = true;
+    info("Running check ",
+         skippable_enabled ? "(with skippable)" : "(without skippable)",
+         " circuit over ",
+         num_rows,
+         " rows.");
 
     // Warning: this destroys the trace.
     auto polynomials = AVM_TRACK_TIME_V("proving/prove:compute_polynomials", constraining::compute_polynomials(trace));
     try {
-        AVM_TRACK_TIME("proving/check_circuit", constraining::run_check_circuit(polynomials, num_rows));
+        AVM_TRACK_TIME("proving/check_circuit",
+                       constraining::run_check_circuit(polynomials, num_rows, skippable_enabled));
     } catch (std::runtime_error& e) {
         // FIXME: This exception is never caught because it's thrown in a different thread.
         // Execution never gets here!


### PR DESCRIPTION
Considers `skippable` in check-circuit. Also fixes that we were not properly testing linearly dependent subrelations.

Check circuit part of bulk test goes from ~11s to ~1s.
