### PR TITLE
feat(avm)!: Handle Empty Calldata

### DIFF
--- a/barretenberg/cpp/pil/vm2/calldata.pil
+++ b/barretenberg/cpp/pil/vm2/calldata.pil
@@ -9,8 +9,19 @@ include "calldata_hashing.pil";
 // increments by one each row until we begin a new calldata instance, where the context_id must
 // increase and latch must indicate the final row.
 //
-// The size and hash of the calldata is constrained by calldata_hashing.pil. These values should be
-// looked up via calldata_hashing.pil's latch.
+// The values in the calldata columns are really hints. Their correctness is constrained by calldata_hashing.pil,
+// where the size and hash of the calldata is validated. The hash is looked up in the tx and matched to
+// the one in a tx's public inputs, and the size is looked up for each call. These values should be
+// looked up via calldata_hashing.pil's latch against the context_id.
+//
+// For empty calldata, we have a special case where no value exists, but should have a row in this
+// trace to indicate that a certain context_id has been processed:
+//  index |  value | context_id | latch |
+// -------+--------+------------+-------+
+//    0   |    0   |     id     |   1   |
+// This is the only case in which index = 0 and sel = 1. Note that no lookups should access this trace
+// with index = 0 unless to confirm that the calldata is empty (data_copy and calldata_hashing lookup
+// all existing values with a +1).
 //
 // e.g. calldata: [0x111, 0x222, 0x333, 0x444]
 // calldata.pil:
@@ -26,7 +37,7 @@ include "calldata_hashing.pil";
 //   index_0_ |  index_1_ | index_2_ | context_id | input_0_ | input_1_ | input_2_ | output_hash | latch | start | rounds_rem | padding | calldata_size |
 // -----------+-----------+----------+------------+----------+----------+----------+-------------+-------+-------+------------+---------+---------------+
 //     0      |     1     |     2    |      1     |    sep   |   0x111  |   0x222  |  cd_hash_0  |   0   |   1   |     2      |    0    |       4       |
-//     3      |     4     |     5    |      1     |   0x444  |     0    |     0    |  cd_hash_0  |   1   |   0   |     1      |    2    |       4       |
+//     3      |     4     |     5    |      1     |   0x333  |   0x444  |     0    |  cd_hash_0  |   1   |   0   |     1      |    1    |       4       |
 
 namespace calldata;
 
@@ -36,7 +47,22 @@ namespace calldata;
     pol commit sel;
     pol commit value;
     pol commit context_id;
-    // Index starts at one:
+    // **NOTE** The index starts at one in this trace (see above comment for special case of empty calldata and index = 0):
+    // We do not currently constrain this (or the existence of a 'start' column) since calldata_hashing constrains it
+    // and all looked up calldata values are basically hints which must also go through calldata_hashing.
+    //      e.g. data_copy will look up values in this trace by context_id. We know that these values are valid (and
+    //      start at index=1) because data_copy also looks up the calldata size by the same context_id, constrained by
+    //      calldata_hashing, which itself constrains the index.
+    // We could constrain this here by introducing a start column:
+    //      pol commit start;
+    // Adding relations like (see calldata_hashing.pil's):
+    //      #[START_AFTER_LATCH]
+    //      sel' * (start' - FIRST_OR_LAST_CALLDATA) = 0;
+    //      #[START_INDEX_IS_ONE]
+    //      sel * start * (is_not_empty * (index - 1) + is_empty * index) = 0;
+    // If start = 1, #[START_INDEX_IS_ONE] should constrain that index = 1 unless we have empty calldata. In that case
+    // the 'special' row must have latch = 1, index = 0, value = 0, and will be constrained by calldata_hashing to have
+    // size = 0. This is a different case to a calldata of one field of value 0, where index = 1.
     pol commit index;
     // Designates end of calldata for that context_id
     pol commit latch;

--- a/barretenberg/cpp/pil/vm2/calldata_hashing.pil
+++ b/barretenberg/cpp/pil/vm2/calldata_hashing.pil
@@ -26,7 +26,12 @@ include "constants_gen.pil";
 //     0      |     1     |     2    |      1     |    sep   |   0x111  |   0x222  |  cd_hash_0  |   0   |   1   |     2      |    0    |       4       |
 //     3      |     4     |     5    |      1     |   0x333  |   0x444  |     0    |  cd_hash_0  |   1   |   0   |     1      |    1    |       4       |
 //     0      |     1     |     2    |      2     |    sep   |   0xaaa  |   0xbbb  |  cd_hash_1  |   1   |   1   |     1      |    0    |       2       |
