### PR TITLE
Fix: Use Math.floor for aztec.archiver.message.sync_per_item_duration in instrumentation

### DIFF
--- a/yarn-project/archiver/src/archiver/instrumentation.ts
+++ b/yarn-project/archiver/src/archiver/instrumentation.ts
@@ -153,8 +153,20 @@ export class ArchiverInstrumentation {
 
   public processNewMessages(count: number, syncPerMessageMs: number) {
     this.syncMessageCount.add(count);
-    this.syncDurationPerMessage.record(Math.ceil(syncPerMessageMs));
-  }
+  const v = Math.round(syncPerMessageMs);
+
+if (!Number.isInteger(v)) {
+  // eslint-disable-next-line no-console
+  console.warn('INT metric got non-integer', {
+    metric: 'aztec.archiver.message.sync_per_item_duration',
+    raw: syncPerMessageMs,
+    rounded: v,
+    source: 'instrumentation.processNewMessages',
+  });
+}
+
+this.syncDurationPerMessage.record(v);
+	}
 
   public processPrune(duration: number) {
     this.pruneCount.add(1);


### PR DESCRIPTION
###Description

Rounds syncPerMessageMs before recording the metric aztec.archiver.message.sync_per_item_duration to ensure integer values for ValueType.INT.

###Motivation

The OTel SDK warning —

“INT value type cannot accept a floating-point value for aztec.archiver.message.sync_per_item_duration”
appears when fractional values reach the INT histogram.

Math.round(...) ensures unbiased integer values (unlike floor/ceil, which skew the distribution) and eliminates the warning.

A temporary Number.isInteger guard was added to quickly catch any other fractional writes.
If sub-ms precision is needed, this metric should switch to ValueType.DOUBLE or report nanoseconds as INT.

###Files changed

yarn-project/archiver/src/archiver/instrumentation.ts