### PR TITLE
chore: Disallow dangerous usage of add_variable and from_witness functions with non-field types

### DIFF
--- a/barretenberg/cpp/src/barretenberg/boomerang_value_detection/graph_description_dynamic_array.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/boomerang_value_detection/graph_description_dynamic_array.test.cpp
@@ -37,7 +37,7 @@ TEST(boomerang_stdlib_dynamic_array, graph_description_dynamic_array_method_resi
 
     field_ct next_size = field_ct(witness_ct(&builder, (uint256_t)(max_size - 1)));
     for (size_t i = 0; i < max_size; ++i) {
-        array.push(field_ct::from_witness(&builder, i));
+        array.push(field_ct::from_witness(&builder, typename field_ct::native(i)));
     }
 
     array.resize(next_size, 7);
@@ -67,7 +67,7 @@ TEST(boomerang_stdlib_dynamic_array, graph_description_dynamic_array_consistency
     DynamicArray_ct array(&builder, max_size);
 
     for (size_t i = 0; i < max_size; ++i) {
-        array.push(field_ct::from_witness(&builder, i));
+        array.push(field_ct::from_witness(&builder, typename field_ct::native(i)));
     }
 
     for (size_t i = 0; i < max_size; ++i) {

--- a/barretenberg/cpp/src/barretenberg/circuit_checker/ultra_circuit_builder.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/circuit_checker/ultra_circuit_builder.test.cpp
@@ -717,10 +717,10 @@ TEST(UltraCircuitBuilder, Rom)
         builder.set_ROM_element(rom_id, i, rom_values[i]);
     }
 
-    uint32_t a_idx = builder.read_ROM_array(rom_id, builder.add_variable(5));
+    uint32_t a_idx = builder.read_ROM_array(rom_id, builder.add_variable(bb::fr(5)));
     EXPECT_EQ(a_idx != rom_values[5], true);
-    uint32_t b_idx = builder.read_ROM_array(rom_id, builder.add_variable(4));
-    uint32_t c_idx = builder.read_ROM_array(rom_id, builder.add_variable(1));
+    uint32_t b_idx = builder.read_ROM_array(rom_id, builder.add_variable(bb::fr(4)));
+    uint32_t c_idx = builder.read_ROM_array(rom_id, builder.add_variable(bb::fr(1)));
 
     const auto d_value = builder.get_variable(a_idx) + builder.get_variable(b_idx) + builder.get_variable(c_idx);
     uint32_t d_idx = builder.add_variable(d_value);
@@ -756,7 +756,7 @@ TEST(UltraCircuitBuilder, RamSimple)
     builder.init_RAM_element(ram_id, /*index_value=*/0, ram_value_idx);
 
     // Read from the RAM array we just created (at the 0th index)
-    uint32_t read_idx = builder.add_variable(0);
+    uint32_t read_idx = builder.add_variable(bb::fr(0));
     uint32_t a_idx = builder.read_RAM_array(ram_id, read_idx);
 
     // Use the result in a simple arithmetic gate
@@ -792,14 +792,14 @@ TEST(UltraCircuitBuilder, Ram)
         builder.init_RAM_element(ram_id, i, ram_values[i]);
     }
 
-    uint32_t a_idx = builder.read_RAM_array(ram_id, builder.add_variable(5));
+    uint32_t a_idx = builder.read_RAM_array(ram_id, builder.add_variable(bb::fr(5)));
     EXPECT_EQ(a_idx != ram_values[5], true);
 
-    uint32_t b_idx = builder.read_RAM_array(ram_id, builder.add_variable(4));
-    uint32_t c_idx = builder.read_RAM_array(ram_id, builder.add_variable(1));
+    uint32_t b_idx = builder.read_RAM_array(ram_id, builder.add_variable(bb::fr(4)));
+    uint32_t c_idx = builder.read_RAM_array(ram_id, builder.add_variable(bb::fr(1)));
 
-    builder.write_RAM_array(ram_id, builder.add_variable(4), builder.add_variable(500));
-    uint32_t d_idx = builder.read_RAM_array(ram_id, builder.add_variable(4));
+    builder.write_RAM_array(ram_id, builder.add_variable(bb::fr(4)), builder.add_variable(bb::fr(500)));
+    uint32_t d_idx = builder.read_RAM_array(ram_id, builder.add_variable(bb::fr(4)));
 
     EXPECT_EQ(builder.get_variable(d_idx), 500);
 
@@ -849,10 +849,10 @@ TEST(UltraCircuitBuilder, RangeChecksOnDuplicates)
 {
     UltraCircuitBuilder builder = UltraCircuitBuilder();
 
-    uint32_t a = builder.add_variable(100);
-    uint32_t b = builder.add_variable(100);
-    uint32_t c = builder.add_variable(100);
-    uint32_t d = builder.add_variable(100);
+    uint32_t a = builder.add_variable(bb::fr(100));
+    uint32_t b = builder.add_variable(bb::fr(100));
+    uint32_t c = builder.add_variable(bb::fr(100));
+    uint32_t d = builder.add_variable(bb::fr(100));
 
     builder.assert_equal(a, b);
     builder.assert_equal(a, c);
@@ -885,8 +885,8 @@ TEST(UltraCircuitBuilder, CheckCircuitShowcase)
     UltraCircuitBuilder builder = UltraCircuitBuilder();
     // check_circuit allows us to check correctness on the go
 
-    uint32_t a = builder.add_variable(0xdead);
-    uint32_t b = builder.add_variable(0xbeef);
+    uint32_t a = builder.add_variable(bb::fr(0xdead));
+    uint32_t b = builder.add_variable(bb::fr(0xbeef));
     // Let's create 2 gates that will bind these 2 variables to be one these two values
     builder.create_poly_gate(
         { a, a, builder.zero_idx, fr(1), -fr(0xdead) - fr(0xbeef), 0, 0, fr(0xdead) * fr(0xbeef) });
@@ -909,7 +909,7 @@ TEST(UltraCircuitBuilder, CheckCircuitShowcase)
     EXPECT_EQ(CircuitChecker::check(builder), false);
 
     // But if we force them both back to be 0xbeef...
-    uint32_t c = builder.add_variable(0xbeef);
+    uint32_t c = builder.add_variable(bb::fr(0xbeef));
     builder.assert_equal(c, b);
 
     // The circuit will magically pass again

--- a/barretenberg/cpp/src/barretenberg/client_ivc/mock_circuit_producer.hpp
+++ b/barretenberg/cpp/src/barretenberg/client_ivc/mock_circuit_producer.hpp
@@ -174,7 +174,7 @@ class PrivateFunctionExecutionMockCircuitProducer {
             MockCircuits::construct_arithmetic_circuit(circuit, log2_num_gates, /* include_public_inputs= */ false);
             // Add some public inputs
             for (size_t i = 0; i < num_public_inputs; ++i) {
-                circuit.add_public_variable(13634816 + i); // arbitrary number
+                circuit.add_public_variable(bb::fr(13634816 + i)); // arbitrary number
             }
         } else {
             // If the number of gates is not specified we create a structured mock circuit

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_integration.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_integration.test.cpp
@@ -82,9 +82,9 @@ class AcirIntegrationTest : public ::testing::Test {
 
     void add_some_simple_RAM_gates(auto& circuit)
     {
-        std::array<uint32_t, 3> ram_values{ circuit.add_variable(5),
-                                            circuit.add_variable(10),
-                                            circuit.add_variable(20) };
+        std::array<uint32_t, 3> ram_values{ circuit.add_variable(bb::fr(5)),
+                                            circuit.add_variable(bb::fr(10)),
+                                            circuit.add_variable(bb::fr(20)) };
 
         size_t ram_id = circuit.create_RAM_array(3);
 
@@ -92,9 +92,9 @@ class AcirIntegrationTest : public ::testing::Test {
             circuit.init_RAM_element(ram_id, i, ram_values[i]);
         }
 
-        auto val_idx_1 = circuit.read_RAM_array(ram_id, circuit.add_variable(1));
-        auto val_idx_2 = circuit.read_RAM_array(ram_id, circuit.add_variable(2));
-        auto val_idx_3 = circuit.read_RAM_array(ram_id, circuit.add_variable(0));
+        auto val_idx_1 = circuit.read_RAM_array(ram_id, circuit.add_variable(bb::fr(1)));
+        auto val_idx_2 = circuit.read_RAM_array(ram_id, circuit.add_variable(bb::fr(2)));
+        auto val_idx_3 = circuit.read_RAM_array(ram_id, circuit.add_variable(bb::fr(0)));
 
         circuit.create_big_add_gate({
             val_idx_1,

--- a/barretenberg/cpp/src/barretenberg/flavor/mega_recursive_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/mega_recursive_flavor.hpp
@@ -124,9 +124,9 @@ template <typename BuilderType> class MegaRecursiveFlavor_ {
          */
         VerificationKey(CircuitBuilder* builder, const std::shared_ptr<NativeVerificationKey>& native_key)
         {
-            this->log_circuit_size = FF::from_witness(builder, native_key->log_circuit_size);
-            this->num_public_inputs = FF::from_witness(builder, native_key->num_public_inputs);
-            this->pub_inputs_offset = FF::from_witness(builder, native_key->pub_inputs_offset);
+            this->log_circuit_size = FF::from_witness(builder, typename FF::native(native_key->log_circuit_size));
+            this->num_public_inputs = FF::from_witness(builder, typename FF::native(native_key->num_public_inputs));
+            this->pub_inputs_offset = FF::from_witness(builder, typename FF::native(native_key->pub_inputs_offset));
 
             // Generate stdlib commitments (biggroup) from the native counterparts
             for (auto [commitment, native_commitment] : zip_view(this->get_all(), native_key->get_all())) {

--- a/barretenberg/cpp/src/barretenberg/flavor/permutation_lib.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/permutation_lib.test.cpp
@@ -17,21 +17,21 @@ class PermutationHelperTests : public ::testing::Test {
     virtual void SetUp()
     {
         bb::srs::init_file_crs_factory(bb::srs::bb_crs_path());
-        circuit_constructor.add_public_variable(1024);
-        circuit_constructor.add_public_variable(1025);
+        circuit_constructor.add_public_variable(bb::fr(1024));
+        circuit_constructor.add_public_variable(bb::fr(1025));
 
-        uint32_t v_1 = circuit_constructor.add_variable(16 + 1);
-        uint32_t v_2 = circuit_constructor.add_variable(16 + 2);
-        uint32_t v_3 = circuit_constructor.add_variable(16 + 3);
-        uint32_t v_4 = circuit_constructor.add_variable(16 + 4);
-        uint32_t v_5 = circuit_constructor.add_variable(16 + 5);
-        uint32_t v_6 = circuit_constructor.add_variable(16 + 6);
-        uint32_t v_7 = circuit_constructor.add_variable(16 + 7);
-        uint32_t v_8 = circuit_constructor.add_variable(16 + 8);
-        uint32_t v_9 = circuit_constructor.add_variable(16 + 9);
-        uint32_t v_10 = circuit_constructor.add_variable(16 + 10);
-        uint32_t v_11 = circuit_constructor.add_variable(16 + 11);
-        uint32_t v_12 = circuit_constructor.add_variable(16 + 12);
+        uint32_t v_1 = circuit_constructor.add_variable(bb::fr(16 + 1));
+        uint32_t v_2 = circuit_constructor.add_variable(bb::fr(16 + 2));
+        uint32_t v_3 = circuit_constructor.add_variable(bb::fr(16 + 3));
+        uint32_t v_4 = circuit_constructor.add_variable(bb::fr(16 + 4));
+        uint32_t v_5 = circuit_constructor.add_variable(bb::fr(16 + 5));
+        uint32_t v_6 = circuit_constructor.add_variable(bb::fr(16 + 6));
+        uint32_t v_7 = circuit_constructor.add_variable(bb::fr(16 + 7));
+        uint32_t v_8 = circuit_constructor.add_variable(bb::fr(16 + 8));
+        uint32_t v_9 = circuit_constructor.add_variable(bb::fr(16 + 9));
+        uint32_t v_10 = circuit_constructor.add_variable(bb::fr(16 + 10));
+        uint32_t v_11 = circuit_constructor.add_variable(bb::fr(16 + 11));
+        uint32_t v_12 = circuit_constructor.add_variable(bb::fr(16 + 12));
 
         circuit_constructor.create_add_gate({ v_1, v_5, v_9, 0, 0, 0, 0 });
         circuit_constructor.create_add_gate({ v_2, v_6, v_10, 0, 0, 0, 0 });

--- a/barretenberg/cpp/src/barretenberg/flavor/ultra_recursive_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/ultra_recursive_flavor.hpp
@@ -124,9 +124,9 @@ template <typename BuilderType> class UltraRecursiveFlavor_ {
          */
         VerificationKey(CircuitBuilder* builder, const std::shared_ptr<NativeVerificationKey>& native_key)
         {
-            this->log_circuit_size = FF::from_witness(builder, native_key->log_circuit_size);
-            this->num_public_inputs = FF::from_witness(builder, native_key->num_public_inputs);
-            this->pub_inputs_offset = FF::from_witness(builder, native_key->pub_inputs_offset);
+            this->log_circuit_size = FF::from_witness(builder, typename FF::native(native_key->log_circuit_size));
+            this->num_public_inputs = FF::from_witness(builder, typename FF::native(native_key->num_public_inputs));
+            this->pub_inputs_offset = FF::from_witness(builder, typename FF::native(native_key->pub_inputs_offset));
 
             // Generate stdlib commitments (biggroup) from the native counterparts
             for (auto [commitment, native_commitment] : zip_view(this->get_all(), native_key->get_all())) {

--- a/barretenberg/cpp/src/barretenberg/flavor/ultra_rollup_recursive_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/ultra_rollup_recursive_flavor.hpp
@@ -70,9 +70,9 @@ template <typename BuilderType> class UltraRollupRecursiveFlavor_ : public Ultra
          */
         VerificationKey(CircuitBuilder* builder, const std::shared_ptr<NativeVerificationKey>& native_key)
         {
-            this->log_circuit_size = FF::from_witness(builder, native_key->log_circuit_size);
-            this->num_public_inputs = FF::from_witness(builder, native_key->num_public_inputs);
-            this->pub_inputs_offset = FF::from_witness(builder, native_key->pub_inputs_offset);
+            this->log_circuit_size = FF::from_witness(builder, typename FF::native(native_key->log_circuit_size));
+            this->num_public_inputs = FF::from_witness(builder, typename FF::native(native_key->num_public_inputs));
+            this->pub_inputs_offset = FF::from_witness(builder, typename FF::native(native_key->pub_inputs_offset));
 
             // Generate stdlib commitments (biggroup) from the native counterparts
             for (auto [commitment, native_commitment] : zip_view(this->get_all(), native_key->get_all())) {

--- a/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy.test.cpp
@@ -260,7 +260,6 @@ template <typename Flavor> class ProtogalaxyTests : public testing::Test {
         pk_1->relation_parameters.eta = 1;
 
         Builder builder2;
-        builder2.add_variable(3);
         stdlib::recursion::PairingPoints<Builder>::add_default_to_public_inputs(builder2);
         auto pk_2 = std::make_shared<DeciderProvingKey>(builder2);
         pk_2->relation_parameters.eta = 3;
@@ -292,7 +291,6 @@ template <typename Flavor> class ProtogalaxyTests : public testing::Test {
         pk_1->alphas.fill(2);
 
         Builder builder2;
-        builder2.add_variable(3);
         stdlib::recursion::PairingPoints<Builder>::add_default_to_public_inputs(builder2);
         auto pk_2 = std::make_shared<DeciderProvingKey>(builder2);
         pk_2->alphas.fill(4);

--- a/barretenberg/cpp/src/barretenberg/stdlib/eccvm_verifier/eccvm_recursive_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/eccvm_verifier/eccvm_recursive_flavor.hpp
@@ -112,8 +112,8 @@ class ECCVMRecursiveFlavor {
             // and the verification key.
             this->log_circuit_size = BF{ static_cast<uint64_t>(CONST_ECCVM_LOG_N) };
             this->log_circuit_size.convert_constant_to_fixed_witness(builder);
-            this->num_public_inputs = BF::from_witness(builder, native_key->num_public_inputs);
-            this->pub_inputs_offset = BF::from_witness(builder, native_key->pub_inputs_offset);
+            this->num_public_inputs = BF::from_witness(builder, typename BF::native(native_key->num_public_inputs));
+            this->pub_inputs_offset = BF::from_witness(builder, typename BF::native(native_key->pub_inputs_offset));
 
             for (auto [native_commitment, commitment] : zip_view(native_key->get_all(), this->get_all())) {
                 commitment = Commitment::from_witness(builder, native_commitment);

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
@@ -300,6 +300,9 @@ template <typename Builder, typename T> class bigfield {
         result.set_free_witness_tag();
         return result;
     }
+    // Disallow from_witness for non-bb::fr types to prevent implicit conversions (specifically, using indices rather
+    // than values)
+    template <typename OT> static bigfield from_witness(Builder* ctx, const OT& input) = delete;
 
     bigfield& operator=(const bigfield& other);
     bigfield& operator=(bigfield&& other) noexcept;

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.test.cpp
@@ -1097,7 +1097,7 @@ template <typename Builder> class stdlib_bigfield : public testing::Test {
         // Set the high bit
         exponent_val |= static_cast<uint32_t>(1) << 31;
         fq_ct base_constant(&builder, static_cast<uint256_t>(base_val));
-        fq_ct base_witness_ct = fq_ct::from_witness(&builder, static_cast<uint256_t>(base_val));
+        fq_ct base_witness_ct = fq_ct::from_witness(&builder, typename fq_ct::native(static_cast<uint256_t>(base_val)));
         // This also tests for the case where the exponent is zero
         for (size_t i = 0; i <= 32; i += 4) {
             uint32_t current_exponent_val = exponent_val >> i;
@@ -1126,7 +1126,7 @@ template <typename Builder> class stdlib_bigfield : public testing::Test {
 
         uint32_t current_exponent_val = 1;
         fq_ct base_constant_ct(&builder, static_cast<uint256_t>(base_val));
-        fq_ct base_witness_ct = fq_ct::from_witness(&builder, static_cast<uint256_t>(base_val));
+        fq_ct base_witness_ct = fq_ct::from_witness(&builder, typename fq_ct::native(static_cast<uint256_t>(base_val)));
         fq expected = base_val.pow(current_exponent_val);
 
         // Check for constant bigfield element with constant exponent
@@ -1170,7 +1170,7 @@ template <typename Builder> class stdlib_bigfield : public testing::Test {
         typedef stdlib::bool_t<Builder> bool_t;
         auto builder = Builder();
 
-        fq_ct w0 = fq_ct::from_witness(&builder, 1);
+        fq_ct w0 = fq_ct::from_witness(&builder, typename fq_ct::native(1));
         w0 = w0.conditional_negate(bool_t(&builder, true));
         w0 = w0.conditional_negate(bool_t(&builder, false));
         w0 = w0.conditional_negate(bool_t(&builder, true));

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/goblin_field.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/goblin_field.hpp
@@ -85,12 +85,16 @@ template <class Builder> class goblin_field {
         uint256_t converted(input);
         uint256_t lo_v = converted.slice(0, NUM_LIMB_BITS * 2);
         uint256_t hi_v = converted.slice(NUM_LIMB_BITS * 2, NUM_LIMB_BITS * 3 + NUM_LAST_LIMB_BITS);
-        field_ct lo = field_ct::from_witness(ctx, lo_v);
-        field_ct hi = field_ct::from_witness(ctx, hi_v);
+        field_ct lo = field_ct::from_witness(ctx, typename field_ct::native(lo_v));
+        field_ct hi = field_ct::from_witness(ctx, typename field_ct::native(hi_v));
         auto result = goblin_field(lo, hi);
         result.set_free_witness_tag();
         return result;
     }
+    // Disallow from_witness for non-bb::fq types to prevent implicit conversions (specifically, using indices rather
+    // than values)
+    template <typename OT> static goblin_field from_witness(Builder* ctx, const OT& input) = delete;
+    template <typename OT> static goblin_field from_witness(Builder* ctx, const OT input) = delete;
 
     /**
      * Create a witness from a constant. This way the value of the witness is fixed and public.

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/field/field.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/field/field.hpp
@@ -427,6 +427,9 @@ template <typename Builder_> class field_t {
         result.set_free_witness_tag();
         return result;
     }
+    // Disallow from_witness for non-bb::fr types to prevent implicit conversions (specifically, using indices rather
+    // than values)
+    template <typename T> static field_t from_witness(Builder* ctx, const T& input) = delete;
 
     static field_t reconstruct_from_public(const std::span<const field_t, PUBLIC_INPUTS_SIZE>& limbs)
     {

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/field/field.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/field/field.test.cpp
@@ -373,7 +373,7 @@ template <typename Builder> class stdlib_field : public testing::Test {
             Builder builder;
             size_t num_gates_start = builder.get_estimated_num_finalized_gates();
             field_ct a(&builder, 9);
-            field_ct b = field_ct::from_witness(&builder, 9);
+            field_ct b = field_ct::from_witness(&builder, typename field_ct::native(9));
             a.assert_equal(b);
             EXPECT_TRUE(CircuitChecker::check(builder));
             // 1 gate is needed to fix the constant
@@ -384,7 +384,7 @@ template <typename Builder> class stdlib_field : public testing::Test {
         {
             Builder builder;
             size_t num_gates_start = builder.get_estimated_num_finalized_gates();
-            field_ct a = field_ct::from_witness(&builder, 42);
+            field_ct a = field_ct::from_witness(&builder, typename field_ct::native(42));
             field_ct b(&builder, 42);
             a.assert_equal(b);
             EXPECT_TRUE(CircuitChecker::check(builder));
@@ -397,8 +397,8 @@ template <typename Builder> class stdlib_field : public testing::Test {
             Builder builder;
             size_t num_gates_start = builder.get_estimated_num_finalized_gates();
 
-            field_ct a = field_ct::from_witness(&builder, 11);
-            field_ct b = field_ct::from_witness(&builder, 11);
+            field_ct a = field_ct::from_witness(&builder, typename field_ct::native(11));
+            field_ct b = field_ct::from_witness(&builder, typename field_ct::native(11));
             a.assert_equal(b);
             EXPECT_TRUE(CircuitChecker::check(builder));
             // Both witnesses are normalized, no gates are created, only a copy constraint
@@ -409,9 +409,9 @@ template <typename Builder> class stdlib_field : public testing::Test {
         {
             Builder builder;
             size_t num_gates_start = builder.get_estimated_num_finalized_gates();
-            field_ct a = field_ct::from_witness(&builder, 10);
+            field_ct a = field_ct::from_witness(&builder, typename field_ct::native(10));
             a += 13;
-            field_ct b = field_ct::from_witness(&builder, 15);
+            field_ct b = field_ct::from_witness(&builder, typename field_ct::native(15));
             b += 1;
             a.assert_equal(b);
             EXPECT_FALSE(CircuitChecker::check(builder));

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/group/cycle_group.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/group/cycle_group.test.cpp
@@ -240,8 +240,8 @@ TYPED_TEST(CycleGroupTest, TestValidateOnCurveInfinitySucceed)
     STDLIB_TYPE_ALIASES;
     Builder builder;
 
-    auto x = stdlib::field_t<Builder>::from_witness(&builder, 1);
-    auto y = stdlib::field_t<Builder>::from_witness(&builder, 1);
+    auto x = stdlib::field_t<Builder>::from_witness(&builder, typename stdlib::field_t<Builder>::native(1));
+    auto y = stdlib::field_t<Builder>::from_witness(&builder, typename stdlib::field_t<Builder>::native(1));
 
     cycle_group_ct a(x, y, /*_is_infinity=*/true); // marks this point as the point at infinity
     a.validate_is_on_curve();
@@ -259,8 +259,8 @@ TYPED_TEST(CycleGroupTest, TestValidateOnCurveFail)
     STDLIB_TYPE_ALIASES;
     Builder builder;
 
-    auto x = stdlib::field_t<Builder>::from_witness(&builder, 1);
-    auto y = stdlib::field_t<Builder>::from_witness(&builder, 1);
+    auto x = stdlib::field_t<Builder>::from_witness(&builder, typename stdlib::field_t<Builder>::native(1));
+    auto y = stdlib::field_t<Builder>::from_witness(&builder, typename stdlib::field_t<Builder>::native(1));
 
     cycle_group_ct a(x, y, /*_is_infinity=*/false);
     a.validate_is_on_curve();
@@ -278,8 +278,8 @@ TYPED_TEST(CycleGroupTest, TestValidateOnCurveFail2)
     STDLIB_TYPE_ALIASES;
     Builder builder;
 
-    auto x = stdlib::field_t<Builder>::from_witness(&builder, 1);
-    auto y = stdlib::field_t<Builder>::from_witness(&builder, 1);
+    auto x = stdlib::field_t<Builder>::from_witness(&builder, typename stdlib::field_t<Builder>::native(1));
+    auto y = stdlib::field_t<Builder>::from_witness(&builder, typename stdlib::field_t<Builder>::native(1));
 
     cycle_group_ct a(x, y, /*_is_infinity=*/bool_ct(witness_ct(&builder, false)));
     a.validate_is_on_curve();
@@ -300,8 +300,8 @@ TYPED_TEST(CycleGroupTest, TestStandardForm)
     input_b.set_point_at_infinity(true);
     input_d.set_point_at_infinity(true);
 
-    auto x = stdlib::field_t<Builder>::from_witness(&builder, 1);
-    auto y = stdlib::field_t<Builder>::from_witness(&builder, 1);
+    auto x = stdlib::field_t<Builder>::from_witness(&builder, typename stdlib::field_t<Builder>::native(1));
+    auto y = stdlib::field_t<Builder>::from_witness(&builder, typename stdlib::field_t<Builder>::native(1));
     cycle_group_ct input_e = cycle_group_ct(x, y, true);
     cycle_group_ct input_f = cycle_group_ct(x, y, bool_ct(witness_ct(&builder, true)));
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/group/cycle_scalar.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/group/cycle_scalar.cpp
@@ -182,8 +182,8 @@ template <typename Builder> cycle_scalar<Builder>::cycle_scalar(BigScalarField& 
             const uint256_t limb = limb0.get_value();
             const uint256_t lo_v = limb.slice(0, BigScalarField::NUM_LIMB_BITS);
             const uint256_t hi_v = limb >> BigScalarField::NUM_LIMB_BITS;
-            field_t lo = field_t::from_witness(ctx, lo_v);
-            field_t hi = field_t::from_witness(ctx, hi_v);
+            field_t lo = field_t::from_witness(ctx, typename field_t::native(lo_v));
+            field_t hi = field_t::from_witness(ctx, typename field_t::native(hi_v));
 
             uint256_t hi_max = (scalar.binary_basis_limbs[0].maximum_value >> BigScalarField::NUM_LIMB_BITS);
             const uint64_t hi_bits = hi_max.get_msb() + 1;
@@ -215,8 +215,8 @@ template <typename Builder> cycle_scalar<Builder>::cycle_scalar(BigScalarField& 
         const uint256_t limb_1_lo_v = limb_1 - (limb_1_hi_v << lo_bits_in_limb_1);
 
         // Step 3: instantiate both slices as witnesses and validate their sum equals limb1
-        field_t limb_1_lo = field_t::from_witness(ctx, limb_1_lo_v);
-        field_t limb_1_hi = field_t::from_witness(ctx, limb_1_hi_v);
+        field_t limb_1_lo = field_t::from_witness(ctx, typename field_t::native(limb_1_lo_v));
+        field_t limb_1_hi = field_t::from_witness(ctx, typename field_t::native(limb_1_hi_v));
 
         // We need to propagate the origin tag to the chunks of limb1
         limb_1_lo.set_origin_tag(limb1.get_origin_tag());
@@ -277,7 +277,8 @@ template <typename Builder> void cycle_scalar<Builder>::validate_scalar_is_in_fi
         const uint256_t r_hi = cycle_group_modulus.slice(LO_BITS, HI_BITS);
 
         bool need_borrow = uint256_t(lo.get_value()) > r_lo;
-        field_t borrow = lo.is_constant() ? need_borrow : field_t::from_witness(get_context(), need_borrow);
+        field_t borrow = lo.is_constant() ? need_borrow
+                                          : field_t::from_witness(get_context(), typename field_t::native(need_borrow));
 
         // directly call `create_new_range_constraint` to avoid creating an arithmetic gate
         if (!lo.is_constant()) {

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/dynamic_array.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/dynamic_array.test.cpp
@@ -85,7 +85,7 @@ TEST(DynamicArray, DynamicArrayReadWriteConsistency)
     DynamicArray_ct array(&builder, max_size);
 
     for (size_t i = 0; i < max_size; ++i) {
-        array.push(field_ct::from_witness(&builder, i));
+        array.push(field_ct::from_witness(&builder, typename field_ct::native(i)));
         EXPECT_EQ(array.read(i).get_value(), i);
     }
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/padding_indicator_array/padding_indicator_array.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/padding_indicator_array/padding_indicator_array.test.cpp
@@ -28,7 +28,7 @@ template <typename Param> class PaddingIndicatorArrayTest : public testing::Test
     {
         for (size_t idx = 1; idx <= domain_size; idx++) {
             Builder builder;
-            Fr x = Fr::from_witness(&builder, idx);
+            Fr x = Fr::from_witness(&builder, typename Fr::native(idx));
 
             auto result = compute_padding_indicator_array<Curve, domain_size>(x);
             EXPECT_TRUE(result[idx - 1].get_value() == 1);
@@ -50,7 +50,7 @@ template <typename Param> class PaddingIndicatorArrayTest : public testing::Test
         {
             Builder builder;
 
-            Fr zero = Fr::from_witness(&builder, 0);
+            Fr zero = Fr::from_witness(&builder, typename Fr::native(0));
 
             compute_padding_indicator_array<Curve, domain_size>(zero);
             info("num gates = ", builder.get_estimated_num_finalized_gates());
@@ -62,7 +62,7 @@ template <typename Param> class PaddingIndicatorArrayTest : public testing::Test
         {
             Builder builder;
 
-            Fr N = Fr::from_witness(&builder, domain_size);
+            Fr N = Fr::from_witness(&builder, typename Fr::native(domain_size));
 
             compute_padding_indicator_array<Curve, domain_size>(N);
             info("num gates = ", builder.get_estimated_num_finalized_gates());
@@ -77,7 +77,7 @@ template <typename Param> class PaddingIndicatorArrayTest : public testing::Test
             Builder builder;
             uint256_t scalar_raw = engine.get_random_uint256();
 
-            Fr x = Fr::from_witness(&builder, scalar_raw);
+            Fr x = Fr::from_witness(&builder, typename Fr::native(scalar_raw));
 
             compute_padding_indicator_array<Curve, domain_size>(x);
             info("num gates = ", builder.get_estimated_num_finalized_gates());
@@ -90,7 +90,7 @@ template <typename Param> class PaddingIndicatorArrayTest : public testing::Test
     {
         auto get_gate_count = [](const uint32_t& scalar_raw) -> size_t {
             Builder builder;
-            Fr x = Fr::from_witness(&builder, scalar_raw);
+            Fr x = Fr::from_witness(&builder, typename Fr::native(scalar_raw));
             auto result = compute_padding_indicator_array<Curve, domain_size>(x);
 
             return builder.get_estimated_num_finalized_gates();

--- a/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/protogalaxy_recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/protogalaxy_recursive_verifier.cpp
@@ -177,7 +177,7 @@ std::shared_ptr<typename DeciderVerificationKeys::DeciderVK> ProtogalaxyRecursiv
     accumulator->gate_challenges = update_gate_challenges(perturbator_challenge, accumulator->gate_challenges, deltas);
 
     // Define a constant virtual log circuit size for the accumulator
-    FF virtual_log_n = FF::from_witness(builder, CONST_PG_LOG_N);
+    FF virtual_log_n = FF::from_witness(builder, typename FF::native(CONST_PG_LOG_N));
     virtual_log_n.fix_witness();
     accumulator->vk_and_hash->vk->log_circuit_size = virtual_log_n;
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/special_public_inputs/special_public_inputs.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/special_public_inputs/special_public_inputs.hpp
@@ -130,7 +130,7 @@ class KernelIO {
             table_commitment.convert_constant_to_fixed_witness(&builder);
             table_commitment.set_public();
         }
-        FF output_pg_accum_hash = FF::from_witness(&builder, 0);
+        FF output_pg_accum_hash = FF::from_witness(&builder, FF::native(0));
         output_pg_accum_hash.set_public();
     }
 };

--- a/barretenberg/cpp/src/barretenberg/stdlib/translator_vm_verifier/translator_recursive_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/translator_vm_verifier/translator_recursive_flavor.hpp
@@ -112,8 +112,8 @@ class TranslatorRecursiveFlavor {
             // and the verification key.
             this->log_circuit_size = FF{ uint64_t(TranslatorFlavor::CONST_TRANSLATOR_LOG_N) };
             this->log_circuit_size.convert_constant_to_fixed_witness(builder);
-            this->num_public_inputs = FF::from_witness(builder, native_key->num_public_inputs);
-            this->pub_inputs_offset = FF::from_witness(builder, native_key->pub_inputs_offset);
+            this->num_public_inputs = FF::from_witness(builder, typename FF::native(native_key->num_public_inputs));
+            this->pub_inputs_offset = FF::from_witness(builder, typename FF::native(native_key->pub_inputs_offset));
 
             for (auto [native_comm, comm] : zip_view(native_key->get_all(), this->get_all())) {
                 comm = Commitment::from_witness(builder, native_comm);

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/circuit_builder_base.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/circuit_builder_base.hpp
@@ -181,6 +181,9 @@ template <typename FF_> class CircuitBuilderBase {
      * @return The index of the new variable in the variables vector
      */
     virtual uint32_t add_variable(const FF& in);
+    // Disallow add_variable for non-FF types to prevent implicit conversions (specifically, using indices rather
+    // than values)
+    template <typename OT> uint32_t add_variable(const OT& in) = delete;
 
     /**
      * Assign a name to a variable(equivalence class). Should be one name per equivalence class.
@@ -218,6 +221,9 @@ template <typename FF_> class CircuitBuilderBase {
      */
     virtual uint32_t add_public_variable(const FF& in);
 
+    // Disallow add_public_variable for non-FF types to prevent implicit conversions (specifically, using indices rather
+    // than values)
+    template <typename OT> uint32_t add_public_variable(const OT& in) = delete;
     /**
      * @brief Make a witness variable public.
      *

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/mega_circuit_builder.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/mega_circuit_builder.cpp
@@ -46,19 +46,19 @@ template <typename FF> void MegaCircuitBuilder_<FF>::add_mega_gates_to_ensure_al
     // Create an arbitrary calldata read gate
     add_public_calldata(this->add_variable(BusVector::DEFAULT_VALUE));    // add one entry in calldata
     auto raw_read_idx = static_cast<uint32_t>(get_calldata().size()) - 1; // read data that was just added
-    auto read_idx = this->add_variable(raw_read_idx);
+    auto read_idx = this->add_variable(bb::fr(raw_read_idx));
     read_calldata(read_idx);
 
     // Create an arbitrary secondary_calldata read gate
     add_public_secondary_calldata(this->add_variable(BusVector::DEFAULT_VALUE)); // add one entry in secondary_calldata
     raw_read_idx = static_cast<uint32_t>(get_secondary_calldata().size()) - 1;   // read data that was just added
-    read_idx = this->add_variable(raw_read_idx);
+    read_idx = this->add_variable(bb::fr(raw_read_idx));
     read_secondary_calldata(read_idx);
 
     // Create an arbitrary return data read gate
     add_public_return_data(this->add_variable(BusVector::DEFAULT_VALUE)); // add one entry in return data
     raw_read_idx = static_cast<uint32_t>(get_return_data().size()) - 1;   // read data that was just added
-    read_idx = this->add_variable(raw_read_idx);
+    read_idx = this->add_variable(bb::fr(raw_read_idx));
     read_return_data(read_idx);
 
     if (op_queue->get_current_subtable_size() == 0) {

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/mock_circuits.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/mock_circuits.hpp
@@ -102,9 +102,9 @@ class MockCircuits {
      */
     template <typename Builder> static void add_RAM_gates(Builder& builder)
     {
-        std::array<uint32_t, 3> ram_values{ builder.add_variable(5),
-                                            builder.add_variable(10),
-                                            builder.add_variable(20) };
+        std::array<uint32_t, 3> ram_values{ builder.add_variable(bb::fr(5)),
+                                            builder.add_variable(bb::fr(10)),
+                                            builder.add_variable(bb::fr(20)) };
 
         size_t ram_id = builder.create_RAM_array(3);
 
@@ -112,9 +112,9 @@ class MockCircuits {
             builder.init_RAM_element(ram_id, i, ram_values[i]);
         }
 
-        auto val_idx_1 = builder.read_RAM_array(ram_id, builder.add_variable(1));
-        auto val_idx_2 = builder.read_RAM_array(ram_id, builder.add_variable(2));
-        auto val_idx_3 = builder.read_RAM_array(ram_id, builder.add_variable(0));
+        auto val_idx_1 = builder.read_RAM_array(ram_id, builder.add_variable(bb::fr(1)));
+        auto val_idx_2 = builder.read_RAM_array(ram_id, builder.add_variable(bb::fr(2)));
+        auto val_idx_3 = builder.read_RAM_array(ram_id, builder.add_variable(bb::fr(0)));
 
         builder.create_big_add_gate({
             val_idx_1,

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/rom_ram_logic.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/rom_ram_logic.cpp
@@ -137,7 +137,7 @@ template <typename ExecutionTrace>
 void RomRamLogic_<ExecutionTrace>::create_ROM_gate(CircuitBuilder* builder, RomRecord& record)
 {
     // Record wire value can't yet be computed
-    record.record_witness = builder->add_variable(0);
+    record.record_witness = builder->add_variable(bb::fr(0));
     builder->apply_memory_selectors(CircuitBuilder::MEMORY_SELECTORS::ROM_READ);
     builder->blocks.memory.populate_wires(
         record.index_witness, record.value_column1_witness, record.value_column2_witness, record.record_witness);
@@ -150,7 +150,7 @@ void RomRamLogic_<ExecutionTrace>::create_ROM_gate(CircuitBuilder* builder, RomR
 template <typename ExecutionTrace>
 void RomRamLogic_<ExecutionTrace>::create_sorted_ROM_gate(CircuitBuilder* builder, RomRecord& record)
 {
-    record.record_witness = builder->add_variable(0);
+    record.record_witness = builder->add_variable(bb::fr(0));
     // record_witness is intentionally used only in a single gate
     builder->update_used_witnesses(record.record_witness);
     builder->apply_memory_selectors(CircuitBuilder::MEMORY_SELECTORS::ROM_CONSISTENCY_CHECK);
@@ -360,7 +360,7 @@ void RomRamLogic_<ExecutionTrace>::create_RAM_gate(CircuitBuilder* builder, RamR
     // However it needs a distinct witness index,
     // we will be applying copy constraints + set membership constraints.
     // Later on during proof construction we will compute the record wire value + assign it
-    record.record_witness = builder->add_variable(0);
+    record.record_witness = builder->add_variable(bb::fr(0));
     builder->apply_memory_selectors(record.access_type == RamRecord::AccessType::READ
                                         ? CircuitBuilder::MEMORY_SELECTORS::RAM_READ
                                         : CircuitBuilder::MEMORY_SELECTORS::RAM_WRITE);
@@ -375,7 +375,7 @@ void RomRamLogic_<ExecutionTrace>::create_RAM_gate(CircuitBuilder* builder, RamR
 template <typename ExecutionTrace>
 void RomRamLogic_<ExecutionTrace>::create_sorted_RAM_gate(CircuitBuilder* builder, RamRecord& record)
 {
-    record.record_witness = builder->add_variable(0);
+    record.record_witness = builder->add_variable(bb::fr(0));
     builder->apply_memory_selectors(CircuitBuilder::MEMORY_SELECTORS::RAM_CONSISTENCY_CHECK);
     builder->blocks.memory.populate_wires(
         record.index_witness, record.timestamp_witness, record.value_witness, record.record_witness);
@@ -390,7 +390,7 @@ void RomRamLogic_<ExecutionTrace>::create_final_sorted_RAM_gate(CircuitBuilder* 
                                                                 RamRecord& record,
                                                                 const size_t ram_array_size)
 {
-    record.record_witness = builder->add_variable(0);
+    record.record_witness = builder->add_variable(bb::fr(0));
     // Note: record the index into the block that contains the RAM/ROM gates
     record.gate_index = builder->blocks.memory.size(); // no -1 since we havent added the gate yet
 
@@ -456,7 +456,7 @@ void RomRamLogic_<ExecutionTrace>::process_RAM_array(CircuitBuilder* builder, co
         const auto index = record.index;
         const auto value = builder->get_variable(record.value_witness);
         const auto index_witness = builder->add_variable(FF((uint64_t)index));
-        const auto timestamp_witess = builder->add_variable(record.timestamp);
+        const auto timestamp_witess = builder->add_variable(bb::fr(record.timestamp));
         const auto value_witness = builder->add_variable(value);
         RamRecord sorted_record{
             .index_witness = index_witness,

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.cpp
@@ -410,8 +410,8 @@ void UltraCircuitBuilder_<ExecutionTrace>::create_big_add_gate_with_bit_extracti
     const uint256_t quad = this->get_variable(in.c) - this->get_variable(in.d) * 4;
     const auto lo_bit = quad & uint256_t(1);
     const auto hi_bit = (quad & uint256_t(2)) >> 1;
-    const auto lo_idx = this->add_variable(lo_bit);
-    const auto hi_idx = this->add_variable(hi_bit);
+    const auto lo_idx = this->add_variable(bb::fr(lo_bit));
+    const auto hi_idx = this->add_variable(bb::fr(hi_bit));
     // lo + hi * 2 - c + 4 * d = 0
     create_big_add_gate({
         lo_idx,
@@ -883,12 +883,12 @@ typename UltraCircuitBuilder_<ExecutionTrace>::RangeList UltraCircuitBuilder_<Ex
 
     result.variable_indices.reserve((uint32_t)num_multiples_of_three);
     for (uint64_t i = 0; i <= num_multiples_of_three; ++i) {
-        const uint32_t index = this->add_variable(i * DEFAULT_PLOOKUP_RANGE_STEP_SIZE);
+        const uint32_t index = this->add_variable(bb::fr(i * DEFAULT_PLOOKUP_RANGE_STEP_SIZE));
         result.variable_indices.emplace_back(index);
         assign_tag(index, result.range_tag);
     }
     {
-        const uint32_t index = this->add_variable(target_range);
+        const uint32_t index = this->add_variable(bb::fr(target_range));
         result.variable_indices.emplace_back(index);
         assign_tag(index, result.range_tag);
     }
@@ -944,7 +944,7 @@ std::vector<uint32_t> UltraCircuitBuilder_<ExecutionTrace>::decompose_into_defau
         accumulator = accumulator >> target_range_bitnum;
     }
     for (size_t i = 0; i < sublimbs.size(); ++i) {
-        const auto limb_idx = this->add_variable(sublimbs[i]);
+        const auto limb_idx = this->add_variable(bb::fr(sublimbs[i]));
         sublimb_indices.emplace_back(limb_idx);
         if ((i == sublimbs.size() - 1) && has_remainder_bits) {
             create_new_range_constraint(limb_idx, last_limb_range);
@@ -1000,7 +1000,7 @@ std::vector<uint32_t> UltraCircuitBuilder_<ExecutionTrace>::decompose_into_defau
             ((i == num_limb_triples - 1) ? false : true));
         // TODO(https://github.com/AztecProtocol/barretenberg/issues/1450): this is probably creating an unused
         // wire/variable in the circuit, in the last iteration of the loop.
-        accumulator_idx = this->add_variable(new_accumulator);
+        accumulator_idx = this->add_variable(bb::fr(new_accumulator));
         accumulator = new_accumulator;
     }
     return sublimb_indices;
@@ -1116,7 +1116,7 @@ template <typename ExecutionTrace> void UltraCircuitBuilder_<ExecutionTrace>::pr
         indices.emplace_back(this->zero_idx);
     }
     for (const auto sorted_value : sorted_list) {
-        const uint32_t index = this->add_variable(sorted_value);
+        const uint32_t index = this->add_variable(bb::fr(sorted_value));
         assign_tag(index, list.tau_tag);
         indices.emplace_back(index);
     }
@@ -1641,15 +1641,16 @@ void UltraCircuitBuilder_<ExecutionTrace>::range_constrain_two_limbs(const uint3
         // We also use zero_idx to substitute variables that should be zero
         constexpr uint256_t MAX_SUBLIMB_MASK = (uint256_t(1) << 14) - 1;
         std::array<uint32_t, 5> sublimb_indices;
-        sublimb_indices[0] = sublimb_masks[0] != 0 ? this->add_variable(limb & MAX_SUBLIMB_MASK) : this->zero_idx;
+        sublimb_indices[0] =
+            sublimb_masks[0] != 0 ? this->add_variable(bb::fr(limb & MAX_SUBLIMB_MASK)) : this->zero_idx;
         sublimb_indices[1] =
-            sublimb_masks[1] != 0 ? this->add_variable((limb >> 14) & MAX_SUBLIMB_MASK) : this->zero_idx;
+            sublimb_masks[1] != 0 ? this->add_variable(bb::fr((limb >> 14) & MAX_SUBLIMB_MASK)) : this->zero_idx;
         sublimb_indices[2] =
-            sublimb_masks[2] != 0 ? this->add_variable((limb >> 28) & MAX_SUBLIMB_MASK) : this->zero_idx;
+            sublimb_masks[2] != 0 ? this->add_variable(bb::fr((limb >> 28) & MAX_SUBLIMB_MASK)) : this->zero_idx;
         sublimb_indices[3] =
-            sublimb_masks[3] != 0 ? this->add_variable((limb >> 42) & MAX_SUBLIMB_MASK) : this->zero_idx;
+            sublimb_masks[3] != 0 ? this->add_variable(bb::fr((limb >> 42) & MAX_SUBLIMB_MASK)) : this->zero_idx;
         sublimb_indices[4] =
-            sublimb_masks[4] != 0 ? this->add_variable((limb >> 56) & MAX_SUBLIMB_MASK) : this->zero_idx;
+            sublimb_masks[4] != 0 ? this->add_variable(bb::fr((limb >> 56) & MAX_SUBLIMB_MASK)) : this->zero_idx;
         return sublimb_indices;
     };
 
@@ -1712,8 +1713,8 @@ std::array<uint32_t, 2> UltraCircuitBuilder_<ExecutionTrace>::decompose_non_nati
     const uint256_t hi = value >> DEFAULT_NON_NATIVE_FIELD_LIMB_BITS;
     BB_ASSERT_EQ(low + (hi << DEFAULT_NON_NATIVE_FIELD_LIMB_BITS), value);
 
-    const uint32_t low_idx = this->add_variable(low);
-    const uint32_t hi_idx = this->add_variable(hi);
+    const uint32_t low_idx = this->add_variable(bb::fr(low));
+    const uint32_t hi_idx = this->add_variable(bb::fr(hi));
 
     BB_ASSERT_GT(num_limb_bits, DEFAULT_NON_NATIVE_FIELD_LIMB_BITS);
     const size_t lo_bits = DEFAULT_NON_NATIVE_FIELD_LIMB_BITS;

--- a/barretenberg/cpp/src/barretenberg/translator_vm/translator_circuit_builder.cpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/translator_circuit_builder.cpp
@@ -403,7 +403,7 @@ void TranslatorCircuitBuilder::assert_well_formed_accumulation_input(const Accum
 void TranslatorCircuitBuilder::populate_wires_from_ultra_op(const UltraOp& ultra_op)
 {
     auto& op_wire = std::get<WireIds::OP>(wires);
-    op_wire.push_back(add_variable(ultra_op.op_code.value()));
+    op_wire.push_back(add_variable(bb::fr(ultra_op.op_code.value())));
     // Similarly to the ColumnPolynomials in the merge protocol, the op_wire is 0 at every second index
     op_wire.push_back(zero_idx);
 

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/databus.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/databus.test.cpp
@@ -78,7 +78,7 @@ template <typename Flavor> class DataBusTests : public ::testing::Test {
         // Read from the bus at some random indices
         for (size_t i = 0; i < NUM_READS; ++i) {
             uint32_t read_idx = engine.get_random_uint32() % NUM_BUS_ENTRIES;
-            uint32_t read_idx_witness_idx = builder.add_variable(read_idx);
+            uint32_t read_idx_witness_idx = builder.add_variable(FF(read_idx));
             read_bus_data(builder, read_idx_witness_idx);
         }
 
@@ -194,7 +194,7 @@ TYPED_TEST(DataBusTests, CallDataDuplicateRead)
     std::vector<uint32_t> result_witness_indices;
     for (uint32_t& read_idx : read_indices) {
         // Create a variable corresponding to the index at which we want to read into calldata
-        uint32_t read_idx_witness_idx = builder.add_variable(read_idx);
+        uint32_t read_idx_witness_idx = builder.add_variable(FF(read_idx));
 
         auto value_witness_idx = builder.read_calldata(read_idx_witness_idx);
         result_witness_indices.emplace_back(value_witness_idx);

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/relation_correctness.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/relation_correctness.test.cpp
@@ -65,8 +65,8 @@ template <typename Flavor> void create_some_lookup_gates(auto& circuit_builder)
             .slice(plookup::fixed_base::table::BITS_PER_LO_SCALAR,
                    plookup::fixed_base::table::BITS_PER_LO_SCALAR + plookup::fixed_base::table::BITS_PER_HI_SCALAR);
     const auto input_lo = uint256_t(pedersen_input_value).slice(0, bb::plookup::fixed_base::table::BITS_PER_LO_SCALAR);
-    const auto input_hi_index = circuit_builder.add_variable(input_hi);
-    const auto input_lo_index = circuit_builder.add_variable(input_lo);
+    const auto input_hi_index = circuit_builder.add_variable(FF(input_hi));
+    const auto input_lo_index = circuit_builder.add_variable(FF(input_lo));
 
     const auto sequence_data_hi =
         plookup::get_lookup_accumulators(bb::plookup::MultiTableId::FIXED_BASE_LEFT_HI, input_hi);
@@ -107,14 +107,14 @@ template <typename Flavor> void create_some_RAM_gates(auto& circuit_builder)
         circuit_builder.init_RAM_element(ram_id, i, ram_values[i]);
     }
 
-    auto a_idx = circuit_builder.read_RAM_array(ram_id, circuit_builder.add_variable(5));
+    auto a_idx = circuit_builder.read_RAM_array(ram_id, circuit_builder.add_variable(FF(5)));
     EXPECT_EQ(a_idx != ram_values[5], true);
 
-    auto b_idx = circuit_builder.read_RAM_array(ram_id, circuit_builder.add_variable(4));
-    auto c_idx = circuit_builder.read_RAM_array(ram_id, circuit_builder.add_variable(1));
+    auto b_idx = circuit_builder.read_RAM_array(ram_id, circuit_builder.add_variable(FF(4)));
+    auto c_idx = circuit_builder.read_RAM_array(ram_id, circuit_builder.add_variable(FF(1)));
 
-    circuit_builder.write_RAM_array(ram_id, circuit_builder.add_variable(4), circuit_builder.add_variable(500));
-    auto d_idx = circuit_builder.read_RAM_array(ram_id, circuit_builder.add_variable(4));
+    circuit_builder.write_RAM_array(ram_id, circuit_builder.add_variable(FF(4)), circuit_builder.add_variable(FF(500)));
+    auto d_idx = circuit_builder.read_RAM_array(ram_id, circuit_builder.add_variable(FF(4)));
 
     EXPECT_EQ(circuit_builder.get_variable(d_idx), 500);
 

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/sumcheck.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/sumcheck.test.cpp
@@ -115,14 +115,14 @@ TEST_F(SumcheckTestsRealCircuit, Ultra)
         builder.init_RAM_element(ram_id, i, ram_values[i]);
     }
 
-    a_idx = builder.read_RAM_array(ram_id, builder.add_variable(5));
+    a_idx = builder.read_RAM_array(ram_id, builder.add_variable(bb::fr(5)));
     EXPECT_EQ(a_idx != ram_values[5], true);
 
-    b_idx = builder.read_RAM_array(ram_id, builder.add_variable(4));
-    c_idx = builder.read_RAM_array(ram_id, builder.add_variable(1));
+    b_idx = builder.read_RAM_array(ram_id, builder.add_variable(bb::fr(4)));
+    c_idx = builder.read_RAM_array(ram_id, builder.add_variable(bb::fr(1)));
 
-    builder.write_RAM_array(ram_id, builder.add_variable(4), builder.add_variable(500));
-    d_idx = builder.read_RAM_array(ram_id, builder.add_variable(4));
+    builder.write_RAM_array(ram_id, builder.add_variable(bb::fr(4)), builder.add_variable(bb::fr(500)));
+    d_idx = builder.read_RAM_array(ram_id, builder.add_variable(bb::fr(4)));
 
     EXPECT_EQ(builder.get_variable(d_idx), 500);
 

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_honk.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_honk.test.cpp
@@ -900,10 +900,10 @@ TYPED_TEST(UltraHonkTests, Rom)
         circuit_builder.set_ROM_element(rom_id, i, rom_values[i]);
     }
 
-    uint32_t a_idx = circuit_builder.read_ROM_array(rom_id, circuit_builder.add_variable(5));
+    uint32_t a_idx = circuit_builder.read_ROM_array(rom_id, circuit_builder.add_variable(bb::fr(5)));
     EXPECT_EQ(a_idx != rom_values[5], true);
-    uint32_t b_idx = circuit_builder.read_ROM_array(rom_id, circuit_builder.add_variable(4));
-    uint32_t c_idx = circuit_builder.read_ROM_array(rom_id, circuit_builder.add_variable(1));
+    uint32_t b_idx = circuit_builder.read_ROM_array(rom_id, circuit_builder.add_variable(bb::fr(4)));
+    uint32_t c_idx = circuit_builder.read_ROM_array(rom_id, circuit_builder.add_variable(bb::fr(1)));
 
     const auto d_value =
         circuit_builder.get_variable(a_idx) + circuit_builder.get_variable(b_idx) + circuit_builder.get_variable(c_idx);
@@ -942,14 +942,15 @@ TYPED_TEST(UltraHonkTests, Ram)
         circuit_builder.init_RAM_element(ram_id, i, ram_values[i]);
     }
 
-    uint32_t a_idx = circuit_builder.read_RAM_array(ram_id, circuit_builder.add_variable(5));
+    uint32_t a_idx = circuit_builder.read_RAM_array(ram_id, circuit_builder.add_variable(bb::fr(5)));
     EXPECT_EQ(a_idx != ram_values[5], true);
 
-    uint32_t b_idx = circuit_builder.read_RAM_array(ram_id, circuit_builder.add_variable(4));
-    uint32_t c_idx = circuit_builder.read_RAM_array(ram_id, circuit_builder.add_variable(1));
+    uint32_t b_idx = circuit_builder.read_RAM_array(ram_id, circuit_builder.add_variable(bb::fr(4)));
+    uint32_t c_idx = circuit_builder.read_RAM_array(ram_id, circuit_builder.add_variable(bb::fr(1)));
 
-    circuit_builder.write_RAM_array(ram_id, circuit_builder.add_variable(4), circuit_builder.add_variable(500));
-    uint32_t d_idx = circuit_builder.read_RAM_array(ram_id, circuit_builder.add_variable(4));
+    circuit_builder.write_RAM_array(
+        ram_id, circuit_builder.add_variable(bb::fr(4)), circuit_builder.add_variable(bb::fr(500)));
+    uint32_t d_idx = circuit_builder.read_RAM_array(ram_id, circuit_builder.add_variable(bb::fr(4)));
 
     EXPECT_EQ(circuit_builder.get_variable(d_idx), 500);
 
@@ -994,10 +995,10 @@ TYPED_TEST(UltraHonkTests, RangeChecksOnDuplicates)
 {
     auto circuit_builder = UltraCircuitBuilder();
 
-    uint32_t a = circuit_builder.add_variable(100);
-    uint32_t b = circuit_builder.add_variable(100);
-    uint32_t c = circuit_builder.add_variable(100);
-    uint32_t d = circuit_builder.add_variable(100);
+    uint32_t a = circuit_builder.add_variable(bb::fr(100));
+    uint32_t b = circuit_builder.add_variable(bb::fr(100));
+    uint32_t c = circuit_builder.add_variable(bb::fr(100));
+    uint32_t d = circuit_builder.add_variable(bb::fr(100));
 
     circuit_builder.assert_equal(a, b);
     circuit_builder.assert_equal(a, c);
@@ -1037,10 +1038,10 @@ TYPED_TEST(UltraHonkTests, RangeConstraintSmallVariable)
 
     uint16_t mask = (1 << 8) - 1;
     int a = engine.get_random_uint16() & mask;
-    uint32_t a_idx = circuit_builder.add_variable(fr(a));
-    uint32_t b_idx = circuit_builder.add_variable(fr(a));
+    uint32_t a_idx = circuit_builder.add_variable(bb::fr(a));
+    uint32_t b_idx = circuit_builder.add_variable(bb::fr(a));
     ASSERT_NE(a_idx, b_idx);
-    uint32_t c_idx = circuit_builder.add_variable(fr(a));
+    uint32_t c_idx = circuit_builder.add_variable(bb::fr(a));
     ASSERT_NE(c_idx, b_idx);
     circuit_builder.create_range_constraint(b_idx, 8, "bad range");
     circuit_builder.assert_equal(a_idx, b_idx);

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/recursion/goblin_avm_recursive_verifier.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/recursion/goblin_avm_recursive_verifier.hpp
@@ -72,7 +72,7 @@ class AvmGoblinRecursiveVerifier {
         , outer_key_fields(outer_key_fields)
     {
         // TODO(#15892): Set this to be the actual vk hash when vk is fixed.
-        vk_hash = UltraFF::from_witness(&builder, /* should be native hash of vk fields*/ 0);
+        vk_hash = UltraFF::from_witness(&builder, /* should be native hash of vk fields*/ typename UltraFF::native(0));
         vk_hash.fix_witness();
     }
 


### PR DESCRIPTION
There were cases of misuse of from_witness and add_variable (for example, `add_variable(zero_idx)`, `from_witness(zero_idx)` instead of `from_witness_index(zero_idx)`. This should automatically block it at compile time, so the developer has to be very stubborn about shooting themselves in the foot