### PR TITLE
feat: Batching wallet interface

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -25,6 +25,7 @@
     "awsvpc",
     "aztecprotocol",
     "barretenberg",
+    "batchable",
     "bbfree",
     "bbmalloc",
     "benesjan",
@@ -399,5 +400,12 @@
     "lib",
     "*.cmake"
   ],
-  "flagWords": ["anonymous", "offence", "offences", "on-chain", "off-chain", "out-of-band"]
+  "flagWords": [
+    "anonymous",
+    "offence",
+    "offences",
+    "on-chain",
+    "off-chain",
+    "out-of-band"
+  ]
 }

--- a/yarn-project/aztec.js/src/wallet/wallet.test.ts
+++ b/yarn-project/aztec.js/src/wallet/wallet.test.ts
@@ -1,0 +1,362 @@
+import type { ChainInfo } from '@aztec/entrypoints/interfaces';
+import { ExecutionPayload } from '@aztec/entrypoints/payload';
+import { Fr } from '@aztec/foundation/fields';
+import { type JsonRpcTestContext, createJsonRpcTestSetup } from '@aztec/foundation/json-rpc/test';
+import type { ContractArtifact, EventMetadataDefinition } from '@aztec/stdlib/abi';
+import { EventSelector } from '@aztec/stdlib/abi';
+import { AuthWitness } from '@aztec/stdlib/auth-witness';
+import { AztecAddress } from '@aztec/stdlib/aztec-address';
+import type { ContractClassMetadata, ContractInstanceWithAddress, ContractMetadata } from '@aztec/stdlib/contract';
+import { PublicKeys } from '@aztec/stdlib/keys';
+import {
+  Tx,
+  TxHash,
+  TxProfileResult,
+  TxProvingResult,
+  TxReceipt,
+  TxSimulationResult,
+  UtilitySimulationResult,
+} from '@aztec/stdlib/tx';
+
+import type {
+  Aliased,
+  BatchableMethods,
+  BatchedMethod,
+  ProfileOptions,
+  SendOptions,
+  SimulateOptions,
+  Wallet,
+} from './wallet.js';
+import { WalletSchema } from './wallet.js';
+
+describe('WalletSchema', () => {
+  let handler: MockWallet;
+  let context: JsonRpcTestContext<Wallet>;
+
+  const tested: Set<string> = new Set();
+
+  beforeEach(async () => {
+    handler = new MockWallet();
+    context = await createJsonRpcTestSetup<Wallet>(handler, WalletSchema);
+  });
+
+  afterEach(() => {
+    tested.add(/^WalletSchema\s+([^(]+)/.exec(expect.getState().currentTestName!)![1]);
+    context.httpServer.close();
+  });
+
+  afterAll(() => {
+    const all = Object.keys(WalletSchema);
+    expect([...tested].sort()).toEqual(all.sort());
+  });
+
+  it('getChainInfo', async () => {
+    const result = await context.client.getChainInfo();
+    expect(result).toEqual({
+      chainId: expect.any(Fr),
+      version: expect.any(Fr),
+    });
+  });
+
+  it('getContractClassMetadata', async () => {
+    const result = await context.client.getContractClassMetadata(Fr.random(), true);
+    expect(result.contractClass).toBeDefined();
+    expect(result.contractClass?.id).toBeInstanceOf(Fr);
+    expect(result.isContractClassPubliclyRegistered).toBe(true);
+    expect(result.artifact).toBeDefined();
+  });
+
+  it('getContractMetadata', async () => {
+    const result = await context.client.getContractMetadata(await AztecAddress.random());
+    expect(result).toEqual({
+      contractInstance: {
+        address: expect.any(AztecAddress),
+        currentContractClassId: expect.any(Fr),
+        deployer: expect.any(AztecAddress),
+        initializationHash: expect.any(Fr),
+        originalContractClassId: expect.any(Fr),
+        publicKeys: expect.any(PublicKeys),
+        salt: expect.any(Fr),
+        version: 1,
+      },
+      isContractInitialized: true,
+      isContractPublished: true,
+    });
+  });
+
+  it('getTxReceipt', async () => {
+    const result = await context.client.getTxReceipt(TxHash.random());
+    expect(result).toBeInstanceOf(TxReceipt);
+  });
+
+  it('getPrivateEvents', async () => {
+    const eventMetadata: EventMetadataDefinition = {
+      eventSelector: EventSelector.fromField(new Fr(1)),
+      abiType: { kind: 'field' },
+      fieldNames: ['field1'],
+    };
+    const result = await context.client.getPrivateEvents(await AztecAddress.random(), eventMetadata, 0, 10, [
+      await AztecAddress.random(),
+    ]);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBeDefined();
+  });
+
+  it('registerSender', async () => {
+    const result = await context.client.registerSender(await AztecAddress.random(), 'test-alias');
+    expect(result).toBeInstanceOf(AztecAddress);
+  });
+
+  it('getSenders', async () => {
+    const result = await context.client.getSenders();
+    expect(result).toEqual([{ alias: 'sender1', item: expect.any(AztecAddress) }]);
+  });
+
+  it('getAccounts', async () => {
+    const result = await context.client.getAccounts();
+    expect(result).toEqual([{ alias: 'account1', item: expect.any(AztecAddress) }]);
+  });
+
+  it('registerContract', async () => {
+    const mockArtifact: ContractArtifact = {
+      name: 'TestContract',
+      functions: [],
+      nonDispatchPublicFunctions: [],
+      outputs: { structs: {}, globals: {} },
+      fileMap: {},
+      storageLayout: {},
+    };
+    const result = await context.client.registerContract(await AztecAddress.random(), mockArtifact, Fr.random());
+    expect(result).toEqual({
+      address: expect.any(AztecAddress),
+      currentContractClassId: expect.any(Fr),
+      deployer: expect.any(AztecAddress),
+      initializationHash: expect.any(Fr),
+      originalContractClassId: expect.any(Fr),
+      publicKeys: expect.any(PublicKeys),
+      salt: expect.any(Fr),
+      version: 1,
+    });
+  });
+
+  it('simulateTx', async () => {
+    const exec: ExecutionPayload = {
+      calls: [],
+      authWitnesses: [],
+      capsules: [],
+      extraHashedArgs: [],
+    };
+    const opts: SimulateOptions = {
+      from: await AztecAddress.random(),
+    };
+    const result = await context.client.simulateTx(exec, opts);
+    expect(result).toBeInstanceOf(TxSimulationResult);
+  });
+
+  it('simulateUtility', async () => {
+    const result = await context.client.simulateUtility('testFunction', [Fr.random()], await AztecAddress.random(), [
+      AuthWitness.random(),
+    ]);
+    expect(result).toBeInstanceOf(UtilitySimulationResult);
+  });
+
+  it('profileTx', async () => {
+    const exec: ExecutionPayload = {
+      calls: [],
+      authWitnesses: [],
+      capsules: [],
+      extraHashedArgs: [],
+    };
+    const opts: ProfileOptions = {
+      from: await AztecAddress.random(),
+      profileMode: 'gates',
+    };
+    const result = await context.client.profileTx(exec, opts);
+    expect(result).toBeInstanceOf(TxProfileResult);
+  });
+
+  it('proveTx', async () => {
+    const exec: ExecutionPayload = {
+      calls: [],
+      authWitnesses: [],
+      capsules: [],
+      extraHashedArgs: [],
+    };
+    const opts: SendOptions = {
+      from: await AztecAddress.random(),
+    };
+    const result = await context.client.proveTx(exec, opts);
+    expect(result).toBeInstanceOf(TxProvingResult);
+  });
+
+  it('sendTx', async () => {
+    const tx = Tx.random();
+    const result = await context.client.sendTx(tx);
+    expect(result).toBeInstanceOf(TxHash);
+  });
+
+  it('createAuthWit', async () => {
+    const result = await context.client.createAuthWit(await AztecAddress.random(), Fr.random());
+    expect(result).toBeInstanceOf(AuthWitness);
+  });
+
+  it('batch', async () => {
+    const address1 = await AztecAddress.random();
+    const address2 = await AztecAddress.random();
+    const exec: ExecutionPayload = {
+      calls: [],
+      authWitnesses: [],
+      capsules: [],
+      extraHashedArgs: [],
+    };
+    const opts: SendOptions = {
+      from: await AztecAddress.random(),
+    };
+
+    const methods: BatchedMethod<keyof BatchableMethods>[] = [
+      { name: 'registerSender', args: [address1, 'alias1'] },
+      { name: 'registerContract', args: [address2, undefined, undefined] },
+      { name: 'proveTx', args: [exec, opts] },
+    ];
+
+    const results = await context.client.batch(methods);
+    expect(results).toHaveLength(3);
+    expect(results[0]).toBeInstanceOf(AztecAddress); // registerSender result
+    expect(results[1]).toHaveProperty('address'); // registerContract result
+    expect(results[2]).toBeInstanceOf(TxProvingResult); // proveTx result
+  });
+});
+
+// eslint-disable-next-line jsdoc/require-jsdoc
+class MockWallet implements Wallet {
+  getChainInfo(): Promise<ChainInfo> {
+    return Promise.resolve({
+      chainId: Fr.random(),
+      version: Fr.random(),
+    });
+  }
+
+  getContractClassMetadata(_id: Fr, _includeArtifact?: boolean): Promise<ContractClassMetadata> {
+    return Promise.resolve({
+      contractClass: {
+        version: 1,
+        id: Fr.random(),
+        artifactHash: Fr.random(),
+        privateFunctions: [],
+        publicBytecodeCommitment: Fr.random(),
+        unconstrainedFunctionsArtifactTreeRoot: Fr.random(),
+        packedBytecode: Buffer.from('1234', 'hex'),
+      },
+      isContractClassPubliclyRegistered: true,
+      artifact: {
+        name: 'MockContract',
+        functions: [],
+        nonDispatchPublicFunctions: [],
+        outputs: { structs: {}, globals: {} },
+        fileMap: {},
+        storageLayout: {},
+      },
+    });
+  }
+
+  async getContractMetadata(_address: AztecAddress): Promise<ContractMetadata> {
+    return {
+      contractInstance: {
+        version: 1,
+        address: await AztecAddress.random(),
+        currentContractClassId: Fr.random(),
+        deployer: await AztecAddress.random(),
+        initializationHash: Fr.random(),
+        originalContractClassId: Fr.random(),
+        publicKeys: await PublicKeys.random(),
+        salt: Fr.random(),
+      },
+      isContractInitialized: true,
+      isContractPublished: true,
+    };
+  }
+
+  getPrivateEvents<T>(
+    _contractAddress: AztecAddress,
+    _eventMetadata: EventMetadataDefinition,
+    _from: number,
+    _numBlocks: number,
+    _recipients: AztecAddress[],
+  ): Promise<T[]> {
+    return Promise.resolve([{ field1: Fr.random() }] as T[]);
+  }
+
+  getTxReceipt(_txHash: TxHash): Promise<TxReceipt> {
+    return Promise.resolve(TxReceipt.empty());
+  }
+
+  registerSender(address: AztecAddress, _alias?: string): Promise<AztecAddress> {
+    return Promise.resolve(address);
+  }
+
+  async getSenders(): Promise<Aliased<AztecAddress>[]> {
+    return [{ alias: 'sender1', item: await AztecAddress.random() }];
+  }
+
+  async getAccounts(): Promise<Aliased<AztecAddress>[]> {
+    return [{ alias: 'account1', item: await AztecAddress.random() }];
+  }
+
+  async registerContract(_instanceData: any, _artifact?: any, _secretKey?: Fr): Promise<ContractInstanceWithAddress> {
+    return {
+      version: 1,
+      address: await AztecAddress.random(),
+      currentContractClassId: Fr.random(),
+      deployer: await AztecAddress.random(),
+      initializationHash: Fr.random(),
+      originalContractClassId: Fr.random(),
+      publicKeys: await PublicKeys.random(),
+      salt: Fr.random(),
+    };
+  }
+
+  simulateTx(_exec: ExecutionPayload, _opts: SimulateOptions): Promise<TxSimulationResult> {
+    return Promise.resolve(TxSimulationResult.random());
+  }
+
+  simulateUtility(
+    _functionName: string,
+    _args: any[],
+    _to: AztecAddress,
+    _authwits?: AuthWitness[],
+  ): Promise<UtilitySimulationResult> {
+    return Promise.resolve(UtilitySimulationResult.random());
+  }
+
+  profileTx(_exec: ExecutionPayload, _opts: ProfileOptions): Promise<TxProfileResult> {
+    return Promise.resolve(TxProfileResult.random());
+  }
+
+  proveTx(_exec: ExecutionPayload, _opts: SendOptions): Promise<TxProvingResult> {
+    return Promise.resolve(TxProvingResult.random());
+  }
+
+  sendTx(_tx: Tx): Promise<TxHash> {
+    return Promise.resolve(TxHash.random());
+  }
+
+  createAuthWit(_from: AztecAddress, _messageHashOrIntent: any): Promise<AuthWitness> {
+    return Promise.resolve(AuthWitness.random());
+  }
+
+  async batch<const T extends readonly BatchedMethod<keyof BatchableMethods>[]>(methods: T): Promise<any> {
+    const results: any[] = [];
+    for (const method of methods) {
+      const { name, args } = method;
+      // Type safety is guaranteed by the BatchedMethod type, which ensures that:
+      // 1. `name` is a valid batchable method name
+      // 2. `args` matches the parameter types of that specific method
+      // 3. The return type is correctly mapped in BatchResults<T>
+      // We use dynamic dispatch here for simplicity, but the types are enforced at the call site.
+      const fn = this[name] as (...args: any[]) => Promise<any>;
+      const result = await fn.apply(this, args);
+      results.push(result);
+    }
+    return results;
+  }
+}

--- a/yarn-project/end-to-end/src/composed/e2e_sandbox_example.test.ts
+++ b/yarn-project/end-to-end/src/composed/e2e_sandbox_example.test.ts
@@ -16,8 +16,7 @@ import { SponsoredFeePaymentMethod } from '@aztec/aztec.js/fee/testing';
 import { timesParallel } from '@aztec/foundation/collection';
 import { TokenContract } from '@aztec/noir-contracts.js/Token';
 import { GasSettings } from '@aztec/stdlib/gas';
-import { registerInitialSandboxAccountsInWallet } from '@aztec/test-wallet/server';
-import { TestWallet } from '@aztec/test-wallet/server';
+import { TestWallet, registerInitialSandboxAccountsInWallet } from '@aztec/test-wallet/server';
 
 import { format } from 'util';
 

--- a/yarn-project/end-to-end/src/composed/e2e_token_bridge_tutorial_test.test.ts
+++ b/yarn-project/end-to-end/src/composed/e2e_token_bridge_tutorial_test.test.ts
@@ -21,8 +21,7 @@ import {
 import { TokenContract } from '@aztec/noir-contracts.js/Token';
 import { TokenBridgeContract } from '@aztec/noir-contracts.js/TokenBridge';
 import { computeL2ToL1MembershipWitness } from '@aztec/stdlib/messaging';
-import { registerInitialSandboxAccountsInWallet } from '@aztec/test-wallet/server';
-import { TestWallet } from '@aztec/test-wallet/server';
+import { TestWallet, registerInitialSandboxAccountsInWallet } from '@aztec/test-wallet/server';
 
 import { getContract } from 'viem';
 

--- a/yarn-project/end-to-end/src/devnet/e2e_smoke.test.ts
+++ b/yarn-project/end-to-end/src/devnet/e2e_smoke.test.ts
@@ -15,8 +15,7 @@ import { FeeJuiceContract } from '@aztec/noir-contracts.js/FeeJuice';
 import { TestContract } from '@aztec/noir-test-contracts.js/Test';
 import type { AztecNode } from '@aztec/stdlib/interfaces/client';
 import { deriveSigningKey } from '@aztec/stdlib/keys';
-import { registerInitialSandboxAccountsInWallet } from '@aztec/test-wallet/server';
-import { TestWallet } from '@aztec/test-wallet/server';
+import { TestWallet, registerInitialSandboxAccountsInWallet } from '@aztec/test-wallet/server';
 
 import { exec } from 'node:child_process';
 import { lookup } from 'node:dns/promises';

--- a/yarn-project/end-to-end/src/spartan/setup_test_wallets.ts
+++ b/yarn-project/end-to-end/src/spartan/setup_test_wallets.ts
@@ -15,8 +15,7 @@ import { createEthereumChain, createExtendedL1Client } from '@aztec/ethereum';
 import type { Logger } from '@aztec/foundation/log';
 import { TokenContract } from '@aztec/noir-contracts.js/Token';
 import type { AztecNodeAdmin } from '@aztec/stdlib/interfaces/client';
-import { registerInitialSandboxAccountsInWallet } from '@aztec/test-wallet/server';
-import { TestWallet } from '@aztec/test-wallet/server';
+import { TestWallet, registerInitialSandboxAccountsInWallet } from '@aztec/test-wallet/server';
 
 import { getACVMConfig } from '../fixtures/get_acvm_config.js';
 import { getBBConfig } from '../fixtures/get_bb_config.js';

--- a/yarn-project/stdlib/src/abi/abi.ts
+++ b/yarn-project/stdlib/src/abi/abi.ts
@@ -195,7 +195,7 @@ export const FunctionAbiSchema = z.object({
   isInitializer: z.boolean(),
   parameters: z.array(z.object({ name: z.string(), type: AbiTypeSchema, visibility: z.enum(ABIParameterVisibility) })),
   returnTypes: z.array(AbiTypeSchema),
-  errorTypes: z.record(AbiErrorTypeSchema),
+  errorTypes: z.record(z.string(), AbiErrorTypeSchema.optional()),
 }) satisfies z.ZodType<FunctionAbi>;
 
 /** Debug metadata for a function. */


### PR DESCRIPTION
Allows specific methods in the wallet to be batched into a single interaction. Additionally, the schemas were exported (as requested by external wallets) and a test in the style of the node API was added to ensure the full API is JSON RPC serializable. 

Closes: https://linear.app/aztec-labs/issue/F-70/batch-wallet-calls