### PR TITLE
fix!: Enable free witness and different transcript checks

### DIFF
--- a/barretenberg/cpp/src/barretenberg/boomerang_value_detection/graph_description_goblin.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/boomerang_value_detection/graph_description_goblin.test.cpp
@@ -91,6 +91,8 @@ TEST_F(BoomerangGoblinRecursiveVerifierTests, graph_description_basic)
             RecursiveCommitment::from_witness(&builder, merge_commitments.t_commitments[idx]);
         recursive_merge_commitments.T_prev_commitments[idx] =
             RecursiveCommitment::from_witness(&builder, merge_commitments.T_prev_commitments[idx]);
+        recursive_merge_commitments.t_commitments[idx].unset_free_witness_tag();
+        recursive_merge_commitments.T_prev_commitments[idx].unset_free_witness_tag();
     }
 
     GoblinRecursiveVerifier verifier{ &builder, verifier_input };

--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/ipa/ipa.hpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/ipa/ipa.hpp
@@ -156,9 +156,6 @@ template <typename Curve_, size_t log_poly_length = CONST_ECCVM_LOG_N> class IPA
     {
         const bb::Polynomial<Fr>& polynomial = opening_claim.polynomial;
 
-        // TODO(https://github.com/AztecProtocol/barretenberg/issues/1150): Hash more things here.
-        // TODO(https://github.com/AztecProtocol/barretenberg/issues/1408): Make IPA fuzzer compatible with `add_to_hash_buffer`.
-        //
         // Step 1.
         // Add the commitment, challenge, and evaluation to the hash buffer.
         // NOTE:

--- a/barretenberg/cpp/src/barretenberg/commitment_schemes_recursion/shplemini.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes_recursion/shplemini.test.cpp
@@ -83,7 +83,11 @@ TEST(ShpleminiRecursionTest, ProveAndVerifySingle)
                            commitments.end(),
                            commitments_in_biggroup.begin(),
                            [&builder](const auto& native_commitment) {
-                               return Commitment::from_witness(&builder, native_commitment);
+                               auto comm = Commitment::from_witness(&builder, native_commitment);
+                               // Removing the free witness tag, since the commitment in the full scheme are supposed to
+                               // be fiat-shamirred earlier
+                               comm.unset_free_witness_tag();
+                               return comm;
                            });
             return commitments_in_biggroup;
         };
@@ -91,7 +95,11 @@ TEST(ShpleminiRecursionTest, ProveAndVerifySingle)
             std::vector<Fr> elements_in_circuit(elements.size());
             std::transform(
                 elements.begin(), elements.end(), elements_in_circuit.begin(), [&builder](const auto& native_element) {
-                    return Fr::from_witness(&builder, native_element);
+                    auto element = Fr::from_witness(&builder, native_element);
+                    // Removing the free witness tag, since the element in the full scheme are supposed to
+                    // be fiat-shamirred earlier
+                    element.unset_free_witness_tag();
+                    return element;
                 });
             return elements_in_circuit;
         };
@@ -111,6 +119,9 @@ TEST(ShpleminiRecursionTest, ProveAndVerifySingle)
 
         for (auto u : u_challenge) {
             u_challenge_in_circuit.emplace_back(Fr::from_witness(&builder, u));
+            // Removing the free witness tag, since the u_challenge in the full scheme are supposed to
+            // be derived from the transcript earlier
+            u_challenge_in_circuit.back().unset_free_witness_tag();
         }
 
         ClaimBatcher claim_batcher{

--- a/barretenberg/cpp/src/barretenberg/commitment_schemes_recursion/shplonk.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes_recursion/shplonk.test.cpp
@@ -26,6 +26,11 @@ template <class Builder> class ShplonkRecursionTest : public CommitmentTest<type
             auto r = Fr::from_witness(builder, opening_claims[idx].opening_pair.challenge);
             auto eval = Fr::from_witness(builder, opening_claims[idx].opening_pair.evaluation);
             auto commit = Commitment::from_witness(builder, opening_claims[idx].commitment);
+            // Removing the free witness tag, since the opening claims in the full scheme are supposed to
+            // be fiat-shamirred or derived from the transcript earlier
+            r.unset_free_witness_tag();
+            eval.unset_free_witness_tag();
+            commit.unset_free_witness_tag();
             stdlib_opening_claims.emplace_back(OpeningClaim<Curve>({ r, eval }, commit));
         }
 
