### PR TITLE
fix: Validate full proposal header during reexecution

### DIFF
--- a/yarn-project/stdlib/src/p2p/consensus_payload.ts
+++ b/yarn-project/stdlib/src/p2p/consensus_payload.ts
@@ -64,6 +64,14 @@ export class ConsensusPayload implements Signable {
     return serializeToBuffer([this.header, this.archive, this.stateReference]);
   }
 
+  public equals(other: ConsensusPayload): boolean {
+    return (
+      this.header.equals(other.header) &&
+      this.archive.equals(other.archive) &&
+      this.stateReference.equals(other.stateReference)
+    );
+  }
+
   static fromBuffer(buf: Buffer | BufferReader): ConsensusPayload {
     const reader = BufferReader.asReader(buf);
     const payload = new ConsensusPayload(
@@ -101,6 +109,14 @@ export class ConsensusPayload implements Signable {
     }
     this.size = this.toBuffer().length;
     return this.size;
+  }
+
+  toInspect() {
+    return {
+      header: this.header.toInspect(),
+      archive: this.archive.toString(),
+      stateReference: this.stateReference.toInspect(),
+    };
   }
 
   toString() {

--- a/yarn-project/stdlib/src/rollup/checkpoint_header.ts
+++ b/yarn-project/stdlib/src/rollup/checkpoint_header.ts
@@ -83,6 +83,19 @@ export class CheckpointHeader {
     );
   }
 
+  equals(other: CheckpointHeader) {
+    return (
+      this.lastArchiveRoot.equals(other.lastArchiveRoot) &&
+      this.contentCommitment.equals(other.contentCommitment) &&
+      this.slotNumber.equals(other.slotNumber) &&
+      this.timestamp === other.timestamp &&
+      this.coinbase.equals(other.coinbase) &&
+      this.feeRecipient.equals(other.feeRecipient) &&
+      this.gasFees.equals(other.gasFees) &&
+      this.totalManaUsed.equals(other.totalManaUsed)
+    );
+  }
+
   toBuffer() {
     // Note: The order here must match the order in the ProposedHeaderLib solidity library.
     return serializeToBuffer([

--- a/yarn-project/stdlib/src/tx/state_reference.ts
+++ b/yarn-project/stdlib/src/tx/state_reference.ts
@@ -137,6 +137,6 @@ export class StateReference {
   }
 
   public equals(other: this): boolean {
-    return this.l1ToL2MessageTree.root.equals(other.l1ToL2MessageTree.root) && this.partial.equals(other.partial);
+    return this.l1ToL2MessageTree.equals(other.l1ToL2MessageTree) && this.partial.equals(other.partial);
   }
 }


### PR DESCRIPTION
Handles malformed proposals where the archive root is not properly derived from the other tree roots, aka _the @alexghr Friday attack_. Also checks that the block proposal is not for a block that already exists, since the proposer had complete freedom to set any past block number for the reexecution (though this would later fail in L1).

Fixes https://linear.app/aztec-labs/issue/A-84/validate-full-block-proposal-before-attesting
