### PR TITLE
fix: codeql issues

### DIFF
--- a/yarn-project/ethereum/src/utils.ts
+++ b/yarn-project/ethereum/src/utils.ts
@@ -181,41 +181,19 @@ export function formatViemError(error: any, abi: Abi = ErrorsAbi): FormattedViem
     return new FormattedViemError(error.message, (error as any)?.metaMessages);
   }
 
-  // Extract the actual error message and highlight it for clarity
-  let formattedRes = extractAndFormatRequestBody(error?.message || String(error));
-
-  let errorDetail = '';
-  // Look for specific details in known locations
-  if (error) {
-    // Check for details property which often has the most specific error message
-    if (typeof error.details === 'string' && error.details) {
-      errorDetail = error.details;
-    }
-    // Check for shortMessage which is often available in Viem errors
-    else if (typeof error.shortMessage === 'string' && error.shortMessage) {
-      errorDetail = error.shortMessage;
-    }
+  const body = String(error);
+  const length = body.length;
+  // LogExplorer can only render up to 2500 characters in it's summary view. Try to keep the whole message below this number
+  // Limit the error to 2000 chacaters in order to allow code higher up to decorate this error with extra details (up to 500 characters)
+  if (length > 2000) {
+    const chunk = 950;
+    const truncated = length - 2 * chunk;
+    return new FormattedViemError(
+      body.slice(0, chunk) + `...${truncated} characters truncated...` + body.slice(-1 * chunk),
+    );
   }
 
-  // If we found a specific error detail, format it clearly
-  if (errorDetail) {
-    // Look for key sections of the formatted result to replace with highlighted error
-    let replaced = false;
-
-    // Try to find the Details: section
-    const detailsMatch = formattedRes.match(/Details: ([^\n]+)/);
-    if (detailsMatch) {
-      formattedRes = formattedRes.replace(detailsMatch[0], `Details: *${errorDetail}*`);
-      replaced = true;
-    }
-
-    // If we didn't find a Details section, add the error at the beginning
-    if (!replaced) {
-      formattedRes = `Error: *${errorDetail}*\n\n${formattedRes}`;
-    }
-  }
-
-  return new FormattedViemError(formattedRes.replace(/\\n/g, '\n'), error?.metaMessages);
+  return new FormattedViemError(body);
 }
 
 function stripAbis(obj: any) {
@@ -239,156 +217,6 @@ function stripAbis(obj: any) {
       stripAbis(value);
     }
   });
