### PR TITLE
feat: add storage budget control for FileBackedMemory

### DIFF
--- a/barretenberg/cpp/src/barretenberg/api/api.hpp
+++ b/barretenberg/cpp/src/barretenberg/api/api.hpp
@@ -22,6 +22,7 @@ class API {
         bool write_vk{ false };    // should we addditionally write the verification key when writing the proof
         bool include_gates_per_opcode{ false }; // should we include gates_per_opcode in the gates command output
         bool slow_low_memory{ false };          // use file backed memory for polynomials
+        size_t storage_budget_gb{ 0 };          // storage budget in GB for file backed memory (0 = no limit)
         bool update_inputs{ false };            // update inputs when check fails
 
         bool optimized_solidity_verifier{ false }; // should we use the optimized sol verifier? (temp)
@@ -40,6 +41,7 @@ class API {
                << "  write_vk " << flags.write_vk << "\n"
                << "  include_gates_per_opcode " << flags.include_gates_per_opcode << "\n"
                << "  slow_low_memory " << flags.slow_low_memory << "\n"
+               << "  storage_budget_gb " << flags.storage_budget_gb << "\n"
                << "]" << std::endl;
             return os;
         }

--- a/barretenberg/cpp/src/barretenberg/api/api.hpp
+++ b/barretenberg/cpp/src/barretenberg/api/api.hpp
@@ -22,7 +22,7 @@ class API {
         bool write_vk{ false };    // should we addditionally write the verification key when writing the proof
         bool include_gates_per_opcode{ false }; // should we include gates_per_opcode in the gates command output
         bool slow_low_memory{ false };          // use file backed memory for polynomials
-        size_t storage_budget_gb{ 0 };          // storage budget in GB for file backed memory (0 = no limit)
+        std::string storage_budget;             // storage budget for file backed memory (e.g. "500m", "2g")
         bool update_inputs{ false };            // update inputs when check fails
 
         bool optimized_solidity_verifier{ false }; // should we use the optimized sol verifier? (temp)
@@ -41,7 +41,7 @@ class API {
                << "  write_vk " << flags.write_vk << "\n"
                << "  include_gates_per_opcode " << flags.include_gates_per_opcode << "\n"
                << "  slow_low_memory " << flags.slow_low_memory << "\n"
-               << "  storage_budget_gb " << flags.storage_budget_gb << "\n"
+               << "  storage_budget " << flags.storage_budget << "\n"
                << "]" << std::endl;
             return os;
         }

--- a/barretenberg/cpp/src/barretenberg/bb/cli.cpp
+++ b/barretenberg/cpp/src/barretenberg/bb/cli.cpp
@@ -265,6 +265,13 @@ int parse_and_run_cli_command(int argc, char* argv[])
             "--slow_low_memory", flags.slow_low_memory, "Enable low memory mode (can be 2x slower or more).");
     };
 
+    const auto add_storage_budget_option = [&](CLI::App* subcommand) {
+        return subcommand->add_option("--storage_budget_gb",
+                                      flags.storage_budget_gb,
+                                      "Storage budget in GB for FileBackedMemory. When exceeded, falls back to RAM "
+                                      "(requires --slow_low_memory).");
+    };
+
     const auto add_update_inputs_flag = [&](CLI::App* subcommand) {
         return subcommand->add_flag("--update_inputs", flags.update_inputs, "Update inputs if vk check fails.");
     };
@@ -345,6 +352,7 @@ int parse_and_run_cli_command(int argc, char* argv[])
     add_slow_low_memory_flag(prove);
     add_print_bench_flag(prove);
     add_bench_out_option(prove);
+    add_storage_budget_option(prove);
 
     prove->add_flag("--verify", "Verify the proof natively, resulting in a boolean output. Useful for testing.");
 
@@ -550,6 +558,9 @@ int parse_and_run_cli_command(int argc, char* argv[])
     debug_logging = flags.debug;
     verbose_logging = debug_logging || flags.verbose;
     slow_low_memory = flags.slow_low_memory;
