### PR TITLE
chore(docs): refactoring cross-chain tutorial

### DIFF
--- a/docs/examples/tutorials/token_bridge_contract/contracts/NFTPortal.sol
+++ b/docs/examples/tutorials/token_bridge_contract/contracts/NFTPortal.sol
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.8.27;
+
+// docs:start:portal_setup
+import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+import {IRegistry} from "@aztec/l1-contracts/src/governance/interfaces/IRegistry.sol";
+import {IInbox} from "@aztec/l1-contracts/src/core/interfaces/messagebridge/IInbox.sol";
+import {IOutbox} from "@aztec/l1-contracts/src/core/interfaces/messagebridge/IOutbox.sol";
+import {IRollup} from "@aztec/l1-contracts/src/core/interfaces/IRollup.sol";
+import {DataStructures} from "@aztec/l1-contracts/src/core/libraries/DataStructures.sol";
+import {Hash} from "@aztec/l1-contracts/src/core/libraries/crypto/Hash.sol";
+
+contract NFTPortal {
+    IRegistry public registry;
+    IERC721 public nftContract;
+    bytes32 public l2Bridge;
+
+    IRollup public rollup;
+    IOutbox public outbox;
+    IInbox public inbox;
+    uint256 public rollupVersion;
+
+    function initialize(address _registry, address _nftContract, bytes32 _l2Bridge) external {
+        registry = IRegistry(_registry);
+        nftContract = IERC721(_nftContract);
+        l2Bridge = _l2Bridge;
+
+        rollup = IRollup(address(registry.getCanonicalRollup()));
+        outbox = rollup.getOutbox();
+        inbox = rollup.getInbox();
+        rollupVersion = rollup.getVersion();
+    }
+    // docs:end:portal_setup
+
+    // docs:start:portal_deposit_and_withdraw
+    // Lock NFT and send message to L2
+    function depositToAztec(uint256 tokenId, bytes32 secretHash) external returns (bytes32, uint256) {
+        // Lock the NFT
+        nftContract.transferFrom(msg.sender, address(this), tokenId);
+
+        // Prepare L2 message - just a naive hash of our tokenId
+        DataStructures.L2Actor memory actor = DataStructures.L2Actor(l2Bridge, rollupVersion);
+        bytes32 contentHash = Hash.sha256ToField(abi.encode(tokenId));
+
+        // Send message to Aztec
+        (bytes32 key, uint256 index) = inbox.sendL2Message(actor, contentHash, secretHash);
+        return (key, index);
+    }
+
+    // Unlock NFT after L2 burn
+    function withdraw(
+        uint256 tokenId,
+        uint256 l2BlockNumber,
+        uint256 leafIndex,
+        bytes32[] calldata path
+    ) external {
+        // Verify message from L2
+        DataStructures.L2ToL1Msg memory message = DataStructures.L2ToL1Msg({
+            sender: DataStructures.L2Actor(l2Bridge, rollupVersion),
+            recipient: DataStructures.L1Actor(address(this), block.chainid),
+            content: Hash.sha256ToField(abi.encodePacked(tokenId, msg.sender))
+        });
+
+        outbox.consume(message, l2BlockNumber, leafIndex, path);
+
+        // Unlock NFT
+        nftContract.transferFrom(address(this), msg.sender, tokenId);
+    }
+}
+// docs:end:portal_deposit_and_withdraw

--- a/docs/examples/tutorials/token_bridge_contract/contracts/SimpleNFT.sol
+++ b/docs/examples/tutorials/token_bridge_contract/contracts/SimpleNFT.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// docs:start:simple_nft
+pragma solidity >=0.8.27;
+
+import {ERC721} from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+
+contract SimpleNFT is ERC721 {
+    uint256 private _currentTokenId;
+
+    constructor() ERC721("SimplePunk", "SPUNK") {}
+
+    function mint(address to) external returns (uint256) {
+        uint256 tokenId = _currentTokenId++;
+        _mint(to, tokenId);
+        return tokenId;
+    }
+}
+// docs:end:simple_nft

--- a/docs/examples/tutorials/token_bridge_contract/contracts/aztec/nft/Nargo.toml
+++ b/docs/examples/tutorials/token_bridge_contract/contracts/aztec/nft/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "nft"
+type = "contract"
+
+[dependencies]
+aztec = { path = "../../../../noir-projects/aztec-nr/aztec" }

