### PR TITLE
fix(avm)!: unconstrained reads in debuglog

### DIFF
--- a/barretenberg/cpp/pil/vm2/memory.pil
+++ b/barretenberg/cpp/pil/vm2/memory.pil
@@ -135,7 +135,6 @@ sel_to_radix_write * (1 - sel_to_radix_write) = 0;
 // Permutation consistency.
 // TODO(#16759): Enable the following relation ensuring that each memory entry is associated with a valid permutation selector.
 //               DebugLog opcode is generating some memory entries which should not be triggered.
-/*
 #[ACTIVE_ROW_NEEDS_PERM_SELECTOR]
 sel = // Addressing.
       sel_addressing_base
@@ -165,7 +164,6 @@ sel = // Addressing.
     + sel_ecc_write[0] + sel_ecc_write[1] + sel_ecc_write[2]
     // To Radix.
     + sel_to_radix_write;
-*/
 
 // Other boolean constraints.
 sel * (1 - sel) = 0; // Ensure mutual exclusivity of the permutation selectors.

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/relations/memory.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/relations/memory.test.cpp
@@ -140,6 +140,10 @@ TEST(MemoryConstrainingTest, MultipleEventsWithTraceGen)
     range_check_trace_builder.process(range_check_events, trace);
     memory_trace_builder.process(mem_events, trace);
 
