### PR TITLE
[NO_MERGE] chore: debug info to debug duplicate nullifier

### DIFF
--- a/noir-projects/noir-contracts/contracts/app/amm_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/amm_contract/src/main.nr
@@ -41,7 +41,7 @@ pub contract AMM {
     };
     use dep::aztec::{
         macros::{functions::{initializer, internal, private, public, utility}, storage::storage},
-        protocol_types::address::AztecAddress,
+        protocol_types::{address::AztecAddress, traits::ToField},
         state_vars::PublicImmutable,
     };
 
@@ -331,6 +331,18 @@ pub contract AMM {
         amount_out_min: u128,
         authwit_nonce: Field,
     ) {
+        // TODO(DUPLICATE_NULLIFIER_ISSUE): Nuke this log once the issue is resolved.
+        aztec::oracle::debug_log::debug_log_format(
+            "swap_exact_tokens_for_tokens: token_in {0}, token_out {1}, amount_in {2}, amount_out_min {3}",
+            [
+                token_in.to_field(),
+                token_out.to_field(),
+                amount_in as Field,
+                amount_out_min as Field,
+            ],
+        );
+        // NUKE_END
+
         let config = storage.config.read();
 
         assert((token_in == config.token0) | (token_in == config.token1), "TOKEN_IN_IS_INVALID");
@@ -356,6 +368,10 @@ pub contract AMM {
                 token_out_partial_note,
             )
             .enqueue(&mut context);
+
+        // TODO(DUPLICATE_NULLIFIER_ISSUE): Nuke this log once the issue is resolved.
+        aztec::oracle::debug_log::debug_log_format("swap_exact_tokens_for_tokens end", []);
+        // NUKE_END
     }
 
     #[public]

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/main.nr
@@ -31,7 +31,9 @@ pub contract Token {
     };
 
     use dep::uint_note::uint_note::{PartialUintNote, UintNote};
-    use aztec::protocol_types::{address::AztecAddress, traits::ToField};
+    use aztec::protocol_types::{
+        abis::side_effect::OrderedValue, address::AztecAddress, traits::ToField,
+    };
 
     // docs:start:import_authwit
     use aztec::authwit::auth::compute_authwit_nullifier;
@@ -235,7 +237,26 @@ pub contract Token {
         amount: u128,
         authwit_nonce: Field,
     ) {
+        // TODO(DUPLICATE_NULLIFIER_ISSUE): Nuke this log once the issue is resolved.
+        aztec::oracle::debug_log::debug_log_format(
+            "transfer_to_public: from {0}, to {1}, amount {2}",
+            [from.to_field(), to.to_field(), amount.to_field()],
+        );
+        aztec::oracle::debug_log::debug_log_format(
+            "nullifiers in context before emission transfer_to_public: {}",
+            context.nullifiers.storage().map(|n| n.value()),
+        );
+        // NUKE_END
+
         storage.balances.at(from).sub(from, amount).emit(encode_and_encrypt_note(&mut context, from));
+
+        // TODO(DUPLICATE_NULLIFIER_ISSUE): Nuke this log once the issue is resolved.
+        aztec::oracle::debug_log::debug_log_format(
+            "nullifiers in context after emission transfer_to_public: {}",
+            context.nullifiers.storage().map(|n| n.value()),
+        );
+        // NUKE_END
+
         Token::at(context.this_address())._increase_public_balance(to, amount).enqueue(&mut context);
     }
     // docs:end:transfer_to_public
