### PR TITLE
fix: surface version mismatch errors over zod validation errors

### DIFF
--- a/yarn-project/stdlib/src/versioning/versioning.ts
+++ b/yarn-project/stdlib/src/versioning/versioning.ts
@@ -117,11 +117,16 @@ export function validatePartialComponentVersionsMatch(
 /** Returns a Koa middleware that injects the versioning info as headers. */
 export function getVersioningMiddleware(versions: Partial<ComponentsVersions>) {
   return async (ctx: Koa.Context, next: () => Promise<void>) => {
-    await next();
-    for (const key in versions) {
-      const value = versions[key as keyof ComponentsVersions];
-      if (value !== undefined) {
-        ctx.set(`x-aztec-${key}`, value.toString());
+    try {
+      await next();
+    } finally {
+      // Always add version headers, even if there was an error
+      // This allows the client to detect version mismatches before processing other errors
+      for (const key in versions) {
+        const value = versions[key as keyof ComponentsVersions];
+        if (value !== undefined) {
+          ctx.set(`x-aztec-${key}`, value.toString());
+        }
       }
     }
   };


### PR DESCRIPTION
## Summary
Fixes issue #17714 where users were getting Zod validation errors instead of clear ComponentsVersionsError messages when client and server versions are mismatched.

The problem occurred when:
- Client on version X sends request with params valid for version X
- Server on version Y receives request and validates against version Y schema  
- Server throws Zod error instead of version mismatch error
- Version headers weren't being added to error responses

## Changes
- **Server**: Modified `getVersioningMiddleware` to use try-finally to ensure version headers are added to ALL responses, including error responses
- **Client**: Modified JSON-RPC client to detect `ComponentsVersionsError` by checking `error.name` and surface it directly instead of converting to generic JSON-RPC error
- **Test coverage**: Added test to verify `ComponentsVersionsError` is thrown for version mismatches even when request would cause validation errors

## Test plan
- [x] Added new test case: "throws ComponentsVersionsError on version mismatch even when request causes validation error"
- [x] All existing versioning tests pass
- [x] Compiled successfully
- [x] Formatted and linted

🤖 Generated with [Claude Code](https://claude.com/claude-code)