### PR TITLE
fix(avm)!: disable address derivation

### DIFF
--- a/barretenberg/cpp/pil/vm2/bytecode/contract_instance_retrieval.pil
+++ b/barretenberg/cpp/pil/vm2/bytecode/contract_instance_retrieval.pil
@@ -133,12 +133,12 @@ namespace contract_instance_retrieval;
     sel * (1 - is_protocol_contract) * (derived_address - address) = 0;
 
     #[PROTOCOL_CONTRACT_DERIVED_ADDRESS]
-    is_protocol_contract { address, derived_address } in
+    /*is_protocol_contract*/ precomputed.zero { address, derived_address } in
     precomputed.sel_protocol_contract { precomputed.clk, precomputed.protocol_contract_derived_address };
 
     // Address derivation lookup (only if the nullifier exists or for protocol contract instances)
     #[ADDRESS_DERIVATION]
-    exists {
+    /*exists*/ precomputed.zero {
         derived_address,
         salt, // hinted
         deployer_addr,

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/relations/contract_instance_retrieval.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/relations/contract_instance_retrieval.test.cpp
@@ -296,7 +296,6 @@ TEST(ContractInstanceRetrievalConstrainingTest, ProtocolContractInstance)
     });
 
     precomputed_builder.process_misc(trace, 6); // Need clk from 1 - 6 to set up protocol canonical addresses
-    precomputed_builder.process_protocol_contract_addresses(trace);
 
     check_relation<contract_instance_retrieval>(trace);
     check_interaction<ContractInstanceRetrievalTraceBuilder,

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/lookups_contract_instance_retrieval.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/lookups_contract_instance_retrieval.hpp
@@ -49,7 +49,7 @@ struct lookup_contract_instance_retrieval_protocol_contract_derived_address_sett
     static constexpr std::string_view NAME = "LOOKUP_CONTRACT_INSTANCE_RETRIEVAL_PROTOCOL_CONTRACT_DERIVED_ADDRESS";
     static constexpr std::string_view RELATION_NAME = "contract_instance_retrieval";
     static constexpr size_t LOOKUP_TUPLE_SIZE = 2;
-    static constexpr Column SRC_SELECTOR = Column::contract_instance_retrieval_is_protocol_contract;
+    static constexpr Column SRC_SELECTOR = Column::precomputed_zero;
     static constexpr Column DST_SELECTOR = Column::precomputed_sel_protocol_contract;
     static constexpr Column COUNTS =
         Column::lookup_contract_instance_retrieval_protocol_contract_derived_address_counts;
@@ -75,7 +75,7 @@ struct lookup_contract_instance_retrieval_address_derivation_settings_ {
     static constexpr std::string_view NAME = "LOOKUP_CONTRACT_INSTANCE_RETRIEVAL_ADDRESS_DERIVATION";
     static constexpr std::string_view RELATION_NAME = "contract_instance_retrieval";
     static constexpr size_t LOOKUP_TUPLE_SIZE = 13;
-    static constexpr Column SRC_SELECTOR = Column::contract_instance_retrieval_exists;
+    static constexpr Column SRC_SELECTOR = Column::precomputed_zero;
     static constexpr Column DST_SELECTOR = Column::address_derivation_sel;
     static constexpr Column COUNTS = Column::lookup_contract_instance_retrieval_address_derivation_counts;
     static constexpr Column INVERSES = Column::lookup_contract_instance_retrieval_address_derivation_inv;

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/precomputed_trace.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/precomputed_trace.cpp
@@ -629,18 +629,4 @@ void PrecomputedTraceBuilder::process_get_contract_instance_table(TraceContainer
     }
 }
 
-void PrecomputedTraceBuilder::process_protocol_contract_addresses(TraceContainer& trace)
-{
-    using C = Column;
-
-    for (const auto& [canonical_addr, derived_addr] : derived_addresses) {
-        // The canonical address is the row value (which is the execution clk)
-        trace.set(static_cast<uint32_t>(canonical_addr),
-                  { {
-                      { C::precomputed_sel_protocol_contract, 1 },
-                      { C::precomputed_protocol_contract_derived_address, derived_addr },
-                  } });
-    }
-}
-
 } // namespace bb::avm2::tracegen

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/precomputed_trace.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/precomputed_trace.hpp
@@ -28,7 +28,6 @@ class PrecomputedTraceBuilder final {
     void process_keccak_round_constants(TraceContainer& trace);
     void process_get_env_var_table(TraceContainer& trace);
     void process_get_contract_instance_table(TraceContainer& trace);
-    void process_protocol_contract_addresses(TraceContainer& trace);
 };
 
 } // namespace bb::avm2::tracegen

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen_helper.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen_helper.cpp
@@ -94,8 +94,6 @@ auto build_precomputed_columns_jobs(TraceContainer& trace)
                            precomputed_builder.process_get_env_var_table(trace));
             AVM_TRACK_TIME("tracegen/precomputed/get_contract_instance_table",
                            precomputed_builder.process_get_contract_instance_table(trace));
-            AVM_TRACK_TIME("tracegen/precomputed/protocol_contract_instance_addresses",
-                           precomputed_builder.process_protocol_contract_addresses(trace));
         },
     };
 }


### PR DESCRIPTION
Intermediate PR to disable the address derivation until we have a cleaner protocol contract instance handler

I could probably remove the TS file generation but have left it for now