### PR TITLE
fix(docs): unify sequencer / validator naming

### DIFF
--- a/docs/docs/aztec/concepts/fees.md
+++ b/docs/docs/aztec/concepts/fees.md
@@ -76,7 +76,7 @@ An account making a transaction can also refer to "fee-paying contracts" (FPCs) 
 ### Operator rewards
 
 The calculated fee-juice of a transaction is deducted from the fee payer (nominated account or fee-paying contract), then pooled together each transaction, block, and epoch.
-Once the epoch is proven, the total fee-juice (minus any burnt congestion amount), is distributed to provers and block validators/sequencers that contributed to the epoch.
+Once the epoch is proven, the total fee-juice (minus any burnt congestion amount), is distributed to provers and block sequencers that contributed to the epoch.
 
 The fees section of the protocol specification explains this distribution of fee-juice between proposers and provers.
 

--- a/docs/docs/developers/reference/environment_reference/sandbox-reference.md
+++ b/docs/docs/developers/reference/environment_reference/sandbox-reference.md
@@ -68,9 +68,7 @@ ROLLUP_CONTRACT_ADDRESS=0x01234567890abcde01234567890abcde
 SEQ_PUBLISHER_PRIVATE_KEY=0x01234567890abcde01234567890abcde # Private key of an ethereum account that will be used by the sequencer to publish blocks.
 SEQ_MAX_TX_PER_BLOCK=32 # Maximum txs to go on a block. (default: 32)
 SEQ_MIN_TX_PER_BLOCK=1 # Minimum txs to go on a block. (default: 1)
