### PR TITLE
fix: disable old chart and proper runner file mounting

### DIFF
--- a/.github/workflows/ci3.yml
+++ b/.github/workflows/ci3.yml
@@ -91,9 +91,9 @@ jobs:
           chmod 600 ~/.ssh/build_instance_key
           sudo apt install -y --no-install-recommends redis-tools parallel
 
-      - name: Write GCP key into credentials file
+      - name: Store the GCP key in a base64 encoded string
         run: |
-          echo "${{ secrets.GCP_SA_KEY }}" > ${{ env.GOOGLE_APPLICATION_CREDENTIALS }}
+          echo "GCP_SA_KEY_B64=$(echo "${{ secrets.GCP_SA_KEY }}" | base64 -w 0)" >> $GITHUB_ENV
 
       - name: Get Tree Hash
         run: echo "TREE_HASH=$(git rev-parse HEAD^{tree})" >> $GITHUB_ENV
@@ -122,6 +122,7 @@ jobs:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
           # Nightly test env vars.
           GOOGLE_APPLICATION_CREDENTIALS: ${{ env.GOOGLE_APPLICATION_CREDENTIALS }}
+          GCP_SA_KEY_B64: ${{ env.GCP_SA_KEY_B64 }}
           EXTERNAL_ETHEREUM_HOSTS: "https://json-rpc.${{ secrets.GCP_SEPOLIA_URL }}?key=${{ secrets.GCP_SEPOLIA_API_KEY }},${{ secrets.INFURA_SEPOLIA_URL }}"
           EXTERNAL_ETHEREUM_CONSENSUS_HOST: "https://beacon.${{ secrets.GCP_SEPOLIA_URL }}"
           EXTERNAL_ETHEREUM_CONSENSUS_HOST_API_KEY: ${{ secrets.GCP_SEPOLIA_API_KEY }}

--- a/.github/workflows/deploy-staging-networks.yml
+++ b/.github/workflows/deploy-staging-networks.yml
@@ -36,13 +36,13 @@ jobs:
           chmod 600 ~/.ssh/build_instance_key
           sudo apt install -y --no-install-recommends redis-tools parallel
 
-      - name: Write GCP key into credentials file
+      - name: Store the GCP key in a base64 encoded string
         run: |
-          echo "${{ secrets.GCP_SA_KEY }}" > ${{ env.GOOGLE_APPLICATION_CREDENTIALS }}
+          echo "GCP_SA_KEY_B64=$(echo "${{ secrets.GCP_SA_KEY }}" | base64 -w 0)" >> $GITHUB_ENV
 
       # note: it is fine to log the mnemonic here. this is an internal,
       # throwaway test network.
-      - name: Write staging-public network env file
+      - name: Write staging-public network env file into a base64 encoded string
         run: |
           SEMVER_SALT = $(echo ${{ github.event.client_payload.major_version }} | md5sum | cut -d' ' -f1)
           cat > ${{ env.NETWORK_ENV_FILE }} <<EOF
@@ -63,6 +63,7 @@ jobs:
           LABS_INFRA_INDICES="0,1,2,3,4,1000"
           VALIDATOR_INDICES="1,2,3,4"
           EOF
+          echo "NETWORK_ENV_FILE_B64=$(echo "${{ env.NETWORK_ENV_FILE }}" | base64 -w 0)" >> $GITHUB_ENV
 
       #############
       # Run
@@ -75,8 +76,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
           RUN_ID: ${{ github.run_id }}
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          # Pass the base64 encoded strings, and where they should be decoded to
           NETWORK_ENV_FILE: ${{ env.NETWORK_ENV_FILE }}
+          NETWORK_ENV_FILE_B64: ${{ env.NETWORK_ENV_FILE_B64 }}
           GOOGLE_APPLICATION_CREDENTIALS: ${{ env.GOOGLE_APPLICATION_CREDENTIALS }}
+          GCP_SA_KEY_B64: ${{ env.GCP_SA_KEY_B64 }}
         run: |
           # the network env file and gcp credentials file are mounted into the ec2 instance
           # see ci3/bootstrap_ec2

--- a/.github/workflows/test-network-scenarios.yml
+++ b/.github/workflows/test-network-scenarios.yml
@@ -35,13 +35,13 @@ jobs:
           chmod 600 ~/.ssh/build_instance_key
           sudo apt install -y --no-install-recommends redis-tools parallel
 
-      - name: Write GCP key into credentials file
+      - name: Store the GCP key in a base64 encoded string
         run: |
-          echo "${{ secrets.GCP_SA_KEY }}" > ${{ env.GOOGLE_APPLICATION_CREDENTIALS }}
+          echo "GCP_SA_KEY_B64=$(echo "${{ secrets.GCP_SA_KEY }}" | base64 -w 0)" >> $GITHUB_ENV
 
       # note: it is fine to log the mnemonic here. this is an internal,
       # throwaway test network, which you can see gets destroyed before it is created each time.