-
+//
+// For empty calldata, we lookup a special row to the calldata.pil trace where index = 0 and latch = 1 for the context_id:
+//   index_0_ |  index_1_ | index_2_ | context_id | input_0_ | input_1_ | input_2_ | output_hash | latch | start | rounds_rem | padding | calldata_size |
+// -----------+-----------+----------+------------+----------+----------+----------+-------------+-------+-------+------------+---------+---------------+
+//     0      |     1     |     2    |      1     |    sep   |     0    |     0    |   H([sep])  |   1   |   1   |     1      |    2    |       0       |
+//
 namespace calldata_hashing;
 
     #[skippable_if]
@@ -164,6 +169,7 @@ namespace calldata_hashing;
     // index[] looked up above.
     // Note: we could probably utilise the other value lookups to check this, but would need to define col.s like
     // input_1_is_final to check against calldata.latch for each value at every row. Worth the overhead?
+    // For empty calldata, the below looks up a special row where calldata.latch = 1 and calldata.index = 0:
     #[CHECK_FINAL_SIZE]
     latch { calldata_size, context_id }
     in

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/relations/calldata_hashing.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/relations/calldata_hashing.test.cpp
@@ -207,6 +207,52 @@ TEST_F(CalldataHashingConstrainingTest, SingleCalldataHashOneElt)
     check_all_interactions<CalldataTraceBuilder>(trace);
 }
 
+TEST_F(CalldataHashingConstrainingTest, EmptyCalldataHash)
+{
+    Poseidon2 poseidon2 =
+        Poseidon2(mock_execution_id_manager, mock_gt, hash_event_emitter, perm_event_emitter, perm_mem_event_emitter);
+    std::vector<FF> calldata_fields = {};
+
+    auto hash = poseidon2.hash({ GENERATOR_INDEX__PUBLIC_CALLDATA });
+
+    auto trace = TestTraceContainer({
+        { { C::precomputed_first_row, 1 } },
+        {
+            { C::calldata_hashing_index_1_, 1 },
+            { C::calldata_hashing_index_2_, 2 },
+            { C::calldata_hashing_input_0_, GENERATOR_INDEX__PUBLIC_CALLDATA },
+            { C::calldata_hashing_input_1_, 0 },
+            { C::calldata_hashing_input_2_, 0 },
+            { C::calldata_hashing_input_len, 1 },
+            { C::calldata_hashing_latch, 1 },
+            { C::calldata_hashing_sel_not_padding_1, 0 },
+            { C::calldata_hashing_sel_not_padding_2, 0 },
+            { C::calldata_hashing_sel_not_start, 0 },
+            { C::calldata_hashing_calldata_size, 0 },
+            { C::calldata_hashing_context_id, 1 },
+            { C::calldata_hashing_index_0_, 0 },
+            { C::calldata_hashing_output_hash, hash },
+            { C::calldata_hashing_rounds_rem, 1 },
+            { C::calldata_hashing_sel, 1 },
+            { C::calldata_hashing_start, 1 },
+        },
+    });
+
+    builder.process_retrieval({ { .context_id = 1, .calldata = calldata_fields } }, trace);
+    poseidon2_builder.process_hash(hash_event_emitter.dump_events(), trace);
+
+    check_relation<calldata_hashing>(trace);
+    check_all_interactions<CalldataTraceBuilder>(trace);
+}
+
+TEST_F(CalldataHashingConstrainingTestTraceHelper, EmptyCalldataHash)
+{
+    TestTraceContainer trace = process_calldata_hashing_trace({}, { 1 });
+
+    check_relation<calldata_hashing>(trace);
+    check_all_interactions<CalldataTraceBuilder>(trace);
+}
+
 TEST_F(CalldataHashingConstrainingTestTraceHelper, SingleCalldataHash100Fields)
 {
     // The hardcoded value is taken from noir-projects/aztec-nr/aztec/src/hash.nr:

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/calldata_hashing.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/calldata_hashing.cpp
@@ -8,11 +8,6 @@ namespace bb::avm2::simulation {
 
 FF CalldataHasher::compute_calldata_hash(std::span<const FF> calldata)
 {
-    if (calldata.empty()) {
-        // Based on the noir short circuit, if the calldata is empty we return 0
-        // There is no need to emit an event.
-        return 0;
-    }
     // todo(ilyas): this probably simulates faster at the cost of re-work in tracegen
     std::vector<FF> calldata_with_sep = { GENERATOR_INDEX__PUBLIC_CALLDATA };
     for (const auto& value : calldata) {

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/calldata_hashing.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/calldata_hashing.test.cpp
@@ -89,9 +89,18 @@ TEST_F(CalldataHashingTest, Hash)
 TEST_F(CalldataHashingTest, Empty)
 {
     std::vector<FF> calldata = {};
-    // We do not emit events for empty calldata:
+    // If we recieve empty calldata, we just hash the separator:
+    std::vector<FF> prepended_calldata_fields = { GENERATOR_INDEX__PUBLIC_CALLDATA };
+
+    auto hash = RawPoseidon2::hash(prepended_calldata_fields);
+    EXPECT_CALL(poseidon2, hash(prepended_calldata_fields)).WillOnce(Return(hash));
+
     calldata_hasher.compute_calldata_hash(calldata);
-    EXPECT_THAT(calldata_events.dump_events(), AllOf(SizeIs(0)));
+    EXPECT_THAT(calldata_events.dump_events(),
+                AllOf(SizeIs(1),
+                      ElementsAre(AllOf(Field(&CalldataEvent::context_id, 1),
+                                        Field(&CalldataEvent::calldata_size, 0),
+                                        Field(&CalldataEvent::calldata, calldata)))));
 }
 
 } // namespace

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/calldata_trace.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/calldata_trace.cpp
@@ -45,8 +45,26 @@ void CalldataTraceBuilder::process_retrieval(
                           // Note that the diff is shifted by 1 to ensure the context_ids are increasing:
                           { C::calldata_diff_context_id,
                             (is_latch && !is_last) ? sorted_events[j + 1]->context_id - context_id - 1 : 0 },
-
                       } });
+            row++;
+        }
+
+        // Handle empty calldata:
+        if (calldata.size() == 0) {
+            // To ensure that we indicate a certain context_id has been processed, we include a special row
+            // in the calldata trace. This is the only case where sel = 1 and index = 0. Lookups into this trace
+            // to access values always shift by 1, so should never attempt to access a non-existent value:
+            trace.set(
+                row,
+                { {
+                    { C::calldata_sel, 1 },
+                    { C::calldata_context_id, context_id },
+                    { C::calldata_value, 0 },
+                    { C::calldata_index, 0 },
+                    { C::calldata_latch, 1 },
+                    // Note that the diff is shifted by 1 to ensure the context_ids are increasing:
+                    { C::calldata_diff_context_id, !is_last ? sorted_events[j + 1]->context_id - context_id - 1 : 0 },
+                } });
             row++;
         }
     }

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/data_copy_trace.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/data_copy_trace.cpp
@@ -191,8 +191,5 @@ const InteractionDefinition DataCopyTraceBuilder::interactions =
         .add<lookup_data_copy_max_read_index_gt_settings, InteractionType::LookupGeneric>(Column::gt_sel)
         .add<lookup_data_copy_check_src_addr_in_range_settings, InteractionType::LookupGeneric>(Column::gt_sel)
         .add<lookup_data_copy_check_dst_addr_in_range_settings, InteractionType::LookupGeneric>(Column::gt_sel)
