### PR TITLE
fix: add validation for archiver sync duration metrics

### DIFF
--- a/yarn-project/archiver/src/archiver/archiver.ts
+++ b/yarn-project/archiver/src/archiver/archiver.ts
@@ -531,7 +531,7 @@ export class Archiver extends (EventEmitter as new () => ArchiverEmitter) implem
       );
       const timer = new Timer();
       await this.store.addL1ToL2Messages(messages);
-      const perMsg = timer.ms() / messages.length;
+      const perMsg = messages.length > 0 ? timer.ms() / messages.length : 0;
       this.instrumentation.processNewMessages(messages.length, perMsg);
       for (const msg of messages) {
         this.log.debug(`Downloaded L1 to L2 message`, { ...msg, leaf: msg.leaf.toString() });

--- a/yarn-project/archiver/src/archiver/instrumentation.ts
+++ b/yarn-project/archiver/src/archiver/instrumentation.ts
@@ -140,7 +140,9 @@ export class ArchiverInstrumentation {
   }
 
   public processNewBlocks(syncTimePerBlock: number, blocks: L2Block[]) {
-    this.syncDurationPerBlock.record(Math.ceil(syncTimePerBlock));
+    // Ensure we only record valid numeric values, avoiding Infinity/NaN
+    const validDuration = isFinite(syncTimePerBlock) ? Math.ceil(syncTimePerBlock) : 0;
+    this.syncDurationPerBlock.record(validDuration);
     this.blockHeight.record(Math.max(...blocks.map(b => b.number)));
     this.syncBlockCount.add(blocks.length);
 
@@ -153,12 +155,16 @@ export class ArchiverInstrumentation {
 
   public processNewMessages(count: number, syncPerMessageMs: number) {
     this.syncMessageCount.add(count);
-    this.syncDurationPerMessage.record(Math.ceil(syncPerMessageMs));
+    // Ensure we only record valid numeric values, avoiding Infinity/NaN
+    const validDuration = isFinite(syncPerMessageMs) ? Math.ceil(syncPerMessageMs) : 0;
+    this.syncDurationPerMessage.record(validDuration);
   }
 
   public processPrune(duration: number) {
     this.pruneCount.add(1);
-    this.pruneDuration.record(Math.ceil(duration));
+    // Ensure we only record valid numeric values, avoiding Infinity/NaN
+    const validDuration = isFinite(duration) ? Math.ceil(duration) : 0;
+    this.pruneDuration.record(validDuration);
   }
 
   public updateLastProvenBlock(blockNumber: number) {


### PR DESCRIPTION
## Problem
Archiver throws "INT value type cannot accept a floating-point value" errors when `messages.length` is 0, causing division by zero that results in `Infinity` values being passed to INT-typed telemetry metrics.

## Solution
- Add zero-check before division in `archiver.ts:534`
- Add `isFinite()` validation in `instrumentation.ts` for all duration metrics
- Convert invalid values (Infinity/NaN) to 0 before recording

## Changes
- `archiver.ts`: `const perMsg = messages.length > 0 ? timer.ms() / messages.length : 0`
- `instrumentation.ts`: Add `isFinite()` checks in `processNewBlocks()`, `processNewMessages()`, `processPrune()`

Fixes #16464