@@ -42,6 +47,11 @@ template <class Builder> class ShplonkRecursionTest : public CommitmentTest<type
             auto r = Fr::from_witness(builder, opening_claim.opening_pair.challenge);
             auto eval = Fr::from_witness(builder, opening_claim.opening_pair.evaluation);
             auto commit = Commitment::from_witness(builder, opening_claim.commitment);
+            // Removing the free witness tag, since the opening pairs and commitments in the full scheme are supposed to
+            // be fiat-shamirred or derived from the transcript earlier
+            r.unset_free_witness_tag();
+            eval.unset_free_witness_tag();
+            commit.unset_free_witness_tag();
             stdlib_opening_pairs.emplace_back(OpeningPair<Curve>(r, eval));
             stdlib_commitments.emplace_back(commit);
         }
@@ -95,7 +105,7 @@ TYPED_TEST(ShplonkRecursionTest, Simple)
     EXPECT_TRUE(CircuitChecker::check(builder));
 }
 
-TYPED_TEST(ShplonkRecursionTest, LineralyDependent)
+TYPED_TEST(ShplonkRecursionTest, LinearlyDependent)
 {
     using Builder = TypeParam;
     using Curve = stdlib::bn254<TypeParam>;
@@ -136,6 +146,10 @@ TYPED_TEST(ShplonkRecursionTest, LineralyDependent)
 
         auto coeff1 = Fr::from_witness(&builder, coefficients[0]);
         auto coeff2 = Fr::from_witness(&builder, coefficients[1]);
+        // Removing the free witness tag, since the coefficients in the full scheme are supposed to
+        // be fiat-shamirred or derived from the transcript earlier
+        coeff1.unset_free_witness_tag();
+        coeff2.unset_free_witness_tag();
 
         // Convert opening claims to witnesses
         auto stdlib_opening_claims =
@@ -148,6 +162,10 @@ TYPED_TEST(ShplonkRecursionTest, LineralyDependent)
         // Opening pair for the linear combination as it would be received by the Verifier from the Prover
         Fr r = Fr::from_witness(&builder, native_opening_claims[2].opening_pair.challenge);
         Fr eval = Fr::from_witness(&builder, native_opening_claims[2].opening_pair.evaluation);
+        // Removing the free witness tag, since the opening pairs in the full scheme are supposed to
+        // be fiat-shamirred or derived from the transcript earlier
+        r.unset_free_witness_tag();
+        eval.unset_free_witness_tag();
 
         // Opening claim for the linear combination
         stdlib_opening_claims.emplace_back(OpeningClaim({ r, eval }, commit));
@@ -176,6 +194,10 @@ TYPED_TEST(ShplonkRecursionTest, LineralyDependent)
 
         auto coeff1 = Fr::from_witness(&builder, coefficients[0]);
         auto coeff2 = Fr::from_witness(&builder, coefficients[1]);
+        // Removing the free witness tag, since the coefficients in the full scheme are supposed to
+        // be fiat-shamirred or derived from the transcript earlier
+        coeff1.unset_free_witness_tag();
+        coeff2.unset_free_witness_tag();
 
         // Convert opening claims to witnesses
         auto [stdlib_commitments, stdlib_opening_pairs] = this->native_to_stdlib_pairs_and_commitments(
@@ -184,6 +206,10 @@ TYPED_TEST(ShplonkRecursionTest, LineralyDependent)
         // Opening pair for the linear combination as it would be received by the Verifier from the Prover
         Fr r = Fr::from_witness(&builder, native_opening_claims[2].opening_pair.challenge);
         Fr eval = Fr::from_witness(&builder, native_opening_claims[2].opening_pair.evaluation);
+        // Removing the free witness tag, since the opening pairs in the full scheme are supposed to
+        // be fiat-shamirred or derived from the transcript earlier
+        r.unset_free_witness_tag();
+        eval.unset_free_witness_tag();
 
         // Update data
         std::vector<typename ShplonkVerifier::LinearCombinationOfClaims> update_data = {

--- a/barretenberg/cpp/src/barretenberg/stdlib/goblin_verifier/goblin_recursive_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/goblin_verifier/goblin_recursive_verifier.test.cpp
@@ -76,6 +76,10 @@ class GoblinRecursiveVerifierTests : public testing::Test {
                     RecursiveCommitment::from_witness(outer_builder, merge_commitments.t_commitments[idx]);
                 recursive_merge_commitments.T_prev_commitments[idx] =
                     RecursiveCommitment::from_witness(outer_builder, merge_commitments.T_prev_commitments[idx]);
+                // Removing the free witness tag, since the merge commitments in the full scheme are supposed to
+                // be fiat-shamirred earlier
+                recursive_merge_commitments.t_commitments[idx].unset_free_witness_tag();
+                recursive_merge_commitments.T_prev_commitments[idx].unset_free_witness_tag();
             }
         }
 
@@ -228,6 +232,8 @@ TEST_F(GoblinRecursiveVerifierTests, TranslatorFailure)
                 RecursiveCommitment::from_witness(&builder, merge_commitments.t_commitments[idx]);
             recursive_merge_commitments.T_prev_commitments[idx] =
                 RecursiveCommitment::from_witness(&builder, merge_commitments.T_prev_commitments[idx]);
+            recursive_merge_commitments.t_commitments[idx].fix_witness();
+            recursive_merge_commitments.T_prev_commitments[idx].fix_witness();
         }
 
         GoblinRecursiveVerifier verifier{ &builder, verifier_input };
@@ -255,6 +261,8 @@ TEST_F(GoblinRecursiveVerifierTests, TranslatorFailure)
                 RecursiveCommitment::from_witness(&builder, merge_commitments.t_commitments[idx]);
             recursive_merge_commitments.T_prev_commitments[idx] =
                 RecursiveCommitment::from_witness(&builder, merge_commitments.T_prev_commitments[idx]);
+            recursive_merge_commitments.t_commitments[idx].fix_witness();
+            recursive_merge_commitments.T_prev_commitments[idx].fix_witness();
         }
 
         GoblinRecursiveVerifier verifier{ &builder, verifier_input };

