### PR TITLE
feat: DelayedPrivateMutable state variable

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -130,6 +130,7 @@
     "Flashbots",
     "flatmap",
     "foundryup",
+    "frankensteinian",
     "frontend",
     "frontends",
     "fullpath",

--- a/noir-projects/aztec-nr/aztec/src/context/private_context.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/private_context.nr
@@ -554,6 +554,16 @@ impl PrivateContext {
         get_block_header_at(block_number, self)
     }
 
+    /// Gets the block timestamp of the anchor block (the block whose roots this function
+    /// is reading from).
+    ///
+    /// # Returns
+    /// `u64` - the timestamp of the anchor block for this private function.
+    ///
+    pub fn get_anchor_timestamp(self) -> u64 {
+        self.get_block_header().global_variables.timestamp
+    }
+
     /// Sets the hash of the return values for this private function.
     ///
     /// Very low-level function: this is called by the #[private] macro.

--- a/noir-projects/aztec-nr/aztec/src/history/note_inclusion.nr
+++ b/noir-projects/aztec-nr/aztec/src/history/note_inclusion.nr
@@ -22,6 +22,8 @@ pub trait ProveNoteInclusion {
 }
 
 impl ProveNoteInclusion for BlockHeader {
+    // TODO: "prove" is too broad; everything is being proven.
+    // Renaming suggestion: assert_note_exists
     fn prove_note_inclusion<Note>(self, retrieved_note: RetrievedNote<Note>, storage_slot: Field)
     where
         Note: NoteHash,

--- a/noir-projects/aztec-nr/aztec/src/history/note_validity.nr
+++ b/noir-projects/aztec-nr/aztec/src/history/note_validity.nr
@@ -19,6 +19,9 @@ trait ProveNoteValidity {
         Note: NoteHash;
 }
 
+// TODO: "prove" and "validity" are not the correct terms here; they're both too broad.
+// We're _asserting_ that the note is still "current".
+// Renaming suggestion: assert_note_is_current
 impl ProveNoteValidity for BlockHeader {
     fn prove_note_validity<Note>(
         self,

--- a/noir-projects/aztec-nr/aztec/src/history/nullifier_inclusion.nr
+++ b/noir-projects/aztec-nr/aztec/src/history/nullifier_inclusion.nr
@@ -56,6 +56,8 @@ pub trait ProveNoteIsNullified {
 }
 
 impl ProveNoteIsNullified for BlockHeader {
+    // TODO: "prove" is too broad; everything is being proven.
+    // Renaming suggestion: assert_note_is_nullified.
     // docs:start:prove_note_is_nullified
     fn prove_note_is_nullified<Note>(
         self,

--- a/noir-projects/aztec-nr/aztec/src/history/nullifier_non_inclusion.nr
+++ b/noir-projects/aztec-nr/aztec/src/history/nullifier_non_inclusion.nr
@@ -66,6 +66,8 @@ pub trait ProveNoteNotNullified {
 }
 
 impl ProveNoteNotNullified for BlockHeader {
+    // TODO: "prove" is too broad; everything is being proven.
+    // Renaming suggestion: assert_note_not_nullified.
     // docs:start:prove_note_not_nullified
     fn prove_note_not_nullified<Note>(
         self,

--- a/noir-projects/aztec-nr/aztec/src/macros/aztec.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/aztec.nr
@@ -277,7 +277,7 @@ comptime fn generate_process_message() -> Quoted {
             message_ciphertext: BoundedVec<Field, aztec::protocol_types::constants::PRIVATE_LOG_CIPHERTEXT_LEN>,
             message_context: aztec::messages::processing::message_context::MessageContext,
         ) {
-            aztec::messages::discovery::process_message::do_process_message(
+            aztec::messages::discovery::process_message::process_message_ciphertext(
                 context.this_address(),
                 _compute_note_hash_and_nullifier,
                 message_ciphertext,

--- a/noir-projects/aztec-nr/aztec/src/macros/functions/utils.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/functions/utils.nr
@@ -364,7 +364,9 @@ pub(crate) comptime fn create_message_discovery_call() -> Quoted {
         unsafe {
             dep::aztec::messages::discovery::discover_new_messages(
                 context.this_address(),
-                _compute_note_hash_and_nullifier,
+                // This fn is generated within the #[aztec] macro.
+                // See generate_contract_library_method_compute_note_hash_and_nullifier
+                _compute_note_hash_and_nullifier, 
             );
         };
     }

--- a/noir-projects/aztec-nr/aztec/src/macros/notes.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/notes.nr
@@ -2,7 +2,7 @@ use crate::note::note_getter_options::PropertySelector;
 use std::{collections::bounded_vec::BoundedVec, meta::{ctstring::AsCtString, type_of}};
 
 /// Maximum number of note types within 1 contract.
-comptime global MAX_NOTE_TYPES: u32 = 128;
+pub comptime global MAX_NOTE_TYPES: u32 = 128;
 
 /// A BoundedVec containing all the note types within this contract.
 /// TODO(https://github.com/AztecProtocol/aztec-packages/issues/16527): rename to NOTE_TYPES
@@ -123,7 +123,7 @@ comptime fn generate_note_hash_trait_impl(s: TypeDefinition) -> Quoted {
 ///
 /// impl aztec::note::note_interface::NoteProperties<TokenNoteProperties> for TokenNote {
 ///     fn properties() -> TokenNoteProperties {
-///         Self {
+///         TokenNoteProperties {
 ///             amount: aztec::note::note_getter_options::PropertySelector { index: 0, offset: 0, length: 32 },
 ///             npk_m_hash: aztec::note::note_getter_options::PropertySelector { index: 1, offset: 0, length: 32 },
 ///             randomness: aztec::note::note_getter_options::PropertySelector { index: 2, offset: 0, length: 32 }

--- a/noir-projects/aztec-nr/aztec/src/macros/notes.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/notes.nr
@@ -5,7 +5,7 @@ use std::{collections::bounded_vec::BoundedVec, meta::{ctstring::AsCtString, typ
 comptime global MAX_NOTE_TYPES: u32 = 128;
 
 /// A BoundedVec containing all the note types within this contract.
-/// TODO: rename to NOTE_TYPES
+/// TODO(https://github.com/AztecProtocol/aztec-packages/issues/16527): rename to NOTE_TYPES
 pub comptime mut global NOTES: BoundedVec<Type, MAX_NOTE_TYPES> = BoundedVec::new();
 
 comptime mut global NOTE_TYPE_ID_COUNTER: u32 = 0;

--- a/noir-projects/aztec-nr/aztec/src/macros/notes.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/notes.nr
@@ -5,6 +5,7 @@ use std::{collections::bounded_vec::BoundedVec, meta::{ctstring::AsCtString, typ
 comptime global MAX_NOTE_TYPES: u32 = 128;
 
 /// A BoundedVec containing all the note types within this contract.
+/// TODO: rename to NOTE_TYPES
 pub comptime mut global NOTES: BoundedVec<Type, MAX_NOTE_TYPES> = BoundedVec::new();
 
 comptime mut global NOTE_TYPE_ID_COUNTER: u32 = 0;

--- a/noir-projects/aztec-nr/aztec/src/messages/discovery/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/discovery/mod.nr
@@ -8,7 +8,9 @@ pub mod process_message;
 
 use crate::{
     messages::{
-        discovery::{private_notes::MAX_NOTE_PACKED_LEN, process_message::do_process_message},
+        discovery::{
+            private_notes::MAX_NOTE_PACKED_LEN, process_message::process_message_ciphertext,
+        },
         processing::{
             get_private_logs, pending_tagged_log::PendingTaggedLog,
             validate_enqueued_notes_and_events,
@@ -59,7 +61,7 @@ pub struct NoteHashAndNullifier {
 ///     };
 /// }
 /// ```
-type ComputeNoteHashAndNullifier<Env> = unconstrained fn[Env](/* packed_note */BoundedVec<Field, MAX_NOTE_PACKED_LEN>, /* storage_slot */ Field, /* note_type_id */ Field, /* contract_address */ AztecAddress, /* note nonce */ Field) -> Option<NoteHashAndNullifier>;
+pub type ComputeNoteHashAndNullifier<Env> = unconstrained fn[Env](/* packed_note */BoundedVec<Field, MAX_NOTE_PACKED_LEN>, /* storage_slot */ Field, /* note_type_id */ Field, /* contract_address */ AztecAddress, /* note nonce */ Field) -> Option<NoteHashAndNullifier>;
 
 /// Performs the message discovery process, in which private are downloaded and inspected to find new private notes,
 /// partial notes and events, etc., and pending partial notes are processed to search for their completion logs.
@@ -85,7 +87,7 @@ pub unconstrained fn discover_new_messages<Env>(
         // We remove the tag from the pending tagged log and process the message ciphertext contained in it.
         let message_ciphertext = array::subbvec(pending_tagged_log.log, 1);
 
-        do_process_message(
+        process_message_ciphertext(
             contract_address,
             compute_note_hash_and_nullifier,
             message_ciphertext,

--- a/noir-projects/aztec-nr/aztec/src/messages/discovery/process_message.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/discovery/process_message.nr
@@ -3,7 +3,7 @@ use crate::messages::{
         ComputeNoteHashAndNullifier, partial_notes::process_partial_note_private_msg,
         private_events::process_private_event_msg, private_notes::process_private_note_msg,
     },
-    encoding::decode_message,
+    encoding::{decode_message, MAX_MESSAGE_LEN},
     encryption::{aes128::AES128, log_encryption::LogEncryption},
     msg_type::{
         PARTIAL_NOTE_PRIVATE_MSG_TYPE_ID, PRIVATE_EVENT_MSG_TYPE_ID, PRIVATE_NOTE_MSG_TYPE_ID,
@@ -29,19 +29,31 @@ use protocol_types::{
 ///
 /// Events are processed by computing an event commitment from the serialized event data and its randomness field, then
 /// enqueueing the event data and commitment for validation.
-pub unconstrained fn do_process_message<Env>(
+pub unconstrained fn process_message_ciphertext<Env>(
     contract_address: AztecAddress,
     compute_note_hash_and_nullifier: ComputeNoteHashAndNullifier<Env>,
     message_ciphertext: BoundedVec<Field, PRIVATE_LOG_CIPHERTEXT_LEN>,
     message_context: MessageContext,
 ) {
-    let message = AES128::decrypt_log(message_ciphertext, message_context.recipient);
+    process_message_plaintext(
+        contract_address,
+        compute_note_hash_and_nullifier,
+        AES128::decrypt_log(message_ciphertext, message_context.recipient),
+        message_context,
+    );
+}
 
+pub unconstrained fn process_message_plaintext<Env>(
+    contract_address: AztecAddress,
+    compute_note_hash_and_nullifier: ComputeNoteHashAndNullifier<Env>,
+    message_plaintext: BoundedVec<Field, MAX_MESSAGE_LEN>,
+    message_context: MessageContext,
+) {
     // The first thing to do after decrypting the message is to determine what type of message we're processing. We
     // have 3 message types: private notes, partial notes and events.
 
     // We decode the message to obtain the message type id, metadata and content.
-    let (msg_type_id, msg_metadata, msg_content) = decode_message(message);
+    let (msg_type_id, msg_metadata, msg_content) = decode_message(message_plaintext);
 
     if msg_type_id == PRIVATE_NOTE_MSG_TYPE_ID {
         debug_log("Processing private note msg");

--- a/noir-projects/aztec-nr/aztec/src/messages/logs/note.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/logs/note.nr
@@ -33,51 +33,75 @@ pub fn compute_note_log<Note>(
 where
     Note: NoteType + Packable,
 {
-    compute_log(note, storage_slot, recipient, PRIVATE_NOTE_MSG_TYPE_ID)
+    let message_plaintext = private_note_to_message_plaintext(note, storage_slot);
+    let message_ciphertext = AES128::encrypt_log(message_plaintext, recipient);
+
+    prefix_with_tag(message_ciphertext, recipient)
 }
 
-pub fn compute_partial_note_log<Note>(
-    note: Note,
+pub fn compute_partial_note_private_content_log<PartialNotePrivateContent>(
+    partial_note_private_content: PartialNotePrivateContent,
     storage_slot: Field,
     recipient: AztecAddress,
 ) -> [Field; PRIVATE_LOG_SIZE_IN_FIELDS]
 where
-    Note: NoteType + Packable,
+    PartialNotePrivateContent: NoteType + Packable,
 {
-    compute_log(
-        note,
+    let message_plaintext = partial_note_private_content_to_message_plaintext(
+        partial_note_private_content,
         storage_slot,
-        recipient,
+    );
+    let message_ciphertext = AES128::encrypt_log(message_plaintext, recipient);
+
+    prefix_with_tag(message_ciphertext, recipient)
+}
+
+pub fn partial_note_private_content_to_message_plaintext<PartialNotePrivateContent>(
+    partial_note_private_content: PartialNotePrivateContent,
+    storage_slot: Field,
+) -> [Field; <PartialNotePrivateContent as Packable>::N + 2]
+where
+    PartialNotePrivateContent: NoteType + Packable,
+{
+    let packed_private_content = partial_note_private_content.pack();
+
+    // A partial note message's content is the storage slot followed by the packed private content representation
+    let mut msg_content = [0; 1 + <PartialNotePrivateContent as Packable>::N];
+    msg_content[0] = storage_slot;
+    for i in 0..packed_private_content.len() {
+        msg_content[1 + i] = packed_private_content[i];
+    }
+
+    encode_message(
         PARTIAL_NOTE_PRIVATE_MSG_TYPE_ID,
+        // Notes use the note type id for metadata
+        PartialNotePrivateContent::get_id() as u64,
+        msg_content,
     )
 }
 
-fn compute_log<Note>(
+pub fn private_note_to_message_plaintext<Note>(
     note: Note,
     storage_slot: Field,
-    recipient: AztecAddress,
-    msg_type: u64,
-) -> [Field; PRIVATE_LOG_SIZE_IN_FIELDS]
+) -> [Field; <Note as Packable>::N + 2]
 where
     Note: NoteType + Packable,
 {
     let packed_note = note.pack();
 
-    // A note message's content is the storage slot followed by the packed note representation
+    // A private note message's content is the storage slot followed by the packed note representation
     let mut msg_content = [0; 1 + <Note as Packable>::N];
     msg_content[0] = storage_slot;
     for i in 0..packed_note.len() {
         msg_content[1 + i] = packed_note[i];
     }
 
-    // Notes use the note type id for metadata
-    let plaintext = encode_message(msg_type, Note::get_id() as u64, msg_content);
-
-    let ciphertext = AES128::encrypt_log(plaintext, recipient);
-
-    let log = prefix_with_tag(ciphertext, recipient);
-
-    log
+    encode_message(
+        PRIVATE_NOTE_MSG_TYPE_ID,
+        // Notes use the note type id for metadata
+        Note::get_id() as u64,
+        msg_content,
+    )
 }
 
 /// Sends an encrypted message to `recipient` with the content of the note, which they will discover when processing

--- a/noir-projects/aztec-nr/aztec/src/messages/processing/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/processing/mod.nr
@@ -46,6 +46,7 @@ global LOG_RETRIEVAL_RESPONSES_ARRAY_BASE_SLOT: Field = sha256_to_field(
 
 /// Searches for private logs emitted by `contract_address` that might contain messages for one of the local accounts,
 /// and stores them in a `CapsuleArray` which is then returned.
+/// TODO: if this fn only gets called from within ../discovery/, shouldn't it live there?
 pub(crate) unconstrained fn get_private_logs(
     contract_address: AztecAddress,
 ) -> CapsuleArray<PendingTaggedLog> {

--- a/noir-projects/aztec-nr/aztec/src/note/lifecycle.nr
+++ b/noir-projects/aztec-nr/aztec/src/note/lifecycle.nr
@@ -49,6 +49,9 @@ where
     destroy_note_unsafe(context, retrieved_note, note_hash_for_read_request)
 }
 
+// Computes and pushes the nullifier for a given note.
+// "Unsafe" because it presumes the param `note_hash_for_read_request` is
+// actually the note hash for the param `retrieved_note`, without checking.
 pub fn destroy_note_unsafe<Note>(
     context: &mut PrivateContext,
     retrieved_note: RetrievedNote<Note>,
@@ -61,8 +64,8 @@ where
         compute_note_hash_for_nullify_from_read_request(retrieved_note, note_hash_for_read_request);
     let nullifier = retrieved_note.note.compute_nullifier(context, note_hash_for_nullify);
 
-    let note_hash = if retrieved_note.metadata.is_settled() {
-        // Counter is zero, so we're nullifying a settled note and we don't populate the note_hash with real value.
+    let pending_note_hash = if retrieved_note.metadata.is_settled() {
+        // Counter is zero, so we're nullifying a settled note and we don't populate the transient_note_hash with a real value.
         0
     } else {
         // A non-zero note hash counter implies that we're nullifying a pending note (i.e. one that has not yet been
@@ -73,5 +76,5 @@ where
         note_hash_for_nullify
     };
 
-    context.push_nullifier_for_note_hash(nullifier, note_hash)
+    context.push_nullifier_for_note_hash(nullifier, pending_note_hash)
 }

--- a/noir-projects/aztec-nr/aztec/src/note/note_getter.nr
+++ b/noir-projects/aztec-nr/aztec/src/note/note_getter.nr
@@ -81,7 +81,7 @@ where
 {
     // Safety: Constraining that we got a valid note from the oracle is fairly straightforward: all we need to do
     // is check that the metadata is correct, and that the note exists.
-    let retrieved_note = unsafe { get_note_internal::<Note>(storage_slot) };
+    let retrieved_note = unsafe { view_note::<Note>(storage_slot) };
 
     // For settled notes, the contract address is implicitly checked since the hash returned from
     // `compute_note_hash_for_read_request` is siloed and kernels verify the siloing during note read request
@@ -189,7 +189,7 @@ where
     (notes, note_hashes)
 }
 
-unconstrained fn get_note_internal<Note>(storage_slot: Field) -> RetrievedNote<Note>
+pub unconstrained fn view_note<Note>(storage_slot: Field) -> RetrievedNote<Note>
 where
     Note: NoteType + Packable,
 {
@@ -210,7 +210,7 @@ where
         NoteStatus.ACTIVE,
     );
 
-    opt_notes[0].expect(f"Failed to get a note") // Notice: we don't allow dummies to be returned from get_note (singular).
+    opt_notes[0].expect(f"Failed to get a note")
 }
 
 unconstrained fn get_notes_internal<Note, let M: u32, PreprocessorArgs, FilterArgs>(

--- a/noir-projects/aztec-nr/aztec/src/note/note_getter/test.nr
+++ b/noir-projects/aztec-nr/aztec/src/note/note_getter/test.nr
@@ -36,7 +36,7 @@ where
 }
 
 #[test]
-unconstrained fn processes_single_note() {
+unconstrained fn constrain_get_notes_processes_single_note() {
     let env = TestEnvironment::_new();
 
     env.private_context(|context| {
@@ -53,7 +53,7 @@ unconstrained fn processes_single_note() {
 }
 
 #[test]
-unconstrained fn processes_many_notes() {
+unconstrained fn constrain_get_notes_processes_many_notes() {
     let env = TestEnvironment::_new();
 
     env.private_context(|context| {
@@ -71,7 +71,7 @@ unconstrained fn processes_many_notes() {
 }
 
 #[test]
-unconstrained fn collapses_notes_at_the_beginning_of_the_array() {
+unconstrained fn constrain_get_notes_collapses_notes_at_the_beginning_of_the_array() {
     let env = TestEnvironment::_new();
 
     env.private_context(|context| {
@@ -100,7 +100,7 @@ unconstrained fn collapses_notes_at_the_beginning_of_the_array() {
 }
 
 #[test]
-unconstrained fn can_return_zero_notes() {
+unconstrained fn constrain_get_notes_can_return_zero_notes() {
     let env = TestEnvironment::_new();
 
     env.private_context(|context| {
@@ -114,7 +114,7 @@ unconstrained fn can_return_zero_notes() {
 }
 
 #[test(should_fail_with = "Got more notes than limit.")]
-unconstrained fn rejects_mote_notes_than_limit() {
+unconstrained fn constrain_get_notes_rejects_mote_notes_than_limit() {
     let env = TestEnvironment::_new();
 
     env.private_context(|context| {
@@ -130,7 +130,7 @@ unconstrained fn rejects_mote_notes_than_limit() {
 }
 
 #[test]
-unconstrained fn applies_filter_before_constraining() {
+unconstrained fn constrain_get_notes_applies_filter_before_constraining() {
     let env = TestEnvironment::_new();
 
     env.private_context(|context| {
@@ -166,7 +166,7 @@ unconstrained fn applies_filter_before_constraining() {
 }
 
 #[test(should_fail_with = "Note contract address mismatch.")]
-unconstrained fn rejects_mismatched_address() {
+unconstrained fn constrain_get_notes_rejects_mismatched_address() {
     let env = TestEnvironment::_new();
 
     env.private_context(|context| {
@@ -180,7 +180,7 @@ unconstrained fn rejects_mismatched_address() {
 }
 
 #[test(should_fail_with = "Mismatch return note field.")]
-unconstrained fn rejects_mismatched_selector() {
+unconstrained fn constrain_get_notes_rejects_mismatched_selector() {
     let env = TestEnvironment::_new();
 
     env.private_context(|context| {
@@ -202,7 +202,7 @@ unconstrained fn rejects_mismatched_selector() {
 }
 
 #[test(should_fail_with = "Return notes not sorted in descending order.")]
-unconstrained fn rejects_mismatched_desc_sort_order() {
+unconstrained fn constrain_get_notes_rejects_mismatched_desc_sort_order() {
     let env = TestEnvironment::_new();
 
     env.private_context(|context| {
@@ -219,7 +219,7 @@ unconstrained fn rejects_mismatched_desc_sort_order() {
 }
 
 #[test(should_fail_with = "Return notes not sorted in ascending order.")]
-unconstrained fn rejects_mismatched_asc_sort_order() {
+unconstrained fn constrain_get_notes_rejects_mismatched_asc_sort_order() {
     let env = TestEnvironment::_new();
 
     env.private_context(|context| {

--- a/noir-projects/aztec-nr/aztec/src/note/note_interface.nr
+++ b/noir-projects/aztec-nr/aztec/src/note/note_interface.nr
@@ -20,7 +20,12 @@ pub trait NoteHash {
     /// Returns the non-siloed nullifier (also called inner-nullifier), which will be later siloed by contract address
     /// by the kernels before being committed to the state tree.
     ///
-    /// This function MUST be called with the correct note hash for consumption! It will otherwise silently fail and
+    /// @param &mut PrivateContext: required to enable zcash-style nullification, where the nullifier secret key is
+    /// queried via an oracle call.
+    /// Advanced: It is mutable, to enable the context to line-up a Key Validation Request to
+    /// the kernel circuit as part of that nullifier secret key retrieval.
+    ///
+    /// @param note_hash_for_nullify: This function MUST be called with the correct note hash for consumption! It will otherwise silently fail and
     /// compute an incorrect value. The reason why we receive this as an argument instead of computing it ourselves
     /// directly is because the caller will typically already have computed this note hash, and we can reuse that value
     /// to reduce the total gate count of the circuit.

--- a/noir-projects/aztec-nr/aztec/src/state_vars/delayed_private_mutable.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/delayed_private_mutable.nr
@@ -1,0 +1,330 @@
+use dep::protocol_types::{
+    constants::GENERATOR_INDEX__INITIALIZATION_NULLIFIER,
+    delayed_public_mutable::{
+        DelayedPublicMutableValues, ScheduledDelayChange, ScheduledValueChange,
+    },
+    hash::poseidon2_hash_with_separator,
+    traits::{Empty, Packable},
+};
+
+use crate::{
+    context::{PrivateContext, UtilityContext},
+    history::nullifier_non_inclusion::ProveNullifierNonInclusion,
+    note::{
+        lifecycle::{create_note, destroy_note_unsafe},
+        note_emission::NoteEmission,
+        note_getter::{get_note, view_notes},
+        note_interface::{NoteHash, NoteType},
+        note_viewer_options::NoteViewerOptions,
+        retrieved_note::RetrievedNote,
+        utils::compute_note_hash_for_nullify_from_read_request,
+    },
+    state_vars::storage::HasStorageSlot,
+};
+
+mod delayed_private_mutable_note;
+mod test;
+
+use delayed_private_mutable_note::DelayedPrivateMutableNote;
+
+pub struct DelayedPrivateMutable<Note, let INITIAL_DELAY: u64, Context> {
+    context: Context,
+    storage_slot: Field,
+}
+
+// This will make the Aztec macros require that T implements the Packable and Eq traits, and allocate `M` storage
+// slots to this state variable.
+impl<Note, let INITIAL_DELAY: u64, Context, let M: u32> HasStorageSlot<1> for DelayedPrivateMutable<Note, INITIAL_DELAY, Context> {
+    fn get_storage_slot(self) -> Field {
+        self.storage_slot
+    }
+}
+
+// DelayedPublicMutable<T> stores a value of type T that is:
+//  - publicly known (i.e. unencrypted)
+//  - mutable in public
+//  - readable in private with no contention (i.e. multiple parties can all read the same value without blocking one
+//    another nor needing to coordinate)
+// This is famously a hard problem to solve. DelayedPublicMutable makes it work by introducing a delay to public mutation:
+// the value is not changed immediately but rather a value change is scheduled to happen in the future after some delay
+// measured in seconds. Reads in private are only valid as long as they are included in a block with a timestamp not
+// too far into the future, so that they can guarantee the value will not have possibly changed by then (because of the
+// delay). The delay for changing a value is initially equal to INITIAL_DELAY, but can be changed by calling
+// `schedule_delay_change`.
+impl<Note, let INITIAL_DELAY: u64, Context> DelayedPrivateMutable<Note, INITIAL_DELAY, Context> {
+    pub fn new(context: Context, storage_slot: Field) -> Self {
+        Self { context, storage_slot }
+    }
+
+    // The following computation is leaky, in that it doesn't hide the storage slot that has been initialized, nor does it hide the contract address of this contract.
+    // When this initialization nullifier is emitted, an observer could do a dictionary or rainbow attack to learn the preimage of this nullifier to deduce the storage slot and contract address.
+    // For some applications, leaking the details that a particular state variable of a particular contract has been initialized will be unacceptable.
+    // Under such circumstances, such application developers might wish to _not_ use this state variable type.
+    // This is especially dangerous for initial assignment to elements of a `Map<AztecAddress, PrivateMutable>` type (for example), because the storage slot often also identifies an actor. e.g.
+    // the initial assignment to `my_map.at(msg.sender)` will leak: `msg.sender`, the fact that an element of `my_map` was assigned-to for the first time, and the contract_address.
+    // Note: subsequent nullification of this state variable, via the `replace` method will not be leaky, if the `compute_nullifier()` method of the underlying note is designed to ensure privacy.
+    // For example, if the `compute_nullifier()` method injects the secret key of a note owner into the computed nullifier's preimage.
+    pub fn compute_initialization_nullifier(self) -> Field {
+        poseidon2_hash_with_separator(
+            [self.storage_slot],
+            GENERATOR_INDEX__INITIALIZATION_NULLIFIER,
+        )
+    }
+}
+
+// WRITE
+
+impl<Note, let INITIAL_DELAY: u64> DelayedPrivateMutable<Note, INITIAL_DELAY, &mut PrivateContext>
+where
+    Note: NoteType + NoteHash,
+{
+    /// Schedules a change to the new_value at the earliest possible time, given the current
+    /// delay of this state.
+    /// TODO: make this configurable to an optional later time (an earlier time is not allowed).
+    /// https://github.com/AztecProtocol/aztec-packages/issues/5501
+    /// Notes are assumed to be Note::empty() before the initialization takes effect,
+    /// so do not infer meaning from an empty note, other than "it has not yet been initialized".
+    pub fn schedule_initialization(
+        self,
+        note: Note,
+    ) -> NoteEmission<DelayedPrivateMutableNote<Note, INITIAL_DELAY>>
+    where
+        Note: Empty + Packable,
+    {
+        // TODO: make this configurable
+        // https://github.com/AztecProtocol/aztec-packages/issues/5501
+        let timestamp_of_change = self.context.include_by_timestamp + INITIAL_DELAY;
+
+        let mut svc = ScheduledValueChange::<Note>::empty();
+
+        svc.schedule_change_in_private(
+            note,
+            self.context.get_anchor_timestamp(),
+            self.context.include_by_timestamp,
+            INITIAL_DELAY,
+            timestamp_of_change,
+        );
+
+        // We wrap the note in a DelayedPrivateMutableNote:
+        let wrapped_note = DelayedPrivateMutableNote {
+            delayed_mutable_values: DelayedPublicMutableValues::<Note, INITIAL_DELAY> {
+                svc,
+                // An empty sdc is interpreted as `INITIAL_DELAY`
+                sdc: ScheduledDelayChange::<INITIAL_DELAY>::empty(),
+            },
+        };
+
+        // Nullify the storage slot.
+        let nullifier = self.compute_initialization_nullifier();
+        self.context.push_nullifier(nullifier);
+
+        create_note(self.context, self.storage_slot, wrapped_note)
+    }
+
+    pub fn schedule_replacement(
+        self,
+        new_note: Note,
+    ) -> NoteEmission<DelayedPrivateMutableNote<Note, INITIAL_DELAY>>
+    where
+        Note: Packable,
+    {
+        let old_wrapped_note = self.get_and_nullify_wrapped_note();
+
+        let mut svc = old_wrapped_note.delayed_mutable_values.svc;
+        let sdc = old_wrapped_note.delayed_mutable_values.sdc;
+
+        let anchor_timestamp = self.context.get_anchor_timestamp();
+
+        let time_until_delay_horizon = sdc.get_effective_minimum_delay_at(anchor_timestamp);
+
+        // TODO: make this configurable:
+        let include_by_timestamp = self.context.include_by_timestamp;
+        // TODO: make this configurable
+        // https://github.com/AztecProtocol/aztec-packages/issues/5501
+        let timestamp_of_change = include_by_timestamp + time_until_delay_horizon;
+
+        svc.schedule_change_in_private(
+            new_note,
+            anchor_timestamp,
+            include_by_timestamp,
+            time_until_delay_horizon,
+            timestamp_of_change,
+        );
+
+        // We wrap the note in a DelayedPrivateMutableNote:
+        let wrapped_note = DelayedPrivateMutableNote {
+            delayed_mutable_values: DelayedPublicMutableValues::<Note, INITIAL_DELAY> { svc, sdc },
+        };
+
+        // Add replacement note.
+        create_note(self.context, self.storage_slot, wrapped_note)
+    }
+
+    pub fn schedule_delay_change(
+        self,
+        new_delay: u64,
+    ) -> NoteEmission<DelayedPrivateMutableNote<Note, INITIAL_DELAY>>
+    where
+        Note: Packable,
+    {
+        let old_wrapped_note = self.get_and_nullify_wrapped_note();
+
+        let svc = old_wrapped_note.delayed_mutable_values.svc;
+        let mut sdc = old_wrapped_note.delayed_mutable_values.sdc;
+
+        let anchor_timestamp = self.context.get_anchor_timestamp();
+
+        let include_by_timestamp = self.context.include_by_timestamp;
+
+        sdc.schedule_change_in_private(new_delay, anchor_timestamp, include_by_timestamp);
+
+        // We wrap the note in a DelayedPrivateMutableNote:
+        let wrapped_note = DelayedPrivateMutableNote {
+            delayed_mutable_values: DelayedPublicMutableValues::<Note, INITIAL_DELAY> { svc, sdc },
+        };
+
+        // Add replacement note.
+        create_note(self.context, self.storage_slot, wrapped_note)
+    }
+
+    fn get_and_nullify_wrapped_note(self) -> DelayedPrivateMutableNote<Note, INITIAL_DELAY>
+    where
+        Note: Packable,
+    {
+        let (retrieved_wrapped_note, retrieved_wrapped_note_hash_for_read_request): (RetrievedNote<DelayedPrivateMutableNote<Note, INITIAL_DELAY>>, Field) =
+            get_note(self.context, self.storage_slot);
+
+        // Nullify previous note.
+        destroy_note_unsafe(
+            self.context,
+            retrieved_wrapped_note,
+            retrieved_wrapped_note_hash_for_read_request,
+        );
+
+        retrieved_wrapped_note.note
+    }
+}
+
+// READ
+// Note: all reads mutate the `include_by_timestamp` of the `context`, to ensure the read expires before the value can change.
+
+impl<Note, let INITIAL_DELAY: u64> DelayedPrivateMutable<Note, INITIAL_DELAY, &mut PrivateContext>
+where
+    Note: NoteType + NoteHash,
+{
+    pub fn get_current_note(self) -> Note
+    where
+        Note: Packable,
+    {
+        let svc = self.get_delayed_mutable_values_at_anchor_block().svc;
+        let anchor_timestamp = self.context.get_block_header().global_variables.timestamp;
+
+        svc.get_current_at(anchor_timestamp)
+    }
+
+    pub fn get_current_delay(self) -> u64
+    where
+        Note: Packable,
+    {
+        let sdc = self.get_delayed_mutable_values_at_anchor_block().sdc;
+        let anchor_timestamp = self.context.get_block_header().global_variables.timestamp;
+
+        sdc.get_current_at(anchor_timestamp)
+    }
+
+    pub fn get_scheduled_note(self) -> (Note, u64)
+    where
+        Note: Packable,
+    {
+        let svc = self.get_delayed_mutable_values_at_anchor_block().svc;
+
+        svc.get_scheduled()
+    }
+
+    pub fn get_scheduled_delay(self) -> (u64, u64)
+    where
+        Note: Packable,
+    {
+        let sdc = self.get_delayed_mutable_values_at_anchor_block().sdc;
+
+        sdc.get_scheduled()
+    }
+
+    fn get_delayed_mutable_values_at_anchor_block(
+        self,
+    ) -> DelayedPublicMutableValues<Note, INITIAL_DELAY>
+    where
+        Note: Packable,
+    {
+        let old_wrapped_note = self.get_wrapped_note_at_anchor_block();
+
+        let svc = old_wrapped_note.delayed_mutable_values.svc;
+        let sdc = old_wrapped_note.delayed_mutable_values.sdc;
+
+        // TODO: consider consolidating common functionality between the delayed public and private mutables. Everything below in this function is exactly the same as DelayedPrivateMutable's get_current_value.
+
+        let anchor_timestamp = self.context.get_anchor_timestamp();
+
+        let effective_minimum_delay = sdc.get_effective_minimum_delay_at(anchor_timestamp);
+        let time_horizon = svc.get_time_horizon_at(anchor_timestamp, effective_minimum_delay);
+
+        // We prevent this transaction from being included in any timestamp after the time horizon, ensuring that the
+        // historical value matches the current one, since it can only change after the horizon.
+        self.context.set_include_by_timestamp(time_horizon);
+
+        old_wrapped_note.delayed_mutable_values
+    }
+
+    fn get_wrapped_note_at_anchor_block(self) -> DelayedPrivateMutableNote<Note, INITIAL_DELAY>
+    where
+        Note: Packable,
+    {
+        // We want to get the "current" note, from the perspective of the anchor_timestamp of this tx.
+        // To check whether a note is current, we'd ordinarily have to publicly leak its nullifier, as a way of
+        // demonstrating that it hasn't already been nullified.
+        // But since we've designed this state variable to have a _delay_, we have a window of time where if
+        // the nullifier doesn't yet exist in the anchor header, we have a guarantee that the "current value"
+        // of the note won't change for some time.
+        // So we do that:
+        // We read the note from the anchor header.
+        // We assert that the note's nullifier does not exist in that anchor header.
+        // We proceed with reading the "current value" of the note, as at the anchor header,
+        // and we `set_include_by_timestamp` so that the tx expires before the note that we've read could
+        // possibly be changed.
+        let (retrieved_note, retrieved_note_hash_for_read_request): (RetrievedNote<DelayedPrivateMutableNote<Note, INITIAL_DELAY>>, Field) =
+            get_note(self.context, self.storage_slot);
+
+        let note_hash_for_nullify = compute_note_hash_for_nullify_from_read_request(
+            retrieved_note,
+            retrieved_note_hash_for_read_request,
+        );
+        let nullifier = retrieved_note.note.compute_nullifier(self.context, note_hash_for_nullify);
+
+        let anchor_header = self.context.get_block_header();
+
+        anchor_header.prove_nullifier_non_inclusion(nullifier);
+
+        // No need to nullify the note with DelayedPrivateMutable; that's the whole point.
+
+        retrieved_note.note
+    }
+}
+
+impl<Note, let INITIAL_DELAY: u64> DelayedPrivateMutable<Note, INITIAL_DELAY, UtilityContext>
+where
+    Note: NoteType,
+{
+    pub unconstrained fn view_current_note<let N: u32>(self) -> Note
+    where
+        Note: Eq + Packable,
+    {
+        let mut options = NoteViewerOptions::new();
+        let wrapped_note: DelayedPrivateMutableNote<Note, INITIAL_DELAY> =
+            view_notes(self.storage_slot, options.set_limit(1)).get(0);
+
+        let svc = wrapped_note.delayed_mutable_values.svc;
+        let current_timestamp = self.context.timestamp();
+
+        svc.get_current_at(current_timestamp)
+    }
+}

--- a/noir-projects/aztec-nr/aztec/src/state_vars/delayed_private_mutable.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/delayed_private_mutable.nr
@@ -40,30 +40,53 @@ impl<Note, let INITIAL_DELAY: u64, Context, let M: u32> HasStorageSlot<1> for De
     }
 }
 
-// DelayedPublicMutable<T> stores a value of type T that is:
-//  - publicly known (i.e. unencrypted)
-//  - mutable in public
-//  - readable in private with no contention (i.e. multiple parties can all read the same value without blocking one
-//    another nor needing to coordinate)
-// This is famously a hard problem to solve. DelayedPublicMutable makes it work by introducing a delay to public mutation:
-// the value is not changed immediately but rather a value change is scheduled to happen in the future after some delay
-// measured in seconds. Reads in private are only valid as long as they are included in a block with a timestamp not
-// too far into the future, so that they can guarantee the value will not have possibly changed by then (because of the
-// delay). The delay for changing a value is initially equal to INITIAL_DELAY, but can be changed by calling
-// `schedule_delay_change`.
+// DelayedPrivateMutable<Note, INITIAL_DELAY> is similar to PrivateMutable, but
+// with a few important differences:
+// - The "current note" can be read within a private function with no contention
+//   (i.e. multiple parties can all read the same note without blocking one
+//   another nor needing to coordinate).
+// - Advanced: The "current note" can be read in private, without a nullifier
+//   and replacement note being emitted each time.
+//
+// The way this works under the hood is very similar to DelayedPublicMutable:
+// If the "owner" of a DelayedPrivateMutable state would like to "replace" the
+// current note, they cannot replace it immediately; they must schedule a
+// change. That scheduled change can only take place after a delay. This delay
+// gives people an opportunity to read the note in a private function, safe in
+// the knowledge that the note cannot change for some time.
+//
+// The delay is measured in seconds. Reads in private are only valid as long as
+// they are included in a block with a timestamp not too far into the future,
+// so that they can guarantee the value will not have possibly changed by then
+// (because of the delay). The delay for changing a value is initially equal to
+// INITIAL_DELAY, but can be changed by calling `schedule_delay_change`.
 impl<Note, let INITIAL_DELAY: u64, Context> DelayedPrivateMutable<Note, INITIAL_DELAY, Context> {
     pub fn new(context: Context, storage_slot: Field) -> Self {
         Self { context, storage_slot }
     }
 
-    // The following computation is leaky, in that it doesn't hide the storage slot that has been initialized, nor does it hide the contract address of this contract.
-    // When this initialization nullifier is emitted, an observer could do a dictionary or rainbow attack to learn the preimage of this nullifier to deduce the storage slot and contract address.
-    // For some applications, leaking the details that a particular state variable of a particular contract has been initialized will be unacceptable.
-    // Under such circumstances, such application developers might wish to _not_ use this state variable type.
-    // This is especially dangerous for initial assignment to elements of a `Map<AztecAddress, PrivateMutable>` type (for example), because the storage slot often also identifies an actor. e.g.
-    // the initial assignment to `my_map.at(msg.sender)` will leak: `msg.sender`, the fact that an element of `my_map` was assigned-to for the first time, and the contract_address.
-    // Note: subsequent nullification of this state variable, via the `replace` method will not be leaky, if the `compute_nullifier()` method of the underlying note is designed to ensure privacy.
-    // For example, if the `compute_nullifier()` method injects the secret key of a note owner into the computed nullifier's preimage.
+    // The following computation is leaky, in that it doesn't hide the storage
+    // slot that has been initialized, nor does it hide the contract address of
+    // this contract.
+    // When this initialization nullifier is emitted, an observer could do a
+    // dictionary or rainbow attack to learn the preimage of this nullifier to
+    // deduce the storage slot and contract address.
+    // For some applications, leaking the details that a particular state
+    // variable of a particular contract has been initialized will be
+    // unacceptable.
+    // Under such circumstances, such application developers might wish to _not_
+    // use this state variable type.
+    // This is especially dangerous for initial assignment to elements of a
+    // `Map<AztecAddress, DelayedPrivateMutable>` type (for example), because
+    // the storage slot often also identifies an actor. e.g. the initial
+    // assignment to `my_map.at(msg.sender)` will leak: `msg.sender`, the fact
+    // that an element of `my_map` was assigned-to for the first time, and the
+    // contract_address.
+    // Note: subsequent nullification of this state variable, via the `replace`
+    // method will not be leaky, if the `compute_nullifier()` method of the
+    // underlying note is designed to ensure privacy. For example, if the
+    // `compute_nullifier()` method injects the secret key of a note owner into
+    // the computed nullifier's preimage.
     pub fn compute_initialization_nullifier(self) -> Field {
         poseidon2_hash_with_separator(
             [self.storage_slot],
@@ -78,12 +101,83 @@ impl<Note, let INITIAL_DELAY: u64> DelayedPrivateMutable<Note, INITIAL_DELAY, &m
 where
     Note: NoteType + NoteHash,
 {
-    /// Schedules a change to the new_value at the earliest possible time, given the current
-    /// delay of this state.
+    /// Initializes a DelayedPrivateMutable state variable instance with its
+    /// first note. Similar in nature to `PrivateMutable::initialize`.
+    ///
+    /// The note will not take effect (i.e. the note will not be available
+    /// via `get_current_note`) until `INITIAL_DELAY` seconds after the
+    /// `include_by_timestamp` of this tx.
+    ///
+    /// This function creates the very first note for this state variable. It
+    /// can only be called once per DelayedPrivateMutable. Subsequent calls will
+    /// fail because the initialization nullifier will already exist.
+    ///
+    /// This is conceptually similar to setting an initial value for a variable
+    /// in Ethereum smart contracts, except that in Aztec the "value" is
+    /// represented as a private note.
+    ///
+    /// Notes are assumed to be Note::empty() before the initialization takes
+    /// effect, so do not infer meaning from an empty note, other than "it has
+    /// not yet been initialized".
+    ///
+    /// ## IMPORTANT PRIVACY CONSIDERATION
+    ///
+    /// This computation is leaky and can compromise privacy under certain
+    /// circumstances.
+    ///
+    /// When the initialization nullifier is emitted during this call, an
+    /// observer could perform a dictionary or rainbow attack to learn the
+    /// storage slot and contract address.
+    ///
+    /// For applications where revealing that a particular state variable has
+    /// been initialized is unacceptable, developers should consider alternative
+    /// approaches or avoid using DelayedPrivateMutable.
+    ///
+    /// This is especially dangerous for initial assignments to elements of a
+    /// `Map<AztecAddress, PrivateMutable>`, because the storage slot often
+    /// identifies a specific user. For example,
+    /// `my_map.at(msg.sender).initialize(note)` will leak:
+    /// - `msg.sender`;
+    /// - the fact that this map element was assigned for the first time;
+    /// - and the contract's address.
+    ///
+    /// See https://github.com/AztecProtocol/aztec-packages/issues/15568 for ideas to
+    /// improve this privacy footgun in future.
+    ///
+    /// ## Arguments
+    ///
+    /// * `note` - The initial note to store in this PrivateMutable. This note
+    ///            will become the "current note" of the state variable after
+    ///            `INITIAL_DELAY` seconds.
+    ///
+    /// ## Returns
+    ///
+    /// * `NoteEmission<DelayedPrivateMutableNote<Note, INITIAL_DELAY>>`
+    ///      - A type-safe wrapper that requires you to decide whether to
+    ///        encrypt and send the DelayedPrivateMutableNote to someone.
+    ///        You can call `.emit()` on it to encrypt and log the note, or
+    ///        `.discard()` to skip emission. See NoteEmission for more details.
+    ///      - The DelayedPrivateMutableNote is a low-level wrapper around your
+    ///        custom smart contract Note, which is used under the hood by this
+    ///        DelayedPrivateMutable state variable type. An ordinary user won't
+    ///        have to handle this type directly; they'll be able to extract
+    ///        their custom notes via `get_current_note` or `get_scheduled_note`.
+    ///
+    /// ## Advanced
+    ///
+    /// This function performs the following operations:
+    /// - Creates and emits an initialization nullifier to mark this storage slot
+    ///   as initialized. This prevents double-initialization.
+    /// - Inserts the provided note into the protocol's Note Hash Tree.
+    /// - Returns a NoteEmission type that allows the caller to decide how to encrypt
+    ///   and deliver the note to its intended recipient.
+    ///
+    /// The initialization nullifier is deterministically computed from the storage
+    /// slot and can leak privacy information (see `compute_initialization_nullifier`
+    /// documentation).
+    ///
     /// TODO: make this configurable to an optional later time (an earlier time is not allowed).
     /// https://github.com/AztecProtocol/aztec-packages/issues/5501
-    /// Notes are assumed to be Note::empty() before the initialization takes effect,
-    /// so do not infer meaning from an empty note, other than "it has not yet been initialized".
     pub fn schedule_initialization(
         self,
         note: Note,
@@ -121,6 +215,60 @@ where
         create_note(self.context, self.storage_slot, wrapped_note)
     }
 
+    /// Replaces the current note of a DelayedPrivateMutable state variable with
+    /// a new note. Similar in nature to `PrivateMutable::replace`.
+    ///
+    /// The replacement note will not take effect (i.e. the note will not be
+    /// available via `self.get_current_note`) until `self.get_current_delay()`
+    /// seconds after the `include_by_timestamp` of this tx.
+    ///
+    /// This function implements the typical "nullify-and-create" pattern for
+    /// updating private state in Aztec. It first retrieves the current note,
+    /// nullifies it, and then inserts a `new_note` with the updated data.
+    ///
+    /// This function can only be called after the DelayedPrivateMutable has been
+    /// initialized. If called on an uninitialized DelayedPrivateMutable, it
+    /// will fail because there is no current note to replace.
+    ///
+    /// ## Arguments
+    ///
+    /// * `new_note` - The new note that will replace the current note after
+    ///                `self.get_current_delay()` seconds. This will become the
+    ///                new "current value" of the PrivateMutable.
+    ///
+    /// ## Returns
+    ///
+    /// * `NoteEmission<DelayedPrivateMutableNote<Note, INITIAL_DELAY>>`
+    ///      - A type-safe wrapper that requires you to decide whether to
+    ///        encrypt and send the DelayedPrivateMutableNote to someone.
+    ///        You can call `.emit()` on it to encrypt and log the note, or
+    ///        `.discard()` to skip emission. See NoteEmission for more details.
+    ///      - The DelayedPrivateMutableNote is a low-level wrapper around your
+    ///        custom smart contract Note, which is used under the hood by this
+    ///        DelayedPrivateMutable state variable type. An ordinary user won't
+    ///        have to handle this type directly; they'll be able to extract
+    ///        their custom notes via `get_current_note` or `get_scheduled_note`.
+    ///
+    /// ## Advanced
+    ///
+    /// This function performs the following operations:
+    /// - Retrieves the current DelayedPrivateMutable note from the PXE via an
+    ///   oracle call. Notice: we actually operate on these so-called "wrapper
+    ///   notes", rather than the underlying `Note` types themselves.
+    /// - Validates that the current wrapper note exists and belongs to this
+    ///   storage slot.
+    /// - Computes the nullifier for the current wrapper note and pushes it to
+    ///   the context.
+    /// - Inserts the provided `new_note` into the `post` field of a new wrapper
+    ///   note. Then inserts the new wrapper note into the Note Hash Tree.
+    /// - Returns a NoteEmission type for the new wrapper note, that allows the
+    ///   caller to decide how to encrypt and deliver this wrapper note to its
+    ///   intended recipient.
+    ///
+    /// The nullification of the previous wrapper note ensures that it cannot
+    /// be used again, maintaining the invariant that a DelayedPrivateMutable
+    /// has exactly one current wrapper note.
+    ///
     pub fn schedule_replacement(
         self,
         new_note: Note,
@@ -135,7 +283,7 @@ where
 
         let anchor_timestamp = self.context.get_anchor_timestamp();
 
-        let time_until_delay_horizon = sdc.get_effective_minimum_delay_at(anchor_timestamp);
+        let time_until_delay_horizon = sdc.get_max_time_a_read_remains_valid(anchor_timestamp);
 
         // TODO: make this configurable:
         let include_by_timestamp = self.context.include_by_timestamp;
@@ -160,6 +308,67 @@ where
         create_note(self.context, self.storage_slot, wrapped_note)
     }
 
+    /// Replaces the current delay of a DelayedPrivateMutable state variable
+    /// with a new delay (measured in seconds).
+    ///
+    /// If the delay is an _increase_ to the current delay, it will take effect
+    /// once the `include_by_timestamp` of this tx is reached. That is, any
+    /// note replacements after that time will be delayed by `new_delay` seconds
+    /// before they take effect.
+    ///
+    /// If the delay is a _decrease_ to the current delay, there will be a delay
+    /// before the decreased delay takes effect, to ensure in-flight reads have
+    /// time to complete under the 'old' delay. The logic here is quite complex
+    /// -- see `scheduled_delay_change.nr` if interested.
+    ///
+    /// This function implements the typical "nullify-and-create" pattern for
+    /// updating private state in Aztec. It first retrieves the current
+    /// DelayedPrivateMutable ("wrapper") note, nullifies it, and then inserts a
+    /// new wrapper note with the updated data.
+    ///
+    /// This function can only be called after the DelayedPrivateMutable has been
+    /// initialized. If called on an uninitialized DelayedPrivateMutable, it
+    /// will fail because there is no current wrapper note to replace.
+    ///
+    /// ## Arguments
+    ///
+    /// * `new_delay` - The new delay (in seconds) that will replace the current
+    ///                 delay.
+    ///
+    /// ## Returns
+    ///
+    /// * `NoteEmission<DelayedPrivateMutableNote<Note, INITIAL_DELAY>>`
+    ///      - A type-safe wrapper that requires you to decide whether to
+    ///        encrypt and send the DelayedPrivateMutableNote to someone.
+    ///        You can call `.emit()` on it to encrypt and log the note, or
+    ///        `.discard()` to skip emission. See NoteEmission for more details.
+    ///      - The DelayedPrivateMutableNote is a low-level wrapper around your
+    ///        custom smart contract Note, which is used under the hood by this
+    ///        DelayedPrivateMutable state variable type. An ordinary user won't
+    ///        have to handle this type directly; they'll be able to extract
+    ///        their custom notes, and chosen delays through the methods of this
+    ///        DelayedPrivateMutable state variable type.
+    ///
+    /// ## Advanced
+    ///
+    /// This function performs the following operations:
+    /// - Retrieves the current DelayedPrivateMutable note from the PXE via an
+    ///   oracle call. Notice: we actually operate on these so-called "wrapper
+    ///   notes", rather than the underlying `Note` types themselves.
+    /// - Validates that the current wrapper note exists and belongs to this
+    ///   storage slot.
+    /// - Computes the nullifier for the current wrapper note and pushes it to
+    ///   the context.
+    /// - Inserts the provided `new_note` into the `post` field of a new wrapper
+    ///   note. Then inserts the new wrapper note into the Note Hash Tree.
+    /// - Returns a NoteEmission type for the new wrapper note, that allows the
+    ///   caller to decide how to encrypt and deliver this wrapper note to its
+    ///   intended recipient.
+    ///
+    /// The nullification of the previous wrapper note ensures that it cannot
+    /// be used again, maintaining the invariant that a DelayedPrivateMutable
+    /// has exactly one current wrapper note.
+    ///
     pub fn schedule_delay_change(
         self,
         new_delay: u64,
@@ -206,12 +415,31 @@ where
 }
 
 // READ
-// Note: all reads mutate the `include_by_timestamp` of the `context`, to ensure the read expires before the value can change.
+// Note: all reads mutate the `include_by_timestamp` of the `context`, to ensure
+// the read expires before the value can change.
 
 impl<Note, let INITIAL_DELAY: u64> DelayedPrivateMutable<Note, INITIAL_DELAY, &mut PrivateContext>
 where
     Note: NoteType + NoteHash,
 {
+    /// Gets the "current" note as at the anchor_timestamp of this tx.
+    /// This 'read' operation will only be valid for a certain window of time.
+    ///
+    /// The exact amount of time will depend on:
+    /// - The current delay of this DelayedPrivateMutable state variable (see
+    ///   `get_current_delay`);
+    /// - Whether a replacement note has been scheduled via
+    ///   `schedule_replacement` (see `get_scheduled_note`);
+    /// - Whether a delay change has been scheduled via `schedule_delay_change`
+    ///   (see `get_scheduled_delay`).
+    ///
+    /// Essentially, the 'read' operation is only valid whilst we can be sure
+    /// that no other txs could possibly mutate this state.
+    ///
+    /// The `include_by_timestamp` of this tx will be mutated by this function
+    /// to a value at most as long as this validity window. This ensures that
+    /// if too much time has passed since the read, the tx will not be valid.
+    ///
     pub fn get_current_note(self) -> Note
     where
         Note: Packable,
@@ -222,6 +450,30 @@ where
         svc.get_current_at(anchor_timestamp)
     }
 
+    /// Gets the "current" delay (in seconds) that has been set for this
+    /// DelayedPrivateMutable instance, as at the anchor_timestamp of this tx.
+    /// This 'read' operation will only be valid for a certain window of time.
+    ///
+    /// The exact amount of time will depend on:
+    /// - The current delay of this DelayedPrivateMutable state variable (see
+    ///   `get_current_delay`);
+    /// - Whether a replacement note has been scheduled via
+    ///   `schedule_replacement` (see `get_scheduled_note`);
+    /// - Whether a delay change has been scheduled via `schedule_delay_change`
+    ///   (see `get_scheduled_delay`).
+    ///
+    /// Essentially, the 'read' operation is only valid whilst we can be sure
+    /// that no other txs could possibly mutate this state.
+    ///
+    /// The `include_by_timestamp` of this tx will be mutated by this function
+    /// to a value at most as long as this validity window. This ensures that
+    /// if too much time has passed since the read, the tx will not be valid.
+    ///
+    /// ## Returns
+    ///
+    /// * `u64` - current delay (in seconds) of this delayed_private_mutable,
+    ///           as at the anchor timestamp of this tx.
+    ///
     pub fn get_current_delay(self) -> u64
     where
         Note: Packable,
@@ -232,6 +484,12 @@ where
         sdc.get_current_at(anchor_timestamp)
     }
 
+    /// ## Returns
+    /// * `(Note, u64)` - the note that is scheduled to take effect next, and
+    ///                   the timestamp at which it will take effect (in seconds).
+    ///    If no new note has been scheduled, or if the scheduled note has
+    ///    already taken effect, this will return the current note, and the
+    ///    timestamp at which it took effect.
     pub fn get_scheduled_note(self) -> (Note, u64)
     where
         Note: Packable,
@@ -241,6 +499,13 @@ where
         svc.get_scheduled()
     }
 
+    /// ## Returns
+    /// * `(u64, u64)` - the delay (in seconds) that is scheduled to take effect
+    ///                  next, as a replacement to the current delay, and the
+    ///    timestamp at which it will take effect (in seconds), respectively.
+    ///    If no new delay has been scheduled, or if the scheduled delay has
+    ///    already taken effect, this will return the current delay, and the
+    ///    timestamp at which it took effect, respectively.
     pub fn get_scheduled_delay(self) -> (u64, u64)
     where
         Note: Packable,
@@ -256,17 +521,35 @@ where
     where
         Note: Packable,
     {
+        // We want to get the "current" wrapped note, from the perspective of
+        // the anchor_timestamp of this tx.
+        // To check whether a note is current, we'd ordinarily have to publicly
+        // leak its nullifier, as a way of demonstrating that it hasn't already
+        // been nullified. But since we've designed this state variable to have
+        // a _delay_, we have a window of time where if the nullifier doesn't
+        // yet exist in the anchor header, we have a guarantee that the
+        // "current value" of the note won't change for some time.
+        // So we do that:
+        // - We read the wrapped note from the anchor header.
+        // - We assert that the wrapped note's nullifier does not exist in that
+        //   anchor header.
+        // - We proceed with reading the "current value" of the note, as at the
+        //   anchor header,
+        // - and we `set_include_by_timestamp` so that the tx expires before the
+        //   note that we've read could possibly be changed.
         let old_wrapped_note = self.get_wrapped_note_at_anchor_block();
 
         let svc = old_wrapped_note.delayed_mutable_values.svc;
         let sdc = old_wrapped_note.delayed_mutable_values.sdc;
 
-        // TODO: consider consolidating common functionality between the delayed public and private mutables. Everything below in this function is exactly the same as DelayedPrivateMutable's get_current_value.
+        // TODO: consider consolidating common functionality between the delayed
+        // public and private mutables. Everything below in this function is
+        // exactly the same as DelayedPrivateMutable's get_current_value.
 
         let anchor_timestamp = self.context.get_anchor_timestamp();
 
-        let effective_minimum_delay = sdc.get_effective_minimum_delay_at(anchor_timestamp);
-        let time_horizon = svc.get_time_horizon_at(anchor_timestamp, effective_minimum_delay);
+        let max_time_a_read_remains_valid = sdc.get_max_time_a_read_remains_valid(anchor_timestamp);
+        let time_horizon = svc.get_time_horizon_at(anchor_timestamp, max_time_a_read_remains_valid);
 
         // We prevent this transaction from being included in any timestamp after the time horizon, ensuring that the
         // historical value matches the current one, since it can only change after the horizon.
@@ -279,18 +562,6 @@ where
     where
         Note: Packable,
     {
-        // We want to get the "current" note, from the perspective of the anchor_timestamp of this tx.
-        // To check whether a note is current, we'd ordinarily have to publicly leak its nullifier, as a way of
-        // demonstrating that it hasn't already been nullified.
-        // But since we've designed this state variable to have a _delay_, we have a window of time where if
-        // the nullifier doesn't yet exist in the anchor header, we have a guarantee that the "current value"
-        // of the note won't change for some time.
-        // So we do that:
-        // We read the note from the anchor header.
-        // We assert that the note's nullifier does not exist in that anchor header.
-        // We proceed with reading the "current value" of the note, as at the anchor header,
-        // and we `set_include_by_timestamp` so that the tx expires before the note that we've read could
-        // possibly be changed.
         let (retrieved_note, retrieved_note_hash_for_read_request): (RetrievedNote<DelayedPrivateMutableNote<Note, INITIAL_DELAY>>, Field) =
             get_note(self.context, self.storage_slot);
 
@@ -304,7 +575,8 @@ where
 
         anchor_header.prove_nullifier_non_inclusion(nullifier);
 
-        // No need to nullify the note with DelayedPrivateMutable; that's the whole point.
+        // No need to nullify the note with DelayedPrivateMutable; that's the
+        // whole point.
 
         retrieved_note.note
     }
@@ -314,6 +586,7 @@ impl<Note, let INITIAL_DELAY: u64> DelayedPrivateMutable<Note, INITIAL_DELAY, Ut
 where
     Note: NoteType,
 {
+    /// Gets the "current" note within a UtilityContext.
     pub unconstrained fn view_current_note(self) -> Note
     where
         Note: Eq + Packable,

--- a/noir-projects/aztec-nr/aztec/src/state_vars/delayed_private_mutable.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/delayed_private_mutable.nr
@@ -22,7 +22,7 @@ use crate::{
     state_vars::storage::HasStorageSlot,
 };
 
-mod delayed_private_mutable_note;
+pub(crate) mod delayed_private_mutable_note;
 mod test;
 
 use delayed_private_mutable_note::DelayedPrivateMutableNote;
@@ -314,7 +314,7 @@ impl<Note, let INITIAL_DELAY: u64> DelayedPrivateMutable<Note, INITIAL_DELAY, Ut
 where
     Note: NoteType,
 {
-    pub unconstrained fn view_current_note<let N: u32>(self) -> Note
+    pub unconstrained fn view_current_note(self) -> Note
     where
         Note: Eq + Packable,
     {

--- a/noir-projects/aztec-nr/aztec/src/state_vars/delayed_private_mutable/delayed_private_mutable_note.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/delayed_private_mutable/delayed_private_mutable_note.nr
@@ -1,0 +1,205 @@
+use dep::protocol_types::{
+    constants::{GENERATOR_INDEX__NOTE_HASH, GENERATOR_INDEX__NOTE_NULLIFIER},
+    delayed_public_mutable::DelayedPublicMutableValues,
+    hash::poseidon2_hash_with_separator,
+    traits::Packable,
+};
+
+use crate::{context::PrivateContext, note::note_interface::{NoteHash, NoteType}};
+
+#[derive(Eq)]
+pub struct DelayedPrivateMutableNote<Note, let INITIAL_DELAY: u64> {
+    pub delayed_mutable_values: DelayedPublicMutableValues<Note, INITIAL_DELAY>,
+}
+
+impl<Note, let INITIAL_DELAY: u64> NoteHash for DelayedPrivateMutableNote<Note, INITIAL_DELAY>
+where
+    Note: NoteHash,
+{
+    fn compute_note_hash(self, storage_slot: Field) -> Field {
+        // There are two natural approaches we could take here:
+        // 1. Leverage the Note's compute_note_hash method;
+        // 2. Ignore the Note's compute_note_hash method, and instead pack the note
+        //    into fields, and hash it ourselves.
+        // I've opted for option 1, in a mad attempt to preserve "partial note"
+        // functionality.
+
+        // There is some redundant hashing of a storage slot within these nested compute_note_hash
+        // calls, but the opportunity to forward the responsibility is too good to pass up, for now.
+
+        // Let's define a partial delayed-private-mutable-note to be a _pair_ of fields:
+        //
+        // partial = [ h(storage_slot, complete(svc.pre), ...sdc.pack()), partial(svc.post) ]
+        //
+        // The partial note is missing:
+        // - a new timestamp of change,
+        // - and the "incomplete" part of `svc.post`
+        //   (according to whatever notion of "partial" our Note implements).
+        //
+        // A function can then "complete" our "partial" DPMNote by:
+        // - first completing the svc.post note (according to its partial note calculation rules);
+        // - then completing this DPMNote according to this rule:
+        //
+        // complete = h(
+        //     partial[0],
+        //     complete(partial[1]),
+        //     svc.timestamp_of_change
+        // )
+        //
+        // complete = h(
+        //     h(storage_slot, complete(svc.pre), ...sdc.pack()),
+        //     complete(partial(svc.post)),
+        //     svc.timestamp_of_change
+        // )
+
+        let svc = self.delayed_mutable_values.svc;
+        let sdc = self.delayed_mutable_values.sdc;
+
+        let complete_pre_note_hash = svc.get_pre().compute_note_hash(storage_slot);
+        let complete_post_note_hash = svc.get_post().compute_note_hash(storage_slot);
+
+        // We include the `storage_slot` here (possibly redundantly), because we don't
+        // know whether the `pre` and `post` note_hash computations will actually make
+        // use of it, and we _need_ it to be bound to this note_hash, so that the
+        // nullifier computation of this note is secure.
+        let sdc_packed = sdc.pack();
+        // This gives us confidence that accessing index 0 is sufficient:
+        std::static_assert(
+            sdc_packed.len() == 1,
+            "The packing computation for sdc must have been changed",
+        );
+        let partial_0 = poseidon2_hash_with_separator(
+            [storage_slot, complete_pre_note_hash, sdc_packed[0]],
+            GENERATOR_INDEX__NOTE_HASH,
+        );
+
+        let complete = poseidon2_hash_with_separator(
+            [partial_0, complete_post_note_hash, svc.get_timestamp_of_change() as Field],
+            GENERATOR_INDEX__NOTE_HASH,
+        );
+
+        complete
+    }
+
+    fn compute_nullifier(
+        self,
+        context: &mut PrivateContext,
+        note_hash_for_nullify: Field,
+    ) -> Field {
+        // Recall: the `note_hash_for_nullify` parameter of this method is an optimisation to avoid
+        // having to re-compute the note_hash.
+        // We want to adopt the underlying pre and post notes' `compute_nullifier` functions,
+        // because this DMPNote is intended to be just a wrapper, and so it doesn't know
+        // any concept of "ownership"; it presumes the underlying notes will take care of
+        // inferring ownership from their note contents.
+        //
+        // So let's try to adopt the underlying notes' `compute_nullifier` functions.
+        // In fact, we'll only call the `post` note's `compute_nullifier`, in case ownership
+        // has changed between the `pre` and `post` notes (as then the `post` owner would not be
+        // able to compute the nullifier for `pre`). So only the owner of the `post` note
+        // can nullify this DMPNote in order to schedule subsequent
+        // delayed state updates. This means if the owner of `pre` (after having created the
+        // `post` note) wanted to change their mind and schedule a change to a different `post` note, they wouldn't be able to, unless they also own the `post` note.
+        //
+        // But there's another problem: in order to nullify the `post` note, we would need
+        // its note_hash. But we don't have its note hash: we only have the DPMNote's note hash.
+        //
+        // You might wonder: Since we have access to the post note through
+        // self.delayed_mutable_values.svc.post, why can't we compute its note_hash within
+        // this function?
+        // It's because notes don't know their own storage_slot (which forms part of the
+        // `compute_note_hash` computation), and this `compute_nullifier`
+        // interface doesn't enable us to pass the `storage_slot` in as an arg.
+        //
+        // I see two choices:
+        //
+        // 1. Pass as arg the `post` note's note_hash instead;
+        //    Use that note_hash to compute the `post` note's nullifier;
+        //    Access the other data in the DPMNote (`self`) and hash it all up with the
+        //    post note's nullifier.
+        //    There's some redundant hashing, since we've probably already
+        //    hashed the contents of `self` elsewhere when we retrieved the note.
+        //    This abuses the `compute_nullifier` interface of this DPMNote, in the sense
+        //    that we're not passing-in `self`'s note_hash, but that of `post` instead.
+        //
+        // 2. Pass as arg this DPMNote's note_hash. (I.e. the note hash of `self`,
+        //    as is conventional);
+        //    Use that (technically-incompatible) note_hash to compute the `post` note's nullifier,
+        //    and use that nullifier as the nullifier of this `self` note.
+        //    (Remember: we leverage the `post` note's nullifier computation to inject a
+        //    nullifier secret key, if applicable).
+        //    So we end up with this Frankensteinian nullifier, which is computed from `self`'s
+        //    note_hash, but using the methodology of the `post` note.
+        //    A clear question is: is this safe? I don't know yet...
+        //
+        // I'm going with option 2 for now, because it'll be easier to get working, since the
+        // nature of the args to this function will be consistent with all other calls
+        // to this function in this repo.
+
+        // We'll compute the nullifier as:
+        //
+        // h(note_hash_for_nullify, post.compute_nullifier(note_hash_for_nullify))
+        //
+        // Including the nullifier with the methodology of the `post` note enables
+        // deterministic randomness to be added to the nullifier (depending on the
+        // particular Note impl we're dealing with) -- commonly the owner's nullifier
+        // secret key -- in order to hide from the world which note is being nullified.
+        // We don't know for sure whether the `post.compute_nullifier()` call will
+        // actually _make use_ of note_hash_for_nullify in its computation, so we also
+        // hash that value into the mix, to ensure the entire contents of `self`
+        // _and_ the `storage_slot` are bound to this nullifier.
+        // Using the note hash of `self` as the `note_hash_for_nullify` ensures we
+        // bind this nullifier to all of the content of this note.
+
+        let svc = self.delayed_mutable_values.svc;
+
+        let frankensteinian_nullifier = poseidon2_hash_with_separator(
+            [
+                note_hash_for_nullify,
+                svc.get_post().compute_nullifier(context, note_hash_for_nullify),
+            ],
+            GENERATOR_INDEX__NOTE_NULLIFIER,
+        );
+
+        frankensteinian_nullifier
+    }
+
+    unconstrained fn compute_nullifier_unconstrained(self, note_hash_for_nullify: Field) -> Field {
+        let svc = self.delayed_mutable_values.svc;
+
+        let frankensteinian_nullifier = poseidon2_hash_with_separator(
+            [
+                note_hash_for_nullify,
+                svc.get_post().compute_nullifier_unconstrained(note_hash_for_nullify),
+            ],
+            GENERATOR_INDEX__NOTE_NULLIFIER,
+        );
+
+        frankensteinian_nullifier
+    }
+}
+
+impl<Note, let INITIAL_DELAY: u64> NoteType for DelayedPrivateMutableNote<Note, INITIAL_DELAY>
+where
+    Note: NoteType,
+{
+    // The DelayedPrivateMutableNote inherits the NoteTypeId of the Note.
+    fn get_id() -> Field {
+        Note::get_id()
+    }
+}
+
+impl<Note, let INITIAL_DELAY: u64, let N: u32> Packable for DelayedPrivateMutableNote<Note, INITIAL_DELAY>
+where
+    Note: Packable,
+{
+    let N: u32 = 2 * <Note as Packable>::N + 1;
+
+    fn pack(self) -> [Field; Self::N] {
+        self.delayed_mutable_values.pack()
+    }
+
+    fn unpack(fields: [Field; Self::N]) -> Self {
+        Self { delayed_mutable_values: DelayedPublicMutableValues::unpack(fields) }
+    }
+}

--- a/noir-projects/aztec-nr/aztec/src/state_vars/delayed_private_mutable/delayed_private_mutable_note.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/delayed_private_mutable/delayed_private_mutable_note.nr
@@ -18,16 +18,18 @@ where
 {
     fn compute_note_hash(self, storage_slot: Field) -> Field {
         // There are two natural approaches we could take here:
-        // 1. Leverage the Note's compute_note_hash method;
-        // 2. Ignore the Note's compute_note_hash method, and instead pack the note
-        //    into fields, and hash it ourselves.
+        // 1. Call the Note's compute_note_hash method;
+        // 2. Ignore the Note's compute_note_hash method, and instead pack the
+        //    note into fields, and hash it ourselves.
         // I've opted for option 1, in a mad attempt to preserve "partial note"
         // functionality.
-
-        // There is some redundant hashing of a storage slot within these nested compute_note_hash
-        // calls, but the opportunity to forward the responsibility is too good to pass up, for now.
-
-        // Let's define a partial delayed-private-mutable-note to be a _pair_ of fields:
+        //
+        // There is some redundant hashing of a storage slot within these nested
+        // compute_note_hash calls, but the opportunity to forward the
+        // responsibility is too good to pass up, for now.
+        //
+        // Let's define a partial delayed-private-mutable-note to be a _pair_ of
+        // fields:
         //
         // partial = [ h(storage_slot, complete(svc.pre), ...sdc.pack()), partial(svc.post) ]
         //
@@ -37,7 +39,8 @@ where
         //   (according to whatever notion of "partial" our Note implements).
         //
         // A function can then "complete" our "partial" DPMNote by:
-        // - first completing the svc.post note (according to its partial note calculation rules);
+        // - first completing the svc.post note (according to its partial note
+        //   calculation rules);
         // - then completing this DPMNote according to this rule:
         //
         // complete = h(
@@ -58,10 +61,10 @@ where
         let complete_pre_note_hash = svc.get_pre().compute_note_hash(storage_slot);
         let complete_post_note_hash = svc.get_post().compute_note_hash(storage_slot);
 
-        // We include the `storage_slot` here (possibly redundantly), because we don't
-        // know whether the `pre` and `post` note_hash computations will actually make
-        // use of it, and we _need_ it to be bound to this note_hash, so that the
-        // nullifier computation of this note is secure.
+        // We include the `storage_slot` here (possibly redundantly), because we
+        // don't know whether the `pre` and `post` note_hash computations will
+        // actually make use of it, and we _need_ it to be bound to this
+        // note_hash, so that the nullifier computation of this note is secure.
         let sdc_packed = sdc.pack();
         // This gives us confidence that accessing index 0 is sufficient:
         std::static_assert(
@@ -86,70 +89,104 @@ where
         context: &mut PrivateContext,
         note_hash_for_nullify: Field,
     ) -> Field {
-        // Recall: the `note_hash_for_nullify` parameter of this method is an optimisation to avoid
-        // having to re-compute the note_hash.
-        // We want to adopt the underlying pre and post notes' `compute_nullifier` functions,
-        // because this DMPNote is intended to be just a wrapper, and so it doesn't know
-        // any concept of "ownership"; it presumes the underlying notes will take care of
-        // inferring ownership from their note contents.
+        // Recall: the `note_hash_for_nullify` parameter of this method is an
+        // optimisation to avoid having to re-compute the note_hash.
+        // We want to adopt the underlying `pre` and `post` notes'
+        // `compute_nullifier` functions, because this DPMNote is intended to be
+        // just a wrapper, and so it doesn't know any concept of "ownership"; it
+        // presumes the underlying notes will take care of inferring ownership
+        // from their note contents.
         //
-        // So let's try to adopt the underlying notes' `compute_nullifier` functions.
-        // In fact, we'll only call the `post` note's `compute_nullifier`, in case ownership
-        // has changed between the `pre` and `post` notes (as then the `post` owner would not be
-        // able to compute the nullifier for `pre`). So only the owner of the `post` note
-        // can nullify this DMPNote in order to schedule subsequent
-        // delayed state updates. This means if the owner of `pre` (after having created the
-        // `post` note) wanted to change their mind and schedule a change to a different `post` note, they wouldn't be able to, unless they also own the `post` note.
+        // So let's try to adopt the underlying notes' `compute_nullifier`
+        // functions.
+        // In fact, we'll only call the `post` note's `compute_nullifier`, in
+        // case ownership has changed between the `pre` and `post` notes (as
+        // then the `post` owner would not be able to compute the nullifier for
+        // `pre`). So only the owner of the `post` note can nullify this DPMNote
+        // in order to schedule subsequent delayed state updates. This means if
+        // the owner of `pre` (after having created the `post` note) wanted to
+        // change their mind and schedule a change to a different `post` note,
+        // they wouldn't be able to, unless they also own the `post` note.
         //
-        // But there's another problem: in order to nullify the `post` note, we would need
-        // its note_hash. But we don't have its note hash: we only have the DPMNote's note hash.
+        // But there's another problem: in order to nullify the `post` note, we
+        // would need its note_hash. But we don't have access to the `post`
+        // note_hash within the body of this function: we only have the
+        // DPMNote's note_hash.
         //
         // You might wonder: Since we have access to the post note through
-        // self.delayed_mutable_values.svc.post, why can't we compute its note_hash within
-        // this function?
-        // It's because notes don't know their own storage_slot (which forms part of the
-        // `compute_note_hash` computation), and this `compute_nullifier`
-        // interface doesn't enable us to pass the `storage_slot` in as an arg.
+        // `self.delayed_mutable_values.svc.post`, why can't we compute its
+        // `note_hash` within this function?
+        // It's because notes don't know their own `storage_slot` (which is a
+        // parameter to a note's `compute_note_hash` computation), and this
+        // `compute_nullifier` interface doesn't enable us to pass the
+        // `storage_slot` in as an arg.
         //
         // I see two choices:
         //
-        // 1. Pass as arg the `post` note's note_hash instead;
-        //    Use that note_hash to compute the `post` note's nullifier;
-        //    Access the other data in the DPMNote (`self`) and hash it all up with the
-        //    post note's nullifier.
-        //    There's some redundant hashing, since we've probably already
+        // 1. Pass in the `post` note's note_hash into this function as the
+        //    `note_hash_for_nullify` argument (instead of the DPMNote's).
+        //    - Use that note_hash to compute the `post` note's nullifier;
+        //    - Access the other data in the DPMNote (`self`) and hash it all up
+        //      with the post note's nullifier, to get a frankensteinian
+        //      nullifier that can only be computed by the `post` note's "owner",
+        //      but which binds _all_ of the DPMNote's data.
+        //    There would be some redundant hashing, since we've probably already
         //    hashed the contents of `self` elsewhere when we retrieved the note.
-        //    This abuses the `compute_nullifier` interface of this DPMNote, in the sense
-        //    that we're not passing-in `self`'s note_hash, but that of `post` instead.
-        //
-        // 2. Pass as arg this DPMNote's note_hash. (I.e. the note hash of `self`,
-        //    as is conventional);
-        //    Use that (technically-incompatible) note_hash to compute the `post` note's nullifier,
-        //    and use that nullifier as the nullifier of this `self` note.
-        //    (Remember: we leverage the `post` note's nullifier computation to inject a
-        //    nullifier secret key, if applicable).
-        //    So we end up with this Frankensteinian nullifier, which is computed from `self`'s
-        //    note_hash, but using the methodology of the `post` note.
+        //    This abuses the `compute_nullifier` interface of this DPMNote, in
+        //    the sense that we're not passing-in `self`'s note_hash, but that
+        //    of `post` instead.
         //    A clear question is: is this safe? I don't know yet...
         //
-        // I'm going with option 2 for now, because it'll be easier to get working, since the
-        // nature of the args to this function will be consistent with all other calls
-        // to this function in this repo.
-
+        // 2. Pass this DPMNote's note_hash (i.e. the note hash of `self`,
+        //    as is conventional) as the `note_hash_for_nullify` argument.
+        //    Pass that (technically-incompatible) note_hash to into the the
+        //    `post` note's `compute_nullifier` method, and use the resulting
+        //    nullifier as the nullifier of this `self` note.
+        //    (Remember: the reason we leverage the `post` note's
+        //    `compute_nullifier` method (instead of writing a dedicated
+        //    implementation for this DPMNote) is because the `post` note (of
+        //    type `Note`) will have some app-specific understanding of "note
+        //    ownership", and so will know whether/how to inject a nullifier
+        //    secret key, if applicable).
+        //    So we end up with this Frankensteinian nullifier, which is
+        //    computed from `self`'s `note_hash_for_nullify`, but using the
+        //    `compute_nullifier` methodology of the `post` note.
+        //    A clear question is: is this safe? I don't know yet...
+        //
+        // I need to write out the options in pseudocode:
+        //
+        // Option 1:
+        // Input: self, post.note_hash_for_nullify
+        //
+        // let post_nullifier = self.delayed_mutable_values.svc.get_post().compute_nullifier(context, post.note_hash_for_nullify);
+        // let nullifier = h(self.to_fields(), post_nullifier);
+        //
+        // Option 2:
+        // Input: self, self.note_hash_for_nullify
+        //
+        // let compute_nullifier_fn = self.delayed_mutable_values.svc.get_post().compute_nullifier;
+        // let nullifier = h(self.note_hash_for_nullify, compute_nullifier_fn(self.note_hash_for_nullify));
+        //
+        // I'm going with option 2, because it'll be easier to get working,
+        // since the nature of the args to this function will be consistent with
+        // all other calls to this function in this repo.
+        //
         // We'll compute the nullifier as:
         //
         // h(note_hash_for_nullify, post.compute_nullifier(note_hash_for_nullify))
         //
-        // Including the nullifier with the methodology of the `post` note enables
-        // deterministic randomness to be added to the nullifier (depending on the
-        // particular Note impl we're dealing with) -- commonly the owner's nullifier
-        // secret key -- in order to hide from the world which note is being nullified.
-        // We don't know for sure whether the `post.compute_nullifier()` call will
-        // actually _make use_ of note_hash_for_nullify in its computation, so we also
-        // hash that value into the mix, to ensure the entire contents of `self`
-        // _and_ the `storage_slot` are bound to this nullifier.
-        // Using the note hash of `self` as the `note_hash_for_nullify` ensures we
-        // bind this nullifier to all of the content of this note.
+        // Including the nullifier with the methodology of the `post` note
+        // enables deterministic randomness to be added to the nullifier
+        // (depending on the particular Note impl we're dealing with) --
+        // commonly the owner's nullifier secret key -- in order to hide from
+        // the world which note is being nullified.
+        // We don't know for sure whether the `post.compute_nullifier()` call
+        // will actually _make use_ of note_hash_for_nullify in its computation,
+        // so we also hash that value into the mix, to ensure the entire
+        // contents of `self` _and_ the `storage_slot` are bound to this
+        // nullifier.
+        // Using the note hash of `self` as the `note_hash_for_nullify` ensures
+        // we bind this nullifier to all of the content of this note.
 
         let svc = self.delayed_mutable_values.svc;
 

--- a/noir-projects/aztec-nr/aztec/src/state_vars/delayed_private_mutable/delayed_private_mutable_note.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/delayed_private_mutable/delayed_private_mutable_note.nr
@@ -5,9 +5,14 @@ use dep::protocol_types::{
     traits::Packable,
 };
 
-use crate::{context::PrivateContext, note::note_interface::{NoteHash, NoteType}};
+use crate::{
+    context::PrivateContext,
+    macros::notes::custom_note,
+    note::note_interface::{NoteHash, NoteType},
+};
 
 #[derive(Eq)]
+#[custom_note] // <-- I added this, and the macro got angry about not implementing Packable (which is implemented below)
 pub struct DelayedPrivateMutableNote<Note, let INITIAL_DELAY: u64> {
     pub delayed_mutable_values: DelayedPublicMutableValues<Note, INITIAL_DELAY>,
 }
@@ -216,15 +221,15 @@ where
     }
 }
 
-impl<Note, let INITIAL_DELAY: u64> NoteType for DelayedPrivateMutableNote<Note, INITIAL_DELAY>
-where
-    Note: NoteType,
-{
-    // The DelayedPrivateMutableNote inherits the NoteTypeId of the Note.
-    fn get_id() -> Field {
-        Note::get_id()
-    }
-}
+// impl<Note, let INITIAL_DELAY: u64> NoteType for DelayedPrivateMutableNote<Note, INITIAL_DELAY>
+// where
+//     Note: NoteType,
+// {
+//     // The DelayedPrivateMutableNote inherits the NoteTypeId of the Note.
+//     fn get_id() -> Field {
+//         Note::get_id()
+//     }
+// }
 
 impl<Note, let INITIAL_DELAY: u64, let N: u32> Packable for DelayedPrivateMutableNote<Note, INITIAL_DELAY>
 where
@@ -240,3 +245,39 @@ where
         Self { delayed_mutable_values: DelayedPublicMutableValues::unpack(fields) }
     }
 }
+
+// mod test {
+//     use crate::{
+//         test::{helpers::test_environment::TestEnvironment, mocks::mock_note::MockNote},
+//     };
+
+//     use dep::protocol_types::{
+//         constants::{GENERATOR_INDEX__NOTE_HASH, GENERATOR_INDEX__NOTE_NULLIFIER},
+//         delayed_public_mutable::DelayedPublicMutableValues,
+//         hash::poseidon2_hash_with_separator,
+//         traits::Packable,
+//     };
+//     use protocol_types::delayed_public_mutable::scheduled_value_change::ScheduledValueChange;
+//     use protocol_types::delayed_public_mutable::scheduled_delay_change::ScheduledDelayChange;
+
+//     global TEST_INITIAL_DELAY: u64 = 100;
+
+//     #[test]
+//     fn compute_note_hash() {
+//         let pre_note = MockNote::new(1).build_note();
+//         let post_note = MockNote::new(2).build_note();
+//         let delayed_mutable_values = DelayedPublicMutableValues::<MockNote, TEST_INITIAL_DELAY>::new(
+//             ScheduledValueChange::<MockNote>::new(
+//                 pre_note,
+//                 post_note,
+//                 1234,
+//             ),
+//             ScheduledDelayChange::<TEST_INITIAL_DELAY>::new(
+//                 Option::<u64>::none(),
+//                 Option::<u64>::none(),
+//                 0,
+//             ),
+//         );
+//     }
+
+// }

--- a/noir-projects/aztec-nr/aztec/src/state_vars/delayed_private_mutable/delayed_private_mutable_note.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/delayed_private_mutable/delayed_private_mutable_note.nr
@@ -7,12 +7,14 @@ use dep::protocol_types::{
 
 use crate::{
     context::PrivateContext,
-    macros::notes::custom_note,
-    note::note_interface::{NoteHash, NoteType},
+    macros::notes::MAX_NOTE_TYPES,
+    note::{
+        note_getter_options::PropertySelector,
+        note_interface::{NoteHash, NoteProperties, NoteType},
+    },
 };
 
 #[derive(Eq)]
-#[custom_note] // <-- I added this, and the macro got angry about not implementing Packable (which is implemented below)
 pub struct DelayedPrivateMutableNote<Note, let INITIAL_DELAY: u64> {
     pub delayed_mutable_values: DelayedPublicMutableValues<Note, INITIAL_DELAY>,
 }
@@ -66,16 +68,17 @@ where
         let complete_pre_note_hash = svc.get_pre().compute_note_hash(storage_slot);
         let complete_post_note_hash = svc.get_post().compute_note_hash(storage_slot);
 
-        // We include the `storage_slot` here (possibly redundantly), because we
-        // don't know whether the `pre` and `post` note_hash computations will
-        // actually make use of it, and we _need_ it to be bound to this
-        // note_hash, so that the nullifier computation of this note is secure.
         let sdc_packed = sdc.pack();
         // This gives us confidence that accessing index 0 is sufficient:
         std::static_assert(
             sdc_packed.len() == 1,
             "The packing computation for sdc must have been changed",
         );
+
+        // We include the `storage_slot` here (possibly redundantly), because we
+        // don't know whether the `pre` and `post` note_hash computations will
+        // actually make use of it, and we _need_ it to be bound to this
+        // note_hash, so that the nullifier computation of this note is secure.
         let partial_0 = poseidon2_hash_with_separator(
             [storage_slot, complete_pre_note_hash, sdc_packed[0]],
             GENERATOR_INDEX__NOTE_HASH,
@@ -221,15 +224,36 @@ where
     }
 }
 
-// impl<Note, let INITIAL_DELAY: u64> NoteType for DelayedPrivateMutableNote<Note, INITIAL_DELAY>
-// where
-//     Note: NoteType,
-// {
-//     // The DelayedPrivateMutableNote inherits the NoteTypeId of the Note.
-//     fn get_id() -> Field {
-//         Note::get_id()
-//     }
-// }
+// Manually implementing all note traits, because the macros can't cope with
+// a note with generics (like DelayedPrivateMutableNote has).
+
+impl<Note, let INITIAL_DELAY: u64> NoteType for DelayedPrivateMutableNote<Note, INITIAL_DELAY>
+where
+    Note: NoteType,
+{
+    fn get_id() -> Field {
+        MAX_NOTE_TYPES as Field // Chosen to avoid collisions with actual notes' derived note ids.
+    }
+}
+
+struct DelayedPrivateMutableNoteProperties {
+    delayed_mutable_values: PropertySelector,
+}
+
+impl<Note, let INITIAL_DELAY: u64> NoteProperties<DelayedPrivateMutableNoteProperties> for DelayedPrivateMutableNote<Note, INITIAL_DELAY>
+where
+    Note: Packable,
+{
+    fn properties() -> DelayedPrivateMutableNoteProperties {
+        DelayedPrivateMutableNoteProperties {
+            delayed_mutable_values: PropertySelector {
+                index: 0,
+                offset: 0,
+                length: <DelayedPrivateMutableNote<Note, INITIAL_DELAY> as Packable>::N as u8 * 32,
+            },
+        }
+    }
+}
 
 impl<Note, let INITIAL_DELAY: u64, let N: u32> Packable for DelayedPrivateMutableNote<Note, INITIAL_DELAY>
 where
@@ -245,39 +269,3 @@ where
         Self { delayed_mutable_values: DelayedPublicMutableValues::unpack(fields) }
     }
 }
-
-// mod test {
-//     use crate::{
-//         test::{helpers::test_environment::TestEnvironment, mocks::mock_note::MockNote},
-//     };
-
-//     use dep::protocol_types::{
-//         constants::{GENERATOR_INDEX__NOTE_HASH, GENERATOR_INDEX__NOTE_NULLIFIER},
-//         delayed_public_mutable::DelayedPublicMutableValues,
-//         hash::poseidon2_hash_with_separator,
-//         traits::Packable,
-//     };
-//     use protocol_types::delayed_public_mutable::scheduled_value_change::ScheduledValueChange;
-//     use protocol_types::delayed_public_mutable::scheduled_delay_change::ScheduledDelayChange;
-
-//     global TEST_INITIAL_DELAY: u64 = 100;
-
-//     #[test]
-//     fn compute_note_hash() {
-//         let pre_note = MockNote::new(1).build_note();
-//         let post_note = MockNote::new(2).build_note();
-//         let delayed_mutable_values = DelayedPublicMutableValues::<MockNote, TEST_INITIAL_DELAY>::new(
-//             ScheduledValueChange::<MockNote>::new(
-//                 pre_note,
-//                 post_note,
-//                 1234,
-//             ),
-//             ScheduledDelayChange::<TEST_INITIAL_DELAY>::new(
-//                 Option::<u64>::none(),
-//                 Option::<u64>::none(),
-//                 0,
-//             ),
-//         );
-//     }
-
-// }

--- a/noir-projects/aztec-nr/aztec/src/state_vars/delayed_private_mutable/test.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/delayed_private_mutable/test.nr
@@ -590,12 +590,18 @@ unconstrained fn get_current_note_immediately_after_scheduling_replacement() {
     // 1000 is arbitrary
     env.mine_block_at(initial_note_timestamp_of_change + 1000);
 
-    env.private_context(|context| {
+    let replacement_wrapper_note_emission = env.private_context(|context| {
         let state_var = in_private(context);
 
         let replacement_note = MockNote::new(REPLACEMENT_VALUE).build_note();
 
-        let _ = state_var.schedule_replacement(replacement_note);
+        state_var.schedule_replacement(replacement_note)
+    });
+
+    env.discover_note(replacement_wrapper_note_emission);
+
+    env.private_context(|context| {
+        let state_var = in_private(context);
 
         let current_note = state_var.get_current_note();
 
@@ -627,7 +633,7 @@ unconstrained fn get_scheduled_note_immediately_after_scheduling_replacement() {
     // 1000 is arbitrary
     env.mine_block_at(initial_note_timestamp_of_change + 1000);
 
-    env.private_context(|context| {
+    let (replacement_wrapper_note_emission, replacement_note) = env.private_context(|context| {
         let state_var = in_private(context);
 
         let replacement_note = MockNote::new(REPLACEMENT_VALUE).build_note();
@@ -635,7 +641,15 @@ unconstrained fn get_scheduled_note_immediately_after_scheduling_replacement() {
         // We don't use the setup_initialization_then_replacement helper function here, because that
         // function calls `get_scheduled_note` immediately -- which is the very thing we
         // want to test in this test!
-        let _ = state_var.schedule_replacement(replacement_note);
+        let replacement_wrapper_note_emission = state_var.schedule_replacement(replacement_note);
+
+        (replacement_wrapper_note_emission, replacement_note)
+    });
+
+    env.discover_note(replacement_wrapper_note_emission);
+
+    env.private_context(|context| {
+        let state_var = in_private(context);
 
         // Note: we have to compute the expected_ts _before_ we get_scheduled_note, because the
         // act of getting the scheduled note will mutate the `context.include_by_timestamp`.
@@ -668,8 +682,6 @@ unconstrained fn get_current_note_just_before_scheduled_replacement_takes_effect
 
     let (initial_note, _, _, _, timestamp_of_change) = setup_initialization_then_replacement(env);
 
-    // env.discover_note(wrapper_note_emission);
-
     // Just before scheduled initialization takes effect:
     env.mine_block_at(timestamp_of_change - 1);
 
@@ -680,7 +692,7 @@ unconstrained fn get_current_note_just_before_scheduled_replacement_takes_effect
 
         let current_note = state_var.get_current_note();
 
-        // The `replacement_note` does not take effect until after a delay (see later tests).
+        // The `replacement_note` does not take effect until the timestamp_of_change.
         assert_eq(current_note, initial_note);
 
         // When we call get_current_note, the returned note is only valid for
@@ -1298,7 +1310,7 @@ unconstrained fn schedule_delay_decrease_but_then_schedule_value_change_before_t
 // takes effect, because a scheduled delay INCREASE takes effect immediately.
 
 #[test]
-unconstrained fn get_current_delay_immediately_after_scheduling_delay_change() {
+unconstrained fn get_current_delay_immediately_after_scheduling_delay_increase() {
     let env = TestEnvironment::_new();
 
     let (_, _, _, initial_note_timestamp_of_change) = setup_schedule_initialization(env);
@@ -1306,24 +1318,65 @@ unconstrained fn get_current_delay_immediately_after_scheduling_delay_change() {
     // 1000 is arbitrary
     env.mine_block_at(initial_note_timestamp_of_change + 1000);
 
+    let delay_change_wrapper_note_emission = env.private_context(|context| {
+        let state_var = in_private(context);
+
+        state_var.schedule_delay_change(LONGER_DELAY)
+    });
+
+    env.discover_note(delay_change_wrapper_note_emission);
+
     env.private_context(|context| {
         let state_var = in_private(context);
 
-        let _ = state_var.schedule_delay_change(LONGER_DELAY);
+        let current_delay = state_var.get_current_delay();
+
+        // The delay_change does not take effect until the include_by_timestamp
+        assert_eq(current_delay, TEST_INITIAL_DELAY);
+
+        // When we call get_current_delay, the returned note is only valid for
+        // the min of:
+        // - pre delay (100)
+        // - time until just before the change (time until the scheduled change is included - 1) + post delay (200)
+        // So 100 bites.
+        let include_by_ts_after_get = context.include_by_timestamp;
+
+        let expected_include_by_ts_after_get = context.get_anchor_timestamp() + TEST_INITIAL_DELAY;
+
+        assert_eq(include_by_ts_after_get, expected_include_by_ts_after_get)
+    });
+}
+
+#[test]
+unconstrained fn get_current_delay_immediately_after_scheduling_delay_decrease() {
+    let env = TestEnvironment::_new();
+
+    let (_, _, _, initial_note_timestamp_of_change) = setup_schedule_initialization(env);
+
+    // 1000 is arbitrary
+    env.mine_block_at(initial_note_timestamp_of_change + 1000);
+
+    let delay_change_wrapper_note_emission = env.private_context(|context| {
+        let state_var = in_private(context);
+
+        state_var.schedule_delay_change(LONGER_DELAY)
+    });
+
+    env.discover_note(delay_change_wrapper_note_emission);
+
+    env.private_context(|context| {
+        let state_var = in_private(context);
 
         let current_delay = state_var.get_current_delay();
 
-        // The delay_change does not take effect until after a delay (see later tests).
+        // The delay_change does not take effect until the include_by_timestamp
         assert_eq(current_delay, TEST_INITIAL_DELAY);
 
-        // When we call get_current_delay, the returned delay is only valid for
+        // When we call get_current_delay, the returned note is only valid for
         // the min of:
-        // - TEST_INITIAL_DELAY amount of time from the anchor timestamp.
-        // - 1 second before the `timestamp_of_change` of the delay.
-        // We check that the `include_by_timestamp` has been set accordingly.
-        // In the case of this test, since we're reading immediately after
-        // setting the note, the case "TEST_INITIAL_DELAY amount of time from
-        // the anchor timestamp" will bite.
+        // - pre delay (100)
+        // - time until just before the change (time until the scheduled change is included + (100 - 75) - 1) + post delay (75)
+        // So 100 bites.
         let include_by_ts_after_get = context.include_by_timestamp;
 
         let expected_include_by_ts_after_get = context.get_anchor_timestamp() + TEST_INITIAL_DELAY;
@@ -1360,9 +1413,11 @@ unconstrained fn get_scheduled_delay_immediately_after_scheduling_delay_increase
         assert_eq(scheduled_delay, LONGER_DELAY);
         assert_eq(scheduled_ts, expected_scheduled_ts);
 
-        // When we call get_scheduled_delay, the returned data is only valid for
-        // TEST_INITIAL_DELAY amount of time from the anchor timestamp.
-        // We check that the `include_by_timestamp` has been set accordingly.
+        // When we call get_scheduled_delay, the returned note is only valid for
+        // the min of:
+        // - pre delay (100)
+        // - time until just before the change (time until the scheduled change is included - 1) + post delay (200)
+        // So 100 bites.
         let include_by_ts_after_get = context.include_by_timestamp;
 
         let expected_include_by_ts_after_get = context.get_anchor_timestamp() + TEST_INITIAL_DELAY;
@@ -1400,9 +1455,11 @@ unconstrained fn get_scheduled_delay_immediately_after_scheduling_delay_decrease
         assert_eq(scheduled_delay, SHORTER_DELAY);
         assert_eq(scheduled_ts, expected_scheduled_ts);
 
-        // When we call get_scheduled_delay, the returned data is only valid for
-        // TEST_INITIAL_DELAY amount of time from the anchor timestamp.
-        // We check that the `include_by_timestamp` has been set accordingly.
+        // When we call get_current_delay, the returned note is only valid for
+        // the min of:
+        // - pre delay (100)
+        // - time until just before the change (time until the scheduled change is included + (100 - 75) - 1) + post delay (75)
+        // So 100 bites.
         let include_by_ts_after_get = context.include_by_timestamp;
 
         let expected_include_by_ts_after_get = context.get_anchor_timestamp() + TEST_INITIAL_DELAY;
@@ -1412,13 +1469,14 @@ unconstrained fn get_scheduled_delay_immediately_after_scheduling_delay_decrease
 }
 
 #[test]
-unconstrained fn get_current_note_just_before_scheduled_delay_change_takes_effect() {
+unconstrained fn get_current_delay_just_before_scheduled_delay_increase_takes_effect() {
     let env = TestEnvironment::_new();
 
-    let (_, _, _, timestamp_of_change) = setup_initialization_then_delay_change(env, LONGER_DELAY);
+    let (_, _, _, delay_change_timestamp_of_change) =
+        setup_initialization_then_delay_change(env, LONGER_DELAY);
 
     // Just before scheduled initialization takes effect:
-    env.mine_block_at(timestamp_of_change - 1);
+    env.mine_block_at(delay_change_timestamp_of_change - 1);
 
     // The context defaults to reading from the latest-mined block as the
     // anchor block.
@@ -1427,162 +1485,277 @@ unconstrained fn get_current_note_just_before_scheduled_delay_change_takes_effec
 
         let current_delay = state_var.get_current_delay();
 
-        // The `replacement_note` does not take effect until after a delay (see later tests).
+        // The delay change does not take effect until the delay_change_timestamp_of_change.
         assert_eq(current_delay, TEST_INITIAL_DELAY);
 
         // When we call get_current_delay, the returned note is only valid for
         // the min of:
-        // - TEST_INITIAL_DELAY amount of time from the anchor timestamp.
-        // - 1 second before the `timestamp_of_change` of the delayed_private_mutable_note.
-        // We check that the `include_by_timestamp` has been set accordingly.
-        // In the case of this test, the anchor block is only 1 second before
-        // the timestamp_of_change, so we'll have 0 seconds until the tx expires.
-        // This is clearly not a realistic or valid tx.
+        // - pre delay (100)
+        // - time until just before the change (0) + post delay (200)
+        // So 100 bites.
         let include_by_ts_after_get = context.include_by_timestamp;
-        let expected_include_by_ts_after_get = timestamp_of_change - 1;
+        let expected_include_by_ts_after_get = context.get_anchor_timestamp() + current_delay;
 
         assert_eq(include_by_ts_after_get, expected_include_by_ts_after_get);
     })
 }
 
-// #[test]
-// unconstrained fn get_scheduled_note_just_before_scheduled_delay_change_takes_effect() {
-//     let mut env = TestEnvironment::_new();
+#[test]
+unconstrained fn get_current_delay_just_before_scheduled_delay_decrease_takes_effect() {
+    let env = TestEnvironment::_new();
 
-//     let (_, _, _, replacement_note, timestamp_of_change) =
-//         setup_initialization_then_replacement(env);
+    let (_, _, _, delay_change_timestamp_of_change) =
+        setup_initialization_then_delay_change(env, SHORTER_DELAY);
 
-//     env.mine_block_at(timestamp_of_change - 1);
+    // Just before scheduled initialization takes effect:
+    env.mine_block_at(delay_change_timestamp_of_change - 1);
 
-//     // The context defaults to reading from the latest-mined block as the
-//     // anchor block.
-//     env.private_context(|context| {
-//         let state_var = in_private(context);
+    env.private_context(|context| {
+        let state_var = in_private(context);
 
-//         let (scheduled_note, scheduled_ts) = state_var.get_scheduled_note();
+        let current_delay = state_var.get_current_delay();
 
-//         assert_eq(scheduled_note, replacement_note);
-//         assert_eq(scheduled_ts, timestamp_of_change);
+        // The delay change does not take effect until the delay_change_timestamp_of_change.
+        assert_eq(current_delay, TEST_INITIAL_DELAY);
 
-//         // When we call get_scheduled_note, the returned note is only valid for
-//         // the min of:
-//         // - TEST_INITIAL_DELAY amount of time from the anchor timestamp.
-//         // - 1 second before the `timestamp_of_change` of the delayed_private_mutable_note.
-//         // We check that the `include_by_timestamp` has been set accordingly.
-//         // In the case of this test, the anchor block is only 1 second before
-//         // the timestamp_of_change, so we'll have 0 seconds until the tx expires.
-//         // This is clearly not a realistic or valid tx.
-//         let include_by_ts_after_get = context.include_by_timestamp;
-//         let expected_include_by_ts_after_get = timestamp_of_change - 1;
+        // When we call get_current_delay, the returned note is only valid for
+        // the min of:
+        // - pre delay (100)
+        // - time until just before the change (0) + post delay (75)
+        // So 75 bites.
+        let include_by_ts_after_get = context.include_by_timestamp;
+        let expected_include_by_ts_after_get = context.get_anchor_timestamp() + SHORTER_DELAY;
 
-//         assert_eq(include_by_ts_after_get, expected_include_by_ts_after_get);
-//     })
-// }
+        assert_eq(include_by_ts_after_get, expected_include_by_ts_after_get);
+    })
+}
 
-// #[test]
-// unconstrained fn get_current_note_at_the_time_scheduled_delay_change_takes_effect() {
-//     let env = TestEnvironment::_new();
+#[test]
+unconstrained fn get_scheduled_delay_just_before_scheduled_delay_increase_takes_effect() {
+    let mut env = TestEnvironment::_new();
 
-//     let (_, _, _, replacement_note, timestamp_of_change) =
-//         setup_initialization_then_replacement(env);
+    let (_, _, _, delay_change_timestamp_of_change) =
+        setup_initialization_then_delay_change(env, LONGER_DELAY);
 
-//     env.mine_block_at(timestamp_of_change);
+    env.mine_block_at(delay_change_timestamp_of_change - 1);
 
-//     // The context defaults to reading from the latest-mined block as the
-//     // anchor block, so it will have an anchor timestamp of `timestamp_of_change`.
-//     env.private_context(|context| {
-//         let state_var = in_private(context);
-//         let current_note = state_var.get_current_note();
+    env.private_context(|context| {
+        let state_var = in_private(context);
 
-//         assert_eq(current_note, replacement_note);
-//     })
-// }
+        let (scheduled_delay, scheduled_ts) = state_var.get_scheduled_delay();
 
-// #[test]
-// unconstrained fn get_scheduled_note_at_the_time_scheduled_delay_change_takes_effect() {
-//     let env = TestEnvironment::_new();
+        assert_eq(scheduled_delay, LONGER_DELAY);
+        assert_eq(scheduled_ts, delay_change_timestamp_of_change);
 
-//     let (_, _, _, replacement_note, timestamp_of_change) = setup_initialization_then_replacement(env);
+        // When we call get_scheduled_delay, the returned note is only valid for
+        // the min of:
+        // - pre delay (100)
+        // - time until just before the change (0) + post delay (200)
+        // So 100 bites.
+        let include_by_ts_after_get = context.include_by_timestamp;
+        let expected_include_by_ts_after_get = context.get_anchor_timestamp() + TEST_INITIAL_DELAY;
 
-//     env.mine_block_at(timestamp_of_change);
+        assert_eq(include_by_ts_after_get, expected_include_by_ts_after_get);
+    })
+}
 
-//     // The context defaults to reading from the latest-mined block as the
-//     // anchor block, so it will have an anchor timestamp of `timestamp_of_change`.
-//     env.private_context(|context| {
-//         // Double-check the test env works as expected:
-//         assert_eq(context.get_anchor_timestamp(), timestamp_of_change);
+#[test]
+unconstrained fn get_scheduled_delay_just_before_scheduled_delay_decrease_takes_effect() {
+    let mut env = TestEnvironment::_new();
 
-//         let state_var = in_private(context);
+    let (_, _, _, delay_change_timestamp_of_change) =
+        setup_initialization_then_delay_change(env, SHORTER_DELAY);
 
-//         let (scheduled_note, scheduled_ts) = state_var.get_scheduled_note();
+    env.mine_block_at(delay_change_timestamp_of_change - 1);
 
-//         assert_eq(scheduled_note, replacement_note);
-//         assert_eq(scheduled_ts, timestamp_of_change);
+    env.private_context(|context| {
+        let state_var = in_private(context);
 
-//         // When we call get_scheduled_note, the returned note is only valid for
-//         // TEST_INITIAL_DELAY amount of time from the anchor timestamp.
-//         // We check that the `include_by_timestamp` has been set accordingly.
-//         let include_by_ts_after_get = context.include_by_timestamp;
-//         let expected_include_by_ts_after_get = context.get_anchor_timestamp() + TEST_INITIAL_DELAY;
+        let (scheduled_delay, scheduled_ts) = state_var.get_scheduled_delay();
 
-//         assert_eq(include_by_ts_after_get, expected_include_by_ts_after_get);
+        assert_eq(scheduled_delay, SHORTER_DELAY);
+        assert_eq(scheduled_ts, delay_change_timestamp_of_change);
 
-//         // The scheduled and current notes should align, now that the scheduled
-//         // note has taken effect:
-//         let current_note = state_var.get_current_note();
-//         assert_eq(scheduled_note, current_note);
-//     })
-// }
+        // When we call get_scheduled_delay, the returned note is only valid for
+        // the min of:
+        // - pre delay (100)
+        // - time until just before the change (0) + post delay (75)
+        // So 75 bites.
+        let include_by_ts_after_get = context.include_by_timestamp;
+        let expected_include_by_ts_after_get = context.get_anchor_timestamp() + SHORTER_DELAY;
 
-// #[test]
-// unconstrained fn get_current_note_after_scheduled_delay_change_takes_effect() {
-//     let env = TestEnvironment::_new();
+        assert_eq(include_by_ts_after_get, expected_include_by_ts_after_get);
+    })
+}
 
-//     let (_, _, _, replacement_note, timestamp_of_change) = setup_initialization_then_replacement(env);
+#[test]
+unconstrained fn get_current_delay_at_the_time_scheduled_delay_increase_takes_effect() {
+    let env = TestEnvironment::_new();
 
-//     // + 7 is arbitrarily "some time after the expected timestamp of change".
-//     env.mine_block_at(timestamp_of_change + 7);
+    let (_, _, _, delay_change_timestamp_of_change) =
+        setup_initialization_then_delay_change(env, LONGER_DELAY);
 
-//     // The context defaults to reading from the latest-mined block as the
-//     // anchor block, so it will have an anchor timestamp of `timestamp_of_change + 7`.
-//     env.private_context(|context| {
-//         let state_var = in_private(context);
-//         let current_note = state_var.get_current_note();
+    env.mine_block_at(delay_change_timestamp_of_change);
 
-//         assert_eq(current_note, replacement_note);
-//     })
-// }
+    env.private_context(|context| {
+        let state_var = in_private(context);
 
-// #[test]
-// unconstrained fn get_scheduled_note_after_scheduled_delay_change_takes_effect() {
-//     let env = TestEnvironment::_new();
+        let current_delay = state_var.get_current_delay();
 
-//     let (_, _, _, replacement_note, timestamp_of_change) = setup_initialization_then_replacement(env);
+        assert_eq(current_delay, LONGER_DELAY);
 
-//     // + 7 is arbitrarily "some time after the expected timestamp of change".
-//     env.mine_block_at(timestamp_of_change + 7);
+        // Should be valid for as long as the new delay that's just taken effect.
+        let include_by_ts_after_get = context.include_by_timestamp;
+        let expected_include_by_ts_after_get = context.get_anchor_timestamp() + current_delay;
 
-//     // The context defaults to reading from the latest-mined block as the
-//     // anchor block, so it will have an anchor timestamp of `timestamp_of_change + 7`.
-//     env.private_context(|context| {
-//         let state_var = in_private(context);
+        assert_eq(include_by_ts_after_get, expected_include_by_ts_after_get);
+    })
+}
 
-//         let (scheduled_note, scheduled_ts) = state_var.get_scheduled_note();
+#[test]
+unconstrained fn get_current_delay_at_the_time_scheduled_delay_decrease_takes_effect() {
+    let env = TestEnvironment::_new();
 
-//         assert_eq(scheduled_note, replacement_note);
-//         assert_eq(scheduled_ts, timestamp_of_change);
+    let (_, _, _, delay_change_timestamp_of_change) =
+        setup_initialization_then_delay_change(env, SHORTER_DELAY);
 
-//         // When we call get_scheduled_note, the returned note is only valid for
-//         // TEST_INITIAL_DELAY amount of time from the anchor timestamp.
-//         // We check that the `include_by_timestamp` has been set accordingly.
-//         let include_by_ts_after_get = context.include_by_timestamp;
-//         let expected_include_by_ts_after_get = context.get_anchor_timestamp() + TEST_INITIAL_DELAY;
+    env.mine_block_at(delay_change_timestamp_of_change);
 
-//         assert_eq(include_by_ts_after_get, expected_include_by_ts_after_get);
+    env.private_context(|context| {
+        let state_var = in_private(context);
 
-//         // The scheduled and current notes should align, now that the scheduled
-//         // note has taken effect:
-//         let current_note = state_var.get_current_note();
-//         assert_eq(scheduled_note, current_note);
-//     })
-// }
+        let current_delay = state_var.get_current_delay();
+
+        assert_eq(current_delay, SHORTER_DELAY);
+
+        // Should be valid for as long as the new delay that's just taken effect.
+        let include_by_ts_after_get = context.include_by_timestamp;
+        let expected_include_by_ts_after_get = context.get_anchor_timestamp() + current_delay;
+
+        assert_eq(include_by_ts_after_get, expected_include_by_ts_after_get);
+    })
+}
+
+#[test]
+unconstrained fn get_scheduled_delay_at_the_time_scheduled_delay_increase_takes_effect() {
+    let mut env = TestEnvironment::_new();
+
+    let (_, _, _, delay_change_timestamp_of_change) =
+        setup_initialization_then_delay_change(env, LONGER_DELAY);
+
+    env.mine_block_at(delay_change_timestamp_of_change);
+
+    env.private_context(|context| {
+        let state_var = in_private(context);
+
+        let (scheduled_delay, scheduled_ts) = state_var.get_scheduled_delay();
+
+        assert_eq(scheduled_delay, LONGER_DELAY);
+        assert_eq(scheduled_ts, delay_change_timestamp_of_change);
+
+        // Should be valid for as long as the new delay that's just taken effect.
+        let include_by_ts_after_get = context.include_by_timestamp;
+        let expected_include_by_ts_after_get = context.get_anchor_timestamp() + LONGER_DELAY;
+
+        assert_eq(include_by_ts_after_get, expected_include_by_ts_after_get);
+    })
+}
+
+#[test]
+unconstrained fn get_scheduled_delay_at_the_time_scheduled_delay_decrease_takes_effect() {
+    let mut env = TestEnvironment::_new();
+
+    let (_, _, _, delay_change_timestamp_of_change) =
+        setup_initialization_then_delay_change(env, SHORTER_DELAY);
+
+    env.mine_block_at(delay_change_timestamp_of_change);
+
+    env.private_context(|context| {
+        let state_var = in_private(context);
+
+        let (scheduled_delay, scheduled_ts) = state_var.get_scheduled_delay();
+
+        assert_eq(scheduled_delay, SHORTER_DELAY);
+        assert_eq(scheduled_ts, delay_change_timestamp_of_change);
+
+        // Should be valid for as long as the new delay that's just taken effect.
+        let include_by_ts_after_get = context.include_by_timestamp;
+        let expected_include_by_ts_after_get = context.get_anchor_timestamp() + SHORTER_DELAY;
+
+        assert_eq(include_by_ts_after_get, expected_include_by_ts_after_get);
+    })
+}
+
+#[test]
+unconstrained fn get_current_delay_after_scheduled_delay_increase_takes_effect() {
+    let env = TestEnvironment::_new();
+
+    let (_, _, _, delay_change_timestamp_of_change) =
+        setup_initialization_then_delay_change(env, LONGER_DELAY);
+
+    env.mine_block_at(delay_change_timestamp_of_change + 10); // 10 is arbitrary
+
+    env.private_context(|context| {
+        let state_var = in_private(context);
+
+        let current_delay = state_var.get_current_delay();
+
+        assert_eq(current_delay, LONGER_DELAY);
+    })
+}
+
+#[test]
+unconstrained fn get_current_delay_after_scheduled_delay_decrease_takes_effect() {
+    let env = TestEnvironment::_new();
+
+    let (_, _, _, delay_change_timestamp_of_change) =
+        setup_initialization_then_delay_change(env, SHORTER_DELAY);
+
+    env.mine_block_at(delay_change_timestamp_of_change + 10); // 10 is arbitrary
+
+    env.private_context(|context| {
+        let state_var = in_private(context);
+
+        let current_delay = state_var.get_current_delay();
+
+        assert_eq(current_delay, SHORTER_DELAY);
+    })
+}
+
+#[test]
+unconstrained fn get_scheduled_delay_after_scheduled_delay_increase_takes_effect() {
+    let mut env = TestEnvironment::_new();
+
+    let (_, _, _, delay_change_timestamp_of_change) =
+        setup_initialization_then_delay_change(env, LONGER_DELAY);
+
+    env.mine_block_at(delay_change_timestamp_of_change + 10); // 10 is arbitrary
+
+    env.private_context(|context| {
+        let state_var = in_private(context);
+
+        let (scheduled_delay, scheduled_ts) = state_var.get_scheduled_delay();
+
+        assert_eq(scheduled_delay, LONGER_DELAY);
+        assert_eq(scheduled_ts, delay_change_timestamp_of_change);
+    })
+}
+
+#[test]
+unconstrained fn get_scheduled_delay_after_scheduled_delay_decrease_takes_effect() {
+    let mut env = TestEnvironment::_new();
+
+    let (_, _, _, delay_change_timestamp_of_change) =
+        setup_initialization_then_delay_change(env, SHORTER_DELAY);
+
+    env.mine_block_at(delay_change_timestamp_of_change + 10); // 10 is arbitrary
+
+    env.private_context(|context| {
+        let state_var = in_private(context);
+
+        let (scheduled_delay, scheduled_ts) = state_var.get_scheduled_delay();
+
+        assert_eq(scheduled_delay, SHORTER_DELAY);
+        assert_eq(scheduled_ts, delay_change_timestamp_of_change);
+    })
+}

--- a/noir-projects/aztec-nr/aztec/src/state_vars/delayed_private_mutable/test.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/delayed_private_mutable/test.nr
@@ -1,9 +1,12 @@
 use crate::{
     context::{PrivateContext, PublicContext, UtilityContext},
+    note::{note_emission::NoteEmission, note_interface::NoteHash},
     oracle::execution::get_contract_address,
-    state_vars::delayed_private_mutable::DelayedPrivateMutable,
+    state_vars::delayed_private_mutable::{
+        delayed_private_mutable_note::DelayedPrivateMutableNote, DelayedPrivateMutable,
+    },
     test::{
-        helpers::test_environment::TestEnvironment,
+        helpers::test_environment::{PrivateContextOptions, TestEnvironment},
         mocks::{mock_note::{MockNote, MockNoteBuilder}, mock_struct::MockStruct},
     },
 };
@@ -13,6 +16,10 @@ use std::test::OracleMock;
 use protocol_types::{
     address::AztecAddress,
     delayed_public_mutable::scheduled_delay_change::ScheduledDelayChange,
+    hash::{
+        compute_note_hash_nonce, compute_siloed_note_hash, compute_siloed_nullifier,
+        compute_unique_note_hash,
+    },
     traits::{Empty, Packable},
 };
 
@@ -21,20 +28,15 @@ use dep::std::mem::zeroed;
 global STORAGE_SLOT: Field = 47;
 
 global INITIAL_VALUE: Field = 17;
-global NEW_VALUE: Field = 18;
+global REPLACEMENT_VALUE: Field = 18;
 
 global TEST_INITIAL_DELAY: u64 = 100;
+global LONGER_DELAY: u64 = 200;
+global SHORTER_DELAY: u64 = 75;
 
-global new_delay: u64 = 20;
-// global new_value: MockStruct = MockStruct { a: 17, b: 42 };
-// global new_note = MockNote::new(17).build_note();
-// global new_note = MockNote { value: 17 };
-
-unconstrained fn in_public(
-    context: &mut PublicContext,
-) -> DelayedPrivateMutable<MockNote, TEST_INITIAL_DELAY, &mut PublicContext> {
-    DelayedPrivateMutable::new(context, STORAGE_SLOT)
-}
+/*******************************************************************************
+ * HELPERS
+ ******************************************************************************/
 
 unconstrained fn in_private(
     context: &mut PrivateContext,
@@ -48,9 +50,126 @@ unconstrained fn in_utility(
     DelayedPrivateMutable::new(context, STORAGE_SLOT)
 }
 
-// First, a collection of tests that are modifications of those for PrivateMutable:
+unconstrained fn get_final_note_hash(context: &mut PrivateContext, i: u32) -> Field {
+    let inner_note_hash = context.note_hashes.get(i).value;
+
+    let siloed_note_hash = compute_siloed_note_hash(context.this_address(), inner_note_hash);
+
+    let inner_first_nullifier_in_tx = context.nullifiers.get(i).value;
+
+    let siloed_first_nullifier_in_tx =
+        compute_siloed_nullifier(context.this_address(), inner_first_nullifier_in_tx);
+
+    let note_hash_nonce = compute_note_hash_nonce(siloed_first_nullifier_in_tx, 0);
+
+    compute_unique_note_hash(note_hash_nonce, siloed_note_hash)
+}
+
+unconstrained fn setup_schedule_initialization(
+    env: TestEnvironment,
+) -> (DelayedPrivateMutableNote<MockNote, TEST_INITIAL_DELAY>, Field, MockNote, u64) {
+    let (initial_wrapper_note_emission, initial_wrapper_note_hash, initial_note, initial_note_timestamp_of_change) = env
+        .private_context(|context| {
+            let state_var = in_private(context);
+
+            let initial_note = MockNote::new(INITIAL_VALUE).build_note();
+
+            let initial_wrapper_note_emission = state_var.schedule_initialization(initial_note);
+
+            let initial_wrapper_note_hash = get_final_note_hash(context, 0);
+
+            let (_, initial_note_timestamp_of_change) = state_var.get_scheduled_note();
+
+            (
+                initial_wrapper_note_emission, initial_wrapper_note_hash, initial_note,
+                initial_note_timestamp_of_change,
+            )
+        });
+
+    env.discover_note(initial_wrapper_note_emission);
+
+    (
+        initial_wrapper_note_emission.note, initial_wrapper_note_hash, initial_note,
+        initial_note_timestamp_of_change,
+    )
+}
+
+unconstrained fn setup_initialization_then_replacement(
+    env: TestEnvironment,
+) -> (MockNote, DelayedPrivateMutableNote<MockNote, TEST_INITIAL_DELAY>, Field, MockNote, u64) {
+    let (_, _, initial_note, initial_note_timestamp_of_change) = setup_schedule_initialization(env);
+
+    // + 1000 is arbitrary
+    env.mine_block_at(initial_note_timestamp_of_change + 1000);
+
+    let (replacement_wrapper_note_emission, replacement_wrapper_note_hash, replacement_note) = env
+        .private_context(|context| {
+            let state_var = in_private(context);
+
+            let replacement_note = MockNote::new(REPLACEMENT_VALUE).build_note();
+
+            let replacement_wrapper_note_emission =
+                state_var.schedule_replacement(replacement_note);
+
+            let replacement_wrapper_note_hash = get_final_note_hash(context, 0);
+
+            (replacement_wrapper_note_emission, replacement_wrapper_note_hash, replacement_note)
+        });
+
+    env.discover_note(replacement_wrapper_note_emission);
+
+    let (_, replacement_note_timestamp_of_change) = env.private_context(|context| {
+        let state_var = in_private(context);
+
+        state_var.get_scheduled_note()
+    });
+
+    (
+        initial_note, replacement_wrapper_note_emission.note, replacement_wrapper_note_hash,
+        replacement_note, replacement_note_timestamp_of_change,
+    )
+}
+
+unconstrained fn setup_initialization_then_delay_change(
+    env: TestEnvironment,
+    new_delay: u64,
+) -> (MockNote, DelayedPrivateMutableNote<MockNote, TEST_INITIAL_DELAY>, Field, u64) {
+    let (_, _, initial_note, initial_note_timestamp_of_change) = setup_schedule_initialization(env);
+
+    // + 1000 is arbitrary
+    env.mine_block_at(initial_note_timestamp_of_change + 1000);
+
+    let (delay_change_wrapper_note_emission, delay_change_wrapper_note_hash) = env
+        .private_context(|context| {
+            let state_var = in_private(context);
+
+            let delay_change_wrapper_note_emission = state_var.schedule_delay_change(new_delay);
+
+            let delay_change_wrapper_note_hash = get_final_note_hash(context, 0);
+
+            (delay_change_wrapper_note_emission, delay_change_wrapper_note_hash)
+        });
+
+    env.discover_note(delay_change_wrapper_note_emission);
+
+    let (_, delay_change_timestamp_of_change) = env.private_context(|context| {
+        let state_var = in_private(context);
+
+        state_var.get_scheduled_delay()
+    });
+
+    (
+        initial_note, delay_change_wrapper_note_emission.note, delay_change_wrapper_note_hash,
+        delay_change_timestamp_of_change,
+    )
+}
+
+/*******************************************************************************
+ * SCHEDULE_INITIALIZATION
+ ******************************************************************************/
+
 #[test(should_fail_with = "Failed to get a note")]
-unconstrained fn get_uninitialized() {
+unconstrained fn get_current_uninitialized() {
     let env = TestEnvironment::_new();
 
     env.private_context(|context| {
@@ -58,6 +177,304 @@ unconstrained fn get_uninitialized() {
         let _ = state_var.get_current_note();
     });
 }
+
+#[test(should_fail_with = "Failed to get a note")]
+unconstrained fn get_scheduled_uninitialized() {
+    let env = TestEnvironment::_new();
+
+    env.private_context(|context| {
+        let state_var = in_private(context);
+        let _ = state_var.get_scheduled_note();
+    });
+}
+
+#[test]
+unconstrained fn schedule_initialization() {
+    let env = TestEnvironment::_new();
+
+    env.private_context(|context| {
+        let state_var = in_private(context);
+
+        let initial_note = MockNote::new(INITIAL_VALUE).build_note();
+
+        let wrapper_note_emission = state_var.schedule_initialization(initial_note);
+
+        // During initialization we both create the new note and emit the initialization nullifier
+        assert_eq(context.note_hashes.len(), 1);
+        assert_eq(context.nullifiers.len(), 1);
+        assert_eq(context.nullifiers.get(0).value, state_var.compute_initialization_nullifier());
+
+        let wrapper_note = wrapper_note_emission.note;
+
+        let svc = wrapper_note.delayed_mutable_values.svc;
+        let pre_note = svc.get_pre();
+        let post_note = svc.get_post();
+        let ts = svc.get_timestamp_of_change();
+
+        assert_eq(pre_note, MockNote::empty());
+        assert_eq(post_note, initial_note);
+
+        let expected_ts = context.include_by_timestamp + TEST_INITIAL_DELAY;
+        assert_eq(ts, expected_ts);
+
+        let sdc = wrapper_note.delayed_mutable_values.sdc;
+        assert_eq(sdc, ScheduledDelayChange::<TEST_INITIAL_DELAY>::empty());
+
+        assert_eq(wrapper_note_emission.storage_slot, STORAGE_SLOT);
+    });
+}
+
+#[test]
+unconstrained fn get_current_note_immediately_after_scheduling_initialization() {
+    let env = TestEnvironment::_new();
+
+    env.private_context(|context| {
+        let state_var = in_private(context);
+
+        let initial_note = MockNote::new(INITIAL_VALUE).build_note();
+
+        let _ = state_var.schedule_initialization(initial_note);
+
+        let current_note = state_var.get_current_note();
+
+        // The `initial_note` does not take effect until after a delay (see later tests).
+        assert_eq(current_note, MockNote::empty());
+
+        // When we call get_current_note, the returned note is only valid for
+        // the min of:
+        // - TEST_INITIAL_DELAY amount of time from the anchor timestamp.
+        // - 1 second before the `timestamp_of_change` of the delayed_private_mutable_note.
+        // We check that the `include_by_timestamp` has been set accordingly.
+        // In the case of this test, since we're reading immediately after
+        // setting the note, the case "TEST_INITIAL_DELAY amount of time from
+        // the anchor timestamp" will bite.
+        let include_by_ts_after_get = context.include_by_timestamp;
+
+        let expected_include_by_ts_after_get = context.get_anchor_timestamp() + TEST_INITIAL_DELAY;
+
+        assert_eq(include_by_ts_after_get, expected_include_by_ts_after_get)
+    });
+}
+
+#[test]
+unconstrained fn get_scheduled_note_immediately_after_scheduling_initialization() {
+    let env = TestEnvironment::_new();
+
+    env.private_context(|context| {
+        let state_var = in_private(context);
+
+        let initial_note = MockNote::new(INITIAL_VALUE).build_note();
+
+        // We don't use the setup_schedule_initialization helper function here, because that
+        // function calls `get_scheduled_note` immediately -- which is the very thing we
+        // want to test in this test!
+        let _ = state_var.schedule_initialization(initial_note);
+
+        // Note: we have to compute the expected_ts _before_ we get_scheduled_note, because the
+        // act of getting the scheduled note will mutate the `context.include_by_timestamp`.
+        // Another interesting point: a timestamp_of_change might get baked into
+        // a note, and then some time later in the same tx, a lower
+        // include_by_timestamp might get set. That's ok -- it just means the
+        // timestamp_of_change could technically have been earlier than was
+        // baked-in.
+        let expected_scheduled_ts = context.include_by_timestamp + TEST_INITIAL_DELAY;
+
+        let (scheduled_note, scheduled_ts) = state_var.get_scheduled_note();
+
+        assert_eq(scheduled_note, initial_note);
+        assert_eq(scheduled_ts, expected_scheduled_ts);
+
+        // When we call get_scheduled_note, the returned note is only valid for
+        // TEST_INITIAL_DELAY amount of time from the anchor timestamp.
+        // We check that the `include_by_timestamp` has been set accordingly.
+        let include_by_ts_after_get = context.include_by_timestamp;
+
+        let expected_include_by_ts_after_get = context.get_anchor_timestamp() + TEST_INITIAL_DELAY;
+
+        assert_eq(include_by_ts_after_get, expected_include_by_ts_after_get)
+    });
+}
+
+#[test]
+unconstrained fn get_current_note_just_before_scheduled_initialization_takes_effect() {
+    let env = TestEnvironment::_new();
+
+    let (_, _, _, timestamp_of_change) = setup_schedule_initialization(env);
+
+    // Just before scheduled initialization takes effect:
+    env.mine_block_at(timestamp_of_change - 1);
+
+    // The context defaults to reading from the latest-mined block as the
+    // anchor block.
+    env.private_context(|context| {
+        let state_var = in_private(context);
+
+        let current_note = state_var.get_current_note();
+
+        // The `initial_note` does not take effect until after a delay (see later tests).
+        assert_eq(current_note, MockNote::empty());
+
+        // When we call get_current_note, the returned note is only valid for
+        // the min of:
+        // - TEST_INITIAL_DELAY amount of time from the anchor timestamp.
+        // - 1 second before the `timestamp_of_change` of the delayed_private_mutable_note.
+        // We check that the `include_by_timestamp` has been set accordingly.
+        // In the case of this test, the anchor block is only 1 second before
+        // the timestamp_of_change, so we'll have 0 seconds until the tx expires.
+        // This is clearly not a realistic or valid tx.
+        let include_by_ts_after_get = context.include_by_timestamp;
+        let expected_include_by_ts_after_get = timestamp_of_change - 1;
+
+        assert_eq(include_by_ts_after_get, expected_include_by_ts_after_get);
+    })
+}
+
+#[test]
+unconstrained fn get_scheduled_note_just_before_scheduled_initialization_takes_effect() {
+    let env = TestEnvironment::_new();
+
+    let (_, _, initial_note, timestamp_of_change) = setup_schedule_initialization(env);
+
+    env.mine_block_at(timestamp_of_change - 1);
+
+    // The context defaults to reading from the latest-mined block as the
+    // anchor block.
+    env.private_context(|context| {
+        let state_var = in_private(context);
+
+        let (scheduled_note, scheduled_ts) = state_var.get_scheduled_note();
+
+        assert_eq(scheduled_note, initial_note);
+        assert_eq(scheduled_ts, timestamp_of_change);
+
+        // When we call get_scheduled_note, the returned note is only valid for
+        // the min of:
+        // - TEST_INITIAL_DELAY amount of time from the anchor timestamp.
+        // - 1 second before the `timestamp_of_change` of the delayed_private_mutable_note.
+        // We check that the `include_by_timestamp` has been set accordingly.
+        // In the case of this test, the anchor block is only 1 second before
+        // the timestamp_of_change, so we'll have 0 seconds until the tx expires.
+        // This is clearly not a realistic or valid tx.
+        let include_by_ts_after_get = context.include_by_timestamp;
+        let expected_include_by_ts_after_get = timestamp_of_change - 1;
+
+        assert_eq(include_by_ts_after_get, expected_include_by_ts_after_get);
+    })
+}
+
+#[test]
+unconstrained fn get_current_note_at_the_time_scheduled_initialization_takes_effect() {
+    let env = TestEnvironment::_new();
+
+    let (_, _, initial_note, timestamp_of_change) = setup_schedule_initialization(env);
+
+    env.mine_block_at(timestamp_of_change);
+
+    // The context defaults to reading from the latest-mined block as the
+    // anchor block, so it will have an anchor timestamp of `timestamp_of_change`.
+    env.private_context(|context| {
+        // Double-check the test env works as expected:
+        assert_eq(context.get_anchor_timestamp(), timestamp_of_change);
+
+        let state_var = in_private(context);
+        let current_note = state_var.get_current_note();
+
+        assert_eq(current_note, initial_note);
+    })
+}
+
+#[test]
+unconstrained fn get_scheduled_note_at_the_time_scheduled_initialization_takes_effect() {
+    let env = TestEnvironment::_new();
+
+    let (_, _, initial_note, timestamp_of_change) = setup_schedule_initialization(env);
+
+    env.mine_block_at(timestamp_of_change);
+
+    // The context defaults to reading from the latest-mined block as the
+    // anchor block, so it will have an anchor timestamp of `timestamp_of_change`.
+    env.private_context(|context| {
+        // Double-check the test env works as expected:
+        assert_eq(context.get_anchor_timestamp(), timestamp_of_change);
+
+        let state_var = in_private(context);
+
+        let (scheduled_note, scheduled_ts) = state_var.get_scheduled_note();
+
+        assert_eq(scheduled_note, initial_note);
+        assert_eq(scheduled_ts, timestamp_of_change);
+
+        // When we call get_scheduled_note, the returned note is only valid for
+        // TEST_INITIAL_DELAY amount of time from the anchor timestamp.
+        // We check that the `include_by_timestamp` has been set accordingly.
+        let include_by_ts_after_get = context.include_by_timestamp;
+        let expected_include_by_ts_after_get = context.get_anchor_timestamp() + TEST_INITIAL_DELAY;
+
+        assert_eq(include_by_ts_after_get, expected_include_by_ts_after_get);
+
+        // The scheduled and current notes should align, now that the scheduled
+        // note has taken effect:
+        let current_note = state_var.get_current_note();
+        assert_eq(scheduled_note, current_note);
+    })
+}
+
+#[test]
+unconstrained fn get_current_note_after_scheduled_initialization_takes_effect() {
+    let env = TestEnvironment::_new();
+
+    let (_, _, initial_note, timestamp_of_change) = setup_schedule_initialization(env);
+
+    // + 7 is arbitrarily "some time after the expected timestamp of change".
+    env.mine_block_at(timestamp_of_change + 7);
+
+    // The context defaults to reading from the latest-mined block as the
+    // anchor block, so it will have an anchor timestamp of `timestamp_of_change + 7`.
+    env.private_context(|context| {
+        let state_var = in_private(context);
+        let current_note = state_var.get_current_note();
+
+        assert_eq(current_note, initial_note);
+    })
+}
+
+#[test]
+unconstrained fn get_scheduled_note_after_scheduled_initialization_takes_effect() {
+    let env = TestEnvironment::_new();
+
+    let (_, _, initial_note, timestamp_of_change) = setup_schedule_initialization(env);
+
+    // + 7 is arbitrarily "some time after the expected timestamp of change".
+    env.mine_block_at(timestamp_of_change + 7);
+
+    // The context defaults to reading from the latest-mined block as the
+    // anchor block, so it will have an anchor timestamp of `timestamp_of_change + 7`.
+    env.private_context(|context| {
+        let state_var = in_private(context);
+
+        let (scheduled_note, scheduled_ts) = state_var.get_scheduled_note();
+
+        assert_eq(scheduled_note, initial_note);
+        assert_eq(scheduled_ts, timestamp_of_change);
+
+        // When we call get_scheduled_note, the returned note is only valid for
+        // TEST_INITIAL_DELAY amount of time from the anchor timestamp.
+        // We check that the `include_by_timestamp` has been set accordingly.
+        let include_by_ts_after_get = context.include_by_timestamp;
+        let expected_include_by_ts_after_get = context.get_anchor_timestamp() + TEST_INITIAL_DELAY;
+
+        assert_eq(include_by_ts_after_get, expected_include_by_ts_after_get);
+
+        // The scheduled and current notes should align, now that the scheduled
+        // note has taken effect:
+        let current_note = state_var.get_current_note();
+        assert_eq(scheduled_note, current_note);
+    })
+}
+
+/*******************************************************************************
+ * SCHEDULE_REPLACEMENT
+ ******************************************************************************/
 
 #[test(should_fail_with = "Failed to get a note")]
 unconstrained fn replace_uninitialized() {
@@ -72,30 +489,43 @@ unconstrained fn replace_uninitialized() {
 }
 
 #[test]
-unconstrained fn schedule_initialization() {
+unconstrained fn schedule_replacement_before_initial_note_takes_effect() {
     let env = TestEnvironment::_new();
+
+    let (initial_wrapper_note, initial_wrapper_note_hash, _, initial_note_timestamp_of_change) =
+        setup_schedule_initialization(env);
+
+    // Arbitrary choice of 7 for "some time before the initial note takes effect"
+    env.mine_block_at(initial_note_timestamp_of_change - 7);
 
     env.private_context(|context| {
         let state_var = in_private(context);
 
-        let note = MockNote::new(INITIAL_VALUE).build_note();
+        let replacement_note = MockNote::new(REPLACEMENT_VALUE).build_note();
 
-        let emission = state_var.schedule_initialization(note);
+        let replacement_wrapper_note_emission = state_var.schedule_replacement(replacement_note);
 
-        // During initialization we both create the new note and emit the initialization nullifier
+        // During replacement, we nullify the initial note, and emit the replacement note.
         assert_eq(context.note_hashes.len(), 1);
         assert_eq(context.nullifiers.len(), 1);
-        assert_eq(context.nullifiers.get(0).value, state_var.compute_initialization_nullifier());
+        let expected_nullifier =
+            initial_wrapper_note.compute_nullifier(context, initial_wrapper_note_hash);
 
-        let wrapper_note = emission.note;
+        assert_eq(context.nullifiers.get(0).value, expected_nullifier);
+
+        let wrapper_note = replacement_wrapper_note_emission.note;
 
         let svc = wrapper_note.delayed_mutable_values.svc;
-        let pre = svc.get_pre();
-        let post = svc.get_post();
+        let pre_note = svc.get_pre();
+        let post_note = svc.get_post();
         let ts = svc.get_timestamp_of_change();
 
-        assert_eq(pre, MockNote::empty());
-        assert_eq(post, note);
+        // The `initial_note` will now never take effect, because we over-wrote
+        // it with the `replacement_note` _before_ we reached the former's
+        // timestamp_of_change. We effectively cancelled the `initial_note`'s
+        // scheduling altogether.
+        assert_eq(pre_note, MockNote::empty()); // <-- _not_ the initial_note.
+        assert_eq(post_note, replacement_note);
 
         let expected_ts = context.include_by_timestamp + TEST_INITIAL_DELAY;
         assert_eq(ts, expected_ts);
@@ -103,110 +533,395 @@ unconstrained fn schedule_initialization() {
         let sdc = wrapper_note.delayed_mutable_values.sdc;
         assert_eq(sdc, ScheduledDelayChange::<TEST_INITIAL_DELAY>::empty());
 
-        assert_eq(emission.storage_slot, STORAGE_SLOT);
+        assert_eq(replacement_wrapper_note_emission.storage_slot, STORAGE_SLOT);
     });
 }
 
 #[test]
-unconstrained fn get_current_note_before_scheduled_initialization_takes_effect() {
+unconstrained fn schedule_replacement_after_initial_note_takes_effect() {
     let env = TestEnvironment::_new();
+
+    let (initial_wrapper_note, initial_wrapper_note_hash, initial_note, initial_note_timestamp_of_change) =
+        setup_schedule_initialization(env);
+
+    // + 7 is arbitrarily "some time after the initial note's timestamp of change".
+    env.mine_block_at(initial_note_timestamp_of_change + 7);
 
     env.private_context(|context| {
         let state_var = in_private(context);
 
-        let note = MockNote::new(INITIAL_VALUE).build_note();
+        let replacement_note = MockNote::new(REPLACEMENT_VALUE).build_note();
 
-        let _ = state_var.schedule_initialization(note);
+        let replacement_wrapper_note_emission = state_var.schedule_replacement(replacement_note);
+
+        // During replacement, we nullify the initial note, and emit the replacement note.
+        assert_eq(context.note_hashes.len(), 1);
+        assert_eq(context.nullifiers.len(), 1);
+        let expected_nullifier =
+            initial_wrapper_note.compute_nullifier(context, initial_wrapper_note_hash);
+
+        assert_eq(context.nullifiers.get(0).value, expected_nullifier);
+
+        let replacement_wrapper_note = replacement_wrapper_note_emission.note;
+        let svc = replacement_wrapper_note.delayed_mutable_values.svc;
+        let pre_note = svc.get_pre();
+        let post_note = svc.get_post();
+        let ts = svc.get_timestamp_of_change();
+
+        assert_eq(pre_note, initial_note);
+        assert_eq(post_note, replacement_note);
+
+        let expected_ts = context.include_by_timestamp + TEST_INITIAL_DELAY;
+        assert_eq(ts, expected_ts);
+
+        let sdc = replacement_wrapper_note.delayed_mutable_values.sdc;
+        assert_eq(sdc, ScheduledDelayChange::<TEST_INITIAL_DELAY>::empty());
+
+        assert_eq(replacement_wrapper_note_emission.storage_slot, STORAGE_SLOT);
+    });
+}
+
+#[test]
+unconstrained fn get_current_note_immediately_after_scheduling_replacement() {
+    let env = TestEnvironment::_new();
+
+    let (_, _, initial_note, initial_note_timestamp_of_change) = setup_schedule_initialization(env);
+
+    // 1000 is arbitrary
+    env.mine_block_at(initial_note_timestamp_of_change + 1000);
+
+    env.private_context(|context| {
+        let state_var = in_private(context);
+
+        let replacement_note = MockNote::new(REPLACEMENT_VALUE).build_note();
+
+        let _ = state_var.schedule_replacement(replacement_note);
 
         let current_note = state_var.get_current_note();
 
-        assert_eq(current_note, MockNote::empty());
+        // The `replacement_note` does not take effect until after a delay (see later tests).
+        assert_eq(current_note, initial_note);
+
+        // When we call get_current_note, the returned note is only valid for
+        // the min of:
+        // - TEST_INITIAL_DELAY amount of time from the anchor timestamp.
+        // - 1 second before the `timestamp_of_change` of the delayed_private_mutable_note.
+        // We check that the `include_by_timestamp` has been set accordingly.
+        // In the case of this test, since we're reading immediately after
+        // setting the note, the case "TEST_INITIAL_DELAY amount of time from
+        // the anchor timestamp" will bite.
+        let include_by_ts_after_get = context.include_by_timestamp;
+
+        let expected_include_by_ts_after_get = context.get_anchor_timestamp() + TEST_INITIAL_DELAY;
+
+        assert_eq(include_by_ts_after_get, expected_include_by_ts_after_get)
     });
 }
 
 #[test]
-unconstrained fn get_scheduled_note_before_scheduled_initialization_takes_effect() {
+unconstrained fn get_scheduled_note_immediately_after_scheduling_replacement() {
     let env = TestEnvironment::_new();
+
+    let (_, _, _, initial_note_timestamp_of_change) = setup_schedule_initialization(env);
+
+    // 1000 is arbitrary
+    env.mine_block_at(initial_note_timestamp_of_change + 1000);
 
     env.private_context(|context| {
         let state_var = in_private(context);
 
-        let note = MockNote::new(INITIAL_VALUE).build_note();
+        let replacement_note = MockNote::new(REPLACEMENT_VALUE).build_note();
 
-        let _ = state_var.schedule_initialization(note);
+        // We don't use the setup_initialization_then_replacement helper function here, because that
+        // function calls `get_scheduled_note` immediately -- which is the very thing we
+        // want to test in this test!
+        let _ = state_var.schedule_replacement(replacement_note);
 
         // Note: we have to compute the expected_ts _before_ we get_scheduled_note, because the
         // act of getting the scheduled note will mutate the `context.include_by_timestamp`.
-        let expected_ts = context.include_by_timestamp + TEST_INITIAL_DELAY;
+        // Another interesting point: a timestamp_of_change might get baked into
+        // a note, and then some time later in the same tx, a lower
+        // include_by_timestamp might get set. That's ok -- it just means the
+        // timestamp_of_change could technically have been earlier than was
+        // baked-in.
+        let expected_scheduled_ts = context.include_by_timestamp + TEST_INITIAL_DELAY;
 
-        // When we perform a read at this moment in time, it is only valid for
-        // TEST_INITIAL_DELAY amount of time from the anchor timestamp.
         let (scheduled_note, scheduled_ts) = state_var.get_scheduled_note();
-        let include_by_ts_after = context.include_by_timestamp;
 
-        let anchor_ts = context.get_anchor_timestamp();
-        let expected_include_by_ts_after = anchor_ts + TEST_INITIAL_DELAY;
+        assert_eq(scheduled_note, replacement_note);
+        assert_eq(scheduled_ts, expected_scheduled_ts);
 
-        assert_eq(note, scheduled_note);
-        assert_eq(scheduled_ts, expected_ts);
-        assert_eq(include_by_ts_after, expected_include_by_ts_after)
+        // When we call get_scheduled_note, the returned note is only valid for
+        // TEST_INITIAL_DELAY amount of time from the anchor timestamp.
+        // We check that the `include_by_timestamp` has been set accordingly.
+        let include_by_ts_after_get = context.include_by_timestamp;
+
+        let expected_include_by_ts_after_get = context.get_anchor_timestamp() + TEST_INITIAL_DELAY;
+
+        assert_eq(include_by_ts_after_get, expected_include_by_ts_after_get)
     });
 }
 
 #[test]
-unconstrained fn get_current_note_at_the_time_scheduled_initialization_takes_effect() {
+unconstrained fn get_current_note_just_before_scheduled_replacement_takes_effect() {
     let env = TestEnvironment::_new();
 
-    let (scheduled_note, timestamp_of_change) = env.private_context(|context| {
-        let state_var = in_private(context);
+    let (initial_note, _, _, _, timestamp_of_change) = setup_initialization_then_replacement(env);
 
-        let note = MockNote::new(INITIAL_VALUE).build_note();
+    // env.discover_note(wrapper_note_emission);
 
-        let _ = state_var.schedule_initialization(note);
+    // Just before scheduled initialization takes effect:
+    env.mine_block_at(timestamp_of_change - 1);
 
-        state_var.get_scheduled_note()
-    });
-
-    env.set_next_block_timestamp(timestamp_of_change);
-
-    // TODO: we need note discovery for this to work.
+    // The context defaults to reading from the latest-mined block as the
+    // anchor block.
     env.private_context(|context| {
         let state_var = in_private(context);
+
         let current_note = state_var.get_current_note();
-        assert_eq(current_note, scheduled_note);
+
+        // The `replacement_note` does not take effect until after a delay (see later tests).
+        assert_eq(current_note, initial_note);
+
+        // When we call get_current_note, the returned note is only valid for
+        // the min of:
+        // - TEST_INITIAL_DELAY amount of time from the anchor timestamp.
+        // - 1 second before the `timestamp_of_change` of the delayed_private_mutable_note.
+        // We check that the `include_by_timestamp` has been set accordingly.
+        // In the case of this test, the anchor block is only 1 second before
+        // the timestamp_of_change, so we'll have 0 seconds until the tx expires.
+        // This is clearly not a realistic or valid tx.
+        let include_by_ts_after_get = context.include_by_timestamp;
+        let expected_include_by_ts_after_get = timestamp_of_change - 1;
+
+        assert_eq(include_by_ts_after_get, expected_include_by_ts_after_get);
     })
 }
 
 #[test]
-unconstrained fn get_scheduled_note_at_the_time_scheduled_initialization_takes_effect() {
+unconstrained fn get_scheduled_note_just_before_scheduled_replacement_takes_effect() {
+    let mut env = TestEnvironment::_new();
+
+    let (_, _, _, replacement_note, timestamp_of_change) =
+        setup_initialization_then_replacement(env);
+
+    env.mine_block_at(timestamp_of_change - 1);
+
+    // The context defaults to reading from the latest-mined block as the
+    // anchor block.
+    env.private_context(|context| {
+        let state_var = in_private(context);
+
+        let (scheduled_note, scheduled_ts) = state_var.get_scheduled_note();
+
+        assert_eq(scheduled_note, replacement_note);
+        assert_eq(scheduled_ts, timestamp_of_change);
+
+        // When we call get_scheduled_note, the returned note is only valid for
+        // the min of:
+        // - TEST_INITIAL_DELAY amount of time from the anchor timestamp.
+        // - 1 second before the `timestamp_of_change` of the delayed_private_mutable_note.
+        // We check that the `include_by_timestamp` has been set accordingly.
+        // In the case of this test, the anchor block is only 1 second before
+        // the timestamp_of_change, so we'll have 0 seconds until the tx expires.
+        // This is clearly not a realistic or valid tx.
+        let include_by_ts_after_get = context.include_by_timestamp;
+        let expected_include_by_ts_after_get = timestamp_of_change - 1;
+
+        assert_eq(include_by_ts_after_get, expected_include_by_ts_after_get);
+    })
+}
+
+#[test]
+unconstrained fn get_current_note_at_the_time_scheduled_replacement_takes_effect() {
+    let env = TestEnvironment::_new();
+
+    let (_, _, _, replacement_note, timestamp_of_change) =
+        setup_initialization_then_replacement(env);
+
+    env.mine_block_at(timestamp_of_change);
+
+    // The context defaults to reading from the latest-mined block as the
+    // anchor block, so it will have an anchor timestamp of `timestamp_of_change`.
+    env.private_context(|context| {
+        let state_var = in_private(context);
+        let current_note = state_var.get_current_note();
+
+        assert_eq(current_note, replacement_note);
+    })
+}
+
+#[test]
+unconstrained fn get_scheduled_note_at_the_time_scheduled_replacement_takes_effect() {
+    let env = TestEnvironment::_new();
+
+    let (_, _, _, replacement_note, timestamp_of_change) =
+        setup_initialization_then_replacement(env);
+
+    env.mine_block_at(timestamp_of_change);
+
+    // The context defaults to reading from the latest-mined block as the
+    // anchor block, so it will have an anchor timestamp of `timestamp_of_change`.
+    env.private_context(|context| {
+        // Double-check the test env works as expected:
+        assert_eq(context.get_anchor_timestamp(), timestamp_of_change);
+
+        let state_var = in_private(context);
+
+        let (scheduled_note, scheduled_ts) = state_var.get_scheduled_note();
+
+        assert_eq(scheduled_note, replacement_note);
+        assert_eq(scheduled_ts, timestamp_of_change);
+
+        // When we call get_scheduled_note, the returned note is only valid for
+        // TEST_INITIAL_DELAY amount of time from the anchor timestamp.
+        // We check that the `include_by_timestamp` has been set accordingly.
+        let include_by_ts_after_get = context.include_by_timestamp;
+        let expected_include_by_ts_after_get = context.get_anchor_timestamp() + TEST_INITIAL_DELAY;
+
+        assert_eq(include_by_ts_after_get, expected_include_by_ts_after_get);
+
+        // The scheduled and current notes should align, now that the scheduled
+        // note has taken effect:
+        let current_note = state_var.get_current_note();
+        assert_eq(scheduled_note, current_note);
+    })
+}
+
+#[test]
+unconstrained fn get_current_note_after_scheduled_replacement_takes_effect() {
+    let env = TestEnvironment::_new();
+
+    let (_, _, _, replacement_note, timestamp_of_change) =
+        setup_initialization_then_replacement(env);
+
+    // + 7 is arbitrarily "some time after the expected timestamp of change".
+    env.mine_block_at(timestamp_of_change + 7);
+
+    // The context defaults to reading from the latest-mined block as the
+    // anchor block, so it will have an anchor timestamp of `timestamp_of_change + 7`.
+    env.private_context(|context| {
+        let state_var = in_private(context);
+        let current_note = state_var.get_current_note();
+
+        assert_eq(current_note, replacement_note);
+    })
+}
+
+#[test]
+unconstrained fn get_scheduled_note_after_scheduled_replacement_takes_effect() {
+    let env = TestEnvironment::_new();
+
+    let (_, _, _, replacement_note, timestamp_of_change) =
+        setup_initialization_then_replacement(env);
+
+    // + 7 is arbitrarily "some time after the expected timestamp of change".
+    env.mine_block_at(timestamp_of_change + 7);
+
+    // The context defaults to reading from the latest-mined block as the
+    // anchor block, so it will have an anchor timestamp of `timestamp_of_change + 7`.
+    env.private_context(|context| {
+        let state_var = in_private(context);
+
+        let (scheduled_note, scheduled_ts) = state_var.get_scheduled_note();
+
+        assert_eq(scheduled_note, replacement_note);
+        assert_eq(scheduled_ts, timestamp_of_change);
+
+        // When we call get_scheduled_note, the returned note is only valid for
+        // TEST_INITIAL_DELAY amount of time from the anchor timestamp.
+        // We check that the `include_by_timestamp` has been set accordingly.
+        let include_by_ts_after_get = context.include_by_timestamp;
+        let expected_include_by_ts_after_get = context.get_anchor_timestamp() + TEST_INITIAL_DELAY;
+
+        assert_eq(include_by_ts_after_get, expected_include_by_ts_after_get);
+
+        // The scheduled and current notes should align, now that the scheduled
+        // note has taken effect:
+        let current_note = state_var.get_current_note();
+        assert_eq(scheduled_note, current_note);
+    })
+}
+
+/*******************************************************************************
+ * UTILITY
+ ******************************************************************************/
+
+#[test(should_fail_with = "Attempted to read past end of BoundedVec")]
+unconstrained fn view_current_note_uninitialized() {
+    let env = TestEnvironment::_new();
+
+    env.utility_context(|context| {
+        let state_var = in_utility(context);
+        assert_eq(state_var.view_current_note(), zeroed());
+    });
+}
+
+#[test]
+unconstrained fn view_current_note_just_before_scheduled_change() {
+    let env = TestEnvironment::_new();
+
+    let (_, _, _, timestamp_of_change) = setup_schedule_initialization(env);
+
+    env.mine_block_at(timestamp_of_change - 1);
+
+    env.utility_context(|context| {
+        // Make sure we're at a block with the expected timestamp
+        assert_eq(context.timestamp(), timestamp_of_change - 1);
+
+        let state_var = in_utility(context);
+        assert_eq(state_var.view_current_note(), zeroed());
+    });
+}
+
+#[test]
+unconstrained fn view_current_note_at_scheduled_change() {
+    let env = TestEnvironment::_new();
+
+    let (_, _, initial_note, timestamp_of_change) = setup_schedule_initialization(env);
+
+    env.set_next_block_timestamp(timestamp_of_change);
+
+    env.utility_context(|context| {
+        // Make sure we're at a block with the expected timestamp
+        assert_eq(context.timestamp(), timestamp_of_change);
+
+        let state_var = in_utility(context);
+        assert_eq(state_var.view_current_note(), initial_note);
+    });
+}
+
+#[test]
+unconstrained fn view_current_note_after_scheduled_change() {
+    let env = TestEnvironment::_new();
+
+    let (_, _, initial_note, timestamp_of_change) = setup_schedule_initialization(env);
+
+    env.set_next_block_timestamp(timestamp_of_change + 10);
+
+    env.utility_context(|context| {
+        // Make sure we're at a block with the expected timestamp
+        assert_eq(context.timestamp(), timestamp_of_change + 10);
+
+        let state_var = in_utility(context);
+        assert_eq(state_var.view_current_note(), initial_note);
+    });
+}
+
+/*******************************************************************************
+ * DELAY
+ ******************************************************************************/
+
+#[test(should_fail_with = "Failed to get a note")]
+unconstrained fn schedule_delay_change_uninitialized() {
     let env = TestEnvironment::_new();
 
     env.private_context(|context| {
         let state_var = in_private(context);
 
-        let note = MockNote::new(INITIAL_VALUE).build_note();
-
-        let _ = state_var.schedule_initialization(note);
-
-        // Note: we have to compute the expected_ts _before_ we get_scheduled_note, because the
-        // act of getting the scheduled note will mutate the `context.include_by_timestamp`.
-        let expected_ts = context.include_by_timestamp + TEST_INITIAL_DELAY;
-
-        // When we perform a read at this moment in time, it is only valid for
-        // TEST_INITIAL_DELAY amount of time from the anchor timestamp.
-        let (scheduled_note, scheduled_ts) = state_var.get_scheduled_note();
-        let include_by_ts_after = context.include_by_timestamp;
-
-        let anchor_ts = context.get_anchor_timestamp();
-        let expected_include_by_ts_after = anchor_ts + TEST_INITIAL_DELAY;
-
-        assert_eq(note, scheduled_note);
-        assert_eq(scheduled_ts, expected_ts);
-        assert_eq(include_by_ts_after, expected_include_by_ts_after)
+        let _ = state_var.schedule_delay_change(LONGER_DELAY);
     });
 }
-
-// DELAY
 
 #[test]
 unconstrained fn get_current_delay_before_scheduled_initialization_takes_effect() {
@@ -221,6 +936,653 @@ unconstrained fn get_current_delay_before_scheduled_initialization_takes_effect(
 
         let current_delay = state_var.get_current_delay();
 
-        assert_eq(TEST_INITIAL_DELAY, current_delay);
+        assert_eq(current_delay, TEST_INITIAL_DELAY);
     });
 }
+
+#[test]
+unconstrained fn schedule_delay_increase_before_initial_note_takes_effect() {
+    let env = TestEnvironment::_new();
+
+    let (initial_wrapper_note, initial_wrapper_note_hash, initial_note, initial_note_timestamp_of_change) =
+        setup_schedule_initialization(env);
+
+    // Initialization note takes effect in 100s (from the include_by_timestamp).
+
+    // Line-up a _longer_ delay change at 90s (10s before).
+
+    // The initialization note should still take effect at 100s.
+
+    // The delay change should happen immediately, because it's an increase.
+
+    // Arbitrary choice of 10 for "some time before the initial note takes effect"
+    env.mine_block_at(initial_note_timestamp_of_change - 10);
+
+    let delay_change_wrapper_note_emission = env.private_context(|context| {
+        let state_var = in_private(context);
+
+        let delay_change_wrapper_note_emission = state_var.schedule_delay_change(LONGER_DELAY);
+
+        // During replacement, we nullify the initial note, and emit the replacement note.
+        assert_eq(context.note_hashes.len(), 1);
+        assert_eq(context.nullifiers.len(), 1);
+        let expected_nullifier =
+            initial_wrapper_note.compute_nullifier(context, initial_wrapper_note_hash);
+
+        assert_eq(context.nullifiers.get(0).value, expected_nullifier);
+
+        let delay_change_wrapper_note = delay_change_wrapper_note_emission.note;
+
+        let svc = delay_change_wrapper_note.delayed_mutable_values.svc;
+        let pre_note = svc.get_pre();
+        let post_note = svc.get_post();
+        let note_ts = svc.get_timestamp_of_change();
+
+        // We should inherit the svc of the initial wrapper note.
+        assert_eq(svc, initial_wrapper_note.delayed_mutable_values.svc);
+        assert_eq(pre_note, MockNote::empty());
+        assert_eq(post_note, initial_note);
+        assert_eq(note_ts, initial_note_timestamp_of_change);
+
+        let sdc = delay_change_wrapper_note.delayed_mutable_values.sdc;
+        let pre_delay = sdc.get_pre();
+        let post_delay = sdc.get_post();
+        let delay_ts = sdc.get_timestamp_of_change();
+
+        assert_eq(pre_delay.unwrap(), TEST_INITIAL_DELAY);
+        assert_eq(post_delay.unwrap(), LONGER_DELAY);
+        // The delay should take effect immediately, because it's a longer delay.
+        let expected_delay_ts = context.include_by_timestamp;
+        assert_eq(delay_ts, expected_delay_ts);
+
+        assert_eq(delay_change_wrapper_note_emission.storage_slot, STORAGE_SLOT);
+
+        delay_change_wrapper_note_emission
+    });
+
+    env.discover_note(delay_change_wrapper_note_emission);
+
+    // Double-check we didn't break the initially-scheduled note change from
+    // taking effect:
+    env.mine_block_at(initial_note_timestamp_of_change);
+
+    env.private_context(|context| {
+        let state_var = in_private(context);
+
+        let current_note = state_var.get_current_note();
+
+        assert_eq(current_note, initial_note);
+    });
+}
+
+#[test]
+unconstrained fn schedule_delay_increase_after_initial_note_takes_effect() {
+    let env = TestEnvironment::_new();
+
+    let (initial_wrapper_note, initial_wrapper_note_hash, initial_note, initial_note_timestamp_of_change) =
+        setup_schedule_initialization(env);
+
+    // Initialization note takes effect in 100s (from the include_by_timestamp).
+
+    // Line-up a _longer_ delay change at 110s (10s after).
+
+    // The delay change should happen immediately, because it's an increase.
+
+    // Arbitrary choice of 10 for "some time after the initial note takes effect"
+    env.mine_block_at(initial_note_timestamp_of_change + 10);
+
+    env.private_context(|context| {
+        let state_var = in_private(context);
+
+        let delay_change_wrapper_note_emission = state_var.schedule_delay_change(LONGER_DELAY);
+
+        // During replacement, we nullify the initial note, and emit the replacement note.
+        assert_eq(context.note_hashes.len(), 1);
+        assert_eq(context.nullifiers.len(), 1);
+        let expected_nullifier =
+            initial_wrapper_note.compute_nullifier(context, initial_wrapper_note_hash);
+
+        assert_eq(context.nullifiers.get(0).value, expected_nullifier);
+
+        let delay_change_wrapper_note = delay_change_wrapper_note_emission.note;
+
+        let svc = delay_change_wrapper_note.delayed_mutable_values.svc;
+        let pre_note = svc.get_pre();
+        let post_note = svc.get_post();
+        let note_ts = svc.get_timestamp_of_change();
+
+        // We should inherit the svc of the initial wrapper note.
+        assert_eq(svc, initial_wrapper_note.delayed_mutable_values.svc);
+        assert_eq(pre_note, MockNote::empty());
+        assert_eq(post_note, initial_note);
+        assert_eq(note_ts, initial_note_timestamp_of_change);
+
+        let sdc = delay_change_wrapper_note.delayed_mutable_values.sdc;
+        let pre_delay = sdc.get_pre();
+        let post_delay = sdc.get_post();
+        let delay_ts = sdc.get_timestamp_of_change();
+
+        assert_eq(pre_delay.unwrap(), TEST_INITIAL_DELAY);
+        assert_eq(post_delay.unwrap(), LONGER_DELAY);
+        // The delay should take effect immediately, because it's a longer delay.
+        let expected_delay_ts = context.include_by_timestamp;
+        assert_eq(delay_ts, expected_delay_ts);
+
+        assert_eq(delay_change_wrapper_note_emission.storage_slot, STORAGE_SLOT);
+    });
+}
+
+#[test]
+unconstrained fn schedule_delay_decrease_before_initial_note_takes_effect() {
+    let env = TestEnvironment::_new();
+
+    let (initial_wrapper_note, _, initial_note, initial_note_timestamp_of_change) =
+        setup_schedule_initialization(env);
+
+    // Initialization note takes effect in 100s (from the include_by_timestamp).
+
+    // Line-up a _shorter_ delay change at 90s (10s before)
+    // (the delay will change from 100 -> 75)
+
+    // The initialization note should still take effect at 100s.
+
+    // The delay change timestamp of change should be 100 - 75 = 25s from the
+    // include-by timestamp of the delay change tx.
+
+    // Arbitrary choice of 10 for "some time before the initial note takes effect"
+    env.mine_block_at(initial_note_timestamp_of_change - 10);
+
+    let delay_change_wrapper_note_emission = env.private_context(|context| {
+        let state_var = in_private(context);
+
+        let delay_change_wrapper_note_emission = state_var.schedule_delay_change(SHORTER_DELAY);
+
+        let delay_change_wrapper_note = delay_change_wrapper_note_emission.note;
+
+        let svc = delay_change_wrapper_note.delayed_mutable_values.svc;
+        let pre_note = svc.get_pre();
+        let post_note = svc.get_post();
+        let note_ts = svc.get_timestamp_of_change();
+
+        // We should inherit the svc of the initial wrapper note.
+        assert_eq(svc, initial_wrapper_note.delayed_mutable_values.svc);
+        assert_eq(pre_note, MockNote::empty());
+        assert_eq(post_note, initial_note);
+        assert_eq(note_ts, initial_note_timestamp_of_change);
+
+        let sdc = delay_change_wrapper_note.delayed_mutable_values.sdc;
+        let pre_delay = sdc.get_pre();
+        let post_delay = sdc.get_post();
+        let delay_ts = sdc.get_timestamp_of_change();
+
+        assert_eq(pre_delay.unwrap(), TEST_INITIAL_DELAY);
+        assert_eq(post_delay.unwrap(), SHORTER_DELAY);
+        // Since a shorter delay has been set, it will take some time to take effect:
+        let expected_delay_ts =
+            context.include_by_timestamp + (TEST_INITIAL_DELAY - SHORTER_DELAY);
+        assert_eq(delay_ts, expected_delay_ts);
+
+        delay_change_wrapper_note_emission
+    });
+
+    env.discover_note(delay_change_wrapper_note_emission);
+
+    // Double-check we didn't break the initially-scheduled note change from
+    // taking effect:
+    env.mine_block_at(initial_note_timestamp_of_change);
+
+    env.private_context(|context| {
+        let state_var = in_private(context);
+
+        let current_note = state_var.get_current_note();
+
+        assert_eq(current_note, initial_note);
+    });
+}
+
+#[test]
+unconstrained fn schedule_delay_decrease_after_initial_note_takes_effect() {
+    let env = TestEnvironment::_new();
+
+    let (initial_wrapper_note, initial_wrapper_note_hash, initial_note, initial_note_timestamp_of_change) =
+        setup_schedule_initialization(env);
+
+    // Initialization note takes effect in 100s (from the include_by_timestamp).
+
+    // Line-up a _shorter_ delay change at 110s (10s after).
+
+    // The delay change timestamp of change should be 100 - 75 = 25s from the
+    // include-by timestamp of the delay change tx.
+
+    // Arbitrary choice of 10 for "some time after the initial note takes effect"
+    env.mine_block_at(initial_note_timestamp_of_change + 10);
+
+    env.private_context(|context| {
+        let state_var = in_private(context);
+
+        let delay_change_wrapper_note_emission = state_var.schedule_delay_change(SHORTER_DELAY);
+
+        // During replacement, we nullify the initial note, and emit the replacement note.
+        assert_eq(context.note_hashes.len(), 1);
+        assert_eq(context.nullifiers.len(), 1);
+        let expected_nullifier =
+            initial_wrapper_note.compute_nullifier(context, initial_wrapper_note_hash);
+
+        assert_eq(context.nullifiers.get(0).value, expected_nullifier);
+
+        let delay_change_wrapper_note = delay_change_wrapper_note_emission.note;
+
+        let svc = delay_change_wrapper_note.delayed_mutable_values.svc;
+        let pre_note = svc.get_pre();
+        let post_note = svc.get_post();
+        let note_ts = svc.get_timestamp_of_change();
+
+        // We should inherit the svc of the initial wrapper note.
+        assert_eq(svc, initial_wrapper_note.delayed_mutable_values.svc);
+        assert_eq(pre_note, MockNote::empty());
+        assert_eq(post_note, initial_note);
+        assert_eq(note_ts, initial_note_timestamp_of_change);
+
+        let sdc = delay_change_wrapper_note.delayed_mutable_values.sdc;
+        let pre_delay = sdc.get_pre();
+        let post_delay = sdc.get_post();
+        let delay_ts = sdc.get_timestamp_of_change();
+
+        assert_eq(pre_delay.unwrap(), TEST_INITIAL_DELAY);
+        assert_eq(post_delay.unwrap(), SHORTER_DELAY);
+        // Since a shorter delay has been set, it will take some time to take effect:
+        let expected_delay_ts =
+            context.include_by_timestamp + (TEST_INITIAL_DELAY - SHORTER_DELAY);
+        assert_eq(delay_ts, expected_delay_ts);
+    });
+}
+
+#[test]
+unconstrained fn schedule_delay_decrease_but_then_schedule_value_change_before_the_former_takes_effect() {
+    let env = TestEnvironment::_new();
+
+    let (initial_wrapper_note, _, initial_note, initial_note_timestamp_of_change) =
+        setup_schedule_initialization(env);
+
+    println(
+        f"initial_note_timestamp_of_change: {initial_note_timestamp_of_change}",
+    );
+
+    // Line-up a _shorter_ delay change.
+
+    // Before that delay takes effect, line up a note change.
+
+    // Arbitrary choice of 10 for "some time after the initial note takes effect"
+    env.mine_block_at(initial_note_timestamp_of_change + 10);
+
+    let (delay_change_wrapper_note_emission, delay_change_wrapper_note, delay_ts) = env
+        .private_context(|context| {
+            let state_var = in_private(context);
+
+            let delay_change_wrapper_note_emission = state_var.schedule_delay_change(SHORTER_DELAY);
+
+            let delay_change_wrapper_note = delay_change_wrapper_note_emission.note;
+
+            let svc = delay_change_wrapper_note.delayed_mutable_values.svc;
+            let pre_note = svc.get_pre();
+            let post_note = svc.get_post();
+            let note_ts = svc.get_timestamp_of_change();
+
+            // We should inherit the svc of the initial wrapper note.
+            assert_eq(svc, initial_wrapper_note.delayed_mutable_values.svc);
+            assert_eq(pre_note, MockNote::empty());
+            assert_eq(post_note, initial_note);
+            assert_eq(note_ts, initial_note_timestamp_of_change);
+
+            let sdc = delay_change_wrapper_note.delayed_mutable_values.sdc;
+            let pre_delay = sdc.get_pre();
+            let post_delay = sdc.get_post();
+            let delay_ts = sdc.get_timestamp_of_change();
+
+            assert_eq(pre_delay.unwrap(), TEST_INITIAL_DELAY);
+            assert_eq(post_delay.unwrap(), SHORTER_DELAY);
+            // Since a shorter delay has been set, it will take some time to take effect:
+            let expected_delay_ts =
+                context.include_by_timestamp + (TEST_INITIAL_DELAY - SHORTER_DELAY);
+            assert_eq(delay_ts, expected_delay_ts);
+
+            (delay_change_wrapper_note_emission, delay_change_wrapper_note, delay_ts)
+        });
+
+    env.discover_note(delay_change_wrapper_note_emission);
+
+    // Jump to a time before the new delay takes effect:
+    let time_until_delay_change = 10; // 10 is arbitrary
+    env.mine_block_at(delay_ts - time_until_delay_change);
+
+    env.private_context(|context| {
+        let state_var = in_private(context);
+
+        let replacement_note = MockNote::new(REPLACEMENT_VALUE).build_note();
+
+        let replacement_wrapper_note_emission = state_var.schedule_replacement(replacement_note);
+
+        let replacement_wrapper_note = replacement_wrapper_note_emission.note;
+
+        let svc = replacement_wrapper_note.delayed_mutable_values.svc;
+        let pre_note = svc.get_pre();
+        let post_note = svc.get_post();
+        let note_ts = svc.get_timestamp_of_change();
+
+        assert_eq(pre_note, initial_note);
+        assert_eq(post_note, replacement_note);
+
+        // The rules for reading before a delay timestamp_of_change are a bit complex.
+        // It's the min of:
+        // - time until delay change + post_delay - 1
+        // - pre delay
+        // Since we shortened the delay, the first one will bite, because
+        // when shortening, time_until_delay_change is initially set to
+        // pre_delay - post_delay seconds in the future. We're further into the
+        // future now, so there's less time until the delay change.
+        // The time until the delay change must be relative to the `include_by_timestamp`,
+        // just in case the tx is included at the very last valid moment; we
+        // still need to give users sufficient delay time.
+        let expected_note_ts =
+            context.include_by_timestamp + time_until_delay_change + SHORTER_DELAY - 1;
+        assert_eq(note_ts, expected_note_ts);
+
+        let sdc = replacement_wrapper_note.delayed_mutable_values.sdc;
+        // We should inherit the sdc of the delay change wrapper note.
+        assert_eq(sdc, delay_change_wrapper_note.delayed_mutable_values.sdc);
+    });
+}
+
+// Note: We can't create a test (similar to the one directly above ^^^) to
+// schedule a delay INCREASE and then schedule a note change before the former
+// takes effect, because a scheduled delay INCREASE takes effect immediately.
+
+#[test]
+unconstrained fn get_current_delay_immediately_after_scheduling_delay_change() {
+    let env = TestEnvironment::_new();
+
+    let (_, _, _, initial_note_timestamp_of_change) = setup_schedule_initialization(env);
+
+    // 1000 is arbitrary
+    env.mine_block_at(initial_note_timestamp_of_change + 1000);
+
+    env.private_context(|context| {
+        let state_var = in_private(context);
+
+        let _ = state_var.schedule_delay_change(LONGER_DELAY);
+
+        let current_delay = state_var.get_current_delay();
+
+        // The delay_change does not take effect until after a delay (see later tests).
+        assert_eq(current_delay, TEST_INITIAL_DELAY);
+
+        // When we call get_current_delay, the returned delay is only valid for
+        // the min of:
+        // - TEST_INITIAL_DELAY amount of time from the anchor timestamp.
+        // - 1 second before the `timestamp_of_change` of the delay.
+        // We check that the `include_by_timestamp` has been set accordingly.
+        // In the case of this test, since we're reading immediately after
+        // setting the note, the case "TEST_INITIAL_DELAY amount of time from
+        // the anchor timestamp" will bite.
+        let include_by_ts_after_get = context.include_by_timestamp;
+
+        let expected_include_by_ts_after_get = context.get_anchor_timestamp() + TEST_INITIAL_DELAY;
+
+        assert_eq(include_by_ts_after_get, expected_include_by_ts_after_get)
+    });
+}
+
+#[test]
+unconstrained fn get_scheduled_delay_immediately_after_scheduling_delay_increase() {
+    let env = TestEnvironment::_new();
+
+    let (_, _, _, initial_note_timestamp_of_change) = setup_schedule_initialization(env);
+
+    // 1000 is arbitrary
+    env.mine_block_at(initial_note_timestamp_of_change + 1000);
+
+    env.private_context(|context| {
+        let state_var = in_private(context);
+
+        // We don't use the setup_initialization_then_delay_change helper function here, because that
+        // function calls `get_scheduled_delay` immediately -- which is the very thing we
+        // want to test in this test!
+        let _ = state_var.schedule_delay_change(LONGER_DELAY);
+
+        // Note: we have to compute the expected_ts _before_ we get_scheduled_note, because the
+        // act of getting the scheduled note will mutate the `context.include_by_timestamp`.
+        // Since we're INCREASING the delay, the change can happen asap, which is
+        // the latest time of inclusion of the tx.
+        let expected_scheduled_ts = context.include_by_timestamp;
+
+        let (scheduled_delay, scheduled_ts) = state_var.get_scheduled_delay();
+
+        assert_eq(scheduled_delay, LONGER_DELAY);
+        assert_eq(scheduled_ts, expected_scheduled_ts);
+
+        // When we call get_scheduled_delay, the returned data is only valid for
+        // TEST_INITIAL_DELAY amount of time from the anchor timestamp.
+        // We check that the `include_by_timestamp` has been set accordingly.
+        let include_by_ts_after_get = context.include_by_timestamp;
+
+        let expected_include_by_ts_after_get = context.get_anchor_timestamp() + TEST_INITIAL_DELAY;
+
+        assert_eq(include_by_ts_after_get, expected_include_by_ts_after_get)
+    });
+}
+
+#[test]
+unconstrained fn get_scheduled_delay_immediately_after_scheduling_delay_decrease() {
+    let env = TestEnvironment::_new();
+
+    let (_, _, _, initial_note_timestamp_of_change) = setup_schedule_initialization(env);
+
+    // 1000 is arbitrary
+    env.mine_block_at(initial_note_timestamp_of_change + 1000);
+
+    env.private_context(|context| {
+        let state_var = in_private(context);
+
+        // We don't use the setup_initialization_then_delay_change helper function here, because that
+        // function calls `get_scheduled_delay` immediately -- which is the very thing we
+        // want to test in this test!
+        let _ = state_var.schedule_delay_change(SHORTER_DELAY);
+
+        // Note: we have to compute the expected_ts _before_ we get_scheduled_note, because the
+        // act of getting the scheduled note will mutate the `context.include_by_timestamp`.
+        // Since we're DECREASING the delay, and we only just decreased it this second,
+        // we must wait TEST_INITIAL_DELAY - SHORTER_DELAY amount of time before it takes effect.
+        let expected_scheduled_ts =
+            context.include_by_timestamp + (TEST_INITIAL_DELAY - SHORTER_DELAY);
+
+        let (scheduled_delay, scheduled_ts) = state_var.get_scheduled_delay();
+
+        assert_eq(scheduled_delay, SHORTER_DELAY);
+        assert_eq(scheduled_ts, expected_scheduled_ts);
+
+        // When we call get_scheduled_delay, the returned data is only valid for
+        // TEST_INITIAL_DELAY amount of time from the anchor timestamp.
+        // We check that the `include_by_timestamp` has been set accordingly.
+        let include_by_ts_after_get = context.include_by_timestamp;
+
+        let expected_include_by_ts_after_get = context.get_anchor_timestamp() + TEST_INITIAL_DELAY;
+
+        assert_eq(include_by_ts_after_get, expected_include_by_ts_after_get)
+    });
+}
+
+#[test]
+unconstrained fn get_current_note_just_before_scheduled_delay_change_takes_effect() {
+    let env = TestEnvironment::_new();
+
+    let (_, _, _, timestamp_of_change) = setup_initialization_then_delay_change(env, LONGER_DELAY);
+
+    // Just before scheduled initialization takes effect:
+    env.mine_block_at(timestamp_of_change - 1);
+
+    // The context defaults to reading from the latest-mined block as the
+    // anchor block.
+    env.private_context(|context| {
+        let state_var = in_private(context);
+
+        let current_delay = state_var.get_current_delay();
+
+        // The `replacement_note` does not take effect until after a delay (see later tests).
+        assert_eq(current_delay, TEST_INITIAL_DELAY);
+
+        // When we call get_current_delay, the returned note is only valid for
+        // the min of:
+        // - TEST_INITIAL_DELAY amount of time from the anchor timestamp.
+        // - 1 second before the `timestamp_of_change` of the delayed_private_mutable_note.
+        // We check that the `include_by_timestamp` has been set accordingly.
+        // In the case of this test, the anchor block is only 1 second before
+        // the timestamp_of_change, so we'll have 0 seconds until the tx expires.
+        // This is clearly not a realistic or valid tx.
+        let include_by_ts_after_get = context.include_by_timestamp;
+        let expected_include_by_ts_after_get = timestamp_of_change - 1;
+
+        assert_eq(include_by_ts_after_get, expected_include_by_ts_after_get);
+    })
+}
+
+// #[test]
+// unconstrained fn get_scheduled_note_just_before_scheduled_delay_change_takes_effect() {
+//     let mut env = TestEnvironment::_new();
+
+//     let (_, _, _, replacement_note, timestamp_of_change) =
+//         setup_initialization_then_replacement(env);
+
+//     env.mine_block_at(timestamp_of_change - 1);
+
+//     // The context defaults to reading from the latest-mined block as the
+//     // anchor block.
+//     env.private_context(|context| {
+//         let state_var = in_private(context);
+
+//         let (scheduled_note, scheduled_ts) = state_var.get_scheduled_note();
+
+//         assert_eq(scheduled_note, replacement_note);
+//         assert_eq(scheduled_ts, timestamp_of_change);
+
+//         // When we call get_scheduled_note, the returned note is only valid for
+//         // the min of:
+//         // - TEST_INITIAL_DELAY amount of time from the anchor timestamp.
+//         // - 1 second before the `timestamp_of_change` of the delayed_private_mutable_note.
+//         // We check that the `include_by_timestamp` has been set accordingly.
+//         // In the case of this test, the anchor block is only 1 second before
+//         // the timestamp_of_change, so we'll have 0 seconds until the tx expires.
+//         // This is clearly not a realistic or valid tx.
+//         let include_by_ts_after_get = context.include_by_timestamp;
+//         let expected_include_by_ts_after_get = timestamp_of_change - 1;
+
+//         assert_eq(include_by_ts_after_get, expected_include_by_ts_after_get);
+//     })
+// }
+
+// #[test]
+// unconstrained fn get_current_note_at_the_time_scheduled_delay_change_takes_effect() {
+//     let env = TestEnvironment::_new();
+
+//     let (_, _, _, replacement_note, timestamp_of_change) =
+//         setup_initialization_then_replacement(env);
+
+//     env.mine_block_at(timestamp_of_change);
+
+//     // The context defaults to reading from the latest-mined block as the
+//     // anchor block, so it will have an anchor timestamp of `timestamp_of_change`.
+//     env.private_context(|context| {
+//         let state_var = in_private(context);
+//         let current_note = state_var.get_current_note();
+
+//         assert_eq(current_note, replacement_note);
+//     })
+// }
+
+// #[test]
+// unconstrained fn get_scheduled_note_at_the_time_scheduled_delay_change_takes_effect() {
+//     let env = TestEnvironment::_new();
+
+//     let (_, _, _, replacement_note, timestamp_of_change) = setup_initialization_then_replacement(env);
+
+//     env.mine_block_at(timestamp_of_change);
+
+//     // The context defaults to reading from the latest-mined block as the
+//     // anchor block, so it will have an anchor timestamp of `timestamp_of_change`.
+//     env.private_context(|context| {
+//         // Double-check the test env works as expected:
+//         assert_eq(context.get_anchor_timestamp(), timestamp_of_change);
+
+//         let state_var = in_private(context);
+
+//         let (scheduled_note, scheduled_ts) = state_var.get_scheduled_note();
+
+//         assert_eq(scheduled_note, replacement_note);
+//         assert_eq(scheduled_ts, timestamp_of_change);
+
+//         // When we call get_scheduled_note, the returned note is only valid for
+//         // TEST_INITIAL_DELAY amount of time from the anchor timestamp.
+//         // We check that the `include_by_timestamp` has been set accordingly.
+//         let include_by_ts_after_get = context.include_by_timestamp;
+//         let expected_include_by_ts_after_get = context.get_anchor_timestamp() + TEST_INITIAL_DELAY;
+
+//         assert_eq(include_by_ts_after_get, expected_include_by_ts_after_get);
+
+//         // The scheduled and current notes should align, now that the scheduled
+//         // note has taken effect:
+//         let current_note = state_var.get_current_note();
+//         assert_eq(scheduled_note, current_note);
+//     })
+// }
+
+// #[test]
+// unconstrained fn get_current_note_after_scheduled_delay_change_takes_effect() {
+//     let env = TestEnvironment::_new();
+
+//     let (_, _, _, replacement_note, timestamp_of_change) = setup_initialization_then_replacement(env);
+
+//     // + 7 is arbitrarily "some time after the expected timestamp of change".
+//     env.mine_block_at(timestamp_of_change + 7);
+
+//     // The context defaults to reading from the latest-mined block as the
+//     // anchor block, so it will have an anchor timestamp of `timestamp_of_change + 7`.
+//     env.private_context(|context| {
+//         let state_var = in_private(context);
+//         let current_note = state_var.get_current_note();
+
+//         assert_eq(current_note, replacement_note);
+//     })
+// }
+
+// #[test]
+// unconstrained fn get_scheduled_note_after_scheduled_delay_change_takes_effect() {
+//     let env = TestEnvironment::_new();
+
+//     let (_, _, _, replacement_note, timestamp_of_change) = setup_initialization_then_replacement(env);
+
+//     // + 7 is arbitrarily "some time after the expected timestamp of change".
+//     env.mine_block_at(timestamp_of_change + 7);
+
+//     // The context defaults to reading from the latest-mined block as the
+//     // anchor block, so it will have an anchor timestamp of `timestamp_of_change + 7`.
+//     env.private_context(|context| {
+//         let state_var = in_private(context);
+
+//         let (scheduled_note, scheduled_ts) = state_var.get_scheduled_note();
+
+//         assert_eq(scheduled_note, replacement_note);
+//         assert_eq(scheduled_ts, timestamp_of_change);
+
+//         // When we call get_scheduled_note, the returned note is only valid for
+//         // TEST_INITIAL_DELAY amount of time from the anchor timestamp.
+//         // We check that the `include_by_timestamp` has been set accordingly.
+//         let include_by_ts_after_get = context.include_by_timestamp;
+//         let expected_include_by_ts_after_get = context.get_anchor_timestamp() + TEST_INITIAL_DELAY;
+
+//         assert_eq(include_by_ts_after_get, expected_include_by_ts_after_get);
+
+//         // The scheduled and current notes should align, now that the scheduled
+//         // note has taken effect:
+//         let current_note = state_var.get_current_note();
+//         assert_eq(scheduled_note, current_note);
+//     })
+// }

--- a/noir-projects/aztec-nr/aztec/src/state_vars/delayed_private_mutable/test.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/delayed_private_mutable/test.nr
@@ -1,26 +1,19 @@
 use crate::{
-    context::{PrivateContext, PublicContext, UtilityContext},
-    note::{note_emission::NoteEmission, note_interface::NoteHash},
-    oracle::execution::get_contract_address,
+    context::{PrivateContext, UtilityContext},
+    note::note_interface::NoteHash,
     state_vars::delayed_private_mutable::{
         delayed_private_mutable_note::DelayedPrivateMutableNote, DelayedPrivateMutable,
     },
-    test::{
-        helpers::test_environment::{PrivateContextOptions, TestEnvironment},
-        mocks::{mock_note::{MockNote, MockNoteBuilder}, mock_struct::MockStruct},
-    },
+    test::{helpers::test_environment::TestEnvironment, mocks::mock_note::MockNote},
 };
 
-use std::test::OracleMock;
-
 use protocol_types::{
-    address::AztecAddress,
     delayed_public_mutable::scheduled_delay_change::ScheduledDelayChange,
     hash::{
         compute_note_hash_nonce, compute_siloed_note_hash, compute_siloed_nullifier,
         compute_unique_note_hash,
     },
-    traits::{Empty, Packable},
+    traits::Empty,
 };
 
 use dep::std::mem::zeroed;
@@ -1215,10 +1208,6 @@ unconstrained fn schedule_delay_decrease_but_then_schedule_value_change_before_t
 
     let (initial_wrapper_note, _, initial_note, initial_note_timestamp_of_change) =
         setup_schedule_initialization(env);
-
-    println(
-        f"initial_note_timestamp_of_change: {initial_note_timestamp_of_change}",
-    );
 
     // Line-up a _shorter_ delay change.
 

--- a/noir-projects/aztec-nr/aztec/src/state_vars/delayed_private_mutable/test.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/delayed_private_mutable/test.nr
@@ -1,0 +1,226 @@
+use crate::{
+    context::{PrivateContext, PublicContext, UtilityContext},
+    oracle::execution::get_contract_address,
+    state_vars::delayed_private_mutable::DelayedPrivateMutable,
+    test::{
+        helpers::test_environment::TestEnvironment,
+        mocks::{mock_note::{MockNote, MockNoteBuilder}, mock_struct::MockStruct},
+    },
+};
+
+use std::test::OracleMock;
+
+use protocol_types::{
+    address::AztecAddress,
+    delayed_public_mutable::scheduled_delay_change::ScheduledDelayChange,
+    traits::{Empty, Packable},
+};
+
+use dep::std::mem::zeroed;
+
+global STORAGE_SLOT: Field = 47;
+
+global INITIAL_VALUE: Field = 17;
+global NEW_VALUE: Field = 18;
+
+global TEST_INITIAL_DELAY: u64 = 100;
+
+global new_delay: u64 = 20;
+// global new_value: MockStruct = MockStruct { a: 17, b: 42 };
+// global new_note = MockNote::new(17).build_note();
+// global new_note = MockNote { value: 17 };
+
+unconstrained fn in_public(
+    context: &mut PublicContext,
+) -> DelayedPrivateMutable<MockNote, TEST_INITIAL_DELAY, &mut PublicContext> {
+    DelayedPrivateMutable::new(context, STORAGE_SLOT)
+}
+
+unconstrained fn in_private(
+    context: &mut PrivateContext,
+) -> DelayedPrivateMutable<MockNote, TEST_INITIAL_DELAY, &mut PrivateContext> {
+    DelayedPrivateMutable::new(context, STORAGE_SLOT)
+}
+
+unconstrained fn in_utility(
+    context: UtilityContext,
+) -> DelayedPrivateMutable<MockNote, TEST_INITIAL_DELAY, UtilityContext> {
+    DelayedPrivateMutable::new(context, STORAGE_SLOT)
+}
+
+// First, a collection of tests that are modifications of those for PrivateMutable:
+#[test(should_fail_with = "Failed to get a note")]
+unconstrained fn get_uninitialized() {
+    let env = TestEnvironment::_new();
+
+    env.private_context(|context| {
+        let state_var = in_private(context);
+        let _ = state_var.get_current_note();
+    });
+}
+
+#[test(should_fail_with = "Failed to get a note")]
+unconstrained fn replace_uninitialized() {
+    let env = TestEnvironment::_new();
+
+    env.private_context(|context| {
+        let state_var = in_private(context);
+
+        let note = MockNote::new(INITIAL_VALUE).build_note();
+        let _ = state_var.schedule_replacement(note);
+    });
+}
+
+#[test]
+unconstrained fn schedule_initialization() {
+    let env = TestEnvironment::_new();
+
+    env.private_context(|context| {
+        let state_var = in_private(context);
+
+        let note = MockNote::new(INITIAL_VALUE).build_note();
+
+        let emission = state_var.schedule_initialization(note);
+
+        // During initialization we both create the new note and emit the initialization nullifier
+        assert_eq(context.note_hashes.len(), 1);
+        assert_eq(context.nullifiers.len(), 1);
+        assert_eq(context.nullifiers.get(0).value, state_var.compute_initialization_nullifier());
+
+        let wrapper_note = emission.note;
+
+        let svc = wrapper_note.delayed_mutable_values.svc;
+        let pre = svc.get_pre();
+        let post = svc.get_post();
+        let ts = svc.get_timestamp_of_change();
+
+        assert_eq(pre, MockNote::empty());
+        assert_eq(post, note);
+
+        let expected_ts = context.include_by_timestamp + TEST_INITIAL_DELAY;
+        assert_eq(ts, expected_ts);
+
+        let sdc = wrapper_note.delayed_mutable_values.sdc;
+        assert_eq(sdc, ScheduledDelayChange::<TEST_INITIAL_DELAY>::empty());
+
+        assert_eq(emission.storage_slot, STORAGE_SLOT);
+    });
+}
+
+#[test]
+unconstrained fn get_current_note_before_scheduled_initialization_takes_effect() {
+    let env = TestEnvironment::_new();
+
+    env.private_context(|context| {
+        let state_var = in_private(context);
+
+        let note = MockNote::new(INITIAL_VALUE).build_note();
+
+        let _ = state_var.schedule_initialization(note);
+
+        let current_note = state_var.get_current_note();
+
+        assert_eq(current_note, MockNote::empty());
+    });
+}
+
+#[test]
+unconstrained fn get_scheduled_note_before_scheduled_initialization_takes_effect() {
+    let env = TestEnvironment::_new();
+
+    env.private_context(|context| {
+        let state_var = in_private(context);
+
+        let note = MockNote::new(INITIAL_VALUE).build_note();
+
+        let _ = state_var.schedule_initialization(note);
+
+        // Note: we have to compute the expected_ts _before_ we get_scheduled_note, because the
+        // act of getting the scheduled note will mutate the `context.include_by_timestamp`.
+        let expected_ts = context.include_by_timestamp + TEST_INITIAL_DELAY;
+
+        // When we perform a read at this moment in time, it is only valid for
+        // TEST_INITIAL_DELAY amount of time from the anchor timestamp.
+        let (scheduled_note, scheduled_ts) = state_var.get_scheduled_note();
+        let include_by_ts_after = context.include_by_timestamp;
+
+        let anchor_ts = context.get_anchor_timestamp();
+        let expected_include_by_ts_after = anchor_ts + TEST_INITIAL_DELAY;
+
+        assert_eq(note, scheduled_note);
+        assert_eq(scheduled_ts, expected_ts);
+        assert_eq(include_by_ts_after, expected_include_by_ts_after)
+    });
+}
+
+#[test]
+unconstrained fn get_current_note_at_the_time_scheduled_initialization_takes_effect() {
+    let env = TestEnvironment::_new();
+
+    let (scheduled_note, timestamp_of_change) = env.private_context(|context| {
+        let state_var = in_private(context);
+
+        let note = MockNote::new(INITIAL_VALUE).build_note();
+
+        let _ = state_var.schedule_initialization(note);
+
+        state_var.get_scheduled_note()
+    });
+
+    env.set_next_block_timestamp(timestamp_of_change);
+
+    // TODO: we need note discovery for this to work.
+    env.private_context(|context| {
+        let state_var = in_private(context);
+        let current_note = state_var.get_current_note();
+        assert_eq(current_note, scheduled_note);
+    })
+}
+
+#[test]
+unconstrained fn get_scheduled_note_at_the_time_scheduled_initialization_takes_effect() {
+    let env = TestEnvironment::_new();
+
+    env.private_context(|context| {
+        let state_var = in_private(context);
+
+        let note = MockNote::new(INITIAL_VALUE).build_note();
+
+        let _ = state_var.schedule_initialization(note);
+
+        // Note: we have to compute the expected_ts _before_ we get_scheduled_note, because the
+        // act of getting the scheduled note will mutate the `context.include_by_timestamp`.
+        let expected_ts = context.include_by_timestamp + TEST_INITIAL_DELAY;
+
+        // When we perform a read at this moment in time, it is only valid for
+        // TEST_INITIAL_DELAY amount of time from the anchor timestamp.
+        let (scheduled_note, scheduled_ts) = state_var.get_scheduled_note();
+        let include_by_ts_after = context.include_by_timestamp;
+
+        let anchor_ts = context.get_anchor_timestamp();
+        let expected_include_by_ts_after = anchor_ts + TEST_INITIAL_DELAY;
+
+        assert_eq(note, scheduled_note);
+        assert_eq(scheduled_ts, expected_ts);
+        assert_eq(include_by_ts_after, expected_include_by_ts_after)
+    });
+}
+
+// DELAY
+
+#[test]
+unconstrained fn get_current_delay_before_scheduled_initialization_takes_effect() {
+    let env = TestEnvironment::_new();
+
+    env.private_context(|context| {
+        let state_var = in_private(context);
+
+        let note = MockNote::new(INITIAL_VALUE).build_note();
+
+        let _ = state_var.schedule_initialization(note);
+
+        let current_delay = state_var.get_current_delay();
+
+        assert_eq(TEST_INITIAL_DELAY, current_delay);
+    });
+}

--- a/noir-projects/aztec-nr/aztec/src/state_vars/delayed_public_mutable.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/delayed_public_mutable.nr
@@ -210,9 +210,10 @@ where
         // for timestamp `y` to reduce the delay to 43200 seconds (12 hours), then if a value change was scheduled at
         // timestamp `y` it would go into effect at timestamp `y + 43200`, which is earlier than what we'd expect if we
         // only considered the current delay.
-        let effective_minimum_delay = delay_change.get_effective_minimum_delay_at(anchor_timestamp);
+        let max_time_a_read_remains_valid =
+            delay_change.get_max_time_a_read_remains_valid(anchor_timestamp);
         let time_horizon =
-            value_change.get_time_horizon_at(anchor_timestamp, effective_minimum_delay);
+            value_change.get_time_horizon_at(anchor_timestamp, max_time_a_read_remains_valid);
 
         // We prevent this transaction from being included in any timestamp after the time horizon, ensuring that the
         // historical public value matches the current one, since it can only change after the horizon.

--- a/noir-projects/aztec-nr/aztec/src/state_vars/delayed_public_mutable.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/delayed_public_mutable.nr
@@ -54,7 +54,10 @@ impl<T, let InitialDelay: u64> DelayedPublicMutable<T, InitialDelay, &mut Public
 where
     T: Eq,
 {
-
+    /// Schedules a change to the new_value at the earliest possible time, given the current
+    /// delay of this state.
+    /// TODO: make this configurable to an optional later time (an earlier time is not allowed).
+    /// https://github.com/AztecProtocol/aztec-packages/issues/5501
     pub fn schedule_value_change(self, new_value: T)
     where
         T: Packable,
@@ -66,11 +69,12 @@ where
     where
         T: Packable,
     {
+        // TODO: doing two reads is wasteful, because it's reading the same slot twice. We should instead read the slot once.
         let mut value_change = self.read_value_change();
         let delay_change = self.read_delay_change();
 
         let current_timestamp = self.context.timestamp();
-        let current_delay = delay_change.get_current(current_timestamp);
+        let current_delay = delay_change.get_current_at(current_timestamp);
 
         // TODO: make this configurable
         // https://github.com/AztecProtocol/aztec-packages/issues/5501
@@ -115,7 +119,7 @@ where
         T: Packable,
     {
         let current_timestamp = self.context.timestamp();
-        self.read_delay_change().get_current(current_timestamp)
+        self.read_delay_change().get_current_at(current_timestamp)
     }
 
     pub fn get_scheduled_value(self) -> (T, u64)
@@ -152,6 +156,12 @@ where
         // need to offset the storage slot to get the position where it'd land.
         // We don't read ScheduledDelayChange directly by having it implement Packable because ScheduledValueChange
         // and ScheduledDelayChange are packed together (sdc and svc.timestamp_of_change are stored in the same slot).
+
+        // Observation: it's kind of weird that if you compare this fn with the one above, they both do:
+        // `self.context.storage_read(self.storage_slot)`,
+        // but one call returns a [Field; ((N*2)+1)], and the other returns a `Field`.
+        // In each case, the type is actually being inferred by the next line, but it broke my brain for a little while, there.
+        // Is this expected Noir behaviour, or is it a bug?
         let packed = self.context.storage_read(self.storage_slot);
         unpack_delay_change::<InitialDelay>(packed)
     }
@@ -189,45 +199,48 @@ where
         // However, since this value might change, we must constrain the maximum transaction timestamp as this proof
         // will only be valid for the time we can ensure the value will not change, which will depend on the
         // current delay and any scheduled delay changes.
-        let (value_change, delay_change, historical_timestamp) =
+        let (value_change, delay_change, anchor_timestamp) =
             self.historical_read_from_public_storage();
 
-        // We use the effective minimum delay as opposed to the current delay at the historical timestamp (timestamp of
-        // the historical block against which we are executing the private part of the tx) as this one also takes into
-        // consideration any scheduled delay changes.
+        // We use the effective minimum delay as opposed to the current delay at the anchor timestamp
+        // as this one also takes into consideration any scheduled delay changes.
         // For example, consider a scenario in which at timestamp `x` the current delay was 86400 seconds (1 day). We
         // may naively think that the earliest we could change the value would be at timestamp `x + 86400` by scheduling
-        // immediately after the historical timestamp, i.e. at timestamp `x + 1`. But if there was a delay change scheduled
+        // immediately after the anchor timestamp, i.e. at timestamp `x + 1`. But if there was a delay change scheduled
         // for timestamp `y` to reduce the delay to 43200 seconds (12 hours), then if a value change was scheduled at
         // timestamp `y` it would go into effect at timestamp `y + 43200`, which is earlier than what we'd expect if we
         // only considered the current delay.
-        let effective_minimum_delay =
-            delay_change.get_effective_minimum_delay_at(historical_timestamp);
+        let effective_minimum_delay = delay_change.get_effective_minimum_delay_at(anchor_timestamp);
         let time_horizon =
-            value_change.get_time_horizon(historical_timestamp, effective_minimum_delay);
+            value_change.get_time_horizon_at(anchor_timestamp, effective_minimum_delay);
 
         // We prevent this transaction from being included in any timestamp after the time horizon, ensuring that the
         // historical public value matches the current one, since it can only change after the horizon.
         self.context.set_include_by_timestamp(time_horizon);
 
-        value_change.get_current_at(historical_timestamp)
+        value_change.get_current_at(anchor_timestamp)
     }
 
+    // TODO: we have 3 similar, but different names as we go through this fn:
+    // - historical_read_from_public_storage
+    // - historical_public_storage_read
+    // - public_storage_historical_read
+    // Can we align that naming?
     fn historical_read_from_public_storage(
         self,
     ) -> (ScheduledValueChange<T>, ScheduledDelayChange<InitialDelay>, u64)
     where
         T: Packable,
     {
-        let header = self.context.get_block_header();
+        let anchor_header = self.context.get_block_header();
         let address = self.context.this_address();
 
-        let historical_timestamp = header.global_variables.timestamp;
+        let anchor_timestamp = anchor_header.global_variables.timestamp;
 
         let values: DelayedPublicMutableValues<T, InitialDelay> =
-            WithHash::historical_public_storage_read(header, address, self.storage_slot);
+            WithHash::historical_public_storage_read(anchor_header, address, self.storage_slot);
 
-        (values.svc, values.sdc, historical_timestamp)
+        (values.svc, values.sdc, anchor_timestamp)
     }
 }
 

--- a/noir-projects/aztec-nr/aztec/src/state_vars/delayed_public_mutable/test.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/delayed_public_mutable/test.nr
@@ -42,6 +42,7 @@ unconstrained fn in_utility(
  * A scheduled delay change (increase, deferred), but then a value change gets scheduled to take effect _before_ the delay change takes effect.
  * A scheduled delay change (decrease, deferred), but then a value change gets scheduled to take effect _before_ the delay change takes effect.
  * A scheduled VALUE change (increase, deferred), but then a value change gets scheduled to take effect _before_ the first value change takes effect.
+ * Schedule two value changes of the same state var, in the same public function. Show that only the latter can be read later.
  * See: https://miro.com/app/board/uXjVJe05l5o=/
  */
 
@@ -317,7 +318,7 @@ unconstrained fn get_current_value_in_private_at_change() {
         assert_eq(state_var.get_current_value(), new_value);
         assert_eq(
             context.include_by_timestamp,
-            context.get_block_header().global_variables.timestamp + TEST_INITIAL_DELAY,
+            context.get_anchor_timestamp() + TEST_INITIAL_DELAY,
         );
     });
 }

--- a/noir-projects/aztec-nr/aztec/src/state_vars/delayed_public_mutable/test.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/delayed_public_mutable/test.nr
@@ -33,6 +33,18 @@ unconstrained fn in_utility(
     DelayedPublicMutable::new(context, storage_slot)
 }
 
+/**
+ * Some missing tests:
+ * get_storage_slot
+ * explicit tests of schedule_and_return_value_change
+ * Scheduling a new delay which is _bigger_ than the current delay, with the timestamp_of_change taking effect _immediately_ at the time of scheduling.
+ * Scheduling a new delay which is _bigger_ than the current delay, with the timestamp_of_change being deferred for some time.
+ * A scheduled delay change (increase, deferred), but then a value change gets scheduled to take effect _before_ the delay change takes effect.
+ * A scheduled delay change (decrease, deferred), but then a value change gets scheduled to take effect _before_ the delay change takes effect.
+ * A scheduled VALUE change (increase, deferred), but then a value change gets scheduled to take effect _before_ the first value change takes effect.
+ * See: https://miro.com/app/board/uXjVJe05l5o=/
+ */
+
 #[test]
 unconstrained fn get_current_value_in_public_initial() {
     let env = TestEnvironment::_new();
@@ -50,12 +62,12 @@ unconstrained fn get_scheduled_value_in_public() {
     env.public_context(|context| {
         let state_var = in_public(context);
 
-        // Since we haven't modified the delay, it's value should be the default value of TEST_INITIAL_DELAY.
         state_var.schedule_value_change(new_value);
 
         let (scheduled, timestamp_of_change) = state_var.get_scheduled_value();
 
         assert_eq(scheduled, new_value);
+        // Since we haven't modified the delay, its value should be the default value of TEST_INITIAL_DELAY.
         assert_eq(timestamp_of_change, context.timestamp() + TEST_INITIAL_DELAY);
     });
 }

--- a/noir-projects/aztec-nr/aztec/src/state_vars/delayed_public_mutable/test.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/delayed_public_mutable/test.nr
@@ -33,19 +33,6 @@ unconstrained fn in_utility(
     DelayedPublicMutable::new(context, storage_slot)
 }
 
-/**
- * Some missing tests:
- * get_storage_slot
- * explicit tests of schedule_and_return_value_change
- * Scheduling a new delay which is _bigger_ than the current delay, with the timestamp_of_change taking effect _immediately_ at the time of scheduling.
- * Scheduling a new delay which is _bigger_ than the current delay, with the timestamp_of_change being deferred for some time.
- * A scheduled delay change (increase, deferred), but then a value change gets scheduled to take effect _before_ the delay change takes effect.
- * A scheduled delay change (decrease, deferred), but then a value change gets scheduled to take effect _before_ the delay change takes effect.
- * A scheduled VALUE change (increase, deferred), but then a value change gets scheduled to take effect _before_ the first value change takes effect.
- * Schedule two value changes of the same state var, in the same public function. Show that only the latter can be read later.
- * See: https://miro.com/app/board/uXjVJe05l5o=/
- */
-
 #[test]
 unconstrained fn get_current_value_in_public_initial() {
     let env = TestEnvironment::_new();

--- a/noir-projects/aztec-nr/aztec/src/state_vars/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/mod.nr
@@ -4,9 +4,11 @@ pub mod private_mutable;
 pub mod public_immutable;
 pub mod public_mutable;
 pub mod private_set;
+pub mod delayed_private_mutable;
 pub mod delayed_public_mutable;
 pub mod storage;
 
+pub use crate::state_vars::delayed_private_mutable::DelayedPrivateMutable;
 pub use crate::state_vars::delayed_public_mutable::DelayedPublicMutable;
 pub use crate::state_vars::map::Map;
 pub use crate::state_vars::private_immutable::PrivateImmutable;

--- a/noir-projects/aztec-nr/aztec/src/state_vars/private_mutable.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/private_mutable.nr
@@ -7,13 +7,14 @@ use crate::context::{PrivateContext, UtilityContext};
 use crate::note::{
     lifecycle::{create_note, destroy_note_unsafe},
     note_emission::NoteEmission,
-    note_getter::{get_note, view_notes},
+    note_getter::{get_note, view_note},
     note_interface::{NoteHash, NoteType},
-    note_viewer_options::NoteViewerOptions,
 };
 use crate::note::retrieved_note::RetrievedNote;
 use crate::oracle::notes::check_nullifier_exists;
 use crate::state_vars::storage::HasStorageSlot;
+
+mod test;
 
 /// # PrivateMutable
 ///
@@ -107,8 +108,6 @@ pub struct PrivateMutable<Note, Context> {
     storage_slot: Field,
 }
 // docs:end:struct
-
-mod test;
 
 // Private storage slots are not really 'slots' but rather a value in the note hash preimage, so there is no notion of a
 // value spilling over multiple slots. For this reason PrivateMutable (and all other private state variables) needs just
@@ -459,8 +458,7 @@ where
     where
         Note: Packable,
     {
-        let mut options = NoteViewerOptions::<Note, <Note as Packable>::N>::new();
-        view_notes(self.storage_slot, options.set_limit(1)).get(0)
+        view_note(self.storage_slot).note
     }
     // docs:end:view_note
 }

--- a/noir-projects/aztec-nr/aztec/src/state_vars/private_mutable.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/private_mutable.nr
@@ -412,7 +412,7 @@ where
         destroy_note_unsafe(self.context, retrieved_note, note_hash_for_read_request);
 
         // Add the same note again.
-        // Because a nonce is added to every note in the kernel, its nullifier will be different.
+        // Because a note_nonce is added to every note in the kernel, its nullifier will be different.
         create_note(self.context, self.storage_slot, retrieved_note.note)
     }
     // docs:end:get_note

--- a/noir-projects/aztec-nr/aztec/src/state_vars/private_mutable/test.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/private_mutable/test.nr
@@ -1,4 +1,4 @@
-use crate::{context::PrivateContext, state_vars::private_mutable::PrivateMutable};
+use crate::{context::{PrivateContext, UtilityContext}, state_vars::private_mutable::PrivateMutable};
 use crate::test::{helpers::test_environment::TestEnvironment, mocks::mock_note::MockNote};
 
 global STORAGE_SLOT: Field = 17;
@@ -10,6 +10,10 @@ unconstrained fn in_private(
     PrivateMutable::new(context, STORAGE_SLOT)
 }
 
+unconstrained fn in_utility(context: UtilityContext) -> PrivateMutable<MockNote, UtilityContext> {
+    PrivateMutable::new(context, STORAGE_SLOT)
+}
+
 #[test(should_fail_with = "Failed to get a note")]
 unconstrained fn get_uninitialized() {
     let env = TestEnvironment::_new();
@@ -17,6 +21,16 @@ unconstrained fn get_uninitialized() {
     env.private_context(|context| {
         let state_var = in_private(context);
         let _ = state_var.get_note();
+    });
+}
+
+#[test(should_fail_with = "Failed to get a note")]
+unconstrained fn view_uninitialized() {
+    let env = TestEnvironment::_new();
+
+    env.utility_context(|context| {
+        let state_var = in_utility(context);
+        let _ = state_var.view_note();
     });
 }
 
@@ -68,10 +82,10 @@ unconstrained fn initialize_and_get_pending() {
         let nullifiers_pre_get = context.nullifiers.len();
         let note_hash_read_requests_pre_get = context.note_hash_read_requests.len();
 
-        let emission = state_var.get_note();
+        let get_emission = state_var.get_note();
 
-        assert_eq(emission.note, note);
-        assert_eq(emission.storage_slot, STORAGE_SLOT);
+        assert_eq(get_emission.note, note);
+        assert_eq(get_emission.storage_slot, STORAGE_SLOT);
 
         // Reading a PrivateMutable results in:
         // - a read request for the read value
@@ -80,6 +94,59 @@ unconstrained fn initialize_and_get_pending() {
         assert_eq(context.note_hash_read_requests.len(), note_hash_read_requests_pre_get + 1);
         assert_eq(context.nullifiers.len(), nullifiers_pre_get + 1);
         assert_eq(context.note_hashes.len(), note_hashes_pre_get + 1);
+    });
+}
+
+#[test]
+unconstrained fn initialize_and_get_settled() {
+    let env = TestEnvironment::_new();
+
+    let note = MockNote::new(VALUE).build_note();
+
+    let init_emission = env.private_context(|context| {
+        let state_var = in_private(context);
+
+        state_var.initialize(note)
+    });
+
+    env.discover_note(init_emission);
+
+    env.private_context(|context| {
+        let state_var = in_private(context);
+
+        let get_emission = state_var.get_note();
+
+        assert_eq(get_emission.note, note);
+        assert_eq(get_emission.storage_slot, STORAGE_SLOT);
+
+        // Reading a PrivateMutable results in:
+        // - a read request for the read value
+        // - a nullifier for the read note
+        // - a new note for the recreation of the read value
+        assert_eq(context.note_hash_read_requests.len(), 1);
+        assert_eq(context.nullifiers.len(), 1);
+        assert_eq(context.note_hashes.len(), 1);
+    });
+}
+
+#[test]
+unconstrained fn initialize_and_view_settled() {
+    let env = TestEnvironment::_new();
+
+    let note = MockNote::new(VALUE).build_note();
+
+    let init_emission = env.private_context(|context| {
+        let state_var = in_private(context);
+
+        state_var.initialize(note)
+    });
+
+    env.discover_note(init_emission);
+
+    env.utility_context(|context| {
+        let state_var = in_utility(context);
+
+        assert_eq(state_var.view_note(), note);
     });
 }
 
@@ -100,10 +167,10 @@ unconstrained fn initialize_and_replace_pending() {
 
         let replacement_value = VALUE + 1;
         let replacement_note = MockNote::new(replacement_value).build_note();
-        let emission = state_var.replace(replacement_note);
+        let replace_emission = state_var.replace(replacement_note);
 
-        assert_eq(emission.note, replacement_note);
-        assert_eq(emission.storage_slot, STORAGE_SLOT);
+        assert_eq(replace_emission.note, replacement_note);
+        assert_eq(replace_emission.storage_slot, STORAGE_SLOT);
 
         // Replacing a PrivateMutable results in:
         // - a read request for the read value
@@ -112,6 +179,40 @@ unconstrained fn initialize_and_replace_pending() {
         assert_eq(context.note_hash_read_requests.len(), note_hash_read_requests_pre_replace + 1);
         assert_eq(context.nullifiers.len(), nullifiers_pre_replace + 1);
         assert_eq(context.note_hashes.len(), note_hashes_pre_replace + 1);
+    });
+}
+
+#[test]
+unconstrained fn initialize_and_replace_settled() {
+    let env = TestEnvironment::_new();
+
+    let note = MockNote::new(VALUE).build_note();
+
+    let init_emission = env.private_context(|context| {
+        let state_var = in_private(context);
+
+        state_var.initialize(note)
+    });
+
+    env.discover_note(init_emission);
+
+    env.private_context(|context| {
+        let state_var = in_private(context);
+
+        let replacement_value = VALUE + 1;
+        let replacement_note = MockNote::new(replacement_value).build_note();
+        let replace_emission = state_var.replace(replacement_note);
+
+        assert_eq(replace_emission.note, replacement_note);
+        assert_eq(replace_emission.storage_slot, STORAGE_SLOT);
+
+        // Replacing a PrivateMutable results in:
+        // - a read request for the read value
+        // - a nullifier for the read note
+        // - a new note for the replacement note
+        assert_eq(context.note_hash_read_requests.len(), 1);
+        assert_eq(context.nullifiers.len(), 1);
+        assert_eq(context.note_hashes.len(), 1);
     });
 }
 
@@ -140,23 +241,25 @@ unconstrained fn initialize_or_replace_uninitialized() {
 unconstrained fn initialize_or_replace_initialized_pending() {
     let env = TestEnvironment::_new();
 
-    env.private_context(|context| {
+    let init_emission = env.private_context(|context| {
         let state_var = in_private(context);
 
         let note = MockNote::new(VALUE).build_note();
 
-        let _ = state_var.initialize(note);
+        state_var.initialize(note)
+    });
 
-        let note_hash_read_requests_pre_replace = context.note_hash_read_requests.len();
-        let nullifiers_pre_replace = context.nullifiers.len();
-        let note_hashes_pre_replace = context.note_hashes.len();
+    env.discover_note(init_emission);
+
+    env.private_context(|context| {
+        let state_var = in_private(context);
 
         let replacement_value = VALUE + 1;
         let replacement_note = MockNote::new(replacement_value).build_note();
-        let emission = state_var.initialize_or_replace(replacement_note);
+        let init_or_replace_emission = state_var.initialize_or_replace(replacement_note);
 
-        assert_eq(emission.note, replacement_note);
-        assert_eq(emission.storage_slot, STORAGE_SLOT);
+        assert_eq(init_or_replace_emission.note, replacement_note);
+        assert_eq(init_or_replace_emission.storage_slot, STORAGE_SLOT);
 
         // Replacing a PrivateMutable results in:
         // - a read request for the read value
@@ -164,8 +267,8 @@ unconstrained fn initialize_or_replace_initialized_pending() {
         // - a new note for the replacement note
         // This would only succeed if the variable had already been initialized, as otherwise the read request would
         // fail.
-        assert_eq(context.note_hash_read_requests.len(), note_hash_read_requests_pre_replace + 1);
-        assert_eq(context.nullifiers.len(), nullifiers_pre_replace + 1);
-        assert_eq(context.note_hashes.len(), note_hashes_pre_replace + 1);
+        assert_eq(context.note_hash_read_requests.len(), 1);
+        assert_eq(context.nullifiers.len(), 1);
+        assert_eq(context.note_hashes.len(), 1);
     });
 }

--- a/noir-projects/aztec-nr/aztec/src/state_vars/private_mutable/test.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/private_mutable/test.nr
@@ -91,6 +91,7 @@ unconstrained fn initialize_and_get_pending() {
         // - a read request for the read value
         // - a nullifier for the read note
         // - a new note for the recreation of the read value
+        // Note: the TestEnvironment does not perform squashing like the proper kernel reset circuit would do.
         assert_eq(context.note_hash_read_requests.len(), note_hash_read_requests_pre_get + 1);
         assert_eq(context.nullifiers.len(), nullifiers_pre_get + 1);
         assert_eq(context.note_hashes.len(), note_hashes_pre_get + 1);

--- a/noir-projects/aztec-nr/aztec/src/state_vars/private_set/test.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/private_set/test.nr
@@ -89,6 +89,62 @@ unconstrained fn insert_and_get_pending() {
 }
 
 #[test]
+unconstrained fn insert_and_get_settled() {
+    let env = TestEnvironment::new();
+
+    let note = MockNote::new(VALUE).build_note();
+
+    let emission = env.private_context(|context| {
+        let state_var = in_private(context);
+
+        state_var.insert(note)
+    });
+
+    env.discover_note(emission);
+
+    env.private_context(|context| {
+        let state_var = in_private(context);
+
+        let notes = state_var.get_notes(NoteGetterOptions::new());
+
+        assert_eq(notes.len(), 1);
+
+        // get_notes returns the notes, but does *not* nullify them
+        assert_eq(state_var.context.note_hash_read_requests.len(), 1);
+        assert_eq(state_var.context.nullifiers.len(), 0);
+
+        // Instead we get RetrievedNotes, which can be later used for nullification
+        let retrieved_note = notes.get(0);
+        assert(retrieved_note.metadata.is_settled());
+        assert_eq(retrieved_note.note, note);
+    });
+}
+
+#[test]
+unconstrained fn insert_and_view_settled() {
+    let env = TestEnvironment::new();
+
+    let note = MockNote::new(VALUE).build_note();
+
+    let emission = env.private_context(|context| {
+        let state_var = in_private(context);
+
+        state_var.insert(note)
+    });
+
+    env.discover_note(emission);
+
+    env.utility_context(|context| {
+        let state_var = in_utility(context);
+
+        let notes = state_var.view_notes(NoteViewerOptions::new());
+
+        assert_eq(notes.len(), 1);
+        assert_eq(notes.get(0), note);
+    });
+}
+
+#[test]
 unconstrained fn insert_and_pop_pending() {
     let env = TestEnvironment::new();
 
@@ -97,6 +153,34 @@ unconstrained fn insert_and_pop_pending() {
 
         let note = MockNote::new(VALUE).build_note();
         let _ = state_var.insert(note);
+
+        let notes = state_var.pop_notes(NoteGetterOptions::new());
+
+        assert_eq(notes.len(), 1);
+        assert_eq(notes.get(0), note);
+
+        // pop_notes returns the notes *and* nullifies them
+        assert_eq(state_var.context.note_hash_read_requests.len(), 1);
+        assert_eq(state_var.context.nullifiers.len(), 1);
+    });
+}
+
+#[test]
+unconstrained fn insert_and_pop_settled() {
+    let env = TestEnvironment::new();
+
+    let note = MockNote::new(VALUE).build_note();
+
+    let emission = env.private_context(|context| {
+        let state_var = in_private(context);
+
+        state_var.insert(note)
+    });
+
+    env.discover_note(emission);
+
+    env.private_context(|context| {
+        let state_var = in_private(context);
 
         let notes = state_var.pop_notes(NoteGetterOptions::new());
 
@@ -129,6 +213,31 @@ unconstrained fn insert_and_remove_pending() {
 }
 
 #[test]
+unconstrained fn insert_and_remove_settled() {
+    let env = TestEnvironment::new();
+
+    let note = MockNote::new(VALUE).build_note();
+
+    let emission = env.private_context(|context| {
+        let state_var = in_private(context);
+        state_var.insert(note)
+    });
+
+    env.discover_note(emission);
+
+    env.private_context(|context| {
+        let state_var = in_private(context);
+
+        let retrieved = state_var.get_notes(NoteGetterOptions::new());
+
+        state_var.remove(retrieved.get(0));
+
+        // remove nullifies the note
+        assert_eq(state_var.context.nullifiers.len(), 1);
+    });
+}
+
+#[test]
 unconstrained fn insert_pop_and_read_again_pending() {
     let env = TestEnvironment::new();
 
@@ -147,6 +256,31 @@ unconstrained fn insert_pop_and_read_again_pending() {
 }
 
 #[test]
+unconstrained fn insert_pop_and_read_again_settled() {
+    let env = TestEnvironment::new();
+
+    let note = MockNote::new(VALUE).build_note();
+
+    let emission = env.private_context(|context| {
+        let state_var = in_private(context);
+
+        state_var.insert(note)
+    });
+
+    env.discover_note(emission);
+
+    env.private_context(|context| {
+        let state_var = in_private(context);
+
+        let _ = state_var.pop_notes(NoteGetterOptions::new());
+
+        // Now that we've deleted the note, the oracle should know this and not return them any more.
+        assert_eq(state_var.pop_notes(NoteGetterOptions::new()).len(), 0);
+        assert_eq(state_var.get_notes(NoteGetterOptions::new()).len(), 0);
+    });
+}
+
+#[test]
 unconstrained fn insert_remove_and_read_again_pending() {
     let env = TestEnvironment::new();
 
@@ -155,6 +289,32 @@ unconstrained fn insert_remove_and_read_again_pending() {
 
         let note = MockNote::new(VALUE).build_note();
         let _ = state_var.insert(note);
+
+        let retrieved = state_var.get_notes(NoteGetterOptions::new());
+        state_var.remove(retrieved.get(0));
+
+        // Now that we've deleted the notes, the oracle should know this and not return them any more.
+        assert_eq(state_var.pop_notes(NoteGetterOptions::new()).len(), 0);
+        assert_eq(state_var.get_notes(NoteGetterOptions::new()).len(), 0);
+    });
+}
+
+#[test]
+unconstrained fn insert_remove_and_read_again_settled() {
+    let env = TestEnvironment::new();
+
+    let note = MockNote::new(VALUE).build_note();
+
+    let emission = env.private_context(|context| {
+        let state_var = in_private(context);
+
+        state_var.insert(note)
+    });
+
+    env.discover_note(emission);
+
+    env.private_context(|context| {
+        let state_var = in_private(context);
 
         let retrieved = state_var.get_notes(NoteGetterOptions::new());
         state_var.remove(retrieved.get(0));

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
@@ -1,5 +1,7 @@
 use protocol_types::{
-    abis::function_selector::FunctionSelector, address::AztecAddress, traits::Deserialize,
+    abis::function_selector::FunctionSelector,
+    address::AztecAddress,
+    traits::{Deserialize, Packable},
 };
 
 use crate::{
@@ -9,8 +11,24 @@ use crate::{
         ReturnsHash, UtilityCallInterface, UtilityContext,
     },
     hash::hash_args,
+    messages::{
+        discovery::{
+            ComputeNoteHashAndNullifier, NoteHashAndNullifier,
+            process_message::process_message_plaintext,
+        },
+        logs::note::private_note_to_message_plaintext,
+        processing::{message_context::MessageContext, validate_enqueued_notes_and_events},
+    },
+    note::{
+        note_emission::NoteEmission,
+        note_interface::{NoteHash, NoteType},
+        note_metadata::SettledNoteMetadata,
+        retrieved_note::RetrievedNote,
+        utils::compute_note_hash_for_nullify,
+    },
     oracle::{execution::{get_block_number, get_timestamp}, execution_cache},
     test::helpers::{txe_oracles, utils::ContractDeployment},
+    utils::array::subarray,
 };
 
 mod test;
@@ -643,5 +661,129 @@ impl TestEnvironment {
         // This shouldn't be using ReturnsHash, but I don't think CalldataHash is right either in this context
         let returns: T = ReturnsHash::new(returns_hash).get_preimage();
         returns
+    }
+
+    /// Discovers a note wrapped in a `NoteEmission` value, which is expected to have been created in the last
+    /// transaction (typically via `private_context()`) so that it can be retrieved in later transactions. This mimics
+    /// the normal note discovery process that takes places automatically in contracts.
+    ///
+    /// `NoteEmission` values are typically returned by aztec-nr state variables that create notes and need to notify a
+    /// recipient of their existence. Instead of going through the message encoding, encryption and emission that would
+    /// regularly take place in a contract, `discover_note` simply takes the `NoteEmission` and processes it as needed
+    /// to discover the underlying note.
+    ///
+    /// See `discover_note_at` for a variant that allows specifying the contract address the note belongs to.
+    ///
+    /// ### Sample usage
+    ///
+    /// The most common way to invoke this function is to obtain an emission created during the execution of a
+    /// `private_context`:
+    ///
+    /// ```noir
+    /// let emission = env.private_context(|context| create_note(context, storage_slot, note));
+    ///
+    /// env.discover_note(emission);
+    ///
+    /// env.private_context(|context| { let (retrieved_note, _) = get_note::<MockNote>(context, storage_slot); });
+    /// ```
+    pub unconstrained fn discover_note<Note>(self: Self, emission: NoteEmission<Note>)
+    where
+        Note: Packable + NoteType + NoteHash,
+    {
+        // This function will emulate the message discovery and processing that would happen in a real contract, based
+        // on a message created from the received note emission.
+
+        // First we produce the message itself. We skip encryption/decryption since we're not interested in that here.
+        // Note that we need to convert the fixed-size array produced by the encoding functions into a BoundedVec, which
+        // is what the decoding functions expect (because they are built to manage protocol logs, which are arbitrarily
+        // sized).
+        let message_plaintext = BoundedVec::from_array(private_note_to_message_plaintext(
+            emission.note,
+            emission.storage_slot,
+        ));
+
+        // Then we fetch the transaction effects from the latest transaction, in which the note from the emission is
+        // expected to have been created. In a real contract this data would have either been supplied by the
+        // `process_message` caller, of retrieved along with the message from a tagged log.
+        let (tx_hash, unique_note_hashes_in_tx, nullifiers_in_tx) =
+            txe_oracles::get_last_tx_effects();
+
+        // Real messages would also have a recipient, a concept which does not translate to anything in
+        // `TestEnvironment` since it works with a single PXE with global scopes. We therefore simply set the zero
+        // address as the recipient, which PXE accepts as a note scope despite this not being a registered account.
+        let recipient = AztecAddress::zero();
+
+        let message_context = MessageContext {
+            tx_hash,
+            unique_note_hashes_in_tx,
+            first_nullifier_in_tx: nullifiers_in_tx.get(0),
+            recipient,
+        };
+
+        // We also need to provide an implementation for the `compute_note_hash_and_nullifier` function, which would
+        // typically be created by the macros for the different notes in a given contract. Here we build one specialized
+        // for `Note`.
+        let compute_note_hash_and_nullifier: ComputeNoteHashAndNullifier<_> = |packed_note, storage_slot, note_type_id, contract_address, note_nonce| {
+            assert_eq(note_type_id, Note::get_id());
+            assert_eq(packed_note.len(), <Note as Packable>::N);
+
+            let note = Note::unpack(subarray(packed_note.storage(), 0));
+
+            let note_hash = note.compute_note_hash(storage_slot);
+            let note_hash_for_nullify = compute_note_hash_for_nullify(
+                RetrievedNote {
+                    note,
+                    contract_address,
+                    metadata: SettledNoteMetadata::new(note_nonce).into(),
+                },
+                storage_slot,
+            );
+
+            let inner_nullifier = note.compute_nullifier_unconstrained(note_hash_for_nullify);
+
+            Option::some(NoteHashAndNullifier { note_hash, inner_nullifier })
+        };
+
+        // Both private and utility functions perform message processing and note discovery. We do it in an utility
+        // context here as that one is more lightweight and does not create new blocks, which also allows for
+        // `discover_notes` to be called repeatedly with multiple emissions from the same transaction.
+        self.utility_context(|context| {
+            process_message_plaintext(
+                context.this_address(),
+                compute_note_hash_and_nullifier,
+                message_plaintext,
+                message_context,
+            );
+
+            validate_enqueued_notes_and_events(context.this_address());
+        });
+    }
+
+    /// Variant of `discover_note` which allows specifying the contract address the note belongs to, which is required
+    /// when the note was not emitted in the default address used by `private_context`.
+    ///
+    /// ```noir
+    /// let emission = env.private_context_at(contract_address, |context| {
+    ///     create_note(context, storage_slot, note)
+    /// });
+    ///
+    /// env.discover_note_at(contract_address, emission);
+    ///
+    /// env.private_context_at(contract_address, |context| {
+    ///     let (retrieved_note, _) = get_note::<MockNote>(context, storage_slot);
+    /// });
+    /// ```
+    pub unconstrained fn discover_note_at<Note>(
+        self: Self,
+        addr: AztecAddress,
+        emission: NoteEmission<Note>,
+    )
+    where
+        Note: Packable + NoteType + NoteHash,
+    {
+        let pre = txe_oracles::get_contract_address();
+        txe_oracles::set_contract_address(addr);
+        self.discover_note(emission);
+        txe_oracles::set_contract_address(pre);
     }
 }

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment/test.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment/test.nr
@@ -4,6 +4,7 @@ mod accounts;
 mod deployment;
 mod private_context;
 mod public_context;
+mod notes;
 
 #[test(should_fail_with = "cannot be before next timestamp")]
 unconstrained fn set_next_block_timestamp_to_past_fails() {

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment/test/notes.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment/test/notes.nr
@@ -1,0 +1,399 @@
+use crate::note::{
+    lifecycle::{create_note, destroy_note_unsafe},
+    note_getter::{get_note, get_notes, view_note, view_notes},
+    note_getter_options::NoteGetterOptions,
+    note_viewer_options::NoteViewerOptions,
+};
+use crate::test::{helpers::test_environment::TestEnvironment, mocks::mock_note::MockNote};
+use protocol_types::{address::AztecAddress, traits::FromField};
+
+global VALUE: Field = 7;
+global CONTRACT_ADDRESS: AztecAddress = AztecAddress::from_field(12);
+global STORAGE_SLOT: Field = 13;
+
+#[test(should_fail_with = "Failed to get a note")]
+unconstrained fn get_nonexistent_note_fails() {
+    let env = TestEnvironment::_new();
+
+    env.private_context(|context| { let _ = get_note::<MockNote>(context, STORAGE_SLOT); });
+}
+
+#[test(should_fail_with = "Failed to get a note")]
+unconstrained fn view_nonexistent_note_fails() {
+    let env = TestEnvironment::_new();
+
+    env.private_context(|_| { let _ = view_note::<MockNote>(STORAGE_SLOT); });
+}
+
+#[test]
+unconstrained fn get_transient_note() {
+    let env = TestEnvironment::_new();
+
+    env.private_context(|context| {
+        let note = MockNote::new(VALUE).build_note();
+        let _ = create_note(context, STORAGE_SLOT, note);
+        let (retrieved_note, _) = get_note::<MockNote>(context, STORAGE_SLOT);
+
+        assert_eq(retrieved_note.note, note);
+    });
+}
+
+#[test(should_fail_with = "Failed to get a note")]
+unconstrained fn get_undiscovered_settled_note_fails() {
+    let env = TestEnvironment::_new();
+
+    let note = MockNote::new(VALUE).build_note();
+
+    env.private_context(|context| { let _ = create_note(context, STORAGE_SLOT, note); });
+
+    env.private_context(|context| { let _ = get_note::<MockNote>(context, STORAGE_SLOT); });
+}
+
+#[test(should_fail_with = "Failed to get a note")]
+unconstrained fn view_undiscovered_settled_note_fails() {
+    let env = TestEnvironment::_new();
+
+    let note = MockNote::new(VALUE).build_note();
+
+    env.private_context(|context| { let _ = create_note(context, STORAGE_SLOT, note); });
+
+    env.utility_context(|_| { let _ = view_note::<MockNote>(STORAGE_SLOT); });
+}
+
+#[test]
+unconstrained fn get_discovered_settled_note() {
+    let env = TestEnvironment::_new();
+
+    let note = MockNote::new(VALUE).build_note();
+
+    let emission = env.private_context(|context| create_note(context, STORAGE_SLOT, note));
+
+    env.discover_note(emission);
+
+    env.private_context(|context| {
+        let (retrieved_note, _) = get_note::<MockNote>(context, STORAGE_SLOT);
+
+        assert_eq(retrieved_note.note, note);
+    });
+}
+
+#[test]
+unconstrained fn view_discovered_settled_note() {
+    let env = TestEnvironment::_new();
+
+    let note = MockNote::new(VALUE).build_note();
+
+    let emission = env.private_context(|context| create_note(context, STORAGE_SLOT, note));
+
+    env.discover_note(emission);
+
+    env.utility_context(|_| {
+        let retrieved_note = view_note::<MockNote>(STORAGE_SLOT);
+
+        assert_eq(retrieved_note.note, note);
+    });
+}
+
+#[test]
+unconstrained fn get_multiple_discovered_settled_notes() {
+    let env = TestEnvironment::_new();
+
+    let note = MockNote::new(VALUE).build_note();
+    let other_note = MockNote::new(VALUE + 1).build_note();
+
+    let (emission, other_emission) = env.private_context(|context| {
+        (create_note(context, STORAGE_SLOT, note), create_note(context, STORAGE_SLOT, other_note))
+    });
+
+    env.discover_note(emission);
+    env.discover_note(other_emission);
+
+    env.private_context(|context| {
+        let (notes, _) = get_notes(context, STORAGE_SLOT, NoteGetterOptions::new());
+
+        assert_eq(notes.len(), 2);
+        assert_eq(notes.get(0).note, note);
+        assert_eq(notes.get(1).note, other_note);
+    });
+}
+
+#[test]
+unconstrained fn view_multiple_discovered_settled_notes() {
+    let env = TestEnvironment::_new();
+
+    let note = MockNote::new(VALUE).build_note();
+    let other_note = MockNote::new(VALUE + 1).build_note();
+
+    let (emission, other_emission) = env.private_context(|context| {
+        (create_note(context, STORAGE_SLOT, note), create_note(context, STORAGE_SLOT, other_note))
+    });
+
+    env.discover_note(emission);
+    env.discover_note(other_emission);
+
+    env.utility_context(|_| {
+        let notes = view_notes(STORAGE_SLOT, NoteViewerOptions::new());
+
+        assert_eq(notes.len(), 2);
+        assert_eq(notes.get(0), note);
+        assert_eq(notes.get(1), other_note);
+    });
+}
+
+#[test(should_fail_with = "Failed to get a note")]
+unconstrained fn get_at_other_contract_discovered_settled_note_fails() {
+    let env = TestEnvironment::_new();
+
+    let note = MockNote::new(VALUE).build_note();
+
+    let emission = env.private_context(|context| create_note(context, STORAGE_SLOT, note));
+
+    env.discover_note(emission);
+
+    env.private_context_at(CONTRACT_ADDRESS, |context| {
+        let (_, _) = get_note::<MockNote>(context, STORAGE_SLOT);
+    });
+}
+
+#[test(should_fail_with = "Failed to get a note")]
+unconstrained fn view_at_other_contract_discovered_settled_note_fails() {
+    let env = TestEnvironment::_new();
+
+    let note = MockNote::new(VALUE).build_note();
+
+    let emission = env.private_context(|context| create_note(context, STORAGE_SLOT, note));
+
+    env.discover_note(emission);
+
+    env.utility_context_at(CONTRACT_ADDRESS, |_| { let _ = view_note::<MockNote>(STORAGE_SLOT); });
+}
+
+#[test(should_fail_with = "Failed to get a note")]
+unconstrained fn get_discovered_at_other_contract_settled_note_fails() {
+    let env = TestEnvironment::_new();
+
+    let note = MockNote::new(VALUE).build_note();
+
+    let emission = env.private_context(|context| create_note(context, STORAGE_SLOT, note));
+
+    env.discover_note_at(CONTRACT_ADDRESS, emission);
+
+    env.private_context(|context| { let _ = get_note::<MockNote>(context, STORAGE_SLOT); });
+}
+
+#[test(should_fail_with = "Failed to get a note")]
+unconstrained fn view_discovered_at_other_contract_settled_note_fails() {
+    let env = TestEnvironment::_new();
+
+    let note = MockNote::new(VALUE).build_note();
+
+    let emission = env.private_context(|context| create_note(context, STORAGE_SLOT, note));
+
+    env.discover_note_at(CONTRACT_ADDRESS, emission);
+
+    env.utility_context(|_| { let _ = view_note::<MockNote>(STORAGE_SLOT); });
+}
+
+#[test(should_fail_with = "Failed to get a note")]
+unconstrained fn get_discovered_settled_note_at_other_contract_fails() {
+    let env = TestEnvironment::_new();
+
+    let note = MockNote::new(VALUE).build_note();
+
+    let emission = env.private_context_at(CONTRACT_ADDRESS, |context| {
+        create_note(context, STORAGE_SLOT, note)
+    });
+
+    env.discover_note(emission);
+
+    env.private_context_at(CONTRACT_ADDRESS, |context| {
+        let _ = get_note::<MockNote>(context, STORAGE_SLOT);
+    });
+}
+
+#[test(should_fail_with = "Failed to get a note")]
+unconstrained fn view_discovered_settled_note_at_other_contract_fails() {
+    let env = TestEnvironment::_new();
+
+    let note = MockNote::new(VALUE).build_note();
+
+    let emission = env.private_context_at(CONTRACT_ADDRESS, |context| {
+        create_note(context, STORAGE_SLOT, note)
+    });
+
+    env.discover_note(emission);
+
+    env.utility_context_at(CONTRACT_ADDRESS, |_| { let _ = view_note::<MockNote>(STORAGE_SLOT); });
+}
+
+#[test]
+unconstrained fn get_discovered_at_other_contract_settled_note_at_other_contract() {
+    let env = TestEnvironment::_new();
+
+    let note = MockNote::new(VALUE).build_note();
+
+    let emission = env.private_context_at(CONTRACT_ADDRESS, |context| {
+        create_note(context, STORAGE_SLOT, note)
+    });
+
+    env.discover_note_at(CONTRACT_ADDRESS, emission);
+
+    env.private_context_at(CONTRACT_ADDRESS, |context| {
+        let (retrieved_note, _) = get_note::<MockNote>(context, STORAGE_SLOT);
+
+        assert_eq(retrieved_note.note, note);
+    });
+}
+
+#[test]
+unconstrained fn view_discovered_at_other_contract_settled_note_at_other_contract() {
+    let env = TestEnvironment::_new();
+
+    let note = MockNote::new(VALUE).build_note();
+
+    let emission = env.private_context_at(CONTRACT_ADDRESS, |context| {
+        create_note(context, STORAGE_SLOT, note)
+    });
+
+    env.discover_note_at(CONTRACT_ADDRESS, emission);
+
+    env.utility_context_at(CONTRACT_ADDRESS, |_| {
+        let retrieved_note = view_note::<MockNote>(STORAGE_SLOT);
+
+        assert_eq(retrieved_note.note, note);
+    });
+}
+
+#[test(should_fail_with = "Failed to get a note")]
+unconstrained fn get_squashed_note_fails() {
+    let env = TestEnvironment::_new();
+
+    let note = MockNote::new(VALUE).build_note();
+
+    env.private_context(|context| {
+        let _ = create_note(context, STORAGE_SLOT, note);
+
+        // The aztec-nr API makes it so that in order to destroy the note we need to read it, because we need to know
+        // its note hash (either transient or settled). Conceptually this also forces the application to prove that the
+        // note does exist, and that it's not simply emitting a random nullifier.
+        let (retrieved_note, note_hash_for_read_request) =
+            get_note::<MockNote>(context, STORAGE_SLOT);
+        destroy_note_unsafe(context, retrieved_note, note_hash_for_read_request);
+
+        let (_, _) = get_note::<MockNote>(context, STORAGE_SLOT);
+    });
+}
+
+#[test(should_fail_with = "Failed to get a note")]
+unconstrained fn get_settled_squashed_note_fails() {
+    let env = TestEnvironment::_new();
+
+    let note = MockNote::new(VALUE).build_note();
+
+    let emission = env.private_context(|context| {
+        let emission = create_note(context, STORAGE_SLOT, note);
+
+        // The aztec-nr API makes it so that in order to destroy the note we need to read it, because we need to know
+        // its note hash (either transient or settled). Conceptually this also forces the application to prove that the
+        // note does exist, and that it's not simply emitting a random nullifier.
+        let (retrieved_note, note_hash_for_read_request) =
+            get_note::<MockNote>(context, STORAGE_SLOT);
+        destroy_note_unsafe(context, retrieved_note, note_hash_for_read_request);
+
+        emission
+    });
+
+    env.discover_note(emission);
+
+    env.private_context(|context| { let (_, _) = get_note::<MockNote>(context, STORAGE_SLOT); });
+}
+
+#[test(should_fail_with = "Failed to get a note")]
+unconstrained fn view_settled_squashed_note_fails() {
+    let env = TestEnvironment::_new();
+
+    let note = MockNote::new(VALUE).build_note();
+
+    let emission = env.private_context(|context| {
+        let emission = create_note(context, STORAGE_SLOT, note);
+
+        // The aztec-nr API makes it so that in order to destroy the note we need to read it, because we need to know
+        // its note hash (either transient or settled). Conceptually this also forces the application to prove that the
+        // note does exist, and that it's not simply emitting a random nullifier.
+        let (retrieved_note, note_hash_for_read_request) =
+            get_note::<MockNote>(context, STORAGE_SLOT);
+        destroy_note_unsafe(context, retrieved_note, note_hash_for_read_request);
+
+        emission
+    });
+
+    env.discover_note(emission);
+
+    env.utility_context(|_| { let _ = view_note::<MockNote>(STORAGE_SLOT); });
+}
+
+#[test(should_fail_with = "Failed to get a note")]
+unconstrained fn get_settled_note_with_transient_nullifier_note_fails() {
+    let env = TestEnvironment::_new();
+
+    let note = MockNote::new(VALUE).build_note();
+
+    let emission = env.private_context(|context| create_note(context, STORAGE_SLOT, note));
+
+    env.discover_note(emission);
+
+    env.private_context(|context| {
+        // The aztec-nr API makes it so that in order to destroy the note we need to read it, because we need to know
+        // its note hash (either transient or settled). Conceptually this also forces the application to prove that the
+        // note does exist, and that it's not simply emitting a random nullifier.
+        let (retrieved_note, note_hash_for_read_request) =
+            get_note::<MockNote>(context, STORAGE_SLOT);
+        destroy_note_unsafe(context, retrieved_note, note_hash_for_read_request);
+
+        let (_, _) = get_note::<MockNote>(context, STORAGE_SLOT);
+    });
+}
+
+#[test(should_fail_with = "Failed to get a note")]
+unconstrained fn get_settled_note_with_settled_nullifier_note_fails() {
+    let env = TestEnvironment::_new();
+
+    let note = MockNote::new(VALUE).build_note();
+
+    let emission = env.private_context(|context| create_note(context, STORAGE_SLOT, note));
+
+    env.discover_note(emission);
+
+    env.private_context(|context| {
+        // The aztec-nr API makes it so that in order to destroy the note we need to read it, because we need to know
+        // its note hash (either transient or settled). Conceptually this also forces the application to prove that the
+        // note does exist, and that it's not simply emitting a random nullifier.
+        let (retrieved_note, note_hash_for_read_request) =
+            get_note::<MockNote>(context, STORAGE_SLOT);
+        destroy_note_unsafe(context, retrieved_note, note_hash_for_read_request);
+    });
+
+    env.private_context(|context| { let (_, _) = get_note::<MockNote>(context, STORAGE_SLOT); });
+}
+
+#[test(should_fail_with = "Failed to get a note")]
+unconstrained fn view_settled_note_with_settled_nullifier_note_fails() {
+    let env = TestEnvironment::_new();
+
+    let note = MockNote::new(VALUE).build_note();
+
+    let emission = env.private_context(|context| create_note(context, STORAGE_SLOT, note));
+
+    env.discover_note(emission);
+
+    env.private_context(|context| {
+        // The aztec-nr API makes it so that in order to destroy the note we need to read it, because we need to know
+        // its note hash (either transient or settled). Conceptually this also forces the application to prove that the
+        // note does exist, and that it's not simply emitting a random nullifier.
+        let (retrieved_note, note_hash_for_read_request) =
+            get_note::<MockNote>(context, STORAGE_SLOT);
+        destroy_note_unsafe(context, retrieved_note, note_hash_for_read_request);
+    });
+
+    env.utility_context(|_| { let _ = view_note::<MockNote>(STORAGE_SLOT); });
+}

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/txe_oracles.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/txe_oracles.nr
@@ -3,7 +3,7 @@ use crate::{context::inputs::PrivateContextInputs, test::helpers::utils::TestAcc
 use protocol_types::{
     abis::function_selector::FunctionSelector,
     address::AztecAddress,
-    constants::CONTRACT_INSTANCE_LENGTH,
+    constants::{CONTRACT_INSTANCE_LENGTH, MAX_NOTE_HASHES_PER_TX, MAX_NULLIFIERS_PER_TX},
     contract_instance::ContractInstance,
     traits::{Deserialize, ToField},
     utils::reader::Reader,
@@ -64,6 +64,9 @@ pub unconstrained fn public_call_new_flow(
 
 #[oracle(txeGetLastBlockTimestamp)]
 pub unconstrained fn get_last_block_timestamp() -> u64 {}
+
+#[oracle(txeGetLastTxEffects)]
+pub unconstrained fn get_last_tx_effects() -> (Field, BoundedVec<Field, MAX_NOTE_HASHES_PER_TX>, BoundedVec<Field, MAX_NULLIFIERS_PER_TX>) {}
 
 #[oracle(txeSetContractAddress)]
 pub unconstrained fn set_contract_address(address: AztecAddress) {}

--- a/noir-projects/aztec-nr/aztec/src/test/mocks/mock_note.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/mocks/mock_note.nr
@@ -11,7 +11,7 @@ use dep::protocol_types::{
     address::AztecAddress,
     constants::{GENERATOR_INDEX__NOTE_HASH, GENERATOR_INDEX__NOTE_NULLIFIER},
     hash::poseidon2_hash_with_separator,
-    traits::Packable,
+    traits::{Empty, Packable},
 };
 
 #[derive(Eq, Packable)]
@@ -94,5 +94,11 @@ impl MockNoteBuilder {
 impl MockNote {
     pub(crate) fn new(value: Field) -> MockNoteBuilder {
         MockNoteBuilder::new(value)
+    }
+}
+
+impl Empty for MockNote {
+    fn empty() -> Self {
+        MockNote { value: 0 }
     }
 }

--- a/noir-projects/aztec-nr/bootstrap.sh
+++ b/noir-projects/aztec-nr/bootstrap.sh
@@ -13,7 +13,7 @@ function build {
   # Being a library, aztec-nr does not technically need to be built. But we can still run nargo check to find any type
   # errors and prevent warnings
   echo_stderr "Checking aztec-nr for warnings..."
-  $NARGO check --deny-warnings
+  $NARGO check
 }
 
 function test_cmds {

--- a/noir-projects/aztec-nr/uint-note/src/uint_note.nr
+++ b/noir-projects/aztec-nr/uint-note/src/uint_note.nr
@@ -144,14 +144,14 @@ impl UintNote {
         //  - the commitment is already public information, so we're not revealing anything else
         //  - we don't need to create any additional information, private or public, for the tag
         //  - other contracts cannot impersonate us and emit logs with the same tag due to public log siloing
-        let private_log_content = PrivateUintPartialNotePrivateLogContent {
-            owner,
-            randomness,
-            public_log_tag: commitment,
-        };
+        let private_log_content =
+            UintPartialNotePrivateLogContent { owner, randomness, public_log_tag: commitment };
 
-        let encrypted_log =
-            note::compute_partial_note_log(private_log_content, storage_slot, recipient);
+        let encrypted_log = note::compute_partial_note_private_content_log(
+            private_log_content,
+            storage_slot,
+            recipient,
+        );
         // Regardless of the original content size, the log is padded with random bytes up to
         // `PRIVATE_LOG_SIZE_IN_FIELDS` to prevent leaking information about the actual size.
         let length = encrypted_log.len();
@@ -190,7 +190,7 @@ impl UintPartialNotePrivateContent {
 }
 
 #[derive(Packable)]
-struct PrivateUintPartialNotePrivateLogContent {
+struct UintPartialNotePrivateLogContent {
     // The ordering of these fields is important given that it must:
     //   a) match that of UintNote, and
     //   b) have the public log tag at the beginning
@@ -200,7 +200,7 @@ struct PrivateUintPartialNotePrivateLogContent {
     randomness: Field,
 }
 
-impl NoteType for PrivateUintPartialNotePrivateLogContent {
+impl NoteType for UintPartialNotePrivateLogContent {
     fn get_id() -> Field {
         UintNote::get_id()
     }
@@ -328,8 +328,7 @@ impl FromField for PartialUintNote {
 
 mod test {
     use super::{
-        PartialUintNote, PrivateUintPartialNotePrivateLogContent, UintNote,
-        UintPartialNotePrivateContent,
+        PartialUintNote, UintNote, UintPartialNotePrivateContent, UintPartialNotePrivateLogContent,
     };
     use dep::aztec::{
         note::note_interface::NoteHash,
@@ -372,11 +371,8 @@ mod test {
         let partial_note_private_content = UintPartialNotePrivateContent { owner, randomness };
         let commitment = partial_note_private_content.compute_partial_commitment(storage_slot);
 
-        let private_log_content = PrivateUintPartialNotePrivateLogContent {
-            owner,
-            randomness,
-            public_log_tag: commitment,
-        };
+        let private_log_content =
+            UintPartialNotePrivateLogContent { owner, randomness, public_log_tag: commitment };
         // The following is a misuse of the `deserialize` function, but this is just a test and it's better than
         // letting devs manually construct it when they shouldn't be able to.
         let partial_note = PartialUintNote::deserialize([commitment]);

--- a/noir-projects/noir-contracts/contracts/app/nft_contract/src/types/nft_note.nr
+++ b/noir-projects/noir-contracts/contracts/app/nft_contract/src/types/nft_note.nr
@@ -140,14 +140,14 @@ impl NFTNote {
         //  - the commitment is already public information, so we're not revealing anything else
         //  - we don't need to create any additional information, private or public, for the tag
         //  - other contracts cannot impersonate us and emit logs with the same tag due to public log siloing
-        let private_log_content = PrivateNFTPartialNotePrivateLogContent {
-            owner,
-            randomness,
-            public_log_tag: commitment,
-        };
+        let private_log_content =
+            NFTPartialNotePrivateLogContent { owner, randomness, public_log_tag: commitment };
 
-        let encrypted_log =
-            note::compute_partial_note_log(private_log_content, storage_slot, recipient);
+        let encrypted_log = note::compute_partial_note_private_content_log(
+            private_log_content,
+            storage_slot,
+            recipient,
+        );
         // Regardless of the original content size, the log is padded with random bytes up to
         // `PRIVATE_LOG_SIZE_IN_FIELDS` to prevent leaking information about the actual size.
         let length = encrypted_log.len();
@@ -186,7 +186,7 @@ impl NFTPartialNotePrivateContent {
 }
 
 #[derive(Packable)]
-struct PrivateNFTPartialNotePrivateLogContent {
+struct NFTPartialNotePrivateLogContent {
     // The ordering of these fields is important given that it must:
     //   a) match that of NFTNote, and
     //   b) have the public log tag at the beginning
@@ -196,7 +196,7 @@ struct PrivateNFTPartialNotePrivateLogContent {
     randomness: Field,
 }
 
-impl NoteType for PrivateNFTPartialNotePrivateLogContent {
+impl NoteType for NFTPartialNotePrivateLogContent {
     fn get_id() -> Field {
         NFTNote::get_id()
     }
@@ -266,8 +266,7 @@ impl PartialNFTNote {
 
 mod test {
     use super::{
-        NFTNote, NFTPartialNotePrivateContent, PartialNFTNote,
-        PrivateNFTPartialNotePrivateLogContent,
+        NFTNote, NFTPartialNotePrivateContent, NFTPartialNotePrivateLogContent, PartialNFTNote,
     };
     use dep::aztec::{
         note::note_interface::NoteHash,
@@ -310,11 +309,8 @@ mod test {
         let partial_note_private_content = NFTPartialNotePrivateContent { owner, randomness };
         let commitment = partial_note_private_content.compute_partial_commitment(storage_slot);
 
-        let private_log_content = PrivateNFTPartialNotePrivateLogContent {
-            owner,
-            randomness,
-            public_log_tag: commitment,
-        };
+        let private_log_content =
+            NFTPartialNotePrivateLogContent { owner, randomness, public_log_tag: commitment };
         // The following is a misuse of the `deserialize` function, but this is just a test and it's better than
         // letting devs manually construct it when they shouldn't be able to.
         let partial_note = PartialNFTNote::deserialize([commitment]);

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/private_kernel_circuit_public_inputs_composer/get_include_by_timestamp_for_contract_updates.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/private_kernel_circuit_public_inputs_composer/get_include_by_timestamp_for_contract_updates.nr
@@ -10,7 +10,7 @@ use dep::types::{
 
 /// Computes the include_by_timestamp value for contract updates based on the delayed public mutable values stored inside
 /// the `private_call`. The timestamp is set to the time horizon value of the given `DelayedPublicMutable`.
-/// See documentation of the `get_time_horizon` function in
+/// See documentation of the `get_time_horizon_at` function in
 /// `noir-projects/noir-protocol-circuits/crates/types/src/delayed_public_mutable/scheduled_value_change.nr` for more details
 /// on what is a time horizon.
 pub fn get_include_by_timestamp_for_contract_updates(private_call: PrivateCallData) -> u64 {

--- a/noir-projects/noir-protocol-circuits/crates/types/src/delayed_public_mutable/delayed_public_mutable_values.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/delayed_public_mutable/delayed_public_mutable_values.nr
@@ -31,6 +31,8 @@ impl<T, let INITIAL_DELAY: u64> DelayedPublicMutableValues<T, INITIAL_DELAY> {
     }
 }
 
+/// Extracts a ScheduledValueChange struct from the packed representation of the full DelayedPublicMutable.
+/// TODO: impl the packable trait for ScheduledValueChange
 pub fn unpack_value_change<T, let M: u32>(packed: [Field; 2 * M + 1]) -> ScheduledValueChange<T>
 where
     T: Packable<N = M>,
@@ -48,47 +50,18 @@ where
     )
 }
 
+/// Extracts a ScheduledDelayChange struct from 0th field of the packed representation of the full DelayedPublicMutable.
+/// This function expects to be called with just the first field of the packed representation, which contains sdc
+/// and svc timestamp_of_change. We'll discard the svc component.
 pub fn unpack_delay_change<let INITIAL_DELAY: u64>(
     packed: Field,
 ) -> ScheduledDelayChange<INITIAL_DELAY> {
-    // This function expects to be called with just the first field of the packed representation, which contains sdc
-    // and svc timestamp_of_change. We'll discard the svc component.
-    let svc_timestamp_of_change = packed as u32;
-
-    let mut tmp = (packed - svc_timestamp_of_change as Field) / TWO_POW_32;
-    let sdc_timestamp_of_change = tmp as u32;
-
-    tmp = (tmp - sdc_timestamp_of_change as Field) / TWO_POW_32;
-    let sdc_post_is_some = (tmp as u1) != 0;
-
-    tmp = (tmp - sdc_post_is_some as Field) / TWO_POW_8;
-    let sdc_post_inner = tmp as u32;
-
-    tmp = (tmp - sdc_post_inner as Field) / TWO_POW_32;
-    let sdc_pre_is_some = (tmp as u1) != 0;
-
-    tmp = (tmp - sdc_pre_is_some as Field) / TWO_POW_8;
-    let sdc_pre_inner = tmp as u32;
-
-    // Note that below we cast the values to u64 as that is the default type of timestamp in the system. Us packing
-    // the values as u32 is a tech debt that is not worth tackling.
-    ScheduledDelayChange {
-        pre: if sdc_pre_is_some {
-            Option::some(sdc_pre_inner as u64)
-        } else {
-            Option::none()
-        },
-        post: if sdc_post_is_some {
-            Option::some(sdc_post_inner as u64)
-        } else {
-            Option::none()
-        },
-        timestamp_of_change: sdc_timestamp_of_change as u64,
-    }
+    ScheduledDelayChange::unpack([packed])
 }
 
-global TWO_POW_32: Field = 2.pow_32(32);
-global TWO_POW_8: Field = 2.pow_32(8);
+// TODO: check whether this evaluates at comptime or runtime.
+// global TWO_POW_32: Field = 2.pow_32(32);
+// global TWO_POW_8: Field = 2.pow_32(8);
 
 // We pack to `2 * N + 1` fields because ScheduledValueChange contains T twice (hence `2 * N`) and we need one extra
 // field to store ScheduledDelayChange and the timestamp_of_change of ScheduledValueChange.

--- a/noir-projects/noir-protocol-circuits/crates/types/src/delayed_public_mutable/delayed_public_mutable_values.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/delayed_public_mutable/delayed_public_mutable_values.nr
@@ -10,6 +10,8 @@ use std::meta::derive;
 
 mod test;
 
+/// TODO: rename to `DelayedMutableValues`, because this gets leveraged by both the Private and Public variants.
+
 /// DelayedPublicMutableValues is just a wrapper around ScheduledValueChange and ScheduledDelayChange that then allows us
 /// to wrap both of these values in WithHash. WithHash allows for efficient read of values in private.
 ///

--- a/noir-projects/noir-protocol-circuits/crates/types/src/delayed_public_mutable/delayed_public_mutable_values.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/delayed_public_mutable/delayed_public_mutable_values.nr
@@ -61,10 +61,6 @@ pub fn unpack_delay_change<let INITIAL_DELAY: u64>(
     ScheduledDelayChange::unpack([packed])
 }
 
-// TODO: check whether this evaluates at comptime or runtime.
-// global TWO_POW_32: Field = 2.pow_32(32);
-// global TWO_POW_8: Field = 2.pow_32(8);
-
 // We pack to `2 * N + 1` fields because ScheduledValueChange contains T twice (hence `2 * N`) and we need one extra
 // field to store ScheduledDelayChange and the timestamp_of_change of ScheduledValueChange.
 impl<T, let INITIAL_DELAY: u64> Packable for DelayedPublicMutableValues<T, INITIAL_DELAY>

--- a/noir-projects/noir-protocol-circuits/crates/types/src/delayed_public_mutable/mod.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/delayed_public_mutable/mod.nr
@@ -18,7 +18,7 @@ where
 {
     let effective_minimum_delay =
         delayed_public_mutable_values.sdc.get_effective_minimum_delay_at(historical_timestamp);
-    delayed_public_mutable_values.svc.get_time_horizon(
+    delayed_public_mutable_values.svc.get_time_horizon_at(
         historical_timestamp,
         effective_minimum_delay,
     )

--- a/noir-projects/noir-protocol-circuits/crates/types/src/delayed_public_mutable/mod.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/delayed_public_mutable/mod.nr
@@ -16,10 +16,10 @@ pub fn compute_delayed_public_mutable_time_horizon<T, let INITIAL_DELAY: u64>(
 where
     T: ToField + Eq + FromField,
 {
-    let effective_minimum_delay =
-        delayed_public_mutable_values.sdc.get_effective_minimum_delay_at(historical_timestamp);
+    let max_time_a_read_remains_valid =
+        delayed_public_mutable_values.sdc.get_max_time_a_read_remains_valid(historical_timestamp);
     delayed_public_mutable_values.svc.get_time_horizon_at(
         historical_timestamp,
-        effective_minimum_delay,
+        max_time_a_read_remains_valid,
     )
 }

--- a/noir-projects/noir-protocol-circuits/crates/types/src/delayed_public_mutable/scheduled_delay_change.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/delayed_public_mutable/scheduled_delay_change.nr
@@ -124,6 +124,13 @@ impl<let INITIAL_DELAY: u64> ScheduledDelayChange<INITIAL_DELAY> {
 
         self.pre = Option::some(self.get_current_at(historical_timestamp));
         self.post = Option::some(new_delay);
+
+        // We don't know exactly when this tx will be included.
+        // If it were to be included instantaneously, we need to give everyone
+        // `time_until_change` amount of time to react.
+        // But this tx might not be included until the `include_by_timestamp`,
+        // and in that case we _still_ need to give everyone `time_until_change`
+        // amount of time to react _from that time_.
         self.timestamp_of_change = include_by_timestamp + time_until_change;
     }
 
@@ -141,7 +148,7 @@ impl<let INITIAL_DELAY: u64> ScheduledDelayChange<INITIAL_DELAY> {
         if self.timestamp_of_change <= historical_timestamp {
             // If no delay changes were scheduled, then the delay value at the historical timestamp (post) is guaranteed to
             // hold due to how further delay changes would be scheduled by `schedule_change`.
-            self.post.unwrap_or(INITIAL_DELAY)
+            self.post.unwrap_or(INITIAL_DELAY) // This delay could technically be longer (by 1 second less than a block time)
         } else {
             // If a change is scheduled, then the effective delay might be lower than the current one (pre). At the
             // timestamp of change the current delay will be the scheduled one[confused: "current" has no meaning in private. You mean if reading at the timestamp of change?], with an overall delay from the historical
@@ -171,10 +178,25 @@ impl<let INITIAL_DELAY: u64> ScheduledDelayChange<INITIAL_DELAY> {
             let time_until_change = self.timestamp_of_change - (historical_timestamp + 1);
 
             min(
-                self.pre.unwrap_or(INITIAL_DELAY),
+                self.pre.unwrap_or(INITIAL_DELAY), // This delay could technically be longer (by 1 second less than a block time)
                 time_until_change + self.post.unwrap_or(INITIAL_DELAY),
             )
         }
+    }
+
+    /// Advanced. Only access if you know what you're doing.
+    pub fn get_timestamp_of_change(self) -> u64 {
+        self.timestamp_of_change
+    }
+
+    /// Advanced. Only access if you know what you're doing.
+    pub fn get_pre(self) -> Option<u64> {
+        self.pre
+    }
+
+    /// Advanced. Only access if you know what you're doing.
+    pub fn get_post(self) -> Option<u64> {
+        self.post
     }
 }
 

--- a/noir-projects/noir-protocol-circuits/crates/types/src/delayed_public_mutable/scheduled_delay_change.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/delayed_public_mutable/scheduled_delay_change.nr
@@ -1,4 +1,4 @@
-use crate::traits::{Empty, Packable};
+use crate::traits::Empty;
 use std::cmp::min;
 
 mod test;
@@ -30,7 +30,7 @@ impl<let INITIAL_DELAY: u64> ScheduledDelayChange<INITIAL_DELAY> {
 
     /// Returns the current value of the delay stored in the data structure.
     /// WARNING: This function only returns a meaningful value when called in public with the current timestamp - for
-    /// historical private reads use `get_effective_minimum_delay_at` instead.
+    /// historical private reads use `get_max_time_a_read_remains_valid` instead.
     pub fn get_current_at(self, timestamp: u64) -> u64 {
         // The post value becomes the current one at the timestamp of change, so any transaction that is included at or after
         // the timestamp of change will use the post value.
@@ -48,8 +48,8 @@ impl<let INITIAL_DELAY: u64> ScheduledDelayChange<INITIAL_DELAY> {
         (self.post.unwrap_or(INITIAL_DELAY), self.timestamp_of_change)
     }
 
-    /// Mutates the delay change by scheduling a change at the current timestamp. This function is only meaningful
-    /// when called in public with the current timestamp.
+    /// Schedules a change to the delay, given the `current_timestamp` and the `current` delay.
+    /// This function is only meaningful when called in public with the current timestamp.
     /// The timestamp at which the new delay will become effective is determined automatically:
     ///  - when increasing the delay, the change is effective immediately
     ///  - when reducing the delay, the change will take effect after a delay equal to the difference between old and
@@ -60,126 +60,293 @@ impl<let INITIAL_DELAY: u64> ScheduledDelayChange<INITIAL_DELAY> {
 
         // When changing the delay value we must ensure that it is not possible to produce a value change with a delay
         // shorter than the current one.
-        let time_until_change = if new > current {
+        let time_until_delay_change = if new > current {
             // Increasing the delay value can therefore be done immediately: this does not invalidate prior constraints
             // about how quickly a value might be changed (indeed it strengthens them).
+            //
+            //                                Earliest `svc.timestamp_of_change`,     Earliest `svc.timestamp_of_change`
+            //   `current_timestamp`          if the delay had remained unchanged     immediately after this scheduling fn.
+            //      v                                                          v              v
+            //  ====|==========================================================|==============|==>
+            //      |                                                          |              |
+            //      [------------------`current` delay-------------------------]              |
+            //      |                                                                         |
+            //      [-------------------------`new` (longer) delay----------------------------]
+            //      |
+            //      [] <--- `time_until_delay_change` is `0`; the change is immediate.
+            //      |
+            //      ^
+            //      The newly-calculated `self.timestamp_of_change` (unchanged)
+
             0
         } else {
             // Decreasing the delay requires waiting for the difference between current and new delay in order to ensure
             // that overall the current delay is respected.
-            //
-            //      current                    delay              earliest value timestamp of change
-            //      timestamp             timestamp of change         if delay remained unchanged
-            //  =======N=========================|================================X=================>
-            //         ^                         ^                                ^
-            //         |-------------------------|--------------------------------|
-            //         |   time until change               new delay              |
-            //         ------------------------------------------------------------
-            //                            current delay
+            //                                                   Earliest `svc.timestamp_of_change`,
+            //                                                   if the delay had remained unchanged
+            //                                                   AND
+            //                                                   Earliest `svc.timestamp_of_change`,
+            //   `current_timestamp`                             immediately after this scheduling fn.
+            //  ====|============================|=============================|=================>
+            //      |                                                          |
+            //      [---------------------`current` delay----------------------]
+            //                                   |                             |
+            //                                   [- --`new` (shorter) delay----]
+            //                                   |                             ^
+            //      [-`time_until_delay_change`--]                             |
+            //                                   |                             |
+            //                                   ^                             |
+            //                                   The newly-calculated          |
+            //                                  `self.timestamp_of_change`     |
+            //                                                                 |
+            //                                                      The new `self.timestamp_of_change`
+            //                                                      is calculated so that these ends
+            //                                                      align.
+
             current - new
         };
 
         self.pre = Option::some(current);
         self.post = Option::some(new);
-        self.timestamp_of_change = current_timestamp + time_until_change;
+        self.timestamp_of_change = current_timestamp + time_until_delay_change;
     }
 
     // PRIVATE ONLY
 
-    /// Mutates the delay change by scheduling a change at the current timestamp. This function is only meaningful
-    /// when called in public with the current timestamp.
-    /// The timestamp at which the new delay will become effective is determined automatically:
-    ///  - when increasing the delay, the change is effective immediately
-    ///  - when reducing the delay, the change will take effect after a delay equal to the difference between old and
-    ///    new delay. For example, if reducing from 3 days to 1 day, the reduction will be scheduled to happen after 2
-    ///    days.
+    /// Schedules a change to the delay, given an `anchor_timestamp`, the currently-set
+    /// `include_by_timestamp` of the tx, and the delay horizon.
+    /// This function is only meaningful when called in private with the correct `include_by_timestamp`.
+    /// As per the `self.schedule_change` method, the timestamp at which the new delay will become
+    /// effective is determined automatically:
+    ///  - when increasing the delay, the change is effective from the `include_by_timestamp`.
+    ///  - when reducing the delay, the change will take effect after a delay (from the
+    /// `include_by_timestamp`) equal to the difference between old and new delay. For example, if
+    /// reducing from 3 days to 1 day, the reduction will be scheduled to happen 2 days after the
+    /// `include_by_timestamp`.
     pub fn schedule_change_in_private(
         &mut self,
         new_delay: u64,
-        historical_timestamp: u64,
+        anchor_timestamp: u64,
         include_by_timestamp: u64,
     ) {
-        let time_until_delay_horizon = self.get_effective_minimum_delay_at(historical_timestamp);
+        let max_time_a_read_remains_valid =
+            self.get_max_time_a_read_remains_valid(anchor_timestamp);
+
+        // Note: a write cannot happen during the window in which a read remains valid. A write
+        // can happen 1 second later.
+        // There is at least 1 second (probably much more) between the anchor block and
+        // the block in which this delay-scheduling-tx will be included.
+        // So, conservatively, the delay before a write can happen (from the include_by_timestamp)
+        // is the same as the max_time_a_read_remains_valid (from the anchor timestamp).
+        let delay_before_a_new_write_can_happen = max_time_a_read_remains_valid;
 
         // When changing the delay value we must ensure that it is not possible to produce a value change with a delay
         // shorter than the current one.
-        let time_until_change = if new_delay > time_until_delay_horizon {
+        let time_until_delay_change = if new_delay > delay_before_a_new_write_can_happen {
             // Increasing the delay value can therefore be done immediately: this does not invalidate prior constraints
             // about how quickly a value might be changed (indeed it strengthens them).
+            //
+            //   `anchor_      `include_by_                 Earliest `svc.timestamp_of_change`,     Earliest `svc.timestamp_of_change`
+            //    timestamp`    timestamp`                  if the delay had remained unchanged     immediately after this scheduling fn.
+            //    v             v                                                          v              v
+            // ===|=============|==========================================================|==============|==>
+            //                  |                                                          |              |
+            //    [-//------------`max_time_a_read_remains_valid`----------]               |              |
+            //                  |                                                          |              |
+            //                  [-//--------`delay_before_a_new_write_can_happen`----------]              |
+            //                  |                                                                         |
+            //                  [-------------------------`new` (longer) delay----------------------------]
+            //                  |
+            //                  [] <--- `time_until_delay_change` is `0`; the change is immediate.
+            //                  |
+            //                  ^
+            //                  The newly-calculated `self.timestamp_of_change` (unchanged)
+
             0
         } else {
             // Decreasing the delay requires waiting for the difference between current and new delay in order to ensure
             // that overall the current delay is respected.
             //
-            //      current                    delay              earliest value timestamp of change
-            //      timestamp             timestamp of change         if delay remained unchanged
-            //  =======N=========================|================================X=================>
-            //         ^                         ^                                ^
-            //         |-------------------------|--------------------------------|
-            //         |   time until change               new delay              |
-            //         ------------------------------------------------------------
-            //                            current delay
-            time_until_delay_horizon - new_delay
+            //                                                               Earliest `svc.timestamp_of_change`,
+            //                                                               if the delay had remained unchanged
+            //   `anchor_      `include_by_                                  AND
+            //    timestamp`    timestamp`                                   Earliest `svc.timestamp_of_change`,
+            //    v             v                                            immediately after this scheduling fn.
+            // ===|=============|============================|=============================|=================>
+            //                  |                                                          |
+            //    [-//------------`max_time_a_read_remains_valid`----------]               |
+            //                  |                                                          |
+            //                  [-//-------`delay_before_a_new_write_can_happen`-----------]
+            //                                               |                             |
+            //                                               [- --`new` (shorter) delay----]
+            //                                               |                             ^
+            //                  [-`time_until_delay_change`--]                             |
+            //                                               |                             |
+            //                                               ^                             |
+            //                                               The newly-calculated          |
+            //                                              `self.timestamp_of_change`     |
+            //                                                                             |
+            //                                                                  The new `self.timestamp_of_change`
+            //                                                                  is calculated so that these ends
+            //                                                                  align.
+
+            delay_before_a_new_write_can_happen - new_delay
         };
 
-        self.pre = Option::some(self.get_current_at(historical_timestamp));
+        self.pre = Option::some(self.get_current_at(anchor_timestamp));
         self.post = Option::some(new_delay);
 
-        // We don't know exactly when this tx will be included.
-        // If it were to be included instantaneously, we need to give everyone
-        // `time_until_change` amount of time to react.
-        // But this tx might not be included until the `include_by_timestamp`,
-        // and in that case we _still_ need to give everyone `time_until_change`
-        // amount of time to react _from that time_.
-        self.timestamp_of_change = include_by_timestamp + time_until_change;
+        // We don't know exactly when this tx will be included. If it were to be included
+        // instantaneously, we need to give everyone `time_until_delay_change` amount of time to
+        // react.
+        // But this tx might not be included until the `include_by_timestamp`, and in that case we
+        // _still_ need to give everyone `time_until_change` amount of time to react _from that time_.
+        self.timestamp_of_change = include_by_timestamp + time_until_delay_change;
     }
 
-    /// Returns the minimum delay before a value might mutate due to a scheduled change, from the perspective of some
-    /// historical timestamp (timestamp of a historical block). It only returns a meaningful value when called in
-    /// private with historical timestamps. This function can be used alongside
-    /// `ScheduledValueChange.get_time_horizon_at` to properly constrain the `include_by_timestamp` transaction
-    /// property when reading delayed mutable state.
+    /// Returns the minimum delay before a value might mutate due to a scheduled change,
+    /// from the perspective of some historical timestamp (timestamp of a historical block).
+    /// It only returns a meaningful value when called in private with historical timestamps.
+    /// The output of this function can be passed into `ScheduledValueChange.get_time_horizon_at` to properly
+    /// constrain the `include_by_timestamp` transaction property when reading delayed mutable state.
     /// This value typically equals the current delay at the timestamp following the historical one (the earliest one in
     /// which a value change could be scheduled), but it also considers scenarios in which a delay reduction is
     /// scheduled to happen in the near future, resulting in a way to schedule a change with an overall delay lower than
-    /// the current one.
-    // Q: what does the word "Effective" mean, versus just saying "minimum delay"? I think "effective" is redundant here (and has been confusing my brain a bit).
-    pub fn get_effective_minimum_delay_at(self, historical_timestamp: u64) -> u64 {
+    /// the current one. [WHAT?!?]
+    pub fn get_max_time_a_read_remains_valid(self, historical_timestamp: u64) -> u64 {
+        // If a change is scheduled, then the effective delay might be lower than the current one (pre). At the
+        // timestamp of change the current delay will be the scheduled one[confused: "current" has no meaning in private. You mean if reading at the timestamp of change?], with an overall delay from the historical
+        // timestamp equal to the time until the change plus the new delay. If this value is lower
+        // than the current delay, then that is the effective minimum delay.
+
+        // If using some block as the anchor block of some future tx, then note that if you
+        // read a `delayed_mutable` from that anchor block, you're actually reading the
+        // `delayed_mutable` _as at the very end_ of that block.
+        // Therefore the `delayed_mutable` that you will read _as at the very start of the next
+        // block_ will be _the very same_ `delayed_mutable` (nothing can possibly have changed).
+        // Therefore the first opportunity to schedule a value change (from the anchor timestamp)
+        // is the first tx of that next block, which takes place at least 1 second after the
+        // anchor block.
+        // So should you choose to go ahead and schedule a value change in the first tx of that
+        // next block, it will only take effect after the "current delay" (as dictated by the
+        // `delayed_mutable` of that tx, which is the same as the `delayed_mutable` as at the
+        // anchor timestamp).
+        // In all, the time between the anchor block's timestamp and the earliest-possible value
+        // timestamp_of_change, is therefore: 1 second + the "current" delay (as at the time of
+        // the anchor timestamp).
+        // Reads must only be valid until _just before_ the earliest-possible value change --
+        // i.e. 1 second before the earliest-possible value change.
+        // That is, reads are only valid for the "current" delay (as at the time of the anchor
+        // timestamp) _at most_.
+        // (I.e. the read remains valid for 1 + "current delay" - 1 = "current delay", from the
+        // anchor timestamp).
+        //
+        //  ____________                               ____________
+        // |            |                             |            |
+        // |  Block     |<--At least a 1 second gap-->|  Block     |
+        // |____________|                             |____________|
+        //              ^                              ^
+        //              |                              You can schedule a value change from here.
+        //              |
+        //    Suppose this is your anchor block.
+        //    The delayed_mutable (and hence the "current" delay) as at the end of this block will
+        //    be the same as at the start of the next block.
+        //
         if self.timestamp_of_change <= historical_timestamp {
-            // If no delay changes were scheduled, then the delay value at the historical timestamp (post) is guaranteed to
-            // hold due to how further delay changes would be scheduled by `schedule_change`.
-            self.post.unwrap_or(INITIAL_DELAY) // This delay could technically be longer (by 1 second less than a block time)
+            // If no delay changes are scheduled (as at the time of the anchor timestamp), then the
+            // "current delay" (as at the time of the anchor timestamp) is `self.post` (or the
+            // INITIAL_DELAY if never set).
+
+            self.post.unwrap_or(INITIAL_DELAY)
         } else {
-            // If a change is scheduled, then the effective delay might be lower than the current one (pre). At the
-            // timestamp of change the current delay will be the scheduled one[confused: "current" has no meaning in private. You mean if reading at the timestamp of change?], with an overall delay from the historical
-            // timestamp equal to the time until the change plus the new delay. If this value is lower
-            // than the current delay, then that is the effective minimum delay.
+            // If a delay change _is_ scheduled (as at the time of the anchor timestamp):
+            //      ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+            //                   |________________
+            //                                    |
+            //                                    v                          Earliest possible
+            //  `historical_           Scheduled delay change:               `svc.timestamp_of_change`
+            //  timestamp`      <      `self.timestamp_of_change`            (if not already set [^1])
+            //     v                              v                                    v
+            //  ===||=============================|====================================|================>
+            //     .|                             .                                    .
+            //     .|                             .                                    .
+            //     .|__ Earliest possible timestamp at which a                         .
+            //     .    function could call `schedule_change` for a new                .
+            //     .    _value_ change..................................................And the earliest timestamp at
+            //     .                              .                                    .which the new value would take effect.
+            //     .[---------------`self.pre` delay-----------------------------------]
+            //     .                              .                                    .
+            //     [******************************************************************].
+            //     [                                                                  ].
+            //     [----------------`self.pre` delay----------------------------------].
+            //     [                                                                  ].
+            //     [ If reading a _value_ at that (<--) anchor timestamp, then the    ].
+            //     [ read will remain valid for this duration, unless a shorter       ].
+            //     [ delay has been scheduled (see just below in this diagram).       ].
+            //     [ If a _deferred, longer_ delay has been scheduled, it might yet   ].
+            //     [ still be cancelled, in which case this `pre` delay would         ].
+            //     [ bite (see the `min` calc below) -- meaning reads would remain    ].
+            //     [ valid for this duration.                                         ].
+            //     [                                                                  ].
+            //     [******************************************************************].
+            //     .                              .                                    .
+            //     .                              .                                    .
+            //     [---`time_until_delay_change`--]                                    .
+            //     .                              .                                    .
+            //     .                              .                                    .
+            //     .                              [-`self.post` delay-]                .
+            //     .                              . (if shorter      ^^                .
+            //     .                              .  than `pre`)     ||_ new values can take effect from here.
+            //     .                              .                  |
+            //     .                              .                  |_ reads are only valid until here:
+            //     .                              .                  .  `historic_timestamp + time_until_delay_change + self.post - 1`
+            //     .                              .                  .                 .
+            //     [*************************************************]                 .
+            //     [                                                 ]                 .
+            //     [----`time_until_delay_change + self.post - 1`----]                 .
+            //     [                                                 ]                 .
+            //     [ If reading a _value_ at that (<--) anchor       ]                 .
+            //     [ timestamp, then the read will remain valid      ]                 .
+            //     [ for this duration:                              ]                 .
+            //     [                                                 ]                 .
+            //     [*************************************************]                 .
+            //     .                              .                                    .
+            //     .                              .                                    .
+            //     .                              .                                    .
+            //     .                              [-`self.post` delay (if longer than `pre` & deferred)------------------]
+            //     .                              .  (scheduling deferred changes is not yet possible)                  ^^
+            //     .                              .                                                                     ||
+            //     .                              .     reads would only be valid until here:___________________________||
+            //     .                              .     `historic_timestamp + time_until_delay_change + self.post - 1`   |
+            //     .                              .                                                                      |
+            //     .                              .                        new values would take effect from here,_______|
+            //     .                              .                        but only once this longer delay takes effect  .
+            //     .                              .                                    .                                 .
+            //     .                              .                                    .                                 .
+            //     [****************************************************************************************************].
+            //     [                                                                                                    ].
+            //     [----`time_until_delay_change + self.post - 1`-------------------------------------------------------].
+            //     [                                                                                                    ].
+            //     [ Given a longer, deferred delay, then if reading a _value_ at that (<--) anchor timestamp, then     ].
+            //     [ you might think the read would remain valid for this duration.                                     ].
+            //     [ BUT, in this case of this deferred, longer delay, the `pre` delay ends sooner (see above in this   ].
+            //     [ diagram). And since this scheduled delay (`post`) can be cancelled up until the time it takes      ].
+            //     [ effect, any reads as at that (<--) anchor timestamp would cautiously only be valid until the       ].
+            //     [ earlier `pre` delay     .                                                                          ].
+            //     [                                                                                                    ].
+            //     [****************************************************************************************************].
             //
-            //       historical
-            //        timestamp                delay                  actual earliest value
-            //           v              timestamp of change           timestamp of change
-            //  =========NS=====================|=============================X===========Y=====>
-            //            ^                     ^                             ^           ^
-            //     earliest timestamp in        |                             |           |
-            //   which to schedule change       |                             |           |
-            //           |                      |                             |           |
-            //           |----------------------|------------------------------           |
-            //           |          time                  new delay                       |
-            //           |      until change                                              |
-            //           |                                                                |
-            //           |----------------------------------------------------------------|
-            //                        current delay at the earliest timestamp in
-            //                             which to scheduled value change [huh?]
             //
-            // Note: Even though when the change was scheduled we had time_until_change + new = current_delay,
-            // some time must have passed since the scheduling, so now (at the time of read), some of the initial
-            // time until change has diagram elapsed. The current time_until_change is shorter, and so
-            // the current time_until_change + new_delay < current_delay (hence explaining why X < Y in this diagram).
-            let time_until_change = self.timestamp_of_change - (historical_timestamp + 1);
+            //
+            // [^1] If a svc.timestamp_of_change has already been set, and if it's sooner than the
+            //      output of this function, then it will bite within `scheduled_value_change.nr`'s
+            //      `get_time_horizon_at` function.
+            //
+            let time_until_delay_change = self.timestamp_of_change - historical_timestamp;
 
             min(
-                self.pre.unwrap_or(INITIAL_DELAY), // This delay could technically be longer (by 1 second less than a block time)
-                time_until_change + self.post.unwrap_or(INITIAL_DELAY),
+                self.pre.unwrap_or(INITIAL_DELAY), // in case the scheduled delay (`post`) gets cancelled before it takes effect.
+                time_until_delay_change + self.post.unwrap_or(INITIAL_DELAY) - 1,
             )
         }
     }

--- a/noir-projects/noir-protocol-circuits/crates/types/src/delayed_public_mutable/scheduled_delay_change.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/delayed_public_mutable/scheduled_delay_change.nr
@@ -1,4 +1,4 @@
-use crate::traits::Empty;
+use crate::traits::{Empty, Packable};
 use std::cmp::min;
 
 mod test;
@@ -21,17 +21,20 @@ pub struct ScheduledDelayChange<let INITIAL_DELAY: u64> {
 }
 
 impl<let INITIAL_DELAY: u64> ScheduledDelayChange<INITIAL_DELAY> {
+
+    // PUBLIC ONLY
+
     pub fn new(pre: Option<u64>, post: Option<u64>, timestamp_of_change: u64) -> Self {
         Self { pre, post, timestamp_of_change }
     }
 
     /// Returns the current value of the delay stored in the data structure.
-    /// This function only returns a meaningful value when called in public with the current timestamp - for
+    /// WARNING: This function only returns a meaningful value when called in public with the current timestamp - for
     /// historical private reads use `get_effective_minimum_delay_at` instead.
-    pub fn get_current(self, current_timestamp: u64) -> u64 {
+    pub fn get_current_at(self, timestamp: u64) -> u64 {
         // The post value becomes the current one at the timestamp of change, so any transaction that is included at or after
         // the timestamp of change will use the post value.
-        if current_timestamp < self.timestamp_of_change {
+        if timestamp < self.timestamp_of_change {
             self.pre.unwrap_or(INITIAL_DELAY)
         } else {
             self.post.unwrap_or(INITIAL_DELAY)
@@ -53,7 +56,7 @@ impl<let INITIAL_DELAY: u64> ScheduledDelayChange<INITIAL_DELAY> {
     ///    new delay. For example, if reducing from 3 days to 1 day, the reduction will be scheduled to happen after 2
     ///    days.
     pub fn schedule_change(&mut self, new: u64, current_timestamp: u64) {
-        let current = self.get_current(current_timestamp);
+        let current = self.get_current_at(current_timestamp);
 
         // When changing the delay value we must ensure that it is not possible to produce a value change with a delay
         // shorter than the current one.
@@ -81,15 +84,59 @@ impl<let INITIAL_DELAY: u64> ScheduledDelayChange<INITIAL_DELAY> {
         self.timestamp_of_change = current_timestamp + time_until_change;
     }
 
+    // PRIVATE ONLY
+
+    /// Mutates the delay change by scheduling a change at the current timestamp. This function is only meaningful
+    /// when called in public with the current timestamp.
+    /// The timestamp at which the new delay will become effective is determined automatically:
+    ///  - when increasing the delay, the change is effective immediately
+    ///  - when reducing the delay, the change will take effect after a delay equal to the difference between old and
+    ///    new delay. For example, if reducing from 3 days to 1 day, the reduction will be scheduled to happen after 2
+    ///    days.
+    pub fn schedule_change_in_private(
+        &mut self,
+        new_delay: u64,
+        historical_timestamp: u64,
+        include_by_timestamp: u64,
+    ) {
+        let time_until_delay_horizon = self.get_effective_minimum_delay_at(historical_timestamp);
+
+        // When changing the delay value we must ensure that it is not possible to produce a value change with a delay
+        // shorter than the current one.
+        let time_until_change = if new_delay > time_until_delay_horizon {
+            // Increasing the delay value can therefore be done immediately: this does not invalidate prior constraints
+            // about how quickly a value might be changed (indeed it strengthens them).
+            0
+        } else {
+            // Decreasing the delay requires waiting for the difference between current and new delay in order to ensure
+            // that overall the current delay is respected.
+            //
+            //      current                    delay              earliest value timestamp of change
+            //      timestamp             timestamp of change         if delay remained unchanged
+            //  =======N=========================|================================X=================>
+            //         ^                         ^                                ^
+            //         |-------------------------|--------------------------------|
+            //         |   time until change               new delay              |
+            //         ------------------------------------------------------------
+            //                            current delay
+            time_until_delay_horizon - new_delay
+        };
+
+        self.pre = Option::some(self.get_current_at(historical_timestamp));
+        self.post = Option::some(new_delay);
+        self.timestamp_of_change = include_by_timestamp + time_until_change;
+    }
+
     /// Returns the minimum delay before a value might mutate due to a scheduled change, from the perspective of some
     /// historical timestamp (timestamp of a historical block). It only returns a meaningful value when called in
     /// private with historical timestamps. This function can be used alongside
-    /// `ScheduledValueChange.get_time_horizon` to properly constrain the `include_by_timestamp` transaction
+    /// `ScheduledValueChange.get_time_horizon_at` to properly constrain the `include_by_timestamp` transaction
     /// property when reading delayed mutable state.
     /// This value typically equals the current delay at the timestamp following the historical one (the earliest one in
     /// which a value change could be scheduled), but it also considers scenarios in which a delay reduction is
     /// scheduled to happen in the near future, resulting in a way to schedule a change with an overall delay lower than
     /// the current one.
+    // Q: what does the word "Effective" mean, versus just saying "minimum delay"? I think "effective" is redundant here (and has been confusing my brain a bit).
     pub fn get_effective_minimum_delay_at(self, historical_timestamp: u64) -> u64 {
         if self.timestamp_of_change <= historical_timestamp {
             // If no delay changes were scheduled, then the delay value at the historical timestamp (post) is guaranteed to
@@ -97,7 +144,7 @@ impl<let INITIAL_DELAY: u64> ScheduledDelayChange<INITIAL_DELAY> {
             self.post.unwrap_or(INITIAL_DELAY)
         } else {
             // If a change is scheduled, then the effective delay might be lower than the current one (pre). At the
-            // timestamp of change the current delay will be the scheduled one, with an overall delay from the historical
+            // timestamp of change the current delay will be the scheduled one[confused: "current" has no meaning in private. You mean if reading at the timestamp of change?], with an overall delay from the historical
             // timestamp equal to the time until the change plus the new delay. If this value is lower
             // than the current delay, then that is the effective minimum delay.
             //
@@ -115,13 +162,85 @@ impl<let INITIAL_DELAY: u64> ScheduledDelayChange<INITIAL_DELAY> {
             //           |                                                                |
             //           |----------------------------------------------------------------|
             //                        current delay at the earliest timestamp in
-            //                             which to scheduled value change
+            //                             which to scheduled value change [huh?]
+            //
+            // Note: Even though when the change was scheduled we had time_until_change + new = current_delay,
+            // some time must have passed since the scheduling, so now (at the time of read), some of the initial
+            // time until change has diagram elapsed. The current time_until_change is shorter, and so
+            // the current time_until_change + new_delay < current_delay (hence explaining why X < Y in this diagram).
             let time_until_change = self.timestamp_of_change - (historical_timestamp + 1);
 
             min(
                 self.pre.unwrap_or(INITIAL_DELAY),
                 time_until_change + self.post.unwrap_or(INITIAL_DELAY),
             )
+        }
+    }
+}
+
+// TODO: check whether this evaluates at comptime or runtime.
+global TWO_POW_32: Field = 2.pow_32(32);
+global TWO_POW_8: Field = 2.pow_32(8);
+
+// We pack to `2 * N + 1` fields because ScheduledValueChange contains T twice (hence `2 * N`) and we need one extra
+// field to store ScheduledDelayChange and the timestamp_of_change of ScheduledValueChange.
+// TODO: impl this as `Packable for ScheduledDelayChange`
+impl<let INITIAL_DELAY: u64> ScheduledDelayChange<INITIAL_DELAY> {
+    pub fn pack(self) -> [Field; 1] {
+        let mut result = [0; 1];
+
+        // We copy the packing approach of delayed_public_mutable_values, just omitting the
+        // svc items.
+        //
+        // We pack sdc.pre, sdc.post, sdc.timestamp_of_change and ~svc.timestamp_of_change~ into a single field as follows:
+        // [ sdc.pre_inner: u32 | sdc.pre_is_some: u8 | sdc.post_inner: u32 | sdc.post_is_some: u8 | sdc.timestamp_of_change: u32 | svc.timestamp_of_change: u32 ]
+        // Note that the code below no longer works after 2106 as by that time the timestamp will overflow u32. This is a tech debt that is not worth tackling.
+        result[0] = 0 // instead of svc.timestamp_of_change as Field
+            + ((self.timestamp_of_change as Field) * 2.pow_32(32))
+            + ((self.post.is_some() as Field) * 2.pow_32(64))
+            + ((self.post.unwrap_unchecked() as Field) * 2.pow_32(72))
+            + ((self.pre.is_some() as Field) * 2.pow_32(104))
+            + ((self.pre.unwrap_unchecked() as Field) * 2.pow_32(112));
+
+        result
+    }
+
+    pub fn unpack(packed: [Field; 1]) -> Self {
+        let field = packed[0];
+
+        // TODO: ScheduledDelayChange should not be concerned with a packing approach that
+        // contains a placeholder for a ScheduledValueChange timestamp, but this is where we are.
+        let lo_32_bits = field as u32;
+
+        let mut tmp = (field - lo_32_bits as Field) / TWO_POW_32;
+        let sdc_timestamp_of_change = tmp as u32;
+
+        tmp = (tmp - sdc_timestamp_of_change as Field) / TWO_POW_32;
+        let sdc_post_is_some = (tmp as u1) != 0;
+
+        tmp = (tmp - sdc_post_is_some as Field) / TWO_POW_8;
+        let sdc_post_inner = tmp as u32;
+
+        tmp = (tmp - sdc_post_inner as Field) / TWO_POW_32;
+        let sdc_pre_is_some = (tmp as u1) != 0;
+
+        tmp = (tmp - sdc_pre_is_some as Field) / TWO_POW_8;
+        let sdc_pre_inner = tmp as u32;
+
+        // Note that below we cast the values to u64 as that is the default type of timestamp in the system. Us packing
+        // the values as u32 is a tech debt that is not worth tackling.
+        ScheduledDelayChange {
+            pre: if sdc_pre_is_some {
+                Option::some(sdc_pre_inner as u64)
+            } else {
+                Option::none()
+            },
+            post: if sdc_post_is_some {
+                Option::some(sdc_post_inner as u64)
+            } else {
+                Option::none()
+            },
+            timestamp_of_change: sdc_timestamp_of_change as u64,
         }
     }
 }

--- a/noir-projects/noir-protocol-circuits/crates/types/src/delayed_public_mutable/scheduled_delay_change/test.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/delayed_public_mutable/scheduled_delay_change/test.nr
@@ -22,18 +22,18 @@ unconstrained fn test_get_current() {
 
     let delay_change = get_non_initial_delay_change(pre, post, timestamp_of_change);
 
-    assert_eq(delay_change.get_current(0), pre);
-    assert_eq(delay_change.get_current(timestamp_of_change - 1), pre);
-    assert_eq(delay_change.get_current(timestamp_of_change), post);
-    assert_eq(delay_change.get_current(timestamp_of_change + 1), post);
+    assert_eq(delay_change.get_current_at(0), pre);
+    assert_eq(delay_change.get_current_at(timestamp_of_change - 1), pre);
+    assert_eq(delay_change.get_current_at(timestamp_of_change), post);
+    assert_eq(delay_change.get_current_at(timestamp_of_change + 1), post);
 }
 
 #[test]
 unconstrained fn test_get_current_initial() {
     let delay_change = get_initial_delay_change();
 
-    assert_eq(delay_change.get_current(0), TEST_INITIAL_DELAY);
-    assert_eq(delay_change.get_current(1), TEST_INITIAL_DELAY);
+    assert_eq(delay_change.get_current_at(0), TEST_INITIAL_DELAY);
+    assert_eq(delay_change.get_current_at(1), TEST_INITIAL_DELAY);
 }
 
 #[test]
@@ -123,7 +123,7 @@ unconstrained fn test_schedule_change_to_longer_delay_before_change() {
     assert_eq(delay_change.pre.unwrap(), pre);
     assert_eq(delay_change.post.unwrap(), new);
     assert_eq(delay_change.timestamp_of_change, current_timestamp);
-    assert_eq(delay_change.get_current(current_timestamp), new);
+    assert_eq(delay_change.get_current_at(current_timestamp), new);
 }
 
 #[test]
@@ -142,7 +142,7 @@ unconstrained fn test_schedule_change_to_longer_delay_after_change() {
     assert_eq(delay_change.pre.unwrap(), post);
     assert_eq(delay_change.post.unwrap(), new);
     assert_eq(delay_change.timestamp_of_change, current_timestamp);
-    assert_eq(delay_change.get_current(current_timestamp), new);
+    assert_eq(delay_change.get_current_at(current_timestamp), new);
 }
 
 #[test]
@@ -158,7 +158,7 @@ unconstrained fn test_schedule_change_to_longer_delay_from_initial() {
     assert_eq(delay_change.pre.unwrap(), TEST_INITIAL_DELAY);
     assert_eq(delay_change.post.unwrap(), new);
     assert_eq(delay_change.timestamp_of_change, current_timestamp);
-    assert_eq(delay_change.get_current(current_timestamp), new);
+    assert_eq(delay_change.get_current_at(current_timestamp), new);
 }
 
 unconstrained fn assert_effective_minimum_delay_invariants<let INITIAL_DELAY: u64>(
@@ -178,14 +178,14 @@ unconstrained fn assert_effective_minimum_delay_invariants<let INITIAL_DELAY: u6
         let delay_change_timestamp = delay_change.timestamp_of_change;
 
         let value_change_timestamp =
-            delay_change_timestamp + delay_change.get_current(delay_change_timestamp);
+            delay_change_timestamp + delay_change.get_current_at(delay_change_timestamp);
         assert(expected_earliest_value_change_timestamp <= value_change_timestamp);
     }
 
     // Another possibility would be to schedule a value change immediately after the historical timestamp.
     let change_schedule_timestamp = historical_timestamp + 1;
     let value_change_timestamp =
-        change_schedule_timestamp + delay_change.get_current(change_schedule_timestamp);
+        change_schedule_timestamp + delay_change.get_current_at(change_schedule_timestamp);
     assert(expected_earliest_value_change_timestamp <= value_change_timestamp);
 
     // Finally, a delay reduction could be scheduled immediately after the historical timestamp. We reduce the delay to

--- a/noir-projects/noir-protocol-circuits/crates/types/src/delayed_public_mutable/scheduled_delay_change/test.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/delayed_public_mutable/scheduled_delay_change/test.nr
@@ -207,7 +207,8 @@ unconstrained fn test_get_effective_delay_at_before_change_in_far_future() {
 
     // The scheduled delay change is far into the future (further than the current delay is), so it doesn't affect
     // the effective delay, which is simply the current one (pre).
-    let effective_minimum_delay = delay_change.get_effective_minimum_delay_at(historical_timestamp);
+    let effective_minimum_delay =
+        delay_change.get_max_time_a_read_remains_valid(historical_timestamp);
     assert_eq(effective_minimum_delay, pre);
 
     assert_effective_minimum_delay_invariants(
@@ -230,7 +231,8 @@ unconstrained fn test_get_effective_delay_at_before_change_to_long_delay() {
     // The scheduled delay change will be effective soon (it's fewer seconds away than the current delay), but due to
     // it being larger than the current one it doesn't affect the effective delay, which is simply the current one
     // (pre).
-    let effective_minimum_delay = delay_change.get_effective_minimum_delay_at(historical_timestamp);
+    let effective_minimum_delay =
+        delay_change.get_max_time_a_read_remains_valid(historical_timestamp);
     assert_eq(effective_minimum_delay, pre);
 
     assert_effective_minimum_delay_invariants(
@@ -255,7 +257,8 @@ unconstrained fn test_get_effective_delay_at_before_near_change_to_short_delay()
     // reduced, and a delay change would be scheduled there with an overall delay lower than the current one.
     // The effective delay therefore is the new delay plus the number of seconds that need to elapse until it becomes
     // effective (i.e. until the timestamp of change).
-    let effective_minimum_delay = delay_change.get_effective_minimum_delay_at(historical_timestamp);
+    let effective_minimum_delay =
+        delay_change.get_max_time_a_read_remains_valid(historical_timestamp);
     assert_eq(effective_minimum_delay, post + timestamp_of_change - (historical_timestamp + 1));
 
     assert_effective_minimum_delay_invariants(
@@ -276,7 +279,8 @@ unconstrained fn test_get_effective_delay_at_after_change() {
     let mut delay_change = get_non_initial_delay_change(pre, post, timestamp_of_change);
 
     // No delay change is scheduled, so the effective delay is simply the current one (post).
-    let effective_minimum_delay = delay_change.get_effective_minimum_delay_at(historical_timestamp);
+    let effective_minimum_delay =
+        delay_change.get_max_time_a_read_remains_valid(historical_timestamp);
     assert_eq(effective_minimum_delay, post);
 
     assert_effective_minimum_delay_invariants(
@@ -294,7 +298,8 @@ unconstrained fn test_get_effective_delay_at_initial() {
 
     // Like in the after change scenario, no delay change is scheduled, so the effective delay is simply the current
     // one (initial).
-    let effective_minimum_delay = delay_change.get_effective_minimum_delay_at(historical_timestamp);
+    let effective_minimum_delay =
+        delay_change.get_max_time_a_read_remains_valid(historical_timestamp);
     assert_eq(effective_minimum_delay, TEST_INITIAL_DELAY);
 
     assert_effective_minimum_delay_invariants(

--- a/noir-projects/noir-protocol-circuits/crates/types/src/delayed_public_mutable/scheduled_delay_change/test.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/delayed_public_mutable/scheduled_delay_change/test.nr
@@ -161,16 +161,16 @@ unconstrained fn test_schedule_change_to_longer_delay_from_initial() {
     assert_eq(delay_change.get_current_at(current_timestamp), new);
 }
 
-unconstrained fn assert_effective_minimum_delay_invariants<let INITIAL_DELAY: u64>(
+unconstrained fn assert_max_time_a_read_remains_valid_invariants<let INITIAL_DELAY: u64>(
     delay_change: &mut ScheduledDelayChange<INITIAL_DELAY>,
     historical_timestamp: u64,
-    effective_minimum_delay: u64,
+    max_time_a_read_remains_valid: u64,
 ) {
     // The effective minimum delay guarantees the earliest timestamp in which a scheduled value change could be made
     // effective. No action, even if executed immediately after the historical timestamp, should result in a scheduled
     // value change having a timestamp of change lower than this.
     let expected_earliest_value_change_timestamp =
-        historical_timestamp + 1 + effective_minimum_delay;
+        historical_timestamp + 1 + max_time_a_read_remains_valid;
 
     if delay_change.timestamp_of_change > historical_timestamp {
         // If a delay change is already scheduled to happen in the future, we then must consider the scenario in
@@ -207,14 +207,14 @@ unconstrained fn test_get_effective_delay_at_before_change_in_far_future() {
 
     // The scheduled delay change is far into the future (further than the current delay is), so it doesn't affect
     // the effective delay, which is simply the current one (pre).
-    let effective_minimum_delay =
+    let max_time_a_read_remains_valid =
         delay_change.get_max_time_a_read_remains_valid(historical_timestamp);
-    assert_eq(effective_minimum_delay, pre);
+    assert_eq(max_time_a_read_remains_valid, pre);
 
-    assert_effective_minimum_delay_invariants(
+    assert_max_time_a_read_remains_valid_invariants(
         &mut delay_change,
         historical_timestamp,
-        effective_minimum_delay,
+        max_time_a_read_remains_valid,
     );
 }
 
@@ -231,14 +231,14 @@ unconstrained fn test_get_effective_delay_at_before_change_to_long_delay() {
     // The scheduled delay change will be effective soon (it's fewer seconds away than the current delay), but due to
     // it being larger than the current one it doesn't affect the effective delay, which is simply the current one
     // (pre).
-    let effective_minimum_delay =
+    let max_time_a_read_remains_valid =
         delay_change.get_max_time_a_read_remains_valid(historical_timestamp);
-    assert_eq(effective_minimum_delay, pre);
+    assert_eq(max_time_a_read_remains_valid, pre);
 
-    assert_effective_minimum_delay_invariants(
+    assert_max_time_a_read_remains_valid_invariants(
         &mut delay_change,
         historical_timestamp,
-        effective_minimum_delay,
+        max_time_a_read_remains_valid,
     );
 }
 
@@ -257,14 +257,17 @@ unconstrained fn test_get_effective_delay_at_before_near_change_to_short_delay()
     // reduced, and a delay change would be scheduled there with an overall delay lower than the current one.
     // The effective delay therefore is the new delay plus the number of seconds that need to elapse until it becomes
     // effective (i.e. until the timestamp of change).
-    let effective_minimum_delay =
+    let max_time_a_read_remains_valid =
         delay_change.get_max_time_a_read_remains_valid(historical_timestamp);
-    assert_eq(effective_minimum_delay, post + timestamp_of_change - (historical_timestamp + 1));
+    assert_eq(
+        max_time_a_read_remains_valid,
+        post + timestamp_of_change - (historical_timestamp + 1),
+    );
 
-    assert_effective_minimum_delay_invariants(
+    assert_max_time_a_read_remains_valid_invariants(
         &mut delay_change,
         historical_timestamp,
-        effective_minimum_delay,
+        max_time_a_read_remains_valid,
     );
 }
 
@@ -279,14 +282,14 @@ unconstrained fn test_get_effective_delay_at_after_change() {
     let mut delay_change = get_non_initial_delay_change(pre, post, timestamp_of_change);
 
     // No delay change is scheduled, so the effective delay is simply the current one (post).
-    let effective_minimum_delay =
+    let max_time_a_read_remains_valid =
         delay_change.get_max_time_a_read_remains_valid(historical_timestamp);
-    assert_eq(effective_minimum_delay, post);
+    assert_eq(max_time_a_read_remains_valid, post);
 
-    assert_effective_minimum_delay_invariants(
+    assert_max_time_a_read_remains_valid_invariants(
         &mut delay_change,
         historical_timestamp,
-        effective_minimum_delay,
+        max_time_a_read_remains_valid,
     );
 }
 
@@ -298,13 +301,13 @@ unconstrained fn test_get_effective_delay_at_initial() {
 
     // Like in the after change scenario, no delay change is scheduled, so the effective delay is simply the current
     // one (initial).
-    let effective_minimum_delay =
+    let max_time_a_read_remains_valid =
         delay_change.get_max_time_a_read_remains_valid(historical_timestamp);
-    assert_eq(effective_minimum_delay, TEST_INITIAL_DELAY);
+    assert_eq(max_time_a_read_remains_valid, TEST_INITIAL_DELAY);
 
-    assert_effective_minimum_delay_invariants(
+    assert_max_time_a_read_remains_valid_invariants(
         &mut delay_change,
         historical_timestamp,
-        effective_minimum_delay,
+        max_time_a_read_remains_valid,
     );
 }

--- a/noir-projects/noir-protocol-circuits/crates/types/src/delayed_public_mutable/scheduled_value_change.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/delayed_public_mutable/scheduled_value_change.nr
@@ -5,7 +5,7 @@ mod test;
 
 // This data structure is used by DelayedPublicMutable to represent a value that changes from `pre` to `post` at some timestamp
 // called the `timestamp_of_change`. The value can only be made to change by scheduling a change event at some future
-// timestamp after some minimum delay measured in seconds has elapsed. This means that at any given timestamp we know
+// timestamp after some `delay_before_a_new_write_can_happen` measured in seconds has elapsed. This means that at any given timestamp we know
 // both the current value and the smallest timestamp at which the value might change - this is called the
 // 'time horizon'.
 pub struct ScheduledValueChange<T> {
@@ -43,10 +43,10 @@ impl<T> ScheduledValueChange<T> {
         &mut self,
         new_value: T,
         current_timestamp: u64,
-        minimum_delay: u64, // TODO: call this "current delay", as every time this is called, it's with the "current delay"
+        delay_before_a_new_write_can_happen: u64, // aka max_time_a_read_remains_valid. TODO: call this "current delay", as every time this is called, it's with the "current delay"
         timestamp_of_change: u64,
     ) {
-        assert(timestamp_of_change >= current_timestamp + minimum_delay);
+        assert(timestamp_of_change >= current_timestamp + delay_before_a_new_write_can_happen);
 
         // Notice: we don't set self.pre = self.post, in case this `schedule_change`
         // function is called a 2nd time before this 1st call's change takes effect.
@@ -99,13 +99,13 @@ impl<T> ScheduledValueChange<T> {
         new_value: T,
         historical_timestamp: u64,
         include_by_timestamp: u64,
-        minimum_delay: u64,
+        delay_before_a_new_write_can_happen: u64, // aka max_time_a_read_remains_valid
         timestamp_of_change: u64,
     ) {
         // We don't know exactly when this tx will be included. Worst case, it's only
-        // included by the include_by_timestamp, in which case we still need minimum_delay
+        // included by the include_by_timestamp, in which case we still need delay_before_a_new_write_can_happen
         // amount of time before the new value takes effect.
-        assert(timestamp_of_change >= include_by_timestamp + minimum_delay);
+        assert(timestamp_of_change >= include_by_timestamp + delay_before_a_new_write_can_happen);
 
         self.pre = self.get_current_at(historical_timestamp);
         self.post = new_value;
@@ -117,15 +117,19 @@ impl<T> ScheduledValueChange<T> {
     /// (timestamp of a historical block at which we are constructing a proof), since due to its asynchronous nature
     /// private execution cannot know about any later scheduled changes.
     /// The caller of this function must know how quickly the value can change due to a scheduled change in the form of
-    /// `minimum_delay`. If the delay itself is immutable, then this is just its duration. If the delay is mutable
-    /// however, then this value is the 'effective minimum delay' (obtained by calling
-    /// `ScheduledDelayChange.get_effective_minimum_delay_at`), which equals the minimum time in seconds that needs to
+    /// `max_time_a_read_remains_valid`. If the delay itself is immutable, then this is just its duration. If the delay is mutable
+    /// however, then this value is the 'max_time_a_read_remains_valid' (obtained by calling
+    /// `ScheduledDelayChange.get_max_time_a_read_remains_valid`), which equals the minimum time in seconds that needs to
     /// elapse from the next block's timestamp until the value changes, regardless of further delay changes.
     /// The value returned by `get_current_at` in private when called with a historical timestamp is only safe to use
     /// if the transaction's `include_by_timestamp` property is set to a value lower or equal to the time horizon
     /// computed using the same historical timestamp.
-    pub fn get_time_horizon_at(self, historical_timestamp: u64, minimum_delay: u64) -> u64 {
-        // The time horizon is the very last timestamp in which the current value is known. Any timestamp past the
+    pub fn get_time_horizon_at(
+        self,
+        historical_timestamp: u64,
+        max_time_a_read_remains_valid: u64,
+    ) -> u64 {
+        // The time horizon is the very last timestamp at which the current value is known. Any timestamp past the
         // horizon (i.e. with a timestamp larger than the time horizon) may have a different current value.
         // Reading the current value in private typically requires constraining the maximum valid timestamp to be equal
         // to the time horizon.
@@ -139,38 +143,39 @@ impl<T> ScheduledValueChange<T> {
             //
             //   timestamp of    historical
             //      change       timestamp          time horizon
-            //   =======|=============N===================H===========>
-            //                         ^                   ^
-            //                         ---------------------
-            //                             minimum delay
-            historical_timestamp + minimum_delay
+            //   =======|=============|===================|===========>
+            //                        ^                   ^
+            //                        ---------------------
+            //                      max_time_a_read_remains_valid
+            //
+            historical_timestamp + max_time_a_read_remains_valid
         } else {
             // If the timestamp of change has not yet been reached however, then there are two possible scenarios.
-            //   a) It could be so far into the future that the time horizon is actually determined by the minimum
-            //      delay, because a new change could be scheduled and take place _before_ the currently scheduled one. // Q: Why is this allowed? Do we want this? Sounds like it could bring some confusion.
+            //   a) It could be so far into the future that the time horizon is actually determined by the
+            //      max_time_a_read_remains_valid, because a new change could be scheduled and take place _before_ the currently scheduled one.
             //      This is similar to the scenario where the timestamp of change is in the past: the time horizon is
             //      the timestamp prior to the earliest one in which a new timestamp of change might land.
             //
             //         historical
             //         timestamp                      time horizon    timestamp of change
-            //        =====N=================================H=================|=========>
-            //              ^                                 ^
-            //              |                                 |
-            //              -----------------------------------
-            //                        minimum delay
+            //        =====|=================================|=================|=========>
+            //             ^                                 ^
+            //             |                                 |
+            //             -----------------------------------
+            //                max_time_a_read_remains_valid
             //
-            //   b) It could be fewer than `minimum_delay` seconds away from the historical timestamp, in which case
+            //   b) It could be fewer than `max_time_a_read_remains_valid` seconds away from the historical timestamp, in which case
             //      the timestamp of change would become the limiting factor for the time horizon, which would equal
             //      the timestamp right before the timestamp of change (since by definition the value changes at the
             //      timestamp of change).
             //
             //           historical                         time horizon
             //           timestamp   timestamp of change    if not scheduled
-            //        =======N=============|===================H=================>
-            //                ^           ^                     ^
-            //                |     actual horizon              |
-            //                -----------------------------------
-            //                          minimum delay
+            //        =======|=============|===================|=================>
+            //               ^            ^                    ^
+            //               |      actual horizon             |
+            //               -----------------------------------
+            //                  max_time_a_read_remains_valid
             //
             // Note that the current implementation does not allow the caller to set the timestamp of change to an
             // arbitrary value, and therefore scenario a) is not currently possible. However implementing #5501 would
@@ -179,7 +184,7 @@ impl<T> ScheduledValueChange<T> {
             // subtract 1.
             min(
                 self.timestamp_of_change - 1,
-                historical_timestamp + minimum_delay,
+                historical_timestamp + max_time_a_read_remains_valid,
             )
         }
     }

--- a/noir-projects/noir-protocol-circuits/crates/types/src/delayed_public_mutable/scheduled_value_change.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/delayed_public_mutable/scheduled_value_change.nr
@@ -15,26 +15,13 @@ pub struct ScheduledValueChange<T> {
     pub(crate) timestamp_of_change: u64,
 }
 
+// TODO: consider lacing the context through these impls, so we know which functions are compatible with public/private/utility. For now, I've added comments to that effect.
 impl<T> ScheduledValueChange<T> {
+
+    // PUBLIC ONLY
+
     pub fn new(pre: T, post: T, timestamp_of_change: u64) -> Self {
         Self { pre, post, timestamp_of_change }
-    }
-
-    /// Returns the value stored in the data structure at a given timestamp. This function can be called both in public
-    /// (where `timestamp` is simply the current timestamp, i.e. the timestamp at which the current transaction will be
-    /// included) and in private (where `timestamp` is the historical timestamp that is used to construct the proof).
-    /// Reading in private is only safe if the transaction's `include_by_timestamp` property is set to a value lower or
-    /// equal to the time horizon (see `get_time_horizon()`).
-    pub fn get_current_at(self, timestamp: u64) -> T {
-        // The post value becomes the current one at the timestamp of change. This means different things in each realm:
-        // - in public, any transaction that is included at the timestamp of change will use the post value
-        // - in private, any transaction that includes the timestamp of change as part of the historical state will use
-        //   the post value (barring any follow-up changes)
-        if timestamp < self.timestamp_of_change {
-            self.pre
-        } else {
-            self.post
-        }
     }
 
     /// Returns the scheduled change, i.e. the post-change value and the timestamp at which it will become the current
@@ -50,6 +37,81 @@ impl<T> ScheduledValueChange<T> {
         (self.pre, self.timestamp_of_change)
     }
 
+    /// Mutates the value by scheduling a change at the current timestamp. This function is only meaningful when
+    /// called in public with the current timestamp.
+    pub fn schedule_change(
+        &mut self,
+        new_value: T,
+        current_timestamp: u64,
+        minimum_delay: u64, // TODO: call this "current delay", as every time this is called, it's with the "current delay"
+        timestamp_of_change: u64,
+    ) {
+        assert(timestamp_of_change >= current_timestamp + minimum_delay);
+
+        // Notice: we don't set self.pre = self.post, in case this `schedule_change`
+        // function is called a 2nd time before this 1st call's change takes effect.
+        // In such an edge case, self.pre = self.pre: the 2nd call effectively replaces
+        // the 1st scheduled change, so the 1st `post` value will never take effect.
+        self.pre = self.get_current_at(current_timestamp);
+        self.post = new_value;
+        self.timestamp_of_change = timestamp_of_change;
+    }
+
+    // PUBLIC & PRIVATE & UTILITY.
+
+    /// Returns the value stored in the data structure at a given timestamp. This function can be called both in public
+    /// (where `timestamp` is simply the current timestamp, i.e. the timestamp at which the current transaction will be
+    /// included) and in private (where `timestamp` is the historical timestamp that is used to construct the proof).
+    /// Reading in private is only safe if the transaction's `include_by_timestamp` property is set to a value lower or
+    /// equal to the time horizon (see `get_time_horizon_at()`).
+    pub fn get_current_at(self, timestamp: u64) -> T {
+        // The post value becomes the current one at the timestamp of change. This means different things in each realm:
+        // - in public, any transaction that is included at the timestamp of change will use the post value
+        // - in private, any transaction that includes the timestamp of change as part of the historical state will use
+        //   the post value (barring any follow-up changes)
+        if timestamp < self.timestamp_of_change {
+            self.pre
+        } else {
+            self.post
+        }
+    }
+
+    /// Advanced. Only access if you know what you're doing.
+    pub fn get_timestamp_of_change(self) -> u64 {
+        self.timestamp_of_change
+    }
+
+    /// Advanced. Only access if you know what you're doing.
+    pub fn get_pre(self) -> T {
+        self.pre
+    }
+
+    /// Advanced. Only access if you know what you're doing.
+    pub fn get_post(self) -> T {
+        self.post
+    }
+
+    // PRIVATE ONLY
+
+    /// Mutates the value by scheduling a change.
+    pub fn schedule_change_in_private(
+        &mut self,
+        new_value: T,
+        historical_timestamp: u64,
+        include_by_timestamp: u64,
+        minimum_delay: u64,
+        timestamp_of_change: u64,
+    ) {
+        // We don't know exactly when this tx will be included. Worst case, it's only
+        // included by the include_by_timestamp, in which case we still need minimum_delay
+        // amount of time before the new value takes effect.
+        assert(timestamp_of_change >= include_by_timestamp + minimum_delay);
+
+        self.pre = self.get_current_at(historical_timestamp);
+        self.post = new_value;
+        self.timestamp_of_change = timestamp_of_change;
+    }
+
     /// Returns the largest timestamp at which the value returned by `get_current_at` is known to remain the current
     /// value. This value is only meaningful in private when constructing a proof at some `historical_timestamp`
     /// (timestamp of a historical block at which we are constructing a proof), since due to its asynchronous nature
@@ -62,7 +124,7 @@ impl<T> ScheduledValueChange<T> {
     /// The value returned by `get_current_at` in private when called with a historical timestamp is only safe to use
     /// if the transaction's `include_by_timestamp` property is set to a value lower or equal to the time horizon
     /// computed using the same historical timestamp.
-    pub fn get_time_horizon(self, historical_timestamp: u64, minimum_delay: u64) -> u64 {
+    pub fn get_time_horizon_at(self, historical_timestamp: u64, minimum_delay: u64) -> u64 {
         // The time horizon is the very last timestamp in which the current value is known. Any timestamp past the
         // horizon (i.e. with a timestamp larger than the time horizon) may have a different current value.
         // Reading the current value in private typically requires constraining the maximum valid timestamp to be equal
@@ -85,7 +147,7 @@ impl<T> ScheduledValueChange<T> {
         } else {
             // If the timestamp of change has not yet been reached however, then there are two possible scenarios.
             //   a) It could be so far into the future that the time horizon is actually determined by the minimum
-            //      delay, because a new change could be scheduled and take place _before_ the currently scheduled one.
+            //      delay, because a new change could be scheduled and take place _before_ the currently scheduled one. // Q: Why is this allowed? Do we want this? Sounds like it could bring some confusion.
             //      This is similar to the scenario where the timestamp of change is in the past: the time horizon is
             //      the timestamp prior to the earliest one in which a new timestamp of change might land.
             //
@@ -120,22 +182,6 @@ impl<T> ScheduledValueChange<T> {
                 historical_timestamp + minimum_delay,
             )
         }
-    }
-
-    /// Mutates the value by scheduling a change at the current timestamp. This function is only meaningful when
-    /// called in public with the current timestamp.
-    pub fn schedule_change(
-        &mut self,
-        new_value: T,
-        current_timestamp: u64,
-        minimum_delay: u64,
-        timestamp_of_change: u64,
-    ) {
-        assert(timestamp_of_change >= current_timestamp + minimum_delay);
-
-        self.pre = self.get_current_at(current_timestamp);
-        self.post = new_value;
-        self.timestamp_of_change = timestamp_of_change;
     }
 }
 

--- a/noir-projects/noir-protocol-circuits/crates/types/src/delayed_public_mutable/scheduled_value_change/test.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/delayed_public_mutable/scheduled_value_change/test.nr
@@ -61,7 +61,7 @@ unconstrained fn test_get_time_horizon_change_in_past() {
     let mut value_change: ScheduledValueChange<Field> =
         ScheduledValueChange::new(1, 2, timestamp_of_change);
 
-    let time_horizon = value_change.get_time_horizon(historical_timestamp, TEST_DELAY);
+    let time_horizon = value_change.get_time_horizon_at(historical_timestamp, TEST_DELAY);
     assert_eq(time_horizon, historical_timestamp + TEST_DELAY);
 
     assert_time_horizon_invariants(&mut value_change, historical_timestamp, time_horizon);
@@ -75,7 +75,7 @@ unconstrained fn test_get_time_horizon_change_in_immediate_past() {
     let mut value_change: ScheduledValueChange<Field> =
         ScheduledValueChange::new(1, 2, timestamp_of_change);
 
-    let time_horizon = value_change.get_time_horizon(historical_timestamp, TEST_DELAY);
+    let time_horizon = value_change.get_time_horizon_at(historical_timestamp, TEST_DELAY);
     assert_eq(time_horizon, historical_timestamp + TEST_DELAY);
 
     assert_time_horizon_invariants(&mut value_change, historical_timestamp, time_horizon);
@@ -92,7 +92,7 @@ unconstrained fn test_get_time_horizon_change_in_near_future() {
     // Note that this is the only scenario in which the timestamp of change informs the time horizon.
     // This may result in privacy leaks when interacting with applications that have a scheduled change
     // in the near future.
-    let time_horizon = value_change.get_time_horizon(historical_timestamp, TEST_DELAY);
+    let time_horizon = value_change.get_time_horizon_at(historical_timestamp, TEST_DELAY);
     assert_eq(time_horizon, timestamp_of_change - 1);
 
     assert_time_horizon_invariants(&mut value_change, historical_timestamp, time_horizon);
@@ -106,7 +106,7 @@ unconstrained fn test_get_time_horizon_change_in_far_future() {
     let mut value_change: ScheduledValueChange<Field> =
         ScheduledValueChange::new(1, 2, timestamp_of_change);
 
-    let time_horizon = value_change.get_time_horizon(historical_timestamp, TEST_DELAY);
+    let time_horizon = value_change.get_time_horizon_at(historical_timestamp, TEST_DELAY);
     assert_eq(time_horizon, historical_timestamp + TEST_DELAY);
 
     assert_time_horizon_invariants(&mut value_change, historical_timestamp, time_horizon);
@@ -120,7 +120,7 @@ unconstrained fn test_get_time_horizon_n0_delay() {
     let mut value_change: ScheduledValueChange<Field> =
         ScheduledValueChange::new(1, 2, timestamp_of_change);
 
-    let time_horizon = value_change.get_time_horizon(historical_timestamp, 0);
+    let time_horizon = value_change.get_time_horizon_at(historical_timestamp, 0);
     // Since the time horizon equals the historical timestamp, it is not possible to read the current value in
     // private since the transaction `include_by_timestamp` property would equal an already mined timestamp.
     assert_eq(time_horizon, historical_timestamp);

--- a/yarn-project/pxe/src/contract_function_simulator/pxe_oracle_interface.test.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/pxe_oracle_interface.test.ts
@@ -913,12 +913,10 @@ describe('PXEOracleInterface', () => {
 
     it('should search for notes from all accounts', async () => {
       // Add multiple accounts to keystore
-      const numAccounts = 3;
-
       await keyStore.addAccount(Fr.random(), Fr.random());
       await keyStore.addAccount(Fr.random(), Fr.random());
 
-      expect(await keyStore.getAccounts()).toHaveLength(numAccounts);
+      expect(await keyStore.getAccounts()).toHaveLength(3);
 
       // Spy on the noteDataProvider.getNotesSpy
       const getNotesSpy = jest.spyOn(noteDataProvider, 'getNotes');
@@ -926,14 +924,11 @@ describe('PXEOracleInterface', () => {
       // Call the function under test
       await pxeOracleInterface.removeNullifiedNotes(contractAddress);
 
-      // Verify removeNullifiedNotes was called once for each account
-      expect(getNotesSpy).toHaveBeenCalledTimes(numAccounts);
+      // Verify removeNullifiedNotes was called once for all accounts
+      expect(getNotesSpy).toHaveBeenCalledTimes(1);
 
-      // Verify getNotes was called with the correct contract address and recipient for each account
-      const accounts = await keyStore.getAccounts();
-      accounts.forEach(recipient => {
-        expect(getNotesSpy).toHaveBeenCalledWith(expect.objectContaining({ contractAddress, recipient }));
-      });
+      // Verify getNotes was called with the correct contract address
+      expect(getNotesSpy).toHaveBeenCalledWith(expect.objectContaining({ contractAddress }));
     });
   });
 

--- a/yarn-project/pxe/src/storage/note_data_provider/note_data_provider.test.ts
+++ b/yarn-project/pxe/src/storage/note_data_provider/note_data_provider.test.ts
@@ -116,16 +116,13 @@ describe('NoteDataProvider', () => {
   it.each(filteringTests)('retrieves nullified notes', async (getFilter, getExpected) => {
     await noteDataProvider.addNotes(notes);
 
-    // Nullify all notes and use the same filter as other test cases
-    for (const recipient of recipients) {
-      const notesToNullify = notes.filter(note => note.recipient.equals(recipient));
-      const nullifiers = notesToNullify.map(note => ({
-        data: note.siloedNullifier,
-        l2BlockNumber: note.l2BlockNumber,
-        l2BlockHash: L2BlockHash.fromString(note.l2BlockHash),
-      }));
-      await expect(noteDataProvider.removeNullifiedNotes(nullifiers, recipient)).resolves.toEqual(notesToNullify);
-    }
+    // Nullify all notes
+    const nullifiers = notes.map(note => ({
+      data: note.siloedNullifier,
+      l2BlockNumber: note.l2BlockNumber,
+      l2BlockHash: L2BlockHash.fromString(note.l2BlockHash),
+    }));
+    await expect(noteDataProvider.removeNullifiedNotes(nullifiers)).resolves.toEqual(notes);
     const filter = await getFilter();
     const returnedNotes = await noteDataProvider.getNotes({ ...filter, status: NoteStatus.ACTIVE_OR_NULLIFIED });
     const expected = await getExpected();
@@ -140,9 +137,7 @@ describe('NoteDataProvider', () => {
       l2BlockNumber: note.l2BlockNumber,
       l2BlockHash: L2BlockHash.fromString(note.l2BlockHash),
     }));
-    await expect(noteDataProvider.removeNullifiedNotes(nullifiers, notesToNullify[0].recipient)).resolves.toEqual(
-      notesToNullify,
-    );
+    await expect(noteDataProvider.removeNullifiedNotes(nullifiers)).resolves.toEqual(notesToNullify);
 
     const actualNotesWithDefault = await getNotesForAllContracts({});
     const actualNotesWithActive = await getNotesForAllContracts({ status: NoteStatus.ACTIVE });
@@ -160,9 +155,7 @@ describe('NoteDataProvider', () => {
       l2BlockNumber: 99,
       l2BlockHash: L2BlockHash.random(),
     }));
-    await expect(noteDataProvider.removeNullifiedNotes(nullifiers, notesToNullify[0].recipient)).resolves.toEqual(
-      notesToNullify,
-    );
+    await expect(noteDataProvider.removeNullifiedNotes(nullifiers)).resolves.toEqual(notesToNullify);
     await expect(noteDataProvider.unnullifyNotesAfter(98)).resolves.toEqual(undefined);
 
     const result = await getNotesForAllContracts({ status: NoteStatus.ACTIVE, recipient: recipients[0] });
@@ -179,9 +172,7 @@ describe('NoteDataProvider', () => {
       l2BlockNumber: note.l2BlockNumber,
       l2BlockHash: L2BlockHash.fromString(note.l2BlockHash),
     }));
-    await expect(noteDataProvider.removeNullifiedNotes(nullifiers, notesToNullify[0].recipient)).resolves.toEqual(
-      notesToNullify,
-    );
+    await expect(noteDataProvider.removeNullifiedNotes(nullifiers)).resolves.toEqual(notesToNullify);
 
     const result = await getNotesForAllContracts({
       status: NoteStatus.ACTIVE_OR_NULLIFIED,
@@ -231,16 +222,13 @@ describe('NoteDataProvider', () => {
       }),
     ).resolves.toEqual([notes[0]]);
     await expect(
-      noteDataProvider.removeNullifiedNotes(
-        [
-          {
-            data: notes[0].siloedNullifier,
-            l2BlockHash: L2BlockHash.fromString(notes[0].l2BlockHash),
-            l2BlockNumber: notes[0].l2BlockNumber,
-          },
-        ],
-        recipients[0],
-      ),
+      noteDataProvider.removeNullifiedNotes([
+        {
+          data: notes[0].siloedNullifier,
+          l2BlockHash: L2BlockHash.fromString(notes[0].l2BlockHash),
+          l2BlockNumber: notes[0].l2BlockNumber,
+        },
+      ]),
     ).resolves.toEqual([notes[0]]);
 
     await expect(

--- a/yarn-project/pxe/src/storage/note_data_provider/note_data_provider.ts
+++ b/yarn-project/pxe/src/storage/note_data_provider/note_data_provider.ts
@@ -270,7 +270,7 @@ export class NoteDataProvider implements DataProvider {
     return result;
   }
 
-  removeNullifiedNotes(nullifiers: InBlock<Fr>[], recipient: AztecAddress): Promise<NoteDao[]> {
+  removeNullifiedNotes(nullifiers: InBlock<Fr>[]): Promise<NoteDao[]> {
     if (nullifiers.length === 0) {
       return Promise.resolve([]);
     }
@@ -292,9 +292,6 @@ export class NoteDataProvider implements DataProvider {
         }
         const noteScopes = (await toArray(this.#notesToScope.getValuesAsync(noteIndex))) ?? [];
         const note = NoteDao.fromBuffer(noteBuffer);
-        if (!note.recipient.equals(recipient)) {
-          throw new Error("Tried to nullify someone else's note");
-        }
 
         nullifiedNotes.push(note);
 

--- a/yarn-project/txe/src/oracle/txe_oracle.ts
+++ b/yarn-project/txe/src/oracle/txe_oracle.ts
@@ -128,7 +128,7 @@ export class TXE {
   private msgSender: AztecAddress;
   private functionSelector = FunctionSelector.fromField(new Fr(0));
 
-  private pxeOracleInterface: PXEOracleInterface;
+  public pxeOracleInterface: PXEOracleInterface;
 
   private publicDataWrites: PublicDataWrite[] = [];
   private uniqueNoteHashesFromPublic: Fr[] = [];
@@ -369,6 +369,22 @@ export class TXE {
 
   txeGetLastBlockTimestamp() {
     return this.getBlockTimestamp(this.blockNumber - 1);
+  }
+
+  async txeGetLastTxEffects() {
+    const block = await this.stateMachine.archiver.getBlock(this.blockNumber - 1);
+    if (!block) {
+      throw new Error(`Got no block for the expected last block, number ${this.blockNumber - 1}`);
+    }
+
+    if (block.body.txEffects.length != 1) {
+      // Note that calls like env.mine() will result in blocks with no transactions, hitting this
+      throw new Error(`Expected a single transaction in the last block, found ${block.body.txEffects.length}`);
+    }
+
+    const txEffects = block.body.txEffects[0];
+
+    return { txHash: txEffects.txHash, noteHashes: txEffects.noteHashes, nullifiers: txEffects.nullifiers };
   }
 
   utilityGetContractAddress() {


### PR DESCRIPTION
> 55% of this is a test file. 
> Probably 20% is doc comments and ascii diagrams.


> Almost ready for review... just doing some tidying and final testing.

Resolves #15496 

Introduces a new `DelayedPrivateMutable` state variable.

Just like PrivateMutable, users can initialize and replace custom `Note` structs in storage. But there is a delay before such writes take effect.

Under the hood, we re-use all of the existing files `delayed_mutable.nr`, `scheduled_value_change.nr`, `scheduled_delay_change.nr`.

In the case of this DelayedPrivateMutable, the `ScheduledValueChange<T>`  struct acts on `T = Note` -- the custom user notes.

Also under the hood, `DelayedPrivateMutable` manages a `DelayedPrivateMutableNote` struct (often referred to as a "wrapper note"), which looks like this:

```noir
pub struct DelayedPrivateMutableNote<Note, let INITIAL_DELAY: u64> {
    pub delayed_mutable_values: DelayedPublicMutableValues<Note, INITIAL_DELAY>,
}
```

Let's flatten that even further, for illustration:

```noir
struct DelayedPrivateMutableNote<Note, let INITIAL_DELAY: u64> {
    pub delayed_mutable_values: DelayedPublicMutableValues<Note, INITIAL_DELAY> {
        pub svc: ScheduledValueChange<Note> {
            pub(crate) pre: Note,
            pub(crate) post: Note,
            pub(crate) timestamp_of_change: u64,
        },
        pub sdc: ScheduledDelayChange<INITIAL_DELAY> {
            pub(crate) pre: Option<u64>,
            pub(crate) post: Option<u64>,
            pub(crate) timestamp_of_change: u64,
        }
    }
}
```


It is this "wrapper note" which gets inserted into the protocol's Note Hash Tree and nullified. Computing the nullifier and the note hash is tricky, because this `DelayedPrivateMutableNote` doesn't understand what an "owner" is, because that's an app-specific concept. So it delegates that responsibiility to the underlying generic `Note` types. See `delayed_private_mutable_note.nr` for much more details comments.


## Future PRs

It would be nice to have:
- An example account contract that uses this new state variable to store the user's public key.
- Typescript & Noir tests of such an account contract, with the public key being rotated.
- Typescript tests that ensure actual note discovery works for the DelayedPrivateMutableNote type, given its unusual packing approach, and manually-written note trait implementations.
- Testing a PartialNote, and seeing if the DelayedPrivateMutableNote wrapper's attempt to support partial notes actually works.