### PR TITLE
chore: Allow using publishers in invalid states

### DIFF
--- a/yarn-project/sequencer-client/src/publisher/config.ts
+++ b/yarn-project/sequencer-client/src/publisher/config.ts
@@ -74,7 +74,7 @@ export const getPublisherConfigMappings: (
   publisherAllowInvalidStates: {
     description: 'True to use publishers in invalid states (timed out, cancelled, etc) if no other is available',
     env: scope === `PROVER` ? `PROVER_PUBLISHER_ALLOW_INVALID_STATES` : `SEQ_PUBLISHER_ALLOW_INVALID_STATES`,
-    ...booleanConfigHelper(false),
+    ...booleanConfigHelper(true),
   },
   ...l1TxUtilsConfigMappings,
   ...blobSinkConfigMapping,


### PR DESCRIPTION
To avoid `Failed to find an available publisher` errors after an L1 tx timeout. This should help reduce flakes until we wrap up all changes related to publisher EOAs.

Given that the config flag was added in #17131, this PR just changes the default to true.
