### PR TITLE
chore(fix): Fix Terraform Deployment Mocked Proofs for Validators and RPC Node and Fix Tests

### DIFF
--- a/spartan/terraform/deploy-aztec-infra/main.tf
+++ b/spartan/terraform/deploy-aztec-infra/main.tf
@@ -153,8 +153,10 @@ locals {
         "validator.node.env.PUBLISHER_KEY_INDEX_START"      = var.VALIDATOR_PUBLISHER_MNEMONIC_START_INDEX
         "validator.node.env.VALIDATORS_PER_NODE"            = var.VALIDATORS_PER_NODE
         "validator.node.env.PUBLISHERS_PER_VALIDATOR_KEY"   = var.VALIDATOR_PUBLISHERS_PER_VALIDATOR_KEY
+        "validator.node.proverRealProofs"                   = var.PROVER_REAL_PROOFS
         "validator.node.env.SEQ_MIN_TX_PER_BLOCK"           = var.SEQ_MIN_TX_PER_BLOCK
         "validator.node.env.SEQ_MAX_TX_PER_BLOCK"           = var.SEQ_MAX_TX_PER_BLOCK
+        "validator.node.proverRealProofs"                   = var.PROVER_REAL_PROOFS
       }
       boot_node_host_path  = "validator.node.env.BOOT_NODE_HOST"
       bootstrap_nodes_path = "validator.node.env.BOOTSTRAP_NODES"
@@ -217,8 +219,10 @@ locals {
         }
       })] : []
       custom_settings = {
-        "nodeType"            = "rpc"
-        "node.env.NETWORK"    = var.NETWORK
+        "nodeType"              = "rpc"
+        "node.env.NETWORK"      = var.NETWORK
+        "node.proverRealProofs" = var.PROVER_REAL_PROOFS
+
         "ingress.rpc.enabled" = var.RPC_INGRESS_ENABLED
         "ingress.rpc.host"    = var.RPC_INGRESS_HOST
       }

--- a/yarn-project/end-to-end/src/spartan/1tps.test.ts
+++ b/yarn-project/end-to-end/src/spartan/1tps.test.ts
@@ -14,7 +14,7 @@ import {
 } from './setup_test_wallets.js';
 import { setupEnvironment, startPortForwardForRPC } from './utils.js';
 
-const config = { ...setupEnvironment(process.env), REAL_VERIFIER: true }; // TODO: remove REAL_VERIFIER: true
+const config = { ...setupEnvironment(process.env) };
 describe('token transfer test', () => {
   jest.setTimeout(10 * 60 * 2000); // 20 minutes
 

--- a/yarn-project/end-to-end/src/spartan/4epochs.test.ts
+++ b/yarn-project/end-to-end/src/spartan/4epochs.test.ts
@@ -16,7 +16,7 @@ import {
 } from './setup_test_wallets.js';
 import { setupEnvironment, startPortForwardForEthereum, startPortForwardForRPC } from './utils.js';
 
-const config = { ...setupEnvironment(process.env), REAL_VERIFIER: true }; // TODO: remove REAL_VERIFIER: true
+const config = { ...setupEnvironment(process.env) };
 
 describe('token transfer test', () => {
   jest.setTimeout(10 * 60 * 4000); // 40 minutes

--- a/yarn-project/end-to-end/src/spartan/n_tps.test.ts
+++ b/yarn-project/end-to-end/src/spartan/n_tps.test.ts
@@ -12,7 +12,7 @@ import {
 } from './setup_test_wallets.js';
 import { setupEnvironment, startPortForwardForRPC } from './utils.js';
 
-const config = { ...setupEnvironment(process.env), REAL_VERIFIER: true }; // TODO: remove REAL_VERIFIER: true
+const config = { ...setupEnvironment(process.env) };
 
 describe('sustained 10 TPS test', () => {
   jest.setTimeout(20 * 60 * 1000); // 20 minutes

--- a/yarn-project/end-to-end/src/spartan/reorg.test.ts
+++ b/yarn-project/end-to-end/src/spartan/reorg.test.ts
@@ -16,7 +16,7 @@ import {
 } from './setup_test_wallets.js';
 import { applyProverFailure, setupEnvironment, startPortForwardForEthereum, startPortForwardForRPC } from './utils.js';
 
-const config = { ...setupEnvironment(process.env), REAL_VERIFIER: true }; // todo: remove REAL_VERIFIER condition, currently false produces invalid proofs
+const config = { ...setupEnvironment(process.env) };
 const debugLogger = createLogger('e2e:spartan-test:reorg');
 
 async function checkBalances(testAccounts: TestAccounts, mintAmount: bigint, totalAmountTransferred: bigint) {

--- a/yarn-project/end-to-end/src/spartan/setup_test_wallets.ts
+++ b/yarn-project/end-to-end/src/spartan/setup_test_wallets.ts
@@ -88,10 +88,11 @@ export async function deploySponsoredTestAccounts(
 
   await registerSponsoredFPC(wallet);
 
+  const paymentMethod = new SponsoredFeePaymentMethod(await getSponsoredFPCAddress());
+  await recipientAccount.deploy({ fee: { paymentMethod } }).wait({ timeout: 2400 });
   await Promise.all(
     fundedAccounts.map(async a => {
-      const paymentMethod = new SponsoredFeePaymentMethod(await getSponsoredFPCAddress());
-      await recipientAccount.deploy({ fee: { paymentMethod } }).wait({ timeout: 2400 }); // increase timeout on purpose in order to account for two empty epochs
+      await a.deploy({ fee: { paymentMethod } }).wait({ timeout: 2400 }); // increase timeout on purpose in order to account for two empty epochs
       logger.info(`Account deployed at ${a.getAddress()}`);
     }),
   );


### PR DESCRIPTION
- Allow terraform to correctly use mocked proofs for validators and RPC node
- Removes the real proofs from 
     - `1tps.test.ts`
     - `n_tps.test.ts` 
     - `4epochs.test.ts `
     - `reorg.test.ts`
     - tests to use mocked proofs 
- Fix `transfer.test.ts` by fixing the wallet setup to correctly deploy funded accounts.