### PR TITLE
chore: Fix governance vote test

### DIFF
--- a/l1-contracts/test/governance/governance/vote.t.sol
+++ b/l1-contracts/test/governance/governance/vote.t.sol
@@ -97,6 +97,7 @@ contract VoteTest is GovernanceBase {
 
   modifier givenStateIsActive(address _voter, uint256 _depositPower) {
     vm.assume(_voter != address(0));
+    vm.assume(_voter != address(governance));
     depositPower = bound(_depositPower, 1, type(uint128).max);
 
     token.mint(_voter, depositPower);


### PR DESCRIPTION
Fix for [this flake](http://ci.aztec-labs.com/70cbccf418a00d04):

```
17:52:56 Failing tests:
17:52:56 Encountered 1 failing test in test/governance/governance/vote.t.sol:VoteTest
17:52:56 [FAIL: Governance__CallerCannotBeSelf(); counterexample: calldata=0x8147d0ea000000000000000000000000c7183455a4c133ae270771860664b6b7ec320bb100000000000000000000000000000000000000000000000000000000aabc2497676247b4195b3fe545499177befc02b4b4bebd3805a2283b30defcae63d546620000000000000000000000000000000000000000000000000000000000000001 args=[0xc7183455a4C133Ae270771860664b6B7ec320bB1, 2864456855 [2.864e9], 46761869295876087080540616901206191828233224650581977639405101308294462785122 [4.676e76], true]] test_GivenAmountSmallerOrEqAvailablePower(address,uint256,uint256,bool) (runs: 164, μ: 419884, ~: 419972)
```