### PR TITLE
fix: Do not attempt proposer check if late into a slot

### DIFF
--- a/yarn-project/sequencer-client/src/sequencer/sequencer.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.ts
@@ -508,7 +508,11 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
       await this.doRealWork();
     } catch (err) {
       if (err instanceof SequencerTooSlowError) {
-        this.log.warn(err.message);
+        // Log as warn only if we had to abort halfway through the block proposal
+        const logLvl = [SequencerState.INITIALIZING_PROPOSAL, SequencerState.PROPOSER_CHECK].includes(err.proposedState)
+          ? ('debug' as const)
+          : ('warn' as const);
+        this.log[logLvl](err.message, { now: this.dateProvider.nowInSeconds() });
       } else {
         // Re-throw other errors
         throw err;

--- a/yarn-project/sequencer-client/src/sequencer/timetable.ts
+++ b/yarn-project/sequencer-client/src/sequencer/timetable.ts
@@ -141,8 +141,8 @@ export class SequencerTimetable {
       case SequencerState.STOPPED:
       case SequencerState.IDLE:
       case SequencerState.SYNCHRONIZING:
-      case SequencerState.PROPOSER_CHECK:
         return; // We don't really care about times for this states
+      case SequencerState.PROPOSER_CHECK:
       case SequencerState.INITIALIZING_PROPOSAL:
         return this.initializeDeadline;
       case SequencerState.CREATING_BLOCK:


### PR DESCRIPTION
Do not bother checking if we are the current proposer in the sequencer if we won't have time to propose a block anyway.

This should fix a [flake in block-building e2e tests](http://ci.aztec-labs.com/f84c2981d9e62498), where we were seeing `proposer-rollup-check-failed` errors. This was caused because the proposer check was done at the very end of the slot, and ended up being executed on L1 on the following slot.
