### PR TITLE
chore(docs): update Node URL for testnet in documentation

### DIFF
--- a/docs/docs/developers/guides/getting_started_on_testnet.md
+++ b/docs/docs/developers/guides/getting_started_on_testnet.md
@@ -63,7 +63,7 @@ The testnet is version dependent. It is currently running version `#include_test
 Set the required environment variables:
 
 ```bash
-export NODE_URL=https://aztec-alpha-testnet-fullnode.zkv.xyz
+export NODE_URL=https://aztec-testnet-fullnode.zkv.xyz
 export SPONSORED_FPC_ADDRESS=0x299f255076aa461e4e94a843f0275303470a6b8ebe7cb44a471c66711151e529
 ```
 
@@ -139,7 +139,7 @@ If you have an existing app running on sandbox, here's how to migrate it to test
 Instead of running a local sandbox, connect to the testnet node:
 
 ```sh
-export NODE_URL=https://aztec-alpha-testnet-fullnode.zkv.xyz
+export NODE_URL=https://aztec-testnet-fullnode.zkv.xyz
 ```
 
 When running `aztec-wallet` commands, include the node URL:
@@ -171,7 +171,7 @@ import { createAztecNodeClient } from "@aztec/aztec.js";
 import { getPXEServiceConfig } from "@aztec/pxe/server";
 import { createStore } from "@aztec/kv-store/lmdb";
 
-const NODE_URL = "https://aztec-alpha-testnet-fullnode.zkv.xyz";
+const NODE_URL = "https://aztec-testnet-fullnode.zkv.xyz";
 const node = createAztecNodeClient(NODE_URL);
 const l1Contracts = await node.getL1ContractAddresses();
 const config = getPXEServiceConfig();

--- a/docs/docs/try_testnet.md
+++ b/docs/docs/try_testnet.md
@@ -27,7 +27,7 @@ description: "Connect to Aztec Alpha Testnet, explore the ecosystem, and start b
 
 **Version**: `#include_testnet_version`
 
-**Node URL**: `https://aztec-alpha-testnet-fullnode.zkv.xyz`
+**Node URL**: `https://aztec-testnet-fullnode.zkv.xyz`
 
 **L1 Chain ID**: `11155111`
 

--- a/docs/versioned_docs/version-v2.0.2/developers/guides/getting_started_on_testnet.md
+++ b/docs/versioned_docs/version-v2.0.2/developers/guides/getting_started_on_testnet.md
@@ -63,7 +63,7 @@ The testnet is version dependent. It is currently running version `2.0.2`. Maint
 Set the required environment variables:
 
 ```bash
-export NODE_URL=https://aztec-alpha-testnet-fullnode.zkv.xyz
+export NODE_URL=https://aztec-testnet-fullnode.zkv.xyz
 export SPONSORED_FPC_ADDRESS=0x299f255076aa461e4e94a843f0275303470a6b8ebe7cb44a471c66711151e529
 ```
 
@@ -139,7 +139,7 @@ If you have an existing app running on sandbox, here's how to migrate it to test
 Instead of running a local sandbox, connect to the testnet node:
 
 ```sh
-export NODE_URL=https://aztec-alpha-testnet-fullnode.zkv.xyz
+export NODE_URL=https://aztec-testnet-fullnode.zkv.xyz
 ```
 
 When running `aztec-wallet` commands, include the node URL:
@@ -171,7 +171,7 @@ import { createAztecNodeClient } from "@aztec/aztec.js";
 import { getPXEServiceConfig } from "@aztec/pxe/server";
 import { createStore } from "@aztec/kv-store/lmdb";
 
-const NODE_URL = "https://aztec-alpha-testnet-fullnode.zkv.xyz";
+const NODE_URL = "https://aztec-testnet-fullnode.zkv.xyz";
 const node = createAztecNodeClient(NODE_URL);
 const l1Contracts = await node.getL1ContractAddresses();
 const config = getPXEServiceConfig();

--- a/docs/versioned_docs/version-v2.0.2/try_testnet.md
+++ b/docs/versioned_docs/version-v2.0.2/try_testnet.md
@@ -27,7 +27,7 @@ description: "Connect to Aztec Alpha Testnet, explore the ecosystem, and start b
 
 **Version**: `2.0.2`
 
-**Node URL**: `https://aztec-alpha-testnet-fullnode.zkv.xyz`
+**Node URL**: `https://aztec-testnet-fullnode.zkv.xyz`
 
 **L1 Chain ID**: `11155111`
 


### PR DESCRIPTION
Replaced the old Aztec Alpha Testnet URL with the new testnet URL across multiple documentation files to ensure users connect to the correct node.