### PR TITLE
feat: Change slash votes from 4 to 2 bits

### DIFF
--- a/l1-contracts/test/benchmark/happy.t.sol
+++ b/l1-contracts/test/benchmark/happy.t.sol
@@ -391,16 +391,18 @@ contract BenchmarkRollupTest is FeeModelTestPoints, DecoderBase {
    * @return Encoded vote data
    */
   function createTallyVoteData(uint256 _size) internal returns (bytes memory) {
-    require(_size % 2 == 0, "Vote data must have even number of validators");
+    require(_size % 4 == 0, "Vote data must have multiple of 4 validators");
 
     bytes32 seed = keccak256(abi.encode(_size, block.timestamp));
 
-    bytes memory voteData = new bytes(_size / 2);
+    bytes memory voteData = new bytes(_size / 4);
 
-    for (uint256 i = 0; i < _size; i += 2) {
-      uint8 firstValidator = uint8(uint256(keccak256(abi.encode(seed, i)))) & 0x0F;
-      uint8 secondValidator = uint8(uint256(keccak256(abi.encode(seed, i + 1)))) & 0x0F;
-      voteData[i / 2] = bytes1((secondValidator << 4) | firstValidator);
+    for (uint256 i = 0; i < _size; i += 4) {
+      uint8 validator0 = uint8(uint256(keccak256(abi.encode(seed, i)))) & 0x03; // 2 bits
+      uint8 validator1 = uint8(uint256(keccak256(abi.encode(seed, i + 1)))) & 0x03; // 2 bits
+      uint8 validator2 = uint8(uint256(keccak256(abi.encode(seed, i + 2)))) & 0x03; // 2 bits
+      uint8 validator3 = uint8(uint256(keccak256(abi.encode(seed, i + 3)))) & 0x03; // 2 bits
+      voteData[i / 4] = bytes1((validator3 << 6) | (validator2 << 4) | (validator1 << 2) | validator0);
     }
 
     return voteData;

--- a/l1-contracts/test/builder/RollupBuilder.sol
+++ b/l1-contracts/test/builder/RollupBuilder.sol
@@ -224,6 +224,16 @@ contract RollupBuilder is Test {
     return this;
   }
 
+  function setEntryQueueFlushSizeMin(uint256 _flushSizeMin) public returns (RollupBuilder) {
+    config.rollupConfigInput.stakingQueueConfig.normalFlushSizeMin = _flushSizeMin;
+    return this;
+  }
+
+  function setEntryQueueFlushSizeQuotient(uint256 _flushSizeQuotient) public returns (RollupBuilder) {
+    config.rollupConfigInput.stakingQueueConfig.normalFlushSizeQuotient = _flushSizeQuotient;
+    return this;
+  }
+
   function setValidators(CheatDepositArgs[] memory _validators) public returns (RollupBuilder) {
     for (uint256 i = 0; i < _validators.length; i++) {
       config.validators.push(_validators[i]);

--- a/l1-contracts/test/harnesses/TestConstants.sol
+++ b/l1-contracts/test/harnesses/TestConstants.sol
@@ -25,7 +25,7 @@ library TestConstants {
   uint256 internal constant AZTEC_SLASHING_EXECUTION_DELAY_IN_ROUNDS = 0;
   uint256 internal constant AZTEC_SLASHING_OFFSET_IN_ROUNDS = 2;
   address internal constant AZTEC_SLASHING_VETOER = address(0);
-  uint256 internal constant AZTEC_SLASHING_UNIT = 5e18;
+  uint256 internal constant AZTEC_SLASHING_UNIT = 20e18;
   uint256 internal constant AZTEC_MANA_TARGET = 100_000_000;
   uint256 internal constant AZTEC_ENTRY_QUEUE_FLUSH_SIZE_MIN = 4;
   uint256 internal constant AZTEC_ENTRY_QUEUE_FLUSH_SIZE_QUOTIENT = 2;


### PR DESCRIPTION
To reduce gas costs. Also bumps settings in tests to get better benchmarks, so that running:

```
$ FORGE_GAS_REPORT=true forge test --mp test/governance/scenario/slashing/TallySlashing.t.sol --mt Small | grep executeRound
```

Yields 1,614,818 gas
