### PR TITLE
chore!: fix docker image entrypoint

### DIFF
--- a/iac/network/scripts/bootnode_startup.sh
+++ b/iac/network/scripts/bootnode_startup.sh
@@ -136,7 +136,7 @@ docker run \
  --env BOOTSTRAP_NODES \
  --env LOG_LEVEL \
  --env OTEL_EXPORTER_OTLP_METRICS_ENDPOINT \
- $REPO/$IMAGE:$TAG node --no-warnings /usr/src/yarn-project/aztec/dest/bin/index.js start --p2p-bootstrap
+ $REPO/$IMAGE:$TAG start --p2p-bootstrap
 EOF
 chmod +x /home/$SSH_USER/start.sh
 

--- a/iac/network/scripts/generate_encoded_enr.sh
+++ b/iac/network/scripts/generate_encoded_enr.sh
@@ -7,7 +7,7 @@ L1_CHAIN_ID=${4:-}
 TAG=${5:-"latest"}
 
 function get_enr {
-  docker run --rm aztecprotocol/aztec:$TAG node --no-warnings /usr/src/yarn-project/aztec/dest/bin/index.js generate-bootnode-enr $PRIVATE_KEY $P2P_IP $P2P_PORT -c $L1_CHAIN_ID
+  docker run --rm aztecprotocol/aztec:$TAG generate-bootnode-enr $PRIVATE_KEY $P2P_IP $P2P_PORT -c $L1_CHAIN_ID
 }
 
 OUTPUT="$(get_enr)"

--- a/iac/network/scripts/generate_private_key.sh
+++ b/iac/network/scripts/generate_private_key.sh
@@ -2,7 +2,7 @@
 TAG=${1:-"latest"}
 
 function get_key {
-  docker run --rm aztecprotocol/aztec:$TAG  node --no-warnings /usr/src/yarn-project/aztec/dest/bin/index.js generate-p2p-private-key
+  docker run --rm aztecprotocol/aztec:$TAG generate-p2p-private-key
 }
 OUTPUT="$(get_key)"
 PRIVATE_KEY=$(echo "$OUTPUT" | awk -F'Private key: ' '{print $2}' | awk '{print $1}')

--- a/release-image/Dockerfile
+++ b/release-image/Dockerfile
@@ -18,4 +18,4 @@ WORKDIR "/usr/src/yarn-project"
 ARG VERSION
 RUN echo '{".": "'$VERSION'"}' > /usr/src/.release-please-manifest.json
 
-ENTRYPOINT ["/bin/bash", "-c", "node --no-warnings /usr/src/yarn-project/aztec/dest/bin/index.js"]
+ENTRYPOINT ["node", "--no-warnings", "/usr/src/yarn-project/aztec/dest/bin/index.js"]

--- a/spartan/scripts/upgrade_rollup_with_cli.sh
+++ b/spartan/scripts/upgrade_rollup_with_cli.sh
@@ -98,7 +98,7 @@ cleanup() {
 
 # if aztec-docker-tag is set, use it
 if [ -n "$AZTEC_DOCKER_IMAGE" ]; then
-  EXE="docker run --rm --network=host --env-file .env.tmp $AZTEC_DOCKER_IMAGE node --no-warnings $AZTEC_BIN"
+  EXE="docker run --rm --network=host --env-file .env.tmp $AZTEC_DOCKER_IMAGE"
   # Check if the image exists locally before pulling it
   if ! docker images $AZTEC_DOCKER_IMAGE -q; then
     echo "Pulling docker image $AZTEC_DOCKER_IMAGE"


### PR DESCRIPTION
Fix the image's entrypoint so that we might be able to `docker run --rm $AZTEC_IMAGE start --node` (and other commands) instead.