### PR TITLE
chore: refactor avm tx execution to generate "empty phase" events

### DIFF
--- a/barretenberg/cpp/src/barretenberg/vm2/common/aztec_types.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/common/aztec_types.hpp
@@ -29,6 +29,7 @@ enum TransactionPhase {
     COLLECT_GAS_FEES = 10,
     TREE_PADDING = 11,
     CLEANUP = 12,
+    LAST = CLEANUP,
 };
 
 using InternalCallId = uint32_t;

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/events/tx_events.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/events/tx_events.hpp
@@ -48,12 +48,15 @@ struct PadTreesEvent {};
 
 struct CleanupEvent {};
 
+struct EmptyPhaseEvent {};
+
 using TxPhaseEventType = std::variant<EnqueuedCallEvent,
                                       PrivateAppendTreeEvent,
                                       PrivateEmitL2L1MessageEvent,
                                       CollectGasFeeEvent,
                                       PadTreesEvent,
-                                      CleanupEvent>;
+                                      CleanupEvent,
+                                      EmptyPhaseEvent>;
 
 struct TxPhaseEvent {
     TransactionPhase phase;

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/tx_execution.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/tx_execution.hpp
@@ -66,6 +66,8 @@ class TxExecution final {
     void pad_trees();
 
     void cleanup();
+
+    void emit_empty_phase(TransactionPhase phase);
 };
 
 } // namespace bb::avm2::simulation

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/tx_trace.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/tx_trace.cpp
@@ -28,7 +28,7 @@ template <class... Ts> struct overloaded : Ts... {
 // explicit deduction guide (not needed as of C++20)
 template <class... Ts> overloaded(Ts...) -> overloaded<Ts...>;
 
-constexpr size_t NUM_PHASES = 12; // See TransactionPhase enum
+constexpr size_t NUM_PHASES = static_cast<size_t>(TransactionPhase::LAST);
 
 bool is_revertible(TransactionPhase phase)
 {
@@ -529,7 +529,6 @@ void TxTraceBuilder::process(const simulation::EventEmitterInterface<simulation:
 
     // This is the tree state we will use during the "skipped" phases
     TxContextEvent propagated_state = startup_event_data.state;
-    TxContextEvent end_setup_snapshot = startup_event_data.state;
     // Used to track the gas limit for the "padded" phases.
     Gas current_gas_limit = startup_event_data.gas_limit;
     Gas teardown_gas_limit = startup_event_data.teardown_gas_limit;
@@ -538,6 +537,12 @@ void TxTraceBuilder::process(const simulation::EventEmitterInterface<simulation:
     // Go through each phase except startup and process the events in the phase
     for (uint32_t i = 0; i < NUM_PHASES; i++) {
         const auto& phase_events = phase_buckets[i];
+        if (phase_events.empty()) {
+            // There will be no events for a phase if it is skipped (jumped over) due to a revert.
+            // This is different from a phase that has an EmptyPhaseEvent, which is a phase that has no contents to
+            // process, like when app logic starts but has no enqueued calls.
+            continue;
+        }
 
         TransactionPhase phase = phase_array[i];
 
@@ -555,24 +560,6 @@ void TxTraceBuilder::process(const simulation::EventEmitterInterface<simulation:
             current_gas_limit = teardown_gas_limit;
         }
 
-        if (phase_events.empty()) {
-            trace.set(row, insert_state(propagated_state, propagated_state));
-            trace.set(row, handle_padded_row(phase, gas_used, discard));
-            trace.set(row, handle_pi_read(phase, /*phase_length=*/0, /*read_counter*/ 0));
-            trace.set(row, handle_prev_gas_used(gas_used));
-            trace.set(row, handle_next_gas_used(gas_used));
-            trace.set(row, handle_gas_limit(current_gas_limit));
-            trace.set(row, handle_state_change_selectors(phase));
-            if (row == 1) {
-                trace.set(row, handle_first_row());
-            }
-            if (phase == TransactionPhase::SETUP) {
-                // If setup is empty, the end-setup-snapshot should just be current/propagated state
-                end_setup_snapshot = propagated_state;
-            }
-            row++;
-            continue;
-        }
         // Count the number of steps in this phase
         uint32_t phase_counter = 0;
         uint32_t phase_length = static_cast<uint32_t>(phase_events.size());
@@ -591,7 +578,7 @@ void TxTraceBuilder::process(const simulation::EventEmitterInterface<simulation:
                     { C::tx_discard, discard ? 1 : 0 },
                     { C::tx_phase_value, static_cast<uint8_t>(tx_phase_event->phase) },
                     { Column::tx_setup_phase_value, static_cast<uint8_t>(TransactionPhase::SETUP) },
-                    { C::tx_is_padded, 0 },
+                    { C::tx_is_padded, 0 }, // overidden below if this is a skipped phase event
                     { C::tx_start_phase, phase_counter == 0 ? 1 : 0 },
                     { C::tx_sel_read_phase_length, phase_counter == 0 && !is_one_shot_phase(tx_phase_event->phase) },
                     { C::tx_is_revertible, is_revertible(tx_phase_event->phase) ? 1 : 0 },
@@ -640,40 +627,23 @@ void TxTraceBuilder::process(const simulation::EventEmitterInterface<simulation:
                             [&](const simulation::CleanupEvent&) {
                                 trace.set(row, handle_pi_read(tx_phase_event->phase, 1, 0));
                                 trace.set(row, handle_cleanup());
+                            },
+                            [&](const simulation::EmptyPhaseEvent&) {
+                                // EmptyPhaseEvent represents a phase that is not explicitly skipped because of a
+                                // revert, but just has no contents to process, like when app logic starts but has no
+                                // enqueued calls.
+                                trace.set(row, handle_pi_read(tx_phase_event->phase, 0, 0));
+                                trace.set(row, handle_padded_row(tx_phase_event->phase, gas_used, discard));
                             } },
                 tx_phase_event->event);
             trace.set(row, handle_next_gas_used(gas_used));
             trace.set(row, handle_gas_limit(current_gas_limit));
 
-            // Handle a potential phase jump due to a revert, we dont need to check if we are in a revertible phase
-            // since our witgen will have exited for any reverts in a non-revertible phase.
-            // If we revert in a phase that isnt TEARDOWN, we jump to TEARDOWN
-            if (tx_phase_event->reverted && tx_phase_event->phase != TransactionPhase::TEARDOWN) {
-                // Jump to the TEARDOWN phase
-                // we need to -2 because of the loop increment and because the enum is 1-indexed
-                i = static_cast<uint8_t>(TransactionPhase::TEARDOWN) - 2;
-            }
             phase_counter++;
             row++;
         }
         // In case we encounter another skip row
         propagated_state = phase_events.back()->state_after;
-
-        if (phase == TransactionPhase::SETUP) {
-            // Store off the state at the end of setup to rollback to later on revert
-            end_setup_snapshot = phase_events.back()->state_after;
-        }
-        if (phase_events.back()->reverted) {
-            // On revert, roll back to end-setup-snapshot
-            // Even though tx-execution events should already do this,
-            // we need to update propagated state here so that any padded rows
-            // get the correct rolled-back state rather then the pre-rollback state.
-            propagated_state.tree_states = end_setup_snapshot.tree_states;
-            propagated_state.written_public_data_slots_tree_snapshot =
-                end_setup_snapshot.written_public_data_slots_tree_snapshot;
-            propagated_state.side_effect_states = end_setup_snapshot.side_effect_states;
-            // Note: we only rollback tree/side-effect states, not gas used or next_context_id.
-        }
     }
 }
 

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/tx_trace.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/tx_trace.test.cpp
@@ -53,24 +53,10 @@ TEST(TxTraceGenTest, EnqueuedCallEvent)
 
     builder.process({ startup_event, tx_event }, trace);
     auto rows = trace.as_rows();
-    ASSERT_EQ(rows.size(), 13); // 12 tx trace rows + 1 precomputed row
-    EXPECT_THAT(rows[static_cast<uint8_t>(TransactionPhase::NR_NOTE_INSERTION)],
-                AllOf(ROW_FIELD_EQ(tx_sel, 1),
-                      ROW_FIELD_EQ(tx_phase_value, static_cast<uint8_t>(TransactionPhase::NR_NOTE_INSERTION)),
-                      ROW_FIELD_EQ(tx_is_padded, 1),
-                      ROW_FIELD_EQ(tx_is_tree_insert_phase, 1),
-                      ROW_FIELD_EQ(tx_sel_non_revertible_append_note_hash, 1),
-                      ROW_FIELD_EQ(
-                          tx_read_pi_length_offset,
-                          AVM_PUBLIC_INPUTS_PREVIOUS_NON_REVERTIBLE_ACCUMULATED_DATA_ARRAY_LENGTHS_NOTE_HASHES_ROW_IDX),
-                      ROW_FIELD_EQ(tx_read_pi_offset,
-                                   AVM_PUBLIC_INPUTS_PREVIOUS_NON_REVERTIBLE_ACCUMULATED_DATA_NOTE_HASHES_ROW_IDX),
-                      ROW_FIELD_EQ(tx_start_phase, 1),
-                      ROW_FIELD_EQ(tx_end_phase, 1),
-                      ROW_FIELD_EQ(tx_is_static, false)));
+    ASSERT_EQ(rows.size(), 2); // 0th precomputed, setup
 
     // Setup
-    EXPECT_THAT(rows[static_cast<uint8_t>(TransactionPhase::SETUP)],
+    EXPECT_THAT(rows[1],
                 AllOf(ROW_FIELD_EQ(tx_sel, 1),
                       ROW_FIELD_EQ(tx_phase_value, static_cast<uint8_t>(TransactionPhase::SETUP)),
                       ROW_FIELD_EQ(tx_start_phase, 1),
@@ -83,7 +69,8 @@ TEST(TxTraceGenTest, EnqueuedCallEvent)
                       ROW_FIELD_EQ(tx_msg_sender, msg_sender),
                       ROW_FIELD_EQ(tx_contract_addr, contract_address),
                       ROW_FIELD_EQ(tx_calldata_hash, calldata_hash),
-                      ROW_FIELD_EQ(tx_end_phase, 1)));
+                      ROW_FIELD_EQ(tx_end_phase, 1),
+                      ROW_FIELD_EQ(tx_is_static, false)));
 };
 
 TEST(TxTraceGenTest, CollectFeeEvent)
