### PR TITLE
Issue repro: Reading append-only tree beyond max index

### DIFF
--- a/yarn-project/simulator/src/public/avm/opcodes/accrued_substate.ts
+++ b/yarn-project/simulator/src/public/avm/opcodes/accrued_substate.ts
@@ -42,8 +42,9 @@ export class NoteHashExists extends Instruction {
     // Note that this instruction accepts any type in memory, and converts to Field.
     const noteHash = memory.get(noteHashOffset).toFr();
     const leafIndex = memory.get(leafIndexOffset).toBigInt();
-
+    console.log('in accrued_substate.ts, executing note hash exists for', noteHash, 'at: ', leafIndex);
     const exists = await context.persistableState.checkNoteHashExists(context.environment.address, noteHash, leafIndex);
+    console.log('executed checkNoteHashExists result, exists = ', exists);
     memory.set(existsOffset, exists ? new Uint1(1) : new Uint1(0));
   }
 }

--- a/yarn-project/simulator/src/public/fixtures/minimal_public_tx.ts
+++ b/yarn-project/simulator/src/public/fixtures/minimal_public_tx.ts
@@ -3,7 +3,7 @@ import { ProtocolContracts } from '@aztec/stdlib/tx';
 
 import avmMinimalCircuitInputsJson from '../../../artifacts/avm_minimal_inputs.json' with { type: 'json' };
 import { TypeTag } from '../avm/avm_memory_types.js';
-import { Add, Return, Set } from '../avm/opcodes/index.js';
+import { Add, EmitNoteHash, NoteHashExists, Return, Set } from '../avm/opcodes/index.js';
 import { encodeToBytecode } from '../avm/serialization/bytecode_serialization.js';
 import { Opcode } from '../avm/serialization/instruction_serialization.js';
 import type { PublicTxResult } from '../public_tx_simulator/public_tx_simulator.js';
