### PR TITLE
chore: refresh apt pkg cache

### DIFF
--- a/.github/workflows/ci3.yml
+++ b/.github/workflows/ci3.yml
@@ -89,7 +89,7 @@ jobs:
           mkdir -p ~/.ssh
           echo ${{ secrets.BUILD_INSTANCE_SSH_KEY }} | base64 --decode > ~/.ssh/build_instance_key
           chmod 600 ~/.ssh/build_instance_key
-          sudo apt install -y --no-install-recommends redis-tools parallel
+          sudo apt update && sudo apt install -y --no-install-recommends redis-tools parallel
 
       - name: Store the GCP key in a file
         env:


### PR DESCRIPTION
Refresh apt cache to fix

```
E: Failed to fetch mirror+file:/etc/apt/apt-mirrors.txt/pool/universe/r/redis/redis-tools_7.0.15-1ubuntu0.24.04.1_amd64.deb  404  Not Found [IP: 52.154.174.208 80]
```