### PR TITLE
chore: lock noir ref to commit

### DIFF
--- a/noir/noir-repo-ref
+++ b/noir/noir-repo-ref
@@ -1,1 +1,1 @@
-gd/acir-serialisation-changes
+5b65f9637e85a4177692c3190cb35ea678fb15e9


### PR DESCRIPTION
This PR replaces `noir-repo-ref` with the commit hash which `gd/acir-serialisation-changes` currently points to so that changes to that branch won't brick aztec-packages.

Can check commit on this PR: https://github.com/noir-lang/noir/pull/8134