### PR TITLE
fix: Wait until rollup catches up to inbox for msg sync

### DIFF
--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -82,7 +82,7 @@ import {
   tryStop,
 } from '@aztec/stdlib/interfaces/server';
 import type { LogFilter, PrivateLog, TxScopedL2Log } from '@aztec/stdlib/logs';
-import type { L1ToL2MessageSource } from '@aztec/stdlib/messaging';
+import { InboxLeaf, type L1ToL2MessageSource } from '@aztec/stdlib/messaging';
 import { P2PClientType } from '@aztec/stdlib/p2p';
 import type { Offense, SlashPayloadRound } from '@aztec/stdlib/slashing';
 import type { NullifierLeafPreimage, PublicDataTreeLeaf, PublicDataTreeLeafPreimage } from '@aztec/stdlib/trees';
@@ -860,13 +860,19 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, Traceable {
     return [witness.index, witness.path];
   }
 
+  public async getL1ToL2MessageBlock(l1ToL2Message: Fr): Promise<number | undefined> {
+    const messageIndex = await this.l1ToL2MessageSource.getL1ToL2MessageIndex(l1ToL2Message);
+    return messageIndex ? InboxLeaf.l2BlockFromIndex(messageIndex) : undefined;
+  }
+
   /**
    * Returns whether an L1 to L2 message is synced by archiver and if it's ready to be included in a block.
    * @param l1ToL2Message - The L1 to L2 message to check.
    * @returns Whether the message is synced and ready to be included in a block.
    */
   public async isL1ToL2MessageSynced(l1ToL2Message: Fr): Promise<boolean> {
-    return (await this.l1ToL2MessageSource.getL1ToL2MessageIndex(l1ToL2Message)) !== undefined;
+    const messageIndex = await this.l1ToL2MessageSource.getL1ToL2MessageIndex(l1ToL2Message);
+    return messageIndex !== undefined;
   }
 
   /**

--- a/yarn-project/aztec.js/src/api/utils.ts
+++ b/yarn-project/aztec.js/src/api/utils.ts
@@ -19,3 +19,4 @@ export { waitForPXE } from '../utils/pxe.js';
 export { waitForNode, createAztecNodeClient, type AztecNode } from '../utils/node.js';
 export { getFeeJuiceBalance } from '../utils/fee_juice.js';
 export { readFieldCompressedString } from '../utils/field_compressed_string.js';
+export { isL1ToL2MessageReady, waitForL1ToL2MessageReady } from '../utils/cross_chain.js';

--- a/yarn-project/aztec.js/src/contract/batch_call.ts
+++ b/yarn-project/aztec.js/src/contract/batch_call.ts
@@ -15,6 +15,14 @@ export class BatchCall extends BaseContractInteraction {
   }
 
   /**
+   * Creates a new instance with no actual calls. Useful for triggering a no-op.
+   * @param wallet - The wallet to use for sending the batch call.
+   */
+  public static empty(wallet: Wallet) {
+    return new BatchCall(wallet, []);
+  }
+
+  /**
    * Returns an execution request that represents this operation.
    * @param options - An optional object containing additional configuration for the request generation.
    * @returns An execution payload wrapped in promise.

--- a/yarn-project/aztec.js/src/utils/cross_chain.ts
+++ b/yarn-project/aztec.js/src/utils/cross_chain.ts
@@ -1,0 +1,54 @@
+import type { Fr } from '@aztec/foundation/fields';
+import { retryUntil } from '@aztec/foundation/retry';
+
+import type { PXE } from '../api/interfaces.js';
+
+/**
+ * Waits for the L1 to L2 message to be ready to be consumed.
+ * @param pxe - PXE instance
+ * @param l1ToL2MessageHash - Hash of the L1 to L2 message
+ * @param opts - Options
+ */
+export async function waitForL1ToL2MessageReady(
+  pxe: Pick<PXE, 'getBlockNumber' | 'getL1ToL2MessageBlock'>,
+  l1ToL2MessageHash: Fr,
+  opts: {
+    /** Timeout for the operation in seconds */ timeoutSeconds: number;
+    /** True if the message is meant to be consumed from a public function */ forPublicConsumption: boolean;
+  },
+) {
+  const messageBlockNumber = await pxe.getL1ToL2MessageBlock(l1ToL2MessageHash);
+  return retryUntil(
+    () => isL1ToL2MessageReady(pxe, l1ToL2MessageHash, { ...opts, messageBlockNumber }),
+    `L1 to L2 message ${l1ToL2MessageHash.toString()} ready`,
+    opts.timeoutSeconds,
+    1,
+  );
+}
+
+/**
+ * Returns whether the L1 to L2 message is ready to be consumed.
+ * @param pxe - PXE instance
+ * @param l1ToL2MessageHash - Hash of the L1 to L2 message
+ * @param opts - Options
+ * @returns True if the message is ready to be consumed, false otherwise
+ */
+export async function isL1ToL2MessageReady(
+  pxe: Pick<PXE, 'getBlockNumber' | 'getL1ToL2MessageBlock'>,
+  l1ToL2MessageHash: Fr,
+  opts: {
+    /** True if the message is meant to be consumed from a public function */ forPublicConsumption: boolean;
+    /** Cached synced block number for the message (will be fetched from PXE otherwise) */ messageBlockNumber?: number;
+  },
+): Promise<boolean> {
+  const blockNumber = await pxe.getBlockNumber();
+  const messageBlockNumber = opts.messageBlockNumber ?? (await pxe.getL1ToL2MessageBlock(l1ToL2MessageHash));
+  if (messageBlockNumber === undefined) {
+    return false;
+  }
+
+  // Note that public messages can be consumed 1 block earlier, since the sequencer will include the messages
+  // in the L1 to L2 message tree before executing the txs for the block. In private, however, we need to wait
+  // until the message is included so we can make use of the membership witness.
+  return opts.forPublicConsumption ? blockNumber + 1 >= messageBlockNumber : blockNumber >= messageBlockNumber;
+}

