### PR TITLE
refactor: NoteDataProvider - clarify function names, add test coverage and documentation

### DIFF
--- a/yarn-project/pxe/src/contract_function_simulator/execution_data_provider.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/execution_data_provider.ts
@@ -259,9 +259,9 @@ export interface ExecutionDataProvider {
   ): Promise<void>;
 
   /**
-   * Removes all of a contract's notes that have been nullified from the note database.
+   * Looks for nullifiers of active contract notes and marks them as nullified in the db if a nullifier is found.
    */
-  removeNullifiedNotes(contractAddress: AztecAddress): Promise<void>;
+  syncNoteNullifiers(contractAddress: AztecAddress): Promise<void>;
 
   /**
    * Stores arbitrary information in a per-contract non-volatile database, which can later be retrieved with `loadCapsule`.

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
@@ -266,7 +266,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
   public async utilityFetchTaggedLogs(pendingTaggedLogArrayBaseSlot: Fr) {
     await this.executionDataProvider.syncTaggedLogs(this.contractAddress, pendingTaggedLogArrayBaseSlot, this.scopes);
 
-    await this.executionDataProvider.removeNullifiedNotes(this.contractAddress);
+    await this.executionDataProvider.syncNoteNullifiers(this.contractAddress);
   }
 
   public async utilityValidateEnqueuedNotesAndEvents(

--- a/yarn-project/pxe/src/pxe.ts
+++ b/yarn-project/pxe/src/pxe.ts
@@ -36,7 +36,6 @@ import type {
   PrivateKernelTailCircuitPublicInputs,
 } from '@aztec/stdlib/kernel';
 import { type NotesFilter, UniqueNote } from '@aztec/stdlib/note';
-import { MerkleTreeId } from '@aztec/stdlib/trees';
 import {
   type ContractOverrides,
   PrivateExecutionResult,
@@ -383,20 +382,6 @@ export class PXE {
   }
 
   // Public API
-
-  /** Returns an estimate of the db size in bytes. */
-  public async estimateDbSize() {
-    const treeRootsSize = Object.keys(MerkleTreeId).length * Fr.SIZE_IN_BYTES;
-    const dbSizes = await Promise.all([
-      this.addressDataProvider.getSize(),
-      this.capsuleDataProvider.getSize(),
-      this.contractDataProvider.getSize(),
-      this.noteDataProvider.getSize(),
-      this.syncDataProvider.getSize(),
-      this.taggingDataProvider.getSize(),
-    ]);
-    return [...dbSizes, treeRootsSize].reduce((sum, size) => sum + size, 0);
-  }
 
   public getContractInstance(address: AztecAddress): Promise<ContractInstanceWithAddress | undefined> {
     return this.contractDataProvider.getContractInstance(address);

--- a/yarn-project/pxe/src/storage/address_data_provider/address_data_provider.ts
+++ b/yarn-project/pxe/src/storage/address_data_provider/address_data_provider.ts
@@ -3,9 +3,7 @@ import type { AztecAsyncArray, AztecAsyncKVStore, AztecAsyncMap } from '@aztec/k
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
 import { CompleteAddress } from '@aztec/stdlib/contract';
 
-import type { DataProvider } from '../data_provider.js';
-
-export class AddressDataProvider implements DataProvider {
+export class AddressDataProvider {
   #store: AztecAsyncKVStore;
   #completeAddresses: AztecAsyncArray<Buffer>;
   #completeAddressIndex: AztecAsyncMap<string, number>;
@@ -63,9 +61,5 @@ export class AddressDataProvider implements DataProvider {
     return await Promise.all(
       (await toArray(this.#completeAddresses.valuesAsync())).map(v => CompleteAddress.fromBuffer(v)),
     );
-  }
-
-  async getSize(): Promise<number> {
-    return (await this.#completeAddresses.lengthAsync()) * CompleteAddress.SIZE_IN_BYTES;
   }
 }

--- a/yarn-project/pxe/src/storage/capsule_data_provider/capsule_data_provider.ts
+++ b/yarn-project/pxe/src/storage/capsule_data_provider/capsule_data_provider.ts
@@ -1,12 +1,9 @@
 import { Fr } from '@aztec/foundation/fields';
-import { toArray } from '@aztec/foundation/iterable';
 import { type Logger, createLogger } from '@aztec/foundation/log';
 import type { AztecAsyncKVStore, AztecAsyncMap } from '@aztec/kv-store';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
 
-import type { DataProvider } from '../data_provider.js';
-
-export class CapsuleDataProvider implements DataProvider {
+export class CapsuleDataProvider {
   #store: AztecAsyncKVStore;
 
   // Arbitrary data stored by contracts. Key is computed as `${contractAddress}:${key}`
@@ -138,13 +135,6 @@ export class CapsuleDataProvider implements DataProvider {
         await this.deleteCapsule(contractAddress, arraySlot(baseSlot, i));
       }
     });
-  }
-
-  public async getSize() {
-    return (await toArray(this.#capsules.valuesAsync())).reduce(
-      (sum, value) => sum + value.length * Fr.SIZE_IN_BYTES,
-      0,
-    );
   }
 }
 

--- a/yarn-project/pxe/src/storage/contract_data_provider/contract_data_provider.ts
+++ b/yarn-project/pxe/src/storage/contract_data_provider/contract_data_provider.ts
@@ -22,7 +22,6 @@ import {
   getContractClassFromArtifact,
 } from '@aztec/stdlib/contract';
 
-import type { DataProvider } from '../data_provider.js';
 import { PrivateFunctionsTree } from './private_functions_tree.js';
 
 /**
@@ -32,7 +31,7 @@ import { PrivateFunctionsTree } from './private_functions_tree.js';
  * to efficiently serve the requested data. It interacts with the ContractDatabase and AztecNode to fetch
  * the required information and facilitate cryptographic proof generation.
  */
-export class ContractDataProvider implements DataProvider {
+export class ContractDataProvider {
   /** Map from contract class id to private function tree. */
   // TODO: Update it to be LRU cache so that it doesn't keep all the data all the time.
   #privateFunctionTrees: Map<string, PrivateFunctionsTree> = new Map();
@@ -262,12 +261,6 @@ export class ContractDataProvider implements DataProvider {
     const artifact = await this.#getContractArtifactByAddress(contractAddress);
     const fnArtifact = artifact && (await this.#findFunctionAbiBySelector(artifact, selector));
     return `${artifact?.name ?? contractAddress}:${fnArtifact?.name ?? selector}`;
-  }
-
-  public async getSize() {
-    return (await toArray(this.#contractInstances.valuesAsync()))
-      .concat(await toArray(this.#contractArtifacts.valuesAsync()))
-      .reduce((sum, value) => sum + value.length, 0);
   }
 
   async #findFunctionArtifactBySelector(

--- a/yarn-project/pxe/src/storage/data_provider.ts
+++ b/yarn-project/pxe/src/storage/data_provider.ts
@@ -1,3 +1,0 @@
-export interface DataProvider {
-  getSize(): Promise<number>;
-}

--- a/yarn-project/pxe/src/storage/index.ts
+++ b/yarn-project/pxe/src/storage/index.ts
@@ -4,6 +4,5 @@ export * from './contract_data_provider/index.js';
 export * from './note_data_provider/index.js';
 export * from './sync_data_provider/index.js';
 export * from './tagging_data_provider/index.js';
-export * from './data_provider.js';
 export * from './metadata.js';
 export * from './private_event_data_provider/private_event_data_provider.js';

--- a/yarn-project/pxe/src/storage/note_data_provider/note_data_provider.test.ts
+++ b/yarn-project/pxe/src/storage/note_data_provider/note_data_provider.test.ts
@@ -18,6 +18,7 @@ describe('NoteDataProvider', () => {
   let storageSlots: Fr[];
   let notes: NoteDao[];
 
+  // Helper: get notes for all contracts given a filter (without specifying contract)
   type NotesFilterWithoutContract = Omit<NotesFilter, 'contractAddress'>;
   async function getNotesForAllContracts(filter: NotesFilterWithoutContract) {
     const notesArrays = await Promise.all(
@@ -26,18 +27,78 @@ describe('NoteDataProvider', () => {
     return notesArrays.flat();
   }
 
+  // --- Before Each ---
+
+  // Initialize fresh NoteDataProvider before each test
   beforeEach(async () => {
     const store = await openTmpStore('note_data_provider_test');
     noteDataProvider = await NoteDataProvider.create(store);
   });
 
+  /**
+   * Sets up test data before each test case.
+   *
+   * This creates a predictable dataset of 10 notes distributed across:
+   * - 2 recipients (users who can receive notes)
+   * - 2 contract addresses (smart contracts that manage notes)
+   * - 2 storage slots (locations within contracts where notes are stored)
+   *
+   * The notes are distributed in a round-robin fashion using modulo arithmetic,
+   * ensuring each combination of (contract, slot, recipient) has predictable coverage.
+   *
+   * Data Distribution Pattern:
+   * - Notes 0,2,4,6,8: contract[0], slot[0], recipient[0], blocks 0,2,4,6,8
+   * - Notes 1,3,5,7,9: contract[1], slot[1], recipient[1], blocks 1,3,5,7,9
+   *
+   * This setup enables comprehensive testing of filtering combinations:
+   * - Single dimension filters (by contract, slot, or recipient)
+   * - Multi-dimension filters (e.g., contract AND slot)
+   * - Edge cases (non-existent values should return empty results)
+   */
+  beforeEach(async () => {
+    recipients = await timesParallel(2, () => AztecAddress.random());
+    contractAddresses = await timesParallel(2, () => AztecAddress.random());
+    storageSlots = times(2, () => Fr.random());
+
+    // Create 10 notes with deterministic distribution across the above entities
+    // Uses modulo (%) to cycle through arrays, ensuring even distribution
+    notes = await timesParallel(10, i => {
+      return NoteDao.random({
+        contractAddress: contractAddresses[i % contractAddresses.length], // Alternates between 2 contracts
+        storageSlot: storageSlots[i % storageSlots.length], // Alternates between 2 slots
+        recipient: recipients[i % recipients.length], // Alternates between 2 recipients
+        index: BigInt(i), // Sequential index: 0,1,2,...,9
+        l2BlockNumber: i, // Sequential block: 0,1,2,...,9
+      });
+    });
+
+    // Register each recipient with the note data provider so it can track their notes
+    for (const recipient of recipients) {
+      await noteDataProvider.addScope(recipient);
+    }
+  });
+
+  // --- Filtering Tests Definition ---
+
+  /**
+   * Defines an array of tests that filter notes in different ways.
+   * Each test is a tuple of two functions:
+   * 1. A function that returns a NotesFilter object (the filter to apply)
+   * 2. A function that returns the expected array of NoteDao objects that should be returned by getNotes(...) when
+   *    called with the filter from (1).
+   * The tests will add a predefined set of notes to the database, then call getNotes(...) with the filter from (1)
+   * and check that the returned notes match the expected notes from (2).
+   */
   const filteringTests: [() => Promise<NotesFilter>, () => Promise<NoteDao[]>][] = [
+    // Test 1: Filter by contract address only - should return all notes for that contract
     [
       () => Promise.resolve({ contractAddress: contractAddresses[0] }),
       () => Promise.resolve(notes.filter(note => note.contractAddress.equals(contractAddresses[0]))),
     ],
+    // Test 2: Filter by non-existent contract address - should return empty array
     [async () => ({ contractAddress: await AztecAddress.random() }), () => Promise.resolve([])],
 
+    // Test 3: Filter by contract + existing storage slot - should return matching notes
     [
       () => Promise.resolve({ contractAddress: contractAddresses[0], storageSlot: storageSlots[0] }),
       () =>
@@ -47,20 +108,24 @@ describe('NoteDataProvider', () => {
           ),
         ),
     ],
+    // Test 4: Filter by contract + non-existent storage slot - should return empty array
     [
       () => Promise.resolve({ contractAddress: contractAddresses[0], storageSlot: Fr.random() }),
       () => Promise.resolve([]),
     ],
 
+    // Test 5: Filter by contract + existing transaction hash - should return single matching note
     [
       () => Promise.resolve({ contractAddress: contractAddresses[0], txHash: notes[0].txHash }),
       () => Promise.resolve([notes[0]]),
     ],
+    // Test 6: Filter by contract + non-existent transaction hash - should return empty array
     [
       () => Promise.resolve({ contractAddress: contractAddresses[0], txHash: randomTxHash() }),
       () => Promise.resolve([]),
     ],
 
+    // Test 7: Filter by contract + existing recipient - should return notes for that recipient
     [
       () => Promise.resolve({ contractAddress: contractAddresses[0], recipient: recipients[0] }),
       () =>
@@ -70,184 +135,335 @@ describe('NoteDataProvider', () => {
           ),
         ),
     ],
-
-    [
-      () => Promise.resolve({ contractAddress: contractAddresses[0], storageSlot: storageSlots[0] }),
-      () =>
-        Promise.resolve(
-          notes.filter(
-            note => note.contractAddress.equals(contractAddresses[0]) && note.storageSlot.equals(storageSlots[0]),
-          ),
-        ),
-    ],
+    // Test 8: Filter by contract + second storage slot (should be empty due to data distribution)
     [
       () => Promise.resolve({ contractAddress: contractAddresses[0], storageSlot: storageSlots[1] }),
       () => Promise.resolve([]),
     ],
   ];
 
-  beforeEach(async () => {
-    recipients = await timesParallel(2, () => AztecAddress.random());
-    contractAddresses = await timesParallel(2, () => AztecAddress.random());
-    storageSlots = times(2, () => Fr.random());
+  // --- Filtering Tests ---
+  describe('Filtering notes', () => {
+    /**
+     * Basic filtering functionality test.
+     *
+     * Tests that the NoteDataProvider can correctly store and retrieve notes using various filters:
+     * - By contract address only
+     * - By contract + storage slot combinations
+     * - By contract + transaction hash
+     * - By contract + recipient
+     * - Edge cases with non-existent values (should return empty arrays)
+     */
+    it.each(filteringTests)('stores notes and retrieves notes', async (getFilter, getExpected) => {
+      await noteDataProvider.addNotes(notes, AztecAddress.ZERO);
+      const returnedNotes = await noteDataProvider.getNotes(await getFilter());
+      const expected = await getExpected();
+      expect(returnedNotes.sort()).toEqual(expected.sort());
+    });
 
-    notes = await timesParallel(10, i => {
-      return NoteDao.random({
-        contractAddress: contractAddresses[i % contractAddresses.length],
-        storageSlot: storageSlots[i % storageSlots.length],
-        recipient: recipients[i % recipients.length],
-        index: BigInt(i),
-        l2BlockNumber: i,
+    /**
+     * Nullified notes filtering test.
+     *
+     * Tests that the same filtering logic works correctly for nullified (spent) notes.
+     * This test:
+     * 1. Adds all notes to the provider
+     * 2. Nullifies ALL notes (marks them as spent)
+     * 3. Applies the same filters but with ACTIVE_OR_NULLIFIED status
+     * 4. Verifies that nullified notes are still returned when explicitly requested
+     */
+    it.each(filteringTests)('retrieves nullified notes', async (getFilter, getExpected) => {
+      await noteDataProvider.addNotes(notes, AztecAddress.ZERO);
+
+      const nullifiers = notes.map(note => ({
+        data: note.siloedNullifier,
+        l2BlockNumber: note.l2BlockNumber,
+        l2BlockHash: L2BlockHash.fromString(note.l2BlockHash),
+      }));
+      await expect(noteDataProvider.applyNullifiers(nullifiers)).resolves.toEqual(notes);
+      const filter = await getFilter();
+      const returnedNotes = await noteDataProvider.getNotes({ ...filter, status: NoteStatus.ACTIVE_OR_NULLIFIED });
+      const expected = await getExpected();
+      expect(returnedNotes.sort()).toEqual(expected.sort());
+    });
+  });
+
+  // --- Nullification / Status Tests ---
+
+  describe('Note nullification and status handling', () => {
+    /**
+     * Default note status behavior test.
+     *
+     * Tests that nullified (spent) notes are excluded by default from query results.
+     * This test:
+     * 1. Adds all notes
+     * 2. Nullifies notes belonging to the first recipient (half the notes)
+     * 3. Queries notes with no status specified (default behavior)
+     * 4. Queries notes with explicit ACTIVE status
+     * 5. Verifies both queries return the same results (only active notes)
+     */
+    it('skips nullified notes by default or when requesting active', async () => {
+      await noteDataProvider.addNotes(notes, AztecAddress.ZERO);
+      const notesToNullify = notes.filter(note => note.recipient.equals(recipients[0]));
+      const nullifiers = notesToNullify.map(note => ({
+        data: note.siloedNullifier,
+        l2BlockNumber: note.l2BlockNumber,
+        l2BlockHash: L2BlockHash.fromString(note.l2BlockHash),
+      }));
+      await expect(noteDataProvider.applyNullifiers(nullifiers)).resolves.toEqual(notesToNullify);
+
+      const actualNotesWithDefault = await getNotesForAllContracts({});
+      const actualNotesWithActive = await getNotesForAllContracts({ status: NoteStatus.ACTIVE });
+
+      expect(actualNotesWithDefault).toEqual(actualNotesWithActive);
+      expect(actualNotesWithActive).toEqual(notes.filter(note => !notesToNullify.includes(note)));
+    });
+
+    /**
+     * Note restore test.
+     *
+     * Tests the ability to restore (un-nullify) notes - making previously spent notes active again.
+     * This scenario occurs during blockchain reorganizations when transactions get reverted.
+     * This test:
+     * 1. Adds all notes
+     * 2. Nullifies notes at block 99 (simulating they were spent in a transaction)
+     * 3. Calls rewindNullifiersAfterBlock(98) to revert nullifications after block 98
+     * 4. Verifies the previously nullified notes are now active again
+     */
+    it('handles note unnullification', async () => {
+      await noteDataProvider.addNotes(notes, AztecAddress.ZERO);
+
+      const notesToNullify = notes.filter(note => note.recipient.equals(recipients[0]));
+      const nullifiers = notesToNullify.map(note => ({
+        data: note.siloedNullifier,
+        l2BlockNumber: 99,
+        l2BlockHash: L2BlockHash.random(),
+      }));
+      await expect(noteDataProvider.applyNullifiers(nullifiers)).resolves.toEqual(notesToNullify);
+      await expect(noteDataProvider.rollbackNotesAndNullifiers(98, 99)).resolves.toEqual(undefined);
+
+      const result = await getNotesForAllContracts({ status: NoteStatus.ACTIVE, recipient: recipients[0] });
+
+      expect(result.sort()).toEqual([...notesToNullify].sort());
+    });
+
+    /**
+     * Combined active and nullified notes query test.
+     *
+     * Tests that when explicitly requesting ACTIVE_OR_NULLIFIED status, both
+     * active and nullified notes are returned in the results.
+     * This test:
+     * 1. Adds all notes
+     * 2. Nullifies half the notes (recipient[0]'s notes)
+     * 3. Queries with ACTIVE_OR_NULLIFIED status
+     * 4. Verifies ALL original notes are returned (both active and nullified)
+     *
+     * Note: Results are sorted because the database doesn't guarantee order when
+     * combining active and nullified results.
+     */
+    it('returns active and nullified notes when requesting either', async () => {
+      await noteDataProvider.addNotes(notes, AztecAddress.ZERO);
+
+      const notesToNullify = notes.filter(note => note.recipient.equals(recipients[0]));
+      const nullifiers = notesToNullify.map(note => ({
+        data: note.siloedNullifier,
+        l2BlockNumber: note.l2BlockNumber,
+        l2BlockHash: L2BlockHash.fromString(note.l2BlockHash),
+      }));
+      await expect(noteDataProvider.applyNullifiers(nullifiers)).resolves.toEqual(notesToNullify);
+
+      const result = await getNotesForAllContracts({
+        status: NoteStatus.ACTIVE_OR_NULLIFIED,
+      });
+
+      expect(result.sort()).toEqual([...notes].sort());
+    });
+
+    // --- Edge cases ---
+    describe('Note nullification edge cases', () => {
+      /**
+       * Non-existent nullifier rejection test.
+       *
+       * Tests that attempting to nullify notes that don't exist throws an error
+       * and leaves existing notes unaffected.
+       * This test:
+       * 1. Adds all test notes to the provider
+       * 2. Attempts to nullify a fake/non-existent nullifier
+       * 3. Verifies the operation throws a "Nullifier not found" error
+       * 4. Confirms all original notes remain unchanged
+       */
+      it('throws when attempting to nullify notes that do not exist', async () => {
+        await noteDataProvider.addNotes(notes, AztecAddress.ZERO);
+
+        const fakeNullifier = {
+          data: Fr.random(),
+          l2BlockNumber: 999,
+          l2BlockHash: L2BlockHash.random(),
+        };
+
+        await expect(noteDataProvider.applyNullifiers([fakeNullifier])).rejects.toThrow(/Nullifier not found/);
+
+        // verify existing notes are unaffected
+        const allNotes = await getNotesForAllContracts({});
+        expect(allNotes.sort()).toEqual(notes.sort());
+      });
+
+      /**
+       * Mixed nullifiers atomic operation test.
+       *
+       * Tests that nullification operations are atomic - if any nullifier in a batch
+       * doesn't exist, the entire operation fails and no notes are removed.
+       * This test:
+       * 1. Adds all test notes to the provider
+       * 2. Creates a batch with one valid nullifier (for notes[0]) and one fake nullifier
+       * 3. Attempts to nullify both in a single operation
+       * 4. Verifies the operation throws a "Nullifier not found" error
+       * 5. Confirms NO notes were removed (including the valid one)
+       */
+      it('throws when some nullifiers do not exist even if others are valid', async () => {
+        await noteDataProvider.addNotes(notes, AztecAddress.ZERO);
+
+        const realNote = notes[0];
+        const realNullifier = {
+          data: realNote.siloedNullifier,
+          l2BlockNumber: realNote.l2BlockNumber,
+          l2BlockHash: L2BlockHash.fromString(realNote.l2BlockHash),
+        };
+
+        const fakeNullifier = {
+          data: Fr.random(),
+          l2BlockNumber: 999,
+          l2BlockHash: L2BlockHash.random(),
+        };
+
+        const mixedNullifiers = [realNullifier, fakeNullifier];
+
+        await expect(noteDataProvider.applyNullifiers(mixedNullifiers)).rejects.toThrow(/Nullifier not found/);
+
+        const remainingNotes = await getNotesForAllContracts({});
+        expect(remainingNotes.sort()).toEqual(notes.sort());
       });
     });
-
-    for (const recipient of recipients) {
-      await noteDataProvider.addScope(recipient);
-    }
   });
 
-  it.each(filteringTests)('stores notes and retrieves notes', async (getFilter, getExpected) => {
-    await noteDataProvider.addNotes(notes);
-    const returnedNotes = await noteDataProvider.getNotes(await getFilter());
-    const expected = await getExpected();
-    expect(returnedNotes.sort()).toEqual(expected.sort());
-  });
+  // --- Account Scoping Tests ---
 
-  it.each(filteringTests)('retrieves nullified notes', async (getFilter, getExpected) => {
-    await noteDataProvider.addNotes(notes);
+  describe('Account scoping and Account-scoped note storage', () => {
+    /**
+     * Account-scoped note storage and retrieval test.
+     *
+     * Tests that notes can be stored and retrieved per specific account (recipient),
+     * implementing proper privacy isolation between users.
+     * This test:
+     * 1. Stores first 5 notes under recipient[0]'s scope
+     * 2. Stores remaining 5 notes under recipient[1]'s scope
+     * 3. Queries notes scoped to recipient[0] - should get only first 5 notes
+     * 4. Queries notes scoped to recipient[1] - should get only last 5 notes
+     * 5. Queries notes scoped to both recipients - should get all 10 notes
+     */
+    it('stores notes and retrieves notes with siloed account', async () => {
+      await noteDataProvider.addNotes(notes.slice(0, 5), recipients[0]);
+      await noteDataProvider.addNotes(notes.slice(5), recipients[1]);
 
-    // Nullify all notes
-    const nullifiers = notes.map(note => ({
-      data: note.siloedNullifier,
-      l2BlockNumber: note.l2BlockNumber,
-      l2BlockHash: L2BlockHash.fromString(note.l2BlockHash),
-    }));
-    await expect(noteDataProvider.removeNullifiedNotes(nullifiers)).resolves.toEqual(notes);
-    const filter = await getFilter();
-    const returnedNotes = await noteDataProvider.getNotes({ ...filter, status: NoteStatus.ACTIVE_OR_NULLIFIED });
-    const expected = await getExpected();
-    expect(returnedNotes.sort()).toEqual(expected.sort());
-  });
-
-  it('skips nullified notes by default or when requesting active', async () => {
-    await noteDataProvider.addNotes(notes);
-    const notesToNullify = notes.filter(note => note.recipient.equals(recipients[0]));
-    const nullifiers = notesToNullify.map(note => ({
-      data: note.siloedNullifier,
-      l2BlockNumber: note.l2BlockNumber,
-      l2BlockHash: L2BlockHash.fromString(note.l2BlockHash),
-    }));
-    await expect(noteDataProvider.removeNullifiedNotes(nullifiers)).resolves.toEqual(notesToNullify);
-
-    const actualNotesWithDefault = await getNotesForAllContracts({});
-    const actualNotesWithActive = await getNotesForAllContracts({ status: NoteStatus.ACTIVE });
-
-    expect(actualNotesWithDefault).toEqual(actualNotesWithActive);
-    expect(actualNotesWithActive).toEqual(notes.filter(note => !notesToNullify.includes(note)));
-  });
-
-  it('handles note unnullification', async () => {
-    await noteDataProvider.addNotes(notes);
-
-    const notesToNullify = notes.filter(note => note.recipient.equals(recipients[0]));
-    const nullifiers = notesToNullify.map(note => ({
-      data: note.siloedNullifier,
-      l2BlockNumber: 99,
-      l2BlockHash: L2BlockHash.random(),
-    }));
-    await expect(noteDataProvider.removeNullifiedNotes(nullifiers)).resolves.toEqual(notesToNullify);
-    await expect(noteDataProvider.unnullifyNotesAfter(98)).resolves.toEqual(undefined);
-
-    const result = await getNotesForAllContracts({ status: NoteStatus.ACTIVE, recipient: recipients[0] });
-
-    expect(result.sort()).toEqual([...notesToNullify].sort());
-  });
-
-  it('returns active and nullified notes when requesting either', async () => {
-    await noteDataProvider.addNotes(notes);
-
-    const notesToNullify = notes.filter(note => note.recipient.equals(recipients[0]));
-    const nullifiers = notesToNullify.map(note => ({
-      data: note.siloedNullifier,
-      l2BlockNumber: note.l2BlockNumber,
-      l2BlockHash: L2BlockHash.fromString(note.l2BlockHash),
-    }));
-    await expect(noteDataProvider.removeNullifiedNotes(nullifiers)).resolves.toEqual(notesToNullify);
-
-    const result = await getNotesForAllContracts({
-      status: NoteStatus.ACTIVE_OR_NULLIFIED,
-    });
-
-    // We have to compare the sorted arrays since the database does not return the same order as when originally
-    // inserted combining active and nullified results.
-    expect(result.sort()).toEqual([...notes].sort());
-  });
-
-  it('stores notes and retrieves notes with siloed account', async () => {
-    await noteDataProvider.addNotes(notes.slice(0, 5), recipients[0]);
-
-    await noteDataProvider.addNotes(notes.slice(5), recipients[1]);
-
-    const recipient0Notes = await getNotesForAllContracts({
-      scopes: [recipients[0]],
-    });
-
-    expect(recipient0Notes.sort()).toEqual(notes.slice(0, 5).sort());
-
-    const recipient1Notes = await getNotesForAllContracts({
-      scopes: [recipients[1]],
-    });
-
-    expect(recipient1Notes.sort()).toEqual(notes.slice(5).sort());
-
-    const bothRecipientNotes = await getNotesForAllContracts({
-      scopes: [recipients[0], recipients[1]],
-    });
-
-    expect(bothRecipientNotes.sort()).toEqual(notes.sort());
-  });
-
-  it('a nullified note removes notes from all accounts in the pxe', async () => {
-    await noteDataProvider.addNotes([notes[0]], recipients[0]);
-    await noteDataProvider.addNotes([notes[0]], recipients[1]);
-
-    await expect(
-      getNotesForAllContracts({
+      const recipient0Notes = await getNotesForAllContracts({
         scopes: [recipients[0]],
-      }),
-    ).resolves.toEqual([notes[0]]);
-    await expect(
-      getNotesForAllContracts({
-        scopes: [recipients[1]],
-      }),
-    ).resolves.toEqual([notes[0]]);
-    await expect(
-      noteDataProvider.removeNullifiedNotes([
-        {
-          data: notes[0].siloedNullifier,
-          l2BlockHash: L2BlockHash.fromString(notes[0].l2BlockHash),
-          l2BlockNumber: notes[0].l2BlockNumber,
-        },
-      ]),
-    ).resolves.toEqual([notes[0]]);
+      });
 
-    await expect(
-      getNotesForAllContracts({
-        scopes: [recipients[0]],
-      }),
-    ).resolves.toEqual([]);
-    await expect(
-      getNotesForAllContracts({
+      expect(recipient0Notes.sort()).toEqual(notes.slice(0, 5).sort());
+
+      const recipient1Notes = await getNotesForAllContracts({
         scopes: [recipients[1]],
-      }),
-    ).resolves.toEqual([]);
+      });
+
+      expect(recipient1Notes.sort()).toEqual(notes.slice(5).sort());
+
+      const bothRecipientNotes = await getNotesForAllContracts({
+        scopes: [recipients[0], recipients[1]],
+      });
+
+      expect(bothRecipientNotes.sort()).toEqual(notes.sort());
+    });
+
+    /**
+     * Global nullification behavior test.
+     *
+     * Tests that when a note is nullified (spent), it's removed from ALL accounts
+     * that were tracking it, not just the account that spent it.
+     * This test:
+     * 1. Adds the same note to both recipient[0] and recipient[1] scopes
+     * 2. Verifies both recipients can see the note initially
+     * 3. Nullifies the note (simulating it being spent by someone)
+     * 4. Verifies the note is removed from BOTH recipients' views
+     */
+    it('a nullified note removes notes from all accounts in the pxe', async () => {
+      await noteDataProvider.addNotes([notes[0]], recipients[0]);
+      await noteDataProvider.addNotes([notes[0]], recipients[1]);
+
+      await expect(
+        getNotesForAllContracts({
+          scopes: [recipients[0]],
+        }),
+      ).resolves.toEqual([notes[0]]);
+      await expect(
+        getNotesForAllContracts({
+          scopes: [recipients[1]],
+        }),
+      ).resolves.toEqual([notes[0]]);
+      await expect(
+        noteDataProvider.applyNullifiers([
+          {
+            data: notes[0].siloedNullifier,
+            l2BlockHash: L2BlockHash.fromString(notes[0].l2BlockHash),
+            l2BlockNumber: notes[0].l2BlockNumber,
+          },
+        ]),
+      ).resolves.toEqual([notes[0]]);
+
+      await expect(
+        getNotesForAllContracts({
+          scopes: [recipients[0]],
+        }),
+      ).resolves.toEqual([]);
+      await expect(
+        getNotesForAllContracts({
+          scopes: [recipients[1]],
+        }),
+      ).resolves.toEqual([]);
+    });
   });
 
-  it('removes notes after a given block', async () => {
-    await noteDataProvider.addNotes(notes, recipients[0]);
+  // --- Block-based Note Removal Tests ---
 
-    await noteDataProvider.removeNotesAfter(5);
-    const result = await getNotesForAllContracts({ scopes: [recipients[0]] });
-    expect(new Set(result)).toEqual(new Set(notes.slice(0, 6)));
+  describe('Block-based note removal', () => {
+    /**
+     * Synchronization and reorganization test.
+     *
+     * Tests the ability to handle blockchain reorganizations by syncing notes and nullifiers
+     * after a specific block number. This test:
+     * 1. Adds all 10 notes (created in blocks 0-9) under recipient[0]
+     * 2. Nullifies some notes at higher block numbers to simulate spending
+     * 3. Calls syncNotesAndNullifiers(5) to handle a reorg at block 5
+     * 4. Verifies that notes from blocks 6-9 are removed and nullifications after block 5 are restored
+     *
+     */
+    it('syncs notes and nullifiers after a given block', async () => {
+      await noteDataProvider.addNotes(notes, recipients[0]);
+
+      // Nullify some notes at block 7 to simulate spending
+      const notesToNullify = notes.slice(0, 3);
+      const nullifiers = notesToNullify.map(note => ({
+        data: note.siloedNullifier,
+        l2BlockNumber: 7,
+        l2BlockHash: L2BlockHash.fromString(note.l2BlockHash),
+      }));
+      await noteDataProvider.applyNullifiers(nullifiers);
+
+      // Sync after block 5 - should restore nullified notes and remove notes from blocks 6-9
+      await noteDataProvider.rollbackNotesAndNullifiers(5, 9);
+
+      const result = await getNotesForAllContracts({ scopes: [recipients[0]] });
+
+      // Should have notes 0-5 (blocks 0-5) all active, including the previously nullified ones
+      expect(new Set(result)).toEqual(new Set(notes.slice(0, 6)));
+    });
   });
 });

--- a/yarn-project/pxe/src/storage/private_event_data_provider/private_event_data_provider.test.ts
+++ b/yarn-project/pxe/src/storage/private_event_data_provider/private_event_data_provider.test.ts
@@ -194,43 +194,6 @@ describe('PrivateEventDataProvider', () => {
     expect(events).toEqual([]);
   });
 
-  it('tracks size correctly', async () => {
-    expect(await privateEventDataProvider.getSize()).toBe(0);
-
-    await privateEventDataProvider.storePrivateEventLog(
-      contractAddress,
-      recipient,
-      eventSelector,
-      msgContent,
-      txHash,
-      eventCommitmentIndex,
-      blockNumber,
-    );
-    expect(await privateEventDataProvider.getSize()).toBe(1);
-
-    await privateEventDataProvider.storePrivateEventLog(
-      contractAddress,
-      recipient,
-      eventSelector,
-      msgContent,
-      txHash,
-      eventCommitmentIndex,
-      blockNumber,
-    );
-    expect(await privateEventDataProvider.getSize()).toBe(1); // Duplicate event not stored
-
-    await privateEventDataProvider.storePrivateEventLog(
-      contractAddress,
-      recipient,
-      eventSelector,
-      msgContent,
-      TxHash.random(),
-      eventCommitmentIndex + 1,
-      blockNumber,
-    );
-    expect(await privateEventDataProvider.getSize()).toBe(2);
-  });
-
   describe('event ordering', () => {
     let msgContent1: Fr[];
     let msgContent2: Fr[];

--- a/yarn-project/pxe/src/storage/private_event_data_provider/private_event_data_provider.ts
+++ b/yarn-project/pxe/src/storage/private_event_data_provider/private_event_data_provider.ts
@@ -6,8 +6,6 @@ import type { EventSelector } from '@aztec/stdlib/abi';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
 import type { TxHash } from '@aztec/stdlib/tx';
 
-import type { DataProvider } from '../data_provider.js';
-
 interface PrivateEventEntry {
   msgContent: Buffer;
   blockNumber: number;
@@ -17,7 +15,7 @@ interface PrivateEventEntry {
 /**
  * Stores decrypted private event logs.
  */
-export class PrivateEventDataProvider implements DataProvider {
+export class PrivateEventDataProvider {
   #store: AztecAsyncKVStore;
   /** Array storing the actual private event log entries containing the log content and block number */
   #eventLogs: AztecAsyncArray<PrivateEventEntry>;
@@ -126,9 +124,5 @@ export class PrivateEventDataProvider implements DataProvider {
     events.sort((a, b) => a.eventCommitmentIndex - b.eventCommitmentIndex);
 
     return events.map(e => e.msgContent);
-  }
-
-  getSize(): Promise<number> {
-    return this.#eventLogs.lengthAsync();
   }
 }

--- a/yarn-project/pxe/src/storage/sync_data_provider/sync_data_provider.ts
+++ b/yarn-project/pxe/src/storage/sync_data_provider/sync_data_provider.ts
@@ -1,9 +1,7 @@
 import type { AztecAsyncKVStore, AztecAsyncSingleton } from '@aztec/kv-store';
 import { BlockHeader } from '@aztec/stdlib/tx';
 
-import type { DataProvider } from '../data_provider.js';
-
-export class SyncDataProvider implements DataProvider {
+export class SyncDataProvider {
   #store: AztecAsyncKVStore;
   #synchronizedHeader: AztecAsyncSingleton<Buffer>;
 
@@ -32,9 +30,5 @@ export class SyncDataProvider implements DataProvider {
     }
 
     return BlockHeader.fromBuffer(headerBuffer);
-  }
-
-  async getSize(): Promise<number> {
-    return (await this.#synchronizedHeader.getAsync())?.length ?? 0;
   }
 }

--- a/yarn-project/pxe/src/synchronizer/synchronizer.test.ts
+++ b/yarn-project/pxe/src/synchronizer/synchronizer.test.ts
@@ -48,11 +48,8 @@ describe('Synchronizer', () => {
   });
 
   it('removes notes from db on a reorg', async () => {
-    const removeNotesAfter = jest
-      .spyOn(noteDataProvider, 'removeNotesAfter')
-      .mockImplementation(() => Promise.resolve());
-    const unnullifyNotesAfter = jest
-      .spyOn(noteDataProvider, 'unnullifyNotesAfter')
+    const rollbackNotesAndNullifiers = jest
+      .spyOn(noteDataProvider, 'rollbackNotesAndNullifiers')
       .mockImplementation(() => Promise.resolve());
     const resetNoteSyncData = jest
       .spyOn(taggingDataProvider, 'resetNoteSyncData')
@@ -67,8 +64,7 @@ describe('Synchronizer', () => {
     });
     await synchronizer.handleBlockStreamEvent({ type: 'chain-pruned', block: { number: 3, hash: '0x3' } });
 
-    expect(removeNotesAfter).toHaveBeenCalledWith(3);
-    expect(unnullifyNotesAfter).toHaveBeenCalledWith(3, 4);
+    expect(rollbackNotesAndNullifiers).toHaveBeenCalledWith(3, 4);
     expect(resetNoteSyncData).toHaveBeenCalled();
   });
 });

--- a/yarn-project/pxe/src/synchronizer/synchronizer.ts
+++ b/yarn-project/pxe/src/synchronizer/synchronizer.ts
@@ -62,8 +62,7 @@ export class Synchronizer implements L2BlockStreamEventHandler {
         this.log.warn(`Pruning data after block ${event.block.number} due to reorg`);
         // We first unnullify and then remove so that unnullified notes that were created after the block number end up deleted.
         const lastSynchedBlockNumber = await this.syncDataProvider.getBlockNumber();
-        await this.noteDataProvider.unnullifyNotesAfter(event.block.number, lastSynchedBlockNumber);
-        await this.noteDataProvider.removeNotesAfter(event.block.number);
+        await this.noteDataProvider.rollbackNotesAndNullifiers(event.block.number, lastSynchedBlockNumber);
         // Remove all note tagging indexes to force a full resync. This is suboptimal, but unless we track the
         // block number in which each index is used it's all we can do.
         await this.taggingDataProvider.resetNoteSyncData();

--- a/yarn-project/txe/src/txe_session.ts
+++ b/yarn-project/txe/src/txe_session.ts
@@ -263,7 +263,7 @@ export class TXESession implements TXESessionStateHandler {
     // we perform this. We therefore search for known nullifiers now, as otherwise notes that were nullified would not
     // be removed from the database.
     // TODO(#12553): make the synchronizer sync here instead and remove this
-    await this.pxeOracleInterface.removeNullifiedNotes(contractAddress);
+    await this.pxeOracleInterface.syncNoteNullifiers(contractAddress);
 
     // Private execution has two associated block numbers: the anchor block (i.e. the historical block that is used to
     // build the proof), and the *next* block, i.e. the one we'll create once the execution ends, and which will contain
@@ -335,7 +335,7 @@ export class TXESession implements TXESessionStateHandler {
     // we perform this. We therefore search for known nullifiers now, as otherwise notes that were nullified would not
     // be removed from the database.
     // TODO(#12553): make the synchronizer sync here instead and remove this
-    await this.pxeOracleInterface.removeNullifiedNotes(contractAddress);
+    await this.pxeOracleInterface.syncNoteNullifiers(contractAddress);
 
     this.oracleHandler = new UtilityExecutionOracle(contractAddress, [], [], this.pxeOracleInterface);
 


### PR DESCRIPTION
### Overview:
This PR improves the **NoteDataProvider** to make it more maintainable, and easier to understand. It focuses on clearer function naming and documentation, with additional test coverage for edge-cases.

---

**_Documentation_**
- Added explanatory comments to make test data creation, filtering logic, and expected results easier to understand in **note_data_provider.test**
- Added function documentation in **note_data_provider**

**_Added tests_**
- new **edge-case** tests for nullifying non-existent notes and mixed real and fake nullifiers

**_Function renaming for clarity_**
- removeNotesAfter / removeNullifiedNotes / unnullifyNotes were confusing (too similar and not descriptive).
    - unnullifyNotesAfter -> **rewindNullifiersAfterBlock**
    - removeNullifiedNotes -> **applyNullifications**
    - removeNotesAfter -> **deleteNotesAfterBlock**

- pxe_oracle_interface "removeNullifiedNotes" confusing name, renamed: 
    - removeNullifiedNotes -> **syncContractNotes**

**_Identical Reimplementation in PrivateExecutionOracle_**
- Removed **utilityFetchTaggedLogs**

**_Removed getSize() and DataProvider Interface_**
- **getSize** function no longer required in each *DataProvider class -> removed
- **DataProvider** Interface now empty -> removed 

**_Wrapping private functions_**
- Added **syncNotesAndNullifers** to wrap **rewindNullifiersAfterBlock** and **deleteNotesAfterBlock**