-
-## Validator variables ##
-VALIDATOR_PRIVATE_KEY=0x01234567890abcde01234567890abcde  # Private key of the ethereum account that will be used to perform validator duties
+VALIDATOR_PRIVATE_KEY=0x01234567890abcde01234567890abcde  # Private key of the ethereum account that will be used to perform sequencer duties
 ```
 
 **PXE**

--- a/docs/docs/the_aztec_network/concepts/deployments/what_is_deployment.md
+++ b/docs/docs/the_aztec_network/concepts/deployments/what_is_deployment.md
@@ -22,7 +22,7 @@ Hypothetical Asset would live on Ethereum L1. It may have a minter which would b
 
 This is brought up to the community for discussion purposes only to illustrate how proposed governance mechanisms could work with a Hypothetical Asset.
 
-- **Validators** must stake the Hypothetical Asset within the instance's contract to join that instance's validator set.
+- **Sequencers** must stake the Hypothetical Asset within the instance's contract to join that instance's sequencer set.
 - **Holders** must lock Hypothetical Asset with the Governance contract to be able to vote on proposals.
 - **Provers** must deposit Hypothetical Asset in the escrow contract in order to bid for the right to create a proof for an epoch.
 

--- a/docs/docs/the_aztec_network/concepts/governance/putting_forward_proposals.md
+++ b/docs/docs/the_aztec_network/concepts/governance/putting_forward_proposals.md
@@ -10,9 +10,9 @@ Sequencers can only nominate a proposal during an L2 slot for which they’ve be
 
 A mechanism is also proposed whereby any Hypothetical Asset holder (“Holderˮ) can burn a large quantity of Hypothetical Asset to trigger a vote on a proposal, without having the sequencers nominating the proposal. Note that Hypothetical Asset holders would still need to vote to approve any proposals nominated via this mechanism.
 
-To nominate a proposal, a validator of the current canonical rollup would deploy two sets of contracts:
+To nominate a proposal, a sequencer of the current canonical rollup would deploy two sets of contracts:
 
 1. The upgraded contracts they wish to upgrade to
 2. `code` which can be executed by governance to upgrade into these contracts
 
-Then when it is their turn as the proposer, they call `vote(address _proposal)` on the `Proposals` contract, where `_proposal ` is the address of the `code` payload. Alternatively, validators can set the `GOVERNANCE_PROPOSAL_PAYLOAD=_proposal` env variable which will call `vote(address _proposal)` during a slot they're eligible to signal in.
+Then when it is their turn as the proposer, they call `vote(address _proposal)` on the `Proposals` contract, where `_proposal ` is the address of the `code` payload. Alternatively, sequencers can set the `GOVERNANCE_PROPOSAL_PAYLOAD=_proposal` env variable which will call `vote(address _proposal)` during a slot they're eligible to signal in.

--- a/docs/docs/the_aztec_network/concepts/governance/upgrades.md
+++ b/docs/docs/the_aztec_network/concepts/governance/upgrades.md
@@ -38,4 +38,4 @@ After governance approval and a delay period, the proposal becomes executable:
 - Any Ethereum account can call `execute(_proposalId)` on the Governance contract.
 - The `execute` function calls the proposal code, transitioning the network to the new Rollup instance.
 
-For a more hands-on guide to reacting to upgrades as a sequencer/validators, read [this](../../reference/reacting_to_upgrades.md).
+For a more hands-on guide to reacting to upgrades as a sequencer, read [this](../../reference/reacting_to_upgrades.md).

--- a/docs/docs/the_aztec_network/concepts/governance/voting.md
+++ b/docs/docs/the_aztec_network/concepts/governance/voting.md
@@ -8,4 +8,4 @@ Holders have the ability to vote on proposals as long as they lock any Hypotheti
 
 Hypothetical Assets locked in the Governance contract are simply locked and not “at stakeˮ i.e. there are no slashing conditions.
 
-Since sequencers may be able to stake Hypothetical Assets with the rollup instances in order to join the validator set, the rollup instance could in turn lock those Hypothetical Assets in the Governance contract and vote on behalf of the sequencers. This is expected behavior.
+Since sequencers may be able to stake Hypothetical Assets with the rollup instances in order to join the sequencer set, the rollup instance could in turn lock those Hypothetical Assets in the Governance contract and vote on behalf of the sequencers. This is expected behavior.

--- a/docs/docs/the_aztec_network/concepts/proof_of_stake/slashing.md
+++ b/docs/docs/the_aztec_network/concepts/proof_of_stake/slashing.md
@@ -17,21 +17,21 @@ There are some actions that impact the chainʼs ability to finalize new blocks:
 
 ### Insufficient quorum
 
-In the event that a significant portion of the validator set goes offline (i.e. large internet outage) and proposers are unable to get enough attestations on block proposals, the Aztec Rollup will be unable to finalize new blocks. This will require the community to engage to fix the issue and make sure new blocks are being finalized.
+In the event that a significant portion of the sequencer set goes offline (i.e. large internet outage) and proposers are unable to get enough attestations on block proposals, the Aztec Rollup will be unable to finalize new blocks. This will require the community to engage to fix the issue and make sure new blocks are being finalized.
 
 In the event of a prolonged period where the Aztec Rollup is not finalizing new blocks, it may enter Based Fallback mode. The conditions that lead to [Based Fallback (forum link)](https://forum.aztec.network/t/request-for-comments-aztecs-block-production-system/6155) mode are expected to be well defined by the community of sequencers, provers, client teams and all other Aztec Rollup  stakeholders and participants.
 
-During Based Fallback mode, anyone can propose blocks if they supply proofs for these blocks alongside them. This is in contrast to the usual condition that only the sequencer assigned to a particular slot can propose blocks during that slot. This means that the inactive validator set is bypassed and anyone can advance the chain in the event of an inactive / non-participating validator set.
+During Based Fallback mode, anyone can propose blocks if they supply proofs for these blocks alongside them. This is in contrast to the usual condition that only the sequencer assigned to a particular slot can propose blocks during that slot. This means that the inactive sequencer set is bypassed and anyone can advance the chain in the event of an inactive / non-participating sequencer set.
 
-But terminally inactive validators must be removed from the validator set or otherwise we end up in Based Fallback too often. Slashing is a method whereby the validator set votes to “slash” the stake of inactive validators down to a point where they are kicked off the validator set. For example, if we set `MINIMUM_STAKING_BALANCE=50%` then as soon as 50% or more of a validator’s balance is slashed, they will be kicked out of the set.
+But terminally inactive sequencers must be removed from the sequencer set or otherwise we end up in Based Fallback too often. Slashing is a method whereby the sequencer set votes to “slash” the stake of inactive sequencers down to a point where they are kicked off the sequencer set. For example, if we set `MINIMUM_STAKING_BALANCE=50%` then as soon as 50% or more of a sequencer's balance is slashed, they will be kicked out of the set.
 
 ### Committee withholding data from the provers
 
 Provers need the transaction data (i.e. `TxObjects`) plus the client-side generated proofs to produce the final rollup proof, none of which are posted onchain. Client side proofs + transaction data are gossiped on the p2p instead so that committee members can re-execute block proposals and verify that the proposed state root is correct.
 
-Recall from the [RFC (forum link)](https://forum.aztec.network/t/request-for-comments-aztecs-block-production-system/6155) on block production that the committee is a subset of validators, randomly sampled from the entire validator set. Block proposers are sampled from this committee. ⅔ + 1 of this committee  must attest to L2 block proposals before they are posted to the L1 by the block proposer.
+Recall from the [RFC (forum link)](https://forum.aztec.network/t/request-for-comments-aztecs-block-production-system/6155) on block production that the committee is a subset of sequencers, randomly sampled from the entire sequencer set. Block proposers are sampled from this committee. ⅔ + 1 of this committee  must attest to L2 block proposals before they are posted to the L1 by the block proposer.
 
-A malicious committee may not gossip the transaction data or proofs to the rest of the validator set, nor to the provers. As a result, no prover can produce the proof and the epoch in question will reorg by design. Recall from the RFC on block production that if no proof for epoch N is submitted to L1 by the end of epoch N+1, then epoch N + any blocks built in epoch N+1 are reorged.
+A malicious committee may not gossip the transaction data or proofs to the rest of the sequencer set, nor to the provers. As a result, no prover can produce the proof and the epoch in question will reorg by design. Recall from the RFC on block production that if no proof for epoch N is submitted to L1 by the end of epoch N+1, then epoch N + any blocks built in epoch N+1 are reorged.
 
 ### Committee proposing an invalid state root
 
@@ -48,6 +48,6 @@ An honest prover who has funds at stake (i.e. posted a bond to produce the epoch
 
 In all the previous cases, it is very hard to verify and automatically slash for these events onchain. This is mainly due to the fact that neither TxObjects nor client side proofs are posted onchain. Committee members also gossip attestations on the p2p and do not post them directly on chain.
 
-Therefore a slashing mechanism is required as a deterrence against the malicious behaviour by validators and to make sure that the Aztec Rollup retains liveness. The validator set votes to slash dishonest validators based on evidence that is collected onchain + offchain, and discussed and analyzed offchain (i.e. on a forum).
+Therefore a slashing mechanism is required as a deterrence against the malicious behaviour by sequencers and to make sure that the Aztec Rollup retains liveness. The sequencer set votes to slash dishonest sequencers based on evidence that is collected onchain + offchain, and discussed and analyzed offchain (i.e. on a forum).
 
-A validator must aggregate BLS signatures on slashing proposals and post them to the L1 for slash execution.
+A sequencer must aggregate BLS signatures on slashing proposals and post them to the L1 for slash execution.

--- a/docs/docs/the_aztec_network/concepts/provers-and-sequencers/index.md
+++ b/docs/docs/the_aztec_network/concepts/provers-and-sequencers/index.md
@@ -13,4 +13,4 @@ Sequencers will be chosen via a random election, while provers will be selected 
 
 The proposers in the first `C=13` slots in epoch `N+1` will accept quotes to prove epoch N from provers. The winning prover will have until the end of epoch `N+1` to produce and submit the proof to L1.
 
-If are you interested in running a validator node (also known as a sequencer node) or a prover node, you can refer to [the guides section](./../../guides/run_nodes/index.md).
+If are you interested in running a sequencer node or a prover node, you can refer to [the guides section](./../../guides/run_nodes/index.md).

--- a/docs/docs/the_aztec_network/guides/run_nodes/how_to_run_prover.md
+++ b/docs/docs/the_aztec_network/guides/run_nodes/how_to_run_prover.md
@@ -97,7 +97,7 @@ services:
         condition: service_started
         required: true
     environment:
-      # PROVER_COORDINATION_NODE_URL: "http://:8080" # this can point to your own validator - using this replaces the need for the prover node to be on the P2P network and uses your validator as a sentry node of some sort.
+      # PROVER_COORDINATION_NODE_URL: "http://:8080" # this can point to your own sequencer - using this replaces the need for the prover node to be on the P2P network and uses your sequencer as a sentry node of some sort.
       # P2P_ENABLED: "false" # Switch to false if you provide a PROVER_COORDINATION_NODE_URL
       DATA_DIRECTORY: /data
       DATA_STORE_MAP_SIZE_KB: "134217728"

--- a/docs/docs/the_aztec_network/guides/run_nodes/how_to_run_sequencer.md
+++ b/docs/docs/the_aztec_network/guides/run_nodes/how_to_run_sequencer.md
@@ -29,10 +29,10 @@ The Aztec sequencer node is critical infrastructure responsible for ordering tra
 The sequencer node takes part in three key actions:
 
 1. Assemble unprocessed transactions and propose the next block
-2. Attest to correct execution of txs in the proposed block (if part of validator committee)
+2. Attest to correct execution of txs in the proposed block (if part of sequencer committee)
 3. Submit the successfully attested block to L1
 
-When transactions are sent to the Aztec network, sequencer nodes bundles them into blocks, checking various constraints such as gas limits, block size, and transaction validity. Before a block can be published, it must be validated by a committee of other sequencer nodes (validators in this context) who re-execute public transactions and verify private function proofs so they can attest to correct execution. These validators attest to the block's validity by signing it, and once enough attestations are collected (two-thirds of the committee plus one), the sequencer can submit the block to L1.
+When transactions are sent to the Aztec network, sequencer nodes bundles them into blocks, checking various constraints such as gas limits, block size, and transaction validity. Before a block can be published, it must be validated by a committee of other sequencer nodes who re-execute public transactions and verify private function proofs so they can attest to correct execution. These sequencers attest to the block's validity by signing it, and once enough attestations are collected (two-thirds of the committee plus one), the sequencer can submit the block to L1.
 
 The archiver component complements this process by maintaining historical chain data. It continuously monitors L1 for new blocks, processes them, and maintains a synchronized view of the chain state. This includes managing contract data, transaction logs, and L1-to-L2 messages, making it essential for network synchronization and data availability.
 
@@ -65,8 +65,8 @@ The following variable names are specific to the `aztec start` command, set them
 
 - `ETHEREUM_HOSTS=<url>`: One or more comma-separated public rpc provider url(s). NB - don't share your access token
 - `L1_CONSENSUS_HOST_URLS=<url>`: One or more comma-separated public rpc provider url(s) that supports consensus client requests
-- `VALIDATOR_PRIVATE_KEY="Ox<hex value>"`: Private key of testnet L1 EOA that holds Sepolia ETH (0.01 Sepolia ETH can get you started)
-- `COINBASE="0x<eth address>"`: Recipient of block rewards (for node security on mainnet, this should be a different address to the validator eoa)
+- `VALIDATOR_PRIVATE_KEY="Ox<hex value>"`: Private key of testnet L1 EOA that defines the sequencer identity that holds Sepolia ETH (0.01 Sepolia ETH can get you started)
+- `COINBASE="0x<eth address>"`: Recipient of block rewards (for node security on mainnet, this should be a different address to the sequencer EOA)
 - `P2P_IP="x.x.x.x"`: IP address of computer running the node (you can get this by running, `curl api.ipify.org`, on your node)
 
 Now in a terminal start your node as a sequencer and archiver:
@@ -104,9 +104,9 @@ To add your sequencer you'll need the following few values, as well as `ETHEREUM
 
 - `STAKING_ASSET_HANDLER="0xF739D03e98e23A7B65940848aBA8921fF3bAc4b2"`: Constant L1 contract address
 - `L1_CHAIN_ID="11155111"`: Sepolia chainid
