### PR TITLE
feat: check op queue wires are zero past minicircuit in Translator

### DIFF
--- a/barretenberg/cpp/src/barretenberg/relations/translator_vm/translator_extra_relations.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/translator_vm/translator_extra_relations.hpp
@@ -81,7 +81,9 @@ template <typename FF_> class TranslatorAccumulatorTransferRelationImpl {
      */
     template <typename AllEntities> inline static bool skip(const AllEntities& in)
     {
-        return (in.lagrange_odd_in_minicircuit + in.lagrange_last_in_minicircuit + in.lagrange_result_row).is_zero();
+        return (in.lagrange_odd_in_minicircuit + in.lagrange_last_in_minicircuit + in.lagrange_result_row +
+                in.lagrange_mini_masking)
+            .is_zero();
     }
     /**
      * @brief Relation enforcing non-arithmetic transitions of accumulator (value that is tracking the batched
@@ -190,7 +192,9 @@ template <typename FF_> class TranslatorZeroConstraintsRelationImpl {
     template <typename AllEntities> inline static bool skip(const AllEntities& in)
     {
         static constexpr auto minus_one = -FF(1);
-        return (in.lagrange_even_in_minicircuit + in.lagrange_last_in_minicircuit + minus_one).is_zero();
+        return (in.lagrange_even_in_minicircuit + in.lagrange_last_in_minicircuit + in.lagrange_mini_masking +
+                minus_one)
+            .is_zero();
     }
     /**
      * @brief Relation enforcing all the range-constraint polynomials to be zero after the minicircuit

--- a/barretenberg/cpp/src/barretenberg/relations/translator_vm/translator_extra_relations.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/translator_vm/translator_extra_relations.hpp
@@ -29,8 +29,8 @@ template <typename FF_> class TranslatorOpcodeConstraintRelationImpl {
      */
     template <typename AllEntities> static bool skip(const AllEntities& in)
     {
-        // All contributions are zero outside the minicircuit or at odd indices
-        return in.lagrange_even_in_minicircuit.is_zero();
+        // All contributions are zero outside the minicircuit or at odd indices not masked
+        return (in.lagrange_even_in_minicircuit + in.lagrange_mini_masking).is_zero();
     }
     /**
      * @brief Expression for enforcing the value of the Opcode to be {0,3,4,8}
@@ -82,9 +82,11 @@ template <typename FF_> class TranslatorAccumulatorTransferRelationImpl {
      */
     template <typename AllEntities> static bool skip(const AllEntities& in)
     {
-        // All contributions are zero outside the minicircuit or at even indices within the minicircuit (except from the
-        // last and result row in minicircuit)
-        return (in.lagrange_odd_in_minicircuit + in.lagrange_last_in_minicircuit + in.lagrange_result_row).is_zero();
+        // All contributions are zero outside the minicircuit or at even indices within the minicircuite excluding
+        // masked areas (except from the last and result row in minicircuit)
+        return (in.lagrange_odd_in_minicircuit + in.lagrange_last_in_minicircuit + in.lagrange_result_row +
+                in.lagrange_mini_masking)
+            .is_zero();
     }
     /**
      * @brief Relation enforcing non-arithmetic transitions of accumulator (value that is tracking the batched
@@ -192,11 +194,11 @@ template <typename FF_> class TranslatorZeroConstraintsRelationImpl {
      */
     template <typename AllEntities> static bool skip(const AllEntities& in)
     {
-        // All contributions are identically zero if outside the minicircuit or when we have a
+        // All contributions are identically zero if outside the minicircuit and masked area or when we have a
         // no-op (i.e. op is zero at an even index)
         static constexpr auto minus_one = -FF(1);
         return (in.lagrange_even_in_minicircuit + in.op + minus_one).is_zero() ||
-               (in.lagrange_odd_in_minicircuit + in.lagrange_even_in_minicircuit).is_zero();
+               (in.lagrange_odd_in_minicircuit + in.lagrange_even_in_minicircuit + in.lagrange_mini_masking).is_zero();
     }
     /**
      * @brief Relation enforcing all the range-constraint polynomials to be zero after the minicircuit

--- a/barretenberg/cpp/src/barretenberg/relations/translator_vm/translator_extra_relations.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/translator_vm/translator_extra_relations.hpp
@@ -30,9 +30,7 @@ template <typename FF_> class TranslatorOpcodeConstraintRelationImpl {
     template <typename AllEntities> static bool skip(const AllEntities& in)
     {
         // All contributions are zero outside the minicircuit or at odd indices
-        static constexpr auto minus_one = -FF(1);
-        return (in.lagrange_even_in_minicircuit + in.lagrange_odd_in_minicircuit).is_zero() ||
-               (in.lagrange_odd_in_minicircuit + minus_one).is_zero();
+        return in.lagrange_even_in_minicircuit.is_zero();
     }
     /**
      * @brief Expression for enforcing the value of the Opcode to be {0,3,4,8}
@@ -82,13 +80,11 @@ template <typename FF_> class TranslatorAccumulatorTransferRelationImpl {
      * slower.
      *
      */
-    template <typename AllEntities> inline static bool skip(const AllEntities& in)
+    template <typename AllEntities> static bool skip(const AllEntities& in)
     {
-        // All contributions are zero outside the minicircuit or at even indices
-        static constexpr auto minus_one = -FF(1);
-        return (in.lagrange_odd_in_minicircuit + in.lagrange_even_in_minicircuit + in.lagrange_last_in_minicircuit)
-                   .is_zero() ||
-               (in.lagrange_even_in_minicircuit + minus_one).is_zero();
+        // All contributions are zero outside the minicircuit or at even indices within the minicircuit (except from the
+        // last and result row in minicircuit)
+        return (in.lagrange_odd_in_minicircuit + in.lagrange_last_in_minicircuit + in.lagrange_result_row).is_zero();
     }
     /**
      * @brief Relation enforcing non-arithmetic transitions of accumulator (value that is tracking the batched
@@ -194,9 +190,9 @@ template <typename FF_> class TranslatorZeroConstraintsRelationImpl {
      *
      *
      */
-    template <typename AllEntities> inline static bool skip(const AllEntities& in)
+    template <typename AllEntities> static bool skip(const AllEntities& in)
     {
-        // For an honest prover, all contributions are identically zero if outside the minicircuit or when we have a
+        // All contributions are identically zero if outside the minicircuit or when we have a
         // no-op (i.e. op is zero at an even index)
         static constexpr auto minus_one = -FF(1);
         return (in.lagrange_even_in_minicircuit + in.op + minus_one).is_zero() ||

--- a/barretenberg/cpp/src/barretenberg/relations/translator_vm/translator_extra_relations.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/translator_vm/translator_extra_relations.hpp
@@ -27,9 +27,12 @@ template <typename FF_> class TranslatorOpcodeConstraintRelationImpl {
      * @brief Returns true if the contribution from all subrelations for the provided inputs is identically zero
      *
      */
-    template <typename AllEntities> inline static bool skip(const AllEntities& in)
+    template <typename AllEntities> static bool skip(const AllEntities& in)
     {
-        return (in.lagrange_even_in_minicircuit + in.lagrange_mini_masking).is_zero();
+        // All contributions are zero outside the minicircuit or at odd indices
+        static constexpr auto minus_one = -FF(1);
+        return (in.lagrange_even_in_minicircuit + in.lagrange_odd_in_minicircuit).is_zero() ||
+               (in.lagrange_odd_in_minicircuit + minus_one).is_zero();
     }
     /**
      * @brief Expression for enforcing the value of the Opcode to be {0,3,4,8}
@@ -81,9 +84,11 @@ template <typename FF_> class TranslatorAccumulatorTransferRelationImpl {
      */
     template <typename AllEntities> inline static bool skip(const AllEntities& in)
     {
-        return (in.lagrange_odd_in_minicircuit + in.lagrange_last_in_minicircuit + in.lagrange_result_row +
-                in.lagrange_mini_masking)
-            .is_zero();
+        // All contributions are zero outside the minicircuit or at even indices
+        static constexpr auto minus_one = -FF(1);
+        return (in.lagrange_odd_in_minicircuit + in.lagrange_even_in_minicircuit + in.lagrange_last_in_minicircuit)
+                   .is_zero() ||
+               (in.lagrange_even_in_minicircuit + minus_one).is_zero();
     }
     /**
      * @brief Relation enforcing non-arithmetic transitions of accumulator (value that is tracking the batched
@@ -185,16 +190,17 @@ template <typename FF_> class TranslatorZeroConstraintsRelationImpl {
     };
 
     /**
-     * @brief Might return true if the contribution from all subrelations for the provided inputs is identically zero
+     * @brief Returns true if the contribution from all subrelations for the provided inputs is identically zero
      *
      *
      */
     template <typename AllEntities> inline static bool skip(const AllEntities& in)
     {
+        // For an honest prover, all contributions are identically zero if outside the minicircuit or when we have a
+        // no-op (i.e. op is zero at an even index)
         static constexpr auto minus_one = -FF(1);
-        return (in.lagrange_even_in_minicircuit + in.lagrange_last_in_minicircuit + in.lagrange_mini_masking +
-                minus_one)
-            .is_zero();
+        return (in.lagrange_even_in_minicircuit + in.op + minus_one).is_zero() ||
+               (in.lagrange_odd_in_minicircuit + in.lagrange_even_in_minicircuit).is_zero();
     }
     /**
      * @brief Relation enforcing all the range-constraint polynomials to be zero after the minicircuit

--- a/barretenberg/cpp/src/barretenberg/relations/translator_vm/translator_extra_relations.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/translator_vm/translator_extra_relations.hpp
@@ -110,7 +110,7 @@ template <typename FF_> class TranslatorZeroConstraintsRelationImpl {
     // 1 + polynomial degree of this relation
     static constexpr size_t RELATION_LENGTH = 4; // degree((some lagrange)(A)) = 2
 
-    static constexpr std::array<size_t, 64> SUBRELATION_PARTIAL_LENGTHS{
+    static constexpr std::array<size_t, 68> SUBRELATION_PARTIAL_LENGTHS{
         4, // p_x_low_limbs_range_constraint_0 is zero outside of the minicircuit
         4, // p_x_low_limbs_range_constraint_1 is zero outside of the minicircuit
         4, // p_x_low_limbs_range_constraint_2 is zero outside of the minicircuit
@@ -175,6 +175,10 @@ template <typename FF_> class TranslatorZeroConstraintsRelationImpl {
         4, // accumulator_high_limbs_range_constraint_tail is zero outside of the minicircuit
         4, // quotient_low_limbs_range_constraint_tail is zero outside of the minicircuit
         4, // quotient_high_limbs_range_constraint_tail is zero outside of the minicircuit
+        4, // op is zero outside of the minicircuit
+        4, // x_lo_y_hi is zero outside of the minicircuit
+        4, // x_hi_z_1 is zero outside of the minicircuit
+        4, // y_lo_z_2 is zero outside of the minicircuit
 
     };
 

--- a/barretenberg/cpp/src/barretenberg/relations/translator_vm/translator_extra_relations_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/translator_vm/translator_extra_relations_impl.hpp
@@ -207,9 +207,8 @@ void TranslatorAccumulatorTransferRelationImpl<FF>::accumulate(ContainerOverSubr
 };
 
 /**
- * @brief Relation enforcing all the range-constraint polynomials to be zero after the minicircuit
- * @details This relation ensures that while we are out of the minicircuit the range constraint polynomials are zero
- *
+ * @brief Relation enforcing all the range-constraint  and op queue polynomials to be zero after the minicircuit
+
  * @param evals transformed to `evals + C(in(X)...)*scaling_factor`
  * @param in an std::array containing the fully extended Univariate edges.
  * @param parameters contains beta, gamma, and public_input_delta, ....
@@ -295,6 +294,10 @@ void TranslatorZeroConstraintsRelationImpl<FF>::accumulate(ContainerOverSubrelat
     auto accumulator_high_limbs_range_constraint_tail = View(in.accumulator_high_limbs_range_constraint_tail);
     auto quotient_low_limbs_range_constraint_tail = View(in.quotient_low_limbs_range_constraint_tail);
     auto quotient_high_limbs_range_constraint_tail = View(in.quotient_high_limbs_range_constraint_tail);
+    auto op = View(in.op);
+    auto x_lo_y_hi = View(in.x_lo_y_hi);
+    auto x_hi_z_1 = View(in.x_hi_z_1);
+    auto y_lo_z_2 = View(in.y_lo_z_2);
     auto lagrange_mini_masking = View(in.lagrange_mini_masking);
 
     // 0 in the minicircuit, -1 outside
@@ -492,5 +495,17 @@ void TranslatorZeroConstraintsRelationImpl<FF>::accumulate(ContainerOverSubrelat
 
     // Contribution 63, ensure quotient_high_limbs_range_constraint_tail is 0 outside of minicircuit
     std::get<63>(accumulators) += quotient_high_limbs_range_constraint_tail * not_in_mininicircuit_or_masked;
+
+    // Contribution 64, ensure op is 0 outside of minicircuit
+    std::get<64>(accumulators) += op * not_in_mininicircuit_or_masked;
+
+    // Contribution 65, ensure x_lo_y_hi is 0 outside of minicircuit
+    std::get<65>(accumulators) += x_lo_y_hi * not_in_mininicircuit_or_masked;
+
+    // Contribution 66, ensure x_hi_z_1 is 0 outside of minicircuit
+    std::get<66>(accumulators) += x_hi_z_1 * not_in_mininicircuit_or_masked;
+
+    // Contribution 67, ensure y_lo_z_2 is 0 outside of minicircuit
+    std::get<67>(accumulators) += y_lo_z_2 * not_in_mininicircuit_or_masked;
 };
 } // namespace bb

--- a/barretenberg/cpp/src/barretenberg/relations/translator_vm/translator_relation_consistency.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/relations/translator_vm/translator_relation_consistency.test.cpp
@@ -912,7 +912,10 @@ TEST_F(TranslatorRelationConsistency, ZeroConstraintsRelation)
         const auto& relation_wide_limbs_range_constraint_1 = input_elements.relation_wide_limbs_range_constraint_1;
         const auto& relation_wide_limbs_range_constraint_2 = input_elements.relation_wide_limbs_range_constraint_2;
         const auto& relation_wide_limbs_range_constraint_3 = input_elements.relation_wide_limbs_range_constraint_3;
-
+        const auto& op = input_elements.op;
+        const auto& x_lo_y_hi = input_elements.x_lo_y_hi;
+        const auto& x_hi_z_1 = input_elements.x_hi_z_1;
+        const auto& y_lo_z_2 = input_elements.y_lo_z_2;
         const auto& lagrange_odd_in_minicircuit = input_elements.lagrange_odd_in_minicircuit;
         const auto& lagrange_even_in_minicircuit = input_elements.lagrange_even_in_minicircuit;
         const auto& lagrange_mini_masking = input_elements.lagrange_mini_masking;
@@ -1049,6 +1052,14 @@ TEST_F(TranslatorRelationConsistency, ZeroConstraintsRelation)
                               (lagrange_mini_masking - FF(1)) * quotient_low_limbs_range_constraint_tail;
         expected_values[63] = (lagrange_even_in_minicircuit + lagrange_odd_in_minicircuit - 1) *
                               (lagrange_mini_masking - FF(1)) * quotient_high_limbs_range_constraint_tail;
+        expected_values[64] =
+            (lagrange_even_in_minicircuit + lagrange_odd_in_minicircuit - 1) * (lagrange_mini_masking - FF(1)) * op;
+        expected_values[65] = (lagrange_even_in_minicircuit + lagrange_odd_in_minicircuit - 1) *
+                              (lagrange_mini_masking - FF(1)) * x_lo_y_hi;
+        expected_values[66] = (lagrange_even_in_minicircuit + lagrange_odd_in_minicircuit - 1) *
+                              (lagrange_mini_masking - FF(1)) * x_hi_z_1;
+        expected_values[67] = (lagrange_even_in_minicircuit + lagrange_odd_in_minicircuit - 1) *
+                              (lagrange_mini_masking - FF(1)) * y_lo_z_2;
 
         validate_relation_execution<Relation>(expected_values, input_elements, parameters);
     };


### PR DESCRIPTION
At each step of the merge protocol we chech that the `left_table` is of appropriate degree to ensure merging the subtable doesn't cause an overlap. However, as the last subtable is appended so it's the `right_table`, we don't perform a degree check on it currently. We have to ensure merging the last subtable doesn't cause the number of UltraOps does not go over the fixed Translator `MINICIRCUIT_SIZE` and the cheapest way to do this is by updating the `TranslatorZeroConstraintRelation` to ensure the op queue wires are also zero past the `MINICIRCUIT_SIZE`.

On top of that, this PR reviews and document the `skip` conditions for the relations found in `translator_extra_relations.hpp`

Closes https://github.com/AztecProtocol/barretenberg/issues/1399