### PR TITLE
fix: enable AVM in non-release arm64 builds

### DIFF
--- a/barretenberg/cpp/bootstrap.sh
+++ b/barretenberg/cpp/bootstrap.sh
@@ -8,13 +8,6 @@ export native_preset=${NATIVE_PRESET:-clang20}
 export pic_preset=${PIC_PRESET:-clang20-pic}
 export hash=$(cache_content_hash .rebuild_patterns)
 
-if [[ $(arch) == "arm64" && "$CI" -eq 1 ]]; then
-  # Enable AVM for release builds (when REF_NAME is a valid semver), disable for CI/PR builds
-  if ! semver check "$REF_NAME"; then
-    export DISABLE_AZTEC_VM=1
-  fi
-fi
-
 if [ "${DISABLE_AZTEC_VM:-0}" -eq 1 ]; then
   # Make sure the different envs don't read from each other's caches.
   export hash="$hash-no-avm"


### PR DESCRIPTION
This is now needed as we rely on bb to do avm transpilation, and disabling the AVM also disables avm-transpiler linking (which just warns, doesn't error, but maybe we keep it warning now that boxes checks this)
