### PR TITLE
feat: add OTEL_COLLECTOR_URL

### DIFF
--- a/.github/workflows/deploy-aztec-infra.yml
+++ b/.github/workflows/deploy-aztec-infra.yml
@@ -100,6 +100,10 @@ on:
         description: Whether to use an external ingress for the rpc
         required: true
         type: boolean
+      otel_collector_url:
+        description: The OpenTelemetry collector that will receive metrics from this deployment. Optional
+        required: false
+        type: string
     secrets:
       GCP_SA_KEY:
         description: The GCP service account key
@@ -207,6 +211,10 @@ on:
         description: Whether to use an external ingress for the rpc
         required: true
         type: boolean
+      otel_collector_url:
+        description: The OpenTelemetry collector that will receive metrics from this deployment. Optional
+        required: false
+        type: string
 
 jobs:
   deploy_aztec_infra:
@@ -237,6 +245,7 @@ jobs:
       TF_VAR_PROVER_RESOURCE_PROFILE: ${{ inputs.prover_resource_profile }}
       TF_VAR_RPC_RESOURCE_PROFILE: ${{ inputs.rpc_resource_profile }}
       TF_VAR_RPC_EXTERNAL_INGRESS: ${{ inputs.rpc_external_ingress }}
+      TF_VAR_OTEL_COLLECTOR_URL: ${{ inputs.otel_collector_url }}
 
     steps:
       - name: Debug inputs

--- a/spartan/terraform/deploy-aztec-infra/main.tf
+++ b/spartan/terraform/deploy-aztec-infra/main.tf
@@ -58,6 +58,7 @@ locals {
     "global.customAztecNetwork.slashFactoryContractAddress"    = var.SLASH_FACTORY_CONTRACT_ADDRESS
     "global.customAztecNetwork.feeAssetHandlerContractAddress" = var.FEE_ASSET_HANDLER_CONTRACT_ADDRESS
     "global.customAztecNetwork.l1ChainId"                      = var.L1_CHAIN_ID
+    "global.otelCollectorEndpoint"                             = var.OTEL_COLLECTOR_URL
   }
 
   common_list_settings = {

--- a/spartan/terraform/deploy-aztec-infra/variables.tf
+++ b/spartan/terraform/deploy-aztec-infra/variables.tf
@@ -79,10 +79,10 @@ variable "AZTEC_DOCKER_IMAGE" {
   default     = "aztecprotocol/aztec:staging"
 }
 
-variable "METRICS_NAMESPACE" {
-  description = "Namespace to deploy the metrics to"
+variable "OTEL_COLLECTOR_URL" {
+  description = "The URL of an OpenTelemtry collector to send metrics to"
   type        = string
-  default     = "metrics"
+  nullable    = true
 }
 
 variable "VALIDATOR_VALUES" {

--- a/spartan/terraform/deploy-metrics/outputs.tf
+++ b/spartan/terraform/deploy-metrics/outputs.tf
@@ -9,3 +9,8 @@ output "otel_collector_ip" {
   value       = google_compute_address.otel_collector_ip.address
 }
 
+output "otel_collector_base_url" {
+  description = "OTEL Collector IP"
+  value       = "http://${google_compute_address.otel_collector_ip.address}:4318"
+}
+


### PR DESCRIPTION
This PR adds a new input variable to `deploy-aztec-info` to control where metrics are sent for a running network