### PR TITLE
fix: outdated cli reference

### DIFF
--- a/docs/docs/developers/docs/reference/environment_reference/cli_reference.md
+++ b/docs/docs/developers/docs/reference/environment_reference/cli_reference.md
@@ -66,55 +66,54 @@ aztec start [options]
 
 Options:
 
+#### Misc Options
+
+- `--network <value>`: Network to run Aztec on.
+- `--auto-update <value>`: The auto update mode for this node (default: disabled).
+- `--auto-update-url <value>`: Base URL to check for updates.
+- `--sync-mode <value>`: Set sync mode to `full` to always sync via L1, `snapshot` to download a snapshot if there is no local data, `force-snapshot` to download even if there is local data (default: snapshot).
+- `--snapshots-url <value>`: Base URL for snapshots index.
+
 #### Sandbox Options
 
-- `-sb, --sandbox`: Starts the Aztec Sandbox.
-
-#### Network Options
-
-- `--network <value>`: Network to run Aztec on, e.g. `testnet`. By default connects to sandbox (local network)
+- `--sandbox`: Starts Aztec Sandbox.
+- `--sandbox.noPXE`: Do not expose PXE service on sandbox start.
+- `--sandbox.l1Mnemonic <value>`: Mnemonic for L1 accounts. Will be used (default: test test test test test test test test test test test junk).
+- `--sandbox.deployAztecContractsSalt <value>`: Numeric salt for deploying L1 Aztec contracts before starting the sandbox. Needs mnemonic or private key to be set.
 
 #### API Options
 
-- `-p, --port <value>`: Port to run the Aztec Services on (default: 8080).
+- `--port <value>`: Port to run the Aztec Services on (default: 8080).
 - `--admin-port <value>`: Port to run admin APIs of Aztec Services on (default: 8880).
 - `--api-prefix <value>`: Prefix for API routes on any service that is started.
 
 #### Ethereum Options
 
