### PR TITLE
feat: wallet can register contract keys

### DIFF
--- a/boxes/boxes/vanilla/app/embedded-wallet.ts
+++ b/boxes/boxes/vanilla/app/embedded-wallet.ts
@@ -169,10 +169,10 @@ export class EmbeddedWallet extends BaseWallet {
       .getAccountContract()
       .getContractArtifact();
 
-    await this.pxe.registerContract({ artifact, instance });
-    await this.pxe.registerAccount(
-      accountManager.getSecretKey(),
-      (await accountManager.getCompleteAddress()).partialAddress
+    await this.pxe.registerContract(
+      instance,
+      artifact,
+      accountManager.getSecretKey()
     );
   }
 

--- a/playground/src/wallet/embedded_wallet.ts
+++ b/playground/src/wallet/embedded_wallet.ts
@@ -136,11 +136,7 @@ export class EmbeddedWallet extends BaseWallet {
     const instance = await accountManager.getInstance();
     const artifact = await accountManager.getAccountContract().getContractArtifact();
 
-    await this.pxe.registerContract({ artifact, instance });
-    await this.pxe.registerAccount(
-      accountManager.getSecretKey(),
-      (await accountManager.getCompleteAddress()).partialAddress,
-    );
+    await this.registerContract(instance, artifact, accountManager.getSecretKey());
 
     return accountManager;
   }

--- a/yarn-project/aztec.js/src/contract/deploy_method.ts
+++ b/yarn-project/aztec.js/src/contract/deploy_method.ts
@@ -126,12 +126,6 @@ export class DeployMethod<TContract extends ContractBase = Contract> extends Bas
   public async request(options?: RequestDeployOptions): Promise<ExecutionPayload> {
     const publication = await this.getPublicationExecutionPayload(options);
 
-    // TODO: Should we add the contracts to the DB here, or once the tx has been sent or mined?
-    // Note that we need to run this registerContract here so it's available when computeFeeOptionsFromEstimatedGas
-    // runs, since it needs the contract to have been registered in order to estimate gas for its initialization,
-    // in case the initializer is public. This hints at the need of having "transient" contracts scoped to a
-    // simulation, so we can run the simulation with a set of contracts, but only "commit" them to the wallet
-    // once this tx has gone through.
     await this.wallet.registerContract(await this.getInstance(options), this.artifact);
 
     const initialization = await this.getInitializationExecutionPayload(options);

--- a/yarn-project/aztec.js/src/wallet/base_wallet.ts
+++ b/yarn-project/aztec.js/src/wallet/base_wallet.ts
@@ -15,6 +15,7 @@ import {
   type ContractInstanceWithAddress,
   type ContractInstantiationData,
   type ContractMetadata,
+  computePartialAddress,
   getContractClassFromArtifact,
   getContractInstanceFromInstantiationParams,
 } from '@aztec/stdlib/contract';
@@ -192,6 +193,7 @@ export abstract class BaseWallet implements Wallet {
   async registerContract(
     instanceData: AztecAddress | ContractInstanceWithAddress | ContractInstantiationData | ContractInstanceAndArtifact,
     artifact?: ContractArtifact,
+    secretKey?: Fr,
   ): Promise<ContractInstanceWithAddress> {
     /** Determines if the provided instance data is already a contract instance with an address. */
     function isInstanceWithAddress(instanceData: any): instanceData is ContractInstanceWithAddress {
@@ -223,7 +225,7 @@ export abstract class BaseWallet implements Wallet {
       await this.pxe.registerContract({ artifact, instance });
     } else {
       if (!artifact) {
-        throw new Error(`Contract artifact must be provided when registering a contract using address`);
+        throw new Error(`Contract artifact must be provided when registering a contract using an address`);
       }
       const { contractInstance: maybeContractInstance } = await this.pxe.getContractMetadata(instanceData);
       if (!maybeContractInstance) {
@@ -236,6 +238,9 @@ export abstract class BaseWallet implements Wallet {
         await this.pxe.updateContract(instance.address, artifact);
         instance.currentContractClassId = thisContractClass.id;
       }
+    }
+    if (secretKey) {
+      await this.pxe.registerAccount(secretKey, await computePartialAddress(instance));
     }
     return instance;
   }

--- a/yarn-project/aztec.js/src/wallet/wallet.ts
+++ b/yarn-project/aztec.js/src/wallet/wallet.ts
@@ -134,6 +134,7 @@ export type Wallet = {
   registerContract(
     instanceData: AztecAddress | ContractInstanceWithAddress | ContractInstantiationData | ContractInstanceAndArtifact,
     artifact?: ContractArtifact,
+    secretKey?: Fr,
   ): Promise<ContractInstanceWithAddress>;
   simulateTx(exec: ExecutionPayload, opts: SimulateOptions): Promise<TxSimulationResult>;
   simulateUtility(
@@ -275,7 +276,7 @@ export const WalletSchema: ApiSchemaFor<Wallet> = {
   // @ts-expect-error Zod doesn't like optionals
   registerContract: z
     .function()
-    .args(InstanceDataSchema, optional(ContractArtifactSchema))
+    .args(InstanceDataSchema, optional(ContractArtifactSchema), optional(schemas.Fr))
     .returns(ContractInstanceWithAddressSchema),
   simulateTx: z.function().args(ExecutionPayloadSchema, SimulateOptionsSchema).returns(TxSimulationResult.schema),
   simulateUtility: z

--- a/yarn-project/cli-wallet/src/utils/wallet.ts
+++ b/yarn-project/cli-wallet/src/utils/wallet.ts
@@ -113,8 +113,7 @@ export class CLIWallet extends BaseWallet {
     const instance = accountManager.getInstance();
     const artifact = await contract.getContractArtifact();
 
-    await this.pxe.registerContract({ artifact, instance });
-    await this.pxe.registerAccount(secret, (await accountManager.getCompleteAddress()).partialAddress);
+    await this.registerContract(instance, artifact, secret);
     this.accountCache.set(accountManager.address.toString(), await accountManager.getAccount());
     return accountManager;
   }

--- a/yarn-project/end-to-end/src/e2e_crowdfunding_and_claim.test.ts
+++ b/yarn-project/end-to-end/src/e2e_crowdfunding_and_claim.test.ts
@@ -4,7 +4,6 @@ import { ClaimContract } from '@aztec/noir-contracts.js/Claim';
 import { CrowdfundingContract } from '@aztec/noir-contracts.js/Crowdfunding';
 import { TokenContract } from '@aztec/noir-contracts.js/Token';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
-import { computePartialAddress } from '@aztec/stdlib/contract';
 import type { TestWallet } from '@aztec/test-wallet/server';
 
 import { jest } from '@jest/globals';
@@ -96,10 +95,7 @@ describe('e2e_crowdfunding_and_claim', () => {
       deadline,
     );
     const crowdfundingInstance = await crowdfundingDeployment.getInstance();
-    await wallet.registerKeysForEscrowContract(
-      crowdfundingSecretKey,
-      await computePartialAddress(crowdfundingInstance),
-    );
+    await wallet.registerContract(crowdfundingInstance, CrowdfundingContract.artifact, crowdfundingSecretKey);
     crowdfundingContract = await crowdfundingDeployment.send({ from: operatorAddress }).deployed();
     logger.info(`Crowdfunding contract deployed at ${crowdfundingContract.address}`);
 

--- a/yarn-project/end-to-end/src/e2e_escrow_contract.test.ts
+++ b/yarn-project/end-to-end/src/e2e_escrow_contract.test.ts
@@ -1,7 +1,6 @@
 import { type AztecAddress, BatchCall, Fr, type Logger, deriveKeys } from '@aztec/aztec.js';
 import { EscrowContract } from '@aztec/noir-contracts.js/Escrow';
 import { TokenContract } from '@aztec/noir-contracts.js/Token';
-import { computePartialAddress } from '@aztec/stdlib/contract';
 import type { PublicKeys } from '@aztec/stdlib/keys';
 import type { TestWallet } from '@aztec/test-wallet/server';
 
@@ -37,7 +36,7 @@ describe('e2e_escrow_contract', () => {
     escrowPublicKeys = (await deriveKeys(escrowSecretKey)).publicKeys;
     const escrowDeployment = EscrowContract.deployWithPublicKeys(escrowPublicKeys, wallet, owner);
     const escrowInstance = await escrowDeployment.getInstance();
-    await wallet.registerKeysForEscrowContract(escrowSecretKey, await computePartialAddress(escrowInstance));
+    await wallet.registerContract(escrowInstance, EscrowContract.artifact, escrowSecretKey);
     escrowContract = await escrowDeployment.send({ from: owner }).deployed();
     logger.info(`Escrow contract deployed at ${escrowContract.address}`);
 

--- a/yarn-project/test-wallet/src/wallet/test_wallet.ts
+++ b/yarn-project/test-wallet/src/wallet/test_wallet.ts
@@ -19,7 +19,7 @@ import { ExecutionPayload, mergeExecutionPayloads } from '@aztec/entrypoints/pay
 import { Fq, Fr, GrumpkinScalar } from '@aztec/foundation/fields';
 import { AuthWitness } from '@aztec/stdlib/auth-witness';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
-import type { CompleteAddress, ContractInstanceWithAddress, PartialAddress } from '@aztec/stdlib/contract';
+import type { ContractInstanceWithAddress } from '@aztec/stdlib/contract';
 import type { NotesFilter, UniqueNote } from '@aztec/stdlib/note';
 import type { TxSimulationResult } from '@aztec/stdlib/tx';
 
@@ -121,8 +121,7 @@ export abstract class BaseTestWallet extends BaseWallet {
     const instance = accountManager.getInstance();
     const artifact = await contract.getContractArtifact();
 
-    await this.pxe.registerContract({ artifact, instance });
-    await this.pxe.registerAccount(secret, (await accountManager.getCompleteAddress()).partialAddress);
+    await this.registerContract(instance, artifact, secret);
 
     this.accounts.set(accountManager.address.toString(), await accountManager.getAccount());
 
@@ -221,20 +220,6 @@ export abstract class BaseTestWallet extends BaseWallet {
       };
       return this.pxe.simulateTx(txRequest, true /* simulatePublic */, true, true, { contracts: contractOverrides });
     }
-  }
-
-  /**
-   * Adds keys to PXE for an escrow contract.
-   * @param secretKey - Secret key used to derive public keys of the escrow contract.
-   * @param partialAddress - Partial address of the escrow contract.
-   * @deprecated This will be replaced soon with updated registerContract method that will accept secretKey and
-   * partialAddress on the input.
-   *
-   * TODO(#17324): Allow passing on the input secretKey and partialAddress to registerContract and drop this method.
-   * For context this is typically used when registering escrow contracts.
-   */
-  registerKeysForEscrowContract(secretKey: Fr, partialAddress: PartialAddress): Promise<CompleteAddress> {
-    return this.pxe.registerAccount(secretKey, partialAddress);
   }
 
   /**


### PR DESCRIPTION
Interim solution before the cleanup of `registerContract` so externals can be unblocked