### PR TITLE
feat: deploy-eth-devnet.yml github action

### DIFF
--- a/.github/local_workflow.sh
+++ b/.github/local_workflow.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Runs a github workflow locally.
+#
+# Needs `act`. See https://nektosact.com/installation/index.html
+#
+# Bind-mounts the local directory into the container, which executes as the current user.
+# Attempts to use a GCP service account, which you can download from
+# https://console.cloud.google.com/iam-admin/serviceaccounts
+
+# Your workflow may not need a GCP service account, nor a kubeconfig, etc.
+# Feel free to send a PR to tweak the script ;)
+
+# example usage:
+# export GOOGLE_APPLICATION_CREDENTIALS=/your/path/to/testnet-helm-sa.json
+# alias lwfl=/your/path/to/aztec-clones/alpha/.github/local_workflow.sh
+# lwfl deploy_eth_devnet --input cluster=kind --input resource_profile=dev --input namespace=mitch-eth-devnet --input create_static_ips=false
+# lwfl deploy_eth_devnet --input cluster=aztec-gke-private --input resource_profile=prod --input namespace=mitch-eth-devnet --input create_static_ips=false
+
+workflow_name=$1
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+
+if [ -z "$workflow_name" ]; then
+  echo "Usage: $0 <workflow_name> [args ...]"
+  exit 1
+fi
+
+# get the rest of the args (skip the first one which is the workflow name)
+shift
+args=("$@")
+
+SA_KEY_JSON=$(cat "$GOOGLE_APPLICATION_CREDENTIALS")
+
+act workflow_dispatch -j $workflow_name \
+  -s GITHUB_TOKEN="$(gh auth token)" \
+  -s GCP_SA_KEY="$SA_KEY_JSON" \
+  -s KUBECONFIG_B64="$(cat $HOME/.kube/config | base64 -w0)" \
+  --container-options "--user $(id -u):$(id -g)" \
+  --bind \
+  --directory $REPO_ROOT "${args[@]}"

