### PR TITLE
bug: PG works with bad first circuit!

### DIFF
--- a/barretenberg/cpp/src/barretenberg/client_ivc/mock_circuit_producer.hpp
+++ b/barretenberg/cpp/src/barretenberg/client_ivc/mock_circuit_producer.hpp
@@ -191,6 +191,18 @@ class PrivateFunctionExecutionMockCircuitProducer {
         if (is_kernel) {
             ivc.complete_kernel_circuit_logic(circuit);
         } else {
+            // add bad gate
+            info("adding bad gate to circuit");
+            fr a = fr::random_element(&engine);
+            fr b = fr::random_element(&engine);
+            fr c = fr::random_element(&engine);
+            fr d = a + b + c + 1;
+            uint32_t a_idx = circuit.add_variable(a);
+            uint32_t b_idx = circuit.add_variable(b);
+            uint32_t c_idx = circuit.add_variable(c);
+            uint32_t d_idx = circuit.add_variable(d);
+
+            circuit.create_big_add_gate({ a_idx, b_idx, c_idx, d_idx, fr(1), fr(1), fr(1), fr(-1), fr(0) });
             stdlib::recursion::PairingPoints<ClientCircuit>::add_default_to_public_inputs(circuit);
         }
         return circuit;

--- a/barretenberg/cpp/src/barretenberg/flavor/mega_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/mega_flavor.hpp
@@ -75,21 +75,21 @@ class MegaFlavor {
     // Note: made generic for use in MegaRecursive.
     template <typename FF>
     using Relations_ = std::tuple<bb::UltraArithmeticRelation<FF>,
-                                  bb::UltraPermutationRelation<FF>,
-                                  bb::LogDerivLookupRelation<FF>,
+                                  //   bb::UltraPermutationRelation<FF>,
+                                  //   bb::LogDerivLookupRelation<FF>,
                                   bb::DeltaRangeConstraintRelation<FF>,
                                   bb::EllipticRelation<FF>,
                                   bb::MemoryRelation<FF>,
                                   bb::NonNativeFieldRelation<FF>,
                                   bb::EccOpQueueRelation<FF>,
-                                  bb::DatabusLookupRelation<FF>,
+                                  //   bb::DatabusLookupRelation<FF>,
                                   bb::Poseidon2ExternalRelation<FF>,
                                   bb::Poseidon2InternalRelation<FF>>;
     using Relations = Relations_<FF>;
 
     static constexpr size_t MAX_PARTIAL_RELATION_LENGTH = compute_max_partial_relation_length<Relations>();
     static constexpr size_t MAX_TOTAL_RELATION_LENGTH = compute_max_total_relation_length<Relations>();
-    static_assert(MAX_TOTAL_RELATION_LENGTH == 11);
+    static_assert(MAX_TOTAL_RELATION_LENGTH == 7);
     // BATCHED_RELATION_PARTIAL_LENGTH = algebraic degree of sumcheck relation *after* multiplying by the `pow_zeta`
     // random polynomial e.g. For \sum(x) [A(x) * B(x) + C(x)] * PowZeta(X), relation length = 2 and random relation
     // length = 3

--- a/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover_impl.hpp
@@ -57,9 +57,10 @@ std::tuple<std::vector<typename Flavor::FF>, Polynomial<typename Flavor::FF>> Pr
     const FF delta = transcript->template get_challenge<FF>("delta");
     const std::vector<FF> deltas = compute_round_challenge_pows(CONST_PG_LOG_N, delta);
     // An honest prover with valid initial key computes that the perturbator is 0 in the first round
-    const Polynomial<FF> perturbator = accumulator->is_accumulator
-                                           ? pg_internal.compute_perturbator(accumulator, deltas)
-                                           : Polynomial<FF>(CONST_PG_LOG_N + 1);
+    // const Polynomial<FF> perturbator = accumulator->is_accumulator
+    //                                        ? pg_internal.compute_perturbator(accumulator, deltas)
+    //                                        : Polynomial<FF>(CONST_PG_LOG_N + 1);
+    const Polynomial<FF> perturbator = pg_internal.compute_perturbator(accumulator, deltas);
     // Prover doesn't send the constant coefficient of F because this is supposed to be equal to the target sum of
     // the accumulator which the folding verifier has from the previous iteration.
     // TODO(https://github.com/AztecProtocol/barretenberg/issues/1087): Verifier circuit for first IVC step is


### PR DESCRIPTION
I recently discovered that we were setting gate challenges to all 0s in the first accumulator. This arose because in papers like Nova and stackproofs (that uses PG), it was described that the initial accumulator, which was intended as a dummy accumulator, would set its gate challenges to all 0s. However, in practice, our initial accumulator is not a dummy one, but rather it represents the first circuit - this is a significant optimization over said papers as the folding prover is not needed for the first circuit. This PR is a proof of concept that shows that we can get away with incorrect gates in the first circuit, exploiting the fact that the gate challenges are all 0s.