### PR TITLE
feat: PG prover checks the zeroth coefficient of the perturbator

### DIFF
--- a/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.test.cpp
@@ -92,6 +92,8 @@ TEST_F(ClientIVCTests, BasicStructured)
  */
 TEST_F(ClientIVCTests, BadProofFailure)
 {
+    BB_DISABLE_ASSERTS(); // Disable assert in PG prover
+
     const size_t NUM_APP_CIRCUITS = 2;
     TraceSettings trace_settings{ SMALL_TEST_STRUCTURE };
     // Confirm that the IVC verifies if nothing is tampered with
@@ -404,6 +406,8 @@ TEST_F(ClientIVCTests, MsgpackProofFromFileOrBuffer)
  */
 TEST_F(ClientIVCTests, DatabusFailure)
 {
+    BB_DISABLE_ASSERTS(); // Disable assert in PG prover
+
     PrivateFunctionExecutionMockCircuitProducer circuit_producer{ /*num_app_circuits=*/1 };
     const size_t NUM_CIRCUITS = circuit_producer.total_num_circuits;
     ClientIVC ivc{ NUM_CIRCUITS, { AZTEC_TRACE_STRUCTURE } };

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/pg_recursion_constraint.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/pg_recursion_constraint.test.cpp
@@ -596,6 +596,8 @@ TEST_F(IvcRecursionConstraintTest, RecursiveVerifierAppCircuitTest)
  */
 TEST_F(IvcRecursionConstraintTest, BadRecursiveVerifierAppCircuitTest)
 {
+    BB_DISABLE_ASSERTS(); // Disable assert in PG prover
+
     TraceSettings trace_settings{ AZTEC_TRACE_STRUCTURE };
     auto ivc = std::make_shared<ClientIVC>(/*num_circuits*/ 5, trace_settings);
 

--- a/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy.test.cpp
@@ -668,7 +668,7 @@ TYPED_TEST(ProtogalaxyTests, TamperedCommitment)
 
 TYPED_TEST(ProtogalaxyTests, TamperedAccumulatorPolynomial)
 {
-    BB_DISABLE_ASSERTS();
+    BB_DISABLE_ASSERTS(); // Disable assert in PG prover
     TestFixture::test_tampered_accumulator_polynomial();
 }
 

--- a/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy.test.cpp
@@ -668,6 +668,7 @@ TYPED_TEST(ProtogalaxyTests, TamperedCommitment)
 
 TYPED_TEST(ProtogalaxyTests, TamperedAccumulatorPolynomial)
 {
+    BB_DISABLE_ASSERTS();
     TestFixture::test_tampered_accumulator_polynomial();
 }
 

--- a/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover_internal.hpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover_internal.hpp
@@ -300,6 +300,13 @@ template <class ProverInstance> class ProtogalaxyProverInternal {
         for (size_t idx = log_circuit_size; idx < CONST_PG_LOG_N; ++idx) {
             perturbator.emplace_back(FF(0));
         }
+
+        // Check that the perturbator zeroth coefficient is equal to the target sum stored in the accumulator
+        BB_ASSERT_EQ(perturbator[0],
+                     accumulator->target_sum,
+                     "ProtogalaxyProver: the zeroth coefficient of the perturbator is different from the target sum "
+                     "stored in the accumulator.");
+
         return Polynomial<FF>{ perturbator };
     }
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/protogalaxy_recursive_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/protogalaxy_recursive_verifier.test.cpp
@@ -560,6 +560,7 @@ TEST_F(ProtogalaxyRecursiveTests, TamperedDeciderProof)
 
 TEST_F(ProtogalaxyRecursiveTests, TamperedAccumulator)
 {
+    BB_DISABLE_ASSERTS();
     ProtogalaxyRecursiveTests::test_tampered_accumulator();
 }
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/protogalaxy_recursive_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/protogalaxy_recursive_verifier.test.cpp
@@ -560,7 +560,7 @@ TEST_F(ProtogalaxyRecursiveTests, TamperedDeciderProof)
 
 TEST_F(ProtogalaxyRecursiveTests, TamperedAccumulator)
 {
-    BB_DISABLE_ASSERTS();
+    BB_DISABLE_ASSERTS(); // Disable assert in PG prover
     ProtogalaxyRecursiveTests::test_tampered_accumulator();
 }
 


### PR DESCRIPTION
Our PG prover is computing the perturbator polynomial ($F$ in the Protogalaxy paper) as

$$F(X) = \sum pow_i(\beta + X \delta) f_i(\omega)$$

For an $\omega$ which is not valid, i.e. $\sum pow_i(\beta) f_i(\omega) \neq e$, this means the prover is not folding $\omega$, but the instance which is equal to $\omega$ in all aspects, but with target sum equal to $\sum pow_i(\beta) f_i(\omega)$. Thus, PG folds a valid instance in place of $\omega$.

This PR adds a check in the calculation of the perturbator so that $F(0)$ is checked to be equal to $e$, so that we can catch errors early.