### PR TITLE
refactor(Barretenberg): Static analysis of Protogalaxy Recursive Verifier

### DIFF
--- a/barretenberg/cpp/scripts/test_civc_standalone_vks_havent_changed.sh
+++ b/barretenberg/cpp/scripts/test_civc_standalone_vks_havent_changed.sh
@@ -13,7 +13,7 @@ cd ..
 # - Generate a hash for versioning: sha256sum bb-civc-inputs.tar.gz
 # - Upload the compressed results: aws s3 cp bb-civc-inputs.tar.gz s3://aztec-ci-artifacts/protocol/bb-civc-inputs-[hash(0:8)].tar.gz
 # Note: In case of the "Test suite failed to run ... Unexpected token 'with' " error, need to run: docker pull aztecprotocol/build:3.0
-pinned_short_hash="d06b78a2"
+pinned_short_hash="98409939"
 pinned_civc_inputs_url="https://aztec-ci-artifacts.s3.us-east-2.amazonaws.com/protocol/bb-civc-inputs-${pinned_short_hash}.tar.gz"
 
 function compress_and_upload {

--- a/barretenberg/cpp/src/barretenberg/boomerang_value_detection/CMakeLists.txt
+++ b/barretenberg/cpp/src/barretenberg/boomerang_value_detection/CMakeLists.txt
@@ -1,1 +1,3 @@
-barretenberg_module(boomerang_value_detection stdlib_circuit_builders circuit_checker stdlib_primitives numeric stdlib_aes128 stdlib_sha256 stdlib_blake2s stdlib_blake3s stdlib_poseidon2 stdlib_goblin_verifier)
+barretenberg_module(boomerang_value_detection stdlib_circuit_builders circuit_checker 
+                    stdlib_primitives numeric stdlib_aes128 stdlib_sha256 stdlib_blake2s 
+                    stdlib_blake3s stdlib_poseidon2 stdlib_honk_verifier stdlib_protogalaxy_verifier)

--- a/barretenberg/cpp/src/barretenberg/boomerang_value_detection/graph.cpp
+++ b/barretenberg/cpp/src/barretenberg/boomerang_value_detection/graph.cpp
@@ -1,5 +1,6 @@
 #include "./graph.hpp"
 #include "barretenberg/common/assert.hpp"
+#include "barretenberg/stdlib/primitives/circuit_builders/circuit_builders.hpp"
 #include "barretenberg/stdlib_circuit_builders/ultra_circuit_builder.hpp"
 #include <algorithm>
 #include <array>
@@ -17,10 +18,10 @@ namespace cdg {
  * @param block block to find
  * @return size_t index of the found block
  */
-template <typename FF>
-size_t StaticAnalyzer_<FF>::find_block_index(UltraCircuitBuilder& ultra_builder, const UltraBlock& block)
+template <typename FF, typename CircuitBuilder>
+size_t StaticAnalyzer_<FF, CircuitBuilder>::find_block_index(const auto& block)
 {
-    auto blocks_data = ultra_builder.blocks.get();
+    auto blocks_data = circuit_builder.blocks.get();
     size_t index = 0;
     for (size_t i = 0; i < blocks_data.size(); i++) {
         if ((void*)(&blocks_data[i]) == (void*)(&block)) {
@@ -45,10 +46,10 @@ size_t StaticAnalyzer_<FF>::find_block_index(UltraCircuitBuilder& ultra_builder,
  *          4) Updates variable_gates map with gate indices for each variable
  *          5) Increments the gate count for each processed variable
  */
-template <typename FF>
-inline void StaticAnalyzer_<FF>::process_gate_variables(std::vector<uint32_t>& gate_variables,
-                                                        size_t gate_index,
-                                                        size_t block_idx)
+template <typename FF, typename CircuitBuilder>
+inline void StaticAnalyzer_<FF, CircuitBuilder>::process_gate_variables(std::vector<uint32_t>& gate_variables,
+                                                                        size_t gate_index,
+                                                                        size_t block_idx)
 {
     auto unique_variables = std::unique(gate_variables.begin(), gate_variables.end());
     gate_variables.erase(unique_variables, gate_variables.end());
@@ -75,9 +76,9 @@ inline void StaticAnalyzer_<FF>::process_gate_variables(std::vector<uint32_t>& g
  * @details Processes both regular arithmetic gates and minigates, handling fixed witness gates
  *          and different arithmetic operations based on selector values
  */
-template <typename FF>
-inline std::vector<std::vector<uint32_t>> StaticAnalyzer_<FF>::get_arithmetic_gate_connected_component(
-    bb::UltraCircuitBuilder& ultra_circuit_builder, size_t index, size_t block_idx, UltraBlock& blk)
+template <typename FF, typename CircuitBuilder>
+inline std::vector<std::vector<uint32_t>> StaticAnalyzer_<FF, CircuitBuilder>::get_arithmetic_gate_connected_component(
+    size_t index, size_t block_idx, auto& blk)
 {
     auto q_arith = blk.q_arith()[index];
     std::vector<uint32_t> gate_variables;
@@ -98,7 +99,7 @@ inline std::vector<std::vector<uint32_t>> StaticAnalyzer_<FF>::get_arithmetic_ga
     uint32_t fourth_idx = blk.w_4()[index];
     if (q_m.is_zero() && q_1 == 1 && q_2.is_zero() && q_3.is_zero() && q_4.is_zero() && q_arith == FF::one()) {
         // this is fixed_witness gate. So, variable index contains in left wire. So, we have to take only it.
-        fixed_variables.insert(this->to_real(ultra_circuit_builder, left_idx));
+        fixed_variables.insert(this->to_real(left_idx));
     } else if (!q_m.is_zero() || q_1 != FF::one() || !q_2.is_zero() || !q_3.is_zero() || !q_4.is_zero()) {
         //  this is not the gate for fix_witness, so we have to process this gate
         if (!q_m.is_zero()) {
@@ -139,15 +140,14 @@ inline std::vector<std::vector<uint32_t>> StaticAnalyzer_<FF>::get_arithmetic_ga
             }
         }
     }
-    gate_variables = this->to_real(ultra_circuit_builder, gate_variables);
-    minigate_variables = this->to_real(ultra_circuit_builder, minigate_variables);
-    this->process_gate_variables(gate_variables, index, block_idx);
-    this->process_gate_variables(minigate_variables, index, block_idx);
+    gate_variables = to_real(gate_variables);
+    minigate_variables = to_real(minigate_variables);
+    process_gate_variables(gate_variables, index, block_idx);
+    process_gate_variables(minigate_variables, index, block_idx);
     all_gates_variables.emplace_back(gate_variables);
     if (!minigate_variables.empty()) {
         all_gates_variables.emplace_back(minigate_variables);
     }
-
     return all_gates_variables;
 }
 
@@ -162,35 +162,45 @@ inline std::vector<std::vector<uint32_t>> StaticAnalyzer_<FF>::get_arithmetic_ga
  * @details Handles both elliptic curve addition and doubling operations,
  *          collecting variables from current and next gates as needed
  */
-template <typename FF>
-inline std::vector<uint32_t> StaticAnalyzer_<FF>::get_elliptic_gate_connected_component(
-    bb::UltraCircuitBuilder& ultra_circuit_builder, size_t index, size_t block_idx, UltraBlock& blk)
+template <typename FF, typename CircuitBuilder>
+inline std::vector<uint32_t> StaticAnalyzer_<FF, CircuitBuilder>::get_elliptic_gate_connected_component(
+    size_t index, size_t block_idx, auto& blk)
 {
     std::vector<uint32_t> gate_variables;
     if (!blk.q_elliptic()[index].is_zero()) {
+        std::vector<uint32_t> first_row_variables;
+        std::vector<uint32_t> second_row_variables;
         gate_variables.reserve(6);
         bool is_elliptic_add_gate = !blk.q_1()[index].is_zero() && blk.q_m()[index].is_zero();
         bool is_elliptic_dbl_gate = blk.q_1()[index].is_zero() && blk.q_m()[index] == FF::one();
         auto right_idx = blk.w_r()[index];
         auto out_idx = blk.w_o()[index];
-        gate_variables.emplace_back(right_idx);
-        gate_variables.emplace_back(out_idx);
+        first_row_variables.emplace_back(right_idx);
+        first_row_variables.emplace_back(out_idx);
         if (index != blk.size() - 1) {
             if (is_elliptic_add_gate) {
                 // if this gate is ecc_add_gate, we have to get indices x2, x3, y3, y2 from the next gate
-                gate_variables.emplace_back(blk.w_l()[index + 1]);
-                gate_variables.emplace_back(blk.w_r()[index + 1]);
-                gate_variables.emplace_back(blk.w_o()[index + 1]);
-                gate_variables.emplace_back(blk.w_4()[index + 1]);
+                second_row_variables.emplace_back(blk.w_l()[index + 1]);
+                second_row_variables.emplace_back(blk.w_r()[index + 1]);
+                second_row_variables.emplace_back(blk.w_o()[index + 1]);
+                second_row_variables.emplace_back(blk.w_4()[index + 1]);
             }
             if (is_elliptic_dbl_gate) {
                 // if this gate is ecc_dbl_gate, we have to indices x3, y3 from right and output wires
-                gate_variables.emplace_back(blk.w_r()[index + 1]);
-                gate_variables.emplace_back(blk.w_o()[index + 1]);
+                second_row_variables.emplace_back(blk.w_r()[index + 1]);
+                second_row_variables.emplace_back(blk.w_o()[index + 1]);
             }
         }
-        gate_variables = this->to_real(ultra_circuit_builder, gate_variables);
-        this->process_gate_variables(gate_variables, index, block_idx);
+        if (!first_row_variables.empty()) {
+            first_row_variables = to_real(first_row_variables);
+            process_gate_variables(first_row_variables, index, block_idx);
+            gate_variables.insert(gate_variables.end(), first_row_variables.cbegin(), first_row_variables.cend());
+        }
+        if (!second_row_variables.empty()) {
+            second_row_variables = to_real(second_row_variables);
+            process_gate_variables(second_row_variables, index + 1, block_idx);
+            gate_variables.insert(gate_variables.end(), second_row_variables.cbegin(), second_row_variables.cend());
+        }
     }
     return gate_variables;
 }
@@ -206,20 +216,30 @@ inline std::vector<uint32_t> StaticAnalyzer_<FF>::get_elliptic_gate_connected_co
  * @details Processes delta range constraints by collecting all wire indices
  *          from the current gate
  */
-template <typename FF>
-inline std::vector<uint32_t> StaticAnalyzer_<FF>::get_sort_constraint_connected_component(
-    bb::UltraCircuitBuilder& ultra_circuit_builder, size_t index, size_t blk_idx, UltraBlock& block)
+template <typename FF, typename CircuitBuilder>
+inline std::vector<uint32_t> StaticAnalyzer_<FF, CircuitBuilder>::get_sort_constraint_connected_component(
+    size_t index, size_t blk_idx, auto& block)
 {
     std::vector<uint32_t> gate_variables = {};
     if (!block.q_delta_range()[index].is_zero()) {
-        gate_variables.reserve(4);
-        gate_variables.emplace_back(block.w_l()[index]);
-        gate_variables.emplace_back(block.w_r()[index]);
-        gate_variables.emplace_back(block.w_o()[index]);
-        gate_variables.emplace_back(block.w_4()[index]);
+        std::vector<uint32_t> row_variables = {
+            block.w_l()[index], block.w_r()[index], block.w_o()[index], block.w_4()[index]
+        };
+        /*
+        sometimes process_range_list function adds variables with zero_idx in beginning of vector with indices
+        in order to pad a size of indices to gate width. But tool has to ignore these additional variables
+        */
+        for (const auto& var_idx : row_variables) {
+            if (var_idx != circuit_builder.zero_idx) {
+                gate_variables.emplace_back(var_idx);
+            }
+        }
+        if (index != block.size() - 1 && block.w_l()[index + 1] != circuit_builder.zero_idx) {
+            gate_variables.emplace_back(block.w_l()[index + 1]);
+        }
     }
-    gate_variables = this->to_real(ultra_circuit_builder, gate_variables);
-    this->process_gate_variables(gate_variables, index, blk_idx);
+    gate_variables = to_real(gate_variables);
+    process_gate_variables(gate_variables, index, blk_idx);
     return gate_variables;
 }
 
@@ -234,9 +254,10 @@ inline std::vector<uint32_t> StaticAnalyzer_<FF>::get_sort_constraint_connected_
  * @details Processes plookup gates by collecting variables based on selector values,
  *          including variables from the next gate when necessary
  */
-template <typename FF>
-inline std::vector<uint32_t> StaticAnalyzer_<FF>::get_plookup_gate_connected_component(
-    bb::UltraCircuitBuilder& ultra_circuit_builder, size_t index, size_t blk_idx, UltraBlock& block)
+template <typename FF, typename CircuitBuilder>
+inline std::vector<uint32_t> StaticAnalyzer_<FF, CircuitBuilder>::get_plookup_gate_connected_component(size_t index,
+                                                                                                       size_t blk_idx,
+                                                                                                       auto& block)
 {
     std::vector<uint32_t> gate_variables;
     auto q_lookup_type = block.q_lookup_type()[index];
@@ -259,8 +280,8 @@ inline std::vector<uint32_t> StaticAnalyzer_<FF>::get_plookup_gate_connected_com
                 gate_variables.emplace_back(block.w_o()[index + 1]);
             }
         }
-        gate_variables = this->to_real(ultra_circuit_builder, gate_variables);
-        this->process_gate_variables(gate_variables, index, blk_idx);
+        gate_variables = to_real(gate_variables);
+        process_gate_variables(gate_variables, index, blk_idx);
     }
     return gate_variables;
 }
@@ -274,9 +295,10 @@ inline std::vector<uint32_t> StaticAnalyzer_<FF>::get_plookup_gate_connected_com
  * @param block block containing the gates
  * @return std::vector<uint32_t> vector of connected variables from the gate
  */
-template <typename FF>
-inline std::vector<uint32_t> StaticAnalyzer_<FF>::get_poseido2s_gate_connected_component(
-    bb::UltraCircuitBuilder& ultra_circuit_builder, size_t index, size_t blk_idx, UltraBlock& block)
+template <typename FF, typename CircuitBuilder>
+inline std::vector<uint32_t> StaticAnalyzer_<FF, CircuitBuilder>::get_poseido2s_gate_connected_component(size_t index,
+                                                                                                         size_t blk_idx,
+                                                                                                         auto& block)
 {
     std::vector<uint32_t> gate_variables;
     auto internal_selector = block.q_poseidon2_internal()[index];
@@ -293,8 +315,8 @@ inline std::vector<uint32_t> StaticAnalyzer_<FF>::get_poseido2s_gate_connected_c
             gate_variables.emplace_back(block.w_o()[index + 1]);
             gate_variables.emplace_back(block.w_4()[index + 1]);
         }
-        gate_variables = this->to_real(ultra_circuit_builder, gate_variables);
-        this->process_gate_variables(gate_variables, index, blk_idx);
+        gate_variables = to_real(gate_variables);
+        process_gate_variables(gate_variables, index, blk_idx);
     }
     return gate_variables;
 }
@@ -308,9 +330,10 @@ inline std::vector<uint32_t> StaticAnalyzer_<FF>::get_poseido2s_gate_connected_c
  * @param block block containing the gates
  * @return std::vector<uint32_t> vector of connected variables from the gate
  */
-template <typename FF>
-inline std::vector<uint32_t> StaticAnalyzer_<FF>::get_memory_gate_connected_component(
-    bb::UltraCircuitBuilder& ultra_builder, size_t index, size_t blk_idx, UltraBlock& block)
+template <typename FF, typename CircuitBuilder>
+inline std::vector<uint32_t> StaticAnalyzer_<FF, CircuitBuilder>::get_memory_gate_connected_component(size_t index,
+                                                                                                      size_t blk_idx,
+                                                                                                      auto& block)
 {
     std::vector<uint32_t> gate_variables;
     if (!block.q_memory()[index].is_zero()) {
@@ -319,14 +342,6 @@ inline std::vector<uint32_t> StaticAnalyzer_<FF>::get_memory_gate_connected_comp
         auto q_2 = block.q_2()[index];
         auto q_3 = block.q_3()[index];
         auto q_4 = block.q_4()[index];
-        [[maybe_unused]] auto q_m = block.q_m()[index];
-        [[maybe_unused]] auto q_c = block.q_c()[index];
-
-        [[maybe_unused]] auto w_l = block.w_l()[index];
-        [[maybe_unused]] auto w_r = block.w_r()[index];
-        [[maybe_unused]] auto w_o = block.w_o()[index];
-        [[maybe_unused]] auto w_4 = block.w_4()[index];
-
         if (q_1 == FF::one() && q_4 == FF::one()) {
             ASSERT(q_3.is_zero());
             // ram timestamp check
@@ -361,8 +376,8 @@ inline std::vector<uint32_t> StaticAnalyzer_<FF>::get_memory_gate_connected_comp
             }
         }
     }
-    gate_variables = this->to_real(ultra_builder, gate_variables);
-    this->process_gate_variables(gate_variables, index, blk_idx);
+    gate_variables = to_real(gate_variables);
+    process_gate_variables(gate_variables, index, blk_idx);
     return gate_variables;
 }
 
@@ -375,9 +390,9 @@ inline std::vector<uint32_t> StaticAnalyzer_<FF>::get_memory_gate_connected_comp
  * @param block block containing the gates
  * @return std::vector<uint32_t> vector of connected variables from the gate
  */
-template <typename FF>
-inline std::vector<uint32_t> StaticAnalyzer_<FF>::get_non_native_field_gate_connected_component(
-    bb::UltraCircuitBuilder& ultra_builder, size_t index, size_t blk_idx, UltraBlock& block)
+template <typename FF, typename CircuitBuilder>
+inline std::vector<uint32_t> StaticAnalyzer_<FF, CircuitBuilder>::get_non_native_field_gate_connected_component(
+    size_t index, size_t blk_idx, auto& block)
 {
     std::vector<uint32_t> gate_variables;
     if (!block.q_nnf()[index].is_zero()) {
@@ -387,7 +402,6 @@ inline std::vector<uint32_t> StaticAnalyzer_<FF>::get_non_native_field_gate_conn
         auto q_3 = block.q_3()[index];
         auto q_4 = block.q_4()[index];
         auto q_m = block.q_m()[index];
-        [[maybe_unused]] auto q_c = block.q_c()[index];
 
         auto w_l = block.w_l()[index];
         auto w_r = block.w_r()[index];
@@ -444,8 +458,8 @@ inline std::vector<uint32_t> StaticAnalyzer_<FF>::get_non_native_field_gate_conn
             }
         }
     }
-    gate_variables = this->to_real(ultra_builder, gate_variables);
-    this->process_gate_variables(gate_variables, index, blk_idx);
+    gate_variables = to_real(gate_variables);
+    process_gate_variables(gate_variables, index, blk_idx);
     return gate_variables;
 }
 
@@ -456,53 +470,56 @@ inline std::vector<uint32_t> StaticAnalyzer_<FF>::get_non_native_field_gate_conn
  * @param rom_array ROM transcript containing records with witness indices and gate information
  * @return std::vector<uint32_t> vector of connected variables from ROM table gates
  */
