### PR TITLE
feat(no-docker-devex/4): Link AVM transpiler as static library

### DIFF
--- a/avm-transpiler/Cargo.lock
+++ b/avm-transpiler/Cargo.lock
@@ -345,6 +345,7 @@ dependencies = [
  "base64 0.21.7",
  "env_logger",
  "fxhash",
+ "libc",
  "log",
  "noirc_abi",
  "noirc_errors",

--- a/avm-transpiler/Cargo.toml
+++ b/avm-transpiler/Cargo.toml
@@ -5,6 +5,10 @@ authors = ["The Aztec Team <hello@aztecprotocol.com>"]
 edition = "2024"
 license = "MIT OR Apache-2.0"
 
+[lib]
+name = "avm_transpiler"
+crate-type = ["staticlib", "rlib"]
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -14,6 +18,9 @@ noirc_errors = { path = "../noir/noir-repo/compiler/noirc_errors" }
 noirc_abi = { path = "../noir/noir-repo/tooling/noirc_abi" }
 noirc_evaluator = { path = "../noir/noir-repo/compiler/noirc_evaluator", features = ["bn254"] }
 noirc_frontend = { path = "../noir/noir-repo/compiler/noirc_frontend", features = ["test_utils"] }
+
+# FFI
+libc = "0.2"
 
 # external
 base64 = "0.21"

--- a/avm-transpiler/avm_transpiler.h
+++ b/avm-transpiler/avm_transpiler.h
@@ -1,0 +1,70 @@
+#ifndef AVM_TRANSPILER_H
+#define AVM_TRANSPILER_H
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Result structure for transpilation operations
+ *
+ * Fields:
+ * - success: 1 if successful, 0 if failed
+ * - data: Pointer to output data (JSON string as bytes)
+ * - length: Length of output data in bytes
+ * - error_message: Error message if failed (null-terminated string)
+ */
+typedef struct {
+    int success;
+    unsigned char* data;
+    size_t length;
+    char* error_message;
+} TranspileResult;
+
+/**
+ * Transpiles an ACIR contract artifact file to AVM bytecode
+ *
+ * @param input_path Path to input ACIR contract artifact JSON file
+ * @param output_path Path to output transpiled contract artifact JSON file
+ * @return TranspileResult containing success status, output data, or error message
+ *
+ * The function reads the ACIR contract from input_path, transpiles it to AVM bytecode,
+ * and writes the result to output_path. The output data in the result contains
+ * the same JSON that was written to the file.
+ *
+ * Call avm_free_result() to free the returned result.
+ */
+TranspileResult avm_transpile_file(const char* input_path, const char* output_path);
+
+/**
+ * Transpiles raw ACIR contract artifact bytecode to AVM bytecode
+ *
+ * @param input_data Pointer to input ACIR contract artifact JSON data
+ * @param input_length Length of input data in bytes
+ * @return TranspileResult containing success status, output data, or error message
+ *
+ * The function takes raw JSON bytes representing an ACIR contract artifact,
+ * transpiles it to AVM bytecode, and returns the transpiled contract artifact
+ * as JSON bytes in the result.
+ *
+ * Call avm_free_result() to free the returned result.
+ */
+TranspileResult avm_transpile_bytecode(const unsigned char* input_data, size_t input_length);
+
+/**
+ * Frees memory allocated by a TranspileResult
+ *
+ * @param result Pointer to TranspileResult to free
+ *
+ * This function must be called to free the memory allocated by
+ * avm_transpile_file() and avm_transpile_bytecode().
+ */
+void avm_free_result(TranspileResult* result);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* AVM_TRANSPILER_H */

--- a/avm-transpiler/bootstrap.sh
+++ b/avm-transpiler/bootstrap.sh
@@ -15,11 +15,34 @@ function build {
   echo_header "avm-transpiler build"
   artifact=avm-transpiler-$hash.tar.gz
   if ! cache_download $artifact; then
-    denoise "cargo build --release --locked"
+    denoise "cargo build --release --locked --bin avm-transpiler"
+    denoise "cargo build --release --locked --lib"
     denoise "cargo fmt --check"
     denoise "cargo clippy"
-    cache_upload $artifact target/release/avm-transpiler
+    cache_upload $artifact target/release/avm-transpiler target/release/libavm_transpiler.a
   fi
+}
+
+function zig_build {
+  # We build libraries to be linked by barretenberg
+  # For now we only use the zig build for porting to macOS targets
+  if ! command -v cargo-zigbuild >/dev/null 2>&1; then
+    cargo install --locked cargo-zigbuild
+  fi
+
+  targets=(
+    x86_64-apple-darwin
+    aarch64-apple-darwin
+  )
+
+  for target in "${targets[@]}"; do
+    if ! rustup target list --installed | grep -q "^$target$"; then
+      echo "Installing Rust target: $target"
+      rustup target add "$target"
+    fi
+  done
+
+  parallel --tag --line-buffered cargo zigbuild --release --target {} --lib ::: "${targets[@]}"
 }
 
 case "$cmd" in
@@ -28,6 +51,10 @@ case "$cmd" in
     ;;
   ""|"fast"|"full"|"ci")
     build
