### PR TITLE
chore(docs): Fix spellcheck to run on include_code snippets

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "HOST=0.0.0.0 ENV=dev yarn preprocess && ENV=dev docusaurus start --host ${HOST:-localhost}",
     "dev:netlify": "yarn netlify dev",
-    "build": "yarn clean && yarn spellcheck && yarn preprocess && yarn preprocess:move && docusaurus build",
+    "build": "yarn clean && yarn preprocess && yarn spellcheck && yarn preprocess:move && docusaurus build",
     "clean": "./scripts/clean.sh",
     "serve": "docusaurus serve",
     "preprocess": "yarn node -r dotenv/config ./src/preprocess/index.js",
@@ -57,11 +57,11 @@
       "./docs/**/{*.md,*.md?}",
       "./versioned_docs/**/{*.md,*.md?}",
       "./internal_notes/**/{*.md,*.md?}",
-      "./src/components/Snippets/*.js"
+      "./src/components/Snippets/*.js",
+      "./processed-docs/**/{*.md,*.md?}"
     ],
     "ignorePaths": [
       "node_modules",
-      "processed-docs",
       "processed-docs-cache",
       "/docs-words.txt"
     ]


### PR DESCRIPTION
spellcheck was running before docs preprocessing so it wasn't parsing include_code snippets, so if the snippet included a spelling error it would only fail after docs containing the spelling error had been published as part of a nightly release

this PR updates the spell check to run after preprocessing to catch these errors sooner. (added by @critesjosh)