-      - name: Write network env file
+      - name: Write network env file into a base64 encoded string
         run: |
           SEMVER_SALT = $(echo ${{ github.event.client_payload.major_version }} | md5sum | cut -d' ' -f1)
           cat > ${{ env.NETWORK_ENV_FILE }} <<EOF
@@ -58,6 +58,7 @@ jobs:
           ETHEREUM_CHAIN_ID=1337
           LABS_INFRA_MNEMONIC="test test test test test test test test test test test junk"
           EOF
+          echo "NETWORK_ENV_FILE_B64=$(echo "${{ env.NETWORK_ENV_FILE }}" | base64 -w 0)" >> $GITHUB_ENV
 
       - name: Get Tree Hash
         run: echo "TREE_HASH=$(git rev-parse HEAD^{tree})" >> $GITHUB_ENV
@@ -80,8 +81,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
           RUN_ID: ${{ github.run_id }}
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          # Pass the base64 encoded strings, and where they should be decoded to
           NETWORK_ENV_FILE: ${{ env.NETWORK_ENV_FILE }}
+          NETWORK_ENV_FILE_B64: ${{ env.NETWORK_ENV_FILE_B64 }}
           GOOGLE_APPLICATION_CREDENTIALS: ${{ env.GOOGLE_APPLICATION_CREDENTIALS }}
+          GCP_SA_KEY_B64: ${{ env.GCP_SA_KEY_B64 }}
         run: |
           # the network env file and gcp credentials file are mounted into the ec2 instance
           # see ci3/bootstrap_ec2

--- a/ci3/bootstrap_ec2
+++ b/ci3/bootstrap_ec2
@@ -210,6 +210,19 @@ function run {
 
     aws_token=\$(curl -sX PUT http://169.254.169.254/latest/api/token -H 'X-aws-ec2-metadata-token-ttl-seconds: 21600')
 
+
+    # Save GCP_SA_KEY to a file if set
+    if [ -n '${GCP_SA_KEY_B64:-}' ]; then
+      echo '${GCP_SA_KEY_B64:-}' | base64 -d > ${GOOGLE_APPLICATION_CREDENTIALS}
+      echo 'GCP_SA_KEY decoded and saved to ${GOOGLE_APPLICATION_CREDENTIALS}'
+    fi
+
+    # Save NETWORK_ENV_FILE to a file if set
+    if [ -n '${NETWORK_ENV_FILE_B64:-}' ]; then
+      echo '${NETWORK_ENV_FILE_B64:-}' | base64 -d > ${NETWORK_ENV_FILE}
+      echo 'NETWORK_ENV_FILE decoded and saved to ${NETWORK_ENV_FILE}'
+    fi
+
     start_build() {
       echo Starting devbox...
       docker run --privileged --rm \${docker_args:-} \

--- a/spartan/bootstrap.sh
+++ b/spartan/bootstrap.sh
@@ -88,22 +88,13 @@ function single_test {
 
 function start_env {
   if [ "$CI_NIGHTLY" -eq 1 ] && [ "$(arch)" != "arm64" ]; then
-    NIGHTLY_NS=nightly-$(git rev-parse --short HEAD)
-    export MONITOR_DEPLOYMENT=false
-    export WAIT_FOR_DEPLOYMENT=false
-    export CLUSTER_NAME=aztec-gke-private
-    export ZONE=us-west1-a
-    export GCP_PROJECT_ID=${GCP_PROJECT_ID:-"testnet-440309"}
-    echo "Installing test network in namespace $NIGHTLY_NS"
-    ./scripts/deploy_k8s.sh gke "$NIGHTLY_NS" ci-fast-epoch.yaml false "mnemonic.tmp" "$NIGHTLY_NS" "$GCP_PROJECT_ID"
+    echo "Skipping start_env for nightly while we migrate to use the same deployment flow as the scenario/staging networks."
   fi
 }
 
 function stop_env {
   if [ "$CI_NIGHTLY" -eq 1 ] && [ "$(arch)" != "arm64" ]; then
-    NIGHTLY_NS=nightly-$(date -u +%Y%m%d)
-    echo "Uninstalling test network in namespace $NIGHTLY_NS"
-    ./scripts/cleanup_k8s.sh "$NIGHTLY_NS" "$NIGHTLY_NS"
+    echo "Skipping stop_env for nightly while we migrate to use the same deployment flow as the scenario/staging networks."
   fi
 }
 


### PR DESCRIPTION
Properly pass the gcp credentials and network file to the bootstrap instance.

Do not start a test env using the old chart during nightly runs.