### PR TITLE
fix: correct commands in helper scripts

### DIFF
--- a/scripts/auto_rebase_pr.sh
+++ b/scripts/auto_rebase_pr.sh
@@ -65,7 +65,7 @@ done
 if [ "${PUSH:-0}" -eq 1 ]; then
   # update PR branch
   git switch --force-create "$pr_head_ref" "origin/$pr_base_ref"
-  git git reset --hard "$work_branch"
+  git reset --hard "$work_branch"
   git push origin "$pr_head_ref" --force-with-lease
 else
   echo "You are on a successful rebase branch. Use 'git log' to look around."

--- a/spartan/bootstrap.sh
+++ b/spartan/bootstrap.sh
@@ -47,7 +47,7 @@ function gke {
       sudo rm -f /usr/share/keyrings/cloud.google.gpg && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg
       echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
       sudo apt install -y google-cloud-cli
-      sudo apt install google-cloud-cli-gke-gcloud-auth-plugin
+      sudo apt install -y google-cloud-cli-gke-gcloud-auth-plugin
       echo "Now you can run 'gcloud init'. Exiting with 1 as this is a necessary step."
     else
       echo "gcloud not found. This is needed for GKE kubernetes usage." >&2


### PR DESCRIPTION
Hi! I’ve cleaned up a couple of command issues in the scripts:
- remove duplicate `git` in scripts/auto_rebase_pr.sh (`git git reset` → `git reset`)
- add `-y` flag to `apt install google-cloud-cli-gke-gcloud-auth-plugin` in spartan/bootstrap.sh to avoid interactive hangs in CI