### PR TITLE
issue: failure for "VK consistency" 

### DIFF
--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_format.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_format.cpp
@@ -682,13 +682,16 @@ process_avm_recursion_constraints(Builder& builder,
 template <> UltraCircuitBuilder create_circuit(AcirProgram& program, const ProgramMetadata& metadata)
 {
     BB_BENCH();
+    info("creating the circuit...");
     AcirFormat& constraints = program.constraints;
     WitnessVector& witness = program.witness;
 
     Builder builder{ metadata.size_hint, witness, constraints.public_inputs, constraints.varnum };
-
+    info("varnum is: ", constraints.varnum);
+    std::cerr << "varnum is: " << constraints.varnum << std::endl;
+    std::cerr.flush();
     build_constraints(builder, program, metadata);
-
+    info("created the circuit");
     vinfo("created circuit");
 
     return builder;
@@ -711,6 +714,7 @@ template <> MegaCircuitBuilder create_circuit(AcirProgram& program, const Progra
     // Construct a builder using the witness and public input data from acir and with the goblin-owned op_queue
     auto builder = MegaCircuitBuilder{ op_queue, witness, constraints.public_inputs, constraints.varnum };
 
+    info("varnum is: ", constraints.varnum);
     // Populate constraints in the builder via the data in constraint_system
     build_constraints(builder, program, metadata);
 

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/ecdsa_constraints.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/ecdsa_constraints.test.cpp
@@ -151,6 +151,7 @@ TYPED_TEST(EcdsaConstraintsTest, GenerateVKFromConstraints)
 
     std::shared_ptr<VerificationKey> vk_from_witness;
     {
+        info("running with witness...");
         AcirProgram program{ constraint_system, witness_values };
         auto builder = create_circuit<Builder>(program);
         info("Num gates: ", builder.get_estimated_num_finalized_gates());
@@ -164,10 +165,57 @@ TYPED_TEST(EcdsaConstraintsTest, GenerateVKFromConstraints)
 
     std::shared_ptr<VerificationKey> vk_from_constraint;
     {
+        info("running without witness...");
         AcirProgram program{ constraint_system, /*witness=*/{} };
         auto builder = create_circuit<Builder>(program);
         auto prover_instance = std::make_shared<ProvingKey>(builder);
         vk_from_constraint = std::make_shared<VerificationKey>(prover_instance->get_precomputed());
+    }
+
+    // Debug: Compare individual commitments
+    info("Comparing VK commitments:");
+    info("log_circuit_size: ", vk_from_witness->log_circuit_size, " vs ", vk_from_constraint->log_circuit_size);
+    info("num_public_inputs: ", vk_from_witness->num_public_inputs, " vs ", vk_from_constraint->num_public_inputs);
+    info("pub_inputs_offset: ", vk_from_witness->pub_inputs_offset, " vs ", vk_from_constraint->pub_inputs_offset);
+
+    std::vector<std::string> names = { "q_m",
+                                       "q_c",
+                                       "q_l",
+                                       "q_r",
+                                       "q_o",
+                                       "q_4",
+                                       "q_lookup",
+                                       "q_arith",
+                                       "q_delta_range",
+                                       "q_elliptic",
+                                       "q_memory",
+                                       "q_nnf",
+                                       "q_poseidon2_external",
+                                       "q_poseidon2_internal",
+                                       "sigma_1",
+                                       "sigma_2",
+                                       "sigma_3",
+                                       "sigma_4",
+                                       "id_1",
+                                       "id_2",
+                                       "id_3",
+                                       "id_4",
+                                       "table_1",
+                                       "table_2",
+                                       "table_3",
+                                       "table_4",
+                                       "lagrange_first",
+                                       "lagrange_last" };
+
+    auto commitments_witness = vk_from_witness->get_all();
+    auto commitments_constraint = vk_from_constraint->get_all();
+
+    for (size_t i = 0; i < commitments_witness.size(); ++i) {
+        if (commitments_witness[i] != commitments_constraint[i]) {
+            info("DIFFERENCE at ", names[i], " (index ", i, ")");
+            info("  witness:    ", commitments_witness[i]);
+            info("  constraint: ", commitments_constraint[i]);
+        }
     }
 
     EXPECT_EQ(*vk_from_witness, *vk_from_constraint);

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/ecdsa_constraints.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/ecdsa_constraints.test.cpp
@@ -142,6 +142,7 @@ TYPED_TEST_SUITE(EcdsaConstraintsTest, CurveTypes);
 
 TYPED_TEST(EcdsaConstraintsTest, GenerateVKFromConstraints)
 {
+    BB_DISABLE_ASSERTS();
     using Flavor = TestFixture::Flavor;
     using Builder = TestFixture::Builder;
     using ProvingKey = ProverInstance_<Flavor>;
@@ -221,91 +222,91 @@ TYPED_TEST(EcdsaConstraintsTest, GenerateVKFromConstraints)
     EXPECT_EQ(*vk_from_witness, *vk_from_constraint);
 }
 
-// Validate the predicate for EcdsaConstraint
-TYPED_TEST(EcdsaConstraintsTest, EcdsaPredicate)
-{
-    using Builder = TestFixture::Builder;
-    auto [constraint_system, witness_values] = TestFixture::generate_constraint_system();
+// // Validate the predicate for EcdsaConstraint
+// TYPED_TEST(EcdsaConstraintsTest, EcdsaPredicate)
+// {
+//     using Builder = TestFixture::Builder;
+//     auto [constraint_system, witness_values] = TestFixture::generate_constraint_system();
 
-    // Create a predicate witness or constant which takes the index of the last witness in the array
-    auto predicate = WitnessOrConstant<fr>::from_index(static_cast<uint32_t>(witness_values.size()));
+//     // Create a predicate witness or constant which takes the index of the last witness in the array
+//     auto predicate = WitnessOrConstant<fr>::from_index(static_cast<uint32_t>(witness_values.size()));
 
-    witness_values.push_back(fr(1));
-    if (constraint_system.ecdsa_k1_constraints.size() == 1) {
-        constraint_system.ecdsa_k1_constraints[0].predicate = predicate;
-    } else if (constraint_system.ecdsa_r1_constraints.size() == 1) {
-        constraint_system.ecdsa_r1_constraints[0].predicate = predicate;
-    }
+//     witness_values.push_back(fr(1));
+//     if (constraint_system.ecdsa_k1_constraints.size() == 1) {
+//         constraint_system.ecdsa_k1_constraints[0].predicate = predicate;
+//     } else if (constraint_system.ecdsa_r1_constraints.size() == 1) {
+//         constraint_system.ecdsa_r1_constraints[0].predicate = predicate;
+//     }
 
-    // Correct input AND true predicate => Valid Circuit
-    {
-        AcirProgram program{ constraint_system, witness_values };
-        auto builder = create_circuit<Builder>(program);
+//     // Correct input AND true predicate => Valid Circuit
+//     {
+//         AcirProgram program{ constraint_system, witness_values };
+//         auto builder = create_circuit<Builder>(program);
 
-        info("Num gates: ", builder.get_estimated_num_finalized_gates());
+//         info("Num gates: ", builder.get_estimated_num_finalized_gates());
 
-        // Validate the builder
-        EXPECT_TRUE(CircuitChecker::check(builder));
-    }
-    // Correct input AND false predicate => Valid Circuit
-    witness_values.back() = fr(0);
-    {
-        AcirProgram program{ constraint_system, witness_values };
-        auto builder = create_circuit<Builder>(program);
+//         // Validate the builder
+//         EXPECT_TRUE(CircuitChecker::check(builder));
+//     }
+//     // Correct input AND false predicate => Valid Circuit
+//     witness_values.back() = fr(0);
+//     {
+//         AcirProgram program{ constraint_system, witness_values };
+//         auto builder = create_circuit<Builder>(program);
 
-        info("Num gates: ", builder.get_estimated_num_finalized_gates());
+//         info("Num gates: ", builder.get_estimated_num_finalized_gates());
 
-        // Validate the builder
-        EXPECT_TRUE(CircuitChecker::check(builder));
-    }
-    // Incorrect input AND false predicate => Valid Circuit
-    witness_values[40] = fr(0); // change a byte in the signature
-    {
-        AcirProgram program{ constraint_system, witness_values };
-        auto builder = create_circuit<Builder>(program);
+//         // Validate the builder
+//         EXPECT_TRUE(CircuitChecker::check(builder));
+//     }
+//     // Incorrect input AND false predicate => Valid Circuit
+//     witness_values[40] = fr(0); // change a byte in the signature
+//     {
+//         AcirProgram program{ constraint_system, witness_values };
+//         auto builder = create_circuit<Builder>(program);
 
-        info("Num gates: ", builder.get_estimated_num_finalized_gates());
+//         info("Num gates: ", builder.get_estimated_num_finalized_gates());
 
-        // Validate the builder
-        EXPECT_TRUE(CircuitChecker::check(builder));
-    }
-    // Incorrect input AND true predicate => Invalid Circuit
-    witness_values.back() = fr(1);
-    {
-        AcirProgram program{ constraint_system, witness_values };
-        auto builder = create_circuit<Builder>(program);
+//         // Validate the builder
+//         EXPECT_TRUE(CircuitChecker::check(builder));
+//     }
+//     // Incorrect input AND true predicate => Invalid Circuit
+//     witness_values.back() = fr(1);
+//     {
+//         AcirProgram program{ constraint_system, witness_values };
+//         auto builder = create_circuit<Builder>(program);
 
-        info("Num gates: ", builder.get_estimated_num_finalized_gates());
+//         info("Num gates: ", builder.get_estimated_num_finalized_gates());
 
-        EXPECT_TRUE(builder.failed());
-    }
-}
+//         EXPECT_TRUE(builder.failed());
+//     }
+// }
 
-TYPED_TEST(EcdsaConstraintsTest, NonUniquePubKey)
-{
-    // Disable asserts otherwise the test fails because the public keys are not on the curve
-    BB_DISABLE_ASSERTS();
+// TYPED_TEST(EcdsaConstraintsTest, NonUniquePubKey)
+// {
+//     // Disable asserts otherwise the test fails because the public keys are not on the curve
+//     BB_DISABLE_ASSERTS();
 
-    for (size_t idx = 0; idx < 2; idx++) {
-        bool tweak_x = idx == 0;
-        bool tweak_y = idx == 1;
-        std::string failure_msg =
-            idx == 0
-                ? "ECDSA input validation: the x coordinate of the public key is larger than Fq::modulus: hi limb."
-                : "ECDSA input validation: the y coordinate of the public key is larger than Fq::modulus: hi limb.";
+//     for (size_t idx = 0; idx < 2; idx++) {
+//         bool tweak_x = idx == 0;
+//         bool tweak_y = idx == 1;
+//         std::string failure_msg =
+//             idx == 0
+//                 ? "ECDSA input validation: the x coordinate of the public key is larger than Fq::modulus: hi limb."
+//                 : "ECDSA input validation: the y coordinate of the public key is larger than Fq::modulus: hi limb.";
 
-        using Builder = TestFixture::Builder;
+//         using Builder = TestFixture::Builder;
 
-        auto [constraint_system, witness_values] =
-            TestFixture::generate_constraint_system(/*tweak_pub_key_x=*/tweak_x, /*tweak_pub_key_y=*/tweak_y);
+//         auto [constraint_system, witness_values] =
+//             TestFixture::generate_constraint_system(/*tweak_pub_key_x=*/tweak_x, /*tweak_pub_key_y=*/tweak_y);
 
-        AcirProgram program{ constraint_system, witness_values };
-        auto builder = create_circuit<Builder>(program);
+//         AcirProgram program{ constraint_system, witness_values };
+//         auto builder = create_circuit<Builder>(program);
 
-        // Validate the builder
-        EXPECT_FALSE(CircuitChecker::check(builder));
+//         // Validate the builder
+//         EXPECT_FALSE(CircuitChecker::check(builder));
 
-        // Check error message
-        EXPECT_EQ(builder.err(), failure_msg);
-    }
-}
+//         // Check error message
+//         EXPECT_EQ(builder.err(), failure_msg);
+//     }
+// }

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/poseidon2_constraint.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/poseidon2_constraint.test.cpp
@@ -62,4 +62,65 @@ TEST_F(Poseidon2Tests, TestPoseidon2Permutation)
     EXPECT_TRUE(CircuitChecker::check(builder));
 }
 
+TEST_F(Poseidon2Tests, GenerateVKFromConstraints)
+{
+    using Flavor = UltraFlavor;
+    using VerificationKey = Flavor::VerificationKey;
+    using ProvingKey = ProverInstance_<Flavor>;
+    Poseidon2Constraint
+        poseidon2_constraint{
+            .state = {
+                WitnessOrConstant<bb::fr>::from_index(1),
+                WitnessOrConstant<bb::fr>::from_index(2),
+                WitnessOrConstant<bb::fr>::from_index(3),
+                WitnessOrConstant<bb::fr>::from_index(4),
+ },
+            .result = { 5, 6, 7, 8, },
+        };
+
+    AcirFormat constraint_system{
+        .varnum = 9,
+        .num_acir_opcodes = 1,
+        .public_inputs = {},
+        .poseidon2_constraints = { poseidon2_constraint },
+        .original_opcode_indices = create_empty_original_opcode_indices(),
+    };
+    mock_opcode_indices(constraint_system);
+
+    WitnessVector witness_values{
+        1,
+        0,
+        1,
+        2,
+        3,
+        fr(std::string("0x01bd538c2ee014ed5141b29e9ae240bf8db3fe5b9a38629a9647cf8d76c01737")),
+        fr(std::string("0x239b62e7db98aa3a2a8f6a0d2fa1709e7a35959aa6c7034814d9daa90cbac662")),
+        fr(std::string("0x04cbb44c61d928ed06808456bf758cbf0c18d1e15a7b6dbc8245fa7515d5e3cb")),
+        fr(std::string("0x2e11c5cff2a22c64d01304b778d78f6998eff1ab73163a35603f54794c30847a")),
+    };
+
+    std::shared_ptr<VerificationKey> vk_from_witness;
+    {
+        AcirProgram program{ constraint_system, witness_values };
+        auto builder = create_circuit<Builder>(program);
+        info("Num gates: ", builder.get_estimated_num_finalized_gates());
+
+        auto prover_instance = std::make_shared<ProvingKey>(builder);
+        vk_from_witness = std::make_shared<VerificationKey>(prover_instance->get_precomputed());
+
+        // Validate the builder
+        EXPECT_TRUE(CircuitChecker::check(builder));
+    }
+
+    std::shared_ptr<VerificationKey> vk_from_constraint;
+    {
+        AcirProgram program{ constraint_system, /*witness=*/{} };
+        auto builder = create_circuit<Builder>(program);
+        auto prover_instance = std::make_shared<ProvingKey>(builder);
+        vk_from_constraint = std::make_shared<VerificationKey>(prover_instance->get_precomputed());
+    }
+
+    EXPECT_EQ(*vk_from_witness, *vk_from_constraint);
+}
+
 } // namespace acir_format::tests

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_secp256k1.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_secp256k1.hpp
@@ -47,8 +47,11 @@ element<C, Fq, Fr, G> element<C, Fq, Fr, G>::secp256k1_ecdsa_mul(const element& 
      * We do NOT range constrain the wNAF entries, because we will use them to lookup in a ROM/regular table.
      * The ROM/regular table lookup implicitly enforces the range constraint
      */
+    info(u1.get_value());
+    info(u2.get_value());
+    Fr to_be_passed = Fr::from_witness(u1.get_context(), bb::field<typename Fr::TParams>::one());
     const auto [u1_lo_wnaf, u1_hi_wnaf] = compute_secp256k1_endo_wnaf<8, 2, 3>(u1, false);
-    const auto [u2_lo_wnaf, u2_hi_wnaf] = compute_secp256k1_endo_wnaf<4, 0, 1>(u2, false);
+    const auto [u2_lo_wnaf, u2_hi_wnaf] = compute_secp256k1_endo_wnaf<4, 0, 1>(to_be_passed, false);
 
     /**
      * Construct our 4-bit variable-base and 8-bit fixed base lookup tables

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/rom_ram_logic.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/rom_ram_logic.cpp
@@ -193,7 +193,7 @@ void RomRamLogic_<ExecutionTrace>::process_ROM_array(CircuitBuilder* builder, co
         builder->update_used_witnesses(index_witness);
         const auto value1_witness = builder->add_variable(value1);
         const auto value2_witness = builder->add_variable(value2);
-        RomRecord sorted_record{
+        [[maybe_unused]] RomRecord old_sorted_record{
             .index_witness = index_witness,
             .value_column1_witness = value1_witness,
             .value_column2_witness = value2_witness,
@@ -201,6 +201,12 @@ void RomRamLogic_<ExecutionTrace>::process_ROM_array(CircuitBuilder* builder, co
             .record_witness = 0,
             .gate_index = 0,
         };
+        // Note that the _values_ in `old_sorted_record` will be the same as the values in `record`, except for
+        // `gate_index`. HOWEVER, the witness indices will be different. While I was thinking through some aspects of
+        // the execution trace, I tried the following:
+        [[maybe_unused]] RomRecord sorted_record(record);
+        // note that this _simply copies_ the contents of `record` into `sorted_record`. Then `create_sorted_ROM_gate`
+        // will set the `gate_index` correctly.
         create_sorted_ROM_gate(builder, sorted_record);
 
         builder->assign_tag(record.record_witness, read_tag);


### PR DESCRIPTION
### Punchline
After making a trivial change to witness gen for ROM tables (to make sure something worked as I expected), I'm getting a failure in some `acir` tests of the form: vk from constraint $\neq$ vk after witness generation. The change involved _repeating witness indices_ (as opposed to create new witness indices with the same values and then setting a copy constraint).

The memory testing in `ultra_honk_tests` all pass.

#### (some) failing tests
`CivcRecursionConstraintTest.GenerateRecursiveCivcVerifierVKFromConstraints`
`EcdsaConstraintsTest/0.GenerateVKFromConstraints`
`EcdsaConstraintsTest/1.GenerateVKFromConstraints`
`EcdsaConstraintsTest/2.GenerateVKFromConstraints`
`EcdsaConstraintsTest/3.GenerateVKFromConstraints`
`AcirHonkRecursionConstraint/0.TestHonkRecursionConstraintVKGeneration`
`AcirHonkRecursionConstraint/1.TestHonkRecursionConstraintVKGeneration`
`AcirHonkRecursionConstraint/3.TestHonkRecursionConstraintVKGeneration`

### Background
I was trying to understand what gates were added in the `stdlib` construction of ROM/RAM tables to potentially simplify some code. The change I made involves repeating witness indices in the execution trace (as opposed to what was written before, which creates new witness indices and then uses `assign_tag` to set a single copy constraint). (Removing the currently superfluous tags doesn't fix the problem.)

This doesn't change the _values_ in the execution trace.

There are other parts of current circuit code (e.g. `process_RAM_table`, and others according to @suyash67 ) where witness indices are reused. 

As far as I can tell, the VK consistency tests never use RAM tables.

### Question
Is it "good practice" to never repeat witness indices (and just directly use copy constraints via `assign_tag` or `assert_equal`) during witness generation?

### Resolution
Repeating witness indices amounts to copy constraints. However, the relative positions of these copy constraints will depend on the witness, i.e., the particular indices we put in the table. These will cause the polynomials that bear witness to the multiset equality argument to be witness-dependent.