### PR TITLE
refactor: TestWallet API cleanup pt. 1

### DIFF
--- a/docs/docs/developers/reference/environment_reference/cli_reference.md
+++ b/docs/docs/developers/reference/environment_reference/cli_reference.md
@@ -590,24 +590,6 @@ Options:
 - `--sponsored-fpc`: Populate genesis state with a testing sponsored FPC contract
 - `--accelerated-test-deployments`: Fire and forget deployment transactions, use in testing only (default: false)
 
-### deploy-l1-verifier
-
-Deploys the rollup verifier contract.
-
-```bash
-aztec deploy-l1-verifier [options]
-```
-
-Options:
-
-- `--l1-rpc-urls <string>`: List of Ethereum host URLs. Chain identifiers localhost and testnet can be used (comma separated) (default: ["http://host.docker.internal:8545"], env: ETHEREUM_HOSTS)
-- `-c, --l1-chain-id <number>`: Chain ID of the ethereum host (default: 31337, env: L1_CHAIN_ID)
-- `-u, --rpc-url <string>`: URL of the PXE (default: "http://host.docker.internal:8080", env: PXE_URL)
-- `--rollup-address <string>`: The address of the rollup contract (env: ROLLUP_CONTRACT_ADDRESS)
-- `--l1-private-key <string>`: The L1 private key to use for deployment
-- `-m, --mnemonic <string>`: The mnemonic to use in deployment (default: "test test test test test test test test test test test junk")
-- `--verifier <verifier>`: Either mock or real (default: "real")
-
 ### deploy-new-rollup
 
 Deploys a new rollup contract and adds it to the registry (if you are the owner).
@@ -817,7 +799,7 @@ Options:
 - `-ca, --contract-address <address>`: Aztec address of the contract.
 - `--message-hash <messageHash>`: The L1 to L2 message hash.
 - `--secret <secret>`: The secret used to claim the L1 to L2 message
-- `-u, --rpc-url <string>`: URL of the PXE (default: "http://host.docker.internal:8080", env: PXE_URL)
+- `-n, --node-url <string>`: URL of Aztec Node (default: "http://host.docker.internal:8080", env: AZTEC_NODE_URL)
 
 ## P2P Network Commands
 
@@ -893,11 +875,9 @@ aztec setup-protocol-contracts [options]
 
 Options:
 
-- `-u, --rpc-url <string>`: URL of the PXE (default: "http://host.docker.internal:8080", env: PXE_URL)
+- `-n, --node-url <string>`: URL of Aztec Node (default: "http://host.docker.internal:8080", env: AZTEC_NODE_URL)
 - `--testAccounts`: Deploy funded test accounts.
-- `--sponsoredFPC`: Deploy a sponsored FPC.
 - `--json`: Output the contract addresses in JSON format
-- `--skipProofWait`: Don't wait for proofs to land.
 
 ### sequencers
 
@@ -917,7 +897,7 @@ Options:
 - `--l1-rpc-urls <string>`: List of Ethereum host URLs. Chain identifiers localhost and testnet can be used (comma separated) (default: ["http://host.docker.internal:8545"])
 - `-m, --mnemonic <string>`: The mnemonic for the sender of the tx (default: "test test test test test test test test test test test junk")
 - `--block-number <number>`: Block number to query next sequencer for
-- `-u, --rpc-url <string>`: URL of the PXE (default: "http://host.docker.internal:8080", env: PXE_URL)
+- `-n, --node-url <string>`: URL of Aztec Node (default: "http://host.docker.internal:8080", env: AZTEC_NODE_URL)
 - `-c, --l1-chain-id <number>`: Chain ID of the ethereum host (default: 31337, env: L1_CHAIN_ID)
 
 ### preload-crs

--- a/docs/docs/developers/reference/environment_reference/cli_wallet_reference.md
+++ b/docs/docs/developers/reference/environment_reference/cli_wallet_reference.md
@@ -208,7 +208,7 @@ Generates a secret key and deploys an account contract. Uses a Schnorr single-ke
 - `--skip-initialization`: Skip initializing the account contract. Useful for publicly deploying an existing account.
 - `--public-deploy`: Publishes the account contract instance (and the class, if needed). Needed if the contract contains public functions.
 - `-p, --public-key <string>`: Public key that identifies a private signing key stored outside of the wallet. Used for ECDSA SSH accounts over the secp256r1 curve.
