### PR TITLE
fix: orchestrator and agents retry more when connecting to the broker

### DIFF
--- a/yarn-project/aztec/src/cli/cmds/start_prover_agent.ts
+++ b/yarn-project/aztec/src/cli/cmds/start_prover_agent.ts
@@ -45,7 +45,12 @@ export async function startProverAgent(
 
   await preloadCrsDataForServerSideProving(config, userLog);
 
-  const fetch = makeTracedFetch([1, 2, 3], false, makeUndiciFetch(new Agent({ connections: 10 })));
+  const fetch = makeTracedFetch(
+    // retry connections every 3s, up to 30s before giving up
+    [1, 2, 3, 3, 3, 3, 3, 3, 3, 3, 3],
+    false,
+    makeUndiciFetch(new Agent({ connections: 10 })),
+  );
   const broker = createProvingJobBrokerClient(config.proverBrokerUrl, getVersions(), fetch);
 
   const telemetry = initTelemetryClient(extractRelevantOptions(options, telemetryClientConfigMappings, 'tel'));

--- a/yarn-project/aztec/src/cli/cmds/start_prover_node.ts
+++ b/yarn-project/aztec/src/cli/cmds/start_prover_node.ts
@@ -73,7 +73,12 @@ export async function startProverNode(
   if (proverConfig.proverBrokerUrl) {
     // at 1TPS we'd enqueue ~1k tube proofs and ~1k AVM proofs immediately
     // set a lower connection limit such that we don't overload the server
-    const fetch = makeTracedFetch([1, 2, 3], false, makeUndiciFetch(new Agent({ connections: 100 })));
+    // Keep retrying up to 30s
+    const fetch = makeTracedFetch(
+      [1, 2, 3, 3, 3, 3, 3, 3, 3, 3, 3],
+      false,
+      makeUndiciFetch(new Agent({ connections: 100 })),
+    );
     broker = createProvingJobBrokerClient(proverConfig.proverBrokerUrl, getVersions(proverConfig), fetch);
   } else if (options.proverBroker) {
     ({ broker } = await startProverBroker(options, signalHandlers, services, userLog));


### PR DESCRIPTION
This PR increases the number of retries the proving orchestrator and agents attempt before giving up on the broker. 

The previous behaviour would only retry three times, totalling 6 seconds. From logs in GCP it looks like it takes Kubernetes approx 20 seconds to register the pod with its service after the pod becomes ready. The new behaviour retries up to 30 seconds.

Fix A-86