### PR TITLE
chore: remove reference to deleted library

### DIFF
--- a/noir-projects/noir-protocol-circuits/bootstrap.sh
+++ b/noir-projects/noir-protocol-circuits/bootstrap.sh
@@ -159,7 +159,6 @@ function build {
     ./crates/blob \
     ./crates/parity-lib \
     ./crates/private-kernel-lib \
-    ./crates/reset-kernel-lib \
     ./crates/rollup-lib \
     ./crates/types \
 


### PR DESCRIPTION
This line wasn't cleared up by https://github.com/AztecProtocol/aztec-packages/pull/17539 which results in nargo running check on the entire workspace.