### PR TITLE
fix(avm): use prover polys when committing logderivs

### DIFF
--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/prover.cpp
@@ -102,14 +102,11 @@ void AvmProver::execute_log_derivative_inverse_round()
 
 void AvmProver::execute_log_derivative_inverse_commitments_round()
 {
-    // Commit to all logderivative inverse polynomials
-    for (auto [commitment, key_poly] : zip_view(witness_commitments.get_derived(), key->get_derived())) {
-        commitment = commitment_key.commit(key_poly);
-    }
-
-    // Send all commitments to the verifier
-    for (auto [label, commitment] :
-         zip_view(prover_polynomials.get_derived_labels(), witness_commitments.get_derived())) {
+    // Commit to all logderivative inverse polynomials and send to verifier
+    for (auto [derived_poly, commitment, label] : zip_view(prover_polynomials.get_derived(),
+                                                           witness_commitments.get_derived(),
+                                                           prover_polynomials.get_derived_labels())) {
+        commitment = commitment_key.commit(derived_poly);
         transcript->send_to_verifier(label, commitment);
     }
 }


### PR DESCRIPTION
I came across this bug on a PR where I resize the prover polynomials when computing the inverses. I found that the polynomials that were being committed to still had size 0. Verification was not passing. With the changes, it passes.

What I think was happening is that the proving key is created from the prover polynomials and was somehow sharing the backing memory. However, when one was modified, the other wasn't.

I don't think it's correct to refer to the `key` in these committing functions, it should be all `prover_polynomials`. I'm also putting things together in one loop because, for the AVM, these RefArrays are actually big and might take some time to (re)compute (but it probably doesn't make a diff).