+    if (flags.storage_budget_gb > 0) {
+        storage_budget = flags.storage_budget_gb * 1024ULL * 1024ULL * 1024ULL;
+    }
 #ifndef __wasm__
     if (print_bench || !bench_out.empty()) {
         bb::detail::use_bb_bench = true;

--- a/barretenberg/cpp/src/barretenberg/bb/cli.cpp
+++ b/barretenberg/cpp/src/barretenberg/bb/cli.cpp
@@ -266,10 +266,10 @@ int parse_and_run_cli_command(int argc, char* argv[])
     };
 
     const auto add_storage_budget_option = [&](CLI::App* subcommand) {
-        return subcommand->add_option("--storage_budget_gb",
-                                      flags.storage_budget_gb,
-                                      "Storage budget in GB for FileBackedMemory. When exceeded, falls back to RAM "
-                                      "(requires --slow_low_memory).");
+        return subcommand->add_option("--storage_budget",
+                                      flags.storage_budget,
+                                      "Storage budget for FileBackedMemory (e.g. '500m', '2g'). When exceeded, falls "
+                                      "back to RAM (requires --slow_low_memory).");
     };
 
     const auto add_update_inputs_flag = [&](CLI::App* subcommand) {
@@ -558,8 +558,8 @@ int parse_and_run_cli_command(int argc, char* argv[])
     debug_logging = flags.debug;
     verbose_logging = debug_logging || flags.verbose;
     slow_low_memory = flags.slow_low_memory;
-    if (flags.storage_budget_gb > 0) {
-        storage_budget = flags.storage_budget_gb * 1024ULL * 1024ULL * 1024ULL;
+    if (!flags.storage_budget.empty()) {
+        storage_budget = parse_size_string(flags.storage_budget);
     }
 #ifndef __wasm__
     if (print_bench || !bench_out.empty()) {

--- a/barretenberg/cpp/src/barretenberg/polynomials/backing_memory.cpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/backing_memory.cpp
@@ -10,6 +10,9 @@
 bool slow_low_memory =
     std::getenv("BB_SLOW_LOW_MEMORY") == nullptr ? false : std::string(std::getenv("BB_SLOW_LOW_MEMORY")) == "1";
 
+// Storage budget is disabled for WASM builds
+#ifndef __wasm__
+
 // Parse storage size string (e.g., "500m", "2g", "1024k")
 size_t parse_size_string(const std::string& size_str)
 {
@@ -71,3 +74,5 @@ size_t storage_budget = parse_storage_budget();
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 std::atomic<size_t> current_storage_usage{ 0 };
+
+#endif // __wasm__

--- a/barretenberg/cpp/src/barretenberg/polynomials/backing_memory.cpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/backing_memory.cpp
@@ -1,27 +1,70 @@
 #include "barretenberg/polynomials/backing_memory.hpp"
+#include "barretenberg/common/throw_or_abort.hpp"
 #include <atomic>
+#include <cctype>
 #include <cstdlib>
 #include <limits>
+#include <string>
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 bool slow_low_memory =
     std::getenv("BB_SLOW_LOW_MEMORY") == nullptr ? false : std::string(std::getenv("BB_SLOW_LOW_MEMORY")) == "1";
 
-// Parse storage budget from environment variable (in GB)
-static size_t parse_storage_budget()
+// Parse storage size string (e.g., "500m", "2g", "1024k")
+size_t parse_size_string(const std::string& size_str)
 {
-    const char* env_val = std::getenv("BB_STORAGE_BUDGET_GB");
+    if (size_str.empty()) {
+        return std::numeric_limits<size_t>::max();
+    }
+
+    try {
+        std::string str = size_str;
+
+        // Convert to lowercase for case-insensitive comparison
+        char suffix = static_cast<char>(std::tolower(static_cast<unsigned char>(str.back())));
+        size_t multiplier = 1;
+
+        // Check for unit suffix
+        if (suffix == 'k') {
+            multiplier = 1024ULL;
+            str.pop_back();
+        } else if (suffix == 'm') {
+            multiplier = 1024ULL * 1024ULL;
+            str.pop_back();
+        } else if (suffix == 'g') {
+            multiplier = 1024ULL * 1024ULL * 1024ULL;
+            str.pop_back();
+        } else if (std::isdigit(static_cast<unsigned char>(suffix)) == 0) {
+            // Invalid suffix
+            throw_or_abort("Invalid storage size format: '" + size_str + "'. Use format like '500m', '2g', or '1024k'");
+        }
+
+        // Check if remaining string is a valid number
+        if (str.empty()) {
+            throw_or_abort("Invalid storage size format: '" + size_str + "'. No numeric value provided");
+        }
+
+        size_t value = std::stoull(str);
+        return value * multiplier;
+    } catch (const std::invalid_argument&) {
+        throw_or_abort("Invalid storage size format: '" + size_str + "'. Not a valid number");
+    } catch (const std::out_of_range&) {
+        throw_or_abort("Invalid storage size format: '" + size_str + "'. Value out of range");
+    }
+}
+
+namespace {
+// Parse storage budget from environment variable (supports k/m/g suffixes like Docker)
+size_t parse_storage_budget()
+{
+    const char* env_val = std::getenv("BB_STORAGE_BUDGET");
     if (env_val == nullptr) {
         return std::numeric_limits<size_t>::max(); // No limit by default
     }
 
-    try {
-        size_t gb = std::stoull(env_val);
-        return gb * 1024ULL * 1024ULL * 1024ULL; // Convert GB to bytes
-    } catch (...) {
-        return std::numeric_limits<size_t>::max(); // Invalid value, no limit
-    }
+    return parse_size_string(std::string(env_val));
 }
+} // namespace
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 size_t storage_budget = parse_storage_budget();

--- a/barretenberg/cpp/src/barretenberg/polynomials/backing_memory.cpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/backing_memory.cpp
@@ -1,5 +1,30 @@
 #include "barretenberg/polynomials/backing_memory.hpp"
+#include <atomic>
+#include <cstdlib>
+#include <limits>
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 bool slow_low_memory =
     std::getenv("BB_SLOW_LOW_MEMORY") == nullptr ? false : std::string(std::getenv("BB_SLOW_LOW_MEMORY")) == "1";
+
+// Parse storage budget from environment variable (in GB)
+static size_t parse_storage_budget()
+{
+    const char* env_val = std::getenv("BB_STORAGE_BUDGET_GB");
+    if (env_val == nullptr) {
+        return std::numeric_limits<size_t>::max(); // No limit by default
+    }
+
+    try {
+        size_t gb = std::stoull(env_val);
+        return gb * 1024ULL * 1024ULL * 1024ULL; // Convert GB to bytes
+    } catch (...) {
+        return std::numeric_limits<size_t>::max(); // Invalid value, no limit
+    }
+}
+
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+size_t storage_budget = parse_storage_budget();
+
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+std::atomic<size_t> current_storage_usage{ 0 };

--- a/barretenberg/cpp/src/barretenberg/polynomials/backing_memory.hpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/backing_memory.hpp
@@ -21,6 +21,12 @@
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 extern bool slow_low_memory;
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+extern size_t storage_budget;
+
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+extern std::atomic<size_t> current_storage_usage;
+
 template <typename T> class AlignedMemory;
 
 #ifndef __wasm__
@@ -43,7 +49,22 @@ template <typename Fr> class BackingMemory {
     {
 #ifndef __wasm__
         if (slow_low_memory) {
-            return std::shared_ptr<BackingMemory<Fr>>(new FileBackedMemory<Fr>(size));
+            size_t required_bytes = size * sizeof(Fr);
+            size_t current_usage = current_storage_usage.load();
+
+            // Check if we're under the storage budget
+            if (current_usage + required_bytes <= storage_budget) {
+                // Try to use FileBackedMemory
+                try {
+                    auto result = std::shared_ptr<BackingMemory<Fr>>(new FileBackedMemory<Fr>(size));
+                    current_storage_usage.fetch_add(required_bytes);
+                    return result;
+                } catch (const std::exception& e) {
+                    // FileBackedMemory allocation failed, fall back to AlignedMemory
+                    return std::shared_ptr<BackingMemory<Fr>>(new AlignedMemory<Fr>(size));
+                }
+            }
+            // Over budget, use AlignedMemory
         }
 #endif
         return std::shared_ptr<BackingMemory<Fr>>(new AlignedMemory<Fr>(size));
@@ -87,6 +108,8 @@ template <typename T> class FileBackedMemory : public BackingMemory<T> {
         }
         if (memory != nullptr && file_size > 0) {
             munmap(memory, file_size);
+            // Decrement storage usage when FileBackedMemory is freed
+            current_storage_usage.fetch_sub(file_size);
         }
         if (fd >= 0) {
             close(fd);

--- a/barretenberg/cpp/src/barretenberg/polynomials/backing_memory.hpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/backing_memory.hpp
@@ -27,6 +27,9 @@ extern size_t storage_budget;
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 extern std::atomic<size_t> current_storage_usage;
 
+// Parse storage size string (e.g., "500m", "2g", "1024k")
+size_t parse_size_string(const std::string& size_str);
+
 template <typename T> class AlignedMemory;
 
 #ifndef __wasm__

--- a/barretenberg/cpp/src/barretenberg/polynomials/backing_memory.hpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/backing_memory.hpp
@@ -52,27 +52,38 @@ template <typename Fr> class BackingMemory {
     {
 #ifndef __wasm__
         if (slow_low_memory) {
-            size_t required_bytes = size * sizeof(Fr);
-            size_t current_usage = current_storage_usage.load();
-
-            // Check if we're under the storage budget
-            if (current_usage + required_bytes <= storage_budget) {
-                // Try to use FileBackedMemory
-                try {
-                    auto result = std::shared_ptr<BackingMemory<Fr>>(new FileBackedMemory<Fr>(size));
-                    current_storage_usage.fetch_add(required_bytes);
-                    return result;
-                } catch (const std::exception& e) {
-                    // FileBackedMemory allocation failed, fall back to AlignedMemory
-                    return std::shared_ptr<BackingMemory<Fr>>(new AlignedMemory<Fr>(size));
-                }
+            auto file_backed = try_allocate_file_backed(size);
+            if (file_backed) {
+                return file_backed;
             }
-            // Over budget, use AlignedMemory
         }
 #endif
         return std::shared_ptr<BackingMemory<Fr>>(new AlignedMemory<Fr>(size));
     }
 
+  private:
+#ifndef __wasm__
+    static std::shared_ptr<BackingMemory<Fr>> try_allocate_file_backed(size_t size)
+    {
+        size_t required_bytes = size * sizeof(Fr);
+        size_t current_usage = current_storage_usage.load();
+
+        // Check if we're under the storage budget
+        if (current_usage + required_bytes > storage_budget) {
+            return nullptr; // Over budget
+        }
+
+        // Attempt to create FileBackedMemory without exceptions
+        // We'll need to modify FileBackedMemory constructor to be noexcept
+        auto file_backed = FileBackedMemory<Fr>::try_create(size);
+        if (file_backed) {
+            current_storage_usage.fetch_add(required_bytes);
+        }
+        return file_backed;
+    }
+#endif
+
+  public:
     virtual ~BackingMemory() = default;
 };
 
@@ -104,6 +115,57 @@ template <typename T> class FileBackedMemory : public BackingMemory<T> {
 
     T* raw_data() { return memory; }
 
+    // Try to create file-backed memory, returns nullptr on failure
+    static std::shared_ptr<BackingMemory<T>> try_create(size_t size)
+    {
+        if (size == 0) {
+            return std::shared_ptr<BackingMemory<T>>(new FileBackedMemory<T>());
+        }
+
+        size_t file_size = size * sizeof(T);
+        static std::atomic<size_t> file_counter{ 0 };
+        size_t id = file_counter.fetch_add(1);
+
+        std::filesystem::path temp_dir;
+        try {
+            temp_dir = std::filesystem::temp_directory_path();
+        } catch (const std::exception&) {
+            // Fallback to current directory if temp_directory_path() fails
+            temp_dir = std::filesystem::current_path();
+        }
+
+        std::string filename = temp_dir / ("poly-mmap-" + std::to_string(getpid()) + "-" + std::to_string(id));
+
+        int fd = open(filename.c_str(), O_CREAT | O_RDWR | O_TRUNC, 0644);
+        if (fd < 0) {
+            return nullptr; // Failed to create file
+        }
+
+        // Set file size
+        if (ftruncate(fd, static_cast<off_t>(file_size)) != 0) {
+            close(fd);
+            std::filesystem::remove(filename);
+            return nullptr; // Failed to set file size
+        }
+
+        // Memory map the file
+        void* addr = mmap(nullptr, file_size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+        if (addr == MAP_FAILED) {
+            close(fd);
+            std::filesystem::remove(filename);
+            return nullptr; // Failed to mmap
+        }
+
+        // Create the FileBackedMemory object using private constructor
+        auto memory = new FileBackedMemory<T>();
+        memory->file_size = file_size;
+        memory->filename = filename;
+        memory->fd = fd;
+        memory->memory = static_cast<T*>(addr);
+
+        return std::shared_ptr<BackingMemory<T>>(memory);
+    }
+
     ~FileBackedMemory()
     {
         if (file_size == 0) {
@@ -123,46 +185,13 @@ template <typename T> class FileBackedMemory : public BackingMemory<T> {
     }
 
   private:
-    // Create a new file-backed memory region
-    FileBackedMemory(size_t size)
+    // Default constructor for empty file-backed memory
+    FileBackedMemory()
         : BackingMemory<T>()
-        , file_size(size * sizeof(T))
-    {
-        if (file_size == 0) {
-            return;
-        }
-
-        static std::atomic<size_t> file_counter{ 0 };
-        size_t id = file_counter.fetch_add(1);
-        std::filesystem::path temp_dir;
-        try {
-            temp_dir = std::filesystem::temp_directory_path();
-        } catch (const std::exception&) {
-            // Fallback to current directory if temp_directory_path() fails
-            temp_dir = std::filesystem::current_path();
-        }
-
-        filename = temp_dir / ("poly-mmap-" + std::to_string(getpid()) + "-" + std::to_string(id));
-
-        fd = open(filename.c_str(), O_CREAT | O_RDWR | O_TRUNC, 0644);
-        // Create file
-        if (fd < 0) {
-            throw_or_abort("Failed to create backing file: " + filename);
-        }
-
-        // Set file size
-        if (ftruncate(fd, static_cast<off_t>(file_size)) != 0) {
-            throw_or_abort("Failed to set file size");
-        }
-
-        // Memory map the file
-        void* addr = mmap(nullptr, file_size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
-        if (addr == MAP_FAILED) {
-            throw_or_abort("Failed to mmap file: " + std::string(std::strerror(errno)));
-        }
-
-        memory = static_cast<T*>(addr);
-    }
+        , file_size(0)
+        , fd(-1)
+        , memory(nullptr)
+    {}
 
     size_t file_size;
     std::string filename;

--- a/ci3/docker_isolate
+++ b/ci3/docker_isolate
@@ -6,6 +6,7 @@ NO_CD=1 source $(git rev-parse --show-toplevel)/ci3/source
 cmd=$1
 export CPUS=${CPUS:-2}
 export MEM=${MEM:-$((CPUS * 4))g}
+export TMPFS_SIZE=${TMPFS_SIZE:-1g}
 
 function cleanup {
   if [ -n "${cid:-}" ]; then
@@ -54,7 +55,7 @@ cid=$(docker run -d \
   --pid=host \
   --user $(id -u):$(id -g) \
   -v$HOME:$HOME \
-  --mount type=tmpfs,target=/tmp,tmpfs-size=1g \
+  --mount type=tmpfs,target=/tmp,tmpfs-size=$TMPFS_SIZE \
   --workdir $PWD \
   -e HOME \
   -e VERBOSE \
@@ -62,6 +63,7 @@ cid=$(docker run -d \
   -e FORCE_COLOR=true \
   -e CPUS \
   -e MEM \
+  -e TMPFS_SIZE \
   "${arg_env_vars[@]}" \
   aztecprotocol/build:3.0 \
   /bin/bash -c "$cmd")


### PR DESCRIPTION
# Add Storage Budget Control for FileBackedMemory

## Summary
This PR introduces a storage budget feature for `FileBackedMemory` to prevent out-of-memory errors in constrained environments. When the budget is exceeded, the system gracefully falls back to RAM allocation instead of failing.

## Problem
When running barretenberg with `BB_SLOW_LOW_MEMORY=1` in environments with limited tmpfs space (e.g., CI/CD pipelines, Docker containers), the program can crash with bus errors when FileBackedMemory attempts to allocate more space than available.

## Solution
- Added configurable storage budget that limits total FileBackedMemory usage
- Automatic fallback to RAM allocation when budget is exceeded
- Docker-style size format support (e.g., "500m", "2g", "1024k")
- Atomic tracking of current storage usage across all allocations

## Implementation Details

### Environment Variable
- `BB_STORAGE_BUDGET`: Set storage limit (e.g., `BB_STORAGE_BUDGET=2g`)
- Supports k/m/g suffixes like Docker memory limits
- Default: unlimited

### CLI Flag
- `--storage_budget`: Command-line option for bb tool
- Example: `bb prove --slow_low_memory --storage_budget 1g`

### How It Works
1. Tracks total FileBackedMemory usage with atomic counter
2. Before each allocation, checks if it would exceed budget
3. If within budget: allocates FileBackedMemory and increments counter
4. If over budget or allocation fails: falls back to AlignedMemory (RAM)
5. When FileBackedMemory is freed, decrements usage counter

### Error Handling
- Invalid format throws clear error: `"Invalid storage size format: 'xyz'. Use format like '500m', '2g', or '1024k'"`
- Validates numeric values and suffixes
- Handles overflow gracefully

## Testing
Tested with docker_isolate script to verify:
- System works correctly with various budget sizes
- Fallback to RAM occurs when budget exceeded
- No crashes when tmpfs is smaller than memory requirements
- Invalid formats are properly rejected

### Test Commands
```bash
# With 1GB storage budget
BB_STORAGE_BUDGET=1g CPUS=16 TMPFS_SIZE=2g MEM=16g ./ci3/docker_isolate \
  "BB_SLOW_LOW_MEMORY=1 ./barretenberg/cpp/build/bin/ultra_honk_bench --benchmark_filter=.*power_of_2.*/18"

# With 500MB storage budget  
BB_STORAGE_BUDGET=500m CPUS=16 TMPFS_SIZE=1g MEM=16g ./ci3/docker_isolate \
  "BB_SLOW_LOW_MEMORY=1 ./barretenberg/cpp/build/bin/ultra_honk_bench --benchmark_filter=.*power_of_2.*/17"
```

## Additional Changes
- Updated `ci3/docker_isolate` to accept `TMPFS_SIZE` parameter for easier testing
- Added reusable `parse_size_string()` function for consistent size parsing

## Benefits
- Prevents crashes in memory-constrained environments
- Allows fine-tuned control over disk/tmpfs usage
- Graceful degradation when resources are limited
- Better CI/CD reliability with predictable memory behavior

## Breaking Changes
None - feature is opt-in and defaults to unlimited (existing behavior)

## Checklist
- [x] Code compiles and passes existing tests
- [x] Tested with various storage budgets and tmpfs sizes
- [x] Error handling for invalid inputs
- [x] Code formatted with clang-format
- [x] No memory leaks (storage usage properly decremented on free)