### PR TITLE
chore(docs): Switch from `master` to `next` for pulling bbup's installation script

### DIFF
--- a/barretenberg/docs/docs/getting_started.md
+++ b/barretenberg/docs/docs/getting_started.md
@@ -18,7 +18,7 @@ Although it is a standandalone prover, Barretenberg is designed to be used with 
 Inspired by `rustup`, `noirup` and similar tools, you can use the `bbup` installation script to quickly install and update Barretenberg's CLI tool:
 
 ```bash
-curl -L https://raw.githubusercontent.com/AztecProtocol/aztec-packages/refs/heads/master/barretenberg/bbup/install | bash
+curl -L https://raw.githubusercontent.com/AztecProtocol/aztec-packages/refs/heads/next/barretenberg/bbup/install | bash
 bbup
 ```
 

--- a/barretenberg/docs/versioned_docs/version-v0.87.0/getting_started.md
+++ b/barretenberg/docs/versioned_docs/version-v0.87.0/getting_started.md
@@ -18,7 +18,7 @@ Although it is a standandalone prover, Barretenberg is designed to be used with 
 Inspired by `rustup`, `noirup` and similar tools, you can use the `bbup` installation script to quickly install and update Barretenberg's CLI tool:
 
 ```bash
-curl -L https://raw.githubusercontent.com/AztecProtocol/aztec-packages/refs/heads/master/barretenberg/bbup/install | bash
+curl -L https://raw.githubusercontent.com/AztecProtocol/aztec-packages/refs/heads/next/barretenberg/bbup/install | bash
 bbup
 ```
 


### PR DESCRIPTION
## Problem

Master updates aren't necessarily cut frequently to reflect the latest updates in bbup's installation script, causing frictions for its users.

https://github.com/AztecProtocol/aztec-packages/pull/16541 for example, the installation script on master was fetching bbup on master, which lacked the latest list of version compatibility with the latest Noir versions.

## Alternatives considered

We can leave the script as is, and when a new master merge happens it will resolve itself.

I don't personally see benefits in maintaining the delay though, as the script is mostly used by Noir + Barretenberg devs and has no role in Aztec network's operations (hence no network instability introduced).