### PR TITLE
feat: Cross compile node module to escape container.

### DIFF
--- a/barretenberg/cpp/CMakePresets.json
+++ b/barretenberg/cpp/CMakePresets.json
@@ -521,7 +521,8 @@
       "inherits": "zig-base",
       "environment": {
         "CC": "zig cc -target x86_64-linux-musl",
-        "CXX": "zig c++ -target x86_64-linux-musl"
+        "CXX": "zig c++ -target x86_64-linux-musl",
+        "LDFLAGS": "-s"
       },
       "cacheVariables": {
         "CMAKE_SYSTEM_NAME": "Linux",
@@ -533,7 +534,8 @@
       "inherits": "zig-base",
       "environment": {
         "CC": "zig cc -target aarch64-linux-musl",
-        "CXX": "zig c++ -target aarch64-linux-musl"
+        "CXX": "zig c++ -target aarch64-linux-musl",
+        "LDFLAGS": "-s"
       },
       "cacheVariables": {
         "CMAKE_SYSTEM_NAME": "Linux",

--- a/barretenberg/cpp/CMakePresets.json
+++ b/barretenberg/cpp/CMakePresets.json
@@ -520,8 +520,8 @@
       "name": "zig-node-amd64-linux",
       "inherits": "zig-base",
       "environment": {
-        "CC": "zig cc -target x86_64-linux-musl",
-        "CXX": "zig c++ -target x86_64-linux-musl",
+        "CC": "zig cc -target x86_64-linux-gnu",
+        "CXX": "zig c++ -target x86_64-linux-gnu",
         "LDFLAGS": "-s"
       },
       "cacheVariables": {
@@ -533,8 +533,8 @@
       "name": "zig-node-arm64-linux",
       "inherits": "zig-base",
       "environment": {
-        "CC": "zig cc -target aarch64-linux-musl",
-        "CXX": "zig c++ -target aarch64-linux-musl",
+        "CC": "zig cc -target aarch64-linux-gnu",
+        "CXX": "zig c++ -target aarch64-linux-gnu",
         "LDFLAGS": "-s"
       },
       "cacheVariables": {

--- a/barretenberg/cpp/CMakePresets.json
+++ b/barretenberg/cpp/CMakePresets.json
@@ -498,6 +498,73 @@
         "LDFLAGS": "-fxray-instrument -fxray-instruction-threshold=500 -DXRAY=1"
       },
       "binaryDir": "build-xray"
+    },
+    {
+      "name": "zig-base",
+      "displayName": "Zig (base)",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build-${presetName}",
+      "environment": {
+        "CC": "zig cc",
+        "CXX": "zig c++"
+      },
+      "cacheVariables": {
+        "ENABLE_PIC": "ON",
+        "CMAKE_BUILD_TYPE": "Release",
+        "DISABLE_AZTEC_VM": "ON",
+        "CMAKE_AR": "${sourceDir}/scripts/zig-ar.sh",
+        "CMAKE_RANLIB": "${sourceDir}/scripts/zig-ranlib.sh"
+      }
+    },
+    {
+      "name": "zig-node-amd64-linux",
+      "inherits": "zig-base",
+      "environment": {
+        "CC": "zig cc -target x86_64-linux-musl",
+        "CXX": "zig c++ -target x86_64-linux-musl"
+      },
+      "cacheVariables": {
+        "CMAKE_SYSTEM_NAME": "Linux",
+        "TARGET_ARCH": "skylake"
+      }
+    },
+    {
+      "name": "zig-node-arm64-linux",
+      "inherits": "zig-base",
+      "environment": {
+        "CC": "zig cc -target aarch64-linux-musl",
+        "CXX": "zig c++ -target aarch64-linux-musl"
+      },
+      "cacheVariables": {
+        "CMAKE_SYSTEM_NAME": "Linux",
+        "TARGET_ARCH": "generic"
+      }
+    },
+    {
+      "name": "zig-node-amd64-macos",
+      "inherits": "zig-base",
+      "environment": {
+        "CC": "zig cc -target x86_64-macos",
+        "CXX": "zig c++ -target x86_64-macos",
+        "LDFLAGS": "-Wl,-undefined,dynamic_lookup"
+      },
+      "cacheVariables": {
+        "CMAKE_SYSTEM_NAME": "Darwin",
+        "TARGET_ARCH": "sandybridge"
+      }
+    },
+    {
+      "name": "zig-node-arm64-macos",
+      "inherits": "zig-base",
+      "environment": {
+        "CC": "zig cc -target aarch64-macos",
+        "CXX": "zig c++ -target aarch64-macos",
+        "LDFLAGS": "-Wl,-undefined,dynamic_lookup"
+      },
+      "cacheVariables": {
+        "CMAKE_SYSTEM_NAME": "Darwin",
+        "TARGET_ARCH": "generic"
+      }
     }
   ],
   "buildPresets": [
@@ -688,6 +755,30 @@
       "name": "xray",
       "configurePreset": "xray",
       "inherits": "default"
+    },
+    {
+      "name": "zig-node-amd64-linux",
+      "configurePreset": "zig-node-amd64-linux",
+      "inheritConfigureEnvironment": true,
+      "targets": ["nodejs_module"]
+    },
+    {
+      "name": "zig-node-arm64-linux",
+      "configurePreset": "zig-node-arm64-linux",
+      "inheritConfigureEnvironment": true,
+      "targets": ["nodejs_module"]
+    },
+    {
+      "name": "zig-node-amd64-macos",
+      "configurePreset": "zig-node-amd64-macos",
+      "inheritConfigureEnvironment": true,
+      "targets": ["nodejs_module"]
+    },
+    {
+      "name": "zig-node-arm64-macos",
+      "configurePreset": "zig-node-arm64-macos",
+      "inheritConfigureEnvironment": true,
+      "targets": ["nodejs_module"]
     }
   ],
   "testPresets": [

--- a/barretenberg/cpp/bootstrap.sh
+++ b/barretenberg/cpp/bootstrap.sh
@@ -20,6 +20,22 @@ if [ "${DISABLE_AZTEC_VM:-0}" -eq 1 ]; then
   export hash="$hash-no-avm"
 fi
 
+function ensure_zig {
+  if command -v zig &>/dev/null; then
+    return
+  fi
+  local arch=$(uname -m)
+  local zig_version=0.15.1
+  local bin_path=/opt/zig-${arch}-linux-${zig_version}
+  if [ -f $bin_path/zig ]; then
+    export PATH="$bin_path:$PATH"
+    return
+  fi
+  echo "Installing zig $zig_version..."
+  curl -sL https://ziglang.org/download/$zig_version/zig-${arch}-linux-$zig_version.tar.xz | sudo tar -xJ -C /opt
+  export PATH="$bin_path:$PATH"
+}
+
 # Injects version number into a given bb binary.
 # Means we don't actually need to rebuild bb to release a new version if code hasn't changed.
 function inject_version {
@@ -51,6 +67,7 @@ function build_preset() {
   cmake --fresh --preset "$preset" ${DISABLE_AZTEC_VM:+-DDISABLE_AZTEC_VM=$DISABLE_AZTEC_VM}
   cmake --build --preset "$preset" "$@"
 }
+export -f build_preset
 
 # Build all native binaries, including tests.
 function build_native {
@@ -76,10 +93,15 @@ function build_asan_fast {
 
 function build_nodejs_module {
   set -eu
+  ensure_zig
   (cd src/barretenberg/nodejs_module && yarn --frozen-lockfile --prefer-offline)
   if ! cache_download barretenberg-native-nodejs-module-$hash.zst; then
-    build_preset $pic_preset --target nodejs_module
-    cache_upload barretenberg-native-nodejs-module-$hash.zst build-pic/lib/nodejs_module.node
+    parallel --line-buffered --tag --halt now,fail=1 build_preset ::: \
+      zig-node-amd64-linux \
+      zig-node-arm64-linux \
+      zig-node-amd64-macos \
+      zig-node-arm64-macos
+    cache_upload barretenberg-native-nodejs-module-$hash.zst build-zig-*-*/lib/nodejs_module.node
   fi
 }
 
@@ -156,7 +178,7 @@ function build_smt_verification {
 
   sudo apt update && sudo apt install -y python3-pip python3-venv m4 bison
   cmake --preset smt-verification
- 
+
   cvc5_cmake_hash=$(cache_content_hash ^barretenberg/cpp/src/barretenberg/smt_verification/CMakeLists.txt)
   if ! cache_download barretenberg-cvc5-$cvc5_cmake_hash.zst; then
       cmake --build build-smt --target cvc5

--- a/barretenberg/cpp/bootstrap.sh
+++ b/barretenberg/cpp/bootstrap.sh
@@ -207,7 +207,7 @@ function build_release {
   fi
 }
 
-export -f build_preset build_native build_asan_fast build_darwin build_nodejs_module build_wasm build_wasm_threads build_gcc_syntax_check_only build_fuzzing_syntax_check_only build_smt_verification
+export -f ensure_zig build_preset build_native build_asan_fast build_darwin build_nodejs_module build_wasm build_wasm_threads build_gcc_syntax_check_only build_fuzzing_syntax_check_only build_smt_verification
 
 function build {
   echo_header "bb cpp build"

--- a/barretenberg/cpp/bootstrap.sh
+++ b/barretenberg/cpp/bootstrap.sh
@@ -67,7 +67,6 @@ function build_preset() {
   cmake --fresh --preset "$preset" ${DISABLE_AZTEC_VM:+-DDISABLE_AZTEC_VM=$DISABLE_AZTEC_VM}
   cmake --build --preset "$preset" "$@"
 }
-export -f build_preset
 
 # Build all native binaries, including tests.
 function build_native {

--- a/barretenberg/cpp/scripts/zig-ar.sh
+++ b/barretenberg/cpp/scripts/zig-ar.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec zig ar "$@"

--- a/barretenberg/cpp/scripts/zig-ranlib.sh
+++ b/barretenberg/cpp/scripts/zig-ranlib.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec zig ranlib "$@"

--- a/barretenberg/cpp/src/barretenberg/crypto/merkle_tree/indexed_tree/content_addressed_indexed_tree.hpp
+++ b/barretenberg/cpp/src/barretenberg/crypto/merkle_tree/indexed_tree/content_addressed_indexed_tree.hpp
@@ -552,8 +552,8 @@ void ContentAddressedIndexedTree<Store, HashingPolicy>::add_or_update_values_int
     bool capture_witness)
 {
     // We first take a copy of the leaf values and their locations within the set given to us
-    std::shared_ptr<std::vector<std::pair<LeafValueType, size_t>>> values_to_be_sorted =
-        std::make_shared<std::vector<std::pair<LeafValueType, size_t>>>(values.size());
+    std::shared_ptr<std::vector<std::pair<LeafValueType, index_t>>> values_to_be_sorted =
+        std::make_shared<std::vector<std::pair<LeafValueType, index_t>>>(values.size());
     for (size_t i = 0; i < values.size(); ++i) {
         (*values_to_be_sorted)[i] = std::make_pair(values[i], i);
     }
@@ -958,8 +958,8 @@ void ContentAddressedIndexedTree<Store, HashingPolicy>::generate_insertions(
                                                     max_size_));
                 }
                 for (size_t i = 0; i < values.size(); ++i) {
-                    std::pair<LeafValueType, size_t>& value_pair = values[i];
-                    size_t index_into_appended_leaves = value_pair.second;
+                    std::pair<LeafValueType, index_t>& value_pair = values[i];
+                    index_t index_into_appended_leaves = value_pair.second;
                     index_t index_of_new_leaf = static_cast<index_t>(index_into_appended_leaves) + meta.size;
                     if (value_pair.first.is_empty()) {
                         continue;

--- a/barretenberg/cpp/src/barretenberg/crypto/merkle_tree/response.hpp
+++ b/barretenberg/cpp/src/barretenberg/crypto/merkle_tree/response.hpp
@@ -78,7 +78,7 @@ template <typename LeafType> struct LeafUpdateWitnessData {
 template <typename LeafValueType> struct AddIndexedDataResponse {
     AddDataResponse add_data_result;
     fr_sibling_path subtree_path;
-    std::shared_ptr<std::vector<std::pair<LeafValueType, size_t>>> sorted_leaves;
+    std::shared_ptr<std::vector<std::pair<LeafValueType, index_t>>> sorted_leaves;
     std::shared_ptr<std::vector<LeafUpdateWitnessData<LeafValueType>>> low_leaf_witness_data;
 
     AddIndexedDataResponse() = default;

--- a/barretenberg/cpp/src/barretenberg/nodejs_module/lmdb_store/lmdb_store_wrapper.cpp
+++ b/barretenberg/cpp/src/barretenberg/nodejs_module/lmdb_store/lmdb_store_wrapper.cpp
@@ -4,7 +4,6 @@
 #include "barretenberg/nodejs_module/lmdb_store/lmdb_store_message.hpp"
 #include "napi.h"
 #include <algorithm>
-#include <bits/chrono.h>
 #include <chrono>
 #include <cstdint>
 #include <iterator>

--- a/barretenberg/cpp/src/barretenberg/world_state/world_state.hpp
+++ b/barretenberg/cpp/src/barretenberg/world_state/world_state.hpp
@@ -35,7 +35,7 @@ using crypto::merkle_tree::index_t;
 
 template <typename LeafValueType> struct BatchInsertionResult {
     std::vector<crypto::merkle_tree::LeafUpdateWitnessData<LeafValueType>> low_leaf_witness_data;
-    std::vector<std::pair<LeafValueType, size_t>> sorted_leaves;
+    std::vector<std::pair<LeafValueType, index_t>> sorted_leaves;
     crypto::merkle_tree::fr_sibling_path subtree_path;
 
     MSGPACK_FIELDS(low_leaf_witness_data, sorted_leaves, subtree_path);

--- a/release-image/Dockerfile.dockerignore
+++ b/release-image/Dockerfile.dockerignore
@@ -23,7 +23,7 @@
 !/yarn-project/protocol-contracts/artifacts/
 !/yarn-project/noir-contracts.js/artifacts/
 !/yarn-project/simulator/artifacts/
-!/yarn-project/native/build/nodejs_module.node
+!/yarn-project/native/build/
 
 # Needed to generate list of env vars to know what to be able to inject into the container.
 !/yarn-project/foundation/src/config/env_var.ts

--- a/yarn-project/native/package.json
+++ b/yarn-project/native/package.json
@@ -12,7 +12,7 @@
     "clean:cpp": "rm -rf $(git rev-parse --show-toplevel)/barretenberg/cpp/build-pic",
     "clean": "rm -rf ./dest .tsbuildinfo",
     "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --passWithNoTests --maxWorkers=${JEST_MAX_WORKERS:-8}",
-    "generate": "mkdir -p build && cp -v $(git rev-parse --show-toplevel)/barretenberg/cpp/build-pic/lib/nodejs_module.node build"
+    "generate": "bash scripts/copy-modules.sh"
   },
   "inherits": [
     "../package.common.json",
@@ -20,12 +20,10 @@
   ],
   "dependencies": {
     "@aztec/foundation": "workspace:^",
-    "bindings": "^1.5.0",
     "msgpackr": "^1.11.2"
   },
   "devDependencies": {
     "@jest/globals": "^30.0.0",
-    "@types/bindings": "^1.5.5",
     "@types/jest": "^30.0.0",
     "@types/node": "^22.15.17",
     "jest": "^30.0.0",
@@ -35,6 +33,7 @@
   "files": [
     "dest",
     "src",
+    "build",
     "!*.test.*"
   ],
   "engines": {

--- a/yarn-project/native/package.local.json
+++ b/yarn-project/native/package.local.json
@@ -4,6 +4,6 @@
     "build:dev": "tsc -b --watch",
     "build:cpp": "PROJECT=$(pwd); cd $(git rev-parse --show-toplevel)/barretenberg/cpp; cmake --preset ${PRESET:-clang16-pic} && cmake --build --preset ${PRESET:-clang16-pic} --target nodejs_module && cd $PROJECT && yarn generate",
     "clean:cpp": "rm -rf $(git rev-parse --show-toplevel)/barretenberg/cpp/build-pic",
-    "generate": "mkdir -p build && cp -v $(git rev-parse --show-toplevel)/barretenberg/cpp/build-pic/lib/nodejs_module.node build"
+    "generate": "bash scripts/copy-modules.sh"
   }
 }

--- a/yarn-project/native/scripts/copy-modules.sh
+++ b/yarn-project/native/scripts/copy-modules.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BB_ROOT=$(git rev-parse --show-toplevel)/barretenberg/cpp
+rm -rf build
+
+for variant in amd64-linux arm64-linux amd64-macos arm64-macos; do
+  mkdir -p "build/$variant"
+  cp -v "$BB_ROOT/build-zig-node-$variant/lib/nodejs_module.node" "build/$variant/" 2>/dev/null || echo "Warning: $variant not found"
+done

--- a/yarn-project/native/src/native_module.ts
+++ b/yarn-project/native/src/native_module.ts
@@ -1,4 +1,6 @@
-import bindings from 'bindings';
+import { createRequire } from 'module';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
 
 import type { MessageReceiver } from './msgpack_channel.js';
 
@@ -6,7 +8,30 @@ interface NativeClassCtor {
   new (...args: unknown[]): MessageReceiver;
 }
 
-const nativeModule: Record<string, NativeClassCtor> = bindings('nodejs_module');
+function loadNativeModule(): Record<string, NativeClassCtor> {
+  const __filename = fileURLToPath(import.meta.url);
+  const __dirname = dirname(__filename);
+
+  // Map Node.js platform/arch to build directory names
+  const arch = process.arch === 'x64' ? 'amd64' : process.arch;
+  const platform = process.platform === 'darwin' ? 'macos' : process.platform;
+  const variant = `${arch}-${platform}`;
+
+  const modulePath = join(__dirname, '..', 'build', variant, 'nodejs_module.node');
+
+  try {
+    const require = createRequire(import.meta.url);
+    return require(modulePath);
+  } catch (error) {
+    throw new Error(
+      `Failed to load native module for ${variant} from ${modulePath}. ` +
+        `Supported: amd64-linux, arm64-linux, amd64-macos, arm64-macos. ` +
+        `Error: ${error}`,
+    );
+  }
+}
+
+const nativeModule: Record<string, NativeClassCtor> = loadNativeModule();
 
 export const NativeWorldState: NativeClassCtor = nativeModule.WorldState;
 export const NativeLMDBStore: NativeClassCtor = nativeModule.LMDBStore;

--- a/yarn-project/yarn.lock
+++ b/yarn-project/yarn.lock
@@ -1548,10 +1548,8 @@ __metadata:
   dependencies:
     "@aztec/foundation": "workspace:^"
     "@jest/globals": "npm:^30.0.0"
-    "@types/bindings": "npm:^1.5.5"
     "@types/jest": "npm:^30.0.0"
     "@types/node": "npm:^22.15.17"
-    bindings: "npm:^1.5.0"
     jest: "npm:^30.0.0"
     msgpackr: "npm:^1.11.2"
     ts-node: "npm:^10.9.1"
@@ -1637,8 +1635,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@aztec/noir-noir_codegen@portal:../noir/packages/noir_codegen::locator=%40aztec%2Faztec3-packages%40workspace%3A."
   dependencies:
-    "@aztec/noir-types": "npm:1.0.0-beta.13"
-    glob: "npm:^11.0.3"
+    "@aztec/noir-types": "npm:1.0.0-beta.11"
+    glob: "npm:^11.0.2"
     ts-command-line-args: "npm:^2.5.1"
   bin:
     noir-codegen: lib/main.js
@@ -1646,14 +1644,14 @@ __metadata:
   linkType: soft
 
 "@aztec/noir-noir_js@file:../noir/packages/noir_js::locator=%40aztec%2Faztec3-packages%40workspace%3A.":
-  version: 1.0.0-beta.13
-  resolution: "@aztec/noir-noir_js@file:../noir/packages/noir_js#../noir/packages/noir_js::hash=d642c8&locator=%40aztec%2Faztec3-packages%40workspace%3A."
+  version: 1.0.0-beta.11
+  resolution: "@aztec/noir-noir_js@file:../noir/packages/noir_js#../noir/packages/noir_js::hash=6deab3&locator=%40aztec%2Faztec3-packages%40workspace%3A."
   dependencies:
-    "@aztec/noir-acvm_js": "npm:1.0.0-beta.13"
-    "@aztec/noir-noirc_abi": "npm:1.0.0-beta.13"
-    "@aztec/noir-types": "npm:1.0.0-beta.13"
+    "@aztec/noir-acvm_js": "npm:1.0.0-beta.11"
+    "@aztec/noir-noirc_abi": "npm:1.0.0-beta.11"
+    "@aztec/noir-types": "npm:1.0.0-beta.11"
     pako: "npm:^2.1.0"
-  checksum: 10/b21aff9aa2b8d50261730b80bda25201015a540d259917c706fc9c9f9f6c38a7d50b6a91e26b6452814acfb79a05a8854772bac53b50b820441a5532a147cbaa
+  checksum: 10/e6252a0b1812852a24db28a796fcecff7a726863342017e9da9d7a334c098c0c3918e77e42edfcd29c2401a15b6982fd0e43ecde2218c217e6c98b1d9234f74b
   languageName: node
   linkType: hard
 
@@ -1661,7 +1659,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@aztec/noir-noirc_abi@portal:../noir/packages/noirc_abi::locator=%40aztec%2Faztec3-packages%40workspace%3A."
   dependencies:
-    "@aztec/noir-types": "npm:1.0.0-beta.13"
+    "@aztec/noir-types": "npm:1.0.0-beta.11"
   languageName: node
   linkType: soft
 
@@ -7664,15 +7662,6 @@ __metadata:
   dependencies:
     "@babel/types": "npm:^7.20.7"
   checksum: 10/f0352d537448e1e37f27e6bb8c962d7893720a92fde9d8601a68a93dbc14e15c088b4c0c8f71021d0966d09fba802ef3de11fdb6766c33993f8cf24f1277c6a9
-  languageName: node
-  linkType: hard
-
-"@types/bindings@npm:^1.5.5":
-  version: 1.5.5
-  resolution: "@types/bindings@npm:1.5.5"
-  dependencies:
-    "@types/node": "npm:*"
-  checksum: 10/0205bd031677e9af479437b4f358d4ea96d9d1a7d57132657915201d9a8be968d5f8341f526cc79481142fe9456f82e093cf62a0b2bcf6c3cfd4577962603b22
   languageName: node
   linkType: hard
 
@@ -14892,7 +14881,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:^11.0.3":
+"glob@npm:^11.0.2":
   version: 11.0.3
   resolution: "glob@npm:11.0.3"
   dependencies:

--- a/yarn-project/yarn.lock
+++ b/yarn-project/yarn.lock
@@ -1635,8 +1635,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@aztec/noir-noir_codegen@portal:../noir/packages/noir_codegen::locator=%40aztec%2Faztec3-packages%40workspace%3A."
   dependencies:
-    "@aztec/noir-types": "npm:1.0.0-beta.11"
-    glob: "npm:^11.0.2"
+    "@aztec/noir-types": "npm:1.0.0-beta.13"
+    glob: "npm:^11.0.3"
     ts-command-line-args: "npm:^2.5.1"
   bin:
     noir-codegen: lib/main.js
@@ -1644,14 +1644,14 @@ __metadata:
   linkType: soft
 
 "@aztec/noir-noir_js@file:../noir/packages/noir_js::locator=%40aztec%2Faztec3-packages%40workspace%3A.":
-  version: 1.0.0-beta.11
-  resolution: "@aztec/noir-noir_js@file:../noir/packages/noir_js#../noir/packages/noir_js::hash=6deab3&locator=%40aztec%2Faztec3-packages%40workspace%3A."
+  version: 1.0.0-beta.13
+  resolution: "@aztec/noir-noir_js@file:../noir/packages/noir_js#../noir/packages/noir_js::hash=d642c8&locator=%40aztec%2Faztec3-packages%40workspace%3A."
   dependencies:
-    "@aztec/noir-acvm_js": "npm:1.0.0-beta.11"
-    "@aztec/noir-noirc_abi": "npm:1.0.0-beta.11"
-    "@aztec/noir-types": "npm:1.0.0-beta.11"
+    "@aztec/noir-acvm_js": "npm:1.0.0-beta.13"
+    "@aztec/noir-noirc_abi": "npm:1.0.0-beta.13"
+    "@aztec/noir-types": "npm:1.0.0-beta.13"
     pako: "npm:^2.1.0"
-  checksum: 10/e6252a0b1812852a24db28a796fcecff7a726863342017e9da9d7a334c098c0c3918e77e42edfcd29c2401a15b6982fd0e43ecde2218c217e6c98b1d9234f74b
+  checksum: 10/b21aff9aa2b8d50261730b80bda25201015a540d259917c706fc9c9f9f6c38a7d50b6a91e26b6452814acfb79a05a8854772bac53b50b820441a5532a147cbaa
   languageName: node
   linkType: hard
 
@@ -1659,7 +1659,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@aztec/noir-noirc_abi@portal:../noir/packages/noirc_abi::locator=%40aztec%2Faztec3-packages%40workspace%3A."
   dependencies:
-    "@aztec/noir-types": "npm:1.0.0-beta.11"
+    "@aztec/noir-types": "npm:1.0.0-beta.13"
   languageName: node
   linkType: soft
 
@@ -14881,7 +14881,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:^11.0.2":
+"glob@npm:^11.0.3":
   version: 11.0.3
   resolution: "glob@npm:11.0.3"
   dependencies:


### PR DESCRIPTION
Adds 4 new presets to cross-compile to the following nodejs_module variants with zigs toolchain:
* x86_64-linux
* aarch64-linux
* x86_64-macos
* aarch64-macos

In the future this world state stuff will be owned by labs and quite possibly lift out the bb repo (needs thought r.e. headers etc).
It may also become a separate binary with stdin/out io rather than a NAPI module (better isolation, analysis, swapability, flexibility).
It will also probably get rid of cmake and will just use zigs native build system - but bb team are currently beholden to cmake so we keep using it.

This currently installs zig in the cpp/bootstrap - it's pretty fast and trivial time but should go into build image soon.
The native module in yarn-project now copies in the 4 variants and picks depending on system arch.