### PR TITLE
fix(bb): ensure clean asan by not overloading operator new

### DIFF
--- a/barretenberg/cpp/src/barretenberg/common/tracy_mem/CMakeLists.txt
+++ b/barretenberg/cpp/src/barretenberg/common/tracy_mem/CMakeLists.txt
@@ -1,2 +1,1 @@
 add_library(tracy_mem OBJECT overload_operator_new.cpp)
-target_compile_definitions(tracy_mem PRIVATE TRACY_MEMORY)

--- a/barretenberg/cpp/src/barretenberg/common/tracy_mem/overload_operator_new.cpp
+++ b/barretenberg/cpp/src/barretenberg/common/tracy_mem/overload_operator_new.cpp
@@ -1,6 +1,7 @@
 #include "../mem.hpp"
 
 #ifdef TRACY_MEMORY
+
 void* operator new(std::size_t count)
 {
     // NOLINTBEGIN(cppcoreguidelines-no-malloc)
@@ -54,11 +55,39 @@ void operator delete[](void* ptr, std::size_t) noexcept
 // C++17 aligned new
 void* operator new(std::size_t size, std::align_val_t alignment)
 {
-    return aligned_alloc(static_cast<std::size_t>(alignment), size);
+    void* ptr = aligned_alloc(static_cast<std::size_t>(alignment), size);
+    TRACY_ALLOC(ptr, size);
+    return ptr;
+}
+
+void* operator new[](std::size_t size, std::align_val_t alignment)
+{
+    void* ptr = aligned_alloc(static_cast<std::size_t>(alignment), size);
+    TRACY_ALLOC(ptr, size);
+    return ptr;
 }
 
 void operator delete(void* ptr, std::align_val_t) noexcept
 {
+    TRACY_FREE(ptr);
+    aligned_free(ptr);
+}
+
+void operator delete(void* ptr, std::size_t, std::align_val_t) noexcept
+{
+    TRACY_FREE(ptr);
+    aligned_free(ptr);
+}
+
+void operator delete[](void* ptr, std::align_val_t) noexcept
+{
+    TRACY_FREE(ptr);
+    aligned_free(ptr);
+}
+
+void operator delete[](void* ptr, std::size_t, std::align_val_t) noexcept
+{
+    TRACY_FREE(ptr);
     aligned_free(ptr);
 }
 


### PR DESCRIPTION
A change that I should have sent sooner. Also fixes this in tracy builds.