### PR TITLE
refactor: staking queue config now includes max value

### DIFF
--- a/l1-contracts/.gitignore
+++ b/l1-contracts/.gitignore
@@ -36,5 +36,3 @@ gas_benchmark.diff
 /bench-out
 
 /coverage
-
-/script/registration_data.json

--- a/l1-contracts/foundry.toml
+++ b/l1-contracts/foundry.toml
@@ -29,6 +29,7 @@ gas_reports = [
   "RollupWithPreheating",
   "EmpireSlashingProposer",
   "TallySlashingProposer",
+  "MultiAdder"
 ]
 
 remappings = [

--- a/l1-contracts/script/registration_data.json
+++ b/l1-contracts/script/registration_data.json
@@ -1,0 +1,1702 @@
+[
+    {
+      "attester": "0xdEc08eb67aEa96cd8C2F576aEFD5b9F6bA4bc973",
+      "publicKeyInG1": {
+        "x": "0x0d8fd0af4f057a4ab0e7c55b80bcb1e624a0d319edc890a94e32ff8a49b17fd0",
+        "y": "0x288a165b8f273e46b18d308bd94980511ff1ab31cf7977524cc5100a81c639ba"
+      },
+      "publicKeyInG2": {
+        "x0": "0x189965ba927f0bdf8a00df57ca5c2f9fbb08a1c1e5ffe492d4b4c15ecefe3c16",
+        "x1": "0x0041dc6e43f797479233619b2f6da70fd3a0a6bf097a8fa256b9bc83bc309f17",
+        "y0": "0x08b4c50b72aa8ff1205d5d849d10614731fc4e17edfa920e4ee59baf96889661",
+        "y1": "0x167947af5ae7f4277b0c1f6d915c8dd6485b1898d524c5caee08da68c77fa1e1"
+      },
+      "proofOfPossession": {
+        "x": "0x2b53ce30e1ad6869f94eb6c1a0870052932babdd827bde920e0af006a3910c6e",
+        "y": "0x2a59bbc85aeb0ef42b6e22118a256b54822c9656f93b9206e5e70e35c8aad39a"
+      }
+    },
+    {
+      "attester": "0x65Df7Fe8A2Fd26805ab8d9487D548Dd70262B371",
+      "publicKeyInG1": {
+        "x": "0x13c228ed66d3336ba3a9cdd09f17dd72ebe04ee91d3b96009308e5feee87a4a9",
+        "y": "0x21b3da7ed72d72776844138fabb21537913956816338a2988916f349b40868f6"
+      },
+      "publicKeyInG2": {
+        "x0": "0x11dbb4bd7204d4c626cc09ba1a5dfdea248acc892464f379860e4d1d9b687d54",
+        "x1": "0x2ac8ad0079bbf89f1496dee77a2f33410d7d78ca48ab4a1eb9846b2ae584fe53",
+        "y0": "0x229713c0ee5720acaa5747d8e73361dfea8dd78533d59f28f76e2f94599ec9ae",
+        "y1": "0x295e82aa97fda4d7cfd6bd2b3100956825bb8c1a76432d82aa5b7600d4e7824a"
+      },
+      "proofOfPossession": {
+        "x": "0x0443bf41d65fcf3021eb688db733d55a2b5cba2820b97f585e48f0aeee31cac3",
+        "y": "0x2e2a9bb19a2a5b73184f0b231a1b5057fcee9ad3c1c0ece27dff33d255011915"
+      }
+    },
+    {
+      "attester": "0x3B31bA671E50640DC929319f68bEC5D6Dc485Be1",
+      "publicKeyInG1": {
+        "x": "0x1a612809c5d132c776d1ee93e771e91b64e28b76c64b71fd3ddf56528b666a18",
+        "y": "0x0a41e5fce62131f347a0824426903dd96da3757991511d059c948dd4acb64084"
+      },
+      "publicKeyInG2": {
+        "x0": "0x013ef0adea24e873d1bae1a46519fe6c178f0b9707b88fbf23f4bd16de63d113",
+        "x1": "0x2147b7592cabd3ae0f0da30058abe68c38e79f3db109ec2b0a436011ecd7d574",
+        "y0": "0x0fc0d0118d8d7191613181aa8a16a5c581df40dd8c09c47a92f10b79885790a5",
+        "y1": "0x13b3c2ba6089a1f5842c94857ead8f4ffc2df381a3e2383ed6f473858b2902db"
+      },
+      "proofOfPossession": {
+        "x": "0x1da877a8ee72fda27f5e923e678c151668bb42083fbd68b642da9503b9abc778",
+        "y": "0x224096493c053e7268ae25ed4ce325025bd2b914594fdf1b42a57fb253f9c2d1"
+      }
+    },
+    {
+      "attester": "0xD74060d019d93629f20D0de54EDD1fdda326a14A",
+      "publicKeyInG1": {
+        "x": "0x2d971aae78feaae2e7c160f57c9b0b459d1bdb4abb2db606e00e815dce03dfb3",
+        "y": "0x21f4e235a038562fa823f4621dd27ee1b2099b5f309a0900e4cb39479256586c"
+      },
+      "publicKeyInG2": {
+        "x0": "0x2f92922c2b3cf619b1731cab6ca6c7e3236acf04fbcef318f22ed6adf7e9e91a",
+        "x1": "0x08674b4d7c02a99dcada17f5d8c2f86a892c19b0dee823e880b1327217f2419a",
+        "y0": "0x0910130a51646d01be6ef2ef9150543305fbabc1ea8fd96de862eacc355eb96a",
+        "y1": "0x16e2641e6f68ae6879d3a947fbf69dcf4b02b8eee9bbd4120f08bde24b8b1c76"
+      },
+      "proofOfPossession": {
+        "x": "0x0f7ed9afd84ca62b19104da03f01b9f0e7cb162be449a7b6197e835607a5a99d",
+        "y": "0x1f1079d20304e1d6e9ecc56d5d1cff712d201ecbfb9d8a5c7de08e8ac3af5be5"
+      }
+    },
+    {
+      "attester": "0x73B88ec8bC5e16c3D2aE879f94a53EB755Bd6a51",
+      "publicKeyInG1": {
+        "x": "0x0ecec3c57e4e1f04d910a5fe2bde493a454a33b1e1bc3610084bb466d040fbf2",
+        "y": "0x01349c15806bdcfbce6f739ca184a1c641be64c1327a28fdefc7f52ccbf0e94b"
+      },
+      "publicKeyInG2": {
+        "x0": "0x0eea15c1781b8c4217c091dd62cc1848b537711d860f21022b92a50720aa7d72",
+        "x1": "0x17a6c3f889b413f5a04c29c3c57f8cbf14c1d3cdcbf122ec850f2509f0cac346",
+        "y0": "0x1aa53a908eb54269a92cfa55eb8e2d818e951c8f130ea834c7a55932e9c24f5b",
+        "y1": "0x1b91a2a469dba7f9ee878b2fc1bf65e7a1edcfa7156fcad46669afdf8e2824ab"
+      },
+      "proofOfPossession": {
+        "x": "0x17b318e01658b81bda7520fa08ab373448655561c5ba88f6ad436b7aae5ea7c4",
+        "y": "0x03e327b53d8ab0ce355f1313b3b66d774bd3a26ca6bcfecc174a7175afaef294"
+      }
+    },
+    {
+      "attester": "0xf528bb057E29E05252586cEFf8A1eB94fe370Cc6",
+      "publicKeyInG1": {
+        "x": "0x17d4d1627187055d6b7a2ea75b525fd210d1a4c34cfee28f221d3045855153e0",
+        "y": "0x02c72b69e0aa885e42ef8640524bec7ecd0a08865481a4b484cba8120a88ae19"
+      },
+      "publicKeyInG2": {
+        "x0": "0x00d645115f310a9853a09dca9dc8de485035bea0fcd1cce62571e75590837c1a",
+        "x1": "0x2c2d3e34bf42ffc4bcc70ce8c09e6fee411fdac239253f374a62b5da94584f48",
+        "y0": "0x00dca25611e1e7bc606adc45a1c2750a74eae58b2c646871350ca277e6fd59e9",
+        "y1": "0x1b29ea6c1cea3925424da167028a7b23ded13a2429101af2ae3b59ced3d9cdcf"
+      },
+      "proofOfPossession": {
+        "x": "0x2a13fe46a0c3b9c0ca9faafaad6ffde1ed7717aa8da9b4e30601fa434778efe9",
+        "y": "0x2fd5b2b56bbf47c90710279a7cfa0bd0f1648417b829c80ca7f3e8480d830749"
+      }
+    },
+    {
+      "attester": "0xBCAD1d6F664FEe4E76e65B7e741D317a181f9084",
+      "publicKeyInG1": {
+        "x": "0x2fe2b64f7c150d3652bf33e7d785ab72a38b78baa50d23d05861ffbac948ec43",
+        "y": "0x1419f5dcf4c52cf74d1067b7d98409133aa918d4b7efa5c1cc29b4cea340a736"
+      },
+      "publicKeyInG2": {
+        "x0": "0x13b41424947c5376f48517d8a3c3c63864afcb96f47c484831f212edc7c6241c",
+        "x1": "0x26e7d72d516245bc4cb6570e896f60ab0d968663cfa192eee4010a775f66f0d3",
+        "y0": "0x0b80b2965787f1417d01c211b365fb0bacf47360dbc870bcc0c46c7a1e37f9e6",
+        "y1": "0x02510e3570171c3cb7b3b9ac708e98d865afb1c4b23ed2f39663bb6241d1c3f4"
+      },
+      "proofOfPossession": {
+        "x": "0x1c378237678cfb16f4a91f76d47a792ea627b3b90df2a3281b9b5ca8f9520a58",
+        "y": "0x2e4cbfb1b027a1ef1e1d790e63540218ebb60e9116f8c215e7218c2d06064464"
+      }
+    },
+    {
+      "attester": "0x47EadaC92B7bd05cd6f6Df0ff76EB9872c79d188",
+      "publicKeyInG1": {
+        "x": "0x22d33ff5d60b1f23482896689c5335b972a98a87f73f080e9ab4d3d29e6f7351",
+        "y": "0x178e6fb12365d087dc76984e2f017270d5f5743503b8606a12def08f723da910"
+      },
+      "publicKeyInG2": {
+        "x0": "0x166f3e9c2bca7a36fb8837d8161cd510803ec65127d57e4f0141b3e03882d330",
+        "x1": "0x0c9d4f179a458919e1360a5b9f2d540a6fc20a92b0fc47ae7ed4fedc6f59a1e5",
+        "y0": "0x1ae06dbaf838cc4b2539648a70816c2d59823ec8bd0f68740555d902d5c6356d",
+        "y1": "0x1d3f23bbb9a5589787d27296cd35763f2dddbcd30aa8a8435897835271a334ad"
+      },
+      "proofOfPossession": {
+        "x": "0x2a945fae14faf7d67f5610ac5331856e6fc0d72a785d3caffdc501965dcef4c0",
+        "y": "0x1164b41112bc20a801b8f0999602baee11e363e9b82fda83faaea4bbe78311e1"
+      }
+    },
+    {
+      "attester": "0xdd22AD1c88948D25bb13E30D99895a7f8A943A20",
+      "publicKeyInG1": {
+        "x": "0x1b6d2afdf7d835bed51f7e770fed40cad94e7d1c48b0fe2a886493b25912f469",
+        "y": "0x08c7b848310ad2574c97bcfd44c8116dba6e7f5325b450e2b277a23667766d44"
+      },
+      "publicKeyInG2": {
+        "x0": "0x1c02ae1ad06995c130ae8c66f16e8825823939a81de1a7af8521dabc7be2249e",
+        "x1": "0x18da85c577377f4434060b6dbbe296dd48301c61a4f2eb2524c3909171b96be8",
+        "y0": "0x0b3e3d84c0f111d6239e6740e4aebb4ef39606df58b9377da3ca6e6351342542",
+        "y1": "0x26e5b7e0ac133eca8433930f803d49f660a072bad3dbf147c0ff865ae66940e0"
+      },
+      "proofOfPossession": {
+        "x": "0x1c3d30dc0e5d3e93fd6e4a8ee6958d8409681c56d8690280048a19b860ca06ac",
+        "y": "0x181e193877e05561d9e930201b31b460469c1924ec1f991e373c245c571d46dd"
+      }
+    },
+    {
+      "attester": "0xa1FCFa64f30120a11Df2d972665d68734B465EFd",
+      "publicKeyInG1": {
+        "x": "0x260c35140ff9fa6c7a502df27c29326e0a8356a051a72ed1f8f6862fb060b93d",
+        "y": "0x08410720af05333302e4dcf2c0c578b1389a15eaa7c375a4130db757c377b865"
+      },
+      "publicKeyInG2": {
+        "x0": "0x1698cec64605f37f94ee2cc09c6d85170109c807b76094804612bcb4164a2f45",
+        "x1": "0x283e88133e6b593e4a6d8e29f70feee724e922c43b67a09f2a7b9976db96cde8",
+        "y0": "0x1fd8c98ed9e5011d07b788de6a4587840a5caf58c6d0b1185b879f0f334b9fbb",
+        "y1": "0x16c1e55e1404c5d725084ae4891adca519598e9fb8d626af7c274dfde6bf579c"
+      },
+      "proofOfPossession": {
+        "x": "0x17215021c6245983f21821ac4db89ca782bdfa46571c4324396fe4eb7ae17b02",
+        "y": "0x2a1275a388832ca7337e6be50cb889f2ece69391f2b924a0f43cfa0f32cbcfae"
+      }
+    },
+    {
+      "attester": "0x7136F1928bEC919c2A1142725c71A5c9E9B16170",
+      "publicKeyInG1": {
+        "x": "0x20123af8afac58b5510ea85d23a84f24d078db14e786e53ba13b6d754ff2eab3",
+        "y": "0x123abc736d3c97692610890e769013bad5ec320e6f1ed297ae6e1b9a39744c26"
+      },
+      "publicKeyInG2": {
+        "x0": "0x07783221f613c53dd4ab2f8adc19db5cb116f5422876504b9994a72c99d12720",
+        "x1": "0x1ecbd8f5a1848df0e2c8caf28f621bb98a1694f865d5b55b64b897259b00c703",
+        "y0": "0x2985cab35e646edb7d6b6bf67834ce6e71785316d73c85010fa8c26d00a81f6f",
+        "y1": "0x2a09617fc0f4d5501065b5a8b57568773f5eab11700cc72e79cb7b964990a0ef"
+      },
+      "proofOfPossession": {
+        "x": "0x202f46ee96142e9cbc26295c310d6736ebf2480f86ba433fd40342620d9a57aa",
+        "y": "0x2982aac15fe17bedfdba4b6b3da04ecd0de2f29bfe6bfc72d016445e55192365"
+      }
+    },
+    {
+      "attester": "0x37dCF65c113ab3e6fa9DC33187b2539A3b7dF2AB",
+      "publicKeyInG1": {
+        "x": "0x205889781a91e0a9f8109b71e09d72b375fb51d1718d32cd62e739767d7b3ced",
+        "y": "0x01df55d820582e95ed168b2fe22515ce6beebad4753df8f0b3e1820f95ecf670"
+      },
+      "publicKeyInG2": {
+        "x0": "0x0f9690b83bd6f5331d2a77592cd7e15f5da4df17f003cf5f0bedaf318cf04d1e",
+        "x1": "0x200aa58a575b2ba20cbcc7aca9f930b9b6b353f49c82e5ee270bd91aabc353ae",
+        "y0": "0x099628c5f1506dbc6e4346f444de36d0c508ab0f1e2c5f57b589596d6dc3136e",
+        "y1": "0x2851e8407246a11951073fc0bb00ad087990eb1907b45db92483db5313f38d9e"
+      },
+      "proofOfPossession": {
+        "x": "0x30149f6c5653c5cf9e9bd241c3255506ab088635e5ab187f94d2c8105b232ffe",
+        "y": "0x2b6e8cb96fb5adb517d8b490f475b31e2f6d5f0191f2bbcd9760117da2b08e8b"
+      }
+    },
+    {
+      "attester": "0x1E0227ac0dB196ac12893Aee81ba06cE6C319429",
+      "publicKeyInG1": {
+        "x": "0x24c9a60a1de3f5b44bb6c70bf0e6fbec5512067c13b7dee6a08f0e5a13a66947",
+        "y": "0x1fcf63c86973cb19d6bdc5ebb1eb26c79939748271320a177ab0364f5bd72f90"
+      },
+      "publicKeyInG2": {
+        "x0": "0x00d18be68ae5054b88c17c05120956f2ecf06b8f8b7ea0bba27ae2c196382789",
+        "x1": "0x2ee8677371e6e5815a09c04845bea198b079ce850c4f61bd3be73cb08739e398",
+        "y0": "0x254f0e0b2d1a6e2c5e05b0a5b7a7a1f5a2aeb38b214125966306cf37f3432d36",
+        "y1": "0x1a9f62ec76090b03647a9c2c9c68d9ffc452951e34178101a38b6069d7e3e3a0"
+      },
+      "proofOfPossession": {
+        "x": "0x1419e29c2a5b68fb90e75d9f5b0597ce90fcf7f0c05e011e07be194b80af92cc",
+        "y": "0x0d0dc8adeaef8aeaf82ddc1d0e7b6318078c5ee081e6a2f534194a0332ad7568"
+      }
+    },
+    {
+      "attester": "0xA10935D01b921F543FadE4992310C8bd5AC360DD",
+      "publicKeyInG1": {
+        "x": "0x0bb5458b0d91982f0d37bf1dd26c9886e23c27f97994239d39b2504e0a6287a9",
+        "y": "0x0aee1ca2859a31cf85e6d0852c4bdb58808d1ab33399bba89bff927739457248"
+      },
+      "publicKeyInG2": {
+        "x0": "0x0c6057e93bd012abf01fb203f47ff330d60c8846640abd30bc20c066bb2a797e",
+        "x1": "0x2a7dae7122ed092108e033f3666572a37f268953cee15fddeccbaeb301220665",
+        "y0": "0x0758353e461e04968d8cab4627304acd733f574e054f67aa4ba7c112c44f1626",
+        "y1": "0x094d9bc276544d3a3d24adc1c34a55d20bca0f94afb32a14d7f68440e9ed44aa"
+      },
+      "proofOfPossession": {
+        "x": "0x2a617675ec7afbaf2ed6c679e74281b29db557d70fdea4d13a1f7b4cabeee4f6",
+        "y": "0x230cd736279f8a0c423d3b72e85b11a7aebf1b7c1addeecdaab822d1a8bcddf6"
+      }
+    },
+    {
+      "attester": "0x41A05666e1DA484986488947ea958E56D4efD108",
+      "publicKeyInG1": {
+        "x": "0x05285b29fffa1ba8fbf6f6648f0f3ceb85078cc9bb5c28eee9573eb614a49581",
+        "y": "0x20898c2e0415f363f2850ac136219aaaf05a4b8027e9dce9e05458b82400873f"
+      },
+      "publicKeyInG2": {
+        "x0": "0x2c10c1f121b33a5124be5bd87327b474cbbee926d33598fc12e5ef2d94c58cdc",
+        "x1": "0x021638dba2e99cd833ae5732d77e5c5b1bf5ef4d16f35f15c1eeebdaf8f2911f",
+        "y0": "0x1527857ac10efa4e030e7db5ae9800263b60c04e8d7da2c4a1998a6dc81a83a7",
+        "y1": "0x0362ce030807a2c6287404bbc6eb7723ab3259e310e19eba0678980a07d44430"
+      },
+      "proofOfPossession": {
+        "x": "0x124552e0d5bc36704cfe19a7df2b76ce71af17345151b8e7c761d4b12c6ab095",
+        "y": "0x2d8c8fcd469093980ab0d17e1b0fdbd569250cefe72e16e5c3aaa25a30d39b8c"
+      }
+    },
+    {
+      "attester": "0x4B39daAcdf30bD18f2447e9926Ac3473abbdf116",
+      "publicKeyInG1": {
+        "x": "0x0e96d23bf58f226754dc65783c20ed2338d42ba9864e7812a2ac8a23f03a1f71",
+        "y": "0x1d1a4ecd2e4c245d60711e9364d04fd5c3abdaf4a2482dafef99d25522dd6e0c"
+      },
+      "publicKeyInG2": {
+        "x0": "0x303bf3868ce408e57c212223d6b2b9f9839285f051cf9ea2d6f22ff3a6a86033",
+        "x1": "0x2b9644b30b89fd050c36886dbac0cf3ed240d6ec6f7546dec3650f3dc50fbe02",
+        "y0": "0x27fcb70c8bfb6b16ec97ac8edf07809ddccead86f8c48054472b419fae895a41",
+        "y1": "0x136e10ba0cf7614a8efb2efd463dc577400579bbf28cddaf6390ca38e3a4cdcd"
+      },
+      "proofOfPossession": {
+        "x": "0x291a31b522ceb015124d0b0c816017389a0276ea7f3670f4a5991a75a671e112",
+        "y": "0x20b4f75965290bbb258834c1bf9a77b1e561fe95c96e2cecab5ed596a5e7132e"
+      }
+    },
+    {
+      "attester": "0xFaf0b7ef3Fc4474B175bfF6c2d57a4fb3195d5E1",
+      "publicKeyInG1": {
+        "x": "0x2b282b9af6af3dd72df5987671d7f4fd18242c10b407f317d35fb69302fb1e8b",
+        "y": "0x1dd4275c9a2cf8961569116a527c083ede11bf6358128ab40cb21fc67d83938c"
+      },
+      "publicKeyInG2": {
+        "x0": "0x16c94c76ecd9342d9fe0bc11609f5c72e5fdbac19561df1335794e587266ef73",
+        "x1": "0x106fc61d7e05179a96a90ba882164bfc49bd2bc2b8e89a76dc72c1b09e2b61f4",
+        "y0": "0x0b79fdaf9123d7df42ce411d7da47f29ff973883f97438045e7ffb73520db71b",
+        "y1": "0x0d43f01c6dd3bd5225950aed6963119b82141dc15a6cb02be55c052cf010863c"
+      },
+      "proofOfPossession": {
+        "x": "0x25e13fba907951cd892bd0e2d14baffe96678ffff750b5752289770f978f4555",
+        "y": "0x2fcc213f8ad8d42915a7bd013684d6f078ce5bd4ade504a5ec265ee33730398e"
+      }
+    },
+    {
+      "attester": "0xFd2Bed71B4B0159D0cbADa00228f0A5f3Fc28e91",
+      "publicKeyInG1": {
+        "x": "0x25d7346e4e4eabbe7a0972f1afec400abedee7d7975547184c24dac50fc0c8e6",
+        "y": "0x156af30a396d578b5d1ff119ec6a1f2dae7a7f8bb4edc589f1458635e42c5dea"
+      },
+      "publicKeyInG2": {
+        "x0": "0x0c68010a4c63db55c4ddea4acd8444bda002f76e8df65c24c23ad272dc956b3c",
+        "x1": "0x1b06855f2a8c52d3167a7c6e98596e5377912f91f5b57159490a667032d790b0",
+        "y0": "0x1664d344656cbe019947376639333b8a3c7aad06b26383ca1f4600e5cd5157e4",
+        "y1": "0x130aeab1108c671656ad9e63afadf542c01c3cf6d9f81e2abbf53e570c81d8c0"
+      },
+      "proofOfPossession": {
+        "x": "0x2cd0bf91072614cd1bddc286883f312a5100c61e014464b5619c477967facfe0",
+        "y": "0x22f377633a3cad3b661acec22eabfebe94d29c2f5952c91f31e94d972bf7a13a"
+      }
+    },
+    {
+      "attester": "0x4DdaEA5D39a1cc00B3ad8dAA937b6aeaF57eA3AA",
+      "publicKeyInG1": {
+        "x": "0x1a6a8a5e54581bab45d574bde5e89f4408480c3b84d3d72ef4bc53e083dc1c63",
+        "y": "0x0d8a444b86b3297654ac2367c3159fabeac252b73dc0f51c1367362fa1b24f77"
+      },
+      "publicKeyInG2": {
+        "x0": "0x2ba362c0649dc21131db9d9fd9dc5b6219810c9d38c072f050630bd371caef94",
+        "x1": "0x2dccd3d75ad77c13ab321066ae352fd60b9f1195082b7dd739a25e9fdcea3784",
+        "y0": "0x1649825e8b57b7404358c2cdf1c867be690b27b0730e60850b77d18acd18dba3",
+        "y1": "0x1ab8666514c459b8f45ed618c77fe3ebe149a7481225cd429915df31393832fb"
+      },
+      "proofOfPossession": {
+        "x": "0x21f7b157a5b11840110b3be302bc4e7497ca75ac89c5b0c5f93555cf76c0dde6",
+        "y": "0x05ff4833c35b140831db5f8689fb572b61319deda9840b04d78def7cae3035a4"
+      }
+    },
+    {
+      "attester": "0x91d52d7F3Abc49780c1D5b477B76Bd6dde5161ED",
+      "publicKeyInG1": {
+        "x": "0x0ab137b9929bf24a87f23cf3ea13eb18e26fd69ef1d1ea209965f21c87d01df5",
+        "y": "0x168578eed3d80ac21cb9cc0bb859a80e589c089c8dcbac48043831b2c4841951"
+      },
+      "publicKeyInG2": {
+        "x0": "0x2d31fe625fcb6784059e3e12d085b86cbc3976b295aedb71534b06549350ed13",
+        "x1": "0x12eae0ed390716affc103a1d09f9c42b91114d27fb04af084e8aad15aae0ff75",
+        "y0": "0x2dc6358e5bd8e12081a90fa50322c58d6dee7efec30986c7aa96ad1cffe45c9b",
+        "y1": "0x141a1da54e5ee4e5b89f3c56f9809d50d0cfbccdbf80941268bd8373e3ab71d5"
+      },
+      "proofOfPossession": {
+        "x": "0x0dce826de4b074f11fda7c3104fbdf68f766a26d2fda5cf9fc3002a568da0341",
+        "y": "0x28aaf679f696b14a3a04c76312f0d7d9327701a85e9114e698bcec81ac1c200b"
+      }
+    },
+    {
+      "attester": "0x18f8fF2eaa8E6215a7D0ddACC681E8D070292a05",
+      "publicKeyInG1": {
+        "x": "0x2e096f42cee10459655e7dd958a50012c09bbeef92948a70136a3f6f0ffaae96",
+        "y": "0x12bbae14b61a05b7c1e3b59399b27149691c224f80544f2d41d9ec35bb0ef864"
+      },
+      "publicKeyInG2": {
+        "x0": "0x1c539de774d5a72d769b6fbd18317261284afe630c58a69604785ddd042fa626",
+        "x1": "0x27935fb1f6f6aece887d1637c0fb6262c76149787350fcb422fc0dd7e09aad6f",
+        "y0": "0x1ff9693c0b8fecab526f2662a60b2fb335901d9b9285ec2c9ea5423ccce74f11",
+        "y1": "0x2ab3059d7997351a207903dc6494e70cfaba36c6abfbc070318cc48b7eaa86ec"
+      },
+      "proofOfPossession": {
+        "x": "0x1b3c2e52c1155f463421b9a37ae6705357b94e4c7ae9a6bab70f0b9cdb7797ba",
+        "y": "0x00d86e96b0fadbdad697a409bf44a90b552a5ee91511fa63464bebc89155b5be"
+      }
+    },
+    {
+      "attester": "0x31b058e2F0923955986cfc3995E3416DA3ca7AcE",
+      "publicKeyInG1": {
+        "x": "0x2883f93207c9e408f6f73bd4bd769e899346fd031aa57f397a132392372e4519",
+        "y": "0x0346bc74991de3195389d3b59edd42ba9ffd783327a13387c9cb77dbd3d3e0ec"
+      },
+      "publicKeyInG2": {
+        "x0": "0x1b8d89453fe35a338e0733ad5b553a3e203c9c0c719c48a192d1ecf44a67a14d",
+        "x1": "0x2fc359dca1748a2611eeb0ba255106908a7bf21df84f65b6e1f700bd765acb8b",
+        "y0": "0x2ce29874ca2809df339f2f7a2944f8f597d3f67a46b7d230472d13127fbb6721",
+        "y1": "0x296aec85d9793fa99c9a706b05f231968798fbca0bffc11a41eb738700447c2c"
+      },
+      "proofOfPossession": {
+        "x": "0x2d5103c2f2de572ed15611de4b33f3e5defd3f8cf6bfc796d60928a89b289d51",
+        "y": "0x0386f5d4009400dc8d7b73a219a950a498f5dfb8bbab86f31f9d96818a694bb7"
+      }
+    },
+    {
+      "attester": "0xa96237a0F6d3bC477D2d1a3B057b2eFA25c425D0",
+      "publicKeyInG1": {
+        "x": "0x15ab2978fcf9eddebfc7c0328be545fff1154f16b893a1a2895c84d2dc2509d5",
+        "y": "0x2eb4bcab0218b0ae296b61bfdbf00064ec5e85b25ff121dd06341e3a1ae8f840"
+      },
+      "publicKeyInG2": {
+        "x0": "0x1d45b65c90092fabb0750abca16e0703adad03f51bc6a4d53c9a6991af538358",
+        "x1": "0x0b6bdd40571e9557e9a507352642423ff7475da1026ceec35e0131bee5f2244d",
+        "y0": "0x01d8f6d5e3c803789a3da352e3ba118a3360463e5fc55ce2ef73007a8032d4b7",
+        "y1": "0x21b35a0f915f26c2c0c75f0d4373a96f623691c8ba114bcf4bb7ec1bf02e13e2"
+      },
+      "proofOfPossession": {
+        "x": "0x2fb17e3ee863bf71f703a6ec4635d3993390bd9ef5d0eae721bc4d1ddf92b3b8",
+        "y": "0x2ad7ebab851fba0e071eed7300da4ba701c52e43cccb8c35a3ea85ddcc0c70fb"
+      }
+    },
+    {
+      "attester": "0x3aA54797f21921D4698f4be47Ae483e5C464fdD3",
+      "publicKeyInG1": {
+        "x": "0x1d48cd6a9720ba3c41944da79b292bfcaa82ae476269f6194b85ae151bb9c282",
+        "y": "0x0272ed848e9d22eacc84fa8674e5f3f2c4bdcc0dd946521937bcb051c3f41eea"
+      },
+      "publicKeyInG2": {
+        "x0": "0x1e3de3b9565f7ab2a32aaf86286427612e10908982b759677d7a5f6ef9ff31dd",
+        "x1": "0x2245a3a3c8ba954476dc331f552e5fb08dc3a451e0d99db0fcd57ddc12a72b76",
+        "y0": "0x023d47d65ac2ea7e5c992a36dd012c024b2590cdf048929c9de1bc1f0af5365f",
+        "y1": "0x13efb77bfdd55a74f84a52100a0d0ca9d00d569ba40f2c13c8952eac07b7885d"
+      },
+      "proofOfPossession": {
+        "x": "0x1ad8030c33e5656dcf128d932364c6a1fbd75ee01e3e5cfc6857b0dfc07b17d3",
+        "y": "0x25b47f86ca2a56aaabde9346fdb76f80e19faf23f5672d84f9d214222ac863b1"
+      }
+    },
+    {
+      "attester": "0x98d0958eE1Ad1d849488921054D2628A2900fAc0",
+      "publicKeyInG1": {
+        "x": "0x28d9bc59fa6d679663b8016318e1e2b4cce429797923dbf979fdceab12743ca9",
+        "y": "0x17173e14ca1834ee3d0ebf437af4e6fff31a7943d79e023ff05a47315b44228a"
+      },
+      "publicKeyInG2": {
+        "x0": "0x1d495e7507ffd0fa56118317a68694524fc64345e6b53cbc5ef5c6b6253e4ce1",
+        "x1": "0x21f18e2fd9fca17c8c83847ea642f6d8140a4937d805584b953d5b93a2920157",
+        "y0": "0x076553cc645437ce45946600a9e7d63be43c52cb14130629b8db0cea94b4bb36",
+        "y1": "0x29398490ac5c752ee68597fbee53fd415b0057255803908ed9f10eb74358df5b"
+      },
+      "proofOfPossession": {
+        "x": "0x1e53b94d92951e9dc6c2bce0bb2e9611836c24f8d4f40957dca45096ba33c092",
+        "y": "0x1ebedf1a40ae5f54ffa9e5024128832dd28b572ae1513bd112f04ccc28fbe3be"
+      }
+    },
+    {
+      "attester": "0x114B5F431B932169B6D0431A4E63d040873601e7",
+      "publicKeyInG1": {
+        "x": "0x188d61017feb8cf7954056108e85fa9abd29e96e58ec1418bff5220ac7916735",
+        "y": "0x007e3b629bdb4d3be584962f69dc630904fbb5ae0ead8265d6ac116e315a1d82"
+      },
+      "publicKeyInG2": {
+        "x0": "0x054604eb0484c70e340ad0d46864a79e95a47d603c8704f76b0c5c5493f7d950",
+        "x1": "0x13eb1e6adb032aa5619171032f165022f07bf731d87602c1b62abeaa1dd3c9ae",
+        "y0": "0x23348d77e8111e0a0b779e17b85170a416d3e26c8bbc3cb3a04367030e3d81c2",
+        "y1": "0x153895dfb49ad78b32074cd44f322cd832d4333b5d6a7fd361ad7718ce1e23d2"
+      },
+      "proofOfPossession": {
+        "x": "0x19e301076835a5fbee0dc718ff3035170bed9e55350ceda96e2270ae53d0520c",
+        "y": "0x102ff0be72bb4a5f3785b33c824ec99a0e9afd3a3de2c4e068e1418678053cc6"
+      }
+    },
+    {
+      "attester": "0x2Cda54eda64990cC5d502042708fB984714513D6",
+      "publicKeyInG1": {
+        "x": "0x0f74aa90497b457118cbd85c9f83a9b73c4fa04ab7659730fd96be21cce877f8",
+        "y": "0x18365eafc5dbd6d81cf1db3a1d0b7956404da464d38a13bb8e2fa7fd6f191c5e"
+      },
+      "publicKeyInG2": {
+        "x0": "0x0358e759652d9d7bc6140f1dd8ebc6e9956b871e9b0516fdb25efaec6fdc2f00",
+        "x1": "0x087d247a95098cc7e70fa681238501cd15ef39dcd1a663d792ba73a9f7e13bbb",
+        "y0": "0x0891f2a4ccad5dfe2fad9ddbdce04c02dcbb613fecf0d455278077ecac750309",
+        "y1": "0x2e2688d7fbb701f0f6c90f581da6723c732ce54aeb1b5a0361d4d4c97f9ded6f"
+      },
+      "proofOfPossession": {
+        "x": "0x1e7fb93163a33b80185d0fc2f3c80ec6cf736d55f062d027d165b5215d6a08f2",
+        "y": "0x07ac0a8d00312a3272bae8cb53efecc91952534d66823b922e0f89aa8431670a"
+      }
+    },
+    {
+      "attester": "0x62cE081e593e8311A95F3ED8A028cEc5630374Ec",
+      "publicKeyInG1": {
+        "x": "0x1f28179275af90170bd946e4011255261873feb80632babb2760969af96c1509",
+        "y": "0x248d1f4dfefad6532cc49153f4406c8533944ee33626b7551503118be2039a41"
+      },
+      "publicKeyInG2": {
+        "x0": "0x08d3032f3864e18b126897f5b97dfae2000bd4a9521f64481772136611e7fe7c",
+        "x1": "0x0fbe8140cd6a509389ed33da8370843c4f8ad6c0c99516c34d5855b192cf18b0",
+        "y0": "0x0ac5fdf058d9ca51de2e170f6f540eb7d8d63272d95000188bbbe044606fcb04",
+        "y1": "0x13e41cb136291d2ce9d96d10c00a019690c7e651d6cd55ebcb6bb30809eb0df4"
+      },
+      "proofOfPossession": {
+        "x": "0x0eab5976a9312c86f72471cf6222b58171f80d9dc9300824d31cd8fe45c20b87",
+        "y": "0x1d87ae220d88ea36f2b0a1e0814d6da953b01975149a73474d48e73581090d58"
+      }
+    },
+    {
+      "attester": "0x3b80bE67051c04D71b19B600732fe4a15315Dac5",
+      "publicKeyInG1": {
+        "x": "0x0d4947bb1c66db7b6ad293a9b81e7a4a2531ee93ac047f61deef3f87435bbb0e",
+        "y": "0x1eb75c84e7b3375b450159e9e45326850f876d83f4d3433107be5d6565b4d3c9"
+      },
+      "publicKeyInG2": {
+        "x0": "0x242dab615b17f17cf670ebacfe3043cc34bd545c70355ccdacf8a80272685025",
+        "x1": "0x0f1fb1dc5d9e2b54c4e67f516caaec402f23e98ef8c8efd8f904669007f62e20",
+        "y0": "0x268c0bdf14cf53ba336d7232a7a78b4ef7b07c94aa803b5ab618acd35119e116",
+        "y1": "0x2d61a3e74564d51d8082cf8579173046e444a83db0427e8bfc4abf770c74eeb5"
+      },
+      "proofOfPossession": {
+        "x": "0x2405763a38763ef42f48484d47ad78ad5c1899861f5b54b90f45d286fd78ab7f",
+        "y": "0x05aefa6345dfb60ce58dc0508ccad0d12748d3a6e4c05f22f8e018f1eceaa530"
+      }
+    },
+    {
+      "attester": "0xdDE3D5F2e4AC782D829cC1c51d558c6220E51cBE",
+      "publicKeyInG1": {
+        "x": "0x2c35334d4ba0ec79591eea3e441e1ca18f013f2cff92e6ebc658c7f9bf615238",
+        "y": "0x0a6ffb6b8fe935880d85d456f0affd1509948a5268d08ac21de09d42a39d86b7"
+      },
+      "publicKeyInG2": {
+        "x0": "0x0806ee6b0541334d10d1db9656138b4eefe2a565fcc0e3eb716d0162ba21c13f",
+        "x1": "0x2b66da2589d20847e28b5bc665124d486bba143369791f8e118d171ccd171d55",
+        "y0": "0x08c3f6894c68b1c0fe35c8889e18d405e21188279aa0994af485005295a59839",
+        "y1": "0x2bf70c74d786b8518b61dc8b728ed6f007cd036b3d35696c4d6613d7915b794d"
+      },
+      "proofOfPossession": {
+        "x": "0x1190eb0d9aec42264ad239b5cc65ce48b7c3f75c64ab726bf766bbbdb415fd10",
+        "y": "0x21185802d1b9ebfe4bca3f49fd59ccedd94c898113fcc4495a2cff2f27de8127"
+      }
+    },
+    {
+      "attester": "0xb42915f83F02EE6EF3ECAcC76Da3bAb42635d05A",
+      "publicKeyInG1": {
+        "x": "0x0ed038f5e855bc313ab205d6b7c04326950f938df4f155e360b1f3e27398ca12",
+        "y": "0x282e85e61ddb9bea80240c4e0ec941e61b9dcce6ac038fd7a4b26d559b17a6e7"
+      },
+      "publicKeyInG2": {
+        "x0": "0x169f437ec592de03ce25a6a4b032692eb8cbc44ca2a18983ef3bc975a7c93527",
+        "x1": "0x0ce82fd3a8d1b8b8e02089e0a3c362904ad2857e54e71a037a4780ecd2e2481e",
+        "y0": "0x14326fee1a9e5bc290e7afeccba6823dddaeeb193df59d8fed36e07089212300",
+        "y1": "0x0ab70372ec856891cd6ca0fb8ab6e4f6aa131a87eac59108ae6661007457d59d"
+      },
+      "proofOfPossession": {
+        "x": "0x0f02ea5badf9572915228af110bc92d0769dbf570ea5c17eb26efc61060039f3",
+        "y": "0x0335f01b40f1cbf421eace58d624768c5e83f04df2896aa3390da88a02f01b87"
+      }
+    },
+    {
+      "attester": "0x1F072D90467704620b6e16FbEff57c8341bd80D2",
+      "publicKeyInG1": {
+        "x": "0x234617edd83cdfa81e59abc100b284f716a5f28e4aeb9eb25ad4fecf5bdc6061",
+        "y": "0x2d898a58aa9f76d9aa3252e8c357513ba0725f98808566c1813dd20338ef7ec8"
+      },
+      "publicKeyInG2": {
+        "x0": "0x2408c73088af843020f48fd383ea7fe3c9d2f7cea7f461a449a28eb178845bd7",
+        "x1": "0x184aedfd0d109298faa45790e488d163add06fa58a11200fac23deecf241e2cf",
+        "y0": "0x177171686c0be2c2bdb37c416153c2b6895385798e131569c2b2e2a212d1175d",
+        "y1": "0x1a613dc0549f3136a7acaa9a625cf675a9401349ec910839ed6c00841426ea49"
+      },
+      "proofOfPossession": {
+        "x": "0x187c5969b38008cd0b35ee73d2b5aadec9e6610bdae5d264ab2d28d2520f75d4",
+        "y": "0x2c5e0231b925db5e094c384f518726847aeb9ead418f5355aa40de5e538f1ffd"
+      }
+    },
+    {
+      "attester": "0x3aFef8eCA9735560A6056a9a4C397410d030C384",
+      "publicKeyInG1": {
+        "x": "0x0ca65368fa2f6edef59a49464f83723839945b53b4faf318062abb0587942a4b",
+        "y": "0x27c892b032ada0621328c0824e6799813eb5e745eac88d7b0ad2e810c72f0196"
+      },
+      "publicKeyInG2": {
+        "x0": "0x272416130fde03c2e203c00c019c8d34c984c567398ace314940997d13a61a37",
+        "x1": "0x0f7edca29089ea4fe1508b7e6c2a12853c1bedeaa2995f03684f69d2f996d94b",
+        "y0": "0x231312c089b0310e9d09965176c2d27759c0603d3bab77a0260930e4e3a50c21",
+        "y1": "0x15fa8188ab0cb0d696ef0455ee10b3dbaad74da43b5c872c53e92148ffd009ad"
+      },
+      "proofOfPossession": {
+        "x": "0x0c88d6f39e646be1c9a3655f204508c25d1ad997e8ec3b5bdfec7996640881c6",
+        "y": "0x07ccd7e5c526251c3f4fc3e9f633be5ad749fa5956cd6cdf7e0f69425edb0dc0"
+      }
+    },
+    {
+      "attester": "0xEa4818A862FBf968673a2b7632dbb17663a07DB4",
+      "publicKeyInG1": {
+        "x": "0x0e5ee9cf0d03bff64dc94a59e2c59bb515f5472ab7860cfa2d0bfae882965c66",
+        "y": "0x1979ad3afede07a31812b3eb879565be9e1b8edf345742b7f398f3ccf847878a"
+      },
+      "publicKeyInG2": {
+        "x0": "0x1ba2912efb76dd32bf551768ff98006153a566c80233887dce340181032c5e4d",
+        "x1": "0x0bc836c3999d0146f2e7711f101a4a4740ed50c9c066cafe6d27aa3fc05544df",
+        "y0": "0x2c3d283fd4f02f192a69d956a6b43d0d01a6ed88f84a0123ac19a2c4c297f341",
+        "y1": "0x1cae6b2b6cad5841300ad04ad66503a74e4ac3bebc1fae62024aea1a4e48dcec"
+      },
+      "proofOfPossession": {
+        "x": "0x17bdc3e37181cd785fad6c860024504aa3a595216988b787e0eaf0939ae5fa7f",
+        "y": "0x2b8b1db96f8a7128a5e48f174f7921a7d9f0c00f430cba529fadf1862db6f93c"
+      }
+    },
+    {
+      "attester": "0x256288A8e9b86B76cA8379F99e2AF6FeE3Ca5B60",
+      "publicKeyInG1": {
+        "x": "0x20086b33d8b33504198f9f576075d74742f84e7d308abd910d09e7f79720b18a",
+        "y": "0x2aa409af33868f514ba4bfcca023291b5722b4942aca56f5dbee8945b591220e"
+      },
+      "publicKeyInG2": {
+        "x0": "0x1722db7e37e69f871121516207b0d382b9e5e56faa26a9dd77c83425e786e45d",
+        "x1": "0x21a6bcd67fa1fd1a610c7492751f7787f08f92d282eaee0bede13b0c557d6d10",
+        "y0": "0x037407cc132e38bf8e736d1a2ff535ff9c17da913813ccca060bc95e97052252",
+        "y1": "0x2b68e108ab55f0a6ca7e20069484f34ddf3b81c6b789b8f69c762448a771a470"
+      },
+      "proofOfPossession": {
+        "x": "0x095422e24aa147489be18380458cc246b4f6ac72088a6de545b982b525226e87",
+        "y": "0x212d0178ed2901ecf7d0d90e3d85beddc6c34e63d7ff35b95db6f6a684161ed2"
+      }
+    },
+    {
+      "attester": "0xdc75909868ed9Ac64A86833091030Fdf3A041b7f",
+      "publicKeyInG1": {
+        "x": "0x0441ae54b6bf7bb040831ccfc0ace697177b2cee57d0a04c022ca4d81d75073c",
+        "y": "0x2d1d116373b76aef89cdf25d2af26286b21d5307e0e157708e629e1482f65bec"
+      },
+      "publicKeyInG2": {
+        "x0": "0x0bb83cdaf9c53fa3074a9fdf855bdc9b9facae26f6c1da265ac774eb89bf5719",
+        "x1": "0x1f1f761b932fee18f31265b2b9769e2b77721435d0fc365b2ddbc66f65a561c4",
+        "y0": "0x1eb29df8d35cb7ec464b1e46a622c3cc138675bb23645f0d695ef6f6f25ff93e",
+        "y1": "0x267cac22bb86e025f01aab36b34ac21dc78d3033192f54af942d6d512c305018"
+      },
+      "proofOfPossession": {
+        "x": "0x01ed4eff3af2cd5e9fa64d39e6c80f80814c8b23f54f052ed10c558dff578180",
+        "y": "0x0534e0c88b79dd7acedf12fd8952e4b465f9676ef4b9411aa3b53218307c0ec5"
+      }
+    },
+    {
+      "attester": "0x77cD48F0Fb8e5735F7C0ac44B5CbDde10D593107",
+      "publicKeyInG1": {
+        "x": "0x03e3b5dd680b66b8ad3e9002527b8e14521d485bdf37f5706030fb18d36bc8b2",
+        "y": "0x228b2e6380645864e48cf561bec3f940ba62df24752c03a1076bf068e9e56f2a"
+      },
+      "publicKeyInG2": {
+        "x0": "0x1f485feebf61afe07126cc11c052f08ed5cc60b6c49e88af8205af9eb3b70ace",
+        "x1": "0x14c17101a892d99786a6801940d8516f3df2139daa56799f1145403917a667b5",
+        "y0": "0x1e0e9b36a8f05b49af80ebaeff63e2a801e6aa400783b4e18f072eb50bcfadba",
+        "y1": "0x2203f47be3bd1523402e3d3e987e48538d23cea1d210d0acbdfa653296ce266f"
+      },
+      "proofOfPossession": {
+        "x": "0x28139402cc414e881ffb9b1957989aeb1fa5f2745b380273146d0cb3cd6d67b6",
+        "y": "0x11ef21156bbd084bcac48c5b535459feb7c0ee4a241c91f55208154330dc23cd"
+      }
+    },
+    {
+      "attester": "0xCbFeA3aF489c824e117a07Ad119EAB19b3fB69FB",
+      "publicKeyInG1": {
+        "x": "0x19f57acb6162c0feced602b52e01000c2dc300c2666f82d3e6970cb338e4d345",
+        "y": "0x14db3ad3288bc22c2f4e814fd3aa2c1ff33918b370278953ad72886ded679d2b"
+      },
+      "publicKeyInG2": {
+        "x0": "0x26cc715db60669323f63db96e7f40b288ba347b33ead1c6ea152a59698cdfe9f",
+        "x1": "0x287a016903cc87192e25e2125fe422d88490cff100756f58d72f14f3da8700ff",
+        "y0": "0x0be614180eb5bff7fb88d03ac778ff785df74aaaeefae52188fb3f48c6e5d639",
+        "y1": "0x1508bf9901ae2e7ce5917937322920b863ca34902851721b672dcba9ecffeff3"
+      },
+      "proofOfPossession": {
+        "x": "0x25f7956b078791fba14f40a0f238eb966108171c49eed7056e6711ae8362c9c1",
+        "y": "0x163d860ef333f395058d1757c087ce13ea52fc011423b0f8d2984bda255da836"
+      }
+    },
+    {
+      "attester": "0x29735D4BEbD23cF9689Bab167419E0E8A4695fF3",
+      "publicKeyInG1": {
+        "x": "0x11718c32c5f570a25713ff59d5d1f2f051bd185e8e2d7fc46a013336d45690b5",
+        "y": "0x0b9ca870ec15c0fde96302c5f31ad0bbf78f70f4b2876b5c4228d78cccf5f471"
+      },
+      "publicKeyInG2": {
+        "x0": "0x2570d79ad9d01f2964f3925ca4ed56ded8ca38b3e1f44978f58271c7d3843da5",
+        "x1": "0x1498759e12437eb14e83cbd3ad307b79c6ef2da0f78bad3f07c8c68105093d14",
+        "y0": "0x183017af02b66f93b1d47b78042136eca4debf1b969555a348d43fcb23d6499a",
+        "y1": "0x151d31894219f37fed778410b0ff951ff19242d17cde231511eabdb17707c35f"
+      },
+      "proofOfPossession": {
+        "x": "0x2f15789cefe6ced51444dafc7e9fe2c9cd7ef7514cc818e2a3388cdfa4a542e4",
+        "y": "0x0487cd829c45cb34d95e8bdeee0b27af074d6dcce363d0e1ced1303fc91b7abd"
+      }
+    },
+    {
+      "attester": "0x95f9a7e791820D71E29051a991db4e6091615368",
+      "publicKeyInG1": {
+        "x": "0x2ca1c7141c978359b507f4233b923df3ad72b1c2303a7449197be697071539ed",
+        "y": "0x2772b4ae9fc7146752389e9ed05378089f42d708d4c1a988e2294a97550dd1e3"
+      },
+      "publicKeyInG2": {
+        "x0": "0x2a550da95fa9fc25a4bd46700e6b2405b0d9fd75e3981222e1c6f659aac67ffb",
+        "x1": "0x216518d1d15a800109efe2ebb1b85b35ad0a81aecafed939fde90c8d0ed814bc",
+        "y0": "0x0b3e34ee0b3d604cd1df05ce9246b45e3df97152a23e460b6d9bae3a67ce63c4",
+        "y1": "0x2e008236930871bf497320d66d3d4ad17e13484e9acdd11ca4fd82511203ac57"
+      },
+      "proofOfPossession": {
+        "x": "0x27f1832f5e219671f32ba35cbb8b644d20231db692fe309efdf1ae0a88bf46fe",
+        "y": "0x01b5d1ef7e28c63350171f4be6a495ce62ccb0486b7530f23b1d16ff16bad433"
+      }
+    },
+    {
+      "attester": "0xE13e810F4fC4CEa29d897c6bd4062c7f1456bDEB",
+      "publicKeyInG1": {
+        "x": "0x239ef9e3f692d33468fc40cc00cd5082b6c61e201991c73b4831a32706926e57",
+        "y": "0x0a03cb9c7a02d95ae6e27dbc819d208537a81137222575ed8eda93cb2b243858"
+      },
+      "publicKeyInG2": {
+        "x0": "0x2910723d79a157e3bf43caad7e654e69ec316d45b9f8dbf92b7d09a25c848b33",
+        "x1": "0x06686878b2f26195a43d77e5cbcb6eb2d0c3db239b671f9f4fc085d0700b443b",
+        "y0": "0x07fcf89f3b48cdacf28fc975031ddf667ad4bbf070e8133fcd313e3a4c1fcbc8",
+        "y1": "0x29e26c991cb00d370ce530dbd409371270f1b3a0e95a1af35d963b3382d23a9f"
+      },
+      "proofOfPossession": {
+        "x": "0x098c36c16a8b97859f0969c670b4a920727a5f6a46e6498e3ba4f69ed1972924",
+        "y": "0x2feff8b6acf1b39bf596acf8bc9843881db750baf41a93759943666ab290c819"
+      }
+    },
+    {
+      "attester": "0x8721d95669c1E419caa60B62BE1170447606f5DC",
+      "publicKeyInG1": {
+        "x": "0x0e0d3f0e7856169e5db49d9dabed6646fe37d5d546c2d9ae7377b6e0bef38eef",
+        "y": "0x24fb11f8045fe8827305e66e94373dc23675d77ff2e9ffe0e28042a393eeeb27"
+      },
+      "publicKeyInG2": {
+        "x0": "0x179b5e3c099c26d71f0959cfb9002ebebcc056bac323cbd2cae7498232141383",
+        "x1": "0x0d4f5b51ddd1bdcf2e0f2ac92d413732b982c936116185a1be4f3cc736adb458",
+        "y0": "0x2ba1319b2f167dc2b60fc4517cee3ab9688dc9c1aa03a44eb10734a5d57fbf16",
+        "y1": "0x11b04b4777d75fd5b7b31f7682ba656937475cf6a8d075b2771a7ce6ff95ce87"
+      },
+      "proofOfPossession": {
+        "x": "0x19f5cfa8fe54b8424a9597d6bfea6bfe27cacd72246129ea4e91191a2d46027e",
+        "y": "0x1fcde0fb12e3fb53e0a3babc232bfde6c435fd49a9d3eacad301b84a35239db6"
+      }
+    },
+    {
+      "attester": "0x01E83cAe2Ef4a0f3Bf7C57c943ce02D1cb4c931E",
+      "publicKeyInG1": {
+        "x": "0x160171fe5bee5ed04848582f40af48f6dd1586dfca0cd77fbcf0d6e6f23cea9e",
+        "y": "0x22a891bc90d825799f89b424158e86d471dd72bebb4079a182893080ca628746"
+      },
+      "publicKeyInG2": {
+        "x0": "0x2e48127b0553bf2b38e0fd20a7a14655e99fb7076c32dd6f34ff7ee356150803",
+        "x1": "0x2ca9bdbb146a7e9e0729f90b70a87b617b565a116b7e215b85280d5f61a76427",
+        "y0": "0x2734c050c24a8a8059feddf69a18cf9fab5ec4661c91712b88bac7663bdf0703",
+        "y1": "0x2f3d09d2a7b02350e2ade70aca0f4e3361ae31e50a96ec6c04458d5d1f5ab890"
+      },
+      "proofOfPossession": {
+        "x": "0x10534de735a278e0125b490ed680ecb23817929e7eff609c85b6dcc5dd2dd1bc",
+        "y": "0x2b4633f65d9de4dfde62084559826450d7c97191a1fe04a858c13bb0bc3c8c77"
+      }
+    },
+    {
+      "attester": "0xC33624Ef62EcF780beD11c0173cEe7Ef51209a44",
+      "publicKeyInG1": {
+        "x": "0x029f8b7d3de99a95652ec3f510413fb5b01af98ebdb6030512c9a642ed1c2766",
+        "y": "0x2bafe0ec75847ade29dab1af2f2f553005d25a56605114eeaad62fb52184b7f9"
+      },
+      "publicKeyInG2": {
+        "x0": "0x178335953f840d083f7f71eafdb4e4839520daeef606057c3bebc0d31797d441",
+        "x1": "0x2c8b81514e1b5bfb9f25d0b5cfc5892dd9232744660daef00a7b54a8fa674620",
+        "y0": "0x18e385bfa7193bba1bf14566833951e78e9444c3bc28ba56bf6ea8f13fa30dbb",
+        "y1": "0x0191527435a4f2c9d2deba50e1108ebe25aace43638e006008f0558c4c5cb390"
+      },
+      "proofOfPossession": {
+        "x": "0x1c65f2723db5c4fdf7dc60e70323b2b788328be0a03ecab3208ad5a41a8f5445",
+        "y": "0x11531f840b2d7ac9517c84e7ec05818957d45e1b844989433b61c16bb571ed50"
+      }
+    },
+    {
+      "attester": "0xA073Cf01EAC11D0bf6be66477CBb8f9f42eD2B47",
+      "publicKeyInG1": {
+        "x": "0x2714ce461ff5e7c09521f9dea7e34cd3ecfb5712ecacae79835cbc8a91b2d381",
+        "y": "0x1cc257071f2b52f92bd9461e709ed6e824acdea65460e4219f1a5830e7e25844"
+      },
+      "publicKeyInG2": {
+        "x0": "0x01777093a6467bed48ab855694d4c7d4227f687133fdd373bb4ebb388612ce4d",
+        "x1": "0x04d906ff978a589a879e81cf6881ac3d4410dd7f68787c7b66cd2abc96213ec2",
+        "y0": "0x1b44c3f16df32dc2a2dc88c26b1fdbfc16eafdf290a4a0dbdfbf642c5c8c0228",
+        "y1": "0x0cb26d852c0f8f5df3b6f76c4a4094ed619bfa744481032ff50e70b592ee4659"
+      },
+      "proofOfPossession": {
+        "x": "0x2f8a70c262cbb599b32d750b1214b1aaf0803fa44452f532cb5b3dd08f4b1982",
+        "y": "0x2c2f18fe68a424874816ea14df4e6e17216a3313643118dba09a129ef764ceff"
+      }
+    },
+    {
+      "attester": "0xcD0cBFc1a1e05A18aA2E5F456912495d8E08a643",
+      "publicKeyInG1": {
+        "x": "0x20bfdb338d07b6f7e697e6a68724f5759712784a50a51cd4c074e30bce090706",
+        "y": "0x21bb42e18604859332aff6380710bb29b84bc698366d1b672e0055a601f25968"
+      },
+      "publicKeyInG2": {
+        "x0": "0x2561b4ca76df710a132dba6607ca90e9045a0371c9e94507aa1d0209487dd3d9",
+        "x1": "0x021527aec0d37e6ca1a506f1562b01106d75fb37fa7445cd74c91b28d5ce0a54",
+        "y0": "0x13b8ae7dd289aeaee4e57d0bb7d88ef1296f7aa0eeb699e0780bd2f1ec25c709",
+        "y1": "0x08ab116b3c5d183c3dd26e5f8d2a0cfe81936f3255dc5a48ef0beb07defaadc6"
+      },
+      "proofOfPossession": {
+        "x": "0x0f9b03e1c20b47f91d243be399c2fba4f4751cfc312d463e06215ecf887df641",
+        "y": "0x138aa019cd1870f545d4780d1e70002778536bece07906ca85a34f4acc445372"
+      }
+    },
+    {
+      "attester": "0x70a8224E386704760e6d64862d3AF28208DA1E51",
+      "publicKeyInG1": {
+        "x": "0x2b8631b77fac1ddddd64e9b4c790dda6aee72416a1654897da58f3540403815c",
+        "y": "0x11906bb665262a1dd524a80753b0e4bf2f30710f60c53dbadce3c467661d34d3"
+      },
+      "publicKeyInG2": {
+        "x0": "0x161a7a09d5a6440c42bd8ad1e28e75bb95d04f0255a4bb109762343f194647bb",
+        "x1": "0x1400827ff036fd3f7307a5ea52b90a2ba0251faffe0fe4aba84ecb985635d72b",
+        "y0": "0x2787f246104582788afe5ab56da514531e318dd48b2d95cc100facb63f2264bd",
+        "y1": "0x1fbb335a2787ccdfcb67e18349d446aa60ea8170fb0df550b7cd9556e95a39aa"
+      },
+      "proofOfPossession": {
+        "x": "0x1a00ec6e9ec3c377dc241c97bb403f63cece84916bd33d6f55780e7e97907a6b",
+        "y": "0x115c798d1a7b97c36812f3bc495d7bab0bb1d027fd05b219422d156d122856aa"
+      }
+    },
+    {
+      "attester": "0x65FbF9075F6Ae6832F9D46fE6CEdD7EF92468d6C",
+      "publicKeyInG1": {
+        "x": "0x1ce9139538044187cc479b4daa8d761d23c0ed22a931abbd7cfff505aecd4b59",
+        "y": "0x24087554bdfd4fed5ff19faab351425907624c7bd67a2d40827c3c4bc2e5826a"
+      },
+      "publicKeyInG2": {
+        "x0": "0x01e33e0181f548f948fd2045058fc4dc28955ee8497b6acdd5f95a549736e562",
+        "x1": "0x0218da3e733a8f627aa95f34be1be1af3b140f5512c36237d83d79d5f083b50b",
+        "y0": "0x10dc34f98242395b467d5ddcf406c4443fab7bba553a4a0b13ce4a5fafeee32f",
+        "y1": "0x0e8443f957aadef92032db74bb0d2eeb789561580c1800394f8c7aad63197732"
+      },
+      "proofOfPossession": {
+        "x": "0x22bf86c097e4c8e2e7790175d49c4fbaaff97822755197d33b0980134d9e9bd5",
+        "y": "0x1ac4d4f3a41868227a80bc1057e7d77861df20740c2dc3f8e6e0fd3f70220628"
+      }
+    },
+    {
+      "attester": "0x22De988b43C6106ab38e21B6D68CaA2D619f7168",
+      "publicKeyInG1": {
+        "x": "0x2cbe62dfc3b3f96052e9cc9d1ab74fabc5f5bbe06dad4f80266a3305fd020fa2",
+        "y": "0x052917e96a073de49c2fa93d0bf09b87952e539b3424bd12de21e0949522d1c1"
+      },
+      "publicKeyInG2": {
+        "x0": "0x00455f800a6187955b13a7ec73718af3c2cf88763ed59438eb500c49448478fb",
+        "x1": "0x2fb4f4f9d0860c6ae4d65f7070399de2cff5a8d73451adc9585bbc35a34615a2",
+        "y0": "0x01d307abcc617271346d7dabdeef13cf6a11cf51f654c32cdbf36052b5d1cd17",
+        "y1": "0x2ca5e1a9630f53bb60cd3cd2248c7857f64c849e03a646af40dcec499206cb61"
+      },
+      "proofOfPossession": {
+        "x": "0x27b4517ad01d3dadb8a6693c37b282727645bac03f3ab626faca228c78d8fb12",
+        "y": "0x0ab0ec849b7f4aeb90f622d3a109b95d0d8b0a892d7085b848c7aff9d62710d5"
+      }
+    },
+    {
+      "attester": "0x9334067926f67Ca7fbbA685B875426c1Bd122A8E",
+      "publicKeyInG1": {
+        "x": "0x2f1ffc64e9c268ec66dbd55e5abade11cf6950d0ccbd58f5080b2780e074cbcc",
+        "y": "0x0c9fcdc25f10c520c98197bfc26d806f12f4be25037fd958953bb5c09038d786"
+      },
+      "publicKeyInG2": {
+        "x0": "0x226296964acc148c0ca8c814f370bf79ff6d92b8d05f115575eb3b8613b425b9",
+        "x1": "0x0b607258b1a16d33252638ac4eaba537a2be317a45b0e6afc2a1bce947d02c62",
+        "y0": "0x08e3d045266f4893b8433ac6dd7ec47d3707c6767c15ce8df3d4c8cae552352e",
+        "y1": "0x0c2e6045eff682723932d47af5d042d16a23a04096daf43e0448a5c214effc06"
+      },
+      "proofOfPossession": {
+        "x": "0x1eee1000641741774658a97142af9f67b24984256c3aed4659f615b684a1df6d",
+        "y": "0x2b36f85e6fd733334175452b62269932e7837c87f77d6e922829ec8a79206e11"
+      }
+    },
+    {
+      "attester": "0x55B3236522f80154b16945acB41551E2275b6Cbd",
+      "publicKeyInG1": {
+        "x": "0x1e25d9671ad28473b618eee18b76b4a9efd794e1f4578120531c9a108bc31303",
+        "y": "0x2bfc4a91c70a1e50af3a6b57adbe72ba9536a91ec095877283491329f61d6ee4"
+      },
+      "publicKeyInG2": {
+        "x0": "0x0b71655fc1b6c76d80aa10b1b7ebc8c5d4831183ae3bb03a00befa3d9c8242d7",
+        "x1": "0x2635f8c6b8d13ca628e6c6991252b8b9d683064c0ff2d1e4e50d7e97dc1ca204",
+        "y0": "0x0e10a26e286bb9c088b77ae9b270bc7532177572afd83776e4f972a4d43a1eff",
+        "y1": "0x0196f3aa6fd3048b4b3e4ef468c0229d3b34bb72a714baa12ff916fbda9bc919"
+      },
+      "proofOfPossession": {
+        "x": "0x17af36e741ca69ec8935157440b7b8a40fc7350ae6b63b526fde7c9c1700ee3d",
+        "y": "0x0fe3ba244fdec0f137020f882485dcc9f4189ac3e04f290c7536585d45dbe9a2"
+      }
+    },
+    {
+      "attester": "0x0efEA9B04727Fe7c61c59c2C88AD2B1925847Fa6",
+      "publicKeyInG1": {
+        "x": "0x01c14f4e1508b70001f0683cd52640803dacaae00325ea055df50f87b2eb998f",
+        "y": "0x14f0d23f048cf969beb0d1b2a172f20e61a16f68fc13ddded2eac40d623f9336"
+      },
+      "publicKeyInG2": {
+        "x0": "0x145c7b64b70fa4edff4bc1fa13d28ef60cd78908668275226e0f0f30f2cfe679",
+        "x1": "0x2cc16bc17563123bb7f89ffb83192b268ead9e38598e204e09801b31b43ffe77",
+        "y0": "0x03a70040b52493838dd8755546f1200421e339af3ab031961d049d716623275d",
+        "y1": "0x211d7ff49cff9913ca93e0f639daabfa307df145b07048b9920dcd9190666a43"
+      },
+      "proofOfPossession": {
+        "x": "0x076498c281d6f036d4371f838c9d194916edf927d46117229044ec71e9d5b75a",
+        "y": "0x1bfdccf230b1518f971a13bb623c3dc82e41d328693bee05530c95e51a583e91"
+      }
+    },
+    {
+      "attester": "0x5E133B4f794099CF225EB25D567459615c4718f9",
+      "publicKeyInG1": {
+        "x": "0x0bc2cafdbaed747abbf2ed4212be4c0107b49b6c676c231433f46ab915a6a0f7",
+        "y": "0x15f3f4860873d077fa36456e4fa1bb9ca176364bd0d5a144f81ff270ce3ed302"
+      },
+      "publicKeyInG2": {
+        "x0": "0x0fd3242e6e9945742c03a99f1093fda6931bf54c3dd4297488534813e26c3d98",
+        "x1": "0x17c263f9d34a2fe4bc76903d385b46d09f2776d0f9fcfd4a685aa92941b85ae2",
+        "y0": "0x2dc462b5f6cc2baa433716ab0fbd36dc8ec465bb951eebe23c0eb5732a15b8f4",
+        "y1": "0x10939a4421942a2933a4b33436424d517d2e7f8be19490b765d2ca059573a5d0"
+      },
+      "proofOfPossession": {
+        "x": "0x24115736f6ccca1aa063e5365005c1e7e5aa4b44b41e9ffa9aeb8bc30888c025",
+        "y": "0x24650185b18d9eaf8f23a20348102ca01c6dfa83a37c2a3bff73735df884abad"
+      }
+    },
+    {
+      "attester": "0x5Ebf3C778a90EEAd643c61cc8d85DD51a864840e",
+      "publicKeyInG1": {
+        "x": "0x15b1b798ef01cad007df979d79e7e242902be1a73d2c1bd5c8d4ea645d9580be",
+        "y": "0x2dba716933683f69ff3cd1ce4f7f7b578a5bdf3c4708d567d8b5acd71320ae3b"
+      },
+      "publicKeyInG2": {
+        "x0": "0x192525d410766bdc0b8a486593dc4afdcc2463840b59b631391a423b11d01e93",
+        "x1": "0x00fa73a06a12856aaa248b3f16025142593c1cae133a5ba214b728fc9104b8e6",
+        "y0": "0x134effa6b0b29ffcbbe10fbb8f0a4edee680abf538de1a3276507ecfeefa8b2e",
+        "y1": "0x162b53d936d646f0b5e0daeb87b576496715a0e504a67ec7f7a9fb4835d4d5f5"
+      },
+      "proofOfPossession": {
+        "x": "0x0fac435f8948bf8788f6fc8d3887949a10842f11d9a5b02f1aff799c8c4ca25f",
+        "y": "0x24eb148ff127fef5b6657bcf0da3d1dfa848d97b4230da39ccf44c81e4e87426"
+      }
+    },
+    {
+      "attester": "0x7D33D3F0Db22D528B4A87cE2Ca304912eeE02c14",
+      "publicKeyInG1": {
+        "x": "0x2bb5558ce96db2cf54288983cb446394bca6883a5d437bc9c694261bf08253dc",
+        "y": "0x1b5c2e706ed461bf3577b003bcecf698cceb283089a38a4462e18712b7cc83e0"
+      },
+      "publicKeyInG2": {
+        "x0": "0x03817fd73489f38a00599194abbfe358cd528c8e705a8db91182ea336d69064b",
+        "x1": "0x0c78bc66ce28a009381d94c7bcc7c3eb27ce95703123edafbe70aea9ec4e372f",
+        "y0": "0x141945a1f683345d3ede2f1fec3f9c626959f1fcec0fe8032e75150a13e58d27",
+        "y1": "0x2fdfc11aa9fb2929b4f399f3b3ba32a5c447894b1be48e245d403dc03c8f9364"
+      },
+      "proofOfPossession": {
+        "x": "0x13f308effa77bd41a17c4460a570f3e0507d358c0054122794a16a7799afe3f4",
+        "y": "0x022f533a50f2836e05107161bca691e4e9a9cc6e731208517732b6eba2a6f4a7"
+      }
+    },
+    {
+      "attester": "0x119cc8f4472eA8f061179893d28e568A0eFc0F3c",
+      "publicKeyInG1": {
+        "x": "0x04522e94c6905e7113ee79be1063d5e8601a7e42a3e8385127d584597fe1492f",
+        "y": "0x27e9bc119d236ed587c9268351da4610210c2df0d085724046fada788b4e0fad"
+      },
+      "publicKeyInG2": {
+        "x0": "0x07d6dd72837a0e6e2a7b4fc843b5ab78d155768073e7da1ad856f08f590e9430",
+        "x1": "0x0b944f824b4a3d2e84dfaff8ea4afad9efdfa213e938f5df06fd4561003afda3",
+        "y0": "0x2b89b5905d59fd14d7f259a5d1e104879f3d4cb3834626114c729bde2edd2f07",
+        "y1": "0x2ebed3efaa5480ec1ba4b3ca5c8a84efbbab79de9d0a203be4d332869f59e805"
+      },
+      "proofOfPossession": {
+        "x": "0x2f3bbd80c63ed80d0e98b8ae529948a611363f49d0bdf84ad567ef49d3659bf2",
+        "y": "0x2fff75ba770d2060b3e07512193f5c098dfcf8ea34415ec9aa0c7d6d161128e4"
+      }
+    },
+    {
+      "attester": "0x9CeE81D27Eb056BfeD0f6b3eB61048418D14526B",
+      "publicKeyInG1": {
+        "x": "0x073fc718770e458baf5465c644919f202cc0665ca3ddcc328085bb38cab3af25",
+        "y": "0x136278f141b8995e4c3cd17f35c6abe6b35961eb68f49b4d9412739e0f1d69a8"
+      },
+      "publicKeyInG2": {
+        "x0": "0x06096f9f6664a93608bf810cbdd862c402057051fd0e27f1e87d53abcf04ec02",
+        "x1": "0x27ccb75d28e5cfa9a09774f2d21eaf61033ea36b14c9f6c43991f4a531e0b210",
+        "y0": "0x29fe346f9f2c80a01579339b6ca5373245c43eb24d828455904a70128135eac9",
+        "y1": "0x0289782b103d33f2efc18a2a665ccde38762ca3fdf9d1ae2bf4461e2ab213b7c"
+      },
+      "proofOfPossession": {
+        "x": "0x16fda44775511954b6fb5bab3aa0b34fbc877952368aa316e728e0050ce30734",
+        "y": "0x26bd4b0be9150b21afa8101b1f39e79fc11c23b4dc6486a6a92975ec3f60072a"
+      }
+    },
+    {
+      "attester": "0x946F38Ba619e91069C1480f88b2D29Ea1931FF40",
+      "publicKeyInG1": {
+        "x": "0x298f579015dee5f6597f88619359d90873f57cae30e22d35c86d48dc1cf627d8",
+        "y": "0x241dee9fccc55336134ec576f657eb0a5dd1daf15f0d5effae3c2b4b0e75d32b"
+      },
+      "publicKeyInG2": {
+        "x0": "0x2c3434cfe72b381653522440e78c8eec4eb22143aaee967b497022dc8d9eeb3f",
+        "x1": "0x17d83e3411967982733bf604b884a98ab677b437cc33136af7df7bc764dc1ec6",
+        "y0": "0x0d41b91720cea82b033c9bbfd0c5b4715eb4e24e2fa13f3320875552023d01e8",
+        "y1": "0x256c38cce8b2ae628840c91b8e640bcae0ae4900ebadf88170e0a0a3f5f0768f"
+      },
+      "proofOfPossession": {
+        "x": "0x26d9c5c887ed7f785cf1a3b008441a5b74e07621e98cc02f13b93957ed4fd8ec",
+        "y": "0x1772b9b20a1588cc16ece571a799f1b0047d46a28bcb8bbfb070e744a942f6e3"
+      }
+    },
+    {
+      "attester": "0xEFBfd91C680fC354b1936c8D2b7dDA82ed6e446c",
+      "publicKeyInG1": {
+        "x": "0x0875bd2ceae9045c977aafdcdd7951bd22435dc4fc3a80543f8b4e20463235af",
+        "y": "0x1a3ae53d45f1d1b866bfdc524b1fa9b09c7180cd6516eaea13c93eed86e45bf4"
+      },
+      "publicKeyInG2": {
+        "x0": "0x077df624eb58881e56c5762a1cb7e010ee991050fcc2a8288fca59904500a5d4",
+        "x1": "0x0f7c8e37e8728719e486fca4f124d4a3d754471c171418825b9b61b326ed0c5c",
+        "y0": "0x1506c38f9a2062e5c27bc664ee099b053fb58d6a24e71dab6bee3e155de9ff44",
+        "y1": "0x0e6eb3b78bdb732d475d1b0e014801376c67f11f1be77c21efc7a25b0d0fdd5f"
+      },
+      "proofOfPossession": {
+        "x": "0x283edecc2cd4eb5afb997e837c7d7e535585442c130f10fabd316b49d95b8c14",
+        "y": "0x050151c88219f65a1063520c3534654f54176ef46256a42a138e0aacd2035398"
+      }
+    },
+    {
+      "attester": "0xB11cCDD473B9d182200805dda8042057ef4Ce34F",
+      "publicKeyInG1": {
+        "x": "0x16ec94135ce653fb69fdac8b0621efac528dc7ce749624f8fb9fab82ab411b3c",
+        "y": "0x1ff8848992f45ffddf40d2e20929f42b545eee17a0c7789be9cae6b98efdfb37"
+      },
+      "publicKeyInG2": {
+        "x0": "0x07d2639e6a283e8387214036360a3331fdda2109da57a3242855edb241cde806",
+        "x1": "0x2c8bd17d6f9a3b152de2603a31698b6a9f040d442a5606a34079a304acabad16",
+        "y0": "0x074a82232f73e9a9075d3028d00175a0c3d54cceefc576bb0e114646c1bd5f7a",
+        "y1": "0x032cbd3b6112f3517717192d61fa8cfc2bd3b963dad9e2c436e66ead5a1d0e91"
+      },
+      "proofOfPossession": {
+        "x": "0x0fd41a12ab9f35e5a997e68862c426c0bafec47f3a595f5e1e339323387087fb",
+        "y": "0x08dcc509810a4d712216a40736f2ab9c862a97e062beae781fe4d4bde5a17281"
+      }
+    },
+    {
+      "attester": "0x397a373b7Cc119Cb2b0406fCa8447C44B1E34F09",
+      "publicKeyInG1": {
+        "x": "0x14c37699f83833f02a0ab992598e1bae0425306c92735fcf06cefe9eb51e9de3",
+        "y": "0x225bfc75b8f69d7698efa72544481bb1ac93287b8220b18ab9473d72aea7355c"
+      },
+      "publicKeyInG2": {
+        "x0": "0x26b67a53368f62604c776ed75fd3dcd710dea3c66badd3c9768f0675274c6a75",
+        "x1": "0x1976d966afcb9ee1ff1db2d58453fd7252db4943b0ebe20fdbf9f1eae0ea4caa",
+        "y0": "0x2dd4123d31413d8a82907efa2573de1250a3d4d9d408c17fa999d39192358a08",
+        "y1": "0x12c77e7e6d55598fe99d96ab974bb625653a151e9fe23a6370c4090ab74bc3df"
+      },
+      "proofOfPossession": {
+        "x": "0x2a3c2e1a623d264d5a8187bd79164fa6261de8bcbd4c3ac005e3abfd9105b4e7",
+        "y": "0x02c124338cf3dfee542c9200cbd9155efdce23589382bfcf8b8e0c1a05440a43"
+      }
+    },
+    {
+      "attester": "0xCF7cFa438a57F5fc20c51ff232BdB956Aff0Ec54",
+      "publicKeyInG1": {
+        "x": "0x08a0408948433fd2e3b65b62fff48ec3cd300ffffdaf2f03b14bb0956a26c4f0",
+        "y": "0x08c35b8ddddaa25887d4625bb3833c4f88182d305ef2351e440101cfac3681d7"
+      },
+      "publicKeyInG2": {
+        "x0": "0x1748a44c043af689062fcc0a4bf73650f5a307ebed3c6c526c96835009108d12",
+        "x1": "0x2f3c9249f4e7ba254da765cc5f1638bde9f3da15f1c0079ff77dbe4efc788d38",
+        "y0": "0x07e2cc8ec6edbec21e33bae1a1e3226a35856e6d58a66ae1df0d603c222ab02b",
+        "y1": "0x123a996c0ad3ba0180ef8c96f87600950934534aea513028a72bb16aeff7180e"
+      },
+      "proofOfPossession": {
+        "x": "0x1e62d1766e09f38a343ff540d0fce07af2265ea75b28c476d89d112797e4fc03",
+        "y": "0x0c75cbc4253830995af44bd75f97af82935ccd8a0cc251a6dd6dba668f7a67c2"
+      }
+    },
+    {
+      "attester": "0x28b7D43C60951cc06d3f01332374f84227e12820",
+      "publicKeyInG1": {
+        "x": "0x0370a6f0a1d4f7f079dba4686c1fd23d4205a8616194cac0dc854ee18e7943c4",
+        "y": "0x04a066b48d83c5cd475a85e5e195b3cfd154aa01ed4b85fa9ac3427bdc2ef93f"
+      },
+      "publicKeyInG2": {
+        "x0": "0x078f94ef04be439fc5805430f7bc9975c0a400d9ff7540c812fcb1740c87571c",
+        "x1": "0x18ff75bfae1f8b500ce03986ed6d82960569cfc7b82e9e0fbd2013b0c0f7cbec",
+        "y0": "0x1091eb94f285b4968ed6ffe35dd18a310f02ebc8620a0dfff3d6a368543ae1ed",
+        "y1": "0x25343369da2f9d30b206759925dfd959bd99c3a9bf6d0900a1d6677e29f1c266"
+      },
+      "proofOfPossession": {
+        "x": "0x2a6e88113eec8bb10b46ff6092ddc79be0077f7f338a6cfb138512cdfc185a8d",
+        "y": "0x2ba4b6721d425e331a1320c6bfb48966c1c69d68a034d96cd98a5c18de97840a"
+      }
+    },
+    {
+      "attester": "0x653E3B27D94ABB08782f8155D6c76e3f30A576DF",
+      "publicKeyInG1": {
+        "x": "0x1e43c1103c10ebf568ec40fd2163fa9530f7b97e7d4082d30e71e70b3fe67bf8",
+        "y": "0x1949a92b79469c079f331818171fa83e371fa6eb2d0e6bd19bab890680027aab"
+      },
+      "publicKeyInG2": {
+        "x0": "0x05457915116ada11803432dbc9226554a2fe9718865400efdd924924957af2c5",
+        "x1": "0x2390aac55e5b36b546448e01bdd89c9358ca84d8fe29b00906883cdd73f8e88a",
+        "y0": "0x1d6e51d606f392eb79620f7dd6f608d8358e4ab550b4198f73044206c7687c27",
+        "y1": "0x01d676828f0f026f8e7a43d2ff528eec6565f260e9dc4d2593b485267437e8ad"
+      },
+      "proofOfPossession": {
+        "x": "0x0d5387c1eb434346af12a164155d8e1cbcd7b41cca3a29e2c50daadaa682ce14",
+        "y": "0x0f623810a5060fade0850aaa92d9a13fa1458f681dff7d2dda1902fc2b4bbd94"
+      }
+    },
+    {
+      "attester": "0xcb4F73AD2f12d7Bce187c44A3689759665f1c8dB",
+      "publicKeyInG1": {
+        "x": "0x03f9c009d05cc1b93e4873f179f20bc5375422bdfe859c5fc971f0df986668fa",
+        "y": "0x15cec3bd583142bf4d8ebbe5267eae780964ede2c442337d4eb7d436e662e874"
+      },
+      "publicKeyInG2": {
+        "x0": "0x1892d53f0b289360b1c17231cb7aec268a26bbbf021775da438284e4f150f3f8",
+        "x1": "0x221dd7c8169548701a74a0d9229fb700ac3badaef3dc0e00790297912e27fe90",
+        "y0": "0x03a6fe09fd8808590dea6413f75fb94226b14fdeaf738def82c36afc7668f41a",
+        "y1": "0x14c02d7cc9598ecc905ecd0dd3bd093af87c0cda8cf46f0e463e68d3d9470b3a"
+      },
+      "proofOfPossession": {
+        "x": "0x08ce35086753c7a963fe85829678cd86819e5c87a842a8e645d9543a236cda1b",
+        "y": "0x0410ca7e708f4dc50b60b0ce2ac3cd4707eee02bbdc809e7f8614be53d408253"
+      }
+    },
+    {
+      "attester": "0x137770b6F607E4914A74e01aC90AADB770B1103B",
+      "publicKeyInG1": {
+        "x": "0x011902f18444c2a0bb146a2dc512cffe277891cb29d9628a2d06f7afbcf1de9c",
+        "y": "0x03a1798a4941f9f94d910ddec32e072c8c0a96d6f991329b98f3f13dd9802086"
+      },
+      "publicKeyInG2": {
+        "x0": "0x2748529f837b2fa393087e0d8845e2f72b9b37e049edc6c9f31116a694b3eedc",
+        "x1": "0x10d9937a2a39abefa8edaca99082aeb59459470e0afacc1f287a4fe2a387ec07",
+        "y0": "0x14598f6ef6c0fc8be0c0672e371f3d63069aed9113a83da2892b3949c72b054a",
+        "y1": "0x2d890a9929b0dde56525cdb4e780e549d23ae8b8f0118b48f8c71b3fbdfe937e"
+      },
+      "proofOfPossession": {
+        "x": "0x2cd46b50e9a5c965e0193a71adfdd213d9c83b3edc403c21d1adb57fea311dd3",
+        "y": "0x0fc9db50f75e23e1c205f37bc2d0fc088e7137f37295bace5b3b81472b861f2e"
+      }
+    },
+    {
+      "attester": "0xC92e1e56de65953B33c6C53a1EEaa922898a5c00",
+      "publicKeyInG1": {
+        "x": "0x19e5004e94a2b5ccca50559082a79be48de578772a5148af61b400eb8c59f9d3",
+        "y": "0x263ce438f3d28ab4329d81214c98f5b5de2b3d10a0fc88336bf1f0710b8b7c30"
+      },
+      "publicKeyInG2": {
+        "x0": "0x0e1c443537ce6929bc1998c6864e97ceaf74725940c3f162ce31106fce3b5d0b",
+        "x1": "0x2b17090f3a6247dc48457c0340e5daa22bfccc4786a8e7629e267a27f454a203",
+        "y0": "0x06b3e7b881992ad88950097288b6df02ea11c1104acf3de807633aa3b694d9d4",
+        "y1": "0x2920bf6599fe66801c6a46c9a9fae5c833b7baf4aa21e030543e89b29216bbdc"
+      },
+      "proofOfPossession": {
+        "x": "0x1bad5dc96881b125cde91b558ea3ce6a3758c9a7d01dd21f963b53a8ebb72bfe",
+        "y": "0x15d17ecefd399bda1f174ed19bab9ab8d3cfd20cd70e9cabab3a0c44ad42c6f2"
+      }
+    },
+    {
+      "attester": "0xBef1762e6E33104cbF7CC1B31535F1334658e9A8",
+      "publicKeyInG1": {
+        "x": "0x01a2934d353c1fe65942777d7922510e4d71d793b926088ba26f9220f35bfe63",
+        "y": "0x12692eb11dda2c19b78d048f6e2e57cf1b616e1aa45a658d3c30dfa0dddc648c"
+      },
+      "publicKeyInG2": {
+        "x0": "0x0491ec3ec9d12237fd6e9cd6a1a22f9ac52257b0dff4d612665bc31b7da8fbf3",
+        "x1": "0x1ce820c7b4696f48878ef0af648fbc88e7a9d68118bc51e8abbbfc58d8a73bc2",
+        "y0": "0x171f3312c3f7eebc40ee05a0d2fe4bc38df3cb15f9950fd4f5c9d16c89fd6026",
+        "y1": "0x02a5ed1756f741b1d56729f7eb89a61776c9ef9561efa0354b8ba310d5c1c22b"
+      },
+      "proofOfPossession": {
+        "x": "0x05e62017c170e41f61b49252cbfb7db6230856dc08aa9faee9c19c93525f21ad",
+        "y": "0x0fe0769a5a833ac28f06f1d6e0316180f64c94712110044028d23f3b468f0e8e"
+      }
+    },
+    {
+      "attester": "0x7c4a9830a246C81438B81700D4C72B420db6104D",
+      "publicKeyInG1": {
+        "x": "0x0c1c9359e97224452feef5dad4dc1691886271d80b8bd1bcf7399d70716a3763",
+        "y": "0x02ec337ae6672324280481630ee46d67f69cb917916f78321f6506093f2b33b0"
+      },
+      "publicKeyInG2": {
+        "x0": "0x24db27e64ed986961f903d5503565c43b751d7c43682b1b97790ce1ce8a3f2c9",
+        "x1": "0x2241a9f877143859efe902edf591c5a6902dbad66d71380e3d3b2b8c519be63d",
+        "y0": "0x0ead03f87bcf899f1c4f4911528658bd55c461ea2eeaab87c5b420a376f7c13d",
+        "y1": "0x1c87fb3bea4f19500f1ae1753922dd2b2478ffcc43274def6fe5f4176c55cd27"
+      },
+      "proofOfPossession": {
+        "x": "0x195991451f7c54340ff627a351cd31b50558019f23b7470b5eced3da42ab2441",
+        "y": "0x2fa463f38452a4795cc6e0b9cf1c87c42ea9869b2e8a2f6a74f09e6ed901696d"
+      }
+    },
+    {
+      "attester": "0xe631ec7d6f0Fdfb416500D7Bf755A4d403D9f5e4",
+      "publicKeyInG1": {
+        "x": "0x2420ecbc01481bae5bd2640f9e731e0ee487e765f5fcbc1f6be1512d470cd4c1",
+        "y": "0x220214139d9f48e79560bc89b6f522bfabd476df5b0d39a375985f532a5363ac"
+      },
+      "publicKeyInG2": {
+        "x0": "0x24e5f991f5cc1de237ff238645521b55b04edc2d79b325e29a9a2df7ea971b38",
+        "x1": "0x180d4a56fc16994db4943221c40d68e04b747f64cd1878d06ef90786408d2424",
+        "y0": "0x0349cabeff0cdb78d668aaf0395534ade4ee225711e358c96b7161442c19f571",
+        "y1": "0x10dbc71616702da4bb941169cf49c0473b06d7c2063c4cf7e9aea4a8672c3bbd"
+      },
+      "proofOfPossession": {
+        "x": "0x283a23d23c63fd670b2abf4af8ed99f6f7e75d622bf413f1420b7ed4a77c6af3",
+        "y": "0x03d6d81160b2731b928e1aa0a99dce686216ed58f3254e6c510d8d66f97bd63e"
+      }
+    },
+    {
+      "attester": "0xC2e7acB00fC980f6cb1747665549e76008b6d74f",
+      "publicKeyInG1": {
+        "x": "0x2d12eebdc45515ee412edc260934165113ce022ba9cc8a24f9b4112d8b560efb",
+        "y": "0x0f6846596333d9a24dc0885abedbd60ec76624c19ecad5c042a650e00789317c"
+      },
+      "publicKeyInG2": {
+        "x0": "0x0ae0e5192c61748f590435851618ea08d22825702b53922e7c85f32e39c663ce",
+        "x1": "0x302a0474481e5d77e1c8fbcd369c92099bc067261f3f0706d32ec5d093d96320",
+        "y0": "0x13ec6e65cc699a967842dd31835caae90a45aa48f9a1f7fad42f76245b553b68",
+        "y1": "0x2d727aa50771d6cf6b0b43d816f25ee692457fcc80bf630500eb970d82b13bc0"
+      },
+      "proofOfPossession": {
+        "x": "0x286484f3feef168e3c45f69293b76a32b26a5e4ea9c2f9b700e6b00a6fbd24c5",
+        "y": "0x2cb92c908574cf37f6ac94ea1638b7fa189010ae9cf9c1c94a8fed3b00fc7da8"
+      }
+    },
+    {
+      "attester": "0x44f6A5525491d3520D8b3D879d8FdEedFcFA2c47",
+      "publicKeyInG1": {
+        "x": "0x07958e4b47accd7fe94a10e9a98e01fc82f4fdebac3b19f25720034868506c65",
+        "y": "0x1d8b36579a5275bbc6376a2981ebea4182412fea10dc342871ed893e347fd134"
+      },
+      "publicKeyInG2": {
+        "x0": "0x0f0b91ad534a4f7af671354620cc51b721eaab89071b9b64907ab45da14d5f36",
+        "x1": "0x22b30ebb0b7675d6a34137316907a207011bca069529ad7f378975ee928ee68b",
+        "y0": "0x249135547c0d53008e1743217fa61bc63156466c3c3751b5be92614813028d42",
+        "y1": "0x0fcb9b2b2e2de43ae86d66f24e51ea7766cf3b19d947baa18dc2ec036356579f"
+      },
+      "proofOfPossession": {
+        "x": "0x1c4fc36adeb15b7f5dae57516f0bafe96abbeb60a74d1313830882f2021ffc0d",
+        "y": "0x22c15edc8d576bffed2bffa3e7528b6b47c1bcd62eb0bc533dc5631742cada10"
+      }
+    },
+    {
+      "attester": "0xdc2E4a7ca46D5362fb754C973c127C371C0dd321",
+      "publicKeyInG1": {
+        "x": "0x06ed30252cf76f8c9d0c23810ffcb61bce354a18d537bae075be336a32edd591",
+        "y": "0x2018b039586854542cd3615e8159d5cdbd8e906b78aa7c216b58727bfbbe5bb7"
+      },
+      "publicKeyInG2": {
+        "x0": "0x2866d66dda18734b3bfafa46a41beb5edb2ee7eb3d951467f315d49b7d1395c7",
+        "x1": "0x2badfd275c077903b861365e2565313fc403efeddc514cac0826a1e463464667",
+        "y0": "0x1402d9bc331ad53241067e431e874ef2ed06c507076fa4c64f7ccd1c6c768b46",
+        "y1": "0x158d2ac252f4b5e431a1dbc2b5cea34ff6a681e1ecb7ef38af46c484e9d04145"
+      },
+      "proofOfPossession": {
+        "x": "0x27601b7c195ab9107a4610c637154f508a54dcfb1f2696d8385fe577a33e0647",
+        "y": "0x2a68fe065b95a3918a5a3ac71dc8b4dddfa509541a7fcc12eae3509d4c186126"
+      }
+    },
+    {
+      "attester": "0xd56bCCC6dDb9179e5Ad17D4187a971dCB945e064",
+      "publicKeyInG1": {
+        "x": "0x0d480873e9489c01fbc28694d28d638552f3bc1e5d252f487a727cc98cc20277",
+        "y": "0x200ee715646b5e6e9602e4dfe0e3c20360ff1d5e8511269f6c0d5e4fe2f5eaeb"
+      },
+      "publicKeyInG2": {
+        "x0": "0x021a4ab3fdee46722c54a51b98d916187d34993af8a07565b4dee0bd0cfe3def",
+        "x1": "0x174c422a9538eccac5cadfd216552077de6494b3e52cecd73305cdfe583e8fac",
+        "y0": "0x164718eb92ea4af0f5c16982430d40df3c037cf07020b65b0a3ad459262c71a8",
+        "y1": "0x02b4dd76d9eec3d6079a968e569a4b7c540d63e0d18bce8010ed690b8556a0a1"
+      },
+      "proofOfPossession": {
+        "x": "0x217705f07fc0588411d50e429b58d733f369d792ecdea9a57bb8f84a06ea8218",
+        "y": "0x1bd348292f05043c321e49f2247349b3252c16703e4c18e6837a3a74baa10957"
+      }
+    },
+    {
+      "attester": "0x6fE89Ac502967884e46eF2B96d907822c7754852",
+      "publicKeyInG1": {
+        "x": "0x10449bd430def8dc713d13d062f3c3514040f16548ca5ee261b082dcd48eb07f",
+        "y": "0x14a7ba3639d4eae54632f0300afccd696e5b4f875c1bacbc5e6211fbc1c3c346"
+      },
+      "publicKeyInG2": {
+        "x0": "0x2ac057e815460a85f3fa80c490a3127222a1a86c0effffcf7e57b15858c21995",
+        "x1": "0x24a0775643b394a86a34055df4cc60e92faaa313e821b5c7ce3e7cb5c181faa2",
+        "y0": "0x2cd63c6344a8ebcb6fef1e739d5925dc203cffbcd5d9eb686b2f5019ecb11739",
+        "y1": "0x0b03031e0a904f111ff2814684015e5277bd9e2379b78f76729b82c3fe170468"
+      },
+      "proofOfPossession": {
+        "x": "0x18627b24ccd0753b5103cbaf0501833ce4e009025b3aec92c053c61eec3547b6",
+        "y": "0x0849ea588f7c7ede7ea6fc5084e7376b7c6db77b4a29551d7ba021b3d545a517"
+      }
+    },
+    {
+      "attester": "0x5e0c2615584f1905aB4cd7341C019eA1e4323663",
+      "publicKeyInG1": {
+        "x": "0x217549ba36039cb9569317a9c158221ca518ea50e8bc264d2236a4a3a87810de",
+        "y": "0x229e2179ffd52f9b24896457829b2eb0131609cc11bbaefc88bbd6157384e245"
+      },
+      "publicKeyInG2": {
+        "x0": "0x2ff7730343e9095c86f91daed90a8f3b0653b92a577ba608fbff35f1c53af7a7",
+        "x1": "0x1717f5ee4a3eba7126e5196163a1f769f7cba8ed2fabb5f9d4ec9f0b7d4c00e3",
+        "y0": "0x2182d9babd26faa397f40d54ef46a29d98927ca998288bf6e7fcb61e4f17834c",
+        "y1": "0x25ecbe7e8c75321fd4d191835e1251b3f7671ed26b1a2429c1e1f0593e6f2b1e"
+      },
+      "proofOfPossession": {
+        "x": "0x192e15ed38eed45a8af84ebc9a968283a1d53fd51c5a03a557401ff6175e1ae2",
+        "y": "0x1c9907686b75d15bbf6689e8e03c70cca0039cec8c6579e95859379782c88ef7"
+      }
+    },
+    {
+      "attester": "0xDa0656D1A6d1ED158D7dcBbDEBc83c5e22928586",
+      "publicKeyInG1": {
+        "x": "0x237c1dca63e83a93205167d5199fe4cf55205c42bf2a0f35a4e39f4984095edb",
+        "y": "0x1bb4a0f15930504f9835daa446d9793dfb43cad98657e50c8b65ad0d8f53baf2"
+      },
+      "publicKeyInG2": {
+        "x0": "0x22806d585efda1245cce4d6573ddc5ba5a7f7ed983f5f00c75242c36e9fdd810",
+        "x1": "0x12a89a12d124115474d213a08118a274ab1b008605f966d7203dc21858defd7e",
+        "y0": "0x13206cee7820f28c60824b63e52c8f5f2e825e1020f8e120c4df81d21bd1d0cd",
+        "y1": "0x2a5ecef82fc339706aa55f75a2ecccdb23678cf3db34f72df23fa38a637d90e4"
+      },
+      "proofOfPossession": {
+        "x": "0x00fa531b78a9c1368b026c2557fb8b7b033bd5f39f1210e99c64f4db92eb1aff",
+        "y": "0x12df2586b2aa7062d8b80ec24d983d41714a415c42d0c58f273b5f12e5c04b9d"
+      }
+    },
+    {
+      "attester": "0xa713306ED802C5A16599B5821fbb8CF9D4cC2c94",
+      "publicKeyInG1": {
+        "x": "0x10175ced6e5d78b313b045ac0a31f7305f091d297d23667058887b6ee674b94f",
+        "y": "0x2eac2ee35b422cfc685d7e0d306a7c1eaedaabc2cb204d9f8be48a13018f8401"
+      },
+      "publicKeyInG2": {
+        "x0": "0x1988a474565ab60ea7c6fcd3a543d26e5023f961d003d3f520cb9196f0194f9a",
+        "x1": "0x0a748a6808ee9dd0ceb1f9247ad9c9e5cbfdddf1391ad7cf109b4fd7c913bfbb",
+        "y0": "0x087f0af9bcac1838a18592a5ce6213484966222144ad359c19a10328b8bd5d74",
+        "y1": "0x274596e462e6321ccdf5acecf270d5f8ed9087386ee310f1d49d22c73467f6a0"
+      },
+      "proofOfPossession": {
+        "x": "0x01faab49377288ff70fdcf171804ac5d29c08e6bdd9d19b706ec0d9fea2e1e1d",
+        "y": "0x247438840666a49054ee5d25fcb2f320dd5d85d11178d90cebd066a35d4a7514"
+      }
+    },
+    {
+      "attester": "0xEB82DD3d16421e58C54Db6bcBdB54F6e7B83A7bb",
+      "publicKeyInG1": {
+        "x": "0x0189f6564892b101895c23b51b461e9e760fe36c19dce400ed4653ec0663bf10",
+        "y": "0x0a65703434f02529cfe841595b43c816e167b344d108ec2b8cd863bd8b2789f3"
+      },
+      "publicKeyInG2": {
+        "x0": "0x16503058ca3ebfc22eee761aa18a8c615022157a3812132748d46fc06ee86bba",
+        "x1": "0x25f7254af4c23b28a85afc81a2e7f5639468dd30d3d857898d1fe8a4778ee9b6",
+        "y0": "0x1c40f71282abfa1bece2fd2bf862c13b14e7923dc055550614c3a7733be74884",
+        "y1": "0x150991cebea84c5a5dde57e6fed07c136325d5c15a130b5f4eeafa5bea2f8027"
+      },
+      "proofOfPossession": {
+        "x": "0x0218f9321a019a9dca44e7d85fcfdde75185beb0e3ee043fd905294f475ac6c6",
+        "y": "0x09fb5670c1aa400d13fd5362e852bcbe93522c438cf73c2db6c71722539145a8"
+      }
+    },
+    {
+      "attester": "0x95D89d4374D14c4eFB9Fa73F1Ca51a2cFB33F0a6",
+      "publicKeyInG1": {
+        "x": "0x2797dd95a7fe10ffae0b241339fdb4dd89131807e3982012a22d0aba76e71405",
+        "y": "0x0103972529079d6628a88e5b2ed5356c8739c287190a87b2dab6918ef90c94a8"
+      },
+      "publicKeyInG2": {
+        "x0": "0x1853d33af448375c93bca07c91a9690251260fe493bafb0fdcb37a144c127259",
+        "x1": "0x2fae9dcd6e592d9f31292259b66f2d4d45985e95836d4586c0cdca5300ad6562",
+        "y0": "0x072b6dd5b2c514b77752bc76ce68ad8d89bdb3217cf033bcd1bf142245deac43",
+        "y1": "0x03590acf6c6b48cc3abf712d4f79a484c02b1292848888a8d74b1414729ea121"
+      },
+      "proofOfPossession": {
+        "x": "0x08f6a7e86d3bbfa1438ad48bd25d3e256ab3f398292bf680430c9be79b134817",
+        "y": "0x084fb858c3550f233ce41508ac21ce78b3df95c6d4fddb8f17a629c58752c3bc"
+      }
+    },
+    {
+      "attester": "0x241618e649868953abF15AD2281479e84986C9C3",
+      "publicKeyInG1": {
+        "x": "0x22e945bf806521b5674374f1db4863391b291673ba8b5017006e8463dfcf0fc0",
+        "y": "0x10fe364b29f9951c40cccecae7c192e42cf8e533094d2c2b2b423bb845189618"
+      },
+      "publicKeyInG2": {
+        "x0": "0x12418a7632f05937f32ec870ea8792b146d7ccc8d8a174dc46df5bb278f4a5d8",
+        "x1": "0x2d364167896543b32d7439b660a3df40db68191d5aba437faf11ab2099919382",
+        "y0": "0x13f2f78385b9a954f6d454b61e14af1e47ca3a9ee22a9bb2163008fc56b4e55c",
+        "y1": "0x2cbf868c8f1c16c1c851944299a336d37b539a72039971fa9df5a9f4abe19c5b"
+      },
+      "proofOfPossession": {
+        "x": "0x15655f22d8698be32a1ed8c518cddfb19daeecf75ee16c8bd102868a3ffa09dc",
+        "y": "0x29564acb70f878bfa99b80c8488274b601109289c2b748a8046dd4318a13edc3"
+      }
+    },
+    {
+      "attester": "0xc160154Fa57BB10eAd101B739C1cB5DFD48f501f",
+      "publicKeyInG1": {
+        "x": "0x063ba644fd60de9ad1e76d3997bb2c0929c6ef6d4fac799a9ec36aedf65af26f",
+        "y": "0x052d5a9891f53a90dbe33ede5ee9034464957a10ea0ed3c834c94531c4039fe1"
+      },
+      "publicKeyInG2": {
+        "x0": "0x232af331f58a0715b04a501427eee0a503e042ea16d024e237df0c901aba9d48",
+        "x1": "0x246c4999250c81915fe69c4390b37c374a1f9c8a3e79bbfa57d431e017240c4a",
+        "y0": "0x1733136ce22b88ce7c54b00f0d87cebf37788a7792da5e7bb12776ccd51447e9",
+        "y1": "0x2caea16a9133f7427d22b0c8d36abd986ef43e52a18c94ca9474c4ab61a428aa"
+      },
+      "proofOfPossession": {
+        "x": "0x0cc7de61ef84f1616797aabaca9c87b41260928c41acc643b295cf2ec76ed64d",
+        "y": "0x2e28cd3cf152600548a2bd69dd84da26e161bd6b8a91773068815c00c57e0d1e"
+      }
+    },
+    {
+      "attester": "0x5488c67A1408aab0D26D01E2B12a8cc41de7C7fB",
+      "publicKeyInG1": {
+        "x": "0x120409e828c7bc54716ad1f474e375af2ab16c853d5864366e0aa93e69b8b09b",
+        "y": "0x04ec8e954f2e2821979054cc37338ac4353e859b0d0b1302c658a50418940268"
+      },
+      "publicKeyInG2": {
+        "x0": "0x2678b5c3ba0d7afc3c4e1f020bd96f2554d0314ec26ce21c12ce328e532df662",
+        "x1": "0x2dbfb37312163a63f62f85c189ffd81ea88ea84d1eba31230e3b37ac5019c8ce",
+        "y0": "0x006d1f51de3aa7ca3f0384e4e089d08552ffb17f22c234ef839f0be764cffc36",
+        "y1": "0x027fb29d7cc71d8c13ab317df65873606ab6c8f87b22a016c0d8a303253e7ff9"
+      },
+      "proofOfPossession": {
+        "x": "0x1716300350cc15c8249cc5c4688bee80254a9f46953de859a9d6f91091f15245",
+        "y": "0x22c28f304df9755ba25ca9894ff6894ee94497fb627bd8b0457f2900494afa06"
+      }
+    },
+    {
+      "attester": "0xF75C01cD01c84Ef1CD22cFD92A05a05a4e55BCBD",
+      "publicKeyInG1": {
+        "x": "0x04d33397a1a18548c9c779c3e467eac432b35d71f1e498ac98c44c40bea49ed3",
+        "y": "0x1abf0cedc32a29abeb7316656928c44ad5ec6c3ba566c4c89910ed8a1dad2a3e"
+      },
+      "publicKeyInG2": {
+        "x0": "0x2e297bc3e3a0f06787b5901fc2e61d4cf35aefbcfd74e1b8d4d98bcac8ac66fe",
+        "x1": "0x2a7ded64df75cae78dc0db48b72168021417766951e27d50540adffa8258ca8c",
+        "y0": "0x0029f187b17345753202ccfbe45eac598da21b8d9b5dc1b820973155531d9179",
+        "y1": "0x13a898a0decce47df6c59ebe0a86213a163721fafaa420a6d153bce257139b34"
+      },
+      "proofOfPossession": {
+        "x": "0x1261608c767fd1475571de47f002197d3b60543fa302e35874f06aec6db1cf79",
+        "y": "0x106f8e05b062122bfc1f01f0f11ee3f8738ccddeb9dcd6868a061e786165c95e"
+      }
+    },
+    {
+      "attester": "0x763c588f4F21630a4b4D63bce656f88FcC013B8A",
+      "publicKeyInG1": {
+        "x": "0x2a89ae64ac64adda24e498ea3911bfcb322bc72ae48b22edc6749e0cc4a352e3",
+        "y": "0x06b0618f98f351ce14fc7deabd62b2c6296e846b7cbef430ae698e83c17e74b8"
+      },
+      "publicKeyInG2": {
+        "x0": "0x034cc1e446c7024f773dfffe041670920724e3fa51395a7d2d97c28f7348367f",
+        "x1": "0x1f904f622d05fb7924e8582baa23d6692233d4d310e6cf8c8afbe85ba7719f37",
+        "y0": "0x01be9d0b7b056ffbb9fe1df153efaa14bb71de993f55eeb145f7947fc80d655c",
+        "y1": "0x2a0d8609c26060d144b391323d7d22db7236806ac2a951f400ed6f1bca17f7f5"
+      },
+      "proofOfPossession": {
+        "x": "0x03da845b4eeb72a4caa74d0f5088d5085281623d4ce904734eac8d844f03a1d0",
+        "y": "0x2a56ce048d001044a61d94d69645d77b5a13e6a0c765a505cafa24641f8bd4c3"
+      }
+    },
+    {
+      "attester": "0xd5AFaBA332083D6f6200533eB334209Fa4c06fBd",
+      "publicKeyInG1": {
+        "x": "0x14f08405bab59d5c4dc5a454d3bd617495ca9815ead86ef2b7d2303280c590f4",
+        "y": "0x0974dd038365cf61707c4664757b12b70f320e92e768718ee3410cf2457d783d"
+      },
+      "publicKeyInG2": {
+        "x0": "0x0dad54a329f9f6402c59a4ad993b25a40e0bc696888bb98ccd25ca510c8d7e9d",
+        "x1": "0x277561cd9b85718babff0fbaff5296617163e909f6c1c1acdd4871561b8acb84",
+        "y0": "0x2d81fb2ed0a38652d64f78df8cbf8ac86042f650b32047521cb7c8d54771d44a",
+        "y1": "0x13473bf8219d37e02bd49fa2ace6f04cb8bca2dfd71991c803ce1ea380ea4598"
+      },
+      "proofOfPossession": {
+        "x": "0x020942c8d7ada57f2dfc76fa1feca47e8da936d4a27dbb4f4657244ac399106d",
+        "y": "0x0ed572d909116b2162cfbc46fef019b5acc486e5ab7c17a58532cfe22cc19f37"
+      }
+    },
+    {
+      "attester": "0x3C867687FA6469BD8E77fAcfCcb670D8cbF6f752",
+      "publicKeyInG1": {
+        "x": "0x200f51f6ff62ba956cb02a846cb67611cf60d76c5a17d92cc26d142390066591",
+        "y": "0x1d3c15aed112f6f93d5b072fa297df817e078fbfb0032d339ee99c497235e360"
+      },
+      "publicKeyInG2": {
+        "x0": "0x2fc4e28ef89a20c4ef92d4a227dc32492c0fab7462a8ce8a595586d14c643259",
+        "x1": "0x0b46dd591345dc1b80e46af32a46a97dd3fe37aaa02ce15f0427e397a9cb7b1e",
+        "y0": "0x144c603f60fca25b75e9efdaef22f3859684f11e50ec48f2b03f42a0cbad23b5",
+        "y1": "0x0a318c6b9cb276e575ed3dc40d9ad404e369375e360ce4c25c7a76308264cef3"
+      },
+      "proofOfPossession": {
+        "x": "0x1e5be047f5c6bb01daf8ebd323c2f68535dd35a0887e0d3eb869879bf327f7ca",
+        "y": "0x2ea047427f43420bcbd38720a3e8aba58b010381cea3884c129219cb38ad0ad9"
+      }
+    },
+    {
+      "attester": "0x1a993aD87F71355F8094c2528afD8f72289d7F50",
+      "publicKeyInG1": {
+        "x": "0x1a52b9d81b60afbb6be0a93a14c591f7d9cd7ed036cb46d31ac46d6c151fdd01",
+        "y": "0x2b3291888231d06266b260975abc6595c5241095d975a6cbd83e922bd9ea539c"
+      },
+      "publicKeyInG2": {
+        "x0": "0x1c6fac65675e2a00748d359da2034dd9a88f8d309a107014a96887b711b8ffea",
+        "x1": "0x01bdb774d9ec494ab5ff9db5744663b21a2af957ea9beee32b63f1f0c7a46281",
+        "y0": "0x1b332dba4289ded478deb374bc68b7cae90dd97d41f67cceaa53ff26daff27c4",
+        "y1": "0x2a950aa97408280e998b10e24ba08bedb98994b093e0437301ebea1661ac0e23"
+      },
+      "proofOfPossession": {
+        "x": "0x07bbb296bfbfcc0d23731715e0a627a660fbe746d1ab6a85fcfbfe99bad7a196",
+        "y": "0x05f7cc846b330eb57142be736c346cc13b640a95f3b16273b9c998e5f719e7d2"
+      }
+    },
+    {
+      "attester": "0xe10d6375F64017809B2ba5715858810A66F8e31D",
+      "publicKeyInG1": {
+        "x": "0x0fc70e3b709d8e11e767e4447aa492667584597d29fdefbf5022400833948ffb",
+        "y": "0x075e6f53c950184d5d56f07d5c6aa3b2d30f9b9e0839f128fdb65e619a2b1b19"
+      },
+      "publicKeyInG2": {
+        "x0": "0x2c022c3f52cabe48cf39425d3d9c14a789d8e555f48873cf99e4e83a8c933184",
+        "x1": "0x25d1e8031f83045acef464fdeb1dd4be81786616621a50b3e77dc53b1d9e93d9",
+        "y0": "0x052855edbd73ff329f4a43b590ffab5baa85594db38cf01bd421a30a3d6c5f77",
+        "y1": "0x202e20dd3237476a1c05f6ed1256473bd4b36c557bb4723d619d966d9a15521e"
+      },
+      "proofOfPossession": {
+        "x": "0x0293f292353701c69a5e0e4f5a30107b47cb0af9cf8f5bb6ead7ea4af127ce32",
+        "y": "0x059ccfa19903d87db3082e3d8197d3ef89e590b0c875fe43e1978ec59991c8a1"
+      }
+    },
+    {
+      "attester": "0xDCfc7065BaAA202e6a1e27eBEf448D759C60B056",
+      "publicKeyInG1": {
+        "x": "0x10d8aea9b63328d088d22dd98fb906e89e01e587e34a2c0eb9a133264573378b",
+        "y": "0x10fb68265d495da78b42c7caa7c96cd3f90f8c0586dfc4d57ef04a333867f1d5"
+      },
+      "publicKeyInG2": {
+        "x0": "0x00b3335d174425a5adfacb1c903e77978376e1b29ebd5c058ebfcdb37bcae872",
+        "x1": "0x12afd96928df4aafeae4cfc2bd3ec3372680d7687ea94165b58d2909fdd76b8f",
+        "y0": "0x25e1d8d9414d9202f0524ba6e19a52ec10f96305c29e39b6ff01179e2af3c5a9",
+        "y1": "0x2b433c84ad585a7166951a4ef2f4cb900575e625865ad88a86ff1064828668b3"
+      },
+      "proofOfPossession": {
+        "x": "0x0c348a55248552325293858bc64e37a93cd4682bcfb8759ba7d5355d4cf4db3f",
+        "y": "0x18c256076294144f49b9a5b81f24ce0e854fcf5123bdcd43ba96916bea9f1200"
+      }
+    },
+    {
+      "attester": "0xC8c109057D4c6872Db1C20c7013Dae0c91AB2Ee1",
+      "publicKeyInG1": {
+        "x": "0x1ab2bb336c2b147e6f64bcf2523d4740dde827525c3fd7c4749f79249592d62b",
+        "y": "0x2adf45dcbf308733c35dca6fe007b5a883b184ee15a91cf6ddc8ab3f4e810ed1"
+      },
+      "publicKeyInG2": {
+        "x0": "0x26a6a31927ee9a9f5488f82b28bc7357dcb91432b4b83fa173dc1fc109b1684c",
+        "x1": "0x0b04bfdd3a0b9fffd1e302f11b60a7592482cf6c3319ab7dad2df4ff7733c717",
+        "y0": "0x2f092c8dd461d33114d06f464a7e406377a51d0846028e0567e0b23282dc027e",
+        "y1": "0x1802cd7d1ca40e12af5fdcd402f28977c0c5eb21dbdecdb6e105900e8b05a756"
+      },
+      "proofOfPossession": {
+        "x": "0x13493f2a2f4d8c2656b9f943e10220b69944c1aeac226c4e2e195cc6adec36d1",
+        "y": "0x03e44d9b78faae3810c1a2863506585726382d0e8debcae1f9212fd5e70fe09a"
+      }
+    },
+    {
+      "attester": "0x80bE2F25ff8fbf155da4b29554C1011b6eeDf046",
+      "publicKeyInG1": {
+        "x": "0x24d359b508b6687c7a2e3f018b3d5413c906c6e79719f2df3e79fd7491e8028e",
+        "y": "0x01805472ae2e222144584866d1893d7644db403944d1cd2de827c14cedfccebd"
+      },
+      "publicKeyInG2": {
+        "x0": "0x290e7cb4b662faadf17de296951a11f9172d0244662005194b26876336a86841",
+        "x1": "0x0788c3254f95cb3513a607f3bf425ae2b15234bfeba0019ac4ab66dc2c292a50",
+        "y0": "0x27b30c90f3300d7104526027caf352c25cd9a14116b4875030074e0eb389da3d",
+        "y1": "0x2adeda3180be936e44a01ec1a5a8f5b87e0a375ceb00757a6f72fdcde964d3d3"
+      },
+      "proofOfPossession": {
+        "x": "0x253fe71939576b91e91f844cc5496419d6fd8e4c310aae57ff43ec4ff831478b",
+        "y": "0x25b31f40deb0d12f6458704d4436dd70a863f701b8519f3b1358428903a085bd"
+      }
+    },
+    {
+      "attester": "0xa8B161b9E8A945ca537ca4Dea8e11A8bB64C0C11",
+      "publicKeyInG1": {
+        "x": "0x0990dcbf7afa546f31fcf90e182f3e42ef3a483decfdd12b6e7d2f2ff1693e9a",
+        "y": "0x1e73e19ce490c0befe683c50804a68730f833c2ed1c635ee9c6c0acecb259fc0"
+      },
+      "publicKeyInG2": {
+        "x0": "0x02b886e26c7ea6e7571d16ee27eb8b8f4c3f0deadf69ea4cb77d9cbef8895b53",
+        "x1": "0x2d6680855fc1fecac810681c27d210e196adc850459e192cc6ddc7fd388cf31e",
+        "y0": "0x06f24916ca98906c21ea65d8c19986d47d5b2c64f939dafb793e4d88cd69c083",
+        "y1": "0x14e7072b0b7aab13b55e0c2025a4c8d4af70de2507db39074af8bc7f0ef4d317"
+      },
+      "proofOfPossession": {
+        "x": "0x27a7213b4c9b25ac1246083333c66cc4cf3a0c4eb295c3e267bbe2465c514d2b",
+        "y": "0x03212e170b14c85b56263118a49dddd693b0e02079c846c514558707e9e3dce9"
+      }
+    },
+    {
+      "attester": "0xa22fEB3b0d5dF587d6798658416f0d4FEBbD12A1",
+      "publicKeyInG1": {
+        "x": "0x2409f7a22c3b3c962e59b1b7179e969d42a3cb50dbdbcc81e55974e2f7f3aa62",
+        "y": "0x0e2fe6dcacf4be70e452c6af6be24d94018960e9fae5a052b29893ca77a94ad0"
+      },
+      "publicKeyInG2": {
+        "x0": "0x0d7f9b4d7f95b122d294d55ee6831c934e0375daef4718f59281f1794006e6a1",
+        "x1": "0x074c5c39a0c0d6ac3edf10ead86d3caf37f241c9c0d6d5dc2c458218d759cb8d",
+        "y0": "0x0894556bf91f0f0fcefb7b9e578d5665efb270fb6ccec4930d7625d95acdd0e0",
+        "y1": "0x27f25ec2ecc6fa4e716337c3a189aa0bc87f94544f4d48ac71112fb0d670d68a"
+      },
+      "proofOfPossession": {
+        "x": "0x11e9f03f57a73def48e661414113099cd9f4878a27944d1263deb84edb56ab26",
+        "y": "0x00bcb66928ede4a74ba243255280dd50813ccd67e15687e8fe6035743e0b301d"
+      }
+    },
+    {
+      "attester": "0x660BC7C1e4c76C4aE9658dF24Bb32B29E9310B6D",
+      "publicKeyInG1": {
+        "x": "0x0cd553f552b0fd25a969aee34ed7a4dfc6c65431158d1b9c92290586f32c3465",
+        "y": "0x1f6b3594fae5b4ec72fc17d19071972fbfe442b9e5bf61c6f9389827f21e8328"
+      },
+      "publicKeyInG2": {
+        "x0": "0x2d109046fd54d1f884329129fc38f2cc0a701a0d1ae6a1adcd596eac98e10f31",
+        "x1": "0x3025c57b668da826fd4f6be75f3a372cac7185c99f80b026073aabce1d516179",
+        "y0": "0x2d85cb00a82636e4101f65759585020e9ae61714f1dd25c6f28b59833c67a6fd",
+        "y1": "0x256f6e8ddd7eb7dd5a1b01fddbbf3e636b30a6f0bd23e010e01b2f94a97780cd"
+      },
+      "proofOfPossession": {
+        "x": "0x02f610c4483b335295686ded621b79bdb4f745aa9f2a094122ec9b6c06c31721",
+        "y": "0x0d3190cb6d2b934c1fd3dec925968f970a1fa56e4f548c0a5658cfe0cc377db5"
+      }
+    },
+    {
+      "attester": "0xE1b6E785B19bE2B3117249a785e13c0f1d3f2cD0",
+      "publicKeyInG1": {
+        "x": "0x1f44e327013e2d28d53fa4ac7561e0086165b7f6cd3b72f4c6d672607d1556ba",
+        "y": "0x1c69839683401ee7a00b3736456bcbd772b700580a1bdd189ba25f8ff78e377c"
+      },
+      "publicKeyInG2": {
+        "x0": "0x11bfdd25e0f94a25195627178216372140b264e21aba4a11e36c06dce2b06170",
+        "x1": "0x09e359d60c927f4b203d0a36a68c81caf1d5c6277132ae153f8cac7ddc4b3444",
+        "y0": "0x17cded03bed2697a9b4b645c1ca04b34bd1f056b8f4a9b5569dd24ed1ff28397",
+        "y1": "0x1aea7e6e5849a9f04a36c24198049fec3669448fc58afb62332908193cc739e4"
+      },
+      "proofOfPossession": {
+        "x": "0x153d2e381b0a6ae8b7d18343c074fa56f2489246184acbf91ebc23b430479942",
+        "y": "0x10d7a2f6a534c59442b9f750c4ebd9bb463448b44f94e0b69b9559347f8f2c42"
+      }
+    },
+    {
+      "attester": "0x603384FD0B9326E06cEbd6c601ff1e813aFe8B46",
+      "publicKeyInG1": {
+        "x": "0x2e327f17ef190e964b776bacb026e1b72fc30b940d6b6c45fe15033071860d7d",
+        "y": "0x23131e849037b39775c7a4575952cc6463b74229d08ece8678d114606ec95611"
+      },
+      "publicKeyInG2": {
+        "x0": "0x20f5ad2d0e0607271a19d5ad67a2ec72a178dccf425c31b22beeee5170e4226c",
+        "x1": "0x2bbb36859e1c04f33d1757e3e4e8df08f6244ceba1f4760aafd989550acff102",
+        "y0": "0x1eda1a7fd65af413e17f40758a530ad477294eda573c1de7b2935ca6cfc2aeec",
+        "y1": "0x23c803af5b6529dac8e766878146f97169034d7c71c9475e395b28077e4eb472"
+      },
+      "proofOfPossession": {
+        "x": "0x2412027c41fcc285c34f937f1e3c26bb1a221e39dde984d2ed2ad687ca26535b",
+        "y": "0x17de822f19dfc9b879ca6eec4eba9d7914437a15ab63942df9fcba809782d465"
+      }
+    },
+    {
+      "attester": "0x08632f59537f777d19A234F4dFd854169aBA747E",
+      "publicKeyInG1": {
+        "x": "0x06f016e3f1da4c854e2d3a4f99cc141d0f8283db2b49c2e937f899cf349f420f",
+        "y": "0x09530954e2a2748ef02958b8d9db89401a392d86fb58b78c7786d7797b045624"
+      },
+      "publicKeyInG2": {
+        "x0": "0x21abe60951400784754f2a334ec429fe7600edf4e03e716c89283a598faf2b6e",
+        "x1": "0x19956855f9e5a2c55339b320904458bd347cba518fbaa5f44fcf868b24153201",
+        "y0": "0x0a6c9720b90e4508c6e6553586f47a8f51d09de745f153ee6b4de48b92e5a39b",
+        "y1": "0x1a90c829b13900630bc8336dad31b366c42d702879e5822312f004bc86b6659b"
+      },
+      "proofOfPossession": {
+        "x": "0x1e54f8aa6732f055c6953ad4f4d91eb6d7d529ade1b39a8fd485baf04e76653f",
+        "y": "0x0a5fdcedf9fec45cbe96ddd14d70192e22a61829a10935da3717308a9dfa3ef1"
+      }
+    },
+    {
+      "attester": "0x50Ee5dF7BC0be6f041047b072f1615CF5Bbe64d0",
+      "publicKeyInG1": {
+        "x": "0x2bdd94b5570494f37ad5deca26de0678649a2c0302c9c16fae89f677295bfbe3",
+        "y": "0x19e0068c4ae1c7414447ec8e275dcf82e7c45201e1411eb09c5fe13e537b174d"
+      },
+      "publicKeyInG2": {
+        "x0": "0x1f1c6490bb092be7ceb4141cec1800839a01f92c5837f6df0cd2d5609363fd40",
+        "x1": "0x18f3ca5d4b90d1066b37699a9b5473070dec3d7b59c1998cff4d392c4d560f77",
+        "y0": "0x0f078d1844941e1483c4f84c6d2da751f6beb0979b267016aa3fd13168ec6c5f",
+        "y1": "0x056c6b51ab62801ab8592c07a1b815fab9650a1c69007047cfd6c4255f7419d9"
+      },
+      "proofOfPossession": {
+        "x": "0x24ab9c70826b7453d766a2040d6f1c427de64f7489e9ee45bb7a7b2cf1f35665",
+        "y": "0x2c47aab80e7f290c5e9e50c9b6149c560438962356ff6122afe3cc450ad20810"
+      }
+    },
+    {
+      "attester": "0x07EfE31f7c5E4Fc1f870c3EFAA9cF1de704e9760",
+      "publicKeyInG1": {
+        "x": "0x2c9273c0b874fccc711f87459bc01f1bce6e6f2fa1c775365d2e479fc7d7d590",
+        "y": "0x212ab611673a0f989f4e42589ab7b9a289cb84a015443c86c65835cceb7b92b9"
+      },
+      "publicKeyInG2": {
+        "x0": "0x024fa5b52e2c89f603928dcbc4fb8dc4ff5d55b32c04e14ef66e710af89f787f",
+        "x1": "0x24290fe1183bb8e3e0676607a23ed3004c8916099ce6759e5d4e174d62a2d09c",
+        "y0": "0x1fc858fc4da4c8cf6c4be5bc78d0f00ea69f4694a5ce28283278d60dea6faa49",
+        "y1": "0x0487cdae08c9c427af9f162df027f87b0b46d7a17aafc4e39ce0160b2e41ffb9"
+      },
+      "proofOfPossession": {
+        "x": "0x1776ec0a4453b456d09563a435dbf129281446aee7da9739d436ac362df3016a",
+        "y": "0x05c1f5049fc6daae26e1287e1e4a48248b7c68e120e062e574fb9504c12990ed"
+      }
+    }
+  ]

--- a/l1-contracts/src/core/libraries/StakingQueue.sol
+++ b/l1-contracts/src/core/libraries/StakingQueue.sol
@@ -31,10 +31,6 @@ struct StakingQueue {
 }
 
 library StakingQueueLib {
-  // This is a HARD CAP. We will never attempt to flush more than this number of validators,
-  // because it starts to butt up against the block gas limit.
-  uint256 public constant MAX_QUEUE_FLUSH_SIZE = 150;
-
   function init(StakingQueue storage self) internal {
     self.first = 1;
     self.last = 1;

--- a/l1-contracts/src/core/libraries/compressed-data/StakingQueueConfig.sol
+++ b/l1-contracts/src/core/libraries/compressed-data/StakingQueueConfig.sol
@@ -22,28 +22,30 @@ type CompressedStakingQueueConfig is uint256;
  * possible to add validators. This can close the queue even if there are members in the validator set if a very high
  * `normalFlushSizeQuotient` is used.
  *
- * NOTE: We will NEVER flush more than `MAX_QUEUE_FLUSH_SIZE` validators: it is applied as a Max at the end of every
+ * NOTE: We will NEVER flush more than `maxQueueFlushSize` validators: it is applied as a Max at the end of every
  * calculation.
- * This is to prevent a situation where flushing the queue would exceed the block gas limit.
+ * This can be used to prevent a situation where flushing the queue would exceed the block gas limit.
  */
 struct StakingQueueConfig {
   uint256 bootstrapValidatorSetSize;
   uint256 bootstrapFlushSize;
   uint256 normalFlushSizeMin;
   uint256 normalFlushSizeQuotient;
+  uint256 maxQueueFlushSize;
 }
 
 library StakingQueueConfigLib {
   using SafeCast for uint256;
 
-  uint256 private constant MASK_64BIT = 0xFFFFFFFFFFFFFFFF;
+  uint256 private constant MASK_32BIT = 0xFFFFFFFF;
 
   function compress(StakingQueueConfig memory _config) internal pure returns (CompressedStakingQueueConfig) {
     uint256 value = 0;
-    value |= uint256(_config.normalFlushSizeQuotient.toUint64());
-    value |= uint256(_config.normalFlushSizeMin.toUint64()) << 64;
-    value |= uint256(_config.bootstrapFlushSize.toUint64()) << 128;
-    value |= uint256(_config.bootstrapValidatorSetSize.toUint64()) << 192;
+    value |= uint256(_config.maxQueueFlushSize.toUint32());
+    value |= uint256(_config.normalFlushSizeQuotient.toUint32()) << 32;
+    value |= uint256(_config.normalFlushSizeMin.toUint32()) << 64;
+    value |= uint256(_config.bootstrapFlushSize.toUint32()) << 96;
+    value |= uint256(_config.bootstrapValidatorSetSize.toUint32()) << 128;
 
     return CompressedStakingQueueConfig.wrap(value);
   }
@@ -52,10 +54,11 @@ library StakingQueueConfigLib {
     uint256 value = CompressedStakingQueueConfig.unwrap(_compressedConfig);
 
     return StakingQueueConfig({
-      bootstrapValidatorSetSize: (value >> 192) & MASK_64BIT,
-      bootstrapFlushSize: (value >> 128) & MASK_64BIT,
-      normalFlushSizeMin: (value >> 64) & MASK_64BIT,
-      normalFlushSizeQuotient: (value) & MASK_64BIT
+      bootstrapValidatorSetSize: (value >> 128) & MASK_32BIT,
+      bootstrapFlushSize: (value >> 96) & MASK_32BIT,
+      normalFlushSizeMin: (value >> 64) & MASK_32BIT,
+      normalFlushSizeQuotient: (value >> 32) & MASK_32BIT,
+      maxQueueFlushSize: value & MASK_32BIT
     });
   }
 }

--- a/l1-contracts/src/core/libraries/rollup/StakingLib.sol
+++ b/l1-contracts/src/core/libraries/rollup/StakingLib.sol
@@ -303,7 +303,7 @@ library StakingLib {
    *      The function will revert if:
    *      - The current epoch is before nextFlushableEpoch (max 1 flush per epoch). This limit:
    *        1. Controls validator set growth by only allowing a fixed number of additions per epoch (we can flush at
-   *           most MAX_QUEUE_FLUSH_SIZE validators at once - hence the limit)
+   *           most maxQueueFlushSize validators at once - hence the limit)
    *        2. Aligns with committee selection which happens once per epoch anyway
    *        3. Groups validator additions into epoch-sized chunks for efficient binary searches (fewer snapshots in
    *           GSE)
@@ -509,7 +509,7 @@ library StakingLib {
    *      3. Normal phase: After the initial bootstrap and growth phases, returns a number proportional to the current
    *         set size for conservative steady-state growth, unless constrained by configuration (`normalFlushSizeMin`).
    *
-   *      All phases are subject to a hard cap of `MAX_QUEUE_FLUSH_SIZE`.
+   *      All phases are subject to a hard cap of `maxQueueFlushSize`.
    *
    *      The motivation for floodgates is that the whole system starts producing blocks with what is considered
    *      a sufficiently decentralized set of validators.
@@ -536,14 +536,14 @@ library StakingLib {
 
       // If growth:
       if (activeAttesterCount < config.bootstrapValidatorSetSize) {
-        return Math.min(config.bootstrapFlushSize, StakingQueueLib.MAX_QUEUE_FLUSH_SIZE);
+        return Math.min(config.bootstrapFlushSize, config.maxQueueFlushSize);
       }
     }
 
     // If normal:
     return Math.min(
       Math.max(activeAttesterCount / config.normalFlushSizeQuotient, config.normalFlushSizeMin),
-      StakingQueueLib.MAX_QUEUE_FLUSH_SIZE
+      config.maxQueueFlushSize
     );
   }
 

--- a/l1-contracts/src/mock/MultiAdder.sol
+++ b/l1-contracts/src/mock/MultiAdder.sol
@@ -16,6 +16,7 @@ struct CheatDepositArgs {
 
 interface IMultiAdder {
   function addValidators(CheatDepositArgs[] memory _args) external;
+  function addValidators(CheatDepositArgs[] memory _args, bool _skipFlush) external;
 }
 
 contract MultiAdder is IMultiAdder {
@@ -32,7 +33,11 @@ contract MultiAdder is IMultiAdder {
     stakingAsset.approve(address(STAKING), type(uint256).max);
   }
 
-  function addValidators(CheatDepositArgs[] memory _args) external override(IMultiAdder) {
+  function addValidators(CheatDepositArgs[] memory _args) public override(IMultiAdder) {
+    addValidators(_args, false);
+  }
+
+  function addValidators(CheatDepositArgs[] memory _args, bool _skipFlush) public override(IMultiAdder) {
     require(msg.sender == OWNER, NotOwner());
     for (uint256 i = 0; i < _args.length; i++) {
       STAKING.deposit(
@@ -45,7 +50,7 @@ contract MultiAdder is IMultiAdder {
       );
     }
 
-    if (STAKING.getCurrentEpoch() >= STAKING.getNextFlushableEpoch()) {
+    if (!_skipFlush && STAKING.getCurrentEpoch() >= STAKING.getNextFlushableEpoch()) {
       STAKING.flushEntryQueue();
     }
   }

--- a/l1-contracts/test/compression/StakingQueueConfig.t.sol
+++ b/l1-contracts/test/compression/StakingQueueConfig.t.sol
@@ -14,16 +14,18 @@ contract StakingQueueConfigTest is Test {
   using StakingQueueConfigLib for CompressedStakingQueueConfig;
 
   function test_compressAndDecompress(
-    uint64 _bootstrapValidatorSetSize,
-    uint64 _bootstrapFlushSize,
-    uint64 _normalFlushSizeMin,
-    uint64 _normalFlushSizeQuotient
+    uint32 _bootstrapValidatorSetSize,
+    uint32 _bootstrapFlushSize,
+    uint32 _normalFlushSizeMin,
+    uint32 _normalFlushSizeQuotient,
+    uint32 _maxQueueFlushSize
   ) public pure {
     StakingQueueConfig memory a = StakingQueueConfig({
       bootstrapValidatorSetSize: _bootstrapValidatorSetSize,
       bootstrapFlushSize: _bootstrapFlushSize,
       normalFlushSizeMin: _normalFlushSizeMin,
-      normalFlushSizeQuotient: _normalFlushSizeQuotient
+      normalFlushSizeQuotient: _normalFlushSizeQuotient,
+      maxQueueFlushSize: _maxQueueFlushSize
     });
 
     CompressedStakingQueueConfig b = a.compress();
@@ -33,5 +35,6 @@ contract StakingQueueConfigTest is Test {
     assertEq(c.bootstrapFlushSize, a.bootstrapFlushSize, "Bootstrap flush size");
     assertEq(c.normalFlushSizeMin, a.normalFlushSizeMin, "Normal flush size min");
     assertEq(c.normalFlushSizeQuotient, a.normalFlushSizeQuotient, "Normal flush size quotient");
+    assertEq(c.maxQueueFlushSize, a.maxQueueFlushSize, "Max queue flush size");
   }
 }

--- a/l1-contracts/test/harnesses/TestConstants.sol
+++ b/l1-contracts/test/harnesses/TestConstants.sol
@@ -31,6 +31,7 @@ library TestConstants {
   uint256 internal constant AZTEC_ENTRY_QUEUE_FLUSH_SIZE_QUOTIENT = 2;
   uint256 internal constant AZTEC_ENTRY_QUEUE_BOOTSTRAP_VALIDATOR_SET_SIZE = 0;
   uint256 internal constant AZTEC_ENTRY_QUEUE_BOOTSTRAP_FLUSH_SIZE = 0;
+  uint256 internal constant AZTEC_ENTRY_QUEUE_MAX_FLUSH_SIZE = 480;
   uint256 internal constant AZTEC_EXIT_DELAY_SECONDS = 2 * 24 * 60 * 60; // 2 days
   EthValue internal constant AZTEC_PROVING_COST_PER_MANA = EthValue.wrap(100);
 
@@ -81,7 +82,8 @@ library TestConstants {
       bootstrapValidatorSetSize: AZTEC_ENTRY_QUEUE_BOOTSTRAP_VALIDATOR_SET_SIZE,
       bootstrapFlushSize: AZTEC_ENTRY_QUEUE_BOOTSTRAP_FLUSH_SIZE,
       normalFlushSizeMin: AZTEC_ENTRY_QUEUE_FLUSH_SIZE_MIN,
-      normalFlushSizeQuotient: AZTEC_ENTRY_QUEUE_FLUSH_SIZE_QUOTIENT
+      normalFlushSizeQuotient: AZTEC_ENTRY_QUEUE_FLUSH_SIZE_QUOTIENT,
+      maxQueueFlushSize: AZTEC_ENTRY_QUEUE_MAX_FLUSH_SIZE
     });
   }
 

--- a/l1-contracts/test/staking/flushEntryQueue.t.sol
+++ b/l1-contracts/test/staking/flushEntryQueue.t.sol
@@ -18,6 +18,8 @@ import {Rollup} from "@aztec/core/Rollup.sol";
 import {BN254Lib, G1Point, G2Point} from "@aztec/shared/libraries/BN254Lib.sol";
 
 contract FlushEntryQueueTest is StakingBase {
+  uint256 public constant MAX_QUEUE_FLUSH_SIZE = 48;
+
   function test_GivenTheQueueHasAlreadyBeenFlushedThisEpoch() external {
     // it reverts
 
@@ -40,10 +42,11 @@ contract FlushEntryQueueTest is StakingBase {
     uint256 _normalFlushSizeQuotient
   ) internal {
     StakingQueueConfig memory stakingQueueConfig = StakingQueueConfig({
-      bootstrapValidatorSetSize: bound(_bootstrapValidatorSetSize, 0, type(uint64).max),
-      bootstrapFlushSize: bound(_bootstrapFlushSize, 0, type(uint64).max),
-      normalFlushSizeMin: bound(_normalFlushSizeMin, 0, type(uint64).max),
-      normalFlushSizeQuotient: bound(_normalFlushSizeQuotient, 0, type(uint64).max)
+      bootstrapValidatorSetSize: bound(_bootstrapValidatorSetSize, 0, type(uint32).max),
+      bootstrapFlushSize: bound(_bootstrapFlushSize, 0, type(uint32).max),
+      normalFlushSizeMin: bound(_normalFlushSizeMin, 0, type(uint32).max),
+      normalFlushSizeQuotient: bound(_normalFlushSizeQuotient, 0, type(uint32).max),
+      maxQueueFlushSize: MAX_QUEUE_FLUSH_SIZE
     });
     Rollup rollup = Rollup(address(registry.getCanonicalRollup()));
     vm.prank(rollup.owner());
@@ -67,7 +70,7 @@ contract FlushEntryQueueTest is StakingBase {
 
     _bootstrapValidatorSetSize = bound(_bootstrapValidatorSetSize, 1, 1000);
     _numValidators = bound(_numValidators, 0, _bootstrapValidatorSetSize - 1);
-    _bootstrapFlushSize = bound(_bootstrapFlushSize, 1, StakingQueueLib.MAX_QUEUE_FLUSH_SIZE);
+    _bootstrapFlushSize = bound(_bootstrapFlushSize, 1, MAX_QUEUE_FLUSH_SIZE);
 
     _setupQueueConfig(_bootstrapValidatorSetSize, _bootstrapFlushSize, _normalFlushSizeMin, _normalFlushSizeQuotient);
 
@@ -100,7 +103,7 @@ contract FlushEntryQueueTest is StakingBase {
     _bootstrapValidatorSetSize = bound(_bootstrapValidatorSetSize, 1, 1000);
     _numValidators = bound(_numValidators, _bootstrapValidatorSetSize, _bootstrapValidatorSetSize * 2);
     _bootstrapFlushSize = bound(_bootstrapFlushSize, 1, _bootstrapValidatorSetSize * 2);
-    uint256 effectiveFlushSize = Math.min(_bootstrapFlushSize, StakingQueueLib.MAX_QUEUE_FLUSH_SIZE);
+    uint256 effectiveFlushSize = Math.min(_bootstrapFlushSize, MAX_QUEUE_FLUSH_SIZE);
 
     _setupQueueConfig(_bootstrapValidatorSetSize, _bootstrapFlushSize, _normalFlushSizeMin, _normalFlushSizeQuotient);
 
@@ -122,7 +125,7 @@ contract FlushEntryQueueTest is StakingBase {
 
     _bootstrapValidatorSetSize = bound(_bootstrapValidatorSetSize, 3, 1000);
     _bootstrapFlushSize = bound(_bootstrapFlushSize, 1, _bootstrapValidatorSetSize / 3);
-    uint256 effectiveFlushSize = Math.min(_bootstrapFlushSize, StakingQueueLib.MAX_QUEUE_FLUSH_SIZE);
+    uint256 effectiveFlushSize = Math.min(_bootstrapFlushSize, MAX_QUEUE_FLUSH_SIZE);
 
     _setupQueueConfig(_bootstrapValidatorSetSize, _bootstrapFlushSize, _normalFlushSizeMin, _normalFlushSizeQuotient);
 
@@ -158,7 +161,7 @@ contract FlushEntryQueueTest is StakingBase {
     _normalFlushSizeMin = bound(_normalFlushSizeMin, 1, 500);
     _normalFlushSizeQuotient = bound(_normalFlushSizeQuotient, 1, 500);
     uint256 effectiveFlushSize = Math.max(_normalFlushSizeMin, _activeAttesterCount / _normalFlushSizeQuotient);
-    effectiveFlushSize = Math.min(effectiveFlushSize, StakingQueueLib.MAX_QUEUE_FLUSH_SIZE);
+    effectiveFlushSize = Math.min(effectiveFlushSize, MAX_QUEUE_FLUSH_SIZE);
 
     _setupQueueConfig(0, 0, _normalFlushSizeMin, _normalFlushSizeQuotient);
 

--- a/l1-contracts/test/staking/invalidDeposit.t.sol
+++ b/l1-contracts/test/staking/invalidDeposit.t.sol
@@ -38,7 +38,8 @@ contract InvalidPointsFlushEntryQueueTest is StakingBase, BN254Fixtures {
       bootstrapValidatorSetSize: 0,
       bootstrapFlushSize: 0,
       normalFlushSizeMin: 2,
-      normalFlushSizeQuotient: 1
+      normalFlushSizeQuotient: 1,
+      maxQueueFlushSize: 48
     });
 
     Rollup rollup = Rollup(address(registry.getCanonicalRollup()));

--- a/l1-contracts/test/staking/tmnt221.t.sol
+++ b/l1-contracts/test/staking/tmnt221.t.sol
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024 Aztec Labs.
+pragma solidity >=0.8.27;
+
+import {TestBase} from "@test/base/Base.sol";
+
+import {IInstance} from "@aztec/core/interfaces/IInstance.sol";
+import {MultiAdder, CheatDepositArgs} from "@aztec/mock/MultiAdder.sol";
+import {G1Point, G2Point} from "@aztec/shared/libraries/BN254Lib.sol";
+import {RollupBuilder} from "@test/builder/RollupBuilder.sol";
+import {TestERC20} from "@aztec/mock/TestERC20.sol";
+
+struct RegistrationData {
+  address attester;
+  G1Point proofOfPossession;
+  G1Point publicKeyInG1;
+  G2Point publicKeyInG2;
+}
+
+contract TestTMNT221 is TestBase {
+  IInstance public INSTANCE;
+  TestERC20 public STAKING_ASSET;
+  address public WITHDRAWER = address(bytes20("WITHDRAWER"));
+
+  RegistrationData[] public $registrations;
+
+  uint256 public constant VALIDATOR_COUNT = 32;
+  bool public constant SEPARATE_FLUSH = false;
+  uint256 public constant GAS_LIMIT = 30_000_000;
+
+  function setUp() public {
+    string memory root = vm.projectRoot();
+    string memory path = string.concat(root, "/script/registration_data.json");
+    string memory json = vm.readFile(path);
+    bytes memory jsonBytes = vm.parseJson(json);
+    RegistrationData[] memory registrations = abi.decode(jsonBytes, (RegistrationData[]));
+
+    for (uint256 i = 0; i < registrations.length; i++) {
+      $registrations.push(registrations[i]);
+    }
+
+    RollupBuilder builder = new RollupBuilder(address(this)).setUpdateOwnerships(false).setCheckProofOfPossession(true)
+      .setEntryQueueFlushSizeMin(VALIDATOR_COUNT).deploy();
+
+    INSTANCE = IInstance(address(builder.getConfig().rollup));
+    STAKING_ASSET = builder.getConfig().testERC20;
+
+    vm.prank(STAKING_ASSET.owner());
+    STAKING_ASSET.addMinter(address(this));
+  }
+
+  /// forge-config: default.isolate = true
+  function test_tmnt221() external {
+    uint256 activationThreshold = INSTANCE.getActivationThreshold();
+
+    MultiAdder adder = new MultiAdder(address(INSTANCE), address(this));
+
+    STAKING_ASSET.mint(address(adder), activationThreshold * 2 * VALIDATOR_COUNT);
+
+    CheatDepositArgs[] memory args = new CheatDepositArgs[](VALIDATOR_COUNT);
+
+    for (uint256 i = 0; i < VALIDATOR_COUNT; i++) {
+      args[i] = CheatDepositArgs(
+        $registrations[i].attester,
+        WITHDRAWER,
+        $registrations[i].publicKeyInG1,
+        $registrations[i].publicKeyInG2,
+        $registrations[i].proofOfPossession
+      );
+    }
+
+    adder.addValidators{gas: GAS_LIMIT}(args, SEPARATE_FLUSH);
+
+    if (SEPARATE_FLUSH) {
+      INSTANCE.flushEntryQueue{gas: GAS_LIMIT}();
+    }
+
+    emit log_named_uint("Validator count", INSTANCE.getActiveAttesterCount());
+    assertEq(INSTANCE.getActiveAttesterCount(), VALIDATOR_COUNT);
+  }
+}

--- a/l1-contracts/test/staking/updateStakingQueueConfig.t.sol
+++ b/l1-contracts/test/staking/updateStakingQueueConfig.t.sol
@@ -32,10 +32,11 @@ contract UpdateStakingQueueConfigTest is StakingBase {
     // it emits a {StakingQueueConfigUpdated} event
 
     // Update the config to have sane values that can be compressed
-    _config.bootstrapValidatorSetSize = bound(_config.bootstrapValidatorSetSize, 0, type(uint64).max);
-    _config.bootstrapFlushSize = bound(_config.bootstrapFlushSize, 0, type(uint64).max);
-    _config.normalFlushSizeMin = bound(_config.normalFlushSizeMin, 0, type(uint64).max);
-    _config.normalFlushSizeQuotient = bound(_config.normalFlushSizeQuotient, 0, type(uint64).max);
+    _config.bootstrapValidatorSetSize = bound(_config.bootstrapValidatorSetSize, 0, type(uint32).max);
+    _config.bootstrapFlushSize = bound(_config.bootstrapFlushSize, 0, type(uint32).max);
+    _config.normalFlushSizeMin = bound(_config.normalFlushSizeMin, 0, type(uint32).max);
+    _config.normalFlushSizeQuotient = bound(_config.normalFlushSizeQuotient, 0, type(uint32).max);
+    _config.maxQueueFlushSize = bound(_config.maxQueueFlushSize, 0, type(uint32).max);
 
     Rollup rollup = Rollup(address(registry.getCanonicalRollup()));
     vm.prank(rollup.owner());

--- a/yarn-project/ethereum/src/config.ts
+++ b/yarn-project/ethereum/src/config.ts
@@ -187,15 +187,17 @@ export const getRewardBoostConfig = (networkName: NetworkNames) => {
 const LocalEntryQueueConfig = {
   bootstrapValidatorSetSize: 0n,
   bootstrapFlushSize: 0n,
-  normalFlushSizeMin: 48n,
+  normalFlushSizeMin: 48n, // will effectively be bounded by maxQueueFlushSize
   normalFlushSizeQuotient: 2n,
+  maxQueueFlushSize: 48n,
 };
 
 const TestnetEntryQueueConfig = {
   bootstrapValidatorSetSize: 750n,
-  bootstrapFlushSize: 75n,
+  bootstrapFlushSize: 75n, // will effectively be bounded by maxQueueFlushSize
   normalFlushSizeMin: 1n,
   normalFlushSizeQuotient: 2475n,
+  maxQueueFlushSize: 32n, // Limited to 32 so flush cost are kept below 15M gas.
 };
 
 export const getEntryQueueConfig = (networkName: NetworkNames) => {

--- a/yarn-project/ethereum/src/contracts/rollup.ts
+++ b/yarn-project/ethereum/src/contracts/rollup.ts
@@ -384,6 +384,10 @@ export class RollupContract {
     return this.rollup.read.getTimestampForSlot([slot]);
   }
 
+  getEntryQueueLength() {
+    return this.rollup.read.getEntryQueueLength();
+  }
+
   async getEpochNumber(blockNumber?: bigint) {
     blockNumber ??= await this.getBlockNumber();
     return this.rollup.read.getEpochForBlock([BigInt(blockNumber)]);

--- a/yarn-project/ethereum/src/deploy_l1_contracts.ts
+++ b/yarn-project/ethereum/src/deploy_l1_contracts.ts
@@ -806,7 +806,8 @@ export const addMultipleValidators = async (
         }),
       });
 
-      const validatorCount = await rollup.getActiveAttesterCount();
+      const entryQueueLengthBefore = await rollup.getEntryQueueLength();
+      const validatorCountBefore = await rollup.getActiveAttesterCount();
 
       logger.info(`Adding ${validators.length} validators to the rollup`);
 
@@ -824,10 +825,21 @@ export const addMultipleValidators = async (
         },
       );
 
+      const entryQueueLengthAfter = await rollup.getEntryQueueLength();
       const validatorCountAfter = await rollup.getActiveAttesterCount();
-      if (validatorCountAfter < validatorCount + BigInt(validators.length)) {
-        throw new Error(`Failed to add ${validators.length} validators. ${validatorCount} -> ${validatorCountAfter} `);
+
+      if (
+        entryQueueLengthAfter + validatorCountAfter <
+        entryQueueLengthBefore + validatorCountBefore + BigInt(validators.length)
+      ) {
+        throw new Error(
+          `Failed to add ${validators.length} validators. Active validators: ${validatorCountBefore} -> ${validatorCountAfter}. Queue: ${entryQueueLengthBefore} -> ${entryQueueLengthAfter}`,
+        );
       }
+
+      logger.info(
+        `Added ${validators.length} validators. Active validators: ${validatorCountBefore} -> ${validatorCountAfter}. Queue: ${entryQueueLengthBefore} -> ${entryQueueLengthAfter}`,
+      );
     }
   }
 };


### PR DESCRIPTION
With the changes for BLS keys to be included, the cost of the queue and deposits was heavily impacted. however the upper limit of queue members to consume was not altered. It is now a config value along with the rest of the staking queue config.

The config is important as it pose a potential DOS. If there are sufficient queue members it will be impossible to actually flush the queue, so making it updatable is a sane way to deal with changing costs of op-codes etc. 

Also it can be used to put limits more easily on set growth. 

Fixes an issue in the migration loading, and adds a test to showcase gas costs related to additions.