### PR TITLE
fix: improve polynomial structuring in translator and fix bug

### DIFF
--- a/barretenberg/cpp/src/barretenberg/relations/translator_vm/translator_extra_relations_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/translator_vm/translator_extra_relations_impl.hpp
@@ -123,8 +123,8 @@ void TranslatorAccumulatorTransferRelationImpl<FF>::accumulate(ContainerOverSubr
     // Lagrange ensuring the accumulator result is validated at the correct row
     auto lagrange_result_row = View(in.lagrange_result_row);
 
-    // Lagrange at index (size of minicircuit without masking - 1) is used to enforce that the accumulator is
-    // initialized to zero in the circuit
+    // Lagrange at index (size of minicircuit without masking - 1) is used to enforce that the accumulator starts from
+    // zero
     auto lagrange_last_in_minicircuit = View(in.lagrange_last_in_minicircuit);
 
     // Locations of randomness in the minicircuit

--- a/barretenberg/cpp/src/barretenberg/relations/translator_vm/translator_extra_relations_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/translator_vm/translator_extra_relations_impl.hpp
@@ -123,8 +123,8 @@ void TranslatorAccumulatorTransferRelationImpl<FF>::accumulate(ContainerOverSubr
     // Lagrange ensuring the accumulator result is validated at the correct row
     auto lagrange_result_row = View(in.lagrange_result_row);
 
-    // Lagrange at index (size of minicircuit - 1) is used to enforce that the accumulator is initialized to zero in
-    // the circuit
+    // Lagrange at index (size of minicircuit without masking - 1) is used to enforce that the accumulator is
+    // initialized to zero in the circuit
     auto lagrange_last_in_minicircuit = View(in.lagrange_last_in_minicircuit);
 
     // Locations of randomness in the minicircuit

--- a/barretenberg/cpp/src/barretenberg/translator_vm/translator_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/translator_flavor.hpp
@@ -67,6 +67,9 @@ class TranslatorFlavor {
     // Log of size of interleaved_* and ordered_* polynomials
     static constexpr size_t CONST_TRANSLATOR_LOG_N = LOG_MINI_CIRCUIT_SIZE + numeric::get_msb(INTERLEAVING_GROUP_SIZE);
 
+    // For the translator, the genuine and virtual log circuit size coincide
+    static constexpr size_t VIRTUAL_LOG_N = CONST_TRANSLATOR_LOG_N;
+
     static constexpr size_t MINI_CIRCUIT_SIZE = 1UL << LOG_MINI_CIRCUIT_SIZE;
 
     // The number of interleaved_* wires

--- a/barretenberg/cpp/src/barretenberg/translator_vm/translator_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/translator_flavor.hpp
@@ -67,9 +67,6 @@ class TranslatorFlavor {
     // Log of size of interleaved_* and ordered_* polynomials
     static constexpr size_t CONST_TRANSLATOR_LOG_N = LOG_MINI_CIRCUIT_SIZE + numeric::get_msb(INTERLEAVING_GROUP_SIZE);
 
-    // For the translator, the genuine and virtual log circuit size coincide
-    static constexpr size_t VIRTUAL_LOG_N = CONST_TRANSLATOR_LOG_N;
-
     static constexpr size_t MINI_CIRCUIT_SIZE = 1UL << LOG_MINI_CIRCUIT_SIZE;
 
     // The number of interleaved_* wires
@@ -89,6 +86,9 @@ class TranslatorFlavor {
     // Number of random ops found at he end of Translator trace multiplied by 2 as each accumulation gates occupies two
     // rows.
     static constexpr size_t NUM_MASKED_ROWS_END = CircuitBuilder::NUM_RANDOM_OPS_END * 2;
+
+    // Index at which random coefficients start (for zk) within Translator trace
+    static constexpr size_t RANDOMNESS_START = 2 * CircuitBuilder::NUM_NO_OPS_START;
 
     // The bitness of the range constraint
     static constexpr size_t MICRO_LIMB_BITS = CircuitBuilder::MICRO_LIMB_BITS;
@@ -367,8 +367,6 @@ class TranslatorFlavor {
                                WireToBeShiftedEntities<DataType>::get_all());
         };
 
-        auto get_wires_to_be_shifted() { return WireToBeShiftedEntities<DataType>::get_all(); };
-
         /**
          * @brief Witness Entities to which the prover commits and do not require challenges (i.e. not derived).
          */
@@ -603,7 +601,7 @@ class TranslatorFlavor {
       public:
         DEFINE_COMPOUND_GET_ALL(PrecomputedEntities<DataType>, WitnessEntities<DataType>, ShiftedEntities<DataType>)
 
-        auto get_precomputed() const { return PrecomputedEntities<DataType>::get_all(); };
+        auto get_precomputed() { return PrecomputedEntities<DataType>::get_all(); };
 
         /**
          * @brief Getter for entities constructed by interleaving
@@ -616,7 +614,7 @@ class TranslatorFlavor {
          */
         auto get_ordered_range_constraints() { return OrderedRangeConstraints<DataType>::get_all(); };
 
-        auto get_unshifted()
+        auto get_unshifted() const
         {
             return concatenate(PrecomputedEntities<DataType>::get_all(), WitnessEntities<DataType>::get_unshifted());
         }
@@ -666,6 +664,7 @@ class TranslatorFlavor {
         {
 
             const size_t circuit_size = 1 << CONST_TRANSLATOR_LOG_N;
+            const size_t circuit_size_without_masking = circuit_size - NUM_MASKED_ROWS_END * INTERLEAVING_GROUP_SIZE;
             for (auto& ordered_range_constraint : get_ordered_range_constraints()) {
                 ordered_range_constraint = Polynomial{ /*size*/ circuit_size - 1,
                                                        /*largest possible index*/ circuit_size,
@@ -679,6 +678,8 @@ class TranslatorFlavor {
                                  /*virtual_size*/ circuit_size,
                                  /*start_index*/ 1 };
 
+            op = Polynomial{ MINI_CIRCUIT_SIZE, circuit_size };
+
             // All to_be_shifted witnesses except the ordered range constraints and z_perm are only non-zero in the mini
             // circuit
             for (auto& poly : get_to_be_shifted()) {
@@ -689,18 +690,33 @@ class TranslatorFlavor {
                 }
             }
 
-            // Initialize some one-off polys with special structure
+            // Initialize lagrange polynomialso and the ordered extra range constraints numerator (the precomputed
+            // polynomials) within the appropriate range they operate on
             lagrange_first = Polynomial{ /*size*/ 1, /*virtual_size*/ circuit_size };
-            lagrange_result_row = Polynomial{ /*size*/ RESULT_ROW + 1, /*virtual_size*/ circuit_size };
-            lagrange_even_in_minicircuit = Polynomial{ /*size*/ MINI_CIRCUIT_SIZE, /*virtual_size*/ circuit_size };
-            lagrange_odd_in_minicircuit = Polynomial{ /*size*/ MINI_CIRCUIT_SIZE, /*virtual_size*/ circuit_size };
+            lagrange_result_row = Polynomial{ /*size*/ 1, /*virtual_size*/ circuit_size, /*start_index*/ RESULT_ROW };
+            lagrange_even_in_minicircuit = Polynomial{ /*size*/ MINI_CIRCUIT_SIZE - RESULT_ROW,
+                                                       /*virtual_size*/ circuit_size,
+                                                       /*start_index=*/RESULT_ROW };
+            lagrange_odd_in_minicircuit = Polynomial{ /*size*/ MINI_CIRCUIT_SIZE - RESULT_ROW - 1,
+                                                      /*virtual_size*/ circuit_size,
+                                                      /*start_index=*/RESULT_ROW + 1 };
+            lagrange_last_in_minicircuit = Polynomial{ /*size*/ MINI_CIRCUIT_SIZE,
+                                                       /*virtual_size*/ circuit_size };
+            lagrange_mini_masking = Polynomial{ /*size*/ MINI_CIRCUIT_SIZE - RANDOMNESS_START,
+                                                /*virtual_size*/ circuit_size,
+                                                /*start_index=*/RANDOMNESS_START };
+            lagrange_masking = Polynomial{ /*size*/ circuit_size - circuit_size_without_masking,
+                                           /*virtual_size*/ circuit_size,
+                                           /*start_index*/ circuit_size_without_masking };
+            lagrange_last = Polynomial{ /*size*/ 1,
+                                        /*virtual_size*/ circuit_size,
+                                        /*start_index*/ circuit_size - 1 };
+            lagrange_real_last = Polynomial{ /*size*/ 1,
+                                             /*virtual_size*/ circuit_size,
+                                             /*start_index*/ circuit_size_without_masking - 1 };
+            ordered_extra_range_constraints_numerator =
+                Polynomial{ SORTED_STEPS_COUNT * (NUM_INTERLEAVED_WIRES + 1), circuit_size };
 
-            for (auto& poly : get_unshifted()) {
-                if (poly.is_empty()) {
-                    // Not set above
-                    poly = Polynomial{ circuit_size };
-                }
-            }
             set_shifted();
         }
         ProverPolynomials& operator=(const ProverPolynomials&) = delete;
@@ -708,7 +724,7 @@ class TranslatorFlavor {
         ProverPolynomials(ProverPolynomials&& o) noexcept = default;
         ProverPolynomials& operator=(ProverPolynomials&& o) noexcept = default;
         ~ProverPolynomials() = default;
-        [[nodiscard]] size_t get_polynomial_size() const { return this->op.size(); }
+        [[nodiscard]] static size_t get_polynomial_size() { return 1UL << CONST_TRANSLATOR_LOG_N; }
         /**
          * @brief Returns the evaluations of all prover polynomials at one point on the boolean
          * hypercube, which represents one row in the execution trace.
@@ -924,11 +940,12 @@ class TranslatorFlavor {
             this->ordered_range_constraints_2 = "ORDERED_RANGE_CONSTRAINTS_2";
             this->ordered_range_constraints_3 = "ORDERED_RANGE_CONSTRAINTS_3";
             this->ordered_range_constraints_4 = "ORDERED_RANGE_CONSTRAINTS_4";
+            this->z_perm = "Z_PERM";
             this->interleaved_range_constraints_0 = "INTERLEAVED_RANGE_CONSTRAINTS_0";
             this->interleaved_range_constraints_1 = "INTERLEAVED_RANGE_CONSTRAINTS_1";
             this->interleaved_range_constraints_2 = "INTERLEAVED_RANGE_CONSTRAINTS_2";
             this->interleaved_range_constraints_3 = "INTERLEAVED_RANGE_CONSTRAINTS_3";
-            this->z_perm = "Z_PERM";
+
             // "__" are only used for debugging
             this->lagrange_first = "__LAGRANGE_FIRST";
             this->lagrange_last = "__LAGRANGE_LAST";

--- a/barretenberg/cpp/src/barretenberg/translator_vm/translator_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/translator_flavor.hpp
@@ -601,7 +601,7 @@ class TranslatorFlavor {
       public:
         DEFINE_COMPOUND_GET_ALL(PrecomputedEntities<DataType>, WitnessEntities<DataType>, ShiftedEntities<DataType>)
 
-        auto get_precomputed() { return PrecomputedEntities<DataType>::get_all(); };
+        auto get_precomputed() const { return PrecomputedEntities<DataType>::get_all(); };
 
         /**
          * @brief Getter for entities constructed by interleaving

--- a/barretenberg/cpp/src/barretenberg/translator_vm/translator_proving_key.cpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/translator_proving_key.cpp
@@ -246,7 +246,7 @@ void TranslatorProvingKey::compute_lagrange_polynomials()
         proving_key->polynomials.lagrange_masking.at(i) = 1;
     }
 
-    for (size_t i = Flavor::CircuitBuilder::NUM_NO_OPS_START * 2; i < Flavor::RESULT_ROW; i++) {
+    for (size_t i = Flavor::RANDOMNESS_START; i < Flavor::RESULT_ROW; i++) {
         proving_key->polynomials.lagrange_mini_masking.at(i) = 1;
     }
 


### PR DESCRIPTION
In ths PR:
* improve polynomial structuring in Translator 
* fix https://github.com/AztecProtocol/barretenberg/issues/1416 - TL;DR we should only ever have to define the `op` polynomial on the `MINI_CIRCUIT_SIZE` but that was causing `TranslatorPermutationRelation` to fail, which doesn't even use the `op` polynomial. The issue: `get_polynomial_size()` was returning the size of the op polynomial and was used in the computation of the grand product polynomial (which is supposed to be defined on the full Translator size `MINI_CIRCUIT_SIZE * INTERLEAVING_GROUP_SIZE`)
* update some relation correctness tests that were stale to work with lagrange polynomials being initialised only where they should  be