### PR TITLE
feat(docs): add docs example dir and use include code to update current tutorials 

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -29,3 +29,5 @@ yarn-error.log*
 test-results
 
 !CLAUDE.md
+
+target

--- a/docs/Nargo.toml
+++ b/docs/Nargo.toml
@@ -1,0 +1,5 @@
+[workspace]
+members = [
+    "examples/tutorials/counter_contract",
+    "examples/tutorials/bob_token_contract"
+]

--- a/docs/bootstrap.sh
+++ b/docs/bootstrap.sh
@@ -3,6 +3,12 @@ source $(git rev-parse --show-toplevel)/ci3/source_bootstrap
 
 cmd=${1:-}
 
+export BB=${BB:-../barretenberg/cpp/build/bin/bb}
+export NARGO=${NARGO:-../noir/noir-repo/target/release/nargo}
+export TRANSPILER=${TRANSPILER:-../avm-transpiler/target/release/avm-transpiler}
+export BB_HASH=${BB_HASH:-$(../barretenberg/cpp/bootstrap.sh hash)}
+export NOIR_HASH=${NOIR_HASH:-$(../noir/bootstrap.sh hash)}
+
 # We search the docs/*.md files to find included code, and use those as our rebuild dependencies.
 # We prefix the results with ^ to make them "not a file", otherwise they'd be interpreted as pattern files.
 hash=$(
@@ -52,6 +58,7 @@ case "$cmd" in
     git clean -fdx
     ;;
   "ci")
+    DOCS_WORKING_DIR="$(pwd)" ../noir-projects/noir-contracts/bootstrap.sh compile --
     build_docs
     test
     ;;
@@ -60,6 +67,10 @@ case "$cmd" in
     ;;
   "hash")
     echo "$hash"
+    ;;
+  "compile")
+    shift
+    DOCS_WORKING_DIR="$(pwd)" ../noir-projects/noir-contracts/bootstrap.sh compile
     ;;
   test|test_cmds)
     $cmd

