### PR TITLE
fix: make check nullifier exists check the note cache in private exec

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/state_vars/private_mutable/test.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/private_mutable/test.nr
@@ -250,36 +250,35 @@ unconstrained fn initialize_or_replace_uninitialized() {
     });
 }
 
-// TODO(#16800): restore this test once we correctly fetch a transient nullifier
-// #[test]
-// unconstrained fn initialize_or_replace_initialized_pending() {
-//     let env = TestEnvironment::new();
-//
-//     env.private_context(|context| {
-//         let state_var = in_private(context);
+#[test]
+unconstrained fn initialize_or_replace_initialized_pending() {
+    let env = TestEnvironment::new();
 
-//         // Initialize with a known value
-//         let init_note = MockNote::new(VALUE).build_note();
-//         let _ = state_var.initialize(init_note);
+    env.private_context(|context| {
+        let state_var = in_private(context);
 
-//         // Record context lengths before replacement
-//         let note_hash_read_requests_pre_replace = context.note_hash_read_requests.len();
-//         let nullifiers_pre_replace = context.nullifiers.len();
-//         let note_hashes_pre_replace = context.note_hashes.len();
+        let note = MockNote::new(VALUE).build_note();
+        let _ = state_var.initialize(note);
 
-//         // Use initialize_or_replace with the helper function
-//         let emission = state_var.initialize_or_replace(init_note, plus_one);
+        let note_hash_read_requests_pre_replace = context.note_hash_read_requests.len();
+        let nullifiers_pre_replace = context.nullifiers.len();
+        let note_hashes_pre_replace = context.note_hashes.len();
 
-//         let expected_note = MockNote::new(VALUE + 1).build_note();
-//         assert_eq(emission.note, expected_note);
-//         // assert_eq(emission.storage_slot, STORAGE_SLOT);
+        let replacement_note = MockNote::new(note.value + 1).build_note();
+        let emission = state_var.initialize_or_replace(|opt_current_note| {
+            assert_eq(opt_current_note.unwrap(), note);
+            replacement_note
+        });
 
-//         // Verify context updates: read request, nullifier, and new note
-//         assert_eq(context.note_hash_read_requests.len(), note_hash_read_requests_pre_replace + 1);
-//         assert_eq(context.nullifiers.len(), nullifiers_pre_replace + 1);
-//         assert_eq(context.note_hashes.len(), note_hashes_pre_replace + 1);
-//     });
-// }
+        assert_eq(emission.note, replacement_note);
+        assert_eq(emission.storage_slot, STORAGE_SLOT);
+
+        // Verify context updates: read request, nullifier, and new note
+        assert_eq(context.note_hash_read_requests.len(), note_hash_read_requests_pre_replace + 1);
+        assert_eq(context.nullifiers.len(), nullifiers_pre_replace + 1);
+        assert_eq(context.note_hashes.len(), note_hashes_pre_replace + 1);
+    });
+}
 
 #[test]
 unconstrained fn initialize_or_replace_initialized_settled() {
@@ -302,8 +301,7 @@ unconstrained fn initialize_or_replace_initialized_settled() {
         let nullifiers_pre_replace = context.nullifiers.len();
         let note_hashes_pre_replace = context.note_hashes.len();
 
-        let replacement_value = VALUE + 1;
-        let replacement_note = MockNote::new(replacement_value).build_note();
+        let replacement_note = MockNote::new(note.value + 1).build_note();
         let emission = state_var.initialize_or_replace(|opt_current_note| {
             assert_eq(opt_current_note.unwrap(), note);
             replacement_note

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment/test.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment/test.nr
@@ -5,6 +5,7 @@ mod accounts;
 mod deployment;
 mod private_context;
 mod public_context;
+mod utility_context;
 mod notes;
 
 #[test(should_fail_with = "cannot be before next timestamp")]

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment/test/private_context.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment/test/private_context.nr
@@ -1,3 +1,4 @@
+use crate::oracle::notes::check_nullifier_exists;
 use crate::test::helpers::test_environment::{PrivateContextOptions, TestEnvironment};
 use protocol_types::{
     abis::function_selector::FunctionSelector, address::AztecAddress, traits::FromField,
@@ -100,5 +101,31 @@ unconstrained fn set_teardown_fails() {
             FunctionSelector::zero(),
             [],
         );
+    });
+}
+
+#[test]
+unconstrained fn check_nullifier_exists_nonexistent() {
+    let env = TestEnvironment::new();
+
+    env.private_context(|_| { assert(!check_nullifier_exists(1)); });
+}
+
+#[test]
+unconstrained fn check_nullifier_exists_settled() {
+    let env = TestEnvironment::new();
+
+    env.private_context(|context| { context.push_nullifier(1); });
+
+    env.private_context(|_| { assert(check_nullifier_exists(1)); });
+}
+
+#[test]
+unconstrained fn check_nullifier_exists_pending() {
+    let env = TestEnvironment::new();
+
+    env.private_context(|context| {
+        context.push_nullifier(1);
+        assert(check_nullifier_exists(1));
     });
 }

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment/test/utility_context.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment/test/utility_context.nr
@@ -1,0 +1,19 @@
+use crate::test::helpers::test_environment::TestEnvironment;
+
+use crate::oracle::notes::check_nullifier_exists;
+
+#[test]
+unconstrained fn check_nullifier_exists_nonexistent() {
+    let env = TestEnvironment::new();
+
+    env.utility_context(|_| { assert(!check_nullifier_exists(1)); });
+}
+
+#[test]
+unconstrained fn check_nullifier_exists_settled() {
+    let env = TestEnvironment::new();
+
+    env.private_context(|context| { context.push_nullifier(1); });
+
+    env.utility_context(|_| { assert(check_nullifier_exists(1)); });
+}


### PR DESCRIPTION
Merge after #17315.

With #17315 it's now very easy to fix this for PXE and test it directly in Noir tests, since we're testing how the _oracle_ behaves. I restored the failing `PrivateMutable` test and added new tests for the utility and private oracle. Also found #17318 while doing this.

Fixes #16800.