### PR TITLE
feat: scaffold deploy-scenario-network.yml

### DIFF
--- a/.github/workflows/deploy-eth-devnet.yml
+++ b/.github/workflows/deploy-eth-devnet.yml
@@ -59,6 +59,11 @@ on:
         required: false
         type: string
         default: "false"
+      mnemonic:
+        description: The mnemonic to use for the eth devnet
+        required: false
+        type: string
+        default: "test test test test test test test test test test test junk"
     secrets:
       GCP_SA_KEY:
         description: The JSON key for the GCP service account
@@ -66,6 +71,19 @@ on:
       KUBECONFIG_B64:
         description: The base64 encoded kubeconfig
         required: true
+    outputs:
+      rpc_url:
+        description: The RPC URL for the eth devnet
+        value: ${{ jobs.deploy_eth_devnet.outputs.rpc_url }}
+      ws_url:
+        description: The WebSocket URL for the eth devnet
+        value: ${{ jobs.deploy_eth_devnet.outputs.ws_url }}
+      beacon_url:
+        description: The Beacon URL for the eth devnet
+        value: ${{ jobs.deploy_eth_devnet.outputs.beacon_url }}
+      chain_id:
+        description: The chain ID for the eth devnet
+        value: ${{ jobs.deploy_eth_devnet.outputs.chain_id }}
 
   workflow_dispatch:
     inputs:
@@ -114,10 +132,20 @@ on:
         required: false
         type: string
         default: "false"
+      mnemonic:
+        description: The mnemonic to use for the eth devnet
+        required: false
+        type: string
+        default: "test test test test test test test test test test test junk"
 
 jobs:
   deploy_eth_devnet:
     runs-on: ubuntu-latest
+    outputs:
+      rpc_url: ${{ steps.get-eth-devnet-results.outputs.rpc_url }}
+      ws_url: ${{ steps.get-eth-devnet-results.outputs.ws_url }}
+      beacon_url: ${{ steps.get-eth-devnet-results.outputs.beacon_url }}
+      chain_id: ${{ steps.get-eth-devnet-results.outputs.chain_id }}
     env:
       TF_STATE_BUCKET: aztec-terraform
       REGION: us-west1-a
@@ -131,6 +159,11 @@ jobs:
       TF_VAR_RESOURCE_PROFILE: ${{ inputs.resource_profile || 'prod' }}
 
     steps:
+      - name: Mask the mnemonic
+        id: mask-mnemonic
+        run: |
+          echo "::add-mask::${{ inputs.mnemonic }}"
+
       - name: Debug inputs
         run: |
           echo "cluster: ${{ inputs.cluster }}"
@@ -179,3 +212,27 @@ jobs:
         working-directory: ./spartan/terraform/deploy-eth-devnet
         run: |
           terraform apply tfplan
+
+      - name: Get eth devnet deployment results
+        id: get-eth-devnet-results
+        working-directory: ./spartan/terraform/deploy-eth-devnet
+
+        run: |
+          echo "=== Eth Devnet Deployment Results ==="
+
+          # Get outputs from the eth-devnet deployment
+          RPC_URL=$(terraform output -raw eth_execution_rpc_url)
+          WS_URL=$(terraform output -raw eth_execution_ws_url)
+          BEACON_URL=$(terraform output -raw eth_beacon_api_url)
+          CHAIN_ID=$(terraform output -raw chain_id)
+
+          echo "RPC_URL: $RPC_URL"
+          echo "WS_URL: $WS_URL"
+          echo "BEACON_URL: $BEACON_URL"
+          echo "CHAIN_ID: $CHAIN_ID"
+
+          # Export as outputs for other steps
+          echo "rpc_url=$RPC_URL" >> $GITHUB_OUTPUT
+          echo "ws_url=$WS_URL" >> $GITHUB_OUTPUT
+          echo "beacon_url=$BEACON_URL" >> $GITHUB_OUTPUT
+          echo "chain_id=$CHAIN_ID" >> $GITHUB_OUTPUT

