### PR TITLE
fix: misc fixes to simulator test fixtures, yarn-project bootstrap, bb-prover AVM error message

### DIFF
--- a/yarn-project/bb-prover/src/avm_proving_tests/avm_bulk.test.ts
+++ b/yarn-project/bb-prover/src/avm_proving_tests/avm_bulk.test.ts
@@ -1,4 +1,5 @@
 import { createLogger } from '@aztec/foundation/log';
+import { AvmTestContractArtifact } from '@aztec/noir-test-contracts.js/AvmTest';
 import { TestExecutorMetrics, bulkTest, defaultGlobals } from '@aztec/simulator/public/fixtures';
 
 import { mkdirSync, writeFileSync } from 'fs';
@@ -33,7 +34,7 @@ describe('AVM proven bulk test', () => {
   it(
     'Prove and verify',
     async () => {
-      await bulkTest(tester, logger, (b: boolean) => expect(b).toBe(true));
+      await bulkTest(tester, logger, AvmTestContractArtifact, (b: boolean) => expect(b).toBe(true));
     },
     TIMEOUT,
   );

--- a/yarn-project/bb-prover/src/avm_proving_tests/avm_check_circuit_amm.test.ts
+++ b/yarn-project/bb-prover/src/avm_proving_tests/avm_check_circuit_amm.test.ts
@@ -1,4 +1,6 @@
 import { createLogger } from '@aztec/foundation/log';
+import { AMMContractArtifact } from '@aztec/noir-contracts.js/AMM';
+import { TokenContractArtifact } from '@aztec/noir-contracts.js/Token';
 import { TestExecutorMetrics, ammTest, defaultGlobals } from '@aztec/simulator/public/fixtures';
 
 import { mkdirSync, writeFileSync } from 'fs';
@@ -34,7 +36,7 @@ describe.skip('AVM proven AMM', () => {
   it(
     'proven AMM operations: addLiquidity, swap, removeLiquidity (simulates constructors, set_minter)',
     async () => {
-      await ammTest(tester, logger, (b: boolean) => expect(b).toBe(true));
+      await ammTest(tester, logger, TokenContractArtifact, AMMContractArtifact, (b: boolean) => expect(b).toBe(true));
     },
     TIMEOUT,
   );

--- a/yarn-project/bb-prover/src/avm_proving_tests/avm_check_circuit_token.test.ts
+++ b/yarn-project/bb-prover/src/avm_proving_tests/avm_check_circuit_token.test.ts
@@ -1,4 +1,5 @@
 import { createLogger } from '@aztec/foundation/log';
+import { TokenContractArtifact } from '@aztec/noir-contracts.js/Token';
 import { TestExecutorMetrics, defaultGlobals, tokenTest } from '@aztec/simulator/public/fixtures';
 
 import { mkdirSync, writeFileSync } from 'fs';
@@ -33,7 +34,7 @@ describe('AVM proven TokenContract', () => {
   it(
     'proven token transfer (simulates constructor, mint, burn, check balance)',
     async () => {
-      await tokenTest(tester, logger, (b: boolean) => expect(b).toBe(true));
+      await tokenTest(tester, logger, TokenContractArtifact, (b: boolean) => expect(b).toBe(true));
     },
     TIMEOUT,
   );

--- a/yarn-project/bb-prover/src/avm_proving_tests/avm_mega_bulk.test.ts
+++ b/yarn-project/bb-prover/src/avm_proving_tests/avm_mega_bulk.test.ts
@@ -1,4 +1,5 @@
 import { createLogger } from '@aztec/foundation/log';
+import { AvmTestContractArtifact } from '@aztec/noir-test-contracts.js/AvmTest';
 import { TestExecutorMetrics, defaultGlobals, megaBulkTest } from '@aztec/simulator/public/fixtures';
 
 import { mkdirSync, writeFileSync } from 'fs';
@@ -34,7 +35,7 @@ describe.skip('AVM proven MEGA bulk test', () => {
   it(
     'Prove and verify mega bulk test',
     async () => {
-      await megaBulkTest(tester, logger, (b: boolean) => expect(b).toBe(true));
+      await megaBulkTest(tester, logger, AvmTestContractArtifact, (b: boolean) => expect(b).toBe(true));
     },
     TIMEOUT,
   );

--- a/yarn-project/bb-prover/src/bb/execute.ts
+++ b/yarn-project/bb-prover/src/bb/execute.ts
@@ -434,7 +434,7 @@ export async function generateAvmProof(
     // Not a great error message here but it is difficult to decipher what comes from bb
     return {
       status: BB_RESULT.FAILURE,
-      reason: `Failed to generate proof. Exit code ${result.exitCode}. Signal ${result.signal}.`,
+      reason: `Failed to generate proof. AVM proof for TX hash ${input.hints.tx.hash}. Exit code ${result.exitCode}. Signal ${result.signal}.`,
       retry: !!result.signal,
     };
   } catch (error) {

--- a/yarn-project/bootstrap.sh
+++ b/yarn-project/bootstrap.sh
@@ -142,7 +142,7 @@ function test_cmds {
     fi
 
     if [[ "$test" =~ rollup_ivc_integration || "$test" =~ avm_integration ]]; then
-      cmd_env+=" LOG_LEVEL=trace BB_VERBOSE=1 "
+      cmd_env+=" LOG_LEVEL=debug BB_VERBOSE=1 "
     fi
 
     echo "${prefix}${cmd_env} yarn-project/scripts/run_test.sh $test"

--- a/yarn-project/ivc-integration/src/avm_integration.test.ts
+++ b/yarn-project/ivc-integration/src/avm_integration.test.ts
@@ -6,6 +6,7 @@ import {
 } from '@aztec/constants';
 import { createLogger } from '@aztec/foundation/log';
 import { mapAvmCircuitPublicInputsToNoir } from '@aztec/noir-protocol-circuits-types/server';
+import { AvmTestContractArtifact } from '@aztec/noir-test-contracts.js/AvmTest';
 import { PublicTxSimulationTester, bulkTest, createAvmMinimalPublicTx } from '@aztec/simulator/public/fixtures';
 import type { AvmCircuitInputs } from '@aztec/stdlib/avm';
 import type { ProofAndVerificationKey } from '@aztec/stdlib/interfaces/server';
@@ -102,7 +103,9 @@ describe('AVM Integration', () => {
   });
 
   it('Should generate and verify an ultra honk proof from an AVM verification of the bulk test', async () => {
-    const avmSimulationResult = await bulkTest(simTester, logger, (b: boolean) => expect(b).toBe(true));
+    const avmSimulationResult = await bulkTest(simTester, logger, AvmTestContractArtifact, (b: boolean) =>
+      expect(b).toBe(true),
+    );
     const avmCircuitInputs = avmSimulationResult.avmProvingRequest.inputs;
 
     await proveMockPublicBaseRollup(

--- a/yarn-project/ivc-integration/src/rollup_ivc_integration.test.ts
+++ b/yarn-project/ivc-integration/src/rollup_ivc_integration.test.ts
@@ -7,6 +7,7 @@ import {
 import { Fr } from '@aztec/foundation/fields';
 import { createLogger } from '@aztec/foundation/log';
 import { mapAvmCircuitPublicInputsToNoir } from '@aztec/noir-protocol-circuits-types/server';
+import { AvmTestContractArtifact } from '@aztec/noir-test-contracts.js/AvmTest';
 import { PublicTxSimulationTester, bulkTest } from '@aztec/simulator/public/fixtures';
 import { AvmCircuitPublicInputs } from '@aztec/stdlib/avm';
 import type { ProofAndVerificationKey } from '@aztec/stdlib/interfaces/server';
@@ -73,7 +74,9 @@ describe('Rollup IVC Integration', () => {
     const avmWorkingDirectory = await getWorkingDirectory('bb-rollup-ivc-integration-avm-');
 
     const simTester = await PublicTxSimulationTester.create();
-    const avmSimulationResult = await bulkTest(simTester, logger, (b: boolean) => expect(b).toBe(true));
+    const avmSimulationResult = await bulkTest(simTester, logger, AvmTestContractArtifact, (b: boolean) =>
+      expect(b).toBe(true),
+    );
 
     const avmCircuitInputs = avmSimulationResult.avmProvingRequest.inputs;
     ({

--- a/yarn-project/simulator/src/public/fixtures/amm_test.ts
+++ b/yarn-project/simulator/src/public/fixtures/amm_test.ts
@@ -3,7 +3,7 @@ import { poseidon2HashWithSeparator } from '@aztec/foundation/crypto';
 import { Fr } from '@aztec/foundation/fields';
 import type { Logger } from '@aztec/foundation/log';
 import { Timer } from '@aztec/foundation/timer';
-import { AMMContractArtifact } from '@aztec/noir-contracts.js/AMM';
+import type { ContractArtifact } from '@aztec/stdlib/abi';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import type { ContractInstanceWithAddress } from '@aztec/stdlib/contract';
 
@@ -16,22 +16,28 @@ const INITIAL_TOKEN_BALANCE = 1_000_000_000n;
  * `.skip` it or literally just delete it and notify AVM team.
  * You do NOT need permission to remove this test!
  */
-export async function ammTest(tester: PublicTxSimulationTester, logger: Logger, expectToBeTrue: (x: boolean) => void) {
+export async function ammTest(
+  tester: PublicTxSimulationTester,
+  logger: Logger,
+  tokenArtifact: ContractArtifact,
+  ammArtifact: ContractArtifact,
+  expectToBeTrue: (x: boolean) => void,
+) {
   const timer = new Timer();
 
   const admin = AztecAddress.fromNumber(42);
   const sender = AztecAddress.fromNumber(111);
 
   logger.debug(`Deploying tokens`);
-  const token0 = await setUpToken(tester, admin, expectToBeTrue, /*seed=*/ 0);
-  const token1 = await setUpToken(tester, admin, expectToBeTrue, /*seed=*/ 1);
-  const liquidityToken = await setUpToken(tester, admin, expectToBeTrue, /*seed=*/ 2);
+  const token0 = await setUpToken(tester, tokenArtifact, admin, expectToBeTrue, /*seed=*/ 0);
+  const token1 = await setUpToken(tester, tokenArtifact, admin, expectToBeTrue, /*seed=*/ 1);
+  const liquidityToken = await setUpToken(tester, tokenArtifact, admin, expectToBeTrue, /*seed=*/ 2);
   logger.debug(`Deploying AMM`);
   const constructorArgs = [token0, token1, liquidityToken];
   const amm = await tester.registerAndDeployContract(
     constructorArgs,
     /*deployer=*/ admin,
-    AMMContractArtifact,
+    ammArtifact,
     /*skipNullifierInsertion=*/ false,
     /*seed=*/ 3,
   );

--- a/yarn-project/simulator/src/public/fixtures/bulk_test.ts
+++ b/yarn-project/simulator/src/public/fixtures/bulk_test.ts
@@ -1,19 +1,24 @@
 import { Fr } from '@aztec/foundation/fields';
 import type { Logger } from '@aztec/foundation/log';
 import { Timer } from '@aztec/foundation/timer';
-import { AvmTestContractArtifact } from '@aztec/noir-test-contracts.js/AvmTest';
+import type { ContractArtifact } from '@aztec/stdlib/abi';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
 
 import { PublicTxSimulationTester } from './public_tx_simulation_tester.js';
 
-export async function bulkTest(tester: PublicTxSimulationTester, logger: Logger, expectToBeTrue: (x: boolean) => void) {
+export async function bulkTest(
+  tester: PublicTxSimulationTester,
+  logger: Logger,
+  avmTestContractArtifact: ContractArtifact,
+  expectToBeTrue: (x: boolean) => void,
+) {
   const timer = new Timer();
 
   const deployer = AztecAddress.fromNumber(42);
   const avmTestContract = await tester.registerAndDeployContract(
     /*constructorArgs=*/ [],
     deployer,
-    /*contractArtifact=*/ AvmTestContractArtifact,
+    avmTestContractArtifact,
   );
 
   // Get a deployed contract instance to pass to the contract
@@ -65,6 +70,7 @@ export async function bulkTest(tester: PublicTxSimulationTester, logger: Logger,
 export async function megaBulkTest(
   tester: PublicTxSimulationTester,
   logger: Logger,
+  avmTestContractArtifact: ContractArtifact,
   expectToBeTrue: (x: boolean) => void,
 ) {
   const timer = new Timer();
@@ -73,7 +79,7 @@ export async function megaBulkTest(
   const avmTestContract = await tester.registerAndDeployContract(
     /*constructorArgs=*/ [],
     deployer,
-    /*contractArtifact=*/ AvmTestContractArtifact,
+    avmTestContractArtifact,
   );
   // Get a deployed contract instance to pass to the contract
   // for it to use as "expected" values when testing contract instance retrieval.

--- a/yarn-project/simulator/src/public/fixtures/token_test.ts
+++ b/yarn-project/simulator/src/public/fixtures/token_test.ts
@@ -1,7 +1,7 @@
 import { Fr } from '@aztec/foundation/fields';
 import type { Logger } from '@aztec/foundation/log';
 import { Timer } from '@aztec/foundation/timer';
-import { TokenContractArtifact } from '@aztec/noir-contracts.js/Token';
+import type { ContractArtifact } from '@aztec/stdlib/abi';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import type { ContractInstanceWithAddress } from '@aztec/stdlib/contract';
 
@@ -10,6 +10,7 @@ import { PublicTxSimulationTester } from './public_tx_simulation_tester.js';
 export async function tokenTest(
   tester: PublicTxSimulationTester,
   logger: Logger,
+  tokenArtifact: ContractArtifact,
   expectToBeTrue: (x: boolean) => void,
 ) {
   const timer = new Timer();
@@ -18,7 +19,7 @@ export async function tokenTest(
   const sender = AztecAddress.fromNumber(111);
   const receiver = AztecAddress.fromNumber(222);
 
-  const token = await setUpToken(tester, admin, expectToBeTrue);
+  const token = await setUpToken(tester, tokenArtifact, admin, expectToBeTrue);
 
   const mintAmount = 100n;
   // EXECUTE! This means that if using AvmProvingTester subclass, it will PROVE the transaction!
@@ -77,6 +78,7 @@ export async function tokenTest(
 
 export async function setUpToken(
   tester: PublicTxSimulationTester,
+  tokenArtifact: ContractArtifact,
   admin: AztecAddress,
   expectToBeTrue: (x: boolean) => void,
   seed = 0,
@@ -85,7 +87,7 @@ export async function setUpToken(
   const token = await tester.registerAndDeployContract(
     constructorArgs,
     /*deployer=*/ admin,
-    TokenContractArtifact,
+    tokenArtifact,
     /*skipNullifierInsertion=*/ false,
     seed,
   );

--- a/yarn-project/simulator/src/public/public_tx_simulator/apps_tests/amm.test.ts
+++ b/yarn-project/simulator/src/public/public_tx_simulator/apps_tests/amm.test.ts
@@ -1,4 +1,6 @@
 import { createLogger } from '@aztec/foundation/log';
+import { AMMContractArtifact } from '@aztec/noir-contracts.js/AMM';
+import { TokenContractArtifact } from '@aztec/noir-contracts.js/Token';
 
 import { ammTest } from '../../fixtures/amm_test.js';
 import { PublicTxSimulationTester } from '../../fixtures/public_tx_simulation_tester.js';
@@ -13,6 +15,6 @@ describe('Public TX simulator apps tests: AMM Contract', () => {
   });
 
   it('amm operations', async () => {
-    await ammTest(tester, logger, (b: boolean) => expect(b).toBe(true));
+    await ammTest(tester, logger, TokenContractArtifact, AMMContractArtifact, (b: boolean) => expect(b).toBe(true));
   });
 });

--- a/yarn-project/simulator/src/public/public_tx_simulator/apps_tests/avm_test.test.ts
+++ b/yarn-project/simulator/src/public/public_tx_simulator/apps_tests/avm_test.test.ts
@@ -1,4 +1,5 @@
 import { createLogger } from '@aztec/foundation/log';
+import { AvmTestContractArtifact } from '@aztec/noir-test-contracts.js/AvmTest';
 
 import { bulkTest } from '../../fixtures/bulk_test.js';
 import { PublicTxSimulationTester } from '../../fixtures/public_tx_simulation_tester.js';
@@ -12,6 +13,6 @@ describe('Public TX simulator apps tests: AvmTestContract', () => {
   });
 
   it('bulk testing', async () => {
-    await bulkTest(simTester, logger, (b: boolean) => expect(b).toBe(true));
+    await bulkTest(simTester, logger, AvmTestContractArtifact, (b: boolean) => expect(b).toBe(true));
   });
 });

--- a/yarn-project/simulator/src/public/public_tx_simulator/apps_tests/bench.test.ts
+++ b/yarn-project/simulator/src/public/public_tx_simulator/apps_tests/bench.test.ts
@@ -1,6 +1,8 @@
 import { randomInt } from '@aztec/foundation/crypto';
 import { Fr } from '@aztec/foundation/fields';
 import { createLogger } from '@aztec/foundation/log';
+import { AMMContractArtifact } from '@aztec/noir-contracts.js/AMM';
+import { TokenContractArtifact } from '@aztec/noir-contracts.js/Token';
 import { AvmGadgetsTestContractArtifact } from '@aztec/noir-test-contracts.js/AvmGadgetsTest';
 import { AvmTestContractArtifact } from '@aztec/noir-test-contracts.js/AvmTest';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
@@ -39,22 +41,22 @@ describe('Public TX simulator apps tests: benchmarks', () => {
 
   it('Token Contract test', async () => {
     tester.setMetricsPrefix('Token contract tests');
-    await tokenTest(tester, logger, (b: boolean) => expect(b).toBe(true));
+    await tokenTest(tester, logger, TokenContractArtifact, (b: boolean) => expect(b).toBe(true));
   });
 
   it('AMM Contract test', async () => {
     tester.setMetricsPrefix('AMM contract tests');
-    await ammTest(tester, logger, (b: boolean) => expect(b).toBe(true));
+    await ammTest(tester, logger, TokenContractArtifact, AMMContractArtifact, (b: boolean) => expect(b).toBe(true));
   });
 
   it('AVM simulator bulk test', async () => {
     tester.setMetricsPrefix('AvmTest contract tests');
-    await bulkTest(tester, logger, (b: boolean) => expect(b).toBe(true));
+    await bulkTest(tester, logger, AvmTestContractArtifact, (b: boolean) => expect(b).toBe(true));
   });
 
   it('AVM simulator MEGA bulk test', async () => {
     tester.setMetricsPrefix('AvmTest contract tests');
-    await megaBulkTest(tester, logger, (b: boolean) => expect(b).toBe(true));
+    await megaBulkTest(tester, logger, AvmTestContractArtifact, (b: boolean) => expect(b).toBe(true));
   });
 
   it('AVM large calldata test', async () => {

--- a/yarn-project/simulator/src/public/public_tx_simulator/apps_tests/token.test.ts
+++ b/yarn-project/simulator/src/public/public_tx_simulator/apps_tests/token.test.ts
@@ -1,4 +1,5 @@
 import { createLogger } from '@aztec/foundation/log';
+import { TokenContractArtifact } from '@aztec/noir-contracts.js/Token';
 
 import { PublicTxSimulationTester } from '../../fixtures/public_tx_simulation_tester.js';
 import { tokenTest } from '../../fixtures/token_test.js';
@@ -13,6 +14,6 @@ describe('Public TX simulator apps tests: TokenContract', () => {
   });
 
   it('token constructor, mint, transfer, burn, check balances)', async () => {
-    await tokenTest(tester, logger, (b: boolean) => expect(b).toBe(true));
+    await tokenTest(tester, logger, TokenContractArtifact, (b: boolean) => expect(b).toBe(true));
   });
 });


### PR DESCRIPTION
1. Modify public simulator test fixtures to accept contract artifacts as args and avoid needing `noir-[test-]contracts.js` as a prod dependency.
2. Reduce `yarn-project/bootstrap.sh`'s log-level to `debug` for avm/rollup ivc-integration tests.
3. bb-prover error message for failed AVM proofs includes TX hash