### PR TITLE
fix: outdated defaults in benchmark_client_ivc.sh

### DIFF
--- a/barretenberg/cpp/scripts/benchmark_client_ivc.sh
+++ b/barretenberg/cpp/scripts/benchmark_client_ivc.sh
@@ -2,7 +2,7 @@
 set -eu
 
 TARGET=${1:-"client_ivc_bench"}
-BENCHMARK="ClientIVCBench/Full/6"
+BENCHMARK="ClientIVCBench/Full/5"
 BUILD_DIR="build"
 FILTER="${BENCHMARK}$" # '$' to ensure only specified bench is run
 
@@ -20,7 +20,3 @@ cd $(dirname $0)/..
 # Retrieve output from benching instance
 cd $BUILD_DIR
 scp $BB_SSH_KEY $BB_SSH_INSTANCE:$BB_SSH_CPP_PATH/build/$TARGET.json .
-
-# Analyze the results
-cd ../
-python3 ./scripts/analyze_client_ivc_bench.py --json "$TARGET.json" --benchmark "$BENCHMARK" --prefix "$BUILD_DIR"


### PR DESCRIPTION
`analyze_client_ivc_bench.py` was already gone and there's no `Full/6` bench now.