### PR TITLE
fix(docs): change min reqs and rename prover node in run-prover

### DIFF
--- a/docs/docs/the_aztec_network/guides/run_nodes/how_to_run_prover.md
+++ b/docs/docs/the_aztec_network/guides/run_nodes/how_to_run_prover.md
@@ -41,25 +41,38 @@ Before following this guide, make sure you:
 
 ## Understanding Prover Architecture
 
-The Aztec prover involves three key components: the Prover Node, the Proving Broker, and the Proving Agent.
+The Aztec prover node involves three key components: the full Node, the Proving Broker, and the Proving Agent.
 
-#### Prover Node
+#### Full Node
 
-The Prover Node is responsible for polling the L1 for unproven epochs and initiating the proof process. When an epoch is ready to be proven, the prover node creates proving jobs and distributes them to the broker. The Prover Node is also responsible for submitting the final rollup proof to the rollup contract.
+The full Node is responsible for polling the L1 for unproven epochs and initiating the proof process. When an epoch is ready to be proven, the full node creates proving jobs and distributes them to the broker. The full Node is also responsible for submitting the final rollup proof to the rollup contract.
 
-- **Resources**: Up to 8 cores, 16GB RAM, ~1TB disk for storing state.
+Minimum specifications:
+
+- 2 core / 4 vCPU
+- 16 GB RAM
+- 1 TB NVMe SDD
+- 25 Mbps network connection
 
 #### Proving Broker
 
 Manages a queue of proving jobs, distributing them to available agents and forwarding results back to the node.
 
-- **Resources**: Up to 4 cores, 16GB RAM, ~1GB disk.
+Minimum specifications:
+
+- 2 core / 4 vCPU
+- 16 GB RAM
+- 10 GB SDD
 
 #### Proving Agents
 
 Executes the actual proof jobs. Agents are stateless, fetch work from the broker, and return the results.
 
-- **Resources**: Each agent may use up to 16 cores and 128GB RAM.
+Minimum specifications:
+
+- 32 core / 64 vCPU
+- 128 GB RAM
+- 10 GB SDD
 
 ## Setting Up Your Prover
 

--- a/docs/docs/the_aztec_network/guides/run_nodes/how_to_run_sequencer.md
+++ b/docs/docs/the_aztec_network/guides/run_nodes/how_to_run_sequencer.md
@@ -42,11 +42,10 @@ The archiver component complements this process by maintaining historical chain 
 
 A computer running Linux or MacOS with the following specifictions:
 
-- CPU: 8-cores
-- RAM: 16 GiB
-- Storage: 1 TB SSD
-
-A Network connection of at least 25 Mbps up/down.
+- 2 core / 4 vCPU
+- 16 GB RAM
+- 1 TB NVMe SDD
+- 25 Mbps network connection
 
 ### Installation
 

--- a/docs/docs/the_aztec_network/index.md
+++ b/docs/docs/the_aztec_network/index.md
@@ -18,8 +18,8 @@ Please note that there are two other types of nodes available that we are not co
 Minimum hardware requirements:
 
 - 2 core / 4 vCPU
-- 8 GB RAM
-- 10 GB SDD
+- 16 GB RAM
+- 1 TB NVMe SDD
 - 25 Mbps network connection
 
 Please note that these requirements are subject to change as the network throughput increases.

--- a/docs/versioned_docs/version-v1.2.0/the_aztec_network/guides/run_nodes/how_to_run_prover.md
+++ b/docs/versioned_docs/version-v1.2.0/the_aztec_network/guides/run_nodes/how_to_run_prover.md
@@ -41,25 +41,38 @@ Before following this guide, make sure you:
 
 ## Understanding Prover Architecture
 
-The Aztec prover involves three key components: the Prover Node, the Proving Broker, and the Proving Agent.
+The Aztec prover node involves three key components: the full Node, the Proving Broker, and the Proving Agent.
 
-#### Prover Node
+#### Full Node
 
-The Prover Node is responsible for polling the L1 for unproven epochs and initiating the proof process. When an epoch is ready to be proven, the prover node creates proving jobs and distributes them to the broker. The Prover Node is also responsible for submitting the final rollup proof to the rollup contract.
+The full Node is responsible for polling the L1 for unproven epochs and initiating the proof process. When an epoch is ready to be proven, the full node creates proving jobs and distributes them to the broker. The full Node is also responsible for submitting the final rollup proof to the rollup contract.
 
-- **Resources**: Up to 8 cores, 16GB RAM, ~1TB disk for storing state.
+Minimum specifications:
+
+- 2 core / 4 vCPU
+- 16 GB RAM
+- 1 TB NVMe SDD
+- 25 Mbps network connection
 
 #### Proving Broker
 
 Manages a queue of proving jobs, distributing them to available agents and forwarding results back to the node.
 
-- **Resources**: Up to 4 cores, 16GB RAM, ~1GB disk.
+Minimum specifications:
+
+- 2 core / 4 vCPU
+- 16 GB RAM
+- 10 GB SDD
 
 #### Proving Agents
 
 Executes the actual proof jobs. Agents are stateless, fetch work from the broker, and return the results.
 
-- **Resources**: Each agent may use up to 16 cores and 128GB RAM.
+Minimum specifications:
+
+- 32 core / 64 vCPU
+- 128 GB RAM
+- 10 GB SDD
 
 ## Setting Up Your Prover
 

--- a/docs/versioned_docs/version-v1.2.0/the_aztec_network/guides/run_nodes/how_to_run_sequencer.md
+++ b/docs/versioned_docs/version-v1.2.0/the_aztec_network/guides/run_nodes/how_to_run_sequencer.md
@@ -42,11 +42,10 @@ The archiver component complements this process by maintaining historical chain 
 
 A computer running Linux or MacOS with the following specifictions:
 
-- CPU: 8-cores
-- RAM: 16 GiB
-- Storage: 1 TB SSD
-
-A Network connection of at least 25 Mbps up/down.
+- 2 core / 4 vCPU
+- 16 GB RAM
+- 1 TB NVMe SDD
+- 25 Mbps network connection
 
 ### Installation
 

--- a/docs/versioned_docs/version-v1.2.0/the_aztec_network/index.md
+++ b/docs/versioned_docs/version-v1.2.0/the_aztec_network/index.md
@@ -18,8 +18,8 @@ Please note that there are two other types of nodes available that we are not co
 Minimum hardware requirements:
 
 - 2 core / 4 vCPU
-- 8 GB RAM
-- 10 GB SDD
+- 16 GB RAM
+- 1 TB NVMe SDD
 - 25 Mbps network connection
 
 Please note that these requirements are subject to change as the network throughput increases.


### PR DESCRIPTION
Right now I'm assuming Prover node = (full node + prover broker + prover agent)

If we want to remove prover node nomenclature entirely it may be a bit bigger of a change