-- `-n, --node-url <string>`: URL of the PXE (default: "http://host.docker.internal:8080")
+- `-n, --node-url <string>`: URL of Aztec Node (default: "http://host.docker.internal:8080")
 - `-sk, --secret-key <string>`: Secret key for account. Uses random by default. (env: `SECRET_KEY`)
 - `-a, --alias <string>`: Alias for the account. Used for easy reference in subsequent commands.
 - `-t, --type <string>`: Type of account to create (choices: "schnorr", "ecdsasecp256r1", "ecdsasecp256r1ssh", "ecdsasecp256k1", default: "schnorr")
@@ -247,7 +247,7 @@ aztec-wallet deploy-account [options]
 #### Options
 
 - `-f, --from <string>`: Alias or address of the account to deploy
-- `-n, --node-url <string>`: URL of the PXE (default: "http://host.docker.internal:8080", env: `AZTEC_NODE_URL`)
+- `-n, --node-url <string>`: URL of Aztec Node (default: "http://host.docker.internal:8080", env: `AZTEC_NODE_URL`)
 - `--json`: Emit output as json
 - `--no-wait`: Skip waiting for the contract to be deployed. Print the hash of deployment transaction
 - `--register-class`: Register the contract class (useful for when the contract class has not been deployed yet)
@@ -306,7 +306,7 @@ aztec-wallet deploy [options] [artifact]
 - `-k, --public-key <string>`: Optional encryption public key for this address. Set this value only if this contract is expected to receive private notes, which will be encrypted using this public key
 - `-s, --salt <hex string>`: Optional deployment salt as a hex string for generating the deployment address
 - `--universal`: Do not mix the sender address into the deployment
-- `-n, --node-url <string>`: URL of the PXE (default: "http://host.docker.internal:8080", env: `AZTEC_NODE_URL`)
+- `-n, --node-url <string>`: URL of Aztec Node (default: "http://host.docker.internal:8080", env: `AZTEC_NODE_URL`)
 - `--args [args...]`: Constructor arguments (default: [])
 - `-sk, --secret-key <string>`: The sender's secret key (env: `SECRET_KEY`)
 - `-f, --from <string>`: Alias or address of the account to deploy from
@@ -358,7 +358,7 @@ aztec-wallet register-contract [options] [address] [artifact]
 - `-s, --salt <hex string>`: Optional deployment salt as a hex string for generating the deployment address
   Sends a transaction by calling a function on an Aztec contract.
 - `--args [args...]`: Constructor arguments (default: [])
-- `-n, --node-url <string>`: URL of the PXE (default: "http://host.docker.internal:8080", env: `AZTEC_NODE_URL`)
+- `-n, --node-url <string>`: URL of Aztec Node (default: "http://host.docker.internal:8080", env: `AZTEC_NODE_URL`)
 - `-f, --from <string>`: Alias or address of the account to simulate from
 - `-a, --alias <string>`: Alias for the contact. Used for easy reference in subsequent commands
 
@@ -382,7 +382,7 @@ aztec-wallet send [options] <functionName>
 
 #### Options
 
-- `-n, --node-url <string>`: URL of the PXE (default: "http://host.docker.internal:8080", env: `AZTEC_NODE_URL`)
+- `-n, --node-url <string>`: URL of Aztec Node (default: "http://host.docker.internal:8080", env: `AZTEC_NODE_URL`)
 - `--args [args...]`: Function arguments (default: [])
 - `-c, --contract-artifact <fileLocation>`: Path to a compiled Aztec contract's artifact in JSON format. If executed inside a nargo workspace, a package and contract name can be specified as package@contract
 - `-ca, --contract-address <address>`: Aztec address of the contract
@@ -435,7 +435,7 @@ aztec-wallet simulate [options] <functionName>
 
 #### Options
 
-- `-n, --node-url <string>`: URL of the PXE (default: "http://host.docker.internal:8080", env: `AZTEC_NODE_URL`)
+- `-n, --node-url <string>`: URL of Aztec Node (default: "http://host.docker.internal:8080", env: `AZTEC_NODE_URL`)
 - `--args [args...]`: Function arguments (default: [])
 - `-ca, --contract-address <address>`: Aztec address of the contract
 - `-c, --contract-artifact <fileLocation>`: Path to a compiled Aztec contract's artifact in JSON format. If executed inside a nargo workspace, a package and contract name can be specified as package@contract
@@ -463,7 +463,7 @@ aztec-wallet profile [options] <functionName>
 
 #### Options
 
