### PR TITLE
fix(avm)!: Append-only tree reads

### DIFF
--- a/barretenberg/cpp/src/barretenberg/world_state/world_state.hpp
+++ b/barretenberg/cpp/src/barretenberg/world_state/world_state.hpp
@@ -482,6 +482,8 @@ std::optional<T> WorldState::get_leaf(const WorldStateRevision& revision,
         const auto& wrapper = std::get<TreeWithStore<FrTree>>(fork->_trees.at(tree_id));
         auto callback = [&signal, &leaf, &success, &error_msg](const TypedResponse<GetLeafResponse>& response) {
             if (!response.success || !response.inner.leaf.has_value()) {
+                // TODO(#17755): Permeate errors to TS? (native_world_state_instance.ts -> call() translates this to
+                // null)
                 success = false;
                 error_msg = response.message;
             } else {

--- a/barretenberg/cpp/src/barretenberg/world_state/world_state.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/world_state/world_state.test.cpp
@@ -55,7 +55,14 @@ void assert_leaf_status(
     const WorldState& ws, WorldStateRevision revision, MerkleTreeId tree_id, index_t leaf_index, bool exists)
 {
     std::optional<Leaf> leaf = ws.get_leaf<Leaf>(revision, tree_id, leaf_index);
-    EXPECT_EQ(leaf.has_value(), exists);
+    // TODO(#17755): Unwritten leaves at valid indices (index <= max_index) now return 0-value leaves with a message in
+    // the response from the tree, so leaf.has_value() is always true:
+    EXPECT_EQ(leaf.has_value(), true);
+    if (exists) {
+        EXPECT_NE(leaf.value(), fr::zero());
+    } else {
+        EXPECT_EQ(leaf.value(), fr::zero());
+    }
 }
 
 template <typename Leaf>

--- a/yarn-project/simulator/src/public/avm/avm_simulator.test.ts
+++ b/yarn-project/simulator/src/public/avm/avm_simulator.test.ts
@@ -80,9 +80,9 @@ import {
   mockGetBytecodeCommitment,
   mockGetContractClass,
   mockGetContractInstance,
-  mockL1ToL2MessageExists,
+  mockGetL1ToL2LeafValue,
+  mockGetNoteHash,
   mockNoteHashCount,
-  mockNoteHashExists,
   mockStorageRead,
   mockStorageReadWithMap,
   mockTraceFork,
@@ -626,7 +626,10 @@ describe('AVM simulator: transpiled Noir contracts', () => {
         const context = createContext(calldata);
         const bytecode = getAvmTestContractBytecode('note_hash_exists');
         if (mockAtLeafIndex !== undefined) {
-          mockNoteHashExists(treesDB, mockAtLeafIndex, value0);
+          mockGetNoteHash(treesDB, mockAtLeafIndex, value0);
+        } else {
+          // We still need to mock a response for the state manager to handle:
+          mockGetNoteHash(treesDB, leafIndex);
         }
 
         const results = await new AvmSimulator(context).executeBytecode(bytecode);
@@ -668,7 +671,10 @@ describe('AVM simulator: transpiled Noir contracts', () => {
         const context = createContext(calldata);
         const bytecode = getAvmTestContractBytecode('l1_to_l2_msg_exists');
         if (mockAtLeafIndex !== undefined) {
-          mockL1ToL2MessageExists(treesDB, mockAtLeafIndex, value0, /*valueAtOtherIndices=*/ value1);
+          mockGetL1ToL2LeafValue(treesDB, mockAtLeafIndex, value0);
+        } else {
+          // We still need to mock a response for the state manager to handle:
+          mockGetL1ToL2LeafValue(treesDB, leafIndex);
         }
 
         const results = await new AvmSimulator(context).executeBytecode(bytecode);

--- a/yarn-project/simulator/src/public/avm/opcodes/accrued_substate.test.ts
+++ b/yarn-project/simulator/src/public/avm/opcodes/accrued_substate.test.ts
@@ -17,12 +17,7 @@ import type { AvmContext } from '../avm_context.js';
 import { Field, Uint8, Uint32, Uint64 } from '../avm_memory_types.js';
 import { InstructionExecutionError, StaticCallAlterationError } from '../errors.js';
 import { initContext, initExecutionEnvironment, initPersistableStateManager } from '../fixtures/initializers.js';
-import {
-  mockCheckNullifierExists,
-  mockL1ToL2MessageExists,
-  mockNoteHashCount,
-  mockNoteHashExists,
-} from '../test_utils.js';
+import { mockCheckNullifierExists, mockGetL1ToL2LeafValue, mockGetNoteHash, mockNoteHashCount } from '../test_utils.js';
 import {
   EmitNoteHash,
   EmitNullifier,
@@ -94,7 +89,10 @@ describe('Accrued Substate', () => {
       const foundAtStr = existsElsewhere ? `at leafIndex=${mockAtLeafIndex} (exists at leafIndex=${leafIndex})` : '';
       it(`Should return ${expectFound} (and be traced) when noteHash ${existsStr} ${foundAtStr}`, async () => {
         if (mockAtLeafIndex !== undefined) {
-          mockNoteHashExists(treesDB, mockAtLeafIndex, value0);
+          mockGetNoteHash(treesDB, mockAtLeafIndex, value0);
+        } else {
+          // We still need to mock a response for the state manager to handle:
+          mockGetNoteHash(treesDB, leafIndex);
         }
 
         context.machineState.memory.set(value0Offset, new Field(value0)); // noteHash
@@ -260,7 +258,10 @@ describe('Accrued Substate', () => {
 
       it(`Should return ${expectFound} (and be traced) when l1 to l2 message ${existsStr} ${foundAtStr}`, async () => {
         if (mockAtLeafIndex !== undefined) {
-          mockL1ToL2MessageExists(treesDB, mockAtLeafIndex, value0, /*valueAtOtherIndices=*/ value1);
+          mockGetL1ToL2LeafValue(treesDB, mockAtLeafIndex, value0);
+        } else {
+          // We still need to mock a response for the state manager to handle:
+          mockGetL1ToL2LeafValue(treesDB, leafIndex);
         }
 
         context.machineState.memory.set(value0Offset, new Field(value0)); // msg hash

--- a/yarn-project/simulator/src/public/avm/test_utils.ts
+++ b/yarn-project/simulator/src/public/avm/test_utils.ts
@@ -27,13 +27,12 @@ export function mockStorageReadWithMap(worldStateDB: PublicTreesDB, mockedStorag
   );
 }
 
-export function mockNoteHashExists(worldStateDB: PublicTreesDB, _leafIndex: bigint, value?: Fr) {
+export function mockGetNoteHash(worldStateDB: PublicTreesDB, _leafIndex: bigint, value?: Fr) {
   (worldStateDB as jest.Mocked<PublicTreesDB>).getNoteHash.mockImplementation((index: bigint) => {
-    if (index == _leafIndex) {
+    if (index == _leafIndex && value) {
       return Promise.resolve(value);
     } else {
-      // This is ok for now since the traceing functions handle it
-      return Promise.resolve(undefined);
+      return Promise.resolve(Fr.ZERO);
     }
   });
 }
@@ -42,19 +41,12 @@ export function mockCheckNullifierExists(worldStateDB: PublicTreesDB, exists: bo
   (worldStateDB as jest.Mocked<PublicTreesDB>).checkNullifierExists.mockResolvedValue(exists);
 }
 
-export function mockL1ToL2MessageExists(
-  worldStateDB: PublicTreesDB,
-  leafIndex: bigint,
-  value: Fr,
-  valueAtOtherIndices?: Fr,
-) {
+export function mockGetL1ToL2LeafValue(worldStateDB: PublicTreesDB, leafIndex: bigint, value?: Fr) {
   (worldStateDB as jest.Mocked<PublicTreesDB>).getL1ToL2LeafValue.mockImplementation((index: bigint) => {
-    if (index == leafIndex) {
+    if (index == leafIndex && value) {
       return Promise.resolve(value);
     } else {
-      // any indices other than mockAtLeafIndex will return a different value
-      // (or undefined if no value is specified for other indices)
-      return Promise.resolve(valueAtOtherIndices!);
+      return Promise.resolve(Fr.ZERO!);
     }
   });
 }

--- a/yarn-project/simulator/src/public/side_effect_errors.ts
+++ b/yarn-project/simulator/src/public/side_effect_errors.ts
@@ -1,8 +1,10 @@
 import {
+  L1_TO_L2_MSG_TREE_LEAF_COUNT,
   MAX_L2_TO_L1_MSGS_PER_TX,
   MAX_NOTE_HASHES_PER_TX,
   MAX_NULLIFIERS_PER_TX,
   MAX_PUBLIC_CALLS_TO_UNIQUE_CONTRACT_CLASS_IDS,
+  NOTE_HASH_TREE_LEAF_COUNT,
 } from '@aztec/constants';
 
 import { CheckedPublicExecutionError } from './public_errors.js';
@@ -57,5 +59,38 @@ export class NullifierCollisionError extends SideEffectError {
   constructor(message: string) {
     super(`Nullifier collision: ${message}`);
     this.name = 'NullifierCollisionError';
+  }
+}
+
+/**
+ * Any error that can be thrown during side effect reads in public.
+ * Note: Thrown at state manager level and unknown by simulation, hence NOT considered
+ * CheckedPublicExecutionErrors. Currently only includes append-only tree reads.
+ */
+export abstract class SideEffectReadError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'SideEffectReadError';
+  }
+}
+
+export class IndexOutOfRangeError extends SideEffectReadError {
+  constructor(tree: string, index: number, limit: number) {
+    super(`Attempting to read index ${index} of ${tree} tree with maximum ${limit} leaves`);
+    this.name = 'IndexOutOfRangeError';
+  }
+}
+
+export class NoteHashIndexOutOfRangeError extends IndexOutOfRangeError {
+  constructor(index: number) {
+    super('note hash', index, NOTE_HASH_TREE_LEAF_COUNT);
+    this.name = 'NoteHashIndexOutOfRangeError';
+  }
+}
+
+export class L1ToL2MessageIndexOutOfRangeError extends IndexOutOfRangeError {
+  constructor(index: number) {
+    super('l1 to l2 message', index, L1_TO_L2_MSG_TREE_LEAF_COUNT);
+    this.name = 'L1ToL2MessageIndexOutOfRangeError';
   }
 }


### PR DESCRIPTION
### AVM append-only tree reads
Closes #17330

This PR unifies the behaviour between AVM simulation and circuits for reading leaves in append-only trees (note hash and l1 to l2 message trees). There are two key changes:

- Reading beyond the maximum index a tree can hold now 'throws' in both cases and is handled by setting a `false` response to the opcodes `NOTEHASHEXISTS` & `L1TOL2MSGEXISTS`
  - We now just skip the world state call by throwing in ts, mirroring circuit behaviour where we skip the tree lookup if `note_hash_leaf_in_range == 0`
  - I additionally added changes in the cpp append-only tree to fix an issue where `get_leaf` would return the leaf at index `i` when calling `get_leaf(MAX_INDEX + i)` (see #17755) and instead return null
 - Reading an unwritten leaf (i.e. at some valid index `i < MAX_INDEX`) now returns an empty leaf instead of null
   - This required changes in cpp `world_state` to ensure we differentiate between responses where a leaf is not yet written to vs a leaf which cannot exist at an invalid index

### TODOs/Notes

 - The handling of invalid indices in the cpp append-only tree is a bit of a quick fix, and I'm not sure the best way to handle, see #17755
 - Handle `leaf_index > blockData.size` - ~I'm not sure whether the intended behaviour here is to 'fail' (current impl - returns with `response.success = false`) or mirror the behaviour of `get_leaf` without specifying a block, which is to return an empty leaf~ Keeping with `response.success = false` since note and msg trees don't seem to ever reach this path (and changing the behaviour may cause far reaching problems with other trees specifying block number in the revision e.g. archive tree).