### PR TITLE
fix: update bigfield tests to avoid unexpected failures

### DIFF
--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.test.cpp
@@ -1291,10 +1291,9 @@ template <typename BigField> class stdlib_bigfield : public testing::Test {
     static void test_assert_is_in_field_fails()
     {
         auto builder = Builder();
-        size_t num_repetitions = 10;
         fq_ct c_ct = fq_ct::zero();
         fq_native expected = fq_native::zero();
-        for (size_t i = 0; i < num_repetitions; ++i) {
+        for (size_t i = 0; i < 1000; ++i) {
 
             auto [a_native, a_ct] = get_random_witness(&builder); // fq_native, fq_ct
             auto [b_native, b_ct] = get_random_witness(&builder); // fq_native, fq_ct
@@ -1303,10 +1302,12 @@ template <typename BigField> class stdlib_bigfield : public testing::Test {
                 c_ct += a_ct * b_ct;
                 expected += a_native * b_native;
             }
-        }
 
-        // Ensure that c has exceeded p (as mul and add have been performed without reduction so far)
-        EXPECT_EQ(c_ct.get_value() >= fq_ct::modulus, true);
+            // Break out of the loop if c has exceeded the modulus
+            if (c_ct.get_value() >= fq_ct::modulus) {
+                break;
+            }
+        }
 
         // this will fail because mult and add have been performed without reduction
         c_ct.assert_is_in_field();
@@ -1350,13 +1351,12 @@ template <typename BigField> class stdlib_bigfield : public testing::Test {
     static void test_assert_less_than_fails()
     {
         auto builder = Builder();
-        size_t num_repetitions = 10;
         constexpr size_t num_bits = 200;
         constexpr uint256_t bit_mask = (uint256_t(1) << num_bits) - 1;
 
         fq_ct c_ct = fq_ct::zero();
         fq_native expected = fq_native::zero();
-        for (size_t i = 0; i < num_repetitions; ++i) {
+        for (size_t i = 0; i < 1000; ++i) {
 
             uint256_t a_u256 = uint256_t(fq_native::random_element()) & bit_mask;
             uint256_t b_u256 = uint256_t(fq_native::random_element()) & bit_mask;
@@ -1372,10 +1372,12 @@ template <typename BigField> class stdlib_bigfield : public testing::Test {
                 c_ct += a_ct * b_ct;
                 expected += fq_native(a_u256) * fq_native(b_u256);
             }
-        }
 
-        // Ensure that c has exceeded 200 bits
-        EXPECT_EQ(c_ct.get_value().get_msb() >= num_bits, true);
+            // Break out of the loop if c has exceeded 200 bits
+            if (c_ct.get_value().get_msb() >= num_bits) {
+                break;
+            }
+        }
 
         // check that assert_less_than fails
         c_ct.assert_less_than(bit_mask + 1);

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.test.cpp
@@ -1291,9 +1291,10 @@ template <typename BigField> class stdlib_bigfield : public testing::Test {
     static void test_assert_is_in_field_fails()
     {
         auto builder = Builder();
+        size_t num_repetitions = 1000;
         fq_ct c_ct = fq_ct::zero();
         fq_native expected = fq_native::zero();
-        for (size_t i = 0; i < 1000; ++i) {
+        for (size_t i = 0; i < num_repetitions; ++i) {
 
             auto [a_native, a_ct] = get_random_witness(&builder); // fq_native, fq_ct
             auto [b_native, b_ct] = get_random_witness(&builder); // fq_native, fq_ct
@@ -1354,9 +1355,10 @@ template <typename BigField> class stdlib_bigfield : public testing::Test {
         constexpr size_t num_bits = 200;
         constexpr uint256_t bit_mask = (uint256_t(1) << num_bits) - 1;
 
+        size_t num_repetitions = 1000;
         fq_ct c_ct = fq_ct::zero();
         fq_native expected = fq_native::zero();
-        for (size_t i = 0; i < 1000; ++i) {
+        for (size_t i = 0; i < num_repetitions; ++i) {
 
             uint256_t a_u256 = uint256_t(fq_native::random_element()) & bit_mask;
             uint256_t b_u256 = uint256_t(fq_native::random_element()) & bit_mask;


### PR DESCRIPTION
Fixes the [flake](http://ci.aztec-labs.com/4680579fdf46ecc5) flagged by @spalladino in bigfield test(s). 

```bash
11:36:22 Running main() from /home/aztec-dev/aztec-packages/barretenberg/cpp/build/_deps/gtest-src/googletest/src/gtest_main.cc
11:36:22 Note: Google Test filter = stdlib_bigfield/1.assert_is_in_field_fails
11:36:22 [==========] Running 1 test from 1 test suite.
11:36:22 [----------] Global test environment set-up.
11:36:22 [----------] 1 test from stdlib_bigfield/1, where TypeParam = bb::stdlib::bigfield<bb::UltraCircuitBuilder_<bb::UltraExecutionTraceBlocks>, bb::secp256k1::FqParams>
11:36:22 [ RUN      ] stdlib_bigfield/1.assert_is_in_field_fails
11:36:22 /home/aztec-dev/aztec-packages/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.test.cpp:1309: Failure
11:36:22 Expected equality of these values:
11:36:22   c_ct.get_value() >= fq_ct::modulus
11:36:22     Which is: false
11:36:22   true
11:36:22 (Experimental) WARNING: Builder failure when we have real witnesses! Ignore if writing vk. (mem: 17.00 MiB)
11:36:22 Failed Arithmetic relation at row idx = 4181 (mem: 24.00 MiB)
11:36:22 Failed at block idx = 2 (mem: 24.00 MiB)
11:36:22 [  FAILED  ] stdlib_bigfield/1.assert_is_in_field_fails, where TypeParam = bb::stdlib::bigfield<bb::UltraCircuitBuilder_<bb::UltraExecutionTraceBlocks>, bb::secp256k1::FqParams> (56 ms)
11:36:22 [----------] 1 test from stdlib_bigfield/1 (57 ms total)
11:36:22 
11:36:22 [----------] Global test environment tear-down
11:36:22 [==========] 1 test from 1 test suite ran. (57 ms total)
11:36:22 [  PASSED  ] 0 tests.
11:36:22 [  FAILED  ] 1 test, listed below:
11:36:22 [  FAILED  ] stdlib_bigfield/1.assert_is_in_field_fails, where TypeParam = bb::stdlib::bigfield<bb::UltraCircuitBuilder_<bb::UltraExecutionTraceBlocks>, bb::secp256k1::FqParams>
```

In this particular [test](https://github.com/AztecProtocol/aztec-packages/blob/3106f2af97e701bcb3f767f5eb91142d23b8de56/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.test.cpp#L1291), we keep adding random bigfield product to create a bigfield element larger than the field modulus:
$$c \longleftarrow c + a_i \cdot b_i$$
We iterate for $10 \times 16 = 160$ times but in some rare case, this still may not be enough to exceed the value of $c$ over the modulus. To avoid this, we increase the iterations by 100 times and exit out of the loop as soon as $c > p$.
