### PR TITLE
chore(slack): notify alpha team about merge-train/spartan

### DIFF
--- a/ci3/merge_train_failure_slack_notify
+++ b/ci3/merge_train_failure_slack_notify
@@ -11,6 +11,8 @@ elif [[ "$REF_NAME" == "merge-train/avm" ]]; then
   channel="#team-bonobos"
 elif [[ "$REF_NAME" == "merge-train/docs" ]]; then
   channel="#dev-rels"
+elif [[ "$REF_NAME" == "merge-train/spartan" ]]; then
+  channel="#team-alpha"
 else
   exit 0
 fi


### PR DESCRIPTION
This is the only piece that needs to be turned on for alpha team to start using the merge-train.