### PR TITLE
feat: (A-107) add BLS key support to key store

### DIFF
--- a/yarn-project/end-to-end/src/e2e_multi_validator/utils.ts
+++ b/yarn-project/end-to-end/src/e2e_multi_validator/utils.ts
@@ -157,9 +157,7 @@ export async function createKeyFile3(
     schemaVersion: 1,
     validators: [
       {
-        attester: {
-          address: validatorAddress.toChecksumString(),
-        },
+        attester: validatorAddress.toChecksumString(),
         coinbase: coinbase.toChecksumString(),
         publisher: [publisher1Key, publisher2Key],
         feeRecipient: feeRecipient.toString(),
@@ -193,9 +191,7 @@ export async function createKeyFile4(
     },
     validators: [
       {
-        attester: {
-          address: validator1Address.toChecksumString(),
-        },
+        attester: validator1Address.toChecksumString(),
         coinbase: coinbase1.toChecksumString(),
         publisher: {
           mnemonic: mnemonic,
@@ -206,9 +202,7 @@ export async function createKeyFile4(
         feeRecipient: feeRecipient1.toString(),
       },
       {
-        attester: {
-          address: validator2Address.toChecksumString(),
-        },
+        attester: validator2Address.toChecksumString(),
         coinbase: coinbase2.toChecksumString(),
         publisher: [publisher2Key, publisher3Key],
         feeRecipient: feeRecipient2.toString(),

--- a/yarn-project/node-keystore/examples/everything.json
+++ b/yarn-project/node-keystore/examples/everything.json
@@ -32,6 +32,7 @@
         "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
         {
           "address": "0xffffffffffffffffffffffffffffffffffffffff",
+          "remoteSignerUrl": "https://localhost:9100",
           "certPass": "optional"
         },
         {
@@ -61,6 +62,13 @@
       },
       "feeRecipient": "0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd",
       "fundingAccount": "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    },
+    {
+      "attester": {
+        "eth": "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "bls": "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      },
+      "feeRecipient": "0x9999999999999999999999999999999999999999999999999999999999999999"
     }
   ],
   "prover": {

--- a/yarn-project/node-keystore/examples/multiple-validators-remote.json
+++ b/yarn-project/node-keystore/examples/multiple-validators-remote.json
@@ -26,6 +26,20 @@
         "mnemonic": "test test test test test test test test test test test junk",
         "addressCount": 4
       }
+    },
+    {
+      "attester": {
+        "address": "0x1111111111111111111111111111111111111111",
+        "remoteSignerUrl": "https://localhost:8082"
+      },
+      "feeRecipient": "0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd"
+    },
+    {
+      "attester": {
+        "eth": "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "bls": "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      },
+      "feeRecipient": "0x9999999999999999999999999999999999999999999999999999999999999999"
     }
   ]
 }

--- a/yarn-project/node-keystore/src/schemas.test.ts
+++ b/yarn-project/node-keystore/src/schemas.test.ts
@@ -10,7 +10,7 @@ import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 
 import { keystoreSchema } from '../src/schemas.js';
-import type { EthMnemonicConfig, ProverKeyStoreWithId } from './types.js';
+import type { MnemonicConfig, ProverKeyStoreWithId } from './types.js';
 
 // Helper to load example JSON files
 const loadExample = (filename: string) => {
@@ -61,10 +61,17 @@ describe('Keystore Schema Validation', () => {
 
     const parsed = keystoreSchema.parse(keystore);
     expect(parsed.schemaVersion).toBe(1);
-    expect(parsed.validators).toHaveLength(3);
+    expect(parsed.validators).toHaveLength(5);
     expect(parsed.remoteSigner).toBe('https://localhost:8080');
     const address = parsed.slasher as EthAddress;
     expect(address.equals(EthAddress.fromString('0x1234567890123456789012345678901234567890'))).toBeTruthy();
+
+    // BLS attester check
+    expect(parsed.validators).toBeDefined();
+    const v0: any = parsed.validators![4];
+    expect(typeof v0.attester).toBe('object');
+    expect(v0.attester.eth).toBe('0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
+    expect(v0.attester.bls).toBe('0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb');
   });
 
   it('should validate prover with publishers example', () => {
@@ -76,7 +83,8 @@ describe('Keystore Schema Validation', () => {
     expect(typeof parsed.prover).toBe('object');
     const prover = parsed.prover as ProverKeyStoreWithId;
     expect(prover.id.equals(EthAddress.fromString('0x1234567890123456789012345678901234567890'))).toBeTruthy();
-    expect(prover.publisher).toHaveLength(2);
+    expect(Array.isArray(prover.publisher)).toBe(true);
+    expect(prover.publisher as any[]).toHaveLength(2);
     expect(parsed.fundingAccount).toBe('0xdddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd');
   });
 
@@ -89,7 +97,13 @@ describe('Keystore Schema Validation', () => {
     expect(typeof parsed.prover).toBe('object');
     const prover = parsed.prover as ProverKeyStoreWithId;
     expect(prover.id.equals(EthAddress.fromString('0x1234567890123456789012345678901234567890'))).toBeTruthy();
-    expect((parsed.prover as any).publisher).toBe('0x1234567890123456789012345678901234567890123456789012345678901234');
+    if (Array.isArray(prover.publisher)) {
+      expect(prover.publisher).toHaveLength(1);
+      expect(prover.publisher[0]).toBe('0x1234567890123456789012345678901234567890123456789012345678901234');
+    } else {
+      expect(typeof prover.publisher === 'string').toBe(true);
+      expect(prover.publisher).toBe('0x1234567890123456789012345678901234567890123456789012345678901234');
+    }
   });
 
   it('should validate prover with mnemonic publisher example', () => {
@@ -103,7 +117,7 @@ describe('Keystore Schema Validation', () => {
     expect(prover.id.equals(EthAddress.fromString('0x1234567890123456789012345678901234567890'))).toBeTruthy();
 
     const mnemonic = 'test test test test test test test test test test test junk';
-    const publisher: EthMnemonicConfig = prover.publisher as EthMnemonicConfig;
+    const publisher: MnemonicConfig = prover.publisher as MnemonicConfig;
     expect(publisher.mnemonic).toBe(mnemonic);
     expect(publisher.addressCount).toBe(3);
   });

--- a/yarn-project/node-keystore/src/types.ts
+++ b/yarn-project/node-keystore/src/types.ts
@@ -12,10 +12,13 @@ import type { AztecAddress } from '@aztec/stdlib/aztec-address';
 export type Hex<TByteLength extends number> = `0x${string}` & { readonly _length: TByteLength };
 
 /** A json keystore config points to a local file with the encrypted private key, and may require a password for decrypting it */
-export type EthJsonKeyFileV3Config = { path: string; password?: string };
+export type JsonKeyFileV3Config = { path: string; password?: string };
 
 /** A private key is a 32-byte 0x-prefixed hex */
 export type EthPrivateKey = Hex<32>;
+
+/** A BLS private key is a 32-byte 0x-prefixed hex */
+export type BLSPrivateKey = Hex<32>;
 
 /** URL type for remote signers */
 export type Url = string;
@@ -39,16 +42,16 @@ export type EthRemoteSignerAccount =
   | EthAddress
   | {
       address: EthAddress;
-      remoteSignerUrl?: Url;
+      remoteSignerUrl: Url;
       certPath?: string;
       certPass?: string;
     };
 
 /** An L1 account is a private key, a remote signer configuration, or a standard json key store file */
-export type EthAccount = EthPrivateKey | EthRemoteSignerAccount | EthJsonKeyFileV3Config;
+export type EthAccount = EthPrivateKey | EthRemoteSignerAccount | JsonKeyFileV3Config;
 
 /** A mnemonic can be used to define a set of accounts */
-export type EthMnemonicConfig = {
+export type MnemonicConfig = {
   mnemonic: string;
   addressIndex?: number;
   accountIndex?: number;
@@ -57,7 +60,7 @@ export type EthMnemonicConfig = {
 };
 
 /** One or more L1 accounts */
-export type EthAccounts = EthAccount | EthAccount[] | EthMnemonicConfig;
+export type EthAccounts = EthAccount | EthAccount[] | MnemonicConfig;
 
 export type ProverKeyStoreWithId = {
   /** Address that identifies the prover. This address will receive the rewards. */
@@ -68,12 +71,21 @@ export type ProverKeyStoreWithId = {
 
 export type ProverKeyStore = ProverKeyStoreWithId | EthAccount;
 
+/** A BLS account is either a private key, or a standard json key store file */
+export type BLSAccount = BLSPrivateKey | JsonKeyFileV3Config;
+
+/** An AttesterAccount is a combined EthAccount and optional BLSAccount */
+export type AttesterAccount = { eth: EthAccount; bls?: BLSAccount } | EthAccount;
+
+/** One or more attester accounts combining ETH and BLS keys */
+export type AttesterAccounts = AttesterAccount | AttesterAccount[] | MnemonicConfig;
+
 export type ValidatorKeyStore = {
   /**
    * One or more validator attester keys to handle in this configuration block.
    * An attester address may only appear once across all configuration blocks across all keystore files.
    */
-  attester: EthAccounts;
+  attester: AttesterAccounts;
   /**
    * Coinbase address to use when proposing an L2 block as any of the validators in this configuration block.
    * Falls back to the attester address if not set.

--- a/yarn-project/node-keystore/src/validation.test.ts
+++ b/yarn-project/node-keystore/src/validation.test.ts
@@ -61,6 +61,35 @@ describe('Keystore Duplication Validation', () => {
     expect(() => mergeKeystores([keystore1, keystore2])).toThrow(/Multiple prover configurations found/);
   });
 
+  it('should reject duplicate ETH attester across keystores even if BLS differs', () => {
+    const eth = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' as any;
+    const bls1 = '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' as any;
+    const bls2 = '0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc' as any;
+
+    const keystore1: KeyStore = {
+      schemaVersion: 1,
+      validators: [
+        {
+          attester: { eth, bls: bls1 } as any,
+          feeRecipient: '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef' as any,
+        },
+      ],
+    };
+
+    const keystore2: KeyStore = {
+      schemaVersion: 1,
+      validators: [
+        {
+          attester: { eth, bls: bls2 } as any, // same eth, different bls
+          feeRecipient: '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef' as any,
+        },
+      ],
+    };
+
+    expect(() => mergeKeystores([keystore1, keystore2])).toThrow(KeyStoreLoadError);
+    expect(() => mergeKeystores([keystore1, keystore2])).toThrow(/Duplicate attester address/);
+  });
+
   it('should allow unique attester addresses across keystores', () => {
     logger.info('Testing unique attester addresses');
 


### PR DESCRIPTION
Adds BLS key parsing and structure as well as other naming changes to the keystore as per https://github.com/AztecProtocol/engineering-designs/pull/83/files.

This PR does not include BLS signing only the structure. 

- modifies EthRemoteSignerAccount to require remote signer url and update relevant tests
- adds BLS key parsing and structure support with tests
- enforces new name changes to the keystore types
