### PR TITLE
feat: adds analytis, nps and email subscription

### DIFF
--- a/barretenberg/docs/.env.template
+++ b/barretenberg/docs/.env.template
@@ -1,0 +1,2 @@
+BREVO_API_KEY=your_api_key_here
+ENV=dev

--- a/barretenberg/docs/.gitignore
+++ b/barretenberg/docs/.gitignore
@@ -10,6 +10,7 @@
 
 # Misc
 .DS_Store
+.env
 .env.local
 .env.development.local
 .env.test.local

--- a/barretenberg/docs/README.md
+++ b/barretenberg/docs/README.md
@@ -11,10 +11,28 @@ yarn
 ## Local Development
 
 ```bash
-yarn start
+yarn dev
 ```
 
 This command starts a local development server and opens up a browser window. Most changes are reflected live without having to restart the server.
+
+### Netlify Development (Full-Stack Testing)
+
+For testing features that require Netlify functions (like email subscriptions), use the Netlify development environment:
+
+```bash
+yarn dev:netlify
+```
+
+**Environment Setup:**
+Create a `.env` file in the project root for Netlify functions:
+
+```bash
+# Copy .env.template to .env and update with your API key
+cp .env.template .env
+```
+
+Then edit `.env` with your actual Brevo API key.
 
 ## Build
 

--- a/barretenberg/docs/docusaurus.config.ts
+++ b/barretenberg/docs/docusaurus.config.ts
@@ -63,6 +63,10 @@ const config: Config = {
     defaultLocale: "en",
     locales: ["en"],
   },
