### PR TITLE
chore: add txe session

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/context/returns_hash.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/returns_hash.nr
@@ -45,7 +45,7 @@ mod test {
 
     #[test]
     unconstrained fn retrieves_preimage() {
-        let env = TestEnvironment::_new();
+        let env = TestEnvironment::new();
         env.private_context(|_| {
             let value = MockStruct::new(4, 7);
             let serialized = value.serialize();
@@ -59,7 +59,7 @@ mod test {
 
     #[test]
     unconstrained fn retrieves_empty_preimage() {
-        let env = TestEnvironment::_new();
+        let env = TestEnvironment::new();
         env.private_context(|_| {
             let value = ();
             let serialized = [];

--- a/noir-projects/aztec-nr/aztec/src/note/note_getter/test.nr
+++ b/noir-projects/aztec-nr/aztec/src/note/note_getter/test.nr
@@ -37,7 +37,7 @@ where
 
 #[test]
 unconstrained fn processes_single_note() {
-    let env = TestEnvironment::_new();
+    let env = TestEnvironment::new();
 
     env.private_context(|context| {
         let mut notes_to_constrain = [Option::none(); _];
@@ -54,7 +54,7 @@ unconstrained fn processes_single_note() {
 
 #[test]
 unconstrained fn processes_many_notes() {
-    let env = TestEnvironment::_new();
+    let env = TestEnvironment::new();
 
     env.private_context(|context| {
         let mut notes_to_constrain = [Option::none(); _];
@@ -72,7 +72,7 @@ unconstrained fn processes_many_notes() {
 
 #[test]
 unconstrained fn collapses_notes_at_the_beginning_of_the_array() {
-    let env = TestEnvironment::_new();
+    let env = TestEnvironment::new();
 
     env.private_context(|context| {
         let mut opt_notes = [Option::none(); _];
@@ -101,7 +101,7 @@ unconstrained fn collapses_notes_at_the_beginning_of_the_array() {
 
 #[test]
 unconstrained fn can_return_zero_notes() {
-    let env = TestEnvironment::_new();
+    let env = TestEnvironment::new();
 
     env.private_context(|context| {
         let opt_notes: [Option<RetrievedNote<MockNote>>; _] = [Option::none(); _];
@@ -115,7 +115,7 @@ unconstrained fn can_return_zero_notes() {
 
 #[test(should_fail_with = "Got more notes than limit.")]
 unconstrained fn rejects_mote_notes_than_limit() {
-    let env = TestEnvironment::_new();
+    let env = TestEnvironment::new();
 
     env.private_context(|context| {
         let mut opt_notes: [Option<RetrievedNote<MockNote>>; _] = [Option::none(); _];
@@ -131,7 +131,7 @@ unconstrained fn rejects_mote_notes_than_limit() {
 
 #[test]
 unconstrained fn applies_filter_before_constraining() {
-    let env = TestEnvironment::_new();
+    let env = TestEnvironment::new();
 
     env.private_context(|context| {
         let mut notes_to_constrain = [Option::none(); _];
@@ -167,7 +167,7 @@ unconstrained fn applies_filter_before_constraining() {
 
 #[test(should_fail_with = "Note contract address mismatch.")]
 unconstrained fn rejects_mismatched_address() {
-    let env = TestEnvironment::_new();
+    let env = TestEnvironment::new();
 
     env.private_context(|context| {
         let note = MockNote::new(1).build_retrieved_note(); // We're not setting the right contract address
@@ -181,7 +181,7 @@ unconstrained fn rejects_mismatched_address() {
 
 #[test(should_fail_with = "Mismatch return note field.")]
 unconstrained fn rejects_mismatched_selector() {
-    let env = TestEnvironment::_new();
+    let env = TestEnvironment::new();
 
     env.private_context(|context| {
         let value = 10;
@@ -203,7 +203,7 @@ unconstrained fn rejects_mismatched_selector() {
 
 #[test(should_fail_with = "Return notes not sorted in descending order.")]
 unconstrained fn rejects_mismatched_desc_sort_order() {
-    let env = TestEnvironment::_new();
+    let env = TestEnvironment::new();
 
     env.private_context(|context| {
         let mut opt_notes = [Option::none(); _];
@@ -220,7 +220,7 @@ unconstrained fn rejects_mismatched_desc_sort_order() {
 
 #[test(should_fail_with = "Return notes not sorted in ascending order.")]
 unconstrained fn rejects_mismatched_asc_sort_order() {
-    let env = TestEnvironment::_new();
+    let env = TestEnvironment::new();
 
     env.private_context(|context| {
         let mut opt_notes = [Option::none(); _];

--- a/noir-projects/aztec-nr/aztec/src/oracle/capsules.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/capsules.nr
@@ -85,7 +85,7 @@ mod test {
 
     #[test]
     unconstrained fn stores_and_loads() {
-        let env = TestEnvironment::_new();
+        let env = TestEnvironment::new();
         env.private_context(|context| {
             let contract_address = context.this_address();
 
@@ -98,7 +98,7 @@ mod test {
 
     #[test]
     unconstrained fn store_overwrites() {
-        let env = TestEnvironment::_new();
+        let env = TestEnvironment::new();
         env.private_context(|context| {
             let contract_address = context.this_address();
 
@@ -114,7 +114,7 @@ mod test {
 
     #[test]
     unconstrained fn loads_empty_slot() {
-        let env = TestEnvironment::_new();
+        let env = TestEnvironment::new();
         env.private_context(|context| {
             let contract_address = context.this_address();
 
@@ -125,7 +125,7 @@ mod test {
 
     #[test]
     unconstrained fn deletes_stored_value() {
-        let env = TestEnvironment::_new();
+        let env = TestEnvironment::new();
         env.private_context(|context| {
             let contract_address = context.this_address();
 
@@ -140,7 +140,7 @@ mod test {
 
     #[test]
     unconstrained fn deletes_empty_slot() {
-        let env = TestEnvironment::_new();
+        let env = TestEnvironment::new();
         env.private_context(|context| {
             let contract_address = context.this_address();
 
@@ -152,7 +152,7 @@ mod test {
 
     #[test]
     unconstrained fn copies_non_overlapping_values() {
-        let env = TestEnvironment::_new();
+        let env = TestEnvironment::new();
         env.private_context(|context| {
             let contract_address = context.this_address();
 
@@ -174,7 +174,7 @@ mod test {
 
     #[test]
     unconstrained fn copies_overlapping_values_with_src_ahead() {
-        let env = TestEnvironment::_new();
+        let env = TestEnvironment::new();
         env.private_context(|context| {
             let contract_address = context.this_address();
 
@@ -201,7 +201,7 @@ mod test {
 
     #[test]
     unconstrained fn copies_overlapping_values_with_dst_ahead() {
-        let env = TestEnvironment::_new();
+        let env = TestEnvironment::new();
         env.private_context(|context| {
             let contract_address = context.this_address();
 
@@ -228,7 +228,7 @@ mod test {
 
     #[test(should_fail_with = "copy empty slot")]
     unconstrained fn cannot_copy_empty_values() {
-        let env = TestEnvironment::_new();
+        let env = TestEnvironment::new();
         env.private_context(|context| {
             let contract_address = context.this_address();
 
@@ -238,7 +238,7 @@ mod test {
 
     #[test(should_fail_with = "not allowed to access")]
     unconstrained fn cannot_store_other_contract() {
-        let env = TestEnvironment::_new();
+        let env = TestEnvironment::new();
         env.private_context(|context| {
             let contract_address = context.this_address();
             let other_contract_address = AztecAddress::from_field(contract_address.to_field() + 1);
@@ -250,7 +250,7 @@ mod test {
 
     #[test(should_fail_with = "not allowed to access")]
     unconstrained fn cannot_load_other_contract() {
-        let env = TestEnvironment::_new();
+        let env = TestEnvironment::new();
         env.private_context(|context| {
             let contract_address = context.this_address();
             let other_contract_address = AztecAddress::from_field(contract_address.to_field() + 1);
@@ -261,7 +261,7 @@ mod test {
 
     #[test(should_fail_with = "not allowed to access")]
     unconstrained fn cannot_delete_other_contract() {
-        let env = TestEnvironment::_new();
+        let env = TestEnvironment::new();
         env.private_context(|context| {
             let contract_address = context.this_address();
             let other_contract_address = AztecAddress::from_field(contract_address.to_field() + 1);
@@ -272,7 +272,7 @@ mod test {
 
     #[test(should_fail_with = "not allowed to access")]
     unconstrained fn cannot_copy_other_contract() {
-        let env = TestEnvironment::_new();
+        let env = TestEnvironment::new();
         env.private_context(|context| {
             let contract_address = context.this_address();
             let other_contract_address = AztecAddress::from_field(contract_address.to_field() + 1);

--- a/noir-projects/aztec-nr/aztec/src/state_vars/delayed_public_mutable/test.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/delayed_public_mutable/test.nr
@@ -35,7 +35,7 @@ unconstrained fn in_utility(
 
 #[test]
 unconstrained fn get_current_value_in_public_initial() {
-    let env = TestEnvironment::_new();
+    let env = TestEnvironment::new();
 
     env.public_context(|context| {
         let state_var = in_public(context);
@@ -45,7 +45,7 @@ unconstrained fn get_current_value_in_public_initial() {
 
 #[test]
 unconstrained fn get_scheduled_value_in_public() {
-    let env = TestEnvironment::_new();
+    let env = TestEnvironment::new();
 
     env.public_context(|context| {
         let state_var = in_public(context);
@@ -62,7 +62,7 @@ unconstrained fn get_scheduled_value_in_public() {
 
 #[test]
 unconstrained fn get_current_value_in_public_before_scheduled_change() {
-    let env = TestEnvironment::_new();
+    let env = TestEnvironment::new();
 
     let (original_value, timestamp_of_change) = env.public_context(|context| {
         let state_var = in_public(context);
@@ -90,7 +90,7 @@ unconstrained fn get_current_value_in_public_before_scheduled_change() {
 
 #[test]
 unconstrained fn get_current_value_in_public_at_scheduled_change() {
-    let env = TestEnvironment::_new();
+    let env = TestEnvironment::new();
 
     let (_, timestamp_of_change) = env.public_context(|context| {
         let state_var = in_public(context);
@@ -109,7 +109,7 @@ unconstrained fn get_current_value_in_public_at_scheduled_change() {
 
 #[test]
 unconstrained fn get_current_value_in_public_after_scheduled_change() {
-    let env = TestEnvironment::_new();
+    let env = TestEnvironment::new();
 
     let (_, timestamp_of_change) = env.public_context(|context| {
         let state_var = in_public(context);
@@ -129,7 +129,7 @@ unconstrained fn get_current_value_in_public_after_scheduled_change() {
 
 #[test]
 unconstrained fn get_current_delay_in_public_initial() {
-    let env = TestEnvironment::_new();
+    let env = TestEnvironment::new();
     env.public_context(|context| {
         let state_var = in_public(context);
         assert_eq(state_var.get_current_delay(), TEST_INITIAL_DELAY);
@@ -138,7 +138,7 @@ unconstrained fn get_current_delay_in_public_initial() {
 
 #[test]
 unconstrained fn get_scheduled_delay_in_public() {
-    let env = TestEnvironment::_new();
+    let env = TestEnvironment::new();
 
     env.public_context(|context| {
         let state_var = in_public(context);
@@ -154,7 +154,7 @@ unconstrained fn get_scheduled_delay_in_public() {
 
 #[test]
 unconstrained fn get_current_delay_in_public_before_scheduled_change() {
-    let env = TestEnvironment::_new();
+    let env = TestEnvironment::new();
 
     let (original_delay, timestamp_of_change) = env.public_context(|context| {
         let state_var = in_public(context);
@@ -182,7 +182,7 @@ unconstrained fn get_current_delay_in_public_before_scheduled_change() {
 
 #[test]
 unconstrained fn get_current_delay_in_public_at_scheduled_change() {
-    let env = TestEnvironment::_new();
+    let env = TestEnvironment::new();
 
     let (_, timestamp_of_change) = env.public_context(|context| {
         let state_var = in_public(context);
@@ -202,7 +202,7 @@ unconstrained fn get_current_delay_in_public_at_scheduled_change() {
 
 #[test]
 unconstrained fn get_current_delay_in_public_after_scheduled_change() {
-    let env = TestEnvironment::_new();
+    let env = TestEnvironment::new();
 
     let (_, timestamp_of_change) = env.public_context(|context| {
         let state_var = in_public(context);
@@ -222,7 +222,7 @@ unconstrained fn get_current_delay_in_public_after_scheduled_change() {
 
 #[test]
 unconstrained fn get_current_value_in_private_initial() {
-    let env = TestEnvironment::_new();
+    let env = TestEnvironment::new();
 
     env.private_context(|context| {
         let state_var = in_private(context);
@@ -237,7 +237,7 @@ unconstrained fn get_current_value_in_private_initial() {
 
 #[test]
 unconstrained fn get_current_value_in_private_before_change() {
-    let env = TestEnvironment::_new();
+    let env = TestEnvironment::new();
 
     let (_, timestamp_of_change) = env.public_context(|context| {
         let state_var = in_public(context);
@@ -257,7 +257,7 @@ unconstrained fn get_current_value_in_private_before_change() {
 
 #[test]
 unconstrained fn get_current_value_in_private_immediately_before_change() {
-    let env = TestEnvironment::_new();
+    let env = TestEnvironment::new();
 
     let (_, timestamp_of_change) = env.public_context(|context| {
         let state_var = in_public(context);
@@ -284,7 +284,7 @@ unconstrained fn get_current_value_in_private_immediately_before_change() {
 
 #[test]
 unconstrained fn get_current_value_in_private_at_change() {
-    let env = TestEnvironment::_new();
+    let env = TestEnvironment::new();
 
     let (_, timestamp_of_change) = env.public_context(|context| {
         let state_var = in_public(context);
@@ -312,7 +312,7 @@ unconstrained fn get_current_value_in_private_at_change() {
 
 #[test]
 unconstrained fn get_current_value_in_private_after_change() {
-    let env = TestEnvironment::_new();
+    let env = TestEnvironment::new();
 
     let (_, timestamp_of_change) = env.public_context(|context| {
         let state_var = in_public(context);
@@ -340,7 +340,7 @@ unconstrained fn get_current_value_in_private_after_change() {
 
 #[test]
 unconstrained fn get_current_value_in_private_with_non_initial_delay() {
-    let env = TestEnvironment::_new();
+    let env = TestEnvironment::new();
 
     let ((_, value_timestamp_of_change), (_, delay_timestamp_of_change)) = env
         .public_context(|context| {
@@ -368,7 +368,7 @@ unconstrained fn get_current_value_in_private_with_non_initial_delay() {
 
 #[test]
 unconstrained fn get_current_value_in_utility_initial() {
-    let env = TestEnvironment::_new();
+    let env = TestEnvironment::new();
     env.utility_context(|context| {
         let state_var = in_utility(context);
         assert_eq(state_var.get_current_value(), zeroed());
@@ -377,7 +377,7 @@ unconstrained fn get_current_value_in_utility_initial() {
 
 #[test]
 unconstrained fn get_current_value_in_utility_before_scheduled_change() {
-    let env = TestEnvironment::_new();
+    let env = TestEnvironment::new();
 
     let (_, timestamp_of_change) = env.public_context(|context| {
         let state_var = in_public(context);
@@ -400,7 +400,7 @@ unconstrained fn get_current_value_in_utility_before_scheduled_change() {
 
 #[test]
 unconstrained fn get_current_value_in_utility_at_scheduled_change() {
-    let env = TestEnvironment::_new();
+    let env = TestEnvironment::new();
 
     let (_, timestamp_of_change) = env.public_context(|context| {
         let state_var = in_public(context);
@@ -423,7 +423,7 @@ unconstrained fn get_current_value_in_utility_at_scheduled_change() {
 
 #[test]
 unconstrained fn get_current_value_in_utility_after_scheduled_change() {
-    let env = TestEnvironment::_new();
+    let env = TestEnvironment::new();
 
     let (_, timestamp_of_change) = env.public_context(|context| {
         let state_var = in_public(context);

--- a/noir-projects/aztec-nr/aztec/src/state_vars/private_mutable/test.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/private_mutable/test.nr
@@ -12,7 +12,7 @@ unconstrained fn in_private(
 
 #[test(should_fail_with = "Failed to get a note")]
 unconstrained fn get_uninitialized() {
-    let env = TestEnvironment::_new();
+    let env = TestEnvironment::new();
 
     env.private_context(|context| {
         let state_var = in_private(context);
@@ -22,7 +22,7 @@ unconstrained fn get_uninitialized() {
 
 #[test(should_fail_with = "Failed to get a note")]
 unconstrained fn replace_uninitialized() {
-    let env = TestEnvironment::_new();
+    let env = TestEnvironment::new();
 
     env.private_context(|context| {
         let state_var = in_private(context);
@@ -34,7 +34,7 @@ unconstrained fn replace_uninitialized() {
 
 #[test]
 unconstrained fn initialize() {
-    let env = TestEnvironment::_new();
+    let env = TestEnvironment::new();
 
     env.private_context(|context| {
         let state_var = in_private(context);
@@ -55,7 +55,7 @@ unconstrained fn initialize() {
 
 #[test]
 unconstrained fn initialize_and_get_pending() {
-    let env = TestEnvironment::_new();
+    let env = TestEnvironment::new();
 
     env.private_context(|context| {
         let state_var = in_private(context);
@@ -85,7 +85,7 @@ unconstrained fn initialize_and_get_pending() {
 
 #[test]
 unconstrained fn initialize_and_replace_pending() {
-    let env = TestEnvironment::_new();
+    let env = TestEnvironment::new();
 
     env.private_context(|context| {
         let state_var = in_private(context);
@@ -117,7 +117,7 @@ unconstrained fn initialize_and_replace_pending() {
 
 #[test]
 unconstrained fn initialize_or_replace_uninitialized() {
-    let env = TestEnvironment::_new();
+    let env = TestEnvironment::new();
 
     env.private_context(|context| {
         let state_var = in_private(context);
@@ -138,7 +138,7 @@ unconstrained fn initialize_or_replace_uninitialized() {
 
 #[test]
 unconstrained fn initialize_or_replace_initialized_pending() {
-    let env = TestEnvironment::_new();
+    let env = TestEnvironment::new();
 
     env.private_context(|context| {
         let state_var = in_private(context);

--- a/noir-projects/aztec-nr/aztec/src/state_vars/public_immutable/test.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/public_immutable/test.nr
@@ -21,7 +21,7 @@ fn in_utility(context: UtilityContext) -> PublicImmutable<MockStruct, UtilityCon
 
 #[test]
 unconstrained fn is_uninitialized_by_default() {
-    let env = TestEnvironment::_new();
+    let env = TestEnvironment::new();
 
     env.public_context(|context| {
         let state_var = in_public(context);
@@ -31,7 +31,7 @@ unconstrained fn is_uninitialized_by_default() {
 
 #[test]
 unconstrained fn initialize_uninitialized_same_tx() {
-    let env = TestEnvironment::_new();
+    let env = TestEnvironment::new();
 
     env.public_context(|context| {
         let state_var = in_public(context);
@@ -45,7 +45,7 @@ unconstrained fn initialize_uninitialized_same_tx() {
 
 #[test]
 unconstrained fn initialize_uninitialized_other_tx() {
-    let env = TestEnvironment::_new();
+    let env = TestEnvironment::new();
 
     env.public_context(|context| {
         let state_var = in_public(context);
@@ -62,7 +62,7 @@ unconstrained fn initialize_uninitialized_other_tx() {
 
 #[test(should_fail_with = "Duplicate")]
 unconstrained fn initialize_already_initialized_same_tx() {
-    let env = TestEnvironment::_new();
+    let env = TestEnvironment::new();
 
     env.public_context(|context| {
         let state_var = in_public(context);
@@ -77,7 +77,7 @@ unconstrained fn initialize_already_initialized_same_tx() {
 
 #[test(should_fail_with = "already present")]
 unconstrained fn initialize_already_initialized_other_tx() {
-    let env = TestEnvironment::_new();
+    let env = TestEnvironment::new();
 
     env.public_context(|context| {
         let state_var = in_public(context);
@@ -94,7 +94,7 @@ unconstrained fn initialize_already_initialized_other_tx() {
 
 #[test(should_fail_with = "Trying to read from uninitialized PublicImmutable")]
 unconstrained fn read_uninitialized_public_fails() {
-    let env = TestEnvironment::_new();
+    let env = TestEnvironment::new();
 
     env.public_context(|context| {
         let state_var = in_public(context);
@@ -105,7 +105,7 @@ unconstrained fn read_uninitialized_public_fails() {
 // TODO(#15703): this test should be made to fail
 #[test]
 unconstrained fn read_uninitialized_private_returns_default() {
-    let env = TestEnvironment::_new();
+    let env = TestEnvironment::new();
 
     env.private_context(|context| {
         let state_var = in_private(context);
@@ -116,7 +116,7 @@ unconstrained fn read_uninitialized_private_returns_default() {
 // TODO(#15703): this test should be made to fail
 #[test]
 unconstrained fn read_uninitialized_utility_returns_default() {
-    let env = TestEnvironment::_new();
+    let env = TestEnvironment::new();
 
     env.utility_context(|context| {
         let state_var = in_utility(context);
@@ -126,7 +126,7 @@ unconstrained fn read_uninitialized_utility_returns_default() {
 
 #[test]
 unconstrained fn read_initialized_public_same_tx() {
-    let env = TestEnvironment::_new();
+    let env = TestEnvironment::new();
 
     env.public_context(|context| {
         let state_var = in_public(context);
@@ -139,7 +139,7 @@ unconstrained fn read_initialized_public_same_tx() {
 
 #[test]
 unconstrained fn read_initialized_public_other_tx() {
-    let env = TestEnvironment::_new();
+    let env = TestEnvironment::new();
     let value = MockStruct::new(5, 6);
 
     env.public_context(|context| {
@@ -155,7 +155,7 @@ unconstrained fn read_initialized_public_other_tx() {
 
 #[test]
 unconstrained fn read_initialized_private() {
-    let env = TestEnvironment::_new();
+    let env = TestEnvironment::new();
     let value = MockStruct::new(5, 6);
 
     env.public_context(|context| {
@@ -171,7 +171,7 @@ unconstrained fn read_initialized_private() {
 
 #[test]
 unconstrained fn read_initialized_utility() {
-    let env = TestEnvironment::_new();
+    let env = TestEnvironment::new();
     let value = MockStruct::new(5, 6);
 
     env.public_context(|context| {

--- a/noir-projects/aztec-nr/aztec/src/state_vars/public_mutable/test.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/public_mutable/test.nr
@@ -14,7 +14,7 @@ fn in_utility(context: UtilityContext) -> PublicMutable<MockStruct, UtilityConte
 
 #[test]
 unconstrained fn read_uninitialized_public_returns_zero() {
-    let env = TestEnvironment::_new();
+    let env = TestEnvironment::new();
 
     env.public_context(|context| {
         let state_var = in_public(context);
@@ -24,7 +24,7 @@ unconstrained fn read_uninitialized_public_returns_zero() {
 
 #[test]
 unconstrained fn read_uninitialized_utility_returns_default() {
-    let env = TestEnvironment::_new();
+    let env = TestEnvironment::new();
 
     env.utility_context(|context| {
         let state_var = in_utility(context);
@@ -34,7 +34,7 @@ unconstrained fn read_uninitialized_utility_returns_default() {
 
 #[test]
 unconstrained fn write_read_public_same_tx() {
-    let env = TestEnvironment::_new();
+    let env = TestEnvironment::new();
 
     env.public_context(|context| {
         let state_var = in_public(context);
@@ -47,7 +47,7 @@ unconstrained fn write_read_public_same_tx() {
 
 #[test]
 unconstrained fn write_read_public_other_tx() {
-    let env = TestEnvironment::_new();
+    let env = TestEnvironment::new();
 
     let value = MockStruct::new(5, 6);
 
@@ -64,7 +64,7 @@ unconstrained fn write_read_public_other_tx() {
 
 #[test]
 unconstrained fn write_read_utility() {
-    let env = TestEnvironment::_new();
+    let env = TestEnvironment::new();
     let value = MockStruct::new(5, 6);
 
     env.public_context(|context| {

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
@@ -109,15 +109,6 @@ impl TestEnvironment {
         }
     }
 
-    pub unconstrained fn _new() -> Self {
-        txe_oracles::enable_context_checks();
-        Self {
-            light_account_secret: Counter::new(),
-            contract_account_secret: Counter::new(),
-            contract_deployment_secret: Counter::new(),
-        }
-    }
-
     /// Creates a `PublicContext`, which allows using aztec-nr features as if inside a public contract function. Useful
     /// for low-level testing of public state variables and utilities.
     ///

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment/test.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment/test.nr
@@ -7,14 +7,14 @@ mod public_context;
 
 #[test(should_fail_with = "cannot be before next timestamp")]
 unconstrained fn set_next_block_timestamp_to_past_fails() {
-    let env = TestEnvironment::_new();
+    let env = TestEnvironment::new();
 
     env.set_next_block_timestamp(env.last_block_timestamp() - 1);
 }
 
 #[test]
 unconstrained fn set_next_block_timestamp_does_not_mine_a_block() {
-    let env = TestEnvironment::_new();
+    let env = TestEnvironment::new();
 
     let next_block_number_before = env.next_block_number();
     env.set_next_block_timestamp(env.last_block_timestamp() + 3600);
@@ -25,7 +25,7 @@ unconstrained fn set_next_block_timestamp_does_not_mine_a_block() {
 
 #[test]
 unconstrained fn set_next_block_timestamp_sets_next_manually_mined_block_timestamp() {
-    let env = TestEnvironment::_new();
+    let env = TestEnvironment::new();
 
     let expected_next_block_timestamp = env.last_block_timestamp() + 3600;
     env.set_next_block_timestamp(expected_next_block_timestamp);
@@ -36,7 +36,7 @@ unconstrained fn set_next_block_timestamp_sets_next_manually_mined_block_timesta
 
 #[test]
 unconstrained fn set_next_block_timestamp_sets_next_public_context_timestamp() {
-    let env = TestEnvironment::_new();
+    let env = TestEnvironment::new();
 
     let expected_next_block_timestamp = env.last_block_timestamp() + 3600;
     env.set_next_block_timestamp(expected_next_block_timestamp);
@@ -46,7 +46,7 @@ unconstrained fn set_next_block_timestamp_sets_next_public_context_timestamp() {
 
 #[test]
 unconstrained fn set_next_block_timestamp_sets_next_private_context_inclusion_block_timestamp() {
-    let env = TestEnvironment::_new();
+    let env = TestEnvironment::new();
 
     let last_block_timestamp = env.last_block_timestamp();
     let expected_next_block_timestamp = env.last_block_timestamp() + 3600;
@@ -64,7 +64,7 @@ unconstrained fn set_next_block_timestamp_sets_next_private_context_inclusion_bl
 
 #[test]
 unconstrained fn advance_next_block_timestamp_by_does_not_mine_a_block() {
-    let env = TestEnvironment::_new();
+    let env = TestEnvironment::new();
 
     let next_block_number_before = env.next_block_number();
     env.advance_next_block_timestamp_by(0);
@@ -75,7 +75,7 @@ unconstrained fn advance_next_block_timestamp_by_does_not_mine_a_block() {
 
 #[test]
 unconstrained fn advance_next_block_timestamp_by_sets_next_manually_mined_block_timestamp() {
-    let env = TestEnvironment::_new();
+    let env = TestEnvironment::new();
 
     let expected_next_block_timestamp = env.last_block_timestamp() + 3600;
     env.advance_next_block_timestamp_by(3600);
@@ -86,7 +86,7 @@ unconstrained fn advance_next_block_timestamp_by_sets_next_manually_mined_block_
 
 #[test]
 unconstrained fn advance_next_block_timestamp_by_sets_next_public_context_timestamp() {
-    let env = TestEnvironment::_new();
+    let env = TestEnvironment::new();
 
     let expected_next_block_timestamp = env.last_block_timestamp() + 3600;
     env.advance_next_block_timestamp_by(3600);
@@ -96,7 +96,7 @@ unconstrained fn advance_next_block_timestamp_by_sets_next_public_context_timest
 
 #[test]
 unconstrained fn mine_block_mines_a_block() {
-    let env = TestEnvironment::_new();
+    let env = TestEnvironment::new();
 
     let next_block_number_before = env.next_block_number();
     env.mine_block();
@@ -107,7 +107,7 @@ unconstrained fn mine_block_mines_a_block() {
 
 #[test]
 unconstrained fn mine_block_does_not_advance_the_timestamp() {
-    let env = TestEnvironment::_new();
+    let env = TestEnvironment::new();
 
     let previous_block_timestamp = env.last_block_timestamp();
     env.mine_block();
@@ -118,7 +118,7 @@ unconstrained fn mine_block_does_not_advance_the_timestamp() {
 
 #[test]
 unconstrained fn mine_block_at_mines_a_block() {
-    let env = TestEnvironment::_new();
+    let env = TestEnvironment::new();
 
     let next_block_number_before = env.next_block_number();
     env.mine_block_at(env.last_block_timestamp() + 1);
@@ -129,7 +129,7 @@ unconstrained fn mine_block_at_mines_a_block() {
 
 #[test]
 unconstrained fn mine_block_at_sets_the_block_timestamp() {
-    let env = TestEnvironment::_new();
+    let env = TestEnvironment::new();
 
     let expected_block_timestamp = env.last_block_timestamp() + 3600 * 24 * 30; // Advance a month
     env.mine_block_at(expected_block_timestamp);
@@ -139,7 +139,7 @@ unconstrained fn mine_block_at_sets_the_block_timestamp() {
 
 #[test(should_fail_with = "Cannot go back in time")]
 unconstrained fn mine_block_at_fails_with_past_timestamps() {
-    let env = TestEnvironment::_new();
+    let env = TestEnvironment::new();
 
     let expected_block_timestamp = env.last_block_timestamp() - 1;
     env.mine_block_at(expected_block_timestamp);
@@ -147,7 +147,7 @@ unconstrained fn mine_block_at_fails_with_past_timestamps() {
 
 #[test]
 unconstrained fn public_context_uses_next_block_number() {
-    let env = TestEnvironment::_new();
+    let env = TestEnvironment::new();
 
     let pending = env.next_block_number();
 
@@ -156,7 +156,7 @@ unconstrained fn public_context_uses_next_block_number() {
 
 #[test]
 unconstrained fn public_context_advances_block_number() {
-    let env = TestEnvironment::_new();
+    let env = TestEnvironment::new();
 
     let first_block_number = env.public_context(|context| context.block_number());
     let second_block_number = env.public_context(|context| context.block_number());
@@ -166,7 +166,7 @@ unconstrained fn public_context_advances_block_number() {
 
 #[test]
 unconstrained fn public_context_does_not_advance_the_timestamp() {
-    let env = TestEnvironment::_new();
+    let env = TestEnvironment::new();
 
     let first_timestamp = env.public_context(|context| context.timestamp());
     let second_timestamp = env.public_context(|context| context.timestamp());
@@ -186,7 +186,7 @@ unconstrained fn public_context_repeats_contract_address() {
 
 #[test]
 unconstrained fn private_context_uses_last_block_number() {
-    let env = TestEnvironment::_new();
+    let env = TestEnvironment::new();
 
     let last_block_number = env.last_block_number();
 
@@ -197,7 +197,7 @@ unconstrained fn private_context_uses_last_block_number() {
 
 #[test]
 unconstrained fn private_context_advances_block_number() {
-    let env = TestEnvironment::_new();
+    let env = TestEnvironment::new();
 
     let first_block_number =
         env.private_context(|context| context.get_block_header().global_variables.block_number);
@@ -209,7 +209,7 @@ unconstrained fn private_context_advances_block_number() {
 
 #[test]
 unconstrained fn private_context_does_not_advance_the_timestamp() {
-    let env = TestEnvironment::_new();
+    let env = TestEnvironment::new();
 
     env.private_context(|_| {});
     let first_timestamp = env.last_block_timestamp();
@@ -234,7 +234,7 @@ unconstrained fn private_context_repeats_contract_address() {
 // implemented as actual separate handlers we'll be able to make this test pass.
 // #[test]
 // unconstrained fn utility_context_uses_last_block_number() {
-//     let env = TestEnvironment::_new();
+//     let env = TestEnvironment::new();
 
 //     let last_block_number = env.last_block_number();
 
@@ -245,7 +245,7 @@ unconstrained fn private_context_repeats_contract_address() {
 
 #[test]
 unconstrained fn utility_context_does_not_advance_block_number() {
-    let env = TestEnvironment::_new();
+    let env = TestEnvironment::new();
 
     let first_block_number = env.utility_context(|context| context.block_number());
     let second_block_number = env.utility_context(|context| context.block_number());
@@ -255,7 +255,7 @@ unconstrained fn utility_context_does_not_advance_block_number() {
 
 #[test]
 unconstrained fn utility_context_does_not_advance_the_timestamp() {
-    let env = TestEnvironment::_new();
+    let env = TestEnvironment::new();
 
     env.utility_context(|_| {});
     let first_timestamp = env.last_block_timestamp();

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment/test/accounts.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment/test/accounts.nr
@@ -8,7 +8,7 @@ use protocol_types::{abis::function_selector::FunctionSelector, address::AztecAd
 
 #[test]
 unconstrained fn create_light_account_does_not_repeat_accounts() {
-    let mut env = TestEnvironment::_new();
+    let mut env = TestEnvironment::new();
 
     let first_account = env.create_light_account();
     let second_account = env.create_light_account();

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment/test/private_context.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment/test/private_context.nr
@@ -5,7 +5,7 @@ use protocol_types::{
 
 #[test]
 unconstrained fn at_sets_contract_address() {
-    let env = TestEnvironment::_new();
+    let env = TestEnvironment::new();
     let contract_address = AztecAddress::from_field(17);
 
     env.private_context_at(contract_address, |context| {
@@ -15,7 +15,7 @@ unconstrained fn at_sets_contract_address() {
 
 #[test]
 unconstrained fn opts_sets_contract_address_and_historical_block_number() {
-    let env = TestEnvironment::_new();
+    let env = TestEnvironment::new();
 
     env.mine_block();
     let historical_block_number = env.last_block_number() - 1;

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment/test/public_context.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment/test/public_context.nr
@@ -17,7 +17,7 @@ global nullifier: Field = 9;
 
 #[test]
 unconstrained fn at_sets_contract_address() {
-    let env = TestEnvironment::_new();
+    let env = TestEnvironment::new();
     let contract_address = AztecAddress::from_field(17);
 
     env.public_context_at(contract_address, |context| {
@@ -27,7 +27,7 @@ unconstrained fn at_sets_contract_address() {
 
 #[test]
 unconstrained fn default_storage_value() {
-    let env = TestEnvironment::_new();
+    let env = TestEnvironment::new();
 
     env.public_context(|context| {
         assert_eq(context.storage_read::<MockStruct>(storage_slot), zeroed());
@@ -36,7 +36,7 @@ unconstrained fn default_storage_value() {
 
 #[test]
 unconstrained fn storage_write_in_same_context() {
-    let env = TestEnvironment::_new();
+    let env = TestEnvironment::new();
 
     env.public_context(|context| {
         context.storage_write(storage_slot, value);
@@ -46,7 +46,7 @@ unconstrained fn storage_write_in_same_context() {
 
 #[test]
 unconstrained fn storage_write_in_future_context() {
-    let env = TestEnvironment::_new();
+    let env = TestEnvironment::new();
 
     env.public_context(|context| { context.storage_write(storage_slot, value); });
 
@@ -55,7 +55,7 @@ unconstrained fn storage_write_in_future_context() {
 
 #[test]
 unconstrained fn storage_multiple_writes_in_same_context() {
-    let env = TestEnvironment::_new();
+    let env = TestEnvironment::new();
 
     env.public_context(|context| {
         context.storage_write(storage_slot, value);
@@ -67,7 +67,7 @@ unconstrained fn storage_multiple_writes_in_same_context() {
 
 #[test]
 unconstrained fn storage_multiple_writes_in_future_context() {
-    let env = TestEnvironment::_new();
+    let env = TestEnvironment::new();
 
     env.public_context(|context| { context.storage_write(storage_slot, value); });
 
@@ -79,7 +79,7 @@ unconstrained fn storage_multiple_writes_in_future_context() {
 
 #[test]
 unconstrained fn read_nonexistent_nullifier() {
-    let env = TestEnvironment::_new();
+    let env = TestEnvironment::new();
 
     env.public_context(|context| {
         assert(!context.nullifier_exists(nullifier, context.this_address()));
@@ -88,7 +88,7 @@ unconstrained fn read_nonexistent_nullifier() {
 
 #[test]
 unconstrained fn read_public_nullifier_same_context() {
-    let env = TestEnvironment::_new();
+    let env = TestEnvironment::new();
 
     env.public_context(|context| {
         context.push_nullifier(nullifier);
@@ -98,7 +98,7 @@ unconstrained fn read_public_nullifier_same_context() {
 
 #[test]
 unconstrained fn read_public_nullifier_other_context() {
-    let env = TestEnvironment::_new();
+    let env = TestEnvironment::new();
 
     env.public_context(|context| { context.push_nullifier(nullifier); });
 
@@ -109,7 +109,7 @@ unconstrained fn read_public_nullifier_other_context() {
 
 #[test]
 unconstrained fn read_private_nullifier() {
-    let env = TestEnvironment::_new();
+    let env = TestEnvironment::new();
 
     env.private_context(|context| { context.push_nullifier(nullifier); });
 

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/txe_oracles.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/txe_oracles.nr
@@ -117,9 +117,6 @@ unconstrained fn public_call_new_flow_oracle(
     is_static_call: bool,
 ) -> [Field; 2] {}
 
-#[oracle(txeEnableContextChecks)]
-pub unconstrained fn enable_context_checks() {}
-
 #[oracle(txeSetTopLevelTXEContext)]
 pub unconstrained fn set_top_level_txe_context() {}
 

--- a/yarn-project/txe/src/index.ts
+++ b/yarn-project/txe/src/index.ts
@@ -22,7 +22,7 @@ import { readFile, readdir } from 'fs/promises';
 import { join, parse } from 'path';
 import { z } from 'zod';
 
-import { TXEService } from './txe_service/txe_service.js';
+import { type TXEOracleFunctionName, TXESession } from './txe_session.js';
 import {
   type ForeignCallArgs,
   ForeignCallArgsSchema,
@@ -36,7 +36,7 @@ import {
 } from './util/encoding.js';
 import type { ContractArtifactWithHash } from './util/txe_contract_data_provider.js';
 
-const TXESessions = new Map<number, TXEService>();
+const sessions = new Map<number, TXESession>();
 
 /*
  * TXE typically has to load the same contract artifacts over and over again for multiple tests,
@@ -47,13 +47,9 @@ const TXEArtifactsCache = new Map<
   { artifact: ContractArtifactWithHash; instance: ContractInstanceWithAddress }
 >();
 
-type MethodNames<T> = {
-  [K in keyof T]: T[K] extends (...args: any[]) => any ? K : never;
-}[keyof T];
-
 type TXEForeignCallInput = {
   session_id: number;
-  function: MethodNames<TXEService>;
+  function: TXEOracleFunctionName;
   root_path: string;
   package_name: string;
   inputs: ForeignCallArgs;
@@ -62,7 +58,7 @@ type TXEForeignCallInput = {
 const TXEForeignCallInputSchema = z.object({
   // eslint-disable-next-line camelcase
   session_id: z.number().int().nonnegative(),
-  function: z.string() as ZodFor<MethodNames<TXEService>>,
+  function: z.string() as ZodFor<TXEOracleFunctionName>,
   // eslint-disable-next-line camelcase
   root_path: z.string(),
   // eslint-disable-next-line camelcase
@@ -205,14 +201,14 @@ class TXEDispatcher {
     const { session_id: sessionId, function: functionName, inputs } = callData;
     this.logger.debug(`Calling ${functionName} on session ${sessionId}`);
 
-    if (!TXESessions.has(sessionId)) {
+    if (!sessions.has(sessionId)) {
       this.logger.debug(`Creating new session ${sessionId}`);
       if (!this.protocolContracts) {
         this.protocolContracts = await Promise.all(
           protocolContractNames.map(name => new BundledProtocolContractsProvider().getProtocolContractArtifact(name)),
         );
       }
-      TXESessions.set(sessionId, await TXEService.init(this.protocolContracts));
+      sessions.set(sessionId, await TXESession.init(this.protocolContracts));
     }
 
     switch (functionName) {
@@ -226,21 +222,7 @@ class TXEDispatcher {
       }
     }
 
-    const txeService = TXESessions.get(sessionId);
-
-    // Check if the function exists on the txeService before calling it
-    if (typeof (txeService as any)[functionName] !== 'function') {
-      const availableMethods = Object.getOwnPropertyNames(Object.getPrototypeOf(txeService))
-        .filter(name => typeof (txeService as any)[name] === 'function' && name !== 'constructor')
-        .sort();
-
-      throw new Error(
-        `TXE function '${functionName}' is not available. ` + `Available methods: ${availableMethods.join(', ')}`,
-      );
-    }
-
-    const response = await (txeService as any)[functionName](...inputs);
-    return response;
+    return await sessions.get(sessionId)!.processFunction(functionName, inputs);
   }
 }
 

--- a/yarn-project/txe/src/txe_service/txe_service.ts
+++ b/yarn-project/txe/src/txe_service/txe_service.ts
@@ -23,17 +23,7 @@ import {
   toSingle,
 } from '../util/encoding.js';
 
-enum TXEContext {
-  TOP_LEVEL,
-  PRIVATE,
-  PUBLIC,
-  UTILITY,
-}
-
 export class TXEService {
-  context = TXEContext.TOP_LEVEL;
-  contextChecksEnabled = false;
-
   constructor(private txe: TXE) {}
 
   static async init(protocolContracts: ProtocolContract[]) {
@@ -42,59 +32,6 @@ export class TXEService {
     const service = new TXEService(txe);
     await service.txeAdvanceBlocksBy(toSingle(new Fr(1n)));
     return service;
-  }
-
-  // TXE Context manipulation
-
-  // Temporary workaround - once all tests migrate to calling the new flow, in which this oracle is called at the
-  // beginning of a txe test, we'll make the context check be mandatory
-  txeEnableContextChecks() {
-    this.contextChecksEnabled = true;
-    return toForeignCallResult([]);
-  }
-
-  txeSetTopLevelTXEContext() {
-    if (this.contextChecksEnabled) {
-      if (this.context == TXEContext.TOP_LEVEL) {
-        throw new Error(`Call to txeSetTopLevelTXEContext while in context ${TXEContext[this.context]}`);
-      }
-    }
-
-    this.context = TXEContext.TOP_LEVEL;
-    return toForeignCallResult([]);
-  }
-
-  txeSetPrivateTXEContext() {
-    if (this.contextChecksEnabled) {
-      if (this.context != TXEContext.TOP_LEVEL) {
-        throw new Error(`Call to txeSetPrivateTXEContext while in context ${TXEContext[this.context]}`);
-      }
-    }
-
-    this.context = TXEContext.PRIVATE;
-    return toForeignCallResult([]);
-  }
-
-  txeSetPublicTXEContext() {
-    if (this.contextChecksEnabled) {
-      if (this.context != TXEContext.TOP_LEVEL) {
-        throw new Error(`Call to txeSetPublicTXEContext while in context ${TXEContext[this.context]}`);
-      }
-    }
-
-    this.context = TXEContext.PUBLIC;
-    return toForeignCallResult([]);
-  }
-
-  txeSetUtilityTXEContext() {
-    if (this.contextChecksEnabled) {
-      if (this.context != TXEContext.TOP_LEVEL) {
-        throw new Error(`Call to txeSetUtilityTXEContext while in context ${TXEContext[this.context]}`);
-      }
-    }
-
-    this.context = TXEContext.UTILITY;
-    return toForeignCallResult([]);
   }
 
   // Cheatcodes
@@ -190,37 +127,18 @@ export class TXEService {
   // PXE oracles
 
   utilityGetRandomField() {
-    if (this.contextChecksEnabled && this.context == TXEContext.TOP_LEVEL) {
-      throw new Error(
-        'Oracle access from the root of a TXe test are not enabled. Please use env._ to interact with the oracles.',
-      );
-    }
-
     const randomField = this.txe.utilityGetRandomField();
 
     return toForeignCallResult([toSingle(randomField)]);
   }
 
   async utilityGetContractAddress() {
-    if (
-      this.contextChecksEnabled &&
-      this.context != TXEContext.TOP_LEVEL &&
-      this.context != TXEContext.UTILITY &&
-      this.context != TXEContext.PRIVATE
-    ) {
-      throw new Error(`Attempted to call utilityGetContractAddress while in context ${TXEContext[this.context]}`);
-    }
-
     const contractAddress = await this.txe.utilityGetContractAddress();
 
     return toForeignCallResult([toSingle(contractAddress.toField())]);
   }
 
   async utilityGetBlockNumber() {
-    if (this.contextChecksEnabled && this.context != TXEContext.TOP_LEVEL && this.context != TXEContext.UTILITY) {
-      throw new Error(`Attempted to call utilityGetBlockNumber while in context ${TXEContext[this.context]}`);
-    }
-
     const blockNumber = await this.txe.utilityGetBlockNumber();
 
     return toForeignCallResult([toSingle(new Fr(blockNumber))]);
@@ -228,20 +146,12 @@ export class TXEService {
 
   // seems to be used to mean the timestamp of the last mined block in txe (but that's not what is done here)
   async utilityGetTimestamp() {
-    if (this.contextChecksEnabled && this.context != TXEContext.TOP_LEVEL && this.context != TXEContext.UTILITY) {
-      throw new Error(`Attempted to call utilityGetTimestamp while in context ${TXEContext[this.context]}`);
-    }
-
     const timestamp = await this.txe.utilityGetTimestamp();
 
     return toForeignCallResult([toSingle(new Fr(timestamp))]);
   }
 
   async txeGetLastBlockTimestamp() {
-    if (this.contextChecksEnabled && this.context != TXEContext.TOP_LEVEL) {
-      throw new Error(`Attempted to call txeGetLastBlockTimestamp while in context ${TXEContext[this.context]}`);
-    }
-
     const timestamp = await this.txe.txeGetLastBlockTimestamp();
 
     return toForeignCallResult([toSingle(new Fr(timestamp))]);
@@ -253,11 +163,6 @@ export class TXEService {
     foreignValues: ForeignCallArray,
     foreignHash: ForeignCallSingle,
   ) {
-    if (this.contextChecksEnabled && this.context == TXEContext.TOP_LEVEL) {
-      throw new Error(
-        'Oracle access from the root of a TXe test are not enabled. Please use env._ to interact with the oracles.',
-      );
-    }
     const values = fromArray(foreignValues);
     const hash = fromSingle(foreignHash);
 
@@ -267,11 +172,6 @@ export class TXEService {
   }
 
   async privateLoadFromExecutionCache(foreignHash: ForeignCallSingle) {
-    if (this.contextChecksEnabled && this.context == TXEContext.TOP_LEVEL) {
-      throw new Error(
-        'Oracle access from the root of a TXe test are not enabled. Please use env._ to interact with the oracles.',
-      );
-    }
     const hash = fromSingle(foreignHash);
 
     const returns = await this.txe.privateLoadFromExecutionCache(hash);
@@ -312,11 +212,6 @@ export class TXEService {
   }
 
   async utilityGetPublicDataWitness(foreignBlockNumber: ForeignCallSingle, foreignLeafSlot: ForeignCallSingle) {
-    if (this.contextChecksEnabled && this.context == TXEContext.TOP_LEVEL) {
-      throw new Error(
-        'Oracle access from the root of a TXe test are not enabled. Please use env._ to interact with the oracles.',
-      );
-    }
     const blockNumber = fromSingle(foreignBlockNumber).toNumber();
     const leafSlot = fromSingle(foreignLeafSlot);
 
@@ -346,11 +241,6 @@ export class TXEService {
     foreignMaxNotes: ForeignCallSingle,
     foreignPackedRetrievedNoteLength: ForeignCallSingle,
   ) {
-    if (this.contextChecksEnabled && this.context == TXEContext.TOP_LEVEL) {
-      throw new Error(
-        'Oracle access from the root of a TXe test are not enabled. Please use env._ to interact with the oracles.',
-      );
-    }
     const storageSlot = fromSingle(foreignStorageSlot);
     const numSelects = fromSingle(foreignNumSelects).toNumber();
     const selectByIndexes = fromArray(foreignSelectByIndexes).map(fr => fr.toNumber());
@@ -409,11 +299,6 @@ export class TXEService {
     foreignNoteHash: ForeignCallSingle,
     foreignCounter: ForeignCallSingle,
   ) {
-    if (this.contextChecksEnabled && this.context == TXEContext.TOP_LEVEL) {
-      throw new Error(
-        'Oracle access from the root of a TXe test are not enabled. Please use env._ to interact with the oracles.',
-      );
-    }
     const storageSlot = fromSingle(foreignStorageSlot);
     const noteTypeId = NoteSelector.fromField(fromSingle(foreignNoteTypeId));
     const note = fromArray(foreignNote);
@@ -430,11 +315,6 @@ export class TXEService {
     foreignNoteHash: ForeignCallSingle,
     foreignCounter: ForeignCallSingle,
   ) {
-    if (this.contextChecksEnabled && this.context == TXEContext.TOP_LEVEL) {
-      throw new Error(
-        'Oracle access from the root of a TXe test are not enabled. Please use env._ to interact with the oracles.',
-      );
-    }
     const innerNullifier = fromSingle(foreignInnerNullifier);
     const noteHash = fromSingle(foreignNoteHash);
     const counter = fromSingle(foreignCounter).toNumber();
@@ -445,11 +325,6 @@ export class TXEService {
   }
 
   async privateNotifyCreatedNullifier(foreignInnerNullifier: ForeignCallSingle) {
-    if (this.contextChecksEnabled && this.context == TXEContext.TOP_LEVEL) {
-      throw new Error(
-        'Oracle access from the root of a TXe test are not enabled. Please use env._ to interact with the oracles.',
-      );
-    }
     const innerNullifier = fromSingle(foreignInnerNullifier);
 
     await this.txe.privateNotifyCreatedNullifier(innerNullifier);
@@ -458,11 +333,6 @@ export class TXEService {
   }
 
   async utilityCheckNullifierExists(foreignInnerNullifier: ForeignCallSingle) {
-    if (this.contextChecksEnabled && this.context == TXEContext.TOP_LEVEL) {
-      throw new Error(
-        'Oracle access from the root of a TXe test are not enabled. Please use env._ to interact with the oracles.',
-      );
-    }
     const innerNullifier = fromSingle(foreignInnerNullifier);
 
     const exists = await this.txe.utilityCheckNullifierExists(innerNullifier);
@@ -471,11 +341,6 @@ export class TXEService {
   }
 
   async utilityGetContractInstance(foreignAddress: ForeignCallSingle) {
-    if (this.contextChecksEnabled && this.context == TXEContext.TOP_LEVEL) {
-      throw new Error(
-        'Oracle access from the root of a TXe test are not enabled. Please use env._ to interact with the oracles.',
-      );
-    }
     const address = addressFromSingle(foreignAddress);
 
     const instance = await this.txe.utilityGetContractInstance(address);
@@ -492,11 +357,6 @@ export class TXEService {
   }
 
   async utilityGetPublicKeysAndPartialAddress(foreignAddress: ForeignCallSingle) {
-    if (this.contextChecksEnabled && this.context == TXEContext.TOP_LEVEL) {
-      throw new Error(
-        'Oracle access from the root of a TXe test are not enabled. Please use env._ to interact with the oracles.',
-      );
-    }
     const address = addressFromSingle(foreignAddress);
 
     const { publicKeys, partialAddress } = await this.txe.utilityGetCompleteAddress(address);
@@ -505,11 +365,6 @@ export class TXEService {
   }
 
   async utilityGetKeyValidationRequest(foreignPkMHash: ForeignCallSingle) {
-    if (this.contextChecksEnabled && this.context == TXEContext.TOP_LEVEL) {
-      throw new Error(
-        'Oracle access from the root of a TXe test are not enabled. Please use env._ to interact with the oracles.',
-      );
-    }
     const pkMHash = fromSingle(foreignPkMHash);
 
     const keyValidationRequest = await this.txe.utilityGetKeyValidationRequest(pkMHash);
@@ -533,11 +388,6 @@ export class TXEService {
     foreignBlockNumber: ForeignCallSingle,
     foreignNullifier: ForeignCallSingle,
   ) {
-    if (this.contextChecksEnabled && this.context == TXEContext.TOP_LEVEL) {
-      throw new Error(
-        'Oracle access from the root of a TXe test are not enabled. Please use env._ to interact with the oracles.',
-      );
-    }
     const blockNumber = fromSingle(foreignBlockNumber).toNumber();
     const nullifier = fromSingle(foreignNullifier);
 
@@ -550,11 +400,6 @@ export class TXEService {
   }
 
   async utilityGetAuthWitness(foreignMessageHash: ForeignCallSingle) {
-    if (this.contextChecksEnabled && this.context == TXEContext.TOP_LEVEL) {
-      throw new Error(
-        'Oracle access from the root of a TXe test are not enabled. Please use env._ to interact with the oracles.',
-      );
-    }
     const messageHash = fromSingle(foreignMessageHash);
 
     const authWitness = await this.txe.utilityGetAuthWitness(messageHash);
@@ -588,35 +433,18 @@ export class TXEService {
   }
 
   async utilityGetChainId() {
-    if (this.contextChecksEnabled && this.context == TXEContext.TOP_LEVEL) {
-      throw new Error(
-        'Oracle access from the root of a TXe test are not enabled. Please use env._ to interact with the oracles.',
-      );
-    }
-
     const chainId = await this.txe.utilityGetChainId();
 
     return toForeignCallResult([toSingle(chainId)]);
   }
 
   async utilityGetVersion() {
-    if (this.contextChecksEnabled && this.context == TXEContext.TOP_LEVEL) {
-      throw new Error(
-        'Oracle access from the root of a TXe test are not enabled. Please use env._ to interact with the oracles.',
-      );
-    }
-
     const version = await this.txe.utilityGetVersion();
 
     return toForeignCallResult([toSingle(version)]);
   }
 
   async utilityGetBlockHeader(foreignBlockNumber: ForeignCallSingle) {
-    if (this.contextChecksEnabled && this.context == TXEContext.TOP_LEVEL) {
-      throw new Error(
-        'Oracle access from the root of a TXe test are not enabled. Please use env._ to interact with the oracles.',
-      );
-    }
     const blockNumber = fromSingle(foreignBlockNumber).toNumber();
 
     const header = await this.txe.utilityGetBlockHeader(blockNumber);
@@ -632,11 +460,6 @@ export class TXEService {
     foreignTreeId: ForeignCallSingle,
     foreignLeafValue: ForeignCallSingle,
   ) {
-    if (this.contextChecksEnabled && this.context == TXEContext.TOP_LEVEL) {
-      throw new Error(
-        'Oracle access from the root of a TXe test are not enabled. Please use env._ to interact with the oracles.',
-      );
-    }
     const blockNumber = fromSingle(foreignBlockNumber).toNumber();
     const treeId = fromSingle(foreignTreeId).toNumber();
     const leafValue = fromSingle(foreignLeafValue);
@@ -655,11 +478,6 @@ export class TXEService {
     foreignBlockNumber: ForeignCallSingle,
     foreignNullifier: ForeignCallSingle,
   ) {
-    if (this.contextChecksEnabled && this.context == TXEContext.TOP_LEVEL) {
-      throw new Error(
-        'Oracle access from the root of a TXe test are not enabled. Please use env._ to interact with the oracles.',
-      );
-    }
     const blockNumber = fromSingle(foreignBlockNumber).toNumber();
     const nullifier = fromSingle(foreignNullifier);
 
@@ -672,11 +490,6 @@ export class TXEService {
   }
 
   async utilityGetIndexedTaggingSecretAsSender(foreignSender: ForeignCallSingle, foreignRecipient: ForeignCallSingle) {
-    if (this.contextChecksEnabled && this.context == TXEContext.TOP_LEVEL) {
-      throw new Error(
-        'Oracle access from the root of a TXe test are not enabled. Please use env._ to interact with the oracles.',
-      );
-    }
     const sender = AztecAddress.fromField(fromSingle(foreignSender));
     const recipient = AztecAddress.fromField(fromSingle(foreignRecipient));
 
@@ -686,11 +499,6 @@ export class TXEService {
   }
 
   async utilityFetchTaggedLogs(foreignPendingTaggedLogArrayBaseSlot: ForeignCallSingle) {
-    if (this.contextChecksEnabled && this.context == TXEContext.TOP_LEVEL) {
-      throw new Error(
-        'Oracle access from the root of a TXe test are not enabled. Please use env._ to interact with the oracles.',
-      );
-    }
     const pendingTaggedLogArrayBaseSlot = fromSingle(foreignPendingTaggedLogArrayBaseSlot);
 
     await this.txe.utilityFetchTaggedLogs(pendingTaggedLogArrayBaseSlot);
@@ -703,11 +511,6 @@ export class TXEService {
     foreignNoteValidationRequestsArrayBaseSlot: ForeignCallSingle,
     foreignEventValidationRequestsArrayBaseSlot: ForeignCallSingle,
   ) {
-    if (this.contextChecksEnabled && this.context == TXEContext.TOP_LEVEL) {
-      throw new Error(
-        'Oracle access from the root of a TXe test are not enabled. Please use env._ to interact with the oracles.',
-      );
-    }
     const contractAddress = AztecAddress.fromField(fromSingle(foreignContractAddress));
     const noteValidationRequestsArrayBaseSlot = fromSingle(foreignNoteValidationRequestsArrayBaseSlot);
     const eventValidationRequestsArrayBaseSlot = fromSingle(foreignEventValidationRequestsArrayBaseSlot);
@@ -726,11 +529,6 @@ export class TXEService {
     foreignLogRetrievalRequestsArrayBaseSlot: ForeignCallSingle,
     foreignLogRetrievalResponsesArrayBaseSlot: ForeignCallSingle,
   ) {
-    if (this.contextChecksEnabled && this.context == TXEContext.TOP_LEVEL) {
-      throw new Error(
-        'Oracle access from the root of a TXe test are not enabled. Please use env._ to interact with the oracles.',
-      );
-    }
     const contractAddress = AztecAddress.fromField(fromSingle(foreignContractAddress));
     const logRetrievalRequestsArrayBaseSlot = fromSingle(foreignLogRetrievalRequestsArrayBaseSlot);
     const logRetrievalResponsesArrayBaseSlot = fromSingle(foreignLogRetrievalResponsesArrayBaseSlot);
@@ -749,11 +547,6 @@ export class TXEService {
     foreignSlot: ForeignCallSingle,
     foreignCapsule: ForeignCallArray,
   ) {
-    if (this.contextChecksEnabled && this.context == TXEContext.TOP_LEVEL) {
-      throw new Error(
-        'Oracle access from the root of a TXe test are not enabled. Please use env._ to interact with the oracles.',
-      );
-    }
     const contractAddress = AztecAddress.fromField(fromSingle(foreignContractAddress));
     const slot = fromSingle(foreignSlot);
     const capsule = fromArray(foreignCapsule);
@@ -768,11 +561,6 @@ export class TXEService {
     foreignSlot: ForeignCallSingle,
     foreignTSize: ForeignCallSingle,
   ) {
-    if (this.contextChecksEnabled && this.context == TXEContext.TOP_LEVEL) {
-      throw new Error(
-        'Oracle access from the root of a TXe test are not enabled. Please use env._ to interact with the oracles.',
-      );
-    }
     const contractAddress = AztecAddress.fromField(fromSingle(foreignContractAddress));
     const slot = fromSingle(foreignSlot);
     const tSize = fromSingle(foreignTSize).toNumber();
@@ -791,11 +579,6 @@ export class TXEService {
   }
 
   async utilityDeleteCapsule(foreignContractAddress: ForeignCallSingle, foreignSlot: ForeignCallSingle) {
-    if (this.contextChecksEnabled && this.context == TXEContext.TOP_LEVEL) {
-      throw new Error(
-        'Oracle access from the root of a TXe test are not enabled. Please use env._ to interact with the oracles.',
-      );
-    }
     const contractAddress = AztecAddress.fromField(fromSingle(foreignContractAddress));
     const slot = fromSingle(foreignSlot);
 
@@ -810,11 +593,6 @@ export class TXEService {
     foreignDstSlot: ForeignCallSingle,
     foreignNumEntries: ForeignCallSingle,
   ) {
-    if (this.contextChecksEnabled && this.context == TXEContext.TOP_LEVEL) {
-      throw new Error(
-        'Oracle access from the root of a TXe test are not enabled. Please use env._ to interact with the oracles.',
-      );
-    }
     const contractAddress = AztecAddress.fromField(fromSingle(foreignContractAddress));
     const srcSlot = fromSingle(foreignSrcSlot);
     const dstSlot = fromSingle(foreignDstSlot);
@@ -835,11 +613,6 @@ export class TXEService {
     foreignIv: ForeignCallArray,
     foreignSymKey: ForeignCallArray,
   ) {
-    if (this.contextChecksEnabled && this.context == TXEContext.TOP_LEVEL) {
-      throw new Error(
-        'Oracle access from the root of a TXe test are not enabled. Please use env._ to interact with the oracles.',
-      );
-    }
     const ciphertext = fromUintBoundedVec(foreignCiphertextBVecStorage, foreignCiphertextLength, 8);
     const iv = fromUintArray(foreignIv, 8);
     const symKey = fromUintArray(foreignSymKey, 8);
@@ -857,11 +630,6 @@ export class TXEService {
     foreignEphPKField1: ForeignCallSingle,
     foreignEphPKField2: ForeignCallSingle,
   ) {
-    if (this.contextChecksEnabled && this.context == TXEContext.TOP_LEVEL) {
-      throw new Error(
-        'Oracle access from the root of a TXe test are not enabled. Please use env._ to interact with the oracles.',
-      );
-    }
     const address = AztecAddress.fromField(fromSingle(foreignAddress));
     const ephPK = Point.fromFields([
       fromSingle(foreignEphPKField0),
@@ -881,20 +649,11 @@ export class TXEService {
   // AVM opcodes
 
   avmOpcodeEmitUnencryptedLog(_foreignMessage: ForeignCallArray) {
-    if (this.contextChecksEnabled && this.context != TXEContext.PUBLIC) {
-      throw new Error(
-        `Attempted to call the avmOpcodeEmitUnencryptedLog oracle while in context ${TXEContext[this.context]}`,
-      );
-    }
-
     // TODO(#8811): Implement
     return toForeignCallResult([]);
   }
 
   async avmOpcodeStorageRead(foreignSlot: ForeignCallSingle) {
-    if (this.contextChecksEnabled && this.context != TXEContext.PUBLIC) {
-      throw new Error(`Attempted to call the avmOpcodeStorageRead oracle while in context ${TXEContext[this.context]}`);
-    }
     const slot = fromSingle(foreignSlot);
 
     const value = (await this.txe.avmOpcodeStorageRead(slot)).value;
@@ -903,11 +662,6 @@ export class TXEService {
   }
 
   async avmOpcodeStorageWrite(foreignSlot: ForeignCallSingle, foreignValue: ForeignCallSingle) {
-    if (this.contextChecksEnabled && this.context != TXEContext.PUBLIC) {
-      throw new Error(
-        `Attempted to call the avmOpcodeStorageWrite oracle while in context ${TXEContext[this.context]}`,
-      );
-    }
     const slot = fromSingle(foreignSlot);
     const value = fromSingle(foreignValue);
 
@@ -917,11 +671,6 @@ export class TXEService {
   }
 
   async avmOpcodeGetContractInstanceDeployer(foreignAddress: ForeignCallSingle) {
-    if (this.contextChecksEnabled && this.context != TXEContext.PUBLIC) {
-      throw new Error(
-        `Attempted to call the avmOpcodeGetContractInstanceDeployer oracle while in context ${TXEContext[this.context]}`,
-      );
-    }
     const address = addressFromSingle(foreignAddress);
 
     const instance = await this.txe.utilityGetContractInstance(address);
@@ -934,11 +683,6 @@ export class TXEService {
   }
 
   async avmOpcodeGetContractInstanceClassId(foreignAddress: ForeignCallSingle) {
-    if (this.contextChecksEnabled && this.context != TXEContext.PUBLIC) {
-      throw new Error(
-        `Attempted to call the avmOpcodeGetContractInstanceClassId oracle while in context ${TXEContext[this.context]}`,
-      );
-    }
     const address = addressFromSingle(foreignAddress);
 
     const instance = await this.txe.utilityGetContractInstance(address);
@@ -951,11 +695,6 @@ export class TXEService {
   }
 
   async avmOpcodeGetContractInstanceInitializationHash(foreignAddress: ForeignCallSingle) {
-    if (this.contextChecksEnabled && this.context != TXEContext.PUBLIC) {
-      throw new Error(
-        `Attempted to call the avmOpcodeGetContractInstanceInitializationHash oracle while in context ${TXEContext[this.context]}`,
-      );
-    }
     const address = addressFromSingle(foreignAddress);
 
     const instance = await this.txe.utilityGetContractInstance(address);
@@ -968,21 +707,12 @@ export class TXEService {
   }
 
   avmOpcodeSender() {
-    if (this.contextChecksEnabled && this.context != TXEContext.PUBLIC) {
-      throw new Error(`Attempted to call the avmOpcodeSender oracle while in context ${TXEContext[this.context]}`);
-    }
-
     const sender = this.txe.getMsgSender();
 
     return toForeignCallResult([toSingle(sender)]);
   }
 
   async avmOpcodeEmitNullifier(foreignNullifier: ForeignCallSingle) {
-    if (this.contextChecksEnabled && this.context != TXEContext.PUBLIC) {
-      throw new Error(
-        `Attempted to call the avmOpcodeEmitNullifier oracle while in context ${TXEContext[this.context]}`,
-      );
-    }
     const nullifier = fromSingle(foreignNullifier);
 
     await this.txe.avmOpcodeEmitNullifier(nullifier);
@@ -991,11 +721,6 @@ export class TXEService {
   }
 
   async avmOpcodeEmitNoteHash(foreignNoteHash: ForeignCallSingle) {
-    if (this.contextChecksEnabled && this.context != TXEContext.PUBLIC) {
-      throw new Error(
-        `Attempted to call the avmOpcodeEmitNoteHash oracle while in context ${TXEContext[this.context]}`,
-      );
-    }
     const noteHash = fromSingle(foreignNoteHash);
 
     await this.txe.avmOpcodeEmitNoteHash(noteHash);
@@ -1004,11 +729,6 @@ export class TXEService {
   }
 
   async avmOpcodeNullifierExists(foreignInnerNullifier: ForeignCallSingle, foreignTargetAddress: ForeignCallSingle) {
-    if (this.contextChecksEnabled && this.context != TXEContext.PUBLIC) {
-      throw new Error(
-        `Attempted to call the avmOpcodeNullifierExists oracle while in context ${TXEContext[this.context]}`,
-      );
-    }
     const innerNullifier = fromSingle(foreignInnerNullifier);
     const targetAddress = AztecAddress.fromField(fromSingle(foreignTargetAddress));
 
@@ -1018,42 +738,24 @@ export class TXEService {
   }
 
   async avmOpcodeAddress() {
-    if (this.contextChecksEnabled && this.context != TXEContext.PUBLIC) {
-      throw new Error(`Attempted to call the avmOpcodeAddress oracle while in context ${TXEContext[this.context]}`);
-    }
-
     const contractAddress = await this.txe.utilityGetContractAddress();
 
     return toForeignCallResult([toSingle(contractAddress.toField())]);
   }
 
   async avmOpcodeBlockNumber() {
-    if (this.contextChecksEnabled && this.context != TXEContext.PUBLIC) {
-      throw new Error(`Attempted to call the avmOpcodeBlockNumber oracle while in context ${TXEContext[this.context]}`);
-    }
-
     const blockNumber = await this.txe.utilityGetBlockNumber();
 
     return toForeignCallResult([toSingle(new Fr(blockNumber))]);
   }
 
   async avmOpcodeTimestamp() {
-    if (this.contextChecksEnabled && this.context != TXEContext.PUBLIC) {
-      throw new Error(`Attempted to call the avmOpcodeTimestamp oracle while in context ${TXEContext[this.context]}`);
-    }
-
     const timestamp = await this.txe.utilityGetTimestamp();
 
     return toForeignCallResult([toSingle(new Fr(timestamp))]);
   }
 
   avmOpcodeIsStaticCall() {
-    if (this.contextChecksEnabled && this.context != TXEContext.PUBLIC) {
-      throw new Error(
-        `Attempted to call the avmOpcodeIsStaticCall oracle while in context ${TXEContext[this.context]}`,
-      );
-    }
-
     // TestEnvironment::public_context is always static
     const isStaticCall = true;
 
@@ -1061,20 +763,12 @@ export class TXEService {
   }
 
   async avmOpcodeChainId() {
-    if (this.contextChecksEnabled && this.context != TXEContext.PUBLIC) {
-      throw new Error(`Attempted to call the avmOpcodeChainId oracle while in context ${TXEContext[this.context]}`);
-    }
-
     const chainId = await this.txe.utilityGetChainId();
 
     return toForeignCallResult([toSingle(chainId)]);
   }
 
   async avmOpcodeVersion() {
-    if (this.contextChecksEnabled && this.context != TXEContext.PUBLIC) {
-      throw new Error(`Attempted to call the avmOpcodeVersion oracle while in context ${TXEContext[this.context]}`);
-    }
-
     const version = await this.txe.utilityGetVersion();
 
     return toForeignCallResult([toSingle(version)]);
@@ -1182,12 +876,6 @@ export class TXEService {
   }
 
   async privateGetSenderForTags() {
-    if (this.contextChecksEnabled && this.context == TXEContext.TOP_LEVEL) {
-      throw new Error(
-        'Oracle access from the root of a TXe test are not enabled. Please use env._ to interact with the oracles.',
-      );
-    }
-
     const sender = await this.txe.privateGetSenderForTags();
 
     // Return a Noir Option struct with `some` and `value` fields
@@ -1201,11 +889,6 @@ export class TXEService {
   }
 
   async privateSetSenderForTags(foreignSenderForTags: ForeignCallSingle) {
-    if (this.contextChecksEnabled && this.context == TXEContext.TOP_LEVEL) {
-      throw new Error(
-        'Oracle access from the root of a TXe test are not enabled. Please use env._ to interact with the oracles.',
-      );
-    }
     const senderForTags = AztecAddress.fromField(fromSingle(foreignSenderForTags));
 
     await this.txe.privateSetSenderForTags(senderForTags);

--- a/yarn-project/txe/src/txe_session.ts
+++ b/yarn-project/txe/src/txe_session.ts
@@ -1,0 +1,132 @@
+import { type Logger, createLogger } from '@aztec/foundation/log';
+import type { ProtocolContract } from '@aztec/protocol-contracts';
+
+import { TXEService } from './txe_service/txe_service.js';
+import { type ForeignCallArgs, type ForeignCallResult, toForeignCallResult } from './util/encoding.js';
+
+/**
+ * A TXE Session can be ine one of four states, which change as the test progresses and different oracles are called.
+ * The current state determines which oracles are available.
+ */
+enum SessionState {
+  /**
+   * The top-level state is the default state, before any other state has been entered. This is where contracts can be
+   * deployed, accounts created, blocks mined, etc.
+   */
+  TOP_LEVEL,
+  /**
+   * The private state is entered via the `private_context` function. In this state the PXE oracles that `#[private]`
+   * functions use are available, such as those related to note retrieval, notification of side-effects, capsule access,
+   * etc. */
+  PRIVATE,
+  /**
+   * The public state is entered via the `public_context` function. In this state the AVM opcodes that `#[public]`
+   * functions execute are resolved as oracles by TXE, since Noir tests are not transpiled. */
+  PUBLIC,
+  /**
+   * The utility state is entered via the `utility_context` function. In this state the PXE oracles that `#[utility]`
+   * functions use are available, such as those related to (unconstrained) note retrieval, capsule access, public
+   * storage reads, etc.
+   */
+  UTILITY,
+}
+
+const STATE_TRANSITION_FUNCTIONS = [
+  'txeSetTopLevelTXEContext',
+  'txeSetPrivateTXEContext',
+  'txeSetPublicTXEContext',
+  'txeSetUtilityTXEContext',
+] as const;
+
+type TXESessionStateTransitionFunction = (typeof STATE_TRANSITION_FUNCTIONS)[number];
+
+type MethodNames<T> = {
+  [K in keyof T]: T[K] extends (...args: any[]) => any ? K : never;
+}[keyof T];
+
+/**
+ * The name of an oracle function that TXE supports, which are a combination of PXE oracles, non-transpiled AVM opcodes,
+ * and custom TXE oracles.
+ */
+export type TXEOracleFunctionName = MethodNames<TXEService> | TXESessionStateTransitionFunction;
+
+/**
+ * A `TXESession` corresponds to a Noir `#[test]` function, and handles all of its oracle calls, stores test-specific
+ * state, etc., independent of all other tests running in parallel.
+ */
+export class TXESession {
+  state = SessionState.TOP_LEVEL;
+
+  constructor(
+    private logger: Logger,
+    private service: TXEService,
+  ) {}
+
+  static async init(protocolContracts: ProtocolContract[]) {
+    return new TXESession(createLogger('txe:session'), await TXEService.init(protocolContracts));
+  }
+
+  /**
+   * Processes an oracle function invoked by the Noir test associated to this session.
+   * @param functionName The name of the oracle.
+   * @param inputs The inputs of the oracle.
+   * @returns The oracle return values.
+   */
+  async processFunction(functionName: TXEOracleFunctionName, inputs: ForeignCallArgs): Promise<ForeignCallResult> {
+    // TXE state transition oracles are handled directly here instead of delegating to TXE service.
+    if (STATE_TRANSITION_FUNCTIONS.some(f => f == functionName)) {
+      this.state = this.processStateTransition(functionName as TXESessionStateTransitionFunction);
+      this.logger.debug(`Transitioned to state ${SessionState[this.state]}`);
+
+      return toForeignCallResult([]);
+    } else {
+      // Check if the function exists on the txeService before calling it
+      // TODO: why does the zod validation in the txe dispatcher not do this already?
+      if (typeof (this.service as any)[functionName] !== 'function') {
+        const availableMethods = Object.getOwnPropertyNames(Object.getPrototypeOf(this.service))
+          .filter(name => typeof (this.service as any)[name] === 'function' && name !== 'constructor')
+          .sort();
+
+        throw new Error(
+          `TXE function '${functionName}' is not available. ` + `Available methods: ${availableMethods.join(', ')}`,
+        );
+      }
+
+      return await (this.service as any)[functionName](...inputs);
+    }
+  }
+
+  processStateTransition(functionName: TXESessionStateTransitionFunction): SessionState {
+    switch (functionName) {
+      case 'txeSetTopLevelTXEContext':
+        this.assertNotInTopLevelState();
+        return SessionState.TOP_LEVEL;
+
+      case 'txeSetPrivateTXEContext':
+        this.assertInTopLevelState();
+        return SessionState.PRIVATE;
+
+      case 'txeSetPublicTXEContext':
+        this.assertInTopLevelState();
+        return SessionState.PUBLIC;
+
+      case 'txeSetUtilityTXEContext':
+        this.assertInTopLevelState();
+        return SessionState.UTILITY;
+    }
+  }
+
+  assertInTopLevelState() {
+    if (this.state != SessionState.TOP_LEVEL) {
+      throw new Error(
+        `Expected to be in state ${SessionState[SessionState.TOP_LEVEL]}, but got '${SessionState[this.state]}' instead`,
+      );
+    }
+  }
+
+  assertNotInTopLevelState() {
+    if (this.state == SessionState.TOP_LEVEL) {
+      throw new Error(`Expected to be in state other than ${SessionState[SessionState.TOP_LEVEL]}`);
+    }
+  }
+}


### PR DESCRIPTION
This introduces `TXESession`, which handles a session's state (the counterpart to each noir `#[test]`). Combined with https://github.com/AztecProtocol/aztec-packages/pull/16537, it means we're now in a good place to split the oracle into smaller oracles that get swapped depending on the session state.