### PR TITLE
fix: attesters use their own address for coinbase by default

### DIFF
--- a/yarn-project/node-keystore/src/keystore_manager.test.ts
+++ b/yarn-project/node-keystore/src/keystore_manager.test.ts
@@ -242,8 +242,8 @@ describe('KeystoreManager', () => {
       };
 
       const manager = new KeystoreManager(keystore);
-      const coinbase = manager.getCoinbaseAddress(0);
       const attesterSigners = manager.createAttesterSigners(0);
+      const coinbase = manager.getCoinbaseAddress(0, attesterSigners[0].address);
 
       expect(coinbase.toString()).toBe(attesterSigners[0].address.toString());
     });
@@ -261,9 +261,38 @@ describe('KeystoreManager', () => {
       };
 
       const manager = new KeystoreManager(keystore);
-      const coinbase = manager.getCoinbaseAddress(0);
+      const attesterSigners = manager.createAttesterSigners(0);
+      const coinbase = manager.getCoinbaseAddress(0, attesterSigners[0].address);
 
       expect(coinbase.toString()).toBe('0x9876543210987654321098765432109876543210');
+    });
+
+    it('should get coinbase address for each attester when no explicit coinbase is set', async () => {
+      const keystore: KeyStore = {
+        schemaVersion: 1,
+        validators: [
+          {
+            attester: [
+              '0x1234567890123456789012345678901234567890123456789012345678901234',
+              '0x2345678901234567890123456789012345678901234567890123456789012345',
+              '0x3456789012345678901234567890123456789012345678901234567890123456',
+            ] as any[],
+            feeRecipient: await AztecAddress.random(),
+          },
+        ],
+      };
+
+      const manager = new KeystoreManager(keystore);
+      const attesterSigners = manager.createAttesterSigners(0);
+
+      // Each attester should get its own address as coinbase
+      const coinbase0 = manager.getCoinbaseAddress(0, attesterSigners[0].address);
+      const coinbase1 = manager.getCoinbaseAddress(0, attesterSigners[1].address);
+      const coinbase2 = manager.getCoinbaseAddress(0, attesterSigners[2].address);
+
+      expect(coinbase0.toString()).toBe(attesterSigners[0].address.toString());
+      expect(coinbase1.toString()).toBe(attesterSigners[1].address.toString());
+      expect(coinbase2.toString()).toBe(attesterSigners[2].address.toString());
     });
   });
 

--- a/yarn-project/node-keystore/src/keystore_manager.ts
+++ b/yarn-project/node-keystore/src/keystore_manager.ts
@@ -320,22 +320,17 @@ export class KeystoreManager {
   }
 
   /**
-   * Get coinbase address for validator (falls back to first attester address)
+   * Get coinbase address for validator (falls back to the specific attester address)
    */
-  getCoinbaseAddress(validatorIndex: number): EthAddress {
+  getCoinbaseAddress(validatorIndex: number, attesterAddress: EthAddress): EthAddress {
     const validator = this.getValidator(validatorIndex);
 
     if (validator.coinbase) {
       return validator.coinbase;
     }
 
-    // Fall back to first attester address
-    const attesterSigners = this.createAttesterSigners(validatorIndex);
-    if (attesterSigners.length === 0) {
-      throw new KeystoreError(`No attester signers found for validator ${validatorIndex}`);
-    }
-
-    return attesterSigners[0].address;
+    // Fall back to the specific attester address
+    return attesterAddress;
   }
 
   /**

--- a/yarn-project/validator-client/src/key_store/node_keystore_adapter.ts
+++ b/yarn-project/validator-client/src/key_store/node_keystore_adapter.ts
@@ -324,7 +324,7 @@ export class NodeKeystoreAdapter implements ExtendedValidatorKeyStore {
    */
   getCoinbaseAddress(attesterAddress: EthAddress): EthAddress {
     const validatorIndex = this.findValidatorIndexForAttester(attesterAddress);
-    return this.keystoreManager.getCoinbaseAddress(validatorIndex);
+    return this.keystoreManager.getCoinbaseAddress(validatorIndex, attesterAddress);
   }
 
   /**


### PR DESCRIPTION
Validators running multiple attesters would default the coinbase to the first attester in their array. This changes the code such that _that_ attester gets the reward for the block they propose

Fix A-145