### PR TITLE
chore: Deflake epoch prune slash test

### DIFF
--- a/yarn-project/end-to-end/src/e2e_p2p/data_withholding_slash.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/data_withholding_slash.test.ts
@@ -47,6 +47,7 @@ describe('e2e_p2p_data_withholding_slash', () => {
   const slashingUnit = BigInt(1e18);
   const slashingQuorum = 3;
   const slashingRoundSize = 4;
+  const aztecEpochDuration = 2;
 
   beforeEach(async () => {
     t = await P2PNetworkTest.create({
@@ -57,13 +58,13 @@ describe('e2e_p2p_data_withholding_slash', () => {
       metricsPort: shouldCollectMetrics(),
       initialConfig: {
         listenAddress: '127.0.0.1',
-        aztecEpochDuration: 2,
+        aztecEpochDuration,
         ethereumSlotDuration: 4,
         aztecSlotDuration: AZTEC_SLOT_DURATION,
         aztecProofSubmissionEpochs: 0, // effectively forces instant reorgs
         aztecTargetCommitteeSize: COMMITTEE_SIZE,
         slashingQuorum,
-        slashingRoundSizeInEpochs: slashingRoundSize / 2,
+        slashingRoundSizeInEpochs: slashingRoundSize / aztecEpochDuration,
         slashAmountSmall: slashingUnit,
         slashAmountMedium: slashingUnit * 2n,
         slashAmountLarge: slashingUnit * 3n,
@@ -179,6 +180,7 @@ describe('e2e_p2p_data_withholding_slash', () => {
     // Check offenses are correct
     expect(offenses.map(o => o.validator.toChecksumString()).sort()).toEqual(committee.map(a => a.toString()).sort());
     expect(offenses.map(o => o.offenseType)).toEqual(times(COMMITTEE_SIZE, () => OffenseType.DATA_WITHHOLDING));
+    const offenseEpoch = Number(offenses[0].epochOrSlot);
 
     await awaitCommitteeKicked({
       rollup,
@@ -190,6 +192,8 @@ describe('e2e_p2p_data_withholding_slash', () => {
       aztecSlotDuration: AZTEC_SLOT_DURATION,
       logger: t.logger,
       dateProvider: t.ctx.dateProvider,
+      offenseEpoch,
+      aztecEpochDuration,
     });
   });
 });

--- a/yarn-project/end-to-end/src/e2e_p2p/valid_epoch_pruned_slash.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/valid_epoch_pruned_slash.test.ts
@@ -161,9 +161,6 @@ describe('e2e_p2p_valid_epoch_pruned_slash', () => {
     t.logger.warn(`Removing initial node`);
     await t.removeInitialNode();
 
-    // Warp forward so we can prune the epoch
-    await t.ctx.cheatCodes.rollup.advanceToNextEpoch({ updateDateProvider: t.ctx.dateProvider });
-
     // Wait for epoch to be pruned and the offense to be detected
     const offenses = await awaitOffenseDetected({
       logger: t.logger,
@@ -176,6 +173,7 @@ describe('e2e_p2p_valid_epoch_pruned_slash', () => {
     // Check offenses are correct
     expect(offenses.map(o => o.validator.toChecksumString()).sort()).toEqual(committee.map(a => a.toString()).sort());
     expect(offenses.map(o => o.offenseType)).toEqual(times(COMMITTEE_SIZE, () => OffenseType.VALID_EPOCH_PRUNED));
+    const offenseEpoch = Number(offenses[0].epochOrSlot);
 
     // And then wait for them to be kicked out
     await awaitCommitteeKicked({
@@ -188,6 +186,8 @@ describe('e2e_p2p_valid_epoch_pruned_slash', () => {
       aztecSlotDuration,
       logger: t.logger,
       dateProvider: t.ctx.dateProvider,
+      offenseEpoch,
+      aztecEpochDuration,
     });
   });
 });

--- a/yarn-project/slasher/src/watchers/epoch_prune_watcher.ts
+++ b/yarn-project/slasher/src/watchers/epoch_prune_watcher.ts
@@ -78,7 +78,6 @@ export class EpochPruneWatcher extends (EventEmitter as new () => WatcherEmitter
 
   private handlePruneL2Blocks(event: L2BlockPruneEvent): void {
     const { blocks, epochNumber } = event;
-    this.log.info(`Detected chain prune. Validating epoch ${epochNumber}`);
     void this.processPruneL2Blocks(blocks, epochNumber).catch(err =>
       this.log.error('Error processing pruned L2 blocks', err, { epochNumber }),
     );


### PR DESCRIPTION
The epoch warp was causing a voting round to be skipped in slow environments, so the slash payload was never executed.
