### PR TITLE
fix: bigfield test flake

### DIFF
--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.test.cpp
@@ -1929,9 +1929,9 @@ template <typename BigField> class stdlib_bigfield : public testing::Test {
             native_sum += uint1024_t(a_natives[i]) * uint1024_t(b_natives[i]);
         }
         auto [q_native_1024, r_native_1024] = native_sum.divmod(uint1024_t(fq_ct::modulus));
-        fq_ct q_ct =
-            fq_ct::create_from_u512_as_witness(&builder, q_native_1024.lo + uint512_t(1)); // Intentionally poisoned
-        fq_ct r_ct = fq_ct::create_from_u512_as_witness(&builder, r_native_1024.lo);
+        fq_ct q_ct = fq_ct::create_from_u512_as_witness(
+            &builder, q_native_1024.lo + uint512_t(1), true); // Intentionally poisoned
+        fq_ct r_ct = fq_ct::create_from_u512_as_witness(&builder, r_native_1024.lo, true);
 
         // Call unsafe_evaluate_multiply_add (via friendly class)
         stdlib::bigfield_test_access::unsafe_evaluate_multiple_multiply_add(a_cts, b_cts, { c_ct }, q_ct, { r_ct });
@@ -1939,7 +1939,7 @@ template <typename BigField> class stdlib_bigfield : public testing::Test {
         // Check circuit correctness
         bool result = CircuitChecker::check(builder);
         EXPECT_EQ(result, false);
-        EXPECT_EQ(builder.err(), "bigfield::create_from_u512_as_witness: limb 2 or 3 too large: hi limb.");
+        EXPECT_EQ(builder.err(), "bigfield: prime limb identity failed");
     }
 
     static void test_nonnormalized_field_bug_regression()

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.test.cpp
@@ -343,7 +343,7 @@ template <typename BigField> class stdlib_bigfield : public testing::Test {
 
         bool result_check = CircuitChecker::check(builder);
         EXPECT_EQ(result_check, false);
-        EXPECT_EQ(builder.err(), "ultra_circuit_builder: sublimb of low too large");
+        EXPECT_EQ(builder.err(), "bigfield::construct_from_limbs: limb 0 or 1 too large: lo limb.");
     }
 
     static void test_add_two(InputType a_type, InputType b_type, InputType c_type)
@@ -1939,7 +1939,7 @@ template <typename BigField> class stdlib_bigfield : public testing::Test {
         // Check circuit correctness
         bool result = CircuitChecker::check(builder);
         EXPECT_EQ(result, false);
-        EXPECT_EQ(builder.err(), "bigfield: prime limb identity failed");
+        EXPECT_EQ(builder.err(), "bigfield::create_from_u512_as_witness: limb 2 or 3 too large: hi limb.");
     }
 
     static void test_nonnormalized_field_bug_regression()

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
@@ -1828,13 +1828,15 @@ template <typename Builder, typename T> void bigfield<Builder, T>::assert_less_t
     ctx->range_constrain_two_limbs(binary_basis_limbs[0].element.get_normalized_witness_index(),
                                    binary_basis_limbs[1].element.get_normalized_witness_index(),
                                    static_cast<size_t>(NUM_LIMB_BITS),
-                                   static_cast<size_t>(NUM_LIMB_BITS));
+                                   static_cast<size_t>(NUM_LIMB_BITS),
+                                   "bigfield::assert_less_than: limb 0 or 1 too large");
 
     // Range constrain the last two limbs to NUM_LIMB_BITS and NUM_LAST_LIMB_BITS
     ctx->range_constrain_two_limbs(binary_basis_limbs[2].element.get_normalized_witness_index(),
                                    binary_basis_limbs[3].element.get_normalized_witness_index(),
                                    static_cast<size_t>(NUM_LIMB_BITS),
-                                   static_cast<size_t>(NUM_LAST_LIMB_BITS));
+                                   static_cast<size_t>(NUM_LAST_LIMB_BITS),
+                                   "bigfield::assert_less_than: limb 2 or 3 too large");
 
     // Now we can check that the element is < upper_limit.
     unsafe_assert_less_than(upper_limit);
@@ -1912,11 +1914,13 @@ void bigfield<Builder, T>::unsafe_assert_less_than(const uint256_t& upper_limit)
     get_context()->range_constrain_two_limbs(r0.get_normalized_witness_index(),
                                              r1.get_normalized_witness_index(),
                                              static_cast<size_t>(NUM_LIMB_BITS),
-                                             static_cast<size_t>(NUM_LIMB_BITS));
+                                             static_cast<size_t>(NUM_LIMB_BITS),
+                                             "bigfield::unsafe_assert_less_than: r0 or r1 too large");
     get_context()->range_constrain_two_limbs(r2.get_normalized_witness_index(),
                                              r3.get_normalized_witness_index(),
                                              static_cast<size_t>(NUM_LIMB_BITS),
-                                             static_cast<size_t>(NUM_LIMB_BITS));
+                                             static_cast<size_t>(NUM_LIMB_BITS),
+                                             "bigfield::unsafe_assert_less_than: r2 or r3 too large");
 }
 
 // check elements are equal mod p by proving their integer difference is a multiple of p.

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/field/field.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/field/field.cpp
@@ -683,7 +683,7 @@ template <typename Builder> void field_t<Builder>::assert_is_zero(std::string co
         return;
     }
 
