### PR TITLE
chore: Try fix multi-eoas test

### DIFF
--- a/yarn-project/ethereum/src/publisher_manager.ts
+++ b/yarn-project/ethereum/src/publisher_manager.ts
@@ -28,7 +28,7 @@ const busyStates: TxUtilsState[] = [
 export type PublisherFilter<UtilsType extends L1TxUtils> = (utils: UtilsType) => boolean;
 
 export class PublisherManager<UtilsType extends L1TxUtils = L1TxUtils> {
-  private log = createLogger('PublisherManager');
+  private log = createLogger('publisher:manager');
   private config: { publisherAllowInvalidStates?: boolean };
 
   constructor(
@@ -47,6 +47,14 @@ export class PublisherManager<UtilsType extends L1TxUtils = L1TxUtils> {
   // 4. Then priority based on highest balance
   // 5. Then priority based on least recently used
   public async getAvailablePublisher(filter: PublisherFilter<UtilsType> = () => true): Promise<UtilsType> {
+    this.log.debug(`Getting available publisher`, {
+      publishers: this.publishers.map(p => ({
+        address: p.getSenderAddress(),
+        state: p.state,
+        lastMined: p.lastMinedAtBlockNumber,
+      })),
+    });
+
     // Extract the valid publishers
     let validPublishers = this.publishers.filter((pub: UtilsType) => !busyStates.includes(pub.state) && filter(pub));
 


### PR DESCRIPTION
Try fix multi-eoas test. Issue was that speed-ups were causing publishers to change state or balance during the `testAccountRotation`. Let's see if disabling speed ups fixes the issue.