### PR TITLE
feat(no-docker-devex/1): Add nested parallel_for support

### DIFF
--- a/barretenberg/cpp/src/barretenberg/bbapi/bbapi_ultra_honk.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/bbapi/bbapi_ultra_honk.test.cpp
@@ -23,7 +23,7 @@ class BBApiUltraHonkTest : public ::testing::Test {
     void TearDown() override
     {
         // Restore original concurrency
-        set_hardware_concurrency(original_concurrency);
+        set_parallel_for_concurrency(original_concurrency);
     }
 
     size_t original_concurrency;
@@ -73,7 +73,7 @@ TEST_F(BBApiUltraHonkTest, CircuitProve)
 TEST_F(BBApiUltraHonkTest, ParallelComputeVk)
 {
     // Set hardware concurrency to 8 to ensure we can run 8 VK computations in parallel
-    set_hardware_concurrency(8);
+    set_parallel_for_concurrency(8);
 
     constexpr size_t num_vks = 8;
 

--- a/barretenberg/cpp/src/barretenberg/bbapi/bbapi_ultra_honk.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/bbapi/bbapi_ultra_honk.test.cpp
@@ -1,16 +1,32 @@
 #include "barretenberg/bbapi/bbapi_ultra_honk.hpp"
 #include "barretenberg/client_ivc/acir_bincode_mocks.hpp"
+#include "barretenberg/common/thread.hpp"
 #include "barretenberg/dsl/acir_format/acir_format.hpp"
 #include "barretenberg/dsl/acir_format/acir_to_constraint_buf.hpp"
 #include "barretenberg/flavor/mega_flavor.hpp"
 #include "barretenberg/flavor/ultra_flavor.hpp"
 #include <gtest/gtest.h>
+#include <vector>
 
 namespace bb::bbapi {
 
 class BBApiUltraHonkTest : public ::testing::Test {
   protected:
     static void SetUpTestSuite() { bb::srs::init_file_crs_factory(bb::srs::bb_crs_path()); }
+
+    void SetUp() override
+    {
+        // Store original concurrency for restoration
+        original_concurrency = get_num_cpus();
+    }
+
+    void TearDown() override
+    {
+        // Restore original concurrency
+        set_hardware_concurrency(original_concurrency);
+    }
+
+    size_t original_concurrency;
 };
 TEST_F(BBApiUltraHonkTest, CircuitProve)
 {
@@ -51,6 +67,64 @@ TEST_F(BBApiUltraHonkTest, CircuitProve)
         EXPECT_TRUE(verify_response.verified)
             << "Failed with ipa_accumulation=" << settings.ipa_accumulation
             << ", oracle_hash_type=" << settings.oracle_hash_type << ", disable_zk=" << settings.disable_zk;
+    }
+}
+
+TEST_F(BBApiUltraHonkTest, ParallelComputeVk)
+{
+    // Set hardware concurrency to 8 to ensure we can run 8 VK computations in parallel
+    set_hardware_concurrency(8);
+
+    constexpr size_t num_vks = 8;
+
+    // Create different circuits by varying the number of constraints
+    std::vector<std::vector<uint8_t>> bytecodes(num_vks);
+    std::vector<std::vector<uint8_t>> witnesses(num_vks);
+    for (size_t i = 0; i < num_vks; ++i) {
+        // Create circuit with i+1 constraints (so each circuit is different)
+        auto [bytecode, witness] = acir_bincode_mocks::create_simple_circuit_bytecode(i + 1);
+        bytecodes[i] = bytecode;
+        witnesses[i] = witness;
+    }
+
+    std::vector<CircuitComputeVk::Response> parallel_vks(num_vks);
+    std::vector<CircuitComputeVk::Response> sequential_vks(num_vks);
+
+    // Use default settings
+    bbapi::ProofSystemSettings settings{ .ipa_accumulation = false,
+                                         .oracle_hash_type = "poseidon2",
+                                         .disable_zk = false };
+
+    // Compute VKs in parallel
+    parallel_for(num_vks, [&](size_t i) {
+        parallel_vks[i] =
+            CircuitComputeVk{ .circuit = { .name = "test_circuit_" + std::to_string(i), .bytecode = bytecodes[i] },
+                              .settings = settings }
+                .execute();
+    });
+
+    // Compute VKs sequentially
+    for (size_t i = 0; i < num_vks; ++i) {
+        sequential_vks[i] =
+            CircuitComputeVk{ .circuit = { .name = "test_circuit_" + std::to_string(i), .bytecode = bytecodes[i] },
+                              .settings = settings }
+                .execute();
+    }
+
+    // Verify all VKs were computed successfully and match between parallel and sequential
+    for (size_t i = 0; i < num_vks; ++i) {
+        EXPECT_FALSE(parallel_vks[i].bytes.empty()) << "Parallel VK " << i << " is empty";
+        EXPECT_FALSE(sequential_vks[i].bytes.empty()) << "Sequential VK " << i << " is empty";
+
+        // Parallel and sequential should produce identical VKs for the same circuit
+        EXPECT_EQ(parallel_vks[i].bytes, sequential_vks[i].bytes)
+            << "Parallel VK " << i << " differs from sequential VK " << i;
+
+        // Each circuit should have a different VK (different number of constraints)
+        if (i > 0) {
+            EXPECT_NE(parallel_vks[i].bytes, parallel_vks[0].bytes)
+                << "VK " << i << " should differ from VK 0 (different circuits)";
+        }
     }
 }
 

--- a/barretenberg/cpp/src/barretenberg/common/parallel_for_mutex_pool.cpp
+++ b/barretenberg/cpp/src/barretenberg/common/parallel_for_mutex_pool.cpp
@@ -171,9 +171,9 @@ void parallel_for_mutex_pool(size_t num_iterations, const std::function<void(siz
 
     // Initialize the pool if needed, or grow it if hardware concurrency has increased.
     // The ThreadPool is default-constructed with 0 workers, so grow() will initialize it on first use.
-    // Growing past that is a niche scenario that mostly comes up in testing where we may have multiple
-    // set_parallel_for_concurrency values (a pool that is bigger is not an issue as set_parallel_for_concurrency
-    // affects get_num_cpus(), which will naturally limit concurrency).
+    // Growing past the first initialization, however, is a niche scenario that mostly comes up in testing 
+    // where we may have multiple set_parallel_for_concurrency values (a pool that is bigger is not an issue 
+    // as set_parallel_for_concurrency affects get_num_cpus(), which will naturally limit concurrency).
     if (get_num_cpus() > pool.get_num_workers() + 1) {
         pool.grow(get_num_cpus() - 1);
     }

--- a/barretenberg/cpp/src/barretenberg/common/parallel_for_mutex_pool.cpp
+++ b/barretenberg/cpp/src/barretenberg/common/parallel_for_mutex_pool.cpp
@@ -19,7 +19,7 @@ namespace {
 
 class ThreadPool {
   public:
-    ThreadPool(size_t num_threads);
+    ThreadPool(size_t num_threads = 0);
     ThreadPool(const ThreadPool& other) = delete;
     ThreadPool(ThreadPool&& other) = delete;
     ~ThreadPool();
@@ -156,10 +156,19 @@ namespace bb {
  */
 void parallel_for_mutex_pool(size_t num_iterations, const std::function<void(size_t)>& func)
 {
-    static thread_local ThreadPool pool(get_num_cpus() - 1);
+    static thread_local size_t nesting_level = 0;
+    static thread_local std::array<ThreadPool, PARALLEL_FOR_MAX_NESTING> pools;
 
-    // If hardware concurrency has increased, grow the pool with more workers
-    // This is a niche scenario that mostly comes up in testing where we may play with multiple
+    // If we exceed max nesting, throw an error
+    if (nesting_level >= PARALLEL_FOR_MAX_NESTING) {
+        throw_or_abort("parallel_for_mutex_pool: exceeded maximum nesting level");
+    }
+
+    ThreadPool& pool = pools[nesting_level];
+
+    // Initialize the pool if needed, or grow it if hardware concurrency has increased.
+    // The ThreadPool is default-constructed with 0 workers, so grow() will initialize it on first use.
+    // Growing past that is a niche scenario that mostly comes up in testing where we may play with multiple
     // set_parallel_for_concurrency values (a pool that is bigger is not an issue as set_parallel_for_concurrency
     // affects get_num_cpus(), which will naturally limit concurrency).
     if (get_num_cpus() > pool.get_num_workers() + 1) {
@@ -180,7 +189,10 @@ void parallel_for_mutex_pool(size_t num_iterations, const std::function<void(siz
     // more threads to share the work.
     size_t total_threads = pool.get_num_workers() + 1;
     size_t inner_concurrency = std::max(size_t{ 2 }, (total_threads + num_iterations - 1) / num_iterations);
+
+    nesting_level++;
     pool.start_tasks(num_iterations, func, inner_concurrency);
+    nesting_level--;
 }
 } // namespace bb
 #endif

--- a/barretenberg/cpp/src/barretenberg/common/parallel_for_mutex_pool.cpp
+++ b/barretenberg/cpp/src/barretenberg/common/parallel_for_mutex_pool.cpp
@@ -157,6 +157,9 @@ namespace bb {
 void parallel_for_mutex_pool(size_t num_iterations, const std::function<void(size_t)>& func)
 {
     static thread_local size_t nesting_level = 0;
+    // There is a unique pool for each thread * nesting level.
+    // The main thread will have nesting_level one greater than its child threads.
+    // This needs to be an array so that when the main thread recurses here, it uses a different thread pool.
     static thread_local std::array<ThreadPool, PARALLEL_FOR_MAX_NESTING> pools;
 
     // If we exceed max nesting, throw an error

--- a/barretenberg/cpp/src/barretenberg/common/parallel_for_mutex_pool.cpp
+++ b/barretenberg/cpp/src/barretenberg/common/parallel_for_mutex_pool.cpp
@@ -171,8 +171,8 @@ void parallel_for_mutex_pool(size_t num_iterations, const std::function<void(siz
 
     // Initialize the pool if needed, or grow it if hardware concurrency has increased.
     // The ThreadPool is default-constructed with 0 workers, so grow() will initialize it on first use.
-    // Growing past the first initialization, however, is a niche scenario that mostly comes up in testing 
-    // where we may have multiple set_parallel_for_concurrency values (a pool that is bigger is not an issue 
+    // Growing past the first initialization, however, is a niche scenario that mostly comes up in testing
+    // where we may have multiple set_parallel_for_concurrency values (a pool that is bigger is not an issue
     // as set_parallel_for_concurrency affects get_num_cpus(), which will naturally limit concurrency).
     if (get_num_cpus() > pool.get_num_workers() + 1) {
         pool.grow(get_num_cpus() - 1);

--- a/barretenberg/cpp/src/barretenberg/common/parallel_for_mutex_pool.cpp
+++ b/barretenberg/cpp/src/barretenberg/common/parallel_for_mutex_pool.cpp
@@ -40,7 +40,6 @@ class ThreadPool {
         }
         condition.notify_all();
 
-        info("MAIN");
         do_iterations();
 
         {
@@ -157,14 +156,12 @@ namespace bb {
  */
 void parallel_for_mutex_pool(size_t num_iterations, const std::function<void(size_t)>& func)
 {
-    static thread_local size_t i = 0;
     static thread_local size_t nesting_level = 0;
     // There is a unique pool for each thread * nesting level.
     // The main thread will have nesting_level one greater than its child threads.
     // This needs to be an array so that when the main thread recurses here, it uses a different thread pool.
     static thread_local std::array<ThreadPool, PARALLEL_FOR_MAX_NESTING> pools;
 
-    info(nesting_level, ": parallel_for_mutex_pool with ", num_iterations, " iterations", i++);
     // If we exceed max nesting, throw an error
     if (nesting_level >= PARALLEL_FOR_MAX_NESTING) {
         throw_or_abort("parallel_for_mutex_pool: exceeded maximum nesting level");

--- a/barretenberg/cpp/src/barretenberg/common/parallel_for_mutex_pool.cpp
+++ b/barretenberg/cpp/src/barretenberg/common/parallel_for_mutex_pool.cpp
@@ -168,7 +168,7 @@ void parallel_for_mutex_pool(size_t num_iterations, const std::function<void(siz
 
     // Initialize the pool if needed, or grow it if hardware concurrency has increased.
     // The ThreadPool is default-constructed with 0 workers, so grow() will initialize it on first use.
-    // Growing past that is a niche scenario that mostly comes up in testing where we may play with multiple
+    // Growing past that is a niche scenario that mostly comes up in testing where we may have multiple
     // set_parallel_for_concurrency values (a pool that is bigger is not an issue as set_parallel_for_concurrency
     // affects get_num_cpus(), which will naturally limit concurrency).
     if (get_num_cpus() > pool.get_num_workers() + 1) {

--- a/barretenberg/cpp/src/barretenberg/common/parallel_for_mutex_pool.cpp
+++ b/barretenberg/cpp/src/barretenberg/common/parallel_for_mutex_pool.cpp
@@ -7,6 +7,7 @@
 #include <atomic>
 #include <condition_variable>
 #include <functional>
+#include <memory>
 #include <mutex>
 #include <queue>
 #include <thread>
@@ -26,7 +27,7 @@ class ThreadPool {
     ThreadPool& operator=(const ThreadPool& other) = delete;
     ThreadPool& operator=(ThreadPool&& other) = delete;
 
-    void start_tasks(size_t num_iterations, const std::function<void(size_t)>& func)
+    void start_tasks(size_t num_iterations, const std::function<void(size_t)>& func, size_t inner_concurrency)
     {
         parent.store(bb::detail::GlobalBenchStatsContainer::parent);
         {
@@ -35,6 +36,7 @@ class ThreadPool {
             num_iterations_ = num_iterations;
             iteration_ = 0;
             complete_ = 0;
+            inner_concurrency_ = inner_concurrency;
         }
         condition.notify_all();
 
@@ -47,11 +49,27 @@ class ThreadPool {
         }
     }
 
+    void grow(size_t target_num_threads)
+    {
+        std::unique_lock<std::mutex> lock(tasks_mutex);
+        size_t current_workers = workers.size();
+        if (target_num_threads <= current_workers) {
+            return;
+        }
+        workers.reserve(target_num_threads);
+        for (size_t i = current_workers; i < target_num_threads; ++i) {
+            workers.emplace_back(&ThreadPool::worker_loop, this, i);
+        }
+    }
+
+    size_t get_num_workers() const { return workers.size(); }
+
   private:
     std::atomic<bb::detail::TimeStatsEntry*> parent = nullptr;
     std::vector<std::thread> workers;
     std::mutex tasks_mutex;
     std::function<void(size_t)> task_;
+    size_t inner_concurrency_ = 1;
     size_t num_iterations_ = 0;
     size_t iteration_ = 0;
     size_t complete_ = 0;
@@ -116,6 +134,11 @@ void ThreadPool::worker_loop(size_t /*unused*/)
             if (stop) {
                 break;
             }
+            // NOTE: This sets the concurrency for this thread. That is, the amount of threads
+            // that are used when this calls parallel_for_mutex_pool() (including itself).
+            // The current design for nested parallel_for calls still closely follows the original design where it was
+            // not possible, so this has a somewhat awkward name.
+            bb::set_hardware_concurrency(inner_concurrency_);
         }
         // Make sure nested stats accounting works under multithreading
         // Note: parent is a thread-local variable.
@@ -133,19 +156,31 @@ namespace bb {
  */
 void parallel_for_mutex_pool(size_t num_iterations, const std::function<void(size_t)>& func)
 {
-    static ThreadPool pool(get_num_cpus() - 1);
-    // Note that if this is used safely, we don't need the std::atomic_bool (can use bool), but if we are catching the
-    // mess up case of nesting parallel_for this should be atomic
-    static std::atomic_bool nested = false;
-    // Check if we are already in a nested parallel_for_mutex_pool call
-    bool expected = false;
-    if (!nested.compare_exchange_strong(expected, true)) {
-        throw_or_abort("Error: Nested parallel_for_mutex_pool calls are not allowed.");
+    static thread_local ThreadPool pool(get_num_cpus() - 1);
+
+    // If hardware concurrency has increased, grow the pool with more workers
+    // This is a niche scenario that mostly comes up in testing where we may play with multiple set_hardware_concurrency
+    // values (a pool that is bigger is not an issue as set_hardware_concurrency affects get_num_cpus(), which will
+    // naturally limit concurrency).
+    if (get_num_cpus() > pool.get_num_workers() + 1) {
+        pool.grow(get_num_cpus() - 1);
     }
-    // info("starting job with iterations: ", num_iterations);
-    pool.start_tasks(num_iterations, func);
-    // info("done");
-    nested = false;
+
+    if (pool.get_num_workers() == 0 || num_iterations <= 1) {
+        for (size_t i = 0; i < num_iterations; ++i) {
+            func(i);
+        }
+        return;
+    }
+
+    // We compute inner concurrency here.
+    // This controls behavior if parallel_for_mutex_pool is called from within a task that is itself running in
+    // parallel_for_mutex_pool. For the cases where we do want inner concurrency, (e.g. processing contracts in
+    // aztec_process.cpp) having at least some inner concurrency smoothes out the task having uneven times, allowing
+    // more threads to share the work.
+    size_t total_threads = pool.get_num_workers() + 1;
+    size_t inner_concurrency = std::max(size_t{ 2 }, (total_threads + num_iterations - 1) / num_iterations);
+    pool.start_tasks(num_iterations, func, inner_concurrency);
 }
 } // namespace bb
 #endif

--- a/barretenberg/cpp/src/barretenberg/common/parallel_for_mutex_pool.cpp
+++ b/barretenberg/cpp/src/barretenberg/common/parallel_for_mutex_pool.cpp
@@ -138,7 +138,7 @@ void ThreadPool::worker_loop(size_t /*unused*/)
             // that are used when this calls parallel_for_mutex_pool() (including itself).
             // The current design for nested parallel_for calls still closely follows the original design where it was
             // not possible, so this has a somewhat awkward name.
-            bb::set_hardware_concurrency(inner_concurrency_);
+            bb::set_parallel_for_concurrency(inner_concurrency_);
         }
         // Make sure nested stats accounting works under multithreading
         // Note: parent is a thread-local variable.
@@ -159,9 +159,9 @@ void parallel_for_mutex_pool(size_t num_iterations, const std::function<void(siz
     static thread_local ThreadPool pool(get_num_cpus() - 1);
 
     // If hardware concurrency has increased, grow the pool with more workers
-    // This is a niche scenario that mostly comes up in testing where we may play with multiple set_hardware_concurrency
-    // values (a pool that is bigger is not an issue as set_hardware_concurrency affects get_num_cpus(), which will
-    // naturally limit concurrency).
+    // This is a niche scenario that mostly comes up in testing where we may play with multiple
+    // set_parallel_for_concurrency values (a pool that is bigger is not an issue as set_parallel_for_concurrency
+    // affects get_num_cpus(), which will naturally limit concurrency).
     if (get_num_cpus() > pool.get_num_workers() + 1) {
         pool.grow(get_num_cpus() - 1);
     }

--- a/barretenberg/cpp/src/barretenberg/common/parallel_for_mutex_pool.cpp
+++ b/barretenberg/cpp/src/barretenberg/common/parallel_for_mutex_pool.cpp
@@ -40,6 +40,7 @@ class ThreadPool {
         }
         condition.notify_all();
 
+        info("MAIN");
         do_iterations();
 
         {
@@ -156,12 +157,14 @@ namespace bb {
  */
 void parallel_for_mutex_pool(size_t num_iterations, const std::function<void(size_t)>& func)
 {
+    static thread_local size_t i = 0;
     static thread_local size_t nesting_level = 0;
     // There is a unique pool for each thread * nesting level.
     // The main thread will have nesting_level one greater than its child threads.
     // This needs to be an array so that when the main thread recurses here, it uses a different thread pool.
     static thread_local std::array<ThreadPool, PARALLEL_FOR_MAX_NESTING> pools;
 
+    info(nesting_level, ": parallel_for_mutex_pool with ", num_iterations, " iterations", i++);
     // If we exceed max nesting, throw an error
     if (nesting_level >= PARALLEL_FOR_MAX_NESTING) {
         throw_or_abort("parallel_for_mutex_pool: exceeded maximum nesting level");
@@ -178,20 +181,14 @@ void parallel_for_mutex_pool(size_t num_iterations, const std::function<void(siz
         pool.grow(get_num_cpus() - 1);
     }
 
-    if (pool.get_num_workers() == 0 || num_iterations <= 1) {
-        for (size_t i = 0; i < num_iterations; ++i) {
-            func(i);
-        }
-        return;
-    }
-
     // We compute inner concurrency here.
     // This controls behavior if parallel_for_mutex_pool is called from within a task that is itself running in
     // parallel_for_mutex_pool. For the cases where we do want inner concurrency, (e.g. processing contracts in
     // aztec_process.cpp) having at least some inner concurrency smoothes out the task having uneven times, allowing
     // more threads to share the work.
     size_t total_threads = pool.get_num_workers() + 1;
-    size_t inner_concurrency = std::max(size_t{ 2 }, (total_threads + num_iterations - 1) / num_iterations);
+    size_t inner_concurrency =
+        std::max(size_t{ 2 }, (total_threads + num_iterations - 1) / std::max(num_iterations, size_t{ 1 }));
 
     nesting_level++;
     pool.start_tasks(num_iterations, func, inner_concurrency);

--- a/barretenberg/cpp/src/barretenberg/common/thread.cpp
+++ b/barretenberg/cpp/src/barretenberg/common/thread.cpp
@@ -108,7 +108,7 @@ void parallel_for_atomic_pool(size_t num_iterations, const std::function<void(si
 
 void parallel_for_mutex_pool(size_t num_iterations, const std::function<void(size_t)>& func);
 
-void parallel_for_impl(size_t num_iterations, const std::function<void(size_t)>& func)
+void parallel_for(size_t num_iterations, const std::function<void(size_t)>& func)
 {
 #ifdef NO_MULTITHREADING
     for (size_t i = 0; i < num_iterations; ++i) {
@@ -125,11 +125,6 @@ void parallel_for_impl(size_t num_iterations, const std::function<void(size_t)>&
     // parallel_for_queued(num_iterations, func);
 #endif
 #endif
-}
-
-void parallel_for(size_t num_iterations, const std::function<void(size_t)>& func)
-{
-    parallel_for_impl(num_iterations, func);
 }
 
 /**

--- a/barretenberg/cpp/src/barretenberg/common/thread.cpp
+++ b/barretenberg/cpp/src/barretenberg/common/thread.cpp
@@ -21,7 +21,7 @@ uint32_t& get_num_cores_ref()
 
 namespace bb {
 // only for testing purposes currently
-void set_hardware_concurrency([[maybe_unused]] size_t num_cores)
+void set_parallel_for_concurrency([[maybe_unused]] size_t num_cores)
 {
 #ifdef NO_MULTITHREADING
     throw_or_abort("Cannot set hardware concurrency when multithreading is disabled.");

--- a/barretenberg/cpp/src/barretenberg/common/thread.cpp
+++ b/barretenberg/cpp/src/barretenberg/common/thread.cpp
@@ -1,5 +1,44 @@
 #include "thread.hpp"
 #include "log.hpp"
+#include "throw_or_abort.hpp"
+#include <barretenberg/env/hardware_concurrency.hpp>
+#include <cstdlib>
+#include <string>
+
+#ifndef NO_MULTITHREADING
+#include <thread>
+
+namespace {
+uint32_t& get_num_cores_ref()
+{
+    static thread_local const char* val = std::getenv("HARDWARE_CONCURRENCY");
+    static thread_local uint32_t cores =
+        val != nullptr ? static_cast<uint32_t>(std::stoul(val)) : env_hardware_concurrency();
+    return cores;
+}
+} // namespace
+#endif
+
+namespace bb {
+// only for testing purposes currently
+void set_hardware_concurrency([[maybe_unused]] size_t num_cores)
+{
+#ifdef NO_MULTITHREADING
+    throw_or_abort("Cannot set hardware concurrency when multithreading is disabled.");
+#else
+    get_num_cores_ref() = static_cast<uint32_t>(num_cores);
+#endif
+}
+
+size_t get_num_cpus()
+{
+#ifdef NO_MULTITHREADING
+    return 1;
+#else
+    return static_cast<size_t>(get_num_cores_ref());
+#endif
+}
+} // namespace bb
 
 /**
  * There's a lot to talk about here. To bring threading to WASM, parallel_for was written to replace the OpenMP loops
@@ -69,7 +108,7 @@ void parallel_for_atomic_pool(size_t num_iterations, const std::function<void(si
 
 void parallel_for_mutex_pool(size_t num_iterations, const std::function<void(size_t)>& func);
 
-void parallel_for(size_t num_iterations, const std::function<void(size_t)>& func)
+void parallel_for_impl(size_t num_iterations, const std::function<void(size_t)>& func)
 {
 #ifdef NO_MULTITHREADING
     for (size_t i = 0; i < num_iterations; ++i) {
@@ -86,6 +125,11 @@ void parallel_for(size_t num_iterations, const std::function<void(size_t)>& func
     // parallel_for_queued(num_iterations, func);
 #endif
 #endif
+}
+
+void parallel_for(size_t num_iterations, const std::function<void(size_t)>& func)
+{
+    parallel_for_impl(num_iterations, func);
 }
 
 /**

--- a/barretenberg/cpp/src/barretenberg/common/thread.hpp
+++ b/barretenberg/cpp/src/barretenberg/common/thread.hpp
@@ -9,8 +9,12 @@
 #include <vector>
 
 namespace bb {
-
+#ifdef __wasm__
+// Fixed number of workers in WASM environment
+constexpr size_t PARALLEL_FOR_MAX_NESTING = 1;
+#else
 constexpr size_t PARALLEL_FOR_MAX_NESTING = 2;
+#endif
 
 // Useful for programatically benching different thread counts
 // Note this is threadsafe and affects parallel_for's just in that thread if so.

--- a/barretenberg/cpp/src/barretenberg/common/thread.hpp
+++ b/barretenberg/cpp/src/barretenberg/common/thread.hpp
@@ -10,6 +10,8 @@
 
 namespace bb {
 
+constexpr size_t PARALLEL_FOR_MAX_NESTING = 2;
+
 // Useful for programatically benching different thread counts
 // Note this is threadsafe and affects parallel_for's just in that thread if so.
 void set_parallel_for_concurrency(size_t num_cores);

--- a/barretenberg/cpp/src/barretenberg/common/thread.hpp
+++ b/barretenberg/cpp/src/barretenberg/common/thread.hpp
@@ -11,7 +11,8 @@
 namespace bb {
 
 // Useful for programatically benching different thread counts
-void set_hardware_concurrency(size_t num_cores);
+// Note this is threadsafe and affects parallel_for's just in that thread if so.
+void set_parallel_for_concurrency(size_t num_cores);
 size_t get_num_cpus();
 
 // For algorithms that need to be divided amongst power of 2 threads.

--- a/barretenberg/cpp/src/barretenberg/common/thread.hpp
+++ b/barretenberg/cpp/src/barretenberg/common/thread.hpp
@@ -12,10 +12,7 @@ namespace bb {
 
 // Useful for programatically benching different thread counts
 void set_hardware_concurrency(size_t num_cores);
-inline size_t get_num_cpus()
-{
-    return env_hardware_concurrency();
-}
+size_t get_num_cpus();
 
 // For algorithms that need to be divided amongst power of 2 threads.
 inline size_t get_num_cpus_pow2()

--- a/barretenberg/cpp/src/barretenberg/common/thread.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/common/thread.test.cpp
@@ -1,4 +1,5 @@
 #include "thread.hpp"
+#include "barretenberg/common/log.hpp"
 #include <atomic>
 #include <gtest/gtest.h>
 #include <set>
@@ -316,30 +317,4 @@ TEST_F(ThreadTest, ConcurrencyIsolation)
     EXPECT_EQ(cpus_after, 8);
     EXPECT_EQ(cpus_before, cpus_after);
 }
-
-// Test deeply nested parallel_for concurrency
-TEST_F(ThreadTest, DeeplyNestedConcurrency)
-{
-    set_parallel_for_concurrency(16);
-
-    std::atomic<size_t> level1_cpus{ 0 };
-    std::atomic<size_t> level2_cpus{ 0 };
-    std::atomic<size_t> level3_cpus{ 0 };
-
-    parallel_for(2, [&](size_t) {
-        level1_cpus.store(get_num_cpus());
-
-        parallel_for(2, [&](size_t) {
-            level2_cpus.store(get_num_cpus());
-
-            parallel_for(2, [&](size_t) { level3_cpus.store(get_num_cpus()); });
-        });
-    });
-
-    // All levels should see at least 2 CPUs
-    EXPECT_GE(level1_cpus.load(), 2);
-    EXPECT_GE(level2_cpus.load(), 2);
-    EXPECT_GE(level3_cpus.load(), 2);
-}
-
 } // namespace bb

--- a/barretenberg/cpp/src/barretenberg/common/thread.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/common/thread.test.cpp
@@ -1,0 +1,345 @@
+#include "thread.hpp"
+#include <atomic>
+#include <gtest/gtest.h>
+#include <set>
+#include <thread>
+
+namespace bb {
+
+class ThreadTest : public ::testing::Test {
+  protected:
+    void SetUp() override
+    {
+        // Store original concurrency for restoration
+        original_concurrency = get_num_cpus();
+    }
+
+    void TearDown() override
+    {
+        // Restore original concurrency
+        set_hardware_concurrency(original_concurrency);
+    }
+
+    size_t original_concurrency;
+};
+
+// Test basic parallel_for functionality
+TEST_F(ThreadTest, BasicParallelFor)
+{
+    constexpr size_t num_iterations = 100;
+    std::vector<char> flags(num_iterations, 0);
+
+    parallel_for(num_iterations, [&](size_t i) { flags[i] = 1; });
+
+    // All iterations should have been executed
+    for (size_t i = 0; i < num_iterations; ++i) {
+        EXPECT_TRUE(flags[i]);
+    }
+}
+
+// Test nested parallel_for
+TEST_F(ThreadTest, NestedParallelFor)
+{
+    constexpr size_t outer_iterations = 4;
+    constexpr size_t inner_iterations = 10;
+
+    std::vector<std::vector<char>> flags(outer_iterations, std::vector<char>(inner_iterations, 0));
+
+    parallel_for(outer_iterations,
+                 [&](size_t i) { parallel_for(inner_iterations, [&](size_t j) { flags[i][j] = 1; }); });
+
+    // All iterations should have been executed
+    for (size_t i = 0; i < outer_iterations; ++i) {
+        for (size_t j = 0; j < inner_iterations; ++j) {
+            EXPECT_TRUE(flags[i][j]);
+        }
+    }
+}
+
+// Test thread count calculation
+TEST_F(ThreadTest, CalculateNumThreads)
+{
+    set_hardware_concurrency(8);
+
+    // With default min iterations per thread (16)
+    // 160 iterations / 16 = 10 desired threads, min(10, 8) = 8
+    EXPECT_EQ(calculate_num_threads(160), 8);
+
+    // 64 iterations / 16 = 4 desired threads, min(4, 8) = 4
+    EXPECT_EQ(calculate_num_threads(64), 4);
+
+    // 8 iterations / 16 = 0 desired threads, but should be at least 1
+    EXPECT_EQ(calculate_num_threads(8), 1);
+
+    // Custom min iterations per thread
+    // 100 iterations / 10 = 10 desired threads, min(10, 8) = 8
+    EXPECT_EQ(calculate_num_threads(100, 10), 8);
+
+    // 30 iterations / 10 = 3 desired threads, min(3, 8) = 3
+    EXPECT_EQ(calculate_num_threads(30, 10), 3);
+}
+
+// Test thread count calculation with power of 2
+TEST_F(ThreadTest, CalculateNumThreadsPow2)
+{
+    set_hardware_concurrency(8);
+
+    // With default min iterations per thread (16)
+    // 160 iterations / 16 = 10 desired, nearest power of 2 is 8, min(8, 8) = 8
+    EXPECT_EQ(calculate_num_threads_pow2(160), 8);
+
+    // 64 iterations / 16 = 4 desired, power of 2 is 4, min(4, 8) = 4
+    EXPECT_EQ(calculate_num_threads_pow2(64), 4);
+
+    // 96 iterations / 16 = 6 desired, nearest power of 2 is 4, min(4, 8) = 4
+    EXPECT_EQ(calculate_num_threads_pow2(96), 4);
+
+    // 8 iterations / 16 = 0 desired, should be at least 1
+    EXPECT_EQ(calculate_num_threads_pow2(8), 1);
+}
+
+// Test nested parallel_for thread count
+TEST_F(ThreadTest, NestedThreadCount)
+{
+    set_hardware_concurrency(8);
+
+    std::atomic<size_t> outer_unique_threads{ 0 };
+    std::atomic<size_t> max_inner_unique_threads{ 0 };
+    std::mutex outer_mutex;
+    std::set<std::thread::id> outer_thread_ids;
+
+    constexpr size_t outer_iterations = 4;
+    constexpr size_t inner_iterations = 100;
+
+    parallel_for(outer_iterations, [&](size_t) {
+        // Track outer thread
+        {
+            std::lock_guard<std::mutex> lock(outer_mutex);
+            outer_thread_ids.insert(std::this_thread::get_id());
+        }
+
+        // Track inner threads
+        std::mutex inner_mutex;
+        std::set<std::thread::id> inner_thread_ids;
+
+        parallel_for(inner_iterations, [&](size_t) {
+            std::lock_guard<std::mutex> lock(inner_mutex);
+            inner_thread_ids.insert(std::this_thread::get_id());
+            std::this_thread::sleep_for(std::chrono::microseconds(100));
+        });
+
+        // Update max inner thread count
+        size_t inner_count = inner_thread_ids.size();
+        size_t current_max = max_inner_unique_threads.load();
+        while (inner_count > current_max && !max_inner_unique_threads.compare_exchange_weak(current_max, inner_count)) {
+            // Retry until we successfully update or someone else set a higher value
+        }
+    });
+
+    outer_unique_threads = outer_thread_ids.size();
+
+    // Outer should use available CPUs (up to 8)
+    EXPECT_GE(outer_unique_threads, 4);
+    EXPECT_LE(outer_unique_threads, 9); // Main thread + 8 workers
+
+    // Inner parallel_for runs sequentially within each outer thread
+    // So each inner parallel_for should see all CPUs available
+    EXPECT_GE(max_inner_unique_threads, 4);
+}
+
+// Test parallel_for with zero iterations
+TEST_F(ThreadTest, ZeroIterations)
+{
+    size_t counter = 0;
+
+    parallel_for(0, [&](size_t) { counter++; });
+
+    EXPECT_EQ(counter, 0);
+}
+
+// Test parallel_for with one iteration
+TEST_F(ThreadTest, OneIteration)
+{
+    size_t counter = 0;
+
+    parallel_for(1, [&](size_t i) {
+        counter++;
+        EXPECT_EQ(i, 0);
+    });
+
+    EXPECT_EQ(counter, 1);
+}
+
+// Test calculate_thread_data bounds
+TEST_F(ThreadTest, CalculateThreadDataBounds)
+{
+    set_hardware_concurrency(4);
+
+    auto data = calculate_thread_data(100);
+
+    // Should create some threads (at least 1)
+    EXPECT_GE(data.num_threads, 1);
+    EXPECT_LE(data.num_threads, 4);
+
+    // Vectors should be sized correctly
+    EXPECT_EQ(data.start.size(), data.num_threads);
+    EXPECT_EQ(data.end.size(), data.num_threads);
+
+    // First thread starts at 0
+    EXPECT_EQ(data.start[0], 0);
+
+    // Last thread ends at num_iterations
+    EXPECT_EQ(data.end[data.num_threads - 1], 100);
+
+    // Bounds should be contiguous and non-overlapping
+    for (size_t i = 0; i < data.num_threads - 1; ++i) {
+        EXPECT_EQ(data.end[i], data.start[i + 1]);
+        EXPECT_LT(data.start[i], data.end[i]);
+    }
+}
+
+// Test parallel_for_range
+TEST_F(ThreadTest, ParallelForRange)
+{
+    constexpr size_t num_points = 100;
+    std::vector<char> flags(num_points, 0);
+
+    parallel_for_range(num_points, [&](size_t start, size_t end) {
+        for (size_t i = start; i < end; ++i) {
+            flags[i] = 1;
+        }
+    });
+
+    // All iterations should have been executed
+    for (size_t i = 0; i < num_points; ++i) {
+        EXPECT_TRUE(flags[i]);
+    }
+}
+
+// Test parallel_for_range with threshold
+TEST_F(ThreadTest, ParallelForRangeThreshold)
+{
+    constexpr size_t num_points = 10;
+    std::vector<char> flags(num_points, 0);
+
+    std::atomic<size_t> call_count{ 0 };
+
+    // Set threshold to 10, so with exactly 10 points it should run sequentially (1 call)
+    parallel_for_range(
+        num_points,
+        [&](size_t start, size_t end) {
+            call_count++;
+            for (size_t i = start; i < end; ++i) {
+                flags[i] = 1;
+            }
+        },
+        10);
+
+    // All iterations should have been executed
+    for (size_t i = 0; i < num_points; ++i) {
+        EXPECT_TRUE(flags[i]);
+    }
+
+    // Should have been called exactly once (sequential)
+    EXPECT_EQ(call_count, 1);
+}
+
+// Test get_num_cpus with different hardware concurrency values
+TEST_F(ThreadTest, HardwareConcurrency)
+{
+    set_hardware_concurrency(1);
+    EXPECT_EQ(get_num_cpus(), 1);
+
+    set_hardware_concurrency(4);
+    EXPECT_EQ(get_num_cpus(), 4);
+
+    set_hardware_concurrency(16);
+    EXPECT_EQ(get_num_cpus(), 16);
+
+    set_hardware_concurrency(128);
+    EXPECT_EQ(get_num_cpus(), 128);
+}
+
+// Test get_num_cpus_pow2
+TEST_F(ThreadTest, HardwareConcurrencyPow2)
+{
+    set_hardware_concurrency(1);
+    EXPECT_EQ(get_num_cpus_pow2(), 1);
+
+    set_hardware_concurrency(4);
+    EXPECT_EQ(get_num_cpus_pow2(), 4);
+
+    set_hardware_concurrency(5);
+    EXPECT_EQ(get_num_cpus_pow2(), 4); // Round down to power of 2
+
+    set_hardware_concurrency(7);
+    EXPECT_EQ(get_num_cpus_pow2(), 4); // Round down to power of 2
+
+    set_hardware_concurrency(8);
+    EXPECT_EQ(get_num_cpus_pow2(), 8);
+
+    set_hardware_concurrency(15);
+    EXPECT_EQ(get_num_cpus_pow2(), 8); // Round down to power of 2
+
+    set_hardware_concurrency(16);
+    EXPECT_EQ(get_num_cpus_pow2(), 16);
+}
+
+// Test main thread concurrency isolation and nested concurrency
+TEST_F(ThreadTest, ConcurrencyIsolation)
+{
+    set_hardware_concurrency(8);
+
+    // Main thread concurrency should be preserved before/after parallel_for
+    size_t cpus_before = get_num_cpus();
+    EXPECT_EQ(cpus_before, 8);
+
+    std::vector<std::atomic<size_t>> observed_inner_cpus(4);
+
+    parallel_for(4, [&](size_t outer_idx) {
+        // Worker threads get their own thread_local concurrency set by the pool
+        // With 8 CPUs and 4 outer tasks, each gets at least 2 CPUs for inner work
+        size_t inner_cpus = get_num_cpus();
+        observed_inner_cpus[outer_idx].store(inner_cpus);
+
+        // Run a nested parallel_for to verify inner concurrency works
+        parallel_for(10, [](size_t) {});
+    });
+
+    // All inner parallel_for calls should see at least 2 CPUs
+    for (size_t i = 0; i < 4; ++i) {
+        EXPECT_GE(observed_inner_cpus[i].load(), 2);
+    }
+
+    // Main thread concurrency should be unchanged
+    size_t cpus_after = get_num_cpus();
+    EXPECT_EQ(cpus_after, 8);
+    EXPECT_EQ(cpus_before, cpus_after);
+}
+
+// Test deeply nested parallel_for concurrency
+TEST_F(ThreadTest, DeeplyNestedConcurrency)
+{
+    set_hardware_concurrency(16);
+
+    std::atomic<size_t> level1_cpus{ 0 };
+    std::atomic<size_t> level2_cpus{ 0 };
+    std::atomic<size_t> level3_cpus{ 0 };
+
+    parallel_for(2, [&](size_t) {
+        level1_cpus.store(get_num_cpus());
+
+        parallel_for(2, [&](size_t) {
+            level2_cpus.store(get_num_cpus());
+
+            parallel_for(2, [&](size_t) { level3_cpus.store(get_num_cpus()); });
+        });
+    });
+
+    // All levels should see at least 2 CPUs
+    EXPECT_GE(level1_cpus.load(), 2);
+    EXPECT_GE(level2_cpus.load(), 2);
+    EXPECT_GE(level3_cpus.load(), 2);
+}
+
+} // namespace bb

--- a/barretenberg/cpp/src/barretenberg/common/thread.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/common/thread.test.cpp
@@ -197,6 +197,7 @@ TEST_F(ThreadTest, CalculateThreadDataBounds)
         EXPECT_EQ(data.end[i], data.start[i + 1]);
         EXPECT_LT(data.start[i], data.end[i]);
     }
+    EXPECT_LT(data.start[data.num_threads - 1], data.end[data.num_threads - 1]);
 }
 
 // Test parallel_for_range

--- a/barretenberg/cpp/src/barretenberg/common/thread.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/common/thread.test.cpp
@@ -17,7 +17,7 @@ class ThreadTest : public ::testing::Test {
     void TearDown() override
     {
         // Restore original concurrency
-        set_hardware_concurrency(original_concurrency);
+        set_parallel_for_concurrency(original_concurrency);
     }
 
     size_t original_concurrency;
@@ -59,7 +59,7 @@ TEST_F(ThreadTest, NestedParallelFor)
 // Test thread count calculation
 TEST_F(ThreadTest, CalculateNumThreads)
 {
-    set_hardware_concurrency(8);
+    set_parallel_for_concurrency(8);
 
     // With default min iterations per thread (16)
     // 160 iterations / 16 = 10 desired threads, min(10, 8) = 8
@@ -82,7 +82,7 @@ TEST_F(ThreadTest, CalculateNumThreads)
 // Test thread count calculation with power of 2
 TEST_F(ThreadTest, CalculateNumThreadsPow2)
 {
-    set_hardware_concurrency(8);
+    set_parallel_for_concurrency(8);
 
     // With default min iterations per thread (16)
     // 160 iterations / 16 = 10 desired, nearest power of 2 is 8, min(8, 8) = 8
@@ -101,7 +101,7 @@ TEST_F(ThreadTest, CalculateNumThreadsPow2)
 // Test nested parallel_for thread count
 TEST_F(ThreadTest, NestedThreadCount)
 {
-    set_hardware_concurrency(8);
+    set_parallel_for_concurrency(8);
 
     std::atomic<size_t> outer_unique_threads{ 0 };
     std::atomic<size_t> max_inner_unique_threads{ 0 };
@@ -173,7 +173,7 @@ TEST_F(ThreadTest, OneIteration)
 // Test calculate_thread_data bounds
 TEST_F(ThreadTest, CalculateThreadDataBounds)
 {
-    set_hardware_concurrency(4);
+    set_parallel_for_concurrency(4);
 
     auto data = calculate_thread_data(100);
 
@@ -247,48 +247,48 @@ TEST_F(ThreadTest, ParallelForRangeThreshold)
 // Test get_num_cpus with different hardware concurrency values
 TEST_F(ThreadTest, HardwareConcurrency)
 {
-    set_hardware_concurrency(1);
+    set_parallel_for_concurrency(1);
     EXPECT_EQ(get_num_cpus(), 1);
 
-    set_hardware_concurrency(4);
+    set_parallel_for_concurrency(4);
     EXPECT_EQ(get_num_cpus(), 4);
 
-    set_hardware_concurrency(16);
+    set_parallel_for_concurrency(16);
     EXPECT_EQ(get_num_cpus(), 16);
 
-    set_hardware_concurrency(128);
+    set_parallel_for_concurrency(128);
     EXPECT_EQ(get_num_cpus(), 128);
 }
 
 // Test get_num_cpus_pow2
 TEST_F(ThreadTest, HardwareConcurrencyPow2)
 {
-    set_hardware_concurrency(1);
+    set_parallel_for_concurrency(1);
     EXPECT_EQ(get_num_cpus_pow2(), 1);
 
-    set_hardware_concurrency(4);
+    set_parallel_for_concurrency(4);
     EXPECT_EQ(get_num_cpus_pow2(), 4);
 
-    set_hardware_concurrency(5);
+    set_parallel_for_concurrency(5);
     EXPECT_EQ(get_num_cpus_pow2(), 4); // Round down to power of 2
 
-    set_hardware_concurrency(7);
+    set_parallel_for_concurrency(7);
     EXPECT_EQ(get_num_cpus_pow2(), 4); // Round down to power of 2
 
-    set_hardware_concurrency(8);
+    set_parallel_for_concurrency(8);
     EXPECT_EQ(get_num_cpus_pow2(), 8);
 
-    set_hardware_concurrency(15);
+    set_parallel_for_concurrency(15);
     EXPECT_EQ(get_num_cpus_pow2(), 8); // Round down to power of 2
 
-    set_hardware_concurrency(16);
+    set_parallel_for_concurrency(16);
     EXPECT_EQ(get_num_cpus_pow2(), 16);
 }
 
 // Test main thread concurrency isolation and nested concurrency
 TEST_F(ThreadTest, ConcurrencyIsolation)
 {
-    set_hardware_concurrency(8);
+    set_parallel_for_concurrency(8);
 
     // Main thread concurrency should be preserved before/after parallel_for
     size_t cpus_before = get_num_cpus();
@@ -320,7 +320,7 @@ TEST_F(ThreadTest, ConcurrencyIsolation)
 // Test deeply nested parallel_for concurrency
 TEST_F(ThreadTest, DeeplyNestedConcurrency)
 {
-    set_hardware_concurrency(16);
+    set_parallel_for_concurrency(16);
 
     std::atomic<size_t> level1_cpus{ 0 };
     std::atomic<size_t> level2_cpus{ 0 };

--- a/barretenberg/cpp/src/barretenberg/ecc/scalar_multiplication/scalar_multiplication.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/scalar_multiplication/scalar_multiplication.test.cpp
@@ -538,7 +538,7 @@ TYPED_TEST(ScalarMultiplicationTest, BenchBatchMsm)
         all_commitments.push_back(TestFixture::naive_msm(all_scalars.back(), all_points.back()));
     }
     auto func = [&]<bb::detail::OperationLabel thread_prefix>(size_t num_threads) {
-        set_hardware_concurrency(num_threads);
+        set_parallel_for_concurrency(num_threads);
         // Strategy 1: Individual MSMs
         {
             BB_BENCH_NAME((bb::detail::concat<thread_prefix, "IndividualMSMs">()));

--- a/barretenberg/cpp/src/barretenberg/env/hardware_concurrency.cpp
+++ b/barretenberg/cpp/src/barretenberg/env/hardware_concurrency.cpp
@@ -14,8 +14,8 @@ static uint32_t& _get_num_cores()
 #ifdef NO_MULTITHREADING
     static uint32_t cores = 1;
 #else
-    static const char* val = std::getenv("HARDWARE_CONCURRENCY");
-    static uint32_t cores =
+    static thread_local const char* val = std::getenv("HARDWARE_CONCURRENCY");
+    static thread_local uint32_t cores =
         val != nullptr ? static_cast<uint32_t>(std::stoul(val)) : std::thread::hardware_concurrency();
 #endif
     return cores;

--- a/barretenberg/cpp/src/barretenberg/env/hardware_concurrency.cpp
+++ b/barretenberg/cpp/src/barretenberg/env/hardware_concurrency.cpp
@@ -13,6 +13,10 @@ extern "C" {
 
 uint32_t env_hardware_concurrency()
 {
+#ifdef NO_MULTITHREADING
+    return 1;
+#else
     return std::thread::hardware_concurrency();
+#endif
 }
 }

--- a/barretenberg/cpp/src/barretenberg/env/hardware_concurrency.cpp
+++ b/barretenberg/cpp/src/barretenberg/env/hardware_concurrency.cpp
@@ -9,42 +9,10 @@
 #include <thread>
 #endif
 
-static uint32_t& _get_num_cores()
-{
-#ifdef NO_MULTITHREADING
-    static uint32_t cores = 1;
-#else
-    static thread_local const char* val = std::getenv("HARDWARE_CONCURRENCY");
-    static thread_local uint32_t cores =
-        val != nullptr ? static_cast<uint32_t>(std::stoul(val)) : std::thread::hardware_concurrency();
-#endif
-    return cores;
-}
-
-namespace bb {
-// only for testing purposes currently
-void set_hardware_concurrency([[maybe_unused]] size_t num_cores)
-{
-#ifdef NO_MULTITHREADING
-    throw_or_abort("Cannot set hardware concurrency when multithreading is disabled.");
-#else
-    _get_num_cores() = static_cast<uint32_t>(num_cores);
-#endif
-}
-} // namespace bb
-
 extern "C" {
 
 uint32_t env_hardware_concurrency()
 {
-#ifndef __wasm__
-    try {
-#endif
-        return _get_num_cores();
-#ifndef __wasm__
-    } catch (std::exception const&) {
-        throw std::runtime_error("HARDWARE_CONCURRENCY invalid.");
-    }
-#endif
+    return std::thread::hardware_concurrency();
 }
 }

--- a/barretenberg/cpp/src/barretenberg/env/logstr.cpp
+++ b/barretenberg/cpp/src/barretenberg/env/logstr.cpp
@@ -8,6 +8,9 @@
 #include <cstddef>
 #include <iomanip>
 #include <iostream>
+#ifndef NO_MULTITHREADING
+#include <mutex>
+#endif
 
 #if defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__)
 #include <sys/resource.h>
@@ -62,6 +65,11 @@ std::size_t peak_rss_bytes()
 //---------------------------------------------------------------------
 extern "C" void logstr(char const* msg)
 {
+#ifndef NO_MULTITHREADING
+    static std::mutex log_mutex;
+    std::lock_guard<std::mutex> lock(log_mutex);
+#endif
+
     static bool disable_mem_usage = std::getenv("BB_DISABLE_MEM_USAGE") != nullptr;
     if (disable_mem_usage) {
         std::cerr << msg << '\n';

--- a/barretenberg/cpp/src/barretenberg/srs/factories/native_crs_factory.hpp
+++ b/barretenberg/cpp/src/barretenberg/srs/factories/native_crs_factory.hpp
@@ -5,6 +5,9 @@
 #include "barretenberg/srs/factories/mem_grumpkin_crs_factory.hpp"
 #include <filesystem>
 #include <memory>
+#ifndef NO_MULTITHREADING
+#include <mutex>
+#endif
 
 namespace bb::srs::factories {
 
@@ -40,6 +43,9 @@ class NativeBn254CrsFactory : public CrsFactory<curve::BN254> {
     {}
     std::shared_ptr<Crs<curve::BN254>> get_crs(size_t degree) override
     {
+#ifndef NO_MULTITHREADING
+        std::lock_guard<std::mutex> lock(mutex_);
+#endif
         if (degree > last_degree_ || mem_crs_ == nullptr) {
             mem_crs_ = std::make_shared<MemBn254CrsFactory>(init_bn254_crs(path_, degree, allow_download_));
             last_degree_ = degree;
@@ -52,6 +58,9 @@ class NativeBn254CrsFactory : public CrsFactory<curve::BN254> {
     bool allow_download_ = true;
     size_t last_degree_ = 0;
     std::shared_ptr<MemBn254CrsFactory> mem_crs_;
+#ifndef NO_MULTITHREADING
+    std::mutex mutex_;
+#endif
 };
 
 class NativeGrumpkinCrsFactory : public CrsFactory<curve::Grumpkin> {
@@ -63,6 +72,9 @@ class NativeGrumpkinCrsFactory : public CrsFactory<curve::Grumpkin> {
 
     std::shared_ptr<Crs<curve::Grumpkin>> get_crs(size_t degree) override
     {
+#ifndef NO_MULTITHREADING
+        std::lock_guard<std::mutex> lock(mutex_);
+#endif
         if (degree > last_degree_ || mem_crs_ == nullptr) {
             mem_crs_ = std::make_unique<MemGrumpkinCrsFactory>(init_grumpkin_crs(path_, degree, allow_download_));
             last_degree_ = degree;
@@ -75,6 +87,9 @@ class NativeGrumpkinCrsFactory : public CrsFactory<curve::Grumpkin> {
     bool allow_download_ = true;
     size_t last_degree_ = 0;
     std::unique_ptr<MemGrumpkinCrsFactory> mem_crs_;
+#ifndef NO_MULTITHREADING
+    std::mutex mutex_;
+#endif
 };
 
 } // namespace bb::srs::factories


### PR DESCRIPTION
This is tested in bbapi_tests to ensure it allows parallel vk computation. Ran through thread sanitizer to find threading issues.

If you thread over 8 VKs with 8 cores reported by hardware_concurrency(), you will get 2 threads per each (the reasoning is a minimum of 2 in case there is uneven work)

## Summary
- Thread-safe nested parallel_for using thread-local pools
- ThreadPool::grow() method to dynamically increase workers
- Inner concurrency calculation for nested parallelism

This enables computing verification keys in parallel, which we desire for aztec contract processing without fork()