+
+  customFields: {
+    ENV: process.env.ENV,
+  },
   presets: [
     [
       "classic",

--- a/barretenberg/docs/netlify/functions/subscribe.js
+++ b/barretenberg/docs/netlify/functions/subscribe.js
@@ -1,0 +1,249 @@
+// Netlify function for email subscription using Brevo API
+
+const brevo = require('@getbrevo/brevo');
+
+// Email validation function for serverless backend
+function isValidEmail(email) {
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  
+  if (!email || typeof email !== 'string') {
+    return false;
+  }
+  
+  if (!emailRegex.test(email)) {
+    return false;
+  }
+  
+  if (email.length > 254) {
+    return false;
+  }
+  
+  const [localPart, domain] = email.split('@');
+  if (localPart.length > 64 || domain.length > 253) {
+    return false;
+  }
+  
+  return true;
+}
+
+const BREVO_LIST_ID = 102;
+
+// Simple in-memory rate limiting (resets on cold starts)
+const rateLimitMap = new Map();
+const RATE_LIMIT_WINDOW = 60 * 1000; // 1 minute
+const MAX_REQUESTS_PER_WINDOW = 5; // 5 requests per minute per IP
+const MAX_EMAIL_REQUESTS_PER_HOUR = 3; // 3 submissions per hour per email
+
+// Cleanup old entries periodically
+setInterval(() => {
+  const now = Date.now();
+  for (const [key, data] of rateLimitMap.entries()) {
+    if (now - data.firstRequest > RATE_LIMIT_WINDOW) {
+      rateLimitMap.delete(key);
+    }
+  }
+}, RATE_LIMIT_WINDOW);
+
+function isRateLimited(identifier, maxRequests = MAX_REQUESTS_PER_WINDOW) {
+  const now = Date.now();
+  const key = identifier;
+  
+  if (!rateLimitMap.has(key)) {
+    rateLimitMap.set(key, { count: 1, firstRequest: now });
+    return false;
+  }
+  
+  const data = rateLimitMap.get(key);
+  
+  // Reset if window expired
+  if (now - data.firstRequest > RATE_LIMIT_WINDOW) {
+    rateLimitMap.set(key, { count: 1, firstRequest: now });
+    return false;
+  }
+  
+  // Check if over limit
+  if (data.count >= maxRequests) {
+    return true;
+  }
+  
+  // Increment counter
+  data.count++;
+  return false;
+}
+
+exports.handler = async (event, context) => {
+  // Only allow POST requests
+  if (event.httpMethod !== 'POST') {
+    return {
+      statusCode: 405,
+      headers: {
+        'Content-Type': 'application/json',
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Methods': 'POST',
+        'Access-Control-Allow-Headers': 'Content-Type',
+      },
+      body: JSON.stringify({ error: 'Method not allowed' }),
+    };
+  }
+
+  // Get client IP for rate limiting
+  const clientIP = event.headers['client-ip'] || event.headers['x-forwarded-for'] || 'unknown';
+  
+  // Rate limit by IP
+  if (isRateLimited(`ip:${clientIP}`)) {
+    return {
+      statusCode: 429,
+      headers: {
+        'Content-Type': 'application/json',
+        'Access-Control-Allow-Origin': '*',
+        'Retry-After': '60',
+      },
+      body: JSON.stringify({ 
+        error: 'Too many requests. Please try again in a minute.',
+        retryAfter: 60
+      }),
+    };
+  }
+
+  try {
+    // Basic request validation
+    if (!event.body) {
+      return {
+        statusCode: 400,
+        headers: {
+          'Content-Type': 'application/json',
+          'Access-Control-Allow-Origin': '*',
+        },
+        body: JSON.stringify({ error: 'Request body is required' }),
+      };
+    }
+
+    // Limit request body size (prevent large payload attacks)
+    if (event.body.length > 1000) {
+      return {
+        statusCode: 413,
+        headers: {
+          'Content-Type': 'application/json',
+          'Access-Control-Allow-Origin': '*',
+        },
+        body: JSON.stringify({ error: 'Request too large' }),
+      };
+    }
+
+    const { email, source } = JSON.parse(event.body);
+
+    if (!email || typeof email !== 'string' || !isValidEmail(email)) {
+      return {
+        statusCode: 400,
+        headers: {
+          'Content-Type': 'application/json',
+          'Access-Control-Allow-Origin': '*',
+        },
+        body: JSON.stringify({ error: 'Please provide a valid email address' }),
+      };
+    }
+
+    // Normalize and sanitize email
+    const normalizedEmail = email.toLowerCase().trim();
+    
+    // Additional length check (RFC 5321 max email length)
+    if (normalizedEmail.length > 254) {
+      return {
+        statusCode: 400,
+        headers: {
+          'Content-Type': 'application/json',
+          'Access-Control-Allow-Origin': '*',
+        },
+        body: JSON.stringify({ error: 'Email address is too long' }),
+      };
+    }
+
+    // Rate limit by email (prevent spam submissions for same email)
+    if (isRateLimited(`email:${normalizedEmail}`, MAX_EMAIL_REQUESTS_PER_HOUR)) {
+      return {
+        statusCode: 429,
+        headers: {
+          'Content-Type': 'application/json',
+          'Access-Control-Allow-Origin': '*',
+          'Retry-After': '3600',
+        },
+        body: JSON.stringify({ 
+          error: 'This email has been submitted recently. Please try again later.',
+          retryAfter: 3600
+        }),
+      };
+    }
+
+    // Initialize Brevo API client
+    const apiInstance = new brevo.ContactsApi();
+    apiInstance.setApiKey(brevo.ContactsApiApiKeys.apiKey, process.env.BREVO_API_KEY);
+
+    try {
+      // Create contact in Brevo
+      const createContact = new brevo.CreateContact();
+      createContact.email = normalizedEmail;
+      createContact.listIds = [BREVO_LIST_ID];
+      
+      // Add source tracking
+      if (source) {
+        createContact.attributes = { SOURCE: source };
+      }
+      
+      await apiInstance.createContact(createContact);
+      
+    } catch (brevoError) {
+      // Check if contact already exists (Brevo returns 400 with duplicate_parameter code)
+      if (brevoError && (brevoError.status === 400 || brevoError.status === 409) &&
+          brevoError.response?.data?.code === 'duplicate_parameter') {
+        // Contact exists, try to add to list
+        try {
+          const addToList = new brevo.AddContactToList();
+          addToList.emails = [normalizedEmail];
+          
+          await apiInstance.addContactToList(BREVO_LIST_ID, addToList);
+          
+        } catch (listError) {
+          console.error('Error adding existing contact to list:', listError);
+          // Contact exists and might already be in the list
+          return {
+            statusCode: 200,
+            headers: {
+              'Content-Type': 'application/json',
+              'Access-Control-Allow-Origin': '*',
+            },
+            body: JSON.stringify({
+              message: 'You\'re already subscribed! Check your inbox for our latest updates.',
+              alreadySubscribed: true
+            }),
+          };
+        }
+      } else {
+        // Other Brevo API error
+        console.error('Brevo API error:', brevoError);
+        throw brevoError;
+      }
+    }
+
+    return {
+      statusCode: 200,
+      headers: {
+        'Content-Type': 'application/json',
+        'Access-Control-Allow-Origin': '*',
+      },
+      body: JSON.stringify({ 
+        message: 'Successfully subscribed!',
+        email: normalizedEmail 
+      }),
+    };
+  } catch (error) {
+    console.error('Subscription error:', error);
+    return {
+      statusCode: 500,
+      headers: {
+        'Content-Type': 'application/json',
+        'Access-Control-Allow-Origin': '*',
+      },
+      body: JSON.stringify({ error: 'Failed to subscribe. Please try again.' }),
+    };
+  }
+};

--- a/barretenberg/docs/package.json
+++ b/barretenberg/docs/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "docs": "yarn preprocess && docusaurus start --host ${HOST:-localhost}",
     "dev": "HOST=0.0.0.0 ENV=dev yarn run docs",
+    "dev:netlify": "yarn netlify dev",
     "build": "yarn clear && yarn preprocess && ./scripts/build_docs.sh && docusaurus build",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
@@ -21,6 +22,7 @@
     "@docusaurus/plugin-client-redirects": "3.7.0",
     "@docusaurus/plugin-ideal-image": "^3.7.0",
     "@docusaurus/preset-classic": "3.7.0",
+    "@getbrevo/brevo": "^3.0.1",
     "@mdx-js/react": "^3.0.0",
     "@noir-lang/noir_js": "1.0.0-beta.8",
     "axios": "^1.8.3",

--- a/barretenberg/docs/src/components/EmailSubscription/HeroSubscription.module.css
+++ b/barretenberg/docs/src/components/EmailSubscription/HeroSubscription.module.css
@@ -1,0 +1,250 @@
+/* Hero Email Subscription - Inspired by the uploaded design */
+
+.heroContainer {
+  background: linear-gradient(135deg, #4a2c2a 0%, #2d4a2a 50%, #1a3a1a 100%);
+  padding: 4rem 2rem;
+  text-align: center;
+  position: relative;
+  overflow: hidden;
+}
+
+/* Add subtle texture overlay */
+.heroContainer::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: 
+    radial-gradient(circle at 20% 80%, rgba(204, 36, 195, 0.1) 0%, transparent 50%),
+    radial-gradient(circle at 80% 20%, rgba(169, 204, 31, 0.1) 0%, transparent 50%);
+  pointer-events: none;
+}
+
+.heroContent {
+  max-width: 800px;
+  margin: 0 auto;
+  position: relative;
+  z-index: 1;
+}
+
+.heroTitle {
+  font-family: "Oracle", sans-serif;
+  font-size: clamp(2.5rem, 5vw, 4rem);
+  font-weight: 600;
+  color: #a9cc1f;
+  margin: 0 0 2rem 0;
+  line-height: 1.2;
+  letter-spacing: -0.02em;
+}
+
+.heroSubtitle {
+  font-size: 1.25rem;
+  color: rgba(242, 238, 225, 0.8);
+  margin: 0 0 3rem 0;
+  line-height: 1.4;
+  max-width: 600px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.heroForm {
+  margin-top: 3rem;
+}
+
+.inputContainer {
+  display: flex;
+  align-items: center;
+  max-width: 500px;
+  margin: 0 auto;
+  position: relative;
+  gap: 1rem;
+}
+
+.heroInput {
+  flex: 1;
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid rgba(242, 238, 225, 0.3);
+  padding: 1rem 0;
+  font-size: 1.1rem;
+  font-family: "Oracle", sans-serif;
+  color: #f2eee1;
+  transition: all 0.3s ease;
+  outline: none;
+}
+
+.heroInput::placeholder {
+  color: rgba(242, 238, 225, 0.5);
+  font-style: italic;
+}
+
+.heroInput:focus {
+  border-bottom-color: #a9cc1f;
+  box-shadow: 0 2px 0 0 rgba(169, 204, 31, 0.3);
+}
+
+.heroInput:not(:placeholder-shown) {
+  border-bottom-color: rgba(242, 238, 225, 0.6);
+}
+
+.heroButton {
+  background: transparent;
+  border: 2px solid rgba(242, 238, 225, 0.3);
+  border-radius: 50%;
+  width: 48px;
+  height: 48px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #f2eee1;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  flex-shrink: 0;
+}
+
+.heroButton:hover:not(:disabled) {
+  border-color: #a9cc1f;
+  background: rgba(169, 204, 31, 0.1);
+  transform: translateX(4px);
+}
+
+.heroButton:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  transform: none;
+}
+
+.heroButton svg {
+  transition: transform 0.2s ease;
+}
+
+.heroButton:hover:not(:disabled) svg {
+  transform: translateX(2px);
+}
+
+.loadingSpinner {
+  width: 20px;
+  height: 20px;
+  border: 2px solid rgba(242, 238, 225, 0.3);
+  border-top: 2px solid #a9cc1f;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}
+
+.errorMessage {
+  color: #ff6b6b;
+  font-size: 0.9rem;
+  margin-top: 1rem;
+  text-align: center;
+}
+
+/* Success state */
+.successState {
+  padding: 2rem 0;
+}
+
+.successMessage {
+  font-size: 1.1rem;
+  color: rgba(242, 238, 225, 0.8);
+  margin: 1rem 0 0 0;
+  line-height: 1.5;
+}
+
+/* Responsive design */
+@media (max-width: 768px) {
+  .heroContainer {
+    padding: 3rem 1.5rem;
+  }
+  
+  .heroTitle {
+    font-size: 2.5rem;
+    margin-bottom: 1.5rem;
+  }
+  
+  .heroSubtitle {
+    font-size: 1.1rem;
+    margin-bottom: 2rem;
+  }
+  
+  .inputContainer {
+    flex-direction: column;
+    gap: 1.5rem;
+    max-width: 300px;
+  }
+  
+  .heroInput {
+    text-align: center;
+    font-size: 1rem;
+  }
+  
+  .heroButton {
+    align-self: center;
+  }
+}
+
+@media (max-width: 480px) {
+  .heroContainer {
+    padding: 2rem 1rem;
+  }
+  
+  .heroTitle {
+    font-size: 2rem;
+  }
+  
+  .heroSubtitle {
+    font-size: 1rem;
+  }
+}
+
+/* Dark theme specific adjustments */
+[data-theme="light"] .heroContainer {
+  background: linear-gradient(135deg, #f2eee1 0%, #e6dcc4 50%, #d4c4a8 100%);
+}
+
+[data-theme="light"] .heroTitle {
+  color: #1a1400;
+}
+
+[data-theme="light"] .heroSubtitle {
+  color: rgba(26, 20, 0, 0.7);
+}
+
+[data-theme="light"] .heroInput {
+  color: #1a1400;
+  border-bottom-color: rgba(26, 20, 0, 0.3);
+}
+
+[data-theme="light"] .heroInput::placeholder {
+  color: rgba(26, 20, 0, 0.5);
+}
+
+[data-theme="light"] .heroInput:focus {
+  border-bottom-color: #cc24c3;
+  box-shadow: 0 2px 0 0 rgba(204, 36, 195, 0.3);
+}
+
+[data-theme="light"] .heroButton {
+  border-color: rgba(26, 20, 0, 0.3);
+  color: #1a1400;
+}
+
+[data-theme="light"] .heroButton:hover:not(:disabled) {
+  border-color: #cc24c3;
+  background: rgba(204, 36, 195, 0.1);
+}
+
+[data-theme="light"] .loadingSpinner {
+  border-color: rgba(26, 20, 0, 0.3);
+  border-top-color: #cc24c3;
+}
+
+[data-theme="light"] .successMessage {
+  color: rgba(26, 20, 0, 0.7);
+}

--- a/barretenberg/docs/src/components/EmailSubscription/HeroSubscription.tsx
+++ b/barretenberg/docs/src/components/EmailSubscription/HeroSubscription.tsx
@@ -1,0 +1,167 @@
+import React, { useState } from 'react';
+import styles from './HeroSubscription.module.css';
+import { analytics } from '@site/src/utils/analytics';
+
+interface HeroSubscriptionProps {
+  title?: string;
+  subtitle?: string;
+  placeholder?: string;
+  source?: string;
+}
+
+export default function HeroSubscription({
+  title = "Build the future with Aztec",
+  subtitle = "",
+  placeholder = "Enter email",
+  source = "hero-footer"
+}: HeroSubscriptionProps) {
+  const [email, setEmail] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isSubscribed, setIsSubscribed] = useState(false);
+  const [successMessage, setSuccessMessage] = useState('');
+  const [error, setError] = useState('');
+
+  const validateEmail = (email: string): boolean => {
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    return emailRegex.test(email);
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    
+    if (!email.trim()) {
+      setError('Email address is required');
+      return;
+    }
+
+    if (!validateEmail(email)) {
+      setError('Please enter a valid email address');
+      return;
+    }
+
+    setError('');
+    setIsSubmitting(true);
+
+    try {
+      // Track subscription attempt
+      analytics.trackEvent('Email Subscription', 'Attempted', source);
+
+      // Call the real Brevo API endpoint
+      const response = await fetch('/.netlify/functions/subscribe', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          email: email.trim(),
+          source: source,
+          timestamp: Date.now(),
+          url: window.location.href
+        }),
+      });
+
+      const data = await response.json();
+
+      if (response.ok) {
+        if (data.alreadySubscribed) {
+          // Handle already subscribed case - show as success with different message
+          setIsSubscribed(true);
+          setSuccessMessage("It looks like you're already subscribed, good for you!");
+          setEmail('');
+
+          // Track already subscribed event
+          analytics.trackEvent('Email Subscription', 'Already Subscribed', source);
+        } else {
+          // Handle new subscription success
+          setIsSubscribed(true);
+          setSuccessMessage("You'll hear from us soon with the latest updates.");
+          setEmail('');
+
+          // Track successful subscription
+          analytics.trackEvent('Email Subscription', 'Successful', source);
+        }
+
+        console.log('✅ Subscription response:', data.message);
+      } else if (response.status === 429) {
+        // Rate limited
+        const retryAfter = data.retryAfter || 60;
+        const minutes = Math.ceil(retryAfter / 60);
+        throw new Error(`Please wait ${minutes} minute${minutes > 1 ? 's' : ''} before trying again.`);
+      } else {
+        throw new Error(data.error || 'Subscription failed');
+      }
+
+    } catch (err: any) {
+      console.error('Subscription error:', err);
+      setError(err.message || 'Failed to subscribe. Please try again.');
+
+      // Track subscription error
+      analytics.trackEvent('Email Subscription', 'Failed', source);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  if (isSubscribed) {
+    return (
+      <div className={styles.heroContainer}>
+        <div className={styles.heroContent}>
+          <div className={styles.successState}>
+            <h2 className={styles.heroTitle}>Thank you!</h2>
+            <p className={styles.successMessage}>{successMessage}</p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.heroContainer}>
+      <div className={styles.heroContent}>
+        <h2 className={styles.heroTitle}>{title}</h2>
+        {subtitle && <p className={styles.heroSubtitle}>{subtitle}</p>}
+        
+        <form onSubmit={handleSubmit} className={styles.heroForm}>
+          <div className={styles.inputContainer}>
+            <input
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder={placeholder}
+              className={styles.heroInput}
+              disabled={isSubmitting}
+              aria-label="Email address"
+            />
+            <button
+              type="submit"
+              disabled={isSubmitting || !email.trim()}
+              className={styles.heroButton}
+              aria-label="Subscribe"
+            >
+              {isSubmitting ? (
+                <div className={styles.loadingSpinner} />
+              ) : (
+                <svg 
+                  width="24" 
+                  height="24" 
+                  viewBox="0 0 24 24" 
+                  fill="none" 
+                  stroke="currentColor" 
+                  strokeWidth="2"
+                >
+                  <path d="M5 12h14M12 5l7 7-7 7"/>
+                </svg>
+              )}
+            </button>
+          </div>
+          
+          {error && (
+            <div className={styles.errorMessage} role="alert">
+              {error}
+            </div>
+          )}
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/barretenberg/docs/src/components/Matomo/matomo.jsx
+++ b/barretenberg/docs/src/components/Matomo/matomo.jsx
@@ -1,0 +1,126 @@
+import { useEffect, useState } from "react";
+import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
+import Link from "@docusaurus/Link";
+import { useLocation } from "@docusaurus/router";
+
+function getSiteId(env) {
+  // Different site IDs for Barretenberg docs
+  if (env == "dev") {
+    return "7"; // Barretenberg dev
+  } else if (env == "staging") {
+    return "8"; // Barretenberg staging
+  } else {
+    return "9"; // Barretenberg production
+  }
+}
+function pushInstruction(name, ...args) {
+  return window._paq.push([name, ...args]);
+}
+
+export default function useMatomo() {
+  const { siteConfig } = useDocusaurusContext();
+  const [showBanner, setShowBanner] = useState(false);
+  const location = useLocation();
+
+  const env = siteConfig.customFields.ENV;
+  const urlBase = "https://noirlang.matomo.cloud/";
+  const trackerUrl = `${urlBase}matomo.php`;
+  const srcUrl = `${urlBase}matomo.js`;
+
+  window._paq = window._paq || [];
+
+  useEffect(() => {
+    const storedConsent = localStorage.getItem("matomoConsent");
+    if (storedConsent === null) {
+      setShowBanner(true);
+    }
+  }, []);
+
+  useEffect(() => {
+    pushInstruction("setTrackerUrl", trackerUrl);
+    pushInstruction("setSiteId", getSiteId(env));
+    if (env !== "prod") {
+      pushInstruction("setSecureCookie", false);
+    }
+
+    const doc = document;
+    const scriptElement = doc.createElement("script");
+    const scripts = doc.getElementsByTagName("script")[0];
+
+    scriptElement.type = "text/javascript";
+    scriptElement.async = true;
+    scriptElement.defer = true;
+    scriptElement.src = srcUrl;
+
+    if (scripts && scripts.parentNode) {
+      scripts.parentNode.insertBefore(scriptElement, scripts);
+    }
+  }, []);
+
+  useEffect(() => {
+    pushInstruction("trackPageView");
+  }, [location]);
+
+  const optIn = () => {
+    pushInstruction("rememberConsentGiven");
+    localStorage.setItem("matomoConsent", true);
+    setShowBanner(false);
+  };
+
+  const optOut = () => {
+    pushInstruction("forgetConsentGiven");
+    localStorage.setItem("matomoConsent", false);
+    setShowBanner(false);
+  };
+  
+  // Add global debug function for console access
+  useEffect(() => {
+    if (env !== "prod" && typeof window !== 'undefined') {
+      window.forceNPS = () => {
+        const event = new CustomEvent('forceShowNPS');
+        window.dispatchEvent(event);
+        console.log('🔧 Forcing NPS widget to show');
+      };
+
+      // Clean up on unmount
+      return () => {
+        delete window.forceNPS;
+      };
+    }
+  }, [env]);
+
+  if (!showBanner) {
+    return null;
+  }
+
+  return (
+    <div id="optout-form">
+      <div className="homepage_footer">
+        <p>
+          We value your privacy and we only collect statistics and essential
+          cookies. If you'd like to help us improve our websites, you can allow
+          cookies for tracking page views, time on site, and other analytics.
+          <br />
+          <br />
+          <Link to="https://aztec.network/privacy-policy/">
+            Find out how we use cookies and how you can change your settings.
+          </Link>
+        </p>
+        <div className="homepage_cta_footer_container">
+          <button
+            className="cta-button button button--primary button--sm"
+            onClick={optIn}
+          >
+            I accept cookies
+          </button>
+          <button
+            className="cta-button button button--secondary button--sm"
+            onClick={optOut}
+          >
+            I refuse cookies
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/barretenberg/docs/src/components/NPSWidget/index.tsx
+++ b/barretenberg/docs/src/components/NPSWidget/index.tsx
@@ -1,0 +1,313 @@
+import React, { useState, useEffect } from 'react';
+import styles from './styles.module.css';
+import { analytics } from '@site/src/utils/analytics';
+
+interface NPSWidgetProps {
+  siteId?: string;
+  showAfterSeconds?: number;
+  scrollThreshold?: number;
+  pageViewsBeforeShow?: number;
+  timeOnPageBeforeShow?: number;
+}
+
+interface NPSData {
+  score: number;
+  feedback: string;
+  url: string;
+  timestamp: number;
+  userAgent: string;
+}
+
+// Research sources for timing best practices:
+// - https://www.asknicely.com/blog/timing-is-everything-whens-the-best-time-to-ask-for-customer-feedback
+// - https://survicate.com/blog/nps-best-practices/
+// - https://delighted.com/blog/when-to-send-your-nps-survey
+
+export default function NPSWidget({ 
+  siteId = 'barretenberg-docs',
+  showAfterSeconds = 180, // 3 minutes total session time (production default)
+  scrollThreshold = 50, // Show when 50% through content (production default)
+  pageViewsBeforeShow = 2, // Show after 2nd page view (production default)
+  timeOnPageBeforeShow = 120 // 2 minutes actively on current page (production default)
+}: NPSWidgetProps) {
+  const [score, setScore] = useState<number | null>(null);
+  const [feedback, setFeedback] = useState('');
+  const [isSubmitted, setIsSubmitted] = useState(false);
+  const [isVisible, setIsVisible] = useState(false);
+  const [isDismissed, setIsDismissed] = useState(false);
+  const [isAnimatingIn, setIsAnimatingIn] = useState(false);
+
+  // Force show NPS for debugging (listen for custom event)
+  useEffect(() => {
+    const handleForceNPS = () => {
+      console.log('🔧 Force showing NPS widget via event');
+      setIsVisible(true);
+      setTimeout(() => setIsAnimatingIn(true), 50);
+      
+      // Track as debug event
+      analytics.trackEvent('NPS Widget', 'Forced Show', window.location.pathname, 1);
+    };
+
+    window.addEventListener('forceShowNPS', handleForceNPS);
+    
+    return () => {
+      window.removeEventListener('forceShowNPS', handleForceNPS);
+    };
+  }, []);
+
+  // Check if user has already interacted with NPS
+  useEffect(() => {
+    const storageKey = `nps-${siteId}`;
+    const lastResponse = localStorage.getItem(storageKey);
+    
+    if (lastResponse) {
+      const responseData = JSON.parse(lastResponse);
+      const daysSinceResponse = (Date.now() - responseData.timestamp) / (1000 * 60 * 60 * 24);
+      
+      // Show again after 90 days
+      if (daysSinceResponse < 90) {
+        return;
+      }
+    }
+
+    // Check if user dismissed recently (don't show for 7 days)
+    const dismissedKey = `nps-dismissed-${siteId}`;
+    const lastDismissed = localStorage.getItem(dismissedKey);
+    if (lastDismissed) {
+      const daysSinceDismissed = (Date.now() - parseInt(lastDismissed)) / (1000 * 60 * 60 * 24);
+      if (daysSinceDismissed < 7) {
+        return;
+      }
+    }
+
+    // Track page views
+    const pageViewsKey = `nps-pageviews-${siteId}`;
+    const currentPageViews = parseInt(localStorage.getItem(pageViewsKey) || '0');
+    const newPageViews = currentPageViews + 1;
+    localStorage.setItem(pageViewsKey, newPageViews.toString());
+
+    // Don't show if not enough page views yet
+    if (newPageViews < pageViewsBeforeShow) {
+      return;
+    }
+
+    // Tracking variables for multiple conditions
+    let timeoutId: NodeJS.Timeout;
+    let timeOnPageId: NodeJS.Timeout;
+    let startTime = Date.now();
+    let hasShown = false;
+    let timeConditionMet = false;
+    let scrollConditionMet = false;
+    let timeOnPageConditionMet = false;
+    
+    const checkAllConditions = () => {
+      // Require BOTH scroll engagement AND time investment
+      if (scrollConditionMet && (timeConditionMet || timeOnPageConditionMet)) {
+        showWidget();
+      }
+    };
+    
+    const showWidget = () => {
+      if (hasShown) return;
+      hasShown = true;
+      setIsVisible(true);
+      
+      // Track widget shown event
+      analytics.trackEvent('NPS Widget', 'Shown', window.location.pathname, newPageViews);
+      
+      // Add animation delay
+      setTimeout(() => {
+        setIsAnimatingIn(true);
+      }, 50);
+    };
+
+    const handleScroll = () => {
+      const scrolled = (window.scrollY / (document.body.scrollHeight - window.innerHeight)) * 100;
+      if (scrolled > scrollThreshold && !scrollConditionMet) {
+        scrollConditionMet = true;
+        checkAllConditions();
+      }
+    };
+
+    const handleVisibilityChange = () => {
+      if (document.hidden) {
+        // User switched tabs/minimized - pause timer
+        startTime = Date.now();
+      }
+    };
+
+    // Condition 1: After specified time of total session
+    timeoutId = setTimeout(() => {
+      timeConditionMet = true;
+      checkAllConditions();
+    }, showAfterSeconds * 1000);
+
+    // Condition 2: After time actively on current page
+    timeOnPageId = setTimeout(() => {
+      if (!document.hidden && (Date.now() - startTime) >= timeOnPageBeforeShow * 1000) {
+        timeOnPageConditionMet = true;
+        checkAllConditions();
+      }
+    }, timeOnPageBeforeShow * 1000);
+
+    // Always listen for scroll
+    window.addEventListener('scroll', handleScroll);
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+
+    return () => {
+      clearTimeout(timeoutId);
+      clearTimeout(timeOnPageId);
+      window.removeEventListener('scroll', handleScroll);
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
+  }, [siteId, showAfterSeconds, scrollThreshold, pageViewsBeforeShow, timeOnPageBeforeShow]);
+
+  const handleScoreClick = (selectedScore: number) => {
+    setScore(selectedScore);
+  };
+
+  const handleSubmit = () => {
+    if (score === null) return;
+
+    const npsData: NPSData = {
+      score,
+      feedback,
+      url: window.location.href,
+      timestamp: Date.now(),
+      userAgent: navigator.userAgent,
+    };
+
+    // Store response to prevent showing again
+    localStorage.setItem(`nps-${siteId}`, JSON.stringify(npsData));
+
+    // Send to analytics (replace with your preferred service)
+    sendNPSData(npsData);
+    
+    setIsSubmitted(true);
+    
+    // Hide the widget after 4 seconds with animation
+    setTimeout(() => {
+      setIsAnimatingIn(false);
+      setTimeout(() => {
+        setIsVisible(false);
+      }, 300); // Wait for exit animation
+    }, 4000);
+  };
+
+  const handleClose = () => {
+    // Track dismissal
+    analytics.trackEvent('NPS Widget', 'Dismissed', window.location.pathname, score || 0);
+    
+    // Store dismissal to prevent showing for a week
+    localStorage.setItem(`nps-dismissed-${siteId}`, Date.now().toString());
+    setIsDismissed(true);
+    
+    // Animate out
+    setIsAnimatingIn(false);
+    setTimeout(() => {
+      setIsVisible(false);
+    }, 300);
+  };
+
+  // Get NPS category from score
+  const getNPSCategory = (score: number): 'promoter' | 'passive' | 'detractor' => {
+    if (score >= 9) return 'promoter';
+    if (score >= 7) return 'passive';
+    return 'detractor';
+  };
+
+  // Send NPS data using generic analytics
+  const sendNPSData = (data: NPSData) => {
+    const category = getNPSCategory(data.score);
+
+    // Console logging (for development and debugging)
+    console.group('📊 NPS Response Tracked');
+    console.table({
+      Score: data.score,
+      Category: category,
+      'Has Feedback': data.feedback.length > 0,
+      URL: data.url,
+      Timestamp: new Date(data.timestamp).toISOString()
+    });
+    if (data.feedback) {
+      console.log('💬 Feedback:', data.feedback);
+    }
+    console.groupEnd();
+
+    // Track using generic analytics methods
+    analytics.trackEvent('NPS Survey', 'Score Submitted', `Score ${data.score} (${category})`, data.score);
+    analytics.trackEvent('NPS Category', category.charAt(0).toUpperCase() + category.slice(1), window.location.pathname, data.score);
+
+    // Track feedback if provided
+    if (data.feedback && data.feedback.trim().length > 0) {
+      analytics.trackEvent('NPS Feedback', 'Feedback Provided', `${category} - ${data.feedback.slice(0, 100)}...`, data.feedback.length);
+    }
+
+    // Set custom dimensions for better analysis
+    // Dimension 1 = NPS Score
+    // Dimension 2 = NPS Category
+    analytics.trackCustomDimension(1, data.score.toString());
+    analytics.trackCustomDimension(2, category);
+
+    if (category === 'promoter') {
+      analytics.trackGoal(2);
+    }
+  };
+
+  if (!isVisible || isDismissed) return null;
+
+  return (
+    <div className={`${styles.npsWidget} ${isAnimatingIn ? styles.visible : styles.hidden}`}>
+      <div className={styles.npsWidgetContent}>
+        <button className={styles.npsCloseBtn} onClick={handleClose}>×</button>
+        
+        {!isSubmitted ? (
+          <div>
+            <h4>How likely are you to recommend this documentation to a friend or colleague?</h4>
+            
+            <div className={styles.npsScale}>
+              <div className={styles.npsScaleLabels}>
+                <span className={styles.npsScaleLabel}>Not at all likely</span>
+                <span className={styles.npsScaleLabel}>Extremely likely</span>
+              </div>
+              <div className={styles.npsScores}>
+                {[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10].map((num) => (
+                  <button
+                    key={num}
+                    className={`${styles.npsScoreBtn} ${score === num ? styles.selected : ''}`}
+                    onClick={() => handleScoreClick(num)}
+                  >
+                    {num}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            {score !== null && (
+              <div className={styles.npsFeedbackSection}>
+                <label htmlFor="nps-feedback">
+                  What's the main reason for your score?
+                </label>
+                <textarea
+                  id="nps-feedback"
+                  value={feedback}
+                  onChange={(e) => setFeedback(e.target.value)}
+                  placeholder="Optional: Help us understand your rating..."
+                  rows={3}
+                />
+                <button className={styles.npsSubmitBtn} onClick={handleSubmit}>
+                  Submit
+                </button>
+              </div>
+            )}
+          </div>
+        ) : (
+          <div className={styles.npsThankYou}>
+            <h4>Thank you for your feedback!</h4>
+            <p>Your input helps us improve our documentation.</p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/barretenberg/docs/src/components/NPSWidget/styles.module.css
+++ b/barretenberg/docs/src/components/NPSWidget/styles.module.css
@@ -1,0 +1,289 @@
+.npsWidget {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  background: white;
+  box-shadow: 0 2px 4px #0000000f;
+  padding: 20px;
+  max-width: 360px;
+  z-index: 1000;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  
+  /* Animation properties */
+  transition: all 0.4s cubic-bezier(0.34, 1.56, 0.64, 1);
+  transform: translateY(100px) scale(0.8);
+  opacity: 0;
+  visibility: hidden;
+}
+
+.npsWidget.visible {
+  transform: translateY(0) scale(1);
+  opacity: 1;
+  visibility: visible;
+}
+
+.npsWidget.hidden {
+  transform: translateY(20px) scale(0.95);
+  opacity: 0;
+  visibility: hidden;
+  transition: all 0.3s ease-in-out;
+}
+
+[data-theme='dark'] .npsWidget {
+  background: #242526;
+  border-color: #444950;
+  color: #e3e3e3;
+}
+
+.npsWidgetContent {
+  position: relative;
+}
+
+.npsCloseBtn {
+  position: absolute;
+  top: -8px;
+  right: -8px;
+  background: #6c757d;
+  color: white;
+  border: none;
+  width: 20px;
+  height: 20px;
+  cursor: pointer;
+  font-size: 12px;
+  line-height: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.npsCloseBtn:hover {
+  background: #5a6268;
+}
+
+[data-theme='dark'] .npsCloseBtn {
+  background: #5a5a5a;
+}
+
+[data-theme='dark'] .npsCloseBtn:hover {
+  background: #666;
+}
+
+.npsWidget h4 {
+  margin: 0 0 16px 0;
+  font-size: 15px;
+  font-weight: 500;
+  line-height: 1.4;
+  color: #1c1e21;
+}
+
+[data-theme='dark'] .npsWidget h4 {
+  color: #e3e3e3;
+}
+
+.npsScale {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-bottom: 16px;
+}
+
+.npsScaleLabels {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 4px;
+}
+
+.npsScores {
+  display: flex;
+  gap: 3px;
+  justify-content: space-between;
+}
+
+.npsScoreBtn {
+  background: #f8f9fa;
+  border: 1px solid #dee2e6;
+  width: 30px;
+  height: 30px;
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 500;
+  transition: all 0.15s ease;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #495057;
+}
+
+.npsScoreBtn:hover {
+  border-color: #adb5bd;
+  background: #e9ecef;
+}
+
+.npsScoreBtn.selected {
+  border-color: #495057;
+  background: #495057;
+  color: white;
+}
+
+[data-theme='dark'] .npsScoreBtn {
+  background: #3a3b3c;
+  border-color: #5a5a5a;
+  color: #e3e3e3;
+}
+
+[data-theme='dark'] .npsScoreBtn:hover {
+  border-color: #666;
+  background: #4a4b4c;
+}
+
+[data-theme='dark'] .npsScoreBtn.selected {
+  border-color: #e3e3e3;
+  background: #e3e3e3;
+  color: #1c1e21;
+}
+
+.npsScaleLabel {
+  font-size: 11px;
+  color: #6c757d;
+  text-align: center;
+  font-weight: 400;
+}
+
+[data-theme='dark'] .npsScaleLabel {
+  color: #b0b3b8;
+}
+
+.npsFeedbackSection {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-top: 16px;
+  padding-top: 16px;
+  border-top: 1px solid #e1e5e9;
+}
+
+[data-theme='dark'] .npsFeedbackSection {
+  border-top-color: #444950;
+}
+
+.npsFeedbackSection label {
+  font-size: 13px;
+  font-weight: 500;
+  color: #1c1e21;
+  margin: 0;
+}
+
+[data-theme='dark'] .npsFeedbackSection label {
+  color: #e3e3e3;
+}
+
+.npsFeedbackSection textarea {
+  border: 1px solid #dee2e6;
+  padding: 8px 10px;
+  font-size: 13px;
+  resize: vertical;
+  min-height: 60px;
+  font-family: inherit;
+  background: #fff;
+  color: #495057;
+}
+
+.npsFeedbackSection textarea:focus {
+  outline: none;
+  border-color: #86b7fe;
+  box-shadow: 0 0 0 0.2rem rgba(13, 110, 253, 0.25);
+}
+
+.npsFeedbackSection textarea::placeholder {
+  color: #6c757d;
+}
+
+[data-theme='dark'] .npsFeedbackSection textarea {
+  background: #3a3b3c;
+  border-color: #5a5a5a;
+  color: #e3e3e3;
+}
+
+[data-theme='dark'] .npsFeedbackSection textarea:focus {
+  border-color: #66a3ff;
+  box-shadow: 0 0 0 0.2rem rgba(102, 163, 255, 0.25);
+}
+
+[data-theme='dark'] .npsFeedbackSection textarea::placeholder {
+  color: #b0b3b8;
+}
+
+.npsSubmitBtn {
+  background: #495057;
+  color: white;
+  border: none;
+  padding: 6px 16px;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  align-self: flex-start;
+  transition: background-color 0.15s ease;
+}
+
+.npsSubmitBtn:hover {
+  background: #3d4347;
+}
+
+.npsSubmitBtn:disabled {
+  background: #6c757d;
+  cursor: not-allowed;
+}
+
+[data-theme='dark'] .npsSubmitBtn {
+  background: #e3e3e3;
+  color: #1c1e21;
+}
+
+[data-theme='dark'] .npsSubmitBtn:hover {
+  background: #d0d0d0;
+}
+
+.npsThankYou {
+  text-align: center;
+}
+
+.npsThankYou h4 {
+  color: #1c1e21;
+  margin-bottom: 8px;
+}
+
+.npsThankYou p {
+  margin: 0;
+  font-size: 13px;
+  color: #6c757d;
+}
+
+[data-theme='dark'] .npsThankYou h4 {
+  color: #e3e3e3;
+}
+
+[data-theme='dark'] .npsThankYou p {
+  color: #b0b3b8;
+}
+
+/* Mobile responsiveness */
+@media (max-width: 768px) {
+  .npsWidget {
+    bottom: 16px;
+    right: 16px;
+    left: 16px;
+    max-width: none;
+    padding: 16px;
+  }
+  
+  .npsScores {
+    gap: 2px;
+  }
+  
+  .npsScoreBtn {
+    width: 28px;
+    height: 28px;
+    font-size: 12px;
+  }
+}

--- a/barretenberg/docs/src/theme/Footer/Footer.module.css
+++ b/barretenberg/docs/src/theme/Footer/Footer.module.css
@@ -1,0 +1,203 @@
+/* Integrated Footer with Email Subscription - preserving original Docusaurus styles */
+
+.footerGrid {
+  display: grid;
+  grid-template-columns: 2fr 3fr;
+  gap: 3rem;
+  align-items: start;
+  padding: 2rem 0;
+}
+
+/* Left side - Email subscription */
+.footerLeft {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.footerTitle {
+  font-family: "Oracle", sans-serif;
+  font-size: 1.6rem;
+  font-weight: 600;
+  color: var(--ifm-footer-title-color);
+  margin: 0;
+  line-height: 1.3;
+  letter-spacing: -0.01em;
+}
+
+.subscriptionForm {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.inputContainer {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  border-bottom: 2px solid var(--ifm-color-primary-lightest);
+  padding-bottom: 0.4rem;
+  transition: border-color 0.3s ease;
+}
+
+.inputContainer:focus-within {
+  border-bottom-color: var(--ifm-link-color);
+}
+
+.emailInput {
+  flex: 1;
+  background: transparent;
+  border: none;
+  padding: 0.6rem 0;
+  font-size: 0.95rem;
+  font-family: "Oracle", sans-serif;
+  color: var(--ifm-footer-color);
+  outline: none;
+}
+
+.emailInput::placeholder {
+  color: var(--ifm-color-emphasis-600);
+  opacity: 0.8;
+}
+
+.submitButton {
+  background: transparent;
+  border: none;
+  color: var(--ifm-footer-color);
+  cursor: pointer;
+  padding: 0.5rem;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.3s ease;
+  opacity: 0.7;
+}
+
+.submitButton:hover:not(:disabled) {
+  opacity: 1;
+  color: var(--ifm-link-color);
+  transform: translateX(4px);
+}
+
+.submitButton:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+  transform: none;
+}
+
+.spinner {
+  width: 16px;
+  height: 16px;
+  border: 2px solid var(--ifm-color-secondary);
+  border-top: 2px solid var(--ifm-link-color);
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}
+
+.successMessage {
+  color: var(--ifm-color-success);
+  font-weight: 500;
+}
+
+.successMessage p {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.errorMessage {
+  color: #ff6b6b;
+  font-size: 0.85rem;
+  margin-top: 0.75rem;
+  line-height: 1.4;
+}
+
+/* Right side - Original Docusaurus footer navigation (no custom styling needed) */
+.footerRight {
+  /* Let Docusaurus handle the original footer styling */
+}
+
+/* Responsive design */
+@media (max-width: 996px) {
+  .footerGrid {
+    grid-template-columns: 1fr;
+    gap: 3rem;
+  }
+  
+  .footerTitle {
+    font-size: 1.75rem;
+  }
+}
+
+@media (max-width: 768px) {
+  .footerGrid {
+    gap: 2.5rem;
+  }
+  
+  .footerTitle {
+    font-size: 1.5rem;
+  }
+  
+  .inputContainer {
+    gap: 0.75rem;
+  }
+  
+  .emailInput {
+    font-size: 0.95rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .footerTitle {
+    font-size: 1.3rem;
+  }
+}
+
+/* Dark theme specific adjustments */
+[data-theme="dark"] .inputContainer {
+  border-bottom-color: var(--ifm-color-primary-dark);
+}
+
+[data-theme="dark"] .inputContainer:focus-within {
+  border-bottom-color: var(--ifm-link-color);
+}
+
+[data-theme="dark"] .submitButton:hover:not(:disabled) {
+  color: var(--ifm-link-hover-color);
+}
+
+/* Light theme specific adjustments */
+[data-theme="light"] .footerTitle {
+  color: var(--ifm-color-primary);
+}
+
+[data-theme="light"] .sectionTitle {
+  color: var(--ifm-color-primary);
+}
+
+[data-theme="light"] .inputContainer {
+  border-bottom-color: var(--ifm-color-primary-lightest);
+}
+
+[data-theme="light"] .inputContainer:focus-within {
+  border-bottom-color: var(--ifm-link-color);
+}
+
+[data-theme="light"] .submitButton:hover:not(:disabled) {
+  color: var(--ifm-link-hover-color);
+}
+
+[data-theme="light"] .emailInput::placeholder {
+  color: var(--ifm-color-emphasis-700);
+  opacity: 0.7;
+}
+
+[data-theme="dark"] .emailInput::placeholder {
+  color: var(--ifm-color-emphasis-500);
+  opacity: 0.9;
+}

--- a/barretenberg/docs/src/theme/Footer/index.js
+++ b/barretenberg/docs/src/theme/Footer/index.js
@@ -1,0 +1,210 @@
+import React, { useState } from 'react';
+import Footer from '@theme-original/Footer';
+import styles from './Footer.module.css';
+import { isValidEmail } from '@site/src/utils/emailValidation';
+import { analytics } from '@site/src/utils/analytics';
+
+// External link icon component
+const ExternalLinkIcon = () => (
+  <svg width="13.5" height="13.5" aria-hidden="true" viewBox="0 0 24 24" className="iconExternalLink_nPIU">
+    <path fill="currentColor" d="M21 13v10h-21v-19h12v2h-10v15h17v-8h2zm3-12h-10.988l4.035 4-6.977 7.07 2.828 2.828 6.977-7.07 4.125 4.172v-11z"/>
+  </svg>
+);
+
+export default function FooterWrapper(props) {
+  const [email, setEmail] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isSubscribed, setIsSubscribed] = useState(false);
+  const [successMessage, setSuccessMessage] = useState('');
+  const [error, setError] = useState('');
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    
+    // Clear previous messages
+    setError('');
+
+    if (!email.trim()) {
+      setError('Email address is required');
+      return;
+    }
+
+    // Validate email using marketing's validation logic
+    if (!isValidEmail(email)) {
+      setError('Please provide a valid email address');
+      return;
+    }
+
+    setIsSubmitting(true);
+    
+    try {
+      // Track subscription attempt
+      analytics.trackEvent('Email Subscription', 'Attempted', 'footer');
+
+      // Call the real Brevo API endpoint
+      const response = await fetch('/.netlify/functions/subscribe', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ 
+          email: email.trim(),
+          source: 'docs-footer',
+          timestamp: Date.now(),
+          url: window.location.href
+        }),
+      });
+
+      const data = await response.json();
+
+      if (response.ok) {
+        if (data.alreadySubscribed) {
+          // Handle already subscribed case - show as success with different message
+          setIsSubscribed(true);
+          setSuccessMessage("It looks like you're already subscribed, good for you! 🎉");
+          setEmail('');
+
+          // Track already subscribed event
+          analytics.trackEvent('Email Subscription', 'Already Subscribed', 'footer');
+        } else {
+          // Handle new subscription success
+          setIsSubscribed(true);
+          setSuccessMessage("Thanks for subscribing! 🎉");
+          setEmail('');
+
+          // Track successful subscription
+          analytics.trackEvent('Email Subscription', 'Successful', 'footer');
+        }
+
+        console.log('✅ Subscription response:', data.message);
+      } else if (response.status === 429) {
+        // Rate limited
+        const retryAfter = data.retryAfter || 60;
+        const minutes = Math.ceil(retryAfter / 60);
+        throw new Error(`Please wait ${minutes} minute${minutes > 1 ? 's' : ''} before trying again.`);
+      } else {
+        throw new Error(data.error || 'Subscription failed');
+      }
+      
+    } catch (err) {
+      console.error('Subscription error:', err);
+      setError(err.message || 'Failed to subscribe. Please try again.');
+      
+      // Track subscription error
+      analytics.trackEvent('Email Subscription', 'Failed', 'footer');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <footer className="footer footer--dark">
+      <div className="container">
+        <div className={styles.footerGrid}>
+          
+          {/* Left side - Email subscription */}
+          <div className={styles.footerLeft}>
+            <h3 className={styles.footerTitle}>Build the future with Aztec</h3>
+            
+            {isSubscribed ? (
+              <div className={styles.successMessage}>
+                <p>{successMessage}</p>
+              </div>
+            ) : (
+              <form onSubmit={handleSubmit} className={styles.subscriptionForm}>
+                <div className={styles.inputContainer}>
+                  <input
+                    type="email"
+                    value={email}
+                    onChange={(e) => setEmail(e.target.value)}
+                    placeholder="Enter email"
+                    className={styles.emailInput}
+                    disabled={isSubmitting}
+                  />
+                  <button
+                    type="submit"
+                    disabled={isSubmitting || !email.trim()}
+                    className={styles.submitButton}
+                  >
+                    {isSubmitting ? (
+                      <div className={styles.spinner} />
+                    ) : (
+                      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                        <path d="M5 12h14M12 5l7 7-7 7"/>
+                      </svg>
+                    )}
+                  </button>
+                </div>
+                {error && (
+                  <div className={styles.errorMessage}>
+                    {error}
+                  </div>
+                )}
+              </form>
+            )}
+          </div>
+
+          {/* Right side - Original Barretenberg footer content */}
+          <div className={styles.footerRight}>
+            <div className="row footer__links">
+              <div className="col footer__col">
+                <div className="footer__title">Community</div>
+                <ul className="footer__items clean-list">
+                  <li className="footer__item">
+                    <a className="footer__link-item" href="https://forum.aztec.network">
+                      Forum
+                      <ExternalLinkIcon />
+                    </a>
+                  </li>
+                  <li className="footer__item">
+                    <a className="footer__link-item" href="https://discord.com/invite/aztec">
+                      Discord
+                      <ExternalLinkIcon />
+                    </a>
+                  </li>
+                  <li className="footer__item">
+                    <a className="footer__link-item" href="https://x.com/aztecnetwork">
+                      X (Twitter)
+                      <ExternalLinkIcon />
+                    </a>
+                  </li>
+                </ul>
+              </div>
+
+              <div className="col footer__col">
+                <div className="footer__title">More</div>
+                <ul className="footer__items clean-list">
+                  <li className="footer__item">
+                    <a className="footer__link-item" href="https://github.com/AztecProtocol">
+                      GitHub
+                      <ExternalLinkIcon />
+                    </a>
+                  </li>
+                  <li className="footer__item">
+                    <a className="footer__link-item" href="https://github.com/AztecProtocol/awesome-aztec">
+                      Awesome Aztec
+                      <ExternalLinkIcon />
+                    </a>
+                  </li>
+                  <li className="footer__item">
+                    <a className="footer__link-item" href="https://aztec.network/grants">
+                      Grants
+                      <ExternalLinkIcon />
+                    </a>
+                  </li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+        
+        {/* Bottom copyright - using original Docusaurus styling */}
+        <div className="footer__bottom text--center">
+          <div className="footer__copyright">
+            © {new Date().getFullYear()} Aztec Labs. Built with privacy in mind.
+          </div>
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/barretenberg/docs/src/theme/Root.js
+++ b/barretenberg/docs/src/theme/Root.js
@@ -1,17 +1,44 @@
 import React from "react";
 import BrowserOnly from "@docusaurus/BrowserOnly";
 import useIsBrowser from "@docusaurus/useIsBrowser";
-// import AskCookbook from "@cookbookdev/docsbot/react";
-
-// /** It's a public API key, so it's safe to expose it here. */
-// const COOKBOOK_PUBLIC_API_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI2NmIyOWRmZDM3ZWIwYzRiMTVlZGYzMDAiLCJpYXQiOjE3MjI5ODE4ODUsImV4cCI6MjAzODU1Nzg4NX0.19rsZIFNmgVEbpmDjEJ8oPnL7uHYePytf-Ex1pjm2_8';
+import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
+import { AnalyticsManager } from "../utils/analytics";
+import MatomoTracking from "../components/Matomo/matomo";
+import NPSWidget from "../components/NPSWidget";
 
 export default function Root({ children }) {
   const useIsBrowserValue = useIsBrowser();
+  const { siteConfig } = useDocusaurusContext();
+
   if (!useIsBrowserValue) return <>{children}</>;
+
+  // Initialize analytics when in browser
+  if (typeof window !== 'undefined' && !window.analytics) {
+    const analytics = new AnalyticsManager({
+      env: siteConfig.customFields.ENV
+    });
+    window.analytics = analytics;
+
+    // Add global debug function for non-production environments
+    if (siteConfig.customFields.ENV !== "prod") {
+      window.forceNPS = () => {
+        const event = new CustomEvent('forceShowNPS');
+        window.dispatchEvent(event);
+        console.log('🔧 Forcing NPS widget to show');
+      };
+    }
+  }
 
   return (
     <>
+      <BrowserOnly>
+        {() => (
+          <>
+            <MatomoTracking />
+            <NPSWidget />
+          </>
+        )}
+      </BrowserOnly>
       {children}
     </>
   );

--- a/barretenberg/docs/src/types/global.d.ts
+++ b/barretenberg/docs/src/types/global.d.ts
@@ -1,0 +1,22 @@
+// Global type declarations for Aztec Docs
+
+declare global {
+  interface Window {
+    _paq?: Array<Array<string | number | boolean | null>>;
+    analytics?: {
+      trackEvent: (category: string, action: string, name?: string, value?: number) => void;
+      trackCustomDimension: (index: number, value: string) => void;
+      trackGoal: (goalId: number, customRevenue?: number) => void;
+    };
+  }
+}
+
+// Matomo tracking interface
+export interface MatomoTracker {
+  push: (instruction: Array<string | number | boolean | null>) => void;
+  trackEvent: (category: string, action: string, name?: string, value?: number) => void;
+  trackGoal: (goalId: number, customRevenue?: number) => void;
+  trackCustomDimension: (index: number, value: string) => void;
+}
+
+export {};

--- a/barretenberg/docs/src/utils/analytics.ts
+++ b/barretenberg/docs/src/utils/analytics.ts
@@ -1,0 +1,116 @@
+// Generic Analytics utilities for Aztec Docs
+// Provides type-safe Matomo integration with fallback handling
+
+interface AnalyticsConfig {
+  enableConsoleLogging?: boolean;
+  enableMatomo?: boolean;
+  requireConsent?: boolean;
+  env?: string; // Environment from siteConfig
+}
+
+class AnalyticsManager {
+  private config: AnalyticsConfig;
+  
+  constructor(config: AnalyticsConfig = {}) {
+    this.config = {
+      enableConsoleLogging: config.env !== 'prod',
+      enableMatomo: true,
+      requireConsent: true,
+      ...config
+    };
+  }
+
+  /**
+   * Check if Matomo is available and user has consented
+   */
+  private isMatomoAvailable(): boolean {
+    if (!this.config.enableMatomo) return false;
+    
+    // Check if _paq exists
+    if (typeof window === 'undefined' || !window._paq) return false;
+    
+    // Check consent if required
+    if (this.config.requireConsent) {
+      const consent = localStorage.getItem("matomoConsent");
+      return consent === "true";
+    }
+    
+    return true;
+  }
+
+  /**
+   * Track custom dimension in Matomo
+   */
+  trackCustomDimension(index: number, value: string): void {
+    if (this.config.enableConsoleLogging) {
+      console.log(`📊 Custom Dimension: ${index} = ${value}`);
+    }
+
+    if (this.isMatomoAvailable()) {
+      try {
+        window._paq!.push(['setCustomDimension', index, value]);
+      } catch (error) {
+        console.warn('Matomo custom dimension tracking failed:', error);
+      }
+    } else {
+      if (this.config.enableConsoleLogging) {
+        console.warn('Analytics not available (no consent or blocked by adblocker)');
+      }
+    }
+  }
+
+  /**
+   * Track goal completion in Matomo
+   */
+  trackGoal(goalId: number, customRevenue?: number): void {
+    if (this.config.enableConsoleLogging) {
+      console.log(`🎯 Goal: ${goalId}`, customRevenue ? `(customRevenue: ${customRevenue})` : '');
+    }
+
+    if (this.isMatomoAvailable()) {
+      try {
+        window._paq!.push(['trackGoal', goalId, customRevenue || undefined]);
+      } catch (error) {
+        console.warn('Matomo goal tracking failed:', error);
+      }
+    } else {
+      if (this.config.enableConsoleLogging) {
+        console.warn('Analytics not available (no consent or blocked by adblocker)');
+      }
+    }
+  }
+
+  /**
+   * Generic event tracking method
+   */
+  trackEvent(category: string, action: string, name?: string, value?: number): void {
+    if (this.config.enableConsoleLogging) {
+      console.log(`📊 Event: ${category} > ${action}`, { name, value });
+    }
+
+    if (this.isMatomoAvailable()) {
+      try {
+        window._paq!.push([
+          'trackEvent',
+          category,
+          action,
+          name || undefined,
+          value || undefined
+        ]);
+      } catch (error) {
+        console.warn('Matomo event tracking failed:', error);
+      }
+    } else {
+      if (this.config.enableConsoleLogging) {
+        console.warn('Analytics not available (no consent or blocked by adblocker)');
+      }
+    }
+  }
+}
+
+// Export class and singleton instance
+export { AnalyticsManager };
+export const analytics = new AnalyticsManager();
+
+// Export types
+export type { AnalyticsConfig };

--- a/barretenberg/docs/src/utils/emailValidation.js
+++ b/barretenberg/docs/src/utils/emailValidation.js
@@ -1,0 +1,32 @@
+// Email validation utility for frontend (ES modules)
+export function isValidEmail(email) {
+  // RFC 5322 compliant email regex (simplified but robust)
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  
+  if (!email || typeof email !== 'string') {
+    return false;
+  }
+  
+  // Basic format check
+  if (!emailRegex.test(email)) {
+    return false;
+  }
+  
+  // Length checks (RFC 5321)
+  if (email.length > 254) {
+    return false;
+  }
+  
+  // Local part (before @) should be max 64 chars
+  const [localPart, domain] = email.split('@');
+  if (localPart.length > 64) {
+    return false;
+  }
+  
+  // Domain part checks
+  if (domain.length > 253) {
+    return false;
+  }
+  
+  return true;
+}

--- a/barretenberg/docs/yarn.lock
+++ b/barretenberg/docs/yarn.lock
@@ -2853,6 +2853,38 @@
   resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.25.6.tgz#4276edd5c105bc28b11c6a1f76fb9d29d1bd25c1"
   integrity sha512-NgJPHHbEpLQgDH2MjQu90pzW/5vvXIZ7KOnPyNBm92A6WgZ/7b6fJyUBjoumLqeOQQGqY2QjQxRo97ah4Sj0cA==
 
+"@eslint-community/eslint-utils@^4.2.0":
+  version "4.9.0"
+  resolved "https://registry.yarnpkg.com/@eslint-community/eslint-utils/-/eslint-utils-4.9.0.tgz#7308df158e064f0dd8b8fdb58aa14fa2a7f913b3"
+  integrity sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==
+  dependencies:
+    eslint-visitor-keys "^3.4.3"
+
+"@eslint-community/regexpp@^4.6.1":
+  version "4.12.1"
+  resolved "https://registry.yarnpkg.com/@eslint-community/regexpp/-/regexpp-4.12.1.tgz#cfc6cffe39df390a3841cde2abccf92eaa7ae0e0"
+  integrity sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==
+
+"@eslint/eslintrc@^2.1.4":
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-2.1.4.tgz#388a269f0f25c1b6adc317b5a2c55714894c70ad"
+  integrity sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==
+  dependencies:
+    ajv "^6.12.4"
+    debug "^4.3.2"
+    espree "^9.6.0"
+    globals "^13.19.0"
+    ignore "^5.2.0"
+    import-fresh "^3.2.1"
+    js-yaml "^4.1.0"
+    minimatch "^3.1.2"
+    strip-json-comments "^3.1.1"
+
+"@eslint/js@8.57.1":
+  version "8.57.1"
+  resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.57.1.tgz#de633db3ec2ef6a3c89e2f19038063e8a122e2c2"
+  integrity sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==
+
 "@fastify/accept-negotiator@^1.0.0", "@fastify/accept-negotiator@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@fastify/accept-negotiator/-/accept-negotiator-1.1.0.tgz#c1c66b3b771c09742a54dd5bc87c582f6b0630ff"
@@ -2914,6 +2946,15 @@
     fastq "^1.17.0"
     glob "^10.3.4"
 
+"@getbrevo/brevo@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@getbrevo/brevo/-/brevo-3.0.1.tgz#e28470aea29ad49fd37a6e583b394b85abe7cb43"
+  integrity sha512-BS5hlgb9qPHhXqjV+VbEOciygnsEVZV8BgoX+JYpD+I+R9u3U05y/euqdmk8nATfcEUCUlQq+aWdWOWTF4cEjQ==
+  dependencies:
+    axios "^1.6.8"
+    bluebird "^3.5.0"
+    rewire "^7.0.0"
+
 "@hapi/hoek@^9.0.0", "@hapi/hoek@^9.3.0":
   version "9.3.0"
   resolved "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz"
@@ -2926,10 +2967,29 @@
   dependencies:
     "@hapi/hoek" "^9.0.0"
 
+"@humanwhocodes/config-array@^0.13.0":
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.13.0.tgz#fb907624df3256d04b9aa2df50d7aa97ec648748"
+  integrity sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==
+  dependencies:
+    "@humanwhocodes/object-schema" "^2.0.3"
+    debug "^4.3.1"
+    minimatch "^3.0.5"
+
+"@humanwhocodes/module-importer@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz#af5b2691a22b44be847b0ca81641c5fb6ad0172c"
+  integrity sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==
+
 "@humanwhocodes/momoa@^2.0.2":
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/momoa/-/momoa-2.0.4.tgz#8b9e7a629651d15009c3587d07a222deeb829385"
   integrity sha512-RE815I4arJFtt+FVeU1Tgp9/Xvecacji8w/V6XtXsWWH/wz/eNkNbhb+ny/+PlVZjV0rxQpRSQKNKE3lcktHEA==
+
+"@humanwhocodes/object-schema@^2.0.3":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz#4a2868d75d6d6963e423bcf90b7fd1be343409d3"
+  integrity sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==
 
 "@iarna/toml@^2.2.5":
   version "2.2.5"
@@ -4115,7 +4175,7 @@
   resolved "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz"
   integrity sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==
 
-"@nodelib/fs.walk@^1.2.3":
+"@nodelib/fs.walk@^1.2.3", "@nodelib/fs.walk@^1.2.8":
   version "1.2.8"
   resolved "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz"
   integrity sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==
@@ -5182,7 +5242,7 @@
     "@typescript-eslint/types" "8.36.0"
     eslint-visitor-keys "^4.2.1"
 
-"@ungap/structured-clone@^1.0.0":
+"@ungap/structured-clone@^1.0.0", "@ungap/structured-clone@^1.2.0":
   version "1.3.0"
   resolved "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz"
   integrity sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==
@@ -5554,7 +5614,7 @@ acorn-import-attributes@^1.9.5:
   resolved "https://registry.yarnpkg.com/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz#7eb1557b1ba05ef18b5ed0ec67591bfab04688ef"
   integrity sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==
 
-acorn-jsx@^5.0.0:
+acorn-jsx@^5.0.0, acorn-jsx@^5.3.2:
   version "5.3.2"
   resolved "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
@@ -5571,7 +5631,7 @@ acorn@^8.0.0, acorn@^8.0.4, acorn@^8.11.0, acorn@^8.14.0, acorn@^8.8.2:
   resolved "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz"
   integrity sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==
 
-acorn@^8.4.1, acorn@^8.6.0:
+acorn@^8.4.1, acorn@^8.6.0, acorn@^8.9.0:
   version "8.15.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.15.0.tgz#a360898bc415edaac46c8241f6383975b930b816"
   integrity sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==
@@ -5640,7 +5700,7 @@ ajv-keywords@^5.1.0:
   dependencies:
     fast-deep-equal "^3.1.3"
 
-ajv@^6.12.2, ajv@^6.12.5:
+ajv@^6.12.2, ajv@^6.12.4, ajv@^6.12.5:
   version "6.12.6"
   resolved "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz"
   integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
@@ -6021,6 +6081,15 @@ avvio@^8.3.0:
     "@fastify/error" "^3.3.0"
     fastq "^1.17.1"
 
+axios@^1.6.8:
+  version "1.12.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.12.2.tgz#6c307390136cf7a2278d09cec63b136dfc6e6da7"
+  integrity sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==
+  dependencies:
+    follow-redirects "^1.15.6"
+    form-data "^4.0.4"
+    proxy-from-env "^1.1.0"
+
 axios@^1.8.3:
   version "1.8.3"
   resolved "https://registry.npmjs.org/axios/-/axios-1.8.3.tgz"
@@ -6187,6 +6256,11 @@ bl@^4.0.3, bl@^4.1.0:
     buffer "^5.5.0"
     inherits "^2.0.4"
     readable-stream "^3.4.0"
+
+bluebird@^3.5.0:
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
+  integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
 
 blueimp-md5@^2.10.0:
   version "2.19.0"
@@ -7262,7 +7336,7 @@ cron-parser@4.9.0, cron-parser@^4.1.0:
   dependencies:
     luxon "^3.2.1"
 
-cross-spawn@^7.0.3, cross-spawn@^7.0.6:
+cross-spawn@^7.0.2, cross-spawn@^7.0.3, cross-spawn@^7.0.6:
   version "7.0.6"
   resolved "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz"
   integrity sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==
@@ -7519,6 +7593,13 @@ debug@^4, debug@^4.0.1, debug@^4.3.4, debug@^4.3.5:
   dependencies:
     ms "^2.1.3"
 
+debug@^4.3.2:
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.3.tgz#c6ae432d9bd9662582fce08709b038c58e9e3d6a"
+  integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
+  dependencies:
+    ms "^2.1.3"
+
 decache@4.6.2, decache@^4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/decache/-/decache-4.6.2.tgz#c1df1325a2f36d53922e08f33380f083148199cd"
@@ -7556,6 +7637,11 @@ deep-extend@^0.6.0:
   version "0.6.0"
   resolved "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz"
   integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
+
+deep-is@^0.1.3:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.4.tgz#a6f2dce612fadd2ef1f519b73551f17e85199831"
+  integrity sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
 
 deepmerge@^4.2.2, deepmerge@^4.3.1:
   version "4.3.1"
@@ -7888,6 +7974,13 @@ dns-packet@^5.2.2:
   integrity sha512-l4gcSouhcgIKRvyy99RNVOgxXiicE+2jZoNmaNmZ6JXiGajBOJAesk1OBlJuM5k2c+eudGdLxDqXuPCKIj6kpw==
   dependencies:
     "@leichtgewicht/ip-codec" "^2.0.1"
+
+doctrine@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-3.0.0.tgz#addebead72a6574db783639dc87a121773973961"
+  integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
+  dependencies:
+    esutils "^2.0.2"
 
 dom-converter@^0.2.0:
   version "0.2.0"
@@ -8437,7 +8530,15 @@ eslint-scope@5.1.1:
     esrecurse "^4.3.0"
     estraverse "^4.1.1"
 
-eslint-visitor-keys@^3.3.0:
+eslint-scope@^7.2.2:
+  version "7.2.2"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-7.2.2.tgz#deb4f92563390f32006894af62a22dba1c46423f"
+  integrity sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==
+  dependencies:
+    esrecurse "^4.3.0"
+    estraverse "^5.2.0"
+
+eslint-visitor-keys@^3.3.0, eslint-visitor-keys@^3.4.1, eslint-visitor-keys@^3.4.3:
   version "3.4.3"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz#0cd72fe8550e3c2eae156a96a4dddcd1c8ac5800"
   integrity sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==
@@ -8447,10 +8548,70 @@ eslint-visitor-keys@^4.2.1:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz#4cfea60fe7dd0ad8e816e1ed026c1d5251b512c1"
   integrity sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==
 
+eslint@^8.47.0:
+  version "8.57.1"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.57.1.tgz#7df109654aba7e3bbe5c8eae533c5e461d3c6ca9"
+  integrity sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==
+  dependencies:
+    "@eslint-community/eslint-utils" "^4.2.0"
+    "@eslint-community/regexpp" "^4.6.1"
+    "@eslint/eslintrc" "^2.1.4"
+    "@eslint/js" "8.57.1"
+    "@humanwhocodes/config-array" "^0.13.0"
+    "@humanwhocodes/module-importer" "^1.0.1"
+    "@nodelib/fs.walk" "^1.2.8"
+    "@ungap/structured-clone" "^1.2.0"
+    ajv "^6.12.4"
+    chalk "^4.0.0"
+    cross-spawn "^7.0.2"
+    debug "^4.3.2"
+    doctrine "^3.0.0"
+    escape-string-regexp "^4.0.0"
+    eslint-scope "^7.2.2"
+    eslint-visitor-keys "^3.4.3"
+    espree "^9.6.1"
+    esquery "^1.4.2"
+    esutils "^2.0.2"
+    fast-deep-equal "^3.1.3"
+    file-entry-cache "^6.0.1"
+    find-up "^5.0.0"
+    glob-parent "^6.0.2"
+    globals "^13.19.0"
+    graphemer "^1.4.0"
+    ignore "^5.2.0"
+    imurmurhash "^0.1.4"
+    is-glob "^4.0.0"
+    is-path-inside "^3.0.3"
+    js-yaml "^4.1.0"
+    json-stable-stringify-without-jsonify "^1.0.1"
+    levn "^0.4.1"
+    lodash.merge "^4.6.2"
+    minimatch "^3.1.2"
+    natural-compare "^1.4.0"
+    optionator "^0.9.3"
+    strip-ansi "^6.0.1"
+    text-table "^0.2.0"
+
+espree@^9.6.0, espree@^9.6.1:
+  version "9.6.1"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-9.6.1.tgz#a2a17b8e434690a5432f2f8018ce71d331a48c6f"
+  integrity sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==
+  dependencies:
+    acorn "^8.9.0"
+    acorn-jsx "^5.3.2"
+    eslint-visitor-keys "^3.4.1"
+
 esprima@^4.0.0, esprima@^4.0.1:
   version "4.0.1"
   resolved "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
+
+esquery@^1.4.2:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.6.0.tgz#91419234f804d852a82dceec3e16cdc22cf9dae7"
+  integrity sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==
+  dependencies:
+    estraverse "^5.1.0"
 
 esrecurse@^4.3.0:
   version "4.3.0"
@@ -8464,7 +8625,7 @@ estraverse@^4.1.1:
   resolved "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz"
   integrity sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==
 
-estraverse@^5.2.0:
+estraverse@^5.1.0, estraverse@^5.2.0:
   version "5.3.0"
   resolved "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz"
   integrity sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==
@@ -8810,6 +8971,11 @@ fast-json-stringify@^5.7.0, fast-json-stringify@^5.8.0:
     json-schema-ref-resolver "^1.0.1"
     rfdc "^1.2.0"
 
+fast-levenshtein@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
+  integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
+
 fast-querystring@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/fast-querystring/-/fast-querystring-1.1.2.tgz#a6d24937b4fc6f791b4ee31dcb6f53aeafb89f53"
@@ -8992,6 +9158,13 @@ figures@^6.0.0:
   dependencies:
     is-unicode-supported "^2.0.0"
 
+file-entry-cache@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-6.0.1.tgz#211b2dd9659cb0394b073e7323ac3c933d522027"
+  integrity sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==
+  dependencies:
+    flat-cache "^3.0.4"
+
 file-loader@^6.2.0:
   version "6.2.0"
   resolved "https://registry.npmjs.org/file-loader/-/file-loader-6.2.0.tgz"
@@ -9122,10 +9295,24 @@ find-up@^6.0.0, find-up@^6.3.0:
     locate-path "^7.1.0"
     path-exists "^5.0.0"
 
+flat-cache@^3.0.4:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-3.2.0.tgz#2c0c2d5040c99b1632771a9d105725c0115363ee"
+  integrity sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==
+  dependencies:
+    flatted "^3.2.9"
+    keyv "^4.5.3"
+    rimraf "^3.0.2"
+
 flat@^5.0.2:
   version "5.0.2"
   resolved "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz"
   integrity sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==
+
+flatted@^3.2.9:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.3.3.tgz#67c8fad95454a7c7abebf74bb78ee74a44023358"
+  integrity sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==
 
 flush-write-stream@2.0.0:
   version "2.0.0"
@@ -9184,7 +9371,7 @@ form-data-encoder@^2.1.2:
   resolved "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-2.1.4.tgz"
   integrity sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw==
 
-form-data@^4.0.0:
+form-data@^4.0.0, form-data@^4.0.4:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.4.tgz#784cdcce0669a9d68e94d11ac4eea98088edd2c4"
   integrity sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==
@@ -9468,7 +9655,7 @@ glob-parent@^5.1.2, glob-parent@~5.1.2:
   dependencies:
     is-glob "^4.0.1"
 
-glob-parent@^6.0.1:
+glob-parent@^6.0.1, glob-parent@^6.0.2:
   version "6.0.2"
   resolved "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz"
   integrity sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==
@@ -9558,6 +9745,13 @@ globals@^11.1.0:
   resolved "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz"
   integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
 
+globals@^13.19.0:
+  version "13.24.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-13.24.0.tgz#8432a19d78ce0c1e833949c36adb345400bb1171"
+  integrity sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==
+  dependencies:
+    type-fest "^0.20.2"
+
 globby@^11.0.1, globby@^11.0.4, globby@^11.1.0:
   version "11.1.0"
   resolved "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz"
@@ -9631,6 +9825,11 @@ graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.10,
   version "4.2.11"
   resolved "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz"
   integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
+
+graphemer@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/graphemer/-/graphemer-1.4.0.tgz#fb2f1d55e0e3a1849aeffc90c4fa0dd53a0e66c6"
+  integrity sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==
 
 gray-matter@^4.0.3:
   version "4.0.3"
@@ -10230,7 +10429,7 @@ immer@^9.0.7:
   resolved "https://registry.npmjs.org/immer/-/immer-9.0.21.tgz"
   integrity sha512-bc4NBHqOqSfRW7POMkHd51LvClaeMXpm8dx0e8oE2GORbq5aRK7Bxl4FyzVLdGtLmvLKL7BTDBG5ACQm4HWjTA==
 
-import-fresh@^3.1.0, import-fresh@^3.3.0:
+import-fresh@^3.1.0, import-fresh@^3.2.1, import-fresh@^3.3.0:
   version "3.3.1"
   resolved "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz"
   integrity sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==
@@ -10516,7 +10715,7 @@ is-fullwidth-code-point@^5.0.0:
   dependencies:
     get-east-asian-width "^1.0.0"
 
-is-glob@^4.0.1, is-glob@^4.0.3, is-glob@~4.0.1:
+is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3, is-glob@~4.0.1:
   version "4.0.3"
   resolved "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz"
   integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
@@ -10596,7 +10795,7 @@ is-path-cwd@^2.2.0:
   resolved "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.2.0.tgz"
   integrity sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==
 
-is-path-inside@^3.0.2:
+is-path-inside@^3.0.2, is-path-inside@^3.0.3:
   version "3.0.3"
   resolved "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz"
   integrity sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==
@@ -10957,6 +11156,11 @@ json-schema-traverse@^1.0.0:
   resolved "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz"
   integrity sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==
 
+json-stable-stringify-without-jsonify@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
+  integrity sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==
+
 json5@^2.1.2, json5@^2.2.2, json5@^2.2.3:
   version "2.2.3"
   resolved "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz"
@@ -11114,6 +11318,14 @@ leven@^3.1.0, "leven@^3.1.0 < 4":
   version "3.1.0"
   resolved "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz"
   integrity sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==
+
+levn@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/levn/-/levn-0.4.1.tgz#ae4562c007473b932a6200d403268dd2fffc6ade"
+  integrity sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==
+  dependencies:
+    prelude-ls "^1.2.1"
+    type-check "~0.4.0"
 
 light-my-request@^5.11.0:
   version "5.14.0"
@@ -11275,6 +11487,11 @@ lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz"
   integrity sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==
+
+lodash.merge@^4.6.2:
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
+  integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
 lodash.once@^4.0.0:
   version "4.1.1"
@@ -12556,6 +12773,11 @@ napi-wasm@^1.1.0:
   resolved "https://registry.yarnpkg.com/napi-wasm/-/napi-wasm-1.1.3.tgz#7bb95c88e6561f84880bb67195437b1cfbe99224"
   integrity sha512-h/4nMGsHjZDCYmQVNODIrYACVJ+I9KItbG+0si6W/jSjdA9JbWDoU4LLeMXVcEQGHjttI2tuXqDrbGF7qkUHHg==
 
+natural-compare@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
+  integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
+
 negotiator@0.6.3:
   version "0.6.3"
   resolved "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz"
@@ -13204,6 +13426,18 @@ opener@^1.5.2:
   version "1.5.2"
   resolved "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz"
   integrity sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==
+
+optionator@^0.9.3:
+  version "0.9.4"
+  resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.9.4.tgz#7ea1c1a5d91d764fb282139c88fe11e182a3a734"
+  integrity sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==
+  dependencies:
+    deep-is "^0.1.3"
+    fast-levenshtein "^2.0.6"
+    levn "^0.4.1"
+    prelude-ls "^1.2.1"
+    type-check "^0.4.0"
+    word-wrap "^1.2.5"
 
 ora@8.1.1:
   version "8.1.1"
@@ -14404,6 +14638,11 @@ precond@0.2:
   resolved "https://registry.yarnpkg.com/precond/-/precond-0.2.3.tgz#aa9591bcaa24923f1e0f4849d240f47efc1075ac"
   integrity sha512-QCYG84SgGyGzqJ/vlMsxeXd/pgL/I94ixdNFyh1PusWmTCyVfPJjZ1K1jvHtsbfnXQs2TSkEP2fR7QiMZAnKFQ==
 
+prelude-ls@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
+  integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
+
 pretty-error@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/pretty-error/-/pretty-error-4.0.0.tgz"
@@ -15298,6 +15537,13 @@ reusify@^1.0.4:
   version "1.1.0"
   resolved "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz"
   integrity sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==
+
+rewire@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/rewire/-/rewire-7.0.0.tgz#41db5482370c88758ffc9a719f7c92a761fa8fbf"
+  integrity sha512-DyyNyzwMtGYgu0Zl/ya0PR/oaunM+VuCuBxCuhYJHHaV0V+YvYa3bBGxb5OZ71vndgmp1pYY8F4YOwQo1siRGw==
+  dependencies:
+    eslint "^8.47.0"
 
 rfdc@^1.2.0, rfdc@^1.3.0, rfdc@^1.4.1:
   version "1.4.1"
@@ -16624,10 +16870,22 @@ tunnel-agent@^0.6.0:
   dependencies:
     safe-buffer "^5.0.1"
 
+type-check@^0.4.0, type-check@~0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.4.0.tgz#07b8203bfa7056c0657050e3ccd2c37730bab8f1"
+  integrity sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==
+  dependencies:
+    prelude-ls "^1.2.1"
+
 type-detect@^4.0.0, type-detect@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.1.0.tgz#deb2453e8f08dcae7ae98c626b13dddb0155906c"
   integrity sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==
+
+type-fest@^0.20.2:
+  version "0.20.2"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.20.2.tgz#1bf207f4b28f91583666cb5fbd327887301cd5f4"
+  integrity sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==
 
 type-fest@^0.21.3:
   version "0.21.3"
@@ -17368,6 +17626,11 @@ winston@^3.10.0:
     stack-trace "0.0.x"
     triple-beam "^1.3.0"
     winston-transport "^4.9.0"
+
+word-wrap@^1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.5.tgz#d2c45c6dd4fbce621a66f136cbe328afd0410b34"
+  integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
 
 workerpool@^9.2.0:
   version "9.3.3"


### PR DESCRIPTION
This pulls for the work we've done on Aztec's docs:

- Creates a netlify serverless function so as to not expose Brevo's API KEY
- Created Brevo's List for Barretenberg
- Adds an email subscription to the footer
- Adds Matomo
- Adds all tracking for Matomo (NPS + Email Subscription)
- Added Brevo's API KEY to Netlify's environment as secret


Additionally I've created the goals, and the custom dimensions in Matomo's Barretenberg environments (dev, staging, prod). 

Testing:
- `forceNPS()` opens up the NPS widget
- You can track on Matomo in "Real Time"

<img width="1103" height="518" alt="image" src="https://github.com/user-attachments/assets/e418cb0e-b1c2-417c-be98-e9fa376d017c" />
