### PR TITLE
Remove duplicate mktemp for FINAL_SOL in copy_optimized_to_cpp.sh

### DIFF
--- a/barretenberg/sol/scripts/copy_optimized_to_cpp.sh
+++ b/barretenberg/sol/scripts/copy_optimized_to_cpp.sh
@@ -268,7 +268,6 @@ in_loadVk {
 ' "$TEMP_SOL" > "$TEMP_PROCESSED"
 
 # Build the final Solidity content
-FINAL_SOL=$(mktemp)
 
 # Start with SPDX license identifier
 echo "// SPDX-License-Identifier: Apache-2.0" > "$FINAL_SOL"


### PR DESCRIPTION
The script created FINAL_SOL twice: once before installing the trap (captured in the trap’s expansion) and once right before writing the final Solidity. In normal runs this didn’t leak because the second file was explicitly removed; however, if the script terminated after the second mktemp but before the explicit rm, the later temp file could be left behind since the trap only referenced the first path. Reusing the initially-created FINAL_SOL eliminates this race window and keeps cleanup consistent with the trap.