--- a/docs/docs/developers/docs/tutorials/contract_tutorials/counter_contract.md
+++ b/docs/docs/developers/docs/tutorials/contract_tutorials/counter_contract.md
@@ -50,7 +50,7 @@ easy_private_state = { git="https://github.com/AztecProtocol/aztec-packages/", t
 Go to `main.nr`, and replace the boilerplate code with this contract initialization:
 
 ```rust
-#include_code setup /noir-projects/noir-contracts/contracts/test/counter_contract/src/main.nr raw
+#include_code setup /docs/examples/tutorials/counter_contract/src/main.nr raw
 }
 ```
 
@@ -68,7 +68,7 @@ pub contract Counter {
 }
 ```
 
-#include_code imports /noir-projects/noir-contracts/contracts/test/counter_contract/src/main.nr rust
+#include_code imports /docs/examples/tutorials/counter_contract/src/main.nr rust
 
 - `use aztec::macros::{functions::{initializer, private, utility}, storage::storage},`
   Imports the macros needed to define function types (`initializer`, `private`, and `utility`) and the `storage` macro for declaring contract storage structures.
@@ -86,7 +86,7 @@ pub contract Counter {
 
 Add this below the imports. It declares the storage variables for our contract. We are going to store a mapping of values for each `AztecAddress`.
 
-#include_code storage_struct /noir-projects/noir-contracts/contracts/test/counter_contract/src/main.nr rust
+#include_code storage_struct /docs/examples/tutorials/counter_contract/src/main.nr rust
 
 ## Keep the counter private
 
@@ -94,7 +94,7 @@ Now we’ve got a mechanism for storing our private state, we can start using it
 
 Let’s create a constructor method to run on deployment that assigns an initial count to a specified owner. This function is called `initialize`, but behaves like a constructor. It is the `#[initializer]` decorator that specifies that this function behaves like a constructor. Write this:
 
-#include_code constructor /noir-projects/noir-contracts/contracts/test/counter_contract/src/main.nr rust
+#include_code constructor /docs/examples/tutorials/counter_contract/src/main.nr rust
 
 This function accesses the counts from storage. Then it assigns the passed initial counter to the `owner`'s counter privately using `at().add()`.
 
@@ -104,7 +104,7 @@ We have annotated this and other functions with `#[private]` which are ABI macro
 
 Now let’s implement the `increment` function we defined in the first step.
 
-#include_code increment /noir-projects/noir-contracts/contracts/test/counter_contract/src/main.nr rust
+#include_code increment /docs/examples/tutorials/counter_contract/src/main.nr rust
 
 The `increment` function works very similarly to the `constructor`, but instead directly adds 1 to the counter rather than passing in an initial count parameter.
 
@@ -112,7 +112,7 @@ The `increment` function works very similarly to the `constructor`, but instead 
 
 The last thing we need to implement is the function in order to retrieve a counter. In the `getCounter` we defined in the first step, write this:
 
-#include_code get_counter /noir-projects/noir-contracts/contracts/test/counter_contract/src/main.nr rust
+#include_code get_counter /docs/examples/tutorials/counter_contract/src/main.nr rust
 
 This is a `utility` function which is used to obtain the counter information outside of a transaction. We retrieve a reference to the `owner`'s `counter` from the `counters` Map. The `get_balance` function then operates on the owner's counter. This yields a private counter that only the private key owner can decrypt.
 

--- a/docs/examples/tutorials/bob_token_contract/Nargo.toml
+++ b/docs/examples/tutorials/bob_token_contract/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "bob_token_contract"
+type = "contract"
+
+[dependencies]
+aztec = { path = "../../../../noir-projects/aztec-nr/aztec" }
+easy_private_state = { path = "../../../../noir-projects/aztec-nr/easy-private-state" }

--- a/docs/examples/tutorials/bob_token_contract/src/main.nr
+++ b/docs/examples/tutorials/bob_token_contract/src/main.nr
@@ -1,0 +1,164 @@
+// docs:start:start
+use aztec::macros::aztec;
+
+// docs:start:imports
+#[aztec]
+pub contract BobToken {
+    // docs:end:start
+    use aztec::{
+        macros::{functions::{initializer, private, public, utility, internal}, storage::storage},
+        protocol_types::address::AztecAddress, state_vars::Map,
+        state_vars::public_mutable::PublicMutable,
+    };
+    // docs:end:imports
+
+    // docs:start:easy_private_uint
+    use easy_private_state::EasyPrivateUint;
+    // docs:end:easy_private_uint
+
+    // docs:start:public_storage
+    // docs:start:storage
+    #[storage]
+    struct Storage<Context> {
+        // Giggle's admin address
+        owner: PublicMutable<AztecAddress, Context>,
+        // Public balances - visible for transparency
+        public_balances: Map<AztecAddress, PublicMutable<u64, Context>, Context>,
+        // docs:end:public_storage
+        // Private balances - only the owner can see these
+        private_balances: Map<AztecAddress, EasyPrivateUint<Context>, Context>,
+    }
+    // docs:end:storage
+
+    // docs:start:setup
+    #[initializer]
+    #[public]
+    fn setup() {
+        // Giggle becomes the owner who can mint mental health tokens
+        storage.owner.write(context.msg_sender());
+    }
+    // docs:end:setup
+
+    // docs:start:mint_public
+    #[public]
+    fn mint_public(employee: AztecAddress, amount: u64) {
+        // Only Giggle can mint tokens
+        assert_eq(context.msg_sender(), storage.owner.read(), "Only Giggle can mint BOB tokens");
+
+        // Add tokens to employee's public balance
+        let current_balance = storage.public_balances.at(employee).read();
+        storage.public_balances.at(employee).write(current_balance + amount);
+    }
+    // docs:end:mint_public
+
+    // docs:start:transfer_public
+    #[public]
+    fn transfer_public(to: AztecAddress, amount: u64) {
+        let sender = context.msg_sender();
+        let sender_balance = storage.public_balances.at(sender).read();
+        assert(sender_balance >= amount, "Insufficient BOB tokens");
+
+        // Deduct from sender
+        storage.public_balances.at(sender).write(sender_balance - amount);
+
+        // Add to recipient
+        let recipient_balance = storage.public_balances.at(to).read();
+        storage.public_balances.at(to).write(recipient_balance + amount);
+    }
+    // docs:end:transfer_public
+
+    // docs:start:transfer_ownership
+    #[public]
+    fn transfer_ownership(new_owner: AztecAddress) {
+        assert_eq(context.msg_sender(), storage.owner.read(), "Only current admin can transfer ownership");
+        storage.owner.write(new_owner);
+    }
+    // docs:end:transfer_ownership
+
+    // docs:start:public_to_private
+    #[private]
+    fn public_to_private(amount: u64) {
+        let sender = context.msg_sender();
+        // This will enqueue a public function to deduct from public balance
+        BobToken::at(context.this_address())._deduct_public_balance(sender, amount).enqueue(&mut context);
+        // Add to private balance
+        storage.private_balances.at(sender).add(amount, sender);
+    }
+    // docs:end:public_to_private
+
+    // docs:start:_deduct_public_balance
+    #[public]
+    #[internal]
+    fn _deduct_public_balance(owner: AztecAddress, amount: u64) {
+        let balance = storage.public_balances.at(owner).read();
+        assert(balance >= amount, "Insufficient public BOB tokens");
+        storage.public_balances.at(owner).write(balance - amount);
+    }
+    // docs:end:_deduct_public_balance
+
+
+    // docs:start:transfer_private
+    #[private]
+    fn transfer_private(to: AztecAddress, amount: u64) {
+        let sender = context.msg_sender();
+        // Spend sender's notes (consumes existing notes)
+        storage.private_balances.at(sender).sub(amount, sender);
+        // Create new notes for recipient
+        storage.private_balances.at(to).add(amount, to);
+    }
+    // docs:end:transfer_private
+
+    // docs:start:check_balances
+    #[utility]
+    unconstrained fn private_balance_of(owner: AztecAddress) -> Field {
+        storage.private_balances.at(owner).get_value()
+    }
+
+    #[utility]
+    unconstrained fn public_balance_of(owner: AztecAddress) -> pub u64 {
+        storage.public_balances.at(owner).read()
+    }
+    // docs:end:check_balances
+
+    // docs:start:_assert_is_owner
+    #[public]
+    #[internal]
+    fn _assert_is_owner(address: AztecAddress) {
+        assert_eq(address, storage.owner.read(), "Only Giggle can mint BOB tokens");
+    }
+    // docs:end:_assert_is_owner
+
+    // docs:start:mint_private
+    #[private]
+    fn mint_private(employee: AztecAddress, amount: u64) {
+        // Enqueue ownership check (will revert if not Giggle)
+        BobToken::at(context.this_address())
+            ._assert_is_owner(context.msg_sender())
+            .enqueue(&mut context);
+
+        // If check passes, mint tokens privately
+        storage.private_balances.at(employee).add(amount, employee);
+    }
+    // docs:end:mint_private
+
+
+    // docs:start:private_to_public
+    #[private]
+    fn private_to_public(amount: u64) {
+        let sender = context.msg_sender();
+        // Remove from private balance
+        storage.private_balances.at(sender).sub(amount, sender);
+        // Enqueue public credit
+        BobToken::at(context.this_address())
+            ._credit_public_balance(sender, amount)
+            .enqueue(&mut context);
+    }
+
+    #[public]
+    #[internal]
+    fn _credit_public_balance(owner: AztecAddress, amount: u64) {
+        let balance = storage.public_balances.at(owner).read();
+        storage.public_balances.at(owner).write(balance + amount);
+    }
+    // docs:end:private_to_public
+}

--- a/docs/examples/tutorials/counter_contract/Nargo.toml
+++ b/docs/examples/tutorials/counter_contract/Nargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "counter_contract"
+authors = [""]
+compiler_version = ">=0.25.0"
+type = "contract"
+
+[dependencies]
+aztec = { path = "../../../../noir-projects/aztec-nr/aztec" }
+easy_private_state = { path = "../../../../noir-projects/aztec-nr/easy-private-state" }

--- a/docs/examples/tutorials/counter_contract/src/main.nr
+++ b/docs/examples/tutorials/counter_contract/src/main.nr
@@ -1,0 +1,48 @@
+// docs:start:setup
+use dep::aztec::macros::aztec;
+
+#[aztec]
+pub contract Counter {
+    // docs:end:setup
+    // docs:start:imports
+    use aztec::{
+        macros::{functions::{initializer, private, utility}, storage::storage},
+        oracle::debug_log::debug_log_format, protocol_types::{address::AztecAddress, traits::ToField},
+        state_vars::Map,
+    };
+    use easy_private_state::EasyPrivateUint;
+    // docs:end:imports
+
+    // docs:start:storage_struct
+    #[storage]
+    struct Storage<Context> {
+        counters: Map<AztecAddress, EasyPrivateUint<Context>, Context>,
+    }
+    // docs:end:storage_struct
+
+    // docs:start:constructor
+    #[initializer]
+    #[private]
+    // We can name our initializer anything we want as long as it's marked as aztec(initializer)
+    fn initialize(headstart: u64, owner: AztecAddress) {
+        let counters = storage.counters;
+        counters.at(owner).add(headstart, owner);
+    }
+    // docs:end:constructor
+
+    // docs:start:increment
+    #[private]
+    fn increment(owner: AztecAddress) {
+        debug_log_format("Incrementing counter for owner {0}", [owner.to_field()]);
+        let counters = storage.counters;
+        counters.at(owner).add(1, owner);
+    }
+    // docs:end:increment
+
+    // docs:start:get_counter
+    #[utility]
+    unconstrained fn get_counter(owner: AztecAddress) -> Field {
+        storage.counters.at(owner).get_value()
+    }
+    // docs:end:get_counter
+}


### PR DESCRIPTION
I think we need to look into adding typescript code to this, but I want to do that in a follow up PR.  It currently only builds the contracts and does not run any tests, but building the contracts already provides protection against compilation errors.

I've kept changes to noir-contracts/bootstrap.sh purposefully verbose and have not done anything fancy.

We also should have codeowners on this examples directory once this is merged !

Have tested by running `./bootstrap.sh compile` in mainframe !