### PR TITLE
DO NOT SUBMIT: halve ultra honk degree

### DIFF
--- a/barretenberg/cpp/src/barretenberg/common/bb_bench.cpp
+++ b/barretenberg/cpp/src/barretenberg/common/bb_bench.cpp
@@ -74,7 +74,12 @@ std::string format_percentage_value(double percentage, const char* color)
 std::string format_percentage(double value, double total, double min_threshold = 0.0)
 {
     double percentage = (total <= 0) ? 0.0 : (value / total) * 100.0;
-    if (total <= 0 || percentage < min_threshold) {
+    // TEMPORARILY DISABLED: Show all percentages no matter how small
+    // if (total <= 0 || percentage < min_threshold) {
+    //     return "       ";
+    // }
+    (void)min_threshold; // Suppress unused parameter warning
+    if (total <= 0) {
         return "       ";
     }
 
@@ -345,7 +350,8 @@ void GlobalBenchStatsContainer::print_aggregate_counts_hierarchical(std::ostream
 
         // Print time if available with aligned section including indent level
         if (entry.time_max > 0) {
-            if (time_ms < 100.0) {
+            // TEMPORARILY DISABLED: Show full format for all times
+            if (false) { // was: time_ms < 100.0
                 // Minimal format for <100ms: only [level] and percentage, no time display
                 std::ostringstream minimal_oss;
                 minimal_oss << Colors::MAGENTA << "[" << indent_level << "] " << Colors::RESET;
@@ -401,7 +407,9 @@ void GlobalBenchStatsContainer::print_aggregate_counts_hierarchical(std::ostream
         if (!printed_in_detail.contains(key)) {
             for (const auto& [child_key, parent_map] : aggregated) {
                 for (const auto& [parent_key, entry] : parent_map) {
-                    if (parent_key == key && entry.time_max >= 500000) { // 0.5ms in nanoseconds
+                    // TEMPORARILY DISABLED: Show all children no matter how small
+                    // if (parent_key == key && entry.time_max >= 500000) { // 0.5ms in nanoseconds
+                    if (parent_key == key && entry.time_max > 0) { // Show everything
                         children.push_back(child_key);
                         break;
                     }
@@ -438,7 +446,9 @@ void GlobalBenchStatsContainer::print_aggregate_counts_hierarchical(std::ostream
         for (const auto& child_key : children) {
             if (auto it = aggregated.find(child_key); it != aggregated.end()) {
                 for (const auto& [parent_key, entry] : it->second) {
-                    if (parent_key == key && entry.time_max >= 500000) { // 0.5ms in nanoseconds
+                    // TEMPORARILY DISABLED: Count all children time
+                    // if (parent_key == key && entry.time_max >= 500000) { // 0.5ms in nanoseconds
+                    if (parent_key == key && entry.time_max > 0) { // Count everything
                         children_total_time += entry.time_max;
                     }
                 }

--- a/barretenberg/cpp/src/barretenberg/common/parallel_for_mutex_pool.cpp
+++ b/barretenberg/cpp/src/barretenberg/common/parallel_for_mutex_pool.cpp
@@ -41,7 +41,7 @@ class ThreadPool {
         do_iterations();
 
         {
-            BB_BENCH_NAME("spinning main thread");
+            // BB_BENCH_NAME("spinning main thread");
             std::unique_lock<std::mutex> lock(tasks_mutex);
             complete_condition_.wait(lock, [this] { return complete_ == num_iterations_; });
         }
@@ -72,7 +72,7 @@ class ThreadPool {
                 }
                 iteration = iteration_++;
             }
-            BB_BENCH_NAME("do_iterations()");
+            // BB_BENCH_NAME("do_iterations()");
             task_(iteration);
             {
                 std::unique_lock<std::mutex> lock(tasks_mutex);

--- a/barretenberg/cpp/src/barretenberg/ecc/curves/bn254/bn254.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/curves/bn254/bn254.hpp
@@ -43,6 +43,7 @@ class BN254 {
         ScalarField(uint256_t("0x204bd3277422fad364751ad938e2b5e6a54cf8c68712848a692c553d0329f5d6"));
     // The length of the polynomials used to mask the Sumcheck Round Univariates. Computed as
     // max(BATCHED_PARTIAL_RELATION_LENGTH) for BN254 Flavors with ZK
-    static constexpr uint32_t LIBRA_UNIVARIATES_LENGTH = 9;
+    // Temporarily reduced from 9 to 5 for performance testing with reduced relation lengths
+    static constexpr uint32_t LIBRA_UNIVARIATES_LENGTH = 5;
 };
 } // namespace bb::curve

--- a/barretenberg/cpp/src/barretenberg/flavor/mega_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/mega_flavor.hpp
@@ -89,7 +89,7 @@ class MegaFlavor {
 
     static constexpr size_t MAX_PARTIAL_RELATION_LENGTH = compute_max_partial_relation_length<Relations>();
     static constexpr size_t MAX_TOTAL_RELATION_LENGTH = compute_max_total_relation_length<Relations>();
-    static_assert(MAX_TOTAL_RELATION_LENGTH == 11);
+    static_assert(MAX_TOTAL_RELATION_LENGTH == 8); // Temporarily adjusted for performance testing (was 11)
     // BATCHED_RELATION_PARTIAL_LENGTH = algebraic degree of sumcheck relation *after* multiplying by the `pow_zeta`
     // random polynomial e.g. For \sum(x) [A(x) * B(x) + C(x)] * PowZeta(X), relation length = 2 and random relation
     // length = 3

--- a/barretenberg/cpp/src/barretenberg/flavor/mega_zk_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/mega_zk_flavor.hpp
@@ -20,8 +20,9 @@ class MegaZKFlavor : public bb::MegaFlavor {
     static constexpr bool HasZK = true;
     // The degree has to be increased because the relation is multiplied by the Row Disabling Polynomial
     static constexpr size_t BATCHED_RELATION_PARTIAL_LENGTH = MegaFlavor::BATCHED_RELATION_PARTIAL_LENGTH + 1;
-    static_assert(BATCHED_RELATION_PARTIAL_LENGTH == Curve::LIBRA_UNIVARIATES_LENGTH,
-                  "LIBRA_UNIVARIATES_LENGTH must be equal to MegaZKFlavor::BATCHED_RELATION_PARTIAL_LENGTH");
+    // Temporarily disabled for performance testing with reduced relation lengths
+    // static_assert(BATCHED_RELATION_PARTIAL_LENGTH == Curve::LIBRA_UNIVARIATES_LENGTH,
+    //               "LIBRA_UNIVARIATES_LENGTH must be equal to MegaZKFlavor::BATCHED_RELATION_PARTIAL_LENGTH");
 
     // Proof length formula
     static constexpr size_t PROOF_LENGTH_WITHOUT_PUB_INPUTS(size_t virtual_log_n = MegaFlavor::VIRTUAL_LOG_N)

--- a/barretenberg/cpp/src/barretenberg/flavor/ultra_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/ultra_flavor.hpp
@@ -92,9 +92,9 @@ class UltraFlavor {
     using Relations = Relations_<FF>;
 
     static constexpr size_t MAX_PARTIAL_RELATION_LENGTH = compute_max_partial_relation_length<Relations>();
-    static_assert(MAX_PARTIAL_RELATION_LENGTH == 7);
+    static_assert(MAX_PARTIAL_RELATION_LENGTH == 3); // Temporarily set to 3 for performance testing
     static constexpr size_t MAX_TOTAL_RELATION_LENGTH = compute_max_total_relation_length<Relations>();
-    static_assert(MAX_TOTAL_RELATION_LENGTH == 11);
+    static_assert(MAX_TOTAL_RELATION_LENGTH == 8); // Temporarily adjusted for performance testing (was 11)
     static constexpr size_t NUM_SUBRELATIONS = compute_number_of_subrelations<Relations>();
     // For instances of this flavour, used in folding, we need a unique sumcheck batching challenge for each
     // subrelation. This is because using powers of alpha would increase the degree of Protogalaxy polynomial $G$ (the

--- a/barretenberg/cpp/src/barretenberg/flavor/ultra_keccak_zk_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/ultra_keccak_zk_flavor.hpp
@@ -18,8 +18,9 @@ class UltraKeccakZKFlavor : public UltraKeccakFlavor {
     // Determine the number of evaluations of Prover and Libra Polynomials that the Prover sends to the Verifier in
     // the rounds of ZK Sumcheck.
     static constexpr size_t BATCHED_RELATION_PARTIAL_LENGTH = UltraKeccakFlavor::BATCHED_RELATION_PARTIAL_LENGTH + 1;
-    static_assert(BATCHED_RELATION_PARTIAL_LENGTH == Curve::LIBRA_UNIVARIATES_LENGTH,
-                  "LIBRA_UNIVARIATES_LENGTH must be equal to UltraKeccakZKFlavor::BATCHED_RELATION_PARTIAL_LENGTH");
+    // Temporarily disabled for performance testing with reduced relation lengths
+    // static_assert(BATCHED_RELATION_PARTIAL_LENGTH == Curve::LIBRA_UNIVARIATES_LENGTH,
+    //               "LIBRA_UNIVARIATES_LENGTH must be equal to UltraKeccakZKFlavor::BATCHED_RELATION_PARTIAL_LENGTH");
 
     // Proof length formula method
     static constexpr size_t PROOF_LENGTH_WITHOUT_PUB_INPUTS(size_t virtual_log_n = VIRTUAL_LOG_N)

--- a/barretenberg/cpp/src/barretenberg/flavor/ultra_zk_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/ultra_zk_flavor.hpp
@@ -27,8 +27,9 @@ class UltraZKFlavor : public UltraFlavor {
     // Determine the number of evaluations of Prover and Libra Polynomials that the Prover sends to the Verifier in
     // the rounds of ZK Sumcheck.
     static constexpr size_t BATCHED_RELATION_PARTIAL_LENGTH = UltraFlavor::BATCHED_RELATION_PARTIAL_LENGTH + 1;
-    static_assert(BATCHED_RELATION_PARTIAL_LENGTH == Curve::LIBRA_UNIVARIATES_LENGTH,
-                  "LIBRA_UNIVARIATES_LENGTH must be equal to UltraZKFlavor::BATCHED_RELATION_PARTIAL_LENGTH");
+    // Temporarily disabled for performance testing with reduced relation lengths
+    // static_assert(BATCHED_RELATION_PARTIAL_LENGTH == Curve::LIBRA_UNIVARIATES_LENGTH,
+    //               "LIBRA_UNIVARIATES_LENGTH must be equal to UltraZKFlavor::BATCHED_RELATION_PARTIAL_LENGTH");
     static constexpr size_t num_frs_comm = bb::field_conversion::calc_num_bn254_frs<Commitment>();
     static constexpr size_t num_frs_fr = bb::field_conversion::calc_num_bn254_frs<FF>();
 

--- a/barretenberg/cpp/src/barretenberg/relations/delta_range_constraint_relation.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/delta_range_constraint_relation.hpp
@@ -14,10 +14,10 @@ template <typename FF_> class DeltaRangeConstraintRelationImpl {
     using FF = FF_;
 
     static constexpr std::array<size_t, 4> SUBRELATION_PARTIAL_LENGTHS{
-        6, // range constrain sub-relation 1
-        6, // range constrain sub-relation 2
-        6, // range constrain sub-relation 3
-        6  // range constrain sub-relation 4
+        3, // range constrain sub-relation 1 (temporarily reduced from 6)
+        3, // range constrain sub-relation 2 (temporarily reduced from 6)
+        3, // range constrain sub-relation 3 (temporarily reduced from 6)
+        3  // range constrain sub-relation 4 (temporarily reduced from 6)
     };
 
     /**

--- a/barretenberg/cpp/src/barretenberg/relations/elliptic_relation.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/elliptic_relation.hpp
@@ -16,8 +16,8 @@ template <typename FF_> class EllipticRelationImpl {
     using FF = FF_;
 
     static constexpr std::array<size_t, 2> SUBRELATION_PARTIAL_LENGTHS{
-        6, // x-coordinate sub-relation
-        6, // y-coordinate sub-relation
+        3, // x-coordinate sub-relation (temporarily reduced from 6)
+        3, // y-coordinate sub-relation (temporarily reduced from 6)
     };
 
     /**

--- a/barretenberg/cpp/src/barretenberg/relations/logderiv_lookup_relation.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/logderiv_lookup_relation.hpp
@@ -21,8 +21,8 @@ template <typename FF_> class LogDerivLookupRelationImpl {
     using FF = FF_;
     static constexpr size_t WRITE_TERMS = 1; // the number of write terms in the lookup relation
     // 1 + polynomial degree of this relation
-    static constexpr size_t INVERSE_SUBRELATION_LENGTH = 5; // both subrelations are degree 4
-    static constexpr size_t LOOKUP_SUBRELATION_LENGTH = 5;  // both subrelations are degree 4
+    static constexpr size_t INVERSE_SUBRELATION_LENGTH = 3; // temporarily reduced from 5
+    static constexpr size_t LOOKUP_SUBRELATION_LENGTH = 3;  // temporarily reduced from 5
     static constexpr size_t BOOLEAN_CHECK_SUBRELATION_LENGTH =
         3; // deg + 1 of the relation checking that read_tag_m is a boolean value
 

--- a/barretenberg/cpp/src/barretenberg/relations/memory_relation.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/memory_relation.hpp
@@ -15,12 +15,12 @@ template <typename FF_> class MemoryRelationImpl {
     using FF = FF_;
 
     static constexpr std::array<size_t, 6> SUBRELATION_PARTIAL_LENGTHS{
-        6, // memory sub-relation;
-        6, // ROM consistency sub-relation 1
-        6, // ROM consistency sub-relation 2
-        6, // RAM consistency sub-relation 1
-        6, // RAM consistency sub-relation 2
-        6  // RAM consistency sub-relation 3
+        3, // memory sub-relation (temporarily reduced from 6)
+        3, // ROM consistency sub-relation 1 (temporarily reduced from 6)
+        3, // ROM consistency sub-relation 2 (temporarily reduced from 6)
+        3, // RAM consistency sub-relation 1 (temporarily reduced from 6)
+        3, // RAM consistency sub-relation 2 (temporarily reduced from 6)
+        3  // RAM consistency sub-relation 3 (temporarily reduced from 6)
     };
 
     static constexpr std::array<size_t, 6> TOTAL_LENGTH_ADJUSTMENTS{

--- a/barretenberg/cpp/src/barretenberg/relations/non_native_field_relation.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/non_native_field_relation.hpp
@@ -15,7 +15,7 @@ template <typename FF_> class NonNativeFieldRelationImpl {
     using FF = FF_;
 
     static constexpr std::array<size_t, 1> SUBRELATION_PARTIAL_LENGTHS{
-        6 // nnf sub-relation;
+        3 // nnf sub-relation (temporarily reduced from 6)
     };
 
     /**

--- a/barretenberg/cpp/src/barretenberg/relations/permutation_relation.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/permutation_relation.hpp
@@ -32,7 +32,7 @@ template <typename FF_> class UltraPermutationRelationImpl {
     using FF = FF_;
 
     static constexpr std::array<size_t, 2> SUBRELATION_PARTIAL_LENGTHS{
-        6, // grand product construction sub-relation
+        3, // grand product construction sub-relation (temporarily reduced from 6)
         3  // left-shiftable polynomial sub-relation
     };
 

--- a/barretenberg/cpp/src/barretenberg/relations/poseidon2_external_relation.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/poseidon2_external_relation.hpp
@@ -13,10 +13,10 @@ template <typename FF_> class Poseidon2ExternalRelationImpl {
     using FF = FF_;
 
     static constexpr std::array<size_t, 4> SUBRELATION_PARTIAL_LENGTHS{
-        7, // external poseidon2 round sub-relation for first value
-        7, // external poseidon2 round sub-relation for second value
-        7, // external poseidon2 round sub-relation for third value
-        7, // external poseidon2 round sub-relation for fourth value
+        3, // external poseidon2 round sub-relation for first value (temporarily reduced from 7)
+        3, // external poseidon2 round sub-relation for second value (temporarily reduced from 7)
+        3, // external poseidon2 round sub-relation for third value (temporarily reduced from 7)
+        3, // external poseidon2 round sub-relation for fourth value (temporarily reduced from 7)
     };
 
     /**

--- a/barretenberg/cpp/src/barretenberg/relations/poseidon2_internal_relation.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/poseidon2_internal_relation.hpp
@@ -15,10 +15,10 @@ template <typename FF_> class Poseidon2InternalRelationImpl {
     using FF = FF_;
 
     static constexpr std::array<size_t, 4> SUBRELATION_PARTIAL_LENGTHS{
-        7, // internal poseidon2 round sub-relation for first value
-        7, // internal poseidon2 round sub-relation for second value
-        7, // internal poseidon2 round sub-relation for third value
-        7, // internal poseidon2 round sub-relation for fourth value
+        3, // internal poseidon2 round sub-relation for first value (temporarily reduced from 7)
+        3, // internal poseidon2 round sub-relation for second value (temporarily reduced from 7)
+        3, // internal poseidon2 round sub-relation for third value (temporarily reduced from 7)
+        3, // internal poseidon2 round sub-relation for fourth value (temporarily reduced from 7)
     };
 
     static constexpr fr D1 = crypto::Poseidon2Bn254ScalarFieldParams::internal_matrix_diagonal[0]; // decremented by 1

--- a/barretenberg/cpp/src/barretenberg/relations/translator_vm/translator_decomposition_relation.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/translator_vm/translator_decomposition_relation.hpp
@@ -18,10 +18,10 @@ template <typename FF_> class TranslatorDecompositionRelationImpl {
     static constexpr size_t RELATION_LENGTH =
         4; // degree(lagrange_even_in_minicircuit_in_minicircuit(a - a_0 - a_1*2¹⁴ ... - a_l⋅2¹⁴ˡ )op) = 3
     static constexpr std::array<size_t, 48> SUBRELATION_PARTIAL_LENGTHS{
-        4, // decomposition of accumulator limb 0 into microlimbs subrelation
-        4, // decomposition of accumulator limb 1 into microlimbs subrelation
-        4, // decomposition of accumulator limb 2 into microlimbs subrelation
-        4, // decomposition of accumulator limb 3 into microlimbs subrelation
+        3, // decomposition of accumulator limb 0 into microlimbs subrelation (temporarily reduced from 4)
+        3, // decomposition of accumulator limb 1 into microlimbs subrelation (temporarily reduced from 4)
+        3, // decomposition of accumulator limb 2 into microlimbs subrelation (temporarily reduced from 4)
+        3, // decomposition of accumulator limb 3 into microlimbs subrelation (temporarily reduced from 4)
         3, // decomposition of P.y limb 0 into microlimbs subrelation
         3, // decomposition of P.y limb 1 into microlimbs subrelation
         3, // decomposition of P.y limb 2 into microlimbs subrelation

--- a/barretenberg/cpp/src/barretenberg/relations/translator_vm/translator_delta_range_constraint_relation.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/translator_vm/translator_delta_range_constraint_relation.hpp
@@ -18,11 +18,11 @@ template <typename FF_> class TranslatorDeltaRangeConstraintRelationImpl {
         7; // degree((lagrange_real_last - 1)(lagrange_masking - 1) * D(D - 1)(D - 2)(D - 3)) = 6
 
     static constexpr std::array<size_t, 10> SUBRELATION_PARTIAL_LENGTHS{
-        7, // ordered_range_constraints_0 step in {0,1,2,3} subrelation
-        7, // ordered_range_constraints_1 step in {0,1,2,3} subrelation
-        7, // ordered_range_constraints_2 step in {0,1,2,3} subrelation
-        7, // ordered_range_constraints_3 step in {0,1,2,3} subrelation
-        7, // ordered_range_constraints_4 step in {0,1,2,3} subrelation
+        3, // ordered_range_constraints_0 step in {0,1,2,3} subrelation (temporarily reduced from 7)
+        3, // ordered_range_constraints_1 step in {0,1,2,3} subrelation (temporarily reduced from 7)
+        3, // ordered_range_constraints_2 step in {0,1,2,3} subrelation (temporarily reduced from 7)
+        3, // ordered_range_constraints_3 step in {0,1,2,3} subrelation (temporarily reduced from 7)
+        3, // ordered_range_constraints_4 step in {0,1,2,3} subrelation (temporarily reduced from 7)
         3, // ordered_range_constraints_0 ends with defined maximum value subrelation
         3, // ordered_range_constraints_1 ends with defined maximum value subrelation
         3, // ordered_range_constraints_2 ends with defined maximum value subrelation

--- a/barretenberg/cpp/src/barretenberg/relations/translator_vm/translator_extra_relations.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/translator_vm/translator_extra_relations.hpp
@@ -16,11 +16,11 @@ template <typename FF_> class TranslatorOpcodeConstraintRelationImpl {
     // 1 + polynomial degree of this relation
     static constexpr size_t RELATION_LENGTH = 6;
     static constexpr std::array<size_t, 5> SUBRELATION_PARTIAL_LENGTHS{
-        6, // opcode constraint relation
-        6, // opcode constraint relation
-        6, // opcode constraint relation
-        6, // opcode constraint relation
-        6  // opcode constraint relation
+        3, // opcode constraint relation (temporarily reduced from 6)
+        3, // opcode constraint relation (temporarily reduced from 6)
+        3, // opcode constraint relation (temporarily reduced from 6)
+        3, // opcode constraint relation (temporarily reduced from 6)
+        3  // opcode constraint relation (temporarily reduced from 6)
     };
 
     /**
@@ -57,18 +57,22 @@ template <typename FF_> class TranslatorAccumulatorTransferRelationImpl {
     // 1 + polynomial degree of this relation
     static constexpr size_t RELATION_LENGTH = 4; // degree((SOME_LAGRANGE)(A-B)) = 2
     static constexpr std::array<size_t, 12> SUBRELATION_PARTIAL_LENGTHS{
-        4, // transfer accumulator limb 0 at odd index subrelation
-        4, // transfer accumulator limb 1 at odd index subrelation
-        4, // transfer accumulator limb 2 at odd index subrelation
-        4, // transfer accumulator limb 3 at odd index subrelation
-        4, // accumulator limb 0 is zero at the start of accumulation subrelation
-        4, // accumulator limb 1 is zero at the start of accumulation subrelation
-        4, // accumulator limb 2 is zero at the start of accumulation subrelation
-        4, // accumulator limb 3 is zero at the start of accumulation subrelation
-        4, // accumulator limb 0 is equal to given result at the end of accumulation subrelation
-        4, // accumulator limb 1 is equal to given result at the end of accumulation subrelation
-        4, // accumulator limb 2 is equal to given result at the end of accumulation subrelation
-        4  // accumulator limb 3 is equal to given result at the end of accumulation subrelation
+        3, // transfer accumulator limb 0 at odd index subrelation (temporarily reduced from 4)
+        3, // transfer accumulator limb 1 at odd index subrelation (temporarily reduced from 4)
+        3, // transfer accumulator limb 2 at odd index subrelation (temporarily reduced from 4)
+        3, // transfer accumulator limb 3 at odd index subrelation (temporarily reduced from 4)
+        3, // accumulator limb 0 is zero at the start of accumulation subrelation (temporarily reduced from 4)
+        3, // accumulator limb 1 is zero at the start of accumulation subrelation (temporarily reduced from 4)
+        3, // accumulator limb 2 is zero at the start of accumulation subrelation (temporarily reduced from 4)
+        3, // accumulator limb 3 is zero at the start of accumulation subrelation (temporarily reduced from 4)
+        3, // accumulator limb 0 is equal to given result at the end of accumulation subrelation (temporarily reduced
+           // from 4)
+        3, // accumulator limb 1 is equal to given result at the end of accumulation subrelation (temporarily reduced
+           // from 4)
+        3, // accumulator limb 2 is equal to given result at the end of accumulation subrelation (temporarily reduced
+           // from 4)
+        3  // accumulator limb 3 is equal to given result at the end of accumulation subrelation (temporarily reduced
+           // from 4)
 
     };
 
@@ -116,74 +120,74 @@ template <typename FF_> class TranslatorZeroConstraintsRelationImpl {
     static constexpr size_t RELATION_LENGTH = 4; // degree((some lagrange)(A)) = 2
 
     static constexpr std::array<size_t, 68> SUBRELATION_PARTIAL_LENGTHS{
-        4, // p_x_low_limbs_range_constraint_0 is zero outside of the minicircuit
-        4, // p_x_low_limbs_range_constraint_1 is zero outside of the minicircuit
-        4, // p_x_low_limbs_range_constraint_2 is zero outside of the minicircuit
-        4, // p_x_low_limbs_range_constraint_3 is zero outside of the minicircuit
-        4, // p_x_low_limbs_range_constraint_4 is zero outside of the minicircuit
-        4, // p_x_high_limbs_range_constraint_0 is zero outside of the minicircuit
-        4, // p_x_high_limbs_range_constraint_1 is zero outside of the minicircuit
-        4, // p_x_high_limbs_range_constraint_2 is zero outside of the minicircuit
-        4, // p_x_high_limbs_range_constraint_3 is zero outside of the minicircuit
-        4, // p_x_high_limbs_range_constraint_4 is zero outside of the minicircuit
-        4, // p_y_low_limbs_range_constraint_0 is zero outside of the minicircuit
-        4, // p_y_low_limbs_range_constraint_1 is zero outside of the minicircuit
-        4, // p_y_low_limbs_range_constraint_2 is zero outside of the minicircuit
-        4, // p_y_low_limbs_range_constraint_3 is zero outside of the minicircuit
-        4, // p_y_low_limbs_range_constraint_4 is zero outside of the minicircuit
-        4, // p_y_high_limbs_range_constraint_0 is zero outside of the minicircuit
-        4, // p_y_high_limbs_range_constraint_1 is zero outside of the minicircuit
-        4, // p_y_high_limbs_range_constraint_2 is zero outside of the minicircuit
-        4, // p_y_high_limbs_range_constraint_3 is zero outside of the minicircuit
-        4, // p_y_high_limbs_range_constraint_4 is zero outside of the minicircuit
-        4, // z_low_limbs_range_constraint_0 is zero outside of the minicircuit
-        4, // z_low_limbs_range_constraint_1 is zero outside of the minicircuit
-        4, // z_low_limbs_range_constraint_2 is zero outside of the minicircuit
-        4, // z_low_limbs_range_constraint_3 is zero outside of the minicircuit
-        4, // z_low_limbs_range_constraint_4 is zero outside of the minicircuit
-        4, // z_high_limbs_range_constraint_0 is zero outside of the minicircuit
-        4, // z_high_limbs_range_constraint_1 is zero outside of the minicircuit
-        4, // z_high_limbs_range_constraint_2 is zero outside of the minicircuit
-        4, // z_high_limbs_range_constraint_3 is zero outside of the minicircuit
-        4, // z_high_limbs_range_constraint_4 is zero outside of the minicircuit
-        4, // accumulator_low_limbs_range_constraint_0 is zero outside of the minicircuit
-        4, // accumulator_low_limbs_range_constraint_1 is zero outside of the minicircuit
-        4, // accumulator_low_limbs_range_constraint_2 is zero outside of the minicircuit
-        4, // accumulator_low_limbs_range_constraint_3 is zero outside of the minicircuit
-        4, // accumulator_low_limbs_range_constraint_4 is zero outside of the minicircuit
-        4, // accumulator_high_limbs_range_constraint_0 is zero outside of the minicircuit
-        4, // accumulator_high_limbs_range_constraint_1 is zero outside of the minicircuit
-        4, // accumulator_high_limbs_range_constraint_2 is zero outside of the minicircuit
-        4, // accumulator_high_limbs_range_constraint_3 is zero outside of the minicircuit
-        4, // accumulator_high_limbs_range_constraint_4 is zero outside of the minicircuit
-        4, // quotient_low_limbs_range_constraint_0 is zero outside of the minicircuit
-        4, // quotient_low_limbs_range_constraint_1 is zero outside of the minicircuit
-        4, // quotient_low_limbs_range_constraint_2 is zero outside of the minicircuit
-        4, // quotient_low_limbs_range_constraint_3 is zero outside of the minicircuit
-        4, // quotient_low_limbs_range_constraint_4 is zero outside of the minicircuit
-        4, // quotient_high_limbs_range_constraint_0 is zero outside of the minicircuit
-        4, // quotient_high_limbs_range_constraint_1 is zero outside of the minicircuit
-        4, // quotient_high_limbs_range_constraint_2 is zero outside of the minicircuit
-        4, // quotient_high_limbs_range_constraint_3 is zero outside of the minicircuit
-        4, // quotient_high_limbs_range_constraint_4 is zero outside of the minicircuit
-        4, // relation_wide_limbs_range_constraint_0 is zero outside of the minicircuit
-        4, // relation_wide_limbs_range_constraint_1 is zero outside of the minicircuit
-        4, // relation_wide_limbs_range_constraint_2 is zero outside of the minicircuit
-        4, // relation_wide_limbs_range_constraint_3 is zero outside of the minicircuit
-        4, // p_x_low_limbs_range_constraint_tail is zero outside of the minicircuit
-        4, // p_x_high_limbs_range_constraint_tail is zero outside of the minicircuit
-        4, // p_y_low_limbs_range_constraint_tail is zero outside of the minicircuit
-        4, // p_y_high_limbs_range_constraint_tail is zero outside of the minicircuit
-        4, // z_low_limbs_range_constraint_tail is zero outside of the minicircuit
-        4, // z_high_limbs_range_constraint_tail is zero outside of the minicircuit
-        4, // accumulator_low_limbs_range_constraint_tail is zero outside of the minicircuit
-        4, // accumulator_high_limbs_range_constraint_tail is zero outside of the minicircuit
-        4, // quotient_low_limbs_range_constraint_tail is zero outside of the minicircuit
-        4, // quotient_high_limbs_range_constraint_tail is zero outside of the minicircuit
-        4, // op is zero outside of the minicircuit
-        4, // x_lo_y_hi is zero outside of the minicircuit
-        4, // x_hi_z_1 is zero outside of the minicircuit
-        4, // y_lo_z_2 is zero outside of the minicircuit
+        3, // p_x_low_limbs_range_constraint_0 is zero outside of the minicircuit
+        3, // p_x_low_limbs_range_constraint_1 is zero outside of the minicircuit
+        3, // p_x_low_limbs_range_constraint_2 is zero outside of the minicircuit
+        3, // p_x_low_limbs_range_constraint_3 is zero outside of the minicircuit
+        3, // p_x_low_limbs_range_constraint_4 is zero outside of the minicircuit
+        3, // p_x_high_limbs_range_constraint_0 is zero outside of the minicircuit
+        3, // p_x_high_limbs_range_constraint_1 is zero outside of the minicircuit
+        3, // p_x_high_limbs_range_constraint_2 is zero outside of the minicircuit
+        3, // p_x_high_limbs_range_constraint_3 is zero outside of the minicircuit
+        3, // p_x_high_limbs_range_constraint_4 is zero outside of the minicircuit
+        3, // p_y_low_limbs_range_constraint_0 is zero outside of the minicircuit
+        3, // p_y_low_limbs_range_constraint_1 is zero outside of the minicircuit
+        3, // p_y_low_limbs_range_constraint_2 is zero outside of the minicircuit
+        3, // p_y_low_limbs_range_constraint_3 is zero outside of the minicircuit
+        3, // p_y_low_limbs_range_constraint_4 is zero outside of the minicircuit
+        3, // p_y_high_limbs_range_constraint_0 is zero outside of the minicircuit
+        3, // p_y_high_limbs_range_constraint_1 is zero outside of the minicircuit
+        3, // p_y_high_limbs_range_constraint_2 is zero outside of the minicircuit
+        3, // p_y_high_limbs_range_constraint_3 is zero outside of the minicircuit
+        3, // p_y_high_limbs_range_constraint_4 is zero outside of the minicircuit
+        3, // z_low_limbs_range_constraint_0 is zero outside of the minicircuit
+        3, // z_low_limbs_range_constraint_1 is zero outside of the minicircuit
+        3, // z_low_limbs_range_constraint_2 is zero outside of the minicircuit
+        3, // z_low_limbs_range_constraint_3 is zero outside of the minicircuit
+        3, // z_low_limbs_range_constraint_4 is zero outside of the minicircuit
+        3, // z_high_limbs_range_constraint_0 is zero outside of the minicircuit
+        3, // z_high_limbs_range_constraint_1 is zero outside of the minicircuit
+        3, // z_high_limbs_range_constraint_2 is zero outside of the minicircuit
+        3, // z_high_limbs_range_constraint_3 is zero outside of the minicircuit
+        3, // z_high_limbs_range_constraint_4 is zero outside of the minicircuit
+        3, // accumulator_low_limbs_range_constraint_0 is zero outside of the minicircuit
+        3, // accumulator_low_limbs_range_constraint_1 is zero outside of the minicircuit
+        3, // accumulator_low_limbs_range_constraint_2 is zero outside of the minicircuit
+        3, // accumulator_low_limbs_range_constraint_3 is zero outside of the minicircuit
+        3, // accumulator_low_limbs_range_constraint_4 is zero outside of the minicircuit
+        3, // accumulator_high_limbs_range_constraint_0 is zero outside of the minicircuit
+        3, // accumulator_high_limbs_range_constraint_1 is zero outside of the minicircuit
+        3, // accumulator_high_limbs_range_constraint_2 is zero outside of the minicircuit
+        3, // accumulator_high_limbs_range_constraint_3 is zero outside of the minicircuit
+        3, // accumulator_high_limbs_range_constraint_4 is zero outside of the minicircuit
+        3, // quotient_low_limbs_range_constraint_0 is zero outside of the minicircuit
+        3, // quotient_low_limbs_range_constraint_1 is zero outside of the minicircuit
+        3, // quotient_low_limbs_range_constraint_2 is zero outside of the minicircuit
+        3, // quotient_low_limbs_range_constraint_3 is zero outside of the minicircuit
+        3, // quotient_low_limbs_range_constraint_4 is zero outside of the minicircuit
+        3, // quotient_high_limbs_range_constraint_0 is zero outside of the minicircuit
+        3, // quotient_high_limbs_range_constraint_1 is zero outside of the minicircuit
+        3, // quotient_high_limbs_range_constraint_2 is zero outside of the minicircuit
+        3, // quotient_high_limbs_range_constraint_3 is zero outside of the minicircuit
+        3, // quotient_high_limbs_range_constraint_4 is zero outside of the minicircuit
+        3, // relation_wide_limbs_range_constraint_0 is zero outside of the minicircuit
+        3, // relation_wide_limbs_range_constraint_1 is zero outside of the minicircuit
+        3, // relation_wide_limbs_range_constraint_2 is zero outside of the minicircuit
+        3, // relation_wide_limbs_range_constraint_3 is zero outside of the minicircuit
+        3, // p_x_low_limbs_range_constraint_tail is zero outside of the minicircuit
+        3, // p_x_high_limbs_range_constraint_tail is zero outside of the minicircuit
+        3, // p_y_low_limbs_range_constraint_tail is zero outside of the minicircuit
+        3, // p_y_high_limbs_range_constraint_tail is zero outside of the minicircuit
+        3, // z_low_limbs_range_constraint_tail is zero outside of the minicircuit
+        3, // z_high_limbs_range_constraint_tail is zero outside of the minicircuit
+        3, // accumulator_low_limbs_range_constraint_tail is zero outside of the minicircuit
+        3, // accumulator_high_limbs_range_constraint_tail is zero outside of the minicircuit
+        3, // quotient_low_limbs_range_constraint_tail is zero outside of the minicircuit
+        3, // quotient_high_limbs_range_constraint_tail is zero outside of the minicircuit
+        3, // op is zero outside of the minicircuit
+        3, // x_lo_y_hi is zero outside of the minicircuit
+        3, // x_hi_z_1 is zero outside of the minicircuit
+        3, // y_lo_z_2 is zero outside of the minicircuit (temporarily reduced from 4)
 
     };
 

--- a/barretenberg/cpp/src/barretenberg/relations/translator_vm/translator_non_native_field_relation.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/translator_vm/translator_non_native_field_relation.hpp
@@ -16,9 +16,9 @@ template <typename FF_> class TranslatorNonNativeFieldRelationImpl {
 
     // 1 + polynomial degree of this relation
     static constexpr std::array<size_t, 3> SUBRELATION_PARTIAL_LENGTHS{
-        4, // Lower wide limb subrelation (checks result is 0 mod 2¹³⁶)
-        4, // Higher wide limb subrelation (checks result is 0 in higher mod 2¹³⁶),
-        4  // Prime subrelation (checks result in native field)
+        3, // Lower wide limb subrelation (checks result is 0 mod 2¹³⁶) (temporarily reduced from 4)
+        3, // Higher wide limb subrelation (checks result is 0 in higher mod 2¹³⁶) (temporarily reduced from 4)
+        3  // Prime subrelation (checks result in native field) (temporarily reduced from 4)
     };
 
     /**

--- a/barretenberg/cpp/src/barretenberg/relations/translator_vm/translator_permutation_relation.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/translator_vm/translator_permutation_relation.hpp
@@ -16,7 +16,7 @@ template <typename FF_> class TranslatorPermutationRelationImpl {
     static constexpr size_t RELATION_LENGTH = 7;
 
     static constexpr std::array<size_t, 2> SUBRELATION_PARTIAL_LENGTHS{
-        7, // grand product construction sub-relation
+        3, // grand product construction sub-relation (temporarily reduced from 7)
         3  // left-shiftable polynomial sub-relation
     };
 

--- a/barretenberg/cpp/src/barretenberg/relations/ultra_arithmetic_relation.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/ultra_arithmetic_relation.hpp
@@ -14,8 +14,8 @@ template <typename FF_> class UltraArithmeticRelationImpl {
     using FF = FF_;
 
     static constexpr std::array<size_t, 2> SUBRELATION_PARTIAL_LENGTHS{
-        6, // primary arithmetic sub-relation
-        5  // secondary arithmetic sub-relation
+        3, // primary arithmetic sub-relation (temporarily reduced from 6)
+        3  // secondary arithmetic sub-relation (temporarily reduced from 5)
     };
 
     /**

--- a/barretenberg/cpp/src/barretenberg/sumcheck/sumcheck.hpp
+++ b/barretenberg/cpp/src/barretenberg/sumcheck/sumcheck.hpp
@@ -5,6 +5,7 @@
 // =====================
 
 #pragma once
+#include "barretenberg/common/bb_bench.hpp"
 #include "barretenberg/honk/library/grand_product_delta.hpp"
 #include "barretenberg/polynomials/polynomial_arithmetic.hpp"
 #include "barretenberg/sumcheck/sumcheck_output.hpp"
@@ -238,10 +239,13 @@ template <typename Flavor> class SumcheckProver {
         GateSeparatorPolynomial<FF> gate_separators(gate_challenges, multivariate_d);
 
         multivariate_challenge.reserve(virtual_log_n);
-        // In the first round, we compute the first univariate polynomial and populate the book-keeping table of
-        // #partially_evaluated_polynomials, which has \f$ n/2 \f$ rows and \f$ N \f$ columns.
-        auto round_univariate =
-            round.compute_univariate(full_polynomials, relation_parameters, gate_separators, alphas);
+        SumcheckRoundUnivariate round_univariate;
+        {
+            BB_BENCH_NAME("compute first univariate");
+            // In the first round, we compute the first univariate polynomial and populate the book-keeping table of
+            // #partially_evaluated_polynomials, which has \f$ n/2 \f$ rows and \f$ N \f$ columns.
+            round_univariate = round.compute_univariate(full_polynomials, relation_parameters, gate_separators, alphas);
+        }
         // Initialize the partially evaluated polynomials which will be used in the following rounds.
         // This will use the information in the structured full polynomials to save memory if possible.
         partially_evaluated_polynomials = PartiallyEvaluatedMultivariates(full_polynomials, multivariate_n);
@@ -253,9 +257,12 @@ template <typename Flavor> class SumcheckProver {
             transcript->send_to_verifier("Sumcheck:univariate_0", round_univariate);
             FF round_challenge = transcript->template get_challenge<FF>("Sumcheck:u_0");
             multivariate_challenge.emplace_back(round_challenge);
-            // Prepare sumcheck book-keeping table for the next round
-            partially_evaluate(full_polynomials, round_challenge);
-            gate_separators.partially_evaluate(round_challenge);
+            {
+                BB_BENCH_NAME("first partially_evaluate");
+                // Prepare sumcheck book-keeping table for the next round
+                partially_evaluate(full_polynomials, round_challenge);
+                gate_separators.partially_evaluate(round_challenge);
+            }
             round.round_size = round.round_size >> 1; // TODO(#224)(Cody): Maybe partially_evaluate should do this and
             // release memory?        // All but final round
             // We operate on partially_evaluated_polynomials in place.
@@ -263,16 +270,22 @@ template <typename Flavor> class SumcheckProver {
         for (size_t round_idx = 1; round_idx < multivariate_d; round_idx++) {
             BB_BENCH_NAME("sumcheck loop");
 
-            // Write the round univariate to the transcript
-            round_univariate =
-                round.compute_univariate(partially_evaluated_polynomials, relation_parameters, gate_separators, alphas);
+            {
+                BB_BENCH_NAME("compute_univariate in loop");
+                // Write the round univariate to the transcript
+                round_univariate = round.compute_univariate(
+                    partially_evaluated_polynomials, relation_parameters, gate_separators, alphas);
+            }
             // Place evaluations of Sumcheck Round Univariate in the transcript
             transcript->send_to_verifier("Sumcheck:univariate_" + std::to_string(round_idx), round_univariate);
             FF round_challenge = transcript->template get_challenge<FF>("Sumcheck:u_" + std::to_string(round_idx));
             multivariate_challenge.emplace_back(round_challenge);
-            // Prepare sumcheck book-keeping table for the next round.
-            partially_evaluate(partially_evaluated_polynomials, round_challenge);
-            gate_separators.partially_evaluate(round_challenge);
+            {
+                BB_BENCH_NAME("partially_evaluate in loop");
+                // Prepare sumcheck book-keeping table for the next round.
+                partially_evaluate(partially_evaluated_polynomials, round_challenge);
+                gate_separators.partially_evaluate(round_challenge);
+            }
             round.round_size = round.round_size >> 1;
         }
         vinfo("completed ", multivariate_d, " rounds of sumcheck");

--- a/barretenberg/cpp/src/barretenberg/sumcheck/sumcheck_round.hpp
+++ b/barretenberg/cpp/src/barretenberg/sumcheck/sumcheck_round.hpp
@@ -5,6 +5,7 @@
 // =====================
 
 #pragma once
+#include "barretenberg/common/bb_bench.hpp"
 #include "barretenberg/common/thread.hpp"
 #include "barretenberg/flavor/flavor.hpp"
 #include "barretenberg/polynomials/gate_separator.hpp"
@@ -412,7 +413,7 @@ template <typename Flavor> class SumcheckProverRound {
         const bb::GateSeparatorPolynomial<FF>& gate_separators,
         const SubrelationSeparators alphas)
     {
-        BB_BENCH_NAME("compute_univariate_with_row_skipping");
+        // BB_BENCH_NAME("compute_univariate_with_row_skipping");
 
         std::vector<BlockOfContiguousRows> round_manifest = compute_contiguous_round_size(polynomials);
         // Compute how many nonzero rows we have
@@ -448,15 +449,20 @@ template <typename Flavor> class SumcheckProverRound {
                     BB_BENCH_NAME("extend_edges in compute_univariate_with_row_skipping");
                     extend_edges(extended_edges, polynomials, edge_idx);
                 }
-                // Compute the \f$ \ell \f$-th edge's univariate contribution,
-                // scale it by the corresponding \f$ pow_{\beta} \f$ contribution and add it to the accumulators for \f$
-                // \tilde{S}^i(X_i) \f$. If \f$ \ell \f$'s binary representation is given by \f$ (\ell_{i+1},\ldots,
-                // \ell_{d-1})\f$, the \f$ pow_{\beta}\f$-contribution is \f$\beta_{i+1}^{\ell_{i+1}} \cdot \ldots \cdot
-                // \beta_{d-1}^{\ell_{d-1}}\f$.
-                accumulate_relation_univariates(thread_univariate_accumulators[thread_idx],
-                                                extended_edges,
-                                                relation_parameters,
-                                                gate_separators[(edge_idx >> 1) * gate_separators.periodicity]);
+                {
+                    BB_BENCH_NAME("accumulate_relation_univariates in compute_univariate_with_row_skipping");
+                    // Compute the \f$ \ell \f$-th edge's univariate contribution,
+                    // scale it by the corresponding \f$ pow_{\beta} \f$ contribution and add it to the accumulators for
+                    // \f$
+                    // \tilde{S}^i(X_i) \f$. If \f$ \ell \f$'s binary representation is given by \f$ (\ell_{i+1},\ldots,
+                    // \ell_{d-1})\f$, the \f$ pow_{\beta}\f$-contribution is \f$\beta_{i+1}^{\ell_{i+1}} \cdot \ldots
+                    // \cdot
+                    // \beta_{d-1}^{\ell_{d-1}}\f$.
+                    accumulate_relation_univariates(thread_univariate_accumulators[thread_idx],
+                                                    extended_edges,
+                                                    relation_parameters,
+                                                    gate_separators[(edge_idx >> 1) * gate_separators.periodicity]);
+                }
             }
         });
 
@@ -464,13 +470,16 @@ template <typename Flavor> class SumcheckProverRound {
         for (auto& accumulators : thread_univariate_accumulators) {
             Utils::add_nested_tuples(univariate_accumulators, accumulators);
         }
-        // Batch the univariate contributions from each sub-relation to obtain the round univariate
-        // these are unmasked; we will mask in sumcheck.
-        const auto round_univariate =
-            batch_over_relations<SumcheckRoundUnivariate>(univariate_accumulators, alphas, gate_separators);
-        // define eval at 0 from target sum/or previous round univariate
+        {
+            BB_BENCH_NAME("batch_over_relations in compute_univariate_with_row_skipping");
+            // Batch the univariate contributions from each sub-relation to obtain the round univariate
+            // these are unmasked; we will mask in sumcheck.
+            const auto round_univariate =
+                batch_over_relations<SumcheckRoundUnivariate>(univariate_accumulators, alphas, gate_separators);
+            // define eval at 0 from target sum/or previous round univariate
 
-        return round_univariate;
+            return round_univariate;
+        }
     };
     template <typename ProverPolynomialsOrPartiallyEvaluatedMultivariates>
     SumcheckRoundUnivariate compute_hiding_univariate(

--- a/barretenberg/cpp/src/barretenberg/sumcheck/sumcheck_round.hpp
+++ b/barretenberg/cpp/src/barretenberg/sumcheck/sumcheck_round.hpp
@@ -270,7 +270,10 @@ template <typename Flavor> class SumcheckProverRound {
                 size_t start = (chunk_idx * chunk_size) + (thread_idx * chunk_thread_portion_size);
                 size_t end = (chunk_idx * chunk_size) + ((thread_idx + 1) * chunk_thread_portion_size);
                 for (size_t edge_idx = start; edge_idx < end; edge_idx += 2) {
-                    extend_edges(extended_edges, polynomials, edge_idx);
+                    {
+                        BB_BENCH_NAME("extend_edges in compute_univariate_with_chunking");
+                        extend_edges(extended_edges, polynomials, edge_idx);
+                    }
                     // Compute the \f$ \ell \f$-th edge's univariate contribution,
                     // scale it by the corresponding \f$ pow_{\beta} \f$ contribution and add it to the accumulators for
                     // \f$ \tilde{S}^i(X_i) \f$. If \f$ \ell \f$'s binary representation is given by \f$
@@ -441,7 +444,10 @@ template <typename Flavor> class SumcheckProverRound {
             ExtendedEdges extended_edges;
             for (size_t i = start; i < end; ++i) {
                 size_t edge_idx = edge_iterator.get_next_edge();
-                extend_edges(extended_edges, polynomials, edge_idx);
+                {
+                    BB_BENCH_NAME("extend_edges in compute_univariate_with_row_skipping");
+                    extend_edges(extended_edges, polynomials, edge_idx);
+                }
                 // Compute the \f$ \ell \f$-th edge's univariate contribution,
                 // scale it by the corresponding \f$ pow_{\beta} \f$ contribution and add it to the accumulators for \f$
                 // \tilde{S}^i(X_i) \f$. If \f$ \ell \f$'s binary representation is given by \f$ (\ell_{i+1},\ldots,
@@ -511,7 +517,10 @@ template <typename Flavor> class SumcheckProverRound {
         size_t start_edge_idx = (round_idx == 0) ? round_size - 4 : round_size - 2;
 
         for (size_t edge_idx = start_edge_idx; edge_idx < round_size; edge_idx += 2) {
-            extend_edges(extended_edges, polynomials, edge_idx);
+            {
+                BB_BENCH_NAME("extend_edges in compute_disabled_contribution");
+                extend_edges(extended_edges, polynomials, edge_idx);
+            }
             accumulate_relation_univariates(univariate_accumulator,
                                             extended_edges,
                                             relation_parameters,
@@ -545,7 +554,10 @@ template <typename Flavor> class SumcheckProverRound {
         const size_t virtual_contribution_edge_idx = 0;
 
         // Perform the usual sumcheck accumulation, but for a single edge.
-        extend_edges(extended_edges, polynomials, virtual_contribution_edge_idx);
+        {
+            BB_BENCH_NAME("extend_edges in compute_virtual_contribution");
+            extend_edges(extended_edges, polynomials, virtual_contribution_edge_idx);
+        }
         // The tail of G(X) = \prod_{k} (1 + X_k(\beta_k - 1) ) evaluated at the edge (0, ..., 0).
         const FF gate_separator_tail{ 1 };
         accumulate_relation_univariates(


### PR DESCRIPTION
This PR is not intended to be merged, but only serve as testing the performance when the degree is reduced.

Before halving the degree:

```
----------------------------------------------------------------------------------
Benchmark                                        Time             CPU   Iterations
----------------------------------------------------------------------------------
construct_proof_ultrahonk_power_of_2/15        386 ms          301 ms            2

════════════════════════════════════════════════════════════════════════════════════════════════════════════
  Benchmark Results
════════════════════════════════════════════════════════════════════════════════════════════════════════════
  ├─ sumcheck.prove                                                                    [1]  17.9 %   169.2ms    (56.40 ms x 3)
    ├─ PartiallyEvaluatedMultivariates constructor                                       [2]  56.0 %             
      ├─ spinning main thread                                                              [3]  19.3 %             
      ├─ do_iterations()                                                                   [3]  14.3 %             
      └─ (other)                                                                           [3]  66.4 %             
    ├─ sumcheck loop                                                                     [2]  33.0 %             
      ├─ compute_univariate_with_row_skipping                                              [3]  51.5 %             
        ├─ NOTE: Shared children. Can add up to > 100%.
        ├─ spinning main thread                                                              [4]  26.8 %             
        ├─ do_iterations()                                                                   [4]  24.4 %             
      ├─ spinning main thread                                                              [3]  13.7 %             
      ├─ do_iterations()                                                                   [3]  7.2  %             
      └─ (other)                                                                           [3]  27.5 %             
    ├─ rest of sumcheck round 1                                                          [2]  3.8  %             
      ├─ spinning main thread                                                              [3]  74.9 %             
      └─ do_iterations()                                                                   [3]  61.0 %             
    ├─ compute_univariate_with_row_skipping                                              [2]  3.7  %             
    └─ GateSeparatorPolynomial::compute_beta_products                                    [2]  1.4  %             
      ├─ do_iterations()                                                                   [3]  41.8 %             
      └─ (other)                                                                           [3]  58.2 %      
```
```
----------------------------------------------------------------------------------
Benchmark                                        Time             CPU   Iterations
----------------------------------------------------------------------------------
construct_proof_ultrahonk_power_of_2/20       2012 ms         1453 ms            1

════════════════════════════════════════════════════════════════════════════════════════════════════════════
  Benchmark Results
════════════════════════════════════════════════════════════════════════════════════════════════════════════
├─ sumcheck.prove                                                                    [1]  19.6 %   289.1ms   
    ├─ sumcheck loop                                                                     [2]  56.1 %   162.2ms    (8.54 ms x 19)
      ├─ spinning main thread                                                              [3]  47.1 %             
      ├─ compute_univariate_with_row_skipping                                              [3]  47.0 %             
        ├─ NOTE: Shared children. Can add up to > 100%.
        ├─ do_iterations()                                                                   [4]  108.8%             
        └─ spinning main thread                                                              [4]  30.2 %             
      └─ do_iterations()                                                                   [3]  30.7 %             
    ├─ compute_univariate_with_row_skipping                                              [2]  15.3 %             
    ├─ PartiallyEvaluatedMultivariates constructor                                       [2]  14.4 %             
      ├─ spinning main thread                                                              [3]  40.3 %             
      ├─ do_iterations()                                                                   [3]  38.0 %             
      └─ (other)                                                                           [3]  21.7 %             
    ├─ rest of sumcheck round 1                                                          [2]  11.6 %             
      ├─ do_iterations()                                                                   [3]  99.5 %             
      └─ spinning main thread                                                              [3]  97.3 %             
    └─ GateSeparatorPolynomial::compute_beta_products                                    [2]  2.3  %             
      ├─ do_iterations()                                                                   [3]  24.5 %             
      └─ (other)                                                                           [3]  75.5 %         
```

After halving the degree:

```
----------------------------------------------------------------------------------
Benchmark                                        Time             CPU   Iterations
----------------------------------------------------------------------------------
construct_proof_ultrahonk_power_of_2/15        386 ms          302 ms            2

════════════════════════════════════════════════════════════════════════════════════════════════════════════
  Benchmark Results
════════════════════════════════════════════════════════════════════════════════════════════════════════════
  ├─ sumcheck.prove                                                                    [1]  16.1 %   156.7ms    (52.24 ms x 3)
    ├─ PartiallyEvaluatedMultivariates constructor                                       [2]  54.0 %             
      ├─ spinning main thread                                                              [3]  14.2 %             
      ├─ do_iterations()                                                                   [3]  12.5 %             
      └─ (other)                                                                           [3]  73.4 %             
    ├─ sumcheck loop                                                                     [2]  35.0 %             
      ├─ compute_univariate_with_row_skipping                                              [3]  49.2 %             
        ├─ NOTE: Shared children. Can add up to > 100%.
        ├─ do_iterations()                                                                   [4]  22.9 %             
        ├─ spinning main thread                                                              [4]  22.3 %             
      ├─ spinning main thread                                                              [3]  10.5 %             
      ├─ do_iterations()                                                                   [3]  7.7  %             
      └─ (other)                                                                           [3]  32.7 %             
    ├─ rest of sumcheck round 1                                                          [2]  4.1  %             
      ├─ spinning main thread                                                              [3]  73.6 %             
      └─ do_iterations()                                                                   [3]  52.4 %             
    ├─ compute_univariate_with_row_skipping                                              [2]  3.9  %             
    └─ GateSeparatorPolynomial::compute_beta_products                                    [2]  1.6  %             
      ├─ do_iterations()                                                                   [3]  23.5 %             
      └─ (other)                                                                           [3]  76.5 %             
```
```
----------------------------------------------------------------------------------
Benchmark                                        Time             CPU   Iterations
----------------------------------------------------------------------------------
construct_proof_ultrahonk_power_of_2/20       1851 ms         1413 ms            1

════════════════════════════════════════════════════════════════════════════════════════════════════════════
  Benchmark Results
════════════════════════════════════════════════════════════════════════════════════════════════════════════
  ├─ sumcheck.prove                                                                    [1]  19.0 %   245.4ms   
    ├─ sumcheck loop                                                                     [2]  48.4 %   118.7ms    (6.25 ms x 19)
      ├─ compute_univariate_with_row_skipping                                              [3]  48.7 %             
        ├─ NOTE: Shared children. Can add up to > 100%.
        ├─ do_iterations()                                                                   [4]  112.5%             
        └─ spinning main thread                                                              [4]  27.1 %             
      ├─ spinning main thread                                                              [3]  40.8 %             
      └─ do_iterations()                                                                   [3]  32.3 %             
    ├─ PartiallyEvaluatedMultivariates constructor                                       [2]  19.2 %             
      ├─ do_iterations()                                                                   [3]  33.3 %             
      ├─ spinning main thread                                                              [3]  32.1 %             
      └─ (other)                                                                           [3]  34.6 %             
    ├─ rest of sumcheck round 1                                                          [2]  15.2 %             
      ├─ do_iterations()                                                                   [3]  99.6 %             
      └─ spinning main thread                                                              [3]  98.3 %             
    ├─ compute_univariate_with_row_skipping                                              [2]  14.4 %             
    └─ GateSeparatorPolynomial::compute_beta_products                                    [2]  2.6  %             
      └─ do_iterations()                                                                   [3]  341.8%             
```