### PR TITLE
chore: update readme in the eccvm to include description of multiset and lookups

### DIFF
--- a/barretenberg/cpp/src/barretenberg/eccvm/README.md
+++ b/barretenberg/cpp/src/barretenberg/eccvm/README.md
@@ -35,6 +35,8 @@ We also use the following constants:
 - \f$\texttt{NUM-WNAF-DIGITS-PER-SCALAR}=\texttt{NUM-SCALAR-BITS} / \texttt{NUM-WNAF-DIGIT-BITS} = 32\f$
 - \f$\texttt{ADDITIONS-PER-ROW} = 4\f$
 
+Finally, the terminology `pc` stands for _point-counter_. (In particular, it does _not_ stand for "program counter".)
+
 ## Bird's eye overview/motivation
 
 In a nutshell, the ECCVM is a simple virtual machine to facilitate the verification of native elliptic curve computations. Given an `op_queue` of BN-254 operations, the ECCVM compiles the execution of these operations into an _execution trace representation_ over \f$\fq\f$ (the field of definition / base field of BN-254). This field is also the scalar field of Grumpkin.
@@ -631,3 +633,27 @@ Suppose we have an MSM of short scalars of size \f$m\f$. Then the number of rows
 Indeed, there are \f$\lceil \frac{m}{\texttt{ADDITIONS-PER-ROW}}\rceil\f$ `add`-rows per digit, and there are \f$\texttt{NUM-WNAF-DIGITS-PER-SCALAR + 1}\f$ digits per scalar (where the last digit is the `skew` digit). Finally, the last term comes from the doublings.
 
 Note that in the regime where we have a few long MSMs, this is asymptotic to \f$8.25m\f$, which is comparable to the \f$8m\f$ we get from the precomputed columns. On the other hand, if we have many very short MSMs, the size of this table dominates what was produced by the precomputed columns.
+
+## Multisets and Lookups
+
+As explained in the introduction, we psychologically treat these three sets of disjoint columns as three separate tables. There must therefore be a mechanism to ensure that they "communicate" with each other. We do _not_ use bare copy-constraints; instead, we use three multisets equality checks. (These were formerly called "strict lookup arguments", where every write had to have precisely one corresponding read.) The goal of these section is to sketch how these constraints, together with the lookups, fully piece together the ECCVM. We emphasize that this is merely a sketch; for full details, please see the [set relation](../relations/ecc_vm/ecc_set_relation_impl.hpp).
+
+### Multisets
+
+The basic structure: each term corresponds to _two_ multisets. (One could refer to these as an input multiset and an output multiset, but this directionality is purely psychological and we avoid it.) One table contributes to one of the multisets, another to the second multiset, and the term is _satisfied_ if the two multisets are equal.
+
+#### First term: `(pc, round, wnaf_slice)`
+
+This facilitates communication between the Precomputed table and the MSM table. Recall that `pc` stands for point-counter. `round` refers to the wNAF digit-place being processed and `wnaf_slice` is the _compressed_ digit (i.e., it is a way of representing the actual wNAF digit). Recall that the skew digit's place corresponds to `round == 32`.
+
+#### Second term: `(pc, P.x, P.y, scalar-multiplier)`
+
+This facilitates communication between the Precomputed table (and more specifically, the PointTable) and the Transcript table. More precisely, it ensures that the Precomputed table has done the wNAF decomposition correctly for the point `(P.x, P.y)`, which further precisely corresponds to `pc`.
+
+#### Third term: `(pc, P.x, P.y, msm-size)`
+
+This facilitates communication between the MSM table and the Transcript table. More precisely, this links the _output_ of the MSM (that is performed by the MSM table) to what is written in the Transcript table. We also ensure that `msm-size` is correctly inputed into the MSM table.
+
+### Lookups
+
+Unlike the multisets (a.k.a. "strict lookup arguments"), the lookups here are more conventional. For every non-trivial point \f$P\f$, there is a lookup table (computed by the Precomputed table) that contains `(pc, compressed_slice, (2 * (compressed_slice) - 15)[P])`, where `compressed_slice` is in the range {0, ..., 15}. The MSM table will look up the relevant value as it goes through the Straus algorithm. For full details, please see [lookup relation](../relations/ecc_vm/ecc_lookup_relation.hpp).

--- a/barretenberg/cpp/src/barretenberg/eccvm/README.md
+++ b/barretenberg/cpp/src/barretenberg/eccvm/README.md
@@ -636,19 +636,19 @@ Note that in the regime where we have a few long MSMs, this is asymptotic to \f$
 
 ## Multisets and Lookups
 
-As explained in the introduction, we psychologically treat these three sets of disjoint columns as three separate tables. There must therefore be a mechanism to ensure that they "communicate" with each other. We do _not_ use bare copy-constraints; instead, we use three multisets equality checks. (These were formerly called "strict lookup arguments", where every write had to have precisely one corresponding read.) The goal of these section is to sketch how these constraints, together with the lookups, fully piece together the ECCVM. We emphasize that this is merely a sketch; for full details, please see the [set relation](../relations/ecc_vm/ecc_set_relation_impl.hpp).
+As explained in the introduction, we sometimes treat these three sets of disjoint columns as three separate tables. There must be a mechanism to ensure that they "communicate" with each other. We do _not_ use bare copy-constraints; instead, we use three multisets equality checks. (These were formerly called "strict lookup arguments", where every write had to have precisely one corresponding read.) The goal of these section is to sketch how these constraints, together with the lookups, fully piece together the ECCVM. We emphasize that this is merely a sketch; for full details, please see the [set relation](../relations/ecc_vm/ecc_set_relation_impl.hpp).
 
 ### Multisets
 
-The basic structure: each term corresponds to _two_ multisets. (One could refer to these as an input multiset and an output multiset, but this directionality is purely psychological and we avoid it.) One table contributes to one of the multisets, another to the second multiset, and the term is _satisfied_ if the two multisets are equal.
+The basic structure: each term corresponds to _two_ multisets. (One could refer to these as an input multiset and an output multiset, but this directionality is purely psychological and we avoid it.) One table contributes to one of the multisets, another table constributes to the other multiset, and the term is _satisfied_ if the two multisets are equal.
 
 #### First term: `(pc, round, wnaf_slice)`
 
-This facilitates communication between the Precomputed table and the MSM table. Recall that `pc` stands for point-counter. `round` refers to the wNAF digit-place being processed and `wnaf_slice` is the _compressed_ digit (i.e., it is a way of representing the actual wNAF digit). Recall that the skew digit's place corresponds to `round == 32`.
+This facilitates communication between the Precomputed table and the MSM table. Recall that `pc` stands for point-counter. `round` refers to the wNAF digit-place being processed and `wnaf_slice` is the _compressed_ digit (i.e., it is a way of representing the actual wNAF digit). Recall that the skew digit's place corresponds to `round == 32`. This multiset check ensures that at every `round`, for a given point, the wNAF digit computed by the Precomputed table is actually being used by the MSM table.
 
 #### Second term: `(pc, P.x, P.y, scalar-multiplier)`
 
-This facilitates communication between the Precomputed table (and more specifically, the PointTable) and the Transcript table. More precisely, it ensures that the Precomputed table has done the wNAF decomposition correctly for the point `(P.x, P.y)`, which further precisely corresponds to `pc`.
+This facilitates communication between the Precomputed table (and more specifically, the PointTable) and the Transcript table. More precisely, it ensures that the Precomputed table has done the wNAF decomposition correctly for the scalar corresponding to the point at position `pc`.
 
 #### Third term: `(pc, P.x, P.y, msm-size)`
 


### PR DESCRIPTION
only documentation