### PR TITLE
fix: Do not assemble a block larger than blobs allowance

### DIFF
--- a/yarn-project/sequencer-client/src/sequencer/sequencer.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.ts
@@ -1,5 +1,5 @@
 import type { L2Block } from '@aztec/aztec.js';
-import { INITIAL_L2_BLOCK_NUM } from '@aztec/constants';
+import { BLOBS_PER_BLOCK, FIELDS_PER_BLOB, INITIAL_L2_BLOCK_NUM } from '@aztec/constants';
 import type { EpochCache } from '@aztec/epoch-cache';
 import { FormattedViemError, NoCommitteeError, type RollupContract } from '@aztec/ethereum';
 import { omit, pick } from '@aztec/foundation/collection';
@@ -581,6 +581,7 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
       maxTransactions: this.maxTxsPerBlock,
       maxBlockSize: this.maxBlockSizeInBytes,
       maxBlockGas: this.maxBlockGas,
+      maxBlobFields: BLOBS_PER_BLOCK * FIELDS_PER_BLOB,
       deadline,
     };
   }

--- a/yarn-project/stdlib/src/interfaces/block-builder.ts
+++ b/yarn-project/stdlib/src/interfaces/block-builder.ts
@@ -43,6 +43,7 @@ export interface PublicProcessorLimits {
   maxTransactions?: number;
   maxBlockSize?: number;
   maxBlockGas?: Gas;
+  maxBlobFields?: number;
   deadline?: Date;
 }
 


### PR DESCRIPTION
The sequencer publisher enforces a max size for a block, depending on the size it takes up in blobs. If the block exceeds that size, it's rejected by the publisher.

https://github.com/AztecProtocol/aztec-packages/blob/bb87ea4a58a63771e61d551d105d8b52ba2014e6/yarn-project/stdlib/src/block/body.ts#L56-L70

This PR adds a check during block building to ensure that we don't go past that limit.
