### PR TITLE
chore: reset helm values to what's being deployed

### DIFF
--- a/spartan/terraform/deploy-aztec-infra/main.tf
+++ b/spartan/terraform/deploy-aztec-infra/main.tf
@@ -222,7 +222,7 @@ resource "helm_release" "releases" {
   upgrade_install  = true
   force_update     = true
   recreate_pods    = true
-  reuse_values     = true
+  reuse_values     = false
   timeout          = 600
   wait             = true
   wait_for_jobs    = true


### PR DESCRIPTION
Helm releases were mixing in old values during upgrade which meant removing env vars had no effect