### PR TITLE
fix: use correct range constraints in non-native field multiplication tests (in ultra builder)

### DIFF
--- a/barretenberg/cpp/src/barretenberg/circuit_checker/ultra_circuit_builder.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/circuit_checker/ultra_circuit_builder.test.cpp
@@ -709,6 +709,7 @@ TEST(UltraCircuitBuilder, NonNativeFieldMultiplicationRegression)
     builder.range_constrain_two_limbs(lo_1_idx, hi_1_idx, 70, 70);
     bool result_b = CircuitChecker::check(builder);
     EXPECT_EQ(result_b, false);
+    EXPECT_EQ(builder.err(), "range_constrain_two_limbs: hi limb.");
 }
 
 /**

--- a/barretenberg/cpp/src/barretenberg/circuit_checker/ultra_circuit_builder.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/circuit_checker/ultra_circuit_builder.test.cpp
@@ -1,9 +1,12 @@
 #include "barretenberg/stdlib_circuit_builders/ultra_circuit_builder.hpp"
 #include "barretenberg/circuit_checker/circuit_checker.hpp"
 #include "barretenberg/crypto/pedersen_commitment/pedersen.hpp"
+#include "barretenberg/numeric/uint256/uint256.hpp"
+#include "barretenberg/stdlib/primitives/circuit_builders/circuit_builders_fwd.hpp"
 #include "barretenberg/stdlib_circuit_builders/mock_circuits.hpp"
 #include "barretenberg/stdlib_circuit_builders/plookup_tables/fixed_base/fixed_base.hpp"
 
+#include <cstddef>
 #include <gtest/gtest.h>
 
 using namespace bb;
@@ -577,24 +580,14 @@ TEST(UltraCircuitBuilder, ComposedRangeConstraint)
     EXPECT_EQ(result, true);
 }
 
-TEST(UltraCircuitBuilder, NonNativeFieldMultiplication)
+static std::array<uint32_t, 2> helper_non_native_multiplication(UltraCircuitBuilder& builder,
+                                                                const fq& a,
+                                                                const fq& b,
+                                                                const uint256_t& q,
+                                                                const uint256_t& r,
+                                                                const uint256_t& modulus)
 {
-    UltraCircuitBuilder builder = UltraCircuitBuilder();
-
-    fq a = fq::random_element();
-    fq b = fq::random_element();
-    uint256_t modulus = fq::modulus;
-
-    uint1024_t a_big = uint512_t(uint256_t(a));
-    uint1024_t b_big = uint512_t(uint256_t(b));
-    uint1024_t p_big = uint512_t(uint256_t(modulus));
-
-    uint1024_t q_big = (a_big * b_big) / p_big;
-    uint1024_t r_big = (a_big * b_big) % p_big;
-
-    uint256_t q(q_big.lo.lo);
-    uint256_t r(r_big.lo.lo);
-
+    // Splits a 256-bit integer into 4 68-bit limbs
     const auto split_into_limbs = [&](const uint512_t& input) {
         constexpr size_t NUM_BITS = 68;
         std::array<fr, 4> limbs;
@@ -605,6 +598,7 @@ TEST(UltraCircuitBuilder, NonNativeFieldMultiplication)
         return limbs;
     };
 
+    // Adds the 4 limbs as circuit variables and returns their indices
     const auto get_limb_witness_indices = [&](const std::array<fr, 4>& limbs) {
         std::array<uint32_t, 4> limb_indices;
         limb_indices[0] = builder.add_variable(limbs[0]);
@@ -613,22 +607,108 @@ TEST(UltraCircuitBuilder, NonNativeFieldMultiplication)
         limb_indices[3] = builder.add_variable(limbs[3]);
         return limb_indices;
     };
+
+    // Compute negative modulus: (-p) := 2^T - p
     const uint512_t BINARY_BASIS_MODULUS = uint512_t(1) << (68 * 4);
     auto modulus_limbs = split_into_limbs(BINARY_BASIS_MODULUS - uint512_t(modulus));
 
+    // Add a, b, q, r as circuit variables
     const auto a_indices = get_limb_witness_indices(split_into_limbs(uint256_t(a)));
     const auto b_indices = get_limb_witness_indices(split_into_limbs(uint256_t(b)));
     const auto q_indices = get_limb_witness_indices(split_into_limbs(uint256_t(q)));
     const auto r_indices = get_limb_witness_indices(split_into_limbs(uint256_t(r)));
 
+    // Prepare inputs for non-native multiplication gadget
     non_native_multiplication_witnesses<fr> inputs{
         a_indices, b_indices, q_indices, r_indices, modulus_limbs,
     };
     const auto [lo_1_idx, hi_1_idx] = builder.evaluate_non_native_field_multiplication(inputs);
-    builder.range_constrain_two_limbs(lo_1_idx, hi_1_idx, 70, 70);
 
-    bool result = CircuitChecker::check(builder);
-    EXPECT_EQ(result, true);
+    return { lo_1_idx, hi_1_idx };
+}
+
+TEST(UltraCircuitBuilder, NonNativeFieldMultiplication)
+{
+    const size_t num_iterations = 50;
+    for (size_t i = 0; i < num_iterations; i++) {
+        UltraCircuitBuilder builder = UltraCircuitBuilder();
+
+        fq a = fq::random_element();
+        fq b = fq::random_element();
+        uint256_t modulus = fq::modulus;
+
+        uint1024_t a_big = uint512_t(uint256_t(a));
+        uint1024_t b_big = uint512_t(uint256_t(b));
+        uint1024_t p_big = uint512_t(uint256_t(modulus));
+
+        uint1024_t q_big = (a_big * b_big) / p_big;
+        uint1024_t r_big = (a_big * b_big) % p_big;
+
+        uint256_t q(q_big.lo.lo);
+        uint256_t r(r_big.lo.lo);
+
+        const auto [lo_1_idx, hi_1_idx] = helper_non_native_multiplication(builder, a, b, q, r, modulus);
+
+        // Range check the carry (output) lo and hi limbs
+        const bool is_low_70_bits = uint256_t(builder.get_variable(lo_1_idx)).get_msb() < 70;
+        const bool is_high_70_bits = uint256_t(builder.get_variable(hi_1_idx)).get_msb() < 70;
+        if (is_low_70_bits && is_high_70_bits) {
+            // Uses more efficient NNF range check if both limbs are < 2^70
+            builder.range_constrain_two_limbs(lo_1_idx, hi_1_idx, 70, 70);
+        } else {
+            // Fallback to default range checks
+            builder.decompose_into_default_range(lo_1_idx, 72);
+            builder.decompose_into_default_range(hi_1_idx, 72);
+        }
+
+        bool result = CircuitChecker::check(builder);
+        EXPECT_EQ(result, true);
+    }
+}
+
+TEST(UltraCircuitBuilder, NonNativeFieldMultiplicationRegression)
+{
+    UltraCircuitBuilder builder = UltraCircuitBuilder();
+
+    // Edge case values
+    uint256_t a_u256 = uint256_t("0x00ab1504deacff852326adf4a01099e9340f232e2a631042852fce3c4eb8a51b");
+    uint256_t b_u256 = uint256_t("0x1be457323502cfcd85f8cfa54c8c4fea146b9db2a7d86b29d966d61b714ee249");
+    uint256_t q_u256 = uint256_t("0x00629b9d576dfc6b5c28a4a254d5e8e3384124f6a898858e95265254a01414d5");
+    uint256_t r_u256 = uint256_t("0x2c1590eb70a48dce72f7686bbf79b59bf7926c99bc16aba92e474c65a04ea2a0");
+    uint256_t modulus = fq::modulus;
+
+    // Check if native computation yeils same q and r
+    uint1024_t a_big = uint512_t(a_u256);
+    uint1024_t b_big = uint512_t(b_u256);
+    uint1024_t p_big = uint512_t(uint256_t(modulus));
+
+    uint1024_t q_big = (a_big * b_big) / p_big;
+    uint1024_t r_big = (a_big * b_big) % p_big;
+    uint256_t q_computed(q_big.lo.lo);
+    uint256_t r_computed(r_big.lo.lo);
+
+    EXPECT_EQ(q_computed, q_u256);
+    EXPECT_EQ(r_computed, r_u256);
+
+    // This edge case leads to the carry limb being > 2^70, so it used to fail when appying a 2^70 range check
+    // (with range_constrain_two_limbs). Now it should work since we fallback to default range checks in such a case.
+    const auto [lo_1_idx, hi_1_idx] =
+        helper_non_native_multiplication(builder, a_u256, b_u256, q_u256, r_u256, modulus);
+
+    // Range check the carry (output) lo and hi limbs
+    const bool is_high_70_bits = uint256_t(builder.get_variable(hi_1_idx)).get_msb() < 70;
+    ASSERT(is_high_70_bits == false); // Regression should hit this case
+
+    // Decompose into default range: these should work even if the limbs are > 2^70
+    builder.decompose_into_default_range(lo_1_idx, 72);
+    builder.decompose_into_default_range(hi_1_idx, 72);
+    bool result_a = CircuitChecker::check(builder);
+    EXPECT_EQ(result_a, true);
+
+    // Using NNF range check should fail here
+    builder.range_constrain_two_limbs(lo_1_idx, hi_1_idx, 70, 70);
+    bool result_b = CircuitChecker::check(builder);
+    EXPECT_EQ(result_b, false);
 }
 
 /**
@@ -653,37 +733,19 @@ TEST(UltraCircuitBuilder, NonNativeFieldMultiplicationSortCheck)
     uint256_t q(q_big.lo.lo);
     uint256_t r(r_big.lo.lo);
 
-    const auto split_into_limbs = [&](const uint512_t& input) {
-        constexpr size_t NUM_BITS = 68;
-        std::array<fr, 4> limbs;
-        limbs[0] = input.slice(0, NUM_BITS).lo;
-        limbs[1] = input.slice(NUM_BITS * 1, NUM_BITS * 2).lo;
-        limbs[2] = input.slice(NUM_BITS * 2, NUM_BITS * 3).lo;
-        limbs[3] = input.slice(NUM_BITS * 3, NUM_BITS * 4).lo;
-        return limbs;
-    };
+    const auto [lo_1_idx, hi_1_idx] = helper_non_native_multiplication(builder, a, b, q, r, modulus);
 
-    const auto get_limb_witness_indices = [&](const std::array<fr, 4>& limbs) {
-        std::array<uint32_t, 4> limb_indices;
-        limb_indices[0] = builder.add_variable(limbs[0]);
-        limb_indices[1] = builder.add_variable(limbs[1]);
-        limb_indices[2] = builder.add_variable(limbs[2]);
-        limb_indices[3] = builder.add_variable(limbs[3]);
-        return limb_indices;
-    };
-    const uint512_t BINARY_BASIS_MODULUS = uint512_t(1) << (68 * 4);
-    auto modulus_limbs = split_into_limbs(BINARY_BASIS_MODULUS - uint512_t(modulus));
-
-    const auto a_indices = get_limb_witness_indices(split_into_limbs(uint256_t(a)));
-    const auto b_indices = get_limb_witness_indices(split_into_limbs(uint256_t(b)));
-    const auto q_indices = get_limb_witness_indices(split_into_limbs(uint256_t(q)));
-    const auto r_indices = get_limb_witness_indices(split_into_limbs(uint256_t(r)));
-
-    non_native_multiplication_witnesses<fr> inputs{
-        a_indices, b_indices, q_indices, r_indices, modulus_limbs,
-    };
-    const auto [lo_1_idx, hi_1_idx] = builder.evaluate_non_native_field_multiplication(inputs);
-    builder.range_constrain_two_limbs(lo_1_idx, hi_1_idx, 70, 70);
+    // Range check the carry (output) lo and hi limbs
+    const bool is_low_70_bits = uint256_t(builder.get_variable(lo_1_idx)).get_msb() < 70;
+    const bool is_high_70_bits = uint256_t(builder.get_variable(hi_1_idx)).get_msb() < 70;
+    if (is_low_70_bits && is_high_70_bits) {
+        // Uses more efficient NNF range check if both limbs are < 2^70
+        builder.range_constrain_two_limbs(lo_1_idx, hi_1_idx, 70, 70);
+    } else {
+        // Fallback to default range checks
+        builder.decompose_into_default_range(lo_1_idx, 72);
+        builder.decompose_into_default_range(hi_1_idx, 72);
+    }
 
     bool result = CircuitChecker::check(builder);
     EXPECT_EQ(result, true);

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
@@ -208,14 +208,16 @@ template <typename Builder, typename T> class bigfield {
         ctx->range_constrain_two_limbs(result.binary_basis_limbs[0].element.get_normalized_witness_index(),
                                        result.binary_basis_limbs[1].element.get_normalized_witness_index(),
                                        static_cast<size_t>(NUM_LIMB_BITS),
-                                       static_cast<size_t>(NUM_LIMB_BITS));
+                                       static_cast<size_t>(NUM_LIMB_BITS),
+                                       "bigfield::construct_from_limbs: limb 0 or 1 too large");
 
         // Range constrain the last two limbs to NUM_LIMB_BITS and NUM_LAST_LIMB_BITS
         const size_t num_last_limb_bits = (can_overflow) ? NUM_LIMB_BITS : NUM_LAST_LIMB_BITS;
         ctx->range_constrain_two_limbs(result.binary_basis_limbs[2].element.get_normalized_witness_index(),
                                        result.binary_basis_limbs[3].element.get_normalized_witness_index(),
                                        static_cast<size_t>(NUM_LIMB_BITS),
-                                       static_cast<size_t>(num_last_limb_bits));
+                                       static_cast<size_t>(num_last_limb_bits),
+                                       "bigfield::construct_from_limbs: limb 2 or 3 too large");
 
         return result;
     };

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
@@ -195,11 +195,13 @@ bigfield<Builder, T> bigfield<Builder, T>::create_from_u512_as_witness(Builder* 
     ctx->range_constrain_two_limbs(limb_0.get_normalized_witness_index(),
                                    limb_1.get_normalized_witness_index(),
                                    static_cast<size_t>(NUM_LIMB_BITS),
-                                   static_cast<size_t>(NUM_LIMB_BITS));
+                                   static_cast<size_t>(NUM_LIMB_BITS),
+                                   "bigfield::create_from_u512_as_witness: limb 0 or 1 too large");
     ctx->range_constrain_two_limbs(limb_2.get_normalized_witness_index(),
                                    limb_3.get_normalized_witness_index(),
                                    static_cast<size_t>(NUM_LIMB_BITS),
-                                   static_cast<size_t>(num_last_limb_bits));
+                                   static_cast<size_t>(num_last_limb_bits),
+                                   "bigfield::create_from_u512_as_witness: limb 2 or 3 too large");
 
     // Mark the element as coming out of nowhere
     result.set_free_witness_tag();
@@ -2249,7 +2251,8 @@ void bigfield<Builder, T>::unsafe_evaluate_multiply_add(const bigfield& input_le
         ctx->range_constrain_two_limbs(hi.get_normalized_witness_index(),
                                        lo.get_normalized_witness_index(),
                                        static_cast<size_t>(carry_hi_msb),
-                                       static_cast<size_t>(carry_lo_msb));
+                                       static_cast<size_t>(carry_lo_msb),
+                                       "bigfield::unsafe_evaluate_multiply_add: carries too large");
     } else {
         ctx->decompose_into_default_range(hi.get_normalized_witness_index(), carry_hi_msb);
         ctx->decompose_into_default_range(lo.get_normalized_witness_index(), carry_lo_msb);
@@ -2548,7 +2551,8 @@ void bigfield<Builder, T>::unsafe_evaluate_multiple_multiply_add(const std::vect
         ctx->range_constrain_two_limbs(hi.get_normalized_witness_index(),
                                        lo.get_normalized_witness_index(),
                                        static_cast<size_t>(carry_hi_msb),
-                                       static_cast<size_t>(carry_lo_msb));
+                                       static_cast<size_t>(carry_lo_msb),
+                                       "bigfield::unsafe_evaluate_multiply_add: carries too large");
     } else {
         ctx->decompose_into_default_range(hi.get_normalized_witness_index(), carry_hi_msb);
         ctx->decompose_into_default_range(lo.get_normalized_witness_index(), carry_lo_msb);

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.cpp
@@ -1633,7 +1633,7 @@ void UltraCircuitBuilder_<ExecutionTrace>::range_constrain_two_limbs(const uint3
     BB_ASSERT_LTE(lo_limb_bits, 14U * 5U);
     BB_ASSERT_LTE(hi_limb_bits, 14U * 5U);
 
-    // If the value is larger than the range, we raise the error flag
+    // If the value is larger than the range, we log the error in builder
     if (uint256_t(this->get_variable_reference(lo_idx)) >= (uint256_t(1) << lo_limb_bits)) {
         this->failure(msg + ": lo limb.");
     }
@@ -1726,7 +1726,8 @@ std::array<uint32_t, 2> UltraCircuitBuilder_<ExecutionTrace>::decompose_non_nati
     BB_ASSERT_GT(num_limb_bits, DEFAULT_NON_NATIVE_FIELD_LIMB_BITS);
     const size_t lo_bits = DEFAULT_NON_NATIVE_FIELD_LIMB_BITS;
     const size_t hi_bits = num_limb_bits - DEFAULT_NON_NATIVE_FIELD_LIMB_BITS;
-    range_constrain_two_limbs(low_idx, hi_idx, lo_bits, hi_bits);
+    range_constrain_two_limbs(
+        low_idx, hi_idx, lo_bits, hi_bits, "decompose_non_native_field_double_width_limb: limbs too large");
 
     return std::array<uint32_t, 2>{ low_idx, hi_idx };
 }

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.cpp
@@ -1625,12 +1625,21 @@ template <typename ExecutionTrace>
 void UltraCircuitBuilder_<ExecutionTrace>::range_constrain_two_limbs(const uint32_t lo_idx,
                                                                      const uint32_t hi_idx,
                                                                      const size_t lo_limb_bits,
-                                                                     const size_t hi_limb_bits)
+                                                                     const size_t hi_limb_bits,
+                                                                     std::string const& msg)
 {
     // Validate limbs are <= 70 bits. If limbs are larger we require more witnesses and cannot use our limb accumulation
     // custom gate
     BB_ASSERT_LTE(lo_limb_bits, 14U * 5U);
     BB_ASSERT_LTE(hi_limb_bits, 14U * 5U);
+
+    // If the value is larger than the range, we raise the error flag
+    if (uint256_t(this->get_variable_reference(lo_idx)) >= (uint256_t(1) << lo_limb_bits)) {
+        this->failure(msg + ": lo limb.");
+    }
+    if (uint256_t(this->get_variable_reference(hi_idx)) >= (uint256_t(1) << hi_limb_bits)) {
+        this->failure(msg + ": hi limb.");
+    }
 
     // Sometimes we try to use limbs that are too large. It's easier to catch this issue here
     const auto get_sublimbs = [&](const uint32_t& limb_idx, const std::array<uint64_t, 5>& sublimb_masks) {

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.hpp
@@ -794,7 +794,8 @@ class UltraCircuitBuilder_ : public CircuitBuilderBase<typename ExecutionTrace_:
     void range_constrain_two_limbs(const uint32_t lo_idx,
                                    const uint32_t hi_idx,
                                    const size_t lo_limb_bits = DEFAULT_NON_NATIVE_FIELD_LIMB_BITS,
-                                   const size_t hi_limb_bits = DEFAULT_NON_NATIVE_FIELD_LIMB_BITS);
+                                   const size_t hi_limb_bits = DEFAULT_NON_NATIVE_FIELD_LIMB_BITS,
+                                   std::string const& msg = "range_constrain_two_limbs");
     std::array<uint32_t, 2> decompose_non_native_field_double_width_limb(
         const uint32_t limb_idx, const size_t num_limb_bits = (2 * DEFAULT_NON_NATIVE_FIELD_LIMB_BITS));
     std::array<uint32_t, 2> evaluate_non_native_field_multiplication(

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_honk.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_honk.test.cpp
@@ -876,7 +876,18 @@ TYPED_TEST(UltraHonkTests, NonNativeFieldMultiplication)
         a_indices, b_indices, q_indices, r_indices, modulus_limbs,
     };
     const auto [lo_1_idx, hi_1_idx] = circuit_builder.evaluate_non_native_field_multiplication(inputs);
-    circuit_builder.range_constrain_two_limbs(lo_1_idx, hi_1_idx, 70, 70);
+
+    // Range constrain the lo and hi carry outputs
+    const bool is_low_70_bits = uint256_t(circuit_builder.get_variable(lo_1_idx)).get_msb() < 70;
+    const bool is_high_70_bits = uint256_t(circuit_builder.get_variable(hi_1_idx)).get_msb() < 70;
+    if (is_low_70_bits && is_high_70_bits) {
+        // Uses more efficient NNF range check if both limbs are < 2^70
+        circuit_builder.range_constrain_two_limbs(lo_1_idx, hi_1_idx, 70, 70);
+    } else {
+        // Fallback to default range checks
+        circuit_builder.decompose_into_default_range(lo_1_idx, 72);
+        circuit_builder.decompose_into_default_range(hi_1_idx, 72);
+    }
 
     TestFixture::set_default_pairing_points_and_ipa_claim_and_proof(circuit_builder);
 


### PR DESCRIPTION
Fixes the rare test failures seen in `UltraCircuitBuilder` tests in non-native field multiplication.

tldr: we were range constraining the output carries `hi, lo` to be 70 bit numbers each, but in some cases, these could be 71 or 72-bit numbers. 

### The Issue

In the `UltraCircuitBuilder.NonNativeFieldMultiplication` test, we range-constrained the lo and hi carries to be 70-bit field elements:

https://github.com/AztecProtocol/aztec-packages/blob/41110d306c1e5bb616c6eadb4a9f86556f9bddf8/barretenberg/cpp/src/barretenberg/circuit_checker/ultra_circuit_builder.test.cpp#L627-L628  

The function `range_constrain_two_limbs` uses custom NNF gates to range constrain the inputs by breaking them up in 5 parts each of 14 bits. In other words, it allows number of bits ≤ 70. 

In our test, since we choose random inputs $a, b \in \mathbb{F}_q$ for non-native field multiplication, the carries lo and hi could have more than 70 bits. One such example is:

```cpp
uint256_t a_u256 = uint256_t("0x00ab1504deacff852326adf4a01099e9340f232e2a631042852fce3c4eb8a51b");
uint256_t b_u256 = uint256_t("0x1be457323502cfcd85f8cfa54c8c4fea146b9db2a7d86b29d966d61b714ee249");
uint256_t q_u256 = uint256_t("0x00629b9d576dfc6b5c28a4a254d5e8e3384124f6a898858e95265254a01414d5");
uint256_t r_u256 = uint256_t("0x2c1590eb70a48dce72f7686bbf79b59bf7926c99bc16aba92e474c65a04ea2a0");
```

In this example, the hi carry is a 71-bit number and hence it (silently) fails the range-constraint by the function `range_constrain_two_limbs`. 

### Fix

I've modified the test(s) to check if the lo or hi contain more than 70 bits and if so, use `decompose_into_default_range` which allows for larger ranges. I set the range in `decompose_into_default_range` to be 72 bits. See below for why this is sufficient. I've also modified the original `NonNativeFieldMultiplication` test to run for 50 iterations, and added a regression test to show that the fix works for the edge case example. I've also added error logging in usage of `range_constrain_two_limbs`.

### Appendix

To understand why 72 bits is a sufficient range for the edge cases, recall that the max values $(\textcolor{orange}{M_{\textsf{lo}}}, \textcolor{orange}{M_{\textsf{hi}}})$ of the low and high outputs respectively must be:

$$\textsf{max}(\textcolor{orange}{M_{\textsf{lo}}}, \textcolor{orange}{M_{\textsf{hi}}}) < 2^{2Q + L + 3}$$

where $Q$ is the bit-size of the limbs. Refer to the README in bigfield to understand how we get this bound. In the test cases, we know that $Q = L = 68$. Thus, the max values will always be less than $(3L + 3)$. The carry is computed by dividing the max values by $2^{2L}$ and hence the max carry values will always be less than 

$$\frac{2^{(3L + 3)}}{2^{2L}} = 2^{L +3} = 2^{71}$$ 

i.e., 71 bit range constraint should suffice. 

In bigfield computations, we allow the limb sizes to grow to $Q = 78$, in which case this bound would translate to:

$$\frac{2^{(2Q + L + 3)}}{2^{2L}} = 2^{91}$$