### PR TITLE
chore: enable testnet-compatibility test when targeting v2

### DIFF
--- a/yarn-project/bootstrap.sh
+++ b/yarn-project/bootstrap.sh
@@ -155,7 +155,7 @@ function test_cmds {
   echo "$hash cd yarn-project/kv-store && yarn test"
   echo "$hash cd yarn-project/ivc-integration && yarn test:browser"
 
-  if [[ "${TARGET_BRANCH:-}" == "master" || "${TARGET_BRANCH:-}" == "staging" ]]; then
+  if [[ "${TARGET_BRANCH:-}" =~ ^v[0-9]+$ ]]; then
     echo "$hash yarn-project/scripts/run_test.sh aztec/src/testnet_compatibility.test.ts"
   fi
 }


### PR DESCRIPTION
backport of bootstrap changes in #17195 

Related A-82