### PR TITLE
fix: Remove the p2p header

### DIFF
--- a/yarn-project/stdlib/src/p2p/gossipable.test.ts
+++ b/yarn-project/stdlib/src/p2p/gossipable.test.ts
@@ -2,15 +2,13 @@ import { P2PMessage } from '@aztec/stdlib/p2p';
 import { Tx } from '@aztec/stdlib/tx';
 
 describe('p2p message', () => {
-  it('serializes and deserializes', async () => {
+  it('serializes and deserializes', () => {
     const tx = Tx.random({ randomProof: true });
     const txAsBuffer = tx.toBuffer();
-    const p2pMessage = await P2PMessage.fromGossipable(tx);
+    const p2pMessage = P2PMessage.fromGossipable(tx);
     const serialized = p2pMessage.toMessageData();
     const deserializedP2PMessage = P2PMessage.fromMessageData(serialized);
     expect(deserializedP2PMessage.payload.length).toEqual(txAsBuffer.length);
     expect(deserializedP2PMessage.payload).toEqual(txAsBuffer);
-    expect(deserializedP2PMessage.id).toEqual(p2pMessage.id);
-    expect(deserializedP2PMessage.publishTime).toEqual(p2pMessage.publishTime);
   });
 });

--- a/yarn-project/stdlib/src/p2p/gossipable.ts
+++ b/yarn-project/stdlib/src/p2p/gossipable.ts
@@ -1,33 +1,23 @@
 import { Buffer32 } from '@aztec/foundation/buffer';
-import { BufferReader, bigintToUInt64BE, serializeToBuffer } from '@aztec/foundation/serialize';
+import { BufferReader, serializeToBuffer } from '@aztec/foundation/serialize';
 
 import type { TopicType } from './topic_type.js';
 
 export class P2PMessage {
-  constructor(
-    public readonly publishTime: Date,
-    public readonly id: Buffer32,
-    public readonly payload: Buffer,
-  ) {}
+  constructor(public readonly payload: Buffer) {}
 
-  static async fromGossipable(message: Gossipable): Promise<P2PMessage> {
-    return new P2PMessage(new Date(), await message.p2pMessageIdentifier(), message.toBuffer());
+  static fromGossipable(message: Gossipable): P2PMessage {
+    return new P2PMessage(message.toBuffer());
   }
 
   static fromMessageData(messageData: Buffer): P2PMessage {
     const reader = new BufferReader(messageData);
-    const publishTime = reader.readUInt64();
-    const id = Buffer32.fromBuffer(reader);
     const payload = reader.readBuffer();
-    return new P2PMessage(new Date(Number(publishTime)), id, payload);
+    return new P2PMessage(payload);
   }
 
   toMessageData(): Buffer {
-    return serializeToBuffer([
-      bigintToUInt64BE(BigInt(this.publishTime.getTime())),
-      this.id,
-      serializeToBuffer(this.payload.length, this.payload),
-    ]);
+    return serializeToBuffer([serializeToBuffer(this.payload.length, this.payload)]);
   }
 }
 


### PR DESCRIPTION
This PR removes the additional header that was added to P2P messages. This prevents any potential attacks based on re-broadcasting messages with different publish times or message id values.
