### PR TITLE
feat: associating tagging index with tx hash

### DIFF
--- a/yarn-project/pxe/src/contract_function_simulator/pxe_oracle_interface.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/pxe_oracle_interface.ts
@@ -296,7 +296,12 @@ export class PXEOracleInterface implements ExecutionDataProvider {
 
     // Compute and return the tag using the current index
     const indexedTaggingSecret = new IndexedTaggingSecret(appTaggingSecret, index);
-    return indexedTaggingSecret.computeTag(recipient);
+    const appTag = await indexedTaggingSecret.computeTag(recipient);
+
+    // Store the dangling index for later association with tx hash
+    await this.taggingDataProvider.storeDanglingIndex(appTag, sender, recipient, index);
+
+    return appTag;
   }
 
   async #calculateAppTaggingSecret(contractAddress: AztecAddress, sender: AztecAddress, recipient: AztecAddress) {

--- a/yarn-project/pxe/src/pxe.ts
+++ b/yarn-project/pxe/src/pxe.ts
@@ -130,7 +130,7 @@ export class PXE {
     const contractDataProvider = new ContractDataProvider(store);
     const noteDataProvider = await NoteDataProvider.create(store);
     const syncDataProvider = new SyncDataProvider(store);
-    const taggingDataProvider = new TaggingDataProvider(store);
+    const taggingDataProvider = new TaggingDataProvider(store, log);
     const capsuleDataProvider = new CapsuleDataProvider(store);
     const keyStore = new KeyStore(store);
     const tipsStore = new L2TipsKVStore(store, 'pxe');
@@ -715,6 +715,7 @@ export class PXE {
     // computationally demanding that it'd be rare for someone to try to do it concurrently regardless.
     return this.#putInJobQueue(async () => {
       const totalTimer = new Timer();
+      await this.taggingDataProvider.pruneDanglingIndices();
       try {
         const syncTimer = new Timer();
         await this.synchronizer.sync();
@@ -751,6 +752,11 @@ export class PXE {
         };
 
         this.log.debug(`Proving completed in ${totalTime}ms`, { timings });
+
+        // Associate all dangling indices captured during this tx construction with its hash
+        const txHash = (await txRequest.toTxRequest().hash()).toString();
+        await this.taggingDataProvider.associateDanglingIndicesWithTx(txHash);
+
         return new TxProvingResult(privateExecutionResult, publicInputs, clientIvcProof!, {
           timings,
           nodeRPCCalls: contractFunctionSimulator?.getStats().nodeRPCCalls,

--- a/yarn-project/pxe/src/storage/tagging_data_provider/index.ts
+++ b/yarn-project/pxe/src/storage/tagging_data_provider/index.ts
@@ -1,1 +1,1 @@
-export { TaggingDataProvider } from './tagging_data_provider.js';
+export { TaggingDataProvider, type DanglingIndexEntry } from './tagging_data_provider.js';

--- a/yarn-project/pxe/src/storage/tagging_data_provider/tagging_data_provider.test.ts
+++ b/yarn-project/pxe/src/storage/tagging_data_provider/tagging_data_provider.test.ts
@@ -1,0 +1,185 @@
+import { Fr } from '@aztec/foundation/fields';
+import { openTmpStore } from '@aztec/kv-store/lmdb-v2';
+import { AztecAddress } from '@aztec/stdlib/aztec-address';
+import { IndexedTaggingSecret } from '@aztec/stdlib/logs';
+
+import { TaggingDataProvider } from './tagging_data_provider.js';
+
+describe('TaggingDataProvider', () => {
+  let taggingDataProvider: TaggingDataProvider;
+  let store: Awaited<ReturnType<typeof openTmpStore>>;
+
+  beforeEach(async () => {
+    store = await openTmpStore('tagging_data_provider_test');
+    taggingDataProvider = new TaggingDataProvider(store);
+  });
+
+  describe('tagging secret indexes', () => {
+    let sender: AztecAddress;
+    let recipient: AztecAddress;
+    let secretA: Fr;
+    let secretB: Fr;
+
+    beforeEach(async () => {
+      sender = await AztecAddress.random();
+      recipient = await AztecAddress.random();
+      secretA = Fr.random();
+      secretB = Fr.random();
+    });
+
+    it('returns 0 for unset indexes', async () => {
+      const asSender = await taggingDataProvider.getTaggingSecretsIndexesAsSender([secretA, secretB], sender);
+      const asRecipient = await taggingDataProvider.getTaggingSecretsIndexesAsRecipient([secretA, secretB], recipient);
+      expect(asSender).toEqual([0, 0]);
+      expect(asRecipient).toEqual([0, 0]);
+    });
+
+    it('sets and gets indexes for sender direction', async () => {
+      const indexed: IndexedTaggingSecret[] = [
+        new IndexedTaggingSecret(secretA, 1),
+        new IndexedTaggingSecret(secretB, 2),
+      ];
+      await taggingDataProvider.setTaggingSecretsIndexesAsSender(indexed, sender);
+
+      const got = await taggingDataProvider.getTaggingSecretsIndexesAsSender([secretA, secretB], sender);
+      expect(got).toEqual([1, 2]);
+    });
+
+    it('sets and gets indexes for recipient direction', async () => {
+      const indexed: IndexedTaggingSecret[] = [
+        new IndexedTaggingSecret(secretA, 5),
+        new IndexedTaggingSecret(secretB, 7),
+      ];
+      await taggingDataProvider.setTaggingSecretsIndexesAsRecipient(indexed, recipient);
+
+      const got = await taggingDataProvider.getTaggingSecretsIndexesAsRecipient([secretA, secretB], recipient);
+      expect(got).toEqual([5, 7]);
+    });
+
+    it('keeps sender and recipient directions independent', async () => {
+      await taggingDataProvider.setTaggingSecretsIndexesAsSender(
+        [new IndexedTaggingSecret(secretA, 3), new IndexedTaggingSecret(secretB, 4)],
+        sender,
+      );
+      await taggingDataProvider.setTaggingSecretsIndexesAsRecipient(
+        [new IndexedTaggingSecret(secretA, 9), new IndexedTaggingSecret(secretB, 11)],
+        recipient,
+      );
+
+      const asSender = await taggingDataProvider.getTaggingSecretsIndexesAsSender([secretA, secretB], sender);
+      const asRecipient = await taggingDataProvider.getTaggingSecretsIndexesAsRecipient([secretA, secretB], recipient);
+      expect(asSender).toEqual([3, 4]);
+      expect(asRecipient).toEqual([9, 11]);
+    });
+
+    it('resetNoteSyncData clears stored indexes', async () => {
+      await taggingDataProvider.setTaggingSecretsIndexesAsSender(
+        [new IndexedTaggingSecret(secretA, 8), new IndexedTaggingSecret(secretB, 12)],
+        sender,
+      );
+      await taggingDataProvider.setTaggingSecretsIndexesAsRecipient(
+        [new IndexedTaggingSecret(secretA, 13), new IndexedTaggingSecret(secretB, 21)],
+        recipient,
+      );
+
+      await taggingDataProvider.resetNoteSyncData();
+
+      const asSender = await taggingDataProvider.getTaggingSecretsIndexesAsSender([secretA, secretB], sender);
+      const asRecipient = await taggingDataProvider.getTaggingSecretsIndexesAsRecipient([secretA, secretB], recipient);
+      expect(asSender).toEqual([0, 0]);
+      expect(asRecipient).toEqual([0, 0]);
+    });
+  });
+
+  describe('address book', () => {
+    it('adds, lists and removes sender addresses', async () => {
+      const a1 = await AztecAddress.random();
+      const a2 = await AztecAddress.random();
+
+      expect(await taggingDataProvider.addSenderAddress(a1)).toBe(true);
+      expect(await taggingDataProvider.addSenderAddress(a1)).toBe(false); // duplicate
+      expect(await taggingDataProvider.addSenderAddress(a2)).toBe(true);
+
+      const senders = await taggingDataProvider.getSenderAddresses();
+      expect(senders.map(a => a.toString()).sort()).toEqual([a1.toString(), a2.toString()].sort());
+
+      expect(await taggingDataProvider.removeSenderAddress(a1)).toBe(true);
+      expect(await taggingDataProvider.removeSenderAddress(a1)).toBe(false); // already removed
+
+      const remaining = await taggingDataProvider.getSenderAddresses();
+      expect(remaining.map(a => a.toString())).toEqual([a2.toString()]);
+    });
+
+    it('tracks size based on address count', async () => {
+      expect(await taggingDataProvider.getSize()).toBe(0);
+      const a1 = await AztecAddress.random();
+      const a2 = await AztecAddress.random();
+      await taggingDataProvider.addSenderAddress(a1);
+      await taggingDataProvider.addSenderAddress(a2);
+      const expected = 3 * 2 * AztecAddress.SIZE_IN_BYTES; // 3 entries per address
+      expect(await taggingDataProvider.getSize()).toBe(expected);
+    });
+  });
+
+  describe('dangling indices', () => {
+    it('associates dangling indices with a tx and clears them', async () => {
+      const appTag1 = Fr.random();
+      const appTag2 = Fr.random();
+      const sender = await AztecAddress.random();
+      const recipient = await AztecAddress.random();
+
+      await taggingDataProvider.storeDanglingIndex(appTag1, sender, recipient, 1);
+      await taggingDataProvider.storeDanglingIndex(appTag2, sender, recipient, 2);
+
+      // Before association, entries exist in dangling store
+      const dangling = store.openMap<string, { sender: string; recipient: string; index: number }>('dangling_indices');
+      const keysBefore = await Array.fromAsync(dangling.keysAsync());
+      expect(keysBefore.sort()).toEqual([appTag1.toString(), appTag2.toString()].sort());
+
+      const txHash = '0xdeadbeef';
+      await taggingDataProvider.associateDanglingIndicesWithTx(txHash);
+
+      // After association, dangling should be cleared
+      const keysAfter = await Array.fromAsync(dangling.keysAsync());
+      expect(keysAfter).toEqual([]);
+
+      // And indices should be recorded under indices_by_tx_hash
+      const byTx = store.openMap<string, { appTag: string; sender: string; recipient: string; index: number }[]>(
+        'indices_by_tx_hash',
+      );
+      const entries = await byTx.getAsync(txHash);
+      expect(entries?.length).toBe(2);
+      const tags = (entries ?? []).map(e => e.appTag).sort();
+      expect(tags).toEqual([appTag1.toString(), appTag2.toString()].sort());
+    });
+
+    it('prunes dangling indices', async () => {
+      const appTag = Fr.random();
+      const sender = await AztecAddress.random();
+      const recipient = await AztecAddress.random();
+
+      await taggingDataProvider.storeDanglingIndex(appTag, sender, recipient, 42);
+
+      const dangling = store.openMap<string, { sender: string; recipient: string; index: number }>('dangling_indices');
+      const keysBefore = await Array.fromAsync(dangling.keysAsync());
+      expect(keysBefore).toEqual([appTag.toString()]);
+
+      await taggingDataProvider.pruneDanglingIndices();
+
+      const keysAfter = await Array.fromAsync(dangling.keysAsync());
+      expect(keysAfter).toEqual([]);
+    });
+
+    it('throws if storing duplicate app tag', async () => {
+      const appTag = Fr.random();
+      const sender = await AztecAddress.random();
+      const recipient = await AztecAddress.random();
+
+      await taggingDataProvider.storeDanglingIndex(appTag, sender, recipient, 42);
+
+      await expect(taggingDataProvider.storeDanglingIndex(appTag, sender, recipient, 43)).rejects.toThrow(
+        `Dangling index already exists for app tag ${appTag.toString()}`,
+      );
+    });
+  });
+});

--- a/yarn-project/pxe/src/storage/tagging_data_provider/tagging_data_provider.ts
+++ b/yarn-project/pxe/src/storage/tagging_data_provider/tagging_data_provider.ts
@@ -1,8 +1,20 @@
 import type { Fr } from '@aztec/foundation/fields';
 import { toArray } from '@aztec/foundation/iterable';
+import { createLogger } from '@aztec/foundation/log';
 import type { AztecAsyncKVStore, AztecAsyncMap } from '@aztec/kv-store';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import type { IndexedTaggingSecret } from '@aztec/stdlib/logs';
+
+/**
+ * Represents a dangling index entry that associates an app tag with its sender, recipient, and index.
+ * This will later be used to associate a given index with a tx hash.
+ */
+export interface DanglingIndexEntry {
+  appTag: Fr;
+  sender: AztecAddress;
+  recipient: AztecAddress;
+  index: number;
+}
 
 export class TaggingDataProvider {
   #store: AztecAsyncKVStore;
@@ -14,13 +26,25 @@ export class TaggingDataProvider {
   #taggingSecretIndexesForSenders: AztecAsyncMap<string, number>;
   #taggingSecretIndexesForRecipients: AztecAsyncMap<string, number>;
 
-  constructor(store: AztecAsyncKVStore) {
+  // Stores dangling indices that map app tags to (sender, recipient, index) tuples
+  // These will later be associated with tx hashes
+  #danglingIndices: AztecAsyncMap<string, { sender: string; recipient: string; index: number }>;
+
+  // Associates a tx hash to all indices captured during its construction
+  #indicesByTxHash: AztecAsyncMap<string, { appTag: string; sender: string; recipient: string; index: number }[]>;
+
+  constructor(
+    store: AztecAsyncKVStore,
+    private log = createLogger('tagging_data_provider'),
+  ) {
     this.#store = store;
 
     this.#addressBook = this.#store.openMap('address_book');
 
     this.#taggingSecretIndexesForSenders = this.#store.openMap('tagging_secret_indexes_for_senders');
     this.#taggingSecretIndexesForRecipients = this.#store.openMap('tagging_secret_indexes_for_recipients');
+    this.#danglingIndices = this.#store.openMap('dangling_indices');
+    this.#indicesByTxHash = this.#store.openMap('indices_by_tx_hash');
   }
 
   setTaggingSecretsIndexesAsSender(indexedSecrets: IndexedTaggingSecret[], sender: AztecAddress) {
@@ -115,9 +139,73 @@ export class TaggingDataProvider {
     return true;
   }
 
+  // TODO(benesjan): Update this.
   async getSize() {
     const addressesCount = (await toArray(this.#addressBook.keysAsync())).length;
     // All keys are addresses
     return 3 * addressesCount * AztecAddress.SIZE_IN_BYTES;
+  }
+
+  /**
+   * Stores a dangling index entry that associates an app tag with its sender, recipient, and index.
+   * This will later be used to associate a given index with a tx hash.
+   * @param appTag - The computed app tag.
+   * @param sender - The address sending the note.
+   * @param recipient - The address receiving the note.
+   * @param index - The index used to compute the tag.
+   * @throws If the appTag already exists in danglingIndices.
+   */
+  async storeDanglingIndex(appTag: Fr, sender: AztecAddress, recipient: AztecAddress, index: number): Promise<void> {
+    const appTagStr = appTag.toString();
+    if (await this.#danglingIndices.hasAsync(appTagStr)) {
+      throw new Error(`Dangling index already exists for app tag ${appTagStr}`);
+    }
+    await this.#danglingIndices.set(appTagStr, {
+      sender: sender.toString(),
+      recipient: recipient.toString(),
+      index,
+    });
+  }
+
+  /**
+   * Associates all currently stored dangling indices with a given tx hash and clears them from the dangling store.
+   * @param txHash - The transaction hash to associate the currently dangling indices with.
+   */
+  async associateDanglingIndicesWithTx(txHash: string): Promise<void> {
+    await this.#store.transactionAsync(async () => {
+      const appTagKeys = await toArray(this.#danglingIndices.keysAsync());
+      const entries = await Promise.all(
+        appTagKeys.map(async appTagKey => {
+          const value = await this.#danglingIndices.getAsync(appTagKey);
+          return value
+            ? { appTag: appTagKey, sender: value.sender, recipient: value.recipient, index: value.index }
+            : undefined;
+        }),
+      );
+
+      const compact = entries.filter((e): e is { appTag: string; sender: string; recipient: string; index: number } =>
+        Boolean(e),
+      );
+
+      await this.#indicesByTxHash.set(txHash, compact);
+
+      // Clear dangling set
+      await Promise.all(appTagKeys.map(key => this.#danglingIndices.delete(key)));
+    });
+  }
+
+  /**
+   * Deletes all dangling indices from the store.
+   */
+  async pruneDanglingIndices(): Promise<void> {
+    const keys = await toArray(this.#danglingIndices.keysAsync());
+    if (keys.length === 0) {
+      return;
+    }
+
+    const indices = await Promise.all(keys.map(key => this.#danglingIndices.getAsync(key)));
+    this.log.debug(`Pruning ${indices.length} dangling indices`, { indices });
+
+    await Promise.all(keys.map(key => this.#danglingIndices.delete(key)));
   }
 }


### PR DESCRIPTION
In this PR I implement the following:
- when transaction witness generation starts (beginning of pxe.proveTx) we prune indexes without tx hash to get rid of the mess caused by simulations (this should fix [this issue](https://github.com/AztecProtocol/aztec-packages/issues/15753)),
- once the tx construction is finished (end of pxe.proveTx) we associate the new indexes with the given tx hash and mark the tx hash with PENDING status in the TaggingDataProvider,
- the synchronizer then loads all these tx hashes upon sync, requests the node for status and updates the statuses of these indexes (and reverts the statuses on reorgs),
- the possible statuses are: PENDING, DROPPED, FINALIZED (note that whether the tx reverted is irrelevant for indexes)
- the call to privateGetNextAppTagAsSender oracle function in a tx returns tag that corresponds to (highest_tracked_index + 1),
- the `highest_tracked_index` is found over all known indexes, even over dropped transactions BUT its maximum value is capped to LAST_FINALIZED_INDEX + WINDOW_LENGTH. This means that if too many txs get dropped we would link the new tx with the dropped one. Given that this is quite unlikely to happen if we set the WINDOW_LENGTH large enough I think this is fine.
- we prune all the metadata about indexes that are before the LATEST_FINALIZED_INDEX to save db space.
