### PR TITLE
chore: revert whitelist on governance

### DIFF
--- a/l1-contracts/src/governance/Governance.sol
+++ b/l1-contracts/src/governance/Governance.sol
@@ -26,26 +26,6 @@ import {IERC20} from "@oz/token/ERC20/IERC20.sol";
 import {SafeERC20} from "@oz/token/ERC20/utils/SafeERC20.sol";
 
 /**
- * @dev a whitelist, controlling who may have power in the governance contract.
- * That is, an address must be an approved beneficiary to receive power via `deposit`.
- *
- * The caveat is that the owner of the contract may open the floodgates, allowing all addresses to hold power.
- * This is currently a "one-way-valve", since if it were reopened after being shut,
- * the contract is in an odd state where entities are holding power, but not allowed to receive more;
- * the whitelist is enabled, but does not reflect the functional entities in the system.
- * As an aside, it is unlikely that in the event Governance were opened up to all addresses,
- * those same addresses would subsequently vote to close it again.
- *
- * In practice, it is expected that the only authorized beneficiary will be the GSE.
- * This is because all rollup instances deposit their stake into the GSE, which in turn deposits it into the governance
- * contract. In turn, it is the GSE that votes on proposals.
- */
-struct DepositControl {
-  mapping(address beneficiary => bool allowed) isAllowed;
-  bool allBeneficiariesAllowed;
-}
-
-/**
  * @title Governance
  * @author Aztec Labs
  * @notice A contract that implements governance logic for proposal creation, voting, and execution.
@@ -62,11 +42,6 @@ struct DepositControl {
  * **Power**: Funds received via `deposit` are held by Governance and tracked 1:1 as "power" for the beneficiary.
  *
  * **Proposals**: Payloads containing actions to be executed by governance (excluding calls to the governance ASSET).
- *
- * **Deposit Control**: A whitelist system controlling who can hold power in governance.
- * - Initially restricted to approved beneficiaries (expected to be only the GSE)
- * - Can be opened to all addresses via `openFloodgates` (one-way valve)
- * - The GSE aggregates stake from all rollup instances and votes on their behalf
  *
  * **Voting Power**: Based on checkpointed deposit history, calculated per proposal.
  *
@@ -102,7 +77,7 @@ struct DepositControl {
  * @dev USER FLOW:
  *
  * 1. **Deposit**: Transfer ASSET to governance for voting power
- *    - Only whitelisted beneficiaries can hold power
+ *    - Anyone can deposit funds into the governance contract
  *    - Power is checkpointed for historical lookups
  *
  * 2. **Vote**: Use power from proposal's snapshot timestamp
@@ -151,12 +126,6 @@ contract Governance is IGovernance {
    * This address can only be updated by the governance itself through a proposal.
    */
   address public governanceProposer;
