### PR TITLE
fix!: misc avm - fixes constraints, ts sim, cpp sim, tracegen

### DIFF
--- a/barretenberg/cpp/pil/vm2/alu.pil
+++ b/barretenberg/cpp/pil/vm2/alu.pil
@@ -119,7 +119,7 @@ pol EXPECTED_C_TAG = (sel_op_add + sel_op_sub + sel_op_mul + sel_op_div + sel_op
 // Gating with (1 - sel_tag_err) is necessary because when an error occurs, we have to set the tag to 0,
 // which might not be equal to EXPECTED_C_TAG.
 #[C_TAG_CHECK]
-(1 - sel_tag_err) * (EXPECTED_C_TAG - ic_tag) = 0;
+(1 - sel_err) * (EXPECTED_C_TAG - ic_tag) = 0;
 
 pol commit sel_tag_err;
 sel_tag_err * (1 - sel_tag_err) = 0;

--- a/barretenberg/cpp/pil/vm2/context.pil
+++ b/barretenberg/cpp/pil/vm2/context.pil
@@ -12,6 +12,10 @@ namespace execution;
     #[skippable_if]
     sel = 0;
 
+    // TODO: make sure that all uses of `sel_error` here really should be "error" only
+    // since `sel_error` will not be ` for the REVERT opcode. If we need "error or REVERT",
+    // use `sel_failure`.
+
     // Guaranteed to be boolean because sel_execute_call & sel_execute_static_call are mutually exclusive
     pol commit sel_enter_call;
     // The following selectors will be 0 if there is an error during execution (before the opcode execution step).

--- a/barretenberg/cpp/pil/vm2/execution.pil
+++ b/barretenberg/cpp/pil/vm2/execution.pil
@@ -147,7 +147,7 @@ sel_bytecode_retrieval_success {
 
 pol commit sel_instruction_fetching_success;
 // If sel = 0, we want sel_instruction_fetching_success = 0. We shouldn't be using it.
-sel_instruction_fetching_success = sel * (1 - sel_instruction_fetching_failure);
+sel_instruction_fetching_success = sel_bytecode_retrieval_success * (1 - sel_instruction_fetching_failure);
 
 #[INSTRUCTION_FETCHING_BODY]
 sel_instruction_fetching_success {

--- a/barretenberg/cpp/pil/vm2/tx.pil
+++ b/barretenberg/cpp/pil/vm2/tx.pil
@@ -306,7 +306,7 @@ namespace tx;
     execution.enqueued_call_end {
        execution.context_id,
        execution.next_context_id,
-       execution.sel_error,
+       execution.sel_failure,
        execution.discard,
        // Tree State
        execution.note_hash_tree_root,

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/alu_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/alu_impl.hpp
@@ -138,7 +138,7 @@ void aluImpl<FF_>::accumulate(ContainerOverSubrelations& evals,
     }
     { // C_TAG_CHECK
         using Accumulator = typename std::tuple_element_t<8, ContainerOverSubrelations>;
-        auto tmp = (FF(1) - in.get(C::alu_sel_tag_err)) * (alu_EXPECTED_C_TAG - in.get(C::alu_ic_tag));
+        auto tmp = (FF(1) - in.get(C::alu_sel_err)) * (alu_EXPECTED_C_TAG - in.get(C::alu_ic_tag));
         tmp *= scaling_factor;
         std::get<8>(evals) += typename Accumulator::View(tmp);
     }

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/execution_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/execution_impl.hpp
@@ -120,7 +120,8 @@ void executionImpl<FF_>::accumulate(ContainerOverSubrelations& evals,
     {
         using Accumulator = typename std::tuple_element_t<8, ContainerOverSubrelations>;
         auto tmp = (in.get(C::execution_sel_instruction_fetching_success) -
-                    in.get(C::execution_sel) * (FF(1) - in.get(C::execution_sel_instruction_fetching_failure)));
+                    in.get(C::execution_sel_bytecode_retrieval_success) *
+                        (FF(1) - in.get(C::execution_sel_instruction_fetching_failure)));
         tmp *= scaling_factor;
         std::get<8>(evals) += typename Accumulator::View(tmp);
     }

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/lookups_tx.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/lookups_tx.hpp
@@ -243,7 +243,7 @@ struct lookup_tx_dispatch_exec_end_settings_ {
     static constexpr std::array<ColumnAndShifts, LOOKUP_TUPLE_SIZE> DST_COLUMNS = {
         ColumnAndShifts::execution_context_id,
         ColumnAndShifts::execution_next_context_id,
-        ColumnAndShifts::execution_sel_error,
+        ColumnAndShifts::execution_sel_failure,
         ColumnAndShifts::execution_discard,
         ColumnAndShifts::execution_note_hash_tree_root,
         ColumnAndShifts::execution_note_hash_tree_size,

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/tx_execution.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/tx_execution.cpp
@@ -114,6 +114,7 @@ void TxExecution::simulate(const Tx& tx)
                 format("[SETUP] UNRECOVERABLE ERROR! Enqueued call to ", call.request.contractAddress, " failed"));
         }
     }
+    SideEffectStates end_setup_side_effect_states = tx_context.side_effect_states;
 
     // The checkpoint we should go back to if anything from now on reverts.
     merkle_db.create_checkpoint();
@@ -159,6 +160,7 @@ void TxExecution::simulate(const Tx& tx)
         info("Revertible failure while simulating tx ", tx.hash, ": ", e.what());
         // We revert to the post-setup state.
         merkle_db.revert_checkpoint();
+        tx_context.side_effect_states = end_setup_side_effect_states;
         // But we also create a new fork so that the teardown phase can transparently
         // commit or rollback to the end of teardown.
         merkle_db.create_checkpoint();

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/written_public_data_slots_tree_check.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/written_public_data_slots_tree_check.cpp
@@ -139,6 +139,7 @@ void WrittenPublicDataSlotsTreeCheck::create_checkpoint()
 
 void WrittenPublicDataSlotsTreeCheck::commit_checkpoint()
 {
+    // Commit the current top of the stack down one level.
     WrittenPublicDataSlotsTree current_tree = std::move(written_public_data_slots_tree_stack.top());
     written_public_data_slots_tree_stack.pop();
     written_public_data_slots_tree_stack.top() = std::move(current_tree);

--- a/yarn-project/simulator/src/public/avm/avm_simulator.test.ts
+++ b/yarn-project/simulator/src/public/avm/avm_simulator.test.ts
@@ -149,7 +149,12 @@ describe('AVM simulator: injected bytecode', () => {
 
 describe('AVM simulator: transpiled Noir contracts', () => {
   it('execution of a non-existent contract immediately reverts and consumes all allocated gas', async () => {
-    const context = initContext();
+    const treesDB = mock<PublicTreesDB>();
+    const persistableState = initPersistableStateManager({ treesDB });
+    const address = AztecAddress.fromNumber(1234);
+    const env = initExecutionEnvironment({ address });
+    const context = initContext({ env, persistableState });
+    mockCheckNullifierExists(treesDB, false);
     const results = await new AvmSimulator(context).execute();
 
     expect(results.reverted).toBe(true);

--- a/yarn-project/simulator/src/public/avm/opcodes/external_calls.test.ts
+++ b/yarn-project/simulator/src/public/avm/opcodes/external_calls.test.ts
@@ -79,6 +79,8 @@ describe('External Calls', () => {
       // Define dst offset for SuccessCopy
       const successDstOffset = 6;
 
+      mockCheckNullifierExists(treesDB, false);
+
       const { l2GasLeft: initialL2Gas, daGasLeft: initialDaGas } = context.machineState;
 
       context.machineState.memory.set(0, new Uint32(l2Gas));

--- a/yarn-project/simulator/src/public/state_manager/state_manager.test.ts
+++ b/yarn-project/simulator/src/public/state_manager/state_manager.test.ts
@@ -141,6 +141,7 @@ describe('state_manager', () => {
     });
 
     it('Can get undefined contract instance', async () => {
+      mockCheckNullifierExists(treesDB, false);
       await persistableState.getContractInstance(address);
     });
   });
@@ -167,6 +168,7 @@ describe('state_manager', () => {
       );
     });
     it('Can get undefined bytecode', async () => {
+      mockCheckNullifierExists(treesDB, false);
       await persistableState.getBytecode(address);
     });
   });


### PR DESCRIPTION
Fixes to alu, context, execution, tx pil. Fixes to tx execution and tx tracegen. Trace side-effect operations before they fail in TS state manager. Always perform nullifier non-membership check on non-existence in AVM TS. Side-effects rollbacks in tx execution.

1. ALU PIL should disable C's tag check on `sel_err` (any error) rather than `sel_tag_err`. It at least needs to be disabled on div-by-0 as well.
2. `sel_instruction_fetching_success` should be forced to 0 on bytecode retrieval faliure.
3. TX's dispatch "end" interaction to execution's should use execution's `sel_failure` to capture "error or revert opcode".
4. Bytecode retrieval failures should emit an event that includes tree roots so that non-membership can be performed.
5. When bytecode is not found for a contract call, the execution trace's empty row should have opcode 0.
6. TX trace should snapshot and restore end-setup's side effect states.
7. Execution tracegen should handle "exit call scenarios" in a separate if-statement to individual opcodes, because if an opcode errors, we need to set all of the selectors for "exit", but also need to tracegen the failing opcode.
8. In the TS avm simulator, contract instance retrieval should perform the nullifier [non]membership check even if the instance does not exist.