-- `--l1-rpc-urls <value>`: List of URLs of Ethereum RPC nodes that services will connect to (comma separated) (default: http://localhost:8545).
-- `--l1-chain-id <value>`: The L1 chain ID (default: 31337).
-- `--l1-mnemonic <value>`: Mnemonic for L1 accounts. Will be used if no publisher private keys are provided (default: test test test test test test test test test test test junk).
+- `--l1-chain-id <value>`: The chain ID of the ethereum host.
+- `--l1-rpc-urls <value>`: List of URLs of Ethereum RPC nodes that services will connect to (comma separated).
 - `--l1-consensus-host-urls <value>`: List of URLs of the Ethereum consensus nodes that services will connect to (comma separated).
-- `--l1-consensus-host-api-keys <value>`: List of API keys for the corresponding Ethereum consensus nodes.
-- `--l1-consensus-host-api-key-headers <value>`: List of API key headers for the corresponding Ethereum consensus nodes. If not set, the api key for the corresponding node will be appended to the URL as `?key=<api-key>`.
-
-#### Storage Options
-
-- `--data-directory <value>`: Where to store data for services. If not set, will store temporarily.
-- `--data-store-map-size-kb <value>`: The maximum possible size of the data store DB in KB. Can be overridden by component-specific options.
+- `--l1-consensus-host-api-keys <value>`: List of API keys for the corresponding L1 consensus clients, if needed. Added to the end of the corresponding URL as "?key=<api-key>" unless a header is defined.
+- `--l1-consensus-host-api-key-headers <value>`: List of header names for the corresponding L1 consensus client API keys, if needed. Added to the corresponding request as "<api-key-header>: <api-key>".
 
 #### L1 Contract Addresses
 
-- `--rollup-address <value>`: The deployed L1 rollup contract address.
 - `--registry-address <value>`: The deployed L1 registry contract address.
-- `--inbox-address <value>`: The deployed L1 -> L2 inbox contract address.
-- `--outbox-address <value>`: The deployed L2 -> L1 outbox contract address.
-- `--fee-juice-address <value>`: The deployed L1 Fee Juice contract address.
-- `--staking-asset-address <value>`: The deployed L1 Staking Asset contract address.
-- `--fee-juice-portal-address <value>`: The deployed L1 Fee Juice portal contract address.
+- `--rollup-version <value>`: The version of the rollup.
+
+#### Storage Options
+
+- `--data-directory <value>`: Optional dir to store data. If omitted will store in memory.
+- `--data-store-map-size-kb <value>`: The maximum possible size of a data store DB in KB. Can be overridden by component-specific options (default: 134217728).
+
+#### World State Options
+
+- `--world-state-data-directory <value>`: Optional directory for the world state database.
+- `--world-state-db-map-size-kb <value>`: The maximum possible size of the world state DB in KB. Overwrites the general dataStoreMapSizeKB.
+- `--world-state-block-history <value>`: The number of historic blocks to maintain. Values less than 1 mean all history is maintained (default: 64).
 
 #### Aztec Node Options
 
 - `--node`: Starts Aztec Node with options.
-- `--node.archiver-url <value>`: URL for an archiver service.
-- `--node.deploy-aztec-contracts`: Deploys L1 Aztec contracts before starting the node. Needs mnemonic or private key to be set.
-- `--node.deploy-aztec-contracts-salt <value>`: Numeric salt for deploying L1 Aztec contracts before starting the node. Needs mnemonic or private key to be set. Implies --node.deploy-aztec-contracts.
-- `--node.assume-proven-through-block-number <value>`: Cheats the rollup contract into assuming every block until this one is proven. Useful for speeding up bootstraps.
-- `--node.publisher-private-key <value>`: Private key of account for publishing L1 contracts.
-- `--node.world-state-block-check-interval-ms <value>`: Frequency in which to check for blocks in ms (default: 100).
-- `--node.sync-mode <value>`: Set sync mode to `full` to always sync via L1, `snapshot` to download a snapshot if there is no local data, `force-snapshot` to download even if there is local data (default: snapshot).
-- `--node.snapshots-url <value>`: Base URL for downloading snapshots for snapshot sync.
 
 ##### Example Usage
 
@@ -137,57 +136,6 @@ aztec start --node --network testnet
     --archiver
 ```
 
-#### P2P Subsystem Options
-
-- `--p2p-enabled [value]`: Enable P2P subsystem.
-- `--p2p.block-check-interval-ms <value>`: The frequency in which to check for new L2 blocks (default: 100).
-- `--p2p.debug-disable-colocation-penalty <value>`: DEBUG: Disable colocation penalty - NEVER set to true in production.
-- `--p2p.peer-check-interval-ms <value>`: The frequency in which to check for new peers (default: 30000).
-- `--p2p.l2-queue-size <value>`: Size of queue of L2 blocks to store (default: 1000).
-- `--p2p.listen-address <value>`: The listen address. ipv4 address (default: 0.0.0.0).
-- `--p2p.p2p-port <value>`: The port for the P2P service (default: 40400).
-- `--p2p.p2p-ip <value>`: The IP address for the P2P service. ipv4 address.
-- `--p2p.peer-id-private-key <value>`: An optional peer id private key. If blank, will generate a random key.
-- `--p2p.peer-id-private-key-path <value>`: An optional path to store generated peer id private keys.
-- `--p2p.bootstrap-nodes <value>`: A list of bootstrap peer ENRs to connect to. Separated by commas.
-- `--p2p.bootstrap-node-enr-version-check <value>`: Whether to check the version of the bootstrap node ENR.
-- `--p2p.bootstrap-nodes-as-full-peers <value>`: Whether to consider our configured bootnodes as full peers.
-- `--p2p.max-peer-count <value>`: The maximum number of peers to connect to (default: 100).
-- `--p2p.query-for-ip <value>`: If announceUdpAddress or announceTcpAddress are not provided, query for the IP address of the machine. Default is false.
-- `--p2p.keep-proven-txs-in-pool-for <value>`: How many blocks have to pass after a block is proven before its txs are deleted (zero to delete immediately once proven).
-- `--p2p.keep-attestations-in-pool-for <value>`: How many slots to keep attestations for (default: 96).
-- `--p2p.gossipsub-interval <value>`: The interval of the gossipsub heartbeat to perform maintenance tasks (default: 700).
-- `--p2p.gossipsub-d <value>`: The D parameter for the gossipsub protocol (default: 8).
-- `--p2p.gossipsub-dlo <value>`: The Dlo parameter for the gossipsub protocol (default: 4).
-- `--p2p.gossipsub-dhi <value>`: The Dhi parameter for the gossipsub protocol (default: 12).
-- `--p2p.gossipsub-dlazy <value>`: The Dlazy parameter for the gossipsub protocol (default: 8).
-- `--p2p.gossipsub-flood-publish <value>`: Whether to flood publish messages. - For testing purposes only (default: true).
-- `--p2p.gossipsub-mcache-length <value>`: The number of gossipsub interval message cache windows to keep (default: 6).
-- `--p2p.gossipsub-mcache-gossip <value>`: How many message cache windows to include when gossiping with other pears (default: 3).
-- `--p2p.gossipsub-tx-topic-weight <value>`: The weight of the tx topic for the gossipsub protocol (default: 1).
-- `--p2p.gossipsub-tx-invalid-message-deliveries-weight <value>`: The weight of the tx invalid message deliveries for the gossipsub protocol (default: -20).
-- `--p2p.gossipsub-tx-invalid-message-deliveries-decay <value>`: Determines how quickly the penalty for invalid message deliveries decays over time. Between 0 and 1 (default: 0.5).
-- `--p2p.peer-penalty-values <value>`: The values for the peer scoring system. Passed as a comma separated list of values in order: low, mid, high tolerance errors (default: 2,10,50).
-- `--p2p.double-spend-severe-peer-penalty-window <value>`: The "age" (in L2 blocks) of a tx after which we heavily penalize a peer for sending it (default: 30).
-- `--p2p.block-request-batch-size <value>`: The number of blocks to fetch in a single batch (default: 20).
-- `--p2p.archived-tx-limit <value>`: The number of transactions that will be archived. If the limit is set to 0 then archiving will be disabled.
-- `--p2p.trusted-peers <value>`: A list of trusted peers ENRs. Separated by commas.
-- `--p2p.p2p-store-map-size-kb <value>`: The maximum possible size of the P2P DB in KB. Overwrites the general dataStoreMapSizeKB.
-- `--p2p.tx-public-setup-allow-list <value>`: The list of functions calls allowed to run in setup.
-- `--p2p.max-tx-pool-size <value>`: The maximum cumulative tx size of pending txs (in bytes) before evicting lower priority txs (default: 100000000).
-- `--p2p.overall-request-timeout-ms <value>`: The overall timeout for a request response operation (default: 4000).
-- `--p2p.individual-request-timeout-ms <value>`: The timeout for an individual request response peer interaction (default: 2000).
-- `--p2p.rollup-version <value>`: The version of the rollup.
-
-#### Telemetry Options
-
-- `--tel.metrics-collector-url <value>`: The URL of the telemetry collector for metrics.
-- `--tel.traces-collector-url <value>`: The URL of the telemetry collector for traces.
-- `--tel.logs-collector-url <value>`: The URL of the telemetry collector for logs.
-- `--tel.otel-collect-interval-ms <value>`: The interval at which to collect metrics (default: 60000).
-- `--tel.otel-export-timeout-ms <value>`: The timeout for exporting metrics (default: 30000).
-- `--tel.otel-exclude-metrics <value>`: A list of metric prefixes to exclude from export.
-
 ##### Example Usage
 
 ```bash
@@ -197,89 +145,51 @@ aztec start --port 8081 --pxe --pxe.nodeUrl=$BOOTNODE --pxe.proverEnabled true -
 #### Archiver Options
 
 - `--archiver`: Starts Aztec Archiver with options.
-- `--archiver.blob-sink-url <value>`: The URL of the blob sink.
-- `--archiver.archive-api-url <value>`: The URL of the archive API.
-- `--archiver.archiver-polling-interval-ms <value>`: The polling interval in ms for retrieving new L2 blocks and encrypted logs (default: 500).
-- `--archiver.archiver-batch-size <value>`: The number of L2 blocks the archiver will attempt to download at a time (default: 100).
-- `--archiver.max-logs <value>`: The max number of logs that can be obtained in 1 "getPublicLogs" call (default: 1000).
-- `--archiver.archiver-store-map-size-kb <value>`: The maximum possible size of the archiver DB in KB. Overwrites the general dataStoreMapSizeKB.
-- `--archiver.rollup-version <value>`: The version of the rollup.
-- `--archiver.viem-polling-interval-ms <value>`: The polling interval viem uses in ms (default: 1000).
-- `--archiver.ethereum-slot-duration <value>`: How many seconds an L1 slot lasts (default: 12).
-- `--archiver.aztec-slot-duration <value>`: How many seconds an L2 slots lasts (must be multiple of ethereum slot duration) (default: 24).
-- `--archiver.aztec-epoch-duration <value>`: How many L2 slots an epoch lasts (maximum AZTEC_MAX_EPOCH_DURATION) (default: 16).
-- `--archiver.aztec-target-committee-size <value>`: The target validator committee size (default: 48).
-- `--archiver.aztec-proof-submission-window <value>`: The number of L2 slots that a proof for an epoch can be submitted in, starting from the beginning of the epoch (default: 31).
-- `--archiver.minimum-stake <value>`: The minimum stake for a validator (default: 100000000000000000000).
-- `--archiver.slashing-quorum <value>`: The slashing quorum (default: 6).
-- `--archiver.slashing-round-size <value>`: The slashing round size (default: 10).
-- `--archiver.governance-proposer-quorum <value>`: The governance proposing quorum (default: 51).
-- `--archiver.governance-proposer-round-size <value>`: The governance proposing round size (default: 100).
-- `--archiver.mana-target <value>`: The mana target for the rollup (default: 10000000000).
-- `--archiver.proving-cost-per-mana <value>`: The proving cost per mana (default: 100).
-- `--archiver.gas-limit-buffer-percentage <value>`: How much to increase calculated gas limit by (percentage) (default: 20).
-- `--archiver.max-gwei <value>`: Maximum gas price in gwei (default: 500).
-- `--archiver.max-blob-gwei <value>`: Maximum blob fee per gas in gwei (default: 1500).
-- `--archiver.priority-fee-bump-percentage <value>`: How much to increase priority fee by each attempt (percentage) (default: 20).
-- `--archiver.priority-fee-retry-bump-percentage <value>`: How much to increase priority fee by each retry attempt (percentage) (default: 50).
-- `--archiver.fixed-priority-fee-per-gas <value>`: Fixed priority fee per gas in Gwei. Overrides any priority fee bump percentage.
-- `--archiver.max-attempts <value>`: Maximum number of speed-up attempts (default: 3).
-- `--archiver.check-interval-ms <value>`: How often to check tx status (default: 1000).
-- `--archiver.stall-time-ms <value>`: How long before considering tx stalled (default: 45000).
-- `--archiver.tx-timeout-ms <value>`: How long to wait for a tx to be mined before giving up. Set to 0 to disable (default: 300000).
-- `--archiver.tx-propagation-max-query-attempts <value>`: How many attempts will be done to get a tx after it was sent (default: 3).
+- `--archiver.blobSinkUrl <value>`: The URL of the blob sink.
+- `--archiver.blobSinkMapSizeKb <value>`: The maximum possible size of the blob sink DB in KB. Overwrites the general dataStoreMapSizeKB.
+- `--archiver.archiveApiUrl <value>`: The URL of the archive API.
+- `--archiver.archiverPollingIntervalMS <value>`: The polling interval in ms for retrieving new L2 blocks and encrypted logs (default: 500).
+- `--archiver.archiverBatchSize <value>`: The number of L2 blocks the archiver will attempt to download at a time (default: 100).
+- `--archiver.maxLogs <value>`: The max number of logs that can be obtained in 1 "getPublicLogs" call (default: 1000).
+- `--archiver.archiverStoreMapSizeKb <value>`: The maximum possible size of the archiver DB in KB. Overwrites the general dataStoreMapSizeKB.
+- `--archiver.skipValidateBlockAttestations <value>`: Whether to skip validating block attestations (use only for testing).
 
 #### Sequencer Options
 
-- `-n, --node [options]`: Starts the Aztec Node with specified options.
-- `-px, --pxe [options]`: Starts the PXE (Private eXecution Environment) with specified options.
-- `-a, --archiver [options]`: Starts the Archiver with specified options.
-- `-s, --sequencer [options]`: Starts the Sequencer with specified options.
-- `-r, --prover [options]`: Starts the Prover Agent with specified options.
-- `-o, --prover-node [options]`: Starts the Prover Node with specified options.
-- `-p2p, --p2p-bootstrap [options]`: Starts the P2P Bootstrap node with specified options.
-- `-t, --txe [options]`: Starts the TXE (Test eXecution Environment) with specified options.
-- `--faucet [options]`: Starts the Aztec faucet service with specified options.
-- `--sequencer.validator-private-key <value>`: The private key of the validator participating in attestation duties.
-- `--sequencer.disable-validator <value>`: Do not run the validator.
-- `--sequencer.attestation-polling-interval-ms <value>`: Interval between polling for new attestations (default: 200).
-- `--sequencer.validator-reexecute <value>`: Re-execute transactions before attesting (default: true).
-- `--sequencer.transaction-polling-interval-ms <value>`: The number of ms to wait between polling for pending txs (default: 500).
-- `--sequencer.max-txs-per-block <value>`: The maximum number of txs to include in a block (default: 32).
-- `--sequencer.min-txs-per-block <value>`: The minimum number of txs to include in a block (default: 1).
-- `--sequencer.max-l2-block-gas <value>`: The maximum L2 block gas (default: 10000000000).
-- `--sequencer.max-da-block-gas <value>`: The maximum DA block gas (default: 10000000000).
+- `--sequencer`: Starts Aztec Sequencer with options.
+- `--sequencer.validatorPrivateKeys <value>`: List of private keys of the validators participating in attestation duties.
+- `--sequencer.validatorAddresses <value>`: List of addresses of the validators to use with remote signers.
+- `--sequencer.disableValidator <value>`: Do not run the validator.
+- `--sequencer.disabledValidators <value>`: Temporarily disable these specific validator addresses.
+- `--sequencer.attestationPollingIntervalMs <value>`: Interval between polling for new attestations (default: 200).
+- `--sequencer.validatorReexecute <value>`: Re-execute transactions before attesting (default: true).
+- `--sequencer.validatorReexecuteDeadlineMs <value>`: Will re-execute until this many milliseconds are left in the slot (default: 6000).
+- `--sequencer.alwaysReexecuteBlockProposals <value>`: Whether to always reexecute block proposals, even for non-validator nodes (useful for monitoring network status).
+- `--sequencer.transactionPollingIntervalMS <value>`: The number of ms to wait between polling for pending txs (default: 500).
+- `--sequencer.maxTxsPerBlock <value>`: The maximum number of txs to include in a block (default: 32).
+- `--sequencer.minTxsPerBlock <value>`: The minimum number of txs to include in a block (default: 1).
+- `--sequencer.publishTxsWithProposals <value>`:  Whether to publish txs with proposals.
+- `--sequencer.maxL2BlockGas <value>`: The maximum L2 block gas (default: 10000000000).
+- `--sequencer.maxDABlockGas <value>`: The maximum DA block gas (default: 10000000000).
 - `--sequencer.coinbase <value>`: Recipient of block reward.
-- `--sequencer.fee-recipient <value>`: Address to receive fees.
-- `--sequencer.acvm-working-directory <value>`: The working directory to use for simulation/proving.
-- `--sequencer.acvm-binary-path <value>`: The path to the ACVM binary.
-- `--sequencer.max-block-size-in-bytes <value>`: Max block size (default: 1048576).
-- `--sequencer.enforce-time-table <value>`: Whether to enforce the time table when building blocks (default: true).
-- `--sequencer.governance-proposer-payload <value>`: The address of the payload for the governanceProposer (default: 0x0000000000000000000000000000000000000000).
-- `--sequencer.max-l1-tx-inclusion-time-into-slot <value>`: How many seconds into an L1 slot we can still send a tx and get it mined.
-- `--sequencer.tx-public-setup-allow-list <value>`: The list of functions calls allowed to run in setup.
-- `--sequencer.viem-polling-interval-ms <value>`: The polling interval viem uses in ms (default: 1000).
-- `--sequencer.custom-forwarder-contract-address <value>`: The address of the custom forwarder contract (default: 0x0000000000000000000000000000000000000000).
-- `--sequencer.publisher-private-key <value>`: The private key to be used by the publisher (default: 0x0000000000000000000000000000000000000000000000000000000000000000).
-- `--sequencer.l1-publish-retry-interval-ms <value>`: The interval to wait between publish retries (default: 1000).
-- `--sequencer.gas-limit-buffer-percentage <value>`: How much to increase calculated gas limit by (percentage) (default: 20).
-- `--sequencer.max-gwei <value>`: Maximum gas price in gwei (default: 500).
-- `--sequencer.max-blob-gwei <value>`: Maximum blob fee per gas in gwei (default: 1500).
-- `--sequencer.priority-fee-bump-percentage <value>`: How much to increase priority fee by each attempt (percentage) (default: 20).
-- `--sequencer.priority-fee-retry-bump-percentage <value>`: How much to increase priority fee by each retry attempt (percentage) (default: 50).
-- `--sequencer.fixed-priority-fee-per-gas <value>`: Fixed priority fee per gas in Gwei. Overrides any priority fee bump percentage.
-- `--sequencer.max-attempts <value>`: Maximum number of speed-up attempts (default: 3).
-- `--sequencer.check-interval-ms <value>`: How often to check tx status (default: 1000).
-- `--sequencer.stall-time-ms <value>`: How long before considering tx stalled (default: 45000).
-- `--sequencer.tx-timeout-ms <value>`: How long to wait for a tx to be mined before giving up. Set to 0 to disable (default: 300000).
-- `--sequencer.tx-propagation-max-query-attempts <value>`: How many attempts will be done to get a tx after it was sent (default: 3).
-- `--sequencer.blob-sink-url <value>`: The URL of the blob sink.
-- `--sequencer.archive-api-url <value>`: The URL of the archive API.
-- `--sequencer.rollup-version <value>`: The version of the rollup.
-- `--sequencer.ethereum-slot-duration <value>`: How many seconds an L1 slot lasts (default: 12).
-- `--sequencer.aztec-slot-duration <value>`: How many seconds an L2 slots lasts (must be multiple of ethereum slot duration) (default: 24).
-- `--sequencer.aztec-epoch-duration <value>`: How many L2 slots an epoch lasts (maximum AZTEC_MAX_EPOCH_DURATION) (default: 16).
-- `--sequencer.aztec-proof-submission-window <value>`: The number of L2 slots that a proof for an epoch can be submitted in, starting from the beginning of the epoch (default: 31).
+- `--sequencer.feeRecipient <value>`: Address to receive fees.
+- `--sequencer.acvmWorkingDirectory <value>`: The working directory to use for simulation/proving.
+- `--sequencer.acvmBinaryPath <value>`: The path to the ACVM binary.
+- `--sequencer.maxBlockSizeInBytes <value>`: Max block size (default: 1048576).
+- `--sequencer.enforceTimeTable <value>`: Whether to enforce the time table when building blocks (default: true).
+- `--sequencer.governanceProposerPayload <value>`: The address of the payload for the governanceProposer (default: 0x0000000000000000000000000000000000000000).
+- `--sequencer.maxL1TxInclusionTimeIntoSlot <value>`: How many seconds into an L1 slot we can still send a tx and get it mined.
+- `--sequencer.attestationPropagationTime <value>`: How many seconds it takes for proposals and attestations to travel across the p2p layer (one-way) (default: 2).
+- `--sequencer.secondsBeforeInvalidatingBlockAsCommitteeMember <value>`: How many seconds to wait before trying to invalidate a block from the pending chain as a committee member (zero to never invalidate). The next proposer is expected to invalidate, so the committee acts as a fallback (default: 144).
+- `--sequencer.secondsBeforeInvalidatingBlockAsNonCommitteeMember <value>`: How many seconds to wait before trying to invalidate a block from the pending chain as a non-committee member (zero to never invalidate). The next proposer is expected to invalidate, then the committee, so other sequencers act as a fallback (default: 432).
+- `--sequencer.txPublicSetupAllowList <value>`: The list of functions calls allowed to run in setup.
+- `--sequencer.keyStoreDirectory <value>`: Location of key store directory.
+- `--sequencer.publisherPrivateKeys <value>`: The private keys to be used by the publisher.
+- `--sequencer.publisherAddresses <value>`: The addresses of the publishers to use with remote signers.
+- `--sequencer.l1PublishRetryIntervalMS <value>`: The interval to wait between publish retries (default: 1000).
+- `--sequencer.publisherAllowInvalidStates <value>`: True to use publishers in invalid states (timed out, cancelled, etc) if no other is available.
+- `--sequencer.blobSinkUrl <value>`: The URL of the blob sink.
+- `--sequencer.archiveApiUrl <value>`: The URL of the archive API.
 
 #### Example Usage
 
@@ -290,120 +200,185 @@ aztec start --network testnet --l1-rpc-urls https://example.com --l1-consensus-h
 #### Blob Sink Options
 
 - `--blob-sink`: Starts Aztec Blob Sink with options.
-- `--blob-sink.port <value>`: The port to run the blob sink server on.
-- `--blob-sink.archive-api-url <value>`: The URL of the archive API.
-- `--blob-sink.data-store-map-size-kb <value>`: DB mapping size to be applied to all key/value stores (default: 134217728).
-- `--blob-sink.rollup-version <value>`: The version of the rollup.
-- `--blob-sink.viem-polling-interval-ms <value>`: The polling interval viem uses in ms (default: 1000).
+- `--blobSink.port <value>`: The port to run the blob sink server on.
+- `--blobSink.blobSinkMapSizeKb <value>`: The maximum possible size of the blob sink DB in KB. Overwrites the general dataStoreMapSizeKB.
+- `--blobSink.archiveApiUrl <value>`: The URL of the archive API.
 
 #### Prover Node Options
 
 - `--prover-node`: Starts Aztec Prover Node with options.
-- `--prover-node.archiver-url <value>`: URL for an archiver service.
-- `--prover-node.acvm-working-directory <value>`: The working directory to use for simulation/proving.
-- `--prover-node.acvm-binary-path <value>`: The path to the ACVM binary.
-- `--prover-node.bb-working-directory <value>`: The working directory to use for proving.
-- `--prover-node.bb-binary-path <value>`: The path to the bb binary.
-- `--prover-node.bb-skip-cleanup <value>`: Whether to skip cleanup of bb temporary files.
-- `--prover-node.node-url <value>`: The URL to the Aztec node to take proving jobs from.
-- `--prover-node.prover-id <value>`: Hex value that identifies the prover. Defaults to the address used for submitting proofs if not set.
-- `--prover-node.failed-proof-store <value>`: Store for failed proof inputs. Google cloud storage is only supported at the moment. Set this value as gs://bucket-name/path/to/store.
-- `--prover-node.world-state-block-check-interval-ms <value>`: The frequency in which to check (default: 100).
-- `--prover-node.world-state-proven-blocks-only <value>`: Whether to follow only the proven chain.
-- `--prover-node.world-state-block-request-batch-size <value>`: Size of the batch for each get-blocks request from the synchronizer to the archiver.
-- `--prover-node.world-state-db-map-size-kb <value>`: The maximum possible size of the world state DB in KB. Overwrites the general dataStoreMapSizeKB.
-- `--prover-node.world-state-data-directory <value>`: Optional directory for the world state database.
-- `--prover-node.world-state-block-history <value>`: The number of historic blocks to maintain. Values less than 1 mean all history is maintained (default: 64).
-- `--prover-node.l1-publish-retry-interval-ms <value>`: The interval to wait between publish retries (default: 1000).
-- `--prover-node.custom-forwarder-contract-address <value>`: The address of the custom forwarder contract (default: 0x0000000000000000000000000000000000000000).
-- `--prover-node.publisher-private-key <value>`: The private key to be used by the publisher (default: 0x0000000000000000000000000000000000000000000000000000000000000000).
-- `--prover-node.prover-coordination-node-url <value>`: The URL of the tx provider node.
-- `--prover-node.prover-node-max-pending-jobs <value>`: The maximum number of pending jobs for the prover node (default: 10).
-- `--prover-node.prover-node-polling-interval-ms <value>`: The interval in milliseconds to poll for new jobs (default: 1000).
-- `--prover-node.prover-node-max-parallel-blocks-per-epoch <value>`: The Maximum number of blocks to process in parallel while proving an epoch (default: 32).
-- `--prover-node.tx-gathering-timeout-ms <value>`: The maximum amount of time to wait for tx data to be available (default: 60000).
-- `--prover-node.tx-gathering-interval-ms <value>`: How often to check that tx data is available (default: 1000).
-- `--prover-node.tx-gathering-max-parallel-requests <value>`: How many txs to load up a time (default: 100).
-- `--prover-node.test-accounts <value>`: Whether to populate the genesis state with initial fee juice for the test accounts.
-- `--prover-node.sponsored-fpc <value>`: Whether to populate the genesis state with initial fee juice for the sponsored FPC.
-- `--prover-node.sync-mode <value>`: Set sync mode to `full` to always sync via L1, `snapshot` to download a snapshot if there is no local data, `force-snapshot` to download even if there is local data (default: snapshot).
-- `--prover-node.snapshots-url <value>`: Base URL for snapshots index.
+- `--proverNode.keystoreDirectory <value>`: Location of key store directory.
+- `--proverNode.acvmWorkingDirectory <value>`: The working directory to use for simulation/proving.
+- `--proverNode.acvmBinaryPath <value>`: The path to the ACVM binary.
+- `--proverNode.bbWorkingDirectory <value>`: The working directory to use for proving.
+- `--proverNode.bbBinaryPath <value>`: The path to the bb binary.
+- `--proverNode.bbSkipCleanup <value>`: Whether to skip cleanup of bb temporary files.
+- `--proverNode.numConcurrentIVCVerifiers <value>`: Max number of client IVC verifiers to run concurrently (default: 8).
+- `--proverNode.bbIVCConcurrency <value>`: Number of threads to use for IVC verification (default: 1).
+- `--proverNode.nodeUrl <value>`: The URL to the Aztec node to take proving jobs from.
+- `--proverNode.proverId <value>`: Hex value that identifies the prover. Defaults to the address used for submitting proofs if not set.
+- `--proverNode.failedProofStore <value>`: Store for failed proof inputs. Google cloud storage is only supported at the moment. Set this value as gs://bucket-name/path/to/store.
+- `--proverNode.l1PublishRetryIntervalMS <value>`: The interval to wait between publish retries (default: 1000).
+- `--proverNode.publisherAllowInvalidStates <value>`: True to use publishers in invalid states (timed out, cancelled, etc) if no other is available.
+- `--proverNode.publisherPrivateKeys <value>`: The private keys to be used by the publisher.
+- `--proverNode.publisherAddresses <value>`: The addresses of the publishers to use with remote signers.
+- `--proverNode.proverNodeMaxPendingJobs <value>`: The maximum number of pending jobs for the prover node (default: 10).
+- `--proverNode.proverNodePollingIntervalMs <value>`: The interval in milliseconds to poll for new jobs (default: 1000).
+- `--proverNode.proverNodeMaxParallelBlocksPerEpoch <value>`: The Maximum number of blocks to process in parallel while proving an epoch (default: 32).
+- `--proverNode.proverNodeFailedEpochStore <value>`: File store where to upload node state when an epoch fails to be proven.
+- `--proverNode.proverNodeEpochProvingDelayMs <value>`: Optional delay in milliseconds to wait before proving a new epoch.
+- `--proverNode.txGatheringIntervalMs <value>`: How often to check that tx data is available (default: 1000).
+- `--proverNode.txGatheringBatchSize <value>`: How many transactions to gather from a node in a single request (default: 10).
+- `--proverNode.txGatheringMaxParallelRequestsPerNode <value>`: How many tx requests to make in parallel to each node (default: 100).
+- `--proverNode.txGatheringTimeoutMs <value>`: How long to wait for tx data to be available before giving up (default: 120000).
 
 #### Prover Broker Options
 
 - `--prover-broker`: Starts Aztec proving job broker.
-- `--prover-broker.prover-broker-job-timeout-ms <value>`: Jobs are retried if not kept alive for this long (default: 30000).
-- `--prover-broker.prover-broker-poll-interval-ms <value>`: The interval to check job health status (default: 1000).
-- `--prover-broker.prover-broker-job-max-retries <value>`: If starting a prover broker locally, the max number of retries per proving job (default: 3).
-- `--prover-broker.prover-broker-batch-size <value>`: The prover broker writes jobs to disk in batches (default: 100).
-- `--prover-broker.prover-broker-batch-interval-ms <value>`: How often to flush batches to disk (default: 50).
-- `--prover-broker.prover-broker-max-epochs-to-keep-results-for <value>`: The maximum number of epochs to keep results for (default: 1).
-- `--prover-broker.prover-broker-store-map-size-kb <value>`: The size of the prover broker's database. Will override the dataStoreMapSizeKB if set.
-- `--prover-broker.data-store-map-size-kb <value>`: DB mapping size to be applied to all key/value stores (default: 134217728).
-- `--prover-broker.viem-polling-interval-ms <value>`: The polling interval viem uses in ms (default: 1000).
-- `--prover-broker.rollup-version <value>`: The version of the rollup.
+- `--proverBroker.proverBrokerJobTimeoutMs <value>`: Jobs are retried if not kept alive for this long (default: 30000).
+- `--proverBroker.proverBrokerPollIntervalMs <value>`: The interval to check job health status (default: 1000).
+- `--proverBroker.proverBrokerJobMaxRetries <value>`: If starting a prover broker locally, the max number of retries per proving job (default: 3).
+- `--proverBroker.proverBrokerBatchSize <value>`: The prover broker writes jobs to disk in batches (default: 100).
+- `--proverBroker.proverBrokerBatchIntervalMs <value>`: How often to flush batches to disk (default: 50).
+- `--proverBroker.proverBrokerMaxEpochsToKeepResultsFor <value>`: The maximum number of epochs to keep results for (default: 1).
+- `--proverBroker.proverBrokerStoreMapSizeKb <value>`: The size of the prover broker's database. Will override the dataStoreMapSizeKB if set.
 
 #### Prover Agent Options
 
 - `--prover-agent`: Starts Aztec Prover Agent with options.
-- `--prover-agent.prover-agent-count <value>`: Whether this prover has a local prover agent (default: 1).
-- `--prover-agent.prover-agent-poll-interval-ms <value>`: The interval agents poll for jobs at (default: 100).
-- `--prover-agent.prover-agent-proof-types <value>`: The types of proofs the prover agent can generate.
-- `--prover-agent.prover-broker-url <value>`: The URL where this agent takes jobs from.
-- `--prover-agent.real-proofs <value>`: Whether to construct real proofs (default: true).
-- `--prover-agent.prover-test-delay-type <value>`: The type of artificial delay to introduce (default: fixed).
-- `--prover-agent.prover-test-delay-ms <value>`: Artificial delay to introduce to all operations to the test prover.
-- `--prover-agent.prover-test-delay-factor <value>`: If using realistic delays, what percentage of realistic times to apply (default: 1).
+- `--proverAgent.proverAgentCount <value>`: Whether this prover has a local prover agent (default: 1).
+- `--proverAgent.proverAgentPollIntervalMs <value>`: The interval agents poll for jobs at (default: 1000).
+- `--proverAgent.proverAgentProofTypes <value>`: The types of proofs the prover agent can generate.
+- `--proverAgent.proverBrokerUrl <value>`: The URL where this agent takes jobs from.
+- `--proverAgent.realProofs <value>`: Whether to construct real proofs (default: true).
+- `--proverAgent.proverTestDelayType <value>`: The type of artificial delay to introduce (default: fixed).
+- `--proverAgent.proverTestDelayMs <value>`: Artificial delay to introduce to all operations to the test prover.
+- `--proverAgent.proverTestDelayFactor <value>`: If using realistic delays, what percentage of realistic times to apply (default: 1).
+
+#### P2P Subsystem Options
+
+- `--p2p-enabled`: Enable P2P subsystem.
+- `--p2p.p2pDiscoveryDisabled`: A flag dictating whether the P2P discovery system should be disabled.
+- `--p2p.blockCheckIntervalMS <value>`: The frequency in which to check for new L2 blocks (default: 100).
+- `--p2p.debugDisableColocationPenalty <value>`: DEBUG: Disable colocation penalty - NEVER set to true in production.
+- `--p2p.peerCheckIntervalMS <value>`: The frequency in which to check for new peers (default: 30000).
+- `--p2p.l2QueueSize <value>`: Size of queue of L2 blocks to store (default: 1000).
+- `--p2p.listenAddress <value>`: The listen address. ipv4 address (default: 0.0.0.0).
+- `--p2p.p2pPort <value>`: The port for the P2P service (default: 40400).
+- `--p2p.p2pBroadcastPort <value>`: The port to broadcast the P2P service on (included in the node's ENR). Defaults to P2P_PORT.
+- `--p2p.p2pIp <value>`: The IP address for the P2P service. ipv4 address.
+- `--p2p.peerIdPrivateKey <value>`: An optional peer id private key. If blank, will generate a random key.
+- `--p2p.peerIdPrivateKeyPath <value>`: An optional path to store generated peer id private keys.
+- `--p2p.bootstrapNodes <value>`: A list of bootstrap peer ENRs to connect to. Separated by commas.
+- `--p2p.bootstrapNodeEnrVersionCheck <value>`: Whether to check the version of the bootstrap node ENR.
+- `--p2p.bootstrapNodesAsFullPeers <value>`: Whether to consider our configured bootnodes as full peers.
+- `--p2p.maxPeerCount <value>`: The maximum number of peers to connect to (default: 100).
+- `--p2p.queryForIp <value>`: If announceUdpAddress or announceTcpAddress are not provided, query for the IP address of the machine. Default is false.
+- `--p2p.gossipsubInterval <value>`: The interval of the gossipsub heartbeat to perform maintenance tasks (default: 700).
+- `--p2p.gossipsubD <value>`: The D parameter for the gossipsub protocol (default: 8).
+- `--p2p.gossipsubDlo <value>`: The Dlo parameter for the gossipsub protocol (default: 4).
+- `--p2p.gossipsubDhi <value>`: The Dhi parameter for the gossipsub protocol (default: 12).
+- `--p2p.gossipsubDLazy <value>`: The Dlazy parameter for the gossipsub protocol (default: 8).
+- `--p2p.gossipsubFloodPublish <value>`: Whether to flood publish messages. - For testing purposes only.
+- `--p2p.gossipsubMcacheLength <value>`: The number of gossipsub interval message cache windows to keep (default: 6).
+- `--p2p.gossipsubMcacheGossip <value>`: How many message cache windows to include when gossiping with other peers (default: 3).
+- `--p2p.gossipsubSeenTTL <value>`: How long to keep message IDs in the seen cache (default: 1200000).
+- `--p2p.gossipsubTxTopicWeight <value>`: The weight of the tx topic for the gossipsub protocol (default: 1).
+- `--p2p.gossipsubTxInvalidMessageDeliveriesWeight <value>`: The weight of the tx invalid message deliveries for the gossipsub protocol (default: -20).
+- `--p2p.gossipsubTxInvalidMessageDeliveriesDecay <value>`: Determines how quickly the penalty for invalid message deliveries decays over time. Between 0 and 1 (default: 0.5).
+- `--p2p.peerPenaltyValues <value>`: The values for the peer scoring system. Passed as a comma separated list of values in order: low, mid, high tolerance errors (default: 2,10,50).
+- `--p2p.doubleSpendSeverePeerPenaltyWindow <value>`: The "age" (in L2 blocks) of a tx after which we heavily penalize a peer for sending it (default: 30).
+- `--p2p.blockRequestBatchSize <value>`: The number of blocks to fetch in a single batch (default: 20).
+- `--p2p.archivedTxLimit <value>`: The number of transactions that will be archived. If the limit is set to 0 then archiving will be disabled.
+- `--p2p.trustedPeers <value>`: A list of trusted peer ENRs that will always be persisted. Separated by commas.
+- `--p2p.privatePeers <value>`: A list of private peer ENRs that will always be persisted and not be used for discovery. Separated by commas.
+- `--p2p.preferredPeers <value>`: A list of preferred peer ENRs that will always be persisted and not be used for discovery. Separated by commas.
+- `--p2p.p2pStoreMapSizeKb <value>`: The maximum possible size of the P2P DB in KB. Overwrites the general dataStoreMapSizeKB.
+- `--p2p.txPublicSetupAllowList <value>`: The list of functions calls allowed to run in setup.
+- `--p2p.maxTxPoolSize <value>`: The maximum cumulative tx size of pending txs (in bytes) before evicting lower priority txs (default: 100000000).
+- `--p2p.txPoolOverflowFactor <value>`: How much the tx pool can overflow before it starts evicting txs. Must be greater than 1 (default: 1.1).
+- `--p2p.seenMessageCacheSize <value>`: The number of messages to keep in the seen message cache (default: 100000).
+- `--p2p.p2pDisableStatusHandshake <value>`: True to disable the status handshake on peer connected.
+- `--p2p.p2pAllowOnlyValidators <value>`: True to only permit validators to connect.
+- `--p2p.p2pMaxFailedAuthAttemptsAllowed <value>`: Number of auth attempts to allow before peer is banned. Number is inclusive (default: 3).
+- `--p2p.dropTransactions <value>`: True to simulate discarding transactions. - For testing purposes only.
+- `--p2p.dropTransactionsProbability <value>`: The probability that a transaction is discarded. - For testing purposes only
+- `--p2p.disableTransactions <value>`: Whether transactions are disabled for this node. This means transactions will be rejected at the RPC and P2P layers.
+- `--p2p.txPoolDeleteTxsAfterReorg <value>`: Whether to delete transactions from the pool after a reorg instead of moving them back to pending.
+- `--p2p.overallRequestTimeoutMs <value>`: The overall timeout for a request response operation (default: 10000).
+- `--p2p.individualRequestTimeoutMs <value>`: The timeout for an individual request response peer interaction (default: 10000).
+- `--p2p.dialTimeoutMs <value>`: How long to wait for the dial protocol to establish a connection (default: 5000).
+- `--p2p.p2pOptimisticNegotiation <value>`: Whether to use optimistic protocol negotiation when dialing to another peer (opposite of `negotiateFully`).
+- `--p2p.txCollectionFastNodesTimeoutBeforeReqRespMs <value>`: How long to wait before starting reqresp for fast collection (default: 200).
+- `--p2p.txCollectionSlowNodesIntervalMs <value>`: How often to collect from configured nodes in the slow collection loop (default: 12000).
+- `--p2p.txCollectionSlowReqRespIntervalMs <value>`: How often to collect from peers via reqresp in the slow collection loop (default: 12000).
+- `--p2p.txCollectionSlowReqRespTimeoutMs <value>`: How long to wait for a reqresp response during slow collection (default: 20000).
+- `--p2p.txCollectionReconcileIntervalMs <value>`: How often to reconcile found txs from the tx pool (default: 60000).
+- `--p2p.txCollectionDisableSlowDuringFastRequests <value>`: Whether to disable the slow collection loop if we are dealing with any immediate requests (default: true).
+- `--p2p.txCollectionFastNodeIntervalMs <value>`: How many ms to wait between retried request to a node via RPC during fast collection (default: 500).
+- `--p2p.txCollectionNodeRpcUrls <value>`: A comma-separated list of Aztec node RPC URLs to use for tx collection.
+- `--p2p.txCollectionFastMaxParallelRequestsPerNode <value>`: Maximum number of parallel requests to make to a node during fast collection (default: 4).
+- `--p2p.txCollectionNodeRpcMaxBatchSize <value>`: Maximum number of transactions to request from a node in a single batch (default: 50).
 
 #### P2P Bootstrap Options
 
 - `--p2p-bootstrap`: Starts Aztec P2P Bootstrap with options.
-- `--p2p-bootstrap.peer-id-private-key-path <value>`: An optional path to store generated peer id private keys.
-- `--p2p-bootstrap.data-store-map-size-kb <value>`: DB mapping size to be applied to all key/value stores (default: 134217728).
+- `--p2pBootstrap.p2pBroadcastPort <value>`: The port to broadcast the P2P service on (included in the node's ENR). Defaults to P2P_PORT.
+- `--p2pBootstrap.peerIdPrivateKeyPath <value>`: An optional path to store generated peer id private keys. If blank, will default to storing any generated keys in the root of the data directory.
+
+#### Telemetry Options
+
+- `--tel.metricsCollectorUrl <value>`: The URL of the telemetry collector for metrics.
+- `--tel.tracesCollectorUrl <value>`: The URL of the telemetry collector for traces.
+- `--tel.logsCollectorUrl <value>`: The URL of the telemetry collector for logs.
+- `--tel.otelCollectIntervalMs <value>`: The interval at which to collect metrics (default: 60000).
+- `--tel.otelExportTimeoutMs <value>`: The timeout for exporting metrics (default: 30000).
+- `--tel.otelExcludeMetrics <value>`: A list of metric prefixes to exclude from export.
+- `--tel.publicMetricsCollectorUrl <value>`: A URL to publish a subset of metrics for public consumption.
+- `--tel.publicMetricsCollectFrom <value>`: The role types to collect metrics from.
+- `--tel.publicIncludeMetrics <value>`: A list of metric prefixes to publicly export.
+- `--tel.publicMetricsOptOut <value>`: Whether to opt out of sharing optional telemetry.
 
 #### Bot Options
 
 - `--bot`: Starts Aztec Bot with options.
-- `--bot.node-url <value>`: The URL to the Aztec node to check for tx pool status.
-- `--bot.node-admin-url <value>`: The URL to the Aztec node admin API to force-flush txs if configured.
-- `--bot.l1-mnemonic <value>`: The mnemonic for the account to bridge fee juice from L1.
-- `--bot.l1-private-key <value>`: The private key for the account to bridge fee juice from L1.
-- `--bot.sender-private-key <value>`: Signing private key for the sender account.
-- `--bot.sender-salt <value>`: The salt to use to instantiate the sender account.
-- `--bot.recipient-encryption-secret <value>`: Encryption secret for a recipient account (default: 0x00000000000000000000000000000000000000000000000000000000cafecafe).
-- `--bot.token-salt <value>`: The salt to use to instantiate the token contract (default: 0x0000000000000000000000000000000000000000000000000000000000000001).
-- `--bot.tx-interval-seconds <value>`: Every how many seconds should a new tx be sent (default: 60).
-- `--bot.private-transfers-per-tx <value>`: How many private token transfers are executed per tx (default: 1).
-- `--bot.public-transfers-per-tx <value>`: How many public token transfers are executed per tx (default: 1).
-- `--bot.fee-payment-method <value>`: How to handle fee payments. (Options: fee_juice) (default: fee_juice).
-- `--bot.no-start <value>`: True to not automatically setup or start the bot on initialization.
-- `--bot.tx-mined-wait-seconds <value>`: How long to wait for a tx to be mined before reporting an error (default: 180).
-- `--bot.follow-chain <value>`: Which chain the bot follows (default: NONE).
-- `--bot.max-pending-txs <value>`: Do not send a tx if the node's tx pool already has this many pending txs (default: 128).
-- `--bot.flush-setup-transactions <value>`: Make a request for the sequencer to build a block after each setup transaction.
-- `--bot.skip-public-simulation <value>`: Whether to skip public simulation of txs before sending them.
-- `--bot.l2-gas-limit <value>`: L2 gas limit for the tx (empty to have the bot trigger an estimate gas).
-- `--bot.da-gas-limit <value>`: DA gas limit for the tx (empty to have the bot trigger an estimate gas).
+- `--bot.nodeUrl <value>`: The URL to the Aztec node to check for tx pool status.
+- `--bot.nodeAdminUrl <value>`: The URL to the Aztec node admin API to force-flush txs if configured.
+- `--bot.l1Mnemonic <value>`: The mnemonic for the account to bridge fee juice from L1.
+- `--bot.l1PrivateKey <value>`: The private key for the account to bridge fee juice from L1.
+- `--bot.l1ToL2MessageTimeoutSeconds <value>`: How long to wait for L1 to L2 messages to become available on L2 (default: 3600).
+- `--bot.senderPrivateKey <value>`: Signing private key for the sender account.
+- `--bot.senderSalt <value>`: The salt to use to deploy the sender account.
+- `--bot.recipientEncryptionSecret <value>`: Encryption secret for a recipient account (default: 0x00000000000000000000000000000000000000000000000000000000cafecafe).
+- `--bot.tokenSalt <value>`: The salt to use to deploy the token contract (default: 0x0000000000000000000000000000000000000000000000000000000000000001).
+- `--bot.txIntervalSeconds <value>`: Every how many seconds should a new tx be sent (default: 60).
+- `--bot.privateTransfersPerTx <value>`: How many private token transfers are executed per tx (default: 1).
+- `--bot.publicTransfersPerTx <value>`: How many public token transfers are executed per tx (default: 1).
+- `--bot.feePaymentMethod <value>`: How to handle fee payments. (Options: fee_juice) (default: fee_juice).
+- `--bot.noStart <value>`: True to not automatically setup or start the bot on initialization.
+- `--bot.txMinedWaitSeconds <value>`: How long to wait for a tx to be mined before reporting an error (default: 180).
+- `--bot.followChain <value>`: Which chain the bot follows (default: NONE).
+- `--bot.maxPendingTxs <value>`: Do not send a tx if the node's tx pool already has this many pending txs (default: 128).
+- `--bot.flushSetupTransactions <value>`: Make a request for the sequencer to build a block after each setup transaction.
+- `--bot.l2GasLimit <value>`: L2 gas limit for the tx (empty to have the bot trigger an estimate gas).
+- `--bot.daGasLimit <value>`: DA gas limit for the tx (empty to have the bot trigger an estimate gas).
 - `--bot.contract <value>`: Token contract to use (default: TokenContract).
-- `--bot.max-consecutive-errors <value>`: The maximum number of consecutive errors before the bot shuts down.
-- `--bot.stop-when-unhealthy <value>`: Stops the bot if service becomes unhealthy.
-- `--bot.amm-txs <value>`: Deploy an AMM and send swaps to it.
+- `--bot.maxConsecutiveErrors <value>`: The maximum number of consecutive errors before the bot shuts down.
+- `--bot.stopWhenUnhealthy <value>`: Stops the bot if service becomes unhealthy.
+- `--bot.ammTxs <value>`: Deploy an AMM and send swaps to it.
+
+#### PXE Options
+- `--pxe`: Starts Aztec PXE with options.
+- `--pxe.l2BlockBatchSize <value>`: Maximum amount of blocks to pull from the stream in one request when synchronizing (default: 50).
+- `--pxe.bbBinaryPath <value>`: Path to the BB binary.
+- `--pxe.bbWorkingDirectory <value>`: Working directory for the BB binary.
+- `--pxe.bbSkipCleanup <value>`: True to skip cleanup of temporary files for debugging purposes.
+- `--pxe.proverEnabled <value>`: Enable real proofs (default: true).
+- `--pxe.nodeUrl <value>`: Custom Aztec Node URL to connect to.
 
 #### TXE Options
 
 - `--txe`: Starts Aztec TXE with options.
-
-#### Faucet Options
-
-- `--faucet`: Starts the Aztec faucet.
-- `--faucet.api-server`: Starts a simple HTTP server to access the faucet (default: true).
-- `--faucet.api-server-port <value>`: The port on which to start the api server on (default: 8080).
-- `--faucet.viem-polling-interval-ms <value>`: The polling interval viem uses in ms (default: 1000).
-- `--faucet.l1-mnemonic <value>`: The mnemonic for the faucet account.
-- `--faucet.mnemonic-account-index <value>`: The account to use.
-- `--faucet.interval <value>`: How often the faucet can be dripped (default: 3600000).
-- `--faucet.eth-amount <value>`: How much eth the faucet should drip per call (default: 1.0).
-- `--faucet.l1-assets <value>`: Which other L1 assets the faucet is able to drip.
 
 ### Test
 

--- a/docs/docs/the_aztec_network/reference/cli_reference.md
+++ b/docs/docs/the_aztec_network/reference/cli_reference.md
@@ -31,884 +31,707 @@ If two subsystems can contain the same configuration option, only one needs to b
 ```bash
   MISC
 
-    --network <value>                                                                                                              ($NETWORK)
+    --network <value>                                                                                                                      ($NETWORK)
           Network to run Aztec on
 
-    --auto-update <value>                                          (default: disabled)                                           ($AUTO_UPDATE)
-          Configure auto updates
+    --auto-update <value>                                                    (default: disabled)                                           ($AUTO_UPDATE)
+          The auto update mode for this node
 
-    --auto-update-url <value>                                                                                                     ($AUTO_UPDATE_URL)
-          Configure where to get updates from
+    --auto-update-url <value>                                                                                                              ($AUTO_UPDATE_URL)
+          Base URL to check for updates
+
+    --sync-mode <value>                                                      (default: snapshot)                                           ($SYNC_MODE)
+          Set sync mode to `full` to always sync via L1, `snapshot` to download a snapshot if there is no local data, `force-snapshot` to download even if there is local data.
+
+    --snapshots-url <value>                                                                                                                ($SYNC_SNAPSHOTS_URL)
+          Base URL for snapshots index.
 
   SANDBOX
 
     --sandbox
           Starts Aztec Sandbox
 
+    --sandbox.noPXE                                                                                                                        ($NO_PXE)
+          Do not expose PXE service on sandbox start
+
+    --sandbox.l1Mnemonic <value>                                             (default: test test test test test test test test test test test junk)($MNEMONIC)
+          Mnemonic for L1 accounts. Will be used
+
+    --sandbox.deployAztecContractsSalt <value>                                                                                             ($DEPLOY_AZTEC_CONTRACTS_SALT)
+          Numeric salt for deploying L1 Aztec contracts before starting the sandbox. Needs mnemonic or private key to be set.
+
   API
 
-    --port <value>                                                 (default: 8080)                                               ($AZTEC_PORT)
+    --port <value>                                                           (default: 8080)                                               ($AZTEC_PORT)
           Port to run the Aztec Services on
 
-    --admin-port <value>                                           (default: 8880)                                               ($AZTEC_ADMIN_PORT)
-          Port to run admin APIs of Aztec Services on on
+    --admin-port <value>                                                     (default: 8880)                                               ($AZTEC_ADMIN_PORT)
+          Port to run admin APIs of Aztec Services on
 
-    --api-prefix <value>                                                                                                          ($API_PREFIX)
+    --api-prefix <value>                                                                                                                   ($API_PREFIX)
           Prefix for API routes on any service that is started
 
   ETHEREUM
 
-    --l1-rpc-urls <value>                                          (default: http://localhost:8545)                              ($ETHEREUM_HOSTS)
-          List of URLs of the Ethereum RPC nodes that services will connect to (comma separated)
+    --l1-chain-id <value>                                                                                                                  ($L1_CHAIN_ID)
+          The chain ID of the ethereum host.
 
-    --l1-chain-id <value>                                          (default: 31337)                                              ($L1_CHAIN_ID)
-          The L1 chain ID
+    --l1-rpc-urls <value>                                                                                                                  ($ETHEREUM_HOSTS)
+          List of URLs of Ethereum RPC nodes that services will connect to (comma separated).
 
-    --l1-mnemonic <value>                                          (default: test test test test test test test test test test test junk) ($MNEMONIC)
-          Mnemonic for L1 accounts. Will be used if no publisher private keys are provided
-
-    --l1-consensus-host-urls <value>                               (default: )                                                   ($L1_CONSENSUS_HOST_URLS)
+    --l1-consensus-host-urls <value>                                                                                                       ($L1_CONSENSUS_HOST_URLS)
           List of URLs of the Ethereum consensus nodes that services will connect to (comma separated)
 
-    --l1-consensus-host-api-keys <value>                           (default: )                                                   ($L1_CONSENSUS_HOST_API_KEYS)
-          List of API keys for the corresponding Ethereum consensus nodes
+    --l1-consensus-host-api-keys <value>                                                                                                   ($L1_CONSENSUS_HOST_API_KEYS)
+          List of API keys for the corresponding L1 consensus clients, if needed. Added to the end of the corresponding URL as "?key=<api-key>" unless a header is defined
 
-    --l1-consensus-host-api-key-headers <value>                    (default: )                                                   ($L1_CONSENSUS_HOST_API_KEY_HEADERS)
-          List of API key headers for the corresponding Ethereum consensus nodes. If not set, the api key for the corresponding node will be appended to the URL as ?key=<api-key>
+    --l1-consensus-host-api-key-headers <value>                                                                                            ($L1_CONSENSUS_HOST_API_KEY_HEADERS)
+          List of header names for the corresponding L1 consensus client API keys, if needed. Added to the corresponding request as "<api-key-header>: <api-key>"
+
+  L1 CONTRACTS
+
+    --registry-address <value>                                                                                                             ($REGISTRY_CONTRACT_ADDRESS)
+          The deployed L1 registry contract address.
+
+    --rollup-version <value>                                                                                                               ($ROLLUP_VERSION)
+          The version of the rollup.
 
   STORAGE
 
-    --data-directory <value>                                                                                                      ($DATA_DIRECTORY)
-          Where to store data for services. If not set, will store temporarily
+    --data-directory <value>                                                                                                               ($DATA_DIRECTORY)
+          Optional dir to store data. If omitted will store in memory.
 
-    --data-store-map-size-kb <value>                                                                                              ($DATA_STORE_MAP_SIZE_KB)
-          The maximum possible size of the data store DB in KB. Can be overridden by component-specific options.
+    --data-store-map-size-kb <value>                                         (default: 134217728)                                          ($DATA_STORE_MAP_SIZE_KB)
+          The maximum possible size of a data store DB in KB. Can be overridden by component-specific options.
 
-  L1 CONTRACT ADDRESSES
+  WORLD STATE
 
-    --rollup-address <value>                                                                                                      ($ROLLUP_CONTRACT_ADDRESS)
-          The deployed L1 rollup contract address
+    --world-state-data-directory <value>                                                                                                   ($WS_DATA_DIRECTORY)
+          Optional directory for the world state database
 
-    --registry-address <value>                                                                                                    ($REGISTRY_CONTRACT_ADDRESS)
-          The deployed L1 registry contract address
+    --world-state-db-map-size-kb <value>                                                                                                   ($WS_DB_MAP_SIZE_KB)
+          The maximum possible size of the world state DB in KB. Overwrites the general dataStoreMapSizeKB.
 
-    --inbox-address <value>                                                                                                       ($INBOX_CONTRACT_ADDRESS)
-          The deployed L1 -> L2 inbox contract address
-
-    --outbox-address <value>                                                                                                      ($OUTBOX_CONTRACT_ADDRESS)
-          The deployed L2 -> L1 outbox contract address
-
-    --fee-juice-address <value>                                                                                                   ($FEE_JUICE_CONTRACT_ADDRESS)
-          The deployed L1 Fee Juice contract address
-
-    --staking-asset-address <value>                                                                                               ($STAKING_ASSET_CONTRACT_ADDRESS)
-          The deployed L1 Staking Asset contract address
-
-    --fee-juice-portal-address <value>                                                                                            ($FEE_JUICE_PORTAL_CONTRACT_ADDRESS)
-          The deployed L1 Fee Juice portal contract address
+    --world-state-block-history <value>                                      (default: 64)                                                 ($WS_NUM_HISTORIC_BLOCKS)
+          The number of historic blocks to maintain. Values less than 1 mean all history is maintained
 
   AZTEC NODE
 
     --node
           Starts Aztec Node with options
 
-    --node.archiverUrl <value>                                                                                                    ($ARCHIVER_URL)
-          URL for an archiver service
-
-    --node.deployAztecContracts                                                                                                   ($DEPLOY_AZTEC_CONTRACTS)
-          Deploys L1 Aztec contracts before starting the node. Needs mnemonic or private key to be set.
-
-    --node.deployAztecContractsSalt <value>                                                                                       ($DEPLOY_AZTEC_CONTRACTS_SALT)
-          Numeric salt for deploying L1 Aztec contracts before starting the node. Needs mnemonic or private key to be set. Implies --node.deployAztecContracts.
-
-    --node.assumeProvenThroughBlockNumber <value>                                                                                 ($ASSUME_PROVEN_THROUGH_BLOCK_NUMBER)
-          Cheats the rollup contract into assuming every block until this one is proven. Useful for speeding up bootstraps.
-
-    --node.publisherPrivateKey <value>                                                                                            ($L1_PRIVATE_KEY)
-          Private key of account for publishing L1 contracts
-
-    --node.worldStateBlockCheckIntervalMS <value>                  (default: 100)                                                ($WS_BLOCK_CHECK_INTERVAL_MS)
-          Frequency in which to check for blocks in ms
-
-    --node.syncMode <value>                                        (default: snapshot)                                           ($SYNC_MODE)
-          Set sync mode to `full` to always sync via L1, `snapshot` to download a snapshot if there is no local data, `force-snapshot` to download even if there is local data.
-
-    --node.snapshotsUrl <value>                                                                                                   ($SYNC_SNAPSHOTS_URL)
-          Base URL for downloading snapshots for snapshot sync.
-
-  P2P SUBSYSTEM
-
-    --p2p-enabled [value]                                                                                                         ($P2P_ENABLED)
-          Enable P2P subsystem
-
-    --p2p.blockCheckIntervalMS <value>                             (default: 100)                                                ($P2P_BLOCK_CHECK_INTERVAL_MS)
-          The frequency in which to check for new L2 blocks.
-
-    --p2p.debugDisableColocationPenalty <value>                                                                                   ($DEBUG_P2P_DISABLE_COLOCATION_PENALTY)
-          DEBUG: Disable colocation penalty - NEVER set to true in production
-
-    --p2p.peerCheckIntervalMS <value>                              (default: 30000)                                              ($P2P_PEER_CHECK_INTERVAL_MS)
-          The frequency in which to check for new peers.
-
-    --p2p.l2QueueSize <value>                                      (default: 1000)                                               ($P2P_L2_QUEUE_SIZE)
-          Size of queue of L2 blocks to store.
-
-    --p2p.listenAddress <value>                                    (default: 0.0.0.0)                                            ($P2P_LISTEN_ADDR)
-          The listen address. ipv4 address.
-
-    --p2p.p2pPort <value>                                          (default: 40400)                                              ($P2P_PORT)
-          The port for the P2P service. Defaults to 40400
-
-    --p2p.p2pBroadcastPort <value>                                                                                                ($P2P_BROADCAST_PORT)
-          The port to broadcast the P2P service on (included in the node's ENR). Defaults to P2P_PORT.
-
-    --p2p.p2pIp <value>                                                                                                           ($P2P_IP)
-          The IP address for the P2P service. ipv4 address.
-
-    --p2p.peerIdPrivateKey <value>                                                                                                ($PEER_ID_PRIVATE_KEY)
-          An optional peer id private key. If blank, will generate a random key.
-
-    --p2p.peerIdPrivateKeyPath <value>                                                                                            ($PEER_ID_PRIVATE_KEY_PATH)
-          An optional path to store generated peer id private keys. If blank, will default to storing any generated keys in the root of the data directory.
-
-    --p2p.bootstrapNodes <value>                                   (default: )                                                   ($BOOTSTRAP_NODES)
-          A list of bootstrap peer ENRs to connect to. Separated by commas.
-
-    --p2p.bootstrapNodeEnrVersionCheck <value>                                                                                    ($P2P_BOOTSTRAP_NODE_ENR_VERSION_CHECK)
-          Whether to check the version of the bootstrap node ENR.
-
-    --p2p.bootstrapNodesAsFullPeers <value>                                                                                       ($P2P_BOOTSTRAP_NODES_AS_FULL_PEERS)
-          Whether to consider our configured bootnodes as full peers
-
-    --p2p.maxPeerCount <value>                                     (default: 100)                                                ($P2P_MAX_PEERS)
-          The maximum number of peers to connect to.
-
-    --p2p.queryForIp <value>                                                                                                      ($P2P_QUERY_FOR_IP)
-          If announceUdpAddress or announceTcpAddress are not provided, query for the IP address of the machine. Default is false.
-
-    --p2p.gossipsubInterval <value>                                (default: 700)                                                ($P2P_GOSSIPSUB_INTERVAL_MS)
-          The interval of the gossipsub heartbeat to perform maintenance tasks.
-
-    --p2p.gossipsubD <value>                                       (default: 8)                                                  ($P2P_GOSSIPSUB_D)
-          The D parameter for the gossipsub protocol.
-
-    --p2p.gossipsubDlo <value>                                     (default: 4)                                                  ($P2P_GOSSIPSUB_DLO)
-          The Dlo parameter for the gossipsub protocol.
-
-    --p2p.gossipsubDhi <value>                                     (default: 12)                                                 ($P2P_GOSSIPSUB_DHI)
-          The Dhi parameter for the gossipsub protocol.
-
-    --p2p.gossipsubDLazy <value>                                   (default: 8)                                                  ($P2P_GOSSIPSUB_DLAZY)
-          The Dlazy parameter for the gossipsub protocol.
-
-    --p2p.gossipsubFloodPublish <value>                                                                                           ($P2P_GOSSIPSUB_FLOOD_PUBLISH)
-          Whether to flood publish messages. - For testing purposes only
-
-    --p2p.gossipsubMcacheLength <value>                            (default: 6)                                                  ($P2P_GOSSIPSUB_MCACHE_LENGTH)
-          The number of gossipsub interval message cache windows to keep.
-
-    --p2p.gossipsubMcacheGossip <value>                            (default: 3)                                                  ($P2P_GOSSIPSUB_MCACHE_GOSSIP)
-          How many message cache windows to include when gossiping with other peers.
-
-    --p2p.gossipsubSeenTTL <value>                                 (default: 1200000)                                            ($P2P_GOSSIPSUB_SEEN_TTL)
-          How long to keep message IDs in the seen cache.
-
-    --p2p.gossipsubTxTopicWeight <value>                           (default: 1)                                                  ($P2P_GOSSIPSUB_TX_TOPIC_WEIGHT)
-          The weight of the tx topic for the gossipsub protocol.
-
-    --p2p.gossipsubTxInvalidMessageDeliveriesWeight <value>        (default: -20)                                                ($P2P_GOSSIPSUB_TX_INVALID_MESSAGE_DELIVERIES_WEIGHT)
-          The weight of the tx invalid message deliveries for the gossipsub protocol.
-
-    --p2p.gossipsubTxInvalidMessageDeliveriesDecay <value>         (default: 0.5)                                                ($P2P_GOSSIPSUB_TX_INVALID_MESSAGE_DELIVERIES_DECAY)
-          Determines how quickly the penalty for invalid message deliveries decays over time. Between 0 and 1.
-
-    --p2p.peerPenaltyValues <value>                                (default: 2,10,50)                                            ($P2P_PEER_PENALTY_VALUES)
-          The values for the peer scoring system. Passed as a comma separated list of values in order: low, mid, high tolerance errors.
-
-    --p2p.doubleSpendSeverePeerPenaltyWindow <value>               (default: 30)                                                 ($P2P_DOUBLE_SPEND_SEVERE_PEER_PENALTY_WINDOW)
-          The "age" (in L2 blocks) of a tx after which we heavily penalize a peer for sending it.
-
-    --p2p.blockRequestBatchSize <value>                            (default: 20)                                                 ($P2P_BLOCK_REQUEST_BATCH_SIZE)
-          The number of blocks to fetch in a single batch.
-
-    --p2p.archivedTxLimit <value>                                                                                                 ($P2P_ARCHIVED_TX_LIMIT)
-          The number of transactions that will be archived. If the limit is set to 0 then archiving will be disabled.
-
-    --p2p.trustedPeers <value>                                     (default: )                                                   ($P2P_TRUSTED_PEERS)
-          A list of trusted peer ENRs that will always be persisted. Separated by commas.
-
-    --p2p.privatePeers <value>                                     (default: )                                                   ($P2P_PRIVATE_PEERS)
-          A list of private peer ENRs that will always be persisted and not be used for discovery. Separated by commas.
-
-    --p2p.p2pStoreMapSizeKb <value>                                                                                               ($P2P_STORE_MAP_SIZE_KB)
-          The maximum possible size of the P2P DB in KB. Overwrites the general dataStoreMapSizeKB.
-
-    --p2p.txPublicSetupAllowList <value>                                                                                          ($TX_PUBLIC_SETUP_ALLOWLIST)
-          The list of functions calls allowed to run in setup
-
-    --p2p.maxTxPoolSize <value>                                    (default: 100000000)                                          ($P2P_MAX_TX_POOL_SIZE)
-          The maximum cumulative tx size of pending txs (in bytes) before evicting lower priority txs.
-
-    --p2p.txPoolOverflowFactor <value>                             (default: 1.1)                                                ($P2P_TX_POOL_OVERFLOW_FACTOR)
-          How much the tx pool can overflow before it starts evicting txs. Must be greater than 1
-
-    --p2p.seenMessageCacheSize <value>                             (default: 100000)                                             ($P2P_SEEN_MSG_CACHE_SIZE)
-          The number of messages to keep in the seen message cache
-
-    --p2p.p2pDisableStatusHandshake <value>                                                                                       ($P2P_DISABLE_STATUS_HANDSHAKE)
-          True to disable the status handshake on peer connected.
-
-    --p2p.overallRequestTimeoutMs <value>                          (default: 4000)                                               ($P2P_REQRESP_OVERALL_REQUEST_TIMEOUT_MS)
-          The overall timeout for a request response operation.
-
-    --p2p.individualRequestTimeoutMs <value>                       (default: 2000)                                               ($P2P_REQRESP_INDIVIDUAL_REQUEST_TIMEOUT_MS)
-          The timeout for an individual request response peer interaction.
-
-    --p2p.p2pOptimisticNegotiation <value>                                                                                        ($P2P_REQRESP_OPTIMISTIC_NEGOTIATION)
-          Whether to use optimistic protocol negotiation when dialing to another peer (opposite of `negotiateFully`).
-
-    --p2p.rollupVersion <value>                                                                                                   ($ROLLUP_VERSION)
-          The version of the rollup.
-
-  TELEMETRY
-
-    --tel.metricsCollectorUrl <value>                                                                                             ($OTEL_EXPORTER_OTLP_METRICS_ENDPOINT)
-          The URL of the telemetry collector for metrics
-
-    --tel.tracesCollectorUrl <value>                                                                                              ($OTEL_EXPORTER_OTLP_TRACES_ENDPOINT)
-          The URL of the telemetry collector for traces
-
-    --tel.logsCollectorUrl <value>                                                                                                ($OTEL_EXPORTER_OTLP_LOGS_ENDPOINT)
-          The URL of the telemetry collector for logs
-
-    --tel.otelCollectIntervalMs <value>                            (default: 60000)                                              ($OTEL_COLLECT_INTERVAL_MS)
-          The interval at which to collect metrics
-
-    --tel.otelExportTimeoutMs <value>                              (default: 30000)                                              ($OTEL_EXPORT_TIMEOUT_MS)
-          The timeout for exporting metrics
-
-    --tel.otelExcludeMetrics <value>                               (default: )                                                   ($OTEL_EXCLUDE_METRICS)
-          A list of metric prefixes to exclude from export
-
-    --tel.publicMetricsCollectorUrl <value>                                                                                       ($PUBLIC_OTEL_EXPORTER_OTLP_METRICS_ENDPOINT)
-          A URL to publish a subset of metrics for public consumption
-
-    --tel.publicMetricsCollectFrom <value>                         (default: )                                                   ($PUBLIC_OTEL_COLLECT_FROM)
-          The role types to collect metrics from
-
-    --tel.publicIncludeMetrics <value>                             (default: )                                                   ($PUBLIC_OTEL_INCLUDE_METRICS)
-          A list of metric prefixes to publicly export
-
-    --tel.publicMetricsOptOut <value>                                                                                             ($PUBLIC_OTEL_OPT_OUT)
-          Whether to opt out of sharing optional telemetry
-
-  PXE
-
-    --pxe
-          Starts Aztec PXE with options
-
-    --pxe.dataStoreMapSizeKB <value>                               (default: 134217728)                                          ($DATA_STORE_MAP_SIZE_KB)
-          DB mapping size to be applied to all key/value stores
-
-    --pxe.rollupVersion <value>                                                                                                   ($ROLLUP_VERSION)
-          The version of the rollup.
-
-    --pxe.l2BlockBatchSize <value>                                 (default: 50)                                                 ($PXE_L2_BLOCK_BATCH_SIZE)
-          Maximum amount of blocks to pull from the stream in one request when synchronizing
-
-    --pxe.bbBinaryPath <value>                                                                                                    ($BB_BINARY_PATH)
-          Path to the BB binary
-
-    --pxe.bbWorkingDirectory <value>                                                                                              ($BB_WORKING_DIRECTORY)
-          Working directory for the BB binary
-
-    --pxe.bbSkipCleanup <value>                                                                                                   ($BB_SKIP_CLEANUP)
-          True to skip cleanup of temporary files for debugging purposes
-
-    --pxe.proverEnabled <value>                                    (default: true)                                               ($PXE_PROVER_ENABLED)
-          Enable real proofs
-
-    --pxe.nodeUrl <value>                                                                                                         ($AZTEC_NODE_URL)
-          Custom Aztec Node URL to connect to
-
   ARCHIVER
 
     --archiver
           Starts Aztec Archiver with options
 
-    --archiver.blobSinkUrl <value>                                                                                                ($BLOB_SINK_URL)
+    --archiver.blobSinkUrl <value>                                                                                                         ($BLOB_SINK_URL)
           The URL of the blob sink
 
-    --archiver.blobSinkMapSizeKb <value>                                                                                          ($BLOB_SINK_MAP_SIZE_KB)
+    --archiver.blobSinkMapSizeKb <value>                                                                                                   ($BLOB_SINK_MAP_SIZE_KB)
           The maximum possible size of the blob sink DB in KB. Overwrites the general dataStoreMapSizeKB.
 
-    --archiver.archiveApiUrl <value>                                                                                              ($BLOB_SINK_ARCHIVE_API_URL)
+    --archiver.archiveApiUrl <value>                                                                                                       ($BLOB_SINK_ARCHIVE_API_URL)
           The URL of the archive API
 
-    --archiver.archiverPollingIntervalMS <value>                   (default: 500)                                                ($ARCHIVER_POLLING_INTERVAL_MS)
+    --archiver.archiverPollingIntervalMS <value>                             (default: 500)                                                ($ARCHIVER_POLLING_INTERVAL_MS)
           The polling interval in ms for retrieving new L2 blocks and encrypted logs.
 
-    --archiver.archiverBatchSize <value>                           (default: 100)                                                ($ARCHIVER_BATCH_SIZE)
+    --archiver.archiverBatchSize <value>                                     (default: 100)                                                ($ARCHIVER_BATCH_SIZE)
           The number of L2 blocks the archiver will attempt to download at a time.
 
-    --archiver.maxLogs <value>                                     (default: 1000)                                               ($ARCHIVER_MAX_LOGS)
+    --archiver.maxLogs <value>                                               (default: 1000)                                               ($ARCHIVER_MAX_LOGS)
           The max number of logs that can be obtained in 1 "getPublicLogs" call.
 
-    --archiver.archiverStoreMapSizeKb <value>                                                                                     ($ARCHIVER_STORE_MAP_SIZE_KB)
+    --archiver.archiverStoreMapSizeKb <value>                                                                                              ($ARCHIVER_STORE_MAP_SIZE_KB)
           The maximum possible size of the archiver DB in KB. Overwrites the general dataStoreMapSizeKB.
 
-    --archiver.rollupVersion <value>                                                                                              ($ROLLUP_VERSION)
-          The version of the rollup.
-
-    --archiver.viemPollingIntervalMS <value>                       (default: 1000)                                               ($ARCHIVER_VIEM_POLLING_INTERVAL_MS)
-          The polling interval viem uses in ms
-
-    --archiver.ethereumSlotDuration <value>                        (default: 12)                                                 ($ETHEREUM_SLOT_DURATION)
-          How many seconds an L1 slot lasts.
-
-    --archiver.aztecSlotDuration <value>                           (default: 36)                                                 ($AZTEC_SLOT_DURATION)
-          How many seconds an L2 slots lasts (must be multiple of ethereum slot duration).
-
-    --archiver.aztecEpochDuration <value>                          (default: 32)                                                 ($AZTEC_EPOCH_DURATION)
-          How many L2 slots an epoch lasts (maximum AZTEC_MAX_EPOCH_DURATION).
-
-    --archiver.aztecTargetCommitteeSize <value>                    (default: 48)                                                 ($AZTEC_TARGET_COMMITTEE_SIZE)
-          The target validator committee size.
-
-    --archiver.aztecProofSubmissionEpochs <value>                  (default: 1)                                                  ($AZTEC_PROOF_SUBMISSION_EPOCHS)
-          The number of epochs after an epoch ends that proofs are still accepted.
-
-    --archiver.activationThreshold <value>                               (default: 100000000000000000000)                              ($AZTEC_ACTIVATION_THRESHOLD)
-          The deposit amount for a validator
-
-    --archiver.ejectionThreshold <value>                                (default: 50000000000000000000)                               ($AZTEC_EJECTION_THRESHOLD)
-          The minimum stake for a validator.
-
-    --archiver.slashingQuorum <value>                              (default: 101)                                                ($AZTEC_SLASHING_QUORUM)
-          The slashing quorum
-
-    --archiver.slashingRoundSize <value>                           (default: 200)                                                ($AZTEC_SLASHING_ROUND_SIZE)
-          The slashing round size
-
-    --archiver.governanceProposerQuorum <value>                    (default: 151)                                                ($AZTEC_GOVERNANCE_PROPOSER_QUORUM)
-          The governance proposing quorum
-
-    --archiver.governanceProposerRoundSize <value>                 (default: 300)                                                ($AZTEC_GOVERNANCE_PROPOSER_ROUND_SIZE)
-          The governance proposing round size
-
-    --archiver.manaTarget <value>                                  (default: 10000000000)                                        ($AZTEC_MANA_TARGET)
-          The mana target for the rollup
-
-    --archiver.provingCostPerMana <value>                          (default: 100)                                                ($AZTEC_PROVING_COST_PER_MANA)
-          The proving cost per mana
-
-    --archiver.exitDelaySeconds <value>                            (default: 172800)                                             ($AZTEC_EXIT_DELAY_SECONDS)
-          The delay before a validator can exit the set
-
-    --archiver.gasLimitBufferPercentage <value>                    (default: 20)                                                 ($L1_GAS_LIMIT_BUFFER_PERCENTAGE)
-          How much to increase calculated gas limit by (percentage)
-
-    --archiver.maxGwei <value>                                     (default: 500)                                                ($L1_GAS_PRICE_MAX)
-          Maximum gas price in gwei
-
-    --archiver.maxBlobGwei <value>                                 (default: 1500)                                               ($L1_BLOB_FEE_PER_GAS_MAX)
-          Maximum blob fee per gas in gwei
-
-    --archiver.priorityFeeBumpPercentage <value>                   (default: 20)                                                 ($L1_PRIORITY_FEE_BUMP_PERCENTAGE)
-          How much to increase priority fee by each attempt (percentage)
-
-    --archiver.priorityFeeRetryBumpPercentage <value>              (default: 50)                                                 ($L1_PRIORITY_FEE_RETRY_BUMP_PERCENTAGE)
-          How much to increase priority fee by each retry attempt (percentage)
-
-    --archiver.fixedPriorityFeePerGas <value>                                                                                     ($L1_FIXED_PRIORITY_FEE_PER_GAS)
-          Fixed priority fee per gas in Gwei. Overrides any priority fee bump percentage
-
-    --archiver.maxAttempts <value>                                 (default: 3)                                                  ($L1_TX_MONITOR_MAX_ATTEMPTS)
-          Maximum number of speed-up attempts
-
-    --archiver.checkIntervalMs <value>                             (default: 1000)                                               ($L1_TX_MONITOR_CHECK_INTERVAL_MS)
-          How often to check tx status
-
-    --archiver.stallTimeMs <value>                                 (default: 24000)                                              ($L1_TX_MONITOR_STALL_TIME_MS)
-          How long before considering tx stalled
-
-    --archiver.txTimeoutMs <value>                                 (default: 120000)                                             ($L1_TX_MONITOR_TX_TIMEOUT_MS)
-          How long to wait for a tx to be mined before giving up. Set to 0 to disable.
-
-    --archiver.txPropagationMaxQueryAttempts <value>               (default: 3)                                                  ($L1_TX_PROPAGATION_MAX_QUERY_ATTEMPTS)
-          How many attempts will be done to get a tx after it was sent
-
-    --archiver.cancelTxOnTimeout <value>                           (default: true)                                               ($L1_TX_MONITOR_CANCEL_TX_ON_TIMEOUT)
-          Whether to attempt to cancel a tx if it's not mined after txTimeoutMs
+    --archiver.skipValidateBlockAttestations <value>
+          Whether to skip validating block attestations (use only for testing).
 
   SEQUENCER
 
     --sequencer
           Starts Aztec Sequencer with options
 
-    --sequencer.validatorPrivateKeys <value>                       (default: [Redacted])                                         ($VALIDATOR_PRIVATE_KEYS)
+    --sequencer.validatorPrivateKeys <value>                                 (default: [Redacted])                                         ($VALIDATOR_PRIVATE_KEYS)
           List of private keys of the validators participating in attestation duties
 
-    --sequencer.disableValidator <value>                                                                                          ($VALIDATOR_DISABLED)
+    --sequencer.validatorAddresses <value>                                   (default: )                                                   ($VALIDATOR_ADDRESSES)
+          List of addresses of the validators to use with remote signers
+
+    --sequencer.disableValidator <value>                                                                                                   ($VALIDATOR_DISABLED)
           Do not run the validator
 
-    --sequencer.attestationPollingIntervalMs <value>               (default: 200)                                                ($VALIDATOR_ATTESTATIONS_POLLING_INTERVAL_MS)
+    --sequencer.disabledValidators <value>                                   (default: )
+          Temporarily disable these specific validator addresses
+
+    --sequencer.attestationPollingIntervalMs <value>                         (default: 200)                                                ($VALIDATOR_ATTESTATIONS_POLLING_INTERVAL_MS)
           Interval between polling for new attestations
 
-    --sequencer.validatorReexecute <value>                         (default: true)                                               ($VALIDATOR_REEXECUTE)
+    --sequencer.validatorReexecute <value>                                   (default: true)                                               ($VALIDATOR_REEXECUTE)
           Re-execute transactions before attesting
 
-    --sequencer.validatorReexecuteDeadlineMs <value>               (default: 6000)                                               ($VALIDATOR_REEXECUTE_DEADLINE_MS)
+    --sequencer.validatorReexecuteDeadlineMs <value>                         (default: 6000)                                               ($VALIDATOR_REEXECUTE_DEADLINE_MS)
           Will re-execute until this many milliseconds are left in the slot
 
-    --sequencer.transactionPollingIntervalMS <value>               (default: 500)                                                ($SEQ_TX_POLLING_INTERVAL_MS)
+    --sequencer.alwaysReexecuteBlockProposals <value>                                                                                      ($ALWAYS_REEXECUTE_BLOCK_PROPOSALS)
+          Whether to always reexecute block proposals, even for non-validator nodes (useful for monitoring network status).
+
+    --sequencer.transactionPollingIntervalMS <value>                         (default: 500)                                                ($SEQ_TX_POLLING_INTERVAL_MS)
           The number of ms to wait between polling for pending txs.
 
-    --sequencer.maxTxsPerBlock <value>                             (default: 32)                                                 ($SEQ_MAX_TX_PER_BLOCK)
+    --sequencer.maxTxsPerBlock <value>                                       (default: 32)                                                 ($SEQ_MAX_TX_PER_BLOCK)
           The maximum number of txs to include in a block.
 
-    --sequencer.minTxsPerBlock <value>                             (default: 1)                                                  ($SEQ_MIN_TX_PER_BLOCK)
+    --sequencer.minTxsPerBlock <value>                                       (default: 1)                                                  ($SEQ_MIN_TX_PER_BLOCK)
           The minimum number of txs to include in a block.
 
-    --sequencer.publishTxsWithProposals <value>                                                                                   ($SEQ_PUBLISH_TXS_WITH_PROPOSALS)
+    --sequencer.publishTxsWithProposals <value>                                                                                            ($SEQ_PUBLISH_TXS_WITH_PROPOSALS)
           Whether to publish txs with proposals.
 
-    --sequencer.maxL2BlockGas <value>                              (default: 10000000000)                                        ($SEQ_MAX_L2_BLOCK_GAS)
+    --sequencer.maxL2BlockGas <value>                                        (default: 10000000000)                                        ($SEQ_MAX_L2_BLOCK_GAS)
           The maximum L2 block gas.
 
-    --sequencer.maxDABlockGas <value>                              (default: 10000000000)                                        ($SEQ_MAX_DA_BLOCK_GAS)
+    --sequencer.maxDABlockGas <value>                                        (default: 10000000000)                                        ($SEQ_MAX_DA_BLOCK_GAS)
           The maximum DA block gas.
 
-    --sequencer.coinbase <value>                                                                                                  ($COINBASE)
+    --sequencer.coinbase <value>                                                                                                           ($COINBASE)
           Recipient of block reward.
 
-    --sequencer.feeRecipient <value>                                                                                              ($FEE_RECIPIENT)
+    --sequencer.feeRecipient <value>                                                                                                       ($FEE_RECIPIENT)
           Address to receive fees.
 
-    --sequencer.acvmWorkingDirectory <value>                                                                                      ($ACVM_WORKING_DIRECTORY)
+    --sequencer.acvmWorkingDirectory <value>                                                                                               ($ACVM_WORKING_DIRECTORY)
           The working directory to use for simulation/proving
 
-    --sequencer.acvmBinaryPath <value>                                                                                            ($ACVM_BINARY_PATH)
+    --sequencer.acvmBinaryPath <value>                                                                                                     ($ACVM_BINARY_PATH)
           The path to the ACVM binary
 
-    --sequencer.maxBlockSizeInBytes <value>                        (default: 1048576)                                            ($SEQ_MAX_BLOCK_SIZE_IN_BYTES)
+    --sequencer.maxBlockSizeInBytes <value>                                  (default: 1048576)                                            ($SEQ_MAX_BLOCK_SIZE_IN_BYTES)
           Max block size
 
-    --sequencer.enforceTimeTable <value>                           (default: true)                                               ($SEQ_ENFORCE_TIME_TABLE)
+    --sequencer.enforceTimeTable <value>                                     (default: true)                                               ($SEQ_ENFORCE_TIME_TABLE)
           Whether to enforce the time table when building blocks
 
-    --sequencer.governanceProposerPayload <value>                  (default: 0x0000000000000000000000000000000000000000)         ($GOVERNANCE_PROPOSER_PAYLOAD_ADDRESS)
+    --sequencer.governanceProposerPayload <value>                            (default: 0x0000000000000000000000000000000000000000)         ($GOVERNANCE_PROPOSER_PAYLOAD_ADDRESS)
           The address of the payload for the governanceProposer
 
-    --sequencer.maxL1TxInclusionTimeIntoSlot <value>                                                                              ($SEQ_MAX_L1_TX_INCLUSION_TIME_INTO_SLOT)
+    --sequencer.maxL1TxInclusionTimeIntoSlot <value>                                                                                       ($SEQ_MAX_L1_TX_INCLUSION_TIME_INTO_SLOT)
           How many seconds into an L1 slot we can still send a tx and get it mined.
 
-    --sequencer.txPublicSetupAllowList <value>                                                                                    ($TX_PUBLIC_SETUP_ALLOWLIST)
+    --sequencer.attestationPropagationTime <value>                           (default: 2)                                                  ($SEQ_ATTESTATION_PROPAGATION_TIME)
+          How many seconds it takes for proposals and attestations to travel across the p2p layer (one-way)
+
+    --sequencer.secondsBeforeInvalidatingBlockAsCommitteeMember <value>      (default: 144)                                                ($SEQ_SECONDS_BEFORE_INVALIDATING_BLOCK_AS_COMMITTEE_MEMBER)
+          How many seconds to wait before trying to invalidate a block from the pending chain as a committee member (zero to never invalidate). The next proposer is expected to invalidate, so the committee acts as a fallback.
+
+    --sequencer.secondsBeforeInvalidatingBlockAsNonCommitteeMember <value>   (default: 432)                                                ($SEQ_SECONDS_BEFORE_INVALIDATING_BLOCK_AS_NON_COMMITTEE_MEMBER)
+          How many seconds to wait before trying to invalidate a block from the pending chain as a non-committee member (zero to never invalidate). The next proposer is expected to invalidate, then the committee, so other sequencers act as a fallback.
+
+    --sequencer.txPublicSetupAllowList <value>                                                                                             ($TX_PUBLIC_SETUP_ALLOWLIST)
           The list of functions calls allowed to run in setup
 
-    --sequencer.viemPollingIntervalMS <value>                      (default: 1000)                                               ($L1_READER_VIEM_POLLING_INTERVAL_MS)
-          The polling interval viem uses in ms
+    --sequencer.keyStoreDirectory <value>                                                                                                  ($KEY_STORE_DIRECTORY)
+          Location of key store directory
 
-    --sequencer.customForwarderContractAddress <value>             (default: 0x0000000000000000000000000000000000000000)         ($CUSTOM_FORWARDER_CONTRACT_ADDRESS)
-          The address of the custom forwarder contract.
+    --sequencer.publisherPrivateKeys <value>                                 (default: )                                                   ($SEQ_PUBLISHER_PRIVATE_KEYS)
+          The private keys to be used by the publisher.
 
-    --sequencer.publisherPrivateKey <value>                        (default: [Redacted])                                         ($SEQ_PUBLISHER_PRIVATE_KEY)
-          The private key to be used by the publisher.
+    --sequencer.publisherAddresses <value>                                   (default: )                                                   ($SEQ_PUBLISHER_ADDRESSES)
+          The addresses of the publishers to use with remote signers
 
-    --sequencer.l1PublishRetryIntervalMS <value>                   (default: 1000)                                               ($SEQ_PUBLISH_RETRY_INTERVAL_MS)
+    --sequencer.l1PublishRetryIntervalMS <value>                             (default: 1000)                                               ($SEQ_PUBLISH_RETRY_INTERVAL_MS)
           The interval to wait between publish retries.
 
-    --sequencer.gasLimitBufferPercentage <value>                   (default: 20)                                                 ($L1_GAS_LIMIT_BUFFER_PERCENTAGE)
-          How much to increase calculated gas limit by (percentage)
+    --sequencer.publisherAllowInvalidStates <value>                                                                                        ($SEQ_PUBLISHER_ALLOW_INVALID_STATES)
+          True to use publishers in invalid states (timed out, cancelled, etc) if no other is available
 
-    --sequencer.maxGwei <value>                                    (default: 500)                                                ($L1_GAS_PRICE_MAX)
-          Maximum gas price in gwei
-
-    --sequencer.maxBlobGwei <value>                                (default: 1500)                                               ($L1_BLOB_FEE_PER_GAS_MAX)
-          Maximum blob fee per gas in gwei
-
-    --sequencer.priorityFeeBumpPercentage <value>                  (default: 20)                                                 ($L1_PRIORITY_FEE_BUMP_PERCENTAGE)
-          How much to increase priority fee by each attempt (percentage)
-
-    --sequencer.priorityFeeRetryBumpPercentage <value>             (default: 50)                                                 ($L1_PRIORITY_FEE_RETRY_BUMP_PERCENTAGE)
-          How much to increase priority fee by each retry attempt (percentage)
-
-    --sequencer.fixedPriorityFeePerGas <value>                                                                                    ($L1_FIXED_PRIORITY_FEE_PER_GAS)
-          Fixed priority fee per gas in Gwei. Overrides any priority fee bump percentage
-
-    --sequencer.maxAttempts <value>                                (default: 3)                                                  ($L1_TX_MONITOR_MAX_ATTEMPTS)
-          Maximum number of speed-up attempts
-
-    --sequencer.checkIntervalMs <value>                            (default: 1000)                                               ($L1_TX_MONITOR_CHECK_INTERVAL_MS)
-          How often to check tx status
-
-    --sequencer.stallTimeMs <value>                                (default: 24000)                                              ($L1_TX_MONITOR_STALL_TIME_MS)
-          How long before considering tx stalled
-
-    --sequencer.txTimeoutMs <value>                                (default: 120000)                                             ($L1_TX_MONITOR_TX_TIMEOUT_MS)
-          How long to wait for a tx to be mined before giving up. Set to 0 to disable.
-
-    --sequencer.txPropagationMaxQueryAttempts <value>              (default: 3)                                                  ($L1_TX_PROPAGATION_MAX_QUERY_ATTEMPTS)
-          How many attempts will be done to get a tx after it was sent
-
-    --sequencer.cancelTxOnTimeout <value>                          (default: true)                                               ($L1_TX_MONITOR_CANCEL_TX_ON_TIMEOUT)
-          Whether to attempt to cancel a tx if it's not mined after txTimeoutMs
-
-    --sequencer.blobSinkUrl <value>                                                                                               ($BLOB_SINK_URL)
+    --sequencer.blobSinkUrl <value>                                                                                                        ($BLOB_SINK_URL)
           The URL of the blob sink
 
-    --sequencer.blobSinkMapSizeKb <value>                                                                                         ($BLOB_SINK_MAP_SIZE_KB)
-          The maximum possible size of the blob sink DB in KB. Overwrites the general dataStoreMapSizeKB.
-
-    --sequencer.archiveApiUrl <value>                                                                                             ($BLOB_SINK_ARCHIVE_API_URL)
+    --sequencer.archiveApiUrl <value>                                                                                                      ($BLOB_SINK_ARCHIVE_API_URL)
           The URL of the archive API
-
-    --sequencer.rollupVersion <value>                                                                                             ($ROLLUP_VERSION)
-          The version of the rollup.
-
-    --sequencer.ethereumSlotDuration <value>                       (default: 12)                                                 ($ETHEREUM_SLOT_DURATION)
-          How many seconds an L1 slot lasts.
-
-    --sequencer.aztecSlotDuration <value>                          (default: 36)                                                 ($AZTEC_SLOT_DURATION)
-          How many seconds an L2 slots lasts (must be multiple of ethereum slot duration).
-
-    --sequencer.aztecEpochDuration <value>                         (default: 32)                                                 ($AZTEC_EPOCH_DURATION)
-          How many L2 slots an epoch lasts (maximum AZTEC_MAX_EPOCH_DURATION).
 
   BLOB SINK
 
     --blob-sink
           Starts Aztec Blob Sink with options
 
-    --blobSink.port <value>                                                                                                       ($BLOB_SINK_PORT)
+    --blobSink.port <value>                                                                                                                ($BLOB_SINK_PORT)
           The port to run the blob sink server on
 
-    --blobSink.blobSinkUrl <value>                                                                                                ($BLOB_SINK_URL)
-          The URL of the blob sink
-
-    --blobSink.blobSinkMapSizeKb <value>                                                                                          ($BLOB_SINK_MAP_SIZE_KB)
+    --blobSink.blobSinkMapSizeKb <value>                                                                                                   ($BLOB_SINK_MAP_SIZE_KB)
           The maximum possible size of the blob sink DB in KB. Overwrites the general dataStoreMapSizeKB.
 
-    --blobSink.archiveApiUrl <value>                                                                                              ($BLOB_SINK_ARCHIVE_API_URL)
+    --blobSink.archiveApiUrl <value>                                                                                                       ($BLOB_SINK_ARCHIVE_API_URL)
           The URL of the archive API
-
-    --blobSink.dataStoreMapSizeKB <value>                          (default: 134217728)                                          ($DATA_STORE_MAP_SIZE_KB)
-          DB mapping size to be applied to all key/value stores
-
-    --blobSink.rollupVersion <value>                                                                                              ($ROLLUP_VERSION)
-          The version of the rollup.
-
-    --blobSink.viemPollingIntervalMS <value>                       (default: 1000)                                               ($L1_READER_VIEM_POLLING_INTERVAL_MS)
-          The polling interval viem uses in ms
 
   PROVER NODE
 
     --prover-node
           Starts Aztec Prover Node with options
 
-    --proverNode.archiverUrl <value>                                                                                              ($ARCHIVER_URL)
-          URL for an archiver service
+    --proverNode.keyStoreDirectory <value>                                                                                                 ($KEY_STORE_DIRECTORY)
+          Location of key store directory
 
-    --proverNode.acvmWorkingDirectory <value>                                                                                     ($ACVM_WORKING_DIRECTORY)
+    --proverNode.acvmWorkingDirectory <value>                                                                                              ($ACVM_WORKING_DIRECTORY)
           The working directory to use for simulation/proving
 
-    --proverNode.acvmBinaryPath <value>                                                                                           ($ACVM_BINARY_PATH)
+    --proverNode.acvmBinaryPath <value>                                                                                                    ($ACVM_BINARY_PATH)
           The path to the ACVM binary
 
-    --proverNode.bbWorkingDirectory <value>                                                                                       ($BB_WORKING_DIRECTORY)
+    --proverNode.bbWorkingDirectory <value>                                                                                                ($BB_WORKING_DIRECTORY)
           The working directory to use for proving
 
-    --proverNode.bbBinaryPath <value>                                                                                             ($BB_BINARY_PATH)
+    --proverNode.bbBinaryPath <value>                                                                                                      ($BB_BINARY_PATH)
           The path to the bb binary
 
-    --proverNode.bbSkipCleanup <value>                                                                                            ($BB_SKIP_CLEANUP)
+    --proverNode.bbSkipCleanup <value>                                                                                                     ($BB_SKIP_CLEANUP)
           Whether to skip cleanup of bb temporary files
 
-    --proverNode.numConcurrentIVCVerifiers <value>                 (default: 8)                                                  ($BB_NUM_IVC_VERIFIERS)
+    --proverNode.numConcurrentIVCVerifiers <value>                           (default: 8)                                                  ($BB_NUM_IVC_VERIFIERS)
           Max number of client IVC verifiers to run concurrently
 
-    --proverNode.bbIVCConcurrency <value>                          (default: 1)                                                  ($BB_IVC_CONCURRENCY)
+    --proverNode.bbIVCConcurrency <value>                                    (default: 1)                                                  ($BB_IVC_CONCURRENCY)
           Number of threads to use for IVC verification
 
-    --proverNode.nodeUrl <value>                                                                                                  ($AZTEC_NODE_URL)
+    --proverNode.nodeUrl <value>                                                                                                           ($AZTEC_NODE_URL)
           The URL to the Aztec node to take proving jobs from
 
-    --proverNode.proverId <value>                                                                                                 ($PROVER_ID)
+    --proverNode.proverId <value>                                                                                                          ($PROVER_ID)
           Hex value that identifies the prover. Defaults to the address used for submitting proofs if not set.
 
-    --proverNode.failedProofStore <value>                                                                                         ($PROVER_FAILED_PROOF_STORE)
+    --proverNode.failedProofStore <value>                                                                                                  ($PROVER_FAILED_PROOF_STORE)
           Store for failed proof inputs. Google cloud storage is only supported at the moment. Set this value as gs://bucket-name/path/to/store.
 
-    --proverNode.worldStateBlockCheckIntervalMS <value>            (default: 100)                                                ($WS_BLOCK_CHECK_INTERVAL_MS)
-          The frequency in which to check.
-
-    --proverNode.worldStateProvenBlocksOnly <value>                                                                               ($WS_PROVEN_BLOCKS_ONLY)
-          Whether to follow only the proven chain.
-
-    --proverNode.worldStateBlockRequestBatchSize <value>                                                                          ($WS_BLOCK_REQUEST_BATCH_SIZE)
-          Size of the batch for each get-blocks request from the synchronizer to the archiver.
-
-    --proverNode.worldStateDbMapSizeKb <value>                                                                                    ($WS_DB_MAP_SIZE_KB)
-          The maximum possible size of the world state DB in KB. Overwrites the general dataStoreMapSizeKB.
-
-    --proverNode.archiveTreeMapSizeKb <value>                                                                                     ($ARCHIVE_TREE_MAP_SIZE_KB)
-          The maximum possible size of the world state archive tree in KB. Overwrites the general worldStateDbMapSizeKb.
-
-    --proverNode.nullifierTreeMapSizeKb <value>                                                                                   ($NULLIFIER_TREE_MAP_SIZE_KB)
-          The maximum possible size of the world state nullifier tree in KB. Overwrites the general worldStateDbMapSizeKb.
-
-    --proverNode.noteHashTreeMapSizeKb <value>                                                                                    ($NOTE_HASH_TREE_MAP_SIZE_KB)
-          The maximum possible size of the world state note hash tree in KB. Overwrites the general worldStateDbMapSizeKb.
-
-    --proverNode.messageTreeMapSizeKb <value>                                                                                     ($MESSAGE_TREE_MAP_SIZE_KB)
-          The maximum possible size of the world state message tree in KB. Overwrites the general worldStateDbMapSizeKb.
-
-    --proverNode.publicDataTreeMapSizeKb <value>                                                                                  ($PUBLIC_DATA_TREE_MAP_SIZE_KB)
-          The maximum possible size of the world state public data tree in KB. Overwrites the general worldStateDbMapSizeKb.
-
-    --proverNode.worldStateDataDirectory <value>                                                                                  ($WS_DATA_DIRECTORY)
-          Optional directory for the world state database
-
-    --proverNode.worldStateBlockHistory <value>                    (default: 64)                                                 ($WS_NUM_HISTORIC_BLOCKS)
-          The number of historic blocks to maintain. Values less than 1 mean all history is maintained
-
-    --proverNode.l1PublishRetryIntervalMS <value>                  (default: 1000)                                               ($PROVER_PUBLISH_RETRY_INTERVAL_MS)
+    --proverNode.l1PublishRetryIntervalMS <value>                            (default: 1000)                                               ($PROVER_PUBLISH_RETRY_INTERVAL_MS)
           The interval to wait between publish retries.
 
-    --proverNode.customForwarderContractAddress <value>            (default: 0x0000000000000000000000000000000000000000)         ($CUSTOM_FORWARDER_CONTRACT_ADDRESS)
-          The address of the custom forwarder contract.
+    --proverNode.publisherAllowInvalidStates <value>                                                                                       ($PROVER_PUBLISHER_ALLOW_INVALID_STATES)
+          True to use publishers in invalid states (timed out, cancelled, etc) if no other is available
 
-    --proverNode.publisherPrivateKey <value>                       (default: [Redacted])                                         ($PROVER_PUBLISHER_PRIVATE_KEY)
-          The private key to be used by the publisher.
+    --proverNode.publisherPrivateKeys <value>                                (default: )                                                   ($PROVER_PUBLISHER_PRIVATE_KEYS)
+          The private keys to be used by the publisher.
 
-    --proverNode.proverCoordinationNodeUrls <value>                (default: )                                                   ($PROVER_COORDINATION_NODE_URLS)
-          The URLs of the tx provider nodes
+    --proverNode.publisherAddresses <value>                                  (default: )                                                   ($PROVER_PUBLISHER_ADDRESSES)
+          The addresses of the publishers to use with remote signers
 
-    --proverNode.proverNodeMaxPendingJobs <value>                  (default: 10)                                                 ($PROVER_NODE_MAX_PENDING_JOBS)
+    --proverNode.proverNodeMaxPendingJobs <value>                            (default: 10)                                                 ($PROVER_NODE_MAX_PENDING_JOBS)
           The maximum number of pending jobs for the prover node
 
-    --proverNode.proverNodePollingIntervalMs <value>               (default: 1000)                                               ($PROVER_NODE_POLLING_INTERVAL_MS)
+    --proverNode.proverNodePollingIntervalMs <value>                         (default: 1000)                                               ($PROVER_NODE_POLLING_INTERVAL_MS)
           The interval in milliseconds to poll for new jobs
 
-    --proverNode.proverNodeMaxParallelBlocksPerEpoch <value>       (default: 32)                                                 ($PROVER_NODE_MAX_PARALLEL_BLOCKS_PER_EPOCH)
+    --proverNode.proverNodeMaxParallelBlocksPerEpoch <value>                 (default: 32)                                                 ($PROVER_NODE_MAX_PARALLEL_BLOCKS_PER_EPOCH)
           The Maximum number of blocks to process in parallel while proving an epoch
 
-    --proverNode.proverNodeFailedEpochStore <value>                                                                               ($PROVER_NODE_FAILED_EPOCH_STORE)
+    --proverNode.proverNodeFailedEpochStore <value>                                                                                        ($PROVER_NODE_FAILED_EPOCH_STORE)
           File store where to upload node state when an epoch fails to be proven
 
-    --proverNode.txGatheringIntervalMs <value>                     (default: 1000)                                               ($PROVER_NODE_TX_GATHERING_INTERVAL_MS)
+    --proverNode.proverNodeEpochProvingDelayMs <value>
+          Optional delay in milliseconds to wait before proving a new epoch
+
+    --proverNode.txGatheringIntervalMs <value>                               (default: 1000)                                               ($PROVER_NODE_TX_GATHERING_INTERVAL_MS)
           How often to check that tx data is available
 
-    --proverNode.txGatheringBatchSize <value>                      (default: 10)                                                 ($PROVER_NODE_TX_GATHERING_BATCH_SIZE)
+    --proverNode.txGatheringBatchSize <value>                                (default: 10)                                                 ($PROVER_NODE_TX_GATHERING_BATCH_SIZE)
           How many transactions to gather from a node in a single request
 
-    --proverNode.txGatheringMaxParallelRequestsPerNode <value>     (default: 100)                                                ($PROVER_NODE_TX_GATHERING_MAX_PARALLEL_REQUESTS_PER_NODE)
+    --proverNode.txGatheringMaxParallelRequestsPerNode <value>               (default: 100)                                                ($PROVER_NODE_TX_GATHERING_MAX_PARALLEL_REQUESTS_PER_NODE)
           How many tx requests to make in parallel to each node
 
-    --proverNode.testAccounts <value>                                                                                             ($TEST_ACCOUNTS)
-          Whether to populate the genesis state with initial fee juice for the test accounts.
-
-    --proverNode.sponsoredFPC <value>                                                                                             ($SPONSORED_FPC)
-          Whether to populate the genesis state with initial fee juice for the sponsored FPC.
-
-    --proverNode.syncMode <value>                                  (default: snapshot)                                           ($SYNC_MODE)
-          Set sync mode to `full` to always sync via L1, `snapshot` to download a snapshot if there is no local data, `force-snapshot` to download even if there is local data.
-
-    --proverNode.snapshotsUrl <value>                                                                                             ($SYNC_SNAPSHOTS_URL)
-          Base URL for snapshots index.
-
-    --proverNode.autoUpdate <value>                                (default: disabled)                                           ($AUTO_UPDATE)
-          The auto update mode for this node
-
-    --proverNode.autoUpdateUrl <value>                                                                                            ($AUTO_UPDATE_URL)
-          Base URL to check for updates
+    --proverNode.txGatheringTimeoutMs <value>                                (default: 120000)                                             ($PROVER_NODE_TX_GATHERING_TIMEOUT_MS)
+          How long to wait for tx data to be available before giving up
 
   PROVER BROKER
 
     --prover-broker
           Starts Aztec proving job broker
 
-    --proverBroker.proverBrokerJobTimeoutMs <value>                (default: 30000)                                              ($PROVER_BROKER_JOB_TIMEOUT_MS)
+    --proverBroker.proverBrokerJobTimeoutMs <value>                          (default: 30000)                                              ($PROVER_BROKER_JOB_TIMEOUT_MS)
           Jobs are retried if not kept alive for this long
 
-    --proverBroker.proverBrokerPollIntervalMs <value>              (default: 1000)                                               ($PROVER_BROKER_POLL_INTERVAL_MS)
+    --proverBroker.proverBrokerPollIntervalMs <value>                        (default: 1000)                                               ($PROVER_BROKER_POLL_INTERVAL_MS)
           The interval to check job health status
 
-    --proverBroker.proverBrokerJobMaxRetries <value>               (default: 3)                                                  ($PROVER_BROKER_JOB_MAX_RETRIES)
+    --proverBroker.proverBrokerJobMaxRetries <value>                         (default: 3)                                                  ($PROVER_BROKER_JOB_MAX_RETRIES)
           If starting a prover broker locally, the max number of retries per proving job
 
-    --proverBroker.proverBrokerBatchSize <value>                   (default: 100)                                                ($PROVER_BROKER_BATCH_SIZE)
+    --proverBroker.proverBrokerBatchSize <value>                             (default: 100)                                                ($PROVER_BROKER_BATCH_SIZE)
           The prover broker writes jobs to disk in batches
 
-    --proverBroker.proverBrokerBatchIntervalMs <value>             (default: 50)                                                 ($PROVER_BROKER_BATCH_INTERVAL_MS)
+    --proverBroker.proverBrokerBatchIntervalMs <value>                       (default: 50)                                                 ($PROVER_BROKER_BATCH_INTERVAL_MS)
           How often to flush batches to disk
 
-    --proverBroker.proverBrokerMaxEpochsToKeepResultsFor <value>   (default: 1)                                                  ($PROVER_BROKER_MAX_EPOCHS_TO_KEEP_RESULTS_FOR)
+    --proverBroker.proverBrokerMaxEpochsToKeepResultsFor <value>             (default: 1)                                                  ($PROVER_BROKER_MAX_EPOCHS_TO_KEEP_RESULTS_FOR)
           The maximum number of epochs to keep results for
 
-    --proverBroker.proverBrokerStoreMapSizeKB <value>                                                                             ($PROVER_BROKER_STORE_MAP_SIZE_KB)
+    --proverBroker.proverBrokerStoreMapSizeKB <value>                                                                                      ($PROVER_BROKER_STORE_MAP_SIZE_KB)
           The size of the prover broker's database. Will override the dataStoreMapSizeKB if set.
-
-    --proverBroker.dataStoreMapSizeKB <value>                      (default: 134217728)                                          ($DATA_STORE_MAP_SIZE_KB)
-          DB mapping size to be applied to all key/value stores
-
-    --proverBroker.viemPollingIntervalMS <value>                   (default: 1000)                                               ($L1_READER_VIEM_POLLING_INTERVAL_MS)
-          The polling interval viem uses in ms
-
-    --proverBroker.rollupVersion <value>                                                                                          ($ROLLUP_VERSION)
-          The version of the rollup.
 
   PROVER AGENT
 
     --prover-agent
           Starts Aztec Prover Agent with options
 
-    --proverAgent.proverAgentCount <value>                         (default: 1)                                                  ($PROVER_AGENT_COUNT)
+    --proverAgent.proverAgentCount <value>                                   (default: 1)                                                  ($PROVER_AGENT_COUNT)
           Whether this prover has a local prover agent
 
-    --proverAgent.proverAgentPollIntervalMs <value>                (default: 100)                                                ($PROVER_AGENT_POLL_INTERVAL_MS)
+    --proverAgent.proverAgentPollIntervalMs <value>                          (default: 1000)                                               ($PROVER_AGENT_POLL_INTERVAL_MS)
           The interval agents poll for jobs at
 
-    --proverAgent.proverAgentProofTypes <value>                                                                                   ($PROVER_AGENT_PROOF_TYPES)
+    --proverAgent.proverAgentProofTypes <value>                                                                                            ($PROVER_AGENT_PROOF_TYPES)
           The types of proofs the prover agent can generate
 
-    --proverAgent.proverBrokerUrl <value>                                                                                         ($PROVER_BROKER_HOST)
+    --proverAgent.proverBrokerUrl <value>                                                                                                  ($PROVER_BROKER_HOST)
           The URL where this agent takes jobs from
 
-    --proverAgent.realProofs <value>                               (default: true)                                               ($PROVER_REAL_PROOFS)
+    --proverAgent.realProofs <value>                                         (default: true)                                               ($PROVER_REAL_PROOFS)
           Whether to construct real proofs
 
-    --proverAgent.proverTestDelayType <value>                      (default: fixed)                                              ($PROVER_TEST_DELAY_TYPE)
+    --proverAgent.proverTestDelayType <value>                                (default: fixed)                                              ($PROVER_TEST_DELAY_TYPE)
           The type of artificial delay to introduce
 
-    --proverAgent.proverTestDelayMs <value>                                                                                       ($PROVER_TEST_DELAY_MS)
+    --proverAgent.proverTestDelayMs <value>                                                                                                ($PROVER_TEST_DELAY_MS)
           Artificial delay to introduce to all operations to the test prover.
 
-    --proverAgent.proverTestDelayFactor <value>                    (default: 1)                                                  ($PROVER_TEST_DELAY_FACTOR)
+    --proverAgent.proverTestDelayFactor <value>                              (default: 1)                                                  ($PROVER_TEST_DELAY_FACTOR)
           If using realistic delays, what percentage of realistic times to apply.
+
+  P2P SUBSYSTEM
+
+    --p2p-enabled [value]                                                                                                                  ($P2P_ENABLED)
+          Enable P2P subsystem
+
+    --p2p.p2pDiscoveryDisabled <value>                                                                                                     ($P2P_DISCOVERY_DISABLED)
+          A flag dictating whether the P2P discovery system should be disabled.
+
+    --p2p.blockCheckIntervalMS <value>                                       (default: 100)                                                ($P2P_BLOCK_CHECK_INTERVAL_MS)
+          The frequency in which to check for new L2 blocks.
+
+    --p2p.debugDisableColocationPenalty <value>                                                                                            ($DEBUG_P2P_DISABLE_COLOCATION_PENALTY)
+          DEBUG: Disable colocation penalty - NEVER set to true in production
+
+    --p2p.peerCheckIntervalMS <value>                                        (default: 30000)                                              ($P2P_PEER_CHECK_INTERVAL_MS)
+          The frequency in which to check for new peers.
+
+    --p2p.l2QueueSize <value>                                                (default: 1000)                                               ($P2P_L2_QUEUE_SIZE)
+          Size of queue of L2 blocks to store.
+
+    --p2p.listenAddress <value>                                              (default: 0.0.0.0)                                            ($P2P_LISTEN_ADDR)
+          The listen address. ipv4 address.
+
+    --p2p.p2pPort <value>                                                    (default: 40400)                                              ($P2P_PORT)
+          The port for the P2P service. Defaults to 40400
+
+    --p2p.p2pBroadcastPort <value>                                                                                                         ($P2P_BROADCAST_PORT)
+          The port to broadcast the P2P service on (included in the node's ENR). Defaults to P2P_PORT.
+
+    --p2p.p2pIp <value>                                                                                                                    ($P2P_IP)
+          The IP address for the P2P service. ipv4 address.
+
+    --p2p.peerIdPrivateKey <value>                                                                                                         ($PEER_ID_PRIVATE_KEY)
+          An optional peer id private key. If blank, will generate a random key.
+
+    --p2p.peerIdPrivateKeyPath <value>                                                                                                     ($PEER_ID_PRIVATE_KEY_PATH)
+          An optional path to store generated peer id private keys. If blank, will default to storing any generated keys in the root of the data directory.
+
+    --p2p.bootstrapNodes <value>                                             (default: )                                                   ($BOOTSTRAP_NODES)
+          A list of bootstrap peer ENRs to connect to. Separated by commas.
+
+    --p2p.bootstrapNodeEnrVersionCheck <value>                                                                                             ($P2P_BOOTSTRAP_NODE_ENR_VERSION_CHECK)
+          Whether to check the version of the bootstrap node ENR.
+
+    --p2p.bootstrapNodesAsFullPeers <value>                                                                                                ($P2P_BOOTSTRAP_NODES_AS_FULL_PEERS)
+          Whether to consider our configured bootnodes as full peers
+
+    --p2p.maxPeerCount <value>                                               (default: 100)                                                ($P2P_MAX_PEERS)
+          The maximum number of peers to connect to.
+
+    --p2p.queryForIp <value>                                                                                                               ($P2P_QUERY_FOR_IP)
+          If announceUdpAddress or announceTcpAddress are not provided, query for the IP address of the machine. Default is false.
+
+    --p2p.gossipsubInterval <value>                                          (default: 700)                                                ($P2P_GOSSIPSUB_INTERVAL_MS)
+          The interval of the gossipsub heartbeat to perform maintenance tasks.
+
+    --p2p.gossipsubD <value>                                                 (default: 8)                                                  ($P2P_GOSSIPSUB_D)
+          The D parameter for the gossipsub protocol.
+
+    --p2p.gossipsubDlo <value>                                               (default: 4)                                                  ($P2P_GOSSIPSUB_DLO)
+          The Dlo parameter for the gossipsub protocol.
+
+    --p2p.gossipsubDhi <value>                                               (default: 12)                                                 ($P2P_GOSSIPSUB_DHI)
+          The Dhi parameter for the gossipsub protocol.
+
+    --p2p.gossipsubDLazy <value>                                             (default: 8)                                                  ($P2P_GOSSIPSUB_DLAZY)
+          The Dlazy parameter for the gossipsub protocol.
+
+    --p2p.gossipsubFloodPublish <value>                                                                                                    ($P2P_GOSSIPSUB_FLOOD_PUBLISH)
+          Whether to flood publish messages. - For testing purposes only
+
+    --p2p.gossipsubMcacheLength <value>                                      (default: 6)                                                  ($P2P_GOSSIPSUB_MCACHE_LENGTH)
+          The number of gossipsub interval message cache windows to keep.
+
+    --p2p.gossipsubMcacheGossip <value>                                      (default: 3)                                                  ($P2P_GOSSIPSUB_MCACHE_GOSSIP)
+          How many message cache windows to include when gossiping with other peers.
+
+    --p2p.gossipsubSeenTTL <value>                                           (default: 1200000)                                            ($P2P_GOSSIPSUB_SEEN_TTL)
+          How long to keep message IDs in the seen cache.
+
+    --p2p.gossipsubTxTopicWeight <value>                                     (default: 1)                                                  ($P2P_GOSSIPSUB_TX_TOPIC_WEIGHT)
+          The weight of the tx topic for the gossipsub protocol.
+
+    --p2p.gossipsubTxInvalidMessageDeliveriesWeight <value>                  (default: -20)                                                ($P2P_GOSSIPSUB_TX_INVALID_MESSAGE_DELIVERIES_WEIGHT)
+          The weight of the tx invalid message deliveries for the gossipsub protocol.
+
+    --p2p.gossipsubTxInvalidMessageDeliveriesDecay <value>                   (default: 0.5)                                                ($P2P_GOSSIPSUB_TX_INVALID_MESSAGE_DELIVERIES_DECAY)
+          Determines how quickly the penalty for invalid message deliveries decays over time. Between 0 and 1.
+
+    --p2p.peerPenaltyValues <value>                                          (default: 2,10,50)                                            ($P2P_PEER_PENALTY_VALUES)
+          The values for the peer scoring system. Passed as a comma separated list of values in order: low, mid, high tolerance errors.
+
+    --p2p.doubleSpendSeverePeerPenaltyWindow <value>                         (default: 30)                                                 ($P2P_DOUBLE_SPEND_SEVERE_PEER_PENALTY_WINDOW)
+          The "age" (in L2 blocks) of a tx after which we heavily penalize a peer for sending it.
+
+    --p2p.blockRequestBatchSize <value>                                      (default: 20)                                                 ($P2P_BLOCK_REQUEST_BATCH_SIZE)
+          The number of blocks to fetch in a single batch.
+
+    --p2p.archivedTxLimit <value>                                                                                                          ($P2P_ARCHIVED_TX_LIMIT)
+          The number of transactions that will be archived. If the limit is set to 0 then archiving will be disabled.
+
+    --p2p.trustedPeers <value>                                               (default: )                                                   ($P2P_TRUSTED_PEERS)
+          A list of trusted peer ENRs that will always be persisted. Separated by commas.
+
+    --p2p.privatePeers <value>                                               (default: )                                                   ($P2P_PRIVATE_PEERS)
+          A list of private peer ENRs that will always be persisted and not be used for discovery. Separated by commas.
+
+    --p2p.preferredPeers <value>                                             (default: )                                                   ($P2P_PREFERRED_PEERS)
+          A list of preferred peer ENRs that will always be persisted and not be used for discovery. Separated by commas.
+
+    --p2p.p2pStoreMapSizeKb <value>                                                                                                        ($P2P_STORE_MAP_SIZE_KB)
+          The maximum possible size of the P2P DB in KB. Overwrites the general dataStoreMapSizeKB.
+
+    --p2p.txPublicSetupAllowList <value>                                                                                                   ($TX_PUBLIC_SETUP_ALLOWLIST)
+          The list of functions calls allowed to run in setup
+
+    --p2p.maxTxPoolSize <value>                                              (default: 100000000)                                          ($P2P_MAX_TX_POOL_SIZE)
+          The maximum cumulative tx size of pending txs (in bytes) before evicting lower priority txs.
+
+    --p2p.txPoolOverflowFactor <value>                                       (default: 1.1)                                                ($P2P_TX_POOL_OVERFLOW_FACTOR)
+          How much the tx pool can overflow before it starts evicting txs. Must be greater than 1
+
+    --p2p.seenMessageCacheSize <value>                                       (default: 100000)                                             ($P2P_SEEN_MSG_CACHE_SIZE)
+          The number of messages to keep in the seen message cache
+
+    --p2p.p2pDisableStatusHandshake <value>                                                                                                ($P2P_DISABLE_STATUS_HANDSHAKE)
+          True to disable the status handshake on peer connected.
+
+    --p2p.p2pAllowOnlyValidators <value>                                                                                                   ($P2P_ALLOW_ONLY_VALIDATORS)
+          True to only permit validators to connect.
+
+    --p2p.p2pMaxFailedAuthAttemptsAllowed <value>                            (default: 3)                                                  ($P2P_MAX_AUTH_FAILED_ATTEMPTS_ALLOWED)
+          Number of auth attempts to allow before peer is banned. Number is inclusive
+
+    --p2p.dropTransactions <value>                                                                                                         ($P2P_DROP_TX)
+          True to simulate discarding transactions. - For testing purposes only
+
+    --p2p.dropTransactionsProbability <value>                                                                                              ($P2P_DROP_TX_CHANCE)
+          The probability that a transaction is discarded. - For testing purposes only
+
+    --p2p.disableTransactions <value>                                                                                                      ($TRANSACTIONS_DISABLED)
+          Whether transactions are disabled for this node. This means transactions will be rejected at the RPC and P2P layers.
+
+    --p2p.txPoolDeleteTxsAfterReorg <value>                                                                                                ($P2P_TX_POOL_DELETE_TXS_AFTER_REORG)
+          Whether to delete transactions from the pool after a reorg instead of moving them back to pending.
+
+    --p2p.overallRequestTimeoutMs <value>                                    (default: 10000)                                              ($P2P_REQRESP_OVERALL_REQUEST_TIMEOUT_MS)
+          The overall timeout for a request response operation.
+
+    --p2p.individualRequestTimeoutMs <value>                                 (default: 10000)                                              ($P2P_REQRESP_INDIVIDUAL_REQUEST_TIMEOUT_MS)
+          The timeout for an individual request response peer interaction.
+
+    --p2p.dialTimeoutMs <value>                                              (default: 5000)                                               ($P2P_REQRESP_DIAL_TIMEOUT_MS)
+          How long to wait for the dial protocol to establish a connection
+
+    --p2p.p2pOptimisticNegotiation <value>                                                                                                 ($P2P_REQRESP_OPTIMISTIC_NEGOTIATION)
+          Whether to use optimistic protocol negotiation when dialing to another peer (opposite of `negotiateFully`).
+
+    --p2p.txCollectionFastNodesTimeoutBeforeReqRespMs <value>                (default: 200)                                                ($TX_COLLECTION_FAST_NODES_TIMEOUT_BEFORE_REQ_RESP_MS)
+          How long to wait before starting reqresp for fast collection
+
+    --p2p.txCollectionSlowNodesIntervalMs <value>                            (default: 12000)                                              ($TX_COLLECTION_SLOW_NODES_INTERVAL_MS)
+          How often to collect from configured nodes in the slow collection loop
+
+    --p2p.txCollectionSlowReqRespIntervalMs <value>                          (default: 12000)                                              ($TX_COLLECTION_SLOW_REQ_RESP_INTERVAL_MS)
+          How often to collect from peers via reqresp in the slow collection loop
+
+    --p2p.txCollectionSlowReqRespTimeoutMs <value>                           (default: 20000)                                              ($TX_COLLECTION_SLOW_REQ_RESP_TIMEOUT_MS)
+          How long to wait for a reqresp response during slow collection
+
+    --p2p.txCollectionReconcileIntervalMs <value>                            (default: 60000)                                              ($TX_COLLECTION_RECONCILE_INTERVAL_MS)
+          How often to reconcile found txs from the tx pool
+
+    --p2p.txCollectionDisableSlowDuringFastRequests <value>                  (default: true)                                               ($TX_COLLECTION_DISABLE_SLOW_DURING_FAST_REQUESTS)
+          Whether to disable the slow collection loop if we are dealing with any immediate requests
+
+    --p2p.txCollectionFastNodeIntervalMs <value>                             (default: 500)                                                ($TX_COLLECTION_FAST_NODE_INTERVAL_MS)
+          How many ms to wait between retried request to a node via RPC during fast collection
+
+    --p2p.txCollectionNodeRpcUrls <value>                                    (default: )                                                   ($TX_COLLECTION_NODE_RPC_URLS)
+          A comma-separated list of Aztec node RPC URLs to use for tx collection
+
+    --p2p.txCollectionFastMaxParallelRequestsPerNode <value>                 (default: 4)                                                  ($TX_COLLECTION_FAST_MAX_PARALLEL_REQUESTS_PER_NODE)
+          Maximum number of parallel requests to make to a node during fast collection
+
+    --p2p.txCollectionNodeRpcMaxBatchSize <value>                            (default: 50)                                                 ($TX_COLLECTION_NODE_RPC_MAX_BATCH_SIZE)
+          Maximum number of transactions to request from a node in a single batch
 
   P2P BOOTSTRAP
 
     --p2p-bootstrap
           Starts Aztec P2P Bootstrap with options
 
-    --p2pBootstrap.p2pBroadcastPort <value>                                                                                       ($P2P_BROADCAST_PORT)
+    --p2pBootstrap.p2pBroadcastPort <value>                                                                                                ($P2P_BROADCAST_PORT)
           The port to broadcast the P2P service on (included in the node's ENR). Defaults to P2P_PORT.
 
-    --p2pBootstrap.peerIdPrivateKeyPath <value>                                                                                   ($PEER_ID_PRIVATE_KEY_PATH)
+    --p2pBootstrap.peerIdPrivateKeyPath <value>                                                                                            ($PEER_ID_PRIVATE_KEY_PATH)
           An optional path to store generated peer id private keys. If blank, will default to storing any generated keys in the root of the data directory.
 
-    --p2pBootstrap.dataStoreMapSizeKB <value>                      (default: 134217728)                                          ($DATA_STORE_MAP_SIZE_KB)
-          DB mapping size to be applied to all key/value stores
+  TELEMETRY
+
+    --tel.metricsCollectorUrl <value>                                                                                                      ($OTEL_EXPORTER_OTLP_METRICS_ENDPOINT)
+          The URL of the telemetry collector for metrics
+
+    --tel.tracesCollectorUrl <value>                                                                                                       ($OTEL_EXPORTER_OTLP_TRACES_ENDPOINT)
+          The URL of the telemetry collector for traces
+
+    --tel.logsCollectorUrl <value>                                                                                                         ($OTEL_EXPORTER_OTLP_LOGS_ENDPOINT)
+          The URL of the telemetry collector for logs
+
+    --tel.otelCollectIntervalMs <value>                                      (default: 60000)                                              ($OTEL_COLLECT_INTERVAL_MS)
+          The interval at which to collect metrics
+
+    --tel.otelExportTimeoutMs <value>                                        (default: 30000)                                              ($OTEL_EXPORT_TIMEOUT_MS)
+          The timeout for exporting metrics
+
+    --tel.otelExcludeMetrics <value>                                         (default: )                                                   ($OTEL_EXCLUDE_METRICS)
+          A list of metric prefixes to exclude from export
+
+    --tel.publicMetricsCollectorUrl <value>                                                                                                ($PUBLIC_OTEL_EXPORTER_OTLP_METRICS_ENDPOINT)
+          A URL to publish a subset of metrics for public consumption
+
+    --tel.publicMetricsCollectFrom <value>                                   (default: )                                                   ($PUBLIC_OTEL_COLLECT_FROM)
+          The role types to collect metrics from
+
+    --tel.publicIncludeMetrics <value>                                       (default: )                                                   ($PUBLIC_OTEL_INCLUDE_METRICS)
+          A list of metric prefixes to publicly export
+
+    --tel.publicMetricsOptOut <value>                                                                                                      ($PUBLIC_OTEL_OPT_OUT)
+          Whether to opt out of sharing optional telemetry
 
   BOT
 
     --bot
           Starts Aztec Bot with options
 
-    --bot.nodeUrl <value>                                                                                                         ($AZTEC_NODE_URL)
+    --bot.nodeUrl <value>                                                                                                                  ($AZTEC_NODE_URL)
           The URL to the Aztec node to check for tx pool status.
 
-    --bot.nodeAdminUrl <value>                                                                                                    ($AZTEC_NODE_ADMIN_URL)
+    --bot.nodeAdminUrl <value>                                                                                                             ($AZTEC_NODE_ADMIN_URL)
           The URL to the Aztec node admin API to force-flush txs if configured.
 
-    --bot.l1Mnemonic <value>                                                                                                      ($BOT_L1_MNEMONIC)
+    --bot.l1Mnemonic <value>                                                                                                               ($BOT_L1_MNEMONIC)
           The mnemonic for the account to bridge fee juice from L1.
 
-    --bot.l1PrivateKey <value>                                                                                                    ($BOT_L1_PRIVATE_KEY)
+    --bot.l1PrivateKey <value>                                                                                                             ($BOT_L1_PRIVATE_KEY)
           The private key for the account to bridge fee juice from L1.
 
-    --bot.l1ToL2MessageTimeoutSeconds <value>                      (default: 60)                                                 ($BOT_L1_TO_L2_TIMEOUT_SECONDS)
+    --bot.l1ToL2MessageTimeoutSeconds <value>                                (default: 3600)                                               ($BOT_L1_TO_L2_TIMEOUT_SECONDS)
           How long to wait for L1 to L2 messages to become available on L2
 
-    --bot.senderPrivateKey <value>                                 (default: [Redacted])                                         ($BOT_PRIVATE_KEY)
+    --bot.senderPrivateKey <value>                                                                                                         ($BOT_PRIVATE_KEY)
           Signing private key for the sender account.
 
-    --bot.senderSalt <value>                                                                                                      ($BOT_ACCOUNT_SALT)
-          The salt to use to deploys the sender account.
+    --bot.senderSalt <value>                                                                                                               ($BOT_ACCOUNT_SALT)
+          The salt to use to deploy the sender account.
 
-    --bot.recipientEncryptionSecret <value>                        (default: [Redacted])                                         ($BOT_RECIPIENT_ENCRYPTION_SECRET)
+    --bot.recipientEncryptionSecret <value>                                  (default: 0x00000000000000000000000000000000000000000000000000000000cafecafe)($BOT_RECIPIENT_ENCRYPTION_SECRET)
           Encryption secret for a recipient account.
 
-    --bot.tokenSalt <value>                                        (default: 0x0000000000000000000000000000000000000000000000000000000000000001) ($BOT_TOKEN_SALT)
-          Salt for the token contract deployment.
+    --bot.tokenSalt <value>                                                  (default: 0x0000000000000000000000000000000000000000000000000000000000000001)($BOT_TOKEN_SALT)
+          The salt to use to deploy the token contract.
 
-    --bot.txIntervalSeconds <value>                                (default: 60)                                                 ($BOT_TX_INTERVAL_SECONDS)
+    --bot.txIntervalSeconds <value>                                          (default: 60)                                                 ($BOT_TX_INTERVAL_SECONDS)
           Every how many seconds should a new tx be sent.
 
-    --bot.privateTransfersPerTx <value>                            (default: 1)                                                  ($BOT_PRIVATE_TRANSFERS_PER_TX)
+    --bot.privateTransfersPerTx <value>                                      (default: 1)                                                  ($BOT_PRIVATE_TRANSFERS_PER_TX)
           How many private token transfers are executed per tx.
 
-    --bot.publicTransfersPerTx <value>                             (default: 1)                                                  ($BOT_PUBLIC_TRANSFERS_PER_TX)
+    --bot.publicTransfersPerTx <value>                                       (default: 1)                                                  ($BOT_PUBLIC_TRANSFERS_PER_TX)
           How many public token transfers are executed per tx.
 
-    --bot.feePaymentMethod <value>                                 (default: fee_juice)                                          ($BOT_FEE_PAYMENT_METHOD)
+    --bot.feePaymentMethod <value>                                           (default: fee_juice)                                          ($BOT_FEE_PAYMENT_METHOD)
           How to handle fee payments. (Options: fee_juice)
 
-    --bot.noStart <value>                                                                                                         ($BOT_NO_START)
+    --bot.noStart <value>                                                                                                                  ($BOT_NO_START)
           True to not automatically setup or start the bot on initialization.
 
-    --bot.txMinedWaitSeconds <value>                               (default: 180)                                                ($BOT_TX_MINED_WAIT_SECONDS)
+    --bot.txMinedWaitSeconds <value>                                         (default: 180)                                                ($BOT_TX_MINED_WAIT_SECONDS)
           How long to wait for a tx to be mined before reporting an error.
 
-    --bot.followChain <value>                                      (default: NONE)                                               ($BOT_FOLLOW_CHAIN)
+    --bot.followChain <value>                                                (default: NONE)                                               ($BOT_FOLLOW_CHAIN)
           Which chain the bot follows
 
-    --bot.maxPendingTxs <value>                                    (default: 128)                                                ($BOT_MAX_PENDING_TXS)
+    --bot.maxPendingTxs <value>                                              (default: 128)                                                ($BOT_MAX_PENDING_TXS)
           Do not send a tx if the node's tx pool already has this many pending txs.
 
-    --bot.flushSetupTransactions <value>                                                                                          ($BOT_FLUSH_SETUP_TRANSACTIONS)
+    --bot.flushSetupTransactions <value>                                                                                                   ($BOT_FLUSH_SETUP_TRANSACTIONS)
           Make a request for the sequencer to build a block after each setup transaction.
 
-    --bot.l2GasLimit <value>                                                                                                      ($BOT_L2_GAS_LIMIT)
+    --bot.l2GasLimit <value>                                                                                                               ($BOT_L2_GAS_LIMIT)
           L2 gas limit for the tx (empty to have the bot trigger an estimate gas).
 
-    --bot.daGasLimit <value>                                                                                                      ($BOT_DA_GAS_LIMIT)
+    --bot.daGasLimit <value>                                                                                                               ($BOT_DA_GAS_LIMIT)
           DA gas limit for the tx (empty to have the bot trigger an estimate gas).
 
-    --bot.contract <value>                                         (default: TokenContract)                                      ($BOT_TOKEN_CONTRACT)
+    --bot.contract <value>                                                   (default: TokenContract)                                      ($BOT_TOKEN_CONTRACT)
           Token contract to use
 
-    --bot.maxConsecutiveErrors <value>                                                                                            ($BOT_MAX_CONSECUTIVE_ERRORS)
+    --bot.maxConsecutiveErrors <value>                                                                                                     ($BOT_MAX_CONSECUTIVE_ERRORS)
           The maximum number of consecutive errors before the bot shuts down
 
-    --bot.stopWhenUnhealthy <value>                                                                                               ($BOT_STOP_WHEN_UNHEALTHY)
+    --bot.stopWhenUnhealthy <value>                                                                                                        ($BOT_STOP_WHEN_UNHEALTHY)
           Stops the bot if service becomes unhealthy
 
-    --bot.ammTxs <value>                                                                                                          ($BOT_AMM_TXS)
+    --bot.ammTxs <value>                                                                                                                   ($BOT_AMM_TXS)
           Deploy an AMM and send swaps to it
+
+  PXE
+
+    --pxe
+          Starts Aztec PXE with options
+
+    --pxe.l2BlockBatchSize <value>                                           (default: 50)                                                 ($PXE_L2_BLOCK_BATCH_SIZE)
+          Maximum amount of blocks to pull from the stream in one request when synchronizing
+
+    --pxe.bbBinaryPath <value>                                                                                                             ($BB_BINARY_PATH)
+          Path to the BB binary
+
+    --pxe.bbWorkingDirectory <value>                                                                                                       ($BB_WORKING_DIRECTORY)
+          Working directory for the BB binary
+
+    --pxe.bbSkipCleanup <value>                                                                                                            ($BB_SKIP_CLEANUP)
+          True to skip cleanup of temporary files for debugging purposes
+
+    --pxe.proverEnabled <value>                                              (default: true)                                               ($PXE_PROVER_ENABLED)
+          Enable real proofs
+
+    --pxe.nodeUrl <value>                                                                                                                  ($AZTEC_NODE_URL)
+          Custom Aztec Node URL to connect to
 
   TXE
 
     --txe
-          Starts Aztec TXE (Test eXecution Environment) with options
-
-  FAUCET
-
-    --faucet
-          Starts the Aztec faucet
-
-    --faucet.apiServer                                             (default: true)
-          Starts a simple HTTP server to access the faucet
-
-    --faucet.apiServerPort <value>                                 (default: 8080)
-          The port on which to start the api server on
-
-    --faucet.viemPollingIntervalMS <value>                         (default: 1000)                                               ($L1_READER_VIEM_POLLING_INTERVAL_MS)
-          The polling interval viem uses in ms
-
-    --faucet.l1Mnemonic <value>                                                                                                   ($MNEMONIC)
-          The mnemonic for the faucet account
-
-    --faucet.mnemonicAddressIndex <value>                                                                                         ($FAUCET_MNEMONIC_ADDRESS_INDEX)
-          The address to use
-
-    --faucet.interval <value>                                      (default: 3600000)                                            ($FAUCET_INTERVAL_MS)
-          How often the faucet can be dripped
-
-    --faucet.ethAmount <value>                                     (default: 1.0)                                                ($FAUCET_ETH_AMOUNT)
-          How much eth the faucet should drip per call
-
-    --faucet.l1Assets <value>                                                                                                     ($FAUCET_L1_ASSETS)
-          Which other L1 assets the faucet is able to drip
+          Starts Aztec TXE with options
 ```

--- a/yarn-project/aztec/src/cli/aztec_start_options.ts
+++ b/yarn-project/aztec/src/cli/aztec_start_options.ts
@@ -140,7 +140,7 @@ export const aztecStartOptions: { [key: string]: AztecStartOption[] } = {
     },
     {
       flag: '--admin-port <value>',
-      description: 'Port to run admin APIs of Aztec Services on on',
+      description: 'Port to run admin APIs of Aztec Services on',
       defaultValue: 8880,
       env: 'AZTEC_ADMIN_PORT',
       parseVal: val => parseInt(val, 10),

--- a/yarn-project/blob-sink/src/client/config.ts
+++ b/yarn-project/blob-sink/src/client/config.ts
@@ -17,7 +17,7 @@ export interface BlobSinkConfig extends BlobSinkArchiveApiConfig {
   l1RpcUrls?: string[];
 
   /**
-   * List of URLs for L1 consensus clients
+   * List of URLs of the Ethereum consensus nodes that services will connect to (comma separated)
    */
   l1ConsensusHostUrls?: string[];
 
@@ -49,7 +49,7 @@ export const blobSinkConfigMapping: ConfigMappingsType<BlobSinkConfig> = {
   },
   l1ConsensusHostUrls: {
     env: 'L1_CONSENSUS_HOST_URLS',
-    description: 'List of URLS for L1 consensus clients',
+    description: 'List of URLs of the Ethereum consensus nodes that services will connect to (comma separated)',
     parseEnv: (val: string) => val.split(',').map(url => url.trim().replace(/\/$/, '')),
   },
   l1ConsensusHostApiKeys: {

--- a/yarn-project/bot/src/config.ts
+++ b/yarn-project/bot/src/config.ts
@@ -161,7 +161,7 @@ export const botConfigMappings: ConfigMappingsType<BotConfig> = {
   },
   senderSalt: {
     env: 'BOT_ACCOUNT_SALT',
-    description: 'The salt to use to deploys the sender account.',
+    description: 'The salt to use to deploy the sender account.',
     parseEnv: (val: string) => (val ? Fr.fromHexString(val) : undefined),
   },
   recipientEncryptionSecret: {
@@ -172,7 +172,7 @@ export const botConfigMappings: ConfigMappingsType<BotConfig> = {
   },
   tokenSalt: {
     env: 'BOT_TOKEN_SALT',
-    description: 'Salt for the token contract deployment.',
+    description: 'The salt to use to deploy the token contract.',
     parseEnv: (val: string) => Fr.fromHexString(val),
     defaultValue: Fr.fromHexString('1'),
   },

--- a/yarn-project/ethereum/src/client.ts
+++ b/yarn-project/ethereum/src/client.ts
@@ -19,7 +19,7 @@ import { createEthereumChain } from './chain.js';
 import type { ExtendedViemWalletClient, ViemPublicClient } from './types.js';
 
 type Config = {
-  /** The RPC Url of the ethereum host. */
+  /** List of URLs of Ethereum RPC nodes that services will connect to (comma separated). */
   l1RpcUrls: string[];
   /** The chain ID of the ethereum host. */
   l1ChainId: number;

--- a/yarn-project/ethereum/src/l1_reader.ts
+++ b/yarn-project/ethereum/src/l1_reader.ts
@@ -4,7 +4,7 @@ import { type L1ContractAddresses, l1ContractAddressesMapping } from './l1_contr
 
 /** Configuration of the L1GlobalReader. */
 export interface L1ReaderConfig {
-  /** The RPC Url of the ethereum host. */
+  /** List of URLs of Ethereum RPC nodes that services will connect to (comma separated). */
   l1RpcUrls: string[];
   /** The chain ID of the ethereum host. */
   l1ChainId: number;
@@ -26,7 +26,7 @@ export const l1ReaderConfigMappings: ConfigMappingsType<L1ReaderConfig> = {
   },
   l1RpcUrls: {
     env: 'ETHEREUM_HOSTS',
-    description: 'The RPC Url of the ethereum host.',
+    description: 'List of URLs of Ethereum RPC nodes that services will connect to (comma separated).',
     parseEnv: (val: string) => val.split(',').map(url => url.trim()),
     defaultValue: [],
   },

--- a/yarn-project/kv-store/src/config.ts
+++ b/yarn-project/kv-store/src/config.ts
@@ -15,7 +15,7 @@ export const dataConfigMappings: ConfigMappingsType<DataStoreConfig> = {
   },
   dataStoreMapSizeKB: {
     env: 'DATA_STORE_MAP_SIZE_KB',
-    description: 'DB mapping size to be applied to all key/value stores',
+    description: 'The maximum possible size of a data store DB in KB. Can be overridden by component-specific options.',
     ...numberConfigHelper(128 * 1_024 * 1_024), // Defaulted to 128 GB
   },
   l1Contracts: {


### PR DESCRIPTION
The cli reference is extremely outdated. This does a first pass at at least bringing it up to nightly 9/26. A thing we could look into is getting the output of `aztec start --help`, then processing it and diffing it to next. Each time we see a change, we can manually edit what needs to be changed. This is a step below full automation that was discussed earlier but would be much easier and still provide utility to help us catch when we need to update relevant docs so this drift can be avoided. 