### PR TITLE
feat(avm): batch inverses in tracegen

### DIFF
--- a/barretenberg/cpp/src/barretenberg/ecc/fields/field_declarations.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/fields/field_declarations.hpp
@@ -343,7 +343,7 @@ template <class Params_> struct alignas(32) field {
     static constexpr uint256_t modulus_minus_two =
         uint256_t(Params::modulus_0 - 2ULL, Params::modulus_1, Params::modulus_2, Params::modulus_3);
     constexpr field invert() const noexcept;
-    static void batch_invert(std::span<field> coeffs) noexcept;
+    template <typename C> static void batch_invert(C coeffs) noexcept; // C has size() and operator[].
     static void batch_invert(field* coeffs, size_t n) noexcept;
     /**
      * @brief Compute square root of the field element.

--- a/barretenberg/cpp/src/barretenberg/ecc/fields/field_declarations.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/fields/field_declarations.hpp
@@ -343,8 +343,15 @@ template <class Params_> struct alignas(32) field {
     static constexpr uint256_t modulus_minus_two =
         uint256_t(Params::modulus_0 - 2ULL, Params::modulus_1, Params::modulus_2, Params::modulus_3);
     constexpr field invert() const noexcept;
-    template <typename C> static void batch_invert(C coeffs) noexcept; // C has size() and operator[].
+    template <typename C>
+    // has size() and operator[].
+        requires requires(C& c) {
+            { c.size() } -> std::convertible_to<size_t>;
+            { c[0] };
+        }
+    static void batch_invert(C& coeffs) noexcept;
     static void batch_invert(field* coeffs, size_t n) noexcept;
+    static void batch_invert(std::span<field> coeffs) noexcept;
     /**
      * @brief Compute square root of the field element.
      *

--- a/barretenberg/cpp/src/barretenberg/ecc/fields/field_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/fields/field_impl.hpp
@@ -383,13 +383,24 @@ template <class T> constexpr field<T> field<T>::invert() const noexcept
     return pow(modulus_minus_two);
 }
 
+// TODO(https://github.com/AztecProtocol/barretenberg/issues/1166)
 template <class T> void field<T>::batch_invert(field* coeffs, const size_t n) noexcept
 {
     batch_invert(std::span{ coeffs, n });
 }
 
-// TODO(https://github.com/AztecProtocol/barretenberg/issues/1166)
-template <class T> template <typename C> void field<T>::batch_invert(C coeffs) noexcept
+template <class T> void field<T>::batch_invert(std::span<field> coeffs) noexcept
+{
+    batch_invert<decltype(coeffs)>(coeffs);
+}
+
+template <class T>
+template <typename C>
+    requires requires(C& c) {
+        { c.size() } -> std::convertible_to<size_t>;
+        { c[0] };
+    }
+void field<T>::batch_invert(C& coeffs) noexcept
 {
     const size_t n = coeffs.size();
 

--- a/barretenberg/cpp/src/barretenberg/ecc/fields/field_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/fields/field_impl.hpp
@@ -389,7 +389,7 @@ template <class T> void field<T>::batch_invert(field* coeffs, const size_t n) no
 }
 
 // TODO(https://github.com/AztecProtocol/barretenberg/issues/1166)
-template <class T> void field<T>::batch_invert(std::span<field> coeffs) noexcept
+template <class T> template <typename C> void field<T>::batch_invert(C coeffs) noexcept
 {
     const size_t n = coeffs.size();
 

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/bytecode_trace.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/bytecode_trace.cpp
@@ -62,7 +62,7 @@ void BytecodeTraceBuilder::process_decomposition(
                           { C::bc_decomposition_is_windows_eq_remaining, is_windows_eq_remaining ? 1 : 0 },
                           // Inverses will be calculated in batch later.
                           { C::bc_decomposition_bytes_rem_inv, remaining },
-                          { C::bc_decomposition_bytes_rem_min_one_inv, is_last ? 0 : FF(remaining) - 1 },
+                          { C::bc_decomposition_bytes_rem_min_one_inv, is_last ? 0 : FF(remaining - 1) },
                           { C::bc_decomposition_windows_min_remaining_inv,
                             is_windows_eq_remaining ? 0 : FF(DECOMPOSE_WINDOW_SIZE) - FF(remaining) },
                           // Sliding window.

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/bytecode_trace.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/bytecode_trace.cpp
@@ -50,60 +50,60 @@ void BytecodeTraceBuilder::process_decomposition(
             static_assert(MAX_PACKED_PUBLIC_BYTECODE_SIZE_IN_FIELDS * 32 <= 0xffffff);
 
             // We set the decomposition in bytes, and other values.
-            trace.set(
-                row + i,
-                { {
-                    { C::bc_decomposition_sel, 1 },
-                    { C::bc_decomposition_id, id },
-                    { C::bc_decomposition_pc, i },
-                    { C::bc_decomposition_last_of_contract, is_last ? 1 : 0 },
-                    { C::bc_decomposition_bytes_remaining, remaining },
-                    { C::bc_decomposition_bytes_rem_inv, FF(remaining).invert() }, // remaining != 0 for activated rows
-                    { C::bc_decomposition_bytes_rem_min_one_inv, is_last ? 0 : FF(remaining - 1).invert() },
-                    { C::bc_decomposition_bytes_to_read, bytes_to_read },
-                    { C::bc_decomposition_sel_windows_gt_remaining, DECOMPOSE_WINDOW_SIZE > remaining ? 1 : 0 },
-                    { C::bc_decomposition_windows_min_remaining_inv,
-                      is_windows_eq_remaining ? 0 : (FF(DECOMPOSE_WINDOW_SIZE) - FF(remaining)).invert() },
-                    { C::bc_decomposition_is_windows_eq_remaining, is_windows_eq_remaining ? 1 : 0 },
-                    // Sliding window.
-                    { C::bc_decomposition_bytes, bytecode_at(i) },
-                    { C::bc_decomposition_bytes_pc_plus_1, bytecode_at(i + 1) },
-                    { C::bc_decomposition_bytes_pc_plus_2, bytecode_at(i + 2) },
-                    { C::bc_decomposition_bytes_pc_plus_3, bytecode_at(i + 3) },
-                    { C::bc_decomposition_bytes_pc_plus_4, bytecode_at(i + 4) },
-                    { C::bc_decomposition_bytes_pc_plus_5, bytecode_at(i + 5) },
-                    { C::bc_decomposition_bytes_pc_plus_6, bytecode_at(i + 6) },
-                    { C::bc_decomposition_bytes_pc_plus_7, bytecode_at(i + 7) },
-                    { C::bc_decomposition_bytes_pc_plus_8, bytecode_at(i + 8) },
-                    { C::bc_decomposition_bytes_pc_plus_9, bytecode_at(i + 9) },
-                    { C::bc_decomposition_bytes_pc_plus_10, bytecode_at(i + 10) },
-                    { C::bc_decomposition_bytes_pc_plus_11, bytecode_at(i + 11) },
-                    { C::bc_decomposition_bytes_pc_plus_12, bytecode_at(i + 12) },
-                    { C::bc_decomposition_bytes_pc_plus_13, bytecode_at(i + 13) },
-                    { C::bc_decomposition_bytes_pc_plus_14, bytecode_at(i + 14) },
-                    { C::bc_decomposition_bytes_pc_plus_15, bytecode_at(i + 15) },
-                    { C::bc_decomposition_bytes_pc_plus_16, bytecode_at(i + 16) },
-                    { C::bc_decomposition_bytes_pc_plus_17, bytecode_at(i + 17) },
-                    { C::bc_decomposition_bytes_pc_plus_18, bytecode_at(i + 18) },
-                    { C::bc_decomposition_bytes_pc_plus_19, bytecode_at(i + 19) },
-                    { C::bc_decomposition_bytes_pc_plus_20, bytecode_at(i + 20) },
-                    { C::bc_decomposition_bytes_pc_plus_21, bytecode_at(i + 21) },
-                    { C::bc_decomposition_bytes_pc_plus_22, bytecode_at(i + 22) },
-                    { C::bc_decomposition_bytes_pc_plus_23, bytecode_at(i + 23) },
-                    { C::bc_decomposition_bytes_pc_plus_24, bytecode_at(i + 24) },
-                    { C::bc_decomposition_bytes_pc_plus_25, bytecode_at(i + 25) },
-                    { C::bc_decomposition_bytes_pc_plus_26, bytecode_at(i + 26) },
-                    { C::bc_decomposition_bytes_pc_plus_27, bytecode_at(i + 27) },
-                    { C::bc_decomposition_bytes_pc_plus_28, bytecode_at(i + 28) },
-                    { C::bc_decomposition_bytes_pc_plus_29, bytecode_at(i + 29) },
-                    { C::bc_decomposition_bytes_pc_plus_30, bytecode_at(i + 30) },
-                    { C::bc_decomposition_bytes_pc_plus_31, bytecode_at(i + 31) },
-                    { C::bc_decomposition_bytes_pc_plus_32, bytecode_at(i + 32) },
-                    { C::bc_decomposition_bytes_pc_plus_33, bytecode_at(i + 33) },
-                    { C::bc_decomposition_bytes_pc_plus_34, bytecode_at(i + 34) },
-                    { C::bc_decomposition_bytes_pc_plus_35, bytecode_at(i + 35) },
-                    { C::bc_decomposition_bytes_pc_plus_36, bytecode_at(i + 36) },
-                } });
+            trace.set(row + i,
+                      { {
+                          { C::bc_decomposition_sel, 1 },
+                          { C::bc_decomposition_id, id },
+                          { C::bc_decomposition_pc, i },
+                          { C::bc_decomposition_last_of_contract, is_last ? 1 : 0 },
+                          { C::bc_decomposition_bytes_remaining, remaining },
+                          { C::bc_decomposition_bytes_to_read, bytes_to_read },
+                          { C::bc_decomposition_sel_windows_gt_remaining, DECOMPOSE_WINDOW_SIZE > remaining ? 1 : 0 },
+                          { C::bc_decomposition_is_windows_eq_remaining, is_windows_eq_remaining ? 1 : 0 },
+                          // Inverses will be calculated in batch later.
+                          { C::bc_decomposition_bytes_rem_inv, remaining },
+                          { C::bc_decomposition_bytes_rem_min_one_inv, is_last ? 0 : (remaining - 1) },
+                          { C::bc_decomposition_windows_min_remaining_inv,
+                            is_windows_eq_remaining ? 0 : (DECOMPOSE_WINDOW_SIZE - remaining) },
+                          // Sliding window.
+                          { C::bc_decomposition_bytes, bytecode_at(i) },
+                          { C::bc_decomposition_bytes_pc_plus_1, bytecode_at(i + 1) },
+                          { C::bc_decomposition_bytes_pc_plus_2, bytecode_at(i + 2) },
+                          { C::bc_decomposition_bytes_pc_plus_3, bytecode_at(i + 3) },
+                          { C::bc_decomposition_bytes_pc_plus_4, bytecode_at(i + 4) },
+                          { C::bc_decomposition_bytes_pc_plus_5, bytecode_at(i + 5) },
+                          { C::bc_decomposition_bytes_pc_plus_6, bytecode_at(i + 6) },
+                          { C::bc_decomposition_bytes_pc_plus_7, bytecode_at(i + 7) },
+                          { C::bc_decomposition_bytes_pc_plus_8, bytecode_at(i + 8) },
+                          { C::bc_decomposition_bytes_pc_plus_9, bytecode_at(i + 9) },
+                          { C::bc_decomposition_bytes_pc_plus_10, bytecode_at(i + 10) },
+                          { C::bc_decomposition_bytes_pc_plus_11, bytecode_at(i + 11) },
+                          { C::bc_decomposition_bytes_pc_plus_12, bytecode_at(i + 12) },
+                          { C::bc_decomposition_bytes_pc_plus_13, bytecode_at(i + 13) },
+                          { C::bc_decomposition_bytes_pc_plus_14, bytecode_at(i + 14) },
+                          { C::bc_decomposition_bytes_pc_plus_15, bytecode_at(i + 15) },
+                          { C::bc_decomposition_bytes_pc_plus_16, bytecode_at(i + 16) },
+                          { C::bc_decomposition_bytes_pc_plus_17, bytecode_at(i + 17) },
+                          { C::bc_decomposition_bytes_pc_plus_18, bytecode_at(i + 18) },
+                          { C::bc_decomposition_bytes_pc_plus_19, bytecode_at(i + 19) },
+                          { C::bc_decomposition_bytes_pc_plus_20, bytecode_at(i + 20) },
+                          { C::bc_decomposition_bytes_pc_plus_21, bytecode_at(i + 21) },
+                          { C::bc_decomposition_bytes_pc_plus_22, bytecode_at(i + 22) },
+                          { C::bc_decomposition_bytes_pc_plus_23, bytecode_at(i + 23) },
+                          { C::bc_decomposition_bytes_pc_plus_24, bytecode_at(i + 24) },
+                          { C::bc_decomposition_bytes_pc_plus_25, bytecode_at(i + 25) },
+                          { C::bc_decomposition_bytes_pc_plus_26, bytecode_at(i + 26) },
+                          { C::bc_decomposition_bytes_pc_plus_27, bytecode_at(i + 27) },
+                          { C::bc_decomposition_bytes_pc_plus_28, bytecode_at(i + 28) },
+                          { C::bc_decomposition_bytes_pc_plus_29, bytecode_at(i + 29) },
+                          { C::bc_decomposition_bytes_pc_plus_30, bytecode_at(i + 30) },
+                          { C::bc_decomposition_bytes_pc_plus_31, bytecode_at(i + 31) },
+                          { C::bc_decomposition_bytes_pc_plus_32, bytecode_at(i + 32) },
+                          { C::bc_decomposition_bytes_pc_plus_33, bytecode_at(i + 33) },
+                          { C::bc_decomposition_bytes_pc_plus_34, bytecode_at(i + 34) },
+                          { C::bc_decomposition_bytes_pc_plus_35, bytecode_at(i + 35) },
+                          { C::bc_decomposition_bytes_pc_plus_36, bytecode_at(i + 36) },
+                      } });
         }
 
         // We set the packed field every 31 bytes.
@@ -130,6 +130,13 @@ void BytecodeTraceBuilder::process_decomposition(
         // We advance to the next bytecode.
         row += bytecode_len;
     }
+
+    RefVector<FF> ff_vector;
+    trace.visit_column(C::bc_decomposition_bytes_rem_inv, [&](uint32_t, FF& val) { ff_vector.push_back(val); });
+    trace.visit_column(C::bc_decomposition_bytes_rem_min_one_inv, [&](uint32_t, FF& val) { ff_vector.push_back(val); });
+    trace.visit_column(C::bc_decomposition_windows_min_remaining_inv,
+                       [&](uint32_t, FF& val) { ff_vector.push_back(val); });
+    FF::batch_invert<RefVector<FF>&>(ff_vector);
 }
 
 void BytecodeTraceBuilder::process_hashing(

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/bytecode_trace.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/bytecode_trace.cpp
@@ -62,9 +62,9 @@ void BytecodeTraceBuilder::process_decomposition(
                           { C::bc_decomposition_is_windows_eq_remaining, is_windows_eq_remaining ? 1 : 0 },
                           // Inverses will be calculated in batch later.
                           { C::bc_decomposition_bytes_rem_inv, remaining },
-                          { C::bc_decomposition_bytes_rem_min_one_inv, is_last ? 0 : (remaining - 1) },
+                          { C::bc_decomposition_bytes_rem_min_one_inv, is_last ? 0 : FF(remaining) - 1 },
                           { C::bc_decomposition_windows_min_remaining_inv,
-                            is_windows_eq_remaining ? 0 : (DECOMPOSE_WINDOW_SIZE - remaining) },
+                            is_windows_eq_remaining ? 0 : FF(DECOMPOSE_WINDOW_SIZE) - FF(remaining) },
                           // Sliding window.
                           { C::bc_decomposition_bytes, bytecode_at(i) },
                           { C::bc_decomposition_bytes_pc_plus_1, bytecode_at(i + 1) },
@@ -131,12 +131,10 @@ void BytecodeTraceBuilder::process_decomposition(
         row += bytecode_len;
     }
 
-    RefVector<FF> ff_vector;
-    trace.visit_column(C::bc_decomposition_bytes_rem_inv, [&](uint32_t, FF& val) { ff_vector.push_back(val); });
-    trace.visit_column(C::bc_decomposition_bytes_rem_min_one_inv, [&](uint32_t, FF& val) { ff_vector.push_back(val); });
-    trace.visit_column(C::bc_decomposition_windows_min_remaining_inv,
-                       [&](uint32_t, FF& val) { ff_vector.push_back(val); });
-    FF::batch_invert<RefVector<FF>&>(ff_vector);
+    // Batch invert the columns.
+    trace.invert_columns({ { C::bc_decomposition_bytes_rem_inv,
+                             C::bc_decomposition_bytes_rem_min_one_inv,
+                             C::bc_decomposition_windows_min_remaining_inv } });
 }
 
 void BytecodeTraceBuilder::process_hashing(
@@ -235,8 +233,7 @@ void BytecodeTraceBuilder::process_retrieval(
 
                 // Limit handling
                 { C::bc_retrieval_no_remaining_bytecodes, remaining_bytecodes == 0 },
-                { C::bc_retrieval_remaining_bytecodes_inv,
-                  remaining_bytecodes == 0 ? 0 : FF(remaining_bytecodes).invert() },
+                { C::bc_retrieval_remaining_bytecodes_inv, remaining_bytecodes }, // Will be inverted in batch later.
                 { C::bc_retrieval_is_new_class, event.is_new_class },
                 { C::bc_retrieval_should_retrieve, !error },
 
@@ -247,6 +244,9 @@ void BytecodeTraceBuilder::process_retrieval(
             } });
         row++;
     }
+
+    // Batch invert the columns.
+    trace.invert_columns({ { C::bc_retrieval_remaining_bytecodes_inv } });
 }
 
 void BytecodeTraceBuilder::process_instruction_fetching(

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/execution_trace.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/execution_trace.cpp
@@ -301,7 +301,6 @@ void ExecutionTraceBuilder::process(
     FailingContexts failures = preprocess_for_discard(ex_events);
 
     uint32_t last_seen_parent_id = 0;
-    FF cached_parent_id_inv = 0;
 
     // Some variables updated per loop iteration to track
     // whether or not the upcoming row should "discard" [side effects].
@@ -325,8 +324,6 @@ void ExecutionTraceBuilder::process(
         bool has_parent = ex_event.after_context_event.parent_id != 0;
         if (last_seen_parent_id != ex_event.after_context_event.parent_id) {
             last_seen_parent_id = ex_event.after_context_event.parent_id;
-            cached_parent_id_inv =
-                has_parent ? ex_event.after_context_event.parent_id : 0; // Will be inverted in batch later.
         }
 
         /**************************************************************************************************
@@ -429,7 +426,7 @@ void ExecutionTraceBuilder::process(
                   ex_event.after_context_event.side_effect_states.numL2ToL1Messages },
                 // Helpers for identifying parent context
                 { C::execution_has_parent_ctx, has_parent ? 1 : 0 },
-                { C::execution_is_parent_id_inv, cached_parent_id_inv },
+                { C::execution_is_parent_id_inv, last_seen_parent_id },
             } });
 
         // Internal stack
@@ -1029,14 +1026,26 @@ void ExecutionTraceBuilder::process_addressing(const simulation::AddressingEvent
 
 void ExecutionTraceBuilder::invert_columns(TraceContainer& trace)
 {
-    trace.invert_columns({ { C::execution_dying_context_id_inv,
-                             C::execution_dying_context_diff_inv,
-                             // Addressing.
-                             C::execution_addressing_error_collection_inv,
-                             C::execution_base_address_tag_diff_inv,
-                             C::execution_num_relative_operands_inv,
-                             // Registers.
-                             C::execution_batched_tags_diff_inv_reg } });
+    trace.invert_columns({ {
+        // Registers.
+        C::execution_batched_tags_diff_inv_reg,
+        // Context.
+        C::execution_is_parent_id_inv,
+        C::execution_internal_call_return_id_inv,
+        // Trees.
+        C::execution_remaining_data_writes_inv,
+        C::execution_remaining_note_hashes_inv,
+        C::execution_remaining_nullifiers_inv,
+        // L1ToL2MsgExists.
+        C::execution_remaining_l2_to_l1_msgs_inv,
+        // Discard.
+        C::execution_dying_context_id_inv,
+        C::execution_dying_context_diff_inv,
+        // Addressing.
+        C::execution_addressing_error_collection_inv,
+        C::execution_base_address_tag_diff_inv,
+        C::execution_num_relative_operands_inv,
+    } });
 }
 
 void ExecutionTraceBuilder::process_registers(ExecutionOpCode exec_opcode,

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/execution_trace.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/execution_trace.cpp
@@ -426,7 +426,7 @@ void ExecutionTraceBuilder::process(
                   ex_event.after_context_event.side_effect_states.numL2ToL1Messages },
                 // Helpers for identifying parent context
                 { C::execution_has_parent_ctx, has_parent ? 1 : 0 },
-                { C::execution_is_parent_id_inv, last_seen_parent_id },
+                { C::execution_is_parent_id_inv, has_parent ? last_seen_parent_id : 0 },
             } });
 
         // Internal stack

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/execution_trace.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/execution_trace.cpp
@@ -318,14 +318,15 @@ void ExecutionTraceBuilder::process(
             is_phase_discarded(ex_event.after_context_event.phase, failures)) {
             discard = 1;
             dying_context_id = dying_context_for_phase(ex_event.after_context_event.phase, failures);
-            dying_context_id_inv = FF(dying_context_id).invert();
+            dying_context_id_inv = dying_context_id; // Will be inverted in batch later.
         }
 
         // Cache the parent id inversion since we will repeatedly just be doing the same expensive inversion
         bool has_parent = ex_event.after_context_event.parent_id != 0;
         if (last_seen_parent_id != ex_event.after_context_event.parent_id) {
             last_seen_parent_id = ex_event.after_context_event.parent_id;
-            cached_parent_id_inv = has_parent ? FF(ex_event.after_context_event.parent_id).invert() : 0;
+            cached_parent_id_inv =
+                has_parent ? ex_event.after_context_event.parent_id : 0; // Will be inverted in batch later.
         }
 
         /**************************************************************************************************
@@ -620,9 +621,7 @@ void ExecutionTraceBuilder::process(
             } else if (exec_opcode == ExecutionOpCode::INTERNALRETURN) {
                 trace.set(C::execution_internal_call_return_id_inv,
                           row,
-                          ex_event.before_context_event.internal_call_return_id != 0
-                              ? FF(ex_event.before_context_event.internal_call_return_id).invert()
-                              : 0);
+                          ex_event.before_context_event.internal_call_return_id); // Will be inverted in batch later.
             } else if (exec_opcode == ExecutionOpCode::SSTORE) {
                 uint32_t remaining_data_writes = MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX -
                                                  ex_event.before_context_event.tree_states.publicDataTree.counter;
@@ -631,7 +630,7 @@ void ExecutionTraceBuilder::process(
                           { {
                               { C::execution_max_data_writes_reached, remaining_data_writes == 0 },
                               { C::execution_remaining_data_writes_inv,
-                                remaining_data_writes == 0 ? 0 : FF(remaining_data_writes).invert() },
+                                remaining_data_writes }, // Will be inverted in batch later.
                               { C::execution_sel_write_public_data, !opcode_execution_failed },
                           } });
             } else if (exec_opcode == ExecutionOpCode::NOTEHASHEXISTS) {
@@ -652,7 +651,7 @@ void ExecutionTraceBuilder::process(
                           { {
                               { C::execution_sel_reached_max_note_hashes, remaining_note_hashes == 0 },
                               { C::execution_remaining_note_hashes_inv,
-                                remaining_note_hashes == 0 ? 0 : FF(remaining_note_hashes).invert() },
+                                remaining_note_hashes }, // Will be inverted in batch later.
                               { C::execution_sel_write_note_hash, !opcode_execution_failed },
                           } });
             } else if (exec_opcode == ExecutionOpCode::L1TOL2MSGEXISTS) {
@@ -675,7 +674,7 @@ void ExecutionTraceBuilder::process(
                           { {
                               { C::execution_sel_reached_max_nullifiers, remaining_nullifiers == 0 },
                               { C::execution_remaining_nullifiers_inv,
-                                remaining_nullifiers == 0 ? 0 : FF(remaining_nullifiers).invert() },
+                                remaining_nullifiers }, // Will be inverted in batch later.
                               { C::execution_sel_write_nullifier,
                                 remaining_nullifiers != 0 && !ex_event.before_context_event.is_static },
                           } });
@@ -686,7 +685,7 @@ void ExecutionTraceBuilder::process(
                 trace.set(row,
                           { { { C::execution_sel_l2_to_l1_msg_limit_error, remaining_l2_to_l1_msgs == 0 },
                               { C::execution_remaining_l2_to_l1_msgs_inv,
-                                remaining_l2_to_l1_msgs == 0 ? 0 : FF(remaining_l2_to_l1_msgs).invert() },
+                                remaining_l2_to_l1_msgs }, // Will be inverted in batch later.
                               { C::execution_sel_write_l2_to_l1_msg, !opcode_execution_failed && !discard },
                               {
                                   C::execution_public_inputs_index,
@@ -716,9 +715,7 @@ void ExecutionTraceBuilder::process(
         if (!is_dying_context) {
             // Compute inversion when context_id != dying_context_id
             FF diff = FF(ex_event.after_context_event.id) - FF(dying_context_id);
-            if (!diff.is_zero()) {
-                dying_context_diff_inv = diff.invert();
-            }
+            dying_context_diff_inv = diff; // Will be inverted in batch later.
         }
 
         // Needed for bc retrieval
@@ -771,7 +768,7 @@ void ExecutionTraceBuilder::process(
             // context is dying. NOTE: if a [STATIC]CALL instruction _itself_ errors, we don't set the
             // discard flag because we aren't actually entering a new context!
             dying_context_id = ex_event.next_context_id;
-            dying_context_id_inv = FF(dying_context_id).invert();
+            dying_context_id_inv = dying_context_id; // Will be inverted in batch later.
             discard = 1;
         }
         // Otherwise, we aren't entering or exiting a dying context,
@@ -791,6 +788,9 @@ void ExecutionTraceBuilder::process(
     if (!ex_events.empty()) {
         trace.set(C::execution_last, row - 1, 1);
     }
+
+    // Batch invert the columns.
+    invert_columns(trace);
 }
 
 void ExecutionTraceBuilder::process_instr_fetching(const simulation::Instruction& instruction,
@@ -966,11 +966,9 @@ void ExecutionTraceBuilder::process_addressing(const simulation::AddressingEvent
     }
 
     // Inverse when base address is invalid.
-    FF base_address_tag_diff_inv =
-        base_address_invalid
-            ? (FF(static_cast<uint8_t>(addr_event.base_address.get_tag())) - FF(static_cast<uint8_t>(MemoryTag::U32)))
-                  .invert()
-            : 0;
+    FF base_address_tag_diff_inv = base_address_invalid ? FF(static_cast<uint8_t>(addr_event.base_address.get_tag())) -
+                                                              FF(static_cast<uint8_t>(MemoryTag::U32))
+                                                        : 0; // Will be inverted in batch later.
 
     // Tag check after indirection.
     bool some_final_check_failed =
@@ -986,7 +984,7 @@ void ExecutionTraceBuilder::process_addressing(const simulation::AddressingEvent
                 FF(is_indirect_effective[i]) * power_of_2 * (FF(resolved_operand_tag[i]) - FF(MEM_TAG_U32));
             power_of_2 *= 8; // 2^3
         }
-        batched_tags_diff_inv = batched_tags_diff != 0 ? batched_tags_diff.invert() : 0;
+        batched_tags_diff_inv = batched_tags_diff; // Will be inverted in batch later.
     }
 
     // Collect addressing errors. See PIL file for reference.
@@ -1011,8 +1009,7 @@ void ExecutionTraceBuilder::process_addressing(const simulation::AddressingEvent
                                   }) +
                   // Some invalid address after indirection.
                   (some_final_check_failed ? 1 : 0))
-                  .invert()
-            : 0;
+            : 0; // Will be inverted in batch later.
 
     trace.set(row,
               { {
@@ -1023,10 +1020,23 @@ void ExecutionTraceBuilder::process_addressing(const simulation::AddressingEvent
                   { C::execution_base_address_tag_diff_inv, base_address_tag_diff_inv },
                   { C::execution_sel_some_final_check_failed, some_final_check_failed ? 1 : 0 },
                   { C::execution_sel_base_address_failure, base_address_invalid ? 1 : 0 },
-                  { C::execution_num_relative_operands_inv, do_base_check ? FF(num_relative_operands).invert() : 0 },
+                  { C::execution_num_relative_operands_inv,
+                    do_base_check ? num_relative_operands : 0 }, // Will be inverted in batch later.
                   { C::execution_sel_do_base_check, do_base_check ? 1 : 0 },
                   { C::execution_highest_address, AVM_HIGHEST_MEM_ADDRESS },
               } });
+}
+
+void ExecutionTraceBuilder::invert_columns(TraceContainer& trace)
+{
+    trace.invert_columns({ { C::execution_dying_context_id_inv,
+                             C::execution_dying_context_diff_inv,
+                             // Addressing.
+                             C::execution_addressing_error_collection_inv,
+                             C::execution_base_address_tag_diff_inv,
+                             C::execution_num_relative_operands_inv,
+                             // Registers.
+                             C::execution_batched_tags_diff_inv_reg } });
 }
 
 void ExecutionTraceBuilder::process_registers(ExecutionOpCode exec_opcode,
@@ -1088,7 +1098,7 @@ void ExecutionTraceBuilder::process_registers(ExecutionOpCode exec_opcode,
             }
             power_of_2 *= 8; // 2^3
         }
-        batched_tags_diff_inv_reg = batched_tags_diff != 0 ? batched_tags_diff.invert() : 0;
+        batched_tags_diff_inv_reg = batched_tags_diff; // Will be inverted in batch later.
     }
 
     trace.set(row,

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/execution_trace.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/execution_trace.hpp
@@ -27,6 +27,7 @@ class ExecutionTraceBuilder final {
                             const simulation::Instruction& instruction,
                             TraceContainer& trace,
                             uint32_t row);
+    void invert_columns(TraceContainer& trace);
     // Sets global register information and reads.
     void process_registers(ExecutionOpCode exec_opcode,
                            const std::vector<TaggedValue>& inputs,

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/trace_container.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/trace_container.cpp
@@ -1,6 +1,9 @@
 #include "barretenberg/vm2/tracegen/trace_container.hpp"
 
+#include <algorithm>
+
 #include "barretenberg/common/log.hpp"
+#include "barretenberg/common/ref_vector.hpp"
 #include "barretenberg/vm2/common/field.hpp"
 #include "barretenberg/vm2/generated/columns.hpp"
 
@@ -71,7 +74,7 @@ uint32_t TraceContainer::get_column_rows(Column col) const
     if (column_data.row_number_dirty) {
         // Trigger recalculation of max row number.
         auto keys = std::views::keys(column_data.rows);
-        const auto it = std::max_element(keys.begin(), keys.end());
+        const auto it = std::ranges::max_element(keys);
         // We use -1 to indicate that the column is empty.
         column_data.max_row_number = it == keys.end() ? -1 : static_cast<int64_t>(*it);
         column_data.row_number_dirty = false;
@@ -104,13 +107,22 @@ void TraceContainer::visit_column(Column col, const std::function<void(uint32_t,
     }
 }
 
-void TraceContainer::visit_column(Column col, const std::function<void(uint32_t, FF&)>& visitor)
+void TraceContainer::invert_columns(std::span<const Column> cols)
 {
+    for (const auto& col : cols) {
+        invert_column(col);
+    }
+}
+
+void TraceContainer::invert_column(Column col)
+{
+    RefVector<FF> ff_vector;
     auto& column_data = (*trace)[static_cast<size_t>(col)];
     std::unique_lock lock(column_data.mutex);
     for (auto& [row, value] : column_data.rows) {
-        visitor(row, value);
+        ff_vector.push_back(value);
     }
+    FF::batch_invert<RefVector<FF>&>(ff_vector);
 }
 
 void TraceContainer::clear_column(Column col)

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/trace_container.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/trace_container.cpp
@@ -74,7 +74,8 @@ uint32_t TraceContainer::get_column_rows(Column col) const
     if (column_data.row_number_dirty) {
         // Trigger recalculation of max row number.
         auto keys = std::views::keys(column_data.rows);
-        const auto it = std::ranges::max_element(keys);
+        // const auto it = std::ranges::max_element(keys);
+        const auto it = std::max_element(keys.begin(), keys.end());
         // We use -1 to indicate that the column is empty.
         column_data.max_row_number = it == keys.end() ? -1 : static_cast<int64_t>(*it);
         column_data.row_number_dirty = false;
@@ -120,9 +121,10 @@ void TraceContainer::invert_column(Column col)
     auto& column_data = (*trace)[static_cast<size_t>(col)];
     std::unique_lock lock(column_data.mutex);
     for (auto& [row, value] : column_data.rows) {
-        ff_vector.push_back(value);
+        // ff_vector.push_back(value);
+        value = value.invert();
     }
-    FF::batch_invert<RefVector<FF>&>(ff_vector);
+    // FF::batch_invert<RefVector<FF>&>(ff_vector);
 }
 
 void TraceContainer::clear_column(Column col)

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/trace_container.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/trace_container.cpp
@@ -74,8 +74,7 @@ uint32_t TraceContainer::get_column_rows(Column col) const
     if (column_data.row_number_dirty) {
         // Trigger recalculation of max row number.
         auto keys = std::views::keys(column_data.rows);
-        // const auto it = std::ranges::max_element(keys);
-        const auto it = std::max_element(keys.begin(), keys.end());
+        const auto it = std::ranges::max_element(keys);
         // We use -1 to indicate that the column is empty.
         column_data.max_row_number = it == keys.end() ? -1 : static_cast<int64_t>(*it);
         column_data.row_number_dirty = false;
@@ -121,10 +120,9 @@ void TraceContainer::invert_column(Column col)
     auto& column_data = (*trace)[static_cast<size_t>(col)];
     std::unique_lock lock(column_data.mutex);
     for (auto& [row, value] : column_data.rows) {
-        // ff_vector.push_back(value);
-        value = value.invert();
+        ff_vector.push_back(value);
     }
-    // FF::batch_invert<RefVector<FF>&>(ff_vector);
+    FF::batch_invert<RefVector<FF>>(ff_vector);
 }
 
 void TraceContainer::clear_column(Column col)

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/trace_container.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/trace_container.cpp
@@ -104,6 +104,15 @@ void TraceContainer::visit_column(Column col, const std::function<void(uint32_t,
     }
 }
 
+void TraceContainer::visit_column(Column col, const std::function<void(uint32_t, FF&)>& visitor)
+{
+    auto& column_data = (*trace)[static_cast<size_t>(col)];
+    std::unique_lock lock(column_data.mutex);
+    for (auto& [row, value] : column_data.rows) {
+        visitor(row, value);
+    }
+}
+
 void TraceContainer::clear_column(Column col)
 {
     auto& column_data = (*trace)[static_cast<size_t>(col)];

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/trace_container.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/trace_container.hpp
@@ -48,7 +48,6 @@ class TraceContainer {
 
     // Visits non-zero values in a column.
     void visit_column(Column col, const std::function<void(uint32_t, const FF&)>& visitor) const;
-    void visit_column(Column col, const std::function<void(uint32_t, FF&)>& visitor);
     // Returns the number of rows in a column. That is, the maximum non-zero row index + 1.
     uint32_t get_column_rows(Column col) const;
     // Maximum number of rows in any column.
@@ -57,6 +56,9 @@ class TraceContainer {
     uint32_t get_num_rows_without_clk() const;
     // Number of columns (without shifts).
     static constexpr size_t num_columns() { return NUM_COLUMNS_WITHOUT_SHIFTS; }
+
+    // Batch inverts a set of columns.
+    void invert_columns(std::span<const Column> cols);
 
     // Free column memory.
     void clear_column(Column col);
@@ -78,6 +80,8 @@ class TraceContainer {
     // Even if the _content_ of each unordered_map is always heap-allocated, if we have 3k columns
     // we could unnecessarily put strain on the stack with sizeof(unordered_map) * 3k bytes.
     std::unique_ptr<std::array<SparseColumn, NUM_COLUMNS_WITHOUT_SHIFTS>> trace;
+
+    void invert_column(Column col);
 };
 
 } // namespace bb::avm2::tracegen

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/trace_container.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/trace_container.hpp
@@ -48,6 +48,7 @@ class TraceContainer {
 
     // Visits non-zero values in a column.
     void visit_column(Column col, const std::function<void(uint32_t, const FF&)>& visitor) const;
+    void visit_column(Column col, const std::function<void(uint32_t, FF&)>& visitor);
     // Returns the number of rows in a column. That is, the maximum non-zero row index + 1.
     uint32_t get_column_rows(Column col) const;
     // Maximum number of rows in any column.

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/trace_container.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/trace_container.test.cpp
@@ -1,0 +1,33 @@
+#include "barretenberg/vm2/tracegen/trace_container.hpp"
+
+#include <cstdint>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "barretenberg/vm2/generated/columns.hpp"
+
+namespace bb::avm2::tracegen {
+namespace {
+
+TEST(TraceContainerTest, InvertColumns)
+{
+    using C = Column;
+    TraceContainer trace;
+
+    trace.set(C::bc_decomposition_bytes_rem_inv, /*row=*/0, 1);
+    trace.set(C::bc_decomposition_bytes_rem_min_one_inv, /*row=*/0, 2);
+
+    trace.set(C::bc_decomposition_bytes_rem_inv, /*row=*/4, 3);
+    trace.set(C::bc_decomposition_bytes_rem_min_one_inv, /*row=*/4, 4);
+
+    trace.invert_columns({ { C::bc_decomposition_bytes_rem_inv, C::bc_decomposition_bytes_rem_min_one_inv } });
+
+    EXPECT_EQ(trace.get(C::bc_decomposition_bytes_rem_inv, /*row=*/0), FF(1).invert());
+    EXPECT_EQ(trace.get(C::bc_decomposition_bytes_rem_min_one_inv, /*row=*/0), FF(2).invert());
+
+    EXPECT_EQ(trace.get(C::bc_decomposition_bytes_rem_inv, /*row=*/4), FF(3).invert());
+    EXPECT_EQ(trace.get(C::bc_decomposition_bytes_rem_min_one_inv, /*row=*/4), FF(4).invert());
+}
+
+} // namespace
+} // namespace bb::avm2::tracegen


### PR DESCRIPTION
[original idea/request by @jeanmon]

This PR adds batch inverting capabilities to the trace container. It uses them to speed up the bytecode and execution trace(gen).

* Bytecode decomposition gets waay better
* Execution gets slightly better

This can still be applied to memory and other traces, in some other PRs.

BEFORE (bulk 16 cores)

```
tracegen/all_ms: 7640
tracegen/alu_ms: 49
tracegen/bitwise_ms: 445
tracegen/bytecode_decomposition_ms: 2620
tracegen/execution_ms: 4806
tracegen/interactions_ms: 2405
tracegen/memory_ms: 831
tracegen/range_check_ms: 336
```

AFTER (bulk 16 cores)

```
tracegen/all_ms: 5592
tracegen/alu_ms: 48
tracegen/bitwise_ms: 425
tracegen/bytecode_decomposition_ms: 587
tracegen/bytecode_hashing_ms: 14
tracegen/execution_ms: 3177
tracegen/interactions_ms: 2213
tracegen/memory_ms: 775
tracegen/merkle_check_ms: 66
tracegen/poseidon2_permutation_ms: 257
tracegen/range_check_ms: 313
tracegen/traces_ms: 3282
```