-- `PRIVATE_KEY="0x<hex value>`: private key of account with sepolia eth to make transaction (eg can use funded validator key)
+- `PRIVATE_KEY="0x<hex value>`: private key of account with sepolia eth to make transaction (eg can use funded sequencer key)
 
-Then run the aztec command to add your address as an L1 validator, with rpc url(s) for Etheruem L1 execution requests:
+Then run the aztec command to add your address as an L1 sequencer, with rpc url(s) for Etheruem L1 execution requests:
 
 ```bash
 aztec add-l1-validator --staking-asset-handler=0xF739D03e98e23A7B65940848aBA8921fF3bAc4b2 \
@@ -119,11 +119,11 @@ aztec add-l1-validator --staking-asset-handler=0xF739D03e98e23A7B65940848aBA8921
 
 **Tip**: Use `aztec help add-l1-validator` for further parameter details.
 
-:::note Validator Quota Filled
+:::note Sequencer Quota Filled
 
-In the absence of real-world staking incentives, becoming a validator is throttled with time, so you may see `ValidatorQuotaFilledUntil(uint256 _timestamp)` at the beginning of the text returned.
+In the absence of real-world staking incentives, becoming a sequencer is throttled with time, so you may see `ValidatorQuotaFilledUntil(uint256 _timestamp)` at the beginning of the text returned.
 
-The timestamp is when the next round of sequencers can be added as validators, so try again right after that.
+The timestamp is when the next round of sequencers can be added into the sequencer set, so try again right after that.
 
 :::
 
@@ -147,7 +147,7 @@ To use the `aztec start` command, you need to obtain the following:
 
 You will need an Ethereum private key and the corresponding public address. The private key is set via the `--sequencer.validatorPrivateKeys` flag while the public address should be specified via the `--sequencer.coinbase ` flag.
 
-The private key is needed as your validator will post blocks to Ethereum, and the public address will be the recipient of any block rewards.
+The private key is needed as your sequencer will post blocks to Ethereum, and the public address will be the recipient of any block rewards.
 
 Disclaimer: you may want to generate and use a new Ethereum private key.
 
@@ -191,23 +191,23 @@ For a full overview of all available commands, check out the [CLI reference shee
 If you are unable to determine your public ip. Running the command `curl ipv4.icanhazip.com` can retrieve it for you.
 :::
 
-### Register as a Validator
+### Register as a Sequencer
 
-Once your node is fully synced, you can register as a validator using the `add-l1-validator` command:
+Once your node is fully synced, you can register as a sequencer using the `add-l1-validator` command:
 
 ```bash
 aztec add-l1-validator \
   --l1-rpc-urls https://eth-sepolia.g.example.com/example/your-key \
   --private-key your-private-key \
