### PR TITLE
refactor: renaming `IndexedTaggingSecret` as `PreTag`

### DIFF
--- a/yarn-project/pxe/src/contract_function_simulator/execution_tagging_index_cache.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/execution_tagging_index_cache.ts
@@ -1,4 +1,4 @@
-import { DirectionalAppTaggingSecret, type IndexedTaggingSecret } from '@aztec/stdlib/logs';
+import { DirectionalAppTaggingSecret, type PreTag } from '@aztec/stdlib/logs';
 
 /**
  * A map that stores the tagging index for a given directional app tagging secret.
@@ -21,9 +21,9 @@ export class ExecutionTaggingIndexCache {
   }
 
   /**
-   * Returns the indexed tagging secrets that were used in this execution.
+   * Returns the pre tags that were used in this execution (and that need to be stored in the db).
    */
-  public getUsedIndexedTaggingSecrets(): IndexedTaggingSecret[] {
+  public getUsedPreTags(): PreTag[] {
     return Array.from(this.taggingIndexMap.entries()).map(([secret, index]) => ({
       secret: DirectionalAppTaggingSecret.fromString(secret),
       index,

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution.ts
@@ -88,7 +88,7 @@ export async function executePrivateFunction(
   const newNotes = privateExecutionOracle.getNewNotes();
   const noteHashNullifierCounterMap = privateExecutionOracle.getNoteHashNullifierCounterMap();
   const offchainEffects = privateExecutionOracle.getOffchainEffects();
-  const indexedTaggingSecrets = privateExecutionOracle.getUsedIndexedTaggingSecrets();
+  const preTags = privateExecutionOracle.getUsedPreTags();
   const nestedExecutionResults = privateExecutionOracle.getNestedExecutionResults();
 
   let timerSubtractionList = nestedExecutionResults;
@@ -112,7 +112,7 @@ export async function executePrivateFunction(
     noteHashNullifierCounterMap,
     rawReturnValues,
     offchainEffects,
-    indexedTaggingSecrets,
+    preTags,
     nestedExecutionResults,
     contractClassLogs,
     {

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution_oracle.ts
@@ -14,7 +14,7 @@ import type { AuthWitness } from '@aztec/stdlib/auth-witness';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import { computeUniqueNoteHash, siloNoteHash, siloNullifier } from '@aztec/stdlib/hash';
 import { PrivateContextInputs } from '@aztec/stdlib/kernel';
-import type { ContractClassLog, DirectionalAppTaggingSecret, IndexedTaggingSecret } from '@aztec/stdlib/logs';
+import type { ContractClassLog, DirectionalAppTaggingSecret, PreTag } from '@aztec/stdlib/logs';
 import { Note, type NoteStatus } from '@aztec/stdlib/note';
 import {
   type BlockHeader,
@@ -152,10 +152,10 @@ export class PrivateExecutionOracle extends UtilityExecutionOracle implements IP
   }
 
   /**
-   * Returns the indexed tagging secrets that were used in this execution.
+   * Returns the pre tags that were used in this execution (and that need to be stored in the db).
    */
-  public getUsedIndexedTaggingSecrets(): IndexedTaggingSecret[] {
-    return this.taggingIndexCache.getUsedIndexedTaggingSecrets();
+  public getUsedPreTags(): PreTag[] {
+    return this.taggingIndexCache.getUsedPreTags();
   }
 
   /**

--- a/yarn-project/pxe/src/pxe.ts
+++ b/yarn-project/pxe/src/pxe.ts
@@ -743,14 +743,14 @@ export class PXE {
           nodeRPCCalls: contractFunctionSimulator?.getStats().nodeRPCCalls,
         });
 
-        const indexedTaggingSecretsIncrementedInTheTx = privateExecutionResult.entrypoint.indexedTaggingSecrets;
-        if (indexedTaggingSecretsIncrementedInTheTx.length > 0) {
-          await this.taggingDataProvider.setLastUsedIndexesAsSender(indexedTaggingSecretsIncrementedInTheTx);
-          this.log.debug(`Stored last used tagging secret indexes as sender for the tx`, {
-            indexedTaggingSecretsIncrementedInTheTx,
+        const preTagsUsedInTheTx = privateExecutionResult.entrypoint.preTags;
+        if (preTagsUsedInTheTx.length > 0) {
+          await this.taggingDataProvider.setLastUsedIndexesAsSender(preTagsUsedInTheTx);
+          this.log.debug(`Stored used pre tags as sender for the tx`, {
+            preTagsUsedInTheTx,
           });
         } else {
-          this.log.debug(`No tagging secret indexes incremented in the tx`);
+          this.log.debug(`No pre tags used in the tx`);
         }
 
         return txProvingResult;

--- a/yarn-project/pxe/src/tagging/constants.ts
+++ b/yarn-project/pxe/src/tagging/constants.ts
@@ -1,2 +1,2 @@
-// Half the size of the window we slide over the tagging secret indexes.
+// Half the size of the window we slide over the tagging indexes.
 export const WINDOW_HALF_SIZE = 10;

--- a/yarn-project/pxe/src/tagging/index.ts
+++ b/yarn-project/pxe/src/tagging/index.ts
@@ -3,4 +3,4 @@ export * from './constants.js';
 export * from './siloed_tag.js';
 export * from './utils.js';
 export { DirectionalAppTaggingSecret } from '@aztec/stdlib/logs';
-export { type IndexedTaggingSecret } from '@aztec/stdlib/logs';
+export { type PreTag } from '@aztec/stdlib/logs';

--- a/yarn-project/pxe/src/tagging/tag.ts
+++ b/yarn-project/pxe/src/tagging/tag.ts
@@ -1,6 +1,6 @@
 import { poseidon2Hash } from '@aztec/foundation/crypto';
 import type { Fr } from '@aztec/foundation/fields';
-import type { IndexedTaggingSecret } from '@aztec/stdlib/logs';
+import type { PreTag } from '@aztec/stdlib/logs';
 
 /**
  * Represents a tag of a private log. This is not the tag that "appears" on the chain as this tag is first siloed
@@ -9,8 +9,8 @@ import type { IndexedTaggingSecret } from '@aztec/stdlib/logs';
 export class Tag {
   private constructor(public readonly value: Fr) {}
 
-  static async compute(indexedTaggingSecret: IndexedTaggingSecret): Promise<Tag> {
-    const tag = await poseidon2Hash([indexedTaggingSecret.secret.value, indexedTaggingSecret.index]);
+  static async compute(preTag: PreTag): Promise<Tag> {
+    const tag = await poseidon2Hash([preTag.secret.value, preTag.index]);
     return new Tag(tag);
   }
 }

--- a/yarn-project/pxe/src/tagging/utils.ts
+++ b/yarn-project/pxe/src/tagging/utils.ts
@@ -1,9 +1,9 @@
-import type { DirectionalAppTaggingSecret, IndexedTaggingSecret } from '@aztec/stdlib/logs';
+import type { DirectionalAppTaggingSecret, PreTag } from '@aztec/stdlib/logs';
 
 // TODO(benesjan): Make this return tags instead - this will moves some complexity from syncTaggedLogs
-export function getIndexedTaggingSecretsForTheWindow(
+export function getPreTagsForTheWindow(
   secretsAndWindows: { secret: DirectionalAppTaggingSecret; leftMostIndex: number; rightMostIndex: number }[],
-): IndexedTaggingSecret[] {
+): PreTag[] {
   const secrets = [];
   for (const secretAndWindow of secretsAndWindows) {
     for (let i = secretAndWindow.leftMostIndex; i <= secretAndWindow.rightMostIndex; i++) {
@@ -15,18 +15,16 @@ export function getIndexedTaggingSecretsForTheWindow(
 
 /**
  * Creates a map from directional app tagging secret to initial index.
- * @param indexedTaggingSecrets - The indexed tagging secrets to get the initial indexes from.
+ * @param preTags - The pre tags to get the initial indexes map from.
  * @returns The map from directional app tagging secret to initial index.
  */
-export function getInitialIndexesMap(
-  indexedTaggingSecrets: { secret: DirectionalAppTaggingSecret; index: number | undefined }[],
-): {
+export function getInitialIndexesMap(preTags: { secret: DirectionalAppTaggingSecret; index: number | undefined }[]): {
   [k: string]: number;
 } {
   const initialIndexes: { [k: string]: number } = {};
 
-  for (const indexedTaggingSecret of indexedTaggingSecrets) {
-    initialIndexes[indexedTaggingSecret.secret.toString()] = indexedTaggingSecret.index ?? 0;
+  for (const preTag of preTags) {
+    initialIndexes[preTag.secret.toString()] = preTag.index ?? 0;
   }
 
   return initialIndexes;

--- a/yarn-project/stdlib/src/logs/directional_app_tagging_secret.ts
+++ b/yarn-project/stdlib/src/logs/directional_app_tagging_secret.ts
@@ -14,7 +14,7 @@ import { computeAddressSecret, computePreaddress } from '../keys/derivation.js';
  * address: A→B differs from B→A even with the same participants and app.
  *
  * Note: It's a bit unfortunate that this type resides in `stdlib` as the rest of the tagging functionality resides
- * in `pxe/src/tagging`. We need to use this type in `IndexedTaggingSecret` that in turn is used by other types
+ * in `pxe/src/tagging`. We need to use this type in `PreTag` that in turn is used by other types
  * in stdlib hence there doesn't seem to be a good way around this.
  */
 export class DirectionalAppTaggingSecret {

--- a/yarn-project/stdlib/src/logs/index.ts
+++ b/yarn-project/stdlib/src/logs/index.ts
@@ -1,6 +1,6 @@
 export * from './log_with_tx_data.js';
 export * from './directional_app_tagging_secret.js';
-export * from './indexed_tagging_secret.js';
+export * from './pre_tag.js';
 export * from './contract_class_log.js';
 export * from './public_log.js';
 export * from './private_log.js';

--- a/yarn-project/stdlib/src/logs/pre_tag.ts
+++ b/yarn-project/stdlib/src/logs/pre_tag.ts
@@ -14,12 +14,12 @@ import {
  * in `pxe/src/tagging`. But this type is used by other types in stdlib hence there doesn't seem to be a good way
  * around this.
  */
-export type IndexedTaggingSecret = {
+export type PreTag = {
   secret: DirectionalAppTaggingSecret;
   index: number;
 };
 
-export const IndexedTaggingSecretSchema = z.object({
+export const PreTagSchema = z.object({
   secret: DirectionalAppTaggingSecretSchema,
   index: schemas.Integer,
 });

--- a/yarn-project/stdlib/src/tx/private_execution_result.ts
+++ b/yarn-project/stdlib/src/tx/private_execution_result.ts
@@ -10,7 +10,7 @@ import { PrivateCircuitPublicInputs } from '../kernel/private_circuit_public_inp
 import type { IsEmpty } from '../kernel/utils/interfaces.js';
 import { sortByCounter } from '../kernel/utils/order_and_comparison.js';
 import { ContractClassLog, ContractClassLogFields } from '../logs/contract_class_log.js';
-import { type IndexedTaggingSecret, IndexedTaggingSecretSchema } from '../logs/indexed_tagging_secret.js';
+import { type PreTag, PreTagSchema } from '../logs/pre_tag.js';
 import { Note } from '../note/note.js';
 import { type ZodFor, mapSchema, schemas } from '../schemas/index.js';
 import type { UInt32 } from '../types/index.js';
@@ -136,8 +136,8 @@ export class PrivateCallExecutionResult {
     public returnValues: Fr[],
     /** The offchain effects emitted during execution of this function call via the `emit_offchain_effect` oracle. */
     public offchainEffects: { data: Fr[] }[],
-    /** The tagging indexes incremented by this execution along with the directional app tagging secrets. */
-    public indexedTaggingSecrets: IndexedTaggingSecret[],
+    /** The pre tags used in this tx to compute tags for private logs */
+    public preTags: PreTag[],
     /** The nested executions. */
     public nestedExecutionResults: PrivateCallExecutionResult[],
     /**
@@ -161,7 +161,7 @@ export class PrivateCallExecutionResult {
         noteHashNullifierCounterMap: mapSchema(z.coerce.number(), z.number()),
         returnValues: z.array(schemas.Fr),
         offchainEffects: z.array(z.object({ data: z.array(schemas.Fr) })),
-        indexedTaggingSecrets: z.array(IndexedTaggingSecretSchema),
+        preTags: z.array(PreTagSchema),
         nestedExecutionResults: z.array(z.lazy(() => PrivateCallExecutionResult.schema)),
         contractClassLogs: z.array(CountedContractClassLog.schema),
       })
@@ -179,7 +179,7 @@ export class PrivateCallExecutionResult {
       fields.noteHashNullifierCounterMap,
       fields.returnValues,
       fields.offchainEffects,
-      fields.indexedTaggingSecrets,
+      fields.preTags,
       fields.nestedExecutionResults,
       fields.contractClassLogs,
     );


### PR DESCRIPTION
Renamed `IndexedTaggingSecret` as `PreTag` as the original name was confusing. See [this conversation](https://github.com/AztecProtocol/aztec-packages/pull/17445#discussion_r2400346043) for more context.