### PR TITLE
chore: Rename method to create random valid IPA proof

### DIFF
--- a/barretenberg/cpp/src/barretenberg/boomerang_value_detection/graph_description_ultra_recursive_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/boomerang_value_detection/graph_description_ultra_recursive_verifier.test.cpp
@@ -82,7 +82,7 @@ template <typename RecursiveFlavor> class BoomerangRecursiveVerifierTest : publi
 
         if constexpr (HasIPAAccumulator<RecursiveFlavor>) {
             auto [stdlib_opening_claim, ipa_proof] =
-                IPA<grumpkin<InnerBuilder>>::create_fake_ipa_claim_and_proof(builder);
+                IPA<grumpkin<InnerBuilder>>::create_random_valid_ipa_claim_and_proof(builder);
             stdlib_opening_claim.set_public();
             builder.ipa_proof = ipa_proof;
         }

--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/ipa/ipa.hpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/ipa/ipa.hpp
@@ -909,7 +909,7 @@ template <typename Curve_, size_t log_poly_length = CONST_ECCVM_LOG_N> class IPA
         return {output_claim, prover_transcript->export_proof()};
     }
 
-    static std::pair<OpeningClaim<Curve>, HonkProof> create_fake_ipa_claim_and_proof(UltraCircuitBuilder& builder)
+    static std::pair<OpeningClaim<Curve>, HonkProof> create_random_valid_ipa_claim_and_proof(UltraCircuitBuilder& builder)
     requires Curve::is_stdlib_type {
         using NativeCurve = curve::Grumpkin;
         using Builder = typename Curve::Builder;

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_format.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_format.cpp
@@ -474,7 +474,7 @@ std::pair<OpeningClaim<stdlib::grumpkin<Builder>>, HonkProof> handle_IPA_accumul
         // UltraRollupHonk, indicated by the manual setting of the honk_recursion metadata to 2.
         info("Proving with UltraRollupHonk but no IPA claims exist.");
         auto [stdlib_opening_claim, ipa_proof] =
-            IPA<stdlib::grumpkin<Builder>>::create_fake_ipa_claim_and_proof(builder);
+            IPA<stdlib::grumpkin<Builder>>::create_random_valid_ipa_claim_and_proof(builder);
 
         final_ipa_claim = stdlib_opening_claim;
         final_ipa_proof = ipa_proof;

--- a/barretenberg/cpp/src/barretenberg/flavor/native_verification_key.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/native_verification_key.test.cpp
@@ -35,7 +35,8 @@ template <typename Flavor> class NativeVerificationKeyTests : public ::testing::
         stdlib::recursion::PairingPoints<typename Flavor::CircuitBuilder>::add_default_to_public_inputs(builder);
         if constexpr (HasIPAAccumulator<Flavor>) {
             auto [stdlib_opening_claim, ipa_proof] =
-                IPA<stdlib::grumpkin<typename Flavor::CircuitBuilder>>::create_fake_ipa_claim_and_proof(builder);
+                IPA<stdlib::grumpkin<typename Flavor::CircuitBuilder>>::create_random_valid_ipa_claim_and_proof(
+                    builder);
             stdlib_opening_claim.set_public();
             builder.ipa_proof = ipa_proof;
         }

--- a/barretenberg/cpp/src/barretenberg/flavor/stdlib_verification_key.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/stdlib_verification_key.test.cpp
@@ -21,7 +21,8 @@ template <typename Flavor> class StdlibVerificationKeyTests : public ::testing::
         stdlib::recursion::PairingPoints<typename NativeFlavor::CircuitBuilder>::add_default_to_public_inputs(builder);
         if constexpr (HasIPAAccumulator<NativeFlavor>) {
             auto [stdlib_opening_claim, ipa_proof] =
-                IPA<stdlib::grumpkin<typename NativeFlavor::CircuitBuilder>>::create_fake_ipa_claim_and_proof(builder);
+                IPA<stdlib::grumpkin<typename NativeFlavor::CircuitBuilder>>::create_random_valid_ipa_claim_and_proof(
+                    builder);
             stdlib_opening_claim.set_public();
             builder.ipa_proof = ipa_proof;
         }

--- a/barretenberg/cpp/src/barretenberg/stdlib/special_public_inputs/special_public_inputs.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/special_public_inputs/special_public_inputs.hpp
@@ -370,7 +370,8 @@ class RollupIO {
     static void add_default(Builder& builder)
     {
         PairingInputs::add_default_to_public_inputs(builder);
-        auto [stdlib_opening_claim, ipa_proof] = IPA<grumpkin<Builder>>::create_fake_ipa_claim_and_proof(builder);
+        auto [stdlib_opening_claim, ipa_proof] =
+            IPA<grumpkin<Builder>>::create_random_valid_ipa_claim_and_proof(builder);
         stdlib_opening_claim.set_public();
         builder.ipa_proof = ipa_proof;
     };

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_honk.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_honk.test.cpp
@@ -44,7 +44,7 @@ template <typename Flavor> class UltraHonkTests : public ::testing::Test {
         AggregationState::add_default_to_public_inputs(builder);
         if constexpr (HasIPAAccumulator<Flavor>) {
             auto [stdlib_opening_claim, ipa_proof] =
-                IPA<stdlib::grumpkin<UltraCircuitBuilder>>::create_fake_ipa_claim_and_proof(builder);
+                IPA<stdlib::grumpkin<UltraCircuitBuilder>>::create_random_valid_ipa_claim_and_proof(builder);
             stdlib_opening_claim.set_public();
             builder.ipa_proof = ipa_proof;
         }

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_transcript.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_transcript.test.cpp
@@ -182,7 +182,7 @@ template <typename Flavor> class UltraTranscriptTests : public ::testing::Test {
         stdlib::recursion::PairingPoints<Builder>::add_default_to_public_inputs(builder);
         if constexpr (HasIPAAccumulator<Flavor>) {
             auto [stdlib_opening_claim, ipa_proof] =
-                IPA<stdlib::grumpkin<Builder>>::create_fake_ipa_claim_and_proof(builder);
+                IPA<stdlib::grumpkin<Builder>>::create_random_valid_ipa_claim_and_proof(builder);
             stdlib_opening_claim.set_public();
             builder.ipa_proof = ipa_proof;
         }
@@ -198,7 +198,7 @@ template <typename Flavor> class UltraTranscriptTests : public ::testing::Test {
 
         if constexpr (HasIPAAccumulator<Flavor>) {
             auto [stdlib_opening_claim, ipa_proof] =
-                IPA<stdlib::grumpkin<Builder>>::create_fake_ipa_claim_and_proof(builder);
+                IPA<stdlib::grumpkin<Builder>>::create_random_valid_ipa_claim_and_proof(builder);
             stdlib_opening_claim.set_public();
             builder.ipa_proof = ipa_proof;
         }


### PR DESCRIPTION
rename the method `create_fake_ipa_claim_and_proof`, `create_random_valid_ipa_claim_and_proof` 