### PR TITLE
feat: sensible API to AVM C++ simulation

### DIFF
--- a/barretenberg/cpp/src/barretenberg/api/api_avm.cpp
+++ b/barretenberg/cpp/src/barretenberg/api/api_avm.cpp
@@ -82,8 +82,8 @@ void avm_simulate(const std::filesystem::path& inputs_path)
     // This includes input deserialization as well.
     AVM_TRACK_TIME("command/avm_simulate", {
         avm2::AvmAPI avm;
-        auto inputs = avm2::AvmAPI::FastSimulationInputs::from(read_file(inputs_path));
-        avm.simulate(inputs);
+        auto inputs = avm2::AvmAPI::ProvingInputs::from(read_file(inputs_path));
+        avm.simulate_with_hinted_dbs(inputs);
     });
 
     print_avm_stats();

--- a/barretenberg/cpp/src/barretenberg/vm2/avm_api.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/avm_api.cpp
@@ -87,18 +87,20 @@ bool AvmAPI::verify(const AvmProof& proof, const PublicInputs& pi, const AvmVeri
     return AVM_TRACK_TIME_V("verifing/all", proving_helper.verify(proof, pi, vk_data));
 }
 
-void AvmAPI::simulate(const FastSimulationInputs& inputs)
-{
-    info("Simulating...");
-    AvmSimulationHelper simulation_helper;
-    AVM_TRACK_TIME("simulation/all", simulation_helper.simulate_fast(inputs.hints, inputs.wsRevision));
-}
-
 void AvmAPI::simulate(const FastSimulationInputs& inputs, simulation::ContractDBInterface& contract_db)
 {
     info("Simulating...");
     AvmSimulationHelper simulation_helper;
-    AVM_TRACK_TIME("simulation/all", simulation_helper.simulate_fast(inputs.hints, inputs.wsRevision, contract_db));
+    AVM_TRACK_TIME("simulation/all",
+                   simulation_helper.simulate_fast_with_existing_ws(
+                       contract_db, inputs.wsRevision, inputs.tx, inputs.globalVariables, inputs.protocolContracts));
+}
+
+void AvmAPI::simulate_with_hinted_dbs(const ProvingInputs& inputs)
+{
+    info("Simulating...");
+    AvmSimulationHelper simulation_helper;
+    AVM_TRACK_TIME("simulation/all", simulation_helper.simulate_fast_with_hinted_dbs(inputs.hints));
 }
 
 } // namespace bb::avm2

--- a/barretenberg/cpp/src/barretenberg/vm2/avm_api.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/avm_api.hpp
@@ -23,8 +23,9 @@ class AvmAPI {
     bool check_circuit(const ProvingInputs& inputs);
     bool verify(const AvmProof& proof, const PublicInputs& pi, const AvmVerificationKey& vk_data);
 
-    void simulate(const FastSimulationInputs& inputs);
     void simulate(const FastSimulationInputs& inputs, simulation::ContractDBInterface& contract_db);
+
+    void simulate_with_hinted_dbs(const ProvingInputs& inputs);
 };
 
 } // namespace bb::avm2

--- a/barretenberg/cpp/src/barretenberg/vm2/avm_api_sim.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/avm_api_sim.cpp
@@ -1,0 +1,26 @@
+#include "barretenberg/vm2/avm_api.hpp"
+
+#include "barretenberg/vm2/simulation_helper.hpp"
+#include "barretenberg/vm2/tooling/stats.hpp"
+
+namespace bb::avm2 {
+
+using namespace bb::avm2::simulation;
+
+void AvmAPI::simulate(const FastSimulationInputs& inputs, simulation::ContractDBInterface& contract_db)
+{
+    info("Simulating...");
+    AvmSimulationHelper simulation_helper;
+    AVM_TRACK_TIME("simulation/all",
+                   simulation_helper.simulate_fast_with_existing_ws(
+                       contract_db, inputs.wsRevision, inputs.tx, inputs.globalVariables, inputs.protocolContracts));
+}
+
+void AvmAPI::simulate_with_hinted_dbs(const ProvingInputs& inputs)
+{
+    info("Simulating...");
+    AvmSimulationHelper simulation_helper;
+    AVM_TRACK_TIME("simulation/all", simulation_helper.simulate_fast_with_hinted_dbs(inputs.hints));
+}
+
+} // namespace bb::avm2

--- a/barretenberg/cpp/src/barretenberg/vm2/common/avm_inputs.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/common/avm_inputs.hpp
@@ -390,15 +390,15 @@ struct AvmProvingInputs {
 };
 
 struct AvmFastSimulationInputs {
-    // TODO(dbanks12): remove public inputs and hints once fast simulation is standalone
-    PublicInputs publicInputs;
-    ExecutionHints hints;
     world_state::WorldStateRevision wsRevision;
+    Tx tx;
+    GlobalVariables globalVariables;
+    ProtocolContracts protocolContracts;
 
     static AvmFastSimulationInputs from(const std::vector<uint8_t>& data);
     bool operator==(const AvmFastSimulationInputs& other) const = default;
 
-    MSGPACK_FIELDS(publicInputs, hints, wsRevision);
+    MSGPACK_FIELDS(wsRevision, tx, globalVariables, protocolContracts);
 };
 
 } // namespace bb::avm2

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation_helper.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation_helper.cpp
@@ -295,16 +295,11 @@ EventsContainer AvmSimulationHelper::simulate_for_witgen(const ExecutionHints& h
     };
 }
 
