### PR TITLE
fix: Do not return repeated blobs

### DIFF
--- a/.test_patterns.yml
+++ b/.test_patterns.yml
@@ -294,6 +294,10 @@ tests:
     error_regex: "only slashes validator inactive for N consecutive epochs"
     owners:
       - *palla
+  - regex: "e2e_p2p/valid_epoch_pruned_slash.test.ts"
+    error_regex: "Timeout waiting for proposal execution"
+    owners:
+      - *palla
 
   # Nightly GKE tests
   - regex: "spartan/bootstrap.sh"

--- a/yarn-project/blob-sink/src/client/http.test.ts
+++ b/yarn-project/blob-sink/src/client/http.test.ts
@@ -354,7 +354,7 @@ describe('HttpBlobSinkClient', () => {
       expect(retrievedBlobs).toEqual([testEncodedBlobWithIndex]);
     });
 
-    it('even if we ask for non-encoded blobs, we should only get encoded blobs', async () => {
+    it('we get all blobs or nothing', async () => {
       await startExecutionHostServer();
       await startConsensusHostServer();
 
@@ -364,8 +364,7 @@ describe('HttpBlobSinkClient', () => {
       });
 
       const retrievedBlobs = await client.getBlobSidecar('0x1234', [testEncodedBlobHash, testNonEncodedBlobHash]);
-      // We should only get the correctly encoded blob
-      expect(retrievedBlobs).toEqual([testEncodedBlobWithIndex]);
+      expect(retrievedBlobs).toEqual([]);
     });
 
     it('should handle L1 missed slots', async () => {
@@ -447,6 +446,36 @@ describe('HttpBlobSinkClient', () => {
 
       const retrievedBlobs = await client.getBlobSidecar('0x1234', [testEncodedBlobHash]);
       expect(retrievedBlobs).toEqual([testEncodedBlobWithIndex]);
+      expect(archiveSpy).toHaveBeenCalledWith('0x1234');
+    });
+
+    it('should return only one blob when multiple blobs with the same blobHash exist on a block', async () => {
+      // Create a blob data array with two blobs that have the same commitment (thus same blobHash)
+      const duplicateBlobData: BlobJson[] = [
+        {
+          index: '0',
+          blob: `0x${Buffer.from(testEncodedBlob.data).toString('hex')}`,
+          // eslint-disable-next-line camelcase
+          kzg_commitment: `0x${testEncodedBlob.commitment.toString('hex')}`,
+        },
+        {
+          index: '1',
+          blob: `0x${Buffer.from(testEncodedBlob.data).toString('hex')}`,
+          // eslint-disable-next-line camelcase
+          kzg_commitment: `0x${testEncodedBlob.commitment.toString('hex')}`,
+        },
+      ];
+
+      const client = new TestHttpBlobSinkClient({ archiveApiUrl: `https://api.blobscan.com` });
+      const archiveSpy = jest
+        .spyOn(client.getArchiveClient(), 'getBlobsFromBlock')
+        .mockResolvedValue(duplicateBlobData);
+
+      const retrievedBlobs = await client.getBlobSidecar('0x1234', [testEncodedBlobHash]);
+
+      // Should only return one blob despite two blobs with the same hash existing
+      expect(retrievedBlobs).toHaveLength(1);
+      expect(retrievedBlobs[0].blob).toEqual(testEncodedBlob);
       expect(archiveSpy).toHaveBeenCalledWith('0x1234');
     });
   });

--- a/yarn-project/blob-sink/src/client/http.ts
+++ b/yarn-project/blob-sink/src/client/http.ts
@@ -1,7 +1,7 @@
 import { Blob, BlobDeserializationError, type BlobJson } from '@aztec/blob-lib';
 import { type Logger, createLogger } from '@aztec/foundation/log';
 import { makeBackoff, retry } from '@aztec/foundation/retry';
-import { bufferToHex } from '@aztec/foundation/string';
+import { bufferToHex, hexToBuffer } from '@aztec/foundation/string';
 
 import { type RpcBlock, createPublicClient, fallback, http } from 'viem';
 
@@ -157,9 +157,12 @@ export class HttpBlobSinkClient implements BlobSinkClientInterface {
    */
   public async getBlobSidecar(
     blockHash: `0x${string}`,
-    blobHashes: Buffer[] = [],
+    blobHashes: Buffer[],
     indices?: number[],
   ): Promise<BlobWithIndex[]> {
+    // TODO(palla/blobs): Each attempt tries to download all blobs. If it does not download all of them,
+    // it discards the successful ones and then tries the next source. We could instead keep the successful ones
+    // and only try to download the missing ones from the next source.
     let blobs: BlobWithIndex[] = [];
 
     const { blobSinkUrl, l1ConsensusHostUrls } = this.config;
@@ -169,7 +172,7 @@ export class HttpBlobSinkClient implements BlobSinkClientInterface {
       this.log.trace(`Attempting to get blobs from blob sink`, { blobSinkUrl, ...ctx });
       blobs = await this.getBlobsFromSink(blobSinkUrl, blobHashes);
       this.log.debug(`Got ${blobs.length} blobs from blob sink`, { blobSinkUrl, ...ctx });
-      if (blobs.length > 0) {
+      if (blobs.length === blobHashes.length) {
         return blobs;
       }
     }
@@ -194,7 +197,7 @@ export class HttpBlobSinkClient implements BlobSinkClientInterface {
             l1ConsensusHostIndex,
           );
           this.log.debug(`Got ${blobs.length} blobs from consensus host`, { slotNumber, l1ConsensusHostUrl, ...ctx });
-          if (blobs.length > 0) {
+          if (blobs.length === blobHashes.length) {
             return blobs;
           }
         }
@@ -212,7 +215,7 @@ export class HttpBlobSinkClient implements BlobSinkClientInterface {
       this.log.trace(`Got ${allBlobs.length} blobs from archive client before filtering`, archiveCtx);
       blobs = await getRelevantBlobs(allBlobs, blobHashes, this.log, this.opts.onBlobDeserializationError);
       this.log.debug(`Got ${blobs.length} blobs from archive client`, archiveCtx);
-      if (blobs.length > 0) {
+      if (blobs.length === blobHashes.length) {
         return blobs;
       }
     }
@@ -255,6 +258,8 @@ export class HttpBlobSinkClient implements BlobSinkClientInterface {
       const getBlobs = async (res: Response) =>
         getRelevantBlobs((await res.json()).data, blobHashes, this.log, this.opts.onBlobDeserializationError);
 
+      // TODO(palla/blobs): We should be computing the indices ourselves so we can request specific blobs
+      // rather than all blobs in the slot and then filtering.
       let res = await this.fetchBlobSidecars(hostUrl, blockHashOrSlot, indices, l1ConsensusHostIndex);
       if (res.ok) {
         return await getBlobs(res);
@@ -412,35 +417,30 @@ async function getRelevantBlobs(
   logger: Logger,
   onBlobDeserializationError: 'warn' | 'trace' = 'warn',
 ): Promise<BlobWithIndex[]> {
-  const blobsPromise = data
-    // Filter out blobs not requested
-    .filter((b: BlobJson) => {
-      if (blobHashes.length === 0) {
-        return true;
-      }
-      const commitment = Buffer.from(b.kzg_commitment.slice(2), 'hex');
-      const blobHash = Blob.getEthVersionedBlobHash(commitment);
-      logger.trace(`Filtering blob with hash ${blobHash.toString('hex')}`);
-      return blobHashes.some(hash => hash.equals(blobHash));
-    })
-    // Attempt to deserialise the blob
-    // If we cannot decode it, then it is malicious and we should not use it
-    .map(async (b: BlobJson): Promise<BlobWithIndex | undefined> => {
-      try {
-        const blob = await Blob.fromJson(b);
-        return new BlobWithIndex(blob, parseInt(b.index));
-      } catch (err) {
-        if (err instanceof BlobDeserializationError) {
-          logger[onBlobDeserializationError](`Failed to deserialise blob`, { commitment: b.kzg_commitment });
-          return undefined;
-        }
-        throw err;
-      }
-    });
+  const hashToBlob = new Map<string, BlobJson>(
+    data.map(b => [bufferToHex(Blob.getEthVersionedBlobHash(hexToBuffer(b.kzg_commitment))), b] as const),
+  );
 
-  // Second map is async, so we need to await it, and filter out blobs that did not deserialise
-  const maybeBlobs = await Promise.all(blobsPromise);
-  return maybeBlobs.filter((b: BlobWithIndex | undefined): b is BlobWithIndex => b !== undefined);
+  const requestedBlobs = blobHashes
+    .map(bh => hashToBlob.get(bufferToHex(bh)))
+    .filter((b): b is BlobJson => b !== undefined);
+
+  const deserializedBlobs = requestedBlobs.map(async (b: BlobJson): Promise<BlobWithIndex | undefined> => {
+    try {
+      const blob = await Blob.fromJson(b);
+      return new BlobWithIndex(blob, parseInt(b.index));
+    } catch (err) {
+      if (err instanceof BlobDeserializationError) {
+        logger[onBlobDeserializationError](`Failed to deserialise blob`, { commitment: b.kzg_commitment });
+        return undefined;
+      }
+      throw err;
+    }
+  });
+
+  return (await Promise.all(deserializedBlobs)).filter(
+    (b: BlobWithIndex | undefined): b is BlobWithIndex => b !== undefined,
+  );
 }
 
 function getBeaconNodeFetchOptions(url: string, config: BlobSinkConfig, l1ConsensusHostIndex?: number) {


### PR DESCRIPTION
Fixes an issue by which, if there was more than one blob with the same hash in an L1 slot, we would return all copies of that blob when requesting just one. This was problematic when there were multiple empty blobs in the slot, since they all have the same blob hash.