### PR TITLE
fix: never use cache in `verifyProposer`

### DIFF
--- a/l1-contracts/src/core/libraries/rollup/AttestationLib.sol
+++ b/l1-contracts/src/core/libraries/rollup/AttestationLib.sol
@@ -130,49 +130,6 @@ library AttestationLib {
   }
 
   /**
-   * @notice Assert that the size of `_attestations` is as expected, throw otherwise
-   *
-   * @custom:reverts SignatureIndicesSizeMismatch if the signature indices have a wrong size
-   * @custom:reverts SignaturesOrAddressesSizeMismatch if the signatures or addresses object has wrong size
-   *
-   * @param _attestations - The attestation struct
-   * @param _expectedCount - The expected size of the validator set
-   */
-  function assertSizes(CommitteeAttestations memory _attestations, uint256 _expectedCount) internal pure {
-    // Count signatures (1s) and addresses (0s) from bitmap
-    uint256 signatureCount = 0;
-    uint256 addressCount = 0;
-    uint256 bitmapBytes = (_expectedCount + 7) / 8; // Round up to nearest byte
-    require(
-      bitmapBytes == _attestations.signatureIndices.length,
-      Errors.AttestationLib__SignatureIndicesSizeMismatch(bitmapBytes, _attestations.signatureIndices.length)
-    );
-
-    for (uint256 i = 0; i < _expectedCount; i++) {
-      uint256 byteIndex = i / 8;
-      uint256 bitIndex = 7 - (i % 8);
-      uint8 bitMask = uint8(1 << bitIndex);
-
-      if (uint8(_attestations.signatureIndices[byteIndex]) & bitMask != 0) {
-        signatureCount++;
-      } else {
-        addressCount++;
-      }
-    }
-
-    // Calculate expected size
-    uint256 sizeOfSignaturesAndAddresses = (signatureCount * SIGNATURE_LENGTH) + (addressCount * ADDRESS_LENGTH);
-
-    // Validate actual size matches expected
-    require(
-      sizeOfSignaturesAndAddresses == _attestations.signaturesOrAddresses.length,
-      Errors.AttestationLib__SignaturesOrAddressesSizeMismatch(
-        sizeOfSignaturesAndAddresses, _attestations.signaturesOrAddresses.length
-      )
-    );
-  }
-
-  /**
    * Recovers the committee from the addresses in the attestations and signers.
    *
    * @custom:reverts SignatureIndicesSizeMismatch if the signature indices have a wrong size

--- a/l1-contracts/src/core/libraries/rollup/ProposeLib.sol
+++ b/l1-contracts/src/core/libraries/rollup/ProposeLib.sol
@@ -237,7 +237,13 @@ library ProposeLib {
     {
       // Verify that the proposer is the correct one for this slot by checking their signature in the attestations
       ValidatorSelectionLib.verifyProposer(
-        v.header.slotNumber, v.currentEpoch, _attestations, _signers, v.payloadDigest, _attestationsAndSignersSignature
+        v.header.slotNumber,
+        v.currentEpoch,
+        _attestations,
+        _signers,
+        v.payloadDigest,
+        _attestationsAndSignersSignature,
+        true
       );
     }
 

--- a/l1-contracts/src/core/libraries/rollup/RollupOperationsExtLib.sol
+++ b/l1-contracts/src/core/libraries/rollup/RollupOperationsExtLib.sol
@@ -53,7 +53,7 @@ library RollupOperationsExtLib {
     Epoch epoch = slot.epochFromSlot();
     ValidatorSelectionLib.verifyAttestations(slot, epoch, _attestations, _args.digest);
     ValidatorSelectionLib.verifyProposer(
-      slot, epoch, _attestations, _signers, _args.digest, _attestationsAndSignersSignature
+      slot, epoch, _attestations, _signers, _args.digest, _attestationsAndSignersSignature, false
     );
   }
 

--- a/l1-contracts/test/AttestationLib.t.sol
+++ b/l1-contracts/test/AttestationLib.t.sol
@@ -17,10 +17,6 @@ contract AttestationLibWrapper {
     return AttestationLib.isEmpty(_attestations);
   }
 
-  function assertSizes(CommitteeAttestations memory _attestations, uint256 _expectedCount) external pure {
-    AttestationLib.assertSizes(_attestations, _expectedCount);
-  }
-
   function reconstructCommitteeFromSigners(
     CommitteeAttestations memory _attestations,
     address[] memory _signers,
@@ -76,52 +72,6 @@ contract AttestationLibTest is TestBase {
     $attestations = attestationLibWrapper.packAttestations(attestations);
 
     _;
-  }
-
-  function test_assertSizes(uint256 _signatureCount) public createValidAttestations(_signatureCount) {
-    attestationLibWrapper.assertSizes($attestations, SIZE);
-  }
-
-  function test_assertSizes_wrongBitmapSize(uint256 _signatureCount, bool _over)
-    public
-    createValidAttestations(_signatureCount)
-  {
-    uint256 bitmapSize = $attestations.signatureIndices.length;
-    if (_over) {
-      $attestations.signatureIndices = new bytes(bitmapSize + 1);
-    } else {
-      $attestations.signatureIndices = new bytes(bitmapSize - 1);
-    }
-
-    vm.expectRevert(
-      abi.encodeWithSelector(
-        Errors.AttestationLib__SignatureIndicesSizeMismatch.selector, bitmapSize, $attestations.signatureIndices.length
-      )
-    );
-
-    attestationLibWrapper.assertSizes($attestations, SIZE);
-  }
-
-  function test_assertSizes_wrongSignaturesOrAddressesSize(uint256 _signatureCount, bool _over)
-    public
-    createValidAttestations(_signatureCount)
-  {
-    uint256 dataSize = $attestations.signaturesOrAddresses.length;
-    if (_over) {
-      $attestations.signaturesOrAddresses = new bytes(dataSize + 1);
-    } else {
-      $attestations.signaturesOrAddresses = new bytes(dataSize - 1);
-    }
-
-    vm.expectRevert(
-      abi.encodeWithSelector(
-        Errors.AttestationLib__SignaturesOrAddressesSizeMismatch.selector,
-        dataSize,
-        $attestations.signaturesOrAddresses.length
-      )
-    );
-
-    attestationLibWrapper.assertSizes($attestations, SIZE);
   }
 
   function test_reconstructCommitteeFromSigners(uint256 _signatureCount)


### PR DESCRIPTION
Please read [contributing guidelines](CONTRIBUTING.md) and remove this line.

For audit-related pull requests, please use the [audit PR template](?expand=1&template=audit.md).
