### PR TITLE
chore: Set default log level of prover agent to verbose

### DIFF
--- a/spartan/aztec-network/values.yaml
+++ b/spartan/aztec-network/values.yaml
@@ -370,7 +370,7 @@ proverAgent:
   testDelayFactor: 1
   gke:
     spotEnabled: true
-  logLevel: "debug; info: aztec:simulator, json-rpc"
+  logLevel: "verbose; info: aztec:simulator, json-rpc"
   bb:
     hardwareConcurrency: ""
   maxOldSpaceSize: "4608"


### PR DESCRIPTION
> the avm is crushing the logging agent