### PR TITLE
fix: parse node url when starting a bot (backport)

### DIFF
--- a/yarn-project/aztec/src/cli/cmds/start_bot.ts
+++ b/yarn-project/aztec/src/cli/cmds/start_bot.ts
@@ -27,7 +27,12 @@ export async function startBot(
   }
 
   const fetch = makeTracedFetch([1, 2, 3], true);
-  const node = createAztecNodeClient(options.nodeUrl, getVersions(), fetch);
+  const config = extractRelevantOptions<BotConfig>(options, botConfigMappings, 'bot');
+  if (!config.nodeUrl) {
+    throw new Error('The bot requires access to a Node');
+  }
+
+  const node = createAztecNodeClient(config.nodeUrl, getVersions(), fetch);
 
   // Start a PXE client that is used by the bot if required
   let pxe: PXE | undefined;


### PR DESCRIPTION
backport of #16969 