### PR TITLE
chore(docs): keys concept page refactor

### DIFF
--- a/docs/docs/developers/docs/concepts/accounts/_category_.json
+++ b/docs/docs/developers/docs/concepts/accounts/_category_.json
@@ -1,6 +1,6 @@
 {
     "label": "Accounts",
-    "position": 5,
+    "position": 0,
     "collapsible": true,
     "collapsed": true
 }

--- a/docs/docs/developers/docs/concepts/accounts/index.md
+++ b/docs/docs/developers/docs/concepts/accounts/index.md
@@ -1,6 +1,5 @@
 ---
 title: Accounts
-sidebar_position: 1
 tags: [accounts]
 description: Deep dive into Aztec's native account abstraction system - understanding how smart contract accounts work, their architecture, key management, and authorization mechanisms in a privacy-preserving blockchain.
 ---


### PR DESCRIPTION
# Reposition Accounts Documentation and Enhance Key Management Documentation

This PR makes two key improvements to the developer documentation:

1. Repositions the Accounts section to the top of the concepts hierarchy by changing its position from 5 to 0, and removes an unnecessary sidebar position parameter.

2. Completely revamps the Keys documentation with a more comprehensive and structured explanation:
   - Adds detailed explanations of the four key types (nullifier, address, incoming viewing, signing)
   - Introduces comparison tables for easier understanding
   - Adds a mermaid diagram showing the encryption flow
   - Expands key storage patterns with pros/cons analysis
   - Adds sections on key management, app-siloing, and rotation
   - Includes advanced use cases like escrow contracts
   - Improves code examples and visual organization

These changes make the documentation more accessible to developers while providing deeper technical insights into Aztec's key management system.