### PR TITLE
feat: create deploy-rollup-contracts.yml

### DIFF
--- a/.github/actions/setup-k8s-terraform/action.yml
+++ b/.github/actions/setup-k8s-terraform/action.yml
@@ -1,0 +1,154 @@
+name: "Setup K8s and Terraform"
+description: "Common setup for Kubernetes cluster access and Terraform initialization"
+
+inputs:
+  cluster:
+    description: "The cluster to deploy to (e.g., aztec-gke-private or kind)"
+    required: true
+  namespace:
+    description: "The namespace to deploy to"
+    required: true
+  ref:
+    description: "The branch name to deploy from"
+    required: false
+    default: "next"
+  region:
+    description: "GCP region"
+    required: false
+    default: "us-west1-a"
+  gcp_sa_key:
+    description: "GCP service account JSON key"
+    required: true
+  kubeconfig_b64:
+    description: "Base64 encoded kubeconfig for kind clusters"
+    required: false
+  terraform_dir:
+    description: "Terraform working directory"
+    required: true
+  tf_state_bucket:
+    description: "Terraform state bucket for GCS backend"
+    required: false
+    default: "aztec-terraform"
+  tf_state_prefix:
+    description: "Terraform state prefix for GCS backend"
+    required: true
+  additional_state_path:
+    description: "Additional path component for state (e.g., salt value)"
+    required: false
+    default: ""
+  run_terraform_destroy:
+    description: "Whether to run terraform destroy"
+    required: false
+    default: "false"
+
+outputs:
+  kubectl_context:
+    description: "The current kubectl context"
+    value: ${{ steps.setup_vars.outputs.kubectl_context }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Check if directory exists
+      id: check_dir
+      shell: bash
+      run: |
+        if [ -d ".git" ]; then
+          echo "exists=true" >> $GITHUB_OUTPUT
+        else
+          echo "exists=false" >> $GITHUB_OUTPUT
+        fi
+
+    - name: Checkout code
+      if: ${{ steps.check_dir.outputs.exists != 'true' }}
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      with:
+        ref: ${{ inputs.ref }}
+
+    - name: Authenticate to Google Cloud
+      uses: google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f
+      with:
+        credentials_json: ${{ inputs.gcp_sa_key }}
+
+    - name: Set up Cloud SDK
+      uses: google-github-actions/setup-gcloud@6189d56e4096ee891640bb02ac264be376592d6a
+
+    - name: Install GKE Auth Plugin
+      shell: bash
+      run: |
+        gcloud components install gke-gcloud-auth-plugin --quiet
+
+    - name: Configure kubectl with GKE cluster
+      if: ${{ inputs.cluster != 'kind' }}
+      shell: bash
+      run: |
+        gcloud container clusters get-credentials ${{ inputs.cluster }} --region ${{ inputs.region }}
+
+    - name: Configure kubectl with kind cluster
+      if: ${{ inputs.cluster == 'kind' }}
+      shell: bash
+      run: |
+        if [ -z "${{ inputs.kubeconfig_b64 }}" ]; then
+          echo "KUBECONFIG_B64 is not set"
+          exit 1
+        fi
+        mkdir -p $HOME/.kube
+        echo "${{ inputs.kubeconfig_b64 }}" | base64 -d > $HOME/.kube/config
+        kubectl config use-context kind-kind
+
+    - name: Set up kubectl context
+      id: setup_vars
+      shell: bash
+      run: |
+        CLUSTER_CONTEXT=$(kubectl config current-context)
+        echo "kubectl_context=${CLUSTER_CONTEXT}" >> $GITHUB_OUTPUT
+        echo "TF_VAR_K8S_CLUSTER_CONTEXT=${CLUSTER_CONTEXT}" >> $GITHUB_ENV
+
+    - name: Setup Terraform
+      uses: hashicorp/setup-terraform@v3
+      with:
+        terraform_version: "1.5.0"
+
+    - name: Terraform Init
+      shell: bash
+      working-directory: ${{ inputs.terraform_dir }}
+      run: |
+        # Clean up any previous backend overrides
+        rm -f backend_override.tf
+
+        # Build the state path
+        STATE_PATH="${{ inputs.cluster }}/${{ inputs.namespace }}"
+        if [ -n "${{ inputs.additional_state_path }}" ]; then
+          STATE_PATH="${STATE_PATH}/${{ inputs.additional_state_path }}"
+        fi
+
+        if [ "${{ inputs.cluster }}" == "kind" ]; then
+          # For kind, use local backend
+          cat > backend_override.tf << EOF
+        terraform {
+          backend "local" {
+            path = "state/${STATE_PATH}/terraform.tfstate"
+          }
+        }
+        EOF
+        else
+          # For GKE, use GCS backend
+          cat > backend_override.tf << EOF
+        terraform {
+          backend "gcs" {
+            bucket = "${{ inputs.tf_state_bucket }}"
+            prefix = "${{ inputs.tf_state_prefix }}/${{ inputs.region }}/${STATE_PATH}/terraform.tfstate"
+          }
+        }
+        EOF
+        fi
+
+        terraform init -reconfigure
+
+    - name: Terraform Destroy
+      if: ${{ inputs.run_terraform_destroy == 'true' }}
+      shell: bash
+      working-directory: ${{ inputs.terraform_dir }}
+      continue-on-error: true
+      run: |
+        terraform destroy -auto-approve

--- a/.github/workflows/deploy-eth-devnet.yml
+++ b/.github/workflows/deploy-eth-devnet.yml
@@ -131,7 +131,7 @@ jobs:
       TF_VAR_RESOURCE_PROFILE: ${{ inputs.resource_profile || 'prod' }}
 
     steps:
-      - name: debug inputs
+      - name: Debug inputs
         run: |
           echo "cluster: ${{ inputs.cluster }}"
           echo "namespace: ${{ inputs.namespace }}"
@@ -143,111 +143,31 @@ jobs:
           echo "create_static_ips: ${{ inputs.create_static_ips }}"
           echo "run_terraform_destroy: ${{ inputs.run_terraform_destroy }}"
 
-      - name: Check if directory exists
-        id: check_dir
-        run: |
-          if [ -d ".git" ]; then
-            echo "exists=true" >> $GITHUB_OUTPUT
-          else
-            echo "exists=false" >> $GITHUB_OUTPUT
-          fi
-
-      # if running with `act`, skip the checkout since the code is mounted in
-      - name: Checkout code
-        if: ${{ steps.check_dir.outputs.exists != 'true' }}
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - name: Setup K8s and Terraform
+        uses: ./.github/actions/setup-k8s-terraform
         with:
+          cluster: ${{ inputs.cluster }}
+          namespace: ${{ inputs.namespace }}
           ref: ${{ inputs.ref || github.ref }}
+          gcp_sa_key: ${{ secrets.GCP_SA_KEY }}
+          kubeconfig_b64: ${{ secrets.KUBECONFIG_B64 }}
+          terraform_dir: ./spartan/terraform/deploy-eth-devnet
+          tf_state_prefix: deploy-eth-devnet
+          run_terraform_destroy: ${{ inputs.run_terraform_destroy }}
 
-      - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f
-        with:
-          credentials_json: ${{ secrets.GCP_SA_KEY }}
-
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@6189d56e4096ee891640bb02ac264be376592d6a
-
-      - name: Install GKE Auth Plugin
-        run: |
-          gcloud components install gke-gcloud-auth-plugin --quiet
-
-      - name: Configure kubectl with GKE cluster
-        if: ${{ inputs.cluster != 'kind' }}
-        run: |
-          gcloud container clusters get-credentials ${{ inputs.cluster }} --region ${{ env.REGION }}
-
-      - name: Configure kubectl with kind cluster
-        if: ${{ inputs.cluster == 'kind' }}
-        run: |
-          # fail if kubeconfig is not provided
-          if [ -z "${{ secrets.KUBECONFIG_B64 }}" ]; then
-            echo "KUBECONFIG_B64 is not set"
-            exit 1
-          fi
-          mkdir -p $HOME/.kube
-          echo "${{ secrets.KUBECONFIG_B64 }}" | base64 -d > $HOME/.kube/config
-          kubectl config use-context kind-kind
-
-      - name: Set up Terraform variables
-        id: setup_vars
+      - name: Set up CREATE_STATIC_IPS variable
         run: |
           # Set CREATE_STATIC_IPS based on cluster type
-          # Note: Terraform boolean values must be "true" or "false" (lowercase, unquoted)
           if [ "${{ inputs.cluster }}" == "kind" ]; then
             CREATE_STATIC_IPS=false
           else
-            # Convert string "true"/"false" to boolean for Terraform
             if [ "${{ inputs.create_static_ips }}" == "true" ]; then
               CREATE_STATIC_IPS=true
             else
               CREATE_STATIC_IPS=false
             fi
           fi
-
-          # Get kubectl context
-          CLUSTER_CONTEXT=$(kubectl config current-context)
-
-          # Export all as TF_VAR for Terraform
           echo "TF_VAR_CREATE_STATIC_IPS=${CREATE_STATIC_IPS}" >> $GITHUB_ENV
-          echo "TF_VAR_K8S_CLUSTER_CONTEXT=${CLUSTER_CONTEXT}" >> $GITHUB_ENV
-
-      - name: Terraform Init
-        working-directory: ./spartan/terraform/deploy-eth-devnet
-        run: |
-          # Clean up any previous backend overrides
-          rm -f backend_override.tf
-
-          if [ "${{ inputs.cluster }}" == "kind" ]; then
-            # For kind, use local backend with explicit path
-            cat > backend_override.tf << EOF
-          terraform {
-            backend "local" {
-              path = "state/${{ inputs.cluster }}/${{ inputs.namespace }}/terraform.tfstate"
-            }
-          }
-          EOF
-          else
-            # For GKE, use GCS backend with explicit path
-            cat > backend_override.tf << EOF
-          terraform {
-            backend "gcs" {
-              bucket = "${{ env.TF_STATE_BUCKET }}"
-              prefix = "deploy-eth-devnet/${{ env.REGION }}/${{ inputs.cluster }}/${{ inputs.namespace }}/terraform.tfstate"
-            }
-          }
-          EOF
-          fi
-
-          terraform init -reconfigure
-
-      - name: Terraform Destroy
-        working-directory: ./spartan/terraform/deploy-eth-devnet
-        if: ${{ inputs.run_terraform_destroy == 'true' }}
-        # Destroy fails if the resources are already destroyed, so we continue on error
-        continue-on-error: true
-        run: |
-          # All variables are now set as TF_VAR_ environment variables
-          terraform destroy -auto-approve
 
       - name: Terraform Plan
         working-directory: ./spartan/terraform/deploy-eth-devnet

--- a/.github/workflows/deploy-rollup-contracts.yml
+++ b/.github/workflows/deploy-rollup-contracts.yml
@@ -1,0 +1,340 @@
+name: Deploy Rollup Contracts
+
+# This workflow is used to deploy rollup contracts to a cluster.
+# It can be used to deploy to kind or a GKE cluster.
+#
+# Note that you can provide your own docker image. This helps to deploy into GKE.
+# But if you're running against KIND, you can just load your aztecprotocol/aztec image with
+# kind load docker-image aztecprotocol/aztec:yourtag
+#
+# example:
+# export GOOGLE_APPLICATION_CREDENTIALS=/your/path/to/testnet-helm-sa.json
+# alias lwfl=/your/path/to/aztec-clones/alpha/.github/local_workflow.sh
+#
+# lwfl deploy_rollup_contracts --input cluster=aztec-gke-private --input namespace=mitch-eth-devnet --input aztec_docker_image="iamjustmitch/aztec:8ebe8d7c45190b002c77e29358f2b307a23b5336" --input l1_rpc_urls="http://34.83.173.208:8545" --input mnemonic="test test test test test test test test test test test junk" --input l1_chain_id="1337" --input salt="456" --input sponsored_fpc=true --input real_verifier=true --input aztec_target_commitee_size=48
+
+on:
+  workflow_call:
+    inputs:
+      cluster:
+        description: The cluster to deploy to, e.g. aztec-gke-private or kind
+        required: true
+        type: string
+      namespace:
+        description: The namespace to deploy to
+        required: true
+        type: string
+      ref:
+        description: The branch name to deploy from
+        required: false
+        type: string
+        default: "next"
+      aztec_docker_image:
+        description: Aztec Docker image with tag
+        required: true
+        type: string
+      l1_rpc_urls:
+        description: Comma-separated list of L1 RPC URLs
+        required: true
+        type: string
+      mnemonic:
+        description: Mnemonic for deployment
+        required: true
+        type: string
+      l1_chain_id:
+        description: L1 chain ID
+        required: false
+        type: string
+        default: "31337"
+      salt:
+        description: Salt for deployment
+        required: false
+        type: string
+      validators:
+        description: Comma-separated list of validators
+        required: true
+        type: string
+      sponsored_fpc:
+        description: Enable sponsored FPC
+        required: false
+        type: boolean
+        default: false
+      real_verifier:
+        description: Deploy real verifier
+        required: false
+        type: boolean
+        default: false
+      # Aztec environment variables
+      aztec_slot_duration:
+        description: Aztec slot duration
+        required: true
+        type: string
+      aztec_epoch_duration:
+        description: Aztec epoch duration
+        required: true
+        type: string
+      aztec_target_committee_size:
+        description: Aztec target committee size
+        required: true
+        type: string
+      aztec_proof_submission_epochs:
+        description: Aztec proof submission epochs
+        required: true
+        type: string
+      aztec_activation_threshold:
+        description: Aztec activation threshold
+        required: true
+        type: string
+      aztec_ejection_threshold:
+        description: Aztec ejection threshold
+        required: true
+        type: string
+      aztec_slashing_quorum:
+        description: Aztec slashing quorum
+        required: true
+        type: string
+      aztec_slashing_round_size:
+        description: Aztec slashing round size
+        required: true
+        type: string
+      aztec_governance_proposer_quorum:
+        description: Aztec governance proposer quorum
+        required: true
+        type: string
+      aztec_governance_proposer_round_size:
+        description: Aztec governance proposer round size
+        required: true
+        type: string
+      aztec_mana_target:
+        description: Aztec mana target
+        required: true
+        type: string
+      aztec_proving_cost_per_mana:
+        description: Aztec proving cost per mana
+        required: true
+        type: string
+    secrets:
+      GCP_SA_KEY:
+        description: The JSON key for the GCP service account
+        required: true
+      KUBECONFIG_B64:
+        description: The base64 encoded kubeconfig
+        required: true
+
+  workflow_dispatch:
+    inputs:
+      cluster:
+        description: The cluster to deploy to, e.g. aztec-gke-private or kind
+        required: false
+        type: string
+        default: "kind"
+      namespace:
+        description: The namespace to deploy to
+        required: false
+        type: string
+        default: "rollup-contracts"
+      ref:
+        description: The branch name to deploy from
+        required: false
+        type: string
+        default: "next"
+      aztec_docker_image:
+        description: Aztec Docker image with tag
+        required: false
+        type: string
+        default: "aztecprotocol/aztec:latest"
+      l1_rpc_urls:
+        description: Comma-separated list of L1 RPC URLs
+        required: false
+        type: string
+        default: "http://localhost:8545"
+      mnemonic:
+        description: Mnemonic for deployment
+        required: false
+        type: string
+        default: "test test test test test test test test test test test junk"
+      l1_chain_id:
+        description: L1 chain ID
+        required: false
+        type: string
+        default: "1337"
+      salt:
+        description: Salt for deployment
+        required: false
+        type: string
+      validators:
+        description: Comma-separated list of validators
+        required: false
+        type: string
+        default: "0x123456789abcdef"
+      sponsored_fpc:
+        description: Enable sponsored FPC
+        required: false
+        type: boolean
+        default: false
+      real_verifier:
+        description: Deploy real verifier
+        required: false
+        type: boolean
+        default: false
+      # Aztec environment variables
+      aztec_slot_duration:
+        description: Aztec slot duration
+        required: false
+        type: string
+        default: "12"
+      aztec_epoch_duration:
+        description: Aztec epoch duration
+        required: false
+        type: string
+        default: "32"
+      aztec_target_committee_size:
+        description: Aztec target committee size
+        required: false
+        type: string
+        default: "4"
+      aztec_proof_submission_epochs:
+        description: Aztec proof submission epochs
+        required: false
+        type: string
+        default: "2"
+      aztec_activation_threshold:
+        description: Aztec activation threshold
+        required: false
+        type: string
+        default: "100"
+      aztec_ejection_threshold:
+        description: Aztec ejection threshold
+        required: false
+        type: string
+        default: "50"
+      aztec_slashing_quorum:
+        description: Aztec slashing quorum
+        required: false
+        type: string
+        default: "6"
+      aztec_slashing_round_size:
+        description: Aztec slashing round size
+        required: false
+        type: string
+        default: "10"
+      aztec_governance_proposer_quorum:
+        description: Aztec governance proposer quorum
+        required: false
+        type: string
+        default: "6"
+      aztec_governance_proposer_round_size:
+        description: Aztec governance proposer round size
+        required: false
+        type: string
+        default: "10"
+      aztec_mana_target:
+        description: Aztec mana target
+        required: false
+        type: string
+        default: "1000000"
+      aztec_proving_cost_per_mana:
+        description: Aztec proving cost per mana
+        required: false
+        type: string
+        default: "100"
+
+jobs:
+  deploy_rollup_contracts:
+    runs-on: ubuntu-latest
+    env:
+      TF_STATE_BUCKET: aztec-terraform
+      REGION: us-west1-a
+      # Common Terraform variables as environment variables
+      TF_VAR_GCP_PROJECT: ${{ vars.GCP_PROJECT }}
+      TF_VAR_GCP_REGION: us-west1
+      TF_VAR_NAMESPACE: ${{ inputs.namespace || 'rollup-contracts' }}
+      TF_VAR_AZTEC_DOCKER_IMAGE: ${{ inputs.aztec_docker_image || 'aztecprotocol/aztec:latest' }}
+      TF_VAR_L1_RPC_URLS: ${{ inputs.l1_rpc_urls || 'http://localhost:8545' }}
+      TF_VAR_MNEMONIC: ${{ inputs.mnemonic || 'test test test test test test test test test test test junk' }}
+      TF_VAR_L1_CHAIN_ID: ${{ inputs.l1_chain_id || '1337' }}
+      TF_VAR_SALT: ${{ inputs.salt }}
+      TF_VAR_VALIDATORS: ${{ inputs.validators || '0x123456789abcdef' }}
+      TF_VAR_SPONSORED_FPC: ${{ inputs.sponsored_fpc || false }}
+      TF_VAR_REAL_VERIFIER: ${{ inputs.real_verifier || false }}
+      TF_VAR_AZTEC_SLOT_DURATION: ${{ inputs.aztec_slot_duration || '12' }}
+      TF_VAR_AZTEC_EPOCH_DURATION: ${{ inputs.aztec_epoch_duration || '32' }}
+      TF_VAR_AZTEC_TARGET_COMMITTEE_SIZE: ${{ inputs.aztec_target_committee_size || '4' }}
+      TF_VAR_AZTEC_PROOF_SUBMISSION_EPOCHS: ${{ inputs.aztec_proof_submission_epochs || '2' }}
+      TF_VAR_AZTEC_ACTIVATION_THRESHOLD: ${{ inputs.aztec_activation_threshold || '10' }}
+      TF_VAR_AZTEC_EJECTION_THRESHOLD: ${{ inputs.aztec_ejection_threshold || '5' }}
+      TF_VAR_AZTEC_SLASHING_QUORUM: ${{ inputs.aztec_slashing_quorum || '3' }}
+      TF_VAR_AZTEC_SLASHING_ROUND_SIZE: ${{ inputs.aztec_slashing_round_size || '10' }}
+      TF_VAR_AZTEC_GOVERNANCE_PROPOSER_QUORUM: ${{ inputs.aztec_governance_proposer_quorum || '100' }}
+      TF_VAR_AZTEC_GOVERNANCE_PROPOSER_ROUND_SIZE: ${{ inputs.aztec_governance_proposer_round_size || '1000' }}
+      TF_VAR_AZTEC_MANA_TARGET: ${{ inputs.aztec_mana_target || '1000000' }}
+      TF_VAR_AZTEC_PROVING_COST_PER_MANA: ${{ inputs.aztec_proving_cost_per_mana || '100' }}
+
+    steps:
+      - name: debug inputs
+        run: |
+          echo "cluster: ${{ inputs.cluster }}"
+          echo "namespace: ${{ inputs.namespace }}"
+          echo "ref: ${{ inputs.ref }}"
+          echo "aztec_docker_image: ${{ inputs.aztec_docker_image }}"
+          echo "l1_rpc_urls: ${{ inputs.l1_rpc_urls }}"
+          echo "l1_chain_id: ${{ inputs.l1_chain_id }}"
+          echo "validators: ${{ inputs.validators }}"
+          echo "sponsored_fpc: ${{ inputs.sponsored_fpc }}"
+          echo "real_verifier: ${{ inputs.real_verifier }}"
+
+      - name: Setup K8s and Terraform
+        uses: ./.github/actions/setup-k8s-terraform
+        with:
+          cluster: ${{ inputs.cluster }}
+          namespace: ${{ inputs.namespace }}
+          ref: ${{ inputs.ref || github.ref }}
+          gcp_sa_key: ${{ secrets.GCP_SA_KEY }}
+          kubeconfig_b64: ${{ secrets.KUBECONFIG_B64 }}
+          terraform_dir: spartan/terraform/deploy-rollup-contracts
+          tf_state_prefix: deploy-rollup-contracts
+          additional_state_path: ${{ inputs.salt }}
+
+      - name: Terraform Plan
+        working-directory: spartan/terraform/deploy-rollup-contracts
+        run: |
+          # All variables are now set as TF_VAR_ environment variables
+          terraform plan -out=tfplan
+
+      - name: Terraform Apply
+        working-directory: spartan/terraform/deploy-rollup-contracts
+        run: |
+          terraform apply tfplan
+
+      - name: Get deployment results
+        working-directory: spartan/terraform/deploy-rollup-contracts
+        run: |
+          echo "=== Deployment Results ==="
+          echo "Job Name: $(terraform output -raw job_name)"
+
+          if [ "$(terraform output -raw deployment_successful)" = "true" ]; then
+            echo "✅ Rollup contracts deployed successfully!"
+            echo ""
+            echo "Contract Addresses:"
+            echo "  Governance Address: $(terraform output -raw governance_address)"
+            echo "  Governance Proposer Address: $(terraform output -raw governance_proposer_address)"
+            echo "  Rollup Address: $(terraform output -raw rollup_address)"
+            echo "  Registry Address: $(terraform output -raw registry_address)"
+            echo "  Inbox Address: $(terraform output -raw inbox_address)"
+            echo "  Outbox Address: $(terraform output -raw outbox_address)"
+            echo "  Fee Asset Handler Address: $(terraform output -raw fee_asset_handler_address)"
+            echo "  Staking Asset Address: $(terraform output -raw staking_asset_address)"
+            echo "  Reward Distributor Address: $(terraform output -raw reward_distributor_address)"
+            echo "  GSE Address: $(terraform output -raw gse_address)"
+            echo "  Coin Issuer Address: $(terraform output -raw coin_issuer_address)"
+            echo "  Slash Factory Address: $(terraform output -raw slash_factory_address)"
+            echo "  Fee Juice Portal Address: $(terraform output -raw fee_juice_portal_address)"
+            echo "  ZK Passport Verifier Address: $(terraform output -raw zk_passport_verifier_address)"
+            echo "  Staking Asset Handler Address: $(terraform output -raw staking_asset_handler_address)"
+            echo ""
+          else
+            echo "⚠️ JSON output not found in logs, but job completed."
+            echo "Raw output:"
+            terraform output -json contract_addresses_json
+            exit 1
+          fi

--- a/spartan/terraform/deploy-rollup-contracts/main.tf
+++ b/spartan/terraform/deploy-rollup-contracts/main.tf
@@ -1,0 +1,162 @@
+terraform {
+  # Backend will be configured dynamically in the workflow
+  # GCS backend for GKE clusters, local backend for KIND
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.24.0"
+    }
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "google" {
+  project = var.GCP_PROJECT
+  region  = var.GCP_REGION
+}
+
+provider "kubernetes" {
+  alias          = "cluster"
+  config_path    = "~/.kube/config"
+  config_context = var.K8S_CLUSTER_CONTEXT
+}
+
+locals {
+  # Build the command arguments for deploy-l1-contracts
+  deploy_args = concat(
+    ["deploy-l1-contracts"],
+    ["--l1-rpc-urls", var.L1_RPC_URLS],
+    ["--mnemonic", var.MNEMONIC],
+    ["--l1-chain-id", tostring(var.L1_CHAIN_ID)],
+    # ["--validators", var.VALIDATORS],
+    ["--json"], # Always output JSON for easier parsing
+    var.SALT != null ? ["--salt", tostring(var.SALT)] : [],
+    var.SPONSORED_FPC ? ["--sponsored-fpc"] : [],
+    var.REAL_VERIFIER ? ["--real-verifier"] : []
+  )
+
+  # Environment variables for the container
+  env_vars = {
+    AZTEC_SLOT_DURATION                  = var.AZTEC_SLOT_DURATION
+    AZTEC_EPOCH_DURATION                 = var.AZTEC_EPOCH_DURATION
+    AZTEC_TARGET_COMMITTEE_SIZE          = var.AZTEC_TARGET_COMMITTEE_SIZE
+    AZTEC_PROOF_SUBMISSION_EPOCHS        = var.AZTEC_PROOF_SUBMISSION_EPOCHS
+    AZTEC_ACTIVATION_THRESHOLD           = var.AZTEC_ACTIVATION_THRESHOLD
+    AZTEC_EJECTION_THRESHOLD             = var.AZTEC_EJECTION_THRESHOLD
+    AZTEC_SLASHING_QUORUM                = var.AZTEC_SLASHING_QUORUM
+    AZTEC_SLASHING_ROUND_SIZE            = var.AZTEC_SLASHING_ROUND_SIZE
+    AZTEC_GOVERNANCE_PROPOSER_QUORUM     = var.AZTEC_GOVERNANCE_PROPOSER_QUORUM
+    AZTEC_GOVERNANCE_PROPOSER_ROUND_SIZE = var.AZTEC_GOVERNANCE_PROPOSER_ROUND_SIZE
+    AZTEC_MANA_TARGET                    = var.AZTEC_MANA_TARGET
+    AZTEC_PROVING_COST_PER_MANA          = var.AZTEC_PROVING_COST_PER_MANA
+    LOG_LEVEL                            = "debug"
+  }
+
+  # Generate a unique job name with timestamp to avoid conflicts
+  job_name = "${var.JOB_NAME}-${formatdate("YYYY-MM-DD-hhmm", timestamp())}"
+}
+
+resource "kubernetes_job_v1" "deploy_rollup_contracts" {
+  provider = kubernetes.cluster
+
+  metadata {
+    name      = local.job_name
+    namespace = var.NAMESPACE
+    labels = {
+      app     = "deploy-rollup-contracts"
+      version = split(":", var.AZTEC_DOCKER_IMAGE)[1]
+    }
+  }
+
+  spec {
+    backoff_limit              = var.JOB_BACKOFF_LIMIT
+    ttl_seconds_after_finished = var.JOB_TTL_SECONDS_AFTER_FINISHED
+
+    template {
+      metadata {
+        labels = {
+          app     = "deploy-rollup-contracts"
+          version = split(":", var.AZTEC_DOCKER_IMAGE)[1]
+        }
+      }
+
+      spec {
+        restart_policy = "Never"
+
+        container {
+          name    = "deploy-rollup-contracts"
+          image   = var.AZTEC_DOCKER_IMAGE
+          command = ["node"]
+          args = concat(
+            ["--no-warnings", "/usr/src/yarn-project/aztec/dest/bin/index.js"],
+            local.deploy_args
+          )
+
+          # Set environment variables
+          dynamic "env" {
+            for_each = local.env_vars
+            content {
+              name  = env.key
+              value = env.value
+            }
+          }
+
+          # Resource limits
+          resources {
+            limits = {
+              cpu    = "2"
+              memory = "4Gi"
+            }
+            requests = {
+              cpu    = "1"
+              memory = "2Gi"
+            }
+          }
+
+          # Security context
+          security_context {
+            run_as_non_root = true
+            run_as_user     = 1000
+            run_as_group    = 1000
+          }
+        }
+
+        # Pod security context
+        security_context {
+          fs_group = 1000
+        }
+      }
+    }
+
+    # Wait for job completion
+  }
+
+  wait_for_completion = true
+
+  timeouts {
+    create = "10m"
+    update = "10m"
+  }
+}
+
+# Extract JSON output from completed job logs
+data "external" "contract_addresses" {
+  depends_on = [kubernetes_job_v1.deploy_rollup_contracts]
+
+  program = ["bash", "-c", <<-EOT
+    set -e
+
+    # Get pod name for the completed job
+    POD_NAME=$(kubectl get pods -n ${var.NAMESPACE} -l job-name=${kubernetes_job_v1.deploy_rollup_contracts.metadata[0].name} -o jsonpath='{.items[0].metadata.name}')
+
+    # Extract logs from the pod
+    LOGS=$(kubectl logs $POD_NAME -n ${var.NAMESPACE} 2>/dev/null || echo "{}")
+
+    # Extract the final JSON object from logs
+    echo "$LOGS" | grep -v "^\[" | sed -n '/^{$/,/^}$/p' | jq '.'
+  EOT
+  ]
+}

--- a/spartan/terraform/deploy-rollup-contracts/outputs.tf
+++ b/spartan/terraform/deploy-rollup-contracts/outputs.tf
@@ -1,0 +1,124 @@
+output "job_name" {
+  description = "Name of the Kubernetes job that was created"
+  value       = kubernetes_job_v1.deploy_rollup_contracts.metadata[0].name
+}
+
+output "job_namespace" {
+  description = "Namespace where the job was deployed"
+  value       = kubernetes_job_v1.deploy_rollup_contracts.metadata[0].namespace
+}
+
+output "job_uid" {
+  description = "UID of the created job"
+  value       = kubernetes_job_v1.deploy_rollup_contracts.metadata[0].uid
+}
+
+# Since wait_for_completion=true, if we reach here, the job completed successfully
+
+output "contract_addresses_json" {
+  description = "JSON output from deploy-l1-contracts command containing contract addresses"
+  value       = data.external.contract_addresses.result
+}
+
+output "registry_address" {
+  description = "Address of the deployed registry contract"
+  value       = data.external.contract_addresses.result.registryAddress
+}
+
+output "governance_address" {
+  description = "Address of the deployed governance contract"
+  value       = data.external.contract_addresses.result.governanceAddress
+}
+
+
+output "governance_proposer_address" {
+  description = "Address of the deployed governance proposer contract"
+  value       = data.external.contract_addresses.result.governanceProposerAddress
+}
+
+output "rollup_address" {
+  description = "Address of the deployed rollup contract"
+  value       = data.external.contract_addresses.result.rollupAddress
+}
+
+
+output "inbox_address" {
+  description = "Address of the deployed inbox contract"
+  value       = data.external.contract_addresses.result.inboxAddress
+}
+
+output "outbox_address" {
+  description = "Address of the deployed outbox contract"
+  value       = data.external.contract_addresses.result.outboxAddress
+}
+
+output "fee_juice_portal_address" {
+  description = "Address of the deployed fee juice portal contract"
+  value       = data.external.contract_addresses.result.feeJuicePortalAddress
+}
+
+output "fee_juice_address" {
+  description = "Address of the deployed fee juice contract"
+  value       = data.external.contract_addresses.result.feeJuiceAddress
+}
+
+output "staking_asset_address" {
+  description = "Address of the deployed staking asset contract"
+  value       = data.external.contract_addresses.result.stakingAssetAddress
+}
+
+output "reward_distributor_address" {
+  description = "Address of the deployed reward distributor contract"
+  value       = data.external.contract_addresses.result.rewardDistributorAddress
+}
+
+output "gse_address" {
+  description = "Address of the deployed gse contract"
+  value       = data.external.contract_addresses.result.gseAddress
+}
+
+output "coin_issuer_address" {
+  description = "Address of the deployed coin issuer contract"
+  value       = data.external.contract_addresses.result.coinIssuerAddress
+}
+
+output "slash_factory_address" {
+  description = "Address of the deployed slash factory contract"
+  value       = data.external.contract_addresses.result.slashFactoryAddress
+}
+
+output "fee_asset_handler_address" {
+  description = "Address of the deployed fee asset handler contract"
+  value       = data.external.contract_addresses.result.feeAssetHandlerAddress
+}
+
+output "staking_asset_handler_address" {
+  description = "Address of the deployed staking asset handler contract"
+  value       = data.external.contract_addresses.result.stakingAssetHandlerAddress
+}
+
+
+output "zk_passport_verifier_address" {
+  description = "Address of the deployed zk passport verifier contract"
+  value       = data.external.contract_addresses.result.zkPassportVerifierAddress
+}
+
+
+output "docker_image_used" {
+  description = "Docker image that was used for the deployment"
+  value       = var.AZTEC_DOCKER_IMAGE
+}
+
+output "deployment_command" {
+  description = "The full command that was executed"
+  sensitive   = true
+  value = concat(
+    ["node", "--no-warnings", "/usr/src/yarn-project/aztec/dest/bin/index.js"],
+    local.deploy_args
+  )
+}
+
+output "deployment_successful" {
+  description = "Whether the deployment completed successfully with valid contract addresses"
+  value       = lookup(data.external.contract_addresses.result, "status", "success") != "no_json_found"
+}

--- a/spartan/terraform/deploy-rollup-contracts/variables.tf
+++ b/spartan/terraform/deploy-rollup-contracts/variables.tf
@@ -1,0 +1,146 @@
+variable "GCP_PROJECT" {
+  description = "GCP project ID"
+  type        = string
+}
+
+variable "GCP_REGION" {
+  description = "GCP region"
+  type        = string
+  default     = "us-west1"
+}
+
+variable "K8S_CLUSTER_CONTEXT" {
+  description = "Kubernetes cluster context"
+  type        = string
+}
+
+variable "NAMESPACE" {
+  description = "Kubernetes namespace to deploy the job"
+  type        = string
+}
+
+variable "AZTEC_DOCKER_IMAGE" {
+  description = "Aztec Docker image with tag"
+  type        = string
+}
+
+# Deploy L1 contracts configuration
+variable "L1_RPC_URLS" {
+  description = "Comma-separated list of L1 RPC URLs"
+  type        = string
+}
+
+variable "MNEMONIC" {
+  description = "Mnemonic for deployment"
+  type        = string
+  sensitive   = true
+}
+
+variable "L1_CHAIN_ID" {
+  description = "L1 chain ID"
+  type        = number
+  default     = 31337
+}
+
+variable "SALT" {
+  description = "Salt for deployment"
+  type        = number
+  nullable    = true
+  default     = null
+}
+
+variable "VALIDATORS" {
+  description = "Comma-separated list of validators"
+  type        = string
+}
+
+variable "SPONSORED_FPC" {
+  description = "Enable sponsored FPC"
+  type        = bool
+  default     = false
+}
+
+variable "REAL_VERIFIER" {
+  description = "Deploy real verifier"
+  type        = bool
+  default     = false
+}
+
+# Environment variables for the deployment
+variable "AZTEC_SLOT_DURATION" {
+  description = "Aztec slot duration"
+  type        = string
+}
+
+variable "AZTEC_EPOCH_DURATION" {
+  description = "Aztec epoch duration"
+  type        = string
+}
+
+variable "AZTEC_TARGET_COMMITTEE_SIZE" {
+  description = "Aztec target committee size"
+  type        = string
+}
+
+variable "AZTEC_PROOF_SUBMISSION_EPOCHS" {
+  description = "Aztec proof submission epochs"
+  type        = string
+}
+
+variable "AZTEC_ACTIVATION_THRESHOLD" {
+  description = "Aztec activation threshold"
+  type        = string
+}
+
+variable "AZTEC_EJECTION_THRESHOLD" {
+  description = "Aztec ejection threshold"
+  type        = string
+}
+
+variable "AZTEC_SLASHING_QUORUM" {
+  description = "Aztec slashing quorum"
+  type        = string
+}
+
+variable "AZTEC_SLASHING_ROUND_SIZE" {
+  description = "Aztec slashing round size"
+  type        = string
+}
+
+variable "AZTEC_GOVERNANCE_PROPOSER_QUORUM" {
+  description = "Aztec governance proposer quorum"
+  type        = string
+}
+
+variable "AZTEC_GOVERNANCE_PROPOSER_ROUND_SIZE" {
+  description = "Aztec governance proposer round size"
+  type        = string
+}
+
+variable "AZTEC_MANA_TARGET" {
+  description = "Aztec mana target"
+  type        = string
+}
+
+variable "AZTEC_PROVING_COST_PER_MANA" {
+  description = "Aztec proving cost per mana"
+  type        = string
+}
+
+variable "JOB_NAME" {
+  description = "Name for the Kubernetes job"
+  type        = string
+  default     = "deploy-rollup-contracts"
+}
+
+variable "JOB_BACKOFF_LIMIT" {
+  description = "Number of retries for failed job"
+  type        = number
+  default     = 3
+}
+
+variable "JOB_TTL_SECONDS_AFTER_FINISHED" {
+  description = "TTL in seconds for job cleanup after completion"
+  type        = number
+  default     = 3600
+}


### PR DESCRIPTION
Adds a new GitHub workflow and Terraform configuration for deploying Aztec rollup contracts to Kubernetes clusters. The implementation includes:

- A new GitHub workflow file `deploy-rollup-contracts.yml` that can be triggered manually or called from other workflows
- Terraform configuration in `spartan/terraform/deploy-rollup-contracts/` to handle the deployment process
- Support for both GKE and kind clusters with appropriate backend configurations
- Comprehensive configuration options for contract deployment parameters
- Extraction and output of deployed contract addresses

The workflow allows customization of various Aztec parameters like slot duration, epoch duration, committee size, and other protocol-specific settings. It also supports optional features like sponsored FPC and real verifier deployment.