--- a/barretenberg/cpp/src/barretenberg/stdlib/merge_verifier/merge_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/merge_verifier/merge_verifier.test.cpp
@@ -99,6 +99,10 @@ template <class RecursiveBuilder> class RecursiveMergeVerifierTest : public test
                 RecursiveMergeVerifier::Commitment::from_witness(&outer_circuit, merge_commitments.t_commitments[idx]);
             recursive_merge_commitments.T_prev_commitments[idx] = RecursiveMergeVerifier::Commitment::from_witness(
                 &outer_circuit, merge_commitments.T_prev_commitments[idx]);
+            // Removing the free witness tag, since the merge commitments in the full scheme are supposed to
+            // be fiat-shamirred earlier
+            recursive_merge_commitments.t_commitments[idx].unset_free_witness_tag();
+            recursive_merge_commitments.T_prev_commitments[idx].unset_free_witness_tag();
         }
 
         // Create a recursive merge verification circuit for the merge proof

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.test.cpp
@@ -1367,7 +1367,7 @@ TYPED_TEST(stdlib_bigfield, reduce)
 {
     TestFixture::test_reduce();
 }
-TYPED_TEST(stdlib_bigfield, assert_is_in_field_succes)
+TYPED_TEST(stdlib_bigfield, assert_is_in_field_success)
 {
     TestFixture::test_assert_is_in_field_success();
 }

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
@@ -1857,6 +1857,10 @@ template <typename Builder, typename T> void bigfield<Builder, T>::assert_less_t
     bool_t<Builder> borrow_0(witness_t<Builder>(context, borrow_0_value));
     bool_t<Builder> borrow_1(witness_t<Builder>(context, borrow_1_value));
     bool_t<Builder> borrow_2(witness_t<Builder>(context, borrow_2_value));
