### PR TITLE
fix!: tx trace should handle reverts early in phase followed by skipped items

### DIFF
--- a/barretenberg/cpp/pil/vm2/tx.pil
+++ b/barretenberg/cpp/pil/vm2/tx.pil
@@ -68,9 +68,12 @@ namespace tx;
     // end_phase = 1, remaining_phase - 1 = 0;
     pol commit is_revertible;
     pol commit reverted;
+    reverted * (1 - reverted) = 0;
+    #[END_PHASE_ON_REVERT]
+    sel * reverted * (1 - end_phase) = 0;
     // phase_value stays the same unless we are at end_phase or reverted
     #[PHASE_VALUE_CONTINUITY]
-    NOT_PHASE_END * (1 - reverted) * (1 - precomputed.first_row) * (phase_value' - phase_value) = 0;
+    NOT_PHASE_END * (1 - precomputed.first_row) * (phase_value' - phase_value) = 0;
     // At the start of a new phase, we need to increment the phase value
     #[INCR_PHASE_VALUE_ON_END]
     NOT_LAST * (1 - reverted) * end_phase * (phase_value' - (phase_value + 1)) = 0;
@@ -95,7 +98,7 @@ namespace tx;
     pol REM_COUNT_MINUS_1 = remaining_phase_counter - 1;
     // If remaining_phase_counter == 1, end_phase = 1
     #[REM_COUNT_IS_ONE]
-    sel * (1 - is_padded) * (REM_COUNT_MINUS_1 * (end_phase * (1 - remaining_phase_minus_one_inv) + remaining_phase_minus_one_inv) - 1 + end_phase) = 0;
+    sel * (1 - reverted) * (1 - is_padded) * (REM_COUNT_MINUS_1 * (end_phase * (1 - remaining_phase_minus_one_inv) + remaining_phase_minus_one_inv) - 1 + end_phase) = 0;
 
     // TODO: Add constraints to propagate down the things read from precomputed
     // while NOT_PHASE_END

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/tx.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/tx.hpp
@@ -14,10 +14,10 @@ template <typename FF_> class txImpl {
   public:
     using FF = FF_;
 
-    static constexpr std::array<size_t, 56> SUBRELATION_PARTIAL_LENGTHS = { 3, 4, 3, 4, 3, 3, 3, 3, 3, 4, 7, 6, 3, 5,
-                                                                            6, 4, 3, 6, 6, 3, 3, 4, 4, 4, 4, 2, 4, 5,
-                                                                            3, 3, 3, 4, 5, 4, 4, 4, 4, 6, 4, 3, 4, 2,
-                                                                            4, 4, 4, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3 };
+    static constexpr std::array<size_t, 58> SUBRELATION_PARTIAL_LENGTHS = { 3, 4, 3, 4, 3, 3, 3, 3, 3, 4, 3, 4, 6, 6, 3,
+                                                                            5, 7, 4, 3, 6, 6, 3, 3, 4, 4, 4, 4, 2, 4, 5,
+                                                                            3, 3, 3, 4, 5, 4, 4, 4, 4, 6, 4, 3, 4, 2, 4,
+                                                                            4, 4, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3 };
 
     template <typename AllEntities> inline static bool skip(const AllEntities& in)
     {
@@ -43,27 +43,28 @@ template <typename FF> class tx : public Relation<txImpl<FF>> {
     static constexpr size_t SR_NO_EARLY_END = 3;
     static constexpr size_t SR_START_WITH_SEL = 4;
     static constexpr size_t SR_START_FOLLOWS_END = 9;
-    static constexpr size_t SR_PHASE_VALUE_CONTINUITY = 10;
-    static constexpr size_t SR_INCR_PHASE_VALUE_ON_END = 11;
-    static constexpr size_t SR_REM_COUNT_IS_ZERO = 13;
-    static constexpr size_t SR_REM_COUNT_IS_ONE = 14;
-    static constexpr size_t SR_READ_PI_LENGTH_SEL = 15;
-    static constexpr size_t SR_ONE_SHOT_REMAINING_PHASE_COUNTER_ONE = 16;
-    static constexpr size_t SR_DECR_REM_PHASE_EVENTS = 17;
-    static constexpr size_t SR_INCR_READ_PI_OFFSET = 18;
-    static constexpr size_t SR_MAX_NOTE_HASH_WRITES_REACHED = 27;
-    static constexpr size_t SR_MAX_NULLIFIER_WRITES_REACHED = 32;
-    static constexpr size_t SR_MAX_L2_L1_MSG_WRITES_REACHED = 37;
-    static constexpr size_t SR_UPDATE_NUM_L2_TO_L1_MSGS = 40;
-    static constexpr size_t SR_COMPUTE_FEE = 42;
-    static constexpr size_t SR_TEARDOWN_GETS_FEE = 43;
-    static constexpr size_t SR_FEE_ZERO_UNLESS_COLLECT_FEE_OR_TEARDOWN = 44;
-    static constexpr size_t SR_NOTE_HASH_TREE_ROOT_IMMUTABLE_IN_PADDING = 50;
-    static constexpr size_t SR_PAD_NOTE_HASH_TREE = 51;
-    static constexpr size_t SR_NOTE_HASHES_EMITTED_IMMUTABLE_IN_PADDING = 52;
-    static constexpr size_t SR_NULLIFIER_TREE_ROOT_IMMUTABLE_IN_PADDING = 53;
-    static constexpr size_t SR_PAD_NULLIFIER_TREE = 54;
-    static constexpr size_t SR_NULLIFIERS_EMITTED_IMMUTABLE_IN_PADDING = 55;
+    static constexpr size_t SR_END_PHASE_ON_REVERT = 11;
+    static constexpr size_t SR_PHASE_VALUE_CONTINUITY = 12;
+    static constexpr size_t SR_INCR_PHASE_VALUE_ON_END = 13;
+    static constexpr size_t SR_REM_COUNT_IS_ZERO = 15;
+    static constexpr size_t SR_REM_COUNT_IS_ONE = 16;
+    static constexpr size_t SR_READ_PI_LENGTH_SEL = 17;
+    static constexpr size_t SR_ONE_SHOT_REMAINING_PHASE_COUNTER_ONE = 18;
+    static constexpr size_t SR_DECR_REM_PHASE_EVENTS = 19;
+    static constexpr size_t SR_INCR_READ_PI_OFFSET = 20;
+    static constexpr size_t SR_MAX_NOTE_HASH_WRITES_REACHED = 29;
+    static constexpr size_t SR_MAX_NULLIFIER_WRITES_REACHED = 34;
+    static constexpr size_t SR_MAX_L2_L1_MSG_WRITES_REACHED = 39;
+    static constexpr size_t SR_UPDATE_NUM_L2_TO_L1_MSGS = 42;
+    static constexpr size_t SR_COMPUTE_FEE = 44;
+    static constexpr size_t SR_TEARDOWN_GETS_FEE = 45;
+    static constexpr size_t SR_FEE_ZERO_UNLESS_COLLECT_FEE_OR_TEARDOWN = 46;
+    static constexpr size_t SR_NOTE_HASH_TREE_ROOT_IMMUTABLE_IN_PADDING = 52;
+    static constexpr size_t SR_PAD_NOTE_HASH_TREE = 53;
+    static constexpr size_t SR_NOTE_HASHES_EMITTED_IMMUTABLE_IN_PADDING = 54;
+    static constexpr size_t SR_NULLIFIER_TREE_ROOT_IMMUTABLE_IN_PADDING = 55;
+    static constexpr size_t SR_PAD_NULLIFIER_TREE = 56;
+    static constexpr size_t SR_NULLIFIERS_EMITTED_IMMUTABLE_IN_PADDING = 57;
 
     static std::string get_subrelation_label(size_t index)
     {
@@ -78,6 +79,8 @@ template <typename FF> class tx : public Relation<txImpl<FF>> {
             return "START_WITH_SEL";
         case SR_START_FOLLOWS_END:
             return "START_FOLLOWS_END";
+        case SR_END_PHASE_ON_REVERT:
+            return "END_PHASE_ON_REVERT";
         case SR_PHASE_VALUE_CONTINUITY:
             return "PHASE_VALUE_CONTINUITY";
         case SR_INCR_PHASE_VALUE_ON_END:

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/tx_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/tx_impl.hpp
@@ -93,28 +93,38 @@ void txImpl<FF_>::accumulate(ContainerOverSubrelations& evals,
                     (static_cast<View>(in.get(C::tx_end_phase)) + static_cast<View>(in.get(C::precomputed_first_row))));
         std::get<9>(evals) += (tmp * scaling_factor);
     }
-    { // PHASE_VALUE_CONTINUITY
+    {
         using View = typename std::tuple_element_t<10, ContainerOverSubrelations>::View;
-        auto tmp = CView(tx_NOT_PHASE_END) * (FF(1) - static_cast<View>(in.get(C::tx_reverted))) *
-                   (FF(1) - static_cast<View>(in.get(C::precomputed_first_row))) *
-                   (static_cast<View>(in.get(C::tx_phase_value_shift)) - static_cast<View>(in.get(C::tx_phase_value)));
+        auto tmp = static_cast<View>(in.get(C::tx_reverted)) * (FF(1) - static_cast<View>(in.get(C::tx_reverted)));
         std::get<10>(evals) += (tmp * scaling_factor);
     }
-    { // INCR_PHASE_VALUE_ON_END
+    { // END_PHASE_ON_REVERT
         using View = typename std::tuple_element_t<11, ContainerOverSubrelations>::View;
+        auto tmp = static_cast<View>(in.get(C::tx_sel)) * static_cast<View>(in.get(C::tx_reverted)) *
+                   (FF(1) - static_cast<View>(in.get(C::tx_end_phase)));
+        std::get<11>(evals) += (tmp * scaling_factor);
+    }
+    { // PHASE_VALUE_CONTINUITY
+        using View = typename std::tuple_element_t<12, ContainerOverSubrelations>::View;
+        auto tmp = CView(tx_NOT_PHASE_END) * (FF(1) - static_cast<View>(in.get(C::precomputed_first_row))) *
+                   (static_cast<View>(in.get(C::tx_phase_value_shift)) - static_cast<View>(in.get(C::tx_phase_value)));
+        std::get<12>(evals) += (tmp * scaling_factor);
+    }
+    { // INCR_PHASE_VALUE_ON_END
+        using View = typename std::tuple_element_t<13, ContainerOverSubrelations>::View;
         auto tmp = CView(tx_NOT_LAST) * (FF(1) - static_cast<View>(in.get(C::tx_reverted))) *
                    static_cast<View>(in.get(C::tx_end_phase)) *
                    (static_cast<View>(in.get(C::tx_phase_value_shift)) -
                     (static_cast<View>(in.get(C::tx_phase_value)) + FF(1)));
-        std::get<11>(evals) += (tmp * scaling_factor);
+        std::get<13>(evals) += (tmp * scaling_factor);
     }
     {
-        using View = typename std::tuple_element_t<12, ContainerOverSubrelations>::View;
+        using View = typename std::tuple_element_t<14, ContainerOverSubrelations>::View;
         auto tmp = static_cast<View>(in.get(C::tx_reverted)) * (FF(1) - static_cast<View>(in.get(C::tx_is_revertible)));
-        std::get<12>(evals) += (tmp * scaling_factor);
+        std::get<14>(evals) += (tmp * scaling_factor);
     }
     { // REM_COUNT_IS_ZERO
-        using View = typename std::tuple_element_t<13, ContainerOverSubrelations>::View;
+        using View = typename std::tuple_element_t<15, ContainerOverSubrelations>::View;
         auto tmp = static_cast<View>(in.get(C::tx_sel)) *
                    ((static_cast<View>(in.get(C::tx_remaining_phase_counter)) *
                          (static_cast<View>(in.get(C::tx_is_padded)) *
@@ -122,115 +132,116 @@ void txImpl<FF_>::accumulate(ContainerOverSubrelations& evals,
                           static_cast<View>(in.get(C::tx_remaining_phase_inv))) -
                      FF(1)) +
                     static_cast<View>(in.get(C::tx_is_padded)));
-        std::get<13>(evals) += (tmp * scaling_factor);
+        std::get<15>(evals) += (tmp * scaling_factor);
     }
     { // REM_COUNT_IS_ONE
-        using View = typename std::tuple_element_t<14, ContainerOverSubrelations>::View;
-        auto tmp = static_cast<View>(in.get(C::tx_sel)) * (FF(1) - static_cast<View>(in.get(C::tx_is_padded))) *
+        using View = typename std::tuple_element_t<16, ContainerOverSubrelations>::View;
+        auto tmp = static_cast<View>(in.get(C::tx_sel)) * (FF(1) - static_cast<View>(in.get(C::tx_reverted))) *
+                   (FF(1) - static_cast<View>(in.get(C::tx_is_padded))) *
                    ((CView(tx_REM_COUNT_MINUS_1) *
                          (static_cast<View>(in.get(C::tx_end_phase)) *
                               (FF(1) - static_cast<View>(in.get(C::tx_remaining_phase_minus_one_inv))) +
                           static_cast<View>(in.get(C::tx_remaining_phase_minus_one_inv))) -
                      FF(1)) +
                     static_cast<View>(in.get(C::tx_end_phase)));
-        std::get<14>(evals) += (tmp * scaling_factor);
+        std::get<16>(evals) += (tmp * scaling_factor);
     }
     { // READ_PI_LENGTH_SEL
-        using View = typename std::tuple_element_t<15, ContainerOverSubrelations>::View;
+        using View = typename std::tuple_element_t<17, ContainerOverSubrelations>::View;
         auto tmp = static_cast<View>(in.get(C::tx_sel)) *
                    (static_cast<View>(in.get(C::tx_sel_read_phase_length)) -
                     static_cast<View>(in.get(C::tx_start_phase)) * (FF(1) - CView(tx_IS_ONE_SHOT_PHASE)));
-        std::get<15>(evals) += (tmp * scaling_factor);
+        std::get<17>(evals) += (tmp * scaling_factor);
     }
     { // ONE_SHOT_REMAINING_PHASE_COUNTER_ONE
-        using View = typename std::tuple_element_t<16, ContainerOverSubrelations>::View;
+        using View = typename std::tuple_element_t<18, ContainerOverSubrelations>::View;
         auto tmp = CView(tx_IS_ONE_SHOT_PHASE) * (static_cast<View>(in.get(C::tx_remaining_phase_counter)) - FF(1));
-        std::get<16>(evals) += (tmp * scaling_factor);
+        std::get<18>(evals) += (tmp * scaling_factor);
     }
     { // DECR_REM_PHASE_EVENTS
-        using View = typename std::tuple_element_t<17, ContainerOverSubrelations>::View;
+        using View = typename std::tuple_element_t<19, ContainerOverSubrelations>::View;
         auto tmp = (FF(1) - static_cast<View>(in.get(C::precomputed_first_row))) * CView(tx_NOT_PHASE_END) *
                    (static_cast<View>(in.get(C::tx_remaining_phase_counter_shift)) -
                     (static_cast<View>(in.get(C::tx_remaining_phase_counter)) - FF(1)));
-        std::get<17>(evals) += (tmp * scaling_factor);
+        std::get<19>(evals) += (tmp * scaling_factor);
     }
     { // INCR_READ_PI_OFFSET
-        using View = typename std::tuple_element_t<18, ContainerOverSubrelations>::View;
+        using View = typename std::tuple_element_t<20, ContainerOverSubrelations>::View;
         auto tmp = (FF(1) - static_cast<View>(in.get(C::precomputed_first_row))) * CView(tx_NOT_PHASE_END) *
                    (static_cast<View>(in.get(C::tx_read_pi_offset_shift)) -
                     (static_cast<View>(in.get(C::tx_read_pi_offset)) + FF(1)));
-        std::get<18>(evals) += (tmp * scaling_factor);
-    }
-    {
-        using View = typename std::tuple_element_t<19, ContainerOverSubrelations>::View;
-        auto tmp = (static_cast<View>(in.get(C::tx_should_process_call_request)) -
-                    static_cast<View>(in.get(C::tx_is_public_call_request)) *
-                        (FF(1) - static_cast<View>(in.get(C::tx_is_padded))));
-        std::get<19>(evals) += (tmp * scaling_factor);
-    }
-    {
-        using View = typename std::tuple_element_t<20, ContainerOverSubrelations>::View;
-        auto tmp = static_cast<View>(in.get(C::tx_is_teardown_phase)) *
-                   (FF(1) - static_cast<View>(in.get(C::tx_is_teardown_phase)));
         std::get<20>(evals) += (tmp * scaling_factor);
     }
     {
         using View = typename std::tuple_element_t<21, ContainerOverSubrelations>::View;
+        auto tmp = (static_cast<View>(in.get(C::tx_should_process_call_request)) -
+                    static_cast<View>(in.get(C::tx_is_public_call_request)) *
+                        (FF(1) - static_cast<View>(in.get(C::tx_is_padded))));
+        std::get<21>(evals) += (tmp * scaling_factor);
+    }
+    {
+        using View = typename std::tuple_element_t<22, ContainerOverSubrelations>::View;
+        auto tmp = static_cast<View>(in.get(C::tx_is_teardown_phase)) *
+                   (FF(1) - static_cast<View>(in.get(C::tx_is_teardown_phase)));
+        std::get<22>(evals) += (tmp * scaling_factor);
+    }
+    {
+        using View = typename std::tuple_element_t<23, ContainerOverSubrelations>::View;
         auto tmp = static_cast<View>(in.get(C::tx_should_process_call_request)) *
                    (((FF(0) - static_cast<View>(in.get(C::tx_prev_l2_gas_used))) *
                          static_cast<View>(in.get(C::tx_is_teardown_phase)) +
                      static_cast<View>(in.get(C::tx_prev_l2_gas_used))) -
                     static_cast<View>(in.get(C::tx_prev_l2_gas_used_sent_to_enqueued_call)));
-        std::get<21>(evals) += (tmp * scaling_factor);
+        std::get<23>(evals) += (tmp * scaling_factor);
     }
     {
-        using View = typename std::tuple_element_t<22, ContainerOverSubrelations>::View;
+        using View = typename std::tuple_element_t<24, ContainerOverSubrelations>::View;
         auto tmp = static_cast<View>(in.get(C::tx_should_process_call_request)) *
                    (((FF(0) - static_cast<View>(in.get(C::tx_prev_da_gas_used))) *
                          static_cast<View>(in.get(C::tx_is_teardown_phase)) +
                      static_cast<View>(in.get(C::tx_prev_da_gas_used))) -
                     static_cast<View>(in.get(C::tx_prev_da_gas_used_sent_to_enqueued_call)));
-        std::get<22>(evals) += (tmp * scaling_factor);
+        std::get<24>(evals) += (tmp * scaling_factor);
     }
     {
-        using View = typename std::tuple_element_t<23, ContainerOverSubrelations>::View;
+        using View = typename std::tuple_element_t<25, ContainerOverSubrelations>::View;
         auto tmp = static_cast<View>(in.get(C::tx_should_process_call_request)) *
                    (((static_cast<View>(in.get(C::tx_prev_l2_gas_used)) -
                       static_cast<View>(in.get(C::tx_next_l2_gas_used_sent_to_enqueued_call))) *
                          static_cast<View>(in.get(C::tx_is_teardown_phase)) +
                      static_cast<View>(in.get(C::tx_next_l2_gas_used_sent_to_enqueued_call))) -
                     static_cast<View>(in.get(C::tx_next_l2_gas_used)));
-        std::get<23>(evals) += (tmp * scaling_factor);
+        std::get<25>(evals) += (tmp * scaling_factor);
     }
     {
-        using View = typename std::tuple_element_t<24, ContainerOverSubrelations>::View;
+        using View = typename std::tuple_element_t<26, ContainerOverSubrelations>::View;
         auto tmp = static_cast<View>(in.get(C::tx_should_process_call_request)) *
                    (((static_cast<View>(in.get(C::tx_prev_da_gas_used)) -
                       static_cast<View>(in.get(C::tx_next_da_gas_used_sent_to_enqueued_call))) *
                          static_cast<View>(in.get(C::tx_is_teardown_phase)) +
                      static_cast<View>(in.get(C::tx_next_da_gas_used_sent_to_enqueued_call))) -
                     static_cast<View>(in.get(C::tx_next_da_gas_used)));
-        std::get<24>(evals) += (tmp * scaling_factor);
+        std::get<26>(evals) += (tmp * scaling_factor);
     }
     {
-        using View = typename std::tuple_element_t<25, ContainerOverSubrelations>::View;
+        using View = typename std::tuple_element_t<27, ContainerOverSubrelations>::View;
         auto tmp = (static_cast<View>(in.get(C::tx_is_tree_insert_phase)) -
                     (static_cast<View>(in.get(C::tx_sel_revertible_append_note_hash)) +
                      static_cast<View>(in.get(C::tx_sel_non_revertible_append_note_hash)) +
                      static_cast<View>(in.get(C::tx_sel_revertible_append_nullifier)) +
                      static_cast<View>(in.get(C::tx_sel_non_revertible_append_nullifier))));
-        std::get<25>(evals) += (tmp * scaling_factor);
+        std::get<27>(evals) += (tmp * scaling_factor);
     }
     {
-        using View = typename std::tuple_element_t<26, ContainerOverSubrelations>::View;
+        using View = typename std::tuple_element_t<28, ContainerOverSubrelations>::View;
         auto tmp = (static_cast<View>(in.get(C::tx_should_try_note_hash_append)) -
                     static_cast<View>(in.get(C::tx_sel)) * (FF(1) - static_cast<View>(in.get(C::tx_is_padded))) *
                         (static_cast<View>(in.get(C::tx_sel_revertible_append_note_hash)) +
                          static_cast<View>(in.get(C::tx_sel_non_revertible_append_note_hash))));
-        std::get<26>(evals) += (tmp * scaling_factor);
+        std::get<28>(evals) += (tmp * scaling_factor);
     }
     { // MAX_NOTE_HASH_WRITES_REACHED
-        using View = typename std::tuple_element_t<27, ContainerOverSubrelations>::View;
+        using View = typename std::tuple_element_t<29, ContainerOverSubrelations>::View;
         auto tmp = static_cast<View>(in.get(C::tx_should_try_note_hash_append)) *
                    ((CView(tx_REMAINING_NOTE_HASH_WRITES) *
                          (static_cast<View>(in.get(C::tx_reverted)) *
@@ -238,39 +249,39 @@ void txImpl<FF_>::accumulate(ContainerOverSubrelations& evals,
                           static_cast<View>(in.get(C::tx_remaining_side_effects_inv))) -
                      FF(1)) +
                     static_cast<View>(in.get(C::tx_reverted)));
-        std::get<27>(evals) += (tmp * scaling_factor);
-    }
-    {
-        using View = typename std::tuple_element_t<28, ContainerOverSubrelations>::View;
-        auto tmp = static_cast<View>(in.get(C::tx_should_try_note_hash_append)) *
-                   ((FF(1) - static_cast<View>(in.get(C::tx_reverted))) -
-                    static_cast<View>(in.get(C::tx_should_note_hash_append)));
-        std::get<28>(evals) += (tmp * scaling_factor);
-    }
-    {
-        using View = typename std::tuple_element_t<29, ContainerOverSubrelations>::View;
-        auto tmp = static_cast<View>(in.get(C::tx_should_note_hash_append)) *
-                   ((static_cast<View>(in.get(C::tx_prev_note_hash_tree_size)) + FF(1)) -
-                    static_cast<View>(in.get(C::tx_next_note_hash_tree_size)));
         std::get<29>(evals) += (tmp * scaling_factor);
     }
     {
         using View = typename std::tuple_element_t<30, ContainerOverSubrelations>::View;
-        auto tmp = static_cast<View>(in.get(C::tx_should_note_hash_append)) *
-                   ((static_cast<View>(in.get(C::tx_prev_num_note_hashes_emitted)) + FF(1)) -
-                    static_cast<View>(in.get(C::tx_next_num_note_hashes_emitted)));
+        auto tmp = static_cast<View>(in.get(C::tx_should_try_note_hash_append)) *
+                   ((FF(1) - static_cast<View>(in.get(C::tx_reverted))) -
+                    static_cast<View>(in.get(C::tx_should_note_hash_append)));
         std::get<30>(evals) += (tmp * scaling_factor);
     }
     {
         using View = typename std::tuple_element_t<31, ContainerOverSubrelations>::View;
+        auto tmp = static_cast<View>(in.get(C::tx_should_note_hash_append)) *
+                   ((static_cast<View>(in.get(C::tx_prev_note_hash_tree_size)) + FF(1)) -
+                    static_cast<View>(in.get(C::tx_next_note_hash_tree_size)));
+        std::get<31>(evals) += (tmp * scaling_factor);
+    }
+    {
+        using View = typename std::tuple_element_t<32, ContainerOverSubrelations>::View;
+        auto tmp = static_cast<View>(in.get(C::tx_should_note_hash_append)) *
+                   ((static_cast<View>(in.get(C::tx_prev_num_note_hashes_emitted)) + FF(1)) -
+                    static_cast<View>(in.get(C::tx_next_num_note_hashes_emitted)));
+        std::get<32>(evals) += (tmp * scaling_factor);
+    }
+    {
+        using View = typename std::tuple_element_t<33, ContainerOverSubrelations>::View;
         auto tmp = (static_cast<View>(in.get(C::tx_should_try_nullifier_append)) -
                     static_cast<View>(in.get(C::tx_sel)) * (FF(1) - static_cast<View>(in.get(C::tx_is_padded))) *
                         (static_cast<View>(in.get(C::tx_sel_revertible_append_nullifier)) +
                          static_cast<View>(in.get(C::tx_sel_non_revertible_append_nullifier))));
-        std::get<31>(evals) += (tmp * scaling_factor);
+        std::get<33>(evals) += (tmp * scaling_factor);
     }
     { // MAX_NULLIFIER_WRITES_REACHED
-        using View = typename std::tuple_element_t<32, ContainerOverSubrelations>::View;
+        using View = typename std::tuple_element_t<34, ContainerOverSubrelations>::View;
         auto tmp = static_cast<View>(in.get(C::tx_should_try_nullifier_append)) *
                    ((CView(tx_REMAINING_NULLIFIER_WRITES) *
                          (CView(tx_NULLIFIER_LIMIT_ERROR) *
@@ -278,40 +289,40 @@ void txImpl<FF_>::accumulate(ContainerOverSubrelations& evals,
                           static_cast<View>(in.get(C::tx_remaining_side_effects_inv))) -
                      FF(1)) +
                     CView(tx_NULLIFIER_LIMIT_ERROR));
-        std::get<32>(evals) += (tmp * scaling_factor);
-    }
-    {
-        using View = typename std::tuple_element_t<33, ContainerOverSubrelations>::View;
-        auto tmp = static_cast<View>(in.get(C::tx_should_try_nullifier_append)) * CView(tx_NULLIFIER_LIMIT_ERROR) *
-                   (FF(1) - static_cast<View>(in.get(C::tx_reverted)));
-        std::get<33>(evals) += (tmp * scaling_factor);
-    }
-    {
-        using View = typename std::tuple_element_t<34, ContainerOverSubrelations>::View;
-        auto tmp = static_cast<View>(in.get(C::tx_should_nullifier_append)) *
-                   (FF(1) - static_cast<View>(in.get(C::tx_reverted))) *
-                   ((static_cast<View>(in.get(C::tx_prev_nullifier_tree_size)) + FF(1)) -
-                    static_cast<View>(in.get(C::tx_next_nullifier_tree_size)));
         std::get<34>(evals) += (tmp * scaling_factor);
     }
     {
         using View = typename std::tuple_element_t<35, ContainerOverSubrelations>::View;
-        auto tmp = static_cast<View>(in.get(C::tx_should_nullifier_append)) *
-                   (FF(1) - static_cast<View>(in.get(C::tx_reverted))) *
-                   ((static_cast<View>(in.get(C::tx_prev_num_nullifiers_emitted)) + FF(1)) -
-                    static_cast<View>(in.get(C::tx_next_num_nullifiers_emitted)));
+        auto tmp = static_cast<View>(in.get(C::tx_should_try_nullifier_append)) * CView(tx_NULLIFIER_LIMIT_ERROR) *
+                   (FF(1) - static_cast<View>(in.get(C::tx_reverted)));
         std::get<35>(evals) += (tmp * scaling_factor);
     }
     {
         using View = typename std::tuple_element_t<36, ContainerOverSubrelations>::View;
+        auto tmp = static_cast<View>(in.get(C::tx_should_nullifier_append)) *
+                   (FF(1) - static_cast<View>(in.get(C::tx_reverted))) *
+                   ((static_cast<View>(in.get(C::tx_prev_nullifier_tree_size)) + FF(1)) -
+                    static_cast<View>(in.get(C::tx_next_nullifier_tree_size)));
+        std::get<36>(evals) += (tmp * scaling_factor);
+    }
+    {
+        using View = typename std::tuple_element_t<37, ContainerOverSubrelations>::View;
+        auto tmp = static_cast<View>(in.get(C::tx_should_nullifier_append)) *
+                   (FF(1) - static_cast<View>(in.get(C::tx_reverted))) *
+                   ((static_cast<View>(in.get(C::tx_prev_num_nullifiers_emitted)) + FF(1)) -
+                    static_cast<View>(in.get(C::tx_next_num_nullifiers_emitted)));
+        std::get<37>(evals) += (tmp * scaling_factor);
+    }
+    {
+        using View = typename std::tuple_element_t<38, ContainerOverSubrelations>::View;
         auto tmp = (static_cast<View>(in.get(C::tx_should_try_l2_l1_msg_append)) -
                     static_cast<View>(in.get(C::tx_sel)) * (FF(1) - static_cast<View>(in.get(C::tx_is_padded))) *
                         (static_cast<View>(in.get(C::tx_sel_revertible_append_l2_l1_msg)) +
                          static_cast<View>(in.get(C::tx_sel_non_revertible_append_l2_l1_msg))));
-        std::get<36>(evals) += (tmp * scaling_factor);
+        std::get<38>(evals) += (tmp * scaling_factor);
     }
     { // MAX_L2_L1_MSG_WRITES_REACHED
-        using View = typename std::tuple_element_t<37, ContainerOverSubrelations>::View;
+        using View = typename std::tuple_element_t<39, ContainerOverSubrelations>::View;
         auto tmp = static_cast<View>(in.get(C::tx_should_try_l2_l1_msg_append)) *
                    (FF(1) - static_cast<View>(in.get(C::tx_is_padded))) *
                    ((CView(tx_REMAINING_L2_TO_L1_MSG_WRITES) *
@@ -320,140 +331,140 @@ void txImpl<FF_>::accumulate(ContainerOverSubrelations& evals,
                           static_cast<View>(in.get(C::tx_remaining_side_effects_inv))) -
                      FF(1)) +
                     static_cast<View>(in.get(C::tx_reverted)));
-        std::get<37>(evals) += (tmp * scaling_factor);
+        std::get<39>(evals) += (tmp * scaling_factor);
     }
     {
-        using View = typename std::tuple_element_t<38, ContainerOverSubrelations>::View;
+        using View = typename std::tuple_element_t<40, ContainerOverSubrelations>::View;
         auto tmp =
             static_cast<View>(in.get(C::tx_should_try_l2_l1_msg_append)) *
             ((FF(1) - static_cast<View>(in.get(C::tx_reverted))) * (FF(1) - static_cast<View>(in.get(C::tx_discard))) -
              static_cast<View>(in.get(C::tx_should_l2_l1_msg_append)));
-        std::get<38>(evals) += (tmp * scaling_factor);
-    }
-    {
-        using View = typename std::tuple_element_t<39, ContainerOverSubrelations>::View;
-        auto tmp = static_cast<View>(in.get(C::tx_should_l2_l1_msg_append)) *
-                   ((CView(constants_AVM_PUBLIC_INPUTS_AVM_ACCUMULATED_DATA_L2_TO_L1_MSGS_ROW_IDX) +
-                     static_cast<View>(in.get(C::tx_prev_num_l2_to_l1_messages))) -
-                    static_cast<View>(in.get(C::tx_write_pi_offset)));
-        std::get<39>(evals) += (tmp * scaling_factor);
-    }
-    { // UPDATE_NUM_L2_TO_L1_MSGS
-        using View = typename std::tuple_element_t<40, ContainerOverSubrelations>::View;
-        auto tmp = static_cast<View>(in.get(C::tx_should_try_l2_l1_msg_append)) *
-                   (FF(1) - static_cast<View>(in.get(C::tx_reverted))) *
-                   ((static_cast<View>(in.get(C::tx_prev_num_l2_to_l1_messages)) + FF(1)) -
-                    static_cast<View>(in.get(C::tx_next_num_l2_to_l1_messages)));
         std::get<40>(evals) += (tmp * scaling_factor);
     }
     {
         using View = typename std::tuple_element_t<41, ContainerOverSubrelations>::View;
+        auto tmp = static_cast<View>(in.get(C::tx_should_l2_l1_msg_append)) *
+                   ((CView(constants_AVM_PUBLIC_INPUTS_AVM_ACCUMULATED_DATA_L2_TO_L1_MSGS_ROW_IDX) +
+                     static_cast<View>(in.get(C::tx_prev_num_l2_to_l1_messages))) -
+                    static_cast<View>(in.get(C::tx_write_pi_offset)));
+        std::get<41>(evals) += (tmp * scaling_factor);
+    }
+    { // UPDATE_NUM_L2_TO_L1_MSGS
+        using View = typename std::tuple_element_t<42, ContainerOverSubrelations>::View;
+        auto tmp = static_cast<View>(in.get(C::tx_should_try_l2_l1_msg_append)) *
+                   (FF(1) - static_cast<View>(in.get(C::tx_reverted))) *
+                   ((static_cast<View>(in.get(C::tx_prev_num_l2_to_l1_messages)) + FF(1)) -
+                    static_cast<View>(in.get(C::tx_next_num_l2_to_l1_messages)));
+        std::get<42>(evals) += (tmp * scaling_factor);
+    }
+    {
+        using View = typename std::tuple_element_t<43, ContainerOverSubrelations>::View;
         auto tmp =
             (static_cast<View>(in.get(C::tx_fee_payer_pi_offset)) -
              static_cast<View>(in.get(C::tx_is_collect_fee)) * CView(constants_AVM_PUBLIC_INPUTS_FEE_PAYER_ROW_IDX));
-        std::get<41>(evals) += (tmp * scaling_factor);
+        std::get<43>(evals) += (tmp * scaling_factor);
     }
     { // COMPUTE_FEE
-        using View = typename std::tuple_element_t<42, ContainerOverSubrelations>::View;
+        using View = typename std::tuple_element_t<44, ContainerOverSubrelations>::View;
         auto tmp = static_cast<View>(in.get(C::tx_is_collect_fee)) *
                    ((static_cast<View>(in.get(C::tx_effective_fee_per_da_gas)) *
                          static_cast<View>(in.get(C::tx_prev_da_gas_used)) +
                      static_cast<View>(in.get(C::tx_effective_fee_per_l2_gas)) *
                          static_cast<View>(in.get(C::tx_prev_l2_gas_used))) -
                     static_cast<View>(in.get(C::tx_fee)));
-        std::get<42>(evals) += (tmp * scaling_factor);
+        std::get<44>(evals) += (tmp * scaling_factor);
     }
     { // TEARDOWN_GETS_FEE
-        using View = typename std::tuple_element_t<43, ContainerOverSubrelations>::View;
+        using View = typename std::tuple_element_t<45, ContainerOverSubrelations>::View;
         auto tmp = static_cast<View>(in.get(C::tx_is_teardown_phase)) *
                    (FF(1) - static_cast<View>(in.get(C::tx_is_padded))) *
                    (static_cast<View>(in.get(C::tx_fee_shift)) - static_cast<View>(in.get(C::tx_fee)));
-        std::get<43>(evals) += (tmp * scaling_factor);
-    }
-    { // FEE_ZERO_UNLESS_COLLECT_FEE_OR_TEARDOWN
-        using View = typename std::tuple_element_t<44, ContainerOverSubrelations>::View;
-        auto tmp = (FF(1) - static_cast<View>(in.get(C::tx_is_collect_fee))) *
-                   (FF(1) - static_cast<View>(in.get(C::tx_is_teardown_phase))) * static_cast<View>(in.get(C::tx_fee));
-        std::get<44>(evals) += (tmp * scaling_factor);
-    }
-    {
-        using View = typename std::tuple_element_t<45, ContainerOverSubrelations>::View;
-        auto tmp = static_cast<View>(in.get(C::tx_is_collect_fee)) *
-                   (CView(constants_FEE_JUICE_ADDRESS) - static_cast<View>(in.get(C::tx_fee_juice_contract_address)));
         std::get<45>(evals) += (tmp * scaling_factor);
     }
-    {
+    { // FEE_ZERO_UNLESS_COLLECT_FEE_OR_TEARDOWN
         using View = typename std::tuple_element_t<46, ContainerOverSubrelations>::View;
-        auto tmp =
-            static_cast<View>(in.get(C::tx_is_collect_fee)) *
-            (CView(constants_FEE_JUICE_BALANCES_SLOT) - static_cast<View>(in.get(C::tx_fee_juice_balances_slot)));
+        auto tmp = (FF(1) - static_cast<View>(in.get(C::tx_is_collect_fee))) *
+                   (FF(1) - static_cast<View>(in.get(C::tx_is_teardown_phase))) * static_cast<View>(in.get(C::tx_fee));
         std::get<46>(evals) += (tmp * scaling_factor);
     }
     {
         using View = typename std::tuple_element_t<47, ContainerOverSubrelations>::View;
         auto tmp = static_cast<View>(in.get(C::tx_is_collect_fee)) *
-                   ((static_cast<View>(in.get(C::tx_fee_payer_balance)) - static_cast<View>(in.get(C::tx_fee))) -
-                    static_cast<View>(in.get(C::tx_fee_payer_new_balance)));
+                   (CView(constants_FEE_JUICE_ADDRESS) - static_cast<View>(in.get(C::tx_fee_juice_contract_address)));
         std::get<47>(evals) += (tmp * scaling_factor);
     }
     {
         using View = typename std::tuple_element_t<48, ContainerOverSubrelations>::View;
-        auto tmp = static_cast<View>(in.get(C::tx_is_collect_fee)) *
-                   (static_cast<View>(in.get(C::tx_uint32_max)) - FF(4294967295UL));
+        auto tmp =
+            static_cast<View>(in.get(C::tx_is_collect_fee)) *
+            (CView(constants_FEE_JUICE_BALANCES_SLOT) - static_cast<View>(in.get(C::tx_fee_juice_balances_slot)));
         std::get<48>(evals) += (tmp * scaling_factor);
     }
     {
         using View = typename std::tuple_element_t<49, ContainerOverSubrelations>::View;
         auto tmp = static_cast<View>(in.get(C::tx_is_collect_fee)) *
-                   (CView(constants_AVM_PUBLIC_INPUTS_TRANSACTION_FEE_ROW_IDX) -
-                    static_cast<View>(in.get(C::tx_write_pi_offset)));
+                   ((static_cast<View>(in.get(C::tx_fee_payer_balance)) - static_cast<View>(in.get(C::tx_fee))) -
+                    static_cast<View>(in.get(C::tx_fee_payer_new_balance)));
         std::get<49>(evals) += (tmp * scaling_factor);
     }
-    { // NOTE_HASH_TREE_ROOT_IMMUTABLE_IN_PADDING
+    {
         using View = typename std::tuple_element_t<50, ContainerOverSubrelations>::View;
+        auto tmp = static_cast<View>(in.get(C::tx_is_collect_fee)) *
+                   (static_cast<View>(in.get(C::tx_uint32_max)) - FF(4294967295UL));
+        std::get<50>(evals) += (tmp * scaling_factor);
+    }
+    {
+        using View = typename std::tuple_element_t<51, ContainerOverSubrelations>::View;
+        auto tmp = static_cast<View>(in.get(C::tx_is_collect_fee)) *
+                   (CView(constants_AVM_PUBLIC_INPUTS_TRANSACTION_FEE_ROW_IDX) -
+                    static_cast<View>(in.get(C::tx_write_pi_offset)));
+        std::get<51>(evals) += (tmp * scaling_factor);
+    }
+    { // NOTE_HASH_TREE_ROOT_IMMUTABLE_IN_PADDING
+        using View = typename std::tuple_element_t<52, ContainerOverSubrelations>::View;
         auto tmp = static_cast<View>(in.get(C::tx_is_tree_padding)) *
                    (static_cast<View>(in.get(C::tx_prev_note_hash_tree_root)) -
                     static_cast<View>(in.get(C::tx_next_note_hash_tree_root)));
-        std::get<50>(evals) += (tmp * scaling_factor);
+        std::get<52>(evals) += (tmp * scaling_factor);
     }
     { // PAD_NOTE_HASH_TREE
-        using View = typename std::tuple_element_t<51, ContainerOverSubrelations>::View;
+        using View = typename std::tuple_element_t<53, ContainerOverSubrelations>::View;
         auto tmp =
             static_cast<View>(in.get(C::tx_is_tree_padding)) *
             (((static_cast<View>(in.get(C::tx_prev_note_hash_tree_size)) + CView(constants_MAX_NOTE_HASHES_PER_TX)) -
               static_cast<View>(in.get(C::tx_prev_num_note_hashes_emitted))) -
              static_cast<View>(in.get(C::tx_next_note_hash_tree_size)));
-        std::get<51>(evals) += (tmp * scaling_factor);
+        std::get<53>(evals) += (tmp * scaling_factor);
     }
     { // NOTE_HASHES_EMITTED_IMMUTABLE_IN_PADDING
-        using View = typename std::tuple_element_t<52, ContainerOverSubrelations>::View;
+        using View = typename std::tuple_element_t<54, ContainerOverSubrelations>::View;
         auto tmp = static_cast<View>(in.get(C::tx_is_tree_padding)) *
                    (static_cast<View>(in.get(C::tx_prev_num_note_hashes_emitted)) -
                     static_cast<View>(in.get(C::tx_next_num_note_hashes_emitted)));
-        std::get<52>(evals) += (tmp * scaling_factor);
+        std::get<54>(evals) += (tmp * scaling_factor);
     }
     { // NULLIFIER_TREE_ROOT_IMMUTABLE_IN_PADDING
-        using View = typename std::tuple_element_t<53, ContainerOverSubrelations>::View;
+        using View = typename std::tuple_element_t<55, ContainerOverSubrelations>::View;
         auto tmp = static_cast<View>(in.get(C::tx_is_tree_padding)) *
                    (static_cast<View>(in.get(C::tx_prev_nullifier_tree_root)) -
                     static_cast<View>(in.get(C::tx_next_nullifier_tree_root)));
-        std::get<53>(evals) += (tmp * scaling_factor);
+        std::get<55>(evals) += (tmp * scaling_factor);
     }
     { // PAD_NULLIFIER_TREE
-        using View = typename std::tuple_element_t<54, ContainerOverSubrelations>::View;
+        using View = typename std::tuple_element_t<56, ContainerOverSubrelations>::View;
         auto tmp =
             static_cast<View>(in.get(C::tx_is_tree_padding)) *
             (((static_cast<View>(in.get(C::tx_prev_nullifier_tree_size)) + CView(constants_MAX_NULLIFIERS_PER_TX)) -
               static_cast<View>(in.get(C::tx_prev_num_nullifiers_emitted))) -
              static_cast<View>(in.get(C::tx_next_nullifier_tree_size)));
-        std::get<54>(evals) += (tmp * scaling_factor);
+        std::get<56>(evals) += (tmp * scaling_factor);
     }
     { // NULLIFIERS_EMITTED_IMMUTABLE_IN_PADDING
-        using View = typename std::tuple_element_t<55, ContainerOverSubrelations>::View;
+        using View = typename std::tuple_element_t<57, ContainerOverSubrelations>::View;
         auto tmp = static_cast<View>(in.get(C::tx_is_tree_padding)) *
                    (static_cast<View>(in.get(C::tx_prev_num_nullifiers_emitted)) -
                     static_cast<View>(in.get(C::tx_next_num_nullifiers_emitted)));
-        std::get<55>(evals) += (tmp * scaling_factor);
+        std::get<57>(evals) += (tmp * scaling_factor);
     }
 }
 

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/events/tx_events.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/events/tx_events.hpp
@@ -3,16 +3,45 @@
 #include <cstdint>
 #include <variant>
 
+#include "barretenberg/vm2/common/avm_inputs.hpp"
 #include "barretenberg/vm2/common/aztec_types.hpp"
 #include "barretenberg/vm2/common/field.hpp"
 #include "barretenberg/vm2/simulation/events/tx_context_event.hpp"
 
 namespace bb::avm2::simulation {
 
+struct PhaseLengths {
+    uint32_t nr_nullifier_insertion = 0;
+    uint32_t nr_note_insertion = 0;
+    uint32_t nr_l2_to_l1_message = 0;
+    uint32_t setup = 0;
+    uint32_t r_nullifier_insertion = 0;
+    uint32_t r_note_insertion = 0;
+    uint32_t r_l2_to_l1_message = 0;
+    uint32_t app_logic = 0;
+    uint32_t teardown = 0;
+
+    static PhaseLengths from_tx(const Tx& tx)
+    {
+        return PhaseLengths{
+            .nr_nullifier_insertion = static_cast<uint32_t>(tx.nonRevertibleAccumulatedData.nullifiers.size()),
+            .nr_note_insertion = static_cast<uint32_t>(tx.nonRevertibleAccumulatedData.noteHashes.size()),
+            .nr_l2_to_l1_message = static_cast<uint32_t>(tx.nonRevertibleAccumulatedData.l2ToL1Messages.size()),
+            .setup = static_cast<uint32_t>(tx.setupEnqueuedCalls.size()),
+            .r_nullifier_insertion = static_cast<uint32_t>(tx.revertibleAccumulatedData.nullifiers.size()),
+            .r_note_insertion = static_cast<uint32_t>(tx.revertibleAccumulatedData.noteHashes.size()),
+            .r_l2_to_l1_message = static_cast<uint32_t>(tx.revertibleAccumulatedData.l2ToL1Messages.size()),
+            .app_logic = static_cast<uint32_t>(tx.appLogicEnqueuedCalls.size()),
+            .teardown = tx.teardownEnqueuedCall ? 1U : 0U,
+        };
+    }
+};
+
 struct TxStartupEvent {
     TxContextEvent state;
     Gas gas_limit;
     Gas teardown_gas_limit;
+    PhaseLengths phase_lengths;
 };
 
 struct EnqueuedCallEvent {

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/tx_execution.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/tx_execution.cpp
@@ -68,6 +68,7 @@ void TxExecution::simulate(const Tx& tx)
         .state = tx_context.serialize_tx_context_event(),
         .gas_limit = gas_limit,
         .teardown_gas_limit = teardown_gas_limit,
+        .phase_lengths = PhaseLengths::from_tx(tx), // extract lengths of each phase at start
     });
 
     info("Simulating tx ",

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/tx_trace.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/tx_trace.test.cpp
@@ -34,6 +34,7 @@ TEST(TxTraceGenTest, EnqueuedCallEvent)
         .state = { .gas_used = { 500, 1000 }, .tree_states = {}, .written_public_data_slots_tree_snapshot = {} },
         .gas_limit = { 1000, 2000 },
         .teardown_gas_limit = { 0, 0 },
+        .phase_lengths = { .setup = 1 },
     };
 
     simulation::TxPhaseEvent tx_event = {

--- a/yarn-project/bb-prover/src/avm_proving_tests/avm_check_circuit3.test.ts
+++ b/yarn-project/bb-prover/src/avm_proving_tests/avm_check_circuit3.test.ts
@@ -1,7 +1,9 @@
+import { EthAddress } from '@aztec/foundation/eth-address';
 import { Fr } from '@aztec/foundation/fields';
 import { AvmTestContractArtifact } from '@aztec/noir-test-contracts.js/AvmTest';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import type { ContractInstanceWithAddress } from '@aztec/stdlib/contract';
+import { L2ToL1Message, ScopedL2ToL1Message } from '@aztec/stdlib/messaging';
 
 import { AvmProvingTester } from './avm_proving_tester.js';
 
@@ -34,6 +36,7 @@ describe('AVM check-circuit – unhappy paths 3', () => {
     },
     TIMEOUT,
   );
+
   it(
     'top-level exceptional halt in app logic, but teardown succeeds',
     async () => {
@@ -51,6 +54,103 @@ describe('AVM check-circuit – unhappy paths 3', () => {
     },
     TIMEOUT,
   );
+
+  it(
+    'top-level exceptional halt in app logic, and remaining app logic calls are skipped, no teardown',
+    async () => {
+      await tester.simProveVerify(
+        sender,
+        /*setupCalls=*/ [],
+        /*appCalls=*/ [
+          { address: avmTestContractInstance.address, fnName: 'add_args_return', args: [new Fr(1), new Fr(2)] },
+          { address: avmTestContractInstance.address, fnName: 'divide_by_zero', args: [0] },
+          { address: avmTestContractInstance.address, fnName: 'add_args_return', args: [new Fr(1), new Fr(2)] },
+        ],
+        /*teardownCall=*/ undefined,
+        /*expectRevert=*/ true,
+      );
+    },
+    TIMEOUT,
+  );
+
+  it(
+    'top-level exceptional halt in app logic, remaining app logic calls are skipped, and teardown is fine',
+    async () => {
+      await tester.simProveVerify(
+        sender,
+        /*setupCalls=*/ [],
+        /*appCalls=*/ [
+          { address: avmTestContractInstance.address, fnName: 'add_args_return', args: [new Fr(1), new Fr(2)] },
+          { address: avmTestContractInstance.address, fnName: 'divide_by_zero', args: [0] },
+          { address: avmTestContractInstance.address, fnName: 'add_args_return', args: [new Fr(1), new Fr(2)] },
+        ],
+        // and progression to teardown should be fine!
+        /*teardownCall=*/ {
+          address: avmTestContractInstance.address,
+          fnName: 'add_args_return',
+          args: [new Fr(1), new Fr(2)],
+        },
+        /*expectRevert=*/ true,
+      );
+    },
+    TIMEOUT,
+  );
+
+  it(
+    'top-level exceptional halt during revertible nullifiers (collision), remaining revertibles are skipped, and teardown is fine',
+    async () => {
+      await tester.simProveVerify(
+        sender,
+        /*setupCalls=*/ [],
+        /*appCalls=*/ [
+          // skipped after nullifier collision
+          { address: avmTestContractInstance.address, fnName: 'add_args_return', args: [new Fr(1), new Fr(2)] },
+        ],
+        // and progression to teardown should be fine!
+        /*teardownCall=*/ {
+          address: avmTestContractInstance.address,
+          fnName: 'add_args_return',
+          args: [new Fr(1), new Fr(2)],
+        },
+        /*expectRevert=*/ true,
+        /*feePayer=*/ sender,
+        /*privateInsertions=*/ {
+          revertible: {
+            // nullifier collision ends revertible insertions and skips to teardown
+            nullifiers: [
+              new Fr(66666),
+              new Fr(42000),
+              /*duplicate*/ new Fr(66666),
+              /*rest are skipped*/ new Fr(11111),
+              new Fr(22222),
+            ],
+            // skipped ...
+            noteHashes: [new Fr(11111), new Fr(22222), new Fr(33333), new Fr(44444), new Fr(55555)],
+            // skipped ...
+            l2ToL1Msgs: [
+              new ScopedL2ToL1Message(
+                new L2ToL1Message(EthAddress.fromNumber(0x1111), new Fr(0xdddd)),
+                AztecAddress.fromNumber(0x1111),
+              ),
+              new ScopedL2ToL1Message(
+                new L2ToL1Message(EthAddress.fromNumber(0x2222), new Fr(0xeeee)),
+                AztecAddress.fromNumber(0x2222),
+              ),
+              new ScopedL2ToL1Message(
+                new L2ToL1Message(EthAddress.fromNumber(0x3333), new Fr(0xffff)),
+                AztecAddress.fromNumber(0x3333),
+              ),
+            ],
+          },
+          nonRevertible: {
+            nullifiers: [/*firstNullifier=*/ new Fr(66000)], // required
+          },
+        },
+      );
+    },
+    TIMEOUT,
+  );
+
   it(
     'top-level exceptional halt in teardown, but app logic succeeds',
     async () => {


### PR DESCRIPTION
## The bug
TX trace was failing proving when a transaction reverted early in a phase and skipped later entries in that same phase. For example:
1. App logic has 2 enqueued calls
2. First one reverts
3. Second is skipped

The `TX_READ_PHASE_LENGTH` lookup to public inputs was failing because tracegen was using the `phase.events` length to populate the `remaining_phase_counter` column, but that wasn't right when there was an early revert in the phase! In that case, we would write the "number of events emitted for the phase" into this column, and then the lookup to public inputs would fail.

Furthermore, we had a constraint that `remaining_phase_counter` must be 1 at the end of the phase. That constraint needed to caveat it with "except if reverted" (`* (1 - reverted)`).

## What i did
1. Included the `phase_lengths` (total number of items that COULD be processed in a phase) in `TxStartupEvent`s to properly tracegen this column for all phases
2. Constrained that `end_phase` gets 1 when `reverted == 1` (and misc related cleanup including constraining that `reverted` is bool).
3. Added bb-prover tests that replicate a ccouple variations of this