### PR TITLE
fix: Validate tx hashes from external sources

### DIFF
--- a/yarn-project/p2p/src/client/test/p2p_client.integration_block_txs.test.ts
+++ b/yarn-project/p2p/src/client/test/p2p_client.integration_block_txs.test.ts
@@ -6,7 +6,7 @@ import { type Logger, createLogger } from '@aztec/foundation/log';
 import { sleep } from '@aztec/foundation/sleep';
 import { emptyChainConfig } from '@aztec/stdlib/config';
 import type { WorldStateSynchronizer } from '@aztec/stdlib/interfaces/server';
-import { makeBlockProposal, makeL2BlockHeader, mockTx } from '@aztec/stdlib/testing';
+import { makeBlockProposal, makeL2BlockHeader } from '@aztec/stdlib/testing';
 import { Tx, TxHash } from '@aztec/stdlib/tx';
 
 import { describe, expect, it, jest } from '@jest/globals';
@@ -21,6 +21,7 @@ import { BitVector } from '../../services/reqresp/protocols/block_txs/bitvector.
 import { BlockTxsRequest, BlockTxsResponse } from '../../services/reqresp/protocols/block_txs/block_txs_reqresp.js';
 import { ReqRespStatus } from '../../services/reqresp/status.js';
 import { makeAndStartTestP2PClients } from '../../test-helpers/make-test-p2p-clients.js';
+import { createMockTxWithMetadata } from '../../test-helpers/mock-tx-helpers.js';
 
 const TEST_TIMEOUT = 120000;
 jest.setTimeout(TEST_TIMEOUT);
