### PR TITLE
refactor: returning last used tagging index

### DIFF
--- a/yarn-project/pxe/src/contract_function_simulator/execution_data_provider.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/execution_data_provider.ts
@@ -239,7 +239,7 @@ export interface ExecutionDataProvider {
   syncTaggedLogsAsSender(secret: DirectionalAppTaggingSecret, contractAddress: AztecAddress): Promise<void>;
 
   /**
-   * Returns the last used index when sending a log.
+   * Returns the last used index when sending a log with a given secret.
    * @param secret - The directional app tagging secret.
    * @returns The last used index for the given directional app tagging secret, or undefined if we never sent a log
    * from this sender to a recipient in a given contract (implicitly included in the secret).

--- a/yarn-project/pxe/src/contract_function_simulator/execution_data_provider.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/execution_data_provider.ts
@@ -239,11 +239,12 @@ export interface ExecutionDataProvider {
   syncTaggedLogsAsSender(secret: DirectionalAppTaggingSecret, contractAddress: AztecAddress): Promise<void>;
 
   /**
-   * Returns the next index to be used to compute a tag when sending a log.
+   * Returns the last used index when sending a log.
    * @param secret - The directional app tagging secret.
-   * @returns The next index to be used to compute a tag for the given directional app tagging secret.
+   * @returns The last used index for the given directional app tagging secret, or undefined if we never sent a log
+   * from this sender to a recipient in a given contract (implicitly included in the secret).
    */
-  getNextIndexAsSender(secret: DirectionalAppTaggingSecret): Promise<number>;
+  getLastUsedIndexAsSender(secret: DirectionalAppTaggingSecret): Promise<number | undefined>;
 
   /**
    * Synchronizes the private logs tagged with scoped addresses and all the senders in the address book. Stores the found

--- a/yarn-project/pxe/src/contract_function_simulator/execution_tagging_index_cache.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/execution_tagging_index_cache.ts
@@ -8,11 +8,11 @@ import { DirectionalAppTaggingSecret, type IndexedTaggingSecret } from '@aztec/s
 export class ExecutionTaggingIndexCache {
   private taggingIndexMap: Map<string, number> = new Map();
 
-  public getTaggingIndex(secret: DirectionalAppTaggingSecret): number | undefined {
+  public getLastUsedIndex(secret: DirectionalAppTaggingSecret): number | undefined {
     return this.taggingIndexMap.get(secret.toString());
   }
 
-  public setTaggingIndex(secret: DirectionalAppTaggingSecret, index: number) {
+  public setLastUsedIndex(secret: DirectionalAppTaggingSecret, index: number) {
     const currentValue = this.taggingIndexMap.get(secret.toString());
     if (currentValue !== undefined && currentValue !== index - 1) {
       throw new Error(`Invalid tagging index update. Current value: ${currentValue}, new value: ${index}`);
@@ -20,7 +20,7 @@ export class ExecutionTaggingIndexCache {
     this.taggingIndexMap.set(secret.toString(), index);
   }
 
-  public getIndexedTaggingSecrets(): IndexedTaggingSecret[] {
+  public getLastUsedIndexedTaggingSecrets(): IndexedTaggingSecret[] {
     return Array.from(this.taggingIndexMap.entries()).map(([secret, index]) => ({
       secret: DirectionalAppTaggingSecret.fromString(secret),
       index,

--- a/yarn-project/pxe/src/contract_function_simulator/execution_tagging_index_cache.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/execution_tagging_index_cache.ts
@@ -20,7 +20,10 @@ export class ExecutionTaggingIndexCache {
     this.taggingIndexMap.set(secret.toString(), index);
   }
 
-  public getLastUsedIndexedTaggingSecrets(): IndexedTaggingSecret[] {
+  /**
+   * Returns the indexed tagging secrets that were used in this execution.
+   */
+  public getUsedIndexedTaggingSecrets(): IndexedTaggingSecret[] {
     return Array.from(this.taggingIndexMap.entries()).map(([secret, index]) => ({
       secret: DirectionalAppTaggingSecret.fromString(secret),
       index,

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution.test.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution.test.ts
@@ -302,8 +302,8 @@ describe('Private Execution test suite', () => {
       throw new Error(`Unknown address: ${address}. Recipient: ${recipient}, Owner: ${owner}`);
     });
 
-    executionDataProvider.getNextIndexAsSender.mockImplementation((_secret: DirectionalAppTaggingSecret) => {
-      return Promise.resolve(0);
+    executionDataProvider.getLastUsedIndexAsSender.mockImplementation((_secret: DirectionalAppTaggingSecret) => {
+      return Promise.resolve(undefined);
     });
     executionDataProvider.getFunctionArtifact.mockImplementation(async (address, selector) => {
       const contract = contracts[address.toString()];

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution.ts
@@ -88,7 +88,7 @@ export async function executePrivateFunction(
   const newNotes = privateExecutionOracle.getNewNotes();
   const noteHashNullifierCounterMap = privateExecutionOracle.getNoteHashNullifierCounterMap();
   const offchainEffects = privateExecutionOracle.getOffchainEffects();
-  const indexedTaggingSecrets = privateExecutionOracle.getIndexedTaggingSecrets();
+  const indexedTaggingSecrets = privateExecutionOracle.getUsedIndexedTaggingSecrets();
   const nestedExecutionResults = privateExecutionOracle.getNestedExecutionResults();
 
   let timerSubtractionList = nestedExecutionResults;

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution_oracle.ts
@@ -152,10 +152,10 @@ export class PrivateExecutionOracle extends UtilityExecutionOracle implements IP
   }
 
   /**
-   * Return the tagging indexes incremented by this execution along with the directional app tagging secrets.
+   * Returns the indexed tagging secrets that were used in this execution.
    */
-  public getIndexedTaggingSecrets(): IndexedTaggingSecret[] {
-    return this.taggingIndexCache.getLastUsedIndexedTaggingSecrets();
+  public getUsedIndexedTaggingSecrets(): IndexedTaggingSecret[] {
+    return this.taggingIndexCache.getUsedIndexedTaggingSecrets();
   }
 
   /**

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution_oracle.ts
@@ -209,6 +209,11 @@ export class PrivateExecutionOracle extends UtilityExecutionOracle implements IP
     );
 
     const index = await this.#getIndexToUseForSecret(secret);
+    this.log.debug(
+      `Incrementing tagging index for sender: ${sender}, recipient: ${recipient}, contract: ${this.contractAddress} to ${index}`,
+    );
+    this.taggingIndexCache.setLastUsedIndex(secret, index);
+
     return Tag.compute({ secret, index });
   }
 

--- a/yarn-project/pxe/src/contract_function_simulator/pxe_oracle_interface.test.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/pxe_oracle_interface.test.ts
@@ -209,7 +209,7 @@ describe('PXEOracleInterface', () => {
       // First sender should have 2 logs, but keep index 1 since they were built using the same tag
       // Next 4 senders should also have index 1 = offset + 1
       // Last 5 senders should have index 2 = offset + 2
-      const indexes = await taggingDataProvider.getNextIndexesAsRecipient(secrets);
+      const indexes = await taggingDataProvider.getLastUsedIndexesAsRecipient(secrets);
 
       expect(indexes).toHaveLength(NUM_SENDERS);
       expect(indexes).toEqual([1, 1, 1, 1, 1, 2, 2, 2, 2, 2]);
@@ -244,7 +244,7 @@ describe('PXEOracleInterface', () => {
       );
 
       const getTaggingSecretsIndexesAsSenderForSenders = () =>
-        Promise.all(secrets.map(secret => taggingDataProvider.getNextIndexAsSender(secret)));
+        Promise.all(secrets.map(secret => taggingDataProvider.getLastUsedIndexesAsSender(secret)));
 
       const indexesAsSender = await getTaggingSecretsIndexesAsSenderForSenders();
       expect(indexesAsSender).toStrictEqual([0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
@@ -316,7 +316,7 @@ describe('PXEOracleInterface', () => {
       // First sender should have 2 logs, but keep index 6 since they were built using the same tag
       // Next 4 senders should also have index 6 = offset + 1
       // Last 5 senders should have index 7 = offset + 2
-      const indexes = await taggingDataProvider.getNextIndexesAsRecipient(secrets);
+      const indexes = await taggingDataProvider.getLastUsedIndexesAsRecipient(secrets);
 
       expect(indexes).toHaveLength(NUM_SENDERS);
       expect(indexes).toEqual([6, 6, 6, 6, 6, 7, 7, 7, 7, 7]);
@@ -344,8 +344,8 @@ describe('PXEOracleInterface', () => {
         ),
       );
 
-      // Increase our indexes to 2
-      await taggingDataProvider.setNextIndexesAsRecipient(secrets.map(secret => ({ secret, index: 2 })));
+      // Set last used indexes to 1 (so next scan starts at 2)
+      await taggingDataProvider.setLastUsedIndexesAsRecipient(secrets.map(secret => ({ secret, index: 1 })));
 
       await pxeOracleInterface.syncTaggedLogs(contractAddress, PENDING_TAGGED_LOG_ARRAY_BASE_SLOT);
 
@@ -356,7 +356,7 @@ describe('PXEOracleInterface', () => {
       // First sender should have 2 logs, but keep index 2 since they were built using the same tag
       // Next 4 senders should also have index 2 = tagIndex + 1
       // Last 5 senders should have index 3 = tagIndex + 2
-      const indexes = await taggingDataProvider.getNextIndexesAsRecipient(secrets);
+      const indexes = await taggingDataProvider.getLastUsedIndexesAsRecipient(secrets);
 
       expect(indexes).toHaveLength(NUM_SENDERS);
       expect(indexes).toEqual([2, 2, 2, 2, 2, 3, 3, 3, 3, 3]);
@@ -384,10 +384,10 @@ describe('PXEOracleInterface', () => {
         ),
       );
 
-      // We set the indexes to WINDOW_HALF_SIZE + 1 so that it's outside the window and for this reason no updates
-      // should be triggered.
+      // We set the last used indexes to WINDOW_HALF_SIZE so that next scan starts at WINDOW_HALF_SIZE + 1,
+      // which is outside the window, and for this reason no updates should be triggered.
       const index = WINDOW_HALF_SIZE + 1;
-      await taggingDataProvider.setNextIndexesAsRecipient(secrets.map(secret => ({ secret, index })));
+      await taggingDataProvider.setLastUsedIndexesAsRecipient(secrets.map(secret => ({ secret, index: index - 1 })));
 
       await pxeOracleInterface.syncTaggedLogs(contractAddress, PENDING_TAGGED_LOG_ARRAY_BASE_SLOT);
 
@@ -396,7 +396,7 @@ describe('PXEOracleInterface', () => {
       await expectPendingTaggedLogArrayLengthToBe(contractAddress, NUM_SENDERS / 2);
 
       // Indexes should remain where we set them (window_size + 1)
-      const indexes = await taggingDataProvider.getNextIndexesAsRecipient(secrets);
+      const indexes = await taggingDataProvider.getLastUsedIndexesAsRecipient(secrets);
 
       expect(indexes).toHaveLength(NUM_SENDERS);
       expect(indexes).toEqual([index, index, index, index, index, index, index, index, index, index]);
@@ -423,8 +423,8 @@ describe('PXEOracleInterface', () => {
         ),
       );
 
-      await taggingDataProvider.setNextIndexesAsRecipient(
-        secrets.map(secret => ({ secret, index: WINDOW_HALF_SIZE + 2 })),
+      await taggingDataProvider.setLastUsedIndexesAsRecipient(
+        secrets.map(secret => ({ secret, index: WINDOW_HALF_SIZE + 1 })),
       );
 
       await pxeOracleInterface.syncTaggedLogs(contractAddress, PENDING_TAGGED_LOG_ARRAY_BASE_SLOT);
@@ -446,7 +446,7 @@ describe('PXEOracleInterface', () => {
       // First sender should have 2 logs, but keep index 1 since they were built using the same tag
       // Next 4 senders should also have index 1 = offset + 1
       // Last 5 senders should have index 2 = offset + 2
-      const indexes = await taggingDataProvider.getNextIndexesAsRecipient(secrets);
+      const indexes = await taggingDataProvider.getLastUsedIndexesAsRecipient(secrets);
 
       expect(indexes).toHaveLength(NUM_SENDERS);
       expect(indexes).toEqual([1, 1, 1, 1, 1, 2, 2, 2, 2, 2]);

--- a/yarn-project/pxe/src/contract_function_simulator/pxe_oracle_interface.test.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/pxe_oracle_interface.test.ts
@@ -206,13 +206,13 @@ describe('PXEOracleInterface', () => {
         ),
       );
 
-      // First sender should have 2 logs, but keep index 1 since they were built using the same tag
-      // Next 4 senders should also have index 1 = offset + 1
-      // Last 5 senders should have index 2 = offset + 2
+      // First sender should have 2 logs, but keep index 0 since they were built using the same tag
+      // Next 4 senders should also have index 0 = offset + 0
+      // Last 5 senders should have index 1 = offset + 1
       const indexes = await taggingDataProvider.getLastUsedIndexesAsRecipient(secrets);
 
       expect(indexes).toHaveLength(NUM_SENDERS);
-      expect(indexes).toEqual([1, 1, 1, 1, 1, 2, 2, 2, 2, 2]);
+      expect(indexes).toEqual([0, 0, 0, 0, 0, 1, 1, 1, 1, 1]);
 
       // We should have called the node 2 times:
       // 2 times: first time during initial request, second time after pushing the edge of the window once
@@ -247,7 +247,18 @@ describe('PXEOracleInterface', () => {
         Promise.all(secrets.map(secret => taggingDataProvider.getLastUsedIndexesAsSender(secret)));
 
       const indexesAsSender = await getTaggingSecretsIndexesAsSenderForSenders();
-      expect(indexesAsSender).toStrictEqual([0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
+      expect(indexesAsSender).toStrictEqual([
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+      ]);
 
       expect(aztecNode.getLogsByTags.mock.calls.length).toBe(0);
 
@@ -263,7 +274,7 @@ describe('PXEOracleInterface', () => {
       }
 
       let indexesAsSenderAfterSync = await getTaggingSecretsIndexesAsSenderForSenders();
-      expect(indexesAsSenderAfterSync).toStrictEqual([1, 1, 1, 1, 1, 2, 2, 2, 2, 2]);
+      expect(indexesAsSenderAfterSync).toStrictEqual([0, 0, 0, 0, 0, 1, 1, 1, 1, 1]);
 
       // Only 1 window is obtained for each sender
       expect(aztecNode.getLogsByTags.mock.calls.length).toBe(NUM_SENDERS);
@@ -285,7 +296,7 @@ describe('PXEOracleInterface', () => {
       }
 
       indexesAsSenderAfterSync = await getTaggingSecretsIndexesAsSenderForSenders();
-      expect(indexesAsSenderAfterSync).toStrictEqual([12, 12, 12, 12, 12, 13, 13, 13, 13, 13]);
+      expect(indexesAsSenderAfterSync).toStrictEqual([10, 10, 10, 10, 10, 11, 11, 11, 11, 11]);
 
       expect(aztecNode.getLogsByTags.mock.calls.length).toBe(NUM_SENDERS * 2);
     });
@@ -313,13 +324,13 @@ describe('PXEOracleInterface', () => {
         ),
       );
 
-      // First sender should have 2 logs, but keep index 6 since they were built using the same tag
-      // Next 4 senders should also have index 6 = offset + 1
-      // Last 5 senders should have index 7 = offset + 2
+      // First sender should have 2 logs, but keep index 5 since they were built using the same tag
+      // Next 4 senders should also have index 5 = offset
+      // Last 5 senders should have index 6 = offset + 1
       const indexes = await taggingDataProvider.getLastUsedIndexesAsRecipient(secrets);
 
       expect(indexes).toHaveLength(NUM_SENDERS);
-      expect(indexes).toEqual([6, 6, 6, 6, 6, 7, 7, 7, 7, 7]);
+      expect(indexes).toEqual([5, 5, 5, 5, 5, 6, 6, 6, 6, 6]);
 
       // We should have called the node 2 times:
       // 2 times: first time during initial request, second time after pushing the edge of the window once
@@ -353,13 +364,13 @@ describe('PXEOracleInterface', () => {
       // since the window starts at Math.max(0, 2 - window_size) = 0
       await expectPendingTaggedLogArrayLengthToBe(contractAddress, NUM_SENDERS + 1 + NUM_SENDERS / 2);
 
-      // First sender should have 2 logs, but keep index 2 since they were built using the same tag
-      // Next 4 senders should also have index 2 = tagIndex + 1
-      // Last 5 senders should have index 3 = tagIndex + 2
+      // First sender should have 2 logs, but keep index 1 since they were built using the same tag
+      // Next 4 senders should also have index 1 = tagIndex
+      // Last 5 senders should have index 2 = tagIndex + 1
       const indexes = await taggingDataProvider.getLastUsedIndexesAsRecipient(secrets);
 
       expect(indexes).toHaveLength(NUM_SENDERS);
-      expect(indexes).toEqual([2, 2, 2, 2, 2, 3, 3, 3, 3, 3]);
+      expect(indexes).toEqual([1, 1, 1, 1, 1, 2, 2, 2, 2, 2]);
 
       // We should have called the node 2 times:
       // first time during initial request, second time after pushing the edge of the window once
@@ -387,7 +398,7 @@ describe('PXEOracleInterface', () => {
       // We set the last used indexes to WINDOW_HALF_SIZE so that next scan starts at WINDOW_HALF_SIZE + 1,
       // which is outside the window, and for this reason no updates should be triggered.
       const index = WINDOW_HALF_SIZE + 1;
-      await taggingDataProvider.setLastUsedIndexesAsRecipient(secrets.map(secret => ({ secret, index: index - 1 })));
+      await taggingDataProvider.setLastUsedIndexesAsRecipient(secrets.map(secret => ({ secret, index })));
 
       await pxeOracleInterface.syncTaggedLogs(contractAddress, PENDING_TAGGED_LOG_ARRAY_BASE_SLOT);
 
@@ -395,7 +406,7 @@ describe('PXEOracleInterface', () => {
       // be skipped
       await expectPendingTaggedLogArrayLengthToBe(contractAddress, NUM_SENDERS / 2);
 
-      // Indexes should remain where we set them (window_size + 1)
+      // Indexes should remain where we set them (window_size)
       const indexes = await taggingDataProvider.getLastUsedIndexesAsRecipient(secrets);
 
       expect(indexes).toHaveLength(NUM_SENDERS);
@@ -424,7 +435,7 @@ describe('PXEOracleInterface', () => {
       );
 
       await taggingDataProvider.setLastUsedIndexesAsRecipient(
-        secrets.map(secret => ({ secret, index: WINDOW_HALF_SIZE + 1 })),
+        secrets.map(secret => ({ secret, index: WINDOW_HALF_SIZE + 2 })),
       );
 
       await pxeOracleInterface.syncTaggedLogs(contractAddress, PENDING_TAGGED_LOG_ARRAY_BASE_SLOT);
@@ -443,13 +454,13 @@ describe('PXEOracleInterface', () => {
 
       await pxeOracleInterface.syncTaggedLogs(contractAddress, PENDING_TAGGED_LOG_ARRAY_BASE_SLOT);
 
-      // First sender should have 2 logs, but keep index 1 since they were built using the same tag
-      // Next 4 senders should also have index 1 = offset + 1
-      // Last 5 senders should have index 2 = offset + 2
+      // First sender should have 2 logs, but keep index 0 since they were built using the same tag
+      // Next 4 senders should also have index 0 = offset
+      // Last 5 senders should have index 1 = offset + 1
       const indexes = await taggingDataProvider.getLastUsedIndexesAsRecipient(secrets);
 
       expect(indexes).toHaveLength(NUM_SENDERS);
-      expect(indexes).toEqual([1, 1, 1, 1, 1, 2, 2, 2, 2, 2]);
+      expect(indexes).toEqual([0, 0, 0, 0, 0, 1, 1, 1, 1, 1]);
 
       // We should have called the node 2 times:
       // first time during initial request, second time after pushing the edge of the window once

--- a/yarn-project/pxe/src/contract_function_simulator/pxe_oracle_interface.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/pxe_oracle_interface.ts
@@ -350,7 +350,6 @@ export class PXEOracleInterface implements ExecutionDataProvider {
     const WINDOW_SIZE = MIN_CONSECUTIVE_EMPTY_LOGS * 2;
 
     let [numConsecutiveEmptyLogs, currentIndex] = [0, startIndex];
-    let indexOfLastLog = -1;
     do {
       // We compute the tags for the current window of indexes
       const currentTags = await timesParallel(WINDOW_SIZE, async i => {
@@ -364,7 +363,7 @@ export class PXEOracleInterface implements ExecutionDataProvider {
       const possibleLogs = await this.#getPrivateLogsByTags(tagsAsFr);
 
       // We find the index of the last log in the window that is not empty
-      indexOfLastLog = possibleLogs.findLastIndex(possibleLog => possibleLog.length !== 0);
+      const indexOfLastLog = possibleLogs.findLastIndex(possibleLog => possibleLog.length !== 0);
 
       if (indexOfLastLog === -1) {
         // We haven't found any logs in the current window so we stop looking
@@ -380,10 +379,10 @@ export class PXEOracleInterface implements ExecutionDataProvider {
 
     const contractName = await this.contractDataProvider.getDebugContractName(contractAddress);
     if (currentIndex !== startIndex) {
-      await this.taggingDataProvider.setLastUsedIndexesAsSender([{ secret, index: indexOfLastLog }]);
+      await this.taggingDataProvider.setLastUsedIndexesAsSender([{ secret, index: currentIndex }]);
 
       this.log.debug(`Syncing logs for secret ${secret.toString()} at contract ${contractName}(${contractAddress})`, {
-        index: indexOfLastLog,
+        index: currentIndex,
         contractName,
         contractAddress,
       });

--- a/yarn-project/pxe/src/contract_function_simulator/pxe_oracle_interface.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/pxe_oracle_interface.ts
@@ -295,9 +295,9 @@ export class PXEOracleInterface implements ExecutionDataProvider {
    * so we're keeping it private for now.
    * @param contractAddress - The contract address to silo the secret for
    * @param recipient - The address receiving the notes
-   * @returns A list of indexed tagging secrets
+   * @returns A list of indexed tagging secrets. If the corresponding secret was never used, the index is undefined.
    */
-  async #getIndexedTaggingSecretsForSenders(
+  async #getLastUsedIndexedTaggingSecretsForSenders(
     contractAddress: AztecAddress,
     recipient: AztecAddress,
   ): Promise<{ secret: DirectionalAppTaggingSecret; index: number | undefined }[]> {
@@ -425,7 +425,7 @@ export class PXEOracleInterface implements ExecutionDataProvider {
     const contractName = await this.contractDataProvider.getDebugContractName(contractAddress);
     for (const recipient of recipients) {
       // Get all the secrets for the recipient and sender pairs (#9365)
-      const indexedSecrets = await this.#getIndexedTaggingSecretsForSenders(contractAddress, recipient);
+      const indexedSecrets = await this.#getLastUsedIndexedTaggingSecretsForSenders(contractAddress, recipient);
 
       // We fetch logs for a window of indexes in a range:
       //    <latest_log_index - WINDOW_HALF_SIZE, latest_log_index + WINDOW_HALF_SIZE>.

--- a/yarn-project/pxe/src/pxe.ts
+++ b/yarn-project/pxe/src/pxe.ts
@@ -744,12 +744,12 @@ export class PXE {
 
         const indexedTaggingSecretsIncrementedInTheTx = privateExecutionResult.entrypoint.indexedTaggingSecrets;
         if (indexedTaggingSecretsIncrementedInTheTx.length > 0) {
-          await this.taggingDataProvider.setNextIndexesAsSender(indexedTaggingSecretsIncrementedInTheTx);
-          this.log.debug(`Incremented next tagging secret indexes as sender for the tx`, {
+          await this.taggingDataProvider.setLastUsedIndexesAsSender(indexedTaggingSecretsIncrementedInTheTx);
+          this.log.debug(`Stored last used tagging secret indexes as sender for the tx`, {
             indexedTaggingSecretsIncrementedInTheTx,
           });
         } else {
-          this.log.debug(`No next tagging secret indexes incremented in the tx`);
+          this.log.debug(`No tagging secret indexes incremented in the tx`);
         }
 
         return txProvingResult;

--- a/yarn-project/pxe/src/storage/tagging_data_provider/tagging_data_provider.ts
+++ b/yarn-project/pxe/src/storage/tagging_data_provider/tagging_data_provider.ts
@@ -58,7 +58,7 @@ export class TaggingDataProvider {
   }
 
   /**
-   * Returns the last used index when sending a log.
+   * Returns the last used index when sending a log with a given secret.
    * @param secret - The directional app tagging secret.
    * @returns The last used index for the given directional app tagging secret, or undefined if not found.
    */

--- a/yarn-project/pxe/src/tagging/utils.ts
+++ b/yarn-project/pxe/src/tagging/utils.ts
@@ -18,13 +18,15 @@ export function getIndexedTaggingSecretsForTheWindow(
  * @param indexedTaggingSecrets - The indexed tagging secrets to get the initial indexes from.
  * @returns The map from directional app tagging secret to initial index.
  */
-export function getInitialIndexesMap(indexedTaggingSecrets: IndexedTaggingSecret[]): {
+export function getInitialIndexesMap(
+  indexedTaggingSecrets: { secret: DirectionalAppTaggingSecret; index: number | undefined }[],
+): {
   [k: string]: number;
 } {
   const initialIndexes: { [k: string]: number } = {};
 
   for (const indexedTaggingSecret of indexedTaggingSecrets) {
-    initialIndexes[indexedTaggingSecret.secret.toString()] = indexedTaggingSecret.index;
+    initialIndexes[indexedTaggingSecret.secret.toString()] = indexedTaggingSecret.index ?? 0;
   }
 
   return initialIndexes;


### PR DESCRIPTION
As [discussed](https://github.com/AztecProtocol/aztec-packages/pull/17445#discussion_r2405913527) in a PR down the stack returning the next tagging index in various places of tagging was confusing and it's better to return the last used one. In this PR I do this change.

Some of the code is quite weird but I think it doesn't make sense to invest time in that as I will replace all the tagging sync it all in followup PRs.