### PR TITLE
fix!: Include proposer signature in attestations

### DIFF
--- a/.test_patterns.yml
+++ b/.test_patterns.yml
@@ -252,7 +252,7 @@ tests:
     error_regex: "will propagate messages to peers at the same version"
     owners:
       - *palla
-  - regex: "p2p/src/client/test/p2p_client.integration_status_handshake.test.ts"
+  - regex: "src/client/test/p2p_client.integration_status_handshake.test.ts"
     error_regex: "Expected number of calls"
     owners:
       - *palla

--- a/yarn-project/aztec-node/src/sentinel/sentinel.test.ts
+++ b/yarn-project/aztec-node/src/sentinel/sentinel.test.ts
@@ -7,11 +7,12 @@ import type { P2PClient } from '@aztec/p2p';
 import { OffenseType, WANT_TO_SLASH_EVENT, type WantToSlashArgs } from '@aztec/slasher';
 import type { SlasherConfig } from '@aztec/slasher/config';
 import {
+  CommitteeAttestation,
   type L2BlockSource,
   type L2BlockStream,
   type L2BlockStreamEvent,
-  type PublishedL2Block,
-  getAttestationsFromPublishedL2Block,
+  PublishedL2Block,
+  getAttestationInfoFromPublishedL2Block,
 } from '@aztec/stdlib/block';
 import { type L1RollupConstants, getEpochAtSlot } from '@aztec/stdlib/epoch-helpers';
 import type { BlockAttestation } from '@aztec/stdlib/p2p';