+    // Unset free witness tag because these are auxiliary witnesses
+    borrow_0.unset_free_witness_tag();
+    borrow_1.unset_free_witness_tag();
+    borrow_2.unset_free_witness_tag();
 
     // The way we use borrows here ensures that we are checking that upper_limit - binary_basis > 0.
     // We check that the result in each limb is > 0.

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/field/field.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/field/field.cpp
@@ -930,7 +930,6 @@ template <typename Builder> void field_t<Builder>::assert_equal(const field_t& r
 {
     const field_t lhs = *this;
     Builder* ctx = validate_context(lhs.get_context(), rhs.get_context());
-    (void)OriginTag(get_origin_tag(), rhs.get_origin_tag());
     if (lhs.is_constant() && rhs.is_constant()) {
         BB_ASSERT_EQ(lhs.get_value(), rhs.get_value(), "field_t::assert_equal: constants are not equal");
         return;

--- a/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/protogalaxy_recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/protogalaxy_recursive_verifier.cpp
@@ -24,7 +24,7 @@ void ProtogalaxyRecursiveVerifier_<DeciderVerificationKeys>::run_oink_verifier_o
     if (!key->is_complete) {
         OinkRecursiveVerifier_<Flavor> oink_verifier{ builder, key, transcript, domain_separator + '_' };
         oink_verifier.verify();
-        key->target_sum = FF::from_witness(builder, builder->zero_idx);
+        key->target_sum = FF::from_witness_index(builder, builder->zero_idx);
         // Get the gate challenges for sumcheck/combiner computation
         key->gate_challenges =
             transcript->template get_powers_of_challenge<FF>(domain_separator + "_gate_challenge", CONST_PG_LOG_N);

--- a/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/protogalaxy_recursive_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/protogalaxy_recursive_verifier.test.cpp
@@ -209,21 +209,19 @@ class ProtogalaxyRecursiveTests : public testing::Test {
         auto recursive_vk_and_hash_2 = std::make_shared<RecursiveVKAndHash>(folding_circuit, decider_vk_2->vk);
         stdlib::Proof<OuterBuilder> stdlib_proof(folding_circuit, folding_proof.proof);
 
-        auto verifier = FoldingRecursiveVerifier{ &folding_circuit,
-                                                  recursive_decider_vk_1,
-                                                  { recursive_vk_and_hash_2 },
-                                                  std::make_shared<typename FoldingRecursiveVerifier::Transcript>() };
+        auto recursive_transcript = std::make_shared<typename FoldingRecursiveVerifier::Transcript>();
+        auto verifier = FoldingRecursiveVerifier{
+            &folding_circuit, recursive_decider_vk_1, { recursive_vk_and_hash_2 }, recursive_transcript
+        };
         std::shared_ptr<RecursiveDeciderVerificationKey> accumulator;
         for (size_t idx = 0; idx < num_verifiers; idx++) {
             verifier.transcript->enable_manifest();
             accumulator = verifier.verify_folding_proof(stdlib_proof);
             if (idx < num_verifiers - 1) { // else the transcript is null in the test below
                 auto recursive_vk_and_hash = std::make_shared<RecursiveVKAndHash>(folding_circuit, decider_vk_1->vk);
-                verifier =
-                    FoldingRecursiveVerifier{ &folding_circuit,
-                                              accumulator,
-                                              { recursive_vk_and_hash },
-                                              std::make_shared<typename FoldingRecursiveVerifier::Transcript>() };
+                verifier = FoldingRecursiveVerifier{
+                    &folding_circuit, accumulator, { recursive_vk_and_hash }, recursive_transcript
+                };
             }
         }
         info("Folding Recursive Verifier: num gates unfinalized = ", folding_circuit.num_gates);
@@ -231,16 +229,15 @@ class ProtogalaxyRecursiveTests : public testing::Test {
 
         // Perform native folding verification and ensure it returns the same result (either true or false) as
         // calling check_circuit on the recursive folding verifier
-        InnerFoldingVerifier native_folding_verifier({ decider_vk_1, decider_vk_2 },
-                                                     std::make_shared<typename InnerFoldingVerifier::Transcript>());
+        auto native_transcript = std::make_shared<typename InnerFoldingVerifier::Transcript>();
+        InnerFoldingVerifier native_folding_verifier({ decider_vk_1, decider_vk_2 }, native_transcript);
         native_folding_verifier.transcript->enable_manifest();
         std::shared_ptr<InnerDeciderVerificationKey> native_accumulator;
         for (size_t idx = 0; idx < num_verifiers; idx++) {
             native_accumulator = native_folding_verifier.verify_folding_proof(folding_proof.proof);
             if (idx < num_verifiers - 1) { // else the transcript is null in the test below
                 native_folding_verifier =
-                    InnerFoldingVerifier{ { native_accumulator, decider_vk_1 },
-                                          std::make_shared<typename InnerFoldingVerifier::Transcript>() };
+                    InnerFoldingVerifier{ { native_accumulator, decider_vk_1 }, native_transcript };
                 native_folding_verifier.transcript->enable_manifest();
             }
         }
@@ -339,12 +336,25 @@ class ProtogalaxyRecursiveTests : public testing::Test {
                 << "Recursive Verifier/Verifier manifest discrepency in round " << i;
         }
 
-        InnerDeciderProver decider_prover(folding_proof.accumulator);
+        // Manually hashing the accumulator to ensure it gets a proper origin tag
+        auto native_decider_transcript = std::make_shared<typename InnerFlavor::Transcript>();
+        auto native_accum_hash = verifier_accumulator->hash_through_transcript("", *native_decider_transcript);
+        native_decider_transcript->add_to_hash_buffer("accum_hash", native_accum_hash);
+
+        InnerDeciderProver decider_prover(folding_proof.accumulator, native_decider_transcript);
         decider_prover.construct_proof();
         auto decider_proof = decider_prover.export_proof();
 
         OuterBuilder decider_circuit;
-        DeciderRecursiveVerifier decider_verifier{ &decider_circuit, native_verifier_acc };
+
+        auto stdlib_verifier_acc =
+            std::make_shared<RecursiveDeciderVerificationKey>(&decider_circuit, native_verifier_acc);
+        auto stdlib_verifier_transcript = std::make_shared<typename RecursiveFlavor::Transcript>();
+        auto stdlib_accum_hash = stdlib_verifier_acc->hash_through_transcript("", *stdlib_verifier_transcript);
+
+        // Manually hashing the accumulator to ensure it gets a proper origin tag
+        stdlib_verifier_transcript->add_to_hash_buffer("accum_hash", stdlib_accum_hash);
+        DeciderRecursiveVerifier decider_verifier{ &decider_circuit, stdlib_verifier_acc, stdlib_verifier_transcript };
         auto pairing_points = decider_verifier.verify_proof(decider_proof);
 
         // IO
@@ -358,7 +368,9 @@ class ProtogalaxyRecursiveTests : public testing::Test {
 
         // Perform native verification then perform the pairing on the outputs of the recursive decider verifier and
         // check that the result agrees.
-        InnerDeciderVerifier native_decider_verifier(verifier_accumulator);
+        auto native_decider_verifier_transcript = std::make_shared<typename InnerFlavor::Transcript>();
+        native_decider_verifier_transcript->add_to_hash_buffer("accum_hash", native_accum_hash);
+        InnerDeciderVerifier native_decider_verifier(verifier_accumulator, native_decider_verifier_transcript);
         auto native_decider_output = native_decider_verifier.verify_proof(decider_proof);
         auto native_result = native_decider_output.check();
         NativeVerifierCommitmentKey pcs_vkey{};
@@ -386,13 +398,24 @@ class ProtogalaxyRecursiveTests : public testing::Test {
         verifier_accumulator->target_sum = FF::random_element(&engine);
 
         // Create a decider proof for accumulator obtained through folding
-        InnerDeciderProver decider_prover(prover_accumulator);
+        auto decider_prover_transcript = std::make_shared<typename InnerFlavor::Transcript>();
+        auto accum_hash = verifier_accumulator->hash_through_transcript("", *decider_prover_transcript);
+        decider_prover_transcript->add_to_hash_buffer("accum_hash", accum_hash);
+        InnerDeciderProver decider_prover(prover_accumulator, decider_prover_transcript);
         decider_prover.construct_proof();
         auto decider_proof = decider_prover.export_proof();
 
         // Create a decider verifier circuit for recursively verifying the decider proof
         OuterBuilder decider_circuit;
-        DeciderRecursiveVerifier decider_verifier{ &decider_circuit, verifier_accumulator };
+        auto stdlib_verifier_accumulator =
+            std::make_shared<RecursiveDeciderVerificationKey>(&decider_circuit, verifier_accumulator);
+        auto stdlib_decider_verifier_transcript = std::make_shared<typename RecursiveFlavor::Transcript>();
+        auto stdlib_verifier_accum_hash =
+            stdlib_verifier_accumulator->hash_through_transcript("", *stdlib_decider_verifier_transcript);
+        stdlib_decider_verifier_transcript->add_to_hash_buffer("accum_hash", stdlib_verifier_accum_hash);
+        DeciderRecursiveVerifier decider_verifier{ &decider_circuit,
+                                                   stdlib_verifier_accumulator,
+                                                   stdlib_decider_verifier_transcript };
         [[maybe_unused]] auto output = decider_verifier.verify_proof(decider_proof);
         info("Decider Recursive Verifier: num gates = ", decider_circuit.num_gates);
 
@@ -417,9 +440,11 @@ class ProtogalaxyRecursiveTests : public testing::Test {
 
         // Generate a folding proof with the incorrect polynomials which would result in the prover having the wrong
         // target sum
-        InnerFoldingProver folding_prover({ prover_accumulator, prover_inst },
-                                          { verifier_accumulator, verifier_inst },
-                                          std::make_shared<typename InnerFoldingProver::Transcript>());
+        auto folding_prover_transcript = std::make_shared<typename InnerFoldingProver::Transcript>();
+        folding_prover_transcript->add_to_hash_buffer(
+            "accum_hash", verifier_accumulator->hash_through_transcript("", *folding_prover_transcript));
+        InnerFoldingProver folding_prover(
+            { prover_accumulator, prover_inst }, { verifier_accumulator, verifier_inst }, folding_prover_transcript);
         auto folding_proof = folding_prover.prove();
 
         // Create a folding verifier circuit
@@ -430,10 +455,13 @@ class ProtogalaxyRecursiveTests : public testing::Test {
         auto recursive_vk_and_hash_2 = std::make_shared<RecursiveVKAndHash>(folding_circuit, verifier_inst->vk);
         stdlib::Proof<OuterBuilder> stdlib_proof(folding_circuit, folding_proof.proof);
 
-        auto verifier = FoldingRecursiveVerifier{ &folding_circuit,
-                                                  recursive_decider_vk_1,
-                                                  { recursive_vk_and_hash_2 },
-                                                  std::make_shared<typename FoldingRecursiveVerifier::Transcript>() };
+        auto stdlib_folding_verifier_transcript = std::make_shared<typename FoldingRecursiveVerifier::Transcript>();
+        stdlib_folding_verifier_transcript->add_to_hash_buffer(
+            "accum_hash", recursive_decider_vk_1->hash_through_transcript("", *stdlib_folding_verifier_transcript));
+
+        auto verifier = FoldingRecursiveVerifier{
+            &folding_circuit, recursive_decider_vk_1, { recursive_vk_and_hash_2 }, stdlib_folding_verifier_transcript
+        };
         auto recursive_verifier_acc = verifier.verify_folding_proof(stdlib_proof);
 
         // Validate that the target sum between prover and verifier is now different

--- a/barretenberg/cpp/src/barretenberg/stdlib/translator_vm_verifier/translator_recursive_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/translator_vm_verifier/translator_recursive_verifier.test.cpp
@@ -172,10 +172,13 @@ class TranslatorRecursiveTests : public ::testing::Test {
             [[maybe_unused]] auto _ = transcript->template receive_from_prover<typename RecursiveFlavor::BF>("init");
 
             RecursiveVerifier verifier{ &outer_circuit, verification_key, transcript };
+            // Manually hashing the evaluation and batching challenges to ensure they get a proper origin tag
+            auto stdlib_evaluation_challenge_x = TranslatorBF::from_witness(&outer_circuit, evaluation_challenge_x);
+            auto stdlib_batching_challenge_v = TranslatorBF::from_witness(&outer_circuit, batching_challenge_v);
+            transcript->add_to_hash_buffer("evaluation_challenge_x", stdlib_evaluation_challenge_x);
+            transcript->add_to_hash_buffer("batching_challenge_v", stdlib_batching_challenge_v);
             typename RecursiveVerifier::PairingPoints pairing_points =
-                verifier.verify_proof(inner_proof,
-                                      TranslatorBF::from_witness(&outer_circuit, evaluation_challenge_x),
-                                      TranslatorBF::from_witness(&outer_circuit, batching_challenge_v));
+                verifier.verify_proof(inner_proof, stdlib_evaluation_challenge_x, stdlib_batching_challenge_v);
             pairing_points.set_public();
 
             auto outer_proving_key = std::make_shared<OuterDeciderProvingKey>(outer_circuit);

--- a/barretenberg/cpp/src/barretenberg/transcript/origin_tag.hpp
+++ b/barretenberg/cpp/src/barretenberg/transcript/origin_tag.hpp
@@ -20,9 +20,7 @@
 #include <ostream>
 
 // Currently disabled, because there are violations of the tag invariant in the codebase everywhere.
-// TODO(https://github.com/AztecProtocol/barretenberg/issues/1409): Re-enable this once the tag invariant is restored.
-#define DISABLE_FREE_WITNESS_CHECK
-#define DISABLE_DIFFERENT_TRANSCRIPT_CHECKS
+// TODO(https://github.com/AztecProtocol/barretenberg/issues/1532): Re-enable this once we resolve these issues.
 #define DISABLE_CHILD_TAG_CHECKS
 
 // Disable origin tags in release builds

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/prover.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/prover.hpp
@@ -31,6 +31,7 @@ class AvmProver {
     // Note: all the following methods are virtual to allow Avm2 to tweak the behaviour.
     // We can remove this once the transition is done.
     virtual void execute_preamble_round();
+    virtual void execute_public_inputs_round();
     virtual void execute_wire_commitments_round();
     virtual void execute_log_derivative_inverse_round();
     virtual void execute_log_derivative_inverse_commitments_round();

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/recursion/recursive_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/recursion/recursive_verifier.test.cpp
@@ -41,12 +41,13 @@ class AvmRecursiveTests : public ::testing::Test {
     {
         auto [trace, public_inputs] = testing::get_minimal_trace_with_pi();
 
+        const auto public_inputs_cols = public_inputs.to_columns();
+
         InnerProver prover;
         const auto [proof, vk_data] = prover.prove(std::move(trace));
         const auto verification_key = InnerProver::create_verification_key(vk_data);
         InnerVerifier verifier(verification_key);
 
-        const auto public_inputs_cols = public_inputs.to_columns();
         const bool verified = verifier.verify_proof(proof, public_inputs_cols);
 
         // Should be in principle ASSERT_TRUE, but compiler does not like it.

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/verifier.test.cpp
@@ -29,10 +29,10 @@ class AvmVerifierTests : public ::testing::Test {
         auto [trace, public_inputs] = testing::get_minimal_trace_with_pi();
 
         Prover prover;
+        auto public_inputs_cols = public_inputs.to_columns();
         const auto [proof, vk_data] = prover.prove(std::move(trace));
         const auto verification_key = prover.create_verification_key(vk_data);
 
-        auto public_inputs_cols = public_inputs.to_columns();
         return { proof, verification_key, public_inputs_cols };
     }
 };


### PR DESCRIPTION
Closes https://github.com/AztecProtocol/barretenberg/issues/1409 and also enables the different transcript check.

We want to enable the origin tag checks, but many tests do things that lead to them failing. This PR is an attempt to find real bugs in our code and also resolve false positives.

So far, I've found three real bugs:
- incorrect transcript_index resulting from branch_transcript()
- not sharing the transcript between PG and Decider in the hiding kernel (fixed in https://github.com/AztecProtocol/aztec-packages/pull/16642)
- calling from_witness with builder->zero_idx instead of from_witness_index (my bad, oops!)

@Rumata888 :
Once enabled to run with AVM, it also found:
1. VK is not being hashed  (intended in the future, but it is not fixed, so had to manually disable the check there)
2. There is a special boolean that allow AVM to disregard Public Inputs on recursive verification (temporary, while we get it to work, so had to disable the check and create issues)
3. Public inputs verification via multilinear polynomial evaluation is insecure (public inputs are not in fiat shamir). Fixed