### PR TITLE
fix: only "known" errors should be caught during public tx simulation

### DIFF
--- a/yarn-project/simulator/src/public/avm/avm_simulator.test.ts
+++ b/yarn-project/simulator/src/public/avm/avm_simulator.test.ts
@@ -28,6 +28,7 @@ import { PublicKeys } from '@aztec/stdlib/keys';
 import { makeContractClassPublic, makeContractInstanceFromClassId } from '@aztec/stdlib/testing';
 import { NativeWorldStateService } from '@aztec/world-state';
 
+import { jest } from '@jest/globals';
 import { strict as assert } from 'assert';
 import { randomInt } from 'crypto';
 import { mock } from 'jest-mock-extended';
@@ -63,7 +64,7 @@ import {
   EmitNoteHash,
   EmitNullifier,
   EmitUnencryptedLog,
-  type Instruction,
+  Instruction,
   Jump,
   Return,
   SStore,
@@ -1470,6 +1471,33 @@ describe('AVM simulator: shift operations with huge amounts', () => {
       expect(results.reverted).toBe(false);
       expect(results.output).toEqual([new Fr(0)]);
     });
+  });
+});
+
+describe('AVM simulator: "unchecked" errors should NOT be caught', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('Unchecked error during instruction execution NOT be caught', async () => {
+    const context = initContext();
+    const instruction = new Add(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).as(
+      Opcode.ADD_8,
+      Add.wireFormat8,
+    );
+
+    const msg = 'This is an unchecked error during instruction execution';
+    jest.spyOn(Add.prototype, 'execute').mockRejectedValue(new Error(msg));
+    const bytecode = encodeToBytecode([instruction]);
+
+    await expect(new AvmSimulator(context).executeBytecode(bytecode)).rejects.toThrow(msg);
+  });
+
+  it('Unchecked error during getBytecode NOT be caught', async () => {
+    const context = initContext();
+    const msg = 'This is an unchecked error during getBytecode';
+    jest.spyOn(context.persistableState, 'getBytecode').mockRejectedValue(new Error(msg));
+    await expect(new AvmSimulator(context).execute()).rejects.toThrow(msg);
   });
 });
 

--- a/yarn-project/simulator/src/public/avm/errors.ts
+++ b/yarn-project/simulator/src/public/avm/errors.ts
@@ -1,23 +1,16 @@
 import type { Point } from '@aztec/foundation/fields';
-import type { AztecAddress } from '@aztec/stdlib/aztec-address';
 import type { FailingFunction, NoirCallStack } from '@aztec/stdlib/errors';
 
 import { ExecutionError } from '../../common/errors.js';
+import { CheckedPublicExecutionError } from '../public_errors.js';
 
 /**
  * Avm-specific errors should derive from this
  */
