### PR TITLE
chore(docs): update migration notes relevant to v2.0.2

### DIFF
--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -118,6 +118,14 @@
   --brand-background: #1a1400;
   --ifm-font-color-base: #f2eee1;
   background: #1a1400;
+
+  /* Dark theme Typesense/DocSearch contrast improvements */
+  --docsearch-modal-background: #1a1400;
+  --docsearch-hit-background: #a9cc1f;
+  --docsearch-highlight-color: #a9cc1f;
+  --docsearch-text-color: #f2eee1;
+  --docsearch-muted-color: #999;
+  --docsearch-searchbox-focus-background: #2a2000;
 }
 
 [data-theme="dark"] .footer {

--- a/docs/versioned_docs/version-v2.0.2/migration_notes.md
+++ b/docs/versioned_docs/version-v2.0.2/migration_notes.md
@@ -7,7 +7,7 @@ tags: [migration, updating, sandbox]
 
 Aztec is in full-speed development. Literally every version breaks compatibility with the previous ones. This page attempts to target errors and difficulties you might encounter when upgrading, and how to resolve them.
 
-## TBD
+## 2.0.2
 
 ## [Aztec Tools]
 
@@ -56,9 +56,9 @@ The private event emission API has been significantly reworked to provide cleare
 1. `emit_event_in_private_log` has been renamed to `emit_event_in_private` and now takes a `delivery_mode` parameter instead of `constraints`
 2. `emit_event_as_offchain_message` has been removed in favor of using `emit_event_in_private` with `MessageDelivery.UNCONSTRAINED_OFFCHAIN`
 3. `PrivateLogContent` enum has been replaced with `MessageDelivery` enum with the following values:
-   - `CONSTRAINED_ONCHAIN`: For onchain delivery with cryptographic guarantees (replaces `CONSTRAINED_ENCRYPTION`)
-   - `UNCONSTRAINED_OFFCHAIN`: For offchain delivery without constraints
-   - `UNCONSTRAINED_ONCHAIN`: For onchain delivery without constraints (replaces `NO_CONSTRAINTS`)
+   - `CONSTRAINED_ONCHAIN`: For onchain delivery with cryptographic guarantees that recipients can discover and decrypt messages. Uses constrained encryption but is slower to prove. Best for critical messages that contracts need to verify.
+   - `UNCONSTRAINED_ONCHAIN`: For onchain delivery without encryption constraints. Faster proving but trusts the sender. Good when the sender is incentivized to perform encryption correctly (e.g. they are buying something and will only get it if the recipient sees the note). No guarantees that recipients will be able to find or decrypt messages.
+   - `UNCONSTRAINED_OFFCHAIN`: For offchain delivery (e.g. cloud storage) without constraints. Lowest cost since no onchain storage needed. Requires custom infrastructure for delivery. No guarantees that messages will be delivered or that recipients will ever find them.
 
 ### Contract functions can no longer be `pub` or `pub(crate)`
 


### PR DESCRIPTION
updates the migration notes in the docs. also fixes the background highlight color for dark mode search