### PR TITLE
chore!: PG audit 1 - Docs and code clean up

### DIFF
--- a/barretenberg/cpp/scripts/test_civc_standalone_vks_havent_changed.sh
+++ b/barretenberg/cpp/scripts/test_civc_standalone_vks_havent_changed.sh
@@ -13,7 +13,7 @@ cd ..
 # - Generate a hash for versioning: sha256sum bb-civc-inputs.tar.gz
 # - Upload the compressed results: aws s3 cp bb-civc-inputs.tar.gz s3://aztec-ci-artifacts/protocol/bb-civc-inputs-[hash(0:8)].tar.gz
 # Note: In case of the "Test suite failed to run ... Unexpected token 'with' " error, need to run: docker pull aztecprotocol/build:3.0
-pinned_short_hash="62254472"
+pinned_short_hash="14944afe"
 pinned_civc_inputs_url="https://aztec-ci-artifacts.s3.us-east-2.amazonaws.com/protocol/bb-civc-inputs-${pinned_short_hash}.tar.gz"
 
 function compress_and_upload {

--- a/barretenberg/cpp/src/barretenberg/flavor/flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/flavor.hpp
@@ -501,7 +501,7 @@ template <typename RelationsTuple> constexpr auto create_sumcheck_tuple_of_tuple
  * RelationsTuple, where the element at index idx in the tuple is an array of FF elements of length equal to the number
  * of subrelations that made up the the relation at index idx in RelationsTuple.
  *
- * Example: if RelationsTuple = UltraFlavor::Relations_, then the tuple returned by the function is a tuple of length 9,
+ * @example if RelationsTuple = UltraFlavor::Relations_, then the tuple returned by the function is a tuple of length 9,
  * where the first element of the tuple is an array of length 2 (as the first relation in UltraFlavor::Relations_ is the
  * UltraArithmeticRelation, which is made up by two subrelations).
  *

--- a/barretenberg/cpp/src/barretenberg/flavor/flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/flavor.hpp
@@ -494,9 +494,18 @@ template <typename RelationsTuple> constexpr auto create_sumcheck_tuple_of_tuple
 }
 
 /**
- * @brief Construct tuple of arrays
- * @details Container for storing value of each identity in each relation. Each Relation contributes an array of
- * length num-identities.
+ * @brief Create a tuple of arrays
+ *
+ * @details This function is used to declare a type whose instances are containers for the evaluations of the Ultra/Mega
+ * Honk subrelations. More precisely, the function returns a tuple of length equal to the number of relations defined by
+ * RelationsTuple, where the element at index idx in the tuple is an array of FF elements of length equal to the number
+ * of subrelations that made up the the relation at index idx in RelationsTuple.
+ *
+ * Example: if RelationsTuple = UltraFlavor::Relations_, then the tuple returned by the function is a tuple of length 9,
+ * where the first element of the tuple is an array of length 2 (as the first relation in UltraFlavor::Relations_ is the
+ * UltraArithmeticRelation, which is made up by two subrelations).
+ *
+ * @tparam RelationsTuple
  */
 template <typename RelationsTuple> constexpr auto create_tuple_of_arrays_of_values()
 {

--- a/barretenberg/cpp/src/barretenberg/polynomials/univariate.hpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/univariate.hpp
@@ -27,10 +27,11 @@ template <class Fr, size_t view_domain_end, size_t view_domain_start, size_t ski
  * memory efficiency purposes, we store the evaluations in an array starting from 0 and make the mapping to the right
  * domain under the hood.
  *
- * @tparam skip_count Skip computing the values of elements [domain_start+1,..,domain_start+skip_count]. Used for
- * optimising computation in protogalaxy. The value at [domain_start] is the value from the accumulator, while the
- * values in [domain_start+1, ... domain_start + skip_count] in the accumulator should be zero if the original if the
- * skip_count-many keys to be folded are all valid
+ * @tparam skip_count Skip computing the values of the univariate at the points
+ * [domain_start+1, .., domain_start+skip_count]. Used for optimising the computation of the combiner (the polynomial
+ * \f$G\f$) in Protogalaxy. The value at [domain_start] is the value from the accumulator, while the values at
+ * [domain_start+1, ... domain_start + skip_count] should be zero if the skip_count-many keys to be
+ * folded are all valid.
  */
 template <class Fr, size_t domain_end, size_t domain_start = 0, size_t skip_count = 0> class Univariate {
   public:

--- a/barretenberg/cpp/src/barretenberg/polynomials/univariate.hpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/univariate.hpp
@@ -549,6 +549,12 @@ template <class Fr, size_t domain_end, size_t domain_start = 0, size_t skip_coun
         return result;
     }
 
+    /**
+     * @brief Compute the evaluations of the polynomial from the INITIAL_LENGTH up to the total LENGTH. Currently only
+     * supports INITIAL_LENGTH = 2.
+     *
+     * @tparam INITIAL_LENGTH
+     */
     template <size_t INITIAL_LENGTH> void self_extend_from()
     {
         if constexpr (INITIAL_LENGTH == 2) {
@@ -558,6 +564,8 @@ template <class Fr, size_t domain_end, size_t domain_start = 0, size_t skip_coun
                 next += delta;
                 value_at(idx) = next;
             }
+        } else {
+            throw_or_abort("self_extend_from called with INITIAL_LENGTH different from 2.");
         }
     }
 

--- a/barretenberg/cpp/src/barretenberg/protogalaxy/combiner.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/combiner.test.cpp
@@ -285,12 +285,14 @@ TEST(Protogalaxy, CombinerOn2Keys)
                       0    0    0    0    0    0    0              0    0    6   18   36   60   90      */
 
             GateSeparatorPolynomial<FF> gate_separators({ 2 }, /*log_num_monomials=*/1);
-            PGInternalTest::UnivariateRelationParametersNoOptimisticSkipping univariate_relation_parameters_no_skpping;
+            PGInternalTest::UnivariateRelationParametersNoOptimisticSkipping univariate_relation_parameters_no_skipping;
             PGInternalTest::UnivariateRelationParameters univariate_relation_parameters;
             auto result_no_skipping = pg_internal.compute_combiner_no_optimistic_skipping(
-                keys, gate_separators, univariate_relation_parameters_no_skpping, alphas);
-            auto result_with_skipping =
-                pg_internal.compute_combiner(keys, gate_separators, univariate_relation_parameters, alphas);
+                keys, gate_separators, univariate_relation_parameters_no_skipping, alphas);
+            // Note: {} is required to initialize the tuple contents. Otherwise the univariates contain garbage.
+            PGInternalTest::TupleOfTuplesOfUnivariates accumulators{};
+            auto result_with_skipping = pg_internal.compute_combiner(
+                keys, gate_separators, univariate_relation_parameters, alphas, accumulators);
             auto expected_result =
                 Univariate<FF, 12>(std::array<FF, 12>{ 0, 0, 12, 36, 72, 120, 180, 252, 336, 432, 540, 660 });
 
@@ -407,8 +409,10 @@ TEST(Protogalaxy, CombinerOptimizationConsistency)
             PGInternalTest::UnivariateRelationParameters univariate_relation_parameters;
             auto result_no_skipping = pg_internal.compute_combiner_no_optimistic_skipping(
                 keys, gate_separators, univariate_relation_parameters_no_skpping, alphas);
-            auto result_with_skipping =
-                pg_internal.compute_combiner(keys, gate_separators, univariate_relation_parameters, alphas);
+            // Note: {} is required to initialize the tuple contents. Otherwise the univariates contain garbage.
+            PGInternalTest::TupleOfTuplesOfUnivariates accumulators{};
+            auto result_with_skipping = pg_internal.compute_combiner(
+                keys, gate_separators, univariate_relation_parameters, alphas, accumulators);
 
             EXPECT_EQ(result_no_skipping, expected_result);
             EXPECT_EQ(result_with_skipping, expected_result);
@@ -477,8 +481,10 @@ TEST(Protogalaxy, CombinerOptimizationConsistency)
             PGInternalTest::UnivariateRelationParameters univariate_relation_parameters;
             auto result_no_skipping = pg_internal.compute_combiner_no_optimistic_skipping(
                 keys, gate_separators, univariate_relation_parameters_no_skpping, alphas);
-            auto result_with_skipping =
-                pg_internal.compute_combiner(keys, gate_separators, univariate_relation_parameters, alphas);
+            // Note: {} is required to initialize the tuple contents. Otherwise the univariates contain garbage.
+            PGInternalTest::TupleOfTuplesOfUnivariates accumulators{};
+            auto result_with_skipping = pg_internal.compute_combiner(
+                keys, gate_separators, univariate_relation_parameters, alphas, accumulators);
             auto expected_result =
                 Univariate<FF, 12>(std::array<FF, 12>{ 0, 0, 12, 36, 72, 120, 180, 252, 336, 432, 540, 660 });
 

