### PR TITLE
fix: proposer sign digest of attestations

### DIFF
--- a/l1-contracts/src/core/Rollup.sol
+++ b/l1-contracts/src/core/Rollup.sol
@@ -24,6 +24,7 @@ import {StakingLib} from "@aztec/core/libraries/rollup/StakingLib.sol";
 import {GSE} from "@aztec/governance/GSE.sol";
 import {IRewardDistributor} from "@aztec/governance/interfaces/IRewardDistributor.sol";
 import {CompressedSlot, CompressedTimestamp, CompressedTimeMath} from "@aztec/shared/libraries/CompressedTimeMath.sol";
+import {Signature} from "@aztec/shared/libraries/SignatureLib.sol";
 import {ChainTipsLib, CompressedChainTips} from "./libraries/compressed-data/Tips.sol";
 import {ProposeLib, ValidateHeaderArgs} from "./libraries/rollup/ProposeLib.sol";
 import {RewardLib, RewardConfig} from "./libraries/rollup/RewardLib.sol";
@@ -88,6 +89,7 @@ contract Rollup is IStaking, IValidatorSelection, IRollup, RollupCore {
     ProposedHeader calldata _header,
     CommitteeAttestations memory _attestations,
     address[] calldata _signers,
+    Signature memory _attestationsAndSignersSignature,
     bytes32 _digest,
     bytes32 _blobsHash,
     BlockHeaderValidationFlags memory _flags
@@ -102,7 +104,8 @@ contract Rollup is IStaking, IValidatorSelection, IRollup, RollupCore {
         flags: _flags
       }),
       _attestations,
-      _signers
+      _signers,
+      _attestationsAndSignersSignature
     );
   }
 

--- a/l1-contracts/src/core/RollupCore.sol
+++ b/l1-contracts/src/core/RollupCore.sol
@@ -38,6 +38,7 @@ import {StakingQueueConfig} from "@aztec/core/libraries/compressed-data/StakingQ
 import {FeeConfigLib, CompressedFeeConfig} from "@aztec/core/libraries/compressed-data/fees/FeeConfig.sol";
 import {G1Point, G2Point} from "@aztec/shared/libraries/BN254Lib.sol";
 import {ChainTipsLib, CompressedChainTips} from "@aztec/core/libraries/compressed-data/Tips.sol";
+import {Signature} from "@aztec/shared/libraries/SignatureLib.sol";
 
 /**
  * @title RollupCore
@@ -507,9 +508,12 @@ contract RollupCore is EIP712("Aztec Rollup", "1"), Ownable, IStakingCore, IVali
     ProposeArgs calldata _args,
     CommitteeAttestations memory _attestations,
     address[] calldata _signers,
+    Signature calldata _attestationsAndSignersSignature,
     bytes calldata _blobInput
   ) external override(IRollupCore) {
-    RollupOperationsExtLib.propose(_args, _attestations, _signers, _blobInput, checkBlob);
+    RollupOperationsExtLib.propose(
+      _args, _attestations, _signers, _attestationsAndSignersSignature, _blobInput, checkBlob
+    );
   }
 
   /**

--- a/l1-contracts/src/core/interfaces/IRollup.sol
+++ b/l1-contracts/src/core/interfaces/IRollup.sol
@@ -19,6 +19,7 @@ import {RewardConfig} from "@aztec/core/libraries/rollup/RewardLib.sol";
 import {RewardBoostConfig} from "@aztec/core/reward-boost/RewardBooster.sol";
 import {IHaveVersion} from "@aztec/governance/interfaces/IRegistry.sol";
 import {IRewardDistributor} from "@aztec/governance/interfaces/IRewardDistributor.sol";
+import {Signature} from "@aztec/shared/libraries/SignatureLib.sol";
 import {Timestamp, Slot, Epoch} from "@aztec/shared/libraries/TimeMath.sol";
 import {IERC20} from "@oz/token/ERC20/IERC20.sol";
 
@@ -116,6 +117,7 @@ interface IRollupCore {
     ProposeArgs calldata _args,
     CommitteeAttestations memory _attestations,
     address[] memory _signers,
+    Signature memory _attestationsAndSignersSignature,
     bytes calldata _blobInput
   ) external;
 
@@ -146,6 +148,7 @@ interface IRollup is IRollupCore, IHaveVersion {
     ProposedHeader calldata _header,
     CommitteeAttestations memory _attestations,
     address[] memory _signers,
+    Signature memory _attestationsAndSignersSignature,
     bytes32 _digest,
     bytes32 _blobsHash,
     BlockHeaderValidationFlags memory _flags

--- a/l1-contracts/src/core/libraries/rollup/AttestationLib.sol
+++ b/l1-contracts/src/core/libraries/rollup/AttestationLib.sol
@@ -13,7 +13,8 @@ uint256 constant ADDRESS_LENGTH = 20;
  */
 enum SignatureDomainSeparator {
   blockProposal,
-  blockAttestation
+  blockAttestation,
+  attestationsAndSigners
 }
 
 // A committee attestation can be made up of a signature and an address.
@@ -254,5 +255,13 @@ library AttestationLib {
     );
 
     return addresses;
+  }
+
+  function getAttestationsAndSignersDigest(CommitteeAttestations memory _attestations, address[] memory _signers)
+    internal
+    pure
+    returns (bytes32)
+  {
+    return keccak256(abi.encode(SignatureDomainSeparator.attestationsAndSigners, _attestations, _signers));
   }
 }

--- a/l1-contracts/src/core/libraries/rollup/RollupOperationsExtLib.sol
+++ b/l1-contracts/src/core/libraries/rollup/RollupOperationsExtLib.sol
@@ -13,6 +13,7 @@ import {AttestationLib} from "@aztec/core/libraries/rollup/AttestationLib.sol";
 import {
   ProposeLib, ProposeArgs, CommitteeAttestations, ValidateHeaderArgs, ValidatorSelectionLib
 } from "./ProposeLib.sol";
