### PR TITLE
docs: fix a broken link in glossary.md

### DIFF
--- a/docs/docs/glossary.md
+++ b/docs/docs/glossary.md
@@ -51,7 +51,7 @@ Read more and review the source code [here](https://aztec.nr).
 
 With `nargo`, you can start new projects, compile, execute, and test your Noir programs.
 
-You can find more information in the nargo installation docs [here](https://noir-lang.org/docs/getting_started/installation/) and the nargo command reference [here](https://noir-lang.org/docs/reference/nargo_commands).
+You can find more information in the nargo installation docs [here](https://noir-lang.org/docs/getting_started/quick_start) and the nargo command reference [here](https://noir-lang.org/docs/reference/nargo_commands).
 
 ### Noir
 


### PR DESCRIPTION
Fixed an invalid link for nargo installation in the glossary.