### PR TITLE
feat(bb): runtime stack traces in debug mode

### DIFF
--- a/barretenberg/README.md
+++ b/barretenberg/README.md
@@ -326,7 +326,7 @@ If you are in a scenario where you have a failing call to check_circuit and wish
 
 Usage instructions:
 
-- On ubuntu (or our mainframe accounts) use `sudo apt-get install libdw-dev libelf-dev libbackward-cpp-dev` to support trace printing
+- On ubuntu (or our mainframe accounts) use `sudo apt-get install libdw-dev libelf-dev` to support trace printing
 - Use `cmake --preset debug-fast-circuit-check-traces` and `cmake --build --preset debug-fast-circuit-check-traces` to enable the backward-cpp dependency through the CHECK_CIRCUIT_STACKTRACES CMake variable.
 - Run any case where you have a failing check_circuit call, you will now have a stack trace illuminating where this constraint was added in code.
 

--- a/barretenberg/cpp/CMakeLists.txt
+++ b/barretenberg/cpp/CMakeLists.txt
@@ -30,6 +30,7 @@ option(ENABLE_ASAN "Address sanitizer for debugging tricky memory corruption" OF
 option(ENABLE_HEAVY_TESTS "Enable heavy tests when collecting coverage" OFF)
 # Note: Must do 'sudo apt-get install libdw-dev' or equivalent
 option(CHECK_CIRCUIT_STACKTRACES "Enable (slow) stack traces for check circuit" OFF)
+option(ENABLE_STACKTRACES "Enable stack traces on assertion" OFF)
 option(ENABLE_TRACY "Enable low-medium overhead profiling for memory and performance with tracy" OFF)
 option(ENABLE_PIC "Builds with position independent code" OFF)
 option(SYNTAX_ONLY "only check syntax (-fsyntax-only)" OFF)
@@ -44,7 +45,9 @@ if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64" OR CMAKE_SYSTEM_PROCESSOR MATCHES "a
 endif()
 
 if(CHECK_CIRCUIT_STACKTRACES)
-    add_compile_options(-DCHECK_CIRCUIT_STACKTRACES)
+    add_compile_options(-DCHECK_CIRCUIT_STACKTRACES -DSTACKTRACES)
+elseif(ENABLE_STACKTRACES)
+    add_compile_options(-DSTACKTRACES)
 endif()
 
 if(ENABLE_TRACY OR ENABLE_TRACY_TIME_INSTRUMENTED)

--- a/barretenberg/cpp/CMakePresets.json
+++ b/barretenberg/cpp/CMakePresets.json
@@ -119,14 +119,15 @@
       "inherits": "clang20",
       "binaryDir": "build-debug",
       "environment": {
-        "CMAKE_BUILD_TYPE": "Debug",
         "CFLAGS": "-gdwarf-4",
         "CXXFLAGS": "-gdwarf-4",
         "LDFLAGS": "-gdwarf-4"
       },
       "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
         "ENABLE_ASAN": "OFF",
-        "DISABLE_ASM": "ON"
+        "DISABLE_ASM": "ON",
+        "ENABLE_STACKTRACES": "ON"
       }
     },
     {
@@ -163,12 +164,12 @@
       "binaryDir": "build-tracy-time-sampled",
       "inherits": "clang20",
       "environment": {
-        "CMAKE_BUILD_TYPE": "RelWithDebInfo",
         "CFLAGS": "-g -fno-omit-frame-pointer",
         "CXXFLAGS": "-g -fno-omit-frame-pointer",
         "LDFLAGS": "-g -fno-omit-frame-pointer -rdynamic"
       },
       "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo",
         "ENABLE_TRACY": "ON"
       }
     },
