### PR TITLE
feat!: merge the txe session state transition oracles, redo the internal wiring, introduce context handlers

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
@@ -149,13 +149,11 @@ impl TestEnvironment {
         _self: Self,
         f: fn[Env](&mut PublicContext) -> T,
     ) -> T {
-        txe_oracles::set_public_txe_context();
+        txe_oracles::set_public_txe_context(Option::none());
 
         let mut context = PublicContext::new(|| 0);
         let ret_value = f(&mut context);
 
-        // merge calls below into 'exit public txe context' -> this mines a block
-        txe_oracles::advance_blocks_by(1);
         txe_oracles::set_top_level_txe_context();
 
         ret_value
@@ -164,17 +162,18 @@ impl TestEnvironment {
     /// Variant of `public_context` which allows specifying the contract address in which the public context will
     /// execute, which will affect note and nullifier siloing, storage access, etc.
     pub unconstrained fn public_context_at<Env, T>(
-        self,
+        _self: Self,
         addr: AztecAddress,
         f: fn[Env](&mut PublicContext) -> T,
     ) -> T {
-        // temporary hack until we reimplement the public context oracle and have it take this as a param
-        let pre = txe_oracles::get_contract_address();
-        txe_oracles::set_contract_address(addr);
-        let ret = self.public_context(f);
-        txe_oracles::set_contract_address(pre);
+        txe_oracles::set_public_txe_context(Option::some(addr));
 
-        ret
+        let mut context = PublicContext::new(|| 0);
+        let ret_value = f(&mut context);
+
+        txe_oracles::set_top_level_txe_context();
+
+        ret_value
     }
 
     /// Creates a `PrivateContext`, which allows using aztec-nr features as if inside a private contract function.
@@ -210,22 +209,18 @@ impl TestEnvironment {
     ///   state_var.get_note()
     /// });
     /// ```
-    pub unconstrained fn private_context<Env, T>(self, f: fn[Env](&mut PrivateContext) -> T) -> T {
-        // merge the two oracles below - the creation of a context implies a transition to a private txe context. right
-        // now we have them in this order because creating the private context requires reading the latest block number,
-        // which we only allow for top level and utility
+    pub unconstrained fn private_context<Env, T>(
+        _self: Self,
+        f: fn[Env](&mut PrivateContext) -> T,
+    ) -> T {
         let mut context = PrivateContext::new(
-            txe_oracles::get_private_context_inputs(Option::some(self.last_block_number())),
+            txe_oracles::set_private_txe_context(Option::none(), Option::none()),
             0,
         );
-        txe_oracles::set_private_txe_context();
 
         let ret_value = f(&mut context);
-        txe_oracles::set_top_level_txe_context();
 
-        // todo: should commit the context to mine a block with the side effects of the context. we should have an
-        // oracle that receives the context we produced probably
-        self.mine_block();
+        txe_oracles::set_top_level_txe_context();
 
         ret_value
     }
@@ -233,53 +228,39 @@ impl TestEnvironment {
     /// Variant of `private_context` which allows specifying the contract address in which the private context will
     /// execute, which will affect note and nullifier siloing, storage access, etc.
     pub unconstrained fn private_context_at<Env, T>(
-        self,
+        _self: Self,
         addr: AztecAddress,
         f: fn[Env](&mut PrivateContext) -> T,
     ) -> T {
-        // temporary hack until we reimplement the public context oracle and have it take this as a param
-        let pre = txe_oracles::get_contract_address();
-        txe_oracles::set_contract_address(addr);
-        let ret = self.private_context(f);
-        txe_oracles::set_contract_address(pre);
+        let mut context = PrivateContext::new(
+            txe_oracles::set_private_txe_context(Option::some(addr), Option::none()),
+            0,
+        );
 
-        ret
+        let ret_value = f(&mut context);
+
+        txe_oracles::set_top_level_txe_context();
+
+        ret_value
     }
 
     /// Variant of `private_context` which allows specifying multiple configuration values via `PrivateContextOptions`.
     pub unconstrained fn private_context_opts<Env, T>(
-        self,
+        _self: Self,
         opts: PrivateContextOptions,
         f: fn[Env](&mut PrivateContext) -> T,
     ) -> T {
-        // temporary hack until we reimplement the public context oracle and have it take this as a param
-
-        let pre_contract_address = txe_oracles::get_contract_address();
-
-        if opts.contract_address.is_some() {
-            txe_oracles::set_contract_address(opts.contract_address.unwrap());
-        }
-
-        // merge the two oracles below - the creation of a context implies a transition to a private txe context. right
-        // now we have them in this order because creating the private context requires reading the latest block number,
-        // which we only allow for top level and utility
         let mut context = PrivateContext::new(
-            txe_oracles::get_private_context_inputs(opts.historical_block_number.or_else(|| {
-                Option::some(self.last_block_number())
-            })),
+            txe_oracles::set_private_txe_context(
+                opts.contract_address,
+                opts.historical_block_number,
+            ),
             0,
         );
 
-        txe_oracles::set_private_txe_context();
-
         let ret_value = f(&mut context);
+
         txe_oracles::set_top_level_txe_context();
-
-        // todo: should commit the context to mine a block with the side effects of the context. we should have an
-        // oracle that receives the context we produced probably
-        self.mine_block();
-
-        txe_oracles::set_contract_address(pre_contract_address);
 
         ret_value
     }
@@ -314,7 +295,7 @@ impl TestEnvironment {
         _self: Self,
         f: fn[Env](UtilityContext) -> T,
     ) -> T {
-        txe_oracles::set_utility_txe_context();
+        txe_oracles::set_utility_txe_context(Option::none());
         let context = UtilityContext::new();
         let ret_value = f(context);
         txe_oracles::set_top_level_txe_context();
@@ -325,17 +306,16 @@ impl TestEnvironment {
     /// Variant of `utility_context` which allows specifying the contract address in which the utility context will
     /// execute, which will affect note and storage access.
     pub unconstrained fn utility_context_at<Env, T>(
-        self,
+        _self: Self,
         addr: AztecAddress,
         f: fn[Env](UtilityContext) -> T,
     ) -> T {
-        // temporary hack until we reimplement the utility context oracle and have it take this as a param
-        let pre = txe_oracles::get_contract_address();
-        txe_oracles::set_contract_address(addr);
-        let ret = self.utility_context(f);
-        txe_oracles::set_contract_address(pre);
+        txe_oracles::set_utility_txe_context(Option::some(addr));
+        let context = UtilityContext::new();
+        let ret_value = f(context);
+        txe_oracles::set_top_level_txe_context();
 
-        ret
+        ret_value
     }
 
     /// Returns the number of the next block to be mined.

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/txe_oracles.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/txe_oracles.nr
@@ -65,22 +65,11 @@ pub unconstrained fn public_call_new_flow(
 #[oracle(txeGetLastBlockTimestamp)]
 pub unconstrained fn get_last_block_timestamp() -> u64 {}
 
-#[oracle(txeSetContractAddress)]
-pub unconstrained fn set_contract_address(address: AztecAddress) {}
-
-#[oracle(utilityGetContractAddress)]
-pub unconstrained fn get_contract_address() -> AztecAddress {}
-
 #[oracle(txeAdvanceBlocksBy)]
 pub unconstrained fn advance_blocks_by(blocks: u32) {}
 
 #[oracle(txeAdvanceTimestampBy)]
 pub unconstrained fn advance_timestamp_by(duration: u64) {}
-
-#[oracle(txeGetPrivateContextInputs)]
-pub unconstrained fn get_private_context_inputs(
-    historical_block_number: Option<u32>,
-) -> PrivateContextInputs {}
 
 #[oracle(txeDeploy)]
 pub unconstrained fn deploy_oracle<let N: u32, let P: u32>(
@@ -121,10 +110,13 @@ unconstrained fn public_call_new_flow_oracle(
 pub unconstrained fn set_top_level_txe_context() {}
 
 #[oracle(txeSetPrivateTXEContext)]
-pub unconstrained fn set_private_txe_context() {}
+pub unconstrained fn set_private_txe_context(
+    contract_address: Option<AztecAddress>,
+    historical_block_number: Option<u32>,
+) -> PrivateContextInputs {}
 
 #[oracle(txeSetPublicTXEContext)]
-pub unconstrained fn set_public_txe_context() {}
+pub unconstrained fn set_public_txe_context(contract_address: Option<AztecAddress>) {}
 
 #[oracle(txeSetUtilityTXEContext)]
-pub unconstrained fn set_utility_txe_context() {}
+pub unconstrained fn set_utility_txe_context(contract_address: Option<AztecAddress>) {}

--- a/noir-projects/aztec-nr/aztec/src/utils/with_hash.nr
+++ b/noir-projects/aztec-nr/aztec/src/utils/with_hash.nr
@@ -120,7 +120,6 @@ where
 
 mod test {
     use crate::{
-        oracle::random::random,
         test::{helpers::test_environment::TestEnvironment, mocks::mock_struct::MockStruct},
         utils::with_hash::WithHash,
     };
@@ -211,7 +210,7 @@ mod test {
             let value = MockStruct { a: 5, b: 3 };
             context.storage_write(STORAGE_SLOT, value);
 
-            let incorrect_hash = random();
+            let incorrect_hash = 13;
             let hash_storage_slot = STORAGE_SLOT + (value.pack().len() as Field);
             context.storage_write(hash_storage_slot, [incorrect_hash]);
         });

--- a/yarn-project/txe/src/index.ts
+++ b/yarn-project/txe/src/index.ts
@@ -55,6 +55,7 @@ type TXEForeignCallInput = {
   inputs: ForeignCallArgs;
 };
 
+// TODO: why does the zod validation in the txe dispatcher not reject invalid function names?
 const TXEForeignCallInputSchema = z.object({
   // eslint-disable-next-line camelcase
   session_id: z.number().int().nonnegative(),

--- a/yarn-project/txe/src/oracle/txe_oracle.ts
+++ b/yarn-project/txe/src/oracle/txe_oracle.ts
@@ -59,7 +59,6 @@ import {
   countArgumentsSize,
 } from '@aztec/stdlib/abi';
 import { AuthWitness } from '@aztec/stdlib/auth-witness';
-import { PublicDataWrite } from '@aztec/stdlib/avm';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import { type ContractInstance, type ContractInstanceWithAddress, computePartialAddress } from '@aztec/stdlib/contract';
 import { Gas, GasFees, GasSettings } from '@aztec/stdlib/gas';
@@ -81,7 +80,7 @@ import {
   PrivateToPublicAccumulatedData,
   PublicCallRequest,
 } from '@aztec/stdlib/kernel';
-import { ContractClassLog, IndexedTaggingSecret, PrivateLog, type PublicLog } from '@aztec/stdlib/logs';
+import { ContractClassLog, IndexedTaggingSecret, PrivateLog } from '@aztec/stdlib/logs';
 import type { NoteStatus } from '@aztec/stdlib/note';
 import { ClientIvcProof } from '@aztec/stdlib/proofs';
 import {
@@ -94,7 +93,6 @@ import {
   AppendOnlyTreeSnapshot,
   MerkleTreeId,
   NullifierMembershipWitness,
-  PublicDataTreeLeaf,
   type PublicDataTreeLeafPreimage,
   PublicDataWitness,
 } from '@aztec/stdlib/trees';
@@ -133,11 +131,7 @@ export class TXE extends TXETypedOracle {
 
   private pxeOracleInterface: PXEOracleInterface;
 
-  private publicDataWrites: PublicDataWrite[] = [];
-  private uniqueNoteHashesFromPublic: Fr[] = [];
-  private siloedNullifiersFromPublic: Fr[] = [];
   private privateLogs: PrivateLog[] = [];
-  private publicLogs: PublicLog[] = [];
 
   private committedBlocks = new Set<number>();
 
@@ -167,7 +161,7 @@ export class TXE extends TXETypedOracle {
     private privateEventDataProvider: PrivateEventDataProvider,
     private accountDataProvider: TXEAccountDataProvider,
     private contractAddress: AztecAddress,
-    private baseFork: MerkleTreeWriteOperations,
+    public baseFork: MerkleTreeWriteOperations,
     private stateMachine: TXEStateMachine,
   ) {
     super();
@@ -312,7 +306,7 @@ export class TXE extends TXETypedOracle {
   }
 
   override async txeGetPrivateContextInputs(
-    blockNumber: number | null,
+    blockNumber?: number,
     sideEffectsCounter = this.sideEffectCounter,
     isStaticCall = false,
   ) {
@@ -351,15 +345,6 @@ export class TXE extends TXETypedOracle {
     this.authwits.set(authWitness.requestHash.toString(), authWitness);
   }
 
-  async addPublicDataWrites(writes: PublicDataWrite[]) {
-    this.publicDataWrites.push(...writes);
-
-    await this.baseFork.sequentialInsert(
-      MerkleTreeId.PUBLIC_DATA_TREE,
-      writes.map(w => new PublicDataTreeLeaf(w.leafSlot, w.value).toBuffer()),
-    );
-  }
-
   async checkNullifiersNotInTree(contractAddress: AztecAddress, nullifiers: Fr[]) {
     const siloedNullifiers = await Promise.all(nullifiers.map(nullifier => siloNullifier(contractAddress, nullifier)));
     const db = this.baseFork;
@@ -370,14 +355,6 @@ export class TXE extends TXETypedOracle {
     if (nullifierIndexesInTree.some(index => index !== undefined)) {
       throw new Error(`Rejecting tx for emitting duplicate nullifiers`);
     }
-  }
-
-  addSiloedNullifiersFromPublic(siloedNullifiers: Fr[]) {
-    this.siloedNullifiersFromPublic.push(...siloedNullifiers);
-  }
-
-  addUniqueNoteHashesFromPublic(siloedNoteHashes: Fr[]) {
-    this.uniqueNoteHashesFromPublic.push(...siloedNoteHashes);
   }
 
   // TypedOracle
@@ -608,19 +585,6 @@ export class TXE extends TXETypedOracle {
     return values;
   }
 
-  override async storageWrite(startStorageSlot: Fr, values: Fr[]): Promise<Fr[]> {
-    const publicDataWrites = await Promise.all(
-      values.map(async (value, i) => {
-        const storageSlot = startStorageSlot.add(new Fr(i));
-        this.logger.debug(`Oracle storage write: slot=${storageSlot.toString()} value=${value}`);
-        return new PublicDataWrite(await computePublicDataTreeLeafSlot(this.contractAddress, storageSlot), value);
-      }),
-    );
-
-    await this.addPublicDataWrites(publicDataWrites);
-    return publicDataWrites.map(write => write.value);
-  }
-
   async commitState() {
     const blockNumber = await this.utilityGetBlockNumber();
     const { usedTxRequestHashForNonces } = this.noteCache.finish();
@@ -647,17 +611,14 @@ export class TXE extends TXETypedOracle {
           ),
         ),
     );
-    txEffect.noteHashes = [...uniqueNoteHashesFromPrivate, ...this.uniqueNoteHashesFromPublic];
-
-    txEffect.nullifiers = [...this.siloedNullifiersFromPublic, ...this.noteCache.getAllNullifiers()];
+    txEffect.noteHashes = uniqueNoteHashesFromPrivate;
+    txEffect.nullifiers = this.noteCache.getAllNullifiers();
 
     if (usedTxRequestHashForNonces) {
       txEffect.nullifiers.unshift(this.getTxRequestHash());
     }
 
-    txEffect.publicDataWrites = this.publicDataWrites;
     txEffect.privateLogs = this.privateLogs;
-    txEffect.publicLogs = this.publicLogs;
     txEffect.txHash = new TxHash(new Fr(blockNumber));
 
     const body = new Body([txEffect]);
@@ -722,11 +683,7 @@ export class TXE extends TXETypedOracle {
 
     await this.stateMachine.handleL2Block(l2Block);
 
-    this.publicDataWrites = [];
     this.privateLogs = [];
-    this.publicLogs = [];
-    this.uniqueNoteHashesFromPublic = [];
-    this.siloedNullifiersFromPublic = [];
     this.noteCache = new ExecutionNoteCache(this.getTxRequestHash());
   }
 
@@ -875,46 +832,6 @@ export class TXE extends TXETypedOracle {
       logRetrievalRequestsArrayBaseSlot,
       logRetrievalResponsesArrayBaseSlot,
     );
-  }
-
-  override async avmOpcodeNullifierExists(innerNullifier: Fr, targetAddress: AztecAddress): Promise<boolean> {
-    const nullifier = await siloNullifier(targetAddress, innerNullifier!);
-    const db = this.baseFork;
-
-    const treeIndex = (await db.findLeafIndices(MerkleTreeId.NULLIFIER_TREE, [nullifier.toBuffer()]))[0];
-    const transientIndex = this.siloedNullifiersFromPublic.find(n => n.equals(nullifier));
-
-    return treeIndex !== undefined || transientIndex !== undefined;
-  }
-
-  override async avmOpcodeEmitNullifier(nullifier: Fr) {
-    const siloedNullifier = await siloNullifier(this.contractAddress, nullifier);
-    this.addSiloedNullifiersFromPublic([siloedNullifier]);
-
-    return Promise.resolve();
-  }
-
-  // Doesn't this need to get hashed w/ the nonce ?
-  override async avmOpcodeEmitNoteHash(noteHash: Fr) {
-    const siloedNoteHash = await siloNoteHash(this.contractAddress, noteHash);
-    this.addUniqueNoteHashesFromPublic([siloedNoteHash]);
-    return Promise.resolve();
-  }
-
-  override async avmOpcodeStorageRead(slot: Fr) {
-    const leafSlot = await computePublicDataTreeLeafSlot(this.contractAddress, slot);
-
-    const lowLeafResult = await this.baseFork.getPreviousValueIndex(MerkleTreeId.PUBLIC_DATA_TREE, leafSlot.toBigInt());
-    if (!lowLeafResult || !lowLeafResult.alreadyPresent) {
-      return Fr.ZERO;
-    }
-
-    const preimage = (await this.baseFork.getLeafPreimage(
-      MerkleTreeId.PUBLIC_DATA_TREE,
-      lowLeafResult.index,
-    )) as PublicDataTreeLeafPreimage;
-
-    return preimage.leaf.value;
   }
 
   override utilityStoreCapsule(contractAddress: AztecAddress, slot: Fr, capsule: Fr[]): Promise<void> {

--- a/yarn-project/txe/src/oracle/txe_oracle_public_context.ts
+++ b/yarn-project/txe/src/oracle/txe_oracle_public_context.ts
@@ -1,0 +1,198 @@
+import {
+  MAX_NOTE_HASHES_PER_TX,
+  MAX_NULLIFIERS_PER_TX,
+  NULLIFIER_SUBTREE_HEIGHT,
+  NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP,
+} from '@aztec/constants';
+import { padArrayEnd } from '@aztec/foundation/collection';
+import { Fr } from '@aztec/foundation/fields';
+import { type Logger, createLogger } from '@aztec/foundation/log';
+import { PublicDataWrite } from '@aztec/stdlib/avm';
+import type { AztecAddress } from '@aztec/stdlib/aztec-address';
+import { Body, L2Block } from '@aztec/stdlib/block';
+import { computePublicDataTreeLeafSlot, siloNoteHash, siloNullifier } from '@aztec/stdlib/hash';
+import { makeAppendOnlyTreeSnapshot, makeContentCommitment } from '@aztec/stdlib/testing';
+import {
+  AppendOnlyTreeSnapshot,
+  MerkleTreeId,
+  type MerkleTreeWriteOperations,
+  PublicDataTreeLeaf,
+  PublicDataTreeLeafPreimage,
+} from '@aztec/stdlib/trees';
+import { BlockHeader, GlobalVariables, TxEffect, TxHash } from '@aztec/stdlib/tx';
+import type { UInt32 } from '@aztec/stdlib/types';
+
+import { TXETypedOracle } from './txe_typed_oracle.js';
+
+export class TXEOraclePublicContext extends TXETypedOracle {
+  private logger: Logger;
+  private transientUniqueNoteHashes: Fr[] = [];
+  private transientSiloedNullifiers: Fr[] = [];
+  private publicDataWrites: PublicDataWrite[] = [];
+
+  constructor(
+    private contractAddress: AztecAddress,
+    private worldTrees: MerkleTreeWriteOperations,
+    private txRequestHash: Fr,
+    private globalVariables: GlobalVariables,
+  ) {
+    super();
+    this.logger = createLogger('txe:public_context');
+
+    this.logger.debug('Entering PublicContext', {
+      contractAddress,
+      blockNumber: globalVariables.blockNumber,
+      timestamp: globalVariables.timestamp,
+    });
+  }
+
+  override avmOpcodeAddress(): Promise<AztecAddress> {
+    return Promise.resolve(this.contractAddress);
+  }
+
+  override avmOpcodeBlockNumber(): Promise<UInt32> {
+    return Promise.resolve(this.globalVariables.blockNumber);
+  }
+
+  override avmOpcodeTimestamp(): Promise<bigint> {
+    return Promise.resolve(this.globalVariables.timestamp);
+  }
+
+  override avmOpcodeIsStaticCall(): Promise<boolean> {
+    return Promise.resolve(false);
+  }
+
+  override avmOpcodeChainId(): Promise<Fr> {
+    return Promise.resolve(this.globalVariables.chainId);
+  }
+
+  override avmOpcodeVersion(): Promise<Fr> {
+    return Promise.resolve(this.globalVariables.version);
+  }
+
+  override async avmOpcodeEmitNullifier(nullifier: Fr) {
+    const siloedNullifier = await siloNullifier(this.contractAddress, nullifier);
+    this.transientSiloedNullifiers.push(siloedNullifier);
+  }
+
+  override async avmOpcodeEmitNoteHash(noteHash: Fr) {
+    const siloedNoteHash = await siloNoteHash(this.contractAddress, noteHash);
+    // TODO: make the note hash unique - they are only siloed right now
+    this.transientUniqueNoteHashes.push(siloedNoteHash);
+  }
+
+  override async avmOpcodeNullifierExists(innerNullifier: Fr, targetAddress: AztecAddress): Promise<boolean> {
+    const nullifier = await siloNullifier(targetAddress, innerNullifier!);
+
+    const treeIndex = (await this.worldTrees.findLeafIndices(MerkleTreeId.NULLIFIER_TREE, [nullifier.toBuffer()]))[0];
+    const transientIndex = this.transientSiloedNullifiers.find(n => n.equals(nullifier));
+
+    return treeIndex !== undefined || transientIndex !== undefined;
+  }
+
+  override async avmOpcodeStorageWrite(slot: Fr, value: Fr) {
+    this.logger.debug('AVM storage write', { slot, value });
+
+    const dataWrite = new PublicDataWrite(await computePublicDataTreeLeafSlot(this.contractAddress, slot), value);
+
+    this.publicDataWrites.push(dataWrite);
+
+    await this.worldTrees.sequentialInsert(MerkleTreeId.PUBLIC_DATA_TREE, [
+      new PublicDataTreeLeaf(dataWrite.leafSlot, dataWrite.value).toBuffer(),
+    ]);
+  }
+
+  override async avmOpcodeStorageRead(slot: Fr): Promise<Fr> {
+    const leafSlot = await computePublicDataTreeLeafSlot(this.contractAddress, slot);
+
+    const lowLeafResult = await this.worldTrees.getPreviousValueIndex(
+      MerkleTreeId.PUBLIC_DATA_TREE,
+      leafSlot.toBigInt(),
+    );
+
+    const value =
+      !lowLeafResult || !lowLeafResult.alreadyPresent
+        ? Fr.ZERO
+        : (
+            (await this.worldTrees.getLeafPreimage(
+              MerkleTreeId.PUBLIC_DATA_TREE,
+              lowLeafResult.index,
+            )) as PublicDataTreeLeafPreimage
+          ).leaf.value;
+
+    this.logger.debug('AVM storage read', { slot, value });
+
+    return value;
+  }
+
+  async close(): Promise<L2Block> {
+    this.logger.debug('Exiting PublicContext, building block with collected side effects', {
+      blockNumber: this.globalVariables.blockNumber,
+    });
+
+    const txEffect = this.makeTxEffect();
+    await this.insertSideEffectIntoWorldTrees(txEffect);
+
+    const block = new L2Block(
+      makeAppendOnlyTreeSnapshot(this.globalVariables.blockNumber),
+      await this.makeBlockHeader(),
+      new Body([txEffect]),
+    );
+
+    await this.worldTrees.close();
+
+    this.logger.debug('Exited PublicContext with built block', {
+      blockNumber: block.number,
+      txEffects: block.body.txEffects,
+    });
+
+    return block;
+  }
+
+  private makeTxEffect(): TxEffect {
+    const txEffect = TxEffect.empty();
+
+    txEffect.noteHashes = this.transientUniqueNoteHashes;
+    txEffect.nullifiers = [this.txRequestHash, ...this.transientSiloedNullifiers];
+
+    txEffect.publicDataWrites = this.publicDataWrites;
+    // TODO: support public logs
+
+    txEffect.txHash = new TxHash(new Fr(this.globalVariables.blockNumber));
+
+    return txEffect;
+  }
+
+  private async insertSideEffectIntoWorldTrees(txEffect: TxEffect) {
+    const l1ToL2Messages = Array(NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP).fill(0).map(Fr.zero);
+
+    await this.worldTrees.appendLeaves(
+      MerkleTreeId.NOTE_HASH_TREE,
+      padArrayEnd(txEffect.noteHashes, Fr.ZERO, MAX_NOTE_HASHES_PER_TX),
+    );
+
+    await this.worldTrees.appendLeaves(MerkleTreeId.L1_TO_L2_MESSAGE_TREE, l1ToL2Messages);
+
+    // We do not need to add public data writes because we apply them as we go.
+
+    await this.worldTrees.batchInsert(
+      MerkleTreeId.NULLIFIER_TREE,
+      padArrayEnd(txEffect.nullifiers, Fr.ZERO, MAX_NULLIFIERS_PER_TX).map(nullifier => nullifier.toBuffer()),
+      NULLIFIER_SUBTREE_HEIGHT,
+    );
+  }
+
+  private async makeBlockHeader(): Promise<BlockHeader> {
+    const stateReference = await this.worldTrees.getStateReference();
+    const archiveInfo = await this.worldTrees.getTreeInfo(MerkleTreeId.ARCHIVE);
+
+    return new BlockHeader(
+      new AppendOnlyTreeSnapshot(new Fr(archiveInfo.root), Number(archiveInfo.size)),
+      makeContentCommitment(),
+      stateReference,
+      this.globalVariables,
+      Fr.ZERO,
+      Fr.ZERO,
+    );
+  }
+}

--- a/yarn-project/txe/src/oracle/txe_typed_oracle.ts
+++ b/yarn-project/txe/src/oracle/txe_typed_oracle.ts
@@ -4,7 +4,7 @@ import { TypedOracle } from '@aztec/pxe/simulator';
 import type { FunctionSelector } from '@aztec/stdlib/abi';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
 import type { PrivateContextInputs } from '@aztec/stdlib/kernel';
-import type { UInt64 } from '@aztec/stdlib/types';
+import type { UInt32, UInt64 } from '@aztec/stdlib/types';
 
 class OracleMethodNotAvailableError extends Error {
   constructor(methodName: string) {
@@ -13,6 +13,30 @@ class OracleMethodNotAvailableError extends Error {
 }
 
 export class TXETypedOracle extends TypedOracle {
+  avmOpcodeAddress(): Promise<AztecAddress> {
+    throw new OracleMethodNotAvailableError('avmOpcodeAddress');
+  }
+
+  avmOpcodeBlockNumber(): Promise<UInt32> {
+    throw new OracleMethodNotAvailableError('avmOpcodeBlockNumber');
+  }
+
+  avmOpcodeTimestamp(): Promise<bigint> {
+    throw new OracleMethodNotAvailableError('avmOpcodeTimestamp');
+  }
+
+  avmOpcodeIsStaticCall(): Promise<boolean> {
+    throw new OracleMethodNotAvailableError('avmOpcodeIsStaticCall');
+  }
+
+  avmOpcodeChainId(): Promise<Fr> {
+    throw new OracleMethodNotAvailableError('avmOpcodeChainId');
+  }
+
+  avmOpcodeVersion(): Promise<Fr> {
+    throw new OracleMethodNotAvailableError('avmOpcodeVersion');
+  }
+
   avmOpcodeEmitNullifier(_nullifier: Fr): Promise<void> {
     throw new OracleMethodNotAvailableError('avmOpcodeEmitNullifier');
   }
@@ -33,7 +57,7 @@ export class TXETypedOracle extends TypedOracle {
     throw new OracleMethodNotAvailableError('avmOpcodeStorageRead');
   }
 
-  txeGetPrivateContextInputs(_blockNumber: number | null): Promise<PrivateContextInputs> {
+  txeGetPrivateContextInputs(_blockNumber?: number): Promise<PrivateContextInputs> {
     throw new OracleMethodNotAvailableError('txeGetPrivateContextInputs');
   }
 

--- a/yarn-project/txe/src/txe_service/txe_service.ts
+++ b/yarn-project/txe/src/txe_service/txe_service.ts
@@ -5,6 +5,7 @@ import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import { MerkleTreeId } from '@aztec/stdlib/trees';
 
 import type { TXETypedOracle } from '../oracle/txe_typed_oracle.js';
+import type { TXESessionStateHandler } from '../txe_session.js';
 import {
   type ForeignCallArray,
   type ForeignCallSingle,
@@ -22,34 +23,81 @@ import {
 } from '../util/encoding.js';
 
 export class TXEService {
-  private executor: TXETypedOracle;
-  constructor(executor: TXETypedOracle) {
-    this.executor = executor;
+  /**
+   * Create a new instance of `TXEService` that will translate all TXE RPC calls to and from the foreign
+   * (`ForeignCallSingle`, `ForeignCallResult`, etc.) and native TS types, delegating actual execution of the oracles
+   * to the different handlers.
+   * @param stateHandler The handler that will process TXE session state transitions, such as entering a private or
+   * public context.
+   * @param oracleHandler The handler that will process all other oracle calls that are not directly related to session
+   * state.
+   */
+  constructor(
+    private stateHandler: TXESessionStateHandler,
+    private oracleHandler: TXETypedOracle,
+  ) {}
+
+  // TXE session state transition functions - these get handled by the state handler
+
+  async txeSetTopLevelTXEContext() {
+    await this.stateHandler.setTopLevelContext();
+
+    return toForeignCallResult([]);
   }
 
-  setExecutor(executor: TXETypedOracle) {
-    this.executor = executor;
-  }
-
-  // Cheatcodes
-
-  async txeGetPrivateContextInputs(
-    foreignBlockNumberIsSome: ForeignCallSingle,
-    foreignBlockNumberValue: ForeignCallSingle,
+  async txeSetPrivateTXEContext(
+    foreignContractAddressIsSome: ForeignCallSingle,
+    foreignContractAddressValue: ForeignCallSingle,
+    foreignHistoricalBlockNumberIsSome: ForeignCallSingle,
+    foreignHistoricalBlockNumberValue: ForeignCallSingle,
   ) {
-    const blockNumber = fromSingle(foreignBlockNumberIsSome).toBool()
-      ? fromSingle(foreignBlockNumberValue).toNumber()
-      : null;
+    const contractAddress = fromSingle(foreignContractAddressIsSome).toBool()
+      ? AztecAddress.fromField(fromSingle(foreignContractAddressValue))
+      : undefined;
 
-    const inputs = await this.executor.txeGetPrivateContextInputs(blockNumber);
+    const historicalBlockNumber = fromSingle(foreignHistoricalBlockNumberIsSome).toBool()
+      ? fromSingle(foreignHistoricalBlockNumberValue).toNumber()
+      : undefined;
 
-    return toForeignCallResult(inputs.toFields().map(toSingle));
+    const privateContextInputs = await this.stateHandler.setPrivateContext(contractAddress, historicalBlockNumber);
+
+    return toForeignCallResult(privateContextInputs.toFields().map(toSingle));
   }
+
+  async txeSetPublicTXEContext(
+    foreignContractAddressIsSome: ForeignCallSingle,
+    foreignContractAddressValue: ForeignCallSingle,
+  ) {
+    const contractAddress = fromSingle(foreignContractAddressIsSome).toBool()
+      ? AztecAddress.fromField(fromSingle(foreignContractAddressValue))
+      : undefined;
+
+    await this.stateHandler.setPublicContext(contractAddress);
+
+    return toForeignCallResult([]);
+  }
+
+  async txeSetUtilityTXEContext(
+    foreignContractAddressIsSome: ForeignCallSingle,
+    foreignContractAddressValue: ForeignCallSingle,
+  ) {
+    const contractAddress = fromSingle(foreignContractAddressIsSome).toBool()
+      ? AztecAddress.fromField(fromSingle(foreignContractAddressValue))
+      : undefined;
+
+    await this.stateHandler.setUtilityContext(contractAddress);
+
+    return toForeignCallResult([]);
+  }
+
+  // Other oracles - these get handled by the oracle handler
+
+  // TXE-specific oracles
 
   async txeAdvanceBlocksBy(foreignBlocks: ForeignCallSingle) {
     const blocks = fromSingle(foreignBlocks).toNumber();
 
-    await this.executor.txeAdvanceBlocksBy(blocks);
+    await this.oracleHandler.txeAdvanceBlocksBy(blocks);
 
     return toForeignCallResult([]);
   }
@@ -57,15 +105,7 @@ export class TXEService {
   txeAdvanceTimestampBy(foreignDuration: ForeignCallSingle) {
     const duration = fromSingle(foreignDuration).toBigInt();
 
-    this.executor.txeAdvanceTimestampBy(duration);
-
-    return toForeignCallResult([]);
-  }
-
-  txeSetContractAddress(foreignAddress: ForeignCallSingle) {
-    const address = addressFromSingle(foreignAddress);
-
-    this.executor.txeSetContractAddress(address);
+    this.oracleHandler.txeAdvanceTimestampBy(duration);
 
     return toForeignCallResult([]);
   }
@@ -73,7 +113,7 @@ export class TXEService {
   async txeDeploy(artifact: ContractArtifact, instance: ContractInstanceWithAddress, foreignSecret: ForeignCallSingle) {
     const secret = fromSingle(foreignSecret);
 
-    await this.executor.txeDeploy(artifact, instance, secret);
+    await this.oracleHandler.txeDeploy(artifact, instance, secret);
 
     return toForeignCallResult([
       toArray([
@@ -89,7 +129,7 @@ export class TXEService {
   async txeCreateAccount(foreignSecret: ForeignCallSingle) {
     const secret = fromSingle(foreignSecret);
 
-    const completeAddress = await this.executor.txeCreateAccount(secret);
+    const completeAddress = await this.oracleHandler.txeCreateAccount(secret);
 
     return toForeignCallResult([
       toSingle(completeAddress.address),
@@ -104,7 +144,7 @@ export class TXEService {
   ) {
     const secret = fromSingle(foreignSecret);
 
-    const completeAddress = await this.executor.txeAddAccount(artifact, instance, secret);
+    const completeAddress = await this.oracleHandler.txeAddAccount(artifact, instance, secret);
 
     return toForeignCallResult([
       toSingle(completeAddress.address),
@@ -116,7 +156,7 @@ export class TXEService {
     const address = addressFromSingle(foreignAddress);
     const messageHash = fromSingle(foreignMessageHash);
 
-    await this.executor.txeAddAuthWitness(address, messageHash);
+    await this.oracleHandler.txeAddAuthWitness(address, messageHash);
 
     return toForeignCallResult([]);
   }
@@ -126,38 +166,38 @@ export class TXEService {
   utilityAssertCompatibleOracleVersion(foreignVersion: ForeignCallSingle) {
     const version = fromSingle(foreignVersion).toNumber();
 
-    this.executor.utilityAssertCompatibleOracleVersion(version);
+    this.oracleHandler.utilityAssertCompatibleOracleVersion(version);
 
     return toForeignCallResult([]);
   }
 
   utilityGetRandomField() {
-    const randomField = this.executor.utilityGetRandomField();
+    const randomField = this.oracleHandler.utilityGetRandomField();
 
     return toForeignCallResult([toSingle(randomField)]);
   }
 
   async utilityGetContractAddress() {
-    const contractAddress = await this.executor.utilityGetContractAddress();
+    const contractAddress = await this.oracleHandler.utilityGetContractAddress();
 
     return toForeignCallResult([toSingle(contractAddress.toField())]);
   }
 
   async utilityGetBlockNumber() {
-    const blockNumber = await this.executor.utilityGetBlockNumber();
+    const blockNumber = await this.oracleHandler.utilityGetBlockNumber();
 
     return toForeignCallResult([toSingle(new Fr(blockNumber))]);
   }
 
   // seems to be used to mean the timestamp of the last mined block in txe (but that's not what is done here)
   async utilityGetTimestamp() {
-    const timestamp = await this.executor.utilityGetTimestamp();
+    const timestamp = await this.oracleHandler.utilityGetTimestamp();
 
     return toForeignCallResult([toSingle(new Fr(timestamp))]);
   }
 
   async txeGetLastBlockTimestamp() {
-    const timestamp = await this.executor.txeGetLastBlockTimestamp();
+    const timestamp = await this.oracleHandler.txeGetLastBlockTimestamp();
 
     return toForeignCallResult([toSingle(new Fr(timestamp))]);
   }
@@ -171,7 +211,7 @@ export class TXEService {
     const values = fromArray(foreignValues);
     const hash = fromSingle(foreignHash);
 
-    this.executor.privateStoreInExecutionCache(values, hash);
+    this.oracleHandler.privateStoreInExecutionCache(values, hash);
 
     return toForeignCallResult([]);
   }
@@ -179,7 +219,7 @@ export class TXEService {
   async privateLoadFromExecutionCache(foreignHash: ForeignCallSingle) {
     const hash = fromSingle(foreignHash);
 
-    const returns = await this.executor.privateLoadFromExecutionCache(hash);
+    const returns = await this.oracleHandler.privateLoadFromExecutionCache(hash);
 
     return toForeignCallResult([toArray(returns)]);
   }
@@ -195,7 +235,7 @@ export class TXEService {
       .join('');
     const fields = fromArray(foreignFields);
 
-    this.executor.utilityDebugLog(message, fields);
+    this.oracleHandler.utilityDebugLog(message, fields);
 
     return toForeignCallResult([]);
   }
@@ -211,7 +251,7 @@ export class TXEService {
     const blockNumber = fromSingle(foreignBlockNumber).toNumber();
     const numberOfElements = fromSingle(foreignNumberOfElements).toNumber();
 
-    const values = await this.executor.utilityStorageRead(
+    const values = await this.oracleHandler.utilityStorageRead(
       contractAddress,
       startStorageSlot,
       blockNumber,
@@ -225,7 +265,7 @@ export class TXEService {
     const blockNumber = fromSingle(foreignBlockNumber).toNumber();
     const leafSlot = fromSingle(foreignLeafSlot);
 
-    const witness = await this.executor.utilityGetPublicDataWitness(blockNumber, leafSlot);
+    const witness = await this.oracleHandler.utilityGetPublicDataWitness(blockNumber, leafSlot);
 
     if (!witness) {
       throw new Error(`Public data witness not found for slot ${leafSlot} at block ${blockNumber}.`);
@@ -268,7 +308,7 @@ export class TXEService {
     const maxNotes = fromSingle(foreignMaxNotes).toNumber();
     const packedRetrievedNoteLength = fromSingle(foreignPackedRetrievedNoteLength).toNumber();
 
-    const noteDatas = await this.executor.utilityGetNotes(
+    const noteDatas = await this.oracleHandler.utilityGetNotes(
       storageSlot,
       numSelects,
       selectByIndexes,
@@ -315,7 +355,7 @@ export class TXEService {
     const noteHash = fromSingle(foreignNoteHash);
     const counter = fromSingle(foreignCounter).toNumber();
 
-    this.executor.privateNotifyCreatedNote(storageSlot, noteTypeId, note, noteHash, counter);
+    this.oracleHandler.privateNotifyCreatedNote(storageSlot, noteTypeId, note, noteHash, counter);
 
     return toForeignCallResult([]);
   }
@@ -329,7 +369,7 @@ export class TXEService {
     const noteHash = fromSingle(foreignNoteHash);
     const counter = fromSingle(foreignCounter).toNumber();
 
-    await this.executor.privateNotifyNullifiedNote(innerNullifier, noteHash, counter);
+    await this.oracleHandler.privateNotifyNullifiedNote(innerNullifier, noteHash, counter);
 
     return toForeignCallResult([]);
   }
@@ -337,7 +377,7 @@ export class TXEService {
   async privateNotifyCreatedNullifier(foreignInnerNullifier: ForeignCallSingle) {
     const innerNullifier = fromSingle(foreignInnerNullifier);
 
-    await this.executor.privateNotifyCreatedNullifier(innerNullifier);
+    await this.oracleHandler.privateNotifyCreatedNullifier(innerNullifier);
 
     return toForeignCallResult([]);
   }
@@ -345,7 +385,7 @@ export class TXEService {
   async utilityCheckNullifierExists(foreignInnerNullifier: ForeignCallSingle) {
     const innerNullifier = fromSingle(foreignInnerNullifier);
 
-    const exists = await this.executor.utilityCheckNullifierExists(innerNullifier);
+    const exists = await this.oracleHandler.utilityCheckNullifierExists(innerNullifier);
 
     return toForeignCallResult([toSingle(new Fr(exists))]);
   }
@@ -353,7 +393,7 @@ export class TXEService {
   async utilityGetContractInstance(foreignAddress: ForeignCallSingle) {
     const address = addressFromSingle(foreignAddress);
 
-    const instance = await this.executor.utilityGetContractInstance(address);
+    const instance = await this.oracleHandler.utilityGetContractInstance(address);
 
     return toForeignCallResult(
       [
@@ -369,7 +409,7 @@ export class TXEService {
   async utilityGetPublicKeysAndPartialAddress(foreignAddress: ForeignCallSingle) {
     const address = addressFromSingle(foreignAddress);
 
-    const { publicKeys, partialAddress } = await this.executor.utilityGetCompleteAddress(address);
+    const { publicKeys, partialAddress } = await this.oracleHandler.utilityGetCompleteAddress(address);
 
     return toForeignCallResult([toArray([...publicKeys.toFields(), partialAddress])]);
   }
@@ -377,7 +417,7 @@ export class TXEService {
   async utilityGetKeyValidationRequest(foreignPkMHash: ForeignCallSingle) {
     const pkMHash = fromSingle(foreignPkMHash);
 
-    const keyValidationRequest = await this.executor.utilityGetKeyValidationRequest(pkMHash);
+    const keyValidationRequest = await this.oracleHandler.utilityGetKeyValidationRequest(pkMHash);
 
     return toForeignCallResult(keyValidationRequest.toFields().map(toSingle));
   }
@@ -401,7 +441,7 @@ export class TXEService {
     const blockNumber = fromSingle(foreignBlockNumber).toNumber();
     const nullifier = fromSingle(foreignNullifier);
 
-    const witness = await this.executor.utilityGetNullifierMembershipWitness(blockNumber, nullifier);
+    const witness = await this.oracleHandler.utilityGetNullifierMembershipWitness(blockNumber, nullifier);
 
     if (!witness) {
       throw new Error(`Nullifier membership witness not found at block ${blockNumber}.`);
@@ -412,7 +452,7 @@ export class TXEService {
   async utilityGetAuthWitness(foreignMessageHash: ForeignCallSingle) {
     const messageHash = fromSingle(foreignMessageHash);
 
-    const authWitness = await this.executor.utilityGetAuthWitness(messageHash);
+    const authWitness = await this.oracleHandler.utilityGetAuthWitness(messageHash);
 
     if (!authWitness) {
       throw new Error(`Auth witness not found for message hash ${messageHash}.`);
@@ -443,13 +483,13 @@ export class TXEService {
   }
 
   async utilityGetChainId() {
-    const chainId = await this.executor.utilityGetChainId();
+    const chainId = await this.oracleHandler.utilityGetChainId();
 
     return toForeignCallResult([toSingle(chainId)]);
   }
 
   async utilityGetVersion() {
-    const version = await this.executor.utilityGetVersion();
+    const version = await this.oracleHandler.utilityGetVersion();
 
     return toForeignCallResult([toSingle(version)]);
   }
@@ -457,7 +497,7 @@ export class TXEService {
   async utilityGetBlockHeader(foreignBlockNumber: ForeignCallSingle) {
     const blockNumber = fromSingle(foreignBlockNumber).toNumber();
 
-    const header = await this.executor.utilityGetBlockHeader(blockNumber);
+    const header = await this.oracleHandler.utilityGetBlockHeader(blockNumber);
 
     if (!header) {
       throw new Error(`Block header not found for block ${blockNumber}.`);
@@ -474,7 +514,7 @@ export class TXEService {
     const treeId = fromSingle(foreignTreeId).toNumber();
     const leafValue = fromSingle(foreignLeafValue);
 
-    const witness = await this.executor.utilityGetMembershipWitness(blockNumber, treeId, leafValue);
+    const witness = await this.oracleHandler.utilityGetMembershipWitness(blockNumber, treeId, leafValue);
 
     if (!witness) {
       throw new Error(
@@ -491,7 +531,7 @@ export class TXEService {
     const blockNumber = fromSingle(foreignBlockNumber).toNumber();
     const nullifier = fromSingle(foreignNullifier);
 
-    const witness = await this.executor.utilityGetLowNullifierMembershipWitness(blockNumber, nullifier);
+    const witness = await this.oracleHandler.utilityGetLowNullifierMembershipWitness(blockNumber, nullifier);
 
     if (!witness) {
       throw new Error(`Low nullifier witness not found for nullifier ${nullifier} at block ${blockNumber}.`);
@@ -503,7 +543,7 @@ export class TXEService {
     const sender = AztecAddress.fromField(fromSingle(foreignSender));
     const recipient = AztecAddress.fromField(fromSingle(foreignRecipient));
 
-    const secret = await this.executor.utilityGetIndexedTaggingSecretAsSender(sender, recipient);
+    const secret = await this.oracleHandler.utilityGetIndexedTaggingSecretAsSender(sender, recipient);
 
     return toForeignCallResult(secret.toFields().map(toSingle));
   }
@@ -511,7 +551,7 @@ export class TXEService {
   async utilityFetchTaggedLogs(foreignPendingTaggedLogArrayBaseSlot: ForeignCallSingle) {
     const pendingTaggedLogArrayBaseSlot = fromSingle(foreignPendingTaggedLogArrayBaseSlot);
 
-    await this.executor.utilityFetchTaggedLogs(pendingTaggedLogArrayBaseSlot);
+    await this.oracleHandler.utilityFetchTaggedLogs(pendingTaggedLogArrayBaseSlot);
 
     return toForeignCallResult([]);
   }
@@ -525,7 +565,7 @@ export class TXEService {
     const noteValidationRequestsArrayBaseSlot = fromSingle(foreignNoteValidationRequestsArrayBaseSlot);
     const eventValidationRequestsArrayBaseSlot = fromSingle(foreignEventValidationRequestsArrayBaseSlot);
 
-    await this.executor.utilityValidateEnqueuedNotesAndEvents(
+    await this.oracleHandler.utilityValidateEnqueuedNotesAndEvents(
       contractAddress,
       noteValidationRequestsArrayBaseSlot,
       eventValidationRequestsArrayBaseSlot,
@@ -543,7 +583,7 @@ export class TXEService {
     const logRetrievalRequestsArrayBaseSlot = fromSingle(foreignLogRetrievalRequestsArrayBaseSlot);
     const logRetrievalResponsesArrayBaseSlot = fromSingle(foreignLogRetrievalResponsesArrayBaseSlot);
 
-    await this.executor.utilityBulkRetrieveLogs(
+    await this.oracleHandler.utilityBulkRetrieveLogs(
       contractAddress,
       logRetrievalRequestsArrayBaseSlot,
       logRetrievalResponsesArrayBaseSlot,
@@ -561,7 +601,7 @@ export class TXEService {
     const slot = fromSingle(foreignSlot);
     const capsule = fromArray(foreignCapsule);
 
-    await this.executor.utilityStoreCapsule(contractAddress, slot, capsule);
+    await this.oracleHandler.utilityStoreCapsule(contractAddress, slot, capsule);
 
     return toForeignCallResult([]);
   }
@@ -575,7 +615,7 @@ export class TXEService {
     const slot = fromSingle(foreignSlot);
     const tSize = fromSingle(foreignTSize).toNumber();
 
-    const values = await this.executor.utilityLoadCapsule(contractAddress, slot);
+    const values = await this.oracleHandler.utilityLoadCapsule(contractAddress, slot);
 
     // We are going to return a Noir Option struct to represent the possibility of null values. Options are a struct
     // with two fields: `some` (a boolean) and `value` (a field array in this case).
@@ -592,7 +632,7 @@ export class TXEService {
     const contractAddress = AztecAddress.fromField(fromSingle(foreignContractAddress));
     const slot = fromSingle(foreignSlot);
 
-    await this.executor.utilityDeleteCapsule(contractAddress, slot);
+    await this.oracleHandler.utilityDeleteCapsule(contractAddress, slot);
 
     return toForeignCallResult([]);
   }
@@ -608,7 +648,7 @@ export class TXEService {
     const dstSlot = fromSingle(foreignDstSlot);
     const numEntries = fromSingle(foreignNumEntries).toNumber();
 
-    await this.executor.utilityCopyCapsule(contractAddress, srcSlot, dstSlot, numEntries);
+    await this.oracleHandler.utilityCopyCapsule(contractAddress, srcSlot, dstSlot, numEntries);
 
     return toForeignCallResult([]);
   }
@@ -627,7 +667,7 @@ export class TXEService {
     const iv = fromUintArray(foreignIv, 8);
     const symKey = fromUintArray(foreignSymKey, 8);
 
-    const plaintextBuffer = await this.executor.utilityAes128Decrypt(ciphertext, iv, symKey);
+    const plaintextBuffer = await this.oracleHandler.utilityAes128Decrypt(ciphertext, iv, symKey);
 
     return toForeignCallResult(
       arrayToBoundedVec(bufferToU8Array(plaintextBuffer), foreignCiphertextBVecStorage.length),
@@ -647,7 +687,7 @@ export class TXEService {
       fromSingle(foreignEphPKField2),
     ]);
 
-    const secret = await this.executor.utilityGetSharedSecret(address, ephPK);
+    const secret = await this.oracleHandler.utilityGetSharedSecret(address, ephPK);
 
     return toForeignCallResult(secret.toFields().map(toSingle));
   }
@@ -666,7 +706,7 @@ export class TXEService {
   async avmOpcodeStorageRead(foreignSlot: ForeignCallSingle) {
     const slot = fromSingle(foreignSlot);
 
-    const value = (await this.executor.avmOpcodeStorageRead(slot)).value;
+    const value = (await this.oracleHandler.avmOpcodeStorageRead(slot)).value;
 
     return toForeignCallResult([toSingle(new Fr(value))]);
   }
@@ -675,7 +715,7 @@ export class TXEService {
     const slot = fromSingle(foreignSlot);
     const value = fromSingle(foreignValue);
 
-    await this.executor.storageWrite(slot, [value]);
+    await this.oracleHandler.avmOpcodeStorageWrite(slot, value);
 
     return toForeignCallResult([]);
   }
@@ -683,7 +723,7 @@ export class TXEService {
   async avmOpcodeGetContractInstanceDeployer(foreignAddress: ForeignCallSingle) {
     const address = addressFromSingle(foreignAddress);
 
-    const instance = await this.executor.utilityGetContractInstance(address);
+    const instance = await this.oracleHandler.utilityGetContractInstance(address);
 
     return toForeignCallResult([
       toSingle(instance.deployer),
@@ -695,7 +735,7 @@ export class TXEService {
   async avmOpcodeGetContractInstanceClassId(foreignAddress: ForeignCallSingle) {
     const address = addressFromSingle(foreignAddress);
 
-    const instance = await this.executor.utilityGetContractInstance(address);
+    const instance = await this.oracleHandler.utilityGetContractInstance(address);
 
     return toForeignCallResult([
       toSingle(instance.currentContractClassId),
@@ -707,7 +747,7 @@ export class TXEService {
   async avmOpcodeGetContractInstanceInitializationHash(foreignAddress: ForeignCallSingle) {
     const address = addressFromSingle(foreignAddress);
 
-    const instance = await this.executor.utilityGetContractInstance(address);
+    const instance = await this.oracleHandler.utilityGetContractInstance(address);
 
     return toForeignCallResult([
       toSingle(instance.initializationHash),
@@ -717,7 +757,7 @@ export class TXEService {
   }
 
   avmOpcodeSender() {
-    const sender = this.executor.getMsgSender();
+    const sender = this.oracleHandler.getMsgSender();
 
     return toForeignCallResult([toSingle(sender)]);
   }
@@ -725,7 +765,7 @@ export class TXEService {
   async avmOpcodeEmitNullifier(foreignNullifier: ForeignCallSingle) {
     const nullifier = fromSingle(foreignNullifier);
 
-    await this.executor.avmOpcodeEmitNullifier(nullifier);
+    await this.oracleHandler.avmOpcodeEmitNullifier(nullifier);
 
     return toForeignCallResult([]);
   }
@@ -733,7 +773,7 @@ export class TXEService {
   async avmOpcodeEmitNoteHash(foreignNoteHash: ForeignCallSingle) {
     const noteHash = fromSingle(foreignNoteHash);
 
-    await this.executor.avmOpcodeEmitNoteHash(noteHash);
+    await this.oracleHandler.avmOpcodeEmitNoteHash(noteHash);
 
     return toForeignCallResult([]);
   }
@@ -742,44 +782,43 @@ export class TXEService {
     const innerNullifier = fromSingle(foreignInnerNullifier);
     const targetAddress = AztecAddress.fromField(fromSingle(foreignTargetAddress));
 
-    const exists = await this.executor.avmOpcodeNullifierExists(innerNullifier, targetAddress);
+    const exists = await this.oracleHandler.avmOpcodeNullifierExists(innerNullifier, targetAddress);
 
     return toForeignCallResult([toSingle(new Fr(exists))]);
   }
 
   async avmOpcodeAddress() {
-    const contractAddress = await this.executor.utilityGetContractAddress();
+    const contractAddress = await this.oracleHandler.avmOpcodeAddress();
 
     return toForeignCallResult([toSingle(contractAddress.toField())]);
   }
 
   async avmOpcodeBlockNumber() {
-    const blockNumber = await this.executor.utilityGetBlockNumber();
+    const blockNumber = await this.oracleHandler.avmOpcodeBlockNumber();
 
     return toForeignCallResult([toSingle(new Fr(blockNumber))]);
   }
 
   async avmOpcodeTimestamp() {
-    const timestamp = await this.executor.utilityGetTimestamp();
+    const timestamp = await this.oracleHandler.avmOpcodeTimestamp();
 
     return toForeignCallResult([toSingle(new Fr(timestamp))]);
   }
 
-  avmOpcodeIsStaticCall() {
-    // TestEnvironment::public_context is always static
-    const isStaticCall = true;
+  async avmOpcodeIsStaticCall() {
+    const isStaticCall = await this.oracleHandler.avmOpcodeIsStaticCall();
 
     return toForeignCallResult([toSingle(new Fr(isStaticCall ? 1 : 0))]);
   }
 
   async avmOpcodeChainId() {
-    const chainId = await this.executor.utilityGetChainId();
+    const chainId = await this.oracleHandler.avmOpcodeChainId();
 
     return toForeignCallResult([toSingle(chainId)]);
   }
 
   async avmOpcodeVersion() {
-    const version = await this.executor.utilityGetVersion();
+    const version = await this.oracleHandler.avmOpcodeVersion();
 
     return toForeignCallResult([toSingle(version)]);
   }
@@ -842,7 +881,7 @@ export class TXEService {
     const argsHash = fromSingle(foreignArgsHash);
     const isStaticCall = fromSingle(foreignIsStaticCall).toBool();
 
-    const result = await this.executor.txePrivateCallNewFlow(
+    const result = await this.oracleHandler.txePrivateCallNewFlow(
       from,
       targetContractAddress,
       functionSelector,
@@ -863,7 +902,7 @@ export class TXEService {
     const functionSelector = FunctionSelector.fromField(fromSingle(foreignFunctionSelector));
     const argsHash = fromSingle(foreignArgsHash);
 
-    const result = await this.executor.simulateUtilityFunction(targetContractAddress, functionSelector, argsHash);
+    const result = await this.oracleHandler.simulateUtilityFunction(targetContractAddress, functionSelector, argsHash);
 
     return toForeignCallResult([toSingle(result)]);
   }
@@ -880,13 +919,13 @@ export class TXEService {
     const calldata = fromArray(foreignCalldata);
     const isStaticCall = fromSingle(foreignIsStaticCall).toBool();
 
-    const result = await this.executor.txePublicCallNewFlow(from, address, calldata, isStaticCall);
+    const result = await this.oracleHandler.txePublicCallNewFlow(from, address, calldata, isStaticCall);
 
     return toForeignCallResult([toArray([result.returnsHash, result.txHash.hash])]);
   }
 
   async privateGetSenderForTags() {
-    const sender = await this.executor.privateGetSenderForTags();
+    const sender = await this.oracleHandler.privateGetSenderForTags();
 
     // Return a Noir Option struct with `some` and `value` fields
     if (sender === undefined) {
@@ -901,7 +940,7 @@ export class TXEService {
   async privateSetSenderForTags(foreignSenderForTags: ForeignCallSingle) {
     const senderForTags = AztecAddress.fromField(fromSingle(foreignSenderForTags));
 
-    await this.executor.privateSetSenderForTags(senderForTags);
+    await this.oracleHandler.privateSetSenderForTags(senderForTags);
 
     return toForeignCallResult([]);
   }


### PR DESCRIPTION
This one leaves things in a bit of a messy state, as doing _the entire_ transition is unfeasiable, but the things that are ready _do_ look good, and it's a good starting place for future changes.

The session now calls the translator (service) with a handler for state changes (the session itself) and a handler for all other calls. On session state transitions, a new handler is installed and the old one closed and committed to. There's now a handler for `public_context` which does the avm opcodes, and consequently the `txe_oracle` no longer knows how to process these (because it doesn't need to).

I also cleaned up the state transition oracles to take all params in one go instead of relying on mutating global session state, which helps make this smoother and also helps with the cleanup and eventual removal of the `txe_oracle`.