### PR TITLE
chore: Try deflake L1 reorgs test (again)

### DIFF
--- a/ci3/filter_cached_test_cmd
+++ b/ci3/filter_cached_test_cmd
@@ -19,7 +19,7 @@ function process_batch {
 
   # Iterate over the results and output lines whose hashes don't exist in redis.
   for i in "${!results[@]}"; do
-    if [ -z "${results[$i]}" ]; then
+    if [ -z "${results[$i]}" ] || [[ "${lines[$i]}" == *disabled-cache* ]]; then
       echo "${lines[$i]}"
     else
       echo -e "${blue}SKIPPED${reset} (${yellow}$(ci_term_link ${results[$i]})${reset}): ${lines[$i]}" >&3

--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_l1_reorgs.test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_l1_reorgs.test.ts
@@ -259,7 +259,7 @@ describe('e2e_epochs/epochs_l1_reorgs', () => {
       await blobSinkClient.sendBlobsToBlobSink(blobs);
 
       // And wait for the node to see the new block
-      await retryUntil(() => node.getBlockNumber().then(b => b === L2_BLOCK_NUMBER), 'node sync', 5, 0.1);
+      await retryUntil(() => node.getBlockNumber().then(b => b === L2_BLOCK_NUMBER), 'node sync', 20, 0.1);
     });
   });
 


### PR DESCRIPTION
Increase timeout for detecting new block number. In a failed run, the archiver finds the new block during test shutdown.