### PR TITLE
fix: Link dwarf in fuzzing builds too 

### DIFF
--- a/barretenberg/cpp/cmake/module.cmake
+++ b/barretenberg/cpp/cmake/module.cmake
@@ -200,10 +200,23 @@ function(barretenberg_module MODULE_NAME)
                 ${MODULE_LINK_NAME}
                 ${ARGN}
             )
+
+            if(ENABLE_STACKTRACES)
+                target_link_libraries(
+                    ${MODULE_NAME}_${FUZZER_NAME_STEM}_fuzzer
+                    PUBLIC
+                    Backward::Interface
+                )
+                target_link_options(
+                    ${MODULE_NAME}_${FUZZER_NAME_STEM}_fuzzer
+                    PRIVATE
+                    -ldw -lelf
+                )
+            endif()
         endforeach()
     endif()
-    file(GLOB_RECURSE BENCH_SOURCE_FILES *.bench.cpp)
 
+    file(GLOB_RECURSE BENCH_SOURCE_FILES *.bench.cpp)
     if(BENCH_SOURCE_FILES AND NOT FUZZING)
         foreach(BENCHMARK_SOURCE ${BENCH_SOURCE_FILES})
             get_filename_component(BENCHMARK_NAME ${BENCHMARK_SOURCE} NAME_WE) # extract name without extension

--- a/container-builds/fuzzing-container/src/Dockerfile
+++ b/container-builds/fuzzing-container/src/Dockerfile
@@ -1,7 +1,20 @@
 FROM ubuntu:noble AS base-build
 
 RUN apt-get update && \
-    apt-get install -y build-essential python3 wget unzip git cmake clang ninja-build curl && \
+    apt-get install -y \
+        build-essential \
+        python3 \
+        wget \
+        curl \
+        unzip \
+        git \
+        cmake \
+        clang \
+        ninja-build \
+        libdw-dev \
+        binutils-dev \
+        libelf-dev \
+        libdwarf-dev && \
     apt-get -y autoremove && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*


### PR DESCRIPTION
This pr adds a link to dwarf library in fuzzing setup whenever it is present on a system

Also added the required packages for fuzzing container build