### PR TITLE
chore: dont flake circuit_checker_tests UltraCircuitBuilder.NonNativeFieldMultiplication

### DIFF
--- a/.test_patterns.yml
+++ b/.test_patterns.yml
@@ -72,18 +72,6 @@ tests:
     error_regex: "Aborted.*core dumped"
     owners:
       - *adam
-  # Failed NonNativeField relation at row idx = 5 (mem: 9.00 MiB)
-  # Failed at block idx = 6 (mem: 9.00 MiB)
-  # /home/aztec-dev/aztec-packages/barretenberg/cpp/src/barretenberg/circuit_checker/ultra_circuit_builder.test.cpp:631: Failure
-  # Expected equality of these values:
-  #   result
-  #     Which is: false
-  #   true
-  # http://ci.aztec-labs.com/f5aa7b4b0e45ade3
-  - regex: "barretenberg/cpp/scripts/run_test.sh circuit_checker_tests UltraCircuitBuilder.NonNativeFieldMultiplication"
-    error_regex: "ultra_circuit_builder.test.cpp:631: Failure"
-    owners:
-      - *luke
 
   # /home/aztec-dev/aztec-packages/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_edge_cases.test.cpp:142: Failure
   # Expected equality of these values:


### PR DESCRIPTION
we fixed it in https://github.com/AztecProtocol/aztec-packages/commit/8ad345e56c724269439fce0a6500eb41374e41a0
