### PR TITLE
chore: Revert #17207

### DIFF
--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -300,7 +300,12 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, Traceable {
       deps.p2pClientDeps,
     );
 
-    // We should really not be modifying the config object
+    // Start world state and wait for it to sync to the archiver.
+    await worldStateSynchronizer.start();
+
+    // Start p2p. Note that it depends on world state to be running.
+    await p2pClient.start();
+
     config.txPublicSetupAllowList = config.txPublicSetupAllowList ?? (await getDefaultAllowedSetupFunctions());
 
     const blockBuilder = new BlockBuilder(
@@ -311,34 +316,7 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, Traceable {
       telemetry,
     );
 
-    // We'll accumulate sentinel watchers here
     const watchers: Watcher[] = [];
-
-    // Create validator client if required
-    const validatorClient = createValidatorClient(config, {
-      p2pClient,
-      telemetry,
-      dateProvider,
-      epochCache,
-      blockBuilder,
-      blockSource: archiver,
-      l1ToL2MessageSource: archiver,
-      keyStoreManager,
-    });
-
-    // If we have a validator client, register it as a source of offenses for the slasher,
-    // and have it register callbacks on the p2p client *before* we start it, otherwise messages
-    // like attestations or auths will fail.
-    if (validatorClient) {
-      watchers.push(validatorClient);
-      await validatorClient.registerHandlers();
-    }
-
-    // Start world state and wait for it to sync to the archiver.
-    await worldStateSynchronizer.start();
-
-    // Start p2p. Note that it depends on world state to be running.
-    await p2pClient.start();
 
     const validatorsSentinel = await createSentinel(epochCache, archiver, p2pClient, config);
     if (validatorsSentinel) {
@@ -369,6 +347,21 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, Traceable {
       attestationsBlockWatcher = new AttestationsBlockWatcher(archiver, epochCache, config);
       await attestationsBlockWatcher.start();
       watchers.push(attestationsBlockWatcher);
+    }
+
+    const validatorClient = createValidatorClient(config, {
+      p2pClient,
+      telemetry,
+      dateProvider,
+      epochCache,
+      blockBuilder,
+      blockSource: archiver,
+      l1ToL2MessageSource: archiver,
+      keyStoreManager,
+    });
+
+    if (validatorClient) {
+      watchers.push(validatorClient);
     }
 
     log.verbose(`All Aztec Node subsystems synced`);

--- a/yarn-project/stdlib/src/interfaces/validator.ts
+++ b/yarn-project/stdlib/src/interfaces/validator.ts
@@ -54,6 +54,7 @@ export const ValidatorClientConfigSchema = z.object({
 
 export interface Validator {
   start(): Promise<void>;
+  registerBlockProposalHandler(): void;
   updateConfig(config: Partial<ValidatorClientFullConfig>): void;
 
   // Block validation responsibilities

--- a/yarn-project/validator-client/src/validator.ts
+++ b/yarn-project/validator-client/src/validator.ts
@@ -62,9 +62,6 @@ export class ValidatorClient extends (EventEmitter as new () => WatcherEmitter) 
   private validationService: ValidationService;
   private metrics: ValidatorMetrics;
 
-  // Whether it has already registered handlers on the p2p client
-  private hasRegisteredHandlers = false;
-
   // Used to check if we are sending the same proposal twice
   private previousProposal?: BlockProposal;
 
@@ -215,9 +212,12 @@ export class ValidatorClient extends (EventEmitter as new () => WatcherEmitter) 
       return;
     }
 
-    await this.registerHandlers();
+    this.registerBlockProposalHandler();
 
+    // Sync the committee from the smart contract
+    // https://github.com/AztecProtocol/aztec-packages/issues/7962
     const myAddresses = this.getValidatorAddresses();
+
     const inCommittee = await this.epochCache.filterInCommittee('now', myAddresses);
     if (inCommittee.length > 0) {
       this.log.info(
@@ -230,6 +230,9 @@ export class ValidatorClient extends (EventEmitter as new () => WatcherEmitter) 
     }
     this.epochCacheUpdateLoop.start();
 
+    this.p2pClient.registerThisValidatorAddresses(myAddresses);
+    await this.p2pClient.addReqRespSubProtocol(ReqRespSubProtocol.AUTH, this.handleAuthRequest.bind(this));
+
     return Promise.resolve();
   }
 
@@ -237,20 +240,10 @@ export class ValidatorClient extends (EventEmitter as new () => WatcherEmitter) 
     await this.epochCacheUpdateLoop.stop();
   }
 
-  /** Register handlers on the p2p client */
-  public async registerHandlers() {
-    if (!this.hasRegisteredHandlers) {
-      this.hasRegisteredHandlers = true;
-
-      const handler = (block: BlockProposal, proposalSender: PeerId): Promise<BlockAttestation[] | undefined> =>
-        this.attestToProposal(block, proposalSender);
-      this.p2pClient.registerBlockProposalHandler(handler);
-
-      const myAddresses = this.getValidatorAddresses();
-      this.p2pClient.registerThisValidatorAddresses(myAddresses);
-
-      await this.p2pClient.addReqRespSubProtocol(ReqRespSubProtocol.AUTH, this.handleAuthRequest.bind(this));
-    }
+  public registerBlockProposalHandler() {
+    const handler = (block: BlockProposal, proposalSender: PeerId): Promise<BlockAttestation[] | undefined> =>
+      this.attestToProposal(block, proposalSender);
+    this.p2pClient.registerBlockProposalHandler(handler);
   }
 
   async attestToProposal(proposal: BlockProposal, proposalSender: PeerId): Promise<BlockAttestation[] | undefined> {


### PR DESCRIPTION
Revert "fix: Register validator callbacks on p2p client before starting (#17207)"

This reverts commit ebd08ad413e006d7b0d75ef7f4ee3ff404f1145c, reversing changes made to 2255c329a90b7a175223940f4970019ce49f792e.

This is causing an avalanche of flakes.