### PR TITLE
refactor: minor naming fix

### DIFF
--- a/docs/docs/developers/docs/concepts/smart_contracts/functions/attributes.md
+++ b/docs/docs/developers/docs/concepts/smart_contracts/functions/attributes.md
@@ -221,12 +221,12 @@ impl NoteHash for CustomNote {
         poseidon2_hash_with_separator(inputs, GENERATOR_INDEX__NOTE_HASH)
     }
 
-    fn compute_nullifier(self, context: &mut PrivateContext, note_hash_for_nullify: Field) -> Field {
+    fn compute_nullifier(self, context: &mut PrivateContext, note_hash_for_nullification: Field) -> Field {
         let owner_npk_m_hash = get_public_keys(self.owner).npk_m.hash();
         let secret = context.request_nsk_app(owner_npk_m_hash);
         poseidon2_hash_with_separator(
             [
-            note_hash_for_nullify,
+            note_hash_for_nullification,
             secret
         ],
             GENERATOR_INDEX__NOTE_NULLIFIER as Field
@@ -237,12 +237,12 @@ impl NoteHash for CustomNote {
         // We set the note_hash_counter to 0 as the note is not transient and the concept of transient note does
         // not make sense in an unconstrained context.
         let retrieved_note = RetrievedNote { note: self, contract_address, nonce: note_nonce, note_hash_counter: 0 };
-        let note_hash_for_nullify = compute_note_hash_for_nullify(retrieved_note, storage_slot);
+        let note_hash_for_nullification = compute_note_hash_for_nullification(retrieved_note, storage_slot);
         let owner_npk_m_hash = get_public_keys(self.owner).npk_m.hash();
         let secret = get_nsk_app(owner_npk_m_hash);
         poseidon2_hash_with_separator(
             [
-            note_hash_for_nullify,
+            note_hash_for_nullification,
             secret
         ],
             GENERATOR_INDEX__NOTE_NULLIFIER as Field

--- a/docs/docs/developers/docs/guides/smart_contracts/advanced/how_to_prove_history.md
+++ b/docs/docs/developers/docs/guides/smart_contracts/advanced/how_to_prove_history.md
@@ -71,7 +71,7 @@ use dep::aztec::history::nullifier_inclusion::ProveNullifierInclusion;
 use dep::aztec::protocol_types::hash::compute_siloed_nullifier;
 
 // Compute nullifier (requires note hash)
-let nullifier = note.compute_nullifier(&mut context, note_hash_for_nullify);
+let nullifier = note.compute_nullifier(&mut context, note_hash_for_nullification);
 let siloed_nullifier = compute_siloed_nullifier(context.this_address(), nullifier);
 
 // Prove nullifier was included

--- a/docs/docs/developers/docs/guides/smart_contracts/how_to_implement_custom_notes.md
+++ b/docs/docs/developers/docs/guides/smart_contracts/how_to_implement_custom_notes.md
@@ -179,19 +179,19 @@ impl NoteHash for TransparentNote {
     fn compute_nullifier(
         self,
         _context: &mut PrivateContext,
-        note_hash_for_nullify: Field,
+        note_hash_for_nullification: Field,
     ) -> Field {
         poseidon2_hash_with_separator(
-            [note_hash_for_nullify],
+            [note_hash_for_nullification],
             GENERATOR_INDEX__NOTE_NULLIFIER as Field,
         )
     }
 
     unconstrained fn compute_nullifier_unconstrained(
         self,
-        note_hash_for_nullify: Field
+        note_hash_for_nullification: Field
     ) -> Field {
-        self.compute_nullifier(zeroed(), note_hash_for_nullify)
+        self.compute_nullifier(zeroed(), note_hash_for_nullification)
     }
 }
 ```

--- a/docs/docs/developers/migration_notes.md
+++ b/docs/docs/developers/migration_notes.md
@@ -1940,7 +1940,7 @@ let historical_header = context.header_at(some_block_number);
 
 ### NoteInterface changes
 
-`compute_note_hash_and_nullifier*` functions were renamed as `compute_nullifier*` and the `compute_nullifier` function now takes `note_hash_for_nullify` as an argument (this allowed us to reduce gate counts and the hash was typically computed before). Also `compute_note_hash_for_consumption` function was renamed as `compute_note_hash_for_nullify`.
+`compute_note_hash_and_nullifier*` functions were renamed as `compute_nullifier*` and the `compute_nullifier` function now takes `note_hash_for_nullify` as an argument (this allowed us to reduce gate counts and the hash was typically computed before). Also `compute_note_hash_for_consumption` function was renamed as `compute_note_hash_for_nullification`.
 
 ```diff
 impl NoteInterface<VALUE_NOTE_LEN, VALUE_NOTE_BYTES_LEN> for ValueNote {
@@ -1977,7 +1977,7 @@ impl NoteInterface<VALUE_NOTE_LEN, VALUE_NOTE_BYTES_LEN> for ValueNote {
 +        )
 +    }
 +    fn compute_nullifier_without_context(self) -> Field {
-+        let note_hash_for_nullify = compute_note_hash_for_nullify(self);
++        let note_hash_for_nullify = compute_note_hash_for_nullification(self);
 +        let secret = get_nsk_app(self.npk_m_hash);
 +        poseidon2_hash_with_separator([
 +            note_hash_for_nullify,

--- a/noir-projects/aztec-nr/aztec/src/history/note_inclusion.nr
+++ b/noir-projects/aztec-nr/aztec/src/history/note_inclusion.nr
@@ -4,7 +4,7 @@ use dep::protocol_types::merkle_tree::root::root_from_sibling_path;
 use crate::{
     note::{
         note_interface::NoteHash, retrieved_note::RetrievedNote,
-        utils::compute_note_hash_for_nullify,
+        utils::compute_note_hash_for_nullification,
     },
     oracle::get_membership_witness::get_note_hash_membership_witness,
 };
@@ -26,7 +26,7 @@ impl ProveNoteInclusion for BlockHeader {
     where
         Note: NoteHash,
     {
-        let note_hash = compute_note_hash_for_nullify(retrieved_note, storage_slot);
+        let note_hash = compute_note_hash_for_nullification(retrieved_note, storage_slot);
 
         // Safety: The witness is only used as a "magical value" that makes the merkle proof below pass. Hence it's safe.
         let witness = unsafe {

--- a/noir-projects/aztec-nr/aztec/src/macros/aztec.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/aztec.nr
@@ -178,7 +178,7 @@ comptime fn generate_contract_library_method_compute_note_hash_and_nullifier() -
                         // The message discovery process finds settled notes, that is, notes that were created in prior
                         // transactions and are therefore already part of the note hash tree. We therefore compute the
                         // nullification note hash by treating the note as a settled note with the provided note nonce.
-                        let note_hash_for_nullify = aztec::note::utils::compute_note_hash_for_nullify(
+                        let note_hash_for_nullification = aztec::note::utils::compute_note_hash_for_nullification(
                             aztec::note::retrieved_note::RetrievedNote{ 
                                 note, 
                                 contract_address, 
@@ -187,7 +187,7 @@ comptime fn generate_contract_library_method_compute_note_hash_and_nullifier() -
                             storage_slot,
                         );
 
-                        let inner_nullifier = $compute_nullifier_unconstrained(note, note_hash_for_nullify);
+                        let inner_nullifier = $compute_nullifier_unconstrained(note, note_hash_for_nullification);
 
                         Option::some(
                             aztec::messages::discovery::NoteHashAndNullifier {

--- a/noir-projects/aztec-nr/aztec/src/macros/notes.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/notes.nr
@@ -61,9 +61,9 @@ comptime fn generate_note_type_impl(s: TypeDefinition, note_type_id: Field) -> Q
 /// impl NoteHash for NoteStruct {
 ///     fn compute_note_hash(self, storage_slot: Field) -> Field { ... }
 ///
-///     fn compute_nullifier(self, context: &mut PrivateContext, note_hash_for_nullify: Field) -> Field { ... }
+///     fn compute_nullifier(self, context: &mut PrivateContext, note_hash_for_nullification: Field) -> Field { ... }
 ///
-///     unconstrained fn compute_nullifier_unconstrained(note_hash_for_nullify: Field) -> Field { ... }
+///     unconstrained fn compute_nullifier_unconstrained(note_hash_for_nullification: Field) -> Field { ... }
 /// }
 /// ```
 comptime fn generate_note_hash_trait_impl(s: TypeDefinition) -> Quoted {
@@ -79,7 +79,7 @@ comptime fn generate_note_hash_trait_impl(s: TypeDefinition) -> Quoted {
             fn compute_nullifier(
                 self,
                 context: &mut aztec::context::PrivateContext,
-                note_hash_for_nullify: Field,
+                note_hash_for_nullification: Field,
             ) -> Field {
                 let owner_npk_m = aztec::keys::getters::get_public_keys(self.owner).npk_m;
                 // We invoke hash as a static trait function rather than calling owner_npk_m.hash() directly
@@ -87,14 +87,14 @@ comptime fn generate_note_hash_trait_impl(s: TypeDefinition) -> Quoted {
                 let owner_npk_m_hash = aztec::protocol_types::traits::Hash::hash(owner_npk_m);
                 let secret = context.request_nsk_app(owner_npk_m_hash);
                 aztec::protocol_types::hash::poseidon2_hash_with_separator(
-                    [note_hash_for_nullify, secret],
+                    [note_hash_for_nullification, secret],
                     aztec::protocol_types::constants::GENERATOR_INDEX__NOTE_NULLIFIER as Field,
                 )
             }
 
             unconstrained fn compute_nullifier_unconstrained(
                 self,
-                note_hash_for_nullify: Field,
+                note_hash_for_nullification: Field,
             ) -> Field {
                 let owner_npk_m = aztec::keys::getters::get_public_keys(self.owner).npk_m;
                 // We invoke hash as a static trait function rather than calling owner_npk_m.hash() directly
@@ -102,7 +102,7 @@ comptime fn generate_note_hash_trait_impl(s: TypeDefinition) -> Quoted {
                 let owner_npk_m_hash = aztec::protocol_types::traits::Hash::hash(owner_npk_m);
                 let secret = aztec::keys::getters::get_nsk_app(owner_npk_m_hash);
                 aztec::protocol_types::hash::poseidon2_hash_with_separator(
-                    [note_hash_for_nullify, secret],
+                    [note_hash_for_nullification, secret],
                     aztec::protocol_types::constants::GENERATOR_INDEX__NOTE_NULLIFIER as Field,
                 )
             }

--- a/noir-projects/aztec-nr/aztec/src/messages/discovery/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/discovery/mod.nr
@@ -42,12 +42,12 @@ pub struct NoteHashAndNullifier {
 ///         let note = MyNoteType::unpack(aztec::utils::array::subarray(packed_note.storage(), 0));
 ///
 ///         let note_hash = note.compute_note_hash(storage_slot);
-///         let note_hash_for_nullify = aztec::note::utils::compute_note_hash_for_nullify(
+///         let note_hash_for_nullification = aztec::note::utils::compute_note_hash_for_nullification(
 ///             RetrievedNote{ note, contract_address, metadata: SettledNoteMetadata::new(note_nonce).into() },
 ///             storage_slot
 ///         );
 ///
-///         let inner_nullifier = note.compute_nullifier_unconstrained(note_hash_for_nullify);
+///         let inner_nullifier = note.compute_nullifier_unconstrained(note_hash_for_nullification);
 ///
 ///         Option::some(
 ///             aztec::messages::discovery::NoteHashAndNullifier {

--- a/noir-projects/aztec-nr/aztec/src/messages/discovery/nonce_discovery.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/discovery/nonce_discovery.nr
@@ -97,7 +97,7 @@ mod test {
             note_interface::{NoteHash, NoteType},
             note_metadata::SettledNoteMetadata,
             retrieved_note::RetrievedNote,
-            utils::compute_note_hash_for_nullify,
+            utils::compute_note_hash_for_nullification,
         },
         oracle::random::random,
         test::mocks::mock_note::MockNote,
@@ -125,7 +125,7 @@ mod test {
             let note = MockNote::unpack(array::subarray(packed_note.storage(), 0));
             let note_hash = note.compute_note_hash(storage_slot);
 
-            let note_hash_for_nullify = compute_note_hash_for_nullify(
+            let note_hash_for_nullification = compute_note_hash_for_nullification(
                 RetrievedNote {
                     note,
                     contract_address,
@@ -134,7 +134,7 @@ mod test {
                 storage_slot,
             );
 
-            let inner_nullifier = note.compute_nullifier_unconstrained(note_hash_for_nullify);
+            let inner_nullifier = note.compute_nullifier_unconstrained(note_hash_for_nullification);
 
             Option::some(NoteHashAndNullifier { note_hash, inner_nullifier })
         } else {
@@ -206,10 +206,9 @@ mod test {
             note_nonce,
             compute_siloed_note_hash(CONTRACT_ADDRESS, note_hash),
         );
-        let inner_nullifier = note.compute_nullifier_unconstrained(compute_note_hash_for_nullify(
-            retrieved_note,
-            STORAGE_SLOT,
-        ));
+        let inner_nullifier = note.compute_nullifier_unconstrained(
+            compute_note_hash_for_nullification(retrieved_note, STORAGE_SLOT),
+        );
 
         NoteAndData { note, note_nonce, note_hash, unique_note_hash, inner_nullifier }
     }

--- a/noir-projects/aztec-nr/aztec/src/note/lifecycle.nr
+++ b/noir-projects/aztec-nr/aztec/src/note/lifecycle.nr
@@ -3,7 +3,9 @@ use crate::note::{
     note_emission::NoteEmission,
     note_interface::{NoteHash, NoteType},
     retrieved_note::RetrievedNote,
-    utils::{compute_note_hash_for_nullify_from_read_request, compute_note_hash_for_read_request},
+    utils::{
+        compute_note_hash_for_nullification_from_read_request, compute_note_hash_for_read_request,
+    },
 };
 use crate::oracle::notes::notify_created_note;
 use protocol_types::traits::Packable;
@@ -57,9 +59,11 @@ pub fn destroy_note_unsafe<Note>(
 where
     Note: NoteHash,
 {
-    let note_hash_for_nullify =
-        compute_note_hash_for_nullify_from_read_request(retrieved_note, note_hash_for_read_request);
-    let nullifier = retrieved_note.note.compute_nullifier(context, note_hash_for_nullify);
+    let note_hash_for_nullification = compute_note_hash_for_nullification_from_read_request(
+        retrieved_note,
+        note_hash_for_read_request,
+    );
+    let nullifier = retrieved_note.note.compute_nullifier(context, note_hash_for_nullification);
 
     let note_hash = if retrieved_note.metadata.is_settled() {
         // Counter is zero, so we're nullifying a settled note and we don't populate the note_hash with real value.
@@ -70,7 +74,7 @@ where
         // hash with real value to inform the kernel which note we're nullifying so that it can either squash both
         // the note and the nullifier if it's an inner note hash, or check that the it matches a pending note if it's
         // a siloed note hash.
-        note_hash_for_nullify
+        note_hash_for_nullification
     };
 
     context.push_nullifier_for_note_hash(nullifier, note_hash)

--- a/noir-projects/aztec-nr/aztec/src/note/note_interface.nr
+++ b/noir-projects/aztec-nr/aztec/src/note/note_interface.nr
@@ -28,12 +28,19 @@ pub trait NoteHash {
     /// This function receives the context since nullifier computation typically involves proving nullifying keys, and
     /// we require the kernel's assistance to do this in order to prevent having to reveal private keys to application
     /// circuits.
-    fn compute_nullifier(self, context: &mut PrivateContext, note_hash_for_nullify: Field) -> Field;
+    fn compute_nullifier(
+        self,
+        context: &mut PrivateContext,
+        note_hash_for_nullification: Field,
+    ) -> Field;
 
     /// Like `compute_nullifier`, except this variant is unconstrained: there are no guarantees on the returned value
     /// being correct. Because of that it doesn't need to take a context (since it won't perform any kernel key
     /// validation requests).
-    unconstrained fn compute_nullifier_unconstrained(self, note_hash_for_nullify: Field) -> Field;
+    unconstrained fn compute_nullifier_unconstrained(
+        self,
+        note_hash_for_nullification: Field,
+    ) -> Field;
 }
 // docs:end:note_interfaces
 

--- a/noir-projects/aztec-nr/aztec/src/note/utils.nr
+++ b/noir-projects/aztec-nr/aztec/src/note/utils.nr
@@ -35,23 +35,23 @@ where
 
 /// Returns the note hash that must be used to compute a note's nullifier when calling `NoteHash::compute_nullifier` or
 /// `NoteHash::compute_nullifier_unconstrained`.
-pub fn compute_note_hash_for_nullify<Note>(
+pub fn compute_note_hash_for_nullification<Note>(
     retrieved_note: RetrievedNote<Note>,
     storage_slot: Field,
 ) -> Field
 where
     Note: NoteHash,
 {
-    compute_note_hash_for_nullify_from_read_request(
+    compute_note_hash_for_nullification_from_read_request(
         retrieved_note,
         compute_note_hash_for_read_request(retrieved_note, storage_slot),
     )
 }
 
-/// Same as `compute_note_hash_for_nullify`, except it takes the note hash used in a read request (i.e. what
+/// Same as `compute_note_hash_for_nullification`, except it takes the note hash used in a read request (i.e. what
 /// `compute_note_hash_for_read_request` would return). This is useful in scenarios where that hash has already been
 /// computed to reduce constraints by reusing this value.
-pub fn compute_note_hash_for_nullify_from_read_request<Note>(
+pub fn compute_note_hash_for_nullification_from_read_request<Note>(
     retrieved_note: RetrievedNote<Note>,
     note_hash_for_read_request: Field,
 ) -> Field {
@@ -83,8 +83,10 @@ pub fn compute_siloed_note_nullifier<Note>(
 where
     Note: NoteHash,
 {
-    let note_hash_for_nullify = compute_note_hash_for_nullify(retrieved_note, storage_slot);
-    let inner_nullifier = retrieved_note.note.compute_nullifier(context, note_hash_for_nullify);
+    let note_hash_for_nullification =
+        compute_note_hash_for_nullification(retrieved_note, storage_slot);
+    let inner_nullifier =
+        retrieved_note.note.compute_nullifier(context, note_hash_for_nullification);
 
     compute_siloed_nullifier(retrieved_note.contract_address, inner_nullifier)
 }

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
@@ -24,7 +24,7 @@ use crate::{
         note_interface::{NoteHash, NoteType},
         note_metadata::SettledNoteMetadata,
         retrieved_note::RetrievedNote,
-        utils::compute_note_hash_for_nullify,
+        utils::compute_note_hash_for_nullification,
     },
     oracle::version::assert_compatible_oracle_version,
     test::helpers::{txe_oracles, utils::ContractDeployment},
@@ -738,7 +738,7 @@ impl TestEnvironment {
             let note = Note::unpack(subarray(packed_note.storage(), 0));
 
             let note_hash = note.compute_note_hash(storage_slot);
-            let note_hash_for_nullify = compute_note_hash_for_nullify(
+            let note_hash_for_nullification = compute_note_hash_for_nullification(
                 RetrievedNote {
                     note,
                     contract_address,
@@ -747,7 +747,7 @@ impl TestEnvironment {
                 storage_slot,
             );
 
-            let inner_nullifier = note.compute_nullifier_unconstrained(note_hash_for_nullify);
+            let inner_nullifier = note.compute_nullifier_unconstrained(note_hash_for_nullification);
 
             Option::some(NoteHashAndNullifier { note_hash, inner_nullifier })
         };

--- a/noir-projects/aztec-nr/aztec/src/test/mocks/mock_note.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/mocks/mock_note.nr
@@ -35,21 +35,24 @@ impl NoteHash for MockNote {
     fn compute_nullifier(
         _self: Self,
         _context: &mut PrivateContext,
-        note_hash_for_nullify: Field,
+        note_hash_for_nullification: Field,
     ) -> Field {
         // We don't use any kind of secret here since this is only a mock note and having it here would make tests
         // more cumbersome
         poseidon2_hash_with_separator(
-            [note_hash_for_nullify],
+            [note_hash_for_nullification],
             GENERATOR_INDEX__NOTE_NULLIFIER as Field,
         )
     }
 
-    unconstrained fn compute_nullifier_unconstrained(self, note_hash_for_nullify: Field) -> Field {
+    unconstrained fn compute_nullifier_unconstrained(
+        self,
+        note_hash_for_nullification: Field,
+    ) -> Field {
         // We don't use any kind of secret here since this is only a mock note and having it here would make tests
         // more cumbersome
         poseidon2_hash_with_separator(
-            [note_hash_for_nullify],
+            [note_hash_for_nullification],
             GENERATOR_INDEX__NOTE_NULLIFIER as Field,
         )
     }

--- a/noir-projects/aztec-nr/uint-note/src/uint_note.nr
+++ b/noir-projects/aztec-nr/uint-note/src/uint_note.nr
@@ -68,23 +68,26 @@ impl NoteHash for UintNote {
     fn compute_nullifier(
         self,
         context: &mut PrivateContext,
-        note_hash_for_nullify: Field,
+        note_hash_for_nullification: Field,
     ) -> Field {
         let owner_npk_m = get_public_keys(self.owner).npk_m;
         let owner_npk_m_hash = owner_npk_m.hash();
         let secret = context.request_nsk_app(owner_npk_m_hash);
         poseidon2_hash_with_separator(
-            [note_hash_for_nullify, secret],
+            [note_hash_for_nullification, secret],
             GENERATOR_INDEX__NOTE_NULLIFIER,
         )
     }
 
-    unconstrained fn compute_nullifier_unconstrained(self, note_hash_for_nullify: Field) -> Field {
+    unconstrained fn compute_nullifier_unconstrained(
+        self,
+        note_hash_for_nullification: Field,
+    ) -> Field {
         let owner_npk_m = get_public_keys(self.owner).npk_m;
         let owner_npk_m_hash = owner_npk_m.hash();
         let secret = get_nsk_app(owner_npk_m_hash);
         poseidon2_hash_with_separator(
-            [note_hash_for_nullify, secret],
+            [note_hash_for_nullification, secret],
             GENERATOR_INDEX__NOTE_NULLIFIER,
         )
     }

--- a/noir-projects/noir-contracts/contracts/app/claim_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/claim_contract/src/main.nr
@@ -7,7 +7,7 @@ pub contract Claim {
         macros::{functions::{initializer, private, public}, storage::storage},
         note::{
             note_interface::NoteHash, retrieved_note::RetrievedNote,
-            utils::compute_note_hash_for_nullify,
+            utils::compute_note_hash_for_nullification,
         },
         protocol_types::address::AztecAddress,
         state_vars::PublicImmutable,
@@ -58,11 +58,11 @@ pub contract Claim {
         // The nullifier is unique to the note and THIS contract because the protocol siloes all nullifiers with
         // the address of a contract it was emitted from.
         // TODO(#7775): manually computing the hash and passing it to compute_nullifier func is not great as note could
-        // handle it on its own or we could make prove_note_inclusion return note_hash_for_nullify.
-        let note_hash_for_nullify =
-            compute_note_hash_for_nullify(proof_retrieved_note, note_storage_slot);
+        // handle it on its own or we could make prove_note_inclusion return note_hash_for_nullification.
+        let note_hash_for_nullification =
+            compute_note_hash_for_nullification(proof_retrieved_note, note_storage_slot);
         let nullifier =
-            proof_retrieved_note.note.compute_nullifier(&mut context, note_hash_for_nullify);
+            proof_retrieved_note.note.compute_nullifier(&mut context, note_hash_for_nullification);
         context.push_nullifier(nullifier);
 
         // 4) Finally we mint the reward token to the sender of the transaction

--- a/noir-projects/noir-contracts/contracts/app/nft_contract/src/types/nft_note.nr
+++ b/noir-projects/noir-contracts/contracts/app/nft_contract/src/types/nft_note.nr
@@ -68,23 +68,26 @@ impl NoteHash for NFTNote {
     fn compute_nullifier(
         self,
         context: &mut PrivateContext,
-        note_hash_for_nullify: Field,
+        note_hash_for_nullification: Field,
     ) -> Field {
         let owner_npk_m = get_public_keys(self.owner).npk_m;
         let owner_npk_m_hash = owner_npk_m.hash();
         let secret = context.request_nsk_app(owner_npk_m_hash);
         poseidon2_hash_with_separator(
-            [note_hash_for_nullify, secret],
+            [note_hash_for_nullification, secret],
             GENERATOR_INDEX__NOTE_NULLIFIER,
         )
     }
 
-    unconstrained fn compute_nullifier_unconstrained(self, note_hash_for_nullify: Field) -> Field {
+    unconstrained fn compute_nullifier_unconstrained(
+        self,
+        note_hash_for_nullification: Field,
+    ) -> Field {
         let owner_npk_m = get_public_keys(self.owner).npk_m;
         let owner_npk_m_hash = owner_npk_m.hash();
         let secret = get_nsk_app(owner_npk_m_hash);
         poseidon2_hash_with_separator(
-            [note_hash_for_nullify, secret],
+            [note_hash_for_nullification, secret],
             GENERATOR_INDEX__NOTE_NULLIFIER,
         )
     }

--- a/noir-projects/noir-contracts/contracts/app/token_blacklist_contract/src/types/transparent_note.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_blacklist_contract/src/types/transparent_note.nr
@@ -39,17 +39,20 @@ impl NoteHash for TransparentNote {
     fn compute_nullifier(
         self,
         _context: &mut PrivateContext,
-        note_hash_for_nullify: Field,
+        note_hash_for_nullification: Field,
     ) -> Field {
         poseidon2_hash_with_separator(
-            [note_hash_for_nullify],
+            [note_hash_for_nullification],
             GENERATOR_INDEX__NOTE_NULLIFIER as Field,
         )
     }
 
-    unconstrained fn compute_nullifier_unconstrained(self, note_hash_for_nullify: Field) -> Field {
+    unconstrained fn compute_nullifier_unconstrained(
+        self,
+        note_hash_for_nullification: Field,
+    ) -> Field {
         // compute_nullifier ignores context so we can reuse it here
-        self.compute_nullifier(zeroed(), note_hash_for_nullify)
+        self.compute_nullifier(zeroed(), note_hash_for_nullification)
     }
 }
 // docs:end:transparent_note_impl

--- a/noir-projects/noir-contracts/contracts/test/test_contract/src/test_note.nr
+++ b/noir-projects/noir-contracts/contracts/test/test_contract/src/test_note.nr
@@ -26,7 +26,7 @@ impl NoteHash for TestNote {
     fn compute_nullifier(
         _self: Self,
         _context: &mut PrivateContext,
-        _note_hash_for_nullify: Field,
+        _note_hash_for_nullification: Field,
     ) -> Field {
         // This note's nullifier is never used for any meaningful purpose so we don't care about having a real
         // implementation here.
@@ -35,7 +35,7 @@ impl NoteHash for TestNote {
 
     unconstrained fn compute_nullifier_unconstrained(
         _self: Self,
-        _note_hash_for_nullify: Field,
+        _note_hash_for_nullification: Field,
     ) -> Field {
         // This note's nullifier is never used for any meaningful purpose so we don't care about having a real
         // implementation here.


### PR DESCRIPTION
Fixes #11950

`compute_note_hash_for_nullify` --> `compute_note_hash_for_nullification`

Decided to just tackles this as I was cleaning up old issues and this is quick to do.