### PR TITLE
fix(docs): Remove unnecessary argument from bootstrap script command

### DIFF
--- a/docs/bootstrap.sh
+++ b/docs/bootstrap.sh
@@ -58,7 +58,7 @@ case "$cmd" in
     git clean -fdx
     ;;
   "ci")
-    DOCS_WORKING_DIR="$(pwd)" ../noir-projects/noir-contracts/bootstrap.sh compile --
+    DOCS_WORKING_DIR="$(pwd)" ../noir-projects/noir-contracts/bootstrap.sh compile
     build_docs
     test
     ;;


### PR DESCRIPTION
Simplifies the command in the bootstrap script by removing an extraneous argument from the call to compile the noir contracts.
