### PR TITLE
chore: clarify sequencer / validator naming in cli

### DIFF
--- a/docs/docs/developers/reference/environment_reference/cli_reference.md
+++ b/docs/docs/developers/reference/environment_reference/cli_reference.md
@@ -209,9 +209,9 @@ aztec start --port 8081 --pxe --pxe.nodeUrl=$BOOTNODE --pxe.proverEnabled true -
 - `--archiver.ethereum-slot-duration <value>`: How many seconds an L1 slot lasts (default: 12).
 - `--archiver.aztec-slot-duration <value>`: How many seconds an L2 slots lasts (must be multiple of ethereum slot duration) (default: 24).
 - `--archiver.aztec-epoch-duration <value>`: How many L2 slots an epoch lasts (maximum AZTEC_MAX_EPOCH_DURATION) (default: 16).
-- `--archiver.aztec-target-committee-size <value>`: The target validator committee size (default: 48).
+- `--archiver.aztec-target-committee-size <value>`: The target sequencer committee size (default: 48).
 - `--archiver.aztec-proof-submission-window <value>`: The number of L2 slots that a proof for an epoch can be submitted in, starting from the beginning of the epoch (default: 31).
-- `--archiver.minimum-stake <value>`: The minimum stake for a validator (default: 100000000000000000000).
+- `--archiver.minimum-stake <value>`: The minimum stake for a sequencer (default: 100000000000000000000).
 - `--archiver.slashing-quorum <value>`: The slashing quorum (default: 6).
 - `--archiver.slashing-round-size <value>`: The slashing round size (default: 10).
 - `--archiver.governance-proposer-quorum <value>`: The governance proposing quorum (default: 51).
@@ -241,8 +241,8 @@ aztec start --port 8081 --pxe --pxe.nodeUrl=$BOOTNODE --pxe.proverEnabled true -
 - `-p2p, --p2p-bootstrap [options]`: Starts the P2P Bootstrap node with specified options.
 - `-t, --txe [options]`: Starts the TXE (Test eXecution Environment) with specified options.
 - `--faucet [options]`: Starts the Aztec faucet service with specified options.
-- `--sequencer.validator-private-key <value>`: The private key of the validator participating in attestation duties.
-- `--sequencer.disable-validator <value>`: Do not run the validator.
+- `--sequencer.validator-private-key <value>`: The private key that the sequencer uses to participate in attestation duties.
+- `--sequencer.disable-validator <value>`: Disable sequencer attesting.
 - `--sequencer.attestation-polling-interval-ms <value>`: Interval between polling for new attestations (default: 200).
 - `--sequencer.validator-reexecute <value>`: Re-execute transactions before attesting (default: true).
 - `--sequencer.transaction-polling-interval-ms <value>`: The number of ms to wait between polling for pending txs (default: 500).
@@ -580,7 +580,7 @@ Options:
 
 - `--l1-rpc-urls <string>`: List of Ethereum host URLs. Chain identifiers localhost and testnet can be used (comma separated) (default: ["http://host.docker.internal:8545"], env: ETHEREUM_HOSTS)
 - `-pk, --private-key <string>`: The private key to use for deployment
-- `--validators <string>`: Comma separated list of validators
+- `--validators <string>`: Comma separated list of attestors
 - `-m, --mnemonic <string>`: The mnemonic to use in deployment (default: "test test test test test test test test test test test junk")
 - `-i, --mnemonic-index <number>`: The index of the mnemonic to use in deployment (default: 0)
 - `-c, --l1-chain-id <number>`: Chain ID of the ethereum host (default: 31337, env: L1_CHAIN_ID)
@@ -621,7 +621,7 @@ Options:
 - `-r, --registry-address <string>`: The address of the registry contract
 - `--l1-rpc-urls <string>`: List of Ethereum host URLs. Chain identifiers localhost and testnet can be used (comma separated) (default: ["http://host.docker.internal:8545"], env: ETHEREUM_HOSTS)
 - `-pk, --private-key <string>`: The private key to use for deployment
-- `--validators <string>`: Comma separated list of validators
+- `--validators <string>`: Comma separated list of attestors
 - `-m, --mnemonic <string>`: The mnemonic to use in deployment (default: "test test test test test test test test test test test junk")
 - `-i, --mnemonic-index <number>`: The index of the mnemonic to use in deployment (default: 0)
 - `-c, --l1-chain-id <number>`: Chain ID of the ethereum host (default: 31337, env: L1_CHAIN_ID)