+import {Signature} from "@aztec/shared/libraries/SignatureLib.sol";
 
 /**
  * @title RollupOperationsExtLib - External Rollup Library (Proposal and Proof Verification Functions)
@@ -40,7 +41,8 @@ library RollupOperationsExtLib {
   function validateHeaderWithAttestations(
     ValidateHeaderArgs calldata _args,
     CommitteeAttestations calldata _attestations,
-    address[] calldata _signers
+    address[] calldata _signers,
+    Signature calldata _attestationsAndSignersSignature
   ) external {
     ProposeLib.validateHeader(_args);
     if (_attestations.isEmpty()) {
@@ -50,17 +52,20 @@ library RollupOperationsExtLib {
     Slot slot = _args.header.slotNumber;
     Epoch epoch = slot.epochFromSlot();
     ValidatorSelectionLib.verifyAttestations(slot, epoch, _attestations, _args.digest);
-    ValidatorSelectionLib.verifyProposer(slot, epoch, _attestations, _signers, _args.digest);
+    ValidatorSelectionLib.verifyProposer(
+      slot, epoch, _attestations, _signers, _args.digest, _attestationsAndSignersSignature
+    );
   }
 
   function propose(
     ProposeArgs calldata _args,
     CommitteeAttestations memory _attestations,
     address[] calldata _signers,
+    Signature calldata _attestationsAndSignersSignature,
     bytes calldata _blobInput,
     bool _checkBlob
   ) external {
-    ProposeLib.propose(_args, _attestations, _signers, _blobInput, _checkBlob);
+    ProposeLib.propose(_args, _attestations, _signers, _attestationsAndSignersSignature, _blobInput, _checkBlob);
   }
 
   function prune() external {

--- a/l1-contracts/src/core/libraries/rollup/ValidatorSelectionLib.sol
+++ b/l1-contracts/src/core/libraries/rollup/ValidatorSelectionLib.sol
@@ -203,7 +203,8 @@ library ValidatorSelectionLib {
     Epoch _epochNumber,
     CommitteeAttestations memory _attestations,
     address[] memory _signers,
-    bytes32 _digest
+    bytes32 _digest,
+    Signature memory _attestationsAndSignersSignature
   ) internal {
     // Try load the proposer from cache
     (address proposer, uint256 proposerIndex) = getCachedProposer(_slot);
@@ -252,6 +253,12 @@ library ValidatorSelectionLib {
     bytes32 digest = _digest.toEthSignedMessageHash();
     Signature memory signature = _attestations.getSignature(proposerIndex);
     SignatureLib.verify(signature, proposer, digest);
+
+    // Check that the proposer have signed the `_attestations|_signers` data such that invalid `_attestations|_signers`
+    // data can be attributed to the `proposer` specifically.
+    bytes32 attestationsAndSignersDigest =
+      _attestations.getAttestationsAndSignersDigest(_signers).toEthSignedMessageHash();
+    SignatureLib.verify(_attestationsAndSignersSignature, proposer, attestationsAndSignersDigest);
   }
 
   /**

--- a/l1-contracts/src/governance/proposer/EmpireBase.sol
+++ b/l1-contracts/src/governance/proposer/EmpireBase.sol
@@ -305,7 +305,6 @@ abstract contract EmpireBase is EIP712, IEmpire {
 
     round.signalCount[_payload] += 1;
 
-    // @todo We can optimize here for gas by storing some of it packed with the payloadWithMostSignals.
     if (
       round.payloadWithMostSignals != _payload
         && round.signalCount[_payload] > round.signalCount[round.payloadWithMostSignals]

--- a/l1-contracts/test/Rollup.t.sol
+++ b/l1-contracts/test/Rollup.t.sol
@@ -242,7 +242,13 @@ contract RollupTest is RollupBase {
     });
     bytes32 realBlobHash = this.getBlobHashes(data.blobCommitments)[0];
     vm.expectRevert(abi.encodeWithSelector(Errors.Rollup__InvalidBlobHash.selector, blobHashes[0], realBlobHash));
-    rollup.propose(args, AttestationLibHelper.packAttestations(attestations), signers, data.blobCommitments);
+    rollup.propose(
+      args,
+      AttestationLibHelper.packAttestations(attestations),
+      signers,
+      attestationsAndSignersSignature,
+      data.blobCommitments
+    );
   }
 
   function testExtraBlobs() public setUpFor("mixed_block_1") {
@@ -324,7 +330,13 @@ contract RollupTest is RollupBase {
       stateReference: EMPTY_STATE_REFERENCE,
       oracleInput: OracleInput(0)
     });
-    rollup.propose(args, AttestationLibHelper.packAttestations(attestations), signers, data.blobCommitments);
+    rollup.propose(
+      args,
+      AttestationLibHelper.packAttestations(attestations),
+      signers,
+      attestationsAndSignersSignature,
+      data.blobCommitments
+    );
   }
 
   function testInvalidL2Fee() public setUpFor("mixed_block_1") {
@@ -350,7 +362,13 @@ contract RollupTest is RollupBase {
       stateReference: EMPTY_STATE_REFERENCE,
       oracleInput: OracleInput(0)
     });
-    rollup.propose(args, AttestationLibHelper.packAttestations(attestations), signers, data.blobCommitments);
+    rollup.propose(
+      args,
+      AttestationLibHelper.packAttestations(attestations),
+      signers,
+      attestationsAndSignersSignature,
+      data.blobCommitments
+    );
   }
 
   function testProvingFeeUpdates() public setUpFor("mixed_block_1") {
@@ -456,7 +474,13 @@ contract RollupTest is RollupBase {
         stateReference: EMPTY_STATE_REFERENCE,
         oracleInput: OracleInput(0)
       });
-      rollup.propose(args, AttestationLibHelper.packAttestations(attestations), signers, data.blobCommitments);
+      rollup.propose(
+        args,
+        AttestationLibHelper.packAttestations(attestations),
+        signers,
+        attestationsAndSignersSignature,
+        data.blobCommitments
+      );
       assertEq(testERC20.balanceOf(header.coinbase), 0, "invalid coinbase balance");
     }
 
@@ -675,7 +699,13 @@ contract RollupTest is RollupBase {
       stateReference: EMPTY_STATE_REFERENCE,
       oracleInput: OracleInput(0)
     });
-    rollup.propose(args, AttestationLibHelper.packAttestations(attestations), signers, new bytes(144));
+    rollup.propose(
+      args,
+      AttestationLibHelper.packAttestations(attestations),
+      signers,
+      attestationsAndSignersSignature,
+      new bytes(144)
+    );
   }
 
   function testRevertInvalidCoinbase() public setUpFor("empty_block_1") {
@@ -698,7 +728,13 @@ contract RollupTest is RollupBase {
       stateReference: EMPTY_STATE_REFERENCE,
       oracleInput: OracleInput(0)
     });
-    rollup.propose(args, AttestationLibHelper.packAttestations(attestations), signers, new bytes(144));
+    rollup.propose(
+      args,
+      AttestationLibHelper.packAttestations(attestations),
+      signers,
+      attestationsAndSignersSignature,
+      new bytes(144)
+    );
   }
 
   function testSubmitProofNonExistentBlock() public setUpFor("empty_block_1") {

--- a/l1-contracts/test/base/RollupBase.sol
+++ b/l1-contracts/test/base/RollupBase.sol
@@ -22,6 +22,7 @@ import {AttestationLibHelper} from "@test/helper_libraries/AttestationLibHelper.
 
 import {Inbox} from "@aztec/core/messagebridge/Inbox.sol";
 import {Outbox} from "@aztec/core/messagebridge/Outbox.sol";
+import {Signature} from "@aztec/shared/libraries/SignatureLib.sol";
 
 contract RollupBase is DecoderBase {
   IInstance internal rollup;
@@ -31,6 +32,7 @@ contract RollupBase is DecoderBase {
 
   CommitteeAttestation[] internal attestations;
   address[] internal signers;
+  Signature internal attestationsAndSignersSignature;
 
   mapping(uint256 => uint256) internal blockFees;
 
@@ -184,7 +186,13 @@ contract RollupBase is DecoderBase {
     if (_revertMsg.length > 0) {
       vm.expectRevert(_revertMsg);
     }
-    rollup.propose(args, AttestationLibHelper.packAttestations(attestations), signers, blobCommitments);
+    rollup.propose(
+      args,
+      AttestationLibHelper.packAttestations(attestations),
+      signers,
+      attestationsAndSignersSignature,
+      blobCommitments
+    );
 
     if (_revertMsg.length > 0) {
       return;

--- a/l1-contracts/test/compression/PreHeating.t.sol
+++ b/l1-contracts/test/compression/PreHeating.t.sol
@@ -114,6 +114,7 @@ contract PreHeatingTest is FeeModelTestPoints, DecoderBase {
     bytes blobInputs;
     CommitteeAttestation[] attestations;
     address[] signers;
+    Signature attestationsAndSignersSignature;
   }
 
   DecoderBase.Full full = load("empty_block_1");
@@ -236,7 +237,13 @@ contract PreHeatingTest is FeeModelTestPoints, DecoderBase {
         blockAttestations[currentBlockNumber] = AttestationLibHelper.packAttestations(b.attestations);
 
         vm.prank(proposer);
-        rollup.propose(b.proposeArgs, AttestationLibHelper.packAttestations(b.attestations), b.signers, b.blobInputs);
+        rollup.propose(
+          b.proposeArgs,
+          AttestationLibHelper.packAttestations(b.attestations),
+          b.signers,
+          b.attestationsAndSignersSignature,
+          b.blobInputs
+        );
 
         nextSlot = nextSlot + Slot.wrap(1);
       }
@@ -383,11 +390,20 @@ contract PreHeatingTest is FeeModelTestPoints, DecoderBase {
       }
     }
 
+    Signature memory attestationsAndSignersSignature;
+    if (proposer != address(0)) {
+      attestationsAndSignersSignature = createAttestation(
+        proposer,
+        AttestationLib.getAttestationsAndSignersDigest(AttestationLibHelper.packAttestations(attestations), signers)
+      ).signature;
+    }
+
     return Block({
       proposeArgs: proposeArgs,
       blobInputs: full.block.blobCommitments,
       attestations: attestations,
-      signers: signers
+      signers: signers,
+      attestationsAndSignersSignature: attestationsAndSignersSignature
     });
   }
 

--- a/l1-contracts/test/fees/FeeRollup.t.sol
+++ b/l1-contracts/test/fees/FeeRollup.t.sol
@@ -55,6 +55,7 @@ import {ProposedHeader} from "@aztec/core/libraries/rollup/ProposedHeaderLib.sol
 import {MinimalFeeModel} from "./MinimalFeeModel.sol";
 import {RollupBuilder} from "../builder/RollupBuilder.sol";
 import {AttestationLibHelper} from "@test/helper_libraries/AttestationLibHelper.sol";
+import {Signature} from "@aztec/shared/libraries/SignatureLib.sol";
 
 // solhint-disable comprehensive-interface
 
@@ -75,6 +76,7 @@ contract FeeRollupTest is FeeModelTestPoints, DecoderBase {
     bytes blobInputs;
     CommitteeAttestation[] attestations;
     address[] signers;
+    Signature attestationsAndSignersSignature;
   }
 
   DecoderBase.Full full = load("empty_block_1");
@@ -170,7 +172,8 @@ contract FeeRollupTest is FeeModelTestPoints, DecoderBase {
       body: body,
       blobInputs: full.block.blobCommitments,
       attestations: attestations,
-      signers: signers
+      signers: signers,
+      attestationsAndSignersSignature: Signature({v: 0, r: 0, s: 0})
     });
   }
 
@@ -194,6 +197,7 @@ contract FeeRollupTest is FeeModelTestPoints, DecoderBase {
           }),
           AttestationLibHelper.packAttestations(b.attestations),
           b.signers,
+          b.attestationsAndSignersSignature,
           b.blobInputs
         );
         nextSlot = nextSlot + Slot.wrap(1);
@@ -285,6 +289,7 @@ contract FeeRollupTest is FeeModelTestPoints, DecoderBase {
           }),
           AttestationLibHelper.packAttestations(b.attestations),
           b.signers,
+          b.attestationsAndSignersSignature,
           b.blobInputs
         );
 

--- a/l1-contracts/test/ignition/tmnt223.t.sol
+++ b/l1-contracts/test/ignition/tmnt223.t.sol
@@ -32,6 +32,7 @@ import {SafeCast} from "@oz/utils/math/SafeCast.sol";
 import {AttestationLibHelper} from "@test/helper_libraries/AttestationLibHelper.sol";
 import {Ownable} from "@oz/access/Ownable.sol";
 import {IInbox} from "@aztec/core/interfaces/messagebridge/IInbox.sol";
+import {Signature} from "@aztec/shared/libraries/SignatureLib.sol";
 // solhint-disable comprehensive-interface
 
 struct Block {
@@ -39,12 +40,9 @@ struct Block {
   bytes blobInputs;
   CommitteeAttestation[] attestations;
   address[] signers;
+  Signature attestationsAndSignersSignature;
 }
 
-/**
- * Blocks are generated using the `integration_l1_publisher.test.ts` tests.
- * Main use of these test is shorter cycles when updating the decoder contract.
- */
 contract Tmnt223Test is RollupBase {
   using ProposeLib for ProposeArgs;
   using TimeLib for Timestamp;
@@ -112,6 +110,7 @@ contract Tmnt223Test is RollupBase {
         l2Block.proposeArgs,
         AttestationLibHelper.packAttestations(l2Block.attestations),
         l2Block.signers,
+        l2Block.attestationsAndSignersSignature,
         l2Block.blobInputs
       );
       timeCheater.cheat__progressSlot();
@@ -129,6 +128,7 @@ contract Tmnt223Test is RollupBase {
       nonEmptyBlock.proposeArgs,
       AttestationLibHelper.packAttestations(nonEmptyBlock.attestations),
       nonEmptyBlock.signers,
+      nonEmptyBlock.attestationsAndSignersSignature,
       nonEmptyBlock.blobInputs
     );
 
@@ -173,7 +173,8 @@ contract Tmnt223Test is RollupBase {
       proposeArgs: proposeArgs,
       blobInputs: full.block.blobCommitments,
       attestations: attestations,
-      signers: signers
+      signers: signers,
+      attestationsAndSignersSignature: Signature({v: 0, r: 0, s: 0})
     });
   }
 }

