### PR TITLE
feat: create test-network-scenarios.yml

### DIFF
--- a/.github/.gitignore
+++ b/.github/.gitignore
@@ -1,1 +1,2 @@
 .secrets
+.act-tool-cache

--- a/.github/local_workflow.sh
+++ b/.github/local_workflow.sh
@@ -32,10 +32,13 @@ args=("$@")
 
 SA_KEY_JSON=$(cat "$GOOGLE_APPLICATION_CREDENTIALS")
 
+mkdir -p $REPO_ROOT/.github/.act-tool-cache
+
 act workflow_dispatch -j $workflow_name \
+  --env RUNNER_TOOL_CACHE=/work/toolcache \
   -s GITHUB_TOKEN="$(gh auth token)" \
   -s GCP_SA_KEY="$SA_KEY_JSON" \
   -s KUBECONFIG_B64="$(cat $HOME/.kube/config | base64 -w0)" \
-  --container-options "--user $(id -u):$(id -g)" \
+  --container-options "-v $REPO_ROOT/.github/.act-tool-cache:/work/toolcache --user $(id -u):$(id -g)" \
   --bind \
   --directory $REPO_ROOT "${args[@]}"

--- a/.github/workflows/ci3.yml
+++ b/.github/workflows/ci3.yml
@@ -149,6 +149,25 @@ jobs:
         if: steps.ci_cache.outputs.cache-hit != 'true'
         run: echo "success" > ci-success.txt
 
+      - name: Get Semver from Tag
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+        id: semver
+        run: |
+          semver="${{ github.ref_name }}"
+          # Remove 'v' prefix if present (e.g., v1.2.3 -> 1.2.3)
+          semver=${semver#v}
+          # Extract major version (e.g., 1.2.3 -> 1)
+          major_version=${semver%%.*}
+          echo "semver=$semver" >> $GITHUB_OUTPUT
+          echo "major_version=$major_version" >> $GITHUB_OUTPUT
+
+      - name: Trigger Network Deployments
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+        uses: peter-evans/repository-dispatch@0ee9de00feb82e6165438c503f0bc29f628b8317
+        with:
+          event-type: network-deployments
+          client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}", "semver": "${{ steps.semver.outputs.semver }}", "major_version": "${{ steps.semver.outputs.major_version }}"}'
+
       # If we have passed CI and labelled with ci-squash-and-merge, squash the PR.
       # This will rerun CI on the squash commit - but is intended to be a no-op due to caching.
       - name: CI Squash and Merge

--- a/.github/workflows/deploy-scenario-network.yml
+++ b/.github/workflows/deploy-scenario-network.yml
@@ -38,7 +38,7 @@ on:
         required: true
       KUBECONFIG_B64:
         description: The base64 encoded kubeconfig
-        required: true
+        required: false
 
   workflow_dispatch:
     inputs:
@@ -122,7 +122,7 @@ jobs:
       aztec_slashing_round_size: 10
       aztec_governance_proposer_quorum: 6
       aztec_governance_proposer_round_size: 10
-      aztec_mana_target: 1000000
+      aztec_mana_target: 1000000000
       aztec_proving_cost_per_mana: 100
     secrets:
       GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}

--- a/.github/workflows/test-network-scenarios.yml
+++ b/.github/workflows/test-network-scenarios.yml
@@ -1,0 +1,103 @@
+# CI for Aztec Network Scenarios.
+# Effectively runs CI_SCENARIO_TEST=1 spartan/bootstrap.sh test
+# Triggered by network-deployments event, which is emitted by ci3.yml when a tagged release passes "normal" CI.
+#
+name: Test Network Scenarios
+
+on:
+  repository_dispatch:
+    types:
+      - network-deployments
+
+concurrency:
+  group: network-scenarios-${{ github.event.client_payload.major_version }}
+  cancel-in-progress: true
+
+jobs:
+  test_network_scenarios_dispatch_deploy_scenario_network:
+    uses: ./.github/workflows/deploy-scenario-network.yml
+    with:
+      cluster: aztec-gke-private
+      namespace: v${{ github.event.client_payload.major_version }}-scenario
+      ref: ${{ github.event.client_payload.ref }}
+      aztec_docker_image: "aztecprotocol/aztec:${{ github.event.client_payload.semver }}"
+      devnet_mnemonic: "test test test test test test test test test test test junk"
+      rollup_deployment_mnemonic: "test test test test test test test test test test test junk"
+    secrets:
+      GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
+
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      #############
+      # Prepare Env
+      #############
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+
+      - name: CI Network Scenario Override
+        run: echo "CI_NETWORK_SCENARIO=1" >> $GITHUB_ENV
+
+      - name: Compute Target Branch
+        id: target_branch
+        run: |
+          if [ "${{ github.event_name }}" == "merge_group" ]; then
+            target_branch=${{ github.event.merge_group.base_ref }}
+          elif [ "${{ github.event_name }}" == "pull_request" ]; then
+            target_branch=${{ github.event.pull_request.base.ref }}
+          else
+            target_branch=${{ github.ref_name }}
+          fi
+          target_branch=${target_branch#refs/heads/}
+          echo "target_branch=$target_branch" >> $GITHUB_OUTPUT
+          echo "TARGET_BRANCH=${target_branch}" >> $GITHUB_ENV
+
+      - name: Setup
+        run: |
+          # Ensure we can SSH into the spot instances we request.
+          mkdir -p ~/.ssh
+          echo ${{ secrets.BUILD_INSTANCE_SSH_KEY }} | base64 --decode > ~/.ssh/build_instance_key
+          chmod 600 ~/.ssh/build_instance_key
+          sudo apt install -y --no-install-recommends redis-tools parallel
+
+      - name: Prepare GCP key
+        env:
+          GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
+        run: |
+          echo "$GCP_SA_KEY" | base64 -w 0 > gcp_sa_key.b64
+          echo "GCP_SA_KEY_B64=$(cat gcp_sa_key.b64)" >> $GITHUB_ENV
+
+      - name: Get Tree Hash
+        run: echo "TREE_HASH=$(git rev-parse HEAD^{tree})" >> $GITHUB_ENV
+
+      - name: Check CI Cache
+        id: ci_cache
+        uses: actions/cache@v3
+        with:
+          path: ci-success.txt
+          key: ci-network-scenario-${{ env.TREE_HASH }}
+
+      #############
+      # Run
+      #############
+      - name: Run
+        if: steps.ci_cache.outputs.cache-hit != 'true'
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          GITHUB_TOKEN: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
+          RUN_ID: ${{ github.run_id }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          # Nightly test env vars.
+          GCP_SA_KEY_B64: ${{ env.GCP_SA_KEY_B64 }}
+          GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+          NAMESPACE: "v${{ github.event.client_payload.major_version }}-scenario"
+        run: |
+          exec ./ci.sh network-scenario
+
+      - name: Save CI Success
+        if: steps.ci_cache.outputs.cache-hit != 'true'
+        run: echo "success" > ci-success.txt

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -438,6 +438,13 @@ case "$cmd" in
     test
     release
     ;;
+  "ci-network-scenario")
+    export CI=1
+    export USE_TEST_CACHE=1
+    export CI_SCENARIO_TEST=1
+    build
+    spartan/bootstrap.sh test
+    ;;
   "ci-release")
     export CI=1
     export USE_TEST_CACHE=1

--- a/ci.sh
+++ b/ci.sh
@@ -141,6 +141,17 @@ case "$cmd" in
       'run x4-full amd64 ci-full' \
       'run a1-fast arm64 ci-fast' | DUP=1 cache_log "Merge queue CI run" $RUN_ID
     ;;
+  "network-scenario")
+    prep_vars
+    # Spin up ec2 instance and run the network scenario flow.
+    run() {
+      JOB_ID=$1 INSTANCE_POSTFIX=$1 ARCH=$2 exec denoise "bootstrap_ec2 './bootstrap.sh ci-network-scenario'"
+    }
+    export -f run
+    # We need to run the network scenario flow on both x86 and arm64.
+    parallel --termseq 'TERM,10000' --tagstring '{= $_=~s/run (\w+).*/$1/; =}' --line-buffered --halt now,fail=1 ::: \
+      'run x-network-scenario amd64' | DUP=1 cache_log "Network scenario CI run" $RUN_ID
+    ;;
   "nightly")
     prep_vars
     # Spin up ec2 instance and run the nightly flow.

