### PR TITLE
chore: remove inner `ProvingKey` in Translator

### DIFF
--- a/barretenberg/cpp/scripts/test_civc_standalone_vks_havent_changed.sh
+++ b/barretenberg/cpp/scripts/test_civc_standalone_vks_havent_changed.sh
@@ -13,7 +13,7 @@ cd ..
 # - Generate a hash for versioning: sha256sum bb-civc-inputs.tar.gz
 # - Upload the compressed results: aws s3 cp bb-civc-inputs.tar.gz s3://aztec-ci-artifacts/protocol/bb-civc-inputs-[hash(0:8)].tar.gz
 # Note: In case of the "Test suite failed to run ... Unexpected token 'with' " error, need to run: docker pull aztecprotocol/build:3.0
-pinned_short_hash="e10fd231"
+pinned_short_hash="721d24f8"
 pinned_civc_inputs_url="https://aztec-ci-artifacts.s3.us-east-2.amazonaws.com/protocol/bb-civc-inputs-${pinned_short_hash}.tar.gz"
 
 function compress_and_upload {

--- a/barretenberg/cpp/src/barretenberg/stdlib/translator_vm_verifier/translator_recursive_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/translator_vm_verifier/translator_recursive_verifier.test.cpp
@@ -111,7 +111,8 @@ class TranslatorRecursiveTests : public ::testing::Test {
         transcript->load_proof(stdlib_proof);
         [[maybe_unused]] auto _ = transcript->template receive_from_prover<RecursiveFlavor::BF>("init");
 
-        auto verification_key = std::make_shared<typename InnerFlavor::VerificationKey>(prover.key->proving_key);
+        auto verification_key = std::make_shared<typename InnerFlavor::VerificationKey>(
+            InnerFlavor::PrecomputedData{ prover.key->polynomials.get_precomputed() });
         RecursiveVerifier verifier{ &outer_circuit, verification_key, transcript };
         typename RecursiveVerifier::PairingPoints pairing_points =
             verifier.verify_proof(proof, evaluation_challenge_x, batching_challenge_v);
@@ -176,9 +177,8 @@ class TranslatorRecursiveTests : public ::testing::Test {
             // Generate a proof over the inner circuit
             auto inner_proving_key = std::make_shared<TranslatorProvingKey>(inner_circuit);
             InnerProver inner_prover(inner_proving_key, prover_transcript);
-            info("test circuit size: ", inner_proving_key->proving_key->circuit_size);
-            auto verification_key =
-                std::make_shared<typename InnerFlavor::VerificationKey>(inner_prover.key->proving_key);
+            auto verification_key = std::make_shared<typename InnerFlavor::VerificationKey>(
+                InnerFlavor::PrecomputedData{ inner_prover.key->polynomials.get_precomputed() });
             auto inner_proof = inner_prover.construct_proof();
 
             // Create a recursive verification circuit for the proof of the inner circuit

--- a/barretenberg/cpp/src/barretenberg/stdlib/translator_vm_verifier/translator_recursive_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/translator_vm_verifier/translator_recursive_verifier.test.cpp
@@ -111,8 +111,7 @@ class TranslatorRecursiveTests : public ::testing::Test {
         transcript->load_proof(stdlib_proof);
         [[maybe_unused]] auto _ = transcript->template receive_from_prover<RecursiveFlavor::BF>("init");
 
-        auto verification_key = std::make_shared<typename InnerFlavor::VerificationKey>(
-            InnerFlavor::PrecomputedData{ prover.key->polynomials.get_precomputed() });
+        auto verification_key = std::make_shared<typename InnerFlavor::VerificationKey>(prover.key->get_precomputed());
         RecursiveVerifier verifier{ &outer_circuit, verification_key, transcript };
         typename RecursiveVerifier::PairingPoints pairing_points =
             verifier.verify_proof(proof, evaluation_challenge_x, batching_challenge_v);
@@ -177,8 +176,8 @@ class TranslatorRecursiveTests : public ::testing::Test {
             // Generate a proof over the inner circuit
             auto inner_proving_key = std::make_shared<TranslatorProvingKey>(inner_circuit);
             InnerProver inner_prover(inner_proving_key, prover_transcript);
-            auto verification_key = std::make_shared<typename InnerFlavor::VerificationKey>(
-                InnerFlavor::PrecomputedData{ inner_prover.key->polynomials.get_precomputed() });
+            auto verification_key =
+                std::make_shared<typename InnerFlavor::VerificationKey>(inner_prover.key->get_precomputed());
             auto inner_proof = inner_prover.construct_proof();
 
             // Create a recursive verification circuit for the proof of the inner circuit

--- a/barretenberg/cpp/src/barretenberg/translator_vm/relation_correctness.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/relation_correctness.test.cpp
@@ -579,8 +579,7 @@ TEST_F(TranslatorRelationCorrectnessTests, ZeroKnowledgePermutation)
     const size_t full_masking_offset = NUM_DISABLED_ROWS_IN_SUMCHECK * Flavor::INTERLEAVING_GROUP_SIZE;
 
     TranslatorProvingKey key{};
-    key.proving_key = std::make_shared<typename Flavor::ProvingKey>();
-    ProverPolynomials& prover_polynomials = key.proving_key->polynomials;
+    ProverPolynomials& prover_polynomials = key.polynomials;
     const size_t dyadic_circuit_size_without_masking = full_circuit_size - full_masking_offset;
 
     // Fill required relation parameters
@@ -632,9 +631,8 @@ TEST_F(TranslatorRelationCorrectnessTests, ZeroKnowledgeDeltaRange)
     using ProverPolynomials = typename Flavor::ProverPolynomials;
     auto& engine = numeric::get_debug_randomness();
 
-    TranslatorProvingKey key;
-    key.proving_key = std::make_shared<typename Flavor::ProvingKey>();
-    ProverPolynomials& prover_polynomials = key.proving_key->polynomials;
+    TranslatorProvingKey key{};
+    ProverPolynomials& prover_polynomials = key.polynomials;
 
     const size_t full_masking_offset = NUM_DISABLED_ROWS_IN_SUMCHECK * Flavor::INTERLEAVING_GROUP_SIZE;
     const size_t dyadic_circuit_size_without_masking = TranslatorProvingKey::dyadic_circuit_size_without_masking;

--- a/barretenberg/cpp/src/barretenberg/translator_vm/translator.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/translator.test.cpp
@@ -84,7 +84,8 @@ class TranslatorTests : public ::testing::Test {
         auto proof = prover.construct_proof();
 
         // Create verifier
-        auto verification_key = std::make_shared<TranslatorFlavor::VerificationKey>(proving_key->proving_key);
+        auto verification_key = std::make_shared<TranslatorFlavor::VerificationKey>(
+            TranslatorFlavor::PrecomputedData{ proving_key->polynomials.get_precomputed() });
         TranslatorVerifier verifier(verification_key, verifier_transcript);
 
         // Verify proof and return result
@@ -193,7 +194,8 @@ TEST_F(TranslatorTests, FixedVK)
             generate_test_circuit(batching_challenge_v, evaluation_challenge_x, circuit_size_parameter);
         auto proving_key = std::make_shared<TranslatorProvingKey>(circuit_builder);
         TranslatorProver prover{ proving_key, prover_transcript };
-        TranslatorFlavor::VerificationKey computed_vk(proving_key->proving_key);
+        TranslatorFlavor::VerificationKey computed_vk(
+            TranslatorFlavor::PrecomputedData{ proving_key->polynomials.get_precomputed() });
         auto labels = TranslatorFlavor::VerificationKey::get_labels();
         size_t index = 0;
         for (auto [vk_commitment, fixed_commitment] : zip_view(computed_vk.get_all(), fixed_vk.get_all())) {

--- a/barretenberg/cpp/src/barretenberg/translator_vm/translator.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/translator.test.cpp
@@ -84,8 +84,7 @@ class TranslatorTests : public ::testing::Test {
         auto proof = prover.construct_proof();
 
         // Create verifier
-        auto verification_key = std::make_shared<TranslatorFlavor::VerificationKey>(
-            TranslatorFlavor::PrecomputedData{ proving_key->polynomials.get_precomputed() });
+        auto verification_key = std::make_shared<TranslatorFlavor::VerificationKey>(proving_key->get_precomputed());
         TranslatorVerifier verifier(verification_key, verifier_transcript);
 
         // Verify proof and return result
@@ -194,8 +193,7 @@ TEST_F(TranslatorTests, FixedVK)
             generate_test_circuit(batching_challenge_v, evaluation_challenge_x, circuit_size_parameter);
         auto proving_key = std::make_shared<TranslatorProvingKey>(circuit_builder);
         TranslatorProver prover{ proving_key, prover_transcript };
-        TranslatorFlavor::VerificationKey computed_vk(
-            TranslatorFlavor::PrecomputedData{ proving_key->polynomials.get_precomputed() });
+        TranslatorFlavor::VerificationKey computed_vk(proving_key->get_precomputed());
         auto labels = TranslatorFlavor::VerificationKey::get_labels();
         size_t index = 0;
         for (auto [vk_commitment, fixed_commitment] : zip_view(computed_vk.get_all(), fixed_vk.get_all())) {

--- a/barretenberg/cpp/src/barretenberg/translator_vm/translator_composer.fuzzer.cpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/translator_composer.fuzzer.cpp
@@ -46,7 +46,8 @@ extern "C" int LLVMFuzzerTestOneInput(const unsigned char* data, size_t size)
     auto verifier_transcript = std::make_shared<bb::TranslatorFlavor::Transcript>();
     verifier_transcript->load_proof(prover_transcript->export_proof());
     verifier_transcript->template receive_from_prover<Fq>("init");
-    auto verification_key = std::make_shared<TranslatorFlavor::VerificationKey>(proving_key->proving_key);
+    auto verification_key = std::make_shared<TranslatorFlavor::VerificationKey>(
+        TranslatorFlavor::PrecomputedData{ proving_key->polynomials.get_precomputed() });
     TranslatorVerifier verifier(verification_key, verifier_transcript);
     bool verified = verifier.verify_proof(proof, x, translation_batching_challenge);
     (void)checked;

--- a/barretenberg/cpp/src/barretenberg/translator_vm/translator_composer.fuzzer.cpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/translator_composer.fuzzer.cpp
@@ -46,8 +46,7 @@ extern "C" int LLVMFuzzerTestOneInput(const unsigned char* data, size_t size)
     auto verifier_transcript = std::make_shared<bb::TranslatorFlavor::Transcript>();
     verifier_transcript->load_proof(prover_transcript->export_proof());
     verifier_transcript->template receive_from_prover<Fq>("init");
-    auto verification_key = std::make_shared<TranslatorFlavor::VerificationKey>(
-        TranslatorFlavor::PrecomputedData{ proving_key->polynomials.get_precomputed() });
+    auto verification_key = std::make_shared<TranslatorFlavor::VerificationKey>(proving_key->get_precomputed());
     TranslatorVerifier verifier(verification_key, verifier_transcript);
     bool verified = verifier.verify_proof(proof, x, translation_batching_challenge);
     (void)checked;

--- a/barretenberg/cpp/src/barretenberg/translator_vm/translator_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/translator_flavor.hpp
@@ -604,7 +604,7 @@ class TranslatorFlavor {
       public:
         DEFINE_COMPOUND_GET_ALL(PrecomputedEntities<DataType>, WitnessEntities<DataType>, ShiftedEntities<DataType>)
 
-        auto get_precomputed() const { return PrecomputedEntities<DataType>::get_all(); };
+        auto get_precomputed() { return PrecomputedEntities<DataType>::get_all(); };
 
         /**
          * @brief Getter for entities constructed by interleaving
@@ -749,22 +749,7 @@ class TranslatorFlavor {
         }
     };
 
-    /**
-     * @brief The proving key is responsible for storing the polynomials used by the prover.
-     *
-     */
-    class ProvingKey {
-      public:
-        size_t circuit_size = 1UL << CONST_TRANSLATOR_LOG_N;
-        size_t log_circuit_size = CONST_TRANSLATOR_LOG_N;
-
-        ProverPolynomials polynomials; // storage for all polynomials evaluated by the prover
-        CommitmentKey commitment_key = CommitmentKey();
-
-        ProvingKey(const CommitmentKey& commitment_key = CommitmentKey())
-            : commitment_key(commitment_key)
-        {}
-    };
+    using PrecomputedData = PrecomputedData_<Polynomial, NUM_PRECOMPUTED_ENTITIES>;
 
     /**
      * @brief The verification key is responsible for storing the commitments to the precomputed (non-witnessk)
@@ -789,15 +774,15 @@ class TranslatorFlavor {
             }
         }
 
-        VerificationKey(const std::shared_ptr<ProvingKey>& proving_key)
+        VerificationKey(const PrecomputedData& precomputed)
         {
             this->log_circuit_size = CONST_TRANSLATOR_LOG_N;
             this->num_public_inputs = 0;
             this->pub_inputs_offset = 0;
 
-            for (auto [polynomial, commitment] :
-                 zip_view(proving_key->polynomials.get_precomputed(), this->get_all())) {
-                commitment = proving_key->commitment_key.commit(polynomial);
+            CommitmentKey commitment_key{ 1UL << CONST_TRANSLATOR_LOG_N };
+            for (auto [polynomial, commitment] : zip_view(precomputed.polynomials, this->get_all())) {
+                commitment = commitment_key.commit(polynomial);
             }
         }
 

--- a/barretenberg/cpp/src/barretenberg/translator_vm/translator_prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/translator_prover.cpp
@@ -20,8 +20,8 @@ TranslatorProver::TranslatorProver(const std::shared_ptr<TranslatorProvingKey>& 
     , key(key)
 {
     BB_BENCH();
-    if (!key->proving_key->commitment_key.initialized()) {
-        key->proving_key->commitment_key = CommitmentKey(key->proving_key->circuit_size);
+    if (!key->commitment_key.initialized()) {
+        key->commitment_key = CommitmentKey(key->dyadic_circuit_size);
     }
 }
 
@@ -41,16 +41,15 @@ void TranslatorProver::execute_preamble_round()
     const auto SHIFTx2 = uint256_t(1) << (Flavor::NUM_LIMB_BITS * 2);
     const auto SHIFTx3 = uint256_t(1) << (Flavor::NUM_LIMB_BITS * 3);
     const size_t RESULT_ROW = Flavor::RESULT_ROW;
-    const auto accumulated_result =
-        BF(uint256_t(key->proving_key->polynomials.accumulators_binary_limbs_0[RESULT_ROW]) +
-           uint256_t(key->proving_key->polynomials.accumulators_binary_limbs_1[RESULT_ROW]) * SHIFT +
-           uint256_t(key->proving_key->polynomials.accumulators_binary_limbs_2[RESULT_ROW]) * SHIFTx2 +
-           uint256_t(key->proving_key->polynomials.accumulators_binary_limbs_3[RESULT_ROW]) * SHIFTx3);
+    const auto accumulated_result = BF(uint256_t(key->polynomials.accumulators_binary_limbs_0[RESULT_ROW]) +
+                                       uint256_t(key->polynomials.accumulators_binary_limbs_1[RESULT_ROW]) * SHIFT +
+                                       uint256_t(key->polynomials.accumulators_binary_limbs_2[RESULT_ROW]) * SHIFTx2 +
+                                       uint256_t(key->polynomials.accumulators_binary_limbs_3[RESULT_ROW]) * SHIFTx3);
 
-    relation_parameters.accumulated_result = { key->proving_key->polynomials.accumulators_binary_limbs_0[RESULT_ROW],
-                                               key->proving_key->polynomials.accumulators_binary_limbs_1[RESULT_ROW],
-                                               key->proving_key->polynomials.accumulators_binary_limbs_2[RESULT_ROW],
-                                               key->proving_key->polynomials.accumulators_binary_limbs_3[RESULT_ROW] };
+    relation_parameters.accumulated_result = { key->polynomials.accumulators_binary_limbs_0[RESULT_ROW],
+                                               key->polynomials.accumulators_binary_limbs_1[RESULT_ROW],
+                                               key->polynomials.accumulators_binary_limbs_2[RESULT_ROW],
+                                               key->polynomials.accumulators_binary_limbs_3[RESULT_ROW] };
 
     // Send the accumulation result to the verifier, this value cannot be linked to the actual content of the op queue
     // in practice (CIVC scenario) as we add a random, but genuine scalar mul operation to the op queue
@@ -65,7 +64,7 @@ void TranslatorProver::execute_preamble_round()
  */
 void TranslatorProver::commit_to_witness_polynomial(Polynomial& polynomial, const std::string& label)
 {
-    transcript->send_to_verifier(label, key->proving_key->commitment_key.commit(polynomial));
+    transcript->send_to_verifier(label, key->commitment_key.commit(polynomial));
 }
 
 /**
@@ -75,16 +74,14 @@ void TranslatorProver::commit_to_witness_polynomial(Polynomial& polynomial, cons
 void TranslatorProver::execute_wire_and_sorted_constraints_commitments_round()
 {
 
-    for (const auto& [wire, label] :
-         zip_view(key->proving_key->polynomials.get_wires(), commitment_labels.get_wires())) {
+    for (const auto& [wire, label] : zip_view(key->polynomials.get_wires(), commitment_labels.get_wires())) {
 
         commit_to_witness_polynomial(wire, label);
     }
 
     // The ordered range constraints are of full circuit size.
-    for (const auto& [ordered_range_constraint, label] :
-         zip_view(key->proving_key->polynomials.get_ordered_range_constraints(),
-                  commitment_labels.get_ordered_range_constraints())) {
+    for (const auto& [ordered_range_constraint, label] : zip_view(key->polynomials.get_ordered_range_constraints(),
+                                                                  commitment_labels.get_ordered_range_constraints())) {
         commit_to_witness_polynomial(ordered_range_constraint, label);
     }
 }
@@ -128,9 +125,9 @@ void TranslatorProver::execute_grand_product_computation_round()
         };
     }
     // Compute constraint permutation grand product
-    compute_grand_products<Flavor>(key->proving_key->polynomials, relation_parameters);
+    compute_grand_products<Flavor>(key->polynomials, relation_parameters);
 
-    commit_to_witness_polynomial(key->proving_key->polynomials.z_perm, commitment_labels.z_perm);
+    commit_to_witness_polynomial(key->polynomials.z_perm, commitment_labels.z_perm);
 }
 
 /**
@@ -150,10 +147,10 @@ void TranslatorProver::execute_relation_check_rounds()
         gate_challenges[idx] = transcript->template get_challenge<FF>("Sumcheck:gate_challenge_" + std::to_string(idx));
     }
 
-    const size_t circuit_size = key->proving_key->circuit_size;
+    const size_t circuit_size = key->dyadic_circuit_size;
 
     Sumcheck sumcheck(circuit_size,
-                      key->proving_key->polynomials,
+                      key->polynomials,
                       transcript,
                       alpha,
                       gate_challenges,
@@ -166,7 +163,7 @@ void TranslatorProver::execute_relation_check_rounds()
     // until we enter the PCS round
     CommitmentKey ck(1 << (log_subgroup_size + 1));
 
-    zk_sumcheck_data = ZKData(key->proving_key->log_circuit_size, transcript, ck);
+    zk_sumcheck_data = ZKData(Flavor::CONST_TRANSLATOR_LOG_N, transcript, ck);
 
     sumcheck_output = sumcheck.prove(zk_sumcheck_data);
 }
@@ -185,23 +182,23 @@ void TranslatorProver::execute_pcs_rounds()
     using PolynomialBatcher = GeminiProver_<Curve>::PolynomialBatcher;
 
     // Check whether the commitment key has been deallocated and reinitialize it if necessary
-    auto& ck = key->proving_key->commitment_key;
+    auto& ck = key->commitment_key;
     if (!ck.initialized()) {
-        ck = CommitmentKey(key->proving_key->circuit_size);
+        ck = CommitmentKey(key->dyadic_circuit_size);
     }
 
     SmallSubgroupIPA small_subgroup_ipa_prover(
         zk_sumcheck_data, sumcheck_output.challenge, sumcheck_output.claimed_libra_evaluation, transcript, ck);
     small_subgroup_ipa_prover.prove();
 
-    PolynomialBatcher polynomial_batcher(key->proving_key->circuit_size);
-    polynomial_batcher.set_unshifted(key->proving_key->polynomials.get_unshifted_without_interleaved());
-    polynomial_batcher.set_to_be_shifted_by_one(key->proving_key->polynomials.get_to_be_shifted());
-    polynomial_batcher.set_interleaved(key->proving_key->polynomials.get_interleaved(),
-                                       key->proving_key->polynomials.get_groups_to_be_interleaved());
+    PolynomialBatcher polynomial_batcher(key->dyadic_circuit_size);
+    polynomial_batcher.set_unshifted(key->polynomials.get_unshifted_without_interleaved());
+    polynomial_batcher.set_to_be_shifted_by_one(key->polynomials.get_to_be_shifted());
+    polynomial_batcher.set_interleaved(key->polynomials.get_interleaved(),
+                                       key->polynomials.get_groups_to_be_interleaved());
 
     const OpeningClaim prover_opening_claim =
-        ShpleminiProver_<Curve>::prove(key->proving_key->circuit_size,
+        ShpleminiProver_<Curve>::prove(key->dyadic_circuit_size,
                                        polynomial_batcher,
                                        sumcheck_output.challenge,
                                        ck,
@@ -232,7 +229,7 @@ HonkProof TranslatorProver::construct_proof()
 
     // #ifndef __wasm__
     // Free the commitment key
-    key->proving_key->commitment_key = CommitmentKey();
+    key->commitment_key = CommitmentKey();
     // #endif
 
     // Fiat-Shamir: alpha

--- a/barretenberg/cpp/src/barretenberg/translator_vm/translator_prover.hpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/translator_prover.hpp
@@ -21,7 +21,6 @@ class TranslatorProver {
     using BF = typename Flavor::BF;
     using Commitment = typename Flavor::Commitment;
     using CommitmentKey = typename Flavor::CommitmentKey;
-    using ProvingKey = typename Flavor::ProvingKey;
     using Polynomial = typename Flavor::Polynomial;
     using CommitmentLabels = typename Flavor::CommitmentLabels;
     using PCS = typename Flavor::PCS;

--- a/barretenberg/cpp/src/barretenberg/translator_vm/translator_proving_key.cpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/translator_proving_key.cpp
@@ -27,14 +27,14 @@ namespace bb {
 void TranslatorProvingKey::compute_interleaved_polynomials()
 {
     // The vector of groups of polynomials to be interleaved
-    auto interleaved = proving_key->polynomials.get_groups_to_be_interleaved();
+    auto interleaved = polynomials.get_groups_to_be_interleaved();
     // Resulting interleaved polynomials
-    auto targets = proving_key->polynomials.get_interleaved();
+    auto targets = polynomials.get_interleaved();
 
     const size_t num_polys_in_group = interleaved[0].size();
     BB_ASSERT_EQ(num_polys_in_group, Flavor::INTERLEAVING_GROUP_SIZE);
 
-    // Targets have to be full-sized proving_key->polynomials. We can compute the mini circuit size from them by
+    // Targets have to be full-sized polynomials. We can compute the mini circuit size from them by
     // dividing by the number of polynomials in the group
     const size_t MINI_CIRCUIT_SIZE = targets[0].size() / num_polys_in_group;
     BB_ASSERT_EQ(MINI_CIRCUIT_SIZE * num_polys_in_group, targets[0].size());
@@ -83,14 +83,14 @@ void TranslatorProvingKey::compute_translator_range_constraint_ordered_polynomia
     // Get constants
     constexpr size_t num_interleaved_wires = Flavor::NUM_INTERLEAVED_WIRES;
 
-    RefArray ordered_constraint_polynomials{ proving_key->polynomials.ordered_range_constraints_0,
-                                             proving_key->polynomials.ordered_range_constraints_1,
-                                             proving_key->polynomials.ordered_range_constraints_2,
-                                             proving_key->polynomials.ordered_range_constraints_3 };
+    RefArray ordered_constraint_polynomials{ polynomials.ordered_range_constraints_0,
+                                             polynomials.ordered_range_constraints_1,
+                                             polynomials.ordered_range_constraints_2,
+                                             polynomials.ordered_range_constraints_3 };
     std::vector<size_t> extra_denominator_uint(dyadic_circuit_size_without_masking);
 
     const auto sorted_elements = get_sorted_steps();
-    auto to_be_interleaved_groups = proving_key->polynomials.get_groups_to_be_interleaved();
+    auto to_be_interleaved_groups = polynomials.get_groups_to_be_interleaved();
 
     // Given the polynomials in group_i, transfer their elements, sorted in non-descending order, into the corresponding
     // ordered_range_constraint_i up to the given capacity and the remaining elements to the last range constraint.
@@ -160,7 +160,7 @@ void TranslatorProvingKey::compute_translator_range_constraint_ordered_polynomia
 #endif
 
     // Copy the values into the actual polynomial
-    proving_key->polynomials.ordered_range_constraints_4.copy_vector(extra_denominator_uint);
+    polynomials.ordered_range_constraints_4.copy_vector(extra_denominator_uint);
 
     // Transfer randomness from interleaved to ordered polynomials such that the commitments and evaluations of all
     // ordered polynomials and their shifts are hidden
@@ -183,8 +183,8 @@ void TranslatorProvingKey::compute_translator_range_constraint_ordered_polynomia
  */
 void TranslatorProvingKey::split_interleaved_random_coefficients_to_ordered()
 {
-    auto interleaved = proving_key->polynomials.get_interleaved();
-    auto ordered = proving_key->polynomials.get_ordered_range_constraints();
+    auto interleaved = polynomials.get_interleaved();
+    auto ordered = polynomials.get_ordered_range_constraints();
     const size_t num_ordered_polynomials = ordered.size();
 
     const size_t total_num_random_values =
@@ -267,22 +267,22 @@ void TranslatorProvingKey::split_interleaved_random_coefficients_to_ordered()
 void TranslatorProvingKey::compute_lagrange_polynomials()
 {
 
-    proving_key->polynomials.lagrange_first.at(0) = 1;
-    proving_key->polynomials.lagrange_real_last.at(dyadic_circuit_size_without_masking - 1) = 1;
-    proving_key->polynomials.lagrange_last.at(dyadic_circuit_size - 1) = 1;
+    polynomials.lagrange_first.at(0) = 1;
+    polynomials.lagrange_real_last.at(dyadic_circuit_size_without_masking - 1) = 1;
+    polynomials.lagrange_last.at(dyadic_circuit_size - 1) = 1;
 
     // Location of randomness for the polynomials defined within the large size
     for (size_t i = dyadic_circuit_size_without_masking; i < dyadic_circuit_size; i++) {
-        proving_key->polynomials.lagrange_masking.at(i) = 1;
+        polynomials.lagrange_masking.at(i) = 1;
     }
 
     for (size_t i = Flavor::RANDOMNESS_START; i < Flavor::RESULT_ROW; i++) {
-        proving_key->polynomials.lagrange_mini_masking.at(i) = 1;
+        polynomials.lagrange_mini_masking.at(i) = 1;
     }
 
     // Location of randomness for wires defined within the mini circuit
     for (size_t i = dyadic_mini_circuit_size_without_masking; i < mini_circuit_dyadic_size; i++) {
-        proving_key->polynomials.lagrange_mini_masking.at(i) = 1;
+        polynomials.lagrange_mini_masking.at(i) = 1;
     }
 
     // Translator VM processes two rows of its execution trace at a time, establishing different relations between
@@ -290,13 +290,13 @@ void TranslatorProvingKey::compute_lagrange_polynomials()
     // should trigger at odd indices and which at even. These polynomials need to only be active within the range of
     // Translator trace that processes actual ecc ops.
     for (size_t i = Flavor::RESULT_ROW; i < dyadic_mini_circuit_size_without_masking; i += 2) {
-        proving_key->polynomials.lagrange_even_in_minicircuit.at(i) = 1;
-        proving_key->polynomials.lagrange_odd_in_minicircuit.at(i + 1) = 1;
+        polynomials.lagrange_even_in_minicircuit.at(i) = 1;
+        polynomials.lagrange_odd_in_minicircuit.at(i + 1) = 1;
     }
 
     // Position of evaluation result
-    proving_key->polynomials.lagrange_result_row.at(Flavor::RESULT_ROW) = 1;
-    proving_key->polynomials.lagrange_last_in_minicircuit.at(dyadic_mini_circuit_size_without_masking - 1) = 1;
+    polynomials.lagrange_result_row.at(Flavor::RESULT_ROW) = 1;
+    polynomials.lagrange_last_in_minicircuit.at(dyadic_mini_circuit_size_without_masking - 1) = 1;
 }
 
 /**
@@ -321,8 +321,8 @@ void TranslatorProvingKey::compute_extra_range_constraint_numerator()
     // TODO(#756): can be parallelized further. This will use at most 5 threads
     auto fill_with_shift = [&](size_t shift) {
         for (size_t i = 0; i < sorted_elements.size(); i++) {
-            proving_key->polynomials.ordered_extra_range_constraints_numerator.at(
-                shift + i * (Flavor::NUM_INTERLEAVED_WIRES + 1)) = sorted_elements[i];
+            polynomials.ordered_extra_range_constraints_numerator.at(shift + i * (Flavor::NUM_INTERLEAVED_WIRES + 1)) =
+                sorted_elements[i];
         }
     };
     // Fill polynomials with a sequence, where each element is repeated NUM_INTERLEAVED_WIRES+1 times

--- a/barretenberg/cpp/src/barretenberg/translator_vm/translator_proving_key.hpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/translator_proving_key.hpp
@@ -146,7 +146,7 @@ class TranslatorProvingKey {
 
     void split_interleaved_random_coefficients_to_ordered();
 
-    // PrecomputedData get_precomputed() { return PrecomputedData{ polynomials.get_precomputed() }; }
+    PrecomputedData get_precomputed() { return PrecomputedData{ polynomials.get_precomputed() }; };
 };
 
 } // namespace bb

--- a/barretenberg/cpp/src/barretenberg/translator_vm/translator_proving_key.hpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/translator_proving_key.hpp
@@ -17,10 +17,9 @@ class TranslatorProvingKey {
     using Circuit = typename Flavor::CircuitBuilder;
     using FF = typename Flavor::FF;
     using BF = typename Flavor::BF;
-    using ProvingKey = typename Flavor::ProvingKey;
-    using Polynomial = typename Flavor::Polynomial;
     using ProverPolynomials = typename Flavor::ProverPolynomials;
     using CommitmentKey = typename Flavor::CommitmentKey;
+    using PrecomputedData = typename Flavor::PrecomputedData;
 
     static constexpr size_t mini_circuit_dyadic_size = Flavor::MINI_CIRCUIT_SIZE;
     // The actual circuit size is several times bigger than the trace in the circuit, because we use interleaving
@@ -35,7 +34,8 @@ class TranslatorProvingKey {
     static constexpr size_t dyadic_circuit_size_without_masking =
         dyadic_circuit_size - Flavor::NUM_MASKED_ROWS_END * Flavor::INTERLEAVING_GROUP_SIZE;
 
-    std::shared_ptr<ProvingKey> proving_key;
+    ProverPolynomials polynomials;
+    CommitmentKey commitment_key = CommitmentKey();
 
     BF batching_challenge_v = { 0 };
     BF evaluation_input_x = { 0 };
@@ -43,7 +43,8 @@ class TranslatorProvingKey {
     TranslatorProvingKey() = default;
 
     TranslatorProvingKey(const Circuit& circuit, const CommitmentKey& commitment_key = CommitmentKey())
-        : batching_challenge_v(circuit.batching_challenge_v)
+        : commitment_key(std::move(commitment_key))
+        , batching_challenge_v(circuit.batching_challenge_v)
         , evaluation_input_x(circuit.evaluation_input_x)
     {
         BB_BENCH_NAME("TranslatorProvingKey(TranslatorCircuit&)");
@@ -53,8 +54,7 @@ class TranslatorProvingKey {
             throw_or_abort("The Translator circuit size has exceeded the fixed upper bound");
         }
 
-        proving_key = std::make_shared<ProvingKey>(std::move(commitment_key));
-        auto wires = proving_key->polynomials.get_wires();
+        auto wires = polynomials.get_wires();
         for (auto [wire_poly_, wire_] : zip_view(wires, circuit.wires)) {
             auto& wire_poly = wire_poly_;
             const auto& wire = wire_;
@@ -145,5 +145,8 @@ class TranslatorProvingKey {
     void compute_interleaved_polynomials();
 
     void split_interleaved_random_coefficients_to_ordered();
+
+    // PrecomputedData get_precomputed() { return PrecomputedData{ polynomials.get_precomputed() }; }
 };
+
 } // namespace bb

--- a/barretenberg/cpp/src/barretenberg/translator_vm/translator_verifier.hpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/translator_verifier.hpp
@@ -17,7 +17,6 @@ class TranslatorVerifier {
     using FF = Flavor::FF;
     using BF = Flavor::BF;
     using Commitment = Flavor::Commitment;
-    using ProvingKey = Flavor::ProvingKey;
     using VerificationKey = Flavor::VerificationKey;
     using VerifierCommitmentKey = Flavor::VerifierCommitmentKey;
     using TranslationEvaluations = bb::TranslationEvaluations_<BF>;
@@ -36,8 +35,6 @@ class TranslatorVerifier {
 
     TranslatorVerifier(const std::shared_ptr<VerificationKey>& verifier_key,
                        const std::shared_ptr<Transcript>& transcript);
-
-    TranslatorVerifier(const std::shared_ptr<ProvingKey>& proving_key, const std::shared_ptr<Transcript>& transcript);
 
     void put_translation_data_in_relation_parameters(const uint256_t& evaluation_input_x,
                                                      const BF& batching_challenge_v,


### PR DESCRIPTION
Similar to how we've moved the inner ProvingKey in ProverInstance, we do the same in Translator by making the `TranslatorProvingKey` take ownership of the ProverPolynomials