### PR TITLE
chore: Add e2e test for inactivity slash with consecutive epochs

### DIFF
--- a/l1-contracts/test/governance/governance/vote.t.sol
+++ b/l1-contracts/test/governance/governance/vote.t.sol
@@ -97,6 +97,7 @@ contract VoteTest is GovernanceBase {
 
   modifier givenStateIsActive(address _voter, uint256 _depositPower) {
     vm.assume(_voter != address(0));
+    vm.assume(_voter != address(governance));
     depositPower = bound(_depositPower, 1, type(uint128).max);
 
     token.mint(_voter, depositPower);

--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -416,6 +416,8 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, Traceable {
     if (!options.dontStartSequencer && sequencer) {
       await sequencer.start();
       log.verbose(`Sequencer started`);
+    } else if (sequencer) {
+      log.warn(`Sequencer created but not started`);
     }
 
     return new AztecNodeService(

--- a/yarn-project/end-to-end/src/e2e_p2p/inactivity_slash.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/inactivity_slash.test.ts
@@ -1,113 +1,37 @@
-import type { AztecNodeService } from '@aztec/aztec-node';
-import { EthAddress } from '@aztec/aztec.js';
-import { RollupContract } from '@aztec/ethereum';
+import type { EthAddress } from '@aztec/aztec.js';
 import { promiseWithResolvers } from '@aztec/foundation/promise';
 
 import { jest } from '@jest/globals';
-import fs from 'fs';
 import 'jest-extended';
-import os from 'os';
-import path from 'path';
 
-import { createNodes } from '../fixtures/setup_p2p_test.js';
-import { P2PNetworkTest } from './p2p_network.js';
-
-const NUM_NODES = 5;
-const NUM_VALIDATORS = NUM_NODES + 1; // We create an extra validator, who will not have a running node
-const BOOT_NODE_UDP_PORT = 4500;
-const EPOCH_DURATION = 2;
-const SLASHING_QUORUM = 3;
-const SLASHING_ROUND_SIZE = 4;
-const ETHEREUM_SLOT_DURATION = 4;
-const AZTEC_SLOT_DURATION = 8;
-const SLASHING_UNIT = BigInt(1e18);
-const SLASHING_AMOUNT = SLASHING_UNIT * 3n;
-
-const DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'inactivity-slash-'));
+import { P2PInactivityTest } from './inactivity_slash_test.js';
 
 jest.setTimeout(1000 * 60 * 10);
 
+const SLASH_INACTIVITY_CONSECUTIVE_EPOCH_THRESHOLD = 1;
+
 describe('e2e_p2p_inactivity_slash', () => {
-  let t: P2PNetworkTest;
-  let nodes: AztecNodeService[];
-  let rollup: RollupContract;
-  let offlineValidator: EthAddress;
+  let test: P2PInactivityTest;
 
   beforeAll(async () => {
-    t = await P2PNetworkTest.create({
-      testName: 'e2e_p2p_inactivity_slash',
-      numberOfNodes: 0,
-      numberOfValidators: NUM_VALIDATORS,
-      basePort: BOOT_NODE_UDP_PORT,
-      startProverNode: true,
-      initialConfig: {
-        aztecTargetCommitteeSize: NUM_VALIDATORS,
-        aztecSlotDuration: AZTEC_SLOT_DURATION,
-        ethereumSlotDuration: ETHEREUM_SLOT_DURATION,
-        aztecProofSubmissionEpochs: 1024, // effectively do not reorg
-        listenAddress: '127.0.0.1',
-        minTxsPerBlock: 0,
-        aztecEpochDuration: EPOCH_DURATION,
-        validatorReexecute: false,
-        sentinelEnabled: true,
-        slashingQuorum: SLASHING_QUORUM,
-        slashingRoundSizeInEpochs: SLASHING_ROUND_SIZE / EPOCH_DURATION,
-        slashInactivityTargetPercentage: 0.5,
-        slashAmountSmall: SLASHING_UNIT,
-        slashAmountMedium: SLASHING_UNIT * 2n,
-        slashAmountLarge: SLASHING_UNIT * 3n,
-      },
-    });
-
-    await t.applyBaseSnapshots();
-    await t.setup();
-
-    // Set slashing penalties for inactivity
-    ({ rollup } = await t.getContracts());
-    const [activationThreshold, ejectionThreshold, localEjectionThreshold] = await Promise.all([
-      rollup.getActivationThreshold(),
-      rollup.getEjectionThreshold(),
-      rollup.getLocalEjectionThreshold(),
-    ]);
-    const biggestEjection = ejectionThreshold > localEjectionThreshold ? ejectionThreshold : localEjectionThreshold;
-    expect(activationThreshold - SLASHING_AMOUNT).toBeLessThan(biggestEjection);
-    t.ctx.aztecNodeConfig.slashInactivityPenalty = SLASHING_AMOUNT;
-
-    nodes = await createNodes(
-      t.ctx.aztecNodeConfig,
-      t.ctx.dateProvider,
-      t.bootstrapNodeEnr,
-      NUM_NODES, // Note we do not create the last validator yet, so it shows as offline
-      BOOT_NODE_UDP_PORT,
-      t.prefilledPublicData,
-
-      DATA_DIR,
-    );
-    await t.removeInitialNode();
-
-    offlineValidator = t.validators.at(-1)!.attester;
-    t.logger.warn(`Setup complete. Offline validator is ${offlineValidator}.`, {
-      validators: t.validators,
-      offlineValidator,
-    });
+    test = await P2PInactivityTest.create('e2e_p2p_inactivity_slash', {
+      slashInactivityConsecutiveEpochThreshold: SLASH_INACTIVITY_CONSECUTIVE_EPOCH_THRESHOLD,
+      inactiveNodeCount: 1,
+    }).then(t => t.setup());
   });
 
   afterAll(async () => {
-    await t.stopNodes(nodes);
-    await t.teardown();
-    for (let i = 0; i < NUM_NODES; i++) {
-      fs.rmSync(`${DATA_DIR}-${i}`, { recursive: true, force: true, maxRetries: 3 });
-    }
+    await test?.teardown();
   });
 
   it('slashes inactive validator', async () => {
-    const slashPromise = promiseWithResolvers<bigint>();
-    rollup.listenToSlash(args => {
-      t.logger.warn(`Slashed ${args.attester.toString()}`);
-      expect(offlineValidator.toString()).toEqual(args.attester.toString());
-      expect(args.amount).toEqual(SLASHING_AMOUNT);
-      slashPromise.resolve(args.amount);
+    const slashPromise = promiseWithResolvers<{ amount: bigint; attester: EthAddress }>();
+    test.rollup.listenToSlash(args => {
+      test.logger.warn(`Slashed ${args.attester.toString()}`);
+      slashPromise.resolve(args);
     });
-    await slashPromise.promise;
+    const { amount, attester } = await slashPromise.promise;
+    expect(test.offlineValidators[0].toString()).toEqual(attester.toString());
+    expect(amount).toEqual(test.slashingAmount);
   });
 });

--- a/yarn-project/end-to-end/src/e2e_p2p/inactivity_slash_test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/inactivity_slash_test.ts
@@ -1,0 +1,155 @@
+import type { AztecNodeService } from '@aztec/aztec-node';
+import { EthAddress } from '@aztec/aztec.js';
+import { RollupContract } from '@aztec/ethereum';
+
+import fs from 'fs';
+import 'jest-extended';
+import os from 'os';
+import path from 'path';
+
+import { createNodes } from '../fixtures/setup_p2p_test.js';
+import { P2PNetworkTest } from './p2p_network.js';
+
+const NUM_NODES = 6;
+const NUM_VALIDATORS = NUM_NODES;
+const COMMITTEE_SIZE = NUM_VALIDATORS;
+const SLASHING_QUORUM = 3;
+const EPOCH_DURATION = 2;
+const SLASHING_ROUND_SIZE_IN_EPOCHS = 2;
+const BOOT_NODE_UDP_PORT = 4500;
+const ETHEREUM_SLOT_DURATION = 4;
+const AZTEC_SLOT_DURATION = 8;
+const SLASHING_UNIT = BigInt(1e18);
+const SLASHING_AMOUNT = SLASHING_UNIT * 3n;
+
+export class P2PInactivityTest {
+  public nodes!: AztecNodeService[];
+  public activeNodes!: AztecNodeService[];
+  public inactiveNodes!: AztecNodeService[];
+
+  public rollup!: RollupContract;
+  public offlineValidators!: EthAddress[];
+
+  private dataDir: string;
+  private inactiveNodeCount: number;
+
+  constructor(
+    public readonly test: P2PNetworkTest,
+    opts: { inactiveNodeCount: number },
+  ) {
+    this.dataDir = fs.mkdtempSync(path.join(os.tmpdir(), test.testName));
+    this.inactiveNodeCount = opts.inactiveNodeCount;
+  }
+
+  static async create(
+    testName: string,
+    opts: { slashInactivityConsecutiveEpochThreshold: number; inactiveNodeCount: number },
+  ) {
+    const test = await P2PNetworkTest.create({
+      testName,
+      numberOfNodes: 0,
+      numberOfValidators: NUM_VALIDATORS,
+      basePort: BOOT_NODE_UDP_PORT,
+      startProverNode: true,
+      initialConfig: {
+        proverNodeConfig: { proverNodeEpochProvingDelayMs: AZTEC_SLOT_DURATION * 1000 },
+        aztecTargetCommitteeSize: COMMITTEE_SIZE,
+        aztecSlotDuration: AZTEC_SLOT_DURATION,
+        ethereumSlotDuration: ETHEREUM_SLOT_DURATION,
+        aztecProofSubmissionEpochs: 1024, // effectively do not reorg
+        listenAddress: '127.0.0.1',
+        minTxsPerBlock: 0,
+        aztecEpochDuration: EPOCH_DURATION,
+        validatorReexecute: false,
+        sentinelEnabled: true,
+        slashingQuorum: SLASHING_QUORUM,
+        slashingRoundSizeInEpochs: SLASHING_ROUND_SIZE_IN_EPOCHS,
+        slashInactivityTargetPercentage: 0.5,
+        slashGracePeriodL2Slots: EPOCH_DURATION, // do not slash during the first epoch
+        slashAmountSmall: SLASHING_UNIT,
+        slashAmountMedium: SLASHING_UNIT * 2n,
+        slashAmountLarge: SLASHING_UNIT * 3n,
+        ...opts,
+      },
+    });
+    return new P2PInactivityTest(test, opts);
+  }
+
+  public async setup() {
+    await this.test.applyBaseSnapshots();
+    await this.test.setup();
+
+    // Set slashing penalties for inactivity
+    const { rollup } = await this.test.getContracts();
+    const [activationThreshold, ejectionThreshold, localEjectionThreshold] = await Promise.all([
+      rollup.getActivationThreshold(),
+      rollup.getEjectionThreshold(),
+      rollup.getLocalEjectionThreshold(),
+    ]);
+    const biggestEjection = ejectionThreshold > localEjectionThreshold ? ejectionThreshold : localEjectionThreshold;
+    expect(activationThreshold - SLASHING_AMOUNT).toBeLessThan(biggestEjection);
+    this.test.ctx.aztecNodeConfig.slashInactivityPenalty = SLASHING_AMOUNT;
+    this.rollup = rollup;
+
+    // The initial validator that ran on this node is picked up by the first new node started below
+    await this.test.removeInitialNode();
+
+    // Create all active nodes
+    this.activeNodes = await createNodes(
+      this.test.ctx.aztecNodeConfig,
+      this.test.ctx.dateProvider,
+      this.test.bootstrapNodeEnr,
+      NUM_NODES - this.inactiveNodeCount,
+      BOOT_NODE_UDP_PORT,
+      this.test.prefilledPublicData,
+      this.dataDir,
+    );
+
+    // And the ones with an initially disabled sequencer
+    const inactiveConfig = { ...this.test.ctx.aztecNodeConfig, dontStartSequencer: true };
+    this.inactiveNodes = await createNodes(
+      inactiveConfig,
+      this.test.ctx.dateProvider,
+      this.test.bootstrapNodeEnr,
+      this.inactiveNodeCount,
+      BOOT_NODE_UDP_PORT,
+      this.test.prefilledPublicData,
+      this.dataDir,
+      undefined,
+      NUM_NODES - this.inactiveNodeCount,
+    );
+
+    this.nodes = [...this.activeNodes, ...this.inactiveNodes];
+
+    this.offlineValidators = this.test.validators
+      .slice(this.test.validators.length - this.inactiveNodeCount)
+      .map(a => a.attester);
+
+    this.test.logger.warn(`Setup complete. Offline validators are ${this.offlineValidators.join(', ')}.`, {
+      validators: this.test.validators,
+      offlineValidators: this.offlineValidators,
+    });
+
+    return this;
+  }
+
+  public async teardown() {
+    await this.test.stopNodes(this.nodes);
+    await this.test.teardown();
+    for (let i = 0; i < NUM_NODES; i++) {
+      fs.rmSync(`${this.dataDir}-${i}`, { recursive: true, force: true, maxRetries: 3 });
+    }
+  }
+
+  public get ctx() {
+    return this.test.ctx;
+  }
+
+  public get logger() {
+    return this.test.logger;
+  }
+
+  public get slashingAmount() {
+    return SLASHING_AMOUNT;
+  }
+}

--- a/yarn-project/end-to-end/src/e2e_p2p/inactivity_slash_with_consecutive_epochs.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/inactivity_slash_with_consecutive_epochs.test.ts
@@ -1,0 +1,58 @@
+import type { EthAddress } from '@aztec/aztec.js';
+import { unique } from '@aztec/foundation/collection';
+
+import { jest } from '@jest/globals';
+import 'jest-extended';
+
+import { P2PInactivityTest } from './inactivity_slash_test.js';
+
+jest.setTimeout(1000 * 60 * 10);
+
+describe('e2e_p2p_inactivity_slash_with_consecutive_epochs', () => {
+  let test: P2PInactivityTest;
+
+  const slashInactivityConsecutiveEpochThreshold = 3;
+
+  beforeAll(async () => {
+    test = await P2PInactivityTest.create('e2e_p2p_inactivity_slash_with_consecutive_epochs', {
+      slashInactivityConsecutiveEpochThreshold,
+      inactiveNodeCount: 2,
+    }).then(t => t.setup());
+  });
+
+  afterAll(async () => {
+    await test?.teardown();
+  });
+
+  it('only slashes validator inactive for N consecutive epochs', async () => {
+    const [offlineValidator, reenabledValidator] = test.offlineValidators;
+    const { aztecEpochDuration, slashingExecutionDelayInRounds, slashingOffsetInRounds, slashingRoundSizeInEpochs } =
+      test.ctx.aztecNodeConfig;
+
+    const initialEpoch = Number(test.test.monitor.l2EpochNumber) + 1;
+    test.logger.warn(`Waiting until end of epoch ${initialEpoch} to reenable validator ${reenabledValidator}`);
+    await test.test.monitor.waitUntilL2Slot(initialEpoch * aztecEpochDuration);
+
+    test.logger.warn(`Re-enabling offline validator ${reenabledValidator}`);
+    const reenabledNode = test.nodes.at(-1)!;
+    expect(reenabledNode.getSequencer()!.validatorAddresses![0].toString()).toEqual(reenabledValidator.toString());
+    await reenabledNode.getSequencer()!.start();
+
+    test.logger.warn(`Expecting offline validator ${offlineValidator} to be slashed but not ${reenabledValidator}`);
+    const slashed: EthAddress[] = [];
+    test.rollup.listenToSlash(args => {
+      test.logger.warn(`Slashed ${args.attester.toString()}`);
+      slashed.push(args.attester);
+    });
+
+    // Wait until after the slashing would have executed for inactivity plus a bit for good measure
+    const targetEpoch =
+      initialEpoch +
+      slashInactivityConsecutiveEpochThreshold +
+      (slashingExecutionDelayInRounds + slashingOffsetInRounds) * slashingRoundSizeInEpochs +
+      5;
+    test.logger.warn(`Waiting until slot ${aztecEpochDuration * targetEpoch} (epoch ${targetEpoch})`);
+    await test.test.monitor.waitUntilL2Slot(aztecEpochDuration * targetEpoch);
+    expect(unique(slashed.map(addr => addr.toString()))).toEqual([offlineValidator.toString()]);
+  });
+});

--- a/yarn-project/end-to-end/src/e2e_p2p/p2p_network.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/p2p_network.ts
@@ -43,7 +43,7 @@ import {
   createSnapshotManager,
   deployAccounts,
 } from '../fixtures/snapshot_manager.js';
-import { getPrivateKeyFromIndex, getSponsoredFPCAddress } from '../fixtures/utils.js';
+import { type SetupOptions, getPrivateKeyFromIndex, getSponsoredFPCAddress } from '../fixtures/utils.js';
 import { getEndToEndTestTelemetryClient } from '../fixtures/with_telemetry_utils.js';
 
 // Use a fixed bootstrap node private key so that we can re-use the same snapshot and the nodes can find each other
@@ -82,11 +82,11 @@ export class P2PNetworkTest {
   public bootstrapNode?: BootstrapNode;
 
   constructor(
-    testName: string,
+    public readonly testName: string,
     public bootstrapNodeEnr: string,
     public bootNodePort: number,
     public numberOfValidators: number,
-    initialValidatorConfig: AztecNodeConfig,
+    initialValidatorConfig: SetupOptions,
     public numberOfNodes = 0,
     // If set enable metrics collection
     private metricsPort?: number,
@@ -162,7 +162,7 @@ export class P2PNetworkTest {
     numberOfValidators: number;
     basePort?: number;
     metricsPort?: number;
-    initialConfig?: Partial<AztecNodeConfig>;
+    initialConfig?: SetupOptions;
     startProverNode?: boolean;
     mockZkPassportVerifier?: boolean;
   }) {

--- a/yarn-project/end-to-end/src/fixtures/e2e_prover_test.ts
+++ b/yarn-project/end-to-end/src/fixtures/e2e_prover_test.ts
@@ -277,6 +277,7 @@ export class FullProverTest {
       txGatheringMaxParallelRequestsPerNode: 100,
       txGatheringTimeoutMs: 24_000,
       proverNodeFailedEpochStore: undefined,
+      proverNodeEpochProvingDelayMs: undefined,
     };
     const sponsoredFPCAddress = await getSponsoredFPCAddress();
     const { prefilledPublicData } = await getGenesisValues(

--- a/yarn-project/end-to-end/src/fixtures/setup_p2p_test.ts
+++ b/yarn-project/end-to-end/src/fixtures/setup_p2p_test.ts
@@ -39,7 +39,7 @@ export function generatePrivateKeys(startIndex: number, numberOfKeys: number): `
 }
 
 export async function createNodes(
-  config: AztecNodeConfig,
+  config: AztecNodeConfig & { dontStartSequencer?: boolean },
   dateProvider: DateProvider,
   bootstrapNodeEnr: string,
   numNodes: number,
@@ -88,7 +88,7 @@ export async function createNodes(
 
 // creates a P2P enabled instance of Aztec Node Service
 export async function createNode(
-  config: AztecNodeConfig,
+  config: AztecNodeConfig & { dontStartSequencer?: boolean },
   dateProvider: DateProvider,
   tcpPort: number,
   bootstrapNode: string | undefined,
@@ -101,7 +101,11 @@ export async function createNode(
   const createNode = async () => {
     const validatorConfig = await createValidatorConfig(config, bootstrapNode, tcpPort, addressIndex, dataDirectory);
     const telemetry = getEndToEndTestTelemetryClient(metricsPort);
-    return await AztecNodeService.createAndSync(validatorConfig, { telemetry, dateProvider }, { prefilledPublicData });
+    return await AztecNodeService.createAndSync(
+      validatorConfig,
+      { telemetry, dateProvider },
+      { prefilledPublicData, dontStartSequencer: config.dontStartSequencer },
+    );
   };
   return loggerIdStorage ? await loggerIdStorage.run(tcpPort.toString(), createNode) : createNode();
 }

--- a/yarn-project/end-to-end/src/fixtures/utils.ts
+++ b/yarn-project/end-to-end/src/fixtures/utils.ts
@@ -959,6 +959,7 @@ export function createAndSyncProverNode(
       txGatheringTimeoutMs: 24_000,
       proverNodeFailedEpochStore: undefined,
       proverId: EthAddress.fromNumber(1),
+      proverNodeEpochProvingDelayMs: undefined,
       ...proverNodeConfig,
     };
 

--- a/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
+++ b/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
@@ -811,9 +811,8 @@ export class LibP2PService<T extends P2PClientType = P2PClientType.Full> extends
   private async processValidBlockProposal(block: BlockProposal, sender: PeerId) {
     const slot = block.slotNumber.toBigInt();
     const previousSlot = slot - 1n;
-    const epoch = slot / 32n;
     this.logger.verbose(
-      `Received block ${block.blockNumber} for slot ${slot} epoch ${epoch} from external peer ${sender.toString()}.`,
+      `Received block ${block.blockNumber} for slot ${slot} from external peer ${sender.toString()}.`,
       {
         p2pMessageIdentifier: await block.p2pMessageIdentifier(),
         slot: block.slotNumber.toNumber(),

--- a/yarn-project/prover-node/src/config.ts
+++ b/yarn-project/prover-node/src/config.ts
@@ -38,6 +38,7 @@ export type SpecificProverNodeConfig = {
   proverNodePollingIntervalMs: number;
   proverNodeMaxParallelBlocksPerEpoch: number;
   proverNodeFailedEpochStore: string | undefined;
+  proverNodeEpochProvingDelayMs: number | undefined;
   txGatheringTimeoutMs: number;
   txGatheringIntervalMs: number;
   txGatheringBatchSize: number;
@@ -63,6 +64,10 @@ const specificProverNodeConfigMappings: ConfigMappingsType<SpecificProverNodeCon
   proverNodeFailedEpochStore: {
     env: 'PROVER_NODE_FAILED_EPOCH_STORE',
     description: 'File store where to upload node state when an epoch fails to be proven',
+    defaultValue: undefined,
+  },
+  proverNodeEpochProvingDelayMs: {
+    description: 'Optional delay in milliseconds to wait before proving a new epoch',
     defaultValue: undefined,
   },
   txGatheringIntervalMs: {

--- a/yarn-project/prover-node/src/factory.ts
+++ b/yarn-project/prover-node/src/factory.ts
@@ -177,6 +177,7 @@ export async function createProverNode(
       'proverNodeMaxPendingJobs',
       'proverNodeMaxParallelBlocksPerEpoch',
       'proverNodePollingIntervalMs',
+      'proverNodeEpochProvingDelayMs',
       'txGatheringMaxParallelRequests',
       'txGatheringIntervalMs',
       'txGatheringTimeoutMs',
@@ -189,7 +190,7 @@ export async function createProverNode(
 
   const epochMonitor = await EpochMonitor.create(
     archiver,
-    { pollingIntervalMs: config.proverNodePollingIntervalMs },
+    { pollingIntervalMs: config.proverNodePollingIntervalMs, provingDelayMs: config.proverNodeEpochProvingDelayMs },
     telemetry,
   );
 

--- a/yarn-project/prover-node/src/prover-node.test.ts
+++ b/yarn-project/prover-node/src/prover-node.test.ts
@@ -108,6 +108,7 @@ describe('prover-node', () => {
       txGatheringMaxParallelRequestsPerNode: 5,
       proverNodeFailedEpochStore: undefined,
       txGatheringTimeoutMs: 1000,
+      proverNodeEpochProvingDelayMs: undefined,
     };
 
     // World state returns a new mock db every time it is asked to fork

--- a/yarn-project/prover-node/src/prover-node.ts
+++ b/yarn-project/prover-node/src/prover-node.ts
@@ -87,6 +87,7 @@ export class ProverNode implements EpochMonitorHandler, ProverNodeApi, Traceable
       txGatheringMaxParallelRequestsPerNode: 100,
       txGatheringTimeoutMs: 120_000,
       proverNodeFailedEpochStore: undefined,
+      proverNodeEpochProvingDelayMs: undefined,
       ...compact(config),
     };
 

--- a/yarn-project/sequencer-client/src/client/sequencer-client.ts
+++ b/yarn-project/sequencer-client/src/client/sequencer-client.ts
@@ -207,6 +207,7 @@ export class SequencerClient {
    */
   public async stop() {
     await this.sequencer.stop();
+    await this.validatorClient?.stop();
     this.publisherManager.interrupt();
     this.l1Metrics?.stop();
   }

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.ts
@@ -232,7 +232,6 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
     this.log.info(`Stopping sequencer`);
     this.metrics.stop();
     this.publisher?.interrupt();
-    await this.validatorClient?.stop();
     await this.runningPromise?.stop();
     this.setState(SequencerState.STOPPED, undefined, { force: true });
     this.log.info('Stopped sequencer');

--- a/yarn-project/validator-client/src/validator.ts
+++ b/yarn-project/validator-client/src/validator.ts
@@ -171,8 +171,6 @@ export class ValidatorClient extends (EventEmitter as new () => WatcherEmitter) 
       telemetry,
     );
 
-    // TODO(PhilWindle): This seems like it could/should be done inside start()
-    validator.registerBlockProposalHandler();
     return validator;
   }
 
@@ -203,9 +201,15 @@ export class ValidatorClient extends (EventEmitter as new () => WatcherEmitter) 
   }
 
   public async start() {
+    if (this.epochCacheUpdateLoop.isRunning()) {
+      this.log.warn(`Validator client already started`);
+      return;
+    }
+
+    this.registerBlockProposalHandler();
+
     // Sync the committee from the smart contract
     // https://github.com/AztecProtocol/aztec-packages/issues/7962
-
     const myAddresses = this.getValidatorAddresses();
 
     const inCommittee = await this.epochCache.filterInCommittee('now', myAddresses);


### PR DESCRIPTION
Equivalent to existing inactivity slash test, but requires N consecutive epochs of inactivity to slash.

This required adding a new config entry `proverNodeEpochProvingDelayMs` which delays the start of a proving job. Issue was that the sentinel processes missed attestations with a 2-slot delay (to allow time for all attestations to have been propagated), but the proof for a given epoch was landing immediately after it ended, so during `Sentinel.computeProvenPerformance` not all data was available.
