### PR TITLE
docs: fix broken link in Noir testing documentation

### DIFF
--- a/docs/docs/developers/guides/smart_contracts/testing.md
+++ b/docs/docs/developers/guides/smart_contracts/testing.md
@@ -16,7 +16,7 @@ Noir supports the `#[test]` annotation which can be used to write simple logic t
 
 #include_code pure_noir_testing /noir-projects/noir-contracts/contracts/app/card_game_contract/src/cards.nr rust
 
-To learn more about Noir testing, please refer to [the Noir docs](https://Noir-lang.org/docs/tooling/testing/).
+To learn more about Noir testing, please refer to [the Noir docs](https://Noir-lang.org/docs/tooling/tests/).
 
 ## TXE (pronounced "trixie")
 


### PR DESCRIPTION
I found that the link to the Noir docs in the [testing section](https://docs.aztec.network/developers/guides/smart_contracts/testing) was broken, leading to a “Page Not Found” error. Now, I updated it to point to the correct page.