### PR TITLE
fix: Remove tag security from AVM

### DIFF
--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/prover.cpp
@@ -169,8 +169,9 @@ HonkProof AvmProver::construct_proof()
     // Add circuit size public input size and public inputs to transcript.
     execute_preamble_round();
 
-    // Add public inputs to transcript.
-    AVM_TRACK_TIME("prove/public_inputs_round", execute_public_inputs_round());
+    // TODO: Make secure at some point
+    // // Add public inputs to transcript.
+    // AVM_TRACK_TIME("prove/public_inputs_round", execute_public_inputs_round());
 
     // Compute wire commitments.
     AVM_TRACK_TIME("prove/wire_commitments_round", execute_wire_commitments_round());

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/recursion/recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/recursion/recursive_verifier.cpp
@@ -113,11 +113,18 @@ AvmRecursiveVerifier::PairingPoints AvmRecursiveVerifier::verify_proof(
     RelationParams relation_parameters;
     VerifierCommitments commitments{ key };
 
-    // Add public inputs to transcript
+    // TODO (make the protocols secure at some point)
+    // // Add public inputs to transcript
+    // for (size_t i = 0; i < AVM_NUM_PUBLIC_INPUT_COLUMNS; i++) {
+    //     for (size_t j = 0; j < public_inputs[i].size(); j++) {
+    //         transcript->add_to_hash_buffer("public_input_" + std::to_string(i) + "_" + std::to_string(j),
+    //                                        public_inputs[i][j]);
+    //     }
+    // }
+
     for (size_t i = 0; i < AVM_NUM_PUBLIC_INPUT_COLUMNS; i++) {
         for (size_t j = 0; j < public_inputs[i].size(); j++) {
-            transcript->add_to_hash_buffer("public_input_" + std::to_string(i) + "_" + std::to_string(j),
-                                           public_inputs[i][j]);
+            public_inputs[i][j].unset_free_witness_tag();
         }
     }
     // Get commitments to VM wires

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/verifier.cpp
@@ -71,10 +71,11 @@ bool AvmVerifier::verify_proof(const HonkProof& proof, const std::vector<std::ve
             vinfo("Public input size mismatch");
             return false;
         }
-        for (size_t j = 0; j < public_inputs[i].size(); j++) {
-            transcript->add_to_hash_buffer("public_input_" + std::to_string(i) + "_" + std::to_string(j),
-                                           public_inputs[i][j]);
-        }
+        // TODO: make secure at some point
+        // for (size_t j = 0; j < public_inputs[i].size(); j++) {
+        //     transcript->add_to_hash_buffer("public_input_" + std::to_string(i) + "_" + std::to_string(j),
+        //                                    public_inputs[i][j]);
+        // }
     }
     VerifierCommitments commitments{ key };
     // Get commitments to VM wires


### PR DESCRIPTION
Please read [contributing guidelines](CONTRIBUTING.md) and remove this line.

For audit-related pull requests, please use the [audit PR template](?expand=1&template=audit.md).