+    // For the selector consistency, we need to make the read/write come from some trace.
+    trace.visit_column(Column::memory_sel,
+                       [&](uint32_t row, const FF&) { trace.set(Column::memory_sel_register_op_0_, row, 1); });
+
     check_relation<memory>(trace);
     check_all_interactions<MemoryTraceBuilder>(trace);
 }

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/flavor_variables.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/flavor_variables.hpp
@@ -148,7 +148,6 @@ struct AvmFlavorVariables {
     // Need to be templated for recursive verifier
     template <typename FF_>
     using MainRelations_ = flat_tuple::tuple<
-
         // Optimized Relations
         avm2::optimized_poseidon2_perm<FF_>,
         // Relations

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/memory.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/memory.hpp
@@ -14,10 +14,10 @@ template <typename FF_> class memoryImpl {
   public:
     using FF = FF_;
 
-    static constexpr std::array<size_t, 59> SUBRELATION_PARTIAL_LENGTHS = { 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
-                                                                            3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
-                                                                            3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
-                                                                            3, 4, 3, 2, 2, 5, 5, 2, 4, 4, 4, 4, 5, 3 };
+    static constexpr std::array<size_t, 60> SUBRELATION_PARTIAL_LENGTHS = {
+        3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+        3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 2, 3, 3, 3, 3, 4, 3, 2, 2, 5, 5, 2, 4, 4, 4, 4, 5, 3
+    };
 
     template <typename AllEntities> inline static bool skip(const AllEntities& in)
     {
@@ -38,23 +38,26 @@ template <typename FF> class memory : public Relation<memoryImpl<FF>> {
     static constexpr const std::string_view NAME = "memory";
 
     // Subrelation indices constants, to be used in tests.
-    static constexpr size_t SR_MEM_CONTIGUOUS = 46;
-    static constexpr size_t SR_SEL_RNG_CHK = 47;
-    static constexpr size_t SR_GLOBAL_ADDR = 48;
-    static constexpr size_t SR_TIMESTAMP = 49;
-    static constexpr size_t SR_LAST_ACCESS = 50;
-    static constexpr size_t SR_DIFF = 51;
-    static constexpr size_t SR_DIFF_DECOMP = 52;
-    static constexpr size_t SR_MEMORY_INIT_VALUE = 53;
-    static constexpr size_t SR_MEMORY_INIT_TAG = 54;
-    static constexpr size_t SR_READ_WRITE_CONSISTENCY_VALUE = 55;
-    static constexpr size_t SR_READ_WRITE_CONSISTENCY_TAG = 56;
-    static constexpr size_t SR_TAG_IS_FF = 57;
-    static constexpr size_t SR_SEL_RNG_WRITE = 58;
+    static constexpr size_t SR_ACTIVE_ROW_NEEDS_PERM_SELECTOR = 42;
+    static constexpr size_t SR_MEM_CONTIGUOUS = 47;
+    static constexpr size_t SR_SEL_RNG_CHK = 48;
+    static constexpr size_t SR_GLOBAL_ADDR = 49;
+    static constexpr size_t SR_TIMESTAMP = 50;
+    static constexpr size_t SR_LAST_ACCESS = 51;
+    static constexpr size_t SR_DIFF = 52;
+    static constexpr size_t SR_DIFF_DECOMP = 53;
+    static constexpr size_t SR_MEMORY_INIT_VALUE = 54;
+    static constexpr size_t SR_MEMORY_INIT_TAG = 55;
+    static constexpr size_t SR_READ_WRITE_CONSISTENCY_VALUE = 56;
+    static constexpr size_t SR_READ_WRITE_CONSISTENCY_TAG = 57;
+    static constexpr size_t SR_TAG_IS_FF = 58;
+    static constexpr size_t SR_SEL_RNG_WRITE = 59;
 
     static std::string get_subrelation_label(size_t index)
     {
         switch (index) {
+        case SR_ACTIVE_ROW_NEEDS_PERM_SELECTOR:
+            return "ACTIVE_ROW_NEEDS_PERM_SELECTOR";
         case SR_MEM_CONTIGUOUS:
             return "MEM_CONTIGUOUS";
         case SR_SEL_RNG_CHK:

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/memory_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/memory_impl.hpp
@@ -273,65 +273,112 @@ void memoryImpl<FF_>::accumulate(ContainerOverSubrelations& evals,
                    (FF(1) - static_cast<View>(in.get(C::memory_sel_to_radix_write)));
         std::get<41>(evals) += (tmp * scaling_factor);
     }
-    {
+    { // ACTIVE_ROW_NEEDS_PERM_SELECTOR
         using View = typename std::tuple_element_t<42, ContainerOverSubrelations>::View;
-        auto tmp = static_cast<View>(in.get(C::memory_sel)) * (FF(1) - static_cast<View>(in.get(C::memory_sel)));
+        auto tmp =
+            (static_cast<View>(in.get(C::memory_sel)) -
+             (static_cast<View>(in.get(C::memory_sel_addressing_base)) +
+              static_cast<View>(in.get(C::memory_sel_addressing_indirect_0_)) +
+              static_cast<View>(in.get(C::memory_sel_addressing_indirect_1_)) +
+              static_cast<View>(in.get(C::memory_sel_addressing_indirect_2_)) +
+              static_cast<View>(in.get(C::memory_sel_addressing_indirect_3_)) +
+              static_cast<View>(in.get(C::memory_sel_addressing_indirect_4_)) +
+              static_cast<View>(in.get(C::memory_sel_addressing_indirect_5_)) +
+              static_cast<View>(in.get(C::memory_sel_addressing_indirect_6_)) +
+              static_cast<View>(in.get(C::memory_sel_register_op_0_)) +
+              static_cast<View>(in.get(C::memory_sel_register_op_1_)) +
+              static_cast<View>(in.get(C::memory_sel_register_op_2_)) +
+              static_cast<View>(in.get(C::memory_sel_register_op_3_)) +
+              static_cast<View>(in.get(C::memory_sel_register_op_4_)) +
+              static_cast<View>(in.get(C::memory_sel_register_op_5_)) +
+              static_cast<View>(in.get(C::memory_sel_register_op_6_)) +
+              static_cast<View>(in.get(C::memory_sel_data_copy_read)) +
+              static_cast<View>(in.get(C::memory_sel_data_copy_write)) +
+              static_cast<View>(in.get(C::memory_sel_get_contract_instance_exists_write)) +
+              static_cast<View>(in.get(C::memory_sel_get_contract_instance_member_write)) +
+              static_cast<View>(in.get(C::memory_sel_unencrypted_log_read)) +
+              static_cast<View>(in.get(C::memory_sel_poseidon2_read_0_)) +
+              static_cast<View>(in.get(C::memory_sel_poseidon2_read_1_)) +
+              static_cast<View>(in.get(C::memory_sel_poseidon2_read_2_)) +
+              static_cast<View>(in.get(C::memory_sel_poseidon2_read_3_)) +
+              static_cast<View>(in.get(C::memory_sel_poseidon2_write_0_)) +
+              static_cast<View>(in.get(C::memory_sel_poseidon2_write_1_)) +
+              static_cast<View>(in.get(C::memory_sel_poseidon2_write_2_)) +
+              static_cast<View>(in.get(C::memory_sel_poseidon2_write_3_)) +
+              static_cast<View>(in.get(C::memory_sel_keccak)) + static_cast<View>(in.get(C::memory_sel_sha256_read)) +
+              static_cast<View>(in.get(C::memory_sel_sha256_op_0_)) +
+              static_cast<View>(in.get(C::memory_sel_sha256_op_1_)) +
+              static_cast<View>(in.get(C::memory_sel_sha256_op_2_)) +
+              static_cast<View>(in.get(C::memory_sel_sha256_op_3_)) +
+              static_cast<View>(in.get(C::memory_sel_sha256_op_4_)) +
+              static_cast<View>(in.get(C::memory_sel_sha256_op_5_)) +
+              static_cast<View>(in.get(C::memory_sel_sha256_op_6_)) +
+              static_cast<View>(in.get(C::memory_sel_sha256_op_7_)) +
+              static_cast<View>(in.get(C::memory_sel_ecc_write_0_)) +
+              static_cast<View>(in.get(C::memory_sel_ecc_write_1_)) +
+              static_cast<View>(in.get(C::memory_sel_ecc_write_2_)) +
+              static_cast<View>(in.get(C::memory_sel_to_radix_write))));
         std::get<42>(evals) += (tmp * scaling_factor);
     }
     {
         using View = typename std::tuple_element_t<43, ContainerOverSubrelations>::View;
-        auto tmp = static_cast<View>(in.get(C::memory_last_access)) *
-                   (FF(1) - static_cast<View>(in.get(C::memory_last_access)));
+        auto tmp = static_cast<View>(in.get(C::memory_sel)) * (FF(1) - static_cast<View>(in.get(C::memory_sel)));
         std::get<43>(evals) += (tmp * scaling_factor);
     }
     {
         using View = typename std::tuple_element_t<44, ContainerOverSubrelations>::View;
-        auto tmp = static_cast<View>(in.get(C::memory_rw)) * (FF(1) - static_cast<View>(in.get(C::memory_rw)));
+        auto tmp = static_cast<View>(in.get(C::memory_last_access)) *
+                   (FF(1) - static_cast<View>(in.get(C::memory_last_access)));
         std::get<44>(evals) += (tmp * scaling_factor);
     }
     {
         using View = typename std::tuple_element_t<45, ContainerOverSubrelations>::View;
-        auto tmp = static_cast<View>(in.get(C::memory_sel_tag_is_ff)) *
-                   (FF(1) - static_cast<View>(in.get(C::memory_sel_tag_is_ff)));
+        auto tmp = static_cast<View>(in.get(C::memory_rw)) * (FF(1) - static_cast<View>(in.get(C::memory_rw)));
         std::get<45>(evals) += (tmp * scaling_factor);
     }
-    { // MEM_CONTIGUOUS
+    {
         using View = typename std::tuple_element_t<46, ContainerOverSubrelations>::View;
-        auto tmp = (FF(1) - static_cast<View>(in.get(C::precomputed_first_row))) *
-                   (FF(1) - static_cast<View>(in.get(C::memory_sel))) * static_cast<View>(in.get(C::memory_sel_shift));
+        auto tmp = static_cast<View>(in.get(C::memory_sel_tag_is_ff)) *
+                   (FF(1) - static_cast<View>(in.get(C::memory_sel_tag_is_ff)));
         std::get<46>(evals) += (tmp * scaling_factor);
     }
-    { // SEL_RNG_CHK
+    { // MEM_CONTIGUOUS
         using View = typename std::tuple_element_t<47, ContainerOverSubrelations>::View;
-        auto tmp = (static_cast<View>(in.get(C::memory_sel_rng_chk)) -
-                    static_cast<View>(in.get(C::memory_sel)) * static_cast<View>(in.get(C::memory_sel_shift)));
+        auto tmp = (FF(1) - static_cast<View>(in.get(C::precomputed_first_row))) *
+                   (FF(1) - static_cast<View>(in.get(C::memory_sel))) * static_cast<View>(in.get(C::memory_sel_shift));
         std::get<47>(evals) += (tmp * scaling_factor);
     }
-    { // GLOBAL_ADDR
+    { // SEL_RNG_CHK
         using View = typename std::tuple_element_t<48, ContainerOverSubrelations>::View;
+        auto tmp = (static_cast<View>(in.get(C::memory_sel_rng_chk)) -
+                    static_cast<View>(in.get(C::memory_sel)) * static_cast<View>(in.get(C::memory_sel_shift)));
+        std::get<48>(evals) += (tmp * scaling_factor);
+    }
+    { // GLOBAL_ADDR
+        using View = typename std::tuple_element_t<49, ContainerOverSubrelations>::View;
         auto tmp = (static_cast<View>(in.get(C::memory_global_addr)) -
                     (static_cast<View>(in.get(C::memory_space_id)) * FF(4294967296UL) +
                      static_cast<View>(in.get(C::memory_address))));
-        std::get<48>(evals) += (tmp * scaling_factor);
-    }
-    { // TIMESTAMP
-        using View = typename std::tuple_element_t<49, ContainerOverSubrelations>::View;
-        auto tmp = (static_cast<View>(in.get(C::memory_timestamp)) -
-                    (FF(2) * static_cast<View>(in.get(C::memory_clk)) + static_cast<View>(in.get(C::memory_rw))));
         std::get<49>(evals) += (tmp * scaling_factor);
     }
-    { // LAST_ACCESS
+    { // TIMESTAMP
         using View = typename std::tuple_element_t<50, ContainerOverSubrelations>::View;
+        auto tmp = (static_cast<View>(in.get(C::memory_timestamp)) -
+                    (FF(2) * static_cast<View>(in.get(C::memory_clk)) + static_cast<View>(in.get(C::memory_rw))));
+        std::get<50>(evals) += (tmp * scaling_factor);
+    }
+    { // LAST_ACCESS
+        using View = typename std::tuple_element_t<51, ContainerOverSubrelations>::View;
         auto tmp =
             static_cast<View>(in.get(C::memory_sel_rng_chk)) *
             (CView(memory_GLOB_ADDR_DIFF) * ((FF(1) - static_cast<View>(in.get(C::memory_last_access))) *
                                                  (FF(1) - static_cast<View>(in.get(C::memory_glob_addr_diff_inv))) +
                                              static_cast<View>(in.get(C::memory_glob_addr_diff_inv))) -
              static_cast<View>(in.get(C::memory_last_access)));
-        std::get<50>(evals) += (tmp * scaling_factor);
+        std::get<51>(evals) += (tmp * scaling_factor);
     }
     { // DIFF
-        using View = typename std::tuple_element_t<51, ContainerOverSubrelations>::View;
+        using View = typename std::tuple_element_t<52, ContainerOverSubrelations>::View;
         auto tmp =
             (static_cast<View>(in.get(C::memory_diff)) -
              static_cast<View>(in.get(C::memory_sel_rng_chk)) *
@@ -340,61 +387,61 @@ void memoryImpl<FF_>::accumulate(ContainerOverSubrelations& evals,
                       ((static_cast<View>(in.get(C::memory_timestamp_shift)) -
                         static_cast<View>(in.get(C::memory_timestamp))) -
                        static_cast<View>(in.get(C::memory_rw_shift)) * static_cast<View>(in.get(C::memory_rw)))));
-        std::get<51>(evals) += (tmp * scaling_factor);
+        std::get<52>(evals) += (tmp * scaling_factor);
     }
     { // DIFF_DECOMP
-        using View = typename std::tuple_element_t<52, ContainerOverSubrelations>::View;
+        using View = typename std::tuple_element_t<53, ContainerOverSubrelations>::View;
         auto tmp =
             (static_cast<View>(in.get(C::memory_diff)) -
              (static_cast<View>(in.get(C::memory_limb_0_)) + static_cast<View>(in.get(C::memory_limb_1_)) * FF(65536) +
               static_cast<View>(in.get(C::memory_limb_2_)) * FF(4294967296UL)));
-        std::get<52>(evals) += (tmp * scaling_factor);
+        std::get<53>(evals) += (tmp * scaling_factor);
     }
     { // MEMORY_INIT_VALUE
-        using View = typename std::tuple_element_t<53, ContainerOverSubrelations>::View;
+        using View = typename std::tuple_element_t<54, ContainerOverSubrelations>::View;
         auto tmp =
             (static_cast<View>(in.get(C::memory_last_access)) + static_cast<View>(in.get(C::precomputed_first_row))) *
             (FF(1) - static_cast<View>(in.get(C::memory_rw_shift))) * static_cast<View>(in.get(C::memory_value_shift));
-        std::get<53>(evals) += (tmp * scaling_factor);
+        std::get<54>(evals) += (tmp * scaling_factor);
     }
     { // MEMORY_INIT_TAG
-        using View = typename std::tuple_element_t<54, ContainerOverSubrelations>::View;
+        using View = typename std::tuple_element_t<55, ContainerOverSubrelations>::View;
         auto tmp =
             (static_cast<View>(in.get(C::memory_last_access)) + static_cast<View>(in.get(C::precomputed_first_row))) *
             (FF(1) - static_cast<View>(in.get(C::memory_rw_shift))) *
             (static_cast<View>(in.get(C::memory_tag_shift)) - CView(constants_MEM_TAG_FF));
-        std::get<54>(evals) += (tmp * scaling_factor);
-    }
-    { // READ_WRITE_CONSISTENCY_VALUE
-        using View = typename std::tuple_element_t<55, ContainerOverSubrelations>::View;
-        auto tmp = (FF(1) - static_cast<View>(in.get(C::memory_last_access))) *
-                   (FF(1) - static_cast<View>(in.get(C::memory_rw_shift))) *
-                   (static_cast<View>(in.get(C::memory_value_shift)) - static_cast<View>(in.get(C::memory_value)));
         std::get<55>(evals) += (tmp * scaling_factor);
     }
-    { // READ_WRITE_CONSISTENCY_TAG
+    { // READ_WRITE_CONSISTENCY_VALUE
         using View = typename std::tuple_element_t<56, ContainerOverSubrelations>::View;
         auto tmp = (FF(1) - static_cast<View>(in.get(C::memory_last_access))) *
                    (FF(1) - static_cast<View>(in.get(C::memory_rw_shift))) *
-                   (static_cast<View>(in.get(C::memory_tag_shift)) - static_cast<View>(in.get(C::memory_tag)));
+                   (static_cast<View>(in.get(C::memory_value_shift)) - static_cast<View>(in.get(C::memory_value)));
         std::get<56>(evals) += (tmp * scaling_factor);
     }
-    { // TAG_IS_FF
+    { // READ_WRITE_CONSISTENCY_TAG
         using View = typename std::tuple_element_t<57, ContainerOverSubrelations>::View;
+        auto tmp = (FF(1) - static_cast<View>(in.get(C::memory_last_access))) *
+                   (FF(1) - static_cast<View>(in.get(C::memory_rw_shift))) *
+                   (static_cast<View>(in.get(C::memory_tag_shift)) - static_cast<View>(in.get(C::memory_tag)));
+        std::get<57>(evals) += (tmp * scaling_factor);
+    }
+    { // TAG_IS_FF
+        using View = typename std::tuple_element_t<58, ContainerOverSubrelations>::View;
         auto tmp = static_cast<View>(in.get(C::memory_sel)) *
                    ((CView(memory_TAG_FF_DIFF) * (static_cast<View>(in.get(C::memory_sel_tag_is_ff)) *
                                                       (FF(1) - static_cast<View>(in.get(C::memory_tag_ff_diff_inv))) +
                                                   static_cast<View>(in.get(C::memory_tag_ff_diff_inv))) +
                      static_cast<View>(in.get(C::memory_sel_tag_is_ff))) -
                     FF(1));
-        std::get<57>(evals) += (tmp * scaling_factor);
+        std::get<58>(evals) += (tmp * scaling_factor);
     }
     { // SEL_RNG_WRITE
-        using View = typename std::tuple_element_t<58, ContainerOverSubrelations>::View;
+        using View = typename std::tuple_element_t<59, ContainerOverSubrelations>::View;
         auto tmp =
             (static_cast<View>(in.get(C::memory_sel_rng_write)) -
              static_cast<View>(in.get(C::memory_rw)) * (FF(1) - static_cast<View>(in.get(C::memory_sel_tag_is_ff))));
-        std::get<58>(evals) += (tmp * scaling_factor);
+        std::get<59>(evals) += (tmp * scaling_factor);
     }
 }
 

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/memory.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/memory.cpp
@@ -40,6 +40,13 @@ const MemoryValue& Memory::get(MemoryAddress index) const
     return vt;
 }
 
+const MemoryValue& Memory::unconstrained_get(MemoryAddress index) const
+{
+    static const auto default_value = MemoryValue::from<FF>(0);
+    auto it = memory.find(index);
+    return it != memory.end() ? it->second : default_value;
+}
+
 // Sadly this is circuit leaking. In simulation we know the tag-value is consistent.
 // But the circuit does need to force a range check.
 void Memory::validate_tag(const MemoryValue& value) const

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/memory.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/memory.hpp
@@ -43,6 +43,9 @@ class Memory : public MemoryInterface {
 
     uint32_t get_space_id() const override { return space_id; }
 
+    // Only used in debug logging.
+    const MemoryValue& unconstrained_get(MemoryAddress index) const;
+
   private:
     uint32_t space_id;
     unordered_flat_map<size_t, MemoryValue> memory;


### PR DESCRIPTION
Debuglog is not connected to the memory trace, so we can't generate events. The objective of this PR is to enable that while trying not to break the MemoryInterface.

I'm using type-checked casting `dynamic_cast` and adding an unconstrained read to the subclass `Memory`. Still evil, but a bit less evil than changing the interface itself.

In the circuit: I re-enabled the memory selectors check, and check circuit passes with `-d` (which should trigger debug logs).

Closes #16759.