-        .add<lookup_data_copy_offset_gt_max_read_index_settings, InteractionType::LookupGeneric>(Column::gt_sel)
-        // Permutations
-        .add<perm_data_copy_dispatch_cd_copy_settings, InteractionType::Permutation>()
-        .add<perm_data_copy_dispatch_rd_copy_settings, InteractionType::Permutation>();
+        .add<lookup_data_copy_offset_gt_max_read_index_settings, InteractionType::LookupGeneric>(Column::gt_sel);
 } // namespace bb::avm2::tracegen

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/execution_trace.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/execution_trace.cpp
@@ -34,6 +34,7 @@
 #include "barretenberg/vm2/generated/relations/lookups_send_l2_to_l1_msg.hpp"
 #include "barretenberg/vm2/generated/relations/lookups_sload.hpp"
 #include "barretenberg/vm2/generated/relations/lookups_sstore.hpp"
+#include "barretenberg/vm2/generated/relations/perms_data_copy.hpp"
 #include "barretenberg/vm2/generated/relations/perms_execution.hpp"
 #include "barretenberg/vm2/simulation/events/addressing_event.hpp"
 #include "barretenberg/vm2/simulation/events/event_emitter.hpp"
@@ -1174,6 +1175,8 @@ const InteractionDefinition ExecutionTraceBuilder::interactions =
             Column::gt_sel)
         // Dispatch to gadget sub-traces
         .add<perm_execution_dispatch_keccakf1600_settings, InteractionType::Permutation>()
