### PR TITLE
feat: ECDSA audit 7 - test for ECDSA constraints

### DIFF
--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/ecdsa_constraints.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/ecdsa_constraints.cpp
@@ -95,8 +95,8 @@ void create_ecdsa_verify_constraints(typename Curve::Builder& builder,
     // Step 3.
     // Ensure uniqueness of the public key by asserting each of its coordinates is smaller than the modulus of the base
     // field
-    pub_x.assert_is_in_field();
-    pub_y.assert_is_in_field();
+    pub_x.assert_is_in_field("ECDSA input validation: the x coordinate of the public key is larger than Fq::modulus");
+    pub_y.assert_is_in_field("ECDSA input validation: the y coordinate of the public key is larger than Fq::modulus");
 
     // Step 4.
     bool_ct signature_result =


### PR DESCRIPTION
### 🧾 Audit Context

Added failure messages for ECDSA constraints and one test.

### 🛠️ Changes Made

As a final clean up, I added failure messages for `assert_in_field` in ECDSA constraints, and one test ensuring that the failure is caught.

### ✅ Checklist

- [ ] Audited all methods of the relevant module/class
- [ ] Audited the interface of the module/class with other (relevant) components
- [ ] Documented existing functionality and any changes made (as per Doxygen requirements)
- [ ] Resolved and/or closed all issues/TODOs pertaining to the audited files
- [ ] Confirmed and documented any security or other issues found (if applicable)
- [ ] Verified that tests cover all critical paths (and added tests if necessary)
- [ ] Updated audit tracking for the files audited (check the start of each file you audited)

### 📌 Notes for Reviewers