### PR TITLE
refactor: PXE - remove recipient and txHash filters from notes_filter and update noteDataProvider accordingly

### DIFF
--- a/yarn-project/pxe/src/contract_function_simulator/pxe_oracle_interface.test.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/pxe_oracle_interface.test.ts
@@ -533,9 +533,11 @@ describe('PXEOracleInterface', () => {
       );
 
       // Verify note was stored
-      const notes = await noteDataProvider.getNotes({ recipient: recipient.address, contractAddress });
-      expect(notes).toHaveLength(1);
-      expect(notes[0].noteHash.equals(noteHash)).toBe(true);
+      const notes = await noteDataProvider.getNotes({ contractAddress });
+
+      const matchingNotes = notes.filter(n => n.recipient.equals(recipient.address));
+      expect(matchingNotes).toHaveLength(1);
+      expect(matchingNotes[0].noteHash.equals(noteHash)).toBe(true);
     });
 
     it('should throw if note does not exist in note hash tree', async () => {
@@ -583,8 +585,9 @@ describe('PXEOracleInterface', () => {
       );
 
       // Verify note was removed
-      const notes = await noteDataProvider.getNotes({ recipient: recipient.address, contractAddress });
-      expect(notes).toHaveLength(0);
+      const notes = await noteDataProvider.getNotes({ contractAddress });
+      const matchingNotes = notes.filter(n => n.recipient.equals(recipient.address));
+      expect(matchingNotes).toHaveLength(0);
     });
 
     // Verifies that notes are only accepted from blocks that have been synced by PXE. We mock
@@ -654,12 +657,12 @@ describe('PXEOracleInterface', () => {
 
       // Verify note was stored and not removed
       const notes = await noteDataProvider.getNotes({
-        recipient: recipient.address,
         contractAddress,
         status: NoteStatus.ACTIVE,
       });
-      expect(notes).toHaveLength(1);
-      expect(notes[0].noteHash.equals(noteHash)).toBe(true);
+      const matchingNotes = notes.filter(n => n.recipient.equals(recipient.address));
+      expect(matchingNotes).toHaveLength(1);
+      expect(matchingNotes[0].noteHash.equals(noteHash)).toBe(true);
     });
   });
 
