### PR TITLE
chore: Change noir repo ref from branch name to commit sha

### DIFF
--- a/noir/noir-repo-ref
+++ b/noir/noir-repo-ref
@@ -1,1 +1,1 @@
-gd/acir-serialisation-changes
+19f252519a431e961c594ac8b46d5319520871a8


### PR DESCRIPTION
It logs a fatal, but still progresses. Unclear if this is the expected behaviour.

```
[b35ea678fb15e9](fatal: bad object 5b65f9637e85a4177692c3190cb35ea678fb15e9)

--- pull submodules ---
Executing: git submodule update --init --recursive (http://ci.aztec-labs.com/fa9d87d4fae7e056)
   0 . done (0s)
--- noir build ---
Executing: retry install_deps (http://ci.aztec-labs.com/ec495e087920e19e)
   0 ................................................. done (21s)
```