@@ -121,9 +108,9 @@ TEST(TxTraceGenTest, CollectFeeEvent)
 
     builder.process({ startup_event, tx_event }, trace);
     auto rows = trace.as_rows();
-    ASSERT_EQ(rows.size(), 13); // 12 tx trace rows + 1 precomputed row
+    ASSERT_EQ(rows.size(), 2); // 0th precomputed, collect-gas-fees
 
-    EXPECT_THAT(rows[static_cast<uint8_t>(TransactionPhase::COLLECT_GAS_FEES)],
+    EXPECT_THAT(rows[1],
                 AllOf(ROW_FIELD_EQ(tx_sel, 1),
                       ROW_FIELD_EQ(tx_phase_value, static_cast<uint8_t>(TransactionPhase::COLLECT_GAS_FEES)),
                       ROW_FIELD_EQ(tx_is_padded, 0),
@@ -203,9 +190,9 @@ TEST(TxTraceGenTest, PadTreesEvent)
 
     builder.process({ startup_event, tx_event }, trace);
     auto rows = trace.as_rows();
-    ASSERT_EQ(rows.size(), 13); // 12 tx trace rows + 1 precomputed row
+    ASSERT_EQ(rows.size(), 2); // 0th precomputed, tree-padding
 
-    EXPECT_THAT(rows[static_cast<uint8_t>(TransactionPhase::TREE_PADDING)],
+    EXPECT_THAT(rows[1],
                 AllOf(ROW_FIELD_EQ(tx_sel, 1),
                       ROW_FIELD_EQ(tx_phase_value, static_cast<uint8_t>(TransactionPhase::TREE_PADDING)),
                       ROW_FIELD_EQ(tx_start_phase, 1),
@@ -246,10 +233,10 @@ TEST(TxTraceGenTest, CleanupEvent)
 
     builder.process({ startup_event, tx_event }, trace);
     auto rows = trace.as_rows();
-    ASSERT_EQ(rows.size(), 13); // 12 tx trace rows + 1 precomputed row
+    ASSERT_EQ(rows.size(), 2); // 0th precomputed, cleanup
 
     EXPECT_THAT(
-        rows[static_cast<uint8_t>(TransactionPhase::CLEANUP)],
+        rows[1],
         AllOf(ROW_FIELD_EQ(tx_sel, 1),
               ROW_FIELD_EQ(tx_phase_value, static_cast<uint8_t>(TransactionPhase::CLEANUP)),
               ROW_FIELD_EQ(tx_start_phase, 1),

--- a/yarn-project/bb-prover/src/avm_proving_tests/avm_check_circuit2.test.ts
+++ b/yarn-project/bb-prover/src/avm_proving_tests/avm_check_circuit2.test.ts
@@ -69,6 +69,34 @@ describe('AVM check-circuit – unhappy paths 2', () => {
     );
   });
 
+  it('error during revertible insertions - skips to teardown', async () => {
+    await tester.simProveVerify(
+      sender,
+      /*setupCalls=*/ [],
+      /*appCalls=*/ [
+        {
+          address: avmTestContractInstance.address,
+          fnName: 'add_args_return',
+          args: [new Fr(1), new Fr(2)],
+          contractArtifact: AvmTestContractArtifact,
+        },
+      ],
+      /*teardownCall=*/ {
+        address: avmTestContractInstance.address,
+        fnName: 'add_args_return',
+        args: [new Fr(1), new Fr(2)],
+        contractArtifact: AvmTestContractArtifact,
+      },
+      /*expectRevert=*/ true,
+      /*feePayer=*/ sender,
+      // duplicate nullifiers during revertible insertions!
+      /*privateInsertions=*/ {
+        revertible: { nullifiers: [new Fr(100_000), /*duplicate*/ new Fr(100_000)] },
+        nonRevertible: { nullifiers: [/*firstNullifier=*/ new Fr(66000)] },
+      },
+    );
+  });
+
   it(
     'enqueued calls in every phase, with enqueued calls that depend on each other',
     async () => {


### PR DESCRIPTION
This simplifies tracegen so that it doesn't need to know about setup snapshots and rollbacks anymore, doesn't need special handling for situations when a phase is empty, and omits rows for phases skipped due to reverts.

Note that there are two different relevant scenarios:
1. A phase is just "empty". The phase is encountered normally, but has no contents, like when there are no revertible nullifiers to insert, or when app logic has no enqueued calls to execute. **In this case, the phase gets a padding row**.
2. A phase is "skipped" entirely because of a revert. Like if revertible nullifier insertions fail, app-logic won't ever be encountered. **In this case, app-logic doesn't even get a row.**

This PR specifically generates events for scenario 1, when a phase is encountered, but "empty". This "empty" event drives tracegen of a "padding" row.

Creation of an event that drives padding rows means that tracegen no longer needs to know about setup snapshots and rollbacks to ensure that a padding row after a revert gets the post-revert state! Because now the post-revert state will be in the `EmptyPhaseEvent`, so tracegen can just generate a row from the phase event as it does for other rows.

Also note that this now lets us easily differentiate between "empty" phases versus skipped phases. Now, in tracegen, if a phase has no events, it means that it was _skipped_ because if it was "empty" in simulation, it would've generated an `EmptyPhaseEvent`. So, this PR also stops generating padding rows for _skipped_ phases, which was the originally intended mechanism proposed by @IlyasRidhuan, but it was not implemented that way.