### PR TITLE
feat: Allow vetoer to disable slasher

### DIFF
--- a/l1-contracts/src/core/interfaces/ISlasher.sol
+++ b/l1-contracts/src/core/interfaces/ISlasher.sol
@@ -15,4 +15,5 @@ interface ISlasher {
 
   function slash(IPayload _payload) external returns (bool);
   function vetoPayload(IPayload _payload) external returns (bool);
+  function setSlashingEnabled(bool _enabled) external;
 }

--- a/l1-contracts/src/core/slashing/Slasher.sol
+++ b/l1-contracts/src/core/slashing/Slasher.sol
@@ -11,6 +11,8 @@ contract Slasher is ISlasher {
   // solhint-disable-next-line var-name-mixedcase
   address public PROPOSER;
 
+  bool public isSlashingEnabled = true;
+
   mapping(address payload => bool vetoed) public vetoedPayloads;
 
   error Slasher__SlashFailed(address target, bytes data, bytes returnData);
@@ -19,6 +21,7 @@ contract Slasher is ISlasher {
   error Slasher__PayloadVetoed(address payload);
   error Slasher__AlreadyInitialized();
   error Slasher__ProposerZeroAddress();
+  error Slasher__SlashingDisabled();
 
   constructor(address _vetoer, address _governance) {
     GOVERNANCE = _governance;
@@ -39,8 +42,14 @@ contract Slasher is ISlasher {
     return true;
   }
 
+  function setSlashingEnabled(bool _enabled) external override(ISlasher) {
+    require(msg.sender == VETOER, Slasher__CallerNotVetoer(msg.sender, VETOER));
+    isSlashingEnabled = _enabled;
+  }
+
   function slash(IPayload _payload) external override(ISlasher) returns (bool) {
     require(msg.sender == PROPOSER || msg.sender == GOVERNANCE, Slasher__CallerNotAuthorizedToSlash(msg.sender));
+    require(isSlashingEnabled, Slasher__SlashingDisabled());
     require(!vetoedPayloads[address(_payload)], Slasher__PayloadVetoed(address(_payload)));
 
     IPayload.Action[] memory actions = _payload.getActions();

--- a/l1-contracts/test/governance/scenario/slashing/TallySlashing.t.sol
+++ b/l1-contracts/test/governance/scenario/slashing/TallySlashing.t.sol
@@ -307,6 +307,42 @@ contract SlashingTest is TestBase {
     slashingProposer.executeRound(firstSlashingRound, committees);
   }
 
+  function test_CannotSlashIfDisabled(uint256 _lifetimeInRounds, uint256 _executionDelayInRounds, uint256 _jumpToSlot)
+    public
+  {
+    _executionDelayInRounds = bound(_executionDelayInRounds, 1, 50);
+    _lifetimeInRounds = bound(_lifetimeInRounds, _executionDelayInRounds + 1, 127); // Must be < ROUNDABOUT_SIZE
+
+    _setupCommitteeForSlashing(_lifetimeInRounds, _executionDelayInRounds);
+    address[] memory attesters = rollup.getEpochCommittee(Epoch.wrap(INITIAL_EPOCH));
+    uint96 slashAmount = 20e18;
+    SlashRound firstSlashingRound = _createSlashingVotes(slashAmount, attesters.length);
+
+    vm.prank(address(slasher.VETOER()));
+    slasher.setSlashingEnabled(false);
+
+    uint256 firstExecutableSlot =
+      (SlashRound.unwrap(firstSlashingRound) + _executionDelayInRounds + 1) * slashingProposer.ROUND_SIZE();
+    uint256 lastExecutableSlot =
+      (SlashRound.unwrap(firstSlashingRound) + _lifetimeInRounds) * slashingProposer.ROUND_SIZE();
+    _jumpToSlot = bound(_jumpToSlot, firstExecutableSlot, lastExecutableSlot);
+
+    timeCheater.cheat__jumpToSlot(_jumpToSlot);
+
+    address[][] memory committees = new address[][](slashingProposer.ROUND_SIZE_IN_EPOCHS());
+    for (uint256 i = 0; i < committees.length; i++) {
+      Epoch epochSlashed = slashingProposer.getSlashTargetEpoch(firstSlashingRound, i);
+      committees[i] = rollup.getEpochCommittee(epochSlashed);
+    }
+
+    vm.expectRevert(abi.encodeWithSelector(Slasher.Slasher__SlashingDisabled.selector));
+    slashingProposer.executeRound(firstSlashingRound, committees);
+
+    vm.prank(address(slasher.VETOER()));
+    slasher.setSlashingEnabled(true);
+    slashingProposer.executeRound(firstSlashingRound, committees);
+  }
+
   function test_SlashingSmallAmount() public {
     _setupCommitteeForSlashing();
     uint256 howManyToSlash = HOW_MANY_SLASHED;

--- a/yarn-project/ethereum/src/contracts/slasher_contract.ts
+++ b/yarn-project/ethereum/src/contracts/slasher_contract.ts
@@ -39,6 +39,19 @@ export class SlasherContract {
   }
 
   /**
+   * Checks if slashing is currently enabled. Slashing can be disabled by the vetoer.
+   * @returns True if slashing is enabled, false otherwise
+   */
+  public async isSlashingEnabled(): Promise<boolean> {
+    try {
+      return await this.contract.read.isSlashingEnabled();
+    } catch (error) {
+      this.log.error(`Error checking if slashing is enabled`, error);
+      throw error;
+    }
+  }
+
+  /**
    * Gets the current vetoer address.
    * @returns The vetoer address
    */

--- a/yarn-project/slasher/src/empire_slasher_client.test.ts
+++ b/yarn-project/slasher/src/empire_slasher_client.test.ts
@@ -163,6 +163,7 @@ describe('EmpireSlasherClient', () => {
     // Setup rollup and slasher contract mocks
     rollupContract.getSlasherContract.mockResolvedValue(slasherContract);
     slasherContract.isPayloadVetoed.mockResolvedValue(false);
+    slasherContract.isSlashingEnabled.mockResolvedValue(true);
 
     // Create watcher
     dummyWatcher = new DummyWatcher();

--- a/yarn-project/slasher/src/empire_slasher_client.ts
+++ b/yarn-project/slasher/src/empire_slasher_client.ts
@@ -403,12 +403,18 @@ export class EmpireSlasherClient implements ProposerSlashActionProvider, Slasher
         continue;
       }
 
-      // Check if the slash payload is vetoed
+      // Check if slashing is enabled at all
       const slasherContract = await this.rollup.getSlasherContract();
+      if (!(await slasherContract.isSlashingEnabled())) {
+        this.log.warn(`Slashing is disabled in the Slasher contract (skipping execution)`);
+        return undefined;
+      }
+
+      // Check if the slash payload is vetoed
       const isVetoed = await slasherContract.isPayloadVetoed(payload.payload);
 
       if (isVetoed) {
-        this.log.info(`Payload ${payload.payload} from round ${payload.round} is vetoed, skipping execution`);
+        this.log.info(`Payload ${payload.payload} from round ${payload.round} is vetoed (skipping execution)`);
         toRemove.push(payload);
         continue;
       }

--- a/yarn-project/slasher/src/tally_slasher_client.test.ts
+++ b/yarn-project/slasher/src/tally_slasher_client.test.ts
@@ -154,6 +154,7 @@ describe('TallySlasherClient', () => {
     // Setup rollup and slasher contract mocks
     rollup.getSlasherContract.mockResolvedValue(slasherContract);
     slasherContract.isPayloadVetoed.mockResolvedValue(false);
+    slasherContract.isSlashingEnabled.mockResolvedValue(true);
 
     // Mock event listeners to return unwatch functions
     tallySlashingProposer.listenToVoteCast.mockReturnValue(() => {});
@@ -372,6 +373,41 @@ describe('TallySlasherClient', () => {
         const actions = await tallySlasherClient.getProposerActions(currentSlot);
 
         expect(actions).toEqual([]);
+      });
+
+      it('should not execute vetoed rounds', async () => {
+        const currentRound = 5n;
+        const currentSlot = currentRound * BigInt(roundSize); // Round 5
+        const executableRound = 2n; // After execution delay of 2: currentRound - delay - 1 = 5 - 2 - 1 = 2
+
+        tallySlashingProposer.getRound.mockResolvedValueOnce({
+          isExecuted: false,
+          readyToExecute: true,
+          voteCount: 120n,
+        });
+
+        const payloadAddress = EthAddress.random();
+        tallySlashingProposer.getPayload.mockResolvedValue({
+          address: payloadAddress,
+          actions: [{ validator: committee[0], slashAmount: slashingUnit }],
+        });
+
+        slasherContract.isPayloadVetoed.mockResolvedValueOnce(true);
+        const actions = await tallySlasherClient.getProposerActions(currentSlot);
+
+        expect(actions).toHaveLength(0);
+        expect(tallySlashingProposer.getRound).toHaveBeenCalledWith(executableRound);
+        expect(slasherContract.isPayloadVetoed).toHaveBeenCalledWith(payloadAddress);
+      });
+
+      it('should not execute when slashing is disabled', async () => {
+        const currentRound = 5n;
+        const currentSlot = currentRound * BigInt(roundSize); // Round 5
+
+        slasherContract.isSlashingEnabled.mockResolvedValue(false);
+        const actions = await tallySlasherClient.getProposerActions(currentSlot);
+
+        expect(actions).toHaveLength(0);
       });
     });
 

--- a/yarn-project/slasher/src/tally_slasher_client.ts
+++ b/yarn-project/slasher/src/tally_slasher_client.ts
@@ -187,6 +187,13 @@ export class TallySlasherClient implements ProposerSlashActionProvider, SlasherC
 
     const logData = { currentRound, executableRound, slotNumber };
     try {
+      // Check if slashing is enabled at all
+      const slasherContract = await this.rollup.getSlasherContract();
+      if (!(await slasherContract.isSlashingEnabled())) {
+        this.log.warn(`Slashing is disabled in the Slasher contract (skipping execution)`, logData);
+        return undefined;
+      }
+
       const roundInfo = await this.tallySlashingProposer.getRound(executableRound);
       if (roundInfo.isExecuted) {
         this.log.verbose(`Round ${executableRound} has already been executed`, logData);
@@ -207,7 +214,6 @@ export class TallySlasherClient implements ProposerSlashActionProvider, SlasherC
 
       // Check if the slash payload is vetoed
       const payload = await this.tallySlashingProposer.getPayload(executableRound);
-      const slasherContract = await this.rollup.getSlasherContract();
       const isVetoed = await slasherContract.isPayloadVetoed(payload.address);
       if (isVetoed) {
         this.log.warn(`Round ${executableRound} payload is vetoed (skipping execution)`, {


### PR DESCRIPTION
Allows the vetoer to disable slashing altogether temporarily. This allows the vetoer to stop all slashes if a bug is detected that continuously triggers slashes that are not valid, so the vetoer does not need to continuously vetoed every individual slash until the issue is solved.

Note that this does NOT give the vetoer any more power than they had before, it just allows them to blanket veto any slash payload while the `disable` flag is set.