### PR TITLE
feat: Skip blob downloading if empty

### DIFF
--- a/yarn-project/archiver/src/archiver/archiver.test.ts
+++ b/yarn-project/archiver/src/archiver/archiver.test.ts
@@ -1,4 +1,4 @@
-import { Blob } from '@aztec/blob-lib';
+import { Blob, EMPTY_BLOB_VERSIONED_HASH } from '@aztec/blob-lib';
 import type { BlobSinkClientInterface } from '@aztec/blob-sink/client';
 import { BlobWithIndex } from '@aztec/blob-sink/types';
 import { GENESIS_ARCHIVE_ROOT } from '@aztec/constants';
@@ -16,6 +16,7 @@ import { bufferToHex, withoutHexPrefix } from '@aztec/foundation/string';
 import { openTmpStore } from '@aztec/kv-store/lmdb-v2';
 import { type InboxAbi, RollupAbi } from '@aztec/l1-artifacts';
 import {
+  Body,
   CommitteeAttestation,
   CommitteeAttestationsAndSigners,
   L2Block,
@@ -925,6 +926,71 @@ describe('Archiver', () => {
     // Then the archiver must reprocess the old block to get to the new one
     await retryUntil(async () => (await archiver.getBlockNumber()) === 3, 'resync', 10, 0.1);
   });
+
+  it('handles empty blob hash without downloading blob', async () => {
+    let latestBlockNum = await archiver.getBlockNumber();
+    expect(latestBlockNum).toEqual(0);
+
+    // Create a block with an empty body
+    const emptyBlock = blocks[0];
+    emptyBlock.body = Body.empty();
+
+    const emptyBlobHash = bufferToHex(EMPTY_BLOB_VERSIONED_HASH);
+    const rollupTx = await makeRollupTx(emptyBlock);
+
+    mockL1BlockNumbers(100n);
+
+    mockRollup.read.status.mockResolvedValue([0n, GENESIS_ROOT, 1n, emptyBlock.archive.root.toString(), GENESIS_ROOT]);
+
+    makeL2BlockProposedEvent(70n, 1n, emptyBlock.archive.root.toString(), [emptyBlobHash]);
+
+    // Mock getBlobSidecar to return empty array (simulating blob not downloaded)
+    blobSinkClient.getBlobSidecar.mockResolvedValueOnce([]);
+
+    publicClient.getTransaction.mockResolvedValueOnce(rollupTx);
+
+    await archiver.start(false);
+
+    // Wait until block 1 is processed
+    await waitUntilArchiverBlock(1);
+
+    latestBlockNum = await archiver.getBlockNumber();
+    expect(latestBlockNum).toEqual(1);
+
+    // Verify the block was synced successfully
+    const syncedBlock = await archiver.getBlock(1);
+    expect(syncedBlock).toBeDefined();
+    expect(syncedBlock!.body.txEffects.length).toEqual(0);
+  }, 10_000);
+
+  it('throws error when blob hashes and bodies mismatch (non-empty case)', async () => {
+    let latestBlockNum = await archiver.getBlockNumber();
+    expect(latestBlockNum).toEqual(0);
+
+    const block = blocks[0];
+    const blobHashes = await makeVersionedBlobHashes(block);
+    const rollupTx = await makeRollupTx(block);
+
+    mockL1BlockNumbers(100n);
+
+    mockRollup.read.status.mockResolvedValue([0n, GENESIS_ROOT, 1n, block.archive.root.toString(), GENESIS_ROOT]);
+
+    makeL2BlockProposedEvent(70n, 1n, block.archive.root.toString(), blobHashes);
+
+    // Mock getBlobSidecar to return empty array (missing blobs)
+    blobSinkClient.getBlobSidecar.mockResolvedValueOnce([]);
+
+    publicClient.getTransaction.mockResolvedValueOnce(rollupTx);
+
+    await archiver.start(false);
+
+    // Give it some time to attempt processing
+    await sleep(1000);
+
+    // Should still be at block 0 since the blob fetch failed
+    latestBlockNum = await archiver.getBlockNumber();
+    expect(latestBlockNum).toEqual(0);
+  }, 10_000);
 
   // TODO(palla/reorg): Add a unit test for the archiver handleEpochPrune
   xit('handles an upcoming L2 prune', () => {});

--- a/yarn-project/archiver/src/archiver/data_retrieval.ts
+++ b/yarn-project/archiver/src/archiver/data_retrieval.ts
@@ -1,4 +1,4 @@
-import { Blob, BlobDeserializationError } from '@aztec/blob-lib';
+import { Blob, BlobDeserializationError, EMPTY_BLOB_VERSIONED_HASH } from '@aztec/blob-lib';
 import type { BlobSinkClientInterface } from '@aztec/blob-sink/client';
 import type {
   EpochProofPublicInputArgs,
@@ -14,6 +14,7 @@ import type { EthAddress } from '@aztec/foundation/eth-address';
 import type { ViemSignature } from '@aztec/foundation/eth-signature';
 import { Fr } from '@aztec/foundation/fields';
 import { type Logger, createLogger } from '@aztec/foundation/log';
+import { bufferToHex } from '@aztec/foundation/string';
 import { type InboxAbi, RollupAbi } from '@aztec/l1-artifacts';
 import { Body, CommitteeAttestation, L2Block, PublishedL2Block } from '@aztec/stdlib/block';
 import { Proof } from '@aztec/stdlib/proofs';
@@ -340,25 +341,7 @@ async function getBlockFromRollupTx(
   // TODO(md): why is the proposed block header different to the actual block header?
   // This is likely going to be a footgun
   const header = ProposedBlockHeader.fromViem(decodedArgs.header);
-  const blobBodies = await blobSinkClient.getBlobSidecar(blockHash, blobHashes);
-  if (blobBodies.length === 0) {
-    throw new NoBlobBodiesFoundError(l2BlockNumber);
-  }
-
-  let blockFields: Fr[];
-  try {
-    blockFields = Blob.toEncodedFields(blobBodies.map(b => b.blob));
-  } catch (err: any) {
-    if (err instanceof BlobDeserializationError) {
-      logger.fatal(err.message);
-    } else {
-      logger.fatal('Unable to sync: failed to decode fetched blob, this blob was likely not created by us');
-    }
-    throw err;
-  }
-
-  // The blob source gives us blockFields, and we must construct the body from them:
-  const body = Body.fromBlobFields(blockFields);
+  const body = await getBlockBodyFromBlobs(blobSinkClient, blockHash!, blobHashes, l2BlockNumber, logger);
 
   const archiveRoot = new Fr(Buffer.from(hexToBytes(decodedArgs.archive)));
 
@@ -372,6 +355,46 @@ async function getBlockFromRollupTx(
     body,
     attestations,
   };
+}
+
+async function getBlockBodyFromBlobs(
+  blobSinkClient: BlobSinkClientInterface,
+  blockHash: string,
+  blobHashes: Buffer<ArrayBufferLike>[],
+  l2BlockNumber: number,
+  logger: Logger,
+) {
+  const blobBodies = await blobSinkClient.getBlobSidecar(blockHash, blobHashes);
+  logger.trace(`Fetched ${blobBodies.length} blob bodies for L2 block ${l2BlockNumber}`, {
+    blobHashes: blobHashes.map(bufferToHex),
+    l2BlockNumber,
+  });
+
+  if (blobBodies.length !== blobHashes.length) {
+    // If there is exactly one blob hash and it is the empty blob hash, we are fine with not downloading it
+    // and just defaulting to an empty block body.
+    if (blobHashes.length === 1 && blobBodies.length === 0 && blobHashes[0].equals(EMPTY_BLOB_VERSIONED_HASH)) {
+      logger.verbose(`Ignoring error fetching blob body for block ${l2BlockNumber} as it is empty`);
+      return Body.empty();
+    } else {
+      throw new NoBlobBodiesFoundError(l2BlockNumber, blobBodies.length, blobHashes.length);
+    }
+  }
+
+  let blockFields: Fr[];
+  try {
+    blockFields = Blob.toEncodedFields(blobBodies.map(b => b.blob));
+  } catch (err: any) {
+    if (err instanceof BlobDeserializationError) {
+      logger.error(err.message);
+    } else {
+      logger.error('Unable to sync: failed to decode fetched blob, this blob was likely not created by us');
+    }
+    throw err;
+  }
+
+  // The blob source gives us blockFields, and we must construct the body from them:
+  return Body.fromBlobFields(blockFields);
 }
 
 /** Given an L1 to L2 message, retrieves its corresponding event from the Inbox within a specific block range. */

--- a/yarn-project/archiver/src/archiver/errors.ts
+++ b/yarn-project/archiver/src/archiver/errors.ts
@@ -1,6 +1,6 @@
 export class NoBlobBodiesFoundError extends Error {
-  constructor(l2BlockNum: number) {
-    super(`No blob bodies found for block ${l2BlockNum}`);
+  constructor(l2BlockNum: number, found: number, expected: number) {
+    super(`No blob bodies found for block ${l2BlockNum} (expected ${expected} but found ${found})`);
   }
 }
 

--- a/yarn-project/blob-lib/src/blob.test.ts
+++ b/yarn-project/blob-lib/src/blob.test.ts
@@ -1,10 +1,11 @@
 import { poseidon2Hash } from '@aztec/foundation/crypto';
 import { Fr } from '@aztec/foundation/fields';
+import { bufferToHex } from '@aztec/foundation/string';
 
 import cKzg from 'c-kzg';
 import type { Blob as BlobBuffer, Bytes48, KZGProof } from 'c-kzg';
 
-import { Blob } from './index.js';
+import { Blob, EMPTY_BLOB_VERSIONED_HASH } from './index.js';
 import { makeEncodedBlob } from './testing.js';
 
 // Importing directly from 'c-kzg' does not work:
@@ -140,5 +141,11 @@ describe('blob', () => {
     const blobJson = blob.toJson(1);
     const deserialisedBlob = await Blob.fromJson(blobJson);
     expect(blob.fieldsHash.equals(deserialisedBlob.fieldsHash)).toBe(true);
+  });
+
+  it('computes correct eth versioned blob hash for an empty blob', async () => {
+    const blob = await Blob.fromFields([]);
+    const versionedHash = blob.getEthVersionedBlobHash();
+    expect(bufferToHex(versionedHash)).toBe(bufferToHex(EMPTY_BLOB_VERSIONED_HASH));
   });
 });

--- a/yarn-project/blob-lib/src/blob.ts
+++ b/yarn-project/blob-lib/src/blob.ts
@@ -15,6 +15,12 @@ const { BYTES_PER_BLOB, FIELD_ELEMENTS_PER_BLOB, blobToKzgCommitment, computeKzg
 // The prefix to the EVM blobHash, defined here: https://eips.ethereum.org/EIPS/eip-4844#specification
 export const VERSIONED_HASH_VERSION_KZG = 0x01;
 
+/** Versioned blob hash for an empty blob */
+export const EMPTY_BLOB_VERSIONED_HASH = Buffer.from(
+  `010657f37554c781402a22917dee2f75def7ab966d7b770905398eba3c444014`,
+  'hex',
+);
+
 /**
  * A class to create, manage, and prove EVM blobs.
  */

--- a/yarn-project/end-to-end/src/e2e_block_building.test.ts
+++ b/yarn-project/end-to-end/src/e2e_block_building.test.ts
@@ -679,6 +679,56 @@ describe('e2e_block_building', () => {
     });
   });
 
