### PR TITLE
chore: change leaf index to Field

### DIFF
--- a/noir-projects/noir-protocol-circuits/crates/reset-kernel-lib/src/reset/read_request.nr
+++ b/noir-projects/noir-protocol-circuits/crates/reset-kernel-lib/src/reset/read_request.nr
@@ -499,7 +499,7 @@ mod tests {
                 let membership_witness = if hint.read_request_index != ReadRequestLen {
                     MembershipWitness {
                         leaf_index: hint.leaf_index as Field,
-                        sibling_path: tree.get_sibling_path(hint.leaf_index),
+                        sibling_path: tree.get_sibling_path(hint.leaf_index as Field),
                     }
                 } else {
                     MembershipWitness::empty()

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/abis/block_rollup_public_inputs.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/abis/block_rollup_public_inputs.nr
@@ -58,7 +58,7 @@ impl BlockRollupPublicInputs {
         // the indices.
         let num_blocks = self.new_archive.next_available_leaf_index
             - self.previous_archive.next_available_leaf_index;
-        assert(num_blocks < (1 << 16), "Too many accumulated blocks");
+        num_blocks.assert_max_bit_size::<16>();
         num_blocks as u16
     }
 }
@@ -79,10 +79,18 @@ fn correct_num_blocks() {
     assert_eq(item.num_blocks(), 3);
 }
 
-#[test(should_fail_with = "Too many accumulated blocks")]
-fn too_many_num_blocks() {
+#[test]
+fn correct_num_blocks_with_large_leaf_indices() {
+    let mut item: BlockRollupPublicInputs = make_fixture(1);
+    item.previous_archive.next_available_leaf_index = ((1 << 16) + 35) as Field;
+    item.new_archive.next_available_leaf_index = ((1 << 16) + 38) as Field;
+    assert_eq(item.num_blocks(), 3);
+}
+
+#[test(should_fail_with = "call to assert_max_bit_size")]
+fn num_blocks_too_large() {
     let mut item: BlockRollupPublicInputs = make_fixture(1);
     item.previous_archive.next_available_leaf_index = 35;
-    item.new_archive.next_available_leaf_index = (1 << 16) + 35;
+    item.new_archive.next_available_leaf_index = ((1 << 16) + 35) as Field;
     let _ = item.num_blocks();
 }

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/block_root/components/block_rollup_public_inputs_composer.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/block_root/components/block_rollup_public_inputs_composer.nr
@@ -191,7 +191,18 @@ impl BlockRollupPublicInputsComposer {
         let sponge_blob_hash = end_sponge_blob_for_block.squeeze();
 
         // Block number equals the index at which the new block header hash is inserted into the archive tree.
-        let block_number = self.previous_archive.next_available_leaf_index;
+        let block_number = self.previous_archive.next_available_leaf_index as u32;
+
+        // Note: For non-empty blocks, a check is performed in `block_root_rollup_inputs_validator.nr` to ensure that
+        // the leaf index matches the block number (u32) in the tx constants, which implies that the leaf index does not
+        // exceed u32. However, for empty blocks, without the check below, the block number would be truncated to a
+        // smaller value (dropping the high bits) if the leaf index exceeded u32. This would allow the block to follow
+        // a block with a much smaller block number, while `last_archive` would still contain the large index.
+        // This mismatch would make it impossible to provide the correct preimage when proving against this block as an
+        // anchor, since the block header hash cannot be constructed without knowing the full leaf index.
+        // Note: An empty block with a mismatched `last_archive` leaf index could be rolled up if it is in the first
+        // checkpoint of an epoch, since only the `last_archive.root` is output from the root rollup and checked on L1.
+        self.previous_archive.next_available_leaf_index.assert_max_bit_size::<32>();
 
         let global_variables = GlobalVariables {
             chain_id: self.constants.chain_id,

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/block_root/components/block_root_rollup_inputs_validator.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/block_root/components/block_root_rollup_inputs_validator.nr
@@ -41,7 +41,7 @@ pub fn validate_previous_rollups<let NumPreviousRollups: u32, let NumVkIndices: 
     // header will be inserted at the correct position.
     let constants = previous_rollups[0].public_inputs.constants;
     assert_eq(
-        constants.global_variables.block_number,
+        constants.global_variables.block_number as Field,
         constants.last_archive.next_available_leaf_index,
         "The block number must match the index at which the block header hash is inserted into the archive",
     );

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/block_root/tests/failures_tests.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/block_root/tests/failures_tests.nr
@@ -44,7 +44,7 @@ fn incorrect_next_available_archive__non_first_single_tx_block() {
     builder.execute_and_fail();
 }
 
-#[test(should_fail_with = "membership check failed")]
+#[test(should_fail_with = "Membership check failed: empty subtree root not found at insertion index")]
 fn incorrect_next_available_archive__empty_block() {
     // The error is different for the empty block root, as it doesn't have a tx, so the code path for the above tests
     // that validates the block number in the tx's constants is not triggered.
@@ -52,6 +52,67 @@ fn incorrect_next_available_archive__empty_block() {
 
     // Tweak the next_available_leaf_index of the last archive.
     builder.left_rollup.constants.last_archive.next_available_leaf_index += 1;
+
+    builder.execute_and_fail();
+}
+
+#[test(should_fail_with = "The block number must match the index at which the block header hash is inserted into the archive")]
+fn next_available_archive_leaf_index_too_large__first_block() {
+    let mut builder = TestBuilder::default(true, false);
+
+    // Tweak the next_available_leaf_index to be larger than u32.
+    builder.left_rollup.constants.last_archive.next_available_leaf_index +=
+        (1 << 32 as u64) as Field;
+    builder.right_rollup.constants.last_archive.next_available_leaf_index +=
+        (1 << 32 as u64) as Field;
+
+    builder.execute_and_fail();
+}
+
+#[test(should_fail_with = "The block number must match the index at which the block header hash is inserted into the archive")]
+fn next_available_archive_leaf_index_too_large__first_single_tx_block() {
+    let mut builder = TestBuilder::default(true, true);
+
+    // Tweak the next_available_leaf_index to be larger than u32.
+    builder.left_rollup.constants.last_archive.next_available_leaf_index +=
+        (1 << 32 as u64) as Field;
+
+    builder.execute_and_fail();
+}
+
+#[test(should_fail_with = "The block number must match the index at which the block header hash is inserted into the archive")]
+fn next_available_archive_leaf_index_too_large__non_first_block() {
+    let mut builder = TestBuilder::default(false, false);
+
+    // Tweak the next_available_leaf_index to be larger than u32.
+    builder.left_rollup.constants.last_archive.next_available_leaf_index +=
+        (1 << 32 as u64) as Field;
+    builder.right_rollup.constants.last_archive.next_available_leaf_index +=
+        (1 << 32 as u64) as Field;
+
+    builder.execute_and_fail();
+}
+
+#[test(should_fail_with = "The block number must match the index at which the block header hash is inserted into the archive")]
+fn next_available_archive_leaf_index_too_large__non_first_single_tx_block() {
+    let mut builder = TestBuilder::default(false, true);
+
+    // Tweak the next_available_leaf_index to be larger than u32.
+    builder.left_rollup.constants.last_archive.next_available_leaf_index +=
+        (1 << 32 as u64) as Field;
+
+    builder.execute_and_fail();
+}
+
+#[test(should_fail_with = "call to assert_max_bit_size")]
+fn next_available_archive_leaf_index_too_large__empty_block() {
+    // The error is different for the empty block root, as it doesn't have a tx, so the code path for the above tests
+    // that validates the block number in the tx's constants is not triggered.
+    let mut builder = TestBuilder::new_empty();
+
+    // Tweak the next_available_leaf_index to be larger than u32.
+    builder.left_rollup.constants.last_archive.next_available_leaf_index +=
+        (1 << 32 as u64) as Field;
 
     builder.execute_and_fail();
 }

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/block_root/tests/mod.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/block_root/tests/mod.nr
@@ -278,7 +278,7 @@ impl TestBuilder {
         };
         let expected_archive_root = root_from_sibling_path(
             block_header.hash(),
-            pi.previous_archive.next_available_leaf_index as Field,
+            pi.previous_archive.next_available_leaf_index,
             self.new_archive_sibling_path,
         );
         assert_eq(pi.new_archive.root, expected_archive_root);

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/tests/rollup_fixture_builder.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/tests/rollup_fixture_builder.nr
@@ -81,7 +81,7 @@ impl RollupFixtureBuilder {
                 self.get_block_header(block_number).hash(),
             ]
         };
-        let insert_index = block_number - block_number % 2;
+        let insert_index = (block_number - block_number % 2) as Field;
         let tree = SingleSubtreeMerkleTree::<2, 1, ARCHIVE_HEIGHT>::new_at_index(
             block_header_hashes,
             insert_index,
@@ -89,11 +89,11 @@ impl RollupFixtureBuilder {
 
         let snapshot = AppendOnlyTreeSnapshot {
             root: tree.get_root(),
-            next_available_leaf_index: block_number + 1,
+            next_available_leaf_index: (block_number + 1) as Field,
         };
 
         // Get the sibling path for the current block.
-        let sibling_path = tree.get_sibling_path(block_number);
+        let sibling_path = tree.get_sibling_path(block_number as Field);
 
         (snapshot, sibling_path)
     }
@@ -110,16 +110,16 @@ impl RollupFixtureBuilder {
         }
         let tree = SingleSubtreeMerkleTree::<4, 2, ARCHIVE_HEIGHT>::new_at_index(
             block_header_hashes,
-            insert_index,
+            insert_index as Field,
         );
 
         let previous_snapshot = AppendOnlyTreeSnapshot {
             root: tree.get_root(),
-            next_available_leaf_index: block_number,
+            next_available_leaf_index: block_number as Field,
         };
 
         // Get the sibling path for inserting the current block header hash.
-        let sibling_path_for_insertion = tree.get_sibling_path(block_number);
+        let sibling_path_for_insertion = tree.get_sibling_path(block_number as Field);
 
         (previous_snapshot, sibling_path_for_insertion)
     }
@@ -130,6 +130,7 @@ impl RollupFixtureBuilder {
     ) -> (AppendOnlyTreeSnapshot, [Field; L1_TO_L2_MSG_TREE_HEIGHT - L1_TO_L2_MSG_SUBTREE_HEIGHT], AppendOnlyTreeSnapshot) {
         // Create a subtree of size 4 filled with subtree roots before the current slot.
         let new_slot_index = self.get_l1_to_l2_message_next_available_leaf_index(slot_number - 1)
+             as u32
             >> L1_TO_L2_MSG_SUBTREE_HEIGHT;
         let start_slot_index = new_slot_index - new_slot_index % 4;
         let mut subtree_roots = [0; 4];
@@ -142,7 +143,7 @@ impl RollupFixtureBuilder {
 
         let mut tree = SingleSubtreeMerkleTree::<4, 2, L1_TO_L2_MSG_TREE_HEIGHT - L1_TO_L2_MSG_SUBTREE_HEIGHT>::new_tree_roots_at_index::<L1_TO_L2_MSG_SUBTREE_HEIGHT>(
             subtree_roots,
-            start_slot_index,
+            start_slot_index as Field,
         );
         let previous_snapshot = AppendOnlyTreeSnapshot {
             root: tree.get_root(),
@@ -152,10 +153,13 @@ impl RollupFixtureBuilder {
         };
 
         // Get the sibling path for inserting the current l1-to-l2 messages.
-        let sibling_path_for_insertion = tree.get_sibling_path(new_slot_index);
+        let sibling_path_for_insertion = tree.get_sibling_path(new_slot_index as Field);
 
         // Insert subtree of the current l1-to-l2 messages.
-        tree.update_leaf(new_slot_index, self.get_l1_to_l2_message_subtree_root(slot_number));
+        tree.update_leaf(
+            new_slot_index as Field,
+            self.get_l1_to_l2_message_subtree_root(slot_number),
+        );
         let new_snapshot = AppendOnlyTreeSnapshot {
             root: tree.get_root(),
             next_available_leaf_index: self.get_l1_to_l2_message_next_available_leaf_index(
@@ -447,8 +451,8 @@ impl RollupFixtureBuilder {
         slot_number * 7639901
     }
 
-    fn get_l1_to_l2_message_next_available_leaf_index(_self: Self, slot_number: Field) -> u32 {
-        (slot_number as u32 + 1) * (1 << L1_TO_L2_MSG_SUBTREE_HEIGHT)
+    fn get_l1_to_l2_message_next_available_leaf_index(_self: Self, slot_number: Field) -> Field {
+        (slot_number + 1) * (1 << L1_TO_L2_MSG_SUBTREE_HEIGHT) as Field
     }
 
     fn get_l1_to_l2_message_tree_snapshot(self, slot_number: Field) -> AppendOnlyTreeSnapshot {
@@ -460,7 +464,7 @@ impl RollupFixtureBuilder {
     fn get_archive(_self: Self, block_number: u32) -> AppendOnlyTreeSnapshot {
         AppendOnlyTreeSnapshot {
             root: block_number as Field * 30785,
-            next_available_leaf_index: block_number + 1,
+            next_available_leaf_index: (block_number + 1) as Field,
         }
     }
 

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/tx_base/tests/private_tx_base/end_blob_sponge_tests.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/tx_base/tests/private_tx_base/end_blob_sponge_tests.nr
@@ -83,7 +83,7 @@ unconstrained fn full_tx_effects() {
     offset += MAX_L2_TO_L1_MSGS_PER_TX;
 
     let fee_payer_balance_leaf_preimage =
-        builder.pre_existing_public_data_leaves[builder.fee_payer_balance_leaf_index];
+        builder.pre_existing_public_data_preimages[builder.fee_payer_preimage_index];
     expected_blob_fields[offset] = fee_payer_balance_leaf_preimage.slot;
     expected_blob_fields[offset + 1] = fee_payer_balance_leaf_preimage.value - transaction_fee;
     offset += 2;
@@ -191,7 +191,7 @@ unconstrained fn all_side_effects_non_full() {
     offset += num_l2_to_l1_msgs;
 
     let fee_payer_balance_leaf_preimage =
-        builder.pre_existing_public_data_leaves[builder.fee_payer_balance_leaf_index];
+        builder.pre_existing_public_data_preimages[builder.fee_payer_preimage_index];
     expected_blob_fields[offset] = fee_payer_balance_leaf_preimage.slot;
     expected_blob_fields[offset + 1] = fee_payer_balance_leaf_preimage.value - transaction_fee;
     offset += 2;
@@ -280,7 +280,7 @@ unconstrained fn partially_empty_tx_effects() {
     offset += num_note_hashes;
 
     let fee_payer_balance_leaf_preimage =
-        builder.pre_existing_public_data_leaves[builder.fee_payer_balance_leaf_index];
+        builder.pre_existing_public_data_preimages[builder.fee_payer_preimage_index];
     expected_blob_fields[offset] = fee_payer_balance_leaf_preimage.slot;
     expected_blob_fields[offset + 1] = fee_payer_balance_leaf_preimage.value - transaction_fee;
     offset += 2;

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/tx_base/tests/private_tx_base/end_tree_snapshot_tests.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/tx_base/tests/private_tx_base/end_tree_snapshot_tests.nr
@@ -1,4 +1,4 @@
-use super::TestBuilder;
+use super::{TEST_PUBLIC_DATA_SUBTREE_WIDTH, TestBuilder};
 use types::{
     abis::{
         append_only_tree_snapshot::AppendOnlyTreeSnapshot, gas_fees::GasFees,
@@ -7,6 +7,7 @@ use types::{
     constants::{
         MAX_NOTE_HASHES_PER_TX, MAX_NULLIFIERS_PER_TX, NOTE_HASH_SUBTREE_HEIGHT,
         NOTE_HASH_TREE_HEIGHT, NULLIFIER_SUBTREE_HEIGHT, NULLIFIER_TREE_HEIGHT,
+        PUBLIC_DATA_TREE_HEIGHT,
     },
     merkle_tree::{LeafPreimage, MembershipWitness},
     tests::{merkle_tree_utils::SingleSubtreeMerkleTree, utils::pad_end},
@@ -21,14 +22,15 @@ impl TestBuilder {
         let note_hashes = self.pre_existing_note_hashes.concat(new_note_hashes);
 
         let existing_leaf_start_index =
-            self.note_hash_tree.get_next_available_index() - MAX_NOTE_HASHES_PER_TX;
+            self.note_hash_tree.get_next_available_index() - MAX_NOTE_HASHES_PER_TX as Field;
 
         let full_note_hash_tree = SingleSubtreeMerkleTree::<MAX_NOTE_HASHES_PER_TX * 2, NOTE_HASH_SUBTREE_HEIGHT + 1, NOTE_HASH_TREE_HEIGHT>::new_at_index(
             note_hashes,
             existing_leaf_start_index,
         );
 
-        let next_available_leaf_index = existing_leaf_start_index + MAX_NULLIFIERS_PER_TX * 2;
+        let next_available_leaf_index =
+            existing_leaf_start_index + (MAX_NULLIFIERS_PER_TX * 2) as Field;
 
         AppendOnlyTreeSnapshot { root: full_note_hash_tree.get_root(), next_available_leaf_index }
     }
@@ -41,14 +43,15 @@ impl TestBuilder {
         let nullifiers = updated_existing_nullifiers.concat(new_nullifiers);
 
         let existing_leaf_start_index =
-            self.nullifier_tree.get_next_available_index() - MAX_NULLIFIERS_PER_TX;
+            self.nullifier_tree.get_next_available_index() - MAX_NULLIFIERS_PER_TX as Field;
 
         let full_nullifier_tree = SingleSubtreeMerkleTree::<MAX_NULLIFIERS_PER_TX * 2, NULLIFIER_SUBTREE_HEIGHT + 1, NULLIFIER_TREE_HEIGHT>::new_at_index(
             nullifiers.map(|nullifier| nullifier.as_leaf()),
             existing_leaf_start_index,
         );
 
-        let next_available_leaf_index = existing_leaf_start_index + MAX_NULLIFIERS_PER_TX * 2;
+        let next_available_leaf_index =
+            existing_leaf_start_index + (MAX_NULLIFIERS_PER_TX * 2) as Field;
 
         AppendOnlyTreeSnapshot { root: full_nullifier_tree.get_root(), next_available_leaf_index }
     }
@@ -73,14 +76,16 @@ unconstrained fn tree_roots_not_change_if_no_side_effects_and_transaction_fee() 
     // The next available leaf index should be incremented by the number of note hashes.
     assert_eq(
         end_tree_snapshots.note_hash_tree.next_available_leaf_index,
-        start_tree_snapshots.note_hash_tree.next_available_leaf_index + MAX_NOTE_HASHES_PER_TX,
+        start_tree_snapshots.note_hash_tree.next_available_leaf_index
+            + MAX_NOTE_HASHES_PER_TX as Field,
     );
 
     assert_eq(end_tree_snapshots.nullifier_tree.root, start_tree_snapshots.nullifier_tree.root);
     // The next available leaf index should be incremented by the number of nullifiers.
     assert_eq(
         end_tree_snapshots.nullifier_tree.next_available_leaf_index,
-        start_tree_snapshots.nullifier_tree.next_available_leaf_index + MAX_NULLIFIERS_PER_TX,
+        start_tree_snapshots.nullifier_tree.next_available_leaf_index
+            + MAX_NULLIFIERS_PER_TX as Field,
     );
 
     // The fee payer doesn't have to pay fee. Their balance leaf is untouched, so public data tree should be the same.
@@ -90,6 +95,8 @@ unconstrained fn tree_roots_not_change_if_no_side_effects_and_transaction_fee() 
         start_tree_snapshots.public_data_tree.next_available_leaf_index,
     );
 }
+
+// --- Note hash tree ---
 
 #[test]
 unconstrained fn full_note_hashes() {
@@ -130,6 +137,33 @@ unconstrained fn identical_note_hashes() {
 }
 
 #[test]
+unconstrained fn insert_at_large_index_to_fill_note_hash_tree() {
+    let mut builder = TestBuilder::new();
+
+    let max_num_note_hashes = (1 << NOTE_HASH_TREE_HEIGHT as u64) as Field;
+    let start_index = max_num_note_hashes - (MAX_NOTE_HASHES_PER_TX * 2) as Field;
+    builder.build_note_hash_tree(start_index);
+
+    let pi = builder.execute();
+    builder.assert_expected_public_inputs(pi);
+
+    assert_eq(pi.end_tree_snapshots.note_hash_tree.next_available_leaf_index, max_num_note_hashes);
+}
+
+#[test(should_fail_with = "Field failed to decompose into specified 34 limbs")]
+unconstrained fn insert_at_large_index_to_overfill_note_hash_tree() {
+    let mut builder = TestBuilder::new();
+
+    let max_num_note_hashes = (1 << NOTE_HASH_TREE_HEIGHT as u64) as Field;
+    let start_index = max_num_note_hashes - MAX_NOTE_HASHES_PER_TX as Field;
+    builder.build_note_hash_tree(start_index);
+
+    builder.execute_and_fail();
+}
+
+// --- Nullifier tree ---
+
+#[test]
 unconstrained fn full_nullifiers_all_larger_than_existing() {
     let mut builder = TestBuilder::new();
 
@@ -160,7 +194,7 @@ unconstrained fn full_nullifiers_all_larger_than_existing() {
         new_nullifiers[i] = NullifierLeafPreimage {
             nullifier: new_nullifier_values[i],
             next_nullifier: new_nullifier_values[i + 1],
-            next_index: new_leaf_start_index + i + 1,
+            next_index: new_leaf_start_index + 1 + i as Field,
         };
     }
     // Only need to set the value for the largest nullifier because it points to infinity.
@@ -183,8 +217,8 @@ unconstrained fn non_full_unordered_nullifiers() {
     let pi = builder.execute();
     builder.assert_expected_public_inputs(pi);
 
-    let existing_leaf_start_index =
-        pi.start_tree_snapshots.nullifier_tree.next_available_leaf_index - MAX_NULLIFIERS_PER_TX;
+    let existing_leaf_start_index = pi.start_tree_snapshots.nullifier_tree.next_available_leaf_index
+        - MAX_NULLIFIERS_PER_TX as Field;
     let new_leaf_start_index = pi.start_tree_snapshots.nullifier_tree.next_available_leaf_index;
 
     let updated_existing_nullifiers = [
@@ -247,9 +281,9 @@ unconstrained fn new_nullifier_same_as_existing_use_empty_leaf_as_low_leaf() {
     builder.build_hints_for_new_nullifiers();
 
     // Set the hint to use an empty leaf as the low leaf.
-    let empty_leaf_index = builder.pre_existing_nullifiers.len();
+    let empty_leaf_index = builder.pre_existing_nullifiers.len() as Field;
     builder.tree_snapshot_diff_hints.nullifier_predecessor_membership_witnesses[0] = MembershipWitness {
-        leaf_index: empty_leaf_index as Field,
+        leaf_index: empty_leaf_index,
         sibling_path: builder.nullifier_tree.get_sibling_path(empty_leaf_index),
     };
 
@@ -273,7 +307,7 @@ unconstrained fn new_nullifier_same_as_existing_use_low_leaf_with_smaller_value(
     builder.tree_snapshot_diff_hints.nullifier_predecessor_preimages[0] = low_leaf;
     builder.tree_snapshot_diff_hints.nullifier_predecessor_membership_witnesses[0] = MembershipWitness {
         leaf_index: low_leaf_index as Field,
-        sibling_path: builder.nullifier_tree.get_sibling_path(low_leaf_index),
+        sibling_path: builder.nullifier_tree.get_sibling_path(low_leaf_index as Field),
     };
 
     builder.execute_and_fail();
@@ -296,7 +330,7 @@ unconstrained fn new_nullifier_same_as_existing_use_low_leaf_with_valid_next_lea
     builder.tree_snapshot_diff_hints.nullifier_predecessor_preimages[0] = low_leaf;
     builder.tree_snapshot_diff_hints.nullifier_predecessor_membership_witnesses[0] = MembershipWitness {
         leaf_index: low_leaf_index as Field,
-        sibling_path: builder.nullifier_tree.get_sibling_path(low_leaf_index),
+        sibling_path: builder.nullifier_tree.get_sibling_path(low_leaf_index as Field),
     };
 
     builder.execute_and_fail();
@@ -342,6 +376,33 @@ unconstrained fn identical_new_nullifiers() {
 }
 
 #[test]
+unconstrained fn insert_at_large_index_to_fill_nullifier_tree() {
+    let mut builder = TestBuilder::new();
+
+    let max_num_nullifiers = (1 << NULLIFIER_TREE_HEIGHT as u64) as Field;
+    let start_index = max_num_nullifiers - (MAX_NULLIFIERS_PER_TX * 2) as Field;
+    builder.build_nullifier_tree(start_index);
+
+    let pi = builder.execute();
+    builder.assert_expected_public_inputs(pi);
+
+    assert_eq(pi.end_tree_snapshots.nullifier_tree.next_available_leaf_index, max_num_nullifiers);
+}
+
+#[test(should_fail_with = "Field failed to decompose into specified 34 limbs")]
+unconstrained fn insert_at_large_index_to_overfill_nullifier_tree() {
+    let mut builder = TestBuilder::new();
+
+    let max_num_nullifiers = (1 << NULLIFIER_TREE_HEIGHT as u64) as Field;
+    let start_index = max_num_nullifiers - MAX_NULLIFIERS_PER_TX as Field;
+    builder.build_nullifier_tree(start_index);
+
+    builder.execute_and_fail();
+}
+
+// --- Public data tree ---
+
+#[test]
 unconstrained fn fee_payer_balance_leaf_updated() {
     let mut builder = TestBuilder::new();
 
@@ -349,25 +410,79 @@ unconstrained fn fee_payer_balance_leaf_updated() {
     assert(!tx_fee.is_empty());
 
     // Set the fee payer's balance to be 11 more than the transaction fee.
-    let leaf_index = builder.fee_payer_balance_leaf_index;
-    builder.pre_existing_public_data_leaves[leaf_index].value = tx_fee + 11;
-    builder.build_public_data_tree();
+    let leaf_index = builder.fee_payer_preimage_index;
+    builder.pre_existing_public_data_preimages[leaf_index].value = tx_fee + 11;
+    // Re-build the tree and hints.
+    builder.build_public_data_tree(0);
 
     let pi = builder.execute();
     builder.assert_expected_public_inputs(pi);
 
-    let mut fee_payer_new_balance_leaf = builder.pre_existing_public_data_leaves[leaf_index];
+    // Fee payer's balance is now 11.
+    let mut fee_payer_new_balance_leaf = builder.pre_existing_public_data_preimages[leaf_index];
     fee_payer_new_balance_leaf.value = 11;
 
     let mut new_public_data_tree = builder.public_data_tree;
-    new_public_data_tree.update_leaf(leaf_index, fee_payer_new_balance_leaf.as_leaf());
+    new_public_data_tree.update_leaf(leaf_index as Field, fee_payer_new_balance_leaf.as_leaf());
     let expected_end_tree_root = new_public_data_tree.get_root();
 
     let start_tree_snapshot = pi.start_tree_snapshots.public_data_tree;
     let end_tree_snapshot = pi.end_tree_snapshots.public_data_tree;
+    assert(end_tree_snapshot.root != start_tree_snapshot.root);
     assert_eq(end_tree_snapshot.root, expected_end_tree_root);
     assert_eq(
         end_tree_snapshot.next_available_leaf_index,
         start_tree_snapshot.next_available_leaf_index,
     );
+}
+
+#[test]
+unconstrained fn fee_payer_balance_leaf_update_at_large_index() {
+    let mut builder = TestBuilder::new();
+
+    let tx_fee = builder.get_transaction_fee();
+    assert(!tx_fee.is_empty());
+
+    // Set the fee payer's balance to be 11 more than the transaction fee.
+    builder.pre_existing_public_data_preimages[builder.fee_payer_preimage_index].value =
+        tx_fee + 11;
+    // Add the existing leaves to the end of the tree.
+    let max_public_data_leaves = (1 << PUBLIC_DATA_TREE_HEIGHT as u64) as Field;
+    let start_index = max_public_data_leaves - TEST_PUBLIC_DATA_SUBTREE_WIDTH as Field;
+    // Re-build the tree and hints.
+    builder.build_public_data_tree(start_index);
+    builder.build_hints_for_fee_payer_balance();
+
+    let pi = builder.execute();
+    builder.assert_expected_public_inputs(pi);
+
+    // Fee payer's balance is now 11.
+    let mut fee_payer_new_balance_leaf =
+        builder.pre_existing_public_data_preimages[builder.fee_payer_preimage_index];
+    fee_payer_new_balance_leaf.value = 11;
+
+    let mut new_public_data_tree = builder.public_data_tree;
+    let leaf_index = start_index + builder.fee_payer_preimage_index as Field;
+    new_public_data_tree.update_leaf(leaf_index as Field, fee_payer_new_balance_leaf.as_leaf());
+    let expected_end_tree_root = new_public_data_tree.get_root();
+
+    let start_tree_snapshot = pi.start_tree_snapshots.public_data_tree;
+    let end_tree_snapshot = pi.end_tree_snapshots.public_data_tree;
+    assert(end_tree_snapshot.root != start_tree_snapshot.root);
+    assert_eq(end_tree_snapshot.root, expected_end_tree_root);
+    assert_eq(
+        end_tree_snapshot.next_available_leaf_index,
+        start_tree_snapshot.next_available_leaf_index,
+    );
+}
+
+#[test(should_fail_with = "attempt to bit-shift with overflow")]
+unconstrained fn fee_payer_balance_leaf_index_too_large() {
+    let mut builder = TestBuilder::new();
+
+    // Tweak the index of the leaf to be beyond the tree size.
+    builder.tree_snapshot_diff_hints.fee_payer_balance_membership_witness.leaf_index +=
+        (1 << PUBLIC_DATA_TREE_HEIGHT) as Field;
+
+    builder.execute_and_fail();
 }

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/tx_base/tests/private_tx_base/fee_tests.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/tx_base/tests/private_tx_base/fee_tests.nr
@@ -4,8 +4,8 @@ use super::TestBuilder;
 unconstrained fn hint_to_incorrect_public_data_leaf() {
     let mut builder = TestBuilder::new();
 
-    // Point to another fee payer's balance leaf.
-    builder.fee_payer_balance_leaf_index += 1;
+    // Point to another public data preimage.
+    builder.fee_payer_preimage_index += 1;
     builder.build_hints_for_fee_payer_balance();
 
     builder.execute_and_fail();
@@ -18,9 +18,8 @@ unconstrained fn insufficient_balance_to_pay_fee() {
     let tx_fee = builder.get_transaction_fee();
 
     // Set the fee payer's balance to be less than the transaction fee.
-    builder.pre_existing_public_data_leaves[builder.fee_payer_balance_leaf_index].value =
-        tx_fee - 1;
-    builder.build_public_data_tree();
+    builder.pre_existing_public_data_preimages[builder.fee_payer_preimage_index].value = tx_fee - 1;
+    builder.build_public_data_tree(0);
 
     builder.execute_and_fail();
 }
@@ -32,8 +31,8 @@ unconstrained fn balance_equal_transaction_fee() {
     let tx_fee = builder.get_transaction_fee();
 
     // Set the fee payer's balance to be equal to the transaction fee.
-    builder.pre_existing_public_data_leaves[builder.fee_payer_balance_leaf_index].value = tx_fee;
-    builder.build_public_data_tree();
+    builder.pre_existing_public_data_preimages[builder.fee_payer_preimage_index].value = tx_fee;
+    builder.build_public_data_tree(0);
 
     let pi = builder.execute();
     builder.assert_expected_public_inputs(pi);
@@ -46,7 +45,17 @@ unconstrained fn incorrect_fee_payer_balance_leaf_preimage() {
     let mut builder = TestBuilder::new();
 
     // Tweak the value of the preimage without updating it to the tree.
-    builder.pre_existing_public_data_leaves[builder.fee_payer_balance_leaf_index].value += 1;
+    builder.pre_existing_public_data_preimages[builder.fee_payer_preimage_index].value += 1;
+
+    builder.execute_and_fail();
+}
+
+#[test(should_fail_with = "Membership check failed: public data leaf preimage does not exist in tree")]
+unconstrained fn incorrect_fee_payer_pre_existing_leaf_index() {
+    let mut builder = TestBuilder::new();
+
+    // Tweak the value of the leaf index.
+    builder.pre_existing_public_data_preimages[builder.fee_payer_preimage_index].slot += 1;
 
     builder.execute_and_fail();
 }

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/tx_base/tests/private_tx_base/mod.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/tx_base/tests/private_tx_base/mod.nr
@@ -28,8 +28,9 @@ use dep::types::{
     constants::{
         ARCHIVE_HEIGHT, CONTRACT_CLASS_LOG_SIZE_IN_FIELDS, HIDING_KERNEL_TO_ROLLUP_VK_INDEX,
         MAX_CONTRACT_CLASS_LOGS_PER_TX, MAX_L2_TO_L1_MSGS_PER_TX, MAX_NOTE_HASHES_PER_TX,
-        MAX_NULLIFIERS_PER_TX, NOTE_HASH_SUBTREE_HEIGHT, NOTE_HASH_TREE_HEIGHT,
-        NULLIFIER_SUBTREE_HEIGHT, NULLIFIER_TREE_HEIGHT, PUBLIC_DATA_TREE_HEIGHT,
+        MAX_NULLIFIERS_PER_TX, MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX, NOTE_HASH_SUBTREE_HEIGHT,
+        NOTE_HASH_TREE_HEIGHT, NULLIFIER_SUBTREE_HEIGHT, NULLIFIER_TREE_HEIGHT,
+        PUBLIC_DATA_TREE_HEIGHT,
     },
     data::public_data_tree_leaf_preimage::PublicDataTreeLeafPreimage,
     hash::silo_l2_to_l1_message,
@@ -57,10 +58,10 @@ pub struct TestBuilder {
     tree_snapshot_diff_hints: TreeSnapshotDiffHints,
     pre_existing_note_hashes: [Field; MAX_NOTE_HASHES_PER_TX],
     note_hash_tree: SingleSubtreeMerkleTree<MAX_NOTE_HASHES_PER_TX, NOTE_HASH_SUBTREE_HEIGHT, NOTE_HASH_TREE_HEIGHT>,
-    pre_existing_public_data_leaves: [PublicDataTreeLeafPreimage; TEST_PUBLIC_DATA_SUBTREE_WIDTH],
-    nullifier_tree: SingleSubtreeMerkleTree<MAX_NULLIFIERS_PER_TX, NULLIFIER_SUBTREE_HEIGHT, NULLIFIER_TREE_HEIGHT>,
     pre_existing_nullifiers: [NullifierLeafPreimage; 4],
-    fee_payer_balance_leaf_index: u32,
+    nullifier_tree: SingleSubtreeMerkleTree<MAX_NULLIFIERS_PER_TX, NULLIFIER_SUBTREE_HEIGHT, NULLIFIER_TREE_HEIGHT>,
+    pre_existing_public_data_preimages: [PublicDataTreeLeafPreimage; TEST_PUBLIC_DATA_SUBTREE_WIDTH],
+    fee_payer_preimage_index: u32,
     public_data_tree: SingleSubtreeMerkleTree<TEST_PUBLIC_DATA_SUBTREE_WIDTH, TEST_PUBLIC_DATA_SUBTREE_HEIGHT, PUBLIC_DATA_TREE_HEIGHT>,
 }
 
@@ -98,7 +99,7 @@ impl TestBuilder {
 
         // Public data writes in the tree before the tx.
         let fee_payer_balance_leaf_slot = compute_fee_payer_fee_juice_balance_leaf_slot(fee_payer);
-        let pre_existing_public_data_leaves = [
+        let pre_existing_public_data_preimages = [
             PublicDataTreeLeafPreimage {
                 slot: fee_payer_balance_leaf_slot + 10,
                 value: 1100,
@@ -124,7 +125,7 @@ impl TestBuilder {
                 next_index: 1,
             },
         ];
-        let fee_payer_balance_leaf_index = 1;
+        let fee_payer_preimage_index = 1;
 
         // Nullifiers in the tree before the tx.
         let pre_existing_nullifiers = [
@@ -145,17 +146,21 @@ impl TestBuilder {
             tree_snapshot_diff_hints: std::mem::zeroed(),
             pre_existing_note_hashes: pad_end(pre_existing_note_hashes),
             note_hash_tree: std::mem::zeroed(),
-            pre_existing_public_data_leaves: pad_end(pre_existing_public_data_leaves),
+            pre_existing_public_data_preimages,
             nullifier_tree: std::mem::zeroed(),
             pre_existing_nullifiers,
-            fee_payer_balance_leaf_index,
+            fee_payer_preimage_index,
             public_data_tree: std::mem::zeroed(),
         };
 
-        builder.build_note_hash_tree();
-        builder.build_nullifier_tree();
+        // Insert the pre-existing note hashes at a non-zero index by default.
+        let note_hash_start_index = (MAX_NOTE_HASHES_PER_TX * 26) as Field;
+        builder.build_note_hash_tree(note_hash_start_index);
+        // Insert the pre-existing nullifiers at index 0 by default.
+        builder.build_nullifier_tree(0);
         builder.build_hints_for_new_nullifiers();
-        builder.build_public_data_tree();
+        // Insert the pre-existing public data leaves at index 0.
+        builder.build_public_data_tree(0);
         builder.build_hints_for_fee_payer_balance();
 
         builder
@@ -182,16 +187,13 @@ impl TestBuilder {
         self.contract_class_log_fields = fixture_builder.contract_class_log_fields.storage();
     }
 
-    pub fn build_note_hash_tree(&mut self) {
-        // Insert the pre-existing note hashes at a non-zero index.
-        let start_index = MAX_NOTE_HASHES_PER_TX * 26;
-
+    pub fn build_note_hash_tree(&mut self, start_index: Field) {
         self.note_hash_tree = SingleSubtreeMerkleTree::new_at_index(
             pad_end(self.pre_existing_note_hashes),
             start_index,
         );
 
-        let next_available_leaf_index = start_index + MAX_NOTE_HASHES_PER_TX;
+        let next_available_leaf_index = start_index + MAX_NOTE_HASHES_PER_TX as Field;
 
         self.start_tree_snapshots.note_hash_tree = AppendOnlyTreeSnapshot {
             root: self.note_hash_tree.get_root(),
@@ -204,19 +206,17 @@ impl TestBuilder {
         );
     }
 
-    pub fn build_nullifier_tree(&mut self) {
+    pub fn build_nullifier_tree(&mut self, start_index: Field) {
         let leaf_values = self.pre_existing_nullifiers.map(|nullifier| nullifier.as_leaf());
-
-        self.nullifier_tree = SingleSubtreeMerkleTree::new_at_index(pad_end(leaf_values), 0);
-
-        let next_available_leaf_index = MAX_NULLIFIERS_PER_TX;
+        self.nullifier_tree =
+            SingleSubtreeMerkleTree::new_at_index(pad_end(leaf_values), start_index);
 
         self.start_tree_snapshots.nullifier_tree = AppendOnlyTreeSnapshot {
             root: self.nullifier_tree.get_root(),
-            next_available_leaf_index,
+            next_available_leaf_index: start_index + MAX_NULLIFIERS_PER_TX as Field,
         };
 
-        // If nullifier tree is rebuilt, might need to call `build_hints_for_new_nullifiers` again to update the hints.
+        // If the tree is rebuilt, might need to call `build_hints_for_new_nullifiers` again to update the hints.
     }
 
     pub fn build_hints_for_new_nullifiers(&mut self) {
@@ -231,7 +231,8 @@ impl TestBuilder {
 
         let mut cloned_nullifier_tree = self.nullifier_tree;
         let mut low_leaves = self.pre_existing_nullifiers;
-        let new_batch_start_index = MAX_NULLIFIERS_PER_TX;
+        let new_batch_start_index =
+            self.start_tree_snapshots.nullifier_tree.next_available_leaf_index;
         for i in 0..sorted_nullifiers.len() {
             let new_nullifier = sorted_nullifiers[i];
             // Safety: This is for testing only.
@@ -248,47 +249,51 @@ impl TestBuilder {
                 self.tree_snapshot_diff_hints.nullifier_predecessor_preimages[i] =
                     low_leaves[low_leaf_index];
 
+                let low_tree_leaf_index = low_leaf_index as Field;
                 self.tree_snapshot_diff_hints.nullifier_predecessor_membership_witnesses[i] = MembershipWitness {
-                    leaf_index: low_leaf_index as Field,
-                    sibling_path: cloned_nullifier_tree.get_sibling_path(low_leaf_index),
+                    leaf_index: low_tree_leaf_index,
+                    sibling_path: cloned_nullifier_tree.get_sibling_path(low_tree_leaf_index),
                 };
 
                 low_leaves[low_leaf_index].next_nullifier = new_nullifier;
                 low_leaves[low_leaf_index].next_index =
-                    new_batch_start_index + sorted_nullifier_indexes[i];
+                    new_batch_start_index + sorted_nullifier_indexes[i] as Field;
 
                 cloned_nullifier_tree.update_leaf(
-                    low_leaf_index,
+                    low_tree_leaf_index,
                     low_leaves[low_leaf_index].as_leaf(),
                 );
             }
         }
 
-        let next_available_leaf_index = MAX_NULLIFIERS_PER_TX;
         self.tree_snapshot_diff_hints.nullifier_subtree_root_sibling_path = subarray(
-            cloned_nullifier_tree.get_sibling_path(next_available_leaf_index),
+            cloned_nullifier_tree.get_sibling_path(new_batch_start_index),
             NULLIFIER_SUBTREE_HEIGHT,
         );
     }
 
-    pub fn build_public_data_tree(&mut self) {
+    pub fn build_public_data_tree(&mut self, start_index: Field) {
         self.public_data_tree = SingleSubtreeMerkleTree::new_at_index(
-            self.pre_existing_public_data_leaves.map(|leaf| leaf.as_leaf()),
-            0,
+            self.pre_existing_public_data_preimages.map(|leaf| leaf.as_leaf()),
+            start_index,
         );
-
-        let next_available_leaf_index = TEST_PUBLIC_DATA_SUBTREE_WIDTH;
 
         self.start_tree_snapshots.public_data_tree = AppendOnlyTreeSnapshot {
             root: self.public_data_tree.get_root(),
-            next_available_leaf_index,
+            next_available_leaf_index: MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX as Field,
         };
+
+        // If the tree is rebuilt and the start index has changed, call `build_hints_for_fee_payer_balance` again to
+        // update the hints.
     }
 
     pub fn build_hints_for_fee_payer_balance(&mut self) {
+        let start_index = self.public_data_tree.get_next_available_index()
+            - TEST_PUBLIC_DATA_SUBTREE_WIDTH as Field;
+        let leaf_index = start_index + self.fee_payer_preimage_index as Field;
         self.tree_snapshot_diff_hints.fee_payer_balance_membership_witness = MembershipWitness {
-            leaf_index: self.fee_payer_balance_leaf_index as Field,
-            sibling_path: self.public_data_tree.get_sibling_path(self.fee_payer_balance_leaf_index),
+            leaf_index,
+            sibling_path: self.public_data_tree.get_sibling_path(leaf_index),
         };
     }
 
@@ -297,7 +302,7 @@ impl TestBuilder {
             RollupFixtureBuilder::make_proof_data(self.private_tail, self.hiding_kernel_vk_index);
 
         let fee_payer_balance_leaf_preimage =
-            self.pre_existing_public_data_leaves[self.fee_payer_balance_leaf_index];
+            self.pre_existing_public_data_preimages[self.fee_payer_preimage_index];
 
         PrivateTxBaseRollupPrivateInputs {
             hiding_kernel_proof_data,

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/append_only_tree_snapshot.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/append_only_tree_snapshot.nr
@@ -4,8 +4,7 @@ use std::meta::derive;
 #[derive(Deserialize, Eq, Serialize)]
 pub struct AppendOnlyTreeSnapshot {
     pub root: Field,
-    // TODO(Alvaro) change this to a u64
-    pub next_available_leaf_index: u32,
+    pub next_available_leaf_index: Field,
 }
 
 impl Empty for AppendOnlyTreeSnapshot {

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/avm_circuit_public_inputs.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/avm_circuit_public_inputs.nr
@@ -151,7 +151,7 @@ fn set_snapshot_in_cols(
     row_idx: u32,
 ) {
     cols[0][row_idx] = snapshot.root;
-    cols[1][row_idx] = snapshot.next_available_leaf_index as Field;
+    cols[1][row_idx] = snapshot.next_available_leaf_index;
 }
 fn set_gas_in_cols(
     gas: Gas,

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/nullifier_leaf_preimage.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/nullifier_leaf_preimage.nr
@@ -10,7 +10,7 @@ use crate::{
 pub struct NullifierLeafPreimage {
     pub nullifier: Field,
     pub next_nullifier: Field,
-    pub next_index: u32,
+    pub next_index: Field,
 }
 
 impl Empty for NullifierLeafPreimage {
@@ -48,7 +48,7 @@ impl IndexedTreeLeafPreimage<Field> for NullifierLeafPreimage {
         (self.next_nullifier == 0) & (self.next_index == 0)
     }
 
-    fn update_pointers(self, next_key: Field, next_index: u32) -> Self {
+    fn update_pointers(self, next_key: Field, next_index: Field) -> Self {
         Self { nullifier: self.nullifier, next_nullifier: next_key, next_index }
     }
 
@@ -80,11 +80,11 @@ impl NullifierLeafPreimage {
     }
 
     pub fn serialize(self) -> [Field; NULLIFIER_LEAF_PREIMAGE_LENGTH] {
-        [self.nullifier, self.next_nullifier, self.next_index as Field]
+        [self.nullifier, self.next_nullifier, self.next_index]
     }
 
     pub fn deserialize(fields: [Field; NULLIFIER_LEAF_PREIMAGE_LENGTH]) -> Self {
-        Self { nullifier: fields[0], next_nullifier: fields[1], next_index: fields[2] as u32 }
+        Self { nullifier: fields[0], next_nullifier: fields[1], next_index: fields[2] }
     }
 }
 

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/protocol_contract_leaf_preimage.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/protocol_contract_leaf_preimage.nr
@@ -42,7 +42,7 @@ impl IndexedTreeLeafPreimage<Field> for ProtocolContractLeafPreimage {
         self.next_address == 0
     }
 
-    fn update_pointers(self, _next_key: Field, _next_index: u32) -> Self {
+    fn update_pointers(self, _next_key: Field, _next_index: Field) -> Self {
         assert(false, "Tried to update a static protocol contract index");
         Self::empty()
     }

--- a/noir-projects/noir-protocol-circuits/crates/types/src/data/public_data_tree_leaf_preimage.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/data/public_data_tree_leaf_preimage.nr
@@ -8,7 +8,7 @@ pub struct PublicDataTreeLeafPreimage {
     pub slot: Field,
     pub value: Field,
     pub next_slot: Field,
-    pub next_index: u32,
+    pub next_index: Field,
 }
 
 impl Empty for PublicDataTreeLeafPreimage {
@@ -60,7 +60,7 @@ impl IndexedTreeLeafPreimage<PublicDataTreeLeaf> for PublicDataTreeLeafPreimage 
         (self.next_slot == 0) & (self.next_index == 0)
     }
 
-    fn update_pointers(self, next_slot: Field, next_index: u32) -> Self {
+    fn update_pointers(self, next_slot: Field, next_index: Field) -> Self {
         Self { slot: self.slot, value: self.value, next_slot, next_index }
     }
 

--- a/noir-projects/noir-protocol-circuits/crates/types/src/delayed_public_mutable/with_hash.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/delayed_public_mutable/with_hash.nr
@@ -116,16 +116,16 @@ mod tests {
         let contract_address = AztecAddress::from_field(42);
 
         let public_data_prefill = 2;
+        let leaf_index = (public_data_prefill - 1) as Field;
 
         let public_data_tree = empty_public_data_tree::<4, 2>(public_data_prefill);
         let mut historical_header = BlockHeader::empty();
         historical_header.state.partial.public_data_tree.root = public_data_tree.get_root();
-        historical_header.state.partial.public_data_tree.next_available_leaf_index =
-            public_data_prefill;
+        historical_header.state.partial.public_data_tree.next_available_leaf_index = leaf_index + 1;
 
         let witness = MembershipWitness {
-            leaf_index: (public_data_prefill - 1) as Field,
-            sibling_path: public_data_tree.get_sibling_path(public_data_prefill - 1),
+            leaf_index,
+            sibling_path: public_data_tree.get_sibling_path(leaf_index),
         };
 
         let leaf_preimage = PublicDataTreeLeafPreimage {
@@ -170,15 +170,17 @@ mod tests {
         );
 
         let public_data_prefill = 2;
+        let last_leaf_index = (public_data_prefill - 1) as Field;
+        let new_leaf_index = last_leaf_index + 1;
 
         let mut public_data_tree = empty_public_data_tree::<4, 2>(public_data_prefill);
         public_data_tree.update_leaf(
-            public_data_prefill - 1,
+            last_leaf_index,
             PublicDataTreeLeafPreimage {
                 slot: (public_data_prefill - 1) as Field,
                 value: 0,
                 next_slot: hash_leaf_slot,
-                next_index: public_data_prefill,
+                next_index: last_leaf_index + 1,
             }
                 .hash(),
         );
@@ -189,16 +191,16 @@ mod tests {
             next_slot: 0,
             next_index: 0,
         };
-        public_data_tree.update_leaf(public_data_prefill, leaf_preimage.hash());
+        public_data_tree.update_leaf(new_leaf_index, leaf_preimage.hash());
 
         let mut historical_header = BlockHeader::empty();
         historical_header.state.partial.public_data_tree.root = public_data_tree.get_root();
         historical_header.state.partial.public_data_tree.next_available_leaf_index =
-            public_data_prefill + 1;
+            new_leaf_index + 1;
 
         let witness = MembershipWitness {
-            leaf_index: public_data_prefill as Field,
-            sibling_path: public_data_tree.get_sibling_path(public_data_prefill),
+            leaf_index: new_leaf_index,
+            sibling_path: public_data_tree.get_sibling_path(new_leaf_index),
         };
 
         validate_with_hash_hints(
@@ -238,7 +240,7 @@ mod tests {
         let mut historical_header = BlockHeader::empty();
         historical_header.state.partial.public_data_tree.root = public_data_tree.get_root();
         historical_header.state.partial.public_data_tree.next_available_leaf_index =
-            public_data_prefill;
+            public_data_prefill as Field;
 
         let witness =
             MembershipWitness { leaf_index: 0, sibling_path: public_data_tree.get_sibling_path(0) };
@@ -269,16 +271,16 @@ mod tests {
         let contract_address = AztecAddress::from_field(42);
 
         let public_data_prefill = 2;
+        let leaf_index = (public_data_prefill - 1) as Field;
 
         let public_data_tree = empty_public_data_tree::<4, 2>(public_data_prefill);
         let mut historical_header = BlockHeader::empty();
         historical_header.state.partial.public_data_tree.root = public_data_tree.get_root();
-        historical_header.state.partial.public_data_tree.next_available_leaf_index =
-            public_data_prefill;
+        historical_header.state.partial.public_data_tree.next_available_leaf_index = leaf_index + 1;
 
         let witness = MembershipWitness {
-            leaf_index: (public_data_prefill - 1) as Field,
-            sibling_path: public_data_tree.get_sibling_path(public_data_prefill - 1),
+            leaf_index,
+            sibling_path: public_data_tree.get_sibling_path(leaf_index),
         };
 
         let leaf_preimage = PublicDataTreeLeafPreimage {
@@ -329,15 +331,17 @@ mod tests {
         let hashed_value = 9000; // Incorrect hash
 
         let public_data_prefill = 2;
+        let last_leaf_index = (public_data_prefill - 1) as Field;
+        let new_leaf_index = last_leaf_index + 1;
 
         let mut public_data_tree = empty_public_data_tree::<4, 2>(public_data_prefill);
         public_data_tree.update_leaf(
-            public_data_prefill - 1,
+            last_leaf_index,
             PublicDataTreeLeafPreimage {
                 slot: (public_data_prefill - 1) as Field,
                 value: 0,
                 next_slot: hash_leaf_slot,
-                next_index: public_data_prefill,
+                next_index: last_leaf_index + 1,
             }
                 .hash(),
         );
@@ -348,16 +352,16 @@ mod tests {
             next_slot: 0,
             next_index: 0,
         };
-        public_data_tree.update_leaf(public_data_prefill, leaf_preimage.hash());
+        public_data_tree.update_leaf(new_leaf_index, leaf_preimage.hash());
 
         let mut historical_header = BlockHeader::empty();
         historical_header.state.partial.public_data_tree.root = public_data_tree.get_root();
         historical_header.state.partial.public_data_tree.next_available_leaf_index =
-            public_data_prefill + 1;
+            new_leaf_index + 1;
 
         let witness = MembershipWitness {
-            leaf_index: public_data_prefill as Field,
-            sibling_path: public_data_tree.get_sibling_path(public_data_prefill),
+            leaf_index: new_leaf_index,
+            sibling_path: public_data_tree.get_sibling_path(new_leaf_index),
         };
 
         validate_with_hash_hints(

--- a/noir-projects/noir-protocol-circuits/crates/types/src/merkle_tree/append_only_tree.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/merkle_tree/append_only_tree.nr
@@ -1,7 +1,7 @@
 use crate::{
     abis::append_only_tree_snapshot::AppendOnlyTreeSnapshot,
     merkle_tree::{
-        membership::assert_check_membership,
+        membership::check_membership,
         root::{calculate_empty_tree_root, root_from_sibling_path},
     },
 };
@@ -19,18 +19,29 @@ pub fn insert_subtree_root_to_snapshot<let TreeHeight: u32, let SubtreeHeight: u
     sibling_path: [Field; TreeHeight - SubtreeHeight],
     subtree_root_to_insert: Field,
 ) -> AppendOnlyTreeSnapshot {
+    // Sanity check: ensure the tree height is not greater than 64, since we later cast the leaf index to u64.
+    // If this function is called with a tree of height greater than 64, the subtree root will be inserted at the wrong
+    // index once the tree grows beyond 2^64 leaves.
+    assert(
+        TreeHeight <= 64,
+        "`insert_subtree_root_to_snapshot` does not support trees with height greater than 64",
+    );
+
     // Find the index of the subtree root at the depth of the insertion.
     // If index of leaf is x, index of its parent is x/2 (or x >> 1).
     let subtree_root_index_at_depth =
-        (snapshot.next_available_leaf_index >> SubtreeHeight) as Field;
+        (snapshot.next_available_leaf_index as u64 >> SubtreeHeight as u64) as Field;
 
     // Check that there is an empty subtree at the insertion location against the current root.
     let empty_subtree_root = calculate_empty_tree_root(SubtreeHeight);
-    assert_check_membership(
-        empty_subtree_root,
-        subtree_root_index_at_depth,
-        sibling_path,
-        snapshot.root,
+    assert(
+        check_membership(
+            empty_subtree_root,
+            subtree_root_index_at_depth,
+            sibling_path,
+            snapshot.root,
+        ),
+        "Membership check failed: empty subtree root not found at insertion index",
     );
 
     // Compute the new root by inserting the subtree root at `subtree_root_index_at_depth`.
@@ -42,7 +53,191 @@ pub fn insert_subtree_root_to_snapshot<let TreeHeight: u32, let SubtreeHeight: u
 
     // Advance the next available leaf index by the number of leaves in the subtree.
     let num_subtree_leaves = 1 << SubtreeHeight;
-    let next_available_leaf_index = snapshot.next_available_leaf_index + num_subtree_leaves;
+    let next_available_leaf_index =
+        snapshot.next_available_leaf_index + num_subtree_leaves as Field;
 
     AppendOnlyTreeSnapshot { root: new_root, next_available_leaf_index }
+}
+
+mod tests {
+    use crate::{
+        abis::append_only_tree_snapshot::AppendOnlyTreeSnapshot,
+        merkle_tree::merkle_tree::MerkleTree,
+        tests::{
+            merkle_tree_utils::single_subtree_merkle_tree::{
+                compute_zero_hashes, SingleSubtreeMerkleTree,
+            },
+            utils::pad_end,
+        },
+        utils::arrays::subarray,
+    };
+    use super::insert_subtree_root_to_snapshot;
+
+    struct TestBuilder<let SubtreeWidth: u32, let SubtreeHeight: u32, let TreeHeight: u32> {
+        tree: SingleSubtreeMerkleTree<SubtreeWidth, SubtreeHeight, TreeHeight>,
+        pre_existing_leaves: [Field; SubtreeWidth],
+        snapshot: AppendOnlyTreeSnapshot,
+        sibling_path: [Field; TreeHeight - SubtreeHeight],
+        new_leaves: [Field; SubtreeWidth],
+        subtree_root_to_insert: Field,
+    }
+
+    impl TestBuilder<4, 2, 5> {
+        pub fn default() -> TestBuilder<4, 2, 5> {
+            Self::default_at_index(0)
+        }
+
+        pub fn default_at_index(index: Field) -> TestBuilder<4, 2, 5> {
+            let mut builder = Self::new([11, 22, 33, 44], index);
+            builder.build_subtree([88, 77, 66, 55]);
+            builder
+        }
+    }
+
+    impl<let SubtreeWidth: u32, let SubtreeHeight: u32, let TreeHeight: u32> TestBuilder<SubtreeWidth, SubtreeHeight, TreeHeight> {
+        pub fn new<let N: u32>(
+            pre_existing_leaves: [Field; N],
+            start_index: Field,
+        ) -> TestBuilder<SubtreeWidth, SubtreeHeight, TreeHeight> {
+            let tree = SingleSubtreeMerkleTree::<SubtreeWidth, SubtreeHeight, TreeHeight>::new_at_index(
+                pad_end(pre_existing_leaves),
+                start_index,
+            );
+            let mut builder = Self {
+                tree,
+                pre_existing_leaves: pad_end(pre_existing_leaves),
+                snapshot: AppendOnlyTreeSnapshot {
+                    root: tree.get_root(),
+                    next_available_leaf_index: tree.get_next_available_index(),
+                },
+                sibling_path: pad_end([]),
+                new_leaves: pad_end([]),
+                subtree_root_to_insert: 0,
+            };
+            let insertion_index = start_index + SubtreeWidth as Field;
+            builder.sibling_path = builder.get_top_tree_sibling_path(insertion_index);
+            builder
+        }
+
+        pub fn get_top_tree_sibling_path(
+            self,
+            index: Field,
+        ) -> [Field; TreeHeight - SubtreeHeight] {
+            let full_sibling_path = self.tree.get_sibling_path(index);
+            subarray(full_sibling_path, SubtreeHeight)
+        }
+
+        pub fn build_subtree(&mut self, new_leaves: [Field; SubtreeWidth]) {
+            let tree = MerkleTree::new(new_leaves);
+            self.new_leaves = new_leaves;
+            self.subtree_root_to_insert = tree.get_root();
+        }
+
+        pub fn execute(self) -> AppendOnlyTreeSnapshot {
+            insert_subtree_root_to_snapshot::<TreeHeight, SubtreeHeight>(
+                self.snapshot,
+                self.sibling_path,
+                self.subtree_root_to_insert,
+            )
+        }
+    }
+
+    #[test]
+    fn insert_at_index_0() {
+        let builder = TestBuilder::default();
+        let pre_existing_tree = MerkleTree::new(builder.pre_existing_leaves);
+        let subtree_root_to_insert = pre_existing_tree.get_root();
+
+        let zero_hashes = compute_zero_hashes::<5>();
+        let empty_root = zero_hashes[4];
+        let sibling_path_0 = subarray(zero_hashes, 1);
+        let empty_snapshot =
+            AppendOnlyTreeSnapshot { root: empty_root, next_available_leaf_index: 0 };
+
+        let snapshot = insert_subtree_root_to_snapshot::<5, 2>(
+            empty_snapshot,
+            sibling_path_0,
+            subtree_root_to_insert,
+        );
+        assert_eq(snapshot, builder.snapshot);
+    }
+
+    #[test]
+    fn insert_at_middle() {
+        let builder = TestBuilder::default();
+        let snapshot = builder.execute();
+
+        let all_leaves = builder.pre_existing_leaves.concat(builder.new_leaves);
+        let expected_tree = SingleSubtreeMerkleTree::<8, 3, 5>::new(all_leaves);
+        assert_eq(snapshot.root, expected_tree.get_root());
+        assert_eq(snapshot.next_available_leaf_index, 8);
+    }
+
+    #[test(should_fail_with = "Membership check failed: empty subtree root not found at insertion index")]
+    fn wrong_sibling_path() {
+        let mut builder = TestBuilder::default();
+
+        builder.sibling_path[0] += 1;
+
+        let _ = builder.execute();
+    }
+
+    #[test(should_fail_with = "Membership check failed: empty subtree root not found at insertion index")]
+    fn insert_at_pre_existing_index() {
+        let mut builder = TestBuilder::default();
+
+        builder.snapshot.next_available_leaf_index = 2;
+        builder.sibling_path = builder.get_top_tree_sibling_path(2);
+
+        let _ = builder.execute();
+    }
+
+    #[test]
+    fn insert_to_fill_tree() {
+        let max_tree_size = (1 << 5) as Field;
+        let builder = TestBuilder::default_at_index(max_tree_size - 8);
+        let snapshot = builder.execute();
+
+        let all_leaves = builder.pre_existing_leaves.concat(builder.new_leaves);
+        let expected_tree =
+            SingleSubtreeMerkleTree::<8, 3, 5>::new_at_index(all_leaves, max_tree_size - 8);
+        assert_eq(snapshot.root, expected_tree.get_root());
+        assert_eq(snapshot.next_available_leaf_index, max_tree_size);
+    }
+
+    #[test(should_fail_with = "Field failed to decompose into specified 3 limbs")]
+    fn insert_to_overfill_tree() {
+        let max_tree_size = (1 << 5) as Field;
+        let builder = TestBuilder::default_at_index(max_tree_size - 4);
+        let _ = builder.execute();
+    }
+
+    #[test]
+    fn with_tree_of_height_64() {
+        let zero_hashes = compute_zero_hashes::<64>();
+        let empty_root = zero_hashes[63];
+        let sibling_path_0 = subarray(zero_hashes, 0);
+        let empty_snapshot =
+            AppendOnlyTreeSnapshot { root: empty_root, next_available_leaf_index: 0 };
+
+        // Insert a subtree of height 1 with 2 leaves
+        let subtree_root = MerkleTree::new([11, 22]).get_root();
+        let snapshot =
+            insert_subtree_root_to_snapshot::<64, 1>(empty_snapshot, sibling_path_0, subtree_root);
+
+        let expected_tree = SingleSubtreeMerkleTree::<2, 1, 64>::new([11, 22]);
+        assert_eq(snapshot.root, expected_tree.get_root());
+        assert_eq(snapshot.next_available_leaf_index, 2);
+    }
+
+    #[test(should_fail_with = "`insert_subtree_root_to_snapshot` does not support trees with height greater than 64")]
+    fn with_tree_of_height_65() {
+        let zero_hashes = compute_zero_hashes::<65>();
+        let empty_root = zero_hashes[64];
+        let sibling_path_0 = subarray(zero_hashes, 0);
+        let empty_snapshot =
+            AppendOnlyTreeSnapshot { root: empty_root, next_available_leaf_index: 0 };
+
+        let _ = insert_subtree_root_to_snapshot::<65, 1>(empty_snapshot, sibling_path_0, 0);
+    }
 }

--- a/noir-projects/noir-protocol-circuits/crates/types/src/merkle_tree/indexed_tree.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/merkle_tree/indexed_tree.nr
@@ -78,7 +78,7 @@ where
             leaves_to_append[value_index] = Leaf::build_insertion_leaf(value, low_leaf_preimage);
 
             // Point the low leaf to the new leaf and update it in the tree.
-            let new_leaf_insertion_index = start_insertion_index + value_index;
+            let new_leaf_insertion_index = start_insertion_index + value_index as Field;
             let updated_low_leaf =
                 low_leaf_preimage.update_pointers(value_key, new_leaf_insertion_index);
             current_tree_root = root_from_sibling_path(

--- a/noir-projects/noir-protocol-circuits/crates/types/src/merkle_tree/leaf_preimage.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/merkle_tree/leaf_preimage.nr
@@ -10,7 +10,7 @@ pub trait IndexedTreeLeafPreimage<Value>: Empty + LeafPreimage {
 
     fn points_to_infinity(self) -> bool;
 
-    fn update_pointers(self, next_key: Field, next_index: u32) -> Self;
+    fn update_pointers(self, next_key: Field, next_index: Field) -> Self;
 
     fn update_value(self, value: Value) -> Self;
 

--- a/noir-projects/noir-protocol-circuits/crates/types/src/merkle_tree/membership.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/merkle_tree/membership.nr
@@ -116,7 +116,7 @@ mod tests {
         check_membership(
             leaf,
             leaf_index,
-            tree.get_sibling_path(leaf_index as u32),
+            tree.get_sibling_path(leaf_index),
             tree_root,
         )
     }
@@ -128,16 +128,16 @@ mod tests {
         assert_check_membership(
             leaf,
             leaf_index,
-            tree.get_sibling_path(leaf_index as u32),
+            tree.get_sibling_path(leaf_index),
             tree_root,
         );
     }
 
-    fn assert_check_non_membership_at_index(low_leaf_index: u32, key: Field) {
+    fn assert_check_non_membership_at_index(low_leaf_index: Field, key: Field) {
         let tree = build_tree();
         let tree_root = tree.get_root();
-        let leaf_preimage = if low_leaf_index as u32 < leaf_preimages.len() {
-            leaf_preimages[low_leaf_index]
+        let leaf_preimage = if low_leaf_index.lt(leaf_preimages.len() as Field) {
+            leaf_preimages[low_leaf_index as u32]
         } else {
             TestLeafPreimage { value: 0, next_value: 0 }
         };
@@ -146,7 +146,7 @@ mod tests {
             key,
             leaf_preimage,
             MembershipWitness {
-                leaf_index: low_leaf_index as Field,
+                leaf_index: low_leaf_index,
                 sibling_path: tree.get_sibling_path(low_leaf_index),
             },
             tree_root,
@@ -155,13 +155,13 @@ mod tests {
 
     fn conditionally_assert_check_membership_at_index(
         exists: bool,
-        low_leaf_index: u32,
+        low_leaf_index: Field,
         key: Field,
     ) {
         let tree = build_tree();
         let tree_root = tree.get_root();
-        let leaf_preimage = if low_leaf_index as u32 < leaf_preimages.len() {
-            leaf_preimages[low_leaf_index]
+        let leaf_preimage = if low_leaf_index.lt(leaf_preimages.len() as Field) {
+            leaf_preimages[low_leaf_index as u32]
         } else {
             TestLeafPreimage { value: 0, next_value: 0 }
         };
@@ -171,7 +171,7 @@ mod tests {
             exists,
             leaf_preimage,
             MembershipWitness {
-                leaf_index: low_leaf_index as Field,
+                leaf_index: low_leaf_index,
                 sibling_path: tree.get_sibling_path(low_leaf_index),
             },
             tree_root,

--- a/noir-projects/noir-protocol-circuits/crates/types/src/merkle_tree/merkle_tree.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/merkle_tree/merkle_tree.nr
@@ -27,14 +27,6 @@ impl<let N: u32> MerkleTree<N> {
         self.nodes[N - 2]
     }
 
-    pub fn sibling_index(index: u32) -> u32 {
-        if index % 2 == 0 {
-            index + 1
-        } else {
-            index - 1
-        }
-    }
-
     pub fn get_sibling_path<let K: u32>(self, leaf_index: u32) -> [Field; K] {
         assert_eq(2.pow_32(K as Field), N as Field, "Invalid path length");
 

--- a/noir-projects/noir-protocol-circuits/crates/types/src/tests/fixture_builder.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/tests/fixture_builder.nr
@@ -483,17 +483,19 @@ impl FixtureBuilder {
     pub fn compute_update_tree_and_hints(&mut self) {
         let public_data_prefill = 2;
         let mut public_data_tree = empty_public_data_tree::<8, 3>(public_data_prefill);
+        let last_leaf_index = (public_data_prefill - 1) as Field;
+        let new_leaf_index = last_leaf_index + 1;
 
         if self.updated_class_id_value_change.is_empty()
             & self.updated_class_id_delay_change.is_empty() {
             self.anchor_block_header.state.partial.public_data_tree.root =
                 public_data_tree.get_root();
             self.anchor_block_header.state.partial.public_data_tree.next_available_leaf_index =
-                public_data_prefill;
+                public_data_prefill as Field;
 
             self.updated_class_id_witness = MembershipWitness {
-                leaf_index: (public_data_prefill - 1) as Field,
-                sibling_path: public_data_tree.get_sibling_path(public_data_prefill - 1),
+                leaf_index: last_leaf_index,
+                sibling_path: public_data_tree.get_sibling_path(last_leaf_index),
             };
             self.updated_class_id_leaf = PublicDataTreeLeafPreimage {
                 slot: (public_data_prefill - 1) as Field,
@@ -517,12 +519,12 @@ impl FixtureBuilder {
                 hash_slot,
             );
             public_data_tree.update_leaf(
-                public_data_prefill - 1,
+                last_leaf_index,
                 PublicDataTreeLeafPreimage {
                     slot: (public_data_prefill - 1) as Field,
                     value: 0,
                     next_slot: hash_leaf_slot,
-                    next_index: public_data_prefill,
+                    next_index: last_leaf_index + 1,
                 }
                     .hash(),
             );
@@ -532,14 +534,14 @@ impl FixtureBuilder {
                 next_slot: 0,
                 next_index: 0,
             };
-            public_data_tree.update_leaf(public_data_prefill, self.updated_class_id_leaf.hash());
+            public_data_tree.update_leaf(new_leaf_index, self.updated_class_id_leaf.hash());
             self.anchor_block_header.state.partial.public_data_tree.root =
                 public_data_tree.get_root();
             self.anchor_block_header.state.partial.public_data_tree.next_available_leaf_index =
-                public_data_prefill + 1;
+                new_leaf_index + 1;
             self.updated_class_id_witness = MembershipWitness {
-                leaf_index: public_data_prefill as Field,
-                sibling_path: public_data_tree.get_sibling_path(public_data_prefill),
+                leaf_index: new_leaf_index,
+                sibling_path: public_data_tree.get_sibling_path(new_leaf_index),
             };
         }
     }

--- a/noir-projects/noir-protocol-circuits/crates/types/src/tests/fixtures/public_data_tree.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/tests/fixtures/public_data_tree.nr
@@ -13,7 +13,7 @@ pub fn empty_public_data_tree<let SubtreeWidth: u32, let SubtreeHeight: u32>(
             slot: i as Field,
             value: 0,
             next_slot: (i + 1) as Field,
-            next_index: i + 1,
+            next_index: (i + 1) as Field,
         };
         leaves[i] = leaf.hash();
     }

--- a/noir-projects/noir-protocol-circuits/crates/types/src/tests/merkle_tree_utils/single_subtree_merkle_tree.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/tests/merkle_tree_utils/single_subtree_merkle_tree.nr
@@ -1,6 +1,6 @@
 use crate::{
     hash::merkle_hash,
-    merkle_tree::{calculate_empty_tree_root, merkle_tree, MerkleTree},
+    merkle_tree::{calculate_empty_tree_root, MerkleTree},
     utils::arrays::subarray,
 };
 
@@ -10,7 +10,7 @@ pub struct SingleSubtreeMerkleTree<let SubtreeWidth: u32, let SubtreeHeight: u32
     subtree_zero_hashes: [Field; SubtreeHeight],
     path_to_subtree_root: [Field; TreeHeight - SubtreeHeight],
     tree_root: Field,
-    first_leaf_index: u32,
+    first_leaf_index: Field,
 }
 
 impl<let SubtreeWidth: u32, let SubtreeHeight: u32, let TreeHeight: u32> SingleSubtreeMerkleTree<SubtreeWidth, SubtreeHeight, TreeHeight> {
@@ -18,7 +18,7 @@ impl<let SubtreeWidth: u32, let SubtreeHeight: u32, let TreeHeight: u32> SingleS
         Self::new_at_index(subtree_leaves, 0)
     }
 
-    pub fn new_at_index(subtree_leaves: [Field; SubtreeWidth], first_leaf_index: u32) -> Self {
+    pub fn new_at_index(subtree_leaves: [Field; SubtreeWidth], first_leaf_index: Field) -> Self {
         Self::new_tree_roots_at_index::<0>(subtree_leaves, first_leaf_index)
     }
 
@@ -26,10 +26,10 @@ impl<let SubtreeWidth: u32, let SubtreeHeight: u32, let TreeHeight: u32> SingleS
     /// extra layers (`InsertedValueTreeHeight`) of the inserted values.
     pub fn new_tree_roots_at_index<let InsertedValueTreeHeight: u32>(
         subtree_leaves: [Field; SubtreeWidth],
-        first_leaf_index: u32,
+        first_leaf_index: Field,
     ) -> Self {
         assert_eq(
-            first_leaf_index % SubtreeWidth,
+            first_leaf_index as u64 % SubtreeWidth as u64,
             0,
             "First leaf index must be a multiple of the subtree width",
         );
@@ -41,9 +41,12 @@ impl<let SubtreeWidth: u32, let SubtreeHeight: u32, let TreeHeight: u32> SingleS
         let subtree = MerkleTree::new(subtree_leaves);
 
         let subtree_root = subtree.get_root();
-        let subtree_root_index = first_leaf_index >> SubtreeHeight;
-        let (tree_root, path_to_subtree_root) =
-            build_root_and_path_to_value(subtree_root_index, subtree_root, top_tree_zero_hashes);
+        let subtree_root_index = first_leaf_index as u64 >> SubtreeHeight as u64;
+        let (tree_root, path_to_subtree_root) = build_root_and_path_to_value(
+            subtree_root_index as Field,
+            subtree_root,
+            top_tree_zero_hashes,
+        );
 
         Self {
             subtree,
@@ -55,21 +58,21 @@ impl<let SubtreeWidth: u32, let SubtreeHeight: u32, let TreeHeight: u32> SingleS
         }
     }
 
-    pub fn get_sibling_path(self, leaf_index: u32) -> [Field; TreeHeight] {
+    pub fn get_sibling_path(self, leaf_index: Field) -> [Field; TreeHeight] {
         let subtree_sibling_path: [Field; SubtreeHeight] = if self.is_leaf_index_in_subtree(
             leaf_index,
         ) {
-            let index_in_subtree = leaf_index % SubtreeWidth;
-            self.subtree.get_sibling_path(index_in_subtree)
+            let index_in_subtree = leaf_index as u64 % SubtreeWidth as u64;
+            self.subtree.get_sibling_path(index_in_subtree as u32)
         } else {
             self.subtree_zero_hashes
         };
 
         let mut top_tree_sibling_path = [0; TreeHeight - SubtreeHeight];
-        let mut index_at_level = leaf_index >> SubtreeHeight;
-        let mut path_index_at_level = self.first_leaf_index >> SubtreeHeight;
+        let mut index_at_level = leaf_index as u64 >> SubtreeHeight as u64;
+        let mut path_index_at_level = self.first_leaf_index as u64 >> SubtreeHeight as u64;
         for level in 0..top_tree_sibling_path.len() {
-            let sibling_index = merkle_tree::sibling_index(index_at_level);
+            let sibling_index = get_sibling_index(index_at_level);
             top_tree_sibling_path[level] = if sibling_index == path_index_at_level {
                 self.path_to_subtree_root[level]
             } else {
@@ -82,14 +85,14 @@ impl<let SubtreeWidth: u32, let SubtreeHeight: u32, let TreeHeight: u32> SingleS
         subtree_sibling_path.concat(top_tree_sibling_path)
     }
 
-    pub fn update_leaf(&mut self, leaf_index: u32, value: Field) {
+    pub fn update_leaf(&mut self, leaf_index: Field, value: Field) {
         assert(self.is_leaf_index_in_subtree(leaf_index), "Cannot update leaf at given index");
 
-        let index_in_subtree = leaf_index % SubtreeWidth;
+        let index_in_subtree = (leaf_index as u64 % SubtreeWidth as u64) as u32;
         self.subtree.update_leaf::<SubtreeHeight>(index_in_subtree, value);
 
         let subtree_root = self.subtree.get_root();
-        let subtree_root_index = leaf_index >> SubtreeHeight;
+        let subtree_root_index = (leaf_index as u64 >> SubtreeHeight as u64) as Field;
         let (tree_root, path_to_subtree_root) = build_root_and_path_to_value(
             subtree_root_index,
             subtree_root,
@@ -104,16 +107,24 @@ impl<let SubtreeWidth: u32, let SubtreeHeight: u32, let TreeHeight: u32> SingleS
         self.tree_root
     }
 
-    pub fn get_next_available_index(self) -> u32 {
-        self.first_leaf_index + (1 << SubtreeHeight)
+    pub fn get_next_available_index(self) -> Field {
+        self.first_leaf_index + (1 << SubtreeHeight as u64) as Field
     }
 
-    fn is_leaf_index_in_subtree(self, leaf_index: u32) -> bool {
-        (leaf_index >= self.first_leaf_index) & (leaf_index < self.get_next_available_index())
+    fn is_leaf_index_in_subtree(self, leaf_index: Field) -> bool {
+        !leaf_index.lt(self.first_leaf_index) & leaf_index.lt(self.get_next_available_index())
     }
 }
 
-fn compute_zero_hashes<let N: u32>() -> [Field; N] {
+fn get_sibling_index(index: u64) -> u64 {
+    if index % 2 == 0 {
+        index + 1
+    } else {
+        index - 1
+    }
+}
+
+pub fn compute_zero_hashes<let N: u32>() -> [Field; N] {
     let mut hashes = [0; N];
     hashes[0] = merkle_hash(0, 0);
 
@@ -125,13 +136,13 @@ fn compute_zero_hashes<let N: u32>() -> [Field; N] {
 }
 
 fn build_root_and_path_to_value<let TreeHeight: u32>(
-    leaf_index: u32,
+    leaf_index: Field,
     value: Field,
     sibling_path: [Field; TreeHeight],
 ) -> (Field, [Field; TreeHeight]) {
     let mut path_to_value = [0; TreeHeight];
     let mut node = value;
-    let mut index_at_level = leaf_index;
+    let mut index_at_level = leaf_index as u64;
 
     for level in 0..TreeHeight {
         path_to_value[level] = node;
@@ -284,7 +295,7 @@ fn insert_tree_roots_as_subtree_leaves_insert_front() {
     let leaf_index = 5;
     let subtree_root_at_index = 5 >> 1;
     assert_eq(
-        combined_tree.get_sibling_path(subtree_root_at_index),
+        combined_tree.get_sibling_path(subtree_root_at_index as Field),
         subarray(whole_tree.get_sibling_path(leaf_index), 1),
     );
 }
@@ -308,7 +319,7 @@ fn insert_tree_roots_as_subtree_leaves_insert_middle() {
     let leaf_index = 5;
     let subtree_root_at_index = 5 >> 1;
     assert_eq(
-        combined_tree.get_sibling_path(subtree_root_at_index),
+        combined_tree.get_sibling_path(subtree_root_at_index as Field),
         subarray(whole_tree.get_sibling_path(leaf_index), 1),
     );
 }

--- a/noir-projects/noir-protocol-circuits/crates/types/src/tests/types/test_leaf_preimage.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/tests/types/test_leaf_preimage.nr
@@ -37,7 +37,7 @@ impl IndexedTreeLeafPreimage<Field> for TestLeafPreimage {
         (self.next_value == 0)
     }
 
-    fn update_pointers(self, next_value: Field, _next_index: u32) -> Self {
+    fn update_pointers(self, next_value: Field, _next_index: Field) -> Self {
         Self { value: self.value, next_value }
     }
 


### PR DESCRIPTION
The `next_available_leaf_index` in `AppendOnlyTreeSnapshot` was `u32`. The `leaf_index` for membership check is `Field`. And the trees can be up to 40 deep, so the leaf indices need to be at least `u64`.
Changing the `next_available_leaf_index` in `AppendOnlyTreeSnapshot` to `Field` to allow trees to grow fully.
Choosing Field instead of `u64` because of its cheaper `to_le_bits` operation.