-export abstract class AvmExecutionError extends Error {
+export abstract class AvmExecutionError extends CheckedPublicExecutionError {
   constructor(message: string) {
     super(message);
     this.name = 'AvmExecutionError';
-  }
-}
-
-export class NoBytecodeForContractError extends AvmExecutionError {
-  constructor(contractAddress: AztecAddress) {
-    super(`No bytecode found at: ${contractAddress}`);
-    this.name = 'NoBytecodeFoundInterpreterError';
   }
 }
 
@@ -129,22 +122,12 @@ export class OutOfGasError extends AvmExecutionError {
 }
 
 /**
- * Error is thrown when the supplied points length is not a multiple of 3. Specific for MSM opcode.
+ * Error is thrown when one of the supplied points does not lie on the Grumpkin curve. Specific for ECADD opcode.
  */
-export class MSMPointsLengthError extends AvmExecutionError {
-  constructor(pointsReadLength: number) {
-    super(`Points vector length should be a multiple of 3, was ${pointsReadLength}`);
-    this.name = 'MSMPointsLengthError';
-  }
-}
-
-/**
- * Error is thrown when one of the supplied points does not lie on the Grumpkin curve. Specific for MSM opcode.
- */
-export class MSMPointNotOnCurveError extends AvmExecutionError {
-  constructor(point: Point) {
-    super(`Point ${point.toString()} is not on the curve.`);
-    this.name = 'MSMPointNotOnCurveError';
+export class EcAddPointNotOnCurveError extends AvmExecutionError {
+  constructor(pointIndex: number, point: Point) {
+    super(`EcAdd point${pointIndex} (${point.toString()}) is not on the curve.`);
+    this.name = 'EcAddPointNotOnCurveError';
   }
 }
 

--- a/yarn-project/simulator/src/public/avm/opcodes/accrued_substate.ts
+++ b/yarn-project/simulator/src/public/avm/opcodes/accrued_substate.ts
@@ -1,4 +1,4 @@
-import { NullifierCollisionError } from '../../state_manager/nullifiers.js';
+import { NullifierCollisionError } from '../../side_effect_errors.js';
 import type { AvmContext } from '../avm_context.js';
 import { TypeTag, Uint1 } from '../avm_memory_types.js';
 import { InstructionExecutionError, StaticCallAlterationError } from '../errors.js';

--- a/yarn-project/simulator/src/public/avm/opcodes/addressing_mode.ts
+++ b/yarn-project/simulator/src/public/avm/opcodes/addressing_mode.ts
@@ -2,6 +2,8 @@ import { AVM_MAX_OPERANDS } from '@aztec/constants';
 import { padArrayEnd } from '@aztec/foundation/collection';
 import type { Tuple } from '@aztec/foundation/serialize';
 
+import { strict as assert } from 'assert';
+
 import { MemoryValue, TaggedMemory, type TaggedMemoryInterface, TypeTag } from '../avm_memory_types.js';
 import { RelativeAddressOutOfRangeError, TagCheckError } from '../errors.js';
 
@@ -20,9 +22,7 @@ export class Addressing {
   ) {}
 
   public static fromModes(modes: AddressingMode[]): Addressing {
-    if (modes.length > AVM_MAX_OPERANDS) {
-      throw new Error('Too many operands for addressing mode');
-    }
+    assert(modes.length <= AVM_MAX_OPERANDS, 'Too many operands for addressing mode');
     return new Addressing(padArrayEnd(modes, AddressingMode.DIRECT, AVM_MAX_OPERANDS));
   }
 

--- a/yarn-project/simulator/src/public/avm/opcodes/ec_add.ts
+++ b/yarn-project/simulator/src/public/avm/opcodes/ec_add.ts
@@ -3,6 +3,7 @@ import { Point } from '@aztec/foundation/fields';
 
 import type { AvmContext } from '../avm_context.js';
 import { Field, TypeTag, Uint1 } from '../avm_memory_types.js';
+import { EcAddPointNotOnCurveError } from '../errors.js';
 import { Opcode, OperandType } from '../serialization/instruction_serialization.js';
 import { Addressing } from './addressing_mode.js';
 import { Instruction } from './instruction.js';
@@ -65,7 +66,7 @@ export class EcAdd extends Instruction {
     const p1IsInfinite = memory.get(p1IsInfiniteOffset).toNumber() === 1;
     const p1 = new Point(p1X.toFr(), p1Y.toFr(), p1IsInfinite);
     if (!p1.isOnGrumpkin()) {
-      throw new Error(`Point1 is not on the curve`);
+      throw new EcAddPointNotOnCurveError(/*pointIndex=*/ 1, p1);
     }
 
     const p2X = memory.get(p2XOffset);
@@ -74,7 +75,7 @@ export class EcAdd extends Instruction {
     const p2IsInfinite = memory.get(p2IsInfiniteOffset).toNumber() === 1;
     const p2 = new Point(p2X.toFr(), p2Y.toFr(), p2IsInfinite);
     if (!p2.isOnGrumpkin()) {
-      throw new Error(`Point1 is not on the curve`);
+      throw new EcAddPointNotOnCurveError(/*pointIndex=*/ 2, p2);
     }
 
     const grumpkin = new Grumpkin();

--- a/yarn-project/simulator/src/public/avm/opcodes/environment_getters.ts
+++ b/yarn-project/simulator/src/public/avm/opcodes/environment_getters.ts
@@ -20,8 +20,8 @@ export enum EnvironmentVariable {
   DAGASLEFT,
 }
 
-function getValue(e: EnvironmentVariable, ctx: AvmContext) {
-  switch (e) {
+function getValue(varEnum: EnvironmentVariable, ctx: AvmContext) {
+  switch (varEnum) {
     case EnvironmentVariable.ADDRESS:
       return new Field(ctx.environment.address.toField());
     case EnvironmentVariable.SENDER:
@@ -47,7 +47,7 @@ function getValue(e: EnvironmentVariable, ctx: AvmContext) {
     case EnvironmentVariable.DAGASLEFT:
       return new Uint32(ctx.machineState.daGasLeft);
     default:
-      throw new Error(`Unknown environment variable ${e}`);
+      throw new InstructionExecutionError(`Invalid GETENVVAR var enum ${varEnum}`);
   }
 }
 
@@ -77,13 +77,11 @@ export class GetEnvVar extends Instruction {
       this.baseGasCost(addressing.indirectOperandsCount(), addressing.relativeOperandsCount()),
     );
 
-    if (!(this.varEnum in EnvironmentVariable)) {
-      throw new InstructionExecutionError(`Invalid GETENVVAR var enum ${this.varEnum}`);
-    }
-
     const operands = [this.dstOffset];
     const [dstOffset] = addressing.resolve(operands, memory);
 
-    memory.set(dstOffset, getValue(this.varEnum as EnvironmentVariable, context));
+    const value = getValue(this.varEnum as EnvironmentVariable, context);
+
+    memory.set(dstOffset, value);
   }
 }

--- a/yarn-project/simulator/src/public/avm/opcodes/instruction.ts
+++ b/yarn-project/simulator/src/public/avm/opcodes/instruction.ts
@@ -114,9 +114,7 @@ export abstract class Instruction {
    */
   public get type(): string {
     const type = 'type' in this.constructor && (this.constructor.type as string);
-    if (!type) {
-      throw new Error(`Instruction class ${this.constructor.name} does not have a static 'type' property defined.`);
-    }
+    assert(!!type, `Instruction class ${this.constructor.name} does not have a static 'type' property defined.`);
     return type;
   }
 
@@ -126,9 +124,11 @@ export abstract class Instruction {
    */
   public get opcode(): Opcode {
     const opcode = 'opcode' in this.constructor ? (this.constructor.opcode as Opcode) : undefined;
-    if (opcode === undefined || Opcode[opcode] === undefined) {
-      throw new Error(`Instruction class ${this.constructor.name} does not have a static 'opcode' property defined.`);
-    }
+    assert(
+      opcode !== undefined,
+      `Instruction class ${this.constructor.name} does not have a static 'opcode' property defined.`,
+    );
+    assert(Opcode[opcode] !== undefined, `Invalid opcode ${opcode} for instruction class ${this.constructor.name}.`);
     return opcode;
   }
 }

--- a/yarn-project/simulator/src/public/bytecode_errors.ts
+++ b/yarn-project/simulator/src/public/bytecode_errors.ts
@@ -1,6 +1,0 @@
-export class ContractClassBytecodeError extends Error {
-  constructor(contractAddress: string) {
-    super(`Failed to get bytecode for contract at address ${contractAddress}`);
-    this.name = 'ContractClassBytecodeError';
-  }
-}

--- a/yarn-project/simulator/src/public/public_errors.ts
+++ b/yarn-project/simulator/src/public/public_errors.ts
@@ -1,0 +1,14 @@
+/**
+ * Any known (and checked) error that can be thrown during public execution.
+ * Includes AvmExecutionErrors and SideEffectErrors.
+ *
+ * AvmSimulator catches any checked errors before returning a boolean "reverted".
+ * Unchecked errors are generally the result of a bug. They are propagated and
+ * ultimately will be the resonsibility of PublicProcessor to handle.
+ */
+export abstract class CheckedPublicExecutionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'CheckedPublicExecutionError';
+  }
+}

--- a/yarn-project/simulator/src/public/public_processor/public_processor.test.ts
+++ b/yarn-project/simulator/src/public/public_processor/public_processor.test.ts
@@ -126,7 +126,7 @@ describe('public_processor', () => {
     });
 
     it('returns failed txs without aborting entire operation', async function () {
-      publicTxSimulator.simulate.mockRejectedValue(new SimulationError(`Failed`, []));
+      publicTxSimulator.simulate.mockRejectedValue(new Error(`Failed`));
 
       const tx = await mockTxWithPublicCalls();
       const [processed, failed] = await processor.process([tx]);
@@ -134,7 +134,7 @@ describe('public_processor', () => {
       expect(processed).toEqual([]);
       expect(failed.length).toBe(1);
       expect(failed[0].tx).toEqual(tx);
-      expect(failed[0].error).toEqual(new SimulationError(`Failed`, []));
+      expect(failed[0].error).toEqual(new Error(`Failed`));
 
       expect(merkleTree.commitCheckpoint).toHaveBeenCalledTimes(0);
       expect(merkleTree.revertCheckpoint).toHaveBeenCalledTimes(1);

--- a/yarn-project/simulator/src/public/public_tx_simulator/measured_public_tx_simulator.ts
+++ b/yarn-project/simulator/src/public/public_tx_simulator/measured_public_tx_simulator.ts
@@ -48,11 +48,10 @@ export class MeasuredPublicTxSimulator extends PublicTxSimulator {
     this.metrics.recordPrivateEffectsInsertion(timer.us(), 'non-revertible');
   }
 
-  protected override async insertRevertiblesFromPrivate(context: PublicTxContext, tx: Tx): Promise<boolean> {
+  protected override async insertRevertiblesFromPrivate(context: PublicTxContext, tx: Tx) {
     const timer = new Timer();
-    const result = await super.insertRevertiblesFromPrivate(context, tx);
+    await super.insertRevertiblesFromPrivate(context, tx);
     this.metrics.recordPrivateEffectsInsertion(timer.us(), 'revertible');
-    return result;
   }
 
   protected override async simulatePhase(phase: TxExecutionPhase, context: PublicTxContext): Promise<ProcessedPhase> {

--- a/yarn-project/simulator/src/public/side_effect_errors.ts
+++ b/yarn-project/simulator/src/public/side_effect_errors.ts
@@ -1,6 +1,61 @@
-export class SideEffectLimitReachedError extends Error {
+import {
+  MAX_L2_TO_L1_MSGS_PER_TX,
+  MAX_NOTE_HASHES_PER_TX,
+  MAX_NULLIFIERS_PER_TX,
+  MAX_PUBLIC_CALLS_TO_UNIQUE_CONTRACT_CLASS_IDS,
+} from '@aztec/constants';
+
+import { CheckedPublicExecutionError } from './public_errors.js';
+
+/**
+ * Any error that can be thrown during side effect insertion in public.
+ * Includes SideEffectLimitReachedError and NullifierCollisionError.
+ */
+export abstract class SideEffectError extends CheckedPublicExecutionError {
+  constructor(message: string) {
+    super(message);
+    this.name = 'SideEffectInsertionError';
+  }
+}
+
+export class SideEffectLimitReachedError extends SideEffectError {
   constructor(sideEffectType: string, limit: number) {
     super(`Reached the limit (${limit}) on number of '${sideEffectType}' per tx`);
     this.name = 'SideEffectLimitReachedError';
+  }
+}
+
+export class MaxCallsToUniqueContractClassIdsError extends SideEffectLimitReachedError {
+  constructor() {
+    super('contract calls to unique class IDs', MAX_PUBLIC_CALLS_TO_UNIQUE_CONTRACT_CLASS_IDS);
+    this.name = 'MaxCallsToUniqueContractClassIdsError';
+  }
+}
+
+export class NullifierLimitReachedError extends SideEffectLimitReachedError {
+  constructor() {
+    super('nullifier', MAX_NULLIFIERS_PER_TX);
+    this.name = 'NullifierLimitReachedError';
+  }
+}
+
+export class NoteHashLimitReachedError extends SideEffectLimitReachedError {
+  constructor() {
+    super('note hash', MAX_NOTE_HASHES_PER_TX);
+    this.name = 'NoteHashLimitReachedError';
+  }
+}
+
+export class L2ToL1MessageLimitReachedError extends SideEffectLimitReachedError {
+  constructor() {
+    super('l2 to l1 message', MAX_L2_TO_L1_MSGS_PER_TX);
+    this.name = 'L2ToL1MessageLimitReachedError';
+  }
+}
+
+export class NullifierCollisionError extends SideEffectError {
+  constructor(message: string) {
+    super(`Nullifier collision: ${message}`);
+    this.name = 'NullifierCollisionError';
   }
 }

--- a/yarn-project/simulator/src/public/side_effect_trace.test.ts
+++ b/yarn-project/simulator/src/public/side_effect_trace.test.ts
@@ -20,7 +20,7 @@ import { makeContractClassPublic } from '@aztec/stdlib/testing';
 
 import { randomInt } from 'crypto';
 
-import { SideEffectLimitReachedError } from './side_effect_errors.js';
+import { MaxCallsToUniqueContractClassIdsError, SideEffectLimitReachedError } from './side_effect_errors.js';
 import { SideEffectArrayLengths, SideEffectTrace } from './side_effect_trace.js';
 
 describe('Public Side Effect Trace', () => {
@@ -172,7 +172,9 @@ describe('Public Side Effect Trace', () => {
         ...(await makeContractClassPublic(MAX_PUBLIC_CALLS_TO_UNIQUE_CONTRACT_CLASS_IDS)),
         publicBytecodeCommitment: Fr.random(),
       };
-      expect(() => trace.traceGetContractClass(klass.id, /*exists=*/ true)).toThrow(SideEffectLimitReachedError);
+      expect(() => trace.traceGetContractClass(klass.id, /*exists=*/ true)).toThrow(
+        MaxCallsToUniqueContractClassIdsError,
+      );
 
       // can re-trace same first class
       trace.traceGetContractClass(firstClass.id, /*exists=*/ true);

--- a/yarn-project/simulator/src/public/state_manager/nullifiers.ts
+++ b/yarn-project/simulator/src/public/state_manager/nullifiers.ts
@@ -1,6 +1,7 @@
 import type { Fr } from '@aztec/foundation/fields';
 
 import type { PublicTreesDB } from '../public_db_sources.js';
+import { NullifierCollisionError } from '../side_effect_errors.js';
 
 /**
  * A class to manage new nullifier staging and existence checks during a contract call's AVM simulation.
@@ -98,12 +99,5 @@ export class NullifierManager {
       }
     }
     this.cache = new Set([...this.cache, ...incomingNullifiers.cache]);
-  }
-}
-
-export class NullifierCollisionError extends Error {
-  constructor(message: string, ...rest: any[]) {
-    super(message, ...rest);
-    this.name = 'NullifierCollisionError';
   }
 }


### PR DESCRIPTION
PublicTxSimulator should only catch known errors, and only those from revertible insertions. It should absolutely not catch unknown errors! **It _also_ should not catch "known" errors thrown by the AvmSimulator!** The AvmSimulator catches known errors and returns happily with `reverted: true`. It will never throw an error up to PublicTxSimulator unless there is a bug.

I created two abstract error classes:
1. `CheckedPublicExecutionError`: parent class of _all_ checked/known errors that can be thrown during public execution (`AvmExecutionError` and `SideEffectError`)
2. `SideEffectError`: all side effect errors that can be thrown during public tx execution (including `SideEffectLimitReachedError` and `NullifierCollisionError`)

And I the following narrow error classes (subclasses of `SideEffectLimitReachedError` which is itself a `SideEffectError`):
1. `MaxCallsToUniqueContractClassIdsError`
2. `NullifierLimitReachedError`
3. `NoteHashLimitReachedError`
4. `L2ToL1MessageLimitReachedError`

`NullifierCollision` subclasses `SideEffectError`.

During instruction execution, AvmSimulator can just catch `KnownPublicExecutionErrors`.

During revertible insertions, PublicTxSimulator catches the narrowest possible errors:
1. During nullifier insertions: `NullifierLimitReachedError || NullifierCollisionError`
2. During note hash insertions: `NoteHashLimitReachedError`
3. During message insertions: `L2ToL1MessageLimitReachedError`

I created 3 new errors that are internal to the `PublicTxSimulator` for control flow and rollback to post-setup state:
1. `TxSimRevertibleInsertionsRevert` (thrown by PublicTxSimulator for any of the checked/known revertible insertion errors
2. `TxSimAppLogicRevert` (thrown in `PublicTxSimulator.simulate(tx)` if app logic reverts)
3. `TxSimTeardownRevert` (thrown in `PublicTxSimulator.simulate(tx)` if teardown reverts)

The top-level `PublicTxSimulator.simulate(tx)` uses these three errors for 

A special case: on bytecode retrieval, if `StateManager` encounters `MaxCallsToUniqueContractClassIdsError` (new side effect error subclass), it will catch it and return undefined (as it does when bytecode does not exist). This means that `AvmSimulator` does not need a try-catch for `getBytecode`.

**This PR adds several tests that errors are caught when they should be, and that unknown errors are not caught.**
