### PR TITLE
chore: IRM for multiple deployments

### DIFF
--- a/spartan/metrics/testnet-monitor/grafana/dashboards/alpha-testnet-monitor.json
+++ b/spartan/metrics/testnet-monitor/grafana/dashboards/alpha-testnet-monitor.json
@@ -105,8 +105,8 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "rollup_pending_block_number",
-          "legendFormat": "Pending block height",
+          "expr": "rollup_pending_block_number{network=\"$network\"}",
+          "legendFormat": "Pending block height ($network)",
           "range": true,
           "refId": "A"
         },
@@ -117,7 +117,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "rollup_proven_block_number",
+          "expr": "rollup_proven_block_number{network=\"$network\"}",
           "fullMetaSearch": false,
           "hide": false,
           "includeNullMetadata": true,
@@ -214,8 +214,8 @@
       "pluginVersion": "12.1.0-89781",
       "targets": [
         {
-          "expr": "rollup_pending_block_number",
-          "legendFormat": "{{job}}",
+          "expr": "rollup_pending_block_number{network=\"$network\"}",
+          "legendFormat": "{{network}}",
           "refId": "A"
         }
       ],
@@ -305,8 +305,8 @@
       "pluginVersion": "12.1.0-89781",
       "targets": [
         {
-          "expr": "rollup_proven_block_number",
-          "legendFormat": "{{job}}",
+          "expr": "rollup_proven_block_number{network=\"$network\"}",
+          "legendFormat": "{{network}}",
           "refId": "A"
         }
       ],

--- a/spartan/metrics/testnet-monitor/index.ts
+++ b/spartan/metrics/testnet-monitor/index.ts
@@ -1,17 +1,19 @@
 import express, { Request, Response } from "express";
 import { createPublicClient, http } from "viem";
-import { sepolia } from "viem/chains";
 import client from "prom-client";
 
-const { ROLLUP_CONTRACT_ADDRESS, ETHEREUM_HOST } = process.env;
+const { ROLLUP_CONTRACT_ADDRESS, ETHEREUM_HOST, NETWORK } = process.env;
 
-if (!ROLLUP_CONTRACT_ADDRESS || !ETHEREUM_HOST) {
+if (!ROLLUP_CONTRACT_ADDRESS || !ETHEREUM_HOST || !NETWORK) {
   console.error(
-    "ROLLUP_CONTRACT_ADDRESS and ETHEREUM_HOST are required. Provided: ",
+    "ROLLUP_CONTRACT_ADDRESS, ETHEREUM_HOST and NETWORK are required. Provided: ",
     ROLLUP_CONTRACT_ADDRESS,
-    ETHEREUM_HOST
+    ETHEREUM_HOST,
+    NETWORK
   );
-  throw new Error("ROLLUP_CONTRACT_ADDRESS and ETHEREUM_HOST are required");
+  throw new Error(
+    "ROLLUP_CONTRACT_ADDRESS, ETHEREUM_HOST and NETWORK are required"
+  );
 }
 
 if (!ROLLUP_CONTRACT_ADDRESS.startsWith("0x")) {
@@ -21,7 +23,6 @@ if (!ROLLUP_CONTRACT_ADDRESS.startsWith("0x")) {
 const transport = http(ETHEREUM_HOST);
 
 const publicClient = createPublicClient({
-  chain: sepolia,
   transport,
 });
 
@@ -53,6 +54,9 @@ const ROLLUP_ABI = [
     stateMutability: "view",
   },
 ] as const;
+
+// Add a default label to all metrics (including process metrics)
+client.register.setDefaultLabels({ network: NETWORK as string });
 
 const provenBlockNumberGauge = new client.Gauge({
   name: "rollup_proven_block_number",

--- a/spartan/metrics/testnet-monitor/irm/alert-rules.yml
+++ b/spartan/metrics/testnet-monitor/irm/alert-rules.yml
@@ -18,7 +18,7 @@ groups:
               disableTextWrap: false
               editorMode: code
               exemplar: false
-              expr: rollup_pending_block_number
+              expr: rollup_pending_block_number{network=~"$network"}
               fullMetaSearch: false
               includeNullMetadata: true
               instant: true
@@ -39,7 +39,7 @@ groups:
                 type: prometheus
                 uid: grafanacloud-prom
               editorMode: code
-              expr: rollup_pending_block_number offset 1m
+              expr: rollup_pending_block_number{network=~"$network"} offset 1m
               instant: true
               intervalMs: 1000
               legendFormat: __auto
@@ -75,7 +75,7 @@ groups:
         dashboardUid: alpha-testnet-monitor
         panelId: 3
         noDataState: NoData
-        execErrState: Error
+        execErrState: KeepLast
         annotations:
           __dashboardUid__: alpha-testnet-monitor
           __panelId__: "3"
@@ -84,6 +84,7 @@ groups:
           summary: Testnet pending block height was reduced
         labels:
           alertname: ReOrg
+          network: "$network"
         isPaused: false
         notification_settings:
           receiver: Testnet On-Call IRM
@@ -103,7 +104,7 @@ groups:
             datasourceUid: grafanacloud-prom
             model:
               editorMode: code
-              expr: sum without (instance) (changes(rollup_pending_block_number[40m]))
+              expr: sum without (instance) (changes(rollup_pending_block_number{network=~"$network"}[40m]))
               instant: true
               intervalMs: 1000
               legendFormat: __auto
@@ -120,7 +121,7 @@ groups:
                 type: prometheus
                 uid: grafanacloud-prom
               editorMode: code
-              expr: sum without (instance)  (rollup_pending_block_number)
+              expr: sum without (instance)  (rollup_pending_block_number{network=~"$network"})
               instant: true
               intervalMs: 1000
               legendFormat: __auto
@@ -155,7 +156,7 @@ groups:
         dashboardUid: alpha-testnet-monitor
         panelId: 3
         noDataState: NoData
-        execErrState: Error
+        execErrState: KeepLast
         annotations:
           __dashboardUid__: alpha-testnet-monitor
           __panelId__: "3"
@@ -163,6 +164,7 @@ groups:
           summary: Alpha Testnet pending block number hasn't increased for 2 epochs (40 minutes)
         labels:
           alertname: NoNewBlocks
+          network: "$network"
         isPaused: false
         notification_settings:
           receiver: Testnet On-Call IRM

--- a/spartan/metrics/testnet-monitor/kubernetes/monitoring-deployment.yaml
+++ b/spartan/metrics/testnet-monitor/kubernetes/monitoring-deployment.yaml
@@ -15,7 +15,7 @@ spec:
         app: testnet-monitor
     spec:
       containers:
-        - name: testnet-monitor
+        - name: aztec-chain-monitor
           image: aztecprotocol/aztec-block-height-monitor:latest
           imagePullPolicy: Always
           ports:
@@ -29,6 +29,8 @@ spec:
                   name: testnet-monitor-secrets
                   key: infura-sepolia-url
             - name: ROLLUP_CONTRACT_ADDRESS
+              value: ""
+            - name: NETWORK
               value: ""
             - name: GRAFANA_CLOUD_PASSWORD
               valueFrom:


### PR DESCRIPTION
- Add `NETWORK` var for multiple monitoring deployments
- make rpc node detection more robust
- Make sure we target correct alerts by adding `network` label

Prep for https://linear.app/aztec-labs/issue/A-19/setup-irm-monitoring-for-mainnet
Fixes https://linear.app/aztec-labs/issue/A-59/update-monitoring-for-multiple-networks