### PR TITLE
chore: Persist validation status in archiver

### DIFF
--- a/yarn-project/archiver/src/archiver/archiver_store.ts
+++ b/yarn-project/archiver/src/archiver/archiver_store.ts
@@ -3,7 +3,7 @@ import type { Fr } from '@aztec/foundation/fields';
 import type { CustomRange } from '@aztec/kv-store';
 import type { FunctionSelector } from '@aztec/stdlib/abi';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
-import type { L2Block } from '@aztec/stdlib/block';
+import type { L2Block, ValidateBlockResult } from '@aztec/stdlib/block';
 import type {
   ContractClassPublic,
   ContractInstanceUpdateWithAddress,
@@ -272,4 +272,10 @@ export interface ArchiverDataStore {
 
   /** Returns the last L1 to L2 message stored. */
   getLastL1ToL2Message(): Promise<InboxMessage | undefined>;
+
+  /** Returns the last synced validation status of the pending chain. */
+  getPendingChainValidationStatus(): Promise<ValidateBlockResult | undefined>;
+
+  /** Sets the last synced validation status of the pending chain. */
+  setPendingChainValidationStatus(status: ValidateBlockResult | undefined): Promise<void>;
 }

--- a/yarn-project/archiver/src/archiver/data_retrieval.ts
+++ b/yarn-project/archiver/src/archiver/data_retrieval.ts
@@ -15,7 +15,7 @@ import type { ViemSignature } from '@aztec/foundation/eth-signature';
 import { Fr } from '@aztec/foundation/fields';
 import { type Logger, createLogger } from '@aztec/foundation/log';
 import { type InboxAbi, RollupAbi } from '@aztec/l1-artifacts';
-import { Body, CommitteeAttestation, L2Block } from '@aztec/stdlib/block';
+import { Body, CommitteeAttestation, L2Block, PublishedL2Block } from '@aztec/stdlib/block';
 import { Proof } from '@aztec/stdlib/proofs';
 import { AppendOnlyTreeSnapshot } from '@aztec/stdlib/trees';
 import { BlockHeader, GlobalVariables, ProposedBlockHeader, StateReference } from '@aztec/stdlib/tx';
@@ -33,7 +33,7 @@ import {
 import { NoBlobBodiesFoundError } from './errors.js';
 import type { DataRetrieval } from './structs/data_retrieval.js';
 import type { InboxMessage } from './structs/inbox_message.js';
-import type { L1PublishedData, PublishedL2Block } from './structs/published.js';
+import type { L1PublishedData } from './structs/published.js';
 
 export type RetrievedL2Block = {
   l2BlockNumber: number;
@@ -87,11 +87,7 @@ export function retrievedBlockToPublishedL2Block(retrievedBlock: RetrievedL2Bloc
 
   const block = new L2Block(archive, header, body);
 
-  return {
-    block,
-    l1,
-    attestations,
-  };
+  return PublishedL2Block.fromFields({ block, l1, attestations });
 }
 
 /**

--- a/yarn-project/archiver/src/archiver/kv_archiver_store/kv_archiver_store.ts
+++ b/yarn-project/archiver/src/archiver/kv_archiver_store/kv_archiver_store.ts
@@ -5,7 +5,7 @@ import { createLogger } from '@aztec/foundation/log';
 import type { AztecAsyncKVStore, CustomRange, StoreSize } from '@aztec/kv-store';
 import { FunctionSelector } from '@aztec/stdlib/abi';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
-import type { L2Block } from '@aztec/stdlib/block';
+import type { L2Block, ValidateBlockResult } from '@aztec/stdlib/block';
 import type {
   ContractClassPublic,
   ContractDataSource,
@@ -394,5 +394,13 @@ export class KVArchiverDataStore implements ArchiverDataStore, ContractDataSourc
 
   public removeL1ToL2Messages(startIndex: bigint): Promise<void> {
     return this.#messageStore.removeL1ToL2Messages(startIndex);
+  }
+
+  public getPendingChainValidationStatus(): Promise<ValidateBlockResult | undefined> {
+    return this.#blockStore.getPendingChainValidationStatus();
+  }
+
+  public setPendingChainValidationStatus(status: ValidateBlockResult | undefined): Promise<void> {
+    return this.#blockStore.setPendingChainValidationStatus(status);
   }
 }

--- a/yarn-project/archiver/src/test/mock_l2_block_source.ts
+++ b/yarn-project/archiver/src/test/mock_l2_block_source.ts
@@ -5,7 +5,14 @@ import type { Fr } from '@aztec/foundation/fields';
 import { createLogger } from '@aztec/foundation/log';
 import type { FunctionSelector } from '@aztec/stdlib/abi';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
-import { L2Block, L2BlockHash, type L2BlockSource, type L2Tips, type ValidateBlockResult } from '@aztec/stdlib/block';
+import {
+  L2Block,
+  L2BlockHash,
+  type L2BlockSource,
+  type L2Tips,
+  PublishedL2Block,
+  type ValidateBlockResult,
+} from '@aztec/stdlib/block';
 import type { ContractClassPublic, ContractDataSource, ContractInstanceWithAddress } from '@aztec/stdlib/contract';
 import { EmptyL1RollupConstants, type L1RollupConstants, getSlotRangeForEpoch } from '@aztec/stdlib/epoch-helpers';
 import { type BlockHeader, TxHash, TxReceipt, TxStatus } from '@aztec/stdlib/tx';
@@ -106,15 +113,17 @@ export class MockL2BlockSource implements L2BlockSource, ContractDataSource {
 
   public async getPublishedBlocks(from: number, limit: number, proven?: boolean) {
     const blocks = await this.getBlocks(from, limit, proven);
-    return blocks.map(block => ({
-      block,
-      l1: {
-        blockNumber: BigInt(block.number),
-        blockHash: Buffer32.random().toString(),
-        timestamp: BigInt(block.number),
-      },
-      attestations: [],
-    }));
+    return blocks.map(block =>
+      PublishedL2Block.fromFields({
+        block,
+        l1: {
+          blockNumber: BigInt(block.number),
+          blockHash: Buffer32.random().toString(),
+          timestamp: BigInt(block.number),
+        },
+        attestations: [],
+      }),
+    );
   }
 
   getBlockHeader(number: number | 'latest'): Promise<BlockHeader | undefined> {

--- a/yarn-project/foundation/src/eth-signature/eth_signature.ts
+++ b/yarn-project/foundation/src/eth-signature/eth_signature.ts
@@ -94,9 +94,7 @@ export class Signature {
   }
 
   toBuffer(): Buffer {
-    const buffer = serializeToBuffer([this.r, this.s, this.v]);
-    this.size = buffer.length;
-    return buffer;
+    return serializeToBuffer([this.r, this.s, this.v]);
   }
 
   getSize(): number {

--- a/yarn-project/foundation/src/serialize/buffer_reader.ts
+++ b/yarn-project/foundation/src/serialize/buffer_reader.ts
@@ -130,6 +130,11 @@ export class BufferReader {
     return result;
   }
 
+  /** Alias for readUInt256 */
+  public readBigInt(): bigint {
+    return this.readUInt256();
+  }
+
   /**
    * Reads a 16-bit unsigned integer from the buffer at the current index position.
    * Updates the index position by 2 bytes after reading the number.

--- a/yarn-project/p2p/src/mem_pools/attestation_pool/attestation_pool_test_suite.ts
+++ b/yarn-project/p2p/src/mem_pools/attestation_pool/attestation_pool_test_suite.ts
@@ -264,10 +264,6 @@ export function describeAttestationPool(getAttestationPool: () => AttestationPoo
 
       const retrievedProposal = await ap.getBlockProposal(proposalId);
 
-      // This are cached values, so we need to call them to ensure they are not undefined
-      retrievedProposal!.payload.getSize();
-      retrievedProposal!.signature.getSize();
-
       expect(retrievedProposal).toBeDefined();
       expect(retrievedProposal!).toEqual(proposal);
     });
@@ -376,10 +372,6 @@ export function describeAttestationPool(getAttestationPool: () => AttestationPoo
       const retrievedAttestations = await ap.getAttestationsForSlotAndProposal(BigInt(slotNumber), proposalId);
 
       expect(retrievedProposal).toBeDefined();
-      // This are cached values, so we need to call them to ensure they are not undefined
-      retrievedProposal!.payload.getSize();
-      retrievedProposal!.signature.getSize();
-
       expect(retrievedProposal).toEqual(proposal);
 
       compareAttestations(retrievedAttestations, attestations);

--- a/yarn-project/p2p/src/services/tx_collection/fast_tx_collection.ts
+++ b/yarn-project/p2p/src/services/tx_collection/fast_tx_collection.ts
@@ -5,7 +5,7 @@ import { boundInclusive } from '@aztec/foundation/number';
 import { promiseWithResolvers } from '@aztec/foundation/promise';
 import { sleep } from '@aztec/foundation/sleep';
 import { DateProvider, elapsed } from '@aztec/foundation/timer';
-import type { BlockInfo } from '@aztec/stdlib/block';
+import type { L2BlockInfo } from '@aztec/stdlib/block';
 import type { BlockProposal } from '@aztec/stdlib/p2p';
 import { type Tx, TxHash } from '@aztec/stdlib/tx';
 
@@ -54,7 +54,7 @@ export class FastTxCollection {
       return [];
     }
 
-    const blockInfo: BlockInfo =
+    const blockInfo: L2BlockInfo =
       input.type === 'proposal' ? input.blockProposal.toBlockInfo() : input.block.toBlockInfo();
 
     // This promise is used to await for the collection to finish during the main collectFast method.

--- a/yarn-project/p2p/src/services/tx_collection/tx_collection.ts
+++ b/yarn-project/p2p/src/services/tx_collection/tx_collection.ts
@@ -2,7 +2,7 @@ import { compactArray } from '@aztec/foundation/collection';
 import { type Logger, createLogger } from '@aztec/foundation/log';
 import { type PromiseWithResolvers, RunningPromise } from '@aztec/foundation/promise';
 import { DateProvider } from '@aztec/foundation/timer';
-import type { BlockInfo, L2Block } from '@aztec/stdlib/block';
+import type { L2Block, L2BlockInfo } from '@aztec/stdlib/block';
 import type { L1RollupConstants } from '@aztec/stdlib/epoch-helpers';
 import type { BlockProposal } from '@aztec/stdlib/p2p';
 import { Tx, TxHash } from '@aztec/stdlib/tx';
@@ -30,7 +30,7 @@ export type FastCollectionRequestInput =
 export type FastCollectionRequest = FastCollectionRequestInput & {
   missingTxHashes: Set<string>;
   deadline: Date;
-  blockInfo: BlockInfo;
+  blockInfo: L2BlockInfo;
   promise: PromiseWithResolvers<void>;
   foundTxs: Map<string, Tx>;
 };

--- a/yarn-project/p2p/src/services/tx_provider.ts
+++ b/yarn-project/p2p/src/services/tx_provider.ts
@@ -1,7 +1,7 @@
 import { compactArray } from '@aztec/foundation/collection';
 import { type Logger, createLogger } from '@aztec/foundation/log';
 import { elapsed } from '@aztec/foundation/timer';
-import type { BlockInfo, L2Block } from '@aztec/stdlib/block';
+import type { L2Block, L2BlockInfo } from '@aztec/stdlib/block';
 import type { ITxProvider } from '@aztec/stdlib/interfaces/server';
 import type { BlockProposal } from '@aztec/stdlib/p2p';
 import { Tx, TxHash } from '@aztec/stdlib/tx';
@@ -77,7 +77,7 @@ export class TxProvider implements ITxProvider {
 
   private async getOrderedTxsFromAllSources(
     request: FastCollectionRequestInput,
-    blockInfo: BlockInfo,
+    blockInfo: L2BlockInfo,
     txHashes: TxHash[],
     opts: { pinnedPeer: PeerId | undefined; deadline: Date },
   ) {
@@ -114,7 +114,7 @@ export class TxProvider implements ITxProvider {
 
   private async getTxsFromAllSources(
     request: FastCollectionRequestInput,
-    blockInfo: BlockInfo,
+    blockInfo: L2BlockInfo,
     txHashes: TxHash[],
     opts: { pinnedPeer: PeerId | undefined; deadline: Date },
   ) {

--- a/yarn-project/prover-node/src/job/epoch-proving-job-data.test.ts
+++ b/yarn-project/prover-node/src/job/epoch-proving-job-data.test.ts
@@ -30,7 +30,6 @@ describe('EpochProvingJobData', () => {
 
     const serialized = serializeEpochProvingJobData(jobData);
     const deserialized = deserializeEpochProvingJobData(serialized);
-    deserialized.attestations.forEach(a => a.signature.getSize());
     expect(deserialized).toEqual(jobData);
   });
 });

--- a/yarn-project/sequencer-client/src/publisher/sequencer-publisher.ts
+++ b/yarn-project/sequencer-client/src/publisher/sequencer-publisher.ts
@@ -386,11 +386,11 @@ export class SequencerPublisher {
     }
 
     const { reason, block } = validationResult;
-    const blockNumber = block.block.number;
-    const logData = { ...block.block.toBlockInfo(), reason };
+    const blockNumber = block.blockNumber;
+    const logData = { ...block, reason };
 
     const currentBlockNumber = await this.rollupContract.getBlockNumber();
-    if (currentBlockNumber < validationResult.block.block.number) {
+    if (currentBlockNumber < validationResult.block.blockNumber) {
       this.log.verbose(
         `Skipping block ${blockNumber} invalidation since it has already been removed from the pending chain`,
         { currentBlockNumber, ...logData },
@@ -444,21 +444,23 @@ export class SequencerPublisher {
     }
 
     const { block, committee, reason } = validationResult;
-    const logData = { ...block.block.toBlockInfo(), reason };
-    this.log.debug(`Simulating invalidate block ${block.block.number}`, logData);
+    const logData = { ...block, reason };
+    this.log.debug(`Simulating invalidate block ${block.blockNumber}`, logData);
 
-    const attestationsAndSigners = new CommitteeAttestationsAndSigners(block.attestations).getPackedAttestations();
+    const attestationsAndSigners = new CommitteeAttestationsAndSigners(
+      validationResult.attestations,
+    ).getPackedAttestations();
 
     if (reason === 'invalid-attestation') {
       return this.rollupContract.buildInvalidateBadAttestationRequest(
-        block.block.number,
+        block.blockNumber,
         attestationsAndSigners,
         committee,
         validationResult.invalidIndex,
       );
     } else if (reason === 'insufficient-attestations') {
       return this.rollupContract.buildInvalidateInsufficientAttestationsRequest(
-        block.block.number,
+        block.blockNumber,
         attestationsAndSigners,
         committee,
       );

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.ts
@@ -907,17 +907,17 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
       return;
     }
 
-    const invalidL1Timestamp = pendingChainValidationStatus.block.l1.timestamp;
-    const timeSinceChainInvalid = this.dateProvider.nowInSeconds() - Number(invalidL1Timestamp);
-    const invalidBlockNumber = pendingChainValidationStatus.block.block.number;
+    const invalidBlockNumber = pendingChainValidationStatus.block.blockNumber;
+    const invalidBlockTimestamp = pendingChainValidationStatus.block.timestamp;
+    const timeSinceChainInvalid = this.dateProvider.nowInSeconds() - Number(invalidBlockTimestamp);
 
     const { secondsBeforeInvalidatingBlockAsCommitteeMember, secondsBeforeInvalidatingBlockAsNonCommitteeMember } =
       this.config;
 
     const logData = {
-      invalidL1Timestamp,
+      invalidL1Timestamp: invalidBlockTimestamp,
       l1Timestamp,
-      invalidBlock: pendingChainValidationStatus.block.block.toBlockInfo(),
+      invalidBlock: pendingChainValidationStatus.block,
       secondsBeforeInvalidatingBlockAsCommitteeMember,
       secondsBeforeInvalidatingBlockAsNonCommitteeMember,
       ourValidatorAddresses,

--- a/yarn-project/stdlib/src/block/index.ts
+++ b/yarn-project/stdlib/src/block/index.ts
@@ -7,3 +7,5 @@ export * from './l2_block_source.js';
 export * from './block_hash.js';
 export * from './published_l2_block.js';
 export * from './proposal/index.js';
+export * from './validate_block_result.js';
+export * from './l2_block_info.js';

--- a/yarn-project/stdlib/src/block/l2_block.ts
+++ b/yarn-project/stdlib/src/block/l2_block.ts
@@ -8,6 +8,7 @@ import { AppendOnlyTreeSnapshot } from '../trees/append_only_tree_snapshot.js';
 import { BlockHeader } from '../tx/block_header.js';
 import { Body } from './body.js';
 import { makeAppendOnlyTreeSnapshot, makeHeader } from './l2_block_code_to_purge.js';
+import type { L2BlockInfo } from './l2_block_info.js';
 
 /**
  * The data that makes up the rollup proof, with encoder decoder functions.
@@ -156,13 +157,15 @@ export class L2Block {
     };
   }
 
-  toBlockInfo(): BlockInfo {
+  toBlockInfo(): L2BlockInfo {
     return {
-      blockHash: this.blockHash?.toString(),
-      archive: this.archive.root.toString(),
+      blockHash: this.blockHash,
+      archive: this.archive.root,
+      lastArchive: this.header.lastArchive.root,
       blockNumber: this.number,
       slotNumber: Number(this.header.getSlot()),
       txCount: this.body.txEffects.length,
+      timestamp: this.header.globalVariables.timestamp,
     };
   }
 
@@ -170,11 +173,3 @@ export class L2Block {
     return this.archive.equals(other.archive) && this.header.equals(other.header) && this.body.equals(other.body);
   }
 }
-
-export type BlockInfo = {
-  blockHash?: string;
-  archive: string;
-  blockNumber: number;
-  slotNumber: number;
-  txCount: number;
-};

--- a/yarn-project/stdlib/src/block/l2_block_info.ts
+++ b/yarn-project/stdlib/src/block/l2_block_info.ts
@@ -1,0 +1,63 @@
+import { Fr } from '@aztec/foundation/fields';
+import { schemas } from '@aztec/foundation/schemas';
+import { BufferReader, serializeToBuffer } from '@aztec/foundation/serialize';
+
+import { z } from 'zod';
+
+export type L2BlockInfo = {
+  blockHash?: Fr;
+  archive: Fr;
+  lastArchive: Fr;
+  blockNumber: number;
+  slotNumber: number;
+  txCount: number;
+  timestamp: bigint;
+};
+
+export function randomBlockInfo(blockNumber?: number): L2BlockInfo {
+  return {
+    blockHash: Fr.random(),
+    archive: Fr.random(),
+    lastArchive: Fr.random(),
+    blockNumber: blockNumber ?? Math.floor(Math.random() * 100000) + 1,
+    slotNumber: Math.floor(Math.random() * 100000) + 1,
+    txCount: Math.floor(Math.random() * 100),
+    timestamp: BigInt(Math.floor(Date.now() / 1000)),
+  };
+}
+
+export const BlockInfoSchema = z.object({
+  blockHash: schemas.Fr.optional(),
+  archive: schemas.Fr,
+  lastArchive: schemas.Fr,
+  blockNumber: z.number(),
+  slotNumber: z.number(),
+  txCount: z.number(),
+  timestamp: schemas.BigInt,
+});
+
+export function serializeBlockInfo(blockInfo: L2BlockInfo): Buffer {
+  return serializeToBuffer(
+    blockInfo.blockHash ?? Fr.ZERO,
+    blockInfo.archive,
+    blockInfo.lastArchive,
+    blockInfo.blockNumber,
+    blockInfo.slotNumber,
+    blockInfo.txCount,
+    blockInfo.timestamp,
+  );
+}
+
+export function deserializeBlockInfo(buffer: Buffer | BufferReader): L2BlockInfo {
+  const reader = BufferReader.asReader(buffer);
+  const blockHash = reader.readObject(Fr);
+  return {
+    blockHash: blockHash.equals(Fr.ZERO) ? undefined : blockHash,
+    archive: reader.readObject(Fr),
+    lastArchive: reader.readObject(Fr),
+    blockNumber: reader.readNumber(),
+    slotNumber: reader.readNumber(),
+    txCount: reader.readNumber(),
+    timestamp: reader.readBigInt(),
+  };
+}

--- a/yarn-project/stdlib/src/block/l2_block_source.ts
+++ b/yarn-project/stdlib/src/block/l2_block_source.ts
@@ -1,17 +1,16 @@
 import type { EthAddress } from '@aztec/foundation/eth-address';
-import { type ZodFor, schemas } from '@aztec/foundation/schemas';
 import type { TypedEventEmitter } from '@aztec/foundation/types';
 
 import { z } from 'zod';
 
 import type { L1RollupConstants } from '../epoch-helpers/index.js';
-import { BlockAttestation } from '../p2p/block_attestation.js';
 import type { BlockHeader } from '../tx/block_header.js';
 import type { IndexedTxEffect } from '../tx/indexed_tx_effect.js';
 import type { TxHash } from '../tx/tx_hash.js';
 import type { TxReceipt } from '../tx/tx_receipt.js';
 import type { L2Block } from './l2_block.js';
 import { PublishedL2Block } from './published_l2_block.js';
+import type { ValidateBlockNegativeResult, ValidateBlockResult } from './validate_block_result.js';
 
 /**
  * Interface of classes allowing for the retrieval of L2 blocks.
@@ -140,59 +139,10 @@ export interface L2BlockSource {
   syncImmediate(): Promise<void>;
 }
 
-/** Subtype for invalid block validation results */
-export type ValidateBlockNegativeResult =
-  | {
-      valid: false;
-      block: PublishedL2Block;
-      committee: EthAddress[];
-      epoch: bigint;
-      seed: bigint;
-      attestations: BlockAttestation[];
-      reason: 'insufficient-attestations';
-    }
-  | {
-      valid: false;
-      block: PublishedL2Block;
-      committee: EthAddress[];
-      epoch: bigint;
-      seed: bigint;
-      reason: 'invalid-attestation';
-      attestations: BlockAttestation[];
-      invalidIndex: number;
-    };
-
-/** Result type for validating a block attestations */
-export type ValidateBlockResult = { valid: true } | ValidateBlockNegativeResult;
-
-export const ValidateBlockResultSchema = z.union([
-  z.object({ valid: z.literal(true), block: PublishedL2Block.schema.optional() }),
-  z.object({
-    valid: z.literal(false),
-    block: PublishedL2Block.schema,
-    committee: z.array(schemas.EthAddress),
-    epoch: schemas.BigInt,
-    seed: schemas.BigInt,
-    attestations: z.array(BlockAttestation.schema),
-    reason: z.literal('insufficient-attestations'),
-  }),
-  z.object({
-    valid: z.literal(false),
-    block: PublishedL2Block.schema,
-    committee: z.array(schemas.EthAddress),
-    epoch: schemas.BigInt,
-    seed: schemas.BigInt,
-    attestations: z.array(BlockAttestation.schema),
-    reason: z.literal('invalid-attestation'),
-    invalidIndex: z.number(),
-  }),
-]) satisfies ZodFor<ValidateBlockResult>;
-
 /**
  * L2BlockSource that emits events upon pending / proven chain changes.
  * see L2BlockSourceEvents for the events emitted.
  */
-
 export type ArchiverEmitter = TypedEventEmitter<{
   [L2BlockSourceEvents.L2PruneDetected]: (args: L2BlockPruneEvent) => void;
   [L2BlockSourceEvents.L2BlockProven]: (args: L2BlockProvenEvent) => void;

--- a/yarn-project/stdlib/src/block/published_l2_block.test.ts
+++ b/yarn-project/stdlib/src/block/published_l2_block.test.ts
@@ -1,17 +1,19 @@
 import { jsonStringify } from '@aztec/foundation/json-rpc';
+import { randomPublishedL2Block } from '@aztec/stdlib/testing';
 
-import { L2Block } from './l2_block.js';
-import { CommitteeAttestation } from './proposal/committee_attestation.js';
 import { PublishedL2Block } from './published_l2_block.js';
 
 describe('PublishedL2Block', () => {
   it('convert to and from json', async () => {
-    const block = {
-      block: await L2Block.random(1),
-      attestations: [CommitteeAttestation.random()],
-      l1: { blockHash: `0x`, blockNumber: 1n, timestamp: 0n },
-    };
+    const block = await randomPublishedL2Block(1);
     const parsed = PublishedL2Block.schema.parse(JSON.parse(jsonStringify(block)));
     expect(parsed).toEqual(block);
+  });
+
+  it('serializes and deserializes to buffer', async () => {
+    const block = await randomPublishedL2Block(1);
+    const serialized = block.toBuffer();
+    const deserialized = PublishedL2Block.fromBuffer(serialized);
+    expect(deserialized).toEqual(block);
   });
 });

--- a/yarn-project/stdlib/src/block/test/l2_tips_store_test_suite.ts
+++ b/yarn-project/stdlib/src/block/test/l2_tips_store_test_suite.ts
@@ -1,6 +1,6 @@
 import { times } from '@aztec/foundation/collection';
 import { Fr } from '@aztec/foundation/fields';
-import type { L2Block, L2BlockId, PublishedL2Block } from '@aztec/stdlib/block';
+import { type L2Block, type L2BlockId, PublishedL2Block } from '@aztec/stdlib/block';
 import type { BlockHeader } from '@aztec/stdlib/tx';
 
 import { jestExpect as expect } from '@jest/expect';
@@ -14,11 +14,12 @@ export function testL2TipsStore(makeTipsStore: () => Promise<L2TipsStore>) {
     tipsStore = await makeTipsStore();
   });
 
-  const makeBlock = (number: number): PublishedL2Block => ({
-    block: { number, header: { hash: () => Promise.resolve(new Fr(number)) } as BlockHeader } as L2Block,
-    l1: { blockNumber: BigInt(number), blockHash: `0x${number}`, timestamp: BigInt(number) },
-    attestations: [],
-  });
+  const makeBlock = (number: number): PublishedL2Block =>
+    PublishedL2Block.fromFields({
+      block: { number, header: { hash: () => Promise.resolve(new Fr(number)) } as BlockHeader } as L2Block,
+      l1: { blockNumber: BigInt(number), blockHash: `0x${number}`, timestamp: BigInt(number) },
+      attestations: [],
+    });
 
   const makeBlockId = (number: number): L2BlockId => ({
     number,

--- a/yarn-project/stdlib/src/block/validate_block_result.test.ts
+++ b/yarn-project/stdlib/src/block/validate_block_result.test.ts
@@ -1,0 +1,53 @@
+import { EthAddress } from '@aztec/foundation/eth-address';
+
+import { randomBlockInfo } from './l2_block_info.js';
+import { CommitteeAttestation } from './proposal/committee_attestation.js';
+import {
+  type ValidateBlockResult,
+  deserializeValidateBlockResult,
+  serializeValidateBlockResult,
+} from './validate_block_result.js';
+
+describe('ValidateBlockResult', () => {
+  describe('serialization to buffer', () => {
+    it('valid result', () => {
+      const result: ValidateBlockResult = { valid: true };
+      const serialized = serializeValidateBlockResult(result);
+      const deserialized = deserializeValidateBlockResult(serialized);
+      expect(deserialized).toEqual(result);
+    });
+
+    it('invalid-attestation result', () => {
+      const result: ValidateBlockResult = {
+        valid: false,
+        reason: 'invalid-attestation',
+        block: randomBlockInfo(),
+        committee: [EthAddress.random(), EthAddress.random()],
+        epoch: 1n,
+        seed: 2n,
+        attestors: [EthAddress.random(), EthAddress.random()],
+        invalidIndex: 4,
+        attestations: [CommitteeAttestation.random(), CommitteeAttestation.random()],
+      };
+      const serialized = serializeValidateBlockResult(result);
+      const deserialized = deserializeValidateBlockResult(serialized);
+      expect(deserialized).toEqual(result);
+    });
+
+    it('insufficient-attestations result', () => {
+      const result: ValidateBlockResult = {
+        valid: false,
+        reason: 'insufficient-attestations',
+        block: randomBlockInfo(),
+        committee: [EthAddress.random(), EthAddress.random()],
+        epoch: 1n,
+        seed: 2n,
+        attestors: [EthAddress.random(), EthAddress.random()],
+        attestations: [CommitteeAttestation.random(), CommitteeAttestation.random()],
+      };
+      const serialized = serializeValidateBlockResult(result);
+      const deserialized = deserializeValidateBlockResult(serialized);
+      expect(deserialized).toEqual(result);
+    });
+  });
+});

--- a/yarn-project/stdlib/src/block/validate_block_result.ts
+++ b/yarn-project/stdlib/src/block/validate_block_result.ts
@@ -1,0 +1,122 @@
+import { EthAddress } from '@aztec/foundation/eth-address';
+import { type ZodFor, schemas } from '@aztec/foundation/schemas';
+import { BufferReader, serializeToBuffer } from '@aztec/foundation/serialize';
+
+import { z } from 'zod';
+
+import { BlockInfoSchema, type L2BlockInfo, deserializeBlockInfo, serializeBlockInfo } from './l2_block_info.js';
+import { CommitteeAttestation } from './proposal/committee_attestation.js';
+
+/** Subtype for invalid block validation results */
+export type ValidateBlockNegativeResult =
+  | {
+      valid: false;
+      /** Identifiers from the invalid block */
+      block: L2BlockInfo;
+      /** Committee members at the epoch this block was proposed */
+      committee: EthAddress[];
+      /** Epoch in which this block was proposed */
+      epoch: bigint;
+      /** Proposer selection seed for the epoch */
+      seed: bigint;
+      /** List of committee members who signed this block proposal */
+      attestors: EthAddress[];
+      /** Committee attestations for this block as they were posted to L1 */
+      attestations: CommitteeAttestation[];
+      /** Reason for the block being invalid: not enough attestations were posted */
+      reason: 'insufficient-attestations';
+    }
+  | {
+      valid: false;
+      /** Identifiers from the invalid block */
+      block: L2BlockInfo;
+      /** Committee members at the epoch this block was proposed */
+      committee: EthAddress[];
+      /** Epoch in which this block was proposed */
+      epoch: bigint;
+      /** Proposer selection seed for the epoch */
+      seed: bigint;
+      /** List of committee members who signed this block proposal */
+      attestors: EthAddress[];
+      /** Committee attestations for this block as they were posted to L1 */
+      attestations: CommitteeAttestation[];
+      /** Reason for the block being invalid: an invalid attestation was posted */
+      reason: 'invalid-attestation';
+      /** Index in the attestations array of the invalid attestation posted */
+      invalidIndex: number;
+    };
+
+/** Result type for validating a block attestations */
+export type ValidateBlockResult = { valid: true } | ValidateBlockNegativeResult;
+
+export const ValidateBlockResultSchema = z.union([
+  z.object({ valid: z.literal(true) }),
+  z.object({
+    valid: z.literal(false),
+    block: BlockInfoSchema,
+    committee: z.array(schemas.EthAddress),
+    epoch: schemas.BigInt,
+    seed: schemas.BigInt,
+    attestors: z.array(schemas.EthAddress),
+    attestations: z.array(CommitteeAttestation.schema),
+    reason: z.literal('insufficient-attestations'),
+  }),
+  z.object({
+    valid: z.literal(false),
+    block: BlockInfoSchema,
+    committee: z.array(schemas.EthAddress),
+    epoch: schemas.BigInt,
+    seed: schemas.BigInt,
+    attestors: z.array(schemas.EthAddress),
+    attestations: z.array(CommitteeAttestation.schema),
+    reason: z.literal('invalid-attestation'),
+    invalidIndex: z.number(),
+  }),
+]) satisfies ZodFor<ValidateBlockResult>;
+
+export function serializeValidateBlockResult(result: ValidateBlockResult): Buffer {
+  if (result.valid) {
+    return serializeToBuffer(true);
+  }
+
+  const l2Block = serializeBlockInfo(result.block);
+  return serializeToBuffer(
+    result.valid,
+    result.reason,
+    l2Block.length,
+    l2Block,
+    result.committee.length,
+    result.committee,
+    result.epoch,
+    result.seed ?? 0n,
+    result.attestors.length,
+    result.attestors,
+    result.attestations.length,
+    result.attestations,
+    result.reason === 'invalid-attestation' ? result.invalidIndex : 0,
+  );
+}
+
+export function deserializeValidateBlockResult(bufferOrReader: Buffer | BufferReader): ValidateBlockResult {
+  const reader = BufferReader.asReader(bufferOrReader);
+  const valid = reader.readBoolean();
+  if (valid) {
+    return { valid };
+  }
+  const reason = reader.readString() as 'insufficient-attestations' | 'invalid-attestation';
+  const block = deserializeBlockInfo(reader.readBuffer());
+  const committee = reader.readVector(EthAddress);
+  const epoch = reader.readBigInt();
+  const seed = reader.readBigInt();
+  const attestors = reader.readVector(EthAddress);
+  const attestations = reader.readVector(CommitteeAttestation);
+  const invalidIndex = reader.readNumber();
+  if (reason === 'insufficient-attestations') {
+    return { valid, reason, block, committee, epoch, seed, attestors, attestations: attestations };
+  } else if (reason === 'invalid-attestation') {
+    return { valid, reason, block, committee, epoch, seed, attestors, invalidIndex, attestations: attestations };
+  } else {
+    const _: never = reason;
+    throw new Error(`Unknown reason: ${reason}`);
+  }
+}

--- a/yarn-project/stdlib/src/interfaces/archiver.test.ts
+++ b/yarn-project/stdlib/src/interfaces/archiver.test.ts
@@ -10,8 +10,9 @@ import { FunctionSelector } from '../abi/function_selector.js';
 import { AztecAddress } from '../aztec-address/index.js';
 import { CommitteeAttestation, L2BlockHash } from '../block/index.js';
 import { L2Block } from '../block/l2_block.js';
-import type { L2Tips, ValidateBlockResult } from '../block/l2_block_source.js';
-import type { PublishedL2Block } from '../block/published_l2_block.js';
+import type { L2Tips } from '../block/l2_block_source.js';
+import { PublishedL2Block } from '../block/published_l2_block.js';
+import type { ValidateBlockResult } from '../block/validate_block_result.js';
 import { getContractClassFromArtifact } from '../contract/contract_class.js';
 import {
   type ContractClassPublic,
@@ -292,11 +293,11 @@ class MockArchiver implements ArchiverApi {
   }
   async getPublishedBlocks(from: number, _limit: number, _proven?: boolean): Promise<PublishedL2Block[]> {
     return [
-      {
+      PublishedL2Block.fromFields({
         block: await L2Block.random(from),
         attestations: [CommitteeAttestation.random()],
         l1: { blockHash: `0x`, blockNumber: 1n, timestamp: 0n },
-      },
+      }),
     ];
   }
   async getTxEffect(_txHash: TxHash): Promise<IndexedTxEffect | undefined> {

--- a/yarn-project/stdlib/src/interfaces/archiver.ts
+++ b/yarn-project/stdlib/src/interfaces/archiver.ts
@@ -3,8 +3,9 @@ import type { ApiSchemaFor } from '@aztec/foundation/schemas';
 import { z } from 'zod';
 
 import { L2Block } from '../block/l2_block.js';
-import { type L2BlockSource, L2TipsSchema, ValidateBlockResultSchema } from '../block/l2_block_source.js';
+import { type L2BlockSource, L2TipsSchema } from '../block/l2_block_source.js';
 import { PublishedL2Block } from '../block/published_l2_block.js';
+import { ValidateBlockResultSchema } from '../block/validate_block_result.js';
 import {
   ContractClassPublicSchema,
   type ContractDataSource,

--- a/yarn-project/stdlib/src/interfaces/aztec-node.test.ts
+++ b/yarn-project/stdlib/src/interfaces/aztec-node.test.ts
@@ -7,6 +7,7 @@ import {
 } from '@aztec/constants';
 import { type L1ContractAddresses, L1ContractsNames } from '@aztec/ethereum/l1-contract-addresses';
 import { Buffer32 } from '@aztec/foundation/buffer';
+import { timesAsync } from '@aztec/foundation/collection';
 import { randomInt } from '@aztec/foundation/crypto';
 import { memoize } from '@aztec/foundation/decorators';
 import { EthAddress } from '@aztec/foundation/eth-address';
@@ -23,7 +24,7 @@ import type { InBlock } from '../block/in_block.js';
 import { CommitteeAttestation, L2BlockHash, type L2BlockNumber } from '../block/index.js';
 import { L2Block } from '../block/l2_block.js';
 import type { L2Tips } from '../block/l2_block_source.js';
-import type { PublishedL2Block } from '../block/published_l2_block.js';
+import { PublishedL2Block } from '../block/published_l2_block.js';
 import {
   type ContractClassPublic,
   type ContractInstanceWithAddress,
@@ -610,14 +611,12 @@ class MockAztecNode implements AztecNode {
     );
   }
   getPublishedBlocks(from: number, limit: number): Promise<PublishedL2Block[]> {
-    return Promise.all(
-      Array(limit)
-        .fill(0)
-        .map(async i => ({
-          block: await L2Block.random(from + i),
-          attestations: [CommitteeAttestation.random()],
-          l1: { blockHash: Buffer32.random().toString(), blockNumber: 1n, timestamp: 1n },
-        })),
+    return timesAsync(limit, async i =>
+      PublishedL2Block.fromFields({
+        block: await L2Block.random(from + i),
+        attestations: [CommitteeAttestation.random()],
+        l1: { blockHash: Buffer32.random().toString(), blockNumber: 1n, timestamp: 1n },
+      }),
     );
   }
   getNodeVersion(): Promise<string> {

--- a/yarn-project/stdlib/src/p2p/block_attestation.ts
+++ b/yarn-project/stdlib/src/p2p/block_attestation.ts
@@ -98,6 +98,10 @@ export class BlockAttestation extends Gossipable {
     return new BlockAttestation(0, ConsensusPayload.empty(), Signature.empty());
   }
 
+  static random(): BlockAttestation {
+    return new BlockAttestation(Math.floor(Math.random() * 1000) + 1, ConsensusPayload.random(), Signature.random());
+  }
+
   getSize(): number {
     return 4 /* blockNumber */ + this.payload.getSize() + this.signature.getSize();
   }

--- a/yarn-project/stdlib/src/p2p/block_proposal.ts
+++ b/yarn-project/stdlib/src/p2p/block_proposal.ts
@@ -5,7 +5,7 @@ import { Signature } from '@aztec/foundation/eth-signature';
 import { Fr } from '@aztec/foundation/fields';
 import { BufferReader, serializeToBuffer } from '@aztec/foundation/serialize';
 
-import type { BlockInfo } from '../block/l2_block.js';
+import type { L2BlockInfo } from '../block/l2_block_info.js';
 import { TxHash } from '../tx/index.js';
 import { Tx } from '../tx/tx.js';
 import type { UInt32 } from '../types/index.js';
@@ -71,11 +71,13 @@ export class BlockProposal extends Gossipable {
     return this.payload.header.slotNumber;
   }
 
-  toBlockInfo(): BlockInfo {
+  toBlockInfo(): L2BlockInfo {
     return {
       blockNumber: this.blockNumber,
       slotNumber: this.slotNumber.toNumber(),
-      archive: this.archive.toString(),
+      lastArchive: this.payload.header.lastArchiveRoot,
+      timestamp: this.payload.header.timestamp,
+      archive: this.archive,
       txCount: this.txHashes.length,
     };
   }

--- a/yarn-project/stdlib/src/p2p/consensus_payload.ts
+++ b/yarn-project/stdlib/src/p2p/consensus_payload.ts
@@ -60,18 +60,17 @@ export class ConsensusPayload implements Signable {
   }
 
   toBuffer(): Buffer {
-    const buffer = serializeToBuffer([this.header, this.archive, this.stateReference]);
-    this.size = buffer.length;
-    return buffer;
+    return serializeToBuffer([this.header, this.archive, this.stateReference]);
   }
 
   static fromBuffer(buf: Buffer | BufferReader): ConsensusPayload {
     const reader = BufferReader.asReader(buf);
-    return new ConsensusPayload(
+    const payload = new ConsensusPayload(
       reader.readObject(ProposedBlockHeader),
       reader.readObject(Fr),
       reader.readObject(StateReference),
     );
+    return payload;
   }
 
   static fromFields(fields: FieldsOf<ConsensusPayload>): ConsensusPayload {
@@ -84,6 +83,10 @@ export class ConsensusPayload implements Signable {
 
   static empty(): ConsensusPayload {
     return new ConsensusPayload(ProposedBlockHeader.empty(), Fr.ZERO, StateReference.empty());
+  }
+
+  static random(): ConsensusPayload {
+    return new ConsensusPayload(ProposedBlockHeader.random(), Fr.random(), StateReference.random());
   }
 
   /**

--- a/yarn-project/stdlib/src/tests/mocks.ts
+++ b/yarn-project/stdlib/src/tests/mocks.ts
@@ -6,10 +6,10 @@ import { Fr } from '@aztec/foundation/fields';
 
 import type { ContractArtifact } from '../abi/abi.js';
 import { AztecAddress } from '../aztec-address/index.js';
-import { CommitteeAttestation } from '../block/index.js';
+import { CommitteeAttestation, L1PublishedData } from '../block/index.js';
 import { L2Block } from '../block/l2_block.js';
 import type { CommitteeAttestationsAndSigners } from '../block/proposal/attestations_and_signers.js';
-import type { PublishedL2Block } from '../block/published_l2_block.js';
+import { PublishedL2Block } from '../block/published_l2_block.js';
 import { computeContractAddressFromInstance } from '../contract/contract_address.js';
 import { getContractClassFromArtifact } from '../contract/contract_class.js';
 import { SerializableContractInstance } from '../contract/contract_instance.js';
@@ -318,16 +318,16 @@ export async function randomPublishedL2Block(
   opts: { signers?: Secp256k1Signer[] } = {},
 ): Promise<PublishedL2Block> {
   const block = await L2Block.random(l2BlockNumber);
-  const l1 = {
+  const l1 = L1PublishedData.fromFields({
     blockNumber: BigInt(block.number),
     timestamp: block.header.globalVariables.timestamp,
     blockHash: Buffer32.random().toString(),
-  };
+  });
 
   const signers = opts.signers ?? times(3, () => Secp256k1Signer.random());
   const atts = await Promise.all(signers.map(signer => makeBlockAttestationFromBlock(block, signer)));
   const attestations = atts.map(
     (attestation, i) => new CommitteeAttestation(signers[i].address, attestation.signature),
   );
-  return { block, l1, attestations };
+  return new PublishedL2Block(block, l1, attestations);
 }

--- a/yarn-project/stdlib/src/tx/content_commitment.ts
+++ b/yarn-project/stdlib/src/tx/content_commitment.ts
@@ -75,6 +75,10 @@ export class ContentCommitment {
     return new ContentCommitment(reader.readField(), reader.readField(), reader.readField());
   }
 
+  static random(): ContentCommitment {
+    return new ContentCommitment(Fr.random(), Fr.random(), Fr.random());
+  }
+
   static empty(): ContentCommitment {
     return new ContentCommitment(Fr.zero(), Fr.zero(), Fr.zero());
   }

--- a/yarn-project/stdlib/src/tx/partial_state_reference.ts
+++ b/yarn-project/stdlib/src/tx/partial_state_reference.ts
@@ -64,6 +64,14 @@ export class PartialStateReference {
     );
   }
 
+  static random(): PartialStateReference {
+    return new PartialStateReference(
+      AppendOnlyTreeSnapshot.random(),
+      AppendOnlyTreeSnapshot.random(),
+      AppendOnlyTreeSnapshot.random(),
+    );
+  }
+
   toViem(): ViemPartialStateReference {
     return {
       noteHashTree: this.noteHashTree.toViem(),

--- a/yarn-project/stdlib/src/tx/proposed_block_header.ts
+++ b/yarn-project/stdlib/src/tx/proposed_block_header.ts
@@ -116,6 +116,19 @@ export class ProposedBlockHeader {
     });
   }
 
+  static random(): ProposedBlockHeader {
+    return new ProposedBlockHeader(
+      Fr.random(),
+      ContentCommitment.random(),
+      new Fr(BigInt(Math.floor(Math.random() * 1000) + 1)),
+      BigInt(Math.floor(Date.now() / 1000)),
+      EthAddress.random(),
+      new AztecAddress(Fr.random()),
+      GasFees.random(),
+      new Fr(BigInt(Math.floor(Math.random() * 1000000))),
+    );
+  }
+
   isEmpty(): boolean {
     return (
       this.lastArchiveRoot.isZero() &&

--- a/yarn-project/stdlib/src/tx/state_reference.ts
+++ b/yarn-project/stdlib/src/tx/state_reference.ts
@@ -78,6 +78,10 @@ export class StateReference {
     return new StateReference(AppendOnlyTreeSnapshot.empty(), PartialStateReference.empty());
   }
 
+  static random(): StateReference {
+    return new StateReference(AppendOnlyTreeSnapshot.random(), PartialStateReference.random());
+  }
+
   toViem(): ViemStateReference {
     return {
       l1ToL2MessageTree: this.l1ToL2MessageTree.toViem(),

--- a/yarn-project/txe/src/state_machine/archiver.ts
+++ b/yarn-project/txe/src/state_machine/archiver.ts
@@ -139,7 +139,7 @@ export class TXEArchiver extends ArchiverStoreHelper implements L2BlockSource {
     return Promise.resolve(false);
   }
 
-  public getPendingChainValidationStatus(): Promise<ValidateBlockResult> {
+  public override getPendingChainValidationStatus(): Promise<ValidateBlockResult> {
     return Promise.resolve({ valid: true });
   }
 }

--- a/yarn-project/txe/src/state_machine/index.ts
+++ b/yarn-project/txe/src/state_machine/index.ts
@@ -3,7 +3,7 @@ import { TestCircuitVerifier } from '@aztec/bb-prover/test';
 import { createLogger } from '@aztec/foundation/log';
 import type { AztecAsyncKVStore } from '@aztec/kv-store';
 import { SyncDataProvider } from '@aztec/pxe/server';
-import type { L2Block } from '@aztec/stdlib/block';
+import { type L2Block, PublishedL2Block } from '@aztec/stdlib/block';
 import type { AztecNode } from '@aztec/stdlib/interfaces/client';
 import { getPackageVersion } from '@aztec/stdlib/update-checker';
 
@@ -61,7 +61,7 @@ export class TXEStateMachine {
     await Promise.all([
       this.synchronizer.handleL2Block(block),
       this.archiver.addBlocks([
-        {
+        PublishedL2Block.fromFields({
           block,
           l1: {
             blockHash: block.header.globalVariables.blockNumber.toString(),
@@ -69,7 +69,7 @@ export class TXEStateMachine {
             timestamp: block.header.globalVariables.timestamp,
           },
           attestations: [],
-        },
+        }),
       ]),
       this.syncDataProvider.setHeader(block.header),
     ]);


### PR DESCRIPTION
Adds the _pending chain validation status_ to the archiver store, so it is persisted across node restarts. The pending chain validation status is whether the last block seen in the pending chain is valid or not, as in it having valid attestations or not.

Also, this PR fixes the condition in which it's updated: if a new block with the same number and still invalid is detected, the validation status is updated. This is tested in https://github.com/AztecProtocol/aztec-packages/pull/16836.

This PR also changes that shape of the validation result, so instead of storing a full L2 block, we only store the identifiers and attestations needed to invalidate it. It also adds serialization and static `random` methods to some adjacent classes.