-- `-n, --node-url <string>`: URL of the PXE (default: "http://host.docker.internal:8080", env: `AZTEC_NODE_URL`)
+- `-n, --node-url <string>`: URL of Aztec Node (default: "http://host.docker.internal:8080", env: `AZTEC_NODE_URL`)
 - `--args [args...]`: Function arguments (default: [])
 - `-ca, --contract-address <address>`: Aztec address of the contract
 - `-c, --contract-artifact <fileLocation>`: Path to a compiled Aztec contract's artifact in JSON format. If executed inside a nargo workspace, a package and contract name can be specified as package@contract
@@ -493,7 +493,7 @@ aztec-wallet create-authwit [options] <functionName> <caller>
 
 #### Options
 
-- `-n, --node-url <string>`: URL of the PXE (default: "http://host.docker.internal:8080", env: `AZTEC_NODE_URL`)
+- `-n, --node-url <string>`: URL of Aztec Node (default: "http://host.docker.internal:8080", env: `AZTEC_NODE_URL`)
 - `--args [args...]`: Function arguments (default: [])
 - `-ca, --contract-address <address>`: Aztec address of the contract
 - `-c, --contract-artifact <fileLocation>`: Path to a compiled Aztec contract's artifact in JSON format. If executed inside a nargo workspace, a package and contract name can be specified as package@contract
@@ -530,7 +530,7 @@ aztec-wallet authorize-action [options] <functionName> <caller>
 
 #### Options
 
-- `-n, --node-url <string>`: URL of the PXE (default: "http://host.docker.internal:8080", env: `AZTEC_NODE_URL`)
+- `-n, --node-url <string>`: URL of Aztec Node (default: "http://host.docker.internal:8080", env: `AZTEC_NODE_URL`)
 - `--args [args...]`: Function arguments (default: [])
 - `-ca, --contract-address <address>`: Aztec address of the contract
 - `-c, --contract-artifact <fileLocation>`: Path to a compiled Aztec contract's artifact in JSON format. If executed inside a nargo workspace, a package and contract name can be specified as package@contract
@@ -570,7 +570,7 @@ aztec-wallet bridge-fee-juice [options] <amount> <recipient>
 - `-m, --mnemonic <string>`: The mnemonic to use for deriving the Ethereum address that will mint and bridge (default: "test test test test test test test test test test test junk")
 - `--mint`: Mint the tokens on L1 (default: false)
 - `--l1-private-key <string>`: The private key to the eth account bridging
-- `-n, --node-url <string>`: URL of the PXE (default: "http://host.docker.internal:8080", env: `AZTEC_NODE_URL`)
+- `-n, --node-url <string>`: URL of Aztec Node (default: "http://host.docker.internal:8080", env: `AZTEC_NODE_URL`)
 - `-c, --l1-chain-id <number>`: Chain ID of the ethereum host (default: 31337, env: `L1_CHAIN_ID`)
 - `--json`: Output the claim in JSON format
 - `--no-wait`: Wait for the bridged funds to be available in L2, polling every 60 seconds
@@ -598,7 +598,7 @@ aztec-wallet get-tx [options] [txHash]
 
 #### Options
 
-- `-n, --node-url <string>`: URL of the PXE (default: "http://host.docker.internal:8080", env: `AZTEC_NODE_URL`)
+- `-n, --node-url <string>`: URL of Aztec Node (default: "http://host.docker.internal:8080", env: `AZTEC_NODE_URL`)
 - `-p, --page <number>`: The page number to display (default: 1)
 - `-s, --page-size <number>`: The number of transactions to display per page (default: 10)
 
@@ -662,7 +662,7 @@ aztec-wallet register-sender [options] [address]
 
 #### Options
 
-- `-n, --node-url <string>`: URL of the PXE (default: "http://host.docker.internal:8080", env: `AZTEC_NODE_URL`)
+- `-n, --node-url <string>`: URL of Aztec Node (default: "http://host.docker.internal:8080", env: `AZTEC_NODE_URL`)
 - `-f, --from <string>`: Alias or address of the account to simulate from
 - `-a, --alias <string>`: Alias for the sender. Used for easy reference in subsequent commands
 