+        .add<perm_data_copy_dispatch_cd_copy_settings, InteractionType::Permutation>()
+        .add<perm_data_copy_dispatch_rd_copy_settings, InteractionType::Permutation>()
         // GetEnvVar opcode
         .add<lookup_get_env_var_precomputed_info_settings, InteractionType::LookupIntoIndexedByClk>()
         .add<lookup_get_env_var_read_from_public_inputs_col0_settings, InteractionType::LookupIntoIndexedByClk>()

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/tx_trace.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/tx_trace.test.cpp
@@ -46,6 +46,7 @@ TEST(TxTraceGenTest, EnqueuedCallEvent)
                 .msg_sender = msg_sender,
                 .contract_address = contract_address,
                 .is_static = false,
+                .calldata_size = 2,
                 .calldata_hash = calldata_hash,
                 .success = true,
             },
@@ -68,6 +69,7 @@ TEST(TxTraceGenTest, EnqueuedCallEvent)
                       ROW_FIELD_EQ(tx_remaining_phase_inv, 1),
                       ROW_FIELD_EQ(tx_msg_sender, msg_sender),
                       ROW_FIELD_EQ(tx_contract_addr, contract_address),
+                      ROW_FIELD_EQ(tx_calldata_size, 2),
                       ROW_FIELD_EQ(tx_calldata_hash, calldata_hash),
                       ROW_FIELD_EQ(tx_end_phase, 1),
                       ROW_FIELD_EQ(tx_is_static, false)));

--- a/noir-projects/aztec-nr/aztec/src/hash.nr
+++ b/noir-projects/aztec-nr/aztec/src/hash.nr
@@ -105,20 +105,12 @@ pub fn hash_args(args: [Field]) -> Field {
 
 // Computes the hash of calldata for public functions.
 pub fn hash_calldata_array<let N: u32>(calldata: [Field; N]) -> Field {
-    if calldata.len() == 0 {
-        0
-    } else {
-        poseidon2_hash_with_separator(calldata, GENERATOR_INDEX__PUBLIC_CALLDATA)
-    }
+    poseidon2_hash_with_separator(calldata, GENERATOR_INDEX__PUBLIC_CALLDATA)
 }
 
 // Same as `hash_calldata_array`, but takes a slice instead of an array.
 pub fn hash_calldata(calldata: [Field]) -> Field {
-    if calldata.len() == 0 {
-        0
-    } else {
-        poseidon2_hash_with_separator_slice(calldata, GENERATOR_INDEX__PUBLIC_CALLDATA)
-    }
+    poseidon2_hash_with_separator_slice(calldata, GENERATOR_INDEX__PUBLIC_CALLDATA)
 }
 
 /**

--- a/yarn-project/stdlib/src/hash/hash.ts
+++ b/yarn-project/stdlib/src/hash/hash.ts
@@ -109,10 +109,6 @@ export function computeVarArgsHash(args: Fr[]): Promise<Fr> {
  * @returns Hash of the calldata.
  */
 export function computeCalldataHash(calldata: Fr[]): Promise<Fr> {
-  if (calldata.length === 0) {
-    return Promise.resolve(Fr.ZERO);
-  }
-
   return poseidon2HashWithSeparator(calldata, GeneratorIndex.PUBLIC_CALLDATA);
 }
 


### PR DESCRIPTION
## Empty Calldata

This is a follow-up to #17224 which handles empty calldata within the AVM. The main change is that **we no longer return 0 for empty calldata**:

```rust
   // if calldata.len() == 0 { // <-- removed
   //     0
   //  } else {
        poseidon2_hash_with_separator_slice(calldata, GENERATOR_INDEX__PUBLIC_CALLDATA)
   // }
```
When given an empty array, the AVM will just hash the separator. This is handled inside the circuit by including a special case in the `calldata` trace which indicates we have a `calldata_size` of 0:
```
//  index |  value | context_id | latch |
// -------+--------+------------+-------+
//    0   |    0   |     id     |   1   |
```
This is different from the case where we have calldata of `[ 0 ]`, which would have `index = 1` and `calldata_hash = H([sep, 0])` (with lookups confirming that the poseidon `input_len` is actually 2 and `calldata_size = 1`). I've added some comments to explain that we should never look up the `calldata` trace with an `index` of 0 unless we are looking to confirm that some `context_id` has empty calldata.

### Notes/TODOs

- The protocol will always prepend the function selector to its calldata array, so we won't ever 'see' this case in an e2e test (but we do want to handle it)