### PR TITLE
feat: cvc5 build cache in CI 2

### DIFF
--- a/barretenberg/cpp/bootstrap.sh
+++ b/barretenberg/cpp/bootstrap.sh
@@ -156,6 +156,13 @@ function build_smt_verification {
 
   sudo apt update && sudo apt install -y python3-pip python3-venv m4 bison
   cmake --preset smt-verification
+ 
+  cvc5_cmake_hash=$(cache_content_hash ^barretenberg/cpp/src/barretenberg/smt_verification/CMakeLists.txt)
+  if ! cache_download barretenberg-cvc5-$cvc5_cmake_hash.zst; then
+      cmake --build build-smt --target cvc5
+      cache_upload barretenberg-cvc5-$cvc5_cmake_hash.zst build-smt/_deps/cvc5
+  fi
+
   cmake --build build-smt --target smt_verification_tests
   cache_upload barretenberg-smt-$hash.zst build-smt
 }


### PR DESCRIPTION
This pr adds a cached version of cvc5 for smt-build
