### PR TITLE
chore: Set variable can only be used when writing vks

### DIFF
--- a/barretenberg/cpp/src/barretenberg/multilinear_batching/multilinear_batching_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/multilinear_batching/multilinear_batching_verifier.cpp
@@ -66,8 +66,6 @@ std::pair<bool, typename MultilinearBatchingVerifier<Flavor_>::VerifierClaim> Mu
     // commitments and accumulator commitment
     verifier_claim.non_shifted_commitment =
         non_shifted_accumulator_commitment + non_shifted_instance_commitment * claim_batching_challenge;
-    // TODO(https://github.com/AztecProtocol/barretenberg/issues/1558): perform a single MSM to batch incoming instance
-    // commitments and accumulator commitment
     verifier_claim.shifted_commitment =
         shifted_accumulator_commitment + shifted_instance_commitment * claim_batching_challenge;
     verifier_claim.shifted_evaluation =

--- a/barretenberg/cpp/src/barretenberg/multilinear_batching/multilinear_batching_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/multilinear_batching/multilinear_batching_verifier.cpp
@@ -62,8 +62,12 @@ std::pair<bool, typename MultilinearBatchingVerifier<Flavor_>::VerifierClaim> Mu
     // Construct new claim
     auto claim_batching_challenge = transcript->template get_challenge<FF>("claim_batching_challenge");
     VerifierClaim verifier_claim;
+    // TODO(https://github.com/AztecProtocol/barretenberg/issues/1558): perform a single MSM to batch incoming instance
+    // commitments and accumulator commitment
     verifier_claim.non_shifted_commitment =
         non_shifted_accumulator_commitment + non_shifted_instance_commitment * claim_batching_challenge;
+    // TODO(https://github.com/AztecProtocol/barretenberg/issues/1558): perform a single MSM to batch incoming instance
+    // commitments and accumulator commitment
     verifier_claim.shifted_commitment =
         shifted_accumulator_commitment + shifted_instance_commitment * claim_batching_challenge;
     verifier_claim.shifted_evaluation =

--- a/barretenberg/cpp/src/barretenberg/stdlib/hash/sha256/sha256.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/hash/sha256/sha256.test.cpp
@@ -436,6 +436,8 @@ TEST(stdlib_sha256, test_input_str_len_multiple)
 
 TEST(stdlib_sha256, test_boomerang_value_regression)
 {
+    BB_DISABLE_ASSERTS(); // Disable assert to allow set_variable
+
     auto builder = Builder();
     std::array<field_t<Builder>, 16> input;
 

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/circuit_builder_base.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/circuit_builder_base.hpp
@@ -141,6 +141,7 @@ template <typename FF_> class CircuitBuilderBase {
     inline void set_variable(const uint32_t index, const FF& value)
     {
         BB_ASSERT_DEBUG(variables.size() > real_variable_index[index]);
+        BB_ASSERT(has_dummy_witnesses());
         variables[real_variable_index[index]] = value;
     }
 


### PR DESCRIPTION
To prevent misuse of `builder.set_variable()`, the function checks that the builder was constructed with empty witnesses, which means we are either in a `write_vk` scenario, and thus we need to set variables to construct the vk, or in a test with `BB_DISABLE_ASSERTS`