### PR TITLE
chore: do not clang format generated protocol_contract_data.cpp

### DIFF
--- a/barretenberg/cpp/.clang-format-ignore
+++ b/barretenberg/cpp/.clang-format-ignore
@@ -1,0 +1,1 @@
+src/barretenberg/vm2/common/protocol_contract_data.cpp

--- a/barretenberg/cpp/src/barretenberg/vm2/common/protocol_contract_data.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/common/protocol_contract_data.cpp
@@ -4,16 +4,12 @@
 namespace bb::avm2 {
 
 const std::unordered_map<CanonicalAddress, DerivedAddress> derived_addresses = {
-    { CANONICAL_AUTH_REGISTRY_ADDRESS,
-      AztecAddress("0x288ca72d9121175bf02bf3d1db95420b3a3b71ecab2df6836e82bb7eab016b03") },
-    { CONTRACT_INSTANCE_REGISTRY_CONTRACT_ADDRESS,
-      AztecAddress("0x15b43fb84cb3f1cfddbb1ce47383e8fabf1ebbff402f8cd3ace2a703bde0f42c") },
-    { CONTRACT_CLASS_REGISTRY_CONTRACT_ADDRESS,
-      AztecAddress("0x2bf5f175f63f44f4b861c46ce6c186928c9cebba7fd3a5ba3bc19ca43fca28cb") },
-    { MULTI_CALL_ENTRYPOINT_ADDRESS,
-      AztecAddress("0x1b0f47860b942aa342a69c59d0e2626dd191760fdac6c89fc1ecad74baaad798") },
-    { FEE_JUICE_ADDRESS, AztecAddress("0x17ed1ecf287e9cbcd4b3b591a3c873d08aa90de0888e369e31dd5b37e3046e20") },
-    { ROUTER_ADDRESS, AztecAddress("0x2c0c3298030d7fcf0ec09cf0066437bfb09eba45d130c88bb87a5ab011caac2e") }
+    { CANONICAL_AUTH_REGISTRY_ADDRESS, AztecAddress("0x288ca72d9121175bf02bf3d1db95420b3a3b71ecab2df6836e82bb7eab016b03") },
+	{ CONTRACT_INSTANCE_REGISTRY_CONTRACT_ADDRESS, AztecAddress("0x15b43fb84cb3f1cfddbb1ce47383e8fabf1ebbff402f8cd3ace2a703bde0f42c") },
+	{ CONTRACT_CLASS_REGISTRY_CONTRACT_ADDRESS, AztecAddress("0x2bf5f175f63f44f4b861c46ce6c186928c9cebba7fd3a5ba3bc19ca43fca28cb") },
+	{ MULTI_CALL_ENTRYPOINT_ADDRESS, AztecAddress("0x1b0f47860b942aa342a69c59d0e2626dd191760fdac6c89fc1ecad74baaad798") },
+	{ FEE_JUICE_ADDRESS, AztecAddress("0x17ed1ecf287e9cbcd4b3b591a3c873d08aa90de0888e369e31dd5b37e3046e20") },
+	{ ROUTER_ADDRESS, AztecAddress("0x2c0c3298030d7fcf0ec09cf0066437bfb09eba45d130c88bb87a5ab011caac2e") }
 };
 
 } // namespace bb::avm2


### PR DESCRIPTION
This tells clang format to skip this file. Otherwise we need to tell the `yarn generate` in protocol-contracts to run clang format which may get ugly.