-}
-
-function extractAndFormatRequestBody(message: string): string {
-  // First check if message is extremely large and contains very large hex strings
-  if (message.length > 50000) {
-    message = replaceHexStrings(message, { minLength: 10000, truncateLength: 200 });
-  }
-
-  // Add a specific check for RPC calls with large params
-  if (message.includes('"method":"eth_sendRawTransaction"')) {
-    message = replaceHexStrings(message, {
-      pattern: /"params":\s*\[\s*"(0x[a-fA-F0-9]{1000,})"\s*\]/g,
-      transform: hex => `"params":["${truncateHex(hex, 200)}"]`,
-    });
-  }
-
-  // First handle Request body JSON
-  const requestBodyRegex = /Request body: ({[\s\S]*?})\n/g;
-  let result = message.replace(requestBodyRegex, (match, body) => {
-    return `Request body: ${formatRequestBody(body)}\n`;
-  });
-
-  // Then handle Arguments section
-  const argsRegex = /((?:Request |Estimate Gas )?Arguments:[\s\S]*?(?=\n\n|$))/g;
-  result = result.replace(argsRegex, section => {
-    const lines = section.split('\n');
-    const processedLines = lines.map(line => {
-      // Check if line contains a colon followed by content
-      const colonIndex = line.indexOf(':');
-      if (colonIndex !== -1) {
-        const [prefix, content] = [line.slice(0, colonIndex + 1), line.slice(colonIndex + 1).trim()];
-        // If content contains a hex string, truncate it
-        if (content.includes('0x')) {
-          const processedContent = replaceHexStrings(content);
-          return `${prefix} ${processedContent}`;
-        }
-      }
-      return line;
-    });
-    return processedLines.join('\n');
-  });
-
-  // Finally, catch any remaining hex strings in the message
-  result = replaceHexStrings(result);
-
-  return result;
-}
-
-function truncateHex(hex: string, length = 100) {
-  if (!hex || typeof hex !== 'string') {
-    return hex;
-  }
-  if (!hex.startsWith('0x')) {
-    return hex;
-  }
-  if (hex.length <= length * 2) {
-    return hex;
-  }
-  // For extremely large hex strings, use more aggressive truncation
-  if (hex.length > 10000) {
-    return `${hex.slice(0, length)}...<${hex.length - length * 2} chars omitted>...${hex.slice(-length)}`;
-  }
-  return `${hex.slice(0, length)}...${hex.slice(-length)}`;
-}
-
-function replaceHexStrings(
-  text: string,
-  options: {
-    minLength?: number;
-    maxLength?: number;
-    truncateLength?: number;
-    pattern?: RegExp;
-    transform?: (hex: string) => string;
-  } = {},
-): string {
-  const {
-    minLength = 10,
-    maxLength = Infinity,
-    truncateLength = 100,
-    pattern,
-    transform = hex => truncateHex(hex, truncateLength),
-  } = options;
-
-  const hexRegex = pattern ?? new RegExp(`(0x[a-fA-F0-9]{${minLength},${maxLength}})`, 'g');
-  return text.replace(hexRegex, match => transform(match));
-}
-
-function formatRequestBody(body: string) {
-  try {
-    // Special handling for eth_sendRawTransaction
-    if (body.includes('"method":"eth_sendRawTransaction"')) {
-      try {
-        const parsed = JSON.parse(body);
-        if (parsed.params && Array.isArray(parsed.params) && parsed.params.length > 0) {
-          // These are likely large transaction hex strings
-          parsed.params = parsed.params.map((param: any) => {
-            if (typeof param === 'string' && param.startsWith('0x') && param.length > 1000) {
-              return truncateHex(param, 200);
-            }
-            return param;
-          });
-        }
-        return JSON.stringify(parsed, null, 2);
-      } catch {
-        // If specific parsing fails, fall back to regex-based truncation
-        return replaceHexStrings(body, {
-          pattern: /"params":\s*\[\s*"(0x[a-fA-F0-9]{1000,})"\s*\]/g,
-          transform: hex => `"params":["${truncateHex(hex, 200)}"]`,
-        });
-      }
-    }
-
-    // For extremely large request bodies, use simple truncation instead of parsing
-    if (body.length > 50000) {
-      const jsonStart = body.indexOf('{');
-      const jsonEnd = body.lastIndexOf('}');
-      if (jsonStart >= 0 && jsonEnd > jsonStart) {
-        return replaceHexStrings(body, { minLength: 10000, truncateLength: 200 });
-      }
-    }
-
-    const parsed = JSON.parse(body);
-
-    // Process the entire request body
-    const processed = processParams(parsed);
-    return JSON.stringify(processed, null, 2);
-  } catch {
-    // If JSON parsing fails, do a simple truncation of any large hex strings
-    return replaceHexStrings(body, { minLength: 1000, truncateLength: 150 });
-  }
-}
-
-// Recursively process all parameters that might contain hex strings
-function processParams(obj: any): any {
-  if (Array.isArray(obj)) {
-    return obj.map(item => processParams(item));
-  }
-  if (typeof obj === 'object' && obj !== null) {
-    const result: any = {};
-    for (const [key, value] of Object.entries(obj)) {
-      result[key] = processParams(value);
-    }
-    return result;
-  }
-  if (typeof obj === 'string') {
-    if (obj.startsWith('0x')) {
-      return truncateHex(obj);
-    }
-  }
-  return obj;
 }
 
 export function tryGetCustomErrorName(err: any) {

--- a/yarn-project/foundation/src/string/index.test.ts
+++ b/yarn-project/foundation/src/string/index.test.ts
@@ -6,8 +6,11 @@ describe('string', () => {
       expect(urlJoin('http://example.com', 'foo', 'bar')).toBe('http://example.com/foo/bar');
     });
 
-    it('removes duplicate slashes', () => {
-      expect(urlJoin('http://example.com/', '/foo/', '/bar/')).toBe('http://example.com/foo/bar');
+    it.each([
+      [['http://example.com/', '/foo/', '/bar/'], 'http://example.com/foo/bar'],
+      [['http://example.com/', '', '//', '///', '////foo//', '//bar////', 'baz'], 'http://example.com/foo/bar/baz'],
+    ])('removes duplicate slashes', (parts, url) => {
+      expect(urlJoin(...parts)).toBe(url);
     });
   });
 

--- a/yarn-project/foundation/src/string/index.ts
+++ b/yarn-project/foundation/src/string/index.ts
@@ -39,5 +39,25 @@ export function isoDate(date?: Date) {
 }
 
 export function urlJoin(...args: string[]): string {
-  return args.map(arg => arg.replace(/\/+$/, '').replace(/^\/+/, '')).join('/');
+  const processed = [];
+  for (const arg of args) {
+    if (arg.length === 0) {
+      continue;
+    }
+
+    let start = 0;
+    let end = arg.length - 1;
+
+    while (start <= end && arg[start] === '/') {
+      start++;
+    }
+    while (end >= start && arg[end] === '/') {
+      end--;
+    }
+
+    if (start < end) {
+      processed.push(arg.slice(start, end + 1));
+    }
+  }
+  return processed.join('/');
 }


### PR DESCRIPTION
This PR fixes a couple of 'high' severity CodeQL issues:

1. `urlJoin` ReDOS - Instead of using regexes we walk the start/end of each string and cut appropriately
2. viem error parsing and formatting ReDOS - this was problematic because we were potentially applying regexes on tens of KB of body. It now only renders the first 1KB of text and the last 1KB of text based on the fact `data: 0x...` being in the middle and not really useful.

Fix TMNT-279