### PR TITLE
fix: Do not send slashing vote if computed vote is zero

### DIFF
--- a/yarn-project/slasher/src/empire_slasher_client.test.ts
+++ b/yarn-project/slasher/src/empire_slasher_client.test.ts
@@ -48,6 +48,7 @@ describe('EmpireSlasherClient', () => {
     l1StartBlock: 0n,
     slotDuration: 4,
     ethereumSlotDuration: 12,
+    slashingAmounts: undefined,
   };
 
   const config: SlasherConfig = {

--- a/yarn-project/slasher/src/factory/create_implementation.ts
+++ b/yarn-project/slasher/src/factory/create_implementation.ts
@@ -93,6 +93,7 @@ async function createEmpireSlasher(
     slotDuration: Number(slotDuration),
     l1StartBlock,
     ethereumSlotDuration: config.ethereumSlotDuration,
+    slashingAmounts: undefined,
   };
 
   const payloadsStore = new SlasherPayloadsStore(kvStore, {

--- a/yarn-project/slasher/src/slash_offenses_collector.test.ts
+++ b/yarn-project/slasher/src/slash_offenses_collector.test.ts
@@ -21,6 +21,7 @@ describe('SlashOffensesCollector', () => {
 
   const settings: SlashOffensesCollectorSettings = {
     epochDuration: 32,
+    slashingAmounts: [100n, 200n, 300n],
   };
 
   const config: SlasherConfig = {

--- a/yarn-project/slasher/src/tally_slasher_client.ts
+++ b/yarn-project/slasher/src/tally_slasher_client.ts
@@ -292,6 +292,17 @@ export class TallySlasherClient implements ProposerSlashActionProvider, SlasherC
 
     const committees = await this.collectCommitteesActiveDuringRound(slashedRound);
     const votes = getSlashConsensusVotesFromOffenses(offensesToSlash, committees, this.settings);
+    if (votes.every(v => v === 0)) {
+      this.log.warn(`Computed votes for offenses are all zero. Skipping vote.`, {
+        slotNumber,
+        currentRound,
+        slashedRound,
+        offensesToSlash,
+        committees,
+      });
+      return undefined;
+    }
+
     this.log.debug(`Computed votes for slashing ${offensesToSlash.length} offenses`, {
       slashedRound,
       currentRound,


### PR DESCRIPTION
Fixes https://linear.app/aztec-labs/issue/TMNT-231/inconsistent-voting-empty-votes

Also adds a warning in the offenses collector if the offense amount is below the minimum slash.
