### PR TITLE
chore: alter number of blocks for alpha

### DIFF
--- a/l1-contracts/gas_benchmark.md
+++ b/l1-contracts/gas_benchmark.md
@@ -16,23 +16,23 @@
 
 | Function             | Avg Gas | Max Gas | Calldata Size | Calldata Gas |
 |----------------------|---------|---------|---------------|--------------|
-| propose              | 142,569 | 157,723 |         1,060 |       16,960 |
-| submitEpochRootProof | 567,842 | 591,073 |         3,812 |       60,992 |
-| setupEpoch           |  31,585 | 108,397 |             - |            - |
+| propose              | 141,065 | 157,701 |         1,060 |       16,960 |
+| submitEpochRootProof | 556,226 | 591,073 |         3,812 |       60,992 |
+| setupEpoch           |  31,172 | 110,940 |             - |            - |
 
-**Avg Gas Cost per Second**: 869.2 gas/second
+**Avg Gas Cost per Second**: 858.8 gas/second
 *Epoch duration*: 2h 33m 36s
 
 ### Validators (IGNITION)
 
 | Function             | Avg Gas | Max Gas | Calldata Size | Calldata Gas |
 |----------------------|---------|---------|---------------|--------------|
-| propose              | 207,888 | 227,249 |         2,852 |       45,632 |
-| submitEpochRootProof | 679,690 | 701,700 |         5,092 |       81,472 |
-| aggregate3           | 245,657 | 265,021 |             - |            - |
-| setupEpoch           |  38,145 | 327,074 |             - |            - |
+| propose              | 208,357 | 227,227 |         2,852 |       45,632 |
+| submitEpochRootProof | 668,084 | 701,700 |         5,092 |       81,472 |
+| aggregate3           | 266,755 | 282,020 |             - |            - |
+| setupEpoch           |  36,638 | 329,613 |             - |            - |
 
-**Avg Gas Cost per Second**: 1,234.4 gas/second
+**Avg Gas Cost per Second**: 1,234.2 gas/second
 *Epoch duration*: 2h 33m 36s
 
 
@@ -52,22 +52,22 @@
 
 | Function             | Avg Gas | Max Gas | Calldata Size | Calldata Gas |
 |----------------------|---------|---------|---------------|--------------|
-| propose              | 219,926 | 235,984 |         1,060 |       16,960 |
-| submitEpochRootProof | 687,107 | 726,001 |         3,812 |       60,992 |
-| setupEpoch           |  32,376 | 108,397 |             - |            - |
+| propose              | 219,686 | 235,962 |         1,060 |       16,960 |
+| submitEpochRootProof | 682,260 | 726,001 |         3,812 |       60,992 |
+| setupEpoch           |  31,832 | 110,940 |             - |            - |
 
-**Avg Gas Cost per Second**: 7,330.1 gas/second
+**Avg Gas Cost per Second**: 7,314.5 gas/second
 *Epoch duration*: 0h 19m 12s
 
 ### Validators (Alpha)
 
 | Function             | Avg Gas | Max Gas | Calldata Size | Calldata Gas |
 |----------------------|---------|---------|---------------|--------------|
-| propose              | 334,960 | 352,320 |         4,580 |       73,280 |
-| submitEpochRootProof | 895,025 | 933,081 |         6,308 |      100,928 |
-| aggregate3           | 373,092 | 390,455 |             - |            - |
-| setupEpoch           |  49,728 | 542,190 |             - |            - |
+| propose              | 335,463 | 352,298 |         4,580 |       73,280 |
+| submitEpochRootProof | 890,592 | 933,081 |         6,308 |      100,928 |
+| aggregate3           | 393,732 | 406,787 |             - |            - |
+| setupEpoch           |  46,292 | 544,725 |             - |            - |
 
-**Avg Gas Cost per Second**: 10,901.5 gas/second
+**Avg Gas Cost per Second**: 10,904.8 gas/second
 *Epoch duration*: 0h 19m 12s
 

