### PR TITLE
chore: Backport ignition slashing config to v2

### DIFF
--- a/yarn-project/cli/src/config/chain_l2_config.ts
+++ b/yarn-project/cli/src/config/chain_l2_config.ts
@@ -88,23 +88,64 @@ export const stagingIgnitionL2ChainConfig: L2ChainConfig = {
   publicMetricsCollectorUrl: 'https://telemetry.alpha-testnet.aztec-labs.com/v1/metrics',
   publicMetricsCollectFrom: ['sequencer'],
 
-  ...DefaultL1ContractsConfig,
-  ...DefaultSlashConfig,
-
   /** How many seconds an L1 slot lasts. */
   ethereumSlotDuration: 12,
   /** How many seconds an L2 slots lasts (must be multiple of ethereum slot duration). */
-  aztecSlotDuration: 36,
+  aztecSlotDuration: 72,
   /** How many L2 slots an epoch lasts. */
   aztecEpochDuration: 32,
   /** The target validator committee size. */
-  aztecTargetCommitteeSize: 48,
+  aztecTargetCommitteeSize: 24,
+  /** The number of epochs to lag behind the current epoch for validator selection. */
+  lagInEpochs: 2,
   /** The number of epochs after an epoch ends that proofs are still accepted. */
   aztecProofSubmissionEpochs: 1,
+  /** How many sequencers must agree with a slash for it to be executed. */
+  slashingQuorum: 65,
+
+  slashingRoundSizeInEpochs: 4,
+  slashingLifetimeInRounds: 40,
+  slashingExecutionDelayInRounds: 28,
+  slashAmountSmall: 2_000n * 10n ** 18n,
+  slashAmountMedium: 10_000n * 10n ** 18n,
+  slashAmountLarge: 50_000n * 10n ** 18n,
+  slashingOffsetInRounds: 2,
+  slasherFlavor: 'tally',
+  slashingVetoer: EthAddress.ZERO, // TODO TMNT-329
+
   /** The mana target for the rollup */
   manaTarget: 0n,
+
+  exitDelaySeconds: 5 * 24 * 60 * 60,
+
   /** The proving cost per mana */
   provingCostPerMana: 0n,
+  localEjectionThreshold: 196_000n * 10n ** 18n,
+
+  ejectionThreshold: 100_000n * 10n ** 18n,
+  activationThreshold: 200_000n * 10n ** 18n,
+
+  governanceProposerRoundSize: 300, // TODO TMNT-322
+  governanceProposerQuorum: 151, // TODO TMNT-322
+
+  // Node slashing config
+  // TODO TMNT-330
+  slashMinPenaltyPercentage: 0.5,
+  slashMaxPenaltyPercentage: 2.0,
+  slashInactivityTargetPercentage: 0.7,
+  slashInactivityConsecutiveEpochThreshold: 2,
+  slashInactivityPenalty: 2_000n * 10n ** 18n,
+  slashPrunePenalty: 0n, // 2_000n * 10n ** 18n, We disable slashing for prune offenses right now
+  slashDataWithholdingPenalty: 0n, // 2_000n * 10n ** 18n, We disable slashing for data withholding offenses right now
+  slashProposeInvalidAttestationsPenalty: 50_000n * 10n ** 18n,
+  slashAttestDescendantOfInvalidPenalty: 50_000n * 10n ** 18n,
+  slashUnknownPenalty: 2_000n * 10n ** 18n,
+  slashBroadcastedInvalidBlockPenalty: 10_000n * 10n ** 18n,
+  slashMaxPayloadSize: 50,
+  slashGracePeriodL2Slots: 32 * 4, // One round from genesis
+  slashOffenseExpirationRounds: 8,
+  sentinelEnabled: true,
+  slashingDisableDuration: 5 * 24 * 60 * 60,
 };
 
 export const stagingPublicL2ChainConfig: L2ChainConfig = {
@@ -203,6 +244,8 @@ export const testnetL2ChainConfig: L2ChainConfig = {
   exitDelaySeconds: DefaultL1ContractsConfig.exitDelaySeconds,
 
   ...DefaultSlashConfig,
+  slashPrunePenalty: 0n,
+  slashDataWithholdingPenalty: 0n,
 };
 
 const BOOTNODE_CACHE_DURATION_MS = 60 * 60 * 1000; // 1 hour;

--- a/yarn-project/cli/src/config/chain_l2_config.ts
+++ b/yarn-project/cli/src/config/chain_l2_config.ts
@@ -96,8 +96,6 @@ export const stagingIgnitionL2ChainConfig: L2ChainConfig = {
   aztecEpochDuration: 32,
   /** The target validator committee size. */
   aztecTargetCommitteeSize: 24,
-  /** The number of epochs to lag behind the current epoch for validator selection. */
-  lagInEpochs: 2,
   /** The number of epochs after an epoch ends that proofs are still accepted. */
   aztecProofSubmissionEpochs: 1,
   /** How many sequencers must agree with a slash for it to be executed. */
@@ -120,7 +118,6 @@ export const stagingIgnitionL2ChainConfig: L2ChainConfig = {
 
   /** The proving cost per mana */
   provingCostPerMana: 0n,
-  localEjectionThreshold: 196_000n * 10n ** 18n,
 
   ejectionThreshold: 100_000n * 10n ** 18n,
   activationThreshold: 200_000n * 10n ** 18n,
@@ -145,7 +142,6 @@ export const stagingIgnitionL2ChainConfig: L2ChainConfig = {
   slashGracePeriodL2Slots: 32 * 4, // One round from genesis
   slashOffenseExpirationRounds: 8,
   sentinelEnabled: true,
-  slashingDisableDuration: 5 * 24 * 60 * 60,
 };
 
 export const stagingPublicL2ChainConfig: L2ChainConfig = {
@@ -246,6 +242,7 @@ export const testnetL2ChainConfig: L2ChainConfig = {
   ...DefaultSlashConfig,
   slashPrunePenalty: 0n,
   slashDataWithholdingPenalty: 0n,
+  slashInactivityPenalty: DefaultL1ContractsConfig.slashAmountMedium,
 };
 
 const BOOTNODE_CACHE_DURATION_MS = 60 * 60 * 1000; // 1 hour;

--- a/yarn-project/end-to-end/src/e2e_fees/fees_test.ts
+++ b/yarn-project/end-to-end/src/e2e_fees/fees_test.ts
@@ -145,13 +145,14 @@ export class FeesTest {
 
   async getBlockRewards() {
     const blockReward = await this.rollupContract.getBlockReward();
+    const rewardConfig = await this.rollupContract.getRewardConfig();
 
     const balance = await this.feeJuiceBridgeTestHarness.getL1FeeJuiceBalance(
-      this.context.deployL1ContractsValues.l1ContractAddresses.rewardDistributorAddress,
+      EthAddress.fromString(rewardConfig.rewardDistributor),
     );
 
     const toDistribute = balance > blockReward ? blockReward : balance;
-    const sequencerBlockRewards = toDistribute / 2n;
+    const sequencerBlockRewards = (toDistribute * BigInt(rewardConfig.sequencerBps)) / 10000n;
     const proverBlockRewards = toDistribute - sequencerBlockRewards;
 
     return { sequencerBlockRewards, proverBlockRewards };

--- a/yarn-project/ethereum/src/config.ts
+++ b/yarn-project/ethereum/src/config.ts
@@ -72,11 +72,12 @@ export const DefaultL1ContractsConfig = {
   aztecEpochDuration: 32,
   aztecTargetCommitteeSize: 48,
   aztecProofSubmissionEpochs: 1, // you have a full epoch to submit a proof after the epoch to prove ends
-  activationThreshold: BigInt(100e18),
-  ejectionThreshold: BigInt(50e18),
-  slashAmountSmall: BigInt(10e18),
-  slashAmountMedium: BigInt(20e18),
-  slashAmountLarge: BigInt(50e18),
+  activationThreshold: 100n * 10n ** 18n,
+  ejectionThreshold: 50n * 10n ** 18n,
+  localEjectionThreshold: 98n * 10n ** 18n,
+  slashAmountSmall: 10n * 10n ** 18n,
+  slashAmountMedium: 20n * 10n ** 18n,
+  slashAmountLarge: 50n * 10n ** 18n,
   slashingRoundSizeInEpochs: 4,
   slashingLifetimeInRounds: 5,
   slashingExecutionDelayInRounds: 0, // round N may be submitted in round N + 1
@@ -119,31 +120,32 @@ const StagingPublicGovernanceConfiguration = {
 
 const TestnetGovernanceConfiguration = {
   proposeConfig: {
-    lockDelay: 60n * 60n * 24n,
-    lockAmount: DefaultL1ContractsConfig.activationThreshold * 100n,
+    lockDelay: 10n * 365n * 24n * 60n * 60n,
+    lockAmount: 1250n * 200_000n * 10n ** 18n,
   },
-  votingDelay: 60n,
-  votingDuration: 60n * 60n,
-  executionDelay: 60n * 60n * 24n,
-  gracePeriod: 60n * 60n * 24n * 7n,
-  quorum: 3n * 10n ** 17n, // 30%
-  requiredYeaMargin: 4n * 10n ** 16n, // 4%
-  minimumVotes: DefaultL1ContractsConfig.ejectionThreshold * 200n,
+
+  votingDelay: 12n * 60n * 60n, // 12 hours
+  votingDuration: 1n * 24n * 60n * 60n, // 1 day
+  executionDelay: 12n * 60n * 60n, // 12 hours
+  gracePeriod: 1n * 24n * 60n * 60n, // 1 day
+  quorum: 2n * 10n ** 17n, // 20%
+  requiredYeaMargin: 1n * 10n ** 17n, // 10%
+  minimumVotes: 1250n * 200_000n * 10n ** 18n,
 };
 
 const StagingIgnitionGovernanceConfiguration = {
   proposeConfig: {
-    lockDelay: 60n * 60n * 24n * 30n, // 30 days
-    lockAmount: DefaultL1ContractsConfig.activationThreshold * 100n,
+    lockDelay: 10n * 365n * 24n * 60n * 60n,
+    lockAmount: 1250n * 200_000n * 10n ** 18n,
   },
 
-  votingDelay: 60n,
-  votingDuration: 60n * 60n,
-  executionDelay: 60n,
-  gracePeriod: 60n * 60n * 24n * 7n,
-  quorum: 3n * 10n ** 17n, // 30%
-  requiredYeaMargin: 4n * 10n ** 16n, // 4%
-  minimumVotes: DefaultL1ContractsConfig.ejectionThreshold * 200n, // >= 200 validators must vote
+  votingDelay: 7n * 24n * 60n * 60n,
+  votingDuration: 7n * 24n * 60n * 60n,
+  executionDelay: 30n * 24n * 60n * 60n,
+  gracePeriod: 7n * 24n * 60n * 60n,
+  quorum: 2n * 10n ** 17n, // 20%
+  requiredYeaMargin: 1n * 10n ** 17n, // 10%
+  minimumVotes: 1250n * 200_000n * 10n ** 18n,
 };
 
 export const getGovernanceConfiguration = (networkName: NetworkNames) => {
@@ -201,10 +203,10 @@ export const getGSEConfiguration = (networkName: NetworkNames) => {
 // for it seems overkill
 
 const DefaultRewardConfig = {
-  sequencerBps: 5000,
+  sequencerBps: 8000,
   rewardDistributor: EthAddress.ZERO.toString(),
   booster: EthAddress.ZERO.toString(),
-  blockReward: BigInt(50e18),
+  blockReward: 500n * 10n ** 18n,
 };
 
 export const getRewardConfig = (networkName: NetworkNames) => {
@@ -219,51 +221,16 @@ export const getRewardConfig = (networkName: NetworkNames) => {
   }
 };
 
-const LocalRewardBoostConfig = {
-  increment: 200000,
-  maxScore: 5000000,
-  a: 5000,
-  k: 1000000,
-  minimum: 100000,
-};
-
-const StagingPublicRewardBoostConfig = {
-  increment: 200000,
-  maxScore: 5000000,
-  a: 5000,
-  k: 1000000,
-  minimum: 100000,
-};
-
-const TestnetRewardBoostConfig = {
-  increment: 125000,
-  maxScore: 15000000,
-  a: 1000,
-  k: 1000000,
-  minimum: 100000,
-};
-
-const StagingIgnitionRewardBoostConfig = {
-  increment: 200000,
-  maxScore: 5000000,
-  a: 5000,
-  k: 1000000,
-  minimum: 100000,
-};
-
-export const getRewardBoostConfig = (networkName: NetworkNames) => {
-  switch (networkName) {
-    case 'local':
-      return LocalRewardBoostConfig;
-    case 'staging-public':
-      return StagingPublicRewardBoostConfig;
-    case 'testnet':
-      return TestnetRewardBoostConfig;
-    case 'staging-ignition':
-      return StagingIgnitionRewardBoostConfig;
-    default:
-      throw new Error(`Unrecognized network name: ${networkName}`);
-  }
+export const getRewardBoostConfig = () => {
+  // The reward configuration is specified with a precision of 1e5, and we use the same across
+  // all networks.
+  return {
+    increment: 125000, // 1.25
+    maxScore: 15000000, // 150
+    a: 1000, // 0.01
+    k: 1000000, // 10
+    minimum: 100000, // 1
+  };
 };
 
 // Similar to the above, no need for environment variables for this.
@@ -285,18 +252,18 @@ const StagingPublicEntryQueueConfig = {
 
 const TestnetEntryQueueConfig = {
   bootstrapValidatorSetSize: 750n,
-  bootstrapFlushSize: 48n, // will effectively be bounded by maxQueueFlushSize
-  normalFlushSizeMin: 1n,
+  bootstrapFlushSize: 32n,
+  normalFlushSizeMin: 32n,
   normalFlushSizeQuotient: 2475n,
-  maxQueueFlushSize: 32n, // Limited to 32 so flush cost are kept below 15M gas.
+  maxQueueFlushSize: 32n,
 };
 
 const StagingIgnitionEntryQueueConfig = {
-  bootstrapValidatorSetSize: 750n,
-  bootstrapFlushSize: 48n, // will effectively be bounded by maxQueueFlushSize
+  bootstrapValidatorSetSize: 1250n,
+  bootstrapFlushSize: 8n,
   normalFlushSizeMin: 1n,
-  normalFlushSizeQuotient: 2475n,
-  maxQueueFlushSize: 32n, // Limited to 32 so flush cost are kept below 15M gas.
+  normalFlushSizeQuotient: 2048n,
+  maxQueueFlushSize: 8n,
 };
 
 export const getEntryQueueConfig = (networkName: NetworkNames) => {

--- a/yarn-project/ethereum/src/config.ts
+++ b/yarn-project/ethereum/src/config.ts
@@ -74,7 +74,6 @@ export const DefaultL1ContractsConfig = {
   aztecProofSubmissionEpochs: 1, // you have a full epoch to submit a proof after the epoch to prove ends
   activationThreshold: 100n * 10n ** 18n,
   ejectionThreshold: 50n * 10n ** 18n,
-  localEjectionThreshold: 98n * 10n ** 18n,
   slashAmountSmall: 10n * 10n ** 18n,
   slashAmountMedium: 20n * 10n ** 18n,
   slashAmountLarge: 50n * 10n ** 18n,

--- a/yarn-project/ethereum/src/contracts/rollup.ts
+++ b/yarn-project/ethereum/src/contracts/rollup.ts
@@ -770,6 +770,10 @@ export class RollupContract {
     return this.rollup.read.getStakingAsset();
   }
 
+  getRewardConfig() {
+    return this.rollup.read.getRewardConfig();
+  }
+
   setupEpoch(l1TxUtils: L1TxUtils) {
     return l1TxUtils.sendAndMonitorTransaction({
       to: this.address,

--- a/yarn-project/ethereum/src/deploy_l1_contracts.ts
+++ b/yarn-project/ethereum/src/deploy_l1_contracts.ts
@@ -543,7 +543,7 @@ export const deployRollup = async (
     provingCostPerMana: args.provingCostPerMana,
     rewardConfig: rewardConfig,
     version: 0,
-    rewardBoostConfig: getRewardBoostConfig(networkName),
+    rewardBoostConfig: getRewardBoostConfig(),
     stakingQueueConfig: getEntryQueueConfig(networkName),
     exitDelaySeconds: BigInt(args.exitDelaySeconds),
     slasherFlavor: slasherFlavorToSolidityEnum(args.slasherFlavor),


### PR DESCRIPTION
This PR backports correct ignition slashing config to `v2`.
