### PR TITLE
fix: Enforce timetable on proposer check

### DIFF
--- a/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
@@ -322,6 +322,7 @@ describe('sequencer', () => {
 
       expect(blockBuilder.buildBlock).not.toHaveBeenCalled();
       expect(publisher.enqueueProposeL2Block).not.toHaveBeenCalled();
+      expect(publisher.canProposeAtNextEthBlock).not.toHaveBeenCalled();
     });
 
     it('does not publish a block if it does not have enough time left in the slot after collecting attestations', async () => {

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.ts
@@ -267,12 +267,12 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
       return;
     }
 
-    this.setState(SequencerState.PROPOSER_CHECK, undefined);
-
     const chainTipArchive = syncedTo.archive;
     const newBlockNumber = syncedTo.blockNumber + 1;
 
     const { slot, ts, now } = this.epochCache.getEpochAndSlotInNextL1Slot();
+
+    this.setState(SequencerState.PROPOSER_CHECK, slot);
 
     // Check that the archiver and dependencies have synced to the previous L1 slot at least
     // TODO(#14766): Archiver reports L1 timestamp based on L1 blocks seen, which means that a missed L1 block will

--- a/yarn-project/sequencer-client/src/sequencer/utils.ts
+++ b/yarn-project/sequencer-client/src/sequencer/utils.ts
@@ -37,7 +37,8 @@ export type SequencerStateWithSlot =
   | SequencerState.INITIALIZING_PROPOSAL
   | SequencerState.CREATING_BLOCK
   | SequencerState.COLLECTING_ATTESTATIONS
-  | SequencerState.PUBLISHING_BLOCK;
+  | SequencerState.PUBLISHING_BLOCK
+  | SequencerState.PROPOSER_CHECK;
 
 export type SequencerStateCallback = () => SequencerState;
 


### PR DESCRIPTION
Fixes the fix from #16668. Since we were not passing the slot number into the `setState` call, the check was never done.
