### PR TITLE
feat: allow any contract to emit contract class logs

### DIFF
--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/private_call_data_validator.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/private_call_data_validator.nr
@@ -12,10 +12,7 @@ use dep::types::{
         transaction::tx_request::TxRequest,
     },
     address::AztecAddress,
-    constants::{
-        CONTRACT_CLASS_LOG_SIZE_IN_FIELDS, CONTRACT_CLASS_REGISTRY_CONTRACT_ADDRESS,
-        MAX_FIELD_VALUE, PRIVATE_LOG_SIZE_IN_FIELDS,
-    },
+    constants::{CONTRACT_CLASS_LOG_SIZE_IN_FIELDS, MAX_FIELD_VALUE, PRIVATE_LOG_SIZE_IN_FIELDS},
     traits::FromField,
     utils::arrays::ClaimedLengthArray,
 };
@@ -241,18 +238,6 @@ impl PrivateCallDataValidator {
                 self.data.public_inputs.contract_class_logs_hashes.length,
                 0,
                 "contract_class_logs_hashes must be empty for static calls",
-            );
-        }
-
-        // TODO(#15092): consider removing this assertion.
-        // Would it be bad if we enabled other functions to emit these logs?
-        // Oh, maybe the AVM does stuff with those logs, with the presumption that they
-        // contain avm bytecode that needs to be validated by the avm?
-        if (self.data.public_inputs.contract_class_logs_hashes.length != 0) {
-            assert_eq(
-                call_context.contract_address,
-                CONTRACT_CLASS_REGISTRY_CONTRACT_ADDRESS,
-                "only the class registry may emit contract class logs",
             );
         }
     }

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/tests/private_call_data_validator_builder/restrict_side_effects.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/tests/private_call_data_validator_builder/restrict_side_effects.nr
@@ -56,13 +56,3 @@ fn validate_call_is_static_creating_contract_class_logs_hashes_fails() {
 
     builder.validate();
 }
-
-#[test(should_fail_with = "only the class registry may emit contract class logs")]
-fn validate_call_is_from_class_registry_fails() {
-    // the default bulder address != CONTRACT_CLASS_REGISTRY_CONTRACT_ADDRESS
-    let mut builder = PrivateCallDataValidatorBuilder::new();
-
-    builder.private_call.add_contract_class_log_hash(1, 2);
-
-    builder.validate();
-}

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/tests/private_call_data_validator_builder/validate_log_lengths.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/tests/private_call_data_validator_builder/validate_log_lengths.nr
@@ -1,21 +1,5 @@
 use crate::tests::private_call_data_validator_builder::PrivateCallDataValidatorBuilder;
-use dep::types::{
-    constants::{
-        CONTRACT_CLASS_LOG_SIZE_IN_FIELDS, CONTRACT_CLASS_REGISTRY_CONTRACT_ADDRESS,
-        PRIVATE_LOG_SIZE_IN_FIELDS,
-    },
-    traits::ToField,
-};
-
-impl PrivateCallDataValidatorBuilder {
-    pub fn new_with_class_registry_contract() -> Self {
-        let mut builder = PrivateCallDataValidatorBuilder::new();
-        let _ = builder.private_call.use_protocol_contract(
-            CONTRACT_CLASS_REGISTRY_CONTRACT_ADDRESS.to_field() as u32,
-        );
-        builder
-    }
-}
+use dep::types::constants::{CONTRACT_CLASS_LOG_SIZE_IN_FIELDS, PRIVATE_LOG_SIZE_IN_FIELDS};
 
 #[test]
 fn validate_private_log_lengths_succeeds() {
@@ -40,7 +24,7 @@ fn validate_private_log_lengths_too_large_fails() {
 
 #[test]
 fn validate_contract_class_log_lengths_succeeds() {
-    let mut builder = PrivateCallDataValidatorBuilder::new_with_class_registry_contract();
+    let mut builder = PrivateCallDataValidatorBuilder::new();
 
     builder.private_call.add_contract_class_log_hash(
         111 /* hash */,
@@ -52,7 +36,7 @@ fn validate_contract_class_log_lengths_succeeds() {
 
 #[test(should_fail_with = "contract class log length is too large")]
 fn validate_contract_class_log_lengths_too_large_fails() {
-    let mut builder = PrivateCallDataValidatorBuilder::new_with_class_registry_contract();
+    let mut builder = PrivateCallDataValidatorBuilder::new();
 
     builder.private_call.add_contract_class_log_hash(
         111 /* hash */,


### PR DESCRIPTION
The address of the contract that emits the log is already included in the blob, and we check that the address is from the registry before decrypting and saving the log data. So it won't break anything if we allow other contracts to emit the "contract class" logs.