-
-  /**
-   * @dev The whitelist of beneficiaries that are allowed to hold power via `deposit`,
-   * and the flag to allow all beneficiaries to hold power.
-   */
-  DepositControl internal depositControl;
 
   /**
    * @dev The proposals that have been made.
@@ -229,55 +198,12 @@ contract Governance is IGovernance {
     _;
   }
 
-  /**
-   * @dev Modifier to ensure that the beneficiary is allowed to hold power in Governance.
-   */
-  modifier isDepositAllowed(address _beneficiary) {
-    require(msg.sender != address(this), Errors.Governance__CallerCannotBeSelf());
-    require(
-      depositControl.allBeneficiariesAllowed || depositControl.isAllowed[_beneficiary],
-      Errors.Governance__DepositNotAllowed()
-    );
-
-    _;
-  }
-
-  /**
-   * @dev the initial _beneficiary is expected to be the GSE.
-   */
-  constructor(IERC20 _asset, address _governanceProposer, address _beneficiary, Configuration memory _configuration) {
+  constructor(IERC20 _asset, address _governanceProposer, Configuration memory _configuration) {
     ASSET = _asset;
     governanceProposer = _governanceProposer;
 
     _configuration.assertValid();
     configuration = CompressedConfigurationLib.compress(_configuration);
-
-    // Unnecessary to set, but better clarity.
-    depositControl.allBeneficiariesAllowed = false;
-    depositControl.isAllowed[_beneficiary] = true;
-    emit BeneficiaryAdded(_beneficiary);
-  }
-
-  /**
-   * @notice Add a beneficiary to the whitelist.
-   * @dev The beneficiary may hold power in the governance contract after this call.
-   * only callable by the governance contract itself.
-   *
-   * @param _beneficiary The address to add to the whitelist.
-   */
-  function addBeneficiary(address _beneficiary) external override(IGovernance) onlySelf {
-    depositControl.isAllowed[_beneficiary] = true;
-    emit BeneficiaryAdded(_beneficiary);
-  }
-
-  /**
-   * @notice Allow all addresses to hold power in the governance contract.
-   * @dev This is a one-way valve.
-   * only callable by the governance contract itself.
-   */
-  function openFloodgates() external override(IGovernance) onlySelf {
-    depositControl.allBeneficiariesAllowed = true;
-    emit FloodGatesOpened();
   }
 
   /**
@@ -317,13 +243,7 @@ contract Governance is IGovernance {
    * @notice Deposit funds into the governance contract, transferring ASSET from msg.sender to the governance contract,
    * increasing the power 1:1 of the beneficiary within the governance contract.
    *
-   * @dev The beneficiary must be allowed to hold power in the governance contract,
-   * according to `depositControl`.
-   *
    * Increments the checkpointed power of the specified beneficiary, and the total power of the governance contract.
-   *
-   * Note that anyone may deposit funds into the governance contract, and the only restriction is that
-   * the beneficiary must be allowed to hold power in the governance contract, according to `depositControl`.
    *
    * It is worth pointing out that someone could attempt to spam the deposit function, and increase the cost to vote
    * as a result of creating many checkpoints. In reality though, as the checkpoints are using time as a key it would
@@ -332,7 +252,8 @@ contract Governance is IGovernance {
    * @param _beneficiary The beneficiary to increase the power of.
    * @param _amount The amount of funds to deposit, which is converted to power 1:1.
    */
-  function deposit(address _beneficiary, uint256 _amount) external override(IGovernance) isDepositAllowed(_beneficiary) {
+  function deposit(address _beneficiary, uint256 _amount) external override(IGovernance) {
+    require(msg.sender != address(this), Errors.Governance__CallerCannotBeSelf());
     ASSET.safeTransferFrom(msg.sender, address(this), _amount);
     users[_beneficiary].add(_amount);
     total.add(_amount);
@@ -563,25 +484,6 @@ contract Governance is IGovernance {
    */
   function totalPowerNow() external view override(IGovernance) returns (uint256) {
     return total.valueNow();
-  }
-
-  /**
-   * @notice Check if an address is permitted to hold power in Governance.
-   *
-   * @param _beneficiary The address to check.
-   * @return True if the address is permitted to hold power in Governance.
-   */
-  function isPermittedInGovernance(address _beneficiary) external view override(IGovernance) returns (bool) {
-    return depositControl.isAllowed[_beneficiary];
-  }
-
-  /**
-   * @notice Check if everyone is permitted to hold power in Governance.
-   *
-   * @return True if everyone is permitted to hold power in Governance.
-   */
-  function isAllBeneficiariesAllowed() external view override(IGovernance) returns (bool) {
-    return depositControl.allBeneficiariesAllowed;
   }
 
   function getConfiguration() external view override(IGovernance) returns (Configuration memory) {

--- a/l1-contracts/src/governance/interfaces/IGovernance.sol
+++ b/l1-contracts/src/governance/interfaces/IGovernance.sol
@@ -64,9 +64,6 @@ struct Withdrawal {
 }
 
 interface IGovernance {
-  event BeneficiaryAdded(address beneficiary);
-  event FloodGatesOpened();
-
   event Proposed(uint256 indexed proposalId, address indexed proposal);
   event VoteCast(uint256 indexed proposalId, address indexed voter, bool support, uint256 amount);
   event ProposalExecuted(uint256 indexed proposalId);
@@ -78,9 +75,6 @@ interface IGovernance {
   event WithdrawInitiated(uint256 indexed withdrawalId, address indexed recipient, uint256 amount);
   event WithdrawFinalized(uint256 indexed withdrawalId);
 
-  function addBeneficiary(address _beneficiary) external;
-  function openFloodgates() external;
-
   function updateGovernanceProposer(address _governanceProposer) external;
   function updateConfiguration(Configuration memory _configuration) external;
   function deposit(address _onBehalfOf, uint256 _amount) external;
@@ -91,9 +85,6 @@ interface IGovernance {
   function vote(uint256 _proposalId, uint256 _amount, bool _support) external;
   function execute(uint256 _proposalId) external;
   function dropProposal(uint256 _proposalId) external;
-
-  function isPermittedInGovernance(address _caller) external view returns (bool);
-  function isAllBeneficiariesAllowed() external view returns (bool);
 
   function powerAt(address _owner, Timestamp _ts) external view returns (uint256);
   function powerNow(address _owner) external view returns (uint256);

--- a/l1-contracts/test/builder/GseBuilder.sol
+++ b/l1-contracts/test/builder/GseBuilder.sol
@@ -17,7 +17,6 @@ import {IRollup} from "@aztec/core/interfaces/IRollup.sol";
 import {stdStorage, StdStorage} from "forge-std/Test.sol";
 
 struct Flags {
-  bool openFloodgates;
   bool checkProofOfPossession;
 }
 
@@ -45,13 +44,7 @@ contract GSEBuilder is TestBase {
   constructor() {
     config.values.govProposerN = 1;
     config.values.govProposerM = 1;
-    config.flags.openFloodgates = true;
     config.flags.checkProofOfPossession = false;
-  }
-
-  function setOpenFloodgates(bool _openFloodgates) public returns (GSEBuilder) {
-    config.flags.openFloodgates = _openFloodgates;
-    return this;
   }
 
   function setGovProposerN(uint256 _govProposerN) public returns (GSEBuilder) {
@@ -88,21 +81,12 @@ contract GSEBuilder is TestBase {
 
     GovernanceProposer proposer =
       new GovernanceProposer(config.registry, config.gse, config.values.govProposerN, config.values.govProposerM);
-    config.governance = new Governance(
-      config.testERC20, address(proposer), address(config.gse), TestConstants.getGovernanceConfiguration()
-    );
+    config.governance = new Governance(config.testERC20, address(proposer), TestConstants.getGovernanceConfiguration());
     vm.label(address(config.governance), "Governance");
     vm.label(address(proposer), "GovernanceProposer");
 
     vm.prank(config.gse.owner());
     config.gse.setGovernance(config.governance);
-
-    if (config.flags.openFloodgates) {
-      vm.prank(address(config.governance));
-      config.governance.openFloodgates();
-
-      assertEq(config.governance.isAllBeneficiariesAllowed(), true);
-    }
 
     vm.startPrank(config.registry.owner());
     config.registry.transferOwnership(address(config.governance));

--- a/l1-contracts/test/builder/RollupBuilder.sol
+++ b/l1-contracts/test/builder/RollupBuilder.sol
@@ -28,7 +28,6 @@ struct ConfigFlags {
   bool makeCanonical;
   bool makeGovernance;
   bool updateOwnerships;
-  bool openFloodgates;
   bool checkProofOfPossession;
 }
 
@@ -77,7 +76,6 @@ contract RollupBuilder is Test {
     config.flags.makeCanonical = true;
     config.flags.makeGovernance = true;
     config.flags.updateOwnerships = true;
-    config.flags.openFloodgates = true;
     config.flags.checkProofOfPossession = false;
   }
 
@@ -138,11 +136,6 @@ contract RollupBuilder is Test {
 
   function setUpdateOwnerships(bool _updateOwnerships) public returns (RollupBuilder) {
     config.flags.updateOwnerships = _updateOwnerships;
-    return this;
-  }
-
-  function setOpenFloodgates(bool _openFloodgates) public returns (RollupBuilder) {
-    config.flags.openFloodgates = _openFloodgates;
     return this;
   }
 
@@ -283,21 +276,12 @@ contract RollupBuilder is Test {
     if (config.flags.makeGovernance) {
       GovernanceProposer proposer =
         new GovernanceProposer(config.registry, config.gse, config.values.govProposerN, config.values.govProposerM);
-      config.governance = new TestGov(
-        config.testERC20, address(proposer), address(config.gse), TestConstants.getGovernanceConfiguration()
-      );
+      config.governance = new TestGov(config.testERC20, address(proposer), TestConstants.getGovernanceConfiguration());
       vm.label(address(config.governance), "Governance");
       vm.label(address(proposer), "GovernanceProposer");
 
       vm.prank(config.gse.owner());
       config.gse.setGovernance(config.governance);
-
-      if (config.flags.openFloodgates) {
-        vm.prank(address(config.governance));
-        config.governance.openFloodgates();
-
-        assertEq(config.governance.isAllBeneficiariesAllowed(), true);
-      }
     }
 
     config.rollupConfigInput.rewardConfig.rewardDistributor = config.rewardDistributor;

--- a/l1-contracts/test/governance/governance-proposer/scenario/tmnt143.t.sol
+++ b/l1-contracts/test/governance/governance-proposer/scenario/tmnt143.t.sol
@@ -102,8 +102,7 @@ contract TestTmnt143 is TestBase {
     rollup = new Fakerollup();
     registry.addRollup(rollup);
 
-    governance =
-      new Governance(asset, address(governanceProposer), address(gse), TestConstants.getGovernanceConfiguration());
+    governance = new Governance(asset, address(governanceProposer), TestConstants.getGovernanceConfiguration());
 
     registry.transferOwnership(address(governance));
 
@@ -112,9 +111,6 @@ contract TestTmnt143 is TestBase {
 
   function test_livelock() external {
     // Make a proposal to move to a new GSE, but people leave early so less than 2/3 on the latest in the GSE.
-
-    vm.prank(address(governance));
-    governance.openFloodgates();
 
     vm.prank(asset.owner());
     asset.mint(address(this), 10_000e18);

--- a/l1-contracts/test/governance/governance/base.t.sol
+++ b/l1-contracts/test/governance/governance/base.t.sol
@@ -36,11 +36,7 @@ contract GovernanceBase is TestBase {
     registry = new Registry(address(this), token);
     governanceProposer = new GovernanceProposer(registry, IGSE(address(0x03)), 677, 1000);
 
-    governance =
-      new TestGov(token, address(governanceProposer), address(this), TestConstants.getGovernanceConfiguration());
-
-    vm.prank(address(governance));
-    governance.openFloodgates();
+    governance = new TestGov(token, address(governanceProposer), TestConstants.getGovernanceConfiguration());
 
     registry.transferOwnership(address(governance));
 

--- a/l1-contracts/test/governance/governance/limitedDeposit.t.sol
+++ b/l1-contracts/test/governance/governance/limitedDeposit.t.sol
@@ -33,27 +33,10 @@ contract LimitedDepositTest is TestBase {
     registry = new Registry(address(this), token);
     governanceProposer = new GovernanceProposer(registry, IGSE(address(0x03)), 677, 1000);
 
-    governance =
-      new Governance(token, address(governanceProposer), address(this), TestConstants.getGovernanceConfiguration());
+    governance = new Governance(token, address(governanceProposer), TestConstants.getGovernanceConfiguration());
   }
 
-  function test_WhenNotAllowedToDeposit(address _caller, address _depositor) external {
-    // it reverts
-
-    vm.assume(_caller != address(0) && _depositor != address(0) && _caller != address(governance));
-    vm.assume(!governance.isPermittedInGovernance(_depositor));
-
-    vm.prank(_caller);
-    vm.expectRevert(abi.encodeWithSelector(Errors.Governance__DepositNotAllowed.selector));
-    governance.deposit(_depositor, 1000);
-  }
-
-  function test_WhenNotAllowedToDepositSelf(address _depositor, bool _floodgatesOpen) external {
-    if (_floodgatesOpen) {
-      vm.prank(address(governance));
-      governance.openFloodgates();
-    }
-
+  function test_WhenNotAllowedToDepositSelf(address _depositor) external {
     vm.prank(address(governance));
     vm.expectRevert(abi.encodeWithSelector(Errors.Governance__CallerCannotBeSelf.selector));
     governance.deposit(_depositor, 1000);
@@ -62,9 +45,6 @@ contract LimitedDepositTest is TestBase {
   function test_WhenIsAllowedToDeposit(address _caller, address _depositor) external {
     // it deposits
     vm.assume(_caller != address(0) && _depositor != address(0) && _caller != address(governance));
-
-    vm.prank(address(governance));
-    governance.addBeneficiary(_depositor);
 
     token.mint(_caller, 1000);
 
@@ -77,13 +57,10 @@ contract LimitedDepositTest is TestBase {
     assertEq(governance.powerNow(_depositor), 1000);
   }
 
-  function test_WhenFloodgatesAreOpen(address _caller, address _depositor) external {
+  function test_WhenAnyoneCanDeposit(address _caller, address _depositor) external {
     // it deposits
 
     vm.assume(_caller != address(0) && _depositor != address(0) && _caller != address(governance));
-
-    vm.prank(address(governance));
-    governance.openFloodgates();
 
     token.mint(_caller, 1000);
 

--- a/l1-contracts/test/governance/governance/tmnt331.t.sol
+++ b/l1-contracts/test/governance/governance/tmnt331.t.sol
@@ -35,14 +35,10 @@ contract DepositTest is TestBase {
     registry = new Registry(address(this), token);
     governanceProposer = new GovernanceProposer(registry, IGSE(address(0x03)), 677, 1000);
 
-    governance =
-      new TestGov(token, address(governanceProposer), address(this), TestConstants.getGovernanceConfiguration());
+    governance = new TestGov(token, address(governanceProposer), TestConstants.getGovernanceConfiguration());
   }
 
   function test_when_calling_self() public {
-    vm.prank(address(governance));
-    governance.openFloodgates();
-
     uint256 amount = 1000e18;
     token.mint(address(this), amount);
     token.approve(address(governance), amount);

--- a/l1-contracts/test/governance/helpers/TestGov.sol
+++ b/l1-contracts/test/governance/helpers/TestGov.sol
@@ -6,8 +6,8 @@ import {IERC20} from "@oz/token/ERC20/IERC20.sol";
 import {Configuration} from "@aztec/governance/interfaces/IGovernance.sol";
 
 contract TestGov is Governance {
-  constructor(IERC20 _asset, address _governanceProposer, address _beneficiary, Configuration memory _configuration)
-    Governance(_asset, _governanceProposer, _beneficiary, _configuration)
+  constructor(IERC20 _asset, address _governanceProposer, Configuration memory _configuration)
+    Governance(_asset, _governanceProposer, _configuration)
   {}
 
   function test__overrideQuorum(uint256 _id, uint64 _quorum) external {

--- a/yarn-project/ethereum/src/deploy_l1_contracts.ts
+++ b/yarn-project/ethereum/src/deploy_l1_contracts.ts
@@ -230,7 +230,6 @@ export const deploySharedContracts = async (
   const { address: governanceAddress } = await deployer.deploy(GovernanceArtifact, [
     stakingAssetAddress.toString(),
     governanceProposerAddress.toString(),
-    gseAddress.toString(),
     getGovernanceConfiguration(networkName),
   ]);
   logger.verbose(`Deployed Governance at ${governanceAddress}`);


### PR DESCRIPTION
# Remove Governance Deposit Control Whitelist

This PR removes the deposit control whitelist from the Governance contract, allowing any address to deposit funds and hold voting power. Previously, only whitelisted beneficiaries (expected to be the GSE) could hold power, with an option to "open the floodgates" to all addresses.

Key changes:
- Removed `DepositControl` struct and related functionality
- Simplified the constructor by removing the `_beneficiary` parameter
- Removed `addBeneficiary` and `openFloodgates` functions
- Removed `isPermittedInGovernance` and `isAllBeneficiariesAllowed` view functions
- Updated documentation to reflect that anyone can deposit funds
- Updated tests and deployment scripts to align with the new implementation

This change simplifies the governance model by removing the whitelist restriction, making the system more open and accessible to all participants.