### PR TITLE
chore: unbrick tf apply

### DIFF
--- a/spartan/terraform/deploy-aztec-infra/variables.tf
+++ b/spartan/terraform/deploy-aztec-infra/variables.tf
@@ -128,14 +128,12 @@ variable "L1_CONSENSUS_HOST_URLS" {
   description = "The L1 consensus host URLs"
   type        = list(string)
   default     = []
-  sensitive   = true
 }
 
 variable "L1_CONSENSUS_HOST_API_KEYS" {
   description = "The L1 consensus host API keys"
   type        = list(string)
   default     = []
-  sensitive   = true
 }
 
 variable "L1_CONSENSUS_HOST_API_KEY_HEADERS" {
@@ -163,7 +161,6 @@ variable "VALIDATOR_MNEMONIC" {
   description = "The validator mnemonic"
   type        = string
   default     = ""
-  sensitive   = true
 }
 
 variable "VALIDATOR_MNEMONIC_START_INDEX" {
@@ -199,7 +196,7 @@ variable "VALIDATOR_REPLICAS" {
 variable "PROVER_MNEMONIC" {
   description = "The prover mnemonic"
   type        = string
-  sensitive   = true
+  default     = "test test test test test test test test test test test junk"
 }
 
 variable "PROVER_REPLICAS" {
@@ -225,7 +222,6 @@ variable "OTEL_COLLECTOR_ENDPOINT" {
   type        = string
   default     = null
   nullable    = true
-  sensitive   = true
 }
 
 variable "SPONSORED_FPC" {
@@ -368,7 +364,6 @@ variable "STORE_SNAPSHOT_URL" {
   type        = string
   nullable    = true
   default     = null
-  sensitive   = true
 }
 
 variable "SNAPSHOT_CRON" {
@@ -381,7 +376,6 @@ variable "BOT_MNEMONIC" {
   description = "The bot mnemonic"
   type        = string
   default     = "test test test test test test test test test test test junk"
-  sensitive   = true
 }
 
 variable "BOT_TRANSFERS_MNEMONIC_START_INDEX" {
@@ -412,7 +406,6 @@ variable "BOT_TRANSFERS_L2_PRIVATE_KEY" {
   description = "Private key for the transfers bot (hex string starting with 0x)"
   nullable    = true
   default     = null
-  sensitive   = true
 }
 
 variable "BOT_SWAPS_MNEMONIC_START_INDEX" {
@@ -444,7 +437,6 @@ variable "BOT_SWAPS_L2_PRIVATE_KEY" {
   type        = string
   nullable    = true
   default     = null
-  sensitive   = true
 }
 
 # RPC ingress configuration (GKE-specific)
@@ -477,7 +469,6 @@ variable "PROVER_FAILED_PROOF_STORE" {
   type        = string
   nullable    = false
   default     = ""
-  sensitive   = true
 }
 
 variable "RPC_REPLICAS" {


### PR DESCRIPTION
In #17711 I marked vars as sensitive. Apparently terraform can not `for_each` on blocks if they contain sensitive blocks