### PR TITLE
chore: fast playground build feat. claude

### DIFF
--- a/playground/package.json
+++ b/playground/package.json
@@ -58,7 +58,6 @@
     "typescript": "~5.7.3",
     "typescript-eslint": "^8.11.0",
     "vite": "^7.1.4",
-    "vite-plugin-bundlesize": "^0.3.0",
     "vite-plugin-node-polyfills": "^0.24.0",
     "vite-plugin-static-copy": "^3.1.2"
   }

--- a/playground/yarn.lock
+++ b/playground/yarn.lock
@@ -102,7 +102,6 @@ __metadata:
     typescript: "npm:~5.7.3"
     typescript-eslint: "npm:^8.11.0"
     vite: "npm:^7.1.4"
-    vite-plugin-bundlesize: "npm:^0.3.0"
     vite-plugin-node-polyfills: "npm:^0.24.0"
     vite-plugin-static-copy: "npm:^3.1.2"
   languageName: unknown
@@ -5708,7 +5707,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"strip-ansi@npm:^7.0.1, strip-ansi@npm:^7.1.0":
+"strip-ansi@npm:^7.0.1":
   version: 7.1.0
   resolution: "strip-ansi@npm:7.1.0"
   dependencies:
@@ -6045,21 +6044,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vite-plugin-bundlesize@npm:^0.3.0":
-  version: 0.3.0
-  resolution: "vite-plugin-bundlesize@npm:0.3.0"
-  dependencies:
-    picomatch: "npm:^4.0.3"
-    strip-ansi: "npm:^7.1.0"
-    vlq: "npm:^2.0.4"
-  peerDependencies:
-    vite: ">= 6.0.0"
-  bin:
-    bundlesize: bin/cli.js
-  checksum: 10c0/2c81c710715c86cc6dc0ff71339ff1a0f233e0f6cada71849e2bd7c66cdb2caca0d393d6f67726496fd8aebf62681a41287de72223ce0b1e8061d2e53e6ef8da
-  languageName: node
-  linkType: hard
-
 "vite-plugin-node-polyfills@npm:^0.24.0":
   version: 0.24.0
   resolution: "vite-plugin-node-polyfills@npm:0.24.0"
@@ -6139,13 +6123,6 @@ __metadata:
   bin:
     vite: bin/vite.js
   checksum: 10c0/dbe2ba29926ffe8985c93d1b3718dcc9040080b7fa10a74c82a52aad7449136a391ba17b265288ff03b864e6f1033b9b537247521a96d5491a9d4af90ac04702
-  languageName: node
-  linkType: hard
-
-"vlq@npm:^2.0.4":
-  version: 2.0.4
-  resolution: "vlq@npm:2.0.4"
-  checksum: 10c0/7b4b14a724ad21a71a5ea8aabc08e7b766271cbf61b51b5a861c6f8c917446d7b10956ceaa95f6ce21cd80f12468875fc42287d3b7b1a40e627c116400ce663e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
The plugin we used to analyze bundle sizes was unnecessarily slow. After isolating the problem, tasked Claude with building a lightweight plugin that just reads the build output and enforcers the limits based on regexp. Works like a charm.

Build went from ~180s to 35.