--- a/.github/workflows/deploy-eth-devnet.yml
+++ b/.github/workflows/deploy-eth-devnet.yml
@@ -1,0 +1,261 @@
+name: Deploy Eth Devnet
+
+# This workflow is used to deploy the eth devnet to a cluster.
+# It can be used to deploy to kind or a GKE cluster.
+#
+# Set yourself up to run locally with:
+# export GOOGLE_APPLICATION_CREDENTIALS=/your/path/to/testnet-helm-sa.json
+# alias lwfl=/your/path/to/aztec-clones/alpha/.github/local_workflow.sh
+#
+# Then deploy to kind:
+# lwfl deploy_eth_devnet --input cluster=kind --input resource_profile=dev --input namespace=mitch-eth-devnet --input create_static_ips=false
+#
+# Or to a GKE cluster:
+# lwfl deploy_eth_devnet --input cluster=aztec-gke-private --input resource_profile=prod --input namespace=mitch-eth-devnet --input create_static_ips=false
+
+on:
+  workflow_call:
+    inputs:
+      cluster:
+        description: The cluster to deploy to, e.g. aztec-gke-private or kind
+        required: true
+        type: string
+      namespace:
+        description: The namespace to deploy to
+        required: true
+        type: string
+      ref:
+        description: The branch name to deploy from
+        required: false
+        type: string
+        default: "next"
+      chain_id:
+        description: Ethereum chain ID for genesis generation
+        required: false
+        type: number
+        default: 1337
+      block_time:
+        description: Block time in seconds for genesis generation
+        required: false
+        type: number
+        default: 12
+      gas_limit:
+        description: Gas limit for blocks in genesis generation
+        required: false
+        type: string
+        default: "32000000"
+      resource_profile:
+        description: Resource profile to use (dev or prod)
+        required: false
+        type: string
+        default: "prod"
+      create_static_ips:
+        description: Whether to create static IPs as part of the eth devnet for the execution and beacon nodes
+        required: false
+        type: string
+        default: "false"
+      run_terraform_destroy:
+        description: Whether to run the terraform destroy
+        required: false
+        type: string
+        default: "false"
+    secrets:
+      GCP_SA_KEY:
+        description: The JSON key for the GCP service account
+        required: true
+      KUBECONFIG_B64:
+        description: The base64 encoded kubeconfig
+        required: true
+
+  workflow_dispatch:
+    inputs:
+      cluster:
+        description: The cluster to deploy to, e.g. aztec-gke-private or kind
+        required: false
+        type: string
+        default: "kind"
+      namespace:
+        description: The namespace to deploy to
+        required: false
+        type: string
+        default: "eth-devnet"
+      ref:
+        description: The branch name to deploy from.
+        required: false
+        type: string
+        default: "next"
+      chain_id:
+        description: Ethereum chain ID for genesis generation
+        required: false
+        type: number
+        default: 1337
+      block_time:
+        description: Block time in seconds for genesis generation
+        required: false
+        type: number
+        default: 12
+      gas_limit:
+        description: Gas limit for blocks in genesis generation
+        required: false
+        type: string
+        default: "32000000"
+      resource_profile:
+        description: Resource profile to use (dev or prod)
+        required: false
+        type: string
+        default: "prod"
+      create_static_ips:
+        description: Whether to create static IPs as part of the eth devnet for the execution and beacon nodes
+        required: false
+        type: string
+        default: "false"
+      run_terraform_destroy:
+        description: Whether to run the terraform destroy
+        required: false
+        type: string
+        default: "false"
+
+jobs:
+  deploy_eth_devnet:
+    runs-on: ubuntu-latest
+    env:
+      TF_STATE_BUCKET: aztec-terraform
+      REGION: us-west1-a
+      # Common Terraform variables as environment variables
+      TF_VAR_NAMESPACE: ${{ inputs.namespace || 'eth-devnet' }}
+      TF_VAR_CHAIN_ID: ${{ inputs.chain_id || 1337 }}
+      TF_VAR_BLOCK_TIME: ${{ inputs.block_time || 12 }}
+      TF_VAR_GAS_LIMIT: ${{ inputs.gas_limit || '32000000' }}
+      TF_VAR_MNEMONIC_SECRET_NAME: eth-devnet-genesis-mnemonic
+      TF_VAR_PREFUNDED_MNEMONIC_INDICES: "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,1000,1001,1002,1003"
+      TF_VAR_RESOURCE_PROFILE: ${{ inputs.resource_profile || 'prod' }}
+
+    steps:
+      - name: debug inputs
+        run: |
+          echo "cluster: ${{ inputs.cluster }}"
+          echo "namespace: ${{ inputs.namespace }}"
+          echo "ref: ${{ inputs.ref }}"
+          echo "chain_id: ${{ inputs.chain_id }}"
+          echo "block_time: ${{ inputs.block_time }}"
+          echo "gas_limit: ${{ inputs.gas_limit }}"
+          echo "resource_profile: ${{ inputs.resource_profile }}"
+          echo "create_static_ips: ${{ inputs.create_static_ips }}"
+          echo "run_terraform_destroy: ${{ inputs.run_terraform_destroy }}"
+
+      - name: Check if directory exists
+        id: check_dir
+        run: |
+          if [ -d ".git" ]; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+
+      # if running with `act`, skip the checkout since the code is mounted in
+      - name: Checkout code
+        if: ${{ steps.check_dir.outputs.exists != 'true' }}
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@6189d56e4096ee891640bb02ac264be376592d6a
+
+      - name: Install GKE Auth Plugin
+        run: |
+          gcloud components install gke-gcloud-auth-plugin --quiet
+
+      - name: Configure kubectl with GKE cluster
+        if: ${{ inputs.cluster != 'kind' }}
+        run: |
+          gcloud container clusters get-credentials ${{ inputs.cluster }} --region ${{ env.REGION }}
+
+      - name: Configure kubectl with kind cluster
+        if: ${{ inputs.cluster == 'kind' }}
+        run: |
+          # fail if kubeconfig is not provided
+          if [ -z "${{ secrets.KUBECONFIG_B64 }}" ]; then
+            echo "KUBECONFIG_B64 is not set"
+            exit 1
+          fi
+          mkdir -p $HOME/.kube
+          echo "${{ secrets.KUBECONFIG_B64 }}" | base64 -d > $HOME/.kube/config
+          kubectl config use-context kind-kind
+
+      - name: Set up Terraform variables
+        id: setup_vars
+        run: |
+          # Set CREATE_STATIC_IPS based on cluster type
+          # Note: Terraform boolean values must be "true" or "false" (lowercase, unquoted)
+          if [ "${{ inputs.cluster }}" == "kind" ]; then
+            CREATE_STATIC_IPS=false
+          else
+            # Convert string "true"/"false" to boolean for Terraform
+            if [ "${{ inputs.create_static_ips }}" == "true" ]; then
+              CREATE_STATIC_IPS=true
+            else
+              CREATE_STATIC_IPS=false
+            fi
+          fi
+
+          # Get kubectl context
+          CLUSTER_CONTEXT=$(kubectl config current-context)
+
+          # Export all as TF_VAR for Terraform
+          echo "TF_VAR_CREATE_STATIC_IPS=${CREATE_STATIC_IPS}" >> $GITHUB_ENV
+          echo "TF_VAR_K8S_CLUSTER_CONTEXT=${CLUSTER_CONTEXT}" >> $GITHUB_ENV
+
+      - name: Terraform Init
+        working-directory: ./spartan/terraform/deploy-eth-devnet
+        run: |
+          # Clean up any previous backend overrides
+          rm -f backend_override.tf
+
+          if [ "${{ inputs.cluster }}" == "kind" ]; then
+            # For kind, use local backend with explicit path
+            cat > backend_override.tf << EOF
+          terraform {
+            backend "local" {
+              path = "state/${{ inputs.cluster }}/${{ inputs.namespace }}/terraform.tfstate"
+            }
+          }
+          EOF
+          else
+            # For GKE, use GCS backend with explicit path
+            cat > backend_override.tf << EOF
+          terraform {
+            backend "gcs" {
+              bucket = "${{ env.TF_STATE_BUCKET }}"
+              prefix = "deploy-eth-devnet/${{ env.REGION }}/${{ inputs.cluster }}/${{ inputs.namespace }}/terraform.tfstate"
+            }
+          }
+          EOF
+          fi
+
+          terraform init -reconfigure
+
+      - name: Terraform Destroy
+        working-directory: ./spartan/terraform/deploy-eth-devnet
+        if: ${{ inputs.run_terraform_destroy == 'true' }}
+        # Destroy fails if the resources are already destroyed, so we continue on error
+        continue-on-error: true
+        run: |
+          # All variables are now set as TF_VAR_ environment variables
+          terraform destroy -auto-approve
+
+      - name: Terraform Plan
+        working-directory: ./spartan/terraform/deploy-eth-devnet
+        run: |
+          # All variables are now set as TF_VAR_ environment variables
+          terraform plan -out=tfplan
+
+      - name: Terraform Apply
+        working-directory: ./spartan/terraform/deploy-eth-devnet
+        run: |
+          terraform apply tfplan