--- a/docs/examples/tutorials/token_bridge_contract/contracts/aztec/nft/src/main.nr
+++ b/docs/examples/tutorials/token_bridge_contract/contracts/aztec/nft/src/main.nr
@@ -1,0 +1,82 @@
+// docs:start:contract_setup
+use aztec::macros::aztec;
+pub mod nft;
+
+#[aztec]
+pub contract NFTPunk {
+    use dep::aztec::{
+        macros::{storage::storage, functions::{utility, private, public, initializer, internal}},
+        protocol_types::{address::AztecAddress},
+        state_vars::{PrivateSet, PublicImmutable, delayed_public_mutable::DelayedPublicMutable, Map}
+    };
+    use crate::nft::NFTNote;
+    use dep::aztec::messages::message_delivery::MessageDelivery;
+    use aztec::note::{note_getter_options::NoteGetterOptions, note_interface::NoteProperties, note_viewer_options::NoteViewerOptions};
+    use aztec::utils::comparison::Comparator;
+
+    #[storage]
+    struct Storage<Context> {
+        admin: PublicImmutable<AztecAddress, Context>,
+        minter: PublicImmutable<AztecAddress, Context>,
+        nfts: Map<Field, DelayedPublicMutable<bool, 2, Context>, Context>,
+        owners: Map<AztecAddress, PrivateSet<NFTNote, Context>, Context>,
+    }
+    #[public]
+    #[initializer]
+    fn constructor(admin: AztecAddress) {
+        storage.admin.initialize(admin);
+    }
+    // docs:end:contract_setup
+
+    // docs:start:set_minter
+    #[public]
+    fn set_minter(minter: AztecAddress) {
+        assert(storage.admin.read().eq(context.msg_sender().unwrap()), "caller is not admin");
+        storage.minter.initialize(minter);
+    }
+    // docs:end:set_minter
+
+    // docs:start:mark_nft_exists
+    #[public]
+    #[internal]
+    fn _mark_nft_exists(token_id: Field, exists: bool) {
+        storage.nfts.at(token_id).schedule_value_change(exists);
+    }
+    // docs:end:mark_nft_exists
+
+    // docs:start:mint
+    #[private]
+    fn mint(to: AztecAddress, token_id: Field) {
+        assert(storage.minter.read().eq(context.msg_sender().unwrap()), "caller is not the authorized minter");
+
+        // we create an NFT note and insert it to the PrivateSet - a collection of notes meant to be read in private
+        let new_nft = NFTNote::new(to, token_id);
+        storage.owners.at(to).insert(new_nft).emit(&mut context, to, MessageDelivery.CONSTRAINED_ONCHAIN);
+
+        // calling the internal public function above to indicate that the NFT is taken
+        NFTPunk::at(context.this_address())._mark_nft_exists(token_id, true).enqueue(&mut context);
+    }
+    // docs:end:mint
+
+    // docs:start:notes_of
+    #[utility]
+    unconstrained fn notes_of(from: AztecAddress) -> Field {
+        let notes = storage.owners.at(from).view_notes(NoteViewerOptions::new());
+        notes.len() as Field
+    }
+    // docs:end:notes_of
+
+    // docs:start:burn
+    #[private]
+    fn burn(from: AztecAddress, token_id: Field) {
+        assert(storage.minter.read().eq(context.msg_sender().unwrap()), "caller is not the authorized minter");
+
+        // from the NFTNote properties, selects token_id and compares it against the token_id to be burned
+        let options = NoteGetterOptions::new().select(NFTNote::properties().token_id, Comparator.EQ, token_id).set_limit(1);
+        let notes = storage.owners.at(from).pop_notes(options);
+        assert(notes.len() == 1, "NFT not found");
+
+        NFTPunk::at(context.this_address())._mark_nft_exists(token_id, false).enqueue(&mut context);
+    }
+    // docs:end:burn
+}