@@ -92,7 +93,7 @@ describe('p2p client integration block txs protocol ', () => {
     await sleep(5000);
     logger.info('Finished waiting for clients to connect');
 
-    txs = await Promise.all(times(5, () => mockTx()));
+    txs = await Promise.all(times(5, i => createMockTxWithMetadata(p2pBaseConfig, i)));
     txHashes = await Promise.all(txs.map(tx => tx.getTxHash()));
     const blockProposal = createBlockProposal(blockNumber, blockHash, txHashes);
     attestationPool.getBlockProposal.mockResolvedValue(blockProposal);

--- a/yarn-project/p2p/src/msg_validators/block_proposal_validator/block_proposal_validator.ts
+++ b/yarn-project/p2p/src/msg_validators/block_proposal_validator/block_proposal_validator.ts
@@ -44,6 +44,15 @@ export class BlockProposalValidator implements P2PValidator<BlockProposal> {
         return PeerErrorSeverity.MidToleranceError;
       }
 
+      // Validate tx hashes for all txs embedded in the proposal
+      if (!(await Promise.all(block.txs?.map(tx => tx.validateTxHash()) ?? [])).every(v => v)) {
+        this.logger.warn(`Penalizing peer for invalid tx hashes in block proposal`, {
+          proposer,
+          slotNumber: slotNumberBigInt,
+        });
+        return PeerErrorSeverity.LowToleranceError;
+      }
+
       return undefined;
     } catch (e) {
       // People shouldn't be sending us block proposals if the committee doesn't exist

--- a/yarn-project/p2p/src/msg_validators/tx_validator/factory.test.ts
+++ b/yarn-project/p2p/src/msg_validators/tx_validator/factory.test.ts
@@ -36,6 +36,7 @@ describe('GasTxValidator', () => {
       'txsPermittedValidator',
       'dataValidator',
       'metadataValidator',
+      'timestampValidator',
       'doubleSpendValidator',
       'gasValidator',
       'phasesValidator',

--- a/yarn-project/p2p/src/msg_validators/tx_validator/factory.ts
+++ b/yarn-project/p2p/src/msg_validators/tx_validator/factory.ts
@@ -20,6 +20,7 @@ import { DoubleSpendTxValidator } from './double_spend_validator.js';
 import { GasTxValidator } from './gas_validator.js';
 import { MetadataTxValidator } from './metadata_validator.js';
 import { PhasesTxValidator } from './phases_validator.js';
+import { TimestampTxValidator } from './timestamp_validator.js';
 import { TxPermittedValidator } from './tx_permitted_validator.js';
 import { TxProofValidator } from './tx_proof_validator.js';
 
@@ -59,12 +60,17 @@ export function createTxMessageValidators(
         validator: new MetadataTxValidator({
           l1ChainId: new Fr(l1ChainId),
           rollupVersion: new Fr(rollupVersion),
-          timestamp,
-          blockNumber,
           protocolContractsHash,
           vkTreeRoot: getVKTreeRoot(),
         }),
         severity: PeerErrorSeverity.HighToleranceError,
+      },
+      timestampValidator: {
+        validator: new TimestampTxValidator<Tx>({
+          timestamp,
+          blockNumber,
+        }),
+        severity: PeerErrorSeverity.MidToleranceError,
       },
       doubleSpendValidator: {
         validator: new DoubleSpendTxValidator({

--- a/yarn-project/p2p/src/msg_validators/tx_validator/index.ts
+++ b/yarn-project/p2p/src/msg_validators/tx_validator/index.ts
@@ -10,3 +10,4 @@ export * from './test_utils.js';
 export * from './allowed_public_setup.js';
 export * from './archive_cache.js';
 export * from './tx_permitted_validator.js';
+export * from './timestamp_validator.js';

--- a/yarn-project/p2p/src/msg_validators/tx_validator/metadata_validator.test.ts
+++ b/yarn-project/p2p/src/msg_validators/tx_validator/metadata_validator.test.ts
@@ -6,13 +6,11 @@ import {
   TX_ERROR_INCORRECT_PROTOCOL_CONTRACTS_HASH,
   TX_ERROR_INCORRECT_ROLLUP_VERSION,
   TX_ERROR_INCORRECT_VK_TREE_ROOT,
-  TX_ERROR_INVALID_INCLUDE_BY_TIMESTAMP,
 } from '@aztec/stdlib/tx';
 
 import { MetadataTxValidator } from './metadata_validator.js';
 
 describe('MetadataTxValidator', () => {
-  let timestamp: bigint;
   let chainId: Fr;
   let rollupVersion: Fr;
   let vkTreeRoot: Fr;
@@ -22,24 +20,21 @@ describe('MetadataTxValidator', () => {
 
   let validator: MetadataTxValidator<AnyTx>;
 
-  const setValidatorAtBlock = (blockNumber: number) => {
+  const setValidatorAtBlock = () => {
     chainId = new Fr(1);
-    timestamp = 10n;
     rollupVersion = new Fr(2);
     vkTreeRoot = new Fr(3);
     protocolContractsHash = new Fr(4);
     validator = new MetadataTxValidator({
       l1ChainId: chainId,
       rollupVersion,
-      timestamp,
-      blockNumber,
       vkTreeRoot,
       protocolContractsHash,
     });
   };
 
   beforeEach(() => {
-    setValidatorAtBlock(3);
+    setValidatorAtBlock();
   });
 
   const expectValid = async (tx: Tx) => {
@@ -97,41 +92,5 @@ describe('MetadataTxValidator', () => {
     await expectValid(goodTxs[1]);
     await expectInvalid(badTxs[0], TX_ERROR_INCORRECT_VK_TREE_ROOT);
     await expectInvalid(badTxs[1], TX_ERROR_INCORRECT_PROTOCOL_CONTRACTS_HASH);
-  });
-
-  it.each([10n, 11n])('allows txs with valid expiration timestamp', async includeByTimestamp => {
-    const [goodTx] = await makeTxs();
-    goodTx.data.includeByTimestamp = includeByTimestamp;
-
-    await expectValid(goodTx);
-  });
-
-  it('allows txs with equal or greater expiration timestamp', async () => {
-    const [goodTx1, goodTx2] = await makeTxs();
-    goodTx1.data.includeByTimestamp = timestamp;
-    goodTx2.data.includeByTimestamp = timestamp + 1n;
-
-    await expectValid(goodTx1);
-    await expectValid(goodTx2);
-  });
-
-  it('rejects txs with lower expiration timestamp', async () => {
-    const [badTx] = await makeTxs();
-    badTx.data.includeByTimestamp = timestamp - 1n;
-
-    await expectInvalid(badTx, TX_ERROR_INVALID_INCLUDE_BY_TIMESTAMP);
-  });
-
-  it('accept txs with lower expiration timestamp when building block 1', async () => {
-    // Since at block 1, we skip the expiration check, we expect the tx to be valid even if the expiration timestamp
-    // is lower than the current timestamp. For details on why the check is disable for block 1 see the
-    // `validate_include_by_timestamp` function in
-    // `noir-projects/noir-protocol-circuits/crates/rollup-lib/src/base/components/validation_requests.nr`.
-    setValidatorAtBlock(1);
-
-    const [badTx] = await makeTxs();
-    badTx.data.includeByTimestamp = timestamp - 1n;
-
-    await expectValid(badTx);
   });
 });

--- a/yarn-project/p2p/src/msg_validators/tx_validator/metadata_validator.ts
+++ b/yarn-project/p2p/src/msg_validators/tx_validator/metadata_validator.ts
@@ -6,12 +6,9 @@ import {
   TX_ERROR_INCORRECT_PROTOCOL_CONTRACTS_HASH,
   TX_ERROR_INCORRECT_ROLLUP_VERSION,
   TX_ERROR_INCORRECT_VK_TREE_ROOT,
-  TX_ERROR_INVALID_INCLUDE_BY_TIMESTAMP,
   type TxValidationResult,
   type TxValidator,
-  getTxHash,
 } from '@aztec/stdlib/tx';
-import type { UInt64 } from '@aztec/stdlib/types';
 
 export class MetadataTxValidator<T extends AnyTx> implements TxValidator<T> {
   #log = createLogger('p2p:tx_validator:tx_metadata');
@@ -20,11 +17,6 @@ export class MetadataTxValidator<T extends AnyTx> implements TxValidator<T> {
     private values: {
       l1ChainId: Fr;
       rollupVersion: Fr;
-      // Timestamp at which we will validate that the tx is not expired. This is typically the timestamp of the block
-      // being built.
-      timestamp: UInt64;
-      // Block number in which the tx is considered to be included.
-      blockNumber: number;
       vkTreeRoot: Fr;
       protocolContractsHash: Fr;
     },
@@ -37,9 +29,6 @@ export class MetadataTxValidator<T extends AnyTx> implements TxValidator<T> {
     }
     if (!this.#hasCorrectRollupVersion(tx)) {
       errors.push(TX_ERROR_INCORRECT_ROLLUP_VERSION);
-    }
-    if (!this.#isValidForTimestamp(tx)) {
-      errors.push(TX_ERROR_INVALID_INCLUDE_BY_TIMESTAMP);
     }
     if (!this.#hasCorrectVkTreeRoot(tx)) {
       errors.push(TX_ERROR_INCORRECT_VK_TREE_ROOT);
@@ -76,29 +65,6 @@ export class MetadataTxValidator<T extends AnyTx> implements TxValidator<T> {
     if (!tx.data.constants.txContext.chainId.equals(this.values.l1ChainId)) {
       this.#log.verbose(
         `Rejecting tx ${'txHash' in tx ? tx.txHash : tx.hash} because of incorrect L1 chain ${tx.data.constants.txContext.chainId.toNumber()} != ${this.values.l1ChainId.toNumber()}`,
-      );
-      return false;
-    } else {
-      return true;
-    }
-  }
-
-  #isValidForTimestamp(tx: T): boolean {
-    const includeByTimestamp = tx.data.includeByTimestamp;
-    // If building block 1, we skip the expiration check. For details on why see the `validate_include_by_timestamp`
-    // function in `noir-projects/noir-protocol-circuits/crates/rollup-lib/src/base/components/validation_requests.nr`.
-    const buildingBlock1 = this.values.blockNumber === 1;
-
-    if (!buildingBlock1 && includeByTimestamp < this.values.timestamp) {
-      if (tx.data.constants.anchorBlockHeader.globalVariables.blockNumber === 0) {
-        this.#log.warn(
-          `A tx built against a genesis block failed to be included in block 1 which is the only block in which txs built against a genesis block are allowed to be included.`,
-        );
-      }
-      this.#log.verbose(
-        `Rejecting tx ${getTxHash(tx)} for low expiration timestamp. Tx expiration timestamp: ${includeByTimestamp}, timestamp: ${
-          this.values.timestamp
-        }.`,
       );
       return false;
     } else {

--- a/yarn-project/p2p/src/msg_validators/tx_validator/timestamp_validator.test.ts
+++ b/yarn-project/p2p/src/msg_validators/tx_validator/timestamp_validator.test.ts
@@ -1,0 +1,75 @@
+import { mockTx, mockTxForRollup } from '@aztec/stdlib/testing';
+import type { AnyTx, Tx } from '@aztec/stdlib/tx';
+import { TX_ERROR_INVALID_INCLUDE_BY_TIMESTAMP } from '@aztec/stdlib/tx';
+
+import { TimestampTxValidator } from './timestamp_validator.js';
+
+describe('TimestampTxValidator', () => {
+  let timestamp: bigint;
+  let seed = 1;
+  let validator: TimestampTxValidator<AnyTx>;
+
+  const setValidatorAtBlock = (blockNumber: number) => {
+    timestamp = 10n;
+    validator = new TimestampTxValidator({
+      timestamp,
+      blockNumber,
+    });
+  };
+
+  beforeEach(() => {
+    setValidatorAtBlock(3);
+  });
+
+  const expectValid = async (tx: Tx) => {
+    await expect(validator.validateTx(tx)).resolves.toEqual({ result: 'valid' });
+  };
+
+  const expectInvalid = async (tx: Tx, reason: string) => {
+    await expect(validator.validateTx(tx)).resolves.toEqual({ result: 'invalid', reason: [reason] });
+  };
+
+  const makeTxs = async () => {
+    const opts = {};
+    const tx1 = await mockTx(seed++, opts);
+    const tx2 = await mockTxForRollup(seed++, opts);
+
+    return [tx1, tx2];
+  };
+
+  it.each([10n, 11n])('allows txs with valid expiration timestamp', async includeByTimestamp => {
+    const [goodTx] = await makeTxs();
+    goodTx.data.includeByTimestamp = includeByTimestamp;
+
+    await expectValid(goodTx);
+  });
+
+  it('allows txs with equal or greater expiration timestamp', async () => {
+    const [goodTx1, goodTx2] = await makeTxs();
+    goodTx1.data.includeByTimestamp = timestamp;
+    goodTx2.data.includeByTimestamp = timestamp + 1n;
+
+    await expectValid(goodTx1);
+    await expectValid(goodTx2);
+  });
+
+  it('rejects txs with lower expiration timestamp', async () => {
+    const [badTx] = await makeTxs();
+    badTx.data.includeByTimestamp = timestamp - 1n;
+
+    await expectInvalid(badTx, TX_ERROR_INVALID_INCLUDE_BY_TIMESTAMP);
+  });
+
+  it('accept txs with lower expiration timestamp when building block 1', async () => {
+    // Since at block 1, we skip the expiration check, we expect the tx to be valid even if the expiration timestamp
+    // is lower than the current timestamp. For details on why the check is disable for block 1 see the
+    // `validate_include_by_timestamp` function in
+    // `noir-projects/noir-protocol-circuits/crates/rollup-lib/src/base/components/validation_requests.nr`.
+    setValidatorAtBlock(1);
+
+    const [badTx] = await makeTxs();
+    badTx.data.includeByTimestamp = timestamp - 1n;
+
+    await expectValid(badTx);
+  });
+});

--- a/yarn-project/p2p/src/msg_validators/tx_validator/timestamp_validator.ts
+++ b/yarn-project/p2p/src/msg_validators/tx_validator/timestamp_validator.ts
@@ -1,0 +1,46 @@
+import { createLogger } from '@aztec/foundation/log';
+import {
+  type AnyTx,
+  TX_ERROR_INVALID_INCLUDE_BY_TIMESTAMP,
+  type TxValidationResult,
+  type TxValidator,
+  getTxHash,
+} from '@aztec/stdlib/tx';
+import type { UInt64 } from '@aztec/stdlib/types';
+
+export class TimestampTxValidator<T extends AnyTx> implements TxValidator<T> {
+  #log = createLogger('p2p:tx_validator:timestamp');
+
+  constructor(
+    private values: {
+      // Timestamp at which we will validate that the tx is not expired. This is typically the timestamp of the block
+      // being built.
+      timestamp: UInt64;
+      // Block number in which the tx is considered to be included.
+      blockNumber: number;
+    },
+  ) {}
+
+  validateTx(tx: T): Promise<TxValidationResult> {
+    const includeByTimestamp = tx.data.includeByTimestamp;
+    // If building block 1, we skip the expiration check. For details on why see the `validate_include_by_timestamp`
+    // function in `noir-projects/noir-protocol-circuits/crates/rollup-lib/src/base/components/validation_requests.nr`.
+    const buildingBlock1 = this.values.blockNumber === 1;
+
+    if (!buildingBlock1 && includeByTimestamp < this.values.timestamp) {
+      if (tx.data.constants.anchorBlockHeader.globalVariables.blockNumber === 0) {
+        this.#log.warn(
+          `A tx built against a genesis block failed to be included in block 1 which is the only block in which txs built against a genesis block are allowed to be included.`,
+        );
+      }
+      this.#log.verbose(
+        `Rejecting tx ${getTxHash(tx)} for low expiration timestamp. Tx expiration timestamp: ${includeByTimestamp}, timestamp: ${
+          this.values.timestamp
+        }.`,
+      );
+      return Promise.resolve({ result: 'invalid', reason: [TX_ERROR_INVALID_INCLUDE_BY_TIMESTAMP] });
+    } else {
+      return Promise.resolve({ result: 'valid' });
+    }
+  }
+}

--- a/yarn-project/p2p/src/test-helpers/mock-tx-helpers.ts
+++ b/yarn-project/p2p/src/test-helpers/mock-tx-helpers.ts
@@ -1,0 +1,24 @@
+import { Fr } from '@aztec/foundation/fields';
+import { getVKTreeRoot } from '@aztec/noir-protocol-circuits-types/vk-tree';
+import { protocolContractsHash } from '@aztec/protocol-contracts';
+import { mockTx } from '@aztec/stdlib/testing';
+import { Tx } from '@aztec/stdlib/tx';
+
+import type { P2PConfig } from '../config.js';
+
+/**
+ * Helper function to create mock transactions with the correct metadata values
+ * that will pass validation when sent over the p2p network.
+ *
+ * @param config - The P2P configuration containing chainId and rollupVersion
+ * @param seed - Optional seed for the mock transaction
+ * @returns A mock transaction with valid metadata for p2p network transmission
+ */
+export const createMockTxWithMetadata = (config: P2PConfig, seed?: number): Promise<Tx> => {
+  return mockTx(seed, {
+    chainId: new Fr(config.l1ChainId),
+    version: new Fr(config.rollupVersion),
+    vkTreeRoot: getVKTreeRoot(),
+    protocolContractsHash,
+  });
+};

--- a/yarn-project/sequencer-client/src/tx_validator/tx_validator_factory.ts
+++ b/yarn-project/sequencer-client/src/tx_validator/tx_validator_factory.ts
@@ -9,6 +9,7 @@ import {
   GasTxValidator,
   MetadataTxValidator,
   PhasesTxValidator,
+  TimestampTxValidator,
   TxPermittedValidator,
   TxProofValidator,
 } from '@aztec/p2p';
@@ -57,10 +58,12 @@ export function createValidatorForAcceptingTxs(
     new MetadataTxValidator({
       l1ChainId: new Fr(l1ChainId),
       rollupVersion: new Fr(rollupVersion),
-      timestamp,
-      blockNumber,
       protocolContractsHash,
       vkTreeRoot: getVKTreeRoot(),
+    }),
+    new TimestampTxValidator({
+      timestamp,
+      blockNumber,
     }),
     new DoubleSpendTxValidator(new NullifierCache(db)),
     new PhasesTxValidator(contractDataSource, setupAllowList, timestamp),
@@ -114,10 +117,12 @@ function preprocessValidator(
     new MetadataTxValidator({
       l1ChainId: globalVariables.chainId,
       rollupVersion: globalVariables.version,
-      timestamp: globalVariables.timestamp,
-      blockNumber: globalVariables.blockNumber,
       protocolContractsHash,
       vkTreeRoot: getVKTreeRoot(),
+    }),
+    new TimestampTxValidator({
+      timestamp: globalVariables.timestamp,
+      blockNumber: globalVariables.blockNumber,
     }),
     new DoubleSpendTxValidator(nullifierCache),
     new PhasesTxValidator(contractDataSource, setupAllowList, globalVariables.timestamp),

--- a/yarn-project/stdlib/src/tx/tx.ts
+++ b/yarn-project/stdlib/src/tx/tx.ts
@@ -162,6 +162,16 @@ export class Tx extends Gossipable {
   }
 
   /**
+   * Validates that the tx hash matches the computed hash from the tx data.
+   * This should be called when deserializing a tx from an untrusted source.
+   * @returns true if the hash is valid, false otherwise
+   */
+  async validateTxHash(): Promise<boolean> {
+    const expectedHash = await Tx.computeTxHash(this);
+    return this.txHash.equals(expectedHash);
+  }
+
+  /**
    * Gets public logs emitted by this tx.
    * @param logsSource - An instance of `L2LogsSource` which can be used to obtain the logs.
    * @returns The requested logs.

--- a/yarn-project/telemetry-client/src/attributes.ts
+++ b/yarn-project/telemetry-client/src/attributes.ts
@@ -41,6 +41,8 @@ export const APP_CIRCUIT_NAME = 'aztec.circuit.app_circuit_name';
 export const BLOCK_ARCHIVE = 'aztec.block.archive';
 /** The block number */
 export const BLOCK_NUMBER = 'aztec.block.number';
+/** The L2 block hash */
+export const BLOCK_HASH = 'aztec.block.hash';
 /** The slot number */
 export const SLOT_NUMBER = 'aztec.slot.number';
 /** The parent's block number */


### PR DESCRIPTION
Ensures tx hashes returned to the tx collection sink (and present in block proposal bodies) are correct.

Also adds validation for txs requested via the BLOCK_TX reqresp subprotocol. These are lighter validations than those for gossipsub.

Fixes A-129