+    ;;
+  "release")
+    # Release builds use zig for cross-compilation to all target platforms
+    zig_build
     ;;
   "test")
     echo "No tests."

--- a/avm-transpiler/src/lib.rs
+++ b/avm-transpiler/src/lib.rs
@@ -1,0 +1,219 @@
+#![warn(clippy::semicolon_if_nothing_returned)]
+#![cfg_attr(not(test), warn(unused_crate_dependencies, unused_extern_crates))]
+
+use env_logger as _;
+use noirc_frontend as _;
+
+use libc::{c_char, c_int, size_t};
+use std::ffi::{CStr, CString};
+use std::fs;
+use std::path::Path;
+use std::slice;
+
+mod bit_traits;
+mod instructions;
+mod opcodes;
+mod procedures;
+mod transpile;
+mod transpile_contract;
+mod utils;
+
+pub use transpile::*;
+pub use transpile_contract::*;
+
+#[repr(C)]
+pub struct TranspileResult {
+    pub success: c_int,
+    pub data: *mut u8,
+    pub length: size_t,
+    pub error_message: *mut c_char,
+}
+
+impl Default for TranspileResult {
+    fn default() -> Self {
+        Self {
+            success: 0,
+            data: std::ptr::null_mut(),
+            length: 0,
+            error_message: std::ptr::null_mut(),
+        }
+    }
+}
+
+fn create_error_result(error: &str) -> TranspileResult {
+    let error_cstr = match CString::new(error) {
+        Ok(cstr) => cstr,
+        Err(_) => CString::new("Error message contains null bytes").unwrap(),
+    };
+
+    TranspileResult {
+        success: 0,
+        data: std::ptr::null_mut(),
+        length: 0,
+        error_message: error_cstr.into_raw(),
+    }
+}
+
+fn create_success_result(data: Vec<u8>) -> TranspileResult {
+    let length = data.len();
+    let data_ptr = Box::into_raw(data.into_boxed_slice()) as *mut u8;
+
+    TranspileResult { success: 1, data: data_ptr, length, error_message: std::ptr::null_mut() }
+}
+
+/// Transpile an Aztec contract from a file.
+///
+/// # Safety
+///
+/// - `input_path` must be a valid pointer to a null-terminated C string
+/// - `output_path` must be a valid pointer to a null-terminated C string
+/// - Both pointers must remain valid for the duration of this call
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn avm_transpile_file(
+    input_path: *const c_char,
+    output_path: *const c_char,
+) -> TranspileResult {
+    if input_path.is_null() || output_path.is_null() {
+        return create_error_result("Input or output path is null");
+    }
+
+    // SAFETY: Caller ensures input_path is valid null-terminated C string
+    let input_path_str = match unsafe { CStr::from_ptr(input_path) }.to_str() {
+        Ok(s) => s,
+        Err(_) => return create_error_result("Invalid UTF-8 in input path"),
+    };
+
+    // SAFETY: Caller ensures output_path is valid null-terminated C string
+    let output_path_str = match unsafe { CStr::from_ptr(output_path) }.to_str() {
+        Ok(s) => s,
+        Err(_) => return create_error_result("Invalid UTF-8 in output path"),
+    };
+
+    let json_parse_error = format!(
+        "Unable to parse json for: {input_path_str}
+    This is probably a stale json file with a different wire format.
+    You might need to recompile the contract or delete the json file"
+    );
+
+    let contract_json = match fs::read_to_string(Path::new(input_path_str)) {
+        Ok(content) => content,
+        Err(e) => {
+            return create_error_result(&format!("Unable to read file {}: {}", input_path_str, e));
+        }
+    };
+
+    let raw_json_obj: serde_json::Value = match serde_json::from_str(&contract_json) {
+        Ok(obj) => obj,
+        Err(_) => return create_error_result(&json_parse_error),
+    };
+
+    if let Some(serde_json::Value::Bool(true)) = raw_json_obj.get("transpiled") {
+        return create_error_result("Contract already transpiled");
+    }
+
+    if Path::new(output_path_str).exists() {
+        if let Err(e) = std::fs::copy(
+            Path::new(output_path_str),
+            Path::new(&(output_path_str.to_string() + ".bak")),
+        ) {
+            return create_error_result(&format!(
+                "Unable to backup file {}: {}",
+                output_path_str, e
+            ));
+        }
+    }
+
+    let contract: CompiledAcirContractArtifact = match serde_json::from_str(&contract_json) {
+        Ok(contract) => contract,
+        Err(_) => return create_error_result(&json_parse_error),
+    };
+
+    let transpiled_contract = TranspiledContractArtifact::from(contract);
+    let transpiled_json = match serde_json::to_string(&transpiled_contract) {
+        Ok(json) => json,
+        Err(e) => return create_error_result(&format!("Unable to serialize json: {}", e)),
+    };
+
+    if let Err(e) = fs::write(output_path_str, &transpiled_json) {
+        return create_error_result(&format!("Unable to write file: {}", e));
+    }
+
+    create_success_result(transpiled_json.into_bytes())
+}
+
+/// Transpile an Aztec contract from bytecode.
+///
+/// # Safety
+///
+/// - `input_data` must be a valid pointer to a buffer of `input_length` bytes
+/// - The buffer must remain valid for the duration of this call
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn avm_transpile_bytecode(
+    input_data: *const u8,
+    input_length: size_t,
+) -> TranspileResult {
+    if input_data.is_null() {
+        return create_error_result("Input data is null");
+    }
+
+    // SAFETY: Caller ensures input_data points to valid memory of input_length bytes
+    let input_slice = unsafe { slice::from_raw_parts(input_data, input_length) };
+    let contract_json = match String::from_utf8(input_slice.to_vec()) {
+        Ok(json) => json,
+        Err(_) => return create_error_result("Input data is not valid UTF-8"),
+    };
+
+    let json_parse_error = "Unable to parse input json. This is probably a stale json file with a different wire format.";
+
+    let raw_json_obj: serde_json::Value = match serde_json::from_str(&contract_json) {
+        Ok(obj) => obj,
+        Err(_) => return create_error_result(json_parse_error),
+    };
+
+    if let Some(serde_json::Value::Bool(true)) = raw_json_obj.get("transpiled") {
+        return create_error_result("Contract already transpiled");
+    }
+
+    let contract: CompiledAcirContractArtifact = match serde_json::from_str(&contract_json) {
+        Ok(contract) => contract,
+        Err(_) => return create_error_result(json_parse_error),
+    };
+
+    let transpiled_contract = TranspiledContractArtifact::from(contract);
+    let transpiled_json = match serde_json::to_string(&transpiled_contract) {
+        Ok(json) => json,
+        Err(e) => return create_error_result(&format!("Unable to serialize json: {}", e)),
+    };
+
+    create_success_result(transpiled_json.into_bytes())
+}
+
+/// Free memory allocated by transpile functions.
+///
+/// # Safety
+///
+/// - `result` must be a valid pointer to a TranspileResult returned by a transpile function
+/// - The result must not be used after calling this function
+/// - This function must be called exactly once per result
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn avm_free_result(result: *mut TranspileResult) {
+    if result.is_null() {
+        return;
+    }
+
+    // SAFETY: Caller ensures result is valid
+    let result = unsafe { &mut *result };
+
+    if !result.data.is_null() && result.length > 0 {
+        // SAFETY: data and length were created by Box::into_raw in create_success_result
+        let _ = unsafe { Box::from_raw(slice::from_raw_parts_mut(result.data, result.length)) };
+        result.data = std::ptr::null_mut();
+        result.length = 0;
+    }
+
+    if !result.error_message.is_null() {
+        // SAFETY: error_message was created by CString::into_raw in create_error_result
+        let _ = unsafe { CString::from_raw(result.error_message) };
+        result.error_message = std::ptr::null_mut();
+    }
+}

