### PR TITLE
chore: Track l1 tx publisher state per tx

### DIFF
--- a/yarn-project/blob-lib/src/types.ts
+++ b/yarn-project/blob-lib/src/types.ts
@@ -1,3 +1,14 @@
 export * from './sponge_blob.js';
 
 // TODO: Separate functions that use c-kzg from classes and export those classes here.
+
+/**
+ * Type definition for the KZG instance returned by Blob.getViemKzgInstance().
+ * Contains the cryptographic functions needed for blob commitment and proof generation.
+ */
+export interface BlobKzgInstance {
+  /** Function to compute KZG commitment from blob data */
+  blobToKzgCommitment(blob: Uint8Array): Uint8Array;
+  /** Function to compute KZG proof for blob data */
+  computeBlobKzgProof(blob: Uint8Array, commitment: Uint8Array): Uint8Array;
+}

--- a/yarn-project/ethereum/src/contracts/governance_proposer.ts
+++ b/yarn-project/ethereum/src/contracts/governance_proposer.ts
@@ -11,7 +11,7 @@ import {
   getContract,
 } from 'viem';
 
-import type { GasPrice, L1TxRequest, L1TxUtils } from '../l1_tx_utils/index.js';
+import type { L1TxRequest, L1TxUtils } from '../l1_tx_utils/index.js';
 import type { ViemClient } from '../types.js';
 import { type IEmpireBase, encodeSignal, encodeSignalWithSignature, signSignalWithSig } from './empire_base.js';
 import { extractProposalIdFromLogs } from './governance.js';
