### PR TITLE
chore: update AztecBot's email address when squashing

### DIFF
--- a/scripts/merge-train/squash-pr.sh
+++ b/scripts/merge-train/squash-pr.sh
@@ -23,7 +23,7 @@ is_fork=$(echo "$pr_info" | jq -r '.isCrossRepository')
 
 # We'll use AztecBot as the committer
 author_name="AztecBot"
-author_email="tech@aztecprotocol.com"
+author_email="49558828+AztecBot@users.noreply.github.com"
 
 # Create a temporary worktree to do the squashing
 worktree_dir=$(mktemp -d)


### PR DESCRIPTION
Fix to link commits to AztecBot

<img width="304" height="48" alt="image" src="https://github.com/user-attachments/assets/8234b944-2c58-492d-80db-06fd6a3f0df6" />
