### PR TITLE
chore: add workflow to create canary release

### DIFF
--- a/.github/workflows/canary-release-tag.yml
+++ b/.github/workflows/canary-release-tag.yml
@@ -1,0 +1,43 @@
+name: Canary Release Tag
+
+on:
+  workflow_dispatch:
+
+# Add permissions for the GitHub Actions bot to push tags
+permissions:
+  contents: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  nightly-release-tag:
+    runs-on: ubuntu-latest
+    steps:
+      # Check out the repository so we can read files and create tags.
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          token: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
+
+      # Extract the current release version from the manifest.
+      # Then, create a canary tag using the current version and the current UTC date.
+      - name: Create Canary Tag
+        run: |
+          git config --global user.email "tech@aztecprotocol.com"
+          git config --global user.name "AztecBot"
+          current_version=$(jq -r '."."' .release-please-manifest.json)
+          # Compute the next major version. e.g. if current version is 1.2.3, next major version is 2.0.0.
+          if [[ "$current_version" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+            major=$(( ${BASH_REMATCH[1]} + 1 ))
+            next_major_version="${major}.0.0"
+          else
+            echo "Error: Current version format is invalid: $current_version"
+            exit 1
+          fi
+          echo "Current version: $current_version"
+          echo "Next version: $next_major_version"
+          canary_tag="v${next_major_version}-canary.$(git rev-parse --short HEAD)"
+          echo "Canary tag: $canary_tag"
+          # Tag and push.
+          git tag -a "$canary_tag" -m "$canary_tag"
+          git push origin "$canary_tag"


### PR DESCRIPTION
This PR adds a new workflow to create canary releases from the HEAD of next. The release use the commit's short-SHA to ensure uniqueness

Close TMNT-164