### PR TITLE
chore: Output `debug_log` as module `aztec-nr:debug_log`

### DIFF
--- a/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
@@ -22,6 +22,8 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
   isMisc = true as const;
   isUtility = true as const;
 
+  private aztecNrDebugLog = createLogger('aztec-nr:debug_log');
+
   constructor(
     protected readonly contractAddress: AztecAddress,
     /** List of transient auth witnesses to be used during this simulation */
@@ -260,7 +262,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
       throw new Error(`Invalid debug log level: ${level}`);
     }
     const levelName = LogLevels[level];
-    this.log[levelName](`${applyStringFormatting(message, fields)}`, { module: `${this.log.module}:debug_log` });
+    this.aztecNrDebugLog[levelName](`${applyStringFormatting(message, fields)}`);
   }
 
   public async utilityFetchTaggedLogs(pendingTaggedLogArrayBaseSlot: Fr) {


### PR DESCRIPTION
Users can tweak how debug_log in their contracts is shown via the aztec-nr module. For instance, setting `LOG_LEVEL='info; trace: aztec-nr'` yields:

```
[11:41:57.867] INFO: archiver Downloaded L2 block 3 {"blockHash":"0x2119d1ad66afd21d68913e5b54bd0520c68e35708c1fffc3141a09e83d938533","blockNumber":3,"txCount":1,"globalVariables":{"blockNumber":3,"chainId":31337,"coinbase":"0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266","feePerDaGas":0,"feePerL2Gas":22470,"feeRecipient":"0x0000000000000000000000000000000000000000000000000000000000000000","slotNumber":6,"timestamp":1759834175,"version":909337395},"archiveRoot":"0x2e45b494165003b33aac246ce409fd7c67ade23138724c22534943c5255b66a0","archiveNextLeafIndex":4}
[11:41:57.870] INFO: archiver Updated proven chain to block 3 {"provenBlockNumber":3}
[11:41:57.959] INFO: world_state World state updated with L2 block 3 {"eventName":"l2-block-handled","duration":9.965565000002243,"unfinalizedBlockNumber":3,"finalizedBlockNumber":0,"oldestHistoricBlock":1,"txCount":1,"blockNumber":3,"blockTimestamp":1759834175,"privateLogCount":0,"publicLogCount":0,"contractClassLogCount":0,"contractClassLogSize":0}
[11:41:58.206] INFO: pxe:service Simulating transaction execution request to 0x9b204f2a at 0x079b1dbbee49a220e23f32464909a77364b37efdbfd0f32d24e8c741a8df2a73 {"origin":"0x079b1dbbee49a220e23f32464909a77364b37efdbfd0f32d24e8c741a8df2a73","functionSelector":"0x9b204f2a","simulatePublic":true,"chainId":"0x0000000000000000000000000000000000000000000000000000000000007a69","version":"0x0000000000000000000000000000000000000000000000000000000036336333","authWitnesses":["0x202760cb11e45cc9c199c13a15af3c6f620b23f10a11f306e17222735c0b4872"]}
[11:41:58.255] DEBUG: aztec-nr:debug_log Performing message discovery
[11:41:58.273] DEBUG: aztec-nr:debug_log Processing log with tag 0x1204e817851d89d9a3bea6210e938b8fb7a16dc4198eccc5c493a9c9ba2fa39c
[11:41:58.287] DEBUG: aztec-nr:debug_log Processing private note msg
[11:41:58.287] DEBUG: aztec-nr:debug_log Attempting nonce discovery on 0x0000000000000000000000000000000000000000000000000000000000000001 potential notes on contract 0x079b1dbbee49a220e23f32464909a77364b37efdbfd0f32d24e8c741a8df2a73 for storage slot 0x0000000000000000000000000000000000000000000000000000000000000001
[11:41:58.295] DEBUG: aztec-nr:debug_log Found valid nonces for a total of 0x0000000000000000000000000000000000000000000000000000000000000001 notes
[11:41:58.295] DEBUG: aztec-nr:debug_log Discovered 0x0000000000000000000000000000000000000000000000000000000000000001 notes from a private message
[11:41:58.296] DEBUG: aztec-nr:debug_log 0x0000000000000000000000000000000000000000000000000000000000000000 pending partial notes
[11:41:58.307] DEBUG: aztec-nr:debug_log Setting 0x079b1dbbee49a220e23f32464909a77364b37efdbfd0f32d24e8c741a8df2a73 as fee payer
[11:41:58.620] INFO: simulator:public-processor Processed 1 successful txs and 0 failed txs in 0.03959560499999861s {"duration":0.03959560499999861,"rate":234116.89251876125,"totalPublicGas":{"daGas":0,"l2Gas":9270},"totalBlockGas":{"daGas":1024,"l2Gas":31298},"totalSizeInBytes":192}
[11:41:58.642] INFO: pxe:service Simulation completed for 0x1088506d4b3cce88a8510ba175940d223c86c363eaafd96806f63eac89ca5f62 in 435.91570299999876ms {"txHash":"0x1088506d4b3cce88a8510ba175940d223c86c363eaafd96806f63eac89ca5f62","origin":"0x079b1dbbee49a220e23f32464909a77364b37efdbfd0f32d24e8c741a8df2a73","functionSelector":"0x9b204f2a","simulatePublic":true,"chainId":"0x0000000000000000000000000000000000000000000000000000000000007a69","version":"0x0000000000000000000000000000000000000000000000000000000036336333","authWitnesses":["0x202760cb11e45cc9c199c13a15af3c6f620b23f10a11f306e17222735c0b4872"],"gasUsed":{"totalGas":{"daGas":1024,"l2Gas":31298},"teardownGas":{"daGas":0,"l2Gas":0},"publicGas":{"daGas":0,"l2Gas":9270},"billedGas":{"daGas":1024,"l2Gas":31298}},"revertCode":0}
```

Fixes #17532
