### PR TITLE
fix: catch potential errors enqueuing gov/slashing signals

### DIFF
--- a/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
@@ -267,6 +267,7 @@ describe('sequencer', () => {
     validatorClient.createBlockProposal.mockImplementation(() => Promise.resolve(createBlockProposal()));
 
     slasherClient = mock<SlasherClientInterface>();
+    slasherClient.getProposerActions.mockResolvedValue([]);
 
     dateProvider = new TestDateProvider();
 


### PR DESCRIPTION
These promises could throw before the code got to the `await` for them (where `catch` handlers were attached) leading to an unhandled rejection and a full process crash.