### PR TITLE
chore(ci): attempt to fix rare flake

### DIFF
--- a/ci3/run_test_cmd
+++ b/ci3/run_test_cmd
@@ -105,7 +105,8 @@ function live_publish_log {
   publish_log
   echo -e "${blue}RUNNING${reset}${log_info:-}: $test_cmd"
   while [ -f $tmp_file ]; do
-    if [ $(( $(date +%s) - $(stat -c %Y "$tmp_file") )) -le 5 ]; then
+    local stat=$(stat -c %Y "$tmp_file" || echo 0)
+    if [ $(( $(date +%s) - "$stat" )) -le 5 ]; then
       publish_log
     fi
     sleep 5 &


### PR DESCRIPTION
I'm assuming this is a very rare time-of-check-vs-time-of-use race condition

```
stat: cannot statx '/tmp/b14e7e9201f291bc': No such file or directory
/home/aztec-dev/aztec-packages/ci3/run_test_cmd: line 108: 1756344688 -  : syntax error: operand expected (error token is "-  ")
``` 
in 
http://ci.aztec-labs.com/8927398b96150dd1