### PR TITLE
chore: Backport epoch cache and rollup fixes to v2

### DIFF
--- a/yarn-project/aztec-node/src/aztec-node/server.test.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.test.ts
@@ -150,7 +150,7 @@ describe('aztec node', () => {
     // on the epoch cache is used so a simple mock will suffice.
     const rollupContract = mock<RollupContract>();
     // We pass MockDateProvider to the epoch cache to have control over the next slot timestamp
-    epochCache = new EpochCache(rollupContract, 0n, undefined, 0n, EmptyL1RollupConstants, new MockDateProvider());
+    epochCache = new EpochCache(rollupContract, EmptyL1RollupConstants, new MockDateProvider());
 
     node = new AztecNodeService(
       nodeConfig,

--- a/yarn-project/cli/src/cmds/l1/update_l1_validators.ts
+++ b/yarn-project/cli/src/cmds/l1/update_l1_validators.ts
@@ -308,7 +308,7 @@ export async function debugRollup({ rpcUrls, chainId, rollupAddress, log }: Roll
   log(`Committee: ${committee?.map(v => v.toString()).join(', ')}`);
   const archive = await rollup.archive();
   log(`Archive: ${archive}`);
-  const epochNum = await rollup.getEpochNumber();
+  const epochNum = await rollup.getCurrentEpochNumber();
   log(`Current epoch: ${epochNum}`);
   const slot = await rollup.getSlotNumber();
   log(`Current slot: ${slot}`);

--- a/yarn-project/end-to-end/src/e2e_l1_publisher/e2e_l1_publisher.test.ts
+++ b/yarn-project/end-to-end/src/e2e_l1_publisher/e2e_l1_publisher.test.ts
@@ -449,7 +449,8 @@ describe('L1Publisher integration', () => {
         const thisBlockNumber = BigInt(block.header.globalVariables.blockNumber);
         const isFirstBlockOfEpoch =
           thisBlockNumber == 1n ||
-          (await rollup.getEpochNumber(thisBlockNumber)) > (await rollup.getEpochNumber(thisBlockNumber - 1n));
+          (await rollup.getEpochNumberForBlock(thisBlockNumber)) >
+            (await rollup.getEpochNumberForBlock(thisBlockNumber - 1n));
         // If we are at the first blob of the epoch, we must initialize the hash:
         prevBlobAccumulatorHash = isFirstBlockOfEpoch ? Buffer.alloc(0) : prevBlobAccumulatorHash;
         const currentBlobAccumulatorHash = hexToBuffer(await rollup.getCurrentBlobCommitmentsHash());

--- a/yarn-project/end-to-end/src/e2e_p2p/add_rollup.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/add_rollup.test.ts
@@ -480,7 +480,7 @@ describe('e2e_p2p_add_rollup', () => {
 
     // With all down, we make a time jump such that we ensure that we will be at a point where epochs are non-empty
     // This is to avoid conflicts when the checkpoints are looking further back.
-    const futureEpoch = 500n + (await newRollup.getEpochNumber());
+    const futureEpoch = 500n + (await newRollup.getCurrentEpochNumber());
     const time = await newRollup.getTimestampForSlot(futureEpoch * BigInt(t.ctx.aztecNodeConfig.aztecEpochDuration));
     if (time > BigInt(await t.ctx.cheatCodes.eth.timestamp())) {
       await t.ctx.cheatCodes.eth.warp(Number(time));

--- a/yarn-project/epoch-cache/src/epoch_cache.ts
+++ b/yarn-project/epoch-cache/src/epoch_cache.ts
@@ -58,26 +58,19 @@ export interface EpochCacheInterface {
  * Note: This class is very dependent on the system clock being in sync.
  */
 export class EpochCache implements EpochCacheInterface {
-  private cache: Map<bigint, EpochCommitteeInfo> = new Map();
+  protected cache: Map<bigint, EpochCommitteeInfo> = new Map();
   private allValidators: Set<string> = new Set();
   private lastValidatorRefresh = 0;
   private readonly log: Logger = createLogger('epoch-cache');
 
   constructor(
     private rollup: RollupContract,
-    initialEpoch: bigint = 0n,
-    initialValidators: EthAddress[] | undefined = undefined,
-    initialSampleSeed: bigint = 0n,
     private readonly l1constants: L1RollupConstants = EmptyL1RollupConstants,
     private readonly dateProvider: DateProvider = new DateProvider(),
-    private readonly config = { cacheSize: 12, validatorRefreshIntervalSeconds: 60 },
+    protected readonly config = { cacheSize: 12, validatorRefreshIntervalSeconds: 60 },
   ) {
-    this.cache.set(initialEpoch, { epoch: initialEpoch, committee: initialValidators, seed: initialSampleSeed });
-    this.log.debug(`Initialized EpochCache with ${initialValidators?.length ?? 'no'} validators`, {
+    this.log.debug(`Initialized EpochCache`, {
       l1constants,
-      initialValidators,
-      initialSampleSeed,
-      initialEpoch,
     });
   }
 
@@ -102,21 +95,9 @@ export class EpochCache implements EpochCacheInterface {
       rollup = new RollupContract(publicClient, rollupOrAddress.toString());
     }
 
-    const [
-      l1StartBlock,
-      l1GenesisTime,
-      initialValidators,
-      sampleSeed,
-      epochNumber,
-      proofSubmissionEpochs,
-      slotDuration,
-      epochDuration,
-    ] = await Promise.all([
+    const [l1StartBlock, l1GenesisTime, proofSubmissionEpochs, slotDuration, epochDuration] = await Promise.all([
       rollup.getL1StartBlock(),
       rollup.getL1GenesisTime(),
-      rollup.getCurrentEpochCommittee(),
-      rollup.getCurrentSampleSeed(),
-      rollup.getEpochNumber(),
       rollup.getProofSubmissionEpochs(),
       rollup.getSlotDuration(),
       rollup.getEpochDuration(),
@@ -131,14 +112,7 @@ export class EpochCache implements EpochCacheInterface {
       ethereumSlotDuration: config.ethereumSlotDuration,
     };
 
-    return new EpochCache(
-      rollup,
-      epochNumber,
-      initialValidators?.map(v => EthAddress.fromString(v)),
-      sampleSeed,
-      l1RollupConstants,
-      deps.dateProvider,
-    );
+    return new EpochCache(rollup, l1RollupConstants, deps.dateProvider);
   }
 
   public getL1Constants(): L1RollupConstants {

--- a/yarn-project/ethereum/src/contracts/rollup.ts
+++ b/yarn-project/ethereum/src/contracts/rollup.ts
@@ -440,20 +440,20 @@ export class RollupContract {
     return this.rollup.read.getEntryQueueLength();
   }
 
-  async getEpochNumber(blockNumber?: bigint) {
-    blockNumber ??= await this.getBlockNumber();
+  getCurrentEpochNumber(): Promise<bigint> {
+    return this.rollup.read.getCurrentEpoch();
+  }
+
+  getEpochNumberForBlock(blockNumber: bigint) {
     return this.rollup.read.getEpochForBlock([BigInt(blockNumber)]);
   }
+
   getAvailableValidatorFlushes() {
     return this.rollup.read.getAvailableValidatorFlushes();
   }
 
   getNextFlushableEpoch() {
     return this.rollup.read.getNextFlushableEpoch();
-  }
-
-  getCurrentEpochNumber(): Promise<bigint> {
-    return this.rollup.read.getCurrentEpoch();
   }
 
   async getRollupAddresses(): Promise<L1RollupContractAddresses> {

--- a/yarn-project/ethereum/src/test/chain_monitor.ts
+++ b/yarn-project/ethereum/src/test/chain_monitor.ts
@@ -116,7 +116,7 @@ export class ChainMonitor extends EventEmitter<ChainMonitorEventMap> {
 
     const newL2BlockNumber = Number(await this.rollup.getBlockNumber());
     if (this.l2BlockNumber !== newL2BlockNumber) {
-      const epochNumber = await this.rollup.getEpochNumber(BigInt(newL2BlockNumber));
+      const epochNumber = await this.rollup.getEpochNumberForBlock(BigInt(newL2BlockNumber));
       msg += ` with new L2 block ${newL2BlockNumber} for epoch ${epochNumber}`;
       this.l2BlockNumber = newL2BlockNumber;
       this.l2BlockTimestamp = timestamp;
@@ -130,7 +130,7 @@ export class ChainMonitor extends EventEmitter<ChainMonitorEventMap> {
 
     const newL2ProvenBlockNumber = Number(await this.rollup.getProvenBlockNumber());
     if (this.l2ProvenBlockNumber !== newL2ProvenBlockNumber) {
-      const epochNumber = await this.rollup.getEpochNumber(BigInt(newL2ProvenBlockNumber));
+      const epochNumber = await this.rollup.getEpochNumberForBlock(BigInt(newL2ProvenBlockNumber));
       msg += ` with proof up to L2 block ${newL2ProvenBlockNumber} for epoch ${epochNumber}`;
       this.l2ProvenBlockNumber = newL2ProvenBlockNumber;
       this.l2ProvenBlockTimestamp = timestamp;

--- a/yarn-project/prover-node/src/metrics.ts
+++ b/yarn-project/prover-node/src/metrics.ts
@@ -91,7 +91,7 @@ export class ProverNodeRewardsMetrics {
   }
 
   private observe = async (observer: BatchObservableResult): Promise<void> => {
-    const epoch = await this.rollup.getEpochNumber();
+    const epoch = await this.rollup.getCurrentEpochNumber();
 
     if (epoch > this.proofSubmissionEpochs) {
       // look at the prev epoch so that we get an accurate value, after proof submission window has closed


### PR DESCRIPTION
## Summary
This PR backports two important fixes to the v2 branch:

1. **PR #17605**: Do not seed the epoch cache on startup
   - Avoids race conditions around querying the current committee and epoch number
   - Removes initial epoch seeding from EpochCache constructor
   - Updates tests to use a TestEpochCache class with manual seeding

2. **PR #16973**: Wait for flushable epoch using actual current epoch (rollup.ts changes only)
   - Fixes the `getEpochNumber` method which did NOT return the current epoch number
   - Splits into `getCurrentEpochNumber()` and `getEpochNumberForBlock(blockNumber)`
   - Updates all call sites to use the appropriate method

## Changes
- Modified `epoch-cache/src/epoch_cache.ts`: Removed initial seeding parameters from constructor
- Modified `epoch-cache/src/epoch_cache.test.ts`: Added TestEpochCache class for testing
- Modified `aztec-node/src/aztec-node/server.test.ts`: Updated EpochCache instantiation
- Modified `ethereum/src/contracts/rollup.ts`: Split getEpochNumber into two methods
- Updated 6 files that call rollup methods to use the correct method

🤖 Generated with [Claude Code](https://claude.com/claude-code)