--- a/.github/workflows/deploy-scenario-network.yml
+++ b/.github/workflows/deploy-scenario-network.yml
@@ -1,0 +1,140 @@
+name: Deploy Scenario Network
+
+on:
+  workflow_call:
+    inputs:
+      cluster:
+        description: The cluster to deploy to, e.g. aztec-gke-private or kind
+        required: true
+        type: string
+      namespace:
+        description: The namespace to deploy to
+        required: true
+        type: string
+      ref:
+        description: The branch name to deploy from
+        required: true
+        type: string
+        default: "next"
+      aztec_docker_image:
+        description: The Docker image to use for the Aztec contracts
+        required: true
+        type: string
+        default: "aztecprotocol/aztec:8ebe8d7c45190b002c77e29358f2b307a23b5336"
+      devnet_mnemonic:
+        description: The mnemonic to use for the devnet
+        required: true
+        type: string
+        default: "test test test test test test test test test test test junk"
+      rollup_deployment_mnemonic:
+        description: The mnemonic to use for the rollup deployment
+        required: true
+        type: string
+        default: "test test test test test test test test test test test junk"
+    secrets:
+      GCP_SA_KEY:
+        description: The JSON key for the GCP service account
+        required: true
+      KUBECONFIG_B64:
+        description: The base64 encoded kubeconfig
+        required: true
+
+  workflow_dispatch:
+    inputs:
+      cluster:
+        description: The cluster to deploy to, e.g. aztec-gke-private or kind
+        required: true
+        type: string
+        default: "kind"
+      namespace:
+        description: The namespace to deploy to
+        required: true
+        type: string
+        default: "eth-devnet"
+      ref:
+        description: The branch name to deploy from.
+        required: true
+        type: string
+        default: "next"
+      aztec_docker_image:
+        description: The Docker image to use for the Aztec contracts
+        required: true
+        type: string
+        default: "aztecprotocol/aztec:8ebe8d7c45190b002c77e29358f2b307a23b5336"
+      devnet_mnemonic:
+        description: The mnemonic to use for the devnet
+        required: true
+        type: string
+        default: "test test test test test test test test test test test junk"
+      rollup_deployment_mnemonic:
+        description: The mnemonic to use for the rollup deployment
+        required: true
+        type: string
+        default: "test test test test test test test test test test test junk"
+
+jobs:
+  # First job: Deploy the Eth Devnet
+  scenario_dispatch_deploy_eth_devnet:
+    uses: ./.github/workflows/deploy-eth-devnet.yml
+    with:
+      cluster: ${{ inputs.cluster }}
+      namespace: ${{ inputs.namespace }}
+      ref: ${{ inputs.ref }}
+      # Prefilled values for scenario network
+      chain_id: 1337
+      block_time: 4 # Faster block time for scenario testing
+      gas_limit: "32000000" # Higher gas limit for complex scenarios
+      resource_profile: ${{ inputs.cluster == 'kind' && 'dev' || 'prod' }}
+      create_static_ips: ${{ inputs.cluster == 'kind' && 'false' || 'true' }}
+      run_terraform_destroy: "false"
+      mnemonic: ${{ inputs.devnet_mnemonic }}
+    secrets:
+      GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
+      KUBECONFIG_B64: ${{ secrets.KUBECONFIG_B64 }}
+
+  scenario_dispatch_deploy_rollup_contracts:
+    needs: scenario_dispatch_deploy_eth_devnet
+    uses: ./.github/workflows/deploy-rollup-contracts.yml
+    with:
+      cluster: ${{ inputs.cluster }}
+      namespace: ${{ inputs.namespace }}
+      ref: ${{ inputs.ref }}
+      l1_rpc_urls: ${{ needs.scenario_dispatch_deploy_eth_devnet.outputs.rpc_url }}
+      l1_chain_id: ${{ needs.scenario_dispatch_deploy_eth_devnet.outputs.chain_id }}
+      aztec_docker_image: ${{ inputs.aztec_docker_image }}
+      mnemonic: ${{ inputs.rollup_deployment_mnemonic }}
+      salt: "456"
+      # indices 1,2,3,4 on the junk mnemonic
+      validators: "0x70997970C51812dc3A010C7d01b50e0d17dc79C8,0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC,0x90F79bf6EB2c4f870365E785982E1f101E93b906,0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65"
+      sponsored_fpc: true
+      real_verifier: true
+      # Aztec environment variables
+      aztec_slot_duration: 12
+      aztec_epoch_duration: 32
+      aztec_target_committee_size: 4
+      aztec_proof_submission_epochs: 1
+      aztec_activation_threshold: 100
+      aztec_ejection_threshold: 50
+      aztec_slashing_quorum: 6
+      aztec_slashing_round_size: 10
+      aztec_governance_proposer_quorum: 6
+      aztec_governance_proposer_round_size: 10
+      aztec_mana_target: 1000000
+      aztec_proving_cost_per_mana: 100
+    secrets:
+      GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
+      KUBECONFIG_B64: ${{ secrets.KUBECONFIG_B64 }}
+
+  deploy_scenario_network:
+    needs: scenario_dispatch_deploy_rollup_contracts
+    runs-on: ubuntu-latest
+    env:
+      TF_STATE_BUCKET: aztec-terraform
+      REGION: us-west1-a
+      # Common Terraform variables as environment variables
+      TF_VAR_NAMESPACE: ${{ inputs.namespace || 'eth-devnet' }}
+
+    steps:
+      - name: Deploy scenario network
+        run: |
+          echo "Deployed scenario network!"