--- a/docs/docs/the_aztec_network/reference/cli_reference.md
+++ b/docs/docs/the_aztec_network/reference/cli_reference.md
@@ -376,16 +376,16 @@ If two subsystems can contain the same configuration option, only one needs to b
           How many L2 slots an epoch lasts (maximum AZTEC_MAX_EPOCH_DURATION).
 
     --archiver.aztecTargetCommitteeSize <value>                    (default: 48)                                                 ($AZTEC_TARGET_COMMITTEE_SIZE)
-          The target validator committee size.
+          The target sequencer committee size.
 
     --archiver.aztecProofSubmissionEpochs <value>                  (default: 1)                                                  ($AZTEC_PROOF_SUBMISSION_EPOCHS)
           The number of epochs after an epoch ends that proofs are still accepted.
 
     --archiver.activationThreshold <value>                               (default: 100000000000000000000)                              ($AZTEC_ACTIVATION_THRESHOLD)
-          The deposit amount for a validator
+          The deposit amount for a sequencer.
 
     --archiver.ejectionThreshold <value>                                (default: 50000000000000000000)                               ($AZTEC_EJECTION_THRESHOLD)
-          The minimum stake for a validator.
+          The minimum stake for a sequencer.
 
     --archiver.slashingQuorum <value>                              (default: 101)                                                ($AZTEC_SLASHING_QUORUM)
           The slashing quorum
@@ -406,7 +406,7 @@ If two subsystems can contain the same configuration option, only one needs to b
           The proving cost per mana
 
     --archiver.exitDelaySeconds <value>                            (default: 172800)                                             ($AZTEC_EXIT_DELAY_SECONDS)
-          The delay before a validator can exit the set
+          The delay before a sequencer can exit the set
 
     --archiver.gasLimitBufferPercentage <value>                    (default: 20)                                                 ($L1_GAS_LIMIT_BUFFER_PERCENTAGE)
           How much to increase calculated gas limit by (percentage)
@@ -447,13 +447,13 @@ If two subsystems can contain the same configuration option, only one needs to b
   SEQUENCER
 
     --sequencer
-          Starts Aztec Sequencer with options
+          Starts an Aztec Sequencer node with options
 
     --sequencer.validatorPrivateKeys <value>                       (default: [Redacted])                                         ($VALIDATOR_PRIVATE_KEYS)
-          List of private keys of the validators participating in attestation duties
+          The attesting sequencers that are operated by this sequencer node
 
     --sequencer.disableValidator <value>                                                                                          ($VALIDATOR_DISABLED)
-          Do not run the validator
+          Disable sequencer attesting
 
     --sequencer.attestationPollingIntervalMs <value>               (default: 200)                                                ($VALIDATOR_ATTESTATIONS_POLLING_INTERVAL_MS)
           Interval between polling for new attestations

