### PR TITLE
chore: compute beta products for max log dyadic size instead of 21

### DIFF
--- a/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover_impl.hpp
@@ -89,7 +89,8 @@ ProtogalaxyProver_<Flavor, NUM_KEYS>::combiner_quotient_round(const std::vector<
     const std::vector<FF> updated_gate_challenges =
         update_gate_challenges(perturbator_challenge, gate_challenges, deltas);
     const UnivariateSubrelationSeparators alphas = PGInternal::compute_and_extend_alphas(keys);
-    const GateSeparatorPolynomial<FF> gate_separators{ updated_gate_challenges, CONST_PG_LOG_N };
+    const GateSeparatorPolynomial<FF> gate_separators{ updated_gate_challenges,
+                                                       numeric::get_msb(keys.get_max_dyadic_size()) };
     const UnivariateRelationParameters relation_parameters =
         PGInternal::template compute_extended_relation_parameters<UnivariateRelationParameters>(keys);
 

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/decider_keys.hpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/decider_keys.hpp
@@ -8,6 +8,8 @@
 #include "barretenberg/common/assert.hpp"
 #include "barretenberg/ultra_honk/decider_proving_key.hpp"
 #include "barretenberg/ultra_honk/decider_verification_key.hpp"
+#include <algorithm>
+#include <ranges>
 
 namespace bb {
 
@@ -90,6 +92,16 @@ template <IsUltraOrMegaHonk Flavor_, size_t NUM_ = 2> struct DeciderProvingKeys_
             dpk_idx++;
         }
         return results;
+    }
+
+    /**
+     * @brief Get the maximum dyadic circuit size among all decider proving keys
+     * @return The maximum dyadic size
+     */
+    size_t get_max_dyadic_size() const
+    {
+        return std::ranges::max(
+            _data | std::views::transform([](const auto& dpk) { return dpk != nullptr ? dpk->dyadic_size() : 0; }));
     }
 
   private:


### PR DESCRIPTION
From running `BB_BENCH=1 ./build/bin/client_ivc_bench --benchmark_filter='.*Full/5.*'`, we can see that the `compute_combiner` only takes up 53.3% of the time of `combiner_quotient_round`.  

```
  ├─ ProtogalaxyProver_::combiner_quotient_round                                       [1]  20.4 %   1.18s      (107.14 ms x 11)
    ├─ compute_combiner                                                                  [2]  53.3 %   628.5ms    (57.14 ms x 11)
    └─ (other)                                                                           [2]  46.7 %   550.1ms   
```

After some investigation, about 40% of the time was spent on `compute_beta_products` to construct gate separators. Its size was a constant 2**21 but we only use it up to the dyadic size of the circuit. This PR passes the max dyadic size instead.

This change saved about 500ms from `combiner_quotient_round` in the `Full/5` benchmark. 

```
  └─ ProtogalaxyProver_::combiner_quotient_round                                       [1]  12.7 %   693.0ms    (63.00 ms x 11)
    ├─ compute_combiner                                                                  [2]  90.2 %   625.1ms    (56.83 ms x 11)
    └─ (other)                                                                           [2]  9.8  %
```