-  --attester your-validator-address \
-  --proposer-eoa your-validator-address \
+  --attester your-sequencer-address \
+  --proposer-eoa your-sequencer-address \
   --staking-asset-handler 0xF739D03e98e23A7B65940848aBA8921fF3bAc4b2 \
   --l1-chain-id 11155111
 ```
 
 :::warning
 
-You may see a warning when trying to register as a validator. To maintain network health there is a daily quota for validators to join the validator set. If you are not able to join, it could mean that today's quota of validators has already been added to the set. If you see this, you can try again later. Read [our blog post](https://aztec.network/blog/what-is-aztec-testnet) for more info.
+You may see a warning when trying to register as a sequencer. To maintain network health there is a daily quota for sequencers to join the sequencer set. If you are not able to join, it could mean that today's quota of sequencers has already been added to the set. If you see this, you can try again later. Read [our blog post](https://aztec.network/blog/what-is-aztec-testnet) for more info.
 
 :::
 

--- a/docs/docs/the_aztec_network/reference/useful_commands.md
+++ b/docs/docs/the_aztec_network/reference/useful_commands.md
@@ -34,9 +34,9 @@ cast call <RegistryContractAddress> "getCanonicalRollup()" --rpc-url https://exa
 The rest of the guide will omit the `--rpc-url` flag for legibility.
 :::
 
-## Query the Validator Set
+## Query the Sequencer Set
 
-### Retrieve a list of all validators
+### Retrieve a list of all sequencers
 
 Run
 
@@ -44,22 +44,22 @@ Run
 cast call <RollupAddress> "getAttesters()" --rpc-url
 ```
 
-### What is the status of a particular validator?
+### What is the status of a particular sequencer?
 
 Run
 
 ```bash
-cast call <RollupAddress> "getInfo(address)" <ValidatorAddress>
+cast call <RollupAddress> "getInfo(address)" <SequencerAddress>
 ```
 
-This will return in order: 1) the validator's balance 2) their `withdrawer` address 3) their `proposer` address and 4) their current status.
+This will return in order: 1) the sequencer's balance 2) their `withdrawer` address 3) their `proposer` address and 4) their current status.
 
 | Status | Meaning                                                                                                              |
 | ------ | -------------------------------------------------------------------------------------------------------------------- |
-| 0      | The validator is not in the validator set                                                                            |
-| 1      | The validator is currently in the validator set.                                                                     |
-| 2      | The validator is not active in the set. This could mean that they initiated a withdrawal and are awaiting final exit |
-| 3      | The validator has completed their exit delay and can be exited from the validator set                                |
+| 0      | The sequencer is not in the sequencer set                                                                            |
+| 1      | The sequencer is currently in the sequencer set.                                                                     |
+| 2      | The sequencer is not active in the set. This could mean that they initiated a withdrawal and are awaiting final exit |
+| 3      | The sequencer has completed their exit delay and can be exited from the sequencer set                                |
 
 ## Governance Upgrades
 

--- a/docs/versioned_docs/version-v1.2.0/aztec/concepts/fees.md
+++ b/docs/versioned_docs/version-v1.2.0/aztec/concepts/fees.md
@@ -53,7 +53,7 @@ import { Gas_Settings_Components, Gas_Settings, Tx_Teardown_Phase } from '@site/
 
 These are:
 
