### PR TITLE
feat(bb): add --vk_policy CLI option for msgpack IVC inputs validation

### DIFF
--- a/barretenberg/cpp/src/barretenberg/api/api.hpp
+++ b/barretenberg/cpp/src/barretenberg/api/api.hpp
@@ -24,6 +24,7 @@ class API {
         bool slow_low_memory{ false };          // use file backed memory for polynomials
         std::string storage_budget;             // storage budget for file backed memory (e.g. "500m", "2g")
         bool update_inputs{ false };            // update inputs when check fails
+        std::string vk_policy{ "default" };     // policy for handling VKs during IVC accumulation
 
         bool optimized_solidity_verifier{ false }; // should we use the optimized sol verifier? (temp)
 
@@ -42,6 +43,7 @@ class API {
                << "  include_gates_per_opcode " << flags.include_gates_per_opcode << "\n"
                << "  slow_low_memory " << flags.slow_low_memory << "\n"
                << "  storage_budget " << flags.storage_budget << "\n"
+               << "  vk_policy " << flags.vk_policy << "\n"
                << "]" << std::endl;
             return os;
         }

--- a/barretenberg/cpp/src/barretenberg/api/api_client_ivc.cpp
+++ b/barretenberg/cpp/src/barretenberg/api/api_client_ivc.cpp
@@ -66,6 +66,7 @@ void ClientIVCAPI::prove(const Flags& flags,
 {
     BB_BENCH_NAME("ClientIVCAPI::prove");
     bbapi::BBApiRequest request;
+    request.vk_policy = bbapi::parse_vk_policy(flags.vk_policy);
     std::vector<PrivateExecutionStepRaw> raw_steps = PrivateExecutionStepRaw::load_and_decompress(input_path);
 
     bbapi::ClientIvcStart{ .num_circuits = raw_steps.size() }.execute(request);

--- a/barretenberg/cpp/src/barretenberg/bb/cli.cpp
+++ b/barretenberg/cpp/src/barretenberg/bb/cli.cpp
@@ -287,6 +287,16 @@ int parse_and_run_cli_command(int argc, char* argv[])
         return subcommand->add_flag("--update_inputs", flags.update_inputs, "Update inputs if vk check fails.");
     };
 
+    const auto add_vk_policy_option = [&](CLI::App* subcommand) {
+        return subcommand
+            ->add_option("--vk_policy",
+                         flags.vk_policy,
+                         "Policy for handling verification keys during IVC accumulation. 'default' uses the provided "
+                         "VK as-is, 'check' verifies the provided VK matches the computed VK (throws error on "
+                         "mismatch), 'recompute' always ignores the provided VK and treats it as nullptr.")
+            ->check(CLI::IsMember({ "default", "check", "recompute" }).name("is_member"));
+    };
+
     const auto add_optimized_solidity_verifier_flag = [&](CLI::App* subcommand) {
         return subcommand->add_flag(
             "--optimized", flags.optimized_solidity_verifier, "Use the optimized Solidity verifier.");
@@ -355,6 +365,7 @@ int parse_and_run_cli_command(int argc, char* argv[])
     add_output_path_option(prove, output_path);
     add_ivc_inputs_path_options(prove);
     add_vk_path_option(prove);
+    add_vk_policy_option(prove);
     add_verbose_flag(prove);
     add_debug_flag(prove);
     add_crs_path_option(prove);

--- a/barretenberg/cpp/src/barretenberg/bbapi/bbapi_client_ivc.cpp
+++ b/barretenberg/cpp/src/barretenberg/bbapi/bbapi_client_ivc.cpp
@@ -59,9 +59,31 @@ ClientIvcAccumulate::Response ClientIvcAccumulate::execute(BBApiRequest& request
     auto circuit = acir_format::create_circuit<IVCBase::ClientCircuit>(program, metadata);
 
     std::shared_ptr<ClientIVC::MegaVerificationKey> precomputed_vk;
-    if (!request.loaded_circuit_vk.empty()) {
-        // Deserialize directly from buffer
+
+    // Apply VK policy
+    if (request.vk_policy == VkPolicy::RECOMPUTE) {
+        // RECOMPUTE: Always ignore the provided VK (treat as nullptr)
+        info("ClientIvcAccumulate - VK policy: RECOMPUTE - ignoring provided VK for circuit '", request.loaded_circuit_name, "'");
+        precomputed_vk = nullptr;
+    } else if (!request.loaded_circuit_vk.empty()) {
+        // Deserialize the provided VK
         precomputed_vk = from_buffer<std::shared_ptr<ClientIVC::MegaVerificationKey>>(request.loaded_circuit_vk);
+
+        if (request.vk_policy == VkPolicy::CHECK) {
+            // CHECK: Verify the provided VK matches the computed VK
+            info("ClientIvcAccumulate - VK policy: CHECK - verifying provided VK for circuit '", request.loaded_circuit_name, "'");
+
+            // Compute the VK from the circuit
+            auto prover_instance = std::make_shared<ClientIVC::ProverInstance>(circuit, request.trace_settings);
+            auto computed_vk = std::make_shared<ClientIVC::MegaVerificationKey>(prover_instance->get_precomputed());
+
+            // Compare VKs by dereferencing the shared pointers
+            if (*precomputed_vk != *computed_vk) {
+                throw_or_abort("VK check failed for circuit '" + request.loaded_circuit_name +
+                             "': provided VK does not match computed VK");
+            }
+            info("ClientIvcAccumulate - VK check passed for circuit '", request.loaded_circuit_name, "'");
+        }
     }
 
     info("ClientIvcAccumulate - accumulating circuit '", request.loaded_circuit_name, "'");

--- a/barretenberg/cpp/src/barretenberg/bbapi/bbapi_client_ivc.cpp
+++ b/barretenberg/cpp/src/barretenberg/bbapi/bbapi_client_ivc.cpp
@@ -60,30 +60,25 @@ ClientIvcAccumulate::Response ClientIvcAccumulate::execute(BBApiRequest& request
 
     std::shared_ptr<ClientIVC::MegaVerificationKey> precomputed_vk;
 
-    // Apply VK policy
     if (request.vk_policy == VkPolicy::RECOMPUTE) {
-        // RECOMPUTE: Always ignore the provided VK (treat as nullptr)
-        info("ClientIvcAccumulate - VK policy: RECOMPUTE - ignoring provided VK for circuit '", request.loaded_circuit_name, "'");
         precomputed_vk = nullptr;
-    } else if (!request.loaded_circuit_vk.empty()) {
-        // Deserialize the provided VK
-        precomputed_vk = from_buffer<std::shared_ptr<ClientIVC::MegaVerificationKey>>(request.loaded_circuit_vk);
+    } else if (request.vk_policy == VkPolicy::DEFAULT || request.vk_policy == VkPolicy::CHECK) {
+        if (!request.loaded_circuit_vk.empty()) {
+            precomputed_vk = from_buffer<std::shared_ptr<ClientIVC::MegaVerificationKey>>(request.loaded_circuit_vk);
 
-        if (request.vk_policy == VkPolicy::CHECK) {
-            // CHECK: Verify the provided VK matches the computed VK
-            info("ClientIvcAccumulate - VK policy: CHECK - verifying provided VK for circuit '", request.loaded_circuit_name, "'");
+            if (request.vk_policy == VkPolicy::CHECK) {
+                auto prover_instance = std::make_shared<ClientIVC::ProverInstance>(circuit, request.trace_settings);
+                auto computed_vk = std::make_shared<ClientIVC::MegaVerificationKey>(prover_instance->get_precomputed());
 
-            // Compute the VK from the circuit
-            auto prover_instance = std::make_shared<ClientIVC::ProverInstance>(circuit, request.trace_settings);
-            auto computed_vk = std::make_shared<ClientIVC::MegaVerificationKey>(prover_instance->get_precomputed());
-
-            // Compare VKs by dereferencing the shared pointers
-            if (*precomputed_vk != *computed_vk) {
-                throw_or_abort("VK check failed for circuit '" + request.loaded_circuit_name +
-                             "': provided VK does not match computed VK");
+                // Dereference to compare VK contents
+                if (*precomputed_vk != *computed_vk) {
+                    throw_or_abort("VK check failed for circuit '" + request.loaded_circuit_name +
+                                 "': provided VK does not match computed VK");
+                }
             }
-            info("ClientIvcAccumulate - VK check passed for circuit '", request.loaded_circuit_name, "'");
         }
+    } else {
+        throw_or_abort("Invalid VK policy");
     }
 
     info("ClientIvcAccumulate - accumulating circuit '", request.loaded_circuit_name, "'");

--- a/barretenberg/cpp/src/barretenberg/bbapi/bbapi_client_ivc.cpp
+++ b/barretenberg/cpp/src/barretenberg/bbapi/bbapi_client_ivc.cpp
@@ -73,7 +73,7 @@ ClientIvcAccumulate::Response ClientIvcAccumulate::execute(BBApiRequest& request
                 // Dereference to compare VK contents
                 if (*precomputed_vk != *computed_vk) {
                     throw_or_abort("VK check failed for circuit '" + request.loaded_circuit_name +
-                                 "': provided VK does not match computed VK");
+                                   "': provided VK does not match computed VK");
                 }
             }
         }

--- a/barretenberg/cpp/src/barretenberg/bbapi/bbapi_client_ivc.cpp
+++ b/barretenberg/cpp/src/barretenberg/bbapi/bbapi_client_ivc.cpp
@@ -78,7 +78,7 @@ ClientIvcAccumulate::Response ClientIvcAccumulate::execute(BBApiRequest& request
             }
         }
     } else {
-        throw_or_abort("Invalid VK policy");
+        throw_or_abort("Invalid VK policy. Valid options: default, check, recompute");
     }
 
     info("ClientIvcAccumulate - accumulating circuit '", request.loaded_circuit_name, "'");

--- a/barretenberg/cpp/src/barretenberg/bbapi/bbapi_shared.hpp
+++ b/barretenberg/cpp/src/barretenberg/bbapi/bbapi_shared.hpp
@@ -26,9 +26,9 @@ inline bool USE_SUMCHECK_IVC = false;
  * @brief Policy for handling verification keys during IVC accumulation
  */
 enum class VkPolicy {
-    DEFAULT,   // Use the provided VK as-is (default behavior)
-    CHECK,     // Verify the provided VK matches the computed VK, throw error if mismatch
-    RECOMPUTE  // Always ignore the provided VK and treat it as nullptr
+    DEFAULT,  // Use the provided VK as-is (default behavior)
+    CHECK,    // Verify the provided VK matches the computed VK, throw error if mismatch
+    RECOMPUTE // Always ignore the provided VK and treat it as nullptr
 };
 
 /**

--- a/barretenberg/cpp/src/barretenberg/bbapi/bbapi_shared.hpp
+++ b/barretenberg/cpp/src/barretenberg/bbapi/bbapi_shared.hpp
@@ -22,6 +22,16 @@ namespace bb::bbapi {
 inline bool USE_SUMCHECK_IVC = false;
 
 /**
+ * @enum VkPolicy
+ * @brief Policy for handling verification keys during IVC accumulation
+ */
+enum class VkPolicy {
+    DEFAULT,   // Use the provided VK as-is (default behavior)
+    CHECK,     // Verify the provided VK matches the computed VK, throw error if mismatch
+    RECOMPUTE  // Always ignore the provided VK and treat it as nullptr
+};
+
+/**
  * @struct CircuitInputNoVK
  * @brief A circuit to be used in either ultrahonk or chonk (ClientIVC+honk) verification key derivation.
  */
@@ -121,6 +131,20 @@ inline OracleHashType parse_oracle_hash_type(const std::string& type)
     return OracleHashType::POSEIDON2; // default
 }
 
+/**
+ * @brief Convert VK policy string to enum for internal use
+ */
+inline VkPolicy parse_vk_policy(const std::string& policy)
+{
+    if (policy == "check") {
+        return VkPolicy::CHECK;
+    }
+    if (policy == "recompute") {
+        return VkPolicy::RECOMPUTE;
+    }
+    return VkPolicy::DEFAULT; // default
+}
+
 struct BBApiRequest {
     TraceSettings trace_settings{ AZTEC_TRACE_STRUCTURE };
     // Current depth of the IVC stack for this request
@@ -132,6 +156,8 @@ struct BBApiRequest {
     std::optional<acir_format::AcirFormat> loaded_circuit_constraints;
     // Store the verification key passed with the circuit
     std::vector<uint8_t> loaded_circuit_vk;
+    // Policy for handling verification keys during accumulation
+    VkPolicy vk_policy = VkPolicy::DEFAULT;
 };
 
 struct Shutdown {


### PR DESCRIPTION
Add support for configurable VK policy validation when proving msgpack IVC inputs bundles via CLI. Implements three policy modes: default, check (validates inputs aren't corrupted), and recompute (ignores inputs).