### PR TITLE
chore: allow zero address in gov constructor to open floodgates

### DIFF
--- a/docs/versioned_docs/version-v3.0.0-nightly.20250930/developers/docs/concepts/call_types.md
+++ b/docs/versioned_docs/version-v3.0.0-nightly.20250930/developers/docs/concepts/call_types.md
@@ -265,7 +265,7 @@ This creates and returns a transaction request, which includes proof of correct 
 
 ```typescript title="local-tx-fails" showLineNumbers 
 await expect(
-  claimContract.methods.claim(anotherDonationNote, donorAddress).send({ from: unrelatedAdress }).wait(),
+  claimContract.methods.claim(anotherDonationNote, donorAddress).send({ from: unrelatedAddress }).wait(),
 ).rejects.toThrow('Note does not belong to the sender');
 ```
 > <sup><sub><a href="https://github.com/AztecProtocol/aztec-packages/blob/v3.0.0-nightly.20250930/yarn-project/end-to-end/src/e2e_crowdfunding_and_claim.test.ts#L232-L236" target="_blank" rel="noopener noreferrer">Source code: yarn-project/end-to-end/src/e2e_crowdfunding_and_claim.test.ts#L232-L236</a></sub></sup>

--- a/l1-contracts/src/governance/Governance.sol
+++ b/l1-contracts/src/governance/Governance.sol
@@ -243,7 +243,7 @@ contract Governance is IGovernance {
   }
 
   /**
-   * @dev the initial _beneficiary is expected to be the GSE.
+   * @dev the initial _beneficiary is expected to be the GSE or address(0) for anyone
    */
   constructor(IERC20 _asset, address _governanceProposer, address _beneficiary, Configuration memory _configuration) {
     ASSET = _asset;
@@ -252,10 +252,14 @@ contract Governance is IGovernance {
     _configuration.assertValid();
     configuration = CompressedConfigurationLib.compress(_configuration);
 
-    // Unnecessary to set, but better clarity.
-    depositControl.allBeneficiariesAllowed = false;
-    depositControl.isAllowed[_beneficiary] = true;
-    emit BeneficiaryAdded(_beneficiary);
+    if (_beneficiary == address(0)) {
+      depositControl.allBeneficiariesAllowed = true;
+      emit FloodGatesOpened();
+    } else {
+      depositControl.allBeneficiariesAllowed = false;
+      depositControl.isAllowed[_beneficiary] = true;
+      emit BeneficiaryAdded(_beneficiary);
+    }
   }
 
   /**

--- a/yarn-project/end-to-end/src/e2e_crowdfunding_and_claim.test.ts
+++ b/yarn-project/end-to-end/src/e2e_crowdfunding_and_claim.test.ts
@@ -201,7 +201,7 @@ describe('e2e_crowdfunding_and_claim', () => {
     const donationAmount = 1000n;
 
     const donorAddress = donor2Address;
-    const unrelatedAdress = donor1Address;
+    const unrelatedAddress = donor1Address;
 
     // 1) We permit the crowdfunding contract to pull the donation amount from the donor's wallet, and we donate
 
@@ -231,7 +231,7 @@ describe('e2e_crowdfunding_and_claim', () => {
     // 2) We try to claim the reward token via the Claim contract with the unrelated wallet
     // docs:start:local-tx-fails
     await expect(
-      claimContract.methods.claim(anotherDonationNote, donorAddress).send({ from: unrelatedAdress }).wait(),
+      claimContract.methods.claim(anotherDonationNote, donorAddress).send({ from: unrelatedAddress }).wait(),
     ).rejects.toThrow('Note does not belong to the sender');
     // docs:end:local-tx-fails
   });


### PR DESCRIPTION
Pass address(0) as the initial beneficiary to the Governance constructor to immediately open floodgates