--- a/.github/workflows/publish-bb-mac.yml
+++ b/.github/workflows/publish-bb-mac.yml
@@ -43,11 +43,11 @@ jobs:
             optional: false
           - label: amd64-darwin-starknet
             runner: macos-13
-            cmake_flags: "-DCMAKE_CXX_FLAGS=\"-DSTARKNET_GARAGA_FLAVORS=1\""
+            cmake_flags: '-DCMAKE_CXX_FLAGS="-DSTARKNET_GARAGA_FLAVORS=1"'
             optional: true
           - label: arm64-darwin-starknet
             runner: macos-14
-            cmake_flags: "-DCMAKE_CXX_FLAGS=\"-DSTARKNET_GARAGA_FLAVORS=1\""
+            cmake_flags: '-DCMAKE_CXX_FLAGS="-DSTARKNET_GARAGA_FLAVORS=1"'
             optional: true
     steps:
       - name: Checkout
@@ -69,14 +69,14 @@ jobs:
 
       - name: Compile Barretenberg
         working-directory: barretenberg/cpp
-        continue-on-error: ${{ matrix.optional }}
+        continue-on-error: ${{ matrix.optional }}
         run: |
           cmake --preset homebrew ${{ matrix.cmake_flags }}
           cmake --build --preset homebrew --target bb
 
       - name: Package barretenberg artifact (${{ matrix.label }})
         working-directory: barretenberg/cpp/build/bin
-        continue-on-error: ${{ matrix.optional }}
+        continue-on-error: ${{ matrix.optional }}
         run: |
           mkdir dist
           cp ./bb ./dist/bb
@@ -84,7 +84,7 @@ jobs:
 
       - name: Upload artifact (${{ matrix.label }})
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
-        continue-on-error: ${{ matrix.optional }}
+        continue-on-error: ${{ matrix.optional }}
         with:
           name: barretenberg-${{ matrix.label }}.tar.gz
           path: ./barretenberg/cpp/build/bin/barretenberg-${{ matrix.label }}.tar.gz

