### PR TITLE
chore: Invalidate block network test

### DIFF
--- a/spartan/environments/scenario.local.env
+++ b/spartan/environments/scenario.local.env
@@ -1,10 +1,12 @@
 NAMESPACE=scenario
+NETWORK=local
 CLUSTER=kind
 CREATE_ETH_DEVNET=true
 SALT=123
 LABS_INFRA_MNEMONIC="test test test test test test test test test test test junk"
 FUNDING_PRIVATE_KEY="0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
 REAL_VERIFIER=false
+PROVER_REAL_PROOFS=false
 SENTINEL_ENABLED=true
 # CREATE_CHAOS_MESH=true
 

--- a/spartan/scripts/deploy_network.sh
+++ b/spartan/scripts/deploy_network.sh
@@ -93,6 +93,12 @@ if [[ -z "${AZTEC_DOCKER_IMAGE:-}" ]]; then
   die "AZTEC_DOCKER_IMAGE is not set"
 fi
 
+# Load image into kind
+if [[ "${CLUSTER}" == "kind" ]]; then
+  log "Loading ${AZTEC_DOCKER_IMAGE} into kind cluster"
+  kind load docker-image "${AZTEC_DOCKER_IMAGE}"
+fi
+
 K8S_CLUSTER_CONTEXT=$(kubectl config current-context)
 
 if [[ "${DESTROY_NAMESPACE:-}" == "true" ]]; then

--- a/spartan/terraform/deploy-aztec-infra/main.tf
+++ b/spartan/terraform/deploy-aztec-infra/main.tf
@@ -124,6 +124,7 @@ locals {
         "validator.slash.maxPayloadSize"                    = var.SLASH_MAX_PAYLOAD_SIZE
         "validator.node.env.TRANSACTIONS_DISABLED"          = var.TRANSACTIONS_DISABLED
         "validator.node.env.NETWORK"                        = var.NETWORK
+        "validator.node.proverRealProofs"                   = var.PROVER_REAL_PROOFS
       }
       boot_node_host_path  = "validator.node.env.BOOT_NODE_HOST"
       bootstrap_nodes_path = "validator.node.env.BOOTSTRAP_NODES"
@@ -160,8 +161,9 @@ locals {
         "rpc-resources-${var.RPC_RESOURCE_PROFILE}.yaml"
       ]
       custom_settings = {
-        "nodeType"         = "rpc"
-        "node.env.NETWORK" = var.NETWORK
+        "nodeType"              = "rpc"
+        "node.env.NETWORK"      = var.NETWORK
+        "node.proverRealProofs" = var.PROVER_REAL_PROOFS
       }
       boot_node_host_path  = "node.env.BOOT_NODE_HOST"
       bootstrap_nodes_path = "node.env.BOOTSTRAP_NODES"

--- a/yarn-project/end-to-end/src/spartan/invalidate_blocks.test.ts
+++ b/yarn-project/end-to-end/src/spartan/invalidate_blocks.test.ts
@@ -1,0 +1,116 @@
+import { type AztecNode, retryUntil } from '@aztec/aztec.js';
+import { RollupContract, type ViemPublicClient } from '@aztec/ethereum';
+import { ChainMonitor } from '@aztec/ethereum/test';
+import { createLogger } from '@aztec/foundation/log';
+import { promiseWithResolvers } from '@aztec/foundation/promise';
+import { timeoutPromise } from '@aztec/foundation/timer';
+import type { L1RollupConstants } from '@aztec/stdlib/epoch-helpers';
+
+import { jest } from '@jest/globals';
+import type { ChildProcess } from 'child_process';
+
+import {
+  getL1DeploymentAddresses,
+  getNodeClient,
+  getPublicViemClient,
+  getSequencersConfig,
+  setupEnvironment,
+  updateSequencersConfig,
+} from './utils.js';
+
+const config = setupEnvironment(process.env);
+const ETHEREUM_SLOT_DURATION = 12;
+
+// This test causes a proposer to push a block without valid attestations, then waits for
+// the following proposer to invalidate it and propose a new block instead. The test also
+// disables slashing to avoid the invalid block proposer getting slashed.
+describe('invalidate blocks test', () => {
+  jest.setTimeout(10 * 60 * 2000); // 20 minutes
+
+  const logger = createLogger(`e2e:slash-inactivity`);
+
+  const forwardProcesses: ChildProcess[] = [];
+
+  let client: ViemPublicClient;
+  let rollup: RollupContract;
+  let constants: L1RollupConstants;
+  let monitor: ChainMonitor;
+  let node: AztecNode;
+  let origMinTxsPerBlock: number = 1;
+
+  beforeAll(async () => {
+    const deployAddresses = await getL1DeploymentAddresses(config);
+    ({ client } = await getPublicViemClient(config, forwardProcesses));
+    rollup = new RollupContract(client, deployAddresses.rollupAddress);
+    monitor = new ChainMonitor(rollup, undefined, logger.createChild('chain-monitor'), 500).start();
+    constants = { ...(await rollup.getRollupConstants()), ethereumSlotDuration: ETHEREUM_SLOT_DURATION };
+
+    const { node: nodeClient, process } = await getNodeClient(config);
+    node = nodeClient;
+    forwardProcesses.push(process);
+  });
+
+  afterAll(async () => {
+    await updateSequencersConfig(config, { skipCollectingAttestations: false, minTxsPerBlock: origMinTxsPerBlock });
+    monitor.removeAllListeners();
+    await monitor.stop();
+    forwardProcesses.forEach(p => p.kill());
+  });
+
+  /** Waits for a BlockInvalidated event */
+  const waitForBlockInvalidated = (timeoutSeconds: number) => {
+    logger.warn(`Waiting until a block is invalidated`);
+    const promise = promiseWithResolvers<{ blockNumber: bigint }>();
+    const unsubscribe = rollup.listenToBlockInvalidated(data => {
+      logger.warn(`Block ${data.blockNumber} has been invalidated`, data);
+      unsubscribe();
+      promise.resolve(data);
+    });
+
+    return Promise.race([promise.promise, timeoutPromise(timeoutSeconds * 1000)]);
+  };
+
+  it('posts an invalid block and next proposer invalidates it', async () => {
+    // Log initial sequencer configs for debugging purposes
+    const configs = await getSequencersConfig(config);
+    configs.forEach(c => logger.info(`Loaded initial sequencer config`, c));
+    origMinTxsPerBlock = configs?.[0].minTxsPerBlock ?? 1;
+    const initialBlockNumber = (await monitor.run()).l2BlockNumber;
+
+    // Update configs so next block is posted with invalid attestations, and we avoid slashing so we do not kick
+    // people of the validator set with this test.
+    await updateSequencersConfig(config, {
+      skipCollectingAttestations: true,
+      slashProposeInvalidAttestationsPenalty: 0n,
+      slashAttestDescendantOfInvalidPenalty: 0n,
+      minTxsPerBlock: 0,
+    });
+
+    // Wait for the invalidation to happen (should not take more than 2 slots, but we wait for 4 just in case)
+    await waitForBlockInvalidated(constants.slotDuration * 4);
+
+    // Restore sequencer configs to normal
+    await updateSequencersConfig(config, { skipCollectingAttestations: false });
+
+    // Wait until a few more blocks have been mined to ensure the chain can progress after the invalid block
+    // Note that we should expect more invalidations depending on when the patched config hits
+    const targetBlockNumber = initialBlockNumber + 4;
+    logger.warn(`Waiting until block ${targetBlockNumber} has been mined to ensure the chain can progress`);
+    await Promise.race([
+      monitor.waitUntilL2Block(targetBlockNumber),
+      timeoutPromise(constants.slotDuration * 8 * 1000, `Timeout waiting for ${targetBlockNumber} L2 block`),
+    ]);
+
+    // Ensure the nodes also sync to this block
+    await retryUntil(
+      async () => {
+        const block = await node.getBlockNumber();
+        logger.info(`L2 block number in node is ${block}`);
+        return block >= targetBlockNumber;
+      },
+      `node to sync to block ${targetBlockNumber}`,
+      10,
+      1,
+    );
+  });
+});