--- a/yarn-project/aztec/src/cli/aztec_start_options.ts
+++ b/yarn-project/aztec/src/cli/aztec_start_options.ts
@@ -203,7 +203,7 @@ export const aztecStartOptions: { [key: string]: AztecStartOption[] } = {
   SEQUENCER: [
     {
       flag: '--sequencer',
-      description: 'Starts Aztec Sequencer with options',
+      description: 'Starts an Aztec Sequencer node with options',
       defaultValue: undefined,
       env: undefined,
     },

--- a/yarn-project/cli/src/cmds/l1/index.ts
+++ b/yarn-project/cli/src/cmds/l1/index.ts
@@ -34,7 +34,7 @@ export function injectCommands(program: Command, log: LogFn, debugLogger: Logger
     .description('Deploys all necessary Ethereum contracts for Aztec.')
     .addOption(l1RpcUrlsOption)
     .option('-pk, --private-key <string>', 'The private key to use for deployment', PRIVATE_KEY)
-    .option('--validators <string>', 'Comma separated list of validators')
+    .option('--validators <string>', 'Comma separated list of attestors')
     .option(
       '-m, --mnemonic <string>',
       'The mnemonic to use in deployment',
@@ -79,7 +79,7 @@ export function injectCommands(program: Command, log: LogFn, debugLogger: Logger
     .requiredOption('-r, --registry-address <string>', 'The address of the registry contract', parseEthereumAddress)
     .addOption(l1RpcUrlsOption)
     .option('-pk, --private-key <string>', 'The private key to use for deployment', PRIVATE_KEY)
-    .option('--validators <string>', 'Comma separated list of validators')
+    .option('--validators <string>', 'Comma separated list of attestors')
     .option(
       '-m, --mnemonic <string>',
       'The mnemonic to use in deployment',

--- a/yarn-project/cli/src/config/chain_l2_config.ts
+++ b/yarn-project/cli/src/config/chain_l2_config.ts
@@ -97,7 +97,7 @@ export const stagingIgnitionL2ChainConfig: L2ChainConfig = {
   aztecSlotDuration: 72,
   /** How many L2 slots an epoch lasts. */
   aztecEpochDuration: 32,
-  /** The target validator committee size. */
+  /** The target sequencer committee size. */
   aztecTargetCommitteeSize: 24,
   /** The number of epochs to lag behind the current epoch for validator selection. */
   lagInEpochs: 2,
@@ -179,7 +179,7 @@ export const stagingPublicL2ChainConfig: L2ChainConfig = {
   aztecSlotDuration: 36,
   /** How many L2 slots an epoch lasts. */
   aztecEpochDuration: 32,
-  /** The target validator committee size. */
+  /** The target sequencer committee size. */
   aztecTargetCommitteeSize: 48,
   /** The number of epochs to lag behind the current epoch for validator selection. */
   lagInEpochs: DefaultL1ContractsConfig.lagInEpochs,
@@ -187,9 +187,9 @@ export const stagingPublicL2ChainConfig: L2ChainConfig = {
   localEjectionThreshold: DefaultL1ContractsConfig.localEjectionThreshold,
   /** The number of epochs after an epoch ends that proofs are still accepted. */
   aztecProofSubmissionEpochs: 1,
-  /** The deposit amount for a validator */
+  /** The deposit amount for a sequencer. */
   activationThreshold: DefaultL1ContractsConfig.activationThreshold,
-  /** The minimum stake for a validator. */
+  /** The minimum stake for a sequencer. */
   ejectionThreshold: DefaultL1ContractsConfig.ejectionThreshold,
   /** The slashing round size */
   slashingRoundSizeInEpochs: DefaultL1ContractsConfig.slashingRoundSizeInEpochs,
@@ -232,15 +232,15 @@ export const testnetL2ChainConfig: L2ChainConfig = {
   aztecSlotDuration: 36,
   /** How many L2 slots an epoch lasts. */
   aztecEpochDuration: 32,
-  /** The target validator committee size. */
+  /** The target sequencer committee size. */
   aztecTargetCommitteeSize: 48,
   /** The number of epochs to lag behind the current epoch for validator selection. */
   lagInEpochs: 2,
   /** The number of epochs after an epoch ends that proofs are still accepted. */
   aztecProofSubmissionEpochs: 1,
-  /** The deposit amount for a validator */
+  /** The deposit amount for a sequencer. */
   activationThreshold: DefaultL1ContractsConfig.activationThreshold,
-  /** The minimum stake for a validator. */
+  /** The minimum stake for a sequencer. */
   ejectionThreshold: DefaultL1ContractsConfig.ejectionThreshold,
   /** The local ejection threshold for a validator. Stricter than ejectionThreshold but local to a specific rollup */
   localEjectionThreshold: DefaultL1ContractsConfig.localEjectionThreshold,

--- a/yarn-project/ethereum/src/config.ts
+++ b/yarn-project/ethereum/src/config.ts
@@ -26,15 +26,15 @@ export type L1ContractsConfig = {
   aztecSlotDuration: number;
   /** How many L2 slots an epoch lasts. */
   aztecEpochDuration: number;
-  /** The target validator committee size. */
+  /** The target sequencer committee size. */
   aztecTargetCommitteeSize: number;
   /** The number of epochs to lag behind the current epoch for validator selection. */
   lagInEpochs: number;
   /** The number of epochs after an epoch ends that proofs are still accepted. */
   aztecProofSubmissionEpochs: number;
-  /** The deposit amount for a validator */
+  /** The deposit amount for a sequencer. */
   activationThreshold: bigint;
-  /** The minimum stake for a validator. */
+  /** The minimum stake for a sequencer. */
   ejectionThreshold: bigint;
   /** The local ejection threshold for a validator. Stricter than ejectionThreshold but local to a specific rollup */
   localEjectionThreshold: bigint;
@@ -272,7 +272,7 @@ export const l1ContractsConfigMappings: ConfigMappingsType<L1ContractsConfig> = 
   },
   aztecTargetCommitteeSize: {
     env: 'AZTEC_TARGET_COMMITTEE_SIZE',
-    description: 'The target validator committee size.',
+    description: 'The target sequencer committee size.',
     ...numberConfigHelper(DefaultL1ContractsConfig.aztecTargetCommitteeSize),
   },
   lagInEpochs: {
@@ -287,12 +287,12 @@ export const l1ContractsConfigMappings: ConfigMappingsType<L1ContractsConfig> = 
   },
   activationThreshold: {
     env: 'AZTEC_ACTIVATION_THRESHOLD',
-    description: 'The deposit amount for a validator',
+    description: 'The deposit amount for a sequencer.',
     ...bigintConfigHelper(DefaultL1ContractsConfig.activationThreshold),
   },
   ejectionThreshold: {
     env: 'AZTEC_EJECTION_THRESHOLD',
-    description: 'The minimum stake for a validator.',
+    description: 'The minimum stake for a sequencer.',
     ...bigintConfigHelper(DefaultL1ContractsConfig.ejectionThreshold),
   },
   localEjectionThreshold: {
@@ -380,7 +380,7 @@ export const l1ContractsConfigMappings: ConfigMappingsType<L1ContractsConfig> = 
   },
   exitDelaySeconds: {
     env: 'AZTEC_EXIT_DELAY_SECONDS',
-    description: 'The delay before a validator can exit the set',
+    description: 'The delay before a sequencer can exit the set',
     ...numberConfigHelper(DefaultL1ContractsConfig.exitDelaySeconds),
   },
   ...l1TxUtilsConfigMappings,

--- a/yarn-project/stdlib/src/interfaces/validator.ts
+++ b/yarn-project/stdlib/src/interfaces/validator.ts
@@ -23,7 +23,7 @@ export interface ValidatorClientConfig {
   /** The addresses of the validators to use with remote signers */
   validatorAddresses?: EthAddress[];
 
-  /** Do not run the validator */
+  /** Disable sequencer attesting */
   disableValidator: boolean;
 
   /** Temporarily disable these specific validator addresses */

--- a/yarn-project/validator-client/src/config.ts
+++ b/yarn-project/validator-client/src/config.ts
@@ -13,7 +13,7 @@ export type { ValidatorClientConfig };
 export const validatorClientConfigMappings: ConfigMappingsType<ValidatorClientConfig> = {
   validatorPrivateKeys: {
     env: 'VALIDATOR_PRIVATE_KEYS',
-    description: 'List of private keys of the validators participating in attestation duties',
+    description: 'The attesting sequencers that are operated by this sequencer node',
     ...secretValueConfigHelper<`0x${string}`[]>(val =>
       val ? val.split(',').map<`0x${string}`>(key => `0x${key.replace('0x', '')}`) : [],
     ),
@@ -31,7 +31,7 @@ export const validatorClientConfigMappings: ConfigMappingsType<ValidatorClientCo
   },
   disableValidator: {
     env: 'VALIDATOR_DISABLED',
-    description: 'Do not run the validator',
+    description: 'Disable sequencer attesting',
     ...booleanConfigHelper(false),
   },
   disabledValidators: {


### PR DESCRIPTION
My assumptions:

sequencer node -> can have multiple sequencers / sequencer identities, just as an l1 validator node -> can have multiple validators

a sequencer is considered a single entity / address. a sequencer is put into a committee where one sequencer is picked to be the proposer, and the rest will be attestors. they can propose a block with a different account "publisher" but it will still be tied to the "attestor" that was selected.

After unifying naming in the docs elsewhere on validator / sequencer naming, this was saved for a follow up task as it required more looking into. I wanted to avoid actual flag name changes as if so the changes percolate further into the codebase, so I have just changed descriptions to make it hard to be confused between a "validator" and "sequencer" by using "attestor" more and by hopefully wording things better.