### PR TITLE
fix: Add fuzzer coverage

### DIFF
--- a/barretenberg/cpp/cmake/module.cmake
+++ b/barretenberg/cpp/cmake/module.cmake
@@ -70,6 +70,14 @@ function(barretenberg_module MODULE_NAME)
             )
         endif()
 
+        if(FUZZING)
+            target_compile_options(
+                ${MODULE_NAME}_objects
+                PRIVATE
+                -fsanitize=fuzzer-no-link
+            )
+        endif()
+
         # enable msgpack downloading via dependency (solves race condition)
         add_dependencies(${MODULE_NAME} msgpack-c)
         add_dependencies(${MODULE_NAME}_objects msgpack-c)

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/group/cycle_group.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/group/cycle_group.cpp
@@ -1073,7 +1073,9 @@ cycle_group<Builder> cycle_group<Builder>::batch_mul(const std::vector<cycle_gro
         } else if (!scalar.is_constant() && point.is_constant()) {
             if (point.get_value().is_point_at_infinity()) {
                 // oi mate, why are you creating a circuit that multiplies a known point at infinity?
+#ifndef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
                 info("Warning: Performing batch mul with constant point at infinity!");
+#endif
                 continue;
             }
             if (scalars_are_full_sized &&


### PR DESCRIPTION
Somewhere along the way the "fuzzer-no-link" option got removed, it seems. Putting it back
