### PR TITLE
chore: make the aes asserts static

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/messages/encryption/aes128.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/encryption/aes128.nr
@@ -208,7 +208,10 @@ impl LogEncryption for AES128 {
         //      = |full_pt| + 16 - (|full_pt| - 16 * (|full_pt| // 16))
         //      = 16 + 16 * (|full_pt| // 16)
         //      = 16 * (1 + |full_pt| // 16)
-        assert(ciphertext_bytes.len() == 16 * (1 + (PlaintextLen * 32) / 16));
+        std::static_assert(
+            ciphertext_bytes.len() == 16 * (1 + (PlaintextLen * 32) / 16),
+            "unexpected ciphertext length",
+        );
 
         // *****************************************************************************
         // Compute the header ciphertext
@@ -225,7 +228,10 @@ impl LogEncryption for AES128 {
         // bytes larger than the input in this case.
         let header_ciphertext_bytes = aes128_encrypt(header_plaintext, header_iv, header_sym_key);
         // I recall that converting a slice to an array incurs constraints, so I'll check the length this way instead:
-        assert(header_ciphertext_bytes.len() == HEADER_CIPHERTEXT_SIZE_IN_BYTES);
+        std::static_assert(
+            header_ciphertext_bytes.len() == HEADER_CIPHERTEXT_SIZE_IN_BYTES,
+            "unexpected ciphertext header length",
+        );
 
         // *****************************************************************************
         // Prepend / append more bytes of data to the ciphertext, before converting back
@@ -240,7 +246,7 @@ impl LogEncryption for AES128 {
 
         let mut log_bytes = get_arr_of_size__log_bytes__from_PT::<PlaintextLen * 32>();
 
-        assert(
+        std::static_assert(
             log_bytes.len() % 31 == 0,
             "Unexpected error: log_bytes.len() should be divisible by 31, by construction.",
         );
@@ -260,11 +266,22 @@ impl LogEncryption for AES128 {
         for i in 0..log_bytes_padding_to_mult_31.len() {
             log_bytes[offset + i] = log_bytes_padding_to_mult_31[i];
         }
+        offset += log_bytes_padding_to_mult_31.len();
 
-        assert(
-            offset + log_bytes_padding_to_mult_31.len() == log_bytes.len(),
-            "Something has gone wrong",
+        // Ideally we would be able to have a static assert where we check that the offset would be such that we've
+        // written to the entire log_bytes array, but we cannot since Noir does not treat the offset as a comptime
+        // value (despite the values that it goes through being known at each stage). We instead check that the
+        // computation used to obtain the offset computes the expected value (which we _can_ do in a static check), and
+        // then add a cheap runtime check to also validate that the offset matches this.
+        std::static_assert(
+            1
+                + header_ciphertext_bytes.len()
+                + ciphertext_bytes.len()
+                + log_bytes_padding_to_mult_31.len()
+                == log_bytes.len(),
+            "unexpected log length",
         );
+        assert(offset == log_bytes.len(), "unexpected encrypted log length");
 
         // *****************************************************************************
         // Convert bytes back to fields


### PR DESCRIPTION
These are all comptime values, and so the asserts would compile to either no-ops or unconditional panics. We want for them to be static, so that we find these things at compile time instead.