--- a/avm-transpiler/src/main.rs
+++ b/avm-transpiler/src/main.rs
@@ -1,22 +1,26 @@
 #![warn(clippy::semicolon_if_nothing_returned)]
 #![cfg_attr(not(test), warn(unused_crate_dependencies, unused_extern_crates))]
 
-use noirc_frontend as _;
-
 use log::warn;
 use std::env;
 use std::fs;
 use std::path::Path;
 
-mod bit_traits;
-mod instructions;
-mod opcodes;
-mod procedures;
-mod transpile;
-mod transpile_contract;
-mod utils;
+// Use the library modules instead of redeclaring them
+use avm_transpiler::{CompiledAcirContractArtifact, TranspiledContractArtifact};
 
-use transpile_contract::{CompiledAcirContractArtifact, TranspiledContractArtifact};
+// Acknowledge dependencies used by the library but not directly by the binary
+use acvm as _;
+use base64 as _;
+use fxhash as _;
+use libc as _;
+use noirc_abi as _;
+use noirc_errors as _;
+use noirc_evaluator as _;
+use noirc_frontend as _;
+use once_cell as _;
+use regex as _;
+use serde as _;
 
 fn main() {
     env_logger::init();

--- a/barretenberg/cpp/cmake/avm-transpiler.cmake
+++ b/barretenberg/cpp/cmake/avm-transpiler.cmake
@@ -1,0 +1,25 @@
+# avm-transpiler static library configuration
+# AVM_TRANSPILER_LIB should be set by the CMake preset to point to the appropriate library
+
+if(NOT AVM_TRANSPILER_LIB)
+    message(FATAL_ERROR "AVM_TRANSPILER_LIB is not set. Set it in your CMake preset to the path of libavm_transpiler.a")
+endif()
+
+# Set the path to avm-transpiler relative to barretenberg
+set(AVM_TRANSPILER_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../avm-transpiler")
+set(AVM_TRANSPILER_INCLUDE "${AVM_TRANSPILER_DIR}")
+
+# Check if the library exists
+if(NOT EXISTS ${AVM_TRANSPILER_LIB})
+    message(FATAL_ERROR "avm-transpiler library not found at ${AVM_TRANSPILER_LIB}\nPlease run './bootstrap.sh' in ${AVM_TRANSPILER_DIR} to build libraries")
+endif()
+
+# Create imported library target
+add_library(avm_transpiler STATIC IMPORTED)
+set_target_properties(avm_transpiler PROPERTIES
+    IMPORTED_LOCATION ${AVM_TRANSPILER_LIB}
+    INTERFACE_INCLUDE_DIRECTORIES ${AVM_TRANSPILER_INCLUDE}
+)
+
+message(STATUS "avm-transpiler library: ${AVM_TRANSPILER_LIB}")
+message(STATUS "avm-transpiler include: ${AVM_TRANSPILER_INCLUDE}")


### PR DESCRIPTION
Link the AVM transpiler as a static library instead of dynamic linking.

Stack:
- #17471
- #17477
- #17473
- **#17474** ← you are here
- #17475
- #17476