-void AvmSimulationHelper::simulate_fast(const ExecutionHints& hints,
-                                        const world_state::WorldStateRevision& world_state_revision)
-{
-    HintedRawContractDB raw_contract_db(hints);
-    simulate_fast(hints, world_state_revision, raw_contract_db);
-}
-
-void AvmSimulationHelper::simulate_fast(const ExecutionHints& hints,
-                                        [[maybe_unused]] const world_state::WorldStateRevision& world_state_revision,
-                                        simulation::ContractDBInterface& raw_contract_db)
+void AvmSimulationHelper::simulate_fast(simulation::ContractDBInterface& raw_contract_db,
+                                        simulation::LowLevelMerkleDBInterface& raw_merkle_db,
+                                        const Tx& tx,
+                                        const GlobalVariables& global_variables,
+                                        const ProtocolContracts& protocol_contracts)
 {
     BB_BENCH_NAME("AvmSimulationHelper::simulate_fast");
 
@@ -350,17 +345,10 @@ void AvmSimulationHelper::simulate_fast(const ExecutionHints& hints,
 
     Ecc ecc(execution_id_manager, greater_than, to_radix, ecc_add_emitter, scalar_mul_emitter, ecc_add_memory_emitter);
 
-    // Connect to world state given the revision, this relies on the world state being already initialized.
-    std::optional<PureRawMerkleDB> maybe_raw_merkle_db = PureRawMerkleDB::connect(world_state_revision);
-    if (!maybe_raw_merkle_db.has_value()) {
-        throw std::runtime_error("AvmSimulationHelper::simulate_fast, failed to connect to world state");
-    }
-    PureRawMerkleDB raw_merkle_db = maybe_raw_merkle_db.value();
-
     PureContractDB contract_db(raw_contract_db);
 
     PureMerkleDB merkle_db(
-        hints.tx.nonRevertibleAccumulatedData.nullifiers[0], raw_merkle_db, written_public_data_slots_tree_check);
+        tx.nonRevertibleAccumulatedData.nullifiers[0], raw_merkle_db, written_public_data_slots_tree_check);
     merkle_db.add_checkpoint_listener(emit_unencrypted_log_component);
 
     NoopUpdateCheck update_check;
@@ -368,7 +356,7 @@ void AvmSimulationHelper::simulate_fast(const ExecutionHints& hints,
     InstructionInfoDB instruction_info_db;
 
     ContractInstanceManager contract_instance_manager(
-        contract_db, merkle_db, update_check, field_gt, hints.protocolContracts, contract_instance_retrieval_emitter);
+        contract_db, merkle_db, update_check, field_gt, protocol_contracts, contract_instance_retrieval_emitter);
 
     PureTxBytecodeManager bytecode_manager(contract_db, contract_instance_manager);
     PureExecutionComponentsProvider execution_components(greater_than, instruction_info_db);
@@ -383,7 +371,7 @@ void AvmSimulationHelper::simulate_fast(const ExecutionHints& hints,
                                      merkle_db,
                                      written_public_data_slots_tree_check,
                                      retrieved_bytecodes_tree_check,
-                                     hints.globalVariables);
+                                     global_variables);
     DataCopy data_copy(execution_id_manager, greater_than, data_copy_emitter);
 
     // Create GetContractInstance opcode component
@@ -426,7 +414,29 @@ void AvmSimulationHelper::simulate_fast(const ExecutionHints& hints,
                              poseidon2,
                              tx_event_emitter);
 
-    tx_execution.simulate(hints.tx);
+    tx_execution.simulate(tx);
+}
+
+void AvmSimulationHelper::simulate_fast_with_hinted_dbs(const ExecutionHints& hints)
+{
+    HintedRawContractDB raw_contract_db(hints);
+    HintedRawMerkleDB raw_merkle_db(hints);
+    simulate_fast(raw_contract_db, raw_merkle_db, hints.tx, hints.globalVariables, hints.protocolContracts);
+}
+
+void AvmSimulationHelper::simulate_fast_with_existing_ws(simulation::ContractDBInterface& raw_contract_db,
+                                                         const world_state::WorldStateRevision& world_state_revision,
+                                                         const Tx& tx,
+                                                         const GlobalVariables& global_variables,
+                                                         const ProtocolContracts& protocol_contracts)
+{
+    // Connect to world state given the revision, this relies on the world state being already initialized.
+    std::optional<PureRawMerkleDB> maybe_raw_merkle_db = PureRawMerkleDB::connect(world_state_revision);
+    if (!maybe_raw_merkle_db.has_value()) {
+        throw std::runtime_error("AvmSimulationHelper::simulate_fast, failed to connect to world state");
+    }
+    PureRawMerkleDB raw_merkle_db = maybe_raw_merkle_db.value();
+    simulate_fast(raw_contract_db, raw_merkle_db, tx, global_variables, protocol_contracts);
 }
 
 } // namespace bb::avm2

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation_helper.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation_helper.hpp
@@ -17,13 +17,22 @@ class AvmSimulationHelper {
                                                     std::vector<PublicDataWrite> public_data_writes);
 
     // Fast simulation without event collection.
