### PR TITLE
chore: Allow publishers in invalid states on flakey e2e test

### DIFF
--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_proof_public_cross_chain.test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_proof_public_cross_chain.test.ts
@@ -19,7 +19,12 @@ describe('e2e_epochs/epochs_proof_public_cross_chain', () => {
   let test: EpochsTestContext;
 
   beforeEach(async () => {
-    test = await EpochsTestContext.setup({ numberOfAccounts: 1, minTxsPerBlock: 1, disableAnvilTestWatcher: true });
+    test = await EpochsTestContext.setup({
+      numberOfAccounts: 1,
+      minTxsPerBlock: 1,
+      disableAnvilTestWatcher: true,
+      publisherAllowInvalidStates: true,
+    });
     ({ context, logger } = test);
   });
 


### PR DESCRIPTION
The `epochs_proof_public_cross_chain` e2e test flakes often with the `Failed to find an available publisher` error (see http://ci.aztec-labs.com/80e4dea68c4ba5d0).

Until we merge #17199 which enables using invalid publishers by default, or we ship a more permanent fix, this should handle flakes on this specific test.
