### PR TITLE
feat: ensuring PXE respects synced block

### DIFF
--- a/yarn-project/pxe/src/contract_function_simulator/pxe_oracle_interface.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/pxe_oracle_interface.ts
@@ -203,22 +203,38 @@ export class PXEOracleInterface implements ExecutionDataProvider {
     return this.aztecNode.getNullifierMembershipWitness(blockNumber, nullifier);
   }
 
-  public getLowNullifierMembershipWitness(
+  public async getLowNullifierMembershipWitness(
     blockNumber: number,
     nullifier: Fr,
   ): Promise<NullifierMembershipWitness | undefined> {
+    const header = await this.getBlockHeader();
+    if (blockNumber > header.globalVariables.blockNumber) {
+      throw new Error(`Block number ${blockNumber} is higher than current block ${header.globalVariables.blockNumber}`);
+    }
     return this.aztecNode.getLowNullifierMembershipWitness(blockNumber, nullifier);
   }
 
   public async getBlock(blockNumber: number): Promise<L2Block | undefined> {
+    const header = await this.getBlockHeader();
+    if (blockNumber > header.globalVariables.blockNumber) {
+      throw new Error(`Block number ${blockNumber} is higher than current block ${header.globalVariables.blockNumber}`);
+    }
     return await this.aztecNode.getBlock(blockNumber);
   }
 
   public async getPublicDataWitness(blockNumber: number, leafSlot: Fr): Promise<PublicDataWitness | undefined> {
+    const header = await this.getBlockHeader();
+    if (blockNumber > header.globalVariables.blockNumber) {
+      throw new Error(`Block number ${blockNumber} is higher than current block ${header.globalVariables.blockNumber}`);
+    }
     return await this.aztecNode.getPublicDataWitness(blockNumber, leafSlot);
   }
 
   public async getPublicStorageAt(blockNumber: number, contract: AztecAddress, slot: Fr): Promise<Fr> {
+    const header = await this.getBlockHeader();
+    if (blockNumber > header.globalVariables.blockNumber) {
+      throw new Error(`Block number ${blockNumber} is higher than current block ${header.globalVariables.blockNumber}`);
+    }
     return await this.aztecNode.getPublicStorageAt(blockNumber, contract, slot);
   }
 


### PR DESCRIPTION
Until know we didn't check that the functions fetching info from Aztec Node with block number on the input respect the PXE's view of the network - refuse to obtain info from a newer block than the one synced by PXE.

In this PR I add the checks in those functions and I test it all behaves as expected. This should make the behavior of PXE more robust - you will not be able to receive info from an Aztec Node whose legitimacy you will not be able to prove against the anchor block (which seems like a very important property).