### PR TITLE
Add SalaryPayroll example contract

### DIFF
--- a/noir-projects/noir-contracts/Nargo.toml
+++ b/noir-projects/noir-contracts/Nargo.toml
@@ -59,5 +59,6 @@ members = [
     "contracts/test/test_contract",
     "contracts/test/test_log_contract",
     "contracts/test/updatable_contract",
-    "contracts/test/updated_contract"
+    "contracts/test/updated_contract",
+    "contracts/salary_payroll_contract"
 ]

--- a/noir-projects/noir-contracts/contracts/salary_payroll_contract/Nargo.toml
+++ b/noir-projects/noir-contracts/contracts/salary_payroll_contract/Nargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "salary_payroll_contract"
+type = "contract"
+authors = ["Umarb97"]
+compiler_version = ">=1.0.0"
+
+[dependencies]
+aztec = { git = "https://github.com/AztecProtocol/aztec-packages/", tag = "v1.2.0", directory = "noir-projects/aztec-nr/aztec" }

--- a/noir-projects/noir-contracts/contracts/salary_payroll_contract/README.md
+++ b/noir-projects/noir-contracts/contracts/salary_payroll_contract/README.md
@@ -1,0 +1,124 @@
+# SalaryPayroll Contract
+
+The `SalaryPayroll` contract is a minimal Aztec.nr example that demonstrates how to define public functions, enforce constraints, and successfully compile a smart contract with Aztec.
+
+## Overview
+
+This contract is intentionally simple, focusing on the basics of Aztec.nr:
+
+- Registering an employee with a salary  
+- Simulating a salary withdrawal  
+- Demonstrating `#[aztec]` and `#[public]` macros  
+- Explaining why `pub` return types are required for entrypoints  
+
+The goal is to provide a clean starting point for developers exploring Aztec smart contracts.
+
+---
+
+## Project Structure
+
+salary_payroll_contract/
+│
+├── Nargo.toml # Project metadata & dependencies
+├── README.md # Documentation
+└── src/
+└── main.nr # Contract source code
+
+rust
+Copy code
+
+---
+
+## Contract Code
+
+```rust
+use dep::aztec::macros::aztec;
+
+#[aztec]
+pub contract SalaryPayroll {
+    use dep::aztec::macros::{functions::{public}, storage::storage};
+    use dep::aztec::prelude::{AztecAddress};
+
+    #[public]
+    fn add_employee(_employee_id: u64, salary: u64) -> pub bool {
+        assert(salary >= 1);
+        assert(salary <= 1_000_000);
+        true
+    }
+
+    #[public]
+    fn withdraw_salary(_employee_id: u64) -> pub bool {
+        true
+    }
+}
+Compilation
+Ensure you are on Aztec v1.2.0:
+
+bash
+Copy code
+aztec-up -v 1.2.0
+Compile the contract:
+
+bash
+Copy code
+$aztec-nargo compile
+Expected output:
+
+bash
+Copy code
+Saved contract artifact to: target/salary_payroll-SalaryPayroll.json
+The generated JSON artifact can be consumed by Aztec.js for deployment or integration tests.
+
+Optional: Deploy with Aztec.js
+This example can also be deployed to the Aztec sandbox.
+
+Start the sandbox:
+
+bash
+Copy code
+$aztec start --sandbox
+Generate TypeScript bindings:
+
+bash
+Copy code
+$aztec codegen target --outdir ts/artifacts
+Example script (ts/index.ts):
+
+ts
+Copy code
+import { createPXEClient, waitForPXE, getInitialTestAccountsWallets } from "@aztec/aztec.js";
+import { SalaryPayrollContract } from "../artifacts/SalaryPayroll.js";
+
+const run = async () => {
+  const pxe = createPXEClient("http://localhost:8080");
+  await waitForPXE(pxe);
+
+  const wallets = await getInitialTestAccountsWallets(pxe);
+  const deployerWallet = wallets[0];
+
+  const payroll = await SalaryPayrollContract.deploy(deployerWallet).send().wait();
+
+  console.log("Contract deployed at:", payroll.address.toString());
+};
+
+run().catch(console.error);
+Run:
+
+bash
+Copy code
+ $npm start
+Why This Example?
+Resolves common beginner errors (public not in scope, missing pub keyword)
+
+Provides a minimal but valid reference contract
+
+Shows end-to-end flow: write → compile → artifact → deploy
+
+Serves as a foundation for more advanced payroll or HR modules
+
+Contribution Notes
+This example is designed as a developer-friendly reference.
+If merged, it can be added under noir-contracts/contracts/examples/salary_payroll_contract/ to help new contributors and developers quickly get started with Aztec.nr.
+
+
+

--- a/noir-projects/noir-contracts/contracts/salary_payroll_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/salary_payroll_contract/src/main.nr
@@ -1,0 +1,20 @@
+use dep::aztec::macros::aztec;
+
+#[aztec]
+pub contract SalaryPayroll {
+    // zaroori imports
+    use dep::aztec::macros::{functions::{public}, storage::storage};
+    use dep::aztec::prelude::{AztecAddress};
+
+    #[public]
+    fn add_employee(_employee_id: u64, salary: u64) -> pub bool {
+        assert(salary >= 1);
+        assert(salary <= 1_000_000);
+        true
+    }
+
+    #[public]
+    fn withdraw_salary(_employee_id: u64) -> pub bool {
+        true
+    }
+}


### PR DESCRIPTION
## Summary
This PR adds a new example contract `SalaryPayroll` under `noir-contracts/contracts/`.

## Motivation
While experimenting with Aztec.nr (v1.2.0), I found that many new developers run into issues when creating their first contract:
- Using the `#[public]` macro correctly
- Understanding why entry point return types must be `pub`
- Seeing compilation errors when the contract is not registered in the workspace

This example provides a minimal, working payroll contract that demonstrates:
- How to define a `#[aztec]` contract
- How to implement `#[public]` functions
- A clear folder structure with `Nargo.toml`, `src/main.nr`, and a README

## Workspace Update
This PR also updates `noir-contracts/Nargo.toml` to register the new `salary_payroll_contract` package as part of the workspace.
Without this change, `aztec-nargo` cannot compile the contract (`Selected package 'salary_payroll_contract' was not found`).

## Details
- `add_employee`: validates salary range and returns `true`
- `withdraw_salary`: placeholder function returning `true`
- Both functions are public and return `pub` values
- Artifact compiles successfully using `aztec-nargo compile`

## Why This is Useful
- Serves as a reference example for beginners
- Helps developers avoid common mistakes when starting with Aztec.nr
- Provides a clean template to extend into more complex payroll systems with storage

## Next Steps
The included README contains:
- Setup and compilation instructions
- An optional deployment section for sandbox testing
