### PR TITLE
chore: Bump foundry version to 1.3.3

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -81,15 +81,21 @@ function check_toolchains {
     exit 1
   fi
   # Check foundry version.
-  local foundry_version="nightly-99634144b6c9371982dcfc551a7975c5dbf9fad8"
+  local foundry_version="v1.3.3"
   for tool in forge anvil; do
     if ! $tool --version 2> /dev/null | grep "${foundry_version#nightly-}" > /dev/null; then
-      encourage_dev_container
       echo "$tool not in PATH or incorrect version (requires $foundry_version)."
-      echo "Installation: https://book.getfoundry.sh/getting-started/installation"
-      echo "  curl -L https://foundry.paradigm.xyz | bash"
-      echo "  foundryup -i $foundry_version"
-      exit 1
+      if [ "${CI:-0}" -eq 1 ]; then
+        echo "Attempting install of required foundry version $foundry_version"
+        curl -L https://foundry.paradigm.xyz | bash
+        ~/.foundry/bin/foundryup -i $foundry_version
+      else
+        encourage_dev_container
+        echo "Installation: https://book.getfoundry.sh/getting-started/installation"
+        echo "  curl -L https://foundry.paradigm.xyz | bash"
+        echo "  foundryup -i $foundry_version"
+        exit 1
+      fi
     fi
   done
   # Check Node.js version.

--- a/build-images/src/Dockerfile
+++ b/build-images/src/Dockerfile
@@ -66,7 +66,7 @@ RUN git clone https://github.com/tpoechtrager/osxcross.git \
 ########################################################################################################################
 # Build foundry.
 FROM base-build AS foundry
-ENV FOUNDRY_VERSION=nightly-99634144b6c9371982dcfc551a7975c5dbf9fad8
+ENV FOUNDRY_VERSION=v1.3.3
 ENV FOUNDRY_BIN_DIR="/root/.foundry/bin"
 ENV RUSTUP_HOME=/opt/rust/rustup
 ENV CARGO_HOME=/opt/rust/cargo


### PR DESCRIPTION
We're getting flakes in tests where we fail to retrieve the receipt for a tx that has just been mined:
- http://ci.aztec-labs.com/44f98153615cd923
- http://ci.aztec-labs.com/a9a71ad5de32f6c6

These are consistent with [this anvil issue](https://github.com/foundry-rs/foundry/issues/10944) reported on and fixed on early July. We were using a [foundry version from June](https://github.com/foundry-rs/foundry/releases?q=nightly-99634144b6c9371982dcfc551a7975c5dbf9fad8&expanded=true). This PR bumps to the latest release so we include the fix.