### PR TITLE
fix: correct ssh-agent sign request length encoding

### DIFF
--- a/yarn-project/accounts/src/utils/ssh_agent.ts
+++ b/yarn-project/accounts/src/utils/ssh_agent.ts
@@ -103,7 +103,11 @@ export function signWithAgent(keyType: Buffer, curveName: Buffer, publicKey: Buf
         keyType,
         Buffer.from([0, 0, 0, curveName.length]),
         curveName,
-        Buffer.from([0, 0, 0, publicKey.length + 1, 4]),
+        (() => {
+          const lengthBuffer = Buffer.alloc(4);
+          lengthBuffer.writeUInt32BE(publicKey.length, 0);
+          return lengthBuffer;
+        })(),
         publicKey,
       ]);
       const request = Buffer.concat([


### PR DESCRIPTION
- encode public key length with writeUInt32BE to follow ssh-agent protocol
- prevent malformed sign requests that previously broke ssh-agent signatures