### PR TITLE
chore: Pin next rc-1 bots to 8 core spots

### DIFF
--- a/spartan/aztec-network/templates/transaction-bot.yaml
+++ b/spartan/aztec-network/templates/transaction-bot.yaml
@@ -26,6 +26,10 @@ spec:
         {{- include "aztec-network.selectorLabels" . | nindent 8 }}
         app: bot
     spec:
+      {{- if .Values.bot.nodeSelector }}
+      nodeSelector:
+        {{- toYaml .Values.bot.nodeSelector | nindent 8 }}
+      {{- end }}
       {{- if and .Values.bot.gke.spotEnabled .Values.network.gke }}
       affinity:
         nodeAffinity:

--- a/spartan/aztec-network/values/rc-1.yaml
+++ b/spartan/aztec-network/values/rc-1.yaml
@@ -54,6 +54,8 @@ bot:
     requests:
       memory: 15Gi
       cpu: 7
+  nodeSelector:
+    cores: "8"
 
 web3signer:
   enabled: true

--- a/spartan/terraform/deploy-testnet/values/testnet-bot.yaml
+++ b/spartan/terraform/deploy-testnet/values/testnet-bot.yaml
@@ -27,6 +27,7 @@ bot:
   nodeSelector:
     local-ssd: "false"
     node-type: "network"
+    cores: "8"
 
   affinity:
     nodeAffinity:

--- a/spartan/terraform/gke-cluster/cluster/main.tf
+++ b/spartan/terraform/gke-cluster/cluster/main.tf
@@ -179,6 +179,7 @@ resource "google_container_node_pool" "spot_nodes_32core" {
       pool      = "spot"
       local-ssd = "false"
       node-type = "network"
+      cores     = "32"
     }
     tags = ["aztec-gke-node", "spot"]
 
@@ -224,6 +225,7 @@ resource "google_container_node_pool" "spot_nodes_8core" {
       pool      = "spot"
       local-ssd = "false"
       node-type = "network"
+      cores     = "8"
     }
     tags = ["aztec-gke-node", "spot"]
 


### PR DESCRIPTION
This PR sets labels on spots node pools and pins next rc-1 bots to 8 core machines.
