### PR TITLE
fix: bigfield `assert_less_than` and add `reduce_mod_target_modulus`

### DIFF
--- a/barretenberg/cpp/scripts/test_civc_standalone_vks_havent_changed.sh
+++ b/barretenberg/cpp/scripts/test_civc_standalone_vks_havent_changed.sh
@@ -13,7 +13,7 @@ cd ..
 # - Generate a hash for versioning: sha256sum bb-civc-inputs.tar.gz
 # - Upload the compressed results: aws s3 cp bb-civc-inputs.tar.gz s3://aztec-ci-artifacts/protocol/bb-civc-inputs-[hash(0:8)].tar.gz
 # Note: In case of the "Test suite failed to run ... Unexpected token 'with' " error, need to run: docker pull aztecprotocol/build:3.0
-pinned_short_hash="8ba25b76"
+pinned_short_hash="5af7338f"
 pinned_civc_inputs_url="https://aztec-ci-artifacts.s3.us-east-2.amazonaws.com/protocol/bb-civc-inputs-${pinned_short_hash}.tar.gz"
 
 function compress_and_upload {

--- a/barretenberg/cpp/scripts/test_civc_standalone_vks_havent_changed.sh
+++ b/barretenberg/cpp/scripts/test_civc_standalone_vks_havent_changed.sh
@@ -13,7 +13,7 @@ cd ..
 # - Generate a hash for versioning: sha256sum bb-civc-inputs.tar.gz
 # - Upload the compressed results: aws s3 cp bb-civc-inputs.tar.gz s3://aztec-ci-artifacts/protocol/bb-civc-inputs-[hash(0:8)].tar.gz
 # Note: In case of the "Test suite failed to run ... Unexpected token 'with' " error, need to run: docker pull aztecprotocol/build:3.0
-pinned_short_hash="cf70d2b7"
+pinned_short_hash="6249f758"
 pinned_civc_inputs_url="https://aztec-ci-artifacts.s3.us-east-2.amazonaws.com/protocol/bb-civc-inputs-${pinned_short_hash}.tar.gz"
 
 function compress_and_upload {

--- a/barretenberg/cpp/scripts/test_civc_standalone_vks_havent_changed.sh
+++ b/barretenberg/cpp/scripts/test_civc_standalone_vks_havent_changed.sh
@@ -13,7 +13,7 @@ cd ..
 # - Generate a hash for versioning: sha256sum bb-civc-inputs.tar.gz
 # - Upload the compressed results: aws s3 cp bb-civc-inputs.tar.gz s3://aztec-ci-artifacts/protocol/bb-civc-inputs-[hash(0:8)].tar.gz
 # Note: In case of the "Test suite failed to run ... Unexpected token 'with' " error, need to run: docker pull aztecprotocol/build:3.0
-pinned_short_hash="5af7338f"
+pinned_short_hash="cf70d2b7"
 pinned_civc_inputs_url="https://aztec-ci-artifacts.s3.us-east-2.amazonaws.com/protocol/bb-civc-inputs-${pinned_short_hash}.tar.gz"
 
 function compress_and_upload {

--- a/barretenberg/cpp/src/barretenberg/stdlib/encryption/ecdsa/ecdsa_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/encryption/ecdsa/ecdsa_impl.hpp
@@ -170,8 +170,8 @@ bool_t<Builder> ecdsa_verify_signature(const stdlib::byte_array<Builder>& hashed
 
     // Step 3.
     Fr s(sig.s);
-    s.assert_less_than((Fr::modulus + 1) / 2); // s < (n+1) / 2
-    s.assert_is_not_equal(Fr::zero());         // 0 < s
+    s.reduce_and_assert_less_than((Fr::modulus + 1) / 2); // s < (n+1) / 2
+    s.assert_is_not_equal(Fr::zero());                    // 0 < s
 
     // Step 4.
     Fr u1 = z.div_without_denominator_check(s);

--- a/barretenberg/cpp/src/barretenberg/stdlib/encryption/ecdsa/ecdsa_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/encryption/ecdsa/ecdsa_impl.hpp
@@ -170,8 +170,8 @@ bool_t<Builder> ecdsa_verify_signature(const stdlib::byte_array<Builder>& hashed
 
     // Step 3.
     Fr s(sig.s);
-    s.reduce_and_assert_less_than((Fr::modulus + 1) / 2); // s < (n+1) / 2
-    s.assert_is_not_equal(Fr::zero());                    // 0 < s
+    s.assert_less_than((Fr::modulus + 1) / 2); // s < (n+1) / 2
+    s.assert_is_not_equal(Fr::zero());         // 0 < s
 
     // Step 4.
     Fr u1 = z.div_without_denominator_check(s);

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
@@ -595,7 +595,8 @@ template <typename Builder, typename T> class bigfield {
     bool_t<Builder> operator==(const bigfield& other) const;
 
     void assert_is_in_field() const;
-    void reduce_and_assert_less_than(const uint256_t& upper_limit) const;
+    void assert_less_than(const uint256_t& upper_limit) const;
+    void reduce_mod_target_modulus() const;
     void assert_equal(const bigfield& other) const;
     void assert_is_not_equal(const bigfield& other) const;
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
@@ -595,8 +595,7 @@ template <typename Builder, typename T> class bigfield {
     bool_t<Builder> operator==(const bigfield& other) const;
 
     void assert_is_in_field() const;
-    void strict_assert_is_in_field() const;
-    void assert_less_than(const uint256_t& upper_limit, const bool reduce_input = true) const;
+    void reduce_and_assert_less_than(const uint256_t& upper_limit) const;
     void assert_equal(const bigfield& other) const;
     void assert_is_not_equal(const bigfield& other) const;
 
@@ -943,6 +942,14 @@ template <typename Builder, typename T> class bigfield {
     friend class bigfield_test_access;
 
   private:
+    /**
+     * @brief Assert that the current bigfield is less than the given upper limit.
+     *
+     * @param upper_limit
+     * @warning This function is UNSAFE as it assumes that the bigfield element is already reduced.
+     */
+    void unsafe_assert_less_than(const uint256_t& upper_limit) const;
+
     /**
      * @brief Get the witness indices of the (normalized) binary basis limbs
      *

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
@@ -1138,6 +1138,12 @@ template <typename Builder, typename T> class bigfield {
 class bigfield_test_access {
   public:
     template <typename bigfield>
+    static void unsafe_assert_less_than(const bigfield& input, const uint256_t& upper_limit)
+    {
+        input.unsafe_assert_less_than(upper_limit);
+    }
+
+    template <typename bigfield>
     static void unsafe_evaluate_multiply_add(const bigfield& input_left,
                                              const bigfield& input_to_mul,
                                              const std::vector<bigfield>& to_add,

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
@@ -595,7 +595,8 @@ template <typename Builder, typename T> class bigfield {
     bool_t<Builder> operator==(const bigfield& other) const;
 
     void assert_is_in_field() const;
-    void assert_less_than(const uint256_t& upper_limit) const;
+    void strict_assert_is_in_field() const;
+    void assert_less_than(const uint256_t& upper_limit, const bool reduce_input = true) const;
     void assert_equal(const bigfield& other) const;
     void assert_is_not_equal(const bigfield& other) const;
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.test.cpp
@@ -1275,6 +1275,59 @@ template <typename BigField> class stdlib_bigfield : public testing::Test {
         EXPECT_EQ(result, true);
     }
 
+    static void test_strict_assert_is_in_field()
+    {
+        auto builder = Builder();
+        size_t num_repetitions = 10;
+        for (size_t i = 0; i < num_repetitions; ++i) {
+            // Get a reduced input
+            auto [a_native, a_ct] = get_random_witness(&builder, true); // fq_native, fq_ct
+            a_ct.set_origin_tag(challenge_origin_tag);
+
+            a_ct.strict_assert_is_in_field();
+
+            // strict_assert_is_in_field preserves tags
+            EXPECT_EQ(a_ct.get_origin_tag(), challenge_origin_tag);
+
+            EXPECT_EQ(a_ct.get_value().get_msb() < (fq_ct::modulus.get_msb() + 1), true);
+        }
+        bool result = CircuitChecker::check(builder);
+        EXPECT_EQ(result, true);
+    }
+
+    static void test_strict_assert_is_in_field_fails()
+    {
+        auto builder = Builder();
+        size_t num_repetitions = 100;
+        fq_ct c_ct = fq_ct::zero();
+        fq_native expected = fq_native::zero();
+        for (size_t i = 0; i < num_repetitions; ++i) {
+
+            auto [a_native, a_ct] = get_random_witness(&builder); // fq_native, fq_ct
+            auto [b_native, b_ct] = get_random_witness(&builder); // fq_native, fq_ct
+
+            for (size_t i = 0; i < 16; ++i) {
+                c_ct += a_ct * b_ct;
+                expected += a_native * b_native;
+            }
+        }
+
+        // Check if c has exceeded p
+        EXPECT_EQ(c_ct.get_value() >= fq_ct::modulus, true);
+
+        // this will fail because mult and add would have exceeded c > p
+        c_ct.strict_assert_is_in_field();
+
+        // results must match (reduction called after strict_assert_is_in_field)
+        c_ct.self_reduce();
+        uint256_t result_val = c_ct.get_value().lo;
+        EXPECT_EQ(result_val, uint256_t(expected));
+
+        bool result = CircuitChecker::check(builder);
+        EXPECT_EQ(result, false);
+        EXPECT_EQ(builder.err(), "decompose_into_default_range");
+    }
+
     static void test_assert_less_than_success()
     {
         auto builder = Builder();
@@ -2198,6 +2251,14 @@ TYPED_TEST(stdlib_bigfield, unsafe_evaluate_multiple_multiply_add_fails)
 TYPED_TEST(stdlib_bigfield, assert_is_in_field_success)
 {
     TestFixture::test_assert_is_in_field_success();
+}
+TYPED_TEST(stdlib_bigfield, strict_assert_is_in_field)
+{
+    TestFixture::test_strict_assert_is_in_field();
+}
+TYPED_TEST(stdlib_bigfield, strict_assert_is_in_field_fails)
+{
+    TestFixture::test_strict_assert_is_in_field_fails();
 }
 TYPED_TEST(stdlib_bigfield, assert_less_than_success)
 {

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.test.cpp
@@ -1251,9 +1251,14 @@ template <typename BigField> class stdlib_bigfield : public testing::Test {
         size_t num_repetitions = 10;
         for (size_t i = 0; i < num_repetitions; ++i) {
 
+            // Get unreduced inputs
             auto [a_native, a_ct] = get_random_witness(&builder); // fq_native, fq_ct
             auto [b_native, b_ct] = get_random_witness(&builder); // fq_native, fq_ct
 
+            // Get a reduced input
+            auto [d_native, d_ct] = get_random_witness(&builder, true); // fq_native, fq_ct
+
+            // c_ct will be unreduced while performing operations
             fq_ct c_ct = a_ct;
             fq_native expected = a_native;
             for (size_t i = 0; i < 16; ++i) {
@@ -1265,11 +1270,15 @@ template <typename BigField> class stdlib_bigfield : public testing::Test {
 
             // We need to reduce before calling assert_is_in_field
             c_ct.self_reduce();
-
             c_ct.assert_is_in_field();
+
+            // We can directly call assert_is_in_field on a reduced element
+            d_ct.set_origin_tag(challenge_origin_tag);
+            d_ct.assert_is_in_field();
 
             // assert_is_in_field preserves tags
             EXPECT_EQ(c_ct.get_origin_tag(), challenge_origin_tag);
+            EXPECT_EQ(d_ct.get_origin_tag(), challenge_origin_tag);
 
             uint256_t result = (c_ct.get_value().lo);
             EXPECT_EQ(result, uint256_t(expected));
@@ -1279,30 +1288,10 @@ template <typename BigField> class stdlib_bigfield : public testing::Test {
         EXPECT_EQ(result, true);
     }
 
-    static void test_assert_is_in_field()
-    {
-        auto builder = Builder();
-        size_t num_repetitions = 10;
-        for (size_t i = 0; i < num_repetitions; ++i) {
-            // Get a reduced input
-            auto [a_native, a_ct] = get_random_witness(&builder, true); // fq_native, fq_ct
-            a_ct.set_origin_tag(challenge_origin_tag);
-
-            a_ct.assert_is_in_field();
-
-            // assert_is_in_field preserves tags
-            EXPECT_EQ(a_ct.get_origin_tag(), challenge_origin_tag);
-
-            EXPECT_EQ(a_ct.get_value().get_msb() < (fq_ct::modulus.get_msb() + 1), true);
-        }
-        bool result = CircuitChecker::check(builder);
-        EXPECT_EQ(result, true);
-    }
-
     static void test_assert_is_in_field_fails()
     {
         auto builder = Builder();
-        size_t num_repetitions = 100;
+        size_t num_repetitions = 10;
         fq_ct c_ct = fq_ct::zero();
         fq_native expected = fq_native::zero();
         for (size_t i = 0; i < num_repetitions; ++i) {
@@ -1316,10 +1305,10 @@ template <typename BigField> class stdlib_bigfield : public testing::Test {
             }
         }
 
-        // Check if c has exceeded p
+        // Ensure that c has exceeded p (as mul and add have been performed without reduction so far)
         EXPECT_EQ(c_ct.get_value() >= fq_ct::modulus, true);
 
-        // this will fail because mult and add would have exceeded c > p
+        // this will fail because mult and add have been performed without reduction
         c_ct.assert_is_in_field();
 
         // results must match (reduction called after assert_is_in_field)
@@ -1331,7 +1320,7 @@ template <typename BigField> class stdlib_bigfield : public testing::Test {
         EXPECT_EQ(result, false);
     }
 
-    static void test_reduce_and_assert_less_than_success()
+    static void test_assert_less_than_success()
     {
         auto builder = Builder();
         size_t num_repetitions = 10;
@@ -1339,37 +1328,106 @@ template <typename BigField> class stdlib_bigfield : public testing::Test {
         constexpr uint256_t bit_mask = (uint256_t(1) << num_bits) - 1;
         for (size_t i = 0; i < num_repetitions; ++i) {
 
-            uint256_t a_u256 = uint256_t(fq_native::random_element()) && bit_mask;
-            uint256_t b_u256 = uint256_t(fq_native::random_element()) && bit_mask;
+            uint256_t a_u256 = uint256_t(fq_native::random_element()) & bit_mask;
+            uint256_t b_u256 = uint256_t(fq_native::random_element()) & bit_mask;
 
+            // Construct 200-bit bigfield elements
             fq_ct a_ct(witness_ct(&builder, fr(a_u256.slice(0, fq_ct::NUM_LIMB_BITS * 2))),
                        witness_ct(&builder, fr(a_u256.slice(fq_ct::NUM_LIMB_BITS * 2, fq_ct::NUM_LIMB_BITS * 4))));
             fq_ct b_ct(witness_ct(&builder, fr(b_u256.slice(0, fq_ct::NUM_LIMB_BITS * 2))),
                        witness_ct(&builder, fr(b_u256.slice(fq_ct::NUM_LIMB_BITS * 2, fq_ct::NUM_LIMB_BITS * 4))));
 
-            fq_ct c_ct = a_ct;
-            fq_native expected = fq_native(a_u256);
-            for (size_t i = 0; i < 16; ++i) {
-                c_ct = b_ct * b_ct + c_ct;
-                expected = fq_native(b_u256) * fq_native(b_u256) + expected;
-            }
-
-            c_ct.reduce_and_assert_less_than(bit_mask + 1);
-            uint256_t result = (c_ct.get_value().lo);
-            EXPECT_EQ(result, uint256_t(expected));
-            EXPECT_EQ(c_ct.get_value().get_msb() < num_bits, true);
+            // Assert a, b < 2^200
+            a_ct.assert_less_than(bit_mask + 1);
+            b_ct.assert_less_than(bit_mask + 1);
+            EXPECT_EQ(a_ct.get_value().get_msb() < num_bits, true);
+            EXPECT_EQ(b_ct.get_value().get_msb() < num_bits, true);
         }
         bool result = CircuitChecker::check(builder);
         EXPECT_EQ(result, true);
+    }
 
-        // Checking edge conditions
-        auto [random_input, a_ct] = get_random_witness(&builder);
+    static void test_assert_less_than_fails()
+    {
+        auto builder = Builder();
+        size_t num_repetitions = 10;
+        constexpr size_t num_bits = 200;
+        constexpr uint256_t bit_mask = (uint256_t(1) << num_bits) - 1;
 
-        a_ct.reduce_and_assert_less_than(random_input + 1);
-        EXPECT_EQ(CircuitChecker::check(builder), true);
+        fq_ct c_ct = fq_ct::zero();
+        fq_native expected = fq_native::zero();
+        for (size_t i = 0; i < num_repetitions; ++i) {
 
-        a_ct.reduce_and_assert_less_than(random_input);
-        EXPECT_EQ(CircuitChecker::check(builder), false);
+            uint256_t a_u256 = uint256_t(fq_native::random_element()) & bit_mask;
+            uint256_t b_u256 = uint256_t(fq_native::random_element()) & bit_mask;
+
+            // Construct 200-bit bigfield elements
+            fq_ct a_ct(witness_ct(&builder, fr(a_u256.slice(0, fq_ct::NUM_LIMB_BITS * 2))),
+                       witness_ct(&builder, fr(a_u256.slice(fq_ct::NUM_LIMB_BITS * 2, fq_ct::NUM_LIMB_BITS * 4))));
+            fq_ct b_ct(witness_ct(&builder, fr(b_u256.slice(0, fq_ct::NUM_LIMB_BITS * 2))),
+                       witness_ct(&builder, fr(b_u256.slice(fq_ct::NUM_LIMB_BITS * 2, fq_ct::NUM_LIMB_BITS * 4))));
+
+            // Mul and add without reduction to exceed 200 bits
+            for (size_t i = 0; i < 16; ++i) {
+                c_ct += a_ct * b_ct;
+                expected += fq_native(a_u256) * fq_native(b_u256);
+            }
+        }
+
+        // Ensure that c has exceeded 200 bits
+        EXPECT_EQ(c_ct.get_value().get_msb() >= num_bits, true);
+
+        // check that assert_less_than fails
+        c_ct.assert_less_than(bit_mask + 1);
+
+        // results must match (reduction called after assert_is_in_field)
+        c_ct.self_reduce();
+        uint256_t result_val = c_ct.get_value().lo;
+        EXPECT_EQ(result_val, uint256_t(expected));
+
+        bool result = CircuitChecker::check(builder);
+        EXPECT_EQ(result, false);
+    }
+
+    static void test_reduce_mod_target_modulus()
+    {
+        auto builder = Builder();
+        size_t num_repetitions = 10;
+        for (size_t i = 0; i < num_repetitions; ++i) {
+
+            // Get unreduced inputs
+            auto [a_native, a_ct] = get_random_witness(&builder); // fq_native, fq_ct
+            auto [b_native, b_ct] = get_random_witness(&builder); // fq_native, fq_ct
+
+            // c_ct will be unreduced while performing operations
+            fq_ct c_ct = a_ct;
+            fq_native expected = a_native;
+            for (size_t i = 0; i < 16; ++i) {
+                c_ct = b_ct * b_ct + c_ct;
+                expected = b_native * b_native + expected;
+            }
+
+            c_ct.set_origin_tag(challenge_origin_tag);
+
+            // reduce c to [0, p)
+            // count gates for the last iteration only
+            if (i == num_repetitions - 1) {
+                BENCH_GATE_COUNT_START(builder, "REDUCE_MOD_P");
+                c_ct.reduce_mod_target_modulus();
+                BENCH_GATE_COUNT_END(builder, "REDUCE_MOD_P");
+            } else {
+                c_ct.reduce_mod_target_modulus();
+            }
+
+            // reduce_mod_target_modulus preserves tags
+            EXPECT_EQ(c_ct.get_origin_tag(), challenge_origin_tag);
+
+            uint256_t result = (c_ct.get_value().lo);
+            EXPECT_EQ(result, uint256_t(expected));
+            EXPECT_EQ(c_ct.get_value() < fq_ct::modulus, true);
+        }
+        bool result = CircuitChecker::check(builder);
+        EXPECT_EQ(result, true);
     }
 
     static void test_byte_array_constructors()
@@ -2255,17 +2313,21 @@ TYPED_TEST(stdlib_bigfield, assert_is_in_field_success)
 {
     TestFixture::test_assert_is_in_field_success();
 }
-TYPED_TEST(stdlib_bigfield, assert_is_in_field)
-{
-    TestFixture::test_assert_is_in_field();
-}
 TYPED_TEST(stdlib_bigfield, assert_is_in_field_fails)
 {
     TestFixture::test_assert_is_in_field_fails();
 }
-TYPED_TEST(stdlib_bigfield, reduce_and_assert_less_than_success)
+TYPED_TEST(stdlib_bigfield, assert_less_than_success)
 {
-    TestFixture::test_reduce_and_assert_less_than_success();
+    TestFixture::test_assert_less_than_success();
+}
+TYPED_TEST(stdlib_bigfield, assert_less_than_fails)
+{
+    TestFixture::test_assert_less_than_fails();
+}
+TYPED_TEST(stdlib_bigfield, reduce_mod_target_modulus)
+{
+    TestFixture::test_reduce_mod_target_modulus();
 }
 TYPED_TEST(stdlib_bigfield, byte_array_constructors)
 {

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.test.cpp
@@ -1641,6 +1641,108 @@ template <typename BigField> class stdlib_bigfield : public testing::Test {
         EXPECT_EQ(check_result, true);
     }
 
+    static void test_unsafe_assert_less_than()
+    {
+        auto builder = Builder();
+        size_t num_repetitions = 10;
+        constexpr size_t num_bits = 200;
+        constexpr uint256_t bit_mask = (uint256_t(1) << num_bits) - 1;
+        for (size_t i = 0; i < num_repetitions; ++i) {
+
+            uint256_t a_u256 = uint256_t(fq_native::random_element()) & bit_mask;
+            uint256_t b_u256 = uint256_t(fq_native::random_element()) & bit_mask;
+
+            // Construct 200-bit bigfield elements
+            fq_ct a_ct(witness_ct(&builder, fr(a_u256.slice(0, fq_ct::NUM_LIMB_BITS * 2))),
+                       witness_ct(&builder, fr(a_u256.slice(fq_ct::NUM_LIMB_BITS * 2, fq_ct::NUM_LIMB_BITS * 4))));
+            fq_ct b_ct(witness_ct(&builder, fr(b_u256.slice(0, fq_ct::NUM_LIMB_BITS * 2))),
+                       witness_ct(&builder, fr(b_u256.slice(fq_ct::NUM_LIMB_BITS * 2, fq_ct::NUM_LIMB_BITS * 4))));
+
+            // Assert a, b < 2^200
+            stdlib::bigfield_test_access::unsafe_assert_less_than(a_ct, bit_mask + 1);
+            stdlib::bigfield_test_access::unsafe_assert_less_than(b_ct, bit_mask + 1);
+            EXPECT_EQ(a_ct.get_value().get_msb() < num_bits, true);
+            EXPECT_EQ(b_ct.get_value().get_msb() < num_bits, true);
+        }
+
+        // Also test when: p < a < bound
+        // define a = p + small_random_value
+        uint256_t small_mask = (uint256_t(1) << 16) - 1;
+        uint256_t a_u256 = uint256_t(fq_native::random_element()) & small_mask;
+        a_u256 += uint256_t(fq_native::modulus);
+
+        // upper bound must be greater than p + 2^16: we set it to p + 2^30
+        uint256_t upper_bound = (uint256_t(1) << 30) + uint256_t(fq_native::modulus);
+
+        // Construct bigfield element
+        fq_ct a_ct(witness_ct(&builder, fr(a_u256.slice(0, fq_ct::NUM_LIMB_BITS * 2))),
+                   witness_ct(&builder, fr(a_u256.slice(fq_ct::NUM_LIMB_BITS * 2, fq_ct::NUM_LIMB_BITS * 4))),
+                   /*can_overflow*/ true);
+
+        // Assert a < bound
+        stdlib::bigfield_test_access::unsafe_assert_less_than(a_ct, upper_bound);
+        EXPECT_EQ(a_ct.get_value() > uint512_t(fq_native::modulus), true);
+
+        // Combined circuit should pass
+        bool result = CircuitChecker::check(builder);
+        EXPECT_EQ(result, true);
+    }
+
+    static void test_unsafe_assert_less_than_fails()
+    {
+        {
+            // Test a case when the value is exactly equal to the limit
+            auto builder = Builder();
+            constexpr size_t num_bits = 200;
+            constexpr uint256_t bit_mask = (uint256_t(1) << num_bits) - 1;
+            fq_ct a_ct(witness_ct(&builder, fr(bit_mask.slice(0, fq_ct::NUM_LIMB_BITS * 2))),
+                       witness_ct(&builder, fr(bit_mask.slice(fq_ct::NUM_LIMB_BITS * 2, fq_ct::NUM_LIMB_BITS * 4))));
+
+            // check that unsafe_assert_less_than fails when we try to check a < a.
+            stdlib::bigfield_test_access::unsafe_assert_less_than(a_ct, a_ct.get_value().lo);
+
+            bool result = CircuitChecker::check(builder);
+            EXPECT_EQ(result, false);
+        }
+        {
+            // Test a case when the value is (B + 2) but the bound is B.
+            auto builder = Builder();
+            constexpr size_t num_bits = 200;
+            constexpr uint256_t bit_mask = (uint256_t(1) << num_bits) - 1;
+            const uint256_t upper_bound = uint256_t(fq_native::random_element()) & bit_mask;
+            const uint256_t a_value = upper_bound + uint256_t(2);
+            fq_ct a_ct(witness_ct(&builder, fr(a_value.slice(0, fq_ct::NUM_LIMB_BITS * 2))),
+                       witness_ct(&builder, fr(a_value.slice(fq_ct::NUM_LIMB_BITS * 2, fq_ct::NUM_LIMB_BITS * 4))));
+
+            // check that unsafe_assert_less_than fails when we try to check (B + 2) < B.
+            stdlib::bigfield_test_access::unsafe_assert_less_than(a_ct, upper_bound);
+
+            bool result = CircuitChecker::check(builder);
+            EXPECT_EQ(result, false);
+        }
+        {
+            // Test a case when p < bound < a
+            auto builder = Builder();
+            uint256_t small_mask = (uint256_t(1) << 32) - 1;
+            uint256_t a_u256 = uint256_t(fq_native::random_element()) & small_mask;
+            a_u256 += uint256_t(fq_native::modulus);
+
+            // upper bound must be greater than p but smaller than a
+            uint256_t upper_bound = uint256_t(fq_native::modulus) + uint256_t(1);
+
+            // Construct bigfield element
+            fq_ct a_ct(witness_ct(&builder, fr(a_u256.slice(0, fq_ct::NUM_LIMB_BITS * 2))),
+                       witness_ct(&builder, fr(a_u256.slice(fq_ct::NUM_LIMB_BITS * 2, fq_ct::NUM_LIMB_BITS * 4))),
+                       /*can_overflow*/ true);
+
+            // check that unsafe_assert_less_than fails when we try to check a < bound.
+            stdlib::bigfield_test_access::unsafe_assert_less_than(a_ct, upper_bound);
+
+            bool result = CircuitChecker::check(builder);
+            EXPECT_EQ(result, false);
+        }
+    }
+
     static void test_unsafe_evaluate_multiply_add()
     {
         Builder builder;
@@ -2292,6 +2394,14 @@ TYPED_TEST(stdlib_bigfield, equality_with_constants)
     TestFixture::test_equality_operator(InputType::CONSTANT, InputType::CONSTANT); // c == c
 }
 
+TYPED_TEST(stdlib_bigfield, unsafe_assert_less_than)
+{
+    TestFixture::test_unsafe_assert_less_than();
+}
+TYPED_TEST(stdlib_bigfield, unsafe_assert_less_than_fails)
+{
+    TestFixture::test_unsafe_assert_less_than_fails();
+}
 TYPED_TEST(stdlib_bigfield, unsafe_evaluate_multiply_add)
 {
     TestFixture::test_unsafe_evaluate_multiply_add();

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.test.cpp
@@ -1262,6 +1262,10 @@ template <typename BigField> class stdlib_bigfield : public testing::Test {
             }
 
             c_ct.set_origin_tag(challenge_origin_tag);
+
+            // We need to reduce before calling assert_is_in_field
+            c_ct.self_reduce();
+
             c_ct.assert_is_in_field();
 
             // assert_is_in_field preserves tags
@@ -1275,7 +1279,7 @@ template <typename BigField> class stdlib_bigfield : public testing::Test {
         EXPECT_EQ(result, true);
     }
 
-    static void test_strict_assert_is_in_field()
+    static void test_assert_is_in_field()
     {
         auto builder = Builder();
         size_t num_repetitions = 10;
@@ -1284,9 +1288,9 @@ template <typename BigField> class stdlib_bigfield : public testing::Test {
             auto [a_native, a_ct] = get_random_witness(&builder, true); // fq_native, fq_ct
             a_ct.set_origin_tag(challenge_origin_tag);
 
-            a_ct.strict_assert_is_in_field();
+            a_ct.assert_is_in_field();
 
-            // strict_assert_is_in_field preserves tags
+            // assert_is_in_field preserves tags
             EXPECT_EQ(a_ct.get_origin_tag(), challenge_origin_tag);
 
             EXPECT_EQ(a_ct.get_value().get_msb() < (fq_ct::modulus.get_msb() + 1), true);
@@ -1295,7 +1299,7 @@ template <typename BigField> class stdlib_bigfield : public testing::Test {
         EXPECT_EQ(result, true);
     }
 
-    static void test_strict_assert_is_in_field_fails()
+    static void test_assert_is_in_field_fails()
     {
         auto builder = Builder();
         size_t num_repetitions = 100;
@@ -1316,19 +1320,18 @@ template <typename BigField> class stdlib_bigfield : public testing::Test {
         EXPECT_EQ(c_ct.get_value() >= fq_ct::modulus, true);
 
         // this will fail because mult and add would have exceeded c > p
-        c_ct.strict_assert_is_in_field();
+        c_ct.assert_is_in_field();
 
-        // results must match (reduction called after strict_assert_is_in_field)
+        // results must match (reduction called after assert_is_in_field)
         c_ct.self_reduce();
         uint256_t result_val = c_ct.get_value().lo;
         EXPECT_EQ(result_val, uint256_t(expected));
 
         bool result = CircuitChecker::check(builder);
         EXPECT_EQ(result, false);
-        EXPECT_EQ(builder.err(), "decompose_into_default_range");
     }
 
-    static void test_assert_less_than_success()
+    static void test_reduce_and_assert_less_than_success()
     {
         auto builder = Builder();
         size_t num_repetitions = 10;
@@ -1351,7 +1354,7 @@ template <typename BigField> class stdlib_bigfield : public testing::Test {
                 expected = fq_native(b_u256) * fq_native(b_u256) + expected;
             }
 
-            c_ct.assert_less_than(bit_mask + 1);
+            c_ct.reduce_and_assert_less_than(bit_mask + 1);
             uint256_t result = (c_ct.get_value().lo);
             EXPECT_EQ(result, uint256_t(expected));
             EXPECT_EQ(c_ct.get_value().get_msb() < num_bits, true);
@@ -1362,10 +1365,10 @@ template <typename BigField> class stdlib_bigfield : public testing::Test {
         // Checking edge conditions
         auto [random_input, a_ct] = get_random_witness(&builder);
 
-        a_ct.assert_less_than(random_input + 1);
+        a_ct.reduce_and_assert_less_than(random_input + 1);
         EXPECT_EQ(CircuitChecker::check(builder), true);
 
-        a_ct.assert_less_than(random_input);
+        a_ct.reduce_and_assert_less_than(random_input);
         EXPECT_EQ(CircuitChecker::check(builder), false);
     }
 
@@ -2252,17 +2255,17 @@ TYPED_TEST(stdlib_bigfield, assert_is_in_field_success)
 {
     TestFixture::test_assert_is_in_field_success();
 }
-TYPED_TEST(stdlib_bigfield, strict_assert_is_in_field)
+TYPED_TEST(stdlib_bigfield, assert_is_in_field)
 {
-    TestFixture::test_strict_assert_is_in_field();
+    TestFixture::test_assert_is_in_field();
 }
-TYPED_TEST(stdlib_bigfield, strict_assert_is_in_field_fails)
+TYPED_TEST(stdlib_bigfield, assert_is_in_field_fails)
 {
-    TestFixture::test_strict_assert_is_in_field_fails();
+    TestFixture::test_assert_is_in_field_fails();
 }
-TYPED_TEST(stdlib_bigfield, assert_less_than_success)
+TYPED_TEST(stdlib_bigfield, reduce_and_assert_less_than_success)
 {
-    TestFixture::test_assert_less_than_success();
+    TestFixture::test_reduce_and_assert_less_than_success();
 }
 TYPED_TEST(stdlib_bigfield, byte_array_constructors)
 {

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_edge_cases.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_edge_cases.test.cpp
@@ -71,16 +71,16 @@ template <typename BigField> class stdlib_bigfield_edge_cases : public testing::
 
   public:
     // Declare edge case values
-    constexpr static std::array<uint512_t, 6> edge_case_values = {
+    constexpr static std::array<uint512_t, 5> edge_case_values = {
         uint512_t(uint256_t(0)),                  // 0
         uint512_t(uint256_t(1)),                  // 1
         uint512_t(fr::modulus) - 1,               // n - 1
         uint512_t(fr::modulus),                   // n
         uint512_t(fq_ct::modulus) - uint512_t(1), // p - 1
-        uint512_t(fq_ct::modulus),                // p
     };
 
-    inline static const std::array<uint512_t, 10> values_larger_than_bigfield = {
+    inline static const std::array<uint512_t, 11> values_larger_than_bigfield = {
+        uint512_t(fq_ct::modulus), // p
         uint512_t(fq_ct::modulus) + uint512_t(1),
         uint512_t(fq_ct::modulus) + uint512_t(fr::modulus),
         (uint512_t(1) << 256) - 1,
@@ -407,6 +407,36 @@ template <typename BigField> class stdlib_bigfield_edge_cases : public testing::
         EXPECT_EQ(result, true);
     }
 
+    static void test_strict_assert_is_in_field()
+    {
+        Builder builder = Builder();
+        for (const auto& value : edge_case_values) {
+            fq_ct edge_case = fq_ct::create_from_u512_as_witness(&builder, value, true);
+
+            // This should pass for values strictly less than modulus
+            edge_case.strict_assert_is_in_field();
+        }
+
+        bool result = CircuitChecker::check(builder);
+        EXPECT_EQ(result, true);
+    }
+
+    static void test_strict_assert_is_in_field_fails()
+    {
+
+        Builder builder = Builder();
+        for (const auto& large_value : values_larger_than_bigfield) {
+            fq_ct large_case = fq_ct::create_from_u512_as_witness(&builder, large_value, true);
+
+            // For values larger than the field modulus, it should trigger a circuit error.
+            large_case.strict_assert_is_in_field();
+        }
+
+        bool result = CircuitChecker::check(builder);
+        EXPECT_EQ(result, false);
+        EXPECT_EQ(builder.err(), "decompose_into_default_range");
+    }
+
     static void test_assert_less_than()
     {
         Builder builder = Builder();
@@ -431,7 +461,7 @@ template <typename BigField> class stdlib_bigfield_edge_cases : public testing::
 
         // One is n, other is (p + n)
         fq_ct value_n = fq_ct::create_from_u512_as_witness(&builder, edge_case_values[3], true);
-        fq_ct value_p_plus_n = fq_ct::create_from_u512_as_witness(&builder, values_larger_than_bigfield[1], true);
+        fq_ct value_p_plus_n = fq_ct::create_from_u512_as_witness(&builder, values_larger_than_bigfield[2], true);
 
         // Both should be equal to n mod p
         value_p_plus_n.assert_equal(value_n);
@@ -585,6 +615,14 @@ TYPED_TEST(stdlib_bigfield_edge_cases, invariants_during_negation)
 TYPED_TEST(stdlib_bigfield_edge_cases, assert_is_in_field)
 {
     TestFixture::test_assert_is_in_field();
+}
+TYPED_TEST(stdlib_bigfield_edge_cases, strict_assert_is_in_field)
+{
+    TestFixture::test_strict_assert_is_in_field();
+}
+TYPED_TEST(stdlib_bigfield_edge_cases, strict_assert_is_in_field_fails)
+{
+    TestFixture::test_strict_assert_is_in_field_fails();
 }
 TYPED_TEST(stdlib_bigfield_edge_cases, assert_less_than)
 {

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_edge_cases.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_edge_cases.test.cpp
@@ -79,18 +79,17 @@ template <typename BigField> class stdlib_bigfield_edge_cases : public testing::
         uint512_t(fq_ct::modulus) - uint512_t(1), // p - 1
     };
 
-    inline static const std::array<uint512_t, 11> values_larger_than_bigfield = {
-        uint512_t(fq_ct::modulus), // p
-        uint512_t(fq_ct::modulus) + uint512_t(1),
-        uint512_t(fq_ct::modulus) + uint512_t(fr::modulus),
-        (uint512_t(1) << 256) - 1,
-        (uint512_t(1) << 256),
-        (uint512_t(1) << 256) + 1,
-        uint512_t(fq_ct::get_maximum_unreduced_value()) - 1,
-        uint512_t(fq_ct::get_maximum_unreduced_value()),
-        uint512_t(fq_ct::get_maximum_unreduced_value()) + 1,
-        uint512_t(fq_ct::get_maximum_unreduced_value()) + 2,
-        (uint512_t(1) << (stdlib::NUM_LIMB_BITS_IN_FIELD_SIMULATION * 4)) - 1,
+    inline static const std::array<uint512_t, 10> values_larger_than_bigfield = {
+        uint512_t(fq_ct::modulus),                                             // p
+        uint512_t(fq_ct::modulus) + uint512_t(1),                              // p + 1
+        uint512_t(fq_ct::modulus) + uint512_t(fr::modulus),                    // p + n
+        (uint512_t(1) << 256) - 1,                                             // 2^256 - 1
+        (uint512_t(1) << 256),                                                 // 2^256
+        (uint512_t(1) << 256) + 1,                                             // 2^256 + 1
+        uint512_t(fq_ct::get_maximum_unreduced_value()) - 1,                   // max unreduced - 1
+        uint512_t(fq_ct::get_maximum_unreduced_value()),                       // max unreduced
+        uint512_t(fq_ct::get_maximum_unreduced_value()) + 1,                   // max unreduced + 1
+        (uint512_t(1) << (stdlib::NUM_LIMB_BITS_IN_FIELD_SIMULATION * 4)) - 1, // 2^272 - 1
     };
 
     constexpr static uint512_t reduction_upper_bound = uint512_t(1) << (fq_ct::modulus.get_msb() + 1); // p < 2^s
@@ -391,45 +390,25 @@ template <typename BigField> class stdlib_bigfield_edge_cases : public testing::
     {
         Builder builder = Builder();
         for (const auto& value : edge_case_values) {
-            fq_ct edge_case = fq_ct::create_from_u512_as_witness(&builder, value, true);
+            fq_ct edge_case = fq_ct::create_from_u512_as_witness(&builder, value, /*can_overflow*/ false);
+
+            // This should pass for values strictly less than modulus
             edge_case.assert_is_in_field();
         }
 
-        for (const auto& large_value : values_larger_than_bigfield) {
-            fq_ct large_case = fq_ct::create_from_u512_as_witness(&builder, large_value, true);
-
-            // Since assert_is_in_field first reduces the value mod p, and then checks if the remainder is < 2^s,
-            // all of our "large" test values will reduce to something < p, so this should always pass.
-            large_case.assert_is_in_field();
-        }
-
         bool result = CircuitChecker::check(builder);
         EXPECT_EQ(result, true);
     }
 
-    static void test_strict_assert_is_in_field()
-    {
-        Builder builder = Builder();
-        for (const auto& value : edge_case_values) {
-            fq_ct edge_case = fq_ct::create_from_u512_as_witness(&builder, value, true);
-
-            // This should pass for values strictly less than modulus
-            edge_case.strict_assert_is_in_field();
-        }
-
-        bool result = CircuitChecker::check(builder);
-        EXPECT_EQ(result, true);
-    }
-
-    static void test_strict_assert_is_in_field_fails()
+    static void test_assert_is_in_field_fails()
     {
 
         Builder builder = Builder();
         for (const auto& large_value : values_larger_than_bigfield) {
-            fq_ct large_case = fq_ct::create_from_u512_as_witness(&builder, large_value, true);
+            fq_ct large_case = fq_ct::create_from_u512_as_witness(&builder, large_value, false);
 
             // For values larger than the field modulus, it should trigger a circuit error.
-            large_case.strict_assert_is_in_field();
+            large_case.assert_is_in_field();
         }
 
         bool result = CircuitChecker::check(builder);
@@ -437,7 +416,7 @@ template <typename BigField> class stdlib_bigfield_edge_cases : public testing::
         EXPECT_EQ(builder.err(), "decompose_into_default_range");
     }
 
-    static void test_assert_less_than()
+    static void test_reduce_and_assert_less_than()
     {
         Builder builder = Builder();
 
@@ -447,12 +426,52 @@ template <typename BigField> class stdlib_bigfield_edge_cases : public testing::
                 fq_ct edge_case_small = fq_ct::create_from_u512_as_witness(&builder, edge_case_values[i], true);
 
                 // This should always pass since edge_case_values is sorted in ascending order
-                edge_case_small.assert_less_than(edge_case_values[j].lo);
+                edge_case_small.reduce_and_assert_less_than(edge_case_values[j].lo);
             }
+        }
+
+        for (const auto& large_value : values_larger_than_bigfield) {
+            // Check for large values
+            fq_ct large_case = fq_ct::create_from_u512_as_witness(&builder, large_value, true);
+
+            // Since reduce_and_assert_is_in_field first reduces the value mod p, and then checks if the remainder is <
+            // 2^s, all of our "large" test values will reduce to something < p, so this should always pass.
+            large_case.reduce_and_assert_less_than(fq_ct::modulus - uint256_t(1)); // p - 1
         }
 
         bool result = CircuitChecker::check(builder);
         EXPECT_EQ(result, true);
+    }
+
+    static void test_reduce_and_assert_less_than_fails()
+    {
+        Builder builder = Builder();
+
+        {
+            // case 1: value_i > value_{i + 1} (skip 0)
+            for (size_t i = 1; i < edge_case_values.size() - 1; ++i) {
+                // Check against all smaller edge case values
+                for (size_t j = 1; j < i; ++j) {
+                    fq_ct edge_case_large = fq_ct::create_from_u512_as_witness(&builder, edge_case_values[i], true);
+
+                    // This should always fail since edge_case_values is sorted in ascending order
+                    edge_case_large.reduce_and_assert_less_than(edge_case_values[j].lo);
+                }
+            }
+
+            bool result = CircuitChecker::check(builder);
+            EXPECT_EQ(result, false);
+            EXPECT_EQ(builder.err(), "decompose_into_default_range");
+        }
+        {
+#ifndef NDEBUG
+            // case 2: upper_limit = p
+            fq_ct edge_case_large = fq_ct::create_from_u512_as_witness(&builder, edge_case_values.back(), true);
+            // In debug mode, this should trigger an assertion failure since value == p
+            EXPECT_THROW_OR_ABORT(edge_case_large.reduce_and_assert_less_than(fq_ct::modulus),
+                                  "upper_limit must be < modulus");
+#endif
+        }
     }
 
     static void test_assert_equal_edge_case()
@@ -616,17 +635,17 @@ TYPED_TEST(stdlib_bigfield_edge_cases, assert_is_in_field)
 {
     TestFixture::test_assert_is_in_field();
 }
-TYPED_TEST(stdlib_bigfield_edge_cases, strict_assert_is_in_field)
+TYPED_TEST(stdlib_bigfield_edge_cases, assert_is_in_field_fails)
 {
-    TestFixture::test_strict_assert_is_in_field();
+    TestFixture::test_assert_is_in_field_fails();
 }
-TYPED_TEST(stdlib_bigfield_edge_cases, strict_assert_is_in_field_fails)
+TYPED_TEST(stdlib_bigfield_edge_cases, reduce_and_assert_less_than)
 {
-    TestFixture::test_strict_assert_is_in_field_fails();
+    TestFixture::test_reduce_and_assert_less_than();
 }
-TYPED_TEST(stdlib_bigfield_edge_cases, assert_less_than)
+TYPED_TEST(stdlib_bigfield_edge_cases, reduce_and_assert_less_than_fails)
 {
-    TestFixture::test_assert_less_than();
+    TestFixture::test_reduce_and_assert_less_than_fails();
 }
 TYPED_TEST(stdlib_bigfield_edge_cases, assert_equal_edge_case)
 {

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_edge_cases.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_edge_cases.test.cpp
@@ -416,7 +416,7 @@ template <typename BigField> class stdlib_bigfield_edge_cases : public testing::
         EXPECT_EQ(builder.err(), "decompose_into_default_range");
     }
 
-    static void test_reduce_and_assert_less_than()
+    static void test_assert_less_than()
     {
         Builder builder = Builder();
 
@@ -426,52 +426,63 @@ template <typename BigField> class stdlib_bigfield_edge_cases : public testing::
                 fq_ct edge_case_small = fq_ct::create_from_u512_as_witness(&builder, edge_case_values[i], true);
 
                 // This should always pass since edge_case_values is sorted in ascending order
-                edge_case_small.reduce_and_assert_less_than(edge_case_values[j].lo);
+                edge_case_small.assert_less_than(edge_case_values[j].lo);
             }
-        }
-
-        for (const auto& large_value : values_larger_than_bigfield) {
-            // Check for large values
-            fq_ct large_case = fq_ct::create_from_u512_as_witness(&builder, large_value, true);
-
-            // Since reduce_and_assert_is_in_field first reduces the value mod p, and then checks if the remainder is <
-            // 2^s, all of our "large" test values will reduce to something < p, so this should always pass.
-            large_case.reduce_and_assert_less_than(fq_ct::modulus - uint256_t(1)); // p - 1
         }
 
         bool result = CircuitChecker::check(builder);
         EXPECT_EQ(result, true);
     }
 
-    static void test_reduce_and_assert_less_than_fails()
+    static void test_assert_less_than_fails()
     {
         Builder builder = Builder();
 
-        {
-            // case 1: value_i > value_{i + 1} (skip 0)
-            for (size_t i = 1; i < edge_case_values.size() - 1; ++i) {
-                // Check against all smaller edge case values
-                for (size_t j = 1; j < i; ++j) {
-                    fq_ct edge_case_large = fq_ct::create_from_u512_as_witness(&builder, edge_case_values[i], true);
+        for (const auto& i : values_larger_than_bigfield) {
+            // get the large value
+            fq_ct large_case = fq_ct::create_from_u512_as_witness(&builder, i, false);
 
-                    // This should always fail since edge_case_values is sorted in ascending order
-                    edge_case_large.reduce_and_assert_less_than(edge_case_values[j].lo);
-                }
+            for (size_t j = 1; j < edge_case_values.size(); ++j) {
+                // current value < next value
+                // but this still would fail because range constraints on current value fail
+                large_case.assert_less_than(edge_case_values[j].lo);
             }
+        }
 
-            bool result = CircuitChecker::check(builder);
-            EXPECT_EQ(result, false);
-            EXPECT_EQ(builder.err(), "decompose_into_default_range");
+        bool result = CircuitChecker::check(builder);
+        EXPECT_EQ(result, false);
+        EXPECT_EQ(builder.err(), "decompose_into_default_range");
+    }
+
+    static void test_reduce_mod_target_modulus()
+    {
+        Builder builder = Builder();
+
+        // Check that both edge case values as well as values larger than bigfield are reduced correctly
+        for (const auto& value : edge_case_values) {
+            fq_ct edge_case = fq_ct::create_from_u512_as_witness(&builder, value, false);
+            fq_native edge_case_native = fq_native(value);
+
+            edge_case.reduce_mod_target_modulus();
+            edge_case_native = edge_case_native.reduce_once().reduce_once();
+
+            EXPECT_EQ(edge_case.get_value() < fq_ct::modulus, true);
+            EXPECT_EQ(edge_case.get_value(), uint512_t(edge_case_native));
         }
-        {
-#ifndef NDEBUG
-            // case 2: upper_limit = p
-            fq_ct edge_case_large = fq_ct::create_from_u512_as_witness(&builder, edge_case_values.back(), true);
-            // In debug mode, this should trigger an assertion failure since value == p
-            EXPECT_THROW_OR_ABORT(edge_case_large.reduce_and_assert_less_than(fq_ct::modulus),
-                                  "upper_limit must be < modulus");
-#endif
+
+        for (const auto& large_value : values_larger_than_bigfield) {
+            fq_ct large_case = fq_ct::create_from_u512_as_witness(&builder, large_value, true);
+            fq_native large_case_native = fq_native(large_value);
+
+            large_case.reduce_mod_target_modulus();
+            large_case_native = large_case_native.reduce_once().reduce_once();
+
+            EXPECT_EQ(large_case.get_value() < fq_ct::modulus, true);
+            EXPECT_EQ(large_case.get_value(), uint512_t(large_case_native));
         }
+
+        bool result = CircuitChecker::check(builder);
+        EXPECT_EQ(result, true);
     }
 
     static void test_assert_equal_edge_case()
@@ -639,13 +650,17 @@ TYPED_TEST(stdlib_bigfield_edge_cases, assert_is_in_field_fails)
 {
     TestFixture::test_assert_is_in_field_fails();
 }
-TYPED_TEST(stdlib_bigfield_edge_cases, reduce_and_assert_less_than)
+TYPED_TEST(stdlib_bigfield_edge_cases, assert_less_than)
 {
-    TestFixture::test_reduce_and_assert_less_than();
+    TestFixture::test_assert_less_than();
 }
-TYPED_TEST(stdlib_bigfield_edge_cases, reduce_and_assert_less_than_fails)
+TYPED_TEST(stdlib_bigfield_edge_cases, assert_less_than_fails)
 {
-    TestFixture::test_reduce_and_assert_less_than_fails();
+    TestFixture::test_assert_less_than_fails();
+}
+TYPED_TEST(stdlib_bigfield_edge_cases, reduce_mod_target_modulus)
+{
+    TestFixture::test_reduce_mod_target_modulus();
 }
 TYPED_TEST(stdlib_bigfield_edge_cases, assert_equal_edge_case)
 {

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_edge_cases.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_edge_cases.test.cpp
@@ -402,18 +402,18 @@ template <typename BigField> class stdlib_bigfield_edge_cases : public testing::
 
     static void test_assert_is_in_field_fails()
     {
-
-        Builder builder = Builder();
         for (const auto& large_value : values_larger_than_bigfield) {
-            fq_ct large_case = fq_ct::create_from_u512_as_witness(&builder, large_value, false);
+            // Checks each large value individually in its own circuit
+            Builder builder = Builder();
 
             // For values larger than the field modulus, it should trigger a circuit error.
+            fq_ct large_case = fq_ct::create_from_u512_as_witness(&builder, large_value, true);
             large_case.assert_is_in_field();
-        }
 
-        bool result = CircuitChecker::check(builder);
-        EXPECT_EQ(result, false);
-        EXPECT_EQ(builder.err(), "decompose_into_default_range");
+            bool result = CircuitChecker::check(builder);
+            EXPECT_EQ(result, false);
+            EXPECT_EQ(builder.err(), "ultra_circuit_builder: sublimb of hi too large");
+        }
     }
 
     static void test_assert_less_than()
@@ -436,22 +436,19 @@ template <typename BigField> class stdlib_bigfield_edge_cases : public testing::
 
     static void test_assert_less_than_fails()
     {
-        Builder builder = Builder();
+        for (size_t i = 2; i < edge_case_values.size(); ++i) {
+            // Checks each large value individually in its own circuit
+            Builder builder = Builder();
 
-        for (const auto& i : values_larger_than_bigfield) {
-            // get the large value
-            fq_ct large_case = fq_ct::create_from_u512_as_witness(&builder, i, false);
+            // This should fail since values in edge_case_values are sorted in ascending order
+            fq_ct larger_value = fq_ct::create_from_u512_as_witness(&builder, edge_case_values[i], true);
+            uint256_t smaller_value = edge_case_values[i - 1].lo;
+            larger_value.assert_less_than(smaller_value);
 
-            for (size_t j = 1; j < edge_case_values.size(); ++j) {
-                // current value < next value
-                // but this still would fail because range constraints on current value fail
-                large_case.assert_less_than(edge_case_values[j].lo);
-            }
+            bool result = CircuitChecker::check(builder);
+            EXPECT_EQ(result, false);
+            EXPECT_EQ(builder.err(), "ultra_circuit_builder: sublimb of hi too large");
         }
-
-        bool result = CircuitChecker::check(builder);
-        EXPECT_EQ(result, false);
-        EXPECT_EQ(builder.err(), "decompose_into_default_range");
     }
 
     static void test_reduce_mod_target_modulus()

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
@@ -1812,9 +1812,15 @@ template <typename Builder, typename T> void bigfield<Builder, T>::sanity_check(
 // non-negative at the end of subtraction, we know the subtraction result is positive as integers and a<p
 template <typename Builder, typename T> void bigfield<Builder, T>::assert_is_in_field() const
 {
+    assert_less_than(modulus);
+}
+
+// Asserts that the element is < upper_limit. We first range constrain the limbs and then calls
+// unsafe_assert_less_than(upper_limit).
+template <typename Builder, typename T> void bigfield<Builder, T>::assert_less_than(const uint256_t& upper_limit) const
+{
     // Range constrain the binary basis limbs of the element to respective limb sizes.
     // This is required because the comparison is done using subtractions, which can result in overflows.
-    //
     // Range constrain the first two limbs each to NUM_LIMB_BITS
     auto ctx = get_context();
     ctx->range_constrain_two_limbs(binary_basis_limbs[0].element.get_normalized_witness_index(),
@@ -1828,26 +1834,20 @@ template <typename Builder, typename T> void bigfield<Builder, T>::assert_is_in_
                                    static_cast<size_t>(NUM_LIMB_BITS),
                                    static_cast<size_t>(NUM_LAST_LIMB_BITS));
 
-    // Now we can check that the element is < modulus.
-    unsafe_assert_less_than(modulus);
+    // Now we can check that the element is < upper_limit.
+    unsafe_assert_less_than(upper_limit);
 }
 
-// Reduces the element mod p (lazy reduction) and asserts that it is < upper_limit.
-// Note that upper_limit must be < p, otherwise this function will always pass.
-template <typename Builder, typename T>
-void bigfield<Builder, T>::reduce_and_assert_less_than(const uint256_t& upper_limit) const
+// Reduces the element mod p. This is a strict reduction mod p, so the output is guaranteed to be < p.
+template <typename Builder, typename T> void bigfield<Builder, T>::reduce_mod_target_modulus() const
 {
     // First we lazy-reduce the element mod p, and constrain the output/remainder to be < 2^s where s = ceil(log2(p)).
     // This brings the element into the range [0, 2^s) such that the limbs of the reduced element are all range
     // constrained to < 2^b (last limb < 2^(s - 3b)).
-    //
-    // This also means that the upper limit must be < p, otherwise we would end up reducing a value greater than p.
-    // If upper_limit >= p, this function will always pass even if the input > upper_limit.
-    BB_ASSERT_LT(upper_limit, modulus, "upper_limit must be < modulus");
     self_reduce();
 
-    // Then we constrain the element to be < upper_limit using strict comparison.
-    unsafe_assert_less_than(upper_limit);
+    // Then we constrain the element to be < target modulus using strict comparison.
+    unsafe_assert_less_than(modulus);
 }
 
 // Asserts that the element is < upper_limit. We mark this as unsafe because it assumes that the element is already

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
@@ -1905,14 +1905,16 @@ void bigfield<Builder, T>::unsafe_assert_less_than(const uint256_t& upper_limit)
     field_t<Builder> r2 = upper_limit_2 - binary_basis_limbs[2].element +
                           (static_cast<field_t<Builder>>(borrow_2) * shift_1) - static_cast<field_t<Builder>>(borrow_1);
     field_t<Builder> r3 = upper_limit_3 - binary_basis_limbs[3].element - static_cast<field_t<Builder>>(borrow_2);
-    r0 = r0.normalize();
-    r1 = r1.normalize();
-    r2 = r2.normalize();
-    r3 = r3.normalize();
-    context->decompose_into_default_range(r0.get_normalized_witness_index(), static_cast<size_t>(NUM_LIMB_BITS));
-    context->decompose_into_default_range(r1.get_normalized_witness_index(), static_cast<size_t>(NUM_LIMB_BITS));
-    context->decompose_into_default_range(r2.get_normalized_witness_index(), static_cast<size_t>(NUM_LIMB_BITS));
-    context->decompose_into_default_range(r3.get_normalized_witness_index(), static_cast<size_t>(NUM_LIMB_BITS));
+
+    // We need to range constrain the r0,r1,r2,r3 values to ensure they are "small enough".
+    get_context()->range_constrain_two_limbs(r0.get_normalized_witness_index(),
+                                             r1.get_normalized_witness_index(),
+                                             static_cast<size_t>(NUM_LIMB_BITS),
+                                             static_cast<size_t>(NUM_LIMB_BITS));
+    get_context()->range_constrain_two_limbs(r2.get_normalized_witness_index(),
+                                             r3.get_normalized_witness_index(),
+                                             static_cast<size_t>(NUM_LIMB_BITS),
+                                             static_cast<size_t>(NUM_LIMB_BITS));
 }
 
 // check elements are equal mod p by proving their integer difference is a multiple of p.

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
@@ -1803,32 +1803,57 @@ template <typename Builder, typename T> void bigfield<Builder, T>::sanity_check(
              limb_overflow_test_2 || limb_overflow_test_3));
 }
 
-// Underneath performs assert_less_than(modulus)
+// Underneath performs unsafe_assert_less_than(modulus)
 // create a version with mod 2^t element part in [0,p-1]
-// After reducing to size 2^s, we check (p-1)-a is non-negative as integer.
+// After range-constraining to size 2^s, we check (p-1)-a is non-negative as integer.
 // We perform subtraction using carries on blocks of size 2^b. The operations inside the blocks are done mod r
 // Including the effect of carries the operation inside each limb is in the range [-2^b-1,2^{b+1}]
 // Assuming this values are all distinct mod r, which happens e.g. if r/2>2^{b+1}, then if all limb values are
 // non-negative at the end of subtraction, we know the subtraction result is positive as integers and a<p
 template <typename Builder, typename T> void bigfield<Builder, T>::assert_is_in_field() const
 {
-    assert_less_than(modulus);
+    // Range constrain the binary basis limbs of the element to respective limb sizes.
+    // This is required because the comparison is done using subtractions, which can result in overflows.
+    //
+    // Range constrain the first two limbs each to NUM_LIMB_BITS
+    auto ctx = get_context();
+    ctx->range_constrain_two_limbs(binary_basis_limbs[0].element.get_normalized_witness_index(),
+                                   binary_basis_limbs[1].element.get_normalized_witness_index(),
+                                   static_cast<size_t>(NUM_LIMB_BITS),
+                                   static_cast<size_t>(NUM_LIMB_BITS));
+
+    // Range constrain the last two limbs to NUM_LIMB_BITS and NUM_LAST_LIMB_BITS
+    ctx->range_constrain_two_limbs(binary_basis_limbs[2].element.get_normalized_witness_index(),
+                                   binary_basis_limbs[3].element.get_normalized_witness_index(),
+                                   static_cast<size_t>(NUM_LIMB_BITS),
+                                   static_cast<size_t>(NUM_LAST_LIMB_BITS));
+
+    // Now we can check that the element is < modulus.
+    unsafe_assert_less_than(modulus);
 }
 
-// A stricter version that requires the element to be fully reduced mod p.
-// While enforcing `this` < p we do not reduce `this`. The reduction does the following:
-// 1) Reduces the element mod p
-// 2) Enforces that the remainder is < 2^s where s = ceil(log2(p))
-//
-// This is useful in places where we want to ensure that the element is fully reduced, e.g. before
-// serializing to bytes.
-template <typename Builder, typename T> void bigfield<Builder, T>::strict_assert_is_in_field() const
-{
-    assert_less_than(modulus, false);
-}
-
+// Reduces the element mod p (lazy reduction) and asserts that it is < upper_limit.
+// Note that upper_limit must be < p, otherwise this function will always pass.
 template <typename Builder, typename T>
-void bigfield<Builder, T>::assert_less_than(const uint256_t& upper_limit, const bool reduce_input) const
+void bigfield<Builder, T>::reduce_and_assert_less_than(const uint256_t& upper_limit) const
+{
+    // First we lazy-reduce the element mod p, and constrain the output/remainder to be < 2^s where s = ceil(log2(p)).
+    // This brings the element into the range [0, 2^s) such that the limbs of the reduced element are all range
+    // constrained to < 2^b (last limb < 2^(s - 3b)).
+    //
+    // This also means that the upper limit must be < p, otherwise we would end up reducing a value greater than p.
+    // If upper_limit >= p, this function will always pass even if the input > upper_limit.
+    BB_ASSERT_LT(upper_limit, modulus, "upper_limit must be < modulus");
+    self_reduce();
+
+    // Then we constrain the element to be < upper_limit using strict comparison.
+    unsafe_assert_less_than(upper_limit);
+}
+
+// Asserts that the element is < upper_limit. We mark this as unsafe because it assumes that the element is already
+// range constrained to < 2^s where s = ceil(log2(p)).
+template <typename Builder, typename T>
+void bigfield<Builder, T>::unsafe_assert_less_than(const uint256_t& upper_limit) const
 {
     // Warning: this assumes we have run circuit construction at least once in debug mode where large non reduced
     // constants are NOT allowed via ASSERT
@@ -1841,9 +1866,6 @@ void bigfield<Builder, T>::assert_less_than(const uint256_t& upper_limit, const 
     // The circuit checks that limit - this >= 0, so if we are doing a less_than comparison, we need to subtract 1
     // from the limit
     uint256_t strict_upper_limit = upper_limit - uint256_t(1);
-    if (reduce_input) {
-        self_reduce(); // this method in particular enforces limb vals are <2^b - needed for logic described above
-    }
     uint256_t value = get_value().lo;
 
     const uint256_t upper_limit_value_0 = strict_upper_limit.slice(0, NUM_LIMB_BITS);
@@ -1877,11 +1899,11 @@ void bigfield<Builder, T>::assert_less_than(const uint256_t& upper_limit, const 
     // The prover can rearrange the borrows the way they like. The important thing is that the borrows are
     // constrained.
     field_t<Builder> r0 =
-        upper_limit_0 - binary_basis_limbs[0].element + static_cast<field_t<Builder>>(borrow_0) * shift_1;
+        upper_limit_0 - binary_basis_limbs[0].element + (static_cast<field_t<Builder>>(borrow_0) * shift_1);
     field_t<Builder> r1 = upper_limit_1 - binary_basis_limbs[1].element +
-                          static_cast<field_t<Builder>>(borrow_1) * shift_1 - static_cast<field_t<Builder>>(borrow_0);
+                          (static_cast<field_t<Builder>>(borrow_1) * shift_1) - static_cast<field_t<Builder>>(borrow_0);
     field_t<Builder> r2 = upper_limit_2 - binary_basis_limbs[2].element +
-                          static_cast<field_t<Builder>>(borrow_2) * shift_1 - static_cast<field_t<Builder>>(borrow_1);
+                          (static_cast<field_t<Builder>>(borrow_2) * shift_1) - static_cast<field_t<Builder>>(borrow_1);
     field_t<Builder> r3 = upper_limit_3 - binary_basis_limbs[3].element - static_cast<field_t<Builder>>(borrow_2);
     r0 = r0.normalize();
     r1 = r1.normalize();

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
@@ -1815,7 +1815,20 @@ template <typename Builder, typename T> void bigfield<Builder, T>::assert_is_in_
     assert_less_than(modulus);
 }
 
-template <typename Builder, typename T> void bigfield<Builder, T>::assert_less_than(const uint256_t& upper_limit) const
+// A stricter version that requires the element to be fully reduced mod p.
+// While enforcing `this` < p we do not reduce `this`. The reduction does the following:
+// 1) Reduces the element mod p
+// 2) Enforces that the remainder is < 2^s where s = ceil(log2(p))
+//
+// This is useful in places where we want to ensure that the element is fully reduced, e.g. before
+// serializing to bytes.
+template <typename Builder, typename T> void bigfield<Builder, T>::strict_assert_is_in_field() const
+{
+    assert_less_than(modulus, false);
+}
+
+template <typename Builder, typename T>
+void bigfield<Builder, T>::assert_less_than(const uint256_t& upper_limit, const bool reduce_input) const
 {
     // Warning: this assumes we have run circuit construction at least once in debug mode where large non reduced
     // constants are NOT allowed via ASSERT
@@ -1828,7 +1841,9 @@ template <typename Builder, typename T> void bigfield<Builder, T>::assert_less_t
     // The circuit checks that limit - this >= 0, so if we are doing a less_than comparison, we need to subtract 1
     // from the limit
     uint256_t strict_upper_limit = upper_limit - uint256_t(1);
-    self_reduce(); // this method in particular enforces limb vals are <2^b - needed for logic described above
+    if (reduce_input) {
+        self_reduce(); // this method in particular enforces limb vals are <2^b - needed for logic described above
+    }
     uint256_t value = get_value().lo;
 
     const uint256_t upper_limit_value_0 = strict_upper_limit.slice(0, NUM_LIMB_BITS);

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup.hpp
@@ -222,8 +222,8 @@ template <class Builder_, class Fq, class Fr, class NativeGroup> class element {
     element normalize() const
     {
         element result(*this);
-        result.x.assert_is_in_field();
-        result.y.assert_is_in_field();
+        result.x.reduce_mod_target_modulus();
+        result.y.reduce_mod_target_modulus();
         return result;
     }
     element scalar_mul(const Fr& scalar, const size_t max_num_bits = 0) const;

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_nafs.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_nafs.hpp
@@ -463,7 +463,7 @@ std::vector<field_t<C>> element<C, Fq, Fr, G>::compute_wnaf(const Fr& scalar)
         Fr offset = Fr(lo_offset, field_t<C>(bb::fr(negative_hi)) + wnaf_entries[wnaf_entries.size() - 1], true);
         Fr reconstructed = Fr(lo_accumulators, hi_accumulators, true);
         reconstructed = (reconstructed + reconstructed) - offset;
-        reconstructed.assert_is_in_field();
+        reconstructed.reduce_mod_target_modulus();
         reconstructed.assert_equal(scalar);
     }
 


### PR DESCRIPTION
### Bit of background

In the current form of the function `assert_less_than`:

https://github.com/AztecProtocol/aztec-packages/blob/d4024136978e4bdc3fb2ee30dc69c7bde9fadcce/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp#L1826-L1840

we prove that a bigfield element $v \in \mathbb{F}_p$ is less than an upper bound $B < 2^{256}$ as:

$$v < B \quad \implies \quad (B - 1) - v \ge 0$$

Here we subtract $v$ from a constant $(B - 1) \in \mathbb{F}\_p$ and then enforce range constraints on the result being "small" integer. If this has to work, we require $v$ to be "reduced" and hence we called `self_reduce()` on L1839, and then computed $(B - 1) - v\_{\textsf{reduced}}$. The reduction enforces a constraint of the form

$$v = q * p + v\_{\textsf{reduced}}$$

such that $v\_{\textsf{reduced}} < 2^s$ (where $s := \textsf{log}\_2(p)$ ).

### The issue

@federicobarbacovi found an issue in the `assert_is_in_field` function:

https://github.com/AztecProtocol/aztec-packages/blob/d4024136978e4bdc3fb2ee30dc69c7bde9fadcce/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp#L1821-L1824

where we check $v < p$. Since we first reduce $v$ to $v\_{\textsf{reduced}} < 2^s$ we can pass $v = (p + 1)$ as input and the circuit checker would still pass. Because in this case $v\_{\textsf{reduced}} = 1$ which is obviously less than $p$. 

### The fix

1. We create a private function `unsafe_assert_less_than` which computes $(B-1) - v$ for bigfield element $v \in \mathbb{F}_q$ and upper bound $B$ and constrains its limbs to be "small" (68-bit range constraints). This function assumes that the input is reduced (i.e., input limbs are constrained). This is why we prefix the function with `unsafe` and keep it as a private function.
2. We modify the `assert_less_than` function to do two things:
    - explicitly range-constrain the input be $< 2^s$ (i.e., range constrain limbs $x_0, x_1, x_2$ to $b=68$ bits and $x_3$ to $(s - 3b)$ bits)
    - calls `unsafe_assert_less_than` for comparison with $B$
3. As a result, `assert_is_in_field` now performs a strict check: any bigfield element $v$ bigger than the field modulus, i.e., $p < v < 2^s$ will lead to circuit failure.
4. We define a new function `reduce_mod_target_modulus` that retains the existing functionality of first reducing an input $v \in [0, 2^{4b})$ to $v\_{\textsf{reduced}} < 2^s$ and then enforce the comparison $(p - 1) - v\_{\textsf{reduced}} \ge 0$.

