### PR TITLE
fix: Wait for flushable epoch using actual current epoch

### DIFF
--- a/.test_patterns.yml
+++ b/.test_patterns.yml
@@ -273,9 +273,6 @@ tests:
     error_regex: "Failed to fetch dynamically imported module"
     owners:
       - *alex
-  - regex: "ethereum/src/deploy_l1_contracts.test.ts"
-    owners:
-      - *palla
   - regex: "ethereum/src/test/tx_delayer.test.ts"
     error_regex: "delays a transaction until a given L1 timestamp"
     owners:

--- a/yarn-project/cli/src/cmds/l1/update_l1_validators.ts
+++ b/yarn-project/cli/src/cmds/l1/update_l1_validators.ts
@@ -308,7 +308,7 @@ export async function debugRollup({ rpcUrls, chainId, rollupAddress, log }: Roll
   log(`Committee: ${committee?.map(v => v.toString()).join(', ')}`);
   const archive = await rollup.archive();
   log(`Archive: ${archive}`);
-  const epochNum = await rollup.getEpochNumber();
+  const epochNum = await rollup.getCurrentEpochNumber();
   log(`Current epoch: ${epochNum}`);
   const slot = await rollup.getSlotNumber();
   log(`Current slot: ${slot}`);

--- a/yarn-project/end-to-end/src/e2e_l1_publisher/e2e_l1_publisher.test.ts
+++ b/yarn-project/end-to-end/src/e2e_l1_publisher/e2e_l1_publisher.test.ts
@@ -444,7 +444,8 @@ describe('L1Publisher integration', () => {
         const thisBlockNumber = BigInt(block.header.globalVariables.blockNumber);
         const isFirstBlockOfEpoch =
           thisBlockNumber == 1n ||
-          (await rollup.getEpochNumber(thisBlockNumber)) > (await rollup.getEpochNumber(thisBlockNumber - 1n));
+          (await rollup.getEpochNumberForBlock(thisBlockNumber)) >
+            (await rollup.getEpochNumberForBlock(thisBlockNumber - 1n));
         // If we are at the first blob of the epoch, we must initialize the hash:
         prevBlobAccumulatorHash = isFirstBlockOfEpoch ? Buffer.alloc(0) : prevBlobAccumulatorHash;
         const currentBlobAccumulatorHash = hexToBuffer(await rollup.getCurrentBlobCommitmentsHash());

--- a/yarn-project/end-to-end/src/e2e_p2p/add_rollup.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/add_rollup.test.ts
@@ -474,7 +474,7 @@ describe('e2e_p2p_add_rollup', () => {
 
     // With all down, we make a time jump such that we ensure that we will be at a point where epochs are non-empty
     // This is to avoid conflicts when the checkpoints are looking further back.
-    const futureEpoch = 500n + (await newRollup.getEpochNumber());
+    const futureEpoch = 500n + (await newRollup.getCurrentEpochNumber());
     const time = await newRollup.getTimestampForSlot(futureEpoch * BigInt(t.ctx.aztecNodeConfig.aztecEpochDuration));
     if (time > BigInt(await t.ctx.cheatCodes.eth.timestamp())) {
       await t.ctx.cheatCodes.eth.warp(Number(time));

--- a/yarn-project/epoch-cache/src/epoch_cache.ts
+++ b/yarn-project/epoch-cache/src/epoch_cache.ts
@@ -116,7 +116,7 @@ export class EpochCache implements EpochCacheInterface {
       rollup.getL1GenesisTime(),
       rollup.getCurrentEpochCommittee(),
       rollup.getCurrentSampleSeed(),
-      rollup.getEpochNumber(),
+      rollup.getCurrentEpochNumber(),
       rollup.getProofSubmissionEpochs(),
       rollup.getSlotDuration(),
       rollup.getEpochDuration(),

--- a/yarn-project/ethereum/src/contracts/rollup.ts
+++ b/yarn-project/ethereum/src/contracts/rollup.ts
@@ -446,8 +446,11 @@ export class RollupContract {
     return this.rollup.read.getNextFlushableEpoch();
   }
 
-  async getEpochNumber(blockNumber?: bigint) {
-    blockNumber ??= await this.getBlockNumber();
+  getCurrentEpochNumber(): Promise<bigint> {
+    return this.rollup.read.getCurrentEpoch();
+  }
+
+  getEpochNumberForBlock(blockNumber: bigint) {
     return this.rollup.read.getEpochForBlock([BigInt(blockNumber)]);
   }
 

--- a/yarn-project/ethereum/src/deploy_l1_contracts.test.ts
+++ b/yarn-project/ethereum/src/deploy_l1_contracts.test.ts
@@ -15,6 +15,7 @@ import { GSEContract } from './contracts/gse.js';
 import { RegistryContract } from './contracts/registry.js';
 import { RollupContract } from './contracts/rollup.js';
 import { type DeployL1ContractsArgs, type Operator, deployL1Contracts } from './deploy_l1_contracts.js';
+import { EthCheatCodes } from './test/eth_cheat_codes.js';
 import { startAnvil } from './test/start_anvil.js';
 import type { ExtendedViemWalletClient } from './types.js';
 
@@ -26,13 +27,16 @@ describe('deploy_l1_contracts', () => {
   let protocolContractTreeRoot: Fr;
   let genesisArchiveRoot: Fr;
   let initialValidators: Operator[];
+  let timeout: NodeJS.Timeout;
 
   // Use these environment variables to run against a live node. Eg to test against spartan's eth-devnet:
   // BLOCK_TIME=1 spartan/aztec-network/eth-devnet/run-locally.sh
   // LOG_LEVEL=verbose L1_RPC_URL=http://localhost:8545 L1_CHAIN_ID=1337 yarn test deploy_l1_contracts
   const chainId = process.env.L1_CHAIN_ID ? parseInt(process.env.L1_CHAIN_ID, 10) : 31337;
+
   let rpcUrl = process.env.L1_RPC_URL;
   let client: ExtendedViemWalletClient;
+  let cheat: EthCheatCodes;
   let stop: () => Promise<void> = () => Promise.resolve();
 
   beforeAll(async () => {
@@ -53,9 +57,14 @@ describe('deploy_l1_contracts', () => {
     }
 
     client = createExtendedL1Client([rpcUrl], privateKey, createEthereumChain([rpcUrl], chainId).chainInfo);
+    cheat = new EthCheatCodes([rpcUrl]);
   });
 
   afterAll(async () => {
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+
     if (stop) {
       try {
         await stop();
@@ -65,17 +74,26 @@ describe('deploy_l1_contracts', () => {
     }
   });
 
-  const deploy = (args: Partial<DeployL1ContractsArgs> = {}) =>
-    deployL1Contracts([rpcUrl!], privateKey, createEthereumChain([rpcUrl!], chainId).chainInfo, logger, {
-      ...DefaultL1ContractsConfig,
-      salt: undefined,
-      vkTreeRoot,
-      protocolContractTreeRoot,
-      genesisArchiveRoot,
-      l1TxConfig: { checkIntervalMs: 100 },
-      realVerifier: false,
-      ...args,
-    });
+  const deploy = (args: Partial<DeployL1ContractsArgs> & { flushEntryQueue?: boolean } = {}) =>
+    deployL1Contracts(
+      [rpcUrl!],
+      privateKey,
+      createEthereumChain([rpcUrl!], chainId).chainInfo,
+      logger,
+      {
+        ...DefaultL1ContractsConfig,
+        salt: undefined,
+        vkTreeRoot,
+        protocolContractTreeRoot,
+        genesisArchiveRoot,
+        l1TxConfig: { checkIntervalMs: 100 },
+        realVerifier: false,
+        ...args,
+      },
+      undefined,
+      false,
+      args.flushEntryQueue ?? true,
+    );
 
   const getRollup = (deployed: Awaited<ReturnType<typeof deploy>>) =>
     new RollupContract(deployed.l1Client, deployed.l1ContractAddresses.rollupAddress);
@@ -147,20 +165,46 @@ describe('deploy_l1_contracts', () => {
   });
 
   it('deploys and adds 48 initialValidators', async () => {
-    // Adds 48 validators.
-    // Note, that not all 48 validators is necessarily added in the active set, some might be in the entry queue
-
+    // Adds 48 validators. Note, that not all 48 validators is necessarily added in the active set, some might be in the entry queue
     const initialValidators = times(48, () => {
       const addr = EthAddress.random();
       const bn254SecretKey = new SecretValue(Fr.random().toBigInt());
       return { attester: addr, withdrawer: addr, bn254SecretKey };
     });
-    const info = await deploy({ initialValidators, aztecTargetCommitteeSize: initialValidators.length });
-    const rollup = new RollupContract(client, info.l1ContractAddresses.rollupAddress);
 
+    const info = await deploy({
+      initialValidators,
+      aztecTargetCommitteeSize: initialValidators.length,
+      flushEntryQueue: false,
+    });
+
+    const rollup = new RollupContract(client, info.l1ContractAddresses.rollupAddress);
     expect((await rollup.getActiveAttesterCount()) + (await rollup.getEntryQueueLength())).toEqual(
       BigInt(initialValidators.length),
     );
+  });
+
+  it('deploys and flushes 48 initialValidators', async () => {
+    // Adds 48 validators. This time we flush the entry queue so we can verify that the flushing logic works as expected.
+    const initialValidators = times(48, () => {
+      const addr = EthAddress.random();
+      const bn254SecretKey = new SecretValue(Fr.random().toBigInt());
+      return { attester: addr, withdrawer: addr, bn254SecretKey };
+    });
+
+    // Set an interval to advance the chain, otherwise we get stuck in "Waiting for next flushable epoch"
+    let timestamp = await client.getBlock({ includeTransactions: false }).then(b => b.timestamp);
+    timeout = setInterval(() => void cheat.warp((timestamp += 60n * 60n)), 1000);
+
+    const info = await deploy({
+      initialValidators,
+      aztecTargetCommitteeSize: initialValidators.length,
+      flushEntryQueue: true,
+    });
+    const rollup = new RollupContract(client, info.l1ContractAddresses.rollupAddress);
+
+    expect(await rollup.getEntryQueueLength()).toEqual(0n);
+    expect(await rollup.getActiveAttesterCount()).toEqual(BigInt(initialValidators.length));
   });
 
   it('ensure governance is the owner', async () => {

--- a/yarn-project/ethereum/src/deploy_l1_contracts.ts
+++ b/yarn-project/ethereum/src/deploy_l1_contracts.ts
@@ -939,7 +939,7 @@ export const addMultipleValidators = async (
 
         let queueLength = await rollup.getEntryQueueLength();
         while (flushEntryQueue && queueLength > 0n) {
-          logger.info(`Flushing entry queue`);
+          logger.info(`Flushing entry queue with ${queueLength} entries`);
 
           try {
             await deployer.l1TxUtils.sendAndMonitorTransaction(
@@ -965,12 +965,14 @@ export const addMultipleValidators = async (
             break;
           }
 
+          logger.info(`Waiting for next flushable epoch to flush remaining ${queueLength} entries`);
           await retryUntil(
             async () => {
               const [currentEpoch, flushableEpoch] = await Promise.all([
-                rollup.getEpochNumber(),
+                rollup.getCurrentEpochNumber(),
                 rollup.getNextFlushableEpoch(),
               ]);
+              logger.debug(`Next flushable epoch is ${flushableEpoch} (current epoch is ${currentEpoch})`);
               return currentEpoch >= flushableEpoch;
             },
             'wait for next flushable epoch',

--- a/yarn-project/ethereum/src/test/chain_monitor.ts
+++ b/yarn-project/ethereum/src/test/chain_monitor.ts
@@ -116,7 +116,7 @@ export class ChainMonitor extends EventEmitter<ChainMonitorEventMap> {
 
     const newL2BlockNumber = Number(await this.rollup.getBlockNumber());
     if (this.l2BlockNumber !== newL2BlockNumber) {
-      const epochNumber = await this.rollup.getEpochNumber(BigInt(newL2BlockNumber));
+      const epochNumber = await this.rollup.getEpochNumberForBlock(BigInt(newL2BlockNumber));
       msg += ` with new L2 block ${newL2BlockNumber} for epoch ${epochNumber}`;
       this.l2BlockNumber = newL2BlockNumber;
       this.l2BlockTimestamp = timestamp;
@@ -130,7 +130,7 @@ export class ChainMonitor extends EventEmitter<ChainMonitorEventMap> {
 
     const newL2ProvenBlockNumber = Number(await this.rollup.getProvenBlockNumber());
     if (this.l2ProvenBlockNumber !== newL2ProvenBlockNumber) {
-      const epochNumber = await this.rollup.getEpochNumber(BigInt(newL2ProvenBlockNumber));
+      const epochNumber = await this.rollup.getEpochNumberForBlock(BigInt(newL2ProvenBlockNumber));
       msg += ` with proof up to L2 block ${newL2ProvenBlockNumber} for epoch ${epochNumber}`;
       this.l2ProvenBlockNumber = newL2ProvenBlockNumber;
       this.l2ProvenBlockTimestamp = timestamp;

--- a/yarn-project/prover-node/src/metrics.ts
+++ b/yarn-project/prover-node/src/metrics.ts
@@ -91,7 +91,7 @@ export class ProverNodeRewardsMetrics {
   }
 
   private observe = async (observer: BatchObservableResult): Promise<void> => {
-    const epoch = await this.rollup.getEpochNumber();
+    const epoch = await this.rollup.getCurrentEpochNumber();
 
     if (epoch > this.proofSubmissionEpochs) {
       // look at the prev epoch so that we get an accurate value, after proof submission window has closed


### PR DESCRIPTION
Turns out the rollup contract method `getEpochNumber` did NOT return the current epoch number: it retutned the epoch number for the latest pending block, so if there was no block production, this number would not increase.

This is now fixed by removing that method in favor of a `getEpochNumberForBlock` and `getCurrentEpochNumber`, and using the latter in the queue flush.

Also fixed the deploy-l1-contracts test to handle this and artificially bump the epoch when testing the flush.

Also removed the test as flake.