### PR TITLE
chore: Deflake epoch prune e2e test (again)

### DIFF
--- a/yarn-project/end-to-end/src/e2e_p2p/shared.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/shared.ts
@@ -242,9 +242,10 @@ export async function awaitCommitteeKicked({
     const slashOffsetInRounds = await slashingProposer.getSlashOffsetInRounds();
     const slashingRoundSizeInEpochs = slashingRoundSize / aztecEpochDuration;
     const slashingOffsetInEpochs = Number(slashOffsetInRounds) * slashingRoundSizeInEpochs;
-    const targetEpoch = offenseEpoch + slashingOffsetInEpochs;
+    const firstEpochInOffenseRound = offenseEpoch - (offenseEpoch % slashingRoundSizeInEpochs);
+    const targetEpoch = firstEpochInOffenseRound + slashingOffsetInEpochs;
     logger.info(`Advancing to epoch ${targetEpoch} so we start slashing`);
-    await cheatCodes.advanceToEpoch(targetEpoch);
+    await cheatCodes.advanceToEpoch(targetEpoch, { offset: -aztecSlotDuration / 2 });
   }
 
   const attestersPre = await rollup.getAttesters();


### PR DESCRIPTION
When warping ahead to the epoch in which we vote to slash the target offenses, if the offenses happened on an epoch near the end of their respective round, we would be jumping ahead to the end of the respective voting round, so we would not collect the votes needed.