-    // FIXME(fcarreiro): This should eventually only take the Tx, Globals and not much more.
-    void simulate_fast(const ExecutionHints& hints, const world_state::WorldStateRevision& ws_revision);
-    void simulate_fast(const ExecutionHints& hints,
-                       const world_state::WorldStateRevision& ws_revision,
-                       simulation::ContractDBInterface& raw_contract_db);
 
-    void prepare_ws();
+    void simulate_fast_with_hinted_dbs(const ExecutionHints& hints);
+
+    void simulate_fast_with_existing_ws(simulation::ContractDBInterface& raw_contract_db,
+                                        const world_state::WorldStateRevision& world_state_revision,
+                                        const Tx& tx,
+                                        const GlobalVariables& global_variables,
+                                        const ProtocolContracts& protocol_contracts);
+
+  private:
+    // helper called by each of the above simulate_fast* functions
+    void simulate_fast(simulation::ContractDBInterface& raw_contract_db,
+                       simulation::LowLevelMerkleDBInterface& raw_merkle_db,
+                       const Tx& tx,
+                       const GlobalVariables& global_variables,
+                       const ProtocolContracts& protocol_contracts);
 };
 
 } // namespace bb::avm2

--- a/barretenberg/cpp/src/barretenberg/vm2_sim/CMakeLists.txt
+++ b/barretenberg/cpp/src/barretenberg/vm2_sim/CMakeLists.txt
@@ -6,12 +6,13 @@
 file(GLOB_RECURSE SOURCE_FILES
   ../vm2/simulation/*.cpp
   ../vm2/common/*.cpp
+  ../vm2/tooling/*.cpp
 )
 
 # Add top-level vm2 files needed for simulation
 list(APPEND SOURCE_FILES
   ../vm2/simulation_helper.cpp
-  ../vm2/avm_api.cpp
+  ../vm2/avm_api_sim.cpp
 )
 
 # Exclude test, bench, and fuzzer files
@@ -21,6 +22,7 @@ list(FILTER SOURCE_FILES EXCLUDE REGEX ".*\\.(test|bench|fuzzer)\\.cpp$")
 file(GLOB_RECURSE HEADER_FILES
   ../vm2/simulation/*.hpp
   ../vm2/common/*.hpp
+  ../vm2/tooling/*.hpp
   ../vm2/simulation_helper.hpp
   ../vm2/avm_api.hpp
 )

--- a/yarn-project/stdlib/src/avm/avm.ts
+++ b/yarn-project/stdlib/src/avm/avm.ts
@@ -643,27 +643,33 @@ export class AvmCircuitInputs {
 
 export class AvmFastSimulationInputs {
   constructor(
-    public readonly hints: AvmExecutionHints,
-    public publicInputs: AvmCircuitPublicInputs,
-    public wsRevision: WorldStateRevision,
+    public readonly wsRevision: WorldStateRevision,
+    public tx: AvmTxHint,
+    public globalVariables: GlobalVariables,
+    public protocolContracts: ProtocolContracts,
   ) {}
 
   static empty() {
     return new AvmFastSimulationInputs(
-      AvmExecutionHints.empty(),
-      AvmCircuitPublicInputs.empty(),
       WorldStateRevision.empty(),
+      AvmTxHint.empty(),
+      GlobalVariables.empty(),
+      ProtocolContracts.empty(),
     );
   }
 
   static get schema() {
     return z
       .object({
-        hints: AvmExecutionHints.schema,
-        publicInputs: AvmCircuitPublicInputs.schema,
         wsRevision: WorldStateRevision.schema,
+        tx: AvmTxHint.schema,
+        globalVariables: GlobalVariables.schema,
+        protocolContracts: ProtocolContracts.schema,
       })
-      .transform(({ hints, publicInputs, wsRevision }) => new AvmFastSimulationInputs(hints, publicInputs, wsRevision));
+      .transform(
+        ({ wsRevision, tx, globalVariables, protocolContracts }) =>
+          new AvmFastSimulationInputs(wsRevision, tx, globalVariables, protocolContracts),
+      );
   }
 
   public serializeWithMessagePack(): Buffer {


### PR DESCRIPTION
This PR may be a throw-away PR. It was a stepping-stone to getting simulate-fast triggered from TS->CPP before NAPI.