### PR TITLE
chore: split non-native multiplication and range constraint tests in ultra circuit builder

### DIFF
--- a/barretenberg/cpp/src/barretenberg/circuit_checker/ultra_circuit_builder.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/circuit_checker/ultra_circuit_builder.test.cpp
@@ -649,17 +649,9 @@ TEST(UltraCircuitBuilder, NonNativeFieldMultiplication)
 
         const auto [lo_1_idx, hi_1_idx] = helper_non_native_multiplication(builder, a, b, q, r, modulus);
 
-        // Range check the carry (output) lo and hi limbs
-        const bool is_low_70_bits = uint256_t(builder.get_variable(lo_1_idx)).get_msb() < 70;
-        const bool is_high_70_bits = uint256_t(builder.get_variable(hi_1_idx)).get_msb() < 70;
-        if (is_low_70_bits && is_high_70_bits) {
-            // Uses more efficient NNF range check if both limbs are < 2^70
-            builder.range_constrain_two_limbs(lo_1_idx, hi_1_idx, 70, 70);
-        } else {
-            // Fallback to default range checks
-            builder.decompose_into_default_range(lo_1_idx, 72);
-            builder.decompose_into_default_range(hi_1_idx, 72);
-        }
+        // Check if the lo and hi carry outputs are "small": lo, hi < 2^72
+        EXPECT_LT(uint256_t(builder.get_variable(lo_1_idx)).get_msb(), 72);
+        ASSERT_LT(uint256_t(builder.get_variable(hi_1_idx)).get_msb(), 72);
 
         bool result = CircuitChecker::check(builder);
         EXPECT_EQ(result, true);
@@ -695,21 +687,13 @@ TEST(UltraCircuitBuilder, NonNativeFieldMultiplicationRegression)
     const auto [lo_1_idx, hi_1_idx] =
         helper_non_native_multiplication(builder, a_u256, b_u256, q_u256, r_u256, modulus);
 
-    // Range check the carry (output) lo and hi limbs
-    const bool is_high_70_bits = uint256_t(builder.get_variable(hi_1_idx)).get_msb() < 70;
-    ASSERT(is_high_70_bits == false); // Regression should hit this case
+    // Range check the carry (output) lo and hi limbs (2^70 <= hi < 2^72, lo < 2^72)
+    EXPECT_EQ(uint256_t(builder.get_variable(hi_1_idx)).get_msb(), 70);
+    EXPECT_LT(uint256_t(builder.get_variable(hi_1_idx)).get_msb(), 72);
+    EXPECT_LT(uint256_t(builder.get_variable(lo_1_idx)).get_msb(), 72);
 
-    // Decompose into default range: these should work even if the limbs are > 2^70
-    builder.decompose_into_default_range(lo_1_idx, 72);
-    builder.decompose_into_default_range(hi_1_idx, 72);
     bool result_a = CircuitChecker::check(builder);
     EXPECT_EQ(result_a, true);
