### PR TITLE
fix: make aztec-nargo and aztec-postprocess-contract commands respect VERSION

### DIFF
--- a/aztec-up/bin/aztec-nargo
+++ b/aztec-up/bin/aztec-nargo
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+export AZTEC_PATH="${AZTEC_PATH:-$HOME/.aztec}"
+export VERSION="${VERSION:-$(cat "$AZTEC_PATH/default_version")}"
+export DOCKER_REPO="${DOCKER_REPO:-"aztecprotocol/aztec"}"
+
 if [[ $PWD != ${HOME}* ]]; then
   >&2 echo "Due to how we containerize our applications, we require your working directory to be somewhere within $HOME."
   exit 1
@@ -16,7 +20,7 @@ if [ "${1:-}" == "lsp" ]; then
     -v $HOME:$HOME \
     -e HOME=$HOME \
     --entrypoint=/usr/src/noir/noir-repo/target/release/nargo \
-    aztecprotocol/aztec lsp
+    $DOCKER_REPO:$VERSION lsp
   exit
 fi
 
@@ -36,4 +40,4 @@ docker run ${args:-} \
   -e HOME=$HOME \
   --workdir="$PWD" \
   --entrypoint=/usr/src/noir/noir-repo/target/release/nargo \
-  aztecprotocol/aztec "$@"
+  $DOCKER_REPO:$VERSION "$@"

--- a/aztec-up/bin/aztec-postprocess-contract
+++ b/aztec-up/bin/aztec-postprocess-contract
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+export AZTEC_PATH="${AZTEC_PATH:-$HOME/.aztec}"
+export VERSION="${VERSION:-$(cat "$AZTEC_PATH/default_version")}"
+export DOCKER_REPO="${DOCKER_REPO:-"aztecprotocol/aztec"}"
+
 if [[ $PWD != ${HOME}* ]]; then
   >&2 echo "Due to how we containerize our applications, we require your working directory to be somewhere within $HOME."
   exit 1
@@ -22,4 +26,4 @@ docker run ${args:-} \
   -e HOME=$HOME \
   --workdir="$PWD" \
   --entrypoint=/usr/src/aztec-postprocess-contract/transpile_contract_and_gen_vks.sh \
-  aztecprotocol/aztec "$@"
+  $DOCKER_REPO:$VERSION "$@"


### PR DESCRIPTION
These commands were previous defaulting to use the "latest" tag. this updates them to use the version specified in ~/.aztec/default_version, like it is done in the "aztec' command