@@ -124,7 +125,13 @@ describe('sentinel', () => {
 
     it('identifies attestors from p2p and archiver', async () => {
       block = await randomPublishedL2Block(Number(slot), { signers: signers.slice(0, 2) });
-      const attestorsFromBlock = compactArray(getAttestationsFromPublishedL2Block(block)).map(att => att.getSender());
+      const attestorsFromBlock = compactArray(
+        getAttestationInfoFromPublishedL2Block(block).map(info =>
+          info.status === 'recovered-from-signature' || info.status === 'provided-as-address'
+            ? info.address
+            : undefined,
+        ),
+      );
       expect(attestorsFromBlock.map(a => a.toString())).toEqual(signers.slice(0, 2).map(a => a.address.toString()));
 
       await sentinel.handleBlockStreamEvent({ type: 'blocks-added', blocks: [block] });
@@ -133,6 +140,44 @@ describe('sentinel', () => {
       const activity = await sentinel.getSlotActivity(slot, epoch, proposer, committee);
       expect(activity[committee[1].toString()]).toEqual('attestation-sent');
       expect(activity[committee[2].toString()]).toEqual('attestation-sent');
+      expect(activity[committee[3].toString()]).toEqual('attestation-missed');
+    });
+
+    it('only counts recovered-from-signature attestations, not placeholder attestations', async () => {
+      // Create a block with only 2 signers (validators 0 and 1), plus placeholders for 2 and 3
+      block = await randomPublishedL2Block(Number(slot), { signers: signers.slice(0, 2) });
+
+      // Add placeholder attestations for the missing validators (no signature)
+      const placeholderAttestations = validators.slice(2).map(addr => CommitteeAttestation.fromAddress(addr));
+
+      // Append placeholders to the existing attestations
+      const allAttestations = [...block.attestations, ...placeholderAttestations];
+      block = new PublishedL2Block(block.block, block.l1, allAttestations);
+
+      // Verify that getAttestationInfoFromPublishedL2Block returns 4 entries total:
+      // - 2 with status 'recovered-from-signature' (actual attestations with valid signatures)
+      // - 2 with status 'provided-as-address' (placeholders for missing validators)
+      const attestationInfo = getAttestationInfoFromPublishedL2Block(block);
+      expect(attestationInfo).toHaveLength(4);
+      const recoveredSignatures = attestationInfo.filter(info => info.status === 'recovered-from-signature');
+      const placeholders = attestationInfo.filter(info => info.status === 'provided-as-address');
+      expect(recoveredSignatures).toHaveLength(2);
+      expect(placeholders).toHaveLength(2);
+
+      // After processing the block, only the validators with actual signatures should be recorded as attestors
+      await sentinel.handleBlockStreamEvent({ type: 'blocks-added', blocks: [block] });
+
+      // No additional attestations from p2p
+      p2p.getAttestationsForSlot.mockResolvedValue([]);
+
+      const activity = await sentinel.getSlotActivity(slot, epoch, proposer, committee);
+
+      // Validators 0 and 1 should be marked as having sent attestations (proposer is validator 0, so block-mined)
+      expect(activity[committee[0].toString()]).toEqual('block-mined');
+      expect(activity[committee[1].toString()]).toEqual('attestation-sent');
+
+      // Validators 2 and 3 should be marked as having missed attestations (not counted as sent despite placeholders)
+      expect(activity[committee[2].toString()]).toEqual('attestation-missed');
       expect(activity[committee[3].toString()]).toEqual('attestation-missed');
     });
 

--- a/yarn-project/aztec-node/src/sentinel/sentinel.ts
+++ b/yarn-project/aztec-node/src/sentinel/sentinel.ts
@@ -1,12 +1,5 @@
 import type { EpochCache } from '@aztec/epoch-cache';
-import {
-  compactArray,
-  countWhile,
-  filterAsync,
-  fromEntries,
-  getEntries,
-  mapValues,
-} from '@aztec/foundation/collection';
+import { countWhile, filterAsync, fromEntries, getEntries, mapValues } from '@aztec/foundation/collection';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { createLogger } from '@aztec/foundation/log';
 import { RunningPromise } from '@aztec/foundation/running-promise';
@@ -25,7 +18,7 @@ import {
   L2BlockStream,
   type L2BlockStreamEvent,
   type L2BlockStreamEventHandler,
-  getAttestationsFromPublishedL2Block,
+  getAttestationInfoFromPublishedL2Block,
 } from '@aztec/stdlib/block';
 import { getEpochAtSlot, getSlotRangeForEpoch, getTimestampForSlot } from '@aztec/stdlib/epoch-helpers';
 import type {
@@ -98,7 +91,9 @@ export class Sentinel extends (EventEmitter as new () => WatcherEmitter) impleme
         this.slotNumberToBlock.set(block.block.header.getSlot(), {
           blockNumber: block.block.number,
           archive: block.block.archive.root.toString(),
-          attestors: compactArray(getAttestationsFromPublishedL2Block(block)).map(att => att.getSender()),
+          attestors: getAttestationInfoFromPublishedL2Block(block)
+            .filter(a => a.status === 'recovered-from-signature')
+            .map(a => a.address!),
         });
       }
 

--- a/yarn-project/end-to-end/scripts/run_test.sh
+++ b/yarn-project/end-to-end/scripts/run_test.sh
@@ -10,10 +10,11 @@ source $(git rev-parse --show-toplevel)/ci3/source
 
 type=$1
 test=$2
+test_name=${3:-}
 
 case "$type" in
   "simple")
-    exec ./test_simple.sh $test
+    exec ./test_simple.sh "$test" "$test_name"
   ;;
   "compose")
     # TODO: Replace this file with test_simple.sh, and just emit the below as part of test_cmds.

--- a/yarn-project/end-to-end/scripts/test_simple.sh
+++ b/yarn-project/end-to-end/scripts/test_simple.sh
@@ -8,6 +8,7 @@
 # - cacheDirectory is used to separate jests greedy consuming /tmp space for transforms. TODO: Fix 80+MB contract json.
 #   Note that jests --no-cache is a lie, that just means don't use the cache. It still creates the cache. Unavoidable.
 # - runInBand is provided, to run the test in the main thread (no child process). It avoids various issues.
+# - testNamePattern is used to filter by test name when a specific test is provided.
 set -eu
 
 cd $(dirname $0)/..
@@ -19,14 +20,22 @@ export LOG_LEVEL=${LOG_LEVEL:-verbose}
 export NODE_NO_WARNINGS=1
 export FORCE_COLOR=1
 
-if [[ "$1" == *".sh" ]]; then
-  $1
+test_file=$1
+test_name=${2:-}
+
+if [[ "$test_file" == *".sh" ]]; then
+  $test_file
 else
-  [ -n "${JEST_CACHE_DIR:-}" ] && args="--cacheDirectory=$JEST_CACHE_DIR"
+  cache_dir_arg=()
+  test_name_arg=()
+  [ -n "${JEST_CACHE_DIR:-}" ] && cache_dir_arg=(--cacheDirectory="$JEST_CACHE_DIR")
+  [ -n "${test_name:-}" ] && test_name_arg=(--testNamePattern="$test_name")
+
   node --experimental-vm-modules ../node_modules/.bin/jest \
   --testTimeout=300000 \
   --forceExit \
   --no-cache \
-  ${args:-} \
-  --runInBand $1
+  "${cache_dir_arg[@]}" \
+  "${test_name_arg[@]}" \
+  --runInBand "$1"
 fi

--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_invalidate_block.parallel.test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_invalidate_block.parallel.test.ts
@@ -44,9 +44,7 @@ describe('e2e_epochs/epochs_invalidate_block', () => {
 
     // Setup context with the given set of validators, mocked gossip sub network, and no anvil test watcher.
     test = await EpochsTestContext.setup({
-      aztecSlotDuration: 8,
-      aztecEpochDuration: 4,
-      ethereumSlotDuration: 4,
+      ethereumSlotDuration: 8,
       numberOfAccounts: 1,
       initialValidators: validators,
       mockGossipSubNetwork: true,

--- a/yarn-project/end-to-end/src/e2e_multi_validator/e2e_multi_validator_node.test.ts
+++ b/yarn-project/end-to-end/src/e2e_multi_validator/e2e_multi_validator_node.test.ts
@@ -19,6 +19,7 @@ import {
   getL1ContractsConfigEnvVars,
 } from '@aztec/ethereum';
 import { SecretValue } from '@aztec/foundation/config';
+import { Signature } from '@aztec/foundation/eth-signature';
 import { RollupAbi } from '@aztec/l1-artifacts/RollupAbi';
 import { StatefulTestContractArtifact } from '@aztec/noir-test-contracts.js/StatefulTest';
 import { BlockAttestation, ConsensusPayload } from '@aztec/stdlib/p2p';
@@ -134,7 +135,7 @@ describe('e2e_multi_validator_node', () => {
     const payload = ConsensusPayload.fromBlock(block.block);
     const attestations = block.attestations
       .filter(a => !a.signature.isEmpty())
-      .map(a => new BlockAttestation(block.block.number, payload, a.signature));
+      .map(a => new BlockAttestation(block.block.number, payload, a.signature, Signature.empty()));
 
     expect(attestations.length).toBeGreaterThanOrEqual((COMMITTEE_SIZE * 2) / 3 + 1);
 
@@ -191,7 +192,7 @@ describe('e2e_multi_validator_node', () => {
     const payload = ConsensusPayload.fromBlock(block.block);
     const attestations = block.attestations
       .filter(a => !a.signature.isEmpty())
-      .map(a => new BlockAttestation(block.block.number, payload, a.signature));
+      .map(a => new BlockAttestation(block.block.number, payload, a.signature, Signature.empty()));
 
     expect(attestations.length).toBeGreaterThanOrEqual((COMMITTEE_SIZE * 2) / 3 + 1);
 

--- a/yarn-project/end-to-end/src/e2e_p2p/gossip_network.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/gossip_network.test.ts
@@ -1,6 +1,7 @@
 import type { Archiver } from '@aztec/archiver';
 import type { AztecNodeConfig, AztecNodeService } from '@aztec/aztec-node';
 import { retryUntil, sleep } from '@aztec/aztec.js';
+import { Signature } from '@aztec/foundation/eth-signature';
 import type { ProverNode } from '@aztec/prover-node';
 import type { SequencerClient } from '@aztec/sequencer-client';
 import { tryStop } from '@aztec/stdlib/interfaces/server';
@@ -173,7 +174,7 @@ describe('e2e_p2p_network', () => {
     const payload = ConsensusPayload.fromBlock(block.block);
     const attestations = block.attestations
       .filter(a => !a.signature.isEmpty())
-      .map(a => new BlockAttestation(blockNumber, payload, a.signature));
+      .map(a => new BlockAttestation(blockNumber, payload, a.signature, Signature.empty()));
     const signers = await Promise.all(attestations.map(att => att.getSender().toString()));
     t.logger.info(`Attestation signers`, { signers });
 

--- a/yarn-project/end-to-end/src/e2e_p2p/gossip_network_no_cheat.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/gossip_network_no_cheat.test.ts
@@ -3,6 +3,7 @@ import type { AztecNodeService } from '@aztec/aztec-node';
 import { EthAddress, Fr, sleep } from '@aztec/aztec.js';
 import { addL1Validator } from '@aztec/cli/l1';
 import { RollupContract } from '@aztec/ethereum';
+import { Signature } from '@aztec/foundation/eth-signature';
 import { MockZKPassportVerifierAbi } from '@aztec/l1-artifacts/MockZKPassportVerifierAbi';
 import { RollupAbi } from '@aztec/l1-artifacts/RollupAbi';
 import { StakingAssetHandlerAbi } from '@aztec/l1-artifacts/StakingAssetHandlerAbi';
@@ -225,7 +226,7 @@ describe('e2e_p2p_network', () => {
     const payload = ConsensusPayload.fromBlock(block.block);
     const attestations = block.attestations
       .filter(a => !a.signature.isEmpty())
-      .map(a => new BlockAttestation(blockNumber, payload, a.signature));
+      .map(a => new BlockAttestation(blockNumber, payload, a.signature, Signature.empty()));
     const signers = await Promise.all(attestations.map(att => att.getSender().toString()));
     t.logger.info(`Attestation signers`, { signers });
 

--- a/yarn-project/end-to-end/src/e2e_p2p/preferred_gossip_network.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/preferred_gossip_network.test.ts
@@ -1,6 +1,7 @@
 import type { Archiver } from '@aztec/archiver';
 import type { AztecNodeConfig, AztecNodeService } from '@aztec/aztec-node';
 import { retryUntil } from '@aztec/aztec.js';
+import { Signature } from '@aztec/foundation/eth-signature';
 import { ENR, type P2PClient, type P2PService, type PeerId } from '@aztec/p2p';
 import type { SequencerClient } from '@aztec/sequencer-client';
 import { BlockAttestation, ConsensusPayload } from '@aztec/stdlib/p2p';
@@ -357,7 +358,7 @@ describe('e2e_p2p_preferred_network', () => {
     const payload = ConsensusPayload.fromBlock(block.block);
     const attestations = block.attestations
       .filter(a => !a.signature.isEmpty())
-      .map(a => new BlockAttestation(blockNumber, payload, a.signature));
+      .map(a => new BlockAttestation(blockNumber, payload, a.signature, Signature.empty()));
     const signers = await Promise.all(attestations.map(att => att.getSender().toString()));
     t.logger.info(`Attestation signers`, { signers });
 

--- a/yarn-project/p2p/src/client/p2p_client.ts
+++ b/yarn-project/p2p/src/client/p2p_client.ts
@@ -387,6 +387,10 @@ export class P2PClient<T extends P2PClientType = P2PClientType.Full>
     return this.attestationPool?.addAttestations(attestations) ?? Promise.resolve();
   }
 
+  public deleteAttestation(attestation: BlockAttestation): Promise<void> {
+    return this.attestationPool?.deleteAttestations([attestation]) ?? Promise.resolve();
+  }
+
   // REVIEW: https://github.com/AztecProtocol/aztec-packages/issues/7963
   // ^ This pattern is not my favorite (md)
   public registerBlockProposalHandler(handler: P2PBlockReceivedCallback): void {

--- a/yarn-project/p2p/src/mem_pools/attestation_pool/mocks.ts
+++ b/yarn-project/p2p/src/mem_pools/attestation_pool/mocks.ts
@@ -35,8 +35,11 @@ export const mockAttestation = (
   const header = makeHeader(1, 2, slot);
   const payload = new ConsensusPayload(header.toPropose(), archive, header.state);
 
-  const hash = getHashedSignaturePayloadEthSignedMessage(payload, SignatureDomainSeparator.blockAttestation);
-  const signature = signer.sign(hash);
+  const attestationHash = getHashedSignaturePayloadEthSignedMessage(payload, SignatureDomainSeparator.blockAttestation);
+  const attestationSignature = signer.sign(attestationHash);
 
-  return new BlockAttestation(header.globalVariables.blockNumber, payload, signature);
+  const proposalHash = getHashedSignaturePayloadEthSignedMessage(payload, SignatureDomainSeparator.blockProposal);
+  const proposerSignature = signer.sign(proposalHash);
+
+  return new BlockAttestation(header.globalVariables.blockNumber, payload, attestationSignature, proposerSignature);
 };

--- a/yarn-project/p2p/src/msg_validators/attestation_validator/attestation_validator.test.ts
+++ b/yarn-project/p2p/src/msg_validators/attestation_validator/attestation_validator.test.ts
@@ -1,4 +1,5 @@
 import type { EpochCache } from '@aztec/epoch-cache';
+import { Secp256k1Signer } from '@aztec/foundation/crypto';
 import { PeerErrorSeverity } from '@aztec/stdlib/p2p';
 import { makeBlockAttestation, makeHeader } from '@aztec/stdlib/testing';
 
@@ -9,10 +10,14 @@ import { AttestationValidator } from './attestation_validator.js';
 describe('AttestationValidator', () => {
   let epochCache: EpochCache;
   let validator: AttestationValidator;
+  let proposer: Secp256k1Signer;
+  let attester: Secp256k1Signer;
 
   beforeEach(() => {
     epochCache = mock<EpochCache>();
     validator = new AttestationValidator(epochCache);
+    proposer = Secp256k1Signer.random();
+    attester = Secp256k1Signer.random();
   });
 
   it('returns high tolerance error if slot number is not current or next slot', async () => {
@@ -20,10 +25,14 @@ describe('AttestationValidator', () => {
     const header = makeHeader(1, 97, 97);
     const mockAttestation = makeBlockAttestation({
       header,
+      attesterSigner: attester,
+      proposerSigner: proposer,
     });
 
     // Mock epoch cache to return different slot numbers
     (epochCache.getProposerAttesterAddressInCurrentOrNextSlot as jest.Mock).mockResolvedValue({
+      currentProposer: proposer.address,
+      nextProposer: proposer.address,
       currentSlot: 98n,
       nextSlot: 99n,
     });
@@ -37,10 +46,14 @@ describe('AttestationValidator', () => {
     // The slot is correct, but the attester is not in the committee
     const mockAttestation = makeBlockAttestation({
       header: makeHeader(1, 100, 100),
+      attesterSigner: attester,
+      proposerSigner: proposer,
     });
 
     // Mock epoch cache to return matching slot number but invalid committee membership
     (epochCache.getProposerAttesterAddressInCurrentOrNextSlot as jest.Mock).mockResolvedValue({
+      currentProposer: proposer.address,
+      nextProposer: proposer.address,
       currentSlot: 100n,
       nextSlot: 101n,
     });
@@ -54,10 +67,14 @@ describe('AttestationValidator', () => {
     // Create an attestation for slot 100
     const mockAttestation = makeBlockAttestation({
       header: makeHeader(1, 100, 100),
+      attesterSigner: attester,
+      proposerSigner: proposer,
     });
 
     // Mock epoch cache for valid case with current slot
     (epochCache.getProposerAttesterAddressInCurrentOrNextSlot as jest.Mock).mockResolvedValue({
+      currentProposer: proposer.address,
+      nextProposer: proposer.address,
       currentSlot: 100n,
       nextSlot: 101n,
     });
@@ -71,10 +88,14 @@ describe('AttestationValidator', () => {
     // Setup attestation for next slot
     const mockAttestation = makeBlockAttestation({
       header: makeHeader(1, 101, 101),
+      attesterSigner: attester,
+      proposerSigner: proposer,
     });
 
     // Mock epoch cache for valid case with next slot
     (epochCache.getProposerAttesterAddressInCurrentOrNextSlot as jest.Mock).mockResolvedValue({
+      currentProposer: proposer.address,
+      nextProposer: proposer.address,
       currentSlot: 100n,
       nextSlot: 101n,
     });
@@ -82,5 +103,26 @@ describe('AttestationValidator', () => {
 
     const result = await validator.validate(mockAttestation);
     expect(result).toBeUndefined();
+  });
+
+  it('returns high tolerance error if proposer signature is invalid', async () => {
+    const wrongProposer = Secp256k1Signer.random();
+    const mockAttestation = makeBlockAttestation({
+      header: makeHeader(1, 100, 100),
+      attesterSigner: attester,
+      proposerSigner: wrongProposer,
+    });
+
+    // Mock epoch cache with different proposer
+    (epochCache.getProposerAttesterAddressInCurrentOrNextSlot as jest.Mock).mockResolvedValue({
+      currentProposer: proposer.address,
+      nextProposer: proposer.address,
+      currentSlot: 100n,
+      nextSlot: 101n,
+    });
+    (epochCache.isInCommittee as jest.Mock).mockResolvedValue(true);
+
+    const result = await validator.validate(mockAttestation);
+    expect(result).toBe(PeerErrorSeverity.HighToleranceError);
   });
 });

--- a/yarn-project/p2p/src/msg_validators/attestation_validator/attestation_validator.ts
+++ b/yarn-project/p2p/src/msg_validators/attestation_validator/attestation_validator.ts
@@ -1,31 +1,58 @@
 import type { EpochCacheInterface } from '@aztec/epoch-cache';
 import { NoCommitteeError } from '@aztec/ethereum';
+import { type Logger, createLogger } from '@aztec/foundation/log';
 import { type BlockAttestation, type P2PValidator, PeerErrorSeverity } from '@aztec/stdlib/p2p';
 
 export class AttestationValidator implements P2PValidator<BlockAttestation> {
   private epochCache: EpochCacheInterface;
+  private logger: Logger;
 
   constructor(epochCache: EpochCacheInterface) {
     this.epochCache = epochCache;
+    this.logger = createLogger('p2p:attestation-validator');
   }
 
   async validate(message: BlockAttestation): Promise<PeerErrorSeverity | undefined> {
-    try {
-      const { currentSlot, nextSlot } = await this.epochCache.getProposerAttesterAddressInCurrentOrNextSlot();
+    const slotNumberBigInt = message.payload.header.slotNumber.toBigInt();
 
-      const slotNumberBigInt = message.payload.header.slotNumber.toBigInt();
+    try {
+      const { currentProposer, nextProposer, currentSlot, nextSlot } =
+        await this.epochCache.getProposerAttesterAddressInCurrentOrNextSlot();
+
       if (slotNumberBigInt !== currentSlot && slotNumberBigInt !== nextSlot) {
+        this.logger.warn(
+          `Attestation slot ${slotNumberBigInt} is not current (${currentSlot}) or next (${nextSlot}) slot`,
+        );
         return PeerErrorSeverity.HighToleranceError;
       }
 
+      // Verify the attester is in the committee for this slot
       const attester = message.getSender();
       if (!(await this.epochCache.isInCommittee(slotNumberBigInt, attester))) {
+        this.logger.warn(`Attester ${attester.toString()} is not in committee for slot ${slotNumberBigInt}`);
         return PeerErrorSeverity.HighToleranceError;
       }
+
+      // Verify the proposer signature matches the expected proposer for this slot
+      const proposer = message.getProposer();
+      const expectedProposer = slotNumberBigInt === currentSlot ? currentProposer : nextProposer;
+      if (!expectedProposer) {
+        this.logger.warn(`No proposer defined for slot ${slotNumberBigInt}`);
+        return PeerErrorSeverity.HighToleranceError;
+      }
+      if (!proposer.equals(expectedProposer)) {
+        this.logger.warn(
+          `Proposer signature mismatch in attestation. ` +
+            `Expected ${expectedProposer?.toString() ?? 'none'} but got ${proposer.toString()} for slot ${slotNumberBigInt}`,
+        );
+        return PeerErrorSeverity.HighToleranceError;
+      }
+
       return undefined;
     } catch (e) {
       // People shouldn't be sending us attestations if the committee doesn't exist
       if (e instanceof NoCommitteeError) {
+        this.logger.warn(`No committee exists for attestation for slot ${slotNumberBigInt}`);
         return PeerErrorSeverity.LowToleranceError;
       }
       throw e;

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
@@ -93,7 +93,12 @@ describe('sequencer', () => {
 
   const getAttestations = () => {
     const consensusPayload = ConsensusPayload.fromBlock(block);
-    const attestation = new BlockAttestation(block.header.globalVariables.blockNumber, consensusPayload, mockedSig);
+    const attestation = new BlockAttestation(
+      block.header.globalVariables.blockNumber,
+      consensusPayload,
+      mockedSig,
+      mockedSig,
+    );
     (attestation as any).sender = committee[0];
     return [attestation];
   };

--- a/yarn-project/stdlib/src/block/attestation_info.ts
+++ b/yarn-project/stdlib/src/block/attestation_info.ts
@@ -1,0 +1,62 @@
+import { recoverAddress } from '@aztec/foundation/crypto';
+import type { EthAddress } from '@aztec/foundation/eth-address';
+
+import { ConsensusPayload } from '../p2p/consensus_payload.js';
+import { SignatureDomainSeparator, getHashedSignaturePayloadEthSignedMessage } from '../p2p/signature_utils.js';
+import type { L2Block } from './l2_block.js';
+import type { CommitteeAttestation } from './proposal/committee_attestation.js';
+
+/**
+ * Status indicating how the attestation address was determined
+ */
+export type AttestationStatus = 'recovered-from-signature' | 'provided-as-address' | 'invalid-signature' | 'empty';
+
+/**
+ * Information about an attestation extracted from a published block
+ */
+export type AttestationInfo =
+  | {
+      /** The validator's address, undefined if signature recovery failed or empty */
+      address?: undefined;
+      /** How the attestation address was determined */
+      status: Extract<AttestationStatus, 'invalid-signature' | 'empty'>;
+    }
+  | {
+      /** The validator's address */
+      address: EthAddress;
+      /** How the attestation address was determined */
+      status: Extract<AttestationStatus, 'provided-as-address' | 'recovered-from-signature'>;
+    };
+
+/**
+ * Extracts attestation information from a published L2 block.
+ * Returns info for each attestation, preserving array indices.
+ */
+export function getAttestationInfoFromPublishedL2Block(block: {
+  attestations: CommitteeAttestation[];
+  block: L2Block;
+}): AttestationInfo[] {
+  const payload = ConsensusPayload.fromBlock(block.block);
+  const hashedPayload = getHashedSignaturePayloadEthSignedMessage(payload, SignatureDomainSeparator.blockAttestation);
+
+  return block.attestations.map(attestation => {
+    // If signature is empty, check if we have an address directly
+    if (attestation.signature.isEmpty()) {
+      if (attestation.address.isZero()) {
+        // No signature and no address - empty
+        return { status: 'empty' as const };
+      }
+      // Address provided without signature
+      return { address: attestation.address, status: 'provided-as-address' as const };
+    }
+
+    // Try to recover address from signature
+    try {
+      const recoveredAddress = recoverAddress(hashedPayload, attestation.signature);
+      return { address: recoveredAddress, status: 'recovered-from-signature' as const };
+    } catch {
+      // Signature present but recovery failed
+      return { status: 'invalid-signature' as const };
+    }
+  });
+}

--- a/yarn-project/stdlib/src/block/index.ts
+++ b/yarn-project/stdlib/src/block/index.ts
@@ -9,3 +9,4 @@ export * from './published_l2_block.js';
 export * from './proposal/index.js';
 export * from './validate_block_result.js';
 export * from './l2_block_info.js';
+export * from './attestation_info.js';

--- a/yarn-project/stdlib/src/block/published_l2_block.ts
+++ b/yarn-project/stdlib/src/block/published_l2_block.ts
@@ -7,8 +7,6 @@ import type { FieldsOf } from '@aztec/foundation/types';
 
 import { z } from 'zod';
 
-import { BlockAttestation } from '../p2p/block_attestation.js';
-import { ConsensusPayload } from '../p2p/consensus_payload.js';
 import { L2Block } from './l2_block.js';
 import { CommitteeAttestation } from './proposal/committee_attestation.js';
 
@@ -81,19 +79,4 @@ export class PublishedL2Block {
       this.attestations,
     );
   }
-}
-
-/**
- * Extracts block attestations from a published L2 block.
- * Returns undefined for attestations with empty signatures, preserving array indices.
- */
-export function getAttestationsFromPublishedL2Block(
-  block: Pick<PublishedL2Block, 'attestations' | 'block'>,
-): (BlockAttestation | undefined)[] {
-  const payload = ConsensusPayload.fromBlock(block.block);
-  return block.attestations.map(attestation =>
-    attestation.signature.isEmpty()
-      ? undefined
-      : new BlockAttestation(block.block.number, payload, attestation.signature),
-  );
 }

--- a/yarn-project/stdlib/src/interfaces/p2p.test.ts
+++ b/yarn-project/stdlib/src/interfaces/p2p.test.ts
@@ -55,6 +55,10 @@ describe('P2PApiSchema', () => {
     const peers = await context.client.getPeers(true);
     expect(peers).toEqual(peers);
   });
+
+  it('deleteAttestation', async () => {
+    await context.client.deleteAttestation(BlockAttestation.empty());
+  });
 });
 
 const peers: PeerInfo[] = [
@@ -89,6 +93,11 @@ class MockP2P implements P2PApi {
 
   addAttestations(attestations: BlockAttestation[]): Promise<void> {
     expect(attestations).toEqual([BlockAttestation.empty(), BlockAttestation.empty()]);
+    return Promise.resolve();
+  }
+
+  deleteAttestation(attestation: BlockAttestation): Promise<void> {
+    expect(attestation).toEqual(BlockAttestation.empty());
     return Promise.resolve();
   }
 }

--- a/yarn-project/stdlib/src/interfaces/p2p.ts
+++ b/yarn-project/stdlib/src/interfaces/p2p.ts
@@ -57,6 +57,9 @@ export interface P2PApiWithAttestations extends P2PApiWithoutAttestations {
    * @returns BlockAttestations
    */
   getAttestationsForSlot(slot: bigint, proposalId?: string): Promise<BlockAttestation[]>;
+
+  /** Deletes a given attestation manually from the p2p client attestation pool. */
+  deleteAttestation(attestation: BlockAttestation): Promise<void>;
 }
 
 export interface P2PClient extends P2PApiWithAttestations {
@@ -85,4 +88,5 @@ export const P2PApiSchema: ApiSchemaFor<P2PApi> = {
   getPendingTxCount: z.function().returns(schemas.Integer),
   getEncodedEnr: z.function().returns(z.string().optional()),
   getPeers: z.function().args(optional(z.boolean())).returns(z.array(PeerInfoSchema)),
+  deleteAttestation: z.function().args(BlockAttestation.schema).returns(z.void()),
 };

--- a/yarn-project/stdlib/src/p2p/block_attestation.ts
+++ b/yarn-project/stdlib/src/p2p/block_attestation.ts
@@ -30,6 +30,7 @@ export class BlockAttestation extends Gossipable {
   static override p2pTopic = TopicType.block_attestation;
 
   private sender: EthAddress | undefined;
+  private proposer: EthAddress | undefined;
 
   constructor(
     /** The block number of the attestation. */
@@ -40,6 +41,9 @@ export class BlockAttestation extends Gossipable {
 
     /** The signature of the block attester */
     public readonly signature: Signature,
+
+    /** The signature from the block proposer */
+    public readonly proposerSignature: Signature,
   ) {
     super();
   }
@@ -50,8 +54,9 @@ export class BlockAttestation extends Gossipable {
         blockNumber: schemas.UInt32,
         payload: ConsensusPayload.schema,
         signature: Signature.schema,
+        proposerSignature: Signature.schema,
       })
-      .transform(obj => new BlockAttestation(obj.blockNumber, obj.payload, obj.signature));
+      .transform(obj => new BlockAttestation(obj.blockNumber, obj.payload, obj.signature, obj.proposerSignature));
   }
 
   override generateP2PMessageIdentifier(): Promise<Buffer32> {
@@ -93,29 +98,54 @@ export class BlockAttestation extends Gossipable {
     }
   }
 
+  /**
+   * Lazily evaluate and cache the proposer of the block
+   * @returns The proposer of the block
+   */
+  getProposer(): EthAddress {
+    if (!this.proposer) {
+      // Recover the proposer from the proposal signature
+      const hashed = getHashedSignaturePayloadEthSignedMessage(this.payload, SignatureDomainSeparator.blockProposal);
+      // Cache the proposer for later use
+      this.proposer = recoverAddress(hashed, this.proposerSignature);
+    }
+
+    return this.proposer;
+  }
+
   getPayload(): Buffer {
     return this.payload.getPayloadToSign(SignatureDomainSeparator.blockAttestation);
   }
 
   toBuffer(): Buffer {
-    return serializeToBuffer([this.blockNumber, this.payload, this.signature]);
+    return serializeToBuffer([this.blockNumber, this.payload, this.signature, this.proposerSignature]);
   }
 
   static fromBuffer(buf: Buffer | BufferReader): BlockAttestation {
     const reader = BufferReader.asReader(buf);
-    return new BlockAttestation(reader.readNumber(), reader.readObject(ConsensusPayload), reader.readObject(Signature));
+    return new BlockAttestation(
+      reader.readNumber(),
+      reader.readObject(ConsensusPayload),
+      reader.readObject(Signature),
+      reader.readObject(Signature),
+    );
   }
 
   static empty(): BlockAttestation {
-    return new BlockAttestation(0, ConsensusPayload.empty(), Signature.empty());
+    return new BlockAttestation(0, ConsensusPayload.empty(), Signature.empty(), Signature.empty());
   }
 
   static random(): BlockAttestation {
-    return new BlockAttestation(Math.floor(Math.random() * 1000) + 1, ConsensusPayload.random(), Signature.random());
+    return new BlockAttestation(
+      Math.floor(Math.random() * 1000) + 1,
+      ConsensusPayload.random(),
+      Signature.random(),
+      Signature.random(),
+    );
   }
 
   getSize(): number {
-    return 4 /* blockNumber */ + this.payload.getSize() + this.signature.getSize();
+    return 4 /* blockNumber */ + this.payload.getSize() + this.signature.getSize() + this.proposerSignature.getSize();
   }
 
   toInspect() {
@@ -123,6 +153,7 @@ export class BlockAttestation extends Gossipable {
       blockNumber: this.blockNumber,
       payload: this.payload.toInspect(),
       signature: this.signature.toString(),
+      proposerSignature: this.proposerSignature.toString(),
     };
   }
 }

--- a/yarn-project/stdlib/src/tests/mocks.ts
+++ b/yarn-project/stdlib/src/tests/mocks.ts
@@ -248,6 +248,8 @@ export const randomDeployedContract = async () => {
 
 export interface MakeConsensusPayloadOptions {
   signer?: Secp256k1Signer;
+  attesterSigner?: Secp256k1Signer;
+  proposerSigner?: Secp256k1Signer;
   header?: BlockHeader;
   archive?: Fr;
   stateReference?: StateReference;
@@ -296,21 +298,58 @@ export const makeBlockProposal = (options?: MakeConsensusPayloadOptions): BlockP
 
 // TODO(https://github.com/AztecProtocol/aztec-packages/issues/8028)
 export const makeBlockAttestation = (options?: MakeConsensusPayloadOptions): BlockAttestation => {
-  const { blockNumber, payload, signature } = makeAndSignConsensusPayload(
-    SignatureDomainSeparator.blockAttestation,
-    options,
-  );
-  return new BlockAttestation(blockNumber, payload, signature);
+  const header = options?.header ?? makeHeader(1);
+  const {
+    signer,
+    attesterSigner = signer ?? Secp256k1Signer.random(),
+    proposerSigner = signer ?? Secp256k1Signer.random(),
+    archive = Fr.random(),
+    stateReference = header.state,
+  } = options ?? {};
+
+  const payload = ConsensusPayload.fromFields({
+    header: header.toPropose(),
+    archive,
+    stateReference,
+  });
+
+  // Sign as attester
+  const attestationHash = getHashedSignaturePayloadEthSignedMessage(payload, SignatureDomainSeparator.blockAttestation);
+  const attestationSignature = attesterSigner.sign(attestationHash);
+
+  // Sign as proposer
+  const proposalHash = getHashedSignaturePayloadEthSignedMessage(payload, SignatureDomainSeparator.blockProposal);
+  const proposerSignature = proposerSigner.sign(proposalHash);
+
+  return new BlockAttestation(header.globalVariables.blockNumber, payload, attestationSignature, proposerSignature);
 };
 
-export const makeBlockAttestationFromBlock = (block: L2Block, signer?: Secp256k1Signer): BlockAttestation => {
-  return makeBlockAttestation({
-    signer,
-    header: block.header,
-    archive: block.archive.root,
-    stateReference: block.header.state,
-    txHashes: block.body.txEffects.map(tx => tx.txHash),
+export const makeBlockAttestationFromBlock = (
+  block: L2Block,
+  attesterSigner?: Secp256k1Signer,
+  proposerSigner?: Secp256k1Signer,
+): BlockAttestation => {
+  const header = block.header;
+  const archive = block.archive.root;
+  const stateReference = block.header.state;
+
+  const payload = ConsensusPayload.fromFields({
+    header: header.toPropose(),
+    archive,
+    stateReference,
   });
+
+  // Sign as attester
+  const attestationHash = getHashedSignaturePayloadEthSignedMessage(payload, SignatureDomainSeparator.blockAttestation);
+  const attestationSigner = attesterSigner ?? Secp256k1Signer.random();
+  const attestationSignature = attestationSigner.sign(attestationHash);
+
+  // Sign as proposer
+  const proposalHash = getHashedSignaturePayloadEthSignedMessage(payload, SignatureDomainSeparator.blockProposal);
+  const proposalSignerToUse = proposerSigner ?? Secp256k1Signer.random();
+  const proposerSignature = proposalSignerToUse.sign(proposalHash);
+
+  return new BlockAttestation(header.globalVariables.blockNumber, payload, attestationSignature, proposerSignature);
 };
 
 export async function randomPublishedL2Block(

--- a/yarn-project/txe/src/state_machine/dummy_p2p_client.ts
+++ b/yarn-project/txe/src/state_machine/dummy_p2p_client.ts
@@ -117,6 +117,10 @@ export class DummyP2P implements P2P {
     throw new Error('DummyP2P does not implement "getAttestationForSlot"');
   }
 
+  public deleteAttestation(_attestation: BlockAttestation): Promise<void> {
+    return Promise.resolve();
+  }
+
   public addAttestations(_attestations: BlockAttestation[]): Promise<void> {
     throw new Error('DummyP2P does not implement "addAttestations"');
   }

--- a/yarn-project/validator-client/src/duties/validation_service.ts
+++ b/yarn-project/validator-client/src/duties/validation_service.ts
@@ -74,8 +74,7 @@ export class ValidationService {
     const signatures = await Promise.all(
       attestors.map(attestor => this.keyStore.signMessageWithAddress(attestor, buf)),
     );
-    //await this.keyStore.signMessage(buf);
-    return signatures.map(sig => new BlockAttestation(proposal.blockNumber, proposal.payload, sig));
+    return signatures.map(sig => new BlockAttestation(proposal.blockNumber, proposal.payload, sig, proposal.signature));
   }
 
   async signAttestationsAndSigners(

--- a/yarn-project/validator-client/src/validator.ts
+++ b/yarn-project/validator-client/src/validator.ts
@@ -396,7 +396,22 @@ export class ValidatorClient extends (EventEmitter as new () => WatcherEmitter) 
 
     let attestations: BlockAttestation[] = [];
     while (true) {
-      const collectedAttestations = await this.p2pClient.getAttestationsForSlot(slot, proposalId);
+      // Filter out attestations with a mismatching payload. This should NOT happen since we have verified
+      // the proposer signature (ie our own) before accepting the attestation into the pool via the p2p client.
+      const collectedAttestations = (await this.p2pClient.getAttestationsForSlot(slot, proposalId)).filter(
+        attestation => {
+          if (!attestation.payload.equals(proposal.payload)) {
+            this.log.warn(
+              `Received attestation for slot ${slot} with mismatched payload from ${attestation.getSender().toString()}`,
+              { attestationPayload: attestation.payload, proposalPayload: proposal.payload },
+            );
+            return false;
+          }
+          return true;
+        },
+      );
+
+      // Log new attestations we collected
       const oldSenders = attestations.map(attestation => attestation.getSender());
       for (const collected of collectedAttestations) {
         const collectedSender = collected.getSender();


### PR DESCRIPTION
Fixes A-126

## Breaking changes

- The `BlockAttestation` struct in the p2p network now requires an additional field.

## Summary

No, this was not written by Claude! 

### Include proposer signature in attestations

Adds the signature of the block proposer over the attestation, which gets validated before accepting and rebroadcasting every attestation. This prevents a malicious attestor from flooding the network with signed attestations for non-existing proposals.

### Validate attestations payload before including them

Fixes Joe's Attack. We should no longer run into this since the attestation must include the proposer's signature, but if somehow the attestation still makes it past to the validator, we add an extra check there and we drop the attestation (and remove it from our pool).

### Use LMDB backed attestation pool

We were using the in-memory attestation pool by default. This changes it to using the lmdb one.

### Reject empty committee attestations during archiver validation

Every entry in the attestations retrieved from the block in the `CommitteeAttestation.fromPacked` call in `data_retrieval.ts` must have either a signature or an address, so the committee commitment can be reconstructed. A completely empty entry here is an error.

### Changed return type for `getAttestationsFromPublishedL2Block`

Since we now require the proposer signature to construct a `BlockAttestation` object, and the proposer signature is mixed with all the other attestations, we change the return type from `BlockAttestation` to a simple struct with the recovered or submitted address, along with the status.