### PR TITLE
chore: Deflake gossip network test

### DIFF
--- a/.test_patterns.yml
+++ b/.test_patterns.yml
@@ -220,8 +220,8 @@ tests:
     error_regex: "✕ Can't claim funds"
     owners:
       - *lasse
-  - regex: "src/composed/integration_l1_publisher"
-    error_regex: "BlockOutOfRangeError"
+  - regex: "src/e2e_l1_publisher/e2e_l1_publisher.test.ts"
+    error_regex: "Anvil failed to stop in time"
     owners:
       - *palla
   # http://ci.aztec-labs.com/f2007345762c50a8

--- a/yarn-project/end-to-end/src/e2e_p2p/gossip_network.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/gossip_network.test.ts
@@ -72,9 +72,7 @@ describe('e2e_p2p_network', () => {
 
   afterEach(async () => {
     await tryStop(proverNode);
-    fs.rmSync(`${DATA_DIR}-prover`, { recursive: true, force: true, maxRetries: 3 });
     await tryStop(monitoringNode);
-    fs.rmSync(`${DATA_DIR}-monitor`, { recursive: true, force: true, maxRetries: 3 });
     await t.stopNodes(nodes);
     await t.teardown();
     for (let i = 0; i < NUM_VALIDATORS; i++) {


### PR DESCRIPTION
As part of #17273 I had added a cleanup to the gossip network test to delete data dirs for the prover. However, the `stop` method on the prover failed to await for all operations, so when the test finished successfully, it would still try to use the db (in particular, it seems to be for the proving broker database `getEpochDatabase`) and abort with a core dump.

This reverts the folder cleanup.