--- a/spartan/.gitignore
+++ b/spartan/.gitignore
@@ -1,3 +1,5 @@
 *.tgz
 scripts/logs
 scripts/LICENSE
+tfplan
+*_override.tf

--- a/spartan/scripts/cleanup_helm.sh
+++ b/spartan/scripts/cleanup_helm.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Script to manually clean up stuck Helm releases
+# Usage: ./cleanup_helm.sh [release-name] [namespace]
+
+RELEASE_NAME=${1:-"eth-devnet"}
+NAMESPACE=${2:-"eth-devnet"}
+
+echo "=== Cleaning up stuck Helm release: $RELEASE_NAME in namespace: $NAMESPACE ==="
+
+# Check current state
+echo "Current Helm releases:"
+helm list -n $NAMESPACE -a
+
+echo "Current Helm secrets:"
+kubectl get secrets -n $NAMESPACE -l owner=helm
+
+# Look for pending operations
+echo "Checking for pending operations..."
+kubectl get secrets -n $NAMESPACE -l owner=helm -o json | jq -r '.items[] | select(.metadata.labels.status == "pending-install" or .metadata.labels.status == "pending-upgrade" or .metadata.labels.status == "pending-rollback") | "\(.metadata.name) - \(.metadata.labels.status)"'
+
+# Force cleanup
+echo "Force deleting pending Helm secrets..."
+kubectl delete secrets -n $NAMESPACE -l owner=helm,status=pending-install --ignore-not-found=true
+kubectl delete secrets -n $NAMESPACE -l owner=helm,status=pending-upgrade --ignore-not-found=true
+kubectl delete secrets -n $NAMESPACE -l owner=helm,status=pending-rollback --ignore-not-found=true
+
+# Try to uninstall
+echo "Attempting to uninstall release..."
+helm uninstall $RELEASE_NAME -n $NAMESPACE --wait --timeout=60s || echo "Uninstall failed or no release found"
+
+# Nuclear option: delete all Helm secrets for this release
+echo "Force deleting all Helm secrets for release $RELEASE_NAME..."
+kubectl delete secrets -n $NAMESPACE -l name=$RELEASE_NAME,owner=helm --ignore-not-found=true
+
+# Clean up all resources in namespace
+echo "Cleaning up all resources in namespace..."
+kubectl delete all --all -n $NAMESPACE --ignore-not-found=true
+
+echo "=== Cleanup complete! ==="
+echo "You can now retry your deployment."

