### PR TITLE
fix: Proper index for invalidation

### DIFF
--- a/yarn-project/archiver/src/archiver/validation.test.ts
+++ b/yarn-project/archiver/src/archiver/validation.test.ts
@@ -1,8 +1,17 @@
 import type { EpochCache, EpochCommitteeInfo } from '@aztec/epoch-cache';
+import { Buffer32 } from '@aztec/foundation/buffer';
 import { times } from '@aztec/foundation/collection';
 import { Secp256k1Signer } from '@aztec/foundation/crypto';
+import { Signature } from '@aztec/foundation/eth-signature';
 import { type Logger, createLogger } from '@aztec/foundation/log';
-import { EthAddress, L1PublishedData, L2Block, PublishedL2Block } from '@aztec/stdlib/block';
+import {
+  CommitteeAttestation,
+  EthAddress,
+  L1PublishedData,
+  L2Block,
+  PublishedL2Block,
+  getAttestationsFromPublishedL2Block,
+} from '@aztec/stdlib/block';
 import { orderAttestations } from '@aztec/stdlib/p2p';
 import { makeBlockAttestationFromBlock } from '@aztec/stdlib/testing';
 
@@ -80,6 +89,49 @@ describe('validateBlockAttestations', () => {
       expect(result.block.archive.toString()).toEqual(block.block.archive.root.toString());
       expect(result.committee).toEqual(committee);
       expect(result.invalidIndex).toBe(5); // The bad signer is at index 5
+    });
+
+    it('fails if there is an attestation with an invalid signature', async () => {
+      const block = await makeBlock(signers.slice(0, 4), committee);
+      // Create an invalid signature that will fail curve point recovery with "Point is not on curve: Cannot find square root"
+      // r = curve_order - 1, s = 1
+      const invalidR = Buffer32.fromBuffer(
+        Buffer.from('FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364140', 'hex'),
+      );
+      const invalidS = Buffer32.fromBuffer(
+        Buffer.from('0000000000000000000000000000000000000000000000000000000000000001', 'hex'),
+      );
+      const invalidSig = new Signature(invalidR, invalidS, 27);
+      block.attestations[0] = new CommitteeAttestation(EthAddress.ZERO, invalidSig);
+
+      // Verify that getSender() actually throws for the invalid signature
+      const attestations = getAttestationsFromPublishedL2Block(block);
+      expect(() => attestations[0]!.getSender()).toThrow('Point is not on curve: Cannot find square root');
+
+      const result = await validateBlockAttestations(block, epochCache, constants, logger);
+      assert(!result.valid);
+      assert(result.reason === 'invalid-attestation');
+      expect(result.block.blockNumber).toEqual(block.block.number);
+      expect(result.block.archive.toString()).toEqual(block.block.archive.root.toString());
+      expect(result.committee).toEqual(committee);
+      expect(result.invalidIndex).toBe(0);
+    });
+
+    it('reports correct index when invalid attestation follows empty signature attestation', async () => {
+      const block = await makeBlock(signers.slice(0, 3), committee);
+
+      // Create an empty signature (index 0) - this will be undefined in getAttestationsFromPublishedL2Block
+      block.attestations[0] = new CommitteeAttestation(EthAddress.ZERO, Signature.empty());
+
+      // Create an invalid signature at index 1 - this should be reported as invalid at index 1, not 0
+      block.attestations[1] = new CommitteeAttestation(EthAddress.ZERO, Signature.random());
+
+      // Index 2 is a valid attestation from signers[2]
+
+      const result = await validateBlockAttestations(block, epochCache, constants, logger);
+      assert(!result.valid);
+      assert(result.reason === 'invalid-attestation');
+      expect(result.invalidIndex).toBe(1); // Should be 1 (the original index), not 0
     });
 
     it('returns false if insufficient attestations', async () => {

--- a/yarn-project/aztec-node/src/sentinel/sentinel.test.ts
+++ b/yarn-project/aztec-node/src/sentinel/sentinel.test.ts
@@ -1,5 +1,5 @@
 import type { EpochCache } from '@aztec/epoch-cache';
-import { times } from '@aztec/foundation/collection';
+import { compactArray, times } from '@aztec/foundation/collection';
 import { Secp256k1Signer } from '@aztec/foundation/crypto';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { AztecLMDBStoreV2, openTmpStore } from '@aztec/kv-store/lmdb-v2';
@@ -124,7 +124,7 @@ describe('sentinel', () => {
 
     it('identifies attestors from p2p and archiver', async () => {
       block = await randomPublishedL2Block(Number(slot), { signers: signers.slice(0, 2) });
-      const attestorsFromBlock = getAttestationsFromPublishedL2Block(block).map(att => att.getSender());
+      const attestorsFromBlock = compactArray(getAttestationsFromPublishedL2Block(block)).map(att => att.getSender());
       expect(attestorsFromBlock.map(a => a.toString())).toEqual(signers.slice(0, 2).map(a => a.address.toString()));
 
       await sentinel.handleBlockStreamEvent({ type: 'blocks-added', blocks: [block] });

--- a/yarn-project/aztec-node/src/sentinel/sentinel.ts
+++ b/yarn-project/aztec-node/src/sentinel/sentinel.ts
@@ -1,5 +1,12 @@
 import type { EpochCache } from '@aztec/epoch-cache';
-import { countWhile, filterAsync, fromEntries, getEntries, mapValues } from '@aztec/foundation/collection';
+import {
+  compactArray,
+  countWhile,
+  filterAsync,
+  fromEntries,
+  getEntries,
+  mapValues,
+} from '@aztec/foundation/collection';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { createLogger } from '@aztec/foundation/log';
 import { RunningPromise } from '@aztec/foundation/running-promise';
@@ -91,7 +98,7 @@ export class Sentinel extends (EventEmitter as new () => WatcherEmitter) impleme
         this.slotNumberToBlock.set(block.block.header.getSlot(), {
           blockNumber: block.block.number,
           archive: block.block.archive.root.toString(),
-          attestors: getAttestationsFromPublishedL2Block(block).map(att => att.getSender()),
+          attestors: compactArray(getAttestationsFromPublishedL2Block(block)).map(att => att.getSender()),
         });
       }
 

--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_invalidate_block.parallel.test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_invalidate_block.parallel.test.ts
@@ -44,7 +44,9 @@ describe('e2e_epochs/epochs_invalidate_block', () => {
 
     // Setup context with the given set of validators, mocked gossip sub network, and no anvil test watcher.
     test = await EpochsTestContext.setup({
-      ethereumSlotDuration: 8,
+      aztecSlotDuration: 8,
+      aztecEpochDuration: 4,
+      ethereumSlotDuration: 4,
       numberOfAccounts: 1,
       initialValidators: validators,
       mockGossipSubNetwork: true,
@@ -177,7 +179,7 @@ describe('e2e_epochs/epochs_invalidate_block', () => {
   // Slot S:   Block N is proposed with invalid attestations
   // Slot S+1: Block N is invalidated, and block N' (same number) is proposed instead, but also has invalid attestations
   // Slot S+2: Proposer tries to invalidate block N, when they should invalidate block N' instead, and fails
-  it('chain progresses if an invalid block is invalidated with an invalid one', async () => {
+  it('chain progresses if a block with insufficient attestations is invalidated with an invalid one', async () => {
     // Configure all sequencers to skip collecting attestations before starting and always build blocks
     logger.warn('Configuring all sequencers to skip attestation collection');
     const sequencers = nodes.map(node => node.getSequencer()!);
@@ -207,6 +209,63 @@ describe('e2e_epochs/epochs_invalidate_block', () => {
     // Disable skipCollectingAttestations
     sequencers.forEach(sequencer => {
       sequencer.updateConfig({ skipCollectingAttestations: false });
+    });
+
+    // Ensure chain progresses
+    const targetBlock = lastInvalidatedBlockNumber! + 2n;
+    logger.warn(`Waiting until block ${targetBlock} has been mined`);
+    await test.monitor.waitUntilL2Block(targetBlock);
+
+    // Wait for all nodes to sync the new block
+    logger.warn(`Waiting for all nodes to sync to block ${targetBlock}`);
+    await retryUntil(
+      async () => {
+        const blockNumbers = await Promise.all(nodes.map(node => node.getBlockNumber()));
+        logger.info(`Node synced block numbers: ${blockNumbers.join(', ')}`);
+        return blockNumbers.every(bn => bn > targetBlock);
+      },
+      'Node sync check',
+      test.L2_SLOT_DURATION_IN_S * 5,
+      0.5,
+    );
+
+    logger.warn(`Test succeeded '${expect.getState().currentTestName}'`);
+  });
+
+  // Regression for Joe's Q42025 London attack. Same as above but with an invalid signature instead of insufficient ones.
+  it('chain progresses if a block with an invalid attestation is invalidated with an invalid one', async () => {
+    // Configure all sequencers to skip collecting attestations before starting and always build blocks
+    logger.warn('Configuring all sequencers to inject one invalid attestation');
+    const sequencers = nodes.map(node => node.getSequencer()!);
+    sequencers.forEach(sequencer => {
+      sequencer.updateConfig({ injectFakeAttestation: true, minTxsPerBlock: 0 });
+    });
+
+    // Start all sequencers
+    await Promise.all(sequencers.map(s => s.start()));
+    logger.warn(`Started all sequencers with injectFakeAttestation=true`);
+
+    // Wait until we see two invalidations, both should be for the same block
+    let lastInvalidatedBlockNumber: bigint | undefined;
+    const invalidatePromise = promiseWithResolvers<void>();
+    const unsubscribe = rollupContract.listenToBlockInvalidated(data => {
+      logger.warn(`Block ${data.blockNumber} has been invalidated`, data);
+      if (lastInvalidatedBlockNumber === undefined) {
+        lastInvalidatedBlockNumber = data.blockNumber;
+      } else {
+        expect(data.blockNumber).toEqual(lastInvalidatedBlockNumber);
+        invalidatePromise.resolve();
+        unsubscribe();
+      }
+    });
+    await Promise.race([
+      timeoutPromise(1000 * test.L2_SLOT_DURATION_IN_S * 8, 'Invalidating blocks'),
+      invalidatePromise.promise,
+    ]);
+
+    // Disable injectFakeAttestation
+    sequencers.forEach(sequencer => {
+      sequencer.updateConfig({ injectFakeAttestation: false });
     });
 
     // Ensure chain progresses

--- a/yarn-project/foundation/src/eth-signature/eth_signature.ts
+++ b/yarn-project/foundation/src/eth-signature/eth_signature.ts
@@ -78,7 +78,7 @@ export class Signature {
   }
 
   static random(): Signature {
-    return new Signature(Buffer32.random(), Buffer32.random(), Math.floor(Math.random() * 2));
+    return new Signature(Buffer32.random(), Buffer32.random(), 1);
   }
 
   static empty(): Signature {

--- a/yarn-project/sequencer-client/src/config.ts
+++ b/yarn-project/sequencer-client/src/config.ts
@@ -145,6 +145,10 @@ export const sequencerConfigMappings: ConfigMappingsType<SequencerConfig> = {
     description: 'Do not invalidate the previous block if invalid when we are the proposer (for testing only)',
     ...booleanConfigHelper(false),
   },
+  injectFakeAttestation: {
+    description: 'Inject a fake attestation (for testing only)',
+    ...booleanConfigHelper(false),
+  },
   ...pickConfigMappings(p2pConfigMappings, ['txPublicSetupAllowList']),
 };
 

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.ts
@@ -3,17 +3,18 @@ import { BLOBS_PER_BLOCK, FIELDS_PER_BLOB, INITIAL_L2_BLOCK_NUM } from '@aztec/c
 import type { EpochCache } from '@aztec/epoch-cache';
 import { FormattedViemError, NoCommitteeError, type RollupContract } from '@aztec/ethereum';
 import { omit, pick } from '@aztec/foundation/collection';
+import { randomInt } from '@aztec/foundation/crypto';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { Signature } from '@aztec/foundation/eth-signature';
 import { Fr } from '@aztec/foundation/fields';
 import { createLogger } from '@aztec/foundation/log';
 import { RunningPromise } from '@aztec/foundation/running-promise';
 import { type DateProvider, Timer } from '@aztec/foundation/timer';
-import type { TypedEventEmitter } from '@aztec/foundation/types';
+import { type TypedEventEmitter, unfreeze } from '@aztec/foundation/types';
 import type { P2P } from '@aztec/p2p';
 import type { SlasherClientInterface } from '@aztec/slasher';
 import {
-  type CommitteeAttestation,
+  CommitteeAttestation,
   CommitteeAttestationsAndSigners,
   type L2BlockSource,
   type ValidateBlockResult,
@@ -767,7 +768,14 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
       collectedAttestationsCount = attestations.length;
 
       // note: the smart contract requires that the signatures are provided in the order of the committee
-      return orderAttestations(attestations, committee);
+      const sorted = orderAttestations(attestations, committee);
+      if (this.config.injectFakeAttestation) {
+        const nonEmpty = sorted.filter(a => !a.signature.isEmpty());
+        const randomIndex = randomInt(nonEmpty.length);
+        this.log.warn(`Injecting fake attestation in block ${block.number}`);
+        unfreeze(nonEmpty[randomIndex]).signature = Signature.random();
+      }
+      return sorted;
     } catch (err) {
       if (err && err instanceof AttestationTimeoutError) {
         collectedAttestationsCount = err.collectedCount;

--- a/yarn-project/stdlib/src/block/published_l2_block.ts
+++ b/yarn-project/stdlib/src/block/published_l2_block.ts
@@ -83,11 +83,17 @@ export class PublishedL2Block {
   }
 }
 
+/**
+ * Extracts block attestations from a published L2 block.
+ * Returns undefined for attestations with empty signatures, preserving array indices.
+ */
 export function getAttestationsFromPublishedL2Block(
   block: Pick<PublishedL2Block, 'attestations' | 'block'>,
-): BlockAttestation[] {
+): (BlockAttestation | undefined)[] {
   const payload = ConsensusPayload.fromBlock(block.block);
-  return block.attestations
-    .filter(attestation => !attestation.signature.isEmpty())
-    .map(attestation => new BlockAttestation(block.block.number, payload, attestation.signature));
+  return block.attestations.map(attestation =>
+    attestation.signature.isEmpty()
+      ? undefined
+      : new BlockAttestation(block.block.number, payload, attestation.signature),
+  );
 }

--- a/yarn-project/stdlib/src/interfaces/configs.ts
+++ b/yarn-project/stdlib/src/interfaces/configs.ts
@@ -52,6 +52,8 @@ export interface SequencerConfig {
   skipCollectingAttestations?: boolean;
   /** Do not invalidate the previous block if invalid when we are the proposer (for testing only) */
   skipInvalidateBlockAsProposer?: boolean;
+  /** Inject a fake attestation (for testing only) */
+  injectFakeAttestation?: boolean;
 }
 
 export const SequencerConfigSchema = z.object({
@@ -75,4 +77,5 @@ export const SequencerConfigSchema = z.object({
   skipCollectingAttestations: z.boolean().optional(),
   secondsBeforeInvalidatingBlockAsCommitteeMember: z.number(),
   secondsBeforeInvalidatingBlockAsNonCommitteeMember: z.number(),
+  injectFakeAttestation: z.boolean().optional(),
 }) satisfies ZodFor<SequencerConfig>;

--- a/yarn-project/stdlib/src/p2p/block_attestation.ts
+++ b/yarn-project/stdlib/src/p2p/block_attestation.ts
@@ -81,6 +81,18 @@ export class BlockAttestation extends Gossipable {
     return this.sender;
   }
 
+  /**
+   * Tries to get the sender of the attestation
+   * @returns The sender of the attestation or undefined if it fails during recovery
+   */
+  tryGetSender(): EthAddress | undefined {
+    try {
+      return this.getSender();
+    } catch {
+      return undefined;
+    }
+  }
+
   getPayload(): Buffer {
     return this.payload.getPayloadToSign(SignatureDomainSeparator.blockAttestation);
   }
@@ -104,5 +116,13 @@ export class BlockAttestation extends Gossipable {
 
   getSize(): number {
     return 4 /* blockNumber */ + this.payload.getSize() + this.signature.getSize();
+  }
+
+  toInspect() {
+    return {
+      blockNumber: this.blockNumber,
+      payload: this.payload.toInspect(),
+      signature: this.signature.toString(),
+    };
   }
 }


### PR DESCRIPTION
## Summary
Fixes a bug where `validateBlockAttestations` was returning incorrect indices for invalid attestations when empty signatures were present.

The issue was that `getAttestationsFromPublishedL2Block` filtered out empty signatures, causing a mismatch between the filtered array indices and the original `publishedBlock.attestations` indices.

Fixes A-127

## Changes
- Modified `getAttestationsFromPublishedL2Block` to return `(BlockAttestation | undefined)[]` instead of filtering, preserving array indices
- Simplified `validateBlockAttestations` to use a single loop instead of tracking both filtered and original indices
- Updated callers in `sentinel.ts` and `sentinel.test.ts` to use `compactArray()` to filter out undefined values
- Added JSDoc comment to `getAttestationsFromPublishedL2Block` explaining the behavior
- Added test case to verify the bug fix: a block with an empty signature at index 0, invalid signature at index 1, and valid signature at index 2 now correctly reports `invalidIndex: 1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)