### PR TITLE
chore: Use npm package resolution to load viem fork

### DIFF
--- a/yarn-project/archiver/package.json
+++ b/yarn-project/archiver/package.json
@@ -78,11 +78,11 @@
     "@aztec/protocol-contracts": "workspace:^",
     "@aztec/stdlib": "workspace:^",
     "@aztec/telemetry-client": "workspace:^",
-    "@spalladino/viem": "2.38.2-eip7594.0",
     "lodash.groupby": "^4.6.0",
     "lodash.omit": "^4.5.0",
     "tsc-watch": "^6.0.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.5.0",
+    "viem": "npm:@spalladino/viem@2.38.2-eip7594.0"
   },
   "devDependencies": {
     "@jest/globals": "^30.0.0",

--- a/yarn-project/archiver/src/archiver/archiver.test.ts
+++ b/yarn-project/archiver/src/archiver/archiver.test.ts
@@ -29,16 +29,9 @@ import { makeAndSignCommitteeAttestationsAndSigners, makeBlockAttestationFromBlo
 import { getTelemetryClient } from '@aztec/telemetry-client';
 
 import { jest } from '@jest/globals';
-import {
-  type FormattedBlock,
-  type Log,
-  type Transaction,
-  encodeFunctionData,
-  multicall3Abi,
-  toHex,
-} from '@spalladino/viem';
 import assert from 'assert';
 import { type MockProxy, mock } from 'jest-mock-extended';
+import { type FormattedBlock, type Log, type Transaction, encodeFunctionData, multicall3Abi, toHex } from 'viem';
 
 import { Archiver } from './archiver.js';
 import type { ArchiverDataStore } from './archiver_store.js';

--- a/yarn-project/archiver/src/archiver/archiver.ts
+++ b/yarn-project/archiver/src/archiver/archiver.ts
@@ -72,9 +72,9 @@ import {
   trackSpan,
 } from '@aztec/telemetry-client';
 
-import { type GetContractReturnType, createPublicClient, fallback, http } from '@spalladino/viem';
 import { EventEmitter } from 'events';
 import groupBy from 'lodash.groupby';
+import { type GetContractReturnType, createPublicClient, fallback, http } from 'viem';
 
 import type { ArchiverDataStore, ArchiverL1SynchPoint } from './archiver_store.js';
 import type { ArchiverConfig } from './config.js';

--- a/yarn-project/archiver/src/archiver/data_retrieval.ts
+++ b/yarn-project/archiver/src/archiver/data_retrieval.ts
@@ -29,7 +29,7 @@ import {
   getAbiItem,
   hexToBytes,
   multicall3Abi,
-} from '@spalladino/viem';
+} from 'viem';
 
 import { NoBlobBodiesFoundError } from './errors.js';
 import type { DataRetrieval } from './structs/data_retrieval.js';

--- a/yarn-project/aztec-faucet/package.json
+++ b/yarn-project/aztec-faucet/package.json
@@ -67,10 +67,10 @@
     "@aztec/foundation": "workspace:^",
     "@aztec/l1-artifacts": "workspace:^",
     "@koa/cors": "^5.0.0",
-    "@spalladino/viem": "2.38.2-eip7594.0",
     "koa": "^2.16.1",
     "koa-bodyparser": "^4.4.1",
     "koa-router": "^13.1.1",
+    "viem": "npm:@spalladino/viem@2.38.2-eip7594.0",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/yarn-project/aztec-faucet/src/faucet.ts
+++ b/yarn-project/aztec-faucet/src/faucet.ts
@@ -12,8 +12,8 @@ import {
   type WalletClient,
   getContract,
   parseEther,
-} from '@spalladino/viem';
-import { mnemonicToAccount } from '@spalladino/viem/accounts';
+} from 'viem';
+import { mnemonicToAccount } from 'viem/accounts';
 
 import type { FaucetConfig, L1AssetConfig } from './config.js';
 

--- a/yarn-project/aztec-node/package.json
+++ b/yarn-project/aztec-node/package.json
@@ -89,10 +89,10 @@
     "@aztec/telemetry-client": "workspace:^",
     "@aztec/validator-client": "workspace:^",
     "@aztec/world-state": "workspace:^",
-    "@spalladino/viem": "2.38.2-eip7594.0",
     "koa": "^2.16.1",
     "koa-router": "^13.1.1",
