### PR TITLE
fix(docs): update nightly release URLS to use nightly/* rather than the specific version number

### DIFF
--- a/barretenberg/docs/docusaurus.config.ts
+++ b/barretenberg/docs/docusaurus.config.ts
@@ -87,14 +87,17 @@ const config: Config = {
           // There should be 2 versions, nightly and stable
           // The stable version is second in the list
           lastVersion: versions[1],
-          ...(process.env.ENV === "dev" && {
-            versions: {
+          versions: {
+            [versions[0]]: {
+              path: "nightly",
+            },
+            ...(process.env.ENV === "dev" && {
               current: {
                 label: "dev",
                 path: "dev",
               },
-            },
-          }),
+            }),
+          },
           editUrl: (params) => {
             return (
               `https://github.com/AztecProtocol/aztec-packages/edit/master/docs/docs/` +

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -68,14 +68,17 @@ const config = {
           // There should be 2 versions, nightly and stable
           // The stable version is second in the list
           lastVersion: versions[1],
-          ...(process.env.ENV === "dev" && {
-            versions: {
+          versions: {
+            [versions[0]]: {
+              path: "nightly",
+            },
+            ...(process.env.ENV === "dev" && {
               current: {
                 label: "dev",
                 path: "dev",
               },
-            },
-          }),
+            }),
+          },
           remarkPlugins: [math],
           rehypePlugins: [
             [


### PR DESCRIPTION
Please read [contributing guidelines](CONTRIBUTING.md) and remove this line.

For audit-related pull requests, please use the [audit PR template](?expand=1&template=audit.md).
