### PR TITLE
fix(docs): update nightly docs release workflow to commit to next

### DIFF
--- a/.github/workflows/nightly-docs-release.yml
+++ b/.github/workflows/nightly-docs-release.yml
@@ -117,12 +117,6 @@ jobs:
         run: |
           ./update_versions.sh
 
-      - name: Commit new Aztec Docs version
-        run: |
-          git add .
-          git commit -m "chore(docs): cut new aztec docs version for tag ${{ env.NIGHTLY_TAG }}"
-          git push
-
       - name: Cleanup Barretenberg docs nightly versions
         working-directory: ./barretenberg/docs
         run: |
@@ -150,8 +144,18 @@ jobs:
         run: |
           ./update_versions.sh
 
-      - name: Commit new Aztec Docs version
+      - name: Commit new Aztec and Barretenberg Docs version
         run: |
+          # Stash the docs changes
           git add .
-          git commit -m "chore(docs): cut new aztec docs version for tag ${{ env.NIGHTLY_TAG }}"
-          git push
+          git stash push --staged -m "nightly docs for ${{ env.NIGHTLY_TAG }}"
+
+          # Checkout the next branch
+          git fetch origin next
+          git checkout next
+
+          # Apply the stashed changes and commit
+          git stash pop
+          git add .
+          git commit -m "chore(docs): cut new aztec and bb docs version for tag ${{ env.NIGHTLY_TAG }}"
+          git push origin next

--- a/barretenberg/docs/scripts/update_versions.sh
+++ b/barretenberg/docs/scripts/update_versions.sh
@@ -72,13 +72,13 @@ if [ -d "$VERSIONED_DOCS_DIR" ]; then
             echo "Found $STABLE_COUNT stable version(s)"
         fi
     else
-        # No versions found, create empty array
-        echo "[]" > "$VERSIONS_FILE"
-        echo "No versions found in versioned_docs"
+        # No versions found, exit with error
+        echo "Error: No versions found in versioned_docs" >&2
+        exit 1
     fi
 else
-    echo "Warning: $VERSIONED_DOCS_DIR not found"
-    echo "[]" > "$VERSIONS_FILE"
+    echo "Error: $VERSIONED_DOCS_DIR not found" >&2
+    exit 1
 fi
 
 echo "Current versions.json:"

--- a/docs/scripts/update_versions.sh
+++ b/docs/scripts/update_versions.sh
@@ -72,13 +72,13 @@ if [ -d "$VERSIONED_DOCS_DIR" ]; then
             echo "Found $STABLE_COUNT stable version(s)"
         fi
     else
-        # No versions found, create empty array
-        echo "[]" > "$VERSIONS_FILE"
-        echo "No versions found in versioned_docs"
+        # No versions found, exit with error
+        echo "Error: No versions found in versioned_docs" >&2
+        exit 1
     fi
 else
-    echo "Warning: $VERSIONED_DOCS_DIR not found"
-    echo "[]" > "$VERSIONS_FILE"
+    echo "Error: $VERSIONED_DOCS_DIR not found" >&2
+    exit 1
 fi
 
 echo "Current versions.json:"


### PR DESCRIPTION
update nightly docs release workflow to commit the nightly version directly to `next`.

This PR also updates the `docs/update_versions.sh` script and corresponding barretenberg/docs script to error on failure instead of committing an empty versions.json file.