-template <typename FF>
-inline std::vector<uint32_t> StaticAnalyzer_<FF>::get_rom_table_connected_component(
-    bb::UltraCircuitBuilder& ultra_builder, const bb::RomTranscript& rom_array)
+template <typename FF, typename CircuitBuilder>
+inline std::vector<uint32_t> StaticAnalyzer_<FF, CircuitBuilder>::get_rom_table_connected_component(
+    const bb::RomTranscript& rom_array)
 {
-    size_t block_index = find_block_index(ultra_builder, ultra_builder.blocks.memory);
-    BB_ASSERT_EQ(block_index, 5U);
-
     // Every RomTranscript data structure has 2 main components that are interested for static analyzer:
     // 1) records contains values that were put in the gate, we can use them to create connections between variables
     // 2) states contains values witness indexes that we can find in the ROM record in the RomTrascript, so we can
     // ignore state of the ROM transcript, because we still can connect all variables using variables from records.
     std::vector<uint32_t> rom_table_variables;
+    if (std::optional<size_t> blk_idx = find_block_index(circuit_builder.blocks.memory); blk_idx) {
+        // Every RomTranscript data structure has 2 main components that are interested for static analyzer:
+        // 1) records contains values that were put in the gate, we can use them to create connections between variables
+        // 2) states contains values witness indexes that we can find in the ROM record in the RomTrascript, so we can
+        // ignore state of the ROM transcript, because we still can connect all variables using variables from records.
+        for (const auto& record : rom_array.records) {
+            std::vector<uint32_t> gate_variables;
+            size_t gate_index = record.gate_index;
 
-    for (const auto& record : rom_array.records) {
-        std::vector<uint32_t> gate_variables;
-        size_t gate_index = record.gate_index;
+            auto q_1 = circuit_builder.blocks.memory.q_1()[gate_index];
+            auto q_2 = circuit_builder.blocks.memory.q_2()[gate_index];
+            auto q_3 = circuit_builder.blocks.memory.q_3()[gate_index];
+            auto q_4 = circuit_builder.blocks.memory.q_4()[gate_index];
+            auto q_m = circuit_builder.blocks.memory.q_m()[gate_index];
+            auto q_c = circuit_builder.blocks.memory.q_c()[gate_index];
 
-        auto q_1 = ultra_builder.blocks.memory.q_1()[gate_index];
-        auto q_2 = ultra_builder.blocks.memory.q_2()[gate_index];
-        auto q_3 = ultra_builder.blocks.memory.q_3()[gate_index];
-        auto q_4 = ultra_builder.blocks.memory.q_4()[gate_index];
-        auto q_m = ultra_builder.blocks.memory.q_m()[gate_index];
-        auto q_c = ultra_builder.blocks.memory.q_c()[gate_index];
+            auto index_witness = record.index_witness;
+            auto vc1_witness = record.value_column1_witness; // state[0] from RomTranscript
+            auto vc2_witness = record.value_column2_witness; // state[1] from RomTranscript
+            auto record_witness = record.record_witness;
 
-        auto index_witness = record.index_witness;
-        auto vc1_witness = record.value_column1_witness; // state[0] from RomTranscript
-        auto vc2_witness = record.value_column2_witness; // state[1] from RomTranscript
-        auto record_witness = record.record_witness;
-
-        if (q_1 == FF::one() && q_m == FF::one() && q_2.is_zero() && q_3.is_zero() && q_4.is_zero() && q_c.is_zero()) {
-            // By default ROM read gate uses variables (w_1, w_2, w_3, w_4) = (index_witness, vc1_witness, vc2_witness,
-            // record_witness) So we can update all of them
-            gate_variables.emplace_back(index_witness);
-            if (vc1_witness != ultra_builder.zero_idx) {
-                gate_variables.emplace_back(vc1_witness);
+            if (q_1 == FF::one() && q_m == FF::one() && q_2.is_zero() && q_3.is_zero() && q_4.is_zero() &&
+                q_c.is_zero()) {
+                // By default ROM read gate uses variables (w_1, w_2, w_3, w_4) = (index_witness, vc1_witness,
+                // vc2_witness, record_witness) So we can update all of them
+                gate_variables.emplace_back(index_witness);
+                if (vc1_witness != circuit_builder.zero_idx) {
+                    gate_variables.emplace_back(vc1_witness);
+                }
+                if (vc2_witness != circuit_builder.zero_idx) {
+                    gate_variables.emplace_back(vc2_witness);
+                }
+                gate_variables.emplace_back(record_witness);
             }
-            if (vc2_witness != ultra_builder.zero_idx) {
-                gate_variables.emplace_back(vc2_witness);
+            gate_variables = to_real(gate_variables);
+            process_gate_variables(gate_variables, gate_index, *blk_idx);
+            // after process_gate_variables function gate_variables constists of real variables indexes, so we can
+            // add all this variables in the final vector to connect all of them
+            if (!gate_variables.empty()) {
+                rom_table_variables.insert(rom_table_variables.end(), gate_variables.begin(), gate_variables.end());
             }
-            gate_variables.emplace_back(record_witness);
-        }
-        gate_variables = this->to_real(ultra_builder, gate_variables);
-        this->process_gate_variables(gate_variables, gate_index, block_index);
-        // after process_gate_variables function gate_variables constists of real variables indexes, so we can add all
-        // this variables in the final vector to connect all of them
-        if (!gate_variables.empty()) {
-            rom_table_variables.insert(rom_table_variables.end(), gate_variables.begin(), gate_variables.end());
         }
     }
     return rom_table_variables;
@@ -515,53 +532,222 @@ inline std::vector<uint32_t> StaticAnalyzer_<FF>::get_rom_table_connected_compon
  * @param ram_array RAM transcript containing records with witness indices and gate information
  * @return std::vector<uint32_t> vector of connected variables from RAM table gates
  */
-template <typename FF>
-inline std::vector<uint32_t> StaticAnalyzer_<FF>::get_ram_table_connected_component(
-    bb::UltraCircuitBuilder& ultra_builder, const bb::RamTranscript& ram_array)
+template <typename FF, typename CircuitBuilder>
+inline std::vector<uint32_t> StaticAnalyzer_<FF, CircuitBuilder>::get_ram_table_connected_component(
+    const bb::RamTranscript& ram_array)
 {
-    size_t block_index = find_block_index(ultra_builder, ultra_builder.blocks.memory);
-    BB_ASSERT_EQ(block_index, 5U);
     std::vector<uint32_t> ram_table_variables;
-    for (const auto& record : ram_array.records) {
-        std::vector<uint32_t> gate_variables;
-        size_t gate_index = record.gate_index;
+    if (std::optional<size_t> blk_idx = find_block_index(circuit_builder.blocks.memory); blk_idx) {
+        for (const auto& record : ram_array.records) {
+            std::vector<uint32_t> gate_variables;
+            size_t gate_index = record.gate_index;
 
-        auto q_1 = ultra_builder.blocks.memory.q_1()[gate_index];
-        auto q_2 = ultra_builder.blocks.memory.q_2()[gate_index];
-        auto q_3 = ultra_builder.blocks.memory.q_3()[gate_index];
-        auto q_4 = ultra_builder.blocks.memory.q_4()[gate_index];
-        auto q_m = ultra_builder.blocks.memory.q_m()[gate_index];
-        auto q_c = ultra_builder.blocks.memory.q_c()[gate_index];
+            auto q_1 = circuit_builder.blocks.memory.q_1()[gate_index];
+            auto q_2 = circuit_builder.blocks.memory.q_2()[gate_index];
+            auto q_3 = circuit_builder.blocks.memory.q_3()[gate_index];
+            auto q_4 = circuit_builder.blocks.memory.q_4()[gate_index];
+            auto q_m = circuit_builder.blocks.memory.q_m()[gate_index];
+            auto q_c = circuit_builder.blocks.memory.q_c()[gate_index];
 
-        auto index_witness = record.index_witness;
-        auto timestamp_witness = record.timestamp_witness;
-        auto value_witness = record.value_witness;
-        auto record_witness = record.record_witness;
+            auto index_witness = record.index_witness;
+            auto timestamp_witness = record.timestamp_witness;
+            auto value_witness = record.value_witness;
+            auto record_witness = record.record_witness;
 
-        if (q_1 == FF::one() && q_m == FF::one() && q_2.is_zero() && q_3.is_zero() && q_4.is_zero() &&
-            (q_c.is_zero() || q_c == FF::one())) {
-            // By default RAM read/write gate uses variables (w_1, w_2, w_3, w_4) = (index_witness, timestamp_witness,
-            // value_witness, record_witness) So we can update all of them
-            gate_variables.emplace_back(index_witness);
-            if (timestamp_witness != ultra_builder.zero_idx) {
-                gate_variables.emplace_back(timestamp_witness);
+            if (q_1 == FF::one() && q_m == FF::one() && q_2.is_zero() && q_3.is_zero() && q_4.is_zero() &&
+                (q_c.is_zero() || q_c == FF::one())) {
+                // By default RAM read/write gate uses variables (w_1, w_2, w_3, w_4) = (index_witness,
+                // timestamp_witness, value_witness, record_witness) So we can update all of them
+                gate_variables.emplace_back(index_witness);
+                if (timestamp_witness != circuit_builder.zero_idx) {
+                    gate_variables.emplace_back(timestamp_witness);
+                }
+                if (value_witness != circuit_builder.zero_idx) {
+                    gate_variables.emplace_back(value_witness);
+                }
+                gate_variables.emplace_back(record_witness);
             }
-            if (value_witness != ultra_builder.zero_idx) {
-                gate_variables.emplace_back(value_witness);
-            }
-            gate_variables.emplace_back(record_witness);
+            gate_variables = to_real(gate_variables);
+            process_gate_variables(gate_variables, gate_index, *blk_idx);
+            // after process_gate_variables function gate_variables constists of real variables indexes, so we can add
+            // all these variables in the final vector to connect all of them
+            ram_table_variables.insert(ram_table_variables.end(), gate_variables.begin(), gate_variables.end());
         }
-        gate_variables = this->to_real(ultra_builder, gate_variables);
-        this->process_gate_variables(gate_variables, gate_index, block_index);
-        // after process_gate_variables function gate_variables constists of real variables indexes, so we can add all
-        // these variables in the final vector to connect all of them
-        ram_table_variables.insert(ram_table_variables.end(), gate_variables.begin(), gate_variables.end());
     }
     return ram_table_variables;
 }
 
 /**
- * @brief Construct a new StaticAnalyzer from Ultra Circuit Builder
+ * @brief this method creates connected components from databus gates
+ * @tparam FF field type
+ * @param index index of the current gate
+ * @param block_idx index of the current block
+ * @param blk block containing the gates
+ * @return std::vector<uint32_t> vector of connected variables from the gate
+ * @details Processes databus read operations by collecting variables from left and right wires
+ */
+template <typename FF, typename CircuitBuilder>
+inline std::vector<uint32_t> StaticAnalyzer_<FF, CircuitBuilder>::get_databus_connected_component(size_t index,
+                                                                                                  size_t block_idx,
+                                                                                                  auto& blk)
+{
+    std::vector<uint32_t> gate_variables;
+    if (!blk.q_busread()[index].is_zero()) {
+        gate_variables.insert(gate_variables.end(), { blk.w_l()[index], blk.w_r()[index] });
+        gate_variables = to_real(gate_variables);
+        process_gate_variables(gate_variables, index, block_idx);
+    }
+    return gate_variables;
+}
+
+/**
+ * @brief this method creates connected components from elliptic curve operation gates
+ * @tparam FF field type
+ * @param index index of the current gate
+ * @param block_idx index of the current block
+ * @param blk block containing the gates
+ * @return std::vector<uint32_t> vector of connected variables from the gate
+ * @details Processes elliptic curve operations by collecting variables from current and next gates,
+ *          handling opcodes and coordinate variables for curve operations
+ */
+template <typename FF, typename CircuitBuilder>
+inline std::vector<uint32_t> StaticAnalyzer_<FF, CircuitBuilder>::get_eccop_part_connected_component(size_t index,
+                                                                                                     size_t block_idx,
+                                                                                                     auto& blk)
+{
+    std::vector<uint32_t> gate_variables;
+    std::vector<uint32_t> first_row_variables;
+    std::vector<uint32_t> second_row_variables;
+    auto w1 = blk.w_l()[index]; // get opcode of operation, because function get_ecc_op_idx returns type
+                                // uint32_t and it adds as w1
+    if (w1 != circuit_builder.zero_idx) {
+        // this is opcode and start of the UltraOp element
+        first_row_variables.insert(
+            first_row_variables.end(),
+            { w1, blk.w_r()[index], blk.w_o()[index], blk.w_4()[index] }); // add op, x_lo, x_hi, y_lo
+        if (index < blk.size() - 1) {
+            second_row_variables.insert(
+                second_row_variables.end(),
+                { blk.w_r()[index + 1], blk.w_o()[index + 1], blk.w_4()[index + 1] }); // add y_hi, z1, z2
+        }
+        first_row_variables = to_real(first_row_variables);
+        second_row_variables = to_real(second_row_variables);
+        process_gate_variables(first_row_variables, index, block_idx);
+        process_gate_variables(second_row_variables, index + 1, block_idx);
+    }
+    if (!first_row_variables.empty()) {
+        gate_variables.insert(gate_variables.end(), first_row_variables.cbegin(), first_row_variables.cend());
+    }
+    if (!second_row_variables.empty()) {
+        gate_variables.insert(gate_variables.end(), second_row_variables.cbegin(), second_row_variables.cend());
+    }
+    return gate_variables;
+}
+
+template <typename FF, typename CircuitBuilder> void StaticAnalyzer_<FF, CircuitBuilder>::process_execution_trace()
+{
+    auto block_data = circuit_builder.blocks.get();
+
+    // We have to determine pub_inputs block index based on circuit builder type, because we have to skip it.
+    // If type of CircuitBuilder is UltraCircuitBuilder, the pub_inputs block is the first block so we can set
+    // pub_inputs_block_idx
+    size_t pub_inputs_block_idx = 0;
+
+    // For MegaCircuitBuilder, pub_inputs block has index 3
+    if constexpr (IsMegaBuilder<CircuitBuilder>) {
+        pub_inputs_block_idx = 3;
+    }
+
+    for (size_t blk_idx = 0; blk_idx < block_data.size() - 1; blk_idx++) {
+        if (block_data[blk_idx].size() == 0 || blk_idx == pub_inputs_block_idx) {
+            continue;
+        }
+        std::vector<uint32_t> sorted_variables;
+        std::vector<uint32_t> eccop_variables;
+        for (size_t gate_idx = 0; gate_idx < block_data[blk_idx].size(); gate_idx++) {
+            auto arithmetic_gates_variables =
+                get_arithmetic_gate_connected_component(gate_idx, blk_idx, block_data[blk_idx]);
+            if (!arithmetic_gates_variables.empty() && connect_variables) {
+                for (const auto& gate_variables : arithmetic_gates_variables) {
+                    connect_all_variables_in_vector(gate_variables);
+                }
+            }
+            auto elliptic_gate_variables =
+                get_elliptic_gate_connected_component(gate_idx, blk_idx, block_data[blk_idx]);
+            if (connect_variables) {
+                connect_all_variables_in_vector(elliptic_gate_variables);
+            }
+            auto lookup_gate_variables = get_plookup_gate_connected_component(gate_idx, blk_idx, block_data[blk_idx]);
+            if (connect_variables) {
+                connect_all_variables_in_vector(lookup_gate_variables);
+            }
+            auto poseidon2_gate_variables =
+                get_poseido2s_gate_connected_component(gate_idx, blk_idx, block_data[blk_idx]);
+            if (connect_variables) {
+                connect_all_variables_in_vector(poseidon2_gate_variables);
+            }
+            auto nnf_gate_variables =
+                get_non_native_field_gate_connected_component(gate_idx, blk_idx, block_data[blk_idx]);
+            if (connect_variables) {
+                connect_all_variables_in_vector(nnf_gate_variables);
+            }
+            auto memory_gate_variables = get_memory_gate_connected_component(gate_idx, blk_idx, block_data[blk_idx]);
+            if (connect_variables) {
+                connect_all_variables_in_vector(memory_gate_variables);
+            }
+            auto delta_range_variables =
+                get_sort_constraint_connected_component(gate_idx, blk_idx, block_data[blk_idx]);
+            if (connect_variables) {
+                connect_all_variables_in_vector(delta_range_variables);
+            }
+            if constexpr (IsMegaBuilder<CircuitBuilder>) {
+                // If type of CircuitBuilder is MegaCircuitBuilder, we'll try to process blocks like they can be
+                // databus or eccop
+                auto databus_variables = get_databus_connected_component(gate_idx, blk_idx, block_data[blk_idx]);
+                if (connect_variables) {
+                    connect_all_variables_in_vector(databus_variables);
+                }
+                auto eccop_gate_variables = get_eccop_part_connected_component(gate_idx, blk_idx, block_data[blk_idx]);
+                if (connect_variables) {
+                    if (!eccop_gate_variables.empty()) {
+                        // The gotten vector of variables contains all variables from UltraOp element of the table
+                        eccop_variables.insert(
+                            eccop_variables.end(), eccop_gate_variables.begin(), eccop_gate_variables.end());
+                        // if a current opcode is responsible for equality and reset, we have to connect all
+                        // variables in global vector and clear it for the next parts
+                        if (eccop_gate_variables[0] == circuit_builder.equality_op_idx) {
+                            connect_all_variables_in_vector(eccop_variables);
+                            eccop_variables.clear();
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    const auto& rom_arrays = circuit_builder.rom_ram_logic.rom_arrays;
+    if (!rom_arrays.empty()) {
+        for (const auto& rom_array : rom_arrays) {
+            std::vector<uint32_t> variable_indices = get_rom_table_connected_component(rom_array);
+            if (connect_variables) {
+                connect_all_variables_in_vector(variable_indices);
+            }
+        }
+    }
+
+    const auto& ram_arrays = circuit_builder.rom_ram_logic.ram_arrays;
+    if (!ram_arrays.empty()) {
+        for (const auto& ram_array : ram_arrays) {
+            std::vector<uint32_t> variable_indices = get_ram_table_connected_component(ram_array);
+            if (connect_variables) {
+                connect_all_variables_in_vector(variable_indices);
+            }
+        }
+    }
+}
+
+/**
+ * @brief Construct a new StaticAnalyzer for Ultra Circuit Builder or Mega Circuit Builder
  * @tparam FF field type used in the circuit
  * @param ultra_circuit_constructor circuit builder containing all gates and variables
  * @details This constructor initializes the graph structure by:
@@ -580,101 +766,21 @@ inline std::vector<uint32_t> StaticAnalyzer_<FF>::get_ram_table_connected_compon
  *          3) Creating connections between variables that appear in the same gate
  *          4) Special handling for sorted constraints in delta range blocks
  */
-template <typename FF>
-StaticAnalyzer_<FF>::StaticAnalyzer_(bb::UltraCircuitBuilder& ultra_circuit_constructor, bool connect_variables)
+template <typename FF, typename CircuitBuilder>
+StaticAnalyzer_<FF, CircuitBuilder>::StaticAnalyzer_(CircuitBuilder& circuit_builder, bool connect_variables)
+    : circuit_builder(circuit_builder)
+    , connect_variables(connect_variables)
 {
-    this->variables_gate_counts =
-        std::unordered_map<uint32_t, size_t>(ultra_circuit_constructor.real_variable_index.size());
-    this->variable_adjacency_lists =
-        std::unordered_map<uint32_t, std::vector<uint32_t>>(ultra_circuit_constructor.real_variable_index.size());
-    this->variables_degree = std::unordered_map<uint32_t, size_t>(ultra_circuit_constructor.real_variable_index.size());
-    for (const auto& variable_index : ultra_circuit_constructor.real_variable_index) {
+    variables_gate_counts = std::unordered_map<uint32_t, size_t>(circuit_builder.real_variable_index.size());
+    variable_adjacency_lists =
+        std::unordered_map<uint32_t, std::vector<uint32_t>>(circuit_builder.real_variable_index.size());
+    variables_degree = std::unordered_map<uint32_t, size_t>(circuit_builder.real_variable_index.size());
+    for (const auto& variable_index : circuit_builder.real_variable_index) {
         variables_gate_counts[variable_index] = 0;
         variables_degree[variable_index] = 0;
         variable_adjacency_lists[variable_index] = {};
     }
-
-    std::map<FF, uint32_t> constant_variable_indices = ultra_circuit_constructor.constant_variable_indices;
-    auto block_data = ultra_circuit_constructor.blocks.get();
-    for (size_t blk_idx = 1; blk_idx < block_data.size() - 1; blk_idx++) {
-        if (block_data[blk_idx].size() == 0) {
-            continue;
-        }
-        std::vector<uint32_t> sorted_variables;
-        for (size_t gate_idx = 0; gate_idx < block_data[blk_idx].size(); gate_idx++) {
-            auto arithmetic_gates_variables = get_arithmetic_gate_connected_component(
-                ultra_circuit_constructor, gate_idx, blk_idx, block_data[blk_idx]);
-            if (!arithmetic_gates_variables.empty() && connect_variables) {
-                for (const auto& gate_variables : arithmetic_gates_variables) {
-                    connect_all_variables_in_vector(ultra_circuit_constructor, gate_variables);
-                }
-            }
-            auto elliptic_gate_variables = get_elliptic_gate_connected_component(
-                ultra_circuit_constructor, gate_idx, blk_idx, block_data[blk_idx]);
-            if (connect_variables) {
-                connect_all_variables_in_vector(ultra_circuit_constructor, elliptic_gate_variables);
-            }
-            auto lookup_gate_variables =
-                get_plookup_gate_connected_component(ultra_circuit_constructor, gate_idx, blk_idx, block_data[blk_idx]);
-            if (connect_variables) {
-                connect_all_variables_in_vector(ultra_circuit_constructor, lookup_gate_variables);
-            }
-            auto poseidon2_gate_variables = get_poseido2s_gate_connected_component(
-                ultra_circuit_constructor, gate_idx, blk_idx, block_data[blk_idx]);
-            if (connect_variables) {
-                connect_all_variables_in_vector(ultra_circuit_constructor, poseidon2_gate_variables);
-            }
-            auto memory_gate_variables =
-                get_memory_gate_connected_component(ultra_circuit_constructor, gate_idx, blk_idx, block_data[blk_idx]);
-            if (connect_variables) {
-                connect_all_variables_in_vector(ultra_circuit_constructor, memory_gate_variables);
-            }
-            auto nnf_gate_variables = get_non_native_field_gate_connected_component(
-                ultra_circuit_constructor, gate_idx, blk_idx, block_data[blk_idx]);
-            if (connect_variables) {
-                connect_all_variables_in_vector(ultra_circuit_constructor, nnf_gate_variables);
-            }
-            if (arithmetic_gates_variables.empty() && elliptic_gate_variables.empty() &&
-                lookup_gate_variables.empty() && poseidon2_gate_variables.empty() && memory_gate_variables.empty() &&
-                nnf_gate_variables.empty()) {
-                // if all vectors are empty it means that current block is delta range, and it needs another
-                // processing method
-                auto delta_range_gate_variables = get_sort_constraint_connected_component(
-                    ultra_circuit_constructor, gate_idx, blk_idx, block_data[blk_idx]);
-                if (delta_range_gate_variables.empty()) {
-                    if (connect_variables) {
-                        connect_all_variables_in_vector(ultra_circuit_constructor, sorted_variables);
-                    }
-                    sorted_variables.clear();
-                } else {
-                    sorted_variables.insert(
-                        sorted_variables.end(), delta_range_gate_variables.begin(), delta_range_gate_variables.end());
-                }
-            }
-        }
-    }
-
-    const auto& rom_arrays = ultra_circuit_constructor.rom_ram_logic.rom_arrays;
-    if (!rom_arrays.empty()) {
-        for (const auto& rom_array : rom_arrays) {
-            std::vector<uint32_t> variable_indices =
-                this->get_rom_table_connected_component(ultra_circuit_constructor, rom_array);
-            if (connect_variables) {
-                this->connect_all_variables_in_vector(ultra_circuit_constructor, variable_indices);
-            }
-        }
-    }
-
-    const auto& ram_arrays = ultra_circuit_constructor.rom_ram_logic.ram_arrays;
-    if (!ram_arrays.empty()) {
-        for (const auto& ram_array : ram_arrays) {
-            std::vector<uint32_t> variable_indices =
-                this->get_ram_table_connected_component(ultra_circuit_constructor, ram_array);
-            if (connect_variables) {
-                this->connect_all_variables_in_vector(ultra_circuit_constructor, variable_indices);
-            }
-        }
-    }
+    process_execution_trace();
 }
 
 /**
@@ -686,14 +792,13 @@ StaticAnalyzer_<FF>::StaticAnalyzer_(bb::UltraCircuitBuilder& ultra_circuit_cons
  * @return false
  */
 
-template <typename FF>
-bool StaticAnalyzer_<FF>::check_is_not_constant_variable(bb::UltraCircuitBuilder& ultra_circuit_builder,
-                                                         const uint32_t& variable_index)
+template <typename FF, typename CircuitBuilder>
+bool StaticAnalyzer_<FF, CircuitBuilder>::check_is_not_constant_variable(const uint32_t& variable_index)
 {
     bool is_not_constant = true;
-    const auto& constant_variable_indices = ultra_circuit_builder.constant_variable_indices;
+    const auto& constant_variable_indices = circuit_builder.constant_variable_indices;
     for (const auto& pair : constant_variable_indices) {
-        if (pair.second == ultra_circuit_builder.real_variable_index[variable_index]) {
+        if (pair.second == circuit_builder.real_variable_index[variable_index]) {
             is_not_constant = false;
             break;
         }
@@ -712,9 +817,8 @@ bool StaticAnalyzer_<FF>::check_is_not_constant_variable(bb::UltraCircuitBuilder
  * @param is_sorted_variables
  */
 
-template <typename FF>
-void StaticAnalyzer_<FF>::connect_all_variables_in_vector(bb::UltraCircuitBuilder& ultra_circuit_builder,
-                                                          const std::vector<uint32_t>& variables_vector)
+template <typename FF, typename CircuitBuilder>
+void StaticAnalyzer_<FF, CircuitBuilder>::connect_all_variables_in_vector(const std::vector<uint32_t>& variables_vector)
 {
     if (variables_vector.empty()) {
         return;
@@ -726,8 +830,8 @@ void StaticAnalyzer_<FF>::connect_all_variables_in_vector(bb::UltraCircuitBuilde
                  variables_vector.end(),
                  std::back_inserter(filtered_variables_vector),
                  [&](uint32_t variable_index) {
-                     return variable_index != ultra_circuit_builder.zero_idx &&
-                            this->check_is_not_constant_variable(ultra_circuit_builder, variable_index);
+                     return variable_index != circuit_builder.zero_idx &&
+                            this->check_is_not_constant_variable(variable_index);
                  });
     // Remove duplicates
     auto unique_pointer = std::unique(filtered_variables_vector.begin(), filtered_variables_vector.end());
@@ -736,7 +840,7 @@ void StaticAnalyzer_<FF>::connect_all_variables_in_vector(bb::UltraCircuitBuilde
         return;
     }
     for (size_t i = 0; i < filtered_variables_vector.size() - 1; i++) {
-        this->add_new_edge(filtered_variables_vector[i], filtered_variables_vector[i + 1]);
+        add_new_edge(filtered_variables_vector[i], filtered_variables_vector[i + 1]);
     }
 }
 
@@ -747,8 +851,9 @@ void StaticAnalyzer_<FF>::connect_all_variables_in_vector(bb::UltraCircuitBuilde
  * @param second_variable_index
  */
 
-template <typename FF>
-void StaticAnalyzer_<FF>::add_new_edge(const uint32_t& first_variable_index, const uint32_t& second_variable_index)
+template <typename FF, typename CircuitBuilder>
+void StaticAnalyzer_<FF, CircuitBuilder>::add_new_edge(const uint32_t& first_variable_index,
+                                                       const uint32_t& second_variable_index)
 {
     variable_adjacency_lists[first_variable_index].emplace_back(second_variable_index);
     variable_adjacency_lists[second_variable_index].emplace_back(first_variable_index);
@@ -764,10 +869,10 @@ void StaticAnalyzer_<FF>::add_new_edge(const uint32_t& first_variable_index, con
  * @param connected_component
  */
 
-template <typename FF>
-void StaticAnalyzer_<FF>::depth_first_search(const uint32_t& variable_index,
-                                             std::unordered_set<uint32_t>& is_used,
-                                             std::vector<uint32_t>& connected_component)
+template <typename FF, typename CircuitBuilder>
+void StaticAnalyzer_<FF, CircuitBuilder>::depth_first_search(const uint32_t& variable_index,
+                                                             std::unordered_set<uint32_t>& is_used,
+                                                             std::vector<uint32_t>& connected_component)
 {
     std::stack<uint32_t> variable_stack;
     variable_stack.push(variable_index);
@@ -787,25 +892,89 @@ void StaticAnalyzer_<FF>::depth_first_search(const uint32_t& variable_index,
 /**
  * @brief this methond finds all connected components in the graph described by adjacency lists
  * @tparam FF
- * @return std::vector<std::vector<uint32_t>> list of connected components where each component is a vector of variable
- * indices
+ * @return std::vector<std::vector<uint32_t>> list of connected components where each component is a vector of
+ * variable indices
  */
 
-template <typename FF> std::vector<std::vector<uint32_t>> StaticAnalyzer_<FF>::find_connected_components()
+template <typename FF, typename CircuitBuilder>
+std::vector<ConnectedComponent> StaticAnalyzer_<FF, CircuitBuilder>::find_connected_components(
+    bool return_all_connected_components)
 {
-    std::unordered_set<uint32_t> is_used;
-    std::vector<std::vector<uint32_t>> connected_components;
+    if (!connect_variables) {
+        throw std::runtime_error("find_connected_components() can only be called when connect_variables is true");
+    }
+    std::unordered_set<uint32_t> visited;
     for (const auto& pair : variable_adjacency_lists) {
         if (pair.first != 0 && variables_degree[pair.first] > 0) {
-            if (!is_used.contains(pair.first)) {
-                std::vector<uint32_t> connected_component;
-                this->depth_first_search(pair.first, is_used, connected_component);
-                std::sort(connected_component.begin(), connected_component.end());
-                connected_components.emplace_back(connected_component);
+            if (!visited.contains(pair.first)) {
+                std::vector<uint32_t> variable_indices;
+                depth_first_search(pair.first, visited, variable_indices);
+                std::sort(variable_indices.begin(), variable_indices.end());
+                connected_components.emplace_back(ConnectedComponent(variable_indices));
             }
         }
     }
+    mark_range_list_connected_components();
+    mark_finalize_connected_components();
+    if (!return_all_connected_components) {
+        main_connected_components.reserve(connected_components.size());
+        for (auto& cc : connected_components) {
+            if (!cc.is_range_list_cc && !cc.is_finalize_cc) {
+                main_connected_components.emplace_back(std::move(cc));
+            }
+        }
+        return main_connected_components;
+    }
     return connected_components;
+}
+
+/**
+ * @brief this method marks some connected componets like they represent range lists
+ * tool needs this method to remove range lists because after method finalize was called
+ * because they aren't connected to other variables in a circuit. It's intended behaviout but the tool shows them as
+ * another connected component
+ * @tparam FF
+ * @tparam CircuitBuilder
+ */
+
+template <typename FF, typename CircuitBuilder>
+void StaticAnalyzer_<FF, CircuitBuilder>::mark_range_list_connected_components()
+{
+    const auto& tags = circuit_builder.real_variable_tags;
+    std::unordered_set<uint32_t> tau_tags;
+    for (const auto& pair : circuit_builder.range_lists) {
+        tau_tags.insert(pair.second.tau_tag);
+    }
+    for (auto& cc : connected_components) {
+        const auto& variables = cc.variable_indices;
+        const uint32_t first_tag = tags[variables[0]];
+        if (tau_tags.contains(first_tag)) {
+            cc.is_range_list_cc =
+                std::all_of(variables.begin() + 1, variables.end(), [&tags, first_tag](uint32_t var_idx) {
+                    return tags[var_idx] == first_tag;
+                });
+        }
+    }
+}
+
+/**
+ * @brief this method marks some connected components like they represent separated finalize blocks
+ * the point is finalize method create additional gates for ecc_op in databus in Mega case and they aren't connected to
+ * other variables in the circuit. It's intended behaviour but the tool shows them as another connected component
+ * @tparam FF
+ * @tparam CircuitBuilder
+ */
+
+template <typename FF, typename CircuitBuilder>
+void StaticAnalyzer_<FF, CircuitBuilder>::mark_finalize_connected_components()
+{
+    const auto& finalize_witnesses = circuit_builder.finalize_witnesses;
+    for (auto& cc : connected_components) {
+        const auto& vars = cc.vars();
+        cc.is_finalize_cc = std::all_of(vars.begin(), vars.end(), [&finalize_witnesses](uint32_t var_idx) {
+            return finalize_witnesses.contains(var_idx);
+        });
+    }
 }
 
 /**
@@ -823,31 +992,29 @@ template <typename FF> std::vector<std::vector<uint32_t>> StaticAnalyzer_<FF>::f
  * @return size_t
  */
 
-template <typename FF>
-inline size_t StaticAnalyzer_<FF>::process_current_decompose_chain(bb::UltraCircuitBuilder& ultra_circuit_constructor,
-                                                                   std::unordered_set<uint32_t>& variables_in_one_gate,
-                                                                   size_t index)
+template <typename FF, typename CircuitBuilder>
+inline size_t StaticAnalyzer_<FF, CircuitBuilder>::process_current_decompose_chain(size_t index)
 {
-    auto& arithmetic_block = ultra_circuit_constructor.blocks.arithmetic;
-    auto zero_idx = ultra_circuit_constructor.zero_idx;
+    auto& arithmetic_block = circuit_builder.blocks.arithmetic;
+    auto zero_idx = circuit_builder.zero_idx;
     size_t current_index = index;
     std::vector<uint32_t> accumulators_indices;
     while (true) {
-        // we have to remove left, right and output wires of the current gate, cause they'are new_limbs, and they are
-        // useless for the analyzer
+        // we have to remove left, right and output wires of the current gate, cause they'are new_limbs, and they
+        // are useless for the analyzer
         auto fourth_idx = arithmetic_block.w_4()[current_index];
-        accumulators_indices.emplace_back(this->to_real(ultra_circuit_constructor, fourth_idx));
+        accumulators_indices.emplace_back(this->to_real(fourth_idx));
         auto left_idx = arithmetic_block.w_l()[current_index];
         if (left_idx != zero_idx) {
-            variables_in_one_gate.erase(this->to_real(ultra_circuit_constructor, left_idx));
+            variables_in_one_gate.erase(this->to_real(left_idx));
         }
         auto right_idx = arithmetic_block.w_r()[current_index];
         if (right_idx != zero_idx) {
-            variables_in_one_gate.erase(this->to_real(ultra_circuit_constructor, right_idx));
+            variables_in_one_gate.erase(this->to_real(right_idx));
         }
         auto out_idx = arithmetic_block.w_o()[current_index];
         if (out_idx != zero_idx) {
-            variables_in_one_gate.erase(this->to_real(ultra_circuit_constructor, out_idx));
+            variables_in_one_gate.erase(this->to_real(out_idx));
         }
         auto q_arith = arithmetic_block.q_arith()[current_index];
         if (q_arith == 1 || current_index == arithmetic_block.size() - 1) {
@@ -858,12 +1025,12 @@ inline size_t StaticAnalyzer_<FF>::process_current_decompose_chain(bb::UltraCirc
     }
     for (size_t i = 0; i < accumulators_indices.size(); i++) {
         if (i == 0) {
-            // the first variable in accumulators is the variable which decompose was created. So, we have to decrement
-            // variable_gate_counts for this variable
+            // the first variable in accumulators is the variable which decompose was created. So, we have to
+            // decrement variable_gate_counts for this variable
             variables_gate_counts[accumulators_indices[i]] -= 1;
         } else {
-            // next accumulators are useless variables that are not interested for the analyzer. So, for these variables
-            // we can nullify variables_gate_counts
+            // next accumulators are useless variables that are not interested for the analyzer. So, for these
+            // variables we can nullify variables_gate_counts
             variables_gate_counts[accumulators_indices[i]] = 0;
         }
     }
@@ -879,17 +1046,15 @@ inline size_t StaticAnalyzer_<FF>::process_current_decompose_chain(bb::UltraCirc
  * @param decompose_variables
  */
 
-template <typename FF>
-inline void StaticAnalyzer_<FF>::remove_unnecessary_decompose_variables(
-    bb::UltraCircuitBuilder& ultra_circuit_builder,
-    std::unordered_set<uint32_t>& variables_in_one_gate,
+template <typename FF, typename CircuitBuilder>
+inline void StaticAnalyzer_<FF, CircuitBuilder>::remove_unnecessary_decompose_variables(
     const std::unordered_set<uint32_t>& decompose_variables)
 {
     auto is_power_two = [&](const uint256_t& number) { return number > 0 && ((number & (number - 1)) == 0); };
     auto find_position = [&](uint32_t variable_index) {
-        return decompose_variables.contains(this->to_real(ultra_circuit_builder, variable_index));
+        return decompose_variables.contains(this->to_real(variable_index));
     };
-    auto& arithmetic_block = ultra_circuit_builder.blocks.arithmetic;
+    auto& arithmetic_block = circuit_builder.blocks.arithmetic;
     if (arithmetic_block.size() > 0) {
         for (size_t i = 0; i < arithmetic_block.size(); i++) {
             auto q_1 = arithmetic_block.q_1()[i];
@@ -916,7 +1081,7 @@ inline void StaticAnalyzer_<FF>::remove_unnecessary_decompose_variables(
                 if (((find_left && find_right && find_out) || (find_left && find_right && !find_out) ||
                      (find_left && find_right && !find_out) || (find_left && !find_right && !find_out)) &&
                     !find_fourth) {
-                    i = this->process_current_decompose_chain(ultra_circuit_builder, variables_in_one_gate, i);
+                    i = this->process_current_decompose_chain(i);
                 }
             }
         }
@@ -931,27 +1096,27 @@ inline void StaticAnalyzer_<FF>::remove_unnecessary_decompose_variables(
  *          1) Variables from delta_range_constraints created by finalize_circuit()
  *          2) Variables from range_constraints created by range_constraint_into_two_limbs
  */
-template <typename FF>
-void StaticAnalyzer_<FF>::remove_unnecessary_range_constrains_variables(bb::UltraCircuitBuilder& ultra_builder)
+template <typename FF, typename CircuitBuilder>
+void StaticAnalyzer_<FF, CircuitBuilder>::remove_unnecessary_range_constrains_variables()
 {
-    std::map<uint64_t, UltraCircuitBuilder::RangeList> range_lists = ultra_builder.range_lists;
+    std::map<uint64_t, typename CircuitBuilder::RangeList> range_lists = circuit_builder.range_lists;
     std::unordered_set<uint32_t> range_lists_tau_tags;
     std::unordered_set<uint32_t> range_lists_range_tags;
-    std::vector<uint32_t> real_variable_tags = ultra_builder.real_variable_tags;
+    std::vector<uint32_t> real_variable_tags = circuit_builder.real_variable_tags;
     for (const auto& pair : range_lists) {
-        UltraCircuitBuilder::RangeList list = pair.second;
+        typename CircuitBuilder::RangeList list = pair.second;
         range_lists_tau_tags.insert(list.tau_tag);
         range_lists_range_tags.insert(list.range_tag);
     }
     for (uint32_t real_index = 0; real_index < real_variable_tags.size(); real_index++) {
         if (variables_in_one_gate.contains(real_index)) {
-            // this if helps us to remove variables from delta_range_constraints when finalize_circuit() function was
-            // called
+            // this if helps us to remove variables from delta_range_constraints when finalize_circuit() function
+            // was called
             if (range_lists_tau_tags.contains(real_variable_tags[real_index])) {
                 variables_in_one_gate.erase(real_index);
             }
-            // this if helps us to remove variables from range_constraints when range_constraint_into_two_limbs function
-            // was called
+            // this if helps us to remove variables from range_constraints when range_constraint_into_two_limbs
+            // function was called
             if (range_lists_range_tags.contains(real_variable_tags[real_index])) {
                 variables_in_one_gate.erase(real_index);
             }
@@ -970,12 +1135,9 @@ void StaticAnalyzer_<FF>::remove_unnecessary_range_constrains_variables(bb::Ultr
  * @param table_id
  * @param gate_index
  */
-template <typename FF>
-inline void StaticAnalyzer_<FF>::remove_unnecessary_aes_plookup_variables(
-    std::unordered_set<uint32_t>& variables_in_one_gate,
-    UltraCircuitBuilder& ultra_circuit_builder,
-    BasicTableId& table_id,
-    size_t gate_index)
+template <typename FF, typename CircuitBuilder>
+inline void StaticAnalyzer_<FF, CircuitBuilder>::remove_unnecessary_aes_plookup_variables(BasicTableId& table_id,
+                                                                                          size_t gate_index)
 {
 
     auto find_position = [&](uint32_t real_variable_index) {
@@ -984,10 +1146,10 @@ inline void StaticAnalyzer_<FF>::remove_unnecessary_aes_plookup_variables(
     std::unordered_set<BasicTableId> aes_plookup_tables{ BasicTableId::AES_SBOX_MAP,
                                                          BasicTableId::AES_SPARSE_MAP,
                                                          BasicTableId::AES_SPARSE_NORMALIZE };
-    auto& lookup_block = ultra_circuit_builder.blocks.lookup;
+    auto& lookup_block = circuit_builder.blocks.lookup;
     if (aes_plookup_tables.contains(table_id)) {
-        uint32_t real_out_idx = this->to_real(ultra_circuit_builder, lookup_block.w_o()[gate_index]);
-        uint32_t real_right_idx = this->to_real(ultra_circuit_builder, lookup_block.w_r()[gate_index]);
+        uint32_t real_out_idx = this->to_real(lookup_block.w_o()[gate_index]);
+        uint32_t real_right_idx = this->to_real(lookup_block.w_r()[gate_index]);
         if (variables_gate_counts[real_out_idx] != 1 || variables_gate_counts[real_right_idx] != 1) {
             bool find_out = find_position(real_out_idx);
             auto q_c = lookup_block.q_c()[gate_index];
@@ -1012,18 +1174,15 @@ inline void StaticAnalyzer_<FF>::remove_unnecessary_aes_plookup_variables(
  * @param gate_index
  */
 
-template <typename FF>
-inline void StaticAnalyzer_<FF>::remove_unnecessary_sha256_plookup_variables(
-    std::unordered_set<uint32_t>& variables_in_one_gate,
-    UltraCircuitBuilder& ultra_circuit_builder,
-    BasicTableId& table_id,
-    size_t gate_index)
+template <typename FF, typename CircuitBuilder>
+inline void StaticAnalyzer_<FF, CircuitBuilder>::remove_unnecessary_sha256_plookup_variables(BasicTableId& table_id,
+                                                                                             size_t gate_index)
 {
 
     auto find_position = [&](uint32_t real_variable_index) {
         return variables_in_one_gate.contains(real_variable_index);
     };
-    auto& lookup_block = ultra_circuit_builder.blocks.lookup;
+    auto& lookup_block = circuit_builder.blocks.lookup;
     std::unordered_set<BasicTableId> sha256_plookup_tables{ BasicTableId::SHA256_WITNESS_SLICE_3,
                                                             BasicTableId::SHA256_WITNESS_SLICE_7_ROTATE_4,
                                                             BasicTableId::SHA256_WITNESS_SLICE_8_ROTATE_7,
@@ -1037,8 +1196,8 @@ inline void StaticAnalyzer_<FF>::remove_unnecessary_sha256_plookup_variables(
                                                             BasicTableId::SHA256_BASE28_ROTATE3,
                                                             BasicTableId::SHA256_BASE28_ROTATE6 };
     if (sha256_plookup_tables.contains(table_id)) {
-        uint32_t real_right_idx = this->to_real(ultra_circuit_builder, lookup_block.w_r()[gate_index]);
-        uint32_t real_out_idx = this->to_real(ultra_circuit_builder, lookup_block.w_o()[gate_index]);
+        uint32_t real_right_idx = this->to_real(lookup_block.w_r()[gate_index]);
+        uint32_t real_out_idx = this->to_real(lookup_block.w_o()[gate_index]);
         if (variables_gate_counts[real_out_idx] != 1 || variables_gate_counts[real_right_idx] != 1) {
             // auto q_m = lookup_block.q_m()[gate_index];
             auto q_c = lookup_block.q_c()[gate_index];
@@ -1068,16 +1227,15 @@ inline void StaticAnalyzer_<FF>::remove_unnecessary_sha256_plookup_variables(
  * @param gate_index
  */
 
-template <typename FF>
-inline void StaticAnalyzer_<FF>::process_current_plookup_gate(bb::UltraCircuitBuilder& ultra_circuit_builder,
-                                                              size_t gate_index)
+template <typename FF, typename CircuitBuilder>
+inline void StaticAnalyzer_<FF, CircuitBuilder>::process_current_plookup_gate(size_t gate_index)
 {
     auto find_position = [&](uint32_t real_variable_index) {
         return variables_in_one_gate.contains(real_variable_index);
     };
-    auto& lookup_block = ultra_circuit_builder.blocks.lookup;
-    auto& lookup_tables = ultra_circuit_builder.lookup_tables;
-    auto table_index = static_cast<size_t>(lookup_block.q_3()[gate_index]);
+    auto& lookup_block = circuit_builder.blocks.lookup;
+    auto& lookup_tables = circuit_builder.lookup_tables;
+    auto table_index = static_cast<size_t>(static_cast<uint256_t>(lookup_block.q_3()[gate_index]));
     for (const auto& table : lookup_tables) {
         if (table.table_index == table_index) {
             std::unordered_set<bb::fr> column_1(table.column_1.begin(), table.column_1.end());
@@ -1085,30 +1243,28 @@ inline void StaticAnalyzer_<FF>::process_current_plookup_gate(bb::UltraCircuitBu
             std::unordered_set<bb::fr> column_3(table.column_3.begin(), table.column_3.end());
             bb::plookup::BasicTableId table_id = table.id;
             // false cases for AES
-            this->remove_unnecessary_aes_plookup_variables(
-                variables_in_one_gate, ultra_circuit_builder, table_id, gate_index);
+            this->remove_unnecessary_aes_plookup_variables(table_id, gate_index);
             // false cases for sha256
-            this->remove_unnecessary_sha256_plookup_variables(
-                variables_in_one_gate, ultra_circuit_builder, table_id, gate_index);
+            this->remove_unnecessary_sha256_plookup_variables(table_id, gate_index);
             // if the amount of unique elements from columns of plookup tables = 1, it means that
             // variable from this column aren't used and we can remove it.
             if (column_1.size() == 1) {
                 uint32_t left_idx = lookup_block.w_l()[gate_index];
-                uint32_t real_left_idx = this->to_real(ultra_circuit_builder, left_idx);
+                uint32_t real_left_idx = this->to_real(left_idx);
                 bool find_left = find_position(real_left_idx);
                 if (find_left) {
                     variables_in_one_gate.erase(real_left_idx);
                 }
             }
             if (column_2.size() == 1) {
-                uint32_t real_right_idx = this->to_real(ultra_circuit_builder, lookup_block.w_r()[gate_index]);
+                uint32_t real_right_idx = this->to_real(lookup_block.w_r()[gate_index]);
                 bool find_right = find_position(real_right_idx);
                 if (find_right) {
                     variables_in_one_gate.erase(real_right_idx);
                 }
             }
             if (column_3.size() == 1) {
-                uint32_t real_out_idx = this->to_real(ultra_circuit_builder, lookup_block.w_o()[gate_index]);
+                uint32_t real_out_idx = this->to_real(lookup_block.w_o()[gate_index]);
                 bool find_out = find_position(real_out_idx);
                 if (find_out) {
                     variables_in_one_gate.erase(real_out_idx);
@@ -1125,13 +1281,13 @@ inline void StaticAnalyzer_<FF>::process_current_plookup_gate(bb::UltraCircuitBu
  * @param variables_in_one_gate
  */
 
-template <typename FF>
-inline void StaticAnalyzer_<FF>::remove_unnecessary_plookup_variables(bb::UltraCircuitBuilder& ultra_circuit_builder)
+template <typename FF, typename CircuitBuilder>
+inline void StaticAnalyzer_<FF, CircuitBuilder>::remove_unnecessary_plookup_variables()
 {
-    auto& lookup_block = ultra_circuit_builder.blocks.lookup;
+    auto& lookup_block = circuit_builder.blocks.lookup;
     if (lookup_block.size() > 0) {
         for (size_t i = 0; i < lookup_block.size(); i++) {
-            this->process_current_plookup_gate(ultra_circuit_builder, i);
+            this->process_current_plookup_gate(i);
         }
     }
 }
@@ -1144,38 +1300,38 @@ inline void StaticAnalyzer_<FF>::remove_unnecessary_plookup_variables(bb::UltraC
  * @param ultra_builder
  */
 
-template <typename FF>
-inline void StaticAnalyzer_<FF>::remove_record_witness_variables(bb::UltraCircuitBuilder& ultra_builder)
+template <typename FF, typename CircuitBuilder>
+inline void StaticAnalyzer_<FF, CircuitBuilder>::remove_record_witness_variables()
 {
-    auto block_data = ultra_builder.blocks.get();
-    size_t blk_idx = find_block_index(ultra_builder, ultra_builder.blocks.memory);
-    std::vector<uint32_t> to_remove;
-    BB_ASSERT_EQ(blk_idx, 5U);
-    for (const auto& var_idx : variables_in_one_gate) {
-        KeyPair key = { var_idx, blk_idx };
-        if (auto search = variable_gates.find(key); search != variable_gates.end()) {
-            std::vector<size_t> gate_indexes = variable_gates[key];
-            BB_ASSERT_EQ(gate_indexes.size(), 1U);
-            size_t gate_idx = gate_indexes[0];
-            auto q_1 = block_data[blk_idx].q_1()[gate_idx];
-            auto q_2 = block_data[blk_idx].q_2()[gate_idx];
-            auto q_3 = block_data[blk_idx].q_3()[gate_idx];
-            auto q_4 = block_data[blk_idx].q_4()[gate_idx];
-            auto q_m = block_data[blk_idx].q_m()[gate_idx];
-            auto q_arith = block_data[blk_idx].q_arith()[gate_idx];
-            if (q_1 == FF::one() && q_m == FF::one() && q_2.is_zero() && q_3.is_zero() && q_4.is_zero() &&
-                q_arith.is_zero()) {
-                // record witness can be in both ROM and RAM gates, so we can ignore q_c
-                // record witness is written as 4th variable in RAM/ROM read/write gate, so we can get 4th wire value
-                // and check it with our variable
-                if (this->to_real(ultra_builder, block_data[blk_idx].w_4()[gate_idx]) == var_idx) {
-                    to_remove.emplace_back(var_idx);
+    auto block_data = circuit_builder.blocks.get();
+    if (std::optional<size_t> blk_idx = find_block_index(circuit_builder.blocks.memory); blk_idx) {
+        std::vector<uint32_t> to_remove;
+        for (const auto& var_idx : variables_in_one_gate) {
+            KeyPair key = { var_idx, *blk_idx };
+            if (auto search = variable_gates.find(key); search != variable_gates.end()) {
+                std::vector<size_t> gate_indexes = variable_gates[key];
+                ASSERT(gate_indexes.size() == 1);
+                size_t gate_idx = gate_indexes[0];
+                auto q_1 = block_data[*blk_idx].q_1()[gate_idx];
+                auto q_2 = block_data[*blk_idx].q_2()[gate_idx];
+                auto q_3 = block_data[*blk_idx].q_3()[gate_idx];
+                auto q_4 = block_data[*blk_idx].q_4()[gate_idx];
+                auto q_m = block_data[*blk_idx].q_m()[gate_idx];
+                auto q_arith = block_data[*blk_idx].q_arith()[gate_idx];
+                if (q_1 == FF::one() && q_m == FF::one() && q_2.is_zero() && q_3.is_zero() && q_4.is_zero() &&
+                    q_arith.is_zero()) {
+                    // record witness can be in both ROM and RAM gates, so we can ignore q_c
+                    // record witness is written as 4th variable in RAM/ROM read/write gate, so we can get 4th
+                    // wire value and check it with our variable
+                    if (this->to_real(block_data[*blk_idx].w_4()[gate_idx]) == var_idx) {
+                        to_remove.emplace_back(var_idx);
+                    }
                 }
             }
         }
-    }
-    for (const auto& elem : to_remove) {
-        variables_in_one_gate.erase(elem);
+        for (const auto& elem : to_remove) {
+            variables_in_one_gate.erase(elem);
+        }
     }
 }
 
@@ -1186,95 +1342,56 @@ inline void StaticAnalyzer_<FF>::remove_record_witness_variables(bb::UltraCircui
  * @return std::unordered_set<uint32_t> set of variable indices
  */
 
-template <typename FF>
-std::unordered_set<uint32_t> StaticAnalyzer_<FF>::show_variables_in_one_gate(
-    bb::UltraCircuitBuilder& ultra_circuit_builder)
+template <typename FF, typename CircuitBuilder>
+std::unordered_set<uint32_t> StaticAnalyzer_<FF, CircuitBuilder>::get_variables_in_one_gate()
 {
     for (const auto& pair : variables_gate_counts) {
-        bool is_not_constant_variable = this->check_is_not_constant_variable(ultra_circuit_builder, pair.first);
+        bool is_not_constant_variable = check_is_not_constant_variable(pair.first);
         if (pair.second == 1 && pair.first != 0 && is_not_constant_variable) {
-            this->variables_in_one_gate.insert(pair.first);
+            variables_in_one_gate.insert(pair.first);
         }
     }
-    auto range_lists = ultra_circuit_builder.range_lists;
-    std::unordered_set<uint32_t> decompose_varialbes;
+    auto range_lists = circuit_builder.range_lists;
+    std::unordered_set<uint32_t> decompose_variables;
     for (auto& pair : range_lists) {
         for (auto& elem : pair.second.variable_indices) {
-            bool is_not_constant_variable = this->check_is_not_constant_variable(ultra_circuit_builder, elem);
-            if (variables_gate_counts[ultra_circuit_builder.real_variable_index[elem]] == 1 &&
-                is_not_constant_variable) {
-                decompose_varialbes.insert(ultra_circuit_builder.real_variable_index[elem]);
+            bool is_not_constant_variable = check_is_not_constant_variable(elem);
+            if (variables_gate_counts[circuit_builder.real_variable_index[elem]] == 1 && is_not_constant_variable) {
+                decompose_variables.insert(circuit_builder.real_variable_index[elem]);
             }
         }
     }
-    this->remove_unnecessary_decompose_variables(
-        ultra_circuit_builder, this->variables_in_one_gate, decompose_varialbes);
-    this->remove_unnecessary_plookup_variables(ultra_circuit_builder);
-    this->remove_unnecessary_range_constrains_variables(ultra_circuit_builder);
-    for (const auto& elem : this->fixed_variables) {
-        this->variables_in_one_gate.erase(elem);
+    remove_unnecessary_decompose_variables(decompose_variables);
+    remove_unnecessary_plookup_variables();
+    remove_unnecessary_range_constrains_variables();
+    for (const auto& elem : fixed_variables) {
+        variables_in_one_gate.erase(elem);
     }
     // we found variables that were in one gate and they are intended cases.
     // so we have to remove them from the scope
-    for (const auto& elem : ultra_circuit_builder.get_used_witnesses()) {
-        this->variables_in_one_gate.erase(elem);
+    for (const auto& elem : circuit_builder.get_used_witnesses()) {
+        variables_in_one_gate.erase(elem);
     }
-    this->remove_record_witness_variables(ultra_circuit_builder);
+    remove_record_witness_variables();
     return variables_in_one_gate;
 }
 
 /**
- * @brief this method returns connected component with a given index and its size
- * @param connected_components vector of all connected components
- * @param index index of required component
- * @return std::pair<std::vector<uint32_t>, size_t> pair of component and its size
- */
-
-std::pair<std::vector<uint32_t>, size_t> get_connected_component_with_index(
-    const std::vector<std::vector<uint32_t>>& connected_components, size_t index)
-{
-    auto connected_component = connected_components[index];
-    auto size = connected_component.size();
-    return std::make_pair(connected_component, size);
-}
-
-/**
- * @brief this method prints graph as vertices and their adjacency lists
- * example: we have an undirected graph from 3 variables: a, b, c.
- * we have edges: a - b, b - c, c - a.
- * so, there will be next adjacency lists:
- * a: b -> c -> 0\
- * b: a -> c -> 0\
- * c: a -> b -> 0\
+ * @brief this method prints additional information about connected components that were found in the graph
  * @tparam FF
  */
-
-template <typename FF> void StaticAnalyzer_<FF>::print_graph()
+template <typename FF, typename CircuitBuilder>
+void StaticAnalyzer_<FF, CircuitBuilder>::print_connected_components_info()
 {
-    for (const auto& elem : variable_adjacency_lists) {
-        info("variable with index ", elem.first);
-        if (variable_adjacency_lists[elem.first].empty()) {
-            info("is isolated");
-        } else {
-            for (const auto& it : elem.second) {
-                info(it);
+    for (size_t i = 0; i < main_connected_components.size(); i++) {
+        info("size of ", i + 1, " connected component == ", main_connected_components[i].size(), ":");
+        info("Does connected component represent range list? ", main_connected_components[i].is_range_list_cc);
+        info("Does connected component represent something from finalize? ",
+             main_connected_components[i].is_finalize_cc);
+        if (main_connected_components[i].size() < 50) {
+            for (const auto& elem : main_connected_components[i].vars()) {
+                info("elem == ", elem);
             }
-        }
-    }
-}
-
-/**
- * @brief this method prints all connected components that were found in the graph
- * @tparam FF
- */
-
-template <typename FF> void StaticAnalyzer_<FF>::print_connected_components()
-{
-    auto connected_components = find_connected_components();
-    for (size_t i = 0; i < connected_components.size(); i++) {
-        info("printing the ", i + 1, " connected component with size ", connected_components[i].size(), ":");
-        for (const auto& it : connected_components[i]) {
-            info(it, " ");
         }
     }
 }
@@ -1284,7 +1401,7 @@ template <typename FF> void StaticAnalyzer_<FF>::print_connected_components()
  * @tparam FF
  */
 
-template <typename FF> void StaticAnalyzer_<FF>::print_variables_gate_counts()
+template <typename FF, typename CircuitBuilder> void StaticAnalyzer_<FF, CircuitBuilder>::print_variables_gate_counts()
 {
     for (const auto& it : variables_gate_counts) {
         info("number of gates with variables ", it.first, " == ", it.second);
@@ -1298,15 +1415,15 @@ template <typename FF> void StaticAnalyzer_<FF>::print_variables_gate_counts()
  * @param real_idx
  */
 
-template <typename FF>
-void StaticAnalyzer_<FF>::print_variable_in_one_gate(bb::UltraCircuitBuilder& ultra_builder, const uint32_t real_idx)
+template <typename FF, typename CircuitBuilder>
+void StaticAnalyzer_<FF, CircuitBuilder>::print_variable_in_one_gate(const uint32_t real_idx)
 {
-    const auto& block_data = ultra_builder.blocks.get();
+    const auto& block_data = circuit_builder.blocks.get();
     for (const auto& [key, gates] : variable_gates) {
         if (key.first == real_idx) {
             BB_ASSERT_EQ(gates.size(), 1U);
             size_t gate_index = gates[0];
-            UltraBlock block = block_data[key.second];
+            auto& block = block_data[key.second];
             info("---- printing variables in this gate");
             info("w_l == ",
                  block.w_l()[gate_index],
@@ -1373,11 +1490,18 @@ void StaticAnalyzer_<FF>::print_variable_in_one_gate(bb::UltraCircuitBuilder& ul
             if (!q_poseidon2_internal.is_zero()) {
                 info("q_poseidon2_internal == ", q_poseidon2_internal);
             }
+            if constexpr (std::is_same_v<CircuitBuilder, bb::MegaCircuitBuilder>) {
+                auto q_databus = block.q_busread()[gate_index];
+                if (!q_databus.is_zero()) {
+                    info("q_databus == ", q_databus);
+                }
+            }
             info("---- finished printing ----");
         }
     }
 }
 
-template class StaticAnalyzer_<bb::fr>;
+template class StaticAnalyzer_<bb::fr, bb::UltraCircuitBuilder>;
+template class StaticAnalyzer_<bb::fr, bb::MegaCircuitBuilder>;
 
 } // namespace cdg

--- a/barretenberg/cpp/src/barretenberg/boomerang_value_detection/graph.hpp
+++ b/barretenberg/cpp/src/barretenberg/boomerang_value_detection/graph.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include "barretenberg/stdlib_circuit_builders/mega_circuit_builder.hpp"
 #include "barretenberg/stdlib_circuit_builders/ultra_circuit_builder.hpp"
 #include <list>
 #include <set>
@@ -9,8 +10,6 @@
 #include <vector>
 
 namespace cdg {
-
-using UltraBlock = bb::UltraTraceBlock;
 /**
  * We've added a new feature to the static analyzer that tracks which gates contain each variable.
  * This is helpful for removing false-positive variables from the analyzer by using gate selectors
@@ -49,6 +48,19 @@ struct KeyEquals {
     }
 };
 
+struct ConnectedComponent {
+    std::vector<uint32_t> variable_indices;
+    bool is_range_list_cc;
+    bool is_finalize_cc;
+    ConnectedComponent() = default;
+    ConnectedComponent(const std::vector<uint32_t>& vector)
+        : variable_indices(vector)
+        , is_range_list_cc(false)
+        , is_finalize_cc(false) {};
+    size_t size() const { return variable_indices.size(); }
+    const std::vector<uint32_t>& vars() const { return variable_indices; }
+};
+
 /*
  * This class describes an arithmetic circuit as an undirected graph, where vertices are variables from the circuit.
  * Edges describe connections between variables through gates. We want to find variables that weren't properly
@@ -57,133 +69,91 @@ struct KeyEquals {
  * variable wasn't constrained properly. If the number of connected components > 1, it means that there were some missed
  * connections between variables.
  */
-template <typename FF> class StaticAnalyzer_ {
+template <typename FF, typename CircuitBuilder> class StaticAnalyzer_ {
   public:
     StaticAnalyzer_() = default;
     StaticAnalyzer_(const StaticAnalyzer_& other) = delete;
     StaticAnalyzer_(StaticAnalyzer_&& other) = delete;
     StaticAnalyzer_& operator=(const StaticAnalyzer_& other) = delete;
     StaticAnalyzer_&& operator=(StaticAnalyzer_&& other) = delete;
-    StaticAnalyzer_(bb::UltraCircuitBuilder& ultra_circuit_constructor, bool connect_variables = true);
+    StaticAnalyzer_(CircuitBuilder& circuit_builder, bool connect_variables = true);
 
     /**
      * @brief Convert a vector of variable indices to their real indices
-     * @param ultra_circuit_constructor The UltraCircuitBuilder instance
      * @param variable_indices The vector of variable indices to convert
      * @return std::vector<uint32_t> A vector of real variable indices
      */
-    std::vector<uint32_t> to_real(bb::UltraCircuitBuilder& ultra_circuit_constructor,
-                                  std::vector<uint32_t>& variable_indices)
+    std::vector<uint32_t> to_real(std::vector<uint32_t>& variable_indices)
     {
         std::vector<uint32_t> real_variable_indices;
         real_variable_indices.reserve(variable_indices.size());
         for (auto& variable_index : variable_indices) {
-            real_variable_indices.push_back(to_real(ultra_circuit_constructor, variable_index));
+            real_variable_indices.push_back(to_real(variable_index));
         }
         return real_variable_indices;
     };
-
-    uint32_t to_real(bb::UltraCircuitBuilder& ultra_circuit_constructor, const uint32_t& variable_index)
+    uint32_t to_real(const uint32_t& variable_index) const
     {
-        return ultra_circuit_constructor.real_variable_index[variable_index];
-    };
-    size_t find_block_index(bb::UltraCircuitBuilder& ultra_builder, const UltraBlock& block);
+        return circuit_builder.real_variable_index[variable_index];
+    }
+    size_t find_block_index(const auto& block);
     void process_gate_variables(std::vector<uint32_t>& gate_variables, size_t gate_index, size_t blk_idx);
-    std::unordered_map<uint32_t, size_t> get_variables_gate_counts() { return this->variables_gate_counts; };
+    std::unordered_map<uint32_t, size_t> get_variables_gate_counts() const { return this->variables_gate_counts; };
 
-    std::vector<std::vector<uint32_t>> get_arithmetic_gate_connected_component(
-        bb::UltraCircuitBuilder& ultra_circuit_builder, size_t index, size_t block_idx, UltraBlock& blk);
-    std::vector<uint32_t> get_elliptic_gate_connected_component(bb::UltraCircuitBuilder& ultra_circuit_builder,
-                                                                size_t index,
-                                                                size_t block_idx,
-                                                                UltraBlock& blk);
-    std::vector<uint32_t> get_plookup_gate_connected_component(bb::UltraCircuitBuilder& ultra_circuit_builder,
-                                                               size_t index,
-                                                               size_t block_idx,
-                                                               UltraBlock& blk);
-    std::vector<uint32_t> get_sort_constraint_connected_component(bb::UltraCircuitBuilder& ultra_circuit_builder,
-                                                                  size_t index,
-                                                                  size_t block_idx,
-                                                                  UltraBlock& blk);
-    std::vector<uint32_t> get_poseido2s_gate_connected_component(bb::UltraCircuitBuilder& ultra_circuit_builder,
-                                                                 size_t index,
-                                                                 size_t block_idx,
-                                                                 UltraBlock& blk);
-    std::vector<uint32_t> get_memory_gate_connected_component(bb::UltraCircuitBuilder& ultra_circuit_builder,
-                                                              size_t index,
-                                                              size_t block_idx,
-                                                              UltraBlock& blk);
-    std::vector<uint32_t> get_non_native_field_gate_connected_component(bb::UltraCircuitBuilder& ultra_circuit_builder,
-                                                                        size_t index,
-                                                                        size_t block_idx,
-                                                                        UltraBlock& blk);
-    std::vector<uint32_t> get_rom_table_connected_component(bb::UltraCircuitBuilder& ultra_circuit_builder,
-                                                            const bb::RomTranscript& rom_array);
-    std::vector<uint32_t> get_ram_table_connected_component(bb::UltraCircuitBuilder& ultra_builder,
-                                                            const bb::RamTranscript& ram_array);
+    void process_execution_trace();
+
+    std::vector<std::vector<uint32_t>> get_arithmetic_gate_connected_component(size_t index,
+                                                                               size_t block_idx,
+                                                                               auto& blk);
+    std::vector<uint32_t> get_elliptic_gate_connected_component(size_t index, size_t block_idx, auto& blk);
+    std::vector<uint32_t> get_plookup_gate_connected_component(size_t index, size_t block_idx, auto& blk);
+    std::vector<uint32_t> get_sort_constraint_connected_component(size_t index, size_t block_idx, auto& blk);
+    std::vector<uint32_t> get_poseido2s_gate_connected_component(size_t index, size_t block_idx, auto& blk);
+    std::vector<uint32_t> get_non_native_field_gate_connected_component(size_t index, size_t block_idx, auto& blk);
+    std::vector<uint32_t> get_memory_gate_connected_component(size_t index, size_t block_idx, auto& blk);
+    std::vector<uint32_t> get_rom_table_connected_component(const bb::RomTranscript& rom_array);
+    std::vector<uint32_t> get_ram_table_connected_component(const bb::RamTranscript& ram_array);
+    // functions for MegaCircuitBuilder
+    std::vector<uint32_t> get_databus_connected_component(size_t index, size_t block_idx, auto& blk);
+    std::vector<uint32_t> get_eccop_connected_component(size_t index, size_t block_idx, auto& blk);
+    std::vector<uint32_t> get_eccop_part_connected_component(size_t index, size_t block_idx, auto& blk);
 
     void add_new_edge(const uint32_t& first_variable_index, const uint32_t& second_variable_index);
-    std::vector<uint32_t> get_variable_adjacency_list(const uint32_t& variable_index)
-    {
-        return variable_adjacency_lists[variable_index];
-    };
-
     void depth_first_search(const uint32_t& variable_index,
                             std::unordered_set<uint32_t>& is_used,
                             std::vector<uint32_t>& connected_component);
-    std::vector<std::vector<uint32_t>> find_connected_components();
-
-    std::vector<uint32_t> find_variables_with_degree_one();
-    std::unordered_set<uint32_t> get_variables_in_one_gate();
-
-    bool find_arithmetic_gate_for_variable(bb::UltraCircuitBuilder& ultra_circuit_builder,
-                                           const uint32_t& variable_idx);
-    bool find_elliptic_gate_for_variable(bb::UltraCircuitBuilder& ultra_circuit_builder, const uint32_t& variable_idx);
-    bool find_lookup_gate_for_variable(bb::UltraCircuitBuilder& ultra_circuit_builder, const uint32_t& variable_idx);
-
-    size_t get_distance_between_variables(const uint32_t& first_variable_index, const uint32_t& second_variable_index);
+    void mark_range_list_connected_components();
+    void mark_finalize_connected_components();
+    std::vector<ConnectedComponent> find_connected_components(bool return_all_connected_components = false);
     bool check_vertex_in_connected_component(const std::vector<uint32_t>& connected_component,
                                              const uint32_t& var_index);
-
-    void connect_all_variables_in_vector(bb::UltraCircuitBuilder& ultra_circuit_builder,
-                                         const std::vector<uint32_t>& variables_vector);
-    bool check_is_not_constant_variable(bb::UltraCircuitBuilder& ultra_circuit_builder, const uint32_t& variable_index);
+    void connect_all_variables_in_vector(const std::vector<uint32_t>& variables_vector);
+    bool check_is_not_constant_variable(const uint32_t& variable_index);
 
     std::pair<std::vector<uint32_t>, size_t> get_connected_component_with_index(
         const std::vector<std::vector<uint32_t>>& connected_components, size_t index);
 
-    std::unordered_set<uint32_t> get_variables_in_one_gate_without_range_constraints(
-        bb::UltraCircuitBuilder& ultra_circuit_builder);
+    size_t process_current_decompose_chain(size_t index);
+    void process_current_plookup_gate(size_t gate_index);
+    void remove_unnecessary_decompose_variables(const std::unordered_set<uint32_t>& decompose_variables);
+    void remove_unnecessary_plookup_variables();
+    void remove_unnecessary_range_constrains_variables();
+    std::unordered_set<uint32_t> get_variables_in_one_gate();
 
-    size_t process_current_decompose_chain(bb::UltraCircuitBuilder& ultra_circuit_constructor,
-                                           std::unordered_set<uint32_t>& variables_in_one_gate,
-                                           size_t index);
-    void process_current_plookup_gate(bb::UltraCircuitBuilder& ultra_circuit_builder, size_t gate_index);
-    void remove_unnecessary_decompose_variables(bb::UltraCircuitBuilder& ultra_circuit_builder,
-                                                std::unordered_set<uint32_t>& variables_in_on_gate,
-                                                const std::unordered_set<uint32_t>& decompose_variables);
-    void remove_unnecessary_plookup_variables(bb::UltraCircuitBuilder& ultra_circuit_builder);
-    void remove_unnecessary_range_constrains_variables(bb::UltraCircuitBuilder& ultra_builder);
-    std::unordered_set<uint32_t> show_variables_in_one_gate(bb::UltraCircuitBuilder& ultra_circuit_builder);
+    void remove_unnecessary_aes_plookup_variables(bb::plookup::BasicTableId& table_id, size_t gate_index);
+    void remove_unnecessary_sha256_plookup_variables(bb::plookup::BasicTableId& table_id, size_t gate_index);
+    void remove_record_witness_variables();
 
-    void remove_unnecessary_aes_plookup_variables(std::unordered_set<uint32_t>& variables_in_one_gate,
-                                                  bb::UltraCircuitBuilder& ultra_circuit_builder,
-                                                  bb::plookup::BasicTableId& table_id,
-                                                  size_t gate_index);
-    void remove_unnecessary_sha256_plookup_variables(std::unordered_set<uint32_t>& variables_in_one_gate,
-                                                     bb::UltraCircuitBuilder& ultra_circuit_builder,
-                                                     bb::plookup::BasicTableId& table_id,
-                                                     size_t gate_index);
-    void remove_record_witness_variables(bb::UltraCircuitBuilder& ultra_builder);
-
-    void print_graph();
-    void print_connected_components();
+    void print_connected_components_info();
     void print_variables_gate_counts();
-    void print_variables_edge_counts();
-    void print_variable_in_one_gate(bb::UltraCircuitBuilder& ultra_builder, const uint32_t real_idx);
+    void print_variable_in_one_gate(const uint32_t real_idx);
     ~StaticAnalyzer_() = default;
 
   private:
+    // Store reference to the circuit builder
+    CircuitBuilder& circuit_builder;
+    bool connect_variables;
+
     std::unordered_map<uint32_t, std::vector<uint32_t>>
         variable_adjacency_lists; // we use this data structure to contain information about variables and their
                                   // connections between each other
@@ -193,11 +163,17 @@ template <typename FF> class StaticAnalyzer_ {
         variables_degree; // we use this data structure to count, how many every variable have edges
     std::unordered_map<KeyPair, std::vector<size_t>, KeyHasher, KeyEquals>
         variable_gates; // we use this data structure to store gates and TraceBlocks for every variables, where static
-                        // analyzer found them in the circuit.
+                        // analyzer finds them in the circuit.
     std::unordered_set<uint32_t> variables_in_one_gate;
     std::unordered_set<uint32_t> fixed_variables;
+    std::vector<ConnectedComponent> connected_components;
+    std::vector<ConnectedComponent>
+        main_connected_components; // connected components without finalize blocks and range lists
 };
 
-using StaticAnalyzer = StaticAnalyzer_<bb::fr>;
+// Type aliases for convenience
+using UltraStaticAnalyzer = StaticAnalyzer_<bb::fr, bb::UltraCircuitBuilder>;
+using MegaStaticAnalyzer = StaticAnalyzer_<bb::fr, bb::MegaCircuitBuilder>;
+using StaticAnalyzer = UltraStaticAnalyzer; // Default to Ultra for backward compatibility
 
 } // namespace cdg

--- a/barretenberg/cpp/src/barretenberg/boomerang_value_detection/graph_description.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/boomerang_value_detection/graph_description.test.cpp
@@ -23,7 +23,6 @@ using namespace cdg;
 TEST(boomerang_ultra_circuit_constructor, test_graph_for_arithmetic_gates)
 {
     UltraCircuitBuilder circuit_constructor = UltraCircuitBuilder();
-
     for (size_t i = 0; i < 16; ++i) {
         for (size_t j = 0; j < 16; ++j) {
             uint64_t left = static_cast<uint64_t>(j);
@@ -41,7 +40,7 @@ TEST(boomerang_ultra_circuit_constructor, test_graph_for_arithmetic_gates)
 
     StaticAnalyzer graph = StaticAnalyzer(circuit_constructor);
     auto connected_components = graph.find_connected_components();
-    auto variables_in_one_gate = graph.show_variables_in_one_gate(circuit_constructor);
+    auto variables_in_one_gate = graph.get_variables_in_one_gate();
     EXPECT_EQ(variables_in_one_gate.size(), 1024);
     EXPECT_EQ(connected_components.size(), 256);
 }
@@ -99,7 +98,7 @@ TEST(boomerang_ultra_circuit_constructor, test_graph_for_boolean_gates)
     StaticAnalyzer graph = StaticAnalyzer(circuit_constructor);
     auto connected_components = graph.find_connected_components();
     auto num_connected_components = connected_components.size();
-    auto variables_in_one_gate = graph.show_variables_in_one_gate(circuit_constructor);
+    auto variables_in_one_gate = graph.get_variables_in_one_gate();
     bool result = num_connected_components == 0;
     EXPECT_EQ(result, true);
     EXPECT_EQ(variables_in_one_gate.size(), 20);
@@ -495,12 +494,12 @@ TEST(boomerang_ultra_circuit_constructor, test_variables_gates_counts_for_sorted
     auto connected_components = graph.find_connected_components();
     EXPECT_EQ(connected_components.size(), 2);
     bool result = true;
-    for (size_t i = 0; i < connected_components[0].size(); i++) {
-        result = result && (variables_gate_counts[connected_components[0][i]] == 1);
+    for (const auto& var_idx : connected_components[0].vars()) {
+        result = result && (variables_gate_counts[var_idx] == 1);
     }
 
-    for (size_t i = 0; i < connected_components[1].size(); i++) {
-        result = result && (variables_gate_counts[connected_components[1][i]] == 1);
+    for (const auto& var_idx : connected_components[1].vars()) {
+        result = result && (variables_gate_counts[var_idx] == 1);
     }
     EXPECT_EQ(result, true);
 }
@@ -514,59 +513,33 @@ TEST(boomerang_ultra_circuit_constructor, test_variables_gates_counts_for_sorted
  */
 TEST(boomerang_ultra_circuit_constructor, test_variables_gates_counts_for_sorted_constraints_with_edges)
 {
-    fr a = fr::one();
-    fr b = fr(2);
-    fr c = fr(3);
-    fr d = fr(4);
-    fr e = fr(5);
-    fr f = fr(6);
-    fr g = fr(7);
-    fr h = fr(8);
-
     UltraCircuitBuilder circuit_constructor;
-    auto a_idx = circuit_constructor.add_variable(a);
-    auto b_idx = circuit_constructor.add_variable(b);
-    auto c_idx = circuit_constructor.add_variable(c);
-    auto d_idx = circuit_constructor.add_variable(d);
-    auto e_idx = circuit_constructor.add_variable(e);
-    auto f_idx = circuit_constructor.add_variable(f);
-    auto g_idx = circuit_constructor.add_variable(g);
-    auto h_idx = circuit_constructor.add_variable(h);
-    circuit_constructor.create_sort_constraint_with_edges(
-        { a_idx, b_idx, c_idx, d_idx, e_idx, f_idx, g_idx, h_idx }, a, h);
-
-    fr a1 = fr(9);
-    fr b1 = fr(10);
-    fr c1 = fr(11);
-    fr d1 = fr(12);
-    fr e1 = fr(13);
-    fr f1 = fr(14);
-    fr g1 = fr(15);
-    fr h1 = fr(16);
-
-    auto a1_idx = circuit_constructor.add_variable(a1);
-    auto b1_idx = circuit_constructor.add_variable(b1);
-    auto c1_idx = circuit_constructor.add_variable(c1);
-    auto d1_idx = circuit_constructor.add_variable(d1);
-    auto e1_idx = circuit_constructor.add_variable(e1);
-    auto f1_idx = circuit_constructor.add_variable(f1);
-    auto g1_idx = circuit_constructor.add_variable(g1);
-    auto h1_idx = circuit_constructor.add_variable(h1);
-
-    circuit_constructor.create_sort_constraint_with_edges(
-        { a1_idx, b1_idx, c1_idx, d1_idx, e1_idx, f1_idx, g1_idx, h1_idx }, a1, h1);
+    auto add_variables = [&circuit_constructor](const std::vector<fr>& vars) {
+        std::vector<uint32_t> res;
+        res.reserve(vars.size());
+        for (const auto& var : vars) {
+            res.emplace_back(circuit_constructor.add_variable(var));
+        }
+        return res;
+    };
+    std::vector<fr> vars1 = { fr::one(), fr(2), fr(3), fr(4), fr(5), fr(6), fr(7), fr(8) };
+    std::vector<fr> vars2 = { fr(9), fr(10), fr(11), fr(12), fr(13), fr(14), fr(15), fr(16) };
+    auto var_idx1 = add_variables(vars1);
+    auto var_idx2 = add_variables(vars2);
+    circuit_constructor.create_sort_constraint_with_edges(var_idx1, vars1[0], vars1[vars1.size() - 1]);
+    circuit_constructor.create_sort_constraint_with_edges(var_idx2, vars2[0], vars2[vars2.size() - 1]);
     StaticAnalyzer graph = StaticAnalyzer(circuit_constructor);
     auto connected_components = graph.find_connected_components();
     auto variables_gate_counts = graph.get_variables_gate_counts();
-    bool result = true;
-    for (size_t i = 0; i < connected_components[0].size(); i++) {
-        result = result && (variables_gate_counts[connected_components[0][i]] == 1);
-    }
-
-    for (size_t i = 0; i < connected_components[1].size(); i++) {
-        result = result && (variables_gate_counts[connected_components[1][i]] == 1);
-    }
     EXPECT_EQ(connected_components.size(), 2);
+    bool result = true;
+    for (size_t i = 0; i < var_idx1.size(); i++) {
+        if (i % 4 == 1 && i > 1) {
+            result = variables_gate_counts[var_idx1[i]] == 2;
+        } else {
+            result = variables_gate_counts[var_idx1[i]] == 1;
+        }
+    }
     EXPECT_EQ(result, true);
 }
 
@@ -600,12 +573,11 @@ TEST(boomerang_ultra_circuit_constructor, test_variables_gates_counts_for_ecc_ad
     StaticAnalyzer graph = StaticAnalyzer(circuit_constructor);
     auto variables_gate_counts = graph.get_variables_gate_counts();
     auto connected_components = graph.find_connected_components();
-    bool result = (variables_gate_counts[connected_components[0][0]] == 1) &&
-                  (variables_gate_counts[connected_components[0][1]] == 1) &&
-                  (variables_gate_counts[connected_components[0][2]] == 1) &&
-                  (variables_gate_counts[connected_components[0][3]] == 1) &&
-                  (variables_gate_counts[connected_components[0][4]] == 1) &&
-                  (variables_gate_counts[connected_components[0][5]] == 1);
+    auto variable_indices = connected_components[0].vars();
+    bool result =
+        (variables_gate_counts[variable_indices[0]] == 1) && (variables_gate_counts[variable_indices[1]] == 1) &&
+        (variables_gate_counts[variable_indices[2]] == 1) && (variables_gate_counts[variable_indices[3]] == 1) &&
+        (variables_gate_counts[variable_indices[4]] == 1) && (variables_gate_counts[variable_indices[5]] == 1);
     EXPECT_EQ(connected_components.size(), 1);
     EXPECT_EQ(result, true);
 }
@@ -638,22 +610,13 @@ TEST(boomerang_ultra_circuit_constructor, test_variables_gates_counts_for_ecc_db
     auto variables_gate_counts = graph.get_variables_gate_counts();
     auto connected_components = graph.find_connected_components();
 
-    bool result = (variables_gate_counts[connected_components[0][0]] == 1) &&
-                  (variables_gate_counts[connected_components[0][1]] == 1) &&
-                  (variables_gate_counts[connected_components[0][2]] == 1) &&
-                  (variables_gate_counts[connected_components[0][3]] == 1);
+    auto vars = connected_components[0].vars();
+    EXPECT_EQ(vars.size(), 4);
+    bool result = (variables_gate_counts[vars[0]] == 1) && (variables_gate_counts[vars[1]] == 1) &&
+                  (variables_gate_counts[vars[2]] == 1) && (variables_gate_counts[vars[3]] == 1);
 
     EXPECT_EQ(connected_components.size(), 1);
     EXPECT_EQ(result, true);
-}
-
-std::vector<uint32_t> add_variables(UltraCircuitBuilder& circuit_constructor, std::vector<fr> variables)
-{
-    std::vector<uint32_t> res;
-    for (size_t i = 0; i < variables.size(); i++) {
-        res.emplace_back(circuit_constructor.add_variable(variables[i]));
-    }
-    return res;
 }
 
 /**
@@ -666,7 +629,15 @@ std::vector<uint32_t> add_variables(UltraCircuitBuilder& circuit_constructor, st
 TEST(boomerang_ultra_circuit_constructor, test_graph_for_range_constraints)
 {
     UltraCircuitBuilder circuit_constructor = UltraCircuitBuilder();
-    auto indices = add_variables(circuit_constructor, { 1, 2, 3, 4 });
+    auto add_variables = [&circuit_constructor](const std::vector<fr>& vars) {
+        std::vector<uint32_t> res;
+        res.reserve(vars.size());
+        for (const auto& var : vars) {
+            res.emplace_back(circuit_constructor.add_variable(var));
+        }
+        return res;
+    };
+    auto indices = add_variables({ fr(1), fr(2), fr(3), fr(4) });
     for (size_t i = 0; i < indices.size(); i++) {
         circuit_constructor.create_new_range_constraint(indices[i], 5);
     }

--- a/barretenberg/cpp/src/barretenberg/boomerang_value_detection/graph_description_aes128.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/boomerang_value_detection/graph_description_aes128.test.cpp
@@ -81,7 +81,7 @@ TEST(boomerang_stdlib_aes, test_graph_for_aes_64_bytes)
     StaticAnalyzer graph = StaticAnalyzer(builder);
     auto connected_components = graph.find_connected_components();
     EXPECT_EQ(connected_components.size(), 1);
-    auto variables_in_one_gate = graph.show_variables_in_one_gate(builder);
+    auto variables_in_one_gate = graph.get_variables_in_one_gate();
     EXPECT_EQ(variables_in_one_gate.size(), 0);
 }
 
@@ -135,6 +135,6 @@ TEST(boomerang_stdlib_aes, test_variable_gates_count_for_aes128cbc)
     StaticAnalyzer graph = StaticAnalyzer(builder);
     auto connected_components = graph.find_connected_components();
     EXPECT_EQ(connected_components.size(), 1);
-    std::unordered_set<uint32_t> variables_in_one_gate = graph.show_variables_in_one_gate(builder);
+    std::unordered_set<uint32_t> variables_in_one_gate = graph.get_variables_in_one_gate();
     EXPECT_EQ(variables_in_one_gate.size(), 0);
 }

--- a/barretenberg/cpp/src/barretenberg/boomerang_value_detection/graph_description_bigfield.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/boomerang_value_detection/graph_description_bigfield.test.cpp
@@ -70,7 +70,7 @@ TEST(boomerang_bigfield, test_graph_description_bigfield_constructors)
     auto graph = StaticAnalyzer(builder);
     auto connected_components = graph.find_connected_components();
     EXPECT_EQ(connected_components.size(), 1);
-    auto variables_in_one_gate = graph.show_variables_in_one_gate(builder);
+    auto variables_in_one_gate = graph.get_variables_in_one_gate();
     EXPECT_EQ(variables_in_one_gate.size(), 1);
 }
 
@@ -101,7 +101,7 @@ TEST(boomerang_bigfield, test_graph_description_bigfield_addition)
     auto graph = StaticAnalyzer(builder);
     auto connected_components = graph.find_connected_components();
     EXPECT_EQ(connected_components.size(), 1);
-    auto variables_in_one_gate = graph.show_variables_in_one_gate(builder);
+    auto variables_in_one_gate = graph.get_variables_in_one_gate();
     EXPECT_EQ(variables_in_one_gate.size(), 0);
 }
 
@@ -133,7 +133,7 @@ TEST(boomerang_bigfield, test_graph_description_bigfield_substraction)
     auto graph = StaticAnalyzer(builder);
     auto connected_components = graph.find_connected_components();
     EXPECT_EQ(connected_components.size(), 1);
-    auto variables_in_one_gate = graph.show_variables_in_one_gate(builder);
+    auto variables_in_one_gate = graph.get_variables_in_one_gate();
     EXPECT_EQ(variables_in_one_gate.size(), 0);
     for (const auto& elem : variables_in_one_gate) {
         info("elem == ", elem);
@@ -164,7 +164,7 @@ TEST(boomerang_bigfield, test_graph_description_bigfield_multiplication)
     auto graph = StaticAnalyzer(builder);
     auto connected_components = graph.find_connected_components();
     EXPECT_EQ(connected_components.size(), 1);
-    auto variables_in_one_gate = graph.show_variables_in_one_gate(builder);
+    auto variables_in_one_gate = graph.get_variables_in_one_gate();
     EXPECT_EQ(variables_in_one_gate.size(), 0);
 }
 
@@ -198,7 +198,7 @@ TEST(boomerang_bigfield, test_graph_description_bigfield_division)
     auto graph = StaticAnalyzer(builder);
     auto connected_components = graph.find_connected_components();
     EXPECT_EQ(connected_components.size(), 1);
-    auto variables_in_one_gate = graph.show_variables_in_one_gate(builder);
+    auto variables_in_one_gate = graph.get_variables_in_one_gate();
     EXPECT_EQ(variables_in_one_gate.size(), 0);
 }
 
@@ -251,7 +251,7 @@ TEST(boomerang_bigfield, test_graph_description_bigfield_mix_operations)
     auto graph = StaticAnalyzer(builder);
     auto connected_components = graph.find_connected_components();
     EXPECT_EQ(connected_components.size(), 1);
-    auto variables_in_one_gate = graph.show_variables_in_one_gate(builder);
+    auto variables_in_one_gate = graph.get_variables_in_one_gate();
     EXPECT_EQ(variables_in_one_gate.size(), 0);
 }
 
@@ -279,7 +279,7 @@ TEST(boomerang_bigfield, test_graph_description_constructor_high_low_bits_and_op
     auto graph = StaticAnalyzer(builder);
     auto connected_components = graph.find_connected_components();
     EXPECT_EQ(connected_components.size(), 1);
-    auto variables_in_one_gate = graph.show_variables_in_one_gate(builder);
+    auto variables_in_one_gate = graph.get_variables_in_one_gate();
     EXPECT_EQ(variables_in_one_gate.size(), 0);
 }
 
@@ -303,7 +303,7 @@ TEST(boomerang_bigfield, test_graph_description_mul_function)
     auto graph = StaticAnalyzer(builder);
     auto connected_components = graph.find_connected_components();
     EXPECT_EQ(connected_components.size(), 1);
-    auto variables_in_one_gate = graph.show_variables_in_one_gate(builder);
+    auto variables_in_one_gate = graph.get_variables_in_one_gate();
     EXPECT_EQ(variables_in_one_gate.size(), 0);
 }
 
@@ -325,7 +325,7 @@ TEST(boomerang_bigfield, test_graph_description_sqr_function)
     auto graph = StaticAnalyzer(builder);
     auto connected_components = graph.find_connected_components();
     EXPECT_EQ(connected_components.size(), 1);
-    auto variables_in_one_gate = graph.show_variables_in_one_gate(builder);
+    auto variables_in_one_gate = graph.get_variables_in_one_gate();
     EXPECT_EQ(variables_in_one_gate.size(), 0);
 }
 
@@ -351,7 +351,7 @@ TEST(boomerang_bigfield, test_graph_description_madd_function)
     auto graph = StaticAnalyzer(builder);
     auto connected_components = graph.find_connected_components();
     EXPECT_EQ(connected_components.size(), 1);
-    auto variables_in_one_gate = graph.show_variables_in_one_gate(builder);
+    auto variables_in_one_gate = graph.get_variables_in_one_gate();
     EXPECT_EQ(variables_in_one_gate.size(), 0);
 }
 
@@ -389,7 +389,7 @@ TEST(boomerang_bigfield, test_graph_description_mult_madd_function)
     fix_bigfield_element(f);
     builder.finalize_circuit(false);
     auto graph = StaticAnalyzer(builder);
-    auto variables_in_one_gate = graph.show_variables_in_one_gate(builder);
+    auto variables_in_one_gate = graph.get_variables_in_one_gate();
     EXPECT_EQ(variables_in_one_gate.size(), 0);
 }
 
@@ -415,6 +415,6 @@ TEST(boomerang_bigfield, test_graph_description_constructor_high_low_bits)
     builder.finalize_circuit(false);
     auto graph = StaticAnalyzer(builder);
     auto connected_components = graph.find_connected_components();
-    auto variables_in_one_gate = graph.show_variables_in_one_gate(builder);
+    auto variables_in_one_gate = graph.get_variables_in_one_gate();
     EXPECT_EQ(variables_in_one_gate.size(), 0);
 }

--- a/barretenberg/cpp/src/barretenberg/boomerang_value_detection/graph_description_blake2s.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/boomerang_value_detection/graph_description_blake2s.test.cpp
@@ -34,7 +34,7 @@ TEST(boomerang_stdlib_blake2s, graph_description_single_block_plookup)
     StaticAnalyzer graph = StaticAnalyzer(builder);
     auto connected_components = graph.find_connected_components();
     EXPECT_EQ(connected_components.size(), 1);
-    auto variables_in_one_gate = graph.show_variables_in_one_gate(builder);
+    auto variables_in_one_gate = graph.get_variables_in_one_gate();
     EXPECT_EQ(variables_in_one_gate.size(), 0);
 }
 
@@ -63,6 +63,6 @@ TEST(boomerang_stdlib_blake2s, graph_description_double_block_plookup)
     StaticAnalyzer graph = StaticAnalyzer(builder);
     auto connected_components = graph.find_connected_components();
     EXPECT_EQ(connected_components.size(), 1);
-    auto variables_in_one_gate = graph.show_variables_in_one_gate(builder);
+    auto variables_in_one_gate = graph.get_variables_in_one_gate();
     EXPECT_EQ(variables_in_one_gate.size(), 0);
 }

--- a/barretenberg/cpp/src/barretenberg/boomerang_value_detection/graph_description_blake3s.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/boomerang_value_detection/graph_description_blake3s.test.cpp
@@ -37,7 +37,7 @@ TEST(boomerang_stdlib_blake3s, test_single_block_plookup)
     StaticAnalyzer graph = StaticAnalyzer(builder);
     auto connected_components = graph.find_connected_components();
     EXPECT_EQ(connected_components.size(), 1);
-    auto variables_in_one_gate = graph.show_variables_in_one_gate(builder);
+    auto variables_in_one_gate = graph.get_variables_in_one_gate();
     EXPECT_EQ(variables_in_one_gate.size(), 0);
 }
 
@@ -61,6 +61,6 @@ TEST(boomerang_stdlib_blake3s, test_double_block_plookup)
     StaticAnalyzer graph = StaticAnalyzer(builder);
     auto connected_components = graph.find_connected_components();
     EXPECT_EQ(connected_components.size(), 1);
-    auto variables_in_one_gate = graph.show_variables_in_one_gate(builder);
+    auto variables_in_one_gate = graph.get_variables_in_one_gate();
     EXPECT_EQ(variables_in_one_gate.size(), 0);
 }

--- a/barretenberg/cpp/src/barretenberg/boomerang_value_detection/graph_description_dynamic_array.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/boomerang_value_detection/graph_description_dynamic_array.test.cpp
@@ -43,7 +43,7 @@ TEST(boomerang_stdlib_dynamic_array, graph_description_dynamic_array_method_resi
     array.resize(next_size, 7);
     StaticAnalyzer graph = StaticAnalyzer(builder);
     auto connected_components = graph.find_connected_components();
-    auto variables_in_one_gate = graph.show_variables_in_one_gate(builder);
+    auto variables_in_one_gate = graph.get_variables_in_one_gate();
     EXPECT_EQ(connected_components.size(), 1);
     EXPECT_EQ(variables_in_one_gate.size(), max_size);
 }
@@ -83,6 +83,6 @@ TEST(boomerang_stdlib_dynamic_array, graph_description_dynamic_array_consistency
     StaticAnalyzer graph = StaticAnalyzer(builder);
     auto connected_components = graph.find_connected_components();
     EXPECT_EQ(connected_components.size(), 1);
-    auto variables_in_one_gate = graph.show_variables_in_one_gate(builder);
+    auto variables_in_one_gate = graph.get_variables_in_one_gate();
     EXPECT_EQ(variables_in_one_gate.size(), max_size);
 }

--- a/barretenberg/cpp/src/barretenberg/boomerang_value_detection/graph_description_goblin.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/boomerang_value_detection/graph_description_goblin.test.cpp
@@ -104,7 +104,7 @@ TEST_F(BoomerangGoblinRecursiveVerifierTests, graph_description_basic)
     translator_pairing_points.P1.y.fix_witness();
     info("Recursive Verifier: num gates = ", builder.num_gates);
     auto graph = cdg::StaticAnalyzer(builder, false);
-    auto variables_in_one_gate = graph.show_variables_in_one_gate(builder);
+    auto variables_in_one_gate = graph.get_variables_in_one_gate();
     EXPECT_EQ(variables_in_one_gate.size(), 0);
 }
 

--- a/barretenberg/cpp/src/barretenberg/boomerang_value_detection/graph_description_megacircuitbuilder.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/boomerang_value_detection/graph_description_megacircuitbuilder.test.cpp
@@ -1,0 +1,85 @@
+#include "barretenberg/boomerang_value_detection/graph.hpp"
+#include "barretenberg/circuit_checker/circuit_checker.hpp"
+#include "barretenberg/common/test.hpp"
+#include "barretenberg/goblin/mock_circuits.hpp"
+#include "barretenberg/stdlib/primitives/bigfield/constants.hpp"
+#include "barretenberg/stdlib/primitives/databus/databus.hpp"
+#include "barretenberg/stdlib_circuit_builders/mega_circuit_builder.hpp"
+
+using namespace bb;
+using namespace cdg;
+
+using Builder = MegaCircuitBuilder;
+using field_ct = stdlib::field_t<Builder>;
+using witness_ct = stdlib::witness_t<Builder>;
+using databus_ct = stdlib::databus<Builder>;
+
+namespace {
+auto& engine = numeric::get_debug_randomness();
+}
+namespace bb {
+
+TEST(BoomerangMegaCircuitBuilder, BasicCircuit)
+{
+    MegaCircuitBuilder builder = MegaCircuitBuilder();
+    fr a = fr::one();
+    builder.add_public_variable(a);
+
+    for (size_t i = 0; i < 16; ++i) {
+        for (size_t j = 0; j < 16; ++j) {
+            uint64_t left = static_cast<uint64_t>(j);
+            uint64_t right = static_cast<uint64_t>(i);
+            uint32_t left_idx = builder.add_variable(fr(left));
+            uint32_t right_idx = builder.add_variable(fr(right));
+            uint32_t result_idx = builder.add_variable(fr(left ^ right));
+
+            uint32_t add_idx = builder.add_variable(fr(left) + fr(right) + builder.get_variable(result_idx));
+            builder.create_big_add_gate(
+                { left_idx, right_idx, result_idx, add_idx, fr(1), fr(1), fr(1), fr(-1), fr(0) });
+        }
+    }
+
+    // Compute a simple point accumulation natively
+    auto P1 = g1::affine_element::random_element();
+    auto P2 = g1::affine_element::random_element();
+    auto z = fr::random_element();
+
+    builder.queue_ecc_add_accum(P1);
+    builder.queue_ecc_mul_accum(P2, z);
+    builder.queue_ecc_eq();
+
+    auto tool = MegaStaticAnalyzer(builder);
+    auto connected_components = tool.find_connected_components();
+    EXPECT_EQ(connected_components.size(), 257);
+    for (size_t i = 0; i < connected_components.size(); i++) {
+        if (connected_components[i].size() != 4) {
+            EXPECT_EQ(connected_components[i].size(), 18);
+        }
+    }
+    auto variables_in_one_gate = tool.get_variables_in_one_gate();
+}
+
+/**
+ * @brief Check that the ultra ops are recorded correctly in the EccOpQueue
+ *
+ */
+TEST(BoomerangMegaCircuitBuilder, OnlyGoblinEccOpQueueUltraOps)
+{
+    // Construct a simple circuit with op gates
+    auto builder = MegaCircuitBuilder();
+
+    // Compute a simple point accumulation natively
+    auto P1 = g1::affine_element::random_element();
+    auto P2 = g1::affine_element::random_element();
+    auto z = fr::random_element();
+
+    // Add gates corresponding to the above operations
+    builder.queue_ecc_add_accum(P1);
+    builder.queue_ecc_mul_accum(P2, z);
+    builder.queue_ecc_eq();
+
+    auto tool = MegaStaticAnalyzer(builder);
+    auto cc = tool.find_connected_components();
+    EXPECT_EQ(cc.size(), 1);
+}
+} // namespace bb

--- a/barretenberg/cpp/src/barretenberg/boomerang_value_detection/graph_description_poseidon2s_permutation.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/boomerang_value_detection/graph_description_poseidon2s_permutation.test.cpp
@@ -74,7 +74,7 @@ void test_poseidon2s_circuit(size_t num_inputs = 5)
     auto graph = StaticAnalyzer(builder);
     auto connected_components = graph.find_connected_components();
     EXPECT_EQ(connected_components.size(), 1);
-    auto variables_in_one_gate = graph.show_variables_in_one_gate(builder);
+    auto variables_in_one_gate = graph.get_variables_in_one_gate();
     std::unordered_set<uint32_t> outputs{
         result.witness_index, result.witness_index + 1, result.witness_index + 2, result.witness_index + 3
     };
@@ -114,7 +114,7 @@ void test_poseidon2s_hash_repeated_pairs(size_t num_inputs = 5)
     auto graph = StaticAnalyzer(builder);
     auto connected_components = graph.find_connected_components();
     EXPECT_EQ(connected_components.size(), 1);
-    auto variables_in_one_gate = graph.show_variables_in_one_gate(builder);
+    auto variables_in_one_gate = graph.get_variables_in_one_gate();
     for (const auto& elem : variables_in_one_gate) {
         EXPECT_EQ(outputs.contains(elem), true);
     }
@@ -145,7 +145,7 @@ TEST(boomerang_poseidon2s, test_graph_for_poseidon2s_one_permutation)
     auto graph = StaticAnalyzer(builder);
     auto connected_components = graph.find_connected_components();
     EXPECT_EQ(connected_components.size(), 1);
-    auto variables_in_one_gate = graph.show_variables_in_one_gate(builder);
+    auto variables_in_one_gate = graph.get_variables_in_one_gate();
     EXPECT_EQ(variables_in_one_gate.size(), 0);
 }
 
@@ -181,7 +181,7 @@ TEST(boomerang_poseidon2s, test_graph_for_poseidon2s_two_permutations)
     auto graph = StaticAnalyzer(builder);
     auto connected_components = graph.find_connected_components();
     EXPECT_EQ(connected_components.size(), 2);
-    auto variables_in_one_gate = graph.show_variables_in_one_gate(builder);
+    auto variables_in_one_gate = graph.get_variables_in_one_gate();
     EXPECT_EQ(variables_in_one_gate.size(), 0);
 }
 

--- a/barretenberg/cpp/src/barretenberg/boomerang_value_detection/graph_description_protogalaxy.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/boomerang_value_detection/graph_description_protogalaxy.test.cpp
@@ -1,0 +1,271 @@
+#include "barretenberg/boomerang_value_detection/graph.hpp"
+#include "barretenberg/circuit_checker/circuit_checker.hpp"
+#include "barretenberg/common/test.hpp"
+#include "barretenberg/protogalaxy/protogalaxy_prover.hpp"
+#include "barretenberg/protogalaxy/protogalaxy_verifier.hpp"
+#include "barretenberg/stdlib/hash/blake3s/blake3s.hpp"
+#include "barretenberg/stdlib/hash/pedersen/pedersen.hpp"
+#include "barretenberg/stdlib/honk_verifier/decider_recursive_verifier.hpp"
+#include "barretenberg/stdlib/protogalaxy_verifier/protogalaxy_recursive_verifier.hpp"
+#include "barretenberg/stdlib/special_public_inputs/special_public_inputs.hpp"
+#include "barretenberg/ultra_honk/decider_prover.hpp"
+#include "barretenberg/ultra_honk/ultra_prover.hpp"
+#include "barretenberg/ultra_honk/ultra_verifier.hpp"
+
+auto& engine = bb::numeric::get_debug_randomness();
+
+namespace bb::stdlib::recursion::honk {
+class BoomerangProtogalaxyRecursiveTests : public testing::Test {
+  public:
+    // Define types for the inner circuit, i.e. the circuit whose proof will be recursively verified
+    using RecursiveFlavor = MegaRecursiveFlavor_<MegaCircuitBuilder>;
+    using InnerFlavor = RecursiveFlavor::NativeFlavor;
+    using InnerProver = UltraProver_<InnerFlavor>;
+    using InnerVerifier = UltraVerifier_<InnerFlavor>;
+    using InnerBuilder = InnerFlavor::CircuitBuilder;
+    using InnerDeciderProvingKey = DeciderProvingKey_<InnerFlavor>;
+    using InnerDeciderVerificationKey = ::bb::DeciderVerificationKey_<InnerFlavor>;
+    using InnerVerificationKey = InnerFlavor::VerificationKey;
+    using InnerCurve = bn254<InnerBuilder>;
+    using Commitment = InnerFlavor::Commitment;
+    using FF = InnerFlavor::FF;
+
+    // Defines types for the outer circuit, i.e. the circuit of the recursive verifier
+    using OuterBuilder = RecursiveFlavor::CircuitBuilder;
+    using OuterFlavor = std::conditional_t<IsMegaBuilder<OuterBuilder>, MegaFlavor, UltraFlavor>;
+    using OuterProver = UltraProver_<OuterFlavor>;
+    using OuterVerifier = UltraVerifier_<OuterFlavor>;
+    using OuterDeciderProvingKey = DeciderProvingKey_<OuterFlavor>;
+
+    using RecursiveDeciderVerificationKeys =
+        ::bb::stdlib::recursion::honk::RecursiveDeciderVerificationKeys_<RecursiveFlavor, 2>;
+    using RecursiveDeciderVerificationKey = RecursiveDeciderVerificationKeys::DeciderVK;
+    using RecursiveVerificationKey = RecursiveDeciderVerificationKeys::VerificationKey;
+    using RecursiveVKAndHash = RecursiveDeciderVerificationKeys::VKAndHash;
+    using FoldingRecursiveVerifier = ProtogalaxyRecursiveVerifier_<RecursiveDeciderVerificationKeys>;
+    using DeciderRecursiveVerifier = DeciderRecursiveVerifier_<RecursiveFlavor>;
+    using InnerDeciderProver = DeciderProver_<InnerFlavor>;
+    using InnerDeciderVerifier = DeciderVerifier_<InnerFlavor>;
+    using InnerDeciderVerificationKeys = DeciderVerificationKeys_<InnerFlavor, 2>;
+    using InnerFoldingVerifier = ProtogalaxyVerifier_<InnerDeciderVerificationKeys>;
+    using InnerFoldingProver = ProtogalaxyProver_<InnerFlavor>;
+    static void SetUpTestSuite() { bb::srs::init_file_crs_factory(bb::srs::bb_crs_path()); }
+
+    static void create_function_circuit(InnerBuilder& builder, size_t log_num_gates = 10)
+    {
+        using fr_ct = typename InnerCurve::ScalarField;
+        using fq_ct = stdlib::bigfield<InnerBuilder, typename InnerCurve::BaseFieldNative::Params>;
+        using public_witness_ct = typename InnerCurve::public_witness_ct;
+        using witness_ct = typename InnerCurve::witness_ct;
+        using byte_array_ct = typename InnerCurve::byte_array_ct;
+        using fr = typename InnerCurve::ScalarFieldNative;
+
+        // Create 2^log_n many add gates based on input log num gates
+        const size_t num_gates = 1 << log_num_gates;
+        for (size_t i = 0; i < num_gates; ++i) {
+            fr a = fr::random_element(&engine);
+            uint32_t a_idx = builder.add_variable(a);
+
+            fr b = fr::random_element(&engine);
+            fr c = fr::random_element(&engine);
+            fr d = a + b + c;
+            uint32_t b_idx = builder.add_variable(b);
+            uint32_t c_idx = builder.add_variable(c);
+            uint32_t d_idx = builder.add_variable(d);
+
+            builder.create_big_add_gate({ a_idx, b_idx, c_idx, d_idx, fr(1), fr(1), fr(1), fr(-1), fr(0) });
+        }
+
+        // Define some additional non-trivial but arbitrary circuit logic
+        fr_ct a(public_witness_ct(&builder, fr::random_element(&engine)));
+        fr_ct b(public_witness_ct(&builder, fr::random_element(&engine)));
+        fr_ct c(public_witness_ct(&builder, fr::random_element(&engine)));
+
+        for (size_t i = 0; i < 32; ++i) {
+            a = (a * b) + b + a;
+            a = a.madd(b, c);
+        }
+        pedersen_hash<InnerBuilder>::hash({ a, b });
+        byte_array_ct to_hash(&builder, "nonsense test data");
+        stdlib::Blake3s<InnerBuilder>::hash(to_hash);
+
+        fr bigfield_data = fr::random_element(&engine);
+        fr bigfield_data_a{ bigfield_data.data[0], bigfield_data.data[1], 0, 0 };
+        fr bigfield_data_b{ bigfield_data.data[2], bigfield_data.data[3], 0, 0 };
+
+        fq_ct big_a(fr_ct(witness_ct(&builder, bigfield_data_a.to_montgomery_form())), fr_ct(witness_ct(&builder, 0)));
+        fq_ct big_b(fr_ct(witness_ct(&builder, bigfield_data_b.to_montgomery_form())), fr_ct(witness_ct(&builder, 0)));
+
+        big_a* big_b;
+
+        stdlib::recursion::PairingPoints<InnerBuilder>::add_default_to_public_inputs(builder);
+    };
+
+    static void test_recursive_folding(const size_t num_verifiers = 1)
+    {
+        // Create two arbitrary circuits for the first round of folding
+        InnerBuilder builder1;
+        create_function_circuit(builder1);
+        InnerBuilder builder2;
+        builder2.add_public_variable(FF(1));
+        create_function_circuit(builder2);
+
+        auto decider_pk_1 = std::make_shared<InnerDeciderProvingKey>(builder1);
+        auto honk_vk_1 = std::make_shared<InnerVerificationKey>(decider_pk_1->get_precomputed());
+        auto decider_vk_1 = std::make_shared<InnerDeciderVerificationKey>(honk_vk_1);
+        auto decider_pk_2 = std::make_shared<InnerDeciderProvingKey>(builder2);
+        auto honk_vk_2 = std::make_shared<InnerVerificationKey>(decider_pk_2->get_precomputed());
+        auto decider_vk_2 = std::make_shared<InnerDeciderVerificationKey>(honk_vk_2);
+        // Generate a folding proof
+        InnerFoldingProver folding_prover({ decider_pk_1, decider_pk_2 },
+                                          { decider_vk_1, decider_vk_2 },
+                                          std::make_shared<typename InnerFoldingProver::Transcript>());
+        auto folding_proof = folding_prover.prove();
+
+        // Create a folding verifier circuit
+        OuterBuilder folding_circuit;
+
+        auto recursive_decider_vk_1 = std::make_shared<RecursiveDeciderVerificationKey>(&folding_circuit, decider_vk_1);
+        auto recursive_vk_and_hash_2 = std::make_shared<RecursiveVKAndHash>(folding_circuit, decider_vk_2->vk);
+        stdlib::Proof<OuterBuilder> stdlib_proof(folding_circuit, folding_proof.proof);
+
+        auto recursive_transcript = std::make_shared<typename FoldingRecursiveVerifier::Transcript>();
+        auto verifier = FoldingRecursiveVerifier{
+            &folding_circuit, recursive_decider_vk_1, { recursive_vk_and_hash_2 }, recursive_transcript
+        };
+        std::shared_ptr<RecursiveDeciderVerificationKey> accumulator;
+        for (size_t idx = 0; idx < num_verifiers; idx++) {
+            verifier.transcript->enable_manifest();
+            accumulator = verifier.verify_folding_proof(stdlib_proof);
+            if (idx < num_verifiers - 1) { // else the transcript is null in the test below
+                auto recursive_vk_and_hash = std::make_shared<RecursiveVKAndHash>(folding_circuit, decider_vk_1->vk);
+                verifier = FoldingRecursiveVerifier{
+                    &folding_circuit, accumulator, { recursive_vk_and_hash }, recursive_transcript
+                };
+            }
+        }
+        {
+            stdlib::recursion::honk::DefaultIO<OuterBuilder>::add_default(folding_circuit);
+            // inefficiently check finalized size
+            folding_circuit.finalize_circuit(/* ensure_nonzero= */ true);
+            info("Folding Recursive Verifier: num gates finalized = ", folding_circuit.num_gates);
+            auto decider_pk = std::make_shared<OuterDeciderProvingKey>(folding_circuit);
+            info("Dyadic size of verifier circuit: ", decider_pk->dyadic_size());
+            auto honk_vk = std::make_shared<typename OuterFlavor::VerificationKey>(decider_pk->get_precomputed());
+            OuterProver prover(decider_pk, honk_vk);
+            OuterVerifier verifier(honk_vk);
+            auto proof = prover.construct_proof();
+            bool verified = verifier.template verify_proof<bb::DefaultIO>(proof).result;
+
+            ASSERT_TRUE(verified);
+        }
+        EXPECT_EQ(folding_circuit.failed(), false) << folding_circuit.err();
+        auto graph = cdg::MegaStaticAnalyzer(folding_circuit);
+        auto variables_in_one_gate = graph.get_variables_in_one_gate();
+        EXPECT_EQ(variables_in_one_gate.size(), 0);
+        auto connected_components = graph.find_connected_components(/*return_all_connected_components==*/false);
+        EXPECT_EQ(connected_components.size(), 1);
+        if (connected_components.size() > 1) {
+            graph.print_connected_components_info();
+        }
+    }
+
+    static void test_full_protogalaxy_recursive()
+    {
+        //  Create two arbitrary circuits for the first round of folding
+        InnerBuilder builder1;
+        create_function_circuit(builder1);
+        InnerBuilder builder2;
+        builder2.add_public_variable(FF(1));
+        create_function_circuit(builder2);
+
+        auto decider_pk_1 = std::make_shared<InnerDeciderProvingKey>(builder1);
+        auto honk_vk_1 = std::make_shared<InnerVerificationKey>(decider_pk_1->get_precomputed());
+        auto decider_vk_1 = std::make_shared<InnerDeciderVerificationKey>(honk_vk_1);
+        auto decider_pk_2 = std::make_shared<InnerDeciderProvingKey>(builder2);
+        auto honk_vk_2 = std::make_shared<InnerVerificationKey>(decider_pk_2->get_precomputed());
+        auto decider_vk_2 = std::make_shared<InnerDeciderVerificationKey>(honk_vk_2);
+        // Generate a folding proof
+        InnerFoldingProver folding_prover({ decider_pk_1, decider_pk_2 },
+                                          { decider_vk_1, decider_vk_2 },
+                                          std::make_shared<typename InnerFoldingProver::Transcript>());
+        auto folding_proof = folding_prover.prove();
+
+        // Create a folding verifier circuit
+        OuterBuilder folding_circuit;
+        auto recursive_decider_vk_1 = std::make_shared<RecursiveDeciderVerificationKey>(&folding_circuit, decider_vk_1);
+        auto recursive_vk_and_hash_2 = std::make_shared<RecursiveVKAndHash>(folding_circuit, decider_vk_2->vk);
+        stdlib::Proof<OuterBuilder> stdlib_proof(folding_circuit, folding_proof.proof);
+
+        auto verifier = FoldingRecursiveVerifier{ &folding_circuit,
+                                                  recursive_decider_vk_1,
+                                                  { recursive_vk_and_hash_2 },
+                                                  std::make_shared<typename FoldingRecursiveVerifier::Transcript>() };
+        verifier.transcript->enable_manifest();
+        auto recursive_verifier_native_accum = verifier.verify_folding_proof(stdlib_proof);
+        auto native_verifier_acc =
+            std::make_shared<InnerDeciderVerificationKey>(recursive_verifier_native_accum->get_value());
+
+        // Perform native folding verification and ensure it returns the same result (either true or false) as
+        // calling check_circuit on the recursive folding verifier
+        InnerFoldingVerifier native_folding_verifier({ decider_vk_1, decider_vk_2 },
+                                                     std::make_shared<typename InnerFoldingVerifier::Transcript>());
+        native_folding_verifier.transcript->enable_manifest();
+        auto verifier_accumulator = native_folding_verifier.verify_folding_proof(folding_proof.proof);
+
+        auto native_decider_transcript = std::make_shared<typename InnerFlavor::Transcript>();
+        auto native_accum_hash = verifier_accumulator->hash_through_transcript("", *native_decider_transcript);
+        native_decider_transcript->add_to_hash_buffer("accum_hash", native_accum_hash);
+
+        InnerDeciderProver decider_prover(folding_proof.accumulator, native_decider_transcript);
+        decider_prover.construct_proof();
+        auto decider_proof = decider_prover.export_proof();
+
+        OuterBuilder decider_circuit;
+
+        auto stdlib_verifier_acc =
+            std::make_shared<RecursiveDeciderVerificationKey>(&decider_circuit, native_verifier_acc);
+        auto stdlib_verifier_transcript = std::make_shared<typename RecursiveFlavor::Transcript>();
+        auto stdlib_accum_hash = stdlib_verifier_acc->hash_through_transcript("", *stdlib_verifier_transcript);
+
+        // Manually hashing the accumulator to ensure it gets a proper origin tag
+        stdlib_verifier_transcript->add_to_hash_buffer("accum_hash", stdlib_accum_hash);
+        DeciderRecursiveVerifier decider_verifier{ &decider_circuit, stdlib_verifier_acc, stdlib_verifier_transcript };
+        auto pairing_points = decider_verifier.verify_proof(decider_proof);
+
+        // IO
+        DefaultIO<OuterBuilder> inputs;
+        inputs.pairing_inputs = pairing_points;
+        inputs.set_public();
+
+        info("Decider Recursive Verifier: num gates = ", decider_circuit.num_gates);
+        // Check for a failure flag in the recursive verifier circuit
+        EXPECT_EQ(decider_circuit.failed(), false) << decider_circuit.err();
+        auto graph = cdg::MegaStaticAnalyzer(decider_circuit);
+        auto variables_in_one_gate = graph.get_variables_in_one_gate();
+        EXPECT_EQ(variables_in_one_gate.size(), 0);
+        auto connected_components = graph.find_connected_components(/*return_all_connected_components==*/false);
+        EXPECT_EQ(connected_components.size(), 1);
+        if (variables_in_one_gate.size() > 0) {
+            for (const auto& elem : variables_in_one_gate) {
+                info("elem == ", elem);
+            }
+        }
+    };
+};
+
+TEST_F(BoomerangProtogalaxyRecursiveTests, RecursiveFoldingTestOneVerifier)
+{
+    BoomerangProtogalaxyRecursiveTests::test_recursive_folding(/* num_verifiers= */ 1);
+}
+
+TEST_F(BoomerangProtogalaxyRecursiveTests, RecursiveFoldingTestTwoVerifiers)
+{
+    BoomerangProtogalaxyRecursiveTests::test_recursive_folding(/* num_verifiers= */ 2);
+}
+
+TEST_F(BoomerangProtogalaxyRecursiveTests, FullProtogalaxyRecursiveTest)
+{
+    BoomerangProtogalaxyRecursiveTests::test_full_protogalaxy_recursive();
+}
+} // namespace bb::stdlib::recursion::honk

--- a/barretenberg/cpp/src/barretenberg/boomerang_value_detection/graph_description_ram_rom.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/boomerang_value_detection/graph_description_ram_rom.test.cpp
@@ -52,7 +52,7 @@ TEST(boomerang_rom_ram_table, graph_description_rom_table)
     StaticAnalyzer graph = StaticAnalyzer(builder);
     auto connected_components = graph.find_connected_components();
     EXPECT_EQ(connected_components.size(), 1);
-    auto variables_in_one_gate = graph.show_variables_in_one_gate(builder);
+    auto variables_in_one_gate = graph.get_variables_in_one_gate();
     for (const auto& elem : variables_in_one_gate) {
         EXPECT_EQ(variables_in_one_gate.contains(elem), true);
     }
@@ -94,7 +94,7 @@ TEST(boomerang_rom_ram_table, graph_description_ram_table_read)
     StaticAnalyzer graph = StaticAnalyzer(builder);
     auto connected_components = graph.find_connected_components();
     EXPECT_EQ(connected_components.size(), 1);
-    auto variables_in_one_gate = graph.show_variables_in_one_gate(builder);
+    auto variables_in_one_gate = graph.get_variables_in_one_gate();
     for (const auto& elem : variables_in_one_gate) {
         EXPECT_EQ(safety_variables.contains(elem), true);
     }
@@ -167,7 +167,7 @@ TEST(boomerang_rom_ram_table, graph_description_ram_table_write)
     StaticAnalyzer graph = StaticAnalyzer(builder);
     auto connected_components = graph.find_connected_components();
     EXPECT_EQ(connected_components.size(), 1);
-    auto variables_in_one_gate = graph.show_variables_in_one_gate(builder);
+    auto variables_in_one_gate = graph.get_variables_in_one_gate();
     for (const auto& elem : variables_in_one_gate) {
         EXPECT_EQ(safety_variables.contains(elem), true);
     }

--- a/barretenberg/cpp/src/barretenberg/boomerang_value_detection/graph_description_sha256.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/boomerang_value_detection/graph_description_sha256.test.cpp
@@ -83,7 +83,7 @@ TEST(boomerang_stdlib_sha256, test_graph_for_sha256_55_bytes)
     StaticAnalyzer graph = StaticAnalyzer(builder);
     auto connected_components = graph.find_connected_components();
     EXPECT_EQ(connected_components.size(), 1);
-    auto variables_in_one_gate = graph.show_variables_in_one_gate(builder);
+    auto variables_in_one_gate = graph.get_variables_in_one_gate();
     EXPECT_EQ(variables_in_one_gate.size(), 0);
 }
 
@@ -125,7 +125,7 @@ HEAVY_TEST(boomerang_stdlib_sha256, test_graph_for_sha256_NIST_vector_five)
 
     StaticAnalyzer graph = StaticAnalyzer(builder);
     auto connected_components = graph.find_connected_components();
-    auto variables_in_one_gate = graph.show_variables_in_one_gate(builder);
+    auto variables_in_one_gate = graph.get_variables_in_one_gate();
     EXPECT_EQ(variables_in_one_gate.size(), 0);
     EXPECT_EQ(connected_components.size(), 1);
 }
@@ -150,7 +150,7 @@ TEST(boomerang_stdlib_sha256, test_graph_for_sha256_NIST_vector_one)
     StaticAnalyzer graph = StaticAnalyzer(builder);
     auto connected_components = graph.find_connected_components();
     EXPECT_EQ(connected_components.size(), 1);
-    std::unordered_set<uint32_t> variables_in_one_gate = graph.show_variables_in_one_gate(builder);
+    std::unordered_set<uint32_t> variables_in_one_gate = graph.get_variables_in_one_gate();
     EXPECT_EQ(variables_in_one_gate.size(), 0);
 }
 
@@ -170,7 +170,7 @@ TEST(boomerang_stdlib_sha256, test_graph_for_sha256_NIST_vector_two)
     StaticAnalyzer graph = StaticAnalyzer(builder);
     auto connected_components = graph.find_connected_components();
     EXPECT_EQ(connected_components.size(), 1);
-    std::unordered_set<uint32_t> variables_in_one_gate = graph.show_variables_in_one_gate(builder);
+    std::unordered_set<uint32_t> variables_in_one_gate = graph.get_variables_in_one_gate();
     EXPECT_EQ(variables_in_one_gate.size(), 0);
 }
 
@@ -192,7 +192,7 @@ TEST(boomerang_stdlib_sha256, test_graph_for_sha256_NIST_vector_three)
     StaticAnalyzer graph = StaticAnalyzer(builder);
     auto connected_components = graph.find_connected_components();
     EXPECT_EQ(connected_components.size(), 1);
-    std::unordered_set<uint32_t> variables_in_one_gate = graph.show_variables_in_one_gate(builder);
+    std::unordered_set<uint32_t> variables_in_one_gate = graph.get_variables_in_one_gate();
     EXPECT_EQ(variables_in_one_gate.size(), 0);
 }
 
@@ -214,6 +214,6 @@ TEST(boomerang_stdlib_sha256, test_graph_for_sha256_NIST_vector_four)
     StaticAnalyzer graph = StaticAnalyzer(builder);
     auto connected_components = graph.find_connected_components();
     EXPECT_EQ(connected_components.size(), 1);
-    std::unordered_set<uint32_t> variables_in_one_gate = graph.show_variables_in_one_gate(builder);
+    std::unordered_set<uint32_t> variables_in_one_gate = graph.get_variables_in_one_gate();
     EXPECT_EQ(variables_in_one_gate.size(), 0);
 }

--- a/barretenberg/cpp/src/barretenberg/boomerang_value_detection/graph_description_ultra_recursive_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/boomerang_value_detection/graph_description_ultra_recursive_verifier.test.cpp
@@ -136,9 +136,9 @@ template <typename RecursiveFlavor> class BoomerangRecursiveVerifierTest : publi
         outer_circuit.finalize_circuit(false);
         auto graph = cdg::StaticAnalyzer(outer_circuit);
         auto connected_components = graph.find_connected_components();
-        EXPECT_EQ(connected_components.size(), 2);
+        EXPECT_EQ(connected_components.size(), 1);
         info("Connected components: ", connected_components.size());
-        auto variables_in_one_gate = graph.show_variables_in_one_gate(outer_circuit);
+        auto variables_in_one_gate = graph.get_variables_in_one_gate();
         EXPECT_EQ(variables_in_one_gate.size(), 2);
     }
 };

--- a/barretenberg/cpp/src/barretenberg/boomerang_value_detection/variable_gates_count.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/boomerang_value_detection/variable_gates_count.test.cpp
@@ -24,7 +24,7 @@ TEST(boomerang_ultra_circuit_constructor, test_variable_gates_count_for_decompos
     circuit_constructor.decompose_into_default_range(a_idx, 134);
 
     StaticAnalyzer graph = StaticAnalyzer(circuit_constructor);
-    std::unordered_set<uint32_t> variables_in_on_gate = graph.show_variables_in_one_gate(circuit_constructor);
+    std::unordered_set<uint32_t> variables_in_on_gate = graph.get_variables_in_one_gate();
     EXPECT_EQ(variables_in_on_gate.size(), 0);
 }
 
@@ -40,7 +40,7 @@ TEST(boomerang_ultra_circuit_constructor, test_variable_gates_count_for_decompos
     circuit_constructor.decompose_into_default_range(a_idx, 42);
 
     StaticAnalyzer graph = StaticAnalyzer(circuit_constructor);
-    auto variables_in_on_gate = graph.show_variables_in_one_gate(circuit_constructor);
+    auto variables_in_on_gate = graph.get_variables_in_one_gate();
     EXPECT_EQ(variables_in_on_gate.size(), 0);
 }
 
@@ -85,7 +85,7 @@ TEST(boomerang_ultra_circuit_constructor, test_variable_gates_count_for_two_deco
     circuit_constructor.decompose_into_default_range(a2_idx, 42);
 
     StaticAnalyzer graph = StaticAnalyzer(circuit_constructor);
-    std::unordered_set<uint32_t> variables_in_one_gate = graph.show_variables_in_one_gate(circuit_constructor);
+    std::unordered_set<uint32_t> variables_in_one_gate = graph.get_variables_in_one_gate();
     EXPECT_EQ(variables_in_one_gate.size(), 0);
 }
 
@@ -110,7 +110,7 @@ TEST(boomerang_ultra_circuit_constructor, test_decompose_with_boolean_gates)
     }
 
     StaticAnalyzer graph = StaticAnalyzer(circuit_constructor);
-    std::unordered_set<uint32_t> variables_in_one_gate = graph.show_variables_in_one_gate(circuit_constructor);
+    std::unordered_set<uint32_t> variables_in_one_gate = graph.get_variables_in_one_gate();
     EXPECT_EQ(variables_in_one_gate.size(), 22);
 }
 
@@ -126,6 +126,6 @@ TEST(boomerang_ultra_circuit_constructor, test_decompose_for_6_bit_number)
     circuit_constructor.decompose_into_default_range(a_idx, 6);
 
     StaticAnalyzer graph = StaticAnalyzer(circuit_constructor);
-    std::unordered_set<uint32_t> variables_in_on_gate = graph.show_variables_in_one_gate(circuit_constructor);
+    std::unordered_set<uint32_t> variables_in_on_gate = graph.get_variables_in_one_gate();
     EXPECT_EQ(variables_in_on_gate.size(), 0);
 }

--- a/barretenberg/cpp/src/barretenberg/protogalaxy/prover_verifier_shared.hpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/prover_verifier_shared.hpp
@@ -44,7 +44,9 @@ template <typename FF> static FF evaluate_perturbator(std::vector<FF> coeffs, FF
     FF result = FF(0);
     for (size_t i = 0; i < coeffs.size(); i++) {
         result += coeffs[i] * point_acc;
-        point_acc *= point;
+        if (i < coeffs.size() - 1) {
+            point_acc *= point;
+        }
     }
     return result;
 };

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_goblin.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_goblin.hpp
@@ -175,12 +175,21 @@ template <class Builder_, class Fq, class Fr, class NativeGroup> class goblin_el
             y_lo.assert_equal(other.y.limbs[0]);
             y_hi.assert_equal(other.y.limbs[1]);
         }
+        // if function queue_ecc_add_accum is used, op_tuple creates as a result of construct_and_populate_ultra_ops
+        // function. In case of queue_ecc_add_accum, scalar is zero, (z_1, z_2) = (scalar, 0) = (0, 0) and they just put
+        // in the wires.
+        builder->update_used_witnesses({ op_tuple.z_1, op_tuple.z_2 });
 
         ecc_op_tuple op_tuple2 = builder->queue_ecc_add_accum(result_value);
         auto x_lo = Fr::from_witness_index(builder, op_tuple2.x_lo);
         auto x_hi = Fr::from_witness_index(builder, op_tuple2.x_hi);
         auto y_lo = Fr::from_witness_index(builder, op_tuple2.y_lo);
         auto y_hi = Fr::from_witness_index(builder, op_tuple2.y_hi);
+
+        // if function queue_ecc_add_accum is used, op_tuple creates as a result of construct_and_populate_ultra_ops
+        // function. In case of queue_ecc_add_accum, scalar is zero, (z_1, z_2) = (scalar, 0) = (0, 0) and they just put
+        // in the wires.
+        builder->update_used_witnesses({ op_tuple2.z_1, op_tuple2.z_2 });
 
         Fq result_x(x_lo, x_hi);
         Fq result_y(y_lo, y_hi);

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_impl.hpp
@@ -133,9 +133,9 @@ element<C, Fq, Fr, G> element<C, Fq, Fr, G>::operator+(const element& other) con
 /**
  * @brief Enforce x and y coordinates of a point to be (0,0) in the case of point at infinity
  *
- * @details We need to have a standard witness in Noir and the point at infinity can have non-zero random coefficients
- * when we get it as output from our optimized algorithms. This function returns a (0,0) point, if it is a point at
- * infinity
+ * @details We need to have a standard witness in Noir and the point at infinity can have non-zero random
+ * coefficients when we get it as output from our optimized algorithms. This function returns a (0,0) point, if
+ * it is a point at infinity
  */
 template <typename C, class Fq, class Fr, class G>
 element<C, Fq, Fr, G> element<C, Fq, Fr, G>::get_standard_form() const
@@ -172,9 +172,9 @@ element<C, Fq, Fr, G> element<C, Fq, Fr, G>::operator-(const element& other) con
     const Fq add_lambda_denominator = other.x - x;
     const Fq dbl_lambda_denominator = y + y;
     Fq lambda_denominator = Fq::conditional_assign(double_predicate, dbl_lambda_denominator, add_lambda_denominator);
-    // If either inputs are points at infinity, we set lambda_denominator to be 1. This ensures we never trigger a
-    // divide by zero error.
-    // (if either inputs are points at infinity we will not use the result of this computation)
+    // If either inputs are points at infinity, we set lambda_denominator to be 1. This ensures we never trigger
+    // a divide by zero error. (if either inputs are points at infinity we will not use the result of this
+    // computation)
     Fq safe_edgecase_denominator = Fq(1);
     lambda_denominator =
         Fq::conditional_assign(has_infinity_input || infinity_predicate, safe_edgecase_denominator, lambda_denominator);
@@ -243,8 +243,8 @@ template <typename C, class Fq, class Fr, class G>
 std::array<element<C, Fq, Fr, G>, 2> element<C, Fq, Fr, G>::checked_unconditional_add_sub(const element& other) const
 {
 
-    // TODO(https://github.com/AztecProtocol/barretenberg/issues/971): This will fail when the two elements are the
-    // same even in the case of a valid circuit
+    // TODO(https://github.com/AztecProtocol/barretenberg/issues/971): This will fail when the two elements are
+    // the same even in the case of a valid circuit
     other.x.assert_is_not_equal(x);
 
     const Fq denominator = other.x - x;
@@ -282,8 +282,8 @@ template <typename C, class Fq, class Fr, class G> element<C, Fq, Fr, G> element
 /**
  * Evaluate a chain addition!
  *
- * When adding a set of points P_1 + ... + P_N, we do not need to compute the y-coordinate of intermediate addition
- *terms.
+ * When adding a set of points P_1 + ... + P_N, we do not need to compute the y-coordinate of intermediate
+ *addition terms.
  *
  * i.e. we substitute `acc.y` with `acc.y = acc.lambda_prev * (acc.x1_prev - acc.x) - acc.y1_prev`
  *
@@ -435,16 +435,16 @@ element<C, Fq, Fr, G> element<C, Fq, Fr, G>::montgomery_ladder(const element& ot
  *
  * We substitute `to_add.y` with `lambda_prev * (to_add.x1_prev - to_add.x) - to_add.y1_prev`
  *
- * Here, `x1_prev, y1_prev, lambda_prev` are the values of `x1, y1, lambda` for the addition operation that PRODUCED
- *to_add
+ * Here, `x1_prev, y1_prev, lambda_prev` are the values of `x1, y1, lambda` for the addition operation that
+ *PRODUCED to_add
  *
  * The reason why this saves us gates, is because the montgomery ladder does not multiply to_add.y by any values
  * i.e. to_add.y is only used in addition operations
  *
  * This allows us to substitute to_add.y with the above relation without requiring additional field reductions
  *
- * e.g. the term (lambda * (x3 - x1) + to_add.y) remains "quadratic" if we replace to_add.y with the above quadratic
- *relation
+ * e.g. the term (lambda * (x3 - x1) + to_add.y) remains "quadratic" if we replace to_add.y with the above
+ *quadratic relation
  *
  **/
 template <typename C, class Fq, class Fr, class G>
@@ -640,10 +640,11 @@ element<C, Fq, Fr, G> element<C, Fq, Fr, G>::multiple_montgomery_ladder(
 
         Fq x_3 = lambda1.madd(lambda1, { -add[i].x3_prev, -previous_x });
 
-        // We can avoid computing y_4, instead substituting the expression `minus_lambda_2 * (x_4 - x) - y` where
-        // needed. This is cheaper, because we can evaluate two field multiplications (or a field multiplication + a
-        // field division) with only one non-native field reduction. E.g. evaluating (a * b) + (c * d) = e mod p only
-        // requires 1 quotient and remainder, which is the major cost of a non-native field multiplication
+        // We can avoid computing y_4, instead substituting the expression `minus_lambda_2 * (x_4 - x) - y`
+        // where needed. This is cheaper, because we can evaluate two field multiplications (or a field
+        // multiplication + a field division) with only one non-native field reduction. E.g. evaluating (a * b)
+        // + (c * d) = e mod p only requires 1 quotient and remainder, which is the major cost of a non-native
+        // field multiplication
         Fq lambda2;
         if (i == 0) {
             lambda2 = Fq::div_without_denominator_check({ y + y }, (previous_x - x_3)) - lambda1;
@@ -670,10 +671,11 @@ element<C, Fq, Fr, G> element<C, Fq, Fr, G>::multiple_montgomery_ladder(
             y_4.is_negative = !previous_y.is_negative;
             y_4.mul_left.emplace_back(lambda2);
             y_4.mul_right.emplace_back(previous_y.is_negative ? previous_x - x_4 : x_4 - previous_x);
-            // append terms in previous_y to y_4. We want to make sure the terms above are added into the start of y_4.
-            // This is to ensure they are cached correctly when
+            // append terms in previous_y to y_4. We want to make sure the terms above are added into the start
+            // of y_4. This is to ensure they are cached correctly when
             // `builder::evaluate_partial_non_native_field_multiplication` is called.
-            // (the 1st mul_left, mul_right elements will trigger builder::evaluate_non_native_field_multiplication
+            // (the 1st mul_left, mul_right elements will trigger
+            // builder::evaluate_non_native_field_multiplication
             //  when Fq::mult_madd is called - this term cannot be cached so we want to make sure it is unique)
             std::copy(previous_y.mul_left.begin(), previous_y.mul_left.end(), std::back_inserter(y_4.mul_left));
             std::copy(previous_y.mul_right.begin(), previous_y.mul_right.end(), std::back_inserter(y_4.mul_right));
@@ -710,15 +712,15 @@ element<C, Fq, Fr, G> element<C, Fq, Fr, G>::multiple_montgomery_ladder(
  * Instead of handling the edge case (which is expensive!) we instead FORBID it from happening by
  * requiring x2 != x1 (other.x.assert_is_not_equal(x) will be present in all group operation methods)
  *
- * This means it is essential we ensure an honest prover will NEVER run into this edge case, or our circuit will lack
- * completeness!
+ * This means it is essential we ensure an honest prover will NEVER run into this edge case, or our circuit will
+ * lack completeness!
  *
  * To ensure an honest prover will not fall foul of this edge case when performing a SCALAR MULTIPLICATION,
  * we init the accumulator with an `offset_generator` point.
  * This point is a generator point that is not equal to the regular generator point for this curve.
  *
- * When adding points into the accumulator, the probability that an honest prover will find a collision is now ~ 1 in
- * 2^128
+ * When adding points into the accumulator, the probability that an honest prover will find a collision is now ~
+ * 1 in 2^128
  *
  * We init `accumulator = generator` and then perform an n-bit scalar mul.
  * The output accumulator will contain a term `2^{n-1} * generator` that we need to subtract off.
@@ -743,8 +745,8 @@ std::pair<element<C, Fq, Fr, G>, element<C, Fq, Fr, G>> element<C, Fq, Fr, G>::c
 /**
  * @brief Generic batch multiplication that works for all elliptic curve types.
  *
- * @details Implementation is identical to `bn254_endo_batch_mul` but WITHOUT the endomorphism transforms OR support for
- * short scalars See `bn254_endo_batch_mul` for description of algorithm.
+ * @details Implementation is identical to `bn254_endo_batch_mul` but WITHOUT the endomorphism transforms OR
+ * support for short scalars See `bn254_endo_batch_mul` for description of algorithm.
  *
  * @tparam C The circuit builder type.
  * @tparam Fq The field of definition of the points in `_points`.
@@ -771,12 +773,11 @@ element<C, Fq, Fr, G> element<C, Fq, Fr, G>::batch_mul(const std::vector<element
     }
     for (size_t i = 0; i < scalars.size(); i++) {
         // If batch_mul actually performs batch multiplication on the points and scalars, subprocedures can do
-        // operations like addition or subtraction of points, which can trigger OriginTag security mechanisms even
-        // though the final result satisfies the security logic
-        // For example result = submitted_in_round_0 *challenge_from_round_0 +submitted_in_round_1 *
-        // challenge_in_round_1 will trigger it, because the addition of submitted_in_round_0 to submitted_in_round_1 is
-        // dangerous by itself. To avoid this, we remove the tags, merge them separately and set the result
-        // appropriately
+        // operations like addition or subtraction of points, which can trigger OriginTag security mechanisms
+        // even though the final result satisfies the security logic For example result = submitted_in_round_0
+        // *challenge_from_round_0 +submitted_in_round_1 * challenge_in_round_1 will trigger it, because the
+        // addition of submitted_in_round_0 to submitted_in_round_1 is dangerous by itself. To avoid this, we
+        // remove the tags, merge them separately and set the result appropriately
         points[i].set_origin_tag(empty_tag);
         scalars[i].set_origin_tag(empty_tag);
     }
@@ -865,12 +866,12 @@ element<C, Fq, Fr, G> element<C, Fq, Fr, G>::scalar_mul(const Fr& scalar, const 
      *
      * We want to construct a circuit that evaluates scalar multiplications of curve E. Where q > r and p > r.
      *
-     * i.e. we need to perform arithmetic in one prime field, using prime field arithmetic in a completely different
-     *prime field.
+     * i.e. we need to perform arithmetic in one prime field, using prime field arithmetic in a completely
+     *different prime field.
      *
      * To do *this*, we need to emulate a binary (or in our case quaternary) number system in Fr, so that we can
-     * use the binary/quaternary basis to emulate arithmetic in Fq. Which is very messy. See bigfield.hpp for the
-     * specifics.
+     * use the binary/quaternary basis to emulate arithmetic in Fq. Which is very messy. See bigfield.hpp for
+     *the specifics.
      *
      **/
     OriginTag tag{};

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/mega_circuit_builder.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/mega_circuit_builder.cpp
@@ -47,25 +47,25 @@ template <typename FF> void MegaCircuitBuilder_<FF>::add_mega_gates_to_ensure_al
     add_public_calldata(this->add_variable(BusVector::DEFAULT_VALUE));    // add one entry in calldata
     auto raw_read_idx = static_cast<uint32_t>(get_calldata().size()) - 1; // read data that was just added
     auto read_idx = this->add_variable(raw_read_idx);
-    read_calldata(read_idx);
+    update_finalize_witnesses({ read_idx, read_calldata(read_idx) });
 
     // Create an arbitrary secondary_calldata read gate
     add_public_secondary_calldata(this->add_variable(BusVector::DEFAULT_VALUE)); // add one entry in secondary_calldata
     raw_read_idx = static_cast<uint32_t>(get_secondary_calldata().size()) - 1;   // read data that was just added
     read_idx = this->add_variable(raw_read_idx);
-    read_secondary_calldata(read_idx);
+    update_finalize_witnesses({ read_idx, read_secondary_calldata(read_idx) });
 
     // Create an arbitrary return data read gate
     add_public_return_data(this->add_variable(BusVector::DEFAULT_VALUE)); // add one entry in return data
     raw_read_idx = static_cast<uint32_t>(get_return_data().size()) - 1;   // read data that was just added
     read_idx = this->add_variable(raw_read_idx);
-    read_return_data(read_idx);
+    update_finalize_witnesses({ read_idx, read_return_data(read_idx) });
 
     if (op_queue->get_current_subtable_size() == 0) {
         // Add a mul dummy op in the subtable to avoid column polynomial being zero (it has to be a mul rather than an
         // add to ensure all 4 column polynomials contain some data)
-        this->queue_ecc_mul_accum(bb::g1::affine_element::one(), 2);
-        this->queue_ecc_eq();
+        this->queue_ecc_mul_accum(bb::g1::affine_element::one(), 2, /*in_finalize=*/true);
+        this->queue_ecc_eq(/*in_finalize=*/true);
     }
 }
 
@@ -107,32 +107,37 @@ template <typename FF> ecc_op_tuple MegaCircuitBuilder_<FF>::queue_ecc_add_accum
  * @tparam FF
  * @param point
  * @param scalar The scalar by which point is multiplied prior to being accumulated
+ * @param in_finalize It's used in boomerang catcher to mark
+ * that all variables from some connected component were created after finalize method was called
  * @return ecc_op_tuple encoding the point and scalar inputs to the mul accum
  */
 template <typename FF>
-ecc_op_tuple MegaCircuitBuilder_<FF>::queue_ecc_mul_accum(const bb::g1::affine_element& point, const FF& scalar)
+ecc_op_tuple MegaCircuitBuilder_<FF>::queue_ecc_mul_accum(const bb::g1::affine_element& point,
+                                                          const FF& scalar,
+                                                          bool in_finalize)
 {
     // Add the operation to the op queue
     auto ultra_op = op_queue->mul_accumulate(point, scalar);
 
     // Add corresponding gates for the operation
-    ecc_op_tuple op_tuple = populate_ecc_op_wires(ultra_op);
+    ecc_op_tuple op_tuple = populate_ecc_op_wires(ultra_op, in_finalize);
     return op_tuple;
 }
 
 /**
  * @brief Add point equality operation to the op queue based on the value of the internal accumulator and add
  * corresponding gates
- *
+ * @param in_finalize It's used in boomerang catcher to mark
+ * that all variables from some connected component were created after finalize method was called
  * @return ecc_op_tuple encoding the point to which equality has been asserted
  */
-template <typename FF> ecc_op_tuple MegaCircuitBuilder_<FF>::queue_ecc_eq()
+template <typename FF> ecc_op_tuple MegaCircuitBuilder_<FF>::queue_ecc_eq(bool in_finalize)
 {
     // Add the operation to the op queue
     auto ultra_op = op_queue->eq_and_reset();
 
     // Add corresponding gates for the operation
-    ecc_op_tuple op_tuple = populate_ecc_op_wires(ultra_op);
+    ecc_op_tuple op_tuple = populate_ecc_op_wires(ultra_op, in_finalize);
     op_tuple.return_is_infinity = ultra_op.return_is_infinity;
     return op_tuple;
 }
@@ -156,9 +161,12 @@ template <typename FF> ecc_op_tuple MegaCircuitBuilder_<FF>::queue_ecc_no_op()
  * @brief Add goblin ecc op gates for a single operation
  *
  * @param ultra_op Operation data expressed in the ultra format
+ * @param in_finalize It's used in boomerang catcher to mark
+ * that all variables from some connected component were created after finalize method was called
  * @note All selectors are set to 0 since the ecc op selector is derived later based on the block size/location.
  */
-template <typename FF> ecc_op_tuple MegaCircuitBuilder_<FF>::populate_ecc_op_wires(const UltraOp& ultra_op)
+template <typename FF>
+ecc_op_tuple MegaCircuitBuilder_<FF>::populate_ecc_op_wires(const UltraOp& ultra_op, bool in_finalize)
 {
     ecc_op_tuple op_tuple;
     op_tuple.op = get_ecc_op_idx(ultra_op.op_code);
@@ -186,6 +194,13 @@ template <typename FF> ecc_op_tuple MegaCircuitBuilder_<FF>::populate_ecc_op_wir
     this->blocks.ecc_op.populate_wires(op_val_idx_2, op_tuple.y_hi, op_tuple.z_1, op_tuple.z_2);
     for (auto& selector : this->blocks.ecc_op.get_selectors()) {
         selector.emplace_back(0);
+    }
+
+    if (in_finalize) {
+        update_used_witnesses(
+            { op_tuple.op, op_tuple.x_lo, op_tuple.x_hi, op_tuple.y_lo, op_tuple.y_hi, op_tuple.z_1, op_tuple.z_2 });
+        update_finalize_witnesses(
+            { op_tuple.op, op_tuple.x_lo, op_tuple.x_hi, op_tuple.y_lo, op_tuple.y_hi, op_tuple.z_1, op_tuple.z_2 });
     }
 
     return op_tuple;

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/mega_circuit_builder.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/mega_circuit_builder.hpp
@@ -36,13 +36,13 @@ template <typename FF> class MegaCircuitBuilder_ : public UltraCircuitBuilder_<M
 
     // Functions for adding ECC op queue "gates"
     ecc_op_tuple queue_ecc_add_accum(const g1::affine_element& point);
-    ecc_op_tuple queue_ecc_mul_accum(const g1::affine_element& point, const FF& scalar);
-    ecc_op_tuple queue_ecc_eq();
+    ecc_op_tuple queue_ecc_mul_accum(const g1::affine_element& point, const FF& scalar, bool in_finalize = false);
+    ecc_op_tuple queue_ecc_eq(bool in_finalize = true);
     ecc_op_tuple queue_ecc_no_op();
     void queue_ecc_random_op();
 
   private:
-    ecc_op_tuple populate_ecc_op_wires(const UltraOp& ultra_op);
+    ecc_op_tuple populate_ecc_op_wires(const UltraOp& ultra_op, bool in_finalize = false);
     void set_goblin_ecc_op_code_constant_variables();
     void create_databus_read_gate(const databus_lookup_gate_<FF>& in, BusId bus_idx);
     void apply_databus_selectors(BusId bus_idx);

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.cpp
@@ -227,9 +227,8 @@ void UltraCircuitBuilder_<ExecutionTrace>::add_gates_to_ensure_all_polys_are_non
                                                           read_data[plookup::ColumnIdx::C2],
                                                           read_data[plookup::ColumnIdx::C3] };
     for (const auto& column : parse_read_data) {
-        for (const auto& index : column) {
-            update_used_witnesses(index);
-        }
+        update_used_witnesses(column);
+        update_finalize_witnesses(column);
     }
 
     // mock a poseidon external gate, with all zeros as input

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.hpp
@@ -221,6 +221,9 @@ class UltraCircuitBuilder_ : public CircuitBuilderBase<typename ExecutionTrace_:
 
     // Witnesses that can be in one gate, but that's intentional (used in boomerang catcher)
     std::vector<uint32_t> used_witnesses;
+    // Witnesses that appear in finalize method (used in boomerang catcher). Need to check
+    // that all variables from some connected component were created after finalize method was called
+    std::unordered_set<uint32_t> finalize_witnesses;
     std::vector<cached_partial_non_native_field_multiplication> cached_partial_non_native_field_multiplications;
 
     bool circuit_finalized = false;
@@ -612,7 +615,50 @@ class UltraCircuitBuilder_ : public CircuitBuilderBase<typename ExecutionTrace_:
 
     std::vector<uint32_t> get_used_witnesses() const { return used_witnesses; }
 
+    /**
+     * @brief Add a witness index to the boomerang exclusion list
+     * @param var_idx Witness index to add to the boomerang exclusion list
+     * @details Barretenberg has special boomerang value detection logic that detects variables that are used in one
+     * gate However, there are some cases where we want to exclude certain variables from this detection (for example,
+     * when we show that x!=0 -> x*(x^-1) = 1).
+     */
     void update_used_witnesses(uint32_t var_idx) { used_witnesses.emplace_back(var_idx); }
+
+    /**
+     * @brief Add a list of witness indices to the boomerang exclusion list
+     * @param used_indices List of witness indices to add to the boomerang exclusion list
+     * @details Barretenberg has special boomerang value detection logic that detects variables that are used in one
+     * gate However, there are some cases where we want to exclude certain variables from this detection (for example,
+     * when we show that x!=0 -> x*(x^-1) = 1).
+     */
+    void update_used_witnesses(const std::vector<uint32_t>& used_indices)
+    {
+        used_witnesses.reserve(used_witnesses.size() + used_indices.size());
+        for (const auto& it : used_indices) {
+            used_witnesses.emplace_back(it);
+        }
+    }
+    /**
+     * @brief Add a witness index to the finalize exclusion list
+     * @param var_idx Witness index to add to the finalize exclusion list
+     * @details Barretenberg has special isolated subcircuit detection logic that ensures that variables in the main
+     * circuit are all connected. However, during finalization we intentionally create some subcircuits that are only
+     * connected through the set permutation. We want to exclude these variables from this detection.
+     */
+    void update_finalize_witnesses(uint32_t var_idx) { finalize_witnesses.insert(var_idx); }
+    /**
+     * @brief Add a list of witness indices to the finalize exclusion list
+     * @param finalize_indices List of witness indices to add to the finalize exclusion list
+     * @details Barretenberg has special isolated subcircuit detection logic that ensures that variables in the main
+     * circuit are all connected. However, during finalization we intentionally create some subcircuits that are only
+     * connected through the set permutation. We want to exclude these variables from this detection.
+     */
+    void update_finalize_witnesses(const std::vector<uint32_t>& finalize_indices)
+    {
+        for (const auto& it : finalize_indices) {
+            finalize_witnesses.insert(it);
+        }
+    }
 
     /**x
      * @brief Print the number and composition of gates in the circuit


### PR DESCRIPTION
This time Protogalaxy Recursive Verifier was tested.

1. The tool was modified in order to be able to process Ultra and Mega Circuit Builders depending on the type of the circuit
2. The algorithm for finding connected components was fixed
3. Small refactoring: unused functions were removed and new added new connected components algorithm, changed find_block_index to remove void* :)
4. Tests for Protogalaxy Recursive Verifier were added for folding and decider circuits. More false cases, 0 vulnerabilities.

