### PR TITLE
fix(docs): removes references to `getInitialTestAccountsWallets`

### DIFF
--- a/yarn-project/accounts/src/testing/index.ts
+++ b/yarn-project/accounts/src/testing/index.ts
@@ -1,8 +1,6 @@
 /**
  * The `@aztec/accounts/testing` export provides utility methods for testing, in particular in a Sandbox environment.
  *
- * Use {@link getInitialTestAccountsWallets} to obtain a list of wallets for the Sandbox pre-seeded accounts.
- *
  * @packageDocumentation
  */
 import { Fr } from '@aztec/aztec.js';

--- a/yarn-project/accounts/src/testing/lazy.ts
+++ b/yarn-project/accounts/src/testing/lazy.ts
@@ -1,8 +1,6 @@
 /**
  * The `@aztec/accounts/testing/lazy` export provides utility methods for testing, in particular in a Sandbox environment.
  *
- * Use {@link getInitialTestAccountsWallets} to obtain a list of wallets for the Sandbox pre-seeded accounts.
- *
  * @packageDocumentation
  */
 import { Fr } from '@aztec/aztec.js';


### PR DESCRIPTION
This removes this deprecated reference in the docs/ directory, for new releases

Leaving the `2.0.2` versioned docs unchanged as it exists in that version

This has been tested with the latest nightlies on m1 mac & yarn 4.9 / node 24