### PR TITLE
fix: rewire some internal oracles

### DIFF
--- a/yarn-project/end-to-end/src/e2e_offchain_effect.test.ts
+++ b/yarn-project/end-to-end/src/e2e_offchain_effect.test.ts
@@ -62,12 +62,6 @@ describe('e2e_offchain_effect', () => {
     expect(provenTx.offchainEffects).toEqual([]);
   });
 
-  it('should revert when emitting offchain effects from utility function', async () => {
-    await expect(
-      contract1.methods.emitting_offchain_effect_from_utility_reverts().simulate({ from: defaultAccountAddress }),
-    ).rejects.toThrow('Cannot emit offchain effects from a utility function');
-  });
-
   it('should emit event as offchain message and process it', async () => {
     const [a, b, c] = [1n, 2n, 3n];
     const provenTx = await contract1.methods

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/interfaces.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/interfaces.ts
@@ -118,7 +118,6 @@ export interface IUtilityExecutionOracle {
   utilityCopyCapsule(contractAddress: AztecAddress, srcKey: Fr, dstKey: Fr, numEntries: number): Promise<void>;
   utilityAes128Decrypt(ciphertext: Buffer, iv: Buffer, symKey: Buffer): Promise<Buffer>;
   utilityGetSharedSecret(address: AztecAddress, ephPk: Point): Promise<Point>;
-  utilityEmitOffchainEffect(data: Fr[]): Promise<void>;
 }
 
 /**
@@ -157,4 +156,5 @@ export interface IPrivateExecutionOracle {
   privateIncrementAppTaggingSecretIndexAsSender(sender: AztecAddress, recipient: AztecAddress): Promise<void>;
   privateGetSenderForTags(): Promise<AztecAddress | undefined>;
   privateSetSenderForTags(senderForTags: AztecAddress): Promise<void>;
+  utilityEmitOffchainEffect(data: Fr[]): Promise<void>;
 }

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/oracle.ts
@@ -563,7 +563,7 @@ export class Oracle {
   }
 
   async utilityEmitOffchainEffect(data: ACVMField[]) {
-    await this.handlerAsUtility().utilityEmitOffchainEffect(data.map(Fr.fromString));
+    await this.handlerAsPrivate().utilityEmitOffchainEffect(data.map(Fr.fromString));
     return [];
   }
 

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution_oracle.ts
@@ -551,13 +551,7 @@ export class PrivateExecutionOracle extends UtilityExecutionOracle implements IP
     await this.executionDataProvider.incrementAppTaggingSecretIndexAsSender(this.contractAddress, sender, recipient);
   }
 
-  public override async utilityFetchTaggedLogs(pendingTaggedLogArrayBaseSlot: Fr) {
-    await this.executionDataProvider.syncTaggedLogs(this.contractAddress, pendingTaggedLogArrayBaseSlot, this.scopes);
-
-    await this.executionDataProvider.removeNullifiedNotes(this.contractAddress);
-  }
-
-  public override utilityEmitOffchainEffect(data: Fr[]): Promise<void> {
+  public utilityEmitOffchainEffect(data: Fr[]): Promise<void> {
     this.offchainEffects.push({ data });
     return Promise.resolve();
   }

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
@@ -365,8 +365,4 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
   public utilityGetSharedSecret(address: AztecAddress, ephPk: Point): Promise<Point> {
     return this.executionDataProvider.getSharedSecret(address, ephPk);
   }
-
-  public utilityEmitOffchainEffect(_data: Fr[]): Promise<void> {
-    return Promise.reject(new Error('Cannot emit offchain effects from a utility function'));
-  }
 }


### PR DESCRIPTION
This is fairly simple: private exec had an override for `fetchTaggedLogs`, despite it doing the exact same thing as the base utility exec (since there is no difference in message processing between utility and private). Additionally, utility implemented emitOffchainMessage despite it not actually being available (and throwing). I moved it to the other interface, but did not change the iface itself as I want to do that in a single cohesive pass to avoid compatibility problems.