--- a/yarn-project/aztec/src/testing/anvil_test_watcher.ts
+++ b/yarn-project/aztec/src/testing/anvil_test_watcher.ts
@@ -50,6 +50,7 @@ export class AnvilTestWatcher {
   }
 
   setIsMarkingAsProven(isMarkingAsProven: boolean) {
+    this.logger.warn(`Watcher is now ${isMarkingAsProven ? 'marking' : 'not marking'} blocks as proven`);
     this.isMarkingAsProven = isMarkingAsProven;
   }
 

--- a/yarn-project/bot/src/config.ts
+++ b/yarn-project/bot/src/config.ts
@@ -154,7 +154,7 @@ export const botConfigMappings: ConfigMappingsType<BotConfig> = {
   l1ToL2MessageTimeoutSeconds: {
     env: 'BOT_L1_TO_L2_TIMEOUT_SECONDS',
     description: 'How long to wait for L1 to L2 messages to become available on L2',
-    ...numberConfigHelper(60),
+    ...numberConfigHelper(3600),
   },
   senderPrivateKey: {
     env: 'BOT_PRIVATE_KEY',

--- a/yarn-project/end-to-end/src/e2e_cross_chain_messaging/l1_to_l2.test.ts
+++ b/yarn-project/end-to-end/src/e2e_cross_chain_messaging/l1_to_l2.test.ts
@@ -1,74 +1,234 @@
-import { type AztecAddress, Fr, generateClaimSecret } from '@aztec/aztec.js';
+import {
+  AztecAddress,
+  type AztecNode,
+  BatchCall,
+  Fr,
+  type Logger,
+  TxStatus,
+  type Wallet,
+  generateClaimSecret,
+  retryUntil,
+} from '@aztec/aztec.js';
+import { isL1ToL2MessageReady } from '@aztec/aztec.js';
+import { timesAsync } from '@aztec/foundation/collection';
 import { TestContract } from '@aztec/noir-test-contracts.js/Test';
 
 import { sendL1ToL2Message } from '../fixtures/l1_to_l2_messaging.js';
+import type { CrossChainTestHarness } from '../shared/cross_chain_test_harness.js';
 import { CrossChainMessagingTest } from './cross_chain_messaging_test.js';
 
 describe('e2e_cross_chain_messaging l1_to_l2', () => {
-  const t = new CrossChainMessagingTest('l1_to_l2');
+  let t: CrossChainMessagingTest;
+  let log: Logger;
+  let crossChainTestHarness: CrossChainTestHarness;
+  let aztecNode: AztecNode;
+  let wallet: Wallet;
+  let user1Address: AztecAddress;
+  let testContract: TestContract;
 
-  let { crossChainTestHarness, aztecNode, wallet, user1Address } = t;
-
-  beforeAll(async () => {
+  beforeEach(async () => {
+    t = new CrossChainMessagingTest(
+      'l1_to_l2',
+      { minTxsPerBlock: 1 },
+      { aztecProofSubmissionEpochs: 2, aztecEpochDuration: 4 },
+    );
     await t.applyBaseSnapshots();
     await t.setup();
-    // Have to destructure again to ensure we have latest refs.
-    ({ crossChainTestHarness, wallet, user1Address } = t);
 
-    aztecNode = crossChainTestHarness.aztecNode;
+    ({ logger: log, crossChainTestHarness, wallet, user1Address, aztecNode } = t);
+    testContract = await TestContract.deploy(wallet).send({ from: user1Address }).deployed();
   }, 300_000);
 
-  afterAll(async () => {
+  afterEach(async () => {
     await t.teardown();
   });
 
-  // Note: We register one portal address when deploying contract but that address is no-longer the only address
+  const getConsumeMethod = (scope: 'private' | 'public') =>
+    scope === 'private'
+      ? testContract.methods.consume_message_from_arbitrary_sender_private
+      : testContract.methods.consume_message_from_arbitrary_sender_public;
+
+  // Sends a tx to L2 to advance the block number by 1
+  const advanceBlock = async () => {
+    const block = await aztecNode.getBlockNumber();
+    log.warn(`Sending noop tx at block ${block}`);
+    await BatchCall.empty(wallet).send({ from: user1Address }).wait();
+    const newBlock = await aztecNode.getBlockNumber();
+    log.warn(`Advanced to block ${newBlock}`);
+    if (newBlock !== block + 1) {
+      throw new Error(`Failed to advance block ${block}`);
+    }
+    return undefined;
+  };
+
+  // Same as above but ignores errors. Useful if we expect a prune.
+  const tryAdvanceBlock = async () => {
+    try {
+      await advanceBlock();
+    } catch (err) {
+      log.warn(`Failed to advance block: ${(err as Error).message}`);
+    }
+  };
+
+  // Waits until the message is fetched by the archiver of the node and returns the msg target block
+  const waitForMessageFetched = async (msgHash: Fr) => {
+    log.warn(`Waiting until the message is fetched by the node`);
+    return await retryUntil(
+      async () => (await aztecNode.getL1ToL2MessageBlock(msgHash)) ?? (await advanceBlock()),
+      'get msg block',
+      60,
+    );
+  };
+
+  // Waits until the message is ready to be consumed on L2 as it's been added to the world state
+  const waitForMessageReady = async (
+    msgHash: Fr,
+    scope: 'private' | 'public',
+    onNotReady?: (blockNumber: number) => Promise<void>,
+  ) => {
+    const msgBlock = await waitForMessageFetched(msgHash);
+    log.warn(`Waiting until L2 reaches msg block ${msgBlock} (current is ${await aztecNode.getBlockNumber()})`);
+    await retryUntil(
+      async () => {
+        const blockNumber = await aztecNode.getBlockNumber();
+        const witness = await aztecNode.getL1ToL2MessageMembershipWitness('latest', msgHash);
+        const isReady = await isL1ToL2MessageReady(aztecNode, msgHash, { forPublicConsumption: scope === 'public' });
+        log.info(`Block is ${blockNumber}. Message block is ${msgBlock}. Witness ${!!witness}. Ready ${isReady}.`);
+        if (!isReady) {
+          await (onNotReady ? onNotReady(blockNumber) : advanceBlock());
+        }
+        return isReady;
+      },
+      `wait for rollup to reach msg block ${msgBlock}`,
+      120,
+    );
+  };
+
+  // We register one portal address when deploying contract but that address is no-longer the only address
   // allowed to send messages to the given contract. In the following test we'll test that it's really the case.
-  it.each([true, false])(
-    'can send an L1 -> L2 message from a non-registered portal address consumed from private or public and then sends and claims exactly the same message again',
-    async (isPrivate: boolean) => {
-      const testContract = await TestContract.deploy(wallet).send({ from: user1Address }).deployed();
-
-      const consumeMethod = isPrivate
-        ? testContract.methods.consume_message_from_arbitrary_sender_private
-        : testContract.methods.consume_message_from_arbitrary_sender_public;
-
+  // We'll also test that we can send the same message content across the bridge multiple times.
+  it.each(['private', 'public'] as const)(
+    'can send an L1 to L2 message from a non-registered portal address consumed from %s repeatedly',
+    async (scope: 'private' | 'public') => {
+      // Generate and send the message to the L1 contract
       const [secret, secretHash] = await generateClaimSecret();
-
       const message = { recipient: testContract.address, content: Fr.random(), secretHash };
-      const [message1Hash, actualMessage1Index] = await sendL2Message(message);
+      const { msgHash: message1Hash, globalLeafIndex: actualMessage1Index } = await sendL1ToL2Message(
+        message,
+        crossChainTestHarness,
+      );
 
-      const [message1Index] = (await aztecNode.getL1ToL2MessageMembershipWitness('latest', message1Hash))!;
-      expect(actualMessage1Index.toBigInt()).toBe(message1Index);
+      await waitForMessageReady(message1Hash, scope);
 
-      // Finally, we consume the L1 -> L2 message using the test contract either from private or public
-      await consumeMethod(message.content, secret, crossChainTestHarness.ethAccount, message1Index)
+      // The waitForMessageReady returns true earlier for public-land, so we can only check the membership
+      // witness for private-land here.
+      if (scope === 'private') {
+        const [message1Index] = (await aztecNode.getL1ToL2MessageMembershipWitness('latest', message1Hash))!;
+        expect(actualMessage1Index.toBigInt()).toBe(message1Index);
+      }
+
+      // We consume the L1 to L2 message using the test contract either from private or public
+      await getConsumeMethod(scope)(message.content, secret, crossChainTestHarness.ethAccount, actualMessage1Index)
         .send({ from: user1Address })
         .wait();
 
       // We send and consume the exact same message the second time to test that oracles correctly return the new
       // non-nullified message
-      const [message2Hash, actualMessage2Index] = await sendL2Message(message);
+      const { msgHash: message2Hash, globalLeafIndex: actualMessage2Index } = await sendL1ToL2Message(
+        message,
+        crossChainTestHarness,
+      );
 
       // We check that the duplicate message was correctly inserted by checking that its message index is defined
-      const [message2Index] = (await aztecNode.getL1ToL2MessageMembershipWitness('latest', message2Hash))!;
+      await waitForMessageReady(message2Hash, scope);
 
-      expect(message2Index).toBeDefined();
-      expect(message2Index).toBeGreaterThan(message1Index);
-      expect(actualMessage2Index.toBigInt()).toBe(message2Index);
+      if (scope === 'private') {
+        const [message2Index] = (await aztecNode.getL1ToL2MessageMembershipWitness('latest', message2Hash))!;
+        expect(message2Index).toBeDefined();
+        expect(message2Index).toBeGreaterThan(actualMessage1Index.toBigInt());
+        expect(actualMessage2Index.toBigInt()).toBe(message2Index);
+      }
 
       // Now we consume the message again. Everything should pass because oracle should return the duplicate message
       // which is not nullified
-      await consumeMethod(message.content, secret, crossChainTestHarness.ethAccount, message2Index)
+      await getConsumeMethod(scope)(message.content, secret, crossChainTestHarness.ethAccount, actualMessage2Index)
         .send({ from: user1Address })
         .wait();
     },
     120_000,
   );
 
-  const sendL2Message = async (message: { recipient: AztecAddress; content: Fr; secretHash: Fr }) => {
-    const { msgHash, globalLeafIndex } = await sendL1ToL2Message(message, crossChainTestHarness);
-    await crossChainTestHarness.makeMessageConsumable(msgHash);
-    return [msgHash, globalLeafIndex];
-  };
+  // Inbox block number can drift on two scenarios: if the rollup reorgs and rolls back its own
+  // block number, or if the inbox receives too many messages and they are inserted faster than
+  // they are consumed. In this test, we mine several blocks without marking them as proven until
+  // we can trigger a reorg, and then wait until the message can be processed to consume it.
+  it.each(['private', 'public'] as const)(
+    'can consume L1 to L2 message in %s after inbox drifts away from the rollup',
+    async (scope: 'private' | 'public') => {
+      // Stop proving
+      const lastProven = await aztecNode.getBlockNumber();
+      log.warn(`Stopping proof submission at block ${lastProven} to allow drift`);
+      t.ctx.watcher.setIsMarkingAsProven(false);
+
+      // Mine several blocks to ensure drift
+      log.warn(`Mining blocks to allow drift`);
+      await timesAsync(4, advanceBlock);
+
+      // Generate and send the message to the L1 contract
+      log.warn(`Sending L1 to L2 message`);
+      const [secret, secretHash] = await generateClaimSecret();
+      const message = { recipient: testContract.address, content: Fr.random(), secretHash };
+      const { msgHash, globalLeafIndex } = await sendL1ToL2Message(message, crossChainTestHarness);
+
+      // Wait until the Aztec node has synced it
+      const msgBlockNumber = await waitForMessageFetched(msgHash);
+      log.warn(`Message synced for block ${msgBlockNumber}`);
+      expect(lastProven + 4).toBeLessThan(msgBlockNumber);
+
+      // And keep mining until we prune back to the original block number. Now the "waiting for two blocks"
+      // strategy for the message to be ready to use shouldn't work, since the lastProven block is more than
+      // two blocks behind the message block. This is the scenario we want to test.
+      log.warn(`Waiting until we prune back to ${lastProven}`);
+      await retryUntil(
+        async () =>
+          (await aztecNode.getBlockNumber().then(b => b === lastProven || b === lastProven + 1)) ||
+          (await tryAdvanceBlock()),
+        'wait for prune',
+        40,
+      );
+
+      // Check that there is no witness yet
+      expect(await aztecNode.getL1ToL2MessageMembershipWitness('latest', msgHash)).toBeUndefined();
+
+      // Define L2 function to consume the message
+      const consume = () =>
+        getConsumeMethod(scope)(message.content, secret, crossChainTestHarness.ethAccount, globalLeafIndex);
+
+      // Wait until the message is ready to be consumed, checking that it cannot be consumed beforehand
+      await waitForMessageReady(msgHash, scope, async () => {
+        if (scope === 'private') {
+          // On private, we simulate the tx locally and check that we get a missing message error, then we advance to the next block
+          await expect(() => consume().simulate({ from: user1Address })).rejects.toThrow(/No L1 to L2 message found/);
+          await advanceBlock();
+          await t.ctx.watcher.markAsProven();
+        } else {
+          // On public, we actually send the tx and check that it reverts due to the missing message.
+          // This advances the block too as a side-effect. Note that we do not rely on a simulation since the cross chain messages
+          // do not get added at the beginning of the block during node_simulatePublicCalls (maybe they should?).
+          const { status } = await consume().send({ from: user1Address }).wait({ dontThrowOnRevert: true });
+          expect(status).toEqual(TxStatus.APP_LOGIC_REVERTED);
+          await t.ctx.watcher.markAsProven();
+        }
+      });
+
+      // Verify the membership witness is available for creating the tx (private-land only)
+      if (scope === 'private') {
+        const [messageIndex] = (await aztecNode.getL1ToL2MessageMembershipWitness('latest', msgHash))!;
+        expect(messageIndex).toEqual(globalLeafIndex.toBigInt());
+      }
+
+      // And consume the message
+      await consume().send({ from: user1Address }).wait();
+    },
+  );
 });

--- a/yarn-project/ethereum/src/test/rollup_cheat_codes.test.ts
+++ b/yarn-project/ethereum/src/test/rollup_cheat_codes.test.ts
@@ -1,0 +1,98 @@
+import { getPublicClient } from '@aztec/ethereum';
+import { Fr } from '@aztec/foundation/fields';
+import { type Logger, createLogger } from '@aztec/foundation/log';
+import { InboxAbi } from '@aztec/l1-artifacts/InboxAbi';
+
+import type { Anvil } from '@viem/anvil';
+import { type PrivateKeyAccount, privateKeyToAccount } from 'viem/accounts';
+import { foundry } from 'viem/chains';
+
+import { DefaultL1ContractsConfig } from '../config.js';
+import { deployL1Contracts } from '../deploy_l1_contracts.js';
+import type { ViemClient } from '../types.js';
+import { EthCheatCodes } from './eth_cheat_codes.js';
+import { RollupCheatCodes } from './rollup_cheat_codes.js';
+import { startAnvil } from './start_anvil.js';
+
+describe('RollupCheatCodes', () => {
+  let anvil: Anvil;
+  let rpcUrl: string;
+  let privateKey: PrivateKeyAccount;
+  let logger: Logger;
+  let publicClient: ViemClient;
+  let cheatCodes: EthCheatCodes;
+  let rollupCheatCodes: RollupCheatCodes;
+
+  let vkTreeRoot: Fr;
+  let protocolContractTreeRoot: Fr;
+  let deployedL1Contracts: Awaited<ReturnType<typeof deployL1Contracts>>;
+
+  beforeAll(async () => {
+    logger = createLogger('ethereum:test:rollup_cheat_codes');
+    // this is the 6th address that gets funded by the junk mnemonic
+    privateKey = privateKeyToAccount('0x8b3a350cf5c34c9194ca85829a2df0ec3153be0318b5e2d3348e872092edffba');
+    vkTreeRoot = Fr.random();
+    protocolContractTreeRoot = Fr.random();
+
+    ({ anvil, rpcUrl } = await startAnvil());
+
+    publicClient = getPublicClient({ l1RpcUrls: [rpcUrl], l1ChainId: 31337 });
+    cheatCodes = new EthCheatCodes([rpcUrl]);
+
+    deployedL1Contracts = await deployL1Contracts([rpcUrl], privateKey, foundry, logger, {
+      ...DefaultL1ContractsConfig,
+      salt: undefined,
+      vkTreeRoot,
+      protocolContractTreeRoot,
+      genesisArchiveRoot: Fr.random(),
+      realVerifier: false,
+    });
+
+    rollupCheatCodes = RollupCheatCodes.create([rpcUrl], deployedL1Contracts.l1ContractAddresses);
+  });
+
+  afterAll(async () => {
+    await cheatCodes.setIntervalMining(0);
+    await anvil?.stop().catch(err => createLogger('cleanup').error(err));
+  });
+
+  describe('advanceInboxInProgress', () => {
+    it('should advance the inbox inProgress field correctly', async () => {
+      const inboxAddress = deployedL1Contracts.l1ContractAddresses.inboxAddress.toString();
+
+      // Read initial state directly from contract
+      const initialState = await publicClient.readContract({
+        address: inboxAddress as `0x${string}`,
+        abi: InboxAbi,
+        functionName: 'getState',
+      });
+
+      const initialInProgress = initialState.inProgress;
+      const initialRollingHash = initialState.rollingHash;
+      const initialTotalMessagesInserted = initialState.totalMessagesInserted;
+
+      // Advance the inbox inProgress by a large amount
+      const advanceBy = 1000n;
+      const newInProgress = await rollupCheatCodes.advanceInboxInProgress(advanceBy);
+
+      // Read state after advancement
+      const finalState = await publicClient.readContract({
+        address: inboxAddress as `0x${string}`,
+        abi: InboxAbi,
+        functionName: 'getState',
+      });
+
+      const finalInProgress = finalState.inProgress;
+      const finalRollingHash = finalState.rollingHash;
+      const finalTotalMessagesInserted = finalState.totalMessagesInserted;
+
+      // Check that the advancement worked
+      expect(newInProgress).toBe(initialInProgress + advanceBy);
+      expect(finalInProgress).toBe(initialInProgress + advanceBy);
+
+      // Check that all other fields remain unchanged
+      expect(finalRollingHash).toBe(initialRollingHash);
+      expect(finalTotalMessagesInserted).toBe(initialTotalMessagesInserted);
+    });
+  });
+});

--- a/yarn-project/pxe/src/pxe_service/pxe_service.ts
+++ b/yarn-project/pxe/src/pxe_service/pxe_service.ts
@@ -206,6 +206,10 @@ export class PXEService implements PXE {
     return this.node.isL1ToL2MessageSynced(l1ToL2Message);
   }
 
+  public getL1ToL2MessageBlock(l1ToL2Message: Fr): Promise<number | undefined> {
+    return this.node.getL1ToL2MessageBlock(l1ToL2Message);
+  }
+
   public async getL2ToL1MembershipWitness(
     blockNumber: number,
     l2Tol1Message: Fr,

--- a/yarn-project/slasher/src/watchers/epoch_prune_watcher.ts
+++ b/yarn-project/slasher/src/watchers/epoch_prune_watcher.ts
@@ -93,7 +93,9 @@ export class EpochPruneWatcher extends (EventEmitter as new () => WatcherEmitter
       })
       .catch(async error => {
         if (error instanceof TransactionsNotAvailableError) {
-          this.log.info(`Data for pruned epoch ${epochNumber} was not available. Will want to slash.`, error);
+          this.log.info(`Data for pruned epoch ${epochNumber} was not available. Will want to slash.`, {
+            message: error.message,
+          });
           const validators = await this.getValidatorsForEpoch(epochNumber);
           return {
             validators,

--- a/yarn-project/stdlib/src/interfaces/aztec-node.test.ts
+++ b/yarn-project/stdlib/src/interfaces/aztec-node.test.ts
@@ -119,6 +119,11 @@ describe('AztecNodeApiSchema', () => {
     expect(response).toEqual([1n, expect.any(SiblingPath)]);
   });
 
+  it('getL1ToL2MessageBlock', async () => {
+    const response = await context.client.getL1ToL2MessageBlock(Fr.random());
+    expect(response).toEqual(5);
+  });
+
   it('isL1ToL2MessageSynced', async () => {
     const response = await context.client.isL1ToL2MessageSynced(Fr.random());
     expect(response).toBe(true);
@@ -533,6 +538,10 @@ class MockAztecNode implements AztecNode {
   ): Promise<MembershipWitness<typeof NOTE_HASH_TREE_HEIGHT> | undefined> {
     expect(noteHash).toBeInstanceOf(Fr);
     return Promise.resolve(MembershipWitness.random(NOTE_HASH_TREE_HEIGHT));
+  }
+  getL1ToL2MessageBlock(l1ToL2Message: Fr): Promise<number | undefined> {
+    expect(l1ToL2Message).toBeInstanceOf(Fr);
+    return Promise.resolve(5);
   }
   isL1ToL2MessageSynced(l1ToL2Message: Fr): Promise<boolean> {
     expect(l1ToL2Message).toBeInstanceOf(Fr);

--- a/yarn-project/stdlib/src/interfaces/aztec-node.ts
+++ b/yarn-project/stdlib/src/interfaces/aztec-node.ts
@@ -199,10 +199,14 @@ export interface AztecNode
     l1ToL2Message: Fr,
   ): Promise<[bigint, SiblingPath<typeof L1_TO_L2_MSG_TREE_HEIGHT>] | undefined>;
 
+  /** Returns the L2 block number in which this L1 to L2 message becomes available, or undefined if not found. */
+  getL1ToL2MessageBlock(l1ToL2Message: Fr): Promise<number | undefined>;
+
   /**
-   * Returns whether an L1 to L2 message is synced by archiver and if it's ready to be included in a block.
+   * Returns whether an L1 to L2 message is synced by archiver.
    * @param l1ToL2Message - The L1 to L2 message to check.
-   * @returns Whether the message is synced and ready to be included in a block.
+   * @returns Whether the message is synced.
+   * @deprecated Use `getL1ToL2MessageBlock` instead. This method may return true even if the message is not ready to use.
    */
   isL1ToL2MessageSynced(l1ToL2Message: Fr): Promise<boolean>;
 
@@ -500,6 +504,8 @@ export const AztecNodeApiSchema: ApiSchemaFor<AztecNode> = {
     .function()
     .args(L2BlockNumberSchema, schemas.Fr)
     .returns(z.tuple([schemas.BigInt, SiblingPath.schemaFor(L1_TO_L2_MSG_TREE_HEIGHT)]).optional()),
+
+  getL1ToL2MessageBlock: z.function().args(schemas.Fr).returns(z.number().optional()),
 
   isL1ToL2MessageSynced: z.function().args(schemas.Fr).returns(z.boolean()),
 

--- a/yarn-project/stdlib/src/interfaces/pxe.test.ts
+++ b/yarn-project/stdlib/src/interfaces/pxe.test.ts
@@ -104,6 +104,11 @@ describe('PXESchema', () => {
     await context.client.isL1ToL2MessageSynced(Fr.random());
   });
 
+  it('getL1ToL2MessageBlock', async () => {
+    const result = await context.client.getL1ToL2MessageBlock(Fr.random());
+    expect(result).toEqual(5);
+  });
+
   it('registerAccount', async () => {
     const result = await context.client.registerAccount(Fr.random(), Fr.random());
     expect(result).toBeInstanceOf(CompleteAddress);
@@ -323,6 +328,9 @@ class MockPXE implements PXE {
 
   isL1ToL2MessageSynced(_l1ToL2Message: Fr): Promise<boolean> {
     return Promise.resolve(false);
+  }
+  getL1ToL2MessageBlock(_l1ToL2Message: Fr): Promise<number | undefined> {
+    return Promise.resolve(5);
   }
   registerAccount(secretKey: Fr, partialAddress: Fr): Promise<CompleteAddress> {
     expect(secretKey).toBeInstanceOf(Fr);

--- a/yarn-project/stdlib/src/interfaces/pxe.ts
+++ b/yarn-project/stdlib/src/interfaces/pxe.ts
@@ -56,11 +56,19 @@ import {
  */
 export interface PXE {
   /**
-   * Returns whether an L1 to L2 message is synced by archiver and if it's ready to be included in a block.
+   * Returns whether an L1 to L2 message is synced by archiver.
    * @param l1ToL2Message - The L1 to L2 message to check.
    * @returns Whether the message is synced and ready to be included in a block.
+   * @deprecated Use `waitForL1ToL2MessageReady` and `isL1ToL2MessageReady` instead.
    */
   isL1ToL2MessageSynced(l1ToL2Message: Fr): Promise<boolean>;
+
+  /**
+   * Returns the L2 block number in which this L1 to L2 message becomes available, or undefined if not found.
+   * @param l1ToL2Message - The L1 to L2 message to check.
+   * @returns The L2 block number or undefined if not synced yet.
+   */
+  getL1ToL2MessageBlock(l1ToL2Message: Fr): Promise<number | undefined>;
 
   /**
    * Registers a user account in PXE given its master encryption private key.
@@ -447,6 +455,7 @@ const PXEInfoSchema = z.object({
 
 export const PXESchema: ApiSchemaFor<PXE> = {
   isL1ToL2MessageSynced: z.function().args(schemas.Fr).returns(z.boolean()),
+  getL1ToL2MessageBlock: z.function().args(schemas.Fr).returns(z.number().optional()),
   registerAccount: z.function().args(schemas.Fr, schemas.Fr).returns(CompleteAddress.schema),
   getRegisteredAccounts: z.function().returns(z.array(CompleteAddress.schema)),
   registerSender: z.function().args(schemas.AztecAddress).returns(schemas.AztecAddress),

--- a/yarn-project/stdlib/src/messaging/inbox_leaf.ts
+++ b/yarn-project/stdlib/src/messaging/inbox_leaf.ts
@@ -35,4 +35,9 @@ export class InboxLeaf {
     const end = start + BigInt(NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP);
     return [start, end];
   }
+
+  /** Returns the L2 block number for a given leaf index */
+  static l2BlockFromIndex(index: bigint): number {
+    return Number(index / BigInt(NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP)) + INITIAL_L2_BLOCK_NUM;
+  }
 }


### PR DESCRIPTION
Do not acknowledge an L1 to L2 message as synced until the rollup
pending block number has caught up with the message block. The inbox
block number may drift way ahead of the rollup block number in the event
of a reorg or if there are too many l1 to l2 messages being inserted.    

Note that the existing approach used throughout the codebase of waiting
for two blocks if flawed, since if there was an earlier reorg on the
chain, then the inbox will have drifted and the message will require
more blocks to become available.    

This PR does NOT remove the existing isL1ToL2MessageSynced call, since
it's used all over the place, but rather flags it as deprecated.

Instead, the node and pxe now expose a function that returns the block
in which the message is to be available, and aztecjs provides a helper
to wait until the block is reached.    

The bot factory is updated to use this new approach.
