### PR TITLE
chore: temporarily disable smt build

### DIFF
--- a/barretenberg/cpp/bootstrap.sh
+++ b/barretenberg/cpp/bootstrap.sh
@@ -148,17 +148,17 @@ function build_fuzzing_syntax_check_only {
 }
 
 # Do basic tests that the smt preset still compiles and runs
-function build_smt_verification {
-  set -eu
-  if cache_download barretenberg-smt-$hash.zst; then
-    return
-  fi
+# function build_smt_verification {
+#   set -eu
+#   if cache_download barretenberg-smt-$hash.zst; then
+#     return
+#   fi
 
-  sudo apt update && sudo apt install -y python3-pip python3-venv m4 bison
-  cmake --preset smt-verification
-  cmake --build build-smt --target smt_verification_tests
-  cache_upload barretenberg-smt-$hash.zst build-smt
-}
+#   sudo apt update && sudo apt install -y python3-pip python3-venv m4 bison
+#   cmake --preset smt-verification
+#   cmake --build build-smt --target smt_verification_tests
+#   cache_upload barretenberg-smt-$hash.zst build-smt
+# }
 
 function build_release {
   local arch=$(arch)
@@ -178,7 +178,7 @@ function build_release {
   fi
 }
 
-export -f build_preset build_native build_asan_fast build_darwin build_nodejs_module build_wasm build_wasm_threads build_gcc_syntax_check_only build_fuzzing_syntax_check_only build_smt_verification
+export -f build_preset build_native build_asan_fast build_darwin build_nodejs_module build_wasm build_wasm_threads build_gcc_syntax_check_only build_fuzzing_syntax_check_only
 
 function build {
   echo_header "bb cpp build"
@@ -189,7 +189,7 @@ function build {
     build_wasm_threads
   )
   if [ "$(arch)" == "amd64" ] && [ "$CI" -eq 1 ]; then
-    builds+=(build_gcc_syntax_check_only build_fuzzing_syntax_check_only build_asan_fast build_smt_verification)
+    builds+=(build_gcc_syntax_check_only build_fuzzing_syntax_check_only build_asan_fast)
   fi
   if [ "$CI_FULL" -eq 1 ]; then
     builds+=(build_darwin)
@@ -239,11 +239,11 @@ function test_cmds {
     done
   fi
 
-  # Run the SMT compatibility tests
-  if [ "$(arch)" == "amd64" ] &&  [ "$CI" -eq 1 ]; then
-    local prefix="$hash:CPUS=4:MEM=8g"
-    echo -e "$prefix barretenberg/cpp/build-smt/bin/smt_verification_tests"
-  fi
+  # # Run the SMT compatibility tests
+  # if [ "$(arch)" == "amd64" ] &&  [ "$CI" -eq 1 ]; then
+  #   local prefix="$hash:CPUS=4:MEM=8g"
+  #   echo -e "$prefix barretenberg/cpp/build-smt/bin/smt_verification_tests"
+  # fi
 
   echo "$hash barretenberg/cpp/scripts/test_civc_standalone_vks_havent_changed.sh"
 }
@@ -354,7 +354,7 @@ case "$cmd" in
   "hash")
     echo $hash
     ;;
-  test|test_cmds|bench|bench_cmds|build_bench|release|build_native|build_nodejs_module|build_asan_fast|build_wasm|build_wasm_threads|build_gcc_syntax_check_only|build_fuzzing_syntax_check_only|build_darwin|build_release|build_smt_verification|inject_version)
+  test|test_cmds|bench|bench_cmds|build_bench|release|build_native|build_nodejs_module|build_asan_fast|build_wasm|build_wasm_threads|build_gcc_syntax_check_only|build_fuzzing_syntax_check_only|build_darwin|build_release|inject_version)
     $cmd "$@"
     ;;
   *)


### PR DESCRIPTION
There is some intermittent issue with the smt_verification build that is cause CI/development pain. Disabling until it can be properly resolved.