### PR TITLE
chore: reduce depth of release-please

### DIFF
--- a/.github/release-please-v2.json
+++ b/.github/release-please-v2.json
@@ -7,6 +7,9 @@
   "pull-request-header": "Pending Aztec Packages v2 release",
   "versioning": "always-bump-patch",
   "include-component-in-tag": false,
+  "release-search-depth": 50,
+  "commit-search-depth": 150,
+  "sequential-calls": true,
   "changelog-sections": [
     { "type": "feat", "section": "Features", "hidden": false },
     { "type": "fix", "section": "Bug Fixes", "hidden": false },


### PR DESCRIPTION
This PR reduces the depth of commit history that release please has to parse in an attempt to make the workflow fail less due to the API rate limits.