### PR TITLE
feat!: remove context from NoteEmission methods

### DIFF
--- a/boxes/boxes/react/src/contracts/src/main.nr
+++ b/boxes/boxes/react/src/contracts/src/main.nr
@@ -22,7 +22,6 @@ contract BoxReact {
         let new_number = ValueNote::new(number, owner);
 
         numbers.at(owner).initialize(new_number).emit(
-            &mut context,
             owner,
             MessageDelivery.CONSTRAINED_ONCHAIN,
         );
@@ -37,7 +36,6 @@ contract BoxReact {
                 ValueNote::new(number, owner)
             }) 
             .emit(
-                &mut context,
                 owner,
                 MessageDelivery.CONSTRAINED_ONCHAIN,
             );

--- a/boxes/boxes/vite/src/contracts/src/main.nr
+++ b/boxes/boxes/vite/src/contracts/src/main.nr
@@ -22,7 +22,6 @@ contract BoxReact {
         let mut new_number = ValueNote::new(number, owner);
 
         numbers.at(owner).initialize(new_number).emit(
-            &mut context,
             owner,
             MessageDelivery.CONSTRAINED_ONCHAIN,
         );
@@ -37,7 +36,6 @@ contract BoxReact {
         .replace(|_old| {
             ValueNote::new(number, owner)
         }).emit(
-            &mut context,
             owner,
             MessageDelivery.CONSTRAINED_ONCHAIN,
         );

--- a/docs/docs/developers/migration_notes.md
+++ b/docs/docs/developers/migration_notes.md
@@ -280,6 +280,7 @@ The note emission API has been significantly reworked to provide clearer semanti
    - `CONSTRAINED_ONCHAIN`: For onchain delivery with cryptographic guarantees that recipients can discover and decrypt messages. Uses constrained encryption but is slower to prove. Best for critical messages that contracts need to verify.
    - `UNCONSTRAINED_ONCHAIN`: For onchain delivery without encryption constraints. Faster proving but trusts the sender. Good when the sender is incentivized to perform encryption correctly (e.g. they are buying something and will only get it if the recipient sees the note). No guarantees that recipients will be able to find or decrypt messages.
    - `UNCONSTRAINED_OFFCHAIN`: For offchain delivery (e.g. cloud storage) without constraints. Lowest cost since no onchain storage needed. Requires custom infrastructure for delivery. No guarantees that messages will be delivered or that recipients will ever find them.
+5. The `context` object no longer needs to be passed to these functions
 
 Example migration:
 

--- a/docs/examples/tutorials/token_bridge_contract/contracts/aztec/nft/src/main.nr
+++ b/docs/examples/tutorials/token_bridge_contract/contracts/aztec/nft/src/main.nr
@@ -51,7 +51,7 @@ pub contract NFTPunk {
 
         // we create an NFT note and insert it to the PrivateSet - a collection of notes meant to be read in private
         let new_nft = NFTNote::new(to, token_id);
-        storage.owners.at(to).insert(new_nft).emit(&mut context, to, MessageDelivery.CONSTRAINED_ONCHAIN);
+        storage.owners.at(to).insert(new_nft).emit( to, MessageDelivery.CONSTRAINED_ONCHAIN);
 
         // calling the internal public function above to indicate that the NFT is taken
         NFTPunk::at(context.this_address())._mark_nft_exists(token_id, true).enqueue(&mut context);

--- a/noir-projects/aztec-nr/aztec/src/note/lifecycle.nr
+++ b/noir-projects/aztec-nr/aztec/src/note/lifecycle.nr
@@ -33,7 +33,7 @@ where
 
     context.push_note_hash(note_hash);
 
-    NoteEmission::new(note, storage_slot, note_hash_counter)
+    NoteEmission::new(note, storage_slot, note_hash_counter, context)
 }
 
 // Note: This function is currently totally unused.

--- a/noir-projects/aztec-nr/aztec/src/note/note_emission.nr
+++ b/noir-projects/aztec-nr/aztec/src/note/note_emission.nr
@@ -11,23 +11,37 @@ use crate::{
 };
 use protocol_types::{address::AztecAddress, traits::Packable};
 
-/**
- * A note emission struct containing the information required for emitting a note.
- * The exact `emit` logic is passed in by the application code
- */
-pub struct NoteEmission<Note> {
+pub struct NoteEmissionContent<Note> {
     // The struct fields are exposed only because of tests.
     pub note: Note,
     pub storage_slot: Field,
     pub note_hash_counter: u32, // a note_hash_counter of 0 means settled
 }
 
+/**
+ * A note emission struct containing the information required for emitting a note.
+ * The exact `emit` logic is passed in by the application code
+ */
+pub struct NoteEmission<Note> {
+    pub content: NoteEmissionContent<Note>,
+
+    // NoteEmission is expected to be constructed when a note is created, which means that the `context` object will be
+    // in scope. By storing a reference to it inside this object we remove the need for its methods to receive it,
+    // resulting in a cleaner end-user API.
+    context: &mut PrivateContext,
+}
+
 impl<Note> NoteEmission<Note>
 where
     Note: NoteType + Packable,
 {
-    pub fn new(note: Note, storage_slot: Field, note_hash_counter: u32) -> Self {
-        Self { note, storage_slot, note_hash_counter }
+    pub fn new(
+        note: Note,
+        storage_slot: Field,
+        note_hash_counter: u32,
+        context: &mut PrivateContext,
+    ) -> Self {
+        Self { content: NoteEmissionContent { note, storage_slot, note_hash_counter }, context }
     }
 
     /// Emits a note that can be delivered either via private logs or offchain messages, with configurable encryption and
@@ -35,11 +49,10 @@ where
     ///
     /// # Arguments
     /// * `self` - The note emission to emit
-    /// * `context` - The private context to emit the note in
     /// * `recipient` - The address that should receive this note
     /// * `delivery_mode` - Controls encryption, tagging, and delivery constraints. Must be a compile-time constant.
     ///   See `MessageDeliveryEnum` for details on the available modes.
-    pub fn emit(self, context: &mut PrivateContext, recipient: AztecAddress, delivery_mode: u8) {
+    pub fn emit(self, recipient: AztecAddress, delivery_mode: u8) {
         // This function relies on `delivery_mode` being a constant in order to reduce circuit constraints when unconstrained
         // usage is requested. If `delivery_mode` were a runtime value then performance would suffer.
         assert_constant(delivery_mode);
@@ -53,7 +66,7 @@ where
         let ciphertext = remove_constraints_if(
             !constrained_encryption,
             || AES128::encrypt(
-                private_note_to_message_plaintext(self.note, self.storage_slot),
+                private_note_to_message_plaintext(self.content.note, self.content.storage_slot),
                 recipient,
             ),
         );
@@ -68,7 +81,7 @@ where
             // Regardless of the original note size `N`, the log is padded with random bytes up to
             // `PRIVATE_LOG_SIZE_IN_FIELDS` to prevent leaking information about the actual size.
             let length = log_content.len();
-            context.emit_raw_note_log(log_content, length, self.note_hash_counter);
+            self.context.emit_raw_note_log(log_content, length, self.content.note_hash_counter);
         }
     }
 
@@ -84,20 +97,29 @@ where
  * a change note in a token's transfer function only when there is "change" left).
  */
 pub struct OuterNoteEmission<Note> {
-    pub emission: Option<NoteEmission<Note>>,
+    pub content_option: Option<NoteEmissionContent<Note>>,
+
+    // OuterNoteEmission is expected to be constructed when a note is created, which means that the `context` object
+    // will be in scope. By storing a reference to it inside this object we remove the need for its methods to receive
+    // it, resulting in a cleaner end-user API.
+    context: &mut PrivateContext,
 }
 
 impl<Note> OuterNoteEmission<Note>
 where
     Note: NoteType + Packable,
 {
-    pub fn new(emission: Option<NoteEmission<Note>>) -> Self {
-        Self { emission }
+    pub fn new(
+        content_option: Option<NoteEmissionContent<Note>>,
+        context: &mut PrivateContext,
+    ) -> Self {
+        Self { content_option, context }
     }
 
-    pub fn emit(self, context: &mut PrivateContext, recipient: AztecAddress, delivery_mode: u8) {
-        if self.emission.is_some() {
-            self.emission.unwrap_unchecked().emit(context, recipient, delivery_mode);
+    pub fn emit(self, recipient: AztecAddress, delivery_mode: u8) {
+        if self.content_option.is_some() {
+            NoteEmission { content: self.content_option.unwrap_unchecked(), context: self.context }
+                .emit(recipient, delivery_mode);
         }
     }
 

--- a/noir-projects/aztec-nr/aztec/src/state_vars/map.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/map.nr
@@ -67,7 +67,7 @@ use dep::protocol_types::{storage::map::derive_storage_slot_in_map, traits::ToFi
 ///
 /// docs:start:map
 pub struct Map<K, V, Context> {
-    context: Context,
+    pub context: Context,
     storage_slot: Field,
     state_var_constructor: fn(Context, Field) -> V,
 }

--- a/noir-projects/aztec-nr/aztec/src/state_vars/private_mutable.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/private_mutable.nr
@@ -348,11 +348,18 @@ where
         let is_initialized =
             unsafe { check_nullifier_exists(self.compute_initialization_nullifier()) };
 
-        if !is_initialized {
-            self.initialize(f(Option::none()))
+        let emission_content = if !is_initialized {
+            self.initialize(f(Option::none())).content
         } else {
-            self.replace(|note| f(Option::some(note)))
-        }
+            self.replace(|note| f(Option::some(note))).content
+        };
+
+        NoteEmission::new(
+            emission_content.note,
+            emission_content.storage_slot,
+            emission_content.note_hash_counter,
+            self.context,
+        )
     }
 
     /// Reads the current note of a PrivateMutable state variable instance.

--- a/noir-projects/aztec-nr/aztec/src/state_vars/private_mutable/test.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/private_mutable/test.nr
@@ -67,8 +67,8 @@ unconstrained fn initialize() {
             state_var.compute_initialization_nullifier(),
         );
 
-        assert_eq(emission.note, note);
-        assert_eq(emission.storage_slot, STORAGE_SLOT);
+        assert_eq(emission.content.note, note);
+        assert_eq(emission.content.storage_slot, STORAGE_SLOT);
     });
 }
 
@@ -89,8 +89,8 @@ unconstrained fn initialize_and_get_pending() {
 
         let get_emission = state_var.get_note();
 
-        assert_eq(get_emission.note, note);
-        assert_eq(get_emission.storage_slot, STORAGE_SLOT);
+        assert_eq(get_emission.content.note, note);
+        assert_eq(get_emission.content.storage_slot, STORAGE_SLOT);
 
         // Reading a PrivateMutable results in:
         // - a read request for the read value
@@ -121,8 +121,8 @@ unconstrained fn initialize_and_get_settled() {
 
         let get_emission = state_var.get_note();
 
-        assert_eq(get_emission.note, note);
-        assert_eq(get_emission.storage_slot, STORAGE_SLOT);
+        assert_eq(get_emission.content.note, note);
+        assert_eq(get_emission.content.storage_slot, STORAGE_SLOT);
 
         // Reading a PrivateMutable results in:
         // - a read request for the read value
@@ -178,8 +178,8 @@ unconstrained fn initialize_and_replace_pending() {
             replacement_note
         });
 
-        assert_eq(replace_emission.note, replacement_note);
-        assert_eq(replace_emission.storage_slot, STORAGE_SLOT);
+        assert_eq(replace_emission.content.note, replacement_note);
+        assert_eq(replace_emission.content.storage_slot, STORAGE_SLOT);
 
         // Replacing a PrivateMutable results in:
         // - a read request for the read value
@@ -215,8 +215,8 @@ unconstrained fn initialize_and_replace_settled() {
             replacement_note
         });
 
-        assert_eq(replace_emission.note, replacement_note);
-        assert_eq(replace_emission.storage_slot, STORAGE_SLOT);
+        assert_eq(replace_emission.content.note, replacement_note);
+        assert_eq(replace_emission.content.storage_slot, STORAGE_SLOT);
 
         // Replacing a PrivateMutable results in:
         // - a read request for the read value
@@ -242,8 +242,8 @@ unconstrained fn initialize_or_replace_uninitialized() {
             init_note
         });
 
-        assert_eq(emission.note, init_note);
-        assert_eq(emission.storage_slot, STORAGE_SLOT);
+        assert_eq(emission.content.note, init_note);
+        assert_eq(emission.content.storage_slot, STORAGE_SLOT);
 
         // During initialization we both create the new note and emit the initialization nullifier. This will only
         // succeed if the initialization nullifier had not been already emitted.
@@ -276,8 +276,8 @@ unconstrained fn initialize_or_replace_initialized_pending() {
             replacement_note
         });
 
-        assert_eq(emission.note, replacement_note);
-        assert_eq(emission.storage_slot, STORAGE_SLOT);
+        assert_eq(emission.content.note, replacement_note);
+        assert_eq(emission.content.storage_slot, STORAGE_SLOT);
 
         // Verify context updates: read request, nullifier, and new note
         assert_eq(context.note_hash_read_requests.len(), note_hash_read_requests_pre_replace + 1);
@@ -313,8 +313,8 @@ unconstrained fn initialize_or_replace_initialized_settled() {
             replacement_note
         });
 
-        assert_eq(emission.note, replacement_note);
-        assert_eq(emission.storage_slot, STORAGE_SLOT);
+        assert_eq(emission.content.note, replacement_note);
+        assert_eq(emission.content.storage_slot, STORAGE_SLOT);
 
         // Replacing a PrivateMutable results in:
         // - a read request for the read value

--- a/noir-projects/aztec-nr/aztec/src/state_vars/private_set/test.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/private_set/test.nr
@@ -58,8 +58,8 @@ unconstrained fn insert() {
         // insert creates a new note
         assert_eq(state_var.context.note_hashes.len(), 1);
 
-        assert_eq(emission.note, new_note);
-        assert_eq(emission.storage_slot, state_var.storage_slot);
+        assert_eq(emission.content.note, new_note);
+        assert_eq(emission.content.storage_slot, state_var.storage_slot);
     });
 }
 

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
@@ -749,8 +749,8 @@ impl TestEnvironment {
         // is what the decoding functions expect (because they are built to manage protocol logs, which are arbitrarily
         // sized).
         let message_plaintext = BoundedVec::from_array(private_note_to_message_plaintext(
-            emission.note,
-            emission.storage_slot,
+            emission.content.note,
+            emission.content.storage_slot,
         ));
 
         // Then we fetch the transaction effects from the latest transaction, in which the note from the emission is

--- a/noir-projects/aztec-nr/easy-private-state/src/easy_private_uint.nr
+++ b/noir-projects/aztec-nr/easy-private-state/src/easy_private_uint.nr
@@ -42,7 +42,7 @@ impl EasyPrivateUint<&mut PrivateContext> {
         let addend_note = ValueNote::new(addend as Field, owner);
 
         // Insert the new note to the owner's set of notes.
-        self.set.insert(addend_note).emit(self.context, owner, MessageDelivery.CONSTRAINED_ONCHAIN);
+        self.set.insert(addend_note).emit(owner, MessageDelivery.CONSTRAINED_ONCHAIN);
     }
 
     // Very similar to `value_note::utils::decrement`.
@@ -63,7 +63,7 @@ impl EasyPrivateUint<&mut PrivateContext> {
         // Creates change note for the owner.
         let result_value = minuend - subtrahend;
         let result_note = ValueNote::new(result_value as Field, owner);
-        self.set.insert(result_note).emit(self.context, owner, MessageDelivery.CONSTRAINED_ONCHAIN);
+        self.set.insert(result_note).emit(owner, MessageDelivery.CONSTRAINED_ONCHAIN);
     }
 }
 

--- a/noir-projects/noir-contracts/contracts/account/ecdsa_k_account_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/account/ecdsa_k_account_contract/src/main.nr
@@ -41,7 +41,6 @@ pub contract EcdsaKAccount {
         // Safety: Comment from above applies here as well.
         unsafe { set_sender_for_tags(this) };
         storage.signing_public_key.initialize(pub_key_note).emit(
-            &mut context,
             this,
             MessageDelivery.CONSTRAINED_ONCHAIN,
         );

--- a/noir-projects/noir-contracts/contracts/account/ecdsa_r_account_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/account/ecdsa_r_account_contract/src/main.nr
@@ -40,7 +40,6 @@ pub contract EcdsaRAccount {
         // Safety: Comment from above applies here as well.
         unsafe { set_sender_for_tags(this) };
         storage.signing_public_key.initialize(pub_key_note).emit(
-            &mut context,
             this,
             MessageDelivery.CONSTRAINED_ONCHAIN,
         );

--- a/noir-projects/noir-contracts/contracts/account/schnorr_account_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/account/schnorr_account_contract/src/main.nr
@@ -55,7 +55,6 @@ pub contract SchnorrAccount {
         // Safety: Comment from above applies here as well.
         unsafe { set_sender_for_tags(this) };
         storage.signing_public_key.initialize(pub_key_note).emit(
-            &mut context,
             this,
             MessageDelivery.CONSTRAINED_ONCHAIN,
         );

--- a/noir-projects/noir-contracts/contracts/app/app_subscription_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/app_subscription_contract/src/main.nr
@@ -82,7 +82,7 @@ pub contract AppSubscription {
             note.remaining_txs -= 1;
             note
         });
-        emission.emit(&mut context, user_address, MessageDelivery.CONSTRAINED_ONCHAIN);
+        emission.emit(user_address, MessageDelivery.CONSTRAINED_ONCHAIN);
 
         context.set_as_fee_payer();
 
@@ -97,7 +97,7 @@ pub contract AppSubscription {
         // is performing the check.
         privately_check_block_number(
             Comparator.LT,
-            emission.note.expiry_block_number,
+            emission.content.note.expiry_block_number,
             &mut context,
         );
 
@@ -158,7 +158,7 @@ pub contract AppSubscription {
             .initialize_or_replace(|_| {
                 SubscriptionNote::new(subscriber, expiry_block_number, tx_count)
             })
-            .emit(&mut context, subscriber, MessageDelivery.CONSTRAINED_ONCHAIN);
+            .emit(subscriber, MessageDelivery.CONSTRAINED_ONCHAIN);
     }
 
     #[utility]

--- a/noir-projects/noir-contracts/contracts/app/card_game_contract/src/cards.nr
+++ b/noir-projects/noir-contracts/contracts/app/card_game_contract/src/cards.nr
@@ -114,11 +114,7 @@ impl Deck<&mut PrivateContext> {
         let mut inserted_cards = &[];
         for card in cards {
             let card_note = CardNote::from_card(card, owner);
-            self.set.insert(card_note.note).emit(
-                self.set.context,
-                owner,
-                MessageDelivery.CONSTRAINED_ONCHAIN,
-            );
+            self.set.insert(card_note.note).emit(owner, MessageDelivery.CONSTRAINED_ONCHAIN);
             inserted_cards = inserted_cards.push_back(card_note);
         }
 

--- a/noir-projects/noir-contracts/contracts/app/crowdfunding_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/crowdfunding_contract/src/main.nr
@@ -70,7 +70,6 @@ pub contract Crowdfunding {
         // We don't constrain encryption because the donor is sending the note to himself. And hence by performing
         // encryption incorrectly would harm himself only.
         storage.donation_receipts.at(donor).insert(note).emit(
-            &mut context,
             donor,
             MessageDelivery.UNCONSTRAINED_ONCHAIN,
         );

--- a/noir-projects/noir-contracts/contracts/app/escrow_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/escrow_contract/src/main.nr
@@ -23,7 +23,7 @@ pub contract Escrow {
     #[initializer]
     fn constructor(owner: AztecAddress) {
         let note = AddressNote::new(owner, owner);
-        storage.owner.initialize(note).emit(&mut context, owner, MessageDelivery.CONSTRAINED_ONCHAIN);
+        storage.owner.initialize(note).emit(owner, MessageDelivery.CONSTRAINED_ONCHAIN);
     }
 
     // Withdraws balance. Requires that msg.sender is the owner.

--- a/noir-projects/noir-contracts/contracts/app/nft_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/nft_contract/src/main.nr
@@ -279,7 +279,7 @@ pub contract NFT {
 
         let new_note = NFTNote::new(token_id, to);
 
-        nfts.at(to).insert(new_note).emit(&mut context, to, MessageDelivery.CONSTRAINED_ONCHAIN);
+        nfts.at(to).insert(new_note).emit(to, MessageDelivery.CONSTRAINED_ONCHAIN);
     }
 
     #[authorize_once("from", "authwit_nonce")]

--- a/noir-projects/noir-contracts/contracts/app/simple_token_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/simple_token_contract/src/main.nr
@@ -127,11 +127,7 @@ pub contract SimpleToken {
         amount: u128,
         authwit_nonce: Field,
     ) {
-        storage.balances.at(from).sub(from, amount).emit(
-            &mut context,
-            from,
-            MessageDelivery.CONSTRAINED_ONCHAIN,
-        );
+        storage.balances.at(from).sub(from, amount).emit(from, MessageDelivery.CONSTRAINED_ONCHAIN);
         SimpleToken::at(context.this_address())._increase_public_balance(to, amount).enqueue(
             &mut context,
         );
@@ -148,16 +144,8 @@ pub contract SimpleToken {
             amount,
             INITIAL_TRANSFER_CALL_MAX_NOTES,
         );
-        storage.balances.at(from).add(from, change).emit(
-            &mut context,
-            from,
-            MessageDelivery.UNCONSTRAINED_ONCHAIN,
-        );
-        storage.balances.at(to).add(to, amount).emit(
-            &mut context,
-            to,
-            MessageDelivery.UNCONSTRAINED_ONCHAIN,
-        );
+        storage.balances.at(from).add(from, change).emit(from, MessageDelivery.UNCONSTRAINED_ONCHAIN);
+        storage.balances.at(to).add(to, amount).emit(to, MessageDelivery.UNCONSTRAINED_ONCHAIN);
 
         emit_event_in_private(
             Transfer { from, to, amount },
@@ -170,11 +158,7 @@ pub contract SimpleToken {
     #[authorize_once("from", "authwit_nonce")]
     #[private]
     fn burn_private(from: AztecAddress, amount: u128, authwit_nonce: Field) {
-        storage.balances.at(from).sub(from, amount).emit(
-            &mut context,
-            from,
-            MessageDelivery.CONSTRAINED_ONCHAIN,
-        );
+        storage.balances.at(from).sub(from, amount).emit(from, MessageDelivery.CONSTRAINED_ONCHAIN);
         SimpleToken::at(context.this_address())._reduce_total_supply(amount).enqueue(&mut context);
     }
 

--- a/noir-projects/noir-contracts/contracts/app/simple_token_contract/src/types/balance_set.nr
+++ b/noir-projects/noir-contracts/contracts/app/simple_token_contract/src/types/balance_set.nr
@@ -52,14 +52,16 @@ impl BalanceSet<UtilityContext> {
 
 impl BalanceSet<&mut PrivateContext> {
     pub fn add(self: Self, owner: AztecAddress, addend: u128) -> OuterNoteEmission<UintNote> {
-        if addend == 0 as u128 {
-            OuterNoteEmission::new(Option::none())
+        let content_option = if addend == 0 as u128 {
+            Option::none()
         } else {
             // We fetch the nullifier public key hash from the registry / from our PXE
             let mut addend_note = UintNote::new(addend, owner);
 
-            OuterNoteEmission::new(Option::some(self.set.insert(addend_note)))
-        }
+            Option::some(self.set.insert(addend_note).content)
+        };
+
+        OuterNoteEmission::new(content_option, self.set.context)
     }
 
     pub fn sub(self: Self, owner: AztecAddress, amount: u128) -> OuterNoteEmission<UintNote> {

--- a/noir-projects/noir-contracts/contracts/app/token_blacklist_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_blacklist_contract/src/main.nr
@@ -191,7 +191,7 @@ pub contract TokenBlacklist {
         assert(notes.len() == 1, "note not popped");
 
         // Add the token note to user's balances set
-        storage.balances.add(to, amount).emit(&mut context, to, MessageDelivery.CONSTRAINED_ONCHAIN);
+        storage.balances.add(to, amount).emit(to, MessageDelivery.CONSTRAINED_ONCHAIN);
     }
 
     #[authorize_once("from", "authwit_nonce")]
@@ -202,11 +202,7 @@ pub contract TokenBlacklist {
         let to_roles = storage.roles.at(to).get_current_value();
         assert(!to_roles.is_blacklisted, "Blacklisted: Recipient");
 
-        storage.balances.sub(from, amount).emit(
-            &mut context,
-            from,
-            MessageDelivery.CONSTRAINED_ONCHAIN,
-        );
+        storage.balances.sub(from, amount).emit(from, MessageDelivery.CONSTRAINED_ONCHAIN);
 
         TokenBlacklist::at(context.this_address())._increase_public_balance(to, amount).enqueue(
             &mut context,
@@ -222,16 +218,8 @@ pub contract TokenBlacklist {
         let to_roles = storage.roles.at(to).get_current_value();
         assert(!to_roles.is_blacklisted, "Blacklisted: Recipient");
 
-        storage.balances.sub(from, amount).emit(
-            &mut context,
-            from,
-            MessageDelivery.UNCONSTRAINED_ONCHAIN,
-        );
-        storage.balances.add(to, amount).emit(
-            &mut context,
-            to,
-            MessageDelivery.UNCONSTRAINED_ONCHAIN,
-        );
+        storage.balances.sub(from, amount).emit(from, MessageDelivery.UNCONSTRAINED_ONCHAIN);
+        storage.balances.add(to, amount).emit(to, MessageDelivery.UNCONSTRAINED_ONCHAIN);
     }
 
     #[authorize_once("from", "authwit_nonce")]
@@ -240,11 +228,7 @@ pub contract TokenBlacklist {
         let from_roles = storage.roles.at(from).get_current_value();
         assert(!from_roles.is_blacklisted, "Blacklisted: Sender");
 
-        storage.balances.sub(from, amount).emit(
-            &mut context,
-            from,
-            MessageDelivery.CONSTRAINED_ONCHAIN,
-        );
+        storage.balances.sub(from, amount).emit(from, MessageDelivery.CONSTRAINED_ONCHAIN);
 
         TokenBlacklist::at(context.this_address())._reduce_total_supply(amount).enqueue(&mut context);
     }

--- a/noir-projects/noir-contracts/contracts/app/token_blacklist_contract/src/types/balances_map.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_blacklist_contract/src/types/balances_map.nr
@@ -74,13 +74,15 @@ impl<Note> BalancesMap<Note, &mut PrivateContext> {
     where
         Note: NoteType + NoteHash + OwnedNote + Eq + Packable,
     {
-        if addend == 0 as u128 {
-            OuterNoteEmission::new(Option::none())
+        let content_option = if addend == 0 as u128 {
+            Option::none()
         } else {
             let addend_note = Note::new(addend, owner);
 
-            OuterNoteEmission::new(Option::some(self.map.at(owner).insert(addend_note)))
-        }
+            Option::some(self.map.at(owner).insert(addend_note).content)
+        };
+
+        OuterNoteEmission::new(content_option, self.map.context)
     }
 
     pub fn sub(self: Self, owner: AztecAddress, subtrahend: u128) -> OuterNoteEmission<Note>

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/main.nr
@@ -195,11 +195,7 @@ pub contract Token {
         amount: u128,
         authwit_nonce: Field,
     ) {
-        storage.balances.at(from).sub(from, amount).emit(
-            &mut context,
-            from,
-            MessageDelivery.CONSTRAINED_ONCHAIN,
-        );
+        storage.balances.at(from).sub(from, amount).emit(from, MessageDelivery.CONSTRAINED_ONCHAIN);
         Token::at(context.this_address())._increase_public_balance(to, amount).enqueue(&mut context);
     }
 
@@ -225,11 +221,7 @@ pub contract Token {
         amount: u128,
         authwit_nonce: Field,
     ) -> PartialUintNote {
-        storage.balances.at(from).sub(from, amount).emit(
-            &mut context,
-            from,
-            MessageDelivery.CONSTRAINED_ONCHAIN,
-        );
+        storage.balances.at(from).sub(from, amount).emit(from, MessageDelivery.CONSTRAINED_ONCHAIN);
         Token::at(context.this_address())._increase_public_balance(to, amount).enqueue(&mut context);
 
         // We prepare the private balance increase (the partial note for the change).
@@ -253,16 +245,8 @@ pub contract Token {
             amount,
             INITIAL_TRANSFER_CALL_MAX_NOTES,
         );
-        storage.balances.at(from).add(from, change).emit(
-            &mut context,
-            from,
-            MessageDelivery.UNCONSTRAINED_ONCHAIN,
-        );
-        storage.balances.at(to).add(to, amount).emit(
-            &mut context,
-            to,
-            MessageDelivery.UNCONSTRAINED_ONCHAIN,
-        );
+        storage.balances.at(from).add(from, change).emit(from, MessageDelivery.UNCONSTRAINED_ONCHAIN);
+        storage.balances.at(to).add(to, amount).emit(to, MessageDelivery.UNCONSTRAINED_ONCHAIN);
 
         // We don't constrain encryption of the note log in `transfer` (unlike in `transfer_in_private`) because the transfer
         // function is only designed to be used in situations where the event is not strictly necessary (e.g. payment to
@@ -345,27 +329,15 @@ pub contract Token {
         authwit_nonce: Field,
     ) {
         // docs:start:increase_private_balance
-        storage.balances.at(from).sub(from, amount).emit(
-            &mut context,
-            from,
-            MessageDelivery.CONSTRAINED_ONCHAIN,
-        );
+        storage.balances.at(from).sub(from, amount).emit(from, MessageDelivery.CONSTRAINED_ONCHAIN);
         // docs:end:increase_private_balance
-        storage.balances.at(to).add(to, amount).emit(
-            &mut context,
-            to,
-            MessageDelivery.CONSTRAINED_ONCHAIN,
-        );
+        storage.balances.at(to).add(to, amount).emit(to, MessageDelivery.CONSTRAINED_ONCHAIN);
     }
 
     #[authorize_once("from", "authwit_nonce")]
     #[private]
     fn burn_private(from: AztecAddress, amount: u128, authwit_nonce: Field) {
-        storage.balances.at(from).sub(from, amount).emit(
-            &mut context,
-            from,
-            MessageDelivery.CONSTRAINED_ONCHAIN,
-        );
+        storage.balances.at(from).sub(from, amount).emit(from, MessageDelivery.CONSTRAINED_ONCHAIN);
         Token::at(context.this_address())._reduce_total_supply(amount).enqueue(&mut context);
     }
 
@@ -455,11 +427,7 @@ pub contract Token {
         authwit_nonce: Field,
     ) {
         // First we subtract the `amount` from the private balance of `from`
-        storage.balances.at(from).sub(from, amount).emit(
-            &mut context,
-            from,
-            MessageDelivery.CONSTRAINED_ONCHAIN,
-        );
+        storage.balances.at(from).sub(from, amount).emit(from, MessageDelivery.CONSTRAINED_ONCHAIN);
 
         partial_note.complete_from_private(&mut context, context.msg_sender().unwrap(), amount);
     }

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/types/balance_set.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/types/balance_set.nr
@@ -55,14 +55,16 @@ impl BalanceSet<UtilityContext> {
 
 impl BalanceSet<&mut PrivateContext> {
     pub fn add(self: Self, owner: AztecAddress, addend: u128) -> OuterNoteEmission<UintNote> {
-        if addend == 0 as u128 {
-            OuterNoteEmission::new(Option::none())
+        let content = if addend == 0 as u128 {
+            Option::none()
         } else {
             // We fetch the nullifier public key hash from the registry / from our PXE
             let mut addend_note = UintNote::new(addend, owner);
 
-            OuterNoteEmission::new(Option::some(self.set.insert(addend_note)))
-        }
+            Option::some(self.set.insert(addend_note).content)
+        };
+
+        OuterNoteEmission::new(content, self.set.context)
     }
 
     pub fn sub(self: Self, owner: AztecAddress, amount: u128) -> OuterNoteEmission<UintNote> {
@@ -187,8 +189,11 @@ mod test {
             let smaller_note_value = std::cmp::min(first_note_value, second_note_value);
             let larger_note_value = std::cmp::max(first_note_value, second_note_value);
 
-            let note =
-                recipient_balance_set.sub(recipient, smaller_note_value).emission.unwrap().note;
+            let note = recipient_balance_set
+                .sub(recipient, smaller_note_value)
+                .content_option
+                .unwrap()
+                .note;
             assert_eq(note.get_value(), larger_note_value - smaller_note_value);
         });
     }

--- a/noir-projects/noir-contracts/contracts/docs/docs_example_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/docs/docs_example_contract/src/main.nr
@@ -75,7 +75,6 @@ pub contract DocsExample {
         let new_card = CardNote::new(points, context.msg_sender().unwrap());
 
         storage.private_immutable.initialize(new_card).emit(
-            &mut context,
             context.msg_sender().unwrap(),
             MessageDelivery.CONSTRAINED_ONCHAIN,
         );
@@ -100,7 +99,7 @@ pub contract DocsExample {
                 let points = old_card.get_points() + 1;
                 CardNote::new(points, context.msg_sender().unwrap())
             })
-            .emit(&mut context, context.msg_sender().unwrap(), MessageDelivery.CONSTRAINED_ONCHAIN);
+            .emit(context.msg_sender().unwrap(), MessageDelivery.CONSTRAINED_ONCHAIN);
     }
 
     #[utility]

--- a/noir-projects/noir-contracts/contracts/test/benchmarking_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/benchmarking_contract/src/main.nr
@@ -26,11 +26,7 @@ pub contract Benchmarking {
     #[private]
     fn create_note(owner: AztecAddress, value: Field) {
         let note = ValueNote::new(value, owner);
-        storage.notes.at(owner).insert(note).emit(
-            &mut context,
-            owner,
-            MessageDelivery.CONSTRAINED_ONCHAIN,
-        );
+        storage.notes.at(owner).insert(note).emit(owner, MessageDelivery.CONSTRAINED_ONCHAIN);
     }
     // Deletes a note at a specific index in the set and creates a new one with the same value.
     // We explicitly pass in the note index so we can ensure we consume different notes when sending
@@ -43,7 +39,7 @@ pub contract Benchmarking {
         let mut getter_options = NoteGetterOptions::new();
         let notes = owner_notes.pop_notes(getter_options.set_limit(1).set_offset(index));
         let note = notes.get(0);
-        owner_notes.insert(note).emit(&mut context, owner, MessageDelivery.CONSTRAINED_ONCHAIN);
+        owner_notes.insert(note).emit(owner, MessageDelivery.CONSTRAINED_ONCHAIN);
     }
 
     // Reads and writes to public storage and enqueues a call to another public function.

--- a/noir-projects/noir-contracts/contracts/test/child_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/child_contract/src/main.nr
@@ -59,7 +59,6 @@ pub contract Child {
         let note = ValueNote::new(new_value, owner);
 
         storage.a_map_with_private_values.at(owner).insert(note).emit(
-            &mut context,
             owner,
             MessageDelivery.CONSTRAINED_ONCHAIN,
         );

--- a/noir-projects/noir-contracts/contracts/test/no_constructor_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/no_constructor_contract/src/main.nr
@@ -30,7 +30,6 @@ pub contract NoConstructor {
         let note = ValueNote::new(value, context.msg_sender().unwrap());
 
         storage.private_mutable.initialize(note).emit(
-            &mut context,
             context.msg_sender().unwrap(),
             MessageDelivery.CONSTRAINED_ONCHAIN,
         );

--- a/noir-projects/noir-contracts/contracts/test/note_getter_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/note_getter_contract/src/main.nr
@@ -25,7 +25,6 @@ pub contract NoteGetter {
         let note = ValueNote::new(value, context.msg_sender().unwrap());
 
         storage.set.insert(note).emit(
-            &mut context,
             context.msg_sender().unwrap(),
             MessageDelivery.CONSTRAINED_ONCHAIN,
         );

--- a/noir-projects/noir-contracts/contracts/test/offchain_effect_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/offchain_effect_contract/src/main.nr
@@ -64,7 +64,6 @@ contract OffchainEffect {
         let note = UintNote::new(value, owner);
 
         storage.balances.at(owner).insert(note).emit(
-            &mut context,
             context.msg_sender().unwrap(),
             MessageDelivery.UNCONSTRAINED_OFFCHAIN,
         );

--- a/noir-projects/noir-contracts/contracts/test/pending_note_hashes_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/pending_note_hashes_contract/src/main.nr
@@ -44,7 +44,7 @@ pub contract PendingNoteHashes {
         let note = ValueNote::new(amount, owner);
 
         // Insert note
-        owner_balance.insert(note).emit(&mut context, owner, MessageDelivery.CONSTRAINED_ONCHAIN);
+        owner_balance.insert(note).emit(owner, MessageDelivery.CONSTRAINED_ONCHAIN);
 
         let options = NoteGetterOptions::with_filter(filter_notes_min_sum, amount);
         // get note inserted above
@@ -87,7 +87,7 @@ pub contract PendingNoteHashes {
         let note = ValueNote::new(amount, owner);
 
         // Insert note
-        owner_balance.insert(note).emit(&mut context, owner, MessageDelivery.CONSTRAINED_ONCHAIN);
+        owner_balance.insert(note).emit(owner, MessageDelivery.CONSTRAINED_ONCHAIN);
     }
 
     // Nested/inner function to create and insert a note
@@ -103,7 +103,7 @@ pub contract PendingNoteHashes {
         let note = ValueNote::unpack([amount.to_field(), owner.to_field(), randomness.to_field()]);
 
         // Insert note
-        owner_balance.insert(note).emit(&mut context, owner, MessageDelivery.CONSTRAINED_ONCHAIN);
+        owner_balance.insert(note).emit(owner, MessageDelivery.CONSTRAINED_ONCHAIN);
     }
 
     // Nested/inner function to create and insert a note
@@ -117,10 +117,10 @@ pub contract PendingNoteHashes {
         // Insert note
         let emission = owner_balance.insert(note);
 
-        emission.emit(&mut context, owner, MessageDelivery.CONSTRAINED_ONCHAIN);
+        emission.emit(owner, MessageDelivery.CONSTRAINED_ONCHAIN);
 
         // Emit note again
-        emission.emit(&mut context, owner, MessageDelivery.CONSTRAINED_ONCHAIN);
+        emission.emit(owner, MessageDelivery.CONSTRAINED_ONCHAIN);
     }
 
     // Nested/inner function to get a note and confirm it matches the expected value
@@ -298,7 +298,7 @@ pub contract PendingNoteHashes {
         sender: AztecAddress,
         how_many_recursions: u64,
     ) {
-        create_max_notes(owner, storage, &mut context);
+        create_max_notes(owner, storage);
 
         PendingNoteHashes::at(context.this_address())
             .recursively_destroy_and_create_notes(owner, sender, how_many_recursions)
@@ -314,7 +314,7 @@ pub contract PendingNoteHashes {
         assert(executions_left > 0);
 
         destroy_max_notes(owner, storage);
-        create_max_notes(owner, storage, &mut context);
+        create_max_notes(owner, storage);
 
         let executions_left = executions_left - 1;
 
@@ -335,31 +335,28 @@ pub contract PendingNoteHashes {
         let good_note = ValueNote::new(10, owner);
         // Insert good note with real log
         let good_note_emission = owner_balance.insert(good_note);
-        good_note_emission.emit(&mut context, owner, MessageDelivery.CONSTRAINED_ONCHAIN);
+        good_note_emission.emit(owner, MessageDelivery.CONSTRAINED_ONCHAIN);
 
         // We will emit a note log with an incorrect preimage to ensure the pxe throws
         // This note has not been inserted...
         // ...but we need a 'good' note's storage slot and note hash counter to get the context to add the note log
         let bad_note_emission = NoteEmission::new(
             ValueNote::new(5, owner),
-            good_note_emission.storage_slot,
-            good_note_emission.note_hash_counter,
+            good_note_emission.content.storage_slot,
+            good_note_emission.content.note_hash_counter,
+            &mut context,
         );
 
-        bad_note_emission.emit(&mut context, owner, MessageDelivery.CONSTRAINED_ONCHAIN);
+        bad_note_emission.emit(owner, MessageDelivery.CONSTRAINED_ONCHAIN);
     }
 
     #[contract_library_method]
-    fn create_max_notes(
-        owner: AztecAddress,
-        storage: Storage<&mut PrivateContext>,
-        context: &mut PrivateContext,
-    ) {
+    fn create_max_notes(owner: AztecAddress, storage: Storage<&mut PrivateContext>) {
         let owner_balance = storage.balances.at(owner);
 
         for i in 0..max_notes_per_call() {
             let note = ValueNote::new(i as Field, owner);
-            owner_balance.insert(note).emit(context, owner, MessageDelivery.CONSTRAINED_ONCHAIN);
+            owner_balance.insert(note).emit(owner, MessageDelivery.CONSTRAINED_ONCHAIN);
         }
     }
 

--- a/noir-projects/noir-contracts/contracts/test/spam_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/spam_contract/src/main.nr
@@ -34,7 +34,6 @@ pub contract Spam {
 
         for _ in 0..MAX_NOTE_HASHES_PER_CALL {
             storage.balances.at(caller).add(caller, amount).emit(
-                &mut context,
                 caller,
                 MessageDelivery.UNCONSTRAINED_ONCHAIN,
             );

--- a/noir-projects/noir-contracts/contracts/test/spam_contract/src/types/balance_set.nr
+++ b/noir-projects/noir-contracts/contracts/test/spam_contract/src/types/balance_set.nr
@@ -67,13 +67,15 @@ impl<Note> BalanceSet<Note, &mut PrivateContext> {
     where
         Note: NoteType + NoteHash + OwnedNote + Eq + Packable,
     {
-        if addend == 0 as u128 {
-            OuterNoteEmission::new(Option::none())
+        let content_option = if addend == 0 as u128 {
+            Option::none()
         } else {
             let mut addend_note = Note::new(addend, owner);
 
-            OuterNoteEmission::new(Option::some(self.set.insert(addend_note)))
-        }
+            Option::some(self.set.insert(addend_note).content)
+        };
+
+        OuterNoteEmission::new(content_option, self.set.context)
     }
 
     pub fn sub(self: Self, owner: AztecAddress, amount: u128) -> OuterNoteEmission<Note>

--- a/noir-projects/noir-contracts/contracts/test/state_vars_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/state_vars_contract/src/main.nr
@@ -102,7 +102,6 @@ pub contract StateVars {
         let new_note = ValueNote::new(value, context.msg_sender().unwrap());
 
         storage.private_immutable.initialize(new_note).emit(
-            &mut context,
             context.msg_sender().unwrap(),
             MessageDelivery.CONSTRAINED_ONCHAIN,
         );
@@ -113,7 +112,6 @@ pub contract StateVars {
         let private_mutable = ValueNote::new(value, context.msg_sender().unwrap());
 
         storage.private_mutable.initialize(private_mutable).emit(
-            &mut context,
             context.msg_sender().unwrap(),
             MessageDelivery.CONSTRAINED_ONCHAIN,
         );
@@ -124,7 +122,7 @@ pub contract StateVars {
         storage
             .private_mutable
             .replace(|_old_note| ValueNote::new(value, context.msg_sender().unwrap()))
-            .emit(&mut context, context.msg_sender().unwrap(), MessageDelivery.CONSTRAINED_ONCHAIN);
+            .emit(context.msg_sender().unwrap(), MessageDelivery.CONSTRAINED_ONCHAIN);
     }
 
     #[private]
@@ -136,7 +134,7 @@ pub contract StateVars {
                 let new_value = old_note.value() + 1;
                 ValueNote::new(new_value, context.msg_sender().unwrap())
             })
-            .emit(&mut context, context.msg_sender().unwrap(), MessageDelivery.CONSTRAINED_ONCHAIN);
+            .emit(context.msg_sender().unwrap(), MessageDelivery.CONSTRAINED_ONCHAIN);
     }
 
     #[utility]

--- a/noir-projects/noir-contracts/contracts/test/stateful_test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/stateful_test_contract/src/main.nr
@@ -52,7 +52,7 @@ pub contract StatefulTest {
         if (value != 0) {
             let loc = storage.notes.at(owner);
             let note = ValueNote::new(value, owner);
-            loc.insert(note).emit(&mut context, owner, MessageDelivery.CONSTRAINED_ONCHAIN);
+            loc.insert(note).emit(owner, MessageDelivery.CONSTRAINED_ONCHAIN);
         }
     }
 
@@ -62,7 +62,7 @@ pub contract StatefulTest {
         if (value != 0) {
             let loc = storage.notes.at(owner);
             let note = ValueNote::new(value, owner);
-            loc.insert(note).emit(&mut context, owner, MessageDelivery.CONSTRAINED_ONCHAIN);
+            loc.insert(note).emit(owner, MessageDelivery.CONSTRAINED_ONCHAIN);
         }
     }
 
@@ -75,7 +75,6 @@ pub contract StatefulTest {
         let _ = sender_notes.pop_notes(NoteGetterOptions::new().set_limit(2));
 
         storage.notes.at(recipient).insert(ValueNote::new(92, recipient)).emit(
-            &mut context,
             recipient,
             MessageDelivery.CONSTRAINED_ONCHAIN,
         );
@@ -90,7 +89,6 @@ pub contract StatefulTest {
         let _ = sender_notes.pop_notes(NoteGetterOptions::new().set_limit(2));
 
         storage.notes.at(recipient).insert(ValueNote::new(92, recipient)).emit(
-            &mut context,
             recipient,
             MessageDelivery.CONSTRAINED_ONCHAIN,
         );

--- a/noir-projects/noir-contracts/contracts/test/static_child_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/static_child_contract/src/main.nr
@@ -46,11 +46,7 @@ pub contract StaticChild {
     #[view]
     fn private_illegal_set_value(new_value: Field, owner: AztecAddress) -> Field {
         let note = ValueNote::new(new_value, owner);
-        storage.a_private_value.insert(note).emit(
-            &mut context,
-            owner,
-            MessageDelivery.CONSTRAINED_ONCHAIN,
-        );
+        storage.a_private_value.insert(note).emit(owner, MessageDelivery.CONSTRAINED_ONCHAIN);
         new_value
     }
 
@@ -59,11 +55,7 @@ pub contract StaticChild {
     fn private_set_value(new_value: Field, owner: AztecAddress, sender: AztecAddress) -> Field {
         let note = ValueNote::new(new_value, owner);
 
-        storage.a_private_value.insert(note).emit(
-            &mut context,
-            owner,
-            MessageDelivery.CONSTRAINED_ONCHAIN,
-        );
+        storage.a_private_value.insert(note).emit(owner, MessageDelivery.CONSTRAINED_ONCHAIN);
         new_value
     }
 

--- a/noir-projects/noir-contracts/contracts/test/test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/test_contract/src/main.nr
@@ -141,7 +141,6 @@ pub contract Test {
     ) {
         let note = UintNote::new(value, owner);
         create_note(&mut context, storage_slot, note).emit(
-            &mut context,
             owner,
             MessageDelivery.CONSTRAINED_ONCHAIN,
         );

--- a/noir-projects/noir-contracts/contracts/test/updatable_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/updatable_contract/src/main.nr
@@ -26,11 +26,7 @@ contract Updatable {
     fn initialize(initial_value: Field) {
         let owner = context.msg_sender().unwrap();
         let new_value = ValueNote::new(initial_value, owner);
-        storage.private_value.initialize(new_value).emit(
-            &mut context,
-            owner,
-            MessageDelivery.CONSTRAINED_ONCHAIN,
-        );
+        storage.private_value.initialize(new_value).emit(owner, MessageDelivery.CONSTRAINED_ONCHAIN);
         Updatable::at(context.this_address()).set_public_value(initial_value).enqueue(&mut context);
     }
 

--- a/noir-projects/noir-contracts/contracts/test/updated_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/updated_contract/src/main.nr
@@ -28,7 +28,6 @@ contract Updated {
         let owner = context.msg_sender().unwrap();
 
         storage.private_value.replace(|_old| ValueNote::new(27, owner)).emit(
-            &mut context,
             owner,
             MessageDelivery.CONSTRAINED_ONCHAIN,
         );


### PR DESCRIPTION
In discussing how to improve developer experience by getting rid of the `context` object as much as possible, I realized some of it is quite low hanging fruit. We can take a similar approach to the `storage` object and have the aztec-nr intermediate structs keep references to the context, resulting in the end-user invoking methods that already reference the context instead of having to manually provide it. The diff speaks for itself.

Closes https://linear.app/aztec-labs/issue/F-109/remove-context-when-delivering-messages.