### PR TITLE
chore: Try deflake L1 reorgs test

### DIFF
--- a/.test_patterns.yml
+++ b/.test_patterns.yml
@@ -249,6 +249,11 @@ tests:
     error_regex: "Timeout waiting for proposal execution"
     owners:
       - *palla
+  # http://ci.aztec-labs.com/3055aa95e441471f
+  - regex: "src/e2e_p2p/e2e_p2p_broadcasted_invalid_block_proposal_slash.test.ts"
+    error_regex: "Timeout awaiting non-empty offenses"
+    owners:
+      - *palla
 
   # yarn-project tests
   - regex: "p2p/src/services/discv5/discv5_service.test.ts"

--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_l1_reorgs.test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_l1_reorgs.test.ts
@@ -259,7 +259,7 @@ describe('e2e_epochs/epochs_l1_reorgs', () => {
       await blobSinkClient.sendBlobsToBlobSink(blobs);
 
       // And wait for the node to see the new block
-      await retryUntil(() => node.getBlockNumber().then(b => b === L2_BLOCK_NUMBER), 'node sync', 5, 0.1);
+      await retryUntil(() => node.getBlockNumber().then(b => b === L2_BLOCK_NUMBER), 'node sync', 20, 0.1);
     });
   });
 


### PR DESCRIPTION
Increase timeout for detecting new block number. In a failed run, the archiver finds the new block during test shutdown.