### PR TITLE
chore: flag WebKit browser tests as flaky

### DIFF
--- a/.test_patterns.yml
+++ b/.test_patterns.yml
@@ -72,6 +72,9 @@ tests:
     error_regex: "Aborted.*core dumped"
     owners:
       - *adam
+  - regex: "barretenberg/acir_tests/scripts/browser_prove.sh .* webkit"
+    owners:
+      - *luke
 
   # /home/aztec-dev/aztec-packages/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_edge_cases.test.cpp:142: Failure
   # Expected equality of these values:


### PR DESCRIPTION
This PR flags WebKit browser tests as flaky due to intermittent failures.

See http://ci.aztec-labs.com/76d24c47ab2a42ef

The pattern matches: `barretenberg/acir_tests/scripts/browser_prove.sh .* webkit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)