--- a/l1-contracts/gas_benchmark_results.json
+++ b/l1-contracts/gas_benchmark_results.json
@@ -2,26 +2,26 @@
   "ignition": {
     "no_validators": {
       "propose": {
-        "calls": 100,
-        "min": 139463,
-        "mean": 142569,
-        "median": 142433,
-        "max": 157723,
+        "calls": 200,
+        "min": 137813,
+        "mean": 141065,
+        "median": 139813,
+        "max": 157701,
         "calldata_size": 1060,
         "calldata_gas": 16960
       },
       "setupEpoch": {
-        "calls": 100,
-        "min": 29235,
-        "mean": 31585,
-        "median": 29235,
-        "max": 108397
+        "calls": 200,
+        "min": 29191,
+        "mean": 31172,
+        "median": 29191,
+        "max": 110940
       },
       "submitEpochRootProof": {
-        "calls": 2,
+        "calls": 4,
         "min": 544611,
-        "mean": 567842,
-        "median": 567842,
+        "mean": 556226,
+        "median": 544611,
         "max": 591073,
         "calldata_size": 3812,
         "calldata_gas": 60992
@@ -29,62 +29,62 @@
     },
     "validators": {
       "propose": {
-        "calls": 100,
-        "min": 201617,
-        "mean": 207888,
-        "median": 208237,
-        "max": 227249,
+        "calls": 200,
+        "min": 201595,
+        "mean": 208357,
+        "median": 208245,
+        "max": 227227,
         "calldata_size": 2852,
         "calldata_gas": 45632
       },
       "setupEpoch": {
-        "calls": 100,
-        "min": 29235,
-        "mean": 38145,
-        "median": 29235,
-        "max": 327074
+        "calls": 200,
+        "min": 29191,
+        "mean": 36638,
+        "median": 29191,
+        "max": 329613
       },
       "submitEpochRootProof": {
-        "calls": 2,
-        "min": 657681,
-        "mean": 679690,
-        "median": 679690,
+        "calls": 4,
+        "min": 655226,
+        "mean": 668084,
+        "median": 657706,
         "max": 701700,
         "calldata_size": 5092,
         "calldata_gas": 81472
       },
       "aggregate3": {
-        "calls": 100,
-        "min": 239377,
-        "mean": 245657,
-        "median": 245997,
-        "max": 265021
+        "calls": 57,
+        "min": 259989,
+        "mean": 266755,
+        "median": 266907,
+        "max": 282020
       }
     }
   },
   "alpha": {
     "no_validators": {
       "propose": {
-        "calls": 100,
-        "min": 212503,
-        "mean": 219926,
-        "median": 219136,
-        "max": 235984,
+        "calls": 150,
+        "min": 212481,
+        "mean": 219686,
+        "median": 218499,
+        "max": 235962,
         "calldata_size": 1060,
         "calldata_gas": 16960
       },
       "setupEpoch": {
-        "calls": 100,
-        "min": 29235,
-        "mean": 32376,
-        "median": 29235,
-        "max": 108397
+        "calls": 150,
+        "min": 29191,
+        "mean": 31832,
+        "median": 29191,
+        "max": 110940
       },
       "submitEpochRootProof": {
-        "calls": 3,
+        "calls": 4,
         "min": 667612,
-        "mean": 687107,
-        "median": 667708,
+        "mean": 682260,
+        "median": 667714,
         "max": 726001,
         "calldata_size": 3812,
         "calldata_gas": 60992
@@ -92,36 +92,36 @@
     },
     "validators": {
       "propose": {
-        "calls": 100,
-        "min": 319383,
-        "mean": 334960,
-        "median": 335406,
-        "max": 352320,
+        "calls": 150,
+        "min": 319361,
+        "mean": 335463,
+        "median": 335702,
+        "max": 352298,
         "calldata_size": 4580,
         "calldata_gas": 73280
       },
       "setupEpoch": {
-        "calls": 100,
-        "min": 29235,
-        "mean": 49728,
-        "median": 29235,
-        "max": 542190
+        "calls": 150,
+        "min": 29191,
+        "mean": 46292,
+        "median": 29191,
+        "max": 544725
       },
       "submitEpochRootProof": {
-        "calls": 3,
+        "calls": 4,
         "min": 874800,
-        "mean": 895025,
-        "median": 877195,
+        "mean": 890592,
+        "median": 877244,
         "max": 933081,
         "calldata_size": 6308,
         "calldata_gas": 100928
       },
       "aggregate3": {
-        "calls": 100,
-        "min": 357518,
-        "mean": 373092,
-        "median": 373541,
-        "max": 390455
+        "calls": 55,
+        "min": 382167,
+        "mean": 393732,
+        "median": 393570,
+        "max": 406787
       }
     }
   }

--- a/l1-contracts/test/benchmark/happy.t.sol
+++ b/l1-contracts/test/benchmark/happy.t.sol
@@ -132,6 +132,8 @@ contract BenchmarkRollupTest is FeeModelTestPoints, DecoderBase {
   uint256 internal PROOFS_PER_EPOCH; // given as e2, for simple decimals, e.g., 200 = 2.00
   uint256 internal VOTING_ROUND_SIZE = 500;
 
+  bool internal IS_IGNITION;
+
   Rollup internal rollup;
 
   address internal coinbase = address(bytes20("MONEY MAKER"));
@@ -216,6 +218,8 @@ contract BenchmarkRollupTest is FeeModelTestPoints, DecoderBase {
       MANA_TARGET = 0;
       TARGET_COMMITTEE_SIZE = 24;
       PROOFS_PER_EPOCH = 200; // 2.00
+
+      IS_IGNITION = true;
     } else {
       full = load("single_tx_block_1");
 
@@ -224,6 +228,8 @@ contract BenchmarkRollupTest is FeeModelTestPoints, DecoderBase {
       MANA_TARGET = 1e8;
       TARGET_COMMITTEE_SIZE = 48;
       PROOFS_PER_EPOCH = 200; // 2.00
+
+      IS_IGNITION = false;
     }
 
     FeeLib.initialize(MANA_TARGET, EthValue.wrap(100));
@@ -460,9 +466,12 @@ contract BenchmarkRollupTest is FeeModelTestPoints, DecoderBase {
     Slot nextSlot = Slot.wrap(EPOCH_DURATION * 3 + 1);
     Epoch nextEpoch = Epoch.wrap(4);
     bool warmedUp = false;
+
+    uint256 stopAtBlock = IS_IGNITION ? 200 : 150;
+
     // Loop through all of the L1 metadata
     for (uint256 i = 0; i < l1Metadata.length; i++) {
-      if (rollup.getPendingBlockNumber() >= 200) {
+      if (rollup.getPendingBlockNumber() >= stopAtBlock) {
         break;
       }
 


### PR DESCRIPTION
Had to update the number of blocks that we loop over for the gas benchmarks, as when running with the `GAS_REPORT` flags it will be more expensive and use all the gas. 

To fix, simply altered to use 150 blocks for alpha and 200 for ignition.