### PR TITLE
chore(ci): space bump workaround

### DIFF
--- a/ci3/aws_request_instance_type
+++ b/ci3/aws_request_instance_type
@@ -36,7 +36,7 @@ launch_spec=$(cat <<EOF
     {
       "DeviceName": "/dev/sda1",
       "Ebs": {
-        "VolumeSize": 96,
+        "VolumeSize": 128,
         "VolumeType": "gp3",
         "Throughput": 1000,
         "Iops": 4000


### PR DESCRIPTION
We should certainly see why we are gobbling so many gigabytes, but we can bump up for now