### PR TITLE
feat: Improve polynomial folding in PG

### DIFF
--- a/barretenberg/cpp/src/barretenberg/common/thread.hpp
+++ b/barretenberg/cpp/src/barretenberg/common/thread.hpp
@@ -154,7 +154,7 @@ constexpr size_t ALWAYS_MULTITHREAD = 100000;
 struct ThreadChunk {
     size_t thread_index;
     size_t total_threads;
-    auto range(size_t size) const
+    auto range(size_t size, size_t offset = 0) const
     {
         if (total_threads == 0 || thread_index >= total_threads) {
             return std::views::iota(size_t{ 0 }, size_t{ 0 });
@@ -167,12 +167,12 @@ struct ThreadChunk {
             // Threads with index < remainder get chunk_size + 1 elements
             size_t start = thread_index * (chunk_size + 1);
             size_t end = start + chunk_size + 1;
-            return std::views::iota(start, end);
+            return std::views::iota(start + offset, end + offset);
         }
         // Threads with index >= remainder get chunk_size elements
         size_t start = remainder * (chunk_size + 1) + (thread_index - remainder) * chunk_size;
         size_t end = start + chunk_size;
-        return std::views::iota(start, end);
+        return std::views::iota(start + offset, end + offset);
     }
 };
 

--- a/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover_impl.hpp
@@ -140,7 +140,8 @@ void ProtogalaxyProver_<Flavor>::update_target_sum_and_fold(
     // solution is to simply reverse the order or the terms in the linear combination by swapping the polynomials and
     // the lagrange coefficients between the accumulator and the incoming key.
     // TODO(https://github.com/AztecProtocol/barretenberg/issues/1417): make this swapping logic more robust.
-    if (incoming->get_overflow_size() > accumulator->get_overflow_size()) {
+    bool swap_polys = incoming->get_overflow_size() > accumulator->get_overflow_size();
+    if (swap_polys) {
         std::swap(accumulator->polynomials, incoming->polynomials); // swap the polys
         std::swap(lagranges[0], lagranges[1]);                 // swap the lagrange coefficients so the sum is unchanged
         accumulator->set_dyadic_size(incoming->dyadic_size()); // update dyadic size of accumulator
@@ -159,7 +160,6 @@ void ProtogalaxyProver_<Flavor>::update_target_sum_and_fold(
     size_t max_size = 0;
     for (size_t i = 0; i < num_polys; ++i) {
         max_size = std::max(max_size, key_polys[i].size());
-        max_size = std::max(max_size, accumulator_polys[i].size());
     }
     const size_t num_threads = calculate_num_threads(max_size);
 
@@ -175,24 +175,35 @@ void ProtogalaxyProver_<Flavor>::update_target_sum_and_fold(
     }
 
     // Multithread the next part which computes the folded polynomials
-    parallel_for(num_threads, [&](size_t j) {
+    parallel_for(num_threads, [&](size_t thread_idx) {
         for (size_t i = 0; i < num_polys; ++i) {
             auto& acc = acc_spans[i];
             auto& key = key_spans[i];
             BB_ASSERT_LTE(acc.start_index, key.start_index);
             BB_ASSERT_GTE(acc.end_index(), key.end_index());
-            const size_t range_per_thread = key.size() / num_threads;
-            const size_t leftovers = key.size() - (range_per_thread * num_threads);
+            const size_t range_per_thread = acc.size() / num_threads;
+            const size_t leftovers = acc.size() - (num_threads * range_per_thread);
 
-            const size_t offset = j * range_per_thread + key.start_index;
+            const size_t offset = (thread_idx * range_per_thread) + acc.start_index;
+            // The last thread takes up more work than the previous ones
             const size_t end =
-                (j == num_threads - 1) ? offset + range_per_thread + leftovers : offset + range_per_thread;
+                (thread_idx == num_threads - 1) ? offset + range_per_thread + leftovers : offset + range_per_thread;
 
-            // for each polynomial, we fold by computing acc = acc * lagranges[0] + key * lagranges[1]
-            // which is equivalent to acc * (1 - gamma) + key * gamma
-            // which is equivalent to acc + (key - acc) * gamma
+            // For each polynomial, we fold by computing: acc = acc * lagranges[0] + key * lagranges[1]
+            // Note that outside the range [key.start_index, key.end_index) this becomes: acc = acc * lagranges[0]
             for (size_t k = offset; k < end; ++k) {
-                acc[k] += (key[k] - acc[k]) * combiner_challenge;
+                if ((k < key.start_index) || (k >= key.end_index())) {
+                    acc[k] = acc[k] * lagranges[0];
+                } else {
+                    // acc * lagranges[0] + key * lagranges[1] =
+                    // acc + (key - acc) * combiner_challenge (if !swap_polys)
+                    // key + (acc - key) * combiner_challenge (if swap_polys)
+                    if (swap_polys) {
+                        acc[k] = key[k] + (acc[k] - key[k]) * combiner_challenge;
+                    } else {
+                        acc[k] = acc[k] + (key[k] - acc[k]) * combiner_challenge;
+                    }
+                }
             }
         }
     });

--- a/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover_impl.hpp
@@ -149,22 +149,13 @@ void ProtogalaxyProver_<Flavor>::update_target_sum_and_fold(
     }
 
     // Fold the prover polynomials
-    auto accumulator_polys = accumulator->polynomials.get_unshifted();
-    auto key_polys = incoming->polynomials.get_unshifted();
-
-    // Instead of iterating the polynomial set and multithreading each inner polynomial,
-    // we only spin up threads to cover the whole polynomial set e.g. say we have 50 polys all of size 100k and have 10
-    // threads we want each thread to iterate over 50 polys and iterate over a 10k range (and not spin up 500 threads
-    // where each thread iterates over a 10k range for 1 poly)
-    const size_t num_polys = key_polys.size();
-    size_t max_size = 0;
-    for (size_t i = 0; i < num_polys; ++i) {
-        max_size = std::max(max_size, key_polys[i].size());
-    }
-    const size_t num_threads = calculate_num_threads(max_size);
 
     // Convert the polynomials into spans to remove boundary checks and if checks that normally apply when calling
     // getter/setters in Polynomial (see SharedShiftedVirtualZeroesArray::get)
+    auto accumulator_polys = accumulator->polynomials.get_unshifted();
+    auto key_polys = incoming->polynomials.get_unshifted();
+    const size_t num_polys = key_polys.size();
+
     std::vector<PolynomialSpan<FF>> acc_spans;
     std::vector<PolynomialSpan<FF>> key_spans;
     acc_spans.reserve(num_polys);
@@ -174,34 +165,20 @@ void ProtogalaxyProver_<Flavor>::update_target_sum_and_fold(
         key_spans.emplace_back(static_cast<PolynomialSpan<FF>>(key_polys[i]));
     }
 
-    // Multithread the next part which computes the folded polynomials
-    parallel_for(num_threads, [&](size_t thread_idx) {
-        for (size_t i = 0; i < num_polys; ++i) {
-            auto& acc = acc_spans[i];
-            auto& key = key_spans[i];
-            BB_ASSERT_LTE(acc.start_index, key.start_index);
-            BB_ASSERT_GTE(acc.end_index(), key.end_index());
-            const size_t range_per_thread = acc.size() / num_threads;
-            const size_t leftovers = acc.size() - (num_threads * range_per_thread);
-
-            const size_t offset = (thread_idx * range_per_thread) + acc.start_index;
-            // The last thread takes up more work than the previous ones
-            const size_t end =
-                (thread_idx == num_threads - 1) ? offset + range_per_thread + leftovers : offset + range_per_thread;
-
-            // For each polynomial, we fold by computing: acc = acc * lagranges[0] + key * lagranges[1]
-            // Note that outside the range [key.start_index, key.end_index) this becomes: acc = acc * lagranges[0]
-            for (size_t k = offset; k < end; ++k) {
-                if ((k < key.start_index) || (k >= key.end_index())) {
-                    acc[k] = acc[k] * lagranges[0];
+    parallel_for([&acc_spans, &key_spans, &lagranges, &combiner_challenge, &swap_polys](const ThreadChunk& chunk) {
+        for (auto [acc_poly, key_poly] : zip_view(acc_spans, key_spans)) {
+            size_t offset = acc_poly.start_index;
+            for (size_t idx : chunk.range(acc_poly.size(), offset)) {
+                if ((idx < key_poly.start_index) || (idx >= key_poly.end_index())) {
+                    acc_poly[idx] *= lagranges[0];
                 } else {
                     // acc * lagranges[0] + key * lagranges[1] =
                     // acc + (key - acc) * combiner_challenge (if !swap_polys)
                     // key + (acc - key) * combiner_challenge (if swap_polys)
                     if (swap_polys) {
-                        acc[k] = key[k] + (acc[k] - key[k]) * combiner_challenge;
+                        acc_poly[idx] = key_poly[idx] + (acc_poly[idx] - key_poly[idx]) * combiner_challenge;
                     } else {
-                        acc[k] = acc[k] + (key[k] - acc[k]) * combiner_challenge;
+                        acc_poly[idx] = acc_poly[idx] + (key_poly[idx] - acc_poly[idx]) * combiner_challenge;
                     }
                 }
             }

--- a/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover_impl.hpp
@@ -147,18 +147,53 @@ void ProtogalaxyProver_<Flavor>::update_target_sum_and_fold(
         accumulator->set_overflow_size(incoming->get_overflow_size()); // swap overflow size
     }
 
-    // Fold the proving key polynomials
-    parallel_for([&accumulator, &lagranges](const ThreadChunk& chunk) {
-        for (auto& poly : accumulator->polynomials.get_unshifted()) {
-            poly.multiply_chunk(chunk, lagranges[0]);
-        }
-    });
+    // Fold the prover polynomials
+    auto accumulator_polys = accumulator->polynomials.get_unshifted();
+    auto key_polys = incoming->polynomials.get_unshifted();
 
-    // This cannot be combined with the previous parallel_for because add_scaled_chunk is by the key_poly size
-    parallel_for([&accumulator, &lagranges, &incoming](const ThreadChunk& chunk) {
-        for (auto [acc_poly, key_poly] :
-             zip_view(accumulator->polynomials.get_unshifted(), incoming->polynomials.get_unshifted())) {
-            acc_poly.add_scaled_chunk(chunk, key_poly, lagranges[1]);
+    // Instead of iterating the polynomial set and multithreading each inner polynomial,
+    // we only spin up threads to cover the whole polynomial set e.g. say we have 50 polys all of size 100k and have 10
+    // threads we want each thread to iterate over 50 polys and iterate over a 10k range (and not spin up 500 threads
+    // where each thread iterates over a 10k range for 1 poly)
+    const size_t num_polys = key_polys.size();
+    size_t max_size = 0;
+    for (size_t i = 0; i < num_polys; ++i) {
+        max_size = std::max(max_size, key_polys[i].size());
+        max_size = std::max(max_size, accumulator_polys[i].size());
+    }
+    const size_t num_threads = calculate_num_threads(max_size);
+
+    // Convert the polynomials into spans to remove boundary checks and if checks that normally apply when calling
+    // getter/setters in Polynomial (see SharedShiftedVirtualZeroesArray::get)
+    std::vector<PolynomialSpan<FF>> acc_spans;
+    std::vector<PolynomialSpan<FF>> key_spans;
+    acc_spans.reserve(num_polys);
+    key_spans.reserve(num_polys);
+    for (size_t i = 0; i < num_polys; ++i) {
+        acc_spans.emplace_back(static_cast<PolynomialSpan<FF>>(accumulator_polys[i]));
+        key_spans.emplace_back(static_cast<PolynomialSpan<FF>>(key_polys[i]));
+    }
+
+    // Multithread the next part which computes the folded polynomials
+    parallel_for(num_threads, [&](size_t j) {
+        for (size_t i = 0; i < num_polys; ++i) {
+            auto& acc = acc_spans[i];
+            auto& key = key_spans[i];
+            BB_ASSERT_LTE(acc.start_index, key.start_index);
+            BB_ASSERT_GTE(acc.end_index(), key.end_index());
+            const size_t range_per_thread = key.size() / num_threads;
+            const size_t leftovers = key.size() - (range_per_thread * num_threads);
+
+            const size_t offset = j * range_per_thread + key.start_index;
+            const size_t end =
+                (j == num_threads - 1) ? offset + range_per_thread + leftovers : offset + range_per_thread;
+
+            // for each polynomial, we fold by computing acc = acc * lagranges[0] + key * lagranges[1]
+            // which is equivalent to acc * (1 - gamma) + key * gamma
+            // which is equivalent to acc + (key - acc) * gamma
+            for (size_t k = offset; k < end; ++k) {
+                acc[k] += (key[k] - acc[k]) * combiner_challenge;
+            }
         }
     });
 


### PR DESCRIPTION
**Update:** Given the strange benchmark results, this PR is currently marked as draft. Relevant issue for investigating PR benchmarks is [here](https://github.com/AztecProtocol/barretenberg/issues/1544)

**Update**: PR (to be) merged. Issue investigating benchmark results is still open.

PG folds two instances, so folding can be performed more efficiently by folding using the formula `acc = acc + (acc - inc) * combiner_challenge` instead of `acc = (1 - combiner_challenge) * acc + inc * combiner_challenge`. This PR multithreads polynomial folding using this formula.

Improvements depend on the transaction:
| Tx | Improvement in `update_target_sum_and_fold` | Improvement in Prover|
| --- | ------ | --- |
| deploy_ecdsar1+sponsored_fpc | 140ms | 520ms |
| deploy_schnorr+sponsored_fpc | 132ms | 550ms |
| ecdsar1+amm_add_liquidity_1_recursions+sponsored_fpc | 181ms | 980ms |
| ecdsar1+transfer_1_recursions+private_fpc | 136ms | 730ms |

This PR is based on https://github.com/AztecProtocol/aztec-packages/pull/11748.
```
════════════════════════════════════════════════════════════════════════════════════════════════════════════
  Benchmark Results: deploy_ecdsar1+sponsored_fpc, without the change
════════════════════════════════════════════════════════════════════════════════════════════════════════════
ClientIVCAPI::prove                                                               [0]           16.11s
  ├─ ClientIvcAccumulate                                                               [1]  67.3 %   10.84s     (722.82 ms x 15)
    ├─ ProtogalaxyProver::prove                                                          [2]  53.2 %   5.76s      (443.38 ms x 13)
      └─ ProtogalaxyProver_::update_target_sum_and_fold                                    [3]  9.2  %   532.8ms    (40.99 ms x 13)
        ├─ do_iterations()                                                                   [4]  87.2 %   464.4ms    (1.12 ms x 416)  16 threads 463.64ms average 0.00% stddev
        ├─ spinning main thread                                                              [4]  0.9  %
        └─ (other)                                                                           [4]  11.9 %
────────────────────────────────────────────────────────────────────────────────────────────────────────────
  Total: 88 functions (14 shared), 166130 measurements, 16.11 seconds
════════════════════════════════════════════════════════════════════════════════════════════════════════════
```

```
════════════════════════════════════════════════════════════════════════════════════════════════════════════
  Benchmark Results: deploy_ecdsar1+sponsored_fpc, with the change
════════════════════════════════════════════════════════════════════════════════════════════════════════════
ClientIVCAPI::prove                                                               [0]           15.59s
  ├─ ClientIvcAccumulate                                                               [1]  66.2 %   10.32s     (688.01 ms x 15)
    ├─ ProtogalaxyProver::prove                                                          [2]  54.5 %   5.62s      (432.52 ms x 13)
      └─ ProtogalaxyProver_::update_target_sum_and_fold                                    [3]  7.0  %   392.8ms    (30.22 ms x 13)
        ├─ do_iterations()                                                                   [4]  83.0 %   326.0ms    (1.57 ms x 208)  16 threads 325.57ms average 0.00% stddev
        ├─ spinning main thread                                                              [4]  1.1  %
        └─ (other)                                                                           [4]  16.0 %
────────────────────────────────────────────────────────────────────────────────────────────────────────────
    Total: 88 functions (14 shared), 165909 measurements, 15.59 seconds
════════════════════════════════════════════════════════════════════════════════════════════════════════════
```

```
════════════════════════════════════════════════════════════════════════════════════════════════════════════
  Benchmark Results: deploy_schnorr+sponsored_fpc, without the change
════════════════════════════════════════════════════════════════════════════════════════════════════════════
ClientIVCAPI::prove                                                               [0]           15.44s
  ├─ ClientIvcAccumulate                                                               [1]  65.7 %   10.14s     (675.91 ms x 15)
    ├─ ProtogalaxyProver::prove                                                          [2]  52.6 %   5.33s      (409.97 ms x 13)
      └─ ProtogalaxyProver_::update_target_sum_and_fold                                    [3]  10.0 %   531.4ms    (40.88 ms x 13)
        ├─ do_iterations()                                                                   [4]  87.2 %   463.6ms    (1.11 ms x 416)  16 threads 462.99ms average 0.00% stddev
        ├─ spinning main thread                                                              [4]  0.8  %
        └─ (other)                                                                           [4]  12.0 %
────────────────────────────────────────────────────────────────────────────────────────────────────────────
  Total: 88 functions (14 shared), 166140 measurements, 15.44 seconds
════════════════════════════════════════════════════════════════════════════════════════════════════════════
```

```
════════════════════════════════════════════════════════════════════════════════════════════════════════════
  Benchmark Results: deploy_schnorr+sponsored_fpc, with the change
════════════════════════════════════════════════════════════════════════════════════════════════════════════
ClientIVCAPI::prove                                                               [0]           14.89s
  ├─ ClientIvcAccumulate                                                               [1]  64.6 %   9.62s      (641.12 ms x 15)
    ├─ ProtogalaxyProver::prove                                                          [2]  53.9 %   5.18s      (398.62 ms x 13)
      └─ ProtogalaxyProver_::update_target_sum_and_fold                                    [3]  7.6  %   392.1ms    (30.16 ms x 13)
        ├─ do_iterations()                                                                   [4]  83.0 %   325.4ms    (1.56 ms x 208)  16 threads 324.73ms average 0.00% stddev
        ├─ spinning main thread                                                              [4]  0.8  %
        └─ (other)                                                                           [4]  16.2 %
────────────────────────────────────────────────────────────────────────────────────────────────────────────
    Total: 88 functions (14 shared), 165919 measurements, 14.89 seconds
════════════════════════════════════════════════════════════════════════════════════════════════════════════
```

```
════════════════════════════════════════════════════════════════════════════════════════════════════════════
  Benchmark Results: ecdsar1+amm_add_liquidity_1_recursions+sponsored_fpc, without the change
════════════════════════════════════════════════════════════════════════════════════════════════════════════
ClientIVCAPI::prove                                                               [0]           24.82s
  ├─ ClientIvcAccumulate                                                               [1]  75.1 %   18.64s     (981.31 ms x 19)
    ├─ ProtogalaxyProver::prove                                                          [2]  56.1 %   10.46s     (615.39 ms x 17)
      └─ ProtogalaxyProver_::update_target_sum_and_fold                                    [3]  8.6  %   896.8ms    (52.75 ms x 17)
        ├─ do_iterations()                                                                   [4]  89.6 %   803.8ms    (1.48 ms x 544)  16 threads 799.85ms average 0.00% stddev
        ├─ spinning main thread                                                              [4]  1.2  %
        └─ (other)                                                                           [4]  9.2  %
────────────────────────────────────────────────────────────────────────────────────────────────────────────
  Total: 88 functions (14 shared), 186270 measurements, 24.82 seconds
════════════════════════════════════════════════════════════════════════════════════════════════════════════
```

```
════════════════════════════════════════════════════════════════════════════════════════════════════════════
  Benchmark Results: ecdsar1+amm_add_liquidity_1_recursions+sponsored_fpc, with the change
════════════════════════════════════════════════════════════════════════════════════════════════════════════
ClientIVCAPI::prove                                                               [0]           23.84s
  ├─ ClientIvcAccumulate                                                               [1]  74.2 %   17.69s     (931.21 ms x 19)
    ├─ ProtogalaxyProver::prove                                                          [2]  57.9 %   10.24s     (602.16 ms x 17)
      └─ ProtogalaxyProver_::update_target_sum_and_fold                                    [3]  7.0  %   715.1ms    (42.07 ms x 17)
        ├─ do_iterations()                                                                   [4]  86.1 %   615.7ms    (2.26 ms x 272)  16 threads 612.59ms average 0.00% stddev
        ├─ spinning main thread                                                              [4]  2.4  %
        └─ (other)                                                                           [4]  11.5 %
────────────────────────────────────────────────────────────────────────────────────────────────────────────
  Total: 88 functions (14 shared), 185981 measurements, 23.84 seconds
════════════════════════════════════════════════════════════════════════════════════════════════════════════
```

```
════════════════════════════════════════════════════════════════════════════════════════════════════════════
  Benchmark Results: ecdsar1+transfer_1_recursions+private_fpc, without the change
════════════════════════════════════════════════════════════════════════════════════════════════════════════
ClientIVCAPI::prove                                                               [0]           22.68s
  ├─ ClientIvcAccumulate                                                               [1]  74.5 %   16.91s     (994.49 ms x 17)
    ├─ ProtogalaxyProver::prove                                                          [2]  52.2 %   8.83s      (588.53 ms x 15)
      └─ ProtogalaxyProver_::update_target_sum_and_fold                                    [3]  8.0  %   703.8ms    (46.92 ms x 15)
        ├─ do_iterations()                                                                   [4]  88.8 %   625.1ms    (1.30 ms x 480)  16 threads 624.38ms average 0.00% stddev
        ├─ spinning main thread                                                              [4]  0.7  %
        └─ (other)                                                                           [4]  10.5 %
────────────────────────────────────────────────────────────────────────────────────────────────────────────
  Total: 88 functions (14 shared), 176311 measurements, 22.68 seconds
════════════════════════════════════════════════════════════════════════════════════════════════════════════
```

```
════════════════════════════════════════════════════════════════════════════════════════════════════════════
  Benchmark Results: ecdsar1+transfer_1_recursions+private_fpc, with the change
════════════════════════════════════════════════════════════════════════════════════════════════════════════
ClientIVCAPI::prove                                                               [0]           21.95s
  ├─ ClientIvcAccumulate                                                               [1]  73.8 %   16.20s     (952.97 ms x 17)
    ├─ ProtogalaxyProver::prove                                                          [2]  53.5 %   8.67s      (577.78 ms x 15)
      └─ ProtogalaxyProver_::update_target_sum_and_fold                                    [3]  6.5  %   567.3ms    (37.82 ms x 15)
        ├─ do_iterations()                                                                   [4]  84.7 %   480.3ms    (2.00 ms x 240)  16 threads 465.79ms average 1.00% stddev
        ├─ spinning main thread                                                              [4]  5.6  %
        └─ (other)                                                                           [4]  9.7  %
────────────────────────────────────────────────────────────────────────────────────────────────────────────
    Total: 88 functions (14 shared), 176056 measurements, 21.95 seconds
════════════════════════════════════════════════════════════════════════════════════════════════════════════
```