### PR TITLE
chore: Updated metrics alerting for bootnodes

### DIFF
--- a/iac/network/bootnode/vm/gcp/main.tf
+++ b/iac/network/bootnode/vm/gcp/main.tf
@@ -79,6 +79,7 @@ resource "google_compute_instance" "vm" {
       PUBLIC_IP              = data.terraform_remote_state.ip.outputs.ip_addresses[var.regions[count.index]],
       PEER_ID_PRIVATE_KEY    = var.peer_id_private_keys[count.index],
       LOCATION               = "GCP",
+      REGION                 = var.regions[count.index],
       DATA_STORE_MAP_SIZE_KB = 16777216,
       P2P_PORT               = var.p2p_port,
       SSH_USER               = local.ssh_user,

--- a/iac/network/scripts/bootnode_startup.sh
+++ b/iac/network/scripts/bootnode_startup.sh
@@ -15,6 +15,7 @@ L1_CHAIN_ID="${L1_CHAIN_ID}"
 NETWORK_NAME="${NETWORK_NAME}"
 TAG="${TAG}"
 OTEL_COLLECTOR_URL="${OTEL_COLLECTOR_URL}"
+REGION="${REGION}"
 
 # Update system packages
 echo "Updating system packages..."
@@ -100,6 +101,7 @@ CONTAINER_NAME="aztec-bootnode"
 REPO=aztecprotocol
 IMAGE=aztec
 LOG_LEVEL=verbose
+OTEL_RESOURCE_ATTRIBUTES="region=${REGION},ip=${PUBLIC_IP},network=${NETWORK_NAME}"
 
 cat <<EOF > /home/$SSH_USER/tag.sh
 #!/usr/bin/env bash
@@ -136,6 +138,7 @@ docker run \
  --env BOOTSTRAP_NODES \
  --env LOG_LEVEL \
  --env OTEL_EXPORTER_OTLP_METRICS_ENDPOINT \
+ --env OTEL_RESOURCE_ATTRIBUTES \
  $REPO/$IMAGE:$TAG start --p2p-bootstrap
 EOF
 chmod +x /home/$SSH_USER/start.sh
@@ -173,6 +176,7 @@ Environment="IMAGE=$IMAGE"
 Environment="TAG=$TAG"
 Environment="CONTAINER_NAME=$CONTAINER_NAME"
 Environment="OTEL_EXPORTER_OTLP_METRICS_ENDPOINT=$OTEL_EXPORTER_OTLP_METRICS_ENDPOINT"
+Environment="OTEL_RESOURCE_ATTRIBUTES=$OTEL_RESOURCE_ATTRIBUTES"
 ExecStartPre=-/usr/bin/docker rm -f $CONTAINER_NAME
 ExecStart=/home/$SSH_USER/start.sh
 ExecStop=/usr/bin/docker stop $CONTAINER_NAME

--- a/spartan/metrics/grafana/alerts/contactpoints.yaml
+++ b/spartan/metrics/grafana/alerts/contactpoints.yaml
@@ -1,7 +1,7 @@
 apiVersion: 1
 contactPoints:
   - orgId: 1
-    name: "Slack #network-alerts channel"
+    name: "Slack #network-alerts channel by namespace"
     receivers:
       - uid: deexubp9hzpc1b
         type: slack
@@ -44,9 +44,9 @@ contactPoints:
         disableResolveMessage: false
 
   - orgId: 1
-    name: "Slack #alerts-staging-public"
+    name: "Slack #alerts-staging-public by namespace"
     receivers:
-      - uid: alertsstagingpublic
+      - uid: alertsstagingpublicbynamespace
         type: slack
         settings:
           url: $SLACK_WEBHOOK_STAGING_PUBLIC_URL
@@ -87,9 +87,9 @@ contactPoints:
         disableResolveMessage: false
 
   - orgId: 1
-    name: "Slack #alerts-staging-ignition"
+    name: "Slack #alerts-staging-ignition by namespace"
     receivers:
-      - uid: alertsstagingignition
+      - uid: alertsstagingignitionbynamespace
         type: slack
         settings:
           url: $SLACK_WEBHOOK_STAGING_IGNITION_URL
@@ -130,9 +130,9 @@ contactPoints:
         disableResolveMessage: false
 
   - orgId: 1
-    name: "Slack #alerts-next-scenario"
+    name: "Slack #alerts-next-scenario by namespace"
     receivers:
-      - uid: alertsnextscenario
+      - uid: alertsnextscenariobynamespace
         type: slack
         settings:
           url: $SLACK_WEBHOOK_NEXT_SCENARIO_URL
@@ -173,9 +173,9 @@ contactPoints:
         disableResolveMessage: false
 
   - orgId: 1
-    name: "Slack #alerts-testnet"
+    name: "Slack #alerts-testnet by namespace"
     receivers:
-      - uid: alertstestnet
+      - uid: alertstestnetbynamespace
         type: slack
         settings:
           url: $SLACK_WEBHOOK_TESTNET_URL
@@ -216,9 +216,9 @@ contactPoints:
         disableResolveMessage: false
 
   - orgId: 1
-    name: "Slack #alerts-mainnet"
+    name: "Slack #alerts-mainnet by namespace"
     receivers:
-      - uid: alertsmainnet
+      - uid: alertsmainnetbynamespace
         type: slack
         settings:
           url: $SLACK_WEBHOOK_MAINNET_URL
@@ -256,4 +256,116 @@ contactPoints:
             {{ "}}" }}{{ "{{" }} urlquery . {{ "}}" }}{{ "{{" }} else {{ "}}" }}unknown{{ "{{" }} end {{ "}}" }}{{ "{{" }} else {{ "}}" }}{{ "{{" }}
               with (index .CommonLabels "k8s_namespace_name")
             {{ "}}" }}{{ "{{" }} urlquery . {{ "}}" }}{{ "{{" }} else {{ "}}" }}unknown{{ "{{" }} end {{ "}}" }}{{ "{{" }} end {{ "}}" }}%22%5D%29%29
+        disableResolveMessage: false
+
+  - orgId: 1
+    name: "Slack #alerts-staging-public by network"
+    receivers:
+      - uid: alertsstagingpublicbynetwork
+        type: slack
+        settings:
+          url: $SLACK_WEBHOOK_STAGING_PUBLIC_URL
+          text: |-
+            {{ "{{" }} if gt (len .Alerts) 0 {{ "}}" }}
+            *Alerts:*
+            {{ "{{" }} range .Alerts {{ "}}" }}
+            - {{ "{{" }} with (index .Labels "network") {{ "}}" }}{{ "{{" }} . {{ "}}" }}{{ "{{" }} else {{ "}}" }}unknown-network{{ "{{" }} end {{ "}}" }}: {{ "{{" }} with (index .Annotations "summary") {{ "}}" }}{{ "{{" }} . {{ "}}" }}{{ "{{" }} else {{ "}}" }}(no summary){{ "{{" }} end {{ "}}" }}
+            {{ "{{" }} end {{ "}}" }}
+            {{ "{{" }} else {{ "}}" }}
+            *Alerts:*
+            - {{ "{{" }} with (index .CommonAnnotations "summary") {{ "}}" }}{{ "{{" }} . {{ "}}" }}{{ "{{" }} else {{ "}}" }}(no summary){{ "{{" }} end {{ "}}" }}
+            {{ "{{" }} end {{ "}}" }}
+
+            *Grafana overview:*
+            {{ "{{" }} .ExternalURL {{ "}}" }}d/bexge5lz3e51cd/p2p-bootnodes?orgId=1&var-network={{ "{{" }}
+              if gt (len .Alerts) 0
+            {{ "}}" }}{{ "{{" }}
+              with (index (index .Alerts 0).Labels "network")
+            {{ "}}" }}{{ "{{" }} urlquery . {{ "}}" }}{{ "{{" }} else {{ "}}" }}unknown{{ "{{" }} end {{ "}}" }}{{ "{{" }} else {{ "}}" }}{{ "{{" }}
+              with (index .CommonLabels "network")
+            {{ "}}" }}{{ "{{" }} urlquery . {{ "}}" }}{{ "{{" }} else {{ "}}" }}unknown{{ "{{" }} end {{ "}}" }}{{ "{{" }} end {{ "}}" }}
+        disableResolveMessage: false
+
+  - orgId: 1
+    name: "Slack #alerts-staging-ignition by network"
+    receivers:
+      - uid: alertsstagingignitionbynetwork
+        type: slack
+        settings:
+          url: $SLACK_WEBHOOK_STAGING_IGNITION_URL
+          text: |-
+            {{ "{{" }} if gt (len .Alerts) 0 {{ "}}" }}
+            *Alerts:*
+            {{ "{{" }} range .Alerts {{ "}}" }}
+            - {{ "{{" }} with (index .Labels "network") {{ "}}" }}{{ "{{" }} . {{ "}}" }}{{ "{{" }} else {{ "}}" }}unknown-network{{ "{{" }} end {{ "}}" }}: {{ "{{" }} with (index .Annotations "summary") {{ "}}" }}{{ "{{" }} . {{ "}}" }}{{ "{{" }} else {{ "}}" }}(no summary){{ "{{" }} end {{ "}}" }}
+            {{ "{{" }} end {{ "}}" }}
+            {{ "{{" }} else {{ "}}" }}
+            *Alerts:*
+            - {{ "{{" }} with (index .CommonAnnotations "summary") {{ "}}" }}{{ "{{" }} . {{ "}}" }}{{ "{{" }} else {{ "}}" }}(no summary){{ "{{" }} end {{ "}}" }}
+            {{ "{{" }} end {{ "}}" }}
+
+            *Grafana overview:*
+            {{ "{{" }} .ExternalURL {{ "}}" }}d/bexge5lz3e51cd/p2p-bootnodes?orgId=1&var-network={{ "{{" }}
+              if gt (len .Alerts) 0
+            {{ "}}" }}{{ "{{" }}
+              with (index (index .Alerts 0).Labels "network")
+            {{ "}}" }}{{ "{{" }} urlquery . {{ "}}" }}{{ "{{" }} else {{ "}}" }}unknown{{ "{{" }} end {{ "}}" }}{{ "{{" }} else {{ "}}" }}{{ "{{" }}
+              with (index .CommonLabels "network")
+            {{ "}}" }}{{ "{{" }} urlquery . {{ "}}" }}{{ "{{" }} else {{ "}}" }}unknown{{ "{{" }} end {{ "}}" }}{{ "{{" }} end {{ "}}" }}
+        disableResolveMessage: false
+
+  - orgId: 1
+    name: "Slack #alerts-testnet by network"
+    receivers:
+      - uid: alertstestnetbynetwork
+        type: slack
+        settings:
+          url: $SLACK_WEBHOOK_TESTNET_URL
+          text: |-
+            {{ "{{" }} if gt (len .Alerts) 0 {{ "}}" }}
+            *Alerts:*
+            {{ "{{" }} range .Alerts {{ "}}" }}
+            - {{ "{{" }} with (index .Labels "network") {{ "}}" }}{{ "{{" }} . {{ "}}" }}{{ "{{" }} else {{ "}}" }}unknown-network{{ "{{" }} end {{ "}}" }}: {{ "{{" }} with (index .Annotations "summary") {{ "}}" }}{{ "{{" }} . {{ "}}" }}{{ "{{" }} else {{ "}}" }}(no summary){{ "{{" }} end {{ "}}" }}
+            {{ "{{" }} end {{ "}}" }}
+            {{ "{{" }} else {{ "}}" }}
+            *Alerts:*
+            - {{ "{{" }} with (index .CommonAnnotations "summary") {{ "}}" }}{{ "{{" }} . {{ "}}" }}{{ "{{" }} else {{ "}}" }}(no summary){{ "{{" }} end {{ "}}" }}
+            {{ "{{" }} end {{ "}}" }}
+
+            *Grafana overview:*
+            {{ "{{" }} .ExternalURL {{ "}}" }}d/bexge5lz3e51cd/p2p-bootnodes?orgId=1&var-network={{ "{{" }}
+              if gt (len .Alerts) 0
+            {{ "}}" }}{{ "{{" }}
+              with (index (index .Alerts 0).Labels "network")
+            {{ "}}" }}{{ "{{" }} urlquery . {{ "}}" }}{{ "{{" }} else {{ "}}" }}unknown{{ "{{" }} end {{ "}}" }}{{ "{{" }} else {{ "}}" }}{{ "{{" }}
+              with (index .CommonLabels "network")
+            {{ "}}" }}{{ "{{" }} urlquery . {{ "}}" }}{{ "{{" }} else {{ "}}" }}unknown{{ "{{" }} end {{ "}}" }}{{ "{{" }} end {{ "}}" }}
+        disableResolveMessage: false
+
+  - orgId: 1
+    name: "Slack #alerts-mainnet by network"
+    receivers:
+      - uid: alertsmainnetbynetwork
+        type: slack
+        settings:
+          url: $SLACK_WEBHOOK_MAINNET_URL
+          text: |-
+            {{ "{{" }} if gt (len .Alerts) 0 {{ "}}" }}
+            *Alerts:*
+            {{ "{{" }} range .Alerts {{ "}}" }}
+            - {{ "{{" }} with (index .Labels "network") {{ "}}" }}{{ "{{" }} . {{ "}}" }}{{ "{{" }} else {{ "}}" }}unknown-network{{ "{{" }} end {{ "}}" }}: {{ "{{" }} with (index .Annotations "summary") {{ "}}" }}{{ "{{" }} . {{ "}}" }}{{ "{{" }} else {{ "}}" }}(no summary){{ "{{" }} end {{ "}}" }}
+            {{ "{{" }} end {{ "}}" }}
+            {{ "{{" }} else {{ "}}" }}
+            *Alerts:*
+            - {{ "{{" }} with (index .CommonAnnotations "summary") {{ "}}" }}{{ "{{" }} . {{ "}}" }}{{ "{{" }} else {{ "}}" }}(no summary){{ "{{" }} end {{ "}}" }}
+            {{ "{{" }} end {{ "}}" }}
+
+            *Grafana overview:*
+            {{ "{{" }} .ExternalURL {{ "}}" }}d/bexge5lz3e51cd/p2p-bootnodes?orgId=1&var-network={{ "{{" }}
+              if gt (len .Alerts) 0
+            {{ "}}" }}{{ "{{" }}
+              with (index (index .Alerts 0).Labels "network")
+            {{ "}}" }}{{ "{{" }} urlquery . {{ "}}" }}{{ "{{" }} else {{ "}}" }}unknown{{ "{{" }} end {{ "}}" }}{{ "{{" }} else {{ "}}" }}{{ "{{" }}
+              with (index .CommonLabels "network")
+            {{ "}}" }}{{ "{{" }} urlquery . {{ "}}" }}{{ "{{" }} else {{ "}}" }}unknown{{ "{{" }} end {{ "}}" }}{{ "{{" }} end {{ "}}" }}
         disableResolveMessage: false

--- a/spartan/metrics/grafana/alerts/policies.yaml
+++ b/spartan/metrics/grafana/alerts/policies.yaml
@@ -6,37 +6,86 @@ policies:
       - grafana_folder
       - alertname
     routes:
-      - receiver: "Slack #alerts-staging-public"
+      # Staging Public - by namespace
+      - receiver: "Slack #alerts-staging-public by namespace"
         object_matchers:
           - - k8s_namespace_name
             - =~
             - $STAGING_PUBLIC_REGEX
-      - receiver: "Slack #alerts-staging-ignition"
+      # Staging Public - by network label
+      - receiver: "Slack #alerts-staging-public by network"
+        object_matchers:
+          - - network
+            - =~
+            - $STAGING_PUBLIC_REGEX
+
+
+
+
+      # Staging Ignition - by namespace
+      - receiver: "Slack #alerts-staging-ignition by namespace"
         object_matchers:
           - - k8s_namespace_name
             - =~
             - $STAGING_IGNITION_REGEX
-      - receiver: "Slack #alerts-next-scenario"
+      # Staging Ignition - by network label
+      - receiver: "Slack #alerts-staging-ignition by network"
+        object_matchers:
+          - - network
+            - =~
+            - $STAGING_IGNITION_REGEX
+
+
+
+      # Next Scenario - by namespace
+      - receiver: "Slack #alerts-next-scenario by namespace"
         object_matchers:
           - - k8s_namespace_name
             - =~
             - $NEXT_SCENARIO_REGEX
-      - receiver: "Slack #alerts-testnet"
+
+
+
+      # Testnet - by namespace
+      - receiver: "Slack #alerts-testnet by namespace"
         object_matchers:
           - - k8s_namespace_name
             - =~
             - $TESTNET_NAMESPACES_REGEX
-      - receiver: "Slack #alerts-mainnet"
+
+      # Testnet - by network label
+      - receiver: "Slack #alerts-testnet by network"
+        object_matchers:
+          - - network
+            - =~
+            - $TESTNET_NAMESPACES_REGEX
+
+
+
+      # Mainnet - by namespace
+      - receiver: "Slack #alerts-mainnet by namespace"
         object_matchers:
           - - k8s_namespace_name
             - =~
             - $MAINNET_NAMESPACES_REGEX
-      - receiver: "Slack #network-alerts channel"
+
+      # Mainnet - by network label
+      - receiver: "Slack #alerts-mainnet by network"
+        object_matchers:
+          - - network
+            - =~
+            - $MAINNET_NAMESPACES_REGEX
+
+
+
+      # Production - by namespace
+      - receiver: "Slack #network-alerts channel by namespace"
         object_matchers:
           - - k8s_namespace_name
             - =~
             - $PRODUCTION_NAMESPACES_REGEX
-      - receiver: "Slack #network-alerts channel"
+      # Nightly - by namespace
+      - receiver: "Slack #network-alerts channel by namespace"
         object_matchers:
           - - k8s_namespace_name
             - =~

--- a/spartan/metrics/grafana/alerts/rules.yaml
+++ b/spartan/metrics/grafana/alerts/rules.yaml
@@ -935,3 +935,68 @@ groups:
           labels:
             <<: *common_labels
           isPaused: false
+    - orgId: 1
+      name: Bootnodes
+      folder: Aztec
+      interval: 1m
+      rules:
+        - uid: cezjxssj1y2v4a
+          title: Bootnode Availability
+          condition: C
+          data:
+            - refId: A
+              relativeTimeRange:
+                from: 600
+                to: 0
+              datasourceUid: spartan-metrics-prometheus
+              model:
+                editorMode: code
+                expr: count by(network)(discv5_kad_table_size{network!=""})
+                instant: true
+                intervalMs: 1000
+                legendFormat: __auto
+                maxDataPoints: 43200
+                range: false
+                refId: A
+            - refId: C
+              relativeTimeRange:
+                from: 600
+                to: 0
+              datasourceUid: __expr__
+              model:
+                conditions:
+                    - evaluator:
+                        params:
+                            - 3
+                        type: lt
+                      operator:
+                        type: and
+                      query:
+                        params:
+                            - C
+                      reducer:
+                        params: []
+                        type: last
+                      type: query
+                datasource:
+                    type: __expr__
+                    uid: __expr__
+                expression: A
+                intervalMs: 1000
+                maxDataPoints: 43200
+                refId: C
+                type: threshold
+          dashboardUid: bexge5lz3e51cd
+          panelId: 5
+          noDataState: NoData
+          execErrState: Error
+          for: 1m
+          annotations:
+            __dashboardUid__: bexge5lz3e51cd
+            __panelId__: "5"
+            description: ""
+            runbook_url: ""
+            summary: One or more bootnodes for {{ ` {{ $labels.network }} ` }} may have stopped.
+          labels:
+            "": ""
+          isPaused: false

--- a/spartan/metrics/grafana/dashboards/bootnodes.json
+++ b/spartan/metrics/grafana/dashboards/bootnodes.json
@@ -1,0 +1,594 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 13,
+  "links": [],
+  "panels": [
+    {
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 7,
+      "title": "Availability by Network",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "default": true,
+        "type": "prometheus",
+        "uid": "spartan-metrics-prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "left",
+            "axisSoftMax": 12,
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 0,
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 1
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": [
+            "last"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "spartan-metrics-prometheus"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "count by(network)(discv5_kad_table_size{network!=\"\"})",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "legendFormat": "{{network}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Number of Running Bootnodes",
+      "type": "timeseries"
+    },
+    {
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 9
+      },
+      "id": 6,
+      "title": "Network Metrics",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "default": true,
+        "type": "prometheus",
+        "uid": "spartan-metrics-prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 18,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 10
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "spartan-metrics-prometheus"
+          },
+          "editorMode": "code",
+          "expr": "process_memory_usage{network=\"$network\"}",
+          "instant": false,
+          "legendFormat": "{{region}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Process memory",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "default": true,
+        "type": "prometheus",
+        "uid": "spartan-metrics-prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 18,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 10
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "spartan-metrics-prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (region)(process_cpu_utilization{network=\"$network\", process_cpu_state!=\"idle\"})",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Process CPU",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "default": true,
+        "type": "prometheus",
+        "uid": "spartan-metrics-prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "axisSoftMax": 12,
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 0,
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 18
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "spartan-metrics-prometheus"
+          },
+          "editorMode": "code",
+          "expr": "discv5_kad_table_size{network=\"$network\"}",
+          "instant": false,
+          "legendFormat": "{{region}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "KAD table size",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "default": true,
+        "type": "prometheus",
+        "uid": "spartan-metrics-prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 18
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "spartan-metrics-prometheus"
+          },
+          "editorMode": "code",
+          "expr": "nodejs_eventloop_utilization{network=\"$network\"}",
+          "instant": false,
+          "legendFormat": "{{region}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Event loop utilization",
+      "type": "timeseries"
+    }
+  ],
+  "schemaVersion": 39,
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "staging-ignition",
+          "value": "staging-ignition"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "spartan-metrics-prometheus"
+        },
+        "definition": "label_values(discv5_kad_table_size,network)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Network",
+        "multi": false,
+        "name": "network",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(discv5_kad_table_size,network)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "P2P bootnodes",
+  "uid": "bexge5lz3e51cd",
+  "version": 7,
+  "weekStart": ""
+}

--- a/spartan/metrics/values.tmp.yaml
+++ b/spartan/metrics/values.tmp.yaml
@@ -122,7 +122,7 @@ grafana:
     STAGING_IGNITION_REGEX: "staging-ignition"
     NEXT_SCENARIO_REGEX: "v[0-9]+-scenario|next-scenario|next-rc-.*"
     TESTNET_NAMESPACES_REGEX: "testnet|v[0-9]+-testnet"
-    MAINNET_NAMESPACES_REGEX: "mainnet|v[0-9]+-mainnet"
+    MAINNET_NAMESPACES_REGEX: "mainnet|v[0-9]+-mainnet|ignition"
     SLACK_WEBHOOK_URL: "http://127.0.0.1" # dummy value
     SLACK_WEBHOOK_STAGING_PUBLIC_URL: "http://127.0.0.1" # dummy value
     SLACK_WEBHOOK_STAGING_IGNITION_URL: "http://127.0.0.1" # dummy value


### PR DESCRIPTION
This PR adds contact points and policies for routing alerts from 'network' labels.
