### PR TITLE
fix: bigfield veridise audit fixes

### DIFF
--- a/barretenberg/cpp/scripts/test_civc_standalone_vks_havent_changed.sh
+++ b/barretenberg/cpp/scripts/test_civc_standalone_vks_havent_changed.sh
@@ -13,7 +13,7 @@ cd ..
 # - Generate a hash for versioning: sha256sum bb-civc-inputs.tar.gz
 # - Upload the compressed results: aws s3 cp bb-civc-inputs.tar.gz s3://aztec-ci-artifacts/protocol/bb-civc-inputs-[hash(0:8)].tar.gz
 # Note: In case of the "Test suite failed to run ... Unexpected token 'with' " error, need to run: docker pull aztecprotocol/build:3.0
-pinned_short_hash="889c209e"
+pinned_short_hash="5a4a96d8"
 pinned_civc_inputs_url="https://aztec-ci-artifacts.s3.us-east-2.amazonaws.com/protocol/bb-civc-inputs-${pinned_short_hash}.tar.gz"
 
 function compress_and_upload {

--- a/barretenberg/cpp/scripts/test_civc_standalone_vks_havent_changed.sh
+++ b/barretenberg/cpp/scripts/test_civc_standalone_vks_havent_changed.sh
@@ -13,7 +13,7 @@ cd ..
 # - Generate a hash for versioning: sha256sum bb-civc-inputs.tar.gz
 # - Upload the compressed results: aws s3 cp bb-civc-inputs.tar.gz s3://aztec-ci-artifacts/protocol/bb-civc-inputs-[hash(0:8)].tar.gz
 # Note: In case of the "Test suite failed to run ... Unexpected token 'with' " error, need to run: docker pull aztecprotocol/build:3.0
-pinned_short_hash="e70f08be"
+pinned_short_hash="889c209e"
 pinned_civc_inputs_url="https://aztec-ci-artifacts.s3.us-east-2.amazonaws.com/protocol/bb-civc-inputs-${pinned_short_hash}.tar.gz"
 
 function compress_and_upload {

--- a/barretenberg/cpp/scripts/test_civc_standalone_vks_havent_changed.sh
+++ b/barretenberg/cpp/scripts/test_civc_standalone_vks_havent_changed.sh
@@ -13,7 +13,7 @@ cd ..
 # - Generate a hash for versioning: sha256sum bb-civc-inputs.tar.gz
 # - Upload the compressed results: aws s3 cp bb-civc-inputs.tar.gz s3://aztec-ci-artifacts/protocol/bb-civc-inputs-[hash(0:8)].tar.gz
 # Note: In case of the "Test suite failed to run ... Unexpected token 'with' " error, need to run: docker pull aztecprotocol/build:3.0
-pinned_short_hash="5a4a96d8"
+pinned_short_hash="8ba25b76"
 pinned_civc_inputs_url="https://aztec-ci-artifacts.s3.us-east-2.amazonaws.com/protocol/bb-civc-inputs-${pinned_short_hash}.tar.gz"
 
 function compress_and_upload {

--- a/barretenberg/cpp/src/barretenberg/stdlib/eccvm_verifier/eccvm_recursive_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/eccvm_verifier/eccvm_recursive_verifier.test.cpp
@@ -139,7 +139,7 @@ class ECCVMRecursiveTests : public ::testing::Test {
         }
 
         // Check that the size of the recursive verifier is consistent with historical expectation
-        uint32_t NUM_GATES_EXPECTED = 213775;
+        uint32_t NUM_GATES_EXPECTED = 216508;
         ASSERT_EQ(static_cast<uint32_t>(outer_circuit.get_num_finalized_gates()), NUM_GATES_EXPECTED)
             << "Ultra-arithmetized ECCVM Recursive verifier gate count changed! Update this value if you are sure this "
                "is expected.";

--- a/barretenberg/cpp/src/barretenberg/stdlib/eccvm_verifier/eccvm_recursive_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/eccvm_verifier/eccvm_recursive_verifier.test.cpp
@@ -139,7 +139,7 @@ class ECCVMRecursiveTests : public ::testing::Test {
         }
 
         // Check that the size of the recursive verifier is consistent with historical expectation
-        uint32_t NUM_GATES_EXPECTED = 216508;
+        uint32_t NUM_GATES_EXPECTED = 216360;
         ASSERT_EQ(static_cast<uint32_t>(outer_circuit.get_num_finalized_gates()), NUM_GATES_EXPECTED)
             << "Ultra-arithmetized ECCVM Recursive verifier gate count changed! Update this value if you are sure this "
                "is expected.";

--- a/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/ultra_recursive_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/ultra_recursive_verifier.test.cpp
@@ -293,7 +293,7 @@ template <typename RecursiveFlavor> class RecursiveVerifierTest : public testing
         }
         // Check the size of the recursive verifier
         if constexpr (std::same_as<RecursiveFlavor, MegaZKRecursiveFlavor_<UltraCircuitBuilder>>) {
-            uint32_t NUM_GATES_EXPECTED = 801953;
+            uint32_t NUM_GATES_EXPECTED = 803778;
             ASSERT_EQ(static_cast<uint32_t>(outer_circuit.get_num_finalized_gates()), NUM_GATES_EXPECTED)
                 << "MegaZKHonk Recursive verifier changed in Ultra gate count! Update this value if you "
                    "are sure this is expected.";

--- a/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/ultra_recursive_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/ultra_recursive_verifier.test.cpp
@@ -293,7 +293,7 @@ template <typename RecursiveFlavor> class RecursiveVerifierTest : public testing
         }
         // Check the size of the recursive verifier
         if constexpr (std::same_as<RecursiveFlavor, MegaZKRecursiveFlavor_<UltraCircuitBuilder>>) {
-            uint32_t NUM_GATES_EXPECTED = 803778;
+            uint32_t NUM_GATES_EXPECTED = 808803;
             ASSERT_EQ(static_cast<uint32_t>(outer_circuit.get_num_finalized_gates()), NUM_GATES_EXPECTED)
                 << "MegaZKHonk Recursive verifier changed in Ultra gate count! Update this value if you "
                    "are sure this is expected.";

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/README.md
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/README.md
@@ -413,22 +413,22 @@ $$
 >
 > $$
 > \begin{aligned}
-> \textcolor{orange}{D_{\textsf{lo}}} &= (2^{Q} - 1)^2 + 2 \cdot (2^{Q} - 1)^2 \cdot 2^L \ < \ 2^{2Q + L + 1}, \\
-> \textcolor{orange}{D_{\textsf{hi}}} &= 3 \cdot (2^{Q} - 1)^2 + 4 \cdot (2^{Q} - 1)^2 \cdot 2^L \ < \ 2^{2Q + L + 2}.
+> \textcolor{orange}{D_{\textsf{lo}}} &= (2^{Q} - 1)^2 + 2 \cdot (2^{Q} - 1)^2 \cdot 2^L \ < \ 2^{2Q + L + 2}, \\
+> \textcolor{orange}{D_{\textsf{hi}}} &= 3 \cdot (2^{Q} - 1)^2 + 4 \cdot (2^{Q} - 1)^2 \cdot 2^L \ < \ 2^{2Q + L + 3}.
 > \end{aligned}
 > $$
 >
 > Clearly, maximum value of $\textcolor{orange}{D_{\textsf{hi}}}$ determines the overall maximum of the two outputs of multiplication:
 >
 > $$
-> \textsf{max}(\textcolor{orange}{D_{\textsf{lo}}}, \textcolor{orange}{D_{\textsf{hi}}}) < 2^{2Q + L + 2}.
+> \textsf{max}(\textcolor{orange}{D_{\textsf{lo}}}, \textcolor{orange}{D_{\textsf{hi}}}) < 2^{2Q + L + 3}.
 > $$
 >
 > This is the maximum value of the resulting limbs of a single product $d = a \cdot b$. Suppose we have $2^k$ such products, then the maximum value of the limbs of the sum of these products would be:
 >
 > $$
 > \begin{aligned}
-> \sum_{i=1}^{2^k} \textcolor{orange}{D_{\textsf{hi}, i}} & \ < \ 2^{k + 2Q + L + 2}.
+> \sum_{i=1}^{2^k} \textcolor{orange}{D_{\textsf{hi}, i}} & \ < \ 2^{k + 2Q + L + 3}.
 > \end{aligned}
 > $$
 >
@@ -436,11 +436,11 @@ $$
 >
 > $$
 > \begin{aligned}
-> 2^{k + 2Q + L + 2} &< n \quad \implies \quad \boxed{Q < \frac{\text{log}_2(n) - L - k - 2}{2}}.
+> 2^{k + 2Q + L + 3} &< n \quad \implies \quad \boxed{Q < \frac{\text{log}_2(n) - L - k - 3}{2}}.
 > \end{aligned}
 > $$
 >
-> This means that the maximum limb size that must be allowed is $Q = \left\lfloor\frac{253.5 - 68 - 10 - 2}{2}\right\rfloor = 86$.
+> This means that the maximum limb size that must be allowed is $Q = \left\lfloor\frac{253.5 - 68 - 10 - 3}{2}\right\rfloor = 86$.
 >
 > .
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
@@ -55,7 +55,7 @@ template <typename Builder, typename T> class bigfield {
         }
         friend std::ostream& operator<<(std::ostream& os, const Limb& a)
         {
-            os << "{ " << a.element << " < " << a.maximum_value << " }";
+            os << "{ " << a.element << " <= " << a.maximum_value << " }";
             return os;
         }
         Limb(const Limb& other) = default;
@@ -326,29 +326,25 @@ template <typename Builder, typename T> class bigfield {
     static constexpr size_t MAXIMUM_SUMMAND_COUNT_LOG = 4;
     static constexpr size_t MAXIMUM_SUMMAND_COUNT = 1 << MAXIMUM_SUMMAND_COUNT_LOG;
 
-    static constexpr uint256_t prime_basis_maximum_limb =
-        modulus_u512.slice(NUM_LIMB_BITS * (NUM_LIMBS - 1), NUM_LIMB_BITS* NUM_LIMBS).lo;
     static constexpr Basis prime_basis{ uint512_t(bb::fr::modulus), bb::fr::modulus.get_msb() + 1 };
     static constexpr Basis binary_basis{ uint512_t(1) << LOG2_BINARY_MODULUS, LOG2_BINARY_MODULUS };
     static constexpr Basis target_basis{ modulus_u512, static_cast<size_t>(modulus_u512.get_msb() + 1) };
     static constexpr bb::fr shift_1 = bb::fr(uint256_t(1) << NUM_LIMB_BITS);
     static constexpr bb::fr shift_2 = bb::fr(uint256_t(1) << (NUM_LIMB_BITS * 2));
     static constexpr bb::fr shift_3 = bb::fr(uint256_t(1) << (NUM_LIMB_BITS * 3));
-    static constexpr bb::fr shift_right_1 = bb::fr(1) / shift_1;
-    static constexpr bb::fr shift_right_2 = bb::fr(1) / shift_2;
-    static constexpr bb::fr negative_prime_modulus_mod_binary_basis = -bb::fr(uint256_t(modulus_u512));
-    static constexpr uint512_t negative_prime_modulus = binary_basis.modulus - target_basis.modulus;
-    static constexpr std::array<uint256_t, NUM_LIMBS> neg_modulus_limbs_u256{
-        negative_prime_modulus.slice(0, NUM_LIMB_BITS).lo,
-        negative_prime_modulus.slice(NUM_LIMB_BITS, NUM_LIMB_BITS * 2).lo,
-        negative_prime_modulus.slice(NUM_LIMB_BITS * 2, NUM_LIMB_BITS * 3).lo,
-        negative_prime_modulus.slice(NUM_LIMB_BITS * 3, NUM_LIMB_BITS * 4).lo,
+    static constexpr bb::fr negative_prime_modulus_mod_native_basis = -bb::fr(uint256_t(target_basis.modulus));
+    static constexpr uint512_t negative_prime_modulus_mod_binary_basis = binary_basis.modulus - target_basis.modulus;
+    static constexpr std::array<uint256_t, NUM_LIMBS> neg_modulus_mod_binary_basis_limbs_u256{
+        negative_prime_modulus_mod_binary_basis.slice(0, NUM_LIMB_BITS).lo,
+        negative_prime_modulus_mod_binary_basis.slice(NUM_LIMB_BITS, NUM_LIMB_BITS * 2).lo,
+        negative_prime_modulus_mod_binary_basis.slice(NUM_LIMB_BITS * 2, NUM_LIMB_BITS * 3).lo,
+        negative_prime_modulus_mod_binary_basis.slice(NUM_LIMB_BITS * 3, NUM_LIMB_BITS * 4).lo,
     };
-    static constexpr std::array<bb::fr, NUM_LIMBS> neg_modulus_limbs{
-        bb::fr(negative_prime_modulus.slice(0, NUM_LIMB_BITS).lo),
-        bb::fr(negative_prime_modulus.slice(NUM_LIMB_BITS, NUM_LIMB_BITS * 2).lo),
-        bb::fr(negative_prime_modulus.slice(NUM_LIMB_BITS * 2, NUM_LIMB_BITS * 3).lo),
-        bb::fr(negative_prime_modulus.slice(NUM_LIMB_BITS * 3, NUM_LIMB_BITS * 4).lo),
+    static constexpr std::array<bb::fr, NUM_LIMBS> neg_modulus_mod_binary_basis_limbs{
+        bb::fr(negative_prime_modulus_mod_binary_basis.slice(0, NUM_LIMB_BITS).lo),
+        bb::fr(negative_prime_modulus_mod_binary_basis.slice(NUM_LIMB_BITS, NUM_LIMB_BITS * 2).lo),
+        bb::fr(negative_prime_modulus_mod_binary_basis.slice(NUM_LIMB_BITS * 2, NUM_LIMB_BITS * 3).lo),
+        bb::fr(negative_prime_modulus_mod_binary_basis.slice(NUM_LIMB_BITS * 3, NUM_LIMB_BITS * 4).lo),
     };
 
     /**
@@ -770,7 +766,7 @@ template <typename Builder, typename T> class bigfield {
         //
         // a * b = q * p + r
         //
-        // where p is the quotient, r is the remainder, and p is the size of the non-native field.
+        // where q is the quotient, r is the remainder, and p is the size of the non-native field.
         // The CRT requires that we check that the equation:
         // (a) holds modulo the size of the native field n,
         // (b) holds modulo the size of the bigger ring 2^t,
@@ -787,7 +783,7 @@ template <typename Builder, typename T> class bigfield {
         // Note: We use a further safer bound of 2^((t + m - 1) / 2). We use -1 to stay safer,
         // because it provides additional space to avoid the overflow, but get_msb() by itself should be enough.
         uint64_t maximum_product_bits = maximum_product.get_msb() - 1;
-        return (uint512_t(1) << (maximum_product_bits >> 1));
+        return (uint512_t(1) << (maximum_product_bits >> 1)) - uint512_t(1);
     }
 
     // If we encounter this maximum value of a bigfield we stop execution
@@ -925,7 +921,7 @@ template <typename Builder, typename T> class bigfield {
     // If the logarithm of the maximum value of a limb is more than this, we need to reduce.
     // We allow an element to be added to itself 10 times, so we allow the limb to grow by 10 bits.
     // Number 10 is arbitrary, there's no actual usecase for adding 1024 elements together.
-    static constexpr uint64_t MAX_UNREDUCED_LIMB_BITS = NUM_LIMB_BITS + 10;
+    static constexpr uint64_t MAX_UNREDUCED_LIMB_BITS = NUM_LIMB_BITS + MAX_ADDITION_LOG;
 
     // If we reach this size of a limb, we stop execution (as safety measure). This should never reach during addition
     // as we would reduce the limbs before they reach this size.

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
@@ -568,7 +568,7 @@ template <typename Builder, typename T> class bigfield {
                              const std::vector<bigfield>& mul_right,
                              const bigfield& divisor,
                              const std::vector<bigfield>& to_sub,
-                             bool enable_divisor_nz_check = false);
+                             bool enable_divisor_nz_check = true);
 
     static bigfield sum(const std::vector<bigfield>& terms);
     static bigfield internal_div(const std::vector<bigfield>& numerators,

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
@@ -911,12 +911,12 @@ template <typename Builder, typename T> class bigfield {
     //           = 2^k * (3 * 2^2Q) + 2^k * 2^L * (4 * 2^2Q)
     //           < 2^k * (2^L + 1) * (4 * 2^2Q)
     //           < n
-    // ==> 2^k * 2^L * 2^(2Q + 2) < n
-    // ==> 2Q + 2 < (log(n) - k - L)
-    // ==> Q < ((log(n) - k - L) - 2) / 2
+    // ==> 2^k * 2^L * 2^(2Q + 3) < n
+    // ==> 2Q + 3 < (log(n) - k - L)
+    // ==> Q < ((log(n) - k - L) - 3) / 2
     //
     static constexpr uint64_t MAXIMUM_LIMB_SIZE_THAT_WOULDNT_OVERFLOW =
-        (bb::fr::modulus.get_msb() - MAX_ADDITION_LOG - NUM_LIMB_BITS - 2) / 2;
+        (bb::fr::modulus.get_msb() - MAX_ADDITION_LOG - NUM_LIMB_BITS - 3) / 2;
 
     // If the logarithm of the maximum value of a limb is more than this, we need to reduce.
     // We allow an element to be added to itself 10 times, so we allow the limb to grow by 10 bits.

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
@@ -932,7 +932,10 @@ template <typename Builder, typename T> class bigfield {
     static constexpr uint64_t PROHIBITED_LIMB_BITS = MAX_UNREDUCED_LIMB_BITS + 5;
 
     // If we encounter this maximum value of a bigfield we need to reduce it.
-    static constexpr uint256_t get_maximum_unreduced_limb_value() { return uint256_t(1) << MAX_UNREDUCED_LIMB_BITS; }
+    static constexpr uint256_t get_maximum_unreduced_limb_value()
+    {
+        return ((uint256_t(1) << MAX_UNREDUCED_LIMB_BITS) - uint256_t(1));
+    }
 
     // If we encounter this maximum value of a limb we stop execution
     static constexpr uint256_t get_prohibited_limb_value() { return uint256_t(1) << PROHIBITED_LIMB_BITS; }

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_edge_cases.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_edge_cases.test.cpp
@@ -484,6 +484,20 @@ template <typename BigField> class stdlib_bigfield_edge_cases : public testing::
             EXPECT_EQ(builder.err(), "bigfield: prime limb identity failed");
         }
         {
+            // numerator is empty, denominator is witness
+            fq_ct zero = fq_ct::create_from_u512_as_witness(&builder, uint512_t(0), true);
+
+            // Division by zero should trigger an assertion failure
+            fq_ct output = fq_ct::div_check_denominator_nonzero({}, zero);
+
+            // outputs are irrelevant
+            EXPECT_EQ(output.get_value(), 0);
+
+            bool result = CircuitChecker::check(builder);
+            EXPECT_EQ(result, false);
+            EXPECT_EQ(builder.err(), "bigfield: prime limb diff is zero, but expected non-zero");
+        }
+        {
             // numerator is witness, denominator is constant
             [[maybe_unused]] auto [a_native, a_ct] = get_random_witness(&builder, false);
             fq_ct constant_zero = fq_ct(&builder, uint256_t(0));
@@ -501,6 +515,14 @@ template <typename BigField> class stdlib_bigfield_edge_cases : public testing::
 #ifndef NDEBUG
             fq_ct constant_zero = fq_ct(&builder, uint256_t(0));
             EXPECT_THROW_OR_ABORT(a_ct / constant_zero, "bigfield: division by zero in constant division");
+#endif
+        }
+        {
+            // numerator is empty, denominator is constant
+#ifndef NDEBUG
+            fq_ct constant_zero = fq_ct(&builder, uint256_t(0));
+            EXPECT_THROW_OR_ABORT(fq_ct::div_check_denominator_nonzero({}, constant_zero),
+                                  "bigfield: prime limb diff is zero, but expected non-zero");
 #endif
         }
     }

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_edge_cases.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_edge_cases.test.cpp
@@ -490,7 +490,7 @@ template <typename BigField> class stdlib_bigfield_edge_cases : public testing::
 
 #ifndef NDEBUG
             // In debug mode, we should hit an assertion failure
-            EXPECT_DEATH(a_ct / constant_zero, "field_t::assert_is_not_zero");
+            EXPECT_THROW_OR_ABORT(a_ct / constant_zero, "bigfield: prime limb diff is zero, but expected non-zero");
 #endif
         }
         {
@@ -500,7 +500,7 @@ template <typename BigField> class stdlib_bigfield_edge_cases : public testing::
 
 #ifndef NDEBUG
             fq_ct constant_zero = fq_ct(&builder, uint256_t(0));
-            EXPECT_DEATH(a_ct / constant_zero, "bigfield: division by zero in constant division");
+            EXPECT_THROW_OR_ABORT(a_ct / constant_zero, "bigfield: division by zero in constant division");
 #endif
         }
     }

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_edge_cases.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_edge_cases.test.cpp
@@ -444,6 +444,65 @@ template <typename BigField> class stdlib_bigfield_edge_cases : public testing::
         bool result = CircuitChecker::check(builder);
         EXPECT_EQ(result, true);
     }
+
+    static void test_divide_by_zero_fails()
+    {
+        Builder builder = Builder();
+        {
+            // numerator and denominator both are witnesses
+            auto [a_native, a_ct] = get_random_witness(&builder, false);
+            fq_ct zero = fq_ct::create_from_u512_as_witness(&builder, uint512_t(0), true);
+            fq_ct zero_modulus = fq_ct::create_from_u512_as_witness(&builder, uint512_t(fq_ct::modulus), true);
+
+            // Division by zero should trigger an assertion failure
+            fq_ct output = a_ct / zero;
+            fq_ct output_modulus = a_ct / zero_modulus;
+
+            // outputs are irrelevant
+            EXPECT_EQ(output.get_value(), 0);
+            EXPECT_EQ(output_modulus.get_value(), 0);
+
+            bool result = CircuitChecker::check(builder);
+            EXPECT_EQ(result, false);
+            EXPECT_EQ(builder.err(), "bigfield: prime limb identity failed");
+        }
+        {
+            // numerator is constant, denominator is witness
+            fq_native a_native = fq_native::random_element();
+            fq_ct a_ct(&builder, uint256_t(a_native));
+            fq_ct zero = fq_ct::create_from_u512_as_witness(&builder, uint512_t(0), true);
+
+            // Division by zero should trigger an assertion failure
+            fq_ct output = a_ct / zero;
+
+            // outputs are irrelevant
+            EXPECT_EQ(output.get_value(), 0);
+
+            bool result = CircuitChecker::check(builder);
+            EXPECT_EQ(result, false);
+            EXPECT_EQ(builder.err(), "bigfield: prime limb identity failed");
+        }
+        {
+            // numerator is witness, denominator is constant
+            [[maybe_unused]] auto [a_native, a_ct] = get_random_witness(&builder, false);
+            fq_ct constant_zero = fq_ct(&builder, uint256_t(0));
+
+#ifndef NDEBUG
+            // In debug mode, we should hit an assertion failure
+            EXPECT_DEATH(a_ct / constant_zero, "field_t::assert_is_not_zero");
+#endif
+        }
+        {
+            // numerator and denominator both are constant
+            fq_native a_native = fq_native::random_element();
+            fq_ct a_ct(&builder, uint256_t(a_native));
+
+#ifndef NDEBUG
+            fq_ct constant_zero = fq_ct(&builder, uint256_t(0));
+            EXPECT_DEATH(a_ct / constant_zero, "bigfield: division by zero in constant division");
+#endif
+        }
+    }
 };
 
 // Define types for which the above tests will be constructed.
@@ -511,4 +570,9 @@ TYPED_TEST(stdlib_bigfield_edge_cases, assert_less_than)
 TYPED_TEST(stdlib_bigfield_edge_cases, assert_equal_edge_case)
 {
     TestFixture::test_assert_equal_edge_case();
+}
+
+TYPED_TEST(stdlib_bigfield_edge_cases, divide_by_zero_fails)
+{
+    TestFixture::test_divide_by_zero_fails();
 }

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_edge_cases.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_edge_cases.test.cpp
@@ -80,7 +80,7 @@ template <typename BigField> class stdlib_bigfield_edge_cases : public testing::
         uint512_t(fq_ct::modulus),                // p
     };
 
-    inline static const std::array<uint512_t, 9> values_larger_than_bigfield = {
+    inline static const std::array<uint512_t, 10> values_larger_than_bigfield = {
         uint512_t(fq_ct::modulus) + uint512_t(1),
         uint512_t(fq_ct::modulus) + uint512_t(fr::modulus),
         (uint512_t(1) << 256) - 1,
@@ -89,6 +89,7 @@ template <typename BigField> class stdlib_bigfield_edge_cases : public testing::
         uint512_t(fq_ct::get_maximum_unreduced_value()) - 1,
         uint512_t(fq_ct::get_maximum_unreduced_value()),
         uint512_t(fq_ct::get_maximum_unreduced_value()) + 1,
+        uint512_t(fq_ct::get_maximum_unreduced_value()) + 2,
         (uint512_t(1) << (stdlib::NUM_LIMB_BITS_IN_FIELD_SIMULATION * 4)) - 1,
     };
 
@@ -135,7 +136,7 @@ template <typename BigField> class stdlib_bigfield_edge_cases : public testing::
 
         // Check that the combined max value is greater than the maximum unreduced bigfield value
         EXPECT_GT(combined_a.get_maximum_value(),      // 2^68 * 2^68 * 2^68 * 2^61 = 2^265
-                  fq_ct::get_maximum_unreduced_value() // sqrt(2^272 * |Fr|) ≈ 2^(263) or 2^(264)
+                  fq_ct::get_maximum_unreduced_value() // sqrt(2^272 * |Fr|) ≈ (2^(263) - 1) or (2^(264) - 1)
         );
 
         // Squaring op must perform self-reduction
@@ -144,7 +145,7 @@ template <typename BigField> class stdlib_bigfield_edge_cases : public testing::
 
         // Check that original combined value is now reduced
         EXPECT_EQ(combined_a.get_value() < reduction_upper_bound, true); // reduced value < 2^s
-        EXPECT_EQ(combined_a.get_maximum_value() < fq_ct::get_maximum_unreduced_value(), true);
+        EXPECT_EQ(combined_a.get_maximum_value() <= fq_ct::get_maximum_unreduced_value(), true);
 
         bool result = CircuitChecker::check(builder);
         EXPECT_EQ(result, true);
@@ -176,14 +177,14 @@ template <typename BigField> class stdlib_bigfield_edge_cases : public testing::
             (uint256_t(1) << fq_ct::MAX_UNREDUCED_LIMB_BITS) + 1000; // > 2^78
 
         // Check that the combined max value is less than the maximum unreduced bigfield value
-        EXPECT_EQ(combined_a.get_maximum_value() < fq_ct::get_maximum_unreduced_value(), true);
+        EXPECT_EQ(combined_a.get_maximum_value() <= fq_ct::get_maximum_unreduced_value(), true);
 
         // Perform a squaring which should trigger reduction
         combined_a.sqr();
 
         // Check that the original combined value is now reduced
         EXPECT_EQ(combined_a.get_value() < reduction_upper_bound, true);
-        EXPECT_EQ(combined_a.get_maximum_value() < fq_ct::get_maximum_unreduced_value(), true);
+        EXPECT_EQ(combined_a.get_maximum_value() <= fq_ct::get_maximum_unreduced_value(), true);
 
         // Check the circuit is valid
         bool result = CircuitChecker::check(builder);

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_edge_cases.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_edge_cases.test.cpp
@@ -126,11 +126,11 @@ template <typename BigField> class stdlib_bigfield_edge_cases : public testing::
         fq_ct combined_a = fq_ct::unsafe_construct_from_limbs(limb_0, limb_1, limb_2, limb_3, true);
         combined_a.binary_basis_limbs[3].maximum_value = other_mask;
 
-        // Check that individual limbs are less than maximum unreduced limb value
-        const bool limbs_less_than_max = (limb_0_native < fq_ct::get_maximum_unreduced_limb_value()) &&
-                                         (limb_1_native < fq_ct::get_maximum_unreduced_limb_value()) &&
-                                         (limb_2_native < fq_ct::get_maximum_unreduced_limb_value()) &&
-                                         (limb_3_native < fq_ct::get_maximum_unreduced_limb_value());
+        // Check that individual limbs are ≤ than maximum unreduced limb value
+        const bool limbs_less_than_max = (limb_0_native <= fq_ct::get_maximum_unreduced_limb_value()) &&
+                                         (limb_1_native <= fq_ct::get_maximum_unreduced_limb_value()) &&
+                                         (limb_2_native <= fq_ct::get_maximum_unreduced_limb_value()) &&
+                                         (limb_3_native <= fq_ct::get_maximum_unreduced_limb_value());
         EXPECT_EQ(limbs_less_than_max, true);
 
         // Check that the combined max value is greater than the maximum unreduced bigfield value

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
@@ -2104,7 +2104,24 @@ void bigfield<Builder, T>::unsafe_evaluate_multiply_add(const bigfield& input_le
         max_remainders_lo += remainder.binary_basis_limbs[0].maximum_value +
                              (remainder.binary_basis_limbs[1].maximum_value << NUM_LIMB_BITS);
     }
-    uint256_t borrow_lo_value = max_remainders_lo >> (2 * NUM_LIMB_BITS);
+
+    // While performing the subtraction of remainder r as:
+    //
+    // (a * b + q * p') - (r)
+    //
+    // we want to ensure that the lower limbs do not underflow. So we add a borrow value
+    // to the lower limbs and subtract it from the higher limbs. Naturally, such a borrow value
+    // must be a multiple of 2^2L (where L = NUM_LIMB_BITS). Let borrow_lo_value be the value
+    // borrowed from the hi limbs, then we must have:
+    //
+    // borrow_lo_value * 2^(2L) >= max_remainders_lo
+    //
+    // Thus, we can compute the minimum borrow_lo_value as:
+    //
+    // borrow_lo_value = ⌈ max_remainders_lo / 2^(2L) ⌉
+    //
+    uint256_t borrow_lo_value =
+        (max_remainders_lo + ((uint256_t(1) << (2 * NUM_LIMB_BITS)) - 1)) >> (2 * NUM_LIMB_BITS);
     field_t<Builder> borrow_lo(ctx, bb::fr(borrow_lo_value));
 
     uint512_t max_a0(0);
@@ -2348,7 +2365,24 @@ void bigfield<Builder, T>::unsafe_evaluate_multiple_multiply_add(const std::vect
         max_remainders_lo += remainder.binary_basis_limbs[0].maximum_value +
                              (remainder.binary_basis_limbs[1].maximum_value << NUM_LIMB_BITS);
     }
-    uint256_t borrow_lo_value = max_remainders_lo >> (2 * NUM_LIMB_BITS);
+
+    // While performing the subtraction of (sum of) remainder(s) as:
+    //
+    // (Σi ai * bi + q * p') - (Σj rj)
+    //
+    // we want to ensure that the lower limbs do not underflow. So we add a borrow value
+    // to the lower limbs and subtract it from the higher limbs. Naturally, such a borrow value
+    // must be a multiple of 2^2L (where L = NUM_LIMB_BITS). Let borrow_lo_value be the value
+    // borrowed from the hi limbs, then we must have:
+    //
+    // borrow_lo_value * 2^(2L) >= max_remainders_lo
+    //
+    // Thus, we can compute the minimum borrow_lo_value as:
+    //
+    // borrow_lo_value = ⌈ max_remainders_lo / 2^(2L) ⌉
+    //
+    uint256_t borrow_lo_value =
+        (max_remainders_lo + ((uint256_t(1) << (2 * NUM_LIMB_BITS)) - 1)) >> (2 * NUM_LIMB_BITS);
     field_t<Builder> borrow_lo(ctx, bb::fr(borrow_lo_value));
 
     // Compute the maximum value of the quotient times modulus.

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
@@ -2139,6 +2139,9 @@ void bigfield<Builder, T>::unsafe_evaluate_multiply_add(const bigfield& input_le
     uint64_t max_lo_bits = (max_lo.get_msb() + 1);
     uint64_t max_hi_bits = max_hi.get_msb() + 1;
 
+    ASSERT(max_lo_bits > (2 * NUM_LIMB_BITS));
+    ASSERT(max_hi_bits > (2 * NUM_LIMB_BITS));
+
     uint64_t carry_lo_msb = max_lo_bits - (2 * NUM_LIMB_BITS);
     uint64_t carry_hi_msb = max_hi_bits - (2 * NUM_LIMB_BITS);
 
@@ -2581,6 +2584,9 @@ void bigfield<Builder, T>::unsafe_evaluate_multiple_multiply_add(const std::vect
 
     field_t lo = field_t<Builder>::from_witness_index(ctx, lo_1_idx) + borrow_lo;
     field_t hi = field_t<Builder>::from_witness_index(ctx, hi_1_idx);
+
+    ASSERT(max_lo_bits > (2 * NUM_LIMB_BITS));
+    ASSERT(max_hi_bits > (2 * NUM_LIMB_BITS));
 
     uint64_t carry_lo_msb = max_lo_bits - (2 * NUM_LIMB_BITS);
     uint64_t carry_hi_msb = max_hi_bits - (2 * NUM_LIMB_BITS);

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
@@ -838,6 +838,10 @@ bigfield<Builder, T> bigfield<Builder, T>::internal_div(const std::vector<bigfie
     bigfield inverse;
     bigfield quotient;
     if (numerator_constant && denominator.is_constant()) {
+        if (check_for_zero) {
+            // We want to avoid division by zero in the constant case
+            ASSERT(denominator.get_value() != uint512_t(0), "bigfield: division by zero in constant division");
+        }
         inverse = bigfield(ctx, uint256_t(inverse_value));
         inverse.set_origin_tag(tag);
         return inverse;

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
@@ -1983,7 +1983,7 @@ template <typename Builder, typename T> void bigfield<Builder, T>::assert_is_not
         diff = diff * (base_diff + prime_basis_accumulator);
         prime_basis_accumulator += prime_basis;
     }
-    diff.assert_is_not_zero();
+    diff.assert_is_not_zero("bigfield: prime limb diff is zero, but expected non-zero");
 }
 
 // We reduce an element's mod 2^t representation (t=4*NUM_LIMB_BITS) to size 2^s for smallest s with 2^s>p

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
@@ -784,6 +784,10 @@ bigfield<Builder, T> bigfield<Builder, T>::internal_div(const std::vector<bigfie
 {
     BB_ASSERT_LT(numerators.size(), MAXIMUM_SUMMAND_COUNT);
     if (numerators.empty()) {
+        if (check_for_zero) {
+            // We want to avoid division by zero in the constant case
+            ASSERT(denominator.get_value() != uint512_t(0), "bigfield: division by zero in constant division");
+        }
         return bigfield<Builder, T>(denominator.get_context(), uint256_t(0));
     }
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
@@ -2264,14 +2264,8 @@ void bigfield<Builder, T>::unsafe_evaluate_multiply_add(const bigfield& input_le
                                        static_cast<size_t>(carry_hi_msb),
                                        static_cast<size_t>(carry_lo_msb));
     } else {
-        ctx->decompose_into_default_range(hi.get_normalized_witness_index(),
-                                          carry_hi_msb,
-                                          Builder::DEFAULT_PLOOKUP_RANGE_BITNUM,
-                                          "bigfield: carry_hi too large");
-        ctx->decompose_into_default_range(lo.get_normalized_witness_index(),
-                                          carry_lo_msb,
-                                          Builder::DEFAULT_PLOOKUP_RANGE_BITNUM,
-                                          "bigfield: carry_lo too large");
+        hi.create_range_constraint(carry_hi_msb, "bigfield: carry_hi too large");
+        lo.create_range_constraint(carry_lo_msb, "bigfield: carry_lo too large");
     }
 }
 
@@ -2588,14 +2582,8 @@ void bigfield<Builder, T>::unsafe_evaluate_multiple_multiply_add(const std::vect
                                        static_cast<size_t>(carry_hi_msb),
                                        static_cast<size_t>(carry_lo_msb));
     } else {
-        ctx->decompose_into_default_range(hi.get_normalized_witness_index(),
-                                          carry_hi_msb,
-                                          Builder::DEFAULT_PLOOKUP_RANGE_BITNUM,
-                                          "bigfield: carry_hi too large");
-        ctx->decompose_into_default_range(lo.get_normalized_witness_index(),
-                                          carry_lo_msb,
-                                          Builder::DEFAULT_PLOOKUP_RANGE_BITNUM,
-                                          "bigfield: carry_hi too large");
+        hi.create_range_constraint(carry_hi_msb, "bigfield: carry_hi too large");
+        lo.create_range_constraint(carry_lo_msb, "bigfield: carry_lo too large");
     }
 }
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
@@ -785,8 +785,8 @@ bigfield<Builder, T> bigfield<Builder, T>::internal_div(const std::vector<bigfie
     BB_ASSERT_LT(numerators.size(), MAXIMUM_SUMMAND_COUNT);
     if (numerators.empty()) {
         if (check_for_zero) {
-            // We want to avoid division by zero in the constant case
-            ASSERT(denominator.get_value() != uint512_t(0), "bigfield: division by zero in constant division");
+            // We do not want to trigger division by zero in the empty sum case
+            denominator.assert_is_not_equal(zero());
         }
         return bigfield<Builder, T>(denominator.get_context(), uint256_t(0));
     }

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
@@ -2264,8 +2264,8 @@ void bigfield<Builder, T>::unsafe_evaluate_multiply_add(const bigfield& input_le
                                        static_cast<size_t>(carry_hi_msb),
                                        static_cast<size_t>(carry_lo_msb));
     } else {
-        hi.create_range_constraint(carry_hi_msb, "bigfield: carry_hi too large");
-        lo.create_range_constraint(carry_lo_msb, "bigfield: carry_lo too large");
+        hi.create_range_constraint(static_cast<size_t>(carry_hi_msb), "bigfield: carry_hi too large");
+        lo.create_range_constraint(static_cast<size_t>(carry_lo_msb), "bigfield: carry_lo too large");
     }
 }
 
@@ -2582,8 +2582,8 @@ void bigfield<Builder, T>::unsafe_evaluate_multiple_multiply_add(const std::vect
                                        static_cast<size_t>(carry_hi_msb),
                                        static_cast<size_t>(carry_lo_msb));
     } else {
-        hi.create_range_constraint(carry_hi_msb, "bigfield: carry_hi too large");
-        lo.create_range_constraint(carry_lo_msb, "bigfield: carry_lo too large");
+        hi.create_range_constraint(static_cast<size_t>(carry_hi_msb), "bigfield: carry_hi too large");
+        lo.create_range_constraint(static_cast<size_t>(carry_lo_msb), "bigfield: carry_lo too large");
     }
 }
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
@@ -332,7 +332,7 @@ bigfield<Builder, T> bigfield<Builder, T>::add_to_lower_limb(const field_t<Build
     // If the original value is constant, we have to reinitialize the higher limbs to be witnesses when adding a witness
     if (is_constant()) {
         auto context = other.context;
-        for (size_t i = 1; i < 4; i++) {
+        for (size_t i = 1; i < NUM_LIMBS; i++) {
             // Construct a witness element from the original constant limb
             result.binary_basis_limbs[i] =
                 Limb(field_t<Builder>::from_witness(context, binary_basis_limbs[i].element.get_value()),
@@ -393,18 +393,8 @@ bigfield<Builder, T> bigfield<Builder, T>::operator+(const bigfield& other) cons
     bool both_prime_limb_multiplicative_constant_one =
         (prime_basis_limb.multiplicative_constant == 1 && other.prime_basis_limb.multiplicative_constant == 1);
     if (both_prime_limb_multiplicative_constant_one && both_witness) {
-        bool limbconst = binary_basis_limbs[0].element.is_constant();
-        limbconst = limbconst || binary_basis_limbs[1].element.is_constant();
-        limbconst = limbconst || binary_basis_limbs[2].element.is_constant();
-        limbconst = limbconst || binary_basis_limbs[3].element.is_constant();
-        limbconst = limbconst || prime_basis_limb.is_constant();
-        limbconst = limbconst || other.binary_basis_limbs[0].element.is_constant();
-        limbconst = limbconst || other.binary_basis_limbs[1].element.is_constant();
-        limbconst = limbconst || other.binary_basis_limbs[2].element.is_constant();
-        limbconst = limbconst || other.binary_basis_limbs[3].element.is_constant();
-        limbconst = limbconst || other.prime_basis_limb.is_constant();
-        limbconst =
-            limbconst ||
+        bool limbconst =
+            is_constant() || other.is_constant() ||
             (prime_basis_limb.get_witness_index() ==
              other.prime_basis_limb.get_witness_index()); // We are comparing if the bigfield elements are exactly the
                                                           // same object, so we compare the unnormalized witness indices
@@ -640,20 +630,12 @@ bigfield<Builder, T> bigfield<Builder, T>::operator-(const bigfield& other) cons
     bool both_prime_limb_multiplicative_constant_one =
         (prime_basis_limb.multiplicative_constant == 1 && other.prime_basis_limb.multiplicative_constant == 1);
     if (both_prime_limb_multiplicative_constant_one && both_witness) {
-        bool limbconst = result.binary_basis_limbs[0].element.is_constant();
-        limbconst = limbconst || result.binary_basis_limbs[1].element.is_constant();
-        limbconst = limbconst || result.binary_basis_limbs[2].element.is_constant();
-        limbconst = limbconst || result.binary_basis_limbs[3].element.is_constant();
-        limbconst = limbconst || prime_basis_limb.is_constant();
-        limbconst = limbconst || other.binary_basis_limbs[0].element.is_constant();
-        limbconst = limbconst || other.binary_basis_limbs[1].element.is_constant();
-        limbconst = limbconst || other.binary_basis_limbs[2].element.is_constant();
-        limbconst = limbconst || other.binary_basis_limbs[3].element.is_constant();
-        limbconst = limbconst || other.prime_basis_limb.is_constant();
-        limbconst = limbconst ||
-                    (prime_basis_limb.witness_index ==
-                     other.prime_basis_limb.witness_index); // We are checking if this is and identical element, so we
-                                                            // need to compare the actual indices, not normalized ones
+        bool limbconst =
+            is_constant() || other.is_constant() ||
+            (prime_basis_limb.get_witness_index() ==
+             other.prime_basis_limb.get_witness_index()); // We are checking if `this` and `other` are identical, so we
+                                                          // need to compare the actual indices, not normalized ones
+
         if (!limbconst) {
             // Extract witness indices and multiplicative constants for binary basis limbs
             std::array<std::pair<uint32_t, bb::fr>, NUM_LIMBS> x_scaled;
@@ -1963,9 +1945,9 @@ template <typename Builder, typename T> void bigfield<Builder, T>::assert_equal(
 // mod r) but different mod p, you can't construct a proof. The chances of an honest prover running afoul of this
 // condition are extremely small (TODO: compute probability) Note also that the number of constraints depends on how
 // much the values have overflown beyond p e.g. due to an addition chain The function is based on the following.
-// Suppose a-b = 0 mod p. Then a-b = k*p for k in a range [-R,L] such that L*p>= a, R*p>=b. And also a-b = k*p mod r
-// for such k. Thus we can verify a-b is non-zero mod p by taking the product of such values (a-b-kp) and showing
-// it's non-zero mod r
+// Suppose a-b = 0 mod p. Then a-b = k*p for k in a range [-R,L] for largest L and R such that L*p>= a, R*p>=b.
+// And also a-b = k*p mod r for such k. Thus we can verify a-b is non-zero mod p by taking the product of such values
+// (a-b-kp) and showing it's non-zero mod r
 template <typename Builder, typename T> void bigfield<Builder, T>::assert_is_not_equal(const bigfield& other) const
 {
     // Why would we use this for 2 constants? Turns out, in biggroup
@@ -2094,8 +2076,8 @@ void bigfield<Builder, T>::unsafe_evaluate_multiply_add(const bigfield& input_le
     // Compute the maximum value of the product of the quotient and neg_modulus: max(q * p')
     uint512_t max_q_neg_p_lo(0);
     uint512_t max_q_neg_p_hi(0);
-    std::tie(max_q_neg_p_lo, max_q_neg_p_hi) =
-        compute_partial_schoolbook_multiplication(neg_modulus_limbs_u256, quotient.get_binary_basis_limb_maximums());
+    std::tie(max_q_neg_p_lo, max_q_neg_p_hi) = compute_partial_schoolbook_multiplication(
+        neg_modulus_mod_binary_basis_limbs_u256, quotient.get_binary_basis_limb_maximums());
 
     // Compute the maximum value that needs to be borrowed from the hi limbs to the lo limb.
     // Check the README for the explanation of the borrow.
@@ -2256,16 +2238,18 @@ void bigfield<Builder, T>::unsafe_evaluate_multiply_add(const bigfield& input_le
             remainder_limbs[2].get_normalized_witness_index(),
             remainder_limbs[3].get_normalized_witness_index(),
         },
-        { neg_modulus_limbs[0], neg_modulus_limbs[1], neg_modulus_limbs[2], neg_modulus_limbs[3] },
+        { neg_modulus_mod_binary_basis_limbs[0],
+          neg_modulus_mod_binary_basis_limbs[1],
+          neg_modulus_mod_binary_basis_limbs[2],
+          neg_modulus_mod_binary_basis_limbs[3] },
     };
 
     // N.B. this method DOES NOT evaluate the prime field component of the non-native field mul
     const auto [lo_idx, hi_idx] = ctx->evaluate_non_native_field_multiplication(witnesses);
 
-    bb::fr neg_prime = -bb::fr(uint256_t(target_basis.modulus));
     field_t<Builder>::evaluate_polynomial_identity(left.prime_basis_limb,
                                                    to_mul.prime_basis_limb,
-                                                   quotient.prime_basis_limb * neg_prime,
+                                                   quotient.prime_basis_limb * negative_prime_modulus_mod_native_basis,
                                                    -remainder_prime_limb,
                                                    "bigfield: prime limb identity failed");
 
@@ -2303,8 +2287,6 @@ void bigfield<Builder, T>::unsafe_evaluate_multiple_multiply_add(const std::vect
     BB_ASSERT_LTE(to_add.size(), MAXIMUM_SUMMAND_COUNT);
     BB_ASSERT_LTE(input_remainders.size(), MAXIMUM_SUMMAND_COUNT);
 
-    BB_ASSERT_EQ(input_left.size(), input_right.size());
-    BB_ASSERT_LT(input_left.size(), 1024U);
     // Sanity checks
     bool is_left_constant = true;
     for (auto& el : input_left) {
@@ -2354,9 +2336,8 @@ void bigfield<Builder, T>::unsafe_evaluate_multiple_multiply_add(const std::vect
     /**
      * Step 1: Compute the maximum potential value of our product limbs
      *
-     * max_lo = maximum value of limb products that span the range 0 - 2^{3t}
-     * max_hi = maximum value of limb products that span the range 2^{2t} - 2^{5t}
-     * (t = NUM_LIMB_BITS)
+     * max_lo = maximum value of limb products that span the range 0 - 2^{3L}
+     * max_hi = maximum value of limb products that span the range 2^{2L} - 2^{5L}
      **/
     uint512_t max_lo = 0;
     uint512_t max_hi = 0;
@@ -2389,8 +2370,8 @@ void bigfield<Builder, T>::unsafe_evaluate_multiple_multiply_add(const std::vect
     field_t<Builder> borrow_lo(ctx, bb::fr(borrow_lo_value));
 
     // Compute the maximum value of the quotient times modulus.
-    const auto [max_q_neg_p_lo, max_q_neg_p_hi] =
-        compute_partial_schoolbook_multiplication(neg_modulus_limbs_u256, quotient.get_binary_basis_limb_maximums());
+    const auto [max_q_neg_p_lo, max_q_neg_p_hi] = compute_partial_schoolbook_multiplication(
+        neg_modulus_mod_binary_basis_limbs_u256, quotient.get_binary_basis_limb_maximums());
 
     // update max_lo, max_hi with quotient limb product terms.
     max_lo += max_q_neg_p_lo + max_remainders_lo;
@@ -2569,16 +2550,17 @@ void bigfield<Builder, T>::unsafe_evaluate_multiple_multiply_add(const std::vect
             remainder_limbs[2].get_normalized_witness_index(),
             remainder_limbs[3].get_normalized_witness_index(),
         },
-        { neg_modulus_limbs[0], neg_modulus_limbs[1], neg_modulus_limbs[2], neg_modulus_limbs[3] },
+        { neg_modulus_mod_binary_basis_limbs[0],
+          neg_modulus_mod_binary_basis_limbs[1],
+          neg_modulus_mod_binary_basis_limbs[2],
+          neg_modulus_mod_binary_basis_limbs[3] },
     };
 
     const auto [lo_1_idx, hi_1_idx] = ctx->evaluate_non_native_field_multiplication(witnesses);
 
-    bb::fr neg_prime = -bb::fr(uint256_t(target_basis.modulus));
-
     field_t<Builder>::evaluate_polynomial_identity(left[0].prime_basis_limb,
                                                    right[0].prime_basis_limb,
-                                                   quotient.prime_basis_limb * neg_prime,
+                                                   quotient.prime_basis_limb * negative_prime_modulus_mod_native_basis,
                                                    -remainder_prime_limb,
                                                    "bigfield: prime limb identity failed");
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_impl.hpp
@@ -273,12 +273,13 @@ template <typename C, class Fq, class Fr, class G> element<C, Fq, Fr, G> element
     Fq two_x = x + x;
     if constexpr (G::has_a) {
         Fq a(get_context(), uint256_t(G::curve_a));
-        Fq neg_lambda = Fq::msub_div({ x }, { (two_x + x) }, (y + y), { a });
+        Fq neg_lambda = Fq::msub_div({ x }, { (two_x + x) }, (y + y), { a }, /*enable_divisor_nz_check*/ false);
         Fq x_3 = neg_lambda.sqradd({ -(two_x) });
         Fq y_3 = neg_lambda.madd(x_3 - x, { -y });
         return element(x_3, y_3);
     }
-    Fq neg_lambda = Fq::msub_div({ x }, { (two_x + x) }, (y + y), {});
+    // TODO(): handle y = 0 case.
+    Fq neg_lambda = Fq::msub_div({ x }, { (two_x + x) }, (y + y), {}, /*enable_divisor_nz_check*/ false);
     Fq x_3 = neg_lambda.sqradd({ -(two_x) });
     Fq y_3 = neg_lambda.madd(x_3 - x, { -y });
     element result = element(x_3, y_3);
@@ -350,7 +351,12 @@ typename element<C, Fq, Fr, G>::chain_add_accumulator element<C, Fq, Fr, G>::cha
      * Requires only 2 non-native field reductions
      **/
     auto& x2 = acc.x3_prev;
-    const auto lambda = Fq::msub_div({ acc.lambda_prev }, { (x2 - acc.x1_prev) }, (x2 - p1.x), { acc.y1_prev, p1.y });
+    const auto lambda =
+        Fq::msub_div({ acc.lambda_prev },
+                     { (x2 - acc.x1_prev) },
+                     (x2 - p1.x),
+                     { acc.y1_prev, p1.y },
+                     /*enable_divisor_nz_check*/ false); // divisor is non-zero as x2 != p1.x is enforced
     const auto x3 = lambda.sqradd({ -x2, -p1.x });
 
     chain_add_accumulator output;
@@ -471,8 +477,11 @@ element<C, Fq, Fr, G> element<C, Fq, Fr, G>::montgomery_ladder(const chain_add_a
     // => lambda = - (lambda_prev * (x2 - x1_prev) + y1_prev + y1) / (x2 - x1)
 
     auto& x2 = to_add.x3_prev;
-    const auto lambda =
-        Fq::msub_div({ to_add.lambda_prev }, { (x2 - to_add.x1_prev) }, (x2 - x), { to_add.y1_prev, y });
+    const auto lambda = Fq::msub_div({ to_add.lambda_prev },
+                                     { (x2 - to_add.x1_prev) },
+                                     (x2 - x),
+                                     { to_add.y1_prev, y },
+                                     /*enable_divisor_nz_check*/ false); // divisor is non-zero as x2 != x is enforced
     const auto x3 = lambda.sqradd({ -x2, -x });
 
     const Fq minus_lambda_2 = lambda + Fq::div_without_denominator_check({ y + y }, (x3 - x));
@@ -505,10 +514,11 @@ element<C, Fq, Fr, G> element<C, Fq, Fr, G>::quadruple_and_add(const std::vector
     Fq minus_lambda_dbl;
     if constexpr (G::has_a) {
         Fq a(get_context(), uint256_t(G::curve_a));
-        minus_lambda_dbl = Fq::msub_div({ x }, { (two_x + x) }, (y + y), { a });
+        minus_lambda_dbl = Fq::msub_div({ x }, { (two_x + x) }, (y + y), { a }, /*enable_divisor_nz_check*/ false);
         x_1 = minus_lambda_dbl.sqradd({ -(two_x) });
     } else {
-        minus_lambda_dbl = Fq::msub_div({ x }, { (two_x + x) }, (y + y), {});
+        // TODO(): handle y = 0 case.
+        minus_lambda_dbl = Fq::msub_div({ x }, { (two_x + x) }, (y + y), {}, /*enable_divisor_nz_check*/ false);
         x_1 = minus_lambda_dbl.sqradd({ -(two_x) });
     }
 
@@ -517,12 +527,22 @@ element<C, Fq, Fr, G> element<C, Fq, Fr, G>::quadruple_and_add(const std::vector
 
     const Fq x_minus_x_1 = x - x_1;
 
-    const Fq lambda_1 = Fq::msub_div({ minus_lambda_dbl }, { x_minus_x_1 }, (x_1 - to_add[0].x), { to_add[0].y, y });
+    const Fq lambda_1 =
+        Fq::msub_div({ minus_lambda_dbl },
+                     { x_minus_x_1 },
+                     (x_1 - to_add[0].x),
+                     { to_add[0].y, y },
+                     /*enable_divisor_nz_check*/ false); // divisor is non-zero as x1 != to_add[0].x is enforced
 
     const Fq x_3 = lambda_1.sqradd({ -to_add[0].x, -x_1 });
 
+    // TODO(): analyse if (x3 - x1) can be zero.
     const Fq half_minus_lambda_2_minus_lambda_1 =
-        Fq::msub_div({ minus_lambda_dbl }, { x_minus_x_1 }, (x_3 - x_1), { y });
+        Fq::msub_div({ minus_lambda_dbl },
+                     { x_minus_x_1 },
+                     (x_3 - x_1),
+                     { y },
+                     /*enable_divisor_nz_check*/ false); // divisor is non-zero as x3 != x1 is enforced
 
     const Fq minus_lambda_2_minus_lambda_1 = half_minus_lambda_2_minus_lambda_1 + half_minus_lambda_2_minus_lambda_1;
     const Fq minus_lambda_2 = minus_lambda_2_minus_lambda_1 + lambda_1;
@@ -537,8 +557,12 @@ element<C, Fq, Fr, G> element<C, Fq, Fr, G>::quadruple_and_add(const std::vector
     }
     to_add[1].x.assert_is_not_equal(to_add[0].x);
 
-    Fq minus_lambda_3 = Fq::msub_div(
-        { minus_lambda_dbl, minus_lambda_2 }, { x_minus_x_1, x_4_sub_x_1 }, (x_4 - to_add[1].x), { y, -(to_add[1].y) });
+    // TODO(): analyse if (x4 - x1) can be zero.
+    Fq minus_lambda_3 = Fq::msub_div({ minus_lambda_dbl, minus_lambda_2 },
+                                     { x_minus_x_1, x_4_sub_x_1 },
+                                     (x_4 - to_add[1].x),
+                                     { y, -(to_add[1].y) },
+                                     /*enable_divisor_nz_check*/ false);
 
     // X5 = L3.L3 - X4 - XB
     const Fq x_5 = minus_lambda_3.sqradd({ -x_4, -to_add[1].x });
@@ -557,10 +581,13 @@ element<C, Fq, Fr, G> element<C, Fq, Fr, G>::quadruple_and_add(const std::vector
         to_add[i].x.assert_is_not_equal(to_add[i - 1].x);
         // Lambda = Yprev - Yadd[i] / Xprev - Xadd[i]
         //        = -Lprev.(Xprev - Xadd[i-1]) - Yadd[i - 1] - Yadd[i] / Xprev - Xadd[i]
-        const Fq minus_lambda = Fq::msub_div({ minus_lambda_prev },
-                                             { to_add[i - 1].x - x_prev },
-                                             (to_add[i].x - x_prev),
-                                             { to_add[i - 1].y, to_add[i].y });
+        const Fq minus_lambda =
+            Fq::msub_div({ minus_lambda_prev },
+                         { to_add[i - 1].x - x_prev },
+                         (to_add[i].x - x_prev),
+                         { to_add[i - 1].y, to_add[i].y },
+                         /*enable_divisor_nz_check*/ false); // divisor is non-zero as x_prev != to_add[i].x is enforced
+
         // X = Lambda * Lambda - Xprev - Xadd[i]
         const Fq x_out = minus_lambda.sqradd({ -x_prev, -to_add[i].x });
 
@@ -640,7 +667,12 @@ element<C, Fq, Fr, G> element<C, Fq, Fr, G>::multiple_montgomery_ladder(
         if (!add[i].is_element || i > 0) {
             bool flip_lambda1_denominator = !negate_add_y;
             Fq denominator = flip_lambda1_denominator ? previous_x - add[i].x3_prev : add[i].x3_prev - previous_x;
-            lambda1 = Fq::msub_div(lambda1_left, lambda1_right, denominator, lambda1_add);
+            lambda1 = Fq::msub_div(
+                lambda1_left,
+                lambda1_right,
+                denominator,
+                lambda1_add,
+                /*enable_divisor_nz_check*/ false); // divisor is non-zero as previous_x != add[i].x3_prev is enforced
         } else {
             lambda1 = Fq::div_without_denominator_check({ add[i].y3_prev - y }, (add[i].x3_prev - x));
         }
@@ -657,8 +689,12 @@ element<C, Fq, Fr, G> element<C, Fq, Fr, G>::multiple_montgomery_ladder(
             lambda2 = Fq::div_without_denominator_check({ y + y }, (previous_x - x_3)) - lambda1;
         } else {
             Fq l2_denominator = previous_y.is_negative ? previous_x - x_3 : x_3 - previous_x;
-            Fq partial_lambda2 =
-                Fq::msub_div(previous_y.mul_left, previous_y.mul_right, l2_denominator, previous_y.add);
+            // TODO(): analyse if l2_denominator can be zero.
+            Fq partial_lambda2 = Fq::msub_div(previous_y.mul_left,
+                                              previous_y.mul_right,
+                                              l2_denominator,
+                                              previous_y.add,
+                                              /*enable_divisor_nz_check*/ false);
             partial_lambda2 = partial_lambda2 + partial_lambda2;
             lambda2 = partial_lambda2 - lambda1;
         }


### PR DESCRIPTION
Summary of the fixes based on the audit of the `bigfield` class by Veridise (on commit [480f49d](https://github.com/AztecProtocol/aztec-packages/tree/480f49dad314ea4e753ff1e5180992a16926d2b3)):

#### [V-AZT-VUL-001: Missing zero-check for division by constant]()

Added an assertion that triggers when the divisor is a constant zero and the flag `check_for_zero` is set to true. Also added a test that validates this behaviour.

Response: Fixed in https://github.com/AztecProtocol/aztec-packages/pull/16842/commits/bbf2f738fa24fee516d62f1c91e03f51c2faf7c4

#### [V-AZT-VUL-002: Incomplete ‘assert_is_not_equal‘ assumes random distribution]()

The function `assert_is_not_equal` is no longer exposed as a public function (via noir). In fact, none of the non-native field methods (and group operations) are exposed to developers via noir. Noir instead uses the natively written [noir-bignum](https://github.com/noir-lang/noir-bignum) library. (The `bigint_constraint.cpp` file that contains the interface for non-native field methods between noir and barretenberg is yet to be removed from the repository, this will be done in an upcoming PR.)

Response: Acknowledged 

#### [V-AZT-VUL-003: borrow_lo rounds down]()

Updated the computation of `borrow_lo_value` to use ceiling instead of floor:
```cpp
uint256_t borrow_lo_value = (max_remainders_lo + ((uint256_t(1) << (2 * NUM_LIMB_BITS)) - 1)) >> (2 * NUM_LIMB_BITS);
```

Response: Fixed in https://github.com/AztecProtocol/aztec-packages/pull/16842/commits/c1bdd88a8fb6681ff164bc4f02d17433983c8924

#### [V-AZT-VUL-004: Unsafe default for `msub_div()`]()

Changed the default value of `enable_divisor_nz_check` to `true` and explicitly pass it as `false` in its usage in the `biggroup` class. In a few instances, passing this parameter as `false` can lead to incorrect handling of the point at infinity, added TODOs at such places. These instances will be analysed separately to avoid any unexpected behaviour.

Response: Fixed in https://github.com/AztecProtocol/aztec-packages/pull/16842/commits/25e820ce8184020d433e7df49db20687dfd93496, usage of `msub_div` will be analysed separately

 #### [V-AZT-VUL-005: Limbs with a maximum value of 0 trigger compilation failure]()

In the function `decompose_into_default_range` we have an assertion:
```cpp
ASSERT(num_bits > 0)
``` 
because number of bits (of a circuit variable) being 0 does not really make sense. The only case when `carry_hi_msb` or `carry_lo_msb` can be 0 is when:
```cpp
template <typename Builder, typename T>
void bigfield<Builder, T>::unsafe_evaluate_multiply_add(const bigfield& input_left,
                                                        const bigfield& input_to_mul,
                                                        const std::vector<bigfield>& to_add,
                                                        const bigfield& input_quotient,
                                                        const std::vector<bigfield>& input_remainders)
```
 is called with `input_to_mul` as constant 0 and/or `input_quotient` as constant 0. In the usage of the function `unsafe_evaluate_multiply_add` (or `unsafe_evaluate_multiple_multiply_add`) the `input_quotient` is always a circuit witness. This ensures that the `carry_lo_msb > 0` and `carry_hi_msb > 0` (added assertions to verify this empirically). 

Response: We think it does not make sense to support `num_bits = 0` in range constraint functions, but open to discussion on this if there's any way  `carry_lo_msb` or `carry_hi_msb` can actually be 0 in practice.

#### [V-AZT-VUL-006: Off-by-one comparison of maximum_unreduced_limb_value]()

Changed the definition of `get_maximum_unreduced_limb_value()` to $2^Q - 1$ (from $2^Q$).

Response: Fixed in https://github.com/AztecProtocol/aztec-packages/pull/16842/commits/3da35ba4db4dc753cdfb131c02f1113bb3a765af

#### [V-AZT-VUL-007: Maintainability Improvements]()

1. Removed unused constants:
    - `bigfield.prime_basis_maximum_limb`
    - `bigfield.shift_right_1`
    - `bigfield.shift_right_2`
2. Renamed `negative_prime_modulus_mod_binary_basis` to `negative_prime_modulus_mod_native_basis` and use that while checking the prime limb consistency (in `evaluate_polynomial_identity`)
3. Used `NUM_LIMBS` instead of hard-coded 4.
4. Fixed comments (using $L$ instead of $t$)
5. Changed the definition of `get_maximum_unreduced_value()` to a form $(2^N - 1)$ and use the comparison operators correctly
6. Fixed `static constexpr uint64_t MAX_UNREDUCED_LIMB_BITS = NUM_LIMB_BITS + MAX_ADDITION_LOG`
7. Got rid of variable `neg_prime`
8. Used `is_constant()` instead of iterating over each limb to check constant-ness in `operator+` and `operator-`.
9. Removed duplicate/redundant assertion: `ASSERT(input_left.size() == input_right.size() && input_left.size() < 1024);`
10. Fixed misc comments

Response: Fixed in https://github.com/AztecProtocol/aztec-packages/pull/16842/commits/e2024dfe83c24464522d248fb6174bcc924c8a21

#### [V-AZT-VUL-008: Incorrect term used during calculation on bound of upper limb]()

Corrected the calculation of the resultant maximum bound of the upper and lower limbs:

$$D_{\textsf{hi}} < 2^{2Q + L + \textcolor{red}{3}},$$
$$D_{\textsf{lo}} < 2^{2Q + L + \textcolor{red}{2}}.$$ 

Response: Fixed in https://github.com/AztecProtocol/aztec-packages/pull/16842/commits/f41813e83b3558b0fb18dd991e6df71b812620df

#### [V-AZT-VUL-009: Optimization Improvements]()

1. In the function `add_two`, we could add another `if` condition when two of the three inputs are constant and reduced by the prime. But the current implementation should handle that implicitly on calling `add_two` on each limb. Note that no additional gates would be added since each `add_two` call on limbs would just update additive constants on the witness.
2. Agree with the observation but we think its fine to have redundant reductions in constant case as that would cause negligible impact on prover performance.
3. It is a good suggestion to use a tighter bound for range constraint on the quotient when reduction is not necessary. However, while creating the quotient witness using the constructor:
    ```cpp
    template <typename Builder, typename T>
    bigfield<Builder, T> bigfield<Builder, T>::create_from_u512_as_witness(Builder* ctx,
                                                                           const uint512_t& value,
                                                                           const bool can_overflow,
                                                                           const size_t maximum_bitlength)
    ```
    when `can_overflow` is set to `false`, `maximum_bitlength` must be greater than $3L$. This assertion breaks if we use tighter range constraint on the quotient. This needs to be investigated further.