### PR TITLE
chore: Accumulate blobs across sources

### DIFF
--- a/yarn-project/blob-sink/src/client/http.test.ts
+++ b/yarn-project/blob-sink/src/client/http.test.ts
@@ -354,7 +354,7 @@ describe('HttpBlobSinkClient', () => {
       expect(retrievedBlobs).toEqual([testEncodedBlobWithIndex]);
     });
 
-    it('we get all blobs or nothing', async () => {
+    it('accumulates successfully retrieved blobs even if some fail', async () => {
       await startExecutionHostServer();
       await startConsensusHostServer();
 
@@ -364,7 +364,170 @@ describe('HttpBlobSinkClient', () => {
       });
 
       const retrievedBlobs = await client.getBlobSidecar('0x1234', [testEncodedBlobHash, testNonEncodedBlobHash]);
-      expect(retrievedBlobs).toEqual([]);
+      // Should return the successfully retrieved blob, even though one failed to deserialize
+      expect(retrievedBlobs).toEqual([testEncodedBlobWithIndex]);
+    });
+
+    it('should retrieve blobs from blob sink when it only has a partial set', async () => {
+      blobSinkServer = new TestBlobSinkServer({ port: 0 });
+      await blobSinkServer.start();
+
+      // Only send testEncodedBlob to blob sink
+      await blobSinkServer.blobStore.addBlobs([testEncodedBlobWithIndex]);
+
+      await startExecutionHostServer();
+      await startConsensusHostServer();
+
+      const client = new HttpBlobSinkClient({
+        blobSinkUrl: `http://localhost:${blobSinkServer.port}`,
+        l1RpcUrls: [`http://localhost:${executionHostPort}`],
+        l1ConsensusHostUrls: [`http://localhost:${consensusHostPort}`],
+      });
+
+      // Create a third blob that will be available from consensus
+      const testEncodedBlob2 = await makeEncodedBlob(4);
+      const testEncodedBlobHash2 = testEncodedBlob2.getEthVersionedBlobHash();
+      const testEncodedBlobWithIndex2 = new BlobWithIndex(testEncodedBlob2, 3);
+
+      // Update blobData to include the third blob
+      const originalBlobData = blobData;
+      blobData = [
+        ...originalBlobData,
+        {
+          index: '3',
+          blob: `0x${Buffer.from(testEncodedBlob2.data).toString('hex')}`,
+          // eslint-disable-next-line camelcase
+          kzg_commitment: `0x${testEncodedBlob2.commitment.toString('hex')}`,
+        },
+      ];
+
+      // Request both blobs - testEncodedBlob should come from blob sink, testEncodedBlob2 from consensus
+      const retrievedBlobs = await client.getBlobSidecar('0x1234', [testEncodedBlobHash, testEncodedBlobHash2]);
+
+      // Restore original blobData
+      blobData = originalBlobData;
+
+      // Should accumulate both blobs from different sources
+      expect(retrievedBlobs).toHaveLength(2);
+      expect(retrievedBlobs).toContainEqual(testEncodedBlobWithIndex);
+      expect(retrievedBlobs).toContainEqual(testEncodedBlobWithIndex2);
+    });
+
+    it('should accumulate blobs across all three sources (blob sink, consensus, archive)', async () => {
+      blobSinkServer = new TestBlobSinkServer({ port: 0 });
+      await blobSinkServer.start();
+
+      // Create three blobs for testing
+      const blob1 = await makeEncodedBlob(5);
+      const blob1Hash = blob1.getEthVersionedBlobHash();
+      const blob1WithIndex = new BlobWithIndex(blob1, 4);
+
+      const blob2 = await makeEncodedBlob(6);
+      const blob2Hash = blob2.getEthVersionedBlobHash();
+      const blob2WithIndex = new BlobWithIndex(blob2, 5);
+
+      const blob3 = await makeEncodedBlob(7);
+      const blob3Hash = blob3.getEthVersionedBlobHash();
+      const blob3WithIndex = new BlobWithIndex(blob3, 6);
+
+      // Blob 1 only in blob sink
+      await blobSinkServer.blobStore.addBlobs([blob1WithIndex]);
+
+      // Blob 2 only in consensus host
+      await startExecutionHostServer();
+      await startConsensusHostServer();
+      const originalBlobData = blobData;
+      blobData = [
+        {
+          index: '5',
+          blob: `0x${Buffer.from(blob2.data).toString('hex')}`,
+          // eslint-disable-next-line camelcase
+          kzg_commitment: `0x${blob2.commitment.toString('hex')}`,
+        },
+      ];
+
+      // Blob 3 only in archive
+      const blob3Json: BlobJson = {
+        index: '6',
+        blob: `0x${Buffer.from(blob3.data).toString('hex')}`,
+        // eslint-disable-next-line camelcase
+        kzg_commitment: `0x${blob3.commitment.toString('hex')}`,
+      };
+
+      const client = new TestHttpBlobSinkClient({
+        blobSinkUrl: `http://localhost:${blobSinkServer.port}`,
+        l1RpcUrls: [`http://localhost:${executionHostPort}`],
+        l1ConsensusHostUrls: [`http://localhost:${consensusHostPort}`],
+        archiveApiUrl: `https://api.blobscan.com`,
+      });
+
+      const archiveSpy = jest.spyOn(client.getArchiveClient(), 'getBlobsFromBlock').mockResolvedValue([blob3Json]);
+
+      // Request all three blobs
+      const retrievedBlobs = await client.getBlobSidecar('0x1234', [blob1Hash, blob2Hash, blob3Hash]);
+
+      // Restore original blobData
+      blobData = originalBlobData;
+
+      // Should accumulate all three blobs from different sources
+      expect(retrievedBlobs).toHaveLength(3);
+      expect(retrievedBlobs).toContainEqual(blob1WithIndex);
+      expect(retrievedBlobs).toContainEqual(blob2WithIndex);
+      expect(retrievedBlobs).toContainEqual(blob3WithIndex);
+      expect(archiveSpy).toHaveBeenCalledWith('0x1234');
+    });
+
+    it('should return duplicate blobs when same hash is requested multiple times', async () => {
+      await startExecutionHostServer();
+      await startConsensusHostServer();
+
+      const client = new HttpBlobSinkClient({
+        l1RpcUrls: [`http://localhost:${executionHostPort}`],
+        l1ConsensusHostUrls: [`http://localhost:${consensusHostPort}`],
+      });
+
+      // Request the same blob hash twice
+      const retrievedBlobs = await client.getBlobSidecar('0x1234', [testEncodedBlobHash, testEncodedBlobHash]);
+
+      // Should return two blobs with the same content
+      expect(retrievedBlobs).toHaveLength(2);
+      expect(retrievedBlobs[0]).toEqual(testEncodedBlobWithIndex);
+      expect(retrievedBlobs[1]).toEqual(testEncodedBlobWithIndex);
+    });
+
+    it('should preserve blob order when requesting multiple blobs', async () => {
+      blobSinkServer = new TestBlobSinkServer({ port: 0 });
+      await blobSinkServer.start();
+
+      // Create three distinct blobs
+      const blob1 = await makeEncodedBlob(8);
+      const blob1Hash = blob1.getEthVersionedBlobHash();
+      const blob1WithIndex = new BlobWithIndex(blob1, 10);
+
+      const blob2 = await makeEncodedBlob(9);
+      const blob2Hash = blob2.getEthVersionedBlobHash();
+      const blob2WithIndex = new BlobWithIndex(blob2, 11);
+
+      const blob3 = await makeEncodedBlob(10);
+      const blob3Hash = blob3.getEthVersionedBlobHash();
+      const blob3WithIndex = new BlobWithIndex(blob3, 12);
+
+      // Add all blobs to blob sink
+      await blobSinkServer.blobStore.addBlobs([blob1WithIndex, blob2WithIndex, blob3WithIndex]);
+
+      const client = new HttpBlobSinkClient({
+        blobSinkUrl: `http://localhost:${blobSinkServer.port}`,
+      });
+
+      // Request blobs in a specific order: blob3, blob1, blob2, blob1 (with duplicate)
+      const retrievedBlobs = await client.getBlobSidecar('0x1234', [blob3Hash, blob1Hash, blob2Hash, blob1Hash]);
+
+      // Should return blobs in the exact order requested
+      expect(retrievedBlobs).toHaveLength(4);
+      expect(retrievedBlobs[0]).toEqual(blob3WithIndex);
+      expect(retrievedBlobs[1]).toEqual(blob1WithIndex);
+      expect(retrievedBlobs[2]).toEqual(blob2WithIndex);
+      expect(retrievedBlobs[3]).toEqual(blob1WithIndex);
     });
 
     it('should handle L1 missed slots', async () => {

--- a/yarn-project/blob-sink/src/client/http.ts
+++ b/yarn-project/blob-sink/src/client/http.ts
@@ -160,24 +160,58 @@ export class HttpBlobSinkClient implements BlobSinkClientInterface {
     blobHashes: Buffer[],
     indices?: number[],
   ): Promise<BlobWithIndex[]> {
-    // TODO(palla/blobs): Each attempt tries to download all blobs. If it does not download all of them,
-    // it discards the successful ones and then tries the next source. We could instead keep the successful ones
-    // and only try to download the missing ones from the next source.
-    let blobs: BlobWithIndex[] = [];
+    // Accumulate blobs across sources, preserving order and handling duplicates
+    // resultBlobs[i] will contain the blob for blobHashes[i], or undefined if not yet found
+    const resultBlobs: (BlobWithIndex | undefined)[] = new Array(blobHashes.length).fill(undefined);
+
+    // Helper to get  missing blob hashes that we still need to fetch
+    const getMissingBlobHashes = (): Buffer[] =>
+      blobHashes
+        .map((bh, i) => (resultBlobs[i] === undefined ? bh : undefined))
+        .filter((bh): bh is Buffer => bh !== undefined);
+
+    // Helper to fill in results from fetched blobs
+    const fillResults = (fetchedBlobs: BlobWithIndex[]) => {
+      // Create a map from hash to blob for quick lookup
+      const hashToBlob = new Map<string, BlobWithIndex>(
+        fetchedBlobs.map(b => [bufferToHex(b.blob.getEthVersionedBlobHash()), b] as const),
+      );
+
+      // Fill in any missing positions with matching blobs
+      for (let i = 0; i < blobHashes.length; i++) {
+        if (resultBlobs[i] === undefined) {
+          const blob = hashToBlob.get(bufferToHex(blobHashes[i]));
+          if (blob) {
+            resultBlobs[i] = blob;
+          }
+        }
+      }
+    };
+
+    // Helper to count how many blobs we have successfully fetched so far
+    const getFilledCount = () => resultBlobs.filter(b => b !== undefined).length;
 
     const { blobSinkUrl, l1ConsensusHostUrls } = this.config;
     const ctx = { blockHash, blobHashes: blobHashes.map(bufferToHex), indices };
 
     if (blobSinkUrl) {
-      this.log.trace(`Attempting to get blobs from blob sink`, { blobSinkUrl, ...ctx });
-      blobs = await this.getBlobsFromSink(blobSinkUrl, blobHashes);
-      this.log.debug(`Got ${blobs.length} blobs from blob sink`, { blobSinkUrl, ...ctx });
-      if (blobs.length === blobHashes.length) {
-        return blobs;
+      const missingHashes = getMissingBlobHashes();
+      if (missingHashes.length > 0) {
+        this.log.trace(`Attempting to get ${missingHashes.length} blobs from blob sink`, { blobSinkUrl, ...ctx });
+        const blobs = await this.getBlobsFromSink(blobSinkUrl, missingHashes);
+        fillResults(blobs);
+        this.log.debug(`Got ${blobs.length} blobs from blob sink (total: ${getFilledCount()}/${blobHashes.length})`, {
+          blobSinkUrl,
+          ...ctx,
+        });
+        if (getFilledCount() === blobHashes.length) {
+          return resultBlobs.filter((b): b is BlobWithIndex => b !== undefined);
+        }
       }
     }
 
-    if (blobs.length == 0 && l1ConsensusHostUrls && l1ConsensusHostUrls.length > 0) {
+    const missingAfterSink = getMissingBlobHashes();
+    if (missingAfterSink.length > 0 && l1ConsensusHostUrls && l1ConsensusHostUrls.length > 0) {
       // The beacon api can query by slot number, so we get that first
       const consensusCtx = { l1ConsensusHostUrls, ...ctx };
       this.log.trace(`Attempting to get slot number for block hash`, consensusCtx);
@@ -187,45 +221,74 @@ export class HttpBlobSinkClient implements BlobSinkClientInterface {
       if (slotNumber) {
         let l1ConsensusHostUrl: string;
         for (let l1ConsensusHostIndex = 0; l1ConsensusHostIndex < l1ConsensusHostUrls.length; l1ConsensusHostIndex++) {
+          const missingHashes = getMissingBlobHashes();
+          if (missingHashes.length === 0) {
+            break;
+          }
+
           l1ConsensusHostUrl = l1ConsensusHostUrls[l1ConsensusHostIndex];
-          this.log.trace(`Attempting to get blobs from consensus host`, { slotNumber, l1ConsensusHostUrl, ...ctx });
+          this.log.trace(`Attempting to get ${missingHashes.length} blobs from consensus host`, {
+            slotNumber,
+            l1ConsensusHostUrl,
+            ...ctx,
+          });
           const blobs = await this.getBlobSidecarFrom(
             l1ConsensusHostUrl,
             slotNumber,
-            blobHashes,
+            missingHashes,
             indices,
             l1ConsensusHostIndex,
           );
-          this.log.debug(`Got ${blobs.length} blobs from consensus host`, { slotNumber, l1ConsensusHostUrl, ...ctx });
-          if (blobs.length === blobHashes.length) {
-            return blobs;
+          fillResults(blobs);
+          this.log.debug(
+            `Got ${blobs.length} blobs from consensus host (total: ${getFilledCount()}/${blobHashes.length})`,
+            { slotNumber, l1ConsensusHostUrl, ...ctx },
+          );
+          if (getFilledCount() === blobHashes.length) {
+            return resultBlobs.filter((b): b is BlobWithIndex => b !== undefined);
           }
         }
       }
     }
 
-    if (blobs.length == 0 && this.archiveClient) {
+    const missingAfterConsensus = getMissingBlobHashes();
+    if (missingAfterConsensus.length > 0 && this.archiveClient) {
       const archiveCtx = { archiveUrl: this.archiveClient.getBaseUrl(), ...ctx };
-      this.log.trace(`Attempting to get blobs from archive`, archiveCtx);
+      this.log.trace(`Attempting to get ${missingAfterConsensus.length} blobs from archive`, archiveCtx);
       const allBlobs = await this.archiveClient.getBlobsFromBlock(blockHash);
       if (!allBlobs) {
         this.log.debug('No blobs found from archive client', archiveCtx);
-        return [];
+        return resultBlobs.filter((b): b is BlobWithIndex => b !== undefined);
       }
       this.log.trace(`Got ${allBlobs.length} blobs from archive client before filtering`, archiveCtx);
-      blobs = await getRelevantBlobs(allBlobs, blobHashes, this.log, this.opts.onBlobDeserializationError);
-      this.log.debug(`Got ${blobs.length} blobs from archive client`, archiveCtx);
-      if (blobs.length === blobHashes.length) {
-        return blobs;
+      const blobs = await getRelevantBlobs(
+        allBlobs,
+        missingAfterConsensus,
+        this.log,
+        this.opts.onBlobDeserializationError,
+      );
+      fillResults(blobs);
+      this.log.debug(
+        `Got ${blobs.length} blobs from archive client (total: ${getFilledCount()}/${blobHashes.length})`,
+        archiveCtx,
+      );
+      if (getFilledCount() === blobHashes.length) {
+        return resultBlobs.filter((b): b is BlobWithIndex => b !== undefined);
       }
     }
 
-    this.log.warn(`Failed to fetch blobs for ${blockHash} from all blob sources`, {
-      blobSinkUrl,
-      l1ConsensusHostUrls,
-      archiveUrl: this.archiveClient?.getBaseUrl(),
-    });
-    return [];
+    const filledCount = getFilledCount();
+    if (filledCount < blobHashes.length) {
+      this.log.warn(
+        `Failed to fetch all blobs for ${blockHash} from all blob sources (got ${filledCount}/${blobHashes.length})`,
+        {
+          blobSinkUrl,
+          l1ConsensusHostUrls,
+          archiveUrl: this.archiveClient?.getBaseUrl(),
+        },
+      );
+    }
+    return resultBlobs.filter((b): b is BlobWithIndex => b !== undefined);
   }
 
   private async getBlobsFromSink(blobSinkUrl: string, blobHashes: Buffer[]): Promise<BlobWithIndex[]> {
@@ -258,8 +321,6 @@ export class HttpBlobSinkClient implements BlobSinkClientInterface {
       const getBlobs = async (res: Response) =>
         getRelevantBlobs((await res.json()).data, blobHashes, this.log, this.opts.onBlobDeserializationError);
 
-      // TODO(palla/blobs): We should be computing the indices ourselves so we can request specific blobs
-      // rather than all blobs in the slot and then filtering.
       let res = await this.fetchBlobSidecars(hostUrl, blockHashOrSlot, indices, l1ConsensusHostIndex);
       if (res.ok) {
         return await getBlobs(res);


### PR DESCRIPTION
Fixes TODO to accumulate blobs across different sources in the blob client. If the blob sink has multiple sources configured, and a given source can only fetch a subset of the blobs requested, these are preserved instead of thrown away.