-```javascript title="gas_settings_vars" showLineNumbers 
+```javascript title="gas_settings_vars" showLineNumbers
 /** Gas usage and fees limits set by the transaction sender for different dimensions and phases. */
 export class GasSettings {
   constructor(
@@ -87,7 +87,7 @@ An account making a transaction can also refer to "fee-paying contracts" (FPCs) 
 ### Operator rewards
 
 The calculated fee-juice of a transaction is deducted from the fee payer (nominated account or fee-paying contract), then pooled together each transaction, block, and epoch.
-Once the epoch is proven, the total fee-juice (minus any burnt congestion amount), is distributed to provers and block validators/sequencers that contributed to the epoch.
+Once the epoch is proven, the total fee-juice (minus any burnt congestion amount), is distributed to provers and block sequencers that contributed to the epoch.
 
 The fees section of the protocol specification explains this distribution of fee-juice between proposers and provers.
 

--- a/docs/versioned_docs/version-v1.2.0/aztec/concepts/wallets/architecture.md
+++ b/docs/versioned_docs/version-v1.2.0/aztec/concepts/wallets/architecture.md
@@ -20,7 +20,7 @@ In code, this translates to a wallet implementing an **AccountInterface** interf
 
 The account interface is used for creating an _execution request_ out of one or more _function calls_ requested by a dapp, as well as creating an _auth witness_ for a given message hash. Account contracts are expected to handle multiple function calls per transaction, since dapps may choose to batch multiple actions into a single request to the wallet.
 
-```typescript title="account-interface" showLineNumbers 
+```typescript title="account-interface" showLineNumbers
 
 /**
  * Handler for interfacing with an account. Knows how to create transaction execution
@@ -47,7 +47,7 @@ export interface AccountInterface extends EntrypointInterface, AuthWitnessProvid
 
 A wallet exposes the PXE interface to dapps by running a PXE instance. The PXE requires a keystore and a database implementation for storing keys, private state, and recipient encryption public keys.
 
-```typescript title="pxe-interface" showLineNumbers 
+```typescript title="pxe-interface" showLineNumbers
 /**
  * Private eXecution Environment (PXE) runs locally for each user, providing functionality for all the operations
  * needed to interact with the Aztec network, including account management, private data management,
@@ -136,7 +136,7 @@ export interface PXE {
 
   /**
    * Proves the private portion of a simulated transaction, ready to send to the network
-   * (where validators prove the public portion).
+   * (where sequencers prove the public portion).
    *
    * @param txRequest - An authenticated tx request ready for proving
    * @param privateExecutionResult - (optional) The result of the private execution of the transaction. The txRequest

--- a/docs/versioned_docs/version-v1.2.0/developers/reference/aztecjs/pxe/interfaces/PXE.md
+++ b/docs/versioned_docs/version-v1.2.0/developers/reference/aztecjs/pxe/interfaces/PXE.md
@@ -494,7 +494,7 @@ ___
 ▸ **proveTx**(`txRequest`, `privateExecutionResult?`): `Promise`\<`TxProvingResult`\>
 
 Proves the private portion of a simulated transaction, ready to send to the network
-(where validators prove the public portion).
+(where sequencers prove the public portion).
 
 #### Parameters
 

--- a/docs/versioned_docs/version-v1.2.0/developers/reference/environment_reference/sandbox-reference.md
+++ b/docs/versioned_docs/version-v1.2.0/developers/reference/environment_reference/sandbox-reference.md
@@ -68,9 +68,7 @@ ROLLUP_CONTRACT_ADDRESS=0x01234567890abcde01234567890abcde
 SEQ_PUBLISHER_PRIVATE_KEY=0x01234567890abcde01234567890abcde # Private key of an ethereum account that will be used by the sequencer to publish blocks.
 SEQ_MAX_TX_PER_BLOCK=32 # Maximum txs to go on a block. (default: 32)
 SEQ_MIN_TX_PER_BLOCK=1 # Minimum txs to go on a block. (default: 1)
-
-## Validator variables ##
-VALIDATOR_PRIVATE_KEY=0x01234567890abcde01234567890abcde  # Private key of the ethereum account that will be used to perform validator duties
+VALIDATOR_PRIVATE_KEY=0x01234567890abcde01234567890abcde  # Private key of the ethereum account that will be used to perform sequencer duties
 ```
 
 **PXE**

--- a/docs/versioned_docs/version-v1.2.0/the_aztec_network/concepts/deployments/what_is_deployment.md
+++ b/docs/versioned_docs/version-v1.2.0/the_aztec_network/concepts/deployments/what_is_deployment.md
@@ -22,7 +22,7 @@ Hypothetical Asset would live on Ethereum L1. It may have a minter which would b
 
 This is brought up to the community for discussion purposes only to illustrate how proposed governance mechanisms could work with a Hypothetical Asset.
 
-- **Validators** must stake the Hypothetical Asset within the instance's contract to join that instance's validator set.
+- **Sequencers** must stake the Hypothetical Asset within the instance's contract to join that instance's sequencer set.
 - **Holders** must lock Hypothetical Asset with the Governance contract to be able to vote on proposals.
 - **Provers** must deposit Hypothetical Asset in the escrow contract in order to bid for the right to create a proof for an epoch.
 

--- a/docs/versioned_docs/version-v1.2.0/the_aztec_network/concepts/governance/putting_forward_proposals.md
+++ b/docs/versioned_docs/version-v1.2.0/the_aztec_network/concepts/governance/putting_forward_proposals.md
@@ -10,9 +10,9 @@ Sequencers can only nominate a proposal during an L2 slot for which they’ve be
 
 A mechanism is also proposed whereby any Hypothetical Asset holder (“Holderˮ) can burn a large quantity of Hypothetical Asset to trigger a vote on a proposal, without having the sequencers nominating the proposal. Note that Hypothetical Asset holders would still need to vote to approve any proposals nominated via this mechanism.
 
-To nominate a proposal, a validator of the current canonical rollup would deploy two sets of contracts:
+To nominate a proposal, a sequencer of the current canonical rollup would deploy two sets of contracts:
 
 1. The upgraded contracts they wish to upgrade to
 2. `code` which can be executed by governance to upgrade into these contracts
 
-Then when it is their turn as the proposer, they call `vote(address _proposal)` on the `Proposals` contract, where `_proposal ` is the address of the `code` payload. Alternatively, validators can set the `GOVERNANCE_PROPOSAL_PAYLOAD=_proposal` env variable which will call `vote(address _proposal)` during a slot they're eligible to signal in.
+Then when it is their turn as the proposer, they call `vote(address _proposal)` on the `Proposals` contract, where `_proposal ` is the address of the `code` payload. Alternatively, sequencers can set the `GOVERNANCE_PROPOSAL_PAYLOAD=_proposal` env variable which will call `vote(address _proposal)` during a slot they're eligible to signal in.

--- a/docs/versioned_docs/version-v1.2.0/the_aztec_network/concepts/governance/upgrades.md
+++ b/docs/versioned_docs/version-v1.2.0/the_aztec_network/concepts/governance/upgrades.md
@@ -38,4 +38,4 @@ After governance approval and a delay period, the proposal becomes executable:
 - Any Ethereum account can call `execute(_proposalId)` on the Governance contract.
 - The `execute` function calls the proposal code, transitioning the network to the new Rollup instance.
 
-For a more hands-on guide to reacting to upgrades as a sequencer/validators, read [this](../../reference/reacting_to_upgrades.md).
+For a more hands-on guide to reacting to upgrades as a sequencer, read [this](../../reference/reacting_to_upgrades.md).

--- a/docs/versioned_docs/version-v1.2.0/the_aztec_network/concepts/governance/voting.md
+++ b/docs/versioned_docs/version-v1.2.0/the_aztec_network/concepts/governance/voting.md
@@ -8,4 +8,4 @@ Holders have the ability to vote on proposals as long as they lock any Hypotheti
 
 Hypothetical Assets locked in the Governance contract are simply locked and not “at stakeˮ i.e. there are no slashing conditions.
 
-Since sequencers may be able to stake Hypothetical Assets with the rollup instances in order to join the validator set, the rollup instance could in turn lock those Hypothetical Assets in the Governance contract and vote on behalf of the sequencers. This is expected behavior.
+Since sequencers may be able to stake Hypothetical Assets with the rollup instances in order to join the sequencer set, the rollup instance could in turn lock those Hypothetical Assets in the Governance contract and vote on behalf of the sequencers. This is expected behavior.

--- a/docs/versioned_docs/version-v1.2.0/the_aztec_network/concepts/proof_of_stake/slashing.md
+++ b/docs/versioned_docs/version-v1.2.0/the_aztec_network/concepts/proof_of_stake/slashing.md
@@ -17,21 +17,21 @@ There are some actions that impact the chainʼs ability to finalize new blocks:
 
 ### Insufficient quorum
 
-In the event that a significant portion of the validator set goes offline (i.e. large internet outage) and proposers are unable to get enough attestations on block proposals, the Aztec Rollup will be unable to finalize new blocks. This will require the community to engage to fix the issue and make sure new blocks are being finalized.
+In the event that a significant portion of the sequencer set goes offline (i.e. large internet outage) and proposers are unable to get enough attestations on block proposals, the Aztec Rollup will be unable to finalize new blocks. This will require the community to engage to fix the issue and make sure new blocks are being finalized.
 
 In the event of a prolonged period where the Aztec Rollup is not finalizing new blocks, it may enter Based Fallback mode. The conditions that lead to [Based Fallback (forum link)](https://forum.aztec.network/t/request-for-comments-aztecs-block-production-system/6155) mode are expected to be well defined by the community of sequencers, provers, client teams and all other Aztec Rollup  stakeholders and participants.
 
-During Based Fallback mode, anyone can propose blocks if they supply proofs for these blocks alongside them. This is in contrast to the usual condition that only the sequencer assigned to a particular slot can propose blocks during that slot. This means that the inactive validator set is bypassed and anyone can advance the chain in the event of an inactive / non-participating validator set.
+During Based Fallback mode, anyone can propose blocks if they supply proofs for these blocks alongside them. This is in contrast to the usual condition that only the sequencer assigned to a particular slot can propose blocks during that slot. This means that the inactive sequencer set is bypassed and anyone can advance the chain in the event of an inactive / non-participating sequencer set.
 
-But terminally inactive validators must be removed from the validator set or otherwise we end up in Based Fallback too often. Slashing is a method whereby the validator set votes to “slash” the stake of inactive validators down to a point where they are kicked off the validator set. For example, if we set `MINIMUM_STAKING_BALANCE=50%` then as soon as 50% or more of a validator’s balance is slashed, they will be kicked out of the set.
+But terminally inactive sequencers must be removed from the sequencer set or otherwise we end up in Based Fallback too often. Slashing is a method whereby the sequencer set votes to “slash” the stake of inactive sequencers down to a point where they are kicked off the sequencer set. For example, if we set `MINIMUM_STAKING_BALANCE=50%` then as soon as 50% or more of a sequencer's balance is slashed, they will be kicked out of the set.
 
 ### Committee withholding data from the provers
 
 Provers need the transaction data (i.e. `TxObjects`) plus the client-side generated proofs to produce the final rollup proof, none of which are posted onchain. Client side proofs + transaction data are gossiped on the p2p instead so that committee members can re-execute block proposals and verify that the proposed state root is correct.
 
-Recall from the [RFC (forum link)](https://forum.aztec.network/t/request-for-comments-aztecs-block-production-system/6155) on block production that the committee is a subset of validators, randomly sampled from the entire validator set. Block proposers are sampled from this committee. ⅔ + 1 of this committee  must attest to L2 block proposals before they are posted to the L1 by the block proposer.
+Recall from the [RFC (forum link)](https://forum.aztec.network/t/request-for-comments-aztecs-block-production-system/6155) on block production that the committee is a subset of sequencers, randomly sampled from the entire sequencer set. Block proposers are sampled from this committee. ⅔ + 1 of this committee  must attest to L2 block proposals before they are posted to the L1 by the block proposer.
 
-A malicious committee may not gossip the transaction data or proofs to the rest of the validator set, nor to the provers. As a result, no prover can produce the proof and the epoch in question will reorg by design. Recall from the RFC on block production that if no proof for epoch N is submitted to L1 by the end of epoch N+1, then epoch N + any blocks built in epoch N+1 are reorged.
+A malicious committee may not gossip the transaction data or proofs to the rest of the sequencer set, nor to the provers. As a result, no prover can produce the proof and the epoch in question will reorg by design. Recall from the RFC on block production that if no proof for epoch N is submitted to L1 by the end of epoch N+1, then epoch N + any blocks built in epoch N+1 are reorged.
 
 ### Committee proposing an invalid state root
 
@@ -48,6 +48,6 @@ An honest prover who has funds at stake (i.e. posted a bond to produce the epoch
 
 In all the previous cases, it is very hard to verify and automatically slash for these events onchain. This is mainly due to the fact that neither TxObjects nor client side proofs are posted onchain. Committee members also gossip attestations on the p2p and do not post them directly on chain.
 
-Therefore a slashing mechanism is required as a deterrence against the malicious behaviour by validators and to make sure that the Aztec Rollup retains liveness. The validator set votes to slash dishonest validators based on evidence that is collected onchain + offchain, and discussed and analyzed offchain (i.e. on a forum).
+Therefore a slashing mechanism is required as a deterrence against the malicious behaviour by sequencers and to make sure that the Aztec Rollup retains liveness. The sequencer set votes to slash dishonest sequencers based on evidence that is collected onchain + offchain, and discussed and analyzed offchain (i.e. on a forum).
 
-A validator must aggregate BLS signatures on slashing proposals and post them to the L1 for slash execution.
+A sequencer must aggregate BLS signatures on slashing proposals and post them to the L1 for slash execution.

--- a/docs/versioned_docs/version-v1.2.0/the_aztec_network/concepts/provers-and-sequencers/index.md
+++ b/docs/versioned_docs/version-v1.2.0/the_aztec_network/concepts/provers-and-sequencers/index.md
@@ -13,4 +13,4 @@ Sequencers will be chosen via a random election, while provers will be selected 
 
 The proposers in the first `C=13` slots in epoch `N+1` will accept quotes to prove epoch N from provers. The winning prover will have until the end of epoch `N+1` to produce and submit the proof to L1.
 
-If are you interested in running a validator node (also known as a sequencer node) or a prover node, you can refer to [the guides section](./../../guides/run_nodes/index.md).
+If are you interested in running a sequencer node or a prover node, you can refer to [the guides section](./../../guides/run_nodes/index.md).

--- a/docs/versioned_docs/version-v1.2.0/the_aztec_network/guides/run_nodes/how_to_run_prover.md
+++ b/docs/versioned_docs/version-v1.2.0/the_aztec_network/guides/run_nodes/how_to_run_prover.md
@@ -97,7 +97,7 @@ services:
         condition: service_started
         required: true
     environment:
-      # PROVER_COORDINATION_NODE_URL: "http://:8080" # this can point to your own validator - using this replaces the need for the prover node to be on the P2P network and uses your validator as a sentry node of some sort.
+      # PROVER_COORDINATION_NODE_URL: "http://:8080" # this can point to your own sequencer - using this replaces the need for the prover node to be on the P2P network and uses your sequencer as a sentry node of some sort.
       # P2P_ENABLED: "false" # Switch to false if you provide a PROVER_COORDINATION_NODE_URL
       DATA_DIRECTORY: /data
       DATA_STORE_MAP_SIZE_KB: "134217728"

--- a/docs/versioned_docs/version-v1.2.0/the_aztec_network/guides/run_nodes/how_to_run_sequencer.md
+++ b/docs/versioned_docs/version-v1.2.0/the_aztec_network/guides/run_nodes/how_to_run_sequencer.md
@@ -29,10 +29,10 @@ The Aztec sequencer node is critical infrastructure responsible for ordering tra
 The sequencer node takes part in three key actions:
 
 1. Assemble unprocessed transactions and propose the next block
-2. Attest to correct execution of txs in the proposed block (if part of validator committee)
+2. Attest to correct execution of txs in the proposed block (if part of sequencer committee)
 3. Submit the successfully attested block to L1
 
-When transactions are sent to the Aztec network, sequencer nodes bundles them into blocks, checking various constraints such as gas limits, block size, and transaction validity. Before a block can be published, it must be validated by a committee of other sequencer nodes (validators in this context) who re-execute public transactions and verify private function proofs so they can attest to correct execution. These validators attest to the block's validity by signing it, and once enough attestations are collected (two-thirds of the committee plus one), the sequencer can submit the block to L1.
+When transactions are sent to the Aztec network, sequencer nodes bundles them into blocks, checking various constraints such as gas limits, block size, and transaction validity. Before a block can be published, it must be validated by a committee of other sequencer nodes who re-execute public transactions and verify private function proofs so they can attest to correct execution. These sequencers attest to the block's validity by signing it, and once enough attestations are collected (two-thirds of the committee plus one), the sequencer can submit the block to L1.
 
 The archiver component complements this process by maintaining historical chain data. It continuously monitors L1 for new blocks, processes them, and maintains a synchronized view of the chain state. This includes managing contract data, transaction logs, and L1-to-L2 messages, making it essential for network synchronization and data availability.
 
@@ -65,8 +65,8 @@ The following variable names are specific to the `aztec start` command, set them
 
 - `ETHEREUM_HOSTS=<url>`: One or more comma-separated public rpc provider url(s). NB - don't share your access token
 - `L1_CONSENSUS_HOST_URLS=<url>`: One or more comma-separated public rpc provider url(s) that supports consensus client requests
-- `VALIDATOR_PRIVATE_KEY="Ox<hex value>"`: Private key of testnet L1 EOA that holds Sepolia ETH (0.01 Sepolia ETH can get you started)
-- `COINBASE="0x<eth address>"`: Recipient of block rewards (for node security on mainnet, this should be a different address to the validator eoa)
+- `VALIDATOR_PRIVATE_KEY="Ox<hex value>"`: Private key of testnet L1 EOA that defines the sequencer identity that holds Sepolia ETH (0.01 Sepolia ETH can get you started)
+- `COINBASE="0x<eth address>"`: Recipient of block rewards (for node security on mainnet, this should be a different address to the sequencer EOA)
 - `P2P_IP="x.x.x.x"`: IP address of computer running the node (you can get this by running, `curl api.ipify.org`, on your node)
 
 Now in a terminal start your node as a sequencer and archiver:
@@ -104,9 +104,9 @@ To add your sequencer you'll need the following few values, as well as `ETHEREUM
 
 - `STAKING_ASSET_HANDLER="0xF739D03e98e23A7B65940848aBA8921fF3bAc4b2"`: Constant L1 contract address
 - `L1_CHAIN_ID="11155111"`: Sepolia chainid
-- `PRIVATE_KEY="0x<hex value>`: private key of account with sepolia eth to make transaction (eg can use funded validator key)
+- `PRIVATE_KEY="0x<hex value>`: private key of account with sepolia eth to make transaction (eg can use funded sequencer key)
 
-Then run the aztec command to add your address as an L1 validator, with rpc url(s) for Etheruem L1 execution requests:
+Then run the aztec command to add your address as an L1 sequencer, with rpc url(s) for Etheruem L1 execution requests:
 
 ```bash
 aztec add-l1-validator --staking-asset-handler=0xF739D03e98e23A7B65940848aBA8921fF3bAc4b2 \
@@ -119,11 +119,11 @@ aztec add-l1-validator --staking-asset-handler=0xF739D03e98e23A7B65940848aBA8921
 
 **Tip**: Use `aztec help add-l1-validator` for further parameter details.
 
-:::note Validator Quota Filled
+:::note Sequencer Quota Filled
 
-In the absence of real-world staking incentives, becoming a validator is throttled with time, so you may see `ValidatorQuotaFilledUntil(uint256 _timestamp)` at the beginning of the text returned.
+In the absence of real-world staking incentives, becoming a sequencer is throttled with time, so you may see `ValidatorQuotaFilledUntil(uint256 _timestamp)` at the beginning of the text returned.
 
-The timestamp is when the next round of sequencers can be added as validators, so try again right after that.
+The timestamp is when the next round of sequencers can be added into the sequencer set, so try again right after that.
 
 :::
 
@@ -147,7 +147,7 @@ To use the `aztec start` command, you need to obtain the following:
 
 You will need an Ethereum private key and the corresponding public address. The private key is set via the `--sequencer.validatorPrivateKeys` flag while the public address should be specified via the `--sequencer.coinbase ` flag.
 
-The private key is needed as your validator will post blocks to Ethereum, and the public address will be the recipient of any block rewards.
+The private key is needed as your sequencer will post blocks to Ethereum, and the public address will be the recipient of any block rewards.
 
 Disclaimer: you may want to generate and use a new Ethereum private key.
 
@@ -191,23 +191,23 @@ For a full overview of all available commands, check out the [CLI reference shee
 If you are unable to determine your public ip. Running the command `curl ipv4.icanhazip.com` can retrieve it for you.
 :::
 
-### Register as a Validator
+### Register as a Sequencer
 
-Once your node is fully synced, you can register as a validator using the `add-l1-validator` command:
+Once your node is fully synced, you can register as a sequencer using the `add-l1-validator` command:
 
 ```bash
 aztec add-l1-validator \
   --l1-rpc-urls https://eth-sepolia.g.example.com/example/your-key \
   --private-key your-private-key \
-  --attester your-validator-address \
-  --proposer-eoa your-validator-address \
+  --attester your-sequencer-address \
+  --proposer-eoa your-sequencer-address \
   --staking-asset-handler 0xF739D03e98e23A7B65940848aBA8921fF3bAc4b2 \
   --l1-chain-id 11155111
 ```
 
 :::warning
 
-You may see a warning when trying to register as a validator. To maintain network health there is a daily quota for validators to join the validator set. If you are not able to join, it could mean that today's quota of validators has already been added to the set. If you see this, you can try again later. Read [our blog post](https://aztec.network/blog/what-is-aztec-testnet) for more info.
+You may see a warning when trying to register as a sequencer. To maintain network health there is a daily quota for sequencers to join the sequencer set. If you are not able to join, it could mean that today's quota of sequencers has already been added to the set. If you see this, you can try again later. Read [our blog post](https://aztec.network/blog/what-is-aztec-testnet) for more info.
 
 :::
 

--- a/docs/versioned_docs/version-v1.2.0/the_aztec_network/reference/useful_commands.md
+++ b/docs/versioned_docs/version-v1.2.0/the_aztec_network/reference/useful_commands.md
@@ -34,9 +34,9 @@ cast call <RegistryContractAddress> "getCanonicalRollup()" --rpc-url https://exa
 The rest of the guide will omit the `--rpc-url` flag for legibility.
 :::
 
-## Query the Validator Set
+## Query the Sequencer Set
 
-### Retrieve a list of all validators
+### Retrieve a list of all sequencers
 
 Run
 
@@ -44,22 +44,22 @@ Run
 cast call <RollupAddress> "getAttesters()" --rpc-url
 ```
 
-### What is the status of a particular validator?
+### What is the status of a particular sequencer?
 
 Run
 
 ```bash
-cast call <RollupAddress> "getInfo(address)" <ValidatorAddress>
+cast call <RollupAddress> "getInfo(address)" <SequencerAddress>
 ```
 
-This will return in order: 1) the validator's balance 2) their `withdrawer` address 3) their `proposer` address and 4) their current status.
+This will return in order: 1) the sequencer's balance 2) their `withdrawer` address 3) their `proposer` address and 4) their current status.
 
 | Status | Meaning                                                                                                              |
 | ------ | -------------------------------------------------------------------------------------------------------------------- |
-| 0      | The validator is not in the validator set                                                                            |
-| 1      | The validator is currently in the validator set.                                                                     |
-| 2      | The validator is not active in the set. This could mean that they initiated a withdrawal and are awaiting final exit |
-| 3      | The validator has completed their exit delay and can be exited from the validator set                                |
+| 0      | The sequencer is not in the sequencer set                                                                            |
+| 1      | The sequencer is currently in the sequencer set.                                                                     |
+| 2      | The sequencer is not active in the set. This could mean that they initiated a withdrawal and are awaiting final exit |
+| 3      | The sequencer has completed their exit delay and can be exited from the sequencer set                                |
 
 ## Governance Upgrades
 


### PR DESCRIPTION
This does not touch any CLI option naming. this should be done by eng / dev rel with confirmation from eng in a follow up pr