### PR TITLE
chore: Reduce gas cost for tally slash proposer

### DIFF
--- a/l1-contracts/src/core/RollupCore.sol
+++ b/l1-contracts/src/core/RollupCore.sol
@@ -238,7 +238,7 @@ contract RollupCore is EIP712("Aztec Rollup", "1"), Ownable, IStakingCore, IVali
     // We call one external library or another based on the slasher flavor
     // This allows us to keep the slash flavors in separate external libraries so we do not exceed max contract size
     // Note that we do not deploy a slasher if we run with no committees (i.e. targetCommitteeSize == 0)
-    if (_config.targetCommitteeSize == 0) {
+    if (_config.targetCommitteeSize == 0 || _config.slasherFlavor == SlasherFlavor.NONE) {
       slasher = ISlasher(address(0));
     } else if (_config.slasherFlavor == SlasherFlavor.TALLY) {
       slasher = TallySlasherDeploymentExtLib.deployTallySlasher(

--- a/l1-contracts/src/core/interfaces/ISlasher.sol
+++ b/l1-contracts/src/core/interfaces/ISlasher.sol
@@ -5,8 +5,9 @@ pragma solidity >=0.8.27;
 import {IPayload} from "@aztec/governance/interfaces/IPayload.sol";
 
 enum SlasherFlavor {
-  EMPIRE,
-  TALLY
+  NONE,
+  TALLY,
+  EMPIRE
 }
 
 interface ISlasher {

--- a/l1-contracts/src/core/libraries/Errors.sol
+++ b/l1-contracts/src/core/libraries/Errors.sol
@@ -197,4 +197,8 @@ library Errors {
   error TallySlashingProposer__VotingNotOpen(SlashRound currentRound);
   error TallySlashingProposer__SlashOffsetMustBeGreaterThanZero(uint256 slashOffset);
   error TallySlashingProposer__InvalidEpochIndex(uint256 epochIndex, uint256 roundSizeInEpochs);
+  error TallySlashingProposer__VoteSizeTooBig(uint256 voteSize, uint256 maxSize);
+
+  // SlashPayloadLib
+  error SlashPayload_ArraySizeMismatch(uint256 expected, uint256 actual);
 }

--- a/l1-contracts/src/core/libraries/SlashPayloadLib.sol
+++ b/l1-contracts/src/core/libraries/SlashPayloadLib.sol
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024 Aztec Labs.
+pragma solidity >=0.8.27;
+
+import {Errors} from "./Errors.sol";
+
+/**
+ * @title SlashPayloadLib
+ * @author Aztec Labs
+ * @notice Library for encoding immutable arguments for SlashPayloadCloneable contracts
+ * @dev Provides utilities for encoding validator addresses and amounts into a format
+ *      suitable for use with EIP-1167 minimal proxy clones with immutable arguments
+ */
+library SlashPayloadLib {
+  /**
+   * @notice Encode immutable arguments for SlashPayloadCloneable clones
+   * @dev Encodes data in the format expected by SlashPayloadCloneable._getImmutableArgs()
+   *      Layout: [validatorSelection(20 bytes)][arrayLength(32 bytes)][validators+amounts array data]
+   *      Each validator entry: [address(20 bytes)][amount(12 bytes for uint96)]
+   * @param _validatorSelection Address of the validator selection contract
+   * @param _validators Array of validator addresses to slash
+   * @param _amounts Array of amounts to slash for each validator (uint96 values)
+   * @return Encoded arguments for use with cloneDeterministicWithImmutableArgs
+   */
+  function encodeImmutableArgs(address _validatorSelection, address[] memory _validators, uint96[] memory _amounts)
+    internal
+    pure
+    returns (bytes memory)
+  {
+    require(
+      _validators.length == _amounts.length, Errors.SlashPayload_ArraySizeMismatch(_validators.length, _amounts.length)
+    );
+
+    // Calculate total size: 20 bytes (address) + 32 bytes (length) + (20 + 12) * length
+    uint256 dataSize = 52 + 32 * _validators.length;
+    bytes memory data = new bytes(dataSize);
+
+    assembly {
+      let ptr := add(data, 0x20)
+
+      // Store validator selection address (20 bytes)
+      // Shift left by 96 bits (12 bytes) to align to the left of the 32-byte slot
+      mstore(ptr, shl(96, _validatorSelection))
+      ptr := add(ptr, 0x14) // Move 20 bytes forward
+
+      // Store array length (32 bytes)
+      mstore(ptr, mload(_validators))
+      ptr := add(ptr, 0x20) // Move 32 bytes forward
+
+      // Store validators and amounts
+      let len := mload(_validators)
+      let validatorsPtr := add(_validators, 0x20)
+      let amountsPtr := add(_amounts, 0x20)
+
+      for { let i := 0 } lt(i, len) { i := add(i, 1) } {
+        // Store validator address (20 bytes)
+        // Shift left by 96 bits to align to the left of the 32-byte slot
+        mstore(ptr, shl(96, mload(add(validatorsPtr, mul(i, 0x20)))))
+        ptr := add(ptr, 0x14) // Move 20 bytes forward
+
+        // Store amount (12 bytes for uint96)
+        // Shift left by 160 bits (20 bytes) to align to the left of the remaining space
+        mstore(ptr, shl(160, mload(add(amountsPtr, mul(i, 0x20)))))
+        ptr := add(ptr, 0x0c) // Move 12 bytes forward
+      }
+    }
+
+    return data;
+  }
+}

--- a/l1-contracts/src/periphery/SlashPayloadCloneable.sol
+++ b/l1-contracts/src/periphery/SlashPayloadCloneable.sol
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024 Aztec Labs.
+pragma solidity >=0.8.27;
+
+import {IStakingCore} from "@aztec/core/interfaces/IStaking.sol";
+import {IPayload} from "@aztec/governance/interfaces/IPayload.sol";
+import {Clones} from "@openzeppelin/contracts/proxy/Clones.sol";
+
+/**
+ * @notice Cloneable SlashPayload implementation that fetches arguments from immutable storage
+ * @dev This contract is deployed once as an implementation and then cloned for each slash payload
+ * Using EIP-1167 minimal proxy pattern with immutable arguments to save gas on deployment
+ * @dev This contract can be further optimized by NOT storing the actions as immutables, and instead
+ * store them in transient storage in the main contract, and just storing the round number here. Then,
+ * when actions are requested, we just call back into the proposer and return them. Note that we cannot
+ * just compute them on the fly on the proposer, since we need the committees to be provided as calldata.
+ */
+contract SlashPayloadCloneable is IPayload {
+  using Clones for address;
+
+  /**
+   * @notice Get the actions to execute for this slash payload
+   * @return actions Array of actions to slash validators
+   */
+  function getActions() external view override(IPayload) returns (IPayload.Action[] memory actions) {
+    (address validatorSelection, address[] memory validators, uint96[] memory amounts) = _getImmutableArgs();
+
+    actions = new IPayload.Action[](validators.length);
+
+    for (uint256 i = 0; i < validators.length; i++) {
+      actions[i] = IPayload.Action({
+        target: validatorSelection,
+        data: abi.encodeWithSelector(IStakingCore.slash.selector, validators[i], amounts[i])
+      });
+    }
+  }
+
+  /**
+   * @notice Get the URI for this payload
+   * @return The URI string
+   */
+  function getURI() external pure override(IPayload) returns (string memory) {
+    return "SlashPayload";
+  }
+
+  /**
+   * @notice Decode the immutable arguments stored in the clone's bytecode
+   * @return validatorSelection The address of the validator selection contract
+   * @return validators Array of validator addresses to slash
+   * @return amounts Array of amounts to slash for each validator
+   */
+  function _getImmutableArgs()
+    private
+    view
+    returns (address validatorSelection, address[] memory validators, uint96[] memory amounts)
+  {
+    // Fetch immutable args from clone's bytecode
+    bytes memory args = Clones.fetchCloneArgs(address(this));
+
+    // Decode the arguments
+    // Layout: [validatorSelection(20 bytes)][arrayLength(32 bytes)][validators+amounts array data]
+    assembly {
+      // Read validator selection address (first 20 bytes)
+      validatorSelection := shr(96, mload(add(args, 0x20)))
+
+      // Read array length (next 32 bytes after the address)
+      let arrayLen := mload(add(args, 0x34))
+
+      // Allocate memory for validators array
+      validators := mload(0x40)
+      mstore(validators, arrayLen)
+      let validatorsData := add(validators, 0x20)
+
+      // Allocate memory for amounts array
+      amounts := add(validatorsData, mul(arrayLen, 0x20))
+      mstore(amounts, arrayLen)
+      let amountsData := add(amounts, 0x20)
+
+      // Update free memory pointer
+      mstore(0x40, add(amountsData, mul(arrayLen, 0x20)))
+
+      // Copy validator addresses and amounts
+      let srcPtr := add(args, 0x54) // Start after validatorSelection + arrayLength
+
+      for { let i := 0 } lt(i, arrayLen) { i := add(i, 1) } {
+        // Read validator address (20 bytes)
+        let validator := shr(96, mload(srcPtr))
+        mstore(add(validatorsData, mul(i, 0x20)), validator)
+        srcPtr := add(srcPtr, 0x14)
+
+        // Read amount (12 bytes for uint96)
+        let amount := shr(160, mload(srcPtr))
+        mstore(add(amountsData, mul(i, 0x20)), amount)
+        srcPtr := add(srcPtr, 0x0c)
+      }
+    }
+  }
+}

--- a/l1-contracts/test/SlashPayloadCloneable.t.sol
+++ b/l1-contracts/test/SlashPayloadCloneable.t.sol
@@ -1,0 +1,319 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024 Aztec Labs.
+pragma solidity >=0.8.27;
+
+import {Test} from "forge-std/Test.sol";
+import {SlashPayloadCloneable} from "@aztec/periphery/SlashPayloadCloneable.sol";
+import {SlashPayloadLib} from "@aztec/core/libraries/SlashPayloadLib.sol";
+import {IStakingCore} from "@aztec/core/interfaces/IStaking.sol";
+import {IPayload} from "@aztec/governance/interfaces/IPayload.sol";
+import {Clones} from "@openzeppelin/contracts/proxy/Clones.sol";
+import {Errors} from "@aztec/core/libraries/Errors.sol";
+
+/**
+ * @title SlashPayloadCloneableTest
+ * @author Aztec Labs
+ * @notice Test suite for SlashPayloadCloneable contract to verify proper encoding/decoding
+ *         of immutable arguments and correct execution of slash actions
+ */
+contract SlashPayloadCloneableTest is Test {
+  using Clones for address;
+
+  SlashPayloadCloneable private implementation;
+  address private mockValidatorSelection;
+
+  // Test data
+  address[] private testValidators;
+  uint96[] private testAmounts;
+
+  event SlashCalled(address indexed validator, uint96 amount);
+
+  /**
+   * @notice Helper function to decode slash call data
+   * @param callData The encoded call data
+   * @return selector The function selector
+   * @return validator The validator address
+   * @return amount The slash amount
+   */
+  function decodeSlashCallData(bytes memory callData)
+    internal
+    pure
+    returns (bytes4 selector, address validator, uint96 amount)
+  {
+    // Extract selector
+    assembly {
+      selector := mload(add(callData, 0x20))
+    }
+
+    // Skip the selector (4 bytes) and decode the parameters
+    bytes memory params = new bytes(callData.length - 4);
+    for (uint256 i = 0; i < params.length; i++) {
+      params[i] = callData[i + 4];
+    }
+    (validator, amount) = abi.decode(params, (address, uint96));
+  }
+
+  function setUp() public {
+    // Deploy the implementation contract
+    implementation = new SlashPayloadCloneable();
+
+    // Create a mock validator selection contract
+    mockValidatorSelection = makeAddr("mockValidatorSelection");
+    vm.etch(mockValidatorSelection, type(MockValidatorSelection).creationCode);
+
+    // Set up test data
+    testValidators = new address[](3);
+    testValidators[0] = makeAddr("validator1");
+    testValidators[1] = makeAddr("validator2");
+    testValidators[2] = makeAddr("validator3");
+
+    testAmounts = new uint96[](3);
+    testAmounts[0] = 100e18; // 100 tokens
+    testAmounts[1] = 250e18; // 250 tokens
+    testAmounts[2] = 75e18; // 75 tokens
+  }
+
+  /**
+   * @notice Test basic encoding and decoding with a single validator
+   */
+  function test_SingleValidatorEncodingDecoding() public {
+    // Create arrays with single validator
+    address[] memory validators = new address[](1);
+    validators[0] = testValidators[0];
+    uint96[] memory amounts = new uint96[](1);
+    amounts[0] = testAmounts[0];
+
+    // Encode arguments
+    bytes memory immutableArgs = SlashPayloadLib.encodeImmutableArgs(mockValidatorSelection, validators, amounts);
+
+    // Deploy clone
+    bytes32 salt = keccak256("test_single");
+    address clone = Clones.cloneDeterministicWithImmutableArgs(address(implementation), immutableArgs, salt);
+
+    // Get actions and verify
+    IPayload.Action[] memory actions = SlashPayloadCloneable(clone).getActions();
+
+    assertEq(actions.length, 1, "Should have 1 action");
+    assertEq(actions[0].target, mockValidatorSelection, "Target should be validator selection");
+
+    // Decode the call data to verify validator and amount
+    (bytes4 selector, address validator, uint96 amount) = decodeSlashCallData(actions[0].data);
+    assertEq(selector, IStakingCore.slash.selector, "Should be slash selector");
+    assertEq(validator, validators[0], "Validator should match");
+    assertEq(amount, amounts[0], "Amount should match");
+  }
+
+  /**
+   * @notice Test encoding and decoding with multiple validators
+   */
+  function test_MultipleValidatorsEncodingDecoding() public {
+    // Encode arguments with all test validators
+    bytes memory immutableArgs =
+      SlashPayloadLib.encodeImmutableArgs(mockValidatorSelection, testValidators, testAmounts);
+
+    // Deploy clone
+    bytes32 salt = keccak256("test_multiple");
+    address clone = Clones.cloneDeterministicWithImmutableArgs(address(implementation), immutableArgs, salt);
+
+    // Get actions and verify
+    IPayload.Action[] memory actions = SlashPayloadCloneable(clone).getActions();
+
+    assertEq(actions.length, testValidators.length, "Should have matching number of actions");
+
+    // Verify each action
+    for (uint256 i = 0; i < testValidators.length; i++) {
+      assertEq(actions[i].target, mockValidatorSelection, "Target should be validator selection");
+
+      (bytes4 selector, address validator, uint96 amount) = decodeSlashCallData(actions[i].data);
+      assertEq(selector, IStakingCore.slash.selector, "Should be slash selector");
+      assertEq(validator, testValidators[i], string.concat("Validator should match at index ", vm.toString(i)));
+      assertEq(amount, testAmounts[i], string.concat("Amount should match at index ", vm.toString(i)));
+    }
+  }
+
+  /**
+   * @notice Test that getURI returns expected value
+   */
+  function test_GetURI() public {
+    // Deploy any clone to test URI
+    bytes memory immutableArgs =
+      SlashPayloadLib.encodeImmutableArgs(mockValidatorSelection, testValidators, testAmounts);
+
+    address clone =
+      Clones.cloneDeterministicWithImmutableArgs(address(implementation), immutableArgs, keccak256("test_uri"));
+
+    string memory uri = SlashPayloadCloneable(clone).getURI();
+    assertEq(uri, "SlashPayload", "URI should be 'SlashPayload'");
+  }
+
+  /**
+   * @notice Test with edge case: empty validators array
+   */
+  function test_EmptyValidatorsArray() public {
+    address[] memory emptyValidators = new address[](0);
+    uint96[] memory emptyAmounts = new uint96[](0);
+
+    bytes memory immutableArgs =
+      SlashPayloadLib.encodeImmutableArgs(mockValidatorSelection, emptyValidators, emptyAmounts);
+
+    address clone =
+      Clones.cloneDeterministicWithImmutableArgs(address(implementation), immutableArgs, keccak256("test_empty"));
+
+    IPayload.Action[] memory actions = SlashPayloadCloneable(clone).getActions();
+    assertEq(actions.length, 0, "Should have no actions for empty arrays");
+  }
+
+  /**
+   * @notice Test with large amounts (near uint96 max)
+   */
+  function test_LargeAmounts() public {
+    address[] memory validators = new address[](2);
+    validators[0] = makeAddr("validator_large1");
+    validators[1] = makeAddr("validator_large2");
+
+    uint96[] memory amounts = new uint96[](2);
+    amounts[0] = type(uint96).max - 1; // Near max uint96
+    amounts[1] = type(uint96).max; // Max uint96
+
+    bytes memory immutableArgs = SlashPayloadLib.encodeImmutableArgs(mockValidatorSelection, validators, amounts);
+
+    address clone =
+      Clones.cloneDeterministicWithImmutableArgs(address(implementation), immutableArgs, keccak256("test_large"));
+
+    IPayload.Action[] memory actions = SlashPayloadCloneable(clone).getActions();
+
+    // Verify large amounts are preserved correctly
+    for (uint256 i = 0; i < 2; i++) {
+      (, address validator, uint96 amount) = decodeSlashCallData(actions[i].data);
+      assertEq(validator, validators[i], "Large amount validator should match");
+      assertEq(amount, amounts[i], "Large amount should be preserved");
+    }
+  }
+
+  /**
+   * @notice Test deterministic address prediction
+   */
+  function test_DeterministicAddressPrediction() public {
+    bytes memory immutableArgs =
+      SlashPayloadLib.encodeImmutableArgs(mockValidatorSelection, testValidators, testAmounts);
+
+    bytes32 salt = keccak256("deterministic_test");
+
+    // Predict address before deployment
+    address predictedAddress =
+      Clones.predictDeterministicAddressWithImmutableArgs(address(implementation), immutableArgs, salt, address(this));
+
+    // Deploy clone
+    address actualAddress = Clones.cloneDeterministicWithImmutableArgs(address(implementation), immutableArgs, salt);
+
+    assertEq(actualAddress, predictedAddress, "Predicted address should match actual address");
+  }
+
+  /**
+   * @notice Test that different salts produce different addresses
+   */
+  function test_DifferentSaltsProduceDifferentAddresses() public {
+    bytes memory immutableArgs =
+      SlashPayloadLib.encodeImmutableArgs(mockValidatorSelection, testValidators, testAmounts);
+
+    address clone1 =
+      Clones.cloneDeterministicWithImmutableArgs(address(implementation), immutableArgs, keccak256("salt1"));
+
+    address clone2 =
+      Clones.cloneDeterministicWithImmutableArgs(address(implementation), immutableArgs, keccak256("salt2"));
+
+    assertTrue(clone1 != clone2, "Different salts should produce different addresses");
+
+    // But both should have the same actions
+    IPayload.Action[] memory actions1 = SlashPayloadCloneable(clone1).getActions();
+    IPayload.Action[] memory actions2 = SlashPayloadCloneable(clone2).getActions();
+
+    assertEq(actions1.length, actions2.length, "Both clones should have same number of actions");
+    for (uint256 i = 0; i < actions1.length; i++) {
+      assertEq(actions1[i].target, actions2[i].target, "Targets should match");
+      assertEq(keccak256(actions1[i].data), keccak256(actions2[i].data), "Data should match");
+    }
+  }
+
+  /**
+   * @notice Test array length mismatch error in encoding
+   */
+  function test_RevertOnArrayLengthMismatch() public {
+    address[] memory validators = new address[](2);
+    validators[0] = testValidators[0];
+    validators[1] = testValidators[1];
+
+    uint96[] memory amounts = new uint96[](3); // Mismatched length
+    amounts[0] = testAmounts[0];
+    amounts[1] = testAmounts[1];
+    amounts[2] = testAmounts[2];
+
+    // Create a wrapper to test the library function revert
+    TestLibraryWrapper wrapper = new TestLibraryWrapper();
+    vm.expectPartialRevert(Errors.SlashPayload_ArraySizeMismatch.selector);
+    wrapper.encodeArgs(mockValidatorSelection, validators, amounts);
+  }
+
+  /**
+   * @notice Fuzz test with random validators and amounts
+   */
+  function testFuzz_RandomValidatorsAndAmounts(uint8 validatorCount, bytes32 seedValidators, bytes32 seedAmounts)
+    public
+  {
+    // Bound validator count to reasonable range
+    validatorCount = uint8(bound(validatorCount, 1, 50));
+
+    // Generate random validators and amounts
+    address[] memory validators = new address[](validatorCount);
+    uint96[] memory amounts = new uint96[](validatorCount);
+
+    for (uint256 i = 0; i < validatorCount; i++) {
+      validators[i] = address(uint160(uint256(keccak256(abi.encodePacked(seedValidators, i)))));
+      amounts[i] = uint96(uint256(keccak256(abi.encodePacked(seedAmounts, i))) % type(uint96).max);
+    }
+
+    // Test encoding/decoding
+    bytes memory immutableArgs = SlashPayloadLib.encodeImmutableArgs(mockValidatorSelection, validators, amounts);
+
+    address clone = Clones.cloneDeterministicWithImmutableArgs(
+      address(implementation), immutableArgs, keccak256(abi.encodePacked("fuzz", validatorCount))
+    );
+
+    IPayload.Action[] memory actions = SlashPayloadCloneable(clone).getActions();
+
+    // Verify all actions are correct
+    assertEq(actions.length, validatorCount, "Action count should match validator count");
+
+    for (uint256 i = 0; i < validatorCount; i++) {
+      assertEq(actions[i].target, mockValidatorSelection, "Target should be validator selection");
+
+      (, address validator, uint96 amount) = decodeSlashCallData(actions[i].data);
+      assertEq(validator, validators[i], "Fuzz validator should match");
+      assertEq(amount, amounts[i], "Fuzz amount should match");
+    }
+  }
+}
+
+/**
+ * @notice Mock contract that implements the slash function for testing
+ */
+contract MockValidatorSelection {
+  event SlashCalled(address indexed validator, uint96 amount);
+
+  function slash(address validator, uint96 amount) external {
+    emit SlashCalled(validator, amount);
+  }
+}
+
+/**
+ * @notice Wrapper contract to test library functions that can revert
+ */
+contract TestLibraryWrapper {
+  function encodeArgs(address _validatorSelection, address[] memory _validators, uint96[] memory _amounts)
+    external
+    pure
+    returns (bytes memory)
+  {
+    return SlashPayloadLib.encodeImmutableArgs(_validatorSelection, _validators, _amounts);
+  }
+}

--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_invalidate_block.test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_invalidate_block.test.ts
@@ -52,6 +52,7 @@ describe('e2e_epochs/epochs_invalidate_block', () => {
       archiverPollingIntervalMS: 200,
       anvilAccounts: 20,
       anvilPort: ++anvilPort,
+      slasherFlavor: 'tally',
     });
 
     ({ context, logger, l1Client } = test);

--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_test.ts
@@ -131,6 +131,7 @@ export class EpochsTestContext {
       txPropagationMaxQueryAttempts: opts.txPropagationMaxQueryAttempts ?? 12,
       worldStateBlockHistory: WORLD_STATE_BLOCK_HISTORY,
       exitDelaySeconds: DefaultL1ContractsConfig.exitDelaySeconds,
+      slasherFlavor: 'none',
       ...opts,
     });
 

--- a/yarn-project/end-to-end/src/e2e_p2p/gossip_network.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/gossip_network.test.ts
@@ -59,6 +59,8 @@ describe('e2e_p2p_network', () => {
       initialConfig: {
         ...SHORTENED_BLOCK_TIME_CONFIG_NO_PRUNES,
         aztecEpochDuration: 4,
+        slashingRoundSize: 8,
+        slashingQuorum: 5,
         listenAddress: '127.0.0.1',
       },
     });

--- a/yarn-project/end-to-end/src/e2e_p2p/p2p_network.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/p2p_network.ts
@@ -116,6 +116,8 @@ export class P2PNetworkTest {
         aztecSlotDuration: initialValidatorConfig.aztecSlotDuration ?? l1ContractsConfig.aztecSlotDuration,
         aztecProofSubmissionEpochs:
           initialValidatorConfig.aztecProofSubmissionEpochs ?? l1ContractsConfig.aztecProofSubmissionEpochs,
+        slashingRoundSize: initialValidatorConfig.slashingRoundSize ?? l1ContractsConfig.slashingRoundSize,
+        slasherFlavor: initialValidatorConfig.slasherFlavor ?? 'tally',
         aztecTargetCommitteeSize: numberOfValidators,
         salt: 420,
         metricsPort: metricsPort,
@@ -125,6 +127,9 @@ export class P2PNetworkTest {
       {
         ...initialValidatorConfig,
         aztecEpochDuration: initialValidatorConfig.aztecEpochDuration ?? l1ContractsConfig.aztecEpochDuration,
+        slashingRoundSize: initialValidatorConfig.slashingRoundSize ?? l1ContractsConfig.slashingRoundSize,
+        slasherFlavor: initialValidatorConfig.slasherFlavor ?? 'tally',
+
         ethereumSlotDuration: initialValidatorConfig.ethereumSlotDuration ?? l1ContractsConfig.ethereumSlotDuration,
         aztecSlotDuration: initialValidatorConfig.aztecSlotDuration ?? l1ContractsConfig.aztecSlotDuration,
         aztecProofSubmissionEpochs:

--- a/yarn-project/end-to-end/src/e2e_p2p/reqresp.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/reqresp.test.ts
@@ -36,6 +36,8 @@ describe('e2e_p2p_reqresp_tx', () => {
         ...SHORTENED_BLOCK_TIME_CONFIG_NO_PRUNES,
         listenAddress: '127.0.0.1',
         aztecEpochDuration: 64, // stable committee
+        slashingRoundSize: 128,
+        slashingQuorum: 65,
       },
     });
     await t.applyBaseSnapshots();

--- a/yarn-project/end-to-end/src/e2e_p2p/reqresp_no_handshake.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/reqresp_no_handshake.test.ts
@@ -41,6 +41,8 @@ describe('e2e_p2p_reqresp_tx_no_handshake', () => {
         p2pDisableStatusHandshake: true, // DIFFERENCE FROM reqresp.test.ts
         listenAddress: '127.0.0.1',
         aztecEpochDuration: 64, // stable committee
+        slashingRoundSize: 128,
+        slashingQuorum: 65,
       },
     });
     await t.applyBaseSnapshots();

--- a/yarn-project/end-to-end/src/e2e_p2p/validators_sentinel.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/validators_sentinel.test.ts
@@ -37,13 +37,15 @@ describe('e2e_p2p_validators_sentinel', () => {
       basePort: BOOT_NODE_UDP_PORT,
       startProverNode: true,
       initialConfig: {
-        aztecTargetCommitteeSize: NUM_NODES, // ensure we can progress even after slash happens
+        aztecTargetCommitteeSize: NUM_VALIDATORS,
         aztecSlotDuration: AZTEC_SLOT_DURATION,
         ethereumSlotDuration: ETHEREUM_SLOT_DURATION,
         aztecProofSubmissionEpochs: 1024, // effectively do not reorg
         listenAddress: '127.0.0.1',
         minTxsPerBlock: 0,
         aztecEpochDuration: EPOCH_DURATION,
+        slashingRoundSize: EPOCH_DURATION * 2,
+        slashingQuorum: EPOCH_DURATION + 1,
         validatorReexecute: false,
         sentinelEnabled: true,
         slashInactivityEnabled: false,

--- a/yarn-project/end-to-end/src/fixtures/snapshot_manager.ts
+++ b/yarn-project/end-to-end/src/fixtures/snapshot_manager.ts
@@ -308,7 +308,7 @@ async function setupFromFresh(
 
   // Fetch the AztecNode config.
   // TODO: For some reason this is currently the union of a bunch of subsystems. That needs fixing.
-  const aztecNodeConfig: AztecNodeConfig & SetupOptions = { ...getConfigEnvVars(), ...opts };
+  const aztecNodeConfig: AztecNodeConfig & SetupOptions = { ...getConfigEnvVars(), slasherFlavor: 'none', ...opts };
   aztecNodeConfig.peerCheckIntervalMS = TEST_PEER_CHECK_INTERVAL_MS;
   aztecNodeConfig.maxTxPoolSize = opts.maxTxPoolSize ?? TEST_MAX_TX_POOL_SIZE;
   // Only enable proving if specifically requested.

--- a/yarn-project/end-to-end/src/fixtures/utils.ts
+++ b/yarn-project/end-to-end/src/fixtures/utils.ts
@@ -392,7 +392,7 @@ export async function setup(
   try {
     opts.aztecTargetCommitteeSize ??= 0;
 
-    const config = { ...getConfigEnvVars(), ...opts };
+    const config: AztecNodeConfig & SetupOptions = { ...getConfigEnvVars(), slasherFlavor: 'none', ...opts };
     // use initialValidators for the node config
     config.validatorPrivateKeys = new SecretValue(opts.initialValidators?.map(v => v.privateKey) ?? []);
 

--- a/yarn-project/ethereum/src/config.ts
+++ b/yarn-project/ethereum/src/config.ts
@@ -46,7 +46,7 @@ export type L1ContractsConfig = {
   /** How many slashing rounds back we slash (ie when slashing in round N, we slash for offenses committed during epochs of round N-offset) */
   slashingOffsetInRounds: number;
   /** Type of slasher proposer */
-  slasherFlavor: 'empire' | 'tally';
+  slasherFlavor: 'empire' | 'tally' | 'none';
   /** Minimum slashing unit for consensus-based slashing (all slashes will be a 1-3x this value) */
   slashingUnit: bigint;
   /** Governance proposing quorum */

--- a/yarn-project/ethereum/src/contracts/rollup.ts
+++ b/yarn-project/ethereum/src/contracts/rollup.ts
@@ -98,8 +98,9 @@ export type ViemAppendOnlyTreeSnapshot = {
 };
 
 export enum SlashingProposerType {
-  Empire = 0,
+  None = 0,
   Tally = 1,
+  Empire = 2,
 }
 
 export class RollupContract {


### PR DESCRIPTION
Reduce gas cost for executing a slash in the tally slash proposer.
Builds on [16514](https://github.com/AztecProtocol/aztec-packages/pull/16514).

## L1 changes

- Votes are represented with fixed-size arrays, so we save a storage operation by not having to store or load the array length.
- Slash payloads are implemented using EIP1167 clones to reduce deployment cost.
- Tally matrix is compacted to reduce memory usage, and votes are processed in batches with early exits (since most vote arrays will be sparse).
- Add a config option to deploy no slasher.
- Generic improvements like unchecked operations, loop unrolling, using calldata over memory, etc.

## Other changes

- Add extra checks during deployment to alert if a tx reverted.
- Default tests to deploy no slasher (required to avoid triggering new validations in the tally slashing proposer contract that failed when epoch lengths were set to very small values).

## Gas benchmarks

Given the following settings:

```
  uint256 constant VALIDATOR_COUNT = 128;
  uint256 constant COMMITTEE_SIZE = 48;
  uint256 constant ROUND_SIZE_IN_EPOCHS = 6;
  uint256 constant EPOCH_DURATION = 32;
```

Gas costs before and after this change:

| How many slashed | Before | After | Reduction |
| -------- | -------- | -------- | -- |
| 1  | 4003168  | 1461217  | 63% |
| 48  | 12299046  | 8362076  | 32%  |
