### PR TITLE
fix: Fix L1 publishing

### DIFF
--- a/.test_patterns.yml
+++ b/.test_patterns.yml
@@ -183,6 +183,9 @@ tests:
     error_regex: "This is a bug"
     owners:
       - *palla
+  - regex: "src/e2e_epochs/epochs_l1_reorgs.test.ts"
+    owners:
+      - *palla
   - regex: "src/e2e_epochs/epochs_empty_blocks"
     error_regex: "✕ successfully proves multiple epochs"
     owners:


### PR DESCRIPTION
This fixes a bug in the L1 Tx Publisher. The bug manifests as:

1. A tx is sent to L1. The publisher monitors it for a period of time (until it would no longer be valid).
2. The publisher believes it has timed out, but it hasn't. There is a race condition and it has actually been mined.
3. The publisher submits and monitors cancellation transactions.
4. It no longer monitors the original transaction and so remains stuck in a terminal state of 'cancelling'.
