### PR TITLE
refactor(bb): disable expensive asserts in release, more direct poly memory access

### DIFF
--- a/barretenberg/cpp/CMakePresets.json
+++ b/barretenberg/cpp/CMakePresets.json
@@ -18,7 +18,7 @@
         "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
       },
       "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "RelWithAssert",
+        "CMAKE_BUILD_TYPE": "Release",
         "TARGET_ARCH": "skylake"
       }
     },

--- a/barretenberg/cpp/src/barretenberg/common/assert.hpp
+++ b/barretenberg/cpp/src/barretenberg/common/assert.hpp
@@ -6,6 +6,11 @@
 #include <cstdint>
 #include <sstream>
 
+// Enable this for (VERY SLOW) stats on which asserts are hit the most. Note that the time measured will be very
+// inaccurate, but you can still see what is called too often to be in a release build.
+// #define BB_BENCH_ASSERT(x) BB_BENCH_NAME(x)
+#define BB_BENCH_ASSERT(x)
+
 namespace bb {
 enum class AssertMode : std::uint8_t { ABORT, WARN };
 AssertMode& get_assert_mode();
@@ -62,7 +67,6 @@ struct AssertGuard {
 #else
 #define ASSERT_IN_CONSTEXPR(expression, ...)                                                                           \
     do {                                                                                                               \
-        BB_BENCH_NAME(#expression);                                                                                    \
         if (!(BB_LIKELY(expression))) {                                                                                \
             info("Assertion failed: (" #expression ")");                                                               \
             __VA_OPT__(info("Reason   : ", __VA_ARGS__);)                                                              \
@@ -72,7 +76,7 @@ struct AssertGuard {
 
 #define ASSERT(expression, ...)                                                                                        \
     do {                                                                                                               \
-        BB_BENCH_NAME(#expression);                                                                                    \
+        BB_BENCH_ASSERT("ASSERT" #expression);                                                                         \
         if (!(BB_LIKELY(expression))) {                                                                                \
             std::ostringstream oss;                                                                                    \
             oss << "Assertion failed: (" #expression ")";                                                              \
@@ -83,7 +87,7 @@ struct AssertGuard {
 
 #define BB_ASSERT_EQ(actual, expected, ...)                                                                            \
     do {                                                                                                               \
-        BB_BENCH_NAME(#actual " == " #expected);                                                                       \
+        BB_BENCH_ASSERT("BB_ASSERT_EQ" #actual " == " #expected);                                                      \
         auto _actual = (actual);                                                                                       \
         auto _expected = (expected);                                                                                   \
         if (!(BB_LIKELY(_actual == _expected))) {                                                                      \
@@ -98,7 +102,7 @@ struct AssertGuard {
 
 #define BB_ASSERT_NEQ(actual, expected, ...)                                                                           \
     do {                                                                                                               \
-        BB_BENCH_NAME(#actual " != " #expected);                                                                       \
+        BB_BENCH_ASSERT("BB_ASSERT_NEQ" #actual " != " #expected);                                                     \
         auto _actual = (actual);                                                                                       \
         auto _expected = (expected);                                                                                   \
         if (!(BB_LIKELY(_actual != _expected))) {                                                                      \
@@ -113,6 +117,7 @@ struct AssertGuard {
 
 #define BB_ASSERT_GT(left, right, ...)                                                                                 \
     do {                                                                                                               \
+        BB_BENCH_ASSERT("BB_ASSERT_GT" #left " > " #right);                                                            \
         auto _left = (left);                                                                                           \
         auto _right = (right);                                                                                         \
         if (!(BB_LIKELY(_left > _right))) {                                                                            \
@@ -127,6 +132,7 @@ struct AssertGuard {
 
 #define BB_ASSERT_GTE(left, right, ...)                                                                                \
     do {                                                                                                               \
+        BB_BENCH_ASSERT("BB_ASSERT_GTE" #left " >= " #right);                                                          \
         auto _left = (left);                                                                                           \
         auto _right = (right);                                                                                         \
         if (!(BB_LIKELY(_left >= _right))) {                                                                           \
@@ -141,6 +147,7 @@ struct AssertGuard {
 
 #define BB_ASSERT_LT(left, right, ...)                                                                                 \
     do {                                                                                                               \
+        BB_BENCH_ASSERT("BB_ASSERT_LT" #left " < " #right);                                                            \
         auto _left = (left);                                                                                           \
         auto _right = (right);                                                                                         \
         if (!(BB_LIKELY(_left < _right))) {                                                                            \
@@ -155,6 +162,7 @@ struct AssertGuard {
 
 #define BB_ASSERT_LTE(left, right, ...)                                                                                \
     do {                                                                                                               \
+        BB_BENCH_ASSERT("BB_ASSERT_LTE" #left " <= " #right);                                                          \
         auto _left = (left);                                                                                           \
         auto _right = (right);                                                                                         \
         if (!(BB_LIKELY(_left <= _right))) {                                                                           \

--- a/barretenberg/cpp/src/barretenberg/common/assert.hpp
+++ b/barretenberg/cpp/src/barretenberg/common/assert.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "barretenberg/common/bb_bench.hpp"
 #include "barretenberg/common/compiler_hints.hpp"
 #include "barretenberg/common/throw_or_abort.hpp"
 #include <cstdint>
@@ -61,6 +62,7 @@ struct AssertGuard {
 #else
 #define ASSERT_IN_CONSTEXPR(expression, ...)                                                                           \
     do {                                                                                                               \
+        BB_BENCH_NAME(#expression);                                                                                    \
         if (!(BB_LIKELY(expression))) {                                                                                \
             info("Assertion failed: (" #expression ")");                                                               \
             __VA_OPT__(info("Reason   : ", __VA_ARGS__);)                                                              \
@@ -70,6 +72,7 @@ struct AssertGuard {
 
 #define ASSERT(expression, ...)                                                                                        \
     do {                                                                                                               \
+        BB_BENCH_NAME(#expression);                                                                                    \
         if (!(BB_LIKELY(expression))) {                                                                                \
             std::ostringstream oss;                                                                                    \
             oss << "Assertion failed: (" #expression ")";                                                              \
@@ -80,6 +83,7 @@ struct AssertGuard {
 
 #define BB_ASSERT_EQ(actual, expected, ...)                                                                            \
     do {                                                                                                               \
+        BB_BENCH_NAME(#actual " == " #expected);                                                                       \
         auto _actual = (actual);                                                                                       \
         auto _expected = (expected);                                                                                   \
         if (!(BB_LIKELY(_actual == _expected))) {                                                                      \
@@ -94,6 +98,7 @@ struct AssertGuard {
 
 #define BB_ASSERT_NEQ(actual, expected, ...)                                                                           \
     do {                                                                                                               \
+        BB_BENCH_NAME(#actual " != " #expected);                                                                       \
         auto _actual = (actual);                                                                                       \
         auto _expected = (expected);                                                                                   \
         if (!(BB_LIKELY(_actual != _expected))) {                                                                      \

--- a/barretenberg/cpp/src/barretenberg/common/ref_array.hpp
+++ b/barretenberg/cpp/src/barretenberg/common/ref_array.hpp
@@ -48,7 +48,7 @@ template <typename T, std::size_t N> class RefArray {
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Warray-bounds"
 #endif
-        BB_ASSERT_LT(idx, N);
+        ASSERT_DEBUG(idx < N);
         return *storage[idx];
 #if !defined(__clang__) && defined(__GNUC__)
 #pragma GCC diagnostic pop

--- a/barretenberg/cpp/src/barretenberg/common/ref_vector.hpp
+++ b/barretenberg/cpp/src/barretenberg/common/ref_vector.hpp
@@ -51,7 +51,7 @@ template <typename T> class RefVector {
 
     T& operator[](std::size_t idx) const
     {
-        BB_ASSERT_LT(idx, storage.size());
+        ASSERT_DEBUG(idx < storage.size());
         return *storage[idx];
     }
 

--- a/barretenberg/cpp/src/barretenberg/ecc/scalar_multiplication/bitvector.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/scalar_multiplication/bitvector.hpp
@@ -21,7 +21,7 @@ class BitVector {
 
     BB_INLINE void set(size_t index, bool value) noexcept
     {
-        BB_ASSERT_LT(index, num_bits_);
+        ASSERT_DEBUG(index < num_bits_);
         const size_t word = index >> 6;
         const size_t bit = index & 63;
 
@@ -35,7 +35,7 @@ class BitVector {
 
     BB_INLINE bool get(size_t index) const noexcept
     {
-        BB_ASSERT_LT(index, num_bits_);
+        ASSERT_DEBUG(index < num_bits_);
         const uint64_t word = index >> 6;
         const uint64_t bit = index & 63;
         return ((data_[static_cast<size_t>(word)] >> bit) & 1) == 1;

--- a/barretenberg/cpp/src/barretenberg/ecc/scalar_multiplication/scalar_multiplication.cpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/scalar_multiplication/scalar_multiplication.cpp
@@ -154,7 +154,7 @@ std::vector<typename MSM<Curve>::ThreadWorkUnits> MSM<Curve>::get_work_units(
     size_t thread_accumulated_work = 0;
     size_t current_thread_idx = 0;
     for (size_t i = 0; i < num_msms; ++i) {
-        BB_ASSERT_LT(i, msm_scalar_indices.size());
+        ASSERT_DEBUG(i < msm_scalar_indices.size());
         size_t msm_work = msm_scalar_indices[i].size();
         size_t msm_size = msm_work;
         while (msm_work > 0) {
@@ -450,9 +450,9 @@ typename Curve::Element MSM<Curve>::evaluate_small_pippenger_round(MSMData& msm_
 
     const size_t size = nonzero_scalar_indices.size();
     for (size_t i = 0; i < size; ++i) {
-        BB_ASSERT_LT(nonzero_scalar_indices[i], scalars.size());
+        ASSERT_DEBUG(nonzero_scalar_indices[i] < scalars.size());
         uint32_t bucket_index = get_scalar_slice(scalars[nonzero_scalar_indices[i]], round_index, bits_per_slice);
-        BB_ASSERT_LT(bucket_index, static_cast<uint32_t>(1 << bits_per_slice));
+        ASSERT_DEBUG(bucket_index < static_cast<uint32_t>(1 << bits_per_slice));
         if (bucket_index > 0) {
             // do this check because we do not reset bucket_data.buckets after each round
             // (i.e. not neccessarily at infinity)
@@ -511,7 +511,7 @@ typename Curve::Element MSM<Curve>::evaluate_pippenger_round(MSMData& msm_data,
     // 1. low 32 bits: which bucket index do we add the point into? (bucket index = slice value)
     // 2. high 32 bits: which point index do we source the point from?
     for (size_t i = 0; i < size; ++i) {
-        BB_ASSERT_LT(scalar_indices[i], scalars.size());
+        ASSERT_DEBUG(scalar_indices[i] < scalars.size());
         round_schedule[i] = get_scalar_slice(scalars[scalar_indices[i]], round_index, bits_per_slice);
         round_schedule[i] += (static_cast<uint64_t>(scalar_indices[i]) << 32ULL);
     }
@@ -692,7 +692,7 @@ void MSM<Curve>::consume_point_schedule(std::span<const uint64_t> point_schedule
     while ((affine_output_it < (num_affine_output_points - 1)) && (num_affine_output_points > 0)) {
         size_t lhs_bucket = static_cast<size_t>(affine_addition_output_bucket_destinations[affine_output_it]);
         size_t rhs_bucket = static_cast<size_t>(affine_addition_output_bucket_destinations[affine_output_it + 1]);
-        BB_ASSERT_LT(lhs_bucket, bucket_accumulator_exists.size());
+        ASSERT_DEBUG(lhs_bucket < bucket_accumulator_exists.size());
 
         bool has_bucket_accumulator = bucket_accumulator_exists.get(lhs_bucket);
         bool buckets_match = (lhs_bucket == rhs_bucket);
@@ -724,9 +724,9 @@ void MSM<Curve>::consume_point_schedule(std::span<const uint64_t> point_schedule
 
         bool has_bucket_accumulator = bucket_accumulator_exists.get(lhs_bucket);
         if (has_bucket_accumulator) {
-            BB_ASSERT_LT(new_scratch_space_it + 1, affine_addition_scratch_space.size());
-            BB_ASSERT_LT(lhs_bucket, bucket_accumulators.size());
-            BB_ASSERT_LT(new_scratch_space_it >> 1, output_point_schedule.size());
+            ASSERT_DEBUG(new_scratch_space_it + 1 < affine_addition_scratch_space.size());
+            ASSERT_DEBUG(lhs_bucket < bucket_accumulators.size());
+            ASSERT_DEBUG((new_scratch_space_it >> 1) < output_point_schedule.size());
             affine_addition_scratch_space[new_scratch_space_it] = affine_output[affine_output_it];
             affine_addition_scratch_space[new_scratch_space_it + 1] = bucket_accumulators[lhs_bucket];
             bucket_accumulator_exists.set(lhs_bucket, false);

--- a/barretenberg/cpp/src/barretenberg/ecc/scalar_multiplication/scalar_multiplication.cpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/scalar_multiplication/scalar_multiplication.cpp
@@ -65,11 +65,11 @@ void MSM<Curve>::transform_scalar_and_get_nonzero_scalar_indices(std::span<typen
         const size_t start = thread_idx * scalars_per_thread;
         const size_t end = last_thread ? scalars.size() : (thread_idx + 1) * scalars_per_thread;
         if (!empty_thread) {
-            BB_ASSERT_GT(end, start);
+            ASSERT_DEBUG(end > start);
             std::vector<uint32_t>& thread_scalar_indices = thread_indices[thread_idx];
             thread_scalar_indices.reserve(end - start);
             for (size_t i = start; i < end; ++i) {
-                BB_ASSERT_LT(i, scalars.size());
+                ASSERT_DEBUG(i < scalars.size());
                 auto& scalar = scalars[i];
                 scalar.self_from_montgomery_form();
 
@@ -518,7 +518,7 @@ typename Curve::Element MSM<Curve>::evaluate_pippenger_round(MSMData& msm_data,
     // Sort our point schedules based on their bucket values. Reduces memory throughput in next step of algo
     const size_t num_zero_entries = scalar_multiplication::process_buckets_count_zero_entries(
         &round_schedule[0], size, static_cast<uint32_t>(bits_per_slice));
-    BB_ASSERT_LTE(num_zero_entries, size);
+    ASSERT_DEBUG(num_zero_entries <= size);
     const size_t round_size = size - num_zero_entries;
 
     Element round_output;
@@ -665,7 +665,7 @@ void MSM<Curve>::consume_point_schedule(std::span<const uint64_t> point_schedule
             affine_input_it += 2;
             point_it += 1;
         } else { // otherwise, cache the point into the bucket
-            BB_ASSERT_LT(lhs_point, points.size());
+            ASSERT_DEBUG(lhs_point < points.size());
             bucket_accumulators[lhs_bucket] = points[lhs_point];
             bucket_accumulator_exists.set(lhs_bucket, true);
             point_it += 1;

--- a/barretenberg/cpp/src/barretenberg/ecc/scalar_multiplication/scalar_multiplication.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/scalar_multiplication/scalar_multiplication.hpp
@@ -161,7 +161,7 @@ template <typename Curve> class MSM {
         Element sum = prefix_sum + offset_generator;
         for (int i = static_cast<int>(starting_index - 1); i > 0; --i) {
             size_t idx = static_cast<size_t>(i);
-            BB_ASSERT_LT(idx, bucket_accumulators.bucket_exists.size());
+            ASSERT_DEBUG(idx < bucket_accumulators.bucket_exists.size());
             if (bucket_accumulators.bucket_exists.get(idx)) {
 
                 prefix_sum += buckets[idx];

--- a/barretenberg/cpp/src/barretenberg/ecc/scalar_multiplication/scalar_multiplication.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/scalar_multiplication/scalar_multiplication.hpp
@@ -132,7 +132,7 @@ template <typename Curve> class MSM {
     template <typename BucketType> static Element accumulate_buckets(BucketType& bucket_accumulators) noexcept
     {
         auto& buckets = bucket_accumulators.buckets;
-        BB_ASSERT_GT(buckets.size(), static_cast<size_t>(0));
+        ASSERT_DEBUG(buckets.size() > static_cast<size_t>(0));
         int starting_index = static_cast<int>(buckets.size() - 1);
         Element prefix_sum;
         bool found_start = false;
@@ -149,7 +149,7 @@ template <typename Curve> class MSM {
         if (!found_start) {
             return Curve::Group::point_at_infinity;
         }
-        BB_ASSERT_GT(starting_index, 0);
+        ASSERT_DEBUG(starting_index > 0);
         AffineElement offset_generator = Curve::Group::affine_point_at_infinity;
         if constexpr (std::same_as<typename Curve::Group, bb::g1>) {
             constexpr auto gen = get_precomputed_generators<typename Curve::Group, "ECCVM_OFFSET_GENERATOR", 1>()[0];

--- a/barretenberg/cpp/src/barretenberg/eccvm/eccvm_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/eccvm/eccvm_flavor.hpp
@@ -7,6 +7,7 @@
 #pragma once
 #include "barretenberg/commitment_schemes/ipa/ipa.hpp"
 #include "barretenberg/common/assert.hpp"
+#include "barretenberg/common/bb_bench.hpp"
 #include "barretenberg/common/std_array.hpp"
 #include "barretenberg/ecc/curves/bn254/bn254.hpp"
 #include "barretenberg/ecc/curves/grumpkin/grumpkin.hpp"

--- a/barretenberg/cpp/src/barretenberg/honk/execution_trace/execution_trace_block.hpp
+++ b/barretenberg/cpp/src/barretenberg/honk/execution_trace/execution_trace_block.hpp
@@ -153,13 +153,13 @@ template <typename FF> class ZeroSelector : public Selector<FF> {
 
     void set(size_t idx, int value) override
     {
-        BB_ASSERT_LT(idx, size_);
+        ASSERT_DEBUG(idx < size_);
         BB_ASSERT_EQ(value, 0, "Calling ZeroSelector::set with a non zero value.");
     }
 
     void set(size_t idx, const FF& value) override
     {
-        BB_ASSERT_LT(idx, size_);
+        ASSERT_DEBUG(idx < size_);
         ASSERT(value.is_zero());
         size_++;
     }
@@ -170,7 +170,7 @@ template <typename FF> class ZeroSelector : public Selector<FF> {
 
     const FF& operator[](size_t index) const override
     {
-        BB_ASSERT_LT(index, size_);
+        ASSERT_DEBUG(index < size_);
         return zero;
     }
 

--- a/barretenberg/cpp/src/barretenberg/numeric/uintx/uintx_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/numeric/uintx/uintx_impl.hpp
@@ -13,7 +13,7 @@ template <class base_uint>
 std::pair<uintx<base_uint>, uintx<base_uint>> uintx<base_uint>::divmod_base(const uintx& b) const
 
 {
-    ASSERT(b != 0);
+    ASSERT_DEBUG(b != 0);
     if (*this == 0) {
         return { uintx(0), uintx(0) };
     }

--- a/barretenberg/cpp/src/barretenberg/polynomials/backing_memory.hpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/backing_memory.hpp
@@ -66,8 +66,28 @@ template <typename Fr> struct BackingMemory {
     BackingMemory(const BackingMemory&) = default;
     BackingMemory& operator=(const BackingMemory&) = default;
 
-    BackingMemory(BackingMemory&& other) noexcept = default;
-    BackingMemory& operator=(BackingMemory&& other) noexcept = default;
+    BackingMemory(BackingMemory&& other) noexcept
+        : raw_data(other.raw_data)
+#ifndef __wasm__
+        , file_backed(std::move(other.file_backed))
+#endif
+        , aligned_memory(std::move(other.aligned_memory))
+    {
+        other.raw_data = nullptr;
+    }
+
+    BackingMemory& operator=(BackingMemory&& other) noexcept
+    {
+        if (this != &other) {
+            raw_data = other.raw_data;
+#ifndef __wasm__
+            file_backed = std::move(other.file_backed);
+#endif
+            aligned_memory = std::move(other.aligned_memory);
+            other.raw_data = nullptr;
+        }
+        return *this;
+    }
 
     // Allocate memory, preferring file-backed if in low memory mode
     static BackingMemory allocate(size_t size)

--- a/barretenberg/cpp/src/barretenberg/polynomials/backing_memory.hpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/backing_memory.hpp
@@ -58,13 +58,8 @@ template <typename Fr> struct BackingMemory {
     };
     std::shared_ptr<FileBackedData> file_backed;
 #endif
-
     // Aligned memory data substruct
-    struct AlignedMemoryData {
-        // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays)
-        std::shared_ptr<Fr[]> data;
-    };
-    std::shared_ptr<AlignedMemoryData> aligned_memory;
+    std::shared_ptr<Fr[]> aligned_memory;
 
     BackingMemory() = default;
 
@@ -94,11 +89,9 @@ template <typename Fr> struct BackingMemory {
   private:
     static void allocate_aligned(BackingMemory& memory, size_t size)
     {
-        auto aligned = std::make_shared<AlignedMemoryData>();
         // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays)
-        aligned->data = std::static_pointer_cast<Fr[]>(std::move(bb::get_mem_slab(sizeof(Fr) * size)));
-        memory.raw_data = aligned->data.get();
-        memory.aligned_memory = std::move(aligned);
+        memory.aligned_memory = std::static_pointer_cast<Fr[]>(std::move(bb::get_mem_slab(sizeof(Fr) * size)));
+        memory.raw_data = memory.aligned_memory.get();
     }
 
 #ifndef __wasm__

--- a/barretenberg/cpp/src/barretenberg/polynomials/backing_memory.hpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/backing_memory.hpp
@@ -30,99 +30,93 @@ extern std::atomic<size_t> current_storage_usage;
 // Parse storage size string (e.g., "500m", "2g", "1024k")
 size_t parse_size_string(const std::string& size_str);
 
-template <typename T> class AlignedMemory;
+template <typename Fr> struct BackingMemory {
+    // Common raw data pointer used by all storage types
+    Fr* raw_data = nullptr;
 
 #ifndef __wasm__
-template <typename T> class FileBackedMemory;
+    // File-backed data substruct with cleanup metadata
+    struct FileBackedData {
+        size_t file_size;
+        std::string filename;
+        int fd;
+        Fr* raw_data_ptr;
+
+        ~FileBackedData()
+        {
+            if (raw_data_ptr != nullptr && file_size > 0) {
+                munmap(raw_data_ptr, file_size);
+                current_storage_usage.fetch_sub(file_size);
+            }
+            if (fd >= 0) {
+                close(fd);
+            }
+            if (!filename.empty()) {
+                std::filesystem::remove(filename);
+            }
+        }
+    };
+    std::shared_ptr<FileBackedData> file_backed;
 #endif
 
-template <typename Fr> class BackingMemory {
-  public:
+    // Aligned memory data substruct
+    struct AlignedMemoryData {
+        // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays)
+        std::shared_ptr<Fr[]> data;
+    };
+    std::shared_ptr<AlignedMemoryData> aligned_memory;
+
     BackingMemory() = default;
 
-    BackingMemory(const BackingMemory&) = delete;            // delete copy constructor
-    BackingMemory& operator=(const BackingMemory&) = delete; // delete copy assignment
+    BackingMemory(const BackingMemory&) = default;
+    BackingMemory& operator=(const BackingMemory&) = default;
 
-    BackingMemory(BackingMemory&& other) = delete;            // delete move constructor
-    BackingMemory& operator=(const BackingMemory&&) = delete; // delete move assignment
+    BackingMemory(BackingMemory&& other) noexcept = default;
+    BackingMemory& operator=(BackingMemory&& other) noexcept = default;
 
-    virtual Fr* raw_data() = 0;
-
-    static std::shared_ptr<BackingMemory<Fr>> allocate(size_t size)
+    // Allocate memory, preferring file-backed if in low memory mode
+    static BackingMemory allocate(size_t size)
     {
+        BackingMemory memory;
 #ifndef __wasm__
         if (slow_low_memory) {
-            auto file_backed = try_allocate_file_backed(size);
-            if (file_backed) {
-                return file_backed;
+            if (try_allocate_file_backed(memory, size)) {
+                return memory;
             }
         }
 #endif
-        return std::shared_ptr<BackingMemory<Fr>>(new AlignedMemory<Fr>(size));
+        allocate_aligned(memory, size);
+        return memory;
     }
 
+    ~BackingMemory() = default;
+
   private:
-#ifndef __wasm__
-    static std::shared_ptr<BackingMemory<Fr>> try_allocate_file_backed(size_t size)
+    static void allocate_aligned(BackingMemory& memory, size_t size)
     {
+        auto aligned = std::make_shared<AlignedMemoryData>();
+        // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays)
+        aligned->data = std::static_pointer_cast<Fr[]>(std::move(bb::get_mem_slab(sizeof(Fr) * size)));
+        memory.raw_data = aligned->data.get();
+        memory.aligned_memory = std::move(aligned);
+    }
+
+#ifndef __wasm__
+    static bool try_allocate_file_backed(BackingMemory& memory, size_t size)
+    {
+        if (size == 0) {
+            return false;
+        }
+
         size_t required_bytes = size * sizeof(Fr);
         size_t current_usage = current_storage_usage.load();
 
         // Check if we're under the storage budget
         if (current_usage + required_bytes > storage_budget) {
-            return nullptr; // Over budget
+            return false;
         }
 
-        // Attempt to create FileBackedMemory without exceptions
-        // We'll need to modify FileBackedMemory constructor to be noexcept
-        auto file_backed = FileBackedMemory<Fr>::try_create(size);
-        if (file_backed) {
-            current_storage_usage.fetch_add(required_bytes);
-        }
-        return file_backed;
-    }
-#endif
-
-  public:
-    virtual ~BackingMemory() = default;
-};
-
-template <typename T> class AlignedMemory : public BackingMemory<T> {
-  public:
-    T* raw_data() { return data.get(); }
-
-  private:
-    AlignedMemory(size_t size)
-        : BackingMemory<T>()
-        // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays)
-        , data(std::static_pointer_cast<T[]>(std::move(bb::get_mem_slab(sizeof(T) * size))))
-    {}
-
-    // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays)
-    std::shared_ptr<T[]> data;
-
-    friend BackingMemory<T>;
-};
-
-#ifndef __wasm__
-template <typename T> class FileBackedMemory : public BackingMemory<T> {
-  public:
-    FileBackedMemory(const FileBackedMemory&) = delete;            // delete copy constructor
-    FileBackedMemory& operator=(const FileBackedMemory&) = delete; // delete copy assignment
-
-    FileBackedMemory(FileBackedMemory&& other) = delete;            // delete move constructor
-    FileBackedMemory& operator=(const FileBackedMemory&&) = delete; // delete move assignment
-
-    T* raw_data() { return memory; }
-
-    // Try to create file-backed memory, returns nullptr on failure
-    static std::shared_ptr<BackingMemory<T>> try_create(size_t size)
-    {
-        if (size == 0) {
-            return std::shared_ptr<BackingMemory<T>>(new FileBackedMemory<T>());
-        }
-
-        size_t file_size = size * sizeof(T);
+        size_t file_size = required_bytes;
         static std::atomic<size_t> file_counter{ 0 };
         size_t id = file_counter.fetch_add(1);
 
@@ -130,7 +124,6 @@ template <typename T> class FileBackedMemory : public BackingMemory<T> {
         try {
             temp_dir = std::filesystem::temp_directory_path();
         } catch (const std::exception&) {
-            // Fallback to current directory if temp_directory_path() fails
             temp_dir = std::filesystem::current_path();
         }
 
@@ -138,66 +131,34 @@ template <typename T> class FileBackedMemory : public BackingMemory<T> {
 
         int fd = open(filename.c_str(), O_CREAT | O_RDWR | O_TRUNC, 0644);
         if (fd < 0) {
-            return nullptr; // Failed to create file
+            return false;
         }
 
-        // Set file size
         if (ftruncate(fd, static_cast<off_t>(file_size)) != 0) {
             close(fd);
             std::filesystem::remove(filename);
-            return nullptr; // Failed to set file size
+            return false;
         }
 
-        // Memory map the file
         void* addr = mmap(nullptr, file_size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
         if (addr == MAP_FAILED) {
             close(fd);
             std::filesystem::remove(filename);
-            return nullptr; // Failed to mmap
+            return false;
         }
 
-        // Create the FileBackedMemory object using private constructor
-        auto memory = new FileBackedMemory<T>();
-        memory->file_size = file_size;
-        memory->filename = filename;
-        memory->fd = fd;
-        memory->memory = static_cast<T*>(addr);
+        auto file_backed_data = std::make_shared<FileBackedData>();
+        file_backed_data->file_size = file_size;
+        file_backed_data->filename = filename;
+        file_backed_data->fd = fd;
+        file_backed_data->raw_data_ptr = static_cast<Fr*>(addr);
 
-        return std::shared_ptr<BackingMemory<T>>(memory);
+        memory.raw_data = static_cast<Fr*>(addr);
+        memory.file_backed = std::move(file_backed_data);
+
+        current_storage_usage.fetch_add(required_bytes);
+
+        return true;
     }
-
-    ~FileBackedMemory()
-    {
-        if (file_size == 0) {
-            return;
-        }
-        if (memory != nullptr && file_size > 0) {
-            munmap(memory, file_size);
-            // Decrement storage usage when FileBackedMemory is freed
-            current_storage_usage.fetch_sub(file_size);
-        }
-        if (fd >= 0) {
-            close(fd);
-        }
-        if (!filename.empty()) {
-            std::filesystem::remove(filename);
-        }
-    }
-
-  private:
-    // Default constructor for empty file-backed memory
-    FileBackedMemory()
-        : BackingMemory<T>()
-        , file_size(0)
-        , fd(-1)
-        , memory(nullptr)
-    {}
-
-    size_t file_size;
-    std::string filename;
-    int fd;
-    T* memory;
-
-    friend BackingMemory<T>;
+#endif
 };
-#endif // __EMSCRIPTEN___

--- a/barretenberg/cpp/src/barretenberg/polynomials/polynomial.cpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/polynomial.cpp
@@ -70,7 +70,7 @@ void Polynomial<Fr>::allocate_backing_memory(size_t size, size_t virtual_size, s
  */
 template <typename Fr> Polynomial<Fr>::Polynomial(size_t size, size_t virtual_size, size_t start_index)
 {
-
+    BB_BENCH_NAME("Polynomial::Polynomial(size_t, size_t, size_t)");
     allocate_backing_memory(size, virtual_size, start_index);
 
     size_t num_threads = calculate_num_threads(size);

--- a/barretenberg/cpp/src/barretenberg/polynomials/polynomial.cpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/polynomial.cpp
@@ -6,6 +6,7 @@
 
 #include "polynomial.hpp"
 #include "barretenberg/common/assert.hpp"
+#include "barretenberg/common/bb_bench.hpp"
 #include "barretenberg/common/slab_allocator.hpp"
 #include "barretenberg/common/thread.hpp"
 #include "barretenberg/numeric/bitop/get_msb.hpp"
@@ -50,6 +51,7 @@ SharedShiftedVirtualZeroesArray<Fr> _clone(const SharedShiftedVirtualZeroesArray
 template <typename Fr>
 void Polynomial<Fr>::allocate_backing_memory(size_t size, size_t virtual_size, size_t start_index)
 {
+    BB_BENCH_NAME("Polynomial::allocate_backing_memory");
     BB_ASSERT_LTE(start_index + size, virtual_size);
     coefficients_ = SharedShiftedVirtualZeroesArray<Fr>{
         start_index,        /* start index, used for shifted polynomials and offset 'islands' of non-zeroes */

--- a/barretenberg/cpp/src/barretenberg/polynomials/polynomial.cpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/polynomial.cpp
@@ -33,17 +33,18 @@ SharedShiftedVirtualZeroesArray<Fr> _clone(const SharedShiftedVirtualZeroesArray
                                            size_t left_expansion = 0)
 {
     size_t expanded_size = array.size() + right_expansion + left_expansion;
-    std::shared_ptr<BackingMemory<Fr>> backing_clone = BackingMemory<Fr>::allocate(expanded_size);
+    BackingMemory<Fr> backing_clone = BackingMemory<Fr>::allocate(expanded_size);
     // zero any left extensions to the array
-    memset(static_cast<void*>(backing_clone->raw_data()), 0, sizeof(Fr) * left_expansion);
+    memset(static_cast<void*>(backing_clone.raw_data), 0, sizeof(Fr) * left_expansion);
     // copy our cloned array over
-    memcpy(static_cast<void*>(backing_clone->raw_data() + left_expansion),
+    memcpy(static_cast<void*>(backing_clone.raw_data + left_expansion),
            static_cast<const void*>(array.data()),
            sizeof(Fr) * array.size());
     // zero any right extensions to the array
-    memset(
-        static_cast<void*>(backing_clone->raw_data() + left_expansion + array.size()), 0, sizeof(Fr) * right_expansion);
-    return { array.start_ - left_expansion, array.end_ + right_expansion, array.virtual_size_, backing_clone };
+    memset(static_cast<void*>(backing_clone.raw_data + left_expansion + array.size()), 0, sizeof(Fr) * right_expansion);
+    return {
+        array.start_ - left_expansion, array.end_ + right_expansion, array.virtual_size_, std::move(backing_clone)
+    };
 }
 
 template <typename Fr>

--- a/barretenberg/cpp/src/barretenberg/polynomials/polynomial.hpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/polynomial.hpp
@@ -36,14 +36,14 @@ template <typename Fr> struct PolynomialSpan {
     size_t size() const { return span.size(); }
     Fr& operator[](size_t index)
     {
-        BB_ASSERT_GTE(index, start_index);
-        BB_ASSERT_LT(index, end_index());
+        ASSERT_DEBUG(index >= start_index);
+        ASSERT_DEBUG(index < end_index());
         return span[index - start_index];
     }
     const Fr& operator[](size_t index) const
     {
-        BB_ASSERT_GTE(index, start_index);
-        BB_ASSERT_LT(index, end_index());
+        ASSERT_DEBUG(index >= start_index);
+        ASSERT_DEBUG(index < end_index());
         return span[index - start_index];
     }
     PolynomialSpan subspan(size_t offset, size_t length)

--- a/barretenberg/cpp/src/barretenberg/polynomials/polynomial.hpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/polynomial.hpp
@@ -102,10 +102,7 @@ template <typename Fr> class Polynomial {
     {}
 
     /**
-     * @brief Utility to efficiently construct a shift from the original polynomial.
-     *
-     * @param virtual_size the size of the polynomial to be shifted
-     * @return Polynomial
+     * @brief Utility to create a shiftable polynomial of given virtual size.
      */
     static Polynomial shiftable(size_t virtual_size)
     {

--- a/barretenberg/cpp/src/barretenberg/polynomials/shared_shifted_virtual_zeroes_array.hpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/shared_shifted_virtual_zeroes_array.hpp
@@ -77,8 +77,8 @@ template <typename T> struct SharedShiftedVirtualZeroesArray {
      *
      * @return A pointer to the beginning of the memory-backed range.
      */
-    T* data() { return backing_memory_ ? backing_memory_->raw_data() : nullptr; }
-    const T* data() const { return backing_memory_ ? backing_memory_->raw_data() : nullptr; }
+    T* data() { return backing_memory.raw_data; }
+    const T* data() const { return backing_memory.raw_data; }
     // Our size is end_ - start_. Note that we need to offset end_ when doing a shift to
     // correctly maintain the size.
     size_t size() const { return end_ - start_; }
@@ -135,10 +135,10 @@ template <typename T> struct SharedShiftedVirtualZeroesArray {
     size_t virtual_size_ = 0;
 
     /**
-     * @brief Shared pointer to the underlying memory array.
+     * @brief The underlying memory storage.
      *
-     * The memory is allocated for at least the range [start_, end_). It is shared across instances to allow
-     * for efficient memory use when arrays are shifted or otherwise manipulated.
+     * The memory is allocated for at least the range [start_, end_). Shared pointers within BackingMemory
+     * allow for efficient memory use when arrays are shifted or otherwise manipulated.
      */
-    std::shared_ptr<BackingMemory<T>> backing_memory_;
+    BackingMemory<T> backing_memory;
 };

--- a/barretenberg/cpp/src/barretenberg/polynomials/shared_shifted_virtual_zeroes_array.hpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/shared_shifted_virtual_zeroes_array.hpp
@@ -37,8 +37,8 @@ template <typename T> struct SharedShiftedVirtualZeroesArray {
      */
     void set(size_t index, const T& value)
     {
-        BB_ASSERT_GTE(index, start_);
-        BB_ASSERT_LT(index, end_);
+        ASSERT_DEBUG(index >= start_);
+        ASSERT_DEBUG(index < end_);
         data()[index - start_] = value;
     }
 
@@ -64,7 +64,7 @@ template <typename T> struct SharedShiftedVirtualZeroesArray {
                  ", virtual_padding = ",
                  virtual_padding);
         }
-        BB_ASSERT_LT(index, virtual_size_ + virtual_padding);
+        ASSERT_DEBUG(index < virtual_size_ + virtual_padding);
         if (index >= start_ && index < end_) {
             return data()[index - start_];
         }
@@ -93,15 +93,15 @@ template <typename T> struct SharedShiftedVirtualZeroesArray {
 
     T& operator[](size_t index)
     {
-        BB_ASSERT_GTE(index, start_);
-        BB_ASSERT_LT(index, end_);
+        ASSERT_DEBUG(index >= start_);
+        ASSERT_DEBUG(index < end_);
         return data()[index - start_];
     }
     // get() is more useful, but for completeness with the non-const operator[]
     const T& operator[](size_t index) const
     {
-        BB_ASSERT_GTE(index, start_);
-        BB_ASSERT_LT(index, end_);
+        ASSERT_DEBUG(index >= start_);
+        ASSERT_DEBUG(index < end_);
         return data()[index - start_];
     }
 

--- a/barretenberg/cpp/src/barretenberg/polynomials/shared_shifted_virtual_zeroes_array.hpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/shared_shifted_virtual_zeroes_array.hpp
@@ -56,14 +56,6 @@ template <typename T> struct SharedShiftedVirtualZeroesArray {
     const T& get(size_t index, size_t virtual_padding = 0) const
     {
         static const T zero{};
-        if (index >= virtual_size_ + virtual_padding) {
-            info("BAD GET(): index = ",
-                 index,
-                 ", virtual_size_ = ",
-                 virtual_size_,
-                 ", virtual_padding = ",
-                 virtual_padding);
-        }
         ASSERT_DEBUG(index < virtual_size_ + virtual_padding);
         if (index >= start_ && index < end_) {
             return data()[index - start_];
@@ -77,8 +69,8 @@ template <typename T> struct SharedShiftedVirtualZeroesArray {
      *
      * @return A pointer to the beginning of the memory-backed range.
      */
-    T* data() { return backing_memory.raw_data; }
-    const T* data() const { return backing_memory.raw_data; }
+    T* data() { return backing_memory_.raw_data; }
+    const T* data() const { return backing_memory_.raw_data; }
     // Our size is end_ - start_. Note that we need to offset end_ when doing a shift to
     // correctly maintain the size.
     size_t size() const { return end_ - start_; }
@@ -140,5 +132,5 @@ template <typename T> struct SharedShiftedVirtualZeroesArray {
      * The memory is allocated for at least the range [start_, end_). Shared pointers within BackingMemory
      * allow for efficient memory use when arrays are shifted or otherwise manipulated.
      */
-    BackingMemory<T> backing_memory;
+    BackingMemory<T> backing_memory_;
 };

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/byte_array/byte_array.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/byte_array/byte_array.cpp
@@ -277,7 +277,7 @@ template <typename Builder> byte_array<Builder>& byte_array<Builder>::write_at(b
  */
 template <typename Builder> byte_array<Builder> byte_array<Builder>::slice(size_t offset) const
 {
-    BB_ASSERT_LT(offset, values.size());
+    ASSERT_DEBUG(offset < values.size());
     return byte_array(context, bytes_t(values.begin() + static_cast<ptrdiff_t>(offset), values.end()));
 }
 
@@ -287,9 +287,9 @@ template <typename Builder> byte_array<Builder> byte_array<Builder>::slice(size_
  **/
 template <typename Builder> byte_array<Builder> byte_array<Builder>::slice(size_t offset, size_t length) const
 {
-    BB_ASSERT_LT(offset, values.size());
+    ASSERT_DEBUG(offset < values.size());
     // it's <= cause vector constructor doesn't include end point
-    BB_ASSERT_LTE(length, values.size() - offset);
+    ASSERT_DEBUG(length <= values.size() - offset);
     auto start = values.begin() + static_cast<ptrdiff_t>(offset);
     auto end = values.begin() + static_cast<ptrdiff_t>((offset + length));
     return byte_array(context, bytes_t(start, end));

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/field/field.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/field/field.cpp
@@ -832,7 +832,7 @@ template <typename Builder> bb::fr field_t<Builder>::get_value() const
         ASSERT(context);
         return (multiplicative_constant * context->get_variable(witness_index)) + additive_constant;
     }
-    BB_ASSERT_EQ(multiplicative_constant, bb::fr::one());
+    ASSERT_DEBUG(multiplicative_constant == bb::fr::one());
     // A constant field_t's value is tracked wholly by its additive_constant member.
     return additive_constant;
 }

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/field/field.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/field/field.hpp
@@ -28,7 +28,7 @@ template <typename T, typename... Ts> T* validate_context(T* first, Ts*... rest)
     if (!tail) {
         return first; // tail is null, use first
     }
-    ASSERT(first == tail && "Pointers refer to different builder objects!");
+    ASSERT_DEBUG(first == tail && "Pointers refer to different builder objects!");
     return first;
 }
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/field/field.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/field/field.hpp
@@ -28,7 +28,7 @@ template <typename T, typename... Ts> T* validate_context(T* first, Ts*... rest)
     if (!tail) {
         return first; // tail is null, use first
     }
-    ASSERT_DEBUG(first == tail && "Pointers refer to different builder objects!");
+    ASSERT(first == tail, "Pointers refer to different builder objects!");
     return first;
 }
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/field/field.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/field/field.test.cpp
@@ -1696,10 +1696,12 @@ TYPED_TEST(stdlib_field, test_multiplicative_constant_regression)
 {
     TestFixture::test_multiplicative_constant_regression();
 }
+#ifndef AZTEC_NO_ORIGIN_TAGS
 TYPED_TEST(stdlib_field, test_origin_tag_consistency)
 {
     TestFixture::test_origin_tag_consistency();
 }
+#endif
 TYPED_TEST(stdlib_field, test_postfix_increment)
 {
     TestFixture::test_postfix_increment();

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/field/field.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/field/field.test.cpp
@@ -1696,12 +1696,10 @@ TYPED_TEST(stdlib_field, test_multiplicative_constant_regression)
 {
     TestFixture::test_multiplicative_constant_regression();
 }
-#ifndef AZTEC_NO_ORIGIN_TAGS
 TYPED_TEST(stdlib_field, test_origin_tag_consistency)
 {
     TestFixture::test_origin_tag_consistency();
 }
-#endif
 TYPED_TEST(stdlib_field, test_postfix_increment)
 {
     TestFixture::test_postfix_increment();

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/group/cycle_group.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/group/cycle_group.test.cpp
@@ -559,7 +559,6 @@ TYPED_TEST(CycleGroupTest, TestDblMixedConstantWitness)
     // The issue is that when we have mixed constant/witness coordinates, the dbl()
     // implementation tries to access witness indices that don't exist for constants
 
-    // In test builds, assertions throw exceptions rather than terminating
     EXPECT_THROW(
         { [[maybe_unused]] cycle_group_ct result = a.dbl(); },
         std::exception // Expect exception from assertion failure

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/circuit_builder_base.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/circuit_builder_base.hpp
@@ -119,7 +119,7 @@ template <typename FF_> class CircuitBuilderBase {
      * */
     inline FF get_variable(const uint32_t index) const
     {
-        BB_ASSERT_GT(variables.size(), real_variable_index[index]);
+        ASSERT_DEBUG(variables.size() > real_variable_index[index]);
         return variables[real_variable_index[index]];
     }
 
@@ -136,7 +136,7 @@ template <typename FF_> class CircuitBuilderBase {
      */
     inline void set_variable(const uint32_t index, const FF& value)
     {
-        BB_ASSERT_GT(variables.size(), real_variable_index[index]);
+        ASSERT_DEBUG(variables.size() > real_variable_index[index]);
         variables[real_variable_index[index]] = value;
     }
 
@@ -150,7 +150,7 @@ template <typename FF_> class CircuitBuilderBase {
      * */
     inline const FF& get_variable_reference(const uint32_t index) const
     {
-        BB_ASSERT_GT(variables.size(), index);
+        ASSERT_DEBUG(variables.size() > index);
         return variables[real_variable_index[index]];
     }
 

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/circuit_builder_base_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/circuit_builder_base_impl.hpp
@@ -213,7 +213,7 @@ template <typename FF_>
 void CircuitBuilderBase<FF_>::assert_valid_variables(const std::vector<uint32_t>& variable_indices)
 {
     for (const auto& variable_index : variable_indices) {
-        ASSERT_DEBUG(variable_index < variables.size());
+        BB_ASSERT_LT(variable_index, variables.size());
     }
 }
 

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/circuit_builder_base_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/circuit_builder_base_impl.hpp
@@ -93,7 +93,7 @@ template <typename FF_> uint32_t CircuitBuilderBase<FF_>::add_variable(const FF&
 
 template <typename FF_> void CircuitBuilderBase<FF_>::set_variable_name(uint32_t index, const std::string& name)
 {
-    BB_ASSERT_GT(variables.size(), index);
+    ASSERT_DEBUG(variables.size() > index);
     uint32_t first_idx = get_first_variable_in_class(index);
 
     if (variable_names.contains(first_idx)) {
@@ -213,7 +213,7 @@ template <typename FF_>
 void CircuitBuilderBase<FF_>::assert_valid_variables(const std::vector<uint32_t>& variable_indices)
 {
     for (const auto& variable_index : variable_indices) {
-        BB_ASSERT_LT(variable_index, variables.size());
+        ASSERT_DEBUG(variable_index < variables.size());
     }
 }
 

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/plookup_tables/types.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/plookup_tables/types.hpp
@@ -333,7 +333,7 @@ struct LookupHashTable {
     Value operator[](const Key& key) const
     {
         auto it = index_map.find(key);
-        ASSERT(it != index_map.end(), "LookupHashTable: Key not found!");
+        ASSERT_DEBUG(it != index_map.end(), "LookupHashTable: Key not found!");
         return it->second;
     }
 
@@ -394,8 +394,8 @@ struct BasicTable {
 
     size_t size() const
     {
-        BB_ASSERT_EQ(column_1.size(), column_2.size());
-        BB_ASSERT_EQ(column_2.size(), column_3.size());
+        ASSERT_DEBUG(column_1.size() == column_2.size());
+        ASSERT_DEBUG(column_2.size() == column_3.size());
         return column_1.size();
     }
 };

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.hpp
@@ -337,7 +337,7 @@ class UltraCircuitBuilder_ : public CircuitBuilderBase<typename ExecutionTrace_:
             const auto& block_selectors = block.get_selectors();
             size_t nominal_size = block_selectors[0].size();
             for (size_t idx = 1; idx < block_selectors.size(); ++idx) {
-                ASSERT_DEBUG(block_selectors[idx].size() == nominal_size);
+                BB_ASSERT_EQ(block_selectors[idx].size(), nominal_size);
             }
         }
 

--- a/barretenberg/cpp/src/barretenberg/transcript/origin_tag.hpp
+++ b/barretenberg/cpp/src/barretenberg/transcript/origin_tag.hpp
@@ -23,10 +23,6 @@
 // TODO(https://github.com/AztecProtocol/barretenberg/issues/1532): Re-enable this once we resolve these issues.
 #define DISABLE_CHILD_TAG_CHECKS
 
-// Disable origin tags in release builds
-#ifdef NDEBUG
-#define AZTEC_NO_ORIGIN_TAGS
-#endif
 #define STANDARD_TESTING_TAGS /*Tags reused in tests*/                                                                 \
     const size_t parent_id = 0;                                                                                        \
     [[maybe_unused]] const auto clear_tag = OriginTag();                                                               \

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/ecc.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/ecc.cpp
@@ -25,7 +25,7 @@ EmbeddedCurvePoint Ecc::add(const EmbeddedCurvePoint& p, const EmbeddedCurvePoin
 EmbeddedCurvePoint Ecc::scalar_mul(const EmbeddedCurvePoint& point, const FF& scalar)
 {
     // This is bad - the scalar mul circuit assumes that the point is on the curve.
-    assert(point.on_curve() && "Point must be on the curve for scalar multiplication");
+    ASSERT(point.on_curve(), "Point must be on the curve for scalar multiplication");
 
     auto intermediate_states = std::vector<ScalarMulIntermediateState>(254);
     auto bits = to_radix.to_le_bits(scalar, 254).first;

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/ecc.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/ecc.test.cpp
@@ -2,6 +2,7 @@
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include <stdexcept>
 
 #include "barretenberg/vm2/common/aztec_constants.hpp"
 #include "barretenberg/vm2/common/field.hpp"
@@ -131,7 +132,8 @@ TEST(AvmSimulationEccDeathTest, ScalarMulNotOnCurve)
 
     FF scalar("0x009242167ec31949c00cbe441cd36757607406e87844fa2c8c4364a4403e66d7");
 
-    ASSERT_DEATH(ecc.scalar_mul(p, scalar), "Point must be on the curve for scalar multiplication");
+    // prints: Point must be on the curve for scalar multiplication
+    ASSERT_THROW(ecc.scalar_mul(p, scalar), std::runtime_error);
 }
 
 TEST(AvmSimulationEccTest, AddWithMemory)

--- a/ci3/aws_request_instance_type
+++ b/ci3/aws_request_instance_type
@@ -36,7 +36,7 @@ launch_spec=$(cat <<EOF
     {
       "DeviceName": "/dev/sda1",
       "Ebs": {
-        "VolumeSize": 96,
+        "VolumeSize": 128,
         "VolumeType": "gp3",
         "Throughput": 1000,
         "Iops": 4000


### PR DESCRIPTION
We had costly indirection in polynomials and asserts in things called millions/billions of times. Refactor the polynomial backing memory and relegate very common asserts to debug mode.