### PR TITLE
chore: increase proof of possession gas limit

### DIFF
--- a/l1-contracts/src/governance/GSE.sol
+++ b/l1-contracts/src/governance/GSE.sol
@@ -218,12 +218,13 @@ contract GSECore is IGSECore, Ownable {
   // Must exceed the happy path gas consumption to ensure deposits succeed.
   // Acts as a cap on unhappy path gas usage to prevent excessive consumption.
   //
-  // - Happy path average: 140K gas
-  // - Buffer: 60K gas (~40% margin)
+  // - Happy path average: 150K gas
+  // - Buffer for loop: 50K gas
+  // - Buffer for opcode cost changes: 50K gas
   //
   // WARNING: If set below happy path requirements, all deposits will fail.
   // Governance can adjust this value via proposal.
-  uint64 public proofOfPossessionGasLimit = 200_000;
+  uint64 public proofOfPossessionGasLimit = 250_000;
 
   /**
    * @dev enforces that the caller is a registered rollup.

--- a/l1-contracts/test/governance/gse/gse/tmnt395.t.sol
+++ b/l1-contracts/test/governance/gse/gse/tmnt395.t.sol
@@ -95,9 +95,9 @@ contract Tmnt395Test is TestBase {
     }
 
     vm.expectRevert(abi.encodeWithSelector(CoreErrors.Staking__DepositOutOfGas.selector));
-    INSTANCE.flushEntryQueue{gas: 500_000}();
+    INSTANCE.flushEntryQueue{gas: 600_000}();
 
-    INSTANCE.flushEntryQueue{gas: 1_500_000}();
+    INSTANCE.flushEntryQueue{gas: 1_800_000}();
 
     // Ensure that only one of the attesters were added
     assertEq(INSTANCE.getActiveAttesterCount(), 1, "invalid active attester count");


### PR DESCRIPTION
With the updates to BLS #17512 the cost was slightly increase, so when running at the margins it lead to the random values used in the deploy-l1-contracts test to run into one of the pairs that while valid will be outside of the span of compute allowed.

I have increased the limit by 50K for 2 reasons: 
1. To address this increased cost
2. To keep some room left for increases due to Fusaka.