### PR TITLE
feat: check remote-signer is available

### DIFF
--- a/yarn-project/aztec-node/src/aztec-node/config.ts
+++ b/yarn-project/aztec-node/src/aztec-node/config.ts
@@ -92,7 +92,7 @@ export function getConfigEnvVars(): AztecNodeConfig {
 
 type ConfigRequiredToBuildKeyStore = TxSenderConfig & SequencerClientConfig & SharedNodeConfig & ValidatorClientConfig;
 
-function createKeyStoreFromWeb3Signer(config: ConfigRequiredToBuildKeyStore) {
+function createKeyStoreFromWeb3Signer(config: ConfigRequiredToBuildKeyStore): KeyStore | undefined {
   const validatorKeyStores: ValidatorKeyStore[] = [];
 
   if (
@@ -122,7 +122,7 @@ function createKeyStoreFromWeb3Signer(config: ConfigRequiredToBuildKeyStore) {
   return keyStore;
 }
 
-function createKeyStoreFromPrivateKeys(config: ConfigRequiredToBuildKeyStore) {
+function createKeyStoreFromPrivateKeys(config: ConfigRequiredToBuildKeyStore): KeyStore | undefined {
   const validatorKeyStores: ValidatorKeyStore[] = [];
   const ethPrivateKeys = config.validatorPrivateKeys
     ? config.validatorPrivateKeys.getValue().map(x => ethPrivateKeySchema.parse(x))
@@ -156,7 +156,9 @@ function createKeyStoreFromPrivateKeys(config: ConfigRequiredToBuildKeyStore) {
   return keyStore;
 }
 
-export function createKeyStoreForValidator(config: TxSenderConfig & SequencerClientConfig & SharedNodeConfig) {
+export function createKeyStoreForValidator(
+  config: TxSenderConfig & SequencerClientConfig & SharedNodeConfig,
+): KeyStore | undefined {
   if (config.web3SignerUrl !== undefined && config.web3SignerUrl.length > 0) {
     return createKeyStoreFromWeb3Signer(config);
   }

--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -212,6 +212,8 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, Traceable {
       }
     }
 
+    await keyStoreManager?.validateSigners();
+
     // If we are a validator, verify our configuration before doing too much more.
     if (!config.disableValidator) {
       if (keyStoreManager === undefined) {

--- a/yarn-project/end-to-end/bootstrap.sh
+++ b/yarn-project/end-to-end/bootstrap.sh
@@ -48,7 +48,17 @@ function test_cmds {
     echo "$hash:ONLY_TERM_PARENT=1 $run_test_script compose $test"
   done
 
-  echo "$hash:ONLY_TERM_PARENT=1 $run_test_script web3signer src/composed/web3signer/integration_remote_signer.test.ts"
+  tests=(
+    src/composed/web3signer/*.test.ts
+  )
+  for test in "${tests[@]}"; do
+    # We must set ONLY_TERM_PARENT=1 to allow the script to fully control cleanup process.
+    echo "$hash:ONLY_TERM_PARENT=1 $run_test_script web3signer $test"
+  done
+
+  #echo "$hash:ONLY_TERM_PARENT=1 $run_test_script simple src/e2e_multi_validator/e2e_multi_validator_node.test.ts"
+  # echo "$hash:ONLY_TERM_PARENT=1 $run_test_script web3signer src/composed/web3signer/integration_remote_signer.test.ts"
+  #echo "$hash:ONLY_TERM_PARENT=1 $run_test_script web3signer src/e2e_multi_validator/e2e_multi_validator_node_key_store.test.ts"
 
   # TODO(AD): figure out workaround for mainframe subnet exhaustion
   if [ "$CI" -eq 1 ]; then

--- a/yarn-project/end-to-end/scripts/web3signer/docker-compose.yml
+++ b/yarn-project/end-to-end/scripts/web3signer/docker-compose.yml
@@ -1,18 +1,6 @@
-configs:
-  test_private_key:
-    content: |
-      type: file-raw
-      keyType: SECP256K1
-      privateKey: 0x1111111111111111111111111111111111111111111111111111111111111111
-
 services:
   web3signer:
     image: consensys/web3signer:25.6.0
-    ports:
-      - "9000:9000"
-    configs:
-      - source: test_private_key
-        target: /keys/test_private_key.yaml
     command:
       - --http-listen-port=9000
       - --http-host-allowlist=*
@@ -20,6 +8,8 @@ services:
       - --logging=ALL
       - eth1
       - --chain-id=31337
+    volumes:
+      - web3signer_keys:/keys
 
   end-to-end:
     image: aztecprotocol/build:3.0
@@ -29,6 +19,7 @@ services:
     volumes:
       - ../../../../:/root/aztec-packages
       - ${HOME}/.bb-crs:/root/.bb-crs
+      - web3signer_keys:/keys
     tmpfs:
       - /tmp:rw,size=1g
       - /tmp-jest:rw,size=512m
@@ -38,6 +29,7 @@ services:
       LOG_LEVEL: ${LOG_LEVEL:-verbose}
       L1_CHAIN_ID: 31337
       WEB3_SIGNER_URL: http://web3signer:9000
+      WEB3_SIGNER_TEST_KEYSTORE_DIR: /keys
       FORCE_COLOR: ${FORCE_COLOR:-1}
       # Allow git usage despite different ownership. Relevant for script tests.
       GIT_CONFIG_GLOBAL: /root/aztec-packages/build-images/src/home/.gitconfig
@@ -60,8 +52,6 @@ services:
     # There's a lot of doubling of $'s to escape dockers string interpolation.
     entrypoint: >
       bash -c '
-        export TEST_PRIVATE_KEY=$(yq .privateKey /keys/test_private_key.yaml)
-
         while ! nc -z web3signer 9000; do sleep 1; done;
         setsid ./scripts/test_simple.sh ${TEST:-./src/e2e_deploy_contract.test.ts} &
         pid=$$!
@@ -72,7 +62,7 @@ services:
       '
     depends_on:
       - web3signer
-    configs:
-      # mount in the test as well in order to compare remote against local signer
-      - source: test_private_key
-        target: /keys/test_private_key.yaml
+
+volumes:
+  # a shared volume so that tests can load up arbitrary private keys into web3signer
+  web3signer_keys: {}

--- a/yarn-project/end-to-end/src/fixtures/web3signer.ts
+++ b/yarn-project/end-to-end/src/fixtures/web3signer.ts
@@ -1,0 +1,46 @@
+import { sleep } from '@aztec/aztec.js';
+import { randomBytes } from '@aztec/foundation/crypto';
+
+import { mkdirSync } from 'node:fs';
+import { writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+export async function createWeb3SignerKeystore(dir: string, ...privateKeys: string[]) {
+  const yaml = privateKeys
+    .map(
+      pk => `\
+type: file-raw
+keyType: SECP256K1
+privateKey: ${pk}`,
+    )
+    .join('\n---\n');
+
+  // NOTE: nodejs stdlib can only create temp directories, not temp files!
+  // this write uses wx (write-exclusive) so it'll throw if the file already exists
+  const path = join(dir, `keystore-${randomBytes(4).toString('hex')}.yaml`);
+  await writeFile(path, yaml, { flag: 'wx' });
+}
+
+export async function refreshWeb3Signer(url: string) {
+  await fetch(new URL('reload', url), { method: 'POST' });
+  // give the service a chance to load up the new files
+  // 1s might not be enough if there are a lot of files to scan
+  await sleep(1000);
+}
+
+export function getWeb3SignerTestKeystoreDir(): string {
+  if (process.env.WEB3_SIGNER_TEST_KEYSTORE_DIR) {
+    mkdirSync(process.env.WEB3_SIGNER_TEST_KEYSTORE_DIR, { recursive: true });
+    return process.env.WEB3_SIGNER_TEST_KEYSTORE_DIR;
+  } else {
+    throw new Error('Web3signer not running');
+  }
+}
+
+export function getWeb3SignerUrl(): string {
+  if (process.env.WEB3_SIGNER_URL) {
+    return process.env.WEB3_SIGNER_URL;
+  } else {
+    throw new Error('Web3signer not running');
+  }
+}

--- a/yarn-project/prover-node/src/config.ts
+++ b/yarn-project/prover-node/src/config.ts
@@ -123,7 +123,7 @@ export function getProverNodeAgentConfigFromEnv(): ProverAgentConfig & BBConfig 
   };
 }
 
-function createKeyStoreFromWeb3Signer(config: ProverNodeConfig) {
+function createKeyStoreFromWeb3Signer(config: ProverNodeConfig): KeyStore | undefined {
   // If we don't have a valid prover Id then we can't build a valid key store with remote signers
   if (config.proverId === undefined) {
     return undefined;
@@ -149,7 +149,7 @@ function createKeyStoreFromWeb3Signer(config: ProverNodeConfig) {
   return keyStore;
 }
 
-function createKeyStoreFromPublisherKeys(config: ProverNodeConfig) {
+function createKeyStoreFromPublisherKeys(config: ProverNodeConfig): KeyStore | undefined {
   // Extract the publisher keys from the provided config.
   const publisherKeys = config.publisherPrivateKeys
     ? config.publisherPrivateKeys.map(k => ethPrivateKeySchema.parse(k.getValue()))
@@ -179,7 +179,7 @@ function createKeyStoreFromPublisherKeys(config: ProverNodeConfig) {
   return keyStore;
 }
 
-export function createKeyStoreForProver(config: ProverNodeConfig) {
+export function createKeyStoreForProver(config: ProverNodeConfig): KeyStore | undefined {
   if (config.web3SignerUrl !== undefined && config.web3SignerUrl.length > 0) {
     return createKeyStoreFromWeb3Signer(config);
   }

--- a/yarn-project/prover-node/src/factory.ts
+++ b/yarn-project/prover-node/src/factory.ts
@@ -73,6 +73,8 @@ export async function createProverNode(
     }
   }
 
+  await keyStoreManager?.validateSigners();
+
   // Extract the prover signers from the key store and verify that we have one.
   const proverSigners = keyStoreManager?.createProverSigners();
 


### PR DESCRIPTION
This PR adds a validation step after opening up a keystore to make sure remote signers are available.

Fix A-45