### PR TITLE
refactor(bb): enable circuit stacktraces in debug mode automatically

### DIFF
--- a/barretenberg/cpp/CMakeLists.txt
+++ b/barretenberg/cpp/CMakeLists.txt
@@ -29,7 +29,6 @@ option(COVERAGE "Enable collecting coverage from tests" OFF)
 option(ENABLE_ASAN "Address sanitizer for debugging tricky memory corruption" OFF)
 option(ENABLE_HEAVY_TESTS "Enable heavy tests when collecting coverage" OFF)
 # Note: Must do 'sudo apt-get install libdw-dev' or equivalent
-option(CHECK_CIRCUIT_STACKTRACES "Enable (slow) stack traces for check circuit" OFF)
 option(ENABLE_STACKTRACES "Enable stack traces on assertion" OFF)
 option(ENABLE_TRACY "Enable low-medium overhead profiling for memory and performance with tracy" OFF)
 option(ENABLE_PIC "Builds with position independent code" OFF)
@@ -44,10 +43,8 @@ if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64" OR CMAKE_SYSTEM_PROCESSOR MATCHES "a
     set(RUN_HAVE_POSIX_REGEX 0)
 endif()
 
-if(CHECK_CIRCUIT_STACKTRACES)
+if(ENABLE_STACKTRACES)
     add_compile_options(-DCHECK_CIRCUIT_STACKTRACES -DSTACKTRACES)
-elseif(ENABLE_STACKTRACES)
-    add_compile_options(-DSTACKTRACES)
 endif()
 
 if(ENABLE_TRACY OR ENABLE_TRACY_TIME_INSTRUMENTED)

--- a/barretenberg/cpp/CMakePresets.json
+++ b/barretenberg/cpp/CMakePresets.json
@@ -248,16 +248,6 @@
       }
     },
     {
-      "name": "debug-fast-circuit-check-traces",
-      "displayName": "Optimized debug build with Clang-20 with stack traces for failing circuit checks",
-      "description": "Build with globally installed Clang-20 in optimized debug mode with stack traces for failing circuit checks",
-      "inherits": "debug-fast",
-      "binaryDir": "build-debug-fast-circuit-check-traces",
-      "cacheVariables": {
-        "CHECK_CIRCUIT_STACKTRACES": "ON"
-      }
-    },
-    {
       "name": "asan-fast",
       "displayName": "Debugging build with address sanitizer on Clang-20 in optimized debug mode",
       "description": "Build with address sanitizer on clang20 in optimized debug mode",
@@ -655,11 +645,6 @@
       "name": "debug-fast-notraces",
       "inherits": "default",
       "configurePreset": "debug-fast-notraces"
-    },
-    {
-      "name": "debug-fast-circuit-check-traces",
-      "inherits": "debug-fast",
-      "configurePreset": "debug-fast-circuit-check-traces"
     },
     {
       "name": "asan-fast",

--- a/barretenberg/cpp/cmake/backward-cpp.cmake
+++ b/barretenberg/cpp/cmake/backward-cpp.cmake
@@ -1,4 +1,4 @@
-if(CHECK_CIRCUIT_STACKTRACES OR ENABLE_STACKTRACES)
+if(ENABLE_STACKTRACES)
     include(FetchContent)
 
     # Also requires one of: libbfd (gnu binutils), libdwarf, libdw (elfutils)

--- a/barretenberg/cpp/cmake/module.cmake
+++ b/barretenberg/cpp/cmake/module.cmake
@@ -57,7 +57,7 @@ function(barretenberg_module MODULE_NAME)
             ${TBB_IMPORTED_TARGETS}
         )
 
-        if(CHECK_CIRCUIT_STACKTRACES OR ENABLE_STACKTRACES)
+        if(ENABLE_STACKTRACES)
             target_link_libraries(
                 ${MODULE_NAME}_objects
                 PUBLIC
@@ -108,7 +108,7 @@ function(barretenberg_module MODULE_NAME)
         )
         list(APPEND exe_targets ${MODULE_NAME}_tests)
 
