### PR TITLE
chore: increase both startup probe duration

### DIFF
--- a/spartan/aztec-bot/values.yaml
+++ b/spartan/aztec-bot/values.yaml
@@ -59,6 +59,11 @@ bot:
 
     hostNetwork: true
 
+    # give the bot 5 minutes to start
+    startupProbe:
+      periodSeconds: 30
+      failureThreshold: 10
+
   service:
     p2p:
       enabled: false


### PR DESCRIPTION
The bots did not have enough time to bridge and deploy contracts before K8s restarted the pod