@@ -14,7 +14,36 @@ export async function simAvmMinimalPublicTx(): Promise<PublicTxResult> {
   const minimalBytecode = encodeToBytecode([
     new Set(/*indirect*/ 0, /*dstOffset*/ 0, TypeTag.UINT32, /*value*/ 1).as(Opcode.SET_8, Set.wireFormat8),
     new Set(/*indirect*/ 0, /*dstOffset*/ 1, TypeTag.UINT32, /*value*/ 2).as(Opcode.SET_8, Set.wireFormat8),
-    new Add(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).as(Opcode.ADD_8, Add.wireFormat8),
+    // Set some FF value at offset = 3:
+    new Set(/*indirect*/ 0, /*dstOffset*/ 3, TypeTag.FIELD, /*value*/ 20).as(Opcode.SET_8, Set.wireFormat8),
+    // Set 1 at offset = 4:
+    new Set(/*indirect*/ 0, /*dstOffset*/ 4, TypeTag.UINT64, /*value*/ 1).as(Opcode.SET_8, Set.wireFormat8),
+    // Add a note hash at index = 0:
+    new EmitNoteHash(/*indirect*/ 0, /*noteHashOffset*/ 3).as(Opcode.EMITNOTEHASH, EmitNoteHash.wireFormat),
+    // Add a note hash at index = 1:
+    new EmitNoteHash(/*indirect*/ 0, /*noteHashOffset*/ 3).as(Opcode.EMITNOTEHASH, EmitNoteHash.wireFormat),
+    // The note hash is siloed, so won't match the value, but will correctly get the siloed hash from index 1:
+    new NoteHashExists(/*indirect*/ 0, /*noteHashOffset*/ 3, /*leafIndexOffset*/ 4, /*existsOffset*/ 5).as(
+      Opcode.NOTEHASHEXISTS,
+      NoteHashExists.wireFormat,
+    ),
+    // Set 2 at offset = 4:
+    new Set(/*indirect*/ 0, /*dstOffset*/ 4, TypeTag.UINT64, /*value*/ 2).as(Opcode.SET_8, Set.wireFormat8),
+    // Below returns null from world_state at index 2, since it's an unwritten leaf:
+    new NoteHashExists(/*indirect*/ 0, /*noteHashOffset*/ 3, /*leafIndexOffset*/ 4, /*existsOffset*/ 5).as(
+      Opcode.NOTEHASHEXISTS,
+      NoteHashExists.wireFormat,
+    ),
+    // Set MAX_INDEX + 1 at offset = 4:
+    new Set(/*indirect*/ 0, /*dstOffset*/ 4, TypeTag.UINT64, /*value*/ 4398046511105n).as(
+      Opcode.SET_64,
+      Set.wireFormat64,
+    ),
+    // Below INCORRECTLY gets the siloed hash from index 1 when looking for a leaf at  MAX_INDEX + 1 :
+    new NoteHashExists(/*indirect*/ 0, /*noteHashOffset*/ 3, /*leafIndexOffset*/ 4, /*existsOffset*/ 5).as(
+      Opcode.NOTEHASHEXISTS,
+      NoteHashExists.wireFormat,
+    ),
     new Return(/*indirect=*/ 0, /*copySizeOffset=*/ 0, /*returnOffset=*/ 2),
   ]);
 

--- a/yarn-project/simulator/src/public/public_db_sources.ts
+++ b/yarn-project/simulator/src/public/public_db_sources.ts
@@ -338,10 +338,13 @@ export class PublicTreesDB implements PublicStateDBInterface {
   }
 
   public async getNoteHash(leafIndex: bigint): Promise<Fr | undefined> {
+    // accrued substate -> state manager -> here
     const timer = new Timer();
     const leafValue = await this.db.getLeafValue(MerkleTreeId.NOTE_HASH_TREE, leafIndex);
     // TODO: We need this for the hints. See class comment for more details.
     await this.db.getSiblingPath(MerkleTreeId.NOTE_HASH_TREE, leafIndex);
+
+    console.log('in public_db_sources.ts, leafValue: ', leafValue, 'at: ', leafIndex);
 
     this.logger.debug(`Fetched note hash leaf value (leafIndex=${leafIndex}, value=${leafValue})`, {
       eventName: 'public-db-access',

--- a/yarn-project/simulator/src/public/public_tx_simulator/apps_tests/avm_minimal.test.ts
+++ b/yarn-project/simulator/src/public/public_tx_simulator/apps_tests/avm_minimal.test.ts
@@ -20,13 +20,14 @@ describe('Public TX simulator apps tests: AvmMinimalTestContract', () => {
     expect(expectedAvmInputs).toStrictEqual(inputs);
   });
 
-  it('Minimal Tx avm inputs snapshot loaded from json file', async () => {
+  it.only('Minimal Tx avm inputs snapshot loaded from json file', async () => {
     // If the test data needs to be updated, run the above ^ test case
     // with AZTEC_GENERATE_TEST_DATA=1, and _then_ rerun this test and it should pass.
     const result = await simAvmMinimalPublicTx();
-    const inputs = result.avmProvingRequest.inputs;
-    const avmInputsFromFile = readAvmMinimalPublicTxInputsFromFile();
-    expect(inputs).toStrictEqual(avmInputsFromFile);
+    console.log('res (check note hashes):', result);
+    // const inputs = result.avmProvingRequest.inputs;
+    // const avmInputsFromFile = readAvmMinimalPublicTxInputsFromFile();
+    // expect(inputs).toStrictEqual(avmInputsFromFile);
   });
 
   // This test makes sure that any TS changes are propagated to the testdata,

--- a/yarn-project/simulator/src/public/state_manager/state_manager.ts
+++ b/yarn-project/simulator/src/public/state_manager/state_manager.ts
@@ -185,8 +185,10 @@ export class PublicPersistableStateManager {
    * @returns true if the note hash exists at the given leaf index, false otherwise
    */
   public async checkNoteHashExists(contractAddress: AztecAddress, noteHash: Fr, leafIndex: bigint): Promise<boolean> {
+    // accrued substate -> here
     const gotLeafValue = await this.treesDB.getNoteHash(leafIndex);
     const exists = gotLeafValue !== undefined && gotLeafValue.equals(noteHash);
+    console.log('in state_manager.ts, gotLeafValue: ', gotLeafValue, 'at: ', leafIndex);
     this.log.trace(
       `noteHashes(${contractAddress})@${noteHash} ?? leafIndex: ${leafIndex} | gotLeafValue: ${gotLeafValue}, exists: ${exists}.`,
     );

--- a/yarn-project/world-state/src/native/merkle_trees_facade.ts
+++ b/yarn-project/world-state/src/native/merkle_trees_facade.ts
@@ -99,6 +99,7 @@ export class MerkleTreesFacade implements MerkleTreeReadOperations {
     treeId: ID,
     leafIndex: bigint,
   ): Promise<MerkleTreeLeafType<ID> | undefined> {
+    // accrued substate -> state manager -> public db sources -> here
     const resp = await this.instance.call(WorldStateMessageType.GET_LEAF_VALUE, {
       leafIndex,
       revision: this.revision,
@@ -106,10 +107,18 @@ export class MerkleTreesFacade implements MerkleTreeReadOperations {
     });
 
     if (!resp) {
+      // Expected if index OOR:
+      console.log('in merkle_trees_facade.ts, returned no resp from world state for index: ', leafIndex);
       return undefined;
     }
 
     const leaf = deserializeLeafValue(resp);
+    console.log(
+      'in merkle_trees_facade.ts, returned non-null resp from world state for index: ',
+      leafIndex,
+      ': ',
+      leaf,
+    );
     if (leaf instanceof Fr) {
       return leaf as any;
     } else {


### PR DESCRIPTION
### Repro

(Related to #17330)

- `./bootstrap.sh`
- `cd yarn-project && ./bootstrap.sh` (root bootstrap won't like the console logs, so need to run again!)
- `cd simulator && yarn build` (sometimes bootstrap will use the cache despite changes in `/simulator`)
- `LOG_LEVEL=trace yarn test minimal`

Note in the logs that:

- We return an actual leaf for the out of range index e.g.:
```
in merkle_trees_facade.ts, returned non-null resp from world state for index:  4398046511105n :  Fr<0x0f7a161bbb1c5633810c356724c23d7a5fdbe7993e35f15954d3bbb57e986df7>
in public_db_sources.ts, leafValue:  Fr<0x0f7a161bbb1c5633810c356724c23d7a5fdbe7993e35f15954d3bbb57e986df7> at:  4398046511105n
in state_manager.ts, gotLeafValue:  Fr<0x0f7a161bbb1c5633810c356724c23d7a5fdbe7993e35f15954d3bbb57e986df7> at:  4398046511105n
```
(where in my case, `0x0f7a161bbb1c5633810c356724c23d7a5fdbe7993e35f15954d3bbb57e986df7` lives at index 1)
 - We return null for a valid index but unwritten leaf e.g.:

```
in merkle_trees_facade.ts, returned no resp from world state for index:  2n
in public_db_sources.ts, leafValue:  undefined at:  2n
in state_manager.ts, gotLeafValue:  undefined at:  2n
```

### Planned fix

 - Return null for index > max_index from world state
 - Return 0-value leaf for unwritten but valid (<= max_index) from world state
