### PR TITLE
docs(v1.2.0): replace broken blog link with docs.aztec.network

### DIFF
--- a/docs/versioned_docs/version-v1.2.0/index.mdx
+++ b/docs/versioned_docs/version-v1.2.0/index.mdx
@@ -22,7 +22,7 @@ On Ethereum today, everything is publicly visible, by everyone. In the real worl
 
 To make this possible, Aztec is _not EVM compatible_ and is extending the Ethereum ecosystem by creating a new alt-VM!
 
-To learn more about how Aztec achieves these things, check out the [Aztec concepts overview](/aztec).
+To learn more about how Aztec achieves these things, check out the [https://docs.aztec.network/](/aztec).
 
 ## Start coding
 


### PR DESCRIPTION
- Old link (aztec.network/blog-what-is-aztec-testnet) returned 404  
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/50016176-5c5f-4014-ad7d-788c0e78317e" />

- Updated to https://docs.aztec.network/ as the canonical docs site  
-  Fix applied in versioned_docs/version-v1.2.0/index.mdx

Please read [contributing guidelines](CONTRIBUTING.md) and remove this line.

For audit-related pull requests, please use the [audit PR template](?expand=1&template=audit.md).
