### PR TITLE
refactor: compression of config in gov to reduce costs.

### DIFF
--- a/l1-contracts/foundry.toml
+++ b/l1-contracts/foundry.toml
@@ -16,6 +16,7 @@ gas_reports = [
   "CoinIssuer",
   "FeeJuicePortal",
   "Governance",
+  "TestGov",
   "GovernanceProposer",
   "GSE",
   "Inbox",
@@ -36,38 +37,37 @@ remappings = [
   "@aztec/=src",
   "@test/=test",
   "@zkpassport/=lib/circuits/src/solidity/src/",
-  "@zkpassport-test/=lib/circuits/src/solidity/test"
+  "@zkpassport-test/=lib/circuits/src/solidity/test",
 ]
 
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config
 
 fs_permissions = [
-  {access = "read", path = "./test/fixtures/bn254_constants.json"},
-  {access = "read", path = "./test/fixtures/mixed_block_1.json"},
-  {access = "read", path = "./test/fixtures/mixed_block_2.json"},
-  {access = "read", path = "./test/fixtures/single_tx_block_1.json"},
-  {access = "read", path = "./test/fixtures/single_tx_block_2.json"},
-  {access = "read", path = "./test/fixtures/empty_block_1.json"},
-  {access = "read", path = "./test/fixtures/empty_block_2.json"},
-  {access = "read", path = "./test/fixtures/fee_data_points.json"},
-  {access = "read", path = "./test/staking_asset_handler/zkpassport/fixtures/valid_proof.hex"},
-  {access = "read", path = "./test/staking_asset_handler/zkpassport/fixtures/valid_committed_inputs.hex"},
-  {access = "read", path = "./test/staking_asset_handler/zkpassport/fixtures/valid_public_inputs.json"},
-  {access = "read", path = "./test/fixtures/boosted_rewards/shares.json"},
-  {access = "read", path = "./test/fixtures/boosted_rewards/activity_scores.json"},
-  {access = "read", path = "./script/registration_data.json"},
+  { access = "read", path = "./test/fixtures/bn254_constants.json" },
+  { access = "read", path = "./test/fixtures/mixed_block_1.json" },
+  { access = "read", path = "./test/fixtures/mixed_block_2.json" },
+  { access = "read", path = "./test/fixtures/single_tx_block_1.json" },
+  { access = "read", path = "./test/fixtures/single_tx_block_2.json" },
+  { access = "read", path = "./test/fixtures/empty_block_1.json" },
+  { access = "read", path = "./test/fixtures/empty_block_2.json" },
+  { access = "read", path = "./test/fixtures/fee_data_points.json" },
+  { access = "read", path = "./test/staking_asset_handler/zkpassport/fixtures/valid_proof.hex" },
+  { access = "read", path = "./test/staking_asset_handler/zkpassport/fixtures/valid_committed_inputs.hex" },
+  { access = "read", path = "./test/staking_asset_handler/zkpassport/fixtures/valid_public_inputs.json" },
+  { access = "read", path = "./test/fixtures/boosted_rewards/shares.json" },
+  { access = "read", path = "./test/fixtures/boosted_rewards/activity_scores.json" },
+  { access = "read", path = "./script/registration_data.json" },
 ]
 
-no_match_contract="(ScreamAndShoutTest|UniswapPortalTest|MerkleCheck)"
+no_match_contract = "(ScreamAndShoutTest|UniswapPortalTest|MerkleCheck)"
 
 [fmt]
 line_length = 120
 tab_width = 2
-variable_override_spacing=false
+variable_override_spacing = false
 wrap_comments = true
 number_underscore = "thousands"
 override_spacing = false
 
 [rpc_endpoints]
-mainnet_fork="https://mainnet.infura.io/v3/9928b52099854248b3a096be07a6b23c"
-
+mainnet_fork = "https://mainnet.infura.io/v3/9928b52099854248b3a096be07a6b23c"

--- a/l1-contracts/script/InternalGov.s.sol
+++ b/l1-contracts/script/InternalGov.s.sol
@@ -13,7 +13,6 @@ import {IRegistry} from "@aztec/governance/interfaces/IRegistry.sol";
 import {IValidatorSelection} from "@aztec/core/interfaces/IValidatorSelection.sol";
 import {IPayload} from "@aztec/governance/interfaces/IPayload.sol";
 import {RegisterNewRollupVersionPayload} from "../test/governance/scenario/RegisterNewRollupVersionPayload.sol";
-import {ProposalLib} from "@aztec/governance/libraries/ProposalLib.sol";
 import {Ownable} from "@oz/access/Ownable.sol";
 import {Fakerollup} from "../test/governance/governance-proposer/mocks/Fakerollup.sol";
 import {StakingAssetHandler} from "../src/mock/StakingAssetHandler.sol";
@@ -23,9 +22,10 @@ import {IStaking} from "@aztec/core/interfaces/IStaking.sol";
 import {RewardDistributor} from "@aztec/governance/RewardDistributor.sol";
 import {IInstance} from "@aztec/core/interfaces/IInstance.sol";
 import {RoundAccounting} from "@aztec/governance/proposer/EmpireBase.sol";
+import {UncompressedProposalWrapper} from "@test/governance/helpers/UncompressedProposalTestLib.sol";
 
 contract GovScript is Test {
-  using ProposalLib for Proposal;
+  UncompressedProposalWrapper internal upw = new UncompressedProposalWrapper();
 
   address internal constant ME = address(0xf8d7d601759CBcfB78044bA7cA9B0c0D6301A54f);
 
@@ -138,14 +138,14 @@ contract GovScript is Test {
     proposal = governance.getProposal(_proposalId);
     ProposalState state = governance.getProposalState(_proposalId);
 
-    Timestamp pendingThrough = proposal.pendingThrough();
+    Timestamp pendingThrough = upw.pendingThrough(proposal);
 
     emit log_named_string("Proposal state", stateNames[uint256(state)]);
     emit log_named_address("Proposal payload", address(proposal.payload));
     emit log_named_uint("pendingThrough   ", Timestamp.unwrap(pendingThrough));
-    emit log_named_uint("activeThrough    ", Timestamp.unwrap(proposal.activeThrough()));
-    emit log_named_uint("queuedThrough    ", Timestamp.unwrap(proposal.queuedThrough()));
-    emit log_named_uint("executableThrough", Timestamp.unwrap(proposal.executableThrough()));
+    emit log_named_uint("activeThrough    ", Timestamp.unwrap(upw.activeThrough(proposal)));
+    emit log_named_uint("queuedThrough    ", Timestamp.unwrap(upw.queuedThrough(proposal)));
+    emit log_named_uint("executableThrough", Timestamp.unwrap(upw.executableThrough(proposal)));
     emit log_named_uint("creation         ", Timestamp.unwrap(proposal.creation));
     emit log_named_decimal_uint("yeaCount         ", proposal.summedBallot.yea, 18);
     emit log_named_decimal_uint("nayCount         ", proposal.summedBallot.nay, 18);
@@ -317,7 +317,7 @@ contract GovScript is Test {
 
     proposal = governance.getProposal(_proposalId);
 
-    uint256 power = governance.powerAt(ME, proposal.pendingThrough());
+    uint256 power = governance.powerAt(ME, upw.pendingThrough(proposal));
     emit log_named_decimal_uint("power", power, 18);
 
     vm.startBroadcast(ME);

--- a/l1-contracts/src/core/libraries/rollup/StakingLib.sol
+++ b/l1-contracts/src/core/libraries/rollup/StakingLib.sol
@@ -147,7 +147,7 @@ library StakingLib {
     Proposal memory proposal = gov.getProposal(_proposalId);
     require(proposal.proposer == address(govProposer), Errors.Staking__IncorrectGovProposer(_proposalId));
 
-    Timestamp ts = proposal.pendingThroughMemory();
+    Timestamp ts = proposal.creation + proposal.config.votingDelay;
 
     // Cast votes with all our power
     uint256 vp = store.gse.getVotingPowerAt(address(this), ts);

--- a/l1-contracts/src/governance/GSE.sol
+++ b/l1-contracts/src/governance/GSE.sol
@@ -10,7 +10,6 @@ import {
   DepositDelegationLib, DepositAndDelegationAccounting
 } from "@aztec/governance/libraries/DepositDelegationLib.sol";
 import {Errors} from "@aztec/governance/libraries/Errors.sol";
-import {ProposalLib} from "@aztec/governance/libraries/ProposalLib.sol";
 import {BN254Lib, G1Point, G2Point} from "@aztec/shared/libraries/BN254Lib.sol";
 import {Timestamp} from "@aztec/shared/libraries/TimeMath.sol";
 import {Ownable} from "@oz/access/Ownable.sol";
@@ -122,7 +121,6 @@ contract GSECore is IGSECore, Ownable {
   using SafeCast for uint224;
   using Checkpoints for Checkpoints.Trace224;
   using DepositDelegationLib for DepositAndDelegationAccounting;
-  using ProposalLib for Proposal;
 
   /**
    * Create a special "bonus" address for use by the latest rollup.
@@ -619,7 +617,9 @@ contract GSECore is IGSECore, Ownable {
   }
 
   function _pendingThrough(uint256 _proposalId) internal view returns (Timestamp) {
-    return getGovernance().getProposal(_proposalId).pendingThroughMemory();
+    // Directly compute pendingThrough for memory proposal
+    Proposal memory proposal = getGovernance().getProposal(_proposalId);
+    return proposal.creation + proposal.config.votingDelay;
   }
 }
 

--- a/l1-contracts/src/governance/Governance.sol
+++ b/l1-contracts/src/governance/Governance.sol
@@ -7,11 +7,17 @@ import {
   Proposal,
   ProposalState,
   Configuration,
-  Ballot,
+  ProposeConfiguration,
   Withdrawal
 } from "@aztec/governance/interfaces/IGovernance.sol";
 import {IPayload} from "@aztec/governance/interfaces/IPayload.sol";
 import {Checkpoints, CheckpointedUintLib} from "@aztec/governance/libraries/CheckpointedUintLib.sol";
+import {Ballot, CompressedBallot, BallotLib} from "@aztec/governance/libraries/compressed-data/Ballot.sol";
+import {
+  CompressedConfiguration,
+  CompressedConfigurationLib
+} from "@aztec/governance/libraries/compressed-data/Configuration.sol";
+import {CompressedProposal, CompressedProposalLib} from "@aztec/governance/libraries/compressed-data/Proposal.sol";
 import {ConfigurationLib} from "@aztec/governance/libraries/ConfigurationLib.sol";
 import {Errors} from "@aztec/governance/libraries/Errors.sol";
 import {ProposalLib, VoteTabulationReturn} from "@aztec/governance/libraries/ProposalLib.sol";
@@ -129,9 +135,13 @@ struct DepositControl {
  */
 contract Governance is IGovernance {
   using SafeERC20 for IERC20;
-  using ProposalLib for Proposal;
+  using ProposalLib for CompressedProposal;
   using CheckpointedUintLib for Checkpoints.Trace224;
   using ConfigurationLib for Configuration;
+  using ConfigurationLib for CompressedConfiguration;
+  using CompressedConfigurationLib for CompressedConfiguration;
+  using CompressedProposalLib for CompressedProposal;
+  using BallotLib for CompressedBallot;
 
   IERC20 public immutable ASSET;
 
@@ -155,15 +165,16 @@ contract Governance is IGovernance {
    * New proposals are created by calling `_propose`, via `propose` or `proposeWithLock`.
    * The storage of a proposal may be modified by calling `vote`, `execute`, or `dropProposal`.
    */
-  mapping(uint256 proposalId => Proposal proposal) internal proposals;
+  mapping(uint256 proposalId => CompressedProposal proposal) internal proposals;
 
   /**
    * @dev The ballots that have been cast for each proposal.
    *
-   * `Ballot`s contain a `yea` and `nay` count, which are the number of votes for and against the proposal.
+   * `CompressedBallot`s contain a compressed `yea` and `nay` count (uint128 each packed into uint256),
+   * which are the number of votes for and against the proposal.
    * `ballots` is only updated during `vote`.
    */
-  mapping(uint256 proposalId => mapping(address user => Ballot ballot)) public ballots;
+  mapping(uint256 proposalId => mapping(address user => CompressedBallot ballot)) internal ballots;
 
   /**
    * @dev Checkpointed deposit amounts for an address.
@@ -185,7 +196,7 @@ contract Governance is IGovernance {
    * `configuration` is set in the constructor, and is only updated during `updateConfiguration`,
    * which must be done via a proposal.
    */
-  Configuration internal configuration;
+  CompressedConfiguration internal configuration;
 
   /**
    * @dev The total power of the governance contract.
@@ -237,8 +248,8 @@ contract Governance is IGovernance {
     ASSET = _asset;
     governanceProposer = _governanceProposer;
 
-    configuration = _configuration;
-    configuration.assertValid();
+    _configuration.assertValid();
+    configuration = CompressedConfigurationLib.compress(_configuration);
 
     // Unnecessary to set, but better clarity.
     depositControl.allBeneficiariesAllowed = false;
@@ -296,7 +307,7 @@ contract Governance is IGovernance {
     // This following MUST revert if the configuration is invalid
     _configuration.assertValid();
 
-    configuration = _configuration;
+    configuration = CompressedConfigurationLib.compress(_configuration);
 
     emit ConfigurationUpdated(Timestamp.wrap(block.timestamp));
   }
@@ -332,14 +343,14 @@ contract Governance is IGovernance {
    * @notice Initiate a withdrawal of funds from the governance contract,
    * decreasing the power of the beneficiary within the governance contract.
    *
-   * @dev the withdraw may be finalized by anyone after configuration.withdrawalDelay() has passed.
+   * @dev the withdraw may be finalized by anyone after configuration.getWithdrawalDelay() has passed.
    *
    * @param _to The address that will receive the funds when the withdrawal is finalized.
    * @param _amount The amount of power to reduce, and thus funds to withdraw.
    * @return The id of the withdrawal, passed to `finalizeWithdraw`.
    */
   function initiateWithdraw(address _to, uint256 _amount) external override(IGovernance) returns (uint256) {
-    return _initiateWithdraw(msg.sender, _to, _amount, configuration.withdrawalDelay());
+    return _initiateWithdraw(msg.sender, _to, _amount, configuration.getWithdrawalDelay());
   }
 
   /**
@@ -405,7 +416,8 @@ contract Governance is IGovernance {
    * @return The id of the proposal
    */
   function proposeWithLock(IPayload _proposal, address _to) external override(IGovernance) returns (uint256) {
-    _initiateWithdraw(msg.sender, _to, configuration.proposeConfig.lockAmount, configuration.proposeConfig.lockDelay);
+    ProposeConfiguration memory proposeConfig = configuration.getProposeConfig();
+    _initiateWithdraw(msg.sender, _to, proposeConfig.lockAmount, proposeConfig.lockDelay);
     return _propose(_proposal, address(this));
   }
 
@@ -435,18 +447,18 @@ contract Governance is IGovernance {
     // alter the power while the proposal is active since all txs in a block have the same timestamp.
     uint256 userPower = users[msg.sender].valueAt(proposals[_proposalId].pendingThrough());
 
-    Ballot storage userBallot = ballots[_proposalId][msg.sender];
+    CompressedBallot userBallot = ballots[_proposalId][msg.sender];
 
-    uint256 availablePower = userPower - (userBallot.nay + userBallot.yea);
+    uint256 availablePower = userPower - (userBallot.getNay() + userBallot.getYea());
     require(_amount <= availablePower, Errors.Governance__InsufficientPower(msg.sender, availablePower, _amount));
 
-    Ballot storage summedBallot = proposals[_proposalId].summedBallot;
+    CompressedProposal storage proposal = proposals[_proposalId];
     if (_support) {
-      userBallot.yea += _amount;
-      summedBallot.yea += _amount;
+      ballots[_proposalId][msg.sender] = userBallot.addYea(_amount);
+      proposal.addYea(_amount);
     } else {
-      userBallot.nay += _amount;
-      summedBallot.nay += _amount;
+      ballots[_proposalId][msg.sender] = userBallot.addNay(_amount);
+      proposal.addNay(_amount);
     }
 
     emit VoteCast(_proposalId, msg.sender, _support, _amount);
@@ -470,7 +482,7 @@ contract Governance is IGovernance {
     ProposalState state = getProposalState(_proposalId);
     require(state == ProposalState.Executable, Errors.Governance__ProposalNotExecutable());
 
-    Proposal storage proposal = proposals[_proposalId];
+    CompressedProposal storage proposal = proposals[_proposalId];
     proposal.cachedState = ProposalState.Executed;
 
     IPayload.Action[] memory actions = proposal.payload.getActions();
@@ -496,7 +508,7 @@ contract Governance is IGovernance {
    * @param _proposalId The id of the proposal to mark as `Dropped`.
    */
   function dropProposal(uint256 _proposalId) external override(IGovernance) returns (bool) {
-    Proposal storage self = proposals[_proposalId];
+    CompressedProposal storage self = proposals[_proposalId];
     require(self.cachedState != ProposalState.Dropped, Errors.Governance__ProposalAlreadyDropped());
     require(getProposalState(_proposalId) == ProposalState.Droppable, Errors.Governance__ProposalCannotBeDropped());
 
@@ -577,7 +589,7 @@ contract Governance is IGovernance {
   }
 
   function getConfiguration() external view override(IGovernance) returns (Configuration memory) {
-    return configuration;
+    return configuration.decompress();
   }
 
   /**
@@ -589,7 +601,7 @@ contract Governance is IGovernance {
    * @return The proposal.
    */
   function getProposal(uint256 _proposalId) external view override(IGovernance) returns (Proposal memory) {
-    return proposals[_proposalId];
+    return proposals[_proposalId].decompress();
   }
 
   /**
@@ -602,6 +614,19 @@ contract Governance is IGovernance {
    */
   function getWithdrawal(uint256 _withdrawalId) external view override(IGovernance) returns (Withdrawal memory) {
     return withdrawals[_withdrawalId];
+  }
+
+  /**
+   * @notice Get a user's ballot for a specific proposal.
+   *
+   * @dev Returns the uncompressed Ballot struct for external callers.
+   *
+   * @param _proposalId The id of the proposal.
+   * @param _user The address of the user.
+   * @return The user's ballot with yea and nay votes.
+   */
+  function getBallot(uint256 _proposalId, address _user) external view override(IGovernance) returns (Ballot memory) {
+    return ballots[_proposalId][_user].decompress();
   }
 
   /**
@@ -648,7 +673,7 @@ contract Governance is IGovernance {
   function getProposalState(uint256 _proposalId) public view override(IGovernance) returns (ProposalState) {
     require(_proposalId < proposalCount, Errors.Governance__ProposalDoesNotExists(_proposalId));
 
-    Proposal storage self = proposals[_proposalId];
+    CompressedProposal storage self = proposals[_proposalId];
 
     // A proposal's state is "stable" after `execute` or `dropProposal` has been called on it.
     // In this case, the state of the proposal as returned by `getProposalState` is the same as the cached state,
@@ -735,14 +760,8 @@ contract Governance is IGovernance {
   function _propose(IPayload _proposal, address _proposer) internal returns (uint256) {
     uint256 proposalId = proposalCount++;
 
-    proposals[proposalId] = Proposal({
-      config: configuration,
-      cachedState: ProposalState.Pending,
-      payload: _proposal,
-      proposer: _proposer,
-      creation: Timestamp.wrap(block.timestamp),
-      summedBallot: Ballot({yea: 0, nay: 0})
-    });
+    proposals[proposalId] =
+      CompressedProposalLib.create(_proposer, _proposal, Timestamp.wrap(block.timestamp), configuration);
 
     emit Proposed(proposalId, address(_proposal));
 

--- a/l1-contracts/src/governance/interfaces/IGovernance.sol
+++ b/l1-contracts/src/governance/interfaces/IGovernance.sol
@@ -3,6 +3,7 @@
 pragma solidity >=0.8.27;
 
 import {IPayload} from "@aztec/governance/interfaces/IPayload.sol";
+import {Ballot} from "@aztec/governance/libraries/compressed-data/Ballot.sol";
 import {Timestamp} from "@aztec/shared/libraries/TimeMath.sol";
 
 // @notice if this changes, please update the enum in governance.ts
@@ -34,13 +35,20 @@ struct Configuration {
   uint256 minimumVotes;
 }
 
-struct Ballot {
-  uint256 yea;
-  uint256 nay;
+// Configuration for proposals - same as Configuration but without proposeConfig
+// since proposeConfig is only used for proposeWithLock, not for the proposal itself
+struct ProposalConfiguration {
+  Timestamp votingDelay;
+  Timestamp votingDuration;
+  Timestamp executionDelay;
+  Timestamp gracePeriod;
+  uint256 quorum;
+  uint256 requiredYeaMargin;
+  uint256 minimumVotes;
 }
 
 struct Proposal {
-  Configuration config;
+  ProposalConfiguration config;
   ProposalState cachedState;
   IPayload payload;
   address proposer;
@@ -95,4 +103,5 @@ interface IGovernance {
   function getConfiguration() external view returns (Configuration memory);
   function getProposal(uint256 _proposalId) external view returns (Proposal memory);
   function getWithdrawal(uint256 _withdrawalId) external view returns (Withdrawal memory);
+  function getBallot(uint256 _proposalId, address _user) external view returns (Ballot memory);
 }

--- a/l1-contracts/src/governance/libraries/ConfigurationLib.sol
+++ b/l1-contracts/src/governance/libraries/ConfigurationLib.sol
@@ -3,17 +3,24 @@
 pragma solidity >=0.8.27;
 
 import {Configuration} from "@aztec/governance/interfaces/IGovernance.sol";
+import {CompressedConfiguration} from "@aztec/governance/libraries/compressed-data/Configuration.sol";
 import {Errors} from "@aztec/governance/libraries/Errors.sol";
+import {CompressedTimeMath, CompressedTimestamp} from "@aztec/shared/libraries/CompressedTimeMath.sol";
 import {Timestamp} from "@aztec/shared/libraries/TimeMath.sol";
 
 library ConfigurationLib {
+  using CompressedTimeMath for CompressedTimestamp;
+
   uint256 internal constant QUORUM_LOWER = 1;
   uint256 internal constant QUORUM_UPPER = 1e18;
 
   uint256 internal constant REQUIRED_YEA_MARGIN_UPPER = 1e18;
 
   uint256 internal constant VOTES_LOWER = 1;
+  uint256 internal constant VOTES_UPPER = type(uint96).max; // Maximum for compressed storage (uint96)
+
   uint256 internal constant LOCK_AMOUNT_LOWER = 2;
+  uint256 internal constant LOCK_AMOUNT_UPPER = type(uint96).max; // Maximum for compressed storage (uint96)
 
   Timestamp internal constant TIME_LOWER = Timestamp.wrap(60);
   Timestamp internal constant TIME_UPPER = Timestamp.wrap(30 * 24 * 3600);
@@ -26,8 +33,12 @@ library ConfigurationLib {
    *
    * The "small buffer" is somewhat arbitrarily set to the votingDelay / 5.
    */
-  function withdrawalDelay(Configuration storage _self) internal view returns (Timestamp) {
-    return Timestamp.wrap(Timestamp.unwrap(_self.votingDelay) / 5) + _self.votingDuration + _self.executionDelay;
+  function getWithdrawalDelay(CompressedConfiguration storage _self) internal view returns (Timestamp) {
+    Timestamp votingDelay = _self.votingDelay.decompress();
+    Timestamp votingDuration = _self.votingDuration.decompress();
+    Timestamp executionDelay = _self.executionDelay.decompress();
+
+    return Timestamp.wrap(Timestamp.unwrap(votingDelay) / 5) + votingDuration + executionDelay;
   }
 
   /**
@@ -45,8 +56,13 @@ library ConfigurationLib {
     );
 
     require(_self.minimumVotes >= VOTES_LOWER, Errors.Governance__ConfigurationLib__InvalidMinimumVotes());
+    require(_self.minimumVotes <= VOTES_UPPER, Errors.Governance__ConfigurationLib__InvalidMinimumVotes());
+
     require(
       _self.proposeConfig.lockAmount >= LOCK_AMOUNT_LOWER, Errors.Governance__ConfigurationLib__LockAmountTooSmall()
+    );
+    require(
+      _self.proposeConfig.lockAmount <= LOCK_AMOUNT_UPPER, Errors.Governance__ConfigurationLib__LockAmountTooBig()
     );
 
     // Beyond checking the bounds like this, it might be useful to ensure that the value is larger than the withdrawal

--- a/l1-contracts/src/governance/libraries/Errors.sol
+++ b/l1-contracts/src/governance/libraries/Errors.sol
@@ -37,6 +37,7 @@ library Errors {
 
   error Governance__ConfigurationLib__InvalidMinimumVotes();
   error Governance__ConfigurationLib__LockAmountTooSmall();
+  error Governance__ConfigurationLib__LockAmountTooBig();
   error Governance__ConfigurationLib__QuorumTooSmall();
   error Governance__ConfigurationLib__QuorumTooBig();
   error Governance__ConfigurationLib__RequiredYeaMarginTooBig();

--- a/l1-contracts/src/governance/libraries/compressed-data/Ballot.sol
+++ b/l1-contracts/src/governance/libraries/compressed-data/Ballot.sol
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024 Aztec Labs.
+pragma solidity >=0.8.27;
+
+import {SafeCast} from "@oz/utils/math/SafeCast.sol";
+
+struct Ballot {
+  uint256 yea;
+  uint256 nay;
+}
+
+type CompressedBallot is uint256;
+
+library BallotLib {
+  using SafeCast for uint256;
+
+  uint256 internal constant YEA_MASK = 0xffffffffffffffffffffffffffffffff00000000000000000000000000000000;
+  uint256 internal constant NAY_MASK = 0xffffffffffffffffffffffffffffffff;
+
+  function getYea(CompressedBallot _compressedBallot) internal pure returns (uint256) {
+    return CompressedBallot.unwrap(_compressedBallot) >> 128;
+  }
+
+  function getNay(CompressedBallot _compressedBallot) internal pure returns (uint256) {
+    return CompressedBallot.unwrap(_compressedBallot) & NAY_MASK;
+  }
+
+  function updateYea(CompressedBallot _compressedBallot, uint256 _yea) internal pure returns (CompressedBallot) {
+    uint256 value = CompressedBallot.unwrap(_compressedBallot) & ~YEA_MASK;
+    return CompressedBallot.wrap(value | (_yea << 128));
+  }
+
+  function updateNay(CompressedBallot _compressedBallot, uint256 _nay) internal pure returns (CompressedBallot) {
+    uint256 value = CompressedBallot.unwrap(_compressedBallot) & ~NAY_MASK;
+    return CompressedBallot.wrap(value | _nay);
+  }
+
+  function addYea(CompressedBallot _compressedBallot, uint256 _amount) internal pure returns (CompressedBallot) {
+    uint256 currentYea = getYea(_compressedBallot);
+    uint256 newYea = currentYea + _amount;
+    return updateYea(_compressedBallot, newYea.toUint128());
+  }
+
+  function addNay(CompressedBallot _compressedBallot, uint256 _amount) internal pure returns (CompressedBallot) {
+    uint256 currentNay = getNay(_compressedBallot);
+    uint256 newNay = currentNay + _amount;
+    return updateNay(_compressedBallot, newNay.toUint128());
+  }
+
+  function compress(Ballot memory _ballot) internal pure returns (CompressedBallot) {
+    // We are doing cast to uint128 but inside a uint256 to not wreck the shifting.
+    uint256 yea = _ballot.yea.toUint128();
+    uint256 nay = _ballot.nay.toUint128();
+    return CompressedBallot.wrap((yea << 128) | nay);
+  }
+
+  function decompress(CompressedBallot _compressedBallot) internal pure returns (Ballot memory) {
+    return Ballot({yea: getYea(_compressedBallot), nay: getNay(_compressedBallot)});
+  }
+}

--- a/l1-contracts/src/governance/libraries/compressed-data/Configuration.sol
+++ b/l1-contracts/src/governance/libraries/compressed-data/Configuration.sol
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024 Aztec Labs.
+pragma solidity >=0.8.27;
+
+import {Configuration, ProposeConfiguration} from "@aztec/governance/interfaces/IGovernance.sol";
+import {CompressedTimestamp, CompressedTimeMath} from "@aztec/shared/libraries/CompressedTimeMath.sol";
+import {Timestamp} from "@aztec/shared/libraries/TimeMath.sol";
+import {SafeCast} from "@oz/utils/math/SafeCast.sol";
+
+/**
+ * @title CompressedConfiguration
+ * @notice Compressed storage representation of governance configuration
+ * @dev Packs configuration into minimal storage slots:
+ *      Slot 1: Timing & percentages - votingDelay (32), votingDuration (32), executionDelay (32), gracePeriod (32),
+ * quorum (64), requiredYeaMargin (64)
+ *      Slot 2: Amounts & proposeConfig - minimumVotes (96), lockAmount (96), lockDelay (32), unused (32)
+ *
+ * This packing reduces storage from ~8 slots to 2 slots.
+ * All timestamps use CompressedTimestamp (uint32, valid until year 2106).
+ * Percentages (quorum, requiredYeaMargin) use uint64 (max 1e18).
+ * Amounts use uint96 for realistic token amounts.
+ * ProposeConfig fields are kept together in Slot 2.
+ */
+struct CompressedConfiguration {
+  // Slot 1: Timing and percentages - 32*4 + 64*2 = 256 bits
+  CompressedTimestamp votingDelay;
+  CompressedTimestamp votingDuration;
+  CompressedTimestamp executionDelay;
+  CompressedTimestamp gracePeriod;
+  uint64 quorum;
+  uint64 requiredYeaMargin;
+  // Slot 2: Amounts and proposeConfig - 96 + 96 + 32 = 224 bits (32 bits unused)
+  uint96 minimumVotes;
+  uint96 lockAmount;
+  CompressedTimestamp lockDelay;
+}
+
+library CompressedConfigurationLib {
+  using SafeCast for uint256;
+  using CompressedTimeMath for Timestamp;
+  using CompressedTimeMath for CompressedTimestamp;
+
+  /**
+   * @notice Get the propose configuration directly from storage
+   * @param _compressed Storage pointer to compressed configuration
+   * @return The propose configuration
+   */
+  function getProposeConfig(CompressedConfiguration storage _compressed)
+    internal
+    view
+    returns (ProposeConfiguration memory)
+  {
+    return ProposeConfiguration({lockDelay: _compressed.lockDelay.decompress(), lockAmount: _compressed.lockAmount});
+  }
+
+  /**
+   * @notice Compress a Configuration struct into CompressedConfiguration
+   * @param _config The uncompressed configuration
+   * @return The compressed configuration
+   * @dev Values that exceed the compressed type limits will cause a revert.
+   *      This is intentional to prevent storing invalid configurations.
+   */
+  function compress(Configuration memory _config) internal pure returns (CompressedConfiguration memory) {
+    // Validate that amounts fit in their compressed types
+    require(_config.proposeConfig.lockAmount <= type(uint96).max, "lockAmount exceeds uint96");
+    require(_config.minimumVotes <= type(uint96).max, "minimumVotes exceeds uint96");
+    require(_config.quorum <= type(uint64).max, "quorum exceeds uint64");
+    require(_config.requiredYeaMargin <= type(uint64).max, "requiredYeaMargin exceeds uint64");
+
+    return CompressedConfiguration({
+      votingDelay: _config.votingDelay.compress(),
+      votingDuration: _config.votingDuration.compress(),
+      executionDelay: _config.executionDelay.compress(),
+      gracePeriod: _config.gracePeriod.compress(),
+      quorum: _config.quorum.toUint64(),
+      requiredYeaMargin: _config.requiredYeaMargin.toUint64(),
+      minimumVotes: _config.minimumVotes.toUint96(),
+      lockAmount: _config.proposeConfig.lockAmount.toUint96(),
+      lockDelay: _config.proposeConfig.lockDelay.compress()
+    });
+  }
+
+  /**
+   * @notice Decompress a CompressedConfiguration into Configuration
+   * @param _compressed The compressed configuration
+   * @return The uncompressed configuration
+   */
+  function decompress(CompressedConfiguration memory _compressed) internal pure returns (Configuration memory) {
+    return Configuration({
+      proposeConfig: ProposeConfiguration({
+        lockDelay: _compressed.lockDelay.decompress(),
+        lockAmount: _compressed.lockAmount
+      }),
+      votingDelay: _compressed.votingDelay.decompress(),
+      votingDuration: _compressed.votingDuration.decompress(),
+      executionDelay: _compressed.executionDelay.decompress(),
+      gracePeriod: _compressed.gracePeriod.decompress(),
+      quorum: _compressed.quorum,
+      requiredYeaMargin: _compressed.requiredYeaMargin,
+      minimumVotes: _compressed.minimumVotes
+    });
+  }
+}

--- a/l1-contracts/src/governance/libraries/compressed-data/Proposal.sol
+++ b/l1-contracts/src/governance/libraries/compressed-data/Proposal.sol
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024 Aztec Labs.
+pragma solidity >=0.8.27;
+
+import {Proposal, ProposalState, ProposalConfiguration} from "@aztec/governance/interfaces/IGovernance.sol";
+import {IPayload} from "@aztec/governance/interfaces/IPayload.sol";
+import {CompressedBallot, BallotLib} from "@aztec/governance/libraries/compressed-data/Ballot.sol";
+import {CompressedConfiguration} from "@aztec/governance/libraries/compressed-data/Configuration.sol";
+import {CompressedTimestamp, CompressedTimeMath} from "@aztec/shared/libraries/CompressedTimeMath.sol";
+import {Timestamp} from "@aztec/shared/libraries/TimeMath.sol";
+import {SafeCast} from "@oz/utils/math/SafeCast.sol";
+
+/**
+ * @title CompressedProposal
+ * @notice Compressed storage representation of governance proposals
+ * @dev Packs proposal data with embedded config values into 4 storage slots:
+ *      Slot 1: proposer (160) + minimumVotes (96) = 256 bits
+ *      Slot 2: cachedState (8) + creation (32) + timing fields (32*4) + quorum (64) = 232 bits
+ *      Slot 3: summedBallot (256 bits as CompressedBallot)
+ *      Slot 4: payload (160) + requiredYeaMargin (64) = 224 bits
+ *
+ * This packing reduces storage from ~10 slots to 4 slots by embedding config values
+ * directly instead of storing the entire configuration struct.
+ */
+struct CompressedProposal {
+  // Slot 1: Core Identity (256 bits)
+  address proposer; // 160 bits
+  uint96 minimumVotes; // 96 bits - from config
+  // Slot 2: Timing (232 bits used, 24 bits padding)
+  ProposalState cachedState; // 8 bits
+  CompressedTimestamp creation; // 32 bits
+  CompressedTimestamp votingDelay; // 32 bits - from config
+  CompressedTimestamp votingDuration; // 32 bits - from config
+  CompressedTimestamp executionDelay; // 32 bits - from config
+  CompressedTimestamp gracePeriod; // 32 bits - from config
+  uint64 quorum; // 64 bits - from config
+  // Slot 3: Votes (256 bits)
+  CompressedBallot summedBallot; // 256 bits (128 yea + 128 nay)
+  // Slot 4: References (224 bits used, 32 bits padding)
+  IPayload payload; // 160 bits
+  uint64 requiredYeaMargin; // 64 bits - from config
+}
+
+library CompressedProposalLib {
+  using SafeCast for uint256;
+  using CompressedTimeMath for Timestamp;
+  using CompressedTimeMath for CompressedTimestamp;
+  using BallotLib for CompressedBallot;
+
+  /**
+   * @notice Add yea votes to the proposal
+   * @param _compressed Storage pointer to compressed proposal
+   * @param _amount The amount of yea votes to add
+   */
+  function addYea(CompressedProposal storage _compressed, uint256 _amount) internal {
+    _compressed.summedBallot = _compressed.summedBallot.addYea(_amount);
+  }
+
+  /**
+   * @notice Add nay votes to the proposal
+   * @param _compressed Storage pointer to compressed proposal
+   * @param _amount The amount of nay votes to add
+   */
+  function addNay(CompressedProposal storage _compressed, uint256 _amount) internal {
+    _compressed.summedBallot = _compressed.summedBallot.addNay(_amount);
+  }
+
+  /**
+   * @notice Get yea and nay votes
+   * @param _compressed Storage pointer to compressed proposal
+   * @return yea The yea votes
+   * @return nay The nay votes
+   */
+  function getVotes(CompressedProposal storage _compressed) internal view returns (uint256 yea, uint256 nay) {
+    yea = _compressed.summedBallot.getYea();
+    nay = _compressed.summedBallot.getNay();
+  }
+
+  /**
+   * @notice Create a compressed proposal from uncompressed data and config
+   * @param _proposer The proposal creator
+   * @param _payload The payload to execute
+   * @param _creation The creation timestamp
+   * @param _config The compressed configuration to embed
+   * @return The compressed proposal
+   */
+  function create(address _proposer, IPayload _payload, Timestamp _creation, CompressedConfiguration memory _config)
+    internal
+    pure
+    returns (CompressedProposal memory)
+  {
+    return CompressedProposal({
+      proposer: _proposer,
+      minimumVotes: _config.minimumVotes,
+      cachedState: ProposalState.Pending,
+      creation: _creation.compress(),
+      votingDelay: _config.votingDelay,
+      votingDuration: _config.votingDuration,
+      executionDelay: _config.executionDelay,
+      gracePeriod: _config.gracePeriod,
+      quorum: _config.quorum,
+      summedBallot: CompressedBallot.wrap(0),
+      payload: _payload,
+      requiredYeaMargin: _config.requiredYeaMargin
+    });
+  }
+
+  /**
+   * @notice Compress an uncompressed Proposal into a CompressedProposal
+   * @param _proposal The uncompressed proposal to compress
+   * @return The compressed proposal
+   */
+  function compress(Proposal memory _proposal) internal pure returns (CompressedProposal memory) {
+    return CompressedProposal({
+      proposer: _proposal.proposer,
+      minimumVotes: _proposal.config.minimumVotes.toUint96(),
+      cachedState: _proposal.cachedState,
+      creation: _proposal.creation.compress(),
+      votingDelay: _proposal.config.votingDelay.compress(),
+      votingDuration: _proposal.config.votingDuration.compress(),
+      executionDelay: _proposal.config.executionDelay.compress(),
+      gracePeriod: _proposal.config.gracePeriod.compress(),
+      quorum: _proposal.config.quorum.toUint64(),
+      summedBallot: BallotLib.compress(_proposal.summedBallot),
+      payload: _proposal.payload,
+      requiredYeaMargin: _proposal.config.requiredYeaMargin.toUint64()
+    });
+  }
+
+  /**
+   * @notice Decompress a CompressedProposal into a standard Proposal
+   * @param _compressed The compressed proposal
+   * @return The uncompressed proposal
+   */
+  function decompress(CompressedProposal memory _compressed) internal pure returns (Proposal memory) {
+    return Proposal({
+      config: ProposalConfiguration({
+        votingDelay: _compressed.votingDelay.decompress(),
+        votingDuration: _compressed.votingDuration.decompress(),
+        executionDelay: _compressed.executionDelay.decompress(),
+        gracePeriod: _compressed.gracePeriod.decompress(),
+        quorum: _compressed.quorum,
+        requiredYeaMargin: _compressed.requiredYeaMargin,
+        minimumVotes: _compressed.minimumVotes
+      }),
+      cachedState: _compressed.cachedState,
+      payload: _compressed.payload,
+      proposer: _compressed.proposer,
+      creation: _compressed.creation.decompress(),
+      summedBallot: _compressed.summedBallot.decompress()
+    });
+  }
+}

--- a/l1-contracts/test/builder/RollupBuilder.sol
+++ b/l1-contracts/test/builder/RollupBuilder.sol
@@ -21,6 +21,7 @@ import {MultiAdder, CheatDepositArgs} from "@aztec/mock/MultiAdder.sol";
 import {CoinIssuer} from "@aztec/governance/CoinIssuer.sol";
 import {stdStorage, StdStorage} from "forge-std/Test.sol";
 import {GSEWithSkip} from "@test/GSEWithSkip.sol";
+import {TestGov} from "@test/governance/helpers/TestGov.sol";
 
 // Stack the layers to avoid the stack too deep 🧌
 struct ConfigFlags {
@@ -272,7 +273,7 @@ contract RollupBuilder is Test {
     if (config.flags.makeGovernance) {
       GovernanceProposer proposer =
         new GovernanceProposer(config.registry, config.gse, config.values.govProposerN, config.values.govProposerM);
-      config.governance = new Governance(
+      config.governance = new TestGov(
         config.testERC20, address(proposer), address(config.gse), TestConstants.getGovernanceConfiguration()
       );
       vm.label(address(config.governance), "Governance");

--- a/l1-contracts/test/compression/Ballot.t.sol
+++ b/l1-contracts/test/compression/Ballot.t.sol
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024 Aztec Labs.
+pragma solidity >=0.8.27;
+
+import {Test} from "forge-std/Test.sol";
+import {Ballot, CompressedBallot, BallotLib} from "@aztec/governance/libraries/compressed-data/Ballot.sol";
+
+contract BallotTest is Test {
+  using BallotLib for CompressedBallot;
+  using BallotLib for Ballot;
+
+  function test_compress_uncompress(uint128 _yea, uint128 _nay) public pure {
+    Ballot memory ballot = Ballot({yea: _yea, nay: _nay});
+
+    CompressedBallot compressedBallot = ballot.compress();
+    Ballot memory decompressedBallot = compressedBallot.decompress();
+
+    assertEq(compressedBallot.getYea(), ballot.yea, "getYea");
+    assertEq(compressedBallot.getNay(), ballot.nay, "getNay");
+
+    assertEq(decompressedBallot.yea, ballot.yea, "decompressed yea");
+    assertEq(decompressedBallot.nay, ballot.nay, "decompressed nay");
+  }
+
+  function test_updateYea(uint128 _yea, uint128 _nay) public pure {
+    uint256 yea = bound(_yea, 0, type(uint128).max - 1);
+    Ballot memory a = Ballot({yea: yea, nay: _nay});
+
+    CompressedBallot b = a.compress();
+    CompressedBallot c = b.updateYea(yea + 1);
+
+    assertEq(c.getYea(), yea + 1, "c.getYea");
+    assertEq(c.getNay(), _nay, "c.getNay");
+    assertEq(c.getYea(), b.getYea() + 1, "c.getYea != b.getYea + 1");
+  }
+
+  function test_updateNay(uint128 _yea, uint128 _nay) public pure {
+    uint256 nay = bound(_nay, 0, type(uint128).max - 1);
+    Ballot memory a = Ballot({yea: _yea, nay: nay});
+
+    CompressedBallot b = a.compress();
+    CompressedBallot c = b.updateNay(nay + 1);
+
+    assertEq(c.getYea(), _yea, "c.getYea");
+    assertEq(c.getNay(), nay + 1, "c.getNay");
+    assertEq(c.getNay(), b.getNay() + 1, "c.getNay != b.getNay + 1");
+  }
+
+  function test_addYea(uint128 _initialYea, uint128 _nay, uint128 _amount) public pure {
+    uint256 initialYea = bound(_initialYea, 0, type(uint128).max / 2);
+    uint256 amount = bound(_amount, 0, type(uint128).max / 2);
+
+    Ballot memory a = Ballot({yea: initialYea, nay: _nay});
+    CompressedBallot b = a.compress();
+    CompressedBallot c = b.addYea(amount);
+
+    assertEq(c.getYea(), initialYea + amount, "c.getYea after addYea");
+    assertEq(c.getNay(), _nay, "c.getNay should remain unchanged");
+  }
+
+  function test_addNay(uint128 _yea, uint128 _initialNay, uint128 _amount) public pure {
+    uint256 initialNay = bound(_initialNay, 0, type(uint128).max / 2);
+    uint256 amount = bound(_amount, 0, type(uint128).max / 2);
+
+    Ballot memory a = Ballot({yea: _yea, nay: initialNay});
+    CompressedBallot b = a.compress();
+    CompressedBallot c = b.addNay(amount);
+
+    assertEq(c.getYea(), _yea, "c.getYea should remain unchanged");
+    assertEq(c.getNay(), initialNay + amount, "c.getNay after addNay");
+  }
+
+  function test_addYeaMultipleTimes(uint128 _nay) public pure {
+    CompressedBallot ballot = BallotLib.compress(Ballot({yea: 0, nay: _nay}));
+
+    ballot = ballot.addYea(100);
+    assertEq(ballot.getYea(), 100, "After first addYea");
+
+    ballot = ballot.addYea(200);
+    assertEq(ballot.getYea(), 300, "After second addYea");
+
+    ballot = ballot.addYea(400);
+    assertEq(ballot.getYea(), 700, "After third addYea");
+
+    assertEq(ballot.getNay(), _nay, "Nay should remain unchanged");
+  }
+
+  function test_addNayMultipleTimes(uint128 _yea) public pure {
+    CompressedBallot ballot = BallotLib.compress(Ballot({yea: _yea, nay: 0}));
+
+    ballot = ballot.addNay(50);
+    assertEq(ballot.getNay(), 50, "After first addNay");
+
+    ballot = ballot.addNay(150);
+    assertEq(ballot.getNay(), 200, "After second addNay");
+
+    ballot = ballot.addNay(300);
+    assertEq(ballot.getNay(), 500, "After third addNay");
+
+    assertEq(ballot.getYea(), _yea, "Yea should remain unchanged");
+  }
+
+  function test_mixedOperations(uint128 _initialYea, uint128 _initialNay) public pure {
+    uint256 initialYea = bound(_initialYea, 0, type(uint128).max / 4);
+    uint256 initialNay = bound(_initialNay, 0, type(uint128).max / 4);
+
+    Ballot memory initialBallot = Ballot({yea: initialYea, nay: initialNay});
+    CompressedBallot ballot = initialBallot.compress();
+
+    // Add to both yea and nay
+    ballot = ballot.addYea(1000);
+    ballot = ballot.addNay(500);
+
+    assertEq(ballot.getYea(), initialYea + 1000, "Yea after operations");
+    assertEq(ballot.getNay(), initialNay + 500, "Nay after operations");
+
+    // Decompress and verify
+    Ballot memory finalBallot = ballot.decompress();
+    assertEq(finalBallot.yea, initialYea + 1000, "Final decompressed yea");
+    assertEq(finalBallot.nay, initialNay + 500, "Final decompressed nay");
+  }
+}

--- a/l1-contracts/test/delegation/minimal.t.sol
+++ b/l1-contracts/test/delegation/minimal.t.sol
@@ -16,6 +16,7 @@ import {GovernanceProposer} from "@aztec/governance/proposer/GovernanceProposer.
 import {Fakerollup} from "../governance/governance-proposer/mocks/Fakerollup.sol";
 import {IRollup} from "@aztec/core/interfaces/IRollup.sol";
 import {BN254Lib, G1Point, G2Point} from "@aztec/shared/libraries/BN254Lib.sol";
+import {UncompressedProposalWrapper} from "@test/governance/helpers/UncompressedProposalTestLib.sol";
 
 struct Timestamps {
   uint256 ts1;
@@ -31,6 +32,8 @@ struct Timestamps {
 // Not to be seen as full tests
 contract MinimalDelegationTest is GSEBase {
   using stdStorage for StdStorage;
+
+  UncompressedProposalWrapper internal upw = new UncompressedProposalWrapper();
 
   address bonus;
   uint256 activationThreshold;
@@ -54,7 +57,7 @@ contract MinimalDelegationTest is GSEBase {
     stdstore.target(proposer).sig("getProposalProposer(uint256)").with_key(proposalId).checked_write(address(ROLLUP));
     assertEq(GovernanceProposer(proposer).getProposalProposer(proposalId), address(ROLLUP));
 
-    uint256 votingTime = Timestamp.unwrap(ProposalLib.pendingThroughMemory(governance.getProposal(0)));
+    uint256 votingTime = Timestamp.unwrap(upw.pendingThrough(governance.getProposal(0)));
 
     Timestamps memory ts;
 

--- a/l1-contracts/test/governance/governance-proposer/scenario/tmnt143.t.sol
+++ b/l1-contracts/test/governance/governance-proposer/scenario/tmnt143.t.sol
@@ -21,6 +21,7 @@ import {Governance} from "@aztec/governance/Governance.sol";
 import {TestConstants} from "../../../harnesses/TestConstants.sol";
 import {Proposal, ProposalState} from "@aztec/governance/interfaces/IGovernance.sol";
 import {ProposalLib} from "@aztec/governance/libraries/ProposalLib.sol";
+import {UncompressedProposalWrapper} from "@test/governance/helpers/UncompressedProposalTestLib.sol";
 import {IGSE} from "@aztec/governance/GSE.sol";
 
 contract MisconfiguredPayload is IPayload {
@@ -81,7 +82,7 @@ contract FakeGSE {
 
 // https://linear.app/aztec-labs/issue/TMNT-143/spearbit-gov-finding-8-governance-deadlock
 contract TestTmnt143 is TestBase {
-  using ProposalLib for Proposal;
+  UncompressedProposalWrapper internal upw = new UncompressedProposalWrapper();
 
   TestERC20 public asset;
   Registry public registry;
@@ -150,14 +151,14 @@ contract TestTmnt143 is TestBase {
     // are fine with staying, they like the tech/deployment.
     gse.setSupplyOf(bonusInstance, 0);
 
-    vm.warp(Timestamp.unwrap(proposal.pendingThrough()) + 1);
+    vm.warp(Timestamp.unwrap(upw.pendingThrough(proposal)) + 1);
 
     governance.vote(0, 10_000e18, true);
 
-    vm.warp(Timestamp.unwrap(proposal.activeThrough()) + 1);
+    vm.warp(Timestamp.unwrap(upw.activeThrough(proposal)) + 1);
     assertTrue(governance.getProposalState(0) == ProposalState.Queued);
 
-    vm.warp(Timestamp.unwrap(proposal.queuedThrough()) + 1);
+    vm.warp(Timestamp.unwrap(upw.queuedThrough(proposal)) + 1);
     assertTrue(governance.getProposalState(0) == ProposalState.Executable);
     assertEq(governance.governanceProposer(), address(governanceProposer));
 

--- a/l1-contracts/test/governance/governance/initiateWithdraw.t.sol
+++ b/l1-contracts/test/governance/governance/initiateWithdraw.t.sol
@@ -100,7 +100,10 @@ contract InitiateWithdrawTest is GovernanceBase {
 
       Withdrawal memory withdrawal = governance.getWithdrawal(withdrawalId);
       assertEq(withdrawal.amount, amount, "invalid amount");
-      assertEq(withdrawal.unlocksAt, Timestamp.wrap(block.timestamp) + config.withdrawalDelay(), "Invalid timestamp");
+      Configuration memory memConfig = config;
+      assertEq(
+        withdrawal.unlocksAt, Timestamp.wrap(block.timestamp) + upw.getWithdrawalDelay(memConfig), "Invalid timestamp"
+      );
       assertEq(withdrawal.recipient, recipient, "invalid recipient");
       assertFalse(withdrawal.claimed, "already claimed");
       assertEq(governance.totalPowerNow(), sum);

--- a/l1-contracts/test/governance/governance/proposallib/static.t.sol
+++ b/l1-contracts/test/governance/governance/proposallib/static.t.sol
@@ -3,11 +3,11 @@ pragma solidity >=0.8.27;
 
 import {TestBase} from "@test/base/Base.sol";
 import {Proposal, Configuration} from "@aztec/governance/interfaces/IGovernance.sol";
-import {ProposalLib} from "@aztec/governance/libraries/ProposalLib.sol";
+import {UncompressedProposalWrapper} from "@test/governance/helpers/UncompressedProposalTestLib.sol";
 import {Timestamp} from "@aztec/core/libraries/TimeLib.sol";
 
 contract Static is TestBase {
-  using ProposalLib for Proposal;
+  UncompressedProposalWrapper internal upw = new UncompressedProposalWrapper();
 
   Proposal internal proposal;
 
@@ -24,21 +24,23 @@ contract Static is TestBase {
 
   function test_pendingThrough(Configuration memory _config, uint256 _creation) external limitConfig(_config) {
     proposal.creation = Timestamp.wrap(bound(_creation, 0, type(uint32).max));
-    assertEq(proposal.pendingThrough(), proposal.creation + proposal.config.votingDelay);
+    assertEq(upw.pendingThrough(proposal), proposal.creation + proposal.config.votingDelay);
 
     Proposal memory proposalMemory = proposal;
-    assertEq(proposalMemory.pendingThroughMemory(), proposal.creation + proposal.config.votingDelay);
+    assertEq(upw.pendingThrough(proposalMemory), proposal.creation + proposal.config.votingDelay);
   }
 
   function test_activeThrough(Configuration memory _config, uint256 _creation) external limitConfig(_config) {
     proposal.creation = Timestamp.wrap(bound(_creation, 0, type(uint32).max));
-    assertEq(proposal.activeThrough(), proposal.creation + proposal.config.votingDelay + proposal.config.votingDuration);
+    assertEq(
+      upw.activeThrough(proposal), proposal.creation + proposal.config.votingDelay + proposal.config.votingDuration
+    );
   }
 
   function test_queuedThrough(Configuration memory _config, uint256 _creation) external limitConfig(_config) {
     proposal.creation = Timestamp.wrap(bound(_creation, 0, type(uint32).max));
     assertEq(
-      proposal.queuedThrough(),
+      upw.queuedThrough(proposal),
       proposal.creation + proposal.config.votingDelay + proposal.config.votingDuration + proposal.config.executionDelay
     );
   }
@@ -46,7 +48,7 @@ contract Static is TestBase {
   function test_executableThrough(Configuration memory _config, uint256 _creation) external limitConfig(_config) {
     proposal.creation = Timestamp.wrap(bound(_creation, 0, type(uint32).max));
     assertEq(
-      proposal.executableThrough(),
+      upw.executableThrough(proposal),
       proposal.creation + proposal.config.votingDelay + proposal.config.votingDuration + proposal.config.executionDelay
         + proposal.config.gracePeriod
     );

--- a/l1-contracts/test/governance/governance/proposallib/voteTabulation.t.sol
+++ b/l1-contracts/test/governance/governance/proposallib/voteTabulation.t.sol
@@ -3,13 +3,11 @@ pragma solidity >=0.8.27;
 
 import {GovernanceBase} from "../base.t.sol";
 import {Configuration, Proposal} from "@aztec/governance/interfaces/IGovernance.sol";
-import {ProposalLib, VoteTabulationReturn, VoteTabulationInfo} from "@aztec/governance/libraries/ProposalLib.sol";
+import {VoteTabulationReturn, VoteTabulationInfo} from "@aztec/governance/libraries/ProposalLib.sol";
 import {ConfigurationLib} from "@aztec/governance/libraries/ConfigurationLib.sol";
-
 import {Math, Panic} from "@oz/utils/math/Math.sol";
 
 contract VoteTabulationTest is GovernanceBase {
-  using ProposalLib for Proposal;
   using ConfigurationLib for Configuration;
 
   uint256 internal totalPower;
@@ -18,7 +16,7 @@ contract VoteTabulationTest is GovernanceBase {
   uint256 internal yeaLimit;
 
   modifier whenMinimumGt0(Configuration memory _config) {
-    proposal.config.minimumVotes = bound(_config.minimumVotes, ConfigurationLib.VOTES_LOWER, type(uint256).max);
+    proposal.config.minimumVotes = bound(_config.minimumVotes, ConfigurationLib.VOTES_LOWER, type(uint96).max);
     _;
   }
 
@@ -28,13 +26,13 @@ contract VoteTabulationTest is GovernanceBase {
   {
     // it return (Rejected, TotalPowerLtMinimum)
     totalPower = bound(_totalPower, 0, proposal.config.minimumVotes - 1);
-    (VoteTabulationReturn vtr, VoteTabulationInfo vti) = proposal.voteTabulation(totalPower);
+    (VoteTabulationReturn vtr, VoteTabulationInfo vti) = upw.voteTabulation(proposal, totalPower);
     assertEq(vtr, VoteTabulationReturn.Rejected, "invalid return value");
     assertEq(vti, VoteTabulationInfo.TotalPowerLtMinimum, "invalid info value");
   }
 
   modifier whenTotalPowerGteMinimum(uint256 _totalPower) {
-    totalPower = bound(_totalPower, proposal.config.minimumVotes, type(uint256).max);
+    totalPower = bound(_totalPower, proposal.config.minimumVotes, type(uint96).max);
     _;
   }
 
@@ -49,7 +47,7 @@ contract VoteTabulationTest is GovernanceBase {
     whenQuorumConfigInvalid
   {
     // it return (Invalid, VotesNeededEqZero)
-    (VoteTabulationReturn vtr, VoteTabulationInfo vti) = proposal.voteTabulation(totalPower);
+    (VoteTabulationReturn vtr, VoteTabulationInfo vti) = upw.voteTabulation(proposal, totalPower);
     assertEq(vtr, VoteTabulationReturn.Invalid, "invalid return value");
     assertEq(vti, VoteTabulationInfo.VotesNeededEqZero, "invalid info value");
   }
@@ -65,11 +63,11 @@ contract VoteTabulationTest is GovernanceBase {
     proposal.config.quorum = 1e18 + 1;
 
     // Overwriting some limits such that we do not overflow
-    uint256 upperLimit = Math.mulDiv(type(uint256).max, 1e18, proposal.config.quorum);
+    uint256 upperLimit = Math.mulDiv(type(uint96).max, 1e18, proposal.config.quorum);
     proposal.config.minimumVotes = bound(_config.minimumVotes, ConfigurationLib.VOTES_LOWER, upperLimit);
     totalPower = bound(_totalPower, proposal.config.minimumVotes, upperLimit);
 
-    (VoteTabulationReturn vtr, VoteTabulationInfo vti) = proposal.voteTabulation(totalPower);
+    (VoteTabulationReturn vtr, VoteTabulationInfo vti) = upw.voteTabulation(proposal, totalPower);
     assertEq(vtr, VoteTabulationReturn.Invalid, "invalid return value");
     assertEq(vti, VoteTabulationInfo.VotesNeededGtTotalPower, "invalid info value");
   }
@@ -84,7 +82,7 @@ contract VoteTabulationTest is GovernanceBase {
     totalPower = type(uint256).max;
     proposal.config.quorum = 1e18 + 1;
     vm.expectRevert(abi.encodeWithSelector(0x4e487b71, Panic.UNDER_OVERFLOW));
-    this.callVoteTabulation(totalPower);
+    upw.voteTabulation(proposal, totalPower);
   }
 
   modifier whenQuorumConfigValid(Configuration memory _config) {
@@ -112,7 +110,7 @@ contract VoteTabulationTest is GovernanceBase {
     proposal.summedBallot.yea = yea;
     proposal.summedBallot.nay = nay;
 
-    (VoteTabulationReturn vtr, VoteTabulationInfo vti) = proposal.voteTabulation(totalPower);
+    (VoteTabulationReturn vtr, VoteTabulationInfo vti) = upw.voteTabulation(proposal, totalPower);
     assertEq(vtr, VoteTabulationReturn.Rejected, "invalid return value");
     assertEq(vti, VoteTabulationInfo.VotesCastLtVotesNeeded, "invalid info value");
   }
@@ -140,23 +138,6 @@ contract VoteTabulationTest is GovernanceBase {
     // which is already handled as `votesCast >= votesNeeded` and `votesNeeded > 0`.
   }
 
-  function test_WhenYeaLimitGtUint256Max(Configuration memory _config, uint256 _totalPower, uint256 _votes)
-    external
-    whenMinimumGt0(_config)
-    whenTotalPowerGteMinimum(_totalPower)
-    whenQuorumConfigValid(_config)
-    whenVotesCastGteVotesNeeded(_votes)
-    whenDifferentialConfigInvalid
-  {
-    // it revert
-    proposal.config.requiredYeaMargin = 1e18 + 1;
-    totalPower = type(uint256).max;
-    proposal.summedBallot.nay = totalPower;
-
-    vm.expectRevert(abi.encodeWithSelector(0x4e487b71, Panic.UNDER_OVERFLOW));
-    this.callVoteTabulation(totalPower);
-  }
-
   function test_WhenYeaLimitGtVotesCast(Configuration memory _config, uint256 _totalPower, uint256 _votes)
     external
     whenMinimumGt0(_config)
@@ -169,14 +150,14 @@ contract VoteTabulationTest is GovernanceBase {
     proposal.config.requiredYeaMargin = 1e18 + 1;
 
     // Overwriting some limits such that we do not overflow
-    uint256 upperLimit = Math.mulDiv(type(uint256).max, 1e18, proposal.config.requiredYeaMargin);
+    uint256 upperLimit = Math.mulDiv(type(uint96).max, 1e18, proposal.config.requiredYeaMargin);
     proposal.config.minimumVotes = bound(_config.minimumVotes, ConfigurationLib.VOTES_LOWER, upperLimit);
     totalPower = bound(_totalPower, proposal.config.minimumVotes, upperLimit);
     votesNeeded = Math.mulDiv(totalPower, proposal.config.quorum, 1e18, Math.Rounding.Ceil);
     votes = bound(_votes, votesNeeded, totalPower);
     proposal.summedBallot.nay = votes;
 
-    (VoteTabulationReturn vtr, VoteTabulationInfo vti) = proposal.voteTabulation(totalPower);
+    (VoteTabulationReturn vtr, VoteTabulationInfo vti) = upw.voteTabulation(proposal, totalPower);
     assertEq(vtr, VoteTabulationReturn.Invalid, "invalid return value");
     assertEq(vti, VoteTabulationInfo.YeaLimitGtVotesCast, "invalid info value");
   }
@@ -200,7 +181,7 @@ contract VoteTabulationTest is GovernanceBase {
     // it return (Accepted, YeaVotesEqVotesCast)
     proposal.summedBallot.yea = votes;
 
-    (VoteTabulationReturn vtr, VoteTabulationInfo vti) = proposal.voteTabulation(totalPower);
+    (VoteTabulationReturn vtr, VoteTabulationInfo vti) = upw.voteTabulation(proposal, totalPower);
     assertEq(vtr, VoteTabulationReturn.Accepted, "invalid return value");
     assertEq(vti, VoteTabulationInfo.YeaVotesEqVotesCast, "invalid info value");
   }
@@ -227,7 +208,7 @@ contract VoteTabulationTest is GovernanceBase {
     proposal.summedBallot.yea = yea;
     proposal.summedBallot.nay = nay;
 
-    (VoteTabulationReturn vtr, VoteTabulationInfo vti) = proposal.voteTabulation(totalPower);
+    (VoteTabulationReturn vtr, VoteTabulationInfo vti) = upw.voteTabulation(proposal, totalPower);
     assertEq(vtr, VoteTabulationReturn.Rejected, "invalid return value");
     assertEq(vti, VoteTabulationInfo.YeaVotesLeYeaLimit, "invalid info value");
   }
@@ -257,14 +238,8 @@ contract VoteTabulationTest is GovernanceBase {
 
     assertGt(yea, nay, "yea <= nay");
 
-    (VoteTabulationReturn vtr, VoteTabulationInfo vti) = proposal.voteTabulation(totalPower);
+    (VoteTabulationReturn vtr, VoteTabulationInfo vti) = upw.voteTabulation(proposal, totalPower);
     assertEq(vtr, VoteTabulationReturn.Accepted, "invalid return value");
     assertEq(vti, VoteTabulationInfo.YeaVotesGtYeaLimit, "invalid info value");
-  }
-
-  // @dev helper for testing, to avoid:
-  // "call didn't revert at a lower depth than cheatcode call depth"
-  function callVoteTabulation(uint256 _totalPower) external view {
-    proposal.voteTabulation(_totalPower);
   }
 }

--- a/l1-contracts/test/governance/governance/proposallib/voteTabulation.tree
+++ b/l1-contracts/test/governance/governance/proposallib/voteTabulation.tree
@@ -19,8 +19,6 @@ VoteTabulationTest
                 ├── when differential config invalid
                 │   ├── when yea limit eq 0
                 │   │   └── it return (Invalid, YeaLimitEqZero)
-                │   ├── when yea limit gt uint256 max
-                │   │   └── it revert
                 │   └── when yea limit gt votes cast
                 │       └── it return (Invalid, YeaLimitGtVotesCast)
                 └── when differential config valid

--- a/l1-contracts/test/governance/governance/scenarios/lockAndPass.t.sol
+++ b/l1-contracts/test/governance/governance/scenarios/lockAndPass.t.sol
@@ -8,11 +8,8 @@ import {IGovernance, Proposal, ProposalState, Configuration} from "@aztec/govern
 import {Timestamp} from "@aztec/core/libraries/TimeLib.sol";
 import {Errors} from "@aztec/governance/libraries/Errors.sol";
 import {UpgradePayload, FakeRollup} from "../TestPayloads.sol";
-import {ProposalLib} from "@aztec/governance/libraries/ProposalLib.sol";
 
 contract LockAndPassTest is GovernanceBase {
-  using ProposalLib for Proposal;
-
   function setUp() public override {
     super.setUp();
 
@@ -43,16 +40,16 @@ contract LockAndPassTest is GovernanceBase {
     token.approve(address(governance), config.minimumVotes);
     governance.deposit(address(this), config.minimumVotes);
 
-    vm.warp(Timestamp.unwrap(proposal.pendingThrough()) + 1);
+    vm.warp(Timestamp.unwrap(upw.pendingThrough(proposal)) + 1);
     assertEq(governance.getProposalState(proposalId), ProposalState.Active);
 
     vm.prank(address(this));
     governance.vote(proposalId, config.minimumVotes, true);
 
-    vm.warp(Timestamp.unwrap(proposal.activeThrough()) + 1);
+    vm.warp(Timestamp.unwrap(upw.activeThrough(proposal)) + 1);
     assertEq(governance.getProposalState(proposalId), ProposalState.Queued);
 
-    vm.warp(Timestamp.unwrap(proposal.queuedThrough()) + 1);
+    vm.warp(Timestamp.unwrap(upw.queuedThrough(proposal)) + 1);
     assertEq(governance.getProposalState(proposalId), ProposalState.Executable);
 
     assertNotEq(address(registry.getCanonicalRollup()), address(payload.NEW_ROLLUP()));

--- a/l1-contracts/test/governance/governance/scenarios/noVoteAndExit.t.sol
+++ b/l1-contracts/test/governance/governance/scenarios/noVoteAndExit.t.sol
@@ -6,10 +6,8 @@ import {Proposal, ProposalState, Withdrawal} from "@aztec/governance/interfaces/
 import {Errors} from "@aztec/governance/libraries/Errors.sol";
 import {Math} from "@oz/utils/math/Math.sol";
 import {Timestamp} from "@aztec/core/libraries/TimeLib.sol";
-import {ProposalLib} from "@aztec/governance/libraries/ProposalLib.sol";
 
 contract NoVoteAndExitTest is GovernanceBase {
-  using ProposalLib for Proposal;
   // Ensure that it is not possible to BOTH vote on proposal AND withdraw the funds before
   // it can be executed
 
@@ -36,7 +34,7 @@ contract NoVoteAndExitTest is GovernanceBase {
     vm.stopPrank();
 
     // Jump up to the point where the proposal becomes active
-    vm.warp(Timestamp.unwrap(proposal.pendingThrough()) + 1);
+    vm.warp(Timestamp.unwrap(upw.pendingThrough(proposal)) + 1);
 
     assertEq(governance.getProposalState(proposalId), ProposalState.Active);
 
@@ -49,10 +47,10 @@ contract NoVoteAndExitTest is GovernanceBase {
     uint256 withdrawalId = governance.initiateWithdraw(_voter, totalPower);
 
     // Jump to the block just before we become executable.
-    vm.warp(Timestamp.unwrap(proposal.queuedThrough()));
+    vm.warp(Timestamp.unwrap(upw.queuedThrough(proposal)));
     assertEq(governance.getProposalState(proposalId), ProposalState.Queued);
 
-    vm.warp(Timestamp.unwrap(proposal.queuedThrough()) + 1);
+    vm.warp(Timestamp.unwrap(upw.queuedThrough(proposal)) + 1);
     assertEq(governance.getProposalState(proposalId), ProposalState.Executable);
 
     Withdrawal memory withdrawal = governance.getWithdrawal(withdrawalId);

--- a/l1-contracts/test/governance/governance/updateConfiguration.t.sol
+++ b/l1-contracts/test/governance/governance/updateConfiguration.t.sol
@@ -178,9 +178,11 @@ contract UpdateConfigurationTest is GovernanceBase {
     assertEq(config.votingDelay, fresh.votingDelay);
     assertEq(config.votingDuration, fresh.votingDuration);
 
-    assertEq(config.withdrawalDelay(), fresh.withdrawalDelay());
+    Configuration memory memConfig = config;
+    Configuration memory memFresh = fresh;
+    assertEq(upw.getWithdrawalDelay(memConfig), upw.getWithdrawalDelay(memFresh));
     assertEq(
-      config.withdrawalDelay(),
+      upw.getWithdrawalDelay(memConfig),
       Timestamp.wrap(Timestamp.unwrap(fresh.votingDelay) / 5) + fresh.votingDuration + fresh.executionDelay
     );
     assertEq(config.proposeConfig.lockAmount, fresh.proposeConfig.lockAmount);
@@ -220,7 +222,7 @@ contract UpdateConfigurationTest is GovernanceBase {
     // it updates the configuration
     // it emits {ConfigurationUpdated} event
 
-    uint256 val = bound(_val, ConfigurationLib.VOTES_LOWER, type(uint256).max);
+    uint256 val = bound(_val, ConfigurationLib.VOTES_LOWER, ConfigurationLib.VOTES_UPPER);
 
     vm.assume(val != config.minimumVotes);
     config.minimumVotes = val;
@@ -230,7 +232,7 @@ contract UpdateConfigurationTest is GovernanceBase {
     // it updates the configuration
     // it emits {ConfigurationUpdated} event
 
-    uint256 val = bound(_val, ConfigurationLib.LOCK_AMOUNT_LOWER, type(uint256).max);
+    uint256 val = bound(_val, ConfigurationLib.LOCK_AMOUNT_LOWER, ConfigurationLib.LOCK_AMOUNT_UPPER);
 
     vm.assume(val != config.proposeConfig.lockAmount);
     config.proposeConfig.lockAmount = val;

--- a/l1-contracts/test/governance/gse/gse/vote.t.sol
+++ b/l1-contracts/test/governance/gse/gse/vote.t.sol
@@ -6,9 +6,12 @@ import {IPayload, Proposal} from "@aztec/governance/interfaces/IGovernance.sol";
 import {ProposalLib} from "@aztec/governance/libraries/ProposalLib.sol";
 import {Timestamp} from "@aztec/shared/libraries/TimeMath.sol";
 import {Errors} from "@aztec/governance/libraries/Errors.sol";
+import {UncompressedProposalWrapper} from "@test/governance/helpers/UncompressedProposalTestLib.sol";
 
 contract VoteTest is WithGSE {
   using ProposalLib for Proposal;
+
+  UncompressedProposalWrapper internal upw = new UncompressedProposalWrapper();
 
   function setUp() public override {
     super.setUp();
@@ -87,11 +90,11 @@ contract VoteTest is WithGSE {
     }
 
     Proposal memory proposal = governance.getProposal(0);
-    vm.warp(Timestamp.unwrap(proposal.pendingThroughMemory()) + 1);
+    vm.warp(Timestamp.unwrap(upw.pendingThrough(proposal)) + 1);
 
     address voter = _delegate ? _delegatee : _attester;
 
-    uint256 availablePower = gse.getVotingPowerAt(voter, proposal.pendingThroughMemory());
+    uint256 availablePower = gse.getVotingPowerAt(voter, upw.pendingThrough(proposal));
 
     return (voter, availablePower);
   }

--- a/l1-contracts/test/governance/gse/gse/voteWithBonus.t.sol
+++ b/l1-contracts/test/governance/gse/gse/voteWithBonus.t.sol
@@ -6,9 +6,12 @@ import {IPayload, Proposal} from "@aztec/governance/interfaces/IGovernance.sol";
 import {ProposalLib} from "@aztec/governance/libraries/ProposalLib.sol";
 import {Timestamp} from "@aztec/shared/libraries/TimeMath.sol";
 import {Errors} from "@aztec/governance/libraries/Errors.sol";
+import {UncompressedProposalWrapper} from "@test/governance/helpers/UncompressedProposalTestLib.sol";
 
 contract VoteWithBonusTest is WithGSE {
   using ProposalLib for Proposal;
+
+  UncompressedProposalWrapper internal upw = new UncompressedProposalWrapper();
 
   address internal BONUS_ADDRESS;
 
@@ -88,9 +91,9 @@ contract VoteWithBonusTest is WithGSE {
     cheat_deposit(_instance, _attester, _attester, true);
 
     Proposal memory proposal = governance.getProposal(0);
-    vm.warp(Timestamp.unwrap(proposal.pendingThroughMemory()) + 1);
+    vm.warp(Timestamp.unwrap(upw.pendingThrough(proposal)) + 1);
 
-    uint256 availablePower = gse.getVotingPowerAt(BONUS_ADDRESS, proposal.pendingThroughMemory());
+    uint256 availablePower = gse.getVotingPowerAt(BONUS_ADDRESS, upw.pendingThrough(proposal));
 
     return availablePower;
   }

--- a/l1-contracts/test/governance/helpers/TestGov.sol
+++ b/l1-contracts/test/governance/helpers/TestGov.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.27;
+
+import {Governance} from "@aztec/governance/Governance.sol";
+import {IERC20} from "@oz/token/ERC20/IERC20.sol";
+import {Configuration} from "@aztec/governance/interfaces/IGovernance.sol";
+
+contract TestGov is Governance {
+  constructor(IERC20 _asset, address _governanceProposer, address _beneficiary, Configuration memory _configuration)
+    Governance(_asset, _governanceProposer, _beneficiary, _configuration)
+  {}
+
+  function test__overrideQuorum(uint256 _id, uint64 _quorum) external {
+    proposals[_id].quorum = _quorum;
+  }
+}

--- a/l1-contracts/test/governance/helpers/UncompressedProposalTestLib.sol
+++ b/l1-contracts/test/governance/helpers/UncompressedProposalTestLib.sol
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024 Aztec Labs.
+pragma solidity >=0.8.27;
+
+import {Proposal} from "@aztec/governance/interfaces/IGovernance.sol";
+import {CompressedProposal, CompressedProposalLib} from "@aztec/governance/libraries/compressed-data/Proposal.sol";
+import {ProposalLib, VoteTabulationReturn, VoteTabulationInfo} from "@aztec/governance/libraries/ProposalLib.sol";
+import {Timestamp} from "@aztec/shared/libraries/TimeMath.sol";
+import {Math} from "@oz/utils/math/Math.sol";
+import {
+  Configuration,
+  CompressedConfiguration,
+  CompressedConfigurationLib
+} from "@aztec/governance/libraries/compressed-data/Configuration.sol";
+import {ConfigurationLib} from "@aztec/governance/libraries/ConfigurationLib.sol";
+
+contract UncompressedProposalWrapper {
+  using CompressedProposalLib for CompressedProposal;
+  using CompressedProposalLib for Proposal;
+  using ProposalLib for CompressedProposal;
+  using CompressedConfigurationLib for CompressedConfiguration;
+  using CompressedConfigurationLib for Configuration;
+  using ConfigurationLib for Configuration;
+  using ConfigurationLib for CompressedConfiguration;
+
+  CompressedProposal internal cp;
+  CompressedConfiguration internal cc;
+
+  function voteTabulation(Proposal memory _self, uint256 _totalPower)
+    external
+    returns (VoteTabulationReturn, VoteTabulationInfo)
+  {
+    cp = CompressedProposalLib.compress(_self);
+    return cp.voteTabulation(_totalPower);
+  }
+
+  function pendingThrough(Proposal memory _self) external returns (Timestamp) {
+    cp = CompressedProposalLib.compress(_self);
+    return cp.pendingThrough();
+  }
+
+  function activeThrough(Proposal memory _self) external returns (Timestamp) {
+    cp = CompressedProposalLib.compress(_self);
+    return cp.activeThrough();
+  }
+
+  function queuedThrough(Proposal memory _self) external returns (Timestamp) {
+    cp = CompressedProposalLib.compress(_self);
+    return cp.queuedThrough();
+  }
+
+  function executableThrough(Proposal memory _self) external returns (Timestamp) {
+    cp = CompressedProposalLib.compress(_self);
+    return cp.executableThrough();
+  }
+
+  function getWithdrawalDelay(Configuration memory _self) external returns (Timestamp) {
+    cc = CompressedConfigurationLib.compress(_self);
+    return cc.getWithdrawalDelay();
+  }
+}

--- a/l1-contracts/test/governance/scenario/AddRollup.t.sol
+++ b/l1-contracts/test/governance/scenario/AddRollup.t.sol
@@ -29,6 +29,7 @@ import {RegisterNewRollupVersionPayload} from "./RegisterNewRollupVersionPayload
 import {IInstance} from "@aztec/core/interfaces/IInstance.sol";
 import {StakingQueueConfig} from "@aztec/core/libraries/compressed-data/StakingQueueConfig.sol";
 import {BN254Lib, G1Point, G2Point} from "@aztec/shared/libraries/BN254Lib.sol";
+import {UncompressedProposalWrapper} from "@test/governance/helpers/UncompressedProposalTestLib.sol";
 
 contract BadRollup {
   IGSE public immutable gse;
@@ -47,7 +48,7 @@ contract BadRollup {
 }
 
 contract AddRollupTest is TestBase {
-  using ProposalLib for Proposal;
+  UncompressedProposalWrapper internal upw = new UncompressedProposalWrapper();
 
   TestERC20 internal token;
   Registry internal registry;
@@ -136,16 +137,16 @@ contract AddRollupTest is TestBase {
     governance.deposit(EMPEROR, 10_000 ether);
     vm.stopPrank();
 
-    vm.warp(Timestamp.unwrap(proposal.pendingThrough()) + 1);
+    vm.warp(Timestamp.unwrap(upw.pendingThrough(proposal)) + 1);
     assertTrue(governance.getProposalState(0) == ProposalState.Active);
 
     vm.prank(EMPEROR);
     governance.vote(0, 10_000 ether, true);
 
-    vm.warp(Timestamp.unwrap(proposal.activeThrough()) + 1);
+    vm.warp(Timestamp.unwrap(upw.activeThrough(proposal)) + 1);
     assertTrue(governance.getProposalState(0) == ProposalState.Queued);
 
-    vm.warp(Timestamp.unwrap(proposal.queuedThrough()) + 1);
+    vm.warp(Timestamp.unwrap(upw.queuedThrough(proposal)) + 1);
     assertTrue(governance.getProposalState(0) == ProposalState.Executable);
     assertEq(governance.governanceProposer(), address(governanceProposer));
 

--- a/l1-contracts/test/governance/scenario/UpgradeGovernanceProposerTest.t.sol
+++ b/l1-contracts/test/governance/scenario/UpgradeGovernanceProposerTest.t.sol
@@ -25,6 +25,7 @@ import {IGSE} from "@aztec/governance/GSE.sol";
 import {GSEPayload} from "@aztec/governance/GSEPayload.sol";
 import {TimeCheater} from "../../staking/TimeCheater.sol";
 import {BN254Lib, G1Point, G2Point} from "@aztec/shared/libraries/BN254Lib.sol";
+import {UncompressedProposalWrapper} from "@test/governance/helpers/UncompressedProposalTestLib.sol";
 
 /**
  * @title UpgradeGovernanceProposerTest
@@ -32,7 +33,7 @@ import {BN254Lib, G1Point, G2Point} from "@aztec/shared/libraries/BN254Lib.sol";
  * @notice A test that showcases an upgrade of the governance system, here the governanceProposer contract.
  */
 contract UpgradeGovernanceProposerTest is TestBase {
-  using ProposalLib for Proposal;
+  UncompressedProposalWrapper internal upw = new UncompressedProposalWrapper();
 
   TestERC20 internal token;
   Registry internal registry;
@@ -120,16 +121,16 @@ contract UpgradeGovernanceProposerTest is TestBase {
     governance.deposit(EMPEROR, 10_000 ether);
     vm.stopPrank();
 
-    vm.warp(Timestamp.unwrap(proposal.pendingThrough()) + 1);
+    vm.warp(Timestamp.unwrap(upw.pendingThrough(proposal)) + 1);
     assertTrue(governance.getProposalState(0) == ProposalState.Active);
 
     vm.prank(EMPEROR);
     governance.vote(0, 10_000 ether, true);
 
-    vm.warp(Timestamp.unwrap(proposal.activeThrough()) + 1);
+    vm.warp(Timestamp.unwrap(upw.activeThrough(proposal)) + 1);
     assertTrue(governance.getProposalState(0) == ProposalState.Queued);
 
-    vm.warp(Timestamp.unwrap(proposal.queuedThrough()) + 1);
+    vm.warp(Timestamp.unwrap(upw.queuedThrough(proposal)) + 1);
     assertTrue(governance.getProposalState(0) == ProposalState.Executable);
     assertEq(governance.governanceProposer(), address(governanceProposer));
 


### PR DESCRIPTION
Spearbit suggested altering the `configuration` storage to use a map and just have an id in the proposal. However, we can heavily compress the values of the configuration that needs to actually go into the proposal. So I believe a better option is to do that (we can get it down to 2 slots), as we then reduced the number of reads on more important functions such as `vote` with only a minor added cost over the id for the proposal itself.

- Ballots can be stored in a single `uint256` as they will never meaningfully be size > `uint128`.
- All the timings in the configuration can be compressed to `uint32` (the `CompressedTimestamp` that we already have). 
- Altering the ordering in the `Proposal` allow us to more tightly pack it for storage. 

It is a bit more tricky to update some of the storage in tests, but we can utilise a testonly wrapper that allow direct manipulation to address that.

```solidity
struct CompressedConfiguration {
  // Slot 1: Timing and percentages - 32*4 + 64*2 = 256 bits
  CompressedTimestamp votingDelay;
  CompressedTimestamp votingDuration;
  CompressedTimestamp executionDelay;
  CompressedTimestamp gracePeriod;
  uint64 quorum;
  uint64 requiredYeaMargin;
  // Slot 2: Amounts and proposeConfig - 96 + 96 + 32 = 224 bits (32 bits unused)
  uint96 minimumVotes;
  uint96 lockAmount;
  CompressedTimestamp lockDelay;
}

struct CompressedProposal {
  // Slot 1: Core Identity (256 bits)
  address proposer; // 160 bits
  uint96 minimumVotes; // 96 bits - from config
  // Slot 2: Timing (232 bits used, 24 bits padding)
  ProposalState cachedState; // 8 bits
  CompressedTimestamp creation; // 32 bits
  CompressedTimestamp votingDelay; // 32 bits - from config
  CompressedTimestamp votingDuration; // 32 bits - from config
  CompressedTimestamp executionDelay; // 32 bits - from config
  CompressedTimestamp gracePeriod; // 32 bits - from config
  uint64 quorum; // 64 bits - from config
  // Slot 3: Votes (256 bits)
  CompressedBallot summedBallot; // 256 bits (128 yea + 128 nay)
  // Slot 4: References (224 bits used, 32 bits padding)
  IPayload payload; // 160 bits
  uint64 requiredYeaMargin; // 64 bits - from config
}
```