### PR TITLE
refactor(bb): thread chunk for better work distribution

### DIFF
--- a/barretenberg/cpp/scripts/bench_cpu_scaling_remote.sh
+++ b/barretenberg/cpp/scripts/bench_cpu_scaling_remote.sh
@@ -127,6 +127,9 @@ for cpu_count in "${CPU_COUNTS[@]}"; do
     echo -e "${CYAN}Executing on remote via benchmark_remote.sh...${NC}"
     start_time=$(date +%s.%N)
 
+    # Clean up any stale benchmark file from previous runs on remote
+    ssh $BB_SSH_KEY $BB_SSH_INSTANCE "rm -f /tmp/bench_${cpu_count}.json" 2>/dev/null
+
     # Use benchmark_remote.sh to execute on remote with --bench_out for JSON output
     # The benchmark_remote.sh script handles locking and setup
     # Use tee to show output in real-time AND save to log file
@@ -135,6 +138,9 @@ for cpu_count in "${CPU_COUNTS[@]}"; do
     
     # Retrieve the JSON file from remote
     ssh $BB_SSH_KEY $BB_SSH_INSTANCE "cat /tmp/bench_${cpu_count}.json" > "$bench_json_file" 2>/dev/null
+    
+    # Clean up the remote benchmark file after retrieval
+    ssh $BB_SSH_KEY $BB_SSH_INSTANCE "rm -f /tmp/bench_${cpu_count}.json" 2>/dev/null
 
     end_time=$(date +%s.%N)
     wall_time=$(awk -v e="$end_time" -v s="$start_time" 'BEGIN{printf "%.2f", e-s}')
@@ -289,5 +295,9 @@ if [ "${#ALL_SPEEDUPS[@]}" -gt 1 ]; then
         echo -e "  At ${last_cpu} CPUs: ${actual_efficiency}% efficiency"
     fi
 fi
+
+# Clean up all temporary benchmark files on remote
+echo -e "${CYAN}Cleaning up remote temporary files...${NC}"
+ssh $BB_SSH_KEY $BB_SSH_INSTANCE "rm -f /tmp/bench_*.json" 2>/dev/null
 
 echo ""

--- a/barretenberg/cpp/scripts/bench_cpu_scaling_remote.sh
+++ b/barretenberg/cpp/scripts/bench_cpu_scaling_remote.sh
@@ -222,9 +222,9 @@ for i in "${!ALL_CPUS[@]}"; do
         color="${GREEN}"
     else
         eff_val=$(echo "$efficiency" | sed 's/%//')
-        if (( $(echo "$eff_val > 75" | bc -l) )); then
+        if awk -v eff="$eff_val" 'BEGIN {exit !(eff > 75)}'; then
             color="${GREEN}"
-        elif (( $(echo "$eff_val > 50" | bc -l) )); then
+        elif awk -v eff="$eff_val" 'BEGIN {exit !(eff > 50)}'; then
             color="${YELLOW}"
         else
             color="${RED}"
@@ -277,11 +277,11 @@ if [ "${#ALL_SPEEDUPS[@]}" -gt 1 ]; then
     last_cpu="${ALL_CPUS[-1]}"
     actual_efficiency=$(awk -v sp="$last_speedup" -v cpus="$last_cpu" 'BEGIN{printf "%.1f", (sp / cpus) * 100}')
 
-    if (( $(echo "$actual_efficiency < 50" | bc -l) )); then
+    if awk -v eff="$actual_efficiency" 'BEGIN {exit !(eff < 50)}'; then
         echo -e "${YELLOW}⚠ Warning: Poor scaling detected!${NC}"
         echo -e "  At ${last_cpu} CPUs: ${actual_efficiency}% efficiency"
         echo -e "  Consider investigating thread contention or memory bottlenecks."
-    elif (( $(echo "$actual_efficiency < 75" | bc -l) )); then
+    elif awk -v eff="$actual_efficiency" 'BEGIN {exit !(eff < 75)}'; then
         echo -e "${YELLOW}Note: Moderate scaling efficiency at high CPU counts.${NC}"
         echo -e "  At ${last_cpu} CPUs: ${actual_efficiency}% efficiency"
     else

