### PR TITLE
fix: Check slash round lifetime when looking back executable rounds (#17652)

### DIFF
--- a/.test_patterns.yml
+++ b/.test_patterns.yml
@@ -232,6 +232,10 @@ tests:
       - *palla
 
   # yarn-project tests
+  - regex: "src/e2e_p2p/valid_epoch_pruned_slash.test.ts"
+    error_regex: "Timeout waiting for proposal execution"
+    owners:
+      - *palla
   - regex: "p2p/src/services/discv5/discv5_service.test.ts"
     error_regex: "Timeout: Failed to connect to"
     owners:

--- a/yarn-project/slasher/src/tally_slasher_client.test.ts
+++ b/yarn-project/slasher/src/tally_slasher_client.test.ts
@@ -384,6 +384,52 @@ describe('TallySlasherClient', () => {
 
         expect(actions).toHaveLength(0);
       });
+
+      it('should return earliest execute when multiple are available', async () => {
+        const currentRound = 5n;
+        const currentSlot = currentRound * BigInt(roundSize);
+
+        tallySlasherClient.updateConfig({ slashExecuteRoundsLookBack: 5 });
+
+        tallySlashingProposer.getRound
+          .mockResolvedValueOnce({ ...executedRoundData }) // round 0
+          .mockResolvedValueOnce({ ...executableRoundData }); // round 1
+
+        const actions = await tallySlasherClient.getProposerActions(currentSlot);
+
+        expect(actions).toHaveLength(1);
+        expectActionExecuteSlash(actions[0], 1n);
+        expect(tallySlashingProposer.getRound).toHaveBeenCalledTimes(2);
+        expect(tallySlashingProposer.getRound).toHaveBeenCalledWith(0n);
+        expect(tallySlashingProposer.getRound).toHaveBeenCalledWith(1n);
+      });
+
+      it('should respect lifetimeInRounds when computing oldestExecutableRound', async () => {
+        // Use a large lookBack to test that lifetimeInRounds constrains it
+        tallySlasherClient.updateConfig({ slashExecuteRoundsLookBack: 20 });
+
+        const currentRound = 15n;
+        const currentSlot = currentRound * BigInt(roundSize);
+        const slashingLifetimeInRounds = BigInt(settings.slashingLifetimeInRounds); // 10
+
+        // The oldest executable round should be currentRound - lifetimeInRounds = 15 - 10 = 5
+        // NOT currentRound - executionDelay - 1 - lookBack = 15 - 2 - 1 - 20 = -8 (clamped to 0)
+        const expectedOldestRound = currentRound - slashingLifetimeInRounds; // 5
+
+        // Mock rounds 5-12 as executable (executableRound = currentRound - executionDelay - 1 = 15 - 2 - 1 = 12)
+        tallySlashingProposer.getRound.mockImplementation((round: bigint) =>
+          Promise.resolve(round >= expectedOldestRound && round <= 12n ? executableRoundData : emptyRoundData),
+        );
+
+        const actions = await tallySlasherClient.getProposerActions(currentSlot);
+
+        // Should execute the oldest round (5), not try to execute rounds before that
+        expect(actions).toHaveLength(1);
+        expectActionExecuteSlash(actions[0], expectedOldestRound);
+
+        // Verify we didn't try to check rounds older than the lifetime allows
+        expect(tallySlashingProposer.getRound).not.toHaveBeenCalledWith(expectedOldestRound - 1n);
+      });
     });
 
     describe('multiple', () => {


### PR DESCRIPTION
Backport of #17652

In #17245 we changed the slasher client to check for older rounds pending execution, with a config variable that indicates how far to look back.

However, the lifetime in rounds in staging ended up being smaller than the lookback, so we were picking rounds no longer valid.

This PR checks that we do not look that far back.