### PR TITLE
fix: Sentinel computes inactivity based on missed proposals too

### DIFF
--- a/yarn-project/aztec-node/src/sentinel/sentinel.test.ts
+++ b/yarn-project/aztec-node/src/sentinel/sentinel.test.ts
@@ -4,7 +4,7 @@ import { Secp256k1Signer } from '@aztec/foundation/crypto';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { AztecLMDBStoreV2, openTmpStore } from '@aztec/kv-store/lmdb-v2';
 import type { P2PClient } from '@aztec/p2p';
-import { OffenseType, WANT_TO_SLASH_EVENT } from '@aztec/slasher';
+import { OffenseType, WANT_TO_SLASH_EVENT, type WantToSlashArgs } from '@aztec/slasher';
 import type { SlasherConfig } from '@aztec/slasher/config';
 import {
   type L2BlockSource,
@@ -24,7 +24,7 @@ import type {
 } from '@aztec/stdlib/validators';
 
 import { jest } from '@jest/globals';
-import { type MockProxy, mock, mockDeep } from 'jest-mock-extended';
+import { type MockProxy, mock } from 'jest-mock-extended';
 
 import { Sentinel } from './sentinel.js';
 import { SentinelStore } from './store.js';
@@ -287,8 +287,8 @@ describe('sentinel', () => {
         jest.spyOn(sentinel, 'computeStatsForValidator').mockReturnValue({
           address: validator,
           totalSlots: 2,
-          missedProposals: { count: 0, currentStreak: 0, rate: 0 },
-          missedAttestations: { count: 0, currentStreak: 0, rate: 0 },
+          missedProposals: { count: 0, currentStreak: 0, rate: 0, total: 0 },
+          missedAttestations: { count: 0, currentStreak: 0, rate: 0, total: 0 },
           history: mockHistory,
         });
 
@@ -298,8 +298,8 @@ describe('sentinel', () => {
           validator: {
             address: validator,
             totalSlots: 2,
-            missedProposals: { count: 0, currentStreak: 0, rate: 0 },
-            missedAttestations: { count: 0, currentStreak: 0, rate: 0 },
+            missedProposals: { count: 0, currentStreak: 0, rate: 0, total: 0 },
+            missedAttestations: { count: 0, currentStreak: 0, rate: 0, total: 0 },
             history: mockHistory,
           },
           allTimeProvenPerformance: mockProvenPerformance,
@@ -316,8 +316,8 @@ describe('sentinel', () => {
         const computeStatsSpy = jest.spyOn(sentinel, 'computeStatsForValidator').mockReturnValue({
           address: validator,
           totalSlots: 1,
-          missedProposals: { count: 0, currentStreak: 0, rate: 0 },
-          missedAttestations: { count: 0, currentStreak: 0, rate: 0 },
+          missedProposals: { count: 0, currentStreak: 0, rate: 0, total: 0 },
+          missedAttestations: { count: 0, currentStreak: 0, rate: 0, total: 0 },
           history: mockHistory,
         });
 
@@ -333,8 +333,8 @@ describe('sentinel', () => {
         const computeStatsSpy = jest.spyOn(sentinel, 'computeStatsForValidator').mockReturnValue({
           address: validator,
           totalSlots: 1,
-          missedProposals: { count: 0, currentStreak: 0, rate: 0 },
-          missedAttestations: { count: 0, currentStreak: 0, rate: 0 },
+          missedProposals: { count: 0, currentStreak: 0, rate: 0, total: 0 },
+          missedAttestations: { count: 0, currentStreak: 0, rate: 0, total: 0 },
           history: mockHistory,
         });
 
@@ -357,8 +357,8 @@ describe('sentinel', () => {
         jest.spyOn(sentinel, 'computeStatsForValidator').mockReturnValue({
           address: validator,
           totalSlots: 1,
-          missedProposals: { count: 0, currentStreak: 0, rate: 0 },
-          missedAttestations: { count: 0, currentStreak: 0, rate: 0 },
+          missedProposals: { count: 0, currentStreak: 0, rate: 0, total: 0 },
+          missedAttestations: { count: 0, currentStreak: 0, rate: 0, total: 0 },
           history: mockHistory,
         });
 
@@ -379,65 +379,52 @@ describe('sentinel', () => {
       const epochNumber = getEpochAtSlot(slot, l1Constants);
       const validator1 = EthAddress.random();
       const validator2 = EthAddress.random();
-      const headerSlots = times(5, i => slot - BigInt(i));
-      const mockHeaders = headerSlots.map(s => {
-        const header = mockDeep<PublishedL2Block['block']['header']>();
-        header.getSlot.mockReturnValue(s);
-        return header;
-      });
+      const validator3 = EthAddress.random();
+      const headerSlots = times(l1Constants.epochDuration, i => slot - BigInt(i)).reverse();
 
       epochCache.getEpochAndSlotNow.mockReturnValue({ epoch: epochNumber, slot, ts, now: ts });
       archiver.getBlock.calledWith(blockNumber).mockResolvedValue(mockBlock.block);
       archiver.getL1Constants.mockResolvedValue(l1Constants);
-
-      archiver.getBlockHeadersForEpoch.calledWith(epochNumber).mockResolvedValue(mockHeaders as any);
+      epochCache.getL1Constants.mockReturnValue(l1Constants);
 
       epochCache.getCommittee.mockResolvedValue({
-        committee: [validator1, validator2],
+        committee: [validator1, validator2, validator3],
         seed: 0n,
         epoch: epochNumber,
       });
-      const statsResult = {
+
+      const statsResult: ValidatorsStats = {
         stats: {
+          // Validator 1 missed 1 attestation only, we won't slash them
           [validator1.toString()]: {
             address: validator1,
             totalSlots: headerSlots.length,
-            missedProposals: { count: 0, currentStreak: 0, rate: 0 },
-            missedAttestations: { count: 1, currentStreak: 0, rate: 1 / 5 },
-            history: [
-              { slot: headerSlots[0], status: 'attestation-sent' },
-              { slot: headerSlots[1], status: 'attestation-missed' },
-              { slot: headerSlots[2], status: 'attestation-sent' },
-              { slot: headerSlots[3], status: 'attestation-sent' },
-              { slot: headerSlots[4], status: 'attestation-sent' },
-            ],
-          } as ValidatorStats,
+            missedProposals: { count: 0, currentStreak: 0, rate: 0, total: 0 },
+            missedAttestations: { count: 1, currentStreak: 0, rate: 1 / 8, total: 8 },
+            history: [],
+          },
+          // Validator 2 missed 7 out of 8, we will slash them
           [validator2.toString()]: {
             address: validator2,
             totalSlots: headerSlots.length,
-            missedProposals: { count: 0, currentStreak: 0, rate: 0 },
-            // We should only count the slots that are in the proven epoch (0, 1, 2)!!
-            missedAttestations: { count: 4, currentStreak: 3, rate: 4 / 5 },
-            history: [
-              { slot: headerSlots[0], status: 'attestation-missed' },
-              { slot: headerSlots[1], status: 'attestation-sent' },
-              { slot: headerSlots[2], status: 'attestation-missed' },
-              { slot: headerSlots[3], status: 'attestation-missed' },
-              { slot: headerSlots[4], status: 'attestation-missed' },
-            ],
-          } as ValidatorStats,
-          '0xNotAnAddress': {
-            address: EthAddress.ZERO, // Placeholder
-            totalSlots: 0,
-            missedProposals: { count: 0, currentStreak: 0, rate: undefined },
-            missedAttestations: { count: 0, currentStreak: 0, rate: undefined },
+            missedProposals: { count: 0, currentStreak: 0, rate: 0, total: 0 },
+            missedAttestations: { count: 7, currentStreak: 3, rate: 7 / 8, total: 8 },
             history: [],
-          } as ValidatorStats, // To test filtering
+          },
+          // Validator 3 missed 4 attestations out of 4, so we will slash them even though the epoch has 8 slots
+          // This difference happens because we don't count attestations for a slot where there was no proposal
+          [validator3.toString()]: {
+            address: validator3,
+            totalSlots: headerSlots.length,
+            missedProposals: { count: 0, currentStreak: 0, rate: 0, total: 0 },
+            missedAttestations: { count: 4, currentStreak: 4, rate: 4 / 4, total: 4 },
+            history: [],
+          },
         },
         lastProcessedSlot: slot,
         initialSlot: 0n,
         slotWindow: 15,
-      } as ValidatorsStats;
+      };
       const computeStatsSpy = jest.spyOn(sentinel, 'computeStats').mockResolvedValue(statsResult);
       const emitSpy = jest.spyOn(sentinel, 'emit');
 
@@ -446,19 +433,19 @@ describe('sentinel', () => {
       expect(computeStatsSpy).toHaveBeenCalledWith({
         fromSlot: headerSlots[0],
         toSlot: headerSlots[headerSlots.length - 1],
+        validators: [validator1, validator2, validator3],
+      });
+      const makeInactivitySlash = (validator: EthAddress): WantToSlashArgs => ({
+        validator,
+        amount: config.slashInactivityPenalty,
+        offenseType: OffenseType.INACTIVITY,
+        epochOrSlot: 1n,
       });
 
       expect(emitSpy).toHaveBeenCalledTimes(1);
       expect(emitSpy).toHaveBeenCalledWith(
         WANT_TO_SLASH_EVENT,
-        expect.arrayContaining([
-          expect.objectContaining({
-            validator: validator2,
-            amount: config.slashInactivityPenalty,
-            offenseType: OffenseType.INACTIVITY,
-            epochOrSlot: epochNumber,
-          }),
-        ]),
+        expect.arrayContaining([makeInactivitySlash(validator2), makeInactivitySlash(validator3)]),
       );
     });
   });
@@ -671,10 +658,6 @@ class TestSentinel extends Sentinel {
 
   public override handleProvenPerformance(epoch: bigint, performance: ValidatorsEpochPerformance) {
     return super.handleProvenPerformance(epoch, performance);
-  }
-
-  public override updateProvenPerformance(epoch: bigint, performance: ValidatorsEpochPerformance) {
-    return super.updateProvenPerformance(epoch, performance);
   }
 
   public override getValidatorStats(validatorAddress: EthAddress, fromSlot?: bigint, toSlot?: bigint) {

--- a/yarn-project/aztec-node/src/sentinel/sentinel.ts
+++ b/yarn-project/aztec-node/src/sentinel/sentinel.ts
@@ -1,5 +1,5 @@
 import type { EpochCache } from '@aztec/epoch-cache';
-import { countWhile, filterAsync } from '@aztec/foundation/collection';
+import { countWhile, filterAsync, fromEntries, getEntries, mapValues } from '@aztec/foundation/collection';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { createLogger } from '@aztec/foundation/log';
 import { RunningPromise } from '@aztec/foundation/running-promise';
@@ -14,7 +14,7 @@ import {
   type L2BlockStreamEventHandler,
   getAttestationsFromPublishedL2Block,
 } from '@aztec/stdlib/block';
-import { getEpochAtSlot, getTimestampForSlot } from '@aztec/stdlib/epoch-helpers';
+import { getEpochAtSlot, getSlotRangeForEpoch, getTimestampForSlot } from '@aztec/stdlib/epoch-helpers';
 import type {
   SingleValidatorStats,
   ValidatorStats,
@@ -115,53 +115,38 @@ export class Sentinel extends (EventEmitter as new () => WatcherEmitter) impleme
       return;
     }
 
-    const epoch = getEpochAtSlot(block.header.getSlot(), await this.archiver.getL1Constants());
+    // TODO(palla/slash): We should only be computing proven performance if this is
+    // a full proof epoch and not a partial one, otherwise we'll end up with skewed stats.
+    const epoch = getEpochAtSlot(block.header.getSlot(), this.epochCache.getL1Constants());
     this.logger.debug(`Computing proven performance for epoch ${epoch}`);
     const performance = await this.computeProvenPerformance(epoch);
     this.logger.info(`Computed proven performance for epoch ${epoch}`, performance);
 
-    await this.updateProvenPerformance(epoch, performance);
+    await this.store.updateProvenPerformance(epoch, performance);
     await this.handleProvenPerformance(epoch, performance);
   }
 
-  protected async computeProvenPerformance(epoch: bigint) {
-    const headers = await this.archiver.getBlockHeadersForEpoch(epoch);
-    const provenSlots = headers.map(h => h.getSlot());
-    const fromSlot = provenSlots[0];
-    const toSlot = provenSlots[provenSlots.length - 1];
+  protected async computeProvenPerformance(epoch: bigint): Promise<ValidatorsEpochPerformance> {
+    const [fromSlot, toSlot] = getSlotRangeForEpoch(epoch, this.epochCache.getL1Constants());
     const { committee } = await this.epochCache.getCommittee(fromSlot);
     if (!committee) {
       this.logger.trace(`No committee found for slot ${fromSlot}`);
       return {};
     }
-    const stats = await this.computeStats({ fromSlot, toSlot });
-    this.logger.debug(`Stats for epoch ${epoch}`, stats);
 
-    const performance: ValidatorsEpochPerformance = {};
-    for (const validator of Object.keys(stats.stats)) {
-      let address;
-      try {
-        address = EthAddress.fromString(validator);
-      } catch (e) {
-        this.logger.error(`Invalid validator address ${validator}`, e);
-        continue;
-      }
-      if (!committee.find(v => v.equals(address))) {
-        continue;
-      }
-      let missed = 0;
-      for (const history of stats.stats[validator].history) {
-        if (provenSlots.includes(history.slot) && history.status === 'attestation-missed') {
-          missed++;
-        }
-      }
-      performance[address.toString()] = { missed, total: provenSlots.length };
-    }
-    return performance;
-  }
+    const stats = await this.computeStats({ fromSlot, toSlot, validators: committee });
+    this.logger.debug(`Stats for epoch ${epoch}`, { ...stats, fromSlot, toSlot, epoch });
 
-  protected updateProvenPerformance(epoch: bigint, performance: ValidatorsEpochPerformance) {
-    return this.store.updateProvenPerformance(epoch, performance);
+    // Note that we are NOT using the total slots in the epoch as `total` here, since we only
+    // compute missed attestations over the blocks that had a proposal in them. So, let's say
+    // we have an epoch with 10 slots, but only 5 had a block proposal. A validator that was
+    // offline, assuming they were not picked as proposer, will then be reported as having missed
+    // 5/5 attestations. If we used the total, they'd be reported as 5/10, which would probably
+    // allow them to avoid being slashed.
+    return mapValues(stats.stats, stat => ({
+      missed: stat.missedAttestations.count + stat.missedProposals.count,
+      total: stat.missedAttestations.total + stat.missedProposals.total,
+    }));
   }
 
   /**
@@ -199,11 +184,9 @@ export class Sentinel extends (EventEmitter as new () => WatcherEmitter) impleme
   }
 
   protected async handleProvenPerformance(epoch: bigint, performance: ValidatorsEpochPerformance) {
-    const inactiveValidators = Object.entries(performance)
-      .filter(([_, { missed, total }]) => {
-        return missed / total >= this.config.slashInactivityTargetPercentage;
-      })
-      .map(([address]) => address as `0x${string}`);
+    const inactiveValidators = getEntries(performance)
+      .filter(([_, { missed, total }]) => missed / total >= this.config.slashInactivityTargetPercentage)
+      .map(([address]) => address);
 
     this.logger.debug(`Found ${inactiveValidators.length} inactive validators in epoch ${epoch}`, {
       inactiveValidators,
@@ -326,15 +309,18 @@ export class Sentinel extends (EventEmitter as new () => WatcherEmitter) impleme
     // (contains the ones synced from mined blocks, which we may have missed from p2p).
     const block = this.slotNumberToBlock.get(slot);
     const p2pAttested = await this.p2p.getAttestationsForSlot(slot, block?.archive);
-    const attestors = new Set([
-      ...p2pAttested.map(a => a.getSender().toString()),
-      ...(block?.attestors.map(a => a.toString()) ?? []),
-    ]);
+    const attestors = new Set(
+      [...p2pAttested.map(a => a.getSender().toString()), ...(block?.attestors.map(a => a.toString()) ?? [])].filter(
+        addr => proposer.toString() !== addr, // Exclude the proposer from the attestors
+      ),
+    );
 
-    // We assume that there was a block proposal if at least one of the validators attested to it.
+    // We assume that there was a block proposal if at least one of the validators (other than the proposer) attested to it.
     // It could be the case that every single validator failed, and we could differentiate it by having
     // this node re-execute every block proposal it sees and storing it in the attestation pool.
     // But we'll leave that corner case out to reduce pressure on the node.
+    // TODO(palla/slash): This breaks if a given node has more than one validator in the current committee,
+    // since they will attest to their own proposal it even if it's not re-executable.
     const blockStatus = block ? 'mined' : attestors.size > 0 ? 'proposed' : 'missed';
     this.logger.debug(`Block for slot ${slot} was ${blockStatus}`, { ...block, slot });
 
@@ -378,20 +364,24 @@ export class Sentinel extends (EventEmitter as new () => WatcherEmitter) impleme
 
   /** Computes stats to be returned based on stored data. */
   public async computeStats({
-    fromSlot: _fromSlot,
-    toSlot: _toSlot,
-  }: { fromSlot?: bigint; toSlot?: bigint } = {}): Promise<ValidatorsStats> {
-    const histories = await this.store.getHistories();
+    fromSlot,
+    toSlot,
+    validators,
+  }: { fromSlot?: bigint; toSlot?: bigint; validators?: EthAddress[] } = {}): Promise<ValidatorsStats> {
+    const histories = validators
+      ? fromEntries(await Promise.all(validators.map(async v => [v.toString(), await this.store.getHistory(v)])))
+      : await this.store.getHistories();
+
     const slotNow = this.epochCache.getEpochAndSlotNow().slot;
-    const fromSlot = _fromSlot ?? (this.lastProcessedSlot ?? slotNow) - BigInt(this.store.getHistoryLength());
-    const toSlot = _toSlot ?? this.lastProcessedSlot ?? slotNow;
-    const result: Record<`0x${string}`, ValidatorStats> = {};
-    for (const [address, history] of Object.entries(histories)) {
-      const validatorAddress = address as `0x${string}`;
-      result[validatorAddress] = this.computeStatsForValidator(validatorAddress, history, fromSlot, toSlot);
-    }
+    fromSlot ??= (this.lastProcessedSlot ?? slotNow) - BigInt(this.store.getHistoryLength());
+    toSlot ??= this.lastProcessedSlot ?? slotNow;
+
+    const stats = mapValues(histories, (history, address) =>
+      this.computeStatsForValidator(address, history ?? [], fromSlot, toSlot),
+    );
+
     return {
-      stats: result,
+      stats,
       lastProcessedSlot: this.lastProcessedSlot,
       initialSlot: this.initialSlot,
       slotWindow: this.store.getHistoryLength(),
@@ -447,30 +437,31 @@ export class Sentinel extends (EventEmitter as new () => WatcherEmitter) impleme
   ): ValidatorStats {
     let history = fromSlot ? allHistory.filter(h => h.slot >= fromSlot) : allHistory;
     history = toSlot ? history.filter(h => h.slot <= toSlot) : history;
+    const lastProposal = history.filter(h => h.status === 'block-proposed' || h.status === 'block-mined').at(-1);
+    const lastAttestation = history.filter(h => h.status === 'attestation-sent').at(-1);
     return {
       address: EthAddress.fromString(address),
-      lastProposal: this.computeFromSlot(
-        history.filter(h => h.status === 'block-proposed' || h.status === 'block-mined').at(-1)?.slot,
-      ),
-      lastAttestation: this.computeFromSlot(history.filter(h => h.status === 'attestation-sent').at(-1)?.slot),
+      lastProposal: this.computeFromSlot(lastProposal?.slot),
+      lastAttestation: this.computeFromSlot(lastAttestation?.slot),
       totalSlots: history.length,
-      missedProposals: this.computeMissed(history, 'block', 'block-missed'),
-      missedAttestations: this.computeMissed(history, 'attestation', 'attestation-missed'),
+      missedProposals: this.computeMissed(history, 'block', ['block-missed']),
+      missedAttestations: this.computeMissed(history, 'attestation', ['attestation-missed']),
       history,
     };
   }
 
   protected computeMissed(
     history: ValidatorStatusHistory,
-    computeOverPrefix: ValidatorStatusType,
-    filter: ValidatorStatusInSlot,
+    computeOverPrefix: ValidatorStatusType | undefined,
+    filter: ValidatorStatusInSlot[],
   ) {
-    const relevantHistory = history.filter(h => h.status.startsWith(computeOverPrefix));
-    const filteredHistory = relevantHistory.filter(h => h.status === filter);
+    const relevantHistory = history.filter(h => !computeOverPrefix || h.status.startsWith(computeOverPrefix));
+    const filteredHistory = relevantHistory.filter(h => filter.includes(h.status));
     return {
-      currentStreak: countWhile([...relevantHistory].reverse(), h => h.status === filter),
+      currentStreak: countWhile([...relevantHistory].reverse(), h => filter.includes(h.status)),
       rate: relevantHistory.length === 0 ? undefined : filteredHistory.length / relevantHistory.length,
       count: filteredHistory.length,
+      total: relevantHistory.length,
     };
   }
 

--- a/yarn-project/stdlib/src/epoch-helpers/index.ts
+++ b/yarn-project/stdlib/src/epoch-helpers/index.ts
@@ -56,7 +56,10 @@ export function getEpochAtSlot(slot: bigint, constants: Pick<L1RollupConstants, 
 }
 
 /** Returns the range of L2 slots (inclusive) for a given epoch number. */
-export function getSlotRangeForEpoch(epochNumber: bigint, constants: Pick<L1RollupConstants, 'epochDuration'>) {
+export function getSlotRangeForEpoch(
+  epochNumber: bigint,
+  constants: Pick<L1RollupConstants, 'epochDuration'>,
+): [bigint, bigint] {
   const startSlot = epochNumber * BigInt(constants.epochDuration);
   return [startSlot, startSlot + BigInt(constants.epochDuration) - 1n];
 }
@@ -68,7 +71,7 @@ export function getSlotRangeForEpoch(epochNumber: bigint, constants: Pick<L1Roll
 export function getTimestampRangeForEpoch(
   epochNumber: bigint,
   constants: Pick<L1RollupConstants, 'l1GenesisTime' | 'slotDuration' | 'epochDuration' | 'ethereumSlotDuration'>,
-) {
+): [bigint, bigint] {
   const [startSlot, endSlot] = getSlotRangeForEpoch(epochNumber, constants);
   const ethereumSlotsPerL2Slot = constants.slotDuration / constants.ethereumSlotDuration;
   return [

--- a/yarn-project/stdlib/src/interfaces/aztec-node.test.ts
+++ b/yarn-project/stdlib/src/interfaces/aztec-node.test.ts
@@ -322,11 +322,13 @@ describe('AztecNodeApiSchema', () => {
           missedAttestations: {
             currentStreak: 1,
             count: 1,
+            total: 1,
           },
           missedProposals: {
             currentStreak: 1,
             rate: 1,
             count: 1,
+            total: 1,
           },
           history: [{ slot: 1n, status: 'block-mined' }],
         },
@@ -373,8 +375,8 @@ describe('AztecNodeApiSchema', () => {
       validator: {
         address: validatorAddress,
         totalSlots: 5,
-        missedAttestations: { currentStreak: 0, count: 0 },
-        missedProposals: { currentStreak: 0, count: 0 },
+        missedAttestations: { currentStreak: 0, count: 0, total: 1 },
+        missedProposals: { currentStreak: 0, count: 0, total: 1 },
         history: [{ slot: 1n, status: 'block-mined' }],
       },
       allTimeProvenPerformance: [],
@@ -398,8 +400,8 @@ describe('AztecNodeApiSchema', () => {
       validator: {
         address: validatorAddress,
         totalSlots: 3,
-        missedAttestations: { currentStreak: 0, count: 0 },
-        missedProposals: { currentStreak: 0, count: 0 },
+        missedAttestations: { currentStreak: 0, count: 0, total: 0 },
+        missedProposals: { currentStreak: 0, count: 0, total: 0 },
         history: [{ slot: 5n, status: 'attestation-sent' }],
       },
       allTimeProvenPerformance: [],

--- a/yarn-project/stdlib/src/validators/schemas.ts
+++ b/yarn-project/stdlib/src/validators/schemas.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 
 import type {
   SingleValidatorStats,
+  ValidatorMissedStats,
   ValidatorStats,
   ValidatorStatusHistory,
   ValidatorStatusInSlot,
@@ -35,19 +36,20 @@ const ValidatorTimeStatSchema = z.object({
   date: z.string(),
 });
 
-const ValidatorFilteredHistorySchema = z.object({
+const ValidatorMissedStatsSchema = z.object({
   currentStreak: schemas.Integer,
   rate: z.number().optional(),
   count: schemas.Integer,
-});
+  total: schemas.Integer,
+}) satisfies ZodFor<ValidatorMissedStats>;
 
 export const ValidatorStatsSchema = z.object({
   address: schemas.EthAddress,
   lastProposal: ValidatorTimeStatSchema.optional(),
   lastAttestation: ValidatorTimeStatSchema.optional(),
   totalSlots: schemas.Integer,
-  missedProposals: ValidatorFilteredHistorySchema,
-  missedAttestations: ValidatorFilteredHistorySchema,
+  missedProposals: ValidatorMissedStatsSchema,
+  missedAttestations: ValidatorMissedStatsSchema,
   history: ValidatorStatusHistorySchema,
 }) satisfies ZodFor<ValidatorStats>;
 

--- a/yarn-project/stdlib/src/validators/types.ts
+++ b/yarn-project/stdlib/src/validators/types.ts
@@ -11,21 +11,20 @@ export type ValidatorStatusInSlot =
 
 export type ValidatorStatusHistory = { slot: bigint; status: ValidatorStatusInSlot }[];
 
+export type ValidatorMissedStats = {
+  currentStreak: number;
+  rate?: number;
+  count: number;
+  total: number;
+};
+
 export type ValidatorStats = {
   address: EthAddress;
   lastProposal?: { timestamp: bigint; slot: bigint; date: string };
   lastAttestation?: { timestamp: bigint; slot: bigint; date: string };
   totalSlots: number;
-  missedProposals: {
-    currentStreak: number;
-    rate?: number;
-    count: number;
-  };
-  missedAttestations: {
-    currentStreak: number;
-    rate?: number;
-    count: number;
-  };
+  missedProposals: ValidatorMissedStats;
+  missedAttestations: ValidatorMissedStats;
   history: ValidatorStatusHistory;
 };
 


### PR DESCRIPTION
We now account for missed proposals for computing inactivity for proven performance, rather than considering only slots where there was a block mined.
