### PR TITLE
chore: Consistent dateprovider usage

### DIFF
--- a/yarn-project/aztec/src/sandbox/sandbox.ts
+++ b/yarn-project/aztec/src/sandbox/sandbox.ts
@@ -179,7 +179,7 @@ export async function createSandbox(config: Partial<SandboxConfig> = {}, userLog
     });
 
     watcher = new AnvilTestWatcher(
-      new EthCheatCodes([l1RpcUrl]),
+      new EthCheatCodes([l1RpcUrl], dateProvider),
       l1ContractAddresses.rollupAddress,
       publicClient,
       dateProvider,

--- a/yarn-project/aztec/src/testing/anvil_test_watcher.ts
+++ b/yarn-project/aztec/src/testing/anvil_test_watcher.ts
@@ -133,7 +133,6 @@ export class AnvilTestWatcher {
         try {
           await this.cheatcodes.warp(nextSlotTimestamp, {
             resetBlockInterval: true,
-            updateDateProvider: this.dateProvider,
           });
         } catch (e) {
           this.logger.error(`Failed to warp to timestamp ${nextSlotTimestamp}: ${e}`);
@@ -151,10 +150,7 @@ export class AnvilTestWatcher {
       const currentTimestamp = this.dateProvider?.now() ?? Date.now();
       if (currentTimestamp > nextSlotTimestamp * 1000) {
         try {
-          await this.cheatcodes.warp(nextSlotTimestamp, {
-            resetBlockInterval: true,
-            updateDateProvider: this.dateProvider,
-          });
+          await this.cheatcodes.warp(nextSlotTimestamp, { resetBlockInterval: true });
         } catch (e) {
           this.logger.error(`Failed to warp to timestamp ${nextSlotTimestamp}: ${e}`);
         }

--- a/yarn-project/aztec/src/testing/cheat_codes.ts
+++ b/yarn-project/aztec/src/testing/cheat_codes.ts
@@ -1,5 +1,6 @@
 import { retryUntil } from '@aztec/aztec.js';
 import { EthCheatCodes, RollupCheatCodes } from '@aztec/ethereum/test';
+import type { DateProvider } from '@aztec/foundation/timer';
 import type { SequencerClient } from '@aztec/sequencer-client';
 import type { AztecNode } from '@aztec/stdlib/interfaces/client';
 import type { NotesFilter, UniqueNote } from '@aztec/stdlib/note';
@@ -23,8 +24,9 @@ export class CheatCodes {
     rpcUrls: string[],
     testWalletOrPxe: { getNotes(filter: NotesFilter): Promise<UniqueNote[]> },
     node: AztecNode,
+    dateProvider: DateProvider,
   ): Promise<CheatCodes> {
-    const ethCheatCodes = new EthCheatCodes(rpcUrls);
+    const ethCheatCodes = new EthCheatCodes(rpcUrls, dateProvider);
     const aztecCheatCodes = new AztecCheatCodes(testWalletOrPxe, node);
     const rollupCheatCodes = new RollupCheatCodes(
       ethCheatCodes,

--- a/yarn-project/cli/src/cmds/l1/advance_epoch.ts
+++ b/yarn-project/cli/src/cmds/l1/advance_epoch.ts
@@ -1,12 +1,13 @@
 import { createAztecNodeClient } from '@aztec/aztec.js';
 import { RollupCheatCodes } from '@aztec/ethereum/test';
 import type { LogFn } from '@aztec/foundation/log';
+import { DateProvider } from '@aztec/foundation/timer';
 
 export async function advanceEpoch(l1RpcUrls: string[], nodeUrl: string, log: LogFn) {
   const aztecNode = createAztecNodeClient(nodeUrl);
   const rollupAddress = await aztecNode.getNodeInfo().then(i => i.l1ContractAddresses.rollupAddress);
 
-  const cheat = RollupCheatCodes.create(l1RpcUrls, { rollupAddress });
+  const cheat = RollupCheatCodes.create(l1RpcUrls, { rollupAddress }, new DateProvider());
 
   await cheat.advanceToNextEpoch();
   log(`Warped time to advance to next epoch`);

--- a/yarn-project/cli/src/cmds/l1/assume_proven_through.ts
+++ b/yarn-project/cli/src/cmds/l1/assume_proven_through.ts
@@ -1,6 +1,7 @@
 import { createAztecNodeClient } from '@aztec/aztec.js';
 import { RollupCheatCodes } from '@aztec/ethereum/test';
 import type { LogFn } from '@aztec/foundation/log';
+import { DateProvider } from '@aztec/foundation/timer';
 
 export async function assumeProvenThrough(
   blockNumberOrLatest: number | undefined,
@@ -12,7 +13,7 @@ export async function assumeProvenThrough(
   const rollupAddress = await aztecNode.getNodeInfo().then(i => i.l1ContractAddresses.rollupAddress);
   const blockNumber = blockNumberOrLatest ?? (await aztecNode.getBlockNumber());
 
-  const rollupCheatCodes = RollupCheatCodes.create(l1RpcUrls, { rollupAddress });
+  const rollupCheatCodes = RollupCheatCodes.create(l1RpcUrls, { rollupAddress }, new DateProvider());
 
   await rollupCheatCodes.markAsProven(blockNumber);
   log(`Assumed proven through block ${blockNumber}`);

--- a/yarn-project/cli/src/cmds/l1/update_l1_validators.ts
+++ b/yarn-project/cli/src/cmds/l1/update_l1_validators.ts
@@ -11,6 +11,7 @@ import {
 import { EthCheatCodes } from '@aztec/ethereum/test';
 import type { EthAddress } from '@aztec/foundation/eth-address';
 import type { LogFn, Logger } from '@aztec/foundation/log';
+import { DateProvider } from '@aztec/foundation/timer';
 import { RollupAbi, StakingAssetHandlerAbi } from '@aztec/l1-artifacts';
 import { ZkPassportProofParams } from '@aztec/stdlib/zkpassport';
 
@@ -120,7 +121,7 @@ export async function addL1Validator({
   await l1Client.waitForTransactionReceipt({ hash: receipt.transactionHash });
   if (isAnvilTestChain(chainId)) {
     dualLog(`Funding validator on L1`);
-    const cheatCodes = new EthCheatCodes(rpcUrls, debugLogger);
+    const cheatCodes = new EthCheatCodes(rpcUrls, new DateProvider(), debugLogger);
     await cheatCodes.setBalance(attesterAddress, 10n ** 20n);
   } else {
     const balance = await l1Client.getBalance({ address: attesterAddress.toString() });
@@ -194,7 +195,7 @@ export async function addL1ValidatorViaRollup({
   await l1Client.waitForTransactionReceipt({ hash: receipt.transactionHash });
   if (isAnvilTestChain(chainId)) {
     dualLog(`Funding validator on L1`);
-    const cheatCodes = new EthCheatCodes(rpcUrls, debugLogger);
+    const cheatCodes = new EthCheatCodes(rpcUrls, new DateProvider(), debugLogger);
     await cheatCodes.setBalance(attesterAddress, 10n ** 20n);
   } else {
     const balance = await l1Client.getBalance({ address: attesterAddress.toString() });
@@ -275,7 +276,7 @@ export async function fastForwardEpochs({
     client: publicClient,
   });
 
-  const cheatCodes = new EthCheatCodes(rpcUrls, debugLogger);
+  const cheatCodes = new EthCheatCodes(rpcUrls, new DateProvider(), debugLogger);
   const currentSlot = await rollup.read.getCurrentSlot();
   const l2SlotsInEpoch = await rollup.read.getEpochDuration();
   const timestamp = await rollup.read.getTimestampForSlot([currentSlot + l2SlotsInEpoch * numEpochs]);

--- a/yarn-project/end-to-end/src/bench/client_flows/client_flows_benchmark.ts
+++ b/yarn-project/end-to-end/src/bench/client_flows/client_flows_benchmark.ts
@@ -201,11 +201,11 @@ export class ClientFlowsBenchmark {
       deployAccounts(2, this.logger),
       async (
         { deployedAccounts: [{ address: adminAddress }, { address: sequencerAddress }] },
-        { wallet, aztecNode, aztecNodeConfig },
+        { wallet, aztecNode, cheatCodes },
       ) => {
         this.adminWallet = wallet;
         this.aztecNode = aztecNode;
-        this.cheatCodes = await CheatCodes.create(aztecNodeConfig.l1RpcUrls, wallet, aztecNode);
+        this.cheatCodes = cheatCodes;
 
         this.adminAddress = adminAddress;
         this.sequencerAddress = sequencerAddress;

--- a/yarn-project/end-to-end/src/e2e_cheat_codes.test.ts
+++ b/yarn-project/end-to-end/src/e2e_cheat_codes.test.ts
@@ -2,6 +2,7 @@ import { type AztecAddress, EthAddress, Fr, type Wallet } from '@aztec/aztec.js'
 import { AnvilTestWatcher, CheatCodes, EthCheatCodes } from '@aztec/aztec/testing';
 import { type ExtendedViemWalletClient, createExtendedL1Client } from '@aztec/ethereum';
 import { RollupContract } from '@aztec/ethereum/contracts';
+import { DateProvider } from '@aztec/foundation/timer';
 import { TokenContract } from '@aztec/noir-contracts.js/Token';
 
 import type { Anvil } from '@viem/anvil';
@@ -24,7 +25,7 @@ describe('e2e_cheat_codes', () => {
     beforeEach(async () => {
       const res = await startAnvil();
       anvil = res.anvil;
-      ethCheatCodes = new EthCheatCodes([res.rpcUrl]);
+      ethCheatCodes = new EthCheatCodes([res.rpcUrl], new DateProvider());
       const account = mnemonicToAccount(MNEMONIC, { addressIndex: 0 });
       l1Client = createExtendedL1Client([res.rpcUrl], account, foundry);
     });

--- a/yarn-project/end-to-end/src/e2e_cross_chain_messaging/cross_chain_messaging_test.ts
+++ b/yarn-project/end-to-end/src/e2e_cross_chain_messaging/cross_chain_messaging_test.ts
@@ -71,7 +71,7 @@ export class CrossChainMessagingTest {
     this.aztecNode = this.ctx.aztecNode;
     this.wallet = this.ctx.wallet;
     this.aztecNodeConfig = this.ctx.aztecNodeConfig;
-    this.cheatCodes = await CheatCodes.create(this.aztecNodeConfig.l1RpcUrls, this.wallet, this.aztecNode);
+    this.cheatCodes = this.ctx.cheatCodes;
     this.deployL1ContractsValues = this.ctx.deployL1ContractsValues;
     this.aztecNodeAdmin = this.ctx.aztecNode;
   }

--- a/yarn-project/end-to-end/src/e2e_cross_chain_messaging/token_bridge_private.test.ts
+++ b/yarn-project/end-to-end/src/e2e_cross_chain_messaging/token_bridge_private.test.ts
@@ -37,7 +37,7 @@ describe('e2e_cross_chain_messaging token_bridge_private', () => {
       crossChainTestHarness!.l1ContractAddresses.rollupAddress,
     );
 
-    cheatCodes = await CheatCodes.create(t.aztecNodeConfig.l1RpcUrls, t.wallet, t.aztecNode);
+    cheatCodes = t.ctx.cheatCodes;
   }, 300_000);
 
   afterEach(async () => {

--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_first_slot.test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_first_slot.test.ts
@@ -108,7 +108,6 @@ describe('e2e_epochs/epochs_first_slot', () => {
     const [epochStart] = getTimestampRangeForEpoch(EPOCH, test.constants);
     await test.context.cheatCodes.eth.warp(Number(epochStart) - test.L1_BLOCK_TIME_IN_S, {
       resetBlockInterval: true,
-      updateDateProvider: test.context.dateProvider,
     });
 
     // Start the sequencers

--- a/yarn-project/end-to-end/src/e2e_fees/fees_test.ts
+++ b/yarn-project/end-to-end/src/e2e_fees/fees_test.ts
@@ -182,11 +182,11 @@ export class FeesTest {
     await this.snapshotManager.snapshot(
       'initial_accounts',
       deployAccounts(this.numberOfAccounts, this.logger),
-      async ({ deployedAccounts }, { wallet, aztecNode, aztecNodeConfig }) => {
+      async ({ deployedAccounts }, { wallet, aztecNode, cheatCodes }) => {
         this.wallet = wallet;
         this.aztecNode = aztecNode;
         this.gasSettings = GasSettings.default({ maxFeesPerGas: (await this.aztecNode.getCurrentBaseFees()).mul(2) });
-        this.cheatCodes = await CheatCodes.create(aztecNodeConfig.l1RpcUrls, wallet, aztecNode);
+        this.cheatCodes = cheatCodes;
         this.accounts = deployedAccounts.map(a => a.address);
         this.accounts.forEach((a, i) => this.logger.verbose(`Account ${i} address: ${a}`));
         [this.aliceAddress, this.bobAddress, this.sequencerAddress] = this.accounts.slice(0, 3);

--- a/yarn-project/end-to-end/src/e2e_l1_publisher/e2e_l1_publisher.test.ts
+++ b/yarn-project/end-to-end/src/e2e_l1_publisher/e2e_l1_publisher.test.ts
@@ -138,7 +138,7 @@ describe('L1Publisher integration', () => {
     const currentSlot = await rollup.getSlotNumber();
     const timestamp = await rollup.getTimestampForSlot(currentSlot + slotsToJump);
     if (timestamp > currentTime) {
-      await ethCheatCodes.warp(Number(timestamp), { resetBlockInterval: true, updateDateProvider: dateProvider });
+      await ethCheatCodes.warp(Number(timestamp), { resetBlockInterval: true });
     }
   };
 
@@ -153,7 +153,8 @@ describe('L1Publisher integration', () => {
       ...deployL1ContractsArgs,
     }));
 
-    ethCheatCodes = new EthCheatCodesWithState(config.l1RpcUrls);
+    dateProvider = new TestDateProvider();
+    ethCheatCodes = new EthCheatCodesWithState(config.l1RpcUrls, dateProvider);
 
     rollupAddress = getAddress(l1ContractAddresses.rollupAddress.toString());
     outboxAddress = getAddress(l1ContractAddresses.outboxAddress.toString());
@@ -167,8 +168,6 @@ describe('L1Publisher integration', () => {
       abi: OutboxAbi,
       client: l1Client,
     });
-
-    dateProvider = new TestDateProvider();
 
     builderDb = await NativeWorldStateService.tmp(EthAddress.fromString(rollupAddress));
     blocks = [];
@@ -264,9 +263,7 @@ describe('L1Publisher integration', () => {
     baseFee = new GasFees(0, await rollup.getManaBaseFeeAt(ts, true));
 
     // We jump two epochs such that the committee can be setup.
-    await rollupCheatCodes.advanceToEpoch(BigInt(config.lagInEpochs + 1), {
-      updateDateProvider: dateProvider,
-    });
+    await rollupCheatCodes.advanceToEpoch(BigInt(config.lagInEpochs + 1));
     await rollupCheatCodes.setupEpoch();
 
     ({ committee } = await epochCache.getCommittee());

--- a/yarn-project/end-to-end/src/e2e_p2p/add_rollup.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/add_rollup.test.ts
@@ -317,7 +317,7 @@ describe('e2e_p2p_add_rollup', () => {
         const leafId = getL2ToL1MessageLeafId(l2ToL1MessageResult!);
 
         // We need to mark things as proven
-        const cheatcodes = RollupCheatCodes.create(l1RpcUrls, l1ContractAddresses);
+        const cheatcodes = RollupCheatCodes.create(l1RpcUrls, l1ContractAddresses, t.ctx.dateProvider);
         await cheatcodes.markAsProven();
 
         // Then we want to go and comsume it!

--- a/yarn-project/end-to-end/src/e2e_p2p/data_withholding_slash.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/data_withholding_slash.test.ts
@@ -97,7 +97,7 @@ describe('e2e_p2p_data_withholding_slash', () => {
     const { rollup, slashingProposer, slashFactory } = await t.getContracts();
 
     // Jump forward to an epoch in the future such that the validator set is not empty
-    await t.ctx.cheatCodes.rollup.advanceToEpoch(4n, { updateDateProvider: t.ctx.dateProvider });
+    await t.ctx.cheatCodes.rollup.advanceToEpoch(4n);
     await debugRollup();
 
     const [activationThreshold, ejectionThreshold, localEjectionThreshold] = await Promise.all([
@@ -139,7 +139,7 @@ describe('e2e_p2p_data_withholding_slash', () => {
     // Considering the slot duration is 32 seconds,
     // Considering the epoch duration is 2 slots,
     // we have ~64 seconds to do this.
-    await t.ctx.cheatCodes.rollup.advanceToEpoch(8n, { updateDateProvider: t.ctx.dateProvider });
+    await t.ctx.cheatCodes.rollup.advanceToEpoch(8n);
     await t.sendDummyTx();
     await debugRollup();
 
@@ -191,7 +191,6 @@ describe('e2e_p2p_data_withholding_slash', () => {
       slashingRoundSize,
       aztecSlotDuration: AZTEC_SLOT_DURATION,
       logger: t.logger,
-      dateProvider: t.ctx.dateProvider,
       offenseEpoch,
       aztecEpochDuration,
     });

--- a/yarn-project/end-to-end/src/e2e_p2p/shared.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/shared.ts
@@ -14,7 +14,6 @@ import type { RollupCheatCodes } from '@aztec/aztec/testing';
 import type { EmpireSlashingProposerContract, RollupContract, TallySlashingProposerContract } from '@aztec/ethereum';
 import { timesAsync, unique } from '@aztec/foundation/collection';
 import { pluralize } from '@aztec/foundation/string';
-import type { TestDateProvider } from '@aztec/foundation/timer';
 import type { SpamContract } from '@aztec/noir-test-contracts.js/Spam';
 import { TestContract, TestContractArtifact } from '@aztec/noir-test-contracts.js/Test';
 import { PXEService, createPXEService, getPXEServiceConfig as getRpcConfig } from '@aztec/pxe/server';
@@ -199,7 +198,6 @@ export async function awaitCommitteeKicked({
   aztecSlotDuration,
   aztecEpochDuration,
   logger,
-  dateProvider,
   offenseEpoch,
 }: {
   rollup: RollupContract;
@@ -210,7 +208,6 @@ export async function awaitCommitteeKicked({
   slashingRoundSize: number;
   aztecSlotDuration: number;
   aztecEpochDuration: number;
-  dateProvider: TestDateProvider;
   logger: Logger;
   offenseEpoch: number;
 }) {
@@ -224,7 +221,7 @@ export async function awaitCommitteeKicked({
     // Await for the slash payload to be created if empire (no payload is created on tally until execution time)
     const targetEpoch = (await cheatCodes.getEpoch()) + (await rollup.getLagInEpochs()) + 1n;
     logger.info(`Advancing to epoch ${targetEpoch} so we start slashing`);
-    await cheatCodes.advanceToEpoch(targetEpoch, { updateDateProvider: dateProvider });
+    await cheatCodes.advanceToEpoch(targetEpoch);
 
     const slashPayloadEvents = await retryUntil(
       async () => {
@@ -247,7 +244,7 @@ export async function awaitCommitteeKicked({
     const slashingOffsetInEpochs = Number(slashOffsetInRounds) * slashingRoundSizeInEpochs;
     const targetEpoch = offenseEpoch + slashingOffsetInEpochs;
     logger.info(`Advancing to epoch ${targetEpoch} so we start slashing`);
-    await cheatCodes.advanceToEpoch(targetEpoch, { updateDateProvider: dateProvider });
+    await cheatCodes.advanceToEpoch(targetEpoch);
   }
 
   const attestersPre = await rollup.getAttesters();
@@ -277,9 +274,7 @@ export async function awaitCommitteeKicked({
 
   logger.info(`Advancing to check current committee`);
   await cheatCodes.debugRollup();
-  await cheatCodes.advanceToEpoch((await cheatCodes.getEpoch()) + (await rollup.getLagInEpochs()) + 1n, {
-    updateDateProvider: dateProvider,
-  });
+  await cheatCodes.advanceToEpoch((await cheatCodes.getEpoch()) + (await rollup.getLagInEpochs()) + 1n);
   await cheatCodes.debugRollup();
 
   const committeeNextEpoch = await rollup.getCurrentEpochCommittee();

--- a/yarn-project/end-to-end/src/e2e_p2p/valid_epoch_pruned_slash.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/valid_epoch_pruned_slash.test.ts
@@ -124,7 +124,7 @@ describe('e2e_p2p_valid_epoch_pruned_slash', () => {
     await debugRollup();
 
     // Wait for the committee to exist
-    await t.ctx.cheatCodes.rollup.advanceToEpoch(2, { updateDateProvider: t.ctx.dateProvider });
+    await t.ctx.cheatCodes.rollup.advanceToEpoch(2);
     await t.ctx.cheatCodes.rollup.markAsProven();
     const committee = await awaitCommitteeExists({ rollup, logger: t.logger });
     await debugRollup();
@@ -136,10 +136,7 @@ describe('e2e_p2p_valid_epoch_pruned_slash', () => {
 
     // Warp forward to after the initial grace period
     expect(await rollup.getCurrentEpoch()).toBeLessThan(initialEpoch);
-    await t.ctx.cheatCodes.rollup.advanceToEpoch(initialEpoch, {
-      updateDateProvider: t.ctx.dateProvider,
-      offset: -ethereumSlotDuration,
-    });
+    await t.ctx.cheatCodes.rollup.advanceToEpoch(initialEpoch, { offset: -ethereumSlotDuration });
     await t.ctx.cheatCodes.rollup.markAsProven();
 
     // Send a tx to deploy a contract so that we have a tx with public function execution in the pruned epoch
@@ -185,7 +182,6 @@ describe('e2e_p2p_valid_epoch_pruned_slash', () => {
       slashingRoundSize,
       aztecSlotDuration,
       logger: t.logger,
-      dateProvider: t.ctx.dateProvider,
       offenseEpoch,
       aztecEpochDuration,
     });

--- a/yarn-project/end-to-end/src/e2e_sequencer/gov_proposal.test.ts
+++ b/yarn-project/end-to-end/src/e2e_sequencer/gov_proposal.test.ts
@@ -9,7 +9,6 @@ import {
 import { times } from '@aztec/foundation/collection';
 import { SecretValue } from '@aztec/foundation/config';
 import { bufferToHex } from '@aztec/foundation/string';
-import type { TestDateProvider } from '@aztec/foundation/timer';
 import { NewGovernanceProposerPayloadAbi } from '@aztec/l1-artifacts/NewGovernanceProposerPayloadAbi';
 import { NewGovernanceProposerPayloadBytecode } from '@aztec/l1-artifacts/NewGovernanceProposerPayloadBytecode';
 import { TestContract } from '@aztec/noir-test-contracts.js/Test';
@@ -35,7 +34,6 @@ describe('e2e_gov_proposal', () => {
   let aztecNodeAdmin: AztecNodeAdmin | undefined;
   let deployL1ContractsValues: DeployL1ContractsReturnType;
   let cheatCodes: CheatCodes;
-  let dateProvider: TestDateProvider | undefined;
 
   beforeEach(async () => {
     const validatorOffset = 10;
@@ -46,22 +44,21 @@ describe('e2e_gov_proposal', () => {
       return { attester: address, withdrawer: address, privateKey };
     });
     let accounts: AztecAddress[] = [];
-    ({ teardown, logger, wallet, aztecNodeAdmin, deployL1ContractsValues, cheatCodes, dateProvider, accounts } =
-      await setup(1, {
-        anvilAccounts: 100,
-        aztecTargetCommitteeSize: COMMITTEE_SIZE,
-        initialValidators: validators.map(v => ({ ...v, bn254SecretKey: new SecretValue(Fr.random().toBigInt()) })),
-        validatorPrivateKeys: new SecretValue(validators.map(v => v.privateKey)), // sequencer runs with all validator keys
-        governanceProposerRoundSize: ROUND_SIZE,
-        governanceProposerQuorum: QUORUM_SIZE,
-        ethereumSlotDuration: ETHEREUM_SLOT_DURATION,
-        aztecSlotDuration: AZTEC_SLOT_DURATION,
-        aztecProofSubmissionEpochs: 128, // no pruning
-        salt: 420,
-        minTxsPerBlock: TXS_PER_BLOCK,
-        enforceTimeTable: true,
-        automineL1Setup: true, // speed up setup
-      }));
+    ({ teardown, logger, wallet, aztecNodeAdmin, deployL1ContractsValues, cheatCodes, accounts } = await setup(1, {
+      anvilAccounts: 100,
+      aztecTargetCommitteeSize: COMMITTEE_SIZE,
+      initialValidators: validators.map(v => ({ ...v, bn254SecretKey: new SecretValue(Fr.random().toBigInt()) })),
+      validatorPrivateKeys: new SecretValue(validators.map(v => v.privateKey)), // sequencer runs with all validator keys
+      governanceProposerRoundSize: ROUND_SIZE,
+      governanceProposerQuorum: QUORUM_SIZE,
+      ethereumSlotDuration: ETHEREUM_SLOT_DURATION,
+      aztecSlotDuration: AZTEC_SLOT_DURATION,
+      aztecProofSubmissionEpochs: 128, // no pruning
+      salt: 420,
+      minTxsPerBlock: TXS_PER_BLOCK,
+      enforceTimeTable: true,
+      automineL1Setup: true, // speed up setup
+    }));
     defaultAccountAddress = accounts[0];
   }, 3 * 60000);
 
@@ -109,7 +106,6 @@ describe('e2e_gov_proposal', () => {
 
       await cheatCodes.eth.warp(Number(nextRoundBeginsAtTimestamp), {
         resetBlockInterval: true,
-        updateDateProvider: dateProvider,
       });
 
       // Now we submit a bunch of transactions to the PXE.

--- a/yarn-project/end-to-end/src/guides/dapp_testing.test.ts
+++ b/yarn-project/end-to-end/src/guides/dapp_testing.test.ts
@@ -10,6 +10,7 @@ import {
   waitForPXE,
 } from '@aztec/aztec.js';
 import { CheatCodes } from '@aztec/aztec/testing';
+import { TestDateProvider } from '@aztec/foundation/timer';
 import { TokenContract } from '@aztec/noir-contracts.js/Token';
 // docs:end:imports
 // docs:start:import_contract
@@ -101,7 +102,7 @@ describe('guides/dapp/testing', () => {
         await mintTokensToPrivate(token, ownerAddress, ownerAddress, mintAmount);
 
         // docs:start:calc-slot
-        cheats = await CheatCodes.create(ETHEREUM_HOSTS.split(','), wallet, aztecNode);
+        cheats = await CheatCodes.create(ETHEREUM_HOSTS.split(','), wallet, aztecNode, new TestDateProvider());
         // The balances mapping is indexed by user address
         ownerSlot = await cheats.aztec.computeSlotInMap(TokenContract.storage.balances.slot, ownerAddress);
         // docs:end:calc-slot

--- a/yarn-project/end-to-end/src/spartan/4epochs.test.ts
+++ b/yarn-project/end-to-end/src/spartan/4epochs.test.ts
@@ -3,6 +3,7 @@ import { RollupCheatCodes } from '@aztec/aztec/testing';
 import { getL1ContractsConfigEnvVars } from '@aztec/ethereum';
 import { EthCheatCodesWithState } from '@aztec/ethereum/test';
 import { createLogger } from '@aztec/foundation/log';
+import { DateProvider } from '@aztec/foundation/timer';
 import { TestWallet } from '@aztec/test-wallet';
 
 import { jest } from '@jest/globals';
@@ -70,7 +71,7 @@ describe('token transfer test', () => {
   });
 
   it('transfer tokens for 4 epochs', async () => {
-    const ethCheatCodes = new EthCheatCodesWithState(ETHEREUM_HOSTS);
+    const ethCheatCodes = new EthCheatCodesWithState(ETHEREUM_HOSTS, new DateProvider());
     const l1ContractAddresses = await testAccounts.aztecNode.getNodeInfo().then(n => n.l1ContractAddresses);
     // Get 4 epochs
     const rollupCheatCodes = new RollupCheatCodes(ethCheatCodes, l1ContractAddresses);

--- a/yarn-project/end-to-end/src/spartan/reorg.test.ts
+++ b/yarn-project/end-to-end/src/spartan/reorg.test.ts
@@ -3,6 +3,7 @@ import { type AztecNode, sleep } from '@aztec/aztec.js';
 import { RollupCheatCodes } from '@aztec/aztec/testing';
 import { EthCheatCodesWithState } from '@aztec/ethereum/test';
 import { createLogger } from '@aztec/foundation/log';
+import { DateProvider } from '@aztec/foundation/timer';
 import { TestWallet } from '@aztec/test-wallet';
 
 import { expect, jest } from '@jest/globals';
@@ -69,7 +70,7 @@ describe('reorg test', () => {
 
   it('survives a reorg', async () => {
     const rollupCheatCodes = new RollupCheatCodes(
-      new EthCheatCodesWithState(ETHEREUM_HOSTS),
+      new EthCheatCodesWithState(ETHEREUM_HOSTS, new DateProvider()),
       await testAccounts.aztecNode.getNodeInfo().then(n => n.l1ContractAddresses),
     );
     const { epochDuration, slotDuration } = await rollupCheatCodes.getConfig();

--- a/yarn-project/ethereum/src/contracts/registry.test.ts
+++ b/yarn-project/ethereum/src/contracts/registry.test.ts
@@ -1,6 +1,7 @@
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { Fr } from '@aztec/foundation/fields';
 import { type Logger, createLogger } from '@aztec/foundation/log';
+import { DateProvider } from '@aztec/foundation/timer';
 import { RegistryAbi } from '@aztec/l1-artifacts/RegistryAbi';
 
 import type { Anvil } from '@viem/anvil';
@@ -68,7 +69,7 @@ describe('Registry', () => {
     const rollup = new RollupContract(l1Client, deployedAddresses.rollupAddress);
     deployedVersion = Number(await rollup.getVersion());
 
-    ethCheatCodes = new EthCheatCodes([rpcUrl]);
+    ethCheatCodes = new EthCheatCodes([rpcUrl], new DateProvider());
     await ethCheatCodes.setBalance(deployedAddresses.governanceAddress, 10n ** 18n);
   });
 

--- a/yarn-project/ethereum/src/contracts/rollup.test.ts
+++ b/yarn-project/ethereum/src/contracts/rollup.test.ts
@@ -2,6 +2,7 @@ import { getPublicClient } from '@aztec/ethereum';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { Fr } from '@aztec/foundation/fields';
 import { type Logger, createLogger } from '@aztec/foundation/log';
+import { DateProvider } from '@aztec/foundation/timer';
 import { RollupAbi } from '@aztec/l1-artifacts/RollupAbi';
 
 import type { Anvil } from '@viem/anvil';
@@ -39,7 +40,7 @@ describe('Rollup', () => {
     ({ anvil, rpcUrl } = await startAnvil());
 
     publicClient = getPublicClient({ l1RpcUrls: [rpcUrl], l1ChainId: 31337 });
-    cheatCodes = new EthCheatCodes([rpcUrl]);
+    cheatCodes = new EthCheatCodes([rpcUrl], new DateProvider());
 
     const deployed = await deployL1Contracts([rpcUrl], privateKey, foundry, logger, {
       ...DefaultL1ContractsConfig,

--- a/yarn-project/ethereum/src/contracts/tally_slashing_proposer.test.ts
+++ b/yarn-project/ethereum/src/contracts/tally_slashing_proposer.test.ts
@@ -12,6 +12,7 @@ import { EthAddress } from '@aztec/foundation/eth-address';
 import { Fr } from '@aztec/foundation/fields';
 import { type Logger, createLogger } from '@aztec/foundation/log';
 import { bufferToHex } from '@aztec/foundation/string';
+import { DateProvider } from '@aztec/foundation/timer';
 import { TallySlashingProposerAbi } from '@aztec/l1-artifacts/TallySlashingProposerAbi';
 
 import type { Anvil } from '@viem/anvil';
@@ -82,7 +83,7 @@ describe('TallySlashingProposer', () => {
     };
 
     const deployed = await deployL1Contracts([rpcUrl], deployerPrivateKey, foundry, logger, testConfig);
-    cheatCodes = new EthCheatCodes([rpcUrl]);
+    cheatCodes = new EthCheatCodes([rpcUrl], new DateProvider());
     rollupCheatCodes = new RollupCheatCodes(cheatCodes, deployed.l1ContractAddresses);
 
     writeClient = createExtendedL1Client([rpcUrl], deployerPrivateKey);

--- a/yarn-project/ethereum/src/l1_tx_utils.test.ts
+++ b/yarn-project/ethereum/src/l1_tx_utils.test.ts
@@ -5,7 +5,7 @@ import { jsonStringify } from '@aztec/foundation/json-rpc';
 import { createLogger } from '@aztec/foundation/log';
 import { retryUntil } from '@aztec/foundation/retry';
 import { sleep } from '@aztec/foundation/sleep';
-import { TestDateProvider } from '@aztec/foundation/timer';
+import { DateProvider, TestDateProvider } from '@aztec/foundation/timer';
 
 import { jest } from '@jest/globals';
 import type { Anvil } from '@viem/anvil';
@@ -60,7 +60,7 @@ describe('L1TxUtils', () => {
 
   beforeEach(async () => {
     ({ anvil, rpcUrl } = await startAnvil({ l1BlockTime: 1, port: port++ }));
-    cheatCodes = new EthCheatCodes([rpcUrl]);
+    cheatCodes = new EthCheatCodes([rpcUrl], new DateProvider());
     const hdAccount = mnemonicToAccount(MNEMONIC, { addressIndex: 0 });
     const privKeyRaw = hdAccount.getHdKey().privateKey;
     if (!privKeyRaw) {

--- a/yarn-project/ethereum/src/test/eth_cheat_codes.test.ts
+++ b/yarn-project/ethereum/src/test/eth_cheat_codes.test.ts
@@ -1,6 +1,7 @@
 import { Blob } from '@aztec/blob-lib';
 import { times, timesAsync } from '@aztec/foundation/collection';
 import { type Logger, createLogger } from '@aztec/foundation/log';
+import { DateProvider } from '@aztec/foundation/timer';
 import { TestERC20Abi, TestERC20Bytecode } from '@aztec/l1-artifacts';
 
 import type { Anvil } from '@viem/anvil';
@@ -32,7 +33,7 @@ describe('EthCheatCodes', () => {
       ({ anvil, rpcUrl } = await startAnvil());
     }
 
-    cheatCodes = new EthCheatCodes([rpcUrl]);
+    cheatCodes = new EthCheatCodes([rpcUrl], new DateProvider());
     logger = createLogger('ethereum:test:eth_cheat_codes');
 
     const hdAccount = mnemonicToAccount(MNEMONIC, { addressIndex: 0 });

--- a/yarn-project/ethereum/src/test/rollup_cheat_codes.test.ts
+++ b/yarn-project/ethereum/src/test/rollup_cheat_codes.test.ts
@@ -1,6 +1,7 @@
 import { getPublicClient } from '@aztec/ethereum';
 import { Fr } from '@aztec/foundation/fields';
 import { type Logger, createLogger } from '@aztec/foundation/log';
+import { DateProvider } from '@aztec/foundation/timer';
 import { InboxAbi } from '@aztec/l1-artifacts/InboxAbi';
 
 import type { Anvil } from '@viem/anvil';
@@ -37,7 +38,7 @@ describe('RollupCheatCodes', () => {
     ({ anvil, rpcUrl } = await startAnvil());
 
     publicClient = getPublicClient({ l1RpcUrls: [rpcUrl], l1ChainId: 31337 });
-    cheatCodes = new EthCheatCodes([rpcUrl]);
+    cheatCodes = new EthCheatCodes([rpcUrl], new DateProvider());
 
     deployedL1Contracts = await deployL1Contracts([rpcUrl], privateKey, foundry, logger, {
       ...DefaultL1ContractsConfig,
@@ -48,7 +49,7 @@ describe('RollupCheatCodes', () => {
       realVerifier: false,
     });
 
-    rollupCheatCodes = RollupCheatCodes.create([rpcUrl], deployedL1Contracts.l1ContractAddresses);
+    rollupCheatCodes = RollupCheatCodes.create([rpcUrl], deployedL1Contracts.l1ContractAddresses, new DateProvider());
   });
 
   afterAll(async () => {

--- a/yarn-project/ethereum/src/test/tx_delayer.test.ts
+++ b/yarn-project/ethereum/src/test/tx_delayer.test.ts
@@ -2,7 +2,7 @@ import { Blob } from '@aztec/blob-lib';
 import { type Logger, createLogger } from '@aztec/foundation/log';
 import { retryUntil } from '@aztec/foundation/retry';
 import { sleep } from '@aztec/foundation/sleep';
-import { TestDateProvider } from '@aztec/foundation/timer';
+import { DateProvider, TestDateProvider } from '@aztec/foundation/timer';
 import { TestERC20Abi, TestERC20Bytecode } from '@aztec/l1-artifacts';
 
 import type { Anvil } from '@viem/anvil';
@@ -29,7 +29,7 @@ describe('tx_delayer', () => {
 
   beforeAll(async () => {
     ({ anvil, rpcUrl } = await startAnvil({ l1BlockTime: ETHEREUM_SLOT_DURATION }));
-    cheatCodes = new EthCheatCodes([rpcUrl]);
+    cheatCodes = new EthCheatCodes([rpcUrl], new DateProvider());
     logger = createLogger('ethereum:test:tx_delayer');
   });
 

--- a/yarn-project/ethereum/src/test/upgrade_utils.ts
+++ b/yarn-project/ethereum/src/test/upgrade_utils.ts
@@ -1,4 +1,5 @@
 import type { Logger } from '@aztec/foundation/log';
+import { DateProvider } from '@aztec/foundation/timer';
 import { GovernanceAbi } from '@aztec/l1-artifacts/GovernanceAbi';
 import { TestERC20Abi as StakingAssetAbi } from '@aztec/l1-artifacts/TestERC20Abi';
 
@@ -30,7 +31,7 @@ export async function executeGovernanceProposal(
     });
   };
 
-  const cheatCodes = new EthCheatCodes(rpcUrls, logger);
+  const cheatCodes = new EthCheatCodes(rpcUrls, new DateProvider(), logger);
 
   const timeToActive = proposal.creation + proposal.config.votingDelay;
   logger.info(`Warping to ${timeToActive + 1n}`);

--- a/yarn-project/stdlib/src/l1-contracts/slash_factory.test.ts
+++ b/yarn-project/stdlib/src/l1-contracts/slash_factory.test.ts
@@ -10,6 +10,7 @@ import { EthCheatCodes, startAnvil } from '@aztec/ethereum/test';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { Fr } from '@aztec/foundation/fields';
 import { type Logger, createLogger } from '@aztec/foundation/log';
+import { DateProvider } from '@aztec/foundation/timer';
 import { SlashFactoryAbi } from '@aztec/l1-artifacts/SlashFactoryAbi';
 
 import type { Anvil } from '@viem/anvil';
@@ -56,7 +57,7 @@ describe('SlashFactory', () => {
     ({ anvil, rpcUrl } = await startAnvil());
 
     publicClient = getPublicClient({ l1RpcUrls: [rpcUrl], l1ChainId: 31337 });
-    cheatCodes = new EthCheatCodes([rpcUrl]);
+    cheatCodes = new EthCheatCodes([rpcUrl], new DateProvider());
 
     const deployed = await deployL1Contracts([rpcUrl], privateKey, foundry, logger, {
       ...DefaultL1ContractsConfig,


### PR DESCRIPTION
Adds a required dateprovider to cheatcodes, so that we always update the current date when performing a warp on anvil.

I considered changing all dateprovider arguments in favor of using a singleton, but we have had issues in the past where different packages would load different instances of `foundation`, so I preferred to be explicit with the dependencies.
