### PR TITLE
feat: Store and metrics for L1 tx utils

### DIFF
--- a/yarn-project/cli/src/cmds/l1/update_l1_validators.ts
+++ b/yarn-project/cli/src/cmds/l1/update_l1_validators.ts
@@ -97,7 +97,7 @@ export async function addL1Validator({
 
   const registrationTuple = await gse.makeRegistrationTuple(blsSecretKey);
 
-  const l1TxUtils = createL1TxUtilsFromViemWallet(l1Client, debugLogger);
+  const l1TxUtils = createL1TxUtilsFromViemWallet(l1Client, { logger: debugLogger });
   const proofParamsObj = ZkPassportProofParams.fromBuffer(proofParams);
   const merkleProofArray = merkleProof.map(proof => addLeadingHex(proof));
 
@@ -173,7 +173,7 @@ export async function addL1ValidatorViaRollup({
 
   const registrationTuple = await gse.makeRegistrationTuple(blsSecretKey);
 
-  const l1TxUtils = createL1TxUtilsFromViemWallet(l1Client, debugLogger);
+  const l1TxUtils = createL1TxUtilsFromViemWallet(l1Client, { logger: debugLogger });
 
   const { receipt } = await l1TxUtils.sendAndMonitorTransaction({
     to: rollupAddress.toString(),
@@ -220,7 +220,7 @@ export async function removeL1Validator({
   const account = getAccount(privateKey, mnemonic);
   const chain = createEthereumChain(rpcUrls, chainId);
   const l1Client = createExtendedL1Client(rpcUrls, account, chain.chainInfo);
-  const l1TxUtils = createL1TxUtilsFromViemWallet(l1Client, debugLogger);
+  const l1TxUtils = createL1TxUtilsFromViemWallet(l1Client, { logger: debugLogger });
 
   dualLog(`Removing validator ${validatorAddress.toString()} from rollup ${rollupAddress.toString()}`);
   const { receipt } = await l1TxUtils.sendAndMonitorTransaction({
@@ -247,7 +247,7 @@ export async function pruneRollup({
   const account = getAccount(privateKey, mnemonic);
   const chain = createEthereumChain(rpcUrls, chainId);
   const l1Client = createExtendedL1Client(rpcUrls, account, chain.chainInfo);
-  const l1TxUtils = createL1TxUtilsFromViemWallet(l1Client, debugLogger);
+  const l1TxUtils = createL1TxUtilsFromViemWallet(l1Client, { logger: debugLogger });
 
   dualLog(`Trying prune`);
   const { receipt } = await l1TxUtils.sendAndMonitorTransaction({

--- a/yarn-project/end-to-end/src/e2e_l1_publisher/e2e_l1_publisher.test.ts
+++ b/yarn-project/end-to-end/src/e2e_l1_publisher/e2e_l1_publisher.test.ts
@@ -223,7 +223,7 @@ describe('L1Publisher integration', () => {
     await worldStateSynchronizer.start();
 
     const sequencerL1Client = createExtendedL1Client(config.l1RpcUrls, sequencerPK, foundry);
-    const l1TxUtils = createL1TxUtilsWithBlobsFromViemWallet(sequencerL1Client, logger, dateProvider, config);
+    const l1TxUtils = createL1TxUtilsWithBlobsFromViemWallet(sequencerL1Client, { logger, dateProvider }, config);
     const rollupContract = new RollupContract(sequencerL1Client, l1ContractAddresses.rollupAddress.toString());
     const slashingProposerContract = await rollupContract.getSlashingProposer();
     governanceProposerContract = new GovernanceProposerContract(

--- a/yarn-project/end-to-end/src/e2e_p2p/slash_veto_demo.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/slash_veto_demo.test.ts
@@ -112,7 +112,10 @@ describe('veto slash', () => {
       t.ctx.aztecNodeConfig.l1RpcUrls,
       bufferToHex(getPrivateKeyFromIndex(VETOER_PRIVATE_KEY_INDEX)!),
     );
-    vetoerL1TxUtils = createL1TxUtilsFromViemWallet(vetoerL1Client, t.logger, t.ctx.dateProvider);
+    vetoerL1TxUtils = createL1TxUtilsFromViemWallet(vetoerL1Client, {
+      logger: t.logger,
+      dateProvider: t.ctx.dateProvider,
+    });
 
     ({ rollup } = await t.getContracts());
 
@@ -193,7 +196,10 @@ describe('veto slash', () => {
     }
 
     debugLogger.info(`\n\ninitializing slasher with proposer: ${proposer}\n\n`);
-    const txUtils = createL1TxUtilsFromViemWallet(deployerClient, t.logger, t.ctx.dateProvider);
+    const txUtils = createL1TxUtilsFromViemWallet(deployerClient, {
+      logger: t.logger,
+      dateProvider: t.ctx.dateProvider,
+    });
     await txUtils.sendAndMonitorTransaction({
       to: slasher.toString(),
       data: encodeFunctionData({

--- a/yarn-project/end-to-end/src/e2e_synching.test.ts
+++ b/yarn-project/end-to-end/src/e2e_synching.test.ts
@@ -411,8 +411,7 @@ describe('e2e_synching', () => {
 
     const l1TxUtils = createL1TxUtilsWithBlobsFromViemWallet(
       deployL1ContractsValues.l1Client,
-      logger,
-      dateProvider!,
+      { logger, dateProvider: dateProvider! },
       config,
     );
     const rollupAddress = deployL1ContractsValues.l1ContractAddresses.rollupAddress.toString();

--- a/yarn-project/ethereum/src/contracts/fee_asset_handler.test.ts
+++ b/yarn-project/ethereum/src/contracts/fee_asset_handler.test.ts
@@ -49,7 +49,7 @@ describe('FeeAssetHandler', () => {
     });
     // Since the registry cannot "see" the slash factory, we omit it from the addresses for this test
     const deployedAddresses = omit(deployed.l1ContractAddresses, 'slashFactoryAddress');
-    const txUtils = createL1TxUtilsFromViemWallet(l1Client, logger);
+    const txUtils = createL1TxUtilsFromViemWallet(l1Client, { logger });
     feeAssetHandler = new FeeAssetHandlerContract(deployedAddresses.feeAssetHandlerAddress!.toString(), txUtils);
     feeAsset = getContract({
       address: deployedAddresses.feeJuiceAddress!.toString(),

--- a/yarn-project/ethereum/src/contracts/governance.ts
+++ b/yarn-project/ethereum/src/contracts/governance.ts
@@ -187,7 +187,7 @@ export class GovernanceContract extends ReadOnlyGovernanceContract {
     retries: number;
     logger: Logger;
   }) {
-    const l1TxUtils = createL1TxUtilsFromViemWallet(this.client, logger);
+    const l1TxUtils = createL1TxUtilsFromViemWallet(this.client, { logger });
     const retryDelaySeconds = 12;
 
     voteAmount = voteAmount ?? (await this.getPower());
@@ -244,7 +244,7 @@ export class GovernanceContract extends ReadOnlyGovernanceContract {
     retries: number;
     logger: Logger;
   }) {
-    const l1TxUtils = createL1TxUtilsFromViemWallet(this.client, logger);
+    const l1TxUtils = createL1TxUtilsFromViemWallet(this.client, { logger });
     const retryDelaySeconds = 12;
     let success = false;
     for (let i = 0; i < retries; i++) {

--- a/yarn-project/ethereum/src/contracts/multicall.test.ts
+++ b/yarn-project/ethereum/src/contracts/multicall.test.ts
@@ -66,7 +66,7 @@ describe('Multicall3', () => {
       client: walletClient,
     });
 
-    l1TxUtils = createL1TxUtilsFromViemWallet(walletClient, logger);
+    l1TxUtils = createL1TxUtilsFromViemWallet(walletClient, { logger });
 
     const addMinterHash = await tokenContract.write.addMinter([MULTI_CALL_3_ADDRESS], { account: privateKey });
     await walletClient.waitForTransactionReceipt({ hash: addMinterHash });

--- a/yarn-project/ethereum/src/deploy_l1_contracts.ts
+++ b/yarn-project/ethereum/src/deploy_l1_contracts.ts
@@ -1473,10 +1473,8 @@ export class L1Deployer {
     this.salt = maybeSalt ? padHex(numberToHex(maybeSalt), { size: 32 }) : undefined;
     this.l1TxUtils = createL1TxUtilsFromViemWallet(
       this.client,
-      this.logger,
-      dateProvider,
-      this.txUtilsConfig,
-      this.acceleratedTestDeployments,
+      { logger: this.logger, dateProvider },
+      { ...this.txUtilsConfig, debugMaxGasLimit: acceleratedTestDeployments },
     );
   }
 
@@ -1604,7 +1602,11 @@ export async function deployL1Contract(
 
   if (!l1TxUtils) {
     const config = getL1TxUtilsConfigEnvVars();
-    l1TxUtils = createL1TxUtilsFromViemWallet(extendedClient, logger, undefined, config, acceleratedTestDeployments);
+    l1TxUtils = createL1TxUtilsFromViemWallet(
+      extendedClient,
+      { logger },
+      { ...config, debugMaxGasLimit: acceleratedTestDeployments },
+    );
   }
 
   if (libraries) {

--- a/yarn-project/ethereum/src/l1_tx_utils/index.ts
+++ b/yarn-project/ethereum/src/l1_tx_utils/index.ts
@@ -1,6 +1,7 @@
 export * from './config.js';
 export * from './constants.js';
 export * from './factory.js';
+export * from './interfaces.js';
 export * from './l1_tx_utils.js';
 export * from './readonly_l1_tx_utils.js';
 export * from './signer.js';

--- a/yarn-project/ethereum/src/l1_tx_utils/interfaces.ts
+++ b/yarn-project/ethereum/src/l1_tx_utils/interfaces.ts
@@ -1,0 +1,86 @@
+import type { L1BlobInputs, L1TxState } from './types.js';
+
+/**
+ * Interface for L1 transaction state storage.
+ * Implementations handle persistence of transaction states across restarts.
+ */
+export interface IL1TxStore {
+  /**
+   * Gets the next available state ID for an account.
+   */
+  consumeNextStateId(account: string): Promise<number>;
+
+  /**
+   * Saves a single transaction state for a specific account.
+   * Does not save blob data (see saveBlobs).
+   * @param account - The sender account address
+   * @param state - Transaction state to save
+   */
+  saveState(account: string, state: L1TxState): Promise<L1TxState>;
+
+  /**
+   * Saves blobs for a given state.
+   * @param account - The sender account address
+   * @param stateId - The state ID
+   * @param blobInputs - Blob inputs to save
+   */
+  saveBlobs(account: string, stateId: number, blobInputs: L1BlobInputs | undefined): Promise<void>;
+
+  /**
+   * Loads all transaction states for a specific account.
+   * @param account - The sender account address
+   * @returns Array of transaction states with their IDs
+   */
+  loadStates(account: string): Promise<L1TxState[]>;
+
+  /**
+   * Loads a single state by ID.
+   * @param account - The sender account address
+   * @param stateId - The state ID
+   * @returns The transaction state or undefined if not found
+   */
+  loadState(account: string, stateId: number): Promise<L1TxState | undefined>;
+
+  /**
+   * Deletes a specific state and its associated blobs.
+   * @param account - The sender account address
+   * @param stateId - The state ID to delete
+   */
+  deleteState(account: string, stateId: number): Promise<void>;
+
+  /**
+   * Clears all transaction states for a specific account.
+   * @param account - The sender account address
+   */
+  clearStates(account: string): Promise<void>;
+
+  /**
+   * Gets all accounts that have stored states.
+   * @returns Array of account addresses
+   */
+  getAllAccounts(): Promise<string[]>;
+
+  /**
+   * Closes the store.
+   */
+  close(): Promise<void>;
+}
+
+/**
+ * Interface for L1 transaction metrics recording.
+ * Implementations handle tracking of transaction lifecycle and gas costs.
+ */
+export interface IL1TxMetrics {
+  /**
+   * Records metrics when a transaction is mined
+   * @param state - The L1 transaction state
+   * @param l1Timestamp - The current L1 timestamp
+   */
+  recordMinedTx(state: L1TxState, l1Timestamp: Date): void;
+
+  /**
+   * Records metrics when a transaction is dropped
+   * @param state - The L1 transaction state
+   */
+  recordDroppedTx(state: L1TxState): void;
+}

--- a/yarn-project/ethereum/src/l1_tx_utils/readonly_l1_tx_utils.ts
+++ b/yarn-project/ethereum/src/l1_tx_utils/readonly_l1_tx_utils.ts
@@ -39,7 +39,7 @@ export class ReadOnlyL1TxUtils {
 
   constructor(
     public client: ViemClient,
-    protected logger: Logger = createLogger('ReadOnlyL1TxUtils'),
+    protected logger: Logger = createLogger('ethereum:readonly-l1-utils'),
     public readonly dateProvider: DateProvider,
     config?: Partial<L1TxUtilsConfig>,
     protected debugMaxGasLimit: boolean = false,

--- a/yarn-project/ethereum/src/l1_tx_utils/types.ts
+++ b/yarn-project/ethereum/src/l1_tx_utils/types.ts
@@ -50,6 +50,7 @@ export enum TxUtilsState {
 export const TerminalTxUtilsState = [TxUtilsState.IDLE, TxUtilsState.MINED, TxUtilsState.NOT_MINED];
 
 export type L1TxState = {
+  id: number;
   txHashes: Hex[];
   cancelTxHashes: Hex[];
   gasLimit: bigint;

--- a/yarn-project/ethereum/src/publisher_manager.ts
+++ b/yarn-project/ethereum/src/publisher_manager.ts
@@ -40,6 +40,11 @@ export class PublisherManager<UtilsType extends L1TxUtils = L1TxUtils> {
     this.config = pick(config, 'publisherAllowInvalidStates');
   }
 
+  /** Loads the state of all publishers and resumes monitoring any pending txs */
+  public async loadState(): Promise<void> {
+    await Promise.all(this.publishers.map(pub => pub.loadStateAndResumeMonitoring()));
+  }
+
   // Finds and prioritises available publishers based on
   // 1. Validity as per the provided filter function
   // 2. Validity based on the state the publisher is in

--- a/yarn-project/node-lib/package.json
+++ b/yarn-project/node-lib/package.json
@@ -4,7 +4,10 @@
   "type": "module",
   "exports": {
     "./actions": "./dest/actions/index.js",
-    "./config": "./dest/config/index.js"
+    "./config": "./dest/config/index.js",
+    "./factories": "./dest/factories/index.js",
+    "./metrics": "./dest/metrics/index.js",
+    "./stores": "./dest/stores/index.js"
   },
   "inherits": [
     "../package.common.json"
@@ -75,6 +78,7 @@
     "tslib": "^2.4.0"
   },
   "devDependencies": {
+    "@aztec/blob-lib": "workspace:^",
     "@jest/globals": "^30.0.0",
     "@types/jest": "^30.0.0",
     "@types/node": "^22.15.17",

--- a/yarn-project/node-lib/src/factories/index.ts
+++ b/yarn-project/node-lib/src/factories/index.ts
@@ -1,0 +1,1 @@
+export * from './l1_tx_utils.js';

--- a/yarn-project/node-lib/src/factories/l1_tx_utils.ts
+++ b/yarn-project/node-lib/src/factories/l1_tx_utils.ts
@@ -1,0 +1,122 @@
+import {
+  createL1TxUtilsFromEthSigner as createL1TxUtilsFromEthSignerBase,
+  createL1TxUtilsFromViemWallet as createL1TxUtilsFromViemWalletBase,
+} from '@aztec/ethereum';
+import type { EthSigner, ExtendedViemWalletClient, L1TxUtilsConfig, ViemClient } from '@aztec/ethereum';
+import {
+  createL1TxUtilsWithBlobsFromEthSigner as createL1TxUtilsWithBlobsFromEthSignerBase,
+  createL1TxUtilsWithBlobsFromViemWallet as createL1TxUtilsWithBlobsFromViemWalletBase,
+} from '@aztec/ethereum/l1-tx-utils-with-blobs';
+import { omit } from '@aztec/foundation/collection';
+import { createLogger } from '@aztec/foundation/log';
+import type { DateProvider } from '@aztec/foundation/timer';
+import type { DataStoreConfig } from '@aztec/kv-store/config';
+import { createStore } from '@aztec/kv-store/lmdb-v2';
+import type { TelemetryClient } from '@aztec/telemetry-client';
+
+import type { L1TxScope } from '../metrics/l1_tx_metrics.js';
+import { L1TxMetrics } from '../metrics/l1_tx_metrics.js';
+import { L1TxStore } from '../stores/l1_tx_store.js';
+
+const L1_TX_STORE_NAME = 'l1-tx-utils';
+
+/**
+ * Creates shared dependencies (logger, store, metrics) for L1TxUtils instances.
+ */
+async function createSharedDeps(
+  config: DataStoreConfig & { scope?: L1TxScope },
+  deps: {
+    telemetry: TelemetryClient;
+    logger?: ReturnType<typeof createLogger>;
+    dateProvider?: DateProvider;
+  },
+) {
+  const logger = deps.logger ?? createLogger('l1-tx-utils');
+
+  // Note that we do NOT bind them to the rollup address, since we still need to
+  // monitor and cancel txs for previous rollups to free up our nonces.
+  const noRollupConfig = omit(config, 'l1Contracts');
+  const kvStore = await createStore(L1_TX_STORE_NAME, L1TxStore.SCHEMA_VERSION, noRollupConfig, logger);
+  const store = new L1TxStore(kvStore, logger);
+
+  const meter = deps.telemetry.getMeter('L1TxUtils');
+  const metrics = new L1TxMetrics(meter, config.scope ?? 'other', logger);
+
+  return { logger, store, metrics, dateProvider: deps.dateProvider };
+}
+
+/**
+ * Creates L1TxUtils with blobs from multiple Viem wallets, sharing store and metrics.
+ */
+export async function createL1TxUtilsWithBlobsFromViemWallet(
+  clients: ExtendedViemWalletClient[],
+  config: DataStoreConfig & Partial<L1TxUtilsConfig> & { debugMaxGasLimit?: boolean; scope?: L1TxScope },
+  deps: {
+    telemetry: TelemetryClient;
+    logger?: ReturnType<typeof createLogger>;
+    dateProvider?: DateProvider;
+  },
+) {
+  const sharedDeps = await createSharedDeps(config, deps);
+
+  return clients.map(client =>
+    createL1TxUtilsWithBlobsFromViemWalletBase(client, sharedDeps, config, config.debugMaxGasLimit),
+  );
+}
+
+/**
+ * Creates L1TxUtils with blobs from multiple EthSigners, sharing store and metrics.
+ */
+export async function createL1TxUtilsWithBlobsFromEthSigner(
+  client: ViemClient,
+  signers: EthSigner[],
+  config: DataStoreConfig & Partial<L1TxUtilsConfig> & { debugMaxGasLimit?: boolean; scope?: L1TxScope },
+  deps: {
+    telemetry: TelemetryClient;
+    logger?: ReturnType<typeof createLogger>;
+    dateProvider?: DateProvider;
+  },
+) {
+  const sharedDeps = await createSharedDeps(config, deps);
+
+  return signers.map(signer =>
+    createL1TxUtilsWithBlobsFromEthSignerBase(client, signer, sharedDeps, config, config.debugMaxGasLimit),
+  );
+}
+
+/**
+ * Creates L1TxUtils (without blobs) from multiple Viem wallets, sharing store and metrics.
+ */
+export async function createL1TxUtilsFromViemWalletWithStore(
+  clients: ExtendedViemWalletClient[],
+  config: DataStoreConfig & Partial<L1TxUtilsConfig> & { debugMaxGasLimit?: boolean; scope?: L1TxScope },
+  deps: {
+    telemetry: TelemetryClient;
+    logger?: ReturnType<typeof createLogger>;
+    dateProvider?: DateProvider;
+    scope?: L1TxScope;
+  },
+) {
+  const sharedDeps = await createSharedDeps(config, deps);
+
+  return clients.map(client => createL1TxUtilsFromViemWalletBase(client, sharedDeps, config));
+}
+
+/**
+ * Creates L1TxUtils (without blobs) from multiple EthSigners, sharing store and metrics.
+ */
+export async function createL1TxUtilsFromEthSignerWithStore(
+  client: ViemClient,
+  signers: EthSigner[],
+  config: DataStoreConfig & Partial<L1TxUtilsConfig> & { debugMaxGasLimit?: boolean; scope?: L1TxScope },
+  deps: {
+    telemetry: TelemetryClient;
+    logger?: ReturnType<typeof createLogger>;
+    dateProvider?: DateProvider;
+    scope?: L1TxScope;
+  },
+) {
+  const sharedDeps = await createSharedDeps(config, deps);
+
+  return signers.map(signer => createL1TxUtilsFromEthSignerBase(client, signer, sharedDeps, config));
+}

--- a/yarn-project/node-lib/src/metrics/index.ts
+++ b/yarn-project/node-lib/src/metrics/index.ts
@@ -1,0 +1,1 @@
+export * from './l1_tx_metrics.js';

--- a/yarn-project/node-lib/src/metrics/l1_tx_metrics.ts
+++ b/yarn-project/node-lib/src/metrics/l1_tx_metrics.ts
@@ -1,0 +1,169 @@
+import type { IL1TxMetrics, L1TxState } from '@aztec/ethereum';
+import { TxUtilsState } from '@aztec/ethereum';
+import { createLogger } from '@aztec/foundation/log';
+import {
+  Attributes,
+  type Histogram,
+  type Meter,
+  Metrics,
+  type UpDownCounter,
+  ValueType,
+} from '@aztec/telemetry-client';
+
+export type L1TxScope = 'sequencer' | 'prover' | 'other';
+
+/**
+ * Metrics for L1 transaction utils tracking tx lifecycle and gas costs.
+ */
+export class L1TxMetrics implements IL1TxMetrics {
+  // Time until tx is mined
+  private txMinedDuration: Histogram;
+
+  // Number of attempts until mined
+  private txAttemptsUntilMined: Histogram;
+
+  // Counters for end states
+  private txMinedCount: UpDownCounter;
+  private txRevertedCount: UpDownCounter;
+  private txCancelledCount: UpDownCounter;
+  private txNotMinedCount: UpDownCounter;
+
+  // Gas price histograms (at end state, in wei)
+  private maxPriorityFeeHistogram: Histogram;
+  private maxFeeHistogram: Histogram;
+  private blobFeeHistogram: Histogram;
+
+  constructor(
+    private meter: Meter,
+    private scope: L1TxScope = 'other',
+    private logger = createLogger('l1-tx-utils:metrics'),
+  ) {
+    this.txMinedDuration = this.meter.createHistogram(Metrics.L1_TX_MINED_DURATION, {
+      description: 'Time from initial tx send until mined',
+      unit: 's',
+      valueType: ValueType.INT,
+    });
+
+    this.txAttemptsUntilMined = this.meter.createHistogram(Metrics.L1_TX_ATTEMPTS_UNTIL_MINED, {
+      description: 'Number of tx attempts (including speed-ups) until mined',
+      unit: 'attempts',
+      valueType: ValueType.INT,
+    });
+
+    this.txMinedCount = this.meter.createUpDownCounter(Metrics.L1_TX_MINED_COUNT, {
+      description: 'Count of transactions successfully mined',
+      valueType: ValueType.INT,
+    });
+
+    this.txRevertedCount = this.meter.createUpDownCounter(Metrics.L1_TX_REVERTED_COUNT, {
+      description: 'Count of transactions that reverted',
+      valueType: ValueType.INT,
+    });
+
+    this.txCancelledCount = this.meter.createUpDownCounter(Metrics.L1_TX_CANCELLED_COUNT, {
+      description: 'Count of transactions cancelled',
+      valueType: ValueType.INT,
+    });
+
+    this.txNotMinedCount = this.meter.createUpDownCounter(Metrics.L1_TX_NOT_MINED_COUNT, {
+      description: 'Count of transactions not mined (timed out)',
+      valueType: ValueType.INT,
+    });
+
+    this.maxPriorityFeeHistogram = this.meter.createHistogram(Metrics.L1_TX_MAX_PRIORITY_FEE, {
+      description: 'Max priority fee per gas at tx end state (in wei)',
+      unit: 'wei',
+      valueType: ValueType.INT,
+    });
+
+    this.maxFeeHistogram = this.meter.createHistogram(Metrics.L1_TX_MAX_FEE, {
+      description: 'Max fee per gas at tx end state (in wei)',
+      unit: 'wei',
+      valueType: ValueType.INT,
+    });
+
+    this.blobFeeHistogram = this.meter.createHistogram(Metrics.L1_TX_BLOB_FEE, {
+      description: 'Max fee per blob gas at tx end state (in wei)',
+      unit: 'wei',
+      valueType: ValueType.INT,
+    });
+  }
+
+  /**
+   * Records metrics when a transaction is mined.
+   * @param state - The L1 transaction state
+   * @param l1Timestamp - The current L1 timestamp
+   */
+  public recordMinedTx(state: L1TxState, l1Timestamp: Date): void {
+    if (state.status !== TxUtilsState.MINED) {
+      this.logger.warn(
+        `Attempted to record mined tx metrics for a tx not in MINED state (state: ${TxUtilsState[state.status]})`,
+        { scope: this.scope, nonce: state.nonce },
+      );
+      return;
+    }
+
+    const attributes = { [Attributes.L1_TX_SCOPE]: this.scope };
+    const isCancelTx = state.cancelTxHashes.length > 0;
+    const isReverted = state.receipt?.status === 'reverted';
+
+    if (isCancelTx) {
+      this.txCancelledCount.add(1, attributes);
+    } else if (isReverted) {
+      this.txRevertedCount.add(1, attributes);
+    } else {
+      this.txMinedCount.add(1, attributes);
+    }
+
+    // Record time to mine using provided L1 timestamp
+    const duration = Math.floor((l1Timestamp.getTime() - state.sentAtL1Ts.getTime()) / 1000);
+    this.txMinedDuration.record(duration, attributes);
+
+    // Record number of attempts until mined
+    const attempts = isCancelTx ? state.cancelTxHashes.length : state.txHashes.length;
+    this.txAttemptsUntilMined.record(attempts, attributes);
+
+    // Record gas prices at end state (in wei as integers)
+    const maxPriorityFeeWei = Number(state.gasPrice.maxPriorityFeePerGas);
+    const maxFeeWei = Number(state.gasPrice.maxFeePerGas);
+    const blobFeeWei = state.gasPrice.maxFeePerBlobGas ? Number(state.gasPrice.maxFeePerBlobGas) : undefined;
+
+    this.maxPriorityFeeHistogram.record(maxPriorityFeeWei, attributes);
+    this.maxFeeHistogram.record(maxFeeWei, attributes);
+
+    // Record blob fee if present (in wei as integer)
+    if (blobFeeWei !== undefined) {
+      this.blobFeeHistogram.record(blobFeeWei, attributes);
+    }
+
+    this.logger.debug(`Recorded tx end state metrics`, {
+      status: TxUtilsState[state.status],
+      nonce: state.nonce,
+      isCancelTx,
+      isReverted,
+      scope: this.scope,
+      maxPriorityFeeWei,
+      maxFeeWei,
+      blobFeeWei,
+    });
+  }
+
+  public recordDroppedTx(state: L1TxState): void {
+    if (state.status !== TxUtilsState.NOT_MINED) {
+      this.logger.warn(
+        `Attempted to record dropped tx metrics for a tx not in NOT_MINED state (state: ${TxUtilsState[state.status]})`,
+        { scope: this.scope, nonce: state.nonce },
+      );
+      return;
+    }
+
+    const attributes = { [Attributes.L1_TX_SCOPE]: this.scope };
+    this.txNotMinedCount.add(1, attributes);
+
+    this.logger.debug(`Recorded tx dropped metrics`, {
+      status: TxUtilsState[state.status],
+      nonce: state.nonce,
+      scope: this.scope,
+    });
+  }
+}

--- a/yarn-project/node-lib/src/stores/index.ts
+++ b/yarn-project/node-lib/src/stores/index.ts
@@ -1,0 +1,1 @@
+export * from './l1_tx_store.js';

--- a/yarn-project/node-lib/src/stores/l1_tx_store.test.ts
+++ b/yarn-project/node-lib/src/stores/l1_tx_store.test.ts
@@ -1,0 +1,449 @@
+import { Blob } from '@aztec/blob-lib';
+import { type L1TxState, TxUtilsState } from '@aztec/ethereum';
+import { omit } from '@aztec/foundation/collection';
+import type { AztecAsyncKVStore } from '@aztec/kv-store';
+import { openTmpStore } from '@aztec/kv-store/lmdb-v2';
+
+import type { Hex } from 'viem';
+
+import { L1TxStore } from './l1_tx_store.js';
+
+describe('L1TxStore', () => {
+  let store: L1TxStore;
+  let kvStore: AztecAsyncKVStore;
+  let count = 0;
+
+  beforeEach(async () => {
+    kvStore = await openTmpStore(`l1-tx-store-test-${count++}`, true);
+    store = new L1TxStore(kvStore);
+  });
+
+  afterEach(async () => {
+    await store.close();
+    if (kvStore) {
+      await kvStore.close();
+    }
+  });
+
+  const createMockState = (nonce: number, status: TxUtilsState = TxUtilsState.SENT): L1TxState => {
+    const now = new Date();
+    return {
+      id: nonce,
+      txHashes: [`0xabc${nonce}` as Hex],
+      cancelTxHashes: [],
+      gasLimit: 21000n,
+      gasPrice: {
+        maxFeePerGas: 1000000000n,
+        maxPriorityFeePerGas: 1000000n,
+      },
+      txConfigOverrides: {},
+      request: {
+        to: '0x1234567890123456789012345678901234567890' as `0x${string}`,
+        data: '0x' as `0x${string}`,
+        value: 0n,
+      },
+      status,
+      nonce,
+      sentAtL1Ts: now,
+      lastSentAtL1Ts: now,
+      blobInputs: undefined,
+    };
+  };
+
+  describe('saveState and loadStates', () => {
+    it('should save and load transaction states for an account', async () => {
+      const account = '0xabc123';
+      const state1 = createMockState(1);
+      const state2 = createMockState(2);
+
+      await store.saveState(account, state1);
+      await store.saveState(account, state2);
+
+      const loaded = await store.loadStates(account);
+      expect(loaded).toHaveLength(2);
+      expect(loaded[0].nonce).toBe(1);
+      expect(loaded[1].nonce).toBe(2);
+      expect(loaded[0].gasLimit).toBe(21000n);
+      expect(loaded[0].id).toBe(1);
+      expect(loaded[1].id).toBe(2);
+    });
+
+    it('should return empty array for non-existent account', async () => {
+      const loaded = await store.loadStates('0xnonexistent');
+      expect(loaded).toEqual([]);
+    });
+
+    it('should assign auto-incremental IDs to states', async () => {
+      const account = '0xabc123';
+
+      const result1 = await store.saveState(account, createMockState(1));
+      expect(result1.id).toBe(1);
+
+      const result2 = await store.saveState(account, createMockState(2));
+      expect(result2.id).toBe(2);
+
+      const result3 = await store.saveState(account, createMockState(3));
+      expect(result3.id).toBe(3);
+    });
+
+    it('should update existing state when ID is provided', async () => {
+      const account = '0xabc123';
+
+      const result1 = await store.saveState(account, createMockState(1));
+      const stateId = result1.id;
+
+      // Update the same state
+      const updatedState = { ...createMockState(1), status: TxUtilsState.MINED, id: stateId } as L1TxState & {
+        id: number;
+      };
+      await store.saveState(account, updatedState);
+
+      const loaded = await store.loadStates(account);
+      expect(loaded).toHaveLength(1);
+      expect(loaded[0].id).toBe(stateId);
+      expect(loaded[0].status).toBe(TxUtilsState.MINED);
+    });
+
+    it('should correctly serialize and deserialize dates', async () => {
+      const account = '0xabc123';
+      const sentAt = new Date('2024-01-01T00:00:00Z');
+      const lastSentAt = new Date('2024-01-01T00:05:00Z');
+      const state = {
+        ...createMockState(1),
+        sentAtL1Ts: sentAt,
+        lastSentAtL1Ts: lastSentAt,
+      };
+
+      await store.saveState(account, state);
+
+      const loaded = await store.loadStates(account);
+      expect(loaded[0].sentAtL1Ts).toBeInstanceOf(Date);
+      expect(loaded[0].sentAtL1Ts.getTime()).toBe(sentAt.getTime());
+      expect(loaded[0].lastSentAtL1Ts.getTime()).toBe(lastSentAt.getTime());
+    });
+
+    it('should correctly serialize and deserialize bigints', async () => {
+      const account = '0xabc123';
+      const state = createMockState(1);
+      state.gasLimit = 123456789012345n;
+      state.gasPrice.maxFeePerGas = 987654321098765n;
+      state.request.value = 5000000000000000000n;
+
+      await store.saveState(account, state);
+
+      const loaded = await store.loadStates(account);
+      expect(loaded[0].gasLimit).toBe(123456789012345n);
+      expect(loaded[0].gasPrice.maxFeePerGas).toBe(987654321098765n);
+      expect(loaded[0].request.value).toBe(5000000000000000000n);
+    });
+
+    it('should correctly serialize and deserialize blob inputs', async () => {
+      const account = '0xabc123';
+      const blobData = new Uint8Array(131072).fill(1);
+      const kzg = Blob.getViemKzgInstance();
+      const state = createMockState(1);
+      state.blobInputs = {
+        blobs: [blobData],
+        kzg,
+        maxFeePerBlobGas: 1000000n,
+      };
+
+      await store.saveState(account, state);
+      await store.saveBlobs(account, state.id, state.blobInputs);
+
+      const loaded = await store.loadStates(account);
+      expect(loaded[0].blobInputs).toBeDefined();
+      expect(loaded[0].blobInputs!.blobs).toHaveLength(1);
+      expect(loaded[0].blobInputs!.blobs[0]).toEqual(blobData);
+      expect(loaded[0].blobInputs!.maxFeePerBlobGas).toBe(1000000n);
+      expect(loaded[0].blobInputs!.kzg).toBeDefined();
+    });
+
+    it('should handle states with receipts', async () => {
+      const account = '0xabc123';
+      const state = createMockState(1);
+      state.status = TxUtilsState.MINED;
+      state.receipt = {
+        transactionHash: '0xreceipt',
+        blockNumber: 12345n,
+        status: 'success',
+        blockHash: '0xblockhash',
+        cumulativeGasUsed: 21000n,
+        effectiveGasPrice: 50000000000n,
+        from: '0xfromaddress',
+        to: '0xtoaddress',
+        gasUsed: 21000n,
+        logsBloom: '0xlogsbloom',
+        type: 'eip1559',
+        contractAddress: null,
+        logs: [],
+        transactionIndex: 1,
+      };
+      await store.saveState(account, state);
+
+      const loaded = await store.loadStates(account);
+      expect(loaded[0].receipt).toBeDefined();
+      expect(loaded[0].receipt!.transactionHash).toBe('0xreceipt');
+    });
+
+    it('should load all states', async () => {
+      const account = '0xabc123';
+
+      await store.saveState(account, createMockState(1));
+      await store.saveState(account, createMockState(2));
+      await store.saveState(account, createMockState(3));
+      await store.saveState(account, createMockState(4));
+      await store.saveState(account, createMockState(5));
+
+      await store.saveState('0xanother', createMockState(6));
+
+      const loaded = await store.loadStates(account);
+      expect(loaded).toHaveLength(5);
+      expect(loaded[0].id).toBe(1);
+      expect(loaded[1].id).toBe(2);
+      expect(loaded[2].id).toBe(3);
+      expect(loaded[3].id).toBe(4);
+      expect(loaded[4].id).toBe(5);
+    });
+  });
+
+  describe('loadState', () => {
+    it('should load a single state by ID', async () => {
+      const account = '0xabc123';
+
+      const saved = await store.saveState(account, createMockState(1));
+      const loaded = await store.loadState(account, saved.id);
+
+      expect(loaded).toBeDefined();
+      expect(loaded!.id).toBe(saved.id);
+      expect(loaded!.nonce).toBe(1);
+    });
+
+    it('should return undefined for non-existent state ID', async () => {
+      const account = '0xabc123';
+      const loaded = await store.loadState(account, 999);
+      expect(loaded).toBeUndefined();
+    });
+  });
+
+  describe('saveBlobs', () => {
+    it('should save and load blobs separately', async () => {
+      const account = '0xabc123';
+      const blobData = new Uint8Array(131072).fill(1);
+      const kzg = Blob.getViemKzgInstance();
+
+      // Save state without blobs
+      const state = createMockState(1);
+      const saved = await store.saveState(account, state);
+
+      // Save blobs separately
+      const blobInputs = {
+        blobs: [blobData],
+        kzg,
+        maxFeePerBlobGas: 2000000n,
+      };
+      await store.saveBlobs(account, saved.id, blobInputs);
+
+      // Update the state to indicate it has blobs
+      state.blobInputs = blobInputs;
+      await store.saveState(account, { ...state, id: saved.id });
+
+      const loaded = await store.loadState(account, saved.id);
+      expect(loaded!.blobInputs).toBeDefined();
+      expect(loaded!.blobInputs!.blobs[0]).toEqual(blobData);
+    });
+  });
+
+  describe('deleteState', () => {
+    it('should delete a specific state', async () => {
+      const account = '0xabc123';
+
+      const saved1 = await store.saveState(account, createMockState(1));
+      const saved2 = await store.saveState(account, createMockState(2));
+
+      await store.deleteState(account, saved1.id);
+
+      const loaded = await store.loadStates(account);
+      expect(loaded).toHaveLength(1);
+      expect(loaded[0].id).toBe(saved2.id);
+    });
+
+    it('should delete state and associated blobs', async () => {
+      const account = '0xabc123';
+      const blobData = new Uint8Array(131072).fill(1);
+      const kzg = Blob.getViemKzgInstance();
+      const state = createMockState(1);
+      state.blobInputs = {
+        blobs: [blobData],
+        kzg,
+      };
+
+      const saved = await store.saveState(account, state);
+      await store.deleteState(account, saved.id);
+
+      const loaded = await store.loadState(account, saved.id);
+      expect(loaded).toBeUndefined();
+    });
+  });
+
+  describe('clearStates', () => {
+    it('should clear all states for an account', async () => {
+      const account = '0xabc123';
+      await store.saveState(account, createMockState(1));
+      await store.saveState(account, createMockState(2));
+
+      expect(await store.loadStates(account)).toHaveLength(2);
+
+      await store.clearStates(account);
+      expect(await store.loadStates(account)).toHaveLength(0);
+    });
+
+    it('should not throw when clearing non-existent account', async () => {
+      await expect(store.clearStates('0xnonexistent')).resolves.not.toThrow();
+    });
+
+    it('should reset ID counter when clearing states', async () => {
+      const account = '0xabc123';
+      const another = '0xdef456';
+
+      await store.consumeNextStateId(account); // ID 1
+      await store.consumeNextStateId(account); // ID 2
+      await store.consumeNextStateId(another); // ID 1 for another account
+      await store.consumeNextStateId(another); // ID 2 for another account
+      await store.consumeNextStateId(another); // ID 3 for another account
+
+      // Save some states
+      await store.clearStates(account);
+
+      // IDs should start from 1 again
+      expect(await store.consumeNextStateId(account)).toBe(1);
+      expect(await store.consumeNextStateId(another)).toBe(4); // Another account continues its own sequence
+    });
+  });
+
+  describe('getAllAccounts', () => {
+    it('should return empty array when no accounts exist', async () => {
+      const accounts = await store.getAllAccounts();
+      expect(accounts).toEqual([]);
+    });
+
+    it('should return all accounts with stored states', async () => {
+      const account1 = '0xabc123';
+      const account2 = '0xdef456';
+      const account3 = '0x789xyz';
+
+      await store.saveState(account1, createMockState(1));
+      await store.saveState(account2, createMockState(2));
+      await store.saveState(account3, createMockState(3));
+
+      const accounts = await store.getAllAccounts();
+      expect(accounts).toHaveLength(3);
+      expect(accounts).toContain(account1);
+      expect(accounts).toContain(account2);
+      expect(accounts).toContain(account3);
+    });
+  });
+
+  describe('multiple accounts', () => {
+    it('should keep states separate per account', async () => {
+      const account1 = '0xabc123';
+      const account2 = '0xdef456';
+
+      await store.saveState(account1, createMockState(1));
+      await store.saveState(account1, createMockState(2));
+      await store.saveState(account2, createMockState(3));
+      await store.saveState(account2, createMockState(4));
+
+      const loaded1 = await store.loadStates(account1);
+      const loaded2 = await store.loadStates(account2);
+
+      expect(loaded1).toHaveLength(2);
+      expect(loaded2).toHaveLength(2);
+      expect(loaded1[0].nonce).toBe(1);
+      expect(loaded2[0].nonce).toBe(3);
+    });
+
+    it('should maintain separate ID counters per account', async () => {
+      const account1 = '0xabc123';
+      const account2 = '0xdef456';
+
+      const state1 = await store.saveState(account1, createMockState(1));
+      const state2 = await store.saveState(account2, createMockState(1));
+      const state3 = await store.saveState(account1, createMockState(2));
+
+      expect(state1.id).toBe(1);
+      expect(state2.id).toBe(1); // Different account, so ID 1 again
+      expect(state3.id).toBe(2); // Same account as state1
+    });
+  });
+
+  describe('serialize/deserialize roundtrip', () => {
+    it('should preserve all state fields through serialization', async () => {
+      const account = '0xabc123';
+      const blobData = new Uint8Array(131072).fill(1);
+      const kzg = Blob.getViemKzgInstance();
+      const stateToSave: L1TxState = {
+        id: 1,
+        txHashes: ['0xhash1' as Hex, '0xhash2' as Hex],
+        cancelTxHashes: ['0xcancel1' as Hex],
+        gasLimit: 123456n,
+        gasPrice: {
+          maxFeePerGas: 50000000000n,
+          maxPriorityFeePerGas: 2000000000n,
+          maxFeePerBlobGas: 1000000000n,
+        },
+        txConfigOverrides: {
+          gasLimit: 200000n,
+          txTimeoutMs: 60000,
+          stallTimeMs: 12000,
+          checkIntervalMs: 1000,
+          maxSpeedUpAttempts: 5,
+          cancelTxOnTimeout: true,
+          txCancellationFinalTimeoutMs: 30000,
+          txUnseenConsideredDroppedMs: 10000,
+          priorityFeeRetryBumpPercentage: 25,
+          txTimeoutAt: new Date('2024-12-31T23:59:59Z'),
+        },
+        request: {
+          to: '0x1234567890123456789012345678901234567890' as `0x${string}`,
+          data: '0xabcdef' as `0x${string}`,
+          value: 1000000000000000000n,
+          abi: [{ name: 'test', type: 'function', inputs: [], outputs: [], stateMutability: 'view' }] as const,
+        },
+        status: TxUtilsState.SPEED_UP,
+        nonce: 42,
+        sentAtL1Ts: new Date('2024-01-01T10:00:00Z'),
+        lastSentAtL1Ts: new Date('2024-01-01T10:05:00Z'),
+        receipt: {
+          transactionHash: '0xreceipt',
+          blockNumber: 12345n,
+          status: 'success',
+          blockHash: '0xblockhash',
+          cumulativeGasUsed: 21000n,
+          effectiveGasPrice: 50000000000n,
+          from: '0xfromaddress',
+          to: '0xtoaddress',
+          gasUsed: 21000n,
+          logsBloom: '0xlogsbloom',
+          type: 'eip1559',
+          contractAddress: null,
+          logs: [],
+          transactionIndex: 1,
+        },
+        blobInputs: {
+          blobs: [blobData],
+          kzg,
+          maxFeePerBlobGas: 5000000n,
+        },
+      };
+
+      const originalState = await store.saveState(account, stateToSave);
+      const loaded = await store.loadStates(account);
+
+      expect(loaded).toHaveLength(1);
+      const roundtrippedState = loaded[0];
+      expect(omit(roundtrippedState, 'blobInputs', 'request')).toEqual(omit(originalState, 'blobInputs', 'request'));
+      expect(omit(roundtrippedState.request, 'abi')).toEqual(omit(originalState.request, 'abi'));
+    });
+  });
+});

--- a/yarn-project/node-lib/src/stores/l1_tx_store.ts
+++ b/yarn-project/node-lib/src/stores/l1_tx_store.ts
@@ -1,0 +1,387 @@
+import type { IL1TxStore, L1BlobInputs, L1TxConfig, L1TxState } from '@aztec/ethereum';
+import { jsonStringify } from '@aztec/foundation/json-rpc';
+import type { Logger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
+import type { AztecAsyncKVStore, AztecAsyncMap } from '@aztec/kv-store';
+
+import type { TransactionReceipt } from 'viem';
+
+/**
+ * Serializable version of L1TxRequest for storage.
+ */
+interface SerializableL1TxRequest {
+  to: string | null;
+  data?: string;
+  value?: string;
+}
+
+/**
+ * Serializable version of GasPrice for storage.
+ */
+interface SerializableGasPrice {
+  maxFeePerGas: string;
+  maxPriorityFeePerGas: string;
+  maxFeePerBlobGas?: string;
+}
+
+/**
+ * Serializable version of L1TxConfig for storage.
+ */
+interface SerializableL1TxConfig {
+  gasLimit?: string;
+  txTimeoutAt?: number;
+  txTimeoutMs?: number;
+  checkIntervalMs?: number;
+  stallTimeMs?: number;
+  priorityFeeRetryBumpPercentage?: number;
+  maxSpeedUpAttempts?: number;
+  cancelTxOnTimeout?: boolean;
+  txCancellationFinalTimeoutMs?: number;
+  txUnseenConsideredDroppedMs?: number;
+}
+
+/**
+ * Serializable version of blob inputs for storage (without the actual blob data).
+ */
+interface SerializableBlobMetadata {
+  maxFeePerBlobGas?: string;
+}
+
+/**
+ * Serializable version of L1TxState for storage.
+ * Dates and bigints are converted to strings/numbers for JSON serialization.
+ * Blob data is NOT included here - it's stored separately.
+ */
+interface SerializableL1TxState {
+  id: number;
+  txHashes: string[];
+  cancelTxHashes: string[];
+  gasLimit: string;
+  gasPrice: SerializableGasPrice;
+  txConfigOverrides: SerializableL1TxConfig;
+  request: SerializableL1TxRequest;
+  status: number;
+  nonce: number;
+  sentAt: number;
+  lastSentAt: number;
+  receipt?: TransactionReceipt;
+  hasBlobInputs: boolean;
+  blobMetadata?: SerializableBlobMetadata;
+}
+
+/**
+ * Serializable blob inputs for separate storage.
+ */
+interface SerializableBlobInputs {
+  blobs: string[]; // base64 encoded
+  kzg: string; // JSON stringified KZG instance
+}
+
+/**
+ * Store for persisting L1 transaction states across all L1TxUtils instances.
+ * Each state is stored individually with a unique ID, and blobs are stored separately.
+ * @remarks This class lives in this package instead of `ethereum` because it depends on `kv-store`.
+ */
+export class L1TxStore implements IL1TxStore {
+  public static readonly SCHEMA_VERSION = 2;
+
+  private readonly states: AztecAsyncMap<string, string>; // key: "account-stateId", value: SerializableL1TxState
+  private readonly blobs: AztecAsyncMap<string, string>; // key: "account-stateId", value: SerializableBlobInputs
+  private readonly stateIdCounter: AztecAsyncMap<string, number>; // key: "account", value: next ID
+
+  constructor(
+    private readonly store: AztecAsyncKVStore,
+    private readonly log: Logger = createLogger('l1-tx-utils:store'),
+  ) {
+    this.states = store.openMap<string, string>('l1_tx_states');
+    this.blobs = store.openMap<string, string>('l1_tx_blobs');
+    this.stateIdCounter = store.openMap<string, number>('l1_tx_state_id_counter');
+  }
+
+  /**
+   * Gets the next available state ID for an account.
+   */
+  public consumeNextStateId(account: string): Promise<number> {
+    return this.store.transactionAsync(async () => {
+      const currentId = (await this.stateIdCounter.getAsync(account)) ?? 0;
+      const nextId = currentId + 1;
+      await this.stateIdCounter.set(account, nextId);
+      return nextId;
+    });
+  }
+
+  /**
+   * Creates a storage key for state/blob data.
+   */
+  private makeKey(account: string, stateId: number): string {
+    return `${account}-${stateId.toString().padStart(10, '0')}`;
+  }
+
+  /**
+   * Saves a single transaction state for a specific account.
+   * Blobs are not stored here, use saveBlobs instead.
+   * @param account - The sender account address
+   * @param state - Transaction state to save
+   */
+  public async saveState(account: string, state: L1TxState): Promise<L1TxState> {
+    const key = this.makeKey(account, state.id);
+
+    const serializable = this.serializeState(state);
+    await this.states.set(key, jsonStringify(serializable));
+    this.log.debug(`Saved tx state ${state.id} for account ${account} with nonce ${state.nonce}`);
+
+    return state as L1TxState;
+  }
+
+  /**
+   * Saves blobs for a given state.
+   * @param account - The sender account address
+   * @param stateId - The state ID
+   * @param blobInputs - Blob inputs to save
+   */
+  public async saveBlobs(account: string, stateId: number, blobInputs: L1BlobInputs | undefined): Promise<void> {
+    if (!blobInputs) {
+      return;
+    }
+    const key = this.makeKey(account, stateId);
+    const blobData = this.serializeBlobInputs(blobInputs);
+    await this.blobs.set(key, jsonStringify(blobData));
+    this.log.debug(`Saved blobs for state ${stateId} of account ${account}`);
+  }
+
+  /**
+   * Loads all transaction states for a specific account.
+   * @param account - The sender account address
+   * @returns Array of transaction states with their IDs
+   */
+  public async loadStates(account: string): Promise<L1TxState[]> {
+    const states: L1TxState[] = [];
+    const prefix = `${account}-`;
+
+    for await (const [key, stateJson] of this.states.entriesAsync({ start: prefix, end: `${prefix}Z` })) {
+      const [keyAccount, stateIdStr] = key.split('-');
+      if (keyAccount !== account) {
+        throw new Error(`Mismatched account in key: expected ${account} but got ${keyAccount}`);
+      }
+
+      const stateId = parseInt(stateIdStr, 10);
+
+      try {
+        const serialized: SerializableL1TxState = JSON.parse(stateJson);
+
+        // Load blobs if they exist
+        let blobInputs: L1BlobInputs | undefined;
+        if (serialized.hasBlobInputs) {
+          const blobJson = await this.blobs.getAsync(key);
+          if (blobJson) {
+            blobInputs = this.deserializeBlobInputs(JSON.parse(blobJson), serialized.blobMetadata);
+          }
+        }
+
+        const state = this.deserializeState(serialized, blobInputs);
+        states.push({ ...state, id: stateId });
+      } catch (err) {
+        this.log.error(`Failed to deserialize state ${key}`, err);
+      }
+    }
+
+    // Sort by ID
+    states.sort((a, b) => a.id - b.id);
+
+    this.log.debug(`Loaded ${states.length} tx states for account ${account}`);
+    return states;
+  }
+
+  /**
+   * Loads a single state by ID.
+   * @param account - The sender account address
+   * @param stateId - The state ID
+   * @returns The transaction state or undefined if not found
+   */
+  public async loadState(account: string, stateId: number): Promise<L1TxState | undefined> {
+    const key = this.makeKey(account, stateId);
+    const stateJson = await this.states.getAsync(key);
+
+    if (!stateJson) {
+      return undefined;
+    }
+
+    try {
+      const serialized: SerializableL1TxState = JSON.parse(stateJson);
+
+      // Load blobs if they exist
+      let blobInputs: L1BlobInputs | undefined;
+      if (serialized.hasBlobInputs) {
+        const blobJson = await this.blobs.getAsync(key);
+        if (blobJson) {
+          blobInputs = this.deserializeBlobInputs(JSON.parse(blobJson), serialized.blobMetadata);
+        }
+      }
+
+      const state = this.deserializeState(serialized, blobInputs);
+      return { ...state, id: stateId };
+    } catch (err) {
+      this.log.error(`Failed to deserialize state ${key}`, err);
+      return undefined;
+    }
+  }
+
+  /**
+   * Deletes a specific state and its associated blobs.
+   * @param account - The sender account address
+   * @param stateId - The state ID to delete
+   */
+  public async deleteState(account: string, stateId: number): Promise<void> {
+    const key = this.makeKey(account, stateId);
+    await this.states.delete(key);
+    await this.blobs.delete(key);
+    this.log.debug(`Deleted state ${stateId} for account ${account}`);
+  }
+
+  /**
+   * Clears all transaction states for a specific account.
+   * @param account - The sender account address
+   */
+  public async clearStates(account: string): Promise<void> {
+    const states = await this.loadStates(account);
+
+    for (const state of states) {
+      await this.deleteState(account, state.id);
+    }
+
+    await this.stateIdCounter.delete(account);
+    this.log.info(`Cleared all tx states for account ${account}`);
+  }
+
+  /**
+   * Gets all accounts that have stored states.
+   * @returns Array of account addresses
+   */
+  public async getAllAccounts(): Promise<string[]> {
+    const accounts = new Set<string>();
+
+    for await (const [key] of this.states.entriesAsync()) {
+      const account = key.substring(0, key.lastIndexOf('-'));
+      accounts.add(account);
+    }
+
+    return Array.from(accounts);
+  }
+
+  /**
+   * Closes the store.
+   */
+  public async close(): Promise<void> {
+    await this.store.close();
+    this.log.info('Closed L1 tx state store');
+  }
+
+  /**
+   * Serializes an L1TxState for storage.
+   */
+  private serializeState(state: L1TxState): SerializableL1TxState {
+    const txConfigOverrides: SerializableL1TxConfig = {
+      ...state.txConfigOverrides,
+      gasLimit: state.txConfigOverrides.gasLimit?.toString(),
+      txTimeoutAt: state.txConfigOverrides.txTimeoutAt?.getTime(),
+    };
+
+    return {
+      id: state.id,
+      txHashes: state.txHashes,
+      cancelTxHashes: state.cancelTxHashes,
+      gasLimit: state.gasLimit.toString(),
+      gasPrice: {
+        maxFeePerGas: state.gasPrice.maxFeePerGas.toString(),
+        maxPriorityFeePerGas: state.gasPrice.maxPriorityFeePerGas.toString(),
+        maxFeePerBlobGas: state.gasPrice.maxFeePerBlobGas?.toString(),
+      },
+      txConfigOverrides,
+      request: {
+        ...state.request,
+        value: state.request.value?.toString(),
+      },
+      status: state.status,
+      nonce: state.nonce,
+      sentAt: state.sentAtL1Ts.getTime(),
+      lastSentAt: state.lastSentAtL1Ts.getTime(),
+      receipt: state.receipt,
+      hasBlobInputs: state.blobInputs !== undefined,
+      blobMetadata: state.blobInputs?.maxFeePerBlobGas
+        ? { maxFeePerBlobGas: state.blobInputs.maxFeePerBlobGas.toString() }
+        : undefined,
+    };
+  }
+
+  /**
+   * Deserializes a stored state back to L1TxState.
+   */
+  private deserializeState(stored: SerializableL1TxState, blobInputs?: L1BlobInputs): L1TxState {
+    const txConfigOverrides: L1TxConfig = {
+      ...stored.txConfigOverrides,
+      gasLimit: stored.txConfigOverrides.gasLimit !== undefined ? BigInt(stored.txConfigOverrides.gasLimit) : undefined,
+      txTimeoutAt:
+        stored.txConfigOverrides.txTimeoutAt !== undefined ? new Date(stored.txConfigOverrides.txTimeoutAt) : undefined,
+    };
+
+    const receipt = stored.receipt
+      ? {
+          ...stored.receipt,
+          blockNumber: BigInt(stored.receipt.blockNumber),
+          cumulativeGasUsed: BigInt(stored.receipt.cumulativeGasUsed),
+          effectiveGasPrice: BigInt(stored.receipt.effectiveGasPrice),
+          gasUsed: BigInt(stored.receipt.gasUsed),
+        }
+      : undefined;
+
+    return {
+      id: stored.id,
+      txHashes: stored.txHashes as `0x${string}`[],
+      cancelTxHashes: stored.cancelTxHashes as `0x${string}`[],
+      gasLimit: BigInt(stored.gasLimit),
+      gasPrice: {
+        maxFeePerGas: BigInt(stored.gasPrice.maxFeePerGas),
+        maxPriorityFeePerGas: BigInt(stored.gasPrice.maxPriorityFeePerGas),
+        maxFeePerBlobGas: stored.gasPrice.maxFeePerBlobGas ? BigInt(stored.gasPrice.maxFeePerBlobGas) : undefined,
+      },
+      txConfigOverrides,
+      request: {
+        to: stored.request.to as `0x${string}` | null,
+        data: stored.request.data as `0x${string}` | undefined,
+        value: stored.request.value ? BigInt(stored.request.value) : undefined,
+      },
+      status: stored.status,
+      nonce: stored.nonce,
+      sentAtL1Ts: new Date(stored.sentAt),
+      lastSentAtL1Ts: new Date(stored.lastSentAt),
+      receipt,
+      blobInputs,
+    };
+  }
+
+  /**
+   * Serializes blob inputs for separate storage.
+   */
+  private serializeBlobInputs(blobInputs: L1BlobInputs): SerializableBlobInputs {
+    return {
+      blobs: blobInputs.blobs.map(b => Buffer.from(b).toString('base64')),
+      kzg: jsonStringify(blobInputs.kzg),
+    };
+  }
+
+  /**
+   * Deserializes blob inputs from storage, combining blob data with metadata.
+   */
+  private deserializeBlobInputs(stored: SerializableBlobInputs, metadata?: SerializableBlobMetadata): L1BlobInputs {
+    const blobInputs: L1BlobInputs = {
+      blobs: stored.blobs.map(b => new Uint8Array(Buffer.from(b, 'base64'))),
+      kzg: JSON.parse(stored.kzg),
+    };
+
+    if (metadata?.maxFeePerBlobGas) {
+      blobInputs.maxFeePerBlobGas = BigInt(metadata.maxFeePerBlobGas);
+    }
+
+    return blobInputs;
+  }
+}

--- a/yarn-project/node-lib/tsconfig.json
+++ b/yarn-project/node-lib/tsconfig.json
@@ -59,6 +59,9 @@
     },
     {
       "path": "../world-state"
+    },
+    {
+      "path": "../blob-lib"
     }
   ],
   "include": ["src"]

--- a/yarn-project/prover-node/src/prover-node.ts
+++ b/yarn-project/prover-node/src/prover-node.ts
@@ -144,6 +144,7 @@ export class ProverNode implements EpochMonitorHandler, ProverNodeApi, Traceable
    */
   async start() {
     this.epochsMonitor.start(this);
+    await this.publisherFactory.start();
     this.publisher = await this.publisherFactory.create();
     await this.rewardsMetrics.start();
     this.l1Metrics.start();
@@ -159,6 +160,7 @@ export class ProverNode implements EpochMonitorHandler, ProverNodeApi, Traceable
     await this.prover.stop();
     await tryStop(this.p2pClient);
     await tryStop(this.l2BlockSource);
+    await tryStop(this.publisherFactory);
     this.publisher?.interrupt();
     await Promise.all(Array.from(this.jobs.values()).map(job => job.stop()));
     await this.worldState.stop();

--- a/yarn-project/prover-node/src/prover-publisher-factory.ts
+++ b/yarn-project/prover-node/src/prover-publisher-factory.ts
@@ -13,6 +13,15 @@ export class ProverPublisherFactory {
       telemetry?: TelemetryClient;
     },
   ) {}
+
+  public async start() {
+    await this.deps.publisherManager.loadState();
+  }
+
+  public stop() {
+    this.deps.publisherManager.interrupt();
+  }
+
   /**
    * Creates a new Prover Publisher instance.
    * @returns A new ProverNodePublisher instance.

--- a/yarn-project/sequencer-client/src/client/sequencer-client.ts
+++ b/yarn-project/sequencer-client/src/client/sequencer-client.ts
@@ -202,6 +202,7 @@ export class SequencerClient {
     await this.validatorClient?.start();
     this.sequencer.start();
     this.l1Metrics?.start();
+    await this.publisherManager.loadState();
   }
 
   /**

--- a/yarn-project/telemetry-client/src/attributes.ts
+++ b/yarn-project/telemetry-client/src/attributes.ts
@@ -121,3 +121,6 @@ export const NODEJS_EVENT_LOOP_STATE = 'nodejs.eventloop.state';
 export const TOPIC_NAME = 'aztec.gossip.topic_name';
 
 export const TX_COLLECTION_METHOD = 'aztec.tx_collection.method';
+
+/** Scope of L1 transaction (sequencer, prover, or other) */
+export const L1_TX_SCOPE = 'aztec.l1_tx.scope';

--- a/yarn-project/telemetry-client/src/metrics.ts
+++ b/yarn-project/telemetry-client/src/metrics.ts
@@ -96,6 +96,16 @@ export const L1_BALANCE_ETH = 'aztec.l1.balance';
 export const L1_GAS_PRICE_WEI = 'aztec.l1.gas_price';
 export const L1_BLOB_BASE_FEE_WEI = 'aztec.l1.blob_base_fee';
 
+export const L1_TX_MINED_DURATION = 'aztec.l1_tx.mined_duration';
+export const L1_TX_MINED_COUNT = 'aztec.l1_tx.mined_count';
+export const L1_TX_REVERTED_COUNT = 'aztec.l1_tx.reverted_count';
+export const L1_TX_CANCELLED_COUNT = 'aztec.l1_tx.cancelled_count';
+export const L1_TX_NOT_MINED_COUNT = 'aztec.l1_tx.not_mined_count';
+export const L1_TX_ATTEMPTS_UNTIL_MINED = 'aztec.l1_tx.attempts_until_mined';
+export const L1_TX_MAX_PRIORITY_FEE = 'aztec.l1_tx.max_priority_fee';
+export const L1_TX_MAX_FEE = 'aztec.l1_tx.max_fee';
+export const L1_TX_BLOB_FEE = 'aztec.l1_tx.blob_fee';
+
 export const PEER_MANAGER_GOODBYES_SENT = 'aztec.peer_manager.goodbyes_sent';
 export const PEER_MANAGER_GOODBYES_RECEIVED = 'aztec.peer_manager.goodbyes_received';
 export const PEER_MANAGER_PEER_COUNT = 'aztec.peer_manager.peer_count';

--- a/yarn-project/yarn.lock
+++ b/yarn-project/yarn.lock
@@ -1583,6 +1583,7 @@ __metadata:
   dependencies:
     "@aztec/archiver": "workspace:^"
     "@aztec/bb-prover": "workspace:^"
+    "@aztec/blob-lib": "workspace:^"
     "@aztec/blob-sink": "workspace:^"
     "@aztec/constants": "workspace:^"
     "@aztec/epoch-cache": "workspace:^"


### PR DESCRIPTION
1. Fixes an issue where the speed up of a cancellation tx would be sent with the original request, instead of a noop. This was fixed via the new `makeTxData` helper function in the l1 tx utils.
2. Adds a `store` for persisting all tx states, along with a function to rehydrate them and start background monitoring for all pending txs, so they can be sped up or cancelled as needed. Note that the store was added in `node-lib` instead of the `ethereum` package, since it has a dependency on `kv-store`, which depends on `stdlib`, which depends on `ethereum`. The store is optional, and only set for sequencer and prover publishers.
3. Adds a `metrics` for the l1 tx utils, so that we track count of mined, reverted, and not mined txs, as well as time to mine, and gas prices used. Same as with the store, this has a dependency on `telemetry`, so it lives in `node-lib`.

Fixes A-11
Fixes A-17
Fixes A-106
