### PR TITLE
fix: check whether a contract is transpiled when loading it - loadContractArtifact

### DIFF
--- a/.test_patterns.yml
+++ b/.test_patterns.yml
@@ -363,7 +363,7 @@ tests:
       - *saleel
 
   - regex: "run_compose_test vanilla-all-browsers box boxes"
-    error_regex: "Tag mismatch at offset 0|app_logic_reverted"
+    error_regex: "Tag mismatch at offset 0|app_logic_reverted|public bytecode has not been transpiled"
     owners:
       - *david
 

--- a/yarn-project/stdlib/src/abi/contract_artifact.ts
+++ b/yarn-project/stdlib/src/abi/contract_artifact.ts
@@ -283,6 +283,9 @@ function getStorageLayout(input: NoirCompiledContract) {
  */
 function generateContractArtifact(contract: NoirCompiledContract): ContractArtifact {
   try {
+    if (!contract.transpiled) {
+      throw new Error("Contract's public bytecode has not been transpiled");
+    }
     return ContractArtifactSchema.parse({
       name: contract.name,
       functions: contract.functions.filter(f => retainBytecode(f)).map(f => generateFunctionArtifact(f, contract)),

--- a/yarn-project/stdlib/src/noir/index.ts
+++ b/yarn-project/stdlib/src/noir/index.ts
@@ -64,6 +64,8 @@ interface NoirFunctionEntry {
 export interface NoirCompiledContract {
   /** The name of the contract. */
   name: string;
+  /** Is the contract's public bytecode transpiled? */
+  transpiled?: boolean;
   /** The functions of the contract. */
   functions: NoirFunctionEntry[];
   /** The events of the contract */


### PR DESCRIPTION
Does not fix whatever bug is causing us to load untranspiled contracts, but will let us (and users) catch it way earlier.