### PR TITLE
refactor(bb): ASSERT => BB_ASSERT

### DIFF
--- a/barretenberg/cpp/src/barretenberg/benchmark/ipa_bench/ipa.bench.cpp
+++ b/barretenberg/cpp/src/barretenberg/benchmark/ipa_bench/ipa.bench.cpp
@@ -64,7 +64,7 @@ void ipa_verify(State& state) noexcept
 
         state.ResumeTiming();
         auto result = IPA<Curve>::reduce_verify(vk, opening_claim, verifier_transcript);
-        ASSERT(result);
+        BB_ASSERT(result);
     }
 }
 } // namespace

--- a/barretenberg/cpp/src/barretenberg/boomerang_value_detection/graph.cpp
+++ b/barretenberg/cpp/src/barretenberg/boomerang_value_detection/graph.cpp
@@ -340,7 +340,7 @@ inline std::vector<uint32_t> StaticAnalyzer_<FF, CircuitBuilder>::get_memory_gat
         auto q_3 = block.q_3()[index];
         auto q_4 = block.q_4()[index];
         if (q_1 == FF::one() && q_4 == FF::one()) {
-            ASSERT(q_3.is_zero());
+            BB_ASSERT(q_3.is_zero());
             // ram timestamp check
             if (index < block.size() - 1) {
                 gate_variables.insert(gate_variables.end(),
@@ -351,7 +351,7 @@ inline std::vector<uint32_t> StaticAnalyzer_<FF, CircuitBuilder>::get_memory_gat
                                         block.w_o()[index] });
             }
         } else if (q_1 == FF::one() && q_2 == FF::one()) {
-            ASSERT(q_3.is_zero());
+            BB_ASSERT(q_3.is_zero());
             // rom constitency check
             if (index < block.size() - 1) {
                 gate_variables.insert(
@@ -429,14 +429,14 @@ inline std::vector<uint32_t> StaticAnalyzer_<FF, CircuitBuilder>::get_non_native
                 };
                 if (q_3 == FF::one()) {
                     // bigfield product 1
-                    ASSERT(q_4.is_zero() && q_m.is_zero());
+                    BB_ASSERT(q_4.is_zero() && q_m.is_zero());
                     gate_variables.insert(
                         gate_variables.end(), limb_subproduct_vars.begin(), limb_subproduct_vars.end());
                     gate_variables.insert(gate_variables.end(), { w_o, w_4 });
                 }
                 if (q_4 == FF::one()) {
                     // bigfield product 2
-                    ASSERT(q_3.is_zero() && q_m.is_zero());
+                    BB_ASSERT(q_3.is_zero() && q_m.is_zero());
                     std::vector<uint32_t> non_native_field_gate_2 = { w_l, w_4, w_r, w_o, block.w_o()[index + 1] };
                     gate_variables.insert(
                         gate_variables.end(), non_native_field_gate_2.begin(), non_native_field_gate_2.end());
@@ -446,7 +446,7 @@ inline std::vector<uint32_t> StaticAnalyzer_<FF, CircuitBuilder>::get_non_native
                 }
                 if (q_m == FF::one()) {
                     // bigfield product 3
-                    ASSERT(q_4.is_zero() && q_3.is_zero());
+                    BB_ASSERT(q_4.is_zero() && q_3.is_zero());
                     gate_variables.insert(
                         gate_variables.end(), limb_subproduct_vars.begin(), limb_subproduct_vars.end());
                     gate_variables.insert(gate_variables.end(),
@@ -673,7 +673,7 @@ template <typename FF, typename CircuitBuilder> void StaticAnalyzer_<FF, Circuit
             };
             auto non_empty_count =
                 std::count_if(all_cc.begin(), all_cc.end(), [](const auto& vec) { return !vec.empty(); });
-            ASSERT(non_empty_count < 2U);
+            BB_ASSERT(non_empty_count < 2U);
             auto not_empty_cc_it =
                 std::find_if(all_cc.begin(), all_cc.end(), [](const auto& vec) { return !vec.empty(); });
             if (not_empty_cc_it != all_cc.end() && connect_variables) {

--- a/barretenberg/cpp/src/barretenberg/circuit_checker/ultra_circuit_builder.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/circuit_checker/ultra_circuit_builder.test.cpp
@@ -728,7 +728,7 @@ TEST(UltraCircuitBuilder, NonNativeFieldMultiplicationRegression)
 
     // Range check the carry (output) lo and hi limbs
     const bool is_high_70_bits = uint256_t(builder.get_variable(hi_1_idx)).get_msb() < 70;
-    ASSERT(is_high_70_bits == false); // Regression should hit this case
+    BB_ASSERT(is_high_70_bits == false); // Regression should hit this case
 
     // Decompose into default range: these should work even if the limbs are > 2^70
     builder.decompose_into_default_range(lo_1_idx, 72);

--- a/barretenberg/cpp/src/barretenberg/circuit_checker/ultra_circuit_checker.cpp
+++ b/barretenberg/cpp/src/barretenberg/circuit_checker/ultra_circuit_checker.cpp
@@ -236,7 +236,7 @@ template <typename Builder> bool UltraCircuitChecker::check_databus_read(auto& v
         bool is_calldata_read = (values.q_l == 1);
         bool is_secondary_calldata_read = (values.q_r == 1);
         bool is_return_data_read = (values.q_o == 1);
-        ASSERT(is_calldata_read || is_secondary_calldata_read || is_return_data_read);
+        BB_ASSERT(is_calldata_read || is_secondary_calldata_read || is_return_data_read);
 
         // Check that the claimed value is present in the calldata/return data at the corresponding index
         FF bus_value;

--- a/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.cpp
+++ b/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.cpp
@@ -229,7 +229,7 @@ ClientIVC::perform_recursive_verification_and_databus_consistency_checks(
                      "Kernel circuits should be folded.");
         // Get the previous accum hash
         info("PG accum hash from IO: ", kernel_input.output_pg_accum_hash);
-        ASSERT(prev_accum_hash.has_value());
+        BB_ASSERT(prev_accum_hash.has_value());
         kernel_input.output_pg_accum_hash.assert_equal(*prev_accum_hash);
 
         if (!is_hiding_kernel) {
@@ -447,7 +447,7 @@ void ClientIVC::accumulate(ClientCircuit& circuit, const std::shared_ptr<MegaVer
     BB_ASSERT_LT(
         num_circuits_accumulated, num_circuits, "ClientIVC: Attempting to accumulate more circuits than expected.");
 
-    ASSERT(precomputed_vk != nullptr, "ClientIVC::accumulate - VK expected for the provided circuit");
+    BB_ASSERT(precomputed_vk != nullptr, "ClientIVC::accumulate - VK expected for the provided circuit");
 
     // Construct the prover instance for circuit
     std::shared_ptr<ProverInstance> prover_instance = std::make_shared<ProverInstance>(circuit, trace_settings);

--- a/barretenberg/cpp/src/barretenberg/client_ivc/sumcheck_client_ivc.cpp
+++ b/barretenberg/cpp/src/barretenberg/client_ivc/sumcheck_client_ivc.cpp
@@ -187,7 +187,7 @@ SumcheckClientIVC::perform_recursive_verification_and_databus_consistency_checks
                      "Kernel circuits should be folded.");
         // Get the previous accum hash
         info("Accumulator hash from IO: ", kernel_input.output_pg_accum_hash);
-        ASSERT(prev_accum_hash.has_value());
+        BB_ASSERT(prev_accum_hash.has_value());
         kernel_input.output_pg_accum_hash.assert_equal(*prev_accum_hash);
 
         if (!is_hiding_kernel) {
@@ -358,7 +358,7 @@ void SumcheckClientIVC::accumulate(ClientCircuit& circuit, const std::shared_ptr
                  num_circuits,
                  "SumcheckClientIVC: Attempting to accumulate more circuits than expected.");
 
-    ASSERT(precomputed_vk != nullptr, "SumcheckClientIVC::accumulate - VK expected for the provided circuit");
+    BB_ASSERT(precomputed_vk != nullptr, "SumcheckClientIVC::accumulate - VK expected for the provided circuit");
 
     // Construct the prover instance for circuit
     std::shared_ptr<ProverInstance> prover_instance = std::make_shared<ProverInstance>(circuit);

--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/ipa/ipa.hpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/ipa/ipa.hpp
@@ -182,7 +182,7 @@ template <typename Curve_, size_t log_poly_length = CONST_ECCVM_LOG_N> class IPA
 
         // Checks poly_degree is greater than zero and a power of two
         // In the future, we might want to consider if non-powers of two are needed
-        ASSERT((poly_length > 0) && (!(poly_length & (poly_length - 1))) &&
+        BB_ASSERT((poly_length > 0) && (!(poly_length & (poly_length - 1))) &&
                "The polynomial degree plus 1 should be positive and a power of two");
 
         // Step 4.

--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/ipa/ipa.hpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/ipa/ipa.hpp
@@ -183,7 +183,7 @@ template <typename Curve_, size_t log_poly_length = CONST_ECCVM_LOG_N> class IPA
         // Checks poly_degree is greater than zero and a power of two
         // In the future, we might want to consider if non-powers of two are needed
         BB_ASSERT((poly_length > 0) && (!(poly_length & (poly_length - 1))) &&
-               "The polynomial degree plus 1 should be positive and a power of two");
+                  "The polynomial degree plus 1 should be positive and a power of two");
 
         // Step 4.
         // Set initial vector a to the polynomial monomial coefficients and load vector G

--- a/barretenberg/cpp/src/barretenberg/common/assert.hpp
+++ b/barretenberg/cpp/src/barretenberg/common/assert.hpp
@@ -55,7 +55,6 @@ struct AssertGuard {
 #endif // NDEBUG
 
 #ifdef __wasm__
-#define BB_ASSERT_IN_CONSTEXPR(expression, ...) DONT_EVALUATE((expression))
 #define BB_ASSERT(expression, ...) DONT_EVALUATE((expression))
 
 #define BB_ASSERT_EQ(actual, expected, ...) DONT_EVALUATE((actual) == (expected))
@@ -65,8 +64,6 @@ struct AssertGuard {
 #define BB_ASSERT_LT(left, right, ...) DONT_EVALUATE((left) < (right))
 #define BB_ASSERT_LTE(left, right, ...) DONT_EVALUATE((left) <= (right))
 #else
-#define BB_ASSERT_IN_CONSTEXPR(expression, ...) BB_ASSERT(expression, __VA_ARGS__)
-
 #define BB_ASSERT(expression, ...)                                                                                        \
     do {                                                                                                               \
         BB_BENCH_ASSERT("BB_ASSERT" #expression);                                                                         \

--- a/barretenberg/cpp/src/barretenberg/common/assert.hpp
+++ b/barretenberg/cpp/src/barretenberg/common/assert.hpp
@@ -65,17 +65,15 @@ struct AssertGuard {
 #define BB_ASSERT_LT(left, right, ...) DONT_EVALUATE((left) < (right))
 #define BB_ASSERT_LTE(left, right, ...) DONT_EVALUATE((left) <= (right))
 #else
-// BB_ASSERT_IN_CONSTEXPR: For use in constexpr functions. Does nothing, as we cannot assert in constexpr contexts.
-#define BB_ASSERT_IN_CONSTEXPR(expression, ...) DONT_EVALUATE((expression))
+#define BB_ASSERT_IN_CONSTEXPR(expression, ...) BB_ASSERT(expression, __VA_ARGS__)
 
 #define BB_ASSERT(expression, ...)                                                                                        \
     do {                                                                                                               \
         BB_BENCH_ASSERT("BB_ASSERT" #expression);                                                                         \
         if (!(BB_LIKELY(expression))) {                                                                                \
-            std::ostringstream oss;                                                                                    \
-            oss << "Assertion failed: (" #expression ")";                                                              \
-            __VA_OPT__(oss << " | Reason: " << __VA_ARGS__;)                                                           \
-            bb::assert_failure(oss.str());                                                                             \
+            info("Assertion failed: (" #expression ")");                                                               \
+            __VA_OPT__(info("Reason   : ", __VA_ARGS__);)                                                              \
+            bb::assert_failure("");                                                                                    \
         }                                                                                                              \
     } while (0)
 

--- a/barretenberg/cpp/src/barretenberg/common/assert.hpp
+++ b/barretenberg/cpp/src/barretenberg/common/assert.hpp
@@ -41,7 +41,7 @@ struct AssertGuard {
 #if NDEBUG
 
 // All assertion macros accept an optional message but do nothing in release.
-#define ASSERT_DEBUG(expression, ...) DONT_EVALUATE((expression))
+#define BB_ASSERT_DEBUG(expression, ...) DONT_EVALUATE((expression))
 
 #else
 #include "barretenberg/common/log.hpp"
@@ -51,12 +51,12 @@ struct AssertGuard {
 #include <string>
 
 // Basic assert with optional error message
-#define ASSERT_DEBUG(expression, ...) ASSERT(expression, __VA_ARGS__)
+#define BB_ASSERT_DEBUG(expression, ...) BB_ASSERT(expression, __VA_ARGS__)
 #endif // NDEBUG
 
 #ifdef __wasm__
-#define ASSERT_IN_CONSTEXPR(expression, ...) DONT_EVALUATE((expression))
-#define ASSERT(expression, ...) DONT_EVALUATE((expression))
+#define BB_ASSERT_IN_CONSTEXPR(expression, ...) DONT_EVALUATE((expression))
+#define BB_ASSERT(expression, ...) DONT_EVALUATE((expression))
 
 #define BB_ASSERT_EQ(actual, expected, ...) DONT_EVALUATE((actual) == (expected))
 #define BB_ASSERT_NEQ(actual, expected, ...) DONT_EVALUATE((actual) != (expected))
@@ -65,18 +65,12 @@ struct AssertGuard {
 #define BB_ASSERT_LT(left, right, ...) DONT_EVALUATE((left) < (right))
 #define BB_ASSERT_LTE(left, right, ...) DONT_EVALUATE((left) <= (right))
 #else
-#define ASSERT_IN_CONSTEXPR(expression, ...)                                                                           \
-    do {                                                                                                               \
-        if (!(BB_LIKELY(expression))) {                                                                                \
-            info("Assertion failed: (" #expression ")");                                                               \
-            __VA_OPT__(info("Reason   : ", __VA_ARGS__);)                                                              \
-            bb::assert_failure("");                                                                                    \
-        }                                                                                                              \
-    } while (0)
+// BB_ASSERT_IN_CONSTEXPR: For use in constexpr functions. Does nothing, as we cannot assert in constexpr contexts.
+#define BB_ASSERT_IN_CONSTEXPR(expression, ...) DONT_EVALUATE((expression))
 
-#define ASSERT(expression, ...)                                                                                        \
+#define BB_ASSERT(expression, ...)                                                                                        \
     do {                                                                                                               \
-        BB_BENCH_ASSERT("ASSERT" #expression);                                                                         \
+        BB_BENCH_ASSERT("BB_ASSERT" #expression);                                                                         \
         if (!(BB_LIKELY(expression))) {                                                                                \
             std::ostringstream oss;                                                                                    \
             oss << "Assertion failed: (" #expression ")";                                                              \

--- a/barretenberg/cpp/src/barretenberg/common/assert.hpp
+++ b/barretenberg/cpp/src/barretenberg/common/assert.hpp
@@ -64,9 +64,9 @@ struct AssertGuard {
 #define BB_ASSERT_LT(left, right, ...) DONT_EVALUATE((left) < (right))
 #define BB_ASSERT_LTE(left, right, ...) DONT_EVALUATE((left) <= (right))
 #else
-#define BB_ASSERT(expression, ...)                                                                                        \
+#define BB_ASSERT(expression, ...)                                                                                     \
     do {                                                                                                               \
-        BB_BENCH_ASSERT("BB_ASSERT" #expression);                                                                         \
+        BB_BENCH_ASSERT("BB_ASSERT" #expression);                                                                      \
         if (!(BB_LIKELY(expression))) {                                                                                \
             info("Assertion failed: (" #expression ")");                                                               \
             __VA_OPT__(info("Reason   : ", __VA_ARGS__);)                                                              \

--- a/barretenberg/cpp/src/barretenberg/common/ref_array.hpp
+++ b/barretenberg/cpp/src/barretenberg/common/ref_array.hpp
@@ -48,7 +48,7 @@ template <typename T, std::size_t N> class RefArray {
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Warray-bounds"
 #endif
-        ASSERT_DEBUG(idx < N);
+        BB_ASSERT_DEBUG(idx < N);
         return *storage[idx];
 #if !defined(__clang__) && defined(__GNUC__)
 #pragma GCC diagnostic pop

--- a/barretenberg/cpp/src/barretenberg/common/ref_vector.hpp
+++ b/barretenberg/cpp/src/barretenberg/common/ref_vector.hpp
@@ -62,7 +62,7 @@ template <typename T> class RefVector {
 
     T& operator[](std::size_t idx) const
     {
-        ASSERT_DEBUG(idx < storage.size());
+        BB_ASSERT_DEBUG(idx < storage.size());
         return *storage[idx];
     }
 

--- a/barretenberg/cpp/src/barretenberg/crypto/merkle_tree/hash.hpp
+++ b/barretenberg/cpp/src/barretenberg/crypto/merkle_tree/hash.hpp
@@ -53,7 +53,7 @@ inline bb::fr hash_native(std::vector<bb::fr> const& inputs)
  */
 inline bb::fr compute_tree_root_native(std::vector<bb::fr> const& input)
 {
-    ASSERT(numeric::is_power_of_two(input.size()), "Check if the input vector size is a power of 2.");
+    BB_ASSERT(numeric::is_power_of_two(input.size()), "Check if the input vector size is a power of 2.");
     auto layer = input;
     while (layer.size() > 1) {
         std::vector<bb::fr> next_layer(layer.size() / 2);
@@ -69,7 +69,7 @@ inline bb::fr compute_tree_root_native(std::vector<bb::fr> const& input)
 // TODO write test
 inline std::vector<bb::fr> compute_tree_native(std::vector<bb::fr> const& input)
 {
-    ASSERT(numeric::is_power_of_two(input.size()), "Check if the input vector size is a power of 2.");
+    BB_ASSERT(numeric::is_power_of_two(input.size()), "Check if the input vector size is a power of 2.");
     auto layer = input;
     std::vector<bb::fr> tree(input);
     while (layer.size() > 1) {

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_format.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_format.cpp
@@ -529,7 +529,7 @@ process_honk_recursion_constraints(Builder& builder,
         gate_counter.track_diff(constraint_system.gates_per_opcode,
                                 constraint_system.original_opcode_indices.honk_recursion_constraints.at(idx++));
     }
-    ASSERT(!(output.is_root_rollup && output.nested_ipa_claims.size() != 2),
+    BB_ASSERT(!(output.is_root_rollup && output.nested_ipa_claims.size() != 2),
            "Root rollup must accumulate two IPA proofs.");
     return output;
 }

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_format.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_format.cpp
@@ -530,7 +530,7 @@ process_honk_recursion_constraints(Builder& builder,
                                 constraint_system.original_opcode_indices.honk_recursion_constraints.at(idx++));
     }
     BB_ASSERT(!(output.is_root_rollup && output.nested_ipa_claims.size() != 2),
-           "Root rollup must accumulate two IPA proofs.");
+              "Root rollup must accumulate two IPA proofs.");
     return output;
 }
 

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_to_constraint_buf.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_to_constraint_buf.cpp
@@ -853,7 +853,7 @@ void handle_memory_op(Acir::Opcode::MemoryOp const& mem_op, AcirFormat& af, Bloc
     }
     if (access_type == 1) {
         // We are not allowed to write on the databus
-        ASSERT((block.type != BlockType::CallData) && (block.type != BlockType::ReturnData));
+        BB_ASSERT((block.type != BlockType::CallData) && (block.type != BlockType::ReturnData));
         block.type = BlockType::RAM;
     }
 

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/avm2_recursion_constraint.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/avm2_recursion_constraint.cpp
@@ -110,7 +110,7 @@ void create_dummy_vkey_and_proof(Builder& builder,
     }
 
     // TODO(#13390): Revive the following assertion once we freeze the number of colums in AVM.
-    // ASSERT(offset == proof_size);
+    // BB_ASSERT(offset == proof_size);
 }
 
 } // namespace

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/block_constraint.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/block_constraint.cpp
@@ -117,7 +117,7 @@ void process_ROM_operations(Builder& builder,
         field_ct index = poly_to_field_ct(op.index, builder);
         // For a ROM table, constant read should be optimized out:
         // The rom_table won't work with a constant read because the table may not be initialized
-        ASSERT(op.index.q_l != 0);
+        BB_ASSERT(op.index.q_l != 0);
 
         // In case of invalid witness assignment, we set the value of index value to zero to not hit out of bound in
         // ROM table

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/honk_recursion_constraint.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/honk_recursion_constraint.cpp
@@ -172,7 +172,7 @@ HonkRecursionConstraintOutput<typename Flavor::CircuitBuilder> create_honk_recur
                                   stdlib::recursion::honk::RollupIO,
                                   stdlib::recursion::honk::DefaultIO<Builder>>;
 
-    ASSERT(input.proof_type == HONK || input.proof_type == HONK_ZK || HasIPAAccumulator<Flavor>);
+    BB_ASSERT(input.proof_type == HONK || input.proof_type == HONK_ZK || HasIPAAccumulator<Flavor>);
     BB_ASSERT_EQ(input.proof_type == ROLLUP_HONK || input.proof_type == ROOT_ROLLUP_HONK, HasIPAAccumulator<Flavor>);
 
     // Construct an in-circuit representation of the verification key.

--- a/barretenberg/cpp/src/barretenberg/ecc/batched_affine_addition/batched_affine_addition.cpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/batched_affine_addition/batched_affine_addition.cpp
@@ -163,7 +163,7 @@ std::span<typename BatchedAffineAddition<Curve>::Fq> BatchedAffineAddition<
             const auto& x2 = points[point_idx++].x;
 
             // It is assumed that the input points are random and thus w/h/p do not share an x-coordinate
-            ASSERT(x1 != x2);
+            BB_ASSERT(x1 != x2);
 
             auto diff = x2 - x1;
             differences[pair_idx] = diff;

--- a/barretenberg/cpp/src/barretenberg/ecc/fields/field_conversion.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/fields/field_conversion.hpp
@@ -104,7 +104,7 @@ class FrCodec {
             if (val.x == BaseField::zero() && val.y == BaseField::zero()) {
                 val.self_set_infinity();
             }
-            ASSERT(val.on_curve());
+            BB_ASSERT(val.on_curve());
             return val;
         } else {
             // Array or Univariate
@@ -230,7 +230,7 @@ class U256Codec {
             if (val.x == BaseField::zero() && val.y == BaseField::zero()) {
                 val.self_set_infinity();
             }
-            ASSERT(val.on_curve());
+            BB_ASSERT(val.on_curve());
             return val;
         } else {
             // Array or Univariate

--- a/barretenberg/cpp/src/barretenberg/ecc/fields/field_declarations.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/fields/field_declarations.hpp
@@ -140,7 +140,7 @@ template <class Params_> struct alignas(32) field {
     constexpr explicit operator bool() const
     {
         field out = from_montgomery_form();
-        BB_ASSERT_IN_CONSTEXPR(out.data[0] == 0 || out.data[0] == 1);
+        BB_ASSERT(out.data[0] == 0 || out.data[0] == 1);
         return static_cast<bool>(out.data[0]);
     }
 

--- a/barretenberg/cpp/src/barretenberg/ecc/fields/field_declarations.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/fields/field_declarations.hpp
@@ -140,7 +140,7 @@ template <class Params_> struct alignas(32) field {
     constexpr explicit operator bool() const
     {
         field out = from_montgomery_form();
-        ASSERT_IN_CONSTEXPR(out.data[0] == 0 || out.data[0] == 1);
+        BB_ASSERT_IN_CONSTEXPR(out.data[0] == 0 || out.data[0] == 1);
         return static_cast<bool>(out.data[0]);
     }
 

--- a/barretenberg/cpp/src/barretenberg/ecc/fields/field_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/fields/field_impl.hpp
@@ -577,7 +577,7 @@ template <class T> constexpr field<T> field<T>::tonelli_shanks_sqrt() const noex
             }
         }
 
-        ASSERT_IN_CONSTEXPR(count != table_size);
+        BB_ASSERT_IN_CONSTEXPR(count != table_size);
         e_slices[table_index] = count;
     }
 

--- a/barretenberg/cpp/src/barretenberg/ecc/fields/field_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/fields/field_impl.hpp
@@ -577,7 +577,7 @@ template <class T> constexpr field<T> field<T>::tonelli_shanks_sqrt() const noex
             }
         }
 
-        BB_ASSERT_IN_CONSTEXPR(count != table_size);
+        BB_ASSERT(count != table_size);
         e_slices[table_index] = count;
     }
 

--- a/barretenberg/cpp/src/barretenberg/ecc/groups/affine_element.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/groups/affine_element.hpp
@@ -189,7 +189,7 @@ template <typename Fq_, typename Fr_, typename Params_> class alignas(64) affine
         result.x = Fq::reconstruct_from_public(x_limbs);
         result.y = Fq::reconstruct_from_public(y_limbs);
 
-        ASSERT(result.on_curve());
+        BB_ASSERT(result.on_curve());
         return result;
     }
 

--- a/barretenberg/cpp/src/barretenberg/ecc/scalar_multiplication/bitvector.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/scalar_multiplication/bitvector.hpp
@@ -21,7 +21,7 @@ class BitVector {
 
     BB_INLINE void set(size_t index, bool value) noexcept
     {
-        ASSERT_DEBUG(index < num_bits_);
+        BB_ASSERT_DEBUG(index < num_bits_);
         const size_t word = index >> 6;
         const size_t bit = index & 63;
 
@@ -35,7 +35,7 @@ class BitVector {
 
     BB_INLINE bool get(size_t index) const noexcept
     {
-        ASSERT_DEBUG(index < num_bits_);
+        BB_ASSERT_DEBUG(index < num_bits_);
         const uint64_t word = index >> 6;
         const uint64_t bit = index & 63;
         return ((data_[static_cast<size_t>(word)] >> bit) & 1) == 1;

--- a/barretenberg/cpp/src/barretenberg/ecc/scalar_multiplication/scalar_multiplication.cpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/scalar_multiplication/scalar_multiplication.cpp
@@ -65,11 +65,11 @@ void MSM<Curve>::transform_scalar_and_get_nonzero_scalar_indices(std::span<typen
         const size_t start = thread_idx * scalars_per_thread;
         const size_t end = last_thread ? scalars.size() : (thread_idx + 1) * scalars_per_thread;
         if (!empty_thread) {
-            ASSERT_DEBUG(end > start);
+            BB_ASSERT_DEBUG(end > start);
             std::vector<uint32_t>& thread_scalar_indices = thread_indices[thread_idx];
             thread_scalar_indices.reserve(end - start);
             for (size_t i = start; i < end; ++i) {
-                ASSERT_DEBUG(i < scalars.size());
+                BB_ASSERT_DEBUG(i < scalars.size());
                 auto& scalar = scalars[i];
                 scalar.self_from_montgomery_form();
 
@@ -154,7 +154,7 @@ std::vector<typename MSM<Curve>::ThreadWorkUnits> MSM<Curve>::get_work_units(
     size_t thread_accumulated_work = 0;
     size_t current_thread_idx = 0;
     for (size_t i = 0; i < num_msms; ++i) {
-        ASSERT_DEBUG(i < msm_scalar_indices.size());
+        BB_ASSERT_DEBUG(i < msm_scalar_indices.size());
         size_t msm_work = msm_scalar_indices[i].size();
         size_t msm_size = msm_work;
         while (msm_work > 0) {
@@ -450,9 +450,9 @@ typename Curve::Element MSM<Curve>::evaluate_small_pippenger_round(MSMData& msm_
 
     const size_t size = nonzero_scalar_indices.size();
     for (size_t i = 0; i < size; ++i) {
-        ASSERT_DEBUG(nonzero_scalar_indices[i] < scalars.size());
+        BB_ASSERT_DEBUG(nonzero_scalar_indices[i] < scalars.size());
         uint32_t bucket_index = get_scalar_slice(scalars[nonzero_scalar_indices[i]], round_index, bits_per_slice);
-        ASSERT_DEBUG(bucket_index < static_cast<uint32_t>(1 << bits_per_slice));
+        BB_ASSERT_DEBUG(bucket_index < static_cast<uint32_t>(1 << bits_per_slice));
         if (bucket_index > 0) {
             // do this check because we do not reset bucket_data.buckets after each round
             // (i.e. not neccessarily at infinity)
@@ -511,14 +511,14 @@ typename Curve::Element MSM<Curve>::evaluate_pippenger_round(MSMData& msm_data,
     // 1. low 32 bits: which bucket index do we add the point into? (bucket index = slice value)
     // 2. high 32 bits: which point index do we source the point from?
     for (size_t i = 0; i < size; ++i) {
-        ASSERT_DEBUG(scalar_indices[i] < scalars.size());
+        BB_ASSERT_DEBUG(scalar_indices[i] < scalars.size());
         round_schedule[i] = get_scalar_slice(scalars[scalar_indices[i]], round_index, bits_per_slice);
         round_schedule[i] += (static_cast<uint64_t>(scalar_indices[i]) << 32ULL);
     }
     // Sort our point schedules based on their bucket values. Reduces memory throughput in next step of algo
     const size_t num_zero_entries = scalar_multiplication::process_buckets_count_zero_entries(
         &round_schedule[0], size, static_cast<uint32_t>(bits_per_slice));
-    ASSERT_DEBUG(num_zero_entries <= size);
+    BB_ASSERT_DEBUG(num_zero_entries <= size);
     const size_t round_size = size - num_zero_entries;
 
     Element round_output;
@@ -665,7 +665,7 @@ void MSM<Curve>::consume_point_schedule(std::span<const uint64_t> point_schedule
             affine_input_it += 2;
             point_it += 1;
         } else { // otherwise, cache the point into the bucket
-            ASSERT_DEBUG(lhs_point < points.size());
+            BB_ASSERT_DEBUG(lhs_point < points.size());
             bucket_accumulators[lhs_bucket] = points[lhs_point];
             bucket_accumulator_exists.set(lhs_bucket, true);
             point_it += 1;
@@ -692,7 +692,7 @@ void MSM<Curve>::consume_point_schedule(std::span<const uint64_t> point_schedule
     while ((affine_output_it < (num_affine_output_points - 1)) && (num_affine_output_points > 0)) {
         size_t lhs_bucket = static_cast<size_t>(affine_addition_output_bucket_destinations[affine_output_it]);
         size_t rhs_bucket = static_cast<size_t>(affine_addition_output_bucket_destinations[affine_output_it + 1]);
-        ASSERT_DEBUG(lhs_bucket < bucket_accumulator_exists.size());
+        BB_ASSERT_DEBUG(lhs_bucket < bucket_accumulator_exists.size());
 
         bool has_bucket_accumulator = bucket_accumulator_exists.get(lhs_bucket);
         bool buckets_match = (lhs_bucket == rhs_bucket);
@@ -724,9 +724,9 @@ void MSM<Curve>::consume_point_schedule(std::span<const uint64_t> point_schedule
 
         bool has_bucket_accumulator = bucket_accumulator_exists.get(lhs_bucket);
         if (has_bucket_accumulator) {
-            ASSERT_DEBUG(new_scratch_space_it + 1 < affine_addition_scratch_space.size());
-            ASSERT_DEBUG(lhs_bucket < bucket_accumulators.size());
-            ASSERT_DEBUG((new_scratch_space_it >> 1) < output_point_schedule.size());
+            BB_ASSERT_DEBUG(new_scratch_space_it + 1 < affine_addition_scratch_space.size());
+            BB_ASSERT_DEBUG(lhs_bucket < bucket_accumulators.size());
+            BB_ASSERT_DEBUG((new_scratch_space_it >> 1) < output_point_schedule.size());
             affine_addition_scratch_space[new_scratch_space_it] = affine_output[affine_output_it];
             affine_addition_scratch_space[new_scratch_space_it + 1] = bucket_accumulators[lhs_bucket];
             bucket_accumulator_exists.set(lhs_bucket, false);

--- a/barretenberg/cpp/src/barretenberg/ecc/scalar_multiplication/scalar_multiplication.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/scalar_multiplication/scalar_multiplication.hpp
@@ -132,7 +132,7 @@ template <typename Curve> class MSM {
     template <typename BucketType> static Element accumulate_buckets(BucketType& bucket_accumulators) noexcept
     {
         auto& buckets = bucket_accumulators.buckets;
-        ASSERT_DEBUG(buckets.size() > static_cast<size_t>(0));
+        BB_ASSERT_DEBUG(buckets.size() > static_cast<size_t>(0));
         int starting_index = static_cast<int>(buckets.size() - 1);
         Element prefix_sum;
         bool found_start = false;
@@ -149,7 +149,7 @@ template <typename Curve> class MSM {
         if (!found_start) {
             return Curve::Group::point_at_infinity;
         }
-        ASSERT_DEBUG(starting_index > 0);
+        BB_ASSERT_DEBUG(starting_index > 0);
         AffineElement offset_generator = Curve::Group::affine_point_at_infinity;
         if constexpr (std::same_as<typename Curve::Group, bb::g1>) {
             constexpr auto gen = get_precomputed_generators<typename Curve::Group, "ECCVM_OFFSET_GENERATOR", 1>()[0];
@@ -161,7 +161,7 @@ template <typename Curve> class MSM {
         Element sum = prefix_sum + offset_generator;
         for (int i = static_cast<int>(starting_index - 1); i > 0; --i) {
             size_t idx = static_cast<size_t>(i);
-            ASSERT_DEBUG(idx < bucket_accumulators.bucket_exists.size());
+            BB_ASSERT_DEBUG(idx < bucket_accumulators.bucket_exists.size());
             if (bucket_accumulators.bucket_exists.get(idx)) {
 
                 prefix_sum += buckets[idx];

--- a/barretenberg/cpp/src/barretenberg/ecc/scalar_multiplication/scalar_multiplication.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/scalar_multiplication/scalar_multiplication.test.cpp
@@ -124,7 +124,7 @@ TYPED_TEST(ScalarMultiplicationTest, GetScalarSlice)
         //         }
 
         //         const uint256_t new_input_u256 = input_u256 + (uint256_t(slice) << shift);
-        //         //   ASSERT(new_input_u256 < fr::modulus);
+        //         //   BB_ASSERT(new_input_u256 < fr::modulus);
         //         if (new_input_u256 < fr::modulus) {
         //             input_u256 = new_input_u256;
         //             slices[i] = slice;
@@ -133,7 +133,7 @@ TYPED_TEST(ScalarMultiplicationTest, GetScalarSlice)
         //     }
         // }
 
-        // ASSERT(input_u256 < fr::modulus);
+        // BB_ASSERT(input_u256 < fr::modulus);
         // while (input_u256 > fr::modulus) {
         //     input_u256 -= fr::modulus;
         // }

--- a/barretenberg/cpp/src/barretenberg/eccvm/precomputed_tables_builder.hpp
+++ b/barretenberg/cpp/src/barretenberg/eccvm/precomputed_tables_builder.hpp
@@ -114,7 +114,7 @@ class ECCVMPointTablePrecomputationBuilder {
                     row.pc = entry.pc;
 
                     if (last_row) {
-                        ASSERT(scalar_sum - entry.wnaf_skew, entry.scalar);
+                        BB_ASSERT(scalar_sum - entry.wnaf_skew, entry.scalar);
                     }
                     // the last element of the `precomputed_table` field of a `ScalarMul` is the double of the point.
                     row.precompute_double = entry.precomputed_table[bb::eccvm::POINT_TABLE_SIZE];

--- a/barretenberg/cpp/src/barretenberg/goblin/goblin.cpp
+++ b/barretenberg/cpp/src/barretenberg/goblin/goblin.cpp
@@ -76,7 +76,7 @@ std::pair<Goblin::PairingPoints, Goblin::RecursiveTableCommitments> Goblin::recu
     const std::shared_ptr<RecursiveTranscript>& transcript,
     const MergeSettings merge_settings)
 {
-    ASSERT(!merge_verification_queue.empty());
+    BB_ASSERT(!merge_verification_queue.empty());
     // Recursively verify the next merge proof in the verification queue in a FIFO manner
     const MergeProof& merge_proof = merge_verification_queue.front();
     const stdlib::Proof<MegaBuilder> stdlib_merge_proof(builder, merge_proof);

--- a/barretenberg/cpp/src/barretenberg/honk/execution_trace/execution_trace_block.hpp
+++ b/barretenberg/cpp/src/barretenberg/honk/execution_trace/execution_trace_block.hpp
@@ -141,7 +141,7 @@ template <typename FF> class ZeroSelector : public Selector<FF> {
 
     void push_back(const FF& value) override
     {
-        ASSERT(value.is_zero());
+        BB_ASSERT(value.is_zero());
         size_++;
     }
 
@@ -153,14 +153,14 @@ template <typename FF> class ZeroSelector : public Selector<FF> {
 
     void set(size_t idx, int value) override
     {
-        ASSERT_DEBUG(idx < size_);
+        BB_ASSERT_DEBUG(idx < size_);
         BB_ASSERT_EQ(value, 0, "Calling ZeroSelector::set with a non zero value.");
     }
 
     void set(size_t idx, const FF& value) override
     {
-        ASSERT_DEBUG(idx < size_);
-        ASSERT(value.is_zero());
+        BB_ASSERT_DEBUG(idx < size_);
+        BB_ASSERT(value.is_zero());
         size_++;
     }
 
@@ -170,7 +170,7 @@ template <typename FF> class ZeroSelector : public Selector<FF> {
 
     const FF& operator[](size_t index) const override
     {
-        ASSERT_DEBUG(index < size_);
+        BB_ASSERT_DEBUG(index < size_);
         return zero;
     }
 
@@ -258,7 +258,7 @@ template <typename FF, size_t NUM_WIRES_> class ExecutionTraceBlock {
 
     uint32_t trace_offset() const
     {
-        ASSERT(trace_offset_ != std::numeric_limits<uint32_t>::max());
+        BB_ASSERT(trace_offset_ != std::numeric_limits<uint32_t>::max());
         return trace_offset_;
     }
 

--- a/barretenberg/cpp/src/barretenberg/numeric/general/general.hpp
+++ b/barretenberg/cpp/src/barretenberg/numeric/general/general.hpp
@@ -22,7 +22,7 @@ namespace bb::numeric {
  */
 template <typename T> constexpr T ceil_div(const T& numerator, const T& denominator)
 {
-    BB_ASSERT_IN_CONSTEXPR(denominator > 0, "Denominator must be greater than zero.");
+    BB_ASSERT(denominator > 0, "Denominator must be greater than zero.");
     static_assert(std::is_integral_v<T>, "Type must be an integral type.");
     return (numerator + denominator - 1) / denominator;
 }

--- a/barretenberg/cpp/src/barretenberg/numeric/general/general.hpp
+++ b/barretenberg/cpp/src/barretenberg/numeric/general/general.hpp
@@ -22,7 +22,7 @@ namespace bb::numeric {
  */
 template <typename T> constexpr T ceil_div(const T& numerator, const T& denominator)
 {
-    ASSERT_IN_CONSTEXPR(denominator > 0, "Denominator must be greater than zero.");
+    BB_ASSERT_IN_CONSTEXPR(denominator > 0, "Denominator must be greater than zero.");
     static_assert(std::is_integral_v<T>, "Type must be an integral type.");
     return (numerator + denominator - 1) / denominator;
 }

--- a/barretenberg/cpp/src/barretenberg/numeric/uint128/uint128_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/numeric/uint128/uint128_impl.hpp
@@ -190,7 +190,7 @@ constexpr uint128_t uint128_t::pow(const uint128_t& exponent) const
 
 constexpr bool uint128_t::get_bit(const uint64_t bit_index) const
 {
-    BB_ASSERT_IN_CONSTEXPR(bit_index < 128);
+    BB_ASSERT(bit_index < 128);
     if (bit_index > 127) {
         return false;
     }

--- a/barretenberg/cpp/src/barretenberg/numeric/uint128/uint128_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/numeric/uint128/uint128_impl.hpp
@@ -190,7 +190,7 @@ constexpr uint128_t uint128_t::pow(const uint128_t& exponent) const
 
 constexpr bool uint128_t::get_bit(const uint64_t bit_index) const
 {
-    ASSERT_IN_CONSTEXPR(bit_index < 128);
+    BB_ASSERT_IN_CONSTEXPR(bit_index < 128);
     if (bit_index > 127) {
         return false;
     }

--- a/barretenberg/cpp/src/barretenberg/numeric/uint256/uint256_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/numeric/uint256/uint256_impl.hpp
@@ -318,7 +318,6 @@ constexpr uint256_t uint256_t::pow(const uint256_t& exponent) const
 
 constexpr bool uint256_t::get_bit(const uint64_t bit_index) const
 {
-    // Note: Can't use BB_ASSERT in constexpr context. Assertion removed as the bounds check below handles it.
     if (bit_index > 255) {
         return static_cast<bool>(0);
     }

--- a/barretenberg/cpp/src/barretenberg/numeric/uint256/uint256_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/numeric/uint256/uint256_impl.hpp
@@ -318,7 +318,7 @@ constexpr uint256_t uint256_t::pow(const uint256_t& exponent) const
 
 constexpr bool uint256_t::get_bit(const uint64_t bit_index) const
 {
-    ASSERT_IN_CONSTEXPR(bit_index < 256);
+    // Note: Can't use BB_ASSERT in constexpr context. Assertion removed as the bounds check below handles it.
     if (bit_index > 255) {
         return static_cast<bool>(0);
     }

--- a/barretenberg/cpp/src/barretenberg/numeric/uintx/uintx_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/numeric/uintx/uintx_impl.hpp
@@ -13,7 +13,7 @@ template <class base_uint>
 std::pair<uintx<base_uint>, uintx<base_uint>> uintx<base_uint>::divmod_base(const uintx& b) const
 
 {
-    ASSERT_DEBUG(b != 0);
+    BB_ASSERT_DEBUG(b != 0);
     if (*this == 0) {
         return { uintx(0), uintx(0) };
     }
@@ -103,7 +103,7 @@ template <class base_uint> uintx<base_uint> uintx<base_uint>::unsafe_invmod(cons
  **/
 template <class base_uint> uintx<base_uint> uintx<base_uint>::invmod(const uintx& modulus) const
 {
-    ASSERT((*this) != 0);
+    BB_ASSERT((*this) != 0);
     if (modulus == 0) {
         return 0;
     }

--- a/barretenberg/cpp/src/barretenberg/op_queue/ecc_ops_table.hpp
+++ b/barretenberg/cpp/src/barretenberg/op_queue/ecc_ops_table.hpp
@@ -122,7 +122,7 @@ template <typename OpFormat> class EccOpsTable {
     size_t size() const
     {
         BB_ASSERT(current_subtable.empty(),
-               "Current subtable should be merged before computing the size of the full table of ecc ops.");
+                  "Current subtable should be merged before computing the size of the full table of ecc ops.");
         size_t total = 0;
         for (const auto& subtable : table) {
             total += subtable.size();
@@ -153,7 +153,7 @@ template <typename OpFormat> class EccOpsTable {
     const OpFormat& operator[](size_t index) const
     {
         BB_ASSERT(current_subtable.empty(),
-               "Current subtable should be merged before attempting to index into the full table.");
+                  "Current subtable should be merged before attempting to index into the full table.");
         BB_ASSERT_LT(index, size());
         // simple linear search to find the correct subtable
         for (const auto& subtable : table) {
@@ -169,7 +169,7 @@ template <typename OpFormat> class EccOpsTable {
     std::vector<OpFormat> get_reconstructed() const
     {
         BB_ASSERT(current_subtable.empty(),
-               "current subtable should be merged before reconstructing the full table of operations.");
+                  "current subtable should be merged before reconstructing the full table of operations.");
 
         std::vector<OpFormat> reconstructed_table;
         reconstructed_table.reserve(size());
@@ -286,7 +286,7 @@ class UltraEccOpsTable {
     {
 
         BB_ASSERT(get_current_subtable_size() == 0,
-               "current subtable should be merged before reconstructing the full table of operations.");
+                  "current subtable should be merged before reconstructing the full table of operations.");
 
         std::vector<UltraOp> reconstructed_table;
         reconstructed_table.reserve(1 << CONST_OP_QUEUE_LOG_SIZE);

--- a/barretenberg/cpp/src/barretenberg/op_queue/ecc_ops_table.hpp
+++ b/barretenberg/cpp/src/barretenberg/op_queue/ecc_ops_table.hpp
@@ -121,7 +121,7 @@ template <typename OpFormat> class EccOpsTable {
   public:
     size_t size() const
     {
-        ASSERT(current_subtable.empty(),
+        BB_ASSERT(current_subtable.empty(),
                "Current subtable should be merged before computing the size of the full table of ecc ops.");
         size_t total = 0;
         for (const auto& subtable : table) {
@@ -145,14 +145,14 @@ template <typename OpFormat> class EccOpsTable {
 
     void create_new_subtable(size_t size_hint = 0)
     {
-        ASSERT(current_subtable.empty(), "Cannot create a new subtable until the current subtable has been merged.");
+        BB_ASSERT(current_subtable.empty(), "Cannot create a new subtable until the current subtable has been merged.");
         current_subtable.reserve(size_hint);
     }
 
     // const version of operator[]
     const OpFormat& operator[](size_t index) const
     {
-        ASSERT(current_subtable.empty(),
+        BB_ASSERT(current_subtable.empty(),
                "Current subtable should be merged before attempting to index into the full table.");
         BB_ASSERT_LT(index, size());
         // simple linear search to find the correct subtable
@@ -168,7 +168,7 @@ template <typename OpFormat> class EccOpsTable {
     // highly inefficient copy-based reconstruction of the table for use in ECCVM/Translator
     std::vector<OpFormat> get_reconstructed() const
     {
-        ASSERT(current_subtable.empty(),
+        BB_ASSERT(current_subtable.empty(),
                "current subtable should be merged before reconstructing the full table of operations.");
 
         std::vector<OpFormat> reconstructed_table;
@@ -195,7 +195,7 @@ template <typename OpFormat> class EccOpsTable {
         }
 
         current_subtable.clear(); // clear the current subtable after merging
-        ASSERT(current_subtable.empty(), "current subtable should be empty after merging. Check the merge logic.");
+        BB_ASSERT(current_subtable.empty(), "current subtable should be empty after merging. Check the merge logic.");
     }
 };
 
@@ -261,7 +261,7 @@ class UltraEccOpsTable {
     {
         if (settings == MergeSettings::APPEND) {
             // All appends are treated as fixed-location for ultra ops
-            ASSERT(!has_fixed_append, "Can only perform fixed-location append once");
+            BB_ASSERT(!has_fixed_append, "Can only perform fixed-location append once");
             // Set fixed location at which to append ultra ops. If nullopt --> append right after prepended tables
             fixed_append_offset = offset;
             has_fixed_append = true;
@@ -285,7 +285,7 @@ class UltraEccOpsTable {
     std::vector<UltraOp> get_reconstructed_with_fixed_append() const
     {
 
-        ASSERT(get_current_subtable_size() == 0,
+        BB_ASSERT(get_current_subtable_size() == 0,
                "current subtable should be merged before reconstructing the full table of operations.");
 
         std::vector<UltraOp> reconstructed_table;

--- a/barretenberg/cpp/src/barretenberg/op_queue/ecc_ops_table.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/op_queue/ecc_ops_table.test.cpp
@@ -269,7 +269,7 @@ TEST(EccOpsTableTest, UltraOpsFixedLocationAppendWithGap)
     const size_t fixed_offset = 20;
     const size_t fixed_offset_num_rows = fixed_offset * ULTRA_ROWS_PER_OP;
     const size_t prepended_size = (subtable_op_counts[0] + subtable_op_counts[1]) * ULTRA_ROWS_PER_OP;
-    ASSERT(fixed_offset_num_rows > prepended_size);
+    BB_ASSERT(fixed_offset_num_rows > prepended_size);
 
     // Construct the ultra ops table
     for (size_t i = 0; i < NUM_SUBTABLES; ++i) {

--- a/barretenberg/cpp/src/barretenberg/polynomials/evaluation_domain.cpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/evaluation_domain.cpp
@@ -80,9 +80,9 @@ EvaluationDomain<Fr>::EvaluationDomain(const size_t domain_size, const size_t ta
 
     root_inverse = root.invert();
 
-    ASSERT((1UL << log2_size) == size || (size == 0));
-    ASSERT((1UL << log2_thread_size) == thread_size || (size == 0));
-    ASSERT((1UL << log2_num_threads) == num_threads || (size == 0));
+    BB_ASSERT((1UL << log2_size) == size || (size == 0));
+    BB_ASSERT((1UL << log2_thread_size) == thread_size || (size == 0));
+    BB_ASSERT((1UL << log2_num_threads) == num_threads || (size == 0));
 }
 
 template <typename Fr>
@@ -102,9 +102,9 @@ EvaluationDomain<Fr>::EvaluationDomain(const EvaluationDomain& other)
     , generator_inverse(other.generator_inverse)
     , four_inverse(other.four_inverse)
 {
-    ASSERT((1UL << log2_size) == size);
-    ASSERT((1UL << log2_thread_size) == thread_size);
-    ASSERT((1UL << log2_num_threads) == num_threads);
+    BB_ASSERT((1UL << log2_size) == size);
+    BB_ASSERT((1UL << log2_thread_size) == thread_size);
+    BB_ASSERT((1UL << log2_num_threads) == num_threads);
     if (other.roots != nullptr) {
         const size_t mem_size = sizeof(Fr) * size * 2;
         roots = std::static_pointer_cast<Fr[]>(get_mem_slab(mem_size));

--- a/barretenberg/cpp/src/barretenberg/polynomials/polynomial.cpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/polynomial.cpp
@@ -82,7 +82,7 @@ template <typename Fr> Polynomial<Fr>::Polynomial(size_t size, size_t virtual_si
     parallel_for(num_threads, [&](size_t j) {
         size_t offset = j * range_per_thread;
         size_t range = (j == num_threads - 1) ? range_per_thread + leftovers : range_per_thread;
-        ASSERT(offset < size || size == 0);
+        BB_ASSERT(offset < size || size == 0);
         BB_ASSERT_LTE((offset + range), size);
         memset(static_cast<void*>(coefficients_.data() + offset), 0, sizeof(Fr) * range);
     });
@@ -192,13 +192,13 @@ template <typename Fr> Polynomial<Fr>& Polynomial<Fr>::operator+=(PolynomialSpan
 
 template <typename Fr> Fr Polynomial<Fr>::evaluate(const Fr& z, const size_t target_size) const
 {
-    ASSERT(size() == virtual_size());
+    BB_ASSERT(size() == virtual_size());
     return polynomial_arithmetic::evaluate(data(), z, target_size);
 }
 
 template <typename Fr> Fr Polynomial<Fr>::evaluate(const Fr& z) const
 {
-    ASSERT(size() == virtual_size());
+    BB_ASSERT(size() == virtual_size());
     return polynomial_arithmetic::evaluate(data(), z, size());
 }
 

--- a/barretenberg/cpp/src/barretenberg/polynomials/polynomial.hpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/polynomial.hpp
@@ -36,14 +36,14 @@ template <typename Fr> struct PolynomialSpan {
     size_t size() const { return span.size(); }
     Fr& operator[](size_t index)
     {
-        ASSERT_DEBUG(index >= start_index);
-        ASSERT_DEBUG(index < end_index());
+        BB_ASSERT_DEBUG(index >= start_index);
+        BB_ASSERT_DEBUG(index < end_index());
         return span[index - start_index];
     }
     const Fr& operator[](size_t index) const
     {
-        ASSERT_DEBUG(index >= start_index);
-        ASSERT_DEBUG(index < end_index());
+        BB_ASSERT_DEBUG(index >= start_index);
+        BB_ASSERT_DEBUG(index < end_index());
         return span[index - start_index];
     }
     PolynomialSpan subspan(size_t offset, size_t length)
@@ -367,7 +367,7 @@ template <typename Fr> class Polynomial {
      */
     void set_if_valid_index(size_t index, const Fr& value)
     {
-        ASSERT(value.is_zero() || is_valid_set_index(index));
+        BB_ASSERT(value.is_zero() || is_valid_set_index(index));
         if (is_valid_set_index(index)) {
             at(index) = value;
         }
@@ -436,7 +436,7 @@ Fr_ _evaluate_mle(std::span<const Fr_> evaluation_points,
 {
     constexpr bool is_native = IsAnyOf<Fr_, bb::fr, grumpkin::fr>;
     // shift ==> native
-    ASSERT(!shift || is_native);
+    BB_ASSERT(!shift || is_native);
 
     if (coefficients.size() == 0) {
         return Fr_(0);

--- a/barretenberg/cpp/src/barretenberg/polynomials/polynomial_arithmetic.cpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/polynomial_arithmetic.cpp
@@ -115,9 +115,9 @@ void fft_inner_parallel(std::vector<Fr*> coeffs,
     auto scratch_space = scratch_space_ptr.get();
 
     const size_t num_polys = coeffs.size();
-    ASSERT(is_power_of_two(num_polys));
+    BB_ASSERT(is_power_of_two(num_polys));
     const size_t poly_size = domain.size / num_polys;
-    ASSERT(is_power_of_two(poly_size));
+    BB_ASSERT(is_power_of_two(poly_size));
     const size_t poly_mask = poly_size - 1;
     const size_t log2_poly_size = (size_t)numeric::get_msb(poly_size);
 
@@ -375,9 +375,9 @@ void ifft(std::vector<Fr*> coeffs, const EvaluationDomain<Fr>& domain)
     fft_inner_parallel(coeffs, domain, domain.root_inverse, domain.get_inverse_round_roots());
 
     const size_t num_polys = coeffs.size();
-    ASSERT(is_power_of_two(num_polys));
+    BB_ASSERT(is_power_of_two(num_polys));
     const size_t poly_size = domain.size / num_polys;
-    ASSERT(is_power_of_two(poly_size));
+    BB_ASSERT(is_power_of_two(poly_size));
     const size_t poly_mask = poly_size - 1;
     const size_t log2_poly_size = (size_t)numeric::get_msb(poly_size);
 
@@ -407,7 +407,7 @@ template <typename Fr>
 void coset_fft(std::vector<Fr*> coeffs, const EvaluationDomain<Fr>& domain)
 {
     const size_t num_polys = coeffs.size();
-    ASSERT(is_power_of_two(num_polys));
+    BB_ASSERT(is_power_of_two(num_polys));
     const size_t poly_size = domain.size / num_polys;
     const Fr generator_pow_n = domain.generator.pow(poly_size);
     Fr generator_start = 1;
@@ -495,7 +495,7 @@ void coset_ifft(std::vector<Fr*> coeffs, const EvaluationDomain<Fr>& domain)
     ifft(coeffs, domain);
 
     const size_t num_polys = coeffs.size();
-    ASSERT(is_power_of_two(num_polys));
+    BB_ASSERT(is_power_of_two(num_polys));
     const size_t poly_size = domain.size / num_polys;
     const Fr generator_inv_pow_n = domain.generator_inverse.pow(poly_size);
     Fr generator_start = 1;
@@ -536,7 +536,7 @@ template <typename Fr> Fr evaluate(const std::vector<Fr*> coeffs, const Fr& z, c
 {
     const size_t num_polys = coeffs.size();
     const size_t poly_size = large_n / num_polys;
-    ASSERT(is_power_of_two(poly_size));
+    BB_ASSERT(is_power_of_two(poly_size));
     const size_t log2_poly_size = (size_t)numeric::get_msb(poly_size);
     size_t num_threads = get_num_cpus_pow2();
     size_t range_per_thread = large_n / num_threads;

--- a/barretenberg/cpp/src/barretenberg/polynomials/shared_shifted_virtual_zeroes_array.hpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/shared_shifted_virtual_zeroes_array.hpp
@@ -37,8 +37,8 @@ template <typename T> struct SharedShiftedVirtualZeroesArray {
      */
     void set(size_t index, const T& value)
     {
-        ASSERT_DEBUG(index >= start_);
-        ASSERT_DEBUG(index < end_);
+        BB_ASSERT_DEBUG(index >= start_);
+        BB_ASSERT_DEBUG(index < end_);
         data()[index - start_] = value;
     }
 
@@ -56,7 +56,7 @@ template <typename T> struct SharedShiftedVirtualZeroesArray {
     const T& get(size_t index, size_t virtual_padding = 0) const
     {
         static const T zero{};
-        ASSERT_DEBUG(index < virtual_size_ + virtual_padding);
+        BB_ASSERT_DEBUG(index < virtual_size_ + virtual_padding);
         if (index >= start_ && index < end_) {
             return data()[index - start_];
         }
@@ -85,15 +85,15 @@ template <typename T> struct SharedShiftedVirtualZeroesArray {
 
     T& operator[](size_t index)
     {
-        ASSERT_DEBUG(index >= start_);
-        ASSERT_DEBUG(index < end_);
+        BB_ASSERT_DEBUG(index >= start_);
+        BB_ASSERT_DEBUG(index < end_);
         return data()[index - start_];
     }
     // get() is more useful, but for completeness with the non-const operator[]
     const T& operator[](size_t index) const
     {
-        ASSERT_DEBUG(index >= start_);
-        ASSERT_DEBUG(index < end_);
+        BB_ASSERT_DEBUG(index >= start_);
+        BB_ASSERT_DEBUG(index < end_);
         return data()[index - start_];
     }
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/encryption/aes128/aes128.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/encryption/aes128/aes128.cpp
@@ -333,7 +333,7 @@ std::vector<field_t<Builder>> encrypt_buffer_cbc(const std::vector<field_t<Build
         }
     }
 
-    ASSERT(ctx);
+    BB_ASSERT(ctx);
 
     auto round_key = expand_key(ctx, key);
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/hash/blake3s/blake3s.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/hash/blake3s/blake3s.cpp
@@ -183,7 +183,7 @@ template <typename Builder> void Blake3s<Builder>::hasher_finalize(const blake3_
 template <typename Builder> byte_array<Builder> Blake3s<Builder>::hash(const byte_array<Builder>& input)
 {
     BB_ASSERT(input.size() <= BLAKE3_CHUNK_LEN,
-           "Barretenberg does not support blake3s with input lengths greater than 1024 bytes.");
+              "Barretenberg does not support blake3s with input lengths greater than 1024 bytes.");
 
     blake3_hasher hasher = {};
     hasher.context = input.get_context();

--- a/barretenberg/cpp/src/barretenberg/stdlib/hash/blake3s/blake3s.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/hash/blake3s/blake3s.cpp
@@ -182,7 +182,7 @@ template <typename Builder> void Blake3s<Builder>::hasher_finalize(const blake3_
 
 template <typename Builder> byte_array<Builder> Blake3s<Builder>::hash(const byte_array<Builder>& input)
 {
-    ASSERT(input.size() <= BLAKE3_CHUNK_LEN,
+    BB_ASSERT(input.size() <= BLAKE3_CHUNK_LEN,
            "Barretenberg does not support blake3s with input lengths greater than 1024 bytes.");
 
     blake3_hasher hasher = {};

--- a/barretenberg/cpp/src/barretenberg/stdlib/hash/poseidon2/poseidon2_permutation.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/hash/poseidon2/poseidon2_permutation.cpp
@@ -115,7 +115,7 @@ void Poseidon2Permutation<Builder>::matrix_multiplication_external(typename Pose
     state[2] = state[3] + tmp2;
 
     // This can only happen if the input contained constant `field_t` elements.
-    ASSERT(state[0].is_normalized() && state[1].is_normalized() && state[2].is_normalized() &&
+    BB_ASSERT(state[0].is_normalized() && state[1].is_normalized() && state[2].is_normalized() &&
            state[3].is_normalized());
 }
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/hash/poseidon2/poseidon2_permutation.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/hash/poseidon2/poseidon2_permutation.cpp
@@ -116,7 +116,7 @@ void Poseidon2Permutation<Builder>::matrix_multiplication_external(typename Pose
 
     // This can only happen if the input contained constant `field_t` elements.
     BB_ASSERT(state[0].is_normalized() && state[1].is_normalized() && state[2].is_normalized() &&
-           state[3].is_normalized());
+              state[3].is_normalized());
 }
 
 template class Poseidon2Permutation<MegaCircuitBuilder>;

--- a/barretenberg/cpp/src/barretenberg/stdlib/hash/poseidon2/sponge/sponge.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/hash/poseidon2/sponge/sponge.hpp
@@ -96,7 +96,7 @@ template <typename Builder> class FieldSponge {
         Builder* builder = validate_context<Builder>(input);
 
         // Ensure that the pointer is not a `nullptr`
-        ASSERT(builder);
+        BB_ASSERT(builder);
 
         // Initialize the sponge state. Input length is used for domain separation.
         const size_t in_len = input.size();

--- a/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/ultra_verification_keys_comparator.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/ultra_verification_keys_comparator.hpp
@@ -54,7 +54,7 @@ static void compare_ultra_blocks_and_verification_keys(
     BB_ASSERT_EQ(verification_keys[0]->num_public_inputs, verification_keys[1]->num_public_inputs);
     BB_ASSERT_EQ(verification_keys[0]->pub_inputs_offset, verification_keys[1]->pub_inputs_offset);
 
-    ASSERT(!broke);
+    BB_ASSERT(!broke);
 }
 
 } // namespace bb

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.fuzzer.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.fuzzer.hpp
@@ -1022,7 +1022,7 @@ template <typename Builder> class BigFieldBase {
             if (other.bf().is_constant() && !this->bf().is_constant()) {
                 auto to_add = bigfield_t(this->bigfield.context, uint256_t(this->base - other.base));
                 auto new_el = other.bf() + to_add;
-                ASSERT(new_el.is_constant());
+                BB_ASSERT(new_el.is_constant());
 
                 lhs = this->bigfield;
                 rhs = new_el;
@@ -1036,8 +1036,8 @@ template <typename Builder> class BigFieldBase {
                 rhs = this->bf();
             }
 
-            ASSERT(!lhs.is_constant());
-            ASSERT(rhs.is_constant());
+            BB_ASSERT(!lhs.is_constant());
+            BB_ASSERT(rhs.is_constant());
 
             bool overflow = lhs.get_value() >= bb::fq::modulus;
             bool reduce = VarianceRNG.next() & 1;

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
@@ -48,7 +48,7 @@ bigfield<Builder, T>::bigfield(const field_t<Builder>& low_bits_in,
 {
     BB_ASSERT_EQ(low_bits_in.is_constant(), high_bits_in.is_constant());
     BB_ASSERT((can_overflow == true && maximum_bitlength == 0) ||
-           (can_overflow == false && (maximum_bitlength == 0 || maximum_bitlength > (3 * NUM_LIMB_BITS))));
+              (can_overflow == false && (maximum_bitlength == 0 || maximum_bitlength > (3 * NUM_LIMB_BITS))));
 
     // Check that the values of two parts are within specified bounds
     BB_ASSERT_LT(uint256_t(low_bits_in.get_value()), uint256_t(1) << (NUM_LIMB_BITS * 2));
@@ -141,7 +141,7 @@ bigfield<Builder, T> bigfield<Builder, T>::create_from_u512_as_witness(Builder* 
                                                                        const size_t maximum_bitlength)
 {
     BB_ASSERT((can_overflow == true && maximum_bitlength == 0) ||
-           (can_overflow == false && (maximum_bitlength == 0 || maximum_bitlength > (3 * NUM_LIMB_BITS))));
+              (can_overflow == false && (maximum_bitlength == 0 || maximum_bitlength > (3 * NUM_LIMB_BITS))));
     std::array<uint256_t, NUM_LIMBS> limbs;
     limbs[0] = value.slice(0, NUM_LIMB_BITS).lo;
     limbs[1] = value.slice(NUM_LIMB_BITS, NUM_LIMB_BITS * 2).lo;
@@ -1805,7 +1805,7 @@ template <typename Builder, typename T> void bigfield<Builder, T>::sanity_check(
     // max_val < sqrt(2^T * n)
     // Note this is a static assertion, so it is not checked at runtime
     BB_ASSERT(!(get_maximum_value() > get_prohibited_value() || limb_overflow_test_0 || limb_overflow_test_1 ||
-             limb_overflow_test_2 || limb_overflow_test_3));
+                limb_overflow_test_2 || limb_overflow_test_3));
 }
 
 // Underneath performs unsafe_assert_less_than(modulus)

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
@@ -47,7 +47,7 @@ bigfield<Builder, T>::bigfield(const field_t<Builder>& low_bits_in,
                                const size_t maximum_bitlength)
 {
     BB_ASSERT_EQ(low_bits_in.is_constant(), high_bits_in.is_constant());
-    ASSERT((can_overflow == true && maximum_bitlength == 0) ||
+    BB_ASSERT((can_overflow == true && maximum_bitlength == 0) ||
            (can_overflow == false && (maximum_bitlength == 0 || maximum_bitlength > (3 * NUM_LIMB_BITS))));
 
     // Check that the values of two parts are within specified bounds
@@ -140,7 +140,7 @@ bigfield<Builder, T> bigfield<Builder, T>::create_from_u512_as_witness(Builder* 
                                                                        const bool can_overflow,
                                                                        const size_t maximum_bitlength)
 {
-    ASSERT((can_overflow == true && maximum_bitlength == 0) ||
+    BB_ASSERT((can_overflow == true && maximum_bitlength == 0) ||
            (can_overflow == false && (maximum_bitlength == 0 || maximum_bitlength > (3 * NUM_LIMB_BITS))));
     std::array<uint256_t, NUM_LIMBS> limbs;
     limbs[0] = value.slice(0, NUM_LIMB_BITS).lo;
@@ -831,7 +831,7 @@ bigfield<Builder, T> bigfield<Builder, T>::internal_div(const std::vector<bigfie
     if (numerator_constant && denominator.is_constant()) {
         if (check_for_zero) {
             // We want to avoid division by zero in the constant case
-            ASSERT(denominator.get_value() != uint512_t(0), "bigfield: division by zero in constant division");
+            BB_ASSERT(denominator.get_value() != uint512_t(0), "bigfield: division by zero in constant division");
         }
         inverse = bigfield(ctx, uint256_t(inverse_value));
         inverse.set_origin_tag(tag);
@@ -1343,7 +1343,7 @@ bigfield<Builder, T> bigfield<Builder, T>::mult_madd(const std::vector<bigfield>
             // Simply return the constant, no need unsafe_multiply_add
             const auto [quotient_1024, remainder_1024] =
                 (sum_of_constant_products + add_right_constant_sum).divmod(modulus);
-            ASSERT(!fix_remainder_to_zero || remainder_1024 == 0);
+            BB_ASSERT(!fix_remainder_to_zero || remainder_1024 == 0);
             auto result = bigfield(ctx, uint256_t(remainder_1024.lo.lo));
             result.set_origin_tag(new_tag);
             return result;
@@ -1370,7 +1370,7 @@ bigfield<Builder, T> bigfield<Builder, T>::mult_madd(const std::vector<bigfield>
     }
 
     // Now that we know that there is at least 1 non-constant multiplication, we can start estimating reductions.
-    ASSERT(ctx != nullptr);
+    BB_ASSERT(ctx != nullptr);
 
     // Compute the constant term we're adding
     const auto [_, constant_part_remainder_1024] = (sum_of_constant_products + add_right_constant_sum).divmod(modulus);
@@ -1495,7 +1495,7 @@ bigfield<Builder, T> bigfield<Builder, T>::msub_div(const std::vector<bigfield>&
 {
     // Check the basics
     BB_ASSERT_EQ(mul_left.size(), mul_right.size());
-    ASSERT(divisor.get_value() != 0);
+    BB_ASSERT(divisor.get_value() != 0);
 
     OriginTag new_tag = divisor.get_origin_tag();
     for (auto [left_element, right_element] : zip_view(mul_left, mul_right)) {
@@ -1569,7 +1569,7 @@ bigfield<Builder, T> bigfield<Builder, T>::msub_div(const std::vector<bigfield>&
         return result;
     }
 
-    ASSERT(ctx != NULL);
+    BB_ASSERT(ctx != NULL);
     // Create the result witness
     bigfield result = create_from_u512_as_witness(ctx, result_value.lo);
 
@@ -1725,7 +1725,7 @@ template <typename Builder, typename T> bool_t<Builder> bigfield<Builder, T>::op
     }
 
     // The context should not be null at this point.
-    ASSERT(ctx != NULL);
+    BB_ASSERT(ctx != NULL);
     bool_t<Builder> is_equal = witness_t<Builder>(ctx, is_equal_raw);
 
     // We need to manually propagate the origin tag
@@ -1804,7 +1804,7 @@ template <typename Builder, typename T> void bigfield<Builder, T>::sanity_check(
     bool limb_overflow_test_3 = binary_basis_limbs[3].maximum_value > prohibited_limb_value;
     // max_val < sqrt(2^T * n)
     // Note this is a static assertion, so it is not checked at runtime
-    ASSERT(!(get_maximum_value() > get_prohibited_value() || limb_overflow_test_0 || limb_overflow_test_1 ||
+    BB_ASSERT(!(get_maximum_value() > get_prohibited_value() || limb_overflow_test_0 || limb_overflow_test_1 ||
              limb_overflow_test_2 || limb_overflow_test_3));
 }
 
@@ -1872,7 +1872,7 @@ void bigfield<Builder, T>::unsafe_assert_less_than(const uint256_t& upper_limit,
         return;
     }
 
-    ASSERT(upper_limit != 0);
+    BB_ASSERT(upper_limit != 0);
     // The circuit checks that limit - this >= 0, so if we are doing a less_than comparison, we need to subtract 1
     // from the limit
     uint256_t strict_upper_limit = upper_limit - uint256_t(1);
@@ -2129,7 +2129,7 @@ void bigfield<Builder, T>::unsafe_evaluate_multiply_add(const bigfield& input_le
     bigfield quotient = input_quotient;
 
     // Either of the multiplicand must be a witness.
-    ASSERT(!left.is_constant() || !to_mul.is_constant());
+    BB_ASSERT(!left.is_constant() || !to_mul.is_constant());
     Builder* ctx = left.context ? left.context : to_mul.context;
 
     // Compute the maximum value of the product of the two inputs: max(a * b)
@@ -2186,8 +2186,8 @@ void bigfield<Builder, T>::unsafe_evaluate_multiply_add(const bigfield& input_le
     uint64_t max_lo_bits = (max_lo.get_msb() + 1);
     uint64_t max_hi_bits = max_hi.get_msb() + 1;
 
-    ASSERT(max_lo_bits > (2 * NUM_LIMB_BITS));
-    ASSERT(max_hi_bits > (2 * NUM_LIMB_BITS));
+    BB_ASSERT(max_lo_bits > (2 * NUM_LIMB_BITS));
+    BB_ASSERT(max_hi_bits > (2 * NUM_LIMB_BITS));
 
     uint64_t carry_lo_msb = max_lo_bits - (2 * NUM_LIMB_BITS);
     uint64_t carry_hi_msb = max_hi_bits - (2 * NUM_LIMB_BITS);
@@ -2367,7 +2367,7 @@ void bigfield<Builder, T>::unsafe_evaluate_multiple_multiply_add(const std::vect
     }
 
     // We must have at least one left or right multiplicand as witnesses.
-    ASSERT(!is_left_constant || !is_right_constant);
+    BB_ASSERT(!is_left_constant || !is_right_constant);
 
     std::vector<bigfield> remainders(input_remainders);
     std::vector<bigfield> left(input_left);
@@ -2391,7 +2391,7 @@ void bigfield<Builder, T>::unsafe_evaluate_multiple_multiply_add(const std::vect
             }
         }
     }
-    ASSERT(ctx != nullptr);
+    BB_ASSERT(ctx != nullptr);
 
     /**
      * Step 1: Compute the maximum potential value of our product limbs
@@ -2493,7 +2493,7 @@ void bigfield<Builder, T>::unsafe_evaluate_multiple_multiply_add(const std::vect
     // expense of 1 extra gate per constant).
     //
     const auto convert_constant_to_fixed_witness = [ctx](const bigfield& input) {
-        ASSERT(input.is_constant());
+        BB_ASSERT(input.is_constant());
         bigfield output(input);
         output.prime_basis_limb =
             field_t<Builder>::from_witness_index(ctx, ctx->put_constant_variable(input.prime_basis_limb.get_value()));
@@ -2627,8 +2627,8 @@ void bigfield<Builder, T>::unsafe_evaluate_multiple_multiply_add(const std::vect
     field_t lo = field_t<Builder>::from_witness_index(ctx, lo_1_idx) + borrow_lo;
     field_t hi = field_t<Builder>::from_witness_index(ctx, hi_1_idx);
 
-    ASSERT(max_lo_bits > (2 * NUM_LIMB_BITS));
-    ASSERT(max_hi_bits > (2 * NUM_LIMB_BITS));
+    BB_ASSERT(max_lo_bits > (2 * NUM_LIMB_BITS));
+    BB_ASSERT(max_hi_bits > (2 * NUM_LIMB_BITS));
 
     uint64_t carry_lo_msb = max_lo_bits - (2 * NUM_LIMB_BITS);
     uint64_t carry_hi_msb = max_hi_bits - (2 * NUM_LIMB_BITS);

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_goblin.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_goblin.hpp
@@ -171,7 +171,7 @@ template <class Builder_, class Fq, class Fr, class NativeGroup> class goblin_el
     {
         auto builder = get_context(other);
         // Check that the internal accumulator is zero
-        ASSERT(builder->op_queue->get_accumulator().is_point_at_infinity());
+        BB_ASSERT(builder->op_queue->get_accumulator().is_point_at_infinity());
 
         // Compute the result natively, and validate that result + other == *this
         typename NativeGroup::affine_element result_value = typename NativeGroup::affine_element(

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_goblin_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_goblin_impl.hpp
@@ -43,7 +43,7 @@ goblin_element<C, Fq, Fr, G> goblin_element<C, Fq, Fr, G>::batch_mul(const std::
     auto builder = points[0].get_context();
 
     // Check that the internal accumulator is zero?
-    ASSERT(builder->op_queue->get_accumulator().is_point_at_infinity());
+    BB_ASSERT(builder->op_queue->get_accumulator().is_point_at_infinity());
 
     // Loop over all points and scalars
     size_t num_points = points.size();

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_impl.hpp
@@ -730,7 +730,7 @@ element<C, Fq, Fr, G> element<C, Fq, Fr, G>::multiple_montgomery_ladder(
     }
     Fq x_out = previous_x;
 
-    ASSERT(!previous_y.is_negative);
+    BB_ASSERT(!previous_y.is_negative);
 
     Fq y_out = Fq::mult_madd(previous_y.mul_left, previous_y.mul_right, previous_y.add);
     return element(x_out, y_out);

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_secp256k1.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_secp256k1.test.cpp
@@ -315,18 +315,18 @@ template <typename Curve> class stdlibBiggroupSecp256k1 : public testing::Test {
         const uint256_t scalar_u2("0xdefbb9bbabde5b9f8d7175946e75babc2f11203a8bfb71beaeec1d7a2bff17dd");
 
         // Check the assumptions
-        ASSERT(scalar_s1 < fr::modulus);
-        ASSERT(scalar_u1 < fr::modulus);
-        ASSERT(scalar_u2 < fr::modulus);
-        ASSERT((fr(scalar_s1) * fr(scalar_u2) + fr(scalar_u1)).is_zero());
-        ASSERT((g1::one * fr(scalar_u1) + (g1::one * fr(scalar_s1)) * fr(scalar_u2)).is_point_at_infinity());
+        BB_ASSERT(scalar_s1 < fr::modulus);
+        BB_ASSERT(scalar_u1 < fr::modulus);
+        BB_ASSERT(scalar_u2 < fr::modulus);
+        BB_ASSERT((fr(scalar_s1) * fr(scalar_u2) + fr(scalar_u1)).is_zero());
+        BB_ASSERT((g1::one * fr(scalar_u1) + (g1::one * fr(scalar_s1)) * fr(scalar_u2)).is_point_at_infinity());
 
         // Check that the wnaf skews of the lo and hi parts of u2 are as expected
         fr u2_lo;
         fr u2_hi;
         fr::split_into_endomorphism_scalars(fr(scalar_u2).from_montgomery_form(), u2_lo, u2_hi);
-        ASSERT(uint256_t(u2_lo).get_bit(0) == 0); // u2_lo skew is 1 (even)
-        ASSERT(uint256_t(u2_hi).get_bit(0) == 1); // u2_hi skew is 0 (odd)
+        BB_ASSERT(uint256_t(u2_lo).get_bit(0) == 0); // u2_lo skew is 1 (even)
+        BB_ASSERT(uint256_t(u2_hi).get_bit(0) == 1); // u2_hi skew is 0 (odd)
 
         Builder builder = Builder();
         element_ct P_a = element_ct::from_witness(&builder, g1::one * fr(scalar_s1));
@@ -375,11 +375,11 @@ template <typename Curve> class stdlibBiggroupSecp256k1 : public testing::Test {
         const uint256_t scalar_u2("0x1323b0342b1a56a076cbf5e3899156fbf3f439f2c3b0d5a95b9ef74622447f2e");
 
         // Check the assumptions
-        ASSERT(scalar_g1 < fr::modulus);
-        ASSERT(scalar_u1 < fr::modulus);
-        ASSERT(scalar_u2 < fr::modulus);
-        ASSERT((fr(scalar_g1) * fr(scalar_u2) + fr(scalar_u1)).is_zero());
-        ASSERT((g1::one * fr(scalar_u1) + (g1::one * fr(scalar_g1)) * fr(scalar_u2)).is_point_at_infinity());
+        BB_ASSERT(scalar_g1 < fr::modulus);
+        BB_ASSERT(scalar_u1 < fr::modulus);
+        BB_ASSERT(scalar_u2 < fr::modulus);
+        BB_ASSERT((fr(scalar_g1) * fr(scalar_u2) + fr(scalar_u1)).is_zero());
+        BB_ASSERT((g1::one * fr(scalar_u1) + (g1::one * fr(scalar_g1)) * fr(scalar_u2)).is_point_at_infinity());
 
         // Create the circuit
         Builder builder = Builder();

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bool/bool.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bool/bool.cpp
@@ -41,7 +41,7 @@ bool_t<Builder>::bool_t(const witness_t<Builder>& value, const bool& use_range_c
     : context(value.context)
 {
     BB_ASSERT((value.witness == bb::fr::zero()) || (value.witness == bb::fr::one()),
-           "bool_t: witness value is not 0 or 1");
+              "bool_t: witness value is not 0 or 1");
     witness_index = value.witness_index;
 
     if (use_range_constraint) {

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bool/bool.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bool/bool.cpp
@@ -40,7 +40,7 @@ template <typename Builder>
 bool_t<Builder>::bool_t(const witness_t<Builder>& value, const bool& use_range_constraint)
     : context(value.context)
 {
-    ASSERT((value.witness == bb::fr::zero()) || (value.witness == bb::fr::one()),
+    BB_ASSERT((value.witness == bb::fr::zero()) || (value.witness == bb::fr::one()),
            "bool_t: witness value is not 0 or 1");
     witness_index = value.witness_index;
 
@@ -95,7 +95,7 @@ bool_t<Builder>::bool_t(bool_t<Builder>&& other)
 template <typename Builder>
 bool_t<Builder> bool_t<Builder>::from_witness_index_unsafe(Builder* ctx, const uint32_t witness_index)
 {
-    ASSERT(witness_index != IS_CONSTANT);
+    BB_ASSERT(witness_index != IS_CONSTANT);
     bool_t<Builder> result(ctx);
     result.witness_index = witness_index;
     const bb::fr value = ctx->get_variable(witness_index);
@@ -149,7 +149,7 @@ template <typename Builder> bool_t<Builder>& bool_t<Builder>::operator=(bool_t&&
  */
 template <typename Builder> bool_t<Builder>& bool_t<Builder>::operator=(const witness_t<Builder>& other)
 {
-    ASSERT((other.witness == bb::fr::one()) || (other.witness == bb::fr::zero()));
+    BB_ASSERT((other.witness == bb::fr::one()) || (other.witness == bb::fr::zero()));
     context = other.context;
     witness_bool = other.witness == bb::fr::one();
     witness_index = other.witness_index;
@@ -170,7 +170,7 @@ template <typename Builder> bool_t<Builder> bool_t<Builder>::operator&(const boo
     bool right = other.witness_inverted ^ other.witness_bool;
     result.witness_bool = left && right;
 
-    ASSERT(result.context || (is_constant() && other.is_constant()));
+    BB_ASSERT(result.context || (is_constant() && other.is_constant()));
     if (!is_constant() && !other.is_constant()) {
         bb::fr value = result.witness_bool ? bb::fr::one() : bb::fr::zero();
         result.witness_index = context->add_variable(value);
@@ -215,13 +215,13 @@ template <typename Builder> bool_t<Builder> bool_t<Builder>::operator&(const boo
         context->create_poly_gate(
             { witness_index, other.witness_index, result.witness_index, q_m, q_l, q_r, q_o, q_c });
     } else if (!is_constant() && other.is_constant()) {
-        ASSERT(!other.witness_inverted);
+        BB_ASSERT(!other.witness_inverted);
         // If rhs is a constant true, the output is determined by the lhs. Otherwise the output is a constant
         // `false`.
         result = other.witness_bool ? *this : other;
 
     } else if (is_constant() && !other.is_constant()) {
-        ASSERT(!witness_inverted);
+        BB_ASSERT(!witness_inverted);
         // If lhs is a constant true, the output is determined by the rhs. Otherwise the output is a constant
         // `false`.
         result = witness_bool ? other : *this;
@@ -238,7 +238,7 @@ template <typename Builder> bool_t<Builder> bool_t<Builder>::operator|(const boo
 {
     bool_t<Builder> result(context ? context : other.context);
 
-    ASSERT(result.context || (is_constant() && other.is_constant()));
+    BB_ASSERT(result.context || (is_constant() && other.is_constant()));
 
     result.witness_bool = (witness_bool ^ witness_inverted) | (other.witness_bool ^ other.witness_inverted);
     bb::fr value = result.witness_bool ? bb::fr::one() : bb::fr::zero();
@@ -290,7 +290,7 @@ template <typename Builder> bool_t<Builder> bool_t<Builder>::operator^(const boo
 {
     bool_t<Builder> result(context == nullptr ? other.context : context);
 
-    ASSERT(result.context || (is_constant() && other.is_constant()));
+    BB_ASSERT(result.context || (is_constant() && other.is_constant()));
 
     result.witness_bool = (witness_bool ^ witness_inverted) ^ (other.witness_bool ^ other.witness_inverted);
     bb::fr value = result.witness_bool ? bb::fr::one() : bb::fr::zero();
@@ -340,7 +340,7 @@ template <typename Builder> bool_t<Builder> bool_t<Builder>::operator!() const
 {
     bool_t<Builder> result(*this);
     if (result.is_constant()) {
-        ASSERT(!witness_inverted);
+        BB_ASSERT(!witness_inverted);
         // Negate the value of a constant bool_t element.
         result.witness_bool = !result.witness_bool;
     } else {
@@ -355,7 +355,7 @@ template <typename Builder> bool_t<Builder> bool_t<Builder>::operator!() const
  */
 template <typename Builder> bool_t<Builder> bool_t<Builder>::operator==(const bool_t& other) const
 {
-    ASSERT(context || other.context || (is_constant() && other.is_constant()));
+    BB_ASSERT(context || other.context || (is_constant() && other.is_constant()));
     bool_t<Builder> result(context ? context : other.context);
 
     result.witness_bool = (witness_bool ^ witness_inverted) == (other.witness_bool ^ other.witness_inverted);
@@ -428,12 +428,12 @@ template <typename Builder> void bool_t<Builder>::assert_equal(const bool_t& rhs
     if (lhs.is_constant() && rhs.is_constant()) {
         BB_ASSERT_EQ(lhs.get_value(), rhs.get_value());
     } else if (lhs.is_constant()) {
-        ASSERT(!lhs.witness_inverted);
+        BB_ASSERT(!lhs.witness_inverted);
         // if rhs is inverted, flip the value of the lhs constant
         const bool lhs_value = rhs.witness_inverted ? !lhs.witness_bool : lhs.witness_bool;
         ctx->assert_equal_constant(rhs.witness_index, lhs_value, msg);
     } else if (rhs.is_constant()) {
-        ASSERT(!rhs.witness_inverted);
+        BB_ASSERT(!rhs.witness_inverted);
         // if lhs is inverted, flip the value of the rhs constant
         const bool rhs_value = lhs.witness_inverted ? !rhs.witness_bool : rhs.witness_bool;
         ctx->assert_equal_constant(lhs.witness_index, rhs_value, msg);
@@ -505,7 +505,7 @@ template <typename Builder> bool_t<Builder> bool_t<Builder>::implies_both_ways(c
 template <typename Builder> bool_t<Builder> bool_t<Builder>::normalize() const
 {
     if (is_constant()) {
-        ASSERT(!witness_inverted);
+        BB_ASSERT(!witness_inverted);
         return *this;
     }
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bool/bool.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bool/bool.hpp
@@ -114,7 +114,7 @@ template <typename Builder> class bool_t {
     bool is_inverted() const
     {
         if (is_constant()) {
-            ASSERT(!witness_inverted);
+            BB_ASSERT(!witness_inverted);
         }
         return witness_inverted;
     }
@@ -131,8 +131,8 @@ template <typename Builder> class bool_t {
     void unset_free_witness_tag() { tag.unset_free_witness(); }
     void fix_witness()
     {
-        ASSERT(!is_constant());
-        ASSERT(context);
+        BB_ASSERT(!is_constant());
+        BB_ASSERT(context);
         context->fix_witness(witness_index, get_value());
         unset_free_witness_tag();
     }

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/byte_array/byte_array.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/byte_array/byte_array.cpp
@@ -35,7 +35,7 @@ byte_array<Builder>::byte_array(Builder* parent_context, std::vector<uint8_t> co
     : context(parent_context)
     , values(input.size())
 {
-    ASSERT(context);
+    BB_ASSERT(context);
     for (size_t i = 0; i < input.size(); ++i) {
         uint8_t c = input[i];
         field_t<Builder> value(witness_t(context, c));
@@ -239,7 +239,7 @@ template <typename Builder> byte_array<Builder>& byte_array<Builder>::operator=(
 template <typename Builder> byte_array<Builder>::operator field_t<Builder>() const
 {
     const size_t bytes = values.size();
-    ASSERT(bytes < 32);
+    BB_ASSERT(bytes < 32);
     static constexpr uint256_t one(1);
     std::vector<field_t<Builder>> scaled_values;
 
@@ -277,7 +277,7 @@ template <typename Builder> byte_array<Builder>& byte_array<Builder>::write_at(b
  */
 template <typename Builder> byte_array<Builder> byte_array<Builder>::slice(size_t offset) const
 {
-    ASSERT_DEBUG(offset < values.size());
+    BB_ASSERT_DEBUG(offset < values.size());
     return byte_array(context, bytes_t(values.begin() + static_cast<ptrdiff_t>(offset), values.end()));
 }
 
@@ -287,9 +287,9 @@ template <typename Builder> byte_array<Builder> byte_array<Builder>::slice(size_
  **/
 template <typename Builder> byte_array<Builder> byte_array<Builder>::slice(size_t offset, size_t length) const
 {
-    ASSERT_DEBUG(offset < values.size());
+    BB_ASSERT_DEBUG(offset < values.size());
     // it's <= cause vector constructor doesn't include end point
-    ASSERT_DEBUG(length <= values.size() - offset);
+    BB_ASSERT_DEBUG(length <= values.size() - offset);
     auto start = values.begin() + static_cast<ptrdiff_t>(offset);
     auto end = values.begin() + static_cast<ptrdiff_t>((offset + length));
     return byte_array(context, bytes_t(start, end));

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/databus/databus.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/databus/databus.cpp
@@ -22,7 +22,7 @@ void databus<Builder>::bus_vector::set_values(const std::vector<field_pt>& entri
         }
     }
     // Enforce that builder context is known at this stage. Otherwise first read will fail if the index is a constant.
-    ASSERT(context != nullptr);
+    BB_ASSERT(context != nullptr);
 
     // Initialize the bus vector entries from the input entries which are un-normalized and possibly constants
     for (const auto& entry : entries_in) {

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/field/field.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/field/field.hpp
@@ -28,7 +28,7 @@ template <typename T, typename... Ts> T* validate_context(T* first, Ts*... rest)
     if (!tail) {
         return first; // tail is null, use first
     }
-    ASSERT(first == tail, "Pointers refer to different builder objects!");
+    BB_ASSERT(first == tail, "Pointers refer to different builder objects!");
     return first;
 }
 
@@ -309,7 +309,7 @@ template <typename Builder_> class field_t {
         // `divide_no_zero_check`, hence we can safely apply the latter instead of `/` operator.
         auto* ctx = get_context();
         if (is_constant()) {
-            ASSERT(!get_value().is_zero(), "field_t::invert denominator is constant 0");
+            BB_ASSERT(!get_value().is_zero(), "field_t::invert denominator is constant 0");
         }
 
         if (get_value().is_zero() && !ctx->failed()) {
@@ -411,7 +411,7 @@ template <typename Builder_> class field_t {
     };
     uint32_t set_public() const
     {
-        ASSERT(!is_constant());
+        BB_ASSERT(!is_constant());
         return context->set_public_input(get_normalized_witness_index());
     }
 
@@ -421,8 +421,8 @@ template <typename Builder_> class field_t {
      */
     void convert_constant_to_fixed_witness(Builder* ctx)
     {
-        ASSERT(is_constant());
-        ASSERT(ctx);
+        BB_ASSERT(is_constant());
+        BB_ASSERT(ctx);
         context = ctx;
         (*this) = field_t<Builder>(witness_t<Builder>(context, get_value()));
         context->fix_witness(witness_index, get_value());
@@ -448,8 +448,8 @@ template <typename Builder_> class field_t {
      */
     void fix_witness()
     {
-        ASSERT(!is_constant());
-        ASSERT(context);
+        BB_ASSERT(!is_constant());
+        BB_ASSERT(context);
         // Let     a := *this;
         //       q_l :=  1
         //       q_c := -*this.get_value()

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/field/field_conversion.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/field/field_conversion.hpp
@@ -69,8 +69,8 @@ template <typename Field> class StdlibCodec {
                          "field_conversion: convert_challenge");
             Builder* builder = challenge.get_context();
             // All challenges must be circuit witnesses.
-            ASSERT(builder);
-            ASSERT(!challenge.is_constant());
+            BB_ASSERT(builder);
+            BB_ASSERT(!challenge.is_constant());
             return T(challenge, fr::from_witness_index(builder, builder->zero_idx()));
         }
     }
@@ -150,7 +150,7 @@ template <typename Field> class StdlibCodec {
         constexpr size_t expected_size = calc_num_fields<T>();
         BB_ASSERT_EQ(fr_vec.size(), expected_size);
 
-        ASSERT(validate_context<Builder>(fr_vec));
+        BB_ASSERT(validate_context<Builder>(fr_vec));
 
         if constexpr (IsAnyOf<T, field_ct>) {
             // Case 1: input type matches the output type

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/field/field_utils.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/field/field_utils.cpp
@@ -50,7 +50,7 @@ std::pair<field_t<Builder>, field_t<Builder>> split_unique(const field_t<Builder
 {
     using native = typename field_t<Builder>::native;
     static constexpr size_t max_bits = native::modulus.get_msb() + 1;
-    ASSERT(lo_bits < max_bits);
+    BB_ASSERT(lo_bits < max_bits);
 
     const uint256_t value(field.get_value());
     const uint256_t lo_val = value.slice(0, lo_bits);

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/group/cycle_group.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/group/cycle_group.cpp
@@ -57,7 +57,7 @@ cycle_group<Builder>::cycle_group(field_t _x, field_t _y, bool_t is_infinity)
         *this = constant_infinity(this->context);
     }
 
-    ASSERT(get_value().on_curve());
+    BB_ASSERT(get_value().on_curve());
 }
 
 /**
@@ -80,7 +80,7 @@ cycle_group<Builder>::cycle_group(const bb::fr& _x, const bb::fr& _y, bool is_in
     , _is_standard(true)
     , context(nullptr)
 {
-    ASSERT(get_value().on_curve());
+    BB_ASSERT(get_value().on_curve());
 }
 
 /**
@@ -261,7 +261,7 @@ template <typename Builder> void cycle_group<Builder>::set_point_at_infinity(con
     if (is_infinity.is_constant() && this->_is_infinity.is_constant()) {
         // Check that it's not possible to enter the case when
         // The point is already infinity, but `is_infinity` = false
-        ASSERT((this->_is_infinity.get_value() == is_infinity.get_value()) || is_infinity.get_value());
+        BB_ASSERT((this->_is_infinity.get_value() == is_infinity.get_value()) || is_infinity.get_value());
 
         if (is_infinity.get_value()) {
             *this = constant_infinity(this->context);
@@ -291,8 +291,8 @@ template <typename Builder> void cycle_group<Builder>::set_point_at_infinity(con
     this->y = field_t::conditional_assign(is_infinity, 0, this->y).normalize();
 
     // We won't bump into the case where we end up with non constant coordinates
-    ASSERT(!this->x.is_constant());
-    ASSERT(!this->y.is_constant());
+    BB_ASSERT(!this->x.is_constant());
+    BB_ASSERT(!this->y.is_constant());
 
     // We have to check this to avoid the situation, where we change the infinity
     bool_t set_allowed = (this->_is_infinity == is_infinity) || is_infinity;
@@ -315,8 +315,8 @@ template <typename Builder> void cycle_group<Builder>::set_point_at_infinity(con
 template <typename Builder> void cycle_group<Builder>::standardize()
 {
     if (this->is_constant_point_at_infinity()) {
-        ASSERT(this->is_constant());
-        ASSERT(this->_is_standard);
+        BB_ASSERT(this->is_constant());
+        BB_ASSERT(this->_is_standard);
     }
 
     if (this->_is_standard) {
@@ -411,9 +411,9 @@ cycle_group<Builder> cycle_group<Builder>::_unconditional_add_or_subtract(const 
                                                                           const std::optional<AffineElement> hint) const
 {
     // This method should not be called on known points at infinity
-    ASSERT(!this->is_constant_point_at_infinity(),
+    BB_ASSERT(!this->is_constant_point_at_infinity(),
            "cycle_group::_unconditional_add_or_subtract called on constant point at infinity");
-    ASSERT(!other.is_constant_point_at_infinity(),
+    BB_ASSERT(!other.is_constant_point_at_infinity(),
            "cycle_group::_unconditional_add_or_subtract called on constant point at infinity");
 
     auto context = get_context(other);
@@ -504,7 +504,7 @@ cycle_group<Builder> cycle_group<Builder>::checked_unconditional_add(const cycle
 {
     const field_t x_delta = this->x - other.x;
     if (x_delta.is_constant()) {
-        ASSERT(x_delta.get_value() != 0);
+        BB_ASSERT(x_delta.get_value() != 0);
     } else {
         x_delta.assert_is_not_zero("cycle_group::checked_unconditional_add, x-coordinate collision");
     }
@@ -528,7 +528,7 @@ cycle_group<Builder> cycle_group<Builder>::checked_unconditional_subtract(const 
 {
     const field_t x_delta = this->x - other.x;
     if (x_delta.is_constant()) {
-        ASSERT(x_delta.get_value() != 0);
+        BB_ASSERT(x_delta.get_value() != 0);
     } else {
         x_delta.assert_is_not_zero("cycle_group::checked_unconditional_subtract, x-coordinate collision");
     }

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/group/cycle_group.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/group/cycle_group.cpp
@@ -412,9 +412,9 @@ cycle_group<Builder> cycle_group<Builder>::_unconditional_add_or_subtract(const 
 {
     // This method should not be called on known points at infinity
     BB_ASSERT(!this->is_constant_point_at_infinity(),
-           "cycle_group::_unconditional_add_or_subtract called on constant point at infinity");
+              "cycle_group::_unconditional_add_or_subtract called on constant point at infinity");
     BB_ASSERT(!other.is_constant_point_at_infinity(),
-           "cycle_group::_unconditional_add_or_subtract called on constant point at infinity");
+              "cycle_group::_unconditional_add_or_subtract called on constant point at infinity");
 
     auto context = get_context(other);
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/dynamic_array.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/dynamic_array.cpp
@@ -32,7 +32,7 @@ DynamicArray<Builder>::DynamicArray(Builder* builder, const size_t maximum_size)
     , _length(0)
 {
     static_assert(HasPlookup<Builder>);
-    ASSERT(_context != nullptr);
+    BB_ASSERT(_context != nullptr);
     _inner_table = ram_table(_context, maximum_size);
     // Initialize the ram table with all zeroes
     for (size_t i = 0; i < maximum_size; ++i) {

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/ram_table.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/ram_table.cpp
@@ -84,7 +84,7 @@ template <typename Builder> void ram_table<Builder>::initialize_table() const
     if (_ram_table_generated_in_builder) {
         return;
     }
-    ASSERT(_context != nullptr);
+    BB_ASSERT(_context != nullptr);
     _ram_id = _context->create_RAM_array(_length);
 
     if (_raw_entries.size() > 0) {

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/rom_table.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/rom_table.cpp
@@ -46,7 +46,7 @@ template <typename Builder> void rom_table<Builder>::initialize_table() const
     if (initialized) {
         return;
     }
-    ASSERT(context != nullptr);
+    BB_ASSERT(context != nullptr);
     // populate table. Table entries must be normalized and cannot be constants
     for (const auto& entry : raw_entries) {
         if (entry.is_constant()) {
@@ -122,7 +122,7 @@ template <typename Builder> rom_table<Builder>& rom_table<Builder>::operator=(ro
 template <typename Builder> field_t<Builder> rom_table<Builder>::operator[](const size_t index) const
 {
     if (index >= length) {
-        ASSERT(context != nullptr);
+        BB_ASSERT(context != nullptr);
         context->failure("rom_rable: ROM array access out of bounds");
     }
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/twin_rom_table.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/twin_rom_table.cpp
@@ -137,7 +137,7 @@ template <typename Builder>
 std::array<field_t<Builder>, 2> twin_rom_table<Builder>::operator[](const size_t index) const
 {
     if (index >= length) {
-        ASSERT(context != nullptr);
+        BB_ASSERT(context != nullptr);
         context->failure("twin_rom_table: ROM array access out of bounds");
     }
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/pairing_points.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/pairing_points.hpp
@@ -58,7 +58,7 @@ template <typename Builder_> struct PairingPoints {
     // aggregation rather than individually aggregating 1 object at a time.
     void aggregate(PairingPoints const& other)
     {
-        ASSERT(other.has_data, "Cannot aggregate null pairing points.");
+        BB_ASSERT(other.has_data, "Cannot aggregate null pairing points.");
 
         // If LHS is empty, simply set it equal to the incoming pairing points
         if (!this->has_data && other.has_data) {
@@ -97,7 +97,7 @@ template <typename Builder_> struct PairingPoints {
      */
     uint32_t set_public()
     {
-        ASSERT(this->has_data, "Calling set_public on empty pairing points.");
+        BB_ASSERT(this->has_data, "Calling set_public on empty pairing points.");
         uint32_t start_idx = P0.set_public();
         P1.set_public();
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/safe_uint/safe_uint.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/safe_uint/safe_uint.cpp
@@ -75,7 +75,7 @@ template <typename Builder> safe_uint_t<Builder> safe_uint_t<Builder>::operator-
 {
     // If both are constants and the operation is an underflow, throw an error since circuit itself underflows
     BB_ASSERT(!(this->value.is_constant() && other.value.is_constant() &&
-             static_cast<uint256_t>(value.get_value()) < static_cast<uint256_t>(other.value.get_value())));
+                static_cast<uint256_t>(value.get_value()) < static_cast<uint256_t>(other.value.get_value())));
 
     field_ct difference_val = this->value - other.value;
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/safe_uint/safe_uint.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/safe_uint/safe_uint.cpp
@@ -43,7 +43,7 @@ safe_uint_t<Builder> safe_uint_t<Builder>::subtract(const safe_uint_t& other,
                                                     std::string const& description) const
 {
     BB_ASSERT_LTE(difference_bit_size, MAX_BIT_NUM);
-    ASSERT(!(this->value.is_constant() && other.value.is_constant()));
+    BB_ASSERT(!(this->value.is_constant() && other.value.is_constant()));
 
     field_ct difference_val = this->value - other.value;
     // Creates the range constraint that difference_val is in [0, (1<<difference_bit_size) - 1].
@@ -74,7 +74,7 @@ safe_uint_t<Builder> safe_uint_t<Builder>::subtract(const safe_uint_t& other,
 template <typename Builder> safe_uint_t<Builder> safe_uint_t<Builder>::operator-(const safe_uint_t& other) const
 {
     // If both are constants and the operation is an underflow, throw an error since circuit itself underflows
-    ASSERT(!(this->value.is_constant() && other.value.is_constant() &&
+    BB_ASSERT(!(this->value.is_constant() && other.value.is_constant() &&
              static_cast<uint256_t>(value.get_value()) < static_cast<uint256_t>(other.value.get_value())));
 
     field_ct difference_val = this->value - other.value;

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/circuit_builder_base.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/circuit_builder_base.hpp
@@ -123,7 +123,7 @@ template <typename FF_> class CircuitBuilderBase {
      * */
     inline FF get_variable(const uint32_t index) const
     {
-        ASSERT_DEBUG(variables.size() > real_variable_index[index]);
+        BB_ASSERT_DEBUG(variables.size() > real_variable_index[index]);
         return variables[real_variable_index[index]];
     }
 
@@ -140,7 +140,7 @@ template <typename FF_> class CircuitBuilderBase {
      */
     inline void set_variable(const uint32_t index, const FF& value)
     {
-        ASSERT_DEBUG(variables.size() > real_variable_index[index]);
+        BB_ASSERT_DEBUG(variables.size() > real_variable_index[index]);
         variables[real_variable_index[index]] = value;
     }
 
@@ -154,7 +154,7 @@ template <typename FF_> class CircuitBuilderBase {
      * */
     inline const FF& get_variable_reference(const uint32_t index) const
     {
-        ASSERT_DEBUG(variables.size() > index);
+        BB_ASSERT_DEBUG(variables.size() > index);
         return variables[real_variable_index[index]];
     }
 

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/circuit_builder_base_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/circuit_builder_base_impl.hpp
@@ -69,7 +69,7 @@ template <typename FF_> uint32_t CircuitBuilderBase<FF_>::get_public_input_index
             break;
         }
     }
-    ASSERT(result != static_cast<uint32_t>(-1));
+    BB_ASSERT(result != static_cast<uint32_t>(-1));
     return result;
 }
 
@@ -94,7 +94,7 @@ template <typename FF_> uint32_t CircuitBuilderBase<FF_>::add_variable(const FF&
 // AUDITTODO: is this used?
 template <typename FF_> void CircuitBuilderBase<FF_>::set_variable_name(uint32_t index, const std::string& name)
 {
-    ASSERT_DEBUG(variables.size() > index);
+    BB_ASSERT_DEBUG(variables.size() > index);
     uint32_t first_idx = get_first_variable_in_class(index);
 
     if (variable_names.contains(first_idx)) {

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/plookup_tables/fixed_base/fixed_base.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/plookup_tables/fixed_base/fixed_base.cpp
@@ -223,7 +223,7 @@ BasicTable table::generate_basic_fixed_base_table(BasicTableId id, size_t basic_
 
     constexpr function_ptr_table get_values_from_key_table = make_function_pointer_table();
     table.get_values_from_key = get_values_from_key_table[multitable_index][table_index];
-    ASSERT(table.get_values_from_key != nullptr);
+    BB_ASSERT(table.get_values_from_key != nullptr);
 
     table.column_1_step_size = table_size;
     table.column_2_step_size = COLUMN_2_STEP_SIZE;

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/plookup_tables/keccak/keccak_theta.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/plookup_tables/keccak/keccak_theta.hpp
@@ -66,7 +66,7 @@ class Theta {
 
     // template <size_t i> static std::pair<uint64_t, uint64_t> update_counts(std::array<size_t, TABLE_BITS>& counts)
     // {
-    //     ASSERT(i <= TABLE_BITS);
+    //     BB_ASSERT(i <= TABLE_BITS);
     //     if constexpr (i >= TABLE_BITS) {
     //         // TODO use concepts or template metaprogramming to put this condition in method declaration
     //         return std::make_pair(0, 0);

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/plookup_tables/types.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/plookup_tables/types.hpp
@@ -272,7 +272,7 @@ struct LookupHashTable {
     Value operator[](const Key& key) const
     {
         auto it = index_map.find(key);
-        ASSERT_DEBUG(it != index_map.end(), "LookupHashTable: Key not found!");
+        BB_ASSERT_DEBUG(it != index_map.end(), "LookupHashTable: Key not found!");
         return it->second;
     }
 
@@ -333,8 +333,8 @@ struct BasicTable {
 
     size_t size() const
     {
-        ASSERT_DEBUG(column_1.size() == column_2.size());
-        ASSERT_DEBUG(column_2.size() == column_3.size());
+        BB_ASSERT_DEBUG(column_1.size() == column_2.size());
+        BB_ASSERT_DEBUG(column_2.size() == column_3.size());
         return column_1.size();
     }
 };

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/plookup_tables/uint.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/plookup_tables/uint.hpp
@@ -79,7 +79,7 @@ inline BasicTable generate_and_rotate_table(BasicTableId id, const size_t table_
 template <size_t uint_size> inline MultiTable get_uint_xor_table(const MultiTableId id)
 {
     // uint_size must be one of 8, 16, 32, or 64.
-    ASSERT(uint_size == 8 || uint_size == 16 || uint_size == 32 || uint_size == 64,
+    BB_ASSERT(uint_size == 8 || uint_size == 16 || uint_size == 32 || uint_size == 64,
            "unsupported uint size for XOR table generation");
 
     const size_t TABLE_BIT_SIZE = 6;
@@ -113,7 +113,7 @@ template <size_t uint_size> inline MultiTable get_uint_xor_table(const MultiTabl
 template <size_t uint_size> inline MultiTable get_uint_and_table(const MultiTableId id)
 {
     // uint_size must be one of 8, 16, 32, or 64.
-    ASSERT(uint_size == 8 || uint_size == 16 || uint_size == 32 || uint_size == 64,
+    BB_ASSERT(uint_size == 8 || uint_size == 16 || uint_size == 32 || uint_size == 64,
            "unsupported uint size for AND table generation");
 
     const size_t TABLE_BIT_SIZE = 6;

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/plookup_tables/uint.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/plookup_tables/uint.hpp
@@ -80,7 +80,7 @@ template <size_t uint_size> inline MultiTable get_uint_xor_table(const MultiTabl
 {
     // uint_size must be one of 8, 16, 32, or 64.
     BB_ASSERT(uint_size == 8 || uint_size == 16 || uint_size == 32 || uint_size == 64,
-           "unsupported uint size for XOR table generation");
+              "unsupported uint size for XOR table generation");
 
     const size_t TABLE_BIT_SIZE = 6;
     const size_t num_entries = uint_size / TABLE_BIT_SIZE;
@@ -114,7 +114,7 @@ template <size_t uint_size> inline MultiTable get_uint_and_table(const MultiTabl
 {
     // uint_size must be one of 8, 16, 32, or 64.
     BB_ASSERT(uint_size == 8 || uint_size == 16 || uint_size == 32 || uint_size == 64,
-           "unsupported uint size for AND table generation");
+              "unsupported uint size for AND table generation");
 
     const size_t TABLE_BIT_SIZE = 6;
     const size_t num_entries = uint_size / TABLE_BIT_SIZE;

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/rom_ram_logic.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/rom_ram_logic.cpp
@@ -82,7 +82,7 @@ uint32_t RomRamLogic_<ExecutionTrace>::read_ROM_array(CircuitBuilder* builder,
     RomTranscript& rom_array = rom_arrays[rom_id];
     const uint32_t index = static_cast<uint32_t>(uint256_t(builder->get_variable(index_witness)));
     BB_ASSERT_GT(rom_array.state.size(), index);
-    ASSERT(rom_array.state[index][0] != UNINITIALIZED_MEMORY_RECORD);
+    BB_ASSERT(rom_array.state[index][0] != UNINITIALIZED_MEMORY_RECORD);
     const auto value = builder->get_variable(rom_array.state[index][0]);
     const uint32_t value_witness = builder->add_variable(value);
     RomRecord new_record{
@@ -111,8 +111,8 @@ std::array<uint32_t, 2> RomRamLogic_<ExecutionTrace>::read_ROM_array_pair(Circui
     BB_ASSERT_GT(rom_arrays.size(), rom_id);
     RomTranscript& rom_array = rom_arrays[rom_id];
     BB_ASSERT_GT(rom_array.state.size(), index);
-    ASSERT(rom_array.state[index][0] != UNINITIALIZED_MEMORY_RECORD);
-    ASSERT(rom_array.state[index][1] != UNINITIALIZED_MEMORY_RECORD);
+    BB_ASSERT(rom_array.state[index][0] != UNINITIALIZED_MEMORY_RECORD);
+    BB_ASSERT(rom_array.state[index][1] != UNINITIALIZED_MEMORY_RECORD);
     const auto value1 = builder->get_variable(rom_array.state[index][0]);
     const auto value2 = builder->get_variable(rom_array.state[index][1]);
     value_witnesses[0] = builder->add_variable(value1);
@@ -301,7 +301,7 @@ uint32_t RomRamLogic_<ExecutionTrace>::read_RAM_array(CircuitBuilder* builder,
     RamTranscript& ram_array = ram_arrays[ram_id];
     const uint32_t index = static_cast<uint32_t>(uint256_t(builder->get_variable(index_witness)));
     BB_ASSERT_GT(ram_array.state.size(), index);
-    ASSERT(ram_array.state[index] != UNINITIALIZED_MEMORY_RECORD);
+    BB_ASSERT(ram_array.state[index] != UNINITIALIZED_MEMORY_RECORD);
     const auto value = builder->get_variable(ram_array.state[index]);
     const uint32_t value_witness = builder->add_variable(value);
 
@@ -333,7 +333,7 @@ void RomRamLogic_<ExecutionTrace>::write_RAM_array(CircuitBuilder* builder,
     RamTranscript& ram_array = ram_arrays[ram_id];
     const uint32_t index = static_cast<uint32_t>(uint256_t(builder->get_variable(index_witness)));
     BB_ASSERT_GT(ram_array.state.size(), index);
-    ASSERT(ram_array.state[index] != UNINITIALIZED_MEMORY_RECORD);
+    BB_ASSERT(ram_array.state[index] != UNINITIALIZED_MEMORY_RECORD);
 
     RamRecord new_record{ .index_witness = index_witness,
                           .timestamp_witness = builder->put_constant_variable((uint64_t)ram_array.access_count),

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.cpp
@@ -793,7 +793,7 @@ void UltraCircuitBuilder_<ExecutionTrace>::create_new_range_constraint(const uin
                     }
                 }
             }
-            ASSERT(found_tag);
+            BB_ASSERT(found_tag);
         }
         assign_tag(variable_index, list.range_tag);
         list.variable_indices.emplace_back(variable_index);

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.hpp
@@ -450,7 +450,7 @@ class UltraCircuitBuilder_ : public CircuitBuilderBase<typename ExecutionTrace_:
      */
     size_t get_num_finalized_gates() const override
     {
-        ASSERT(circuit_finalized);
+        BB_ASSERT(circuit_finalized);
         return this->num_gates;
     }
 
@@ -521,7 +521,7 @@ class UltraCircuitBuilder_ : public CircuitBuilderBase<typename ExecutionTrace_:
      */
     size_t get_finalized_total_circuit_size() const
     {
-        ASSERT(circuit_finalized);
+        BB_ASSERT(circuit_finalized);
         auto num_filled_gates = get_num_finalized_gates() + this->num_public_inputs();
         return std::max(get_tables_size(), num_filled_gates);
     }

--- a/barretenberg/cpp/src/barretenberg/transcript/transcript.hpp
+++ b/barretenberg/cpp/src/barretenberg/transcript/transcript.hpp
@@ -111,7 +111,7 @@ template <typename Codec_, typename HashFunction> class BaseTranscript {
         // Prevent challenge generation if this is the first challenge we're generating,
         // AND nothing was sent by the prover.
         if (is_first_challenge) {
-            ASSERT(!current_round_data.empty());
+            BB_ASSERT(!current_round_data.empty());
         }
 
         // concatenate the previous challenge (if this is not the first challenge) with the current round data.
@@ -523,11 +523,11 @@ template <typename Codec_, typename HashFunction> class BaseTranscript {
             // If the element is iterable, then we need to check origin tags to all the elements
             if constexpr (is_iterable_v<T>) {
                 for (auto& subelement : element) {
-                    ASSERT(subelement.get_origin_tag() == element_origin_tag);
+                    BB_ASSERT(subelement.get_origin_tag() == element_origin_tag);
                 }
             } else {
                 // If the element is not iterable, then we need to check an origin tag of the element
-                ASSERT(element.get_origin_tag() == element_origin_tag);
+                BB_ASSERT(element.get_origin_tag() == element_origin_tag);
             }
         }
 #ifdef LOG_INTERACTIONS
@@ -621,7 +621,7 @@ template <typename Codec_, typename HashFunction> class BaseTranscript {
      *      what happens before and after the transcript is branched.
      *  4. To ensure soundness:
      *      a. We add to the hash buffer of `branched_transcript` the value `transcript.previous_challenge`
-     *      b. We enforce ASSERT(current_round_data.empty())
+     *      b. We enforce BB_ASSERT(current_round_data.empty())
      *
      * @note We could remove 4.b and add to the hash buffer of `branched_transcript` both
      * `transcript.previous_challenge` and `transcript.current_round_data`. However, this would conflict with 3 (as the
@@ -649,7 +649,7 @@ template <typename Codec_, typename HashFunction> class BaseTranscript {
      */
     BaseTranscript branch_transcript()
     {
-        ASSERT(current_round_data.empty(), "Branching a transcript with non empty round data");
+        BB_ASSERT(current_round_data.empty(), "Branching a transcript with non empty round data");
 
         BaseTranscript branched_transcript;
 

--- a/barretenberg/cpp/src/barretenberg/translator_vm/translator_circuit_builder.cpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/translator_circuit_builder.cpp
@@ -328,7 +328,7 @@ void TranslatorCircuitBuilder::assert_well_formed_ultra_op(const UltraOp& ultra_
 {
     // Opcode should be {0,3,4,8}
     size_t op_code = ultra_op.op_code.value();
-    ASSERT(op_code == 0 || op_code == 3 || op_code == 4 || op_code == 8);
+    BB_ASSERT(op_code == 0 || op_code == 3 || op_code == 4 || op_code == 8);
 
     // Check and insert x_lo and y_hi into wire 1
     BB_ASSERT_LTE(uint256_t(ultra_op.x_lo), MAX_LOW_WIDE_LIMB_SIZE);
@@ -538,7 +538,7 @@ void TranslatorCircuitBuilder::feed_ecc_op_queue_into_circuit(const std::shared_
     num_gates += 2;
 
     auto process_random_op = [&](const UltraOp& ultra_op) {
-        ASSERT(ultra_op.op_code.is_random_op, "function should only be called to process a random op");
+        BB_ASSERT(ultra_op.op_code.is_random_op, "function should only be called to process a random op");
         populate_wires_from_ultra_op(ultra_op);
         // Populate the other wires with zeros
         for (size_t i = WireIds::Y_LOW_Z_2 + 1; i < wires.size(); i++) {

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/ecc.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/ecc.cpp
@@ -25,7 +25,7 @@ EmbeddedCurvePoint Ecc::add(const EmbeddedCurvePoint& p, const EmbeddedCurvePoin
 EmbeddedCurvePoint Ecc::scalar_mul(const EmbeddedCurvePoint& point, const FF& scalar)
 {
     // This is bad - the scalar mul circuit assumes that the point is on the curve.
-    ASSERT(point.on_curve(), "Point must be on the curve for scalar multiplication");
+    BB_ASSERT(point.on_curve(), "Point must be on the curve for scalar multiplication");
 
     auto intermediate_states = std::vector<ScalarMulIntermediateState>(254);
     auto bits = to_radix.to_le_bits(scalar, 254).first;


### PR DESCRIPTION
Rename ASSERT to BB_ASSERT and DEBUG_ASSERT to BB_DEBUG_ASSERT throughout the codebase. Simplify ASSERT_IN_CONSTEXPR to be just BB_ASSERT. This change improves consistency and makes it clear these are custom assertions specific to our project.