### PR TITLE
fix(cmake): setup env for compiler settings of liblmdb

### DIFF
--- a/barretenberg/cpp/cmake/lmdb.cmake
+++ b/barretenberg/cpp/cmake/lmdb.cmake
@@ -13,7 +13,10 @@ ExternalProject_Add(
     GIT_TAG ddd0a773e2f44d38e4e31ec9ed81af81f4e4ccbb
     BUILD_IN_SOURCE YES
     CONFIGURE_COMMAND "" # No configure step
-    BUILD_COMMAND make -C libraries/liblmdb -e XCFLAGS=-fPIC liblmdb.a
+    BUILD_COMMAND ${CMAKE_COMMAND} -E env
+        CC=${CMAKE_C_COMPILER}
+        CFLAGS=${CMAKE_C_FLAGS}
+        make -C libraries/liblmdb -e XCFLAGS=-fPIC liblmdb.a
     INSTALL_COMMAND ""
     UPDATE_COMMAND "" # No update step
     BUILD_BYPRODUCTS ${LMDB_LIB}


### PR DESCRIPTION
## Related Issues
- close #17219 

## Description
Fix cross-compilation support for LMDB by properly configuring compiler environment variables during the build process.

## Changes
- Modified `barretenberg/cpp/cmake/lmdb.cmake` to use CMake's environment setup
- Replaced direct `make` call with `${CMAKE_COMMAND} -E env` to pass proper compiler settings
- Ensures `CC` and `CFLAGS` environment variables are correctly set during liblmdb compilation

## Why
This fix addresses cross-compilation issues where the LMDB library build wasn't inheriting the correct compiler settings from the main CMake configuration, particularly important for embedded or different target architecture builds.

## Files Changed
- `barretenberg/cpp/cmake/lmdb.cmake` - Enhanced compiler environment setup for LMDB build
https://github.com/AztecProtocol/aztec-packages/blob/efce0a3874f1ab0559265b43fda6ba5baee591c3/barretenberg/cpp/cmake/lmdb.cmake#L16