### PR TITLE
chore: secp256k1 refactor lambda functions to private, add documentation 

### DIFF
--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/README.md
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/README.md
@@ -62,3 +62,208 @@ Note that since the y-coordinate remains unchanged under the endomorphism, we ca
 > In the context of biggroup, we need variable-base lookup tables and fixed-base lookup tables. The variable-base lookup tables are used when the base point $P$ is not known at circuit synthesis time and is provided as a circuit witness. In this case, we need to generate the lookup tables on-the-fly based on the input base point $P$. On the other hand, fixed-base lookup tables are used when the base point $P$ is known at circuit synthesis time and can be hardcoded into the circuit (for example group generators). Fixed-base lookup tables are more efficient as they can be precomputed and do not require additional gates to enforce the correctness of the table entries. Variable-base lookup tables are realized using ROM tables (described below) while fixed-base lookup tables are realized using standard lookup tables in the circuit.
 
 Refer to the [ROM table documentation](../memory/README.md) for details on how ROM tables are implemented in Barretenberg.
+
+### wNAF with Stagger
+
+Suppose we have a scalar $a \in \mathbb{F}_r$ that we want to represent in wNAF form with stagger and skew factors. If $a$ is an $N$-bit scalar and the number of stagger bits is $t$, then we can represent $a$ as follows:
+
+$$
+a = b \cdot \windex{2^t} + \mathfrak{c}_a
+$$
+
+where $\mathfrak{c}_a \in [0, 2^t)$ is the stagger part and $b$ is the remaining part of the scalar. We can then represent $b$ in wNAF form with its skew factor $\mathfrak{s}_b \in \{0, 1\}$ as follows:
+
+$$
+\begin{aligned}
+a &:= \left( - \mathfrak{s}_b + \sum_{i=0}^{n-1} b_i \cdot \windex{2^{wi}} \right) \cdot \windex{2^t} + \mathfrak{c}_a
+\end{aligned}
+$$
+
+where $b_i \in \{ -(2^{w} - 1), \ \dots \ , -3, -1, 1, 3, \ \dots \ , (2^{w} - 1)\}$ are the wNAF slices and $n = \left\lceil \frac{(N - t)}{w} \right\rceil$ is the number of wNAF slices with $w$ being the wNAF window size. The skew factor $\mathfrak{s}_b$ is used to represent even numbers, i.e., $\mathfrak{s}_b = 1$ if $b$ is even. We require the wNAF values to be signed odd digits to avoid the digit 0 as that would have to be handled conditionally in circuits. For more details on wNAF representation in barretenberg, refer to the [wNAF hackmd](https://hackmd.io/@aztec-network/rJ3VZcyZ9#wNAF-Representation-of-Scalars-in-mathbbF_r).
+We can simplify the above expression as follows:
+
+$$
+\begin{aligned}
+a = \left(\sum_{i=0}^{n-1} b_i \cdot \windex{2^{wi}} \right) \cdot \windex{2^t}
++
+\underbrace{\left(\mathfrak{c}_a - \mathfrak{s}_b \cdot \windex{2^t} \right)}_{\textsf{adjusted stagger}}
+\end{aligned}
+$$
+
+The adjusted stagger term itself can be represented as wNAF slices. Let $\mathfrak{s}_c$ be the skew factor for the adjusted stagger term, then we can write:
+
+$$
+\begin{aligned}
+a = \left(\sum_{i=0}^{n-1} b_i \cdot \windex{2^{wi}} \right) \cdot \windex{2^t}
++
+\underbrace{\left(-\mathfrak{s}_c + \sum_{i=0}^{m-1} c_i \cdot \windex{2^{wi}} \right),}_{\textsf{adjusted stagger in wnaf form}}
+\end{aligned}
+$$
+
+where number of wNAF slices in the adjusted stagger term is $m = \left\lceil \frac{t}{w} \right\rceil$. In our implementation, we restrict the stagger bits $t \le w$ and thus $m = 1$:
+
+$$
+\begin{aligned}
+a &:= \left(\sum_{i=0}^{n-1} b_i \cdot \windex{2^{wi}} \right) \cdot \windex{2^t}
++
+\underbrace{\left(-\mathfrak{s}_c + c_0 \right).}_{\textsf{adjusted stagger in wnaf form}}
+\end{aligned}
+\tag{1}
+$$
+
+One important detail here is that the raw wNAF value $e_i \in \{0, 1, \dots, 2^{w-1}\}$ along with a sign bit $\pi_i \in \{0, 1\}$ is used to represent the wNAF slices. The sign bit indicates whether the corresponding wNAF slice is positive or negative. To convert the raw wNAF value and sign bit to the signed-odd representation for our implementation, we use the following formula:
+
+$$
+\begin{aligned}
+b_i &= (1 - 2 \pi_i) \cdot (2 e_i + 1) \\
+&=
+\begin{cases}
+(2 e_i + 1), & \text{if } \pi_i = 0 \\
+-(2 e_i + 1), & \text{if } \pi_i = 1
+\end{cases}
+\end{aligned}
+$$
+
+While reconstructing the scalar from its wNAF representation (in a circuit), we prefer to work with non-negative values. Since $|b_i| < 2^{w}$, to make the wNAF values positive, we add a bias of $2^{w}$ to each wNAF slice:
+
+$$
+\begin{aligned}
+b_i + \windex{2^{w}} &=
+\begin{cases}
+(\windex{2^{w}} + 2 e_i + 1), & \text{if } \pi_i = 0 \\
+(\windex{2^{w}} - 2 e_i - 1), & \text{if } \pi_i = 1
+\end{cases} \\
+&=
+\begin{cases}
+2 \cdot (\windex{2^{w - 1}} + e_i) + 1, & \text{if } \pi_i = 0 \\
+2 \cdot (\windex{2^{w - 1}} - e_i - 1) + 1, & \text{if } \pi_i = 1
+\end{cases} \\
+& =: \ 2 \cdot e'_i + 1.
+\end{aligned}
+$$
+
+We need to subtract this bias when reconstructing the scalar from its wNAF representation. Thus, the final scalar reconstruction formula is:
+
+$$
+\begin{aligned}
+a &= \left(\sum_{i=0}^{n-1} (b_i + \windex{2^w}) \cdot \windex{2^{wi}} \right) \cdot \windex{2^t} + c_0 - \mathfrak{s}_c - \underbrace{ \left( \sum_{i=0}^{n-1} \windex{2^{w}} \cdot \windex{2^{wi}} \right) \cdot \windex{2^t}}_{\textsf{bias correction}}
+\end{aligned}
+$$
+
+Similarly, the wNAF slice $c_0$ in the adjusted stagger term can be represented in terms of its raw wNAF value and sign bit as follows:
+
+$$
+\begin{aligned}
+c_0 &= (1 - 2 \pi) \cdot (2 c + 1) \\
+&=
+\begin{cases}
+(2 c + 1), & \text{if } \pi = 0 \\
+-(2 c + 1), & \text{if } \pi = 1
+\end{cases}
+\end{aligned}
+$$
+
+Here as well, we can add a bias of $2^{w}$ to make $c_0$ non-negative (and then subtract the bias when reconstructing the scalar):
+
+$$
+\begin{aligned}
+c_0 + \windex{2^{w}} &=
+\begin{cases}
+(\windex{2^{w}} + 2 c + 1), & \text{if } \pi = 0 \\
+(\windex{2^{w}} - 2 c - 1), & \text{if } \pi = 1
+\end{cases} \\
+&=
+\begin{cases}
+2 \cdot (\windex{2^{w - 1}} + c) + 1, & \text{if } \pi = 0 \\
+2 \cdot (\windex{2^{w - 1}} - c - 1) + 1, & \text{if } \pi = 1
+\end{cases} \\
+& =: \ 2 \cdot c' + 1.
+\end{aligned}
+$$
+
+Substituting the expression for $(b_i + \windex{2^{w}})$ and $(c_0 + \windex{2^{w}})$, we get:
+
+$$
+\begin{aligned}
+a &= \left(\sum_{i=0}^{n-1} (2 \cdot e'_i + 1)
+\cdot \windex{2^{wi}} \right) \cdot \windex{2^t} + (2 \cdot c' + 1) - \mathfrak{s}_c - \underbrace{\left( \left( \sum_{i=0}^{n-1} \windex{2^{w}} \cdot \windex{2^{wi}} \right) \cdot \windex{2^t} + \windex{2^{w}} \right)}_{\textsf{bias correction due to b and c}} \\
+&= \left(\sum_{i=0}^{n-1} (2 \cdot e'_i)
+\cdot \windex{2^{wi}} \right) \cdot \windex{2^t} + (2 \cdot c') - \mathfrak{s}_c - \underbrace{\left( \left( \sum_{i=0}^{n-1} (\windex{2^{w} - 1}) \cdot \windex{2^{wi}} \right) \cdot \windex{2^t} + (\windex{2^{w} - 1}) \right)}_{\textsf{adjusted bias correction}}
+\end{aligned}
+$$
+
+This expression is used in the circuit to reconstruct the scalar from its wNAF representation. The adjusted bias correction term is a constant that can be precomputed and hardcoded into the circuit.
+
+#### Handling Large Scalars
+
+When we have a scalar that is larger than $\frac{r}{2}$, to minimize the number of wNAF slices, we represent the negative of the scalar instead. Thus, for a scalar $a > \frac{r}{2}$, we define $a_{\textsf{negative}} := (r - a) < \frac{r}{2}$ as an $N$-bit scalar and represent $a_{\textsf{negative}}$ in wNAF form as described above. The final scalar multiplication is then computed as:
+
+$$
+\begin{aligned}
+a \cdot P &= (r - a_{\textsf{negative}}) \cdot P \\
+&= r \cdot P - a_{\textsf{negative}} \cdot P \\
+&= - a_{\textsf{negative}} \cdot P
+\end{aligned}
+$$
+
+Thus, to compute the wNAF representation of $-a_{\textsf{negative}} \in \mathbb{F}_r$, we can use the same expression as before (see Equation $(1)$). If $a_{\textsf{negative}}$ is represented as:
+
+$$
+\begin{aligned}
+a_{\textsf{negative}} =
+\left(\sum_{i=0}^{n-1} b_{i, \textsf{negative}} \cdot \windex{2^{wi}} \right) \cdot \windex{2^t}
++
+\underbrace{\left(-\mathfrak{s}_{c, \textsf{negative}} + c_{0, \textsf{negative}} \right).}_{\textsf{adjusted stagger in wnaf form}}
+\end{aligned}
+$$
+
+$$
+\begin{aligned}
+\implies -a_{\textsf{negative}} &= \left(\sum_{i=0}^{n-1} -b_{i, \textsf{negative}} \cdot \windex{2^{wi}} \right) \cdot \windex{2^t}
++
+\mathfrak{s}_{c, \textsf{negative}} - c_{0, \textsf{negative}}.
+\end{aligned}
+$$
+
+We can write the negative wNAF slices $-b_{i, \textsf{negative}}$ in terms of the raw wNAF values and sign bits as follows:
+
+$$
+\begin{aligned}
+-b_{i, \textsf{negative}} &= -(1 - 2 \pi_{i, \textsf{negative}}) \cdot (2 e_{i, \text{negative}} + 1) \\
+&=
+\begin{cases}
+-(2 e_{i, \text{negative}} + 1), & \text{if } \pi_{i, \textsf{negative}} = 0 \\
+(2 e_{i, \text{negative}} + 1), & \text{if } \pi_{i, \textsf{negative}} = 1
+\end{cases} \
+\end{aligned}
+$$
+
+Similarly, we can add a bias of $2^{w}$ to each negative wNAF slice to make them non-negative:
+
+$$
+\begin{aligned}
+-b_{i, \textsf{negative}} + 2^{w} &=
+\begin{cases}
+(\windex{2^{w}} - 2 e_{i, \text{negative}} - 1), & \text{if } \pi_{i, \textsf{negative}} = 0 \\
+(\windex{2^{w}} + 2 e_{i, \text{negative}} + 1), & \text{if } \pi_{i, \textsf{negative}} = 1
+\end{cases} \\
+&=
+\begin{cases}
+2 \cdot (\windex{2^{w - 1}} - e_{i, \text{negative}} - 1) + 1, & \text{if } \pi_{i, \textsf{negative}} = 0 \\
+2 \cdot (\windex{2^{w - 1}} + e_{i, \text{negative}}) + 1, & \text{if } \pi_{i, \textsf{negative}} = 1
+\end{cases} \\
+& =: \ 2 \cdot e'_{i, \textsf{negative}} + 1.
+\end{aligned}
+$$
+
+We can similarly add a bias of $2^{w}$ to the adjusted stagger wNAF slice $c_{0, \textsf{negative}}$. Therefore, the final scalar reconstruction formula for $-a_{\textsf{negative}}$ is:
+
+$$
+\begin{aligned}
+-a_{\textsf{negative}} &= \left(\sum_{i=0}^{n-1} (2e'_{i, \textsf{negative}}) \cdot \windex{2^{wi}} \right) \cdot \windex{2^t} + (2 \cdot c'_{\textsf{negative}}) + \mathfrak{s}_{c, \textsf{negative}} \\
+& \quad
+ - \underbrace{\left( \left( \sum_{i=0}^{n-1} (\windex{2^{w} - 1}) \cdot \windex{2^{wi}} \right) \cdot \windex{2^t} + (\windex{2^{w} - 1}) \right)}_{\textsf{adjusted bias correction for both b and c}}
+\end{aligned}
+$$
+
+Notice that the terms $e'_{i, \textsf{negative}}$ and $c'_{\textsf{negative}}$ are similar to $e'_i$ and $c'$ respectively, except that the sign bits are flipped. Thus, we can use the same circuit logic to reconstruct both $a$ and $-a_{\textsf{negative}}$ from their wNAF representations with appropriate sign bit handling.

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup.hpp
@@ -482,10 +482,6 @@ template <class Builder_, class Fq, class Fr, class NativeGroup> class element {
   private:
     bool_ct _is_infinity;
 
-    // Following are private methods for computation of secp256k1 wNAF. These used to be lambda
-    // functions inside `compute_secp256k1_endo_wnaf`, but we moved them out so that they can be unit tested
-    // individually. They are not intended for public use.
-
     /**
      * @brief Compute the wNAF representation (in circuit) of a scalar for secp256k1
      *
@@ -507,7 +503,7 @@ template <class Builder_, class Fq, class Fr, class NativeGroup> class element {
     /**
      * @brief Compute the stagger-related part of wNAF and the final skew
      *
-     * @param fragment_u64 Stagger-masked lower bits of the skalar
+     * @param fragment_u64 Stagger-masked lower bits of the scalar
      * @param stagger The number of staggering bits
      * @param is_negative If the initial scalar is supposed to be subtracted
      * @param wnaf_skew The skew of the stagger-right-shifted part of the scalar

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup.hpp
@@ -482,6 +482,81 @@ template <class Builder_, class Fq, class Fr, class NativeGroup> class element {
   private:
     bool_ct _is_infinity;
 
+    // Following are private methods for computation of secp256k1 wNAF. These used to be lambda
+    // functions inside `compute_secp256k1_endo_wnaf`, but we moved them out so that they can be unit tested
+    // individually. They are not intended for public use.
+
+    /**
+     * @brief Compute the wNAF representation (in circuit) of a scalar for secp256k1
+     *
+     * @param builder
+     * @param scalar The scalar to be represented in wNAF, should be ≤ 129 bits
+     * @param stagger The stagger value (in terms of number of bits)
+     * @param is_negative Whether the scalar is negative
+     * @param is_lo Whether this is the low part of a split scalar
+     * @return std::pair<Fr, secp256k1_wnaf>
+     *
+     * @details For a scalar k > (r / 2), we compute the wNAF representation of k' = r - k.
+     * We then have k = -k' mod r, and we can perform scalar multiplication using -k'. This case is handled by
+     * setting `is_negative = true`.
+     */
+    template <size_t num_bits, size_t wnaf_size, size_t lo_stagger, size_t hi_stagger>
+    static std::pair<Fr, secp256k1_wnaf> compute_secp256k1_single_wnaf(
+        Builder* builder, const secp256k1::fr& scalar, size_t stagger, bool is_negative, bool is_lo = false);
+
+    /**
+     * @brief Compute the stagger-related part of wNAF and the final skew
+     *
+     * @param fragment_u64 Stagger-masked lower bits of the skalar
+     * @param stagger The number of staggering bits
+     * @param is_negative If the initial scalar is supposed to be subtracted
+     * @param wnaf_skew The skew of the stagger-right-shifted part of the scalar
+     *
+     */
+    template <size_t wnaf_size>
+    static std::pair<uint64_t, bool> compute_secp256k1_staggered_wnaf_fragment(const uint64_t fragment_u64,
+                                                                               const uint64_t stagger,
+                                                                               bool is_negative,
+                                                                               bool wnaf_skew);
+
+    /**
+     * @brief Convert wNAF values to witness values
+     *
+     * @param builder
+     * @param wnaf_values
+     * @param is_negative
+     * @param rounds
+     * @return std::vector<field_t<Builder>>
+     *
+     * @details For 4-bit window, each wNAF value is in the range [-15, 15]. We convert these to the range [0, 30] by
+     * adding 15 if `is_negative = false` and by subtracting from 15 if `is_negative = true`. This ensures that all
+     * values are non-negative, which is required for the ROM table lookup.
+     */
+    template <size_t wnaf_size>
+    static std::vector<field_t<Builder>> convert_wnaf_values_to_witnesses(Builder* builder,
+                                                                          uint64_t* wnaf_values,
+                                                                          bool is_negative,
+                                                                          size_t rounds);
+
+    /**
+     * @brief Reconstruct a scalar from its wNAF representation in circuit
+     *
+     * @param builder
+     * @param wnaf The wNAF representation of the scalar
+     * @param positive_skew The skew to be applied if the scalar is non-negative
+     * @param stagger_fragment The stagger-related fragment of the scalar
+     * @param stagger The number of staggering bits
+     * @param rounds The number of rounds in the wNAF representation
+     * @return Fr The reconstructed scalar
+     */
+    template <size_t wnaf_size>
+    static Fr reconstruct_bigfield_from_wnaf(Builder* builder,
+                                             const std::vector<field_t<Builder>>& wnaf,
+                                             const field_t<Builder>& positive_skew,
+                                             const field_t<Builder>& stagger_fragment,
+                                             const size_t stagger,
+                                             const size_t rounds);
+
     template <size_t num_elements>
     static std::array<twin_rom_table<Builder>, Fq::NUM_LIMBS + 1> create_group_element_rom_tables(
         const std::array<element, num_elements>& rom_data, std::array<uint256_t, Fq::NUM_LIMBS * 2>& limb_max);
@@ -908,7 +983,8 @@ concept IsGoblinBigGroup =
     std::same_as<Fr, bb::stdlib::field_t<Builder>> && std::same_as<NativeGroup, bb::g1>;
 
 /**
- * @brief element wraps either element_default::element or element_goblin::goblin_element depending on parametrisation
+ * @brief element wraps either element_default::element or element_goblin::goblin_element depending on
+ * parametrisation
  * @details if C = MegaBuilder, G = bn254, Fq = bigfield<C, bb::Bn254FqParams>, Fr = field_t then we're cooking
  */
 template <typename C, typename Fq, typename Fr, typename G>

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_nafs.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_nafs.hpp
@@ -11,6 +11,191 @@
 
 namespace bb::stdlib::element_default {
 
+template <typename C, class Fq, class Fr, class G>
+template <size_t wnaf_size>
+std::pair<uint64_t, bool> element<C, Fq, Fr, G>::compute_secp256k1_staggered_wnaf_fragment(const uint64_t fragment_u64,
+                                                                                           const uint64_t stagger,
+                                                                                           bool is_negative,
+                                                                                           bool wnaf_skew)
+{
+    // If there is not stagger then there is no need to change anyhing
+    if (stagger == 0) {
+        return std::make_pair<uint64_t, bool>((uint64_t)0, (bool)wnaf_skew);
+    }
+    int fragment = static_cast<int>(fragment_u64);
+    // Inverse the fragment if it's negative
+    if (is_negative) {
+        fragment = -fragment;
+    }
+    // If the value is positive and there is a skew in wnaf, subtract 2ˢᵗᵃᵍᵍᵉʳ. If negative and there is
+    // skew, then add
+    if (!is_negative && wnaf_skew) {
+        fragment -= (1 << stagger);
+    } else if (is_negative && wnaf_skew) {
+        fragment += (1 << stagger);
+    }
+    // If the lowest bit is zero, then set final skew to 1 and add 1 to the absolute value of the fragment
+    bool output_skew = (fragment_u64 % 2) == 0;
+    if (!is_negative && output_skew) {
+        fragment += 1;
+    } else if (is_negative && output_skew) {
+        fragment -= 1;
+    }
+
+    uint64_t output_fragment;
+    if (fragment < 0) {
+        output_fragment = static_cast<uint64_t>((int)((1ULL << (wnaf_size - 1))) + (fragment / 2 - 1));
+    } else {
+        output_fragment =
+            static_cast<uint64_t>((1ULL << (wnaf_size - 1)) - 1ULL + (uint64_t)((uint64_t)fragment / 2 + 1));
+    }
+
+    return std::make_pair<uint64_t, bool>((uint64_t)output_fragment, (bool)output_skew);
+}
+
+template <typename C, class Fq, class Fr, class G>
+template <size_t wnaf_size>
+std::vector<field_t<C>> element<C, Fq, Fr, G>::convert_wnaf_values_to_witnesses(C* builder,
+                                                                                uint64_t* wnaf_values,
+                                                                                bool is_negative,
+                                                                                size_t rounds)
+{
+    constexpr uint64_t wnaf_window_size = (1ULL << (wnaf_size - 1));
+
+    std::vector<field_t<C>> wnaf_entries;
+    for (size_t i = 0; i < rounds; ++i) {
+        // Predicate == sign of current wnaf value
+        bool predicate = bool((wnaf_values[i] >> 31U) & 1U);
+        uint64_t offset_entry;
+        // If the signs of current entry and the whole scalar are the same, then add the lowest bits of current
+        // wnaf value to the windows size to form an entry. Otherwise, subract the lowest bits along with 1
+        if ((!predicate && !is_negative) || (predicate && is_negative)) {
+            // TODO: Why is this mask fixed?
+            offset_entry = wnaf_window_size + (wnaf_values[i] & 0xffffff);
+        } else {
+            offset_entry = wnaf_window_size - 1 - (wnaf_values[i] & 0xffffff);
+        }
+        field_t<C> entry(witness_t<C>(builder, offset_entry));
+
+        // TODO: Do these need to be range constrained? we use these witnesses
+        // to index a size-16 ROM lookup table, which performs an implicit range constraint
+        entry.create_range_constraint(wnaf_size);
+        wnaf_entries.emplace_back(entry);
+    }
+    return wnaf_entries;
+}
+
+template <typename C, class Fq, class Fr, class G>
+template <size_t wnaf_size>
+Fr element<C, Fq, Fr, G>::reconstruct_bigfield_from_wnaf(Builder* builder,
+                                                         const std::vector<field_t<Builder>>& wnaf,
+                                                         const field_t<Builder>& positive_skew,
+                                                         const field_t<Builder>& stagger_fragment,
+                                                         const size_t stagger,
+                                                         const size_t rounds)
+{
+    std::vector<field_t<C>> accumulator;
+    // Collect positive wnaf entries for accumulation
+    for (size_t i = 0; i < rounds; ++i) {
+        field_t<C> entry = wnaf[rounds - 1 - i];
+        entry *= static_cast<field_t<C>>(uint256_t(1) << (i * wnaf_size));
+        accumulator.emplace_back(entry);
+    }
+    // Accumulate entries, shift by stagger and add the stagger itself
+    field_t<C> sum = field_t<C>::accumulate(accumulator);
+    sum = sum * field_t<C>(bb::fr(1ULL << stagger));
+    sum += (stagger_fragment);
+    sum = sum.normalize();
+    // TODO: improve efficiency by creating a constructor that does NOT require us to range constrain
+    //       limbs (we already know (sum < 2^{130}))
+    // Convert this value to bigfield element
+    Fr reconstructed = Fr(sum, field_t<C>::from_witness_index(builder, builder->zero_idx), false);
+    // Double the final value and add the skew
+    reconstructed = (reconstructed + reconstructed).add_to_lower_limb(positive_skew, uint256_t(1));
+    return reconstructed;
+}
+
+template <typename C, class Fq, class Fr, class G>
+template <size_t num_bits, size_t wnaf_size, size_t lo_stagger, size_t hi_stagger>
+std::pair<Fr, typename element<C, Fq, Fr, G>::secp256k1_wnaf> element<C, Fq, Fr, G>::compute_secp256k1_single_wnaf(
+    C* builder, const secp256k1::fr& scalar, size_t stagger, bool is_negative, bool is_lo)
+{
+    // The number of rounds is the minimal required to cover the whole scalar with wnaf_size windows
+    constexpr size_t num_rounds = ((num_bits + wnaf_size - 1) / wnaf_size);
+    // Stagger mask is needed to retrieve the lowest bits that will not be used in montgomery ladder directly
+    const uint64_t stagger_mask = (1ULL << stagger) - 1;
+    // Stagger scalar represents the lower "staggered" bits that are not used in the ladder
+    const uint64_t stagger_scalar = scalar.data[0] & stagger_mask;
+
+    uint64_t wnaf_values[num_rounds] = { 0 };
+    bool skew_without_stagger;
+    uint256_t k_u256{ scalar.data[0], scalar.data[1], scalar.data[2], scalar.data[3] };
+    k_u256 = k_u256 >> stagger;
+    if (is_lo) {
+        bb::wnaf::fixed_wnaf<num_bits - lo_stagger, 1, wnaf_size>(
+            &k_u256.data[0], &wnaf_values[0], skew_without_stagger, 0);
+    } else {
+        bb::wnaf::fixed_wnaf<num_bits - hi_stagger, 1, wnaf_size>(
+            &k_u256.data[0], &wnaf_values[0], skew_without_stagger, 0);
+    }
+
+    // Number of rounds that are needed to reconstruct the scalar without staggered bits
+    const size_t num_rounds_excluding_stagger_bits = ((num_bits + wnaf_size - 1 - stagger) / wnaf_size);
+
+    // Compute the stagger-related fragment and the final skew due to the same
+    const auto [first_fragment, skew] = compute_secp256k1_staggered_wnaf_fragment<wnaf_size>(
+        stagger_scalar, stagger, is_negative, skew_without_stagger);
+
+    constexpr uint64_t wnaf_window_size = (1ULL << (wnaf_size - 1));
+
+    // Get wnaf witnesses
+    std::vector<field_t<C>> wnaf = convert_wnaf_values_to_witnesses<wnaf_size>(
+        builder, &wnaf_values[0], is_negative, num_rounds_excluding_stagger_bits);
+
+    // Compute and constrain skews
+    field_t<C> negative_skew = witness_t<C>(builder, is_negative ? 0 : skew);
+    field_t<C> positive_skew = witness_t<C>(builder, is_negative ? skew : 0);
+    builder->create_new_range_constraint(negative_skew.witness_index, 1, "biggroup_nafs");
+    builder->create_new_range_constraint(positive_skew.witness_index, 1, "biggroup_nafs");
+    builder->create_new_range_constraint((negative_skew + positive_skew).witness_index, 1, "biggroup_nafs");
+
+    // Initialize stagger witness
+    field_t<C> stagger_fragment = witness_t<C>(builder, first_fragment);
+
+    // Reconstruct bigfield x_pos
+    Fr wnaf_sum = reconstruct_bigfield_from_wnaf<wnaf_size>(
+        builder, wnaf, positive_skew, stagger_fragment, stagger, num_rounds_excluding_stagger_bits);
+
+    // Start reconstructing x_neg
+    uint256_t negative_constant_wnaf_offset(0);
+
+    // Construct 0xF..F
+    for (size_t i = 0; i < num_rounds_excluding_stagger_bits; ++i) {
+        negative_constant_wnaf_offset += uint256_t(wnaf_window_size * 2 - 1) * (uint256_t(1) << (i * wnaf_size));
+    }
+    // Shift by stagger
+    negative_constant_wnaf_offset = negative_constant_wnaf_offset << stagger;
+    // Add for stagger
+    if (stagger > 0) {
+        negative_constant_wnaf_offset += ((1ULL << wnaf_size) - 1ULL); // FROM STAGGER FRAMGENT
+    }
+
+    // TODO: improve efficiency by removing range constraint on lo_offset and hi_offset (we already know are
+    // boolean)
+    // Add the skew to the bigfield constant
+    Fr offset = Fr(nullptr, negative_constant_wnaf_offset).add_to_lower_limb(negative_skew, uint256_t(1));
+    // x_pos - x_neg
+    Fr reconstructed = wnaf_sum - offset;
+
+    secp256k1_wnaf wnaf_out{ .wnaf = wnaf,
+                             .positive_skew = positive_skew,
+                             .negative_skew = negative_skew,
+                             .least_significant_wnaf_fragment = stagger_fragment,
+                             .has_wnaf_fragment = (stagger > 0) };
+
+    return std::make_pair<Fr, secp256k1_wnaf>((Fr)reconstructed, (secp256k1_wnaf)wnaf_out);
+}
+
 /**
  * Split a secp256k1 Fr element into two 129 bit scalars `klo, khi`, where `scalar = klo + \lambda * khi mod n`
  *   where `\lambda` is the cube root of unity mod n, and `n` is the secp256k1 Fr modulus
@@ -132,191 +317,6 @@ typename element<C, Fq, Fr, G>::secp256k1_wnaf_pair element<C, Fq, Fr, G>::compu
 
     constexpr size_t num_bits = 129;
 
-    /**
-     * @brief Compute WNAF of a single 129-bit scalar
-     *
-     * @param k Scalar
-     * @param stagger The number of bits that are used in "staggering"
-     * @param is_negative If it should be subtracted
-     * @param is_lo True if it's the low scalar
-     */
-    const auto compute_single_wnaf = [ctx](const secp256k1::fr& k,
-                                           const auto stagger,
-                                           const bool is_negative,
-                                           const bool is_lo = false) {
-        // The number of rounds is the minimal required to cover the whole scalar with wnaf_size windows
-        constexpr size_t num_rounds = ((num_bits + wnaf_size - 1) / wnaf_size);
-        // Stagger mask is needed to retrieve the lowest bits that will not be used in montgomery ladder directly
-        const uint64_t stagger_mask = (1ULL << stagger) - 1;
-        // Stagger scalar represents the lower "staggered" bits that are not used in the ladder
-        const uint64_t stagger_scalar = k.data[0] & stagger_mask;
-
-        uint64_t wnaf_values[num_rounds] = { 0 };
-        bool skew_without_stagger;
-        uint256_t k_u256{ k.data[0], k.data[1], k.data[2], k.data[3] };
-        k_u256 = k_u256 >> stagger;
-        if (is_lo) {
-            bb::wnaf::fixed_wnaf<num_bits - lo_stagger, 1, wnaf_size>(
-                &k_u256.data[0], &wnaf_values[0], skew_without_stagger, 0);
-        } else {
-            bb::wnaf::fixed_wnaf<num_bits - hi_stagger, 1, wnaf_size>(
-                &k_u256.data[0], &wnaf_values[0], skew_without_stagger, 0);
-        }
-
-        // Number of rounds that are needed to reconstruct the scalar without staggered bits
-        const size_t num_rounds_excluding_stagger_bits = ((num_bits + wnaf_size - 1 - stagger) / wnaf_size);
-
-        /**
-         * @brief Compute the stagger-related part of WNAF and the final skew
-         *
-         * @param fragment_u64 Stagger-masked lower bits of the skalar
-         * @param stagger The number of staggering bits
-         * @param is_negative If the initial scalar is supposed to be subtracted
-         * @param wnaf_skew The skew of the stagger-right-shifted part of the skalar
-         *
-         */
-        const auto compute_staggered_wnaf_fragment =
-            [](const uint64_t fragment_u64, const uint64_t stagger, bool is_negative, bool wnaf_skew) {
-                // If there is not stagger then there is no need to change anyhing
-                if (stagger == 0) {
-                    return std::make_pair<uint64_t, bool>((uint64_t)0, (bool)wnaf_skew);
-                }
-                int fragment = static_cast<int>(fragment_u64);
-                // Inverse the fragment if it's negative
-                if (is_negative) {
-                    fragment = -fragment;
-                }
-                // If the value is positive and there is a skew in wnaf, subtract 2ˢᵗᵃᵍᵍᵉʳ. If negative and there is
-                // skew, then add
-                if (!is_negative && wnaf_skew) {
-                    fragment -= (1 << stagger);
-                } else if (is_negative && wnaf_skew) {
-                    fragment += (1 << stagger);
-                }
-                // If the lowest bit is zero, then set final skew to 1 and add 1 to the absolute value of the fragment
-                bool output_skew = (fragment_u64 % 2) == 0;
-                if (!is_negative && output_skew) {
-                    fragment += 1;
-                } else if (is_negative && output_skew) {
-                    fragment -= 1;
-                }
-
-                uint64_t output_fragment;
-                if (fragment < 0) {
-                    output_fragment = static_cast<uint64_t>((int)((1ULL << (wnaf_size - 1))) + (fragment / 2 - 1));
-                } else {
-                    output_fragment = static_cast<uint64_t>((1ULL << (wnaf_size - 1)) - 1ULL +
-                                                            (uint64_t)((uint64_t)fragment / 2 + 1));
-                }
-
-                return std::make_pair<uint64_t, bool>((uint64_t)output_fragment, (bool)output_skew);
-            };
-
-        // Compute the lowest fragment and final skew
-        const auto [first_fragment, skew] =
-            compute_staggered_wnaf_fragment(stagger_scalar, stagger, is_negative, skew_without_stagger);
-
-        constexpr uint64_t wnaf_window_size = (1ULL << (wnaf_size - 1));
-        /**
-         * @brief Compute wnaf values, convert them into witness field elements and range constrain them
-         *
-         */
-        const auto get_wnaf_wires = [ctx](uint64_t* wnaf_values, bool is_negative, size_t rounds) {
-            std::vector<field_t<C>> wnaf_entries;
-            for (size_t i = 0; i < rounds; ++i) {
-                // Predicate == sign of current wnaf value
-                bool predicate = bool((wnaf_values[i] >> 31U) & 1U);
-                uint64_t offset_entry;
-                // If the signs of current entry and the whole scalar are the same, then add the lowest bits of current
-                // wnaf value to the windows size to form an entry. Otherwise, subract the lowest bits along with 1
-                if ((!predicate && !is_negative) || (predicate && is_negative)) {
-                    // TODO: Why is this mask fixed?
-                    offset_entry = wnaf_window_size + (wnaf_values[i] & 0xffffff);
-                } else {
-                    offset_entry = wnaf_window_size - 1 - (wnaf_values[i] & 0xffffff);
-                }
-                field_t<C> entry(witness_t<C>(ctx, offset_entry));
-
-                // TODO: Do these need to be range constrained? we use these witnesses
-                // to index a size-16 ROM lookup table, which performs an implicit range constraint
-                entry.create_range_constraint(wnaf_size);
-                wnaf_entries.emplace_back(entry);
-            }
-            return wnaf_entries;
-        };
-
-        // Get wnaf witnesses
-        std::vector<field_t<C>> wnaf = get_wnaf_wires(&wnaf_values[0], is_negative, num_rounds_excluding_stagger_bits);
-        // Compute and constrain skews
-        field_t<C> negative_skew = witness_t<C>(ctx, is_negative ? 0 : skew);
-        field_t<C> positive_skew = witness_t<C>(ctx, is_negative ? skew : 0);
-        ctx->create_new_range_constraint(negative_skew.witness_index, 1, "biggroup_nafs");
-        ctx->create_new_range_constraint(positive_skew.witness_index, 1, "biggroup_nafs");
-        ctx->create_new_range_constraint((negative_skew + positive_skew).witness_index, 1, "biggroup_nafs");
-
-        const auto reconstruct_bigfield_from_wnaf = [ctx](const std::vector<field_t<C>>& wnaf,
-                                                          const field_t<C>& positive_skew,
-                                                          const field_t<C>& stagger_fragment,
-                                                          const size_t stagger,
-                                                          const size_t rounds) {
-            std::vector<field_t<C>> accumulator;
-            // Collect positive wnaf entries for accumulation
-            for (size_t i = 0; i < rounds; ++i) {
-                field_t<C> entry = wnaf[rounds - 1 - i];
-                entry *= static_cast<field_t<C>>(uint256_t(1) << (i * wnaf_size));
-                accumulator.emplace_back(entry);
-            }
-            // Accumulate entries, shift by stagger and add the stagger itself
-            field_t<C> sum = field_t<C>::accumulate(accumulator);
-            sum = sum * field_t<C>(bb::fr(1ULL << stagger));
-            sum += (stagger_fragment);
-            sum = sum.normalize();
-            // TODO: improve efficiency by creating a constructor that does NOT require us to range constrain
-            //       limbs (we already know (sum < 2^{130}))
-            // Convert this value to bigfield element
-            Fr reconstructed = Fr(sum, field_t<C>::from_witness_index(ctx, ctx->zero_idx), false);
-            // Double the final value and add the skew
-            reconstructed = (reconstructed + reconstructed).add_to_lower_limb(positive_skew, uint256_t(1));
-            return reconstructed;
-        };
-
-        // Initialize stagger witness
-        field_t<C> stagger_fragment = witness_t<C>(ctx, first_fragment);
-
-        // Reconstruct bigfield x_pos
-        Fr wnaf_sum = reconstruct_bigfield_from_wnaf(
-            wnaf, positive_skew, stagger_fragment, stagger, num_rounds_excluding_stagger_bits);
-
-        // Start reconstructing x_neg
-        uint256_t negative_constant_wnaf_offset(0);
-
-        // Construct 0xF..F
-        for (size_t i = 0; i < num_rounds_excluding_stagger_bits; ++i) {
-            negative_constant_wnaf_offset += uint256_t(wnaf_window_size * 2 - 1) * (uint256_t(1) << (i * wnaf_size));
-        }
-        // Shift by stagger
-        negative_constant_wnaf_offset = negative_constant_wnaf_offset << stagger;
-        // Add for stagger
-        if (stagger > 0) {
-            negative_constant_wnaf_offset += ((1ULL << wnaf_size) - 1ULL); // FROM STAGGER FRAMGENT
-        }
-
-        // TODO: improve efficiency by removing range constraint on lo_offset and hi_offset (we already know are
-        // boolean)
-        // Add the skew to the bigfield constant
-        Fr offset = Fr(nullptr, negative_constant_wnaf_offset).add_to_lower_limb(negative_skew, uint256_t(1));
-        // x_pos - x_neg
-        Fr reconstructed = wnaf_sum - offset;
-
-        secp256k1_wnaf wnaf_out{ .wnaf = wnaf,
-                                 .positive_skew = positive_skew,
-                                 .negative_skew = negative_skew,
-                                 .least_significant_wnaf_fragment = stagger_fragment,
-                                 .has_wnaf_fragment = (stagger > 0) };
-
-        return std::make_pair<Fr, secp256k1_wnaf>((Fr)reconstructed, (secp256k1_wnaf)wnaf_out);
-    };
-
     secp256k1::fr k(scalar.get_value().lo);
     secp256k1::fr klo(0);
     secp256k1::fr khi(0);
@@ -338,8 +338,13 @@ typename element<C, Fq, Fr, G>::secp256k1_wnaf_pair element<C, Fq, Fr, G>::compu
         khi = -khi;
     }
 
-    const auto [klo_reconstructed, klo_out] = compute_single_wnaf(klo, lo_stagger, klo_negative, true);
-    const auto [khi_reconstructed, khi_out] = compute_single_wnaf(khi, hi_stagger, khi_negative, false);
+    const auto [klo_reconstructed, klo_out] =
+        element<C, Fq, Fr, G>::compute_secp256k1_single_wnaf<num_bits, wnaf_size, lo_stagger, hi_stagger>(
+            ctx, klo, lo_stagger, klo_negative, true);
+
+    const auto [khi_reconstructed, khi_out] =
+        element<C, Fq, Fr, G>::compute_secp256k1_single_wnaf<num_bits, wnaf_size, lo_stagger, hi_stagger>(
+            ctx, khi, hi_stagger, khi_negative, false);
 
     uint256_t minus_lambda_val(-secp256k1::fr::cube_root_of_unity());
     Fr minus_lambda(bb::fr(minus_lambda_val.slice(0, 136)), bb::fr(minus_lambda_val.slice(136, 256)), false);

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_nafs.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_nafs.hpp
@@ -18,16 +18,16 @@ std::pair<uint64_t, bool> element<C, Fq, Fr, G>::compute_secp256k1_staggered_wna
                                                                                            bool is_negative,
                                                                                            bool wnaf_skew)
 {
-    // If there is not stagger then there is no need to change anyhing
+    // If there is no stagger then there is no need to change anything
     if (stagger == 0) {
-        return std::make_pair<uint64_t, bool>((uint64_t)0, (bool)wnaf_skew);
+        return std::make_pair(0, wnaf_skew);
     }
     int fragment = static_cast<int>(fragment_u64);
     // Inverse the fragment if it's negative
     if (is_negative) {
         fragment = -fragment;
     }
-    // If the value is positive and there is a skew in wnaf, subtract 2ˢᵗᵃᵍᵍᵉʳ. If negative and there is
+    // If the value is positive and there is a skew in wnaf, subtract 2^{stagger}. If negative and there is
     // skew, then add
     if (!is_negative && wnaf_skew) {
         fragment -= (1 << stagger);
@@ -50,7 +50,7 @@ std::pair<uint64_t, bool> element<C, Fq, Fr, G>::compute_secp256k1_staggered_wna
             static_cast<uint64_t>((1ULL << (wnaf_size - 1)) - 1ULL + (uint64_t)((uint64_t)fragment / 2 + 1));
     }
 
-    return std::make_pair<uint64_t, bool>((uint64_t)output_fragment, (bool)output_skew);
+    return std::make_pair(output_fragment, output_skew);
 }
 
 template <typename C, class Fq, class Fr, class G>
@@ -193,7 +193,7 @@ std::pair<Fr, typename element<C, Fq, Fr, G>::secp256k1_wnaf> element<C, Fq, Fr,
                              .least_significant_wnaf_fragment = stagger_fragment,
                              .has_wnaf_fragment = (stagger > 0) };
 
-    return std::make_pair<Fr, secp256k1_wnaf>((Fr)reconstructed, (secp256k1_wnaf)wnaf_out);
+    return std::make_pair(reconstructed, wnaf_out);
 }
 
 /**


### PR DESCRIPTION
### 🧾 Audit Context

Refactors lambda functions in `biggroup::compute_secp256k1_endo_wnaf` to private functions.

### 🛠️ Changes Made

- No logic changes, only scoops lambda functions to make them private functions for easier testing.
- Adds a section in biggroup README on how the wNAF reconstruction works for secp256k1.

### ✅ Checklist

- [x] Audited all methods of the relevant module/class
- [x] Audited the interface of the module/class with other (relevant) components
- [x] Documented existing functionality and any changes made (as per Doxygen requirements)
- [ ] Resolved and/or closed all issues/TODOs pertaining to the audited files
- [ ] Confirmed and documented any security or other issues found (if applicable)
- [ ] Verified that tests cover all critical paths (and added tests if necessary)
- [ ] Updated audit tracking for the files audited (check the start of each file you audited)

### 📌 Notes for Reviewers

(Optional) Call out anything that reviewers should pay close attention to — like logic changes, performance implications, or potential regressions.