--- a/l1-contracts/test/validator-selection/ValidatorSelectionBase.sol
+++ b/l1-contracts/test/validator-selection/ValidatorSelectionBase.sol
@@ -49,6 +49,7 @@ contract ValidatorSelectionTestBase is DecoderBase {
     address[] committee;
     CommitteeAttestation[] attestations;
     address[] signers;
+    Signature attestationsAndSignersSignature;
     ProposePayload proposePayload;
     ProposeArgs proposeArgs;
     uint256 invalidAddressAttestationIndex;

--- a/l1-contracts/test/validator-selection/tmnt207.t.sol
+++ b/l1-contracts/test/validator-selection/tmnt207.t.sol
@@ -1,0 +1,352 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024 Aztec Labs.
+pragma solidity >=0.8.27;
+
+import {DecoderBase} from "../base/DecoderBase.sol";
+
+import {Registry} from "@aztec/governance/Registry.sol";
+import {FeeJuicePortal} from "@aztec/core/messagebridge/FeeJuicePortal.sol";
+import {TestERC20} from "@aztec/mock/TestERC20.sol";
+import {TestConstants} from "../harnesses/TestConstants.sol";
+import {RewardDistributor} from "@aztec/governance/RewardDistributor.sol";
+import {ProposeArgs, ProposeLib} from "@aztec/core/libraries/rollup/ProposeLib.sol";
+
+import {Timestamp, Slot, Epoch, TimeLib} from "@aztec/core/libraries/TimeLib.sol";
+
+import {Errors} from "@aztec/core/libraries/Errors.sol";
+import {ProposeArgs, ProposePayload, OracleInput, ProposeLib} from "@aztec/core/libraries/rollup/ProposeLib.sol";
+
+import {RollupBase, IInstance} from "../base/RollupBase.sol";
+import {RollupBuilder} from "../builder/RollupBuilder.sol";
+import {TimeCheater} from "../staking/TimeCheater.sol";
+import {Bps, BpsLib} from "@aztec/core/libraries/rollup/RewardLib.sol";
+import {
+  AttestationLib,
+  Signature,
+  CommitteeAttestation,
+  CommitteeAttestations
+} from "@aztec/core/libraries/rollup/AttestationLib.sol";
+import {Constants} from "@aztec/core/libraries/ConstantsGen.sol";
+import {ProposedHeader} from "@aztec/core/libraries/rollup/ProposedHeaderLib.sol";
+import {SafeCast} from "@oz/utils/math/SafeCast.sol";
+import {AttestationLibHelper} from "@test/helper_libraries/AttestationLibHelper.sol";
+import {Ownable} from "@oz/access/Ownable.sol";
+import {IInbox} from "@aztec/core/interfaces/messagebridge/IInbox.sol";
+import {CheatDepositArgs} from "@aztec/mock/MultiAdder.sol";
+import {BN254Lib, G1Point, G2Point} from "@aztec/shared/libraries/BN254Lib.sol";
+import {StakingQueueConfig} from "@aztec/core/libraries/compressed-data/StakingQueueConfig.sol";
+import {ProposedHeaderLib} from "@aztec/core/libraries/rollup/ProposedHeaderLib.sol";
+import {MessageHashUtils} from "@oz/utils/cryptography/MessageHashUtils.sol";
+import {
+  IRollup,
+  IRollupCore,
+  SubmitEpochRootProofArgs,
+  PublicInputArgs,
+  RollupConfigInput
+} from "@aztec/core/interfaces/IRollup.sol";
+import {Signature, SignatureLib__InvalidSignature} from "@aztec/shared/libraries/SignatureLib.sol";
+// solhint-disable comprehensive-interface
+
+struct Block {
+  ProposeArgs proposeArgs;
+  bytes blobInputs;
+  CommitteeAttestation[] attestations;
+  address[] signers;
+  Signature attestationsAndSignersSignature;
+}
+
+contract Tmnt207Test is RollupBase {
+  using MessageHashUtils for bytes32;
+  using ProposeLib for ProposeArgs;
+  using TimeLib for Timestamp;
+  using TimeLib for Slot;
+  using TimeLib for Epoch;
+
+  Registry internal registry;
+  TestERC20 internal testERC20;
+  FeeJuicePortal internal feeJuicePortal;
+  RewardDistributor internal rewardDistributor;
+  TimeCheater internal timeCheater;
+
+  CommitteeAttestation internal emptyAttestation;
+  mapping(address attester => uint256 privateKey) internal attesterPrivateKeys;
+
+  uint256 internal SLOT_DURATION;
+  uint256 internal EPOCH_DURATION;
+  uint256 internal PROOF_SUBMISSION_EPOCHS;
+  uint256 internal MANA_TARGET = 0;
+  uint256 internal COMMITTEE_SIZE = 4;
+
+  address internal sequencer = address(bytes20("sequencer"));
+
+  DecoderBase.Full internal full;
+
+  /**
+   * @notice  Set up the contracts needed for the tests with time aligned to the provided block name
+   */
+  modifier setUpFor(string memory _name) {
+    {
+      full = load(_name);
+      Slot slotNumber = full.block.header.slotNumber;
+      uint256 initialTime = Timestamp.unwrap(full.block.header.timestamp) - Slot.unwrap(slotNumber) * SLOT_DURATION;
+      vm.warp(initialTime);
+    }
+
+    TimeLib.initialize(
+      block.timestamp,
+      TestConstants.AZTEC_SLOT_DURATION,
+      TestConstants.AZTEC_EPOCH_DURATION,
+      TestConstants.AZTEC_PROOF_SUBMISSION_EPOCHS
+    );
+    SLOT_DURATION = TestConstants.AZTEC_SLOT_DURATION;
+    EPOCH_DURATION = TestConstants.AZTEC_EPOCH_DURATION;
+    PROOF_SUBMISSION_EPOCHS = TestConstants.AZTEC_PROOF_SUBMISSION_EPOCHS;
+    timeCheater =
+      new TimeCheater(address(this), block.timestamp, SLOT_DURATION, EPOCH_DURATION, PROOF_SUBMISSION_EPOCHS);
+
+    CheatDepositArgs[] memory initialValidators = new CheatDepositArgs[](COMMITTEE_SIZE);
+
+    for (uint256 i = 1; i < COMMITTEE_SIZE + 1; i++) {
+      uint256 attesterPrivateKey = uint256(keccak256(abi.encode("attester", i)));
+      address attester = vm.addr(attesterPrivateKey);
+      attesterPrivateKeys[attester] = attesterPrivateKey;
+
+      initialValidators[i - 1] = CheatDepositArgs({
+        attester: attester,
+        withdrawer: address(this),
+        publicKeyInG1: BN254Lib.g1Zero(),
+        publicKeyInG2: BN254Lib.g2Zero(),
+        proofOfPossession: BN254Lib.g1Zero()
+      });
+    }
+
+    StakingQueueConfig memory stakingQueueConfig = TestConstants.getStakingQueueConfig();
+    stakingQueueConfig.normalFlushSizeMin = COMMITTEE_SIZE == 0 ? 1 : COMMITTEE_SIZE;
+
+    RollupBuilder builder = new RollupBuilder(address(this)).setManaTarget(MANA_TARGET).setTargetCommitteeSize(
+      COMMITTEE_SIZE
+    ).setValidators(initialValidators).setStakingQueueConfig(stakingQueueConfig);
+    builder.deploy();
+
+    rollup = IInstance(address(builder.getConfig().rollup));
+    testERC20 = builder.getConfig().testERC20;
+    registry = builder.getConfig().registry;
+
+    feeJuicePortal = FeeJuicePortal(address(rollup.getFeeAssetPortal()));
+    rewardDistributor = RewardDistributor(address(registry.getRewardDistributor()));
+
+    _;
+  }
+
+  function test_livelock() public setUpFor("empty_block_1") {
+    // The attacker will frontrun the transaction to submit invalid attestation/signers inputs
+    // Thereby blocking the real block submission, but also make it impossible to prove
+    // so it needs to be invalidated. A DOS vector.
+
+    skipBlobCheck(address(rollup));
+    timeCheater.cheat__progressEpoch();
+    timeCheater.cheat__progressEpoch();
+
+    // Say that someone builds a perfectly nice block
+    Block memory l2BlockReal = getBlock();
+    Block memory l2Block = getBlock();
+    address proposer = rollup.getCurrentProposer();
+
+    // But a malicious man steps in. Take that block, and messes up some of the `attestations` values
+    address attacker = address(0xdeadbeefbedead);
+
+    // Then, MESS the signatures that is not the proposer up!
+    // This way we can still rebuild the same committee, during propose, but impossible to make it pass during proving
+    {
+      for (uint256 i = 0; i < l2Block.attestations.length; i++) {
+        if (l2Block.attestations[i].addr != proposer && l2Block.attestations[i].signature.v != 0) {
+          l2Block.attestations[i].signature.v = 1;
+          l2Block.attestations[i].signature.r = bytes32(uint256(1));
+          l2Block.attestations[i].signature.s = bytes32(uint256(1));
+        }
+      }
+
+      vm.prank(attacker);
+      vm.expectRevert(); // SignatureLib__InvalidSignature.selector
+      rollup.propose(
+        l2Block.proposeArgs,
+        AttestationLibHelper.packAttestations(l2Block.attestations),
+        l2Block.signers,
+        l2Block.attestationsAndSignersSignature,
+        l2Block.blobInputs
+      );
+    }
+
+    // It is also possible to alter the signers if needed. Find someone that is not a signer! And add a signature
+    // When we change the `signers` we need also change the attestations to recreate the correct committee.
+    {
+      address[] memory signers = new address[](l2Block.signers.length + 1);
+      uint256 signersIndex = 0;
+      bool haveAddedSigner = false;
+      for (uint256 i = 0; i < l2Block.attestations.length; i++) {
+        if (!haveAddedSigner && l2Block.attestations[i].addr != proposer && l2Block.attestations[i].signature.v == 0) {
+          l2Block.attestations[i].signature.v = 1;
+          l2Block.attestations[i].signature.r = bytes32(uint256(1));
+          l2Block.attestations[i].signature.s = bytes32(uint256(1));
+          haveAddedSigner = true;
+        }
+
+        if (l2Block.attestations[i].signature.v != 0) {
+          signers[signersIndex] = l2Block.attestations[i].addr;
+          signersIndex++;
+        }
+      }
+
+      vm.prank(attacker);
+      vm.expectRevert(); // SignatureLib__InvalidSignature.selector
+      rollup.propose(
+        l2Block.proposeArgs,
+        AttestationLibHelper.packAttestations(l2Block.attestations),
+        signers,
+        l2Block.attestationsAndSignersSignature,
+        l2Block.blobInputs
+      );
+    }
+
+    // Real
+    {
+      vm.prank(proposer);
+      rollup.propose(
+        l2BlockReal.proposeArgs,
+        AttestationLibHelper.packAttestations(l2BlockReal.attestations),
+        l2BlockReal.signers,
+        l2BlockReal.attestationsAndSignersSignature,
+        l2BlockReal.blobInputs
+      );
+    }
+
+    rollup.submitEpochRootProof(
+      SubmitEpochRootProofArgs({
+        start: 1,
+        end: 1,
+        args: PublicInputArgs({
+          previousArchive: rollup.getBlock(0).archive,
+          endArchive: rollup.getBlock(1).archive,
+          proverId: address(0)
+        }),
+        fees: new bytes32[](Constants.AZTEC_MAX_EPOCH_DURATION * 2),
+        attestations: AttestationLibHelper.packAttestations(l2BlockReal.attestations),
+        blobInputs: full.block.batchedBlobInputs,
+        proof: ""
+      })
+    );
+  }
+
+  function getBlock() internal returns (Block memory) {
+    // We will be using the genesis for both before and after. This will be impossible
+    // to prove, but we don't need to prove anything here.
+    bytes32 archiveRoot = bytes32(Constants.GENESIS_ARCHIVE_ROOT);
+
+    ProposedHeader memory header = full.block.header;
+
+    Slot slotNumber = rollup.getCurrentSlot();
+    Timestamp ts = rollup.getTimestampForSlot(slotNumber);
+
+    address proposer = rollup.getCurrentProposer();
+
+    // Updating the header with important information!
+    header.lastArchiveRoot = archiveRoot;
+    header.slotNumber = slotNumber;
+    header.timestamp = ts;
+    header.coinbase = address(bytes20("coinbase"));
+    header.feeRecipient = bytes32(0);
+    header.gasFees.feePerL2Gas = SafeCast.toUint128(rollup.getManaBaseFeeAt(Timestamp.wrap(block.timestamp), true));
+    if (MANA_TARGET > 0) {
+      header.totalManaUsed = MANA_TARGET;
+    } else {
+      header.totalManaUsed = 0;
+    }
+
+    ProposeArgs memory proposeArgs = ProposeArgs({
+      header: header,
+      archive: archiveRoot,
+      stateReference: EMPTY_STATE_REFERENCE,
+      oracleInput: OracleInput({feeAssetPriceModifier: 0})
+    });
+
+    CommitteeAttestation[] memory attestations;
+    address[] memory signers;
+
+    {
+      address[] memory validators = rollup.getEpochCommittee(rollup.getCurrentEpoch());
+      uint256 needed = validators.length * 2 / 3 + 1;
+      attestations = new CommitteeAttestation[](validators.length);
+      signers = new address[](needed);
+
+      bytes32 headerHash = ProposedHeaderLib.hash(proposeArgs.header);
+
+      ProposePayload memory proposePayload = ProposePayload({
+        archive: proposeArgs.archive,
+        stateReference: proposeArgs.stateReference,
+        oracleInput: proposeArgs.oracleInput,
+        headerHash: headerHash
+      });
+
+      bytes32 digest = ProposeLib.digest(proposePayload);
+
+      // loop through to make sure we create an attestation for the proposer
+      for (uint256 i = 0; i < validators.length; i++) {
+        if (validators[i] == proposer) {
+          attestations[i] = createAttestation(validators[i], digest);
+        }
+      }
+
+      // loop to get to the required number of attestations.
+      // yes, inefficient, but it's simple, clear, and is a test.
+      uint256 sigCount = 1;
+      uint256 signersIndex = 0;
+      for (uint256 i = 0; i < validators.length; i++) {
+        if (validators[i] == proposer) {
+          signers[signersIndex] = validators[i];
+          signersIndex++;
+        } else if (sigCount < needed) {
+          attestations[i] = createAttestation(validators[i], digest);
+          signers[signersIndex] = validators[i];
+          sigCount++;
+          signersIndex++;
+        } else {
+          attestations[i] = createEmptyAttestation(validators[i]);
+        }
+      }
+    }
+
+    Signature memory attestationsAndSignersSignature;
+    if (proposer != address(0)) {
+      attestationsAndSignersSignature = createAttestation(
+        proposer,
+        AttestationLib.getAttestationsAndSignersDigest(AttestationLibHelper.packAttestations(attestations), signers)
+      ).signature;
+    }
+
+    return Block({
+      proposeArgs: proposeArgs,
+      blobInputs: full.block.blobCommitments,
+      attestations: attestations,
+      signers: signers,
+      attestationsAndSignersSignature: attestationsAndSignersSignature
+    });
+  }
+
+  function createAttestation(address _signer, bytes32 _digest) internal view returns (CommitteeAttestation memory) {
+    uint256 privateKey = attesterPrivateKeys[_signer];
+
+    bytes32 digest = _digest.toEthSignedMessageHash();
+    (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, digest);
+
+    Signature memory signature = Signature({v: v, r: r, s: s});
+    // Address can be zero for signed attestations
+    return CommitteeAttestation({addr: _signer, signature: signature});
+  }
+
+  // This is used for attestations that are not signed - we include their address to help reconstruct the committee
+  // commitment
+  function createEmptyAttestation(address _signer) internal pure returns (CommitteeAttestation memory) {
+    Signature memory emptySignature = Signature({v: 0, r: 0, s: 0});
+    return CommitteeAttestation({addr: _signer, signature: emptySignature});
+  }
+}

--- a/yarn-project/archiver/src/archiver/data_retrieval.ts
+++ b/yarn-project/archiver/src/archiver/data_retrieval.ts
@@ -11,6 +11,7 @@ import type {
 import { asyncPool } from '@aztec/foundation/async-pool';
 import { Buffer16, Buffer32 } from '@aztec/foundation/buffer';
 import type { EthAddress } from '@aztec/foundation/eth-address';
+import type { ViemSignature } from '@aztec/foundation/eth-signature';
 import { Fr } from '@aztec/foundation/fields';
 import { type Logger, createLogger } from '@aztec/foundation/log';
 import { type InboxAbi, RollupAbi } from '@aztec/l1-artifacts';
@@ -323,6 +324,7 @@ async function getBlockFromRollupTx(
     },
     ViemCommitteeAttestations,
     Hex[],
+    ViemSignature,
     Hex,
   ];
 

--- a/yarn-project/end-to-end/src/e2e_synching.test.ts
+++ b/yarn-project/end-to-end/src/e2e_synching.test.ts
@@ -56,6 +56,7 @@ import {
 } from '@aztec/ethereum';
 import { createL1TxUtilsWithBlobsFromViemWallet } from '@aztec/ethereum/l1-tx-utils-with-blobs';
 import { SecretValue } from '@aztec/foundation/config';
+import { Signature } from '@aztec/foundation/eth-signature';
 import { Timer } from '@aztec/foundation/timer';
 import { RollupAbi } from '@aztec/l1-artifacts';
 import { SchnorrHardcodedAccountContract } from '@aztec/noir-contracts.js/SchnorrHardcodedAccount';
@@ -64,7 +65,7 @@ import { SpamContract } from '@aztec/noir-test-contracts.js/Spam';
 import type { PXEService } from '@aztec/pxe/server';
 import { SequencerPublisher, SequencerPublisherMetrics } from '@aztec/sequencer-client';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
-import { L2Block } from '@aztec/stdlib/block';
+import { CommitteeAttestationsAndSigners, L2Block } from '@aztec/stdlib/block';
 import { tryStop } from '@aztec/stdlib/interfaces/server';
 import { createWorldStateSynchronizer } from '@aztec/world-state';
 
@@ -462,7 +463,7 @@ describe('e2e_synching', () => {
         await cheatCodes.eth.mine();
       }
       // If it breaks here, first place you should look is the pruning.
-      await publisher.enqueueProposeL2Block(block);
+      await publisher.enqueueProposeL2Block(block, CommitteeAttestationsAndSigners.empty(), Signature.empty());
 
       await cheatCodes.rollup.markAsProven(provenThrough);
     }

--- a/yarn-project/ethereum/src/deploy_l1_contracts.ts
+++ b/yarn-project/ethereum/src/deploy_l1_contracts.ts
@@ -183,7 +183,7 @@ export const deploySharedContracts = async (
   args: DeployL1ContractsArgs,
   logger: Logger,
 ) => {
-  logger.info(`Deploying shared contracts for network configration: ${networkName}`);
+  logger.info(`Deploying shared contracts for network configuration: ${networkName}`);
 
   const txHashes: Hex[] = [];
 

--- a/yarn-project/prover-node/src/prover-node-publisher.ts
+++ b/yarn-project/prover-node/src/prover-node-publisher.ts
@@ -1,11 +1,6 @@
 import { type BatchedBlob, FinalBlobAccumulatorPublicInputs } from '@aztec/blob-lib';
 import { AZTEC_MAX_EPOCH_DURATION } from '@aztec/constants';
-import {
-  type L1TxUtils,
-  type RollupContract,
-  RollupContract as RollupContractClass,
-  type ViemCommitteeAttestation,
-} from '@aztec/ethereum';
+import type { L1TxUtils, RollupContract, ViemCommitteeAttestation } from '@aztec/ethereum';
 import { makeTuple } from '@aztec/foundation/array';
 import { areArraysEqual } from '@aztec/foundation/collection';
 import { EthAddress } from '@aztec/foundation/eth-address';
@@ -16,6 +11,7 @@ import { InterruptibleSleep } from '@aztec/foundation/sleep';
 import { Timer } from '@aztec/foundation/timer';
 import { RollupAbi } from '@aztec/l1-artifacts';
 import type { PublisherConfig, TxSenderConfig } from '@aztec/sequencer-client';
+import { CommitteeAttestation, CommitteeAttestationsAndSigners } from '@aztec/stdlib/block';
 import type { Proof } from '@aztec/stdlib/proofs';
 import type { FeeRecipient, RootRollupPublicInputs } from '@aztec/stdlib/rollup';
 import type { L1PublishProofStats } from '@aztec/stdlib/stats';
@@ -290,7 +286,9 @@ export class ProverNodePublisher {
       end: argsArray[1],
       args: argsArray[2],
       fees: argsArray[3],
-      attestations: RollupContractClass.packAttestations(args.attestations),
+      attestations: new CommitteeAttestationsAndSigners(
+        args.attestations.map(a => CommitteeAttestation.fromViem(a)),
+      ).getPackedAttestations(),
       blobInputs: argsArray[4],
       proof: proofHex,
     };

--- a/yarn-project/sequencer-client/src/publisher/sequencer-publisher.test.ts
+++ b/yarn-project/sequencer-client/src/publisher/sequencer-publisher.test.ts
@@ -19,7 +19,7 @@ import { EthAddress } from '@aztec/foundation/eth-address';
 import { sleep } from '@aztec/foundation/sleep';
 import { TestDateProvider } from '@aztec/foundation/timer';
 import { EmpireBaseAbi, RollupAbi } from '@aztec/l1-artifacts';
-import { L2Block, Signature } from '@aztec/stdlib/block';
+import { CommitteeAttestationsAndSigners, L2Block, Signature } from '@aztec/stdlib/block';
 import type { SlashFactoryContract } from '@aztec/stdlib/l1-contracts';
 import type { ProposedBlockHeader } from '@aztec/stdlib/tx';
 
@@ -232,7 +232,9 @@ describe('SequencerPublisher', () => {
     // Expect the blob sink server to receive the blobs
     await runBlobSinkServer(expectedBlobs);
 
-    expect(await publisher.enqueueProposeL2Block(l2Block)).toEqual(true);
+    expect(
+      await publisher.enqueueProposeL2Block(l2Block, CommitteeAttestationsAndSigners.empty(), Signature.empty()),
+    ).toEqual(true);
     const govPayload = EthAddress.random();
     const voteSig = Signature.random();
     governanceProposerContract.getRoundInfo.mockResolvedValue({
@@ -280,8 +282,9 @@ describe('SequencerPublisher', () => {
         },
         txHashes: [],
       },
-      RollupContract.packAttestations([]),
+      CommitteeAttestationsAndSigners.empty().getPackedAttestations(),
       [],
+      Signature.empty().toViemSignature(),
       blobInput,
     ] as const;
 
@@ -320,7 +323,11 @@ describe('SequencerPublisher', () => {
       errorMsg: undefined,
     });
 
-    const enqueued = await publisher.enqueueProposeL2Block(l2Block);
+    const enqueued = await publisher.enqueueProposeL2Block(
+      l2Block,
+      CommitteeAttestationsAndSigners.empty(),
+      Signature.empty(),
+    );
     expect(enqueued).toEqual(true);
     const result = await publisher.sendRequests();
     expect(result).toEqual(undefined);
@@ -329,7 +336,9 @@ describe('SequencerPublisher', () => {
   it('does not send propose tx if rollup validation fails', async () => {
     l1TxUtils.simulate.mockRejectedValueOnce(new Error('Test error'));
 
-    await expect(publisher.enqueueProposeL2Block(l2Block)).rejects.toThrow();
+    await expect(
+      publisher.enqueueProposeL2Block(l2Block, CommitteeAttestationsAndSigners.empty(), Signature.empty()),
+    ).rejects.toThrow();
 
     expect(l1TxUtils.simulate).toHaveBeenCalledTimes(1);
 
@@ -345,7 +354,11 @@ describe('SequencerPublisher', () => {
       errorMsg: 'Test error',
     });
 
-    const enqueued = await publisher.enqueueProposeL2Block(l2Block);
+    const enqueued = await publisher.enqueueProposeL2Block(
+      l2Block,
+      CommitteeAttestationsAndSigners.empty(),
+      Signature.empty(),
+    );
     expect(enqueued).toEqual(true);
     const result = await publisher.sendRequests();
 
@@ -366,7 +379,11 @@ describe('SequencerPublisher', () => {
           errorMsg: undefined;
         }>,
     );
-    const enqueued = await publisher.enqueueProposeL2Block(l2Block);
+    const enqueued = await publisher.enqueueProposeL2Block(
+      l2Block,
+      CommitteeAttestationsAndSigners.empty(),
+      Signature.empty(),
+    );
     expect(enqueued).toEqual(true);
     publisher.interrupt();
     const resultPromise = publisher.sendRequests();

--- a/yarn-project/stdlib/src/block/proposal/attestations_and_signers.ts
+++ b/yarn-project/stdlib/src/block/proposal/attestations_and_signers.ts
@@ -1,0 +1,121 @@
+import type { ViemCommitteeAttestations } from '@aztec/ethereum';
+import { hexToBuffer } from '@aztec/foundation/string';
+
+import { encodeAbiParameters, parseAbiParameters } from 'viem';
+import { z } from 'zod';
+
+import type { Signable, SignatureDomainSeparator } from '../../p2p/signature_utils.js';
+import { CommitteeAttestation } from './committee_attestation.js';
+
+export class CommitteeAttestationsAndSigners implements Signable {
+  constructor(public attestations: CommitteeAttestation[]) {}
+
+  static get schema() {
+    return z
+      .object({
+        attestations: CommitteeAttestation.schema.array(),
+      })
+      .transform(obj => new CommitteeAttestationsAndSigners(obj.attestations));
+  }
+
+  getPayloadToSign(domainSeparator: SignatureDomainSeparator): Buffer {
+    const abi = parseAbiParameters('uint8,(bytes,bytes),address[]');
+    const packed = this.getPackedAttestations();
+
+    const encodedData = encodeAbiParameters(abi, [
+      domainSeparator,
+      [packed.signatureIndices, packed.signaturesOrAddresses],
+      this.getSigners().map(s => s.toString()),
+    ]);
+
+    return hexToBuffer(encodedData);
+  }
+
+  static empty(): CommitteeAttestationsAndSigners {
+    return new CommitteeAttestationsAndSigners([]);
+  }
+
+  toString() {
+    throw new Error('Not implemented');
+  }
+
+  getSigners() {
+    return this.attestations.filter(a => !a.signature.isEmpty()).map(a => a.address);
+  }
+
+  getSignedAttestations() {
+    return this.attestations.filter(a => !a.signature.isEmpty());
+  }
+
+  /**
+   * Packs an array of committee attestations into the format expected by the Solidity contract
+   *
+   * @param attestations - Array of committee attestations with addresses and signatures
+   * @returns Packed attestations with bitmap and tightly packed signature/address data
+   */
+  getPackedAttestations(): ViemCommitteeAttestations {
+    const length = this.attestations.length;
+    const attestations = this.attestations.map(a => a.toViem());
+
+    // Calculate bitmap size (1 bit per attestation, rounded up to nearest byte)
+    const bitmapSize = Math.ceil(length / 8);
+    const signatureIndices = new Uint8Array(bitmapSize);
+
+    // Calculate total data size needed
+    let totalDataSize = 0;
+    for (let i = 0; i < length; i++) {
+      const signature = attestations[i].signature;
+      // Check if signature is empty (v = 0)
+      const isEmpty = signature.v === 0;
+
+      if (!isEmpty) {
+        totalDataSize += 65; // v (1) + r (32) + s (32)
+      } else {
+        totalDataSize += 20; // address only
+      }
+    }
+
+    const signaturesOrAddresses = new Uint8Array(totalDataSize);
+    let dataIndex = 0;
+
+    // Pack the data
+    for (let i = 0; i < length; i++) {
+      const attestation = attestations[i];
+      const signature = attestation.signature;
+
+      // Check if signature is empty
+      const isEmpty = signature.v === 0;
+
+      if (!isEmpty) {
+        // Set bit in bitmap (bit 7-0 in each byte, left to right)
+        const byteIndex = Math.floor(i / 8);
+        const bitIndex = 7 - (i % 8);
+        signatureIndices[byteIndex] |= 1 << bitIndex;
+
+        // Pack signature: v + r + s
+        signaturesOrAddresses[dataIndex] = signature.v;
+        dataIndex++;
+
+        // Pack r (32 bytes)
+        const rBytes = Buffer.from(signature.r.slice(2), 'hex');
+        signaturesOrAddresses.set(rBytes, dataIndex);
+        dataIndex += 32;
+
+        // Pack s (32 bytes)
+        const sBytes = Buffer.from(signature.s.slice(2), 'hex');
+        signaturesOrAddresses.set(sBytes, dataIndex);
+        dataIndex += 32;
+      } else {
+        // Pack address only (20 bytes)
+        const addrBytes = Buffer.from(attestation.addr.slice(2), 'hex');
+        signaturesOrAddresses.set(addrBytes, dataIndex);
+        dataIndex += 20;
+      }
+    }
+
+    return {
+      signatureIndices: `0x${Buffer.from(signatureIndices).toString('hex')}`,
+      signaturesOrAddresses: `0x${Buffer.from(signaturesOrAddresses).toString('hex')}`,
+    };
+  }
+}

--- a/yarn-project/stdlib/src/block/proposal/index.ts
+++ b/yarn-project/stdlib/src/block/proposal/index.ts
@@ -1,1 +1,2 @@
 export * from './committee_attestation.js';
+export * from './attestations_and_signers.js';

--- a/yarn-project/stdlib/src/interfaces/validator.ts
+++ b/yarn-project/stdlib/src/interfaces/validator.ts
@@ -1,5 +1,6 @@
 import type { SecretValue } from '@aztec/foundation/config';
 import type { EthAddress } from '@aztec/foundation/eth-address';
+import type { Signature } from '@aztec/foundation/eth-signature';
 import { Fr } from '@aztec/foundation/fields';
 import { type ZodFor, schemas } from '@aztec/foundation/schemas';
 import type { SequencerConfig, SlasherConfig } from '@aztec/stdlib/interfaces/server';
@@ -8,6 +9,8 @@ import type { ProposedBlockHeader, StateReference, Tx } from '@aztec/stdlib/tx';
 
 import type { PeerId } from '@libp2p/interface';
 import { z } from 'zod';
+
+import type { CommitteeAttestationsAndSigners } from '../block/index.js';
 
 /**
  * Validator client configuration
@@ -67,4 +70,8 @@ export interface Validator {
 
   broadcastBlockProposal(proposal: BlockProposal): Promise<void>;
   collectAttestations(proposal: BlockProposal, required: number, deadline: Date): Promise<BlockAttestation[]>;
+  signAttestationsAndSigners(
+    attestationsAndSigners: CommitteeAttestationsAndSigners,
+    proposer: EthAddress,
+  ): Promise<Signature>;
 }

--- a/yarn-project/stdlib/src/p2p/signature_utils.ts
+++ b/yarn-project/stdlib/src/p2p/signature_utils.ts
@@ -4,6 +4,7 @@ import { keccak256, makeEthSignDigest } from '@aztec/foundation/crypto';
 export enum SignatureDomainSeparator {
   blockProposal = 0,
   blockAttestation = 1,
+  attestationsAndSigners = 2,
 }
 
 export interface Signable {

--- a/yarn-project/stdlib/src/tests/mocks.ts
+++ b/yarn-project/stdlib/src/tests/mocks.ts
@@ -8,6 +8,7 @@ import type { ContractArtifact } from '../abi/abi.js';
 import { AztecAddress } from '../aztec-address/index.js';
 import { CommitteeAttestation } from '../block/index.js';
 import { L2Block } from '../block/l2_block.js';
+import type { CommitteeAttestationsAndSigners } from '../block/proposal/attestations_and_signers.js';
 import type { PublishedL2Block } from '../block/published_l2_block.js';
 import { computeContractAddressFromInstance } from '../contract/contract_address.js';
 import { getContractClassFromArtifact } from '../contract/contract_class.js';
@@ -271,6 +272,17 @@ const makeAndSignConsensusPayload = (
   const signature = signer.sign(hash);
 
   return { blockNumber: header.globalVariables.blockNumber, payload, signature };
+};
+
+export const makeAndSignCommitteeAttestationsAndSigners = (
+  attestationsAndSigners: CommitteeAttestationsAndSigners,
+  signer: Secp256k1Signer = Secp256k1Signer.random(),
+) => {
+  const hash = getHashedSignaturePayloadEthSignedMessage(
+    attestationsAndSigners,
+    SignatureDomainSeparator.attestationsAndSigners,
+  );
+  return signer.sign(hash);
 };
 
 export const makeBlockProposal = (options?: MakeConsensusPayloadOptions): BlockProposal => {

--- a/yarn-project/validator-client/src/duties/validation_service.ts
+++ b/yarn-project/validator-client/src/duties/validation_service.ts
@@ -3,6 +3,7 @@ import { keccak256 } from '@aztec/foundation/crypto';
 import type { EthAddress } from '@aztec/foundation/eth-address';
 import type { Signature } from '@aztec/foundation/eth-signature';
 import type { Fr } from '@aztec/foundation/fields';
+import type { CommitteeAttestationsAndSigners } from '@aztec/stdlib/block';
 import {
   BlockAttestation,
   BlockProposal,
@@ -75,5 +76,15 @@ export class ValidationService {
     );
     //await this.keyStore.signMessage(buf);
     return signatures.map(sig => new BlockAttestation(proposal.blockNumber, proposal.payload, sig));
+  }
+
+  async signAttestationsAndSigners(
+    attestationsAndSigners: CommitteeAttestationsAndSigners,
+    proposer: EthAddress,
+  ): Promise<Signature> {
+    const buf = Buffer32.fromBuffer(
+      keccak256(attestationsAndSigners.getPayloadToSign(SignatureDomainSeparator.attestationsAndSigners)),
+    );
+    return await this.keyStore.signMessageWithAddress(proposer, buf);
   }
 }

--- a/yarn-project/validator-client/src/validator.ts
+++ b/yarn-project/validator-client/src/validator.ts
@@ -1,6 +1,7 @@
 import { INITIAL_L2_BLOCK_NUM } from '@aztec/constants';
 import type { EpochCache } from '@aztec/epoch-cache';
 import type { EthAddress } from '@aztec/foundation/eth-address';
+import type { Signature } from '@aztec/foundation/eth-signature';
 import { Fr } from '@aztec/foundation/fields';
 import { type Logger, createLogger } from '@aztec/foundation/log';
 import { retryUntil } from '@aztec/foundation/retry';
@@ -20,7 +21,7 @@ import {
   type WatcherEmitter,
 } from '@aztec/slasher';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
-import type { L2BlockSource } from '@aztec/stdlib/block';
+import type { CommitteeAttestationsAndSigners, L2BlockSource } from '@aztec/stdlib/block';
 import { getTimestampForSlot } from '@aztec/stdlib/epoch-helpers';
 import type { IFullNodeBlockBuilder, Validator, ValidatorClientFullConfig } from '@aztec/stdlib/interfaces/server';
 import type { L1ToL2MessageSource } from '@aztec/stdlib/messaging';
@@ -493,6 +494,13 @@ export class ValidatorClient extends (EventEmitter as new () => WatcherEmitter) 
 
   async broadcastBlockProposal(proposal: BlockProposal): Promise<void> {
     await this.p2pClient.broadcastProposal(proposal);
+  }
+
+  async signAttestationsAndSigners(
+    attestationsAndSigners: CommitteeAttestationsAndSigners,
+    proposer: EthAddress,
+  ): Promise<Signature> {
+    return await this.validationService.signAttestationsAndSigners(attestationsAndSigners, proposer);
   }
 
   async collectOwnAttestations(proposal: BlockProposal): Promise<BlockAttestation[]> {


### PR DESCRIPTION
To avoid a potential frontrunning issue, we need the proposer sign over the (attestaions, signers) data such that someone else cannot alter it to make an invalid block and dos.

This does increase the cost of propose 😭 

Some things I ran into when during this:
- There were a bunch of tech debt for the propose in the sequencer, it would pass along the `txHashes` but that is not something we have done for quite some time now. So I removed those.
- I got rid of the `PackAttestation` in rollup.ts and had separate class to easily have the digest computation etc




