### PR TITLE
fix: unbounded lock delay

### DIFF
--- a/l1-contracts/src/governance/libraries/ConfigurationLib.sol
+++ b/l1-contracts/src/governance/libraries/ConfigurationLib.sol
@@ -23,7 +23,7 @@ library ConfigurationLib {
   uint256 internal constant LOCK_AMOUNT_UPPER = type(uint96).max; // Maximum for compressed storage (uint96)
 
   Timestamp internal constant TIME_LOWER = Timestamp.wrap(60);
-  Timestamp internal constant TIME_UPPER = Timestamp.wrap(30 * 24 * 3600);
+  Timestamp internal constant TIME_UPPER = Timestamp.wrap(90 * 24 * 3600);
 
   /**
    * @notice The delay after which a withdrawal can be finalized.
@@ -66,12 +66,13 @@ library ConfigurationLib {
     );
 
     // Beyond checking the bounds like this, it might be useful to ensure that the value is larger than the withdrawal
-    // delay
-    // this, can be useful if one want to ensure that the "locker" cannot himself vote in the proposal, but as it is
-    // unclear
-    // if this is a useful property, it is not enforced.
+    // delay. this, can be useful if one want to ensure that the "locker" cannot himself vote in the proposal, but as
+    // it is unclear if this is a useful property, it is not enforced.
     require(_self.proposeConfig.lockDelay >= TIME_LOWER, Errors.Governance__ConfigurationLib__TimeTooSmall("LockDelay"));
-    require(_self.proposeConfig.lockDelay <= TIME_UPPER, Errors.Governance__ConfigurationLib__TimeTooBig("LockDelay"));
+    require(
+      _self.proposeConfig.lockDelay <= Timestamp.wrap(type(uint32).max),
+      Errors.Governance__ConfigurationLib__TimeTooBig("LockDelay")
+    );
 
     require(_self.votingDelay >= TIME_LOWER, Errors.Governance__ConfigurationLib__TimeTooSmall("VotingDelay"));
     require(_self.votingDelay <= TIME_UPPER, Errors.Governance__ConfigurationLib__TimeTooBig("VotingDelay"));

--- a/l1-contracts/test/governance/governance/updateConfiguration.t.sol
+++ b/l1-contracts/test/governance/governance/updateConfiguration.t.sol
@@ -85,8 +85,7 @@ contract UpdateConfigurationTest is GovernanceBase {
     vm.prank(address(governance));
     governance.updateConfiguration(config);
 
-    config.proposeConfig.lockDelay =
-      Timestamp.wrap(bound(_val, Timestamp.unwrap(ConfigurationLib.TIME_UPPER) + 1, type(uint256).max));
+    config.proposeConfig.lockDelay = Timestamp.wrap(uint256(type(uint32).max) + 1);
     vm.expectRevert(abi.encodeWithSelector(Errors.Governance__ConfigurationLib__TimeTooBig.selector, "LockDelay"));
     vm.prank(address(governance));
     governance.updateConfiguration(config);


### PR DESCRIPTION
Alters configuration limits used in the Governance!

Allow values up to 90 days for most values, but up to `uint32` for the lock delay.