### PR TITLE
chore: make txe_service purely a translation layer

### DIFF
--- a/yarn-project/pxe/src/contract_function_simulator/oracle/oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/oracle.ts
@@ -239,13 +239,6 @@ export class Oracle {
       +status,
     );
 
-    if (noteDatas.length > 0) {
-      const noteLength = noteDatas[0].note.items.length;
-      if (!noteDatas.every(({ note }) => noteLength === note.items.length)) {
-        throw new Error('Notes should all be the same length.');
-      }
-    }
-
     const returnDataAsArrayOfPackedRetrievedNotes = noteDatas.map(packAsRetrievedNote);
 
     // Now we convert each sub-array to an array of ACVMField

--- a/yarn-project/txe/src/bin/index.ts
+++ b/yarn-project/txe/src/bin/index.ts
@@ -20,7 +20,7 @@ async function main() {
     process.exit(0);
   });
 
-  const logger = createLogger('txe:service');
+  const logger = createLogger('txe:rpc');
   logger.info(`Setting up TXE...`);
 
   const txeServer = createTXERpcServer(logger);

--- a/yarn-project/txe/src/index.ts
+++ b/yarn-project/txe/src/index.ts
@@ -212,7 +212,7 @@ class TXEDispatcher {
           protocolContractNames.map(name => new BundledProtocolContractsProvider().getProtocolContractArtifact(name)),
         );
       }