--- a/ci3/bootstrap_ec2
+++ b/ci3/bootstrap_ec2
@@ -252,6 +252,7 @@ function run {
         -e NPM_TOKEN=${NPM_TOKEN:-} \
         -e SLACK_BOT_TOKEN=${SLACK_BOT_TOKEN:-} \
         -e AWS_TOKEN=\$aws_token \
+        -e NAMESPACE=${NAMESPACE:-} \
         -v /tmp/gcp-key.json:/tmp/gcp-key.json:ro \
         --pids-limit=32768 \
         aztecprotocol/devbox:3.0 bash -c $(printf '%q' "$container_script")

--- a/ci3/source_refname
+++ b/ci3/source_refname
@@ -37,6 +37,7 @@ if [ -z "${CI_FULL:-}" ]; then
   fi
 fi
 export CI_NIGHTLY="${CI_NIGHTLY:-0}"
+export CI_SCENARIO_TEST="${CI_SCENARIO_TEST:-0}"
 
 if [ -z "${COMMIT_HASH:-}" ]; then
   export COMMIT_HASH=$(git rev-parse HEAD)

--- a/spartan/bootstrap.sh
+++ b/spartan/bootstrap.sh
@@ -61,10 +61,10 @@ function test_cmds {
   # TODO figure out why these take long sometimes.
   # echo "$hash ./spartan/bootstrap.sh test-kind-smoke"
 
-  if [ "$CI_NIGHTLY" -eq 1 ]; then
-    NIGHTLY_NS=nightly-$(date -u +%Y%m%d)
-    echo "$hash:TIMEOUT=20m FRESH_INSTALL=no-deploy NAMESPACE=$NIGHTLY_NS ./spartan/bootstrap.sh test-gke-transfer reth"
-    echo "$hash:TIMEOUT=20m FRESH_INSTALL=no-deploy NAMESPACE=$NIGHTLY_NS ./spartan/bootstrap.sh test-gke-transfer geth"
+  # if [ "$CI_NIGHTLY" -eq 1 ]; then
+  #   NIGHTLY_NS=nightly-$(date -u +%Y%m%d)
+  #   echo "$hash:TIMEOUT=20m FRESH_INSTALL=no-deploy NAMESPACE=$NIGHTLY_NS ./spartan/bootstrap.sh test-gke-transfer reth"
+  #   echo "$hash:TIMEOUT=20m FRESH_INSTALL=no-deploy NAMESPACE=$NIGHTLY_NS ./spartan/bootstrap.sh test-gke-transfer geth"
 
     # Nethermind test can be enabled once https://github.com/NethermindEth/nethermind/pull/8897 is released
     # echo "$hash:TIMEOUT=20m FRESH_INSTALL=no-deploy NAMESPACE=$NIGHTLY_NS ./spartan/bootstrap.sh test-gke-transfer nethermind"
@@ -79,6 +79,16 @@ function test_cmds {
     # TODO(#12791) re-enable
     # echo "$hash:TIMEOUT=50m ./spartan/bootstrap.sh test-kind-4epochs-sepolia"
     # echo "$hash:TIMEOUT=30m ./spartan/bootstrap.sh test-prod-deployment"
+  # fi
+  if [ "$CI_SCENARIO_TEST" -eq 1 ]; then
+    local run_test_script="yarn-project/end-to-end/scripts/run_test.sh"
+    NAMESPACE=${NAMESPACE:-"scenario"}
+    K8S_CLUSTER=${K8S_CLUSTER:-"aztec-gke-private"}
+    PROJECT_ID=${PROJECT_ID:-"testnet-440309"}
+    REGION=${REGION:-"us-west1-a"}
+    local env_vars="NAMESPACE=$NAMESPACE K8S_CLUSTER=$K8S_CLUSTER PROJECT_ID=$PROJECT_ID REGION=$REGION"
+    echo "$hash:TIMEOUT=20m $env_vars $run_test_script simple src/spartan/smoke.test.ts"
+    echo "$hash:TIMEOUT=20m $env_vars $run_test_script simple src/spartan/transfer.test.ts"
   fi
 }
 
@@ -105,7 +115,19 @@ function stop_env {
 
 function test {
   echo_header "spartan test"
-  test_cmds | filter_test_cmds | parallelize
+  if [ "$CI" -eq 1 ]; then
+    echo "Activating service account"
+    gcloud auth activate-service-account --key-file=/tmp/gcp-key.json
+    gcloud config set project "$GCP_PROJECT_ID"
+  fi
+
+  if [ "$CI_SCENARIO_TEST" -eq 1 ]; then
+    echo "Running network scenario tests sequentially"
+    test_cmds | filter_test_cmds
+  else
+    echo "Running spartan test"
+    test_cmds | filter_test_cmds | parallelize
+  fi
 }
 
 case "$cmd" in

--- a/spartan/terraform/deploy-aztec-infra/main.tf
+++ b/spartan/terraform/deploy-aztec-infra/main.tf
@@ -188,6 +188,4 @@ resource "google_compute_address" "rpc_ingress" {
   provider     = google
   name         = "${var.NAMESPACE}-${var.RELEASE_PREFIX}-rpc-ingress"
   address_type = "EXTERNAL"
-
-
 }

--- a/yarn-project/end-to-end/src/spartan/1tps.test.ts
+++ b/yarn-project/end-to-end/src/spartan/1tps.test.ts
@@ -1,179 +1,179 @@
-// TODO(#11825) finalize (probably once we have nightly tests setup for GKE) & enable in bootstrap.sh
-import {
-  type PXE,
-  ProvenTx,
-  SentTx,
-  SponsoredFeePaymentMethod,
-  Tx,
-  readFieldCompressedString,
-  sleep,
-} from '@aztec/aztec.js';
-import { Fr } from '@aztec/foundation/fields';
-import { createLogger } from '@aztec/foundation/log';
-import { TokenContract } from '@aztec/noir-contracts.js/Token';
+// // TODO(#11825) finalize (probably once we have nightly tests setup for GKE) & enable in bootstrap.sh
+// import {
+//   type PXE,
+//   ProvenTx,
+//   SentTx,
+//   SponsoredFeePaymentMethod,
+//   Tx,
+//   readFieldCompressedString,
+//   sleep,
+// } from '@aztec/aztec.js';
+// import { Fr } from '@aztec/foundation/fields';
+// import { createLogger } from '@aztec/foundation/log';
+// import { TokenContract } from '@aztec/noir-contracts.js/Token';
 
-import { jest } from '@jest/globals';
-import type { ChildProcess } from 'child_process';
+// import { jest } from '@jest/globals';
+// import type { ChildProcess } from 'child_process';
 
-import { getSponsoredFPCAddress } from '../fixtures/utils.js';
-import {
-  type TestWallets,
-  deploySponsoredTestWallets,
-  setupTestWalletsWithTokens,
-  startCompatiblePXE,
-} from './setup_test_wallets.js';
-import { isK8sConfig, setupEnvironment, startPortForward } from './utils.js';
+// import { getSponsoredFPCAddress } from '../fixtures/utils.js';
+// import {
+//   type TestWallets,
+//   deploySponsoredTestWallets,
+//   setupTestWalletsWithTokens,
+//   startCompatiblePXE,
+// } from './setup_test_wallets.js';
+// import { setupEnvironment, startPortForward } from './utils.js';
 
-const config = setupEnvironment(process.env);
+// const config = setupEnvironment(process.env);
 
-describe('token transfer test', () => {
-  jest.setTimeout(10 * 60 * 2000); // 20 minutes
+// describe('token transfer test', () => {
+//   jest.setTimeout(10 * 60 * 2000); // 20 minutes
 
-  const logger = createLogger(`e2e:spartan-test:transfer`);
-  const MINT_AMOUNT = 1000n;
+//   const logger = createLogger(`e2e:spartan-test:transfer`);
+//   const MINT_AMOUNT = 1000n;
 
-  const ROUNDS = 1n;
+//   const ROUNDS = 1n;
 
-  let testWallets: TestWallets;
-  const forwardProcesses: ChildProcess[] = [];
-  let pxe: PXE;
-  let cleanup: undefined | (() => Promise<void>);
+//   let testWallets: TestWallets;
+//   const forwardProcesses: ChildProcess[] = [];
+//   let pxe: PXE;
+//   let cleanup: undefined | (() => Promise<void>);
 
-  afterAll(async () => {
-    await cleanup?.();
-    forwardProcesses.forEach(p => p.kill());
-  });
+//   afterAll(async () => {
+//     await cleanup?.();
+//     forwardProcesses.forEach(p => p.kill());
+//   });
 
-  beforeAll(async () => {
-    if (isK8sConfig(config)) {
-      const { process: sequencerProcess, port: sequencerPort } = await startPortForward({
-        resource: `svc/${config.INSTANCE_NAME}-aztec-network-validator`,
-        namespace: config.NAMESPACE,
-        containerPort: config.CONTAINER_SEQUENCER_PORT,
-      });
-      forwardProcesses.push(sequencerProcess);
-      const NODE_URL = `http://127.0.0.1:${sequencerPort}`;
+//   beforeAll(async () => {
+//     if (isK8sConfig(config)) {
+//       const { process: sequencerProcess, port: sequencerPort } = await startPortForward({
+//         resource: `svc/${config.INSTANCE_NAME}-aztec-network-validator`,
+//         namespace: config.NAMESPACE,
+//         containerPort: config.CONTAINER_SEQUENCER_PORT,
+//       });
+//       forwardProcesses.push(sequencerProcess);
+//       const NODE_URL = `http://127.0.0.1:${sequencerPort}`;
 
-      ({ pxe, cleanup } = await startCompatiblePXE(NODE_URL, ['1', 'true'].includes(config.AZTEC_REAL_PROOFS), logger));
-      testWallets = await deploySponsoredTestWallets(pxe, MINT_AMOUNT, logger);
-    } else {
-      const PXE_URL = config.PXE_URL;
-      testWallets = await setupTestWalletsWithTokens(PXE_URL, MINT_AMOUNT, logger);
-    }
-    expect(ROUNDS).toBeLessThanOrEqual(MINT_AMOUNT);
-  });
+//       ({ pxe, cleanup } = await startCompatiblePXE(NODE_URL, ['1', 'true'].includes(config.AZTEC_REAL_PROOFS), logger));
+//       testWallets = await deploySponsoredTestWallets(pxe, MINT_AMOUNT, logger);
+//     } else {
+//       const PXE_URL = config.PXE_URL;
+//       testWallets = await setupTestWalletsWithTokens(PXE_URL, MINT_AMOUNT, logger);
+//     }
+//     expect(ROUNDS).toBeLessThanOrEqual(MINT_AMOUNT);
+//   });
 
-  it('can get info', async () => {
-    const name = readFieldCompressedString(
-      await testWallets.tokenAdminWallet.methods.private_get_name().simulate({ from: testWallets.tokenAdminAddress }),
-    );
-    expect(name).toBe(testWallets.tokenName);
-  });
+//   it('can get info', async () => {
+//     const name = readFieldCompressedString(
+//       await testWallets.tokenAdminWallet.methods.private_get_name().simulate({ from: testWallets.tokenAdminAddress }),
+//     );
+//     expect(name).toBe(testWallets.tokenName);
+//   });
 
-  it('can transfer 1 token privately and publicly', async () => {
-    const recipient = testWallets.recipientWallet.getAddress();
-    const transferAmount = 1n;
+//   it('can transfer 1 token privately and publicly', async () => {
+//     const recipient = testWallets.recipientWallet.getAddress();
+//     const transferAmount = 1n;
 
-    for (const w of testWallets.wallets) {
-      expect(MINT_AMOUNT).toBe(
-        await testWallets.tokenAdminWallet.methods
-          .balance_of_public(w.getAddress())
-          .simulate({ from: testWallets.tokenAdminAddress }),
-      );
-    }
+//     for (const w of testWallets.wallets) {
+//       expect(MINT_AMOUNT).toBe(
+//         await testWallets.tokenAdminWallet.methods
+//           .balance_of_public(w.getAddress())
+//           .simulate({ from: testWallets.tokenAdminAddress }),
+//       );
+//     }
 
-    expect(0n).toBe(
-      await testWallets.tokenAdminWallet.methods
-        .balance_of_public(recipient)
-        .simulate({ from: testWallets.tokenAdminAddress }),
-    );
+//     expect(0n).toBe(
+//       await testWallets.tokenAdminWallet.methods
+//         .balance_of_public(recipient)
+//         .simulate({ from: testWallets.tokenAdminAddress }),
+//     );
 
-    // For each round, make both private and public transfers
-    // for (let i = 1n; i <= ROUNDS; i++) {
-    //   const interactions = await Promise.all([
-    //     ...testWallets.wallets.map(async w =>
-    //       (
-    //         await TokenContract.at(testWallets.tokenAddress, w)
-    //       ).methods.transfer_in_public(w.getAddress(), recipient, transferAmount, 0),
-    //     ),
-    //   ]);
+//     // For each round, make both private and public transfers
+//     // for (let i = 1n; i <= ROUNDS; i++) {
+//     //   const interactions = await Promise.all([
+//     //     ...testWallets.wallets.map(async w =>
+//     //       (
+//     //         await TokenContract.at(testWallets.tokenAddress, w)
+//     //       ).methods.transfer_in_public(w.getAddress(), recipient, transferAmount, 0),
+//     //     ),
+//     //   ]);
 
-    //   const txs = await Promise.all(interactions.map(async i => await i.prove()));
+//     //   const txs = await Promise.all(interactions.map(async i => await i.prove()));
 
-    //   await Promise.all(txs.map(t => t.send().wait({ timeout: 600 })));
-    // }
+//     //   await Promise.all(txs.map(t => t.send().wait({ timeout: 600 })));
+//     // }
 
-    const wallet = testWallets.wallets[0];
+//     const wallet = testWallets.wallets[0];
 
-    const baseTx = await (await TokenContract.at(testWallets.tokenAddress, wallet)).methods
-      .transfer_in_public(wallet.getAddress(), recipient, transferAmount, 0)
-      .prove({
-        from: testWallets.tokenAdminAddress,
-        fee: { paymentMethod: new SponsoredFeePaymentMethod(await getSponsoredFPCAddress()) },
-      });
+//     const baseTx = await (await TokenContract.at(testWallets.tokenAddress, wallet)).methods
+//       .transfer_in_public(wallet.getAddress(), recipient, transferAmount, 0)
+//       .prove({
+//         from: testWallets.tokenAdminAddress,
+//         fee: { paymentMethod: new SponsoredFeePaymentMethod(await getSponsoredFPCAddress()) },
+//       });
 
-    const txs: ProvenTx[] = [];
-    for (let i = 0; i < 20; i++) {
-      const clonedTxData = Tx.clone(baseTx);
+//     const txs: ProvenTx[] = [];
+//     for (let i = 0; i < 20; i++) {
+//       const clonedTxData = Tx.clone(baseTx);
 
-      // Modify the first nullifier to make it unique
-      const nullifiers = clonedTxData.data.getNonEmptyNullifiers();
-      if (nullifiers.length > 0) {
-        // Create a new nullifier by adding the index to the original
-        const newNullifier = nullifiers[0].add(Fr.fromString(i.toString()));
-        // Replace the first nullifier with our new unique one
-        if (clonedTxData.data.forRollup) {
-          clonedTxData.data.forRollup.end.nullifiers[0] = newNullifier;
-        } else if (clonedTxData.data.forPublic) {
-          clonedTxData.data.forPublic.nonRevertibleAccumulatedData.nullifiers[0] = newNullifier;
-        }
-      }
+//       // Modify the first nullifier to make it unique
+//       const nullifiers = clonedTxData.data.getNonEmptyNullifiers();
+//       if (nullifiers.length > 0) {
+//         // Create a new nullifier by adding the index to the original
+//         const newNullifier = nullifiers[0].add(Fr.fromString(i.toString()));
+//         // Replace the first nullifier with our new unique one
+//         if (clonedTxData.data.forRollup) {
+//           clonedTxData.data.forRollup.end.nullifiers[0] = newNullifier;
+//         } else if (clonedTxData.data.forPublic) {
+//           clonedTxData.data.forPublic.nonRevertibleAccumulatedData.nullifiers[0] = newNullifier;
+//         }
+//       }
 
-      const clonedTx = new ProvenTx(wallet, clonedTxData, []);
-      txs.push(clonedTx);
-    }
+//       const clonedTx = new ProvenTx(wallet, clonedTxData, []);
+//       txs.push(clonedTx);
+//     }
 
-    const sentTxs: SentTx[] = [];
+//     const sentTxs: SentTx[] = [];
 
-    // dump all txs at requested TPS
-    const TPS = 1;
-    logger.info(`Sending ${txs.length} txs at a rate of ${TPS} tx/s`);
-    while (txs.length > 0) {
-      const start = performance.now();
+//     // dump all txs at requested TPS
+//     const TPS = 1;
+//     logger.info(`Sending ${txs.length} txs at a rate of ${TPS} tx/s`);
+//     while (txs.length > 0) {
+//       const start = performance.now();
 
-      const chunk = txs.splice(0, TPS);
-      sentTxs.push(...chunk.map(tx => tx.send()));
-      logger.info(`Sent txs: [${(await Promise.all(chunk.map(tx => tx.getTxHash()))).map(h => h.toString())}]`);
+//       const chunk = txs.splice(0, TPS);
+//       sentTxs.push(...chunk.map(tx => tx.send()));
+//       logger.info(`Sent txs: [${(await Promise.all(chunk.map(tx => tx.getTxHash()))).map(h => h.toString())}]`);
 
-      const end = performance.now();
-      const delta = end - start;
-      if (1000 - delta > 0) {
-        await sleep(1000 - delta);
-      }
-    }
+//       const end = performance.now();
+//       const delta = end - start;
+//       if (1000 - delta > 0) {
+//         await sleep(1000 - delta);
+//       }
+//     }
 
-    await Promise.all(
-      sentTxs.map(async sentTx => {
-        await sentTx.wait({ timeout: 600 });
-        const receipt = await sentTx.getReceipt();
-        logger.info(`tx ${receipt.txHash} included in block: ${receipt.blockNumber}`);
-      }),
-    );
+//     await Promise.all(
+//       sentTxs.map(async sentTx => {
+//         await sentTx.wait({ timeout: 600 });
+//         const receipt = await sentTx.getReceipt();
+//         logger.info(`tx ${receipt.txHash} included in block: ${receipt.blockNumber}`);
+//       }),
+//     );
 
-    const recipientBalance = await testWallets.tokenAdminWallet.methods
-      .balance_of_public(recipient)
-      .simulate({ from: testWallets.tokenAdminAddress });
-    logger.info(`recipientBalance: ${recipientBalance}`);
-    // expect(recipientBalance).toBe(100n * transferAmount);
+//     const recipientBalance = await testWallets.tokenAdminWallet.methods
+//       .balance_of_public(recipient)
+//       .simulate({ from: testWallets.tokenAdminAddress });
+//     logger.info(`recipientBalance: ${recipientBalance}`);
+//     // expect(recipientBalance).toBe(100n * transferAmount);
 
-    // for (const w of testWallets.wallets) {
-    //   expect(MINT_AMOUNT - ROUNDS * transferAmount).toBe(
-    //     await testWallets.tokenAdminWallet.methods.balance_of_public(w.getAddress()).simulate(),
-    //   );
-    // }
+//     // for (const w of testWallets.wallets) {
+//     //   expect(MINT_AMOUNT - ROUNDS * transferAmount).toBe(
+//     //     await testWallets.tokenAdminWallet.methods.balance_of_public(w.getAddress()).simulate(),
+//     //   );
+//     // }
 
-    // expect(ROUNDS * transferAmount * BigInt(testWallets.wallets.length)).toBe(
-    //   await testWallets.tokenAdminWallet.methods.balance_of_public(recipient).simulate(),
-    // );
-  });
-});
+//     // expect(ROUNDS * transferAmount * BigInt(testWallets.wallets.length)).toBe(
+//     //   await testWallets.tokenAdminWallet.methods.balance_of_public(recipient).simulate(),
+//     // );
+//   });
+// });

--- a/yarn-project/end-to-end/src/spartan/4epochs.test.ts
+++ b/yarn-project/end-to-end/src/spartan/4epochs.test.ts
@@ -1,160 +1,160 @@
-import { type PXE, SponsoredFeePaymentMethod, readFieldCompressedString } from '@aztec/aztec.js';
-import { RollupCheatCodes } from '@aztec/aztec/testing';
-import { getL1ContractsConfigEnvVars } from '@aztec/ethereum';
-import { EthCheatCodesWithState } from '@aztec/ethereum/test';
-import { createLogger } from '@aztec/foundation/log';
-import { TokenContract } from '@aztec/noir-contracts.js/Token';
+// import { type PXE, SponsoredFeePaymentMethod, readFieldCompressedString } from '@aztec/aztec.js';
+// import { RollupCheatCodes } from '@aztec/aztec/testing';
+// import { getL1ContractsConfigEnvVars } from '@aztec/ethereum';
+// import { EthCheatCodesWithState } from '@aztec/ethereum/test';
+// import { createLogger } from '@aztec/foundation/log';
+// import { TokenContract } from '@aztec/noir-contracts.js/Token';
 
-import { jest } from '@jest/globals';
-import type { ChildProcess } from 'child_process';
+// import { jest } from '@jest/globals';
+// import type { ChildProcess } from 'child_process';
 
-import { getSponsoredFPCAddress } from '../fixtures/utils.js';
-import {
-  type TestWallets,
-  deploySponsoredTestWallets,
-  setupTestWalletsWithTokens,
-  startCompatiblePXE,
-} from './setup_test_wallets.js';
-import { isK8sConfig, setupEnvironment, startPortForward } from './utils.js';
+// import { getSponsoredFPCAddress } from '../fixtures/utils.js';
+// import {
+//   type TestWallets,
+//   deploySponsoredTestWallets,
+//   setupTestWalletsWithTokens,
+//   startCompatiblePXE,
+// } from './setup_test_wallets.js';
+// import { isK8sConfig, setupEnvironment, startPortForward } from './utils.js';
 
-const config = setupEnvironment(process.env);
+// const config = setupEnvironment(process.env);
 
-describe('token transfer test', () => {
-  jest.setTimeout(10 * 60 * 4000); // 40 minutes
+// describe('token transfer test', () => {
+//   jest.setTimeout(10 * 60 * 4000); // 40 minutes
 
-  const logger = createLogger(`e2e:spartan:4epochs`);
-  const l1Config = getL1ContractsConfigEnvVars();
+//   const logger = createLogger(`e2e:spartan:4epochs`);
+//   const l1Config = getL1ContractsConfigEnvVars();
 
-  // We want plenty of minted tokens for a lot of slots that fill up multiple epochs
-  const MINT_AMOUNT = 2000000n;
-  const TEST_EPOCHS = 4;
-  const MAX_MISSED_SLOTS = 10n;
-  const ROUNDS = BigInt(l1Config.aztecEpochDuration * TEST_EPOCHS);
+//   // We want plenty of minted tokens for a lot of slots that fill up multiple epochs
+//   const MINT_AMOUNT = 2000000n;
+//   const TEST_EPOCHS = 4;
+//   const MAX_MISSED_SLOTS = 10n;
+//   const ROUNDS = BigInt(l1Config.aztecEpochDuration * TEST_EPOCHS);
 
-  let testWallets: TestWallets;
-  let ETHEREUM_HOSTS: string[];
-  const forwardProcesses: ChildProcess[] = [];
-  let pxe: PXE;
-  let cleanup: undefined | (() => Promise<void>);
+//   let testWallets: TestWallets;
+//   let ETHEREUM_HOSTS: string[];
+//   const forwardProcesses: ChildProcess[] = [];
+//   let pxe: PXE;
+//   let cleanup: undefined | (() => Promise<void>);
 
-  afterAll(async () => {
-    await cleanup?.();
-    forwardProcesses.forEach(p => p.kill());
-  });
+//   afterAll(async () => {
+//     await cleanup?.();
+//     forwardProcesses.forEach(p => p.kill());
+//   });
 
-  beforeAll(async () => {
-    if (isK8sConfig(config)) {
-      if (config.SEPOLIA_RUN !== 'true') {
-        const { process: ethProcess, port: ethPort } = await startPortForward({
-          resource: `svc/${config.INSTANCE_NAME}-aztec-network-eth-execution`,
-          namespace: config.NAMESPACE,
-          containerPort: config.CONTAINER_ETHEREUM_PORT,
-        });
-        forwardProcesses.push(ethProcess);
-        ETHEREUM_HOSTS = [`http://127.0.0.1:${ethPort}`];
-      } else {
-        if (!config.ETHEREUM_HOSTS) {
-          throw new Error('ETHEREUM_HOSTS must be set for sepolia runs');
-        }
-        ETHEREUM_HOSTS = config.ETHEREUM_HOSTS.split(',');
-      }
+//   beforeAll(async () => {
+//     if (isK8sConfig(config)) {
+//       if (config.SEPOLIA_RUN !== 'true') {
+//         const { process: ethProcess, port: ethPort } = await startPortForward({
+//           resource: `svc/${config.INSTANCE_NAME}-aztec-network-eth-execution`,
+//           namespace: config.NAMESPACE,
+//           containerPort: config.CONTAINER_ETHEREUM_PORT,
+//         });
+//         forwardProcesses.push(ethProcess);
+//         ETHEREUM_HOSTS = [`http://127.0.0.1:${ethPort}`];
+//       } else {
+//         if (!config.ETHEREUM_HOSTS) {
+//           throw new Error('ETHEREUM_HOSTS must be set for sepolia runs');
+//         }
+//         ETHEREUM_HOSTS = config.ETHEREUM_HOSTS.split(',');
+//       }
 
-      const { process: sequencerProcess, port: sequencerPort } = await startPortForward({
-        resource: `svc/${config.INSTANCE_NAME}-aztec-network-validator`,
-        namespace: config.NAMESPACE,
-        containerPort: config.CONTAINER_SEQUENCER_PORT,
-      });
-      forwardProcesses.push(sequencerProcess);
-      const NODE_URL = `http://127.0.0.1:${sequencerPort}`;
+//       const { process: sequencerProcess, port: sequencerPort } = await startPortForward({
+//         resource: `svc/${config.INSTANCE_NAME}-aztec-network-validator`,
+//         namespace: config.NAMESPACE,
+//         containerPort: config.CONTAINER_SEQUENCER_PORT,
+//       });
+//       forwardProcesses.push(sequencerProcess);
+//       const NODE_URL = `http://127.0.0.1:${sequencerPort}`;
 
-      ({ pxe, cleanup } = await startCompatiblePXE(NODE_URL, ['1', 'true'].includes(config.AZTEC_REAL_PROOFS), logger));
-      testWallets = await deploySponsoredTestWallets(pxe, MINT_AMOUNT, logger);
-    } else {
-      const PXE_URL = config.PXE_URL;
-      ETHEREUM_HOSTS = config.ETHEREUM_HOSTS.split(',');
-      testWallets = await setupTestWalletsWithTokens(PXE_URL, MINT_AMOUNT, logger);
-    }
+//       ({ pxe, cleanup } = await startCompatiblePXE(NODE_URL, ['1', 'true'].includes(config.AZTEC_REAL_PROOFS), logger));
+//       testWallets = await deploySponsoredTestWallets(pxe, MINT_AMOUNT, logger);
+//     } else {
+//       const PXE_URL = config.PXE_URL;
+//       ETHEREUM_HOSTS = config.ETHEREUM_HOSTS.split(',');
+//       testWallets = await setupTestWalletsWithTokens(PXE_URL, MINT_AMOUNT, logger);
+//     }
 
-    expect(ROUNDS).toBeLessThanOrEqual(MINT_AMOUNT);
-    logger.info(`Tested wallets setup: ${ROUNDS} < ${MINT_AMOUNT}`);
-  });
+//     expect(ROUNDS).toBeLessThanOrEqual(MINT_AMOUNT);
+//     logger.info(`Tested wallets setup: ${ROUNDS} < ${MINT_AMOUNT}`);
+//   });
 
-  afterAll(() => {
-    forwardProcesses.forEach(p => p.kill());
-  });
+//   afterAll(() => {
+//     forwardProcesses.forEach(p => p.kill());
+//   });
 
-  it('can get info', async () => {
-    const name = readFieldCompressedString(
-      await testWallets.tokenAdminWallet.methods.private_get_name().simulate({ from: testWallets.tokenAdminAddress }),
-    );
-    expect(name).toBe(testWallets.tokenName);
-    logger.info(`Token name verified: ${name}`);
-  });
+//   it('can get info', async () => {
+//     const name = readFieldCompressedString(
+//       await testWallets.tokenAdminWallet.methods.private_get_name().simulate({ from: testWallets.tokenAdminAddress }),
+//     );
+//     expect(name).toBe(testWallets.tokenName);
+//     logger.info(`Token name verified: ${name}`);
+//   });
 
-  it('transfer tokens for 4 epochs', async () => {
-    const ethCheatCodes = new EthCheatCodesWithState(ETHEREUM_HOSTS);
-    const l1ContractAddresses = await testWallets.pxe.getNodeInfo().then(n => n.l1ContractAddresses);
-    // Get 4 epochs
-    const rollupCheatCodes = new RollupCheatCodes(ethCheatCodes, l1ContractAddresses);
-    logger.info(`Deployed L1 contract addresses: ${JSON.stringify(l1ContractAddresses)}`);
-    const recipient = testWallets.recipientWallet.getAddress();
-    const transferAmount = 1n;
+//   it('transfer tokens for 4 epochs', async () => {
+//     const ethCheatCodes = new EthCheatCodesWithState(ETHEREUM_HOSTS);
+//     const l1ContractAddresses = await testWallets.pxe.getNodeInfo().then(n => n.l1ContractAddresses);
+//     // Get 4 epochs
+//     const rollupCheatCodes = new RollupCheatCodes(ethCheatCodes, l1ContractAddresses);
+//     logger.info(`Deployed L1 contract addresses: ${JSON.stringify(l1ContractAddresses)}`);
+//     const recipient = testWallets.recipientWallet.getAddress();
+//     const transferAmount = 1n;
 
-    for (const w of testWallets.wallets) {
-      expect(MINT_AMOUNT).toBe(
-        await testWallets.tokenAdminWallet.methods
-          .balance_of_public(w.getAddress())
-          .simulate({ from: testWallets.tokenAdminAddress }),
-      );
-    }
+//     for (const w of testWallets.wallets) {
+//       expect(MINT_AMOUNT).toBe(
+//         await testWallets.tokenAdminWallet.methods
+//           .balance_of_public(w.getAddress())
+//           .simulate({ from: testWallets.tokenAdminAddress }),
+//       );
+//     }
 
-    logger.info('Minted tokens');
+//     logger.info('Minted tokens');
 
-    expect(0n).toBe(
-      await testWallets.tokenAdminWallet.methods
-        .balance_of_public(recipient)
-        .simulate({ from: testWallets.tokenAdminAddress }),
-    );
+//     expect(0n).toBe(
+//       await testWallets.tokenAdminWallet.methods
+//         .balance_of_public(recipient)
+//         .simulate({ from: testWallets.tokenAdminAddress }),
+//     );
 
-    // For each round, make both private and public transfers
-    const startSlot = await rollupCheatCodes.getSlot();
-    for (let i = 1n; i <= ROUNDS; i++) {
-      const txs = testWallets.wallets.map(async w =>
-        (await TokenContract.at(testWallets.tokenAddress, w)).methods
-          .transfer_in_public(w.getAddress(), recipient, transferAmount, 0)
-          .prove({
-            from: w.getAddress(),
-            fee: { paymentMethod: new SponsoredFeePaymentMethod(await getSponsoredFPCAddress()) },
-          }),
-      );
+//     // For each round, make both private and public transfers
+//     const startSlot = await rollupCheatCodes.getSlot();
+//     for (let i = 1n; i <= ROUNDS; i++) {
+//       const txs = testWallets.wallets.map(async w =>
+//         (await TokenContract.at(testWallets.tokenAddress, w)).methods
+//           .transfer_in_public(w.getAddress(), recipient, transferAmount, 0)
+//           .prove({
+//             from: w.getAddress(),
+//             fee: { paymentMethod: new SponsoredFeePaymentMethod(await getSponsoredFPCAddress()) },
+//           }),
+//       );
 
-      const provenTxs = await Promise.all(txs);
+//       const provenTxs = await Promise.all(txs);
 
-      logger.info(`Proved ${provenTxs.length} in round ${i} of ${ROUNDS}`);
+//       logger.info(`Proved ${provenTxs.length} in round ${i} of ${ROUNDS}`);
 
-      await Promise.all(provenTxs.map(t => t.send().wait({ timeout: 600 })));
-      const currentSlot = await rollupCheatCodes.getSlot();
-      expect(currentSlot).toBeLessThanOrEqual(startSlot + i + MAX_MISSED_SLOTS);
-      const startEpoch = await rollupCheatCodes.getEpoch();
-      logger.debug(
-        `Successfully reached slot ${currentSlot} (iteration ${
-          currentSlot - startSlot
-        }/${ROUNDS}) (Epoch ${startEpoch})`,
-      );
-    }
+//       await Promise.all(provenTxs.map(t => t.send().wait({ timeout: 600 })));
+//       const currentSlot = await rollupCheatCodes.getSlot();
+//       expect(currentSlot).toBeLessThanOrEqual(startSlot + i + MAX_MISSED_SLOTS);
+//       const startEpoch = await rollupCheatCodes.getEpoch();
+//       logger.debug(
+//         `Successfully reached slot ${currentSlot} (iteration ${
+//           currentSlot - startSlot
+//         }/${ROUNDS}) (Epoch ${startEpoch})`,
+//       );
+//     }
 
-    for (const w of testWallets.wallets) {
-      expect(MINT_AMOUNT - ROUNDS * transferAmount).toBe(
-        await testWallets.tokenAdminWallet.methods
-          .balance_of_public(w.getAddress())
-          .simulate({ from: testWallets.tokenAdminAddress }),
-      );
-    }
+//     for (const w of testWallets.wallets) {
+//       expect(MINT_AMOUNT - ROUNDS * transferAmount).toBe(
+//         await testWallets.tokenAdminWallet.methods
+//           .balance_of_public(w.getAddress())
+//           .simulate({ from: testWallets.tokenAdminAddress }),
+//       );
+//     }
 
-    expect(ROUNDS * transferAmount * BigInt(testWallets.wallets.length)).toBe(
-      await testWallets.tokenAdminWallet.methods
-        .balance_of_public(recipient)
-        .simulate({ from: testWallets.tokenAdminAddress }),
-    );
-  });
-});
+//     expect(ROUNDS * transferAmount * BigInt(testWallets.wallets.length)).toBe(
+//       await testWallets.tokenAdminWallet.methods
+//         .balance_of_public(recipient)
+//         .simulate({ from: testWallets.tokenAdminAddress }),
+//     );
+//   });
+// });

--- a/yarn-project/end-to-end/src/spartan/gating-passive.test.ts
+++ b/yarn-project/end-to-end/src/spartan/gating-passive.test.ts
@@ -1,137 +1,137 @@
-import { createCompatibleClient, sleep } from '@aztec/aztec.js';
-import { RollupCheatCodes } from '@aztec/aztec/testing';
-import { EthCheatCodesWithState } from '@aztec/ethereum/test';
-import { createLogger } from '@aztec/foundation/log';
+// import { createCompatibleClient, sleep } from '@aztec/aztec.js';
+// import { RollupCheatCodes } from '@aztec/aztec/testing';
+// import { EthCheatCodesWithState } from '@aztec/ethereum/test';
+// import { createLogger } from '@aztec/foundation/log';
 
-import { expect, jest } from '@jest/globals';
-import type { ChildProcess } from 'child_process';
+// import { expect, jest } from '@jest/globals';
+// import type { ChildProcess } from 'child_process';
 
-import type { AlertConfig } from '../quality_of_service/alert_checker.js';
-import {
-  applyBootNodeFailure,
-  applyNetworkShaping,
-  applyValidatorKill,
-  awaitL2BlockNumber,
-  enableValidatorDynamicBootNode,
-  isK8sConfig,
-  restartBot,
-  runAlertCheck,
-  setupEnvironment,
-  startPortForward,
-} from './utils.js';
+// import type { AlertConfig } from '../quality_of_service/alert_checker.js';
+// import {
+//   applyBootNodeFailure,
+//   applyNetworkShaping,
+//   applyValidatorKill,
+//   awaitL2BlockNumber,
+//   enableValidatorDynamicBootNode,
+//   isK8sConfig,
+//   restartBot,
+//   runAlertCheck,
+//   setupEnvironment,
+//   startPortForward,
+// } from './utils.js';
 
-const qosAlerts: AlertConfig[] = [
-  {
-    alert: 'SequencerTimeToCollectAttestations',
-    expr: 'avg_over_time(aztec_sequencer_time_to_collect_attestations[2m]) > 2500',
-    labels: { severity: 'error' },
-    for: '10m',
-    annotations: {},
-  },
-  {
-    // Checks that we are not syncing from scratch each time we reboot
-    alert: 'ArchiverL1BlocksSynced',
-    expr: 'rate(aztec_archiver_l1_blocks_synced[1m]) > 0.5',
-    labels: { severity: 'error' },
-    for: '10m',
-    annotations: {},
-  },
-];
+// const qosAlerts: AlertConfig[] = [
+//   {
+//     alert: 'SequencerTimeToCollectAttestations',
+//     expr: 'avg_over_time(aztec_sequencer_time_to_collect_attestations[2m]) > 2500',
+//     labels: { severity: 'error' },
+//     for: '10m',
+//     annotations: {},
+//   },
+//   {
+//     // Checks that we are not syncing from scratch each time we reboot
+//     alert: 'ArchiverL1BlocksSynced',
+//     expr: 'rate(aztec_archiver_l1_blocks_synced[1m]) > 0.5',
+//     labels: { severity: 'error' },
+//     for: '10m',
+//     annotations: {},
+//   },
+// ];
 
-const config = setupEnvironment(process.env);
-if (!isK8sConfig(config)) {
-  throw new Error('This test must be run in a k8s environment');
-}
-const { NAMESPACE, CONTAINER_PXE_PORT, CONTAINER_ETHEREUM_PORT, SPARTAN_DIR, INSTANCE_NAME } = config;
-const debugLogger = createLogger('e2e:spartan-test:gating-passive');
+// const config = setupEnvironment(process.env);
+// if (!isK8sConfig(config)) {
+//   throw new Error('This test must be run in a k8s environment');
+// }
+// const { NAMESPACE, CONTAINER_PXE_PORT, CONTAINER_ETHEREUM_PORT, SPARTAN_DIR, INSTANCE_NAME } = config;
+// const debugLogger = createLogger('e2e:spartan-test:gating-passive');
 
-describe('a test that passively observes the network in the presence of network chaos', () => {
-  jest.setTimeout(60 * 60 * 1000); // 60 minutes
+// describe('a test that passively observes the network in the presence of network chaos', () => {
+//   jest.setTimeout(60 * 60 * 1000); // 60 minutes
 
-  let ETHEREUM_HOST: string;
-  let PXE_URL: string;
-  const forwardProcesses: ChildProcess[] = [];
+//   let ETHEREUM_HOST: string;
+//   let PXE_URL: string;
+//   const forwardProcesses: ChildProcess[] = [];
 
-  afterAll(async () => {
-    await runAlertCheck(config, qosAlerts, debugLogger);
-    forwardProcesses.forEach(p => p.kill());
-  });
+//   afterAll(async () => {
+//     await runAlertCheck(config, qosAlerts, debugLogger);
+//     forwardProcesses.forEach(p => p.kill());
+//   });
 
-  it('survives network chaos', async () => {
-    const { process: pxeProcess, port: pxePort } = await startPortForward({
-      resource: `svc/${config.INSTANCE_NAME}-aztec-network-pxe`,
-      namespace: NAMESPACE,
-      containerPort: CONTAINER_PXE_PORT,
-    });
-    forwardProcesses.push(pxeProcess);
-    PXE_URL = `http://127.0.0.1:${pxePort}`;
+//   it('survives network chaos', async () => {
+//     const { process: pxeProcess, port: pxePort } = await startPortForward({
+//       resource: `svc/${config.INSTANCE_NAME}-aztec-network-pxe`,
+//       namespace: NAMESPACE,
+//       containerPort: CONTAINER_PXE_PORT,
+//     });
+//     forwardProcesses.push(pxeProcess);
+//     PXE_URL = `http://127.0.0.1:${pxePort}`;
 
-    const { process: ethProcess, port: ethPort } = await startPortForward({
-      resource: `svc/${config.INSTANCE_NAME}-aztec-network-eth-execution`,
-      namespace: NAMESPACE,
-      containerPort: CONTAINER_ETHEREUM_PORT,
-    });
-    forwardProcesses.push(ethProcess);
-    ETHEREUM_HOST = `http://127.0.0.1:${ethPort}`;
+//     const { process: ethProcess, port: ethPort } = await startPortForward({
+//       resource: `svc/${config.INSTANCE_NAME}-aztec-network-eth-execution`,
+//       namespace: NAMESPACE,
+//       containerPort: CONTAINER_ETHEREUM_PORT,
+//     });
+//     forwardProcesses.push(ethProcess);
+//     ETHEREUM_HOST = `http://127.0.0.1:${ethPort}`;
 
-    const client = await createCompatibleClient(PXE_URL, debugLogger);
-    const ethCheatCodes = new EthCheatCodesWithState([ETHEREUM_HOST]);
-    const rollupCheatCodes = new RollupCheatCodes(
-      ethCheatCodes,
-      await client.getNodeInfo().then(n => n.l1ContractAddresses),
-    );
-    const { epochDuration, slotDuration } = await rollupCheatCodes.getConfig();
+//     const client = await createCompatibleClient(PXE_URL, debugLogger);
+//     const ethCheatCodes = new EthCheatCodesWithState([ETHEREUM_HOST]);
+//     const rollupCheatCodes = new RollupCheatCodes(
+//       ethCheatCodes,
+//       await client.getNodeInfo().then(n => n.l1ContractAddresses),
+//     );
+//     const { epochDuration, slotDuration } = await rollupCheatCodes.getConfig();
 
-    // make it so the validator will use its peers to bootstrap
-    await enableValidatorDynamicBootNode(INSTANCE_NAME, NAMESPACE, SPARTAN_DIR, debugLogger);
+//     // make it so the validator will use its peers to bootstrap
+//     await enableValidatorDynamicBootNode(INSTANCE_NAME, NAMESPACE, SPARTAN_DIR, debugLogger);
 
-    // restart the bot to ensure that it's not affected by the previous test
-    await restartBot(NAMESPACE, debugLogger);
+//     // restart the bot to ensure that it's not affected by the previous test
+//     await restartBot(NAMESPACE, debugLogger);
 
-    // wait for the chain to build at least 1 epoch's worth of blocks
-    // note, don't forget that normally an epoch doesn't need epochDuration worth of blocks,
-    // but here we do double duty:
-    // we want a handful of blocks, and we want to pass the epoch boundary
-    await awaitL2BlockNumber(rollupCheatCodes, epochDuration, 60 * 6, debugLogger);
+//     // wait for the chain to build at least 1 epoch's worth of blocks
+//     // note, don't forget that normally an epoch doesn't need epochDuration worth of blocks,
+//     // but here we do double duty:
+//     // we want a handful of blocks, and we want to pass the epoch boundary
+//     await awaitL2BlockNumber(rollupCheatCodes, epochDuration, 60 * 6, debugLogger);
 
-    let deploymentOutput: string = '';
-    deploymentOutput = await applyNetworkShaping({
-      valuesFile: 'network-requirements.yaml',
-      namespace: NAMESPACE,
-      spartanDir: SPARTAN_DIR,
-      logger: debugLogger,
-    });
-    debugLogger.info(deploymentOutput);
-    deploymentOutput = await applyBootNodeFailure({
-      durationSeconds: 60 * 60 * 24,
-      namespace: NAMESPACE,
-      spartanDir: SPARTAN_DIR,
-      logger: debugLogger,
-    });
-    debugLogger.info(deploymentOutput);
-    await restartBot(NAMESPACE, debugLogger);
+//     let deploymentOutput: string = '';
+//     deploymentOutput = await applyNetworkShaping({
+//       valuesFile: 'network-requirements.yaml',
+//       namespace: NAMESPACE,
+//       spartanDir: SPARTAN_DIR,
+//       logger: debugLogger,
+//     });
+//     debugLogger.info(deploymentOutput);
+//     deploymentOutput = await applyBootNodeFailure({
+//       durationSeconds: 60 * 60 * 24,
+//       namespace: NAMESPACE,
+//       spartanDir: SPARTAN_DIR,
+//       logger: debugLogger,
+//     });
+//     debugLogger.info(deploymentOutput);
+//     await restartBot(NAMESPACE, debugLogger);
 
-    const rounds = 3;
-    for (let i = 0; i < rounds; i++) {
-      debugLogger.info(`Round ${i + 1}/${rounds}`);
-      deploymentOutput = await applyValidatorKill({
-        namespace: NAMESPACE,
-        spartanDir: SPARTAN_DIR,
-        logger: debugLogger,
-      });
-      debugLogger.info(deploymentOutput);
-      debugLogger.info(`Waiting for 1 epoch to pass`);
-      const controlTips = await rollupCheatCodes.getTips();
-      await sleep(Number(epochDuration * slotDuration) * 1000);
-      const newTips = await rollupCheatCodes.getTips();
+//     const rounds = 3;
+//     for (let i = 0; i < rounds; i++) {
+//       debugLogger.info(`Round ${i + 1}/${rounds}`);
+//       deploymentOutput = await applyValidatorKill({
+//         namespace: NAMESPACE,
+//         spartanDir: SPARTAN_DIR,
+//         logger: debugLogger,
+//       });
+//       debugLogger.info(deploymentOutput);
+//       debugLogger.info(`Waiting for 1 epoch to pass`);
+//       const controlTips = await rollupCheatCodes.getTips();
+//       await sleep(Number(epochDuration * slotDuration) * 1000);
+//       const newTips = await rollupCheatCodes.getTips();
 
-      // calculate the percentage of slots missed for debugging purposes
-      const perfectPending = controlTips.pending + BigInt(Math.floor(Number(epochDuration)));
-      const missedSlots = Number(perfectPending) - Number(newTips.pending);
-      const missedSlotsPercentage = (missedSlots / Number(epochDuration)) * 100;
-      debugLogger.info(`Missed ${missedSlots} slots, ${missedSlotsPercentage.toFixed(2)}%`);
+//       // calculate the percentage of slots missed for debugging purposes
+//       const perfectPending = controlTips.pending + BigInt(Math.floor(Number(epochDuration)));
+//       const missedSlots = Number(perfectPending) - Number(newTips.pending);
+//       const missedSlotsPercentage = (missedSlots / Number(epochDuration)) * 100;
+//       debugLogger.info(`Missed ${missedSlots} slots, ${missedSlotsPercentage.toFixed(2)}%`);
 
-      expect(newTips.pending).toBeGreaterThan(controlTips.pending);
-    }
-  });
-});
+//       expect(newTips.pending).toBeGreaterThan(controlTips.pending);
+//     }
+//   });
+// });

--- a/yarn-project/end-to-end/src/spartan/mempool_limit.test.ts
+++ b/yarn-project/end-to-end/src/spartan/mempool_limit.test.ts
@@ -1,167 +1,167 @@
-import { getSchnorrAccount } from '@aztec/accounts/schnorr';
-import { AztecAddress, Fr, SponsoredFeePaymentMethod, Tx, TxStatus, type Wallet } from '@aztec/aztec.js';
-import type { UserFeeOptions } from '@aztec/entrypoints/interfaces';
-import { asyncPool } from '@aztec/foundation/async-pool';
-import { times } from '@aztec/foundation/collection';
-import { Agent, makeUndiciFetch } from '@aztec/foundation/json-rpc/undici';
-import { createLogger } from '@aztec/foundation/log';
-import { TokenContract } from '@aztec/noir-contracts.js/Token';
-import { createPXEService } from '@aztec/pxe/server';
-import {
-  type AztecNode,
-  type AztecNodeAdmin,
-  createAztecNodeAdminClient,
-  createAztecNodeClient,
-} from '@aztec/stdlib/interfaces/client';
-import { deriveSigningKey } from '@aztec/stdlib/keys';
-import { makeTracedFetch } from '@aztec/telemetry-client';
+// import { getSchnorrAccount } from '@aztec/accounts/schnorr';
+// import { AztecAddress, Fr, SponsoredFeePaymentMethod, Tx, TxStatus, type Wallet } from '@aztec/aztec.js';
+// import type { UserFeeOptions } from '@aztec/entrypoints/interfaces';
+// import { asyncPool } from '@aztec/foundation/async-pool';
+// import { times } from '@aztec/foundation/collection';
+// import { Agent, makeUndiciFetch } from '@aztec/foundation/json-rpc/undici';
+// import { createLogger } from '@aztec/foundation/log';
+// import { TokenContract } from '@aztec/noir-contracts.js/Token';
+// import { createPXEService } from '@aztec/pxe/server';
+// import {
+//   type AztecNode,
+//   type AztecNodeAdmin,
+//   createAztecNodeAdminClient,
+//   createAztecNodeClient,
+// } from '@aztec/stdlib/interfaces/client';
+// import { deriveSigningKey } from '@aztec/stdlib/keys';
+// import { makeTracedFetch } from '@aztec/telemetry-client';
 
-import type { ChildProcess } from 'child_process';
+// import type { ChildProcess } from 'child_process';
 
-import { getSponsoredFPCAddress, registerSponsoredFPC } from '../fixtures/utils.js';
-import { isK8sConfig, setupEnvironment, startPortForward } from './utils.js';
+// import { getSponsoredFPCAddress, registerSponsoredFPC } from '../fixtures/utils.js';
+// import { isK8sConfig, setupEnvironment, startPortForward } from './utils.js';
 
-const config = setupEnvironment(process.env);
+// const config = setupEnvironment(process.env);
 
-const debugLogger = createLogger('e2e:spartan-test:mempool_limiter');
+// const debugLogger = createLogger('e2e:spartan-test:mempool_limiter');
 
-const pxeOptions = {
-  dataDirectory: undefined,
-  dataStoreMapSizeKB: 1024 ** 2, // max size is 1GB
-};
+// const pxeOptions = {
+//   dataDirectory: undefined,
+//   dataStoreMapSizeKB: 1024 ** 2, // max size is 1GB
+// };
 
-const TX_FLOOD_SIZE = 100;
-const TX_MEMPOOL_LIMIT = 25;
-const CONCURRENCY = 25;
+// const TX_FLOOD_SIZE = 100;
+// const TX_MEMPOOL_LIMIT = 25;
+// const CONCURRENCY = 25;
 
-describe('mempool limiter test', () => {
-  // we need a node to change its mempoolTxSize for this test
-  let nodeAdmin: AztecNodeAdmin;
-  // the regular API for the same node
-  let node: AztecNode;
+// describe('mempool limiter test', () => {
+//   // we need a node to change its mempoolTxSize for this test
+//   let nodeAdmin: AztecNodeAdmin;
+//   // the regular API for the same node
+//   let node: AztecNode;
 
-  let accountSecretKey: Fr;
-  let accountSalt: Fr;
-  let tokenContractAddress: AztecAddress;
-  let sampleTx: Tx;
+//   let accountSecretKey: Fr;
+//   let accountSalt: Fr;
+//   let tokenContractAddress: AztecAddress;
+//   let sampleTx: Tx;
 
-  let fee: UserFeeOptions;
+//   let fee: UserFeeOptions;
 
-  const forwardProcesses: ChildProcess[] = [];
+//   const forwardProcesses: ChildProcess[] = [];
 
-  beforeAll(async () => {
-    let NODE_URL: string;
-    let NODE_ADMIN_URL: string;
+//   beforeAll(async () => {
+//     let NODE_URL: string;
+//     let NODE_ADMIN_URL: string;
 
-    if (isK8sConfig(config)) {
-      const nodeAdminFwd = await startPortForward({
-        resource: `svc/${config.INSTANCE_NAME}-aztec-network-full-node-admin`,
-        namespace: config.NAMESPACE,
-        containerPort: config.CONTAINER_NODE_ADMIN_PORT,
-      });
+//     if (isK8sConfig(config)) {
+//       const nodeAdminFwd = await startPortForward({
+//         resource: `svc/${config.INSTANCE_NAME}-aztec-network-full-node-admin`,
+//         namespace: config.NAMESPACE,
+//         containerPort: config.CONTAINER_NODE_ADMIN_PORT,
+//       });
 
-      const nodeFwd = await startPortForward({
-        resource: `svc/${config.INSTANCE_NAME}-aztec-network-full-node`,
-        namespace: config.NAMESPACE,
-        containerPort: config.CONTAINER_NODE_PORT,
-      });
+//       const nodeFwd = await startPortForward({
+//         resource: `svc/${config.INSTANCE_NAME}-aztec-network-full-node`,
+//         namespace: config.NAMESPACE,
+//         containerPort: config.CONTAINER_NODE_PORT,
+//       });
 
-      forwardProcesses.push(nodeAdminFwd.process, nodeFwd.process);
-      NODE_ADMIN_URL = `http://127.0.0.1:${nodeAdminFwd.port}`;
-      NODE_URL = `http://127.0.0.1:${nodeFwd.port}`;
-    } else {
-      NODE_ADMIN_URL = config.NODE_ADMIN_URL;
-      NODE_URL = config.NODE_URL;
-    }
+//       forwardProcesses.push(nodeAdminFwd.process, nodeFwd.process);
+//       NODE_ADMIN_URL = `http://127.0.0.1:${nodeAdminFwd.port}`;
+//       NODE_URL = `http://127.0.0.1:${nodeFwd.port}`;
+//     } else {
+//       NODE_ADMIN_URL = config.NODE_ADMIN_URL;
+//       NODE_URL = config.NODE_URL;
+//     }
 
-    const fetch = makeTracedFetch(
-      times(10, () => 1),
-      false,
-      makeUndiciFetch(new Agent({ connections: CONCURRENCY })),
-    );
-    nodeAdmin = createAztecNodeAdminClient(NODE_ADMIN_URL, {}, fetch);
-    node = createAztecNodeClient(NODE_URL, {}, fetch);
-  });
+//     const fetch = makeTracedFetch(
+//       times(10, () => 1),
+//       false,
+//       makeUndiciFetch(new Agent({ connections: CONCURRENCY })),
+//     );
+//     nodeAdmin = createAztecNodeAdminClient(NODE_ADMIN_URL, {}, fetch);
+//     node = createAztecNodeClient(NODE_URL, {}, fetch);
+//   });
 
-  beforeAll(async () => {
-    debugLogger.debug(`Preparing account and token contract`);
+//   beforeAll(async () => {
+//     debugLogger.debug(`Preparing account and token contract`);
 
-    // set a large pool size so that deploy txs fit
-    await nodeAdmin.setConfig({ maxTxPoolSize: 1e9 });
+//     // set a large pool size so that deploy txs fit
+//     await nodeAdmin.setConfig({ maxTxPoolSize: 1e9 });
 
-    const pxe = await createPXEService(node, pxeOptions);
+//     const pxe = await createPXEService(node, pxeOptions);
 
-    await registerSponsoredFPC(pxe);
-    fee = {
-      paymentMethod: new SponsoredFeePaymentMethod(await getSponsoredFPCAddress()),
-    };
+//     await registerSponsoredFPC(pxe);
+//     fee = {
+//       paymentMethod: new SponsoredFeePaymentMethod(await getSponsoredFPCAddress()),
+//     };
 
-    accountSecretKey = Fr.fromHexString('0xcafe');
-    accountSalt = Fr.ONE;
-    const account = await getSchnorrAccount(pxe, accountSecretKey, deriveSigningKey(accountSecretKey), accountSalt);
-    const meta = await pxe.getContractMetadata(account.getAddress());
-    let wallet: Wallet;
-    if (meta.isContractInitialized) {
-      wallet = await account.register();
-    } else {
-      const res = await account.deploy({ fee }).wait();
-      wallet = res.wallet;
-    }
+//     accountSecretKey = Fr.fromHexString('0xcafe');
+//     accountSalt = Fr.ONE;
+//     const account = await getSchnorrAccount(pxe, accountSecretKey, deriveSigningKey(accountSecretKey), accountSalt);
+//     const meta = await pxe.getContractMetadata(account.getAddress());
+//     let wallet: Wallet;
+//     if (meta.isContractInitialized) {
+//       wallet = await account.register();
+//     } else {
+//       const res = await account.deploy({ fee }).wait();
+//       wallet = res.wallet;
+//     }
 
-    debugLogger.info(`Deployed account: ${account.getAddress()}`);
+//     debugLogger.info(`Deployed account: ${account.getAddress()}`);
 
-    const tokenDeploy = TokenContract.deploy(wallet, wallet.getAddress(), 'TEST', 'T', 18);
-    const token = await tokenDeploy.register({ contractAddressSalt: Fr.ONE });
-    tokenContractAddress = token.address;
+//     const tokenDeploy = TokenContract.deploy(wallet, wallet.getAddress(), 'TEST', 'T', 18);
+//     const token = await tokenDeploy.register({ contractAddressSalt: Fr.ONE });
+//     tokenContractAddress = token.address;
 
-    const tokenMeta = await pxe.getContractMetadata(token.address);
-    if (!tokenMeta.isContractInitialized) {
-      await tokenDeploy.send({ from: wallet.getAddress(), contractAddressSalt: Fr.ONE, fee }).wait();
-      debugLogger.info(`Deployed token contract: ${tokenContractAddress}`);
+//     const tokenMeta = await pxe.getContractMetadata(token.address);
+//     if (!tokenMeta.isContractInitialized) {
+//       await tokenDeploy.send({ from: wallet.getAddress(), contractAddressSalt: Fr.ONE, fee }).wait();
+//       debugLogger.info(`Deployed token contract: ${tokenContractAddress}`);
 
-      await token.methods
-        .mint_to_public(wallet.getAddress(), 10n ** 18n)
-        .send({ from: wallet.getAddress(), fee })
-        .wait();
-      debugLogger.info(`Minted tokens`);
-    } else {
-      debugLogger.info(`Token contract already deployed at: ${token.address}`);
-    }
+//       await token.methods
+//         .mint_to_public(wallet.getAddress(), 10n ** 18n)
+//         .send({ from: wallet.getAddress(), fee })
+//         .wait();
+//       debugLogger.info(`Minted tokens`);
+//     } else {
+//       debugLogger.info(`Token contract already deployed at: ${token.address}`);
+//     }
 
-    debugLogger.debug(`Calculating mempool limits`);
+//     debugLogger.debug(`Calculating mempool limits`);
 
-    const proventx = await token.methods
-      .transfer_in_public(wallet.getAddress(), await AztecAddress.random(), 1, 0)
-      .prove({ from: wallet.getAddress(), fee });
-    sampleTx = proventx;
-    const sampleTxSize = sampleTx.getSize();
-    const maxTxPoolSize = TX_MEMPOOL_LIMIT * sampleTxSize;
+//     const proventx = await token.methods
+//       .transfer_in_public(wallet.getAddress(), await AztecAddress.random(), 1, 0)
+//       .prove({ from: wallet.getAddress(), fee });
+//     sampleTx = proventx;
+//     const sampleTxSize = sampleTx.getSize();
+//     const maxTxPoolSize = TX_MEMPOOL_LIMIT * sampleTxSize;
 
-    await nodeAdmin.setConfig({ maxTxPoolSize });
+//     await nodeAdmin.setConfig({ maxTxPoolSize });
 
-    debugLogger.info(`Sample tx size: ${sampleTxSize} bytes`);
-    debugLogger.info(`Mempool limited to: ${maxTxPoolSize} bytes`);
+//     debugLogger.info(`Sample tx size: ${sampleTxSize} bytes`);
+//     debugLogger.info(`Mempool limited to: ${maxTxPoolSize} bytes`);
 
-    await pxe.stop();
-  }, 240_000);
+//     await pxe.stop();
+//   }, 240_000);
 
-  afterAll(async () => {
-    await nodeAdmin.setConfig({ maxTxPoolSize: 1e9 });
-    forwardProcesses.forEach(p => p.kill());
-  });
+//   afterAll(async () => {
+//     await nodeAdmin.setConfig({ maxTxPoolSize: 1e9 });
+//     forwardProcesses.forEach(p => p.kill());
+//   });
 
-  it('evicts txs to keep mempool under specified limit', async () => {
-    const txs = times(TX_FLOOD_SIZE, () => {
-      const tx = Tx.fromBuffer(sampleTx.toBuffer());
-      // this only works on unproven networks, otherwise this will fail verification
-      tx.data.forPublic!.nonRevertibleAccumulatedData.nullifiers[0] = Fr.random();
-      tx.getTxHash();
-      return tx;
-    });
+//   it('evicts txs to keep mempool under specified limit', async () => {
+//     const txs = times(TX_FLOOD_SIZE, () => {
+//       const tx = Tx.fromBuffer(sampleTx.toBuffer());
+//       // this only works on unproven networks, otherwise this will fail verification
+//       tx.data.forPublic!.nonRevertibleAccumulatedData.nullifiers[0] = Fr.random();
+//       tx.getTxHash();
+//       return tx;
+//     });
 
-    await asyncPool(CONCURRENCY, txs, tx => node.sendTx(tx));
-    const receipts = await asyncPool(CONCURRENCY, txs, async tx => await node.getTxReceipt(tx.getTxHash()));
-    const pending = receipts.reduce((count, receipt) => (receipt.status === TxStatus.PENDING ? count + 1 : count), 0);
-    expect(pending).toBeLessThanOrEqual(TX_MEMPOOL_LIMIT);
-  }, 600_000);
-});
+//     await asyncPool(CONCURRENCY, txs, tx => node.sendTx(tx));
+//     const receipts = await asyncPool(CONCURRENCY, txs, async tx => await node.getTxReceipt(tx.getTxHash()));
+//     const pending = receipts.reduce((count, receipt) => (receipt.status === TxStatus.PENDING ? count + 1 : count), 0);
+//     expect(pending).toBeLessThanOrEqual(TX_MEMPOOL_LIMIT);
+//   }, 600_000);
+// });

--- a/yarn-project/end-to-end/src/spartan/n_tps.test.ts
+++ b/yarn-project/end-to-end/src/spartan/n_tps.test.ts
@@ -1,214 +1,214 @@
-import { Fr, ProvenTx, Tx, readFieldCompressedString, sleep } from '@aztec/aztec.js';
-import { createLogger } from '@aztec/foundation/log';
-import { TokenContract } from '@aztec/noir-contracts.js/Token';
+// import { Fr, ProvenTx, Tx, readFieldCompressedString, sleep } from '@aztec/aztec.js';
+// import { createLogger } from '@aztec/foundation/log';
+// import { TokenContract } from '@aztec/noir-contracts.js/Token';
 
-import { jest } from '@jest/globals';
-import type { ChildProcess } from 'child_process';
+// import { jest } from '@jest/globals';
+// import type { ChildProcess } from 'child_process';
 
-import { type TestWallets, deployTestWalletWithTokens, setupTestWalletsWithTokens } from './setup_test_wallets.js';
-import { isK8sConfig, setupEnvironment, startPortForward } from './utils.js';
+// import { type TestWallets, deployTestWalletWithTokens, setupTestWalletsWithTokens } from './setup_test_wallets.js';
+// import { isK8sConfig, setupEnvironment, startPortForward } from './utils.js';
 
-const config = setupEnvironment(process.env);
+// const config = setupEnvironment(process.env);
 
-describe('sustained 10 TPS test', () => {
-  jest.setTimeout(20 * 60 * 1000); // 20 minutes
+// describe('sustained 10 TPS test', () => {
+//   jest.setTimeout(20 * 60 * 1000); // 20 minutes
 
-  const logger = createLogger(`e2e:spartan-test:sustained-10tps`);
-  const MINT_AMOUNT = 10000n;
-  const TEST_DURATION_SECONDS = 10;
-  const TARGET_TPS = 5; // 10
-  const TOTAL_TXS = TEST_DURATION_SECONDS * TARGET_TPS;
+//   const logger = createLogger(`e2e:spartan-test:sustained-10tps`);
+//   const MINT_AMOUNT = 10000n;
+//   const TEST_DURATION_SECONDS = 10;
+//   const TARGET_TPS = 5; // 10
+//   const TOTAL_TXS = TEST_DURATION_SECONDS * TARGET_TPS;
 
-  let testWallets: TestWallets;
-  let PXE_URL: string;
-  let ETHEREUM_HOSTS: string[];
-  const forwardProcesses: ChildProcess[] = [];
+//   let testWallets: TestWallets;
+//   let PXE_URL: string;
+//   let ETHEREUM_HOSTS: string[];
+//   const forwardProcesses: ChildProcess[] = [];
 
-  afterAll(async () => {
-    // Give processes time to clean up gracefully
-    forwardProcesses.forEach(p => {
-      if (!p.killed) {
-        p.kill();
-      }
-    });
+//   afterAll(async () => {
+//     // Give processes time to clean up gracefully
+//     forwardProcesses.forEach(p => {
+//       if (!p.killed) {
+//         p.kill();
+//       }
+//     });
 
-    // Wait a bit for processes to terminate
-    await new Promise(resolve => setTimeout(resolve, 1000));
-  });
+//     // Wait a bit for processes to terminate
+//     await new Promise(resolve => setTimeout(resolve, 1000));
+//   });
 
-  beforeAll(async () => {
-    if (isK8sConfig(config)) {
-      const { process: pxeProcess, port: pxePort } = await startPortForward({
-        resource: `svc/${config.INSTANCE_NAME}-aztec-network-pxe`,
-        namespace: config.NAMESPACE,
-        containerPort: config.CONTAINER_PXE_PORT,
-      });
-      forwardProcesses.push(pxeProcess);
-      PXE_URL = `http://127.0.0.1:${pxePort}`;
+//   beforeAll(async () => {
+//     if (isK8sConfig(config)) {
+//       const { process: pxeProcess, port: pxePort } = await startPortForward({
+//         resource: `svc/${config.INSTANCE_NAME}-aztec-network-pxe`,
+//         namespace: config.NAMESPACE,
+//         containerPort: config.CONTAINER_PXE_PORT,
+//       });
+//       forwardProcesses.push(pxeProcess);
+//       PXE_URL = `http://127.0.0.1:${pxePort}`;
 
-      const { process: ethProcess, port: ethPort } = await startPortForward({
-        resource: `svc/${config.INSTANCE_NAME}-aztec-network-eth-execution`,
-        namespace: config.NAMESPACE,
-        containerPort: config.CONTAINER_ETHEREUM_PORT,
-      });
-      forwardProcesses.push(ethProcess);
-      ETHEREUM_HOSTS = [`http://127.0.0.1:${ethPort}`];
+//       const { process: ethProcess, port: ethPort } = await startPortForward({
+//         resource: `svc/${config.INSTANCE_NAME}-aztec-network-eth-execution`,
+//         namespace: config.NAMESPACE,
+//         containerPort: config.CONTAINER_ETHEREUM_PORT,
+//       });
+//       forwardProcesses.push(ethProcess);
+//       ETHEREUM_HOSTS = [`http://127.0.0.1:${ethPort}`];
 
-      const { process: sequencerProcess, port: sequencerPort } = await startPortForward({
-        resource: `svc/${config.INSTANCE_NAME}-aztec-network-validator`,
-        namespace: config.NAMESPACE,
-        containerPort: config.CONTAINER_SEQUENCER_PORT,
-      });
-      forwardProcesses.push(sequencerProcess);
-      const NODE_URL = `http://127.0.0.1:${sequencerPort}`;
+//       const { process: sequencerProcess, port: sequencerPort } = await startPortForward({
+//         resource: `svc/${config.INSTANCE_NAME}-aztec-network-validator`,
+//         namespace: config.NAMESPACE,
+//         containerPort: config.CONTAINER_SEQUENCER_PORT,
+//       });
+//       forwardProcesses.push(sequencerProcess);
+//       const NODE_URL = `http://127.0.0.1:${sequencerPort}`;
 
-      const L1_ACCOUNT_MNEMONIC = config.L1_ACCOUNT_MNEMONIC;
+//       const L1_ACCOUNT_MNEMONIC = config.L1_ACCOUNT_MNEMONIC;
 
-      logger.info('deploying test wallets');
+//       logger.info('deploying test wallets');
 
-      testWallets = await deployTestWalletWithTokens(
-        PXE_URL,
-        NODE_URL,
-        ETHEREUM_HOSTS,
-        L1_ACCOUNT_MNEMONIC,
-        MINT_AMOUNT,
-        logger,
-      );
-      logger.info(`testWallets ready 1`);
-    } else {
-      PXE_URL = config.PXE_URL;
+//       testWallets = await deployTestWalletWithTokens(
+//         PXE_URL,
+//         NODE_URL,
+//         ETHEREUM_HOSTS,
+//         L1_ACCOUNT_MNEMONIC,
+//         MINT_AMOUNT,
+//         logger,
+//       );
+//       logger.info(`testWallets ready 1`);
+//     } else {
+//       PXE_URL = config.PXE_URL;
 
-      testWallets = await setupTestWalletsWithTokens(PXE_URL, MINT_AMOUNT, logger);
-    }
+//       testWallets = await setupTestWalletsWithTokens(PXE_URL, MINT_AMOUNT, logger);
+//     }
 
-    logger.info(
-      `Test setup complete. Planning ${TOTAL_TXS} transactions over ${TEST_DURATION_SECONDS} seconds at ${TARGET_TPS} TPS`,
-    );
-  });
+//     logger.info(
+//       `Test setup complete. Planning ${TOTAL_TXS} transactions over ${TEST_DURATION_SECONDS} seconds at ${TARGET_TPS} TPS`,
+//     );
+//   });
 
-  // it('can verify token setup', async () => {
-  //   const name = readFieldCompressedString(await tokenContract.methods.private_get_name().simulate());
-  //   expect(name).toBeDefined();
-  //   expect(name.length).toBeGreaterThan(0);
-  //   logger.info(`Token verified: ${name}`);
-  // });
+//   // it('can verify token setup', async () => {
+//   //   const name = readFieldCompressedString(await tokenContract.methods.private_get_name().simulate());
+//   //   expect(name).toBeDefined();
+//   //   expect(name.length).toBeGreaterThan(0);
+//   //   logger.info(`Token verified: ${name}`);
+//   // });
 
-  it('can get info', async () => {
-    const name = readFieldCompressedString(
-      await testWallets.tokenAdminWallet.methods.private_get_name().simulate({ from: testWallets.tokenAdminAddress }),
-    );
-    expect(name).toBe(testWallets.tokenName);
-  });
+//   it('can get info', async () => {
+//     const name = readFieldCompressedString(
+//       await testWallets.tokenAdminWallet.methods.private_get_name().simulate({ from: testWallets.tokenAdminAddress }),
+//     );
+//     expect(name).toBe(testWallets.tokenName);
+//   });
 
-  it('can transfer 10tps tokens', async () => {
-    const recipient = testWallets.recipientWallet.getAddress();
-    const transferAmount = 1n;
+//   it('can transfer 10tps tokens', async () => {
+//     const recipient = testWallets.recipientWallet.getAddress();
+//     const transferAmount = 1n;
 
-    for (const w of testWallets.wallets) {
-      expect(MINT_AMOUNT).toBe(
-        await testWallets.tokenAdminWallet.methods
-          .balance_of_public(w.getAddress())
-          .simulate({ from: testWallets.tokenAdminAddress }),
-      );
-    }
+//     for (const w of testWallets.wallets) {
+//       expect(MINT_AMOUNT).toBe(
+//         await testWallets.tokenAdminWallet.methods
+//           .balance_of_public(w.getAddress())
+//           .simulate({ from: testWallets.tokenAdminAddress }),
+//       );
+//     }
 
-    expect(0n).toBe(
-      await testWallets.tokenAdminWallet.methods
-        .balance_of_public(recipient)
-        .simulate({ from: testWallets.tokenAdminAddress }),
-    );
+//     expect(0n).toBe(
+//       await testWallets.tokenAdminWallet.methods
+//         .balance_of_public(recipient)
+//         .simulate({ from: testWallets.tokenAdminAddress }),
+//     );
 
-    const wallet = testWallets.wallets[0];
+//     const wallet = testWallets.wallets[0];
 
-    const baseTx = await (await TokenContract.at(testWallets.tokenAddress, wallet)).methods
-      .transfer_in_public(wallet.getAddress(), recipient, transferAmount, 0)
-      .prove({ from: testWallets.tokenAdminAddress });
+//     const baseTx = await (await TokenContract.at(testWallets.tokenAddress, wallet)).methods
+//       .transfer_in_public(wallet.getAddress(), recipient, transferAmount, 0)
+//       .prove({ from: testWallets.tokenAdminAddress });
 
-    const allSentTxs: any[] = []; // Store sent transactions separately
+//     const allSentTxs: any[] = []; // Store sent transactions separately
 
-    let globalIdx = 0;
+//     let globalIdx = 0;
 
-    for (let sec = 0; sec < TEST_DURATION_SECONDS; sec++) {
-      const secondStart = Date.now();
+//     for (let sec = 0; sec < TEST_DURATION_SECONDS; sec++) {
+//       const secondStart = Date.now();
 
-      const batchTxs: ProvenTx[] = [];
+//       const batchTxs: ProvenTx[] = [];
 
-      for (let i = 0; i < TARGET_TPS; i++, globalIdx++) {
-        const clonedTxData = Tx.clone(baseTx);
+//       for (let i = 0; i < TARGET_TPS; i++, globalIdx++) {
+//         const clonedTxData = Tx.clone(baseTx);
 
-        const nullifiers = clonedTxData.data.getNonEmptyNullifiers();
-        if (nullifiers.length > 0) {
-          const newNullifier = nullifiers[0].add(Fr.fromString(globalIdx.toString()));
-          if (clonedTxData.data.forRollup) {
-            clonedTxData.data.forRollup.end.nullifiers[0] = newNullifier;
-          } else if (clonedTxData.data.forPublic) {
-            clonedTxData.data.forPublic.nonRevertibleAccumulatedData.nullifiers[0] = newNullifier;
-          }
-        }
+//         const nullifiers = clonedTxData.data.getNonEmptyNullifiers();
+//         if (nullifiers.length > 0) {
+//           const newNullifier = nullifiers[0].add(Fr.fromString(globalIdx.toString()));
+//           if (clonedTxData.data.forRollup) {
+//             clonedTxData.data.forRollup.end.nullifiers[0] = newNullifier;
+//           } else if (clonedTxData.data.forPublic) {
+//             clonedTxData.data.forPublic.nonRevertibleAccumulatedData.nullifiers[0] = newNullifier;
+//           }
+//         }
 
-        const clonedTx = new ProvenTx(wallet, clonedTxData, []);
-        batchTxs.push(clonedTx);
-      }
+//         const clonedTx = new ProvenTx(wallet, clonedTxData, []);
+//         batchTxs.push(clonedTx);
+//       }
 
-      // Send transactions without waiting for inclusion
-      for (let idx = 0; idx < batchTxs.length; idx++) {
-        const tx = batchTxs[idx];
-        const sentTx = tx.send();
-        allSentTxs.push(sentTx);
-        logger.info(`sec ${sec + 1}: sent tx ${globalIdx - TARGET_TPS + idx + 1}`);
-      }
+//       // Send transactions without waiting for inclusion
+//       for (let idx = 0; idx < batchTxs.length; idx++) {
+//         const tx = batchTxs[idx];
+//         const sentTx = tx.send();
+//         allSentTxs.push(sentTx);
+//         logger.info(`sec ${sec + 1}: sent tx ${globalIdx - TARGET_TPS + idx + 1}`);
+//       }
 
-      // 1 second spacing between batches
-      const elapsed = Date.now() - secondStart;
-      if (elapsed < 1000) {
-        await sleep(1000 - elapsed);
-      }
-    }
+//       // 1 second spacing between batches
+//       const elapsed = Date.now() - secondStart;
+//       if (elapsed < 1000) {
+//         await sleep(1000 - elapsed);
+//       }
+//     }
 
-    // Now wait for all transactions to be included
-    logger.info(`All ${TOTAL_TXS} transactions sent. Waiting for inclusion...`);
+//     // Now wait for all transactions to be included
+//     logger.info(`All ${TOTAL_TXS} transactions sent. Waiting for inclusion...`);
 
-    const inclusionPromises = allSentTxs.map((sentTx, idx) =>
-      (async () => {
-        try {
-          await sentTx.wait({
-            timeout: 120,
-            interval: 1,
-            ignoreDroppedReceiptsFor: 2,
-          });
-          const receipt = await sentTx.getReceipt();
-          logger.info(`tx ${idx + 1} included in block ${receipt.blockNumber}`);
-          return { success: true, tx: sentTx };
-        } catch (error) {
-          logger.error(`tx ${idx + 1} was not included: ${error}`);
-          return { success: false, tx: sentTx, error };
-        }
-      })(),
-    );
+//     const inclusionPromises = allSentTxs.map((sentTx, idx) =>
+//       (async () => {
+//         try {
+//           await sentTx.wait({
+//             timeout: 120,
+//             interval: 1,
+//             ignoreDroppedReceiptsFor: 2,
+//           });
+//           const receipt = await sentTx.getReceipt();
+//           logger.info(`tx ${idx + 1} included in block ${receipt.blockNumber}`);
+//           return { success: true, tx: sentTx };
+//         } catch (error) {
+//           logger.error(`tx ${idx + 1} was not included: ${error}`);
+//           return { success: false, tx: sentTx, error };
+//         }
+//       })(),
+//     );
 
-    // Wait for every transaction to be included
-    const results = await Promise.all(inclusionPromises);
+//     // Wait for every transaction to be included
+//     const results = await Promise.all(inclusionPromises);
 
-    // Count successes and failures
-    const successCount = results.filter(r => r.success).length;
-    const failureCount = results.filter(r => !r.success).length;
+//     // Count successes and failures
+//     const successCount = results.filter(r => r.success).length;
+//     const failureCount = results.filter(r => !r.success).length;
 
-    expect(allSentTxs.length).toBe(TOTAL_TXS);
+//     expect(allSentTxs.length).toBe(TOTAL_TXS);
 
-    // Log failed transactions for debugging
-    results
-      .filter(r => !r.success)
-      .forEach((result, idx) => {
-        logger.warn(`Failed transaction ${idx + 1}: ${result.error}`);
-      });
+//     // Log failed transactions for debugging
+//     results
+//       .filter(r => !r.success)
+//       .forEach((result, idx) => {
+//         logger.warn(`Failed transaction ${idx + 1}: ${result.error}`);
+//       });
 
-    logger.info(
-      `Transaction inclusion summary: ${successCount} succeeded, ${failureCount} failed out of ${TOTAL_TXS} total`,
-    );
+//     logger.info(
+//       `Transaction inclusion summary: ${successCount} succeeded, ${failureCount} failed out of ${TOTAL_TXS} total`,
+//     );
 
-    const recipientBalance = await testWallets.tokenAdminWallet.methods
-      .balance_of_public(recipient)
-      .simulate({ from: testWallets.tokenAdminAddress });
-    logger.info(`recipientBalance after load test: ${recipientBalance}`);
-  });
-});
+//     const recipientBalance = await testWallets.tokenAdminWallet.methods
+//       .balance_of_public(recipient)
+//       .simulate({ from: testWallets.tokenAdminAddress });
+//     logger.info(`recipientBalance after load test: ${recipientBalance}`);
+//   });
+// });

--- a/yarn-project/end-to-end/src/spartan/prover-node.test.ts
+++ b/yarn-project/end-to-end/src/spartan/prover-node.test.ts
@@ -1,162 +1,162 @@
-import { retryUntil } from '@aztec/aztec.js';
-import { createLogger } from '@aztec/foundation/log';
+// import { retryUntil } from '@aztec/aztec.js';
+// import { createLogger } from '@aztec/foundation/log';
 
-import type { ChildProcess } from 'child_process';
+// import type { ChildProcess } from 'child_process';
 
-import { AlertTriggeredError } from '../quality_of_service/alert_checker.js';
-import {
-  applyProverBrokerKill,
-  applyProverKill,
-  isK8sConfig,
-  runAlertCheck,
-  setupEnvironment,
-  startPortForward,
-} from './utils.js';
+// import { AlertTriggeredError } from '../quality_of_service/alert_checker.js';
+// import {
+//   applyProverBrokerKill,
+//   applyProverKill,
+//   isK8sConfig,
+//   runAlertCheck,
+//   setupEnvironment,
+//   startPortForward,
+// } from './utils.js';
 
-const config = setupEnvironment(process.env);
-if (!isK8sConfig(config)) {
-  throw new Error('This test requires running in K8s');
-}
+// const config = setupEnvironment(process.env);
+// if (!isK8sConfig(config)) {
+//   throw new Error('This test requires running in K8s');
+// }
 
-const logger = createLogger('e2e:spartan-test:prover-node');
+// const logger = createLogger('e2e:spartan-test:prover-node');
 
-/**
- * This test aims to check that a prover node is able to recover after a crash.
- * How do we that? We check what proofs get submitted to the broker when the node comes back online
- * If everything works as expected, the broker should report a bunch of 'cached' proving jobs.
- * This would be the prover node coming back online and starting the proving process over.
- * Because the proving jobs are cached their results will be available immediately.
- *
- * We'll wait for an epoch to be partially proven (at least one BLOCK_ROOT_ROLLUP has been submitted) so that the next time the prover starts it'll hit the cache.
- */
-const interval = '1m';
-const cachedProvingJobs = {
-  alert: 'CachedProvingJobRate',
-  expr: `increase(sum(last_over_time(aztec_proving_queue_cached_jobs_count[${interval}]) or vector(0))[${interval}:])`,
-  labels: { severity: 'error' },
-  for: interval,
-  annotations: {},
-};
+// /**
+//  * This test aims to check that a prover node is able to recover after a crash.
+//  * How do we that? We check what proofs get submitted to the broker when the node comes back online
+//  * If everything works as expected, the broker should report a bunch of 'cached' proving jobs.
+//  * This would be the prover node coming back online and starting the proving process over.
+//  * Because the proving jobs are cached their results will be available immediately.
+//  *
+//  * We'll wait for an epoch to be partially proven (at least one BLOCK_ROOT_ROLLUP has been submitted) so that the next time the prover starts it'll hit the cache.
+//  */
+// const interval = '1m';
+// const cachedProvingJobs = {
+//   alert: 'CachedProvingJobRate',
+//   expr: `increase(sum(last_over_time(aztec_proving_queue_cached_jobs_count[${interval}]) or vector(0))[${interval}:])`,
+//   labels: { severity: 'error' },
+//   for: interval,
+//   annotations: {},
+// };
 
-const enqueuedBlockRollupJobs = {
-  alert: 'EnqueuedBlockRootRollup',
-  expr: `rate(aztec_proving_queue_enqueued_jobs_count{aztec_proving_job_type=~"BLOCK_ROOT_ROLLUP|SINGLE_TX_BLOCK_ROOT_ROLLUP"}[${interval}])>0`,
-  labels: { severity: 'error' },
-  for: interval,
-  annotations: {},
-};
+// const enqueuedBlockRollupJobs = {
+//   alert: 'EnqueuedBlockRootRollup',
+//   expr: `rate(aztec_proving_queue_enqueued_jobs_count{aztec_proving_job_type=~"BLOCK_ROOT_ROLLUP|SINGLE_TX_BLOCK_ROOT_ROLLUP"}[${interval}])>0`,
+//   labels: { severity: 'error' },
+//   for: interval,
+//   annotations: {},
+// };
 
-const enqueuedRootRollupJobs = {
-  alert: 'EnqueuedRootRollup',
-  expr: `rate(aztec_proving_queue_enqueued_jobs_count{aztec_proving_job_type="ROOT_ROLLUP"}[${interval}])>0`,
-  labels: { severity: 'error' },
-  for: interval,
-  annotations: {},
-};
+// const enqueuedRootRollupJobs = {
+//   alert: 'EnqueuedRootRollup',
+//   expr: `rate(aztec_proving_queue_enqueued_jobs_count{aztec_proving_job_type="ROOT_ROLLUP"}[${interval}])>0`,
+//   labels: { severity: 'error' },
+//   for: interval,
+//   annotations: {},
+// };
 
-describe('prover node recovery', () => {
-  const forwardProcesses: ChildProcess[] = [];
-  beforeAll(async () => {
-    const { process } = await startPortForward({
-      resource: `svc/metrics-grafana`,
-      namespace: 'metrics',
-      containerPort: config.CONTAINER_METRICS_PORT,
-    });
-    forwardProcesses.push(process);
-  });
+// describe('prover node recovery', () => {
+//   const forwardProcesses: ChildProcess[] = [];
+//   beforeAll(async () => {
+//     const { process } = await startPortForward({
+//       resource: `svc/metrics-grafana`,
+//       namespace: 'metrics',
+//       containerPort: config.CONTAINER_METRICS_PORT,
+//     });
+//     forwardProcesses.push(process);
+//   });
 
-  afterAll(() => {
-    forwardProcesses.forEach(p => p.kill());
-  });
+//   afterAll(() => {
+//     forwardProcesses.forEach(p => p.kill());
+//   });
 
-  it('should recover after a crash', async () => {
-    logger.info(`Waiting for epoch to be partially proven`);
+//   it('should recover after a crash', async () => {
+//     logger.info(`Waiting for epoch to be partially proven`);
 
-    // use the alert checker to wait until grafana picks up a proof has started
-    await retryUntil(
-      async () => {
-        try {
-          await runAlertCheck(config, [enqueuedBlockRollupJobs], logger);
-        } catch (err) {
-          return err && err instanceof AlertTriggeredError;
-        }
-      },
-      'wait for proofs',
-      600,
-      5,
-    );
+//     // use the alert checker to wait until grafana picks up a proof has started
+//     await retryUntil(
+//       async () => {
+//         try {
+//           await runAlertCheck(config, [enqueuedBlockRollupJobs], logger);
+//         } catch (err) {
+//           return err && err instanceof AlertTriggeredError;
+//         }
+//       },
+//       'wait for proofs',
+//       600,
+//       5,
+//     );
 
-    logger.info(`Detected partial epoch proven. Killing the prover node`);
+//     logger.info(`Detected partial epoch proven. Killing the prover node`);
 
-    await applyProverKill({
-      namespace: config.NAMESPACE,
-      spartanDir: config.SPARTAN_DIR,
-      logger,
-    });
+//     await applyProverKill({
+//       namespace: config.NAMESPACE,
+//       spartanDir: config.SPARTAN_DIR,
+//       logger,
+//     });
 
-    // wait for the node to start proving again and
-    // validate it hits the cache
-    const result = await retryUntil(
-      async () => {
-        try {
-          await runAlertCheck(config, [cachedProvingJobs], logger);
-        } catch (err) {
-          if (err && err instanceof AlertTriggeredError) {
-            return true;
-          }
-        }
-        return false;
-      },
-      'wait for cached proving jobs',
-      600,
-      5,
-    );
+//     // wait for the node to start proving again and
+//     // validate it hits the cache
+//     const result = await retryUntil(
+//       async () => {
+//         try {
+//           await runAlertCheck(config, [cachedProvingJobs], logger);
+//         } catch (err) {
+//           if (err && err instanceof AlertTriggeredError) {
+//             return true;
+//           }
+//         }
+//         return false;
+//       },
+//       'wait for cached proving jobs',
+//       600,
+//       5,
+//     );
 
-    expect(result).toBeTrue();
-  }, 1_800_000);
+//     expect(result).toBeTrue();
+//   }, 1_800_000);
 
-  it('should recover after a broker crash', async () => {
-    logger.info(`Waiting for epoch proving job to start`);
+//   it('should recover after a broker crash', async () => {
+//     logger.info(`Waiting for epoch proving job to start`);
 
-    // use the alert checker to wait until grafana picks up a proof has started
-    await retryUntil(
-      async () => {
-        try {
-          await runAlertCheck(config, [enqueuedBlockRollupJobs], logger);
-        } catch {
-          return true;
-        }
-      },
-      'wait for epoch',
-      600,
-      5,
-    );
+//     // use the alert checker to wait until grafana picks up a proof has started
+//     await retryUntil(
+//       async () => {
+//         try {
+//           await runAlertCheck(config, [enqueuedBlockRollupJobs], logger);
+//         } catch {
+//           return true;
+//         }
+//       },
+//       'wait for epoch',
+//       600,
+//       5,
+//     );
 
-    logger.info(`Detected epoch proving job. Killing the broker`);
+//     logger.info(`Detected epoch proving job. Killing the broker`);
 
-    await applyProverBrokerKill({
-      namespace: config.NAMESPACE,
-      spartanDir: config.SPARTAN_DIR,
-      logger,
-    });
+//     await applyProverBrokerKill({
+//       namespace: config.NAMESPACE,
+//       spartanDir: config.SPARTAN_DIR,
+//       logger,
+//     });
 
-    // wait for the broker to come back online and for proving to continue
-    const result = await retryUntil(
-      async () => {
-        try {
-          await runAlertCheck(config, [enqueuedRootRollupJobs], logger);
-        } catch (err) {
-          if (err && err instanceof AlertTriggeredError) {
-            return true;
-          }
-        }
-        return false;
-      },
-      'wait for root rollup',
-      600,
-      5,
-    );
+//     // wait for the broker to come back online and for proving to continue
+//     const result = await retryUntil(
+//       async () => {
+//         try {
+//           await runAlertCheck(config, [enqueuedRootRollupJobs], logger);
+//         } catch (err) {
+//           if (err && err instanceof AlertTriggeredError) {
+//             return true;
+//           }
+//         }
+//         return false;
+//       },
+//       'wait for root rollup',
+//       600,
+//       5,
+//     );
 
-    expect(result).toBeTrue();
-  }, 1_800_000);
-});
+//     expect(result).toBeTrue();
+//   }, 1_800_000);
+// });

--- a/yarn-project/end-to-end/src/spartan/proving.test.ts
+++ b/yarn-project/end-to-end/src/spartan/proving.test.ts
@@ -1,73 +1,73 @@
-import { type PXE, createCompatibleClient, sleep } from '@aztec/aztec.js';
-import { createLogger } from '@aztec/foundation/log';
+// import { type PXE, createCompatibleClient, sleep } from '@aztec/aztec.js';
+// import { createLogger } from '@aztec/foundation/log';
 
-import { jest } from '@jest/globals';
-import type { ChildProcess } from 'child_process';
+// import { jest } from '@jest/globals';
+// import type { ChildProcess } from 'child_process';
 
-import { isK8sConfig, setupEnvironment, startPortForward } from './utils.js';
+// import { isK8sConfig, setupEnvironment, startPortForward } from './utils.js';
 
-jest.setTimeout(2_400_000); // 40 minutes
+// jest.setTimeout(2_400_000); // 40 minutes
 
-const config = setupEnvironment(process.env);
-const debugLogger = createLogger('e2e:spartan-test:proving');
-const SLEEP_MS = 1000;
+// const config = setupEnvironment(process.env);
+// const debugLogger = createLogger('e2e:spartan-test:proving');
+// const SLEEP_MS = 1000;
 
-describe('proving test', () => {
-  let pxe: PXE;
-  const forwardProcesses: ChildProcess[] = [];
-  beforeAll(async () => {
-    let PXE_URL;
-    if (isK8sConfig(config)) {
-      const { process, port } = await startPortForward({
-        resource: `svc/${config.INSTANCE_NAME}-aztec-network-pxe`,
-        namespace: config.NAMESPACE,
-        containerPort: config.CONTAINER_PXE_PORT,
-      });
-      forwardProcesses.push(process);
-      PXE_URL = `http://127.0.0.1:${port}`;
-    } else {
-      PXE_URL = config.PXE_URL;
-    }
-    pxe = await createCompatibleClient(PXE_URL, debugLogger);
-  });
+// describe('proving test', () => {
+//   let pxe: PXE;
+//   const forwardProcesses: ChildProcess[] = [];
+//   beforeAll(async () => {
+//     let PXE_URL;
+//     if (isK8sConfig(config)) {
+//       const { process, port } = await startPortForward({
+//         resource: `svc/${config.INSTANCE_NAME}-aztec-network-pxe`,
+//         namespace: config.NAMESPACE,
+//         containerPort: config.CONTAINER_PXE_PORT,
+//       });
+//       forwardProcesses.push(process);
+//       PXE_URL = `http://127.0.0.1:${port}`;
+//     } else {
+//       PXE_URL = config.PXE_URL;
+//     }
+//     pxe = await createCompatibleClient(PXE_URL, debugLogger);
+//   });
 
-  afterAll(() => {
-    forwardProcesses.forEach(p => p.kill());
-  });
+//   afterAll(() => {
+//     forwardProcesses.forEach(p => p.kill());
+//   });
 
-  it('advances the proven chain', async () => {
-    let [provenBlockNumber, blockNumber] = await Promise.all([pxe.getProvenBlockNumber(), pxe.getBlockNumber()]);
-    let ok: boolean;
+//   it('advances the proven chain', async () => {
+//     let [provenBlockNumber, blockNumber] = await Promise.all([pxe.getProvenBlockNumber(), pxe.getBlockNumber()]);
+//     let ok: boolean;
 
-    debugLogger.info(`Initial pending chain tip: ${blockNumber}`);
-    debugLogger.info(`Initial proven chain tip: ${provenBlockNumber}`);
+//     debugLogger.info(`Initial pending chain tip: ${blockNumber}`);
+//     debugLogger.info(`Initial proven chain tip: ${provenBlockNumber}`);
 
-    while (true) {
-      const [newProvenBlockNumber, newBlockNumber] = await Promise.all([
-        pxe.getProvenBlockNumber(),
-        pxe.getBlockNumber(),
-      ]);
+//     while (true) {
+//       const [newProvenBlockNumber, newBlockNumber] = await Promise.all([
+//         pxe.getProvenBlockNumber(),
+//         pxe.getBlockNumber(),
+//       ]);
 
-      if (newBlockNumber > blockNumber) {
-        debugLogger.info(`Pending chain has advanced: ${blockNumber} -> ${newBlockNumber}`);
-      } else if (newBlockNumber < blockNumber) {
-        debugLogger.error(`Pending chain has been pruned: ${blockNumber} -> ${newBlockNumber}`);
-        ok = false;
-        break;
-      }
+//       if (newBlockNumber > blockNumber) {
+//         debugLogger.info(`Pending chain has advanced: ${blockNumber} -> ${newBlockNumber}`);
+//       } else if (newBlockNumber < blockNumber) {
+//         debugLogger.error(`Pending chain has been pruned: ${blockNumber} -> ${newBlockNumber}`);
+//         ok = false;
+//         break;
+//       }
 
-      if (newProvenBlockNumber > provenBlockNumber) {
-        debugLogger.info(`Proven chain has advanced: ${provenBlockNumber} -> ${newProvenBlockNumber}`);
-        ok = true;
-        break;
-      }
+//       if (newProvenBlockNumber > provenBlockNumber) {
+//         debugLogger.info(`Proven chain has advanced: ${provenBlockNumber} -> ${newProvenBlockNumber}`);
+//         ok = true;
+//         break;
+//       }
 
-      provenBlockNumber = newProvenBlockNumber;
-      blockNumber = newBlockNumber;
+//       provenBlockNumber = newProvenBlockNumber;
+//       blockNumber = newBlockNumber;
 
-      await sleep(SLEEP_MS);
-    }
+//       await sleep(SLEEP_MS);
+//     }
 
-    expect(ok).toBeTrue();
-  });
-});
+//     expect(ok).toBeTrue();
+//   });
+// });

--- a/yarn-project/end-to-end/src/spartan/reorg.test.ts
+++ b/yarn-project/end-to-end/src/spartan/reorg.test.ts
@@ -1,137 +1,137 @@
-import { sleep } from '@aztec/aztec.js';
-import { RollupCheatCodes } from '@aztec/aztec/testing';
-import { EthCheatCodesWithState } from '@aztec/ethereum/test';
-import { createLogger } from '@aztec/foundation/log';
+// import { sleep } from '@aztec/aztec.js';
+// import { RollupCheatCodes } from '@aztec/aztec/testing';
+// import { EthCheatCodesWithState } from '@aztec/ethereum/test';
+// import { createLogger } from '@aztec/foundation/log';
 
-import { expect, jest } from '@jest/globals';
-import type { ChildProcess } from 'child_process';
+// import { expect, jest } from '@jest/globals';
+// import type { ChildProcess } from 'child_process';
 
-import { type TestWallets, performTransfers, setupTestWalletsWithTokens } from './setup_test_wallets.js';
-import {
-  applyProverFailure,
-  deleteResourceByLabel,
-  isK8sConfig,
-  setupEnvironment,
-  startPortForward,
-  waitForResourceByLabel,
-} from './utils.js';
+// import { type TestWallets, performTransfers, setupTestWalletsWithTokens } from './setup_test_wallets.js';
+// import {
+//   applyProverFailure,
+//   deleteResourceByLabel,
+//   isK8sConfig,
+//   setupEnvironment,
+//   startPortForward,
+//   waitForResourceByLabel,
+// } from './utils.js';
 
-const config = setupEnvironment(process.env);
-if (!isK8sConfig(config)) {
-  throw new Error('This test must be run in a k8s environment');
-}
-const { NAMESPACE, CONTAINER_PXE_PORT, CONTAINER_ETHEREUM_PORT, SPARTAN_DIR } = config;
-const debugLogger = createLogger('e2e:spartan-test:reorg');
+// const config = setupEnvironment(process.env);
+// if (!isK8sConfig(config)) {
+//   throw new Error('This test must be run in a k8s environment');
+// }
+// const { NAMESPACE, CONTAINER_PXE_PORT, CONTAINER_ETHEREUM_PORT, SPARTAN_DIR } = config;
+// const debugLogger = createLogger('e2e:spartan-test:reorg');
 
-async function checkBalances(testWallets: TestWallets, mintAmount: bigint, totalAmountTransferred: bigint) {
-  for (const w of testWallets.wallets) {
-    expect(
-      await testWallets.tokenAdminWallet.methods
-        .balance_of_public(w.getAddress())
-        .simulate({ from: testWallets.tokenAdminAddress }),
-    ).toBe(mintAmount - totalAmountTransferred);
-  }
+// async function checkBalances(testWallets: TestWallets, mintAmount: bigint, totalAmountTransferred: bigint) {
+//   for (const w of testWallets.wallets) {
+//     expect(
+//       await testWallets.tokenAdminWallet.methods
+//         .balance_of_public(w.getAddress())
+//         .simulate({ from: testWallets.tokenAdminAddress }),
+//     ).toBe(mintAmount - totalAmountTransferred);
+//   }
 
-  expect(
-    await testWallets.tokenAdminWallet.methods
-      .balance_of_public(testWallets.recipientWallet.getAddress())
-      .simulate({ from: testWallets.tokenAdminAddress }),
-  ).toBe(totalAmountTransferred * BigInt(testWallets.wallets.length));
-}
+//   expect(
+//     await testWallets.tokenAdminWallet.methods
+//       .balance_of_public(testWallets.recipientWallet.getAddress())
+//       .simulate({ from: testWallets.tokenAdminAddress }),
+//   ).toBe(totalAmountTransferred * BigInt(testWallets.wallets.length));
+// }
 
-describe('reorg test', () => {
-  jest.setTimeout(60 * 60 * 1000); // 60 minutes
+// describe('reorg test', () => {
+//   jest.setTimeout(60 * 60 * 1000); // 60 minutes
 
-  const MINT_AMOUNT = 2_000_000n;
-  const SETUP_EPOCHS = 2;
-  const TRANSFER_AMOUNT = 1n;
-  let ETHEREUM_HOSTS: string;
-  let PXE_URL: string;
-  const forwardProcesses: ChildProcess[] = [];
+//   const MINT_AMOUNT = 2_000_000n;
+//   const SETUP_EPOCHS = 2;
+//   const TRANSFER_AMOUNT = 1n;
+//   let ETHEREUM_HOSTS: string;
+//   let PXE_URL: string;
+//   const forwardProcesses: ChildProcess[] = [];
 
-  let testWallets: TestWallets;
+//   let testWallets: TestWallets;
 
-  afterAll(() => {
-    forwardProcesses.forEach(p => p.kill());
-  });
+//   afterAll(() => {
+//     forwardProcesses.forEach(p => p.kill());
+//   });
 
-  it('survives a reorg', async () => {
-    const { process: pxeProcess, port: pxePort } = await startPortForward({
-      resource: `svc/${config.INSTANCE_NAME}-aztec-network-pxe`,
-      namespace: NAMESPACE,
-      containerPort: CONTAINER_PXE_PORT,
-    });
-    forwardProcesses.push(pxeProcess);
-    PXE_URL = `http://127.0.0.1:${pxePort}`;
+//   it('survives a reorg', async () => {
+//     const { process: pxeProcess, port: pxePort } = await startPortForward({
+//       resource: `svc/${config.INSTANCE_NAME}-aztec-network-pxe`,
+//       namespace: NAMESPACE,
+//       containerPort: CONTAINER_PXE_PORT,
+//     });
+//     forwardProcesses.push(pxeProcess);
+//     PXE_URL = `http://127.0.0.1:${pxePort}`;
 
-    const { process: ethProcess, port: ethPort } = await startPortForward({
-      resource: `svc/${config.INSTANCE_NAME}-aztec-network-eth-execution`,
-      namespace: NAMESPACE,
-      containerPort: CONTAINER_ETHEREUM_PORT,
-    });
-    forwardProcesses.push(ethProcess);
-    ETHEREUM_HOSTS = `http://127.0.0.1:${ethPort}`;
-    testWallets = await setupTestWalletsWithTokens(PXE_URL, MINT_AMOUNT, debugLogger);
-    const rollupCheatCodes = new RollupCheatCodes(
-      new EthCheatCodesWithState([ETHEREUM_HOSTS]),
-      await testWallets.pxe.getNodeInfo().then(n => n.l1ContractAddresses),
-    );
-    const { epochDuration, slotDuration } = await rollupCheatCodes.getConfig();
+//     const { process: ethProcess, port: ethPort } = await startPortForward({
+//       resource: `svc/${config.INSTANCE_NAME}-aztec-network-eth-execution`,
+//       namespace: NAMESPACE,
+//       containerPort: CONTAINER_ETHEREUM_PORT,
+//     });
+//     forwardProcesses.push(ethProcess);
+//     ETHEREUM_HOSTS = `http://127.0.0.1:${ethPort}`;
+//     testWallets = await setupTestWalletsWithTokens(PXE_URL, MINT_AMOUNT, debugLogger);
+//     const rollupCheatCodes = new RollupCheatCodes(
+//       new EthCheatCodesWithState([ETHEREUM_HOSTS]),
+//       await testWallets.pxe.getNodeInfo().then(n => n.l1ContractAddresses),
+//     );
+//     const { epochDuration, slotDuration } = await rollupCheatCodes.getConfig();
 
-    await performTransfers({
-      testWallets,
-      rounds: Number(epochDuration) * SETUP_EPOCHS,
-      transferAmount: TRANSFER_AMOUNT,
-      logger: debugLogger,
-    });
-    await checkBalances(testWallets, MINT_AMOUNT, TRANSFER_AMOUNT * epochDuration * BigInt(SETUP_EPOCHS));
+//     await performTransfers({
+//       testWallets,
+//       rounds: Number(epochDuration) * SETUP_EPOCHS,
+//       transferAmount: TRANSFER_AMOUNT,
+//       logger: debugLogger,
+//     });
+//     await checkBalances(testWallets, MINT_AMOUNT, TRANSFER_AMOUNT * epochDuration * BigInt(SETUP_EPOCHS));
 
-    // get the tips before the reorg
-    const { pending: preReorgPending, proven: preReorgProven } = await rollupCheatCodes.getTips();
+//     // get the tips before the reorg
+//     const { pending: preReorgPending, proven: preReorgProven } = await rollupCheatCodes.getTips();
 
-    // kill the provers
-    const stdout = await applyProverFailure({
-      namespace: NAMESPACE,
-      spartanDir: SPARTAN_DIR,
-      durationSeconds: Number(epochDuration * slotDuration) * 2,
-      logger: debugLogger,
-    });
-    debugLogger.info(stdout);
+//     // kill the provers
+//     const stdout = await applyProverFailure({
+//       namespace: NAMESPACE,
+//       spartanDir: SPARTAN_DIR,
+//       durationSeconds: Number(epochDuration * slotDuration) * 2,
+//       logger: debugLogger,
+//     });
+//     debugLogger.info(stdout);
 
-    // We only need 2 epochs for a reorg to be triggered, but 3 gives time for the bot to be restarted and the chain to re-stabilize
-    // TODO(#9613): why do we need to wait for 3 epochs?
-    debugLogger.info(`Waiting for 3 epochs to pass`);
-    await sleep(Number(epochDuration * slotDuration) * 3 * 1000);
+//     // We only need 2 epochs for a reorg to be triggered, but 3 gives time for the bot to be restarted and the chain to re-stabilize
+//     // TODO(#9613): why do we need to wait for 3 epochs?
+//     debugLogger.info(`Waiting for 3 epochs to pass`);
+//     await sleep(Number(epochDuration * slotDuration) * 3 * 1000);
 
-    // TODO(#9327): begin delete
-    // The bot must be restarted because the PXE does not handle reorgs without a restart.
-    // When the issue is fixed, we can remove the following delete, wait, startPortForward, and setupTestWallets
-    await deleteResourceByLabel({ resource: 'pods', namespace: NAMESPACE, label: 'app=pxe' });
-    await sleep(30 * 1000);
-    await waitForResourceByLabel({ resource: 'pods', namespace: NAMESPACE, label: 'app=pxe' });
-    await sleep(30 * 1000);
-    await startPortForward({
-      resource: `svc/${config.INSTANCE_NAME}-aztec-network-pxe`,
-      namespace: NAMESPACE,
-      containerPort: CONTAINER_PXE_PORT,
-    });
-    forwardProcesses.push(pxeProcess);
-    PXE_URL = `http://127.0.0.1:${pxePort}`;
-    testWallets = await setupTestWalletsWithTokens(PXE_URL, MINT_AMOUNT, debugLogger);
-    // TODO(#9327): end delete
+//     // TODO(#9327): begin delete
+//     // The bot must be restarted because the PXE does not handle reorgs without a restart.
+//     // When the issue is fixed, we can remove the following delete, wait, startPortForward, and setupTestWallets
+//     await deleteResourceByLabel({ resource: 'pods', namespace: NAMESPACE, label: 'app=pxe' });
+//     await sleep(30 * 1000);
+//     await waitForResourceByLabel({ resource: 'pods', namespace: NAMESPACE, label: 'app=pxe' });
+//     await sleep(30 * 1000);
+//     await startPortForward({
+//       resource: `svc/${config.INSTANCE_NAME}-aztec-network-pxe`,
+//       namespace: NAMESPACE,
+//       containerPort: CONTAINER_PXE_PORT,
+//     });
+//     forwardProcesses.push(pxeProcess);
+//     PXE_URL = `http://127.0.0.1:${pxePort}`;
+//     testWallets = await setupTestWalletsWithTokens(PXE_URL, MINT_AMOUNT, debugLogger);
+//     // TODO(#9327): end delete
 
-    await performTransfers({
-      testWallets,
-      rounds: Number(epochDuration) * SETUP_EPOCHS,
-      transferAmount: TRANSFER_AMOUNT,
-      logger: debugLogger,
-    });
+//     await performTransfers({
+//       testWallets,
+//       rounds: Number(epochDuration) * SETUP_EPOCHS,
+//       transferAmount: TRANSFER_AMOUNT,
+//       logger: debugLogger,
+//     });
 
-    // expect the block height to be at least 4 epochs worth of slots
-    const { pending: newPending, proven: newProven } = await rollupCheatCodes.getTips();
-    expect(newPending).toBeGreaterThan(preReorgPending);
-    expect(newPending).toBeGreaterThan(4 * Number(epochDuration));
-    expect(newProven).toBeGreaterThan(preReorgProven);
-    expect(newProven).toBeGreaterThan(3 * Number(epochDuration));
-  });
-});
+//     // expect the block height to be at least 4 epochs worth of slots
+//     const { pending: newPending, proven: newProven } = await rollupCheatCodes.getTips();
+//     expect(newPending).toBeGreaterThan(preReorgPending);
+//     expect(newPending).toBeGreaterThan(4 * Number(epochDuration));
+//     expect(newProven).toBeGreaterThan(preReorgProven);
+//     expect(newProven).toBeGreaterThan(3 * Number(epochDuration));
+//   });
+// });

--- a/yarn-project/end-to-end/src/spartan/upgrade_governance_proposer.test.ts
+++ b/yarn-project/end-to-end/src/spartan/upgrade_governance_proposer.test.ts
@@ -1,175 +1,175 @@
-import { EthAddress, type NodeInfo, type PXE, createCompatibleClient, sleep } from '@aztec/aztec.js';
-import {
-  GovernanceProposerContract,
-  RollupContract,
-  createEthereumChain,
-  createExtendedL1Client,
-  createL1TxUtilsFromViemWallet,
-  deployL1Contract,
-} from '@aztec/ethereum';
-import { createLogger } from '@aztec/foundation/log';
-import { NewGovernanceProposerPayloadAbi } from '@aztec/l1-artifacts/NewGovernanceProposerPayloadAbi';
-import { NewGovernanceProposerPayloadBytecode } from '@aztec/l1-artifacts/NewGovernanceProposerPayloadBytecode';
+// import { EthAddress, type NodeInfo, type PXE, createCompatibleClient, sleep } from '@aztec/aztec.js';
+// import {
+//   GovernanceProposerContract,
+//   RollupContract,
+//   createEthereumChain,
+//   createExtendedL1Client,
+//   createL1TxUtilsFromViemWallet,
+//   deployL1Contract,
+// } from '@aztec/ethereum';
+// import { createLogger } from '@aztec/foundation/log';
+// import { NewGovernanceProposerPayloadAbi } from '@aztec/l1-artifacts/NewGovernanceProposerPayloadAbi';
+// import { NewGovernanceProposerPayloadBytecode } from '@aztec/l1-artifacts/NewGovernanceProposerPayloadBytecode';
 
-import type { ChildProcess } from 'child_process';
-import { privateKeyToAccount } from 'viem/accounts';
-import { parseEther, stringify } from 'viem/utils';
+// import type { ChildProcess } from 'child_process';
+// import { privateKeyToAccount } from 'viem/accounts';
+// import { parseEther, stringify } from 'viem/utils';
 
-import { MNEMONIC } from '../fixtures/fixtures.js';
-import { isK8sConfig, setupEnvironment, startPortForward, updateSequencersConfig } from './utils.js';
+// import { MNEMONIC } from '../fixtures/fixtures.js';
+// import { isK8sConfig, setupEnvironment, startPortForward, updateSequencersConfig } from './utils.js';
 
-// random private key
-const deployerPrivateKey = '0x23206a40226aad90d5673b8adbbcfe94a617e7a6f9e59fc68615fe1bd4bc72f1';
+// // random private key
+// const deployerPrivateKey = '0x23206a40226aad90d5673b8adbbcfe94a617e7a6f9e59fc68615fe1bd4bc72f1';
 
-const config = setupEnvironment(process.env);
-if (!isK8sConfig(config)) {
-  throw new Error('This test must be run in a k8s environment');
-}
+// const config = setupEnvironment(process.env);
+// if (!isK8sConfig(config)) {
+//   throw new Error('This test must be run in a k8s environment');
+// }
 
-const debugLogger = createLogger('e2e:spartan-test:upgrade_governance_proposer');
+// const debugLogger = createLogger('e2e:spartan-test:upgrade_governance_proposer');
 
-describe('spartan_upgrade_governance_proposer', () => {
-  let pxe: PXE;
-  let nodeInfo: NodeInfo;
-  let ETHEREUM_HOSTS: string[];
-  const forwardProcesses: ChildProcess[] = [];
+// describe('spartan_upgrade_governance_proposer', () => {
+//   let pxe: PXE;
+//   let nodeInfo: NodeInfo;
+//   let ETHEREUM_HOSTS: string[];
+//   const forwardProcesses: ChildProcess[] = [];
 
-  afterAll(() => {
-    forwardProcesses.forEach(p => p.kill());
-  });
+//   afterAll(() => {
+//     forwardProcesses.forEach(p => p.kill());
+//   });
 
-  beforeAll(async () => {
-    const { process: pxeProcess, port: pxePort } = await startPortForward({
-      resource: `svc/${config.INSTANCE_NAME}-aztec-network-pxe`,
-      namespace: config.NAMESPACE,
-      containerPort: config.CONTAINER_PXE_PORT,
-    });
-    forwardProcesses.push(pxeProcess);
-    const PXE_URL = `http://127.0.0.1:${pxePort}`;
+//   beforeAll(async () => {
+//     const { process: pxeProcess, port: pxePort } = await startPortForward({
+//       resource: `svc/${config.INSTANCE_NAME}-aztec-network-pxe`,
+//       namespace: config.NAMESPACE,
+//       containerPort: config.CONTAINER_PXE_PORT,
+//     });
+//     forwardProcesses.push(pxeProcess);
+//     const PXE_URL = `http://127.0.0.1:${pxePort}`;
 
-    const { process: ethProcess, port: ethPort } = await startPortForward({
-      resource: `svc/${config.INSTANCE_NAME}-aztec-network-eth-execution`,
-      namespace: config.NAMESPACE,
-      containerPort: config.CONTAINER_ETHEREUM_PORT,
-    });
-    forwardProcesses.push(ethProcess);
-    ETHEREUM_HOSTS = [`http://127.0.0.1:${ethPort}`];
+//     const { process: ethProcess, port: ethPort } = await startPortForward({
+//       resource: `svc/${config.INSTANCE_NAME}-aztec-network-eth-execution`,
+//       namespace: config.NAMESPACE,
+//       containerPort: config.CONTAINER_ETHEREUM_PORT,
+//     });
+//     forwardProcesses.push(ethProcess);
+//     ETHEREUM_HOSTS = [`http://127.0.0.1:${ethPort}`];
 
-    pxe = await createCompatibleClient(PXE_URL, debugLogger);
-    nodeInfo = await pxe.getNodeInfo();
-  });
+//     pxe = await createCompatibleClient(PXE_URL, debugLogger);
+//     nodeInfo = await pxe.getNodeInfo();
+//   });
 
-  // We need a separate account to deploy the new governance proposer
-  // because the underlying validators are currently producing blob transactions
-  // and you can't submit blob and non-blob transactions from the same account
-  const setupDeployerAccount = async () => {
-    const chain = createEthereumChain(ETHEREUM_HOSTS, 1337);
-    const validatorWalletClient = createExtendedL1Client(ETHEREUM_HOSTS, MNEMONIC, chain.chainInfo);
-    // const privateKey = generatePrivateKey();
-    const privateKey = deployerPrivateKey;
-    debugLogger.info(`deployer privateKey: ${privateKey}`);
-    const account = privateKeyToAccount(privateKey);
-    // check the balance of the account
-    const balance = await validatorWalletClient.getBalance({ address: account.address });
-    debugLogger.info(`deployer balance: ${balance}`);
-    if (balance <= parseEther('5')) {
-      debugLogger.info('sending some eth to the deployer account');
-      // send some eth to the account
-      const tx = await validatorWalletClient.sendTransaction({
-        to: account.address,
-        value: parseEther('10'),
-      });
-      const receipt = await validatorWalletClient.waitForTransactionReceipt({ hash: tx });
-      debugLogger.info(`receipt: ${stringify(receipt)}`);
-    }
-    return createExtendedL1Client(ETHEREUM_HOSTS, account, chain.chainInfo);
-  };
+//   // We need a separate account to deploy the new governance proposer
+//   // because the underlying validators are currently producing blob transactions
+//   // and you can't submit blob and non-blob transactions from the same account
+//   const setupDeployerAccount = async () => {
+//     const chain = createEthereumChain(ETHEREUM_HOSTS, 1337);
+//     const validatorWalletClient = createExtendedL1Client(ETHEREUM_HOSTS, MNEMONIC, chain.chainInfo);
+//     // const privateKey = generatePrivateKey();
+//     const privateKey = deployerPrivateKey;
+//     debugLogger.info(`deployer privateKey: ${privateKey}`);
+//     const account = privateKeyToAccount(privateKey);
+//     // check the balance of the account
+//     const balance = await validatorWalletClient.getBalance({ address: account.address });
+//     debugLogger.info(`deployer balance: ${balance}`);
+//     if (balance <= parseEther('5')) {
+//       debugLogger.info('sending some eth to the deployer account');
+//       // send some eth to the account
+//       const tx = await validatorWalletClient.sendTransaction({
+//         to: account.address,
+//         value: parseEther('10'),
+//       });
+//       const receipt = await validatorWalletClient.waitForTransactionReceipt({ hash: tx });
+//       debugLogger.info(`receipt: ${stringify(receipt)}`);
+//     }
+//     return createExtendedL1Client(ETHEREUM_HOSTS, account, chain.chainInfo);
+//   };
 
-  it(
-    'should deploy new governance proposer',
-    async () => {
-      /** Helpers */
-      const govInfo = async () => {
-        const bn = await l1Client.getBlockNumber();
-        const slot = await rollup.getSlotNumber();
-        const round = await governanceProposer.computeRound(slot);
-        const info = await governanceProposer.getRoundInfo(
-          nodeInfo.l1ContractAddresses.rollupAddress.toString(),
-          round,
-        );
-        const leaderVotes = await governanceProposer.getPayloadSignals(
-          nodeInfo.l1ContractAddresses.rollupAddress.toString(),
-          round,
-          info.payloadWithMostSignals,
-        );
-        return { bn, slot, round, info, leaderVotes };
-      };
+//   it(
+//     'should deploy new governance proposer',
+//     async () => {
+//       /** Helpers */
+//       const govInfo = async () => {
+//         const bn = await l1Client.getBlockNumber();
+//         const slot = await rollup.getSlotNumber();
+//         const round = await governanceProposer.computeRound(slot);
+//         const info = await governanceProposer.getRoundInfo(
+//           nodeInfo.l1ContractAddresses.rollupAddress.toString(),
+//           round,
+//         );
+//         const leaderVotes = await governanceProposer.getPayloadSignals(
+//           nodeInfo.l1ContractAddresses.rollupAddress.toString(),
+//           round,
+//           info.payloadWithMostSignals,
+//         );
+//         return { bn, slot, round, info, leaderVotes };
+//       };
 
-      /** Setup */
+//       /** Setup */
 
-      const l1Client = await setupDeployerAccount();
+//       const l1Client = await setupDeployerAccount();
 
-      const { address: newGovernanceProposerAddress } = await deployL1Contract(
-        l1Client,
-        NewGovernanceProposerPayloadAbi,
-        NewGovernanceProposerPayloadBytecode,
-        [nodeInfo.l1ContractAddresses.registryAddress.toString()],
-        { salt: '0x2a' },
-      );
-      expect(newGovernanceProposerAddress).toBeDefined();
-      expect(newGovernanceProposerAddress.equals(EthAddress.ZERO)).toBeFalsy();
-      debugLogger.info(`newGovernanceProposerAddress: ${newGovernanceProposerAddress.toString()}`);
-      await updateSequencersConfig(config, {
-        governanceProposerPayload: newGovernanceProposerAddress,
-      });
+//       const { address: newGovernanceProposerAddress } = await deployL1Contract(
+//         l1Client,
+//         NewGovernanceProposerPayloadAbi,
+//         NewGovernanceProposerPayloadBytecode,
+//         [nodeInfo.l1ContractAddresses.registryAddress.toString()],
+//         '0x2a', // salt
+//       );
+//       expect(newGovernanceProposerAddress).toBeDefined();
+//       expect(newGovernanceProposerAddress.equals(EthAddress.ZERO)).toBeFalsy();
+//       debugLogger.info(`newGovernanceProposerAddress: ${newGovernanceProposerAddress.toString()}`);
+//       await updateSequencersConfig(config, {
+//         governanceProposerPayload: newGovernanceProposerAddress,
+//       });
 
-      const rollup = new RollupContract(l1Client, nodeInfo.l1ContractAddresses.rollupAddress.toString());
-      const governanceProposer = new GovernanceProposerContract(
-        l1Client,
-        nodeInfo.l1ContractAddresses.governanceProposerAddress.toString(),
-      );
+//       const rollup = new RollupContract(l1Client, nodeInfo.l1ContractAddresses.rollupAddress.toString());
+//       const governanceProposer = new GovernanceProposerContract(
+//         l1Client,
+//         nodeInfo.l1ContractAddresses.governanceProposerAddress.toString(),
+//       );
 
-      let info = await govInfo();
-      expect(info.bn).toBeDefined();
-      expect(info.slot).toBeDefined();
-      debugLogger.info(`info: ${stringify(info)}`);
+//       let info = await govInfo();
+//       expect(info.bn).toBeDefined();
+//       expect(info.slot).toBeDefined();
+//       debugLogger.info(`info: ${stringify(info)}`);
 
-      const quorumSize = await governanceProposer.getQuorumSize();
-      debugLogger.info(`quorumSize: ${quorumSize}`);
-      expect(quorumSize).toBeGreaterThan(0);
+//       const quorumSize = await governanceProposer.getQuorumSize();
+//       debugLogger.info(`quorumSize: ${quorumSize}`);
+//       expect(quorumSize).toBeGreaterThan(0);
 
-      /** GovernanceProposer Voting */
+//       /** GovernanceProposer Voting */
 
-      // Wait until we have enough votes to execute the proposal.
-      while (true) {
-        info = await govInfo();
-        debugLogger.info(`Leader votes: ${info.leaderVotes}`);
-        if (info.leaderVotes >= quorumSize) {
-          debugLogger.info(`Leader votes have reached quorum size`);
-          break;
-        }
-        await sleep(12000);
-      }
+//       // Wait until we have enough votes to execute the proposal.
+//       while (true) {
+//         info = await govInfo();
+//         debugLogger.info(`Leader votes: ${info.leaderVotes}`);
+//         if (info.leaderVotes >= quorumSize) {
+//           debugLogger.info(`Leader votes have reached quorum size`);
+//           break;
+//         }
+//         await sleep(12000);
+//       }
 
-      const executableRound = info.round;
-      debugLogger.info(`Waiting for round ${executableRound + 1n}`);
+//       const executableRound = info.round;
+//       debugLogger.info(`Waiting for round ${executableRound + 1n}`);
 
-      while (info.round === executableRound) {
-        await sleep(12500);
-        info = await govInfo();
-        debugLogger.info(`slot: ${info.slot}`);
-      }
+//       while (info.round === executableRound) {
+//         await sleep(12500);
+//         info = await govInfo();
+//         debugLogger.info(`slot: ${info.slot}`);
+//       }
 
-      expect(info.round).toBeGreaterThan(executableRound);
+//       expect(info.round).toBeGreaterThan(executableRound);
 
-      debugLogger.info(`Executing proposal ${info.round}`);
+//       debugLogger.info(`Executing proposal ${info.round}`);
 
-      const l1TxUtils = createL1TxUtilsFromViemWallet(l1Client, debugLogger);
-      const { receipt } = await governanceProposer.submitRoundWinner(executableRound, l1TxUtils);
-      expect(receipt).toBeDefined();
-      expect(receipt.status).toEqual('success');
-      debugLogger.info(`Executed proposal ${info.round}`);
-    },
-    1000 * 60 * 10,
-  );
-});
+//       const l1TxUtils = createL1TxUtilsFromViemWallet(l1Client, debugLogger);
+//       const { receipt } = await governanceProposer.submitRoundWinner(executableRound, l1TxUtils);
+//       expect(receipt).toBeDefined();
+//       expect(receipt.status).toEqual('success');
+//       debugLogger.info(`Executed proposal ${info.round}`);
+//     },
+//     1000 * 60 * 10,
+//   );
+// });

--- a/yarn-project/end-to-end/src/spartan/upgrade_rollup_version.test.ts
+++ b/yarn-project/end-to-end/src/spartan/upgrade_rollup_version.test.ts
@@ -1,203 +1,203 @@
-import { getInitialTestAccounts } from '@aztec/accounts/testing';
-import { EthAddress, type NodeInfo, type PXE, createCompatibleClient, retryUntil } from '@aztec/aztec.js';
-import {
-  DefaultL1ContractsConfig,
-  type L1ContractAddresses,
-  RegistryContract,
-  RollupContract,
-  createEthereumChain,
-  createExtendedL1Client,
-  defaultL1TxUtilsConfig,
-  deployRollupForUpgrade,
-} from '@aztec/ethereum';
-import { createLogger } from '@aztec/foundation/log';
-import { getVKTreeRoot } from '@aztec/noir-protocol-circuits-types/vk-tree';
-import { protocolContractTreeRoot } from '@aztec/protocol-contracts';
-import { getGenesisValues } from '@aztec/world-state/testing';
+// import { getInitialTestAccounts } from '@aztec/accounts/testing';
+// import { EthAddress, type NodeInfo, type PXE, createCompatibleClient, retryUntil } from '@aztec/aztec.js';
+// import {
+//   DefaultL1ContractsConfig,
+//   type L1ContractAddresses,
+//   RegistryContract,
+//   RollupContract,
+//   createEthereumChain,
+//   createExtendedL1Client,
+//   defaultL1TxUtilsConfig,
+//   deployRollupForUpgrade,
+// } from '@aztec/ethereum';
+// import { createLogger } from '@aztec/foundation/log';
+// import { getVKTreeRoot } from '@aztec/noir-protocol-circuits-types/vk-tree';
+// import { protocolContractTreeRoot } from '@aztec/protocol-contracts';
+// import { getGenesisValues } from '@aztec/world-state/testing';
 
-import type { ChildProcess } from 'child_process';
-import omit from 'lodash.omit';
+// import type { ChildProcess } from 'child_process';
+// import omit from 'lodash.omit';
 
-import { isK8sConfig, rollAztecPods, setupEnvironment, startPortForward } from './utils.js';
+// import { isK8sConfig, rollAztecPods, setupEnvironment, startPortForward } from './utils.js';
 
-const config = setupEnvironment(process.env);
-if (!isK8sConfig(config)) {
-  throw new Error('This test must be run in a k8s environment');
-}
+// const config = setupEnvironment(process.env);
+// if (!isK8sConfig(config)) {
+//   throw new Error('This test must be run in a k8s environment');
+// }
 
-const debugLogger = createLogger('e2e:spartan-test:upgrade_rollup_version');
+// const debugLogger = createLogger('e2e:spartan-test:upgrade_rollup_version');
 
-describe('spartan_upgrade_rollup_version', () => {
-  let pxe: PXE;
-  let nodeInfo: NodeInfo;
-  let ETHEREUM_HOSTS: string[];
-  let originalL1ContractAddresses: L1ContractAddresses;
-  const forwardProcesses: ChildProcess[] = [];
+// describe('spartan_upgrade_rollup_version', () => {
+//   let pxe: PXE;
+//   let nodeInfo: NodeInfo;
+//   let ETHEREUM_HOSTS: string[];
+//   let originalL1ContractAddresses: L1ContractAddresses;
+//   const forwardProcesses: ChildProcess[] = [];
 
-  afterAll(() => {
-    forwardProcesses.forEach(p => p.kill());
-  });
+//   afterAll(() => {
+//     forwardProcesses.forEach(p => p.kill());
+//   });
 
-  beforeAll(async () => {
-    const { process: pxeProcess, port: pxePort } = await startPortForward({
-      resource: `svc/${config.INSTANCE_NAME}-aztec-network-pxe`,
-      namespace: config.NAMESPACE,
-      containerPort: config.CONTAINER_PXE_PORT,
-    });
-    forwardProcesses.push(pxeProcess);
-    const PXE_URL = `http://127.0.0.1:${pxePort}`;
+//   beforeAll(async () => {
+//     const { process: pxeProcess, port: pxePort } = await startPortForward({
+//       resource: `svc/${config.INSTANCE_NAME}-aztec-network-pxe`,
+//       namespace: config.NAMESPACE,
+//       containerPort: config.CONTAINER_PXE_PORT,
+//     });
+//     forwardProcesses.push(pxeProcess);
+//     const PXE_URL = `http://127.0.0.1:${pxePort}`;
 
-    const { process: ethProcess, port: ethPort } = await startPortForward({
-      resource: `svc/${config.INSTANCE_NAME}-aztec-network-eth-execution`,
-      namespace: config.NAMESPACE,
-      containerPort: config.CONTAINER_ETHEREUM_PORT,
-    });
-    forwardProcesses.push(ethProcess);
-    ETHEREUM_HOSTS = [`http://127.0.0.1:${ethPort}`];
+//     const { process: ethProcess, port: ethPort } = await startPortForward({
+//       resource: `svc/${config.INSTANCE_NAME}-aztec-network-eth-execution`,
+//       namespace: config.NAMESPACE,
+//       containerPort: config.CONTAINER_ETHEREUM_PORT,
+//     });
+//     forwardProcesses.push(ethProcess);
+//     ETHEREUM_HOSTS = [`http://127.0.0.1:${ethPort}`];
 
-    pxe = await createCompatibleClient(PXE_URL, debugLogger);
-    nodeInfo = await pxe.getNodeInfo();
-    originalL1ContractAddresses = omit(nodeInfo.l1ContractAddresses, [
-      'slashFactoryAddress',
-      'stakingAssetHandlerAddress',
-      'feeAssetHandlerAddress',
-    ]);
-  });
+//     pxe = await createCompatibleClient(PXE_URL, debugLogger);
+//     nodeInfo = await pxe.getNodeInfo();
+//     originalL1ContractAddresses = omit(nodeInfo.l1ContractAddresses, [
+//       'slashFactoryAddress',
+//       'stakingAssetHandlerAddress',
+//       'feeAssetHandlerAddress',
+//     ]);
+//   });
 
-  // We need a separate account to deploy the new governance proposer
-  // because the underlying validators are currently producing blob transactions
-  // and you can't submit blob and non-blob transactions from the same account
+//   // We need a separate account to deploy the new governance proposer
+//   // because the underlying validators are currently producing blob transactions
+//   // and you can't submit blob and non-blob transactions from the same account
 
-  // @note Look at older commits to find a version that actually go through governance here
-  it(
-    'should upgrade the rollup version',
-    async () => {
-      /** Setup */
+//   // @note Look at older commits to find a version that actually go through governance here
+//   it(
+//     'should upgrade the rollup version',
+//     async () => {
+//       /** Setup */
 
-      const chain = createEthereumChain(ETHEREUM_HOSTS, nodeInfo.l1ChainId);
-      const l1Client = createExtendedL1Client(ETHEREUM_HOSTS, config.L1_ACCOUNT_MNEMONIC, chain.chainInfo);
-      debugLogger.info(`L1 Client address: ${l1Client.account.address}`);
-      const initialTestAccounts = await getInitialTestAccounts();
+//       const chain = createEthereumChain(ETHEREUM_HOSTS, nodeInfo.l1ChainId);
+//       const l1Client = createExtendedL1Client(ETHEREUM_HOSTS, config.L1_ACCOUNT_MNEMONIC, chain.chainInfo);
+//       debugLogger.info(`L1 Client address: ${l1Client.account.address}`);
+//       const initialTestAccounts = await getInitialTestAccounts();
 
-      const { genesisArchiveRoot, fundingNeeded } = await getGenesisValues(initialTestAccounts.map(a => a.address));
+//       const { genesisArchiveRoot, fundingNeeded } = await getGenesisValues(initialTestAccounts.map(a => a.address));
 
-      const rollup = new RollupContract(l1Client, originalL1ContractAddresses.rollupAddress.toString());
-      const { rollup: newRollup } = await deployRollupForUpgrade(
-        l1Client,
-        {
-          salt: Math.floor(Math.random() * 1000000),
-          vkTreeRoot: getVKTreeRoot(),
-          protocolContractTreeRoot,
-          genesisArchiveRoot,
-          ethereumSlotDuration: 12,
-          aztecSlotDuration: 24,
-          aztecEpochDuration: 4,
-          aztecProofSubmissionEpochs: 1,
-          aztecTargetCommitteeSize: 48,
-          slashingQuorum: 5,
-          slashingRoundSize: 8,
-          slashingLifetimeInRounds: 5,
-          slashingExecutionDelayInRounds: 0,
-          slashingVetoer: EthAddress.ZERO,
-          manaTarget: BigInt(100e6),
-          provingCostPerMana: BigInt(100),
-          feeJuicePortalInitialBalance: fundingNeeded,
-          realVerifier: false,
-          exitDelaySeconds: DefaultL1ContractsConfig.exitDelaySeconds,
-          slasherFlavor: DefaultL1ContractsConfig.slasherFlavor,
-          slashingOffsetInRounds: DefaultL1ContractsConfig.slashingOffsetInRounds,
-          slashingUnit: DefaultL1ContractsConfig.slashingUnit,
-        },
-        originalL1ContractAddresses.registryAddress,
-        debugLogger,
-        defaultL1TxUtilsConfig,
-      );
+//       const rollup = new RollupContract(l1Client, originalL1ContractAddresses.rollupAddress.toString());
+//       const { rollup: newRollup } = await deployRollupForUpgrade(
+//         l1Client,
+//         {
+//           salt: Math.floor(Math.random() * 1000000),
+//           vkTreeRoot: getVKTreeRoot(),
+//           protocolContractTreeRoot,
+//           genesisArchiveRoot,
+//           ethereumSlotDuration: 12,
+//           aztecSlotDuration: 24,
+//           aztecEpochDuration: 4,
+//           aztecProofSubmissionEpochs: 1,
+//           aztecTargetCommitteeSize: 48,
+//           slashingQuorum: 6,
+//           slashingRoundSize: 10,
+//           slashingLifetimeInRounds: 5,
+//           slashingExecutionDelayInRounds: 0,
+//           slashingVetoer: EthAddress.ZERO,
+//           manaTarget: BigInt(100e6),
+//           provingCostPerMana: BigInt(100),
+//           feeJuicePortalInitialBalance: fundingNeeded,
+//           realVerifier: false,
+//           exitDelaySeconds: DefaultL1ContractsConfig.exitDelaySeconds,
+//           slasherFlavor: DefaultL1ContractsConfig.slasherFlavor,
+//           slashingOffsetInRounds: DefaultL1ContractsConfig.slashingOffsetInRounds,
+//           slashingUnit: DefaultL1ContractsConfig.slashingUnit,
+//         },
+//         originalL1ContractAddresses.registryAddress,
+//         debugLogger,
+//         defaultL1TxUtilsConfig,
+//       );
 
-      const newAddresses = await newRollup.getRollupAddresses();
+//       const newAddresses = await newRollup.getRollupAddresses();
 
-      const newCanonicalAddresses = await RegistryContract.collectAddresses(
-        l1Client,
-        originalL1ContractAddresses.registryAddress,
-        'canonical',
-      );
+//       const newCanonicalAddresses = await RegistryContract.collectAddresses(
+//         l1Client,
+//         originalL1ContractAddresses.registryAddress,
+//         'canonical',
+//       );
 
-      expect(newCanonicalAddresses).toEqual({
-        // we preserve the original registry/governance addresses
-        ...originalL1ContractAddresses,
-        // but have new instance addresses
-        ...newAddresses,
-      });
+//       expect(newCanonicalAddresses).toEqual({
+//         // we preserve the original registry/governance addresses
+//         ...originalL1ContractAddresses,
+//         // but have new instance addresses
+//         ...newAddresses,
+//       });
 
-      const oldVersion = await new RollupContract(
-        l1Client,
-        originalL1ContractAddresses.rollupAddress.toString(),
-      ).getVersion();
-      const newVersion = await new RollupContract(
-        l1Client,
-        newCanonicalAddresses.rollupAddress.toString(),
-      ).getVersion();
+//       const oldVersion = await new RollupContract(
+//         l1Client,
+//         originalL1ContractAddresses.rollupAddress.toString(),
+//       ).getVersion();
+//       const newVersion = await new RollupContract(
+//         l1Client,
+//         newCanonicalAddresses.rollupAddress.toString(),
+//       ).getVersion();
 
-      debugLogger.info(`oldVersion: ${oldVersion}, address: ${originalL1ContractAddresses.rollupAddress}`);
-      debugLogger.info(`newVersion: ${newVersion}, address: ${newCanonicalAddresses.rollupAddress}`);
-      expect(oldVersion).not.toEqual(newVersion);
+//       debugLogger.info(`oldVersion: ${oldVersion}, address: ${originalL1ContractAddresses.rollupAddress}`);
+//       debugLogger.info(`newVersion: ${newVersion}, address: ${newCanonicalAddresses.rollupAddress}`);
+//       expect(oldVersion).not.toEqual(newVersion);
 
-      await expect(
-        RegistryContract.collectAddresses(l1Client, originalL1ContractAddresses.registryAddress, oldVersion),
-      ).resolves.toEqual(originalL1ContractAddresses);
+//       await expect(
+//         RegistryContract.collectAddresses(l1Client, originalL1ContractAddresses.registryAddress, oldVersion),
+//       ).resolves.toEqual(originalL1ContractAddresses);
 
-      await expect(
-        RegistryContract.collectAddresses(l1Client, originalL1ContractAddresses.registryAddress, newVersion),
-      ).resolves.toEqual(newCanonicalAddresses);
+//       await expect(
+//         RegistryContract.collectAddresses(l1Client, originalL1ContractAddresses.registryAddress, newVersion),
+//       ).resolves.toEqual(newCanonicalAddresses);
 
-      const oldRollupTips = await rollup.getTips();
-      await retryUntil(
-        async () => {
-          const tips = await rollup.getTips();
-          return tips.provenBlockNumber > oldRollupTips.provenBlockNumber;
-        },
-        'old rollup should be building blocks',
-        // +5 just as a buffer
-        (config.AZTEC_PROOF_SUBMISSION_WINDOW + 5) * config.AZTEC_SLOT_DURATION,
-        5,
-      );
+//       const oldRollupTips = await rollup.getTips();
+//       await retryUntil(
+//         async () => {
+//           const tips = await rollup.getTips();
+//           return tips.provenBlockNumber > oldRollupTips.provenBlockNumber;
+//         },
+//         'old rollup should be building blocks',
+//         // +5 just as a buffer
+//         (config.AZTEC_PROOF_SUBMISSION_WINDOW + 5) * config.AZTEC_SLOT_DURATION,
+//         5,
+//       );
 
-      // Now delete all the pods, forcing them to restart on the new rollup
-      await rollAztecPods(config.NAMESPACE);
+//       // Now delete all the pods, forcing them to restart on the new rollup
+//       await rollAztecPods(config.NAMESPACE);
 
-      // start a new port forward
-      const { process: pxeProcess, port: pxePort } = await startPortForward({
-        resource: `svc/${config.INSTANCE_NAME}-aztec-network-pxe`,
-        namespace: config.NAMESPACE,
-        containerPort: config.CONTAINER_PXE_PORT,
-      });
-      forwardProcesses.push(pxeProcess);
-      const PXE_URL = `http://127.0.0.1:${pxePort}`;
-      pxe = await createCompatibleClient(PXE_URL, debugLogger);
+//       // start a new port forward
+//       const { process: pxeProcess, port: pxePort } = await startPortForward({
+//         resource: `svc/${config.INSTANCE_NAME}-aztec-network-pxe`,
+//         namespace: config.NAMESPACE,
+//         containerPort: config.CONTAINER_PXE_PORT,
+//       });
+//       forwardProcesses.push(pxeProcess);
+//       const PXE_URL = `http://127.0.0.1:${pxePort}`;
+//       pxe = await createCompatibleClient(PXE_URL, debugLogger);
 
-      const newNodeInfo = await pxe.getNodeInfo();
+//       const newNodeInfo = await pxe.getNodeInfo();
 
-      // @todo There is an issue here, probably related to #12791, but somehow
-      // the address returned by the pxe node info is NEITHER the old nor the new rollup address
+//       // @todo There is an issue here, probably related to #12791, but somehow
+//       // the address returned by the pxe node info is NEITHER the old nor the new rollup address
 
-      debugLogger.info(`newNodeInfo: ${JSON.stringify(newNodeInfo)}`);
-      debugLogger.info(`originalL1ContractAddresses: ${JSON.stringify(originalL1ContractAddresses)}`);
-      debugLogger.info(`newCanonicalAddresses: ${JSON.stringify(newCanonicalAddresses)}`);
-      expect(newNodeInfo.l1ContractAddresses.rollupAddress).toEqual(newCanonicalAddresses.rollupAddress);
+//       debugLogger.info(`newNodeInfo: ${JSON.stringify(newNodeInfo)}`);
+//       debugLogger.info(`originalL1ContractAddresses: ${JSON.stringify(originalL1ContractAddresses)}`);
+//       debugLogger.info(`newCanonicalAddresses: ${JSON.stringify(newCanonicalAddresses)}`);
+//       expect(newNodeInfo.l1ContractAddresses.rollupAddress).toEqual(newCanonicalAddresses.rollupAddress);
 
-      const l2Tips = await newRollup.getTips();
-      await expect(
-        retryUntil(
-          async () => {
-            const tips = await newRollup.getTips();
-            return tips.provenBlockNumber > l2Tips.provenBlockNumber;
-          },
-          'new rollup should be building/proving blocks',
-          // +5 just as a buffer
-          (config.AZTEC_PROOF_SUBMISSION_WINDOW + 5) * config.AZTEC_SLOT_DURATION,
-          5,
-        ),
-      ).resolves.toBe(true);
-    },
-    6 * config.AZTEC_PROOF_SUBMISSION_WINDOW * config.AZTEC_SLOT_DURATION * 1000,
-  );
-});
+//       const l2Tips = await newRollup.getTips();
+//       await expect(
+//         retryUntil(
+//           async () => {
+//             const tips = await newRollup.getTips();
+//             return tips.provenBlockNumber > l2Tips.provenBlockNumber;
+//           },
+//           'new rollup should be building/proving blocks',
+//           // +5 just as a buffer
+//           (config.AZTEC_PROOF_SUBMISSION_WINDOW + 5) * config.AZTEC_SLOT_DURATION,
+//           5,
+//         ),
+//       ).resolves.toBe(true);
+//     },
+//     6 * config.AZTEC_PROOF_SUBMISSION_WINDOW * config.AZTEC_SLOT_DURATION * 1000,
+//   );
+// });

--- a/yarn-project/end-to-end/src/spartan/upgrade_via_cli.test.ts
+++ b/yarn-project/end-to-end/src/spartan/upgrade_via_cli.test.ts
@@ -1,82 +1,82 @@
-import { type PXE, createCompatibleClient } from '@aztec/aztec.js';
-import { RegistryContract, createEthereumChain, createExtendedL1Client } from '@aztec/ethereum';
-import { createLogger } from '@aztec/foundation/log';
+// import { type PXE, createCompatibleClient } from '@aztec/aztec.js';
+// import { RegistryContract, createEthereumChain, createExtendedL1Client } from '@aztec/ethereum';
+// import { createLogger } from '@aztec/foundation/log';
 
-import type { ChildProcess } from 'child_process';
+// import type { ChildProcess } from 'child_process';
 
-import { getAztecBin, isK8sConfig, runProjectScript, setupEnvironment, startPortForward } from './utils.js';
+// import { getAztecBin, isK8sConfig, runProjectScript, setupEnvironment, startPortForward } from './utils.js';
 
-const config = setupEnvironment(process.env);
+// const config = setupEnvironment(process.env);
 
-// technically it doesn't require a k8s env, but it doesn't seem we're keeping the "local" versions of the spartan scripts up to date
-// and I didn't want to plumb through the config and test this with the local scripts.
-if (!isK8sConfig(config)) {
-  throw new Error('This test must be run in a k8s environment');
-}
+// // technically it doesn't require a k8s env, but it doesn't seem we're keeping the "local" versions of the spartan scripts up to date
+// // and I didn't want to plumb through the config and test this with the local scripts.
+// if (!isK8sConfig(config)) {
+//   throw new Error('This test must be run in a k8s environment');
+// }
 
-const debugLogger = createLogger('e2e:spartan-test:upgrade_via_cli');
+// const debugLogger = createLogger('e2e:spartan-test:upgrade_via_cli');
 
-describe('upgrade via cli', () => {
-  let pxe: PXE;
-  const forwardProcesses: ChildProcess[] = [];
-  let ETHEREUM_HOSTS: string;
-  let MNEMONIC: string;
-  beforeAll(async () => {
-    let PXE_URL: string;
-    MNEMONIC = config.L1_ACCOUNT_MNEMONIC;
-    {
-      const { process, port } = await startPortForward({
-        resource: `svc/${config.INSTANCE_NAME}-aztec-network-pxe`,
-        namespace: config.NAMESPACE,
-        containerPort: config.CONTAINER_PXE_PORT,
-      });
-      forwardProcesses.push(process);
-      PXE_URL = `http://127.0.0.1:${port}`;
-    }
-    {
-      const { process, port } = await startPortForward({
-        resource: `svc/${config.INSTANCE_NAME}-aztec-network-eth-execution`,
-        namespace: config.NAMESPACE,
-        containerPort: config.CONTAINER_ETHEREUM_PORT,
-      });
-      forwardProcesses.push(process);
-      ETHEREUM_HOSTS = `http://127.0.0.1:${port}`;
-    }
-    pxe = await createCompatibleClient(PXE_URL, debugLogger);
-  });
+// describe('upgrade via cli', () => {
+//   let pxe: PXE;
+//   const forwardProcesses: ChildProcess[] = [];
+//   let ETHEREUM_HOSTS: string;
+//   let MNEMONIC: string;
+//   beforeAll(async () => {
+//     let PXE_URL: string;
+//     MNEMONIC = config.L1_ACCOUNT_MNEMONIC;
+//     {
+//       const { process, port } = await startPortForward({
+//         resource: `svc/${config.INSTANCE_NAME}-aztec-network-pxe`,
+//         namespace: config.NAMESPACE,
+//         containerPort: config.CONTAINER_PXE_PORT,
+//       });
+//       forwardProcesses.push(process);
+//       PXE_URL = `http://127.0.0.1:${port}`;
+//     }
+//     {
+//       const { process, port } = await startPortForward({
+//         resource: `svc/${config.INSTANCE_NAME}-aztec-network-eth-execution`,
+//         namespace: config.NAMESPACE,
+//         containerPort: config.CONTAINER_ETHEREUM_PORT,
+//       });
+//       forwardProcesses.push(process);
+//       ETHEREUM_HOSTS = `http://127.0.0.1:${port}`;
+//     }
+//     pxe = await createCompatibleClient(PXE_URL, debugLogger);
+//   });
 
-  afterAll(() => {
-    forwardProcesses.forEach(p => p.kill());
-  });
+//   afterAll(() => {
+//     forwardProcesses.forEach(p => p.kill());
+//   });
 
-  it(
-    'should be able to get node enr',
-    async () => {
-      const info = await pxe.getNodeInfo();
+//   it(
+//     'should be able to get node enr',
+//     async () => {
+//       const info = await pxe.getNodeInfo();
 
-      const chain = createEthereumChain([ETHEREUM_HOSTS], info.l1ChainId);
-      const l1Client = createExtendedL1Client([ETHEREUM_HOSTS], MNEMONIC, chain.chainInfo);
+//       const chain = createEthereumChain([ETHEREUM_HOSTS], info.l1ChainId);
+//       const l1Client = createExtendedL1Client([ETHEREUM_HOSTS], MNEMONIC, chain.chainInfo);
 
-      const registry = new RegistryContract(l1Client, info.l1ContractAddresses.registryAddress.toString());
-      const oldNumberOfVersions = await registry.getNumberOfVersions();
+//       const registry = new RegistryContract(l1Client, info.l1ContractAddresses.registryAddress.toString());
+//       const oldNumberOfVersions = await registry.getNumberOfVersions();
 
-      const exitCode = await runProjectScript(
-        'spartan/scripts/upgrade_rollup_with_cli.sh',
-        ['--aztec-bin', getAztecBin(), '--registry', info.l1ContractAddresses.registryAddress.toString()],
-        debugLogger,
-        {
-          MNEMONIC,
-          ETHEREUM_HOSTS,
-          L1_CHAIN_ID: info.l1ChainId.toString(),
-          LOG_JSON: 'false',
-          LOG_LEVEL: 'debug',
-        },
-      );
-      expect(exitCode).toBe(0);
+//       const exitCode = await runProjectScript(
+//         'spartan/scripts/upgrade_rollup_with_cli.sh',
+//         ['--aztec-bin', getAztecBin(), '--registry', info.l1ContractAddresses.registryAddress.toString()],
+//         debugLogger,
+//         {
+//           MNEMONIC,
+//           ETHEREUM_HOSTS,
+//           L1_CHAIN_ID: info.l1ChainId.toString(),
+//           LOG_JSON: 'false',
+//           LOG_LEVEL: 'debug',
+//         },
+//       );
+//       expect(exitCode).toBe(0);
 
-      const newNumberOfVersions = await registry.getNumberOfVersions();
-      expect(newNumberOfVersions).toBe(oldNumberOfVersions + 1);
-    },
-    6 * config.AZTEC_PROOF_SUBMISSION_WINDOW * config.AZTEC_SLOT_DURATION * 1000,
-  );
-});
+//       const newNumberOfVersions = await registry.getNumberOfVersions();
+//       expect(newNumberOfVersions).toBe(oldNumberOfVersions + 1);
+//     },
+//     6 * config.AZTEC_PROOF_SUBMISSION_WINDOW * config.AZTEC_SLOT_DURATION * 1000,
+//   );
+// });

--- a/yarn-project/end-to-end/src/spartan/utils.ts
+++ b/yarn-project/end-to-end/src/spartan/utils.ts
@@ -2,91 +2,35 @@ import { createLogger, sleep } from '@aztec/aztec.js';
 import type { RollupCheatCodes } from '@aztec/aztec/testing';
 import type { Logger } from '@aztec/foundation/log';
 import { makeBackoff, retry } from '@aztec/foundation/retry';
-import type { SequencerConfig } from '@aztec/sequencer-client';
-import { createAztecNodeAdminClient } from '@aztec/stdlib/interfaces/client';
+import { type AztecNodeAdminConfig, createAztecNodeAdminClient } from '@aztec/stdlib/interfaces/client';
 
 import { ChildProcess, exec, execSync, spawn } from 'child_process';
 import path from 'path';
 import { promisify } from 'util';
 import { z } from 'zod';
 
-import { AlertChecker, type AlertConfig } from '../quality_of_service/alert_checker.js';
+export const RPC_SERVICE_NAME = 'services/aztec-infra-rpc-aztec-node';
 
 const execAsync = promisify(exec);
 
 const logger = createLogger('e2e:k8s-utils');
 
-const ethereumHostsSchema = z.string().refine(
-  str =>
-    str.split(',').every(url => {
-      try {
-        new URL(url.trim());
-        return true;
-      } catch {
-        return false;
-      }
-    }),
-  'ETHEREUM_HOSTS must be a comma-separated list of valid URLs',
-);
-
-const k8sLocalConfigSchema = z.object({
-  ETHEREUM_SLOT_DURATION: z.coerce.number().min(1, 'ETHEREUM_SLOT_DURATION env variable must be set'),
-  AZTEC_SLOT_DURATION: z.coerce.number().min(1, 'AZTEC_SLOT_DURATION env variable must be set'),
-  AZTEC_EPOCH_DURATION: z.coerce.number().min(1, 'AZTEC_EPOCH_DURATION env variable must be set'),
-  AZTEC_PROOF_SUBMISSION_WINDOW: z.coerce.number().min(1, 'AZTEC_PROOF_SUBMISSION_WINDOW env variable must be set'),
-  AZTEC_REAL_PROOFS: z.string().default('false'),
-  INSTANCE_NAME: z.string().min(1, 'INSTANCE_NAME env variable must be set'),
+const testConfigSchema = z.object({
   NAMESPACE: z.string().min(1, 'NAMESPACE env variable must be set'),
-  CONTAINER_NODE_PORT: z.coerce.number().default(8080),
-  CONTAINER_NODE_ADMIN_PORT: z.coerce.number().default(8880),
-  CONTAINER_SEQUENCER_PORT: z.coerce.number().default(8080),
-  CONTAINER_PROVER_NODE_PORT: z.coerce.number().default(8080),
-  CONTAINER_PXE_PORT: z.coerce.number().default(8080),
-  CONTAINER_ETHEREUM_PORT: z.coerce.number().default(8545),
-  CONTAINER_METRICS_PORT: z.coerce.number().default(80),
-  GRAFANA_PASSWORD: z.string().optional(),
-  METRICS_API_PATH: z.string().default('/api/datasources/proxy/uid/spartan-metrics-prometheus/api/v1'),
-  SPARTAN_DIR: z.string().min(1, 'SPARTAN_DIR env variable must be set'),
-  ETHEREUM_HOSTS: ethereumHostsSchema.optional(),
   L1_ACCOUNT_MNEMONIC: z.string().default('test test test test test test test test test test test junk'),
-  SEPOLIA_RUN: z.string().default('false'),
-  K8S: z.literal('local'),
+  K8S_CLUSTER: z.string().min(1, 'K8S_CLUSTER env variable must be set'),
+  REGION: z.string().optional(),
+  PROJECT_ID: z.string().optional(),
+  AZTEC_REAL_PROOFS: z.coerce.boolean().default(false),
 });
 
-const k8sGCloudConfigSchema = k8sLocalConfigSchema.extend({
-  K8S: z.literal('gcloud'),
-  CLUSTER_NAME: z.string().min(1, 'CLUSTER_NAME env variable must be set'),
-  REGION: z.string().min(1, 'REGION env variable must be set'),
-  PROJECT_ID: z.string().min(1, 'PROJECT_ID env variable must be set'),
-});
+export type TestConfig = z.infer<typeof testConfigSchema>;
 
-const directConfigSchema = z.object({
-  PXE_URL: z.string().url('PXE_URL must be a valid URL'),
-  NODE_URL: z.string().url('NODE_URL must be a valid URL'),
-  NODE_ADMIN_URL: z.string().url('NODE_ADMIN_URL must be a valid URL'),
-  ETHEREUM_HOSTS: ethereumHostsSchema,
-  K8S: z.literal('false'),
-});
+export function setupEnvironment(env: unknown): TestConfig {
+  const config = testConfigSchema.parse(env);
 
-const envSchema = z.discriminatedUnion('K8S', [k8sLocalConfigSchema, k8sGCloudConfigSchema, directConfigSchema]);
-
-export type K8sLocalConfig = z.infer<typeof k8sLocalConfigSchema>;
-export type K8sGCloudConfig = z.infer<typeof k8sGCloudConfigSchema>;
-export type DirectConfig = z.infer<typeof directConfigSchema>;
-export type EnvConfig = z.infer<typeof envSchema>;
-
-export function isK8sConfig(config: EnvConfig): config is K8sLocalConfig | K8sGCloudConfig {
-  return config.K8S === 'local' || config.K8S === 'gcloud';
-}
-
-export function isGCloudConfig(config: EnvConfig): config is K8sGCloudConfig {
-  return config.K8S === 'gcloud';
-}
-
-export function setupEnvironment(env: unknown): EnvConfig {
-  const config = envSchema.parse(env);
-  if (isGCloudConfig(config)) {
-    const command = `gcloud container clusters get-credentials ${config.CLUSTER_NAME} --region=${config.REGION} --project=${config.PROJECT_ID}`;
+  if (config.K8S_CLUSTER !== 'kind') {
+    const command = `gcloud container clusters get-credentials ${config.K8S_CLUSTER} --region=${config.REGION} --project=${config.PROJECT_ID}`;
     execSync(command);
   }
   return config;
@@ -210,6 +154,14 @@ export async function startPortForward({
   const port = await connected;
 
   return { process, port };
+}
+
+export function startPortForwardForRPC(namespace: string) {
+  return startPortForward({
+    resource: RPC_SERVICE_NAME,
+    namespace,
+    containerPort: 8080,
+  });
 }
 
 export async function deleteResourceByName({
@@ -550,25 +502,7 @@ export async function enableValidatorDynamicBootNode(
   logger.info(`Validator dynamic boot node enabled`);
 }
 
-export async function runAlertCheck(config: EnvConfig, alerts: AlertConfig[], logger: Logger) {
-  if (isK8sConfig(config)) {
-    const { process, port } = await startPortForward({
-      resource: `svc/metrics-grafana`,
-      namespace: 'metrics',
-      containerPort: config.CONTAINER_METRICS_PORT,
-    });
-    const alertChecker = new AlertChecker(logger, {
-      grafanaEndpoint: `http://localhost:${port}${config.METRICS_API_PATH}`,
-      grafanaCredentials: `admin:${config.GRAFANA_PASSWORD}`,
-    });
-    await alertChecker.runAlertCheck(alerts);
-    process.kill();
-  } else {
-    logger.info('Not running alert check in non-k8s environment');
-  }
-}
-
-export async function updateSequencerConfig(url: string, config: Partial<SequencerConfig>) {
+export async function updateSequencerConfig(url: string, config: Partial<AztecNodeAdminConfig>) {
   const node = createAztecNodeAdminClient(url);
   // Retry incase the port forward is not ready yet
   await retry(() => node.setConfig(config), 'Update sequencer config', makeBackoff([1, 3, 6]), logger);
@@ -583,7 +517,7 @@ export async function getSequencers(namespace: string) {
 async function updateK8sSequencersConfig(args: {
   containerPort: number;
   namespace: string;
-  config: Partial<SequencerConfig>;
+  config: Partial<AztecNodeAdminConfig>;
 }) {
   const { containerPort, namespace, config } = args;
   const sequencers = await getSequencers(namespace);
@@ -600,16 +534,12 @@ async function updateK8sSequencersConfig(args: {
   }
 }
 
-export async function updateSequencersConfig(env: EnvConfig, config: Partial<SequencerConfig>) {
-  if (isK8sConfig(env)) {
-    await updateK8sSequencersConfig({
-      containerPort: env.CONTAINER_NODE_ADMIN_PORT,
-      namespace: env.NAMESPACE,
-      config,
-    });
-  } else {
-    await updateSequencerConfig(env.NODE_ADMIN_URL, config);
-  }
+export async function updateSequencersConfig(env: TestConfig, config: Partial<AztecNodeAdminConfig>) {
+  await updateK8sSequencersConfig({
+    containerPort: 8880,
+    namespace: env.NAMESPACE,
+    config,
+  });
 }
 
 /**


### PR DESCRIPTION
# Network Scenario Testing Framework

This PR adds a new workflow for testing network scenarios on tagged releases. The workflow is triggered when a tag is pushed and CI passes, allowing us to run integration tests against deployed networks.

Key changes:

- Added a new GitHub workflow `test-network-scenarios.yml` that runs when a tagged release passes CI
- Created a network scenario testing mode in the bootstrap script with `CI_SCENARIO_TEST=1`
- Implemented two basic scenario tests: `smoke.test.ts` and `transfer.test.ts`
- Commented out other tests that were either already broken or need to be ported
- Updated the local workflow script to support tool caching for GitHub Actions
- Increased the mana target in the deploy-scenario-network workflow to 1,000,000,000
- Made KUBECONFIG_B64 optional in the deploy-scenario-network workflow
- Simplified the test environment configuration for better maintainability

The PR enables automated testing of deployed networks after releases, ensuring that basic functionality works correctly in production-like environments.

Fix TMNT-168
Fix TMNT-163