### PR TITLE
feat: cvc5 build cache in CI

### DIFF
--- a/barretenberg/cpp/bootstrap.sh
+++ b/barretenberg/cpp/bootstrap.sh
@@ -156,6 +156,13 @@ function build_smt_verification {
 
   sudo apt update && sudo apt install -y python3-pip python3-venv m4 bison
   cmake --preset smt-verification
+  
+  cvc5_commit="5fcdb48eb26dee9385e0d0e6377fcc7e4afee85a"
+  if ! cache_download barretenberg-cvc5-$cvc5_commit.zst; then
+      cmake --build build-smt --target cvc5
+      cache_upload barretenberg-cvc5-$cvc5_commit.zst build-smt/_deps/cvc5
+  fi
+
   cmake --build build-smt --target smt_verification_tests
   cache_upload barretenberg-smt-$hash.zst build-smt
 }

--- a/barretenberg/cpp/src/barretenberg/smt_verification/smt_examples.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/smt_verification/smt_examples.test.cpp
@@ -1,11 +1,11 @@
-#include "barretenberg/circuit_checker/circuit_checker.hpp"
-#include "barretenberg/stdlib_circuit_builders/ultra_circuit_builder.hpp"
 #include <fstream>
 #include <gtest/gtest.h>
 #include <iostream>
 #include <string>
 
+#include "barretenberg/circuit_checker/circuit_checker.hpp"
 #include "barretenberg/stdlib/primitives/field/field.hpp"
+#include "barretenberg/stdlib_circuit_builders/ultra_circuit_builder.hpp"
 
 #include "barretenberg/smt_verification/circuit/ultra_circuit.hpp"
 


### PR DESCRIPTION
This pr adds a cached version of cvc5 for smt-build
(also a minor change in code to test the caching)