--- a/docs/examples/tutorials/token_bridge_contract/contracts/aztec/nft/src/nft.nr
+++ b/docs/examples/tutorials/token_bridge_contract/contracts/aztec/nft/src/nft.nr
@@ -1,0 +1,27 @@
+// docs:start:nft_note_struct
+use dep::aztec::{
+    macros::notes::note,
+    protocol_types::{
+        address::AztecAddress,
+        traits::Packable,
+    },
+    oracle::random::random,
+};
+
+#[derive(Eq, Packable)]
+#[note]
+pub struct NFTNote {
+    owner: AztecAddress,
+    randomness: Field,
+    token_id: Field,
+}
+// docs:end:nft_note_struct
+
+// docs:start:nft_note_new
+impl NFTNote {
+    pub fn new(owner: AztecAddress, token_id: Field) -> Self {
+        // The randomness preserves privacy by preventing brute-forcing
+        NFTNote { owner, randomness: unsafe { random() }, token_id }
+    }
+}
+// docs:end:nft_note_new

--- a/docs/examples/tutorials/token_bridge_contract/contracts/aztec/nft_bridge/Nargo.toml
+++ b/docs/examples/tutorials/token_bridge_contract/contracts/aztec/nft_bridge/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "nft_bridge"
+type = "contract"
+
+[dependencies]
+aztec = { path = "../../../../noir-projects/aztec-nr/aztec" }
+NFTPunk = { path = "../nft" }

--- a/docs/examples/tutorials/token_bridge_contract/contracts/aztec/nft_bridge/src/main.nr
+++ b/docs/examples/tutorials/token_bridge_contract/contracts/aztec/nft_bridge/src/main.nr
@@ -1,0 +1,69 @@
+// docs:start:bridge_setup
+use aztec::macros::aztec;
+
+#[aztec]
+pub contract NFTBridge {
+    use dep::aztec::{
+        macros::{storage::storage, functions::{public, initializer, private}},
+        protocol_types::{address::AztecAddress, address::EthAddress, hash::sha256_to_field},
+        state_vars::{PublicImmutable},
+    };
+    use dep::NFTPunk::NFTPunk;
+    
+    #[storage]
+    struct Storage<Context> {
+        nft: PublicImmutable<AztecAddress, Context>,
+        portal: PublicImmutable<EthAddress, Context>,
+    }
+    
+    #[public]
+    #[initializer]
+    fn constructor(nft: AztecAddress) {
+        storage.nft.initialize(nft);
+    }
+    
+    #[public]
+    fn set_portal(portal: EthAddress) {
+        storage.portal.initialize(portal);
+    }
+    // docs:end:bridge_setup
+
+    // docs:start:claim
+    #[private]
+    fn claim(to: AztecAddress, token_id: Field, secret: Field, message_leaf_index: Field) {
+        // Compute the message hash that was sent from L1
+        let token_id_bytes: [u8; 32] = (token_id as Field).to_be_bytes();
+        let content_hash = sha256_to_field(token_id_bytes);
+
+        // Consume the L1 -> L2 message
+        context.consume_l1_to_l2_message(
+            content_hash,
+            secret,
+            storage.portal.read(),
+            message_leaf_index
+        );
+
+        // Mint the NFT on L2
+        let nft = storage.nft.read();
+        NFTPunk::at(nft).mint(to, token_id).call(&mut context);
+    }
+    // docs:end:claim
+
+    // docs:start:exit
+    #[private]
+    fn exit(
+        token_id: Field,
+        recipient: EthAddress
+    ) {
+        // Create L2->L1 message to unlock NFT on L1
+        let token_id_bytes: [u8; 32] = token_id.to_be_bytes();
+        let recipient_bytes: [u8; 20] = recipient.to_be_bytes();
+        let content = sha256_to_field(token_id_bytes.concat(recipient_bytes));
+        context.message_portal(storage.portal.read(), content);
+
+        // Burn the NFT on L2
+        let nft = storage.nft.read();
+        NFTPunk::at(nft).burn(context.msg_sender().unwrap(), token_id).call(&mut context);
+    }
+    // docs:end:exit
+}

