### PR TITLE
feat: Update watchers and block builder configs

### DIFF
--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -1125,7 +1125,6 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, Traceable {
     this.sequencer?.updateConfig(config);
     this.slasherClient?.updateConfig(config);
     this.validatorsSentinel?.updateConfig(config);
-    // this.blockBuilder.updateConfig(config); // TODO: Spyros has a PR to add the builder to `this`, so we can do this
     await this.p2pClient.updateP2PConfig(config);
 
     if (newConfig.realProofs !== this.config.realProofs) {

--- a/yarn-project/foundation/src/collection/object.test.ts
+++ b/yarn-project/foundation/src/collection/object.test.ts
@@ -1,4 +1,4 @@
-import { compact, mapValues } from './object.js';
+import { compact, mapValues, merge } from './object.js';
 
 describe('mapValues', () => {
   it('should return a new object with mapped values', () => {
@@ -58,5 +58,84 @@ describe('compact', () => {
     const obj = { a: 1, b: 2, c: 3 };
     const result = compact(obj);
     expect(result).toEqual({ a: 1, b: 2, c: 3 });
+  });
+});
+
+describe('merge', () => {
+  it('should merge two objects with no conflicts', () => {
+    const obj1 = { a: 1, b: 2 };
+    const obj2 = { c: 3, d: 4 };
+    const result = merge(obj1, obj2);
+    expect(result).toEqual({ a: 1, b: 2, c: 3, d: 4 });
+  });
+
+  it('should override properties from first object with second object', () => {
+    const obj1 = { a: 1, b: 2, c: 3 };
+    const obj2 = { b: 20, c: 30 };
+    const result = merge(obj1, obj2);
+    expect(result).toEqual({ a: 1, b: 20, c: 30 });
+  });
+
+  it('should ignore undefined values in second object', () => {
+    const obj1 = { a: 1, b: 2, c: 3 };
+    const obj2 = { b: undefined, c: 30, d: undefined };
+    const result = merge(obj1, obj2);
+    expect(result).toEqual({ a: 1, b: 2, c: 30 });
+  });
+
+  it('should handle empty first object', () => {
+    const obj1 = {};
+    const obj2 = { a: 1, b: 2 };
+    const result = merge(obj1, obj2);
+    expect(result).toEqual({ a: 1, b: 2 });
+  });
+
+  it('should handle empty second object', () => {
+    const obj1 = { a: 1, b: 2 };
+    const obj2 = {};
+    const result = merge(obj1, obj2);
+    expect(result).toEqual({ a: 1, b: 2 });
+  });
+
+  it('should handle both objects being empty', () => {
+    const obj1 = {};
+    const obj2 = {};
+    const result = merge(obj1, obj2);
+    expect(result).toEqual({});
+  });
+
+  it('should handle second object with all undefined values', () => {
+    const obj1 = { a: 1, b: 2 };
+    const obj2 = { c: undefined, d: undefined };
+    const result = merge(obj1, obj2);
+    expect(result).toEqual({ a: 1, b: 2 });
+  });
+
+  it('should not mutate the original objects', () => {
+    const obj1 = { a: 1, b: 2 };
+    const obj2 = { b: 20, c: 3 };
+    const originalObj1 = { ...obj1 };
+    const originalObj2 = { ...obj2 };
+
+    const result = merge(obj1, obj2);
+
+    expect(obj1).toEqual(originalObj1);
+    expect(obj2).toEqual(originalObj2);
+    expect(result).not.toBe(obj1);
+    expect(result).not.toBe(obj2);
+  });
+
+  it('should handle different value types', () => {
+    const obj1 = { a: 1, b: 'hello', c: [1, 2] };
+    const obj2 = { b: true, d: { nested: 'value' } };
+    const result = merge(obj1, obj2);
+    expect(result).toEqual({ a: 1, b: true, c: [1, 2], d: { nested: 'value' } });
+  });
+
+  it('should preserve falsy but not undefined values', () => {
+    const obj1 = { a: 1, b: 2, c: 3 };
+    const obj2 = { a: 0, b: false, c: '', d: null };
+    const result = merge(obj1, obj2);
+    expect(result).toEqual({ a: 0, b: false, c: '', d: null });
   });
 });

--- a/yarn-project/foundation/src/collection/object.ts
+++ b/yarn-project/foundation/src/collection/object.ts
@@ -79,3 +79,11 @@ export function assertRequired<T extends object>(obj: T): Required<T> {
   }
   return obj as Required<T>;
 }
+
+/** Returns the result of merging two objects ignoring properties with undefined values. */
+export function merge<T extends object, U extends object>(
+  obj1: T,
+  obj2: U,
+): T & { [P in keyof U]+?: Exclude<U[P], undefined> } {
+  return { ...obj1, ...compact(obj2) };
+}

--- a/yarn-project/sequencer-client/src/client/sequencer-client.ts
+++ b/yarn-project/sequencer-client/src/client/sequencer-client.ts
@@ -37,6 +37,7 @@ export class SequencerClient {
   constructor(
     protected publisherManager: PublisherManager<L1TxUtilsWithBlobs>,
     protected sequencer: Sequencer,
+    protected blockBuilder: IFullNodeBlockBuilder,
     protected validatorClient?: ValidatorClient,
     private l1Metrics?: L1Metrics,
   ) {}
@@ -183,7 +184,7 @@ export class SequencerClient {
 
     await sequencer.init();
 
-    return new SequencerClient(publisherManager, sequencer, validatorClient, l1Metrics);
+    return new SequencerClient(publisherManager, sequencer, blockBuilder, validatorClient, l1Metrics);
   }
 
   /**
@@ -192,6 +193,7 @@ export class SequencerClient {
    */
   public updateConfig(config: SequencerConfig & Partial<ValidatorClientFullConfig>) {
     this.sequencer.updateConfig(config);
+    this.blockBuilder.updateConfig(config);
     this.validatorClient?.updateConfig(config);
   }
 

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.ts
@@ -545,7 +545,13 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
       this.timetable.assertTimeLeft(proposedState, secondsIntoSlot);
     }
 
-    this.log.debug(`Transitioning from ${this.state} to ${proposedState}`, { slotNumber, secondsIntoSlot });
+    const boringStates = [SequencerState.IDLE, SequencerState.SYNCHRONIZING];
+    const logLevel =
+      boringStates.includes(proposedState) && boringStates.includes(this.state)
+        ? ('trace' as const)
+        : ('debug' as const);
+    this.log[logLevel](`Transitioning from ${this.state} to ${proposedState}`, { slotNumber, secondsIntoSlot });
+
     this.emit('state-changed', {
       oldState: this.state,
       newState: proposedState,

--- a/yarn-project/slasher/src/empire_slasher_client.test.ts
+++ b/yarn-project/slasher/src/empire_slasher_client.test.ts
@@ -16,13 +16,13 @@ import {
 import { jest } from '@jest/globals';
 import { type MockProxy, mockDeep } from 'jest-mock-extended';
 import assert from 'node:assert';
-import EventEmitter from 'node:events';
 
 import { DefaultSlasherConfig } from './config.js';
 import { EmpireSlasherClient, type EmpireSlasherSettings } from './empire_slasher_client.js';
 import { SlasherOffensesStore } from './stores/offenses_store.js';
 import { SlasherPayloadsStore } from './stores/payloads_store.js';
-import { WANT_TO_SLASH_EVENT, type WantToSlashArgs, type Watcher, type WatcherEmitter } from './watcher.js';
+import { DummyWatcher } from './test/dummy_watcher.js';
+import type { WantToSlashArgs, Watcher } from './watcher.js';
 
 describe('EmpireSlasherClient', () => {
   let slasherClient: TestEmpireSlasherClient;
@@ -716,11 +716,5 @@ class TestEmpireSlasherClient extends EmpireSlasherClient {
 
   public get offensesCollectorPublic() {
     return (this as any).offensesCollector;
-  }
-}
-
-class DummyWatcher extends (EventEmitter as new () => WatcherEmitter) implements Watcher {
-  public triggerSlash(args: WantToSlashArgs[]) {
-    this.emit(WANT_TO_SLASH_EVENT, args);
   }
 }

--- a/yarn-project/slasher/src/slasher_client_facade.ts
+++ b/yarn-project/slasher/src/slasher_client_facade.ts
@@ -58,6 +58,7 @@ export class SlasherClientFacade implements SlasherClientInterface {
   public updateConfig(config: Partial<SlasherConfig>): void {
     this.config = { ...this.config, ...config };
     this.client?.updateConfig(config);
+    this.watchers.forEach(watcher => watcher.updateConfig?.(config));
   }
 
   public getSlashPayloads(): Promise<SlashPayloadRound[]> {

--- a/yarn-project/slasher/src/tally_slasher_client.test.ts
+++ b/yarn-project/slasher/src/tally_slasher_client.test.ts
@@ -12,12 +12,12 @@ import { type Offense, OffenseType, type ProposerSlashAction } from '@aztec/stdl
 import { jest } from '@jest/globals';
 import { type MockProxy, mockDeep } from 'jest-mock-extended';
 import assert from 'node:assert';
-import EventEmitter from 'node:events';
 
 import { DefaultSlasherConfig } from './config.js';
 import { SlasherOffensesStore } from './stores/offenses_store.js';
 import { TallySlasherClient, type TallySlasherSettings } from './tally_slasher_client.js';
-import { WANT_TO_SLASH_EVENT, type WantToSlashArgs, type Watcher, type WatcherEmitter } from './watcher.js';
+import { DummyWatcher } from './test/dummy_watcher.js';
+import type { WantToSlashArgs } from './watcher.js';
 
 describe('TallySlasherClient', () => {
   let tallySlasherClient: TestTallySlasherClient;
@@ -95,20 +95,6 @@ describe('TallySlasherClient', () => {
     assert(action.type === 'execute-slash');
     expect(action.round).toEqual(expectedRound);
   };
-
-  class DummyWatcher extends (EventEmitter as new () => WatcherEmitter) implements Watcher {
-    public start() {
-      return Promise.resolve();
-    }
-
-    public stop() {
-      return Promise.resolve();
-    }
-
-    public triggerSlash(args: WantToSlashArgs[]) {
-      this.emit(WANT_TO_SLASH_EVENT, args);
-    }
-  }
 
   beforeEach(() => {
     kvStore = openTmpStore(true);

--- a/yarn-project/slasher/src/test/dummy_watcher.ts
+++ b/yarn-project/slasher/src/test/dummy_watcher.ts
@@ -1,0 +1,21 @@
+import type { SlasherConfig } from '@aztec/stdlib/interfaces/server';
+
+import EventEmitter from 'node:events';
+
+import { WANT_TO_SLASH_EVENT, type WantToSlashArgs, type Watcher, type WatcherEmitter } from '../watcher.js';
+
+export class DummyWatcher extends (EventEmitter as new () => WatcherEmitter) implements Watcher {
+  public updateConfig(_config: Partial<SlasherConfig>) {}
+
+  public start() {
+    return Promise.resolve();
+  }
+
+  public stop() {
+    return Promise.resolve();
+  }
+
+  public triggerSlash(args: WantToSlashArgs[]) {
+    this.emit(WANT_TO_SLASH_EVENT, args);
+  }
+}

--- a/yarn-project/slasher/src/watcher.ts
+++ b/yarn-project/slasher/src/watcher.ts
@@ -2,6 +2,8 @@ import { EthAddress } from '@aztec/foundation/eth-address';
 import type { TypedEventEmitter } from '@aztec/foundation/types';
 import { OffenseType } from '@aztec/stdlib/slashing';
 
+import type { SlasherConfig } from './config.js';
+
 export const WANT_TO_SLASH_EVENT = 'want-to-slash' as const;
 
 export interface WantToSlashArgs {
@@ -21,4 +23,5 @@ export type WatcherEmitter = TypedEventEmitter<WatcherEventMap>;
 export type Watcher = WatcherEmitter & {
   start?: () => Promise<void>;
   stop?: () => Promise<void>;
+  updateConfig: (config: Partial<SlasherConfig>) => void;
 };

--- a/yarn-project/stdlib/src/interfaces/block-builder.ts
+++ b/yarn-project/stdlib/src/interfaces/block-builder.ts
@@ -2,6 +2,8 @@ import type { Fr } from '@aztec/foundation/fields';
 import type { Timer } from '@aztec/foundation/timer';
 
 import type { L2Block } from '../block/l2_block.js';
+import type { ChainConfig, SequencerConfig } from '../config/chain-config.js';
+import type { L1RollupConstants } from '../epoch-helpers/index.js';
 import type { Gas } from '../gas/gas.js';
 import type { MerkleTreeWriteOperations } from '../trees/index.js';
 import type { BlockHeader } from '../tx/block_header.js';
@@ -59,13 +61,14 @@ export interface BuildBlockResult {
   usedTxs: Tx[];
 }
 
+export type FullNodeBlockBuilderConfig = Pick<L1RollupConstants, 'l1GenesisTime' | 'slotDuration'> &
+  Pick<ChainConfig, 'l1ChainId' | 'rollupVersion'> &
+  Pick<SequencerConfig, 'txPublicSetupAllowList' | 'fakeProcessingDelayPerTxMs'>;
+
 export interface IFullNodeBlockBuilder {
-  getConfig(): {
-    l1GenesisTime: bigint;
-    slotDuration: number;
-    l1ChainId: number;
-    rollupVersion: number;
-  };
+  getConfig(): FullNodeBlockBuilderConfig;
+
+  updateConfig(config: Partial<FullNodeBlockBuilderConfig>): void;
 
   buildBlock(
     txs: Iterable<Tx> | AsyncIterable<Tx>,


### PR DESCRIPTION
Updates the configs of the slasher watchers and block builder when `updateConfig` is called via the node admin API. 

Note that there may still be more subcomponents not updating their config, I haven't yet gone through all of them.