--- a/yarn-project/aztec.js/src/wallet/account_manager.ts
+++ b/yarn-project/aztec.js/src/wallet/account_manager.ts
@@ -142,7 +142,7 @@ export class AccountManager {
    * @returns A Wallet instance.
    */
   public async register(): Promise<AccountWithSecretKey> {
-    await this.pxe.registerContract({
+    await this.wallet.registerContract({
       artifact: await this.accountContract.getContractArtifact(),
       instance: this.getInstance(),
     });

--- a/yarn-project/cli-wallet/src/cmds/bridge_fee_juice.ts
+++ b/yarn-project/cli-wallet/src/cmds/bridge_fee_juice.ts
@@ -6,12 +6,9 @@ import type { LogFn, Logger } from '@aztec/foundation/log';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
 import { getNonNullifiedL1ToL2MessageWitness } from '@aztec/stdlib/messaging';
 
-import type { CLIWallet } from '../utils/wallet.js';
-
 export async function bridgeL1FeeJuice(
   amount: bigint,
   recipient: AztecAddress,
-  wallet: CLIWallet,
   node: AztecNode,
   l1RpcUrls: string[],
   chainId: number,
@@ -30,7 +27,7 @@ export async function bridgeL1FeeJuice(
 
   const {
     protocolContractAddresses: { feeJuice: feeJuiceAddress },
-  } = await wallet.getPXEInfo();
+  } = await node.getNodeInfo();
 
   // Setup portal manager
   const portal = await L1FeeJuicePortalManager.new(node, client, debugLogger);

--- a/yarn-project/cli-wallet/src/cmds/check_tx.ts
+++ b/yarn-project/cli-wallet/src/cmds/check_tx.ts
@@ -23,20 +23,14 @@ export async function checkTx(
     const receipt = await aztecNode.getTxReceipt(txHash);
     return receipt.status;
   } else {
-    await inspectTx(wallet, aztecNode, txHash, log, { includeBlockInfo: true });
+    await inspectTx(wallet, aztecNode, txHash, log);
   }
 }
 
 // The rest of the code here was copied over here from CLI because in CLI I needed to prune the inspect function of the PXE
 // dependency when dropping PXE JSON RPC Server.
 
-async function inspectTx(
-  wallet: CLIWallet,
-  aztecNode: AztecNode,
-  txHash: TxHash,
-  log: LogFn,
-  opts: { includeBlockInfo?: boolean; artifactMap?: ArtifactMap } = {},
-) {
+async function inspectTx(wallet: CLIWallet, aztecNode: AztecNode, txHash: TxHash, log: LogFn) {
   const [receipt, effectsInBlock] = await Promise.all([aztecNode.getTxReceipt(txHash), aztecNode.getTxEffect(txHash)]);
   // Base tx data
   log(`Tx ${txHash.toString()}`);
@@ -50,11 +44,9 @@ async function inspectTx(
   }
 
   const effects = effectsInBlock.data;
-  const artifactMap = opts?.artifactMap ?? (await getKnownArtifacts(wallet));
+  const artifactMap = await getKnownArtifacts(wallet);
 
-  if (opts.includeBlockInfo) {
-    log(` Block: ${receipt.blockNumber} (${receipt.blockHash?.toString()})`);
-  }
+  log(` Block: ${receipt.blockNumber} (${receipt.blockHash?.toString()})`);
   if (receipt.transactionFee) {
     log(` Fee: ${receipt.transactionFee.toString()}`);
   }

--- a/yarn-project/cli-wallet/src/cmds/index.ts
+++ b/yarn-project/cli-wallet/src/cmds/index.ts
@@ -444,14 +444,10 @@ export function injectCommands(
       const { bridgeL1FeeJuice } = await import('./bridge_fee_juice.js');
       const { l1ChainId, l1RpcUrls, l1PrivateKey, mnemonic, mint, json, wait, interval: intervalS } = options;
 
-      const wallet = walletAndNodeWrapper.wallet;
-      const node = walletAndNodeWrapper.node;
-
       const [secret, messageLeafIndex] = await bridgeL1FeeJuice(
         amount,
         recipient,
-        wallet,
-        node,
+        walletAndNodeWrapper.node,
         l1RpcUrls,
         l1ChainId,
         l1PrivateKey,

--- a/yarn-project/cli-wallet/src/utils/wallet.ts
+++ b/yarn-project/cli-wallet/src/utils/wallet.ts
@@ -22,7 +22,7 @@ import type { LogFn } from '@aztec/foundation/log';
 import type { PXEServiceConfig } from '@aztec/pxe/config';
 import { createPXEService, getPXEServiceConfig } from '@aztec/pxe/server';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
-import type { AztecNode, PXE, PXEInfo } from '@aztec/stdlib/interfaces/client';
+import type { AztecNode, PXE } from '@aztec/stdlib/interfaces/client';
 import { deriveSigningKey } from '@aztec/stdlib/keys';
 import type { NotesFilter } from '@aztec/stdlib/note';
 import type { TxExecutionRequest, TxProvingResult, TxSimulationResult } from '@aztec/stdlib/tx';
@@ -224,22 +224,15 @@ export class CLIWallet extends BaseWallet {
     return simulationResults;
   }
 
-  // Recently added when having the wallet instantiate PXE as PXE is now hidden. This forced me to expose this when
-  // refactoring `checkTx` cli-wallet command.
+  // Exposed because of the `aztec-wallet get-tx` command. It has been decided that it's fine to keep around because
+  // this is just a CLI wallet.
   getContracts(): Promise<AztecAddress[]> {
     return this.pxe.getContracts();
   }
 
-  // Recently added when having the wallet instantiate PXE as PXE is now hidden. This forced me to expose this when
-  // refactoring `checkTx` cli-wallet command.
+  // Exposed because of the `aztec-wallet get-tx` command. It has been decided that it's fine to keep around because
+  // this is just a CLI wallet.
   getNotes(filter: NotesFilter): Promise<UniqueNote[]> {
     return this.pxe.getNotes(filter);
-  }
-
-  // Recently added when having the wallet instantiate PXE as PXE is now hidden. This forced me to expose this when
-  // refactoring `bridge_fee_juice` cli-wallet command.
-  // TODO: This should most likely just be refactored to getProtocolContractAddresses.
-  getPXEInfo(): Promise<PXEInfo> {
-    return this.pxe.getPXEInfo();
   }
 }

--- a/yarn-project/end-to-end/src/composed/e2e_sandbox_example.test.ts
+++ b/yarn-project/end-to-end/src/composed/e2e_sandbox_example.test.ts
@@ -80,9 +80,6 @@ describe('e2e_sandbox_example', () => {
     const tokenContract = await deployToken(wallet, alice, initialSupply, logger);
     // docs:end:Deployment
 
-    // ensure that token contract is registered in PXE
-    expect(await wallet.getContracts()).toEqual(expect.arrayContaining([tokenContract.address]));
-
     // docs:start:Balance
 
     ////////////// QUERYING THE TOKEN BALANCE FOR EACH ACCOUNT //////////////

--- a/yarn-project/end-to-end/src/devnet/e2e_smoke.test.ts
+++ b/yarn-project/end-to-end/src/devnet/e2e_smoke.test.ts
@@ -88,18 +88,6 @@ describe('End-to-end tests for devnet', () => {
     });
     wallet = svc.wallet;
 
-    const nodeInfo = await node.getNodeInfo();
-    const pxeInfo = await wallet.getPXEInfo();
-
-    expect(nodeInfo.protocolContractAddresses.classRegistry).toEqual(pxeInfo.protocolContractAddresses.classRegistry);
-    expect(nodeInfo.protocolContractAddresses.instanceRegistry).toEqual(
-      pxeInfo.protocolContractAddresses.instanceRegistry,
-    );
-    expect(nodeInfo.protocolContractAddresses.feeJuice).toEqual(pxeInfo.protocolContractAddresses.feeJuice);
-    expect(nodeInfo.protocolContractAddresses.multiCallEntrypoint).toEqual(
-      pxeInfo.protocolContractAddresses.multiCallEntrypoint,
-    );
-
     teardown = async () => {
       await svc.teardown();
       await bbConfig?.cleanup();

--- a/yarn-project/pxe/src/pxe_service/pxe_service.ts
+++ b/yarn-project/pxe/src/pxe_service/pxe_service.ts
@@ -5,11 +5,7 @@ import { Timer } from '@aztec/foundation/timer';
 import { KeyStore } from '@aztec/key-store';
 import type { AztecAsyncKVStore } from '@aztec/kv-store';
 import { L2TipsKVStore } from '@aztec/kv-store/stores';
-import {
-  ProtocolContractAddress,
-  type ProtocolContractsProvider,
-  protocolContractNames,
-} from '@aztec/protocol-contracts';
+import { type ProtocolContractsProvider, protocolContractNames } from '@aztec/protocol-contracts';
 import type { CircuitSimulator } from '@aztec/simulator/client';
 import {
   type ContractArtifact,
@@ -32,13 +28,7 @@ import {
 } from '@aztec/stdlib/contract';
 import { SimulationError } from '@aztec/stdlib/errors';
 import { siloNullifier } from '@aztec/stdlib/hash';
-import type {
-  AztecNode,
-  EventMetadataDefinition,
-  PXE,
-  PXEInfo,
-  PrivateKernelProver,
-} from '@aztec/stdlib/interfaces/client';
+import type { AztecNode, EventMetadataDefinition, PXE, PrivateKernelProver } from '@aztec/stdlib/interfaces/client';
 import type {
   PrivateExecutionStep,
   PrivateKernelExecutionProofOutput,
@@ -65,7 +55,6 @@ import {
 import { inspect } from 'util';
 
 import type { PXEServiceConfig } from '../config/index.js';
-import { getPackageInfo } from '../config/package_info.js';
 import {
   ContractFunctionSimulator,
   generateSimulatedProvingResult,
@@ -105,7 +94,6 @@ export class PXEService implements PXE {
     private addressDataProvider: AddressDataProvider,
     private privateEventDataProvider: PrivateEventDataProvider,
     private simulator: CircuitSimulator,
-    private packageVersion: string,
     private proverEnabled: boolean,
     private proofCreator: PrivateKernelProver,
     private protocolContractsProvider: ProtocolContractsProvider,
@@ -134,7 +122,6 @@ export class PXEService implements PXE {
         ? createLogger(loggerOrSuffix ? `pxe:service:${loggerOrSuffix}` : `pxe:service`)
         : loggerOrSuffix;
 
-    const packageVersion = getPackageInfo().version;
     const proverEnabled = !!config.proverEnabled;
     const addressDataProvider = new AddressDataProvider(store);
     const privateEventDataProvider = new PrivateEventDataProvider(store);
@@ -169,7 +156,6 @@ export class PXEService implements PXE {
       addressDataProvider,
       privateEventDataProvider,
       simulator,
-      packageVersion,
       proverEnabled,
       proofCreator,
       protocolContractsProvider,
@@ -931,18 +917,6 @@ export class PXEService implements PXE {
           `scopes=${scopes?.map(s => s.toString()).join(', ') ?? 'undefined'}`,
         );
       }
-    });
-  }
-
-  public getPXEInfo(): Promise<PXEInfo> {
-    return Promise.resolve({
-      pxeVersion: this.packageVersion,
-      protocolContractAddresses: {
-        classRegistry: ProtocolContractAddress.ContractClassRegistry,
-        feeJuice: ProtocolContractAddress.FeeJuice,
-        instanceRegistry: ProtocolContractAddress.ContractInstanceRegistry,
-        multiCallEntrypoint: ProtocolContractAddress.MultiCallEntrypoint,
-      },
     });
   }
 

--- a/yarn-project/stdlib/src/interfaces/pxe.ts
+++ b/yarn-project/stdlib/src/interfaces/pxe.ts
@@ -11,7 +11,6 @@ import {
   type ContractClassWithId,
   type ContractInstanceWithAddress,
   type PartialAddress,
-  type ProtocolContractAddresses,
 } from '../contract/index.js';
 import { UniqueNote } from '../note/extended_note.js';
 import type { NotesFilter } from '../note/notes_filter.js';
@@ -188,11 +187,6 @@ export interface PXE {
   ): Promise<UtilitySimulationResult>;
 
   /**
-   * Returns information about this PXE.
-   */
-  getPXEInfo(): Promise<PXEInfo>;
-
-  /**
    * Returns the contract metadata given an address.
    * The metadata consists of its contract instance, which includes the contract class identifier,
    * initialization hash, deployment salt, and public keys hash; whether the contract instance has been initialized;
@@ -261,14 +255,6 @@ export const EventMetadataDefinitionSchema = z.object({
 export enum EventType {
   Encrypted = 'Encrypted',
   Unencrypted = 'Unencrypted',
-}
-
-/** Provides basic information about the running PXE. */
-export interface PXEInfo {
-  /** Version as tracked in the aztec-packages repository. */
-  pxeVersion: string;
-  /** Protocol contract addresses */
-  protocolContractAddresses: ProtocolContractAddresses;
 }
 
 export interface ContractMetadata {


### PR DESCRIPTION
Followup work of https://github.com/AztecProtocol/aztec-packages/pull/17228

In this PR I drop `getPXEInfo` and `getContracts` from `TestWallet` + add random docs improvements.

`getPXEInfo` was just a tech debt as it was only used to check if node has the same protocol contract addresses which is quite non-sensical because those addresses are no literally 1, 2, 3, 4, 5... I assume this check is there from time when they didn't have these hardcoded addresses.

`getContracts` was used just in one test and the check there was not really that important so I just dropped it.