### PR TITLE
feat!: slimmer wallet interface

### DIFF
--- a/playground/src/wallet/extension_wallet.ts
+++ b/playground/src/wallet/extension_wallet.ts
@@ -1,0 +1,58 @@
+import { type Wallet, WalletSchema } from '@aztec/aztec.js/wallet';
+import { promiseWithResolvers, type PromiseWithResolvers } from '@aztec/foundation/promise';
+import { schemaHasMethod } from '@aztec/foundation/schemas';
+import { jsonStringify } from '@aztec/foundation/json-rpc';
+
+type FunctionsOf<T> = { [K in keyof T as T[K] extends Function ? K : never]: T[K] };
+
+export class ExtensionWallet {
+  private inFlight = new Map<string, PromiseWithResolvers<any>>();
+
+  private constructor() {}
+
+  static create() {
+    const wallet = new ExtensionWallet();
+    window.addEventListener('message', async event => {
+      if (event.source !== window) return;
+
+      const { messageId, response } = event.data;
+      if (!response) {
+        return;
+      }
+      const { resolve, reject } = wallet.inFlight.get(messageId);
+      if (!resolve || !reject) {
+        console.error('No in-flight message for id', messageId);
+        return;
+      }
+      const { value, error } = response;
+      if (error) {
+        reject(new Error(error));
+      } else {
+        resolve(value);
+      }
+      wallet.inFlight.delete(messageId);
+    });
+    return new Proxy(wallet, {
+      get: (target, prop) => {
+        if (schemaHasMethod(WalletSchema, prop.toString())) {
+          return async (...args: any[]) => {
+            return await target.postMessage({
+              type: prop.toString() as keyof FunctionsOf<Wallet>,
+              args,
+            });
+          };
+        } else {
+          return target[prop];
+        }
+      },
+    }) as unknown as Wallet;
+  }
+
+  private async postMessage({ type, args }: { type: keyof FunctionsOf<Wallet>; args: any[] }) {
+    const messageId = globalThis.crypto.randomUUID();
+    window.postMessage(jsonStringify({ type, args, messageId }), '*');
+    const { promise, resolve, reject } = promiseWithResolvers<any>();
+    this.inFlight.set(messageId, { promise, resolve, reject });
+    return promise;
+  }
+}

--- a/yarn-project/aztec.js/package.json
+++ b/yarn-project/aztec.js/package.json
@@ -90,7 +90,8 @@
     "@aztec/stdlib": "workspace:^",
     "axios": "^1.8.2",
     "tslib": "^2.4.0",
-    "viem": "2.23.7"
+    "viem": "2.23.7",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@jest/globals": "^30.0.0",

--- a/yarn-project/aztec.js/src/account/signerless_account.ts
+++ b/yarn-project/aztec.js/src/account/signerless_account.ts
@@ -7,7 +7,7 @@ import type { CompleteAddress } from '@aztec/stdlib/contract';
 import type { TxExecutionRequest } from '@aztec/stdlib/tx';
 
 import type { ContractFunctionInteraction } from '../contract/contract_function_interaction.js';
-import type { IntentAction, IntentInnerHash } from '../utils/authwit.js';
+import type { CallIntent, IntentInnerHash } from '../utils/authwit.js';
 import type { Wallet } from '../wallet/wallet.js';
 import type { Account } from './account.js';
 
@@ -45,13 +45,13 @@ export class SignerlessAccount implements Account {
     throw new Error('SignerlessAccount: Method getAddress not implemented.');
   }
 
