### PR TITLE
chore: store installed version instead of re-tagging

### DIFF
--- a/aztec-up/bin/aztec
+++ b/aztec-up/bin/aztec
@@ -1,16 +1,17 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-NETWORK=${NETWORK:-}
-VERSION=${VERSION:-${NETWORK:-"latest"}}
+export AZTEC_PATH="${AZTEC_PATH:-$HOME/.aztec}"
+export VERSION="${VERSION:-$(cat "$AZTEC_PATH/default_version")}"
+export DOCKER_REPO="${DOCKER_REPO:-"aztecprotocol/aztec"}"
 
-DOCKER_REPO=${DOCKER_REPO:-"aztecprotocol/aztec"}
 # Take copy of command-line arguments, so we can mutate to parse.
 if [ $# -eq 0 ]; then
   args=("--help")
 else
   args=("$@")
 fi
+
 while [ "$#" -gt 0 ]; do
   case $1 in
     -p | --port)
@@ -33,14 +34,6 @@ while [ "$#" -gt 0 ]; do
       ;;
     --admin-port)
       ADMIN_PORT="$2"
-      shift 2
-      ;;
-    --pxe.network)
-      # Set version to user-specified network (e.g. 'devnet')
-      VERSION="$2"
-      echo "Using aztecprotocol/aztec:$VERSION"
-      # Turn on proving if connecting to a network.
-      export PXE_PROVER_ENABLED=1
       shift 2
       ;;
     --help)

--- a/aztec-up/bin/aztec-install
+++ b/aztec-up/bin/aztec-install
@@ -17,7 +17,7 @@ else
   NON_INTERACTIVE=${NON_INTERACTIVE:-0}
 fi
 
-AZTEC_PATH=$HOME/.aztec
+AZTEC_PATH="${AZTEC_PATH:-$HOME/.aztec}"
 BIN_PATH=${BIN_PATH:-$AZTEC_PATH/bin}
 
 # Define version if specified, otherwise set to "latest".
@@ -146,15 +146,14 @@ if ! docker info &>/dev/null; then
   exit 1
 fi
 
+mkdir -p "$AZTEC_PATH"
+TMP_VERSION_FILE="$(mktemp)"
+echo "$VERSION" > "$TMP_VERSION_FILE"
+
 # Pull the aztec container.
 if [ -z "${SKIP_PULL:-}" ]; then
   info "Pulling aztec version $VERSION..."
   docker pull aztecprotocol/aztec:$VERSION
-
-  # If not latest, retag to be latest so it runs from scripts.
-  if [ $VERSION != "latest" ]; then
-    docker tag aztecprotocol/aztec:$VERSION aztecprotocol/aztec:latest
-  fi
 fi
 
 info "Installing scripts in $BIN_PATH..."
@@ -165,6 +164,7 @@ install_bin aztec-up
 install_bin aztec-nargo
 install_bin aztec-postprocess-contract
 install_bin aztec-wallet
+mv "$TMP_VERSION_FILE" "$AZTEC_PATH/default_version"
 
 update_path_env_var $BIN_PATH
 


### PR DESCRIPTION
Store version of the aztec image at install time and use as default rather than re-tagging. This will allow `--pull always` to work if running a custom dist-tag.