### PR TITLE
feat!: share transcript between pg and decider

### DIFF
--- a/barretenberg/cpp/scripts/test_civc_standalone_vks_havent_changed.sh
+++ b/barretenberg/cpp/scripts/test_civc_standalone_vks_havent_changed.sh
@@ -11,7 +11,7 @@ cd ..
 # - Generate a hash for versioning: sha256sum bb-civc-inputs.tar.gz
 # - Upload the compressed results: aws s3 cp bb-civc-inputs.tar.gz s3://aztec-ci-artifacts/protocol/bb-civc-inputs-[hash(0:8)].tar.gz
 # Note: In case of the "Test suite failed to run ... Unexpected token 'with' " error, need to run: docker pull aztecprotocol/build:3.0
-pinned_short_hash="d1e22fdb"
+pinned_short_hash="f22d116f"
 pinned_civc_inputs_url="https://aztec-ci-artifacts.s3.us-east-2.amazonaws.com/protocol/bb-civc-inputs-${pinned_short_hash}.tar.gz"
 
 function compress_and_upload {

--- a/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.cpp
+++ b/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.cpp
@@ -205,7 +205,7 @@ ClientIVC::perform_recursive_verification_and_databus_consistency_checks(
                                                                             prev_accum_hash,
                                                                             verifier_inputs.is_kernel);
         // Perform recursive decider verification
-        DeciderRecursiveVerifier decider{ &circuit, final_verifier_accumulator };
+        DeciderRecursiveVerifier decider{ &circuit, final_verifier_accumulator, accumulation_recursive_transcript };
         decider_pairing_points = decider.verify_proof(decider_proof);
 
         BB_ASSERT_EQ(output_verifier_accumulator, nullptr);
@@ -496,7 +496,7 @@ void ClientIVC::accumulate(ClientCircuit& circuit, const std::shared_ptr<MegaVer
         break;
     case QUEUE_TYPE::PG_FINAL:
         proof = construct_pg_proof(proving_key, honk_vk, prover_accumulation_transcript, is_kernel);
-        decider_proof = construct_decider_proof();
+        decider_proof = construct_decider_proof(prover_accumulation_transcript);
         break;
     case QUEUE_TYPE::MEGA:
         proof = construct_mega_proof_for_hiding_kernel(circuit);
@@ -614,11 +614,11 @@ bool ClientIVC::verify(const Proof& proof) const
  *
  * @return HonkProof
  */
-HonkProof ClientIVC::construct_decider_proof()
+HonkProof ClientIVC::construct_decider_proof(const std::shared_ptr<Transcript>& transcript)
 {
     vinfo("prove decider...");
     fold_output.accumulator->commitment_key = bn254_commitment_key;
-    MegaDeciderProver decider_prover(fold_output.accumulator);
+    MegaDeciderProver decider_prover(fold_output.accumulator, transcript);
     decider_prover.construct_proof();
     return decider_prover.export_proof();
 }

--- a/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.hpp
+++ b/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.hpp
@@ -279,7 +279,7 @@ class ClientIVC {
 
     bool prove_and_verify();
 
-    HonkProof construct_decider_proof();
+    HonkProof construct_decider_proof(const std::shared_ptr<Transcript>& transcript);
 
     VerificationKey get_vk() const;
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/decider_recursive_verifier.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/decider_recursive_verifier.hpp
@@ -42,8 +42,11 @@ template <typename Flavor> class DeciderRecursiveVerifier_ {
      * @param builder
      * @param accumulator
      */
-    explicit DeciderRecursiveVerifier_(Builder* builder, std::shared_ptr<RecursiveDeciderVK> accumulator)
+    explicit DeciderRecursiveVerifier_(Builder* builder,
+                                       std::shared_ptr<RecursiveDeciderVK> accumulator,
+                                       const std::shared_ptr<Transcript>& transcript)
         : builder(builder)
+        , transcript(transcript)
     {
         if (this->builder == accumulator->builder) {
             this->accumulator = std::move(accumulator);


### PR DESCRIPTION
Closes https://github.com/AztecProtocol/barretenberg/issues/1453.

Shares the transcript between PG/Merge and the Decider protocols for hiding kernel soundness. We want to make sure that we can't pick the accumulator that the Decider runs on without affecting the challenges in the Decider. This mitigates an origin tag check failure as we had values from two different transcripts interacting in Decider.