### PR TITLE
fix(authwit): correct FeePayload byte size to include is_fee_payer flag

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/authwit/entrypoint/fee.nr
+++ b/noir-projects/aztec-nr/aztec/src/authwit/entrypoint/fee.nr
@@ -6,8 +6,8 @@ use dep::protocol_types::{
 };
 use std::meta::derive;
 
-// 2 * 98 (FUNCTION_CALL_SIZE_IN_BYTES) + 32
-global FEE_PAYLOAD_SIZE_IN_BYTES: u32 = 228;
+// 2 * 98 (FUNCTION_CALL_SIZE_IN_BYTES) + 32 + 1 (is_fee_payer)
+global FEE_PAYLOAD_SIZE_IN_BYTES: u32 = 229;
 
 global MAX_FEE_FUNCTION_CALLS: u32 = 2;
 


### PR DESCRIPTION
The FEE_PAYLOAD_SIZE_IN_BYTES constant was set to 228 (2 * 98 + 32) but FeePayload::to_be_bytes serializes an extra byte for is_fee_payer, resulting in 229 bytes. This could overflow the BoundedVec capacity. Updated the constant and comment to 229 (2 * 98 + 32 + 1) to match the actual serialization size.
