### PR TITLE
fix: Handle blocks invalidated with an invalid block

### DIFF
--- a/yarn-project/archiver/README.md
+++ b/yarn-project/archiver/README.md
@@ -1,6 +1,7 @@
 # Archiver
 
 Archiver is a service which is used to fetch data on-chain data and present them in a nice-to-consume form.
+
 The on-chain data specifically are the following events:
 
 1. `L2BlockProposed` event emitted on Rollup contract,
@@ -8,9 +9,29 @@ The on-chain data specifically are the following events:
 
 The interfaces defining how the data can be consumed from the archiver are `L2BlockSource`, `L2LogsSource` and `ContractDataSource`.
 
-## Usage
+## Sync process
 
-To install dependencies and build the package run `yarn install` followed by `yarn build`.
-To run test execute `yarn test`.
+The archiver sync process periodically checks its current state against the Rollup contract on L1 and updates its local state.
 
-To start the service export `ETHEREUM_HOSTS` (defaults to `http://127.0.0.1:8545/`), `ARCHIVER_POLLING_INTERVAL_MS` (defaults to `1000 ms`), `ROLLUP_CONTRACT_ADDRESS`, `INBOX_CONTRACT_ADDRESS` environmental variables and start the service with `yarn start`.
+### Handling invalid blocks
+
+After the implementation of [delayed attestation verification](https://github.com/AztecProtocol/engineering-designs/pull/69), the Rollup contract on L1 no longer validates committee attestations. Instead, these are posted in calldata, and L2 nodes are expected to verify them as they download blocks. The archiver handles this validation during its sync process.
+
+Whenever the archiver detects a block with invalid attestations, it skips it. These blocks are not meant to be part of the chain, so the archiver ignores them and continues processing the next blocks. It is expected that an honest proposer will eventually invalidate these blocks, removing them from the chain on L1, and then resume the sequence of valid blocks.
+
+> [!WARNING]  
+> If the committee for the epoch is also malicious and attests to a descendant of an invalid block, nodes should also ignore these descendants, unless they become proven. This is currently not implemented. Nodes assume that the majority of the committee is honest.
+
+When the current node is elected as proposer, the `sequencer` needs to know whether there is an invalid block in L1 that needs to be purged before posting their own block. To support this, the archiver exposes a `pendingChainValidationStatus`, which is the state of the tip of the pending chain. This status can be valid in the happy path, or invalid if the tip of the pending chain has invalid attestations. If invalid, this status also contains all the data needed for purging the block from L1 via an `invalidate` call to the Rollup contract. Note that, if the head of the chain has more than one invalid consecutive block, this status will reference the earliest one that needs to be purged, since a call to purge an invalid block will automatically purge all descendants. Refer to the [InvalidateLib.sol](`l1-contracts/src/core/libraries/rollup/InvalidateLib.sol`) for more info.
+
+> [!TIP]  
+> The archiver can be configured to `skipValidateBlockAttestations`, which will make it skip this validation. This cannot be set via environment variables, only via a call to `nodeAdmin_setConfig`. This setting is only meant for testing purposes.
+
+As an example, let's say the chain has been progressing normally up until block 10, and then:
+1. Block 11 is posted with invalid attestations. The archiver will report 10 as the latest block, but the `pendingChainValidationStatus` will point to block 11.
+2. Block 11 is purged, but another block 11 with invalid attestations is posted in its place. The archiver will still report 10 as latest, and the `pendingChainValidationStatus` will point to the new block 11 that needs to be purged.
+3. Block 12 with invalid attestations is posted. No changes in the archiver.
+4. Block 13 is posted with valid attestations, due to a malicious committee. The archiver will try to sync it and fail, since 13 does not follow 10. This scenario is not gracefully handled yet.
+5. Blocks 11 to 13 are purged. The archiver status will not yet be changed: 10 will still be the latest block, and the `pendingChainValidationStatus` will point to 11. This is because the archiver does **not** follow `BlockInvalidated` events.
+6. Block 11 with valid attestations is posted. The archiver pending chain now reports 11 as latest, and its status is valid.
+

--- a/yarn-project/archiver/src/archiver/config.ts
+++ b/yarn-project/archiver/src/archiver/config.ts
@@ -1,47 +1,28 @@
 import { type BlobSinkConfig, blobSinkConfigMapping } from '@aztec/blob-sink/client';
 import {
-  type L1ContractAddresses,
   type L1ContractsConfig,
   type L1ReaderConfig,
   l1ContractAddressesMapping,
   l1ContractsConfigMappings,
   l1ReaderConfigMappings,
 } from '@aztec/ethereum';
-import { type ConfigMappingsType, getConfigFromMappings, numberConfigHelper } from '@aztec/foundation/config';
+import {
+  type ConfigMappingsType,
+  booleanConfigHelper,
+  getConfigFromMappings,
+  numberConfigHelper,
+} from '@aztec/foundation/config';
 import { type ChainConfig, chainConfigMappings } from '@aztec/stdlib/config';
+import type { ArchiverSpecificConfig } from '@aztec/stdlib/interfaces/server';
 
 /**
+ * The archiver configuration.
  * There are 2 polling intervals used in this configuration. The first is the archiver polling interval, archiverPollingIntervalMS.
  * This is the interval between successive calls to eth_blockNumber via viem.
  * Results of calls to eth_blockNumber are cached by viem with this cache being updated periodically at the interval specified by viemPollingIntervalMS.
  * As a result the maximum observed polling time for new blocks will be viemPollingIntervalMS + archiverPollingIntervalMS.
  */
-
-/**
- * The archiver configuration.
- */
-export type ArchiverConfig = {
-  /** The polling interval in ms for retrieving new L2 blocks and encrypted logs. */
-  archiverPollingIntervalMS?: number;
-
-  /** The number of L2 blocks the archiver will attempt to download at a time. */
-  archiverBatchSize?: number;
-
-  /** The polling interval viem uses in ms */
-  viemPollingIntervalMS?: number;
-
-  /** The deployed L1 contract addresses */
-  l1Contracts: L1ContractAddresses;
-
-  /** The max number of logs that can be obtained in 1 "getPublicLogs" call. */
-  maxLogs?: number;
-
-  /** The maximum possible size of the archiver DB in KB. Overwrites the general dataStoreMapSizeKB. */
-  archiverStoreMapSizeKb?: number;
-} & L1ReaderConfig &
-  L1ContractsConfig &
-  BlobSinkConfig &
-  ChainConfig;
+export type ArchiverConfig = ArchiverSpecificConfig & L1ReaderConfig & L1ContractsConfig & BlobSinkConfig & ChainConfig;
 
 export const archiverConfigMappings: ConfigMappingsType<ArchiverConfig> = {
   ...blobSinkConfigMapping,
@@ -64,6 +45,10 @@ export const archiverConfigMappings: ConfigMappingsType<ArchiverConfig> = {
     env: 'ARCHIVER_STORE_MAP_SIZE_KB',
     parseEnv: (val: string | undefined) => (val ? +val : undefined),
     description: 'The maximum possible size of the archiver DB in KB. Overwrites the general dataStoreMapSizeKB.',
+  },
+  skipValidateBlockAttestations: {
+    description: 'Whether to skip validating block attestations (use only for testing).',
+    ...booleanConfigHelper(false),
   },
   ...chainConfigMappings,
   ...l1ReaderConfigMappings,

--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -1126,7 +1126,10 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, Traceable {
     this.slasherClient?.updateConfig(config);
     this.validatorsSentinel?.updateConfig(config);
     await this.p2pClient.updateP2PConfig(config);
-
+    const archiver = this.blockSource as Archiver;
+    if ('updateConfig' in archiver) {
+      archiver.updateConfig(config);
+    }
     if (newConfig.realProofs !== this.config.realProofs) {
       this.proofVerifier = config.realProofs ? await BBCircuitVerifier.new(newConfig) : new TestCircuitVerifier();
     }

--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_test.ts
@@ -9,6 +9,7 @@ import {
   retryUntil,
   sleep,
 } from '@aztec/aztec.js';
+import { EpochCache } from '@aztec/epoch-cache';
 import { DefaultL1ContractsConfig, type ExtendedViemWalletClient, createExtendedL1Client } from '@aztec/ethereum';
 import { RollupContract } from '@aztec/ethereum/contracts';
 import { ChainMonitor, DelayedTxUtils, type Delayer, waitUntilL1Timestamp, withDelayer } from '@aztec/ethereum/test';
@@ -69,6 +70,7 @@ export class EpochsTestContext {
   public constants!: L1RollupConstants;
   public logger!: Logger;
   public monitor!: ChainMonitor;
+  public epochCache!: EpochCache;
   public proverDelayer!: Delayer;
   public sequencerDelayer!: Delayer;
 
@@ -141,6 +143,7 @@ export class EpochsTestContext {
     this.logger = context.logger;
     this.l1Client = context.deployL1ContractsValues.l1Client;
     this.rollup = RollupContract.getFromConfig(context.config);
+    this.epochCache = await EpochCache.create(this.rollup, context.config, { dateProvider: context.dateProvider });
 
     // Loop that tracks L1 and L2 block numbers and logs whenever there's a new one.
     this.monitor = new ChainMonitor(this.rollup, context.dateProvider, this.logger).start();

--- a/yarn-project/epoch-cache/src/config.ts
+++ b/yarn-project/epoch-cache/src/config.ts
@@ -7,12 +7,7 @@ import {
 
 export type EpochCacheConfig = Pick<
   L1ReaderConfig & L1ContractsConfig,
-  | 'l1RpcUrls'
-  | 'l1ChainId'
-  | 'viemPollingIntervalMS'
-  | 'aztecSlotDuration'
-  | 'ethereumSlotDuration'
-  | 'aztecEpochDuration'
+  'l1RpcUrls' | 'l1ChainId' | 'viemPollingIntervalMS' | 'ethereumSlotDuration'
 >;
 
 export function getEpochCacheConfigEnvVars(): EpochCacheConfig {

--- a/yarn-project/ethereum/src/contracts/rollup.ts
+++ b/yarn-project/ethereum/src/contracts/rollup.ts
@@ -10,6 +10,7 @@ import {
   type GetContractReturnType,
   type Hex,
   type StateOverride,
+  type WatchContractEventReturnType,
   encodeFunctionData,
   getContract,
   hexToBigInt,
@@ -727,7 +728,9 @@ export class RollupContract {
     });
   }
 
-  public listenToSlasherChanged(callback: (args: { oldSlasher: `0x${string}`; newSlasher: `0x${string}` }) => unknown) {
+  public listenToSlasherChanged(
+    callback: (args: { oldSlasher: `0x${string}`; newSlasher: `0x${string}` }) => unknown,
+  ): WatchContractEventReturnType {
     return this.rollup.watchEvent.SlasherUpdated(
       {},
       {
@@ -743,6 +746,22 @@ export class RollupContract {
     );
   }
 
+  public listenToBlockInvalidated(callback: (args: { blockNumber: bigint }) => unknown): WatchContractEventReturnType {
+    return this.rollup.watchEvent.BlockInvalidated(
+      {},
+      {
+        onLogs: logs => {
+          for (const log of logs) {
+            const args = log.args;
+            if (args.blockNumber !== undefined) {
+              callback({ blockNumber: args.blockNumber });
+            }
+          }
+        },
+      },
+    );
+  }
+
   public async getSlashEvents(l1BlockHash: Hex): Promise<{ amount: bigint; attester: EthAddress }[]> {
     const events = await this.rollup.getEvents.Slashed({}, { blockHash: l1BlockHash, strict: true });
     return events.map(event => ({
@@ -751,7 +770,9 @@ export class RollupContract {
     }));
   }
 
-  public listenToSlash(callback: (args: { amount: bigint; attester: EthAddress }) => unknown) {
+  public listenToSlash(
+    callback: (args: { amount: bigint; attester: EthAddress }) => unknown,
+  ): WatchContractEventReturnType {
     return this.rollup.watchEvent.Slashed(
       {},
       {

--- a/yarn-project/sequencer-client/src/client/sequencer-client.ts
+++ b/yarn-project/sequencer-client/src/client/sequencer-client.ts
@@ -111,9 +111,7 @@ export class SequencerClient {
           l1RpcUrls: rpcUrls,
           l1ChainId: chainId,
           viemPollingIntervalMS: config.viemPollingIntervalMS,
-          aztecSlotDuration: config.aztecSlotDuration,
           ethereumSlotDuration: config.ethereumSlotDuration,
-          aztecEpochDuration: config.aztecEpochDuration,
         },
         { dateProvider: deps.dateProvider },
       ));

--- a/yarn-project/sequencer-client/src/publisher/sequencer-publisher.ts
+++ b/yarn-project/sequencer-client/src/publisher/sequencer-publisher.ts
@@ -399,7 +399,7 @@ export class SequencerPublisher {
     }
 
     const request = this.buildInvalidateBlockRequest(validationResult);
-    this.log.debug(`Simulating invalidate block ${blockNumber}`, logData);
+    this.log.debug(`Simulating invalidate block ${blockNumber}`, { ...logData, request });
 
     try {
       const { gasUsed } = await this.l1TxUtils.simulate(request, undefined, undefined, ErrorsAbi);

--- a/yarn-project/slasher/src/watchers/attestations_block_watcher.ts
+++ b/yarn-project/slasher/src/watchers/attestations_block_watcher.ts
@@ -37,6 +37,8 @@ export class AttestationsBlockWatcher extends (EventEmitter as new () => Watcher
   // All invalid archive roots seen
   private invalidArchiveRoots: Set<string> = new Set();
 
+  private config: AttestationsBlockWatcherConfig;
+
   private boundHandleInvalidBlock = (event: InvalidBlockDetectedEvent) => {
     try {
       this.handleInvalidBlock(event);
@@ -51,9 +53,10 @@ export class AttestationsBlockWatcher extends (EventEmitter as new () => Watcher
   constructor(
     private l2BlockSource: L2BlockSourceEventEmitter,
     private epochCache: EpochCache,
-    private config: AttestationsBlockWatcherConfig,
+    config: AttestationsBlockWatcherConfig,
   ) {
     super();
+    this.config = pick(config, ...AttestationsBlockWatcherConfigKeys);
     this.log.info('AttestationsBlockWatcher initialized');
   }
 

--- a/yarn-project/slasher/src/watchers/epoch_prune_watcher.ts
+++ b/yarn-project/slasher/src/watchers/epoch_prune_watcher.ts
@@ -44,15 +44,18 @@ export class EpochPruneWatcher extends (EventEmitter as new () => WatcherEmitter
   // Store bound function reference for proper listener removal
   private boundHandlePruneL2Blocks = this.handlePruneL2Blocks.bind(this);
 
+  private penalties: EpochPruneWatcherPenalties;
+
   constructor(
     private l2BlockSource: L2BlockSourceEventEmitter,
     private l1ToL2MessageSource: L1ToL2MessageSource,
     private epochCache: EpochCache,
     private txProvider: Pick<ITxProvider, 'getAvailableTxs'>,
     private blockBuilder: IFullNodeBlockBuilder,
-    private penalties: EpochPruneWatcherPenalties,
+    penalties: EpochPruneWatcherPenalties,
   ) {
     super();
+    this.penalties = pick(penalties, ...EpochPruneWatcherPenaltiesConfigKeys);
     this.log.verbose(
       `EpochPruneWatcher initialized with penalties: valid epoch pruned=${penalties.slashPrunePenalty} data withholding=${penalties.slashDataWithholdingPenalty}`,
     );

--- a/yarn-project/stdlib/src/interfaces/archiver.ts
+++ b/yarn-project/stdlib/src/interfaces/archiver.ts
@@ -1,3 +1,4 @@
+import type { L1ContractAddresses } from '@aztec/ethereum';
 import type { ApiSchemaFor } from '@aztec/foundation/schemas';
 
 import { z } from 'zod';
@@ -23,6 +24,41 @@ import { TxHash } from '../tx/tx_hash.js';
 import { TxReceipt } from '../tx/tx_receipt.js';
 import { GetContractClassLogsResponseSchema, GetPublicLogsResponseSchema } from './get_logs_response.js';
 import type { L2LogsSource } from './l2_logs_source.js';
+
+/**
+ * The archiver configuration.
+ */
+export type ArchiverSpecificConfig = {
+  /** The polling interval in ms for retrieving new L2 blocks and encrypted logs. */
+  archiverPollingIntervalMS?: number;
+
+  /** The number of L2 blocks the archiver will attempt to download at a time. */
+  archiverBatchSize?: number;
+
+  /** The polling interval viem uses in ms */
+  viemPollingIntervalMS?: number;
+
+  /** The deployed L1 contract addresses */
+  l1Contracts: L1ContractAddresses;
+
+  /** The max number of logs that can be obtained in 1 "getPublicLogs" call. */
+  maxLogs?: number;
+
+  /** The maximum possible size of the archiver DB in KB. Overwrites the general dataStoreMapSizeKB. */
+  archiverStoreMapSizeKb?: number;
+
+  /** Whether to skip validating block attestations (use only for testing). */
+  skipValidateBlockAttestations?: boolean;
+};
+
+export const ArchiverSpecificConfigSchema = z.object({
+  archiverPollingIntervalMS: schemas.Integer.optional(),
+  archiverBatchSize: schemas.Integer.optional(),
+  viemPollingIntervalMS: schemas.Integer.optional(),
+  maxLogs: schemas.Integer.optional(),
+  archiverStoreMapSizeKb: schemas.Integer.optional(),
+  skipValidateBlockAttestations: z.boolean().optional(),
+});
 
 export type ArchiverApi = Omit<
   L2BlockSource & L2LogsSource & ContractDataSource & L1ToL2MessageSource,

--- a/yarn-project/stdlib/src/interfaces/aztec-node-admin.ts
+++ b/yarn-project/stdlib/src/interfaces/aztec-node-admin.ts
@@ -5,6 +5,7 @@ import { z } from 'zod';
 import type { ApiSchemaFor } from '../schemas/schemas.js';
 import { type Offense, OffenseSchema, type SlashPayloadRound, SlashPayloadRoundSchema } from '../slashing/index.js';
 import { type ComponentsVersions, getVersioningResponseHandler } from '../versioning/index.js';
+import { type ArchiverSpecificConfig, ArchiverSpecificConfigSchema } from './archiver.js';
 import { type SequencerConfig, SequencerConfigSchema } from './configs.js';
 import { type ProverConfig, ProverConfigSchema } from './prover-client.js';
 import { type SlasherConfig, SlasherConfigSchema } from './slasher.js';
@@ -54,11 +55,21 @@ export interface AztecNodeAdmin {
 export type AztecNodeAdminConfig = ValidatorClientFullConfig &
   SequencerConfig &
   ProverConfig &
-  SlasherConfig & { maxTxPoolSize: number };
+  SlasherConfig &
+  Pick<ArchiverSpecificConfig, 'archiverPollingIntervalMS' | 'skipValidateBlockAttestations' | 'archiverBatchSize'> & {
+    maxTxPoolSize: number;
+  };
 
 export const AztecNodeAdminConfigSchema = SequencerConfigSchema.merge(ProverConfigSchema)
   .merge(SlasherConfigSchema)
   .merge(ValidatorClientConfigSchema)
+  .merge(
+    ArchiverSpecificConfigSchema.pick({
+      archiverPollingIntervalMS: true,
+      skipValidateBlockAttestations: true,
+      archiverBatchSize: true,
+    }),
+  )
   .merge(z.object({ maxTxPoolSize: z.number() }));
 
 export const AztecNodeAdminApiSchema: ApiSchemaFor<AztecNodeAdmin> = {


### PR DESCRIPTION
Fixes issue with invalidating blocks with invalid attestations. If a block is invalidated, but immediately replaced with another invalid block, then the next proposer will attempt to invalidate the original one, which will fail since its attestations will have been replaced in L1 storage with the ones from the second one. As an example:

1. Slot S:   Block N is proposed with invalid attestations
2. Slot S+1: Block N is invalidated, and block N' (same number) is proposed instead, but also has invalid attestations
3. Slot S+2: Proposer tries to invalidate block N, when they should invalidate block N' instead, and fails

Also added a new env var for the archiver `skipValidateBlockAttestations` so we could force a proposer to keep building on top of an invalid block, so we could write the test `proposer invalidates multiple blocks`. This also required moving the archiver config to stdlib, and adding an `updateConfig` method wired through the node admin API so we could turn that config on or off.

Last, this PR uses a persistent storage for the `pendingChainValidationStatus` in the archiver, so it is persisted across restarts. Otherwise, if a node is restarted while the change is in an invalid state, it will fail to invalidate such block.
