### PR TITLE
chore: Deflake inactivity slash e2e test

### DIFF
--- a/yarn-project/end-to-end/src/e2e_p2p/inactivity_slash.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/inactivity_slash.test.ts
@@ -17,6 +17,7 @@ describe('e2e_p2p_inactivity_slash', () => {
     test = await P2PInactivityTest.create('e2e_p2p_inactivity_slash', {
       slashInactivityConsecutiveEpochThreshold: SLASH_INACTIVITY_CONSECUTIVE_EPOCH_THRESHOLD,
       inactiveNodeCount: 1,
+      keepInitialNode: false,
     }).then(t => t.setup());
   });
 

--- a/yarn-project/end-to-end/src/fixtures/utils.ts
+++ b/yarn-project/end-to-end/src/fixtures/utils.ts
@@ -573,7 +573,7 @@ export async function setup(
     await blobSink.start();
     config.blobSinkUrl = `http://localhost:${blobSinkPort}`;
 
-    logger.verbose('Creating and synching an aztec node...');
+    logger.verbose('Creating and synching an aztec node', config);
 
     const acvmConfig = await getACVMConfig(logger);
     if (acvmConfig) {

--- a/yarn-project/ethereum/src/test/rollup_cheat_codes.ts
+++ b/yarn-project/ethereum/src/test/rollup_cheat_codes.ts
@@ -112,14 +112,14 @@ export class RollupCheatCodes {
    * @param opts - Options
    */
   public async advanceToEpoch(
-    epoch: bigint,
+    epoch: bigint | number,
     opts: {
       /** Optional test date provider to update with the epoch timestamp */
       updateDateProvider?: TestDateProvider;
     } = {},
   ) {
     const { epochDuration: slotsInEpoch } = await this.getConfig();
-    const timestamp = await this.rollup.read.getTimestampForSlot([epoch * slotsInEpoch]);
+    const timestamp = await this.rollup.read.getTimestampForSlot([BigInt(epoch) * slotsInEpoch]);
     try {
       await this.ethCheatCodes.warp(Number(timestamp), { ...opts, silent: true, resetBlockInterval: true });
       this.logger.warn(`Warped to epoch ${epoch}`);


### PR DESCRIPTION
Attempt at fixing the flake on `inactivity_slash.test`. The test was failing as sometimes other validator than the "offline" one was getting slashed, due to inactivity during setup. We try addressing that by setting up a long slashing grace period, so we can safely set up every sequencer during that period, and then warping to after that to start slashing.

We also try avoid slashing an active validator by bumping the inactivity threshold on this PR.