### PR TITLE
test(Barretenberg): Static Analysis results of Merge Recursive Verifier 

### DIFF
--- a/barretenberg/cpp/src/barretenberg/boomerang_value_detection/CMakeLists.txt
+++ b/barretenberg/cpp/src/barretenberg/boomerang_value_detection/CMakeLists.txt
@@ -1,3 +1,4 @@
-barretenberg_module(boomerang_value_detection stdlib_circuit_builders circuit_checker 
-                    stdlib_primitives numeric stdlib_aes128 stdlib_sha256 stdlib_blake2s 
-                    stdlib_blake3s stdlib_poseidon2 stdlib_honk_verifier stdlib_protogalaxy_verifier)
+barretenberg_module(boomerang_value_detection stdlib_circuit_builders circuit_checker
+                    stdlib_primitives numeric stdlib_aes128 stdlib_sha256 stdlib_blake2s
+                    stdlib_blake3s stdlib_poseidon2 stdlib_honk_verifier stdlib_protogalaxy_verifier
+                    stdlib_merge_verifier)

--- a/barretenberg/cpp/src/barretenberg/boomerang_value_detection/graph.cpp
+++ b/barretenberg/cpp/src/barretenberg/boomerang_value_detection/graph.cpp
@@ -1501,6 +1501,14 @@ void StaticAnalyzer_<FF, CircuitBuilder>::print_variable_in_one_gate(const uint3
     }
 }
 
+template <typename FF, typename CircuitBuilder>
+std::pair<std::vector<ConnectedComponent>, std::unordered_set<uint32_t>> StaticAnalyzer_<FF, CircuitBuilder>::
+    analyze_circuit()
+{
+    auto connected_components = find_connected_components();
+    auto variables_in_one_gate = get_variables_in_one_gate();
+    return std::make_pair(connected_components, variables_in_one_gate);
+}
 template class StaticAnalyzer_<bb::fr, bb::UltraCircuitBuilder>;
 template class StaticAnalyzer_<bb::fr, bb::MegaCircuitBuilder>;
 

