### PR TITLE
fix: use consistent default build dir in benchmark_remote.sh

### DIFF
--- a/barretenberg/cpp/scripts/benchmark_remote.sh
+++ b/barretenberg/cpp/scripts/benchmark_remote.sh
@@ -10,7 +10,7 @@ set -eu
 BENCHMARK=${1:-client_ivc_bench}
 COMMAND=${2:-./$BENCHMARK}
 PRESET=${3:-clang20-no-avm}
-BUILD_DIR=${4:-build}
+BUILD_DIR=${4:-build-no-avm}
 HARDWARE_CONCURRENCY=${HARDWARE_CONCURRENCY:-16}
 
 # Move above script dir.


### PR DESCRIPTION
Fixed a bug which will make you run stale bb binary on the remote bench machine even if you changed the source locally. Before the fix, by default, it rebuilt the clang20-no-avm preset but scp the binary in the build dir (should be build-no-avm).