-  createAuthWit(_intent: Fr | Buffer | IntentInnerHash | IntentAction): Promise<AuthWitness> {
+  createAuthWit(_intent: Fr | Buffer | IntentInnerHash | CallIntent): Promise<AuthWitness> {
     throw new Error('SignerlessAccount: Method createAuthWit not implemented.');
   }
 
   setPublicAuthWit(
     _wallet: Wallet,
-    _messageHashOrIntent: Fr | Buffer | IntentInnerHash | IntentAction,
+    _messageHashOrIntent: Fr | Buffer | IntentInnerHash | CallIntent,
     _authorized: boolean,
   ): Promise<ContractFunctionInteraction> {
     throw new Error('SignerlessAccount: Method setPublicAuthWit not implemented.');

--- a/yarn-project/aztec.js/src/api/authorization.ts
+++ b/yarn-project/aztec.js/src/api/authorization.ts
@@ -1,3 +1,14 @@
 export { AuthWitness } from '@aztec/stdlib/auth-witness';
+export {
+  SetPublicAuthwitContractInteraction,
+  type ContractFunctionInteractionCallIntent,
+  getMessageHashFromIntent,
+  computeAuthWitMessageHash,
+  computeInnerAuthWitHashFromAction,
+  lookupValidity,
+  type CallIntent,
+  type IntentInnerHash,
+} from '../utils/authwit.js';
+export { computeInnerAuthWitHash } from '@aztec/stdlib/auth-witness';
 
 export { CallAuthorizationRequest } from '../authorization/call_authorization_request.js';

--- a/yarn-project/aztec.js/src/api/events.ts
+++ b/yarn-project/aztec.js/src/api/events.ts
@@ -1,0 +1,44 @@
+import { EventSelector, decodeFromAbi } from '@aztec/stdlib/abi';
+import type { AztecNode, EventMetadataDefinition } from '@aztec/stdlib/interfaces/client';
+
+/**
+ * Returns decoded public events given search parameters.
+ * @param node - The node to request events from
+ * @param eventMetadata - Metadata of the event. This should be the class generated from the contract. e.g. Contract.events.Event
+ * @param from - The block number to search from.
+ * @param limit - The amount of blocks to search.
+ * @returns - The deserialized events.
+ */
+export async function getDecodedPublicEvents<T>(
+  node: AztecNode,
+  eventMetadataDef: EventMetadataDefinition,
+  from: number,
+  limit: number,
+): Promise<T[]> {
+  const { logs } = await node.getPublicLogs({
+    fromBlock: from,
+    toBlock: from + limit,
+  });
+
+  const decodedEvents = logs
+    .map(log => {
+      // +1 for the event selector
+      const expectedLength = eventMetadataDef.fieldNames.length + 1;
+      if (log.log.emittedLength !== expectedLength) {
+        throw new Error(
+          `Something is weird here, we have matching EventSelectors, but the actual payload has mismatched length. Expected ${expectedLength}. Got ${log.log.emittedLength}.`,
+        );
+      }
+
+      const logFields = log.log.getEmittedFields();
+      // We are assuming here that event logs are the last 4 bytes of the event. This is not enshrined but is a function of aztec.nr raw log emission.
+      if (!EventSelector.fromField(logFields[logFields.length - 1]).equals(eventMetadataDef.eventSelector)) {
+        return undefined;
+      }
+
+      return decodeFromAbi([eventMetadataDef.abiType], log.log.fields) as T;
+    })
+    .filter(log => log !== undefined) as T[];
+
+  return decodedEvents;
+}

--- a/yarn-project/aztec.js/src/api/utils.ts
+++ b/yarn-project/aztec.js/src/api/utils.ts
@@ -8,13 +8,6 @@ export {
   type U128Like,
   type WrappedFieldLike,
 } from '../utils/abi_types.js';
-export {
-  computeAuthWitMessageHash,
-  computeInnerAuthWitHashFromAction,
-  type IntentAction,
-  type IntentInnerHash,
-} from '../utils/authwit.js';
-export { computeInnerAuthWitHash } from '@aztec/stdlib/auth-witness';
 export { waitForPXE } from '../utils/pxe.js';
 export { waitForNode, createAztecNodeClient, type AztecNode } from '../utils/node.js';
 export { getFeeJuiceBalance } from '../utils/fee_juice.js';

--- a/yarn-project/aztec.js/src/api/wallet.ts
+++ b/yarn-project/aztec.js/src/api/wallet.ts
@@ -1,1 +1,8 @@
-export { type Aliased, BaseWallet, type Wallet, AccountManager, type DeployAccountOptions } from '../wallet/index.js';
+export {
+  type Aliased,
+  BaseWallet,
+  type Wallet,
+  AccountManager,
+  type DeployAccountOptions,
+  WalletSchema,
+} from '../wallet/index.js';

--- a/yarn-project/aztec.js/src/fee/private_fee_payment_method.ts
+++ b/yarn-project/aztec.js/src/fee/private_fee_payment_method.ts
@@ -100,7 +100,7 @@ export class PrivateFeePaymentMethod implements FeePaymentMethod {
 
     const witness = await this.wallet.createAuthWit(this.sender, {
       caller: this.paymentContract,
-      action: {
+      call: {
         name: 'transfer_to_public',
         args: [this.sender.toField(), this.paymentContract.toField(), maxFee, txNonce],
         selector: await FunctionSelector.fromSignature('transfer_to_public((Field),(Field),u128,Field)'),

--- a/yarn-project/aztec.js/src/fee/public_fee_payment_method.ts
+++ b/yarn-project/aztec.js/src/fee/public_fee_payment_method.ts
@@ -6,6 +6,7 @@ import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import { GasSettings } from '@aztec/stdlib/gas';
 
 import { ContractFunctionInteraction } from '../contract/contract_function_interaction.js';
+import { SetPublicAuthwitContractInteraction } from '../utils/authwit.js';
 import type { Wallet } from '../wallet/wallet.js';
 import { FeeJuicePaymentMethod } from './fee_juice_payment_method.js';
 
@@ -90,20 +91,23 @@ export class PublicFeePaymentMethod implements FeePaymentMethod {
     const txNonce = Fr.random();
     const maxFee = gasSettings.getFeeLimit();
 
-    const setPublicAuthWitInteraction = await this.wallet.setPublicAuthWit(
-      this.sender,
-      {
-        caller: this.paymentContract,
-        action: {
-          name: 'transfer_in_public',
-          args: [this.sender.toField(), this.paymentContract.toField(), maxFee, txNonce],
-          selector: await FunctionSelector.fromSignature('transfer_in_public((Field),(Field),u128,Field)'),
-          type: FunctionType.PUBLIC,
-          isStatic: false,
-          to: await this.getAsset(),
-          returnTypes: [],
-        },
+    const intent = {
+      caller: this.paymentContract,
+      call: {
+        name: 'transfer_in_public',
+        args: [this.sender.toField(), this.paymentContract.toField(), maxFee, txNonce],
+        selector: await FunctionSelector.fromSignature('transfer_in_public((Field),(Field),u128,Field)'),
+        type: FunctionType.PUBLIC,
+        isStatic: false,
+        to: await this.getAsset(),
+        returnTypes: [],
       },
+    };
+
+    const setPublicAuthWitInteraction = await SetPublicAuthwitContractInteraction.create(
+      this.wallet,
+      this.sender,
+      intent,
       true,
     );
 

--- a/yarn-project/aztec.js/src/index.ts
+++ b/yarn-project/aztec.js/src/index.ts
@@ -76,6 +76,7 @@ export * from './api/account.js';
 export * from './api/addresses.js';
 export * from './api/deployment.js';
 export * from './api/ethereum.js';
+export * from './api/events.js';
 export * from './api/eth_address.js';
 export * from './api/fee.js';
 export * from './api/log.js';

--- a/yarn-project/aztec.js/src/wallet/wallet.ts
+++ b/yarn-project/aztec.js/src/wallet/wallet.ts
@@ -1,28 +1,49 @@
 import type { ExecutionPayload } from '@aztec/entrypoints/payload';
 import type { Fr } from '@aztec/foundation/fields';
-import type { ContractArtifact } from '@aztec/stdlib/abi';
-import type { AuthWitness } from '@aztec/stdlib/auth-witness';
+import {
+  AbiTypeSchema,
+  type ContractArtifact,
+  ContractArtifactSchema,
+  FunctionAbiSchema,
+  FunctionType,
+} from '@aztec/stdlib/abi';
+import { AuthWitness } from '@aztec/stdlib/auth-witness';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
-import type { ContractInstanceWithAddress, ContractInstantiationData } from '@aztec/stdlib/contract';
-import type { GasSettings } from '@aztec/stdlib/gas';
-import type { PXE } from '@aztec/stdlib/interfaces/client';
-import type {
+import {
+  type ContractInstanceWithAddress,
+  ContractInstanceWithAddressSchema,
+  type ContractInstantiationData,
+} from '@aztec/stdlib/contract';
+import { Gas, GasSettings } from '@aztec/stdlib/gas';
+import {
+  ContractClassMetadataSchema,
+  ContractMetadataSchema,
+  EventMetadataDefinitionSchema,
+  type PXE,
+} from '@aztec/stdlib/interfaces/client';
+import { PublicKeys } from '@aztec/stdlib/keys';
+import { AbiDecodedSchema, type ApiSchemaFor, optional, schemas } from '@aztec/stdlib/schemas';
+import {
+  Capsule,
+  HashedValues,
   Tx,
   TxHash,
   TxProfileResult,
   TxProvingResult,
+  TxReceipt,
   TxSimulationResult,
   UtilitySimulationResult,
 } from '@aztec/stdlib/tx';
 
+import { z } from 'zod';
+
 import type { Contract } from '../contract/contract.js';
-import type { ContractFunctionInteraction } from '../contract/contract_function_interaction.js';
 import type {
   ProfileMethodOptions,
   SendMethodOptions,
   SimulateMethodOptions,
 } from '../contract/interaction_options.js';
-import type { IntentAction, IntentInnerHash } from '../utils/authwit.js';
+import type { CallIntent, IntentInnerHash } from '../utils/authwit.js';
 
 /**
  * A wrapper type that allows any item to be associated with an alias.
@@ -43,13 +64,22 @@ export type Aliased<T> = {
  */
 export type ContractInstanceAndArtifact = Pick<Contract, 'artifact' | 'instance'>;
 
+/** Information on the connected chain */
+export type ChainInfo = {
+  /** The L1 chain id */
+  chainId: Fr;
+  /** The version of the rollup  */
+  version: Fr;
+};
+
 /**
  * The wallet interface.
  */
 export type Wallet = Pick<
   PXE,
-  'getContractClassMetadata' | 'getContractMetadata' | 'getTxReceipt' | 'getPrivateEvents' | 'getPublicEvents'
+  'getContractClassMetadata' | 'getContractMetadata' | 'getTxReceipt' | 'getPrivateEvents'
 > & {
+  getChainInfo(): Promise<ChainInfo>;
   registerSender(address: AztecAddress, alias?: string): Promise<AztecAddress>;
   getSenders(): Promise<Aliased<AztecAddress>[]>;
   getAccounts(): Promise<Aliased<AztecAddress>[]>;
@@ -73,11 +103,133 @@ export type Wallet = Pick<
   sendTx(tx: Tx): Promise<TxHash>;
   createAuthWit(
     from: AztecAddress,
-    messageHashOrIntent: Fr | Buffer | IntentInnerHash | IntentAction,
+    messageHashOrIntent: Fr | Buffer<ArrayBuffer> | IntentInnerHash | CallIntent,
   ): Promise<AuthWitness>;
-  setPublicAuthWit(
-    from: AztecAddress,
-    messageHashOrIntent: Fr | Buffer | IntentInnerHash | IntentAction,
-    authorized: boolean,
-  ): Promise<ContractFunctionInteraction>;
+};
+
+const ContractInstantiationDataSchema = z.object({
+  constructorArtifact: optional(z.union([FunctionAbiSchema, z.string()])),
+  constructorArgs: optional(z.array(z.any())),
+  skipArgsDecoding: optional(z.boolean()),
+  salt: schemas.Fr,
+  publicKeys: optional(PublicKeys.schema),
+  deployer: optional(schemas.AztecAddress),
+});
+
+const FunctionCallSchema = z.object({
+  name: z.string(),
+  to: schemas.AztecAddress,
+  selector: schemas.FunctionSelector,
+  type: z.nativeEnum(FunctionType),
+  isStatic: z.boolean(),
+  args: z.array(schemas.Fr),
+  returnTypes: z.array(AbiTypeSchema),
+});
+
+const ExecutionPayloadSchema = z.object({
+  calls: z.array(FunctionCallSchema),
+  authWitnesses: z.array(AuthWitness.schema),
+  capsules: z.array(Capsule.schema),
+  extraHashedArgs: z.array(HashedValues.schema),
+});
+
+const UserFeeOptionsSchema = z.object({
+  gasSettings: optional(
+    z.object({
+      gasLimits: optional(Gas.schema),
+      teardownGasLimits: optional(Gas.schema),
+      maxFeePerGas: optional(z.object({ feePerDaGas: schemas.BigInt, feePerL2Gas: schemas.BigInt })),
+      maxPriorityFeePerGas: optional(z.object({ feePerDaGas: schemas.BigInt, feePerL2Gas: schemas.BigInt })),
+    }),
+  ),
+  baseFeePadding: optional(z.number()),
+  estimateGas: optional(z.boolean()),
+  estimateGasPadding: optional(z.number()),
+});
+
+const SendMethodOptionsSchema = z.object({
+  from: schemas.AztecAddress,
+  authWitnesses: optional(z.array(AuthWitness.schema)),
+  capsules: optional(z.array(Capsule.schema)),
+  fee: optional(UserFeeOptionsSchema),
+});
+
+const EstimateGasOptionSchema = z.object({
+  from: schemas.AztecAddress,
+  authWitnesses: optional(z.array(AuthWitness.schema)),
+  capsules: optional(z.array(Capsule.schema)),
+  fee: optional(UserFeeOptionsSchema.omit({ estimateGas: true })),
+});
+
+const SimulateMethodOptionsSchema = z.object({
+  from: schemas.AztecAddress,
+  authWitnesses: optional(z.array(AuthWitness.schema)),
+  capsules: optional(z.array(Capsule.schema)),
+  fee: optional(UserFeeOptionsSchema),
+  skipTxValidation: optional(z.boolean()),
+  skipFeeEnforcement: optional(z.boolean()),
+  includeMetadata: optional(z.boolean()),
+});
+
+const ProfileMethodOptionsSchema = SimulateMethodOptionsSchema.extend({
+  profileMode: z.enum(['gates', 'execution-steps', 'full']),
+  skipProofGeneration: optional(z.boolean()),
+});
+
+const InstanceDataSchema = z.union([
+  schemas.AztecAddress,
+  ContractInstanceWithAddressSchema,
+  ContractInstantiationDataSchema,
+  z.object({ instance: ContractInstanceWithAddressSchema, artifact: ContractArtifactSchema }),
+]);
+
+const MessageHashOrIntentSchema = z.union([
+  schemas.Fr,
+  schemas.Buffer,
+  z.object({ consumer: schemas.AztecAddress, innerHash: z.union([schemas.Buffer, schemas.Fr]) }),
+  z.object({
+    caller: schemas.AztecAddress,
+    call: FunctionCallSchema,
+  }),
+]);
+
+export const WalletSchema: ApiSchemaFor<Wallet> = {
+  getChainInfo: z
+    .function()
+    .args()
+    .returns(z.object({ chainId: schemas.Fr, version: schemas.Fr })),
+  getContractClassMetadata: z.function().args(schemas.Fr, optional(z.boolean())).returns(ContractClassMetadataSchema),
+  getContractMetadata: z.function().args(schemas.AztecAddress).returns(ContractMetadataSchema),
+  getTxReceipt: z.function().args(TxHash.schema).returns(TxReceipt.schema),
+  getPrivateEvents: z
+    .function()
+    .args(schemas.AztecAddress, EventMetadataDefinitionSchema, z.number(), z.number(), z.array(schemas.AztecAddress))
+    .returns(z.array(AbiDecodedSchema)),
+  registerSender: z.function().args(schemas.AztecAddress, optional(z.string())).returns(schemas.AztecAddress),
+  getSenders: z
+    .function()
+    .args()
+    .returns(z.array(z.object({ alias: z.string(), item: schemas.AztecAddress }))),
+  getAccounts: z
+    .function()
+    .args()
+    .returns(z.array(z.object({ alias: z.string(), item: schemas.AztecAddress }))),
+  // @ts-expect-error Zod doesn't like optionals
+  registerContract: z
+    .function()
+    .args(InstanceDataSchema, optional(ContractArtifactSchema))
+    .returns(ContractInstanceWithAddressSchema),
+  estimateGas: z
+    .function()
+    .args(ExecutionPayloadSchema, EstimateGasOptionSchema)
+    .returns(z.object({ gasLimits: Gas.schema, teardownGasLimits: Gas.schema })),
+  simulateTx: z.function().args(ExecutionPayloadSchema, SimulateMethodOptionsSchema).returns(TxSimulationResult.schema),
+  simulateUtility: z
+    .function()
+    .args(z.string(), z.array(z.any()), schemas.AztecAddress, optional(z.array(AuthWitness.schema)))
+    .returns(UtilitySimulationResult.schema),
+  profileTx: z.function().args(ExecutionPayloadSchema, ProfileMethodOptionsSchema).returns(TxProfileResult.schema),
+  proveTx: z.function().args(ExecutionPayloadSchema, SendMethodOptionsSchema).returns(TxProvingResult.schema),
+  sendTx: z.function().args(Tx.schema).returns(TxHash.schema),
+  createAuthWit: z.function().args(schemas.AztecAddress, MessageHashOrIntentSchema).returns(AuthWitness.schema),
 };

--- a/yarn-project/bot/src/amm_bot.ts
+++ b/yarn-project/bot/src/amm_bot.ts
@@ -55,7 +55,9 @@ export class AmmBot extends BaseBot {
 
     const swapAuthwit = await wallet.createAuthWit(this.defaultAccountAddress, {
       caller: amm.address,
-      action: tokenIn.methods.transfer_to_public(this.defaultAccountAddress, amm.address, amountIn, authwitNonce),
+      call: await tokenIn.methods
+        .transfer_to_public(this.defaultAccountAddress, amm.address, amountIn, authwitNonce)
+        .getFunctionCall(),
     });
 
     const amountOutMin = await amm.methods

--- a/yarn-project/bot/src/factory.ts
+++ b/yarn-project/bot/src/factory.ts
@@ -276,21 +276,25 @@ export class BotFactory {
     // Add authwitnesses for the transfers in AMM::add_liquidity function
     const token0Authwit = await this.wallet.createAuthWit(defaultAccountAddress, {
       caller: amm.address,
-      action: token0.methods.transfer_to_public_and_prepare_private_balance_increase(
-        liquidityProvider,
-        amm.address,
-        amount0Max,
-        authwitNonce,
-      ),
+      call: await token0.methods
+        .transfer_to_public_and_prepare_private_balance_increase(
+          liquidityProvider,
+          amm.address,
+          amount0Max,
+          authwitNonce,
+        )
+        .getFunctionCall(),
     });
     const token1Authwit = await this.wallet.createAuthWit(defaultAccountAddress, {
       caller: amm.address,
-      action: token1.methods.transfer_to_public_and_prepare_private_balance_increase(
-        liquidityProvider,
-        amm.address,
-        amount1Max,
-        authwitNonce,
-      ),
+      call: await token1.methods
+        .transfer_to_public_and_prepare_private_balance_increase(
+          liquidityProvider,
+          amm.address,
+          amount1Max,
+          authwitNonce,
+        )
+        .getFunctionCall(),
     });
 
     const mintTx = new BatchCall(this.wallet, [

--- a/yarn-project/cli-wallet/src/cmds/authorize_action.ts
+++ b/yarn-project/cli-wallet/src/cmds/authorize_action.ts
@@ -1,4 +1,4 @@
-import { type AztecAddress, Contract, type Wallet } from '@aztec/aztec.js';
+import { type AztecAddress, Contract, SetPublicAuthwitContractInteraction, type Wallet } from '@aztec/aztec.js';
 import { prepTx } from '@aztec/cli/utils';
 import type { LogFn } from '@aztec/foundation/log';
 
@@ -30,7 +30,12 @@ export async function authorizeAction(
   const contract = await Contract.at(contractAddress, contractArtifact, wallet);
   const action = contract.methods[functionName](...functionArgs);
 
-  const setAuthwitnessInteraction = await wallet.setPublicAuthWit(from, { caller, action }, true);
+  const setAuthwitnessInteraction = await SetPublicAuthwitContractInteraction.create(
+    wallet,
+    from,
+    { caller, action },
+    true,
+  );
   const witness = await setAuthwitnessInteraction.send({ from }).wait({ timeout: DEFAULT_TX_TIMEOUT_S });
 
   log(`Authorized action ${functionName} on contract ${contractAddress} for caller ${caller}`);

--- a/yarn-project/cli-wallet/src/cmds/create_authwit.ts
+++ b/yarn-project/cli-wallet/src/cmds/create_authwit.ts
@@ -28,9 +28,9 @@ export async function createAuthwit(
   }
 
   const contract = await Contract.at(contractAddress, contractArtifact, wallet);
-  const action = contract.methods[functionName](...functionArgs);
+  const call = await contract.methods[functionName](...functionArgs).getFunctionCall();
 
-  const witness = await wallet.createAuthWit(from, { caller, action });
+  const witness = await wallet.createAuthWit(from, { caller, call });
 
   log(`Created authorization witness for action ${functionName} on contract ${contractAddress} for caller ${caller}`);
 

--- a/yarn-project/end-to-end/src/bench/client_flows/amm.test.ts
+++ b/yarn-project/end-to-end/src/bench/client_flows/amm.test.ts
@@ -3,6 +3,7 @@ import type { AMMContract } from '@aztec/noir-contracts.js/AMM';
 import type { FPCContract } from '@aztec/noir-contracts.js/FPC';
 import type { SponsoredFPCContract } from '@aztec/noir-contracts.js/SponsoredFPC';
 import { TokenContract } from '@aztec/noir-contracts.js/Token';
+import type { TestWallet } from '@aztec/test-wallet';
 
 import { jest } from '@jest/globals';
 
@@ -21,7 +22,7 @@ describe('AMM benchmark', () => {
   // The wallet used by the admin to interact
   let adminWallet: Wallet;
   // The wallet used by the user to interact
-  let userWallet: Wallet;
+  let userWallet: TestWallet;
   // The admin that aids in the setup of the test
   let adminAddress: AztecAddress;
   // FPC that accepts bananas

--- a/yarn-project/end-to-end/src/bench/client_flows/transfers.test.ts
+++ b/yarn-project/end-to-end/src/bench/client_flows/transfers.test.ts
@@ -2,6 +2,7 @@ import { AztecAddress, type AztecNode, Fr, type SimulateMethodOptions, type Wall
 import type { FPCContract } from '@aztec/noir-contracts.js/FPC';
 import type { SponsoredFPCContract } from '@aztec/noir-contracts.js/SponsoredFPC';
 import { TokenContract } from '@aztec/noir-contracts.js/Token';
+import type { TestWallet } from '@aztec/test-wallet';
 
 import { jest } from '@jest/globals';
 
@@ -20,7 +21,7 @@ describe('Transfer benchmark', () => {
   // The wallet used by the admin to interact
   let adminWallet: Wallet;
   // The wallet used by the user to interact
-  let userWallet: Wallet;
+  let userWallet: TestWallet;
   // The admin that aids in the setup of the test
   let adminAddress: AztecAddress;
   // FPC that accepts bananas

--- a/yarn-project/end-to-end/src/e2e_amm.test.ts
+++ b/yarn-project/end-to-end/src/e2e_amm.test.ts
@@ -1,6 +1,7 @@
-import { AztecAddress, Fr, type Logger, type Wallet } from '@aztec/aztec.js';
+import { AztecAddress, Fr, type Logger } from '@aztec/aztec.js';
 import { AMMContract } from '@aztec/noir-contracts.js/AMM';
 import type { TokenContract } from '@aztec/noir-contracts.js/Token';
+import type { TestWallet } from '@aztec/test-wallet';
 
 import { jest } from '@jest/globals';
 
@@ -16,7 +17,7 @@ describe('AMM', () => {
 
   let logger: Logger;
 
-  let wallet: Wallet;
+  let wallet: TestWallet;
 
   let adminAddress: AztecAddress;
   let liquidityProviderAddress: AztecAddress;

--- a/yarn-project/end-to-end/src/e2e_authwit.test.ts
+++ b/yarn-project/end-to-end/src/e2e_authwit.test.ts
@@ -158,7 +158,7 @@ describe('e2e_authwit_tests', () => {
 
         // docs:start:set_public_authwit
         const validateActionInteraction = await wallet.setPublicAuthWit(account1Address, intent, true);
-        await validateActionInteraction.send({ from: account1Address }).wait();
+        await validateActionInteraction.send().wait();
         // docs:end:set_public_authwit
         expect(await wallet.lookupValidity(account1Address, intent, witness)).toEqual({
           isValidInPrivate: true,
@@ -187,7 +187,7 @@ describe('e2e_authwit_tests', () => {
           });
 
           const validateActionInteraction = await wallet.setPublicAuthWit(account1Address, intent, true);
-          await validateActionInteraction.send({ from: account1Address }).wait();
+          await validateActionInteraction.send().wait();
 
           expect(await wallet.lookupValidity(account1Address, intent, witness)).toEqual({
             isValidInPrivate: true,

--- a/yarn-project/end-to-end/src/e2e_blacklist_token_contract/shielding.test.ts
+++ b/yarn-project/end-to-end/src/e2e_blacklist_token_contract/shielding.test.ts
@@ -59,7 +59,7 @@ describe('e2e_blacklist_token_contract shield + redeem_shield', () => {
       { caller: otherAddress, action },
       true,
     );
-    await validateActionInteraction.send({ from: adminAddress }).wait();
+    await validateActionInteraction.send().wait();
 
     const receipt = await action.send({ from: otherAddress }).wait();
 
@@ -113,7 +113,7 @@ describe('e2e_blacklist_token_contract shield + redeem_shield', () => {
         { caller: otherAddress, action },
         true,
       );
-      await validateActionInteraction.send({ from: adminAddress }).wait();
+      await validateActionInteraction.send().wait();
 
       await expect(action.simulate({ from: otherAddress })).rejects.toThrow(U128_UNDERFLOW_ERROR);
     });
@@ -131,7 +131,7 @@ describe('e2e_blacklist_token_contract shield + redeem_shield', () => {
         { caller: otherAddress, action },
         true,
       );
-      await validateActionInteraction.send({ from: adminAddress }).wait();
+      await validateActionInteraction.send().wait();
 
       await expect(action.simulate({ from: blacklistedAddress })).rejects.toThrow(/unauthorized/);
     });

--- a/yarn-project/end-to-end/src/e2e_blacklist_token_contract/transfer_private.test.ts
+++ b/yarn-project/end-to-end/src/e2e_blacklist_token_contract/transfer_private.test.ts
@@ -5,7 +5,7 @@ import { BlacklistTokenContractTest } from './blacklist_token_contract_test.js';
 
 describe('e2e_blacklist_token_contract transfer private', () => {
   const t = new BlacklistTokenContractTest('transfer_private');
-  let { asset, aztecNode, tokenSim, wallet, adminAddress, otherAddress, blacklistedAddress } = t;
+  let { asset, tokenSim, wallet, adminAddress, otherAddress, blacklistedAddress } = t;
 
   beforeAll(async () => {
     await t.applyBaseSnapshots();
@@ -13,7 +13,7 @@ describe('e2e_blacklist_token_contract transfer private', () => {
     await t.applyMintSnapshot();
     await t.setup();
     // Have to destructure again to ensure we have latest refs.
-    ({ asset, aztecNode, tokenSim, wallet, adminAddress, otherAddress, blacklistedAddress } = t);
+    ({ asset, tokenSim, wallet, adminAddress, otherAddress, blacklistedAddress } = t);
   }, 600_000);
 
   afterAll(async () => {
@@ -133,8 +133,8 @@ describe('e2e_blacklist_token_contract transfer private', () => {
       // We need to compute the message we want to sign and add it to the wallet as approved
       const action = asset.methods.transfer(adminAddress, otherAddress, amount, authwitNonce);
       const messageHash = await computeAuthWitMessageHash(
-        { caller: otherAddress, action },
-        { chainId: new Fr(await aztecNode.getChainId()), version: new Fr(await aztecNode.getVersion()) },
+        { caller: otherAddress, call: await action.getFunctionCall() },
+        await wallet.getChainInfo(),
       );
 
       await expect(action.simulate({ from: otherAddress })).rejects.toThrow(
@@ -151,8 +151,8 @@ describe('e2e_blacklist_token_contract transfer private', () => {
       // We need to compute the message we want to sign and add it to the wallet as approved
       const action = asset.methods.transfer(adminAddress, otherAddress, amount, authwitNonce);
       const expectedMessageHash = await computeAuthWitMessageHash(
-        { caller: blacklistedAddress, action },
-        { chainId: new Fr(await aztecNode.getChainId()), version: new Fr(await aztecNode.getVersion()) },
+        { caller: blacklistedAddress, call: await action.getFunctionCall() },
+        await wallet.getChainInfo(),
       );
 
       const witness = await wallet.createAuthWit(adminAddress, { caller: otherAddress, action });

--- a/yarn-project/end-to-end/src/e2e_blacklist_token_contract/transfer_public.test.ts
+++ b/yarn-project/end-to-end/src/e2e_blacklist_token_contract/transfer_public.test.ts
@@ -56,7 +56,7 @@ describe('e2e_blacklist_token_contract transfer public', () => {
       { caller: otherAddress, action },
       true,
     );
-    await validateActionInteraction.send({ from: adminAddress }).wait();
+    await validateActionInteraction.send().wait();
     // docs:end:authwit_public_transfer_example
 
     // Perform the transfer
@@ -121,7 +121,7 @@ describe('e2e_blacklist_token_contract transfer public', () => {
         { caller: otherAddress, action },
         true,
       );
-      await validateActionInteraction.send({ from: adminAddress }).wait();
+      await validateActionInteraction.send().wait();
       // docs:end:set_public_authwit
       // Perform the transfer
       await expect(action.simulate({ from: otherAddress })).rejects.toThrow(U128_UNDERFLOW_ERROR);
@@ -145,7 +145,7 @@ describe('e2e_blacklist_token_contract transfer public', () => {
         { caller: adminAddress, action },
         true,
       );
-      await validateActionInteraction.send({ from: adminAddress }).wait();
+      await validateActionInteraction.send().wait();
 
       // Perform the transfer
       await expect(action.simulate({ from: otherAddress })).rejects.toThrow(/unauthorized/);

--- a/yarn-project/end-to-end/src/e2e_blacklist_token_contract/unshielding.test.ts
+++ b/yarn-project/end-to-end/src/e2e_blacklist_token_contract/unshielding.test.ts
@@ -5,7 +5,7 @@ import { BlacklistTokenContractTest } from './blacklist_token_contract_test.js';
 
 describe('e2e_blacklist_token_contract unshielding', () => {
   const t = new BlacklistTokenContractTest('unshielding');
-  let { asset, tokenSim, aztecNode, wallet, adminAddress, otherAddress, blacklistedAddress } = t;
+  let { asset, tokenSim, wallet, adminAddress, otherAddress, blacklistedAddress } = t;
 
   beforeAll(async () => {
     await t.applyBaseSnapshots();
@@ -13,7 +13,7 @@ describe('e2e_blacklist_token_contract unshielding', () => {
     await t.applyMintSnapshot();
     await t.setup();
     // Have to destructure again to ensure we have latest refs.
-    ({ asset, tokenSim, aztecNode, wallet, adminAddress, otherAddress, blacklistedAddress } = t);
+    ({ asset, tokenSim, wallet, adminAddress, otherAddress, blacklistedAddress } = t);
   }, 600_000);
 
   afterAll(async () => {
@@ -108,8 +108,8 @@ describe('e2e_blacklist_token_contract unshielding', () => {
       // We need to compute the message we want to sign and add it to the wallet as approved
       const action = asset.methods.unshield(adminAddress, otherAddress, amount, authwitNonce);
       const expectedMessageHash = await computeAuthWitMessageHash(
-        { caller: blacklistedAddress, action },
-        { chainId: new Fr(await aztecNode.getChainId()), version: new Fr(await aztecNode.getVersion()) },
+        { caller: blacklistedAddress, call: await action.getFunctionCall() },
+        await wallet.getChainInfo(),
       );
 
       // Both wallets are connected to same node and PXE so we could just insert directly

--- a/yarn-project/end-to-end/src/e2e_cross_chain_messaging/token_bridge_public.test.ts
+++ b/yarn-project/end-to-end/src/e2e_cross_chain_messaging/token_bridge_public.test.ts
@@ -73,7 +73,7 @@ describe('e2e_cross_chain_messaging token_bridge_public', () => {
       },
       true,
     );
-    await validateActionInteraction.send({ from: ownerAddress }).wait();
+    await validateActionInteraction.send().wait();
 
     // 5. Withdraw owner's funds from L2 to L1
     logger.verbose('5. Withdraw owner funds from L2 to L1');

--- a/yarn-project/end-to-end/src/e2e_crowdfunding_and_claim.test.ts
+++ b/yarn-project/end-to-end/src/e2e_crowdfunding_and_claim.test.ts
@@ -1,4 +1,4 @@
-import { Fr, type Logger, type PXE, type UniqueNote, type Wallet, deriveKeys } from '@aztec/aztec.js';
+import { Fr, type Logger, type PXE, type UniqueNote, deriveKeys } from '@aztec/aztec.js';
 import { CheatCodes } from '@aztec/aztec/testing';
 import { ClaimContract } from '@aztec/noir-contracts.js/Claim';
 import { CrowdfundingContract } from '@aztec/noir-contracts.js/Crowdfunding';
@@ -6,6 +6,7 @@ import { TokenContract } from '@aztec/noir-contracts.js/Token';
 import { TestContract } from '@aztec/noir-test-contracts.js/Test';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import { computePartialAddress } from '@aztec/stdlib/contract';
+import type { TestWallet } from '@aztec/test-wallet';
 
 import { jest } from '@jest/globals';
 
@@ -30,7 +31,7 @@ describe('e2e_crowdfunding_and_claim', () => {
 
   let teardown: () => Promise<void>;
 
-  let wallet: Wallet;
+  let wallet: TestWallet;
   let operatorAddress: AztecAddress;
   let donor1Address: AztecAddress;
   let donor2Address: AztecAddress;

--- a/yarn-project/end-to-end/src/e2e_event_logs.test.ts
+++ b/yarn-project/end-to-end/src/e2e_event_logs.test.ts
@@ -1,4 +1,4 @@
-import { AztecAddress, Fr, type Wallet } from '@aztec/aztec.js';
+import { AztecAddress, type AztecNode, Fr, type Wallet, getDecodedPublicEvents } from '@aztec/aztec.js';
 import { makeTuple } from '@aztec/foundation/array';
 import { timesParallel } from '@aztec/foundation/collection';
 import type { Tuple } from '@aztec/foundation/serialize';
@@ -15,6 +15,7 @@ describe('Logs', () => {
   jest.setTimeout(TIMEOUT);
 
   let wallet: Wallet;
+  let aztecNode: AztecNode;
 
   let account1Address: AztecAddress;
   let account2Address: AztecAddress;
@@ -26,6 +27,7 @@ describe('Logs', () => {
       teardown,
       wallet,
       accounts: [account1Address, account2Address],
+      aztecNode,
     } = await setup(2));
 
     await ensureAccountContractsPublished(wallet, [account1Address, account1Address]);
@@ -119,13 +121,15 @@ describe('Logs', () => {
         .send({ from: account1Address })
         .wait();
 
-      const collectedEvent0s = await wallet.getPublicEvents<ExampleEvent0>(
+      const collectedEvent0s = await getDecodedPublicEvents<ExampleEvent0>(
+        aztecNode,
         TestLogContract.events.ExampleEvent0,
         firstTx.blockNumber!,
         lastTx.blockNumber! - firstTx.blockNumber! + 1,
       );
 
-      const collectedEvent1s = await wallet.getPublicEvents<ExampleEvent1>(
+      const collectedEvent1s = await getDecodedPublicEvents<ExampleEvent1>(
+        aztecNode,
         TestLogContract.events.ExampleEvent1,
         firstTx.blockNumber!,
         lastTx.blockNumber! - firstTx.blockNumber! + 1,

--- a/yarn-project/end-to-end/src/e2e_fees/failures.test.ts
+++ b/yarn-project/end-to-end/src/e2e_fees/failures.test.ts
@@ -5,6 +5,7 @@ import {
   FunctionSelector,
   PrivateFeePaymentMethod,
   PublicFeePaymentMethod,
+  SetPublicAuthwitContractInteraction,
   TxStatus,
   type Wallet,
 } from '@aztec/aztec.js';
@@ -347,11 +348,12 @@ class BuggedSetupFeePaymentMethod extends PublicFeePaymentMethod {
 
     const asset = await this.getAsset();
 
-    const setPublicAuthWitInteraction = await this.wallet.setPublicAuthWit(
+    const setPublicAuthWitInteraction = await SetPublicAuthwitContractInteraction.create(
+      this.wallet,
       this.sender,
       {
         caller: this.paymentContract,
-        action: {
+        call: {
           name: 'transfer_in_public',
           args: [this.sender.toField(), this.paymentContract.toField(), maxFee, authwitNonce],
           selector: await FunctionSelector.fromSignature('transfer_in_public((Field),(Field),u128,Field)'),

--- a/yarn-project/end-to-end/src/e2e_lending_contract.test.ts
+++ b/yarn-project/end-to-end/src/e2e_lending_contract.test.ts
@@ -1,10 +1,11 @@
-import { AztecAddress, Fr, type Logger, type Wallet } from '@aztec/aztec.js';
+import { AztecAddress, Fr, type Logger } from '@aztec/aztec.js';
 import { CheatCodes } from '@aztec/aztec/testing';
 import { type DeployL1ContractsReturnType, RollupContract } from '@aztec/ethereum';
 import type { TestDateProvider } from '@aztec/foundation/timer';
 import { LendingContract } from '@aztec/noir-contracts.js/Lending';
 import { PriceFeedContract } from '@aztec/noir-contracts.js/PriceFeed';
 import { TokenContract } from '@aztec/noir-contracts.js/Token';
+import type { TestWallet } from '@aztec/test-wallet';
 
 import { afterAll, jest } from '@jest/globals';
 
@@ -14,7 +15,7 @@ import { LendingAccount, LendingSimulator, TokenSimulator } from './simulators/i
 
 describe('e2e_lending_contract', () => {
   jest.setTimeout(100_000);
-  let wallet: Wallet;
+  let wallet: TestWallet;
   let defaultAccountAddress: AztecAddress;
   let deployL1ContractsValues: DeployL1ContractsReturnType;
 

--- a/yarn-project/end-to-end/src/e2e_token_contract/token_contract_test.ts
+++ b/yarn-project/end-to-end/src/e2e_token_contract/token_contract_test.ts
@@ -1,6 +1,7 @@
-import { AztecAddress, type AztecNode, type Logger, type Wallet, createLogger } from '@aztec/aztec.js';
+import { AztecAddress, type AztecNode, type Logger, createLogger } from '@aztec/aztec.js';
 import { TokenContract } from '@aztec/noir-contracts.js/Token';
 import { InvalidAccountContract } from '@aztec/noir-test-contracts.js/InvalidAccount';
+import type { TestWallet } from '@aztec/test-wallet';
 
 import { jest } from '@jest/globals';
 
@@ -27,7 +28,7 @@ export class TokenContractTest {
   node!: AztecNode;
 
   badAccount!: InvalidAccountContract;
-  wallet!: Wallet;
+  wallet!: TestWallet;
   adminAddress!: AztecAddress;
   account1Address!: AztecAddress;
   account2Address!: AztecAddress;

--- a/yarn-project/end-to-end/src/e2e_token_contract/transfer_in_private.test.ts
+++ b/yarn-project/end-to-end/src/e2e_token_contract/transfer_in_private.test.ts
@@ -5,13 +5,13 @@ import { TokenContractTest } from './token_contract_test.js';
 
 describe('e2e_token_contract transfer private', () => {
   const t = new TokenContractTest('transfer_private');
-  let { asset, tokenSim, wallet, node, adminAddress, account1Address, account2Address, badAccount } = t;
+  let { asset, tokenSim, wallet, adminAddress, account1Address, account2Address, badAccount } = t;
 
   beforeAll(async () => {
     await t.applyBaseSnapshots();
     await t.applyMintSnapshot();
     await t.setup();
-    ({ asset, tokenSim, wallet, node, adminAddress, account1Address, account2Address, badAccount } = t);
+    ({ asset, tokenSim, wallet, adminAddress, account1Address, account2Address, badAccount } = t);
   });
 
   afterAll(async () => {
@@ -101,8 +101,8 @@ describe('e2e_token_contract transfer private', () => {
       // We need to compute the message we want to sign and add it to the wallet as approved
       const action = asset.methods.transfer_in_private(adminAddress, account1Address, amount, authwitNonce);
       const messageHash = await computeAuthWitMessageHash(
-        { caller: account1Address, action },
-        { chainId: new Fr(await node.getChainId()), version: new Fr(await node.getVersion()) },
+        { caller: account1Address, call: await action.getFunctionCall() },
+        await wallet.getChainInfo(),
       );
 
       await expect(action.simulate({ from: account1Address })).rejects.toThrow(
@@ -119,8 +119,8 @@ describe('e2e_token_contract transfer private', () => {
       // We need to compute the message we want to sign and add it to the wallet as approved
       const action = asset.methods.transfer_in_private(adminAddress, account1Address, amount, authwitNonce);
       const expectedMessageHash = await computeAuthWitMessageHash(
-        { caller: account2Address, action },
-        { chainId: new Fr(await node.getChainId()), version: new Fr(await node.getVersion()) },
+        { caller: account2Address, call: await action.getFunctionCall() },
+        await wallet.getChainInfo(),
       );
 
       const witness = await wallet.createAuthWit(adminAddress, { caller: account1Address, action });

--- a/yarn-project/end-to-end/src/e2e_token_contract/transfer_in_public.test.ts
+++ b/yarn-project/end-to-end/src/e2e_token_contract/transfer_in_public.test.ts
@@ -77,7 +77,7 @@ describe('e2e_token_contract transfer public', () => {
       { caller: account1Address, action },
       true,
     );
-    await validateActionInteraction.send({ from: adminAddress }).wait();
+    await validateActionInteraction.send().wait();
     // docs:end:authwit_public_transfer_example
 
     // Perform the transfer
@@ -141,7 +141,7 @@ describe('e2e_token_contract transfer public', () => {
       const intent = { caller: account1Address, action };
       // We need to compute the message we want to sign and add it to the wallet as approved
       const validateActionInteraction = await wallet.setPublicAuthWit(adminAddress, intent, true);
-      await validateActionInteraction.send({ from: adminAddress }).wait();
+      await validateActionInteraction.send().wait();
 
       const witness = await wallet.createAuthWit(adminAddress, { caller: account1Address, action });
 
@@ -171,7 +171,7 @@ describe('e2e_token_contract transfer public', () => {
         { caller: adminAddress, action },
         true,
       );
-      await validateActionInteraction.send({ from: adminAddress }).wait();
+      await validateActionInteraction.send().wait();
 
       // Perform the transfer
       await expect(action.simulate({ from: account1Address })).rejects.toThrow(/unauthorized/);
@@ -196,7 +196,7 @@ describe('e2e_token_contract transfer public', () => {
         { caller: adminAddress, action },
         true,
       );
-      await validateActionInteraction.send({ from: adminAddress }).wait();
+      await validateActionInteraction.send().wait();
 
       // Perform the transfer
       await expect(action.simulate({ from: account1Address })).rejects.toThrow(/unauthorized/);
@@ -220,7 +220,7 @@ describe('e2e_token_contract transfer public', () => {
         { caller: account1Address, action },
         true,
       );
-      await validateActionInteraction.send({ from: adminAddress }).wait();
+      await validateActionInteraction.send().wait();
 
       const cancelActionInteraction = await wallet.setPublicAuthWit(
         adminAddress,
@@ -249,7 +249,7 @@ describe('e2e_token_contract transfer public', () => {
         { caller: account1Address, action },
         true,
       );
-      await validateActionInteraction.send({ from: adminAddress }).wait();
+      await validateActionInteraction.send().wait();
 
       const cancelActionInteraction = await wallet.setPublicAuthWit(
         adminAddress,

--- a/yarn-project/end-to-end/src/e2e_token_contract/transfer_to_public.test.ts
+++ b/yarn-project/end-to-end/src/e2e_token_contract/transfer_to_public.test.ts
@@ -5,14 +5,14 @@ import { TokenContractTest } from './token_contract_test.js';
 
 describe('e2e_token_contract transfer_to_public', () => {
   const t = new TokenContractTest('transfer_to_public');
-  let { asset, node, wallet, adminAddress, account1Address, account2Address, tokenSim } = t;
+  let { asset, wallet, adminAddress, account1Address, account2Address, tokenSim } = t;
 
   beforeAll(async () => {
     await t.applyBaseSnapshots();
     await t.applyMintSnapshot();
     await t.setup();
     // Have to destructure again to ensure we have latest refs.
-    ({ asset, node, wallet, adminAddress, account1Address, account2Address, tokenSim } = t);
+    ({ asset, wallet, adminAddress, account1Address, account2Address, tokenSim } = t);
   });
 
   afterAll(async () => {
@@ -106,8 +106,8 @@ describe('e2e_token_contract transfer_to_public', () => {
       // We need to compute the message we want to sign and add it to the wallet as approved
       const action = asset.methods.transfer_to_public(adminAddress, account1Address, amount, authwitNonce);
       const expectedMessageHash = await computeAuthWitMessageHash(
-        { caller: account2Address, action },
-        { chainId: new Fr(await node.getChainId()), version: new Fr(await node.getVersion()) },
+        { caller: account2Address, call: await action.getFunctionCall() },
+        await wallet.getChainInfo(),
       );
 
       // Both wallets are connected to same node and PXE so we could just insert directly

--- a/yarn-project/pxe/src/pxe_service/pxe_service.ts
+++ b/yarn-project/pxe/src/pxe_service/pxe_service.ts
@@ -15,7 +15,6 @@ import {
 import type { CircuitSimulator } from '@aztec/simulator/client';
 import {
   type ContractArtifact,
-  EventSelector,
   FunctionCall,
   FunctionSelector,
   FunctionType,
@@ -1092,35 +1091,6 @@ export class PXEService implements PXE {
     );
 
     const decodedEvents = events.map((event: Fr[]): T => decodeFromAbi([eventMetadataDef.abiType], event) as T);
-
-    return decodedEvents;
-  }
-
-  async getPublicEvents<T>(eventMetadataDef: EventMetadataDefinition, from: number, limit: number): Promise<T[]> {
-    const { logs } = await this.node.getPublicLogs({
-      fromBlock: from,
-      toBlock: from + limit,
-    });
-
-    const decodedEvents = logs
-      .map(log => {
-        // +1 for the event selector
-        const expectedLength = eventMetadataDef.fieldNames.length + 1;
-        if (log.log.emittedLength !== expectedLength) {
-          throw new Error(
-            `Something is weird here, we have matching EventSelectors, but the actual payload has mismatched length. Expected ${expectedLength}. Got ${log.log.emittedLength}.`,
-          );
-        }
-
-        const logFields = log.log.getEmittedFields();
-        // We are assuming here that event logs are the last 4 bytes of the event. This is not enshrined but is a function of aztec.nr raw log emission.
-        if (!EventSelector.fromField(logFields[logFields.length - 1]).equals(eventMetadataDef.eventSelector)) {
-          return undefined;
-        }
-
-        return decodeFromAbi([eventMetadataDef.abiType], log.log.fields) as T;
-      })
-      .filter(log => log !== undefined) as T[];
 
     return decodedEvents;
   }

--- a/yarn-project/stdlib/src/interfaces/pxe.test.ts
+++ b/yarn-project/stdlib/src/interfaces/pxe.test.ts
@@ -303,15 +303,6 @@ describe('PXESchema', () => {
     );
     expect(result).toEqual([{ value: 1n }]);
   });
-
-  it('getPublicEvents', async () => {
-    const result = await context.client.getPublicEvents<{ value: bigint }>(
-      { abiType: { kind: 'boolean' }, eventSelector: EventSelector.random(), fieldNames: ['name'] },
-      1,
-      1,
-    );
-    expect(result).toEqual([{ value: 1n }]);
-  });
 });
 
 class MockPXE implements PXE {
@@ -544,11 +535,6 @@ class MockPXE implements PXE {
     expect(from).toBe(1);
     expect(limit).toBe(1);
     expect(_recipients[0]).toBeInstanceOf(AztecAddress);
-    return Promise.resolve([{ value: 1n } as T]);
-  }
-  getPublicEvents<T>(_eventMetadata: EventMetadataDefinition, from: number, limit: number): Promise<T[]> {
-    expect(from).toBe(1);
-    expect(limit).toBe(1);
     return Promise.resolve([{ value: 1n } as T]);
   }
 }

--- a/yarn-project/stdlib/src/interfaces/pxe.ts
+++ b/yarn-project/stdlib/src/interfaces/pxe.ts
@@ -378,15 +378,6 @@ export interface PXE {
     numBlocks: number,
     recipients: AztecAddress[],
   ): Promise<T[]>;
-
-  /**
-   * Returns the public events given search parameters.
-   * @param eventMetadata - Metadata of the event. This should be the class generated from the contract. e.g. Contract.events.Event
-   * @param from - The block number to search from.
-   * @param limit - The amount of blocks to search.
-   * @returns - The deserialized events.
-   */
-  getPublicEvents<T>(eventMetadata: EventMetadataDefinition, from: number, limit: number): Promise<T[]>;
 }
 // docs:end:pxe-interface
 
@@ -396,7 +387,7 @@ export type EventMetadataDefinition = {
   fieldNames: string[];
 };
 
-const EventMetadataDefinitionSchema = z.object({
+export const EventMetadataDefinitionSchema = z.object({
   eventSelector: schemas.EventSelector,
   abiType: AbiTypeSchema,
   fieldNames: z.array(z.string()),
@@ -428,13 +419,13 @@ export interface ContractClassMetadata {
   artifact?: ContractArtifact | undefined;
 }
 
-const ContractMetadataSchema = z.object({
+export const ContractMetadataSchema = z.object({
   contractInstance: z.union([ContractInstanceWithAddressSchema, z.undefined()]),
   isContractInitialized: z.boolean(),
   isContractPublished: z.boolean(),
 }) satisfies ZodFor<ContractMetadata>;
 
-const ContractClassMetadataSchema = z.object({
+export const ContractClassMetadataSchema = z.object({
   contractClass: z.union([ContractClassWithIdSchema, z.undefined()]),
   isContractClassPubliclyRegistered: z.boolean(),
   artifact: z.union([ContractArtifactSchema, z.undefined()]),
@@ -524,9 +515,5 @@ export const PXESchema: ApiSchemaFor<PXE> = {
   getPrivateEvents: z
     .function()
     .args(schemas.AztecAddress, EventMetadataDefinitionSchema, z.number(), z.number(), z.array(schemas.AztecAddress))
-    .returns(z.array(AbiDecodedSchema)),
-  getPublicEvents: z
-    .function()
-    .args(EventMetadataDefinitionSchema, z.number(), z.number())
     .returns(z.array(AbiDecodedSchema)),
 };


### PR DESCRIPTION
Keep removing methods that do not belong in the wallet interface. This time:

- `createPublicAuthwit`: This is just a contract interaction. A few convenience methods have been added, and the `TestWallet` keeps the interface to avoid pain the e2e tests, but from now on public authwits are just that: glorified ContractInteractions
- `getPublicEvents`: Nuked also from PXE. There's 0 private information required to decode them, moved to an utility instead

`createAuthwit` in the Wallet loses the ability to compute them from `ContractFunctionInteraction`s since they're not serializable (still kept it in `TestWallet` for the same reasons as above)

Added a new `getChainInfo` method that returns chainId and version and can be used to generate authwits externally and generally to gather information about the chain the wallet is connected to.

Also added a proper validated interface to the `Wallet` that will be used soon ™️ 