--- a/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover.hpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover.hpp
@@ -16,7 +16,6 @@
 namespace bb {
 
 // TODO(https://github.com/AztecProtocol/barretenberg/issues/1437): Change template params back to ProverInstances
-// TODO(https://github.com/AztecProtocol/barretenberg/issues/1239): clean out broken support for multi-folding
 template <IsUltraOrMegaHonk Flavor> class ProtogalaxyProver_ {
   public:
     static constexpr size_t NUM_SUBRELATIONS = Flavor::NUM_SUBRELATIONS;

--- a/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover_impl.hpp
@@ -82,13 +82,19 @@ ProtogalaxyProver_<Flavor>::combiner_quotient_round(const std::vector<FF>& gate_
 {
     BB_BENCH_NAME("ProtogalaxyProver_::combiner_quotient_round");
 
+    // Generate the challenge (\alpha in the paper) at which to evaluate the perturbator (F in the paper)
     const FF perturbator_challenge = transcript->template get_challenge<FF>("perturbator_challenge");
 
+    // Step 8. in the paper: \beta is updated to \beta + \alpha * \delta
     const std::vector<FF> updated_gate_challenges =
         update_gate_challenges(perturbator_challenge, gate_challenges, deltas);
-    const UnivariateSubrelationSeparators alphas = PGInternal::compute_and_extend_alphas(instances);
+
     const GateSeparatorPolynomial<FF> gate_separators{ updated_gate_challenges,
                                                        numeric::get_msb(get_max_dyadic_size()) };
+
+    // Fold the batching challenges (\alphas in the ProverInstances)
+    const UnivariateSubrelationSeparators alphas = PGInternal::compute_and_extend_alphas(instances);
+    // Fold the relation parameters in the ProverInstances
     const UnivariateRelationParameters relation_parameters =
         PGInternal::template compute_extended_relation_parameters<UnivariateRelationParameters>(instances);
 

--- a/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover_impl.hpp
@@ -114,7 +114,7 @@ ProtogalaxyProver_<Flavor>::combiner_quotient_round(const std::vector<FF>& gate_
 }
 
 /**
- * @brief Given the challenge \gamma, compute Z(\gamma) and {L_0(\gamma),L_1(\gamma)}
+ * @brief Given the challenge \f$\gamma\f$, compute \f$Z(\gamma)\f$ and \f$L_0(\gamma),L_1(\gamma)\f$
  */
 template <IsUltraOrMegaHonk Flavor>
 void ProtogalaxyProver_<Flavor>::update_target_sum_and_fold(
@@ -133,9 +133,10 @@ void ProtogalaxyProver_<Flavor>::update_target_sum_and_fold(
     // At this point the virtual sizes of the polynomials should already agree
     BB_ASSERT_EQ(accumulator->polynomials.w_l.virtual_size(), incoming->polynomials.w_l.virtual_size());
 
+    // Step 12., \gamma challenge
     const FF combiner_challenge = transcript->template get_challenge<FF>("combiner_quotient_challenge");
 
-    // Compute the next target sum (for its own use; verifier must compute its own values)
+    // Step 13., compute the next target sum (for its own use; verifier must compute its own values)
     auto [vanishing_polynomial_at_challenge, lagranges] =
         PGInternal::compute_vanishing_polynomial_and_lagranges(combiner_challenge);
     accumulator->target_sum = perturbator_evaluation * lagranges[0] +

--- a/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover_impl.hpp
@@ -58,7 +58,7 @@ std::tuple<std::vector<typename Flavor::FF>, Polynomial<typename Flavor::FF>> Pr
 
     const std::vector<FF> deltas = transcript->template get_powers_of_challenge<FF>("delta", CONST_PG_LOG_N);
     // An honest prover with valid initial key computes that the perturbator is 0 in the first round
-    const Polynomial<FF> perturbator = accumulator->from_first_instance
+    const Polynomial<FF> perturbator = accumulator->is_relaxed_instance
                                            ? pg_internal.compute_perturbator(accumulator, deltas)
                                            : Polynomial<FF>(CONST_PG_LOG_N + 1);
     // Prover doesn't send the constant coefficient of F because this is supposed to be equal to the target sum of
@@ -128,7 +128,7 @@ void ProtogalaxyProver_<Flavor>::update_target_sum_and_fold(
 
     std::shared_ptr<ProverInstance> accumulator = instances[0];
     std::shared_ptr<ProverInstance> incoming = instances[1];
-    accumulator->from_first_instance = true;
+    accumulator->is_relaxed_instance = true;
 
     // At this point the virtual sizes of the polynomials should already agree
     BB_ASSERT_EQ(accumulator->polynomials.w_l.virtual_size(), incoming->polynomials.w_l.virtual_size());

--- a/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover_internal.hpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover_internal.hpp
@@ -379,14 +379,17 @@ template <class ProverInstance> class ProtogalaxyProverInternal {
     }
 
     /**
-     * @brief Compute the combiner polynomial $G$ in the Protogalaxy paper
+     * @brief Compute the combiner polynomial \f$G\f$ in the Protogalaxy paper
+     *
      * @details We have implemented an optimization that (eg in the case where we fold one instance-witness pair at a
      * time) assumes the value G(1) is 0, which is true in the case where the witness to be folded is valid.
      * @todo (https://github.com/AztecProtocol/barretenberg/issues/968) Make combiner tests better
      *
-     * @tparam skip_zero_computations whether to use the optimization that skips computing zero.
-     * @param
+     * @param instances
      * @param gate_separators
+     * @param relation_parameters
+     * @param alphas
+     * @param univariate_accumulators
      * @return ExtendedUnivariateWithRandomization
      */
     ExtendedUnivariateWithRandomization compute_combiner(const ProverInstances& instances,
@@ -403,8 +406,6 @@ template <class ProverInstance> class ProtogalaxyProverInternal {
         const size_t common_polynomial_size = instances[0]->polynomials.w_l.virtual_size();
         const size_t num_threads = compute_num_threads(common_polynomial_size);
 
-        // Univariates are optimized for usual PG, but we need the unoptimized version for tests (it's a version that
-        // doesn't skip computation), so we need to define types depending on the template instantiation
         using ThreadAccumulators = TupleOfTuplesOfUnivariates;
 
         // Construct univariate accumulator containers; one per thread
@@ -449,16 +450,6 @@ template <class ProverInstance> class ProtogalaxyProverInternal {
             deoptimize_univariates(univariate_accumulators);
         //  Batch the univariate contributions from each sub-relation to obtain the round univariate
         return batch_over_relations(deoptimized_univariates, alphas);
-    }
-
-    ExtendedUnivariateWithRandomization compute_combiner(const ProverInstances& instances,
-                                                         const GateSeparatorPolynomial<FF>& gate_separators,
-                                                         const UnivariateRelationParameters& relation_parameters,
-                                                         const UnivariateSubrelationSeparators& alphas)
-    {
-        // Note: {} is required to initialize the tuple contents. Otherwise the univariates contain garbage.
-        TupleOfTuplesOfUnivariates accumulators{};
-        return compute_combiner(instances, gate_separators, relation_parameters, alphas, accumulators);
     }
 
     /**
@@ -543,8 +534,17 @@ template <class ProverInstance> class ProtogalaxyProverInternal {
     }
 
     /**
-     * @brief For each parameter, collect the value in each decider pvogin key in a univariate and extend for use in the
+     * @brief For each parameter, collect the value in each ProverInstance in a univariate and extend for use in the
      * combiner compute.
+     *
+     * @note Univariates are in Lagrange basis. Therefore, this function returns the folded relation parameters.
+     *
+     * @details The ProverInstance is made of prover polynomials, relation parameters, and subrelations batching
+     * challenges. As the relation parameters are part of the instance, they must be folded. This function arranges the
+     * relation parameters from the instances in a matrix where column i represents the relation parameters from the
+     * i-th instance to be folded and then defines a univariate for each row of the matrix by using the relation
+     * parameters in that row as coefficients. The univariates are extended up to length
+     * ProverInstances::EXTENDED_LENGTH.
      */
     template <typename ExtendedRelationParameters>
     static ExtendedRelationParameters compute_extended_relation_parameters(const ProverInstances& instances)
@@ -565,6 +565,19 @@ template <class ProverInstance> class ProtogalaxyProverInternal {
     /**
      * @brief Combine the relation batching parameters (alphas) from each prover instance into a univariate for the
      * combiner computation.
+     *
+     * @note Univariates are in Lagrange basis. Therefore, this function returns the folded batching challenges.
+     *
+     * @details The ProverInstance is made of prover polynomials, relation parameters, and subrelations batching
+     * challenges: the alphas. As the alphas are part of the instance, they must be folded. This function arranges the
+     * alphas from the instances in a matrix where column i represents the alphas from the i-th instance to be folded
+     * and then defines a univariate for each row of the matrix by using the alphas in that row as coefficients. The
+     * univariates are extended up to length ProverInstances::BATCHED_EXTENDED_LENGTH.
+     *
+     *  \f$alpha_{1,1}\f$ \f$alpha_{2,1}\f$ --> result[0] = (\f$alpha_{1,1}\f$, \f$alpha_{2,1}\f$, ...)
+     *  \f$alpha_{1,2}\f$ \f$alpha_{2,2}\f$                                     ...
+     *     ...          ...
+     *  \f$alpha_{1,n}\f$ \f$alpha_{2,n}\f$ --> result[n-1] = (\f$alpha_{1,n}\f$, \f$alpha_{2,n}\f$, ...)
      */
     static UnivariateSubrelationSeparators compute_and_extend_alphas(const ProverInstances& instances)
     {

--- a/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover_internal.hpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover_internal.hpp
@@ -423,12 +423,11 @@ template <class ProverInstance> class ProtogalaxyProverInternal {
             for (const ExecutionTraceUsageTracker::Range& range : trace_usage_tracker.thread_ranges[thread_idx]) {
                 for (size_t idx = range.first; idx < range.second; idx++) {
                     // Instantiate extended univariates: they contain the evaluations of the prover polynomials from the
-                    // instances being folded and are extended to length ProverInstances::EXTENDED_LENGTH, which is the
-                    // maximum length of a folded subrelation polynomial. We set skip_count to ProverInstances::NUM-1
-                    // because the relations evaluate to zero on valid keys, and the evaluations of the combiner on the
-                    // points 1, ..., ProverInstances::NUM-1 are exactly the relation contributions coming from the keys
-                    // being folded (note that the Univariate class skips computing evaluations between 1 and
-                    // skip_count).
+                    // instances being folded and are extended to length EXTENDED_LENGTH, which is the maximum length of
+                    // a folded subrelation polynomial. We set skip_count to NUM_INSTANCES - 1 = 1 because the
+                    // relations evaluate to zero on valid keys, and the evaluations of the combiner on the point 1,
+                    // is exactly the relation contributions coming from the key being folded (note that the Univariate
+                    // class skips computing evaluations between 1 and skip_count).
                     //
                     // The values of the evaluations are still available for skipping relations, but all
                     // derived univariates (coming from addition, multiplication, etc) will ignore those evaluations.
@@ -546,10 +545,9 @@ template <class ProverInstance> class ProtogalaxyProverInternal {
      * instances at once.
      *
      * @details The combiner quotient is defined by the formula \f$G(X) = F(\alpha) L_0(X) + Z(X) K(X)\f$. The
-     * polynomial \f$Z(X)\f$ is the vanishing polynomial of the set 0, .., ProverInstances::NUM-1. Therefore, we cannot
-     * compute the value of \f$K(X)\f$ on these values. We evaluate \f$K(X)\f$ on ProverInstances::NUM, ...,
-     * ProverInstances::BATCHED_EXTENDED_LENGTH (the length of the combiner) and we return the univariate over this
-     * domain.
+     * polynomial \f$Z(X)\f$ is the vanishing polynomial of the set 0, NUM_INSTANCES-1 = 1. Therefore, we cannot
+     * compute the value of \f$K(X)\f$ on these values. We evaluate \f$K(X)\f$ on NUM_INSTANCES = 2, ...,
+     * BATCHED_EXTENDED_LENGTH (the length of the combiner) and we return the univariate over this domain.
      *
      */
     static Univariate<FF, BATCHED_EXTENDED_LENGTH, NUM_INSTANCES> compute_combiner_quotient(
@@ -570,7 +568,7 @@ template <class ProverInstance> class ProtogalaxyProverInternal {
 
     /**
      * @brief For each parameter, collect the value in each ProverInstance in a univariate and extend for use in the
-     * combiner compute.
+     * combiner computation.
      *
      * @note Univariates are in Lagrange basis. Therefore, this function returns the folded relation parameters.
      *
@@ -578,9 +576,8 @@ template <class ProverInstance> class ProtogalaxyProverInternal {
      * challenges. As the relation parameters are part of the instance, they must be folded. This function arranges the
      * relation parameters from the instances in a matrix where column i represents the relation parameters from the
      * i-th instance to be folded and then defines a univariate for each row of the matrix by using the relation
-     * parameters in that row as coefficients. The univariates are extended up to length
-     * ProverInstances::EXTENDED_LENGTH, which is the max length of a subrelation when the relation parameters are
-     * considered as variables.
+     * parameters in that row as coefficients. The univariates are extended up to length EXTENDED_LENGTH, which is the
+     * max length of a subrelation when the relation parameters are considered as variables.
      */
     template <typename ExtendedRelationParameters>
     static ExtendedRelationParameters compute_extended_relation_parameters(const ProverInstances& instances)
@@ -608,13 +605,8 @@ template <class ProverInstance> class ProtogalaxyProverInternal {
      * challenges: the alphas. As the alphas are part of the instance, they must be folded. This function arranges the
      * alphas from the instances in a matrix where column i represents the alphas from the i-th instance to be folded
      * and then defines a univariate for each row of the matrix by using the alphas in that row as coefficients. The
-     * univariates are extended up to length ProverInstances::BATCHED_EXTENDED_LENGTH, which is the max degree of the
+     * univariates are extended up to length BATCHED_EXTENDED_LENGTH, which is the max degree of the
      * \f$f_i\f$'s in the relation calculation.
-     *
-     *  \f$alpha_{1,1}\f$ \f$alpha_{2,1}\f$ --> result[0] = (\f$alpha_{1,1}\f$, \f$alpha_{2,1}\f$, ...)
-     *  \f$alpha_{1,2}\f$ \f$alpha_{2,2}\f$                                     ...
-     *     ...          ...
-     *  \f$alpha_{1,n}\f$ \f$alpha_{2,n}\f$ --> result[n-1] = (\f$alpha_{1,n}\f$, \f$alpha_{2,n}\f$, ...)
      */
     static UnivariateSubrelationSeparators compute_and_extend_alphas(const ProverInstances& instances)
     {

--- a/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover_internal.hpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover_internal.hpp
@@ -548,10 +548,8 @@ template <class ProverInstance> class ProtogalaxyProverInternal {
      * @details The combiner quotient is defined by the formula \f$G(X) = F(\alpha) L_0(X) + Z(X) K(X)\f$. The
      * polynomial \f$Z(X)\f$ is the vanishing polynomial of the set 0, .., ProverInstances::NUM-1. Therefore, we cannot
      * compute the value of \f$K(X)\f$ on these values. We evaluate \f$K(X)\f$ on ProverInstances::NUM, ...,
-     * ProverInstances::BATCHED_EXTENDED_LENGTH (the length of the combiner) and we abuse the class Univariate by
-     * returning a univariate the skips the first ProverInstances::NUM evaluations (abuse because the skip_count in
-     * Univariate is used to denote the points in the domain where the univariate evaluates to zero; in this case we
-     * don't know its evaluation).
+     * ProverInstances::BATCHED_EXTENDED_LENGTH (the length of the combiner) and we return the univariate over this
+     * domain.
      *
      */
     static Univariate<FF, BATCHED_EXTENDED_LENGTH, NUM_INSTANCES> compute_combiner_quotient(

--- a/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover_internal.hpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover_internal.hpp
@@ -422,16 +422,26 @@ template <class ProverInstance> class ProtogalaxyProverInternal {
 
             for (const ExecutionTraceUsageTracker::Range& range : trace_usage_tracker.thread_ranges[thread_idx]) {
                 for (size_t idx = range.first; idx < range.second; idx++) {
-                    // Instantiate univariates, possibly with skipping to ignore computation in those indices
-                    // (they are still available for skipping relations, but all derived univariate will ignore
-                    // those evaluations) No need to initialize extended_univariates to 0, as it's assigned to.
+                    // Instantiate extended univariates: they contain the evaluations of the prover polynomials from the
+                    // instances being folded and are extended to length ProverInstances::EXTENDED_LENGTH, which is the
+                    // maximum length of a folded subrelation polynomial. We set skip_count to ProverInstances::NUM-1
+                    // because the relations evaluate to zero on valid keys, and the evaluations of the combiner on the
+                    // points 1, ..., ProverInstances::NUM-1 are exactly the relation contributions coming from the keys
+                    // being folded (note that the Univariate class skips computing evaluations between 1 and
+                    // skip_count).
+                    //
+                    // The values of the evaluations are still available for skipping relations, but all
+                    // derived univariates (coming from addition, multiplication, etc) will ignore those evaluations.
+                    //
+                    // No need to initialize extended_univariates to 0, as it's assigned to a value in the following
+                    // function.
                     extend_univariates<SKIP_COUNT>(extended_univariates, instances, idx);
 
                     const FF pow_challenge = gate_separators[idx];
 
                     // Accumulate the i-th row's univariate contribution. Note that the relation parameters passed
                     // to this function have already been folded. Moreover, linear-dependent relations that act over
-                    // the entire execution trace rather than on rows, will not be multiplied by the pow challenge.
+                    // the entire execution trace rather than on rows will not be multiplied by the pow challenge.
                     accumulate_relation_univariates(thread_univariate_accumulators[thread_idx],
                                                     extended_univariates,
                                                     relation_parameters, // these parameters have already been folded
@@ -448,7 +458,8 @@ template <class ProverInstance> class ProtogalaxyProverInternal {
         // This does nothing if TupleOfTuples is TupleOfTuplesOfUnivariates
         TupleOfTuplesOfUnivariatesNoOptimisticSkipping deoptimized_univariates =
             deoptimize_univariates(univariate_accumulators);
-        //  Batch the univariate contributions from each sub-relation to obtain the round univariate
+        // Batch the univariate contributions from each folded sub-relation using the folded batching challenges to
+        // obtain the combiner
         return batch_over_relations(deoptimized_univariates, alphas);
     }
 
@@ -478,6 +489,18 @@ template <class ProverInstance> class ProtogalaxyProverInternal {
         return result;
     }
 
+    /**
+     * @brief Given the univariate accumulators and the batching challenges, compute the combiner by batching the
+     * subrelations.
+     *
+     * @details univariate_accumulators contain the contributions from the entire trace for each folded subrelation. To
+     * complete the calculation of the combiner, we have to batch these contributions using the folded batching
+     * challenges.
+     *
+     * @param univariate_accumulators
+     * @param alphas
+     * @return ExtendedUnivariateWithRandomization
+     */
     static ExtendedUnivariateWithRandomization batch_over_relations(
         TupleOfTuplesOfUnivariatesNoOptimisticSkipping& univariate_accumulators,
         const UnivariateSubrelationSeparators& alphas)
@@ -490,6 +513,7 @@ template <class ProverInstance> class ProtogalaxyProverInternal {
                 return;
             }
 
+            // Extend folded subrelation polynomials to the length of the combiner
             auto extended = element.template extend_to<BATCHED_EXTENDED_LENGTH>();
             extended *= alphas[idx];
             result += extended;
@@ -502,6 +526,10 @@ template <class ProverInstance> class ProtogalaxyProverInternal {
         return result;
     }
 
+    /**
+     * @brief Compute the vanishing polynomial \f$Z(X) = X * (X - 1)\f$ and Lagranges \f$L_0(X) = 1 - X, L_1(X) = X\f$
+     * at the challenge.
+     */
     static std::pair<typename ProverInstance::FF, std::array<typename ProverInstance::FF, NUM_INSTANCES>>
     compute_vanishing_polynomial_and_lagranges(const FF& challenge)
     {
@@ -516,6 +544,15 @@ template <class ProverInstance> class ProtogalaxyProverInternal {
     /**
      * @brief Compute the combiner quotient defined as $K$ polynomial in the paper specialised for only folding two
      * instances at once.
+     *
+     * @details The combiner quotient is defined by the formula \f$G(X) = F(\alpha) L_0(X) + Z(X) K(X)\f$. The
+     * polynomial \f$Z(X)\f$ is the vanishing polynomial of the set 0, .., ProverInstances::NUM-1. Therefore, we cannot
+     * compute the value of \f$K(X)\f$ on these values. We evaluate \f$K(X)\f$ on ProverInstances::NUM, ...,
+     * ProverInstances::BATCHED_EXTENDED_LENGTH (the length of the combiner) and we abuse the class Univariate by
+     * returning a univariate the skips the first ProverInstances::NUM evaluations (abuse because the skip_count in
+     * Univariate is used to denote the points in the domain where the univariate evaluates to zero; in this case we
+     * don't know its evaluation).
+     *
      */
     static Univariate<FF, BATCHED_EXTENDED_LENGTH, NUM_INSTANCES> compute_combiner_quotient(
         FF perturbator_evaluation, ExtendedUnivariateWithRandomization combiner)
@@ -544,7 +581,8 @@ template <class ProverInstance> class ProtogalaxyProverInternal {
      * relation parameters from the instances in a matrix where column i represents the relation parameters from the
      * i-th instance to be folded and then defines a univariate for each row of the matrix by using the relation
      * parameters in that row as coefficients. The univariates are extended up to length
-     * ProverInstances::EXTENDED_LENGTH.
+     * ProverInstances::EXTENDED_LENGTH, which is the max length of a subrelation when the relation parameters are
+     * considered as variables.
      */
     template <typename ExtendedRelationParameters>
     static ExtendedRelationParameters compute_extended_relation_parameters(const ProverInstances& instances)
@@ -572,7 +610,8 @@ template <class ProverInstance> class ProtogalaxyProverInternal {
      * challenges: the alphas. As the alphas are part of the instance, they must be folded. This function arranges the
      * alphas from the instances in a matrix where column i represents the alphas from the i-th instance to be folded
      * and then defines a univariate for each row of the matrix by using the alphas in that row as coefficients. The
-     * univariates are extended up to length ProverInstances::BATCHED_EXTENDED_LENGTH.
+     * univariates are extended up to length ProverInstances::BATCHED_EXTENDED_LENGTH, which is the max degree of the
+     * \f$f_i\f$'s in the relation calculation.
      *
      *  \f$alpha_{1,1}\f$ \f$alpha_{2,1}\f$ --> result[0] = (\f$alpha_{1,1}\f$, \f$alpha_{2,1}\f$, ...)
      *  \f$alpha_{1,2}\f$ \f$alpha_{2,2}\f$                                     ...

--- a/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_verifier.cpp
@@ -45,8 +45,9 @@ template <class VerifierInstance>
 std::shared_ptr<VerifierInstance> ProtogalaxyVerifier_<VerifierInstance>::verify_folding_proof(
     const std::vector<FF>& proof)
 {
-    // The degree of the combiner quotient (K in the paper) is dk - k - 1 = k(d - 1) - 1.
-    // Hence we need  k(d - 1) evaluations to represent it.
+    // The degree of the combiner quotient (K in the paper) is equal to deg(G) - deg(Z), where Z is the vanishing
+    // polynomial of the domain 0, .., NUM_INSTANCES-1. Hence, deg(K) = deg(G) - NUM_INSTANCES and we need deg(G) + 1 -
+    // NUM_INSTANCES = BATCHED_EXTENDED_LENGTH - NUM_INSTANCES evaluations to represent it
     static constexpr size_t COMBINER_QUOTIENT_LENGTH = BATCHED_EXTENDED_LENGTH - NUM_INSTANCES;
 
     const std::shared_ptr<VerifierInstance>& accumulator = insts_to_fold[0];

--- a/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_verifier.hpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_verifier.hpp
@@ -60,28 +60,20 @@ template <class VerifierInstance> class ProtogalaxyVerifier_ {
     };
 
     /**
-     * @brief Get data to be folded grouped by commitment index
-     * @example Assume the VKs are arranged as follows
-     *           VK 0    VK 1    VK 2    VK 3
-     *           q_c_0   q_c_1   q_c_2   q_c_3
-     *           q_l_0   q_l_1   q_l_2   q_l_3
-     *             ⋮        ⋮        ⋮       ⋮
-     * If we wanted to extract the commitments from the verification keys in order to fold them, we would pass to the
-     * function the type parameter FOLDING_DATA::PRECOMPUTED_COMMITMETS, and the function would return
-     * {{q_c_0, q_c_1, q_c_2, q_c_3}, {q_l_0, q_l_1, q_l_2, q_l_3},...}. Here the "commitment index" is the index of the
+     * @brief Get data to be folded grouped by commitment index. Here the "commitment index" is the index of the
      * row in the matrix whose columns are given be the instance components to be folded.
      *
      * @tparam FoldingData The type of the parameter to be folded
      */
     template <FOLDING_DATA FoldingData> auto get_data_to_fold() const
     {
-        using PrecomputeCommDataType = RefArray<Commitment, Flavor::NUM_PRECOMPUTED_ENTITIES>;
+        using PrecomputedCommDataType = RefArray<Commitment, Flavor::NUM_PRECOMPUTED_ENTITIES>;
         using WitnessCommitmentsDataType = RefArray<Commitment, Flavor::NUM_WITNESS_ENTITIES>;
         using AlphasDataType = Flavor::SubrelationSeparators;
         using RelationParametersDataType = RefArray<FF, RelationParameters<FF>::NUM_TO_FOLD>;
         using DataType = std::conditional_t<
             FoldingData == FOLDING_DATA::PRECOMPUTED_COMMITMENTS,
-            PrecomputeCommDataType,
+            PrecomputedCommDataType,
             std::conditional_t<
                 FoldingData == FOLDING_DATA::WITNESS_COMMITMENTS,
                 WitnessCommitmentsDataType,
@@ -110,9 +102,9 @@ template <class VerifierInstance> class ProtogalaxyVerifier_ {
 
         const size_t num_to_fold = data[0].size();
         std::vector<std::vector<ReturnValue>> result(num_to_fold, std::vector<ReturnValue>(NUM_INSTANCES));
-        for (size_t idx = 0; auto& commitment_at_idx : result) {
-            commitment_at_idx[0] = data[0][idx];
-            commitment_at_idx[1] = data[1][idx];
+        for (size_t idx = 0; auto& data_at_idx : result) {
+            data_at_idx[0] = data[0][idx];
+            data_at_idx[1] = data[1][idx];
             idx++;
         }
         return result;

--- a/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/protogalaxy_recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/protogalaxy_recursive_verifier.cpp
@@ -114,12 +114,11 @@ std::shared_ptr<VerifierInstance> ProtogalaxyRecursiveVerifier_<VerifierInstance
      *
      * The cost of this verification is 3 size N MSMs with short scalars and 1 size 2 MSM with full scalars, amounting
      * to 3 * (33 * roundup(N/4) + 31) + 64 = 99 * roundup(N/4) + 157 ~ 25 * N + 157 rows (here we use that an MSM of
-     * size k with full scalars account for 33 * roundup(N/2) + 31 rows, which for k = 2 equal 64 rows)
+     * size k with full scalars account for 33 * roundup(N/2) + 31 rows, which for k = 2 equals 64 rows)
      *
      * Note: there are more efficient ways to evaluate this relationship if one solely wants to reduce number of
      * scalar muls, however we must also consider the number of ECCVM operations being executed, as each operation
-     * incurs a cost in the translator circuit Each ECCVM opcode produces 5 rows in the translator circuit, which is
-     * approx. equivalent to 9 ECCVM rows.
+     * incurs a cost in the translator circuit.
      */
 
     // New transcript for challenge generation
@@ -165,7 +164,8 @@ std::shared_ptr<VerifierInstance> ProtogalaxyRecursiveVerifier_<VerifierInstance
         batch_mul_transcript.template get_challenges<FF>(args);
     std::vector<FF> scalars(folding_challenges.begin(), folding_challenges.end());
 
-    // Compute [A] = \sum_i c_i [P_{0,i}]
+    // MSMs: edge cases are handled in the MSM only when the builder is Ultra. When the builder is mega, edge cases are
+    // handled by the ECCVM Compute [A] = \sum_i c_i [P_{0,i}]
     Commitment accumulator_sum = Commitment::batch_mul(accumulator_commitments,
                                                        scalars,
                                                        /*max_num_bits=*/0,

--- a/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/protogalaxy_recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/protogalaxy_recursive_verifier.cpp
@@ -20,7 +20,7 @@ void ProtogalaxyRecursiveVerifier_<VerifierInstance>::run_oink_verifier_on_each_
     auto key = insts_to_fold[0];
     auto domain_separator = std::to_string(0);
 
-    // If the first instance to be folded in non-relaxed we need to complete it and generate the gate challenges
+    // If the first instance to be folded is non-relaxed we need to complete it and generate the gate challenges
     if (!key->is_complete) {
         OinkRecursiveVerifier_<Flavor> oink_verifier{ builder, key, transcript, domain_separator + '_' };
         oink_verifier.verify();
@@ -41,7 +41,7 @@ template <class VerifierInstance>
 std::shared_ptr<VerifierInstance> ProtogalaxyRecursiveVerifier_<VerifierInstance>::verify_folding_proof(
     const stdlib::Proof<Builder>& proof)
 {
-    // The degree of the combiner quotient (K in the paper) is equal to deg(G) - deg(Z), where Z is the vanishing
+    // The degree of the combiner quotient (K in the paper) is equal to deg(G) - deg(Z), where Z is the  vanishing
     // polynomial of the domain 0, .., NUM_INSTANCES-1. Hence, deg(K) = deg(G) - NUM_INSTANCES and we need deg(G) + 1 -
     // NUM_INSTANCES = BATCHED_EXTENDED_LENGTH - NUM_INSTANCES evaluations to represent it
     static constexpr size_t COMBINER_QUOTIENT_LENGTH = BATCHED_EXTENDED_LENGTH - NUM_INSTANCES;
@@ -68,7 +68,7 @@ std::shared_ptr<VerifierInstance> ProtogalaxyRecursiveVerifier_<VerifierInstance
     // Step 7 - Compute evaluation of the perturbator
     const FF perturbator_evaluation = evaluate_perturbator(perturbator_coeffs, perturbator_challenge);
 
-    // Step 11 - Receive coefficients of combiner quotient
+    // Step 11 - Receive evaluations of the combiner quotient
     std::array<FF, COMBINER_QUOTIENT_LENGTH> combiner_quotient_evals;
     for (size_t idx = 0; idx < COMBINER_QUOTIENT_LENGTH; idx++) {
         combiner_quotient_evals[idx] =
@@ -110,11 +110,11 @@ std::shared_ptr<VerifierInstance> ProtogalaxyRecursiveVerifier_<VerifierInstance
      *  [B] = \sum_j c_j [P_{1,j}]
      *  [C] = \sum_j c_j [Q_j]
      * and then verifies:
-     *  [C] = (1 - gamma) * [B] + gamma * [A]
+     *  [C] = (1 - gamma) * [A] + gamma * [B]
      *
      * The cost of this verification is 3 size N MSMs with short scalars and 1 size 2 MSM with full scalars, amounting
      * to 3 * (33 * roundup(N/4) + 31) + 64 = 99 * roundup(N/4) + 157 ~ 25 * N + 157 rows (here we use that an MSM of
-     * size k with full scalars account for 33 * roundup(N/2) + 31 rows, which for k = 2 equals 64 rows)
+     * size k with full scalars accounts for 33 * roundup(N/2) + 31 rows, which for k = 2 equals 64 rows)
      *
      * Note: there are more efficient ways to evaluate this relationship if one solely wants to reduce number of
      * scalar muls, however we must also consider the number of ECCVM operations being executed, as each operation
@@ -128,12 +128,10 @@ std::shared_ptr<VerifierInstance> ProtogalaxyRecursiveVerifier_<VerifierInstance
     std::vector<Commitment> accumulator_commitments;
     std::vector<Commitment> instance_commitments;
     for (const auto& precomputed : get_data_to_fold<FOLDING_DATA::PRECOMPUTED_COMMITMENTS>()) {
-        BB_ASSERT_EQ(precomputed.size(), 2U);
         accumulator_commitments.emplace_back(precomputed[0]);
         instance_commitments.emplace_back(precomputed[1]);
     }
     for (const auto& witness : get_data_to_fold<FOLDING_DATA::WITNESS_COMMITMENTS>()) {
-        BB_ASSERT_EQ(witness.size(), 2U);
         accumulator_commitments.emplace_back(witness[0]);
         instance_commitments.emplace_back(witness[1]);
     }
@@ -142,10 +140,10 @@ std::shared_ptr<VerifierInstance> ProtogalaxyRecursiveVerifier_<VerifierInstance
     std::vector<Commitment> output_commitments;
     for (size_t i = 0; i < accumulator_commitments.size(); ++i) {
         // Out-of-circuit calculation to populate the witness values
-        const auto lhs_scalar = (FF(1) - combiner_challenge).get_value(); // L_0(\gamma)
-        const auto rhs_scalar = combiner_challenge.get_value();           // L_1(\gamma)
-        const auto lhs = accumulator_commitments[i].get_value();          // [P_{0,i}]
-        const auto rhs = instance_commitments[i].get_value();             // [P_{1,i}]
+        const auto lhs_scalar = lagranges[0].get_value();        // L_0(\gamma)
+        const auto rhs_scalar = lagranges[1].get_value();        // L_1(\gamma)
+        const auto lhs = accumulator_commitments[i].get_value(); // [P_{0,i}]
+        const auto rhs = instance_commitments[i].get_value();    // [P_{1,i}]
         const auto output =
             lhs * lhs_scalar + rhs * rhs_scalar; // [Q_i] := L_0(\gamma) * [P_{0,i}] + L_1(\gamma) * [P_{1,i}]
         // Add a new witness whose underlying value for an honest prover is [Q_i]
@@ -164,8 +162,10 @@ std::shared_ptr<VerifierInstance> ProtogalaxyRecursiveVerifier_<VerifierInstance
         batch_mul_transcript.template get_challenges<FF>(args);
     std::vector<FF> scalars(folding_challenges.begin(), folding_challenges.end());
 
-    // MSMs: edge cases are handled in the MSM only when the builder is Ultra. When the builder is mega, edge cases are
-    // handled by the ECCVM Compute [A] = \sum_i c_i [P_{0,i}]
+    // MSMs: note that edge cases are handled in the MSM only when the builder is Ultra. When the builder is mega, edge
+    // cases are handled by the ECCVM
+
+    // Compute [A] = \sum_i c_i [P_{0,i}]
     Commitment accumulator_sum = Commitment::batch_mul(accumulator_commitments,
                                                        scalars,
                                                        /*max_num_bits=*/0,
@@ -182,13 +182,13 @@ std::shared_ptr<VerifierInstance> ProtogalaxyRecursiveVerifier_<VerifierInstance
                                                   scalars,
                                                   /*max_num_bits=*/0,
                                                   /*handle_edge_cases=*/IsUltraBuilder<Builder>);
-    // Compute (1 - gamma) * [B] + gamma * [A]
+    // Compute (1 - gamma) * [A] + gamma * [B]
     Commitment folded_sum = Commitment::batch_mul({ accumulator_sum, instance_sum },
                                                   lagranges,
                                                   /*max_num_bits=*/0,
                                                   /*handle_edge_cases=*/IsUltraBuilder<Builder>);
 
-    // Enforce [C] = (1 - gamma) * [B] + gamma * [A]
+    // Enforce [C] = (1 - gamma) * [A] + gamma * [B]
     output_sum.x.assert_equal(folded_sum.x);
     output_sum.y.assert_equal(folded_sum.y);
     output_sum.is_point_at_infinity().assert_equal(folded_sum.is_point_at_infinity());
@@ -205,11 +205,12 @@ std::shared_ptr<VerifierInstance> ProtogalaxyRecursiveVerifier_<VerifierInstance
     virtual_log_n.fix_witness();
     accumulator->vk_and_hash->vk->log_circuit_size = virtual_log_n;
 
-    // Fold the relation parameters
+    // Fold the batching challenges (alphas)
     for (auto [combination, to_combine] : zip_view(accumulator->alphas, get_data_to_fold<FOLDING_DATA::ALPHAS>())) {
         combination = to_combine[0] + combiner_challenge * (to_combine[1] - to_combine[0]);
     }
 
+    // Fold the relation parameters
     for (auto [combination, to_combine] : zip_view(accumulator->relation_parameters.get_to_fold(),
                                                    get_data_to_fold<FOLDING_DATA::RELATION_PARAMETERS>())) {
         combination = to_combine[0] + combiner_challenge * (to_combine[1] - to_combine[0]);

--- a/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/protogalaxy_recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/protogalaxy_recursive_verifier.cpp
@@ -20,7 +20,7 @@ void ProtogalaxyRecursiveVerifier_<VerifierInstance>::run_oink_verifier_on_each_
     auto key = insts_to_fold[0];
     auto domain_separator = std::to_string(0);
 
-    // If the first instance to be folded is non-relaxed we need to complete it and generate the gate challenges
+    // If the first instance to be folded in pure we need to complete it and generate the gate challenges
     if (!key->is_complete) {
         OinkRecursiveVerifier_<Flavor> oink_verifier{ builder, key, transcript, domain_separator + '_' };
         oink_verifier.verify();
@@ -42,8 +42,8 @@ std::shared_ptr<VerifierInstance> ProtogalaxyRecursiveVerifier_<VerifierInstance
     const stdlib::Proof<Builder>& proof)
 {
     // The degree of the combiner quotient (K in the paper) is equal to deg(G) - deg(Z), where Z is the  vanishing
-    // polynomial of the domain 0, .., NUM_INSTANCES-1. Hence, deg(K) = deg(G) - NUM_INSTANCES and we need deg(G) + 1 -
-    // NUM_INSTANCES = BATCHED_EXTENDED_LENGTH - NUM_INSTANCES evaluations to represent it
+    // polynomial of the domain 0, .., NUM_INSTANCES-1. Hence, deg(K) = deg(G) - NUM_INSTANCES and we need
+    // deg(G) + 1 - NUM_INSTANCES = BATCHED_EXTENDED_LENGTH - NUM_INSTANCES evaluations to represent it
     static constexpr size_t COMBINER_QUOTIENT_LENGTH = BATCHED_EXTENDED_LENGTH - NUM_INSTANCES;
 
     // Step 1

--- a/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/protogalaxy_recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/protogalaxy_recursive_verifier.cpp
@@ -189,9 +189,11 @@ std::shared_ptr<VerifierInstance> ProtogalaxyRecursiveVerifier_<VerifierInstance
                                                   /*handle_edge_cases=*/IsUltraBuilder<Builder>);
 
     // Enforce [C] = (1 - gamma) * [A] + gamma * [B]
-    output_sum.x.assert_equal(folded_sum.x);
-    output_sum.y.assert_equal(folded_sum.y);
     output_sum.is_point_at_infinity().assert_equal(folded_sum.is_point_at_infinity());
+    output_sum.x.assert_equal(
+        BaseField::conditional_assign(output_sum.is_point_at_infinity(), output_sum.x, folded_sum.x));
+    output_sum.y.assert_equal(
+        BaseField::conditional_assign(output_sum.is_point_at_infinity(), output_sum.y, folded_sum.y));
 
     // Step 13. Update the target sum: e^{\ast} = F(\alpha) * L_0(\gamma) + Z(\gamma) * K(\gamma)
     accumulator->target_sum =

--- a/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/protogalaxy_recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/protogalaxy_recursive_verifier.cpp
@@ -191,6 +191,7 @@ std::shared_ptr<VerifierInstance> ProtogalaxyRecursiveVerifier_<VerifierInstance
     // Enforce [C] = (1 - gamma) * [B] + gamma * [A]
     output_sum.x.assert_equal(folded_sum.x);
     output_sum.y.assert_equal(folded_sum.y);
+    output_sum.is_point_at_infinity().assert_equal(folded_sum.is_point_at_infinity());
 
     // Step 13. Update the target sum: e^{\ast} = F(\alpha) * L_0(\gamma) + Z(\gamma) * K(\gamma)
     accumulator->target_sum =

--- a/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/protogalaxy_recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/protogalaxy_recursive_verifier.cpp
@@ -201,6 +201,7 @@ std::shared_ptr<VerifierInstance> ProtogalaxyRecursiveVerifier_<VerifierInstance
     accumulator->gate_challenges = update_gate_challenges(perturbator_challenge, accumulator->gate_challenges, deltas);
 
     // Define a constant virtual log circuit size for the accumulator
+    // TODO(https://github.com/AztecProtocol/barretenberg/issues/1545): Look into this @federicobarbacovi
     FF virtual_log_n = FF::from_witness(builder, CONST_PG_LOG_N);
     virtual_log_n.fix_witness();
     accumulator->vk_and_hash->vk->log_circuit_size = virtual_log_n;

--- a/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/protogalaxy_recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/protogalaxy_recursive_verifier.cpp
@@ -201,7 +201,9 @@ std::shared_ptr<VerifierInstance> ProtogalaxyRecursiveVerifier_<VerifierInstance
     accumulator->gate_challenges = update_gate_challenges(perturbator_challenge, accumulator->gate_challenges, deltas);
 
     // Define a constant virtual log circuit size for the accumulator
-    // TODO(https://github.com/AztecProtocol/barretenberg/issues/1545): Look into this @federicobarbacovi
+    // This is just a placeholder: the decider verifier (PG decider) uses a constant value as the maximum dyadic size of
+    // the circuits that have been folded using PG. The constant is Flavor::VIRTUAL_LOG_N, which is always bigger or
+    // equal than CONST_PG_LOG_N. See also https://github.com/AztecProtocol/barretenberg/issues/1545 for more details.
     FF virtual_log_n = FF::from_witness(builder, CONST_PG_LOG_N);
     virtual_log_n.fix_witness();
     accumulator->vk_and_hash->vk->log_circuit_size = virtual_log_n;

--- a/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/protogalaxy_recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/protogalaxy_recursive_verifier.cpp
@@ -19,6 +19,8 @@ void ProtogalaxyRecursiveVerifier_<VerifierInstance>::run_oink_verifier_on_each_
     transcript->load_proof(proof);
     auto key = insts_to_fold[0];
     auto domain_separator = std::to_string(0);
+
+    // If the first instance to be folded in non-relaxed we need to complete it and generate the gate challenges
     if (!key->is_complete) {
         OinkRecursiveVerifier_<Flavor> oink_verifier{ builder, key, transcript, domain_separator + '_' };
         oink_verifier.verify();
@@ -28,6 +30,7 @@ void ProtogalaxyRecursiveVerifier_<VerifierInstance>::run_oink_verifier_on_each_
             transcript->template get_powers_of_challenge<FF>(domain_separator + "_gate_challenge", CONST_PG_LOG_N);
     }
 
+    // Complete the second instance (Step 1 of the paper)
     key = insts_to_fold[1];
     domain_separator = std::to_string(1);
     OinkRecursiveVerifier_<Flavor> oink_verifier{ builder, key, transcript, domain_separator + '_' };
@@ -38,72 +41,91 @@ template <class VerifierInstance>
 std::shared_ptr<VerifierInstance> ProtogalaxyRecursiveVerifier_<VerifierInstance>::verify_folding_proof(
     const stdlib::Proof<Builder>& proof)
 {
+    // The degree of the combiner quotient (K in the paper) is equal to deg(G) - deg(Z), where Z is the vanishing
+    // polynomial of the domain 0, .., NUM_INSTANCES-1. Hence, deg(K) = deg(G) - NUM_INSTANCES and we need deg(G) + 1 -
+    // NUM_INSTANCES = BATCHED_EXTENDED_LENGTH - NUM_INSTANCES evaluations to represent it
     static constexpr size_t COMBINER_QUOTIENT_LENGTH = BATCHED_EXTENDED_LENGTH - NUM_INSTANCES;
 
+    // Step 1
     run_oink_verifier_on_each_incomplete_instance(proof);
 
     const std::shared_ptr<VerifierInstance>& accumulator = insts_to_fold[0];
 
-    // Perturbator round
+    // Step 2 - 3
     const std::vector<FF> deltas = transcript->template get_powers_of_challenge<FF>("delta", CONST_PG_LOG_N);
+
+    // Step 5 - Receive non-constant coefficients of the perturbator
+    // As n = 2^CONST_PG_LOG_N, the perturbator has degree equal to log(n) = CONST_PG_LOG_N
     std::vector<FF> perturbator_coeffs(CONST_PG_LOG_N + 1, 0);
+    perturbator_coeffs[0] = accumulator->target_sum;
     for (size_t idx = 1; idx <= CONST_PG_LOG_N; idx++) {
         perturbator_coeffs[idx] = transcript->template receive_from_prover<FF>("perturbator_" + std::to_string(idx));
     }
+
+    // Step 6 - Compute perturbator challenge
     const FF perturbator_challenge = transcript->template get_challenge<FF>("perturbator_challenge");
 
-    // Combiner quotient round
-    perturbator_coeffs[0] = accumulator->target_sum;
+    // Step 7 - Compute evaluation of the perturbator
     const FF perturbator_evaluation = evaluate_perturbator(perturbator_coeffs, perturbator_challenge);
 
+    // Step 11 - Receive coefficients of combiner quotient
     std::array<FF, COMBINER_QUOTIENT_LENGTH> combiner_quotient_evals;
     for (size_t idx = 0; idx < COMBINER_QUOTIENT_LENGTH; idx++) {
         combiner_quotient_evals[idx] =
             transcript->template receive_from_prover<FF>("combiner_quotient_" + std::to_string(idx + NUM_INSTANCES));
     }
 
-    // Folding
+    // Step 12 - Compute combiner quotient challenge \gamma (used to generate folding output)
     const FF combiner_challenge = transcript->template get_challenge<FF>("combiner_quotient_challenge");
+
+    // Folding
+    // A VerifierInstance is made up of three components: the commitments to the prover polynomials, the relation
+    // parameters, and the batching challenges. We have to fold each of these components. The commitments require an
+    // MSM, relation parameters and batching challenges require only field operations.
+
+    // Compute K(\gamma)
     const Univariate<FF, BATCHED_EXTENDED_LENGTH, NUM_INSTANCES> combiner_quotient(combiner_quotient_evals);
     const FF combiner_quotient_at_challenge = combiner_quotient.evaluate(combiner_challenge);
 
+    // Compute Z(\gamma)
     const FF vanishing_polynomial_at_challenge = combiner_challenge * (combiner_challenge - FF(1));
+
+    // Compute L_0(\gamma) and L_1(\gamma)
     const std::vector<FF> lagranges = { FF(1) - combiner_challenge, combiner_challenge };
 
-    /*
-        Fold the commitments
-        Note: we use additional challenges to reduce the amount of elliptic curve work performed by the ECCVM
-
-        For an accumulator commitment [P'] and an instance commitment [P] , we compute folded commitment [P''] where
-        [P''] = L0(combiner_challenge).[P'] + L1(combiner_challenge).[P]
-        For the size-2 case this becomes:
-        P'' = (1 - combiner_challenge).[P'] + combiner_challenge.[P] = combiner_challenge.[P - P'] + [P']
-
-        This requires a large number of size-1 scalar muls (about 53)
-        The ECCVM can perform a size-k MSM in 32 + roundup((k/4)) rows, if each scalar multiplier is <128 bits
-        i.e. number of ECCVM rows = 53 * 64 = painful
-
-        To optimize, we generate challenges `c_i` for each commitment and evaluate the relation:
-
-        [A] = \sum c_i.[P_i]
-        [B] = \sum c_i.[P'_i]
-        [C] = \sum c_i.[P''_i]
-        and validate
-        (1 - combiner_challenge).[A] + combiner_challenge.[B] == [C]
-
-
-        This reduces the relation to 3 large MSMs where each commitment requires 3 size-128bit scalar
-       multiplications For a flavor with 53 instance/witness commitments, this is 53 * 24 rows
-
-        Note: there are more efficient ways to evaluate this relationship if one solely wants to reduce number of
-       scalar muls, however we must also consider the number of ECCVM operations being executed, as each operation
-       incurs a cost in the translator circuit Each ECCVM opcode produces 5 rows in the translator circuit, which is
-       approx. equivalent to 9 ECCVM rows. Something to pay attention to
-    */
+    /**
+     * The verifier must compute \phi^{\ast} = L0(\gamma) \phi_0 + L_1(\gamma) \phi_1 = \phi_0 + \gamma * (\phi_1 -
+     * \phi_0). This amounts to compute, for each commitment contained in \phi_i, a scalar mul of size 1 and an
+     * addition.
+     *
+     * The ECCVM handles a size k MSM with scalars of size at most 128 bits in 33 * roundup(k / 4) + 31 rows. Hence, if
+     * N is the number of commitments contained in a committed instance \phi_i, performing all the scalar
+     * multiplications requires N * (33 + 31) = 64 * N rows.
+     *
+     * To optimize the calculation, we make the circuit prover (do not confuse it with the Protogalaxy prover) supply
+     * the purported folded commitment, and make the verifier validate those commitments. Write [P_{i,j}] for the
+     * commitments contained in \phi_i, and [Q_j] for the commitments supplied by the circuit prover. Then, the
+     * Protogalaxy verifier samples random challenges c_1, .., c_N, computes:
+     *  [A] = \sum_j c_j [P_{0,j}]
+     *  [B] = \sum_j c_j [P_{1,j}]
+     *  [C] = \sum_j c_j [Q_j]
+     * and then verifies:
+     *  [C] = (1 - gamma) * [B] + gamma * [A]
+     *
+     * The cost of this verification is 3 size N MSMs with short scalars and 1 size 2 MSM with full scalars, amounting
+     * to 3 * (33 * roundup(N/4) + 31) + 64 = 99 * roundup(N/4) + 157 ~ 25 * N + 157 rows (here we use that an MSM of
+     * size k with full scalars account for 33 * roundup(N/2) + 31 rows, which for k = 2 equal 64 rows)
+     *
+     * Note: there are more efficient ways to evaluate this relationship if one solely wants to reduce number of
+     * scalar muls, however we must also consider the number of ECCVM operations being executed, as each operation
+     * incurs a cost in the translator circuit Each ECCVM opcode produces 5 rows in the translator circuit, which is
+     * approx. equivalent to 9 ECCVM rows.
+     */
 
     // New transcript for challenge generation
     Transcript batch_mul_transcript = transcript->branch_transcript();
 
+    // Prepare accumulator and instance commitments for MSM calculation
     std::vector<Commitment> accumulator_commitments;
     std::vector<Commitment> instance_commitments;
     for (const auto& precomputed : get_data_to_fold<FOLDING_DATA::PRECOMPUTED_COMMITMENTS>()) {
@@ -117,57 +139,64 @@ std::shared_ptr<VerifierInstance> ProtogalaxyRecursiveVerifier_<VerifierInstance
         instance_commitments.emplace_back(witness[1]);
     }
 
-    // derive output commitment witnesses
+    // Construct witnesses holding the purported values of the folding
     std::vector<Commitment> output_commitments;
     for (size_t i = 0; i < accumulator_commitments.size(); ++i) {
-        const auto lhs_scalar = (FF(1) - combiner_challenge).get_value();
-        const auto rhs_scalar = combiner_challenge.get_value();
-
-        const auto lhs = accumulator_commitments[i].get_value();
-
-        const auto rhs = instance_commitments[i].get_value();
-        const auto output = lhs * lhs_scalar + rhs * rhs_scalar;
+        // Out-of-circuit calculation to populate the witness values
+        const auto lhs_scalar = (FF(1) - combiner_challenge).get_value(); // L_0(\gamma)
+        const auto rhs_scalar = combiner_challenge.get_value();           // L_1(\gamma)
+        const auto lhs = accumulator_commitments[i].get_value();          // [P_{0,i}]
+        const auto rhs = instance_commitments[i].get_value();             // [P_{1,i}]
+        const auto output =
+            lhs * lhs_scalar + rhs * rhs_scalar; // [Q_i] := L_0(\gamma) * [P_{0,i}] + L_1(\gamma) * [P_{1,i}]
+        // Add a new witness whose underlying value (for an honest prover) is [Q_i]
         output_commitments.emplace_back(Commitment::from_witness(builder, output));
-        // Add the output commitment to the transcript to ensure the they can't be spoofed
+        // Add the output commitment to the transcript to ensure they can't be spoofed
         batch_mul_transcript.add_to_hash_buffer("new_accumulator_commitment_" + std::to_string(i),
                                                 output_commitments[i]);
     }
 
+    // Generate the challenges c_i
     std::array<std::string, Flavor::NUM_FOLDED_ENTITIES> args;
     for (size_t idx = 0; idx < Flavor::NUM_FOLDED_ENTITIES; ++idx) {
-        args[idx] = "accumulator_combination_challenges" + std::to_string(idx);
+        args[idx] = "accumulator_combination_challenges_" + std::to_string(idx);
     }
     std::array<FF, Flavor::NUM_FOLDED_ENTITIES> folding_challenges =
         batch_mul_transcript.template get_challenges<FF>(args);
     std::vector<FF> scalars(folding_challenges.begin(), folding_challenges.end());
 
+    // Compute [A] = \sum_i c_i [P_{0,i}]
     Commitment accumulator_sum = Commitment::batch_mul(accumulator_commitments,
                                                        scalars,
                                                        /*max_num_bits=*/0,
                                                        /*handle_edge_cases=*/IsUltraBuilder<Builder>);
 
+    // Compute [B] = \sum_i c_i [P_{1,i}]
     Commitment instance_sum = Commitment::batch_mul(instance_commitments,
                                                     scalars,
                                                     /*max_num_bits=*/0,
                                                     /*handle_edge_cases=*/IsUltraBuilder<Builder>);
 
+    // Compute [C] = \sum_i c_i [Q_i]
     Commitment output_sum = Commitment::batch_mul(output_commitments,
                                                   scalars,
                                                   /*max_num_bits=*/0,
                                                   /*handle_edge_cases=*/IsUltraBuilder<Builder>);
-
+    // Compute (1 - gamma) * [B] + gamma * [A]
     Commitment folded_sum = Commitment::batch_mul({ accumulator_sum, instance_sum },
                                                   lagranges,
                                                   /*max_num_bits=*/0,
                                                   /*handle_edge_cases=*/IsUltraBuilder<Builder>);
 
+    // Enforce [C] = (1 - gamma) * [B] + gamma * [A]
     output_sum.x.assert_equal(folded_sum.x);
     output_sum.y.assert_equal(folded_sum.y);
 
-    // Compute next folding parameters
+    // Step 13. Update the target sum: e^{\ast} = F(\alpha) * L_0(\gamma) + Z(\gamma) * K(\gamma)
     accumulator->target_sum =
         perturbator_evaluation * lagranges[0] + vanishing_polynomial_at_challenge * combiner_quotient_at_challenge;
 
+    // Step 8. Update gate challenges: beta^{\ast} = \beta + \alpha * \deltas
     accumulator->gate_challenges = update_gate_challenges(perturbator_challenge, accumulator->gate_challenges, deltas);
 
     // Define a constant virtual log circuit size for the accumulator
@@ -185,11 +214,13 @@ std::shared_ptr<VerifierInstance> ProtogalaxyRecursiveVerifier_<VerifierInstance
         combination = to_combine[0] + combiner_challenge * (to_combine[1] - to_combine[0]);
     }
 
+    // Update the precomputed commitments of the accumulator
     auto accumulator_vkey = accumulator->vk_and_hash->vk->get_all();
     for (size_t i = 0; i < Flavor::NUM_PRECOMPUTED_ENTITIES; ++i) {
         accumulator_vkey[i] = output_commitments[i];
     }
 
+    // Update the witness commitments of the accumulator
     auto accumulator_witnesses = accumulator->witness_commitments.get_all();
     for (size_t i = 0; i < Flavor::NUM_WITNESS_ENTITIES; ++i) {
         accumulator_witnesses[i] = output_commitments[i + accumulator_vkey.size()];

--- a/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/protogalaxy_recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/protogalaxy_recursive_verifier.cpp
@@ -189,11 +189,7 @@ std::shared_ptr<VerifierInstance> ProtogalaxyRecursiveVerifier_<VerifierInstance
                                                   /*handle_edge_cases=*/IsUltraBuilder<Builder>);
 
     // Enforce [C] = (1 - gamma) * [A] + gamma * [B]
-    output_sum.is_point_at_infinity().assert_equal(folded_sum.is_point_at_infinity());
-    output_sum.x.assert_equal(
-        BaseField::conditional_assign(output_sum.is_point_at_infinity(), output_sum.x, folded_sum.x));
-    output_sum.y.assert_equal(
-        BaseField::conditional_assign(output_sum.is_point_at_infinity(), output_sum.y, folded_sum.y));
+    output_sum.incomplete_assert_equal(folded_sum);
 
     // Step 13. Update the target sum: e^{\ast} = F(\alpha) * L_0(\gamma) + Z(\gamma) * K(\gamma)
     accumulator->target_sum =

--- a/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/protogalaxy_recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/protogalaxy_recursive_verifier.cpp
@@ -149,7 +149,7 @@ std::shared_ptr<VerifierInstance> ProtogalaxyRecursiveVerifier_<VerifierInstance
         const auto rhs = instance_commitments[i].get_value();             // [P_{1,i}]
         const auto output =
             lhs * lhs_scalar + rhs * rhs_scalar; // [Q_i] := L_0(\gamma) * [P_{0,i}] + L_1(\gamma) * [P_{1,i}]
-        // Add a new witness whose underlying value (for an honest prover) is [Q_i]
+        // Add a new witness whose underlying value for an honest prover is [Q_i]
         output_commitments.emplace_back(Commitment::from_witness(builder, output));
         // Add the output commitment to the transcript to ensure they can't be spoofed
         batch_mul_transcript.add_to_hash_buffer("new_accumulator_commitment_" + std::to_string(i),

--- a/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/protogalaxy_recursive_verifier.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/protogalaxy_recursive_verifier.hpp
@@ -58,18 +58,25 @@ template <class VerifierInstance> class ProtogalaxyRecursiveVerifier_ {
     };
 
     /**
-     * @brief Process the public data ϕ for the decider verification keys to be folded.
+     * @brief Process the public data \f$\phi\f$ for the decider verification keys to be folded.
      */
     void run_oink_verifier_on_each_incomplete_instance(const std::vector<FF>&);
 
     /**
-     * @brief Run the folding protocol on the verifier side to establish whether the public data ϕ of the new
+     * @brief Run the folding protocol on the verifier side to establish whether the public data \f$\phi\f$ of the new
      * accumulator, received from the prover is the same as that produced by the verifier.
      *
-     * @details In the recursive setting this function doesn't return anything because the equality checks performed by
-     * the recursive verifier, ensuring the folded ϕ*, e* and β* on the verifier side correspond to what has been sent
-     * by the prover, are expressed as constraints.
+     * @note We update the first instance with which the verifier was constructed in-place. That is, the result of the
+     * folding verification is stored in insts_to_fold[0] after the execution of this function.
      *
+     * @note In the recursive setting this function doesn't return anything because the equality checks performed by
+     * the recursive verifier, ensuring the folded \f$\phi^{\ast}\f$, \f$e^{\ast}\f$ and \f$\beta^{\ast}\f$ on the
+     * verifier side correspond to what has been sent by the prover, are expressed as constraints.
+     *
+     * @details We run the Protogalaxy verifier with parameters k = 1 (we fold one instance/accumulator with an
+     * instance) , n = 2^CONST_PG_LOG_N, and d = (Flavor::MAX_TOTAL_RELATION_LENGTH - 1) + 1 (the first term is the
+     * maximum of the degrees of the subrelations considering relation parameters as variables, while the second term
+     * comes from the batching challenges).
      */
     std::shared_ptr<VerifierInstance> verify_folding_proof(const stdlib::Proof<Builder>&);
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/protogalaxy_recursive_verifier.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/protogalaxy_recursive_verifier.hpp
@@ -19,6 +19,7 @@ template <class VerifierInstance> class ProtogalaxyRecursiveVerifier_ {
     using Flavor = typename VerifierInstance::Flavor;
     using FF = typename Flavor::FF;
     using Commitment = typename Flavor::Commitment;
+    using BaseField = typename Commitment::BaseField;
     using VKAndHash = typename Flavor::VKAndHash;
     using VerifierInstances = std::array<std::shared_ptr<VerifierInstance>, NUM_INSTANCES>;
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/protogalaxy_recursive_verifier.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/protogalaxy_recursive_verifier.hpp
@@ -58,13 +58,13 @@ template <class VerifierInstance> class ProtogalaxyRecursiveVerifier_ {
     };
 
     /**
-     * @brief Process the public data \f$\phi\f$ for the decider verification keys to be folded.
+     * @brief Process the public data \f$\phi\f$ for the verification keys to be folded.
      */
     void run_oink_verifier_on_each_incomplete_instance(const std::vector<FF>&);
 
     /**
      * @brief Run the folding protocol on the verifier side to establish whether the public data \f$\phi\f$ of the new
-     * accumulator, received from the prover is the same as that produced by the verifier.
+     * accumulator received from the prover is the same as that produced by the verifier.
      *
      * @note We update the first instance with which the verifier was constructed in-place. That is, the result of the
      * folding verification is stored in insts_to_fold[0] after the execution of this function.
@@ -89,28 +89,20 @@ template <class VerifierInstance> class ProtogalaxyRecursiveVerifier_ {
     };
 
     /**
-     * @brief Get data to be folded grouped by commitment index
-     * @example Assume the VKs are arranged as follows
-     *           VK 0    VK 1    VK 2    VK 3
-     *           q_c_0   q_c_1   q_c_2   q_c_3
-     *           q_l_0   q_l_1   q_l_2   q_l_3
-     *             ⋮        ⋮        ⋮       ⋮
-     * If we wanted to extract the commitments from the verification keys in order to fold them, we would pass to the
-     * function the type parameter FOLDING_DATA::PRECOMPUTED_COMMITMENTS, and the function would return
-     * {{q_c_0, q_c_1, q_c_2, q_c_3}, {q_l_0, q_l_1, q_l_2, q_l_3},...}. Here the "commitment index" is the index of the
+     * @brief Get data to be folded grouped by commitment index. Here the "commitment index" is the index of the
      * row in the matrix whose columns are given be the instance components to be folded.
      *
      * @tparam FoldingData The type of the parameter to be folded
      */
     template <FOLDING_DATA FoldingData> auto get_data_to_fold() const
     {
-        using PrecomputeCommDataType = RefArray<Commitment, Flavor::NUM_PRECOMPUTED_ENTITIES>;
+        using PrecomputedCommDataType = RefArray<Commitment, Flavor::NUM_PRECOMPUTED_ENTITIES>;
         using WitnessCommitmentsDataType = RefArray<Commitment, Flavor::NUM_WITNESS_ENTITIES>;
         using AlphasDataType = Flavor::SubrelationSeparators;
         using RelationParametersDataType = RefArray<FF, RelationParameters<FF>::NUM_TO_FOLD>;
         using DataType = std::conditional_t<
             FoldingData == FOLDING_DATA::PRECOMPUTED_COMMITMENTS,
-            PrecomputeCommDataType,
+            PrecomputedCommDataType,
             std::conditional_t<
                 FoldingData == FOLDING_DATA::WITNESS_COMMITMENTS,
                 WitnessCommitmentsDataType,
@@ -139,9 +131,9 @@ template <class VerifierInstance> class ProtogalaxyRecursiveVerifier_ {
 
         const size_t num_to_fold = data[0].size();
         std::vector<std::vector<ReturnValue>> result(num_to_fold, std::vector<ReturnValue>(NUM_INSTANCES));
-        for (size_t idx = 0; auto& commitment_at_idx : result) {
-            commitment_at_idx[0] = data[0][idx];
-            commitment_at_idx[1] = data[1][idx];
+        for (size_t idx = 0; auto& data_at_idx : result) {
+            data_at_idx[0] = data[0][idx];
+            data_at_idx[1] = data[1][idx];
             idx++;
         }
         return result;

--- a/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/recursive_verifier_instance.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/recursive_verifier_instance.hpp
@@ -65,6 +65,7 @@ template <IsRecursiveFlavor Flavor_> class RecursiveVerifierInstance_ {
         : builder(builder)
         , vk_and_hash(vk_and_hash) {};
 
+    // Constructor from native verifier instance
     RecursiveVerifierInstance_(Builder* builder, std::shared_ptr<NativeVerifierInstance> verification_key)
         : RecursiveVerifierInstance_(builder, verification_key->vk)
     {
@@ -145,6 +146,7 @@ template <IsRecursiveFlavor Flavor_> class RecursiveVerifierInstance_ {
 
     FF hash_through_transcript(const std::string& domain_separator, Transcript& transcript) const
     {
+        BB_ASSERT_EQ(is_complete, true, "Trying to hash a recursive verifier instance that has not been completed.");
         transcript.add_to_independent_hash_buffer(domain_separator + "verifier_inst_log_circuit_size",
                                                   this->vk_and_hash->vk->log_circuit_size);
         transcript.add_to_independent_hash_buffer(domain_separator + "verifier_inst_num_public_inputs",

--- a/barretenberg/cpp/src/barretenberg/transcript/transcript.hpp
+++ b/barretenberg/cpp/src/barretenberg/transcript/transcript.hpp
@@ -440,7 +440,7 @@ template <typename TranscriptParams> class BaseTranscript {
 
     /**
      * @brief Given δ, compute the vector [δ, δ^2,..., δ^2^num_powers].
-     * @details This is Step 2 of the protocol as written in the paper.
+     * @details This is Step 2 of the protocol as written in Protogalaxy the paper.
      */
     template <typename ChallengeType>
     std::vector<ChallengeType> compute_round_challenge_pows(const size_t num_powers,

--- a/barretenberg/cpp/src/barretenberg/transcript/transcript.hpp
+++ b/barretenberg/cpp/src/barretenberg/transcript/transcript.hpp
@@ -440,7 +440,7 @@ template <typename TranscriptParams> class BaseTranscript {
 
     /**
      * @brief Given δ, compute the vector [δ, δ^2,..., δ^2^num_powers].
-     * @details This is Step 2 of the protocol as written in Protogalaxy the paper.
+     * @details This is Step 2 of the protocol as written in the Protogalaxy paper.
      */
     template <typename ChallengeType>
     std::vector<ChallengeType> compute_round_challenge_pows(const size_t num_powers,

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/prover_instance.hpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/prover_instance.hpp
@@ -33,7 +33,7 @@ namespace bb {
  *
  * @details A ProverInstance is the equivalent of \f$\omega\f$ in the Protogalaxy paper.
  *
- * Our arithmetisation works as follows. The Flavor defines \f$fM\f$ (Flavor::NUM_ALL_ENTITIES) and a series of
+ * Our arithmetisation works as follows. The Flavor defines \f$ M\f$ (Flavor::NUM_ALL_ENTITIES) and a series of
  * relations
  * \f$R_1, \dots, R_n\f$ (Flavor::Relations_). Each relation is made up by a series of subrelations: \f$R_i =
  * (R_{i,1}, \dots, R_{i,r_i})\f$.

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/prover_instance.hpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/prover_instance.hpp
@@ -24,13 +24,41 @@
 #include <chrono>
 
 namespace bb {
+
 /**
- * @brief  A ProverInstance is normally constructed from a finalized circuit and it contains all the information
- * required by an Mega Honk prover to create a proof. A ProverInstance is also the result of running the
+ * @brief A ProverInstance is normally constructed from a finalized circuit and it contains all the information
+ * required by a Mega Honk prover to create a proof. A ProverInstance is also the result of running the
  * Protogalaxy prover, in which case it becomes a relaxed counterpart with the folding parameters (target sum and gate
  * challenges set to non-zero values).
  *
- * @details This is the equivalent of ω in the paper.
+ * @details A ProverInstance is the equivalent of \f$\omega\f$ in the Protogalaxy paper.
+ *
+ * Our arithmetisation works as follows. The Flavor defines \f$fM\f$ (Flavor::NUM_ALL_ENTITIES) and a series of
+ * relations
+ * \f$R_1, \dots, R_n\f$ (Flavor::Relations_). Each relation is made up by a series of subrelations: \f$R_i =
+ * (R_{i,1}, \dots, R_{i,n_i})\f$.
+ *
+ * Write \f$p_1, \dots, p_M\f$ for the prover polynomials and \f$p_{i,k}\f$ for the \f$k\f$-th coefficient of \f$p_i\f$.
+ * Let \f$n\f$ be the max degree of the prover polynomials. A non-relaxed ProverInstance is valid if for all \f$i, j,
+ * k\f$ we have \f$R_{i,j}(p_{1,k}, \dots, p_{M,k}) = 0\f$.
+ *
+ * Instead of checking each equality separately, we batch them using challenges that we call `alphas`. Thus, a
+ * ProverInstance is valid if for each \f$k = 0, \dots, n\f$.
+ * \f[
+ *  f_k(\omega) := \sum_{i, j} \alpha_{i,j} R_{i,j}(p_{1,k}, \dots, p_{M,k}) = 0
+ * \f]
+ *
+ * Instead of checking each equality separately, we once again batch them using challenges. These challenges are the
+ * \f$pow_i(\beta)\f$ in the Protogalaxy paper, and are derived using the vector `gate_challenges` as the vector
+ * \f$\beta\f$. Write \f$gc\f$ for the vector `gate_challenges`. Then, a ProverInstance is valid if
+ * \f[
+ *  \sum_{k} pow_k(gc) f_k(\omega) = 0
+ * \f]
+ * The equation is modified for a relaxed ProverInstance to
+ * \f[
+ *  \sum_{k} pow_k(gc) f_k(\omega) = ts
+ * \f]
+ * where we write \f$ts\f$ for the vector `target_sum`.
  */
 
 template <IsUltraOrMegaHonk Flavor_> class ProverInstance_ {

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/prover_instance.hpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/prover_instance.hpp
@@ -33,14 +33,14 @@ namespace bb {
  *
  * @details A ProverInstance is the equivalent of \f$\omega\f$ in the Protogalaxy paper.
  *
- * Our arithmetisation works as follows. The Flavor defines \f$M\f$ (Flavor::NUM_ALL_ENTITIES) and a series of
+ * Our arithmetization works as follows. The Flavor defines \f$fM\f$ (Flavor::NUM_ALL_ENTITIES) and a series of
  * relations
  * \f$R_1, \dots, R_n\f$ (Flavor::Relations_). Each relation is made up by a series of subrelations: \f$R_i =
  * (R_{i,1}, \dots, R_{i,r_i})\f$.
  *
  * Write \f$p_1, \dots, p_M\f$ for the prover polynomials and \f$p_{i,k}\f$ for the \f$k\f$-th coefficient of \f$p_i\f$.
  * Write \f$\theta_1, \dots, \theta_6\f$ for the relation parameters. Let \f$n\f$ be the max degree of the prover
- * polynomials. A non-relaxed ProverInstance is valid if for all \f$i, j, k\f$ we have \f$R_{i,j}(p_{1,k}, \dots,
+ * polynomials. A pure ProverInstance is valid if for all \f$i, j, k\f$ we have \f$R_{i,j}(p_{1,k}, \dots,
  * p_{M,k}, \theta_1, \dots, \theta_6) = 0\f$.
  *
  * Instead of checking each equality separately, we batch them using challenges that we call `alphas`. Thus, a

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/prover_instance.hpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/prover_instance.hpp
@@ -36,16 +36,17 @@ namespace bb {
  * Our arithmetisation works as follows. The Flavor defines \f$fM\f$ (Flavor::NUM_ALL_ENTITIES) and a series of
  * relations
  * \f$R_1, \dots, R_n\f$ (Flavor::Relations_). Each relation is made up by a series of subrelations: \f$R_i =
- * (R_{i,1}, \dots, R_{i,n_i})\f$.
+ * (R_{i,1}, \dots, R_{i,r_i})\f$.
  *
  * Write \f$p_1, \dots, p_M\f$ for the prover polynomials and \f$p_{i,k}\f$ for the \f$k\f$-th coefficient of \f$p_i\f$.
- * Let \f$n\f$ be the max degree of the prover polynomials. A non-relaxed ProverInstance is valid if for all \f$i, j,
- * k\f$ we have \f$R_{i,j}(p_{1,k}, \dots, p_{M,k}) = 0\f$.
+ * Write \f$\theta_1, \dots, \theta_6\f$ for the relation parameters. Let \f$n\f$ be the max degree of the prover
+ * polynomials. A non-relaxed ProverInstance is valid if for all \f$i, j, k\f$ we have \f$R_{i,j}(p_{1,k}, \dots,
+ * p_{M,k}, \theta_1, \dots, \theta_6) = 0\f$.
  *
  * Instead of checking each equality separately, we batch them using challenges that we call `alphas`. Thus, a
  * ProverInstance is valid if for each \f$k = 0, \dots, n\f$.
  * \f[
- *  f_k(\omega) := \sum_{i, j} \alpha_{i,j} R_{i,j}(p_{1,k}, \dots, p_{M,k}) = 0
+ *  f_k(\omega) := \sum_{i, j} \alpha_{i,j} R_{i,j}(p_{1,k}, \dots, p_{M,k}, \theta_1, \dots, \theta_6) = 0
  * \f]
  *
  * Instead of checking each equality separately, we once again batch them using challenges. These challenges are the
@@ -59,6 +60,10 @@ namespace bb {
  *  \sum_{k} pow_k(gc) f_k(\omega) = ts
  * \f]
  * where we write \f$ts\f$ for the vector `target_sum`.
+ *
+ * Hence, the correspondence between the class below and the Protogalaxy paper is \f$\omega = (p_1, \dots, p_M, ,
+ * \theta_1, \dots, \theta_6, \alpha_{1,1}, \dots, \alpha_{n,r_n})\f$, \f$\beta\f$ are the `gate_challenges`, and
+ * \f$e\f$ is `target_sum`.
  */
 
 template <IsUltraOrMegaHonk Flavor_> class ProverInstance_ {

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/prover_instance.hpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/prover_instance.hpp
@@ -33,7 +33,7 @@ namespace bb {
  *
  * @details A ProverInstance is the equivalent of \f$\omega\f$ in the Protogalaxy paper.
  *
- * Our arithmetisation works as follows. The Flavor defines \f$ M\f$ (Flavor::NUM_ALL_ENTITIES) and a series of
+ * Our arithmetisation works as follows. The Flavor defines \f$M\f$ (Flavor::NUM_ALL_ENTITIES) and a series of
  * relations
  * \f$R_1, \dots, R_n\f$ (Flavor::Relations_). Each relation is made up by a series of subrelations: \f$R_i =
  * (R_{i,1}, \dots, R_{i,r_i})\f$.

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/prover_instance.hpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/prover_instance.hpp
@@ -97,7 +97,7 @@ template <IsUltraOrMegaHonk Flavor_> class ProverInstance_ {
 
     HonkProof ipa_proof; // utilized only for UltraRollupFlavor
 
-    bool from_first_instance = false; // whether this instance is the first one
+    bool is_relaxed_instance = false; // whether this instance is relaxed or not
     bool is_complete = false;         // whether this instance has been completely populated
     std::vector<uint32_t> memory_read_records;
     std::vector<uint32_t> memory_write_records;

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/verifier_instance.hpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/verifier_instance.hpp
@@ -13,7 +13,7 @@ namespace bb {
 /**
  * @brief The VerifierInstance encapsulates all the necessary information for a Mega Honk Verifier to verify a
  * proof (sumcheck + Shplemini). In the context of folding, this is returned by the Protogalaxy verifier with non-zero
- * target sum and gate challenges.
+ * target sum.
  *
  * @details This is \f$\phi\f$ in the Protogalaxy paper. It is the committed version of a ProverInstance_. With the
  * notation used in ProverInstance_, a prover instance is \f$\omega = (p_1, \dots, p_M, \theta_1, \dots, \theta_6,

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/verifier_instance.hpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/verifier_instance.hpp
@@ -55,6 +55,8 @@ template <IsUltraOrMegaHonk Flavor_> class VerifierInstance_ {
 
     FF hash_through_transcript(const std::string& domain_separator, Transcript& transcript) const
     {
+        BB_ASSERT_EQ(is_complete, true, "Trying to hash a verifier instance that has not been completed.");
+
         transcript.add_to_independent_hash_buffer(domain_separator + "verifier_inst_log_circuit_size",
                                                   this->vk->log_circuit_size);
         transcript.add_to_independent_hash_buffer(domain_separator + "verifier_inst_num_public_inputs",

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/verifier_instance.hpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/verifier_instance.hpp
@@ -19,7 +19,7 @@ namespace bb {
  * notation used in ProverInstance_, a prover instance is \f$\omega = (p_1, \dots, p_M, \theta_1, \dots, \theta_6,
  * \alpha_{1,1}, \dots, \alpha_{n,r_n})\f$ where the \f$p_i\f$'s are the prover polynomials, the \f$\theta_i\f$'s are
  * the relation parameters, and the \f$\alpha_{i,j}\f$'s are the subrelation batching parameters. Then, \f$\phi\f$ is
- * given by \f$\omega = ([p_1], \dots, [p_M], \alpha_{1,1}, \dots, \alpha_{n,r_n}, \theta_1, \dots, \theta_6)\f$m where
+ * given by \f$\omega = ([p_1], \dots, [p_M], \theta_1, \dots, \theta_6, \alpha_{1,1}, \dots, \alpha_{n,r_n})\f$m where
  * [p_i] denotes the commitment to the i-th prover polynomial.
  */
 template <IsUltraOrMegaHonk Flavor_> class VerifierInstance_ {

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/verifier_instance.hpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/verifier_instance.hpp
@@ -15,7 +15,12 @@ namespace bb {
  * proof (sumcheck + Shplemini). In the context of folding, this is returned by the Protogalaxy verifier with non-zero
  * target sum and gate challenges.
  *
- * @details This is ϕ in the paper.
+ * @details This is \f$\phi\f$ in the Protogalaxy paper. It is the committed version of a ProverInstance_. With the
+ * notation used in ProverInstance_, a prover instance is \f$\omega = (p_1, \dots, p_M, \theta_1, \dots, \theta_6,
+ * \alpha_{1,1}, \dots, \alpha_{n,r_n})\f$ where the \f$p_i\f$'s are the prover polynomials, the \f$\theta_i\f$'s are
+ * the relation parameters, and the \f$\alpha_{i,j}\f$'s are the subrelation batching parameters. Then, \f$\phi\f$ is
+ * given by \f$\omega = ([p_1], \dots, [p_M], \theta_1, \dots, \theta_6, \alpha_{1,1}, \dots, \alpha_{n,r_n})\f$m where
+ * [p_i] denotes the commitment to the i-th prover polynomial.
  */
 template <IsUltraOrMegaHonk Flavor_> class VerifierInstance_ {
   public:

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/verifier_instance.hpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/verifier_instance.hpp
@@ -19,7 +19,7 @@ namespace bb {
  * notation used in ProverInstance_, a prover instance is \f$\omega = (p_1, \dots, p_M, \theta_1, \dots, \theta_6,
  * \alpha_{1,1}, \dots, \alpha_{n,r_n})\f$ where the \f$p_i\f$'s are the prover polynomials, the \f$\theta_i\f$'s are
  * the relation parameters, and the \f$\alpha_{i,j}\f$'s are the subrelation batching parameters. Then, \f$\phi\f$ is
- * given by \f$\omega = ([p_1], \dots, [p_M], \theta_1, \dots, \theta_6, \alpha_{1,1}, \dots, \alpha_{n,r_n})\f$m where
+ * given by \f$\omega = ([p_1], \dots, [p_M], \alpha_{1,1}, \dots, \alpha_{n,r_n}, \theta_1, \dots, \theta_6)\f$m where
  * [p_i] denotes the commitment to the i-th prover polynomial.
  */
 template <IsUltraOrMegaHonk Flavor_> class VerifierInstance_ {


### PR DESCRIPTION
### 🧾 Audit Context

Cleanup and audit of the PG recursive verifier. Docs update cover also PG prover and native verifier, but code audit is only for the PG recursive verifier.

Dependency graph for PG recursive verifier (functions defined in the class and the functions that these functions call):
- `run_oink_...`
- `verify_folding_proof`:
     - `run_oink_...`
     - `get_pows_of_challenge` (from `Transcript`) 
     - `receive_from_prover` (from `Transcript`) 
     -  `get_challenge` and `get_challenges` (from `Transcript`) 
     - `branch_transcript` (from `Transcript`) 
     - `evaluate_perturbator`
     - `evaluate` (barycentric evaluation from `Univariate`)
     - `Commitment:from_witness` (depending on whether we use `Ultra` or `Mega` builder, this function goes down two different code paths; **Note:** The point at infinity is represented with different coordinates in `Ultra` and `Mega`: the former uses the coordinates of the generator, the latter two zeros. Points are checked to be the point at infinity by looking at the infinity flag)
     - `Commitment:batch_mul`
     - `update_gate_challenges`

### 🛠️ Changes Made

- Renamed `is_from_instance` in `ProverInstance` to `is_relaxed_instance`
- Added `throw_or_abort` in `self_extend_from` in `univariates.hpp`.
- Added documentation in PG related files (prover, verifier, recursive verifier)
- Added check for infinity flag in commitment folding, see [here](https://github.com/AztecProtocol/aztec-packages/blob/53e63c5acea6ade2a5a392b9443a2e1f7bc05fb8/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/protogalaxy_recursive_verifier.cpp#L193).

### ✅ Checklist

- [x] Audited all methods of the relevant module/class
- [x] Audited the interface of the module/class with other (relevant) components
- [x] Documented existing functionality and any changes made (as per Doxygen requirements)
- [ ] Resolved and/or closed all issues/TODOs pertaining to the audited files
- [ ] Confirmed and documented any security or other issues found (if applicable)
- [ ] Verified that tests cover all critical paths (and added tests if necessary)
- [ ] Updated audit tracking for the files audited (check the start of each file you audited)

### 📌 Notes for Reviewers

@iakovenkos I added a line of comment in `Transcript.hpp`.
