### PR TITLE
chore(bbup): Update bbup source URL from master to next

### DIFF
--- a/barretenberg/bbup/install
+++ b/barretenberg/bbup/install
@@ -12,7 +12,7 @@ ERROR="✗"
 
 BB_DIR="${HOME}/.bb"
 INSTALL_PATH="${BB_DIR}/bbup"
-BBUP_URL="https://raw.githubusercontent.com/AztecProtocol/aztec-packages/master/barretenberg/bbup/bbup"
+BBUP_URL="https://raw.githubusercontent.com/AztecProtocol/aztec-packages/next/barretenberg/bbup/bbup"
 
 # Create .bb directory if it doesn't exist
 mkdir -p "$BB_DIR"


### PR DESCRIPTION
Update bbup installation script to fetch bbup from the _next_ branch instead of the _master_ branch.

Helps users download the latest bbup on the development branch by default.

## Additional context

The latest Noir release is currently blocked, as bbup installed via the installation script would be an older version on _master_ before https://github.com/AztecProtocol/aztec-packages/pull/16510 that fails to fetch version compatibilities with the latest Noir releases.

It could be unblocked through either:
1. Merging this PR, or
2. Merging _next_ into _master_