### PR TITLE
chore: adds `incomplete_assert_equal` in `biggroup`

### DIFF
--- a/barretenberg/cpp/scripts/test_civc_standalone_vks_havent_changed.sh
+++ b/barretenberg/cpp/scripts/test_civc_standalone_vks_havent_changed.sh
@@ -13,7 +13,7 @@ cd ..
 # - Generate a hash for versioning: sha256sum bb-civc-inputs.tar.gz
 # - Upload the compressed results: aws s3 cp bb-civc-inputs.tar.gz s3://aztec-ci-artifacts/protocol/bb-civc-inputs-[hash(0:8)].tar.gz
 # Note: In case of the "Test suite failed to run ... Unexpected token 'with' " error, need to run: docker pull aztecprotocol/build:3.0
-pinned_short_hash="ce1add3e"
+pinned_short_hash="74e11e79"
 pinned_civc_inputs_url="https://aztec-ci-artifacts.s3.us-east-2.amazonaws.com/protocol/bb-civc-inputs-${pinned_short_hash}.tar.gz"
 
 function compress_and_upload {

--- a/barretenberg/cpp/scripts/test_civc_standalone_vks_havent_changed.sh
+++ b/barretenberg/cpp/scripts/test_civc_standalone_vks_havent_changed.sh
@@ -13,7 +13,7 @@ cd ..
 # - Generate a hash for versioning: sha256sum bb-civc-inputs.tar.gz
 # - Upload the compressed results: aws s3 cp bb-civc-inputs.tar.gz s3://aztec-ci-artifacts/protocol/bb-civc-inputs-[hash(0:8)].tar.gz
 # Note: In case of the "Test suite failed to run ... Unexpected token 'with' " error, need to run: docker pull aztecprotocol/build:3.0
-pinned_short_hash="74e11e79"
+pinned_short_hash="62254472"
 pinned_civc_inputs_url="https://aztec-ci-artifacts.s3.us-east-2.amazonaws.com/protocol/bb-civc-inputs-${pinned_short_hash}.tar.gz"
 
 function compress_and_upload {

--- a/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.cpp
+++ b/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.cpp
@@ -214,8 +214,8 @@ ClientIVC::perform_recursive_verification_and_databus_consistency_checks(
         kernel_input.reconstruct_from_public(public_inputs);
         nested_pairing_points = kernel_input.pairing_inputs;
         // Perform databus consistency checks
-        kernel_input.kernel_return_data.assert_equal(witness_commitments.calldata);
-        kernel_input.app_return_data.assert_equal(witness_commitments.secondary_calldata);
+        kernel_input.kernel_return_data.incomplete_assert_equal(witness_commitments.calldata);
+        kernel_input.app_return_data.incomplete_assert_equal(witness_commitments.secondary_calldata);
 
         // T_prev is read by the public input of the previous kernel K_{i-1} at the beginning of the recursive
         // verification of of the folding of K_{i-1} (kernel), A_{i,1} (app), .., A_{i, n} (app). This verification

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
@@ -599,7 +599,7 @@ template <typename Builder, typename T> class bigfield {
     void assert_is_in_field(std::string const& msg = "bigfield::assert_is_in_field") const;
     void assert_less_than(const uint256_t& upper_limit, std::string const& msg = "bigfield::assert_less_than") const;
     void reduce_mod_target_modulus() const;
-    void assert_equal(const bigfield& other) const;
+    void assert_equal(const bigfield& other, std::string const& msg = "bigfield::assert_equal") const;
     void assert_is_not_equal(const bigfield& other,
                              std::string const& msg = "bigfield: prime limb diff is zero, but expected non-zero") const;
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/goblin_field.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/goblin_field.hpp
@@ -73,10 +73,10 @@ template <class Builder> class goblin_field {
         return result;
     }
 
-    void assert_equal(const goblin_field& other) const
+    void assert_equal(const goblin_field& other, const std::string& msg = "goblin_field::assert_equal") const
     {
-        limbs[0].assert_equal(other.limbs[0]);
-        limbs[1].assert_equal(other.limbs[1]);
+        limbs[0].assert_equal(other.limbs[0], msg);
+        limbs[1].assert_equal(other.limbs[1], msg);
     }
     static goblin_field zero() { return goblin_field{ 0, 0 }; }
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup.hpp
@@ -283,6 +283,23 @@ template <class Builder_, class Fq, class Fr, class NativeGroup> class element {
         return result;
     }
 
+    /**
+     * @brief Asserts that two group elements are equal (i.e., x, y coordinates and infinity flag are all equal).
+     *
+     * @param other
+     * @param msg
+     *
+     * @details Note that checking the coordinates as well as the infinity flag opens up the possibility of honest
+     * prover unable to satisfy constraints if both points are at infinity but have different x, y. This is not a
+     * problem in practice as we should never have multiple representations of the point at infinity in a circuit.
+     */
+    void assert_equal(const element& other, const std::string msg = "biggroup::assert_equal") const
+    {
+        is_point_at_infinity().assert_equal(other.is_point_at_infinity(), msg + " (infinity flag)");
+        x.assert_equal(other.x, msg + " (x coordinate)");
+        y.assert_equal(other.y, msg + " (y coordinate)");
+    }
+
     element normalize() const
     {
         element result(*this);

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup.hpp
@@ -293,7 +293,8 @@ template <class Builder_, class Fq, class Fr, class NativeGroup> class element {
      * prover unable to satisfy constraints if both points are at infinity but have different x, y. This is not a
      * problem in practice as we should never have multiple representations of the point at infinity in a circuit.
      */
-    void assert_equal(const element& other, const std::string msg = "biggroup::assert_equal") const
+    void incomplete_assert_equal(const element& other,
+                                 const std::string msg = "biggroup::incomplete_assert_equal") const
     {
         is_point_at_infinity().assert_equal(other.is_point_at_infinity(), msg + " (infinity flag)");
         x.assert_equal(other.x, msg + " (x coordinate)");

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup.test.cpp
@@ -398,7 +398,7 @@ template <typename TestType> class stdlib_biggroup : public testing::Test {
         EXPECT_CIRCUIT_CORRECTNESS(builder);
     }
 
-    static void test_assert_equal()
+    static void test_incomplete_assert_equal()
     {
         Builder builder;
         size_t num_repetitions = 10;
@@ -411,13 +411,13 @@ template <typename TestType> class stdlib_biggroup : public testing::Test {
             a.set_origin_tag(submitted_value_origin_tag);
             b.set_origin_tag(challenge_origin_tag);
 
-            a.assert_equal(b, "elements don't match");
+            a.incomplete_assert_equal(b, "elements don't match");
         }
 
         EXPECT_CIRCUIT_CORRECTNESS(builder);
     }
 
-    static void test_assert_equal_failure()
+    static void test_incomplete_assert_equal_failure()
     {
         {
             Builder builder;
@@ -434,7 +434,7 @@ template <typename TestType> class stdlib_biggroup : public testing::Test {
             a.set_origin_tag(submitted_value_origin_tag);
             b.set_origin_tag(challenge_origin_tag);
 
-            a.assert_equal(b, "elements don't match");
+            a.incomplete_assert_equal(b, "elements don't match");
 
             // Circuit should fail (Circuit checker doesn't fail because it doesn't actually check copy constraints,
             // it only checks gate constraints)
@@ -458,7 +458,7 @@ template <typename TestType> class stdlib_biggroup : public testing::Test {
 
             // Make the x-coordinates equal, so we should get an error message about y-coordinates
             b.x = a.x;
-            a.assert_equal(b, "elements don't match");
+            a.incomplete_assert_equal(b, "elements don't match");
 
             // Circuit should fail
             EXPECT_EQ(builder.failed(), true);
@@ -466,7 +466,7 @@ template <typename TestType> class stdlib_biggroup : public testing::Test {
         }
     }
 
-    static void test_assert_equal_edge_cases()
+    static void test_incomplete_assert_equal_edge_cases()
     {
         Builder builder;
         // Check that two points at infinity with different x,y coords fail the equality check
@@ -488,7 +488,7 @@ template <typename TestType> class stdlib_biggroup : public testing::Test {
         a.set_origin_tag(submitted_value_origin_tag);
         b.set_origin_tag(challenge_origin_tag);
 
-        a.assert_equal(b, "points at infinity with different x,y should not be equal");
+        a.incomplete_assert_equal(b, "points at infinity with different x,y should not be equal");
 
         // Circuit should fail
         EXPECT_EQ(builder.failed(), true);
@@ -1836,17 +1836,17 @@ TYPED_TEST(stdlib_biggroup, conditional_select)
 {
     TestFixture::test_conditional_select();
 }
-TYPED_TEST(stdlib_biggroup, assert_equal)
+TYPED_TEST(stdlib_biggroup, incomplete_assert_equal)
 {
-    TestFixture::test_assert_equal();
+    TestFixture::test_incomplete_assert_equal();
 }
-TYPED_TEST(stdlib_biggroup, assert_equal_fails)
+TYPED_TEST(stdlib_biggroup, incomplete_assert_equal_fails)
 {
-    TestFixture::test_assert_equal_failure();
+    TestFixture::test_incomplete_assert_equal_failure();
 }
-TYPED_TEST(stdlib_biggroup, assert_equal_edge_cases)
+TYPED_TEST(stdlib_biggroup, incomplete_assert_equal_edge_cases)
 {
-    TestFixture::test_assert_equal_edge_cases();
+    TestFixture::test_incomplete_assert_equal_edge_cases();
 }
 TYPED_TEST(stdlib_biggroup, montgomery_ladder)
 {

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup.test.cpp
@@ -398,27 +398,60 @@ template <typename TestType> class stdlib_biggroup : public testing::Test {
         EXPECT_CIRCUIT_CORRECTNESS(builder);
     }
 
-    static void test_incomplete_assert_equal()
+    static void test_incomplete_assert_equal_success()
     {
-        Builder builder;
-        size_t num_repetitions = 10;
-        for (size_t i = 0; i < num_repetitions; ++i) {
-            affine_element input_a(element::random_element());
-            element_ct a = element_ct::from_witness(&builder, input_a);
-            element_ct b = element_ct::from_witness(&builder, input_a);
+        // Case 1: Should pass because the points are identical
+        {
+            Builder builder;
+            size_t num_repetitions = 10;
+            for (size_t i = 0; i < num_repetitions; ++i) {
+                affine_element input_a(element::random_element());
+                element_ct a = element_ct::from_witness(&builder, input_a);
+                element_ct b = element_ct::from_witness(&builder, input_a);
 
-            // Set different tags in a and b
-            a.set_origin_tag(submitted_value_origin_tag);
-            b.set_origin_tag(challenge_origin_tag);
+                // Set different tags in a and b
+                a.set_origin_tag(submitted_value_origin_tag);
+                b.set_origin_tag(challenge_origin_tag);
 
-            a.incomplete_assert_equal(b, "elements don't match");
+                a.incomplete_assert_equal(b, "elements don't match");
+            }
+            EXPECT_CIRCUIT_CORRECTNESS(builder);
         }
+        // Case 2: Should pass because the points are identical and at infinity
+        {
+            Builder builder;
+            size_t num_repetitions = 10;
+            for (size_t i = 0; i < num_repetitions; ++i) {
+                affine_element input_a(element::random_element());
+                element_ct a = element_ct::from_witness(&builder, input_a);
+                element_ct b = element_ct::from_witness(&builder, input_a);
 
-        EXPECT_CIRCUIT_CORRECTNESS(builder);
+                // Set different tags in a and b
+                a.set_origin_tag(submitted_value_origin_tag);
+                b.set_origin_tag(challenge_origin_tag);
+
+                a.set_point_at_infinity(bool_ct(witness_ct(&builder, true)));
+                b.set_point_at_infinity(bool_ct(witness_ct(&builder, true)));
+
+                a.incomplete_assert_equal(b, "elements don't match");
+            }
+            EXPECT_CIRCUIT_CORRECTNESS(builder);
+        }
+        // Case 3: Self-assertion (point equals itself)
+        {
+            Builder builder;
+            affine_element input(element::random_element());
+            element_ct a = element_ct::from_witness(&builder, input);
+
+            a.incomplete_assert_equal(a, "self assertion test");
+
+            EXPECT_CIRCUIT_CORRECTNESS(builder);
+        }
     }
 
     static void test_incomplete_assert_equal_failure()
     {
+        // Case 1: Should fail because the points are different
         {
             Builder builder;
             affine_element input_a(element::random_element());
@@ -441,6 +474,7 @@ template <typename TestType> class stdlib_biggroup : public testing::Test {
             EXPECT_EQ(builder.failed(), true);
             EXPECT_EQ(builder.err(), "elements don't match (x coordinate)");
         }
+        // Case 2: Should fail because the points have same x but different y
         {
             Builder builder;
             affine_element input_a(element::random_element());
@@ -463,6 +497,24 @@ template <typename TestType> class stdlib_biggroup : public testing::Test {
             // Circuit should fail
             EXPECT_EQ(builder.failed(), true);
             EXPECT_EQ(builder.err(), "elements don't match (y coordinate)");
+        }
+        // Case 3: Infinity flag mismatch (one point at infinity, one not)
+        {
+            Builder builder;
+            affine_element input_a(element::random_element());
+            affine_element input_b(element::random_element());
+
+            element_ct a = element_ct::from_witness(&builder, input_a);
+            element_ct b = element_ct::from_witness(&builder, input_b);
+
+            // Set only one point at infinity
+            a.set_point_at_infinity(bool_ct(witness_ct(&builder, true)));  // at infinity
+            b.set_point_at_infinity(bool_ct(witness_ct(&builder, false))); // not at infinity
+
+            a.incomplete_assert_equal(b, "infinity flag mismatch test");
+
+            EXPECT_EQ(builder.failed(), true);
+            EXPECT_EQ(builder.err(), "infinity flag mismatch test (infinity flag)");
         }
     }
 
@@ -1838,7 +1890,7 @@ TYPED_TEST(stdlib_biggroup, conditional_select)
 }
 TYPED_TEST(stdlib_biggroup, incomplete_assert_equal)
 {
-    TestFixture::test_incomplete_assert_equal();
+    TestFixture::test_incomplete_assert_equal_success();
 }
 TYPED_TEST(stdlib_biggroup, incomplete_assert_equal_fails)
 {

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup.test.cpp
@@ -398,6 +398,103 @@ template <typename TestType> class stdlib_biggroup : public testing::Test {
         EXPECT_CIRCUIT_CORRECTNESS(builder);
     }
 
+    static void test_assert_equal()
+    {
+        Builder builder;
+        size_t num_repetitions = 10;
+        for (size_t i = 0; i < num_repetitions; ++i) {
+            affine_element input_a(element::random_element());
+            element_ct a = element_ct::from_witness(&builder, input_a);
+            element_ct b = element_ct::from_witness(&builder, input_a);
+
+            // Set different tags in a and b
+            a.set_origin_tag(submitted_value_origin_tag);
+            b.set_origin_tag(challenge_origin_tag);
+
+            a.assert_equal(b, "elements don't match");
+        }
+
+        EXPECT_CIRCUIT_CORRECTNESS(builder);
+    }
+
+    static void test_assert_equal_failure()
+    {
+        {
+            Builder builder;
+            affine_element input_a(element::random_element());
+            affine_element input_b(element::random_element());
+            // Ensure inputs are different
+            while (input_a == input_b) {
+                input_b = element::random_element();
+            }
+            element_ct a = element_ct::from_witness(&builder, input_a);
+            element_ct b = element_ct::from_witness(&builder, input_b);
+
+            // Set different tags in a and b
+            a.set_origin_tag(submitted_value_origin_tag);
+            b.set_origin_tag(challenge_origin_tag);
+
+            a.assert_equal(b, "elements don't match");
+
+            // Circuit should fail (Circuit checker doesn't fail because it doesn't actually check copy constraints,
+            // it only checks gate constraints)
+            EXPECT_EQ(builder.failed(), true);
+            EXPECT_EQ(builder.err(), "elements don't match (x coordinate)");
+        }
+        {
+            Builder builder;
+            affine_element input_a(element::random_element());
+            affine_element input_b(element::random_element());
+            // Ensure inputs are different
+            while (input_a == input_b) {
+                input_b = element::random_element();
+            }
+            element_ct a = element_ct::from_witness(&builder, input_a);
+            element_ct b = element_ct::from_witness(&builder, input_b);
+
+            // Set different tags in a and b
+            a.set_origin_tag(submitted_value_origin_tag);
+            b.set_origin_tag(challenge_origin_tag);
+
+            // Make the x-coordinates equal, so we should get an error message about y-coordinates
+            b.x = a.x;
+            a.assert_equal(b, "elements don't match");
+
+            // Circuit should fail
+            EXPECT_EQ(builder.failed(), true);
+            EXPECT_EQ(builder.err(), "elements don't match (y coordinate)");
+        }
+    }
+
+    static void test_assert_equal_edge_cases()
+    {
+        Builder builder;
+        // Check that two points at infinity with different x,y coords fail the equality check
+        affine_element input_a(element::random_element());
+        affine_element input_b(element::random_element());
+
+        // Ensure inputs are different
+        while (input_a == input_b) {
+            input_b = element::random_element();
+        }
+        element_ct a = element_ct::from_witness(&builder, input_a);
+        element_ct b = element_ct::from_witness(&builder, input_b);
+
+        const bool_ct is_infinity = bool_ct(witness_ct(&builder, 1));
+        a.set_point_at_infinity(is_infinity);
+        b.set_point_at_infinity(is_infinity);
+
+        // Set different tags in a and b
+        a.set_origin_tag(submitted_value_origin_tag);
+        b.set_origin_tag(challenge_origin_tag);
+
+        a.assert_equal(b, "points at infinity with different x,y should not be equal");
+
+        // Circuit should fail
+        EXPECT_EQ(builder.failed(), true);
+        EXPECT_EQ(builder.err(), "points at infinity with different x,y should not be equal (x coordinate)");
+    }
+
     static void test_montgomery_ladder()
     {
         Builder builder;
@@ -1738,6 +1835,18 @@ TYPED_TEST(stdlib_biggroup, conditional_negate)
 TYPED_TEST(stdlib_biggroup, conditional_select)
 {
     TestFixture::test_conditional_select();
+}
+TYPED_TEST(stdlib_biggroup, assert_equal)
+{
+    TestFixture::test_assert_equal();
+}
+TYPED_TEST(stdlib_biggroup, assert_equal_fails)
+{
+    TestFixture::test_assert_equal_failure();
+}
+TYPED_TEST(stdlib_biggroup, assert_equal_edge_cases)
+{
+    TestFixture::test_assert_equal_edge_cases();
 }
 TYPED_TEST(stdlib_biggroup, montgomery_ladder)
 {

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_goblin.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_goblin.hpp
@@ -67,13 +67,21 @@ template <class Builder_, class Fq, class Fr, class NativeGroup> class goblin_el
     goblin_element& operator=(goblin_element&& other) noexcept = default;
     ~goblin_element() = default;
 
-    void assert_equal(const goblin_element& other) const
+    /**
+     * @brief Asserts that two goblin elements are equal (i.e., x, y coordinates and infinity flag are all equal).
+     *
+     * @param other
+     * @param msg
+     *
+     * @details Note that checking the coordinates as well as the infinity flag opens up the possibility of honest
+     * prover unable to satisfy constraints if both points are at infinity but have different x, y. This is not a
+     * problem in practice as we should never have multiple representations of the point at infinity in a circuit.
+     */
+    void assert_equal(const goblin_element& other, const std::string msg = "goblin_element::assert_equal") const
     {
-        if (this->get_value() != other.get_value()) {
-            info("WARNING: goblin_element::assert_equal value check failed!");
-        }
-        x.assert_equal(other.x);
-        y.assert_equal(other.y);
+        is_point_at_infinity().assert_equal(other.is_point_at_infinity(), msg + " (infinity flag)");
+        x.assert_equal(other.x, msg + " (x coordinate)");
+        y.assert_equal(other.y, msg + " (y coordinate)");
     }
 
     static goblin_element from_witness(Builder* ctx, const typename NativeGroup::affine_element& input)

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_goblin.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_goblin.hpp
@@ -77,7 +77,8 @@ template <class Builder_, class Fq, class Fr, class NativeGroup> class goblin_el
      * prover unable to satisfy constraints if both points are at infinity but have different x, y. This is not a
      * problem in practice as we should never have multiple representations of the point at infinity in a circuit.
      */
-    void assert_equal(const goblin_element& other, const std::string msg = "goblin_element::assert_equal") const
+    void incomplete_assert_equal(const goblin_element& other,
+                                 const std::string msg = "goblin_element::incomplete_assert_equal") const
     {
         is_point_at_infinity().assert_equal(other.is_point_at_infinity(), msg + " (infinity flag)");
         x.assert_equal(other.x, msg + " (x coordinate)");


### PR DESCRIPTION
Added a new method called `incomplete_assert_equal` to check equality of two biggroup elements by checking:
- the infinity flags are equal,
- the x and y coordinates are equal.

Note that this does not have perfect completeness because if we pass in two points at infinity whose coordinates do not match, an honest prover will not be able to generate a proof. However, we think this does not (rather, should not) appear in practice and a point at infinity should have a consistent representation in circuits (or natively).

I also modify the existing function `assert_equal` in `biggroup_goblin` to include the check on the infinity flag. 