### PR TITLE
chore: dont bump nightly version

### DIFF
--- a/.github/workflows/nightly-release-tag.yml
+++ b/.github/workflows/nightly-release-tag.yml
@@ -27,17 +27,8 @@ jobs:
           git config --global user.email "tech@aztecprotocol.com"
           git config --global user.name "AztecBot"
           current_version=$(jq -r '."."' .release-please-manifest.json)
-          # Compute the next major version. e.g. if current version is 1.2.3, next major version is 2.0.0.
-          if [[ "$current_version" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
-            major=$(( ${BASH_REMATCH[1]} + 1 ))
-            next_major_version="${major}.0.0"
-          else
-            echo "Error: Current version format is invalid: $current_version"
-            exit 1
-          fi
           echo "Current version: $current_version"
-          echo "Next version: $next_major_version"
-          nightly_tag="v${next_major_version}-nightly.$(date -u +%Y%m%d)"
+          nightly_tag="v${current_version}-nightly.$(date -u +%Y%m%d)"
           echo "Nightly tag: $nightly_tag"
           # Tag and push.
           git tag -a "$nightly_tag" -m "$nightly_tag"


### PR DESCRIPTION
We don’t need to manually bump the nightly tag because the release please manifest version on `next`​ is now correct.

Fix TMNT-283