-    "tslib": "^2.4.0"
+    "tslib": "^2.4.0",
+    "viem": "npm:@spalladino/viem@2.38.2-eip7594.0"
   },
   "devDependencies": {
     "@jest/globals": "^30.0.0",

--- a/yarn-project/aztec-node/src/aztec-node/config.test.ts
+++ b/yarn-project/aztec-node/src/aztec-node/config.test.ts
@@ -5,8 +5,8 @@ import type { SequencerClientConfig, TxSenderConfig } from '@aztec/sequencer-cli
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import type { ValidatorClientConfig } from '@aztec/validator-client/config';
 
-import type { Hex } from '@spalladino/viem';
-import { generatePrivateKey, privateKeyToAddress } from '@spalladino/viem/accounts';
+import type { Hex } from 'viem';
+import { generatePrivateKey, privateKeyToAddress } from 'viem/accounts';
 
 import { createKeyStoreForValidator } from './config.js';
 

--- a/yarn-project/aztec-node/src/aztec-node/config.ts
+++ b/yarn-project/aztec-node/src/aztec-node/config.ts
@@ -29,7 +29,7 @@ import type { SlasherConfig } from '@aztec/stdlib/interfaces/server';
 import { type ValidatorClientConfig, validatorClientConfigMappings } from '@aztec/validator-client/config';
 import { type WorldStateConfig, worldStateConfigMappings } from '@aztec/world-state/config';
 
-import { privateKeyToAddress } from '@spalladino/viem/accounts';
+import { privateKeyToAddress } from 'viem/accounts';
 
 import { type SentinelConfig, sentinelConfigMappings } from '../sentinel/config.js';
 

--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -115,7 +115,7 @@ import {
 } from '@aztec/validator-client';
 import { createWorldStateSynchronizer } from '@aztec/world-state';
 
-import { createPublicClient, fallback, http } from '@spalladino/viem';
+import { createPublicClient, fallback, http } from 'viem';
 
 import { createSentinel } from '../sentinel/factory.js';
 import { Sentinel } from '../sentinel/sentinel.js';

--- a/yarn-project/aztec.js/package.json
+++ b/yarn-project/aztec.js/package.json
@@ -88,9 +88,9 @@
     "@aztec/l1-artifacts": "workspace:^",
     "@aztec/protocol-contracts": "workspace:^",
     "@aztec/stdlib": "workspace:^",
-    "@spalladino/viem": "2.38.2-eip7594.0",
     "axios": "^1.12.0",
-    "tslib": "^2.4.0"
+    "tslib": "^2.4.0",
+    "viem": "npm:@spalladino/viem@2.38.2-eip7594.0"
   },
   "devDependencies": {
     "@jest/globals": "^30.0.0",

--- a/yarn-project/aztec.js/src/ethereum/portal_manager.ts
+++ b/yarn-project/aztec.js/src/ethereum/portal_manager.ts
@@ -15,7 +15,7 @@ import { computeL2ToL1MessageHash, computeSecretHash } from '@aztec/stdlib/hash'
 import type { PXE } from '@aztec/stdlib/interfaces/client';
 import { getL2ToL1MessageLeafId } from '@aztec/stdlib/messaging';
 
-import { type Hex, getContract, toFunctionSelector } from '@spalladino/viem';
+import { type Hex, getContract, toFunctionSelector } from 'viem';
 
 import type { Wallet } from '../index.js';
 

--- a/yarn-project/aztec/package.json
+++ b/yarn-project/aztec/package.json
@@ -59,13 +59,13 @@
     "@aztec/telemetry-client": "workspace:^",
     "@aztec/txe": "workspace:^",
     "@aztec/world-state": "workspace:^",
-    "@spalladino/viem": "2.38.2-eip7594.0",
     "@types/chalk": "^2.2.0",
     "abitype": "^0.8.11",
     "chalk": "^5.3.0",
     "commander": "^12.1.0",
     "koa": "^2.16.1",
-    "koa-router": "^13.1.1"
+    "koa-router": "^13.1.1",
+    "viem": "npm:@spalladino/viem@2.38.2-eip7594.0"
   },
   "files": [
     "dest",

--- a/yarn-project/aztec/src/examples/util.ts
+++ b/yarn-project/aztec/src/examples/util.ts
@@ -2,8 +2,8 @@ import { EthAddress } from '@aztec/aztec.js';
 import type { ExtendedViemWalletClient } from '@aztec/ethereum';
 import { jsonStringify } from '@aztec/foundation/json-rpc';
 
-import type { Hex } from '@spalladino/viem';
 import type { Abi, Narrow } from 'abitype';
+import type { Hex } from 'viem';
 
 /**
  * Helper function to deploy ETH contracts.

--- a/yarn-project/aztec/src/sandbox/sandbox.ts
+++ b/yarn-project/aztec/src/sandbox/sandbox.ts
@@ -31,15 +31,9 @@ import {
 } from '@aztec/telemetry-client';
 import { getGenesisValues } from '@aztec/world-state/testing';
 
-import {
-  type HDAccount,
-  type PrivateKeyAccount,
-  createPublicClient,
-  fallback,
-  http as httpViemTransport,
-} from '@spalladino/viem';
-import { mnemonicToAccount, privateKeyToAddress } from '@spalladino/viem/accounts';
-import { foundry } from '@spalladino/viem/chains';
+import { type HDAccount, type PrivateKeyAccount, createPublicClient, fallback, http as httpViemTransport } from 'viem';
+import { mnemonicToAccount, privateKeyToAddress } from 'viem/accounts';
+import { foundry } from 'viem/chains';
 
 import { createAccountLogs } from '../cli/util.js';
 import { DefaultMnemonic } from '../mnemonic.js';

--- a/yarn-project/aztec/src/testing/anvil_test_watcher.ts
+++ b/yarn-project/aztec/src/testing/anvil_test_watcher.ts
@@ -6,7 +6,7 @@ import { RunningPromise } from '@aztec/foundation/running-promise';
 import type { TestDateProvider } from '@aztec/foundation/timer';
 import { RollupAbi } from '@aztec/l1-artifacts/RollupAbi';
 
-import { type GetContractReturnType, getAddress, getContract } from '@spalladino/viem';
+import { type GetContractReturnType, getAddress, getContract } from 'viem';
 
 /**
  * Represents a watcher for a rollup contract.

--- a/yarn-project/bb-prover/package.json
+++ b/yarn-project/bb-prover/package.json
@@ -92,14 +92,14 @@
     "@aztec/noir-test-contracts.js": "workspace:^",
     "@aztec/protocol-contracts": "workspace:^",
     "@jest/globals": "^30.0.0",
-    "@spalladino/viem": "2.38.2-eip7594.0",
     "@types/jest": "^30.0.0",
     "@types/node": "^22.15.17",
     "@types/source-map-support": "^0.5.10",
     "jest": "^30.0.0",
     "jest-mock-extended": "^4.0.0",
     "ts-node": "^10.9.1",
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3",
+    "viem": "npm:@spalladino/viem@2.38.2-eip7594.0"
   },
   "files": [
     "dest",

--- a/yarn-project/blob-sink/package.json
+++ b/yarn-project/blob-sink/package.json
@@ -64,11 +64,11 @@
     "@aztec/kv-store": "workspace:*",
     "@aztec/stdlib": "workspace:^",
     "@aztec/telemetry-client": "workspace:*",
-    "@spalladino/viem": "2.38.2-eip7594.0",
     "express": "^4.21.2",
     "snappy": "^7.2.2",
     "source-map-support": "^0.5.21",
     "tslib": "^2.4.0",
+    "viem": "npm:@spalladino/viem@2.38.2-eip7594.0",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/yarn-project/blob-sink/src/client/http.ts
+++ b/yarn-project/blob-sink/src/client/http.ts
@@ -3,7 +3,7 @@ import { type Logger, createLogger } from '@aztec/foundation/log';
 import { makeBackoff, retry } from '@aztec/foundation/retry';
 import { bufferToHex } from '@aztec/foundation/string';
 
-import { type RpcBlock, createPublicClient, fallback, http } from '@spalladino/viem';
+import { type RpcBlock, createPublicClient, fallback, http } from 'viem';
 
 import { createBlobArchiveClient } from '../archive/factory.js';
 import type { BlobArchiveClient } from '../archive/interface.js';

--- a/yarn-project/blob-sink/src/client/tests.ts
+++ b/yarn-project/blob-sink/src/client/tests.ts
@@ -1,6 +1,6 @@
 import { makeEncodedBlob } from '@aztec/blob-lib/testing';
 
-import type { Hex } from '@spalladino/viem';
+import type { Hex } from 'viem';
 
 import type { BlobSinkClientInterface } from './interface.js';
 

--- a/yarn-project/blob-sink/src/types/api.ts
+++ b/yarn-project/blob-sink/src/types/api.ts
@@ -1,4 +1,4 @@
-import type { Hex } from '@spalladino/viem';
+import type { Hex } from 'viem';
 import { z } from 'zod';
 
 export interface PostBlobSidecarRequest {

--- a/yarn-project/cli/package.json
+++ b/yarn-project/cli/package.json
@@ -83,13 +83,13 @@
     "@aztec/world-state": "workspace:^",
     "@iarna/toml": "^2.2.5",
     "@libp2p/peer-id-factory": "^3.0.4",
-    "@spalladino/viem": "2.38.2-eip7594.0",
     "commander": "^12.1.0",
     "lodash.chunk": "^4.2.0",
     "lodash.groupby": "^4.6.0",
     "semver": "^7.5.4",
     "source-map-support": "^0.5.21",
-    "tslib": "^2.4.0"
+    "tslib": "^2.4.0",
+    "viem": "npm:@spalladino/viem@2.38.2-eip7594.0"
   },
   "devDependencies": {
     "@aztec/accounts": "workspace:^",

--- a/yarn-project/cli/src/cmds/infrastructure/sequencers.ts
+++ b/yarn-project/cli/src/cmds/infrastructure/sequencers.ts
@@ -3,8 +3,8 @@ import { GSEContract, RollupContract, createEthereumChain, getL1ContractsConfigE
 import type { LogFn, Logger } from '@aztec/foundation/log';
 import { RollupAbi, TestERC20Abi } from '@aztec/l1-artifacts';
 
-import { createPublicClient, createWalletClient, fallback, getContract, http } from '@spalladino/viem';
-import { mnemonicToAccount } from '@spalladino/viem/accounts';
+import { createPublicClient, createWalletClient, fallback, getContract, http } from 'viem';
+import { mnemonicToAccount } from 'viem/accounts';
 
 export async function sequencers(opts: {
   command: 'list' | 'add' | 'remove' | 'who-next' | 'flush';

--- a/yarn-project/cli/src/cmds/l1/create_l1_account.ts
+++ b/yarn-project/cli/src/cmds/l1/create_l1_account.ts
@@ -1,6 +1,6 @@
 import type { LogFn } from '@aztec/foundation/log';
 
-import { generatePrivateKey, privateKeyToAccount } from '@spalladino/viem/accounts';
+import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts';
 
 import { prettyPrintJSON } from '../../utils/commands.js';
 

--- a/yarn-project/cli/src/cmds/l1/get_l1_addresses.ts
+++ b/yarn-project/cli/src/cmds/l1/get_l1_addresses.ts
@@ -2,7 +2,7 @@ import { EthAddress } from '@aztec/aztec.js';
 import { RegistryContract, type ViemPublicClient, createEthereumChain } from '@aztec/ethereum';
 import type { LogFn } from '@aztec/foundation/log';
 
-import { createPublicClient, fallback, http } from '@spalladino/viem';
+import { createPublicClient, fallback, http } from 'viem';
 
 export async function getL1Addresses(
   registryAddress: EthAddress,

--- a/yarn-project/cli/src/cmds/l1/get_l1_balance.ts
+++ b/yarn-project/cli/src/cmds/l1/get_l1_balance.ts
@@ -3,7 +3,7 @@ import type { EthAddress } from '@aztec/foundation/eth-address';
 import type { LogFn } from '@aztec/foundation/log';
 import { TestERC20Abi } from '@aztec/l1-artifacts';
 
-import { createPublicClient, fallback, getContract, http } from '@spalladino/viem';
+import { createPublicClient, fallback, getContract, http } from 'viem';
 
 import { prettyPrintJSON } from '../../utils/commands.js';
 

--- a/yarn-project/cli/src/cmds/l1/prover_stats.ts
+++ b/yarn-project/cli/src/cmds/l1/prover_stats.ts
@@ -6,9 +6,9 @@ import { type LogFn, type Logger, createLogger } from '@aztec/foundation/log';
 import { RollupAbi } from '@aztec/l1-artifacts';
 import { createAztecNodeClient } from '@aztec/stdlib/interfaces/client';
 
-import { createPublicClient, fallback, getAbiItem, getAddress, http } from '@spalladino/viem';
 import chunk from 'lodash.chunk';
 import groupBy from 'lodash.groupby';
+import { createPublicClient, fallback, getAbiItem, getAddress, http } from 'viem';
 
 export async function proverStats(opts: {
   l1RpcUrls: string[];

--- a/yarn-project/cli/src/cmds/l1/trigger_seed_snapshot.ts
+++ b/yarn-project/cli/src/cmds/l1/trigger_seed_snapshot.ts
@@ -2,7 +2,7 @@ import { createEthereumChain, createExtendedL1Client } from '@aztec/ethereum';
 import type { LogFn } from '@aztec/foundation/log';
 import { RollupAbi } from '@aztec/l1-artifacts/RollupAbi';
 
-import { getContract } from '@spalladino/viem';
+import { getContract } from 'viem';
 
 import type { RollupCommandArgs } from './update_l1_validators.js';
 

--- a/yarn-project/cli/src/cmds/l1/update_l1_validators.ts
+++ b/yarn-project/cli/src/cmds/l1/update_l1_validators.ts
@@ -14,8 +14,8 @@ import type { LogFn, Logger } from '@aztec/foundation/log';
 import { RollupAbi, StakingAssetHandlerAbi } from '@aztec/l1-artifacts';
 import { ZkPassportProofParams } from '@aztec/stdlib/zkpassport';
 
-import { encodeFunctionData, formatEther, getContract } from '@spalladino/viem';
-import { generatePrivateKey, mnemonicToAccount, privateKeyToAccount } from '@spalladino/viem/accounts';
+import { encodeFunctionData, formatEther, getContract } from 'viem';
+import { generatePrivateKey, mnemonicToAccount, privateKeyToAccount } from 'viem/accounts';
 
 import { addLeadingHex } from '../../utils/aztec.js';
 

--- a/yarn-project/cli/src/utils/aztec.ts
+++ b/yarn-project/cli/src/utils/aztec.ts
@@ -63,7 +63,7 @@ export async function deployAztecContracts(
   debugLogger: Logger,
 ): Promise<DeployL1ContractsReturnType> {
   const { createEthereumChain, deployL1Contracts } = await import('@aztec/ethereum');
-  const { mnemonicToAccount, privateKeyToAccount } = await import('@spalladino/viem/accounts');
+  const { mnemonicToAccount, privateKeyToAccount } = await import('viem/accounts');
 
   const account = !privateKey
     ? mnemonicToAccount(mnemonic!, { addressIndex: mnemonicIndex })
@@ -112,7 +112,7 @@ export async function deployNewRollupContracts(
   logger: Logger,
 ): Promise<{ rollup: RollupContract; slashFactoryAddress: EthAddress }> {
   const { createEthereumChain, deployRollupForUpgrade, createExtendedL1Client } = await import('@aztec/ethereum');
-  const { mnemonicToAccount, privateKeyToAccount } = await import('@spalladino/viem/accounts');
+  const { mnemonicToAccount, privateKeyToAccount } = await import('viem/accounts');
   const { getVKTreeRoot } = await import('@aztec/noir-protocol-circuits-types/vk-tree');
 
   const account = !privateKey

--- a/yarn-project/end-to-end/package.json
+++ b/yarn-project/end-to-end/package.json
@@ -63,7 +63,6 @@
     "@iarna/toml": "^2.2.5",
     "@jest/globals": "^30.0.0",
     "@noble/curves": "=1.0.0",
-    "@spalladino/viem": "2.38.2-eip7594.0",
     "@swc/core": "^1.4.11",
     "@swc/jest": "^0.2.36",
     "@types/fs-extra": "^11.0.2",
@@ -97,6 +96,7 @@
     "tslib": "^2.4.0",
     "typescript": "^5.3.3",
     "util": "^0.12.5",
+    "viem": "npm:@spalladino/viem@2.38.2-eip7594.0",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/yarn-project/end-to-end/src/composed/e2e_token_bridge_tutorial_test.test.ts
+++ b/yarn-project/end-to-end/src/composed/e2e_token_bridge_tutorial_test.test.ts
@@ -22,7 +22,7 @@ import {
 import { TokenContract } from '@aztec/noir-contracts.js/Token';
 import { TokenBridgeContract } from '@aztec/noir-contracts.js/TokenBridge';
 
-import { getContract } from '@spalladino/viem';
+import { getContract } from 'viem';
 
 // docs:end:imports
 // docs:start:utils

--- a/yarn-project/end-to-end/src/composed/integration_proof_verification.test.ts
+++ b/yarn-project/end-to-end/src/composed/integration_proof_verification.test.ts
@@ -7,11 +7,11 @@ import { HonkVerifierAbi, HonkVerifierBytecode, IVerifierAbi } from '@aztec/l1-a
 import { Proof } from '@aztec/stdlib/proofs';
 import { RootRollupPublicInputs } from '@aztec/stdlib/rollup';
 
-import { type GetContractReturnType, type Hex, getContract } from '@spalladino/viem';
-import { mnemonicToAccount } from '@spalladino/viem/accounts';
 import type { Anvil } from '@viem/anvil';
 import { readFile } from 'fs/promises';
 import { join } from 'path';
+import { type GetContractReturnType, type Hex, getContract } from 'viem';
+import { mnemonicToAccount } from 'viem/accounts';
 
 import { MNEMONIC } from '../fixtures/fixtures.js';
 import { getACVMConfig } from '../fixtures/get_acvm_config.js';

--- a/yarn-project/end-to-end/src/composed/web3signer/e2e_multi_validator_node_key_store.test.ts
+++ b/yarn-project/end-to-end/src/composed/web3signer/e2e_multi_validator_node_key_store.test.ts
@@ -25,10 +25,10 @@ import type { ProposedBlockHeader, StateReference, Tx } from '@aztec/stdlib/tx';
 import { NodeKeystoreAdapter, ValidatorClient } from '@aztec/validator-client';
 
 import { jest } from '@jest/globals';
-import { privateKeyToAccount } from '@spalladino/viem/accounts';
 import { mkdtemp, rmdir } from 'fs/promises';
 import { tmpdir } from 'os';
 import { join } from 'path';
+import { privateKeyToAccount } from 'viem/accounts';
 
 import {
   addressForPrivateKey,

--- a/yarn-project/end-to-end/src/composed/web3signer/integration_remote_signer.test.ts
+++ b/yarn-project/end-to-end/src/composed/web3signer/integration_remote_signer.test.ts
@@ -3,8 +3,8 @@ import { Buffer32 } from '@aztec/foundation/buffer';
 import { LocalSigner, RemoteSigner } from '@aztec/node-keystore';
 
 import { jest } from '@jest/globals';
-import type { TransactionSerializable, TypedDataDefinition } from '@spalladino/viem';
-import { generatePrivateKey, privateKeyToAddress } from '@spalladino/viem/accounts';
+import type { TransactionSerializable, TypedDataDefinition } from 'viem';
+import { generatePrivateKey, privateKeyToAddress } from 'viem/accounts';
 
 import {
   createWeb3SignerKeystore,

--- a/yarn-project/end-to-end/src/e2e_cheat_codes.test.ts
+++ b/yarn-project/end-to-end/src/e2e_cheat_codes.test.ts
@@ -4,10 +4,10 @@ import { type ExtendedViemWalletClient, createExtendedL1Client } from '@aztec/et
 import { RollupContract } from '@aztec/ethereum/contracts';
 import { TokenContract } from '@aztec/noir-contracts.js/Token';
 
-import { parseEther } from '@spalladino/viem';
-import { mnemonicToAccount } from '@spalladino/viem/accounts';
-import { foundry } from '@spalladino/viem/chains';
 import type { Anvil } from '@viem/anvil';
+import { parseEther } from 'viem';
+import { mnemonicToAccount } from 'viem/accounts';
+import { foundry } from 'viem/chains';
 
 import { MNEMONIC } from './fixtures/fixtures.js';
 import { mintTokensToPrivate } from './fixtures/token_utils.js';

--- a/yarn-project/end-to-end/src/e2e_cross_chain_messaging/cross_chain_messaging_test.ts
+++ b/yarn-project/end-to-end/src/e2e_cross_chain_messaging/cross_chain_messaging_test.ts
@@ -22,7 +22,7 @@ import { TokenContract } from '@aztec/noir-contracts.js/Token';
 import { TokenBridgeContract } from '@aztec/noir-contracts.js/TokenBridge';
 import type { AztecNodeAdmin } from '@aztec/stdlib/interfaces/client';
 
-import { getContract } from '@spalladino/viem';
+import { getContract } from 'viem';
 
 import { MNEMONIC } from '../fixtures/fixtures.js';
 import {

--- a/yarn-project/end-to-end/src/e2e_cross_chain_messaging/l2_to_l1.test.ts
+++ b/yarn-project/end-to-end/src/e2e_cross_chain_messaging/l2_to_l1.test.ts
@@ -11,7 +11,7 @@ import {
   getL2ToL1MessageLeafId,
 } from '@aztec/stdlib/messaging';
 
-import { type Hex, decodeEventLog, getContract } from '@spalladino/viem';
+import { type Hex, decodeEventLog, getContract } from 'viem';
 
 import type { CrossChainTestHarness } from '../shared/cross_chain_test_harness.js';
 import { CrossChainMessagingTest } from './cross_chain_messaging_test.js';

--- a/yarn-project/end-to-end/src/e2e_cross_chain_messaging/token_bridge_failure_cases.test.ts
+++ b/yarn-project/end-to-end/src/e2e_cross_chain_messaging/token_bridge_failure_cases.test.ts
@@ -2,7 +2,7 @@ import { EthAddress, Fr, L1Actor, L1ToL2Message, L2Actor } from '@aztec/aztec.js
 import { RollupContract } from '@aztec/ethereum';
 import { sha256ToField } from '@aztec/foundation/crypto';
 
-import { toFunctionSelector } from '@spalladino/viem';
+import { toFunctionSelector } from 'viem';
 
 import { NO_L1_TO_L2_MSG_ERROR } from '../fixtures/fixtures.js';
 import { CrossChainMessagingTest } from './cross_chain_messaging_test.js';

--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_first_slot.test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_first_slot.test.ts
@@ -10,7 +10,7 @@ import type { SpamContract } from '@aztec/noir-test-contracts.js/Spam';
 import { getSlotRangeForEpoch } from '@aztec/stdlib/epoch-helpers';
 
 import { jest } from '@jest/globals';
-import { privateKeyToAccount } from '@spalladino/viem/accounts';
+import { privateKeyToAccount } from 'viem/accounts';
 
 import { type EndToEndContext, getPrivateKeyFromIndex } from '../fixtures/utils.js';
 import { EpochsTestContext } from './epochs_test.js';

--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_high_tps_block_building.test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_high_tps_block_building.test.ts
@@ -8,7 +8,7 @@ import { bufferToHex } from '@aztec/foundation/string';
 import type { SpamContract } from '@aztec/noir-test-contracts.js/Spam';
 
 import { jest } from '@jest/globals';
-import { privateKeyToAccount } from '@spalladino/viem/accounts';
+import { privateKeyToAccount } from 'viem/accounts';
 
 import { type EndToEndContext, getPrivateKeyFromIndex } from '../fixtures/utils.js';
 import { EpochsTestContext } from './epochs_test.js';

--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_invalidate_block.parallel.test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_invalidate_block.parallel.test.ts
@@ -13,7 +13,7 @@ import type { SpamContract } from '@aztec/noir-test-contracts.js/Spam';
 import { OffenseType } from '@aztec/slasher';
 
 import { jest } from '@jest/globals';
-import { privateKeyToAccount } from '@spalladino/viem/accounts';
+import { privateKeyToAccount } from 'viem/accounts';
 
 import { type EndToEndContext, getPrivateKeyFromIndex } from '../fixtures/utils.js';
 import { EpochsTestContext } from './epochs_test.js';

--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_l1_reorgs.test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_l1_reorgs.test.ts
@@ -12,8 +12,8 @@ import { executeTimeout } from '@aztec/foundation/timer';
 import type { ProverNode } from '@aztec/prover-node';
 
 import { jest } from '@jest/globals';
-import { keccak256, parseTransaction } from '@spalladino/viem';
 import 'jest-extended';
+import { keccak256, parseTransaction } from 'viem';
 
 import { sendL1ToL2Message } from '../fixtures/l1_to_l2_messaging.js';
 import type { EndToEndContext } from '../fixtures/utils.js';

--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_simple_block_building.test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_simple_block_building.test.ts
@@ -9,7 +9,7 @@ import { executeTimeout } from '@aztec/foundation/timer';
 import type { SpamContract } from '@aztec/noir-test-contracts.js/Spam';
 
 import { jest } from '@jest/globals';
-import { privateKeyToAccount } from '@spalladino/viem/accounts';
+import { privateKeyToAccount } from 'viem/accounts';
 
 import { type EndToEndContext, getPrivateKeyFromIndex } from '../fixtures/utils.js';
 import { EpochsTestContext } from './epochs_test.js';

--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_test.ts
@@ -31,9 +31,9 @@ import { EthAddress, type L2BlockNumber } from '@aztec/stdlib/block';
 import { type L1RollupConstants, getProofSubmissionDeadlineTimestamp } from '@aztec/stdlib/epoch-helpers';
 import { tryStop } from '@aztec/stdlib/interfaces/server';
 
-import type { Hex } from '@spalladino/viem';
-import { privateKeyToAccount } from '@spalladino/viem/accounts';
 import { join } from 'path';
+import type { Hex } from 'viem';
+import { privateKeyToAccount } from 'viem/accounts';
 
 import {
   type EndToEndContext,

--- a/yarn-project/end-to-end/src/e2e_fees/bridging_race.notest.ts
+++ b/yarn-project/end-to-end/src/e2e_fees/bridging_race.notest.ts
@@ -4,7 +4,7 @@ import { Fq } from '@aztec/foundation/fields';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
 
 import { jest } from '@jest/globals';
-import type { Hex } from '@spalladino/viem';
+import type { Hex } from 'viem';
 
 import { FeesTest } from './fees_test.js';
 

--- a/yarn-project/end-to-end/src/e2e_fees/fees_test.ts
+++ b/yarn-project/end-to-end/src/e2e_fees/fees_test.ts
@@ -23,7 +23,7 @@ import { ProtocolContractAddress } from '@aztec/protocol-contracts';
 import { getCanonicalFeeJuice } from '@aztec/protocol-contracts/fee-juice';
 import { GasSettings } from '@aztec/stdlib/gas';
 
-import { getContract } from '@spalladino/viem';
+import { getContract } from 'viem';
 
 import { MNEMONIC } from '../fixtures/fixtures.js';
 import {

--- a/yarn-project/end-to-end/src/e2e_l1_publisher/e2e_l1_publisher.test.ts
+++ b/yarn-project/end-to-end/src/e2e_l1_publisher/e2e_l1_publisher.test.ts
@@ -58,6 +58,8 @@ import {
 } from '@aztec/world-state';
 
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import type { Anvil } from '@viem/anvil';
+import { type MockProxy, mock } from 'jest-mock-extended';
 import {
   type Address,
   type GetContractReturnType,
@@ -66,11 +68,9 @@ import {
   getAddress,
   getContract,
   multicall3Abi,
-} from '@spalladino/viem';
-import { type PrivateKeyAccount, privateKeyToAccount } from '@spalladino/viem/accounts';
-import { foundry } from '@spalladino/viem/chains';
-import type { Anvil } from '@viem/anvil';
-import { type MockProxy, mock } from 'jest-mock-extended';
+} from 'viem';
+import { type PrivateKeyAccount, privateKeyToAccount } from 'viem/accounts';
+import { foundry } from 'viem/chains';
 
 import { sendL1ToL2Message } from '../fixtures/l1_to_l2_messaging.js';
 import { setupL1Contracts } from '../fixtures/utils.js';

--- a/yarn-project/end-to-end/src/e2e_l1_with_wall_time.test.ts
+++ b/yarn-project/end-to-end/src/e2e_l1_with_wall_time.test.ts
@@ -4,7 +4,7 @@ import { SecretValue } from '@aztec/foundation/config';
 import type { PXEService } from '@aztec/pxe/server';
 
 import { jest } from '@jest/globals';
-import { privateKeyToAccount } from '@spalladino/viem/accounts';
+import { privateKeyToAccount } from 'viem/accounts';
 
 import { getPrivateKeyFromIndex, setup } from './fixtures/utils.js';
 import { submitTxsTo } from './shared/submit-transactions.js';

--- a/yarn-project/end-to-end/src/e2e_multi_eoa.test.ts
+++ b/yarn-project/end-to-end/src/e2e_multi_eoa.test.ts
@@ -11,9 +11,9 @@ import type { TestSequencerClient } from '@aztec/sequencer-client/test';
 import type { AztecNodeAdmin, PXE } from '@aztec/stdlib/interfaces/client';
 
 import { jest } from '@jest/globals';
-import { type Hex, type TransactionSerialized, recoverTransactionAddress } from '@spalladino/viem';
-import { mnemonicToAccount } from '@spalladino/viem/accounts';
 import 'jest-extended';
+import { type Hex, type TransactionSerialized, recoverTransactionAddress } from 'viem';
+import { mnemonicToAccount } from 'viem/accounts';
 
 import { MNEMONIC } from './fixtures/fixtures.js';
 import { setup } from './fixtures/utils.js';

--- a/yarn-project/end-to-end/src/e2e_multi_validator/e2e_multi_validator_node.test.ts
+++ b/yarn-project/end-to-end/src/e2e_multi_validator/e2e_multi_validator_node.test.ts
@@ -24,8 +24,8 @@ import { RollupAbi } from '@aztec/l1-artifacts/RollupAbi';
 import { StatefulTestContractArtifact } from '@aztec/noir-test-contracts.js/StatefulTest';
 import { BlockAttestation, ConsensusPayload } from '@aztec/stdlib/p2p';
 
-import { getContract } from '@spalladino/viem';
-import { privateKeyToAccount } from '@spalladino/viem/accounts';
+import { getContract } from 'viem';
+import { privateKeyToAccount } from 'viem/accounts';
 
 import { getPrivateKeyFromIndex, setup } from '../fixtures/utils.js';
 

--- a/yarn-project/end-to-end/src/e2e_multi_validator/utils.ts
+++ b/yarn-project/end-to-end/src/e2e_multi_validator/utils.ts
@@ -3,9 +3,9 @@ import { getAddressFromPrivateKey } from '@aztec/ethereum';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import type { EthPrivateKey } from '@aztec/node-keystore';
 
-import { signMessage, signTypedData } from '@spalladino/viem/accounts';
 import { writeFile } from 'fs/promises';
 import { createServer } from 'http';
+import { signMessage, signTypedData } from 'viem/accounts';
 
 // Create a mock JSON RPC signer
 // Only supports signing messages and type data

--- a/yarn-project/end-to-end/src/e2e_p2p/add_rollup.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/add_rollup.test.ts
@@ -32,11 +32,11 @@ import { computeL2ToL1MembershipWitness, getL2ToL1MessageLeafId } from '@aztec/s
 import { getGenesisValues } from '@aztec/world-state/testing';
 
 import { jest } from '@jest/globals';
-import { type Hex, decodeEventLog, encodeFunctionData, getAddress, getContract } from '@spalladino/viem';
 import fs from 'fs';
 import getPort from 'get-port';
 import os from 'os';
 import path from 'path';
+import { type Hex, decodeEventLog, encodeFunctionData, getAddress, getContract } from 'viem';
 
 import { shouldCollectMetrics } from '../fixtures/fixtures.js';
 import { sendL1ToL2Message } from '../fixtures/l1_to_l2_messaging.js';

--- a/yarn-project/end-to-end/src/e2e_p2p/gossip_network_no_cheat.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/gossip_network_no_cheat.test.ts
@@ -12,10 +12,10 @@ import { BlockAttestation, ConsensusPayload } from '@aztec/stdlib/p2p';
 import { ZkPassportProofParams } from '@aztec/stdlib/zkpassport';
 
 import { jest } from '@jest/globals';
-import { getContract } from '@spalladino/viem';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
+import { getContract } from 'viem';
 
 import { shouldCollectMetrics } from '../fixtures/fixtures.js';
 import { type NodeContext, createNodes } from '../fixtures/setup_p2p_test.js';

--- a/yarn-project/end-to-end/src/e2e_p2p/p2p_network.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/p2p_network.ts
@@ -28,9 +28,9 @@ import type { PublicDataTreeLeaf } from '@aztec/stdlib/trees';
 import { ZkPassportProofParams } from '@aztec/stdlib/zkpassport';
 import { getGenesisValues } from '@aztec/world-state/testing';
 
-import { type GetContractReturnType, getAddress, getContract } from '@spalladino/viem';
-import { privateKeyToAccount } from '@spalladino/viem/accounts';
 import getPort from 'get-port';
+import { type GetContractReturnType, getAddress, getContract } from 'viem';
+import { privateKeyToAccount } from 'viem/accounts';
 
 import {
   ATTESTER_PRIVATE_KEYS_START_INDEX,

--- a/yarn-project/end-to-end/src/e2e_p2p/slash_veto_demo.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/slash_veto_demo.test.ts
@@ -20,12 +20,12 @@ import { GSEAbi } from '@aztec/l1-artifacts/GSEAbi';
 import { RollupAbi } from '@aztec/l1-artifacts/RollupAbi';
 import { SlasherAbi } from '@aztec/l1-artifacts/SlasherAbi';
 
-import { encodeFunctionData, getContract } from '@spalladino/viem';
-import { privateKeyToAccount } from '@spalladino/viem/accounts';
 import assert from 'assert';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
+import { encodeFunctionData, getContract } from 'viem';
+import { privateKeyToAccount } from 'viem/accounts';
 
 import { createNodes } from '../fixtures/setup_p2p_test.js';
 import { getPrivateKeyFromIndex } from '../fixtures/utils.js';

--- a/yarn-project/end-to-end/src/e2e_p2p/upgrade_governance_proposer.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/upgrade_governance_proposer.test.ts
@@ -9,10 +9,10 @@ import {
 } from '@aztec/l1-artifacts';
 
 import { jest } from '@jest/globals';
-import { encodeFunctionData, getAddress, getContract } from '@spalladino/viem';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
+import { encodeFunctionData, getAddress, getContract } from 'viem';
 
 import { shouldCollectMetrics } from '../fixtures/fixtures.js';
 import { createNodes } from '../fixtures/setup_p2p_test.js';

--- a/yarn-project/end-to-end/src/e2e_prover/client.test.ts
+++ b/yarn-project/end-to-end/src/e2e_prover/client.test.ts
@@ -4,7 +4,7 @@ import { parseBooleanEnv } from '@aztec/foundation/config';
 import { FeeJuicePortalAbi, TestERC20Abi } from '@aztec/l1-artifacts';
 
 import '@jest/globals';
-import { type GetContractReturnType, getContract } from '@spalladino/viem';
+import { type GetContractReturnType, getContract } from 'viem';
 
 import { FullProverTest } from '../fixtures/e2e_prover_test.js';
 

--- a/yarn-project/end-to-end/src/e2e_prover/full.test.ts
+++ b/yarn-project/end-to-end/src/e2e_prover/full.test.ts
@@ -12,7 +12,7 @@ import { TX_ERROR_INVALID_PROOF } from '@aztec/stdlib/tx';
 
 import TOML from '@iarna/toml';
 import '@jest/globals';
-import { type GetContractReturnType, getContract } from '@spalladino/viem';
+import { type GetContractReturnType, getContract } from 'viem';
 
 import { FullProverTest } from '../fixtures/e2e_prover_test.js';
 

--- a/yarn-project/end-to-end/src/e2e_public_testnet/e2e_public_testnet_transfer.test.ts
+++ b/yarn-project/end-to-end/src/e2e_public_testnet/e2e_public_testnet_transfer.test.ts
@@ -1,7 +1,7 @@
 import type { AccountWalletWithSecretKey, AztecAddress, Logger } from '@aztec/aztec.js';
 import { PrivateTokenContract } from '@aztec/noir-contracts.js/PrivateToken';
 
-import { foundry, sepolia } from '@spalladino/viem/chains';
+import { foundry, sepolia } from 'viem/chains';
 
 import { setup } from '../fixtures/utils.js';
 

--- a/yarn-project/end-to-end/src/e2e_sequencer/gov_proposal.test.ts
+++ b/yarn-project/end-to-end/src/e2e_sequencer/gov_proposal.test.ts
@@ -15,7 +15,7 @@ import { NewGovernanceProposerPayloadBytecode } from '@aztec/l1-artifacts/NewGov
 import { TestContract } from '@aztec/noir-test-contracts.js/Test';
 import type { AztecNodeAdmin } from '@aztec/stdlib/interfaces/client';
 
-import { privateKeyToAccount } from '@spalladino/viem/accounts';
+import { privateKeyToAccount } from 'viem/accounts';
 
 import { getPrivateKeyFromIndex, setup } from '../fixtures/utils.js';
 

--- a/yarn-project/end-to-end/src/e2e_synching.test.ts
+++ b/yarn-project/end-to-end/src/e2e_synching.test.ts
@@ -69,9 +69,9 @@ import { CommitteeAttestationsAndSigners, L2Block } from '@aztec/stdlib/block';
 import { tryStop } from '@aztec/stdlib/interfaces/server';
 import { createWorldStateSynchronizer } from '@aztec/world-state';
 
-import { getContract } from '@spalladino/viem';
 import * as fs from 'fs';
 import { type MockProxy, mock } from 'jest-mock-extended';
+import { getContract } from 'viem';
 
 import { DEFAULT_BLOB_SINK_PORT } from './fixtures/fixtures.js';
 import { mintTokensToPrivate } from './fixtures/token_utils.js';

--- a/yarn-project/end-to-end/src/fixtures/e2e_prover_test.ts
+++ b/yarn-project/end-to-end/src/fixtures/e2e_prover_test.ts
@@ -33,8 +33,8 @@ import type { PXEService } from '@aztec/pxe/server';
 import type { AztecNodeAdmin } from '@aztec/stdlib/interfaces/client';
 import { getGenesisValues } from '@aztec/world-state/testing';
 
-import { type Hex, getContract } from '@spalladino/viem';
-import { privateKeyToAddress } from '@spalladino/viem/accounts';
+import { type Hex, getContract } from 'viem';
+import { privateKeyToAddress } from 'viem/accounts';
 
 import { TokenSimulator } from '../simulators/token_simulator.js';
 import { getACVMConfig } from './get_acvm_config.js';

--- a/yarn-project/end-to-end/src/fixtures/l1_to_l2_messaging.ts
+++ b/yarn-project/end-to-end/src/fixtures/l1_to_l2_messaging.ts
@@ -4,7 +4,7 @@ import { tryJsonStringify } from '@aztec/foundation/json-rpc';
 import { InboxAbi } from '@aztec/l1-artifacts';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
 
-import { decodeEventLog, getContract } from '@spalladino/viem';
+import { decodeEventLog, getContract } from 'viem';
 
 import { getLogger } from './utils.js';
 

--- a/yarn-project/end-to-end/src/fixtures/setup_l1_contracts.ts
+++ b/yarn-project/end-to-end/src/fixtures/setup_l1_contracts.ts
@@ -3,8 +3,8 @@ import { type DeployL1ContractsArgs, type L1ContractsConfig, deployL1Contracts }
 import { getVKTreeRoot } from '@aztec/noir-protocol-circuits-types/vk-tree';
 import { protocolContractTreeRoot } from '@aztec/protocol-contracts';
 
-import type { HDAccount, PrivateKeyAccount } from '@spalladino/viem';
-import { foundry } from '@spalladino/viem/chains';
+import type { HDAccount, PrivateKeyAccount } from 'viem';
+import { foundry } from 'viem/chains';
 
 export { deployAndInitializeTokenAndBridgeContracts } from '../shared/cross_chain_test_harness.js';
 

--- a/yarn-project/end-to-end/src/fixtures/snapshot_manager.ts
+++ b/yarn-project/end-to-end/src/fixtures/snapshot_manager.ts
@@ -40,9 +40,6 @@ import { tryStop } from '@aztec/stdlib/interfaces/server';
 import { getConfigEnvVars as getTelemetryConfig, initTelemetryClient } from '@aztec/telemetry-client';
 import { getGenesisValues } from '@aztec/world-state/testing';
 
-import type { Hex } from '@spalladino/viem';
-import { mnemonicToAccount } from '@spalladino/viem/accounts';
-import { foundry } from '@spalladino/viem/chains';
 import type { Anvil } from '@viem/anvil';
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
 import { copySync, removeSync } from 'fs-extra/esm';
@@ -50,6 +47,9 @@ import fs from 'fs/promises';
 import getPort from 'get-port';
 import { tmpdir } from 'os';
 import path, { join } from 'path';
+import type { Hex } from 'viem';
+import { mnemonicToAccount } from 'viem/accounts';
+import { foundry } from 'viem/chains';
 
 import { MNEMONIC, TEST_MAX_TX_POOL_SIZE, TEST_PEER_CHECK_INTERVAL_MS } from './fixtures.js';
 import { getACVMConfig } from './get_acvm_config.js';

--- a/yarn-project/end-to-end/src/fixtures/utils.ts
+++ b/yarn-project/end-to-end/src/fixtures/utils.ts
@@ -93,14 +93,14 @@ import {
 import { BenchmarkTelemetryClient } from '@aztec/telemetry-client/bench';
 import { getGenesisValues } from '@aztec/world-state/testing';
 
-import { type Chain, type HDAccount, type Hex, type PrivateKeyAccount, getContract } from '@spalladino/viem';
-import { generatePrivateKey, mnemonicToAccount, privateKeyToAccount } from '@spalladino/viem/accounts';
-import { foundry } from '@spalladino/viem/chains';
 import type { Anvil } from '@viem/anvil';
 import fs from 'fs/promises';
 import getPort from 'get-port';
 import { tmpdir } from 'os';
 import * as path from 'path';
+import { type Chain, type HDAccount, type Hex, type PrivateKeyAccount, getContract } from 'viem';
+import { generatePrivateKey, mnemonicToAccount, privateKeyToAccount } from 'viem/accounts';
+import { foundry } from 'viem/chains';
 
 import { MNEMONIC, TEST_PEER_CHECK_INTERVAL_MS } from './fixtures.js';
 import { getACVMConfig } from './get_acvm_config.js';

--- a/yarn-project/end-to-end/src/shared/cross_chain_test_harness.ts
+++ b/yarn-project/end-to-end/src/shared/cross_chain_test_harness.ts
@@ -23,7 +23,7 @@ import { TestERC20Abi, TokenPortalAbi, TokenPortalBytecode } from '@aztec/l1-art
 import { TokenContract } from '@aztec/noir-contracts.js/Token';
 import { TokenBridgeContract } from '@aztec/noir-contracts.js/TokenBridge';
 
-import { type Hex, getContract } from '@spalladino/viem';
+import { type Hex, getContract } from 'viem';
 
 import { mintTokensToPrivate } from '../fixtures/token_utils.js';
 

--- a/yarn-project/end-to-end/src/shared/uniswap_l1_l2.ts
+++ b/yarn-project/end-to-end/src/shared/uniswap_l1_l2.ts
@@ -24,7 +24,7 @@ import { computeL2ToL1MessageHash } from '@aztec/stdlib/hash';
 import { computeL2ToL1MembershipWitness } from '@aztec/stdlib/messaging';
 
 import { jest } from '@jest/globals';
-import { type GetContractReturnType, getContract, parseEther, toFunctionSelector } from '@spalladino/viem';
+import { type GetContractReturnType, getContract, parseEther, toFunctionSelector } from 'viem';
 
 import { ensureAccountContractsPublished } from '../fixtures/utils.js';
 import { CrossChainTestHarness } from './cross_chain_test_harness.js';

--- a/yarn-project/end-to-end/src/spartan/smoke.test.ts
+++ b/yarn-project/end-to-end/src/spartan/smoke.test.ts
@@ -2,8 +2,8 @@ import { type PXE, retryUntil } from '@aztec/aztec.js';
 import { RollupContract, type ViemPublicClient, createEthereumChain } from '@aztec/ethereum';
 import { createLogger } from '@aztec/foundation/log';
 
-import { createPublicClient, fallback, http } from '@spalladino/viem';
 import type { ChildProcess } from 'child_process';
+import { createPublicClient, fallback, http } from 'viem';
 
 import { startCompatiblePXE } from './setup_test_wallets.js';
 import {

--- a/yarn-project/end-to-end/src/spartan/upgrade_governance_proposer.test.ts
+++ b/yarn-project/end-to-end/src/spartan/upgrade_governance_proposer.test.ts
@@ -12,8 +12,8 @@
 // import { NewGovernanceProposerPayloadBytecode } from '@aztec/l1-artifacts/NewGovernanceProposerPayloadBytecode';
 
 // import type { ChildProcess } from 'child_process';
-// import { privateKeyToAccount } from '@spalladino/viem/accounts';
-// import { parseEther, stringify } from '@spalladino/viem/utils';
+// import { privateKeyToAccount } from 'viem/accounts';
+// import { parseEther, stringify } from 'viem/utils';
 
 // import { MNEMONIC } from '../fixtures/fixtures.js';
 // import { isK8sConfig, setupEnvironment, startPortForward, updateSequencersConfig } from './utils.js';

--- a/yarn-project/end-to-end/src/spartan/utils.ts
+++ b/yarn-project/end-to-end/src/spartan/utils.ts
@@ -11,10 +11,10 @@ import {
   createAztecNodeClient,
 } from '@aztec/stdlib/interfaces/client';
 
-import { createPublicClient, fallback, http } from '@spalladino/viem';
 import { ChildProcess, exec, execSync, spawn } from 'child_process';
 import path from 'path';
 import { promisify } from 'util';
+import { createPublicClient, fallback, http } from 'viem';
 import { z } from 'zod';
 
 const execAsync = promisify(exec);

--- a/yarn-project/epoch-cache/package.json
+++ b/yarn-project/epoch-cache/package.json
@@ -30,12 +30,12 @@
     "@aztec/foundation": "workspace:^",
     "@aztec/l1-artifacts": "workspace:^",
     "@aztec/stdlib": "workspace:*",
-    "@spalladino/viem": "2.38.2-eip7594.0",
     "@viem/anvil": "^0.0.10",
     "dotenv": "^16.0.3",
     "get-port": "^7.1.0",
     "jest-mock-extended": "^4.0.0",
     "tslib": "^2.4.0",
+    "viem": "npm:@spalladino/viem@2.38.2-eip7594.0",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/yarn-project/epoch-cache/src/epoch_cache.ts
+++ b/yarn-project/epoch-cache/src/epoch_cache.ts
@@ -13,7 +13,7 @@ import {
   getTimestampRangeForEpoch,
 } from '@aztec/stdlib/epoch-helpers';
 
-import { createPublicClient, encodeAbiParameters, fallback, http, keccak256 } from '@spalladino/viem';
+import { createPublicClient, encodeAbiParameters, fallback, http, keccak256 } from 'viem';
 
 import { type EpochCacheConfig, getEpochCacheConfigEnvVars } from './config.js';
 

--- a/yarn-project/ethereum/package.json
+++ b/yarn-project/ethereum/package.json
@@ -35,12 +35,12 @@
     "@aztec/constants": "workspace:^",
     "@aztec/foundation": "workspace:^",
     "@aztec/l1-artifacts": "workspace:^",
-    "@spalladino/viem": "2.38.2-eip7594.0",
     "@viem/anvil": "^0.0.10",
     "dotenv": "^16.0.3",
     "lodash.chunk": "^4.2.0",
     "lodash.pickby": "^4.5.0",
     "tslib": "^2.4.0",
+    "viem": "npm:@spalladino/viem@2.38.2-eip7594.0",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/yarn-project/ethereum/src/account.ts
+++ b/yarn-project/ethereum/src/account.ts
@@ -1,4 +1,4 @@
-import { privateKeyToAccount } from '@spalladino/viem/accounts';
+import { privateKeyToAccount } from 'viem/accounts';
 
 export function getAddressFromPrivateKey(privateKey: `0x${string}`): `0x${string}` {
   return privateKeyToAccount(privateKey).address;

--- a/yarn-project/ethereum/src/chain.ts
+++ b/yarn-project/ethereum/src/chain.ts
@@ -1,5 +1,5 @@
-import type { Chain } from '@spalladino/viem';
-import { foundry } from '@spalladino/viem/chains';
+import type { Chain } from 'viem';
+import { foundry } from 'viem/chains';
 
 import { AZTEC_TEST_CHAIN_ID } from './constants.js';
 

--- a/yarn-project/ethereum/src/client.ts
+++ b/yarn-project/ethereum/src/client.ts
@@ -11,9 +11,9 @@ import {
   fallback,
   http,
   publicActions,
-} from '@spalladino/viem';
-import { mnemonicToAccount, privateKeyToAccount } from '@spalladino/viem/accounts';
-import { foundry } from '@spalladino/viem/chains';
+} from 'viem';
+import { mnemonicToAccount, privateKeyToAccount } from 'viem/accounts';
+import { foundry } from 'viem/chains';
 
 import { createEthereumChain } from './chain.js';
 import type { ExtendedViemWalletClient, ViemPublicClient } from './types.js';

--- a/yarn-project/ethereum/src/constants.ts
+++ b/yarn-project/ethereum/src/constants.ts
@@ -1,4 +1,4 @@
-import type { Hex } from '@spalladino/viem';
+import type { Hex } from 'viem';
 
 export const NULL_KEY: Hex = `0x${'0000000000000000000000000000000000000000000000000000000000000000'}`;
 export const AZTEC_TEST_CHAIN_ID = 677692;

--- a/yarn-project/ethereum/src/contracts/empire_base.ts
+++ b/yarn-project/ethereum/src/contracts/empire_base.ts
@@ -2,7 +2,7 @@ import type { EthAddress } from '@aztec/foundation/eth-address';
 import { Signature } from '@aztec/foundation/eth-signature';
 import { EmpireBaseAbi } from '@aztec/l1-artifacts/EmpireBaseAbi';
 
-import { type Hex, type TypedDataDefinition, encodeFunctionData } from '@spalladino/viem';
+import { type Hex, type TypedDataDefinition, encodeFunctionData } from 'viem';
 
 import type { L1TxRequest } from '../l1_tx_utils/index.js';
 

--- a/yarn-project/ethereum/src/contracts/empire_slashing_proposer.ts
+++ b/yarn-project/ethereum/src/contracts/empire_slashing_proposer.ts
@@ -3,6 +3,7 @@ import { createLogger } from '@aztec/foundation/log';
 import { retryUntil } from '@aztec/foundation/retry';
 import { EmpireSlashingProposerAbi } from '@aztec/l1-artifacts/EmpireSlashingProposerAbi';
 
+import EventEmitter from 'events';
 import {
   type EncodeFunctionDataParameters,
   type GetContractReturnType,
@@ -11,8 +12,7 @@ import {
   type TypedDataDefinition,
   encodeFunctionData,
   getContract,
-} from '@spalladino/viem';
-import EventEmitter from 'events';
+} from 'viem';
 
 import type { L1TxRequest, L1TxUtils } from '../l1_tx_utils/index.js';
 import type { ViemClient } from '../types.js';

--- a/yarn-project/ethereum/src/contracts/fee_asset_handler.test.ts
+++ b/yarn-project/ethereum/src/contracts/fee_asset_handler.test.ts
@@ -3,11 +3,11 @@ import { Fr } from '@aztec/foundation/fields';
 import { type Logger, createLogger } from '@aztec/foundation/log';
 import { TestERC20Abi as FeeAssetAbi } from '@aztec/l1-artifacts/TestERC20Abi';
 
-import { type GetContractReturnType, getContract } from '@spalladino/viem';
-import { type PrivateKeyAccount, privateKeyToAccount } from '@spalladino/viem/accounts';
-import { foundry } from '@spalladino/viem/chains';
 import type { Anvil } from '@viem/anvil';
 import omit from 'lodash.omit';
+import { type GetContractReturnType, getContract } from 'viem';
+import { type PrivateKeyAccount, privateKeyToAccount } from 'viem/accounts';
+import { foundry } from 'viem/chains';
 
 import { createExtendedL1Client } from '../client.js';
 import { DefaultL1ContractsConfig } from '../config.js';

--- a/yarn-project/ethereum/src/contracts/fee_asset_handler.ts
+++ b/yarn-project/ethereum/src/contracts/fee_asset_handler.ts
@@ -1,7 +1,7 @@
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { FeeAssetHandlerAbi } from '@aztec/l1-artifacts/FeeAssetHandlerAbi';
 
-import { type Hex, encodeFunctionData, getContract } from '@spalladino/viem';
+import { type Hex, encodeFunctionData, getContract } from 'viem';
 
 import type { L1TxUtils } from '../l1_tx_utils/index.js';
 

--- a/yarn-project/ethereum/src/contracts/fee_juice.ts
+++ b/yarn-project/ethereum/src/contracts/fee_juice.ts
@@ -1,7 +1,7 @@
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { TestERC20Abi as FeeJuiceAbi } from '@aztec/l1-artifacts/TestERC20Abi';
 
-import { type GetContractReturnType, type Hex, getContract } from '@spalladino/viem';
+import { type GetContractReturnType, type Hex, getContract } from 'viem';
 
 import { type ExtendedViemWalletClient, type ViemClient, isExtendedClient } from '../types.js';
 

--- a/yarn-project/ethereum/src/contracts/governance.test.ts
+++ b/yarn-project/ethereum/src/contracts/governance.test.ts
@@ -2,9 +2,9 @@ import { createExtendedL1Client, getPublicClient } from '@aztec/ethereum';
 import { Fr } from '@aztec/foundation/fields';
 import { type Logger, createLogger } from '@aztec/foundation/log';
 
-import { type PrivateKeyAccount, privateKeyToAccount } from '@spalladino/viem/accounts';
-import { foundry } from '@spalladino/viem/chains';
 import type { Anvil } from '@viem/anvil';
+import { type PrivateKeyAccount, privateKeyToAccount } from 'viem/accounts';
+import { foundry } from 'viem/chains';
 
 import { DefaultL1ContractsConfig } from '../config.js';
 import { deployL1Contracts } from '../deploy_l1_contracts.js';

--- a/yarn-project/ethereum/src/contracts/governance.ts
+++ b/yarn-project/ethereum/src/contracts/governance.ts
@@ -11,7 +11,7 @@ import {
   encodeFunctionData,
   getContract,
   parseEventLogs,
-} from '@spalladino/viem';
+} from 'viem';
 
 import type { L1ContractAddresses } from '../l1_contract_addresses.js';
 import { createL1TxUtilsFromViemWallet } from '../l1_tx_utils/index.js';

--- a/yarn-project/ethereum/src/contracts/governance_proposer.ts
+++ b/yarn-project/ethereum/src/contracts/governance_proposer.ts
@@ -9,7 +9,7 @@ import {
   type TypedDataDefinition,
   encodeFunctionData,
   getContract,
-} from '@spalladino/viem';
+} from 'viem';
 
 import type { L1TxRequest, L1TxUtils } from '../l1_tx_utils/index.js';
 import type { ViemClient } from '../types.js';

--- a/yarn-project/ethereum/src/contracts/gse.test.ts
+++ b/yarn-project/ethereum/src/contracts/gse.test.ts
@@ -2,9 +2,9 @@ import { GSEContract, getPublicClient } from '@aztec/ethereum';
 import { Fr } from '@aztec/foundation/fields';
 import { type Logger, createLogger } from '@aztec/foundation/log';
 
-import { type PrivateKeyAccount, privateKeyToAccount } from '@spalladino/viem/accounts';
-import { foundry } from '@spalladino/viem/chains';
 import type { Anvil } from '@viem/anvil';
+import { type PrivateKeyAccount, privateKeyToAccount } from 'viem/accounts';
+import { foundry } from 'viem/chains';
 
 import { DefaultL1ContractsConfig } from '../config.js';
 import { deployL1Contracts } from '../deploy_l1_contracts.js';

--- a/yarn-project/ethereum/src/contracts/gse.ts
+++ b/yarn-project/ethereum/src/contracts/gse.ts
@@ -3,7 +3,7 @@ import { GSEAbi } from '@aztec/l1-artifacts/GSEAbi';
 
 import type { ProjPointType } from '@noble/curves/abstract/weierstrass';
 import { bn254 } from '@noble/curves/bn254';
-import { type GetContractReturnType, type Hex, getContract } from '@spalladino/viem';
+import { type GetContractReturnType, type Hex, getContract } from 'viem';
 
 import type { ViemClient } from '../types.js';
 

--- a/yarn-project/ethereum/src/contracts/inbox.ts
+++ b/yarn-project/ethereum/src/contracts/inbox.ts
@@ -2,7 +2,7 @@ import { Buffer16 } from '@aztec/foundation/buffer';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { InboxAbi } from '@aztec/l1-artifacts/InboxAbi';
 
-import { type BlockTag, type GetContractReturnType, type Hex, getContract } from '@spalladino/viem';
+import { type BlockTag, type GetContractReturnType, type Hex, getContract } from 'viem';
 
 import { getPublicClient } from '../client.js';
 import type { DeployL1ContractsReturnType } from '../deploy_l1_contracts.js';

--- a/yarn-project/ethereum/src/contracts/multicall.test.ts
+++ b/yarn-project/ethereum/src/contracts/multicall.test.ts
@@ -5,10 +5,10 @@ import { GovernanceProposerAbi } from '@aztec/l1-artifacts/GovernanceProposerAbi
 import { TestERC20Abi } from '@aztec/l1-artifacts/TestERC20Abi';
 import { TestERC20Bytecode } from '@aztec/l1-artifacts/TestERC20Bytecode';
 
-import { type GetContractReturnType, type PrivateKeyAccount, encodeFunctionData, getContract } from '@spalladino/viem';
-import { privateKeyToAccount } from '@spalladino/viem/accounts';
-import { foundry } from '@spalladino/viem/chains';
 import type { Anvil } from '@viem/anvil';
+import { type GetContractReturnType, type PrivateKeyAccount, encodeFunctionData, getContract } from 'viem';
+import { privateKeyToAccount } from 'viem/accounts';
+import { foundry } from 'viem/chains';
 
 import { createExtendedL1Client } from '../client.js';
 import { DefaultL1ContractsConfig } from '../config.js';

--- a/yarn-project/ethereum/src/contracts/multicall.ts
+++ b/yarn-project/ethereum/src/contracts/multicall.ts
@@ -2,7 +2,7 @@ import { toHex as toPaddedHex } from '@aztec/foundation/bigint-buffer';
 import { TimeoutError } from '@aztec/foundation/error';
 import type { Logger } from '@aztec/foundation/log';
 
-import { type EncodeFunctionDataParameters, type Hex, encodeFunctionData, multicall3Abi } from '@spalladino/viem';
+import { type EncodeFunctionDataParameters, type Hex, encodeFunctionData, multicall3Abi } from 'viem';
 
 import type { L1BlobInputs, L1TxConfig, L1TxRequest, L1TxUtils } from '../l1_tx_utils/index.js';
 import type { ExtendedViemWalletClient } from '../types.js';

--- a/yarn-project/ethereum/src/contracts/registry.test.ts
+++ b/yarn-project/ethereum/src/contracts/registry.test.ts
@@ -3,11 +3,11 @@ import { Fr } from '@aztec/foundation/fields';
 import { type Logger, createLogger } from '@aztec/foundation/log';
 import { RegistryAbi } from '@aztec/l1-artifacts/RegistryAbi';
 
-import { createPublicClient, getContract, http } from '@spalladino/viem';
-import { type PrivateKeyAccount, privateKeyToAccount } from '@spalladino/viem/accounts';
-import { foundry } from '@spalladino/viem/chains';
 import type { Anvil } from '@viem/anvil';
 import omit from 'lodash.omit';
+import { createPublicClient, getContract, http } from 'viem';
+import { type PrivateKeyAccount, privateKeyToAccount } from 'viem/accounts';
+import { foundry } from 'viem/chains';
 
 import { createExtendedL1Client } from '../client.js';
 import { DefaultL1ContractsConfig } from '../config.js';

--- a/yarn-project/ethereum/src/contracts/registry.ts
+++ b/yarn-project/ethereum/src/contracts/registry.ts
@@ -3,7 +3,7 @@ import { createLogger } from '@aztec/foundation/log';
 import { RegistryAbi } from '@aztec/l1-artifacts/RegistryAbi';
 import { TestERC20Abi } from '@aztec/l1-artifacts/TestERC20Abi';
 
-import { type GetContractReturnType, type Hex, getContract } from '@spalladino/viem';
+import { type GetContractReturnType, type Hex, getContract } from 'viem';
 
 import type { L1ContractAddresses } from '../l1_contract_addresses.js';
 import type { ViemClient } from '../types.js';

--- a/yarn-project/ethereum/src/contracts/rollup.test.ts
+++ b/yarn-project/ethereum/src/contracts/rollup.test.ts
@@ -4,10 +4,10 @@ import { Fr } from '@aztec/foundation/fields';
 import { type Logger, createLogger } from '@aztec/foundation/log';
 import { RollupAbi } from '@aztec/l1-artifacts/RollupAbi';
 
-import type { Abi } from '@spalladino/viem';
-import { type PrivateKeyAccount, privateKeyToAccount } from '@spalladino/viem/accounts';
-import { foundry } from '@spalladino/viem/chains';
 import type { Anvil } from '@viem/anvil';
+import type { Abi } from 'viem';
+import { type PrivateKeyAccount, privateKeyToAccount } from 'viem/accounts';
+import { foundry } from 'viem/chains';
 
 import { DefaultL1ContractsConfig } from '../config.js';
 import { deployL1Contracts } from '../deploy_l1_contracts.js';

--- a/yarn-project/ethereum/src/contracts/rollup.ts
+++ b/yarn-project/ethereum/src/contracts/rollup.ts
@@ -4,6 +4,7 @@ import type { ViemSignature } from '@aztec/foundation/eth-signature';
 import { RollupAbi } from '@aztec/l1-artifacts/RollupAbi';
 import { RollupStorage } from '@aztec/l1-artifacts/RollupStorage';
 
+import chunk from 'lodash.chunk';
 import {
   type Account,
   type GetContractReturnType,
@@ -14,8 +15,7 @@ import {
   getContract,
   hexToBigInt,
   keccak256,
-} from '@spalladino/viem';
-import chunk from 'lodash.chunk';
+} from 'viem';
 
 import { getPublicClient } from '../client.js';
 import type { DeployL1ContractsReturnType } from '../deploy_l1_contracts.js';

--- a/yarn-project/ethereum/src/contracts/slasher_contract.ts
+++ b/yarn-project/ethereum/src/contracts/slasher_contract.ts
@@ -2,7 +2,7 @@ import { EthAddress } from '@aztec/foundation/eth-address';
 import { createLogger } from '@aztec/foundation/log';
 import { SlasherAbi } from '@aztec/l1-artifacts/SlasherAbi';
 
-import { type GetContractReturnType, getContract } from '@spalladino/viem';
+import { type GetContractReturnType, getContract } from 'viem';
 
 import type { ViemClient } from '../types.js';
 

--- a/yarn-project/ethereum/src/contracts/tally_slashing_proposer.test.ts
+++ b/yarn-project/ethereum/src/contracts/tally_slashing_proposer.test.ts
@@ -14,10 +14,10 @@ import { type Logger, createLogger } from '@aztec/foundation/log';
 import { bufferToHex } from '@aztec/foundation/string';
 import { TallySlashingProposerAbi } from '@aztec/l1-artifacts/TallySlashingProposerAbi';
 
-import { type Hex, type TypedDataDefinition, encodeFunctionData, hashTypedData } from '@spalladino/viem';
-import { type PrivateKeyAccount, privateKeyToAccount } from '@spalladino/viem/accounts';
-import { foundry } from '@spalladino/viem/chains';
 import type { Anvil } from '@viem/anvil';
+import { type Hex, type TypedDataDefinition, encodeFunctionData, hashTypedData } from 'viem';
+import { type PrivateKeyAccount, privateKeyToAccount } from 'viem/accounts';
+import { foundry } from 'viem/chains';
 
 import { TallySlashingProposerContract } from './tally_slashing_proposer.js';
 

--- a/yarn-project/ethereum/src/contracts/tally_slashing_proposer.ts
+++ b/yarn-project/ethereum/src/contracts/tally_slashing_proposer.ts
@@ -12,7 +12,7 @@ import {
   type TypedDataDefinition,
   encodeFunctionData,
   getContract,
-} from '@spalladino/viem';
+} from 'viem';
 
 /**
  * Wrapper around the TallySlashingProposer contract that provides

--- a/yarn-project/ethereum/src/deploy_l1_contracts.test.ts
+++ b/yarn-project/ethereum/src/deploy_l1_contracts.test.ts
@@ -6,8 +6,8 @@ import { type Logger, createLogger } from '@aztec/foundation/log';
 import { retryUntil } from '@aztec/foundation/retry';
 import { MockVerifierAbi, MockVerifierBytecode, TestERC20Abi, TestERC20Bytecode } from '@aztec/l1-artifacts';
 
-import type { Hex } from '@spalladino/viem';
-import { type PrivateKeyAccount, privateKeyToAccount } from '@spalladino/viem/accounts';
+import type { Hex } from 'viem';
+import { type PrivateKeyAccount, privateKeyToAccount } from 'viem/accounts';
 
 import { createEthereumChain } from './chain.js';
 import { createExtendedL1Client } from './client.js';

--- a/yarn-project/ethereum/src/deploy_l1_contracts.ts
+++ b/yarn-project/ethereum/src/deploy_l1_contracts.ts
@@ -8,6 +8,9 @@ import { type Logger, createLogger } from '@aztec/foundation/log';
 import { DateProvider } from '@aztec/foundation/timer';
 import { RollupAbi } from '@aztec/l1-artifacts/RollupAbi';
 
+import type { Abi, Narrow } from 'abitype';
+import { mkdir, writeFile } from 'fs/promises';
+import chunk from 'lodash.chunk';
 import {
   type Chain,
   type ContractConstructorArgs,
@@ -23,11 +26,8 @@ import {
   getContractAddress,
   numberToHex,
   padHex,
-} from '@spalladino/viem';
-import { foundry } from '@spalladino/viem/chains';
-import type { Abi, Narrow } from 'abitype';
-import { mkdir, writeFile } from 'fs/promises';
-import chunk from 'lodash.chunk';
+} from 'viem';
+import { foundry } from 'viem/chains';
 
 import { isAnvilTestChain } from './chain.js';
 import { createExtendedL1Client } from './client.js';

--- a/yarn-project/ethereum/src/eth-signer/eth-signer.ts
+++ b/yarn-project/ethereum/src/eth-signer/eth-signer.ts
@@ -5,7 +5,7 @@ import type { Buffer32 } from '@aztec/foundation/buffer';
 import type { EthAddress } from '@aztec/foundation/eth-address';
 import type { Signature } from '@aztec/foundation/eth-signature';
 
-import type { TransactionSerializable, TypedDataDefinition } from '@spalladino/viem';
+import type { TransactionSerializable, TypedDataDefinition } from 'viem';
 
 /**
  * Abstraction for signing operations used by the node keystore.

--- a/yarn-project/ethereum/src/l1_artifacts.ts
+++ b/yarn-project/ethereum/src/l1_artifacts.ts
@@ -60,7 +60,7 @@ import {
   ValidatorSelectionLibBytecode,
 } from '@aztec/l1-artifacts';
 
-import type { Hex } from '@spalladino/viem';
+import type { Hex } from 'viem';
 
 export const RegistryArtifact = {
   name: 'Registry',

--- a/yarn-project/ethereum/src/l1_tx_utils/factory.ts
+++ b/yarn-project/ethereum/src/l1_tx_utils/factory.ts
@@ -2,7 +2,7 @@ import { EthAddress } from '@aztec/foundation/eth-address';
 import type { Logger } from '@aztec/foundation/log';
 import { DateProvider } from '@aztec/foundation/timer';
 
-import type { TransactionSerializable } from '@spalladino/viem';
+import type { TransactionSerializable } from 'viem';
 
 import type { EthSigner } from '../eth-signer/eth-signer.js';
 import type { ExtendedViemWalletClient, ViemClient } from '../types.js';

--- a/yarn-project/ethereum/src/l1_tx_utils/l1_tx_utils.test.ts
+++ b/yarn-project/ethereum/src/l1_tx_utils/l1_tx_utils.test.ts
@@ -9,6 +9,9 @@ import { sleep } from '@aztec/foundation/sleep';
 import { TestDateProvider } from '@aztec/foundation/timer';
 
 import { jest } from '@jest/globals';
+import type { Anvil } from '@viem/anvil';
+import { type MockProxy, mock } from 'jest-mock-extended';
+import assert from 'node:assert';
 import {
   type Abi,
   type BlockTag,
@@ -19,12 +22,9 @@ import {
   createPublicClient,
   encodeFunctionData,
   http,
-} from '@spalladino/viem';
-import { mnemonicToAccount, privateKeyToAccount } from '@spalladino/viem/accounts';
-import { foundry } from '@spalladino/viem/chains';
-import type { Anvil } from '@viem/anvil';
-import { type MockProxy, mock } from 'jest-mock-extended';
-import assert from 'node:assert';
+} from 'viem';
+import { mnemonicToAccount, privateKeyToAccount } from 'viem/accounts';
+import { foundry } from 'viem/chains';
 
 import { createExtendedL1Client, getPublicClient } from '../client.js';
 import { EthCheatCodes } from '../test/eth_cheat_codes.js';

--- a/yarn-project/ethereum/src/l1_tx_utils/l1_tx_utils.ts
+++ b/yarn-project/ethereum/src/l1_tx_utils/l1_tx_utils.ts
@@ -8,6 +8,7 @@ import { sleep } from '@aztec/foundation/sleep';
 import { DateProvider } from '@aztec/foundation/timer';
 import { RollupAbi } from '@aztec/l1-artifacts/RollupAbi';
 
+import pickBy from 'lodash.pickby';
 import {
   type Abi,
   type BlockOverrides,
@@ -20,9 +21,8 @@ import {
   createNonceManager,
   formatGwei,
   serializeTransaction,
-} from '@spalladino/viem';
-import { jsonRpc } from '@spalladino/viem/nonce';
-import pickBy from 'lodash.pickby';
+} from 'viem';
+import { jsonRpc } from 'viem/nonce';
 
 import type { ViemClient } from '../types.js';
 import { formatViemError } from '../utils.js';

--- a/yarn-project/ethereum/src/l1_tx_utils/l1_tx_utils_with_blobs.ts
+++ b/yarn-project/ethereum/src/l1_tx_utils/l1_tx_utils_with_blobs.ts
@@ -3,7 +3,7 @@ import { EthAddress } from '@aztec/foundation/eth-address';
 import type { Logger } from '@aztec/foundation/log';
 import { DateProvider } from '@aztec/foundation/timer';
 
-import type { TransactionSerializable } from '@spalladino/viem';
+import type { TransactionSerializable } from 'viem';
 
 import type { EthSigner } from '../eth-signer/eth-signer.js';
 import type { ExtendedViemWalletClient, ViemClient } from '../types.js';

--- a/yarn-project/ethereum/src/l1_tx_utils/readonly_l1_tx_utils.ts
+++ b/yarn-project/ethereum/src/l1_tx_utils/readonly_l1_tx_utils.ts
@@ -4,6 +4,7 @@ import { makeBackoff, retry } from '@aztec/foundation/retry';
 import { DateProvider } from '@aztec/foundation/timer';
 import { RollupAbi } from '@aztec/l1-artifacts/RollupAbi';
 
+import pickBy from 'lodash.pickby';
 import {
   type Abi,
   type Account,
@@ -18,8 +19,7 @@ import {
   formatGwei,
   getContractError,
   hexToBytes,
-} from '@spalladino/viem';
-import pickBy from 'lodash.pickby';
+} from 'viem';
 
 import type { ViemClient } from '../types.js';
 import { type L1TxUtilsConfig, defaultL1TxUtilsConfig, l1TxUtilsConfigMappings } from './config.js';

--- a/yarn-project/ethereum/src/l1_tx_utils/signer.ts
+++ b/yarn-project/ethereum/src/l1_tx_utils/signer.ts
@@ -1,7 +1,7 @@
 import { EthAddress } from '@aztec/foundation/eth-address';
 import type { ViemTransactionSignature } from '@aztec/foundation/eth-signature';
 
-import { type TransactionSerializable, type WalletClient, parseTransaction } from '@spalladino/viem';
+import { type TransactionSerializable, type WalletClient, parseTransaction } from 'viem';
 
 import type { SigningCallback } from './types.js';
 

--- a/yarn-project/ethereum/src/l1_tx_utils/types.ts
+++ b/yarn-project/ethereum/src/l1_tx_utils/types.ts
@@ -2,7 +2,7 @@ import type { BlobKzgInstance } from '@aztec/blob-lib/types';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import type { ViemTransactionSignature } from '@aztec/foundation/eth-signature';
 
-import type { Abi, Address, Hex, TransactionReceipt, TransactionSerializable } from '@spalladino/viem';
+import type { Abi, Address, Hex, TransactionReceipt, TransactionSerializable } from 'viem';
 
 import type { L1TxUtilsConfig } from './config.js';
 

--- a/yarn-project/ethereum/src/l1_tx_utils/utils.ts
+++ b/yarn-project/ethereum/src/l1_tx_utils/utils.ts
@@ -1,6 +1,6 @@
 import { compactArray } from '@aztec/foundation/collection';
 
-import type { ContractFunctionExecutionError } from '@spalladino/viem';
+import type { ContractFunctionExecutionError } from 'viem';
 
 export function tryGetCustomErrorNameContractFunction(err: ContractFunctionExecutionError) {
   return compactArray([err.shortMessage, ...(err.metaMessages ?? []).slice(0, 2).map(s => s.trim())]).join(' ');

--- a/yarn-project/ethereum/src/test/eth_cheat_codes.test.ts
+++ b/yarn-project/ethereum/src/test/eth_cheat_codes.test.ts
@@ -4,10 +4,10 @@ import { type Logger, createLogger } from '@aztec/foundation/log';
 import { sleep } from '@aztec/foundation/sleep';
 import { TestERC20Abi, TestERC20Bytecode } from '@aztec/l1-artifacts';
 
-import { type Hex, encodeFunctionData, getContract } from '@spalladino/viem';
-import { mnemonicToAccount, privateKeyToAccount } from '@spalladino/viem/accounts';
-import { foundry } from '@spalladino/viem/chains';
 import type { Anvil } from '@viem/anvil';
+import { type Hex, encodeFunctionData, getContract } from 'viem';
+import { mnemonicToAccount, privateKeyToAccount } from 'viem/accounts';
+import { foundry } from 'viem/chains';
 
 import { createExtendedL1Client } from '../client.js';
 import { deployL1Contract } from '../deploy_l1_contracts.js';

--- a/yarn-project/ethereum/src/test/eth_cheat_codes.ts
+++ b/yarn-project/ethereum/src/test/eth_cheat_codes.ts
@@ -6,7 +6,7 @@ import { createLogger } from '@aztec/foundation/log';
 import { pluralize } from '@aztec/foundation/string';
 import type { TestDateProvider } from '@aztec/foundation/timer';
 
-import { type Hex, type Transaction, createPublicClient, fallback, hexToNumber, http } from '@spalladino/viem';
+import { type Hex, type Transaction, createPublicClient, fallback, hexToNumber, http } from 'viem';
 
 import type { ViemPublicClient } from '../types.js';
 

--- a/yarn-project/ethereum/src/test/fallback_transport.test.ts
+++ b/yarn-project/ethereum/src/test/fallback_transport.test.ts
@@ -1,4 +1,5 @@
 import { jest } from '@jest/globals';
+import type { Anvil } from '@viem/anvil';
 import {
   type Account,
   type Chain,
@@ -18,10 +19,9 @@ import {
   fallback,
   http,
   publicActions,
-} from '@spalladino/viem';
-import { privateKeyToAccount } from '@spalladino/viem/accounts';
-import { foundry } from '@spalladino/viem/chains';
-import type { Anvil } from '@viem/anvil';
+} from 'viem';
+import { privateKeyToAccount } from 'viem/accounts';
+import { foundry } from 'viem/chains';
 
 import { startAnvil } from './start_anvil.js';
 

--- a/yarn-project/ethereum/src/test/rollup_cheat_codes.ts
+++ b/yarn-project/ethereum/src/test/rollup_cheat_codes.ts
@@ -13,8 +13,8 @@ import {
   getContract,
   hexToBigInt,
   http,
-} from '@spalladino/viem';
-import { foundry } from '@spalladino/viem/chains';
+} from 'viem';
+import { foundry } from 'viem/chains';
 
 import { EthCheatCodes } from './eth_cheat_codes.js';
 

--- a/yarn-project/ethereum/src/test/start_anvil.test.ts
+++ b/yarn-project/ethereum/src/test/start_anvil.test.ts
@@ -1,8 +1,8 @@
 import { type Logger, createLogger } from '@aztec/foundation/log';
 import { sleep } from '@aztec/foundation/sleep';
 
-import { createPublicClient, http, parseAbiItem } from '@spalladino/viem';
 import type { Anvil } from '@viem/anvil';
+import { createPublicClient, http, parseAbiItem } from 'viem';
 
 import { startAnvil } from './start_anvil.js';
 

--- a/yarn-project/ethereum/src/test/tx_delayer.test.ts
+++ b/yarn-project/ethereum/src/test/tx_delayer.test.ts
@@ -5,17 +5,10 @@ import { sleep } from '@aztec/foundation/sleep';
 import { TestDateProvider } from '@aztec/foundation/timer';
 import { TestERC20Abi, TestERC20Bytecode } from '@aztec/l1-artifacts';
 
-import {
-  type PrivateKeyAccount,
-  createWalletClient,
-  fallback,
-  getContract,
-  http,
-  publicActions,
-} from '@spalladino/viem';
-import { privateKeyToAccount } from '@spalladino/viem/accounts';
-import { foundry } from '@spalladino/viem/chains';
 import type { Anvil } from '@viem/anvil';
+import { type PrivateKeyAccount, createWalletClient, fallback, getContract, http, publicActions } from 'viem';
+import { privateKeyToAccount } from 'viem/accounts';
+import { foundry } from 'viem/chains';
 
 import type { ExtendedViemWalletClient } from '../types.js';
 import { EthCheatCodes } from './eth_cheat_codes.js';

--- a/yarn-project/ethereum/src/test/tx_delayer.ts
+++ b/yarn-project/ethereum/src/test/tx_delayer.ts
@@ -3,6 +3,7 @@ import { type Logger, createLogger } from '@aztec/foundation/log';
 import { retryUntil } from '@aztec/foundation/retry';
 import type { DateProvider } from '@aztec/foundation/timer';
 
+import { inspect } from 'util';
 import {
   type Client,
   type Hex,
@@ -13,8 +14,7 @@ import {
   publicActions,
   serializeTransaction,
   walletActions,
-} from '@spalladino/viem';
-import { inspect } from 'util';
+} from 'viem';
 
 import { type ViemClient, isExtendedClient } from '../types.js';
 

--- a/yarn-project/ethereum/src/test/upgrade_utils.ts
+++ b/yarn-project/ethereum/src/test/upgrade_utils.ts
@@ -2,7 +2,7 @@ import type { Logger } from '@aztec/foundation/log';
 import { GovernanceAbi } from '@aztec/l1-artifacts/GovernanceAbi';
 import { TestERC20Abi as StakingAssetAbi } from '@aztec/l1-artifacts/TestERC20Abi';
 
-import { type GetContractReturnType, type PrivateKeyAccount, getContract } from '@spalladino/viem';
+import { type GetContractReturnType, type PrivateKeyAccount, getContract } from 'viem';
 
 import { extractProposalIdFromLogs } from '../contracts/governance.js';
 import type { L1ContractAddresses } from '../l1_contract_addresses.js';

--- a/yarn-project/ethereum/src/types.ts
+++ b/yarn-project/ethereum/src/types.ts
@@ -11,7 +11,7 @@ import type {
   PublicRpcSchema,
   WalletActions,
   WalletRpcSchema,
-} from '@spalladino/viem';
+} from 'viem';
 
 /** Type for a viem public client */
 export type ViemPublicClient = PublicClient<FallbackTransport<HttpTransport[]>, Chain>;

--- a/yarn-project/ethereum/src/utils.ts
+++ b/yarn-project/ethereum/src/utils.ts
@@ -12,7 +12,7 @@ import {
   type Log,
   decodeErrorResult,
   decodeEventLog,
-} from '@spalladino/viem';
+} from 'viem';
 
 export interface L2Claim {
   claimSecret: Fr;

--- a/yarn-project/foundation/package.json
+++ b/yarn-project/foundation/package.json
@@ -126,7 +126,6 @@
   "devDependencies": {
     "@jest/globals": "^30.0.0",
     "@libp2p/interface": "1.3.1",
-    "@spalladino/viem": "2.38.2-eip7594.0",
     "@types/detect-node": "^2.0.0",
     "@types/jest": "^30.0.0",
     "@types/koa": "^2.15.0",
@@ -153,7 +152,8 @@
     "supertest": "^6.3.3",
     "ts-node": "^10.9.1",
     "typescript": "^5.3.3",
-    "typescript-eslint": "^8.32.1"
+    "typescript-eslint": "^8.32.1",
+    "viem": "npm:@spalladino/viem@2.38.2-eip7594.0"
   },
   "files": [
     "dest",

--- a/yarn-project/foundation/src/crypto/secp256k1-signer/secp256k1_signer.test.ts
+++ b/yarn-project/foundation/src/crypto/secp256k1-signer/secp256k1_signer.test.ts
@@ -2,17 +2,8 @@ import { Buffer32 } from '@aztec/foundation/buffer';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { Signature } from '@aztec/foundation/eth-signature';
 
-import {
-  hashMessage,
-  recoverAddress as viemRecoverAddress,
-  recoverPublicKey as viemRecoverPublicKey,
-} from '@spalladino/viem';
-import {
-  type PrivateKeyAccount,
-  generatePrivateKey,
-  privateKeyToAccount,
-  publicKeyToAddress,
-} from '@spalladino/viem/accounts';
+import { hashMessage, recoverAddress as viemRecoverAddress, recoverPublicKey as viemRecoverPublicKey } from 'viem';
+import { type PrivateKeyAccount, generatePrivateKey, privateKeyToAccount, publicKeyToAddress } from 'viem/accounts';
 
 import { Secp256k1Signer } from './secp256k1_signer.js';
 import { recoverAddress as lightRecoverAddress, recoverPublicKey as lightRecoverPublicKey } from './utils.js';

--- a/yarn-project/node-keystore/package.json
+++ b/yarn-project/node-keystore/package.json
@@ -66,8 +66,8 @@
     "@aztec/foundation": "workspace:^",
     "@aztec/stdlib": "workspace:^",
     "@ethersproject/wallet": "^5.7.0",
-    "@spalladino/viem": "2.38.2-eip7594.0",
     "tslib": "^2.4.0",
+    "viem": "npm:@spalladino/viem@2.38.2-eip7594.0",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/yarn-project/node-keystore/src/keystore_manager.test.ts
+++ b/yarn-project/node-keystore/src/keystore_manager.test.ts
@@ -6,10 +6,10 @@ import { EthAddress } from '@aztec/foundation/eth-address';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
 
 import { describe, expect, it, jest } from '@jest/globals';
-import { mnemonicToAccount } from '@spalladino/viem/accounts';
 import { mkdirSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
+import { mnemonicToAccount } from 'viem/accounts';
 
 import { KeystoreError, KeystoreManager } from '../src/keystore_manager.js';
 import { LocalSigner, RemoteSigner } from '../src/signer.js';

--- a/yarn-project/node-keystore/src/keystore_manager.ts
+++ b/yarn-project/node-keystore/src/keystore_manager.ts
@@ -10,10 +10,10 @@ import type { Signature } from '@aztec/foundation/eth-signature';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
 
 import { Wallet } from '@ethersproject/wallet';
-import type { TypedDataDefinition } from '@spalladino/viem';
-import { mnemonicToAccount } from '@spalladino/viem/accounts';
 import { readFileSync, readdirSync, statSync } from 'fs';
 import { extname, join } from 'path';
+import type { TypedDataDefinition } from 'viem';
+import { mnemonicToAccount } from 'viem/accounts';
 
 import { ethPrivateKeySchema } from './schemas.js';
 import { LocalSigner, RemoteSigner } from './signer.js';

--- a/yarn-project/node-keystore/src/signer.ts
+++ b/yarn-project/node-keystore/src/signer.ts
@@ -18,7 +18,7 @@ import {
   keccak256,
   parseTransaction,
   serializeTransaction,
-} from '@spalladino/viem';
+} from 'viem';
 
 import type { EthRemoteSignerConfig } from './types.js';
 

--- a/yarn-project/node-lib/src/stores/l1_tx_store.test.ts
+++ b/yarn-project/node-lib/src/stores/l1_tx_store.test.ts
@@ -4,7 +4,7 @@ import { omit } from '@aztec/foundation/collection';
 import type { AztecAsyncKVStore } from '@aztec/kv-store';
 import { openTmpStore } from '@aztec/kv-store/lmdb-v2';
 
-import type { Hex } from '@spalladino/viem';
+import type { Hex } from 'viem';
 
 import { L1TxStore } from './l1_tx_store.js';
 

--- a/yarn-project/node-lib/src/stores/l1_tx_store.ts
+++ b/yarn-project/node-lib/src/stores/l1_tx_store.ts
@@ -4,7 +4,7 @@ import type { Logger } from '@aztec/foundation/log';
 import { createLogger } from '@aztec/foundation/log';
 import type { AztecAsyncKVStore, AztecAsyncMap } from '@aztec/kv-store';
 
-import type { TransactionReceipt } from '@spalladino/viem';
+import type { TransactionReceipt } from 'viem';
 
 /**
  * Serializable version of L1TxRequest for storage.

--- a/yarn-project/p2p/package.json
+++ b/yarn-project/p2p/package.json
@@ -107,7 +107,6 @@
     "@aztec/archiver": "workspace:^",
     "@aztec/world-state": "workspace:^",
     "@jest/globals": "^30.0.0",
-    "@spalladino/viem": "2.38.2-eip7594.0",
     "@types/jest": "^30.0.0",
     "@types/node": "^22.15.17",
     "get-port": "^7.1.0",
@@ -117,7 +116,8 @@
     "jest-mock-extended": "^4.0.0",
     "ts-node": "^10.9.1",
     "typescript": "^5.3.3",
-    "uint8arrays": "^5.0.3"
+    "uint8arrays": "^5.0.3",
+    "viem": "npm:@spalladino/viem@2.38.2-eip7594.0"
   },
   "files": [
     "dest",

--- a/yarn-project/p2p/src/mem_pools/attestation_pool/mocks.ts
+++ b/yarn-project/p2p/src/mem_pools/attestation_pool/mocks.ts
@@ -8,7 +8,7 @@ import {
 } from '@aztec/stdlib/p2p';
 import { makeHeader } from '@aztec/stdlib/testing';
 
-import { type LocalAccount, generatePrivateKey, privateKeyToAccount } from '@spalladino/viem/accounts';
+import { type LocalAccount, generatePrivateKey, privateKeyToAccount } from 'viem/accounts';
 
 /** Generate Account
  *

--- a/yarn-project/p2p/src/services/peer-manager/peer_manager.test.ts
+++ b/yarn-project/p2p/src/services/peer-manager/peer_manager.test.ts
@@ -20,8 +20,8 @@ import type { PeerId } from '@libp2p/interface';
 import { peerIdFromString } from '@libp2p/peer-id';
 import { createSecp256k1PeerId } from '@libp2p/peer-id-factory';
 import { multiaddr } from '@multiformats/multiaddr';
-import { generatePrivateKey } from '@spalladino/viem/accounts';
 import { type MockProxy, mock } from 'jest-mock-extended';
+import { generatePrivateKey } from 'viem/accounts';
 
 import { type P2PConfig, getP2PDefaultConfig } from '../../config.js';
 import { PeerEvent } from '../../types/index.js';

--- a/yarn-project/p2p/src/test-helpers/generate-peer-id-private-keys.ts
+++ b/yarn-project/p2p/src/test-helpers/generate-peer-id-private-keys.ts
@@ -1,4 +1,4 @@
-import { generatePrivateKey } from '@spalladino/viem/accounts';
+import { generatePrivateKey } from 'viem/accounts';
 
 /**
  * Generate a list of peer id private keys

--- a/yarn-project/prover-node/package.json
+++ b/yarn-project/prover-node/package.json
@@ -77,9 +77,9 @@
     "@aztec/stdlib": "workspace:^",
     "@aztec/telemetry-client": "workspace:^",
     "@aztec/world-state": "workspace:^",
-    "@spalladino/viem": "2.38.2-eip7594.0",
     "source-map-support": "^0.5.21",
-    "tslib": "^2.4.0"
+    "tslib": "^2.4.0",
+    "viem": "npm:@spalladino/viem@2.38.2-eip7594.0"
   },
   "devDependencies": {
     "@jest/globals": "^30.0.0",

--- a/yarn-project/prover-node/src/config.test.ts
+++ b/yarn-project/prover-node/src/config.test.ts
@@ -1,7 +1,7 @@
 import { EthAddress } from '@aztec/foundation/eth-address';
 import type { EthPrivateKey } from '@aztec/node-keystore';
 
-import { generatePrivateKey, privateKeyToAddress } from '@spalladino/viem/accounts';
+import { generatePrivateKey, privateKeyToAddress } from 'viem/accounts';
 
 import { type ProverNodeConfig, createKeyStoreForProver } from './config.js';
 

--- a/yarn-project/prover-node/src/factory.ts
+++ b/yarn-project/prover-node/src/factory.ts
@@ -20,7 +20,7 @@ import { getPackageVersion } from '@aztec/stdlib/update-checker';
 import { L1Metrics, type TelemetryClient, getTelemetryClient } from '@aztec/telemetry-client';
 import { createWorldStateSynchronizer } from '@aztec/world-state';
 
-import { createPublicClient, fallback, http } from '@spalladino/viem';
+import { createPublicClient, fallback, http } from 'viem';
 
 import { type ProverNodeConfig, createKeyStoreForProver } from './config.js';
 import { EpochMonitor } from './monitors/epoch-monitor.js';

--- a/yarn-project/prover-node/src/metrics.ts
+++ b/yarn-project/prover-node/src/metrics.ts
@@ -16,7 +16,7 @@ import {
   ValueType,
 } from '@aztec/telemetry-client';
 
-import { formatEther, formatUnits } from '@spalladino/viem';
+import { formatEther, formatUnits } from 'viem';
 
 export class ProverNodeJobMetrics {
   proverEpochExecutionDuration: Histogram;

--- a/yarn-project/prover-node/src/prover-node-publisher.ts
+++ b/yarn-project/prover-node/src/prover-node-publisher.ts
@@ -16,8 +16,8 @@ import type { FeeRecipient, RootRollupPublicInputs } from '@aztec/stdlib/rollup'
 import type { L1PublishProofStats } from '@aztec/stdlib/stats';
 import { type TelemetryClient, getTelemetryClient } from '@aztec/telemetry-client';
 
-import { type Hex, type TransactionReceipt, encodeFunctionData } from '@spalladino/viem';
 import { inspect } from 'util';
+import { type Hex, type TransactionReceipt, encodeFunctionData } from 'viem';
 
 import { ProverNodePublisherMetrics } from './metrics.js';
 

--- a/yarn-project/pxe/package.json
+++ b/yarn-project/pxe/package.json
@@ -76,13 +76,13 @@
     "@aztec/protocol-contracts": "workspace:^",
     "@aztec/simulator": "workspace:^",
     "@aztec/stdlib": "workspace:^",
-    "@spalladino/viem": "2.38.2-eip7594.0",
     "json-stringify-deterministic": "1.0.12",
     "koa": "^2.16.1",
     "koa-router": "^13.1.1",
     "lodash.omit": "^4.5.0",
     "sha3": "^2.1.4",
-    "tslib": "^2.4.0"
+    "tslib": "^2.4.0",
+    "viem": "npm:@spalladino/viem@2.38.2-eip7594.0"
   },
   "devDependencies": {
     "@aztec/merkle-tree": "workspace:^",

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution.test.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution.test.ts
@@ -62,8 +62,8 @@ import {
 } from '@aztec/stdlib/tx';
 
 import { jest } from '@jest/globals';
-import { toFunctionSelector } from '@spalladino/viem';
 import { Matcher, type MatcherCreator, type MockProxy, mock } from 'jest-mock-extended';
+import { toFunctionSelector } from 'viem';
 
 import { ContractFunctionSimulator } from '../contract_function_simulator.js';
 import type { ExecutionDataProvider } from '../execution_data_provider.js';

--- a/yarn-project/sequencer-client/package.json
+++ b/yarn-project/sequencer-client/package.json
@@ -50,9 +50,9 @@
     "@aztec/telemetry-client": "workspace:^",
     "@aztec/validator-client": "workspace:^",
     "@aztec/world-state": "workspace:^",
-    "@spalladino/viem": "2.38.2-eip7594.0",
     "lodash.chunk": "^4.2.0",
-    "tslib": "^2.4.0"
+    "tslib": "^2.4.0",
+    "viem": "npm:@spalladino/viem@2.38.2-eip7594.0"
   },
   "devDependencies": {
     "@aztec/archiver": "workspace:^",

--- a/yarn-project/sequencer-client/src/global_variable_builder/global_builder.ts
+++ b/yarn-project/sequencer-client/src/global_variable_builder/global_builder.ts
@@ -13,7 +13,7 @@ import { GasFees } from '@aztec/stdlib/gas';
 import type { GlobalVariableBuilder as GlobalVariableBuilderInterface } from '@aztec/stdlib/tx';
 import { GlobalVariables } from '@aztec/stdlib/tx';
 
-import { createPublicClient, fallback, http } from '@spalladino/viem';
+import { createPublicClient, fallback, http } from 'viem';
 
 /**
  * Simple global variables builder.

--- a/yarn-project/sequencer-client/src/publisher/sequencer-publisher-metrics.ts
+++ b/yarn-project/sequencer-client/src/publisher/sequencer-publisher-metrics.ts
@@ -10,7 +10,7 @@ import {
   ValueType,
 } from '@aztec/telemetry-client';
 
-import { formatEther } from '@spalladino/viem/utils';
+import { formatEther } from 'viem/utils';
 
 export type L1TxType = 'process';
 

--- a/yarn-project/sequencer-client/src/publisher/sequencer-publisher.test.ts
+++ b/yarn-project/sequencer-client/src/publisher/sequencer-publisher.test.ts
@@ -24,17 +24,17 @@ import type { SlashFactoryContract } from '@aztec/stdlib/l1-contracts';
 import type { ProposedBlockHeader } from '@aztec/stdlib/tx';
 
 import { jest } from '@jest/globals';
+import express, { json } from 'express';
+import type { Server } from 'http';
+import { type MockProxy, mock } from 'jest-mock-extended';
 import {
   type GetTransactionReceiptReturnType,
   type PrivateKeyAccount,
   type TransactionReceipt,
   encodeFunctionData,
   toHex,
-} from '@spalladino/viem';
-import { privateKeyToAccount } from '@spalladino/viem/accounts';
-import express, { json } from 'express';
-import type { Server } from 'http';
-import { type MockProxy, mock } from 'jest-mock-extended';
+} from 'viem';
+import { privateKeyToAccount } from 'viem/accounts';
 
 import type { PublisherConfig, TxSenderConfig } from './config.js';
 import type { SequencerPublisherMetrics } from './sequencer-publisher-metrics.js';

--- a/yarn-project/sequencer-client/src/publisher/sequencer-publisher.ts
+++ b/yarn-project/sequencer-client/src/publisher/sequencer-publisher.ts
@@ -39,7 +39,7 @@ import type { L1PublishBlockStats } from '@aztec/stdlib/stats';
 import { type ProposedBlockHeader, StateReference } from '@aztec/stdlib/tx';
 import { type TelemetryClient, getTelemetryClient } from '@aztec/telemetry-client';
 
-import { type TransactionReceipt, type TypedDataDefinition, encodeFunctionData, toHex } from '@spalladino/viem';
+import { type TransactionReceipt, type TypedDataDefinition, encodeFunctionData, toHex } from 'viem';
 
 import type { PublisherConfig, TxSenderConfig } from './config.js';
 import { SequencerPublisherMetrics } from './sequencer-publisher-metrics.js';

--- a/yarn-project/sequencer-client/src/sequencer/metrics.ts
+++ b/yarn-project/sequencer-client/src/sequencer/metrics.ts
@@ -12,7 +12,7 @@ import {
   ValueType,
 } from '@aztec/telemetry-client';
 
-import { type Hex, formatUnits } from '@spalladino/viem';
+import { type Hex, formatUnits } from 'viem';
 
 import type { SequencerState } from './utils.js';
 

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.ts
@@ -37,8 +37,8 @@ import { AttestationTimeoutError } from '@aztec/stdlib/validators';
 import { Attributes, type TelemetryClient, type Tracer, getTelemetryClient, trackSpan } from '@aztec/telemetry-client';
 import type { ValidatorClient } from '@aztec/validator-client';
 
-import type { TypedDataDefinition } from '@spalladino/viem';
 import EventEmitter from 'node:events';
+import type { TypedDataDefinition } from 'viem';
 
 import type { GlobalVariableBuilder } from '../global_variable_builder/global_builder.js';
 import type { SequencerPublisherFactory } from '../publisher/sequencer-publisher-factory.js';

--- a/yarn-project/simulator/package.json
+++ b/yarn-project/simulator/package.json
@@ -83,7 +83,6 @@
     "@aztec/noir-contracts.js": "workspace:^",
     "@aztec/noir-test-contracts.js": "workspace:^",
     "@jest/globals": "^30.0.0",
-    "@spalladino/viem": "2.38.2-eip7594.0",
     "@types/jest": "^30.0.0",
     "@types/lodash.clonedeep": "^4.5.7",
     "@types/lodash.merge": "^4.6.9",
@@ -91,7 +90,8 @@
     "jest": "^30.0.0",
     "jest-mock-extended": "^4.0.0",
     "ts-node": "^10.9.1",
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3",
+    "viem": "npm:@spalladino/viem@2.38.2-eip7594.0"
   },
   "files": [
     "dest",

--- a/yarn-project/slasher/package.json
+++ b/yarn-project/slasher/package.json
@@ -61,9 +61,9 @@
     "@aztec/l1-artifacts": "workspace:^",
     "@aztec/stdlib": "workspace:^",
     "@aztec/telemetry-client": "workspace:^",
-    "@spalladino/viem": "2.38.2-eip7594.0",
     "source-map-support": "^0.5.21",
     "tslib": "^2.4.0",
+    "viem": "npm:@spalladino/viem@2.38.2-eip7594.0",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/yarn-project/slasher/src/tally_slasher_client.ts
+++ b/yarn-project/slasher/src/tally_slasher_client.ts
@@ -18,7 +18,7 @@ import {
   getSlashConsensusVotesFromOffenses,
 } from '@aztec/stdlib/slashing';
 
-import type { Hex } from '@spalladino/viem';
+import type { Hex } from 'viem';
 
 import {
   SlashOffensesCollector,

--- a/yarn-project/slasher/src/watchers/epoch_prune_watcher.test.ts
+++ b/yarn-project/slasher/src/watchers/epoch_prune_watcher.test.ts
@@ -14,9 +14,9 @@ import { OffenseType } from '@aztec/stdlib/slashing';
 import { Tx } from '@aztec/stdlib/tx';
 
 import { jest } from '@jest/globals';
-import type { Hex } from '@spalladino/viem';
 import { type MockProxy, mock } from 'jest-mock-extended';
 import EventEmitter from 'node:events';
+import type { Hex } from 'viem';
 
 import { WANT_TO_SLASH_EVENT, type WantToSlashArgs } from '../watcher.js';
 import { EpochPruneWatcher } from './epoch_prune_watcher.js';

--- a/yarn-project/stdlib/package.json
+++ b/yarn-project/stdlib/package.json
@@ -78,7 +78,6 @@
     "@aztec/l1-artifacts": "workspace:^",
     "@aztec/noir-noirc_abi": "portal:../../noir/packages/noirc_abi",
     "@google-cloud/storage": "^7.15.0",
-    "@spalladino/viem": "2.38.2-eip7594.0",
     "axios": "^1.12.0",
     "json-stringify-deterministic": "1.0.12",
     "lodash.chunk": "^4.2.0",
@@ -88,6 +87,7 @@
     "msgpackr": "^1.11.2",
     "pako": "^2.1.0",
     "tslib": "^2.4.0",
+    "viem": "npm:@spalladino/viem@2.38.2-eip7594.0",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/yarn-project/stdlib/src/block/proposal/attestations_and_signers.ts
+++ b/yarn-project/stdlib/src/block/proposal/attestations_and_signers.ts
@@ -1,7 +1,7 @@
 import type { ViemCommitteeAttestations } from '@aztec/ethereum';
 import { hexToBuffer } from '@aztec/foundation/string';
 
-import { encodeAbiParameters, parseAbiParameters } from '@spalladino/viem';
+import { encodeAbiParameters, parseAbiParameters } from 'viem';
 import { z } from 'zod';
 
 import type { Signable, SignatureDomainSeparator } from '../../p2p/signature_utils.js';

--- a/yarn-project/stdlib/src/l1-contracts/slash_factory.test.ts
+++ b/yarn-project/stdlib/src/l1-contracts/slash_factory.test.ts
@@ -12,10 +12,10 @@ import { Fr } from '@aztec/foundation/fields';
 import { type Logger, createLogger } from '@aztec/foundation/log';
 import { SlashFactoryAbi } from '@aztec/l1-artifacts/SlashFactoryAbi';
 
-import { type TransactionReceipt, decodeFunctionData } from '@spalladino/viem';
-import { type PrivateKeyAccount, privateKeyToAccount } from '@spalladino/viem/accounts';
-import { foundry } from '@spalladino/viem/chains';
 import type { Anvil } from '@viem/anvil';
+import { type TransactionReceipt, decodeFunctionData } from 'viem';
+import { type PrivateKeyAccount, privateKeyToAccount } from 'viem/accounts';
+import { foundry } from 'viem/chains';
 
 import type { L1RollupConstants } from '../epoch-helpers/index.js';
 import { OffenseType, type ValidatorSlash, type ValidatorSlashOffense } from '../slashing/index.js';

--- a/yarn-project/stdlib/src/l1-contracts/slash_factory.ts
+++ b/yarn-project/stdlib/src/l1-contracts/slash_factory.ts
@@ -4,7 +4,7 @@ import { EthAddress } from '@aztec/foundation/eth-address';
 import { createLogger } from '@aztec/foundation/log';
 import { SlashFactoryAbi } from '@aztec/l1-artifacts/SlashFactoryAbi';
 
-import { type GetContractReturnType, type Hex, type Log, encodeFunctionData, getContract } from '@spalladino/viem';
+import { type GetContractReturnType, type Hex, type Log, encodeFunctionData, getContract } from 'viem';
 
 import type { L1RollupConstants } from '../epoch-helpers/index.js';
 import {

--- a/yarn-project/stdlib/src/p2p/consensus_payload.ts
+++ b/yarn-project/stdlib/src/p2p/consensus_payload.ts
@@ -4,7 +4,7 @@ import { BufferReader, serializeToBuffer } from '@aztec/foundation/serialize';
 import { hexToBuffer } from '@aztec/foundation/string';
 import type { FieldsOf } from '@aztec/foundation/types';
 
-import { encodeAbiParameters, parseAbiParameters } from '@spalladino/viem';
+import { encodeAbiParameters, parseAbiParameters } from 'viem';
 import { z } from 'zod';
 
 import type { L2Block } from '../block/l2_block.js';

--- a/yarn-project/telemetry-client/package.json
+++ b/yarn-project/telemetry-client/package.json
@@ -41,8 +41,8 @@
     "@opentelemetry/sdk-metrics": "^1.28.0",
     "@opentelemetry/sdk-trace-node": "^1.28.0",
     "@opentelemetry/semantic-conventions": "^1.28.0",
-    "@spalladino/viem": "2.38.2-eip7594.0",
-    "prom-client": "^15.1.3"
+    "prom-client": "^15.1.3",
+    "viem": "npm:@spalladino/viem@2.38.2-eip7594.0"
   },
   "devDependencies": {
     "@jest/globals": "^30.0.0",

--- a/yarn-project/telemetry-client/src/l1_metrics.ts
+++ b/yarn-project/telemetry-client/src/l1_metrics.ts
@@ -1,13 +1,6 @@
 import type { EthAddress } from '@aztec/foundation/eth-address';
 
-import {
-  type Chain,
-  type FallbackTransport,
-  type Hex,
-  type HttpTransport,
-  type PublicClient,
-  formatEther,
-} from '@spalladino/viem';
+import { type Chain, type FallbackTransport, type Hex, type HttpTransport, type PublicClient, formatEther } from 'viem';
 
 import { L1_SENDER } from './attributes.js';
 import { L1_BALANCE_ETH, L1_BLOB_BASE_FEE_WEI, L1_BLOCK_HEIGHT, L1_GAS_PRICE_WEI } from './metrics.js';

--- a/yarn-project/validator-client/package.json
+++ b/yarn-project/validator-client/package.json
@@ -74,10 +74,10 @@
     "@aztec/slasher": "workspace:^",
     "@aztec/stdlib": "workspace:^",
     "@aztec/telemetry-client": "workspace:^",
-    "@spalladino/viem": "2.38.2-eip7594.0",
     "koa": "^2.16.1",
     "koa-router": "^13.1.1",
-    "tslib": "^2.4.0"
+    "tslib": "^2.4.0",
+    "viem": "npm:@spalladino/viem@2.38.2-eip7594.0"
   },
   "devDependencies": {
     "@jest/globals": "^30.0.0",

--- a/yarn-project/validator-client/src/duties/validation_service.test.ts
+++ b/yarn-project/validator-client/src/duties/validation_service.test.ts
@@ -4,7 +4,7 @@ import { EthAddress } from '@aztec/foundation/eth-address';
 import { makeBlockProposal } from '@aztec/stdlib/testing';
 import { Tx } from '@aztec/stdlib/tx';
 
-import { generatePrivateKey } from '@spalladino/viem/accounts';
+import { generatePrivateKey } from 'viem/accounts';
 
 import { LocalKeyStore } from '../key_store/local_key_store.js';
 import { ValidationService } from './validation_service.js';

--- a/yarn-project/validator-client/src/key_store/interface.ts
+++ b/yarn-project/validator-client/src/key_store/interface.ts
@@ -4,7 +4,7 @@ import type { Signature } from '@aztec/foundation/eth-signature';
 import type { EthRemoteSignerConfig } from '@aztec/node-keystore';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
 
-import type { TypedDataDefinition } from '@spalladino/viem';
+import type { TypedDataDefinition } from 'viem';
 
 /** Key Store
  *

--- a/yarn-project/validator-client/src/key_store/local_key_store.ts
+++ b/yarn-project/validator-client/src/key_store/local_key_store.ts
@@ -3,7 +3,7 @@ import { Secp256k1Signer } from '@aztec/foundation/crypto';
 import type { EthAddress } from '@aztec/foundation/eth-address';
 import type { Signature } from '@aztec/foundation/eth-signature';
 
-import { type TypedDataDefinition, hashTypedData } from '@spalladino/viem';
+import { type TypedDataDefinition, hashTypedData } from 'viem';
 
 import type { ValidatorKeyStore } from './interface.js';
 

--- a/yarn-project/validator-client/src/key_store/node_keystore_adapter.test.ts
+++ b/yarn-project/validator-client/src/key_store/node_keystore_adapter.test.ts
@@ -3,7 +3,7 @@ import { EthAddress } from '@aztec/foundation/eth-address';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
 
 import { beforeEach, describe, expect, it } from '@jest/globals';
-import type { TypedDataDefinition } from '@spalladino/viem';
+import type { TypedDataDefinition } from 'viem';
 
 import { NodeKeystoreAdapter } from './node_keystore_adapter.js';
 

--- a/yarn-project/validator-client/src/key_store/node_keystore_adapter.ts
+++ b/yarn-project/validator-client/src/key_store/node_keystore_adapter.ts
@@ -7,8 +7,8 @@ import type { EthRemoteSignerConfig } from '@aztec/node-keystore';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import { InvalidValidatorPrivateKeyError } from '@aztec/stdlib/validators';
 
-import type { TypedDataDefinition } from '@spalladino/viem';
-import { privateKeyToAccount } from '@spalladino/viem/accounts';
+import type { TypedDataDefinition } from 'viem';
+import { privateKeyToAccount } from 'viem/accounts';
 
 import type { ExtendedValidatorKeyStore } from './interface.js';
 

--- a/yarn-project/validator-client/src/key_store/web3signer_key_store.integration.test.ts
+++ b/yarn-project/validator-client/src/key_store/web3signer_key_store.integration.test.ts
@@ -4,7 +4,7 @@ import { EthAddress } from '@aztec/foundation/eth-address';
 import { Signature } from '@aztec/foundation/eth-signature';
 
 import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
-import { type TypedDataDefinition, hashTypedData } from '@spalladino/viem';
+import { type TypedDataDefinition, hashTypedData } from 'viem';
 
 import { LocalKeyStore } from './local_key_store.js';
 import { Web3SignerKeyStore } from './web3signer_key_store.js';

--- a/yarn-project/validator-client/src/key_store/web3signer_key_store.ts
+++ b/yarn-project/validator-client/src/key_store/web3signer_key_store.ts
@@ -2,7 +2,7 @@ import type { Buffer32 } from '@aztec/foundation/buffer';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { Signature } from '@aztec/foundation/eth-signature';
 
-import type { TypedDataDefinition } from '@spalladino/viem';
+import type { TypedDataDefinition } from 'viem';
 
 import type { ValidatorKeyStore } from './interface.js';
 

--- a/yarn-project/validator-client/src/validator.test.ts
+++ b/yarn-project/validator-client/src/validator.test.ts
@@ -31,8 +31,8 @@ import { BlockHeader, ContentCommitment, type Tx, TxHash } from '@aztec/stdlib/t
 import { AttestationTimeoutError } from '@aztec/stdlib/validators';
 
 import { describe, expect, it, jest } from '@jest/globals';
-import { type PrivateKeyAccount, generatePrivateKey, privateKeyToAccount } from '@spalladino/viem/accounts';
 import { type MockProxy, mock } from 'jest-mock-extended';
+import { type PrivateKeyAccount, generatePrivateKey, privateKeyToAccount } from 'viem/accounts';
 
 import { type ValidatorClientConfig, validatorClientConfigMappings } from './config.js';
 import { ValidatorClient } from './validator.js';

--- a/yarn-project/validator-client/src/validator.ts
+++ b/yarn-project/validator-client/src/validator.ts
@@ -25,8 +25,8 @@ import type { ProposedBlockHeader, StateReference, Tx } from '@aztec/stdlib/tx';
 import { AttestationTimeoutError } from '@aztec/stdlib/validators';
 import { type TelemetryClient, type Tracer, getTelemetryClient } from '@aztec/telemetry-client';
 
-import type { TypedDataDefinition } from '@spalladino/viem';
 import { EventEmitter } from 'events';
+import type { TypedDataDefinition } from 'viem';
 
 import { BlockProposalHandler, type BlockProposalValidationFailureReason } from './block_proposal_handler.js';
 import type { ValidatorClientConfig } from './config.js';

--- a/yarn-project/yarn.lock
+++ b/yarn-project/yarn.lock
@@ -752,7 +752,6 @@ __metadata:
     "@aztec/stdlib": "workspace:^"
     "@aztec/telemetry-client": "workspace:^"
     "@jest/globals": "npm:^30.0.0"
-    "@spalladino/viem": "npm:2.38.2-eip7594.0"
     "@types/jest": "npm:^30.0.0"
     "@types/lodash.groupby": "npm:^4.6.9"
     "@types/lodash.omit": "npm:^4.5.7"
@@ -766,6 +765,7 @@ __metadata:
     tsc-watch: "npm:^6.0.0"
     tslib: "npm:^2.5.0"
     typescript: "npm:^5.3.3"
+    viem: "npm:@spalladino/viem@2.38.2-eip7594.0"
   languageName: unknown
   linkType: soft
 
@@ -778,7 +778,6 @@ __metadata:
     "@aztec/l1-artifacts": "workspace:^"
     "@jest/globals": "npm:^30.0.0"
     "@koa/cors": "npm:^5.0.0"
-    "@spalladino/viem": "npm:2.38.2-eip7594.0"
     "@types/jest": "npm:^30.0.0"
     "@types/koa-bodyparser": "npm:^4.3.12"
     "@types/node": "npm:^22.15.17"
@@ -788,6 +787,7 @@ __metadata:
     koa-router: "npm:^13.1.1"
     ts-node: "npm:^10.9.1"
     typescript: "npm:^5.3.3"
+    viem: "npm:@spalladino/viem@2.38.2-eip7594.0"
     zod: "npm:^3.23.8"
   bin:
     aztec-faucet: ./dest/bin/index.js
@@ -822,7 +822,6 @@ __metadata:
     "@aztec/validator-client": "workspace:^"
     "@aztec/world-state": "workspace:^"
     "@jest/globals": "npm:^30.0.0"
-    "@spalladino/viem": "npm:2.38.2-eip7594.0"
     "@types/jest": "npm:^30.0.0"
     "@types/node": "npm:^22.15.17"
     jest: "npm:^30.0.0"
@@ -832,6 +831,7 @@ __metadata:
     ts-node: "npm:^10.9.1"
     tslib: "npm:^2.4.0"
     typescript: "npm:^5.3.3"
+    viem: "npm:@spalladino/viem@2.38.2-eip7594.0"
   bin:
     aztec-node: ./dest/bin/index.js
   languageName: unknown
@@ -849,7 +849,6 @@ __metadata:
     "@aztec/protocol-contracts": "workspace:^"
     "@aztec/stdlib": "workspace:^"
     "@jest/globals": "npm:^30.0.0"
-    "@spalladino/viem": "npm:2.38.2-eip7594.0"
     "@types/jest": "npm:^30.0.0"
     "@types/node": "npm:^22.15.17"
     axios: "npm:^1.12.0"
@@ -865,6 +864,7 @@ __metadata:
     tslib: "npm:^2.4.0"
     typescript: "npm:^5.3.3"
     util: "npm:^0.12.5"
+    viem: "npm:@spalladino/viem@2.38.2-eip7594.0"
   languageName: unknown
   linkType: soft
 
@@ -923,7 +923,6 @@ __metadata:
     "@aztec/txe": "workspace:^"
     "@aztec/world-state": "workspace:^"
     "@jest/globals": "npm:^30.0.0"
-    "@spalladino/viem": "npm:2.38.2-eip7594.0"
     "@types/chalk": "npm:^2.2.0"
     "@types/jest": "npm:^30.0.0"
     "@types/koa": "npm:^2.15.0"
@@ -935,6 +934,7 @@ __metadata:
     koa-router: "npm:^13.1.1"
     ts-node: "npm:^10.9.1"
     typescript: "npm:^5.3.3"
+    viem: "npm:@spalladino/viem@2.38.2-eip7594.0"
   bin:
     aztec: ./dest/bin/index.js
   languageName: unknown
@@ -960,7 +960,6 @@ __metadata:
     "@aztec/telemetry-client": "workspace:^"
     "@aztec/world-state": "workspace:^"
     "@jest/globals": "npm:^30.0.0"
-    "@spalladino/viem": "npm:2.38.2-eip7594.0"
     "@types/jest": "npm:^30.0.0"
     "@types/node": "npm:^22.15.17"
     "@types/source-map-support": "npm:^0.5.10"
@@ -972,6 +971,7 @@ __metadata:
     ts-node: "npm:^10.9.1"
     tslib: "npm:^2.4.0"
     typescript: "npm:^5.3.3"
+    viem: "npm:@spalladino/viem@2.38.2-eip7594.0"
   bin:
     bb-cli: ./dest/bb/index.js
   languageName: unknown
@@ -1022,7 +1022,6 @@ __metadata:
     "@aztec/stdlib": "workspace:^"
     "@aztec/telemetry-client": "workspace:*"
     "@jest/globals": "npm:^30.0.0"
-    "@spalladino/viem": "npm:2.38.2-eip7594.0"
     "@types/jest": "npm:^30.0.0"
     "@types/node": "npm:^22.15.17"
     "@types/source-map-support": "npm:^0.5.10"
@@ -1036,6 +1035,7 @@ __metadata:
     ts-node: "npm:^10.9.1"
     tslib: "npm:^2.4.0"
     typescript: "npm:^5.3.3"
+    viem: "npm:@spalladino/viem@2.38.2-eip7594.0"
     zod: "npm:^3.23.8"
   bin:
     blob-sink-client: ./dest/client/bin/index.js
@@ -1141,7 +1141,6 @@ __metadata:
     "@iarna/toml": "npm:^2.2.5"
     "@jest/globals": "npm:^30.0.0"
     "@libp2p/peer-id-factory": "npm:^3.0.4"
-    "@spalladino/viem": "npm:2.38.2-eip7594.0"
     "@types/jest": "npm:^30.0.0"
     "@types/lodash.chunk": "npm:^4.2.9"
     "@types/lodash.groupby": "npm:^4.6.9"
@@ -1160,6 +1159,7 @@ __metadata:
     ts-node: "npm:^10.9.1"
     tslib: "npm:^2.4.0"
     typescript: "npm:^5.3.3"
+    viem: "npm:@spalladino/viem@2.38.2-eip7594.0"
   peerDependencies:
     "@aztec/accounts": "workspace:^"
     "@aztec/bb-prover": "workspace:^"
@@ -1240,7 +1240,6 @@ __metadata:
     "@iarna/toml": "npm:^2.2.5"
     "@jest/globals": "npm:^30.0.0"
     "@noble/curves": "npm:=1.0.0"
-    "@spalladino/viem": "npm:2.38.2-eip7594.0"
     "@swc/core": "npm:^1.4.11"
     "@swc/jest": "npm:^0.2.36"
     "@types/fs-extra": "npm:^11.0.2"
@@ -1278,6 +1277,7 @@ __metadata:
     tslib: "npm:^2.4.0"
     typescript: "npm:^5.3.3"
     util: "npm:^0.12.5"
+    viem: "npm:@spalladino/viem@2.38.2-eip7594.0"
     zod: "npm:^3.23.8"
   languageName: unknown
   linkType: soft
@@ -1308,7 +1308,6 @@ __metadata:
     "@aztec/l1-artifacts": "workspace:^"
     "@aztec/stdlib": "workspace:*"
     "@jest/globals": "npm:^30.0.0"
-    "@spalladino/viem": "npm:2.38.2-eip7594.0"
     "@types/jest": "npm:^30.0.0"
     "@types/node": "npm:^22.15.17"
     "@viem/anvil": "npm:^0.0.10"
@@ -1319,6 +1318,7 @@ __metadata:
     ts-node: "npm:^10.9.1"
     tslib: "npm:^2.4.0"
     typescript: "npm:^5.3.3"
+    viem: "npm:@spalladino/viem@2.38.2-eip7594.0"
     zod: "npm:^3.23.8"
   languageName: unknown
   linkType: soft
@@ -1333,7 +1333,6 @@ __metadata:
     "@aztec/l1-artifacts": "workspace:^"
     "@jest/globals": "npm:^30.0.0"
     "@noble/curves": "npm:=1.7.0"
-    "@spalladino/viem": "npm:2.38.2-eip7594.0"
     "@types/jest": "npm:^30.0.0"
     "@types/lodash.pickby": "npm:^4"
     "@types/node": "npm:^22.15.17"
@@ -1348,6 +1347,7 @@ __metadata:
     ts-node: "npm:^10.9.1"
     tslib: "npm:^2.4.0"
     typescript: "npm:^5.3.3"
+    viem: "npm:@spalladino/viem@2.38.2-eip7594.0"
     zod: "npm:^3.23.8"
   languageName: unknown
   linkType: soft
@@ -1361,7 +1361,6 @@ __metadata:
     "@koa/cors": "npm:^5.0.0"
     "@libp2p/interface": "npm:1.3.1"
     "@noble/curves": "npm:=1.7.0"
-    "@spalladino/viem": "npm:2.38.2-eip7594.0"
     "@types/detect-node": "npm:^2.0.0"
     "@types/jest": "npm:^30.0.0"
     "@types/koa": "npm:^2.15.0"
@@ -1405,6 +1404,7 @@ __metadata:
     typescript: "npm:^5.3.3"
     typescript-eslint: "npm:^8.32.1"
     undici: "npm:^5.28.5"
+    viem: "npm:@spalladino/viem@2.38.2-eip7594.0"
     zod: "npm:^3.23.8"
   languageName: unknown
   linkType: soft
@@ -1563,13 +1563,13 @@ __metadata:
     "@aztec/stdlib": "workspace:^"
     "@ethersproject/wallet": "npm:^5.7.0"
     "@jest/globals": "npm:^30.0.0"
-    "@spalladino/viem": "npm:2.38.2-eip7594.0"
     "@types/jest": "npm:^30.0.0"
     "@types/node": "npm:^22.15.17"
     jest: "npm:^30.0.0"
     ts-node: "npm:^10.9.1"
     tslib: "npm:^2.4.0"
     typescript: "npm:^5.3.3"
+    viem: "npm:@spalladino/viem@2.38.2-eip7594.0"
     zod: "npm:^3.23.8"
   languageName: unknown
   linkType: soft
@@ -1765,7 +1765,6 @@ __metadata:
     "@libp2p/prometheus-metrics": "npm:^4.2.4"
     "@libp2p/tcp": "npm:9.0.24"
     "@multiformats/multiaddr": "npm:12.1.14"
-    "@spalladino/viem": "npm:2.38.2-eip7594.0"
     "@types/jest": "npm:^30.0.0"
     "@types/node": "npm:^22.15.17"
     get-port: "npm:^7.1.0"
@@ -1783,6 +1782,7 @@ __metadata:
     tslib: "npm:^2.4.0"
     typescript: "npm:^5.3.3"
     uint8arrays: "npm:^5.0.3"
+    viem: "npm:@spalladino/viem@2.38.2-eip7594.0"
     xxhash-wasm: "npm:^1.1.0"
   languageName: unknown
   linkType: soft
@@ -1873,7 +1873,6 @@ __metadata:
     "@aztec/telemetry-client": "workspace:^"
     "@aztec/world-state": "workspace:^"
     "@jest/globals": "npm:^30.0.0"
-    "@spalladino/viem": "npm:2.38.2-eip7594.0"
     "@types/jest": "npm:^30.0.0"
     "@types/node": "npm:^22.15.17"
     "@types/source-map-support": "npm:^0.5.10"
@@ -1883,6 +1882,7 @@ __metadata:
     ts-node: "npm:^10.9.1"
     tslib: "npm:^2.4.0"
     typescript: "npm:^5.3.3"
+    viem: "npm:@spalladino/viem@2.38.2-eip7594.0"
   languageName: unknown
   linkType: soft
 
@@ -1906,7 +1906,6 @@ __metadata:
     "@aztec/simulator": "workspace:^"
     "@aztec/stdlib": "workspace:^"
     "@jest/globals": "npm:^30.0.0"
-    "@spalladino/viem": "npm:2.38.2-eip7594.0"
     "@types/jest": "npm:^30.0.0"
     "@types/lodash.omit": "npm:^4.5.7"
     "@types/lodash.times": "npm:^4.3.9"
@@ -1922,6 +1921,7 @@ __metadata:
     ts-node: "npm:^10.9.1"
     tslib: "npm:^2.4.0"
     typescript: "npm:^5.3.3"
+    viem: "npm:@spalladino/viem@2.38.2-eip7594.0"
   bin:
     pxe: ./dest/bin/index.js
   languageName: unknown
@@ -1978,7 +1978,6 @@ __metadata:
     "@aztec/validator-client": "workspace:^"
     "@aztec/world-state": "workspace:^"
     "@jest/globals": "npm:^30.0.0"
-    "@spalladino/viem": "npm:2.38.2-eip7594.0"
     "@types/jest": "npm:^30.0.0"
     "@types/lodash.chunk": "npm:^4.2.7"
     "@types/lodash.pick": "npm:^4.4.7"
@@ -1993,6 +1992,7 @@ __metadata:
     ts-node: "npm:^10.9.1"
     tslib: "npm:^2.4.0"
     typescript: "npm:^5.3.3"
+    viem: "npm:@spalladino/viem@2.38.2-eip7594.0"
   languageName: unknown
   linkType: soft
 
@@ -2015,7 +2015,6 @@ __metadata:
     "@aztec/telemetry-client": "workspace:^"
     "@aztec/world-state": "workspace:^"
     "@jest/globals": "npm:^30.0.0"
-    "@spalladino/viem": "npm:2.38.2-eip7594.0"
     "@types/jest": "npm:^30.0.0"
     "@types/lodash.clonedeep": "npm:^4.5.7"
     "@types/lodash.merge": "npm:^4.6.9"
@@ -2027,6 +2026,7 @@ __metadata:
     ts-node: "npm:^10.9.1"
     tslib: "npm:^2.4.0"
     typescript: "npm:^5.3.3"
+    viem: "npm:@spalladino/viem@2.38.2-eip7594.0"
   languageName: unknown
   linkType: soft
 
@@ -2043,7 +2043,6 @@ __metadata:
     "@aztec/stdlib": "workspace:^"
     "@aztec/telemetry-client": "workspace:^"
     "@jest/globals": "npm:^30.0.0"
-    "@spalladino/viem": "npm:2.38.2-eip7594.0"
     "@types/jest": "npm:^30.0.0"
     "@types/node": "npm:^22.15.17"
     "@types/source-map-support": "npm:^0.5.10"
@@ -2053,6 +2052,7 @@ __metadata:
     ts-node: "npm:^10.9.1"
     tslib: "npm:^2.4.0"
     typescript: "npm:^5.3.3"
+    viem: "npm:@spalladino/viem@2.38.2-eip7594.0"
     zod: "npm:^3.23.8"
   languageName: unknown
   linkType: soft
@@ -2073,7 +2073,6 @@ __metadata:
     "@jest/expect": "npm:^30.0.0"
     "@jest/globals": "npm:^30.0.0"
     "@libp2p/interface": "npm:1.3.1"
-    "@spalladino/viem": "npm:2.38.2-eip7594.0"
     "@types/jest": "npm:^30.0.0"
     "@types/lodash.chunk": "npm:^4.2.9"
     "@types/lodash.isequal": "npm:^4.5.8"
@@ -2096,6 +2095,7 @@ __metadata:
     ts-node: "npm:^10.9.1"
     tslib: "npm:^2.4.0"
     typescript: "npm:^5.3.3"
+    viem: "npm:@spalladino/viem@2.38.2-eip7594.0"
     zod: "npm:^3.23.8"
   languageName: unknown
   linkType: soft
@@ -2121,13 +2121,13 @@ __metadata:
     "@opentelemetry/sdk-metrics": "npm:^1.28.0"
     "@opentelemetry/sdk-trace-node": "npm:^1.28.0"
     "@opentelemetry/semantic-conventions": "npm:^1.28.0"
-    "@spalladino/viem": "npm:2.38.2-eip7594.0"
     "@types/jest": "npm:^30.0.0"
     "@types/koa": "npm:^2.15.0"
     jest: "npm:^30.0.0"
     prom-client: "npm:^15.1.3"
     ts-node: "npm:^10.9.1"
     typescript: "npm:^5.3.3"
+    viem: "npm:@spalladino/viem@2.38.2-eip7594.0"
   languageName: unknown
   linkType: soft
 
@@ -2177,7 +2177,6 @@ __metadata:
     "@aztec/stdlib": "workspace:^"
     "@aztec/telemetry-client": "workspace:^"
     "@jest/globals": "npm:^30.0.0"
-    "@spalladino/viem": "npm:2.38.2-eip7594.0"
     "@types/jest": "npm:^30.0.0"
     "@types/node": "npm:^22.15.17"
     jest: "npm:^30.0.0"
@@ -2187,6 +2186,7 @@ __metadata:
     ts-node: "npm:^10.9.1"
     tslib: "npm:^2.4.0"
     typescript: "npm:^5.3.3"
+    viem: "npm:@spalladino/viem@2.38.2-eip7594.0"
   bin:
     validator-client: ./dest/bin/index.js
   languageName: unknown
@@ -6712,27 +6712,6 @@ __metadata:
     "@smithy/types": "npm:^4.5.0"
     tslib: "npm:^2.6.2"
   checksum: 10/019eecded24b9244675da3b956f572261e333d8d2b0d0555f9c85c893f2583f113bf0210521876e825943085d2d89e7e4fdb768cdc802627b9660d809734cce3
-  languageName: node
-  linkType: hard
-
-"@spalladino/viem@npm:2.38.2-eip7594.0":
-  version: 2.38.2-eip7594.0
-  resolution: "@spalladino/viem@npm:2.38.2-eip7594.0"
-  dependencies:
-    "@noble/curves": "npm:1.9.1"
-    "@noble/hashes": "npm:1.8.0"
-    "@scure/bip32": "npm:1.7.0"
-    "@scure/bip39": "npm:1.6.0"
-    abitype: "npm:1.1.0"
-    isows: "npm:1.0.7"
-    ox: "npm:0.9.6"
-    ws: "npm:8.18.3"
-  peerDependencies:
-    typescript: ">=5.0.4"
-  peerDependenciesMeta:
-    typescript:
-      optional: true
-  checksum: 10/ba922b7f02536d3aa86b0cafe4051f4decaec510894a0f133e0d92488f6edeff4f45c6fe84540719a95d4e988f67227acc2eb0349031e1a20ebbf8506e0574b2
   languageName: node
   linkType: hard
 
@@ -22228,6 +22207,27 @@ __metadata:
   version: 1.1.2
   resolution: "vary@npm:1.1.2"
   checksum: 10/31389debef15a480849b8331b220782230b9815a8e0dbb7b9a8369559aed2e9a7800cd904d4371ea74f4c3527db456dc8e7ac5befce5f0d289014dbdf47b2242
+  languageName: node
+  linkType: hard
+
+"viem@npm:@spalladino/viem@2.38.2-eip7594.0":
+  version: 2.38.2-eip7594.0
+  resolution: "@spalladino/viem@npm:2.38.2-eip7594.0"
+  dependencies:
+    "@noble/curves": "npm:1.9.1"
+    "@noble/hashes": "npm:1.8.0"
+    "@scure/bip32": "npm:1.7.0"
+    "@scure/bip39": "npm:1.6.0"
+    abitype: "npm:1.1.0"
+    isows: "npm:1.0.7"
+    ox: "npm:0.9.6"
+    ws: "npm:8.18.3"
+  peerDependencies:
+    typescript: ">=5.0.4"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10/ba922b7f02536d3aa86b0cafe4051f4decaec510894a0f133e0d92488f6edeff4f45c6fe84540719a95d4e988f67227acc2eb0349031e1a20ebbf8506e0574b2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
So we don't tweak every single import. This will make it easier to go back to the main viem package in the future.

Follows the same strategy as the forward port in #17753