### PR TITLE
fix: Stop prover node publisher on prover node stop

### DIFF
--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_l1_reorgs.test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_l1_reorgs.test.ts
@@ -161,10 +161,11 @@ describe('e2e_epochs/epochs_l1_reorgs', () => {
       const [proofTx] = proverDelayer.getCancelledTxs();
       expect(proofTx).toBeDefined();
       await proverNode.stop();
+      logger.warn(`Prover node stopped.`);
 
       // Wait for the node to prune
       const syncTimeout = L2_SLOT_DURATION_IN_S * 2;
-      await retryUntil(() => node.getBlockNumber().then(b => b <= 1), 'node sync', syncTimeout, 0.1);
+      await retryUntil(() => node.getBlockNumber().then(b => b <= 1), 'node prune', syncTimeout, 0.1);
       expect(monitor.l2ProvenBlockNumber).toEqual(0);
       expect(await node.getProvenBlockNumber()).toEqual(0);
 
@@ -180,7 +181,7 @@ describe('e2e_epochs/epochs_l1_reorgs', () => {
       expect(l2ProvenBlockNumber).toBeGreaterThan(0);
 
       // And so the node undoes its reorg
-      await retryUntil(() => node.getBlockNumber().then(b => b >= l2BlockNumber), 'node sync', syncTimeout, 0.1);
+      await retryUntil(() => node.getBlockNumber().then(b => b >= l2BlockNumber), 'node resync', syncTimeout, 0.1);
       await retryUntil(() => node.getProvenBlockNumber().then(b => b >= l2ProvenBlockNumber), 'proof sync', 1, 0.1);
 
       logger.warn(`Test succeeded`);

--- a/yarn-project/prover-node/src/job/epoch-proving-job.ts
+++ b/yarn-project/prover-node/src/job/epoch-proving-job.ts
@@ -302,7 +302,6 @@ export class EpochProvingJob implements Traceable {
   public async stop(state: EpochProvingJobTerminalState = 'stopped') {
     this.state = state;
     this.prover.cancel();
-    // TODO(palla/prover): Stop the publisher as well
     if (this.runPromise) {
       await this.runPromise;
     }

--- a/yarn-project/prover-node/src/prover-node-publisher.ts
+++ b/yarn-project/prover-node/src/prover-node-publisher.ts
@@ -77,6 +77,7 @@ export class ProverNodePublisher {
   public interrupt() {
     this.interrupted = true;
     this.interruptibleSleep.interrupt();
+    this.l1TxUtils.interrupt();
   }
 
   /** Restarts the publisher after calling `interrupt`. */


### PR DESCRIPTION
Prover node was failing to stop properly while the l1-tx-utils was in a loop trying to submit the proof tx.