@@ -102,10 +102,9 @@ export class GovernanceProposerContract implements IEmpireBase {
     l1TxUtils: L1TxUtils,
   ): Promise<{
     receipt: TransactionReceipt;
-    gasPrice: GasPrice;
     proposalId: bigint;
   }> {
-    const { receipt, gasPrice } = await l1TxUtils.sendAndMonitorTransaction({
+    const { receipt } = await l1TxUtils.sendAndMonitorTransaction({
       to: this.address.toString(),
       data: encodeFunctionData({
         abi: this.proposer.abi,
@@ -114,6 +113,6 @@ export class GovernanceProposerContract implements IEmpireBase {
       }),
     });
     const proposalId = extractProposalIdFromLogs(receipt.logs);
-    return { receipt, gasPrice, proposalId };
+    return { receipt, proposalId };
   }
 }

--- a/yarn-project/ethereum/src/contracts/multicall.ts
+++ b/yarn-project/ethereum/src/contracts/multicall.ts
@@ -36,7 +36,7 @@ export class Multicall3 {
     const encodedForwarderData = encodeFunctionData(forwarderFunctionData);
 
     try {
-      const { receipt, gasPrice } = await l1TxUtils.sendAndMonitorTransaction(
+      const { receipt, state } = await l1TxUtils.sendAndMonitorTransaction(
         {
           to: MULTI_CALL_3_ADDRESS,
           data: encodedForwarderData,
@@ -47,7 +47,7 @@ export class Multicall3 {
 
       if (receipt.status === 'success') {
         const stats = await l1TxUtils.getTransactionStats(receipt.transactionHash);
-        return { receipt, gasPrice, stats };
+        return { receipt, stats };
       } else {
         logger.error('Forwarder transaction failed', undefined, { receipt });
 
@@ -59,7 +59,7 @@ export class Multicall3 {
         let errorMsg: string | undefined;
 
         if (blobConfig) {
-          const maxFeePerBlobGas = blobConfig.maxFeePerBlobGas ?? gasPrice.maxFeePerBlobGas;
+          const maxFeePerBlobGas = blobConfig.maxFeePerBlobGas ?? state.gasPrice.maxFeePerBlobGas;
           if (maxFeePerBlobGas === undefined) {
             errorMsg = 'maxFeePerBlobGas is required to get the error message';
           } else {
@@ -90,7 +90,7 @@ export class Multicall3 {
           errorMsg = await l1TxUtils.tryGetErrorFromRevertedTx(encodedForwarderData, args, undefined, []);
         }
 
-        return { receipt, gasPrice, errorMsg };
+        return { receipt, errorMsg };
       }
     } catch (err) {
       if (err instanceof TimeoutError) {

--- a/yarn-project/ethereum/src/deploy_l1_contracts.ts
+++ b/yarn-project/ethereum/src/deploy_l1_contracts.ts
@@ -1449,7 +1449,11 @@ export class L1Deployer {
     tx: L1TxRequest,
     options?: L1GasConfig,
   ): Promise<{ txHash: Hex; gasLimit: bigint; gasPrice: GasPrice }> {
-    return this.l1TxUtils.sendTransaction(tx, options);
+    return this.l1TxUtils.sendTransaction(tx, options).then(({ txHash, state }) => ({
+      txHash,
+      gasLimit: state.gasLimit,
+      gasPrice: state.gasPrice,
+    }));
   }
 }
 

--- a/yarn-project/ethereum/src/l1_tx_utils/factory.ts
+++ b/yarn-project/ethereum/src/l1_tx_utils/factory.ts
@@ -13,7 +13,7 @@ import type { SigningCallback } from './types.js';
 
 export function createL1TxUtilsFromViemWallet(
   client: ExtendedViemWalletClient,
-  logger: Logger = createLogger('L1TxUtils'),
+  logger: Logger = createLogger('l1-tx-utils'),
   dateProvider: DateProvider = new DateProvider(),
   config?: Partial<L1TxUtilsConfig>,
   debugMaxGasLimit: boolean = false,
@@ -32,7 +32,7 @@ export function createL1TxUtilsFromViemWallet(
 export function createL1TxUtilsFromEthSigner(
   client: ViemClient,
   signer: EthSigner,
-  logger: Logger = createLogger('L1TxUtils'),
+  logger: Logger = createLogger('l1-tx-utils'),
   dateProvider: DateProvider = new DateProvider(),
   config?: Partial<L1TxUtilsConfig>,
   debugMaxGasLimit: boolean = false,

--- a/yarn-project/ethereum/src/l1_tx_utils/l1_tx_utils_with_blobs.ts
+++ b/yarn-project/ethereum/src/l1_tx_utils/l1_tx_utils_with_blobs.ts
@@ -3,113 +3,22 @@ import { EthAddress } from '@aztec/foundation/eth-address';
 import { type Logger, createLogger } from '@aztec/foundation/log';
 import { DateProvider } from '@aztec/foundation/timer';
 
-import { type Hex, type TransactionSerializable, formatGwei } from 'viem';
+import type { TransactionSerializable } from 'viem';
 
 import type { EthSigner } from '../eth-signer/eth-signer.js';
 import type { ExtendedViemWalletClient, ViemClient } from '../types.js';
 import type { L1TxUtilsConfig } from './config.js';
 import { L1TxUtils } from './l1_tx_utils.js';
 import { createViemSigner } from './signer.js';
-import type { GasPrice, SigningCallback } from './types.js';
+import type { L1BlobInputs, SigningCallback } from './types.js';
 
+/** Extends L1TxUtils with the capability to cancel blobs. This needs to be a separate class so we don't require a dependency on blob-lib unnecessarily. */
 export class L1TxUtilsWithBlobs extends L1TxUtils {
-  /**
-   * Attempts to cancel a transaction by sending a 0-value tx to self with same nonce but higher gas prices
-   * @param nonce - The nonce of the transaction to cancel
-   * @param allVersions - Hashes of all transactions submitted under the same nonce (any of them could mine)
-   * @param previousGasPrice - The gas price of the previous transaction
-   * @param attempts - The number of attempts to cancel the transaction
-   * @returns The hash of the cancellation transaction
-   */
-  protected override async attemptTxCancellation(
-    currentTxHash: Hex,
-    nonce: number,
-    allVersions: Set<Hex>,
-    isBlobTx = false,
-    previousGasPrice?: GasPrice,
-    attempts = 0,
-  ) {
-    // Get gas price with higher priority fee for cancellation
-    const cancelGasPrice = await this.getGasPrice(
-      {
-        ...this.config,
-        // Use high bump for cancellation to ensure it replaces the original tx
-        priorityFeeRetryBumpPercentage: 150, // 150% bump should be enough to replace any tx
-      },
-      isBlobTx,
-      attempts + 1,
-      previousGasPrice,
-    );
-
-    this.logger?.info(`Attempting to cancel blob L1 transaction ${currentTxHash} with nonce ${nonce}`, {
-      maxFeePerGas: formatGwei(cancelGasPrice.maxFeePerGas),
-      maxPriorityFeePerGas: formatGwei(cancelGasPrice.maxPriorityFeePerGas),
-      maxFeePerBlobGas:
-        cancelGasPrice.maxFeePerBlobGas === undefined ? undefined : formatGwei(cancelGasPrice.maxFeePerBlobGas),
-    });
-    const request = {
-      to: this.getSenderAddress().toString(),
-      value: 0n,
-    };
-
-    // Send 0-value tx to self with higher gas price
-    if (!isBlobTx) {
-      const txData = {
-        ...request,
-        nonce,
-        gas: 21_000n, // Standard ETH transfer gas
-        maxFeePerGas: cancelGasPrice.maxFeePerGas,
-        maxPriorityFeePerGas: cancelGasPrice.maxPriorityFeePerGas,
-      };
-      const signedRequest = await this.prepareSignedTransaction(txData);
-      const cancelTxHash = await this.client.sendRawTransaction({ serializedTransaction: signedRequest });
-
-      this.logger?.info(`Sent cancellation tx ${cancelTxHash} for timed out tx ${currentTxHash}`);
-
-      const receipt = await this.monitorTransaction(
-        request,
-        cancelTxHash,
-        allVersions,
-        { gasLimit: 21_000n },
-        undefined,
-        undefined,
-        true,
-      );
-
-      return receipt.transactionHash;
-    } else {
-      const blobData = new Uint8Array(131072).fill(0);
-      const kzg = Blob.getViemKzgInstance();
-      const blobInputs = {
-        blobs: [blobData],
-        kzg,
-        maxFeePerBlobGas: cancelGasPrice.maxFeePerBlobGas!,
-      };
-      const txData = {
-        ...request,
-        ...blobInputs,
-        nonce,
-        gas: 21_000n,
-        maxFeePerGas: cancelGasPrice.maxFeePerGas,
-        maxPriorityFeePerGas: cancelGasPrice.maxPriorityFeePerGas,
-      };
-      const signedRequest = await this.prepareSignedTransaction(txData);
-      const cancelTxHash = await this.client.sendRawTransaction({ serializedTransaction: signedRequest });
-
-      this.logger?.info(`Sent cancellation tx ${cancelTxHash} for timed out tx ${currentTxHash}`);
-
-      const receipt = await this.monitorTransaction(
-        request,
-        cancelTxHash,
-        allVersions,
-        { gasLimit: 21_000n },
-        undefined,
-        blobInputs,
-        true,
-      );
-
-      return receipt.transactionHash;
-    }
+  /** Makes empty blob inputs for the cancellation tx. */
+  protected override makeEmptyBlobInputs(maxFeePerBlobGas: bigint): Required<L1BlobInputs> {
+    const blobData = new Uint8Array(131072).fill(0);
+    const kzg = Blob.getViemKzgInstance();
+    return { blobs: [blobData], kzg, maxFeePerBlobGas };
   }
 }
 

--- a/yarn-project/ethereum/src/l1_tx_utils/readonly_l1_tx_utils.ts
+++ b/yarn-project/ethereum/src/l1_tx_utils/readonly_l1_tx_utils.ts
@@ -34,7 +34,7 @@ import type { GasPrice, L1BlobInputs, L1TxRequest, TransactionStats } from './ty
 import { getCalldataGasUsage, tryGetCustomErrorNameContractFunction } from './utils.js';
 
 export class ReadOnlyL1TxUtils {
-  public readonly config: L1TxUtilsConfig;
+  public config: L1TxUtilsConfig;
   protected interrupted = false;
 
   constructor(

--- a/yarn-project/ethereum/src/l1_tx_utils/types.ts
+++ b/yarn-project/ethereum/src/l1_tx_utils/types.ts
@@ -1,7 +1,8 @@
+import type { BlobKzgInstance } from '@aztec/blob-lib/types';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import type { ViemTransactionSignature } from '@aztec/foundation/eth-signature';
 
-import type { Abi, Address, Hex, TransactionSerializable } from 'viem';
+import type { Abi, Address, Hex, TransactionReceipt, TransactionSerializable } from 'viem';
 
 import type { L1TxUtilsConfig } from './config.js';
 
@@ -16,7 +17,7 @@ export type L1GasConfig = Partial<L1TxUtilsConfig> & { gasLimit?: bigint; txTime
 
 export interface L1BlobInputs {
   blobs: Uint8Array[];
-  kzg: any;
+  kzg: BlobKzgInstance;
   maxFeePerBlobGas?: bigint;
 }
 
@@ -45,6 +46,19 @@ export enum TxUtilsState {
   NOT_MINED,
   MINED,
 }
+
+export type L1TxState = {
+  txHashes: Hex[];
+  cancelTxHashes: Hex[];
+  gasLimit: bigint;
+  gasPrice: GasPrice;
+  txConfig: L1GasConfig;
+  request: L1TxRequest;
+  status: TxUtilsState;
+  nonce: number;
+  receipt?: TransactionReceipt;
+  blobInputs: L1BlobInputs | undefined;
+};
 
 export type SigningCallback = (
   transaction: TransactionSerializable,

--- a/yarn-project/ethereum/src/publisher_manager.test.ts
+++ b/yarn-project/ethereum/src/publisher_manager.test.ts
@@ -1,13 +1,13 @@
+import { times } from '@aztec/foundation/collection';
 import { EthAddress } from '@aztec/foundation/eth-address';
 
 import { jest } from '@jest/globals';
-import { type MockProxy, mock } from 'jest-mock-extended';
 
 import { L1TxUtils, TxUtilsState } from './l1_tx_utils/index.js';
 import { PublisherManager } from './publisher_manager.js';
 
 describe('PublisherManager', () => {
-  let mockPublishers: MockProxy<L1TxUtils>[];
+  let mockPublishers: (TestL1TxUtils & L1TxUtils)[];
   let publisherManager: PublisherManager<L1TxUtils>;
 
   beforeEach(() => {
@@ -40,17 +40,17 @@ describe('PublisherManager', () => {
     });
 
     it('should throw error when all publishers are in invalid states', async () => {
-      mockPublishers[0]['state'] = TxUtilsState.SENT;
-      mockPublishers[1]['state'] = TxUtilsState.CANCELLED;
-      mockPublishers[2]['state'] = TxUtilsState.NOT_MINED;
+      mockPublishers[0].state = TxUtilsState.SENT;
+      mockPublishers[1].state = TxUtilsState.CANCELLED;
+      mockPublishers[2].state = TxUtilsState.NOT_MINED;
 
       await expect(publisherManager.getAvailablePublisher()).rejects.toThrow('Failed to find an available publisher.');
     });
 
     it('should return a publisher in invalid state if allowed', async () => {
-      mockPublishers[0]['state'] = TxUtilsState.SENT;
-      mockPublishers[1]['state'] = TxUtilsState.CANCELLED;
-      mockPublishers[2]['state'] = TxUtilsState.NOT_MINED;
+      mockPublishers[0].state = TxUtilsState.SENT;
+      mockPublishers[1].state = TxUtilsState.CANCELLED;
+      mockPublishers[2].state = TxUtilsState.NOT_MINED;
 
       publisherManager = new PublisherManager(mockPublishers, { publisherAllowInvalidStates: true });
       await expect(publisherManager.getAvailablePublisher(p => p.state === TxUtilsState.CANCELLED)).resolves.toBe(
@@ -59,13 +59,13 @@ describe('PublisherManager', () => {
     });
 
     it('should return publisher with best state', async () => {
-      mockPublishers[0]['state'] = TxUtilsState.MINED;
-      mockPublishers[1]['state'] = TxUtilsState.IDLE;
-      mockPublishers[2]['state'] = TxUtilsState.MINED;
+      mockPublishers[0].state = TxUtilsState.MINED;
+      mockPublishers[1].state = TxUtilsState.IDLE;
+      mockPublishers[2].state = TxUtilsState.MINED;
 
-      mockPublishers[0].getSenderBalance.mockResolvedValue(1000n);
-      mockPublishers[1].getSenderBalance.mockResolvedValue(500n);
-      mockPublishers[2].getSenderBalance.mockResolvedValue(1500n);
+      mockPublishers[0].balance = 1000n;
+      mockPublishers[1].balance = 500n;
+      mockPublishers[2].balance = 1500n;
 
       const result = await publisherManager.getAvailablePublisher();
 
@@ -73,13 +73,13 @@ describe('PublisherManager', () => {
     });
 
     it('should sort by balance when states are equal', async () => {
-      mockPublishers[0]['state'] = TxUtilsState.MINED;
-      mockPublishers[1]['state'] = TxUtilsState.MINED;
-      mockPublishers[2]['state'] = TxUtilsState.MINED;
+      mockPublishers[0].state = TxUtilsState.MINED;
+      mockPublishers[1].state = TxUtilsState.MINED;
+      mockPublishers[2].state = TxUtilsState.MINED;
 
-      mockPublishers[0].getSenderBalance.mockResolvedValue(1000n);
-      mockPublishers[1].getSenderBalance.mockResolvedValue(2000n);
-      mockPublishers[2].getSenderBalance.mockResolvedValue(500n);
+      mockPublishers[0].balance = 1000n;
+      mockPublishers[1].balance = 2000n;
+      mockPublishers[2].balance = 500n;
 
       const result = await publisherManager.getAvailablePublisher();
 
@@ -87,17 +87,17 @@ describe('PublisherManager', () => {
     });
 
     it('should sort by lastMinedAtBlockNumber when state and balance comparison are equal', async () => {
-      mockPublishers[0]['state'] = TxUtilsState.MINED;
-      mockPublishers[1]['state'] = TxUtilsState.MINED;
-      mockPublishers[2]['state'] = TxUtilsState.MINED;
+      mockPublishers[0].state = TxUtilsState.MINED;
+      mockPublishers[1].state = TxUtilsState.MINED;
+      mockPublishers[2].state = TxUtilsState.MINED;
 
-      mockPublishers[0].getSenderBalance.mockResolvedValue(1000n);
-      mockPublishers[1].getSenderBalance.mockResolvedValue(1000n);
-      mockPublishers[2].getSenderBalance.mockResolvedValue(1000n);
+      mockPublishers[0].balance = 1000n;
+      mockPublishers[1].balance = 1000n;
+      mockPublishers[2].balance = 1000n;
 
-      mockPublishers[0]['lastMinedAtBlockNumber'] = 100n;
-      mockPublishers[1]['lastMinedAtBlockNumber'] = 50n;
-      mockPublishers[2]['lastMinedAtBlockNumber'] = undefined;
+      mockPublishers[0].lastMinedAtBlockNumber = 100n;
+      mockPublishers[1].lastMinedAtBlockNumber = 50n;
+      mockPublishers[2].lastMinedAtBlockNumber = undefined;
 
       const result = await publisherManager.getAvailablePublisher();
 
@@ -105,18 +105,18 @@ describe('PublisherManager', () => {
     });
 
     it('should apply filter correctly', async () => {
-      mockPublishers[0]['state'] = TxUtilsState.IDLE;
-      mockPublishers[1]['state'] = TxUtilsState.MINED;
-      mockPublishers[2]['state'] = TxUtilsState.MINED;
+      mockPublishers[0].state = TxUtilsState.IDLE;
+      mockPublishers[1].state = TxUtilsState.MINED;
+      mockPublishers[2].state = TxUtilsState.MINED;
 
-      mockPublishers[0].getSenderBalance.mockResolvedValue(1000n);
-      mockPublishers[1].getSenderBalance.mockResolvedValue(1000n);
-      mockPublishers[2].getSenderBalance.mockResolvedValue(1000n);
+      mockPublishers[0].balance = 1000n;
+      mockPublishers[1].balance = 1000n;
+      mockPublishers[2].balance = 1000n;
 
       // The first publisher would normally be selected as it is idle but we filter it out
-      mockPublishers[0].getSenderAddress.mockReturnValue(addresses[0]);
-      mockPublishers[1].getSenderAddress.mockReturnValue(addresses[1]);
-      mockPublishers[2].getSenderAddress.mockReturnValue(addresses[2]);
+      mockPublishers[0].senderAddress = addresses[0];
+      mockPublishers[1].senderAddress = addresses[1];
+      mockPublishers[2].senderAddress = addresses[2];
 
       const filter = (publisher: L1TxUtils) => {
         return !publisher.getSenderAddress().equals(addresses[0]); // Filter out the first publisher
@@ -134,27 +134,27 @@ describe('PublisherManager', () => {
       const filter = (utils: L1TxUtils) => utils.getSenderAddress() !== mockPublishers[2].getSenderAddress(); // Filter out publisher in index 2
 
       // Set up different states, balances, and block numbers
-      mockPublishers[0]['state'] = TxUtilsState.MINED;
-      mockPublishers[0].getSenderBalance.mockResolvedValue(500n);
-      mockPublishers[0]['lastMinedAtBlockNumber'] = 200n;
+      mockPublishers[0].state = TxUtilsState.MINED;
+      mockPublishers[0].balance = 500n;
+      mockPublishers[0].lastMinedAtBlockNumber = 200n;
 
-      mockPublishers[1]['state'] = TxUtilsState.IDLE;
-      mockPublishers[1].getSenderBalance.mockResolvedValue(300n);
-      mockPublishers[1]['lastMinedAtBlockNumber'] = undefined;
+      mockPublishers[1].state = TxUtilsState.IDLE;
+      mockPublishers[1].balance = 300n;
+      mockPublishers[1].lastMinedAtBlockNumber = undefined;
 
       // The best candidate in terms of state and balance, but it's filtered out
-      mockPublishers[2]['state'] = TxUtilsState.IDLE;
-      mockPublishers[2].getSenderBalance.mockResolvedValue(10000000000n);
-      mockPublishers[2]['lastMinedAtBlockNumber'] = 0n;
+      mockPublishers[2].state = TxUtilsState.IDLE;
+      mockPublishers[2].balance = 10000000000n;
+      mockPublishers[2].lastMinedAtBlockNumber = 0n;
 
-      mockPublishers[3]['state'] = TxUtilsState.MINED;
-      mockPublishers[3].getSenderBalance.mockResolvedValue(800n);
-      mockPublishers[3]['lastMinedAtBlockNumber'] = 100n;
+      mockPublishers[3].state = TxUtilsState.MINED;
+      mockPublishers[3].balance = 800n;
+      mockPublishers[3].lastMinedAtBlockNumber = 100n;
 
       // The best candidate based on state and balance
-      mockPublishers[4]['state'] = TxUtilsState.IDLE;
-      mockPublishers[4].getSenderBalance.mockResolvedValue(600n);
-      mockPublishers[4]['lastMinedAtBlockNumber'] = 50n;
+      mockPublishers[4].state = TxUtilsState.IDLE;
+      mockPublishers[4].balance = 600n;
+      mockPublishers[4].lastMinedAtBlockNumber = 50n;
 
       const result = await publisherManager.getAvailablePublisher(filter);
 
@@ -163,7 +163,7 @@ describe('PublisherManager', () => {
       expect(result!.getSenderAddress()).toEqual(mockPublishers[4].getSenderAddress());
 
       // Set this publisher to have the same balance as publisher index 1
-      mockPublishers[4].getSenderBalance.mockResolvedValue(300n);
+      mockPublishers[4].balance = 300n;
 
       // Priority should now go to the one that is least recently used, index 1
       const result2 = await publisherManager.getAvailablePublisher(filter);
@@ -172,15 +172,27 @@ describe('PublisherManager', () => {
     });
   });
 
-  function createMockPublishers(count: number, addresses: EthAddress[] = []): MockProxy<L1TxUtils>[] {
+  function createMockPublishers(count: number, addresses: EthAddress[] = []): (TestL1TxUtils & L1TxUtils)[] {
     const tempAddress = [...addresses];
-    return Array.from({ length: count }, () => {
-      return mock<L1TxUtils>({
-        state: TxUtilsState.IDLE,
-        lastMinedAtBlockNumber: undefined,
-        getSenderBalance: jest.fn().mockReturnValue(Promise.resolve(1000n)),
-        getSenderAddress: jest.fn().mockReturnValue(tempAddress.shift() || EthAddress.random()),
-      } as MockProxy<L1TxUtils>);
-    });
+    return times(
+      count,
+      () => new TestL1TxUtils(tempAddress.shift() || EthAddress.random()) as TestL1TxUtils & L1TxUtils,
+    );
   }
 });
+
+class TestL1TxUtils {
+  public state: TxUtilsState = TxUtilsState.IDLE;
+  public lastMinedAtBlockNumber: bigint | undefined = undefined;
+  public balance: bigint = 1000n;
+
+  constructor(public senderAddress: EthAddress) {}
+
+  public getSenderBalance() {
+    return Promise.resolve(this.balance);
+  }
+
+  public getSenderAddress() {
+    return this.senderAddress;
+  }
+}

--- a/yarn-project/prover-node/src/prover-node-publisher.test.ts
+++ b/yarn-project/prover-node/src/prover-node-publisher.test.ts
@@ -245,7 +245,7 @@ describe('prover-node-publisher', () => {
     jest.spyOn(l1Utils, 'getSenderAddress').mockReturnValue(EthAddress.random());
 
     jest.spyOn(l1Utils, 'sendAndMonitorTransaction').mockResolvedValue({
-      gasPrice: {} as any,
+      state: { gasPrice: {} as any } as any,
       receipt: {
         status: 'reverted',
         effectiveGasPrice: 1n,

--- a/yarn-project/sequencer-client/src/publisher/sequencer-publisher.test.ts
+++ b/yarn-project/sequencer-client/src/publisher/sequencer-publisher.test.ts
@@ -160,7 +160,7 @@ describe('SequencerPublisher', () => {
 
     l1TxUtils.sendAndMonitorTransaction.mockResolvedValue({
       receipt: proposeTxReceipt,
-      gasPrice: { maxFeePerGas: 1n, maxPriorityFeePerGas: 1n },
+      state: { gasPrice: { maxFeePerGas: 1n, maxPriorityFeePerGas: 1n } } as any,
     });
     (l1TxUtils as any).estimateGas.mockResolvedValue(GAS_GUESS);
     (l1TxUtils as any).simulate.mockResolvedValue({ gasUsed: 1_000_000n, result: '0x' });
@@ -268,7 +268,6 @@ describe('SequencerPublisher', () => {
 
     forwardSpy.mockResolvedValue({
       receipt: proposeTxReceipt,
-      gasPrice: { maxFeePerGas: 1n, maxPriorityFeePerGas: 1n },
       errorMsg: undefined,
     });
 
@@ -322,7 +321,6 @@ describe('SequencerPublisher', () => {
   it('errors if forwarder tx fails', async () => {
     forwardSpy.mockRejectedValueOnce(new Error()).mockResolvedValueOnce({
       receipt: proposeTxReceipt,
-      gasPrice: { maxFeePerGas: 1n, maxPriorityFeePerGas: 1n },
       errorMsg: undefined,
     });
 
@@ -353,7 +351,6 @@ describe('SequencerPublisher', () => {
   it('returns errorMsg if forwarder tx reverts', async () => {
     forwardSpy.mockResolvedValue({
       receipt: { ...proposeTxReceipt, status: 'reverted' },
-      gasPrice: { maxFeePerGas: 1n, maxPriorityFeePerGas: 1n },
       errorMsg: 'Test error',
     });
 

--- a/yarn-project/sequencer-client/src/publisher/sequencer-publisher.ts
+++ b/yarn-project/sequencer-client/src/publisher/sequencer-publisher.ts
@@ -5,7 +5,6 @@ import type { EpochCache } from '@aztec/epoch-cache';
 import {
   type EmpireSlashingProposerContract,
   FormattedViemError,
-  type GasPrice,
   type GovernanceProposerContract,
   type IEmpireBase,
   type L1BlobInputs,
@@ -98,7 +97,7 @@ interface RequestWithExpiry {
   blobConfig?: L1BlobInputs;
   checkSuccess: (
     request: L1TxRequest,
-    result?: { receipt: TransactionReceipt; gasPrice: GasPrice; stats?: TransactionStats; errorMsg?: string },
+    result?: { receipt: TransactionReceipt; stats?: TransactionStats; errorMsg?: string },
   ) => boolean;
 }
 
@@ -285,7 +284,7 @@ export class SequencerPublisher {
 
   private callbackBundledTransactions(
     requests: RequestWithExpiry[],
-    result?: { receipt: TransactionReceipt; gasPrice: GasPrice } | FormattedViemError,
+    result?: { receipt: TransactionReceipt } | FormattedViemError,
   ) {
     const actionsListStr = requests.map(r => r.action).join(', ');
     if (result instanceof FormattedViemError) {


### PR DESCRIPTION
Introduces a new type `L1TxState` that tracks the status (sent, speed up, etc) of each tx individually, as well as other tx data that was being passed around (last gas price, tx hashes of all sent txs, etc). The l1 tx utils instance now returns the state of its last tx as its own state. This allows calling `sendTransaction` while another tx is still being resolved (eg being cancelled) without having two independent `monitorTransaction` loops updating the state of the publisher at the same time.

This PR also fixes other existing issues:
- State was never update to `CANCELLED` when using `L1TxUtilsWithBlobs`, since the code for `attemptTxCancellation` was duplicated and had not been updated for state tracking.
- The `kzg` property of `L1BlobInputs` was untyped. We now define the type in `blob-lib` and pull it using `import type` so the import is removed after compilation.