-      TXESessions.set(sessionId, await TXEService.init(this.logger, this.protocolContracts));
+      TXESessions.set(sessionId, await TXEService.init(this.protocolContracts));
     }
 
     switch (functionName) {

--- a/yarn-project/txe/src/txe_service/txe_service.ts
+++ b/yarn-project/txe/src/txe_service/txe_service.ts
@@ -1,12 +1,9 @@
 import { type ContractInstanceWithAddress, Fr, Point } from '@aztec/aztec.js';
-import { CONTRACT_INSTANCE_REGISTRY_CONTRACT_ADDRESS } from '@aztec/constants';
-import type { Logger } from '@aztec/foundation/log';
 import { openTmpStore } from '@aztec/kv-store/lmdb-v2';
 import type { ProtocolContract } from '@aztec/protocol-contracts';
 import { packAsRetrievedNote } from '@aztec/pxe/simulator';
 import { type ContractArtifact, FunctionSelector, NoteSelector } from '@aztec/stdlib/abi';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
-import { computePartialAddress } from '@aztec/stdlib/contract';
 import { MerkleTreeId } from '@aztec/stdlib/trees';
 
 import { TXE } from '../oracle/txe_oracle.js';
@@ -37,16 +34,12 @@ export class TXEService {
   context = TXEContext.TOP_LEVEL;
   contextChecksEnabled = false;
 
-  constructor(
-    private logger: Logger,
-    private txe: TXE,
-  ) {}
+  constructor(private txe: TXE) {}
 
-  static async init(logger: Logger, protocolContracts: ProtocolContract[]) {
-    logger.debug(`TXE service initialized`);
+  static async init(protocolContracts: ProtocolContract[]) {
     const store = await openTmpStore('test');
-    const txe = await TXE.create(logger, store, protocolContracts);
-    const service = new TXEService(logger, txe);
+    const txe = await TXE.create(store, protocolContracts);
+    const service = new TXEService(txe);
     await service.txeAdvanceBlocksBy(toSingle(new Fr(1n)));
     return service;
   }
@@ -106,62 +99,47 @@ export class TXEService {
 
   // Cheatcodes
 
-  async txeGetPrivateContextInputs(blockNumberIsSome: ForeignCallSingle, blockNumberValue: ForeignCallSingle) {
-    const blockNumber = fromSingle(blockNumberIsSome).toBool() ? fromSingle(blockNumberValue).toNumber() : null;
+  async txeGetPrivateContextInputs(
+    foreignBlockNumberIsSome: ForeignCallSingle,
+    foreignBlockNumberValue: ForeignCallSingle,
+  ) {
+    const blockNumber = fromSingle(foreignBlockNumberIsSome).toBool()
+      ? fromSingle(foreignBlockNumberValue).toNumber()
+      : null;
 
     const inputs = await this.txe.txeGetPrivateContextInputs(blockNumber);
-
-    this.logger.info(
-      `Created private context for block ${inputs.historicalHeader.globalVariables.blockNumber} (requested ${blockNumber})`,
-    );
 
     return toForeignCallResult(inputs.toFields().map(toSingle));
   }
 
-  async txeAdvanceBlocksBy(blocks: ForeignCallSingle) {
-    const nBlocks = fromSingle(blocks).toNumber();
-    this.logger.debug(`time traveling ${nBlocks} blocks`);
+  async txeAdvanceBlocksBy(foreignBlocks: ForeignCallSingle) {
+    const blocks = fromSingle(foreignBlocks).toNumber();
 
-    for (let i = 0; i < nBlocks; i++) {
-      const blockNumber = await this.txe.utilityGetBlockNumber();
-      await this.txe.commitState();
-      this.txe.setBlockNumber(blockNumber + 1);
-    }
+    await this.txe.txeAdvanceBlocksBy(blocks);
+
     return toForeignCallResult([]);
   }
 
-  txeAdvanceTimestampBy(duration: ForeignCallSingle) {
-    const durationBigInt = fromSingle(duration).toBigInt();
-    this.logger.debug(`time traveling ${durationBigInt} seconds`);
-    this.txe.txeAdvanceTimestampBy(durationBigInt);
+  txeAdvanceTimestampBy(foreignDuration: ForeignCallSingle) {
+    const duration = fromSingle(foreignDuration).toBigInt();
+
+    this.txe.txeAdvanceTimestampBy(duration);
+
     return toForeignCallResult([]);
   }
 
-  txeSetContractAddress(address: ForeignCallSingle) {
-    const typedAddress = addressFromSingle(address);
-    this.txe.txeSetContractAddress(typedAddress);
+  txeSetContractAddress(foreignAddress: ForeignCallSingle) {
+    const address = addressFromSingle(foreignAddress);
+
+    this.txe.txeSetContractAddress(address);
+
     return toForeignCallResult([]);
   }
 
-  async txeDeploy(artifact: ContractArtifact, instance: ContractInstanceWithAddress, secret: ForeignCallSingle) {
-    // Emit deployment nullifier
-    await this.txe.noteCache.nullifierCreated(
-      AztecAddress.fromNumber(CONTRACT_INSTANCE_REGISTRY_CONTRACT_ADDRESS),
-      instance.address.toField(),
-    );
+  async txeDeploy(artifact: ContractArtifact, instance: ContractInstanceWithAddress, foreignSecret: ForeignCallSingle) {
+    const secret = fromSingle(foreignSecret);
 
-    // Make sure the deployment nullifier gets included in a tx in a block
-    const blockNumber = await this.txe.utilityGetBlockNumber();
-    await this.txe.commitState();
-    this.txe.setBlockNumber(blockNumber + 1);
-
-    if (!fromSingle(secret).equals(Fr.ZERO)) {
-      await this.txeAddAccount(artifact, instance, secret);
-    } else {
-      await this.txe.addContractInstance(instance);
-      await this.txe.addContractArtifact(instance.currentContractClassId, artifact);
-      this.logger.debug(`Deployed ${artifact.name} at ${instance.address}`);
-    }
+    await this.txe.txeDeploy(artifact, instance, secret);
 
     return toForeignCallResult([
       toArray([
@@ -174,42 +152,38 @@ export class TXEService {
     ]);
   }
 
-  async txeCreateAccount(secret: ForeignCallSingle) {
-    const keyStore = this.txe.getKeyStore();
-    const secretFr = fromSingle(secret);
-    // This is a footgun !
-    const completeAddress = await keyStore.addAccount(secretFr, secretFr);
-    const accountDataProvider = this.txe.getAccountDataProvider();
-    await accountDataProvider.setAccount(completeAddress.address, completeAddress);
-    const addressDataProvider = this.txe.getAddressDataProvider();
-    await addressDataProvider.addCompleteAddress(completeAddress);
-    this.logger.debug(`Created account ${completeAddress.address}`);
+  async txeCreateAccount(foreignSecret: ForeignCallSingle) {
+    const secret = fromSingle(foreignSecret);
+
+    const completeAddress = await this.txe.txeCreateAccount(secret);
+
     return toForeignCallResult([
       toSingle(completeAddress.address),
       ...completeAddress.publicKeys.toFields().map(toSingle),
     ]);
   }
 
-  async txeAddAccount(artifact: ContractArtifact, instance: ContractInstanceWithAddress, secret: ForeignCallSingle) {
-    this.logger.debug(`Deployed ${artifact.name} at ${instance.address}`);
-    await this.txe.addContractInstance(instance);
-    await this.txe.addContractArtifact(instance.currentContractClassId, artifact);
+  async txeAddAccount(
+    artifact: ContractArtifact,
+    instance: ContractInstanceWithAddress,
+    foreignSecret: ForeignCallSingle,
+  ) {
+    const secret = fromSingle(foreignSecret);
 
-    const keyStore = this.txe.getKeyStore();
-    const completeAddress = await keyStore.addAccount(fromSingle(secret), await computePartialAddress(instance));
-    const accountDataProvider = this.txe.getAccountDataProvider();
-    await accountDataProvider.setAccount(completeAddress.address, completeAddress);
-    const addressDataProvider = this.txe.getAddressDataProvider();
-    await addressDataProvider.addCompleteAddress(completeAddress);
-    this.logger.debug(`Created account ${completeAddress.address}`);
+    const completeAddress = await this.txe.txeAddAccount(artifact, instance, secret);
+
     return toForeignCallResult([
       toSingle(completeAddress.address),
       ...completeAddress.publicKeys.toFields().map(toSingle),
     ]);
   }
 
-  async txeAddAuthWitness(address: ForeignCallSingle, messageHash: ForeignCallSingle) {
-    await this.txe.txeAddAuthWitness(addressFromSingle(address), fromSingle(messageHash));
+  async txeAddAuthWitness(foreignAddress: ForeignCallSingle, foreignMessageHash: ForeignCallSingle) {
+    const address = addressFromSingle(foreignAddress);
+    const messageHash = fromSingle(foreignMessageHash);
+
+    await this.txe.txeAddAuthWitness(address, messageHash);
+
     return toForeignCallResult([]);
   }
 
@@ -222,7 +196,9 @@ export class TXEService {
       );
     }
 
-    return toForeignCallResult([toSingle(this.txe.utilityGetRandomField())]);
+    const randomField = this.txe.utilityGetRandomField();
+
+    return toForeignCallResult([toSingle(randomField)]);
   }
 
   async utilityGetContractAddress() {
@@ -236,6 +212,7 @@ export class TXEService {
     }
 
     const contractAddress = await this.txe.utilityGetContractAddress();
+
     return toForeignCallResult([toSingle(contractAddress.toField())]);
   }
 
@@ -245,6 +222,7 @@ export class TXEService {
     }
 
     const blockNumber = await this.txe.utilityGetBlockNumber();
+
     return toForeignCallResult([toSingle(new Fr(blockNumber))]);
   }
 
@@ -255,6 +233,7 @@ export class TXEService {
     }
 
     const timestamp = await this.txe.utilityGetTimestamp();
+
     return toForeignCallResult([toSingle(new Fr(timestamp))]);
   }
 
@@ -264,121 +243,147 @@ export class TXEService {
     }
 
     const timestamp = await this.txe.txeGetLastBlockTimestamp();
+
     return toForeignCallResult([toSingle(new Fr(timestamp))]);
   }
 
   // Since the argument is a slice, noir automatically adds a length field to oracle call.
-  privateStoreInExecutionCache(_length: ForeignCallSingle, values: ForeignCallArray, hash: ForeignCallSingle) {
+  privateStoreInExecutionCache(
+    _foreignLength: ForeignCallSingle,
+    foreignValues: ForeignCallArray,
+    foreignHash: ForeignCallSingle,
+  ) {
     if (this.contextChecksEnabled && this.context == TXEContext.TOP_LEVEL) {
       throw new Error(
         'Oracle access from the root of a TXe test are not enabled. Please use env._ to interact with the oracles.',
       );
     }
+    const values = fromArray(foreignValues);
+    const hash = fromSingle(foreignHash);
 
-    this.txe.privateStoreInExecutionCache(fromArray(values), fromSingle(hash));
+    this.txe.privateStoreInExecutionCache(values, hash);
+
     return toForeignCallResult([]);
   }
 
-  async privateLoadFromExecutionCache(hash: ForeignCallSingle) {
+  async privateLoadFromExecutionCache(foreignHash: ForeignCallSingle) {
     if (this.contextChecksEnabled && this.context == TXEContext.TOP_LEVEL) {
       throw new Error(
         'Oracle access from the root of a TXe test are not enabled. Please use env._ to interact with the oracles.',
       );
     }
+    const hash = fromSingle(foreignHash);
 
-    const returns = await this.txe.privateLoadFromExecutionCache(fromSingle(hash));
+    const returns = await this.txe.privateLoadFromExecutionCache(hash);
+
     return toForeignCallResult([toArray(returns)]);
   }
 
   // Since the argument is a slice, noir automatically adds a length field to oracle call.
-  utilityDebugLog(message: ForeignCallArray, _length: ForeignCallSingle, fields: ForeignCallArray) {
-    const messageStr = fromArray(message)
+  utilityDebugLog(
+    foreignMessage: ForeignCallArray,
+    _foreignLength: ForeignCallSingle,
+    foreignFields: ForeignCallArray,
+  ) {
+    const message = fromArray(foreignMessage)
       .map(field => String.fromCharCode(field.toNumber()))
       .join('');
-    const fieldsFr = fromArray(fields);
-    this.txe.utilityDebugLog(messageStr, fieldsFr);
+    const fields = fromArray(foreignFields);
+
+    this.txe.utilityDebugLog(message, fields);
+
     return toForeignCallResult([]);
   }
 
   async utilityStorageRead(
-    contractAddress: ForeignCallSingle,
-    startStorageSlot: ForeignCallSingle,
-    blockNumber: ForeignCallSingle,
-    numberOfElements: ForeignCallSingle,
+    foreignContractAddress: ForeignCallSingle,
+    foreignStartStorageSlot: ForeignCallSingle,
+    foreignBlockNumber: ForeignCallSingle,
+    foreignNumberOfElements: ForeignCallSingle,
   ) {
-    const values = await this.txe.utilityStorageRead(
-      addressFromSingle(contractAddress),
-      fromSingle(startStorageSlot),
-      fromSingle(blockNumber).toNumber(),
-      fromSingle(numberOfElements).toNumber(),
-    );
+    const contractAddress = addressFromSingle(foreignContractAddress);
+    const startStorageSlot = fromSingle(foreignStartStorageSlot);
+    const blockNumber = fromSingle(foreignBlockNumber).toNumber();
+    const numberOfElements = fromSingle(foreignNumberOfElements).toNumber();
+
+    const values = await this.txe.utilityStorageRead(contractAddress, startStorageSlot, blockNumber, numberOfElements);
+
     return toForeignCallResult([toArray(values)]);
   }
 
-  async utilityGetPublicDataWitness(blockNumber: ForeignCallSingle, leafSlot: ForeignCallSingle) {
+  async utilityGetPublicDataWitness(foreignBlockNumber: ForeignCallSingle, foreignLeafSlot: ForeignCallSingle) {
     if (this.contextChecksEnabled && this.context == TXEContext.TOP_LEVEL) {
       throw new Error(
         'Oracle access from the root of a TXe test are not enabled. Please use env._ to interact with the oracles.',
       );
     }
+    const blockNumber = fromSingle(foreignBlockNumber).toNumber();
+    const leafSlot = fromSingle(foreignLeafSlot);
 
-    const parsedBlockNumber = fromSingle(blockNumber).toNumber();
-    const parsedLeafSlot = fromSingle(leafSlot);
+    const witness = await this.txe.utilityGetPublicDataWitness(blockNumber, leafSlot);
 
-    const witness = await this.txe.utilityGetPublicDataWitness(parsedBlockNumber, parsedLeafSlot);
     if (!witness) {
-      throw new Error(`Public data witness not found for slot ${parsedLeafSlot} at block ${parsedBlockNumber}.`);
+      throw new Error(`Public data witness not found for slot ${leafSlot} at block ${blockNumber}.`);
     }
     return toForeignCallResult(witness.toNoirRepresentation());
   }
 
   async utilityGetNotes(
-    storageSlot: ForeignCallSingle,
-    numSelects: ForeignCallSingle,
-    selectByIndexes: ForeignCallArray,
-    selectByOffsets: ForeignCallArray,
-    selectByLengths: ForeignCallArray,
-    selectValues: ForeignCallArray,
-    selectComparators: ForeignCallArray,
-    sortByIndexes: ForeignCallArray,
-    sortByOffsets: ForeignCallArray,
-    sortByLengths: ForeignCallArray,
-    sortOrder: ForeignCallArray,
-    limit: ForeignCallSingle,
-    offset: ForeignCallSingle,
-    status: ForeignCallSingle,
-    maxNotes: ForeignCallSingle,
-    packedRetrievedNoteLength: ForeignCallSingle,
+    foreignStorageSlot: ForeignCallSingle,
+    foreignNumSelects: ForeignCallSingle,
+    foreignSelectByIndexes: ForeignCallArray,
+    foreignSelectByOffsets: ForeignCallArray,
+    foreignSelectByLengths: ForeignCallArray,
+    foreignSelectValues: ForeignCallArray,
+    foreignSelectComparators: ForeignCallArray,
+    foreignSortByIndexes: ForeignCallArray,
+    foreignSortByOffsets: ForeignCallArray,
+    foreignSortByLengths: ForeignCallArray,
+    foreignSortOrder: ForeignCallArray,
+    foreignLimit: ForeignCallSingle,
+    foreignOffset: ForeignCallSingle,
+    foreignStatus: ForeignCallSingle,
+    foreignMaxNotes: ForeignCallSingle,
+    foreignPackedRetrievedNoteLength: ForeignCallSingle,
   ) {
     if (this.contextChecksEnabled && this.context == TXEContext.TOP_LEVEL) {
       throw new Error(
         'Oracle access from the root of a TXe test are not enabled. Please use env._ to interact with the oracles.',
       );
     }
+    const storageSlot = fromSingle(foreignStorageSlot);
+    const numSelects = fromSingle(foreignNumSelects).toNumber();
+    const selectByIndexes = fromArray(foreignSelectByIndexes).map(fr => fr.toNumber());
+    const selectByOffsets = fromArray(foreignSelectByOffsets).map(fr => fr.toNumber());
+    const selectByLengths = fromArray(foreignSelectByLengths).map(fr => fr.toNumber());
+    const selectValues = fromArray(foreignSelectValues);
+    const selectComparators = fromArray(foreignSelectComparators).map(fr => fr.toNumber());
+    const sortByIndexes = fromArray(foreignSortByIndexes).map(fr => fr.toNumber());
+    const sortByOffsets = fromArray(foreignSortByOffsets).map(fr => fr.toNumber());
+    const sortByLengths = fromArray(foreignSortByLengths).map(fr => fr.toNumber());
+    const sortOrder = fromArray(foreignSortOrder).map(fr => fr.toNumber());
+    const limit = fromSingle(foreignLimit).toNumber();
+    const offset = fromSingle(foreignOffset).toNumber();
+    const status = fromSingle(foreignStatus).toNumber();
+    const maxNotes = fromSingle(foreignMaxNotes).toNumber();
+    const packedRetrievedNoteLength = fromSingle(foreignPackedRetrievedNoteLength).toNumber();
 
     const noteDatas = await this.txe.utilityGetNotes(
-      fromSingle(storageSlot),
-      fromSingle(numSelects).toNumber(),
-      fromArray(selectByIndexes).map(fr => fr.toNumber()),
-      fromArray(selectByOffsets).map(fr => fr.toNumber()),
-      fromArray(selectByLengths).map(fr => fr.toNumber()),
-      fromArray(selectValues),
-      fromArray(selectComparators).map(fr => fr.toNumber()),
-      fromArray(sortByIndexes).map(fr => fr.toNumber()),
-      fromArray(sortByOffsets).map(fr => fr.toNumber()),
-      fromArray(sortByLengths).map(fr => fr.toNumber()),
-      fromArray(sortOrder).map(fr => fr.toNumber()),
-      fromSingle(limit).toNumber(),
-      fromSingle(offset).toNumber(),
-      fromSingle(status).toNumber(),
+      storageSlot,
+      numSelects,
+      selectByIndexes,
+      selectByOffsets,
+      selectByLengths,
+      selectValues,
+      selectComparators,
+      sortByIndexes,
+      sortByOffsets,
+      sortByLengths,
+      sortOrder,
+      limit,
+      offset,
+      status,
     );
-
-    if (noteDatas.length > 0) {
-      const noteLength = noteDatas[0].note.items.length;
-      if (!noteDatas.every(({ note }) => noteLength === note.items.length)) {
-        throw new Error('Notes should all be the same length.');
-      }
-    }
 
     const returnDataAsArrayOfArrays = noteDatas.map(packAsRetrievedNote);
 
@@ -391,84 +396,90 @@ export class TXEService {
     return toForeignCallResult(
       arrayOfArraysToBoundedVecOfArrays(
         returnDataAsArrayOfForeignCallSingleArrays,
-        fromSingle(maxNotes).toNumber(),
-        fromSingle(packedRetrievedNoteLength).toNumber(),
+        maxNotes,
+        packedRetrievedNoteLength,
       ),
     );
   }
 
   privateNotifyCreatedNote(
-    storageSlot: ForeignCallSingle,
-    noteTypeId: ForeignCallSingle,
-    note: ForeignCallArray,
-    noteHash: ForeignCallSingle,
-    counter: ForeignCallSingle,
+    foreignStorageSlot: ForeignCallSingle,
+    foreignNoteTypeId: ForeignCallSingle,
+    foreignNote: ForeignCallArray,
+    foreignNoteHash: ForeignCallSingle,
+    foreignCounter: ForeignCallSingle,
   ) {
     if (this.contextChecksEnabled && this.context == TXEContext.TOP_LEVEL) {
       throw new Error(
         'Oracle access from the root of a TXe test are not enabled. Please use env._ to interact with the oracles.',
       );
     }
+    const storageSlot = fromSingle(foreignStorageSlot);
+    const noteTypeId = NoteSelector.fromField(fromSingle(foreignNoteTypeId));
+    const note = fromArray(foreignNote);
+    const noteHash = fromSingle(foreignNoteHash);
+    const counter = fromSingle(foreignCounter).toNumber();
 
-    this.txe.privateNotifyCreatedNote(
-      fromSingle(storageSlot),
-      NoteSelector.fromField(fromSingle(noteTypeId)),
-      fromArray(note),
-      fromSingle(noteHash),
-      fromSingle(counter).toNumber(),
-    );
+    this.txe.privateNotifyCreatedNote(storageSlot, noteTypeId, note, noteHash, counter);
+
     return toForeignCallResult([]);
   }
 
   async privateNotifyNullifiedNote(
-    innerNullifier: ForeignCallSingle,
-    noteHash: ForeignCallSingle,
-    counter: ForeignCallSingle,
+    foreignInnerNullifier: ForeignCallSingle,
+    foreignNoteHash: ForeignCallSingle,
+    foreignCounter: ForeignCallSingle,
   ) {
     if (this.contextChecksEnabled && this.context == TXEContext.TOP_LEVEL) {
       throw new Error(
         'Oracle access from the root of a TXe test are not enabled. Please use env._ to interact with the oracles.',
       );
     }
+    const innerNullifier = fromSingle(foreignInnerNullifier);
+    const noteHash = fromSingle(foreignNoteHash);
+    const counter = fromSingle(foreignCounter).toNumber();
 
-    await this.txe.privateNotifyNullifiedNote(
-      fromSingle(innerNullifier),
-      fromSingle(noteHash),
-      fromSingle(counter).toNumber(),
-    );
+    await this.txe.privateNotifyNullifiedNote(innerNullifier, noteHash, counter);
+
     return toForeignCallResult([]);
   }
 
-  async privateNotifyCreatedNullifier(innerNullifier: ForeignCallSingle) {
+  async privateNotifyCreatedNullifier(foreignInnerNullifier: ForeignCallSingle) {
     if (this.contextChecksEnabled && this.context == TXEContext.TOP_LEVEL) {
       throw new Error(
         'Oracle access from the root of a TXe test are not enabled. Please use env._ to interact with the oracles.',
       );
     }
+    const innerNullifier = fromSingle(foreignInnerNullifier);
 
-    await this.txe.privateNotifyCreatedNullifier(fromSingle(innerNullifier));
+    await this.txe.privateNotifyCreatedNullifier(innerNullifier);
+
     return toForeignCallResult([]);
   }
 
-  async utilityCheckNullifierExists(innerNullifier: ForeignCallSingle) {
+  async utilityCheckNullifierExists(foreignInnerNullifier: ForeignCallSingle) {
     if (this.contextChecksEnabled && this.context == TXEContext.TOP_LEVEL) {
       throw new Error(
         'Oracle access from the root of a TXe test are not enabled. Please use env._ to interact with the oracles.',
       );
     }
+    const innerNullifier = fromSingle(foreignInnerNullifier);
 
-    const exists = await this.txe.utilityCheckNullifierExists(fromSingle(innerNullifier));
+    const exists = await this.txe.utilityCheckNullifierExists(innerNullifier);
+
     return toForeignCallResult([toSingle(new Fr(exists))]);
   }
 
-  async utilityGetContractInstance(address: ForeignCallSingle) {
+  async utilityGetContractInstance(foreignAddress: ForeignCallSingle) {
     if (this.contextChecksEnabled && this.context == TXEContext.TOP_LEVEL) {
       throw new Error(
         'Oracle access from the root of a TXe test are not enabled. Please use env._ to interact with the oracles.',
       );
     }
+    const address = addressFromSingle(foreignAddress);
 
-    const instance = await this.txe.utilityGetContractInstance(addressFromSingle(address));
+    const instance = await this.txe.utilityGetContractInstance(address);
+
     return toForeignCallResult(
       [
         instance.salt,
@@ -480,90 +491,99 @@ export class TXEService {
     );
   }
 
-  async utilityGetPublicKeysAndPartialAddress(address: ForeignCallSingle) {
+  async utilityGetPublicKeysAndPartialAddress(foreignAddress: ForeignCallSingle) {
     if (this.contextChecksEnabled && this.context == TXEContext.TOP_LEVEL) {
       throw new Error(
         'Oracle access from the root of a TXe test are not enabled. Please use env._ to interact with the oracles.',
       );
     }
+    const address = addressFromSingle(foreignAddress);
 
-    const parsedAddress = addressFromSingle(address);
-    const { publicKeys, partialAddress } = await this.txe.utilityGetCompleteAddress(parsedAddress);
+    const { publicKeys, partialAddress } = await this.txe.utilityGetCompleteAddress(address);
+
     return toForeignCallResult([toArray([...publicKeys.toFields(), partialAddress])]);
   }
 
-  async utilityGetKeyValidationRequest(pkMHash: ForeignCallSingle) {
+  async utilityGetKeyValidationRequest(foreignPkMHash: ForeignCallSingle) {
     if (this.contextChecksEnabled && this.context == TXEContext.TOP_LEVEL) {
       throw new Error(
         'Oracle access from the root of a TXe test are not enabled. Please use env._ to interact with the oracles.',
       );
     }
+    const pkMHash = fromSingle(foreignPkMHash);
 
-    const keyValidationRequest = await this.txe.utilityGetKeyValidationRequest(fromSingle(pkMHash));
+    const keyValidationRequest = await this.txe.utilityGetKeyValidationRequest(pkMHash);
+
     return toForeignCallResult(keyValidationRequest.toFields().map(toSingle));
   }
 
   privateCallPrivateFunction(
-    _targetContractAddress: ForeignCallSingle,
-    _functionSelector: ForeignCallSingle,
-    _argsHash: ForeignCallSingle,
-    _sideEffectCounter: ForeignCallSingle,
-    _isStaticCall: ForeignCallSingle,
+    _foreignTargetContractAddress: ForeignCallSingle,
+    _foreignFunctionSelector: ForeignCallSingle,
+    _foreignArgsHash: ForeignCallSingle,
+    _foreignSideEffectCounter: ForeignCallSingle,
+    _foreignIsStaticCall: ForeignCallSingle,
   ) {
     throw new Error(
       'Contract calls are forbidden inside a `TestEnvironment::private_context`, use `private_call` instead',
     );
   }
 
-  async utilityGetNullifierMembershipWitness(blockNumber: ForeignCallSingle, nullifier: ForeignCallSingle) {
+  async utilityGetNullifierMembershipWitness(
+    foreignBlockNumber: ForeignCallSingle,
+    foreignNullifier: ForeignCallSingle,
+  ) {
     if (this.contextChecksEnabled && this.context == TXEContext.TOP_LEVEL) {
       throw new Error(
         'Oracle access from the root of a TXe test are not enabled. Please use env._ to interact with the oracles.',
       );
     }
+    const blockNumber = fromSingle(foreignBlockNumber).toNumber();
+    const nullifier = fromSingle(foreignNullifier);
 
-    const parsedBlockNumber = fromSingle(blockNumber).toNumber();
-    const witness = await this.txe.utilityGetNullifierMembershipWitness(parsedBlockNumber, fromSingle(nullifier));
+    const witness = await this.txe.utilityGetNullifierMembershipWitness(blockNumber, nullifier);
+
     if (!witness) {
-      throw new Error(`Nullifier membership witness not found at block ${parsedBlockNumber}.`);
+      throw new Error(`Nullifier membership witness not found at block ${blockNumber}.`);
     }
     return toForeignCallResult(witness.toNoirRepresentation());
   }
 
-  async utilityGetAuthWitness(messageHash: ForeignCallSingle) {
+  async utilityGetAuthWitness(foreignMessageHash: ForeignCallSingle) {
     if (this.contextChecksEnabled && this.context == TXEContext.TOP_LEVEL) {
       throw new Error(
         'Oracle access from the root of a TXe test are not enabled. Please use env._ to interact with the oracles.',
       );
     }
+    const messageHash = fromSingle(foreignMessageHash);
 
-    const parsedMessageHash = fromSingle(messageHash);
-    const authWitness = await this.txe.utilityGetAuthWitness(parsedMessageHash);
+    const authWitness = await this.txe.utilityGetAuthWitness(messageHash);
+
     if (!authWitness) {
-      throw new Error(`Auth witness not found for message hash ${parsedMessageHash}.`);
+      throw new Error(`Auth witness not found for message hash ${messageHash}.`);
     }
     return toForeignCallResult([toArray(authWitness)]);
   }
 
   public privateNotifyEnqueuedPublicFunctionCall(
-    _targetContractAddress: ForeignCallSingle,
-    _calldataHash: ForeignCallSingle,
-    _sideEffectCounter: ForeignCallSingle,
-    _isStaticCall: ForeignCallSingle,
+    _foreignTargetContractAddress: ForeignCallSingle,
+    _foreignCalldataHash: ForeignCallSingle,
+    _foreignSideEffectCounter: ForeignCallSingle,
+    _foreignIsStaticCall: ForeignCallSingle,
   ) {
     throw new Error('Enqueueing public calls is not supported in TestEnvironment::private_context');
   }
 
   public privateNotifySetPublicTeardownFunctionCall(
-    _targetContractAddress: ForeignCallSingle,
-    _calldataHash: ForeignCallSingle,
-    _sideEffectCounter: ForeignCallSingle,
-    _isStaticCall: ForeignCallSingle,
+    _foreignTargetContractAddress: ForeignCallSingle,
+    _foreignCalldataHash: ForeignCallSingle,
+    _foreignSideEffectCounter: ForeignCallSingle,
+    _foreignIsStaticCall: ForeignCallSingle,
   ) {
     throw new Error('Enqueueing public calls is not supported in TestEnvironment::private_context');
   }
 
-  public privateNotifySetMinRevertibleSideEffectCounter(_minRevertibleSideEffectCounter: ForeignCallSingle) {
+  public privateNotifySetMinRevertibleSideEffectCounter(_foreignMinRevertibleSideEffectCounter: ForeignCallSingle) {
     throw new Error('Enqueueing public calls is not supported in TestEnvironment::private_context');
   }
 
@@ -574,7 +594,9 @@ export class TXEService {
       );
     }
 
-    return toForeignCallResult([toSingle(await this.txe.utilityGetChainId())]);
+    const chainId = await this.txe.utilityGetChainId();
+
+    return toForeignCallResult([toSingle(chainId)]);
   }
 
   async utilityGetVersion() {
@@ -584,17 +606,21 @@ export class TXEService {
       );
     }
 
-    return toForeignCallResult([toSingle(await this.txe.utilityGetVersion())]);
+    const version = await this.txe.utilityGetVersion();
+
+    return toForeignCallResult([toSingle(version)]);
   }
 
-  async utilityGetBlockHeader(blockNumber: ForeignCallSingle) {
+  async utilityGetBlockHeader(foreignBlockNumber: ForeignCallSingle) {
     if (this.contextChecksEnabled && this.context == TXEContext.TOP_LEVEL) {
       throw new Error(
         'Oracle access from the root of a TXe test are not enabled. Please use env._ to interact with the oracles.',
       );
     }
+    const blockNumber = fromSingle(foreignBlockNumber).toNumber();
 
-    const header = await this.txe.utilityGetBlockHeader(fromSingle(blockNumber).toNumber());
+    const header = await this.txe.utilityGetBlockHeader(blockNumber);
+
     if (!header) {
       throw new Error(`Block header not found for block ${blockNumber}.`);
     }
@@ -602,175 +628,199 @@ export class TXEService {
   }
 
   async utilityGetMembershipWitness(
-    blockNumber: ForeignCallSingle,
-    treeId: ForeignCallSingle,
-    leafValue: ForeignCallSingle,
+    foreignBlockNumber: ForeignCallSingle,
+    foreignTreeId: ForeignCallSingle,
+    foreignLeafValue: ForeignCallSingle,
   ) {
     if (this.contextChecksEnabled && this.context == TXEContext.TOP_LEVEL) {
       throw new Error(
         'Oracle access from the root of a TXe test are not enabled. Please use env._ to interact with the oracles.',
       );
     }
+    const blockNumber = fromSingle(foreignBlockNumber).toNumber();
+    const treeId = fromSingle(foreignTreeId).toNumber();
+    const leafValue = fromSingle(foreignLeafValue);
 
-    const parsedBlockNumber = fromSingle(blockNumber).toNumber();
-    const parsedTreeId = fromSingle(treeId).toNumber();
-    const parsedLeafValue = fromSingle(leafValue);
-    const witness = await this.txe.utilityGetMembershipWitness(parsedBlockNumber, parsedTreeId, parsedLeafValue);
+    const witness = await this.txe.utilityGetMembershipWitness(blockNumber, treeId, leafValue);
+
     if (!witness) {
       throw new Error(
-        `Membership witness in tree ${MerkleTreeId[parsedTreeId]} not found for value ${parsedLeafValue} at block ${parsedBlockNumber}.`,
+        `Membership witness in tree ${MerkleTreeId[treeId]} not found for value ${leafValue} at block ${blockNumber}.`,
       );
     }
     return toForeignCallResult([toSingle(witness[0]), toArray(witness.slice(1))]);
   }
 
-  async utilityGetLowNullifierMembershipWitness(blockNumber: ForeignCallSingle, nullifier: ForeignCallSingle) {
-    if (this.contextChecksEnabled && this.context == TXEContext.TOP_LEVEL) {
-      throw new Error(
-        'Oracle access from the root of a TXe test are not enabled. Please use env._ to interact with the oracles.',
-      );
-    }
-
-    const parsedBlockNumber = fromSingle(blockNumber).toNumber();
-
-    const witness = await this.txe.utilityGetLowNullifierMembershipWitness(parsedBlockNumber, fromSingle(nullifier));
-    if (!witness) {
-      throw new Error(`Low nullifier witness not found for nullifier ${nullifier} at block ${parsedBlockNumber}.`);
-    }
-    return toForeignCallResult(witness.toNoirRepresentation());
-  }
-
-  async utilityGetIndexedTaggingSecretAsSender(sender: ForeignCallSingle, recipient: ForeignCallSingle) {
-    if (this.contextChecksEnabled && this.context == TXEContext.TOP_LEVEL) {
-      throw new Error(
-        'Oracle access from the root of a TXe test are not enabled. Please use env._ to interact with the oracles.',
-      );
-    }
-
-    const secret = await this.txe.utilityGetIndexedTaggingSecretAsSender(
-      AztecAddress.fromField(fromSingle(sender)),
-      AztecAddress.fromField(fromSingle(recipient)),
-    );
-    return toForeignCallResult(secret.toFields().map(toSingle));
-  }
-
-  async utilityFetchTaggedLogs(pendingTaggedLogArrayBaseSlot: ForeignCallSingle) {
-    if (this.contextChecksEnabled && this.context == TXEContext.TOP_LEVEL) {
-      throw new Error(
-        'Oracle access from the root of a TXe test are not enabled. Please use env._ to interact with the oracles.',
-      );
-    }
-
-    await this.txe.utilityFetchTaggedLogs(fromSingle(pendingTaggedLogArrayBaseSlot));
-    return toForeignCallResult([]);
-  }
-
-  public async utilityValidateEnqueuedNotesAndEvents(
-    contractAddress: ForeignCallSingle,
-    noteValidationRequestsArrayBaseSlot: ForeignCallSingle,
-    eventValidationRequestsArrayBaseSlot: ForeignCallSingle,
+  async utilityGetLowNullifierMembershipWitness(
+    foreignBlockNumber: ForeignCallSingle,
+    foreignNullifier: ForeignCallSingle,
   ) {
     if (this.contextChecksEnabled && this.context == TXEContext.TOP_LEVEL) {
       throw new Error(
         'Oracle access from the root of a TXe test are not enabled. Please use env._ to interact with the oracles.',
       );
     }
+    const blockNumber = fromSingle(foreignBlockNumber).toNumber();
+    const nullifier = fromSingle(foreignNullifier);
+
+    const witness = await this.txe.utilityGetLowNullifierMembershipWitness(blockNumber, nullifier);
+
+    if (!witness) {
+      throw new Error(`Low nullifier witness not found for nullifier ${nullifier} at block ${blockNumber}.`);
+    }
+    return toForeignCallResult(witness.toNoirRepresentation());
+  }
+
+  async utilityGetIndexedTaggingSecretAsSender(foreignSender: ForeignCallSingle, foreignRecipient: ForeignCallSingle) {
+    if (this.contextChecksEnabled && this.context == TXEContext.TOP_LEVEL) {
+      throw new Error(
+        'Oracle access from the root of a TXe test are not enabled. Please use env._ to interact with the oracles.',
+      );
+    }
+    const sender = AztecAddress.fromField(fromSingle(foreignSender));
+    const recipient = AztecAddress.fromField(fromSingle(foreignRecipient));
+
+    const secret = await this.txe.utilityGetIndexedTaggingSecretAsSender(sender, recipient);
+
+    return toForeignCallResult(secret.toFields().map(toSingle));
+  }
+
+  async utilityFetchTaggedLogs(foreignPendingTaggedLogArrayBaseSlot: ForeignCallSingle) {
+    if (this.contextChecksEnabled && this.context == TXEContext.TOP_LEVEL) {
+      throw new Error(
+        'Oracle access from the root of a TXe test are not enabled. Please use env._ to interact with the oracles.',
+      );
+    }
+    const pendingTaggedLogArrayBaseSlot = fromSingle(foreignPendingTaggedLogArrayBaseSlot);
+
+    await this.txe.utilityFetchTaggedLogs(pendingTaggedLogArrayBaseSlot);
+
+    return toForeignCallResult([]);
+  }
+
+  public async utilityValidateEnqueuedNotesAndEvents(
+    foreignContractAddress: ForeignCallSingle,
+    foreignNoteValidationRequestsArrayBaseSlot: ForeignCallSingle,
+    foreignEventValidationRequestsArrayBaseSlot: ForeignCallSingle,
+  ) {
+    if (this.contextChecksEnabled && this.context == TXEContext.TOP_LEVEL) {
+      throw new Error(
+        'Oracle access from the root of a TXe test are not enabled. Please use env._ to interact with the oracles.',
+      );
+    }
+    const contractAddress = AztecAddress.fromField(fromSingle(foreignContractAddress));
+    const noteValidationRequestsArrayBaseSlot = fromSingle(foreignNoteValidationRequestsArrayBaseSlot);
+    const eventValidationRequestsArrayBaseSlot = fromSingle(foreignEventValidationRequestsArrayBaseSlot);
 
     await this.txe.utilityValidateEnqueuedNotesAndEvents(
-      AztecAddress.fromField(fromSingle(contractAddress)),
-      fromSingle(noteValidationRequestsArrayBaseSlot),
-      fromSingle(eventValidationRequestsArrayBaseSlot),
+      contractAddress,
+      noteValidationRequestsArrayBaseSlot,
+      eventValidationRequestsArrayBaseSlot,
     );
 
     return toForeignCallResult([]);
   }
 
   public async utilityBulkRetrieveLogs(
-    contractAddress: ForeignCallSingle,
-    logRetrievalRequestsArrayBaseSlot: ForeignCallSingle,
-    logRetrievalResponsesArrayBaseSlot: ForeignCallSingle,
+    foreignContractAddress: ForeignCallSingle,
+    foreignLogRetrievalRequestsArrayBaseSlot: ForeignCallSingle,
+    foreignLogRetrievalResponsesArrayBaseSlot: ForeignCallSingle,
   ) {
     if (this.contextChecksEnabled && this.context == TXEContext.TOP_LEVEL) {
       throw new Error(
         'Oracle access from the root of a TXe test are not enabled. Please use env._ to interact with the oracles.',
       );
     }
+    const contractAddress = AztecAddress.fromField(fromSingle(foreignContractAddress));
+    const logRetrievalRequestsArrayBaseSlot = fromSingle(foreignLogRetrievalRequestsArrayBaseSlot);
+    const logRetrievalResponsesArrayBaseSlot = fromSingle(foreignLogRetrievalResponsesArrayBaseSlot);
 
     await this.txe.utilityBulkRetrieveLogs(
-      AztecAddress.fromField(fromSingle(contractAddress)),
-      fromSingle(logRetrievalRequestsArrayBaseSlot),
-      fromSingle(logRetrievalResponsesArrayBaseSlot),
+      contractAddress,
+      logRetrievalRequestsArrayBaseSlot,
+      logRetrievalResponsesArrayBaseSlot,
     );
 
     return toForeignCallResult([]);
   }
 
-  async utilityStoreCapsule(contractAddress: ForeignCallSingle, slot: ForeignCallSingle, capsule: ForeignCallArray) {
+  async utilityStoreCapsule(
+    foreignContractAddress: ForeignCallSingle,
+    foreignSlot: ForeignCallSingle,
+    foreignCapsule: ForeignCallArray,
+  ) {
     if (this.contextChecksEnabled && this.context == TXEContext.TOP_LEVEL) {
       throw new Error(
         'Oracle access from the root of a TXe test are not enabled. Please use env._ to interact with the oracles.',
       );
     }
+    const contractAddress = AztecAddress.fromField(fromSingle(foreignContractAddress));
+    const slot = fromSingle(foreignSlot);
+    const capsule = fromArray(foreignCapsule);
 
-    await this.txe.utilityStoreCapsule(
-      AztecAddress.fromField(fromSingle(contractAddress)),
-      fromSingle(slot),
-      fromArray(capsule),
-    );
+    await this.txe.utilityStoreCapsule(contractAddress, slot, capsule);
+
     return toForeignCallResult([]);
   }
 
-  async utilityLoadCapsule(contractAddress: ForeignCallSingle, slot: ForeignCallSingle, tSize: ForeignCallSingle) {
+  async utilityLoadCapsule(
+    foreignContractAddress: ForeignCallSingle,
+    foreignSlot: ForeignCallSingle,
+    foreignTSize: ForeignCallSingle,
+  ) {
     if (this.contextChecksEnabled && this.context == TXEContext.TOP_LEVEL) {
       throw new Error(
         'Oracle access from the root of a TXe test are not enabled. Please use env._ to interact with the oracles.',
       );
     }
+    const contractAddress = AztecAddress.fromField(fromSingle(foreignContractAddress));
+    const slot = fromSingle(foreignSlot);
+    const tSize = fromSingle(foreignTSize).toNumber();
 
-    const values = await this.txe.utilityLoadCapsule(
-      AztecAddress.fromField(fromSingle(contractAddress)),
-      fromSingle(slot),
-    );
+    const values = await this.txe.utilityLoadCapsule(contractAddress, slot);
+
     // We are going to return a Noir Option struct to represent the possibility of null values. Options are a struct
     // with two fields: `some` (a boolean) and `value` (a field array in this case).
     if (values === null) {
       // No data was found so we set `some` to 0 and pad `value` with zeros get the correct return size.
-      return toForeignCallResult([toSingle(new Fr(0)), toArray(Array(fromSingle(tSize).toNumber()).fill(new Fr(0)))]);
+      return toForeignCallResult([toSingle(new Fr(0)), toArray(Array(tSize).fill(new Fr(0)))]);
     } else {
       // Data was found so we set `some` to 1 and return it along with `value`.
       return toForeignCallResult([toSingle(new Fr(1)), toArray(values)]);
     }
   }
 
-  async utilityDeleteCapsule(contractAddress: ForeignCallSingle, slot: ForeignCallSingle) {
+  async utilityDeleteCapsule(foreignContractAddress: ForeignCallSingle, foreignSlot: ForeignCallSingle) {
     if (this.contextChecksEnabled && this.context == TXEContext.TOP_LEVEL) {
       throw new Error(
         'Oracle access from the root of a TXe test are not enabled. Please use env._ to interact with the oracles.',
       );
     }
+    const contractAddress = AztecAddress.fromField(fromSingle(foreignContractAddress));
+    const slot = fromSingle(foreignSlot);
 
-    await this.txe.utilityDeleteCapsule(AztecAddress.fromField(fromSingle(contractAddress)), fromSingle(slot));
+    await this.txe.utilityDeleteCapsule(contractAddress, slot);
+
     return toForeignCallResult([]);
   }
 
   async utilityCopyCapsule(
-    contractAddress: ForeignCallSingle,
-    srcSlot: ForeignCallSingle,
-    dstSlot: ForeignCallSingle,
-    numEntries: ForeignCallSingle,
+    foreignContractAddress: ForeignCallSingle,
+    foreignSrcSlot: ForeignCallSingle,
+    foreignDstSlot: ForeignCallSingle,
+    foreignNumEntries: ForeignCallSingle,
   ) {
     if (this.contextChecksEnabled && this.context == TXEContext.TOP_LEVEL) {
       throw new Error(
         'Oracle access from the root of a TXe test are not enabled. Please use env._ to interact with the oracles.',
       );
     }
+    const contractAddress = AztecAddress.fromField(fromSingle(foreignContractAddress));
+    const srcSlot = fromSingle(foreignSrcSlot);
+    const dstSlot = fromSingle(foreignDstSlot);
+    const numEntries = fromSingle(foreignNumEntries).toNumber();
 
-    await this.txe.utilityCopyCapsule(
-      AztecAddress.fromField(fromSingle(contractAddress)),
-      fromSingle(srcSlot),
-      fromSingle(dstSlot),
-      fromSingle(numEntries).toNumber(),
-    );
+    await this.txe.utilityCopyCapsule(contractAddress, srcSlot, dstSlot, numEntries);
 
     return toForeignCallResult([]);
   }
@@ -780,52 +830,57 @@ export class TXEService {
   // to implement this function here. Isn't there a way to programmatically identify that this is missing, given the
   // existence of a txe_oracle method?
   async utilityAes128Decrypt(
-    ciphertextBVecStorage: ForeignCallArray,
-    ciphertextLength: ForeignCallSingle,
-    iv: ForeignCallArray,
-    symKey: ForeignCallArray,
+    foreignCiphertextBVecStorage: ForeignCallArray,
+    foreignCiphertextLength: ForeignCallSingle,
+    foreignIv: ForeignCallArray,
+    foreignSymKey: ForeignCallArray,
   ) {
     if (this.contextChecksEnabled && this.context == TXEContext.TOP_LEVEL) {
       throw new Error(
         'Oracle access from the root of a TXe test are not enabled. Please use env._ to interact with the oracles.',
       );
     }
+    const ciphertext = fromUintBoundedVec(foreignCiphertextBVecStorage, foreignCiphertextLength, 8);
+    const iv = fromUintArray(foreignIv, 8);
+    const symKey = fromUintArray(foreignSymKey, 8);
 
-    const ciphertext = fromUintBoundedVec(ciphertextBVecStorage, ciphertextLength, 8);
-    const ivBuffer = fromUintArray(iv, 8);
-    const symKeyBuffer = fromUintArray(symKey, 8);
+    const plaintextBuffer = await this.txe.utilityAes128Decrypt(ciphertext, iv, symKey);
 
-    const plaintextBuffer = await this.txe.utilityAes128Decrypt(ciphertext, ivBuffer, symKeyBuffer);
-
-    return toForeignCallResult(arrayToBoundedVec(bufferToU8Array(plaintextBuffer), ciphertextBVecStorage.length));
+    return toForeignCallResult(
+      arrayToBoundedVec(bufferToU8Array(plaintextBuffer), foreignCiphertextBVecStorage.length),
+    );
   }
 
   async utilityGetSharedSecret(
-    address: ForeignCallSingle,
-    ephPKField0: ForeignCallSingle,
-    ephPKField1: ForeignCallSingle,
-    ephPKField2: ForeignCallSingle,
+    foreignAddress: ForeignCallSingle,
+    foreignEphPKField0: ForeignCallSingle,
+    foreignEphPKField1: ForeignCallSingle,
+    foreignEphPKField2: ForeignCallSingle,
   ) {
     if (this.contextChecksEnabled && this.context == TXEContext.TOP_LEVEL) {
       throw new Error(
         'Oracle access from the root of a TXe test are not enabled. Please use env._ to interact with the oracles.',
       );
     }
+    const address = AztecAddress.fromField(fromSingle(foreignAddress));
+    const ephPK = Point.fromFields([
+      fromSingle(foreignEphPKField0),
+      fromSingle(foreignEphPKField1),
+      fromSingle(foreignEphPKField2),
+    ]);
 
-    const secret = await this.txe.utilityGetSharedSecret(
-      AztecAddress.fromField(fromSingle(address)),
-      Point.fromFields([fromSingle(ephPKField0), fromSingle(ephPKField1), fromSingle(ephPKField2)]),
-    );
+    const secret = await this.txe.utilityGetSharedSecret(address, ephPK);
+
     return toForeignCallResult(secret.toFields().map(toSingle));
   }
 
-  emitOffchainEffect(_data: ForeignCallArray) {
+  emitOffchainEffect(_foreignData: ForeignCallArray) {
     throw new Error('Offchain effects are not yet supported in the TestEnvironment');
   }
 
   // AVM opcodes
 
-  avmOpcodeEmitUnencryptedLog(_message: ForeignCallArray) {
+  avmOpcodeEmitUnencryptedLog(_foreignMessage: ForeignCallArray) {
     if (this.contextChecksEnabled && this.context != TXEContext.PUBLIC) {
       throw new Error(
         `Attempted to call the avmOpcodeEmitUnencryptedLog oracle while in context ${TXEContext[this.context]}`,
@@ -836,34 +891,41 @@ export class TXEService {
     return toForeignCallResult([]);
   }
 
-  async avmOpcodeStorageRead(slot: ForeignCallSingle) {
+  async avmOpcodeStorageRead(foreignSlot: ForeignCallSingle) {
     if (this.contextChecksEnabled && this.context != TXEContext.PUBLIC) {
       throw new Error(`Attempted to call the avmOpcodeStorageRead oracle while in context ${TXEContext[this.context]}`);
     }
+    const slot = fromSingle(foreignSlot);
 
-    const value = (await this.txe.avmOpcodeStorageRead(fromSingle(slot))).value;
+    const value = (await this.txe.avmOpcodeStorageRead(slot)).value;
+
     return toForeignCallResult([toSingle(new Fr(value))]);
   }
 
-  async avmOpcodeStorageWrite(slot: ForeignCallSingle, value: ForeignCallSingle) {
+  async avmOpcodeStorageWrite(foreignSlot: ForeignCallSingle, foreignValue: ForeignCallSingle) {
     if (this.contextChecksEnabled && this.context != TXEContext.PUBLIC) {
       throw new Error(
         `Attempted to call the avmOpcodeStorageWrite oracle while in context ${TXEContext[this.context]}`,
       );
     }
+    const slot = fromSingle(foreignSlot);
+    const value = fromSingle(foreignValue);
 
-    await this.txe.storageWrite(fromSingle(slot), [fromSingle(value)]);
+    await this.txe.storageWrite(slot, [value]);
+
     return toForeignCallResult([]);
   }
 
-  async avmOpcodeGetContractInstanceDeployer(address: ForeignCallSingle) {
+  async avmOpcodeGetContractInstanceDeployer(foreignAddress: ForeignCallSingle) {
     if (this.contextChecksEnabled && this.context != TXEContext.PUBLIC) {
       throw new Error(
         `Attempted to call the avmOpcodeGetContractInstanceDeployer oracle while in context ${TXEContext[this.context]}`,
       );
     }
+    const address = addressFromSingle(foreignAddress);
 
-    const instance = await this.txe.utilityGetContractInstance(addressFromSingle(address));
+    const instance = await this.txe.utilityGetContractInstance(address);
+
     return toForeignCallResult([
       toSingle(instance.deployer),
       // AVM requires an extra boolean indicating the instance was found
@@ -871,14 +933,16 @@ export class TXEService {
     ]);
   }
 
-  async avmOpcodeGetContractInstanceClassId(address: ForeignCallSingle) {
+  async avmOpcodeGetContractInstanceClassId(foreignAddress: ForeignCallSingle) {
     if (this.contextChecksEnabled && this.context != TXEContext.PUBLIC) {
       throw new Error(
         `Attempted to call the avmOpcodeGetContractInstanceClassId oracle while in context ${TXEContext[this.context]}`,
       );
     }
+    const address = addressFromSingle(foreignAddress);
 
-    const instance = await this.txe.utilityGetContractInstance(addressFromSingle(address));
+    const instance = await this.txe.utilityGetContractInstance(address);
+
     return toForeignCallResult([
       toSingle(instance.currentContractClassId),
       // AVM requires an extra boolean indicating the instance was found
@@ -886,14 +950,16 @@ export class TXEService {
     ]);
   }
 
-  async avmOpcodeGetContractInstanceInitializationHash(address: ForeignCallSingle) {
+  async avmOpcodeGetContractInstanceInitializationHash(foreignAddress: ForeignCallSingle) {
     if (this.contextChecksEnabled && this.context != TXEContext.PUBLIC) {
       throw new Error(
         `Attempted to call the avmOpcodeGetContractInstanceInitializationHash oracle while in context ${TXEContext[this.context]}`,
       );
     }
+    const address = addressFromSingle(foreignAddress);
 
-    const instance = await this.txe.utilityGetContractInstance(addressFromSingle(address));
+    const instance = await this.txe.utilityGetContractInstance(address);
+
     return toForeignCallResult([
       toSingle(instance.initializationHash),
       // AVM requires an extra boolean indicating the instance was found
@@ -907,42 +973,47 @@ export class TXEService {
     }
 
     const sender = this.txe.getMsgSender();
+
     return toForeignCallResult([toSingle(sender)]);
   }
 
-  async avmOpcodeEmitNullifier(nullifier: ForeignCallSingle) {
+  async avmOpcodeEmitNullifier(foreignNullifier: ForeignCallSingle) {
     if (this.contextChecksEnabled && this.context != TXEContext.PUBLIC) {
       throw new Error(
         `Attempted to call the avmOpcodeEmitNullifier oracle while in context ${TXEContext[this.context]}`,
       );
     }
+    const nullifier = fromSingle(foreignNullifier);
 
-    await this.txe.avmOpcodeEmitNullifier(fromSingle(nullifier));
+    await this.txe.avmOpcodeEmitNullifier(nullifier);
+
     return toForeignCallResult([]);
   }
 
-  async avmOpcodeEmitNoteHash(noteHash: ForeignCallSingle) {
+  async avmOpcodeEmitNoteHash(foreignNoteHash: ForeignCallSingle) {
     if (this.contextChecksEnabled && this.context != TXEContext.PUBLIC) {
       throw new Error(
         `Attempted to call the avmOpcodeEmitNoteHash oracle while in context ${TXEContext[this.context]}`,
       );
     }
+    const noteHash = fromSingle(foreignNoteHash);
 
-    await this.txe.avmOpcodeEmitNoteHash(fromSingle(noteHash));
+    await this.txe.avmOpcodeEmitNoteHash(noteHash);
+
     return toForeignCallResult([]);
   }
 
-  async avmOpcodeNullifierExists(innerNullifier: ForeignCallSingle, targetAddress: ForeignCallSingle) {
+  async avmOpcodeNullifierExists(foreignInnerNullifier: ForeignCallSingle, foreignTargetAddress: ForeignCallSingle) {
     if (this.contextChecksEnabled && this.context != TXEContext.PUBLIC) {
       throw new Error(
         `Attempted to call the avmOpcodeNullifierExists oracle while in context ${TXEContext[this.context]}`,
       );
     }
+    const innerNullifier = fromSingle(foreignInnerNullifier);
+    const targetAddress = AztecAddress.fromField(fromSingle(foreignTargetAddress));
 
-    const exists = await this.txe.avmOpcodeNullifierExists(
-      fromSingle(innerNullifier),
-      AztecAddress.fromField(fromSingle(targetAddress)),
-    );
+    const exists = await this.txe.avmOpcodeNullifierExists(innerNullifier, targetAddress);
+
     return toForeignCallResult([toSingle(new Fr(exists))]);
   }
 
@@ -952,6 +1023,7 @@ export class TXEService {
     }
 
     const contractAddress = await this.txe.utilityGetContractAddress();
+
     return toForeignCallResult([toSingle(contractAddress.toField())]);
   }
 
@@ -961,6 +1033,7 @@ export class TXEService {
     }
 
     const blockNumber = await this.txe.utilityGetBlockNumber();
+
     return toForeignCallResult([toSingle(new Fr(blockNumber))]);
   }
 
@@ -970,6 +1043,7 @@ export class TXEService {
     }
 
     const timestamp = await this.txe.utilityGetTimestamp();
+
     return toForeignCallResult([toSingle(new Fr(timestamp))]);
   }
 
@@ -982,6 +1056,7 @@ export class TXEService {
 
     // TestEnvironment::public_context is always static
     const isStaticCall = true;
+
     return toForeignCallResult([toSingle(new Fr(isStaticCall ? 1 : 0))]);
   }
 
@@ -991,6 +1066,7 @@ export class TXEService {
     }
 
     const chainId = await this.txe.utilityGetChainId();
+
     return toForeignCallResult([toSingle(chainId)]);
   }
 
@@ -1000,6 +1076,7 @@ export class TXEService {
     }
 
     const version = await this.txe.utilityGetVersion();
+
     return toForeignCallResult([toSingle(version)]);
   }
 
@@ -1009,18 +1086,18 @@ export class TXEService {
     );
   }
 
-  avmOpcodeReturndataCopy(_rdOffset: ForeignCallSingle, _copySize: ForeignCallSingle) {
+  avmOpcodeReturndataCopy(_foreignRdOffset: ForeignCallSingle, _foreignCopySize: ForeignCallSingle) {
     throw new Error(
       'Contract calls are forbidden inside a `TestEnvironment::public_context`, use `public_call` instead',
     );
   }
 
   avmOpcodeCall(
-    _l2Gas: ForeignCallSingle,
-    _daGas: ForeignCallSingle,
-    _address: ForeignCallSingle,
-    _length: ForeignCallSingle,
-    _args: ForeignCallArray,
+    _foreignL2Gas: ForeignCallSingle,
+    _foreignDaGas: ForeignCallSingle,
+    _foreignAddress: ForeignCallSingle,
+    _foreignLength: ForeignCallSingle,
+    _foreignArgs: ForeignCallArray,
   ) {
     throw new Error(
       'Contract calls are forbidden inside a `TestEnvironment::public_context`, use `public_call` instead',
@@ -1028,11 +1105,11 @@ export class TXEService {
   }
 
   avmOpcodeStaticCall(
-    _l2Gas: ForeignCallSingle,
-    _daGas: ForeignCallSingle,
-    _address: ForeignCallSingle,
-    _length: ForeignCallSingle,
-    _args: ForeignCallArray,
+    _foreignL2Gas: ForeignCallSingle,
+    _foreignDaGas: ForeignCallSingle,
+    _foreignAddress: ForeignCallSingle,
+    _foreignLength: ForeignCallSingle,
+    _foreignArgs: ForeignCallArray,
   ) {
     throw new Error(
       'Contract calls are forbidden inside a `TestEnvironment::public_context`, use `public_call` instead',
@@ -1046,53 +1123,60 @@ export class TXEService {
   }
 
   async txePrivateCallNewFlow(
-    from: ForeignCallSingle,
-    targetContractAddress: ForeignCallSingle,
-    functionSelector: ForeignCallSingle,
-    _argsLength: ForeignCallSingle,
-    args: ForeignCallArray,
-    argsHash: ForeignCallSingle,
-    isStaticCall: ForeignCallSingle,
+    foreignFrom: ForeignCallSingle,
+    foreignTargetContractAddress: ForeignCallSingle,
+    foreignFunctionSelector: ForeignCallSingle,
+    _foreignArgsLength: ForeignCallSingle,
+    foreignArgs: ForeignCallArray,
+    foreignArgsHash: ForeignCallSingle,
+    foreignIsStaticCall: ForeignCallSingle,
   ) {
+    const from = addressFromSingle(foreignFrom);
+    const targetContractAddress = addressFromSingle(foreignTargetContractAddress);
+    const functionSelector = FunctionSelector.fromField(fromSingle(foreignFunctionSelector));
+    const args = fromArray(foreignArgs);
+    const argsHash = fromSingle(foreignArgsHash);
+    const isStaticCall = fromSingle(foreignIsStaticCall).toBool();
+
     const result = await this.txe.txePrivateCallNewFlow(
-      addressFromSingle(from),
-      addressFromSingle(targetContractAddress),
-      FunctionSelector.fromField(fromSingle(functionSelector)),
-      fromArray(args),
-      fromSingle(argsHash),
-      fromSingle(isStaticCall).toBool(),
+      from,
+      targetContractAddress,
+      functionSelector,
+      args,
+      argsHash,
+      isStaticCall,
     );
 
     return toForeignCallResult([toArray([result.endSideEffectCounter, result.returnsHash, result.txHash.hash])]);
   }
 
   async simulateUtilityFunction(
-    targetContractAddress: ForeignCallSingle,
-    functionSelector: ForeignCallSingle,
-    argsHash: ForeignCallSingle,
+    foreignTargetContractAddress: ForeignCallSingle,
+    foreignFunctionSelector: ForeignCallSingle,
+    foreignArgsHash: ForeignCallSingle,
   ) {
-    const result = await this.txe.simulateUtilityFunction(
-      addressFromSingle(targetContractAddress),
-      FunctionSelector.fromField(fromSingle(functionSelector)),
-      fromSingle(argsHash),
-    );
+    const targetContractAddress = addressFromSingle(foreignTargetContractAddress);
+    const functionSelector = FunctionSelector.fromField(fromSingle(foreignFunctionSelector));
+    const argsHash = fromSingle(foreignArgsHash);
+
+    const result = await this.txe.simulateUtilityFunction(targetContractAddress, functionSelector, argsHash);
 
     return toForeignCallResult([toSingle(result)]);
   }
 
   async txePublicCallNewFlow(
-    from: ForeignCallSingle,
-    address: ForeignCallSingle,
-    _length: ForeignCallSingle,
-    calldata: ForeignCallArray,
-    isStaticCall: ForeignCallSingle,
+    foreignFrom: ForeignCallSingle,
+    foreignAddress: ForeignCallSingle,
+    _foreignLength: ForeignCallSingle,
+    foreignCalldata: ForeignCallArray,
+    foreignIsStaticCall: ForeignCallSingle,
   ) {
-    const result = await this.txe.txePublicCallNewFlow(
-      addressFromSingle(from),
-      addressFromSingle(address),
-      fromArray(calldata),
-      fromSingle(isStaticCall).toBool(),
-    );
+    const from = addressFromSingle(foreignFrom);
+    const address = addressFromSingle(foreignAddress);
+    const calldata = fromArray(foreignCalldata);
+    const isStaticCall = fromSingle(foreignIsStaticCall).toBool();
+
+    const result = await this.txe.txePublicCallNewFlow(from, address, calldata, isStaticCall);
 
     return toForeignCallResult([toArray([result.returnsHash, result.txHash.hash])]);
   }
@@ -1105,6 +1189,7 @@ export class TXEService {
     }
 
     const sender = await this.txe.privateGetSenderForTags();
+
     // Return a Noir Option struct with `some` and `value` fields
     if (sender === undefined) {
       // No sender found, return Option with some=0 and value=0
@@ -1115,14 +1200,16 @@ export class TXEService {
     }
   }
 
-  async privateSetSenderForTags(senderForTags: ForeignCallSingle) {
+  async privateSetSenderForTags(foreignSenderForTags: ForeignCallSingle) {
     if (this.contextChecksEnabled && this.context == TXEContext.TOP_LEVEL) {
       throw new Error(
         'Oracle access from the root of a TXe test are not enabled. Please use env._ to interact with the oracles.',
       );
     }
+    const senderForTags = AztecAddress.fromField(fromSingle(foreignSenderForTags));
 
-    await this.txe.privateSetSenderForTags(AztecAddress.fromField(fromSingle(senderForTags)));
+    await this.txe.privateSetSenderForTags(senderForTags);
+
     return toForeignCallResult([]);
   }
 }


### PR DESCRIPTION
This removes bits from txe_service that did actual work and not just translated foreign data to TS prior to delegation, creating the associated functions in txe_oracle when needed. With this `txe_service` becomes much simpler and closer to its role in the new model.