--- a/spartan/terraform/deploy-eth-devnet/main.tf
+++ b/spartan/terraform/deploy-eth-devnet/main.tf
@@ -1,8 +1,6 @@
 terraform {
-  backend "gcs" {
-    bucket = "aztec-terraform"
-    prefix = "network-deploy/us-west1-a/aztec-gke-private/eth-devnet/terraform.tfstate"
-  }
+
+  backend "local" {}
   required_providers {
     helm = {
       source  = "hashicorp/helm"
@@ -31,14 +29,14 @@ provider "google" {
 provider "kubernetes" {
   alias          = "gke-cluster"
   config_path    = "~/.kube/config"
-  config_context = var.GKE_CLUSTER_CONTEXT
+  config_context = var.K8S_CLUSTER_CONTEXT
 }
 
 provider "helm" {
   alias = "gke-cluster"
   kubernetes {
     config_path    = "~/.kube/config"
-    config_context = var.GKE_CLUSTER_CONTEXT
+    config_context = var.K8S_CLUSTER_CONTEXT
   }
 }
 
@@ -49,8 +47,9 @@ data "google_secret_manager_secret_version" "mnemonic_latest" {
 
 # Static IP addresses for eth-devnet services
 resource "google_compute_address" "eth_execution_ip" {
+  count        = var.CREATE_STATIC_IPS ? 1 : 0
   provider     = google
-  name         = "${var.RELEASE_PREFIX}-execution-ip"
+  name         = "${var.NAMESPACE}-${var.RELEASE_PREFIX}-execution-ip"
   address_type = "EXTERNAL"
   region       = var.region
 
@@ -60,8 +59,9 @@ resource "google_compute_address" "eth_execution_ip" {
 }
 
 resource "google_compute_address" "eth_beacon_ip" {
+  count        = var.CREATE_STATIC_IPS ? 1 : 0
   provider     = google
-  name         = "${var.RELEASE_PREFIX}-beacon-ip"
+  name         = "${var.NAMESPACE}-${var.RELEASE_PREFIX}-beacon-ip"
   address_type = "EXTERNAL"
   region       = var.region
 
@@ -89,6 +89,9 @@ resource "null_resource" "generate_genesis" {
       export GAS_LIMIT="${var.GAS_LIMIT}"
       export MNEMONIC="${data.google_secret_manager_secret_version.mnemonic_latest.secret_data}"
       export PREFUNDED_MNEMONIC_INDICES="${var.PREFUNDED_MNEMONIC_INDICES}"
+
+      # Use a custom directory for Foundry installation to avoid permission issues
+      export FOUNDRY_DIR="$HOME/.foundry"
 
       ./create_genesis.sh
     EOT
@@ -118,6 +121,7 @@ resource "helm_release" "eth_devnet" {
 
   values = [
     file("./values/${var.ETH_DEVNET_VALUES}"),
+    file("./values/resources-${var.RESOURCE_PROFILE}.yaml"),
   ]
 
   set {
@@ -125,14 +129,21 @@ resource "helm_release" "eth_devnet" {
     value = data.google_secret_manager_secret_version.mnemonic_latest.secret_data
   }
 
-  set {
-    name  = "ethereum.execution.service.loadBalancerIP"
-    value = google_compute_address.eth_execution_ip.address
+
+  dynamic "set" {
+    for_each = var.CREATE_STATIC_IPS ? [1] : []
+    content {
+      name  = "ethereum.execution.service.loadBalancerIP"
+      value = google_compute_address.eth_execution_ip[0].address
+    }
   }
 
-  set {
-    name  = "ethereum.beacon.service.loadBalancerIP"
-    value = google_compute_address.eth_beacon_ip.address
+  dynamic "set" {
+    for_each = var.CREATE_STATIC_IPS ? [1] : []
+    content {
+      name  = "ethereum.beacon.service.loadBalancerIP"
+      value = google_compute_address.eth_beacon_ip[0].address
+    }
   }
 
   timeout       = 300

--- a/spartan/terraform/deploy-eth-devnet/outputs.tf
+++ b/spartan/terraform/deploy-eth-devnet/outputs.tf
@@ -1,26 +1,26 @@
 output "eth_execution_ip" {
   description = "Static IP address for Ethereum execution client"
-  value       = google_compute_address.eth_execution_ip.address
+  value       = var.CREATE_STATIC_IPS ? google_compute_address.eth_execution_ip[0].address : null
 }
 
 output "eth_beacon_ip" {
   description = "Static IP address for Ethereum beacon client"
-  value       = google_compute_address.eth_beacon_ip.address
+  value       = var.CREATE_STATIC_IPS ? google_compute_address.eth_beacon_ip[0].address : null
 }
 
 output "eth_execution_rpc_url" {
   description = "Ethereum execution RPC URL"
-  value       = "http://${google_compute_address.eth_execution_ip.address}:8545"
+  value       = var.CREATE_STATIC_IPS ? "http://${google_compute_address.eth_execution_ip[0].address}:8545" : null
 }
 
 output "eth_execution_ws_url" {
   description = "Ethereum execution WebSocket URL"
-  value       = "ws://${google_compute_address.eth_execution_ip.address}:8546"
+  value       = var.CREATE_STATIC_IPS ? "ws://${google_compute_address.eth_execution_ip[0].address}:8546" : null
 }
 
 output "eth_beacon_api_url" {
   description = "Ethereum beacon API URL"
-  value       = "http://${google_compute_address.eth_beacon_ip.address}:5052"
+  value       = var.CREATE_STATIC_IPS ? "http://${google_compute_address.eth_beacon_ip[0].address}:5052" : null
 }
 
 output "chain_id" {

--- a/spartan/terraform/deploy-eth-devnet/values/eth-devnet.yaml
+++ b/spartan/terraform/deploy-eth-devnet/values/eth-devnet.yaml
@@ -23,41 +23,7 @@ ethereum:
 
   execution:
     client: "reth"
-    nodeSelector:
-      local-ssd: "false"
-      node-type: "network"
 
-    service:
-      type: LoadBalancer 
-      annotations: {} 
+  beacon: {}
 
-    storageSize: "10Gi"
-    resources:
-      requests:
-        memory: "12Gi"
-        cpu: "2.5"
-
-  beacon:
-    nodeSelector:
-      local-ssd: "false"
-      node-type: "network"
-
-    service:
-      type: LoadBalancer
-      annotations: {}
-    storageSize: "10Gi"
-    resources:
-      requests:
-        memory: "12Gi"
-        cpu: "2.5"
-
-  validator:
-    nodeSelector:
-      local-ssd: "false"
-      node-type: "network"
-
-    storageSize: "10Gi"
-    resources:
-      requests:
-        memory: "12Gi"
-        cpu: "2.5"
+  validator: {}

--- a/spartan/terraform/deploy-eth-devnet/values/resources-dev.yaml
+++ b/spartan/terraform/deploy-eth-devnet/values/resources-dev.yaml
@@ -1,0 +1,11 @@
+# Development resource specifications for eth-devnet
+ethereum:
+  execution:
+    service:
+      type: ClusterIP
+      annotations: {}
+
+  beacon:
+    service:
+      type: ClusterIP
+      annotations: {}

--- a/spartan/terraform/deploy-eth-devnet/values/resources-prod.yaml
+++ b/spartan/terraform/deploy-eth-devnet/values/resources-prod.yaml
@@ -1,0 +1,37 @@
+# Production resource specifications for eth-devnet
+ethereum:
+  execution:
+    service:
+      type: LoadBalancer
+      annotations: {}
+    nodeSelector:
+      local-ssd: "false"
+      node-type: "network"
+    storageSize: "10Gi"
+    resources:
+      requests:
+        memory: "12Gi"
+        cpu: "2.5"
+
+  beacon:
+    service:
+      type: LoadBalancer
+      annotations: {}
+    nodeSelector:
+      local-ssd: "false"
+      node-type: "network"
+    storageSize: "10Gi"
+    resources:
+      requests:
+        memory: "12Gi"
+        cpu: "2.5"
+
+  validator:
+    nodeSelector:
+      local-ssd: "false"
+      node-type: "network"
+    storageSize: "10Gi"
+    resources:
+      requests:
+        memory: "12Gi"
+        cpu: "2.5"

--- a/spartan/terraform/deploy-eth-devnet/variables.tf
+++ b/spartan/terraform/deploy-eth-devnet/variables.tf
@@ -10,8 +10,8 @@ variable "region" {
   default     = "us-west1"
 }
 
-variable "GKE_CLUSTER_CONTEXT" {
-  description = "GKE cluster context"
+variable "K8S_CLUSTER_CONTEXT" {
+  description = "K8S cluster context"
   type        = string
   default     = "gke_testnet-440309_us-west1-a_aztec-gke-private"
 }
@@ -32,6 +32,14 @@ variable "ETH_DEVNET_VALUES" {
   description = "The values file to apply for eth-devnet"
   type        = string
   default     = "eth-devnet.yaml"
+}
+
+
+
+variable "CREATE_STATIC_IPS" {
+  description = "Whether to create static IP addresses for eth-devnet services"
+  type        = bool
+  default     = true
 }
 
 variable "CHAIN_ID" {
@@ -62,5 +70,15 @@ variable "PREFUNDED_MNEMONIC_INDICES" {
   description = "Comma-separated list of mnemonic indices to prefund with ETH"
   type        = string
   default     = "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,1000,1001,1002,1003"
+}
+
+variable "RESOURCE_PROFILE" {
+  description = "Resource profile to use (dev or prod)"
+  type        = string
+  default     = "prod"
+  validation {
+    condition     = contains(["dev", "prod"], var.RESOURCE_PROFILE)
+    error_message = "RESOURCE_PROFILE must be either 'dev' or 'prod'."
+  }
 }
 


### PR DESCRIPTION
Adds a GitHub workflow for deploying an Ethereum devnet to either a kind or GKE cluster. Includes a script so that you can:

```
# on your local kind
lwfl deploy_eth_devnet --input cluster=kind --input resource_profile=dev --input namespace=mitch-eth-devnet

# into the cloud
lwfl deploy_eth_devnet --input cluster=aztec-gke-private --input resource_profile=prod --input namespace=mitch-eth-devnet --input create_static_ips=false
```

The implementation includes:

- New GitHub workflow file `deploy-eth-devnet.yml` that can be triggered manually or called from other workflows
- Local workflow script (`local_workflow.sh`) to run GitHub workflows locally
- Terraform configuration for deploying the Ethereum devnet with customizable parameters
- Resource profiles for development and production environments
- Support for static IP allocation in GKE (disabled for kind)
- Cleanup script for handling stuck Helm releases

The PR also fixes quote escaping in the Mac build workflow to properly handle CMake flags with spaces.

Fix TMNT-165