### PR TITLE
feat: `ExecutionTaggingIndexCache`

### DIFF
--- a/noir-projects/noir-contracts/contracts/test/test_log_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/test_log_contract/src/main.nr
@@ -6,6 +6,7 @@ pub contract TestLog {
         event::event_emission::{emit_event_in_private, emit_event_in_public},
         macros::{events::event, functions::{private, public}, storage::storage},
         messages::message_delivery::MessageDelivery,
+        oracle::random::random,
         protocol_types::{address::AztecAddress, traits::FromField},
         state_vars::PrivateSet,
     };
@@ -74,5 +75,37 @@ pub contract TestLog {
             },
             &mut context,
         );
+    }
+
+    #[private]
+    fn emit_encrypted_events_nested(other: AztecAddress, num_nested_calls: u32) {
+        // Safety: We use the following just as an arbitrary test value
+        let random_value_0 = unsafe { random() };
+        // Safety: We use the following just as an arbitrary test value
+        let random_value_1 = unsafe { random() };
+        // Safety: We use the following just as an arbitrary test value
+        let random_value_2 = unsafe { random() };
+        // Safety: We use the following just as an arbitrary test value
+        let random_value_3 = unsafe { random() };
+
+        emit_event_in_private(
+            ExampleEvent0 { value0: random_value_0, value1: random_value_1 },
+            &mut context,
+            other,
+            MessageDelivery.UNCONSTRAINED_ONCHAIN,
+        );
+
+        emit_event_in_private(
+            ExampleEvent0 { value0: random_value_2, value1: random_value_3 },
+            &mut context,
+            other,
+            MessageDelivery.UNCONSTRAINED_ONCHAIN,
+        );
+
+        if num_nested_calls > 0 {
+            TestLog::at(context.this_address())
+                .emit_encrypted_events_nested(other, num_nested_calls - 1)
+                .call(&mut context);
+        }
     }
 }