--- a/yarn-project/end-to-end/src/spartan/transfer.test.ts
+++ b/yarn-project/end-to-end/src/spartan/transfer.test.ts
@@ -7,7 +7,7 @@ import type { ChildProcess } from 'child_process';
 
 import { getSponsoredFPCAddress } from '../fixtures/utils.js';
 import { type TestAccounts, deploySponsoredTestAccounts, startCompatiblePXE } from './setup_test_wallets.js';
-import { setupEnvironment, startPortForwardForRPC } from './utils.js';
+import { getSequencersConfig, setupEnvironment, startPortForwardForRPC } from './utils.js';
 
 const config = setupEnvironment(process.env);
 
@@ -33,6 +33,9 @@ describe('token transfer test', () => {
     const { process, port } = await startPortForwardForRPC(config.NAMESPACE);
     forwardProcesses.push(process);
     const rpcUrl = `http://127.0.0.1:${port}`;
+
+    const configs = await getSequencersConfig(config);
+    configs.forEach(c => logger.info(`Loaded initial sequencer config`, c));
 
     ({ pxe, cleanup } = await startCompatiblePXE(rpcUrl, config.REAL_VERIFIER, logger));
 

--- a/yarn-project/end-to-end/src/spartan/utils.ts
+++ b/yarn-project/end-to-end/src/spartan/utils.ts
@@ -5,6 +5,7 @@ import type { Logger } from '@aztec/foundation/log';
 import { makeBackoff, retry } from '@aztec/foundation/retry';
 import { schemas } from '@aztec/foundation/schemas';
 import {
+  type AztecNode,
   type AztecNodeAdmin,
   type AztecNodeAdminConfig,
   createAztecNodeAdminClient,
@@ -593,6 +594,33 @@ export async function getPublicViemClient(
     const client: ViemPublicClient = createPublicClient({ transport: fallback([http(L1_RPC_URLS_JSON)]) });
     return { url: L1_RPC_URLS_JSON, client };
   }
+}
+
+/** Returns a client to the RPC of the given sequencer (defaults to first) */
+export async function getNodeClient(
+  env: TestConfig,
+  index: number = 0,
+): Promise<{ node: AztecNode; port: number; process: ChildProcess }> {
+  const namespace = env.NAMESPACE;
+  const containerPort = 8080;
+  const sequencer = (await getSequencers(env.NAMESPACE))[index];
+  const { process, port } = await startPortForward({
+    resource: `pod/${sequencer}`,
+    namespace,
+    containerPort,
+  });
+
+  const url = `http://localhost:${port}`;
+  await retry(
+    () => fetch(`${url}/status`).then(res => res.status === 200),
+    'forward port',
+    makeBackoff([1, 1, 2, 6]),
+    logger,
+    true,
+  );
+
+  const client = createAztecNodeClient(url);
+  return { node: client, port, process };
 }
 
 /** Queries an Aztec node for the L1 deployment addresses */


### PR DESCRIPTION
Network test for invalidating a block with invalid signatures, as part of _delayed signature verification_ epic. 

Fixes https://linear.app/aztec-labs/issue/TMNT-238/invalid-attestations-block-network-test

Builds on #16836