### PR TITLE
chore: public tx simulation tester should be able to run bytecodes that do not use fn selector

### DIFF
--- a/yarn-project/simulator/src/public/fixtures/custom_bytecode_tester.ts
+++ b/yarn-project/simulator/src/public/fixtures/custom_bytecode_tester.ts
@@ -17,6 +17,7 @@ export async function testCustomBytecode(
   tester: PublicTxSimulationTester,
   txLabel: string,
   contractName: string = 'CustomBytecodeContract',
+  calldata: any[] = [],
 ): Promise<PublicTxResult> {
   const deployer = AztecAddress.fromNumber(42);
 
@@ -41,8 +42,7 @@ export async function testCustomBytecode(
     /*appCalls=*/ [
       {
         address: testContract.address,
-        fnName: 'public_dispatch',
-        args: [],
+        args: calldata,
       },
     ],
   );

--- a/yarn-project/simulator/src/public/fixtures/public_tx_simulation_tester.ts
+++ b/yarn-project/simulator/src/public/fixtures/public_tx_simulation_tester.ts
@@ -30,7 +30,7 @@ const DEFAULT_GAS_FEES = new GasFees(2, 3);
 export type TestEnqueuedCall = {
   sender?: AztecAddress;
   address: AztecAddress;
-  fnName: string;
+  fnName?: string;
   args: any[];
   isStaticCall?: boolean;
   contractArtifact?: ContractArtifact;
@@ -233,10 +233,24 @@ export class PublicTxSimulationTester extends BaseAvmSimulationTester {
       throw new Error(`Contract artifact not found for address: ${address}`);
     }
 
-    const fnSelector = await getFunctionSelector(call.fnName, contractArtifact);
-    const fnAbi = getContractFunctionAbi(call.fnName, contractArtifact)!;
-    const encodedArgs = encodeArguments(fnAbi, call.args);
-    const calldata = [fnSelector.toField(), ...encodedArgs];
+    let calldata: Fr[] = [];
+    if (!call.fnName) {
+      this.logger.warn(
+        `No function name specified for call to contract ${call.address.toString()}. Assuming this is a custom bytecode with no public_dispatch function.`,
+      );
+      this.logger.warn(`Not using ABI to encode arguments. Not prepending fn selector to calldata.`);
+      try {
+        calldata = call.args.map(arg => new Fr(arg));
+      } catch (error) {
+        this.logger.warn(`Tried assuming that all arguments are Field-like. Failed. Error: ${error}`);
+        throw error;
+      }
+    } else {
+      const fnSelector = await getFunctionSelector(call.fnName, contractArtifact);
+      const fnAbi = getContractFunctionAbi(call.fnName, contractArtifact)!;
+      const encodedArgs = encodeArguments(fnAbi, call.args);
+      calldata = [fnSelector.toField(), ...encodedArgs];
+    }
     const isStaticCall = call.isStaticCall ?? false;
     const request = await PublicCallRequest.fromCalldata(sender, address, isStaticCall, calldata);
 

--- a/yarn-project/simulator/src/public/public_tx_simulator/public_tx_simulator.ts
+++ b/yarn-project/simulator/src/public/public_tx_simulator/public_tx_simulator.ts
@@ -303,7 +303,9 @@ export class PublicTxSimulator implements PublicTxSimulatorInterface {
     );
 
     if (result.reverted) {
-      const culprit = `${contractAddress}:${callRequest.functionSelector}`;
+      const fnLabel =
+        fnName !== undefined ? '<no-selector/no-calldata[0]>' : `${fnName}/${callRequest.functionSelector}`;
+      const culprit = `${contractAddress}:${fnLabel}`;
       context.revert(phase, result.revertReason, culprit);
     }
 


### PR DESCRIPTION
Please read [contributing guidelines](CONTRIBUTING.md) and remove this line.

For audit-related pull requests, please use the [audit PR template](?expand=1&template=audit.md).
