### PR TITLE
chore(docs): Remove flamegraph from counter tutorial

### DIFF
--- a/docs/docs/developers/docs/tutorials/contract_tutorials/counter_contract.md
+++ b/docs/docs/developers/docs/tutorials/contract_tutorials/counter_contract.md
@@ -141,26 +141,6 @@ aztec codegen -o src/artifacts target
 
 You can now use the artifact and/or the TS class in your Aztec.js!
 
-## Investigate the `increment` function
-
-Private functions in Aztec contracts are executed client-side, to maintain privacy. Developers need to be mindful of how computationally expensive it is to generate client side proofs for the private functions in the contract they write. To help understand the cost, we can use the Aztec flamegraph tool. The tool takes a contract artifact and function and generates an SVG file that shows the constraint count of each step in the function.
-
-Run it for the `increment` function:
-
-```bash
-SERVE=1 aztec flamegraph target/counter-Counter.json increment
-```
-
-`SERVE=1` will start a local server to view the flamegraph in the browser. You can also run it without this flag and open the generated SVG file in your browser manually.
-
-<Image img={require('/img/flamegraph-counter.png')} />
-
-Note the total gate count at the bottom of the image. The image is interactive; you can hover over different parts of the graph to see the full function name of the execution step and its gate count. This tool also provides insight into the low-level operations that are performed in the private function. Don't worry about the details of the internals of the function right now, just be aware that the more complex the function, the more gates it will use and try out the flamegraph tool on your own functions.
-
-Read more about [profiling transactions with the flamegraph tool](../../guides/smart_contracts/advanced/how_to_profile_transactions.md).
-
-For more information about writing efficient private functions, see [this page](https://noir-lang.org/docs/explainers/explainer-writing-noir) of the Noir documentation.
-
 ## Next Steps
 
 ### Optional: Learn more about concepts mentioned here


### PR DESCRIPTION
Flamegraph is broken in recent versions of Aztec.nr, so removing this section of the tutorial
