### PR TITLE
fix: AVM hints for Cpp must use current block gasFees rather than historical

### DIFF
--- a/.test_patterns.yml
+++ b/.test_patterns.yml
@@ -14,6 +14,7 @@ names:
   - akosh: &akosh "U07PQ3Y4GHJ"
   - alex: &alex "U05QWV669JB"
   - charlie: &charlie "UKUMA5J7K"
+  - david: &david "U03T2QRT1NW"
   - grego: &grego "U0689QRCE9L"
   - lasse: &lasse "U03E5SYLY3Z"
   - leila: &leila "UBLTU1NJ3"
@@ -263,6 +264,8 @@ tests:
       - *luke
   - regex: "e2e_prover/full"
     error_regex: "ProvingError: Failed to verify proof from key!"
+    owners:
+      - *david
   - regex: "slasher/src/slasher_client.test.ts"
     error_regex: "ContractFunctionExecutionError: The contract function"
     owners:

--- a/yarn-project/end-to-end/src/e2e_prover/full.test.ts
+++ b/yarn-project/end-to-end/src/e2e_prover/full.test.ts
@@ -20,8 +20,7 @@ import { FullProverTest } from '../fixtures/e2e_prover_test.js';
 const TIMEOUT = 1_200_000;
 
 // This makes AVM proving throw if there's a failure.
-//process.env.AVM_PROVING_STRICT = '1';
-// TODO(dbanks12): re-enable ^ after debugging and fixing AVM proving failures.
+process.env.AVM_PROVING_STRICT = '1';
 
 describe('full_prover', () => {
   const REAL_PROOFS = !parseBooleanEnv(process.env.FAKE_PROOFS);

--- a/yarn-project/simulator/src/public/public_tx_simulator/public_tx_simulator.ts
+++ b/yarn-project/simulator/src/public/public_tx_simulator/public_tx_simulator.ts
@@ -74,7 +74,7 @@ export class PublicTxSimulator {
       this.log.debug(`Simulating ${tx.publicFunctionCalldata.length} public calls for tx ${txHash}`, { txHash });
 
       // Create hinting DBs.
-      const hints = new AvmExecutionHints(this.globalVariables, AvmTxHint.fromTx(tx));
+      const hints = new AvmExecutionHints(this.globalVariables, AvmTxHint.fromTx(tx, this.globalVariables.gasFees));
       const hintingMerkleTree = await HintingMerkleWriteOperations.create(this.merkleTree, hints);
       const hintingTreesDB = new PublicTreesDB(hintingMerkleTree);
       const hintingContractsDB = new HintingPublicContractsDB(this.contractsDB, hints);

--- a/yarn-project/stdlib/src/avm/avm.ts
+++ b/yarn-project/stdlib/src/avm/avm.ts
@@ -408,15 +408,12 @@ export class AvmTxHint {
     public readonly feePayer: AztecAddress,
   ) {}
 
-  static fromTx(tx: Tx): AvmTxHint {
+  static fromTx(tx: Tx, gasFees: GasFees): AvmTxHint {
     const setupCallRequests = tx.getNonRevertiblePublicCallRequestsWithCalldata();
     const appLogicCallRequests = tx.getRevertiblePublicCallRequestsWithCalldata();
     const teardownCallRequest = tx.getTeardownPublicCallRequestWithCalldata();
     const gasSettings = tx.data.constants.txContext.gasSettings;
-    const effectiveGasFees = computeEffectiveGasFees(
-      tx.data.constants.historicalHeader.globalVariables.gasFees,
-      gasSettings,
-    );
+    const effectiveGasFees = computeEffectiveGasFees(gasFees, gasSettings);
 
     // For informational purposes. Assumed quick because it should be cached.
     const txHash = tx.getTxHash();

--- a/yarn-project/stdlib/src/fees/transaction_fee.ts
+++ b/yarn-project/stdlib/src/fees/transaction_fee.ts
@@ -1,5 +1,7 @@
 import type { Fr } from '@aztec/foundation/fields';
 
+import { strict as assert } from 'assert';
+
 import type { Gas } from '../gas/gas.js';
 import { GasFees } from '../gas/gas_fees.js';
 import type { GasSettings } from '../gas/gas_settings.js';
@@ -11,6 +13,15 @@ import type { GasSettings } from '../gas/gas_settings.js';
 export function computeEffectiveGasFees(gasFees: GasFees, gasSettings: GasSettings): GasFees {
   const { maxFeesPerGas, maxPriorityFeesPerGas } = gasSettings;
   const minBigInt = (f1: bigint, f2: bigint) => (f1 < f2 ? f1 : f2);
+
+  assert(
+    maxFeesPerGas.feePerDaGas >= gasFees.feePerDaGas,
+    `maxFeesPerGas.feePerDaGas must be greater than or equal to gasFees.feePerDaGas, but got maxFeesPerGas.feePerDaGas=${maxFeesPerGas.feePerDaGas} and gasFees.feePerDaGas=${gasFees.feePerDaGas}`,
+  );
+  assert(
+    maxFeesPerGas.feePerL2Gas >= gasFees.feePerL2Gas,
+    `maxFeesPerGas.feePerL2Gas must be greater than or equal to gasFees.feePerL2Gas, but got maxFeesPerGas.feePerL2Gas=${maxFeesPerGas.feePerL2Gas} and gasFees.feePerL2Gas=${gasFees.feePerL2Gas}`,
+  );
   const priorityFees = new GasFees(
     minBigInt(maxPriorityFeesPerGas.feePerDaGas, maxFeesPerGas.feePerDaGas - gasFees.feePerDaGas),
     minBigInt(maxPriorityFeesPerGas.feePerL2Gas, maxFeesPerGas.feePerL2Gas - gasFees.feePerL2Gas),


### PR DESCRIPTION
See [slack discussion](https://aztecprotocol.slack.com/archives/C04DL2L1UP2/p1756916843210969) for context

1. Fix AVM's hinting to C++ to use current block's gasFees rather than historical
2. Add asserts to `computeEffectiveGasFees` so that it will give a helpful error message if `gasFees > maxGasFees` instead of silently underflowing.
3. Re-enable `AVM_PROVING_STRICT` in e2e prover full
4. Add myself as notifyee for the relevant e2e prover flake

I'll be stacking a new test on top of this PR to catch such misuse of historical gasFees.