--- a/spartan/terraform/deploy-eth-devnet/outputs.tf
+++ b/spartan/terraform/deploy-eth-devnet/outputs.tf
@@ -1,26 +1,26 @@
 output "eth_execution_ip" {
-  description = "Static IP address for Ethereum execution client"
-  value       = var.CREATE_STATIC_IPS ? google_compute_address.eth_execution_ip[0].address : null
+  description = "IP address for Ethereum execution client (Static IP or Cluster IP)"
+  value       = var.CREATE_STATIC_IPS ? google_compute_address.eth_execution_ip[0].address : data.kubernetes_service.eth_execution[0].spec[0].cluster_ip
 }
 
 output "eth_beacon_ip" {
-  description = "Static IP address for Ethereum beacon client"
-  value       = var.CREATE_STATIC_IPS ? google_compute_address.eth_beacon_ip[0].address : null
+  description = "IP address for Ethereum beacon client (Static IP or Cluster IP)"
+  value       = var.CREATE_STATIC_IPS ? google_compute_address.eth_beacon_ip[0].address : data.kubernetes_service.eth_beacon[0].spec[0].cluster_ip
 }
 
 output "eth_execution_rpc_url" {
   description = "Ethereum execution RPC URL"
-  value       = var.CREATE_STATIC_IPS ? "http://${google_compute_address.eth_execution_ip[0].address}:8545" : null
+  value       = var.CREATE_STATIC_IPS ? "http://${google_compute_address.eth_execution_ip[0].address}:8545" : "http://${data.kubernetes_service.eth_execution[0].spec[0].cluster_ip}:8545"
 }
 
 output "eth_execution_ws_url" {
   description = "Ethereum execution WebSocket URL"
-  value       = var.CREATE_STATIC_IPS ? "ws://${google_compute_address.eth_execution_ip[0].address}:8546" : null
+  value       = var.CREATE_STATIC_IPS ? "ws://${google_compute_address.eth_execution_ip[0].address}:8546" : "ws://${data.kubernetes_service.eth_execution[0].spec[0].cluster_ip}:8546"
 }
 
 output "eth_beacon_api_url" {
   description = "Ethereum beacon API URL"
-  value       = var.CREATE_STATIC_IPS ? "http://${google_compute_address.eth_beacon_ip[0].address}:5052" : null
+  value       = var.CREATE_STATIC_IPS ? "http://${google_compute_address.eth_beacon_ip[0].address}:5052" : "http://${data.kubernetes_service.eth_beacon[0].spec[0].cluster_ip}:5052"
 }
 
 output "chain_id" {

--- a/spartan/terraform/deploy-eth-devnet/variables.tf
+++ b/spartan/terraform/deploy-eth-devnet/variables.tf
@@ -34,6 +34,12 @@ variable "ETH_DEVNET_VALUES" {
   default     = "eth-devnet.yaml"
 }
 
+variable "MNEMONIC" {
+  description = "The mnemonic to use for the eth devnet"
+  type        = string
+  default     = "test test test test test test test test test test test junk"
+  sensitive   = true
+}
 
 
 variable "CREATE_STATIC_IPS" {

--- a/spartan/terraform/deploy-rollup-contracts/main.tf
+++ b/spartan/terraform/deploy-rollup-contracts/main.tf
@@ -31,7 +31,7 @@ locals {
     ["--l1-rpc-urls", var.L1_RPC_URLS],
     ["--mnemonic", var.MNEMONIC],
     ["--l1-chain-id", tostring(var.L1_CHAIN_ID)],
-    # ["--validators", var.VALIDATORS],
+    ["--validators", var.VALIDATORS],
     ["--json"], # Always output JSON for easier parsing
     var.SALT != null ? ["--salt", tostring(var.SALT)] : [],
     var.SPONSORED_FPC ? ["--sponsored-fpc"] : [],


### PR DESCRIPTION
# Add Scenario Network Deployment Workflow

This PR adds a new workflow for deploying a complete scenario network, which includes:

1. A new `deploy-scenario-network.yml` workflow that orchestrates the deployment of both an Ethereum devnet and rollup contracts
2. Updates to the `deploy-eth-devnet.yml` workflow to:
   - Accept a custom mnemonic as an input parameter
   - Expose deployment results (RPC URL, WebSocket URL, Beacon URL, Chain ID) as workflow outputs
   - Mask the mnemonic in logs for security

3. Updates to the Terraform configuration in `deploy-eth-devnet`:
   - Use the provided mnemonic instead of fetching from Google Secret Manager
   - Support both static IPs and cluster IPs for services
   - Add proper output handling for both IP types

4. Updates to the rollup contracts deployment to properly use the validators parameter

These changes enable more flexible and composable deployment workflows for testing scenarios.