@@ -901,8 +904,9 @@ describe('PXEOracleInterface', () => {
       await pxeOracleInterface.syncNoteNullifiers(contractAddress);
 
       // Verify the note was removed by checking storage
-      const remainingNotes = await noteDataProvider.getNotes({ contractAddress, recipient, status: NoteStatus.ACTIVE });
-      expect(remainingNotes).toHaveLength(0);
+      const remainingNotes = await noteDataProvider.getNotes({ contractAddress, status: NoteStatus.ACTIVE });
+      const matchingNotes = remainingNotes.filter(n => n.recipient.equals(recipient));
+      expect(matchingNotes).toHaveLength(0);
 
       // Verify the note was removed by checking the spy
       expect(noteDataProvider.applyNullifiers).toHaveBeenCalledTimes(1);
@@ -922,9 +926,10 @@ describe('PXEOracleInterface', () => {
       await pxeOracleInterface.syncNoteNullifiers(contractAddress);
 
       // Verify note still exists
-      const remainingNotes = await noteDataProvider.getNotes({ contractAddress, recipient, status: NoteStatus.ACTIVE });
-      expect(remainingNotes).toHaveLength(1);
-      expect(remainingNotes[0]).toEqual(noteDao);
+      const remainingNotes = await noteDataProvider.getNotes({ contractAddress, status: NoteStatus.ACTIVE });
+      const matchingNotes = remainingNotes.filter(n => n.recipient.equals(recipient));
+      expect(matchingNotes).toHaveLength(1);
+      expect(matchingNotes[0]).toEqual(noteDao);
     });
 
     // Verifies that notes are not marked as nullified when their nullifier only exists in blocks that haven't been
@@ -951,9 +956,10 @@ describe('PXEOracleInterface', () => {
       await pxeOracleInterface.syncNoteNullifiers(contractAddress);
 
       // Verify note still exists
-      const remainingNotes = await noteDataProvider.getNotes({ contractAddress, recipient, status: NoteStatus.ACTIVE });
-      expect(remainingNotes).toHaveLength(1);
-      expect(remainingNotes[0]).toEqual(noteDao);
+      const remainingNotes = await noteDataProvider.getNotes({ contractAddress, status: NoteStatus.ACTIVE });
+      const matchingNotes = remainingNotes.filter(n => n.recipient.equals(recipient));
+      expect(matchingNotes).toHaveLength(1);
+      expect(matchingNotes[0]).toEqual(noteDao);
     });
 
     it('should search for notes from all accounts', async () => {

--- a/yarn-project/pxe/src/pxe.ts
+++ b/yarn-project/pxe/src/pxe.ts
@@ -669,18 +669,15 @@ export class PXE {
     const noteDaos = await this.noteDataProvider.getNotes(filter);
 
     const extendedNotes = noteDaos.map(async dao => {
-      let recipient = filter.recipient;
-      if (recipient === undefined) {
-        const completeAddresses = await this.addressDataProvider.getCompleteAddresses();
-        const completeAddressIndex = completeAddresses.findIndex(completeAddress =>
-          completeAddress.address.equals(dao.recipient),
-        );
-        const completeAddress = completeAddresses[completeAddressIndex];
-        if (completeAddress === undefined) {
-          throw new Error(`Cannot find complete address for recipient ${dao.recipient.toString()}`);
-        }
-        recipient = completeAddress.address;
+      const completeAddresses = await this.addressDataProvider.getCompleteAddresses();
+      const completeAddressIndex = completeAddresses.findIndex(completeAddress =>
+        completeAddress.address.equals(dao.recipient),
+      );
+      const completeAddress = completeAddresses[completeAddressIndex];
+      if (completeAddress === undefined) {
+        throw new Error(`Cannot find complete address for recipient ${dao.recipient.toString()}`);
       }
+      const recipient = completeAddress.address;
       return new UniqueNote(dao.note, recipient, dao.contractAddress, dao.storageSlot, dao.txHash, dao.noteNonce);
     });
     return Promise.all(extendedNotes);

--- a/yarn-project/stdlib/src/note/notes_filter.ts
+++ b/yarn-project/stdlib/src/note/notes_filter.ts
@@ -4,7 +4,6 @@ import { z } from 'zod';
 
 import type { AztecAddress } from '../aztec-address/index.js';
 import { type ZodFor, schemas } from '../schemas/index.js';
-import { TxHash } from '../tx/tx_hash.js';
 import { NoteStatus } from './note_status.js';
 
 /**
@@ -17,12 +16,8 @@ export type NotesFilter = {
    * @remarks Providing a contract address is required as we need that information to trigger private state sync.
    */
   contractAddress: AztecAddress;
-  /** Hash of a transaction from which to fetch the notes. */
-  txHash?: TxHash;
   /** The specific storage location of the note on the contract. */
   storageSlot?: Fr;
-  /** The recipient of the note (whose public key was used to encrypt the note). */
-  recipient?: AztecAddress;
   /** The status of the note. Defaults to 'ACTIVE'. */
   status?: NoteStatus;
   /** The siloed nullifier for the note. */
@@ -33,9 +28,7 @@ export type NotesFilter = {
 
 export const NotesFilterSchema: ZodFor<NotesFilter> = z.object({
   contractAddress: schemas.AztecAddress,
-  txHash: TxHash.schema.optional(),
   storageSlot: schemas.Fr.optional(),
-  recipient: schemas.AztecAddress.optional(),
   status: z.nativeEnum(NoteStatus).optional(),
   siloedNullifier: schemas.Fr.optional(),
   scopes: z.array(schemas.AztecAddress).optional(),


### PR DESCRIPTION
### Description:
This PR simplifies note filtering by removing unused or redundant fields, aiming to reduce complexity in filtering logic and note management.

#### Changes
- Removed `recipient` and `txHash` from `notes_filter.ts`.
- Removed associated indexes and maps in `noteDataProvider` that referenced these fields.
- **Updated call sites:** where `getNotes()` was previously called with a `recipient` filter, removed this argument and applied filtering to the returned `noteDAOs` instead.
- **Added tests:** covering `siloedNullifier` filters in `note_data_provider` tests.
