### PR TITLE
feat!: Aggregate multiple pairing points at once

### DIFF
--- a/barretenberg/cpp/scripts/test_civc_standalone_vks_havent_changed.sh
+++ b/barretenberg/cpp/scripts/test_civc_standalone_vks_havent_changed.sh
@@ -13,7 +13,7 @@ cd ..
 # - Generate a hash for versioning: sha256sum bb-civc-inputs.tar.gz
 # - Upload the compressed results: aws s3 cp bb-civc-inputs.tar.gz s3://aztec-ci-artifacts/protocol/bb-civc-inputs-[hash(0:8)].tar.gz
 # Note: In case of the "Test suite failed to run ... Unexpected token 'with' " error, need to run: docker pull aztecprotocol/build:3.0
-pinned_short_hash="6c1efddb"
+pinned_short_hash="a31a4553"
 pinned_civc_inputs_url="https://aztec-ci-artifacts.s3.us-east-2.amazonaws.com/protocol/bb-civc-inputs-${pinned_short_hash}.tar.gz"
 
 function compress_and_upload {

--- a/barretenberg/cpp/scripts/test_civc_standalone_vks_havent_changed.sh
+++ b/barretenberg/cpp/scripts/test_civc_standalone_vks_havent_changed.sh
@@ -13,7 +13,7 @@ cd ..
 # - Generate a hash for versioning: sha256sum bb-civc-inputs.tar.gz
 # - Upload the compressed results: aws s3 cp bb-civc-inputs.tar.gz s3://aztec-ci-artifacts/protocol/bb-civc-inputs-[hash(0:8)].tar.gz
 # Note: In case of the "Test suite failed to run ... Unexpected token 'with' " error, need to run: docker pull aztecprotocol/build:3.0
-pinned_short_hash="a31a4553"
+pinned_short_hash="593caa9c"
 pinned_civc_inputs_url="https://aztec-ci-artifacts.s3.us-east-2.amazonaws.com/protocol/bb-civc-inputs-${pinned_short_hash}.tar.gz"
 
 function compress_and_upload {

--- a/barretenberg/cpp/scripts/test_civc_standalone_vks_havent_changed.sh
+++ b/barretenberg/cpp/scripts/test_civc_standalone_vks_havent_changed.sh
@@ -13,7 +13,7 @@ cd ..
 # - Generate a hash for versioning: sha256sum bb-civc-inputs.tar.gz
 # - Upload the compressed results: aws s3 cp bb-civc-inputs.tar.gz s3://aztec-ci-artifacts/protocol/bb-civc-inputs-[hash(0:8)].tar.gz
 # Note: In case of the "Test suite failed to run ... Unexpected token 'with' " error, need to run: docker pull aztecprotocol/build:3.0
-pinned_short_hash="593caa9c"
+pinned_short_hash="aa8573aa"
 pinned_civc_inputs_url="https://aztec-ci-artifacts.s3.us-east-2.amazonaws.com/protocol/bb-civc-inputs-${pinned_short_hash}.tar.gz"
 
 function compress_and_upload {

--- a/barretenberg/cpp/src/barretenberg/client_ivc/sumcheck_client_ivc.cpp
+++ b/barretenberg/cpp/src/barretenberg/client_ivc/sumcheck_client_ivc.cpp
@@ -90,7 +90,7 @@ void SumcheckClientIVC::instantiate_stdlib_verification_queue(
  * tables as read from the proof by the Merge verifier
  */
 std::tuple<std::optional<SumcheckClientIVC::RecursiveVerifierAccumulator>,
-           SumcheckClientIVC::PairingPoints,
+           std::vector<SumcheckClientIVC::PairingPoints>,
            SumcheckClientIVC::TableCommitments>
 SumcheckClientIVC::perform_recursive_verification_and_databus_consistency_checks(
     ClientCircuit& circuit,
@@ -101,8 +101,8 @@ SumcheckClientIVC::perform_recursive_verification_and_databus_consistency_checks
 {
     using MergeCommitments = Goblin::MergeRecursiveVerifier::InputCommitments;
 
-    // The pairing points produced by the verification of the decider proof
-    PairingPoints decider_pairing_points;
+    // PairingPoints to be returned for aggregation
+    std::vector<PairingPoints> pairing_points;
 
     // Input commitments to be passed to the merge recursive verification
     MergeCommitments merge_commitments{ .T_prev_commitments = T_prev_commitments };
@@ -152,7 +152,7 @@ SumcheckClientIVC::perform_recursive_verification_and_databus_consistency_checks
 
         RecursiveDeciderVerifier decider_verifier(accumulation_recursive_transcript);
         StdlibProof stdlib_decider_proof(circuit, decider_proof);
-        decider_pairing_points = decider_verifier.verify_proof(final_verifier_accumulator, stdlib_decider_proof);
+        pairing_points.emplace_back(decider_verifier.verify_proof(final_verifier_accumulator, stdlib_decider_proof));
 
         BB_ASSERT_EQ(output_verifier_accumulator.has_value(), false);
         break;
@@ -166,13 +166,12 @@ SumcheckClientIVC::perform_recursive_verification_and_databus_consistency_checks
     WitnessCommitments witness_commitments = std::move(verifier_instance->witness_commitments);
     std::vector<StdlibFF> public_inputs = std::move(verifier_instance->public_inputs);
 
-    PairingPoints nested_pairing_points; // to be extracted from public inputs of app or kernel proof just verified
-
     if (verifier_inputs.is_kernel) {
         // Reconstruct the input from the previous kernel from its public inputs
         KernelIO kernel_input; // pairing points, databus return data commitments
         kernel_input.reconstruct_from_public(public_inputs);
-        nested_pairing_points = kernel_input.pairing_inputs;
+        // Add pairing points for aggregation
+        pairing_points.emplace_back(kernel_input.pairing_inputs);
         // Perform databus consistency checks
         kernel_input.kernel_return_data.incomplete_assert_equal(witness_commitments.calldata);
         kernel_input.app_return_data.incomplete_assert_equal(witness_commitments.secondary_calldata);
@@ -198,7 +197,8 @@ SumcheckClientIVC::perform_recursive_verification_and_databus_consistency_checks
         // Reconstruct the input from the previous app from its public inputs
         AppIO app_input; // pairing points
         app_input.reconstruct_from_public(public_inputs);
-        nested_pairing_points = app_input.pairing_inputs;
+        // Add pairing points for aggregation
+        pairing_points.emplace_back(app_input.pairing_inputs);
 
         // Set the app return data commitment to be propagated via the public inputs
         bus_depot.set_app_return_data_commitment(witness_commitments.return_data);
@@ -208,16 +208,9 @@ SumcheckClientIVC::perform_recursive_verification_and_databus_consistency_checks
     merge_commitments.t_commitments = witness_commitments.get_ecc_op_wires().get_copy();
 
     // Recursively verify the corresponding merge proof
-    auto [pairing_points, merged_table_commitments] =
+    auto [merge_pairing_points, merged_table_commitments] =
         goblin.recursively_verify_merge(circuit, merge_commitments, accumulation_recursive_transcript);
-
-    pairing_points.aggregate(nested_pairing_points);
-    if (is_hiding_kernel) {
-        pairing_points.aggregate(decider_pairing_points);
-        // Add randomness at the end of the hiding kernel (whose ecc ops fall right at the end of the op queue table) to
-        // ensure the CIVC proof doesn't leak information about the actual content of the op queue
-        hide_op_queue_content_in_hiding(circuit);
-    }
+    pairing_points.emplace_back(merge_pairing_points);
 
     return { output_verifier_accumulator, pairing_points, merged_table_commitments };
 }
@@ -268,7 +261,7 @@ void SumcheckClientIVC::complete_kernel_circuit_logic(ClientCircuit& circuit)
     circuit.queue_ecc_eq();
 
     // Perform Oink/PG and Merge recursive verification + databus consistency checks for each entry in the queue
-    PairingPoints points_accumulator;
+    std::vector<PairingPoints> points_accumulator;
     std::optional<RecursiveVerifierAccumulator> current_stdlib_verifier_accumulator;
     if (!is_init_kernel) {
         current_stdlib_verifier_accumulator = RecursiveVerifierAccumulator::stdlib_from_native<RecursiveFlavor::Curve>(
@@ -283,7 +276,7 @@ void SumcheckClientIVC::complete_kernel_circuit_logic(ClientCircuit& circuit)
                                                                           current_stdlib_verifier_accumulator,
                                                                           T_prev_commitments,
                                                                           accumulation_recursive_transcript);
-        points_accumulator.aggregate(pairing_points);
+        points_accumulator.insert(points_accumulator.end(), pairing_points.begin(), pairing_points.end());
         // Update commitment to the status of the op_queue
         T_prev_commitments = merged_table_commitments;
         // Update the output verifier accumulator
@@ -291,10 +284,18 @@ void SumcheckClientIVC::complete_kernel_circuit_logic(ClientCircuit& circuit)
 
         stdlib_verification_queue.pop_front();
     }
+
+    // PairingPoint aggregation
+    PairingPoints pairing_points_aggregator = PairingPoints::aggregate_multiple(points_accumulator);
+
     // Set the kernel output data to be propagated via the public inputs
     if (is_hiding_kernel) {
         BB_ASSERT_EQ(current_stdlib_verifier_accumulator.has_value(), false);
-        HidingKernelIO hiding_output{ points_accumulator, T_prev_commitments };
+        // Add randomness at the end of the hiding kernel (whose ecc ops fall right at the end of the op queue table) to
+        // ensure the CIVC proof doesn't leak information about the actual content of the op queue
+        hide_op_queue_content_in_hiding(circuit);
+
+        HidingKernelIO hiding_output{ pairing_points_aggregator, T_prev_commitments };
         hiding_output.set_public();
     } else {
         BB_ASSERT_NEQ(current_stdlib_verifier_accumulator.has_value(), false);
@@ -302,7 +303,7 @@ void SumcheckClientIVC::complete_kernel_circuit_logic(ClientCircuit& circuit)
         recursive_verifier_native_accum = current_stdlib_verifier_accumulator->get_value<VerifierAccumulator>();
 
         KernelIO kernel_output;
-        kernel_output.pairing_inputs = points_accumulator;
+        kernel_output.pairing_inputs = pairing_points_aggregator;
         kernel_output.kernel_return_data = bus_depot.get_kernel_return_data_commitment(circuit);
         kernel_output.app_return_data = bus_depot.get_app_return_data_commitment(circuit);
         kernel_output.ecc_op_tables = T_prev_commitments;

--- a/barretenberg/cpp/src/barretenberg/client_ivc/sumcheck_client_ivc.hpp
+++ b/barretenberg/cpp/src/barretenberg/client_ivc/sumcheck_client_ivc.hpp
@@ -286,7 +286,7 @@ class SumcheckClientIVC : public IVCBase {
                                                const std::vector<std::shared_ptr<RecursiveVKAndHash>>& input_keys = {});
 
     [[nodiscard("Pairing points should be accumulated")]] std::
-        tuple<std::optional<RecursiveVerifierAccumulator>, PairingPoints, TableCommitments>
+        tuple<std::optional<RecursiveVerifierAccumulator>, std::vector<PairingPoints>, TableCommitments>
         perform_recursive_verification_and_databus_consistency_checks(
             ClientCircuit& circuit,
             const StdlibVerifierInputs& verifier_inputs,

--- a/barretenberg/cpp/src/barretenberg/client_ivc/sumcheck_client_ivc.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/client_ivc/sumcheck_client_ivc.test.cpp
@@ -296,7 +296,7 @@ HEAVY_TEST(SumcheckClientIVCKernelCapacity, MaxCapacityPassing)
 {
     bb::srs::init_file_crs_factory(bb::srs::bb_crs_path());
 
-    const size_t NUM_APP_CIRCUITS = 24;
+    const size_t NUM_APP_CIRCUITS = 27;
     auto [proof, vk] = SumcheckClientIVCTests::accumulate_and_prove_ivc(NUM_APP_CIRCUITS);
 
     bool verified = SumcheckClientIVC::verify(proof, vk);

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/pairing_points.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/pairing_points.hpp
@@ -58,6 +58,50 @@ template <typename Builder_> struct PairingPoints {
     typename Curve::bool_ct operator==(PairingPoints const& other) const { return P0 == other.P0 && P1 == other.P1; };
 
     /**
+     * @brief Aggregate multiple PairingPoints
+     *
+     * @details The pairing points are aggregated using challenges generated as the consecutive hashes of the pairing
+     * points being aggregated.
+     */
+    static PairingPoints aggregate_multiple(std::vector<PairingPoints>& pairing_points)
+    {
+        size_t num_points = pairing_points.size();
+        BB_ASSERT_GT(num_points, 1UL, "This method should be used only with more than one pairing point.");
+
+        std::vector<Group> first_components;
+        first_components.reserve(num_points);
+        std::vector<Group> second_components;
+        second_components.reserve(num_points);
+        for (const auto& points : pairing_points) {
+            first_components.emplace_back(points.P0);
+            second_components.emplace_back(points.P1);
+        }
+
+        // Fiat-Shamir
+        StdlibTranscript<Builder> transcript{};
+        std::vector<std::string> labels;
+        labels.reserve(num_points);
+        for (size_t idx = 0; auto [first, second] : zip_view(first_components, second_components)) {
+            transcript.add_to_hash_buffer("first_component_" + std::to_string(idx), first);
+            transcript.add_to_hash_buffer("second_component_" + std::to_string(idx), second);
+            labels.emplace_back("pp_aggregation_challenge_" + std::to_string(idx));
+            idx++;
+        }
+
+        std::vector<Fr> challenges;
+        challenges.reserve(num_points);
+        for (size_t idx = 0; idx < num_points; idx++) {
+            challenges.emplace_back(transcript.template get_challenge<Fr>(labels[idx]));
+        }
+
+        // Batch mul
+        auto P0 = Group::batch_mul(first_components, challenges);
+        auto P1 = Group::batch_mul(second_components, challenges);
+
+        return { P0, P1 };
+    }
+
+    /**
      * @brief Compute a linear combination of the present pairing points with an input set of pairing points
      * @details The linear combination is done with a recursion separator that is the hash of the two sets of pairing
      * points.

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/pairing_points.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/pairing_points.hpp
@@ -27,6 +27,7 @@ static constexpr bb::fq DEFAULT_PAIRING_POINTS_P1_Y(
  * multiple sets of pairing points.
  *
  * TODO(https://github.com/AztecProtocol/barretenberg/issues/1421): Proper tests for `PairingPoints`
+ * TODO(https://github.com/AztecProtocol/barretenberg/issues/1571): Implement tagging mechanism
  * @tparam Builder_
  */
 template <typename Builder_> struct PairingPoints {
@@ -88,11 +89,7 @@ template <typename Builder_> struct PairingPoints {
             idx++;
         }
 
-        std::vector<Fr> challenges;
-        challenges.reserve(num_points);
-        for (size_t idx = 0; idx < num_points; idx++) {
-            challenges.emplace_back(transcript.template get_challenge<Fr>(labels[idx]));
-        }
+        std::vector<Fr> challenges = transcript.template get_challenges<Fr>(labels);
 
         // Batch mul
         auto P0 = Group::batch_mul(first_components, challenges);
@@ -108,8 +105,6 @@ template <typename Builder_> struct PairingPoints {
      * @param other
      * @param recursion_separator
      */
-    // TODO(https://github.com/AztecProtocol/barretenberg/issues/1376): Potentially switch a batch_mul approach to
-    // aggregation rather than individually aggregating 1 object at a time.
     void aggregate(PairingPoints const& other)
     {
         BB_ASSERT(other.has_data, "Cannot aggregate null pairing points.");
@@ -122,7 +117,6 @@ template <typename Builder_> struct PairingPoints {
         // We use a Transcript because it provides us an easy way to hash to get a "random" separator.
         StdlibTranscript<Builder> transcript{};
         // TODO(https://github.com/AztecProtocol/barretenberg/issues/1375): Sometimes unnecesarily hashing constants
-
         transcript.add_to_hash_buffer("Accumulator_P0", P0);
         transcript.add_to_hash_buffer("Accumulator_P1", P1);
         transcript.add_to_hash_buffer("Aggregated_P0", other.P0);


### PR DESCRIPTION
Instead of aggregating pairing points in couple, we aggregate them in one shot. This saves us 194 ECCVM rows per inner kernel. Max capacity goes from 24 to 27.

Closes https://github.com/AztecProtocol/barretenberg/issues/1376