### PR TITLE
chore: silence unhelpful forge lints

### DIFF
--- a/barretenberg/sol/foundry.toml
+++ b/barretenberg/sol/foundry.toml
@@ -13,4 +13,14 @@ runs = 2
 
 solc = "0.8.29"
 
+[lint]
+ignore = ["./lib/**"]
+exclude_lints = [
+  # Silencing due to just being style changes
+  "mixed-case-variable",
+  "mixed-case-function",
+  "screaming-snake-case-const",
+  "screaming-snake-case-immutable",
+]
+
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config

--- a/barretenberg/sol/src/honk/HonkTypes.sol
+++ b/barretenberg/sol/src/honk/HonkTypes.sol
@@ -145,6 +145,7 @@ library Honk {
         G1Point kzgQuotient;
     }
 
+    /// forge-lint: disable-next-item(pascal-case-struct)
     struct ZKProof {
         // Pairing point object
         Fr[PAIRING_POINTS_SIZE] pairingPointObject;

--- a/barretenberg/sol/src/honk/ZKTranscript.sol
+++ b/barretenberg/sol/src/honk/ZKTranscript.sol
@@ -14,6 +14,7 @@ import {Fr, FrLib} from "./Fr.sol";
 import {bytesToG1Point, bytesToFr} from "./utils.sol";
 
 // ZKTranscript library to generate fiat shamir challenges, the ZK transcript only differest
+/// forge-lint: disable-next-item(pascal-case-struct)
 struct ZKTranscript {
     // Oink
     Honk.RelationParameters relationParameters;

--- a/barretenberg/sol/test/base/DifferentialFuzzer.sol
+++ b/barretenberg/sol/test/base/DifferentialFuzzer.sol
@@ -1,6 +1,5 @@
 pragma solidity >=0.8.21;
 
-import {Vm} from "forge-std/Vm.sol";
 import {strings} from "stringutils/strings.sol";
 import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
 import {TestBase} from "./TestBase.sol";

--- a/barretenberg/sol/test/honk/Add2.t.sol
+++ b/barretenberg/sol/test/honk/Add2.t.sol
@@ -9,6 +9,7 @@ import {Add2HonkVerifier} from "../../src/honk/instance/Add2Honk.sol";
 import {DifferentialFuzzer} from "../base/DifferentialFuzzer.sol";
 import {IVerifier} from "../../src/interfaces/IVerifier.sol";
 
+/// forge-lint: disable-next-item(unaliased-plain-import)
 import "forge-std/console.sol";
 
 contract Add2HonkTest is TestBaseHonk {

--- a/barretenberg/sol/test/honk/Add2ZK.t.sol
+++ b/barretenberg/sol/test/honk/Add2ZK.t.sol
@@ -9,6 +9,7 @@ import {Add2HonkZKVerifier} from "../../src/honk/instance/Add2HonkZK.sol";
 import {DifferentialFuzzer} from "../base/DifferentialFuzzer.sol";
 import {IVerifier} from "../../src/interfaces/IVerifier.sol";
 
+/// forge-lint: disable-next-item(unaliased-plain-import)
 import "forge-std/console.sol";
 
 contract Add2HonkZKTest is TestBaseHonkZK {

--- a/barretenberg/sol/test/honk/Blake.t.sol
+++ b/barretenberg/sol/test/honk/Blake.t.sol
@@ -9,6 +9,7 @@ import {BlakeHonkVerifier} from "../../src/honk/instance/BlakeHonk.sol";
 import {DifferentialFuzzer} from "../base/DifferentialFuzzer.sol";
 import {IVerifier} from "../../src/interfaces/IVerifier.sol";
 
+/// forge-lint: disable-next-item(unaliased-plain-import)
 import "forge-std/console.sol";
 
 contract BlakeHonkTest is TestBaseHonk {

--- a/barretenberg/sol/test/honk/BlakeZK.t.sol
+++ b/barretenberg/sol/test/honk/BlakeZK.t.sol
@@ -9,6 +9,7 @@ import {BlakeHonkZKVerifier} from "../../src/honk/instance/BlakeHonkZK.sol";
 import {DifferentialFuzzer} from "../base/DifferentialFuzzer.sol";
 import {IVerifier} from "../../src/interfaces/IVerifier.sol";
 
+/// forge-lint: disable-next-item(unaliased-plain-import)
 import "forge-std/console.sol";
 
 contract BlakeHonZKTest is TestBaseHonkZK {

--- a/barretenberg/sol/test/honk/Recursive.t.sol
+++ b/barretenberg/sol/test/honk/Recursive.t.sol
@@ -9,6 +9,7 @@ import {RecursiveHonkVerifier} from "../../src/honk/instance/RecursiveHonk.sol";
 import {DifferentialFuzzer} from "../base/DifferentialFuzzer.sol";
 import {IVerifier} from "../../src/interfaces/IVerifier.sol";
 
+/// forge-lint: disable-next-item(unaliased-plain-import)
 import "forge-std/console.sol";
 
 contract RecursiveHonkTest is TestBaseHonk {

--- a/barretenberg/sol/test/honk/RecursiveZK.t.sol
+++ b/barretenberg/sol/test/honk/RecursiveZK.t.sol
@@ -9,6 +9,7 @@ import {RecursiveHonkZKVerifier} from "../../src/honk/instance/RecursiveHonkZK.s
 import {DifferentialFuzzer} from "../base/DifferentialFuzzer.sol";
 import {IVerifier} from "../../src/interfaces/IVerifier.sol";
 
+/// forge-lint: disable-next-item(unaliased-plain-import)
 import "forge-std/console.sol";
 
 contract RecursiveHonkTest is TestBaseHonkZK {

--- a/l1-contracts/foundry.toml
+++ b/l1-contracts/foundry.toml
@@ -70,5 +70,20 @@ wrap_comments = true
 number_underscore = "thousands"
 override_spacing = false
 
+[lint]
+ignore = ["./lib/**"]
+exclude_lints = [
+  "unused-import", # Mostly in test code
+  "incorrect-shift", # Throws warnings on construction of bitmasks
+
+  "asm-keccak256", # https://github.com/AztecProtocol/aztec-packages/issues/16808
+
+  # Silencing due to just being style changes
+  "mixed-case-variable",
+  "mixed-case-function",
+  "screaming-snake-case-const",
+  "screaming-snake-case-immutable",
+]
+
 [rpc_endpoints]
 mainnet_fork = "https://mainnet.infura.io/v3/9928b52099854248b3a096be07a6b23c"

--- a/l1-contracts/test/portals/TokenPortal.t.sol
+++ b/l1-contracts/test/portals/TokenPortal.t.sol
@@ -1,5 +1,6 @@
 pragma solidity >=0.8.27;
 
+/// forge-lint: disable-next-item(unaliased-plain-import)
 import "forge-std/Test.sol";
 
 // Rollup Processor

--- a/l1-contracts/test/portals/UniswapPortal.t.sol
+++ b/l1-contracts/test/portals/UniswapPortal.t.sol
@@ -1,5 +1,6 @@
 pragma solidity >=0.8.27;
 
+/// forge-lint: disable-next-item(unaliased-plain-import)
 import "forge-std/Test.sol";
 
 // Rollup Processor

--- a/l1-contracts/test/staking_asset_handler/setWithdrawer.t.sol
+++ b/l1-contracts/test/staking_asset_handler/setWithdrawer.t.sol
@@ -1,11 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity >=0.8.27;
 
+/// forge-lint: disable-next-item(unaliased-plain-import)
+import "forge-std/console.sol";
+
 import {StakingAssetHandlerBase} from "./base.t.sol";
 import {StakingAssetHandler, IStakingAssetHandler} from "@aztec/mock/StakingAssetHandler.sol";
 import {Ownable} from "@oz/access/Ownable.sol";
 import {BN254Lib, G1Point, G2Point} from "@aztec/shared/libraries/BN254Lib.sol";
-import "forge-std/console.sol";
 
 // solhint-disable comprehensive-interface
 // solhint-disable func-name-mixedcase


### PR DESCRIPTION
Foundry has been screaming at me whenever I bootstrap the l1-contracts with what looks like a lot of low-value lints.

I've shied away from making any code changes as I don't think it would be particularly helpful so this PR mostly boils down to silencing lints coming from dependencies and disabling lints which just are just code style-guide items.

One semi-meaningful thing which I've disabled is a lint calling out an opportunities to optimize keccak hashing so I've opened an issue to track this here: https://github.com/AztecProtocol/aztec-packages/issues/16808

`forge lint` now outputs the below. This looks like we can add `/// forge-lint: disable-next-item(erc20-unchecked-transfer)` to these cases as we control the token being used in these situations -  but I'll leave that up to the tmnts.

```
warning[erc20-unchecked-transfer]: ERC20 'transfer' and 'transferFrom' calls should check the return value
  --> /mnt/user-data/tom/aztec-packages/l1-contracts/src/core/libraries/rollup/RewardLib.sol:90:5
   |
90 |     rollupStore.config.feeAsset.transfer(_sequencer, amount);
   |     --------------------------------------------------------
   |
   = help: https://book.getfoundry.sh/reference/forge/forge-lint#erc20-unchecked-transfer

warning[erc20-unchecked-transfer]: ERC20 'transfer' and 'transferFrom' calls should check the return value
   --> /mnt/user-data/tom/aztec-packages/l1-contracts/src/core/libraries/rollup/StakingLib.sol:184:5
    |
184 |     store.stakingAsset.transfer(exit.recipientOrWithdrawer, exit.amount);
    |     --------------------------------------------------------------------
    |
    = help: https://book.getfoundry.sh/reference/forge/forge-lint#erc20-unchecked-transfer

warning[erc20-unchecked-transfer]: ERC20 'transfer' and 'transferFrom' calls should check the return value
   --> /mnt/user-data/tom/aztec-packages/l1-contracts/src/core/libraries/rollup/StakingLib.sol:285:5
    |
285 |     store.stakingAsset.transferFrom(msg.sender, address(this), amount);
    |     ------------------------------------------------------------------
    |
    = help: https://book.getfoundry.sh/reference/forge/forge-lint#erc20-unchecked-transfer

warning[erc20-unchecked-transfer]: ERC20 'transfer' and 'transferFrom' calls should check the return value
   --> /mnt/user-data/tom/aztec-packages/l1-contracts/src/core/libraries/rollup/StakingLib.sol:357:9
    |
357 |         store.stakingAsset.transfer(args.withdrawer, amount);
    |         ----------------------------------------------------
    |
    = help: https://book.getfoundry.sh/reference/forge/forge-lint#erc20-unchecked-transfer

warning[erc20-unchecked-transfer]: ERC20 'transfer' and 'transferFrom' calls should check the return value
   --> /mnt/user-data/tom/aztec-packages/l1-contracts/src/core/libraries/rollup/RewardLib.sol:122:5
    |
122 |     rollupStore.config.feeAsset.transfer(_prover, accumulatedRewards);
    |     -----------------------------------------------------------------
    |
    = help: https://book.getfoundry.sh/reference/forge/forge-lint#erc20-unchecked-transfer

warning[erc20-unchecked-transfer]: ERC20 'transfer' and 'transferFrom' calls should check the return value
   --> /mnt/user-data/tom/aztec-packages/l1-contracts/src/governance/GSE.sol:339:5
    |
339 |     ASSET.transferFrom(msg.sender, address(this), ACTIVATION_THRESHOLD);
    |     -------------------------------------------------------------------
    |
    = help: https://book.getfoundry.sh/reference/forge/forge-lint#erc20-unchecked-transfer

warning[erc20-unchecked-transfer]: ERC20 'transfer' and 'transferFrom' calls should check the return value
   --> /mnt/user-data/tom/aztec-packages/l1-contracts/src/governance/GSE.sol:472:5
    |
472 |     ASSET.transferFrom(msg.sender, address(this), amount);
    |     -----------------------------------------------------
    |
    = help: https://book.getfoundry.sh/reference/forge/forge-lint#erc20-unchecked-transfer

warning[erc20-unchecked-transfer]: ERC20 'transfer' and 'transferFrom' calls should check the return value
   --> /mnt/user-data/tom/aztec-packages/l1-contracts/src/core/libraries/rollup/RewardLib.sol:218:9
    |
218 |         rollupStore.config.feeAsset.transfer(BURN_ADDRESS, t.totalBurn);
    |         ---------------------------------------------------------------
    |
    = help: https://book.getfoundry.sh/reference/forge/forge-lint#erc20-unchecked-transfer

warning[erc20-unchecked-transfer]: ERC20 'transfer' and 'transferFrom' calls should check the return value
   --> /mnt/user-data/tom/aztec-packages/l1-contracts/test/portals/TokenPortal.sol:149:5
    |
149 |     underlying.transfer(_recipient, _amount);
    |     ----------------------------------------
    |
    = help: https://book.getfoundry.sh/reference/forge/forge-lint#erc20-unchecked-transfer

```