--- a/docs/examples/tutorials/token_bridge_contract/scripts/index.ts
+++ b/docs/examples/tutorials/token_bridge_contract/scripts/index.ts
@@ -1,0 +1,281 @@
+// @ts-nocheck
+
+// docs:start:setup
+import { privateKeyToAccount } from 'viem/accounts';
+import { createPublicClient, createWalletClient, http, pad, getAbiItem, toEventHash } from 'viem';
+import { foundry } from 'viem/chains';
+import { EthAddress, createAztecNodeClient, computeSecretHash, Fr, type AztecNode } from '@aztec/aztec.js';
+import { computeL2ToL1MembershipWitness } from '@aztec/stdlib/messaging';
+import { sha256ToField } from '@aztec/foundation/crypto';
+import { computeL2ToL1MessageHash } from '@aztec/stdlib/hash';
+import { TestWallet } from '@aztec/test-wallet/server';
+import { getInitialTestAccountsData } from '@aztec/accounts/testing';
+import SimpleNFT from '../artifacts/contracts/SimpleNFT.sol/SimpleNFT.json';
+import NFTPortal from '../artifacts/contracts/NFTPortal.sol/NFTPortal.json';
+import { NFTPunkContract } from '../contracts/aztec/artifacts/NFTPunk.js';
+import { NFTBridgeContract } from '../contracts/aztec/artifacts/NFTBridge.js';
+
+    // Setup L1 clients using anvil's 1st account which should have a ton of ETH already
+    const l1Account = privateKeyToAccount("0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80");
+    const publicClient = createPublicClient({
+        chain: foundry,
+        transport: http('http://localhost:8545'),
+    });
+    const ethWallet = createWalletClient({
+        account: l1Account,
+        chain: foundry,
+        transport: http('http://localhost:8545'),
+    });
+
+    // Setup L2 using Aztec's sandbox and one of its initial accounts
+    console.log('🔮 Setting up L2...\n');
+    const node = createAztecNodeClient("http://localhost:8080");
+    const aztecWallet = await TestWallet.create(node);
+    const [accData] = await getInitialTestAccountsData();
+    const account = await aztecWallet.createSchnorrAccount(accData.secret, accData.salt);
+    console.log(`✅ Account: ${account.address.toString()}\n`);
+
+    // Get node info
+    const nodeInfo = await node.getNodeInfo();
+    const registryAddress = nodeInfo.l1ContractAddresses.registryAddress.toString();
+    const inboxAddress = nodeInfo.l1ContractAddresses.inboxAddress.toString();
+    // docs:end:setup
+
+    // docs:start:deploy_l1_contracts
+    console.log('📦 Deploying L1 contracts...\n');
+
+    const nftDeploymentHash = await ethWallet.deployContract({
+        abi: SimpleNFT.abi,
+        bytecode: SimpleNFT.bytecode as `0x${string}`,
+    });
+    const nftReceipt = await publicClient.waitForTransactionReceipt({ hash: nftDeploymentHash });
+    const nftAddress = nftReceipt.contractAddress!;
+
+    const portalDeploymentHash = await ethWallet.deployContract({
+        abi: NFTPortal.abi,
+        bytecode: NFTPortal.bytecode as `0x${string}`,
+    });
+    const portalReceipt = await publicClient.waitForTransactionReceipt({ hash: portalDeploymentHash });
+    const portalAddress = portalReceipt.contractAddress!;
+
+    console.log(`✅ SimpleNFT: ${nftAddress}`);
+    console.log(`✅ NFTPortal: ${portalAddress}\n`);
+    // docs:end:deploy_l1_contracts
+
+    // docs:start:deploy_l2_contracts
+    console.log('📦 Deploying L2 contracts...\n');
+
+    const l2Nft = await NFTPunkContract.deploy(aztecWallet, account.address)
+        .send({ from: account.address })
+        .deployed();
+
+    const l2Bridge = await NFTBridgeContract.deploy(aztecWallet, l2Nft.address)
+        .send({ from: account.address })
+        .deployed();
+
+    console.log(`✅ L2 NFT: ${l2Nft.address.toString()}`);
+    console.log(`✅ L2 Bridge: ${l2Bridge.address.toString()}\n`);
+    // docs:end:deploy_l2_contracts
+
+    // docs:start:initialize_portal
+    console.log('🔧 Initializing portal...');
+
+    const hash = await ethWallet.writeContract({
+        address: portalAddress as `0x${string}`,
+        abi: NFTPortal.abi,
+        functionName: 'initialize',
+        args: [
+            registryAddress as `0x${string}`,
+            nftAddress as `0x${string}`,
+            l2Bridge.address.toString() as `0x${string}`
+        ],
+    });
+    await publicClient.waitForTransactionReceipt({ hash });
+
+    console.log('✅ Portal initialized\n');
+    // docs:end:initialize_portal
+
+    // docs:start:initialize_l2_bridge
+    console.log('🔧 Setting up L2 bridge...');
+
+    await l2Bridge.methods.set_portal(EthAddress.fromString(portalAddress))
+        .send({ from: account.address })
+        .wait();
+
+    await l2Nft.methods.set_minter(l2Bridge.address)
+        .send({ from: account.address })
+        .wait();
+
+    console.log('✅ Bridge configured\n');
+    // docs:end:initialize_l2_bridge
+
+    // docs:start:mint_nft_l1
+    console.log('🎨 Minting NFT on L1...');
+
+    const mintHash = await ethWallet.writeContract({
+        address: nftAddress as `0x${string}`,
+        abi: SimpleNFT.abi,
+        functionName: 'mint',
+        args: [l1Account.address],
+    });
+    await publicClient.waitForTransactionReceipt({ hash: mintHash });
+
+    // no need to parse logs, this will be tokenId 0 since it's a fresh contract
+    const tokenId = 0n;
+
+    console.log(`✅ Minted tokenId: ${tokenId}\n`);
+    // docs:end:mint_nft_l1
+
+    // docs:start:deposit_to_aztec
+    console.log('🌉 Depositing NFT to Aztec...');
+
+    const secret = Fr.random();
+    const secretHash = await computeSecretHash(secret);
+
+    const approveHash = await ethWallet.writeContract({
+        address: nftAddress as `0x${string}`,
+        abi: SimpleNFT.abi,
+        functionName: 'approve',
+        args: [portalAddress as `0x${string}`, tokenId],
+    });
+    await publicClient.waitForTransactionReceipt({ hash: approveHash });
+
+    const depositHash = await ethWallet.writeContract({
+        address: portalAddress as `0x${string}`,
+        abi: NFTPortal.abi,
+        functionName: 'depositToAztec',
+        args: [tokenId, pad(secretHash.toString() as `0x${string}`, { dir: 'left', size: 32 })],
+    });
+    const depositReceipt = await publicClient.waitForTransactionReceipt({ hash: depositHash });
+    // docs:end:deposit_to_aztec
+
+    // docs:start:get_message_leaf_index
+    const INBOX_ABI = [{
+        type: 'event',
+        name: 'MessageSent',
+        inputs: [
+            { name: 'l2BlockNumber', type: 'uint256', indexed: true },
+            { name: 'index', type: 'uint256', indexed: false },
+            { name: 'hash', type: 'bytes32', indexed: true },
+            { name: 'rollingHash', type: 'bytes16', indexed: false }
+        ]
+    }] as const;
+    const messageSentTopic = toEventHash(INBOX_ABI[0]);
+    const messageSentLog = depositReceipt.logs!.find(
+        (log: any) => log.address.toLowerCase() === inboxAddress.toLowerCase() &&
+               log.topics[0] === messageSentTopic
+    );
+
+    const indexHex = messageSentLog!.data!.slice(0, 66);
+    const messageLeafIndex = new Fr(BigInt(indexHex));
+    // docs:end:get_message_leaf_index
+
+
+    // docs:start:mine_blocks
+    async function mine2Blocks(aztecWallet: TestWallet, accountAddress: any) {
+        await NFTPunkContract.deploy(aztecWallet, accountAddress)
+            .send({ from: accountAddress, contractAddressSalt: Fr.random() })
+            .deployed();
+        await NFTPunkContract.deploy(aztecWallet, accountAddress)
+            .send({ from: accountAddress, contractAddressSalt: Fr.random() })
+            .deployed();
+    }
+    // docs:end:mine_blocks
+
+    // docs:start:claim_on_l2
+    // Mine blocks
+    await mine2Blocks(aztecWallet, account.address);
+
+    // Check notes before claiming (should be 0)
+    console.log('📝 Checking notes before claim...');
+    const notesBefore = await l2Nft.methods.notes_of(account.address).simulate({ from: account.address });
+    console.log(`   Notes count: ${notesBefore}`);
+
+    console.log('🎯 Claiming NFT on L2...');
+    await l2Bridge.methods.claim(
+        account.address,
+        new Fr(Number(tokenId)),
+        secret,
+        messageLeafIndex
+    )
+        .send({ from: account.address })
+        .wait();
+    console.log('✅ NFT claimed on L2\n');
+
+    // Check notes after claiming (should be 1)
+    console.log('📝 Checking notes after claim...');
+    const notesAfterClaim = await l2Nft.methods.notes_of(account.address).simulate({ from: account.address });
+    console.log(`   Notes count: ${notesAfterClaim}\n`);
+    // docs:end:claim_on_l2
+
+    // docs:start:exit_from_l2
+    // L2 → L1 flow
+    console.log('🚪 Exiting NFT from L2...');
+    // Mine blocks
+    await mine2Blocks(aztecWallet, account.address);
+
+    const recipientEthAddress = EthAddress.fromString(l1Account.address);
+
+    const exitReceipt = await l2Bridge.methods.exit(
+        new Fr(Number(tokenId)),
+        recipientEthAddress
+    )
+        .send({ from: account.address })
+        .wait();
+
+    console.log(`✅ Exit message sent (block: ${exitReceipt.blockNumber})\n`);
+
+    // Check notes after burning (should be 0 again)
+    console.log('📝 Checking notes after burn...');
+    const notesAfterBurn = await l2Nft.methods.notes_of(account.address).simulate({ from: account.address });
+    console.log(`   Notes count: ${notesAfterBurn}\n`);
+    // docs:end:exit_from_l2
+
+    // docs:start:get_withdrawal_witness
+    // Compute the message hash directly from known parameters
+    // This matches what the portal contract expects: Hash.sha256ToField(abi.encodePacked(tokenId, recipient))
+    const tokenIdBuffer = new Fr(Number(tokenId)).toBuffer();
+    const recipientBuffer = Buffer.from(recipientEthAddress.toString().slice(2), 'hex');
+    const content = sha256ToField([Buffer.concat([tokenIdBuffer, recipientBuffer])]);
+
+    // Get rollup version from the portal contract (it stores it during initialize)
+    const version = await publicClient.readContract({
+        address: portalAddress as `0x${string}`,
+        abi: NFTPortal.abi,
+        functionName: 'rollupVersion'
+    });
+
+    // Compute the L2→L1 message hash
+    const msgLeaf = computeL2ToL1MessageHash({
+        l2Sender: l2Bridge.address,
+        l1Recipient: EthAddress.fromString(portalAddress),
+        content,
+        rollupVersion: new Fr(version),
+        chainId: new Fr(foundry.id),
+    });
+
+    // Compute the membership witness using the message hash
+    const witness = await computeL2ToL1MembershipWitness(node, exitReceipt.blockNumber!, msgLeaf);
+    const siblingPathHex = witness!.siblingPath.toBufferArray().map((buf: Buffer) =>
+        `0x${buf.toString('hex')}` as `0x${string}`
+    );
+    // docs:end:get_withdrawal_witness
+
+    // docs:start:withdraw_on_l1
+    console.log('💰 Withdrawing NFT on L1...');
+    const withdrawHash = await ethWallet.writeContract({
+        address: portalAddress as `0x${string}`,
+        abi: NFTPortal.abi,
+        functionName: 'withdraw',
+        args: [
+            tokenId,
+            BigInt(exitReceipt.blockNumber!),
+            BigInt(witness!.leafIndex),
+            siblingPathHex,
+        ],
+    });
+    await publicClient.waitForTransactionReceipt({ hash: withdrawHash });
+    console.log('✅ NFT withdrawn to L1\n');
+    // docs:end:withdraw_on_l1
+
+


### PR DESCRIPTION
# Bridge Your NFT to Aztec: A Private NFT Bridge Tutorial

This PR completely revamps the token bridge tutorial to focus on NFTs with privacy at the core. The new tutorial guides developers through building a complete private NFT bridge between Ethereum and Aztec.

## Key improvements:

- Creates a more engaging narrative around bridging CryptoPunks with private ownership
- Builds a complete end-to-end solution with 4 contracts (2 on L1, 2 on L2)
- Introduces privacy concepts like `PrivateSet` and custom notes for encrypted ownership
- Provides detailed explanations of cross-chain messaging between L1 and L2
- Includes complete code examples with step-by-step instructions

The tutorial now follows a more logical flow:
1. Building the L2 NFT contract with private ownership
2. Creating the L2 bridge contract for claiming messages
3. Implementing the L1 contracts (NFT and portal)
4. Deploying and testing the full bridging flow

This approach gives developers a deeper understanding of Aztec's privacy features while building something practical and useful.