--- a/barretenberg/cpp/src/barretenberg/boomerang_value_detection/graph.hpp
+++ b/barretenberg/cpp/src/barretenberg/boomerang_value_detection/graph.hpp
@@ -147,6 +147,8 @@ template <typename FF, typename CircuitBuilder> class StaticAnalyzer_ {
     void print_connected_components_info();
     void print_variables_gate_counts();
     void print_variable_in_one_gate(const uint32_t real_idx);
+
+    std::pair<std::vector<ConnectedComponent>, std::unordered_set<uint32_t>> analyze_circuit();
     ~StaticAnalyzer_() = default;
 
   private:

--- a/barretenberg/cpp/src/barretenberg/boomerang_value_detection/graph_description_merge_recursive_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/boomerang_value_detection/graph_description_merge_recursive_verifier.test.cpp
@@ -1,0 +1,192 @@
+#include "barretenberg/boomerang_value_detection/graph.hpp"
+#include "barretenberg/circuit_checker/circuit_checker.hpp"
+#include "barretenberg/common/test.hpp"
+#include "barretenberg/ecc/fields/field_conversion.hpp"
+#include "barretenberg/goblin/mock_circuits.hpp"
+#include "barretenberg/stdlib/merge_verifier/merge_recursive_verifier.hpp"
+#include "barretenberg/stdlib/primitives/curves/bn254.hpp"
+#include "barretenberg/ultra_honk/merge_prover.hpp"
+#include "barretenberg/ultra_honk/merge_verifier.hpp"
+#include "barretenberg/ultra_honk/ultra_prover.hpp"
+#include "barretenberg/ultra_honk/ultra_verifier.hpp"
+
+using namespace cdg;
+
+namespace bb::stdlib::recursion::goblin {
+
+/**
+ * @brief Test suite for recursive verification of Goblin Merge proofs
+ * @details The recursive verification circuit is arithmetized using Goblin-style Ultra arithmetization
+ * (MegaCircuitBuilder).
+ *
+ * @tparam Builder
+ */
+template <class RecursiveBuilder> class BoomerangRecursiveMergeVerifierTest : public testing::Test {
+
+    // Types for recursive verifier circuit
+    using RecursiveMergeVerifier = MergeRecursiveVerifier_<RecursiveBuilder>;
+    using RecursiveTableCommitments = MergeRecursiveVerifier_<RecursiveBuilder>::TableCommitments;
+    using RecursiveMergeCommitments = MergeRecursiveVerifier_<RecursiveBuilder>::InputCommitments;
+
+    // Define types relevant for inner circuit
+    using InnerFlavor = MegaFlavor;
+    using InnerProverInstance = ProverInstance_<InnerFlavor>;
+    using InnerBuilder = typename InnerFlavor::CircuitBuilder;
+
+    // Define additional types for testing purposes
+    using Commitment = InnerFlavor::Commitment;
+    using FF = InnerFlavor::FF;
+    using VerifierCommitmentKey = bb::VerifierCommitmentKey<curve::BN254>;
+    using MergeProof = MergeProver::MergeProof;
+    using TableCommitments = MergeVerifier::TableCommitments;
+    using MergeCommitments = MergeVerifier::InputCommitments;
+
+    enum class TamperProofMode { None, Shift, MCommitment, LEval };
+
+  public:
+    static void SetUpTestSuite() { bb::srs::init_file_crs_factory(bb::srs::bb_crs_path()); }
+
+    static void tamper_with_proof(MergeProof& merge_proof, const TamperProofMode tampering_mode)
+    {
+        const size_t shift_idx = 0;        // Index of shift_size in the merge proof
+        const size_t m_commitment_idx = 1; // Index of first commitment to merged table in merge proof
+        const size_t l_eval_idx = 34;      // Index of first evaluation of l(1/kappa) in merge proof
+
+        switch (tampering_mode) {
+        case TamperProofMode::Shift:
+            // Tamper with the shift size in the proof
+            merge_proof[shift_idx] += 1;
+            break;
+        case TamperProofMode::MCommitment: {
+            // Tamper with the commitment in the proof
+            Commitment m_commitment =
+                bb::field_conversion::convert_from_bn254_frs<Commitment>(std::span{ merge_proof }.subspan(
+                    m_commitment_idx, bb::field_conversion::calc_num_bn254_frs<Commitment>()));
+            m_commitment = m_commitment + Commitment::one();
+            auto m_commitment_frs = bb::field_conversion::convert_to_bn254_frs<Commitment>(m_commitment);
+            for (size_t idx = 0; idx < 4; ++idx) {
+                merge_proof[m_commitment_idx + idx] = m_commitment_frs[idx];
+            }
+            break;
+        }
+        case TamperProofMode::LEval:
+            // Tamper with the evaluation in the proof
+            merge_proof[l_eval_idx] -= FF(1);
+            break;
+        default:
+            // Nothing to do
+            break;
+        }
+    }
+
+    static void analyze_circuit(RecursiveBuilder& outer_circuit)
+    {
+        if constexpr (IsMegaBuilder<RecursiveBuilder>) {
+            MegaStaticAnalyzer tool = MegaStaticAnalyzer(outer_circuit);
+            auto result = tool.analyze_circuit();
+            EXPECT_EQ(result.first.size(), 1);
+            EXPECT_EQ(result.second.size(), 0);
+        }
+        if constexpr (IsUltraBuilder<RecursiveBuilder>) {
+            StaticAnalyzer tool = StaticAnalyzer(outer_circuit);
+            auto result = tool.analyze_circuit();
+            EXPECT_EQ(result.first.size(), 1);
+            EXPECT_EQ(result.second.size(), 0);
+        }
+    }
+
+    static void prove_and_verify_merge(const std::shared_ptr<ECCOpQueue>& op_queue,
+                                       const MergeSettings settings = MergeSettings::PREPEND,
+                                       const bool run_analyzer = false,
+                                       const TamperProofMode tampering_mode = TamperProofMode::None,
+                                       const bool expected = true)
+
+    {
+        RecursiveBuilder outer_circuit;
+
+        MergeProver merge_prover{ op_queue, settings };
+        auto merge_proof = merge_prover.construct_proof();
+        tamper_with_proof(merge_proof, tampering_mode);
+
+        // Subtable values and commitments - needed for (Recursive)MergeVerifier
+        MergeCommitments merge_commitments;
+        RecursiveMergeCommitments recursive_merge_commitments;
+        auto t_current = op_queue->construct_current_ultra_ops_subtable_columns();
+        auto T_prev = op_queue->construct_previous_ultra_ops_table_columns();
+        for (size_t idx = 0; idx < InnerFlavor::NUM_WIRES; idx++) {
+            merge_commitments.t_commitments[idx] = merge_prover.pcs_commitment_key.commit(t_current[idx]);
+            merge_commitments.T_prev_commitments[idx] = merge_prover.pcs_commitment_key.commit(T_prev[idx]);
+            recursive_merge_commitments.t_commitments[idx] =
+                RecursiveMergeVerifier::Commitment::from_witness(&outer_circuit, merge_commitments.t_commitments[idx]);
+            recursive_merge_commitments.T_prev_commitments[idx] = RecursiveMergeVerifier::Commitment::from_witness(
+                &outer_circuit, merge_commitments.T_prev_commitments[idx]);
+            // Removing the free witness tag, since the merge commitments in the full scheme are supposed to
+            // be fiat-shamirred earlier
+            recursive_merge_commitments.t_commitments[idx].unset_free_witness_tag();
+            recursive_merge_commitments.T_prev_commitments[idx].unset_free_witness_tag();
+        }
+
+        // Create a recursive merge verification circuit for the merge proof
+        RecursiveMergeVerifier verifier{ &outer_circuit, settings };
+        verifier.transcript->enable_manifest();
+        const stdlib::Proof<RecursiveBuilder> stdlib_merge_proof(outer_circuit, merge_proof);
+        [[maybe_unused]] auto [pairing_points, recursive_merged_table_commitments] =
+            verifier.verify_proof(stdlib_merge_proof, recursive_merge_commitments);
+
+        // Check for a failure flag in the recursive verifier circuit
+        EXPECT_EQ(outer_circuit.failed(), !expected) << outer_circuit.err();
+        if (run_analyzer) {
+            analyze_circuit(outer_circuit);
+        }
+    }
+
+    static void test_recursive_merge_verification_prepend()
+    {
+        auto op_queue = std::make_shared<ECCOpQueue>();
+
+        InnerBuilder circuit{ op_queue };
+        GoblinMockCircuits::construct_simple_circuit(circuit);
+        prove_and_verify_merge(op_queue);
+
+        InnerBuilder circuit2{ op_queue };
+        GoblinMockCircuits::construct_simple_circuit(circuit2);
+        prove_and_verify_merge(op_queue);
+
+        InnerBuilder circuit3{ op_queue };
+        GoblinMockCircuits::construct_simple_circuit(circuit3);
+        prove_and_verify_merge(op_queue, MergeSettings::PREPEND, true);
+    }
+
+    static void test_recursive_merge_verification_append()
+    {
+        auto op_queue = std::make_shared<ECCOpQueue>();
+
+        InnerBuilder circuit{ op_queue };
+        GoblinMockCircuits::construct_simple_circuit(circuit);
+        prove_and_verify_merge(op_queue);
+
+        InnerBuilder circuit2{ op_queue };
+        GoblinMockCircuits::construct_simple_circuit(circuit2);
+        prove_and_verify_merge(op_queue);
+
+        InnerBuilder circuit3{ op_queue };
+        GoblinMockCircuits::construct_simple_circuit(circuit3);
+        prove_and_verify_merge(op_queue, MergeSettings::APPEND, true);
+    }
+};
+
+using Builder = testing::Types<MegaCircuitBuilder>;
+
+TYPED_TEST_SUITE(BoomerangRecursiveMergeVerifierTest, Builder);
+
+TYPED_TEST(BoomerangRecursiveMergeVerifierTest, RecursiveVerificationPrepend)
+{
+    TestFixture::test_recursive_merge_verification_prepend();
+};
+
+TYPED_TEST(BoomerangRecursiveMergeVerifierTest, RecursiveVerificationAppend)
+{
+    TestFixture::test_recursive_merge_verification_append();
+};
+
+} // namespace bb::stdlib::recursion::goblin


### PR DESCRIPTION
1. There were added 2 new tests for Merge Recursive Verifier with 2 merge settings: append and prepend. 
2. There were added new function analyze_circuit() for static analyzer for more convenient testing. 