### PR TITLE
Fix bbup installation instructions

### DIFF
--- a/barretenberg/bbup/README.md
+++ b/barretenberg/bbup/README.md
@@ -9,11 +9,11 @@ It assumes you are using [Noir](https://noir-lang.org) as the frontend language.
 BBup is an installer for whatever version of BB you may want. Install BBup with:
 
 ```bash
-curl -L https://raw.githubusercontent.com/AztecProtocol/aztec-packages/refs/heads/master/barretenberg/bbup/install | bash
+curl -L https://raw.githubusercontent.com/AztecProtocol/aztec-packages/refs/heads/next/barretenberg/bbup/install | bash
 ```
 
 > [!IMPORTANT]
-> *Always* check what scripts do. The above one redirects to [the install script](https://github.com/AztecProtocol/aztec-packages/blob/master/barretenberg/bbup/install) which installs [bbup](https://github.com/AztecProtocol/aztec-packages/blob/master/barretenberg/bbup/bbup) in your system's PATH
+> *Always* check what scripts do. The above one redirects to [the install script](https://github.com/AztecProtocol/aztec-packages/blob/next/barretenberg/bbup/install) which installs [bbup](https://github.com/AztecProtocol/aztec-packages/blob/next/barretenberg/bbup/bbup) in your system's PATH
 
 ## Usage
 


### PR DESCRIPTION
The current instruction don't fetch from the latest bbup which leads to the following error:
```
Querying noir version from nargo
✓ Resolved noir version 1.0.0-beta.11 from nargo
Getting compatible barretenberg version for noir version 1.0.0-beta.11
✓ Resolved to barretenberg version null
Installing to /home/user/.bb
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (22) The requested URL returned error: 404
```
Changing the the branch to next fixes it.

Please read [contributing guidelines](CONTRIBUTING.md) and remove this line.

For audit-related pull requests, please use the [audit PR template](?expand=1&template=audit.md).
