### PR TITLE
chore: Fix flake regex for boxes test

### DIFF
--- a/.test_patterns.yml
+++ b/.test_patterns.yml
@@ -357,12 +357,13 @@ tests:
     owners:
       - *saleel
 
-  - regex: "BOX=vanilla BROWSER=* run_compose_test vanilla-all-browsers box boxes" # http://ci.aztec-labs.com/49f9945bc00aeef9
+  - regex: "run_compose_test vanilla-all-browsers box boxes" # http://ci.aztec-labs.com/49f9945bc00aeef9
     error_regex: "create account and cast vote"
     owners:
       - *saleel
-  - regex: "BOX=vanilla BROWSER=* run_compose_test vanilla-all-browsers box boxes"
-    error_regex: "Tag mismatch at offset 0, got FIELD, expected UINT32"
+
+  - regex: "run_compose_test vanilla-all-browsers box boxes"
+    error_regex: "Tag mismatch at offset 0|app_logic_reverted"
     owners:
       - *david
 


### PR DESCRIPTION
We had this test flagged as error instead of flake after flagging the "Tag mismatch" error. http://ci.aztec-labs.com/a1ce0effba5a8c66

I tested it locally and the `BROWSER=*` screwed up the regex. Removing it made `./ci3/get_test_owner` work as expected.
