### PR TITLE
chore: add test ignore pattern for l1_tx_utils nonce too low error

### DIFF
--- a/.test_patterns.yml
+++ b/.test_patterns.yml
@@ -323,6 +323,10 @@ tests:
     error_regex: "✕ attempts to cancel timed out blob transactions with correct parameters"
     owners:
       - *palla
+  - regex: "ethereum/src/l1_tx_utils/l1_tx_utils.test.ts"
+    error_regex: "nonce too low"
+    owners:
+      - *palla
   - regex: "ivc-integration/src/rollup_ivc_integration.test.ts"
     error_regex: "Exceeded timeout of"
     owners:


### PR DESCRIPTION
## Summary

- Added test ignore pattern for `ethereum/src/l1_tx_utils/l1_tx_utils.test.ts` when it fails with "nonce too low" error
- This addresses the test failure from http://ci.aztec-labs.com/a220d7d5e8299edf.txt

## Test plan

- CI should now recognize this test failure pattern and notify the appropriate owners (@spalladino) instead of failing the build

🤖 Generated with [Claude Code](https://claude.com/claude-code)