### PR TITLE
chore(avm): tune commitment batch size

### DIFF
--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/commitment_key.hpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/commitment_key.hpp
@@ -123,7 +123,6 @@ template <class Curve> class CommitmentKey {
         // First batch, create the commitments vector
         std::vector<Commitment> commitments;
 
-        max_batch_size = 1;
         for (size_t i = 0; i < polynomials.size();) {
             // Note: have to be careful how we compute this to not overlow e.g. max_batch_size + 1 would
             size_t batch_size = std::min(max_batch_size, polynomials.size() - i);

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/prover.cpp
@@ -1,5 +1,7 @@
 #include "barretenberg/vm2/constraining/prover.hpp"
 
+#include <cstdlib>
+
 #include "barretenberg/commitment_schemes/claim.hpp"
 #include "barretenberg/commitment_schemes/commitment_key.hpp"
 #include "barretenberg/commitment_schemes/shplonk/shplemini.hpp"
@@ -12,15 +14,12 @@
 #include "barretenberg/vm2/common/constants.hpp"
 #include "barretenberg/vm2/constraining/polynomials.hpp"
 #include "barretenberg/vm2/tooling/stats.hpp"
-#include <cstdlib>
 
 namespace bb::avm2 {
 
-// TODO(AD): @facundo - tune this value
-// The number of polynomials to compute MSMs for at once. it could be computed heuristically based on a max memory size
-// (maybe that would be the env var?)
+// Maximum number of polynomials to batch commit at once.
 const size_t AVM_MAX_MSM_BATCH_SIZE =
-    getenv("AVM_MAX_MSM_BATCH_SIZE") != nullptr ? std::stoul(getenv("AVM_MAX_MSM_BATCH_SIZE")) : 4;
+    getenv("AVM_MAX_MSM_BATCH_SIZE") != nullptr ? std::stoul(getenv("AVM_MAX_MSM_BATCH_SIZE")) : 32;
 
 using Flavor = AvmFlavor;
 using FF = Flavor::FF;


### PR DESCRIPTION
Enable and tune @ludamad 's batching.

```
NO BATCHING (unlimited cores, sorry)

(mem: 3747.37 MiB)
prove/log_derivative_inverse_commitments_round_ms: 2448
prove/log_derivative_inverse_round_ms: 509
prove/pcs_rounds_ms: 4006
prove/sumcheck_ms: 7051
prove/wire_commitments_round_ms: 8218

-----

BATCHING=32 (unlimited cores, sorry)

(mem: 3734.21 MiB)
prove/log_derivative_inverse_commitments_round_ms: 1631
prove/log_derivative_inverse_round_ms: 472
prove/pcs_rounds_ms: 3466
prove/sumcheck_ms: 6748
prove/wire_commitments_round_ms: 6111
```

Closes #17260.