### PR TITLE
chore: Increase CI time for network tests

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -149,6 +149,7 @@ case "$cmd" in
     ;;
   "network-tests")
     export JOB_ID="x-${NAMESPACE}-network-tests"
+    export AWS_SHUTDOWN_TIME=360 # 6 hours for network tests
     bootstrap_ec2 "./bootstrap.sh ci-network-tests"
     ;;
   "nightly")


### PR DESCRIPTION
This PR increases the EC2 shutdown time to 6 minutes for running network tests. Fixes [A-33](https://linear.app/aztec-labs/issue/A-33/increase-max-ci-time-for-network-tests)
