### PR TITLE
feat(avm): Bulk test for bytecode/calldata hashing

### DIFF
--- a/noir-projects/noir-contracts/contracts/test/avm_test_contract/Nargo.toml
+++ b/noir-projects/noir-contracts/contracts/test/avm_test_contract/Nargo.toml
@@ -11,3 +11,5 @@ sha256 = { git = "https://github.com/noir-lang/sha256", tag = "v0.2.0" }
 keccak256 = { tag = "v0.1.0", git = "https://github.com/noir-lang/keccak256" }
 poseidon = { tag= "v0.1.1", git = "https://github.com/noir-lang/poseidon" }
 fee_juice = { path = "../../protocol/fee_juice_contract" }
+auth_contract = { path = "../../protocol/auth_registry_contract" }
+instance_contract = { path = "../../protocol/contract_instance_registry" }

--- a/noir-projects/noir-contracts/contracts/test/avm_test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/avm_test_contract/src/main.nr
@@ -29,6 +29,7 @@ pub contract AvmTest {
     };
     use dep::aztec::protocol_types::{
         constants::{
+            CANONICAL_AUTH_REGISTRY_ADDRESS, CONTRACT_INSTANCE_REGISTRY_CONTRACT_ADDRESS,
             FEE_JUICE_ADDRESS, GRUMPKIN_ONE_X, GRUMPKIN_ONE_Y,
             MAX_PUBLIC_CALLS_TO_UNIQUE_CONTRACT_CLASS_IDS,
         },
@@ -43,7 +44,9 @@ pub contract AvmTest {
     use aztec::protocol_types::traits::Serialize;
     use std::embedded_curve_ops::{EmbeddedCurvePoint, multi_scalar_mul};
 
+    use dep::auth_contract::AuthRegistry;
     use dep::fee_juice::FeeJuice;
+    use dep::instance_contract::ContractInstanceRegistry;
     use std::ops::Add;
 
     #[storage]
@@ -334,9 +337,16 @@ pub contract AvmTest {
     }
 
     #[public]
-    fn assert_calldata_copy(args: [Field; 3]) {
-        let offset = 0;
+    fn assert_calldata_copy(args: [Field; 3], with_selector: bool) {
+        let offset = with_selector as u32; // Skip the selector stored at i = 0 if used
         let cd: [Field; 3] = dep::aztec::context::public_context::calldata_copy(offset, 3);
+        assert(cd == args, "Calldata copy failed");
+    }
+
+    #[public]
+    fn assert_calldata_copy_large(args: [Field; 300], with_selector: bool) {
+        let offset = with_selector as u32; // Skip the selector stored at i = 0 if used
+        let cd: [Field; 300] = dep::aztec::context::public_context::calldata_copy(offset, 300);
         assert(cd == args, "Calldata copy failed");
     }
 
@@ -685,13 +695,27 @@ pub contract AvmTest {
     }
 
     /************************************************************************
-     * Protocol Contract Call
+     * Protocol Contract Calls
      ************************************************************************/
     #[public]
     fn call_fee_juice() {
         let _ = FeeJuice::at(FEE_JUICE_ADDRESS).balance_of_public(context.this_address()).view(
             &mut context,
         );
+    }
+
+    #[public]
+    fn call_auth_registry() {
+        let _ = AuthRegistry::at(CANONICAL_AUTH_REGISTRY_ADDRESS)
+            .is_reject_all(context.this_address())
+            .view(&mut context);
+    }
+
+    #[public]
+    fn call_instance_registry() {
+        let _ = ContractInstanceRegistry::at(CONTRACT_INSTANCE_REGISTRY_CONTRACT_ADDRESS)
+            .get_update_delay()
+            .view(&mut context);
     }
 
     /************************************************************************

--- a/yarn-project/simulator/src/public/avm/avm_simulator.test.ts
+++ b/yarn-project/simulator/src/public/avm/avm_simulator.test.ts
@@ -215,7 +215,7 @@ describe('AVM simulator: transpiled Noir contracts', () => {
   });
 
   it('Should handle calldata oracle', async () => {
-    const calldata: Fr[] = [new Fr(1), new Fr(2), new Fr(3)];
+    const calldata: Fr[] = [new Fr(1), new Fr(2), new Fr(3), /* with_selector: */ new Fr(0)];
     const context = initContext({ env: initExecutionEnvironment({ calldata }) });
 
     const bytecode = getAvmTestContractBytecode('assert_calldata_copy');

--- a/yarn-project/simulator/src/public/avm/fixtures/base_avm_simulation_tester.ts
+++ b/yarn-project/simulator/src/public/avm/fixtures/base_avm_simulation_tester.ts
@@ -2,7 +2,9 @@ import { CONTRACT_INSTANCE_REGISTRY_CONTRACT_ADDRESS } from '@aztec/constants';
 import { Fr } from '@aztec/foundation/fields';
 import { createLogger } from '@aztec/foundation/log';
 import { ProtocolContractAddress } from '@aztec/protocol-contracts';
+import { getCanonicalAuthRegistry } from '@aztec/protocol-contracts/auth-registry';
 import { computeFeePayerBalanceStorageSlot, getCanonicalFeeJuice } from '@aztec/protocol-contracts/fee-juice';
+import { getCanonicalInstanceRegistry } from '@aztec/protocol-contracts/instance-registry';
 import type { ContractArtifact } from '@aztec/stdlib/abi';
 import { PublicDataWrite } from '@aztec/stdlib/avm';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
@@ -86,6 +88,36 @@ export abstract class BaseAvmSimulationTester {
     };
     await this.contractDataSource.addNewContract(feeJuice.artifact, feeJuiceContractClassPublic, feeJuice.instance);
     return feeJuice.instance;
+  }
+
+  async registerAuthContract(): Promise<ContractInstanceWithAddress> {
+    const authRegistry = await getCanonicalAuthRegistry();
+    const authRegistryContractClassPublic = {
+      ...authRegistry.contractClass,
+      privateFunctions: [],
+      utilityFunctions: [],
+    };
+    await this.contractDataSource.addNewContract(
+      authRegistry.artifact,
+      authRegistryContractClassPublic,
+      authRegistry.instance,
+    );
+    return authRegistry.instance;
+  }
+
+  async registerInstanceRegistryContract(): Promise<ContractInstanceWithAddress> {
+    const instanceRegistry = await getCanonicalInstanceRegistry();
+    const instanceRegistryContractClassPublic = {
+      ...instanceRegistry.contractClass,
+      privateFunctions: [],
+      utilityFunctions: [],
+    };
+    await this.contractDataSource.addNewContract(
+      instanceRegistry.artifact,
+      instanceRegistryContractClassPublic,
+      instanceRegistry.instance,
+    );
+    return instanceRegistry.instance;
   }
 
   async addContractInstance(contractInstance: ContractInstanceWithAddress, skipNullifierInsertion = false) {

--- a/yarn-project/simulator/src/public/fixtures/bulk_test.ts
+++ b/yarn-project/simulator/src/public/fixtures/bulk_test.ts
@@ -22,6 +22,9 @@ export async function bulkTest(
 
   // Needed since we invoke the Fee Juice Contract in the bulk test.registerFeeJuiceContract
   await tester.registerFeeJuiceContract();
+  // Register multiple different protocol contracts (to ensure we don't dedup bytecode hashing events):
+  await tester.registerAuthContract();
+  await tester.registerInstanceRegistryContract();
 
   // Get a deployed contract instance to pass to the contract
   // for it to use as "expected" values when testing contract instance retrieval.
@@ -50,6 +53,26 @@ export async function bulkTest(
         fnName: 'bulk_testing',
         args,
       },
+      // 3 calls creating calldata + asserting calldata copy:
+      {
+        address: avmTestContract.address,
+        fnName: 'assert_calldata_copy_large',
+        args: [Array.from({ length: 300 }, () => Fr.random()), /* with_selector: */ true],
+      },
+      {
+        address: avmTestContract.address,
+        fnName: 'assert_calldata_copy',
+        args: [argsField.slice(3), /* with_selector: */ true],
+      },
+      {
+        address: avmTestContract.address,
+        fnName: 'assert_calldata_copy_large',
+        args: [Array.from({ length: 300 }, () => Fr.random()), /* with_selector: */ true],
+      },
+      // 3 calls to external contracts
+      { address: avmTestContract.address, fnName: 'call_fee_juice', args: [] },
+      { address: avmTestContract.address, fnName: 'call_auth_registry', args: [] },
+      { address: avmTestContract.address, fnName: 'call_instance_registry', args: [] },
     ],
     /*teardownCall=*/ undefined,
     /*feePayer*/ undefined,


### PR DESCRIPTION
## Hashing Bulk Test
Originally part of #17224, but I ~separated it out because the test is pretty long (and to help with reviewing!).~

UPDATE: No longer a separate test but included in separate enqueued calls in the main bulk test. This 'only' increases the time by about 10s. The below stats refer to the data hashing tests on their own!

I added ~a new bulk-style test with~ multiple enqueued calls performing calldata and bytecode hashing.

Key points:

- Performs 3x calldata hashes with reads
- Performs 3x protocol contract calls (=> 3x bytecode hashes)
- Currently takes ~20s (10s check_circuit only)

Since we dedupe hashing events, I added different protocol contracts to force the bytecodes to be unique.



### Metrics

```
INFO: avm-data-hashing-test # Public TX Simulation Metrics (ALL)

## TX Label: AvmTest/data_hashing_testing/0
- Total duration: `361.567 ms`
- Total mana used: `1,335,210`
- Mana per second: `3,692,838`
- Total instructions executed: `59,612`
- Private insertions:
    - Non-revertible: `5.148 ms`
    - Revertible: `0.672 ms`
- Proving:
    - Simulation (all): `375 ms`
    - Trace generation (all): `4,043 ms`
    - Trace generation interactions: `1,127 ms`
    - Trace generation traces: `2,896 ms`
- Enqueued public calls:
    - **Fn: AvmTest.assert_calldata_copy_large**
        - Duration: `155.984 ms`
        - Mana used: `612,309`
        - Mana per second: `3,925,472`
        - Instructions executed: `27,529`
    - **Fn: AvmTest.assert_calldata_copy**
        - Duration: `13.287 ms`
        - Mana used: `17,982`
        - Mana per second: `1,353,396`
        - Instructions executed: `808`
    - **Fn: AvmTest.assert_calldata_copy_large**
        - Duration: `97.561 ms`
        - Mana used: `612,309`
        - Mana per second: `6,276,144`
        - Instructions executed: `27,529`
    - **Fn: AvmTest.call_fee_juice**
        - Duration: `23.704 ms`
        - Mana used: `30,051`
        - Mana per second: `1,267,752`
        - Instructions executed: `1,217`
    - **Fn: AvmTest.call_auth_registry**
        - Duration: `20.407 ms`
        - Mana used: `30,762`
        - Mana per second: `1,507,427`
        - Instructions executed: `1,251`
    - **Fn: AvmTest.call_instance_registry**
        - Duration: `20.087 ms`
        - Mana used: `31,797`
        - Mana per second: `1,582,954`
        - Instructions executed: `1,278`
```

### Column Sizes
```
AvmCircuit (avm_prove) BB out - Column sizes per namespace: (mem: 2342.15 MiB)
  precomputed: 2097152 (~2^21) (mem: 2342.15 MiB)
  public: 4675 (~2^13) (mem: 2342.15 MiB)
  address_derivation: 4 (~2^2) (mem: 2342.15 MiB)
  alu: 5599 (~2^13) (mem: 2342.15 MiB)
  bc_decomposition: 75986 (~2^17) (mem: 2342.15 MiB)
  bc_hashing: 821 (~2^10) (mem: 2342.15 MiB)
  bc_retrieval: 10 (~2^4) (mem: 2342.15 MiB)
  bitwise: 0 (~2^0) (mem: 2342.15 MiB)
  calldata: 613 (~2^10) (mem: 2342.15 MiB)
[16:04:27.902] VERBOSE: avm-simulation-tester AvmCircuit (avm_prove) BB out - 
  class_id_derivation: 4 (~2^2) (mem: 2342.15 MiB)
  context: 3 (~2^2) (mem: 2342.15 MiB)
  contract_instance_retrieval: 10 (~2^4) (mem: 2342.15 MiB)
  data_copy: 1224 (~2^11) (mem: 2342.15 MiB)
  ecc: 1526 (~2^11) (mem: 2342.15 MiB)
  emit_unencrypted_log: 0 (~2^0) (mem: 2342.15 MiB)
  execution: 59613 (~2^16) (mem: 2342.15 MiB)
  ff_gt: 81 (~2^7) (mem: 2342.15 MiB)
  get_contract_instance: 0 (~2^0) (mem: 2342.15 MiB)
  gt: 61515 (~2^16) (mem: 2342.15 MiB)
  instr_fetching: 2258 (~2^12) (mem: 2342.15 MiB)
  internal_call: 1300 (~2^11) (mem: 2342.15 MiB)
  keccak_memory: 0 (~2^0) (mem: 2342.15 MiB)
  keccakf1600: 0 (~2^0) (mem: 2342.15 MiB)
  l1_to_l2_message_tree_check: 0 (~2^0) (mem: 2342.15 MiB)
  memory: 174131 (~2^18) (mem: 2342.15 MiB)
  merkle_check: 880 (~2^10) (mem: 2342.15 MiB)
  note_hash_tree_check: 0 (~2^0) (mem: 2342.15 MiB)
  nullifier_check: 7 (~2^3) (mem: 2342.15 MiB)
  poseidon2_hash: 2197 (~2^12) (mem: 2342.15 MiB)
  poseidon2_perm: 2199 (~2^12) (mem: 2342.15 MiB)
  protocol_contract: 3 (~2^2) (mem: 2342.15 MiB)
  public_data_check: 12 (~2^4) (mem: 2342.15 MiB)
  public_data_squash: 2 (~2^1) (mem: 2342.15 MiB)
  range_check: 63751 (~2^16) (mem: 2342.15 MiB)
  retrieved_bytecodes_tree_check: 18 (~2^5) (mem: 2342.15 MiB)
  scalar_mul: 1017 (~2^10) (mem: 2342.15 MiB)
  sha256: 0 (~2^0) (mem: 2342.15 MiB)
  to_radix: 1017 (~2^10) (mem: 2342.15 MiB)
  tx: 18 (~2^5) (mem: 2342.15 MiB)
  update_check: 6 (~2^3) (mem: 2342.15 MiB)
  written_public_data_slots_tree_check: 0 (~2^0) (mem: 2342.15 MiB)
  lookup: 75970 (~2^17) (mem: 2342.15 MiB)
  perm: 0 (~2^0) (mem: 2342.15 MiB)
Sum of all column rows: 30381356 (~2^25) (mem: 2342.15 MiB)
```
### `check_circuit` Timings
(`num threads: 16`)
```
Running check (with skippable) circuit over 196609 rows.
AvmCircuit (avm_check_circuit) BB out - proving/check_circuit_ms: 1449
proving/init_polys_to_be_shifted_ms: 31
proving/init_polys_unshifted_ms: 32
proving/prove:compute_polynomials_ms: 166
proving/set_polys_shifted_ms: 0
proving/set_polys_unshifted_ms: 102
simulation/all_ms: 371
tracegen/address_derivation_ms: 0
tracegen/all_ms: 4399
tracegen/alu_ms: 30
tracegen/bitwise_ms: 0
tracegen/bytecode_decomposition_ms: 2641
tracegen/bytecode_hashing_ms: 11
tracegen/bytecode_retrieval_ms: 0
tracegen/calldata_hashing_ms: 3
tracegen/calldata_retrieval_ms: 0
tracegen/class_id_derivation_ms: 0
tracegen/context_stack_ms: 0
tracegen/contract_instance_retrieval_ms: 0
tracegen/data_copy_ms: 23
tracegen/ecc_add_memory_ms: 0
tracegen/ecc_add_ms: 31
tracegen/emit_unencrypted_log_ms: 0
tracegen/execution_ms: 2595
tracegen/field_gt_ms: 0
tracegen/get_contract_instance_ms: 0
tracegen/gt_ms: 50
tracegen/instruction_fetching_ms: 18
tracegen/interactions_ms: 1686
tracegen/internal_call_stack_ms: 0
tracegen/keccak_f1600_memory_slices_ms: 0
tracegen/keccak_f1600_permutation_ms: 0
tracegen/l1_to_l2_message_tree_check_ms: 0
tracegen/memory_ms: 518
tracegen/merkle_check_ms: 21
tracegen/note_hash_tree_check_ms: 0
tracegen/nullifier_tree_check_ms: 0
tracegen/poseidon2_hash_ms: 17
tracegen/poseidon2_permutation_ms: 110
tracegen/poseidon2_permutation_with_memory_ms: 0
tracegen/protocol_contract_ms: 0
tracegen/public_data_tree_check_ms: 0
tracegen/range_check_ms: 176
tracegen/retrieved_bytecodes_tree_check_ms: 0
tracegen/scalar_mul_ms: 2
tracegen/sha256_compression_ms: 0
tracegen/to_radix_memory_ms: 0
tracegen/to_radix_ms: 37
tracegen/traces_ms: 2679
tracegen/tx_ms: 0
tracegen/update_check_ms: 0
tracegen/written_public_data_slots_tree_check_ms: 0
```