### PR TITLE
feat: Remove estimate gas

### DIFF
--- a/boxes/boxes/react/src/config.ts
+++ b/boxes/boxes/react/src/config.ts
@@ -1,6 +1,6 @@
 import { AztecAddress, createAztecNodeClient, Wallet } from '@aztec/aztec.js';
 import { TestWallet } from '@aztec/test-wallet/lazy';
-import { PXEServiceConfig, getPXEServiceConfig, createPXEService } from '@aztec/pxe/client/lazy';
+import { getPXEServiceConfig, createPXEService } from '@aztec/pxe/client/lazy';
 import { getInitialTestAccountsData } from '@aztec/accounts/testing';
 
 export class PrivateEnv {
@@ -20,7 +20,7 @@ export class PrivateEnv {
     const configWithContracts = {
       ...config,
       l1Contracts,
-    } as PXEServiceConfig;
+    };
     const pxe = await createPXEService(aztecNode, configWithContracts);
     const wallet = new TestWallet(pxe, aztecNode);
 

--- a/playground/src/wallet/embedded_wallet.ts
+++ b/playground/src/wallet/embedded_wallet.ts
@@ -232,8 +232,10 @@ export class EmbeddedWallet extends BaseWallet {
   ): Promise<TxSimulationResult> {
     const executionOptions = { txNonce: Fr.random(), cancellable: false };
     const { account: fromAccount, instance, artifact } = await this.getFakeAccountDataFor(opts.from);
-    const fee = await this.getFeeOptions(fromAccount, executionPayload, opts.fee, executionOptions);
-    const txRequest = await fromAccount.createTxExecutionRequest(executionPayload, fee, executionOptions);
+    const feeOptions = opts.fee?.estimateGas
+      ? await this.getFeeOptionsForGasEstimation(opts.from, opts.fee)
+      : await this.getDefaultFeeOptions(opts.from, opts.fee);
+    const txRequest = await fromAccount.createTxExecutionRequest(executionPayload, feeOptions, executionOptions);
     const contractOverrides = {
       [opts.from.toString()]: { instance, artifact },
     };

--- a/yarn-project/accounts/src/defaults/account_interface.ts
+++ b/yarn-project/accounts/src/defaults/account_interface.ts
@@ -36,10 +36,10 @@ export class DefaultAccountInterface implements AccountInterface {
 
   createTxExecutionRequest(
     exec: ExecutionPayload,
-    fee: FeeOptions,
+    feeOptions: FeeOptions,
     options: TxExecutionOptions,
   ): Promise<TxExecutionRequest> {
-    return this.entrypoint.createTxExecutionRequest(exec, fee, options);
+    return this.entrypoint.createTxExecutionRequest(exec, feeOptions, options);
   }
 
   createAuthWit(messageHash: Fr): Promise<AuthWitness> {

--- a/yarn-project/accounts/src/stub/index.ts
+++ b/yarn-project/accounts/src/stub/index.ts
@@ -24,7 +24,10 @@ export class StubAccountContract extends StubBaseAccountContract {
 }
 
 /**
- *
+ * Creates a stub account that impersonates the one with the provided originalAddress.
+ * @param originalAddress - The address of the account to stub
+ * @param chainInfo - The chain info that the account is connected to
+ * @returns A stub account that can be used for kernelless simulations
  */
 export function createStubAccount(originalAddress: CompleteAddress, chainInfo: ChainInfo) {
   const accountContract = new StubAccountContract();

--- a/yarn-project/aztec.js/src/account/account.ts
+++ b/yarn-project/aztec.js/src/account/account.ts
@@ -35,10 +35,10 @@ export class BaseAccount implements Account {
 
   createTxExecutionRequest(
     exec: ExecutionPayload,
-    fee: FeeOptions,
+    feeOptions: FeeOptions,
     options: TxExecutionOptions,
   ): Promise<TxExecutionRequest> {
-    return this.account.createTxExecutionRequest(exec, fee, options);
+    return this.account.createTxExecutionRequest(exec, feeOptions, options);
   }
 
   getChainId(): Fr {

--- a/yarn-project/aztec.js/src/account/signerless_account.ts
+++ b/yarn-project/aztec.js/src/account/signerless_account.ts
@@ -19,10 +19,10 @@ export class SignerlessAccount implements Account {
 
   createTxExecutionRequest(
     execution: ExecutionPayload,
-    fee: FeeOptions,
+    feeOptions: FeeOptions,
     options: TxExecutionOptions,
   ): Promise<TxExecutionRequest> {
-    return this.entrypoint.createTxExecutionRequest(execution, fee, options);
+    return this.entrypoint.createTxExecutionRequest(execution, feeOptions, options);
   }
 
   getChainId(): Fr {

--- a/yarn-project/aztec.js/src/api/contract.ts
+++ b/yarn-project/aztec.js/src/api/contract.ts
@@ -53,6 +53,7 @@ export { BatchCall } from '../contract/batch_call.js';
 export { type DeployOptions, DeployMethod } from '../contract/deploy_method.js';
 export { DeploySentTx } from '../contract/deploy_sent_tx.js';
 export { waitForProven, type WaitForProvenOpts, DefaultWaitForProvenOpts } from '../contract/wait_for_proven.js';
+export { getGasLimits } from '../contract/get_gas_limits.js';
 
 export {
   type PartialAddress,

--- a/yarn-project/aztec.js/src/contract/base_contract_interaction.ts
+++ b/yarn-project/aztec.js/src/contract/base_contract_interaction.ts
@@ -1,7 +1,6 @@
 import type { ExecutionPayload } from '@aztec/entrypoints/payload';
 import { createLogger } from '@aztec/foundation/log';
 import type { AuthWitness } from '@aztec/stdlib/auth-witness';
-import type { GasSettings } from '@aztec/stdlib/gas';
 import type { Capsule, TxProvingResult } from '@aztec/stdlib/tx';
 
 import type { Wallet } from '../wallet/wallet.js';
@@ -76,17 +75,5 @@ export abstract class BaseContractInteraction {
       return this.wallet.sendTx(await txProvingResult.toTx());
     };
     return new SentTx(this.wallet, sendTx);
-  }
-
-  /**
-   * Estimates gas for the interaction and returns gas limits for it.
-   * @param options - Options.
-   * @returns Gas limits.
-   */
-  public async estimateGas(
-    options: Omit<SendMethodOptions, 'estimateGas'>,
-  ): Promise<Pick<GasSettings, 'gasLimits' | 'teardownGasLimits'>> {
-    const executionPayload = await this.request(options);
-    return this.wallet.estimateGas(executionPayload, options);
   }
 }

--- a/yarn-project/aztec.js/src/contract/interaction_options.ts
+++ b/yarn-project/aztec.js/src/contract/interaction_options.ts
@@ -1,7 +1,8 @@
-import type { UserFeeOptions } from '@aztec/entrypoints/interfaces';
+import type { SimulationUserFeeOptions, UserFeeOptions } from '@aztec/entrypoints/interfaces';
 import type { AuthWitness } from '@aztec/stdlib/auth-witness';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
-import type { Capsule } from '@aztec/stdlib/tx';
+import type { GasSettings } from '@aztec/stdlib/gas';
+import type { Capsule, OffchainEffect, SimulationStats } from '@aztec/stdlib/tx';
 
 /**
  * Represents the options to configure a request from a contract interaction.
@@ -29,7 +30,9 @@ export type SendMethodOptions = RequestMethodOptions & {
  * Allows specifying the address from which the method should be called.
  * Disregarded for simulation of public functions
  */
-export type SimulateMethodOptions = Pick<SendMethodOptions, 'from' | 'authWitnesses' | 'capsules' | 'fee'> & {
+export type SimulateMethodOptions = Omit<SendMethodOptions, 'fee'> & {
+  /** The fee options for the transaction. */
+  fee?: SimulationUserFeeOptions;
   /** Simulate without checking for the validity of the resulting transaction, e.g. whether it emits any existing nullifiers. */
   skipTxValidation?: boolean;
   /** Whether to ensure the fee payer is not empty and has enough balance to pay for the fee. */
@@ -50,3 +53,22 @@ export type ProfileMethodOptions = SimulateMethodOptions & {
   skipProofGeneration?: boolean;
 };
 // docs:end:profile-method-options
+
+/**
+ * Represents the result type of a simulation.
+ * By default, it will just be the return value of the simulated function
+ * If `includeMetadata` is set to true in `SimulateMethodOptions` on the input of `simulate(...)`,
+ * it will provide extra information.
+ */
+export type SimulationReturn<T extends boolean | undefined> = T extends true
+  ? {
+      /** Additional stats about the simulation */
+      stats: SimulationStats;
+      /** Offchain effects generated during the simulation */
+      offchainEffects: OffchainEffect[];
+      /**  Return value of the function */
+      result: any;
+      /** Gas estimation results */
+      estimatedGas: Pick<GasSettings, 'gasLimits' | 'teardownGasLimits'>;
+    }
+  : any;

--- a/yarn-project/aztec.js/src/utils/authwit.ts
+++ b/yarn-project/aztec.js/src/utils/authwit.ts
@@ -6,11 +6,12 @@ import type { AztecAddress } from '@aztec/stdlib/aztec-address';
 import { computeVarArgsHash } from '@aztec/stdlib/hash';
 import type { TxProfileResult } from '@aztec/stdlib/tx';
 
-import { ContractFunctionInteraction, type SimulationReturn } from '../contract/contract_function_interaction.js';
+import { ContractFunctionInteraction } from '../contract/contract_function_interaction.js';
 import type {
   ProfileMethodOptions,
   SendMethodOptions,
   SimulateMethodOptions,
+  SimulationReturn,
 } from '../contract/interaction_options.js';
 import type { SentTx } from '../contract/sent_tx.js';
 import type { ChainInfo, Wallet } from '../wallet/index.js';

--- a/yarn-project/bot/src/amm_bot.ts
+++ b/yarn-project/bot/src/amm_bot.ts
@@ -68,15 +68,13 @@ export class AmmBot extends BaseBot {
       )
       .simulate({ from: this.defaultAccountAddress });
 
-    const swapExactTokensInteraction = amm.methods.swap_exact_tokens_for_tokens(
-      tokenIn.address,
-      tokenOut.address,
-      amountIn,
-      amountOutMin,
-      authwitNonce,
-    );
+    const swapExactTokensInteraction = amm.methods
+      .swap_exact_tokens_for_tokens(tokenIn.address, tokenOut.address, amountIn, amountOutMin, authwitNonce)
+      .with({
+        authWitnesses: [swapAuthwit],
+      });
 
-    const opts = this.getSendMethodOpts(swapAuthwit);
+    const opts = await this.getSendMethodOpts(swapExactTokensInteraction);
 
     this.log.verbose(`Proving transaction`, logCtx);
     const tx = await swapExactTokensInteraction.prove(opts);

--- a/yarn-project/bot/src/bot.ts
+++ b/yarn-project/bot/src/bot.ts
@@ -59,8 +59,8 @@ export class Bot extends BaseBot {
           token.methods.transfer(TRANSFER_AMOUNT, this.defaultAccountAddress, recipient),
         );
 
-    const opts = this.getSendMethodOpts();
     const batch = new BatchCall(wallet, calls);
+    const opts = await this.getSendMethodOpts(batch);
 
     this.log.verbose(`Simulating transaction with ${calls.length}`, logCtx);
     await batch.simulate({ from: this.defaultAccountAddress });

--- a/yarn-project/cli-wallet/src/cmds/authorize_action.ts
+++ b/yarn-project/cli-wallet/src/cmds/authorize_action.ts
@@ -36,7 +36,7 @@ export async function authorizeAction(
     { caller, action },
     true,
   );
-  const witness = await setAuthwitnessInteraction.send({ from }).wait({ timeout: DEFAULT_TX_TIMEOUT_S });
+  const witness = await setAuthwitnessInteraction.send().wait({ timeout: DEFAULT_TX_TIMEOUT_S });
 
   log(`Authorized action ${functionName} on contract ${contractAddress} for caller ${caller}`);
 

--- a/yarn-project/cli-wallet/src/cmds/cancel_tx.ts
+++ b/yarn-project/cli-wallet/src/cmds/cancel_tx.ts
@@ -32,7 +32,7 @@ export async function cancelTx(
     prevTxGasSettings.maxPriorityFeesPerGas.feePerL2Gas + increasedFees.feePerL2Gas,
   );
 
-  const fee: FeeOptions = {
+  const feeOptions: FeeOptions = {
     paymentMethod,
     gasSettings: GasSettings.from({
       ...prevTxGasSettings,
@@ -41,7 +41,7 @@ export async function cancelTx(
     }),
   };
 
-  const txProvingResult = await wallet.proveCancellationTx(from, txNonce, fee);
+  const txProvingResult = await wallet.proveCancellationTx(from, txNonce, feeOptions);
   const sentTx = new SentTx(wallet, async () => {
     const tx = await txProvingResult.toTx();
     return wallet.sendTx(tx);

--- a/yarn-project/cli-wallet/src/cmds/create_account.ts
+++ b/yarn-project/cli-wallet/src/cmds/create_account.ts
@@ -63,7 +63,7 @@ export async function createAccount(
   let tx;
   let txReceipt;
   if (!registerOnly) {
-    const userFeeOptions = await feeOpts.toUserFeeOptions(wallet, account.getAddress());
+    const userFeeOptions = await feeOpts.toUserFeeOptions(wallet, address);
     const feePayer = await userFeeOptions.paymentMethod?.getFeePayer();
     let paymentAsset;
     try {
@@ -81,9 +81,13 @@ export async function createAccount(
     const deployOpts: DeployOptions = {
       skipClassPublication: !publicDeploy,
       skipInstancePublication: !publicDeploy,
-      skipInitialization: skipInitialization,
+      skipInitialization,
       from,
       fee: userFeeOptions,
+      // Do not mix the deployer in the address, since the account
+      // was created (and thus its address was fixed) like this
+      universalDeploy: true,
+      contractAddressSalt: salt,
     };
 
     /*
@@ -100,29 +104,33 @@ export async function createAccount(
         : deployOpts.fee;
 
     const deployMethod = await account.getDeployMethod();
+    const { stats, estimatedGas } = await deployMethod.simulate({
+      ...deployOpts,
+      fee: { ...deployOpts.fee, estimateGas: true },
+    });
+
+    printProfileResult(stats, log);
 
     if (feeOpts.estimateOnly) {
-      const gas = await deployMethod.estimateGas({
-        ...deployOpts,
-        universalDeploy: true,
-      });
       if (json) {
         out.fee = {
           gasLimits: {
-            da: gas.gasLimits.daGas,
-            l2: gas.gasLimits.l2Gas,
+            da: estimatedGas.gasLimits.daGas,
+            l2: estimatedGas.gasLimits.l2Gas,
           },
           teardownGasLimits: {
-            da: gas.teardownGasLimits.daGas,
-            l2: gas.teardownGasLimits,
+            da: estimatedGas.teardownGasLimits.daGas,
+            l2: estimatedGas.teardownGasLimits,
           },
         };
       }
     } else {
       const provenTx = await deployMethod.prove({
         ...deployOpts,
-        universalDeploy: true,
-        contractAddressSalt: salt,
+        fee: {
+          ...deployOpts.fee,
+          gasSettings: estimatedGas,
+        },
       });
       if (verbose) {
         printProfileResult(provenTx.stats!, log);

--- a/yarn-project/cli-wallet/src/cmds/index.ts
+++ b/yarn-project/cli-wallet/src/cmds/index.ts
@@ -7,7 +7,6 @@ import {
   addOptions,
   createSecretKeyOption,
   l1ChainIdOption,
-  logJson,
   nodeOption,
   parseBigint,
   parseFieldFromHexString,
@@ -105,7 +104,7 @@ export function injectCommands(
     .addOption(createTypeOption(true))
     .option(
       '--register-only',
-      'Just register the account on the PXE. Do not deploy or initialize the account contract.',
+      'Just register the account on the Wallet. Do not deploy or initialize the account contract.',
     )
     .option('--json', 'Emit output as json')
     // `options.wait` is default true. Passing `--no-wait` will set it to false.
@@ -292,7 +291,6 @@ export function injectCommands(
       verbose,
       debugLogger,
       log,
-      logJson(log),
     );
     if (db && address) {
       await db.storeContract(address, artifactPath, log, alias);

--- a/yarn-project/cli-wallet/src/cmds/send.ts
+++ b/yarn-project/cli-wallet/src/cmds/send.ts
@@ -35,7 +35,7 @@ export async function send(
     authWitnesses,
   };
 
-  const gasLimits = await call.estimateGas(sendOptions);
+  const { estimatedGas } = await call.simulate({ ...sendOptions, fee: { ...sendOptions.fee, estimateGas: true } });
 
   if (feeOpts.estimateOnly) {
     return;
@@ -68,7 +68,7 @@ export async function send(
   }
   const gasSettings = GasSettings.from({
     ...provenTx.data.constants.txContext.gasSettings,
-    ...gasLimits,
+    ...estimatedGas,
   });
   return {
     txHash,

--- a/yarn-project/cli-wallet/src/utils/options/fees.ts
+++ b/yarn-project/cli-wallet/src/utils/options/fees.ts
@@ -253,7 +253,6 @@ export class CLIFeeArgs {
     return {
       paymentMethod: await this.paymentMethod(wallet, sender),
       gasSettings: this.gasSettings,
-      estimateGas: this.estimateGas,
     };
   }
 

--- a/yarn-project/end-to-end/src/spartan/mempool_limit.test.ts
+++ b/yarn-project/end-to-end/src/spartan/mempool_limit.test.ts
@@ -45,7 +45,7 @@
 //   let tokenContractAddress: AztecAddress;
 //   let sampleTx: Tx;
 
-//   let fee: UserFeeOptions;
+//   let userFeeOptions: UserFeeOptions;
 
 //   const forwardProcesses: ChildProcess[] = [];
 

--- a/yarn-project/entrypoints/src/account_entrypoint.ts
+++ b/yarn-project/entrypoints/src/account_entrypoint.ts
@@ -22,7 +22,7 @@ export class DefaultAccountEntrypoint implements EntrypointInterface {
 
   async createTxExecutionRequest(
     exec: ExecutionPayload,
-    fee: FeeOptions,
+    feeOptions: FeeOptions,
     options: TxExecutionOptions,
   ): Promise<TxExecutionRequest> {
     // Initial request with calls, authWitnesses and capsules
@@ -32,11 +32,11 @@ export class DefaultAccountEntrypoint implements EntrypointInterface {
     // Encode the calls for the app
     const appEncodedCalls = await EncodedCallsForEntrypoint.fromAppExecution(calls, txNonce);
     // Get the execution payload for the fee, it includes the calls and potentially authWitnesses
-    const { calls: feeCalls, authWitnesses: feeAuthwitnesses } = await fee.paymentMethod.getExecutionPayload(
-      fee.gasSettings,
+    const { calls: feeCalls, authWitnesses: feeAuthwitnesses } = await feeOptions.paymentMethod.getExecutionPayload(
+      feeOptions.gasSettings,
     );
     // Encode the calls for the fee
-    const feePayer = await fee.paymentMethod.getFeePayer();
+    const feePayer = await feeOptions.paymentMethod.getFeePayer();
     const isFeePayer = feePayer.equals(this.address);
     const feeEncodedCalls = await EncodedCallsForEntrypoint.fromFeeCalls(feeCalls, isFeePayer);
 
@@ -56,7 +56,7 @@ export class DefaultAccountEntrypoint implements EntrypointInterface {
       firstCallArgsHash: entrypointHashedArgs.hash,
       origin: this.address,
       functionSelector: await FunctionSelector.fromNameAndParameters(abi.name, abi.parameters),
-      txContext: new TxContext(this.chainId, this.version, fee.gasSettings),
+      txContext: new TxContext(this.chainId, this.version, feeOptions.gasSettings),
       argsOfCalls: [
         ...appEncodedCalls.hashedArguments,
         ...feeEncodedCalls.hashedArguments,

--- a/yarn-project/entrypoints/src/default_entrypoint.ts
+++ b/yarn-project/entrypoints/src/default_entrypoint.ts
@@ -15,7 +15,7 @@ export class DefaultEntrypoint implements EntrypointInterface {
 
   async createTxExecutionRequest(
     exec: ExecutionPayload,
-    fee: FeeOptions,
+    feeOptions: FeeOptions,
     options: TxExecutionOptions,
   ): Promise<TxExecutionRequest> {
     if (options.txNonce || options.cancellable !== undefined) {
@@ -42,7 +42,7 @@ export class DefaultEntrypoint implements EntrypointInterface {
       call.to,
       call.selector,
       hashedArguments[0].hash,
-      new TxContext(this.chainId, this.rollupVersion, fee.gasSettings),
+      new TxContext(this.chainId, this.rollupVersion, feeOptions.gasSettings),
       [...hashedArguments, ...extraHashedArgs],
       authWitnesses,
       capsules,

--- a/yarn-project/entrypoints/src/default_multi_call_entrypoint.ts
+++ b/yarn-project/entrypoints/src/default_multi_call_entrypoint.ts
@@ -18,7 +18,7 @@ export class DefaultMultiCallEntrypoint implements EntrypointInterface {
     private address: AztecAddress = ProtocolContractAddress.MultiCallEntrypoint,
   ) {}
 
-  async createTxExecutionRequest(exec: ExecutionPayload, fee: FeeOptions): Promise<TxExecutionRequest> {
+  async createTxExecutionRequest(exec: ExecutionPayload, feeOptions: FeeOptions): Promise<TxExecutionRequest> {
     // Initial request with calls, authWitnesses and capsules
     const { calls, authWitnesses, capsules, extraHashedArgs } = exec;
 
@@ -27,7 +27,7 @@ export class DefaultMultiCallEntrypoint implements EntrypointInterface {
       calls: feeCalls,
       authWitnesses: feeAuthwitnesses,
       extraHashedArgs: feeExtraHashedArgs,
-    } = await fee.paymentMethod.getExecutionPayload(fee.gasSettings);
+    } = await feeOptions.paymentMethod.getExecutionPayload(feeOptions.gasSettings);
 
     // Encode the calls, including the fee calls
     // (since this entrypoint does not distinguish between app and fee calls)
@@ -42,7 +42,7 @@ export class DefaultMultiCallEntrypoint implements EntrypointInterface {
       firstCallArgsHash: entrypointHashedArgs.hash,
       origin: this.address,
       functionSelector: await FunctionSelector.fromNameAndParameters(abi.name, abi.parameters),
-      txContext: new TxContext(this.chainId, this.version, fee.gasSettings),
+      txContext: new TxContext(this.chainId, this.version, feeOptions.gasSettings),
       argsOfCalls: [...encodedCalls.hashedArguments, entrypointHashedArgs, ...extraHashedArgs, ...feeExtraHashedArgs],
       authWitnesses: [...feeAuthwitnesses, ...authWitnesses],
       capsules,

--- a/yarn-project/entrypoints/src/interfaces.ts
+++ b/yarn-project/entrypoints/src/interfaces.ts
@@ -29,13 +29,13 @@ export interface EntrypointInterface {
   /**
    * Generates an execution request out of set of function calls.
    * @param exec - The execution intents to be run.
-   * @param fee - The fee options for the transaction.
+   * @param feeOptions - The fee options for the transaction.
    * @param options - Transaction nonce and whether the transaction is cancellable.
    * @returns The authenticated transaction execution request.
    */
   createTxExecutionRequest(
     exec: ExecutionPayload,
-    fee: FeeOptions,
+    feeOptions: FeeOptions,
     options: TxExecutionOptions,
   ): Promise<TxExecutionRequest>;
 }
@@ -86,11 +86,13 @@ export type UserFeeOptions = {
   paymentMethod?: FeePaymentMethod;
   /** The gas settings */
   gasSettings?: Partial<FieldsOf<GasSettings>>;
-  /** Percentage to pad the base fee by, if empty, defaults to 0.5 */
-  baseFeePadding?: number;
-  /** Whether to run an initial simulation of the tx with high gas limit to figure out actual gas settings. */
+};
+// docs:end:user_fee_options
+
+/**  Fee options that can be set for simulation *only* */
+export type SimulationUserFeeOptions = UserFeeOptions & {
+  /** Whether to modify the fee settings of the simulation with high gas limit to figure out actual gas settings. */
   estimateGas?: boolean;
   /** Percentage to pad the estimated gas limits by, if empty, defaults to 0.1. Only relevant if estimateGas is set. */
   estimatedGasPadding?: number;
 };
-// docs:end:user_fee_options

--- a/yarn-project/pxe/src/pxe_service/error_enriching.ts
+++ b/yarn-project/pxe/src/pxe_service/error_enriching.ts
@@ -76,6 +76,10 @@ export async function enrichPublicSimulationError(
   const callStack = err.getCallStack();
   const originalFailingFunction = callStack[callStack.length - 1];
 
+  if (!originalFailingFunction) {
+    throw new Error(`Original failing function not found when enriching public simulation, missing callstack`);
+  }
+
   const artifact = await contractDataProvider.getPublicFunctionArtifact(originalFailingFunction.contractAddress);
   if (!artifact) {
     throw new Error(

--- a/yarn-project/pxe/src/pxe_service/pxe_service.ts
+++ b/yarn-project/pxe/src/pxe_service/pxe_service.ts
@@ -620,24 +620,19 @@ export class PXEService implements PXE {
     return Promise.all(extendedNotes);
   }
 
-  public proveTx(
-    txRequest: TxExecutionRequest,
-    privateExecutionResult?: PrivateExecutionResult,
-  ): Promise<TxProvingResult> {
+  public proveTx(txRequest: TxExecutionRequest): Promise<TxProvingResult> {
+    let privateExecutionResult: PrivateExecutionResult;
     // We disable proving concurrently mostly out of caution, since it accesses some of our stores. Proving is so
     // computationally demanding that it'd be rare for someone to try to do it concurrently regardless.
     return this.#putInJobQueue(async () => {
       const totalTimer = new Timer();
       try {
-        let syncTime: number | undefined;
-        let contractFunctionSimulator: ContractFunctionSimulator | undefined;
-        if (!privateExecutionResult) {
-          const syncTimer = new Timer();
-          await this.synchronizer.sync();
-          syncTime = syncTimer.ms();
-          contractFunctionSimulator = this.#getSimulatorForTx();
-          privateExecutionResult = await this.#executePrivate(contractFunctionSimulator, txRequest);
-        }
+        const syncTimer = new Timer();
+        await this.synchronizer.sync();
+        const syncTime = syncTimer.ms();
+        const contractFunctionSimulator = this.#getSimulatorForTx();
+        privateExecutionResult = await this.#executePrivate(contractFunctionSimulator, txRequest);
+
         const {
           publicInputs,
           clientIvcProof,

--- a/yarn-project/stdlib/src/interfaces/pxe.test.ts
+++ b/yarn-project/stdlib/src/interfaces/pxe.test.ts
@@ -139,10 +139,7 @@ describe('PXESchema', () => {
   });
 
   it('proveTx', async () => {
-    const result = await context.client.proveTx(
-      await TxExecutionRequest.random(),
-      await PrivateExecutionResult.random(),
-    );
+    const result = await context.client.proveTx(await TxExecutionRequest.random());
     expect(result).toBeInstanceOf(TxProvingResult);
   });
 
@@ -302,11 +299,14 @@ class MockPXE implements PXE {
       }),
     );
   }
-  proveTx(txRequest: TxExecutionRequest, privateExecutionResult: PrivateExecutionResult): Promise<TxProvingResult> {
+  async proveTx(txRequest: TxExecutionRequest): Promise<TxProvingResult> {
     expect(txRequest).toBeInstanceOf(TxExecutionRequest);
-    expect(privateExecutionResult).toBeInstanceOf(PrivateExecutionResult);
     return Promise.resolve(
-      new TxProvingResult(privateExecutionResult, PrivateKernelTailCircuitPublicInputs.empty(), ClientIvcProof.empty()),
+      new TxProvingResult(
+        await PrivateExecutionResult.random(),
+        PrivateKernelTailCircuitPublicInputs.empty(),
+        ClientIvcProof.empty(),
+      ),
     );
   }
   async simulateTx(

--- a/yarn-project/stdlib/src/interfaces/pxe.ts
+++ b/yarn-project/stdlib/src/interfaces/pxe.ts
@@ -20,7 +20,7 @@ import {
 import { UniqueNote } from '../note/extended_note.js';
 import { type NotesFilter, NotesFilterSchema } from '../note/notes_filter.js';
 import { AbiDecodedSchema, optional, schemas } from '../schemas/schemas.js';
-import { PrivateExecutionResult, SimulationOverrides, TxExecutionRequest, TxSimulationResult } from '../tx/index.js';
+import { SimulationOverrides, TxExecutionRequest, TxSimulationResult } from '../tx/index.js';
 import { TxProfileResult, UtilitySimulationResult } from '../tx/profiling.js';
 import { TxProvingResult } from '../tx/proven_tx.js';
 
@@ -111,13 +111,11 @@ export interface PXE {
    * (where validators prove the public portion).
    *
    * @param txRequest - An authenticated tx request ready for proving
-   * @param privateExecutionResult - (optional) The result of the private execution of the transaction. The txRequest
-   * will be executed if not provided
    * @returns A result containing the proof and public inputs of the tail circuit.
    * @throws If contract code not found, or public simulation reverts.
    * Also throws if simulatePublic is true and public simulation reverts.
    */
-  proveTx(txRequest: TxExecutionRequest, privateExecutionResult?: PrivateExecutionResult): Promise<TxProvingResult>;
+  proveTx(txRequest: TxExecutionRequest): Promise<TxProvingResult>;
 
   /**
    * Simulates a transaction based on the provided preauthenticated execution request.
@@ -314,10 +312,7 @@ export const PXESchema: ApiSchemaFor<PXE> = {
     .returns(z.void()),
   updateContract: z.function().args(schemas.AztecAddress, ContractArtifactSchema).returns(z.void()),
   getContracts: z.function().returns(z.array(schemas.AztecAddress)),
-  proveTx: z
-    .function()
-    .args(TxExecutionRequest.schema, optional(PrivateExecutionResult.schema))
-    .returns(TxProvingResult.schema),
+  proveTx: z.function().args(TxExecutionRequest.schema).returns(TxProvingResult.schema),
   profileTx: z
     .function()
     .args(

--- a/yarn-project/test-wallet/src/wallet/test_wallet.ts
+++ b/yarn-project/test-wallet/src/wallet/test_wallet.ts
@@ -57,6 +57,10 @@ export abstract class BaseTestWallet extends BaseWallet {
     this.simulatedSimulations = false;
   }
 
+  setBaseFeePadding(value?: number) {
+    this.baseFeePadding = value ?? 0.5;
+  }
+
   protected async getAccountFromAddress(address: AztecAddress): Promise<Account> {
     let account: Account | undefined;
     if (address.equals(AztecAddress.ZERO)) {
@@ -163,13 +167,20 @@ export abstract class BaseTestWallet extends BaseWallet {
     executionPayload: ExecutionPayload,
     opts: SimulateMethodOptions,
   ): Promise<TxSimulationResult> {
+    if (this.simulatedSimulations && opts.fee?.estimateGas) {
+      throw new Error(
+        'Simulated simulations potentially skews gas measurements, please disable this feature to estimate gas',
+      );
+    }
     if (!this.simulatedSimulations) {
       return super.simulateTx(executionPayload, opts);
     } else {
       const executionOptions = { txNonce: Fr.random(), cancellable: false };
       const { account: fromAccount, instance, artifact } = await this.getFakeAccountDataFor(opts.from);
-      const fee = await this.getFeeOptions(fromAccount, executionPayload, opts.fee, executionOptions);
-      const txRequest = await fromAccount.createTxExecutionRequest(executionPayload, fee, executionOptions);
+      const feeOptions = opts.fee?.estimateGas
+        ? await this.getFeeOptionsForGasEstimation(opts.from, opts.fee)
+        : await this.getDefaultFeeOptions(opts.from, opts.fee);
+      const txRequest = await fromAccount.createTxExecutionRequest(executionPayload, feeOptions, executionOptions);
       const contractOverrides = {
         [opts.from.toString()]: { instance, artifact },
       };


### PR DESCRIPTION
The estimate gas call was polluting our intefaces, while the same results could be achieved by setting a combination of options in our simulation interface. This PR does just that. 

It also removes the forced fee estimation process when doing `prove`. When requesting a proof, the wallet should have already decided what `GasLimits` its going to use, which is a process that does not depend on the app at all. The ability to estimate fees during simulations requested by the app is kept so the information can be shown in a GUI, for example.