### PR TITLE
refactor: fixing log related naming

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/macros/aztec.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/aztec.nr
@@ -270,11 +270,10 @@ comptime fn generate_process_message() -> Quoted {
     // to determine whether a function is `private`, `public`, or `utility`.
     let utility = crate::macros::functions::utility;
 
-    // TODO(#15012): Here we use PRIVATE_LOG_CIPHERTEXT_LEN for message ciphertext length. Fix message vs log naming.
     quote {
         #[$utility]
         unconstrained fn process_message(
-            message_ciphertext: BoundedVec<Field, aztec::protocol_types::constants::PRIVATE_LOG_CIPHERTEXT_LEN>,
+            message_ciphertext: BoundedVec<Field, aztec::messages::encoding::MESSAGE_CIPHERTEXT_LEN>,
             message_context: aztec::messages::processing::message_context::MessageContext,
         ) {
             aztec::messages::discovery::process_message::do_process_message(

--- a/noir-projects/aztec-nr/aztec/src/messages/discovery/process_message.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/discovery/process_message.nr
@@ -3,7 +3,7 @@ use crate::messages::{
         ComputeNoteHashAndNullifier, partial_notes::process_partial_note_private_msg,
         private_events::process_private_event_msg, private_notes::process_private_note_msg,
     },
-    encoding::decode_message,
+    encoding::{decode_message, MESSAGE_CIPHERTEXT_LEN},
     encryption::{aes128::AES128, log_encryption::LogEncryption},
     msg_type::{
         PARTIAL_NOTE_PRIVATE_MSG_TYPE_ID, PRIVATE_EVENT_MSG_TYPE_ID, PRIVATE_NOTE_MSG_TYPE_ID,
@@ -11,11 +11,7 @@ use crate::messages::{
     processing::message_context::MessageContext,
 };
 
-use protocol_types::{
-    address::AztecAddress,
-    constants::PRIVATE_LOG_CIPHERTEXT_LEN,
-    debug_log::{debug_log, debug_log_format},
-};
+use protocol_types::{address::AztecAddress, debug_log::{debug_log, debug_log_format}};
 
 /// Processes a message that can contain notes, partial notes, or events.
 ///
@@ -32,7 +28,7 @@ use protocol_types::{
 pub unconstrained fn do_process_message<Env>(
     contract_address: AztecAddress,
     compute_note_hash_and_nullifier: ComputeNoteHashAndNullifier<Env>,
-    message_ciphertext: BoundedVec<Field, PRIVATE_LOG_CIPHERTEXT_LEN>,
+    message_ciphertext: BoundedVec<Field, MESSAGE_CIPHERTEXT_LEN>,
     message_context: MessageContext,
 ) {
     let message = AES128::decrypt_log(message_ciphertext, message_context.recipient);

--- a/noir-projects/aztec-nr/aztec/src/messages/encoding.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/encoding.nr
@@ -1,9 +1,28 @@
 // TODO(#12750): don't make these values assume we're using AES.
-use crate::{
-    messages::encryption::log_encryption::PRIVATE_LOG_PLAINTEXT_SIZE_IN_FIELDS, utils::array,
-};
+use crate::utils::array;
+use protocol_types::constants::PRIVATE_LOG_CIPHERTEXT_LEN;
 
-pub global MAX_MESSAGE_LEN: u32 = PRIVATE_LOG_PLAINTEXT_SIZE_IN_FIELDS;
+// We reassign to the constant here to communicate the distinction between a log and a message. In Aztec.nr, unlike in
+// protocol circuits, we have a concept of a message that can be emitted either as a private log or as an offchain
+// message. Message is a piece of data that is to be eventually delivered to a contract via the `process_message(...)`
+// utility function function that is injected by the #[aztec] macro.
+pub global MESSAGE_CIPHERTEXT_LEN: u32 = PRIVATE_LOG_CIPHERTEXT_LEN;
+
+// TODO(#12750): The global variables below should not be here as they are AES128 specific.
+// ciphertext_length (2) + 14 bytes pkcs#7 AES padding.
+pub(crate) global HEADER_CIPHERTEXT_SIZE_IN_BYTES: u32 = 16;
+
+pub global EPH_PK_X_SIZE_IN_FIELDS: u32 = 1;
+pub global EPH_PK_SIGN_BYTE_SIZE_IN_BYTES: u32 = 1;
+
+// (17 - 1) * 31 - 16 - 1 = 479
+global MESSAGE_PLAINTEXT_SIZE_IN_BYTES: u32 = (MESSAGE_CIPHERTEXT_LEN - EPH_PK_X_SIZE_IN_FIELDS)
+    * 31
+    - HEADER_CIPHERTEXT_SIZE_IN_BYTES
+    - EPH_PK_SIGN_BYTE_SIZE_IN_BYTES;
+// Each field of the original note log was serialized to 32 bytes. Below we convert the bytes back to fields.
+// 479 / 32 = 15
+pub global MESSAGE_PLAINTEXT_LEN: u32 = MESSAGE_PLAINTEXT_SIZE_IN_BYTES / 32;
 
 global MESSAGE_EXPANDED_METADATA_LEN: u32 = 1;
 
@@ -29,7 +48,7 @@ global MESSAGE_EXPANDED_METADATA_LEN: u32 = 1;
 // name to make it distinct from the message content given that it is not a full field.
 
 /// The maximum length of a message's content, i.e. not including the expanded message metadata.
-pub global MAX_MESSAGE_CONTENT_LEN: u32 = MAX_MESSAGE_LEN - MESSAGE_EXPANDED_METADATA_LEN;
+pub global MAX_MESSAGE_CONTENT_LEN: u32 = MESSAGE_PLAINTEXT_LEN - MESSAGE_EXPANDED_METADATA_LEN;
 
 /// Encodes a message following aztec-nr's standard message encoding. This message can later be decoded with
 /// `decode_message` to retrieve the original values.
@@ -72,7 +91,7 @@ pub fn encode_message<let N: u32>(
 /// prior to decoding the message type is unknown, and consequentially not known at compile time. If working with
 /// fixed-size messages, consider using `BoundedVec::from_array` to convert them.
 pub unconstrained fn decode_message(
-    message: BoundedVec<Field, MAX_MESSAGE_LEN>,
+    message: BoundedVec<Field, MESSAGE_PLAINTEXT_LEN>,
 ) -> (u64, u64, BoundedVec<Field, MAX_MESSAGE_CONTENT_LEN>) {
     assert(
         message.len() >= MESSAGE_EXPANDED_METADATA_LEN,

--- a/noir-projects/aztec-nr/aztec/src/messages/encryption/aes128.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/encryption/aes128.nr
@@ -1,9 +1,6 @@
 use dep::protocol_types::{
     address::AztecAddress,
-    constants::{
-        GENERATOR_INDEX__SYMMETRIC_KEY, GENERATOR_INDEX__SYMMETRIC_KEY_2,
-        PRIVATE_LOG_CIPHERTEXT_LEN,
-    },
+    constants::{GENERATOR_INDEX__SYMMETRIC_KEY, GENERATOR_INDEX__SYMMETRIC_KEY_2},
     hash::poseidon2_hash_with_separator,
     point::Point,
 };
@@ -14,10 +11,11 @@ use crate::{
         ephemeral::generate_ephemeral_key_pair,
     },
     messages::{
-        encryption::log_encryption::{
+        encoding::{
             EPH_PK_SIGN_BYTE_SIZE_IN_BYTES, EPH_PK_X_SIZE_IN_FIELDS,
-            HEADER_CIPHERTEXT_SIZE_IN_BYTES, LogEncryption, PRIVATE_LOG_PLAINTEXT_SIZE_IN_FIELDS,
+            HEADER_CIPHERTEXT_SIZE_IN_BYTES, MESSAGE_CIPHERTEXT_LEN, MESSAGE_PLAINTEXT_LEN,
         },
+        encryption::log_encryption::LogEncryption,
         logs::arithmetic_generics_utils::{
             get_arr_of_size__log_bytes__from_PT, get_arr_of_size__log_bytes_padding__from_PT,
         },
@@ -161,7 +159,7 @@ impl LogEncryption for AES128 {
     fn encrypt_log<let PlaintextLen: u32>(
         plaintext: [Field; PlaintextLen],
         recipient: AztecAddress,
-    ) -> [Field; PRIVATE_LOG_CIPHERTEXT_LEN] {
+    ) -> [Field; MESSAGE_CIPHERTEXT_LEN] {
         // AES 128 operates on bytes, not fields, so we need to convert the fields to bytes.
         // (This process is then reversed when processing the log in `do_process_log`)
         let plaintext_bytes = fields_to_bytes(plaintext);
@@ -279,7 +277,7 @@ impl LogEncryption for AES128 {
         // Prepend / append fields, to create the final log
         // *****************************************************************************
 
-        let mut ciphertext: [Field; PRIVATE_LOG_CIPHERTEXT_LEN] = [0; PRIVATE_LOG_CIPHERTEXT_LEN];
+        let mut ciphertext: [Field; MESSAGE_CIPHERTEXT_LEN] = [0; MESSAGE_CIPHERTEXT_LEN];
 
         ciphertext[0] = eph_pk.x;
 
@@ -289,7 +287,7 @@ impl LogEncryption for AES128 {
         }
         offset += log_bytes_as_fields.len();
 
-        for i in offset..PRIVATE_LOG_CIPHERTEXT_LEN {
+        for i in offset..MESSAGE_CIPHERTEXT_LEN {
             // We need to get a random value that fits in 31 bytes to not leak information about the size of the log
             // (all the "real" log fields contain at most 31 bytes because of the way we convert the bytes to fields).
             // TODO(#12749): Long term, this is not a good solution.
@@ -304,12 +302,12 @@ impl LogEncryption for AES128 {
     }
 
     unconstrained fn decrypt_log(
-        ciphertext: BoundedVec<Field, PRIVATE_LOG_CIPHERTEXT_LEN>,
+        ciphertext: BoundedVec<Field, MESSAGE_CIPHERTEXT_LEN>,
         recipient: AztecAddress,
-    ) -> BoundedVec<Field, PRIVATE_LOG_PLAINTEXT_SIZE_IN_FIELDS> {
+    ) -> BoundedVec<Field, MESSAGE_PLAINTEXT_LEN> {
         let eph_pk_x = ciphertext.get(0);
 
-        let ciphertext_without_eph_pk_x_fields = array::subbvec::<Field, PRIVATE_LOG_CIPHERTEXT_LEN, PRIVATE_LOG_CIPHERTEXT_LEN - EPH_PK_X_SIZE_IN_FIELDS>(
+        let ciphertext_without_eph_pk_x_fields = array::subbvec::<Field, MESSAGE_CIPHERTEXT_LEN, MESSAGE_CIPHERTEXT_LEN - EPH_PK_X_SIZE_IN_FIELDS>(
             ciphertext,
             EPH_PK_X_SIZE_IN_FIELDS,
         );
@@ -352,9 +350,9 @@ impl LogEncryption for AES128 {
 
         // Extract and decrypt main ciphertext
         let ciphertext_start = header_start + HEADER_CIPHERTEXT_SIZE_IN_BYTES;
-        let ciphertext_with_padding: [u8; (PRIVATE_LOG_CIPHERTEXT_LEN - EPH_PK_X_SIZE_IN_FIELDS) * 31 - HEADER_CIPHERTEXT_SIZE_IN_BYTES - EPH_PK_SIGN_BYTE_SIZE_IN_BYTES] =
+        let ciphertext_with_padding: [u8; (MESSAGE_CIPHERTEXT_LEN - EPH_PK_X_SIZE_IN_FIELDS) * 31 - HEADER_CIPHERTEXT_SIZE_IN_BYTES - EPH_PK_SIGN_BYTE_SIZE_IN_BYTES] =
             array::subarray(ciphertext_without_eph_pk_x.storage(), ciphertext_start);
-        let ciphertext: BoundedVec<u8, (PRIVATE_LOG_CIPHERTEXT_LEN - EPH_PK_X_SIZE_IN_FIELDS) * 31 - HEADER_CIPHERTEXT_SIZE_IN_BYTES - EPH_PK_SIGN_BYTE_SIZE_IN_BYTES> =
+        let ciphertext: BoundedVec<u8, (MESSAGE_CIPHERTEXT_LEN - EPH_PK_X_SIZE_IN_FIELDS) * 31 - HEADER_CIPHERTEXT_SIZE_IN_BYTES - EPH_PK_SIGN_BYTE_SIZE_IN_BYTES> =
             BoundedVec::from_parts(ciphertext_with_padding, ciphertext_length);
 
         // Decrypt main ciphertext and return it
@@ -368,7 +366,7 @@ impl LogEncryption for AES128 {
 mod test {
     use crate::{
         keys::ecdh_shared_secret::derive_ecdh_shared_secret_using_aztec_address,
-        messages::encryption::log_encryption::{LogEncryption, PRIVATE_LOG_PLAINTEXT_SIZE_IN_FIELDS},
+        messages::{encoding::MESSAGE_PLAINTEXT_LEN, encryption::log_encryption::LogEncryption},
         test::helpers::test_environment::TestEnvironment,
     };
     use super::AES128;
@@ -418,8 +416,7 @@ mod test {
 
             // The decryption function spits out a BoundedVec because it's designed to work with logs with unknown length
             // at compile time. For this reason we need to convert the original input to a BoundedVec.
-            let plaintext_bvec =
-                BoundedVec::<Field, PRIVATE_LOG_PLAINTEXT_SIZE_IN_FIELDS>::from_array(plaintext);
+            let plaintext_bvec = BoundedVec::<Field, MESSAGE_PLAINTEXT_LEN>::from_array(plaintext);
 
             // Verify decryption matches original plaintext
             assert_eq(

--- a/noir-projects/aztec-nr/aztec/src/messages/encryption/log_encryption.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/encryption/log_encryption.nr
@@ -1,22 +1,5 @@
-use protocol_types::{address::AztecAddress, constants::PRIVATE_LOG_CIPHERTEXT_LEN};
-
-// TODO(#12750): The global variables below should not be here as they are AES128 specific.
-// ciphertext_length (2) + 14 bytes pkcs#7 AES padding.
-pub(crate) global HEADER_CIPHERTEXT_SIZE_IN_BYTES: u32 = 16;
-
-pub global EPH_PK_X_SIZE_IN_FIELDS: u32 = 1;
-pub global EPH_PK_SIGN_BYTE_SIZE_IN_BYTES: u32 = 1;
-
-// (17 - 1) * 31 - 16 - 1 = 479
-pub global PRIVATE_LOG_PLAINTEXT_SIZE_IN_BYTES: u32 = (
-    PRIVATE_LOG_CIPHERTEXT_LEN - EPH_PK_X_SIZE_IN_FIELDS
-)
-    * 31
-    - HEADER_CIPHERTEXT_SIZE_IN_BYTES
-    - EPH_PK_SIGN_BYTE_SIZE_IN_BYTES;
-// Each field of the original note log was serialized to 32 bytes. Below we convert the bytes back to fields.
-// 479 / 32 = 15
-pub global PRIVATE_LOG_PLAINTEXT_SIZE_IN_FIELDS: u32 = PRIVATE_LOG_PLAINTEXT_SIZE_IN_BYTES / 32;
+use crate::messages::encoding::{MESSAGE_CIPHERTEXT_LEN, MESSAGE_PLAINTEXT_LEN};
+use protocol_types::address::AztecAddress;
 
 /// Trait for encrypting and decrypting private logs in the Aztec protocol.
 ///
@@ -25,8 +8,8 @@ pub global PRIVATE_LOG_PLAINTEXT_SIZE_IN_FIELDS: u32 = PRIVATE_LOG_PLAINTEXT_SIZ
 ///
 /// # Type Parameters
 /// - `PLAINTEXT_LEN`: Length of the plaintext array in fields
-/// - `PRIVATE_LOG_CIPHERTEXT_LEN`: Fixed length of encrypted logs (defined globally)
-/// - `PRIVATE_LOG_PLAINTEXT_SIZE_IN_FIELDS`: Maximum size of decrypted plaintext (defined globally)
+/// - `MESSAGE_CIPHERTEXT_LEN`: Fixed length of encrypted message (defined globally)
+/// - `MESSAGE_PLAINTEXT_LEN`: Maximum size of decrypted plaintext (defined globally)
 ///
 /// # Note on privacy sets
 /// To preserve privacy, `encrypt_log` returns a fixed-length array ensuring all log types are indistinguishable
@@ -43,7 +26,7 @@ pub trait LogEncryption {
     fn encrypt_log<let PlaintextLen: u32>(
         plaintext: [Field; PlaintextLen],
         recipient: AztecAddress,
-    ) -> [Field; PRIVATE_LOG_CIPHERTEXT_LEN];
+    ) -> [Field; MESSAGE_CIPHERTEXT_LEN];
 
     /// Decrypts a private log back into its original plaintext fields.
     /// This function is unconstrained since decryption happens when processing logs in an unconstrained context.
@@ -60,7 +43,7 @@ pub trait LogEncryption {
     /// the `Contract::process_log` function is designed to work with all the private logs, emitted by a given contract
     /// and not just by 1 log type.
     unconstrained fn decrypt_log(
-        ciphertext: BoundedVec<Field, PRIVATE_LOG_CIPHERTEXT_LEN>,
+        ciphertext: BoundedVec<Field, MESSAGE_CIPHERTEXT_LEN>,
         recipient: AztecAddress,
-    ) -> BoundedVec<Field, PRIVATE_LOG_PLAINTEXT_SIZE_IN_FIELDS>;
+    ) -> BoundedVec<Field, MESSAGE_PLAINTEXT_LEN>;
 }

--- a/noir-projects/aztec-nr/aztec/src/messages/logs/arithmetic_generics_utils.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/logs/arithmetic_generics_utils.nr
@@ -1,4 +1,4 @@
-use crate::messages::encryption::log_encryption::HEADER_CIPHERTEXT_SIZE_IN_BYTES;
+use crate::messages::encoding::HEADER_CIPHERTEXT_SIZE_IN_BYTES;
 
 /********************************************************/
 // Disgusting arithmetic on generics

--- a/noir-projects/aztec-nr/aztec/src/messages/logs/event.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/logs/event.nr
@@ -1,24 +1,20 @@
 use crate::{
     event::event_interface::EventInterface,
     messages::{
-        encoding::encode_message,
+        encoding::{encode_message, MESSAGE_CIPHERTEXT_LEN},
         encryption::{aes128::AES128, log_encryption::LogEncryption},
         msg_type::PRIVATE_EVENT_MSG_TYPE_ID,
     },
     oracle::random::random,
 };
-use protocol_types::{
-    address::AztecAddress,
-    constants::PRIVATE_LOG_CIPHERTEXT_LEN,
-    traits::{Serialize, ToField},
-};
+use protocol_types::{address::AztecAddress, traits::{Serialize, ToField}};
 
 /// Creates an encrypted private event message (i.e. one of type `PRIVATE_EVENT_MSG_TYPE_ID`) by encoding the contents
 /// of the event and then encrypting them for `recipient`.
 pub fn to_encrypted_private_event_message<Event>(
     event: Event,
     recipient: AztecAddress,
-) -> ([Field; PRIVATE_LOG_CIPHERTEXT_LEN], Field)
+) -> ([Field; MESSAGE_CIPHERTEXT_LEN], Field)
 where
     Event: EventInterface + Serialize,
 {


### PR DESCRIPTION
Fixes #15012

The naming became strange with the introduction of the concept of a message that can be emitted either as a private log or as an offchain message - via an offchain effect (also used to be called out-of-band). Before we just used to have a private log.

### Changes
- Introduces "alias" for  `PRIVATE_LOG_CIPHERTEXT_LEN` called `MESSAGE_CIPHERTEXT_LEN` in `Aztec.nr`
- Renames `PRIVATE_LOG_PLAINTEXT_SIZE_IN_{BYTES,FIELDS}` → `MESSAGE_PLAINTEXT_SIZE_IN_{BYTES,FIELDS}`
