### PR TITLE
feat(avm)!: enable amm check circuit

### DIFF
--- a/barretenberg/cpp/pil/vm2/context.pil
+++ b/barretenberg/cpp/pil/vm2/context.pil
@@ -128,7 +128,7 @@ namespace execution;
 
     // The initial next_context_id = 2, in row = 1
     #[INCR_NEXT_CONTEXT_ID]
-    NOT_LAST_EXEC * (next_context_id' - (next_context_id + sel_enter_call)) = 0;
+    NOT_LAST_EXEC * (next_context_id' - (next_context_id + sel_enter_call + enqueued_call_start')) = 0;
 
     // nested_exit_call = 1 ==> context_id' = parent_id
     // sel_enter_call   = 1 ==> context_id' = next_context_id
@@ -235,12 +235,12 @@ namespace execution;
     #[PROPAGATE_RD_SIZE]
     NOT_LAST_EXEC * DEFAULT_CTX_ROW * (last_child_returndata_size' - last_child_returndata_size) = 0;
 
-    // sel_exit_call       = 1 ==> last_child_id' = context_id;  <-- sel_exit_call includes error case
+    // nested_exit_call    = 1 ==> last_child_id' = context_id;  <-- sel_exit_call includes error case
     // sel_enter_call      = 1 ==> last_child_id' = 0;
     // enqueued_call_start = 1 ==> last_child_id = 0; <-- Current row is 0
     // otherwise           = 0 ==> last_child_id' = last_child_id;
     #[EXIT_CALL_LAST_CHILD_ID]
-    NOT_LAST_EXEC * sel_exit_call * (last_child_id' - context_id) = 0;
+    NOT_LAST_EXEC * nested_exit_call * (last_child_id' - context_id) = 0;
     #[ENTER_CALL_LAST_CHILD_ID]
     NOT_LAST_EXEC * sel_enter_call * last_child_id' = 0;
     #[LAST_CHILD_ID_IS_ZERO]

--- a/barretenberg/cpp/pil/vm2/opcodes/internal_call.pil
+++ b/barretenberg/cpp/pil/vm2/opcodes/internal_call.pil
@@ -19,7 +19,9 @@ namespace execution;
     // When we encounter this case, the internal call information in the next row is constrained to change (incremented, unwound, etc)
     pol NEW_NEXT_CALL_ID = (sel_execute_internal_call + sel_execute_internal_return) * (1 - sel_error) + sel_exit_call;
 
-    pol PROPAGATE_CALL_ID = 1 - RESET_NEXT_CALL_ID - NEW_NEXT_CALL_ID;
+    // This is an XOR
+    pol RESET_OR_NEW_NEXT_CALL_ID = (RESET_NEXT_CALL_ID + NEW_NEXT_CALL_ID) - (RESET_NEXT_CALL_ID * NEW_NEXT_CALL_ID);
+    pol PROPAGATE_CALL_ID = 1 - RESET_OR_NEW_NEXT_CALL_ID;
 
     // =============================
     // === Internal Call Pointer ===
@@ -57,9 +59,8 @@ namespace execution;
     #[NEXT_CALL_ID_STARTS_TWO]
     RESET_NEXT_CALL_ID * (next_internal_call_id' - 2) = 0;
     // If we encounter a sel_execute_internal_call, we increment the next next_internal_call_id, unless we are changing context
-    pol CONTEXT_CHANGE = (RESET_NEXT_CALL_ID + sel_exit_call) - (RESET_NEXT_CALL_ID * sel_exit_call) ;
     #[INCR_NEXT_INT_CALL_ID]
-    NOT_LAST_EXEC * (1 - CONTEXT_CHANGE) * (next_internal_call_id' - (next_internal_call_id + sel_execute_internal_call)) = 0;
+    NOT_LAST_EXEC * (1 - RESET_OR_NEW_NEXT_CALL_ID) * (next_internal_call_id' - (next_internal_call_id + sel_execute_internal_call)) = 0;
 
     // =============================
     // === Error Handling ====

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/context_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/context_impl.hpp
@@ -91,7 +91,8 @@ void contextImpl<FF_>::accumulate(ContainerOverSubrelations& evals,
         using Accumulator = typename std::tuple_element_t<7, ContainerOverSubrelations>;
         auto tmp =
             execution_NOT_LAST_EXEC * (in.get(C::execution_next_context_id_shift) -
-                                       (in.get(C::execution_next_context_id) + in.get(C::execution_sel_enter_call)));
+                                       (in.get(C::execution_next_context_id) + in.get(C::execution_sel_enter_call) +
+                                        in.get(C::execution_enqueued_call_start_shift)));
         tmp *= scaling_factor;
         std::get<7>(evals) += typename Accumulator::View(tmp);
     }
@@ -285,7 +286,7 @@ void contextImpl<FF_>::accumulate(ContainerOverSubrelations& evals,
     }
     { // EXIT_CALL_LAST_CHILD_ID
         using Accumulator = typename std::tuple_element_t<35, ContainerOverSubrelations>;
-        auto tmp = execution_NOT_LAST_EXEC * in.get(C::execution_sel_exit_call) *
+        auto tmp = execution_NOT_LAST_EXEC * in.get(C::execution_nested_exit_call) *
                    (in.get(C::execution_last_child_id_shift) - in.get(C::execution_context_id));
         tmp *= scaling_factor;
         std::get<35>(evals) += typename Accumulator::View(tmp);

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/internal_call.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/internal_call.hpp
@@ -14,7 +14,7 @@ template <typename FF_> class internal_callImpl {
   public:
     using FF = FF_;
 
-    static constexpr std::array<size_t, 10> SUBRELATION_PARTIAL_LENGTHS = { 3, 3, 3, 6, 3, 3, 6, 3, 6, 5 };
+    static constexpr std::array<size_t, 10> SUBRELATION_PARTIAL_LENGTHS = { 3, 3, 3, 7, 3, 3, 7, 3, 7, 5 };
 
     template <typename AllEntities> inline static bool skip(const AllEntities& in)
     {

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/internal_call_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/internal_call_impl.hpp
@@ -23,9 +23,9 @@ void internal_callImpl<FF_>::accumulate(ContainerOverSubrelations& evals,
         (in.get(C::execution_sel_execute_internal_call) + in.get(C::execution_sel_execute_internal_return)) *
             (FF(1) - in.get(C::execution_sel_error)) +
         in.get(C::execution_sel_exit_call);
-    const auto execution_PROPAGATE_CALL_ID = ((FF(1) - execution_RESET_NEXT_CALL_ID) - execution_NEW_NEXT_CALL_ID);
-    const auto execution_CONTEXT_CHANGE = ((execution_RESET_NEXT_CALL_ID + in.get(C::execution_sel_exit_call)) -
-                                           execution_RESET_NEXT_CALL_ID * in.get(C::execution_sel_exit_call));
+    const auto execution_RESET_OR_NEW_NEXT_CALL_ID = ((execution_RESET_NEXT_CALL_ID + execution_NEW_NEXT_CALL_ID) -
+                                                      execution_RESET_NEXT_CALL_ID * execution_NEW_NEXT_CALL_ID);
+    const auto execution_PROPAGATE_CALL_ID = (FF(1) - execution_RESET_OR_NEW_NEXT_CALL_ID);
 
     { // CALL_ID_STARTS_ONE
         using Accumulator = typename std::tuple_element_t<0, ContainerOverSubrelations>;
@@ -82,7 +82,7 @@ void internal_callImpl<FF_>::accumulate(ContainerOverSubrelations& evals,
     }
     { // INCR_NEXT_INT_CALL_ID
         using Accumulator = typename std::tuple_element_t<8, ContainerOverSubrelations>;
-        auto tmp = execution_NOT_LAST_EXEC * (FF(1) - execution_CONTEXT_CHANGE) *
+        auto tmp = execution_NOT_LAST_EXEC * (FF(1) - execution_RESET_OR_NEW_NEXT_CALL_ID) *
                    (in.get(C::execution_next_internal_call_id_shift) -
                     (in.get(C::execution_next_internal_call_id) + in.get(C::execution_sel_execute_internal_call)));
         tmp *= scaling_factor;

--- a/yarn-project/bb-prover/src/avm_proving_tests/avm_check_circuit_amm.test.ts
+++ b/yarn-project/bb-prover/src/avm_proving_tests/avm_check_circuit_amm.test.ts
@@ -10,8 +10,7 @@ import { AvmProvingTester } from './avm_proving_tester.js';
 
 const TIMEOUT = 300_000;
 
-// TODO: unskip when check-circuit works for AMM. Confirm that it is fast enough to run in CI.
-describe.skip('AVM proven AMM', () => {
+describe('AVM proven AMM', () => {
   const logger = createLogger('avm-proven-tests-amm');
   const metrics = new TestExecutorMetrics();
   let tester: AvmProvingTester;


### PR DESCRIPTION
Fixes identified in @dbanks12 PR [here](https://github.com/AztecProtocol/aztec-packages/pull/16428). Enables the AMM

```
## TX Label: Token/constructor/0
- Total duration: `203.016 ms`
- Total mana used: `310,167`
- Mana per second: `1,527,799`
- Total instructions executed: `18,095`
- Private insertions:
    - Non-revertible: `6.079 ms`
    - Revertible: `0.644 ms`
- Proving:
    - Simulation (all): `197 ms`
    - Trace generation (all): `1,932 ms`
    - Trace generation interactions: `1,089 ms`
    - Trace generation traces: `837 ms`
- Enqueued public calls:
    - **Fn: Token.constructor**
        - Duration: `170.886 ms`
        - Mana used: `310,167`
        - Mana per second: `1,815,048`
        - Instructions executed: `18,095`

---------------------------------------------------------------------

## TX Label: Token/constructor/1
- Total duration: `156.058 ms`
- Total mana used: `310,167`
- Mana per second: `1,987,515`
- Total instructions executed: `18,095`
- Private insertions:
    - Non-revertible: `3.979 ms`
    - Revertible: `0.368 ms`
- Proving:
    - Simulation (all): `226 ms`
    - Trace generation (all): `2,127 ms`
    - Trace generation interactions: `1,232 ms`
    - Trace generation traces: `889 ms`
- Enqueued public calls:
    - **Fn: Token.constructor**
        - Duration: `133.126 ms`
        - Mana used: `310,167`
        - Mana per second: `2,329,871`
        - Instructions executed: `18,095`

---------------------------------------------------------------------
## TX Label: Token/constructor/2
- Total duration: `148.063 ms`
- Total mana used: `310,167`
- Mana per second: `2,094,828`
- Total instructions executed: `18,095`
- Private insertions:
    - Non-revertible: `3.793 ms`
    - Revertible: `0.356 ms`
- Proving:
    - Simulation (all): `197 ms`
    - Trace generation (all): `1,944 ms`
    - Trace generation interactions: `1,067 ms`
    - Trace generation traces: `871 ms`
- Enqueued public calls:
    - **Fn: Token.constructor**
        - Duration: `128.718 ms`
        - Mana used: `310,167`
        - Mana per second: `2,409,667`
        - Instructions executed: `18,095`

---------------------------------------------------------------------

## TX Label: AMM/constructor/3
- Total duration: `69.322 ms`
- Total mana used: `42,927`
- Mana per second: `619,239`
- Total instructions executed: `2,035`
- Private insertions:
    - Non-revertible: `3.276 ms`
    - Revertible: `0.346 ms`
- Proving:
    - Simulation (all): `66 ms`
    - Trace generation (all): `677 ms`
    - Trace generation interactions: `112 ms`
    - Trace generation traces: `560 ms`
- Enqueued public calls:
    - **Fn: AMM.constructor**
        - Duration: `47.049 ms`
        - Mana used: `42,927`
        - Mana per second: `912,395`
        - Instructions executed: `2,035`

---------------------------------------------------------------------
## TX Label: AMM/set_minter/4
- Total duration: `30.908 ms`
- Total mana used: `11,014`
- Mana per second: `356,353`
- Total instructions executed: `623`
- Private insertions:
    - Non-revertible: `2.768 ms`
    - Revertible: `0.359 ms`
- Proving:
    - Simulation (all): `45 ms`
    - Trace generation (all): `969 ms`
    - Trace generation interactions: `135 ms`
    - Trace generation traces: `833 ms`
- Enqueued public calls:
    - **Fn: Token.set_minter**
        - Duration: `11.947 ms`
        - Mana used: `11,014`
        - Mana per second: `921,920`
        - Instructions executed: `623`

---------------------------------------------------------------------

## TX Label: AMM/add_liquidity/5
- Total duration: `141.487 ms`
- Total mana used: `135,912`
- Mana per second: `960,600`
- Total instructions executed: `7,755`
- Private insertions:
    - Non-revertible: `2.524 ms`
    - Revertible: `0.268 ms`
- Proving:
    - Simulation (all): `132 ms`
    - Trace generation (all): `1,822 ms`
    - Trace generation interactions: `439 ms`
    - Trace generation traces: `1,375 ms`
- Enqueued public calls:
    - **Fn: Token._increase_public_balance**
    
---------------------------------------------------------------------    

  ## TX Label: AMM/swap_exact_tokens_for_tokens/6
- Total duration: `86.802 ms`
- Total mana used: `86,181`
- Mana per second: `992,850`
- Total instructions executed: `5,048`
- Private insertions:
    - Non-revertible: `3.308 ms`
    - Revertible: `0.334 ms`
- Proving:
    - Simulation (all): `97 ms`
    - Trace generation (all): `1,622 ms`
    - Trace generation interactions: `301 ms`
    - Trace generation traces: `1,315 ms`
- Enqueued public calls:
    - **Fn: Token._increase_public_balance**
        - Duration: `15.557 ms`
        - Mana used: `17,146`
        - Mana per second: `1,102,164`
        - Instructions executed: `1,027`
    - **Fn: AMM._swap_exact_tokens_for_tokens**
        - Duration: `48.411 ms`
        - Mana used: `69,035`
        - Mana per second: `1,426,009`
        - Instructions executed: `4,021`

---------------------------------------------------------------------

## TX Label: AMM/remove_liquidity/7
- Total duration: `172.86 ms`
- Total mana used: `155,323`
- Mana per second: `898,546`
- Total instructions executed: `8,871`
- Private insertions:
    - Non-revertible: `2.936 ms`
    - Revertible: `0.291 ms`
- Proving:
    - Simulation (all): `145 ms`
    - Trace generation (all): `1,787 ms`
    - Trace generation interactions: `447 ms`
    - Trace generation traces: `1,332 ms`
- Enqueued public calls:
    - **Fn: Token._increase_public_balance**
        - Duration: `15.772 ms`
        - Mana used: `17,146`
        - Mana per second: `1,087,104`
        - Instructions executed: `1,027`
    - **Fn: AMM._remove_liquidity**
        - Duration: `134.25 ms`
        - Mana used: `138,177`
        - Mana per second: `1,029,252`
        - Instructions executed: `7,844`
        - Duration: `14.17 ms`
        - Mana used: `17,146`
        - Mana per second: `1,210,011`
        - Instructions executed: `1,027`
    - **Fn: Token._increase_public_balance**
        - Duration: `15.497 ms`
        - Mana used: `17,146`
        - Mana per second: `1,106,437`
        - Instructions executed: `1,027`
    - **Fn: AMM._add_liquidity**
        - Duration: `91.271 ms`
        - Mana used: `101,620`
        - Mana per second: `1,113,387`
        - Instructions executed: `5,701`

---------------------------------------------------------------------
````