### PR TITLE
chore: Fix slash veto demo flake

### DIFF
--- a/l1-contracts/test/slashing/TallySlashingProposer.t.sol
+++ b/l1-contracts/test/slashing/TallySlashingProposer.t.sol
@@ -864,4 +864,29 @@ contract TallySlashingProposerTest is TestBase {
       }
     }
   }
+
+  function test_getSlashTargetCommitteesEarlyEpochs() public {
+    // Test that getSlashTargetCommittees handles epochs 0 and 1 without throwing
+    // when ValidatorSelection__InsufficientValidatorSetSize is thrown
+
+    // Use a very early slash round that would target epochs 0 and 1
+    // With SLASH_OFFSET_IN_ROUNDS = 2, round 2 targets epochs starting from (2-2)*ROUND_SIZE_IN_EPOCHS = 0
+    SlashRound earlyRound = SlashRound.wrap(SLASH_OFFSET_IN_ROUNDS);
+
+    // This should not revert and should return empty committees for early epochs
+    address[][] memory committees = slashingProposer.getSlashTargetCommittees(earlyRound);
+
+    // Verify we get the expected number of committees
+    assertEq(committees.length, ROUND_SIZE_IN_EPOCHS, "Should return correct number of committees");
+
+    // For very early rounds, we expect empty committees for epochs 0 and 1
+    // Since ROUND_SIZE_IN_EPOCHS = 2, both epochs should be empty
+    for (uint256 i = 0; i < ROUND_SIZE_IN_EPOCHS; i++) {
+      Epoch targetEpoch = slashingProposer.getSlashTargetEpoch(earlyRound, i);
+      if (Epoch.unwrap(targetEpoch) <= 1) {
+        assertEq(committees[i].length, 0, "Committee for early epochs should be empty");
+      }
+      // For epochs > 1, we might get actual committees, but that depends on the test setup
+    }
+  }
 }


### PR DESCRIPTION
The `slash_veto_demo` e2e test was failing since a view-like call to the contract to get the committees slashed for a given round reverted:

```
21:15:59   ● veto slash › vetoes true and sets the new tally slasher
21:15:59 
21:15:59     ContractFunctionExecutionError: The contract function "getSlashTargetCommittees" reverted.
21:15:59 
21:15:59     Error: ValidatorSelection__InsufficientValidatorSetSize(uint256 actual, uint256 expected)
21:15:59                                                            (0, 4)
21:15:59      
21:15:59     Contract Call:
21:15:59       address:   0x9debab8762554f8b8f5dfad92e40c1c7d2b0263a
21:15:59       function:  getSlashTargetCommittees(uint256 _round)
21:15:59       args:                              (3)
21:15:59       sender:    0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
21:15:59 
21:15:59     Docs: https://viem.sh/docs/contract/simulateContract
21:15:59     Version: viem@2.23.7
21:15:59 
21:15:59       71 |     }
21:15:59       72 |     /** Returns the slash actions and payload address for a given round (zero if no slash actions) */ async getPayload(round) {
21:15:59     > 73 |         const { result: committees } = await this.contract.simulate.getSlashTargetCommittees([
21:15:59          |                                        ^
21:15:59       74 |             round
21:15:59       75 |         ]);
21:15:59       76 |         const tally = await this.contract.read.getTally([
21:15:59 
21:15:59       at getContractError (../../node_modules/viem/utils/errors/getContractError.ts:78:10)
21:15:59       at simulateContract (../../node_modules/viem/actions/public/simulateContract.ts:308:11)
21:15:59       at TallySlashingProposerContract.getPayload (../../ethereum/dest/contracts/tally_slashing_proposer.js:73:40)
21:15:59       at e2e_p2p/slash_veto_demo.test.ts:247:40
21:15:59       at retryUntil (../../foundation/dest/retry/index.js:84:24)
21:15:59       at e2e_p2p/slash_veto_demo.test.ts:310:32
21:15:59 
21:15:59     Cause:
21:15:59     ContractFunctionRevertedError: The contract function "getSlashTargetCommittees" reverted.
21:15:59 
21:15:59     Error: ValidatorSelection__InsufficientValidatorSetSize(uint256 actual, uint256 expected)
21:15:59                                                            (0, 4)
```

My guess is this happened because the round queried included early epochs where the committee had not yet been formed, so one of the calls to the rollup to get the committee failed, causing the entire call to fail even if other epochs in the round did have committees.

This PR fixes the L1 contract so it try/catches calls to the rollup and returns whatever committees _could_ be fetched.