### PR TITLE
feat: TXE dispatch function name zod validation check

### DIFF
--- a/yarn-project/txe/src/index.ts
+++ b/yarn-project/txe/src/index.ts
@@ -55,7 +55,6 @@ type TXEForeignCallInput = {
   inputs: ForeignCallArgs;
 };
 
-// TODO: why does the zod validation in the txe dispatcher not reject invalid function names?
 const TXEForeignCallInputSchema = z.object({
   // eslint-disable-next-line camelcase
   session_id: z.number().int().nonnegative(),

--- a/yarn-project/txe/src/rpc_translator.ts
+++ b/yarn-project/txe/src/rpc_translator.ts
@@ -54,6 +54,9 @@ export class RPCTranslator {
       | ITxeExecutionOracle,
   ) {}
 
+  // Note: If you rename the following functions to not start with "handlerAs", you must also update the validation
+  // check in `TXESession.processFunction`.
+
   private handlerAsMisc(): IMiscOracle {
     if (!('isMisc' in this.oracleHandler)) {
       throw new UnavailableOracleError('Misc');

--- a/yarn-project/txe/src/txe_session.test.ts
+++ b/yarn-project/txe/src/txe_session.test.ts
@@ -1,0 +1,50 @@
+import { Fr } from '@aztec/foundation/fields';
+
+import type { TXEOracleFunctionName } from './txe_session.js';
+import { TXESession } from './txe_session.js';
+
+describe('TXESession.processFunction', () => {
+  let session: TXESession;
+
+  beforeAll(() => {
+    session = new TXESession(
+      {} as any, // logger
+      {} as any, // stateMachine
+      {} as any, // oracleHandler
+      {} as any, // contractDataProvider
+      {} as any, // keyStore
+      {} as any, // addressDataProvider
+      {} as any, // accountDataProvider
+      new Fr(1), // chainId
+      new Fr(1), // version
+      0n, // nextBlockTimestamp
+      {} as any, // pxeOracleInterface
+    );
+  });
+
+  it('rejects calling a function that does not exist on RPCTranslator with the expected error message', () => {
+    const invalidName = 'notARealFunction' as unknown as TXEOracleFunctionName;
+
+    expect(() => session.processFunction(invalidName, [])).toThrow(
+      `notARealFunction does not correspond to any oracle handler available on RPCTranslator`,
+    );
+  });
+
+  it('rejects calling internal translator helpers (handlerAs*) with the expected error message', () => {
+    const illegalNames = ['handlerAsMisc', 'handlerAsUtility', 'handlerAsPrivate', 'handlerAsAvm', 'handlerAsTxe'];
+
+    for (const name of illegalNames) {
+      expect(() => session.processFunction(name as any, [])).toThrow(
+        `${name} does not correspond to any oracle handler available on RPCTranslator`,
+      );
+    }
+  });
+
+  it("rejects calling the translator's constructor with the expected error message", () => {
+    const invalidName = 'constructor' as unknown as TXEOracleFunctionName;
+
+    expect(() => session.processFunction(invalidName, [])).toThrow(
+      `constructor does not correspond to any oracle handler available on RPCTranslator`,
+    );
+  });
+});


### PR DESCRIPTION
We didn't perform a runtime check of the function name in the process function of dispatcher. In this PR I fix that.

Without this PR the handler would most likely fail with some random error. With this PR they get a nice error message that there is no oracle handler corresponding to the `functionName`.

Also sneaked in a fix of the `TXEOracleFunctionName` type.