--- a/yarn-project/pxe/src/contract_function_simulator/contract_function_simulator.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/contract_function_simulator.ts
@@ -65,6 +65,7 @@ import {
 import type { ContractDataProvider } from '../storage/index.js';
 import type { ExecutionDataProvider } from './execution_data_provider.js';
 import { ExecutionNoteCache } from './execution_note_cache.js';
+import { ExecutionTaggingIndexCache } from './execution_tagging_index_cache.js';
 import { HashedValuesCache } from './hashed_values_cache.js';
 import { Oracle } from './oracle/oracle.js';
 import { executePrivateFunction, verifyCurrentClassId } from './oracle/private_execution.js';
@@ -133,6 +134,7 @@ export class ContractFunctionSimulator {
 
     const txRequestHash = await request.toTxRequest().hash();
     const noteCache = new ExecutionNoteCache(txRequestHash);
+    const taggingIndexCache = new ExecutionTaggingIndexCache();
 
     const privateExecutionOracle = new PrivateExecutionOracle(
       request.firstCallArgsHash,
@@ -143,6 +145,7 @@ export class ContractFunctionSimulator {
       request.capsules,
       HashedValuesCache.create(request.argsOfCalls),
       noteCache,
+      taggingIndexCache,
       this.executionDataProvider,
       0, // totalPublicArgsCount
       startSideEffectCounter,

--- a/yarn-project/pxe/src/contract_function_simulator/execution_data_provider.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/execution_data_provider.ts
@@ -10,7 +10,6 @@ import type { NoteStatus } from '@aztec/stdlib/note';
 import { type MerkleTreeId, type NullifierMembershipWitness, PublicDataWitness } from '@aztec/stdlib/trees';
 import type { BlockHeader, NodeStats } from '@aztec/stdlib/tx';
 
-import type { Tag } from '../tagging/tag.js';
 import type { NoteData } from './oracle/interfaces.js';
 import type { MessageLoadOracleInputs } from './oracle/message_load_oracle_inputs.js';
 
@@ -240,12 +239,11 @@ export interface ExecutionDataProvider {
   syncTaggedLogsAsSender(secret: DirectionalAppTaggingSecret, contractAddress: AztecAddress): Promise<void>;
 
   /**
-   * Returns the next app tag for a given directional app tagging secret.
-   * @param secret - The secret that's unique for (sender, recipient, contract) tuple while
-   * direction of sender -> recipient matters.
-   * @returns The computed tag.
+   * Returns the next index to be used to compute a tag when sending a log.
+   * @param secret - The directional app tagging secret.
+   * @returns The next index to be used to compute a tag for the given directional app tagging secret.
    */
-  getNextAppTagAsSender(secret: DirectionalAppTaggingSecret): Promise<Tag>;
+  getNextIndexAsSender(secret: DirectionalAppTaggingSecret): Promise<number>;
 
   /**
    * Synchronizes the private logs tagged with scoped addresses and all the senders in the address book. Stores the found

--- a/yarn-project/pxe/src/contract_function_simulator/execution_tagging_index_cache.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/execution_tagging_index_cache.ts
@@ -1,0 +1,29 @@
+import { DirectionalAppTaggingSecret, type IndexedTaggingSecret } from '@aztec/stdlib/logs';
+
+/**
+ * A map that stores the tagging index for a given directional app tagging secret.
+ * Note: The directional app tagging secret is unique for a (sender, recipient, contract) tuple while the direction
+ * of sender -> recipient matters.
+ */
+export class ExecutionTaggingIndexCache {
+  private taggingIndexMap: Map<string, number> = new Map();
+
+  public getTaggingIndex(secret: DirectionalAppTaggingSecret): number | undefined {
+    return this.taggingIndexMap.get(secret.toString());
+  }
+
+  public setTaggingIndex(secret: DirectionalAppTaggingSecret, index: number) {
+    const currentValue = this.taggingIndexMap.get(secret.toString());
+    if (currentValue !== undefined && currentValue !== index - 1) {
+      throw new Error(`Invalid tagging index update. Current value: ${currentValue}, new value: ${index}`);
+    }
+    this.taggingIndexMap.set(secret.toString(), index);
+  }
+
+  public getIndexedTaggingSecrets(): IndexedTaggingSecret[] {
+    return Array.from(this.taggingIndexMap.entries()).map(([secret, index]) => ({
+      secret: DirectionalAppTaggingSecret.fromString(secret),
+      index,
+    }));
+  }
+}

--- a/yarn-project/pxe/src/contract_function_simulator/index.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/index.ts
@@ -1,4 +1,5 @@
 export { ExecutionNoteCache } from './execution_note_cache.js';
+export { ExecutionTaggingIndexCache } from './execution_tagging_index_cache.js';
 export { HashedValuesCache } from './hashed_values_cache.js';
 export { pickNotes } from './pick_notes.js';
 export type { NoteData, IMiscOracle, IUtilityExecutionOracle, IPrivateExecutionOracle } from './oracle/interfaces.js';

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution.test.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution.test.ts
@@ -65,7 +65,6 @@ import { jest } from '@jest/globals';
 import { Matcher, type MatcherCreator, type MockProxy, mock } from 'jest-mock-extended';
 import { toFunctionSelector } from 'viem';
 
-import { Tag } from '../../tagging/tag.js';
 import { ContractFunctionSimulator } from '../contract_function_simulator.js';
 import type { ExecutionDataProvider } from '../execution_data_provider.js';
 import { MessageLoadOracleInputs } from './message_load_oracle_inputs.js';
@@ -303,8 +302,8 @@ describe('Private Execution test suite', () => {
       throw new Error(`Unknown address: ${address}. Recipient: ${recipient}, Owner: ${owner}`);
     });
 
-    executionDataProvider.getNextAppTagAsSender.mockImplementation((_secret: DirectionalAppTaggingSecret) => {
-      return Promise.resolve(Tag.compute({ secret: _secret, index: 0 }));
+    executionDataProvider.getNextIndexAsSender.mockImplementation((_secret: DirectionalAppTaggingSecret) => {
+      return Promise.resolve(0);
     });
     executionDataProvider.getFunctionArtifact.mockImplementation(async (address, selector) => {
       const contract = contracts[address.toString()];
@@ -331,8 +330,12 @@ describe('Private Execution test suite', () => {
     });
 
     executionDataProvider.syncTaggedLogs.mockImplementation((_, __) => Promise.resolve());
-    executionDataProvider.calculateDirectionalAppTaggingSecret.mockResolvedValue(
-      DirectionalAppTaggingSecret.fromString('0x1'),
+    // Provide tagging-related mocks expected by private log emission
+    executionDataProvider.calculateDirectionalAppTaggingSecret.mockImplementation((_contract, _sender, _recipient) => {
+      return Promise.resolve(DirectionalAppTaggingSecret.fromString('0x1'));
+    });
+    executionDataProvider.syncTaggedLogsAsSender.mockImplementation((_directionalAppTaggingSecret, _contractAddress) =>
+      Promise.resolve(),
     );
     executionDataProvider.loadCapsule.mockImplementation((_, __) => Promise.resolve(null));
 

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution.ts
@@ -88,6 +88,7 @@ export async function executePrivateFunction(
   const newNotes = privateExecutionOracle.getNewNotes();
   const noteHashNullifierCounterMap = privateExecutionOracle.getNoteHashNullifierCounterMap();
   const offchainEffects = privateExecutionOracle.getOffchainEffects();
+  const indexedTaggingSecrets = privateExecutionOracle.getIndexedTaggingSecrets();
   const nestedExecutionResults = privateExecutionOracle.getNestedExecutionResults();
 
   let timerSubtractionList = nestedExecutionResults;
@@ -111,6 +112,7 @@ export async function executePrivateFunction(
     noteHashNullifierCounterMap,
     rawReturnValues,
     offchainEffects,
+    indexedTaggingSecrets,
     nestedExecutionResults,
     contractClassLogs,
     {

--- a/yarn-project/pxe/src/contract_function_simulator/pxe_oracle_interface.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/pxe_oracle_interface.ts
@@ -269,32 +269,8 @@ export class PXEOracleInterface implements ExecutionDataProvider {
     return this.taggingDataProvider.getSenderAddresses();
   }
 
-  /**
-   * Returns the next app tag for a given sender and recipient pair.
-   * @param contractAddress - The contract address emitting the log.
-   * @param sender - The address sending the note
-   * @param recipient - The address receiving the note
-   * @returns The computed tag.
-   * TODO(benesjan): In a follow-up PR this will only return the index and that's it.
-   */
-  public async getNextAppTagAsSender(secret: DirectionalAppTaggingSecret): Promise<Tag> {
-    const index = await this.taggingDataProvider.getNextIndexAsSender(secret);
-
-    // TODO(benesjan): This will be reworked in a follow-up PR where we will store the new indexes in the db once
-    // the execution finishes (then we dump the contents of the ExecutionTaggingIndexCache into the db)
-    // Increment the index for next time
-    // const contractName = await this.contractDataProvider.getDebugContractName(contractAddress);
-    // this.log.debug(`Incrementing app tagging secret at ${contractName}(${contractAddress})`, {
-    //   directionalAppTaggingSecret,
-    //   sender,
-    //   recipient,
-    //   contractName,
-    //   contractAddress,
-    // });
-    await this.taggingDataProvider.setNextIndexesAsSender([{ secret, index: index + 1 }]);
-
-    // Compute and return the tag using the current index
-    return Tag.compute({ secret, index });
+  public getNextIndexAsSender(secret: DirectionalAppTaggingSecret): Promise<number> {
+    return this.taggingDataProvider.getNextIndexAsSender(secret);
   }
 
   public async calculateDirectionalAppTaggingSecret(

--- a/yarn-project/pxe/src/private_kernel/private_kernel_execution_prover.test.ts
+++ b/yarn-project/pxe/src/private_kernel/private_kernel_execution_prover.test.ts
@@ -74,6 +74,7 @@ describe('Private Kernel Sequencer', () => {
       new Map(),
       [],
       [],
+      [],
       (dependencies[fnName] || []).map(name => createCallExecutionResult(name)),
       [],
     );

--- a/yarn-project/stdlib/src/logs/directional_app_tagging_secret.ts
+++ b/yarn-project/stdlib/src/logs/directional_app_tagging_secret.ts
@@ -1,6 +1,8 @@
 import { Grumpkin, poseidon2Hash } from '@aztec/foundation/crypto';
 import { type Fq, Fr, type Point } from '@aztec/foundation/fields';
 
+import { z } from 'zod';
+
 import type { AztecAddress } from '../aztec-address/index.js';
 import type { CompleteAddress } from '../contract/complete_address.js';
 import { computeAddressSecret, computePreaddress } from '../keys/derivation.js';
@@ -70,3 +72,7 @@ async function computeSharedTaggingSecret(
   // leads to a positive y-coordinate, which is the only valid address point
   return curve.mul(externalAddressPoint, await computeAddressSecret(knownPreaddress, localIvsk));
 }
+
+export const DirectionalAppTaggingSecretSchema = z.object({
+  value: Fr.schema,
+});

--- a/yarn-project/stdlib/src/logs/indexed_tagging_secret.ts
+++ b/yarn-project/stdlib/src/logs/indexed_tagging_secret.ts
@@ -1,4 +1,11 @@
-import type { DirectionalAppTaggingSecret } from './directional_app_tagging_secret.js';
+import { schemas } from '@aztec/foundation/schemas';
+
+import { z } from 'zod';
+
+import {
+  type DirectionalAppTaggingSecret,
+  DirectionalAppTaggingSecretSchema,
+} from './directional_app_tagging_secret.js';
 
 /**
  * Represents a preimage of a private log tag (see `Tag` in `pxe/src/tagging`).
@@ -11,3 +18,8 @@ export type IndexedTaggingSecret = {
   secret: DirectionalAppTaggingSecret;
   index: number;
 };
+
+export const IndexedTaggingSecretSchema = z.object({
+  secret: DirectionalAppTaggingSecretSchema,
+  index: schemas.Integer,
+});

--- a/yarn-project/stdlib/src/tests/mocks.ts
+++ b/yarn-project/stdlib/src/tests/mocks.ts
@@ -184,6 +184,7 @@ const emptyPrivateCallExecutionResult = () =>
     [],
     [],
     [],
+    [],
   );
 
 const emptyPrivateExecutionResult = () => new PrivateExecutionResult(emptyPrivateCallExecutionResult(), Fr.zero(), []);

--- a/yarn-project/stdlib/src/tx/private_execution_result.test.ts
+++ b/yarn-project/stdlib/src/tx/private_execution_result.test.ts
@@ -23,6 +23,7 @@ function emptyCallExecutionResult(): PrivateCallExecutionResult {
     [],
     [],
     [],
+    [],
   );
 }
 

--- a/yarn-project/stdlib/src/tx/private_execution_result.ts
+++ b/yarn-project/stdlib/src/tx/private_execution_result.ts
@@ -10,6 +10,7 @@ import { PrivateCircuitPublicInputs } from '../kernel/private_circuit_public_inp
 import type { IsEmpty } from '../kernel/utils/interfaces.js';
 import { sortByCounter } from '../kernel/utils/order_and_comparison.js';
 import { ContractClassLog, ContractClassLogFields } from '../logs/contract_class_log.js';
+import { type IndexedTaggingSecret, IndexedTaggingSecretSchema } from '../logs/indexed_tagging_secret.js';
 import { Note } from '../note/note.js';
 import { type ZodFor, mapSchema, schemas } from '../schemas/index.js';
 import type { UInt32 } from '../types/index.js';
@@ -135,6 +136,8 @@ export class PrivateCallExecutionResult {
     public returnValues: Fr[],
     /** The offchain effects emitted during execution of this function call via the `emit_offchain_effect` oracle. */
     public offchainEffects: { data: Fr[] }[],
+    /** The tagging indexes incremented by this execution along with the directional app tagging secrets. */
+    public indexedTaggingSecrets: IndexedTaggingSecret[],
     /** The nested executions. */
     public nestedExecutionResults: PrivateCallExecutionResult[],
     /**
@@ -158,6 +161,7 @@ export class PrivateCallExecutionResult {
         noteHashNullifierCounterMap: mapSchema(z.coerce.number(), z.number()),
         returnValues: z.array(schemas.Fr),
         offchainEffects: z.array(z.object({ data: z.array(schemas.Fr) })),
+        indexedTaggingSecrets: z.array(IndexedTaggingSecretSchema),
         nestedExecutionResults: z.array(z.lazy(() => PrivateCallExecutionResult.schema)),
         contractClassLogs: z.array(CountedContractClassLog.schema),
       })
@@ -175,6 +179,7 @@ export class PrivateCallExecutionResult {
       fields.noteHashNullifierCounterMap,
       fields.returnValues,
       fields.offchainEffects,
+      fields.indexedTaggingSecrets,
       fields.nestedExecutionResults,
       fields.contractClassLogs,
     );
@@ -195,6 +200,7 @@ export class PrivateCallExecutionResult {
           data: [Fr.random()],
         },
       ],
+      [],
       await timesParallel(nested, () => PrivateCallExecutionResult.random(0)),
       [new CountedContractClassLog(await ContractClassLog.random(), randomInt(10))],
     );

--- a/yarn-project/txe/src/oracle/txe_oracle_top_level_context.ts
+++ b/yarn-project/txe/src/oracle/txe_oracle_top_level_context.ts
@@ -19,6 +19,7 @@ import {
 } from '@aztec/pxe/server';
 import {
   ExecutionNoteCache,
+  ExecutionTaggingIndexCache,
   HashedValuesCache,
   type IMiscOracle,
   Oracle,
@@ -292,6 +293,7 @@ export class TXEOracleTopLevelContext implements IMiscOracle, ITxeExecutionOracl
 
     const txRequestHash = getSingleTxBlockRequestHash(blockNumber);
     const noteCache = new ExecutionNoteCache(txRequestHash);
+    const taggingIndexCache = new ExecutionTaggingIndexCache();
 
     const simulator = new WASMSimulator();
 
@@ -307,6 +309,7 @@ export class TXEOracleTopLevelContext implements IMiscOracle, ITxeExecutionOracl
       [],
       HashedValuesCache.create([new HashedValues(args, argsHash)]),
       noteCache,
+      taggingIndexCache,
       this.pxeOracleInterface,
       0,
       1,


### PR DESCRIPTION
Fixes https://github.com/AztecProtocol/aztec-packages/issues/15753

In this PR I implement an ExecutionTaggingIndexCache which stores the used indexes during an execution and at the end we store them in the database. By storing that info once execution is done we'll be able to have indexes associated with a transaction hash. This is a necessary step towards improving of unconstrained tagging as described in [this post](https://forum.aztec.network/t/on-note-discovery-and-index-coordination/7165).

Given that once this PR is merged we will store the indexes in the database only for executions and not for simulations this PR should fix https://github.com/AztecProtocol/aztec-packages/issues/15753.