### PR TITLE
chore: Use nullish instead of optional in key store schema

### DIFF
--- a/yarn-project/node-keystore/src/schemas.ts
+++ b/yarn-project/node-keystore/src/schemas.ts
@@ -19,8 +19,8 @@ const remoteSignerConfigSchema = z.union([
   urlSchema,
   z.object({
     remoteSignerUrl: urlSchema,
-    certPath: z.string().optional(),
-    certPass: z.string().optional(),
+    certPath: z.string().nullish(),
+    certPass: z.string().nullish(),
   }),
 ]);
 
@@ -29,25 +29,25 @@ const remoteSignerAccountSchema = z.union([
   ethAddressSchema,
   z.object({
     address: ethAddressSchema,
-    remoteSignerUrl: urlSchema.optional(),
-    certPath: z.string().optional(),
-    certPass: z.string().optional(),
+    remoteSignerUrl: urlSchema.nullish(),
+    certPath: z.string().nullish(),
+    certPass: z.string().nullish(),
   }),
 ]);
 
 // JSON V3 keystore schema
 const jsonKeyFileV3Schema = z.object({
   path: z.string(),
-  password: z.string().optional(),
+  password: z.string().nullish(),
 });
 
 // Mnemonic config schema
 const mnemonicConfigSchema = z.object({
   mnemonic: z.string().min(1, 'Mnemonic cannot be empty'),
-  addressIndex: z.number().int().min(0).optional(),
-  accountIndex: z.number().int().min(0).optional(),
-  addressCount: z.number().int().min(1).optional(),
-  accountCount: z.number().int().min(1).optional(),
+  addressIndex: z.number().int().min(0).default(0),
+  accountIndex: z.number().int().min(0).default(0),
+  addressCount: z.number().int().min(1).default(1),
+  accountCount: z.number().int().min(1).default(1),
 });
 
 // EthAccount schema
@@ -73,8 +73,8 @@ const proverKeyStoreSchema = z.union([
 // Validator keystore schema
 const validatorKeyStoreSchema = z.object({
   attester: ethAccountsSchema,
-  coinbase: ethAddressSchema.optional(),
-  publisher: ethAccountsSchema.optional(),
+  coinbase: ethAddressSchema.nullish(),
+  publisher: ethAccountsSchema.nullish(),
   feeRecipient: aztecAddressSchema,
   remoteSigner: remoteSignerConfigSchema.nullish(),
 });
@@ -83,10 +83,10 @@ const validatorKeyStoreSchema = z.object({
 export const keystoreSchema = z
   .object({
     schemaVersion: z.literal(1),
-    validators: z.array(validatorKeyStoreSchema).optional(),
-    slasher: ethAccountsSchema.optional(),
+    validators: z.array(validatorKeyStoreSchema).nullish(),
+    slasher: ethAccountsSchema.nullish(),
     remoteSigner: remoteSignerConfigSchema.nullish(),
-    prover: proverKeyStoreSchema.optional(),
+    prover: proverKeyStoreSchema.nullish(),
   })
   .refine(data => data.validators || data.prover, {
     message: 'Keystore must have at least validators or prover configuration',


### PR DESCRIPTION
This PR simply updates the key store schema to use nullish to aid in deployment configurations
