### PR TITLE
fix: detect duplicate nullifier creation in oracles

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment/test/private_context.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment/test/private_context.nr
@@ -51,6 +51,25 @@ unconstrained fn opts_sets_contract_address_and_anchor_block_number() {
     );
 }
 
+#[test(should_fail_with = "Duplicate siloed nullifier")]
+unconstrained fn rejects_duplicate_transient_nullifiers() {
+    let env = TestEnvironment::new();
+
+    env.private_context(|context| {
+        context.push_nullifier(1);
+        context.push_nullifier(1);
+    });
+}
+
+#[test(should_fail_with = "already present")]
+unconstrained fn rejects_duplicate_settled_nullifiers() {
+    let env = TestEnvironment::new();
+
+    env.private_context(|context| { context.push_nullifier(1); });
+
+    env.private_context(|context| { context.push_nullifier(1); });
+}
+
 #[test(should_fail_with = "Contract calls are forbidden")]
 unconstrained fn private_calls_fails() {
     let env = TestEnvironment::new();

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment/test/public_context.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment/test/public_context.nr
@@ -118,6 +118,25 @@ unconstrained fn read_private_nullifier() {
     });
 }
 
+#[test(should_fail_with = "Duplicate key")]
+unconstrained fn rejects_duplicate_transient_nullifiers() {
+    let env = TestEnvironment::new();
+
+    env.public_context(|context| {
+        context.push_nullifier(1);
+        context.push_nullifier(1);
+    });
+}
+
+#[test(should_fail_with = "already present")]
+unconstrained fn rejects_duplicate_settled_nullifiers() {
+    let env = TestEnvironment::new();
+
+    env.public_context(|context| { context.push_nullifier(1); });
+
+    env.public_context(|context| { context.push_nullifier(1); });
+}
+
 #[test(should_fail_with = "Contract calls are forbidden")]
 unconstrained fn public_calls_fails() {
     let env = TestEnvironment::new();


### PR DESCRIPTION
Merge after #17315.

With #17315 we can now detect and fix these things much more easily. It turns out PXE was not checking that you had not emitted the same nullifier twice in the same TX, and in fact the second read was getting silently lost because duplicate writes into a `Set` are a no-op.

Had `NoteExecutionCache` had tests from the get-go this would've been detected, but here we are. It'd not hurt to add tests now, or even to rework it so that the `finish` function isn't as scary looking (it mutates the object unnecessarily). But at least we can begin to use the Noir tests to stablish some groundwork about these basic things being caught.

Note that neither PXE nor TXE check whether nullifiers exist _in the trees_ at creation. In PXE's case, the tx would just become invalid and fail submission when sent.