### PR TITLE
chore: avm TS tests should only ever create a single world state instance

### DIFF
--- a/yarn-project/bb-prover/src/avm_proving_tests/avm_bulk.test.ts
+++ b/yarn-project/bb-prover/src/avm_proving_tests/avm_bulk.test.ts
@@ -1,6 +1,7 @@
 import { createLogger } from '@aztec/foundation/log';
 import { AvmTestContractArtifact } from '@aztec/noir-test-contracts.js/AvmTest';
 import { TestExecutorMetrics, bulkTest, defaultGlobals } from '@aztec/simulator/public/fixtures';
+import { NativeWorldStateService } from '@aztec/world-state';
 
 import { mkdirSync, writeFileSync } from 'fs';
 import path from 'path';
@@ -13,10 +14,21 @@ describe('AVM proven bulk test', () => {
   const logger = createLogger('avm-bulk-test');
   const metrics = new TestExecutorMetrics();
   let tester: AvmProvingTester;
+  let worldStateService: NativeWorldStateService;
 
   beforeEach(async () => {
     // FULL PROVING! Not check-circuit.
-    tester = await AvmProvingTester.new(/*checkCircuitOnly=*/ false, /*globals=*/ defaultGlobals(), metrics);
+    worldStateService = await NativeWorldStateService.tmp();
+    tester = await AvmProvingTester.new(
+      worldStateService,
+      /*checkCircuitOnly=*/ false,
+      /*globals=*/ defaultGlobals(),
+      metrics,
+    );
+  });
+
+  afterEach(async () => {
+    await worldStateService.close();
   });
 
   afterAll(() => {

--- a/yarn-project/bb-prover/src/avm_proving_tests/avm_check_circuit1.test.ts
+++ b/yarn-project/bb-prover/src/avm_proving_tests/avm_check_circuit1.test.ts
@@ -10,6 +10,7 @@ import { Fr } from '@aztec/foundation/fields';
 import { AvmTestContractArtifact } from '@aztec/noir-test-contracts.js/AvmTest';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import type { ContractInstanceWithAddress } from '@aztec/stdlib/contract';
+import { NativeWorldStateService } from '@aztec/world-state';
 
 import { AvmProvingTester } from './avm_proving_tester.js';
 
@@ -18,14 +19,20 @@ const TIMEOUT = 30_000;
 describe('AVM check-circuit – unhappy paths 1', () => {
   let avmTestContractInstance: ContractInstanceWithAddress;
   let tester: AvmProvingTester;
+  let worldStateService: NativeWorldStateService;
 
   beforeEach(async () => {
-    tester = await AvmProvingTester.new(/*checkCircuitOnly*/ true);
+    worldStateService = await NativeWorldStateService.tmp();
+    tester = await AvmProvingTester.new(worldStateService, /*checkCircuitOnly*/ true);
     avmTestContractInstance = await tester.registerAndDeployContract(
       /*constructorArgs=*/ [],
       /*deployer=*/ AztecAddress.fromNumber(420),
       AvmTestContractArtifact,
     );
+  });
+
+  afterEach(async () => {
+    await worldStateService.close();
   });
 
   it(

--- a/yarn-project/bb-prover/src/avm_proving_tests/avm_check_circuit3.test.ts
+++ b/yarn-project/bb-prover/src/avm_proving_tests/avm_check_circuit3.test.ts
@@ -4,6 +4,7 @@ import { AvmTestContractArtifact } from '@aztec/noir-test-contracts.js/AvmTest';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import type { ContractInstanceWithAddress } from '@aztec/stdlib/contract';
 import { L2ToL1Message, ScopedL2ToL1Message } from '@aztec/stdlib/messaging';
+import { NativeWorldStateService } from '@aztec/world-state';
 
 import { AvmProvingTester } from './avm_proving_tester.js';
 
@@ -13,14 +14,20 @@ describe('AVM check-circuit – unhappy paths 3', () => {
   const sender = AztecAddress.fromNumber(42);
   let avmTestContractInstance: ContractInstanceWithAddress;
   let tester: AvmProvingTester;
+  let worldStateService: NativeWorldStateService;
 
   beforeEach(async () => {
-    tester = await AvmProvingTester.new(/*checkCircuitOnly*/ true);
+    worldStateService = await NativeWorldStateService.tmp();
+    tester = await AvmProvingTester.new(worldStateService, /*checkCircuitOnly*/ true);
     avmTestContractInstance = await tester.registerAndDeployContract(
       /*constructorArgs=*/ [],
       /*deployer=*/ AztecAddress.fromNumber(420),
       AvmTestContractArtifact,
     );
+  });
+
+  afterEach(async () => {
+    await worldStateService.close();
   });
 
   it(

--- a/yarn-project/bb-prover/src/avm_proving_tests/avm_check_circuit_amm.test.ts
+++ b/yarn-project/bb-prover/src/avm_proving_tests/avm_check_circuit_amm.test.ts
@@ -2,6 +2,7 @@ import { createLogger } from '@aztec/foundation/log';
 import { AMMContractArtifact } from '@aztec/noir-contracts.js/AMM';
 import { TokenContractArtifact } from '@aztec/noir-contracts.js/Token';
 import { TestExecutorMetrics, ammTest, defaultGlobals } from '@aztec/simulator/public/fixtures';
+import { NativeWorldStateService } from '@aztec/world-state';
 
 import { mkdirSync, writeFileSync } from 'fs';
 import path from 'path';
@@ -14,10 +15,21 @@ describe('AVM proven AMM', () => {
   const logger = createLogger('avm-proven-tests-amm');
   const metrics = new TestExecutorMetrics();
   let tester: AvmProvingTester;
+  let worldStateService: NativeWorldStateService;
 
   beforeEach(async () => {
     // Check-circuit only (no full proving).
-    tester = await AvmProvingTester.new(/*checkCircuitOnly=*/ true, /*globals=*/ defaultGlobals(), metrics);
+    worldStateService = await NativeWorldStateService.tmp();
+    tester = await AvmProvingTester.new(
+      worldStateService,
+      /*checkCircuitOnly=*/ true,
+      /*globals=*/ defaultGlobals(),
+      metrics,
+    );
+  });
+
+  afterEach(async () => {
+    await worldStateService.close();
   });
 
   afterAll(() => {

--- a/yarn-project/bb-prover/src/avm_proving_tests/avm_check_circuit_custom_bc.test.ts
+++ b/yarn-project/bb-prover/src/avm_proving_tests/avm_check_circuit_custom_bc.test.ts
@@ -8,14 +8,21 @@ import {
   invalidTagValueTest,
   pcOutOfRangeTest,
 } from '@aztec/simulator/public/fixtures';
+import { NativeWorldStateService } from '@aztec/world-state';
 
 import { AvmProvingTester } from './avm_proving_tester.js';
 
 describe('AVM custom bytecodes unhappy paths', () => {
   let tester: AvmProvingTester;
+  let worldStateService: NativeWorldStateService;
 
   beforeEach(async () => {
-    tester = await AvmProvingTester.new(/*checkCircuitOnly*/ true, /*globals=*/ defaultGlobals());
+    worldStateService = await NativeWorldStateService.tmp();
+    tester = await AvmProvingTester.new(worldStateService, /*checkCircuitOnly*/ true, /*globals=*/ defaultGlobals());
+  });
+
+  afterEach(async () => {
+    await worldStateService.close();
   });
 
   it('Base address uninitialized indirect relative', async () => {
@@ -31,9 +38,15 @@ describe('AVM custom bytecodes unhappy paths', () => {
 
 describe('AVM bytecode flow unhappy paths', () => {
   let tester: AvmProvingTester;
+  let worldStateService: NativeWorldStateService;
 
   beforeEach(async () => {
-    tester = await AvmProvingTester.new(/*checkCircuitOnly*/ true, /*globals=*/ defaultGlobals());
+    worldStateService = await NativeWorldStateService.tmp();
+    tester = await AvmProvingTester.new(worldStateService, /*checkCircuitOnly*/ true, /*globals=*/ defaultGlobals());
+  });
+
+  afterEach(async () => {
+    await worldStateService.close();
   });
 
   it('PC out of range', async () => {

--- a/yarn-project/bb-prover/src/avm_proving_tests/avm_contract_class_limits.test.ts
+++ b/yarn-project/bb-prover/src/avm_proving_tests/avm_contract_class_limits.test.ts
@@ -2,6 +2,7 @@ import { MAX_PUBLIC_CALLS_TO_UNIQUE_CONTRACT_CLASS_IDS } from '@aztec/constants'
 import { AvmTestContractArtifact } from '@aztec/noir-test-contracts.js/AvmTest';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import type { ContractInstanceWithAddress } from '@aztec/stdlib/contract';
+import { NativeWorldStateService } from '@aztec/world-state';
 
 import { AvmProvingTester } from './avm_proving_tester.js';
 
@@ -12,9 +13,11 @@ describe('AVM check-circuit - contract class limits', () => {
   let instances: ContractInstanceWithAddress[];
   let tester: AvmProvingTester;
   let avmTestContractAddress: AztecAddress;
+  let worldStateService: NativeWorldStateService;
 
   beforeEach(async () => {
-    tester = await AvmProvingTester.new(/*checkCircuitOnly=*/ true);
+    worldStateService = await NativeWorldStateService.tmp();
+    tester = await AvmProvingTester.new(worldStateService, /*checkCircuitOnly=*/ true);
     // create enough unique contract classes to hit the limit
     instances = [];
     for (let i = 0; i <= MAX_PUBLIC_CALLS_TO_UNIQUE_CONTRACT_CLASS_IDS; i++) {
@@ -28,6 +31,10 @@ describe('AVM check-circuit - contract class limits', () => {
       instances.push(instance);
     }
     avmTestContractAddress = instances[0].address;
+  });
+
+  afterEach(async () => {
+    await worldStateService.close();
   });
 
   it(

--- a/yarn-project/bb-prover/src/avm_proving_tests/avm_contract_updates.test.ts
+++ b/yarn-project/bb-prover/src/avm_proving_tests/avm_contract_updates.test.ts
@@ -10,6 +10,7 @@ import {
   ScheduledValueChange,
 } from '@aztec/stdlib/delayed-public-mutable';
 import type { UInt64 } from '@aztec/stdlib/types';
+import { NativeWorldStateService } from '@aztec/world-state';
 
 import { AvmProvingTester } from './avm_proving_tester.js';
 
@@ -21,7 +22,15 @@ describe('AVM check-circuit - contract updates', () => {
   const avmTestContractClassSeed = 0;
   let avmTestContractInstance: ContractInstanceWithAddress;
 
-  beforeEach(async () => {});
+  let worldStateService: NativeWorldStateService;
+
+  beforeEach(async () => {
+    worldStateService = await NativeWorldStateService.tmp();
+  });
+
+  afterEach(async () => {
+    await worldStateService.close();
+  });
 
   const writeContractUpdate = async (
     tester: AvmProvingTester,
@@ -50,7 +59,7 @@ describe('AVM check-circuit - contract updates', () => {
       // Contract was not originally the avmTestContract
       const originalClassId = new Fr(27);
       const globals = defaultGlobals();
-      const tester = await AvmProvingTester.new(/*checkCircuitOnly*/ true, globals);
+      const tester = await AvmProvingTester.new(worldStateService, /*checkCircuitOnly*/ true, globals);
 
       avmTestContractInstance = await tester.registerAndDeployContract(
         /*constructorArgs=*/ [],
@@ -89,7 +98,7 @@ describe('AVM check-circuit - contract updates', () => {
       // Contract was not originally the avmTestContract
       const originalClassId = new Fr(27);
       const globals = defaultGlobals();
-      const tester = await AvmProvingTester.new(/*checkCircuitOnly*/ true, globals);
+      const tester = await AvmProvingTester.new(worldStateService, /*checkCircuitOnly*/ true, globals);
       avmTestContractInstance = await tester.registerAndDeployContract(
         /*constructorArgs=*/ [],
         sender,
@@ -130,7 +139,7 @@ describe('AVM check-circuit - contract updates', () => {
       const newClassId = new Fr(27);
 
       const globals = defaultGlobals();
-      const tester = await AvmProvingTester.new(/*checkCircuitOnly*/ true, globals);
+      const tester = await AvmProvingTester.new(worldStateService, /*checkCircuitOnly*/ true, globals);
       avmTestContractInstance = await tester.registerAndDeployContract(
         /*constructorArgs=*/ [],
         sender,
@@ -167,7 +176,7 @@ describe('AVM check-circuit - contract updates', () => {
       const newClassId = new Fr(27);
 
       const globals = defaultGlobals();
-      const tester = await AvmProvingTester.new(/*checkCircuitOnly*/ true, globals);
+      const tester = await AvmProvingTester.new(worldStateService, /*checkCircuitOnly*/ true, globals);
       avmTestContractInstance = await tester.registerAndDeployContract(
         /*constructorArgs=*/ [],
         sender,

--- a/yarn-project/bb-prover/src/avm_proving_tests/avm_mega_bulk.test.ts
+++ b/yarn-project/bb-prover/src/avm_proving_tests/avm_mega_bulk.test.ts
@@ -1,6 +1,7 @@
 import { createLogger } from '@aztec/foundation/log';
 import { AvmTestContractArtifact } from '@aztec/noir-test-contracts.js/AvmTest';
 import { TestExecutorMetrics, defaultGlobals, megaBulkTest } from '@aztec/simulator/public/fixtures';
+import { NativeWorldStateService } from '@aztec/world-state';
 
 import { mkdirSync, writeFileSync } from 'fs';
 import path from 'path';
@@ -14,10 +15,21 @@ describe.skip('AVM proven MEGA bulk test', () => {
   const logger = createLogger('avm-proven-bulk-test');
   const metrics = new TestExecutorMetrics();
   let tester: AvmProvingTester;
+  let worldStateService: NativeWorldStateService;
 
   beforeEach(async () => {
     // FULL PROVING! Not check-circuit.
-    tester = await AvmProvingTester.new(/*checkCircuitOnly=*/ false, /*globals=*/ defaultGlobals(), metrics);
+    worldStateService = await NativeWorldStateService.tmp();
+    tester = await AvmProvingTester.new(
+      worldStateService,
+      /*checkCircuitOnly=*/ false,
+      /*globals=*/ defaultGlobals(),
+      metrics,
+    );
+  });
+
+  afterEach(async () => {
+    await worldStateService.close();
   });
 
   afterAll(() => {

--- a/yarn-project/bb-prover/src/avm_proving_tests/avm_minimal_proving.test.ts
+++ b/yarn-project/bb-prover/src/avm_proving_tests/avm_minimal_proving.test.ts
@@ -1,18 +1,23 @@
-import { simAvmMinimalPublicTx } from '@aztec/simulator/public/fixtures';
+import { executeAvmMinimalPublicTx } from '@aztec/simulator/public/fixtures';
+import { NativeWorldStateService } from '@aztec/world-state';
 
 import { AvmProvingTester } from './avm_proving_tester.js';
 
 describe('AVM proven minimal tx', () => {
   let tester: AvmProvingTester;
+  let worldStateService: NativeWorldStateService;
 
   beforeEach(async () => {
-    tester = await AvmProvingTester.new();
+    worldStateService = await NativeWorldStateService.tmp();
+    tester = await AvmProvingTester.new(worldStateService);
+  });
+
+  afterEach(async () => {
+    await worldStateService.close();
   });
 
   it('Proving minimal public tx', async () => {
-    const result = await simAvmMinimalPublicTx();
+    const result = await executeAvmMinimalPublicTx(tester);
     expect(result.revertCode.isOK()).toBe(true);
-
-    await tester.proveVerify(result.avmProvingRequest.inputs);
   }, 180_000);
 });

--- a/yarn-project/bb-prover/src/avm_proving_tests/avm_proving_tester.ts
+++ b/yarn-project/bb-prover/src/avm_proving_tests/avm_proving_tester.ts
@@ -101,9 +101,14 @@ export class AvmProvingTester extends PublicTxSimulationTester {
     super(merkleTrees, contractDataSource, globals, metrics);
   }
 
-  static async new(checkCircuitOnly: boolean = false, globals?: GlobalVariables, metrics?: TestExecutorMetrics) {
+  static async new(
+    worldStateService: NativeWorldStateService, // make sure to close this later
+    checkCircuitOnly: boolean = false,
+    globals?: GlobalVariables,
+    metrics?: TestExecutorMetrics,
+  ) {
     const contractDataSource = new SimpleContractDataSource();
-    const merkleTrees = await (await NativeWorldStateService.tmp()).fork();
+    const merkleTrees = await worldStateService.fork();
     return new AvmProvingTester(checkCircuitOnly, contractDataSource, merkleTrees, globals, metrics);
   }
 

--- a/yarn-project/bb-prover/src/avm_proving_tests/avm_public_fee_payment.test.ts
+++ b/yarn-project/bb-prover/src/avm_proving_tests/avm_public_fee_payment.test.ts
@@ -2,6 +2,7 @@ import { Fr } from '@aztec/foundation/fields';
 import { AvmTestContractArtifact } from '@aztec/noir-test-contracts.js/AvmTest';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import type { ContractInstanceWithAddress } from '@aztec/stdlib/contract';
+import { NativeWorldStateService } from '@aztec/world-state';
 
 import { AvmProvingTester } from './avm_proving_tester.js';
 
@@ -14,9 +15,11 @@ describe('AVM check-circuit – public fee payment', () => {
   const initialFeeJuiceBalance = new Fr(20000);
   let avmTestContractInstance: ContractInstanceWithAddress;
   let tester: AvmProvingTester;
+  let worldStateService: NativeWorldStateService;
 
   beforeEach(async () => {
-    tester = await AvmProvingTester.new(/*checkCircuitOnly*/ true);
+    worldStateService = await NativeWorldStateService.tmp();
+    tester = await AvmProvingTester.new(worldStateService, /*checkCircuitOnly*/ true);
 
     await tester.setFeePayerBalance(feePayer, initialFeeJuiceBalance);
 
@@ -25,6 +28,10 @@ describe('AVM check-circuit – public fee payment', () => {
       /*deployer=*/ AztecAddress.fromNumber(420),
       AvmTestContractArtifact,
     );
+  });
+
+  afterEach(async () => {
+    await worldStateService.close();
   });
 
   it(

--- a/yarn-project/ivc-integration/src/rollup_ivc_integration.test.ts
+++ b/yarn-project/ivc-integration/src/rollup_ivc_integration.test.ts
@@ -13,6 +13,7 @@ import { PublicTxSimulationTester, bulkTest } from '@aztec/simulator/public/fixt
 import { AvmCircuitPublicInputs } from '@aztec/stdlib/avm';
 import type { ProofAndVerificationKey } from '@aztec/stdlib/interfaces/server';
 import { VerificationKeyAsFields } from '@aztec/stdlib/vks';
+import { NativeWorldStateService } from '@aztec/world-state/native';
 
 import { jest } from '@jest/globals';
 import path from 'path';
@@ -42,142 +43,158 @@ jest.setTimeout(150_000);
 
 const logger = createLogger('ivc-integration:test:rollup-native');
 
-describe('Rollup IVC Integration', () => {
-  let bbBinaryPath: string;
-
-  let ivcProof: ProofAndVerificationKey<typeof CIVC_PROOF_LENGTH>;
-  let avmVK: VerificationKeyAsFields;
-  let avmProof: Fr[];
-  let avmPublicInputs: AvmCircuitPublicInputs;
-
-  let clientIVCPublicInputs: KernelPublicInputs;
-  let workingDirectory: string;
+describe('Rollup IVC Integration (suite wrapper)', () => {
+  let worldStateService: NativeWorldStateService;
 
   beforeAll(async () => {
-    bbBinaryPath = path.join(path.dirname(fileURLToPath(import.meta.url)), '../../../barretenberg/cpp/build/bin', 'bb');
-
-    // Create a client IVC proof
-    const clientIVCWorkingDirectory = await getWorkingDirectory('bb-rollup-ivc-integration-client-ivc-');
-    const [bytecodes, witnessStack, tailPublicInputs, vks] = await generateTestingIVCStack(1, 0);
-    clientIVCPublicInputs = tailPublicInputs;
-
-    ivcProof = await proveClientIVC(bbBinaryPath, clientIVCWorkingDirectory, witnessStack, bytecodes, vks, logger);
-    const ivcVerifyResult = await verifyClientIvcProof(
-      bbBinaryPath,
-      clientIVCWorkingDirectory.concat('/proof'),
-      clientIVCWorkingDirectory.concat('/vk'),
-      logger.info,
-    );
-    expect(ivcVerifyResult.status).toEqual(BB_RESULT.SUCCESS);
-
-    // Create an AVM proof
-    const avmWorkingDirectory = await getWorkingDirectory('bb-rollup-ivc-integration-avm-');
-
-    const simTester = await PublicTxSimulationTester.create();
-    const avmSimulationResult = await bulkTest(simTester, logger, AvmTestContractArtifact);
-    expect(avmSimulationResult.revertCode.isOK()).toBe(true);
-
-    const avmCircuitInputs = avmSimulationResult.avmProvingRequest.inputs;
-    ({
-      vk: avmVK,
-      proof: avmProof,
-      publicInputs: avmPublicInputs,
-    } = await proveAvm(avmCircuitInputs, avmWorkingDirectory, logger));
+    worldStateService = await NativeWorldStateService.tmp();
   });
 
-  beforeEach(async () => {
-    workingDirectory = await getWorkingDirectory('bb-rollup-ivc-integration-');
+  afterAll(async () => {
+    await worldStateService.close();
   });
 
-  it('Should be able to generate a proof of a 3 transaction rollup', async () => {
-    // Use the pre-generated standalone vk to verify the proof recursively.
-    const ivcVk = await VerificationKeyAsFields.fromKey(
-      MockHidingJson.verificationKey.fields.map((str: string) => Fr.fromHexString(str)),
-    );
+  describe('Rollup IVC Integration', () => {
+    let bbBinaryPath: string;
 
-    const privateBaseRollupWitnessResult = await witnessGenMockRollupTxBasePrivateCircuit({
-      civc_proof_data: {
-        public_inputs: clientIVCPublicInputs,
-        proof: mapRecursiveProofToNoir(ivcProof.proof),
-        vk_data: mapVerificationKeyToNoir(ivcVk, CIVC_VK_LENGTH_IN_FIELDS),
-      },
+    let ivcProof: ProofAndVerificationKey<typeof CIVC_PROOF_LENGTH>;
+    let avmVK: VerificationKeyAsFields;
+    let avmProof: Fr[];
+    let avmPublicInputs: AvmCircuitPublicInputs;
+
+    let clientIVCPublicInputs: KernelPublicInputs;
+    let workingDirectory: string;
+
+    beforeAll(async () => {
+      bbBinaryPath = path.join(
+        path.dirname(fileURLToPath(import.meta.url)),
+        '../../../barretenberg/cpp/build/bin',
+        'bb',
+      );
+
+      // Create a client IVC proof
+      const clientIVCWorkingDirectory = await getWorkingDirectory('bb-rollup-ivc-integration-client-ivc-');
+      const [bytecodes, witnessStack, tailPublicInputs, vks] = await generateTestingIVCStack(1, 0);
+      clientIVCPublicInputs = tailPublicInputs;
+
+      ivcProof = await proveClientIVC(bbBinaryPath, clientIVCWorkingDirectory, witnessStack, bytecodes, vks, logger);
+      const ivcVerifyResult = await verifyClientIvcProof(
+        bbBinaryPath,
+        clientIVCWorkingDirectory.concat('/proof'),
+        clientIVCWorkingDirectory.concat('/vk'),
+        logger.info,
+      );
+      expect(ivcVerifyResult.status).toEqual(BB_RESULT.SUCCESS);
+
+      // Create an AVM proof
+      const avmWorkingDirectory = await getWorkingDirectory('bb-rollup-ivc-integration-avm-');
+
+      const simTester = await PublicTxSimulationTester.create(worldStateService);
+      const avmSimulationResult = await bulkTest(simTester, logger, AvmTestContractArtifact);
+      expect(avmSimulationResult.revertCode.isOK()).toBe(true);
+
+      const avmCircuitInputs = avmSimulationResult.avmProvingRequest.inputs;
+      ({
+        vk: avmVK,
+        proof: avmProof,
+        publicInputs: avmPublicInputs,
+      } = await proveAvm(avmCircuitInputs, avmWorkingDirectory, logger));
     });
 
-    const privateBaseProof = await proveRollupHonk(
-      'MockRollupTxBasePrivateCircuit',
-      bbBinaryPath,
-      workingDirectory,
-      MockRollupTxBasePrivateCircuit,
-      privateBaseRollupWitnessResult.witness,
-      logger,
-    );
-
-    const privateBaseRollupData = {
-      base_or_merge_public_inputs: privateBaseRollupWitnessResult.publicInputs,
-      proof: mapRecursiveProofToNoir(privateBaseProof.proof),
-      vk: mapVerificationKeyToNoir(privateBaseProof.verificationKey.keyAsFields, ULTRA_VK_LENGTH_IN_FIELDS),
-    };
-
-    const publicBaseRollupWitnessResult = await witnessGenMockPublicBaseCircuit({
-      civc_proof_data: {
-        public_inputs: clientIVCPublicInputs,
-        proof: mapRecursiveProofToNoir(ivcProof.proof),
-        vk_data: mapVerificationKeyToNoir(ivcVk, CIVC_VK_LENGTH_IN_FIELDS),
-      },
-      verification_key: mapVerificationKeyToNoir(avmVK, AVM_V2_VERIFICATION_KEY_LENGTH_IN_FIELDS_PADDED),
-      proof: mapAvmProofToNoir(avmProof),
-      public_inputs: mapAvmCircuitPublicInputsToNoir(avmPublicInputs),
+    beforeEach(async () => {
+      workingDirectory = await getWorkingDirectory('bb-rollup-ivc-integration-');
     });
 
-    const publicBaseProof = await proveRollupHonk(
-      'MockRollupTxBasePublicCircuit',
-      bbBinaryPath,
-      workingDirectory,
-      MockRollupTxBasePublicCircuit,
-      publicBaseRollupWitnessResult.witness,
-      logger,
-    );
+    it('Should be able to generate a proof of a 3 transaction rollup', async () => {
+      // Use the pre-generated standalone vk to verify the proof recursively.
+      const ivcVk = await VerificationKeyAsFields.fromKey(
+        MockHidingJson.verificationKey.fields.map((str: string) => Fr.fromHexString(str)),
+      );
 
-    const publicBaseRollupData = {
-      base_or_merge_public_inputs: publicBaseRollupWitnessResult.publicInputs,
-      proof: mapRecursiveProofToNoir(publicBaseProof.proof),
-      vk: mapVerificationKeyToNoir(publicBaseProof.verificationKey.keyAsFields, ULTRA_VK_LENGTH_IN_FIELDS),
-    };
+      const privateBaseRollupWitnessResult = await witnessGenMockRollupTxBasePrivateCircuit({
+        civc_proof_data: {
+          public_inputs: clientIVCPublicInputs,
+          proof: mapRecursiveProofToNoir(ivcProof.proof),
+          vk_data: mapVerificationKeyToNoir(ivcVk, CIVC_VK_LENGTH_IN_FIELDS),
+        },
+      });
 
-    const mergeWitnessResult = await witnessGenMockRollupTxMergeCircuit({
-      a: privateBaseRollupData,
-      b: publicBaseRollupData,
-    });
+      const privateBaseProof = await proveRollupHonk(
+        'MockRollupTxBasePrivateCircuit',
+        bbBinaryPath,
+        workingDirectory,
+        MockRollupTxBasePrivateCircuit,
+        privateBaseRollupWitnessResult.witness,
+        logger,
+      );
 
-    const mergeProof = await proveRollupHonk(
-      'MockRollupTxMergeCircuit',
-      bbBinaryPath,
-      workingDirectory,
-      MockRollupTxMergeCircuit,
-      mergeWitnessResult.witness,
-      logger,
-    );
+      const privateBaseRollupData = {
+        base_or_merge_public_inputs: privateBaseRollupWitnessResult.publicInputs,
+        proof: mapRecursiveProofToNoir(privateBaseProof.proof),
+        vk: mapVerificationKeyToNoir(privateBaseProof.verificationKey.keyAsFields, ULTRA_VK_LENGTH_IN_FIELDS),
+      };
 
-    const mergeRollupData = {
-      base_or_merge_public_inputs: mergeWitnessResult.publicInputs,
-      proof: mapRecursiveProofToNoir(mergeProof.proof),
-      vk: mapVerificationKeyToNoir(mergeProof.verificationKey.keyAsFields, ULTRA_VK_LENGTH_IN_FIELDS),
-    };
+      const publicBaseRollupWitnessResult = await witnessGenMockPublicBaseCircuit({
+        civc_proof_data: {
+          public_inputs: clientIVCPublicInputs,
+          proof: mapRecursiveProofToNoir(ivcProof.proof),
+          vk_data: mapVerificationKeyToNoir(ivcVk, CIVC_VK_LENGTH_IN_FIELDS),
+        },
+        verification_key: mapVerificationKeyToNoir(avmVK, AVM_V2_VERIFICATION_KEY_LENGTH_IN_FIELDS_PADDED),
+        proof: mapAvmProofToNoir(avmProof),
+        public_inputs: mapAvmCircuitPublicInputsToNoir(avmPublicInputs),
+      });
 
-    const rootWitnessResult = await witnessGenMockRollupRootCircuit({ a: privateBaseRollupData, b: mergeRollupData });
+      const publicBaseProof = await proveRollupHonk(
+        'MockRollupTxBasePublicCircuit',
+        bbBinaryPath,
+        workingDirectory,
+        MockRollupTxBasePublicCircuit,
+        publicBaseRollupWitnessResult.witness,
+        logger,
+      );
 
-    // Three transactions are aggregated
-    expect(rootWitnessResult.publicInputs.accumulated).toEqual('0x03');
+      const publicBaseRollupData = {
+        base_or_merge_public_inputs: publicBaseRollupWitnessResult.publicInputs,
+        proof: mapRecursiveProofToNoir(publicBaseProof.proof),
+        vk: mapVerificationKeyToNoir(publicBaseProof.verificationKey.keyAsFields, ULTRA_VK_LENGTH_IN_FIELDS),
+      };
 
-    // This step takes something like 4 minutes, since it needs to actually prove and remove the IPA claims.
-    // Commenting it out for now due to CI speed issues.
-    // await proveKeccakHonk(
-    //   'MockRollupRootCircuit',
-    //   bbBinaryPath,
-    //   workingDirectory,
-    //   MockRollupRootCircuit,
-    //   rootWitnessResult.witness,
-    //   logger,
-    // );
-  }, 300_000);
+      const mergeWitnessResult = await witnessGenMockRollupTxMergeCircuit({
+        a: privateBaseRollupData,
+        b: publicBaseRollupData,
+      });
+
+      const mergeProof = await proveRollupHonk(
+        'MockRollupTxMergeCircuit',
+        bbBinaryPath,
+        workingDirectory,
+        MockRollupTxMergeCircuit,
+        mergeWitnessResult.witness,
+        logger,
+      );
+
+      const mergeRollupData = {
+        base_or_merge_public_inputs: mergeWitnessResult.publicInputs,
+        proof: mapRecursiveProofToNoir(mergeProof.proof),
+        vk: mapVerificationKeyToNoir(mergeProof.verificationKey.keyAsFields, ULTRA_VK_LENGTH_IN_FIELDS),
+      };
+
+      const rootWitnessResult = await witnessGenMockRollupRootCircuit({ a: privateBaseRollupData, b: mergeRollupData });
+
+      // Three transactions are aggregated
+      expect(rootWitnessResult.publicInputs.accumulated).toEqual('0x03');
+
+      // This step takes something like 4 minutes, since it needs to actually prove and remove the IPA claims.
+      // Commenting it out for now due to CI speed issues.
+      // await proveKeccakHonk(
+      //   'MockRollupRootCircuit',
+      //   bbBinaryPath,
+      //   workingDirectory,
+      //   MockRollupRootCircuit,
+      //   rootWitnessResult.witness,
+      //   logger,
+      // );
+    }, 300_000);
+  });
 });

--- a/yarn-project/simulator/src/public/avm/apps_tests/avm_test.test.ts
+++ b/yarn-project/simulator/src/public/avm/apps_tests/avm_test.test.ts
@@ -4,6 +4,7 @@ import { AvmTestContractArtifact } from '@aztec/noir-test-contracts.js/AvmTest';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import type { ContractInstanceWithAddress } from '@aztec/stdlib/contract';
 import { makeContractInstanceFromClassId } from '@aztec/stdlib/testing';
+import { NativeWorldStateService } from '@aztec/world-state';
 
 import { AvmSimulationTester } from '../fixtures/avm_simulation_tester.js';
 
@@ -12,10 +13,12 @@ describe('AVM simulator apps tests: AvmTestContract', () => {
   const sender = AztecAddress.fromNumber(4200);
   let testContractAddress: AztecAddress;
   let instances: ContractInstanceWithAddress[];
+  let worldStateService: NativeWorldStateService;
   let simTester: AvmSimulationTester;
 
   beforeEach(async () => {
-    simTester = await AvmSimulationTester.create();
+    worldStateService = await NativeWorldStateService.tmp();
+    simTester = await AvmSimulationTester.create(worldStateService);
     // create enough unique contract classes to hit the limit
     instances = [];
     for (let i = 0; i <= MAX_PUBLIC_CALLS_TO_UNIQUE_CONTRACT_CLASS_IDS; i++) {
@@ -29,6 +32,10 @@ describe('AVM simulator apps tests: AvmTestContract', () => {
       instances.push(instance);
     }
     testContractAddress = instances[0].address;
+  });
+
+  afterEach(async () => {
+    await worldStateService.close();
   });
 
   it('bulk testing', async () => {

--- a/yarn-project/simulator/src/public/avm/apps_tests/token.test.ts
+++ b/yarn-project/simulator/src/public/avm/apps_tests/token.test.ts
@@ -2,6 +2,7 @@ import { Fr } from '@aztec/foundation/fields';
 import { TokenContractArtifact } from '@aztec/noir-contracts.js/Token';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import type { ContractInstanceWithAddress } from '@aztec/stdlib/contract';
+import { NativeWorldStateService } from '@aztec/world-state';
 
 import { AvmSimulationTester } from '../fixtures/avm_simulation_tester.js';
 
@@ -11,10 +12,12 @@ describe('AVM simulator apps tests: TokenContract', () => {
   const receiver = AztecAddress.fromNumber(222);
 
   let token: ContractInstanceWithAddress;
+  let worldStateService: NativeWorldStateService;
   let simTester: AvmSimulationTester;
 
   beforeEach(async () => {
-    simTester = await AvmSimulationTester.create();
+    worldStateService = await NativeWorldStateService.tmp();
+    simTester = await AvmSimulationTester.create(worldStateService);
     const constructorArgs = [admin, /*name=*/ 'Token', /*symbol=*/ 'TOK', /*decimals=*/ new Fr(18)];
     token = await simTester.registerAndDeployContract(constructorArgs, /*deployer=*/ admin, TokenContractArtifact);
 
@@ -25,6 +28,10 @@ describe('AVM simulator apps tests: TokenContract', () => {
       constructorArgs,
     );
     expect(constructorResult.reverted).toBe(false);
+  });
+
+  afterEach(async () => {
+    await worldStateService.close();
   });
 
   it('token mint, transfer, burn (and check balances)', async () => {

--- a/yarn-project/simulator/src/public/avm/avm_simulator.test.ts
+++ b/yarn-project/simulator/src/public/avm/avm_simulator.test.ts
@@ -1167,6 +1167,7 @@ describe('AVM simulator: transpiled Noir contracts', () => {
     let siloedNullifier0: Fr;
     let uniqueNoteHash0: Fr;
 
+    let worldStateService: NativeWorldStateService;
     let treesDB: PublicTreesDB;
     let contractsDB: PublicContractsDB;
     let trace: PublicSideEffectTraceInterface;
@@ -1184,7 +1185,8 @@ describe('AVM simulator: transpiled Noir contracts', () => {
       mockNoteHashCount(trace, noteHashIndexInTx);
 
       const contractDataSource = new SimpleContractDataSource();
-      const merkleTrees = await (await NativeWorldStateService.tmp()).fork();
+      worldStateService = await NativeWorldStateService.tmp();
+      const merkleTrees = await worldStateService.fork();
       treesDB = new PublicTreesDB(merkleTrees);
       contractsDB = new PublicContractsDB(contractDataSource);
 
@@ -1195,6 +1197,10 @@ describe('AVM simulator: transpiled Noir contracts', () => {
         doMerkleOperations: true,
         firstNullifier,
       });
+    });
+
+    afterEach(async () => {
+      await worldStateService.close();
     });
 
     const createContext = (calldata: Fr[] = []) => {

--- a/yarn-project/simulator/src/public/avm/fixtures/avm_simulation_tester.ts
+++ b/yarn-project/simulator/src/public/avm/fixtures/avm_simulation_tester.ts
@@ -37,9 +37,11 @@ export class AvmSimulationTester extends BaseAvmSimulationTester {
     super(contractDataSource, merkleTrees);
   }
 
-  static async create(): Promise<AvmSimulationTester> {
+  static async create(
+    worldStateService: NativeWorldStateService, // make sure to close this later
+  ): Promise<AvmSimulationTester> {
     const contractDataSource = new SimpleContractDataSource();
-    const merkleTrees = await (await NativeWorldStateService.tmp()).fork();
+    const merkleTrees = await worldStateService.fork();
     const treesDB = new PublicTreesDB(merkleTrees);
     const contractsDB = new PublicContractsDB(contractDataSource);
     const trace = new SideEffectTrace();

--- a/yarn-project/simulator/src/public/fixtures/index.ts
+++ b/yarn-project/simulator/src/public/fixtures/index.ts
@@ -1,7 +1,7 @@
 export * from './public_tx_simulation_tester.js';
 export * from './utils.js';
 export * from './simple_contract_data_source.js';
-export { readAvmMinimalPublicTxInputsFromFile, simAvmMinimalPublicTx } from './minimal_public_tx.js';
+export { readAvmMinimalPublicTxInputsFromFile, executeAvmMinimalPublicTx } from './minimal_public_tx.js';
 export { TestExecutorMetrics } from '../test_executor_metrics.js';
 export { ammTest } from './amm_test.js';
 export { bulkTest, megaBulkTest } from './bulk_test.js';

--- a/yarn-project/simulator/src/public/fixtures/minimal_public_tx.ts
+++ b/yarn-project/simulator/src/public/fixtures/minimal_public_tx.ts
@@ -10,15 +10,13 @@ import type { PublicTxResult } from '../public_tx_simulator/public_tx_simulator.
 import { testCustomBytecode } from './custom_bytecode_tester.js';
 import { PublicTxSimulationTester } from './public_tx_simulation_tester.js';
 
-export async function simAvmMinimalPublicTx(): Promise<PublicTxResult> {
+export async function executeAvmMinimalPublicTx(tester: PublicTxSimulationTester): Promise<PublicTxResult> {
   const minimalBytecode = encodeToBytecode([
     new Set(/*indirect*/ 0, /*dstOffset*/ 0, TypeTag.UINT32, /*value*/ 1).as(Opcode.SET_8, Set.wireFormat8),
     new Set(/*indirect*/ 0, /*dstOffset*/ 1, TypeTag.UINT32, /*value*/ 2).as(Opcode.SET_8, Set.wireFormat8),
     new Add(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).as(Opcode.ADD_8, Add.wireFormat8),
     new Return(/*indirect=*/ 0, /*copySizeOffset=*/ 0, /*returnOffset=*/ 2),
   ]);
-
-  const tester = await PublicTxSimulationTester.create();
 
   const result = await testCustomBytecode(minimalBytecode, tester, 'MinimalTx', 'AvmMinimalContract');
 

--- a/yarn-project/simulator/src/public/fixtures/public_tx_simulation_tester.ts
+++ b/yarn-project/simulator/src/public/fixtures/public_tx_simulation_tester.ts
@@ -60,11 +60,12 @@ export class PublicTxSimulationTester extends BaseAvmSimulationTester {
   }
 
   public static async create(
+    worldStateService: NativeWorldStateService, // make sure to close this later
     globals: GlobalVariables = defaultGlobals(),
     metrics: TestExecutorMetrics = new TestExecutorMetrics(),
   ): Promise<PublicTxSimulationTester> {
     const contractDataSource = new SimpleContractDataSource();
-    const merkleTree = await (await NativeWorldStateService.tmp()).fork();
+    const merkleTree = await worldStateService.fork();
     return new PublicTxSimulationTester(merkleTree, contractDataSource, globals, metrics);
   }
 

--- a/yarn-project/simulator/src/public/public_processor/apps_tests/deployments.test.ts
+++ b/yarn-project/simulator/src/public/public_processor/apps_tests/deployments.test.ts
@@ -21,6 +21,7 @@ describe('Public processor contract registration/deployment tests', () => {
   const admin = AztecAddress.fromNumber(42);
   const sender = AztecAddress.fromNumber(111);
 
+  let worldStateService: NativeWorldStateService;
   let contractsDB: PublicContractsDB;
   let tester: PublicTxSimulationTester;
   let processor: PublicProcessor;
@@ -31,7 +32,8 @@ describe('Public processor contract registration/deployment tests', () => {
     globals.gasFees = new GasFees(2, 3);
 
     const contractDataSource = new SimpleContractDataSource();
-    const merkleTrees = await (await NativeWorldStateService.tmp()).fork();
+    worldStateService = await NativeWorldStateService.tmp();
+    const merkleTrees = await worldStateService.fork();
     const guardedMerkleTrees = new GuardedMerkleTreeOperations(merkleTrees);
     contractsDB = new PublicContractsDB(contractDataSource);
     const simulator = new PublicTxSimulator(guardedMerkleTrees, contractsDB, globals, {
@@ -52,6 +54,10 @@ describe('Public processor contract registration/deployment tests', () => {
     // make sure tx senders have fee balance
     await tester.setFeePayerBalance(admin);
     await tester.setFeePayerBalance(sender);
+  });
+
+  afterEach(async () => {
+    await worldStateService.close();
   });
 
   it('can deploy in a private-only tx and call a public function later in the block', async () => {

--- a/yarn-project/simulator/src/public/public_processor/apps_tests/token.test.ts
+++ b/yarn-project/simulator/src/public/public_processor/apps_tests/token.test.ts
@@ -23,6 +23,7 @@ describe('Public Processor app tests: TokenContract', () => {
   const sender = AztecAddress.fromNumber(111);
 
   let token: ContractInstanceWithAddress;
+  let worldStateService: NativeWorldStateService;
   let contractsDB: PublicContractsDB;
   let tester: PublicTxSimulationTester;
   let processor: PublicProcessor;
@@ -33,7 +34,8 @@ describe('Public Processor app tests: TokenContract', () => {
     globals.gasFees = new GasFees(2, 3);
 
     const contractDataSource = new SimpleContractDataSource();
-    const merkleTrees = await (await NativeWorldStateService.tmp()).fork();
+    worldStateService = await NativeWorldStateService.tmp();
+    const merkleTrees = await worldStateService.fork();
     const guardedMerkleTrees = new GuardedMerkleTreeOperations(merkleTrees);
     contractsDB = new PublicContractsDB(contractDataSource);
     const simulator = new PublicTxSimulator(guardedMerkleTrees, contractsDB, globals, {
@@ -54,6 +56,10 @@ describe('Public Processor app tests: TokenContract', () => {
     // make sure tx senders have fee balance
     await tester.setFeePayerBalance(admin);
     await tester.setFeePayerBalance(sender);
+  });
+
+  afterEach(async () => {
+    await worldStateService.close();
   });
 
   it('token constructor, mint, many transfers', async () => {

--- a/yarn-project/simulator/src/public/public_tx_simulator/apps_tests/amm.test.ts
+++ b/yarn-project/simulator/src/public/public_tx_simulator/apps_tests/amm.test.ts
@@ -1,6 +1,7 @@
 import { createLogger } from '@aztec/foundation/log';
 import { AMMContractArtifact } from '@aztec/noir-contracts.js/AMM';
 import { TokenContractArtifact } from '@aztec/noir-contracts.js/Token';
+import { NativeWorldStateService } from '@aztec/world-state/native';
 
 import { ammTest } from '../../fixtures/amm_test.js';
 import { PublicTxSimulationTester } from '../../fixtures/public_tx_simulation_tester.js';
@@ -8,10 +9,16 @@ import { PublicTxSimulationTester } from '../../fixtures/public_tx_simulation_te
 describe('Public TX simulator apps tests: AMM Contract', () => {
   const logger = createLogger('public-tx-apps-tests-amm');
 
+  let worldStateService: NativeWorldStateService;
   let tester: PublicTxSimulationTester;
 
   beforeEach(async () => {
-    tester = await PublicTxSimulationTester.create();
+    worldStateService = await NativeWorldStateService.tmp();
+    tester = await PublicTxSimulationTester.create(worldStateService);
+  });
+
+  afterEach(async () => {
+    await worldStateService.close();
   });
 
   it('amm operations', async () => {

--- a/yarn-project/simulator/src/public/public_tx_simulator/apps_tests/avm_test.test.ts
+++ b/yarn-project/simulator/src/public/public_tx_simulator/apps_tests/avm_test.test.ts
@@ -1,15 +1,23 @@
 import { createLogger } from '@aztec/foundation/log';
 import { AvmTestContractArtifact } from '@aztec/noir-test-contracts.js/AvmTest';
+import { NativeWorldStateService } from '@aztec/world-state/native';
 
 import { bulkTest } from '../../fixtures/bulk_test.js';
 import { PublicTxSimulationTester } from '../../fixtures/public_tx_simulation_tester.js';
 
 describe('Public TX simulator apps tests: AvmTestContract', () => {
   const logger = createLogger('avm-test-contract-tests');
+
+  let worldStateService: NativeWorldStateService;
   let simTester: PublicTxSimulationTester;
 
   beforeEach(async () => {
-    simTester = await PublicTxSimulationTester.create();
+    worldStateService = await NativeWorldStateService.tmp();
+    simTester = await PublicTxSimulationTester.create(worldStateService);
+  });
+
+  afterEach(async () => {
+    await worldStateService.close();
   });
 
   it('bulk testing', async () => {

--- a/yarn-project/simulator/src/public/public_tx_simulator/apps_tests/custom_bc.test.ts
+++ b/yarn-project/simulator/src/public/public_tx_simulator/apps_tests/custom_bc.test.ts
@@ -1,4 +1,5 @@
 import { addressingWithBaseTagIssueTest } from '@aztec/simulator/public/fixtures';
+import { NativeWorldStateService } from '@aztec/world-state/native';
 
 import {
   instructionTruncatedTest,
@@ -11,10 +12,16 @@ import {
 import { PublicTxSimulationTester } from '../../fixtures/public_tx_simulation_tester.js';
 
 describe('Public TX simulator apps tests: custom bytecodes unhappy paths', () => {
+  let worldStateService: NativeWorldStateService;
   let tester: PublicTxSimulationTester;
 
   beforeEach(async () => {
-    tester = await PublicTxSimulationTester.create();
+    worldStateService = await NativeWorldStateService.tmp();
+    tester = await PublicTxSimulationTester.create(worldStateService);
+  });
+
+  afterEach(async () => {
+    await worldStateService.close();
   });
 
   it('Base address uninitialized indirect relative', async () => {
@@ -29,10 +36,16 @@ describe('Public TX simulator apps tests: custom bytecodes unhappy paths', () =>
 });
 
 describe('Public TX simulator apps tests: bytecode flow unhappy paths', () => {
+  let worldStateService: NativeWorldStateService;
   let tester: PublicTxSimulationTester;
 
   beforeEach(async () => {
-    tester = await PublicTxSimulationTester.create();
+    worldStateService = await NativeWorldStateService.tmp();
+    tester = await PublicTxSimulationTester.create(worldStateService);
+  });
+
+  afterEach(async () => {
+    await worldStateService.close();
   });
 
   it('PC out of range', async () => {

--- a/yarn-project/simulator/src/public/public_tx_simulator/apps_tests/token.test.ts
+++ b/yarn-project/simulator/src/public/public_tx_simulator/apps_tests/token.test.ts
@@ -1,5 +1,6 @@
 import { createLogger } from '@aztec/foundation/log';
 import { TokenContractArtifact } from '@aztec/noir-contracts.js/Token';
+import { NativeWorldStateService } from '@aztec/world-state/native';
 
 import { PublicTxSimulationTester } from '../../fixtures/public_tx_simulation_tester.js';
 import { tokenTest } from '../../fixtures/token_test.js';
@@ -7,10 +8,16 @@ import { tokenTest } from '../../fixtures/token_test.js';
 describe('Public TX simulator apps tests: TokenContract', () => {
   const logger = createLogger('public-tx-apps-tests-token');
 
+  let worldStateService: NativeWorldStateService;
   let tester: PublicTxSimulationTester;
 
   beforeAll(async () => {
-    tester = await PublicTxSimulationTester.create();
+    worldStateService = await NativeWorldStateService.tmp();
+    tester = await PublicTxSimulationTester.create(worldStateService);
+  });
+
+  afterAll(async () => {
+    await worldStateService.close();
   });
 
   it('token constructor, mint, transfer, burn, check balances)', async () => {

--- a/yarn-project/simulator/src/public/public_tx_simulator/public_tx_simulator.test.ts
+++ b/yarn-project/simulator/src/public/public_tx_simulator/public_tx_simulator.test.ts
@@ -76,6 +76,7 @@ describe('public_tx_simulator', () => {
 
   let publicDataTree: AppendOnlyTree<Fr>;
 
+  let worldStateService: NativeWorldStateService;
   let treeStore: AztecKVStore;
   let simulator: PublicTxSimulator;
   let simulateInternal: jest.SpiedFunction<
@@ -311,8 +312,9 @@ describe('public_tx_simulator', () => {
     privateGasUsed = new Gas(13, 17);
     enqueuedCallGasUsed = new Gas(12, 34);
 
-    merkleTrees = await (await NativeWorldStateService.tmp()).fork();
-    merkleTreesCopy = await (await NativeWorldStateService.tmp()).fork();
+    worldStateService = await NativeWorldStateService.tmp();
+    merkleTrees = await worldStateService.fork();
+    merkleTreesCopy = await worldStateService.fork();
     contractsDB = new PublicContractsDB(mock<ContractDataSource>());
 
     treeStore = openTmpStore();
@@ -342,6 +344,7 @@ describe('public_tx_simulator', () => {
   }, 30_000);
 
   afterEach(async () => {
+    await worldStateService.close();
     await treeStore.delete();
   });
 


### PR DESCRIPTION
Please read [contributing guidelines](CONTRIBUTING.md) and remove this line.

For audit-related pull requests, please use the [audit PR template](?expand=1&template=audit.md).
