### PR TITLE
chore: increase default agent poll

### DIFF
--- a/yarn-project/prover-client/src/proving_broker/config.ts
+++ b/yarn-project/prover-client/src/proving_broker/config.ts
@@ -111,7 +111,7 @@ export const proverAgentConfigMappings: ConfigMappingsType<ProverAgentConfig> = 
   proverAgentPollIntervalMs: {
     env: 'PROVER_AGENT_POLL_INTERVAL_MS',
     description: 'The interval agents poll for jobs at',
-    ...numberConfigHelper(100),
+    ...numberConfigHelper(1000),
   },
   proverAgentProofTypes: {
     env: 'PROVER_AGENT_PROOF_TYPES',


### PR DESCRIPTION
For a while the API between agents and the broker has been modified to return jobs from progress report/job result calls. The agent no longer need to poll so often in order to have low latency