### PR TITLE
chore: betas optimization - 2^d multiplications

### DIFF
--- a/barretenberg/cpp/src/barretenberg/polynomials/gate_separator.hpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/gate_separator.hpp
@@ -8,6 +8,7 @@
 #include "barretenberg/common/bb_bench.hpp"
 #include "barretenberg/common/compiler_hints.hpp"
 #include "barretenberg/common/thread.hpp"
+#include "barretenberg/numeric/bitop/get_msb.hpp"
 #include "barretenberg/stdlib/primitives/bool/bool.hpp"
 
 #include <cstddef>
@@ -158,21 +159,29 @@ template <typename FF> struct GateSeparatorPolynomial {
         num_threads = num_threads > 0 ? num_threads : 1;                     // ensure num threads is >= 1
         size_t iterations_per_thread = pow_size / num_threads;               // actual iterations per thread
 
-        // TODO(https://github.com/AztecProtocol/barretenberg/issues/864): This computation is asymtotically slow as it
-        // does pow_size * log(pow_size) work. However, in practice, its super efficient because its trivially
-        // parallelizable and only takes 45ms for the whole 6 iter IVC benchmark. Its also very readable, so we're
-        // leaving it unoptimized for now.
+        std::vector<FF> thread_init_beta_products;
+        thread_init_beta_products.resize(num_threads);
+
+        thread_init_beta_products.at(0) = 1;
+
+        for (size_t beta_idx = numeric::get_msb(iterations_per_thread), window_size = 1; beta_idx < log_num_monomials;
+             beta_idx++) {
+            for (size_t j = 0; j < window_size; j++) {
+                thread_init_beta_products.at(window_size + j) = betas.at(beta_idx) * thread_init_beta_products.at(j);
+            }
+            window_size <<= 1;
+        }
+
         parallel_for(num_threads, [&](size_t thread_idx) {
             size_t start = thread_idx * iterations_per_thread;
-            size_t end = (thread_idx + 1) * iterations_per_thread;
-            for (size_t i = start; i < end; i++) {
-                auto res = FF(1);
-                for (size_t j = i, beta_idx = 0; j > 0; j >>= 1, beta_idx++) {
-                    if ((j & 1) == 1) {
-                        res *= betas[beta_idx];
-                    }
+            size_t num_betas = numeric::get_msb(iterations_per_thread);
+            beta_products.at(start) = thread_init_beta_products.at(thread_idx);
+
+            for (size_t beta_idx = 0, window_size = 1; beta_idx < num_betas; beta_idx++) {
+                for (size_t j = 0; j < window_size; j++) {
+                    beta_products.at(start + window_size + j) = betas.at(beta_idx) * beta_products.at(start + j);
                 }
-                beta_products[i] = res;
+                window_size <<= 1;
             }
         });
 

--- a/barretenberg/cpp/src/barretenberg/polynomials/gate_separator.hpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/gate_separator.hpp
@@ -160,21 +160,55 @@ template <typename FF> struct GateSeparatorPolynomial {
         size_t iterations_per_thread = pow_size / num_threads;               // actual iterations per thread
         const size_t num_betas_per_thread = numeric::get_msb(iterations_per_thread);
 
-        std::vector<FF> thread_init_beta_products(num_threads);
-        thread_init_beta_products.at(0) = 1;
+        // Explanations of the algorithm:
+        // The product of the betas at index i (beta_products[i]) contains the multiplicative factor betas[j] if and
+        // only if the jth bit of i is 1 (j starting with 0 for the least significant bit). For instance, i = 13 = 1101
+        // in binary, so the product is betas[0] * betas[2] * betas[3]. Observe that if we toggle the kth bit of i (0 to
+        // 1), i.e., we add 2^k to i, then the product is multiplied by betas[k]: beta_products[i + 2^k] =
+        // beta_products[i] * betas[k]. If we know the products for the interval of indices [0, 2^k), we can compute all
+        // the products for the interval of indices [2^k, 2^(k+1)) by multiplying each element by betas[k]. Iteratively,
+        // starting with beta_products[0] = 1, we can double the number of computed products at each iteration by
+        // multiplying the previous products by betas[k]. We first multiply beta_products[0] = 1 by betas[0], then we
+        // multiply beta_products[0] and beta_products[1] by betas[1], etc...
+        //
+        // We distribute the computation of the beta_products evenly across threads, i.e., thread number
+        // thread_idx will handle the interval of indices [thread_idx * iterations_per_thread, (thread_idx + 1) *
+        // iterations_per_thread). Note that for a given thread, all the processed indices have the same
+        // prefix in binary. Therefore, each beta_product of the thread is a multiple of this "prefix product". The
+        // successive products are then by the above algorithm whereby we double the interval at each iteration
+        // and multiply by the new beta to process the suffix bits. The difference is that we initialize the first
+        // product with this "prefix product" instead of 1.
 
+        // Compute the prefix products for each thread
+        std::vector<FF> thread_prefix_beta_products(num_threads);
+        thread_prefix_beta_products.at(0) = 1;
+
+        // Same algorithm applies for the prefix products. The difference is that we start at a beta which is not the
+        // first one (index 0), but the one at index num_betas_per_thread. We process the high bits only.
+        // Example: If num_betas_per_thread = 3, we compute after the first iteration:
+        //          (1, beta_3)
+        // 2nd iteration: (1, beta_3, beta_4, beta_3 * beta_4)
+        // 3nd iteration: (1, beta_3, beta_4, beta_3 * beta_4, beta_5, beta_3 * beta_5, beta_4 * beta_5, beta_3 * beta_4
+        // * beta_5)
+        // etc ....
         for (size_t beta_idx = num_betas_per_thread, window_size = 1; beta_idx < log_num_monomials;
              beta_idx++, window_size <<= 1) {
             const auto& beta = betas.at(beta_idx);
             for (size_t j = 0; j < window_size; j++) {
-                thread_init_beta_products.at(window_size + j) = beta * thread_init_beta_products.at(j);
+                thread_prefix_beta_products.at(window_size + j) = beta * thread_prefix_beta_products.at(j);
             }
         }
 
         parallel_for(num_threads, [&](size_t thread_idx) {
             size_t start = thread_idx * iterations_per_thread;
-            beta_products.at(start) = thread_init_beta_products.at(thread_idx);
+            beta_products.at(start) = thread_prefix_beta_products.at(thread_idx);
 
+            // Compute the suffix products for each thread
+            // Example: Assume we start with the prefix product = beta_3 * beta_5
+            // After the first iteration, we get: (beta_3 * beta_5, beta_0 * beta_3 * beta_5)
+            // 2nd iteration: (beta_3 * beta_5, beta_0 * beta_3 * beta_5, beta_1 * beta_3 * beta_5, beta_0 * beta_1 *
+            // beta_3 * beta_5)
+            // etc ...
             for (size_t beta_idx = 0, window_size = 1; beta_idx < num_betas_per_thread; beta_idx++, window_size <<= 1) {
                 const auto& beta = betas.at(beta_idx);
                 for (size_t j = 0; j < window_size; j++) {

--- a/barretenberg/cpp/src/barretenberg/polynomials/gate_separator.hpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/gate_separator.hpp
@@ -158,30 +158,28 @@ template <typename FF> struct GateSeparatorPolynomial {
         size_t num_threads = std::min(desired_num_threads, max_num_threads); // fewer than max if justified
         num_threads = num_threads > 0 ? num_threads : 1;                     // ensure num threads is >= 1
         size_t iterations_per_thread = pow_size / num_threads;               // actual iterations per thread
+        const size_t num_betas_per_thread = numeric::get_msb(iterations_per_thread);
 
-        std::vector<FF> thread_init_beta_products;
-        thread_init_beta_products.resize(num_threads);
-
+        std::vector<FF> thread_init_beta_products(num_threads);
         thread_init_beta_products.at(0) = 1;
 
-        for (size_t beta_idx = numeric::get_msb(iterations_per_thread), window_size = 1; beta_idx < log_num_monomials;
-             beta_idx++) {
+        for (size_t beta_idx = num_betas_per_thread, window_size = 1; beta_idx < log_num_monomials;
+             beta_idx++, window_size <<= 1) {
+            const auto& beta = betas.at(beta_idx);
             for (size_t j = 0; j < window_size; j++) {
-                thread_init_beta_products.at(window_size + j) = betas.at(beta_idx) * thread_init_beta_products.at(j);
+                thread_init_beta_products.at(window_size + j) = beta * thread_init_beta_products.at(j);
             }
-            window_size <<= 1;
         }
 
         parallel_for(num_threads, [&](size_t thread_idx) {
             size_t start = thread_idx * iterations_per_thread;
-            size_t num_betas = numeric::get_msb(iterations_per_thread);
             beta_products.at(start) = thread_init_beta_products.at(thread_idx);
 
-            for (size_t beta_idx = 0, window_size = 1; beta_idx < num_betas; beta_idx++) {
+            for (size_t beta_idx = 0, window_size = 1; beta_idx < num_betas_per_thread; beta_idx++, window_size <<= 1) {
+                const auto& beta = betas.at(beta_idx);
                 for (size_t j = 0; j < window_size; j++) {
-                    beta_products.at(start + window_size + j) = betas.at(beta_idx) * beta_products.at(start + j);
+                    beta_products.at(start + window_size + j) = beta * beta_products.at(start + j);
                 }
-                window_size <<= 1;
             }
         });
 

--- a/barretenberg/cpp/src/barretenberg/polynomials/gate_separator.hpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/gate_separator.hpp
@@ -175,9 +175,9 @@ template <typename FF> struct GateSeparatorPolynomial {
         // thread_idx will handle the interval of indices [thread_idx * iterations_per_thread, (thread_idx + 1) *
         // iterations_per_thread). Note that for a given thread, all the processed indices have the same
         // prefix in binary. Therefore, each beta_product of the thread is a multiple of this "prefix product". The
-        // successive products are then by the above algorithm whereby we double the interval at each iteration
-        // and multiply by the new beta to process the suffix bits. The difference is that we initialize the first
-        // product with this "prefix product" instead of 1.
+        // successive products are then populated by the above algorithm whereby we double the interval at each
+        // iteration and multiply by the new beta to process the suffix bits. The difference is that we initialize the
+        // first product with this "prefix product" instead of 1.
 
         // Compute the prefix products for each thread
         std::vector<FF> thread_prefix_beta_products(num_threads);

--- a/barretenberg/cpp/src/barretenberg/sumcheck/sumcheck.hpp
+++ b/barretenberg/cpp/src/barretenberg/sumcheck/sumcheck.hpp
@@ -519,7 +519,7 @@ template <typename Flavor> class SumcheckProver {
             // virtually zeroize any leftover values beyond the limit (in-place computation).
             // This is important to zeroize leftover values to not mess up with compute_univariate().
             // Note that the virtual size of pep_view[j] remains unchanged.
-            pep_view[j].shrink_end_index(limit / 2 + limit % 2);
+            pep_view[j].shrink_end_index((limit / 2) + (limit % 2));
         });
     };
     /**
@@ -544,7 +544,7 @@ template <typename Flavor> class SumcheckProver {
             // virtually zeroize any leftover values beyond the limit (in-place computation).
             // This is important to zeroize leftover values to not mess up with compute_univariate().
             // Note that the virtual size of pep_view[j] remains unchanged.
-            pep_view[j].shrink_end_index(limit / 2 + limit % 2);
+            pep_view[j].shrink_end_index((limit / 2) + (limit % 2));
         });
     };
 

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/flavor.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/flavor.cpp
@@ -87,7 +87,7 @@ AvmFlavor::PartiallyEvaluatedMultivariates::PartiallyEvaluatedMultivariates(cons
 {
     for (auto [poly, full_poly] : zip_view(get_all(), full_polynomials.get_all())) {
         // After the initial sumcheck round, the new size is CEIL(size/2).
-        size_t desired_size = full_poly.end_index() / 2 + full_poly.end_index() % 2;
+        size_t desired_size = (full_poly.end_index() / 2) + (full_poly.end_index() % 2);
         poly = Polynomial(desired_size, circuit_size / 2);
     }
 }


### PR DESCRIPTION
With 16 cores for the avm trace (2^21), the time goes from ca. 80 ms to 37 ms.
For a trace of size 2^24, timing goes from 600 ms to 280ms.

Relevant issue [#864](https://github.com/AztecProtocol/barretenberg/issues/864) 