-    if (get_value() != bb::fr::zero()) {
+    if ((get_value() != bb::fr::zero()) && !context->failed()) {
         context->failure(msg);
     }
     // Aim of a new `poly` gate: constrain this.v * this.mul + this.add == 0
@@ -714,7 +714,7 @@ template <typename Builder> void field_t<Builder>::assert_is_not_zero(std::strin
         return;
     }
 
-    if (get_value() == bb::fr::zero()) {
+    if ((get_value() == bb::fr::zero()) && !context->failed()) {
         context->failure(msg);
     }
 
@@ -1085,7 +1085,8 @@ void field_t<Builder>::evaluate_linear_identity(
         return;
     }
 
-    if (a.get_value() + b.get_value() + c.get_value() + d.get_value() != bb::fr::zero()) {
+    const bool identity_holds = (a.get_value() + b.get_value() + c.get_value() + d.get_value()).is_zero();
+    if (!identity_holds && !ctx->failed()) {
         ctx->failure(msg);
     }
 
@@ -1120,7 +1121,8 @@ void field_t<Builder>::evaluate_polynomial_identity(
 
     Builder* ctx = validate_context(a.context, b.context, c.context, d.context);
 
-    if ((a.get_value() * b.get_value() + c.get_value() + d.get_value()) != bb::fr::zero()) {
+    const bool identity_holds = ((a.get_value() * b.get_value()) + c.get_value() + d.get_value()).is_zero();
+    if (!identity_holds && !ctx->failed()) {
         ctx->failure(msg);
     }
 

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.cpp
@@ -1019,10 +1019,9 @@ void UltraCircuitBuilder_<ExecutionTrace>::create_new_range_constraint(const uin
                                                                        const uint64_t target_range,
                                                                        std::string const msg)
 {
-    if (uint256_t(this->get_variable(variable_index)).data[0] > target_range) {
-        if (!this->failed()) {
-            this->failure(msg);
-        }
+    const bool is_out_of_range = (uint256_t(this->get_variable(variable_index)).data[0] > target_range);
+    if (is_out_of_range && !this->failed()) {
+        this->failure(msg);
     }
     if (range_lists.count(target_range) == 0) {
         range_lists.insert({ target_range, create_range_list(target_range) });
@@ -1634,10 +1633,12 @@ void UltraCircuitBuilder_<ExecutionTrace>::range_constrain_two_limbs(const uint3
     BB_ASSERT_LTE(hi_limb_bits, 14U * 5U);
 
     // If the value is larger than the range, we log the error in builder
-    if (uint256_t(this->get_variable_reference(lo_idx)) >= (uint256_t(1) << lo_limb_bits)) {
+    const bool is_lo_out_of_range = (uint256_t(this->get_variable_reference(lo_idx)) >= (uint256_t(1) << lo_limb_bits));
+    if (is_lo_out_of_range && !this->failed()) {
         this->failure(msg + ": lo limb.");
     }
-    if (uint256_t(this->get_variable_reference(hi_idx)) >= (uint256_t(1) << hi_limb_bits)) {
+    const bool is_hi_out_of_range = (uint256_t(this->get_variable_reference(hi_idx)) >= (uint256_t(1) << hi_limb_bits));
+    if (is_hi_out_of_range && !this->failed()) {
         this->failure(msg + ": hi limb.");
     }
 


### PR DESCRIPTION
Fixes two issues mainly:

1. Flake flagged by @spalladino (see [test failure](http://ci.aztec-labs.com/9cb61bfe05d4f32f), and test-ignore-patterns [PR](https://github.com/AztecProtocol/aztec-packages/pull/17211))
2. Due to the previous [PR](https://github.com/AztecProtocol/aztec-packages/pull/17197) on better error logging in circuit builder in the function `range_constrain_two_limbs` we need to update bigfield edge case tests to correctly reflect the errors. 

In the circuit builder, in some cases like in `range_constrain_two_limbs`, we were overriding the existing builder failure with the current failure. Updated these instances to only override a failure if there's no existing failure logged. This is consistent with our design of logging the very first error encountered while building circuit. Note that there could be instances where we're not following this, and we should fix such instances during internal audit of the (ultra) circuit builder.