### PR TITLE
fix: ensure point is valid based on predicate before constructing a cycle_group element

### DIFF
--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/ec_operations.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/ec_operations.cpp
@@ -20,11 +20,9 @@ void create_ec_add_constraint(Builder& builder, const EcAdd& input, bool has_val
     using cycle_group_ct = bb::stdlib::cycle_group<Builder>;
 
     auto input1_point = to_grumpkin_point(
-        input.input1_x, input.input1_y, input.input1_infinite, has_valid_witness_assignments, builder);
+        input.input1_x, input.input1_y, input.input1_infinite, has_valid_witness_assignments, input.predicate, builder);
     auto input2_point = to_grumpkin_point(
-        input.input2_x, input.input2_y, input.input2_infinite, has_valid_witness_assignments, builder);
-    input1_point = valid_point(input1_point, input.predicate, builder);
-    input2_point = valid_point(input2_point, input.predicate, builder);
+        input.input2_x, input.input2_y, input.input2_infinite, has_valid_witness_assignments, input.predicate, builder);
 
     // Addition
     cycle_group_ct result = input1_point + input2_point;

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/multi_scalar_mul.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/multi_scalar_mul.cpp
@@ -30,9 +30,12 @@ void create_multi_scalar_mul_constraint(Builder& builder,
 
     for (size_t i = 0; i < input.points.size(); i += 3) {
         // Instantiate the input point/variable base as `cycle_group_ct`
-        cycle_group_ct input_point = to_grumpkin_point(
-            input.points[i], input.points[i + 1], input.points[i + 2], has_valid_witness_assignments, builder);
-        input_point = valid_point(input_point, input.predicate, builder);
+        cycle_group_ct input_point = to_grumpkin_point(input.points[i],
+                                                       input.points[i + 1],
+                                                       input.points[i + 2],
+                                                       has_valid_witness_assignments,
+                                                       input.predicate,
+                                                       builder);
         //  Reconstruct the scalar from the low and high limbs
         field_ct scalar_low_as_field = to_field_ct(input.scalars[2 * (i / 3)], builder);
         field_ct scalar_high_as_field = to_field_ct(input.scalars[2 * (i / 3) + 1], builder);

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/witness_constant.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/witness_constant.cpp
@@ -11,71 +11,77 @@ namespace acir_format {
 
 using namespace bb;
 using namespace bb::stdlib;
+
+/**
+ * @brief Convert WitnessOrConstant inputs representing a Grumpkin point into a cycle_group element.
+ * @details Inputs x, y, and is_infinite are used to construct the point. If no valid witness is provided or if the
+ * predicate is constant false, the point is set to the generator point. If the predicate is a non-constant witness, the
+ * point is conditionally assigned to the generator point based on the predicate value. This ensures that the point is
+ * always valid and will not trigger any on_curve assertions.
+ *
+ * @tparam Builder
+ * @tparam FF
+ * @param input_x x-coordinate of the point
+ * @param input_y y-coordinate of the point
+ * @param input_infinite boolean indicating if the point is at infinity
+ * @param has_valid_witness_assignments boolean indicating whether a witness is provided
+ * @param predicate A relevant predicate used to conditionally assign the point to a valid value
+ * @param builder
+ * @return bb::stdlib::cycle_group<Builder>
+ */
 template <typename Builder, typename FF>
 bb::stdlib::cycle_group<Builder> to_grumpkin_point(const WitnessOrConstant<FF>& input_x,
                                                    const WitnessOrConstant<FF>& input_y,
                                                    const WitnessOrConstant<FF>& input_infinite,
                                                    bool has_valid_witness_assignments,
+                                                   const WitnessOrConstant<FF>& predicate,
                                                    Builder& builder)
 {
     using bool_ct = bb::stdlib::bool_t<Builder>;
+    using field_ct = bb::stdlib::field_t<Builder>;
     auto point_x = to_field_ct(input_x, builder);
     auto point_y = to_field_ct(input_y, builder);
     auto infinite = bool_ct(to_field_ct(input_infinite, builder));
 
+    BB_ASSERT_EQ(input_x.is_constant, input_y.is_constant, "to_grumpkin_point: Inconsistent constancy of coordinates");
     bool constant_coordinates = input_x.is_constant && input_y.is_constant;
 
-    // If witness is not provided and the input is non-constant, overwrite the coordinates to correspond to an arbitrary
-    // valid curve point (affine_one) to avoid triggering assertions in cycle_group.
-    if (!has_valid_witness_assignments && !constant_coordinates) {
+    // In a witness is not provided, or the relevant predicate is constant false, we ensure the coordinates correspond
+    // to a valid point to avoid erroneous failures during circuit construction. We only do this if the coordinates are
+    // non-constant since otherwise no variable indices exist.
+    bool constant_false_predicate = predicate.is_constant && predicate.value == FF(0);
+    if ((!has_valid_witness_assignments || constant_false_predicate) && !constant_coordinates) {
         auto one = bb::grumpkin::g1::affine_one;
         builder.set_variable(input_x.index, one.x);
         builder.set_variable(input_y.index, one.y);
     }
+
+    // If the predicate is a non-constant witness, conditionally replace coordinates with a valid point.
+    // Note: this must be done before constructing the cycle_group to avoid triggering on_curve assertions
+    if (!predicate.is_constant) {
+        bool_ct predicate_witness = bool_ct::from_witness_index_unsafe(&builder, predicate.index);
+        auto generator = bb::grumpkin::g1::affine_one;
+        point_x = field_ct::conditional_assign(predicate_witness, point_x, generator.x).normalize();
+        point_y = field_ct::conditional_assign(predicate_witness, point_y, generator.y).normalize();
+        bool_ct generator_is_infinity = bool_ct(&builder, generator.is_point_at_infinity());
+        infinite = bool_ct::conditional_assign(predicate_witness, infinite, generator_is_infinity).normalize();
+    }
+
     cycle_group<Builder> input_point(point_x, point_y, infinite);
     return input_point;
-}
-
-// Returns a valid point if the 'predicate' is a false witness
-template <typename Builder, typename FF>
-bb::stdlib::cycle_group<Builder> valid_point(const bb::stdlib::cycle_group<Builder>& input,
-                                             const WitnessOrConstant<FF>& predicate,
-                                             Builder& builder)
-{
-    using bool_ct = bb::stdlib::bool_t<Builder>;
-    if (predicate.is_constant) {
-        return input;
-    }
-    // creates a bool_ct from the index, without adding a boolean gate because a predicate is boolean by definition.
-    bool_ct predicate_witness = bool_ct::from_witness_index_unsafe(&builder, predicate.index);
-
-    auto generator = bb::grumpkin::g1::affine_one;
-    auto point_x = field_t<Builder>::conditional_assign(predicate_witness, input.x, generator.x).normalize();
-    auto point_y = field_t<Builder>::conditional_assign(predicate_witness, input.y, generator.y).normalize();
-    bool_ct generator_is_infinity = bool_ct(&builder, generator.is_point_at_infinity());
-    auto infinite =
-        bool_ct::conditional_assign(predicate_witness, input.is_point_at_infinity(), generator_is_infinity).normalize();
-    cycle_group<Builder> result(point_x, point_y, infinite);
-    return result;
 }
 
 template bb::stdlib::cycle_group<UltraCircuitBuilder> to_grumpkin_point(const WitnessOrConstant<fr>& input_x,
                                                                         const WitnessOrConstant<fr>& input_y,
                                                                         const WitnessOrConstant<fr>& input_infinite,
                                                                         bool has_valid_witness_assignments,
+                                                                        const WitnessOrConstant<fr>& predicate,
                                                                         UltraCircuitBuilder& builder);
 template bb::stdlib::cycle_group<MegaCircuitBuilder> to_grumpkin_point(const WitnessOrConstant<fr>& input_x,
                                                                        const WitnessOrConstant<fr>& input_y,
                                                                        const WitnessOrConstant<fr>& input_infinite,
                                                                        bool has_valid_witness_assignments,
+                                                                       const WitnessOrConstant<fr>& predicate,
                                                                        MegaCircuitBuilder& builder);
-template bb::stdlib::cycle_group<UltraCircuitBuilder> valid_point(
-    const bb::stdlib::cycle_group<UltraCircuitBuilder>& input,
-    const WitnessOrConstant<fr>& predicate,
-    UltraCircuitBuilder& builder);
-template bb::stdlib::cycle_group<MegaCircuitBuilder> valid_point(
-    const bb::stdlib::cycle_group<MegaCircuitBuilder>& input,
-    const WitnessOrConstant<fr>& predicate,
-    MegaCircuitBuilder& builder);
 
 } // namespace acir_format

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/witness_constant.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/witness_constant.cpp
@@ -13,7 +13,7 @@ using namespace bb;
 using namespace bb::stdlib;
 
 /**
- * @brief Convert WitnessOrConstant inputs representing a Grumpkin point into a cycle_group element.
+ * @brief Convert inputs representing a Grumpkin point into a cycle_group element.
  * @details Inputs x, y, and is_infinite are used to construct the point. If no valid witness is provided or if the
  * predicate is constant false, the point is set to the generator point. If the predicate is a non-constant witness, the
  * point is conditionally assigned to the generator point based on the predicate value. This ensures that the point is

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/witness_constant.hpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/witness_constant.hpp
@@ -51,11 +51,7 @@ bb::stdlib::cycle_group<Builder> to_grumpkin_point(const WitnessOrConstant<FF>& 
                                                    const WitnessOrConstant<FF>& input_y,
                                                    const WitnessOrConstant<FF>& input_infinite,
                                                    bool has_valid_witness_assignments,
+                                                   const WitnessOrConstant<FF>& predicate,
                                                    Builder& builder);
-
-template <typename Builder, typename FF>
-bb::stdlib::cycle_group<Builder> valid_point(const bb::stdlib::cycle_group<Builder>& input,
-                                             const WitnessOrConstant<FF>& predicate,
-                                             Builder& builder);
 
 } // namespace acir_format


### PR DESCRIPTION
Fixes a failure in `TestECPredicate` that was due to the interaction of two unrelated PRs (1) PR enabling predicate for EC operations in acir and (2) PR which enabled an `on_curve()` assertion in the canonical constructor for `cycle_group`. TestECPredicate was testing the case where predicate = false and the input point is invalid. There was logic in method `valid_point()` to handle this case but it was being called after the construction of a `cycle_group`, which triggered failure of the on-curve check. The solution is to move the "valid point" logic inside of method `to_grumpkin_point()` and ensure the inputs to the cycle_group constructor are valid prior to constructing the element.