### PR TITLE
fix: fixes to AVM tracegen for rollbacks to SETUP snapshot and for SSTORE unhappy path

### DIFF
--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/execution_trace.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/execution_trace.cpp
@@ -605,7 +605,12 @@ void ExecutionTraceBuilder::process(
                               { C::execution_enqueued_call_end, !has_parent ? 1 : 0 },
                               { C::execution_nested_exit_call, has_parent ? 1 : 0 },
                           } });
-            } else if (exec_opcode == ExecutionOpCode::GETENVVAR) {
+            }
+            // Separate if-statement for opcodes.
+            // This cannot be an else-if chained to the above,
+            // because `sel_exit_call` can happen on any opcode
+            // and we still need to tracegen the opcode-specific logic.
+            if (exec_opcode == ExecutionOpCode::GETENVVAR) {
                 assert(ex_event.addressing_event.resolution_info.size() == 2 &&
                        "GETENVVAR should have exactly two resolved operands (envvar enum and output)");
                 // rop[1] is the envvar enum

--- a/yarn-project/simulator/src/public/avm/avm_simulator.test.ts
+++ b/yarn-project/simulator/src/public/avm/avm_simulator.test.ts
@@ -710,9 +710,10 @@ describe('AVM simulator: transpiled Noir contracts', () => {
         expect(results.reverted).toBe(true);
         expect(results.revertReason?.message).toMatch(/Attempted to emit duplicate nullifier/);
 
-        // Nullifier should be traced exactly once
-        expect(trace.traceNewNullifier).toHaveBeenCalledTimes(1);
-        expect(trace.traceNewNullifier).toHaveBeenCalledWith(siloedNullifier0);
+        // Nullifier should still be traced twice. Fails after second trace.
+        expect(trace.traceNewNullifier).toHaveBeenCalledTimes(2);
+        expect(trace.traceNewNullifier).toHaveBeenNthCalledWith(1, siloedNullifier0);
+        expect(trace.traceNewNullifier).toHaveBeenNthCalledWith(2, siloedNullifier0);
       });
     });
 

--- a/yarn-project/simulator/src/public/avm/opcodes/accrued_substate.test.ts
+++ b/yarn-project/simulator/src/public/avm/opcodes/accrued_substate.test.ts
@@ -204,8 +204,9 @@ describe('Accrued Substate', () => {
           `Attempted to emit duplicate nullifier ${value0} (contract address: ${address}).`,
         ),
       );
-      expect(trace.traceNewNullifier).toHaveBeenCalledTimes(1);
-      expect(trace.traceNewNullifier).toHaveBeenCalledWith(siloedNullifier0);
+      expect(trace.traceNewNullifier).toHaveBeenCalledTimes(2);
+      expect(trace.traceNewNullifier).toHaveBeenNthCalledWith(1, siloedNullifier0);
+      expect(trace.traceNewNullifier).toHaveBeenNthCalledWith(2, siloedNullifier0);
     });
 
     it('Nullifier collision reverts (nullifier exists in host state)', async () => {
@@ -216,7 +217,8 @@ describe('Accrued Substate', () => {
           `Attempted to emit duplicate nullifier ${value0} (contract address: ${address}).`,
         ),
       );
-      expect(trace.traceNewNullifier).toHaveBeenCalledTimes(0); // the only attempt should fail before tracing
+      expect(trace.traceNewNullifier).toHaveBeenCalledTimes(1); // fails, but after tracing
+      expect(trace.traceNewNullifier).toHaveBeenCalledWith(siloedNullifier0);
     });
   });
 

--- a/yarn-project/simulator/src/public/state_manager/state_manager.ts
+++ b/yarn-project/simulator/src/public/state_manager/state_manager.ts
@@ -138,6 +138,8 @@ export class PublicPersistableStateManager {
   public async writeStorage(contractAddress: AztecAddress, slot: Fr, value: Fr, protocolWrite = false): Promise<void> {
     this.log.trace(`Storage write (address=${contractAddress}, slot=${slot}): value=${value}`);
 
+    await this.trace.tracePublicStorageWrite(contractAddress, slot, value, protocolWrite);
+
     if (this.doMerkleOperations) {
       // write to native merkle trees
       await this.treesDB.storageWrite(contractAddress, slot, value);
@@ -145,8 +147,6 @@ export class PublicPersistableStateManager {
       // Cache storage writes for later reference/reads
       this.publicStorage.write(contractAddress, slot, value);
     }
-
-    await this.trace.tracePublicStorageWrite(contractAddress, slot, value, protocolWrite);
   }
 
   public isStorageCold(contractAddress: AztecAddress, slot: Fr): boolean {
@@ -217,10 +217,10 @@ export class PublicPersistableStateManager {
    */
   public async writeUniqueNoteHash(uniqueNoteHash: Fr): Promise<void> {
     this.log.trace(`noteHashes += @${uniqueNoteHash}.`);
+    this.trace.traceNewNoteHash(uniqueNoteHash);
     if (this.doMerkleOperations) {
       await this.treesDB.writeNoteHash(uniqueNoteHash);
     }
-    this.trace.traceNewNoteHash(uniqueNoteHash);
   }
 
   /**
@@ -262,6 +262,8 @@ export class PublicPersistableStateManager {
   public async writeSiloedNullifier(siloedNullifier: Fr) {
     this.log.trace(`Inserting siloed nullifier=${siloedNullifier}`);
 
+    this.trace.traceNewNullifier(siloedNullifier);
+
     if (this.doMerkleOperations) {
       const exists = await this.treesDB.checkNullifierExists(siloedNullifier);
 
@@ -277,8 +279,6 @@ export class PublicPersistableStateManager {
       // Cache pending nullifiers for later access
       await this.nullifiers.append(siloedNullifier);
     }
-
-    this.trace.traceNewNullifier(siloedNullifier);
   }
 
   /**


### PR DESCRIPTION
1. TX tracegen needs to roll back `propagated_state` to the `end_setup_snapshot` after a revert, so that any padding rows are filled with the post-rollback state.
2. Execution tracegen must perform per-opcode logic even if `sel_exit_call == 1`. This ensures that unhappy-path tracegen happens for opcodes that error.
3. TS simulator should trace world state ops before performing them to ensure that any side-effect-limits are hit _before_ the state op. This change aligns TS with C++ simulation.
