### PR TITLE
fix: secp256k1 ecdsa mul handling of stagger point additions

### DIFF
--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_secp256k1.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_secp256k1.hpp
@@ -108,8 +108,9 @@ element<C, Fq, Fr, G> element<C, Fq, Fr, G>::secp256k1_ecdsa_mul(const element& 
     const auto& add_1 = endoP1_table[u1_hi_wnaf.least_significant_wnaf_fragment];
     const auto& add_2 = endoP2_table[u2_hi_wnaf.least_significant_wnaf_fragment];
     const auto& add_3 = P1_table[u1_lo_wnaf.least_significant_wnaf_fragment];
-    accumulator = element::chain_add_end(
-        element::chain_add(add_3, element::chain_add(add_2, element::chain_add_start(accumulator, add_1))));
+    accumulator += add_1;
+    accumulator += add_2;
+    accumulator += add_3;
 
     /**
      * Handle wNAF skew.


### PR DESCRIPTION
Fixes the issue found by @federicobarbacovi  in `secp256k1_ecdsa_mul`. The issue was that while adding the stagger points, we were using incomplete addition formula (via `chain_add_start`, `chain_add`, `chain_add_end` functions). This leads to unsatisfiable circuit for certain sets of scalars $s_1, u_1, u_2 \in \mathbb{F}_r$ such that:

1. the public key is computed as $P = s_1 \cdot G$ for generator $G \in \mathbb{G}$
2. $u_1 \cdot G + u_2 \cdot P = \mathcal{O}$

where $\mathcal{O}$ is the point at infinity. In particular, when the skew terms of each of the scalars $u_{1, \textsf{low}}, u_{1, \textsf{high}}, u_{2, \textsf{low}}, u_{2, \textsf{high}}$ is 0, we know that the accumulator would reach the point at infinity before handling any skew terms. In this case, that happens when performing point additions due to the stagger terms. We know the stagger offsets of the scalars are set as:

| Term        | Stagger bits | Point to add |
|-------------|--------------|-------------|
| $u_{1, \textsf{low}}$      | 2            | $P_3 := 2G$  |
|$u_{1, \textsf{high}}$     | 3            | $P_1 := 3λG$ |
|$u_{2, \textsf{low}}$      | 0            | —           |
| $u_{2, \textsf{high}}$     | 1            | $P_2 := λG$  |

For the regression test case in this PR, we first add $P_1, P_2$: 
$A \longleftarrow (A +P_1)$
$A \longleftarrow (A + P_2)$
While adding $P_3$, we reach the point at infinity: $A + P_3 = \mathcal{O}$. To fix this, we simply use complete addition formula for adding each of $P_1, P_2, P_3$. This increases the circuit size for `secp256k1_ecdsa_mul` by 730 gates ($\approx 2$ percent increase in circuit size from 39957 to 40687 gates).  


