### PR TITLE
fix: Register validator callbacks on p2p client before starting

### DIFF
--- a/yarn-project/end-to-end/src/e2e_p2p/preferred_gossip_network.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/preferred_gossip_network.test.ts
@@ -284,6 +284,7 @@ describe('e2e_p2p_preferred_network', () => {
       .concat(validators.map((_, i) => `Validator ${i + 1}`))
       .concat(noDiscoveryValidators.map((_, i) => `Picky Validator ${i + 1}`))
       .concat(['Default Node']);
+    t.logger.warn(`All nodes initialized: ${identifiers.join(', ')}`);
 
     const validatorsUsingDiscovery = validators.length;
     const totalNumValidators = validators.length + noDiscoveryValidators.length;
@@ -297,7 +298,9 @@ describe('e2e_p2p_preferred_network', () => {
       const peerResult = await waitForNodeToAcquirePeers(allNodes[i], expectedPeerCounts[i], 300, identifiers[i]);
       expect(peerResult).toBeTruthy();
     }
-    t.logger.info('All node/validator peer connections established');
+    t.logger.warn(
+      `All node peer connections established: ${identifiers.map((id, i) => `${id} (${expectedPeerCounts[i]})`).join(', ')}`,
+    );
 
     validators.push(...noDiscoveryValidators);
 

--- a/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
+++ b/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
@@ -453,10 +453,6 @@ export class LibP2PService<T extends P2PClientType = P2PClientType.Full> extends
     const goodbyeHandler = reqGoodbyeHandler(this.peerManager);
     const blockHandler = reqRespBlockHandler(this.archiver);
     const statusHandler = reqRespStatusHandler(this.protocolVersion, this.worldStateSynchronizer, this.logger);
-    // In case P2P client doesnt'have attestation pool,
-    // const blockTxsHandler = this.mempools.attestationPool
-    //   ? reqRespBlockTxsHandler(this.mempools.attestationPool, this.mempools.txPool)
-    //   : def;
 
     const requestResponseHandlers: Partial<ReqRespSubProtocolHandlers> = {
       [ReqRespSubProtocol.PING]: pingHandler,

--- a/yarn-project/p2p/src/services/peer-manager/peer_manager.ts
+++ b/yarn-project/p2p/src/services/peer-manager/peer_manager.ts
@@ -883,7 +883,7 @@ export class PeerManager implements PeerManagerInterface {
       const response = await this.reqresp.sendRequestToPeer(peerId, ReqRespSubProtocol.AUTH, authRequest.toBuffer());
       const { status } = response;
       if (status !== ReqRespStatus.SUCCESS) {
-        this.logger.debug(`Disconnecting peer ${peerId} who failed to respond auth handshake`, {
+        this.logger.verbose(`Disconnecting peer ${peerId} who failed to respond auth handshake`, {
           peerId,
           status: ReqRespStatus[status],
         });
@@ -899,7 +899,7 @@ export class PeerManager implements PeerManagerInterface {
 
       const peerStatusMessage = peerAuthResponse.status;
       if (!ourStatus.validate(peerStatusMessage)) {
-        this.logger.debug(`Disconnecting peer ${peerId} due to failed status handshake as part of auth.`, logData);
+        this.logger.verbose(`Disconnecting peer ${peerId} due to failed status handshake as part of auth.`, logData);
         this.markAuthHandshakeFailed(peerId);
         this.markPeerForDisconnect(peerId);
         return;
@@ -911,12 +911,9 @@ export class PeerManager implements PeerManagerInterface {
       const registeredValidators = await this.epochCache.getRegisteredValidators();
       const found = registeredValidators.find(v => v.toString() === sender.toString()) !== undefined;
       if (!found) {
-        this.logger.debug(
+        this.logger.verbose(
           `Disconnecting peer ${peerId} due to failed auth handshake, peer is not a registered validator.`,
-          {
-            peerId,
-            address: sender.toString(),
-          },
+          { ...logData, address: sender.toString() },
         );
         this.markAuthHandshakeFailed(peerId);
         this.markPeerForDisconnect(peerId);
@@ -926,8 +923,9 @@ export class PeerManager implements PeerManagerInterface {
       // Check to see that this validator address isn't already allocated to a different peer
       const peerForAddress = this.authenticatedValidatorAddressToPeerId.get(sender.toString());
       if (peerForAddress !== undefined && peerForAddress.toString() !== peerIdString) {
-        this.logger.debug(
+        this.logger.verbose(
           `Received auth for validator ${sender.toString()} from peer ${peerIdString}, but this validator is already authenticated to peer ${peerForAddress.toString()}`,
+          { ...logData, address: sender.toString() },
         );
         return;
       }
@@ -937,12 +935,13 @@ export class PeerManager implements PeerManagerInterface {
       this.authenticatedValidatorAddressToPeerId.set(sender.toString(), peerId);
       this.logger.info(
         `Successfully completed auth handshake with peer ${peerId}, validator address ${sender.toString()}`,
-        logData,
+        { ...logData, address: sender.toString() },
       );
     } catch (err: any) {
       //TODO: maybe hard ban these peers in the future
-      this.logger.debug(`Disconnecting peer ${peerId} due to error during auth handshake: ${err.message ?? err}`, {
+      this.logger.verbose(`Disconnecting peer ${peerId} due to error during auth handshake: ${err.message}`, {
         peerId,
+        err,
       });
       this.markAuthHandshakeFailed(peerId);
       this.markPeerForDisconnect(peerId);

--- a/yarn-project/p2p/src/services/reqresp/interface.ts
+++ b/yarn-project/p2p/src/services/reqresp/interface.ts
@@ -123,27 +123,6 @@ export type SubProtocolMap = {
 };
 
 /**
- * Default handler for unimplemented sub protocols, this SHOULD be overwritten
- * by the service, but is provided as a fallback
- */
-export const defaultHandler = (_msg: any): Promise<Buffer> => {
-  return Promise.resolve(Buffer.from('unimplemented'));
-};
-
-/**
- * Default sub protocol handlers - this SHOULD be overwritten by the service,
- */
-export const DEFAULT_SUB_PROTOCOL_HANDLERS: ReqRespSubProtocolHandlers = {
-  [ReqRespSubProtocol.PING]: defaultHandler,
-  [ReqRespSubProtocol.STATUS]: defaultHandler,
-  [ReqRespSubProtocol.TX]: defaultHandler,
-  [ReqRespSubProtocol.GOODBYE]: defaultHandler,
-  [ReqRespSubProtocol.BLOCK]: defaultHandler,
-  [ReqRespSubProtocol.AUTH]: defaultHandler,
-  [ReqRespSubProtocol.BLOCK_TXS]: defaultHandler,
-};
-
-/**
  * The Request Response Pair interface defines the methods that each
  * request response pair must implement
  */

--- a/yarn-project/stdlib/src/interfaces/validator.ts
+++ b/yarn-project/stdlib/src/interfaces/validator.ts
@@ -54,7 +54,6 @@ export const ValidatorClientConfigSchema = z.object({
 
 export interface Validator {
   start(): Promise<void>;
-  registerBlockProposalHandler(): void;
   updateConfig(config: Partial<ValidatorClientFullConfig>): void;
 
   // Block validation responsibilities

--- a/yarn-project/validator-client/src/validator.ts
+++ b/yarn-project/validator-client/src/validator.ts
@@ -62,6 +62,9 @@ export class ValidatorClient extends (EventEmitter as new () => WatcherEmitter) 
   private validationService: ValidationService;
   private metrics: ValidatorMetrics;
 
+  // Whether it has already registered handlers on the p2p client
+  private hasRegisteredHandlers = false;
+
   // Used to check if we are sending the same proposal twice
   private previousProposal?: BlockProposal;
 
@@ -212,12 +215,9 @@ export class ValidatorClient extends (EventEmitter as new () => WatcherEmitter) 
       return;
     }
 
-    this.registerBlockProposalHandler();
+    await this.registerHandlers();
 
-    // Sync the committee from the smart contract
-    // https://github.com/AztecProtocol/aztec-packages/issues/7962
     const myAddresses = this.getValidatorAddresses();
-
     const inCommittee = await this.epochCache.filterInCommittee('now', myAddresses);
     if (inCommittee.length > 0) {
       this.log.info(
@@ -230,9 +230,6 @@ export class ValidatorClient extends (EventEmitter as new () => WatcherEmitter) 
     }
     this.epochCacheUpdateLoop.start();
 
-    this.p2pClient.registerThisValidatorAddresses(myAddresses);
-    await this.p2pClient.addReqRespSubProtocol(ReqRespSubProtocol.AUTH, this.handleAuthRequest.bind(this));
-
     return Promise.resolve();
   }
 
@@ -240,10 +237,21 @@ export class ValidatorClient extends (EventEmitter as new () => WatcherEmitter) 
     await this.epochCacheUpdateLoop.stop();
   }
 
-  public registerBlockProposalHandler() {
-    const handler = (block: BlockProposal, proposalSender: PeerId): Promise<BlockAttestation[] | undefined> =>
-      this.attestToProposal(block, proposalSender);
-    this.p2pClient.registerBlockProposalHandler(handler);
+  /** Register handlers on the p2p client */
+  public async registerHandlers() {
+    if (!this.hasRegisteredHandlers) {
+      this.hasRegisteredHandlers = true;
+      this.log.debug(`Registering validator handlers for p2p client`);
+
+      const handler = (block: BlockProposal, proposalSender: PeerId): Promise<BlockAttestation[] | undefined> =>
+        this.attestToProposal(block, proposalSender);
+      this.p2pClient.registerBlockProposalHandler(handler);
+
+      const myAddresses = this.getValidatorAddresses();
+      this.p2pClient.registerThisValidatorAddresses(myAddresses);
+
+      await this.p2pClient.addReqRespSubProtocol(ReqRespSubProtocol.AUTH, this.handleAuthRequest.bind(this));
+    }
   }
 
   async attestToProposal(proposal: BlockProposal, proposalSender: PeerId): Promise<BlockAttestation[] | undefined> {


### PR DESCRIPTION
Second attempt at https://github.com/AztecProtocol/aztec-packages/pull/17207

The issue was that the `start` method on p2p client would overwrite all previously registered subprotocol handlers, hence the errors we were seeing on CI:
```
22:00:04 [22:00:04.697] WARN: p2p:4506:libp2p_service:4506:libp2p_service:4506:reqresp:4506 Unknown stream error while handling the stream, aborting {"protocol":"/aztec/req/auth/1.0.0"}
22:00:04     err: {
22:00:04       "type": "TypeError",
22:00:04       "message": "handler is not a function",
22:00:04       "stack":
22:00:04           TypeError: handler is not a function
22:00:04               at /home/aztec-dev/aztec-packages/yarn-project/p2p/dest/services/reqresp/reqresp.js:452:40
22:00:04               at processTicksAndRejections (node:internal/process/task_queues:105:5)
22:00:04               at duplex.sink (/home/aztec-dev/aztec-packages/yarn-project/node_modules/it-byte-stream/src/index.ts:86:22)
22:00:04     }
```

The test was also failing locally (it had passed before I submitted due to a build issue I missed), and since it was tagged as flake it was greenlighted by CI on the PR.