--- a/barretenberg/cpp/src/barretenberg/polynomials/polynomial.cpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/polynomial.cpp
@@ -280,27 +280,15 @@ template <typename Fr> Polynomial<Fr>& Polynomial<Fr>::operator-=(PolynomialSpan
 
 template <typename Fr> Polynomial<Fr>& Polynomial<Fr>::operator*=(const Fr scaling_factor)
 {
-    const size_t num_threads = calculate_num_threads(size());
-    const size_t range_per_thread = size() / num_threads;
-    const size_t leftovers = size() - (range_per_thread * num_threads);
-    parallel_for(num_threads, [&](size_t j) {
-        const size_t offset = j * range_per_thread;
-        const size_t end = (j == num_threads - 1) ? offset + range_per_thread + leftovers : offset + range_per_thread;
-        for (size_t i = offset; i < end; ++i) {
-            data()[i] *= scaling_factor;
-        }
-    });
-
+    parallel_for([scaling_factor, this](const ThreadChunk& chunk) { multiply_chunk(chunk, scaling_factor); });
     return *this;
 }
 
-template <typename Fr> Polynomial<Fr>& Polynomial<Fr>::multiply_chunk(const ThreadChunk& chunk, const Fr scaling_factor)
+template <typename Fr> void Polynomial<Fr>::multiply_chunk(const ThreadChunk& chunk, const Fr scaling_factor)
 {
     for (size_t i : chunk.range(size())) {
         data()[i] *= scaling_factor;
     }
-
-    return *this;
 }
 
 template <typename Fr> Polynomial<Fr> Polynomial<Fr>::create_non_parallel_zero_init(size_t size, size_t virtual_size)
@@ -345,16 +333,16 @@ template <typename Fr> void Polynomial<Fr>::add_scaled(PolynomialSpan<const Fr> 
 {
     BB_ASSERT_LTE(start_index(), other.start_index);
     BB_ASSERT_GTE(end_index(), other.end_index());
-    const size_t num_threads = calculate_num_threads(other.size());
-    const size_t range_per_thread = other.size() / num_threads;
-    const size_t leftovers = other.size() - (range_per_thread * num_threads);
-    parallel_for(num_threads, [&](size_t j) {
-        const size_t offset = j * range_per_thread + other.start_index;
-        const size_t end = (j == num_threads - 1) ? offset + range_per_thread + leftovers : offset + range_per_thread;
-        for (size_t i = offset; i < end; ++i) {
-            at(i) += scaling_factor * other[i];
-        }
-    });
+    parallel_for(
+        [&other, scaling_factor, this](const ThreadChunk& chunk) { add_scaled_chunk(chunk, other, scaling_factor); });
+}
+
+template <typename Fr>
+void Polynomial<Fr>::add_scaled_chunk(const ThreadChunk& chunk, PolynomialSpan<const Fr> other, Fr scaling_factor) &
+{
+    for (size_t i : chunk.range(other.size())) {
+        at(i) += scaling_factor * other[i];
+    }
 }
 
 template <typename Fr> Polynomial<Fr> Polynomial<Fr>::shifted() const

--- a/barretenberg/cpp/src/barretenberg/polynomials/polynomial.cpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/polynomial.cpp
@@ -341,7 +341,8 @@ template <typename Fr>
 void Polynomial<Fr>::add_scaled_chunk(const ThreadChunk& chunk, PolynomialSpan<const Fr> other, Fr scaling_factor) &
 {
     for (size_t i : chunk.range(other.size())) {
-        at(i) += scaling_factor * other[i];
+        size_t actual_index = other.start_index + i;
+        at(actual_index) += scaling_factor * other[actual_index];
     }
 }
 

--- a/barretenberg/cpp/src/barretenberg/polynomials/polynomial.cpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/polynomial.cpp
@@ -340,9 +340,10 @@ template <typename Fr> void Polynomial<Fr>::add_scaled(PolynomialSpan<const Fr> 
 template <typename Fr>
 void Polynomial<Fr>::add_scaled_chunk(const ThreadChunk& chunk, PolynomialSpan<const Fr> other, Fr scaling_factor) &
 {
-    for (size_t i : chunk.range(other.size())) {
-        size_t actual_index = other.start_index + i;
-        at(actual_index) += scaling_factor * other[actual_index];
+    // Iterate over the chunk of the other polynomial's range
+    for (size_t offset : chunk.range(other.size())) {
+        size_t index = other.start_index + offset;
+        at(index) += scaling_factor * other[index];
     }
 }
 

--- a/barretenberg/cpp/src/barretenberg/polynomials/polynomial.cpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/polynomial.cpp
@@ -294,6 +294,15 @@ template <typename Fr> Polynomial<Fr>& Polynomial<Fr>::operator*=(const Fr scali
     return *this;
 }
 
+template <typename Fr> Polynomial<Fr>& Polynomial<Fr>::multiply_chunk(const ThreadChunk& chunk, const Fr scaling_factor)
+{
+    for (size_t i : chunk.range(size())) {
+        data()[i] *= scaling_factor;
+    }
+
+    return *this;
+}
+
 template <typename Fr> Polynomial<Fr> Polynomial<Fr>::create_non_parallel_zero_init(size_t size, size_t virtual_size)
 {
     Polynomial p(size, virtual_size, Polynomial<Fr>::DontZeroMemory::FLAG);

--- a/barretenberg/cpp/src/barretenberg/polynomials/polynomial.hpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/polynomial.hpp
@@ -252,6 +252,8 @@ template <typename Fr> class Polynomial {
      */
     void add_scaled(PolynomialSpan<const Fr> other, Fr scaling_factor) &;
 
+    void add_scaled_chunk(const ThreadChunk& chunk, PolynomialSpan<const Fr> other, Fr scaling_factor) &;
+
     /**
      * @brief adds the polynomial q(X) 'other'.
      *
@@ -273,7 +275,7 @@ template <typename Fr> class Polynomial {
      */
     Polynomial& operator*=(Fr scaling_factor);
 
-    Polynomial& multiply_chunk(const ThreadChunk& chunk, Fr scaling_factor);
+    void multiply_chunk(const ThreadChunk& chunk, Fr scaling_factor);
 
     /**
      * @brief Add random values to the coefficients of a polynomial. In practice, this is used for ensuring the

--- a/barretenberg/cpp/src/barretenberg/polynomials/polynomial.hpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/polynomial.hpp
@@ -8,6 +8,7 @@
 #include "barretenberg/common/assert.hpp"
 #include "barretenberg/common/bb_bench.hpp"
 #include "barretenberg/common/mem.hpp"
+#include "barretenberg/common/thread.hpp"
 #include "barretenberg/common/throw_or_abort.hpp"
 #include "barretenberg/common/zip_view.hpp"
 #include "barretenberg/constants.hpp"
@@ -271,6 +272,8 @@ template <typename Fr> class Polynomial {
      * @param scaling_factor s
      */
     Polynomial& operator*=(Fr scaling_factor);
+
+    Polynomial& multiply_chunk(const ThreadChunk& chunk, Fr scaling_factor);
 
     /**
      * @brief Add random values to the coefficients of a polynomial. In practice, this is used for ensuring the

--- a/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover_impl.hpp
@@ -6,6 +6,7 @@
 
 #pragma once
 #include "barretenberg/common/bb_bench.hpp"
+#include "barretenberg/common/thread.hpp"
 #include "barretenberg/honk/relation_checker.hpp"
 #include "barretenberg/protogalaxy/protogalaxy_prover_internal.hpp"
 #include "barretenberg/protogalaxy/prover_verifier_shared.hpp"
@@ -149,10 +150,12 @@ void ProtogalaxyProver_<Flavor, NUM_KEYS>::update_target_sum_and_fold(
         accumulator->set_overflow_size(incoming->get_overflow_size()); // swap overflow size
     }
 
-    // Fold the proving key polynomials
-    for (auto& poly : accumulator->polynomials.get_unshifted()) {
-        poly *= lagranges[0];
-    }
+    parallel_for([&accumulator, &lagranges](const ThreadChunk& chunk) {
+        // Fold the proving key polynomials
+        for (auto& poly : accumulator->polynomials.get_unshifted()) {
+            poly.multiply_chunk(chunk, lagranges[0]);
+        }
+    });
     for (auto [acc_poly, key_poly] :
          zip_view(accumulator->polynomials.get_unshifted(), incoming->polynomials.get_unshifted())) {
         acc_poly.add_scaled(key_poly, lagranges[1]);

--- a/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover_impl.hpp
@@ -150,11 +150,17 @@ void ProtogalaxyProver_<Flavor, NUM_KEYS>::update_target_sum_and_fold(
         accumulator->set_overflow_size(incoming->get_overflow_size()); // swap overflow size
     }
 
+    // Fold the proving key polynomials
+    parallel_for([&accumulator, &lagranges](const ThreadChunk& chunk) {
+        for (auto& poly : accumulator->polynomials.get_unshifted()) {
+            poly.multiply_chunk(chunk, lagranges[0]);
+        }
+    });
+
+    // This cannot be combined with the previous parallel_for because add_scaled_chunk is by the key_poly size
     parallel_for([&accumulator, &lagranges, &incoming](const ThreadChunk& chunk) {
-        // Fold the proving key polynomials
         for (auto [acc_poly, key_poly] :
              zip_view(accumulator->polynomials.get_unshifted(), incoming->polynomials.get_unshifted())) {
-            acc_poly.multiply_chunk(chunk, lagranges[0]);
             acc_poly.add_scaled_chunk(chunk, key_poly, lagranges[1]);
         }
     });

--- a/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover_impl.hpp
@@ -150,16 +150,14 @@ void ProtogalaxyProver_<Flavor, NUM_KEYS>::update_target_sum_and_fold(
         accumulator->set_overflow_size(incoming->get_overflow_size()); // swap overflow size
     }
 
-    parallel_for([&accumulator, &lagranges](const ThreadChunk& chunk) {
+    parallel_for([&accumulator, &lagranges, &incoming](const ThreadChunk& chunk) {
         // Fold the proving key polynomials
-        for (auto& poly : accumulator->polynomials.get_unshifted()) {
-            poly.multiply_chunk(chunk, lagranges[0]);
+        for (auto [acc_poly, key_poly] :
+             zip_view(accumulator->polynomials.get_unshifted(), incoming->polynomials.get_unshifted())) {
+            acc_poly.multiply_chunk(chunk, lagranges[0]);
+            acc_poly.add_scaled_chunk(chunk, key_poly, lagranges[1]);
         }
     });
-    for (auto [acc_poly, key_poly] :
-         zip_view(accumulator->polynomials.get_unshifted(), incoming->polynomials.get_unshifted())) {
-        acc_poly.add_scaled(key_poly, lagranges[1]);
-    }
 
     // Evaluate the combined batching  α_i univariate at challenge to obtain next α_i and send it to the
     // verifier, where i ∈ {0,...,NUM_SUBRELATIONS - 1}


### PR DESCRIPTION
### Changes
- Added `ThreadChunk` structure for efficient work distribution across threads
- Implemented `add_scaled_chunk` method for chunked polynomial operations  
- Modified `add_scaled` to use chunked processing for better memory access patterns
- Fixed `bc` command not found errors in CPU scaling benchmark script (replaced with `awk`)

## Benchmark Results

### CPU Scaling Performance

**After optimization (this branch):**
```
CPUs     Time (ms)       Speedup      Efficiency  
──── ────────── ─────── ──────────
1        5840.54         1.00x        100.0%      
2        2968.66         1.97x        98.5%       
4        1530.68         3.82x        95.5%       
8        812.71          7.19x        89.9%       
16       706.82          8.26x        51.6%
```

**Before optimization:**
```
CPUs     Time (ms)       Speedup      Efficiency  
──── ────────── ─────── ──────────
1        5840.56         1.00x        100.0%      
2        2970.08         1.97x        98.5%       
4        1533.58         3.81x        95.2%       
8        813.08          7.18x        89.8%       
16       706.92          8.26x        51.6% 
```



### Performance Impact
- Negligible