### PR TITLE
refactor(bb): optimize batch_mul_with_endomorphism

### DIFF
--- a/barretenberg/cpp/src/barretenberg/common/bb_bench.cpp
+++ b/barretenberg/cpp/src/barretenberg/common/bb_bench.cpp
@@ -31,63 +31,17 @@ struct Colors {
     static constexpr const char* RED = "\033[31m";
 };
 
-// Helper to determine if time is in seconds range
-bool is_seconds_range(double time_ms)
-{
-    return time_ms >= 1000.0;
-}
-
-// Helper to determine if time is in milliseconds range
-bool is_milliseconds_range(double time_ms)
-{
-    return time_ms >= 1.0 && time_ms < 1000.0;
-}
-
-// Helper to convert milliseconds to seconds
-double milliseconds_to_seconds(double time_ms)
-{
-    return time_ms / 1000.0;
-}
-
-// Helper to convert milliseconds to microseconds
-double milliseconds_to_microseconds(double time_ms)
-{
-    return time_ms * 1000.0;
-}
-
-// Helper to convert nanoseconds to milliseconds
-double nanoseconds_to_milliseconds(uint64_t nanoseconds)
-{
-    return static_cast<double>(nanoseconds) / 1000000.0;
-}
-
 // Format time value with appropriate unit
 std::string format_time(double time_ms)
 {
     std::ostringstream oss;
-    if (is_seconds_range(time_ms)) {
-        oss << std::fixed << std::setprecision(2) << milliseconds_to_seconds(time_ms) << " s";
-    } else if (is_milliseconds_range(time_ms)) {
+    if (time_ms >= 1000.0) {
+        oss << std::fixed << std::setprecision(2) << (time_ms / 1000.0) << " s";
+    } else if (time_ms >= 1.0 && time_ms < 1000.0) {
         oss << std::fixed << std::setprecision(2) << time_ms << " ms";
     } else {
-        oss << std::fixed << std::setprecision(1) << milliseconds_to_microseconds(time_ms) << " μs";
+        oss << std::fixed << std::setprecision(1) << (time_ms * 1000.0) << " μs";
     }
-    return oss.str();
-}
-
-// Helper to create formatted time string for seconds
-std::string create_seconds_string(double time_ms)
-{
-    std::ostringstream oss;
-    oss << std::fixed << std::setprecision(2) << milliseconds_to_seconds(time_ms) << "s";
-    return oss.str();
-}
-
-// Helper to create formatted time string for milliseconds
-std::string create_milliseconds_string(double time_ms)
-{
-    std::ostringstream oss;
-    oss << std::fixed << std::setprecision(1) << time_ms << "ms";
     return oss.str();
 }
 
@@ -95,35 +49,16 @@ std::string create_milliseconds_string(double time_ms)
 std::string format_time_aligned(double time_ms)
 {
     std::ostringstream oss;
-    if (is_seconds_range(time_ms)) {
-        std::string time_str = create_seconds_string(time_ms);
-        oss << std::left << std::setw(10) << time_str;
+    if (time_ms >= 1000.0) {
+        std::ostringstream time_oss;
+        time_oss << std::fixed << std::setprecision(2) << (time_ms / 1000.0) << "s";
+        oss << std::left << std::setw(10) << time_oss.str();
     } else {
-        std::string time_str = create_milliseconds_string(time_ms);
-        oss << std::left << std::setw(10) << time_str;
+        std::ostringstream time_oss;
+        time_oss << std::fixed << std::setprecision(1) << time_ms << "ms";
+        oss << std::left << std::setw(10) << time_oss.str();
     }
     return oss.str();
-}
-
-// Helper to calculate percentage
-double calculate_percentage(double value, double total)
-{
-    if (total <= 0) {
-        return 0.0;
-    }
-    return (value / total) * 100.0;
-}
-
-// Helper to check if percentage is below threshold
-bool is_percentage_below_threshold(double percentage, double threshold)
-{
-    return percentage < threshold;
-}
-
-// Helper to create empty percentage string
-std::string create_empty_percentage_string()
-{
-    return "       ";
 }
 
 // Helper to format percentage value
@@ -138,9 +73,9 @@ std::string format_percentage_value(double percentage, const char* color)
 // Helper to format percentage with color based on percentage value
 std::string format_percentage(double value, double total, double min_threshold = 0.0)
 {
-    double percentage = calculate_percentage(value, total);
-    if (total <= 0 || is_percentage_below_threshold(percentage, min_threshold)) {
-        return create_empty_percentage_string();
+    double percentage = (total <= 0) ? 0.0 : (value / total) * 100.0;
+    if (total <= 0 || percentage < min_threshold) {
+        return "       ";
     }
 
     // Choose color based on percentage value (like time colors)
@@ -149,33 +84,13 @@ std::string format_percentage(double value, double total, double min_threshold =
     return format_percentage_value(percentage, color);
 }
 
-// Helper to format indent level indicator
-std::string format_indent_level_indicator(size_t indent_level)
-{
-    std::ostringstream oss;
-    oss << Colors::MAGENTA << "[" << indent_level << "] " << Colors::RESET;
-    return oss.str();
-}
-
-// Helper to check if should show percentage
-bool should_show_percentage(double parent_time, size_t indent_level)
-{
-    return parent_time > 0 && indent_level > 0;
-}
-
 // Helper to format percentage section
 std::string format_percentage_section(double time_ms, double parent_time, size_t indent_level)
 {
-    if (should_show_percentage(parent_time, indent_level)) {
+    if (parent_time > 0 && indent_level > 0) {
         return format_percentage(time_ms * 1000000.0, parent_time);
     }
-    return create_empty_percentage_string();
-}
-
-// Helper to check if time needs dimming
-bool should_dim_time(double time_ms)
-{
-    return time_ms >= 100.0 && time_ms < 1000.0;
+    return "       ";
 }
 
 // Helper to format time section
@@ -183,7 +98,7 @@ std::string format_time_section(double time_ms)
 {
     std::ostringstream oss;
     oss << "   ";
-    if (should_dim_time(time_ms)) {
+    if (time_ms >= 100.0 && time_ms < 1000.0) {
         oss << Colors::DIM << format_time_aligned(time_ms) << Colors::RESET;
     } else {
         oss << format_time_aligned(time_ms);
@@ -191,25 +106,13 @@ std::string format_time_section(double time_ms)
     return oss.str();
 }
 
-// Helper to check if should show call stats
-bool should_show_call_stats(double time_ms, uint64_t count)
-{
-    return time_ms >= 100.0 && count > 1;
-}
-
-// Helper to calculate average time
-double calculate_average_time(double time_ms, uint64_t count)
-{
-    return time_ms / static_cast<double>(count);
-}
-
 // Helper to format call stats
 std::string format_call_stats(double time_ms, uint64_t count)
 {
-    if (!should_show_call_stats(time_ms, count)) {
+    if (!(time_ms >= 100.0 && count > 1)) {
         return "";
     }
-    double avg_ms = calculate_average_time(time_ms, count);
+    double avg_ms = time_ms / static_cast<double>(count);
     std::ostringstream oss;
     oss << Colors::DIM << " (" << format_time(avg_ms) << " x " << count << ")" << Colors::RESET;
     return oss.str();
@@ -220,7 +123,7 @@ std::string format_aligned_section(double time_ms, double parent_time, uint64_t 
     std::ostringstream oss;
 
     // Add indent level indicator at the beginning with different color
-    oss << format_indent_level_indicator(indent_level);
+    oss << Colors::MAGENTA << "[" << indent_level << "] " << Colors::RESET;
 
     // Format percentage FIRST
     oss << format_percentage_section(time_ms, parent_time, indent_level);
@@ -240,45 +143,15 @@ struct TimeColor {
     const char* time_color;
 };
 
-// Helper to check if time is significant (>= 100ms)
-bool is_time_significant(double time_ms)
-{
-    return time_ms >= 100.0;
-}
-
-// Helper to check if time is minimal (< 100ms)
-bool is_time_minimal(double time_ms)
-{
-    return time_ms < 100.0;
-}
-
-// Helper to get colors for significant seconds
-TimeColor get_seconds_colors()
-{
-    return { Colors::BOLD, Colors::WHITE };
-}
-
-// Helper to get colors for significant milliseconds
-TimeColor get_significant_milliseconds_colors()
-{
-    return { Colors::YELLOW, Colors::YELLOW };
-}
-
-// Helper to get colors for minimal time
-TimeColor get_minimal_time_colors()
-{
-    return { Colors::DIM, Colors::DIM };
-}
-
 TimeColor get_time_colors(double time_ms)
 {
-    if (is_seconds_range(time_ms)) {
-        return get_seconds_colors();
+    if (time_ms >= 1000.0) {
+        return { Colors::BOLD, Colors::WHITE };
     }
-    if (is_time_significant(time_ms)) {
-        return get_significant_milliseconds_colors();
+    if (time_ms >= 100.0) {
+        return { Colors::YELLOW, Colors::YELLOW };
     }
-    return get_minimal_time_colors();
+    return { Colors::DIM, Colors::DIM };
 }
 
 // Print separator line
@@ -448,73 +321,47 @@ void GlobalBenchStatsContainer::print_aggregate_counts_hierarchical(std::ostream
         }
     }
 
-    // Helper to create tree prefix
-    auto create_tree_prefix = [](size_t indent_level, bool is_last) -> std::string {
-        if (indent_level == 0) {
-            return "";
-        }
-        return is_last ? "└─ " : "├─ ";
-    };
-
-    // Helper to truncate display name
-    auto truncate_display_name = [](const std::string& name, size_t max_width) -> std::string {
-        if (name.length() <= max_width) {
-            return name;
-        }
-        return name.substr(0, max_width - 3) + "...";
-    };
-
-    // Helper to format minimal time output
-    auto format_minimal_time_output = [&](size_t indent_level, double time_ms, uint64_t parent_time) -> std::string {
-        std::ostringstream oss;
-        oss << format_indent_level_indicator(indent_level);
-        oss << format_percentage_section(time_ms, static_cast<double>(parent_time), indent_level);
-        oss << "   " << std::setw(10) << ""; // Add spacing to replace where time would be
-        return oss.str();
-    };
-
-    // Helper to format thread statistics
-    auto format_thread_stats = [](const AggregateEntry& entry) -> std::string {
-        if (entry.num_threads <= 1) {
-            return "";
-        }
-        double mean_ms = entry.time_mean / 1000000.0;
-        double stddev_percentage = floor(entry.get_std_dev() * 100 / entry.time_mean);
-        std::ostringstream oss;
-        oss << "  " << entry.num_threads << " threads " << mean_ms << "ms average " << stddev_percentage << "% stddev";
-        return oss.str();
-    };
-
     // Helper function to print a stat line with tree drawing
     auto print_entry = [&](const AggregateEntry& entry, size_t indent_level, bool is_last, uint64_t parent_time) {
         std::string indent(indent_level * 2, ' ');
-        std::string prefix = create_tree_prefix(indent_level, is_last);
+        std::string prefix = (indent_level == 0) ? "" : (is_last ? "└─ " : "├─ ");
 
         // Use exactly 80 characters for function name without indent
         const size_t name_width = 80;
-        std::string display_name = truncate_display_name(std::string(entry.key), name_width);
+        std::string display_name = std::string(entry.key);
+        if (display_name.length() > name_width) {
+            display_name = display_name.substr(0, name_width - 3) + "...";
+        }
 
-        double time_ms = nanoseconds_to_milliseconds(entry.time_max);
+        double time_ms = static_cast<double>(entry.time_max) / 1000000.0;
         auto colors = get_time_colors(time_ms);
 
         // Print indent + prefix + name (exactly 80 chars) + time/percentage/calls
         os << indent << prefix << colors.name_color;
-        if (is_seconds_range(time_ms) && colors.name_color == Colors::BOLD) {
+        if (time_ms >= 1000.0 && colors.name_color == Colors::BOLD) {
             os << Colors::YELLOW; // Special case: bold yellow for >= 1s
         }
         os << std::left << std::setw(static_cast<int>(name_width)) << display_name << Colors::RESET;
 
         // Print time if available with aligned section including indent level
         if (entry.time_max > 0) {
-            if (is_time_minimal(time_ms)) {
+            if (time_ms < 100.0) {
                 // Minimal format for <100ms: only [level] and percentage, no time display
-                std::string minimal_output = format_minimal_time_output(indent_level, time_ms, parent_time);
-                os << "  " << colors.time_color << std::setw(40) << std::left << minimal_output << Colors::RESET;
+                std::ostringstream minimal_oss;
+                minimal_oss << Colors::MAGENTA << "[" << indent_level << "] " << Colors::RESET;
+                minimal_oss << format_percentage_section(time_ms, static_cast<double>(parent_time), indent_level);
+                minimal_oss << "   " << std::setw(10) << ""; // Add spacing to replace where time would be
+                os << "  " << colors.time_color << std::setw(40) << std::left << minimal_oss.str() << Colors::RESET;
             } else {
                 std::string aligned_section =
                     format_aligned_section(time_ms, static_cast<double>(parent_time), entry.count, indent_level);
                 os << "  " << colors.time_color << std::setw(40) << std::left << aligned_section << Colors::RESET;
-                os << format_thread_stats(entry);
+                if (entry.num_threads > 1) {
+                    double mean_ms = entry.time_mean / 1000000.0;
+                    double stddev_percentage = floor(entry.get_std_dev() * 100 / entry.time_mean);
+                    os << "  " << entry.num_threads << " threads " << mean_ms << "ms average " << stddev_percentage
+                       << "% stddev";
+                }
             }
         }
 
@@ -549,82 +396,61 @@ void GlobalBenchStatsContainer::print_aggregate_counts_hierarchical(std::ostream
         // Print this entry
         print_entry(*entry_to_print, indent_level, is_last, parent_time);
 
-        // Helper to check if time is meaningful (>= 0.5ms)
-        auto is_time_meaningful = [](uint64_t time_ns) -> bool {
-            return time_ns >= 500000; // 0.5ms in nanoseconds
-        };
-
-        // Helper to find children of a given key
-        auto find_children = [&](OperationKey parent) -> std::vector<OperationKey> {
-            std::vector<OperationKey> result;
+        // Find and print children - operations that have this key as parent (only those with meaningful time >= 0.5ms)
+        std::vector<OperationKey> children;
+        if (!printed_in_detail.contains(key)) {
             for (const auto& [child_key, parent_map] : aggregated) {
                 for (const auto& [parent_key, entry] : parent_map) {
-                    if (parent_key == parent && is_time_meaningful(entry.time_max)) {
-                        result.push_back(child_key);
+                    if (parent_key == key && entry.time_max >= 500000) { // 0.5ms in nanoseconds
+                        children.push_back(child_key);
                         break;
                     }
                 }
             }
-            return result;
-        };
-
-        // Find and print children - operations that have this key as parent (only those with meaningful time >= 0.5ms)
-        std::vector<OperationKey> children;
-        if (!printed_in_detail.contains(key)) {
-            children = find_children(key);
             printed_in_detail.insert(key);
         }
 
-        // Helper to get child time in specific parent context
-        auto get_child_time_in_parent = [&](OperationKey child, OperationKey parent) -> uint64_t {
-            if (auto it = aggregated.find(child); it != aggregated.end()) {
+        // Sort children by their time in THIS parent context
+        std::ranges::sort(children, [&](OperationKey a, OperationKey b) {
+            uint64_t time_a = 0;
+            uint64_t time_b = 0;
+            if (auto it = aggregated.find(a); it != aggregated.end()) {
                 for (const auto& [parent_key, entry] : it->second) {
-                    if (parent_key == parent) {
-                        return entry.time_max;
+                    if (parent_key == key) {
+                        time_a = entry.time_max;
+                        break;
                     }
                 }
             }
-            return 0;
-        };
-
-        // Sort children by their time in THIS parent context
-        std::ranges::sort(children, [&](OperationKey a, OperationKey b) {
-            uint64_t time_a = get_child_time_in_parent(a, key);
-            uint64_t time_b = get_child_time_in_parent(b, key);
+            if (auto it = aggregated.find(b); it != aggregated.end()) {
+                for (const auto& [parent_key, entry] : it->second) {
+                    if (parent_key == key) {
+                        time_b = entry.time_max;
+                        break;
+                    }
+                }
+            }
             return time_a > time_b;
         });
 
-        // Helper to calculate total time for children
-        auto calculate_children_total_time = [&](const std::vector<OperationKey>& child_keys,
-                                                 OperationKey parent) -> uint64_t {
-            uint64_t total = 0;
-            for (const auto& child_key : child_keys) {
-                if (auto it = aggregated.find(child_key); it != aggregated.end()) {
-                    for (const auto& [parent_key, entry] : it->second) {
-                        if (parent_key == parent && entry.time_max >= 500000) { // 0.5ms in nanoseconds
-                            total += entry.time_max;
-                        }
+        // Calculate time spent in children and add "(other)" if >5% unaccounted
+        uint64_t children_total_time = 0;
+        for (const auto& child_key : children) {
+            if (auto it = aggregated.find(child_key); it != aggregated.end()) {
+                for (const auto& [parent_key, entry] : it->second) {
+                    if (parent_key == key && entry.time_max >= 500000) { // 0.5ms in nanoseconds
+                        children_total_time += entry.time_max;
                     }
                 }
             }
-            return total;
-        };
-
-        // Helper to check if unaccounted time is significant
-        auto is_unaccounted_time_significant = [](uint64_t parent_time, uint64_t children_time) -> bool {
-            if (parent_time == 0 || children_time >= parent_time) {
-                return false;
-            }
-            uint64_t unaccounted = parent_time - children_time;
-            double percentage = (static_cast<double>(unaccounted) / static_cast<double>(parent_time)) * 100.0;
-            return percentage > 5.0 && unaccounted > 0;
-        };
-
-        // Calculate time spent in children and add "(other)" if >5% unaccounted
-        uint64_t children_total_time = calculate_children_total_time(children, key);
+        }
         uint64_t parent_total_time = entry_to_print->time_max;
-        bool should_add_other =
-            !children.empty() && is_unaccounted_time_significant(parent_total_time, children_total_time);
+        bool should_add_other = false;
+        if (!children.empty() && parent_total_time > 0 && children_total_time < parent_total_time) {
+            uint64_t unaccounted = parent_total_time - children_total_time;
+            double percentage = (static_cast<double>(unaccounted) / static_cast<double>(parent_total_time)) * 100.0;
+            should_add_other = percentage > 5.0 && unaccounted > 0;
+        }
         uint64_t other_time = should_add_other ? (parent_total_time - children_total_time) : 0;
 
         if (!children.empty() && keys_to_parents[key].size() > 1) {
@@ -637,62 +463,43 @@ void GlobalBenchStatsContainer::print_aggregate_counts_hierarchical(std::ostream
             print_hierarchy(children[i], indent_level + 1, is_last_child, entry_to_print->time, key);
         }
 
-        // Helper to create "other" entry for unaccounted time
-        auto create_other_entry = [](uint64_t time) -> AggregateEntry {
-            AggregateEntry entry;
-            entry.key = "(other)";
-            entry.time = time;
-            entry.time_max = time;
-            entry.count = 1;
-            entry.num_threads = 1;
-            return entry;
-        };
-
         // Print "(other)" category if significant unaccounted time exists
         if (should_add_other && keys_to_parents[key].size() <= 1) {
-            AggregateEntry other_entry = create_other_entry(other_time);
+            AggregateEntry other_entry;
+            other_entry.key = "(other)";
+            other_entry.time = other_time;
+            other_entry.time_max = other_time;
+            other_entry.count = 1;
+            other_entry.num_threads = 1;
             print_entry(other_entry, indent_level + 1, true, parent_total_time); // always last
         }
     };
 
-    // Helper to check if entry is a root (has empty parent with significant time)
-    auto is_root_entry = [&](const auto& parent_map) -> bool {
-        auto empty_parent_it = parent_map.find("");
-        return empty_parent_it != parent_map.end() && empty_parent_it->second.time > 0;
-    };
-
-    // Helper to collect root entries
-    auto collect_root_entries = [&]() -> std::vector<OperationKey> {
-        std::vector<OperationKey> roots;
-        for (const auto& [key, parent_map] : aggregated) {
-            if (is_root_entry(parent_map)) {
-                roots.push_back(key);
-            }
-        }
-        return roots;
-    };
-
-    // Helper to get root entry time
-    auto get_root_entry_time = [&](OperationKey key) -> uint64_t {
-        if (auto it = aggregated.find(key); it != aggregated.end()) {
-            if (auto parent_it = it->second.find(""); parent_it != it->second.end()) {
-                return parent_it->second.time_max;
-            }
-        }
-        return 0;
-    };
-
-    // Helper to sort entries by time (descending)
-    auto sort_by_time_descending = [&](std::vector<OperationKey>& keys) {
-        std::ranges::sort(
-            keys, [&](OperationKey a, OperationKey b) { return get_root_entry_time(a) > get_root_entry_time(b); });
-    };
-
     // Find root entries (those that ONLY have empty parent key and significant time)
-    std::vector<OperationKey> roots = collect_root_entries();
+    std::vector<OperationKey> roots;
+    for (const auto& [key, parent_map] : aggregated) {
+        auto empty_parent_it = parent_map.find("");
+        if (empty_parent_it != parent_map.end() && empty_parent_it->second.time > 0) {
+            roots.push_back(key);
+        }
+    }
 
-    // Sort roots by time
-    sort_by_time_descending(roots);
+    // Sort roots by time (descending)
+    std::ranges::sort(roots, [&](OperationKey a, OperationKey b) {
+        uint64_t time_a = 0;
+        uint64_t time_b = 0;
+        if (auto it_a = aggregated.find(a); it_a != aggregated.end()) {
+            if (auto parent_it = it_a->second.find(""); parent_it != it_a->second.end()) {
+                time_a = parent_it->second.time_max;
+            }
+        }
+        if (auto it_b = aggregated.find(b); it_b != aggregated.end()) {
+            if (auto parent_it = it_b->second.find(""); parent_it != it_b->second.end()) {
+                time_b = parent_it->second.time_max;
+            }
+        }
+        return time_a > time_b;
+    });
 
     // Print hierarchies starting from roots
     for (size_t i = 0; i < roots.size(); ++i) {
@@ -702,89 +509,48 @@ void GlobalBenchStatsContainer::print_aggregate_counts_hierarchical(std::ostream
     // Print summary
     print_separator(os, false);
 
-    // Helper to count unique functions
-    auto count_unique_functions = [&]() -> size_t {
-        std::set<OperationKey> unique;
-        for (const auto& [key, _] : aggregated) {
-            unique.insert(key);
-        }
-        return unique.size();
-    };
-
-    // Helper to count shared functions (with multiple parents)
-    auto count_shared_functions = [&]() -> uint64_t {
-        uint64_t count = 0;
-        for (const auto& [key, parents] : keys_to_parents) {
-            if (parents.size() > 1) {
-                count++;
-            }
-        }
-        return count;
-    };
-
-    // Helper to calculate total time from root entries
-    auto calculate_total_time = [&]() -> uint64_t {
-        uint64_t max_time = 0;
-        for (const auto& [_, parent_map] : aggregated) {
-            if (auto it = parent_map.find(""); it != parent_map.end()) {
-                max_time = std::max(max_time, it->second.time_max);
-            }
-        }
-        return max_time;
-    };
-
-    // Helper to calculate total calls
-    auto calculate_total_calls = [&]() -> uint64_t {
-        uint64_t total = 0;
-        for (const auto& [_, parent_map] : aggregated) {
-            for (const auto& [__, entry] : parent_map) {
-                total += entry.count;
-            }
-        }
-        return total;
-    };
-
     // Calculate totals from root entries
-    size_t unique_functions_count = count_unique_functions();
-    uint64_t shared_count = count_shared_functions();
-    uint64_t total_time = calculate_total_time();
-    uint64_t total_calls = calculate_total_calls();
+    std::set<OperationKey> unique_funcs;
+    for (const auto& [key, _] : aggregated) {
+        unique_funcs.insert(key);
+    }
+    size_t unique_functions_count = unique_funcs.size();
 
-    // Helper to format function count
-    auto format_function_count = [](size_t count, uint64_t shared) -> std::string {
-        std::ostringstream oss;
-        oss << Colors::MAGENTA << count << " functions" << Colors::RESET;
-        if (shared > 0) {
-            oss << " (" << Colors::RED << shared << " shared" << Colors::RESET << ")";
+    uint64_t shared_count = 0;
+    for (const auto& [key, parents] : keys_to_parents) {
+        if (parents.size() > 1) {
+            shared_count++;
         }
-        return oss.str();
-    };
+    }
 
-    // Helper to format measurement count
-    auto format_measurement_count = [](uint64_t count) -> std::string {
-        std::ostringstream oss;
-        oss << Colors::GREEN << count << " measurements" << Colors::RESET;
-        return oss.str();
-    };
-
-    // Helper to format total time with color
-    auto format_total_time_colored = [](double time_ms) -> std::string {
-        std::ostringstream oss;
-        oss << Colors::YELLOW;
-        if (is_seconds_range(time_ms)) {
-            oss << std::fixed << std::setprecision(2) << milliseconds_to_seconds(time_ms) << " seconds";
-        } else {
-            oss << std::fixed << std::setprecision(2) << time_ms << " ms";
+    uint64_t total_time = 0;
+    for (const auto& [_, parent_map] : aggregated) {
+        if (auto it = parent_map.find(""); it != parent_map.end()) {
+            total_time = std::max(total_time, it->second.time_max);
         }
-        oss << Colors::RESET;
-        return oss.str();
-    };
+    }
 
-    double total_time_ms = nanoseconds_to_milliseconds(total_time);
+    uint64_t total_calls = 0;
+    for (const auto& [_, parent_map] : aggregated) {
+        for (const auto& [__, entry] : parent_map) {
+            total_calls += entry.count;
+        }
+    }
 
-    os << "  " << Colors::BOLD << "Total: " << Colors::RESET
-       << format_function_count(unique_functions_count, shared_count) << ", " << format_measurement_count(total_calls)
-       << ", " << format_total_time_colored(total_time_ms);
+    double total_time_ms = static_cast<double>(total_time) / 1000000.0;
+
+    os << "  " << Colors::BOLD << "Total: " << Colors::RESET << Colors::MAGENTA << unique_functions_count
+       << " functions" << Colors::RESET;
+    if (shared_count > 0) {
+        os << " (" << Colors::RED << shared_count << " shared" << Colors::RESET << ")";
+    }
+    os << ", " << Colors::GREEN << total_calls << " measurements" << Colors::RESET << ", " << Colors::YELLOW;
+    if (total_time_ms >= 1000.0) {
+        os << std::fixed << std::setprecision(2) << (total_time_ms / 1000.0) << " seconds";
+    } else {
+        os << std::fixed << std::setprecision(2) << total_time_ms << " ms";
+    }
+    os << Colors::RESET;
 
     os << "\n";
     print_separator(os, true);

--- a/barretenberg/cpp/src/barretenberg/common/bb_bench.cpp
+++ b/barretenberg/cpp/src/barretenberg/common/bb_bench.cpp
@@ -31,17 +31,63 @@ struct Colors {
     static constexpr const char* RED = "\033[31m";
 };
 
+// Helper to determine if time is in seconds range
+bool is_seconds_range(double time_ms)
+{
+    return time_ms >= 1000.0;
+}
+
+// Helper to determine if time is in milliseconds range
+bool is_milliseconds_range(double time_ms)
+{
+    return time_ms >= 1.0 && time_ms < 1000.0;
+}
+
+// Helper to convert milliseconds to seconds
+double milliseconds_to_seconds(double time_ms)
+{
+    return time_ms / 1000.0;
+}
+
+// Helper to convert milliseconds to microseconds
+double milliseconds_to_microseconds(double time_ms)
+{
+    return time_ms * 1000.0;
+}
+
+// Helper to convert nanoseconds to milliseconds
+double nanoseconds_to_milliseconds(uint64_t nanoseconds)
+{
+    return static_cast<double>(nanoseconds) / 1000000.0;
+}
+
 // Format time value with appropriate unit
 std::string format_time(double time_ms)
 {
     std::ostringstream oss;
-    if (time_ms >= 1000.0) {
-        oss << std::fixed << std::setprecision(2) << (time_ms / 1000.0) << " s";
-    } else if (time_ms >= 1.0) {
+    if (is_seconds_range(time_ms)) {
+        oss << std::fixed << std::setprecision(2) << milliseconds_to_seconds(time_ms) << " s";
+    } else if (is_milliseconds_range(time_ms)) {
         oss << std::fixed << std::setprecision(2) << time_ms << " ms";
     } else {
-        oss << std::fixed << std::setprecision(1) << (time_ms * 1000.0) << " μs";
+        oss << std::fixed << std::setprecision(1) << milliseconds_to_microseconds(time_ms) << " μs";
     }
+    return oss.str();
+}
+
+// Helper to create formatted time string for seconds
+std::string create_seconds_string(double time_ms)
+{
+    std::ostringstream oss;
+    oss << std::fixed << std::setprecision(2) << milliseconds_to_seconds(time_ms) << "s";
+    return oss.str();
+}
+
+// Helper to create formatted time string for milliseconds
+std::string create_milliseconds_string(double time_ms)
+{
+    std::ostringstream oss;
+    oss << std::fixed << std::setprecision(1) << time_ms << "ms";
     return oss.str();
 }
 
@@ -49,73 +95,141 @@ std::string format_time(double time_ms)
 std::string format_time_aligned(double time_ms)
 {
     std::ostringstream oss;
-    if (time_ms >= 1000.0) {
-        std::string time_str =
-            (std::ostringstream{} << std::fixed << std::setprecision(2) << (time_ms / 1000.0) << "s").str();
+    if (is_seconds_range(time_ms)) {
+        std::string time_str = create_seconds_string(time_ms);
         oss << std::left << std::setw(10) << time_str;
     } else {
-        std::string time_str = (std::ostringstream{} << std::fixed << std::setprecision(1) << time_ms << "ms").str();
+        std::string time_str = create_milliseconds_string(time_ms);
         oss << std::left << std::setw(10) << time_str;
     }
     return oss.str();
 }
 
-// Helper to format percentage with color based on percentage value
-std::string format_percentage(double value, double total, double min_threshold = 0.0)
+// Helper to calculate percentage
+double calculate_percentage(double value, double total)
 {
     if (total <= 0) {
-        return "       ";
+        return 0.0;
     }
-    double percentage = (value / total) * 100.0;
-    if (percentage < min_threshold) {
-        return "       ";
-    }
+    return (value / total) * 100.0;
+}
 
-    // Choose color based on percentage value (like time colors)
-    const char* color = Colors::CYAN; // Default color
+// Helper to check if percentage is below threshold
+bool is_percentage_below_threshold(double percentage, double threshold)
+{
+    return percentage < threshold;
+}
 
+// Helper to create empty percentage string
+std::string create_empty_percentage_string()
+{
+    return "       ";
+}
+
+// Helper to format percentage value
+std::string format_percentage_value(double percentage, const char* color)
+{
     std::ostringstream oss;
     oss << color << " " << std::left << std::fixed << std::setprecision(1) << std::setw(5) << percentage << "%"
         << Colors::RESET;
     return oss.str();
 }
 
-std::string format_aligned_section(double time_ms,
-                                   double parent_time,
-                                   uint64_t count,
-                                   size_t indent_level,
-                                   size_t num_threads = 1,
-                                   double mean_ms = 0.0)
+// Helper to format percentage with color based on percentage value
+std::string format_percentage(double value, double total, double min_threshold = 0.0)
+{
+    double percentage = calculate_percentage(value, total);
+    if (total <= 0 || is_percentage_below_threshold(percentage, min_threshold)) {
+        return create_empty_percentage_string();
+    }
+
+    // Choose color based on percentage value (like time colors)
+    const char* color = Colors::CYAN; // Default color
+
+    return format_percentage_value(percentage, color);
+}
+
+// Helper to format indent level indicator
+std::string format_indent_level_indicator(size_t indent_level)
+{
+    std::ostringstream oss;
+    oss << Colors::MAGENTA << "[" << indent_level << "] " << Colors::RESET;
+    return oss.str();
+}
+
+// Helper to check if should show percentage
+bool should_show_percentage(double parent_time, size_t indent_level)
+{
+    return parent_time > 0 && indent_level > 0;
+}
+
+// Helper to format percentage section
+std::string format_percentage_section(double time_ms, double parent_time, size_t indent_level)
+{
+    if (should_show_percentage(parent_time, indent_level)) {
+        return format_percentage(time_ms * 1000000.0, parent_time);
+    }
+    return create_empty_percentage_string();
+}
+
+// Helper to check if time needs dimming
+bool should_dim_time(double time_ms)
+{
+    return time_ms >= 100.0 && time_ms < 1000.0;
+}
+
+// Helper to format time section
+std::string format_time_section(double time_ms)
+{
+    std::ostringstream oss;
+    oss << "   ";
+    if (should_dim_time(time_ms)) {
+        oss << Colors::DIM << format_time_aligned(time_ms) << Colors::RESET;
+    } else {
+        oss << format_time_aligned(time_ms);
+    }
+    return oss.str();
+}
+
+// Helper to check if should show call stats
+bool should_show_call_stats(double time_ms, uint64_t count)
+{
+    return time_ms >= 100.0 && count > 1;
+}
+
+// Helper to calculate average time
+double calculate_average_time(double time_ms, uint64_t count)
+{
+    return time_ms / static_cast<double>(count);
+}
+
+// Helper to format call stats
+std::string format_call_stats(double time_ms, uint64_t count)
+{
+    if (!should_show_call_stats(time_ms, count)) {
+        return "";
+    }
+    double avg_ms = calculate_average_time(time_ms, count);
+    std::ostringstream oss;
+    oss << Colors::DIM << " (" << format_time(avg_ms) << " x " << count << ")" << Colors::RESET;
+    return oss.str();
+}
+
+std::string format_aligned_section(double time_ms, double parent_time, uint64_t count, size_t indent_level)
 {
     std::ostringstream oss;
 
     // Add indent level indicator at the beginning with different color
-    oss << Colors::MAGENTA << "[" << indent_level << "] " << Colors::RESET;
+    oss << format_indent_level_indicator(indent_level);
 
     // Format percentage FIRST
-    if (parent_time > 0 && indent_level > 0) {
-        oss << format_percentage(time_ms * 1000000.0, parent_time);
-    } else {
-        oss << "       "; // Keep alignment for root entries
-    }
+    oss << format_percentage_section(time_ms, parent_time, indent_level);
 
     // Format time AFTER percentage with appropriate color (with more spacing)
-    if (time_ms >= 100.0 && time_ms < 1000.0) {
-        oss << "   " << Colors::DIM << format_time_aligned(time_ms) << Colors::RESET;
-    } else {
-        oss << "   " << format_time_aligned(time_ms);
-    }
+    oss << format_time_section(time_ms);
 
     // Format calls/threads info - only show for >= 100ms, make it DIM
-    if (time_ms >= 100.0) {
-        if (num_threads > 1) {
-            oss << Colors::DIM << " (" << std::fixed << std::setprecision(2) << mean_ms << " ms x " << num_threads
-                << ")" << Colors::RESET;
-        } else if (count > 1) {
-            double avg_ms = time_ms / static_cast<double>(count);
-            oss << Colors::DIM << " (" << format_time(avg_ms) << " x " << count << ")" << Colors::RESET;
-        }
-    }
+    oss << format_call_stats(time_ms, count);
 
     return oss.str();
 }
@@ -126,15 +240,45 @@ struct TimeColor {
     const char* time_color;
 };
 
+// Helper to check if time is significant (>= 100ms)
+bool is_time_significant(double time_ms)
+{
+    return time_ms >= 100.0;
+}
+
+// Helper to check if time is minimal (< 100ms)
+bool is_time_minimal(double time_ms)
+{
+    return time_ms < 100.0;
+}
+
+// Helper to get colors for significant seconds
+TimeColor get_seconds_colors()
+{
+    return { Colors::BOLD, Colors::WHITE };
+}
+
+// Helper to get colors for significant milliseconds
+TimeColor get_significant_milliseconds_colors()
+{
+    return { Colors::YELLOW, Colors::YELLOW };
+}
+
+// Helper to get colors for minimal time
+TimeColor get_minimal_time_colors()
+{
+    return { Colors::DIM, Colors::DIM };
+}
+
 TimeColor get_time_colors(double time_ms)
 {
-    if (time_ms >= 1000.0) {
-        return { Colors::BOLD, Colors::WHITE }; // Bold white for >= 1 second
+    if (is_seconds_range(time_ms)) {
+        return get_seconds_colors();
     }
-    if (time_ms >= 100.0) {
-        return { Colors::YELLOW, Colors::YELLOW }; // Yellow for >= 100ms
+    if (is_time_significant(time_ms)) {
+        return get_significant_milliseconds_colors();
     }
-    return { Colors::DIM, Colors::DIM }; // Dim for < 100ms
+    return get_minimal_time_colors();
 }
 
 // Print separator line
@@ -164,12 +308,12 @@ void AggregateEntry::add_thread_time_sample(const TimeAndCount& stats)
     // Account for aggregate time and count
     time += stats.time;
     count += stats.count;
+    time_max = std::max(stats.time, time_max);
     // Use Welford's method to be able to track the variance
-    double time_ms = static_cast<double>(stats.time / stats.count) / 1000000.0;
     num_threads++;
-    double delta = time_ms - time_mean;
+    double delta = static_cast<double>(stats.time) - time_mean;
     time_mean += delta / static_cast<double>(num_threads);
-    double delta2 = time_ms - time_mean;
+    double delta2 = static_cast<double>(stats.time) - time_mean;
     time_m2 += delta * delta2;
 }
 
@@ -261,7 +405,7 @@ void GlobalBenchStatsContainer::print_aggregate_counts(std::ostream& os, size_t 
         // Loop for a flattened view
         uint64_t time = 0;
         for (auto& [parent_key, entry] : entry_map) {
-            time += entry.time;
+            time += entry.time_max;
         }
 
         if (!first) {
@@ -304,55 +448,73 @@ void GlobalBenchStatsContainer::print_aggregate_counts_hierarchical(std::ostream
         }
     }
 
+    // Helper to create tree prefix
+    auto create_tree_prefix = [](size_t indent_level, bool is_last) -> std::string {
+        if (indent_level == 0) {
+            return "";
+        }
+        return is_last ? "└─ " : "├─ ";
+    };
+
+    // Helper to truncate display name
+    auto truncate_display_name = [](const std::string& name, size_t max_width) -> std::string {
+        if (name.length() <= max_width) {
+            return name;
+        }
+        return name.substr(0, max_width - 3) + "...";
+    };
+
+    // Helper to format minimal time output
+    auto format_minimal_time_output = [&](size_t indent_level, double time_ms, uint64_t parent_time) -> std::string {
+        std::ostringstream oss;
+        oss << format_indent_level_indicator(indent_level);
+        oss << format_percentage_section(time_ms, static_cast<double>(parent_time), indent_level);
+        oss << "   " << std::setw(10) << ""; // Add spacing to replace where time would be
+        return oss.str();
+    };
+
+    // Helper to format thread statistics
+    auto format_thread_stats = [](const AggregateEntry& entry) -> std::string {
+        if (entry.num_threads <= 1) {
+            return "";
+        }
+        double mean_ms = entry.time_mean / 1000000.0;
+        double stddev_percentage = floor(entry.get_std_dev() * 100 / entry.time_mean);
+        std::ostringstream oss;
+        oss << "  " << entry.num_threads << " threads " << mean_ms << "ms average " << stddev_percentage << "% stddev";
+        return oss.str();
+    };
+
     // Helper function to print a stat line with tree drawing
     auto print_entry = [&](const AggregateEntry& entry, size_t indent_level, bool is_last, uint64_t parent_time) {
         std::string indent(indent_level * 2, ' ');
-        std::string prefix;
-        if (indent_level > 0) {
-            prefix = is_last ? "└─ " : "├─ ";
-        }
+        std::string prefix = create_tree_prefix(indent_level, is_last);
 
         // Use exactly 80 characters for function name without indent
         const size_t name_width = 80;
-        std::string display_name = std::string(entry.key);
-        if (display_name.length() > name_width) {
-            display_name = display_name.substr(0, name_width - 3) + "...";
-        }
+        std::string display_name = truncate_display_name(std::string(entry.key), name_width);
 
-        double time_ms = static_cast<double>(entry.time) / 1000000.0;
+        double time_ms = nanoseconds_to_milliseconds(entry.time_max);
         auto colors = get_time_colors(time_ms);
 
         // Print indent + prefix + name (exactly 80 chars) + time/percentage/calls
         os << indent << prefix << colors.name_color;
-        if (time_ms >= 1000.0 && colors.name_color == Colors::BOLD) {
+        if (is_seconds_range(time_ms) && colors.name_color == Colors::BOLD) {
             os << Colors::YELLOW; // Special case: bold yellow for >= 1s
         }
         os << std::left << std::setw(static_cast<int>(name_width)) << display_name << Colors::RESET;
 
         // Print time if available with aligned section including indent level
-        if (entry.time > 0) {
-            if (time_ms < 100.0) {
+        if (entry.time_max > 0) {
+            if (is_time_minimal(time_ms)) {
                 // Minimal format for <100ms: only [level] and percentage, no time display
-                std::ostringstream minimal_oss;
-                minimal_oss << Colors::MAGENTA << "[" << indent_level << "] " << Colors::RESET;
-
-                // Format percentage FIRST
-                if (parent_time > 0 && indent_level > 0) {
-                    minimal_oss << format_percentage(time_ms * 1000000.0, static_cast<double>(parent_time));
-                } else {
-                    minimal_oss << "       "; // Keep alignment for root entries
-                }
-
-                // Add spacing to replace where time would be (with extra spacing to match)
-                minimal_oss << "   " << std::setw(10) << "";
-
-                os << "  " << colors.time_color << std::setw(40) << std::left << minimal_oss.str() << Colors::RESET;
+                std::string minimal_output = format_minimal_time_output(indent_level, time_ms, parent_time);
+                os << "  " << colors.time_color << std::setw(40) << std::left << minimal_output << Colors::RESET;
             } else {
-                // Full format for >=100ms
-                double mean_ms = entry.num_threads > 1 ? entry.time_mean / 1000000.0 : 0.0;
-                std::string aligned_section = format_aligned_section(
-                    time_ms, static_cast<double>(parent_time), entry.count, indent_level, entry.num_threads, mean_ms);
+                std::string aligned_section =
+                    format_aligned_section(time_ms, static_cast<double>(parent_time), entry.count, indent_level);
                 os << "  " << colors.time_color << std::setw(40) << std::left << aligned_section << Colors::RESET;
+                os << format_thread_stats(entry);
             }
         }
 
@@ -387,71 +549,83 @@ void GlobalBenchStatsContainer::print_aggregate_counts_hierarchical(std::ostream
         // Print this entry
         print_entry(*entry_to_print, indent_level, is_last, parent_time);
 
+        // Helper to check if time is meaningful (>= 0.5ms)
+        auto is_time_meaningful = [](uint64_t time_ns) -> bool {
+            return time_ns >= 500000; // 0.5ms in nanoseconds
+        };
+
+        // Helper to find children of a given key
+        auto find_children = [&](OperationKey parent) -> std::vector<OperationKey> {
+            std::vector<OperationKey> result;
+            for (const auto& [child_key, parent_map] : aggregated) {
+                for (const auto& [parent_key, entry] : parent_map) {
+                    if (parent_key == parent && is_time_meaningful(entry.time_max)) {
+                        result.push_back(child_key);
+                        break;
+                    }
+                }
+            }
+            return result;
+        };
+
         // Find and print children - operations that have this key as parent (only those with meaningful time >= 0.5ms)
         std::vector<OperationKey> children;
         if (!printed_in_detail.contains(key)) {
-            for (const auto& [child_key, parent_map] : aggregated) {
-                for (const auto& [parent_key, entry] : parent_map) {
-                    if (parent_key == key && entry.time >= 500000) { // 0.5ms in nanoseconds
-                        children.push_back(child_key);
-                        break;
-                    }
-                }
-            }
+            children = find_children(key);
             printed_in_detail.insert(key);
         }
 
+        // Helper to get child time in specific parent context
+        auto get_child_time_in_parent = [&](OperationKey child, OperationKey parent) -> uint64_t {
+            if (auto it = aggregated.find(child); it != aggregated.end()) {
+                for (const auto& [parent_key, entry] : it->second) {
+                    if (parent_key == parent) {
+                        return entry.time_max;
+                    }
+                }
+            }
+            return 0;
+        };
+
         // Sort children by their time in THIS parent context
         std::ranges::sort(children, [&](OperationKey a, OperationKey b) {
-            uint64_t time_a = 0;
-            uint64_t time_b = 0;
-
-            // Get time for child 'a' when called from THIS parent
-            if (auto it = aggregated.find(a); it != aggregated.end()) {
-                for (const auto& [parent_key, entry] : it->second) {
-                    if (parent_key == key) {
-                        time_a = entry.time;
-                        break;
-                    }
-                }
-            }
-
-            // Get time for child 'b' when called from THIS parent
-            if (auto it = aggregated.find(b); it != aggregated.end()) {
-                for (const auto& [parent_key, entry] : it->second) {
-                    if (parent_key == key) {
-                        time_b = entry.time;
-                        break;
-                    }
-                }
-            }
-
+            uint64_t time_a = get_child_time_in_parent(a, key);
+            uint64_t time_b = get_child_time_in_parent(b, key);
             return time_a > time_b;
         });
 
-        // Calculate time spent in children and add "(other)" if >5% unaccounted
-        uint64_t children_total_time = 0;
-        for (const auto& child_key : children) {
-            if (auto it = aggregated.find(child_key); it != aggregated.end()) {
-                // Sum time for this child across all parent contexts where parent matches current key
-                for (const auto& [parent_key, entry] : it->second) {
-                    if (parent_key == key && entry.time >= 500000) { // 0.5ms in nanoseconds
-                        children_total_time += entry.time;
+        // Helper to calculate total time for children
+        auto calculate_children_total_time = [&](const std::vector<OperationKey>& child_keys,
+                                                 OperationKey parent) -> uint64_t {
+            uint64_t total = 0;
+            for (const auto& child_key : child_keys) {
+                if (auto it = aggregated.find(child_key); it != aggregated.end()) {
+                    for (const auto& [parent_key, entry] : it->second) {
+                        if (parent_key == parent && entry.time_max >= 500000) { // 0.5ms in nanoseconds
+                            total += entry.time_max;
+                        }
                     }
                 }
             }
-        }
+            return total;
+        };
 
-        // Check if there's significant unaccounted time (>5%) and we have children
-        uint64_t parent_total_time = entry_to_print->time;
-        bool should_add_other = false;
-        uint64_t other_time = 0;
-        if (!children.empty() && parent_total_time > 0 && children_total_time < parent_total_time) {
-            other_time = parent_total_time - children_total_time;
-            double other_percentage =
-                (static_cast<double>(other_time) / static_cast<double>(parent_total_time)) * 100.0;
-            should_add_other = other_percentage > 5.0 && other_time > 0;
-        }
+        // Helper to check if unaccounted time is significant
+        auto is_unaccounted_time_significant = [](uint64_t parent_time, uint64_t children_time) -> bool {
+            if (parent_time == 0 || children_time >= parent_time) {
+                return false;
+            }
+            uint64_t unaccounted = parent_time - children_time;
+            double percentage = (static_cast<double>(unaccounted) / static_cast<double>(parent_time)) * 100.0;
+            return percentage > 5.0 && unaccounted > 0;
+        };
+
+        // Calculate time spent in children and add "(other)" if >5% unaccounted
+        uint64_t children_total_time = calculate_children_total_time(children, key);
+        uint64_t parent_total_time = entry_to_print->time_max;
+        bool should_add_other =
+            !children.empty() && is_unaccounted_time_significant(parent_total_time, children_total_time);
+        uint64_t other_time = should_add_other ? (parent_total_time - children_total_time) : 0;
 
         if (!children.empty() && keys_to_parents[key].size() > 1) {
             os << std::string(indent_level * 2, ' ') << "  ├─ NOTE: Shared children. Can add up to > 100%.\n";
@@ -463,46 +637,62 @@ void GlobalBenchStatsContainer::print_aggregate_counts_hierarchical(std::ostream
             print_hierarchy(children[i], indent_level + 1, is_last_child, entry_to_print->time, key);
         }
 
+        // Helper to create "other" entry for unaccounted time
+        auto create_other_entry = [](uint64_t time) -> AggregateEntry {
+            AggregateEntry entry;
+            entry.key = "(other)";
+            entry.time = time;
+            entry.time_max = time;
+            entry.count = 1;
+            entry.num_threads = 1;
+            return entry;
+        };
+
         // Print "(other)" category if significant unaccounted time exists
         if (should_add_other && keys_to_parents[key].size() <= 1) {
-            // Create fake AggregateEntry for (other)
-            AggregateEntry other_entry;
-            other_entry.key = "(other)";
-            other_entry.time = other_time;
-            other_entry.count = 1;
-            other_entry.num_threads = 1;
-
+            AggregateEntry other_entry = create_other_entry(other_time);
             print_entry(other_entry, indent_level + 1, true, parent_total_time); // always last
         }
     };
 
-    // Find root entries (those that ONLY have empty parent key and significant time)
-    std::vector<OperationKey> roots;
-    for (const auto& [key, parent_map] : aggregated) {
-        // Check if this operation has an empty parent key entry with significant time
-        if (auto empty_parent_it = parent_map.find(""); empty_parent_it != parent_map.end()) {
-            if (empty_parent_it->second.time > 0) {
+    // Helper to check if entry is a root (has empty parent with significant time)
+    auto is_root_entry = [&](const auto& parent_map) -> bool {
+        auto empty_parent_it = parent_map.find("");
+        return empty_parent_it != parent_map.end() && empty_parent_it->second.time > 0;
+    };
+
+    // Helper to collect root entries
+    auto collect_root_entries = [&]() -> std::vector<OperationKey> {
+        std::vector<OperationKey> roots;
+        for (const auto& [key, parent_map] : aggregated) {
+            if (is_root_entry(parent_map)) {
                 roots.push_back(key);
             }
         }
-    }
+        return roots;
+    };
+
+    // Helper to get root entry time
+    auto get_root_entry_time = [&](OperationKey key) -> uint64_t {
+        if (auto it = aggregated.find(key); it != aggregated.end()) {
+            if (auto parent_it = it->second.find(""); parent_it != it->second.end()) {
+                return parent_it->second.time_max;
+            }
+        }
+        return 0;
+    };
+
+    // Helper to sort entries by time (descending)
+    auto sort_by_time_descending = [&](std::vector<OperationKey>& keys) {
+        std::ranges::sort(
+            keys, [&](OperationKey a, OperationKey b) { return get_root_entry_time(a) > get_root_entry_time(b); });
+    };
+
+    // Find root entries (those that ONLY have empty parent key and significant time)
+    std::vector<OperationKey> roots = collect_root_entries();
 
     // Sort roots by time
-    std::ranges::sort(roots, [&](OperationKey a, OperationKey b) {
-        uint64_t time_a = 0;
-        uint64_t time_b = 0;
-        if (auto it = aggregated.find(a); it != aggregated.end()) {
-            if (auto parent_it = it->second.find(""); parent_it != it->second.end()) {
-                time_a = parent_it->second.time;
-            }
-        }
-        if (auto it = aggregated.find(b); it != aggregated.end()) {
-            if (auto parent_it = it->second.find(""); parent_it != it->second.end()) {
-                time_b = parent_it->second.time;
-            }
-        }
-        return time_a > time_b;
-    });
+    sort_by_time_descending(roots);
 
     // Print hierarchies starting from roots
     for (size_t i = 0; i < roots.size(); ++i) {
@@ -512,42 +702,89 @@ void GlobalBenchStatsContainer::print_aggregate_counts_hierarchical(std::ostream
     // Print summary
     print_separator(os, false);
 
+    // Helper to count unique functions
+    auto count_unique_functions = [&]() -> size_t {
+        std::set<OperationKey> unique;
+        for (const auto& [key, _] : aggregated) {
+            unique.insert(key);
+        }
+        return unique.size();
+    };
+
+    // Helper to count shared functions (with multiple parents)
+    auto count_shared_functions = [&]() -> uint64_t {
+        uint64_t count = 0;
+        for (const auto& [key, parents] : keys_to_parents) {
+            if (parents.size() > 1) {
+                count++;
+            }
+        }
+        return count;
+    };
+
+    // Helper to calculate total time from root entries
+    auto calculate_total_time = [&]() -> uint64_t {
+        uint64_t max_time = 0;
+        for (const auto& [_, parent_map] : aggregated) {
+            if (auto it = parent_map.find(""); it != parent_map.end()) {
+                max_time = std::max(max_time, it->second.time_max);
+            }
+        }
+        return max_time;
+    };
+
+    // Helper to calculate total calls
+    auto calculate_total_calls = [&]() -> uint64_t {
+        uint64_t total = 0;
+        for (const auto& [_, parent_map] : aggregated) {
+            for (const auto& [__, entry] : parent_map) {
+                total += entry.count;
+            }
+        }
+        return total;
+    };
+
     // Calculate totals from root entries
-    uint64_t total_time = 0;
-    uint64_t total_calls = 0;
-    std::set<OperationKey> unique_functions;
-    uint64_t shared_count = 0;
+    size_t unique_functions_count = count_unique_functions();
+    uint64_t shared_count = count_shared_functions();
+    uint64_t total_time = calculate_total_time();
+    uint64_t total_calls = calculate_total_calls();
 
-    for (auto& [key, parent_map] : aggregated) {
-        unique_functions.insert(key);
-
-        // Count as shared if has multiple parents
-        if (keys_to_parents[key].size() > 1) {
-            shared_count++;
+    // Helper to format function count
+    auto format_function_count = [](size_t count, uint64_t shared) -> std::string {
+        std::ostringstream oss;
+        oss << Colors::MAGENTA << count << " functions" << Colors::RESET;
+        if (shared > 0) {
+            oss << " (" << Colors::RED << shared << " shared" << Colors::RESET << ")";
         }
-        auto& root_entry = parent_map[""];
-        total_time += root_entry.time;
-        // Sum ALL calls
-        for (auto& entry : parent_map) {
-            total_calls += entry.second.count;
+        return oss.str();
+    };
+
+    // Helper to format measurement count
+    auto format_measurement_count = [](uint64_t count) -> std::string {
+        std::ostringstream oss;
+        oss << Colors::GREEN << count << " measurements" << Colors::RESET;
+        return oss.str();
+    };
+
+    // Helper to format total time with color
+    auto format_total_time_colored = [](double time_ms) -> std::string {
+        std::ostringstream oss;
+        oss << Colors::YELLOW;
+        if (is_seconds_range(time_ms)) {
+            oss << std::fixed << std::setprecision(2) << milliseconds_to_seconds(time_ms) << " seconds";
+        } else {
+            oss << std::fixed << std::setprecision(2) << time_ms << " ms";
         }
-    }
+        oss << Colors::RESET;
+        return oss.str();
+    };
 
-    double total_time_ms = static_cast<double>(total_time) / 1000000.0;
+    double total_time_ms = nanoseconds_to_milliseconds(total_time);
 
-    os << "  " << Colors::BOLD << "Total: " << Colors::RESET << Colors::MAGENTA << unique_functions.size()
-       << " functions" << Colors::RESET;
-    if (shared_count > 0) {
-        os << " (" << Colors::RED << shared_count << " shared" << Colors::RESET << ")";
-    }
-    os << ", " << Colors::GREEN << total_calls << " measurements" << Colors::RESET << ", ";
-
-    if (total_time_ms >= 1000.0) {
-        os << Colors::YELLOW << std::fixed << std::setprecision(2) << (total_time_ms / 1000.0) << " seconds"
-           << Colors::RESET;
-    } else {
-        os << Colors::YELLOW << std::fixed << std::setprecision(2) << total_time_ms << " ms" << Colors::RESET;
-    }
+    os << "  " << Colors::BOLD << "Total: " << Colors::RESET
+       << format_function_count(unique_functions_count, shared_count) << ", " << format_measurement_count(total_calls)
+       << ", " << format_total_time_colored(total_time_ms);
 
     os << "\n";
     print_separator(os, true);

--- a/barretenberg/cpp/src/barretenberg/common/bb_bench.hpp
+++ b/barretenberg/cpp/src/barretenberg/common/bb_bench.hpp
@@ -52,6 +52,7 @@ struct AggregateEntry {
     std::size_t count = 0;
     size_t num_threads = 0;
     double time_mean = 0;
+    std::size_t time_max = 0;
     double time_stddev = 0;
 
     // Welford's algorithm state

--- a/barretenberg/cpp/src/barretenberg/common/parallel_for_mutex_pool.cpp
+++ b/barretenberg/cpp/src/barretenberg/common/parallel_for_mutex_pool.cpp
@@ -41,6 +41,7 @@ class ThreadPool {
         do_iterations();
 
         {
+            BB_BENCH_NAME("spinning main thread");
             std::unique_lock<std::mutex> lock(tasks_mutex);
             complete_condition_.wait(lock, [this] { return complete_ == num_iterations_; });
         }
@@ -71,6 +72,7 @@ class ThreadPool {
                 }
                 iteration = iteration_++;
             }
+            BB_BENCH_NAME("do_iterations()");
             task_(iteration);
             {
                 std::unique_lock<std::mutex> lock(tasks_mutex);

--- a/barretenberg/cpp/src/barretenberg/ecc/groups/element_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/groups/element_impl.hpp
@@ -834,20 +834,6 @@ std::vector<affine_element<Fq, Fr, T>> element<Fq, Fr, T>::batch_mul_with_endomo
         };
 
     /**
-     * @brief Perform batch affine addition in parallel
-     *
-     */
-    const auto batch_affine_add_internal =
-        [num_points, &scratch_space, &batch_affine_add_chunked](const affine_element* lhs, affine_element* rhs) {
-            parallel_for_heuristic(
-                num_points,
-                [&](size_t start, size_t end, BB_UNUSED size_t chunk_index) {
-                    batch_affine_add_chunked(lhs + start, rhs + start, end - start, &scratch_space[0] + start);
-                },
-                thread_heuristics::FF_ADDITION_COST * 6 + thread_heuristics::FF_MULTIPLICATION_COST * 6);
-        };
-
-    /**
      * @brief Perform point doubling lhs[i]=lhs[i]+lhs[i] with batch inversion
      *
      */
@@ -878,18 +864,6 @@ std::vector<affine_element<Fq, Fr, T>> element<Fq, Fr, T>::batch_mul_with_endomo
                 lhs[i].y = personal_scratch_space[i] * (temp - lhs[i].x) - lhs[i].y;
             }
         };
-    /**
-     * @brief Perform point doubling in parallel
-     *
-     */
-    const auto batch_affine_double = [num_points, &scratch_space, &batch_affine_double_chunked](affine_element* lhs) {
-        parallel_for_heuristic(
-            num_points,
-            [&](size_t start, size_t end, BB_UNUSED size_t chunk_index) {
-                batch_affine_double_chunked(lhs + start, end - start, &scratch_space[0] + start);
-            },
-            thread_heuristics::FF_ADDITION_COST * 7 + thread_heuristics::FF_MULTIPLICATION_COST * 6);
-    };
 
     // We compute the resulting point through WNAF by evaluating (the (\sum_i (16ⁱ⋅
     // (a_i ∈ {-15,-13,-11,-9,-7,-5,-3,-1,1,3,5,7,9,11,13,15}))) - skew), where skew is 0 or 1. The result of the sum is
@@ -916,50 +890,58 @@ std::vector<affine_element<Fq, Fr, T>> element<Fq, Fr, T>::batch_mul_with_endomo
 
     constexpr size_t LOOKUP_SIZE = 8;
     constexpr size_t NUM_ROUNDS = 32;
-    std::array<std::vector<affine_element>, LOOKUP_SIZE> lookup_table;
-    for (auto& table : lookup_table) {
-        table.resize(num_points);
-    }
-    // Initialize first etnries in lookup table
-    std::vector<affine_element> temp_point_vector(num_points);
-    parallel_for_heuristic(
-        num_points,
-        [&](size_t i) {
-            // If the point is at infinity we fix-up the result later
-            // To avoid 'trying to invert zero in the field' we set the point to 'one' here
-            temp_point_vector[i] = points[i].is_point_at_infinity() ? affine_element::one() : points[i];
-            lookup_table[0][i] = points[i].is_point_at_infinity() ? affine_element::one() : points[i];
-        },
-        thread_heuristics::FF_COPY_COST * 2);
-
-    // Construct lookup table
-    batch_affine_double(&temp_point_vector[0]);
-    for (size_t j = 1; j < LOOKUP_SIZE; ++j) {
-        parallel_for_heuristic(
-            num_points,
-            [&](size_t i) { lookup_table[j][i] = lookup_table[j - 1][i]; },
-            thread_heuristics::FF_COPY_COST);
-        batch_affine_add_internal(&temp_point_vector[0], &lookup_table[j][0]);
-    }
 
     detail::EndoScalars endo_scalars = Fr::split_into_endomorphism_scalars(converted_scalar);
     detail::EndomorphismWnaf<element, NUM_ROUNDS> wnaf{ endo_scalars };
 
     std::vector<affine_element> work_elements(num_points);
+    std::array<std::vector<affine_element>, LOOKUP_SIZE> lookup_table;
+    for (auto& table : lookup_table) {
+        table.resize(num_points);
+    }
+    std::vector<affine_element> temp_point_vector(num_points);
 
-    constexpr Fq beta = Fq::cube_root_of_unity();
-    uint64_t wnaf_entry = 0;
-    uint64_t index = 0;
-    bool sign = 0;
-    // Prepare elements for the first batch addition
-    for (size_t j = 0; j < 2; ++j) {
-        wnaf_entry = wnaf.table[j];
-        index = wnaf_entry & 0x0fffffffU;
-        sign = static_cast<bool>((wnaf_entry >> 31) & 1);
-        const bool is_odd = ((j & 1) == 1);
-        parallel_for_heuristic(
-            num_points,
-            [&](size_t i) {
+    auto execute_range = [&](size_t start, size_t end) {
+        // Perform batch affine addition in parallel
+        const auto add_chunked = [&](const affine_element* lhs, affine_element* rhs) {
+            batch_affine_add_chunked(&lhs[start], &rhs[start], end - start, &scratch_space[start]);
+        };
+
+        // Perform point doubling in parallel
+        const auto double_chunked = [&](affine_element* lhs) {
+            batch_affine_double_chunked(&lhs[start], end - start, &scratch_space[start]);
+        };
+
+        // Initialize first entries in lookup table
+        for (size_t i = start; i < end; ++i) {
+            if (points[i].is_point_at_infinity()) {
+                temp_point_vector[i] = affine_element::one();
+                lookup_table[0][i] = affine_element::one();
+            } else {
+                temp_point_vector[i] = points[i];
+                lookup_table[0][i] = points[i];
+            }
+        }
+        // Costruct lookup table
+        double_chunked(&temp_point_vector[0]);
+        for (size_t j = 1; j < LOOKUP_SIZE; ++j) {
+            for (size_t i = start; i < end; ++i) {
+                lookup_table[j][i] = lookup_table[j - 1][i];
+            }
+            add_chunked(&temp_point_vector[0], &lookup_table[j][0]);
+        }
+
+        constexpr Fq beta = Fq::cube_root_of_unity();
+        uint64_t wnaf_entry = 0;
+        uint64_t index = 0;
+        bool sign = 0;
+        // Prepare elements for the first batch addition
+        for (size_t j = 0; j < 2; ++j) {
+            wnaf_entry = wnaf.table[j];
+            index = wnaf_entry & 0x0fffffffU;
+            sign = static_cast<bool>((wnaf_entry >> 31) & 1);
+            const bool is_odd = ((j & 1) == 1);
+            for (size_t i = start; i < end; ++i) {
                 auto to_add = lookup_table[static_cast<size_t>(index)][i];
                 to_add.y.self_conditional_negate(sign ^ is_odd);
                 if (is_odd) {
@@ -970,64 +952,51 @@ std::vector<affine_element<Fq, Fr, T>> element<Fq, Fr, T>::batch_mul_with_endomo
                 } else {
                     temp_point_vector[i] = to_add;
                 }
-            },
-            (is_odd ? thread_heuristics::FF_MULTIPLICATION_COST : 0) + thread_heuristics::FF_COPY_COST +
-                thread_heuristics::FF_ADDITION_COST);
-    }
-    // First cycle of addition
-    batch_affine_add_internal(&temp_point_vector[0], &work_elements[0]);
-    // Run through SM logic in wnaf form (excluding the skew)
-    for (size_t j = 2; j < NUM_ROUNDS * 2; ++j) {
-        wnaf_entry = wnaf.table[j];
-        index = wnaf_entry & 0x0fffffffU;
-        sign = static_cast<bool>((wnaf_entry >> 31) & 1);
-        const bool is_odd = ((j & 1) == 1);
-        if (!is_odd) {
-            for (size_t k = 0; k < 4; ++k) {
-                batch_affine_double(&work_elements[0]);
             }
         }
-        parallel_for_heuristic(
-            num_points,
-            [&](size_t i) {
+        add_chunked(&temp_point_vector[0], &work_elements[0]);
+        // Run through SM logic in wnaf form (excluding the skew)
+        for (size_t j = 2; j < NUM_ROUNDS * 2; ++j) {
+            wnaf_entry = wnaf.table[j];
+            index = wnaf_entry & 0x0fffffffU;
+            sign = static_cast<bool>((wnaf_entry >> 31) & 1);
+            const bool is_odd = ((j & 1) == 1);
+            if (!is_odd) {
+                for (size_t k = 0; k < 4; ++k) {
+                    double_chunked(&work_elements[0]);
+                }
+            }
+            for (size_t i = start; i < end; ++i) {
                 auto to_add = lookup_table[static_cast<size_t>(index)][i];
                 to_add.y.self_conditional_negate(sign ^ is_odd);
                 if (is_odd) {
                     to_add.x *= beta;
                 }
                 temp_point_vector[i] = to_add;
-            },
-            (is_odd ? thread_heuristics::FF_MULTIPLICATION_COST : 0) + thread_heuristics::FF_COPY_COST +
-                thread_heuristics::FF_ADDITION_COST);
-        batch_affine_add_internal(&temp_point_vector[0], &work_elements[0]);
-    }
-
-    // Apply skew for the first endo scalar
-    if (wnaf.skew) {
-        parallel_for_heuristic(
-            num_points,
-            [&](size_t i) { temp_point_vector[i] = -lookup_table[0][i]; },
-            thread_heuristics::FF_ADDITION_COST + thread_heuristics::FF_COPY_COST);
-        batch_affine_add_internal(&temp_point_vector[0], &work_elements[0]);
-    }
-    // Apply skew for the second endo scalar
-    if (wnaf.endo_skew) {
-        parallel_for_heuristic(
-            num_points,
-            [&](size_t i) {
+            }
+            add_chunked(&temp_point_vector[0], &work_elements[0]);
+        }
+        // Apply skew for the first endo scalar
+        if (wnaf.skew) {
+            for (size_t i = start; i < end; ++i) {
+                temp_point_vector[i] = -lookup_table[0][i];
+            }
+            add_chunked(&temp_point_vector[0], &work_elements[0]);
+        }
+        // Apply skew for the second endo scalar
+        if (wnaf.endo_skew) {
+            for (size_t i = start; i < end; ++i) {
                 temp_point_vector[i] = lookup_table[0][i];
                 temp_point_vector[i].x *= beta;
-            },
-            thread_heuristics::FF_MULTIPLICATION_COST + thread_heuristics::FF_COPY_COST);
-        batch_affine_add_internal(&temp_point_vector[0], &work_elements[0]);
-    }
-    // handle points at infinity explicitly
-    parallel_for_heuristic(
-        num_points,
-        [&](size_t i) {
+            }
+            add_chunked(&temp_point_vector[0], &work_elements[0]);
+        }
+        // handle points at infinity explicitly
+        for (size_t i = start; i < end; ++i) {
             work_elements[i] = points[i].is_point_at_infinity() ? work_elements[i].set_infinity() : work_elements[i];
-        },
-        thread_heuristics::FF_COPY_COST);
+        }
+    };
+    parallel_for_range(num_points, execute_range);
 
     return work_elements;
 }

--- a/barretenberg/cpp/src/barretenberg/ecc/groups/element_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/groups/element_impl.hpp
@@ -795,7 +795,7 @@ std::vector<affine_element<Fq, Fr, T>> element<Fq, Fr, T>::batch_mul_with_endomo
     const std::span<const affine_element<Fq, Fr, T>>& points, const Fr& scalar) noexcept
 {
     BB_BENCH();
-    typedef affine_element<Fq, Fr, T> affine_element;
+    using affine_element = affine_element<Fq, Fr, T>;
     const size_t num_points = points.size();
 
     // Space for temporary values


### PR DESCRIPTION
The thread scaling behaviour was a lot better just having a consistent internal loop, operating on a range of the problem at a time

Before
<img width="690" height="85" alt="Screenshot 2025-09-09 at 5 41 46 PM" src="https://github.com/user-attachments/assets/6930d080-ce5d-4cef-bfaf-085033de4861" />

After
<img width="598" height="186" alt="Screenshot 2025-09-09 at 5 42 01 PM" src="https://github.com/user-attachments/assets/f50b04dc-65b0-41fa-92b3-3b3c6e95e48f" />