+  describe('empty blocks', () => {
+    let wallet: Wallet;
+
+    afterEach(async () => {
+      if (teardown) {
+        await teardown();
+      }
+    });
+
+    it('syncs blocks with no access to blobs if they are empty', async () => {
+      const context = await setup(1, {
+        minTxsPerBlock: 0,
+        skipProtocolContracts: true,
+        numberOfInitialFundedAccounts: 1,
+        ethereumSlotDuration: 4,
+        aztecSlotDuration: 8,
+        aztecProofSubmissionEpochs: 32,
+        automineL1Setup: true,
+      });
+
+      ({
+        teardown,
+        logger,
+        aztecNode,
+        wallet,
+        accounts: [ownerAddress],
+      } = context);
+
+      const testContract = await TestContract.deploy(wallet).send({ from: ownerAddress }).deployed();
+      const deploymentBlock = await aztecNode.getBlockNumber();
+      logger.warn(`Test contract deployed at ${testContract.address} at block ${deploymentBlock}`);
+
+      // Mock the blob sink to prevent blob storage
+      logger.warn(`Disabling blob storage`);
+      context.blobSink!.setDisableBlobStorage(true);
+
+      // Produce an empty block (no txs) - should sync fine without blobs
+      logger.warn('Producing empty block without blob publishing');
+      await retryUntil(async () => (await aztecNode.getBlockNumber()) > deploymentBlock + 1, 'wait-empty-block', 24, 1);
+      const emptyBlockNumber = await aztecNode.getBlockNumber();
+      logger.warn(`Empty block ${emptyBlockNumber} synced`);
+
+      // Now produce a block with txs (blobs still blocked)
+      logger.warn('Producing block with txs but no blob publishing');
+      await expect(() =>
+        testContract.methods.emit_nullifier(Fr.random()).send({ from: ownerAddress }).wait({ timeout: 12 }),
+      ).rejects.toThrow(/time/i);
+    });
+  });
+
   const interceptTxProcessorSimulate = (
     node: AztecNodeService,
     stub: (tx: Tx, originalSimulate: (tx: Tx) => Promise<PublicTxResult>) => Promise<PublicTxResult>,


### PR DESCRIPTION
Implements The Greek Defense for Ignition during Fusaka.

Fixes A-168

Note that this cannot be forward ported to `next` since empty blocks are no longer mapped to empty blobs, they now include an "end of block" marker: 

https://github.com/AztecProtocol/aztec-packages/blob/ad9938b8083e0f7fa70baa4a4e950ed582d8aa87/yarn-project/stdlib/src/block/body.ts#L15-L19