### PR TITLE
chore: network test fixes for terraform

### DIFF
--- a/spartan/environments/scenario.local.env
+++ b/spartan/environments/scenario.local.env
@@ -6,6 +6,7 @@ LABS_INFRA_MNEMONIC="test test test test test test test test test test test junk
 FUNDING_PRIVATE_KEY="0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
 REAL_VERIFIER=false
 SENTINEL_ENABLED=true
+# CREATE_CHAOS_MESH=true
 
 AZTEC_EPOCH_DURATION=4
 AZTEC_SLOT_DURATION=24

--- a/spartan/terraform/deploy-aztec-infra/main.tf
+++ b/spartan/terraform/deploy-aztec-infra/main.tf
@@ -75,7 +75,8 @@ locals {
       custom_settings = {
         "nodeType" = "p2p-bootstrap"
       }
-      boot_node_path = ""
+      boot_node_host_path  = ""
+      bootstrap_nodes_path = ""
     } : null
 
     validators = {

--- a/yarn-project/end-to-end/src/spartan/1tps.test.ts
+++ b/yarn-project/end-to-end/src/spartan/1tps.test.ts
@@ -1,179 +1,168 @@
-// // TODO(#11825) finalize (probably once we have nightly tests setup for GKE) & enable in bootstrap.sh
-// import {
-//   type PXE,
-//   ProvenTx,
-//   SentTx,
-//   SponsoredFeePaymentMethod,
-//   Tx,
-//   readFieldCompressedString,
-//   sleep,
-// } from '@aztec/aztec.js';
-// import { Fr } from '@aztec/foundation/fields';
-// import { createLogger } from '@aztec/foundation/log';
-// import { TokenContract } from '@aztec/noir-contracts.js/Token';
+// TODO(#11825) finalize (probably once we have nightly tests setup for GKE) & enable in bootstrap.sh
+import {
+  type PXE,
+  ProvenTx,
+  SentTx,
+  SponsoredFeePaymentMethod,
+  Tx,
+  readFieldCompressedString,
+  sleep,
+} from '@aztec/aztec.js';
+import { Fr } from '@aztec/foundation/fields';
+import { createLogger } from '@aztec/foundation/log';
+import { TokenContract } from '@aztec/noir-contracts.js/Token';
 
-// import { jest } from '@jest/globals';
-// import type { ChildProcess } from 'child_process';
+import { jest } from '@jest/globals';
+import type { ChildProcess } from 'child_process';
 
-// import { getSponsoredFPCAddress } from '../fixtures/utils.js';
-// import {
-//   type TestWallets,
-//   deploySponsoredTestWallets,
-//   setupTestWalletsWithTokens,
-//   startCompatiblePXE,
-// } from './setup_test_wallets.js';
-// import { setupEnvironment, startPortForward } from './utils.js';
+import { getSponsoredFPCAddress } from '../fixtures/utils.js';
+import { type TestWallets, deploySponsoredTestWallets, startCompatiblePXE } from './setup_test_wallets.js';
+import { setupEnvironment, startPortForwardForRPC } from './utils.js';
 
-// const config = setupEnvironment(process.env);
+const config = { ...setupEnvironment(process.env), REAL_VERIFIER: true }; // TODO: remove REAL_VERIFIER: true
+describe('token transfer test', () => {
+  jest.setTimeout(10 * 60 * 2000); // 20 minutes
 
-// describe('token transfer test', () => {
-//   jest.setTimeout(10 * 60 * 2000); // 20 minutes
+  const logger = createLogger(`e2e:spartan-test:transfer`);
+  const MINT_AMOUNT = 1000n;
 
-//   const logger = createLogger(`e2e:spartan-test:transfer`);
-//   const MINT_AMOUNT = 1000n;
+  const ROUNDS = 1n;
 
-//   const ROUNDS = 1n;
+  let testWallets: TestWallets;
+  const forwardProcesses: ChildProcess[] = [];
+  let pxe: PXE;
+  let cleanup: undefined | (() => Promise<void>);
 
-//   let testWallets: TestWallets;
-//   const forwardProcesses: ChildProcess[] = [];
-//   let pxe: PXE;
-//   let cleanup: undefined | (() => Promise<void>);
+  afterAll(async () => {
+    await cleanup?.();
+    forwardProcesses.forEach(p => p.kill());
+  });
 
-//   afterAll(async () => {
-//     await cleanup?.();
-//     forwardProcesses.forEach(p => p.kill());
-//   });
+  beforeAll(async () => {
+    logger.info('Starting port forward for PXE');
+    const { process: aztecRpcProcess, port: aztecRpcPort } = await startPortForwardForRPC(config.NAMESPACE);
+    forwardProcesses.push(aztecRpcProcess);
+    const rpcUrl = `http://127.0.0.1:${aztecRpcPort}`;
 
-//   beforeAll(async () => {
-//     if (isK8sConfig(config)) {
-//       const { process: sequencerProcess, port: sequencerPort } = await startPortForward({
-//         resource: `svc/${config.INSTANCE_NAME}-aztec-network-validator`,
-//         namespace: config.NAMESPACE,
-//         containerPort: config.CONTAINER_SEQUENCER_PORT,
-//       });
-//       forwardProcesses.push(sequencerProcess);
-//       const NODE_URL = `http://127.0.0.1:${sequencerPort}`;
+    ({ pxe, cleanup } = await startCompatiblePXE(rpcUrl, config.REAL_VERIFIER, logger));
 
-//       ({ pxe, cleanup } = await startCompatiblePXE(NODE_URL, ['1', 'true'].includes(config.AZTEC_REAL_PROOFS), logger));
-//       testWallets = await deploySponsoredTestWallets(pxe, MINT_AMOUNT, logger);
-//     } else {
-//       const PXE_URL = config.PXE_URL;
-//       testWallets = await setupTestWalletsWithTokens(PXE_URL, MINT_AMOUNT, logger);
-//     }
-//     expect(ROUNDS).toBeLessThanOrEqual(MINT_AMOUNT);
-//   });
+    // Setup wallets
+    testWallets = await deploySponsoredTestWallets(pxe, MINT_AMOUNT, logger);
 
-//   it('can get info', async () => {
-//     const name = readFieldCompressedString(
-//       await testWallets.tokenAdminWallet.methods.private_get_name().simulate({ from: testWallets.tokenAdminAddress }),
-//     );
-//     expect(name).toBe(testWallets.tokenName);
-//   });
+    expect(ROUNDS).toBeLessThanOrEqual(MINT_AMOUNT);
+  });
 
-//   it('can transfer 1 token privately and publicly', async () => {
-//     const recipient = testWallets.recipientWallet.getAddress();
-//     const transferAmount = 1n;
+  it('can get info', async () => {
+    const name = readFieldCompressedString(
+      await testWallets.tokenAdminWallet.methods.private_get_name().simulate({ from: testWallets.tokenAdminAddress }),
+    );
+    expect(name).toBe(testWallets.tokenName);
+  });
 
-//     for (const w of testWallets.wallets) {
-//       expect(MINT_AMOUNT).toBe(
-//         await testWallets.tokenAdminWallet.methods
-//           .balance_of_public(w.getAddress())
-//           .simulate({ from: testWallets.tokenAdminAddress }),
-//       );
-//     }
+  it('can transfer 1 token privately and publicly', async () => {
+    const recipient = testWallets.recipientWallet.getAddress();
+    const transferAmount = 1n;
 
-//     expect(0n).toBe(
-//       await testWallets.tokenAdminWallet.methods
-//         .balance_of_public(recipient)
-//         .simulate({ from: testWallets.tokenAdminAddress }),
-//     );
+    for (const w of testWallets.wallets) {
+      expect(MINT_AMOUNT).toBe(
+        await testWallets.tokenAdminWallet.methods
+          .balance_of_public(w.getAddress())
+          .simulate({ from: testWallets.tokenAdminAddress }),
+      );
+    }
 
-//     // For each round, make both private and public transfers
-//     // for (let i = 1n; i <= ROUNDS; i++) {
-//     //   const interactions = await Promise.all([
-//     //     ...testWallets.wallets.map(async w =>
-//     //       (
-//     //         await TokenContract.at(testWallets.tokenAddress, w)
-//     //       ).methods.transfer_in_public(w.getAddress(), recipient, transferAmount, 0),
-//     //     ),
-//     //   ]);
+    expect(0n).toBe(
+      await testWallets.tokenAdminWallet.methods
+        .balance_of_public(recipient)
+        .simulate({ from: testWallets.tokenAdminAddress }),
+    );
 
-//     //   const txs = await Promise.all(interactions.map(async i => await i.prove()));
+    // For each round, make both private and public transfers
+    // for (let i = 1n; i <= ROUNDS; i++) {
+    //   const interactions = await Promise.all([
+    //     ...testWallets.wallets.map(async w =>
+    //       (
+    //         await TokenContract.at(testWallets.tokenAddress, w)
+    //       ).methods.transfer_in_public(w.getAddress(), recipient, transferAmount, 0),
+    //     ),
+    //   ]);
 
-//     //   await Promise.all(txs.map(t => t.send().wait({ timeout: 600 })));
-//     // }
+    //   const txs = await Promise.all(interactions.map(async i => await i.prove()));
 
-//     const wallet = testWallets.wallets[0];
+    //   await Promise.all(txs.map(t => t.send().wait({ timeout: 600 })));
+    // }
 
-//     const baseTx = await (await TokenContract.at(testWallets.tokenAddress, wallet)).methods
-//       .transfer_in_public(wallet.getAddress(), recipient, transferAmount, 0)
-//       .prove({
-//         from: testWallets.tokenAdminAddress,
-//         fee: { paymentMethod: new SponsoredFeePaymentMethod(await getSponsoredFPCAddress()) },
-//       });
+    const wallet = testWallets.wallets[0];
 
-//     const txs: ProvenTx[] = [];
-//     for (let i = 0; i < 20; i++) {
-//       const clonedTxData = Tx.clone(baseTx);
+    const baseTx = await (await TokenContract.at(testWallets.tokenAddress, wallet)).methods
+      .transfer_in_public(wallet.getAddress(), recipient, transferAmount, 0)
+      .prove({
+        from: testWallets.tokenAdminAddress,
+        fee: { paymentMethod: new SponsoredFeePaymentMethod(await getSponsoredFPCAddress()) },
+      });
 
-//       // Modify the first nullifier to make it unique
-//       const nullifiers = clonedTxData.data.getNonEmptyNullifiers();
-//       if (nullifiers.length > 0) {
-//         // Create a new nullifier by adding the index to the original
-//         const newNullifier = nullifiers[0].add(Fr.fromString(i.toString()));
-//         // Replace the first nullifier with our new unique one
-//         if (clonedTxData.data.forRollup) {
-//           clonedTxData.data.forRollup.end.nullifiers[0] = newNullifier;
-//         } else if (clonedTxData.data.forPublic) {
-//           clonedTxData.data.forPublic.nonRevertibleAccumulatedData.nullifiers[0] = newNullifier;
-//         }
-//       }
+    const txs: ProvenTx[] = [];
+    for (let i = 0; i < 20; i++) {
+      const clonedTxData = Tx.clone(baseTx);
 
-//       const clonedTx = new ProvenTx(wallet, clonedTxData, []);
-//       txs.push(clonedTx);
-//     }
+      // Modify the first nullifier to make it unique
+      const nullifiers = clonedTxData.data.getNonEmptyNullifiers();
+      if (nullifiers.length > 0) {
+        // Create a new nullifier by adding the index to the original
+        const newNullifier = nullifiers[0].add(Fr.fromString(i.toString()));
+        // Replace the first nullifier with our new unique one
+        if (clonedTxData.data.forRollup) {
+          clonedTxData.data.forRollup.end.nullifiers[0] = newNullifier;
+        } else if (clonedTxData.data.forPublic) {
+          clonedTxData.data.forPublic.nonRevertibleAccumulatedData.nullifiers[0] = newNullifier;
+        }
+      }
 
-//     const sentTxs: SentTx[] = [];
+      const clonedTx = new ProvenTx(wallet, clonedTxData, []);
+      txs.push(clonedTx);
+    }
 
-//     // dump all txs at requested TPS
-//     const TPS = 1;
-//     logger.info(`Sending ${txs.length} txs at a rate of ${TPS} tx/s`);
-//     while (txs.length > 0) {
-//       const start = performance.now();
+    const sentTxs: SentTx[] = [];
 
-//       const chunk = txs.splice(0, TPS);
-//       sentTxs.push(...chunk.map(tx => tx.send()));
-//       logger.info(`Sent txs: [${(await Promise.all(chunk.map(tx => tx.getTxHash()))).map(h => h.toString())}]`);
+    // dump all txs at requested TPS
+    const TPS = 1;
+    logger.info(`Sending ${txs.length} txs at a rate of ${TPS} tx/s`);
+    while (txs.length > 0) {
+      const start = performance.now();
 
-//       const end = performance.now();
-//       const delta = end - start;
-//       if (1000 - delta > 0) {
-//         await sleep(1000 - delta);
-//       }
-//     }
+      const chunk = txs.splice(0, TPS);
+      sentTxs.push(...chunk.map(tx => tx.send()));
+      logger.info(`Sent txs: [${(await Promise.all(chunk.map(tx => tx.getTxHash()))).map(h => h.toString())}]`);
 
-//     await Promise.all(
-//       sentTxs.map(async sentTx => {
-//         await sentTx.wait({ timeout: 600 });
-//         const receipt = await sentTx.getReceipt();
-//         logger.info(`tx ${receipt.txHash} included in block: ${receipt.blockNumber}`);
-//       }),
-//     );
+      const end = performance.now();
+      const delta = end - start;
+      if (1000 - delta > 0) {
+        await sleep(1000 - delta);
+      }
+    }
 
-//     const recipientBalance = await testWallets.tokenAdminWallet.methods
-//       .balance_of_public(recipient)
-//       .simulate({ from: testWallets.tokenAdminAddress });
-//     logger.info(`recipientBalance: ${recipientBalance}`);
-//     // expect(recipientBalance).toBe(100n * transferAmount);
+    await Promise.all(
+      sentTxs.map(async sentTx => {
+        await sentTx.wait({ timeout: 600 });
+        const receipt = await sentTx.getReceipt();
+        logger.info(`tx ${receipt.txHash} included in block: ${receipt.blockNumber}`);
+      }),
+    );
 
-//     // for (const w of testWallets.wallets) {
-//     //   expect(MINT_AMOUNT - ROUNDS * transferAmount).toBe(
-//     //     await testWallets.tokenAdminWallet.methods.balance_of_public(w.getAddress()).simulate(),
-//     //   );
-//     // }
+    const recipientBalance = await testWallets.tokenAdminWallet.methods
+      .balance_of_public(recipient)
+      .simulate({ from: testWallets.tokenAdminAddress });
+    logger.info(`recipientBalance: ${recipientBalance}`);
+    // expect(recipientBalance).toBe(100n * transferAmount);
 
-//     // expect(ROUNDS * transferAmount * BigInt(testWallets.wallets.length)).toBe(
-//     //   await testWallets.tokenAdminWallet.methods.balance_of_public(recipient).simulate(),
-//     // );
-//   });
-// });
+    // for (const w of testWallets.wallets) {
+    //   expect(MINT_AMOUNT - ROUNDS * transferAmount).toBe(
+    //     await testWallets.tokenAdminWallet.methods.balance_of_public(w.getAddress()).simulate(),
+    //   );
+    // }
+
+    // expect(ROUNDS * transferAmount * BigInt(testWallets.wallets.length)).toBe(
+    //   await testWallets.tokenAdminWallet.methods.balance_of_public(recipient).simulate(),
+    // );
+  });
+});

--- a/yarn-project/end-to-end/src/spartan/4epochs.test.ts
+++ b/yarn-project/end-to-end/src/spartan/4epochs.test.ts
@@ -1,160 +1,133 @@
-// import { type PXE, SponsoredFeePaymentMethod, readFieldCompressedString } from '@aztec/aztec.js';
-// import { RollupCheatCodes } from '@aztec/aztec/testing';
-// import { getL1ContractsConfigEnvVars } from '@aztec/ethereum';
-// import { EthCheatCodesWithState } from '@aztec/ethereum/test';
-// import { createLogger } from '@aztec/foundation/log';
-// import { TokenContract } from '@aztec/noir-contracts.js/Token';
+import { type PXE, SponsoredFeePaymentMethod, readFieldCompressedString } from '@aztec/aztec.js';
+import { RollupCheatCodes } from '@aztec/aztec/testing';
+import { getL1ContractsConfigEnvVars } from '@aztec/ethereum';
+import { EthCheatCodesWithState } from '@aztec/ethereum/test';
+import { createLogger } from '@aztec/foundation/log';
+import { TokenContract } from '@aztec/noir-contracts.js/Token';
 
-// import { jest } from '@jest/globals';
-// import type { ChildProcess } from 'child_process';
+import { jest } from '@jest/globals';
+import type { ChildProcess } from 'child_process';
 
-// import { getSponsoredFPCAddress } from '../fixtures/utils.js';
-// import {
-//   type TestWallets,
-//   deploySponsoredTestWallets,
-//   setupTestWalletsWithTokens,
-//   startCompatiblePXE,
-// } from './setup_test_wallets.js';
-// import { isK8sConfig, setupEnvironment, startPortForward } from './utils.js';
+import { getSponsoredFPCAddress } from '../fixtures/utils.js';
+import { type TestWallets, deploySponsoredTestWallets, startCompatiblePXE } from './setup_test_wallets.js';
+import { setupEnvironment, startPortForwardForEthereum, startPortForwardForRPC } from './utils.js';
 
-// const config = setupEnvironment(process.env);
+const config = { ...setupEnvironment(process.env), REAL_VERIFIER: true }; // TODO: remove REAL_VERIFIER: true
 
-// describe('token transfer test', () => {
-//   jest.setTimeout(10 * 60 * 4000); // 40 minutes
+describe('token transfer test', () => {
+  jest.setTimeout(10 * 60 * 4000); // 40 minutes
 
-//   const logger = createLogger(`e2e:spartan:4epochs`);
-//   const l1Config = getL1ContractsConfigEnvVars();
+  const logger = createLogger(`e2e:spartan:4epochs`);
+  const l1Config = getL1ContractsConfigEnvVars();
 
-//   // We want plenty of minted tokens for a lot of slots that fill up multiple epochs
-//   const MINT_AMOUNT = 2000000n;
-//   const TEST_EPOCHS = 4;
-//   const MAX_MISSED_SLOTS = 10n;
-//   const ROUNDS = BigInt(l1Config.aztecEpochDuration * TEST_EPOCHS);
+  // We want plenty of minted tokens for a lot of slots that fill up multiple epochs
+  const MINT_AMOUNT = 2000000n;
+  const TEST_EPOCHS = 4;
+  const MAX_MISSED_SLOTS = 10n;
+  const ROUNDS = BigInt(l1Config.aztecEpochDuration * TEST_EPOCHS);
 
-//   let testWallets: TestWallets;
-//   let ETHEREUM_HOSTS: string[];
-//   const forwardProcesses: ChildProcess[] = [];
-//   let pxe: PXE;
-//   let cleanup: undefined | (() => Promise<void>);
+  let testWallets: TestWallets;
+  let ETHEREUM_HOSTS: string[];
+  const forwardProcesses: ChildProcess[] = [];
+  let pxe: PXE;
+  let cleanup: undefined | (() => Promise<void>);
 
-//   afterAll(async () => {
-//     await cleanup?.();
-//     forwardProcesses.forEach(p => p.kill());
-//   });
+  afterAll(async () => {
+    await cleanup?.();
+    forwardProcesses.forEach(p => p.kill());
+  });
 
-//   beforeAll(async () => {
-//     if (isK8sConfig(config)) {
-//       if (config.SEPOLIA_RUN !== 'true') {
-//         const { process: ethProcess, port: ethPort } = await startPortForward({
-//           resource: `svc/${config.INSTANCE_NAME}-aztec-network-eth-execution`,
-//           namespace: config.NAMESPACE,
-//           containerPort: config.CONTAINER_ETHEREUM_PORT,
-//         });
-//         forwardProcesses.push(ethProcess);
-//         ETHEREUM_HOSTS = [`http://127.0.0.1:${ethPort}`];
-//       } else {
-//         if (!config.ETHEREUM_HOSTS) {
-//           throw new Error('ETHEREUM_HOSTS must be set for sepolia runs');
-//         }
-//         ETHEREUM_HOSTS = config.ETHEREUM_HOSTS.split(',');
-//       }
+  beforeAll(async () => {
+    logger.info('Starting port forward for PXE and Ethereum');
+    const { process: aztecRpcProcess, port: aztecRpcPort } = await startPortForwardForRPC(config.NAMESPACE);
+    const { process: ethereumProcess, port: ethereumPort } = await startPortForwardForEthereum(config.NAMESPACE);
+    forwardProcesses.push(aztecRpcProcess);
+    forwardProcesses.push(ethereumProcess);
 
-//       const { process: sequencerProcess, port: sequencerPort } = await startPortForward({
-//         resource: `svc/${config.INSTANCE_NAME}-aztec-network-validator`,
-//         namespace: config.NAMESPACE,
-//         containerPort: config.CONTAINER_SEQUENCER_PORT,
-//       });
-//       forwardProcesses.push(sequencerProcess);
-//       const NODE_URL = `http://127.0.0.1:${sequencerPort}`;
+    const rpcUrl = `http://127.0.0.1:${aztecRpcPort}`;
+    ETHEREUM_HOSTS = [`http://127.0.0.1:${ethereumPort}`];
 
-//       ({ pxe, cleanup } = await startCompatiblePXE(NODE_URL, ['1', 'true'].includes(config.AZTEC_REAL_PROOFS), logger));
-//       testWallets = await deploySponsoredTestWallets(pxe, MINT_AMOUNT, logger);
-//     } else {
-//       const PXE_URL = config.PXE_URL;
-//       ETHEREUM_HOSTS = config.ETHEREUM_HOSTS.split(',');
-//       testWallets = await setupTestWalletsWithTokens(PXE_URL, MINT_AMOUNT, logger);
-//     }
+    ({ pxe, cleanup } = await startCompatiblePXE(rpcUrl, config.REAL_VERIFIER, logger));
 
-//     expect(ROUNDS).toBeLessThanOrEqual(MINT_AMOUNT);
-//     logger.info(`Tested wallets setup: ${ROUNDS} < ${MINT_AMOUNT}`);
-//   });
+    // Setup wallets
+    testWallets = await deploySponsoredTestWallets(pxe, MINT_AMOUNT, logger);
 
-//   afterAll(() => {
-//     forwardProcesses.forEach(p => p.kill());
-//   });
+    expect(ROUNDS).toBeLessThanOrEqual(MINT_AMOUNT);
+    logger.info(`Tested wallets setup: ${ROUNDS} < ${MINT_AMOUNT}`);
+  });
 
-//   it('can get info', async () => {
-//     const name = readFieldCompressedString(
-//       await testWallets.tokenAdminWallet.methods.private_get_name().simulate({ from: testWallets.tokenAdminAddress }),
-//     );
-//     expect(name).toBe(testWallets.tokenName);
-//     logger.info(`Token name verified: ${name}`);
-//   });
+  it('can get info', async () => {
+    const name = readFieldCompressedString(
+      await testWallets.tokenAdminWallet.methods.private_get_name().simulate({ from: testWallets.tokenAdminAddress }),
+    );
+    expect(name).toBe(testWallets.tokenName);
+    logger.info(`Token name verified: ${name}`);
+  });
 
-//   it('transfer tokens for 4 epochs', async () => {
-//     const ethCheatCodes = new EthCheatCodesWithState(ETHEREUM_HOSTS);
-//     const l1ContractAddresses = await testWallets.pxe.getNodeInfo().then(n => n.l1ContractAddresses);
-//     // Get 4 epochs
-//     const rollupCheatCodes = new RollupCheatCodes(ethCheatCodes, l1ContractAddresses);
-//     logger.info(`Deployed L1 contract addresses: ${JSON.stringify(l1ContractAddresses)}`);
-//     const recipient = testWallets.recipientWallet.getAddress();
-//     const transferAmount = 1n;
+  it('transfer tokens for 4 epochs', async () => {
+    const ethCheatCodes = new EthCheatCodesWithState(ETHEREUM_HOSTS);
+    const l1ContractAddresses = await testWallets.pxe.getNodeInfo().then(n => n.l1ContractAddresses);
+    // Get 4 epochs
+    const rollupCheatCodes = new RollupCheatCodes(ethCheatCodes, l1ContractAddresses);
+    logger.info(`Deployed L1 contract addresses: ${JSON.stringify(l1ContractAddresses)}`);
+    const recipient = testWallets.recipientWallet.getAddress();
+    const transferAmount = 1n;
 
-//     for (const w of testWallets.wallets) {
-//       expect(MINT_AMOUNT).toBe(
-//         await testWallets.tokenAdminWallet.methods
-//           .balance_of_public(w.getAddress())
-//           .simulate({ from: testWallets.tokenAdminAddress }),
-//       );
-//     }
+    for (const w of testWallets.wallets) {
+      expect(MINT_AMOUNT).toBe(
+        await testWallets.tokenAdminWallet.methods
+          .balance_of_public(w.getAddress())
+          .simulate({ from: testWallets.tokenAdminAddress }),
+      );
+    }
 
-//     logger.info('Minted tokens');
+    logger.info('Minted tokens');
 
-//     expect(0n).toBe(
-//       await testWallets.tokenAdminWallet.methods
-//         .balance_of_public(recipient)
-//         .simulate({ from: testWallets.tokenAdminAddress }),
-//     );
+    expect(0n).toBe(
+      await testWallets.tokenAdminWallet.methods
+        .balance_of_public(recipient)
+        .simulate({ from: testWallets.tokenAdminAddress }),
+    );
 
-//     // For each round, make both private and public transfers
-//     const startSlot = await rollupCheatCodes.getSlot();
-//     for (let i = 1n; i <= ROUNDS; i++) {
-//       const txs = testWallets.wallets.map(async w =>
-//         (await TokenContract.at(testWallets.tokenAddress, w)).methods
-//           .transfer_in_public(w.getAddress(), recipient, transferAmount, 0)
-//           .prove({
-//             from: w.getAddress(),
-//             fee: { paymentMethod: new SponsoredFeePaymentMethod(await getSponsoredFPCAddress()) },
-//           }),
-//       );
+    // For each round, make both private and public transfers
+    const startSlot = await rollupCheatCodes.getSlot();
+    for (let i = 1n; i <= ROUNDS; i++) {
+      const txs = testWallets.wallets.map(async w =>
+        (await TokenContract.at(testWallets.tokenAddress, w)).methods
+          .transfer_in_public(w.getAddress(), recipient, transferAmount, 0)
+          .prove({
+            from: w.getAddress(),
+            fee: { paymentMethod: new SponsoredFeePaymentMethod(await getSponsoredFPCAddress()) },
+          }),
+      );
 
-//       const provenTxs = await Promise.all(txs);
+      const provenTxs = await Promise.all(txs);
 
-//       logger.info(`Proved ${provenTxs.length} in round ${i} of ${ROUNDS}`);
+      logger.info(`Proved ${provenTxs.length} in round ${i} of ${ROUNDS}`);
 
-//       await Promise.all(provenTxs.map(t => t.send().wait({ timeout: 600 })));
-//       const currentSlot = await rollupCheatCodes.getSlot();
-//       expect(currentSlot).toBeLessThanOrEqual(startSlot + i + MAX_MISSED_SLOTS);
-//       const startEpoch = await rollupCheatCodes.getEpoch();
-//       logger.debug(
-//         `Successfully reached slot ${currentSlot} (iteration ${
-//           currentSlot - startSlot
-//         }/${ROUNDS}) (Epoch ${startEpoch})`,
-//       );
-//     }
+      await Promise.all(provenTxs.map(t => t.send().wait({ timeout: 600 })));
+      const currentSlot = await rollupCheatCodes.getSlot();
+      expect(currentSlot).toBeLessThanOrEqual(startSlot + i + MAX_MISSED_SLOTS);
+      const startEpoch = await rollupCheatCodes.getEpoch();
+      logger.debug(
+        `Successfully reached slot ${currentSlot} (iteration ${
+          currentSlot - startSlot
+        }/${ROUNDS}) (Epoch ${startEpoch})`,
+      );
+    }
 
-//     for (const w of testWallets.wallets) {
-//       expect(MINT_AMOUNT - ROUNDS * transferAmount).toBe(
-//         await testWallets.tokenAdminWallet.methods
-//           .balance_of_public(w.getAddress())
-//           .simulate({ from: testWallets.tokenAdminAddress }),
-//       );
-//     }
+    for (const w of testWallets.wallets) {
+      expect(MINT_AMOUNT - ROUNDS * transferAmount).toBe(
+        await testWallets.tokenAdminWallet.methods
+          .balance_of_public(w.getAddress())
+          .simulate({ from: testWallets.tokenAdminAddress }),
+      );
+    }
 
-//     expect(ROUNDS * transferAmount * BigInt(testWallets.wallets.length)).toBe(
-//       await testWallets.tokenAdminWallet.methods
-//         .balance_of_public(recipient)
-//         .simulate({ from: testWallets.tokenAdminAddress }),
-//     );
-//   });
-// });
+    expect(ROUNDS * transferAmount * BigInt(testWallets.wallets.length)).toBe(
+      await testWallets.tokenAdminWallet.methods
+        .balance_of_public(recipient)
+        .simulate({ from: testWallets.tokenAdminAddress }),
+    );
+  });
+});

--- a/yarn-project/end-to-end/src/spartan/n_tps.test.ts
+++ b/yarn-project/end-to-end/src/spartan/n_tps.test.ts
@@ -1,214 +1,175 @@
-// import { Fr, ProvenTx, Tx, readFieldCompressedString, sleep } from '@aztec/aztec.js';
-// import { createLogger } from '@aztec/foundation/log';
-// import { TokenContract } from '@aztec/noir-contracts.js/Token';
+import { Fr, type PXE, ProvenTx, Tx, readFieldCompressedString, sleep } from '@aztec/aztec.js';
+import { createLogger } from '@aztec/foundation/log';
+import { TokenContract } from '@aztec/noir-contracts.js/Token';
 
-// import { jest } from '@jest/globals';
-// import type { ChildProcess } from 'child_process';
+import { jest } from '@jest/globals';
+import type { ChildProcess } from 'child_process';
 
-// import { type TestWallets, deployTestWalletWithTokens, setupTestWalletsWithTokens } from './setup_test_wallets.js';
-// import { isK8sConfig, setupEnvironment, startPortForward } from './utils.js';
+import { type TestWallets, deploySponsoredTestWallets, startCompatiblePXE } from './setup_test_wallets.js';
+import { setupEnvironment, startPortForwardForRPC } from './utils.js';
 
-// const config = setupEnvironment(process.env);
+const config = { ...setupEnvironment(process.env), REAL_VERIFIER: true }; // TODO: remove REAL_VERIFIER: true
 
-// describe('sustained 10 TPS test', () => {
-//   jest.setTimeout(20 * 60 * 1000); // 20 minutes
+describe('sustained 10 TPS test', () => {
+  jest.setTimeout(20 * 60 * 1000); // 20 minutes
 
-//   const logger = createLogger(`e2e:spartan-test:sustained-10tps`);
-//   const MINT_AMOUNT = 10000n;
-//   const TEST_DURATION_SECONDS = 10;
-//   const TARGET_TPS = 5; // 10
-//   const TOTAL_TXS = TEST_DURATION_SECONDS * TARGET_TPS;
+  const logger = createLogger(`e2e:spartan-test:sustained-10tps`);
+  const MINT_AMOUNT = 10000n;
+  const TEST_DURATION_SECONDS = 10;
+  const TARGET_TPS = 5; // 10
+  const TOTAL_TXS = TEST_DURATION_SECONDS * TARGET_TPS;
 
-//   let testWallets: TestWallets;
-//   let PXE_URL: string;
-//   let ETHEREUM_HOSTS: string[];
-//   const forwardProcesses: ChildProcess[] = [];
+  let testWallets: TestWallets;
+  let pxe: PXE;
+  let cleanup: undefined | (() => Promise<void>);
+  const forwardProcesses: ChildProcess[] = [];
 
-//   afterAll(async () => {
-//     // Give processes time to clean up gracefully
-//     forwardProcesses.forEach(p => {
-//       if (!p.killed) {
-//         p.kill();
-//       }
-//     });
+  afterAll(async () => {
+    await cleanup?.();
+    forwardProcesses.forEach(p => p.kill());
+  });
 
-//     // Wait a bit for processes to terminate
-//     await new Promise(resolve => setTimeout(resolve, 1000));
-//   });
+  beforeAll(async () => {
+    logger.info('Starting port forward for PXE');
+    const { process: aztecRpcProcess, port: aztecRpcPort } = await startPortForwardForRPC(config.NAMESPACE);
+    forwardProcesses.push(aztecRpcProcess);
+    const rpcUrl = `http://127.0.0.1:${aztecRpcPort}`;
 
-//   beforeAll(async () => {
-//     if (isK8sConfig(config)) {
-//       const { process: pxeProcess, port: pxePort } = await startPortForward({
-//         resource: `svc/${config.INSTANCE_NAME}-aztec-network-pxe`,
-//         namespace: config.NAMESPACE,
-//         containerPort: config.CONTAINER_PXE_PORT,
-//       });
-//       forwardProcesses.push(pxeProcess);
-//       PXE_URL = `http://127.0.0.1:${pxePort}`;
+    ({ pxe, cleanup } = await startCompatiblePXE(rpcUrl, config.REAL_VERIFIER, logger));
 
-//       const { process: ethProcess, port: ethPort } = await startPortForward({
-//         resource: `svc/${config.INSTANCE_NAME}-aztec-network-eth-execution`,
-//         namespace: config.NAMESPACE,
-//         containerPort: config.CONTAINER_ETHEREUM_PORT,
-//       });
-//       forwardProcesses.push(ethProcess);
-//       ETHEREUM_HOSTS = [`http://127.0.0.1:${ethPort}`];
+    // Setup wallets
+    logger.info('deploying test wallets');
+    testWallets = await deploySponsoredTestWallets(pxe, MINT_AMOUNT, logger);
+    logger.info(`testWallets ready`);
 
-//       const { process: sequencerProcess, port: sequencerPort } = await startPortForward({
-//         resource: `svc/${config.INSTANCE_NAME}-aztec-network-validator`,
-//         namespace: config.NAMESPACE,
-//         containerPort: config.CONTAINER_SEQUENCER_PORT,
-//       });
-//       forwardProcesses.push(sequencerProcess);
-//       const NODE_URL = `http://127.0.0.1:${sequencerPort}`;
+    logger.info(
+      `Test setup complete. Planning ${TOTAL_TXS} transactions over ${TEST_DURATION_SECONDS} seconds at ${TARGET_TPS} TPS`,
+    );
+  });
 
-//       const L1_ACCOUNT_MNEMONIC = config.L1_ACCOUNT_MNEMONIC;
+  // it('can verify token setup', async () => {
+  //   const name = readFieldCompressedString(await tokenContract.methods.private_get_name().simulate());
+  //   expect(name).toBeDefined();
+  //   expect(name.length).toBeGreaterThan(0);
+  //   logger.info(`Token verified: ${name}`);
+  // });
 
-//       logger.info('deploying test wallets');
+  it('can get info', async () => {
+    const name = readFieldCompressedString(
+      await testWallets.tokenAdminWallet.methods.private_get_name().simulate({ from: testWallets.tokenAdminAddress }),
+    );
+    expect(name).toBe(testWallets.tokenName);
+  });
 
-//       testWallets = await deployTestWalletWithTokens(
-//         PXE_URL,
-//         NODE_URL,
-//         ETHEREUM_HOSTS,
-//         L1_ACCOUNT_MNEMONIC,
-//         MINT_AMOUNT,
-//         logger,
-//       );
-//       logger.info(`testWallets ready 1`);
-//     } else {
-//       PXE_URL = config.PXE_URL;
+  it('can transfer 10tps tokens', async () => {
+    const recipient = testWallets.recipientWallet.getAddress();
+    const transferAmount = 1n;
 
-//       testWallets = await setupTestWalletsWithTokens(PXE_URL, MINT_AMOUNT, logger);
-//     }
+    for (const w of testWallets.wallets) {
+      expect(MINT_AMOUNT).toBe(
+        await testWallets.tokenAdminWallet.methods
+          .balance_of_public(w.getAddress())
+          .simulate({ from: testWallets.tokenAdminAddress }),
+      );
+    }
 
-//     logger.info(
-//       `Test setup complete. Planning ${TOTAL_TXS} transactions over ${TEST_DURATION_SECONDS} seconds at ${TARGET_TPS} TPS`,
-//     );
-//   });
+    expect(0n).toBe(
+      await testWallets.tokenAdminWallet.methods
+        .balance_of_public(recipient)
+        .simulate({ from: testWallets.tokenAdminAddress }),
+    );
 
-//   // it('can verify token setup', async () => {
-//   //   const name = readFieldCompressedString(await tokenContract.methods.private_get_name().simulate());
-//   //   expect(name).toBeDefined();
-//   //   expect(name.length).toBeGreaterThan(0);
-//   //   logger.info(`Token verified: ${name}`);
-//   // });
+    const wallet = testWallets.wallets[0];
 
-//   it('can get info', async () => {
-//     const name = readFieldCompressedString(
-//       await testWallets.tokenAdminWallet.methods.private_get_name().simulate({ from: testWallets.tokenAdminAddress }),
-//     );
-//     expect(name).toBe(testWallets.tokenName);
-//   });
+    const baseTx = await (await TokenContract.at(testWallets.tokenAddress, wallet)).methods
+      .transfer_in_public(wallet.getAddress(), recipient, transferAmount, 0)
+      .prove({ from: testWallets.tokenAdminAddress });
 
-//   it('can transfer 10tps tokens', async () => {
-//     const recipient = testWallets.recipientWallet.getAddress();
-//     const transferAmount = 1n;
+    const allSentTxs: any[] = []; // Store sent transactions separately
 
-//     for (const w of testWallets.wallets) {
-//       expect(MINT_AMOUNT).toBe(
-//         await testWallets.tokenAdminWallet.methods
-//           .balance_of_public(w.getAddress())
-//           .simulate({ from: testWallets.tokenAdminAddress }),
-//       );
-//     }
+    let globalIdx = 0;
 
-//     expect(0n).toBe(
-//       await testWallets.tokenAdminWallet.methods
-//         .balance_of_public(recipient)
-//         .simulate({ from: testWallets.tokenAdminAddress }),
-//     );
+    for (let sec = 0; sec < TEST_DURATION_SECONDS; sec++) {
+      const secondStart = Date.now();
 
-//     const wallet = testWallets.wallets[0];
+      const batchTxs: ProvenTx[] = [];
 
-//     const baseTx = await (await TokenContract.at(testWallets.tokenAddress, wallet)).methods
-//       .transfer_in_public(wallet.getAddress(), recipient, transferAmount, 0)
-//       .prove({ from: testWallets.tokenAdminAddress });
+      for (let i = 0; i < TARGET_TPS; i++, globalIdx++) {
+        const clonedTxData = Tx.clone(baseTx);
 
-//     const allSentTxs: any[] = []; // Store sent transactions separately
+        const nullifiers = clonedTxData.data.getNonEmptyNullifiers();
+        if (nullifiers.length > 0) {
+          const newNullifier = nullifiers[0].add(Fr.fromString(globalIdx.toString()));
+          if (clonedTxData.data.forRollup) {
+            clonedTxData.data.forRollup.end.nullifiers[0] = newNullifier;
+          } else if (clonedTxData.data.forPublic) {
+            clonedTxData.data.forPublic.nonRevertibleAccumulatedData.nullifiers[0] = newNullifier;
+          }
+        }
 
-//     let globalIdx = 0;
+        const clonedTx = new ProvenTx(wallet, clonedTxData, []);
+        batchTxs.push(clonedTx);
+      }
 
-//     for (let sec = 0; sec < TEST_DURATION_SECONDS; sec++) {
-//       const secondStart = Date.now();
+      // Send transactions without waiting for inclusion
+      for (let idx = 0; idx < batchTxs.length; idx++) {
+        const tx = batchTxs[idx];
+        const sentTx = tx.send();
+        allSentTxs.push(sentTx);
+        logger.info(`sec ${sec + 1}: sent tx ${globalIdx - TARGET_TPS + idx + 1}`);
+      }
 
-//       const batchTxs: ProvenTx[] = [];
+      // 1 second spacing between batches
+      const elapsed = Date.now() - secondStart;
+      if (elapsed < 1000) {
+        await sleep(1000 - elapsed);
+      }
+    }
 
-//       for (let i = 0; i < TARGET_TPS; i++, globalIdx++) {
-//         const clonedTxData = Tx.clone(baseTx);
+    // Now wait for all transactions to be included
+    logger.info(`All ${TOTAL_TXS} transactions sent. Waiting for inclusion...`);
 
-//         const nullifiers = clonedTxData.data.getNonEmptyNullifiers();
-//         if (nullifiers.length > 0) {
-//           const newNullifier = nullifiers[0].add(Fr.fromString(globalIdx.toString()));
-//           if (clonedTxData.data.forRollup) {
-//             clonedTxData.data.forRollup.end.nullifiers[0] = newNullifier;
-//           } else if (clonedTxData.data.forPublic) {
-//             clonedTxData.data.forPublic.nonRevertibleAccumulatedData.nullifiers[0] = newNullifier;
-//           }
-//         }
+    const inclusionPromises = allSentTxs.map((sentTx, idx) =>
+      (async () => {
+        try {
+          await sentTx.wait({
+            timeout: 120,
+            interval: 1,
+            ignoreDroppedReceiptsFor: 2,
+          });
+          const receipt = await sentTx.getReceipt();
+          logger.info(`tx ${idx + 1} included in block ${receipt.blockNumber}`);
+          return { success: true, tx: sentTx };
+        } catch (error) {
+          logger.error(`tx ${idx + 1} was not included: ${error}`);
+          return { success: false, tx: sentTx, error };
+        }
+      })(),
+    );
 
-//         const clonedTx = new ProvenTx(wallet, clonedTxData, []);
-//         batchTxs.push(clonedTx);
-//       }
+    // Wait for every transaction to be included
+    const results = await Promise.all(inclusionPromises);
 
-//       // Send transactions without waiting for inclusion
-//       for (let idx = 0; idx < batchTxs.length; idx++) {
-//         const tx = batchTxs[idx];
-//         const sentTx = tx.send();
-//         allSentTxs.push(sentTx);
-//         logger.info(`sec ${sec + 1}: sent tx ${globalIdx - TARGET_TPS + idx + 1}`);
-//       }
+    // Count successes and failures
+    const successCount = results.filter(r => r.success).length;
+    const failureCount = results.filter(r => !r.success).length;
 
-//       // 1 second spacing between batches
-//       const elapsed = Date.now() - secondStart;
-//       if (elapsed < 1000) {
-//         await sleep(1000 - elapsed);
-//       }
-//     }
+    expect(allSentTxs.length).toBe(TOTAL_TXS);
 
-//     // Now wait for all transactions to be included
-//     logger.info(`All ${TOTAL_TXS} transactions sent. Waiting for inclusion...`);
+    // Log failed transactions for debugging
+    results
+      .filter(r => !r.success)
+      .forEach((result, idx) => {
+        logger.warn(`Failed transaction ${idx + 1}: ${result.error}`);
+      });
 
-//     const inclusionPromises = allSentTxs.map((sentTx, idx) =>
-//       (async () => {
-//         try {
-//           await sentTx.wait({
-//             timeout: 120,
-//             interval: 1,
-//             ignoreDroppedReceiptsFor: 2,
-//           });
-//           const receipt = await sentTx.getReceipt();
-//           logger.info(`tx ${idx + 1} included in block ${receipt.blockNumber}`);
-//           return { success: true, tx: sentTx };
-//         } catch (error) {
-//           logger.error(`tx ${idx + 1} was not included: ${error}`);
-//           return { success: false, tx: sentTx, error };
-//         }
-//       })(),
-//     );
+    logger.info(
+      `Transaction inclusion summary: ${successCount} succeeded, ${failureCount} failed out of ${TOTAL_TXS} total`,
+    );
 
-//     // Wait for every transaction to be included
-//     const results = await Promise.all(inclusionPromises);
-
-//     // Count successes and failures
-//     const successCount = results.filter(r => r.success).length;
-//     const failureCount = results.filter(r => !r.success).length;
-
-//     expect(allSentTxs.length).toBe(TOTAL_TXS);
-
-//     // Log failed transactions for debugging
-//     results
-//       .filter(r => !r.success)
-//       .forEach((result, idx) => {
-//         logger.warn(`Failed transaction ${idx + 1}: ${result.error}`);
-//       });
-
-//     logger.info(
-//       `Transaction inclusion summary: ${successCount} succeeded, ${failureCount} failed out of ${TOTAL_TXS} total`,
-//     );
-
-//     const recipientBalance = await testWallets.tokenAdminWallet.methods
-//       .balance_of_public(recipient)
-//       .simulate({ from: testWallets.tokenAdminAddress });
-//     logger.info(`recipientBalance after load test: ${recipientBalance}`);
-//   });
-// });
+    const recipientBalance = await testWallets.tokenAdminWallet.methods
+      .balance_of_public(recipient)
+      .simulate({ from: testWallets.tokenAdminAddress });
+    logger.info(`recipientBalance after load test: ${recipientBalance}`);
+  });
+});

--- a/yarn-project/end-to-end/src/spartan/reorg.test.ts
+++ b/yarn-project/end-to-end/src/spartan/reorg.test.ts
@@ -1,137 +1,127 @@
-// import { sleep } from '@aztec/aztec.js';
-// import { RollupCheatCodes } from '@aztec/aztec/testing';
-// import { EthCheatCodesWithState } from '@aztec/ethereum/test';
-// import { createLogger } from '@aztec/foundation/log';
+// CREATE_CHAOS_MESH should be set to true to run this test
+import { type PXE, sleep } from '@aztec/aztec.js';
+import { RollupCheatCodes } from '@aztec/aztec/testing';
+import { EthCheatCodesWithState } from '@aztec/ethereum/test';
+import { createLogger } from '@aztec/foundation/log';
 
-// import { expect, jest } from '@jest/globals';
-// import type { ChildProcess } from 'child_process';
+import { expect, jest } from '@jest/globals';
+import type { ChildProcess } from 'child_process';
 
-// import { type TestWallets, performTransfers, setupTestWalletsWithTokens } from './setup_test_wallets.js';
-// import {
-//   applyProverFailure,
-//   deleteResourceByLabel,
-//   isK8sConfig,
-//   setupEnvironment,
-//   startPortForward,
-//   waitForResourceByLabel,
-// } from './utils.js';
+import {
+  type TestWallets,
+  deploySponsoredTestWallets,
+  performTransfers,
+  startCompatiblePXE,
+} from './setup_test_wallets.js';
+import { applyProverFailure, setupEnvironment, startPortForwardForEthereum, startPortForwardForRPC } from './utils.js';
 
-// const config = setupEnvironment(process.env);
-// if (!isK8sConfig(config)) {
-//   throw new Error('This test must be run in a k8s environment');
-// }
-// const { NAMESPACE, CONTAINER_PXE_PORT, CONTAINER_ETHEREUM_PORT, SPARTAN_DIR } = config;
-// const debugLogger = createLogger('e2e:spartan-test:reorg');
+const config = { ...setupEnvironment(process.env), REAL_VERIFIER: true }; // todo: remove REAL_VERIFIER condition, currently false produces invalid proofs
+const debugLogger = createLogger('e2e:spartan-test:reorg');
 
-// async function checkBalances(testWallets: TestWallets, mintAmount: bigint, totalAmountTransferred: bigint) {
-//   for (const w of testWallets.wallets) {
-//     expect(
-//       await testWallets.tokenAdminWallet.methods
-//         .balance_of_public(w.getAddress())
-//         .simulate({ from: testWallets.tokenAdminAddress }),
-//     ).toBe(mintAmount - totalAmountTransferred);
-//   }
+async function checkBalances(testWallets: TestWallets, mintAmount: bigint, totalAmountTransferred: bigint) {
+  for (const w of testWallets.wallets) {
+    expect(
+      await testWallets.tokenAdminWallet.methods
+        .balance_of_public(w.getAddress())
+        .simulate({ from: testWallets.tokenAdminAddress }),
+    ).toBe(mintAmount - totalAmountTransferred);
+  }
 
-//   expect(
-//     await testWallets.tokenAdminWallet.methods
-//       .balance_of_public(testWallets.recipientWallet.getAddress())
-//       .simulate({ from: testWallets.tokenAdminAddress }),
-//   ).toBe(totalAmountTransferred * BigInt(testWallets.wallets.length));
-// }
+  expect(
+    await testWallets.tokenAdminWallet.methods
+      .balance_of_public(testWallets.recipientWallet.getAddress())
+      .simulate({ from: testWallets.tokenAdminAddress }),
+  ).toBe(totalAmountTransferred * BigInt(testWallets.wallets.length));
+}
 
-// describe('reorg test', () => {
-//   jest.setTimeout(60 * 60 * 1000); // 60 minutes
+describe('reorg test', () => {
+  jest.setTimeout(60 * 60 * 1000); // 60 minutes
 
-//   const MINT_AMOUNT = 2_000_000n;
-//   const SETUP_EPOCHS = 2;
-//   const TRANSFER_AMOUNT = 1n;
-//   let ETHEREUM_HOSTS: string;
-//   let PXE_URL: string;
-//   const forwardProcesses: ChildProcess[] = [];
+  const MINT_AMOUNT = 2_000_000n;
+  const SETUP_EPOCHS = 2;
+  const TRANSFER_AMOUNT = 1n;
+  let ETHEREUM_HOSTS: string[];
+  const forwardProcesses: ChildProcess[] = [];
+  let rpcUrl: string;
 
-//   let testWallets: TestWallets;
+  let testWallets: TestWallets;
+  let pxe: PXE;
+  let cleanup: undefined | (() => Promise<void>);
 
-//   afterAll(() => {
-//     forwardProcesses.forEach(p => p.kill());
-//   });
+  afterAll(async () => {
+    await cleanup?.();
+    forwardProcesses.forEach(p => p.kill());
+  });
 
-//   it('survives a reorg', async () => {
-//     const { process: pxeProcess, port: pxePort } = await startPortForward({
-//       resource: `svc/${config.INSTANCE_NAME}-aztec-network-pxe`,
-//       namespace: NAMESPACE,
-//       containerPort: CONTAINER_PXE_PORT,
-//     });
-//     forwardProcesses.push(pxeProcess);
-//     PXE_URL = `http://127.0.0.1:${pxePort}`;
+  beforeAll(async () => {
+    const { process: aztecRpcProcess, port: aztecRpcPort } = await startPortForwardForRPC(config.NAMESPACE);
+    const { process: ethProcess, port: ethPort } = await startPortForwardForEthereum(config.NAMESPACE);
+    forwardProcesses.push(aztecRpcProcess);
+    forwardProcesses.push(ethProcess);
 
-//     const { process: ethProcess, port: ethPort } = await startPortForward({
-//       resource: `svc/${config.INSTANCE_NAME}-aztec-network-eth-execution`,
-//       namespace: NAMESPACE,
-//       containerPort: CONTAINER_ETHEREUM_PORT,
-//     });
-//     forwardProcesses.push(ethProcess);
-//     ETHEREUM_HOSTS = `http://127.0.0.1:${ethPort}`;
-//     testWallets = await setupTestWalletsWithTokens(PXE_URL, MINT_AMOUNT, debugLogger);
-//     const rollupCheatCodes = new RollupCheatCodes(
-//       new EthCheatCodesWithState([ETHEREUM_HOSTS]),
-//       await testWallets.pxe.getNodeInfo().then(n => n.l1ContractAddresses),
-//     );
-//     const { epochDuration, slotDuration } = await rollupCheatCodes.getConfig();
+    rpcUrl = `http://127.0.0.1:${aztecRpcPort}`;
+    ETHEREUM_HOSTS = [`http://127.0.0.1:${ethPort}`];
 
-//     await performTransfers({
-//       testWallets,
-//       rounds: Number(epochDuration) * SETUP_EPOCHS,
-//       transferAmount: TRANSFER_AMOUNT,
-//       logger: debugLogger,
-//     });
-//     await checkBalances(testWallets, MINT_AMOUNT, TRANSFER_AMOUNT * epochDuration * BigInt(SETUP_EPOCHS));
+    ({ pxe, cleanup } = await startCompatiblePXE(rpcUrl, config.REAL_VERIFIER, debugLogger));
+    testWallets = await deploySponsoredTestWallets(pxe, MINT_AMOUNT, debugLogger);
+  });
 
-//     // get the tips before the reorg
-//     const { pending: preReorgPending, proven: preReorgProven } = await rollupCheatCodes.getTips();
+  it('survives a reorg', async () => {
+    const rollupCheatCodes = new RollupCheatCodes(
+      new EthCheatCodesWithState(ETHEREUM_HOSTS),
+      await pxe.getNodeInfo().then(n => n.l1ContractAddresses),
+    );
+    const { epochDuration, slotDuration } = await rollupCheatCodes.getConfig();
 
-//     // kill the provers
-//     const stdout = await applyProverFailure({
-//       namespace: NAMESPACE,
-//       spartanDir: SPARTAN_DIR,
-//       durationSeconds: Number(epochDuration * slotDuration) * 2,
-//       logger: debugLogger,
-//     });
-//     debugLogger.info(stdout);
+    await performTransfers({
+      testWallets,
+      rounds: Number(epochDuration) * SETUP_EPOCHS,
+      transferAmount: TRANSFER_AMOUNT,
+      logger: debugLogger,
+    });
+    await checkBalances(testWallets, MINT_AMOUNT, TRANSFER_AMOUNT * epochDuration * BigInt(SETUP_EPOCHS));
 
-//     // We only need 2 epochs for a reorg to be triggered, but 3 gives time for the bot to be restarted and the chain to re-stabilize
-//     // TODO(#9613): why do we need to wait for 3 epochs?
-//     debugLogger.info(`Waiting for 3 epochs to pass`);
-//     await sleep(Number(epochDuration * slotDuration) * 3 * 1000);
+    // get the tips before the reorg
+    const { pending: preReorgPending, proven: preReorgProven } = await rollupCheatCodes.getTips();
 
-//     // TODO(#9327): begin delete
-//     // The bot must be restarted because the PXE does not handle reorgs without a restart.
-//     // When the issue is fixed, we can remove the following delete, wait, startPortForward, and setupTestWallets
-//     await deleteResourceByLabel({ resource: 'pods', namespace: NAMESPACE, label: 'app=pxe' });
-//     await sleep(30 * 1000);
-//     await waitForResourceByLabel({ resource: 'pods', namespace: NAMESPACE, label: 'app=pxe' });
-//     await sleep(30 * 1000);
-//     await startPortForward({
-//       resource: `svc/${config.INSTANCE_NAME}-aztec-network-pxe`,
-//       namespace: NAMESPACE,
-//       containerPort: CONTAINER_PXE_PORT,
-//     });
-//     forwardProcesses.push(pxeProcess);
-//     PXE_URL = `http://127.0.0.1:${pxePort}`;
-//     testWallets = await setupTestWalletsWithTokens(PXE_URL, MINT_AMOUNT, debugLogger);
-//     // TODO(#9327): end delete
+    // kill the provers
+    const stdout = await applyProverFailure({
+      namespace: config.NAMESPACE,
+      spartanDir: `/workspaces/aztec-packages/spartan`,
+      durationSeconds: Number(epochDuration * slotDuration) * 2,
+      logger: debugLogger,
+    });
+    debugLogger.info(stdout);
 
-//     await performTransfers({
-//       testWallets,
-//       rounds: Number(epochDuration) * SETUP_EPOCHS,
-//       transferAmount: TRANSFER_AMOUNT,
-//       logger: debugLogger,
-//     });
+    // We only need 2 epochs for a reorg to be triggered, but 3 gives time for the bot to be restarted and the chain to re-stabilize
+    // TODO(#9613): why do we need to wait for 3 epochs?
+    debugLogger.info(`Waiting for 3 epochs to pass`);
+    await sleep(Number(epochDuration * slotDuration) * 3 * 1000);
 
-//     // expect the block height to be at least 4 epochs worth of slots
-//     const { pending: newPending, proven: newProven } = await rollupCheatCodes.getTips();
-//     expect(newPending).toBeGreaterThan(preReorgPending);
-//     expect(newPending).toBeGreaterThan(4 * Number(epochDuration));
-//     expect(newProven).toBeGreaterThan(preReorgProven);
-//     expect(newProven).toBeGreaterThan(3 * Number(epochDuration));
-//   });
-// });
+    // TODO(#9327): begin delete
+    // The bot must be restarted because the PXE does not handle reorgs without a restart.
+    // When the issue is fixed, we can remove the following restart logic
+    await cleanup?.();
+    await sleep(30 * 1000);
+
+    // Restart the PXE
+    ({ pxe, cleanup } = await startCompatiblePXE(rpcUrl, config.REAL_VERIFIER, debugLogger));
+    await sleep(30 * 1000);
+    testWallets = await deploySponsoredTestWallets(pxe, MINT_AMOUNT, debugLogger);
+    // TODO(#9327): end delete
+
+    await performTransfers({
+      testWallets,
+      rounds: Number(epochDuration) * SETUP_EPOCHS,
+      transferAmount: TRANSFER_AMOUNT,
+      logger: debugLogger,
+    });
+
+    // expect the block height to be at least 4 epochs worth of slots
+    const { pending: newPending, proven: newProven } = await rollupCheatCodes.getTips();
+    expect(newPending).toBeGreaterThan(preReorgPending);
+    expect(newPending).toBeGreaterThan(4 * Number(epochDuration));
+    expect(newProven).toBeGreaterThan(preReorgProven);
+    expect(newProven).toBeGreaterThan(3 * Number(epochDuration));
+  });
+});


### PR DESCRIPTION
- Fixes 1tps, ntps, and 4epochs, and reorg test for use under terraform deployment.
- Adds an optional fee argument that defaults to the sponsored fee in the test wallet setup. This is needed for the reorg test. 
- Fixes terraform main file variable name mismatch

note: Currently the tests all use real proofs enabled due to proofs being invalid if they are mocked. 