### PR TITLE
fix: oracle interface change check

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -302,6 +302,7 @@
     "starknet",
     "staticcall",
     "stdlib",
+    "stringifying",
     "struct",
     "structs",
     "subarray",

--- a/yarn-project/pxe/package.json
+++ b/yarn-project/pxe/package.json
@@ -76,7 +76,6 @@
     "@aztec/protocol-contracts": "workspace:^",
     "@aztec/simulator": "workspace:^",
     "@aztec/stdlib": "workspace:^",
-    "json-stringify-deterministic": "1.0.12",
     "koa": "^2.16.1",
     "koa-router": "^12.0.0",
     "lodash.omit": "^4.5.0",

--- a/yarn-project/pxe/src/bin/check_oracle_version.ts
+++ b/yarn-project/pxe/src/bin/check_oracle_version.ts
@@ -1,7 +1,5 @@
 import { keccak256String } from '@aztec/foundation/crypto';
 
-import deterministicStringify from 'json-stringify-deterministic';
-
 import { Oracle } from '../contract_function_simulator/oracle/oracle.js';
 import { TypedOracle } from '../contract_function_simulator/oracle/typed_oracle.js';
 import { ORACLE_INTERFACE_HASH } from '../oracle_version.js';
@@ -23,8 +21,13 @@ class OracleMock extends TypedOracle {}
  */
 function assertOracleInterfaceMatches(): void {
   const oracle = new Oracle(new OracleMock('OracleMock'));
+  const acirCallback = oracle.toACIRCallback();
+  // Create a hashable representation of the oracle interface by concatenating its method names. Return values are
+  // excluded from the hash calculation since they are typically arrays of fields and I didn't manage to reliably
+  // stringify them.
+  const oracleInterfaceMethodNames = Object.keys(acirCallback).sort().join('');
   // We use keccak256 here just because we already have it in the dependencies.
-  const oracleInterfaceHash = keccak256String(deterministicStringify(oracle.toACIRCallback()));
+  const oracleInterfaceHash = keccak256String(oracleInterfaceMethodNames);
   if (oracleInterfaceHash !== ORACLE_INTERFACE_HASH) {
     // This check exists only to notify you when you need to update the ORACLE_VERSION constant.
     throw new Error(

--- a/yarn-project/pxe/src/oracle_version.ts
+++ b/yarn-project/pxe/src/oracle_version.ts
@@ -8,4 +8,4 @@ export const ORACLE_VERSION = 1;
 
 /// This hash is computed as by hashing the Oracle interface and it is used to detect when the Oracle interface changes,
 /// which in turn implies that you need to update the ORACLE_VERSION constant.
-export const ORACLE_INTERFACE_HASH = 'b48d38f93eaa084033fc5970bf96e559c33c4cdc07d889ab00b4d63f9590739d';
+export const ORACLE_INTERFACE_HASH = '99187c6367b331ca37f942f1c9dda38ee05d527048c93526f8c58479f5319d38';

--- a/yarn-project/yarn.lock
+++ b/yarn-project/yarn.lock
@@ -1262,7 +1262,6 @@ __metadata:
     "@types/node": "npm:^22.15.17"
     jest: "npm:^30.0.0"
     jest-mock-extended: "npm:^4.0.0"
-    json-stringify-deterministic: "npm:1.0.12"
     koa: "npm:^2.16.1"
     koa-router: "npm:^12.0.0"
     lodash.omit: "npm:^4.5.0"


### PR DESCRIPTION
When I modified oracles in [my other PR](https://github.com/AztecProtocol/aztec-packages/pull/16435) I noticed that the oracle change check I implemented a while ago in [this PR](https://github.com/AztecProtocol/aztec-packages/pull/16435) was not triggered. It turns out that there was a bug and stringifying the object resulted in "{}" string because the serializer didn't manage to handle the value types.

Addressed this by just hashing the oracle method names. I think this is fine because the oracle return values are generally just an array of fields and hence we are anyway not really able to track there changes in types. An advantage also is that we can now drop the "json-stringify-deterministic" dependency from `pxe` package.