### PR TITLE
chore(bb): allow disabling asserts in tests

### DIFF
--- a/barretenberg/cpp/src/barretenberg/common/assert.cpp
+++ b/barretenberg/cpp/src/barretenberg/common/assert.cpp
@@ -1,0 +1,19 @@
+#include "barretenberg/common/assert.hpp"
+#include "barretenberg/common/throw_or_abort.hpp"
+
+namespace bb {
+AssertMode& get_assert_mode()
+{
+    static AssertMode current_mode = AssertMode::ABORT;
+    return current_mode;
+}
+
+void assert_failure(std::string const& err)
+{
+    if (get_assert_mode() == AssertMode::WARN) {
+        info("NOT FOR PROD - assert as warning: ", err);
+        return;
+    }
+    throw_or_abort(err);
+}
+} // namespace bb

--- a/barretenberg/cpp/src/barretenberg/common/assert.hpp
+++ b/barretenberg/cpp/src/barretenberg/common/assert.hpp
@@ -1,7 +1,27 @@
 #pragma once
 
-#include "barretenberg/common/throw_or_abort.hpp"
+#include <cstdint>
 #include <sstream>
+
+namespace bb {
+enum class AssertMode : std::uint8_t { ABORT, WARN };
+AssertMode& get_assert_mode();
+void assert_failure(std::string const& err);
+
+// NOTE do not use in threaded contexts!
+struct AssertGuard {
+    AssertGuard(AssertMode mode)
+        : previous_mode(get_assert_mode())
+    {
+        get_assert_mode() = mode;
+    }
+    ~AssertGuard() { get_assert_mode() = (previous_mode); }
+    AssertMode previous_mode;
+};
+} // namespace bb
+
+// NOTE do not use in threaded contexts!
+#define BB_DISABLE_ASSERTS() bb::AssertGuard __bb_assert_guard(bb::AssertMode::WARN)
 
 // NOLINTBEGIN
 // Compiler should optimize this out in release builds, without triggering unused-variable warnings.
@@ -42,7 +62,7 @@
         if (!(expression)) {                                                                                           \
             info("Assertion failed: (" #expression ")");                                                               \
             __VA_OPT__(info("Reason   : ", __VA_ARGS__);)                                                              \
-            throw_or_abort("");                                                                                        \
+            bb::assert_failure("");                                                                                    \
         }                                                                                                              \
     } while (0)
 
@@ -52,7 +72,7 @@
             std::ostringstream oss;                                                                                    \
             oss << "Assertion failed: (" #expression ")";                                                              \
             __VA_OPT__(oss << " | Reason: " << __VA_ARGS__;)                                                           \
-            throw_or_abort(oss.str());                                                                                 \
+            bb::assert_failure(oss.str());                                                                             \
         }                                                                                                              \
     } while (0)
 
@@ -66,7 +86,7 @@
             oss << "  Actual  : " << _actual << "\n";                                                                  \
             oss << "  Expected: " << _expected;                                                                        \
             __VA_OPT__(oss << "\n  Reason  : " << __VA_ARGS__;)                                                        \
-            throw_or_abort(oss.str());                                                                                 \
+            bb::assert_failure(oss.str());                                                                             \
         }                                                                                                              \
     } while (0)
 
@@ -80,7 +100,7 @@
             oss << "  Actual  : " << _actual << "\n";                                                                  \
             oss << "  Not expected: " << _expected;                                                                    \
             __VA_OPT__(oss << "\n  Reason  : " << __VA_ARGS__;)                                                        \
-            throw_or_abort(oss.str());                                                                                 \
+            bb::assert_failure(oss.str());                                                                             \
         }                                                                                                              \
     } while (0)
 
@@ -94,7 +114,7 @@
             oss << "  Left   : " << _left << "\n";                                                                     \
             oss << "  Right  : " << _right;                                                                            \
             __VA_OPT__(oss << "\n  Reason : " << __VA_ARGS__;)                                                         \
-            throw_or_abort(oss.str());                                                                                 \
+            bb::assert_failure(oss.str());                                                                             \
         }                                                                                                              \
     } while (0)
 
@@ -108,7 +128,7 @@
             oss << "  Left   : " << _left << "\n";                                                                     \
             oss << "  Right  : " << _right;                                                                            \
             __VA_OPT__(oss << "\n  Reason : " << __VA_ARGS__;)                                                         \
-            throw_or_abort(oss.str());                                                                                 \
+            bb::assert_failure(oss.str());                                                                             \
         }                                                                                                              \
     } while (0)
 
@@ -122,7 +142,7 @@
             oss << "  Left   : " << _left << "\n";                                                                     \
             oss << "  Right  : " << _right;                                                                            \
             __VA_OPT__(oss << "\n  Reason : " << __VA_ARGS__;)                                                         \
-            throw_or_abort(oss.str());                                                                                 \
+            bb::assert_failure(oss.str());                                                                             \
         }                                                                                                              \
     } while (0)
 
@@ -136,7 +156,7 @@
             oss << "  Left   : " << _left << "\n";                                                                     \
             oss << "  Right  : " << _right;                                                                            \
             __VA_OPT__(oss << "\n  Reason : " << __VA_ARGS__;)                                                         \
-            throw_or_abort(oss.str());                                                                                 \
+            bb::assert_failure(oss.str());                                                                             \
         }                                                                                                              \
     } while (0)
 #endif // __wasm__


### PR DESCRIPTION
We try to catch likely problems early with asserts. However, this also impedes testing. Previously we had a build without asserts, but that was cumbersome. This adds a runtime global switch to a warning-only mode. 

Usage:
```
void test() {
    BB_DISABLE_ASSERTS();
    ... test logic ...
}
```