-        if(CHECK_CIRCUIT_STACKTRACES OR ENABLE_STACKTRACES)
+        if(ENABLE_STACKTRACES)
             target_link_libraries(
                 ${MODULE_NAME}_test_objects
                 PUBLIC
@@ -237,7 +237,7 @@ function(barretenberg_module MODULE_NAME)
                 ${TRACY_LIBS}
                 ${TBB_IMPORTED_TARGETS}
             )
-            if(CHECK_CIRCUIT_STACKTRACES OR ENABLE_STACKTRACES)
+            if(ENABLE_STACKTRACES)
                 target_link_libraries(
                     ${BENCHMARK_NAME}_bench_objects
                     PUBLIC

--- a/barretenberg/cpp/src/CMakeLists.txt
+++ b/barretenberg/cpp/src/CMakeLists.txt
@@ -252,7 +252,7 @@ if(WASM)
         DEPENDS ${CMAKE_BINARY_DIR}/bin/barretenberg.wasm.gz
     )
 
-    if(CHECK_CIRCUIT_STACKTRACES OR ENABLE_STACKTRACES)
+    if(ENABLE_STACKTRACES)
         target_link_libraries(
             barretenberg.wasm
             PUBLIC

--- a/barretenberg/cpp/src/barretenberg/bb/CMakeLists.txt
+++ b/barretenberg/cpp/src/barretenberg/bb/CMakeLists.txt
@@ -18,7 +18,7 @@ if (NOT(FUZZING))
     if(NOT DISABLE_AZTEC_VM)
         add_dependencies(bb vm2)
     endif()
-    if(CHECK_CIRCUIT_STACKTRACES OR ENABLE_STACKTRACES)
+    if(ENABLE_STACKTRACES)
         target_link_libraries(
             bb
             PUBLIC

--- a/barretenberg/cpp/src/barretenberg/benchmark/decrypt_bench/CMakeLists.txt
+++ b/barretenberg/cpp/src/barretenberg/benchmark/decrypt_bench/CMakeLists.txt
@@ -10,7 +10,7 @@ if (NOT FUZZING)
         ecc
         common
     )
-  if(CHECK_CIRCUIT_STACKTRACES OR ENABLE_STACKTRACES)
+  if(ENABLE_STACKTRACES)
     target_link_libraries(
         decrypt_bench
         PUBLIC

--- a/barretenberg/cpp/src/barretenberg/grumpkin_srs_gen/CMakeLists.txt
+++ b/barretenberg/cpp/src/barretenberg/grumpkin_srs_gen/CMakeLists.txt
@@ -11,7 +11,7 @@ if (NOT(FUZZING))
         ecc
         crypto_sha256
     )
-    if(CHECK_CIRCUIT_STACKTRACES OR ENABLE_STACKTRACES)
+    if(ENABLE_STACKTRACES)
         target_link_libraries(
             grumpkin_srs_gen
             PUBLIC

--- a/barretenberg/cpp/src/barretenberg/solidity_helpers/CMakeLists.txt
+++ b/barretenberg/cpp/src/barretenberg/solidity_helpers/CMakeLists.txt
@@ -17,7 +17,7 @@ if (NOT(FUZZING))
     PRIVATE
     stdlib_solidity_helpers
   )
-  if(CHECK_CIRCUIT_STACKTRACES OR ENABLE_STACKTRACES)
+  if(ENABLE_STACKTRACES)
     target_link_libraries(
         honk_solidity_key_gen
         PUBLIC


### PR DESCRIPTION
## Summary
Removes `CHECK_CIRCUIT_STACKTRACES`, now implied by `ENABLE_STACKTRACES` flags. Therefore, circuit checker stacktraces are now automatically enabled whenever debug mode is active

## Changes
- Removes `CHECK_CIRCUIT_STACKTRACES` as a separate CMake option
- Circuit stacktraces now enabled when `ENABLE_STACKTRACES` is ON (which happens automatically in debug builds)
- Removed `debug-fast-circuit-check-traces` preset (no longer needed since debug builds automatically include this)