@@ -190,10 +191,12 @@
       "inherits": "debug",
       "binaryDir": "build-debug-fast",
       "environment": {
-        "CMAKE_BUILD_TYPE": "Debug",
         "CFLAGS": "-O2 -gdwarf",
         "CXXFLAGS": "-O2 -gdwarf-4",
         "LDFLAGS": "-O2 -gdwarf-4"
+      },
+      "cacheVariables": {
+        "ENABLE_STACKTRACES": "ON"
       }
     },
     {
@@ -207,13 +210,25 @@
       }
     },
     {
-      "name": "debug-no-avm",
+      "name": "debug-fast-no-avm",
       "displayName": "Optimized debug build with Clang-20 (no AVM)",
+      "description": "Build with globally installed Clang-20 in debug mode excluding the Aztec VM",
+      "inherits": "debug-fast",
+      "binaryDir": "build-debug-no-avm",
+      "cacheVariables": {
+        "DISABLE_AZTEC_VM": "ON",
+        "ENABLE_STACKTRACES": "ON"
+      }
+    },
+    {
+      "name": "debug-no-avm",
+      "displayName": "Debug build with Clang-20 (no AVM)",
       "description": "Build with globally installed Clang-20 in debug mode excluding the Aztec VM",
       "inherits": "debug",
       "binaryDir": "build-debug-no-avm",
       "cacheVariables": {
-        "DISABLE_AZTEC_VM": "ON"
+        "DISABLE_AZTEC_VM": "ON",
+        "ENABLE_STACKTRACES": "ON"
       }
     },
     {
@@ -244,9 +259,6 @@
       "description": "Build with address sanitizer on clang20 with debugging information",
       "inherits": "debug",
       "binaryDir": "build-asan",
-      "environment": {
-        "CMAKE_BUILD_TYPE": "Debug"
-      },
       "cacheVariables": {
         "ENABLE_ASAN": "ON",
         "DISABLE_ASM": "ON"
@@ -279,9 +291,7 @@
       "binaryDir": "build-fuzzing",
       "cacheVariables": {
         "FUZZING": "ON",
-        "DISABLE_AZTEC_VM": "ON"
-      },
-      "environment": {
+        "DISABLE_AZTEC_VM": "ON",
         "CMAKE_BUILD_TYPE": "RelWithAssert"
       }
     },
@@ -294,9 +304,7 @@
       "cacheVariables": {
         "FUZZING": "ON",
         "DISABLE_AZTEC_VM": "ON",
-        "DISABLE_ASM": "ON"
-      },
-      "environment": {
+        "DISABLE_ASM": "ON",
         "CMAKE_BUILD_TYPE": "RelWithAssert"
       }
     },
@@ -311,9 +319,7 @@
         "FUZZING_SHOW_INFORMATION": "ON",
         "DISABLE_AZTEC_VM": "ON",
         "ENABLE_ASAN": "ON",
-        "DISABLE_ASM": "ON"
-      },
-      "environment": {
+        "DISABLE_ASM": "ON",
         "CMAKE_BUILD_TYPE": "RelWithAssert"
       }
     },
@@ -326,11 +332,11 @@
       "cacheVariables": {
         "FUZZING": "ON",
         "DISABLE_ASM": "ON",
-        "DISABLE_AZTEC_VM": "ON"
+        "DISABLE_AZTEC_VM": "ON",
+        "CMAKE_BUILD_TYPE": "RelWithAssert"
       },
       "environment": {
-        "CXXFLAGS": "-fprofile-instr-generate -fcoverage-mapping",
-        "CMAKE_BUILD_TYPE": "RelWithAssert"
+        "CXXFLAGS": "-fprofile-instr-generate -fcoverage-mapping"
       }
     },
     {
@@ -446,10 +452,8 @@
       "description": "Build for pthread enabled WASM",
       "inherits": "wasm",
       "binaryDir": "build-wasm-threads",
-      "environment": {
-        "CMAKE_BUILD_TYPE": "Release"
-      },
       "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
         "MULTITHREADING": "ON"
       }
     },
@@ -459,10 +463,8 @@
       "binaryDir": "build-wasm-threads-dbg",
       "description": "Build with wasi-sdk to create debug wasm",
       "inherits": "wasm",
-      "environment": {
-        "CMAKE_BUILD_TYPE": "Debug"
-      },
       "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
         "MULTITHREADING": "ON"
       }
     },
@@ -516,6 +518,11 @@
       "name": "clang20-no-avm",
       "inherits": "default",
       "configurePreset": "clang20-no-avm"