-
-    // Using NNF range check should fail here
-    builder.range_constrain_two_limbs(lo_1_idx, hi_1_idx, 70, 70);
-    bool result_b = CircuitChecker::check(builder);
-    EXPECT_EQ(result_b, false);
-    EXPECT_EQ(builder.err(), "range_constrain_two_limbs: hi limb.");
 }
 
 /**
@@ -736,17 +720,9 @@ TEST(UltraCircuitBuilder, NonNativeFieldMultiplicationSortCheck)
 
     const auto [lo_1_idx, hi_1_idx] = helper_non_native_multiplication(builder, a, b, q, r, modulus);
 
-    // Range check the carry (output) lo and hi limbs
-    const bool is_low_70_bits = uint256_t(builder.get_variable(lo_1_idx)).get_msb() < 70;
-    const bool is_high_70_bits = uint256_t(builder.get_variable(hi_1_idx)).get_msb() < 70;
-    if (is_low_70_bits && is_high_70_bits) {
-        // Uses more efficient NNF range check if both limbs are < 2^70
-        builder.range_constrain_two_limbs(lo_1_idx, hi_1_idx, 70, 70);
-    } else {
-        // Fallback to default range checks
-        builder.decompose_into_default_range(lo_1_idx, 72);
-        builder.decompose_into_default_range(hi_1_idx, 72);
-    }
+    // Check if the lo and hi carry outputs are "small": lo, hi < 2^72
+    EXPECT_LT(uint256_t(builder.get_variable(lo_1_idx)).get_msb(), 72);
+    ASSERT_LT(uint256_t(builder.get_variable(hi_1_idx)).get_msb(), 72);
 
     bool result = CircuitChecker::check(builder);
     EXPECT_EQ(result, true);
@@ -760,6 +736,86 @@ TEST(UltraCircuitBuilder, NonNativeFieldMultiplicationSortCheck)
         EXPECT_EQ(builder.blocks.nnf.q_lookup_type()[i], 0);
         EXPECT_EQ(builder.blocks.nnf.q_poseidon2_external()[i], 0);
         EXPECT_EQ(builder.blocks.nnf.q_poseidon2_internal()[i], 0);
+    }
+}
+
+TEST(UltraCircuitBuilder, RangeConstraintTwoLimbs)
+{
+    // Create a lambda function that generates a random fr element within a given bit size
+    auto random_fr_within_bits = [](size_t num_bits) {
+        uint256_t mask = (uint256_t(1) << num_bits) - 1;
+        return fr(uint256_t(fr::random_element()) & mask);
+    };
+
+    UltraCircuitBuilder builder = UltraCircuitBuilder();
+
+    // Create two variables that fit within 70 bits
+    auto a_idx = builder.add_variable(random_fr_within_bits(70));
+    auto b_idx = builder.add_variable(random_fr_within_bits(70));
+    builder.range_constrain_two_limbs(a_idx, b_idx, 70, 70);
+
+    // Create two variables that fit in 68 bits (default range)
+    auto c_idx = builder.add_variable(random_fr_within_bits(68));
+    auto d_idx = builder.add_variable(random_fr_within_bits(68));
+    builder.range_constrain_two_limbs(c_idx, d_idx);
+
+    // Create two variables that fit in 68 and 70 bits respectively
+    auto e_idx = builder.add_variable(random_fr_within_bits(68));
+    auto f_idx = builder.add_variable(random_fr_within_bits(70));
+    builder.range_constrain_two_limbs(e_idx, f_idx, 68, 70);
+
+    bool result = CircuitChecker::check(builder);
+    EXPECT_EQ(result, true);
+}
+
+TEST(UltraCircuitBuilder, RangeConstraintTwoLimbsFails)
+{
+    // Create a lambda function that generates a random fr element within a given bit size
+    auto random_fr_within_bits = [](size_t num_bits) {
+        uint256_t mask = (uint256_t(1) << num_bits) - 1;
+        return fr(uint256_t(fr::random_element()) & mask);
+    };
+
+    {
+        // Both limbs exceed the specified bit sizes
+        UltraCircuitBuilder builder = UltraCircuitBuilder();
+
+        uint256_t a_value = uint256_t(random_fr_within_bits(71));
+        a_value |= (uint256_t(1) << 70); // set the 71st bit to ensure it exceeds 70 bits
+        auto a_idx = builder.add_variable(fr(a_value));
+        uint256_t b_value = uint256_t(random_fr_within_bits(71));
+        b_value |= (uint256_t(1) << 70); // set the 71st bit to ensure it exceeds 70 bits
+        auto b_idx = builder.add_variable(fr(b_value));
+
+        builder.range_constrain_two_limbs(a_idx, b_idx, 70, 70, "range check failed");
+
+        bool result = CircuitChecker::check(builder);
+        EXPECT_EQ(result, false);
+        EXPECT_EQ(builder.err(), "range check failed: lo limb."); // lo limb fails first
+    }
+    {
+        // Second limb exceeds the specified bit size
+        UltraCircuitBuilder builder = UltraCircuitBuilder();
+        auto a_idx = builder.add_variable(random_fr_within_bits(70));
+
+        uint256_t b_value = uint256_t(random_fr_within_bits(71));
+        b_value |= (uint256_t(1) << 70); // set the 71st bit to ensure it exceeds 70 bits
+        auto b_idx = builder.add_variable(fr(b_value));
+
+        builder.range_constrain_two_limbs(a_idx, b_idx, 70, 70, "range check failed");
+
+        bool result = CircuitChecker::check(builder);
+        EXPECT_EQ(result, false);
+        EXPECT_EQ(builder.err(), "range check failed: hi limb."); // hi limb fails
+    }
+    {
+        // Bit sizes more than 70 are not allowed
+#ifndef NDEBUG
+        UltraCircuitBuilder builder = UltraCircuitBuilder();
+        auto a_idx = builder.add_variable(random_fr_within_bits(70));
+        auto b_idx = builder.add_variable(random_fr_within_bits(70));
+        EXPECT_THROW_OR_ABORT(builder.range_constrain_two_limbs(a_idx, b_idx, 71, 70), "lo bits > 70 not allowed");
+#endif
     }
 }
 

--- a/barretenberg/cpp/src/barretenberg/circuit_checker/ultra_circuit_builder.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/circuit_checker/ultra_circuit_builder.test.cpp
@@ -658,6 +658,56 @@ TEST(UltraCircuitBuilder, NonNativeFieldMultiplication)
     }
 }
 
+TEST(UltraCircuitBuilder, NonNativeFieldMultiplicationFails)
+{
+    UltraCircuitBuilder builder = UltraCircuitBuilder();
+
+    fq a = fq::random_element();
+    fq b = fq::random_element();
+    uint256_t modulus = fq::modulus;
+
+    uint1024_t a_big = uint512_t(uint256_t(a));
+    uint1024_t b_big = uint512_t(uint256_t(b));
+    uint1024_t p_big = uint512_t(uint256_t(modulus));
+
+    uint1024_t q_big = (a_big * b_big) / p_big;
+    uint1024_t r_big = (a_big * b_big) % p_big;
+
+    uint256_t q(q_big.lo.lo);
+    uint256_t r(r_big.lo.lo);
+
+    // Intentionally corrupt q and r
+    q += 1;
+    r += 1;
+
+    const auto [lo_1_idx, hi_1_idx] = helper_non_native_multiplication(builder, a, b, q, r, modulus);
+
+    // Check if the lo and hi carry outputs are "large" because q and r are corrupted: lo, hi >= 2^72
+    EXPECT_GE(uint256_t(builder.get_variable(lo_1_idx)).get_msb(), 72);
+    ASSERT_GE(uint256_t(builder.get_variable(hi_1_idx)).get_msb(), 72);
+
+    // The circuit does not fail here because the non-native multiplication gadget does not enforce correctness of the
+    // relation:
+    //
+    // Eq (1): a * b = q * p + r (mod 2^272).
+    //
+    // It only computes the expression:
+    //
+    // Eq (2): a * b - q * p - r = LO + HI * 2^136 (mod 2^272)
+    //
+    // and returns lo := (LO / 2^136) and hi := (HI / 2^136). If indeed equation (1) holds, then the carries lo and hi
+    // will be small (< 2^72). See the README in bigfield for more details.
+    bool result = CircuitChecker::check(builder);
+    EXPECT_EQ(result, true);
+
+    // Hence, when we try to range-constrain the carries lo and hi to be small, the circuit should fail.
+    builder.range_constrain_two_limbs(lo_1_idx, hi_1_idx, 70, 70, "range check on carries");
+
+    result = CircuitChecker::check(builder);
+    EXPECT_EQ(result, false);
+    EXPECT_EQ(builder.err(), "range check on carries: lo limb.");
+}
+
 TEST(UltraCircuitBuilder, NonNativeFieldMultiplicationRegression)
 {
     UltraCircuitBuilder builder = UltraCircuitBuilder();

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.cpp
@@ -1629,8 +1629,8 @@ void UltraCircuitBuilder_<ExecutionTrace>::range_constrain_two_limbs(const uint3
 {
     // Validate limbs are <= 70 bits. If limbs are larger we require more witnesses and cannot use our limb accumulation
     // custom gate
-    BB_ASSERT_LTE(lo_limb_bits, 14U * 5U);
-    BB_ASSERT_LTE(hi_limb_bits, 14U * 5U);
+    BB_ASSERT_LTE(lo_limb_bits, 14U * 5U, "lo bits > 70 not allowed");
+    BB_ASSERT_LTE(hi_limb_bits, 14U * 5U, "hi bits > 70 not allowed");
 
     // If the value is larger than the range, we log the error in builder
     const bool is_lo_out_of_range = (uint256_t(this->get_variable_reference(lo_idx)) >= (uint256_t(1) << lo_limb_bits));


### PR DESCRIPTION
The function [`evaluate_non_native_field_multiplication`](https://github.com/AztecProtocol/aztec-packages/blob/72f52e7bad0fc1e36da575fbc2e6bfa1b1104aec/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.cpp#L1753) is currently being [tested](https://github.com/AztecProtocol/aztec-packages/blob/72f52e7bad0fc1e36da575fbc2e6bfa1b1104aec/barretenberg/cpp/src/barretenberg/circuit_checker/ultra_circuit_builder.test.cpp#L630-L667) by checking range constraints on its outputs. This PR does the following:

1. Instead of circuit range-checks, we natively check if the carry outputs from `evaluate_non_native_field_multiplication` are less than $2^{72}$. This is done so that we don't have to conditionally use different circuit-range-checks based on bit size. Further, this reduces the scope of the test to only the `evaluate_non_native_field_multiplication` function in circuit.
2. Added a failure test for `evaluate_non_native_field_multiplication` where the carries blow up if the inputs do not obey the expression $(a \cdot b) = (q \cdot p) + r \textsf{ mod } 2^{272}$. Note that the circuit does not fail on `evaluate_non_native_field_multiplication` itself, it fails only when we try to range check the carry outputs from the function.
3. Added standalone success and failure tests for the function [`range_constrain_two_limbs`](https://github.com/AztecProtocol/aztec-packages/blob/72f52e7bad0fc1e36da575fbc2e6bfa1b1104aec/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.cpp#L1624-L1628) that uses custom gates (as a part of the NNF (non-native-field) block).
