### PR TITLE
Enforce RPCTranslator oracle completeness and add utilityEmitOffchainEffect

### DIFF
--- a/yarn-project/txe/src/rpc_translator.ts
+++ b/yarn-project/txe/src/rpc_translator.ts
@@ -743,6 +743,14 @@ export class RPCTranslator {
     return toForeignCallResult(secret.toFields().map(toSingle));
   }
 
+  async utilityEmitOffchainEffect(_foreignData: ForeignCallArray) {
+    const data = fromArray(_foreignData);
+
+    await this.handlerAsPrivate().utilityEmitOffchainEffect(data);
+
+    return toForeignCallResult([]);
+  }
+
   emitOffchainEffect(_foreignData: ForeignCallArray) {
     throw new Error('Offchain effects are not yet supported in the TestEnvironment');
   }
@@ -1010,3 +1018,24 @@ export class RPCTranslator {
     return toForeignCallResult([toSingle(nextAppTag)]);
   }
 }
+
+// Compile-time check: ensure RPCTranslator implements all oracle methods
+// across Misc, Utility, Private, AVM, and TXE interfaces.
+type MethodNames<T> = {
+  [K in keyof T]: T[K] extends (...args: any[]) => any ? K : never;
+}[keyof T];
+
+type AllOracleInterfaces =
+  | IMiscOracle
+  | IUtilityExecutionOracle
+  | IPrivateExecutionOracle
+  | IAvmExecutionOracle
+  | ITxeExecutionOracle;
+
+type OracleMethodNames = MethodNames<AllOracleInterfaces>;
+type TranslatorMethodNames = MethodNames<RPCTranslator>;
+
+// If any oracle method name is missing from RPCTranslator, this type will not be `true`
+// and the following constant assignment will fail at compile-time.
+type MissingOracleHandlers = Exclude<OracleMethodNames, TranslatorMethodNames>;
+const __rpcTranslatorImplementsAllOracles: MissingOracleHandlers extends never ? true : never = true;


### PR DESCRIPTION
- Add type-level assertion that validates RPCTranslator implements every method from IMiscOracle | IUtilityExecutionOracle | IPrivateExecutionOracle | IAvmExecutionOracle | ITxeExecutionOracle.
- Implement missing utilityEmitOffchainEffect forwarding to handlerAsPrivate().utilityEmitOffchainEffect.
- Keeps runtime guardrails intact and preserves existing method naming/encoding conventions.

References: Issue #17443