+    },
+    {
+      "name": "debug-fast-no-avm",
+      "inherits": "default",
+      "configurePreset": "debug-fast-no-avm"
     },
     {
       "name": "debug-no-avm",

--- a/barretenberg/cpp/CMakePresets.json
+++ b/barretenberg/cpp/CMakePresets.json
@@ -214,7 +214,7 @@
       "displayName": "Optimized debug build with Clang-20 (no AVM)",
       "description": "Build with globally installed Clang-20 in debug mode excluding the Aztec VM",
       "inherits": "debug-fast",
-      "binaryDir": "build-debug-no-avm",
+      "binaryDir": "build-debug-fast-no-avm",
       "cacheVariables": {
         "DISABLE_AZTEC_VM": "ON",
         "ENABLE_STACKTRACES": "ON"

--- a/barretenberg/cpp/CMakePresets.json
+++ b/barretenberg/cpp/CMakePresets.json
@@ -250,7 +250,8 @@
       "cacheVariables": {
         "ENABLE_ASAN": "ON",
         "DISABLE_AZTEC_VM": "ON",
-        "DISABLE_ASM": "ON"
+        "DISABLE_ASM": "ON",
+        "ENABLE_STACKTRACES": "OFF"
       }
     },
     {
@@ -261,7 +262,8 @@
       "binaryDir": "build-asan",
       "cacheVariables": {
         "ENABLE_ASAN": "ON",
-        "DISABLE_ASM": "ON"
+        "DISABLE_ASM": "ON",
+        "ENABLE_STACKTRACES": "OFF"
       }
     },
     {

--- a/barretenberg/cpp/cmake/backward-cpp.cmake
+++ b/barretenberg/cpp/cmake/backward-cpp.cmake
@@ -1,4 +1,4 @@
-if(CHECK_CIRCUIT_STACKTRACES)
+if(CHECK_CIRCUIT_STACKTRACES OR ENABLE_STACKTRACES)
     include(FetchContent)
 
     # Also requires one of: libbfd (gnu binutils), libdwarf, libdw (elfutils)

--- a/barretenberg/cpp/cmake/module.cmake
+++ b/barretenberg/cpp/cmake/module.cmake
@@ -57,7 +57,7 @@ function(barretenberg_module MODULE_NAME)
             ${TBB_IMPORTED_TARGETS}
         )
 
-        if(CHECK_CIRCUIT_STACKTRACES)
+        if(CHECK_CIRCUIT_STACKTRACES OR ENABLE_STACKTRACES)
             target_link_libraries(
                 ${MODULE_NAME}_objects
                 PUBLIC
@@ -108,7 +108,7 @@ function(barretenberg_module MODULE_NAME)
         )
         list(APPEND exe_targets ${MODULE_NAME}_tests)
 
-        if(CHECK_CIRCUIT_STACKTRACES)
+        if(CHECK_CIRCUIT_STACKTRACES OR ENABLE_STACKTRACES)
             target_link_libraries(
                 ${MODULE_NAME}_test_objects
                 PUBLIC
@@ -236,7 +236,7 @@ function(barretenberg_module MODULE_NAME)
                 ${TRACY_LIBS}
                 ${TBB_IMPORTED_TARGETS}
             )
-            if(CHECK_CIRCUIT_STACKTRACES)
+            if(CHECK_CIRCUIT_STACKTRACES OR ENABLE_STACKTRACES)
                 target_link_libraries(
                     ${BENCHMARK_NAME}_bench_objects
                     PUBLIC

--- a/barretenberg/cpp/src/CMakeLists.txt
+++ b/barretenberg/cpp/src/CMakeLists.txt
@@ -252,7 +252,7 @@ if(WASM)
         DEPENDS ${CMAKE_BINARY_DIR}/bin/barretenberg.wasm.gz
     )
 
-    if(CHECK_CIRCUIT_STACKTRACES)
+    if(CHECK_CIRCUIT_STACKTRACES OR ENABLE_STACKTRACES)
         target_link_libraries(
             barretenberg.wasm
             PUBLIC

--- a/barretenberg/cpp/src/barretenberg/bb/CMakeLists.txt
+++ b/barretenberg/cpp/src/barretenberg/bb/CMakeLists.txt
@@ -23,7 +23,7 @@ if (NOT(FUZZING))
         bb-cli-lib
         tracy_mem
     )
-    if(CHECK_CIRCUIT_STACKTRACES)
+    if(CHECK_CIRCUIT_STACKTRACES OR ENABLE_STACKTRACES)
         target_link_libraries(
             bb
             PUBLIC

--- a/barretenberg/cpp/src/barretenberg/env/throw_or_abort_impl.cpp
+++ b/barretenberg/cpp/src/barretenberg/env/throw_or_abort_impl.cpp
@@ -1,5 +1,8 @@
 #include "barretenberg/common/log.hpp"
 #include <stdexcept>
+#ifdef STACKTRACES
+#include <backward.hpp>
+#endif
 
 inline void abort_with_message [[noreturn]] (std::string const& err)
 {
@@ -10,6 +13,13 @@ inline void abort_with_message [[noreturn]] (std::string const& err)
 // Native implementation of throw_or_abort
 extern "C" void throw_or_abort_impl [[noreturn]] (const char* err)
 {
+
+#ifdef STACKTRACES
+    // Use backward library to print stack trace
+    backward::StackTrace trace;
+    trace.load_here(32);
+    backward::Printer{}.print(trace);
+#endif
 #ifndef BB_NO_EXCEPTIONS
     throw std::runtime_error(err);
 #else

--- a/build-images/src/Dockerfile
+++ b/build-images/src/Dockerfile
@@ -127,6 +127,9 @@ RUN apt update && \
         libc++-dev \
         libomp-dev \
         doxygen \
+        # C++ stack trace support
+        libdw-dev \
+        libelf-dev \
         # Node
         # WARNING: Need to downgrade to this version in the basebox below as well.
         nodejs=22.16.0-1nodesource1 \


### PR DESCRIPTION
Until the next rebuild of the base image, this means you do need to do:
```
sudo apt-get install libdw-dev libelf-dev
```
on ubuntu (e.g. our mainframe accounts)
to be able to build debug or debug-fast. but now the recommended flow is to always use debug-fast, and you'll always have a detailed stack trace