### PR TITLE
fix(ci/benchmarks): use git tree hash for benchmarks

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -314,7 +314,7 @@ function bench {
   rm -rf bench-out
   mkdir -p bench-out
   bench_merge
-  cache_upload bench-$COMMIT_HASH.tar.gz bench-out/bench.json
+  cache_upload bench-$(git rev-parse HEAD^{tree}).tar.gz bench-out/bench.json
 }
 
 function release_github {

--- a/ci.sh
+++ b/ci.sh
@@ -321,7 +321,7 @@ case "$cmd" in
     print_usage
     ;;
   "gh-bench")
-    cache_download bench-$COMMIT_HASH.tar.gz
+    cache_download bench-$(git rev-parse HEAD^{tree}).tar.gz
     ;;
   "uncached-tests")
     if [ -z "$CI_REDIS_AVAILABLE" ]; then

--- a/yarn-project/p2p/bootstrap.sh
+++ b/yarn-project/p2p/bootstrap.sh
@@ -14,8 +14,6 @@ function bench {
     ./testbench/run_testbench.sh $config ./bench-out/$config
   done
   ./testbench/consolidate_benchmarks.sh
-
-  cache_upload yarn-project-p2p-bench-results-$COMMIT_HASH.tar.gz ./bench-out/p2p-bench.json
 }
 
 case "$cmd" in


### PR DESCRIPTION
Replace commit hash with git tree hash when handing over benchmark results to GitHub Actions. This resolves caching issues where the exact commit hash may not have been run in the cache, ensuring consistent benchmark result lookup across cached and non-cached runs. This affected `ci-full` runs that were squashed.