@@ -423,7 +444,27 @@ pub contract Token {
     /// returned partial note.
     #[private]
     fn prepare_private_balance_increase(to: AztecAddress) -> PartialUintNote {
-        _prepare_private_balance_increase(to, &mut context, storage)
+        // TODO(DUPLICATE_NULLIFIER_ISSUE): Nuke this log once the issue is resolved.
+        aztec::oracle::debug_log::debug_log_format(
+            "prepare_private_balance_increase, to: {0}",
+            [to.to_field()],
+        );
+        aztec::oracle::debug_log::debug_log_format(
+            "nullifiers in context before emission prepare_private_balance_increase: {}",
+            context.nullifiers.storage().map(|n| n.value()),
+        );
+        // NUKE_END
+
+        let partial_note = _prepare_private_balance_increase(to, &mut context, storage);
+
+        // TODO(DUPLICATE_NULLIFIER_ISSUE): Nuke this log once the issue is resolved.
+        aztec::oracle::debug_log::debug_log_format(
+            "nullifiers in context after emission transfer_to_public: {}",
+            context.nullifiers.storage().map(|n| n.value()),
+        );
+        // NUKE_END
+
+        partial_note
     }
     // docs:end:prepare_private_balance_increase
 

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/main.nr
@@ -32,7 +32,8 @@ pub contract Token {
 
     use dep::uint_note::uint_note::{PartialUintNote, UintNote};
     use aztec::protocol_types::{
-        abis::side_effect::OrderedValue, address::AztecAddress, traits::ToField,
+        abis::side_effect::OrderedValue, address::AztecAddress, hash::compute_siloed_nullifier,
+        traits::ToField,
     };
 
     // docs:start:import_authwit
@@ -244,7 +245,14 @@ pub contract Token {
         );
         aztec::oracle::debug_log::debug_log_format(
             "nullifiers in context before emission transfer_to_public: {}",
-            context.nullifiers.storage().map(|n| n.value()),
+            context.nullifiers.storage().map(|n| {
+                let value = n.value();
+                if value != 0 {
+                    compute_siloed_nullifier(context.this_address(), value)
+                } else {
+                    value
+                }
+            }),
         );
         // NUKE_END
 
@@ -253,7 +261,14 @@ pub contract Token {
         // TODO(DUPLICATE_NULLIFIER_ISSUE): Nuke this log once the issue is resolved.
         aztec::oracle::debug_log::debug_log_format(
             "nullifiers in context after emission transfer_to_public: {}",
-            context.nullifiers.storage().map(|n| n.value()),
+            context.nullifiers.storage().map(|n| {
+                let value = n.value();
+                if value != 0 {
+                    compute_siloed_nullifier(context.this_address(), value)
+                } else {
+                    value
+                }
+            }),
         );
         // NUKE_END
 
@@ -444,25 +459,25 @@ pub contract Token {
     /// returned partial note.
     #[private]
     fn prepare_private_balance_increase(to: AztecAddress) -> PartialUintNote {
-        // TODO(DUPLICATE_NULLIFIER_ISSUE): Nuke this log once the issue is resolved.
-        aztec::oracle::debug_log::debug_log_format(
-            "prepare_private_balance_increase, to: {0}",
-            [to.to_field()],
-        );
-        aztec::oracle::debug_log::debug_log_format(
-            "nullifiers in context before emission prepare_private_balance_increase: {}",
-            context.nullifiers.storage().map(|n| n.value()),
-        );
-        // NUKE_END
+        // // TODO(DUPLICATE_NULLIFIER_ISSUE): Nuke this log once the issue is resolved.
+        // aztec::oracle::debug_log::debug_log_format(
+        //     "prepare_private_balance_increase, to: {0}",
+        //     [to.to_field()],
+        // );
+        // aztec::oracle::debug_log::debug_log_format(
+        //     "nullifiers in context before emission prepare_private_balance_increase: {}",
+        //     context.nullifiers.storage().map(|n| n.value()),
+        // );
+        // // NUKE_END
 
         let partial_note = _prepare_private_balance_increase(to, &mut context, storage);
 
-        // TODO(DUPLICATE_NULLIFIER_ISSUE): Nuke this log once the issue is resolved.
-        aztec::oracle::debug_log::debug_log_format(
-            "nullifiers in context after emission prepare_private_balance_increase: {}",
-            context.nullifiers.storage().map(|n| n.value()),
-        );
-        // NUKE_END
+        // // TODO(DUPLICATE_NULLIFIER_ISSUE): Nuke this log once the issue is resolved.
+        // aztec::oracle::debug_log::debug_log_format(
+        //     "nullifiers in context after emission prepare_private_balance_increase: {}",
+        //     context.nullifiers.storage().map(|n| n.value()),
+        // );
+        // // NUKE_END
 
         partial_note
     }

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/main.nr
@@ -459,7 +459,7 @@ pub contract Token {
 
         // TODO(DUPLICATE_NULLIFIER_ISSUE): Nuke this log once the issue is resolved.
         aztec::oracle::debug_log::debug_log_format(
-            "nullifiers in context after emission transfer_to_public: {}",
+            "nullifiers in context after emission prepare_private_balance_increase: {}",
             context.nullifiers.storage().map(|n| n.value()),
         );
         // NUKE_END

--- a/yarn-project/bot/src/base_bot.ts
+++ b/yarn-project/bot/src/base_bot.ts
@@ -61,6 +61,15 @@ export abstract class BaseBot {
 
     await this.onTxMined(receipt, logCtx);
 
+    const txBlockNumber = receipt.blockNumber;
+
+    if (txBlockNumber === undefined) {
+      this.log.warn(`Bot tx with hash ${receipt.txHash} was not included in a block`);
+    } else {
+      // Wait until PXE is synced up to the block containing our transaction
+      await (this.pxe as any).waitForSyncedBlockNumber(txBlockNumber);
+    }
+
     return receipt;
   }
 

--- a/yarn-project/pxe/src/contract_function_simulator/pxe_oracle_interface.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/pxe_oracle_interface.ts
@@ -742,11 +742,10 @@ export class PXEOracleInterface implements ExecutionDataProvider {
       const { data: _, ...blockHashAndNum } = nullifierIndex;
       await this.noteDataProvider.removeNullifiedNotes([{ data: siloedNullifier, ...blockHashAndNum }], recipient);
 
-      this.log.verbose(`Removed just-added note`, {
+      this.log.verbose(`Removed just-added note with nullifier ${siloedNullifier.toString()}`, {
         contract: contractAddress,
         slot: storageSlot,
         noteHash: noteHash,
-        nullifier: siloedNullifier.toString(),
       });
     }
   }
@@ -913,13 +912,15 @@ export class PXEOracleInterface implements ExecutionDataProvider {
   }
 
   public async removeNullifiedNotes(contractAddress: AztecAddress) {
-    this.log.verbose('Searching for nullifiers of known notes', { contract: contractAddress });
-
     // We avoid making node queries at 'latest' since we mark notes as nullified only if the corresponding nullifier
     // has been included in a block up to which PXE has synced. Note that while this technically results in historical
     // queries, we perform it at the latest locally synced block number which *should* be recent enough to be
     // available, even for non-archive nodes.
     const syncedBlockNumber = await this.syncDataProvider.getBlockNumber();
+
+    this.log.verbose(`Searching for nullifiers of known notes. PXE synced up to block ${syncedBlockNumber}`, {
+      contract: contractAddress,
+    });
 
     for (const recipient of await this.keyStore.getAccounts()) {
       const currentNotesForRecipient = await this.noteDataProvider.getNotes({ contractAddress, recipient });
@@ -949,6 +950,15 @@ export class PXEOracleInterface implements ExecutionDataProvider {
         )
       ).flat();
 
+      this.log.verbose(
+        `Looked for note nullifiers:\n${nullifiersToCheck
+          .map(
+            (n, i) =>
+              `  - ${n.toString()}: ${nullifierIndexes[i]?.data !== undefined ? `found at index ${nullifierIndexes[i].data}` : 'not found'}`,
+          )
+          .join('\n')}`,
+      );
+
       const foundNullifiers = nullifiersToCheck
         .map((nullifier, i) => {
           if (nullifierIndexes[i] !== undefined) {
@@ -959,11 +969,13 @@ export class PXEOracleInterface implements ExecutionDataProvider {
 
       const nullifiedNotes = await this.noteDataProvider.removeNullifiedNotes(foundNullifiers, recipient);
       nullifiedNotes.forEach(noteDao => {
-        this.log.verbose(`Removed note for contract ${noteDao.contractAddress} at slot ${noteDao.storageSlot}`, {
-          contract: noteDao.contractAddress,
-          slot: noteDao.storageSlot,
-          nullifier: noteDao.siloedNullifier.toString(),
-        });
+        this.log.verbose(
+          `Removed note for contract ${noteDao.contractAddress} at slot ${noteDao.storageSlot} with nullifier ${noteDao.siloedNullifier.toString()}`,
+          {
+            contract: noteDao.contractAddress,
+            slot: noteDao.storageSlot,
+          },
+        );
       });
     }
   }

--- a/yarn-project/pxe/src/pxe_service/pxe_service.ts
+++ b/yarn-project/pxe/src/pxe_service/pxe_service.ts
@@ -709,6 +709,9 @@ export class PXEService implements PXE {
         if (!privateExecutionResult) {
           const syncTimer = new Timer();
           await this.synchronizer.sync();
+          this.log.info(
+            `Synchronized PXE up to block ${await this.synchronizer.getSynchedBlockNumber()} in proveTx func`,
+          );
           syncTime = syncTimer.ms();
           contractFunctionSimulator = this.#getSimulatorForTx();
           privateExecutionResult = await this.#executePrivate(contractFunctionSimulator, txRequest);

--- a/yarn-project/pxe/src/pxe_service/pxe_service.ts
+++ b/yarn-project/pxe/src/pxe_service/pxe_service.ts
@@ -1132,4 +1132,13 @@ export class PXEService implements PXE {
   public stop(): Promise<void> {
     return this.jobQueue.end();
   }
+
+  public waitForSyncedBlockNumber(blockNumber: number): Promise<void> {
+    return this.#putInJobQueue(async () => {
+      while ((await this.synchronizer.getSynchedBlockNumber()) < blockNumber) {
+        await new Promise(resolve => setTimeout(resolve, 1000));
+        await this.synchronizer.sync();
+      }
+    });
+  }
 }

--- a/yarn-project/simulator/src/public/public_tx_simulator/public_tx_simulator.ts
+++ b/yarn-project/simulator/src/public/public_tx_simulator/public_tx_simulator.ts
@@ -358,7 +358,7 @@ export class PublicTxSimulator {
       context.revert(
         TxExecutionPhase.APP_LOGIC,
         new SimulationError(
-          `Nullifier collision encountered when inserting revertible nullifiers from private.\nDetails: ${String(e)}`,
+          `Nullifier collision encountered when inserting revertible nullifiers from private from tx ${tx.txHash.toString()}.\nDetails: ${String(e)}`,
           [],
         ),
       );


### PR DESCRIPTION
We are getting a duplicate nullifiers in our AMM bot.

Given that the error is this:
"Nullifier collision encountered when inserting revertible nullifiers from private"

and that the the amm function called by the bot is `swap_exact_tokens_for_tokens` I placed the logs only in private functions that are called by the function and that emit nullifiers.

With these logs we should be able to just looks through the logs and find the problematic nullifier duplicate.

Once this is resolved I expect that this PR will be reverted.