### PR TITLE
refactor!: introducing `#[external(...)]` macro

### DIFF
--- a/boxes/boxes/react/src/contracts/src/main.nr
+++ b/boxes/boxes/react/src/contracts/src/main.nr
@@ -4,7 +4,7 @@ use aztec::macros::aztec;
 contract BoxReact {
     use aztec::{
         messages::message_delivery::MessageDelivery,
-        macros::{functions::{initializer, private, utility}, storage::storage},
+        macros::{functions::{external, initializer}, storage::storage},
         protocol_types::address::AztecAddress,
         state_vars::{Map, PrivateMutable},
     };
@@ -15,7 +15,7 @@ contract BoxReact {
         numbers: Map<AztecAddress, PrivateMutable<ValueNote, Context>, Context>,
     }
 
-    #[private]
+    #[external("private")]
     #[initializer]
     fn constructor(number: Field, owner: AztecAddress) {
         let numbers = storage.numbers;
@@ -28,7 +28,7 @@ contract BoxReact {
         );
     }
 
-    #[private]
+    #[external("private")]
     fn setNumber(number: Field, owner: AztecAddress) {
         let numbers = storage.numbers;
 
@@ -44,7 +44,7 @@ contract BoxReact {
     }
 
 
-    #[utility]
+    #[external("utility")]
     unconstrained fn getNumber(owner: AztecAddress) -> ValueNote {
         let numbers = storage.numbers;
         numbers.at(owner).view_note()

--- a/boxes/boxes/vanilla/contracts/src/main.nr
+++ b/boxes/boxes/vanilla/contracts/src/main.nr
@@ -12,7 +12,7 @@ use dep::aztec::macros::aztec;
 pub contract PrivateVoting {
     use dep::aztec::keys::getters::get_public_keys;
     use dep::aztec::macros::{
-        functions::{initializer, internal, private, public, utility},
+        functions::{external, initializer, internal},
         storage::storage,
     };
     use dep::aztec::state_vars::{Map, PublicImmutable, PublicMutable};
@@ -26,7 +26,7 @@ pub contract PrivateVoting {
         active_at_block: PublicImmutable<u32, Context>, // when people can start voting
     }
 
-    #[public]
+    #[external("public")]
     #[initializer]
     fn constructor(admin: AztecAddress) {
         storage.admin.write(admin);
@@ -34,7 +34,7 @@ pub contract PrivateVoting {
         storage.active_at_block.initialize(context.block_number());
     }
 
-    #[private]
+    #[external("private")]
     fn cast_vote(candidate: Field) {
         let msg_sender_npk_m_hash = get_public_keys(context.msg_sender().unwrap()).npk_m.hash();
 
@@ -46,7 +46,7 @@ pub contract PrivateVoting {
         );
     }
 
-    #[public]
+    #[external("public")]
     #[internal]
     fn add_to_tally_public(candidate: Field) {
         assert(storage.vote_ended.read() == false, "Vote has ended"); // assert that vote has not ended
@@ -54,13 +54,13 @@ pub contract PrivateVoting {
         storage.tally.at(candidate).write(new_tally);
     }
 
-    #[public]
+    #[external("public")]
     fn end_vote() {
         assert(storage.admin.read().eq(context.msg_sender().unwrap()), "Only admin can end votes"); // assert that caller is admin
         storage.vote_ended.write(true);
     }
 
-    #[utility]
+    #[external("utility")]
     unconstrained fn get_vote(candidate: Field) -> Field {
         storage.tally.at(candidate).read()
     }

--- a/boxes/boxes/vite/src/contracts/src/main.nr
+++ b/boxes/boxes/vite/src/contracts/src/main.nr
@@ -4,7 +4,7 @@ use aztec::macros::aztec;
 contract BoxReact {
     use aztec::{
         messages::message_delivery::MessageDelivery,
-        macros::{functions::{initializer, private, utility}, storage::storage},
+        macros::{functions::{external, initializer}, storage::storage},
         protocol_types::address::AztecAddress,
         state_vars::{Map, PrivateMutable},
     };
@@ -15,7 +15,7 @@ contract BoxReact {
         numbers: Map<AztecAddress, PrivateMutable<ValueNote, Context>, Context>,
     }
 
-    #[private]
+    #[external("private")]
     #[initializer]
     fn constructor(number: Field, owner: AztecAddress) {
         let numbers = storage.numbers;
@@ -28,7 +28,7 @@ contract BoxReact {
         );
     }
 
-    #[private]
+    #[external("private")]
     fn setNumber(number: Field, owner: AztecAddress) {
         let numbers = storage.numbers;
 
@@ -43,7 +43,7 @@ contract BoxReact {
         );
     }
 
-    #[utility]
+    #[external("utility")]
     unconstrained fn getNumber(owner: AztecAddress) -> ValueNote {
         let numbers = storage.numbers;
         numbers.at(owner).view_note()

--- a/boxes/init/src/main.nr
+++ b/boxes/init/src/main.nr
@@ -3,7 +3,7 @@ use dep::aztec::macros::aztec;
 
 #[aztec]
 contract Main {
-    #[private]
+    #[external("private")]
     #[initializer]
     fn constructor() { }
 }

--- a/docs/docs/developers/docs/concepts/call_types.md
+++ b/docs/docs/developers/docs/concepts/call_types.md
@@ -97,7 +97,7 @@ While Ethereum contracts are defined by bytecode that runs on the EVM, Aztec con
 
 ### Private Execution
 
-Contract functions marked with `#[private]` can only be called privately, and as such 'run' in the user's device. Since they're circuits, their 'execution' is actually the generation of a zk-SNARK proof that'll later be sent to the sequencer for verification.
+Contract functions marked with `#[external("private")]` can only be called privately, and as such 'run' in the user's device. Since they're circuits, their 'execution' is actually the generation of a zk-SNARK proof that'll later be sent to the sequencer for verification.
 
 #### Private Calls
 
@@ -153,7 +153,7 @@ For this reason it is encouraged to try to avoid public function calls and inste
 
 ### Public Execution
 
-Contract functions marked with `#[public]` can only be called publicly, and are executed by the sequencer. The computation model is very similar to the EVM: all state, parameters, etc. are known to the entire network, and no data is private. Static execution like the EVM's `STATICCALL` is possible too, with similar semantics (state can be accessed but not modified, etc.).
+Contract functions marked with `#[external("public")]` can only be called publicly, and are executed by the sequencer. The computation model is very similar to the EVM: all state, parameters, etc. are known to the entire network, and no data is private. Static execution like the EVM's `STATICCALL` is possible too, with similar semantics (state can be accessed but not modified, etc.).
 
 Since private calls are always run in a user's device, it is not possible to perform any private execution from a public context. A reasonably good mental model for public execution is that of an EVM in which some work has already been done privately, and all that is know about it is its correctness and side-effects (new notes and nullifiers, enqueued public calls, etc.). A reverted public execution will also revert the private side-effects.
 
@@ -167,7 +167,7 @@ This is the same function that was called by privately enqueuing a call to it! P
 
 ### Utility
 
-Contract functions marked with `#[utility]` cannot be called as part of a transaction, and are only invoked by applications that interact with contracts to perform state queries from an offchain client (from both private and public state!) or to modify local contract-related PXE state (e.g. when processing logs in Aztec.nr). No guarantees are made on the correctness of the result since the entire execution is unconstrained and heavily reliant on oracle calls. It is possible however to verify that the bytecode being executed is the correct one, since a contract's address includes a commitment to all of its utility functions.
+Contract functions marked with `#[external("utility")]` cannot be called as part of a transaction, and are only invoked by applications that interact with contracts to perform state queries from an offchain client (from both private and public state!) or to modify local contract-related PXE state (e.g. when processing logs in Aztec.nr). No guarantees are made on the correctness of the result since the entire execution is unconstrained and heavily reliant on oracle calls. It is possible however to verify that the bytecode being executed is the correct one, since a contract's address includes a commitment to all of its utility functions.
 
 ### aztec.js
 

--- a/docs/docs/developers/docs/concepts/smart_contracts/contract_upgrades.md
+++ b/docs/docs/developers/docs/concepts/smart_contracts/contract_upgrades.md
@@ -32,7 +32,7 @@ Contract upgrades in Aztec have to be initiated by the contract that wishes to b
 use dep::aztec::protocol_types::contract_class_id::ContractClassId;
 use contract_instance_registry::ContractInstanceRegistry;
 
-#[private]
+#[external("private")]
 fn update_to(new_class_id: ContractClassId) {
     ContractInstanceRegistry::at(CONTRACT_INSTANCE_REGISTRY_CONTRACT_ADDRESS)
         .update(new_class_id)
@@ -43,7 +43,7 @@ fn update_to(new_class_id: ContractClassId) {
 The `update` function in the registry is a public function, so you can enqueue it from a private function like the example or call it from a public function directly.
 
 :::note
-Recall that `#[private]` means calling this function preserves privacy, and it still CAN be called externally by anyone.
+Recall that `#[external("private")]` means calling this function preserves privacy, and it still CAN be called externally by anyone.
 So the `update_to` function above allows anyone to update the contract that implements it. A more complete implementation should have a proper authorization systems to secure contracts from malicious upgrades.
 :::
 
@@ -54,7 +54,7 @@ This means that they have a delay before entering into effect. The default delay
 use dep::aztec::protocol_types::contract_class_id::ContractClassId;
 use contract_instance_registry::ContractInstanceRegistry;
 
-#[private]
+#[external("private")]
 fn set_update_delay(new_delay: u64) {
    ContractInstanceRegistry::at(CONTRACT_INSTANCE_REGISTRY_CONTRACT_ADDRESS)
       .set_update_delay(new_delay)
@@ -107,7 +107,7 @@ Consider this contract as an example:
 contract Updatable {
 ...
 
-    #[private]
+    #[external("private")]
     fn update_to(new_class_id: ContractClassId) {
         ContractInstanceRegistry::at(CONTRACT_INSTANCE_REGISTRY_CONTRACT_ADDRESS).update(new_class_id).enqueue(
             &mut context,
@@ -164,7 +164,7 @@ await RandomContract.at(address, wallet);
 
 ```rust
 contract Updatable {
-    #[private]
+    #[external("private")]
     fn update_to(new_class_id: ContractClassId) {
         // TODO: Add access control
         assert(context.msg_sender() == owner, "Unauthorized");
@@ -175,7 +175,7 @@ contract Updatable {
             .enqueue(&mut context);
     }
 
-    #[private]
+    #[external("private")]
     fn set_update_delay(new_delay: u64) {
         // TODO: Add access control
         ContractInstanceRegistry::at(CONTRACT_INSTANCE_REGISTRY_CONTRACT_ADDRESS)

--- a/docs/docs/developers/docs/concepts/smart_contracts/functions/attributes.md
+++ b/docs/docs/developers/docs/concepts/smart_contracts/functions/attributes.md
@@ -9,11 +9,17 @@ On this page you will learn about function attributes and macros.
 
 If you are looking for a reference of function macros, go [here](../../../reference/smart_contract_reference/macros.md).
 
-## Private functions #[private]
+# External functions #[external("...")]
 
-A private function operates on private information, and is executed by the user on their device. Annotate the function with the `#[private]` attribute to tell the compiler it's a private function. This will make the [private context](./context.md#the-private-context) available within the function's execution scope. The compiler will create a circuit to define this function.
+Like in Solidity, external functions can be called from outside the contract.
+There are 3 types of external functions differing in the execution environment they are executed in: private, public, and utility.
+We will describe each type in the following sections.
 
-`#[private]` is just syntactic sugar. At compile time, the Aztec.nr framework inserts code that allows the function to interact with the [kernel](../../advanced/circuits/kernels/private_kernel.md).
+## Private functions #[external("private")]
+
+A private function operates on private information, and is executed by the user on their device. Annotate the function with the `#[external("private")]` attribute to tell the compiler it's a private function. This will make the [private context](./context.md#the-private-context) available within the function's execution scope. The compiler will create a circuit to define this function.
+
+`#[external("private")]` is just syntactic sugar. At compile time, the Aztec.nr framework inserts code that allows the function to interact with the [kernel](../../advanced/circuits/kernels/private_kernel.md).
 
 To help illustrate how this interacts with the internals of Aztec and its kernel circuits, we can take an example private function, and explore what it looks like after Aztec.nr's macro expansion.
 
@@ -76,9 +82,9 @@ Any state variables declared in the `Storage` struct can now be accessed as norm
 
 This function takes the application context, and converts it into the `PrivateCircuitPublicInputs` structure. This structure is then passed to the kernel circuit.
 
-## Utility functions #[utility]
+## Utility functions #[external("utility")]
 
-Contract functions marked with `#[utility]` are used to perform state queries from an offchain client (from both private and public state!) or to modify local contract-related PXE state (e.g. when processing logs in Aztec.nr), and are never included in any transaction. No guarantees are made on the correctness of the result since the entire execution is unconstrained and heavily reliant on [oracle calls](https://noir-lang.org/docs/explainers/explainer-oracle).
+Contract functions marked with `#[external("utility")]` are used to perform state queries from an offchain client (from both private and public state!) or to modify local contract-related PXE state (e.g. when processing logs in Aztec.nr), and are never included in any transaction. No guarantees are made on the correctness of the result since the entire execution is unconstrained and heavily reliant on [oracle calls](https://noir-lang.org/docs/explainers/explainer-oracle).
 
 Any programming language could be used to construct these queries, since all they do is perform arbitrary computation on data that is either publicly available from any node, or locally available from the PXE. Utility functions exist as Noir contract code because they let developers utilize the rest of the contract code directly by being part of the same Noir crate, and e.g. use the same libraries, structs, etc. instead of having to rely on manual computation of storage slots, struct layout and padding, and so on.
 
@@ -110,7 +116,7 @@ Beyond using them inside your other functions, they are convenient for providing
 Note, that utility functions can have access to both private and (historical) public data when executed on the user's device. This is possible since these functions are not invoked as part of transactions, so we don't need to worry about preventing a contract from e.g. accidentally using stale or unverified public state.
 :::
 
-## Public functions #[public]
+## Public functions #[external("public")]
 
 A public function is executed by the sequencer and has access to a state model that is very similar to that of the EVM and Ethereum. Even though they work in an EVM-like model for public transactions, they are able to write data into private storage that can be consumed later by a private function.
 
@@ -118,7 +124,7 @@ A public function is executed by the sequencer and has access to a state model t
 All data inserted into private storage from a public function will be publicly viewable (not private).
 :::
 
-To create a public function you can annotate it with the `#[public]` attribute. This will make the public context available within the function's execution scope.
+To create a public function you can annotate it with the `#[external("public")]` attribute. This will make the public context available within the function's execution scope.
 
 #include_code set_minter /noir-projects/noir-contracts/contracts/app/token_contract/src/main.nr rust
 
@@ -144,7 +150,7 @@ let storage = Storage::init(&mut context);
 
 ## Constrained `view` Functions #[view]
 
-The `#[view]` attribute can be applied to a `#[private]` or a `#[public]` function and it guarantees that the function cannot modify any contract state (just like `view` functions in Solidity).
+The `#[view]` attribute can be applied to a `#[external("private")]` or a `#[external("public")]` function and it guarantees that the function cannot modify any contract state (just like `view` functions in Solidity).
 
 ## `Initializer` Functions #[initializer]
 

--- a/docs/docs/developers/docs/guides/smart_contracts/advanced/how_to_retrieve_filter_notes.md
+++ b/docs/docs/developers/docs/guides/smart_contracts/advanced/how_to_retrieve_filter_notes.md
@@ -37,8 +37,8 @@ let notes = storage.my_notes.at(owner).get_notes(options);
 // Assuming MyNote has an 'owner' field
 let mut options = NoteGetterOptions::new();
 options = options.select(
-    MyNote::properties().owner, 
-    Comparator.EQ, 
+    MyNote::properties().owner,
+    Comparator.EQ,
     owner
 );
 ```
@@ -84,7 +84,7 @@ fn filter_above_threshold(
 ) -> [Option<RetrievedNote<Note>>; MAX_NOTES] {
     let mut result = [Option::none(); MAX_NOTES];
     let mut count = 0;
-    
+
     for note in notes {
         if note.is_some() & (note.unwrap().note.value >= min) {
             result[count] = note;
@@ -140,7 +140,7 @@ contract.methods.read_notes(Comparator.GTE, 5).simulate({ from: defaultAddress }
 ```rust
 use dep::aztec::note::note_viewer_options::NoteViewerOptions;
 
-#[utility]
+#[external("utility")]
 unconstrained fn view_notes(comparator: u8, value: Field) -> auto {
     let mut options = NoteViewerOptions::new();
     options = options.select(MyNote::properties().value, comparator, value);

--- a/docs/docs/developers/docs/guides/smart_contracts/advanced/writing_efficient_contracts.md
+++ b/docs/docs/developers/docs/guides/smart_contracts/advanced/writing_efficient_contracts.md
@@ -97,12 +97,12 @@ For example:
 comptime global TWO_POW_32: Field = 2.pow_32(16);
 // ...
 {
-    #[private]
+    #[external("private")]
     fn mul_inefficient(number: Field) -> u128 {
         number as u128 << 16 as u8
     } // 5244 gates
 
-    #[private]
+    #[external("private")]
     fn mul_efficient(number: Field) -> u128 {
         (number * TWO_POW_32) as u128
     } // 5184 gates (60 gates less)
@@ -117,7 +117,7 @@ For example, use boolean equality effectively instead of `>=`:
 
 ```rust
 {
-    #[private]
+    #[external("private")]
     fn sum_from_inefficient(from: u32, array: [u32; 1000]) -> u32 {
         let mut sum: u32 = 0;
         for i in 0..1000 {
@@ -128,7 +128,7 @@ For example, use boolean equality effectively instead of `>=`:
         sum
     } // 44317 gates
 
-    #[private]
+    #[external("private")]
     fn sum_from_efficient(from: u32, array: [u32; 1000]) -> u32 {
         let mut sum: u32 = 0;
         let mut do_sum = false;
@@ -171,21 +171,21 @@ use dep::aztec::macros::aztec;
 
 #[aztec]
 pub contract OptimisationExample {
-    use dep::aztec::macros::{functions::{initializer, private, public, utility}, storage::storage};
+    use dep::aztec::macros::{functions::{external, initializer}, storage::storage};
 
     #[storage]
     struct Storage<Context> {}
 
-    #[public]
+    #[external("public")]
     #[initializer]
     fn constructor() {}
 
-    #[private]
+    #[external("private")]
     fn sqrt_inefficient(number: Field) -> Field {
         super::sqrt_constrained(number)
     }
 
-    #[private]
+    #[external("private")]
     fn sqrt_efficient(number: Field) -> Field {
         // Safety: calculate in unconstrained function, then constrain the result
         let x = unsafe { super::sqrt_unconstrained(number) };
@@ -242,7 +242,7 @@ Like with sqrt, we have the inefficient function that does the sort with constra
 ```rust
 //...
 {
-    #[private]
+    #[external("private")]
     fn sort_inefficient(array: [u32; super::ARRAY_SIZE]) -> [u32; super::ARRAY_SIZE] {
         let mut sorted_array = array;
         for i in 0..super::ARRAY_SIZE as u32 {
@@ -257,7 +257,7 @@ Like with sqrt, we have the inefficient function that does the sort with constra
         sorted_array
     } // 6823 gates for 10 elements, 127780 gates for 100 elements
 
-    #[private]
+    #[external("private")]
     fn sort_efficient(array: [u32; super::ARRAY_SIZE]) -> [u32; super::ARRAY_SIZE] {
         // Safety: calculate in unconstrained function, then constrain the result
         let sorted_array = unsafe { super::sort_array(array) };
@@ -290,7 +290,7 @@ Like before, the flamegraph command can be used to present the gate counts of th
 Note: The stdlib provides a highly optimized version of sort on arrays, `array.sort()`, which saves even more gates.
 
 ```rust
-    #[private]
+    #[external("private")]
     fn sort_stdlib(array: [u32; super::ARRAY_SIZE]) -> [u32; super::ARRAY_SIZE] {
         array.sort();
     } // 5943 gates (880 gates less) for 10 elements, 13308 gates for 100 elements (114472 gates less)
@@ -302,7 +302,7 @@ In the same vein, refactoring is inefficient when done constrained, and more eff
 
 ```rust
 {
-    #[private]
+    #[external("private")]
     fn refactor_inefficient(array: [u32; super::ARRAY_SIZE]) -> [u32; super::ARRAY_SIZE] {
         let mut compacted_array = [0; super::ARRAY_SIZE];
         let mut index = 0;
@@ -315,7 +315,7 @@ In the same vein, refactoring is inefficient when done constrained, and more eff
         compacted_array
     } // 6570 gates for 10 elements, 93071 gates for 100 elements
 
-    #[private]
+    #[external("private")]
     fn refactor_efficient(array: [u32; super::ARRAY_SIZE]) -> [u32; super::ARRAY_SIZE] {
         let compacted_array = unsafe { super::refactor_array(array) };
         // count non-zero elements in array

--- a/docs/docs/developers/docs/guides/smart_contracts/how_to_communicate_cross_chain.md
+++ b/docs/docs/developers/docs/guides/smart_contracts/how_to_communicate_cross_chain.md
@@ -58,7 +58,7 @@ To consume a message coming from L1, use the `consume_l1_to_l2_message` function
 - "Consuming" a message pushes a nullifier to prevent double-spending
 
 ```rust
-#[public]
+#[external("public")]
 fn consume_message_from_l1(
     secret: Field,
     message_leaf_index: Field,
@@ -86,7 +86,7 @@ fn consume_message_from_l1(
 Use `message_portal` in your `context` to send messages from L2 to L1:
 
 ```rust
-#[public]
+#[external("public")]
 fn send_message_to_l1(
     // your function parameters
 ) {

--- a/docs/docs/developers/docs/guides/smart_contracts/how_to_compile_contract.md
+++ b/docs/docs/developers/docs/guides/smart_contracts/how_to_compile_contract.md
@@ -64,7 +64,7 @@ Use generated interfaces instead of manual function calls:
 contract FPC {
     use dep::token::Token;
 
-    #[private]
+    #[external("private")]
     fn fee_entrypoint_private(amount: Field, asset: AztecAddress, secret_hash: Field, nonce: Field) {
         assert(asset == storage.other_asset.read());
         Token::at(asset).transfer_to_public(context.msg_sender(), context.this_address(), amount, nonce).call(&mut context);

--- a/docs/docs/developers/docs/guides/smart_contracts/how_to_define_functions.md
+++ b/docs/docs/developers/docs/guides/smart_contracts/how_to_define_functions.md
@@ -15,10 +15,10 @@ This guide shows you how to define different types of functions in your Aztec co
 
 ## Define private functions
 
-Create functions that execute privately on user devices using the `#[private]` annotation. For example:
+Create functions that execute privately on user devices using the `#[external("private")]` annotation. For example:
 
 ```rust
-#[private]
+#[external("private")]
 fn execute_private_action(param1: AztecAddress, param2: u128) {
     // logic
 }
@@ -28,10 +28,10 @@ Private functions maintain privacy of user inputs and execution logic. Private f
 
 ## Define public functions
 
-Create functions that execute on the sequencer using the `#[public]` annotation:
+Create functions that execute on the sequencer using the `#[external("public")]` annotation:
 
 ```rust
-#[public]
+#[external("public")]
 fn create_item(recipient: AztecAddress, item_id: Field) {
     // logic
 }
@@ -41,12 +41,12 @@ Public functions can access public state, similar to EVM contracts. Public funct
 
 ## Define utility functions
 
-Create offchain query functions using the `#[utility]` annotation.
+Create offchain query functions using the `#[external("utility")]` annotation.
 
 Utility functions are standalone unconstrained functions that cannot be called from private or public functions: they are meant to be called by _applications_ to perform auxiliary tasks: query contract state (e.g. a token balance), process messages received offchain, etc. Example:
 
 ```rust
-#[utility]
+#[external("utility")]
 unconstrained fn get_private_items(
     owner: AztecAddress,
     page_index: u32,
@@ -57,10 +57,10 @@ unconstrained fn get_private_items(
 
 ## Define view functions
 
-Create read-only functions using the `#[view]` annotation combined with `#[private]` or `#[public]`:
+Create read-only functions using the `#[view]` annotation combined with `#[external("private")]` or `#[external("public")]`:
 
 ```rust
-#[public]
+#[external("public")]
 #[view]
 fn get_config_value() -> Field {
     // logic
@@ -74,7 +74,7 @@ View functions cannot modify contract state. They're akin to Ethereum's `view` f
 Create contract-only functions using the `#[internal]` annotation:
 
 ```rust
-#[public]
+#[external("public")]
 #[internal]
 fn update_counter_public(item: Field) {
     // logic
@@ -88,7 +88,7 @@ Internal functions are only callable within the same contract.
 Create constructor-like functions using the `#[initializer]` annotation:
 
 ```rust
-#[private]
+#[external("private")]
 #[initializer]
 fn constructor() {
     // logic

--- a/docs/docs/developers/docs/guides/smart_contracts/how_to_define_storage.md
+++ b/docs/docs/developers/docs/guides/smart_contracts/how_to_define_storage.md
@@ -177,7 +177,7 @@ When this function is invoked, it creates a nullifier for the storage slot, ensu
 Set the value of an PrivateImmutable by calling the `initialize` method:
 
 ```rust
-#[private]
+#[external("private")]
 fn initialize_private_immutable(my_value: u8) {
     let new_note = MyNote::new(my_value, context.msg_sender());
 
@@ -207,7 +207,7 @@ Similar to the `PrivateMutable`, we can use the `get_note` method to read the va
 Use this method to retrieve the value of an initialized PrivateImmutable.
 
 ```rust
-#[private]
+#[external("private")]
 fn get_immutable_note() -> MyNote {
     storage.my_private_immutable.get_note()
 }
@@ -369,7 +369,7 @@ A `PublicImmutable`'s storage **must** only be set once via `initialize`. Attemp
 :::
 
 ```rust
-#[public]
+#[external("public")]
 fn initialize_public_immutable(my_value: u8) {
     let mut new_struct = MyStruct { account: context.msg_sender(), value: my_value };
     storage.my_public_immutable.initialize(new_struct);
@@ -381,7 +381,7 @@ fn initialize_public_immutable(my_value: u8) {
 Returns the stored immutable value. This function is available in public, private and utility contexts.
 
 ```rust
-#[utility]
+#[external("utility")]
 unconstrained fn get_public_immutable() -> MyStruct {
     storage.my_public_immutable.read()
 }
@@ -472,7 +472,7 @@ This is the means by which a `DelayedPublicMutable` variable mutates its content
 This function can only be called in public, typically after some access control check:
 
 ```rust
-#[public]
+#[external("public")]
 fn set_my_value(new_value: MyType) {
     assert_eq(storage.admin.read(), context.msg_sender(), "caller is not admin");
     storage.my_delayed_value.schedule_value_change(new_value);

--- a/docs/docs/developers/docs/guides/smart_contracts/how_to_implement_custom_notes.md
+++ b/docs/docs/developers/docs/guides/smart_contracts/how_to_implement_custom_notes.md
@@ -218,7 +218,7 @@ struct Storage<Context> {
 ### Creating and storing notes
 
 ```rust
-#[private]
+#[external("private")]
 fn create_note(owner: AztecAddress, value: Field, data: u32) {
     // Create the note
     let note = CustomNote::new(value, data, owner);
@@ -233,7 +233,7 @@ fn create_note(owner: AztecAddress, value: Field, data: u32) {
 ```rust
 use aztec::note::note_getter_options::NoteGetterOptions;
 
-#[private]
+#[external("private")]
 fn get_notes(owner: AztecAddress) -> BoundedVec<CustomNote, MAX_NOTES_PER_PAGE> {
     // Get all notes for the owner
     let notes = storage.private_notes.at(owner).get_notes(
@@ -243,7 +243,7 @@ fn get_notes(owner: AztecAddress) -> BoundedVec<CustomNote, MAX_NOTES_PER_PAGE> 
     notes
 }
 
-#[private]
+#[external("private")]
 fn find_note_by_value(owner: AztecAddress, target_value: Field) -> CustomNote {
     let options = NoteGetterOptions::new()
         .select(CustomNote::properties().value, target_value, Option::none())
@@ -261,7 +261,7 @@ fn find_note_by_value(owner: AztecAddress, target_value: Field) -> CustomNote {
 To transfer a custom note between users:
 
 ```rust
-#[private]
+#[external("private")]
 fn transfer_note(from: AztecAddress, to: AztecAddress, value: Field) {
     // Find and remove from sender (nullifies the old note)
     let note = find_note_by_value(from, value);
@@ -287,7 +287,7 @@ pub struct ProfileNote {
     randomness: Field,
 }
 
-#[private]
+#[external("private")]
 fn update_profile(new_data: Field) {
     let owner = context.msg_sender();
 

--- a/docs/docs/developers/docs/guides/smart_contracts/how_to_use_authwit.md
+++ b/docs/docs/developers/docs/guides/smart_contracts/how_to_use_authwit.md
@@ -38,7 +38,7 @@ Check if the current call is authenticated using the `authorize_once` macro:
 
 ```rust
 #[authorize_once("from", "authwit_nonce")]
-#[private]
+#[external("private")]
 fn execute_private_action(
     from: AztecAddress,
     to: AztecAddress,
@@ -62,7 +62,7 @@ Enable contracts to approve actions on their behalf by updating the public auth 
 This pattern is commonly used in bridge contracts (like the [uniswap example contract](https://github.com/AztecProtocol/aztec-packages/tree/next/noir-projects/noir-contracts/contracts/app/uniswap_contract)) where one contract needs to authorize another to perform actions on its behalf:
 
 ```rust
-#[public]
+#[external("public")]
 #[internal]
 fn _approve_and_execute_action(
     target_contract: AztecAddress,

--- a/docs/docs/developers/docs/reference/smart_contract_reference/macros.md
+++ b/docs/docs/developers/docs/reference/smart_contract_reference/macros.md
@@ -11,7 +11,7 @@ In addition to the function macros in Noir, Aztec also has its own macros for sp
 It is also worth mentioning Noir's `unconstrained` function type [here (Noir docs page)](https://noir-lang.org/docs/noir/concepts/unconstrained/).
 
 - `#[aztec]` - Defines a contract, placed above `contract ContractName{}`
-- `#[public]`, `#[private]` or `#[utility]` - Whether the function is to be executed from a public, private or utility context (see Further Reading)
+- `#[external("...")]` - Whether the function is to be callable from outside the contract. There are 3 types of external functions: `#[external("public")]`, `#[external("private")]` or `#[external("utility")]` - The type of external defines whether the function is to be executed from a public, private or utility context (see Further Reading)
 - `#[initializer]` - If one or more functions are marked as an initializer, then one of them must be called before any non-initializer functions
 - `#[noinitcheck]` - The function is able to be called before an initializer (if one exists)
 - `#[view]` - Makes calls to the function static
@@ -20,4 +20,5 @@ It is also worth mentioning Noir's `unconstrained` function type [here (Noir doc
 - `#[storage]` - Defines contract storage
 
 ## Further reading
+
 [How do Aztec macros work?](../../concepts/smart_contracts/functions/function_transforms.md)

--- a/docs/docs/developers/docs/tutorials/contract_tutorials/counter_contract.md
+++ b/docs/docs/developers/docs/tutorials/contract_tutorials/counter_contract.md
@@ -70,8 +70,8 @@ pub contract Counter {
 
 #include_code imports /docs/examples/contracts/counter_contract/src/main.nr rust
 
-- `use aztec::macros::{functions::{initializer, private, utility}, storage::storage},`
-  Imports the macros needed to define function types (`initializer`, `private`, and `utility`) and the `storage` macro for declaring contract storage structures.
+- `use aztec::macros::{functions::{external, initializer}, storage::storage},`
+  Imports the macros needed to define function types (`external`, `initializer`) and the `storage` macro for declaring contract storage structures.
 
 - `protocol_types::{address::AztecAddress, traits::ToField},`
   Brings in `AztecAddress` (used to identify accounts/contracts) and traits for converting values to and from field elements, necessary for serialization and formatting inside Aztec.
@@ -98,7 +98,7 @@ Let’s create a constructor method to run on deployment that assigns an initial
 
 This function accesses the counts from storage. Then it assigns the passed initial counter to the `owner`'s counter privately using `at().add()`.
 
-We have annotated this and other functions with `#[private]` which are ABI macros so the compiler understands it will handle private inputs.
+We have annotated this and other functions with `#[external("private")]` which are ABI macros so the compiler understands it will handle private inputs.
 
 ## Incrementing our counter
 
@@ -145,4 +145,4 @@ You can now use the artifact and/or the TS class in your Aztec.js!
 
 ### Optional: Learn more about concepts mentioned here
 
-- [Functions and annotations like `#[private]`](../../concepts/smart_contracts/functions/function_transforms.md#private-functions)
+- [Functions and annotations like `#[external("private")]`](../../concepts/smart_contracts/functions/function_transforms.md#private-functions)

--- a/docs/docs/developers/migration_notes.md
+++ b/docs/docs/developers/migration_notes.md
@@ -197,6 +197,42 @@ The following commands were dropped from the `aztec` command:
 
 ## [Aztec.nr]
 
+### Replacing #[private], #[public], #[utility] with #[external(...)] macro
+
+The original naming was not great in that it did not sufficiently communicate what the given macro did.
+We decided to rename `#[private]` as `#[external("private")]`, `#[public]` as `#[external("public")]`, and `#[utility]` as `#[external("utility")]` to better communicate that these functions are externally callable and to specify their execution context. In this sense, `external` now means the exact same thing as in Solidity, i.e. a function that can be called from other contracts, and that can only be invoked via a contract call (i.e. the `CALL` opcode in the EVM, and a kernel call/AVM `CALL` opcode in Aztec).
+
+You have to do the following changes in your contracts:
+
+Update import:
+
+```diff
+- use aztec::macros::functions::private;
+- use aztec::macros::functions::public;
+- use aztec::macros::functions::utility;
++ use aztec::macros::functions::external;
+```
+
+Update attributes of your functions:
+
+```diff
+-    #[private]
++    #[external("private")]
+    fn my_private_func() {
+```
+
+```diff
+-    #[public]
++    #[external("public")]
+    fn my_public_func() {
+```
+
+```diff
+-    #[utility]
++    #[external("utility")]
+    fn my_utility_func() {
+```
+
 ### Authwit Test Helper now takes `env`
 
 The `add_private_authwit_from_call_interface` test helper available in `test::helpers::authwit` now takes a `TestEnvironment` parameter, mirroring `add_public_authwit_from_call_interface`. This adds some unfortunate verbosity, but there are bigger plans to improve authwit usage in Noir tests in the near future.

--- a/docs/examples/contracts/bob_token_contract/src/main.nr
+++ b/docs/examples/contracts/bob_token_contract/src/main.nr
@@ -6,7 +6,7 @@ use aztec::macros::aztec;
 pub contract BobToken {
     // docs:end:start
     use aztec::{
-        macros::{functions::{initializer, private, public, utility, internal}, storage::storage},
+        macros::{functions::{external, initializer, internal}, storage::storage},
         protocol_types::address::AztecAddress, state_vars::Map,
         state_vars::public_mutable::PublicMutable,
     };
@@ -30,7 +30,7 @@ pub contract BobToken {
 
     // docs:start:setup
     #[initializer]
-    #[public]
+    #[external("public")]
     fn setup() {
         // Giggle becomes the owner who can mint mental health tokens
         storage.owner.write(context.msg_sender().unwrap());
@@ -38,7 +38,7 @@ pub contract BobToken {
     // docs:end:setup
 
     // docs:start:mint_public
-    #[public]
+    #[external("public")]
     fn mint_public(employee: AztecAddress, amount: u64) {
         // Only Giggle can mint tokens
         assert_eq(context.msg_sender().unwrap(), storage.owner.read(), "Only Giggle can mint BOB tokens");
@@ -50,7 +50,7 @@ pub contract BobToken {
     // docs:end:mint_public
 
     // docs:start:transfer_public
-    #[public]
+    #[external("public")]
     fn transfer_public(to: AztecAddress, amount: u64) {
         let sender = context.msg_sender().unwrap();
         let sender_balance = storage.public_balances.at(sender).read();
@@ -66,7 +66,7 @@ pub contract BobToken {
     // docs:end:transfer_public
 
     // docs:start:transfer_ownership
-    #[public]
+    #[external("public")]
     fn transfer_ownership(new_owner: AztecAddress) {
         assert_eq(context.msg_sender().unwrap(), storage.owner.read(), "Only current admin can transfer ownership");
         storage.owner.write(new_owner);
@@ -74,7 +74,7 @@ pub contract BobToken {
     // docs:end:transfer_ownership
 
     // docs:start:public_to_private
-    #[private]
+    #[external("private")]
     fn public_to_private(amount: u64) {
         let sender = context.msg_sender().unwrap();
         // This will enqueue a public function to deduct from public balance
@@ -85,7 +85,7 @@ pub contract BobToken {
     // docs:end:public_to_private
 
     // docs:start:_deduct_public_balance
-    #[public]
+    #[external("public")]
     #[internal]
     fn _deduct_public_balance(owner: AztecAddress, amount: u64) {
         let balance = storage.public_balances.at(owner).read();
@@ -96,7 +96,7 @@ pub contract BobToken {
 
 
     // docs:start:transfer_private
-    #[private]
+    #[external("private")]
     fn transfer_private(to: AztecAddress, amount: u64) {
         let sender = context.msg_sender().unwrap();
         // Spend sender's notes (consumes existing notes)
@@ -107,19 +107,19 @@ pub contract BobToken {
     // docs:end:transfer_private
 
     // docs:start:check_balances
-    #[utility]
+    #[external("utility")]
     unconstrained fn private_balance_of(owner: AztecAddress) -> Field {
         storage.private_balances.at(owner).get_value()
     }
 
-    #[utility]
+    #[external("utility")]
     unconstrained fn public_balance_of(owner: AztecAddress) -> pub u64 {
         storage.public_balances.at(owner).read()
     }
     // docs:end:check_balances
 
     // docs:start:_assert_is_owner
-    #[public]
+    #[external("public")]
     #[internal]
     fn _assert_is_owner(address: AztecAddress) {
         assert_eq(address, storage.owner.read(), "Only Giggle can mint BOB tokens");
@@ -127,7 +127,7 @@ pub contract BobToken {
     // docs:end:_assert_is_owner
 
     // docs:start:mint_private
-    #[private]
+    #[external("private")]
     fn mint_private(employee: AztecAddress, amount: u64) {
         // Enqueue ownership check (will revert if not Giggle)
         BobToken::at(context.this_address())
@@ -141,7 +141,7 @@ pub contract BobToken {
 
 
     // docs:start:private_to_public
-    #[private]
+    #[external("private")]
     fn private_to_public(amount: u64) {
         let sender = context.msg_sender().unwrap();
         // Remove from private balance
@@ -152,7 +152,7 @@ pub contract BobToken {
             .enqueue(&mut context);
     }
 
-    #[public]
+    #[external("public")]
     #[internal]
     fn _credit_public_balance(owner: AztecAddress, amount: u64) {
         let balance = storage.public_balances.at(owner).read();

--- a/docs/examples/contracts/counter_contract/src/main.nr
+++ b/docs/examples/contracts/counter_contract/src/main.nr
@@ -6,7 +6,7 @@ pub contract Counter {
     // docs:end:setup
     // docs:start:imports
     use aztec::{
-        macros::{functions::{initializer, private, utility}, storage::storage},
+        macros::{functions::{external, initializer}, storage::storage},
         oracle::debug_log::debug_log_format, protocol_types::{address::AztecAddress, traits::ToField},
         state_vars::Map,
     };
@@ -22,7 +22,7 @@ pub contract Counter {
 
     // docs:start:constructor
     #[initializer]
-    #[private]
+    #[external("private")]
     // We can name our initializer anything we want as long as it's marked as aztec(initializer)
     fn initialize(headstart: u64, owner: AztecAddress) {
         let counters = storage.counters;
@@ -31,7 +31,7 @@ pub contract Counter {
     // docs:end:constructor
 
     // docs:start:increment
-    #[private]
+    #[external("private")]
     fn increment(owner: AztecAddress) {
         debug_log_format("Incrementing counter for owner {0}", [owner.to_field()]);
         let counters = storage.counters;
@@ -40,7 +40,7 @@ pub contract Counter {
     // docs:end:increment
 
     // docs:start:get_counter
-    #[utility]
+    #[external("utility")]
     unconstrained fn get_counter(owner: AztecAddress) -> Field {
         storage.counters.at(owner).get_value()
     }

--- a/docs/examples/tutorials/token_bridge_contract/contracts/aztec/nft/src/main.nr
+++ b/docs/examples/tutorials/token_bridge_contract/contracts/aztec/nft/src/main.nr
@@ -5,7 +5,7 @@ pub mod nft;
 #[aztec]
 pub contract NFTPunk {
     use dep::aztec::{
-        macros::{storage::storage, functions::{utility, private, public, initializer, internal}},
+        macros::{storage::storage, functions::{external, utility, initializer, internal}},
         protocol_types::{address::AztecAddress},
         state_vars::{PrivateSet, PublicImmutable, delayed_public_mutable::DelayedPublicMutable, Map}
     };
@@ -21,7 +21,7 @@ pub contract NFTPunk {
         nfts: Map<Field, DelayedPublicMutable<bool, 2, Context>, Context>,
         owners: Map<AztecAddress, PrivateSet<NFTNote, Context>, Context>,
     }
-    #[public]
+    #[external("public")]
     #[initializer]
     fn constructor(admin: AztecAddress) {
         storage.admin.initialize(admin);
@@ -29,7 +29,7 @@ pub contract NFTPunk {
     // docs:end:contract_setup
 
     // docs:start:set_minter
-    #[public]
+    #[external("public")]
     fn set_minter(minter: AztecAddress) {
         assert(storage.admin.read().eq(context.msg_sender().unwrap()), "caller is not admin");
         storage.minter.initialize(minter);
@@ -37,7 +37,7 @@ pub contract NFTPunk {
     // docs:end:set_minter
 
     // docs:start:mark_nft_exists
-    #[public]
+    #[external("public")]
     #[internal]
     fn _mark_nft_exists(token_id: Field, exists: bool) {
         storage.nfts.at(token_id).schedule_value_change(exists);
@@ -45,7 +45,7 @@ pub contract NFTPunk {
     // docs:end:mark_nft_exists
 
     // docs:start:mint
-    #[private]
+    #[external("private")]
     fn mint(to: AztecAddress, token_id: Field) {
         assert(storage.minter.read().eq(context.msg_sender().unwrap()), "caller is not the authorized minter");
 
@@ -67,7 +67,7 @@ pub contract NFTPunk {
     // docs:end:notes_of
 
     // docs:start:burn
-    #[private]
+    #[external("private")]
     fn burn(from: AztecAddress, token_id: Field) {
         assert(storage.minter.read().eq(context.msg_sender().unwrap()), "caller is not the authorized minter");
 

--- a/docs/examples/tutorials/token_bridge_contract/contracts/aztec/nft_bridge/src/main.nr
+++ b/docs/examples/tutorials/token_bridge_contract/contracts/aztec/nft_bridge/src/main.nr
@@ -4,7 +4,7 @@ use aztec::macros::aztec;
 #[aztec]
 pub contract NFTBridge {
     use dep::aztec::{
-        macros::{storage::storage, functions::{public, initializer, private}},
+        macros::{storage::storage, functions::{external, initializer}},
         protocol_types::{address::AztecAddress, address::EthAddress, hash::sha256_to_field},
         state_vars::{PublicImmutable},
     };
@@ -16,20 +16,20 @@ pub contract NFTBridge {
         portal: PublicImmutable<EthAddress, Context>,
     }
     
-    #[public]
+    #[external("public")]
     #[initializer]
     fn constructor(nft: AztecAddress) {
         storage.nft.initialize(nft);
     }
     
-    #[public]
+    #[external("public")]
     fn set_portal(portal: EthAddress) {
         storage.portal.initialize(portal);
     }
     // docs:end:bridge_setup
 
     // docs:start:claim
-    #[private]
+    #[external("private")]
     fn claim(to: AztecAddress, token_id: Field, secret: Field, message_leaf_index: Field) {
         // Compute the message hash that was sent from L1
         let token_id_bytes: [u8; 32] = (token_id as Field).to_be_bytes();
@@ -50,7 +50,7 @@ pub contract NFTBridge {
     // docs:end:claim
 
     // docs:start:exit
-    #[private]
+    #[external("private")]
     fn exit(
         token_id: Field,
         recipient: EthAddress

--- a/noir-projects/aztec-nr/README.md
+++ b/noir-projects/aztec-nr/README.md
@@ -104,7 +104,7 @@ Aztec has two kinds of state:
 
 ### Public State
 
-Public state is similar to Ethereum smart contract state. Public state can be mutated by making calls to `#[public]` functions as part of a transaction.
+Public state is similar to Ethereum smart contract state. Public state can be mutated by making calls to `#[external("public")]` functions as part of a transaction.
 
 > The public functions of a transaction are executed by the current Proposer.
 > A Proposer is a node on the network with the temporary power to build blocks filled with transactions. This block-building power is randomly changed regularly between a set of Validators.
@@ -140,7 +140,7 @@ See the relevant files for explanations of their properties, and when to use whi
 
 Private state is fundamentally different from Ethereum smart contract state.
 
-Private state can only be modified by a user who is _privy_ to that private state, to ensure that the user's secrets stay safe on their device. Any changes to private state are executed within `#[private]` functions.
+Private state can only be modified by a user who is _privy_ to that private state, to ensure that the user's secrets stay safe on their device. Any changes to private state are executed within `#[external("private")]` functions.
 
 > Advanced: Each private function execution is proven to be correct with a zero-knowledge proof, which enables private data to be operated on without leaking that data. But generating a proof of a function execution takes slightly longer than conventional native execution of function.
 

--- a/noir-projects/aztec-nr/aztec/src/context/call_interfaces.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/call_interfaces.nr
@@ -55,8 +55,8 @@ where
     ///
     /// # Arguments
     /// * `context` - The PrivateContext -- made magically available to the body
-    ///               of every #[private] function as `context`, through the
-    ///               #[private] annotation's macro.
+    ///               of every #[external("private")] function as `context`, through the
+    ///               #[external("private")] annotation's macro.
     ///
     /// # Returns
     /// * `T` - Whatever data the called function has returned.
@@ -107,8 +107,8 @@ where
     ///
     /// # Arguments
     /// * `context` - The PrivateContext -- made magically available to the body
-    ///               of every #[private] function as `context`, through the
-    ///               #[private] annotation's macro.
+    ///               of every #[external("private")] function as `context`, through the
+    ///               #[external("private")] annotation's macro.
     ///
     /// # Returns
     /// * `T` - Whatever data the called function has returned.
@@ -137,8 +137,8 @@ where
     ///
     /// # Arguments
     /// * `context` - The PrivateContext -- made magically available to the body
-    ///               of every #[private] function as `context`, through the
-    ///               #[private] annotation's macro.
+    ///               of every #[external("private")] function as `context`, through the
+    ///               #[external("private")] annotation's macro.
     ///
     /// # Returns
     /// * `T` - Whatever data the called function has returned.
@@ -218,8 +218,8 @@ impl<let M: u32, T> PrivateStaticCallInterface<M, T> {
     ///
     /// # Arguments
     /// * `context` - The PrivateContext -- made magically available to the body
-    ///               of every #[private] function as `context`, through the
-    ///               #[private] annotation's macro.
+    ///               of every #[external("private")] function as `context`, through the
+    ///               #[external("private")] annotation's macro.
     ///
     pub fn view(self, context: &mut PrivateContext) -> T
     where
@@ -303,8 +303,8 @@ where
     ///
     /// # Arguments
     /// * `context` - The PublicContext -- made magically available to the body
-    ///               of every #[public] function as `context`, through the
-    ///               #[public] annotation's macro.
+    ///               of every #[external("public")] function as `context`, through the
+    ///               #[external("public")] annotation's macro.
     ///
     /// # Returns
     /// * `T` - Whatever data the called function has returned.
@@ -331,8 +331,8 @@ where
     ///
     /// # Arguments
     /// * `context` - The PublicContext -- made magically available to the body
-    ///               of every #[public] function as `context`, through the
-    ///               #[public] annotation's macro.
+    ///               of every #[external("public")] function as `context`, through the
+    ///               #[external("public")] annotation's macro.
     ///
     /// # Returns
     /// * `T` - Whatever data the called function has returned.
@@ -375,8 +375,8 @@ where
     ///
     /// # Arguments
     /// * `context` - The PrivateContext -- made magically available to the body
-    ///               of every #[private] function as `context`, through the
-    ///               #[private] annotation's macro.
+    ///               of every #[external("private")] function as `context`, through the
+    ///               #[external("private")] annotation's macro.
     ///
     pub fn enqueue(self, context: &mut PrivateContext) {
         self.enqueue_impl(context, false, false)
@@ -410,8 +410,8 @@ where
     ///
     /// # Arguments
     /// * `context` - The PrivateContext -- made magically available to the body
-    ///               of every #[private] function as `context`, through the
-    ///               #[private] annotation's macro.
+    ///               of every #[external("private")] function as `context`, through the
+    ///               #[external("private")] annotation's macro.
     ///
     /// Advanced:
     /// - The kernel circuits will permit _any_ private function to set the
@@ -433,8 +433,8 @@ where
     ///
     /// # Arguments
     /// * `context` - The PrivateContext -- made magically available to the body
-    ///               of every #[private] function as `context`, through the
-    ///               #[private] annotation's macro.
+    ///               of every #[external("private")] function as `context`, through the
+    ///               #[external("private")] annotation's macro.
     ///
     pub fn enqueue_view(self, context: &mut PrivateContext) {
         self.enqueue_impl(context, true, false)
@@ -449,8 +449,8 @@ where
     ///
     /// # Arguments
     /// * `context` - The PrivateContext -- made magically available to the body
-    ///               of every #[private] function as `context`, through the
-    ///               #[private] annotation's macro.
+    ///               of every #[external("private")] function as `context`, through the
+    ///               #[external("private")] annotation's macro.
     ///
     pub fn enqueue_view_incognito(self, context: &mut PrivateContext) {
         self.enqueue_impl(context, true, true)
@@ -501,8 +501,8 @@ where
     ///
     /// # Arguments
     /// * `context` - The PrivateContext -- made magically available to the body
-    ///               of every #[private] function as `context`, through the
-    ///               #[private] annotation's macro.
+    ///               of every #[external("private")] function as `context`, through the
+    ///               #[external("private")] annotation's macro.
     ///
     pub fn set_as_teardown(self, context: &mut PrivateContext) {
         self.set_as_teardown_impl(context, false);
@@ -604,8 +604,8 @@ where
     ///
     /// # Arguments
     /// * `context` - The PublicContext -- made magically available to the body
-    ///               of every #[public] function as `context`, through the
-    ///               #[public] annotation's macro.
+    ///               of every #[external("public")] function as `context`, through the
+    ///               #[external("public")] annotation's macro.
     ///
     /// # Returns
     /// * `T` - Whatever data the called function has returned.
@@ -628,8 +628,8 @@ where
     ///
     /// # Arguments
     /// * `context` - The PrivateContext -- made magically available to the body
-    ///               of every #[private] function as `context`, through the
-    ///               #[private] annotation's macro.
+    ///               of every #[external("private")] function as `context`, through the
+    ///               #[external("private")] annotation's macro.
     ///
     pub fn enqueue_view(self, context: &mut PrivateContext) {
         let calldata = self.args.push_front(self.selector.to_field());

--- a/noir-projects/aztec-nr/aztec/src/context/private_context.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/private_context.nr
@@ -50,14 +50,14 @@ use dep::protocol_types::{
 
 /// # PrivateContext
 ///
-/// The **main interface** between a #[private] function and the Aztec blockchain.
+/// The **main interface** between an #[external("private")] function and the Aztec blockchain.
 ///
 /// An instance of the PrivateContext is initialized automatically at the outset
-/// of every private function, within the #[private] macro, so you'll never
+/// of every private function, within the #[external("private")] macro, so you'll never
 /// need to consciously instantiate this yourself.
 ///
 /// The instance is always named `context`, and it is always be available within
-/// the body of every #[private] function in your smart contract.
+/// the body of every #[external("private")] function in your smart contract.
 ///
 /// > For those used to "vanilla" Noir, it might be jarring to have access to
 /// > `context` without seeing a declaration `let context = PrivateContext::new(...)`
@@ -108,9 +108,9 @@ use dep::protocol_types::{
 ///   - New nullifiers
 ///   - Private logs (for sending encrypted note contents or encrypted events)
 ///   - New L2->L1 messages.
-/// - Provides args to the private function (handled by the #[private] macro).
+/// - Provides args to the private function (handled by the #[external("private")] macro).
 /// - Returns the return values of this private function (handled by the
-///   #[private] macro).
+///   #[external("private")] macro).
 /// - Makes Key Validation Requests.
 ///   - Private functions are not allowed to see master secret keys, because we
 ///     do not trust them. They are instead given "app-siloed" secret keys with
@@ -339,7 +339,7 @@ impl PrivateContext {
     /// * `FunctionSelector` - The 4-byte function identifier
     ///
     /// # Advanced
-    /// Only #[private] functions have a function selector as a protocol-
+    /// Only #[external("private")] functions have a function selector as a protocol-
     /// enshrined concept. The function selectors of private functions are
     /// baked into the preimage of the contract address, and are used by the
     /// protocol's kernel circuits to identify each private function and ensure
@@ -353,7 +353,7 @@ impl PrivateContext {
 
     /// Returns the hash of the arguments passed to the current function.
     ///
-    /// Very low-level function: You shouldn't need to call this. The #[private]
+    /// Very low-level function: You shouldn't need to call this. The #[external("private")]
     /// macro calls this, and it makes the arguments neatly available to the
     /// body of your private function.
     ///
@@ -559,7 +559,7 @@ impl PrivateContext {
 
     /// Sets the hash of the return values for this private function.
     ///
-    /// Very low-level function: this is called by the #[private] macro.
+    /// Very low-level function: this is called by the #[external("private")] macro.
     ///
     /// # Arguments
     /// * `serialized_return_values` - The serialized return values as a field array
@@ -574,7 +574,7 @@ impl PrivateContext {
     /// ensure compatibility with the protocol's kernel circuits.
     ///
     /// Very low-level function: This function is automatically called by the
-    /// #[private] macro.
+    /// #[external("private")] macro.
     pub fn finish(self) -> PrivateCircuitPublicInputs {
         PrivateCircuitPublicInputs {
             call_context: self.inputs.call_context,

--- a/noir-projects/aztec-nr/aztec/src/context/public_context.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/public_context.nr
@@ -9,14 +9,14 @@ use dep::protocol_types::traits::{Empty, FromField, Packable, Serialize, ToField
 
 /// # PublicContext
 ///
-/// The **main interface** between a #[public] function and the Aztec blockchain.
+/// The **main interface** between an #[external("public")] function and the Aztec blockchain.
 ///
 /// An instance of the PublicContext is initialized automatically at the outset
-/// of every public function, within the #[public] macro, so you'll never
+/// of every public function, within the #[external("public")] macro, so you'll never
 /// need to consciously instantiate this yourself.
 ///
 /// The instance is always named `context`, and it will always be available
-/// within the body of every #[public] function in your smart contract.
+/// within the body of every #[external("public")] function in your smart contract.
 ///
 /// Typical usage for a smart contract developer will be to call getter
 /// methods of the PublicContext.
@@ -83,7 +83,7 @@ impl Eq for PublicContext {
 impl PublicContext {
     /// Creates a new PublicContext instance.
     ///
-    /// Low-level function: This is called automatically by the #[public]
+    /// Low-level function: This is called automatically by the #[external("public")]
     /// macro, so you shouldn't need to be called directly by smart contract
     /// developers.
     ///
@@ -490,7 +490,7 @@ impl PublicContext {
 
     /// Returns the hash of the arguments passed to the current function.
     ///
-    /// Very low-level function: The #[public] macro uses this internally.
+    /// Very low-level function: The #[external("public")] macro uses this internally.
     /// Smart contract developers typically won't need to access this
     /// directly as arguments are automatically made available.
     ///

--- a/noir-projects/aztec-nr/aztec/src/macros/aztec.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/aztec.nr
@@ -12,8 +12,7 @@ use crate::macros::{
 pub comptime fn aztec(m: Module) -> Quoted {
     let interface = generate_contract_interface(m);
 
-    // Functions that don't have #[private], #[public], #[utility], #[contract_library_method], or #[test] are not
-    // allowed in contracts.
+    // Functions that don't have #[external(...)], #[contract_library_method], or #[test] are not allowed in contracts.
     check_each_fn_macroified(m);
 
     // We generate `_compute_note_hash_and_nullifier`, `sync_private_state` and `process_message`
@@ -248,30 +247,30 @@ comptime fn generate_contract_library_method_compute_note_hash_and_nullifier() -
 }
 
 comptime fn generate_sync_private_state() -> Quoted {
-    // We obtain the `utility` function on the next line instead of directly doing
-    // `#[aztec::macros::functions::utility]` in the returned quote because the latter would result in the function
-    // attribute having the full path in the ABI. This is undesirable because we use the information in the ABI only
-    // to determine whether a function is `private`, `public`, or `utility`.
-    let utility = crate::macros::functions::utility;
+    // We obtain the `external` function on the next line instead of directly doing
+    // `#[aztec::macros::functions::external("utility")]` in the returned quote because the latter would result in
+    // the function attribute having the full path in the ABI. This is undesirable because we use the information in
+    // the ABI only to determine whether a function is `external("private")`, `external("public")`, or `external("utility")`.
+    let external = crate::macros::functions::external;
 
-    // All we need to do here is trigger message discovery, but this is already done by the #[utility] macro - we don't
+    // All we need to do here is trigger message discovery, but this is already done by the #[external("utility")] macro - we don't
     // need to do anything extra.
     quote {
-        #[$utility]
+        #[$external("utility")]
         unconstrained fn sync_private_state() {
         }
     }
 }
 
 comptime fn generate_process_message() -> Quoted {
-    // We obtain the `utility` function on the next line instead of directly doing
-    // `#[aztec::macros::functions::utility]` in the returned quote because the latter would result in the function
-    // attribute having the full path in the ABI. This is undesirable because we use the information in the ABI only
-    // to determine whether a function is `private`, `public`, or `utility`.
-    let utility = crate::macros::functions::utility;
+    // We obtain the `external` function on the next line instead of directly doing
+    // `#[aztec::macros::functions::external("utility")]` in the returned quote because the latter would result in
+    // the function attribute having the full path in the ABI. This is undesirable because we use the information in
+    // the ABI only to determine whether a function is `external("private")`, `external("public")`, or `external("utility")`.
+    let external = crate::macros::functions::external;
 
     quote {
-        #[$utility]
+        #[$external("utility")]
         unconstrained fn process_message(
             message_ciphertext: BoundedVec<Field, aztec::messages::encoding::MESSAGE_CIPHERTEXT_LEN>,
             message_context: aztec::messages::processing::message_context::MessageContext,

--- a/noir-projects/aztec-nr/aztec/src/macros/dispatch.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/dispatch.nr
@@ -107,7 +107,7 @@ pub comptime fn generate_public_dispatch(m: Module) -> Quoted {
             // We mark this as public because our whole system depends on public
             // functions having this attribute. However, the public MACRO will
             // handle the public_dispatch function specially and do nothing.
-            #[public]
+            #[external("public")]
             pub unconstrained fn public_dispatch(selector: Field) {
                 $dispatch
             }

--- a/noir-projects/aztec-nr/aztec/src/macros/functions/auth_registry.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/functions/auth_registry.nr
@@ -3,7 +3,7 @@ use std::{collections::umap::UHashMap, hash::BuildHasherDefault};
 
 /// Registers the functions that have the `#[authorize_once(...)]` macro, and the parameters the macro was invoked with.
 /// This is used to later inject the authorization check (see ./utils.nr -> create_authorize_once_check)
-/// via the #[private] or #[public] macros.
+/// via the #[external("private")] or #[external("public")] macros.
 /// The `#[authorize_once(...)]` macro is not used directly to inject the check because it has to be placed
 /// after context instantiation but before the function body, which only the aforementioned macros can do.
 pub(crate) comptime mut global AUTHORIZE_ONCE_REGISTRY: UHashMap<FunctionDefinition, (CtString, CtString), BuildHasherDefault<Poseidon2Hasher>> =

--- a/noir-projects/aztec-nr/aztec/src/macros/functions/external_registry.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/functions/external_registry.nr
@@ -1,0 +1,24 @@
+use poseidon::poseidon2::Poseidon2Hasher;
+use std::{collections::umap::UHashMap, hash::BuildHasherDefault};
+
+/// Key is external function definition and value is the argument of the #[external] attribute ("private", "public",
+/// or "utility").
+comptime mut global EXTERNAL_REGISTRY: UHashMap<FunctionDefinition, CtString, BuildHasherDefault<Poseidon2Hasher>> =
+    UHashMap::default();
+
+/// Registers functions in the EXTERNAL_REGISTRY map. Called by the #[external] macro.
+pub(crate) comptime fn register(f: FunctionDefinition, f_type: CtString) {
+    // Check if function is already registered as external
+    if EXTERNAL_REGISTRY.get(f).is_some() {
+        let name = f.name();
+        panic(
+            f"The #[external] attribute cannot be applied multiple times to the same function - {name} already has it",
+        );
+    }
+
+    EXTERNAL_REGISTRY.insert(f, f_type);
+}
+
+pub(crate) comptime fn get(f: FunctionDefinition) -> Option<CtString> {
+    EXTERNAL_REGISTRY.get(f)
+}

--- a/noir-projects/aztec-nr/aztec/src/macros/functions/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/functions/mod.nr
@@ -5,6 +5,7 @@ pub(crate) mod call_interface_stubs;
 pub mod initialization_utils;
 pub(crate) mod stub_registry;
 pub(crate) mod auth_registry;
+pub(crate) mod external_registry;
 pub(crate) mod utils;
 
 use crate::macros::{
@@ -12,21 +13,28 @@ use crate::macros::{
         abi_export::create_fn_abi_export,
         utils::{transform_private, transform_public, transform_utility},
     },
-    utils::{is_fn_private, is_fn_public, is_fn_utility, module_has_initializer},
+    utils::{is_fn_external, module_has_initializer},
 };
+use super::utils::{fn_has_noinitcheck, is_fn_initializer, is_fn_internal, is_fn_view};
 use auth_registry::AUTHORIZE_ONCE_REGISTRY;
 
-// Functions can have multiple attributes applied to them, e.g. a single function can have #[public], #[view] and
-// #[internal]. However. the order in which this will be evaluated is unknown, which makes combining them tricky.
+// Note: The internal naming below is deprecated and will soon be renamed. For this reason it's so weird (having
+// external and internal applicable to one function).
 //
-// Our strategy is to have two mutually exclusive attributes, #[private] and #[public] (technically unconstrained is a
-// hidden third kind), and make it so all functions must have one of them. These contain the code for all other
-// attributes, but they only run it if the corresponding attribute has been applied to the function in question.
+// Functions can have multiple attributes applied to them, e.g. a single function can have #[external("public")],
+// #[view] and #[internal]. However. the order in which this will be evaluated is unknown, which makes combining them
+// tricky.
 //
-// For example, `#[private]` knows about `#[internal]` and what it should do, but it only does it if it sees that the
-// private function in question also has the `internal` attribute applied. `#[internal]` itself does nothing - it is
-// what we call a 'marker' attribute, that only exists for `#[private]` or `#[public]` to check if it's been applied.
-// Therefore, the execution order of `#[internal]` and `#[private]` is irrelevant.
+// Our strategy is to have functions accept at most one #[external(...)] attribute that takes a parameter ("private",
+// "public", or "utility") to specify the function type. The private and public handlers that are triggered based on
+// the arg of #[external(...)] attribute contains the code for all other attributes, but they only run if
+// the corresponding marker attribute has been applied to the function.
+//
+// For example, the "private" handler of #[external(...)] knows about #[internal] and what it should do, but it only
+// does it if it sees that the private function in question also has the `internal` attribute applied. `#[internal]`
+// itself does nothing - it is what we call a 'marker' attribute, that only exists for `#[external("private")]`
+// and `#[external(public)]` to check if it's been applied. Therefore, the execution order of `#[internal]` and
+// `#[external(...)]` is irrelevant.
 
 /// An initializer function is similar to a constructor:
 ///  - it can only be called once
@@ -35,10 +43,13 @@ use auth_registry::AUTHORIZE_ONCE_REGISTRY;
 pub comptime fn initializer(f: FunctionDefinition) {
     // Marker attribute - see the comment above
 
-    if !is_fn_private(f) & !is_fn_public(f) {
+    if !is_fn_external(f) {
+        // Unfortunately we cannot check if we are dealing with a utility function here as Noir does not support
+        // getting arguments passed to attributes. For this reason, we will check for this when the utility macro
+        // function is run.
         let name = f.name();
         panic(
-            f"The #[initializer] attribute can only be applied to #[private] or #[public] functions - {name} is neither",
+            f"The #[initializer] attribute can only be applied to #[external(\"private\")] or #[external(\"public\")] functions - {name} is neither",
         );
     }
 }
@@ -47,10 +58,13 @@ pub comptime fn initializer(f: FunctionDefinition) {
 pub comptime fn noinitcheck(f: FunctionDefinition) {
     // Marker attribute - see the comment above
 
-    if !is_fn_private(f) & !is_fn_public(f) {
+    if !is_fn_external(f) {
+        // Unfortunately we cannot check if we are dealing with a utility function here as Noir does not support
+        // getting arguments passed to attributes. For this reason, we will check for this when the utility macro
+        // function is run.
         let name = f.name();
         panic(
-            f"The #[noinitcheck] attribute can only be applied to #[private] or #[public] functions - {name} is neither",
+            f"The #[noinitcheck] attribute can only be applied to #[external(\"private\")] or #[external(\"public\")] functions - {name} is neither",
         );
     }
 
@@ -65,10 +79,13 @@ pub comptime fn noinitcheck(f: FunctionDefinition) {
 pub comptime fn internal(f: FunctionDefinition) {
     // Marker attribute - see the comment above
 
-    if !is_fn_private(f) & !is_fn_public(f) {
+    if !is_fn_external(f) {
+        // Unfortunately we cannot check if we are dealing with a utility function here as Noir does not support
+        // getting arguments passed to attributes. For this reason, we will check for this when the utility macro
+        // function is run.
         let name = f.name();
         panic(
-            f"The #[internal] attribute can only be applied to #[private] or #[public] functions - {name} is neither",
+            f"The #[internal] attribute can only be applied to #[external(\"private\")] or #[external(\"public\")] functions - {name} is neither",
         );
     }
 }
@@ -77,10 +94,13 @@ pub comptime fn internal(f: FunctionDefinition) {
 pub comptime fn view(f: FunctionDefinition) {
     // Marker attribute - see the comment above
 
-    if !is_fn_private(f) & !is_fn_public(f) {
+    if !is_fn_external(f) {
+        // Unfortunately we cannot check if we are dealing with a utility function here as Noir does not support
+        // getting arguments passed to attributes. For this reason, we will check for this when the utility macro
+        // function is run.
         let name = f.name();
         panic(
-            f"The #[view] attribute can only be applied to #[private] or #[public] functions - {name} is neither",
+            f"The #[view] attribute can only be applied to #[external(\"private\")] or #[external(\"public\")] functions - {name} is neither",
         );
     }
 }
@@ -98,37 +118,58 @@ pub comptime fn authorize_once(
     from_arg_name: CtString,
     nonce_arg_name: CtString,
 ) {
-    if !is_fn_private(f) & !is_fn_public(f) {
+    if !is_fn_external(f) {
+        // Unfortunately we cannot check if we are dealing with a utility function here as Noir does not support
+        // getting arguments passed to attributes. For this reason, we will check for this when the utility macro
+        // function is run.
         let name = f.name();
         panic(
-            f"The #[authorize_once] attribute can only be applied to #[private] or #[public] functions - {name} is neither",
+            f"The #[authorize_once] attribute can only be applied to #[external(\"private\")] or #[external(\"public\")] functions - {name} is neither",
         );
     }
 
     AUTHORIZE_ONCE_REGISTRY.insert(f, (from_arg_name, nonce_arg_name));
 }
 
-/// Private functions are executed client-side and preserve privacy.
-pub comptime fn private(f: FunctionDefinition) -> Quoted {
-    if is_fn_public(f) | is_fn_utility(f) {
-        let name = f.name();
+/// Same as in Solidity external functions are functions that our callable from outside the contract. External
+/// functions can be either private, public, or utility.
+pub comptime fn external(f: FunctionDefinition, f_type: CtString) -> Quoted {
+    // Register the function type in the global registry so helper functions can check it
+    external_registry::register(f, f_type);
+
+    if f_type.eq("private") {
+        private(f)
+    } else if f_type.eq("public") {
+        public(f)
+    } else if f_type.eq("utility") {
+        utility(f)
+    } else {
+        let function_name = f.name();
         panic(
-            f"A function marked as #[private] cannot also be #[public] or #[utility] - {name} is more than one of these",
+            f"Function '{function_name}' is marked as #[external(\"{f_type}\")], but '{f_type}' is not a valid external function type. External functions must be one of 'private', 'public' or 'utility'",
         );
+        quote {}
     }
+}
+
+/// Private functions are executed client-side and preserve privacy.
+comptime fn private(f: FunctionDefinition) -> Quoted {
+    // We need to add this attribute to be able to identify if the function is external private when constructing
+    // the contract artifact.
+    f.add_attribute("private");
 
     let visibility = f.visibility();
     if visibility != quote {} {
         let name = f.name();
         panic(
-            f"A function marked as #[private] must not have public Noir visibility - {name}'s visibility is '{visibility}'",
+            f"A function marked as #[external(\"private\")] must not have public Noir visibility - {name}'s visibility is '{visibility}'",
         );
     }
 
     if f.is_unconstrained() {
         let name = f.name();
         panic(
-            f"#[private] functions must not be unconstrained - {name} is",
+            f"#[external(\"private\")] functions must not be unconstrained - {name} is",
         );
     }
 
@@ -141,29 +182,28 @@ pub comptime fn private(f: FunctionDefinition) -> Quoted {
 }
 
 /// Public functions are executed sequencer-side and do not preserve privacy, similar to the EVM.
-pub comptime fn public(f: FunctionDefinition) -> Quoted {
+comptime fn public(f: FunctionDefinition) -> Quoted {
+    // We need to add this attribute to be able to identify if the function is external public when constructing
+    // the contract artifact.
+    f.add_attribute("public");
+
     // We don't want to transform the public_dispatch function.
     if f.name() == quote { public_dispatch } {
         quote {}
     } else {
-        if is_fn_private(f) | is_fn_utility(f) {
-            let name = f.name();
-            panic(
-                f"A function marked as #[public] cannot also be #[private] or #[utility] - {name} is more than one of these",
-            );
-        }
-
         let visibility = f.visibility();
         if visibility != quote {} {
             let name = f.name();
             panic(
-                f"A function marked as #[public] must not have public Noir visibility - {name}'s visibility is '{visibility}'",
+                f"A function marked as #[external(\"public\")] must not have public Noir visibility - {name}'s visibility is '{visibility}'",
             );
         }
 
         if f.is_unconstrained() {
             let name = f.name();
-            panic(f"#[public] functions must not be unconstrained - {name} is");
+            panic(
+                f"#[external(\"public\")] functions must not be unconstrained - {name} is",
+            );
         }
 
         // The abi export function is expected to be executed before the function is transformed.
@@ -178,26 +218,27 @@ pub comptime fn public(f: FunctionDefinition) -> Quoted {
 /// Utility functions are standalone unconstrained functions that cannot be called from another function in a contract.
 /// They are typically used either to obtain some information from the contract (e.g. token balance of a user) or to
 /// modify internal contract-related state of PXE (e.g. processing logs in Aztec.nr during sync).
-pub comptime fn utility(f: FunctionDefinition) -> Quoted {
-    if is_fn_private(f) | is_fn_public(f) {
-        let name = f.name();
-        panic(
-            f"A function marked as #[utility] cannot also be #[private] or #[public] - {name} is more than one of these",
-        );
-    }
+comptime fn utility(f: FunctionDefinition) -> Quoted {
+    // We need to add this attribute to be able to identify if the function is external utility when constructing
+    // the contract artifact.
+    f.add_attribute("utility");
 
     let visibility = f.visibility();
     if visibility != quote {} {
         let name = f.name();
         panic(
-            f"A function marked as #[utility] must not have public Noir visibility - {name}'s visibility is '{visibility}'",
+            f"A function marked as #[external(\"utility\")] must not have public Noir visibility - {name}'s visibility is '{visibility}'",
         );
     }
 
     if !f.is_unconstrained() {
         let name = f.name();
-        panic(f"#[utility] must be unconstrained - {name} isn't");
+        panic(
+            f"#[external(\"utility\")] must be unconstrained - {name} isn't",
+        );
     }
+
+    post_external_utility_checks(f);
 
     // The abi export function is expected to be executed before the function is transformed.
     let fn_abi_export = create_fn_abi_export(f);
@@ -205,4 +246,46 @@ pub comptime fn utility(f: FunctionDefinition) -> Quoted {
     transform_utility(f);
 
     fn_abi_export
+}
+
+/// Utility functions cannot be used with the following modifiers: #[authorize_once], #[internal], #[view],
+/// #[initializer], and #[noinitcheck]. Since we cannot enforce a specific ordering between these modifiers and
+/// #[external(...)], and we cannot access the #[external(...)] argument from within these modifiers' implementations
+/// (as accessing EXTERNAL_REGISTRY would require enforcing ordering), we perform these compatibility checks here in
+/// the utility macro.
+comptime fn post_external_utility_checks(f: FunctionDefinition) {
+    if AUTHORIZE_ONCE_REGISTRY.get(f).is_some() {
+        let name = f.name();
+        panic(
+            f"The #[authorize_once] attribute cannot be applied to #[external(\"utility\")] functions - {name}",
+        );
+    }
+
+    if is_fn_internal(f) {
+        let name = f.name();
+        panic(
+            f"The #[internal] attribute cannot be applied to #[external(\"utility\")] functions - {name}",
+        );
+    }
+
+    if is_fn_view(f) {
+        let name = f.name();
+        panic(
+            f"The #[view] attribute cannot be applied to #[external(\"utility\")] functions - {name}",
+        );
+    }
+
+    if is_fn_initializer(f) {
+        let name = f.name();
+        panic(
+            f"The #[initializer] attribute cannot be applied to #[external(\"utility\")] functions - {name}",
+        );
+    }
+
+    if fn_has_noinitcheck(f) {
+        let name = f.name();
+        panic(
+            f"The #[noinitcheck] attribute cannot be applied to #[external(\"utility\")] functions - {name}",
+        );
+    }
 }

--- a/noir-projects/aztec-nr/aztec/src/macros/functions/utils.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/functions/utils.nr
@@ -5,8 +5,8 @@ use crate::macros::{
     notes::NOTES,
     utils::{
         fn_has_authorize_once, fn_has_noinitcheck, get_fn_visibility, is_fn_contract_library_method,
-        is_fn_initializer, is_fn_internal, is_fn_private, is_fn_public, is_fn_test, is_fn_utility,
-        is_fn_view, modify_fn_body, module_has_initializer, module_has_storage,
+        is_fn_external, is_fn_initializer, is_fn_internal, is_fn_private, is_fn_test, is_fn_view,
+        modify_fn_body, module_has_initializer, module_has_storage,
     },
 };
 use dep::protocol_types::meta::utils::derive_serialization_quotes;
@@ -377,7 +377,7 @@ pub(crate) comptime fn create_authorize_once_check(f: FunctionDefinition) -> Quo
         // We need to for authorize_once to have already executed so that we can retrieve its params - this depends on
         // the order in which the attributes are applied.
         panic(
-            f"Functions marked with #[authorize_once] must have the #[private] or #[public] attribute placed last",
+            f"Functions marked with #[authorize_once] must have the #[external(\"private\")] or #[external(\"public\")] attribute placed last",
         )
     };
 
@@ -437,18 +437,14 @@ pub(crate) comptime fn create_authorize_once_check(f: FunctionDefinition) -> Quo
     }
 }
 
-/// Checks if each function in the module is marked with either #[private], #[public], #[utility],
-/// #[contract_library_method], or #[test]. Non-macroified functions are not allowed in contracts.
+/// Checks if each function in the module is marked with either #[external(...)], #[contract_library_method], or #[test].
+/// Non-macroified functions are not allowed in contracts.
 pub(crate) comptime fn check_each_fn_macroified(m: Module) {
     for f in m.functions() {
         let name = f.name();
-        if !is_fn_private(f)
-            & !is_fn_public(f)
-            & !is_fn_utility(f)
-            & !is_fn_contract_library_method(f)
-            & !is_fn_test(f) {
+        if !is_fn_external(f) & !is_fn_contract_library_method(f) & !is_fn_test(f) {
             panic(
-                f"Function {name} must be marked as either #[private], #[public], #[utility], #[contract_library_method], or #[test]",
+                f"Function {name} must be marked as either #[external(...)], #[contract_library_method], or #[test]",
             );
         }
     }

--- a/noir-projects/aztec-nr/aztec/src/macros/utils.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/utils.nr
@@ -1,26 +1,43 @@
+use crate::macros::functions::external_registry;
 use dep::protocol_types::meta::derive_serialize;
 use std::meta::unquote;
 
 pub(crate) comptime fn get_fn_visibility(f: FunctionDefinition) -> Quoted {
-    if f.has_named_attribute("private") {
-        quote { private }
-    } else if f.has_named_attribute("public") {
-        quote { public }
+    let maybe_external_type = external_registry::get(f);
+    if maybe_external_type.is_some() {
+        let external_type = maybe_external_type.unwrap();
+        if external_type.eq("private") {
+            quote { private }
+        } else if external_type.eq("public") {
+            quote { public }
+        } else {
+            panic(f"Function is neither private nor public")
+        }
     } else {
         panic(f"Function is neither private nor public")
     }
 }
 
+pub(crate) comptime fn is_fn_external(f: FunctionDefinition) -> bool {
+    f.has_named_attribute("external")
+}
+
 pub(crate) comptime fn is_fn_private(f: FunctionDefinition) -> bool {
-    f.has_named_attribute("private")
+    let maybe_external_type = external_registry::get(f);
+    if maybe_external_type.is_some() {
+        maybe_external_type.unwrap_unchecked().eq("private")
+    } else {
+        false
+    }
 }
 
 pub(crate) comptime fn is_fn_public(f: FunctionDefinition) -> bool {
-    f.has_named_attribute("public")
-}
-
-pub(crate) comptime fn is_fn_utility(f: FunctionDefinition) -> bool {
-    f.has_named_attribute("utility")
+    let maybe_external_type = external_registry::get(f);
+    if maybe_external_type.is_some() {
+        maybe_external_type.unwrap_unchecked().eq("public")
+    } else {
+        false
+    }
 }
 
 pub(crate) comptime fn is_fn_contract_library_method(f: FunctionDefinition) -> bool {

--- a/noir-projects/aztec-nr/aztec/src/state_vars/private_mutable.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/private_mutable.nr
@@ -19,7 +19,7 @@ mod test;
 /// # PrivateMutable
 ///
 /// PrivateMutable is a private state variable type, which enables you to read, mutate,
-/// and write private state within the #[private] functions of your smart contract.
+/// and write private state within the #[external("private")] functions of your smart contract.
 ///
 /// You can declare a state variable of type PrivateMutable within your contract's
 /// #[storage] struct:

--- a/noir-projects/aztec-nr/aztec/src/state_vars/private_set.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/private_set.nr
@@ -18,7 +18,7 @@ mod test;
 /// # PrivateSet
 ///
 /// PrivateSet is a private state variable type, which enables you to read, mutate,
-/// and write private state within the #[private] functions of your smart contract.
+/// and write private state within the #[external("private")] functions of your smart contract.
 ///
 /// You can declare a state variable of type PrivateSet within your contract's
 /// #[storage] struct:

--- a/noir-projects/aztec-nr/aztec/src/state_vars/public_mutable.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/public_mutable.nr
@@ -5,7 +5,7 @@ use dep::protocol_types::traits::Packable;
 /// # PublicMutable
 ///
 /// PublicMutable is a public state variable type for values that can be read
-/// and written within #[public] functions of your smart contract.
+/// and written within #[external("public")] functions of your smart contract.
 ///
 /// You can declare a state variable of type PublicMutable within your contract's
 /// #[storage] struct:

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/utils.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/utils.nr
@@ -23,7 +23,7 @@ impl<let N: u32> ContractDeployment<N> {
     /// `interface()` with its arguments:
     /// ```noir
     /// contract MyContract {
-    ///   #[private]
+    ///   #[external("private")]
     ///   #[initializer]
     ///   fn init_fn(owner: AztecAddress) { ... }
     /// }
@@ -75,7 +75,7 @@ impl<let N: u32> ContractDeployment<N> {
     /// `interface()` with its arguments:
     /// ```noir
     /// contract MyContract {
-    ///   #[public]
+    ///   #[external("public")]
     ///   #[initializer]
     ///   fn init_fn(owner: AztecAddress) { ... }
     /// }

--- a/noir-projects/aztec-nr/macro_compilation_failure_tests/failure_contracts/marked_private_unconstrained/src/main.nr
+++ b/noir-projects/aztec-nr/macro_compilation_failure_tests/failure_contracts/marked_private_unconstrained/src/main.nr
@@ -5,10 +5,10 @@ use aztec::macros::aztec;
 
 #[aztec]
 contract MarkedPrivateUnconstrained {
-    use aztec::macros::functions::private;
+    use aztec::macros::functions::external;
 
 
-    #[private]
+    #[external("private")]
     unconstrained fn unconstrained_private_function() {}
 }
 

--- a/noir-projects/aztec-nr/macro_compilation_failure_tests/failure_contracts/marked_public_unconstrained/src/main.nr
+++ b/noir-projects/aztec-nr/macro_compilation_failure_tests/failure_contracts/marked_public_unconstrained/src/main.nr
@@ -5,10 +5,10 @@ use aztec::macros::aztec;
 
 #[aztec]
 contract MarkedPublicUnconstrained {
-    use aztec::macros::functions::public;
+    use aztec::macros::functions::external;
 
 
-    #[public]
+    #[external("public")]
     unconstrained fn unconstrained_public_function() {}
 }
 

--- a/noir-projects/noir-contracts-comp-failures/contracts/invalid_external_function_type/Nargo.toml
+++ b/noir-projects/noir-contracts-comp-failures/contracts/invalid_external_function_type/Nargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "invalid_external_function_type"
+authors = [""]
+compiler_version = ">=0.25.0"
+type = "contract"
+
+[dependencies]
+aztec = { path = "../../../aztec-nr/aztec" }

--- a/noir-projects/noir-contracts-comp-failures/contracts/invalid_external_function_type/expected_error
+++ b/noir-projects/noir-contracts-comp-failures/contracts/invalid_external_function_type/expected_error
@@ -1,0 +1,1 @@
+Function 'invalid_external_function_type' is marked as #[external("invalid")], but 'invalid' is not a valid external function type. External functions must be one of 'private', 'public' or 'utility'

--- a/noir-projects/noir-contracts-comp-failures/contracts/invalid_external_function_type/src/main.nr
+++ b/noir-projects/noir-contracts-comp-failures/contracts/invalid_external_function_type/src/main.nr
@@ -1,0 +1,9 @@
+use aztec::macros::aztec;
+
+#[aztec]
+pub contract InvalidExternalFunctionType {
+    use aztec::macros::functions::external;
+
+    #[external("invalid")]
+    fn invalid_external_function_type() {}
+}

--- a/noir-projects/noir-contracts-comp-failures/contracts/public_function_selector_collision/src/main.nr
+++ b/noir-projects/noir-contracts-comp-failures/contracts/public_function_selector_collision/src/main.nr
@@ -3,11 +3,11 @@ use aztec::macros::aztec;
 /// This contract is used to test that the compile-time public function selector collision detection works.
 #[aztec]
 pub contract PublicFunctionSelectorCollision {
-    use aztec::macros::functions::public;
+    use aztec::macros::functions::external;
 
-    #[public]
+    #[external("public")]
     fn fn_selector_collision() {}
 
-    #[public]
+    #[external("public")]
     fn fn_selector_collision_1442740381() {}
 }

--- a/noir-projects/noir-contracts/contracts/account/ecdsa_k_account_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/account/ecdsa_k_account_contract/src/main.nr
@@ -7,7 +7,7 @@ pub contract EcdsaKAccount {
     use dep::aztec::{
         authwit::{account::AccountActions, entrypoint::app::AppPayload},
         context::PrivateContext,
-        macros::{functions::{initializer, noinitcheck, private, view}, storage::storage},
+        macros::{functions::{external, initializer, noinitcheck, view}, storage::storage},
         messages::message_delivery::MessageDelivery,
         oracle::{auth_witness::get_auth_witness, notes::{get_sender_for_tags, set_sender_for_tags}},
         state_vars::PrivateImmutable,
@@ -21,7 +21,7 @@ pub contract EcdsaKAccount {
     }
 
     // Creates a new account out of an ECDSA public key to use for signature verification
-    #[private]
+    #[external("private")]
     #[initializer]
     fn constructor(signing_pub_key_x: [u8; 32], signing_pub_key_y: [u8; 32]) {
         let this = context.this_address();
@@ -51,7 +51,7 @@ pub contract EcdsaKAccount {
 
     // @dev: If you globally change the entrypoint signature don't forget to update account_entrypoint.ts file (specifically `getEntrypointAbi()`)
     // using noinitcheck is an optimization, it reduces gates by omitting a check that the contract has been initialized
-    #[private]
+    #[external("private")]
     #[noinitcheck]
     fn entrypoint(app_payload: AppPayload, fee_payment_method: u8, cancellable: bool) {
         // Safety: The sender for tags is only used to compute unconstrained shared secrets for emitting logs.
@@ -63,7 +63,7 @@ pub contract EcdsaKAccount {
         actions.entrypoint(app_payload, fee_payment_method, cancellable);
     }
 
-    #[private]
+    #[external("private")]
     #[noinitcheck]
     #[view]
     fn verify_private_authwit(inner_hash: Field) -> Field {

--- a/noir-projects/noir-contracts/contracts/account/ecdsa_r_account_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/account/ecdsa_r_account_contract/src/main.nr
@@ -6,7 +6,7 @@ pub contract EcdsaRAccount {
     use dep::aztec::{
         authwit::{account::AccountActions, entrypoint::app::AppPayload},
         context::PrivateContext,
-        macros::{functions::{initializer, noinitcheck, private, view}, storage::storage},
+        macros::{functions::{external, initializer, noinitcheck, view}, storage::storage},
         messages::message_delivery::MessageDelivery,
         oracle::{auth_witness::get_auth_witness, notes::{get_sender_for_tags, set_sender_for_tags}},
         state_vars::PrivateImmutable,
@@ -20,7 +20,7 @@ pub contract EcdsaRAccount {
     }
 
     // Creates a new account out of an ECDSA public key to use for signature verification
-    #[private]
+    #[external("private")]
     #[initializer]
     fn constructor(signing_pub_key_x: [u8; 32], signing_pub_key_y: [u8; 32]) {
         let this = context.this_address();
@@ -50,7 +50,7 @@ pub contract EcdsaRAccount {
 
     // @dev: If you globally change the entrypoint signature don't forget to update account_entrypoint.ts file (specifically `getEntrypointAbi()`)
     // using noinitcheck is an optimization, it reduces gates by omitting a check that the contract has been initialized
-    #[private]
+    #[external("private")]
     #[noinitcheck]
     fn entrypoint(app_payload: AppPayload, fee_payment_method: u8, cancellable: bool) {
         // Safety: The sender for tags is only used to compute unconstrained shared secrets for emitting logs.
@@ -62,7 +62,7 @@ pub contract EcdsaRAccount {
         actions.entrypoint(app_payload, fee_payment_method, cancellable);
     }
 
-    #[private]
+    #[external("private")]
     #[noinitcheck]
     #[view]
     fn verify_private_authwit(inner_hash: Field) -> Field {

--- a/noir-projects/noir-contracts/contracts/account/schnorr_account_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/account/schnorr_account_contract/src/main.nr
@@ -14,7 +14,7 @@ pub contract SchnorrAccount {
         },
         context::PrivateContext,
         hash::compute_siloed_nullifier,
-        macros::{functions::{initializer, noinitcheck, private, utility, view}, storage::storage},
+        macros::{functions::{external, initializer, noinitcheck, view}, storage::storage},
         messages::message_delivery::MessageDelivery,
         oracle::{
             auth_witness::get_auth_witness,
@@ -35,7 +35,7 @@ pub contract SchnorrAccount {
     }
 
     // Constructs the contract
-    #[private]
+    #[external("private")]
     #[initializer]
     fn constructor(signing_pub_key_x: Field, signing_pub_key_y: Field) {
         let this = context.this_address();
@@ -65,7 +65,7 @@ pub contract SchnorrAccount {
 
     // @dev: If you globally change the entrypoint signature don't forget to update account_entrypoint.ts file (specifically `getEntrypointAbi()`).
     // using noinitcheck is an optimization, it reduces gates by omitting a check that the contract has been initialized
-    #[private]
+    #[external("private")]
     #[noinitcheck]
     fn entrypoint(app_payload: AppPayload, fee_payment_method: u8, cancellable: bool) {
         // Safety: The sender for tags is only used to compute unconstrained shared secrets for emitting logs.
@@ -77,7 +77,7 @@ pub contract SchnorrAccount {
         actions.entrypoint(app_payload, fee_payment_method, cancellable);
     }
 
-    #[private]
+    #[external("private")]
     #[noinitcheck]
     #[view]
     fn verify_private_authwit(inner_hash: Field) -> Field {
@@ -117,7 +117,7 @@ pub contract SchnorrAccount {
     * @param message_hash The message hash of the message to check the validity
     * @return True if the message_hash can be consumed, false otherwise
     */
-    #[utility]
+    #[external("utility")]
     unconstrained fn lookup_validity(consumer: AztecAddress, inner_hash: Field) -> bool {
         let public_key = storage.signing_public_key.view_note();
 

--- a/noir-projects/noir-contracts/contracts/account/schnorr_hardcoded_account_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/account/schnorr_hardcoded_account_contract/src/main.nr
@@ -6,7 +6,7 @@ pub contract SchnorrHardcodedAccount {
     use dep::aztec::{
         authwit::{account::AccountActions, entrypoint::app::AppPayload},
         context::PrivateContext,
-        macros::functions::{private, view},
+        macros::functions::{external, view},
         oracle::{auth_witness::get_auth_witness, notes::set_sender_for_tags},
     };
     use std::embedded_curve_ops::EmbeddedCurvePoint;
@@ -18,7 +18,7 @@ pub contract SchnorrHardcodedAccount {
     };
 
     // @dev: If you globally change the entrypoint signature don't forget to update account_entrypoint.ts (specifically `getEntrypointAbi()`)
-    #[private]
+    #[external("private")]
     fn entrypoint(app_payload: AppPayload, fee_payment_method: u8, cancellable: bool) {
         // Safety: The sender for tags is only used to compute unconstrained shared secrets for emitting logs.
         // Since this value is only used for unconstrained tagging and not for any constrained logic,
@@ -29,7 +29,7 @@ pub contract SchnorrHardcodedAccount {
         actions.entrypoint(app_payload, fee_payment_method, cancellable);
     }
 
-    #[private]
+    #[external("private")]
     #[view]
     fn verify_private_authwit(inner_hash: Field) -> Field {
         let actions = AccountActions::init(&mut context, is_valid_impl);

--- a/noir-projects/noir-contracts/contracts/account/schnorr_single_key_account_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/account/schnorr_single_key_account_contract/src/main.nr
@@ -13,10 +13,10 @@ pub contract SchnorrSingleKeyAccount {
 
     use crate::{auth_oracle::get_auth_witness, util::recover_address};
 
-    use dep::aztec::macros::functions::{private, view};
+    use dep::aztec::macros::functions::{external, view};
 
     // @dev: If you globally change the entrypoint signature don't forget to update account_entrypoint.ts (specifically `getEntrypointAbi()`)
-    #[private]
+    #[external("private")]
     fn entrypoint(app_payload: AppPayload, fee_payment_method: u8, cancellable: bool) {
         // Safety: The sender for tags is only used to compute unconstrained shared secrets for emitting logs.
         // Since this value is only used for unconstrained tagging and not for any constrained logic,
@@ -27,7 +27,7 @@ pub contract SchnorrSingleKeyAccount {
         actions.entrypoint(app_payload, fee_payment_method, cancellable);
     }
 
-    #[private]
+    #[external("private")]
     #[view]
     fn verify_private_authwit(inner_hash: Field) -> Field {
         let actions = AccountActions::init(&mut context, is_valid_impl);

--- a/noir-projects/noir-contracts/contracts/account/simulated_account_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/account/simulated_account_contract/src/main.nr
@@ -11,12 +11,12 @@ pub contract SimulatedAccount {
     use dep::aztec::{
         authwit::{account::AccountActions, auth::IS_VALID_SELECTOR, entrypoint::app::AppPayload},
         context::PrivateContext,
-        macros::functions::{private, utility, view},
+        macros::functions::{external, view},
         oracle::notes::set_sender_for_tags,
     };
 
     // @dev: If you globally change the entrypoint signature don't forget to update account_entrypoint.ts (specifically `getEntrypointAbi()`)
-    #[private]
+    #[external("private")]
     fn entrypoint(app_payload: AppPayload, fee_payment_method: u8, cancellable: bool) {
         // Safety: The sender for tags is only used to compute unconstrained shared secrets for emitting logs.
         // Since this value is only used for unconstrained tagging and not for any constrained logic,
@@ -27,7 +27,7 @@ pub contract SimulatedAccount {
         actions.entrypoint(app_payload, fee_payment_method, cancellable);
     }
 
-    #[private]
+    #[external("private")]
     #[view]
     fn verify_private_authwit(inner_hash: Field) -> Field {
         IS_VALID_SELECTOR
@@ -41,6 +41,6 @@ pub contract SimulatedAccount {
     /// Since this contract normally emulates an account that uses a note to store the public key,
     /// we completely bypass message discovery here to avoid losing time on useless processing
     /// and also enabling the emulation of different accounts with differently sized public key notes.
-    #[utility]
+    #[external("utility")]
     unconstrained fn sync_private_state() {}
 }

--- a/noir-projects/noir-contracts/contracts/app/amm_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/amm_contract/src/main.nr
@@ -40,7 +40,7 @@ pub contract AMM {
         lib::{get_amount_in, get_amount_out, get_amounts_on_remove, get_amounts_to_add},
     };
     use dep::aztec::{
-        macros::{functions::{initializer, internal, private, public, utility}, storage::storage},
+        macros::{functions::{external, initializer, internal}, storage::storage},
         protocol_types::address::AztecAddress,
         state_vars::PublicImmutable,
     };
@@ -61,7 +61,7 @@ pub contract AMM {
 
     // TODO(#9480): Either deploy the liquidity contract in the constructor or verify it that it corresponds to what
     // this contract expects (i.e. that the AMM has permission to mint and burn).
-    #[public]
+    #[external("public")]
     #[initializer]
     fn constructor(token0: AztecAddress, token1: AztecAddress, liquidity_token: AztecAddress) {
         storage.config.initialize(Config { token0, token1, liquidity_token });
@@ -75,7 +75,7 @@ pub contract AMM {
     /// specific call.
     ///
     /// The identity of the liquidity provider is not revealed, but the action and amounts are.
-    #[private]
+    #[external("private")]
     fn add_liquidity(
         amount0_max: u128,
         amount1_max: u128,
@@ -145,7 +145,7 @@ pub contract AMM {
             .enqueue(&mut context);
     }
 
-    #[public]
+    #[external("public")]
     #[internal]
     fn _add_liquidity(
         config: Config, // We could read this in public, but it's cheaper to receive from private
@@ -239,7 +239,7 @@ pub contract AMM {
     /// specific call.
     ///
     /// The identity of the liquidity provider is not revealed, but the action and amounts are.
-    #[private]
+    #[external("private")]
     fn remove_liquidity(
         liquidity: u128,
         amount0_min: u128,
@@ -284,7 +284,7 @@ pub contract AMM {
             .enqueue(&mut context);
     }
 
-    #[public]
+    #[external("public")]
     #[internal]
     fn _remove_liquidity(
         config: Config, // We could read this in public, but it's cheaper to receive from private
@@ -323,7 +323,7 @@ pub contract AMM {
     /// specific call.
     ///
     /// The identity of the swapper is not revealed, but the action and amounts are.
-    #[private]
+    #[external("private")]
     fn swap_exact_tokens_for_tokens(
         token_in: AztecAddress,
         token_out: AztecAddress,
@@ -358,7 +358,7 @@ pub contract AMM {
             .enqueue(&mut context);
     }
 
-    #[public]
+    #[external("public")]
     #[internal]
     fn _swap_exact_tokens_for_tokens(
         token_in: AztecAddress,
@@ -392,7 +392,7 @@ pub contract AMM {
     /// specific call.
     ///
     /// The identity of the swapper is not revealed, but the action and amounts are.
-    #[private]
+    #[external("private")]
     fn swap_tokens_for_exact_tokens(
         token_in: AztecAddress,
         token_out: AztecAddress,
@@ -438,7 +438,7 @@ pub contract AMM {
             .enqueue(&mut context);
     }
 
-    #[public]
+    #[external("public")]
     #[internal]
     fn _swap_tokens_for_exact_tokens(
         token_in: AztecAddress,
@@ -476,7 +476,7 @@ pub contract AMM {
         );
     }
 
-    #[utility]
+    #[external("utility")]
     unconstrained fn get_amount_out_for_exact_in(
         balance_in: u128,
         balance_out: u128,
@@ -486,7 +486,7 @@ pub contract AMM {
         get_amount_out(amount_in, balance_in, balance_out)
     }
 
-    #[utility]
+    #[external("utility")]
     unconstrained fn get_amount_in_for_exact_out(
         balance_in: u128,
         balance_out: u128,

--- a/noir-projects/noir-contracts/contracts/app/app_subscription_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/app_subscription_contract/src/main.nr
@@ -44,7 +44,7 @@ pub contract AppSubscription {
 
     use aztec::{
         authwit::auth::assert_current_call_valid_authwit,
-        macros::{functions::{initializer, private, public, utility}, storage::storage},
+        macros::{functions::{external, initializer}, storage::storage},
         messages::message_delivery::MessageDelivery,
         oracle::notes::set_sender_for_tags,
         protocol_types::address::AztecAddress,
@@ -63,7 +63,7 @@ pub contract AppSubscription {
     global SUBSCRIPTION_DURATION_IN_BLOCKS: u32 = 5;
     global SUBSCRIPTION_TXS: u32 = 5;
 
-    #[private]
+    #[external("private")]
     fn entrypoint(payload: DAppPayload, user_address: AztecAddress) {
         // Safety: The sender for tags is only used to compute unconstrained shared secrets for emitting logs.
         // Since this value is only used for unconstrained tagging and not for any constrained logic,
@@ -104,7 +104,7 @@ pub contract AppSubscription {
         payload.execute_calls(&mut context, config.target_address);
     }
 
-    #[public]
+    #[external("public")]
     #[initializer]
     fn constructor(
         target_address: AztecAddress,
@@ -124,7 +124,7 @@ pub contract AppSubscription {
         );
     }
 
-    #[private]
+    #[external("private")]
     fn subscribe(
         subscriber: AztecAddress,
         authwit_nonce: Field,
@@ -161,7 +161,7 @@ pub contract AppSubscription {
             .emit(&mut context, subscriber, MessageDelivery.CONSTRAINED_ONCHAIN);
     }
 
-    #[utility]
+    #[external("utility")]
     unconstrained fn is_initialized(subscriber: AztecAddress) -> bool {
         storage.subscriptions.at(subscriber).is_initialized()
     }

--- a/noir-projects/noir-contracts/contracts/app/auth_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/auth_contract/src/main.nr
@@ -7,7 +7,7 @@ use dep::aztec::macros::aztec;
 #[aztec]
 pub contract Auth {
     use dep::aztec::{
-        macros::{functions::{initializer, private, public, view}, storage::storage},
+        macros::{functions::{external, initializer, view}, storage::storage},
         protocol_types::address::AztecAddress,
         state_vars::{DelayedPublicMutable, PublicImmutable},
     };
@@ -22,45 +22,45 @@ pub contract Auth {
         authorized: DelayedPublicMutable<AztecAddress, CHANGE_AUTHORIZED_DELAY, Context>,
     }
 
-    #[public]
+    #[external("public")]
     #[initializer]
     fn constructor(admin: AztecAddress) {
         assert(!admin.is_zero(), "invalid admin");
         storage.admin.initialize(admin);
     }
 
-    #[public]
+    #[external("public")]
     fn set_authorized(authorized: AztecAddress) {
         assert_eq(storage.admin.read(), context.msg_sender().unwrap(), "caller is not admin");
         storage.authorized.schedule_value_change(authorized);
     }
 
     // docs:start:public_getter
-    #[public]
+    #[external("public")]
     #[view]
     fn get_authorized() -> AztecAddress {
         storage.authorized.get_current_value()
     }
     // docs:end:public_getter
 
-    #[public]
+    #[external("public")]
     #[view]
     fn get_scheduled_authorized() -> (AztecAddress, u64) {
         storage.authorized.get_scheduled_value()
     }
 
-    #[public]
+    #[external("public")]
     #[view]
     fn get_authorized_delay() -> pub u64 {
         storage.authorized.get_current_delay()
     }
 
-    #[public]
+    #[external("public")]
     fn set_authorized_delay(new_delay: u64) {
         storage.authorized.schedule_delay_change(new_delay);
     }
 
-    #[private]
+    #[external("private")]
     fn do_private_authorized_thing() {
         // Reading a value from authorized in private automatically adds an extra validity condition: the base rollup
         // circuit will reject this tx if timestamp of the block being built is past the time horizon of
@@ -70,7 +70,7 @@ pub contract Auth {
         assert_eq(authorized, context.msg_sender().unwrap(), "caller is not authorized");
     }
 
-    #[private]
+    #[external("private")]
     #[view]
     fn get_authorized_in_private() -> AztecAddress {
         storage.authorized.get_current_value()

--- a/noir-projects/noir-contracts/contracts/app/card_game_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/card_game_contract/src/main.nr
@@ -12,7 +12,7 @@ pub contract CardGame {
 
     use crate::cards::{Card, compute_deck_strength, Deck, get_pack_cards};
     use crate::game::{Game, PLAYABLE_CARDS, PlayerEntry};
-    use dep::aztec::macros::{functions::{internal, private, public, utility}, storage::storage};
+    use dep::aztec::macros::{functions::{external, internal}, storage::storage};
 
     use dep::aztec::protocol_types::traits::{FromField, ToField};
 
@@ -23,7 +23,7 @@ pub contract CardGame {
         games: Map<Field, PublicMutable<Game, Context>, Context>,
     }
 
-    #[private]
+    #[external("private")]
     fn buy_pack(
         seed: Field, // The randomness used to generate the cards. Passed in for now.
     ) {
@@ -34,7 +34,7 @@ pub contract CardGame {
         let _inserted_cards = collection.add_cards(cards, buyer);
     }
 
-    #[private]
+    #[external("private")]
     fn join_game(game: u32, cards_fields: [Field; 2]) {
         let cards = cards_fields.map(|card_field| Card::from_field(card_field));
 
@@ -50,7 +50,7 @@ pub contract CardGame {
         );
     }
 
-    #[public]
+    #[external("public")]
     #[internal]
     fn on_game_joined(game: u32, player: AztecAddress, deck_strength: u32) {
         let game_storage = storage.games.at(game as Field);
@@ -64,7 +64,7 @@ pub contract CardGame {
         game_storage.write(game_data);
     }
 
-    #[public]
+    #[external("public")]
     fn start_game(game: u32) {
         let game_storage = storage.games.at(game as Field);
 
@@ -73,7 +73,7 @@ pub contract CardGame {
         game_storage.write(game_data);
     }
 
-    #[private]
+    #[external("private")]
     fn play_card(game: u32, card: Card) {
         let player = context.msg_sender().unwrap();
 
@@ -85,7 +85,7 @@ pub contract CardGame {
         );
     }
 
-    #[public]
+    #[external("public")]
     #[internal]
     fn on_card_played(game: u32, player: AztecAddress, card_as_field: Field) {
         let game_storage = storage.games.at(game as Field);
@@ -100,7 +100,7 @@ pub contract CardGame {
         game_storage.write(game_data);
     }
 
-    #[private]
+    #[external("private")]
     fn claim_cards(game: u32, cards_fields: [Field; PLAYABLE_CARDS]) {
         let player = context.msg_sender().unwrap();
         let cards = cards_fields.map(|card_field| Card::from_field(card_field));
@@ -112,7 +112,7 @@ pub contract CardGame {
             .enqueue(&mut context);
     }
 
-    #[public]
+    #[external("public")]
     #[internal]
     fn on_cards_claimed(game: u32, player: AztecAddress, cards_hash: Field) {
         let game_storage = storage.games.at(game as Field);
@@ -132,7 +132,7 @@ pub contract CardGame {
         game_storage.write(game_data);
     }
 
-    #[utility]
+    #[external("utility")]
     unconstrained fn view_collection_cards(
         owner: AztecAddress,
         offset: u32,
@@ -141,7 +141,7 @@ pub contract CardGame {
         collection.view_cards(offset)
     }
 
-    #[utility]
+    #[external("utility")]
     unconstrained fn view_game_cards(
         game: u32,
         player: AztecAddress,
@@ -152,7 +152,7 @@ pub contract CardGame {
         game_deck.view_cards(offset)
     }
 
-    #[utility]
+    #[external("utility")]
     unconstrained fn view_game(game: u32) -> Game {
         storage.games.at(game as Field).read()
     }

--- a/noir-projects/noir-contracts/contracts/app/claim_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/claim_contract/src/main.nr
@@ -4,7 +4,7 @@ use dep::aztec::macros::aztec;
 pub contract Claim {
     use dep::aztec::{
         history::note_inclusion::ProveNoteInclusion,
-        macros::{functions::{initializer, private, public}, storage::storage},
+        macros::{functions::{external, initializer}, storage::storage},
         note::{
             note_interface::NoteHash, retrieved_note::RetrievedNote,
             utils::compute_note_hash_for_nullification,
@@ -25,14 +25,14 @@ pub contract Claim {
         reward_token: PublicImmutable<AztecAddress, Context>,
     }
 
-    #[public]
+    #[external("public")]
     #[initializer]
     fn constructor(target_contract: AztecAddress, reward_token: AztecAddress) {
         storage.target_contract.initialize(target_contract);
         storage.reward_token.initialize(reward_token);
     }
 
-    #[private]
+    #[external("private")]
     fn claim(proof_retrieved_note: RetrievedNote<UintNote>, recipient: AztecAddress) {
         // 1) Check that the note corresponds to the target contract and belongs to the sender
         let target_address = storage.target_contract.read();

--- a/noir-projects/noir-contracts/contracts/app/crowdfunding_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/crowdfunding_contract/src/main.nr
@@ -7,11 +7,7 @@ pub contract Crowdfunding {
     use crate::config::Config;
     use aztec::{
         event::event_emission::emit_event_in_public,
-        macros::{
-            events::event,
-            functions::{initializer, internal, private, public, utility},
-            storage::storage,
-        },
+        macros::{events::event, functions::{external, initializer, internal}, storage::storage},
         messages::message_delivery::MessageDelivery,
         protocol_types::address::AztecAddress,
         state_vars::{Map, PrivateSet, PublicImmutable, storage::HasStorageSlot},
@@ -40,14 +36,14 @@ pub contract Crowdfunding {
     // docs:end:storage
 
     // TODO(#8367): Ensure deadline is quantized to improve privacy set.
-    #[public]
+    #[external("public")]
     #[initializer]
     // this-will-error:init-header-error
     fn init(donation_token: AztecAddress, operator: AztecAddress, deadline: u64) {
         storage.config.initialize(Config { donation_token, operator, deadline });
     }
 
-    #[private]
+    #[external("private")]
     fn donate(amount: u128) {
         let config = storage.config.read();
 
@@ -77,7 +73,7 @@ pub contract Crowdfunding {
     }
 
     // Withdraws balance to the operator. Requires that msg_sender() is the operator.
-    #[private]
+    #[external("private")]
     fn withdraw(amount: u128) {
         let config = storage.config.read();
         let operator_address = config.operator;
@@ -93,13 +89,13 @@ pub contract Crowdfunding {
             .enqueue(&mut context);
     }
 
-    #[public]
+    #[external("public")]
     #[internal]
     fn _publish_donation_receipts(amount: u128, to: AztecAddress) {
         emit_event_in_public(WithdrawalProcessed { amount, who: to }, &mut context);
     }
 
-    #[utility]
+    #[external("utility")]
     unconstrained fn get_donation_notes(
         donor: AztecAddress,
         page_index: u32,

--- a/noir-projects/noir-contracts/contracts/app/escrow_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/escrow_contract/src/main.nr
@@ -4,7 +4,7 @@ use aztec::macros::aztec;
 #[aztec]
 pub contract Escrow {
     use aztec::{
-        macros::{functions::{initializer, private}, storage::storage},
+        macros::{functions::{external, initializer}, storage::storage},
         messages::message_delivery::MessageDelivery,
         protocol_types::address::AztecAddress,
         state_vars::PrivateImmutable,
@@ -19,7 +19,7 @@ pub contract Escrow {
     }
 
     // Creates a new instance
-    #[private]
+    #[external("private")]
     #[initializer]
     fn constructor(owner: AztecAddress) {
         let note = AddressNote::new(owner, owner);
@@ -27,7 +27,7 @@ pub contract Escrow {
     }
 
     // Withdraws balance. Requires that msg.sender is the owner.
-    #[private]
+    #[external("private")]
     fn withdraw(token: AztecAddress, amount: u128, recipient: AztecAddress) {
         let sender = context.msg_sender().unwrap();
 

--- a/noir-projects/noir-contracts/contracts/app/lending_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/lending_contract/src/main.nr
@@ -23,10 +23,7 @@ pub contract Lending {
     use dep::price_feed::PriceFeed;
     use dep::token::Token;
 
-    use dep::aztec::macros::{
-        functions::{initializer, internal, private, public, view},
-        storage::storage,
-    };
+    use dep::aztec::macros::{functions::{external, initializer, internal, view}, storage::storage};
 
     use dep::aztec::protocol_types::traits::{FromField, ToField};
 
@@ -41,11 +38,11 @@ pub contract Lending {
     }
 
     // Constructs the contract.
-    #[private]
+    #[external("private")]
     #[initializer]
     fn constructor() {}
 
-    #[public]
+    #[external("public")]
     fn init(
         oracle: AztecAddress,
         loan_to_value: u128,
@@ -77,7 +74,7 @@ pub contract Lending {
     }
 
     // Create a position.
-    #[public]
+    #[external("public")]
     fn update_accumulator() -> Asset {
         let asset_loc = storage.assets.at(0);
         let mut asset: Asset = asset_loc.read();
@@ -102,7 +99,7 @@ pub contract Lending {
         asset
     }
 
-    #[private]
+    #[external("private")]
     fn deposit_private(
         from: AztecAddress,
         amount: u128,
@@ -126,7 +123,7 @@ pub contract Lending {
         // docs:end:enqueue_public
     }
 
-    #[public]
+    #[external("public")]
     fn deposit_public(
         amount: u128,
         authwit_nonce: Field,
@@ -146,7 +143,7 @@ pub contract Lending {
             .call(&mut context);
     }
 
-    #[public]
+    #[external("public")]
     #[internal]
     fn _deposit(owner: AztecAddress, amount: u128, collateral_asset: AztecAddress) {
         let _asset = Lending::at(context.this_address()).update_accumulator().call(&mut context);
@@ -159,7 +156,7 @@ pub contract Lending {
         coll_loc.write(collateral + amount);
     }
 
-    #[private]
+    #[external("private")]
     fn withdraw_private(secret: Field, to: AztecAddress, amount: u128) {
         let on_behalf_of = compute_identifier(secret, 0, context.msg_sender().unwrap().to_field());
         Lending::at(context.this_address())
@@ -167,14 +164,14 @@ pub contract Lending {
             .enqueue(&mut context);
     }
 
-    #[public]
+    #[external("public")]
     fn withdraw_public(to: AztecAddress, amount: u128) {
         let _ = Lending::at(context.this_address())
             ._withdraw(context.msg_sender().unwrap(), to, amount)
             .call(&mut context);
     }
 
-    #[public]
+    #[external("public")]
     #[internal]
     fn _withdraw(owner: AztecAddress, recipient: AztecAddress, amount: u128) {
         let asset = Lending::at(context.this_address()).update_accumulator().call(&mut context);
@@ -208,7 +205,7 @@ pub contract Lending {
             .call(&mut context);
     }
 
-    #[private]
+    #[external("private")]
     fn borrow_private(secret: Field, to: AztecAddress, amount: u128) {
         let on_behalf_of = compute_identifier(secret, 0, context.msg_sender().unwrap().to_field());
         let _ = Lending::at(context.this_address())
@@ -216,14 +213,14 @@ pub contract Lending {
             .enqueue(&mut context);
     }
 
-    #[public]
+    #[external("public")]
     fn borrow_public(to: AztecAddress, amount: u128) {
         let _ = Lending::at(context.this_address())
             ._borrow(context.msg_sender().unwrap(), to, amount)
             .call(&mut context);
     }
 
-    #[public]
+    #[external("public")]
     #[internal]
     fn _borrow(owner: AztecAddress, to: AztecAddress, amount: u128) {
         let asset = Lending::at(context.this_address()).update_accumulator().call(&mut context);
@@ -246,7 +243,7 @@ pub contract Lending {
         let _ = Token::at(stable_coin).mint_to_public(to, amount).call(&mut context);
     }
 
-    #[private]
+    #[external("private")]
     fn repay_private(
         from: AztecAddress,
         amount: u128,
@@ -268,7 +265,7 @@ pub contract Lending {
             .enqueue(&mut context);
     }
 
-    #[public]
+    #[external("public")]
     fn repay_public(
         amount: u128,
         authwit_nonce: Field,
@@ -283,7 +280,7 @@ pub contract Lending {
         );
     }
 
-    #[public]
+    #[external("public")]
     #[internal]
     fn _repay(owner: AztecAddress, amount: u128, stable_coin: AztecAddress) {
         let asset = Lending::at(context.this_address()).update_accumulator().call(&mut context);
@@ -297,13 +294,13 @@ pub contract Lending {
         storage.static_debt.at(owner).write(debt_returns.static_debt);
     }
 
-    #[public]
+    #[external("public")]
     #[view]
     fn get_asset(asset_id: Field) -> Asset {
         storage.assets.at(asset_id).read()
     }
 
-    #[public]
+    #[external("public")]
     #[view]
     fn get_position(owner: AztecAddress) -> pub Position {
         let collateral = storage.collateral.at(owner).read();
@@ -313,7 +310,7 @@ pub contract Lending {
         Position { collateral, static_debt, debt }
     }
 
-    #[public]
+    #[external("public")]
     #[view]
     fn get_assets() -> pub [AztecAddress; 2] {
         [storage.collateral_asset.read(), storage.stable_coin.read()]

--- a/noir-projects/noir-contracts/contracts/app/nft_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/nft_contract/src/main.nr
@@ -13,7 +13,7 @@ pub contract NFT {
         authwit::auth::compute_authwit_nullifier,
         context::{PrivateContext, PublicContext},
         macros::{
-            functions::{authorize_once, initializer, internal, private, public, utility, view},
+            functions::{authorize_once, external, initializer, internal, view},
             storage::storage,
         },
         messages::message_delivery::MessageDelivery,
@@ -59,7 +59,7 @@ pub contract NFT {
     // docs:end:storage_struct
 
     // docs:start:constructor
-    #[public]
+    #[external("public")]
     #[initializer]
     fn constructor(admin: AztecAddress, name: str<31>, symbol: str<31>) {
         assert(!admin.is_zero(), "invalid admin");
@@ -70,21 +70,21 @@ pub contract NFT {
     }
     // docs:end:constructor
 
-    #[public]
+    #[external("public")]
     fn set_admin(new_admin: AztecAddress) {
         assert(storage.admin.read().eq(context.msg_sender().unwrap()), "caller is not an admin");
         storage.admin.write(new_admin);
     }
 
     // docs:start:set_minter
-    #[public]
+    #[external("public")]
     fn set_minter(minter: AztecAddress, approve: bool) {
         assert(storage.admin.read().eq(context.msg_sender().unwrap()), "caller is not an admin");
         storage.minters.at(minter).write(approve);
     }
     // docs:end:set_minter
 
-    #[public]
+    #[external("public")]
     fn mint(to: AztecAddress, token_id: Field) {
         assert(token_id != 0, "zero token ID not supported");
         assert(storage.minters.at(context.msg_sender().unwrap()).read(), "caller is not a minter");
@@ -95,44 +95,44 @@ pub contract NFT {
         storage.public_owners.at(token_id).write(to);
     }
 
-    #[public]
+    #[external("public")]
     #[view]
     fn public_get_name() -> pub FieldCompressedString {
         storage.name.read()
     }
 
-    #[private]
+    #[external("private")]
     #[view]
     fn private_get_name() -> pub FieldCompressedString {
         storage.name.read()
     }
 
-    #[public]
+    #[external("public")]
     #[view]
     fn public_get_symbol() -> pub FieldCompressedString {
         storage.symbol.read()
     }
 
-    #[private]
+    #[external("private")]
     #[view]
     fn private_get_symbol() -> pub FieldCompressedString {
         storage.symbol.read()
     }
 
-    #[public]
+    #[external("public")]
     #[view]
     fn get_admin() -> Field {
         storage.admin.read().to_field()
     }
 
-    #[public]
+    #[external("public")]
     #[view]
     fn is_minter(minter: AztecAddress) -> bool {
         storage.minters.at(minter).read()
     }
 
     #[authorize_once("from", "authwit_nonce")]
-    #[public]
+    #[external("public")]
     fn transfer_in_public(
         from: AztecAddress,
         to: AztecAddress,
@@ -146,7 +146,7 @@ pub contract NFT {
     }
 
     // Transfers token with `token_id` from public balance of message sender to a private balance of `to`.
-    #[private]
+    #[external("private")]
     fn transfer_to_private(to: AztecAddress, token_id: Field) {
         let from = context.msg_sender().unwrap();
 
@@ -162,7 +162,7 @@ pub contract NFT {
 
     /// Prepares an increase of private balance of `to` (partial note). The increase needs to be finalized by calling
     /// `finalize_transfer_to_private` with the returned partial note.
-    #[private]
+    #[external("private")]
     fn prepare_private_balance_increase(to: AztecAddress) -> PartialNFTNote {
         _prepare_private_balance_increase(to, &mut context, storage)
     }
@@ -198,7 +198,7 @@ pub contract NFT {
     /// the caller of this function to ensure that it doesn't happen. If the same `partial_note` is used multiple
     /// times, the NFT with `token_id` would most likely get lost (the partial note log processing functionality
     /// would fail to find the pending partial note when trying to complete it).
-    #[public]
+    #[external("public")]
     fn finalize_transfer_to_private(token_id: Field, partial_note: PartialNFTNote) {
         // Completer is the entity that can complete the partial note. In this case, it's the same as the account
         // `from` from whose account the token is being transferred.
@@ -215,7 +215,7 @@ pub contract NFT {
     /// This is a wrapper around `_finalize_transfer_to_private` placed here so that a call
     /// to `_finalize_transfer_to_private` can be enqueued. Called unsafe as it does not check `from_and_completer`
     /// (this has to be done in the calling function).
-    #[public]
+    #[external("public")]
     #[internal]
     fn _finalize_transfer_to_private_unsafe(
         from_and_completer: AztecAddress,
@@ -255,7 +255,7 @@ pub contract NFT {
      * Cancel a private authentication witness.
      * @param inner_hash The inner hash of the authwit to cancel.
      */
-    #[private]
+    #[external("private")]
     fn cancel_authwit(inner_hash: Field) {
         let on_behalf_of = context.msg_sender().unwrap();
         let nullifier = compute_authwit_nullifier(on_behalf_of, inner_hash);
@@ -263,7 +263,7 @@ pub contract NFT {
     }
 
     #[authorize_once("from", "authwit_nonce")]
-    #[private]
+    #[external("private")]
     fn transfer_in_private(
         from: AztecAddress,
         to: AztecAddress,
@@ -283,7 +283,7 @@ pub contract NFT {
     }
 
     #[authorize_once("from", "authwit_nonce")]
-    #[private]
+    #[external("private")]
     fn transfer_to_public(
         from: AztecAddress,
         to: AztecAddress,
@@ -300,14 +300,14 @@ pub contract NFT {
         );
     }
 
-    #[public]
+    #[external("public")]
     #[internal]
     fn _finish_transfer_to_public(to: AztecAddress, token_id: Field) {
         storage.public_owners.at(token_id).write(to);
     }
 
     // Returns zero address when the token does not have a public owner. Reverts if the token does not exist.
-    #[public]
+    #[external("public")]
     #[view]
     fn owner_of(token_id: Field) -> AztecAddress {
         assert(storage.nft_exists.at(token_id).read(), "token does not exist");
@@ -317,7 +317,7 @@ pub contract NFT {
     /// Returns an array of token IDs owned by `owner` in private and a flag indicating whether a page limit was
     /// reached. Starts getting the notes from page with index `page_index`. Zero values in the array are placeholder
     /// values for non-existing notes.
-    #[utility]
+    #[external("utility")]
     unconstrained fn get_private_nfts(
         owner: AztecAddress,
         page_index: u32,

--- a/noir-projects/noir-contracts/contracts/app/orderbook_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/orderbook_contract/src/main.nr
@@ -35,11 +35,7 @@ pub contract Orderbook {
     use crate::{config::Config, order::Order};
     use aztec::{
         event::event_emission::emit_event_in_public,
-        macros::{
-            events::event,
-            functions::{initializer, internal, private, public, utility},
-            storage::storage,
-        },
+        macros::{events::event, functions::{external, initializer, internal}, storage::storage},
         oracle::notes::check_nullifier_exists,
         protocol_types::{address::AztecAddress, traits::{FromField, ToField}},
         state_vars::{Map, PublicImmutable},
@@ -65,7 +61,7 @@ pub contract Orderbook {
         orders: Map<Field, PublicImmutable<Order, Context>, Context>,
     }
 
-    #[public]
+    #[external("public")]
     #[initializer]
     fn constructor(token0: AztecAddress, token1: AztecAddress) {
         storage.config.initialize(Config::new(token0, token1));
@@ -73,7 +69,7 @@ pub contract Orderbook {
 
     /// Privately creates a new order in the orderbook
     /// The maker specifies the tokens and amounts they want to trade
-    #[private]
+    #[external("private")]
     fn create_order(
         bid_token: AztecAddress,
         ask_token: AztecAddress,
@@ -109,7 +105,7 @@ pub contract Orderbook {
         order_id
     }
 
-    #[public]
+    #[external("public")]
     #[internal]
     fn _create_order(order_id: Field, order: Order) {
         // Note that PublicImmutable can be initialized only once so this is a secondary check that the order is
@@ -121,7 +117,7 @@ pub contract Orderbook {
 
     /// Privately fulfills an existing order in the orderbook
     /// The taker provides the order ID they want to fulfill
-    #[private]
+    #[external("private")]
     fn fulfill_order(order_id: Field, authwit_nonce: Field) {
         let config = storage.config.read();
         let order = storage.orders.at(order_id).read();
@@ -160,7 +156,7 @@ pub contract Orderbook {
             .enqueue(&mut context);
     }
 
-    #[public]
+    #[external("public")]
     #[internal]
     fn _fulfill_order(
         order_id: Field,
@@ -177,7 +173,7 @@ pub contract Orderbook {
     }
 
     /// Returns the order and whether it has been fulfilled.
-    #[utility]
+    #[external("utility")]
     unconstrained fn get_order(order_id: Field) -> pub (Order, bool) {
         let order = storage.orders.at(order_id).read();
         let is_fulfilled = check_nullifier_exists(order_id);

--- a/noir-projects/noir-contracts/contracts/app/price_feed_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/price_feed_contract/src/main.nr
@@ -7,7 +7,7 @@ pub contract PriceFeed {
     use crate::asset::Asset;
     use dep::aztec::state_vars::{Map, PublicMutable};
 
-    use dep::aztec::macros::{functions::{public, view}, storage::storage};
+    use dep::aztec::macros::{functions::{external, view}, storage::storage};
 
     // Storage structure, containing all storage, and specifying what slots they use.
     #[storage]
@@ -15,13 +15,13 @@ pub contract PriceFeed {
         assets: Map<Field, PublicMutable<Asset, Context>, Context>,
     }
 
-    #[public]
+    #[external("public")]
     fn set_price(asset_id: Field, price: u128) {
         let asset = storage.assets.at(asset_id);
         asset.write(Asset { price });
     }
 
-    #[public]
+    #[external("public")]
     #[view]
     fn get_price(asset_id: Field) -> Asset {
         storage.assets.at(asset_id).read()

--- a/noir-projects/noir-contracts/contracts/app/private_token_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/private_token_contract/src/main.nr
@@ -2,7 +2,7 @@ use dep::aztec::macros::aztec;
 
 #[aztec]
 pub contract PrivateToken {
-    use dep::aztec::macros::{functions::{initializer, private, utility}, storage::storage};
+    use dep::aztec::macros::{functions::{external, initializer}, storage::storage};
     use dep::aztec::{protocol_types::address::AztecAddress, state_vars::Map};
     use dep::easy_private_state::EasyPrivateUint;
 
@@ -14,7 +14,7 @@ pub contract PrivateToken {
     /**
      * initialize the contract's initial state variables.
      */
-    #[private]
+    #[external("private")]
     #[initializer]
     fn constructor(initial_supply: u64, owner: AztecAddress) {
         let balances = storage.balances;
@@ -23,7 +23,7 @@ pub contract PrivateToken {
     }
 
     // Mints `amount` of tokens to `owner`.
-    #[private]
+    #[external("private")]
     fn mint(amount: u64, owner: AztecAddress) {
         let balances = storage.balances;
 
@@ -31,7 +31,7 @@ pub contract PrivateToken {
     }
 
     // Transfers `amount` of tokens from `sender` to a `recipient`.
-    #[private]
+    #[external("private")]
     fn transfer(amount: u64, sender: AztecAddress, recipient: AztecAddress) {
         let balances = storage.balances;
 
@@ -40,7 +40,7 @@ pub contract PrivateToken {
     }
 
     // Helper function to get the balance of a user.
-    #[utility]
+    #[external("utility")]
     unconstrained fn get_balance(owner: AztecAddress) -> Field {
         storage.balances.at(owner).get_value()
     }

--- a/noir-projects/noir-contracts/contracts/app/private_voting_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/private_voting_contract/src/main.nr
@@ -14,7 +14,7 @@ pub contract PrivateVoting {
     // docs:start:imports
     use dep::aztec::{
         keys::getters::get_public_keys,
-        macros::{functions::{initializer, internal, private, public, utility}, storage::storage},
+        macros::{functions::{external, initializer, internal}, storage::storage},
     };
     use dep::aztec::protocol_types::{
         address::AztecAddress,
@@ -35,7 +35,7 @@ pub contract PrivateVoting {
     // docs:end:storage_struct
 
     // docs:start:constructor
-    #[public]
+    #[external("public")]
     #[initializer]
     // annotation to mark function as a constructor
     fn constructor(admin: AztecAddress) {
@@ -45,7 +45,7 @@ pub contract PrivateVoting {
     }
     // docs:end:constructor
 
-    #[private]
+    #[external("private")]
     // annotation to mark function as private and expose private context
     fn cast_vote(candidate: Field) {
         let msg_sender_nullifier_public_key_message_hash =
@@ -59,7 +59,7 @@ pub contract PrivateVoting {
         );
     }
 
-    #[public]
+    #[external("public")]
     #[internal]
     fn add_to_tally_public(candidate: Field) {
         assert(storage.vote_ended.read() == false, "Vote has ended"); // assert that vote has not ended
@@ -67,12 +67,12 @@ pub contract PrivateVoting {
         storage.tally.at(candidate).write(new_tally);
     }
 
-    #[public]
+    #[external("public")]
     fn end_vote() {
         assert(storage.admin.read().eq(context.msg_sender().unwrap()), "Only admin can end votes"); // assert that caller is admin
         storage.vote_ended.write(true);
     }
-    #[utility]
+    #[external("utility")]
     unconstrained fn get_vote(candidate: Field) -> Field {
         storage.tally.at(candidate).read()
     }

--- a/noir-projects/noir-contracts/contracts/app/simple_token_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/simple_token_contract/src/main.nr
@@ -18,7 +18,7 @@ pub contract SimpleToken {
         event::event_emission::emit_event_in_private,
         macros::{
             events::event,
-            functions::{authorize_once, initializer, internal, private, public, utility, view},
+            functions::{authorize_once, external, initializer, internal, view},
             storage::storage,
         },
         messages::message_delivery::MessageDelivery,
@@ -50,7 +50,7 @@ pub contract SimpleToken {
         decimals: PublicImmutable<u8, Context>,
     }
 
-    #[public]
+    #[external("public")]
     #[initializer]
     fn constructor(name: str<31>, symbol: str<31>, decimals: u8) {
         storage.name.initialize(FieldCompressedString::from_string(name));
@@ -58,42 +58,42 @@ pub contract SimpleToken {
         storage.decimals.initialize(decimals);
     }
 
-    #[public]
+    #[external("public")]
     #[view]
     fn public_get_name() -> FieldCompressedString {
         storage.name.read()
     }
 
-    #[public]
+    #[external("public")]
     #[view]
     fn public_get_symbol() -> pub FieldCompressedString {
         storage.symbol.read()
     }
 
-    #[public]
+    #[external("public")]
     #[view]
     fn public_get_decimals() -> pub u8 {
         storage.decimals.read()
     }
 
-    #[public]
+    #[external("public")]
     #[view]
     fn public_total_supply() -> u128 {
         storage.total_supply.read()
     }
 
-    #[public]
+    #[external("public")]
     #[view]
     fn public_balance_of(owner: AztecAddress) -> u128 {
         storage.public_balances.at(owner).read()
     }
 
-    #[utility]
+    #[external("utility")]
     unconstrained fn private_balance_of(owner: AztecAddress) -> u128 {
         storage.balances.at(owner).balance_of()
     }
 
-    #[public]
+    #[external("public")]
     fn mint_publicly(to: AztecAddress, amount: u128) {
         let new_balance = storage.public_balances.at(to).read().add(amount);
         let supply = storage.total_supply.read().add(amount);
@@ -102,7 +102,7 @@ pub contract SimpleToken {
     }
 
     #[authorize_once("from", "authwit_nonce")]
-    #[public]
+    #[external("public")]
     fn public_transfer(from: AztecAddress, to: AztecAddress, amount: u128, authwit_nonce: Field) {
         let from_balance = storage.public_balances.at(from).read().sub(amount);
         storage.public_balances.at(from).write(from_balance);
@@ -111,7 +111,7 @@ pub contract SimpleToken {
     }
 
     #[authorize_once("from", "authwit_nonce")]
-    #[public]
+    #[external("public")]
     fn burn_public(from: AztecAddress, amount: u128, authwit_nonce: Field) {
         let from_balance = storage.public_balances.at(from).read().sub(amount);
         storage.public_balances.at(from).write(from_balance);
@@ -120,7 +120,7 @@ pub contract SimpleToken {
     }
 
     #[authorize_once("from", "authwit_nonce")]
-    #[private]
+    #[external("private")]
     fn transfer_from_private_to_public(
         from: AztecAddress,
         to: AztecAddress,
@@ -137,7 +137,7 @@ pub contract SimpleToken {
         );
     }
 
-    #[private]
+    #[external("private")]
     fn private_transfer(to: AztecAddress, amount: u128) {
         let from = context.msg_sender().unwrap();
 
@@ -168,7 +168,7 @@ pub contract SimpleToken {
     }
 
     #[authorize_once("from", "authwit_nonce")]
-    #[private]
+    #[external("private")]
     fn burn_private(from: AztecAddress, amount: u128, authwit_nonce: Field) {
         storage.balances.at(from).sub(from, amount).emit(
             &mut context,
@@ -178,7 +178,7 @@ pub contract SimpleToken {
         SimpleToken::at(context.this_address())._reduce_total_supply(amount).enqueue(&mut context);
     }
 
-    #[private]
+    #[external("private")]
     fn transfer_from_public_to_private(to: AztecAddress, amount: u128) {
         let from = context.msg_sender().unwrap();
         let token = SimpleToken::at(context.this_address());
@@ -187,7 +187,7 @@ pub contract SimpleToken {
         token._finalize_transfer_to_private_unsafe(from, amount, partial_note).enqueue(&mut context);
     }
 
-    #[private]
+    #[external("private")]
     fn prepare_private_balance_increase(to: AztecAddress, from: AztecAddress) -> PartialUintNote {
         _prepare_private_balance_increase(to, &mut context, storage)
     }
@@ -209,7 +209,7 @@ pub contract SimpleToken {
         partial_note
     }
 
-    #[public]
+    #[external("public")]
     fn finalize_transfer_to_private(amount: u128, partial_note: PartialUintNote) {
         let from_and_completer = context.msg_sender().unwrap();
         _finalize_transfer_to_private(
@@ -221,7 +221,7 @@ pub contract SimpleToken {
         );
     }
 
-    #[public]
+    #[external("public")]
     #[internal]
     fn _finalize_transfer_to_private_unsafe(
         from_and_completer: AztecAddress,
@@ -251,7 +251,7 @@ pub contract SimpleToken {
         partial_note.complete(context, from_and_completer, amount);
     }
 
-    #[private]
+    #[external("private")]
     fn mint_privately(from: AztecAddress, to: AztecAddress, amount: u128) {
         let token = SimpleToken::at(context.this_address());
         let partial_note = _prepare_private_balance_increase(to, &mut context, storage);
@@ -260,7 +260,7 @@ pub contract SimpleToken {
             .enqueue(&mut context);
     }
 
-    #[public]
+    #[external("public")]
     fn finalize_mint_to_private(amount: u128, partial_note: PartialUintNote) {
         _finalize_mint_to_private(
             context.msg_sender().unwrap(),
@@ -271,7 +271,7 @@ pub contract SimpleToken {
         );
     }
 
-    #[public]
+    #[external("public")]
     #[internal]
     fn _finalize_mint_to_private_unsafe(
         minter_and_completer: AztecAddress,
@@ -301,7 +301,7 @@ pub contract SimpleToken {
         partial_note.complete(context, completer, amount);
     }
 
-    #[public]
+    #[external("public")]
     #[internal]
     fn _increase_public_balance(to: AztecAddress, amount: u128) {
         _increase_public_balance_inner(to, amount, storage);
@@ -317,14 +317,14 @@ pub contract SimpleToken {
         storage.public_balances.at(to).write(new_balance);
     }
 
-    #[public]
+    #[external("public")]
     #[internal]
     fn _reduce_total_supply(amount: u128) {
         let new_supply = storage.total_supply.read().sub(amount);
         storage.total_supply.write(new_supply);
     }
 
-    #[private]
+    #[external("private")]
     fn cancel_authwit(inner_hash: Field) {
         let on_behalf_of = context.msg_sender().unwrap();
         let nullifier = compute_authwit_nullifier(on_behalf_of, inner_hash);
@@ -360,7 +360,7 @@ pub contract SimpleToken {
     }
 
     #[internal]
-    #[private]
+    #[external("private")]
     fn _recurse_subtract_balance(account: AztecAddress, amount: u128) -> u128 {
         subtract_balance(
             &mut context,

--- a/noir-projects/noir-contracts/contracts/app/token_blacklist_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_blacklist_contract/src/main.nr
@@ -20,7 +20,7 @@ pub contract TokenBlacklist {
     use aztec::{
         hash::compute_secret_hash,
         macros::{
-            functions::{authorize_once, initializer, internal, private, public, utility, view},
+            functions::{authorize_once, external, initializer, internal, view},
             storage::storage,
         },
         messages::{
@@ -58,32 +58,32 @@ pub contract TokenBlacklist {
     }
 
     // docs:start:constructor
-    #[public]
+    #[external("public")]
     #[initializer]
     fn constructor(admin: AztecAddress) {
         let admin_roles = UserFlags { is_admin: true, is_minter: false, is_blacklisted: false };
         storage.roles.at(admin).schedule_value_change(admin_roles);
     }
 
-    #[public]
+    #[external("public")]
     #[view]
     fn total_supply() -> pub Field {
         storage.total_supply.read().to_field()
     }
 
-    #[public]
+    #[external("public")]
     #[view]
     fn balance_of_public(owner: AztecAddress) -> pub Field {
         storage.public_balances.at(owner).read().to_field()
     }
 
-    #[public]
+    #[external("public")]
     #[view]
     fn get_roles(user: AztecAddress) -> UserFlags {
         storage.roles.at(user).get_current_value()
     }
 
-    #[public]
+    #[external("public")]
     fn update_roles(user: AztecAddress, roles: UserFlags) {
         let caller_roles = storage.roles.at(context.msg_sender().unwrap()).get_current_value();
         assert(caller_roles.is_admin, "caller is not admin");
@@ -91,7 +91,7 @@ pub contract TokenBlacklist {
         storage.roles.at(user).schedule_value_change(roles);
     }
 
-    #[public]
+    #[external("public")]
     fn mint_public(to: AztecAddress, amount: u128) {
         let to_roles = storage.roles.at(to).get_current_value();
         assert(!to_roles.is_blacklisted, "Blacklisted: Recipient");
@@ -106,7 +106,7 @@ pub contract TokenBlacklist {
         storage.total_supply.write(supply);
     }
 
-    #[public]
+    #[external("public")]
     fn mint_private(amount: u128, secret_hash: Field) {
         let caller_roles = storage.roles.at(context.msg_sender().unwrap()).get_current_value();
         assert(caller_roles.is_minter, "caller is not minter");
@@ -125,7 +125,7 @@ pub contract TokenBlacklist {
     }
 
     #[authorize_once("from", "authwit_nonce")]
-    #[public]
+    #[external("public")]
     fn shield(from: AztecAddress, amount: u128, secret_hash: Field, authwit_nonce: Field) {
         let from_roles = storage.roles.at(from).get_current_value();
         assert(!from_roles.is_blacklisted, "Blacklisted: Sender");
@@ -145,7 +145,7 @@ pub contract TokenBlacklist {
     }
 
     #[authorize_once("from", "authwit_nonce")]
-    #[public]
+    #[external("public")]
     fn transfer_public(from: AztecAddress, to: AztecAddress, amount: u128, authwit_nonce: Field) {
         let from_roles = storage.roles.at(from).get_current_value();
         assert(!from_roles.is_blacklisted, "Blacklisted: Sender");
@@ -160,7 +160,7 @@ pub contract TokenBlacklist {
     }
 
     #[authorize_once("from", "authwit_nonce")]
-    #[public]
+    #[external("public")]
     fn burn_public(from: AztecAddress, amount: u128, authwit_nonce: Field) {
         let from_roles = storage.roles.at(from).get_current_value();
         assert(!from_roles.is_blacklisted, "Blacklisted: Sender");
@@ -172,7 +172,7 @@ pub contract TokenBlacklist {
         storage.total_supply.write(new_supply);
     }
 
-    #[private]
+    #[external("private")]
     fn redeem_shield(to: AztecAddress, amount: u128, secret: Field) {
         let to_roles = storage.roles.at(to).get_current_value();
         assert(!to_roles.is_blacklisted, "Blacklisted: Recipient");
@@ -195,7 +195,7 @@ pub contract TokenBlacklist {
     }
 
     #[authorize_once("from", "authwit_nonce")]
-    #[private]
+    #[external("private")]
     fn unshield(from: AztecAddress, to: AztecAddress, amount: u128, authwit_nonce: Field) {
         let from_roles = storage.roles.at(from).get_current_value();
         assert(!from_roles.is_blacklisted, "Blacklisted: Sender");
@@ -215,7 +215,7 @@ pub contract TokenBlacklist {
 
     // docs:start:transfer_private
     #[authorize_once("from", "authwit_nonce")]
-    #[private]
+    #[external("private")]
     fn transfer(from: AztecAddress, to: AztecAddress, amount: u128, authwit_nonce: Field) {
         let from_roles = storage.roles.at(from).get_current_value();
         assert(!from_roles.is_blacklisted, "Blacklisted: Sender");
@@ -235,7 +235,7 @@ pub contract TokenBlacklist {
     }
 
     #[authorize_once("from", "authwit_nonce")]
-    #[private]
+    #[external("private")]
     fn burn(from: AztecAddress, amount: u128, authwit_nonce: Field) {
         let from_roles = storage.roles.at(from).get_current_value();
         assert(!from_roles.is_blacklisted, "Blacklisted: Sender");
@@ -250,14 +250,14 @@ pub contract TokenBlacklist {
     }
 
     /// Internal ///
-    #[public]
+    #[external("public")]
     #[internal]
     fn _increase_public_balance(to: AztecAddress, amount: u128) {
         let new_balance = storage.public_balances.at(to).read().add(amount);
         storage.public_balances.at(to).write(new_balance);
     }
 
-    #[public]
+    #[external("public")]
     #[internal]
     fn _reduce_total_supply(amount: u128) {
         // Only to be called from burn.
@@ -265,7 +265,7 @@ pub contract TokenBlacklist {
         storage.total_supply.write(new_supply);
     }
 
-    #[utility]
+    #[external("utility")]
     unconstrained fn balance_of_private(owner: AztecAddress) -> Field {
         storage.balances.balance_of(owner).to_field()
     }
@@ -274,7 +274,7 @@ pub contract TokenBlacklist {
     // originates in public and hence we cannot emit it as an offchain message. We could construct the offchain message
     // "manually" and then pass it to the `process_message` function, but this doesn't seem to be worth the effort
     // given that the TransparentNote flow is deprecated and kept around only for testing purposes.
-    #[utility]
+    #[external("utility")]
     unconstrained fn deliver_transparent_note(
         contract_address: AztecAddress,
         amount: u128,

--- a/noir-projects/noir-contracts/contracts/app/token_bridge_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_bridge_contract/src/main.nr
@@ -23,7 +23,7 @@ pub contract TokenBridge {
 
     use dep::token::Token;
 
-    use dep::aztec::macros::{functions::{initializer, private, public, view}, storage::storage};
+    use dep::aztec::macros::{functions::{external, initializer, view}, storage::storage};
 
     // Storage structure, containing all storage, and specifying what slots they use.
     #[storage]
@@ -32,19 +32,19 @@ pub contract TokenBridge {
     }
 
     // Constructs the contract.
-    #[public]
+    #[external("public")]
     #[initializer]
     fn constructor(token: AztecAddress, portal: EthAddress) {
         storage.config.initialize(Config { token, portal });
     }
 
-    #[private]
+    #[external("private")]
     #[view]
     fn get_config() -> Config {
         storage.config.read()
     }
 
-    #[public]
+    #[external("public")]
     #[view]
     fn get_config_public() -> Config {
         storage.config.read()
@@ -52,7 +52,7 @@ pub contract TokenBridge {
 
     // docs:start:claim_public
     // Consumes a L1->L2 message and calls the token contract to mint the appropriate amount publicly
-    #[public]
+    #[external("public")]
     fn claim_public(to: AztecAddress, amount: u128, secret: Field, message_leaf_index: Field) {
         let content_hash = get_mint_to_public_content_hash(to, amount);
 
@@ -69,7 +69,7 @@ pub contract TokenBridge {
     // docs:start:exit_to_l1_public
     // Burns the appropriate amount of tokens and creates a L2 to L1 withdraw message publicly
     // Requires `msg.sender` to give approval to the bridge to burn tokens on their behalf using witness signatures
-    #[public]
+    #[external("public")]
     fn exit_to_l1_public(
         recipient: EthAddress, // ethereum address to withdraw to
         amount: u128,
@@ -92,7 +92,7 @@ pub contract TokenBridge {
     /// Claims the bridged tokens and makes them accessible in private. Note that recipient's address is not revealed
     /// but the amount is. Hence it's most likely possible to determine to which L1 deposit this claim corresponds to
     /// (unless there are multiple pending deposits of the same amount).
-    #[private]
+    #[external("private")]
     fn claim_private(
         recipient: AztecAddress, // recipient of the bridged tokens
         amount: u128,
@@ -117,7 +117,7 @@ pub contract TokenBridge {
     // docs:start:exit_to_l1_private
     // Burns the appropriate amount of tokens and creates a L2 to L1 withdraw message privately
     // Requires `msg.sender` (caller of the method) to give approval to the bridge to burn tokens on their behalf using witness signatures
-    #[private]
+    #[external("private")]
     fn exit_to_l1_private(
         token: AztecAddress,
         recipient: EthAddress, // ethereum address to withdraw to

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/main.nr
@@ -22,7 +22,7 @@ pub contract Token {
         event::event_emission::emit_event_in_private,
         macros::{
             events::event,
-            functions::{authorize_once, initializer, internal, private, public, utility, view},
+            functions::{authorize_once, external, initializer, internal, view},
             storage::storage,
         },
         messages::message_delivery::MessageDelivery,
@@ -69,7 +69,7 @@ pub contract Token {
     // docs:end:storage_struct
 
     // docs:start:constructor
-    #[public]
+    #[external("public")]
     #[initializer]
     fn constructor(admin: AztecAddress, name: str<31>, symbol: str<31>, decimals: u8) {
         assert(!admin.is_zero(), "invalid admin");
@@ -81,81 +81,81 @@ pub contract Token {
     }
     // docs:end:constructor
 
-    #[public]
+    #[external("public")]
     fn set_admin(new_admin: AztecAddress) {
         assert(storage.admin.read().eq(context.msg_sender().unwrap()), "caller is not admin");
         storage.admin.write(new_admin);
     }
 
-    #[public]
+    #[external("public")]
     #[view]
     fn public_get_name() -> FieldCompressedString {
         storage.name.read()
     }
 
-    #[private]
+    #[external("private")]
     #[view]
     fn private_get_name() -> FieldCompressedString {
         storage.name.read()
     }
 
-    #[public]
+    #[external("public")]
     #[view]
     fn public_get_symbol() -> pub FieldCompressedString {
         storage.symbol.read()
     }
 
-    #[private]
+    #[external("private")]
     #[view]
     fn private_get_symbol() -> pub FieldCompressedString {
         storage.symbol.read()
     }
 
-    #[public]
+    #[external("public")]
     #[view]
     fn public_get_decimals() -> pub u8 {
         storage.decimals.read()
     }
 
-    #[private]
+    #[external("private")]
     #[view]
     fn private_get_decimals() -> pub u8 {
         storage.decimals.read()
     }
 
-    #[public]
+    #[external("public")]
     #[view]
     fn get_admin() -> Field {
         storage.admin.read().to_field()
     }
 
-    #[public]
+    #[external("public")]
     #[view]
     fn is_minter(minter: AztecAddress) -> bool {
         storage.minters.at(minter).read()
     }
 
-    #[public]
+    #[external("public")]
     #[view]
     fn total_supply() -> u128 {
         storage.total_supply.read()
     }
 
-    #[public]
+    #[external("public")]
     #[view]
     fn balance_of_public(owner: AztecAddress) -> u128 {
         storage.public_balances.at(owner).read()
     }
 
     // docs:start:set_minter
-    #[public]
+    #[external("public")]
     fn set_minter(minter: AztecAddress, approve: bool) {
         assert(storage.admin.read().eq(context.msg_sender().unwrap()), "caller is not admin");
         storage.minters.at(minter).write(approve);
     }
     // docs:end:set_minter
 
-    #[public]
+    #[external("public")]
     fn mint_to_public(to: AztecAddress, amount: u128) {
         assert(storage.minters.at(context.msg_sender().unwrap()).read(), "caller is not minter");
         let new_balance = storage.public_balances.at(to).read().add(amount);
@@ -165,7 +165,7 @@ pub contract Token {
     }
 
     #[authorize_once("from", "authwit_nonce")]
-    #[public]
+    #[external("public")]
     fn transfer_in_public(
         from: AztecAddress,
         to: AztecAddress,
@@ -179,7 +179,7 @@ pub contract Token {
     }
 
     #[authorize_once("from", "authwit_nonce")]
-    #[public]
+    #[external("public")]
     fn burn_public(from: AztecAddress, amount: u128, authwit_nonce: Field) {
         let from_balance = storage.public_balances.at(from).read().sub(amount);
         storage.public_balances.at(from).write(from_balance);
@@ -188,7 +188,7 @@ pub contract Token {
     }
 
     #[authorize_once("from", "authwit_nonce")]
-    #[private]
+    #[external("private")]
     fn transfer_to_public(
         from: AztecAddress,
         to: AztecAddress,
@@ -218,7 +218,7 @@ pub contract Token {
     /// The contract can use the returned partial note to complete the transfer back to private
     /// once the final amount is known during public execution.
     #[authorize_once("from", "authwit_nonce")]
-    #[private]
+    #[external("private")]
     fn transfer_to_public_and_prepare_private_balance_increase(
         from: AztecAddress,
         to: AztecAddress,
@@ -236,7 +236,7 @@ pub contract Token {
         _prepare_private_balance_increase(from, &mut context, storage)
     }
 
-    #[private]
+    #[external("private")]
     fn transfer(to: AztecAddress, amount: u128) {
         let from = context.msg_sender().unwrap();
 
@@ -314,7 +314,7 @@ pub contract Token {
     }
 
     #[internal]
-    #[private]
+    #[external("private")]
     fn _recurse_subtract_balance(account: AztecAddress, amount: u128) -> u128 {
         subtract_balance(
             &mut context,
@@ -329,7 +329,7 @@ pub contract Token {
      * Cancel a private authentication witness.
      * @param inner_hash The inner hash of the authwit to cancel.
      */
-    #[private]
+    #[external("private")]
     fn cancel_authwit(inner_hash: Field) {
         let on_behalf_of = context.msg_sender().unwrap();
         let nullifier = compute_authwit_nullifier(on_behalf_of, inner_hash);
@@ -337,7 +337,7 @@ pub contract Token {
     }
 
     #[authorize_once("from", "authwit_nonce")]
-    #[private]
+    #[external("private")]
     fn transfer_in_private(
         from: AztecAddress,
         to: AztecAddress,
@@ -359,7 +359,7 @@ pub contract Token {
     }
 
     #[authorize_once("from", "authwit_nonce")]
-    #[private]
+    #[external("private")]
     fn burn_private(from: AztecAddress, amount: u128, authwit_nonce: Field) {
         storage.balances.at(from).sub(from, amount).emit(
             &mut context,
@@ -370,7 +370,7 @@ pub contract Token {
     }
 
     // Transfers token `amount` from public balance of message sender to a private balance of `to`.
-    #[private]
+    #[external("private")]
     fn transfer_to_private(to: AztecAddress, amount: u128) {
         // `from` is the owner of the public balance from which we'll subtract the `amount`.
         let from = context.msg_sender().unwrap();
@@ -387,7 +387,7 @@ pub contract Token {
     /// Prepares an increase of private balance of `to` (partial note). The increase needs to be finalized by calling
     /// some of the finalization functions (`finalize_transfer_to_private`, `finalize_mint_to_private`) with the
     /// returned partial note.
-    #[private]
+    #[external("private")]
     fn prepare_private_balance_increase(to: AztecAddress) -> PartialUintNote {
         _prepare_private_balance_increase(to, &mut context, storage)
     }
@@ -424,7 +424,7 @@ pub contract Token {
     /// the caller of this function to ensure that it doesn't happen. If the same `partial_note` is used multiple
     /// times, the token `amount` would most likely get lost (the partial note log processing functionality would fail
     /// to find the pending partial note when trying to complete it).
-    #[public]
+    #[external("public")]
     fn finalize_transfer_to_private(amount: u128, partial_note: PartialUintNote) {
         // Completer is the entity that can complete the partial note. In this case, it's the same as the account
         // `from` from whose balance we're subtracting the `amount`.
@@ -447,7 +447,7 @@ pub contract Token {
     /// times, the token `amount` would most likely get lost (the partial note log processing functionality would fail
     /// to find the pending partial note when trying to complete it).
     #[authorize_once("from", "authwit_nonce")]
-    #[private]
+    #[external("private")]
     fn finalize_transfer_to_private_from_private(
         from: AztecAddress,
         partial_note: PartialUintNote,
@@ -467,7 +467,7 @@ pub contract Token {
     /// This is a wrapper around `_finalize_transfer_to_private` placed here so that a call
     /// to `_finalize_transfer_to_private` can be enqueued. Called unsafe as it does not check `from_and_completer`
     /// (this has to be done in the calling function).
-    #[public]
+    #[external("public")]
     #[internal]
     fn _finalize_transfer_to_private_unsafe(
         from_and_completer: AztecAddress,
@@ -504,7 +504,7 @@ pub contract Token {
 
     /// Mints token `amount` to a private balance of `to`. Message sender has to have minter permissions (checked
     /// in the enqueued call).
-    #[private]
+    #[external("private")]
     fn mint_to_private(to: AztecAddress, amount: u128) {
         let token = Token::at(context.this_address());
 
@@ -526,7 +526,7 @@ pub contract Token {
     /// Note: This function is only an optimization as it could be replaced by a combination of `mint_to_public`
     /// and `finalize_transfer_to_private`. It is however used very commonly so it makes sense to optimize it
     /// (e.g. used during token bridging, in AMM liquidity token etc.).
-    #[public]
+    #[external("public")]
     fn finalize_mint_to_private(amount: u128, partial_note: PartialUintNote) {
         // Completer is the entity that can complete the partial note. In this case, it's the same as the minter
         // account.
@@ -545,7 +545,7 @@ pub contract Token {
     /// This is a wrapper around `_finalize_mint_to_private` placed here so that a call
     /// to `_finalize_mint_to_private` can be enqueued. Called unsafe as it does not check `minter_and_completer` (this
     /// has to be done in the calling function).
-    #[public]
+    #[external("public")]
     #[internal]
     fn _finalize_mint_to_private_unsafe(
         minter_and_completer: AztecAddress,
@@ -582,7 +582,7 @@ pub contract Token {
     /// Internal ///
     /// TODO(#9180): Consider adding macro support for functions callable both as an entrypoint and as an internal
     /// function.
-    #[public]
+    #[external("public")]
     #[internal]
     fn _increase_public_balance(to: AztecAddress, amount: u128) {
         _increase_public_balance_inner(to, amount, storage);
@@ -598,7 +598,7 @@ pub contract Token {
         storage.public_balances.at(to).write(new_balance);
     }
 
-    #[public]
+    #[external("public")]
     #[internal]
     fn _reduce_total_supply(amount: u128) {
         // Only to be called from burn.
@@ -607,7 +607,7 @@ pub contract Token {
     }
 
     // docs:start:balance_of_private
-    #[utility]
+    #[external("utility")]
     unconstrained fn balance_of_private(owner: AztecAddress) -> u128 {
         storage.balances.at(owner).balance_of()
     }

--- a/noir-projects/noir-contracts/contracts/app/uniswap_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/uniswap_contract/src/main.nr
@@ -13,7 +13,7 @@ pub contract Uniswap {
             assert_current_call_valid_authwit_public, compute_authwit_message_hash_from_call,
             set_authorized,
         },
-        macros::{functions::{initializer, internal, private, public}, storage::storage},
+        macros::{functions::{external, initializer, internal}, storage::storage},
         protocol_types::{
             abis::function_selector::FunctionSelector,
             address::{AztecAddress, EthAddress},
@@ -31,7 +31,7 @@ pub contract Uniswap {
         portal_address: PublicImmutable<EthAddress, Context>,
     }
 
-    #[public]
+    #[external("public")]
     #[initializer]
     fn constructor(portal_address: EthAddress) {
         storage.portal_address.initialize(portal_address);
@@ -39,7 +39,7 @@ pub contract Uniswap {
     // docs:end:uniswap_setup
 
     // docs:start:swap_public
-    #[public]
+    #[external("public")]
     fn swap_public(
         sender: AztecAddress,
         input_asset_bridge: AztecAddress,
@@ -114,7 +114,7 @@ pub contract Uniswap {
     // docs:end:swap_public
 
     // docs:start:swap_private
-    #[private]
+    #[external("private")]
     fn swap_private(
         input_asset: AztecAddress, // since private, we pass here and later assert that this is as expected by input_bridge
         input_asset_bridge: AztecAddress,
@@ -192,7 +192,7 @@ pub contract Uniswap {
     // Assume `token` relates to `token_bridge` (ie token_bridge.token == token)
     // Note that private can't read public return values so created an internal public that handles everything
     // this method is used for both private and public swaps.
-    #[public]
+    #[external("public")]
     #[internal]
     fn _approve_bridge_and_exit_input_asset_to_L1(
         token: AztecAddress,

--- a/noir-projects/noir-contracts/contracts/docs/docs_example_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/docs/docs_example_contract/src/main.nr
@@ -9,7 +9,7 @@ pub contract DocsExample {
     // how to import dependencies defined in your workspace
     use aztec::{
         context::PrivateContext,
-        macros::{functions::{private, public, utility}, storage::{storage, storage_no_init}},
+        macros::{functions::external, storage::{storage, storage_no_init}},
         messages::message_delivery::MessageDelivery,
         note::{note_interface::NoteProperties, note_viewer_options::NoteViewerOptions},
         protocol_types::address::AztecAddress,
@@ -59,18 +59,18 @@ pub contract DocsExample {
         }
     }
 
-    #[public]
+    #[external("public")]
     fn initialize_public_immutable(points: u8) {
         let mut new_leader = Leader { account: context.msg_sender().unwrap(), points };
         storage.public_immutable.initialize(new_leader);
     }
 
-    #[utility]
+    #[external("utility")]
     unconstrained fn get_public_immutable() -> Leader {
         storage.public_immutable.read()
     }
 
-    #[private]
+    #[external("private")]
     fn initialize_private_immutable(points: u8) {
         let new_card = CardNote::new(points, context.msg_sender().unwrap());
 
@@ -81,18 +81,18 @@ pub contract DocsExample {
         );
     }
 
-    #[utility]
+    #[external("utility")]
     unconstrained fn read_note(comparator: u8, amount: Field) -> BoundedVec<CardNote, 10> {
         let mut options = NoteViewerOptions::new();
         storage.set.view_notes(options.select(CardNote::properties().points, comparator, amount))
     }
 
-    #[private]
+    #[external("private")]
     fn read_legendary_points() {
         storage.legendary_card.get_note()
     }
 
-    #[private]
+    #[external("private")]
     fn increase_legendary_points() {
         storage
             .legendary_card
@@ -103,12 +103,12 @@ pub contract DocsExample {
             .emit(&mut context, context.msg_sender().unwrap(), MessageDelivery.CONSTRAINED_ONCHAIN);
     }
 
-    #[utility]
+    #[external("utility")]
     unconstrained fn is_legendary_initialized() -> bool {
         storage.legendary_card.is_initialized()
     }
 
-    #[private]
+    #[external("private")]
     fn get_imm_card() -> CardNote {
         storage.private_immutable.get_note()
     }
@@ -117,7 +117,7 @@ pub contract DocsExample {
     use dep::aztec::protocol_types::abis::private_circuit_public_inputs::PrivateCircuitPublicInputs;
     use dep::aztec::context::inputs::PrivateContextInputs;
     // docs:start:simple_macro_example
-    #[private]
+    #[external("private")]
     fn simple_macro_example(a: Field, b: Field) -> Field {
         a + b
     }

--- a/noir-projects/noir-contracts/contracts/fees/fpc_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/fees/fpc_contract/src/main.nr
@@ -14,7 +14,7 @@ pub contract FPC {
     use crate::{config::Config, utils::safe_cast_to_u128};
     use dep::uint_note::uint_note::PartialUintNote;
     use aztec::{
-        macros::{functions::{initializer, internal, private, public}, storage::storage},
+        macros::{functions::{external, initializer, internal}, storage::storage},
         protocol_types::address::AztecAddress,
         state_vars::PublicImmutable,
     };
@@ -27,7 +27,7 @@ pub contract FPC {
 
     /// Initializes the contract with an accepted asset (AA) and an admin (address that can pull accumulated AA funds
     /// from this contract).
-    #[public]
+    #[external("public")]
     #[initializer]
     fn constructor(accepted_asset: AztecAddress, admin: AztecAddress) {
         let config = Config { accepted_asset, admin };
@@ -76,7 +76,7 @@ pub contract FPC {
     /// - which FPC has been used to make the payment,
     /// - the asset which was used to make the payment.
     // docs:start:fee_entrypoint_private
-    #[private]
+    #[external("private")]
     fn fee_entrypoint_private(max_fee: u128, authwit_nonce: Field) {
         let accepted_asset = storage.config.read().accepted_asset;
 
@@ -109,7 +109,7 @@ pub contract FPC {
     /// Executed as a public teardown function and is responsible for completing the refund in the private fee payment
     /// flow.
     // docs:start:complete_refund
-    #[public]
+    #[external("public")]
     #[internal]
     fn _complete_refund(
         accepted_asset: AztecAddress,
@@ -152,7 +152,7 @@ pub contract FPC {
     ///
     /// Protocol-enshrined fee-payment phase:
     /// 4. The protocol deducts the actual fee denominated in fee juice from the FPC's balance.
-    #[private]
+    #[external("private")]
     fn fee_entrypoint_public(max_fee: u128, authwit_nonce: Field) {
         let config = storage.config.read();
 
@@ -181,7 +181,7 @@ pub contract FPC {
     /// Pays the refund to the `refund_recipient` as part of the public fee payment flow. The refund is the difference
     /// between the `max_fee` and the actual fee. `accepted_asset` is the asset in which the refund is paid.
     /// It's passed as an argument to avoid the need for another read from public storage.
-    #[public]
+    #[external("public")]
     #[internal]
     fn _pay_refund(refund_recipient: AztecAddress, max_fee: u128, accepted_asset: AztecAddress) {
         let actual_fee = safe_cast_to_u128(context.transaction_fee());
@@ -197,7 +197,7 @@ pub contract FPC {
 
     /// Pulls all the accepted asset funds from this contract to the `to` address. Only the admin can call
     /// this function.
-    #[public]
+    #[external("public")]
     fn pull_funds(to: AztecAddress) {
         let config = storage.config.read();
 
@@ -212,7 +212,7 @@ pub contract FPC {
 
     /// Note: Not marked as view as we need it to be callable as an entrypoint since in some places we need to obtain
     /// this value before we have access to an account contract (kernels do not allow for static entrypoints).
-    #[private]
+    #[external("private")]
     fn get_accepted_asset() -> AztecAddress {
         storage.config.read().accepted_asset
     }

--- a/noir-projects/noir-contracts/contracts/fees/sponsored_fpc_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/fees/sponsored_fpc_contract/src/main.nr
@@ -5,10 +5,10 @@ use dep::aztec::macros::aztec;
 /// This contract covers transaction fees for users unconditionally.
 #[aztec]
 pub contract SponsoredFPC {
-    use dep::aztec::macros::functions::private;
+    use dep::aztec::macros::functions::external;
 
     /// Sponsors the transaction unconditionally.
-    #[private]
+    #[external("private")]
     fn sponsor_unconditionally() {
         // Set the FPC as the fee payer of the tx.
         context.set_as_fee_payer();

--- a/noir-projects/noir-contracts/contracts/protocol/auth_registry_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/auth_registry_contract/src/main.nr
@@ -12,7 +12,7 @@ pub contract AuthRegistry {
         authwit::auth::{
             assert_current_call_valid_authwit, compute_authwit_message_hash, IS_VALID_SELECTOR,
         },
-        macros::{functions::{internal, private, public, utility, view}, storage::storage},
+        macros::{functions::{external, internal, view}, storage::storage},
         protocol_types::address::AztecAddress,
         state_vars::{Map, PublicMutable},
     };
@@ -32,7 +32,7 @@ pub contract AuthRegistry {
      * @param message_hash The message hash being authorized
      * @param authorize True if the caller is authorized to perform the message hash, false otherwise
      */
-    #[public]
+    #[external("public")]
     fn set_authorized(message_hash: Field, authorize: bool) {
         // We use the unsafe method, because for some use cases a "null"
         // msg_sender might be acceptable (e.g. if it doesn't matter who takes
@@ -48,7 +48,7 @@ pub contract AuthRegistry {
      *
      * @param reject True if all actions should be rejected, false otherwise
      */
-    #[public]
+    #[external("public")]
     fn set_reject_all(reject: bool) {
         storage.reject_all.at(context.msg_sender().unwrap()).write(reject);
     }
@@ -63,7 +63,7 @@ pub contract AuthRegistry {
      * @param inner_hash The inner_hash of the authwit
      * @return `IS_VALID_SELECTOR` if the action was consumed, revert otherwise
      */
-    #[public]
+    #[external("public")]
     fn consume(on_behalf_of: AztecAddress, inner_hash: Field) -> Field {
         assert_eq(false, storage.reject_all.at(on_behalf_of).read(), "rejecting all");
 
@@ -93,7 +93,7 @@ pub contract AuthRegistry {
      * @param message_hash The message hash to authorize
      * @param authorize True if the message hash should be authorized, false otherwise
      */
-    #[private]
+    #[external("private")]
     fn set_authorized_private(approver: AztecAddress, message_hash: Field, authorize: bool) {
         assert_current_call_valid_authwit::<3>(&mut context, approver);
         AuthRegistry::at(context.this_address())
@@ -109,7 +109,7 @@ pub contract AuthRegistry {
      * @param message_hash The message hash being authorized
      * @param authorize True if the caller is authorized to perform the message hash, false otherwise
      */
-    #[public]
+    #[external("public")]
     #[internal]
     fn _set_authorized(approver: AztecAddress, message_hash: Field, authorize: bool) {
         storage.approved_actions.at(approver).at(message_hash).write(authorize);
@@ -121,7 +121,7 @@ pub contract AuthRegistry {
      * @param on_behalf_of The address to check
      * @return True if all actions are rejected, false otherwise
      */
-    #[public]
+    #[external("public")]
     #[view]
     fn is_reject_all(on_behalf_of: AztecAddress) -> bool {
         storage.reject_all.at(on_behalf_of).read()
@@ -134,7 +134,7 @@ pub contract AuthRegistry {
      * @param message_hash The message hash to check
      * @return True if the caller is authorized to perform the action, false otherwise
      */
-    #[public]
+    #[external("public")]
     #[view]
     fn is_consumable(on_behalf_of: AztecAddress, message_hash: Field) -> bool {
         storage.approved_actions.at(on_behalf_of).at(message_hash).read()
@@ -143,7 +143,7 @@ pub contract AuthRegistry {
     /**
      * Just like `is_consumable`, but a utility function and not public.
      */
-    #[utility]
+    #[external("utility")]
     unconstrained fn utility_is_consumable(
         on_behalf_of: AztecAddress,
         message_hash: Field,

--- a/noir-projects/noir-contracts/contracts/protocol/contract_class_registry/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/contract_class_registry/src/main.nr
@@ -6,7 +6,7 @@ use dep::aztec::macros::aztec;
 pub contract ContractClassRegistry {
     use dep::aztec::{
         hash::compute_public_bytecode_commitment,
-        macros::functions::private,
+        macros::functions::external,
         protocol_types::{
             constants::{
                 ARTIFACT_FUNCTION_TREE_MAX_HEIGHT, CONTRACT_CLASS_REGISTRY_BYTECODE_CAPSULE_SLOT,
@@ -31,7 +31,7 @@ pub contract ContractClassRegistry {
 
     use dep::aztec::oracle::capsules;
 
-    #[private]
+    #[external("private")]
     fn publish(
         artifact_hash: Field,
         private_functions_root: Field,
@@ -84,7 +84,7 @@ pub contract ContractClassRegistry {
         context.emit_contract_class_log(event.serialize_non_standard());
     }
 
-    #[private]
+    #[external("private")]
     fn broadcast_private_function(
         contract_class_id: ContractClassId,
         artifact_metadata_hash: Field,
@@ -136,7 +136,7 @@ pub contract ContractClassRegistry {
         context.emit_contract_class_log(event.serialize_non_standard());
     }
 
-    #[private]
+    #[external("private")]
     fn broadcast_utility_function(
         contract_class_id: ContractClassId,
         artifact_metadata_hash: Field,
@@ -180,7 +180,7 @@ pub contract ContractClassRegistry {
         context.emit_contract_class_log(event.serialize_non_standard());
     }
 
-    #[private]
+    #[external("private")]
     fn assert_class_id_is_published(contract_class_id: ContractClassId) {
         context.push_nullifier_read_request(contract_class_id.to_field());
     }

--- a/noir-projects/noir-contracts/contracts/protocol/contract_instance_registry/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/contract_instance_registry/src/main.nr
@@ -3,7 +3,7 @@ use aztec::macros::aztec;
 #[aztec]
 pub contract ContractInstanceRegistry {
     use aztec::{
-        macros::{events::event, functions::{private, public, view}, storage::storage},
+        macros::{events::event, functions::{external, view}, storage::storage},
         protocol_types::{
             address::{AztecAddress, PartialAddress},
             constants::{
@@ -95,7 +95,7 @@ pub contract ContractInstanceRegistry {
         updated_class_ids: Map<AztecAddress, DelayedPublicMutable<ContractClassId, DEFAULT_UPDATE_DELAY, Context>, Context>,
     }
 
-    #[private]
+    #[external("private")]
     fn publish_for_public_execution(
         salt: Field,
         contract_class_id: ContractClassId,
@@ -146,7 +146,7 @@ pub contract ContractInstanceRegistry {
         context.emit_private_log(padded_log, length);
     }
 
-    #[public]
+    #[external("public")]
     fn update(new_contract_class_id: ContractClassId) {
         let address = context.msg_sender().unwrap();
 
@@ -180,7 +180,7 @@ pub contract ContractInstanceRegistry {
         context.emit_public_log(event);
     }
 
-    #[public]
+    #[external("public")]
     fn set_update_delay(new_update_delay: u64) {
         let address = context.msg_sender().unwrap();
 
@@ -194,7 +194,7 @@ pub contract ContractInstanceRegistry {
         storage.updated_class_ids.at(address).schedule_delay_change(new_update_delay);
     }
 
-    #[public]
+    #[external("public")]
     #[view]
     fn get_update_delay() -> u64 {
         storage.updated_class_ids.at(context.msg_sender().unwrap()).get_current_delay()

--- a/noir-projects/noir-contracts/contracts/protocol/fee_juice_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/fee_juice_contract/src/main.nr
@@ -6,7 +6,7 @@ use dep::aztec::macros::aztec;
 pub contract FeeJuice {
     use dep::aztec::{
         context::private_context::PrivateContext,
-        macros::{functions::{internal, private, public, view}, storage::storage},
+        macros::{functions::{external, internal, view}, storage::storage},
         protocol_types::{
             address::{AztecAddress, EthAddress},
             constants::FEE_JUICE_ADDRESS,
@@ -48,7 +48,7 @@ pub contract FeeJuice {
     }
 
     /// Claims FeeJuice by consuming an L1 to L2 message with the provided information.
-    #[private]
+    #[external("private")]
     fn claim(to: AztecAddress, amount: u128, secret: Field, message_leaf_index: Field) {
         claim_helper(&mut context, to, amount, secret, message_leaf_index);
     }
@@ -57,7 +57,7 @@ pub contract FeeJuice {
     /// the balance increase it ends the setup phase, making sure the claim happens in the non-revertible phase
     /// of the transaction. This variant should only be used when the intent is to pay the transaction fee via
     /// the claimed fee juice in a single interaction.
-    #[private]
+    #[external("private")]
     fn claim_and_end_setup(
         to: AztecAddress,
         amount: u128,
@@ -68,14 +68,14 @@ pub contract FeeJuice {
         context.end_setup();
     }
 
-    #[public]
+    #[external("public")]
     #[internal]
     fn _increase_public_balance(to: AztecAddress, amount: u128) {
         let new_balance = storage.balances.at(to).read().add(amount);
         storage.balances.at(to).write(new_balance);
     }
 
-    #[public]
+    #[external("public")]
     #[view]
     fn check_balance(fee_limit: u128) {
         assert(
@@ -85,7 +85,7 @@ pub contract FeeJuice {
     }
 
     // utility function for testing
-    #[public]
+    #[external("public")]
     #[view]
     fn balance_of_public(owner: AztecAddress) -> pub u128 {
         storage.balances.at(owner).read()

--- a/noir-projects/noir-contracts/contracts/protocol/multi_call_entrypoint_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/multi_call_entrypoint_contract/src/main.nr
@@ -4,9 +4,9 @@ use dep::aztec::macros::aztec;
 
 #[aztec]
 pub contract MultiCallEntrypoint {
-    use aztec::{authwit::entrypoint::app::AppPayload, macros::functions::private};
+    use aztec::{authwit::entrypoint::app::AppPayload, macros::functions::external};
 
-    #[private]
+    #[external("private")]
     fn entrypoint(app_payload: AppPayload) {
         app_payload.execute_calls(&mut context);
     }

--- a/noir-projects/noir-contracts/contracts/protocol/router_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/router_contract/src/main.nr
@@ -7,12 +7,12 @@ use dep::aztec::macros::aztec;
 /// call. This can be achieved by enqueueing an `incognito` public call.
 #[aztec]
 pub contract Router {
-    use aztec::{macros::functions::{public, view}, utils::comparison::compare};
+    use aztec::{macros::functions::{external, view}, utils::comparison::compare};
 
     // docs:start:check_timestamp
     /// Asserts that the current timestamp satisfies the `operation` with respect
     /// to the `value.
-    #[public]
+    #[external("public")]
     #[view]
     fn check_timestamp(operation: u8, value: u64) {
         let lhs_field = context.timestamp() as Field;
@@ -23,7 +23,7 @@ pub contract Router {
 
     /// Asserts that the current block number satisfies the `operation` with respect
     /// to the `value.
-    #[public]
+    #[external("public")]
     #[view]
     fn check_block_number(operation: u8, value: u32) {
         assert(

--- a/noir-projects/noir-contracts/contracts/test/auth_wit_test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/auth_wit_test_contract/src/main.nr
@@ -4,16 +4,16 @@ use dep::aztec::macros::aztec;
 pub contract AuthWitTest {
     use dep::aztec::{
         authwit::auth::{assert_inner_hash_valid_authwit, assert_inner_hash_valid_authwit_public},
-        macros::functions::{private, public},
+        macros::functions::external,
         protocol_types::address::AztecAddress,
     };
 
-    #[private]
+    #[external("private")]
     fn consume(on_behalf_of: AztecAddress, inner_hash: Field) {
         assert_inner_hash_valid_authwit(&mut context, on_behalf_of, inner_hash);
     }
 
-    #[public]
+    #[external("public")]
     fn consume_public(on_behalf_of: AztecAddress, inner_hash: Field) {
         assert_inner_hash_valid_authwit_public(&mut context, on_behalf_of, inner_hash);
     }

--- a/noir-projects/noir-contracts/contracts/test/avm_gadgets_test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/avm_gadgets_test_contract/src/main.nr
@@ -2,106 +2,106 @@ use dep::aztec::macros::aztec;
 
 #[aztec]
 contract AvmGadgetsTest {
-    use dep::aztec::macros::functions::public;
+    use dep::aztec::macros::functions::external;
 
-    #[public]
+    #[external("public")]
     fn keccak_hash(data: [u8; 10]) -> [u8; 32] {
         keccak256::keccak256(data, data.len())
     }
 
-    #[public]
+    #[external("public")]
     fn keccak_hash_1400(data: [u8; 1400]) -> [u8; 32] {
         keccak256::keccak256(data, data.len())
     }
 
-    #[public]
+    #[external("public")]
     fn keccak_f1600(data: [u64; 25]) -> [u64; 25] {
         std::hash::keccakf1600(data)
     }
 
-    #[public]
+    #[external("public")]
     fn poseidon2_hash(data: [Field; 10]) -> Field {
         poseidon::poseidon2::Poseidon2::hash(data, data.len())
     }
 
-    #[public]
+    #[external("public")]
     fn poseidon2_hash_1000fields(data: [Field; 1000]) -> Field {
         poseidon::poseidon2::Poseidon2::hash(data, data.len())
     }
 
-    #[public]
+    #[external("public")]
     fn sha256_hash_10(data: [u8; 10]) -> [u8; 32] {
         sha256::sha256_var(data, data.len() as u64)
     }
-    #[public]
+    #[external("public")]
     fn sha256_hash_20(data: [u8; 20]) -> [u8; 32] {
         sha256::sha256_var(data, data.len() as u64)
     }
-    #[public]
+    #[external("public")]
     fn sha256_hash_30(data: [u8; 30]) -> [u8; 32] {
         sha256::sha256_var(data, data.len() as u64)
     }
-    #[public]
+    #[external("public")]
     fn sha256_hash_40(data: [u8; 40]) -> [u8; 32] {
         sha256::sha256_var(data, data.len() as u64)
     }
-    #[public]
+    #[external("public")]
     fn sha256_hash_50(data: [u8; 50]) -> [u8; 32] {
         sha256::sha256_var(data, data.len() as u64)
     }
-    #[public]
+    #[external("public")]
     fn sha256_hash_60(data: [u8; 60]) -> [u8; 32] {
         sha256::sha256_var(data, data.len() as u64)
     }
-    #[public]
+    #[external("public")]
     fn sha256_hash_70(data: [u8; 70]) -> [u8; 32] {
         sha256::sha256_var(data, data.len() as u64)
     }
-    #[public]
+    #[external("public")]
     fn sha256_hash_80(data: [u8; 80]) -> [u8; 32] {
         sha256::sha256_var(data, data.len() as u64)
     }
-    #[public]
+    #[external("public")]
     fn sha256_hash_90(data: [u8; 90]) -> [u8; 32] {
         sha256::sha256_var(data, data.len() as u64)
     }
-    #[public]
+    #[external("public")]
     fn sha256_hash_100(data: [u8; 100]) -> [u8; 32] {
         sha256::sha256_var(data, data.len() as u64)
     }
-    #[public]
+    #[external("public")]
     fn sha256_hash_255(data: [u8; 255]) -> [u8; 32] {
         sha256::sha256_var(data, data.len() as u64)
     }
-    #[public]
+    #[external("public")]
     fn sha256_hash_256(data: [u8; 256]) -> [u8; 32] {
         sha256::sha256_var(data, data.len() as u64)
     }
-    #[public]
+    #[external("public")]
     fn sha256_hash_511(data: [u8; 511]) -> [u8; 32] {
         sha256::sha256_var(data, data.len() as u64)
     }
-    #[public]
+    #[external("public")]
     fn sha256_hash_512(data: [u8; 512]) -> [u8; 32] {
         sha256::sha256_var(data, data.len() as u64)
     }
 
-    #[public]
+    #[external("public")]
     fn sha256_hash_1024(data: [u8; 1024]) -> [u8; 32] {
         sha256::sha256_var(data, data.len() as u64)
     }
 
-    #[public]
+    #[external("public")]
     fn sha256_hash_1536(data: [u8; 1536]) -> [u8; 32] {
         sha256::sha256_var(data, data.len() as u64)
     }
 
-    #[public]
+    #[external("public")]
     fn pedersen_hash(data: [Field; 10]) -> Field {
         std::hash::pedersen_hash(data)
     }
 
-    #[public]
+    #[external("public")]
     fn pedersen_hash_with_index(data: [Field; 10]) -> Field {
         std::hash::pedersen_hash_with_separator(data, /*index=*/ 20)
     }

--- a/noir-projects/noir-contracts/contracts/test/avm_initializer_test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/avm_initializer_test_contract/src/main.nr
@@ -4,7 +4,7 @@ use dep::aztec::macros::aztec;
 pub contract AvmInitializerTest {
     // Libs
     use dep::aztec::{
-        macros::{functions::{initializer, public}, storage::storage},
+        macros::{functions::{external, initializer}, storage::storage},
         state_vars::PublicImmutable,
     };
 
@@ -16,13 +16,13 @@ pub contract AvmInitializerTest {
     /************************************************************************
      * Storage
      ************************************************************************/
-    #[public]
+    #[external("public")]
     #[initializer]
     fn constructor() {
         storage.immutable.initialize(42);
     }
 
-    #[public]
+    #[external("public")]
     fn read_storage_immutable() -> pub Field {
         storage.immutable.read()
     }

--- a/noir-projects/noir-contracts/contracts/test/avm_test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/avm_test_contract/src/main.nr
@@ -16,7 +16,7 @@ pub contract AvmTest {
         avm_return, avm_revert, call, returndata_copy, returndata_size, success_copy,
     };
     use dep::aztec::context::gas::GasOpts;
-    use dep::aztec::macros::{functions::{private, public}, storage::storage};
+    use dep::aztec::macros::{functions::external, storage::storage};
     use dep::aztec::oracle::get_contract_instance::{
         get_contract_instance_class_id_avm, get_contract_instance_deployer_avm,
         get_contract_instance_initialization_hash_avm,
@@ -59,47 +59,47 @@ pub contract AvmTest {
     /************************************************************************
      * Storage
      ************************************************************************/
-    #[public]
+    #[external("public")]
     fn set_storage_single(a: Field) {
         storage.single.write(a);
     }
 
-    #[public]
+    #[external("public")]
     fn read_storage_single() -> Field {
         storage.single.read()
     }
 
-    #[public]
+    #[external("public")]
     fn read_assert_storage_single(a: Field) {
         assert(a == storage.single.read(), "Storage value does not match input");
     }
 
     // should still be able to use ` -> pub *` for return type even though macro forces `pub`
-    #[public]
+    #[external("public")]
     fn set_read_storage_single(a: Field) -> pub Field {
         storage.single.write(a);
         storage.single.read()
     }
 
-    #[public]
+    #[external("public")]
     fn set_storage_list(a: Field, b: Field) {
         storage.list.write(Note { a, b });
     }
 
-    #[public]
+    #[external("public")]
     fn read_storage_list() -> [Field; 2] {
         let note: Note = storage.list.read();
         note.serialize()
     }
 
-    #[public]
+    #[external("public")]
     fn set_storage_map(to: AztecAddress, amount: u32) -> Field {
         storage.map.at(to).write(amount);
         // returns storage slot for key
         derive_storage_slot_in_map(storage.map.get_storage_slot(), to)
     }
 
-    #[public]
+    #[external("public")]
     fn add_storage_map(to: AztecAddress, amount: u32) -> Field {
         let new_balance = storage.map.at(to).read().add(amount);
         storage.map.at(to).write(new_balance);
@@ -107,12 +107,12 @@ pub contract AvmTest {
         derive_storage_slot_in_map(storage.map.get_storage_slot(), to)
     }
 
-    #[public]
+    #[external("public")]
     fn read_storage_map(address: AztecAddress) -> u32 {
         storage.map.at(address).read()
     }
 
-    #[public]
+    #[external("public")]
     fn add_args_return(arg_a: Field, arg_b: Field) -> Field {
         add(arg_a, arg_b)
     }
@@ -126,52 +126,52 @@ pub contract AvmTest {
     /************************************************************************
      * General Opcodes
      ************************************************************************/
-    #[public]
+    #[external("public")]
     fn set_opcode_u8() -> u8 {
         8
     }
 
-    #[public]
+    #[external("public")]
     fn set_opcode_u32() -> u32 {
         1 << 30
     }
 
-    #[public]
+    #[external("public")]
     fn set_opcode_u64() -> u64 {
         1 << 60
     }
 
-    #[public]
+    #[external("public")]
     fn set_opcode_small_field() -> Field {
         big_field_128_bits
     }
 
-    #[public]
+    #[external("public")]
     fn set_opcode_big_field() -> Field {
         big_field_136_bits
     }
 
-    #[public]
+    #[external("public")]
     fn set_opcode_really_big_field() -> Field {
         big_field_254_bits
     }
 
-    #[public]
+    #[external("public")]
     fn add_u128(a: u128, b: u128) -> u128 {
         a + b
     }
 
-    #[public]
+    #[external("public")]
     fn modulo2(a: u64) -> u64 {
         a % 2
     }
 
-    #[public]
+    #[external("public")]
     fn elliptic_curve_add(lhs: Point, rhs: Point) -> Point {
         lhs + rhs
     }
 
-    #[public]
+    #[external("public")]
     fn elliptic_curve_add_and_double() -> Point {
         let g = Point { x: GRUMPKIN_ONE_X, y: GRUMPKIN_ONE_Y, is_infinite: false };
 
@@ -180,7 +180,7 @@ pub contract AvmTest {
         added
     }
 
-    #[public]
+    #[external("public")]
     fn variable_base_msm(
         scalar_lo: Field,
         scalar_hi: Field,
@@ -196,13 +196,13 @@ pub contract AvmTest {
         triple_g
     }
 
-    #[public]
+    #[external("public")]
     fn pedersen_commit(x: Field, y: Field) -> EmbeddedCurvePoint {
         let commitment = dep::std::hash::pedersen_commitment_with_separator([x, y], 20);
         commitment
     }
 
-    #[public]
+    #[external("public")]
     fn conditional_move(x: [Field; 1], y: [Field; 1], b: bool) -> [Field; 1] {
         if b {
             x
@@ -211,7 +211,7 @@ pub contract AvmTest {
         }
     }
 
-    #[public]
+    #[external("public")]
     fn bitwise_ops(x: u32, y: u32) -> u32 {
         let mut result = x & y;
         result = result | x;
@@ -224,29 +224,29 @@ pub contract AvmTest {
      * Misc
      ************************************************************************/
 
-    #[public]
+    #[external("public")]
     fn u128_addition_overflow() -> u128 {
         let max_u128: u128 = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF;
         let one: u128 = 1;
         max_u128 + one
     }
 
-    #[public]
+    #[external("public")]
     fn integer_division(x: u8, y: u8) -> u8 {
         x / y
     }
 
-    #[public]
+    #[external("public")]
     fn field_division(x: Field, y: Field) -> Field {
         x / y
     }
 
-    #[public]
+    #[external("public")]
     fn to_le_bytes(input: Field) -> [u8; 10] {
         input.to_le_bytes()
     }
 
-    #[public]
+    #[external("public")]
     fn to_le_bits(input: Field) -> [u1; 16] {
         input.to_le_bits()
     }
@@ -263,28 +263,28 @@ pub contract AvmTest {
         inner_helper_with_failed_assertion();
     }
 
-    #[public]
+    #[external("public")]
     fn assertion_failure() {
         helper_with_failed_assertion()
     }
 
-    #[public]
+    #[external("public")]
     fn external_call_to_assertion_failure() {
         AvmTest::at(context.this_address()).assertion_failure().call(&mut context);
     }
 
-    #[public]
+    #[external("public")]
     // Must be called with `denominator == 0`
     fn divide_by_zero(denominator: u8) -> u8 {
         1 / denominator
     }
 
-    #[public]
+    #[external("public")]
     fn external_call_to_divide_by_zero() {
         let _ = AvmTest::at(context.this_address()).divide_by_zero(0).call(&mut context);
     }
 
-    #[public]
+    #[external("public")]
     fn external_call_to_divide_by_zero_recovers() {
         // Be sure to allocate ~200k+ gas to this function~
 
@@ -313,7 +313,7 @@ pub contract AvmTest {
         );
     }
 
-    #[public]
+    #[external("public")]
     fn debug_logging() {
         dep::aztec::oracle::debug_log::debug_log("just text");
         dep::aztec::oracle::debug_log::debug_log_format("second: {1}", [1, 2, 3, 4]);
@@ -330,27 +330,27 @@ pub contract AvmTest {
         );
     }
 
-    #[public]
+    #[external("public")]
     fn assert_same(arg_a: Field, arg_b: Field) -> pub Field {
         assert(arg_a == arg_b, "Values are not equal");
         1
     }
 
-    #[public]
+    #[external("public")]
     fn assert_calldata_copy(args: [Field; 3], with_selector: bool) {
         let offset = with_selector as u32; // Skip the selector stored at i = 0 if used
         let cd: [Field; 3] = dep::aztec::context::public_context::calldata_copy(offset, 3);
         assert(cd == args, "Calldata copy failed");
     }
 
-    #[public]
+    #[external("public")]
     fn assert_calldata_copy_large(args: [Field; 300], with_selector: bool) {
         let offset = with_selector as u32; // Skip the selector stored at i = 0 if used
         let cd: [Field; 300] = dep::aztec::context::public_context::calldata_copy(offset, 300);
         assert(cd == args, "Calldata copy failed");
     }
 
-    #[public]
+    #[external("public")]
     fn returndata_copy_oracle() {
         let _ = AvmTest::at(context.this_address()).return_oracle().call(&mut context);
         let returndatasize = returndata_size();
@@ -358,13 +358,13 @@ pub contract AvmTest {
         assert(returndata == &[1, 2, 3], "Returndata copy failed");
     }
 
-    #[public]
+    #[external("public")]
     fn return_oracle() -> [Field; 3] {
         avm_return([1, 2, 3]);
         [4, 5, 6] // Should not get here.
     }
 
-    #[public]
+    #[external("public")]
     fn revert_oracle() -> [Field; 3] {
         avm_revert([1, 2, 3]);
         [4, 5, 6] // Should not get here.
@@ -373,7 +373,7 @@ pub contract AvmTest {
     /************************************************************************
      * Contract instance
      ************************************************************************/
-    #[public]
+    #[external("public")]
     fn test_get_contract_instance(address: AztecAddress) {
         let deployer = get_contract_instance_deployer_avm(address);
         let class_id = get_contract_instance_class_id_avm(address);
@@ -392,7 +392,7 @@ pub contract AvmTest {
         assert(initialization_hash.unwrap() == 0x101112);
     }
 
-    #[public]
+    #[external("public")]
     fn test_get_contract_instance_matches(
         address: AztecAddress,
         expected_deployer: AztecAddress,
@@ -429,67 +429,67 @@ pub contract AvmTest {
     /************************************************************************
      * AvmContext functions
      ************************************************************************/
-    #[public]
+    #[external("public")]
     fn get_address() -> AztecAddress {
         context.this_address()
     }
 
-    #[public]
+    #[external("public")]
     fn get_sender() -> AztecAddress {
         context.msg_sender_unsafe()
     }
 
-    #[public]
+    #[external("public")]
     fn get_transaction_fee() -> Field {
         context.transaction_fee()
     }
 
-    #[public]
+    #[external("public")]
     fn get_chain_id() -> Field {
         context.chain_id()
     }
 
-    #[public]
+    #[external("public")]
     fn get_version() -> Field {
         context.version()
     }
 
-    #[public]
+    #[external("public")]
     fn get_block_number() -> u32 {
         context.block_number()
     }
 
-    #[public]
+    #[external("public")]
     fn get_timestamp() -> u64 {
         context.timestamp()
     }
 
-    #[public]
+    #[external("public")]
     fn get_fee_per_l2_gas() -> u128 {
         context.base_fee_per_l2_gas()
     }
 
-    #[public]
+    #[external("public")]
     fn get_fee_per_da_gas() -> u128 {
         context.base_fee_per_da_gas()
     }
 
-    #[public]
+    #[external("public")]
     fn get_l2_gas_left() -> u32 {
         context.l2_gas_left()
     }
 
-    #[public]
+    #[external("public")]
     fn get_da_gas_left() -> u32 {
         context.da_gas_left()
     }
 
-    #[public]
+    #[external("public")]
     fn get_args_hash(_a: u8, _fields: [Field; 3]) -> Field {
         context.get_args_hash()
     }
 
-    #[public]
+    #[external("public")]
     fn emit_public_log() {
         context.emit_public_log(/*message=*/ [10, 20, 30]);
         context.emit_public_log(/*message=*/ "Hello, world!");
@@ -502,52 +502,52 @@ pub contract AvmTest {
         ]); // Large log
     }
 
-    #[public]
+    #[external("public")]
     fn note_hash_exists(note_hash: Field, leaf_index: u64) -> bool {
         context.note_hash_exists(note_hash, leaf_index)
     }
 
     // Use the standard context interface to emit a new note hash
-    #[public]
+    #[external("public")]
     fn new_note_hash(note_hash: Field) {
         context.push_note_hash(note_hash);
     }
 
     // Use the standard context interface to emit a new nullifier
-    #[public]
+    #[external("public")]
     fn new_nullifier(nullifier: Field) {
         context.push_nullifier(nullifier);
     }
 
-    #[public]
+    #[external("public")]
     fn n_storage_writes(num: u32) {
         for i in 0..num {
             storage.map.at(AztecAddress::from_field(i as Field)).write(i);
         }
     }
 
-    #[public]
+    #[external("public")]
     fn n_new_note_hashes(num: u32) {
         for i in 0..num {
             context.push_note_hash(i as Field);
         }
     }
 
-    #[public]
+    #[external("public")]
     fn n_new_nullifiers(num: u32) {
         for i in 0..num {
             context.push_nullifier(i as Field);
         }
     }
 
-    #[public]
+    #[external("public")]
     fn n_new_l2_to_l1_msgs(num: u32) {
         for i in 0..num {
             context.message_portal(EthAddress::from_field(i as Field), i as Field)
         }
     }
 
-    #[public]
+    #[external("public")]
     fn n_new_public_logs(num: u32) {
         for i in 0..num {
             context.emit_public_log(/*message=*/ [i as Field]);
@@ -555,12 +555,12 @@ pub contract AvmTest {
     }
 
     // Use the standard context interface to check for a nullifier
-    #[public]
+    #[external("public")]
     fn nullifier_exists(nullifier: Field) -> bool {
         context.nullifier_exists(nullifier, context.this_address())
     }
 
-    #[public]
+    #[external("public")]
     fn assert_nullifier_exists(nullifier: Field) {
         assert(
             context.nullifier_exists(nullifier, context.this_address()),
@@ -569,7 +569,7 @@ pub contract AvmTest {
     }
 
     // Use the standard context interface to emit a new nullifier
-    #[public]
+    #[external("public")]
     fn emit_nullifier_and_check(nullifier: Field) {
         context.push_nullifier(nullifier);
         let exists = context.nullifier_exists(nullifier, context.this_address());
@@ -577,19 +577,19 @@ pub contract AvmTest {
     }
 
     // Create the same nullifier twice (shouldn't work!)
-    #[public]
+    #[external("public")]
     fn nullifier_collision(nullifier: Field) {
         context.push_nullifier(nullifier);
         // Can't do this twice!
         context.push_nullifier(nullifier);
     }
 
-    #[public]
+    #[external("public")]
     fn l1_to_l2_msg_exists(msg_hash: Field, msg_leaf_index: Field) -> bool {
         context.l1_to_l2_msg_exists(msg_hash, msg_leaf_index)
     }
 
-    #[public]
+    #[external("public")]
     fn send_l2_to_l1_msg(recipient: EthAddress, content: Field) {
         context.message_portal(recipient, content)
     }
@@ -597,13 +597,13 @@ pub contract AvmTest {
     /************************************************************************
      * Nested calls
      ************************************************************************/
-    #[public]
+    #[external("public")]
     fn nested_call_to_nothing() {
         let garbageAddress = AztecAddress::from_field(42);
         AvmTest::at(garbageAddress).nested_call_to_nothing().call(&mut context)
     }
 
-    #[public]
+    #[external("public")]
     fn nested_call_to_nothing_recovers() {
         let garbageAddress = AztecAddress::from_field(42);
         call(1, 1, garbageAddress, &[]);
@@ -614,7 +614,7 @@ pub contract AvmTest {
         );
     }
 
-    #[public]
+    #[external("public")]
     fn nested_call_to_add_with_gas(
         arg_a: Field,
         arg_b: Field,
@@ -628,12 +628,12 @@ pub contract AvmTest {
     }
 
     // Use the `call_public_function` wrapper to initiate a nested call to the add function
-    #[public]
+    #[external("public")]
     fn nested_call_to_add(arg_a: Field, arg_b: Field) -> pub Field {
         AvmTest::at(context.this_address()).add_args_return(arg_a, arg_b).call(&mut context)
     }
 
-    #[public]
+    #[external("public")]
     fn nested_call_to_add_n_times_different_addresses(
         addrs: [AztecAddress; MAX_PUBLIC_CALLS_TO_UNIQUE_CONTRACT_CLASS_IDS + 2],
     ) {
@@ -646,41 +646,41 @@ pub contract AvmTest {
     }
 
     // Indirectly call_static the external call opcode to initiate a nested call to the add function
-    #[public]
+    #[external("public")]
     fn nested_static_call_to_add(arg_a: Field, arg_b: Field) -> pub Field {
         AvmTest::at(context.this_address()).add_args_return(arg_a, arg_b).view(&mut context)
     }
 
     // Indirectly call_static `set_storage_single`. Should revert since it's accessing storage.
-    #[public]
+    #[external("public")]
     fn nested_static_call_to_set_storage() {
         AvmTest::at(context.this_address()).set_storage_single(20).view(&mut context);
     }
 
-    #[public]
+    #[external("public")]
     fn create_same_nullifier_in_nested_call(nestedAddress: AztecAddress, nullifier: Field) {
         context.push_nullifier(nullifier);
         AvmTest::at(nestedAddress).new_nullifier(nullifier).call(&mut context);
     }
 
-    #[public]
+    #[external("public")]
     fn create_different_nullifier_in_nested_call(nestedAddress: AztecAddress, nullifier: Field) {
         context.push_nullifier(nullifier);
         AvmTest::at(nestedAddress).new_nullifier(nullifier + 1).call(&mut context);
     }
 
-    #[public]
+    #[external("public")]
     fn nested_call_to_assert_same(arg_a: Field, arg_b: Field) -> pub Field {
         AvmTest::at(context.this_address()).assert_same(arg_a, arg_b).call(&mut context)
     }
 
     // function with large array as calldata (for benchmarking call interface macros)
-    #[public]
+    #[external("public")]
     fn fn_w_large_calldata(_arr: [Field; 300]) -> pub Field {
         // do nothing and return...
         5
     }
-    #[public]
+    #[external("public")]
     fn nested_call_large_calldata(arr: [Field; 300]) -> pub Field {
         AvmTest::at(context.this_address()).fn_w_large_calldata(arr).call(&mut context)
     }
@@ -688,7 +688,7 @@ pub contract AvmTest {
     /**
      * Enqueue a public call from private
      */
-    #[private]
+    #[external("private")]
     fn enqueue_public_from_private() {
         AvmTest::at(context.this_address()).set_opcode_u8().enqueue_view(&mut context);
         AvmTest::at(context.this_address()).set_read_storage_single(5).enqueue(&mut context);
@@ -697,21 +697,21 @@ pub contract AvmTest {
     /************************************************************************
      * Protocol Contract Calls
      ************************************************************************/
-    #[public]
+    #[external("public")]
     fn call_fee_juice() {
         let _ = FeeJuice::at(FEE_JUICE_ADDRESS).balance_of_public(context.this_address()).view(
             &mut context,
         );
     }
 
-    #[public]
+    #[external("public")]
     fn call_auth_registry() {
         let _ = AuthRegistry::at(CANONICAL_AUTH_REGISTRY_ADDRESS)
             .is_reject_all(context.this_address())
             .view(&mut context);
     }
 
-    #[public]
+    #[external("public")]
     fn call_instance_registry() {
         let _ = ContractInstanceRegistry::at(CONTRACT_INSTANCE_REGISTRY_CONTRACT_ADDRESS)
             .get_update_delay()
@@ -724,7 +724,7 @@ pub contract AvmTest {
      * calls - but not blackboxes!), since otherwise the whole call will
      * be optimized away.
      ************************************************************************/
-    #[public]
+    #[external("public")]
     fn bulk_testing(
         args_field: [Field; 10],
         args_u8: [u8; 10],

--- a/noir-projects/noir-contracts/contracts/test/benchmarking_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/benchmarking_contract/src/main.nr
@@ -8,7 +8,7 @@ use aztec::macros::aztec;
 #[aztec]
 pub contract Benchmarking {
     use aztec::{
-        macros::{functions::{private, public}, storage::storage},
+        macros::{functions::external, storage::storage},
         messages::message_delivery::MessageDelivery,
         note::note_getter_options::NoteGetterOptions,
         protocol_types::address::AztecAddress,
@@ -23,7 +23,7 @@ pub contract Benchmarking {
     }
 
     // Creates a new value note for the target owner. Use this method to seed an initial set of notes.
-    #[private]
+    #[external("private")]
     fn create_note(owner: AztecAddress, value: Field) {
         let note = ValueNote::new(value, owner);
         storage.notes.at(owner).insert(note).emit(
@@ -37,7 +37,7 @@ pub contract Benchmarking {
     // multiple txs that will land on the same block.
     // See https://discourse.aztec.network/t/utxo-concurrency-issues-for-private-state/635
     // by @rahul-kothari for a full explanation on why this is needed.
-    #[private]
+    #[external("private")]
     fn recreate_note(owner: AztecAddress, index: u32) {
         let owner_notes = storage.notes.at(owner);
         let mut getter_options = NoteGetterOptions::new();
@@ -47,7 +47,7 @@ pub contract Benchmarking {
     }
 
     // Reads and writes to public storage and enqueues a call to another public function.
-    #[public]
+    #[external("public")]
     fn increment_balance(owner: AztecAddress, value: Field) {
         let current = storage.balances.at(owner).read();
         storage.balances.at(owner).write(current + value);
@@ -55,13 +55,13 @@ pub contract Benchmarking {
     }
 
     // Emits a public log.
-    #[public]
+    #[external("public")]
     fn broadcast(owner: AztecAddress) {
         context.emit_public_log(storage.balances.at(owner).read());
     }
 
     // Does a bunch of heavy compute
-    #[public]
+    #[external("public")]
     fn sha256_hash_1024(data: [u8; 1024]) -> [u8; 32] {
         sha256::sha256_var(data, data.len() as u64)
     }

--- a/noir-projects/noir-contracts/contracts/test/child_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/child_contract/src/main.nr
@@ -6,7 +6,7 @@ pub contract Child {
     use dep::aztec::protocol_types::address::AztecAddress;
 
     use dep::aztec::{
-        macros::{functions::{internal, private, public}, storage::storage},
+        macros::{functions::{external, internal}, storage::storage},
         messages::message_delivery::MessageDelivery,
         note::{note_getter_options::NoteGetterOptions, note_interface::NoteProperties},
         state_vars::{Map, PrivateSet, PublicMutable},
@@ -21,20 +21,20 @@ pub contract Child {
     }
 
     // Returns a sum of the input and the chain id and version of the contract in private circuit public input's return_values.
-    #[private]
+    #[external("private")]
     fn value(input: Field) -> Field {
         input + context.chain_id() + context.version()
     }
     // Returns a sum of the input and the chain id and version of the contract in private circuit public input's return_values.
     // Can only be called from this contract.
-    #[private]
+    #[external("private")]
     #[internal]
     fn value_internal(input: Field) -> Field {
         input + context.chain_id() + context.version()
     }
 
     // Returns base_value + chain_id + version + block_number + timestamp
-    #[public]
+    #[external("public")]
     fn pub_get_value(base_value: Field) -> Field {
         let return_value = base_value
             + context.chain_id()
@@ -46,7 +46,7 @@ pub contract Child {
     }
 
     // Sets `current_value` to `new_value`
-    #[public]
+    #[external("public")]
     fn pub_set_value(new_value: Field) -> Field {
         storage.current_value.write(new_value);
         context.emit_public_log(new_value);
@@ -54,7 +54,7 @@ pub contract Child {
         new_value
     }
 
-    #[private]
+    #[external("private")]
     fn private_set_value(new_value: Field, owner: AztecAddress) -> Field {
         let note = ValueNote::new(new_value, owner);
 
@@ -66,7 +66,7 @@ pub contract Child {
         new_value
     }
 
-    #[private]
+    #[external("private")]
     fn private_get_value(amount: Field, owner: AztecAddress) -> Field {
         let mut options = NoteGetterOptions::new();
         options = options.select(ValueNote::properties().value, Comparator.EQ, amount).set_limit(1);
@@ -75,7 +75,7 @@ pub contract Child {
     }
 
     // Increments `current_value` by `new_value`
-    #[public]
+    #[external("public")]
     fn pub_inc_value(new_value: Field) -> Field {
         let old_value = storage.current_value.read();
         storage.current_value.write(old_value + new_value);
@@ -85,7 +85,7 @@ pub contract Child {
     }
 
     // Increments `current_value` by `new_value`. Can only be called from this contract.
-    #[public]
+    #[external("public")]
     #[internal]
     fn pub_inc_value_internal(new_value: Field) -> Field {
         let old_value = storage.current_value.read();
@@ -95,21 +95,21 @@ pub contract Child {
         new_value
     }
 
-    #[public]
+    #[external("public")]
     fn set_value_twice_with_nested_first() {
         let _result = Child::at(context.this_address()).pub_set_value(10).call(&mut context);
         storage.current_value.write(20);
         context.emit_public_log(20);
     }
 
-    #[public]
+    #[external("public")]
     fn set_value_twice_with_nested_last() {
         storage.current_value.write(20);
         context.emit_public_log(20);
         let _result = Child::at(context.this_address()).pub_set_value(10).call(&mut context);
     }
 
-    #[public]
+    #[external("public")]
     fn set_value_with_two_nested_calls() {
         Child::at(context.this_address()).set_value_twice_with_nested_first().call(&mut context);
         Child::at(context.this_address()).set_value_twice_with_nested_last().call(&mut context);

--- a/noir-projects/noir-contracts/contracts/test/counter_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/counter_contract/src/main.nr
@@ -6,7 +6,7 @@ pub contract Counter {
     // docs:end:setup
     // docs:start:imports
     use aztec::{
-        macros::{functions::{initializer, private, utility}, storage::storage},
+        macros::{functions::{external, initializer}, storage::storage},
         oracle::debug_log::debug_log_format,
         protocol_types::{address::AztecAddress, traits::ToField},
         state_vars::Map,
@@ -23,7 +23,7 @@ pub contract Counter {
 
     // docs:start:constructor
     #[initializer]
-    #[private]
+    #[external("private")]
     // We can name our initializer anything we want as long as it's marked as aztec(initializer)
     fn initialize(headstart: u64, owner: AztecAddress) {
         let counters = storage.counters;
@@ -32,7 +32,7 @@ pub contract Counter {
     // docs:end:constructor
 
     // docs:start:increment
-    #[private]
+    #[external("private")]
     fn increment(owner: AztecAddress) {
         debug_log_format("Incrementing counter for owner {0}", [owner.to_field()]);
         let counters = storage.counters;
@@ -40,7 +40,7 @@ pub contract Counter {
     }
     // docs:end:increment
 
-    #[private]
+    #[external("private")]
     fn increment_twice(owner: AztecAddress) {
         debug_log_format(
             "Incrementing counter twice for owner {0}",
@@ -51,7 +51,7 @@ pub contract Counter {
         counters.at(owner).add(1, owner);
     }
 
-    #[private]
+    #[external("private")]
     fn increment_and_decrement(owner: AztecAddress) {
         debug_log_format(
             "Incrementing and decrementing counter for owner {0}",
@@ -62,7 +62,7 @@ pub contract Counter {
         counters.at(owner).sub(1, owner);
     }
 
-    #[private]
+    #[external("private")]
     fn decrement(owner: AztecAddress) {
         debug_log_format("Decrementing counter for owner {0}", [owner.to_field()]);
         let counters = storage.counters;
@@ -70,13 +70,13 @@ pub contract Counter {
     }
 
     // docs:start:get_counter
-    #[utility]
+    #[external("utility")]
     unconstrained fn get_counter(owner: AztecAddress) -> Field {
         storage.counters.at(owner).get_value()
     }
     // docs:end:get_counter
 
-    #[private]
+    #[external("private")]
     fn increment_self_and_other(other_counter: AztecAddress, owner: AztecAddress) {
         debug_log_format("Incrementing counter for other {0}", [owner.to_field()]);
 

--- a/noir-projects/noir-contracts/contracts/test/event_only_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/event_only_contract/src/main.nr
@@ -6,7 +6,7 @@ use aztec::macros::aztec;
 contract EventOnly {
     use aztec::{
         event::event_emission::emit_event_in_private,
-        macros::{events::event, functions::private},
+        macros::{events::event, functions::external},
         messages::message_delivery::MessageDelivery,
     };
 
@@ -15,7 +15,7 @@ contract EventOnly {
         value: Field,
     }
 
-    #[private]
+    #[external("private")]
     fn emit_event_for_msg_sender(value: Field) {
         let sender = context.msg_sender().unwrap();
         emit_event_in_private(

--- a/noir-projects/noir-contracts/contracts/test/import_test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/import_test_contract/src/main.nr
@@ -8,12 +8,12 @@ pub contract ImportTest {
 
     use dep::test::Test;
 
-    use dep::aztec::macros::functions::{private, public};
+    use dep::aztec::macros::functions::external;
 
     // Calls the get_this_address on the Test contract at the target address
     // Used for testing calling a function with no arguments
     // See yarn-project/end-to-end/src/e2e_nested_contract.test.ts
-    #[private]
+    #[external("private")]
     fn call_no_args(target: AztecAddress) -> AztecAddress {
         Test::at(target).get_this_address().call(&mut context)
     }
@@ -21,7 +21,7 @@ pub contract ImportTest {
     // Calls the emit_nullifier_public on the Test contract at the target address
     // Used for testing calling a public function
     // See yarn-project/end-to-end/src/e2e_nested_contract.test.ts
-    #[private]
+    #[external("private")]
     fn call_public_fn(target: AztecAddress) {
         Test::at(target).emit_nullifier_public(1).enqueue(&mut context);
     }
@@ -29,7 +29,7 @@ pub contract ImportTest {
     // Calls the emit_nullifier_public on the Test contract at the target address
     // Used for testing calling a public function from another public function
     // See yarn-project/end-to-end/src/e2e_nested_contract.test.ts
-    #[public]
+    #[external("public")]
     fn pub_call_public_fn(target: AztecAddress) {
         Test::at(target).emit_nullifier_public(1).call(&mut context);
     }

--- a/noir-projects/noir-contracts/contracts/test/invalid_account_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/invalid_account_contract/src/main.nr
@@ -4,9 +4,9 @@ use aztec::macros::aztec;
 /// doesn't have an account entrypoint function defined (and the `verify_private_authwit` function is also invalid).
 #[aztec]
 pub contract InvalidAccount {
-    use aztec::macros::functions::{private, view};
+    use aztec::macros::functions::{external, view};
 
-    #[private]
+    #[external("private")]
     #[view]
     fn verify_private_authwit(inner_hash: Field) -> Field {
         // Any return value that is not IS_VALID_SELECTOR (0x47dacd73) means 'invalid authwit'

--- a/noir-projects/noir-contracts/contracts/test/no_constructor_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/no_constructor_contract/src/main.nr
@@ -5,7 +5,7 @@ use aztec::macros::aztec;
 #[aztec]
 pub contract NoConstructor {
     use aztec::{
-        macros::{functions::{private, public, utility}, storage::storage},
+        macros::{functions::external, storage::storage},
         messages::message_delivery::MessageDelivery,
         state_vars::PrivateMutable,
     };
@@ -18,14 +18,14 @@ pub contract NoConstructor {
     }
 
     /// Arbitrary public method used to test that publishing for public execution works for a contract with no constructor.
-    #[public]
+    #[external("public")]
     fn emit_public(value: Field) {
         context.emit_public_log(/*message=*/ value);
     }
 
     /// Arbitrary function used to test that we can call private functions on a contract with
     /// no constructor/initializer.
-    #[private]
+    #[external("private")]
     fn initialize_private_mutable(value: Field) {
         let note = ValueNote::new(value, context.msg_sender().unwrap());
 
@@ -37,7 +37,7 @@ pub contract NoConstructor {
     }
 
     /// Helper function used to test that call to `initialize_private_mutable` was successful or not yet performed.
-    #[utility]
+    #[external("utility")]
     unconstrained fn is_private_mutable_initialized() -> bool {
         storage.private_mutable.is_initialized()
     }

--- a/noir-projects/noir-contracts/contracts/test/note_getter_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/note_getter_contract/src/main.nr
@@ -8,7 +8,7 @@ pub contract NoteGetter {
         messages::message_delivery::MessageDelivery,
         note::note_interface::NoteProperties,
         // Macros
-        macros::{functions::{private, utility}, storage::storage},
+        macros::{functions::external, storage::storage},
         note::note_viewer_options::NoteViewerOptions,
         state_vars::PrivateSet,
     };
@@ -20,7 +20,7 @@ pub contract NoteGetter {
         set: PrivateSet<ValueNote, Context>,
     }
 
-    #[private]
+    #[external("private")]
     fn insert_note(value: Field) {
         let note = ValueNote::new(value, context.msg_sender().unwrap());
 
@@ -31,7 +31,7 @@ pub contract NoteGetter {
         );
     }
 
-    #[utility]
+    #[external("utility")]
     unconstrained fn read_note_values(comparator: u8, value: Field) -> BoundedVec<Field, 10> {
         let notes = storage.set.view_notes(NoteViewerOptions::new().select(
             ValueNote::properties().value,

--- a/noir-projects/noir-contracts/contracts/test/offchain_effect_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/offchain_effect_contract/src/main.nr
@@ -5,7 +5,7 @@ use aztec::macros::aztec;
 contract OffchainEffect {
     use aztec::{
         event::event_emission::emit_event_in_private,
-        macros::{events::event, functions::{private, utility}, storage::storage},
+        macros::{events::event, functions::external, storage::storage},
         messages::message_delivery::MessageDelivery,
         note::note_viewer_options::NoteViewerOptions,
         oracle::offchain_effect::emit_offchain_effect,
@@ -32,7 +32,7 @@ contract OffchainEffect {
         balances: Map<AztecAddress, PrivateSet<UintNote, Context>, Context>,
     }
 
-    #[private]
+    #[external("private")]
     fn emit_offchain_effects(effects: BoundedVec<EffectPayload, 6>) {
         if effects.len() > 0 {
             let mut effects = effects;
@@ -49,7 +49,7 @@ contract OffchainEffect {
         }
     }
 
-    #[private]
+    #[external("private")]
     fn emit_event_as_offchain_message_for_msg_sender(a: u64, b: u64, c: u64) {
         emit_event_in_private(
             TestEvent { a, b, c },
@@ -59,7 +59,7 @@ contract OffchainEffect {
         );
     }
 
-    #[private]
+    #[external("private")]
     fn emit_note_as_offchain_message(value: u128, owner: AztecAddress) {
         let note = UintNote::new(value, owner);
 
@@ -70,12 +70,12 @@ contract OffchainEffect {
         );
     }
 
-    #[utility]
+    #[external("utility")]
     unconstrained fn emitting_offchain_effect_from_utility_reverts() {
         emit_offchain_effect([0; 5]);
     }
 
-    #[utility]
+    #[external("utility")]
     unconstrained fn get_note_value(owner: AztecAddress) -> u128 {
         let notes = storage.balances.at(owner).view_notes(NoteViewerOptions::new());
         assert(notes.len() == 1, "No note found");

--- a/noir-projects/noir-contracts/contracts/test/oracle_version_check_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/oracle_version_check_contract/src/main.nr
@@ -3,14 +3,14 @@ use aztec::macros::aztec;
 /// Used to test that the oracle version check is performed when a private or utility function is called.
 #[aztec]
 pub contract OracleVersionCheck {
-    use aztec::macros::functions::{private, utility};
+    use aztec::macros::functions::external;
 
-    #[private]
+    #[external("private")]
     fn private_function() -> Field {
         0
     }
 
-    #[utility]
+    #[external("utility")]
     unconstrained fn utility_function() -> Field {
         0
     }

--- a/noir-projects/noir-contracts/contracts/test/parent_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/parent_contract/src/main.nr
@@ -3,19 +3,19 @@ use dep::aztec::macros::aztec;
 
 #[aztec]
 pub contract Parent {
-    use dep::aztec::{context::gas::GasOpts, macros::functions::{private, public}};
+    use dep::aztec::{context::gas::GasOpts, macros::functions::external};
     use dep::aztec::protocol_types::constants::MAX_FR_CALLDATA_TO_ALL_ENQUEUED_CALLS;
     use aztec::protocol_types::{
         abis::function_selector::FunctionSelector, address::AztecAddress, traits::ToField,
     };
     // Private function to call another private function in the target_contract using the provided selector
-    #[private]
+    #[external("private")]
     fn entry_point(target_contract: AztecAddress, target_selector: FunctionSelector) -> Field {
         // Call the target private function
         context.call_private_function(target_contract, target_selector, [0]).get_preimage()
     }
     // Public function to directly call another public function to the target_contract using the selector and value provided
-    #[public]
+    #[external("public")]
     fn pub_entry_point(
         target_contract: AztecAddress,
         target_selector: FunctionSelector,
@@ -29,7 +29,7 @@ pub contract Parent {
         )[0]
     }
     // Same as pub_entry_point, but calls the target contract twice, using the return value from the first invocation as the argument for the second.
-    #[public]
+    #[external("public")]
     fn pub_entry_point_twice(
         target_contract: AztecAddress,
         target_selector: FunctionSelector,
@@ -49,7 +49,7 @@ pub contract Parent {
         )[0]
     }
     // Private function to enqueue a call to the target_contract address using the selector and argument provided
-    #[private]
+    #[external("private")]
     fn enqueue_call_to_child(
         target_contract: AztecAddress,
         target_selector: FunctionSelector,
@@ -58,12 +58,12 @@ pub contract Parent {
         context.call_public_function(target_contract, target_selector, [target_value], false);
     }
 
-    #[public]
+    #[external("public")]
     fn public_call_with_max_over_n_args(
         _args: [Field; MAX_FR_CALLDATA_TO_ALL_ENQUEUED_CALLS / 10],
     ) {}
 
-    #[private]
+    #[external("private")]
     fn enqueue_call_to_child_with_many_args_and_recurse(remaining_recursions: u32) {
         let args = [0; MAX_FR_CALLDATA_TO_ALL_ENQUEUED_CALLS / 10];
         // +1 for function selector brings us to max
@@ -80,7 +80,7 @@ pub contract Parent {
     // Private function that enqueues two calls to a child contract:
     // - one through a nested call to enqueue_call_to_child with value 10,
     // - followed by one issued directly from this function with value 20.
-    #[private]
+    #[external("private")]
     fn enqueue_calls_to_child_with_nested_first(
         target_contract: AztecAddress,
         target_selector: FunctionSelector,
@@ -98,7 +98,7 @@ pub contract Parent {
     // Private function that enqueues two calls to a child contract:
     // - one issued directly from this function with value 20,
     // - followed by one through a nested call to enqueue_call_to_child with value 10.
-    #[private]
+    #[external("private")]
     fn enqueue_calls_to_child_with_nested_last(
         target_contract: AztecAddress,
         target_selector: FunctionSelector,
@@ -114,7 +114,7 @@ pub contract Parent {
         );
     }
     // Private function to enqueue a call to the target_contract address using the selector and argument provided
-    #[private]
+    #[external("private")]
     fn enqueue_call_to_child_twice(
         target_contract: AztecAddress,
         target_selector: FunctionSelector,
@@ -126,7 +126,7 @@ pub contract Parent {
         context.call_public_function(target_contract, target_selector, [target_value + 1], false);
     }
     // Private function to enqueue a call to the pub_entry_point function of this same contract, passing the target arguments provided
-    #[private]
+    #[external("private")]
     fn enqueue_call_to_pub_entry_point(
         target_contract: AztecAddress,
         target_selector: FunctionSelector,
@@ -143,7 +143,7 @@ pub contract Parent {
         );
     }
     // Private function to enqueue two calls to the pub_entry_point function of this same contract, passing the target arguments provided
-    #[private]
+    #[external("private")]
     fn enqueue_calls_to_pub_entry_point(
         target_contract: AztecAddress,
         target_selector: FunctionSelector,
@@ -165,7 +165,7 @@ pub contract Parent {
             false,
         );
     }
-    #[private]
+    #[external("private")]
     fn private_static_call(
         target_contract: AztecAddress,
         target_selector: FunctionSelector,
@@ -174,7 +174,7 @@ pub contract Parent {
         // Call the target private function
         context.static_call_private_function(target_contract, target_selector, args).get_preimage()
     }
-    #[private]
+    #[external("private")]
     fn private_call(
         target_contract: AztecAddress,
         target_selector: FunctionSelector,
@@ -184,7 +184,7 @@ pub contract Parent {
         context.call_private_function(target_contract, target_selector, args).get_preimage()
     }
     // Private function to set a static context and verify correct propagation for nested private calls
-    #[private]
+    #[external("private")]
     fn private_nested_static_call(
         target_contract: AztecAddress,
         target_selector: FunctionSelector,
@@ -205,7 +205,7 @@ pub contract Parent {
         return_value
     }
     // Public function to directly call another public function to the target_contract using the selector and value provided
-    #[public]
+    #[external("public")]
     fn public_static_call(
         target_contract: AztecAddress,
         target_selector: FunctionSelector,
@@ -219,7 +219,7 @@ pub contract Parent {
         )[0]
     }
     // Public function to set a static context and verify correct propagation for nested public calls
-    #[public]
+    #[external("public")]
     fn public_nested_static_call(
         target_contract: AztecAddress,
         target_selector: FunctionSelector,
@@ -237,7 +237,7 @@ pub contract Parent {
         )[0]
     }
     // Private function to enqueue a static call to the pub_entry_point function of another contract, passing the target arguments provided
-    #[private]
+    #[external("private")]
     fn enqueue_static_nested_call_to_pub_function(
         target_contract: AztecAddress,
         target_selector: FunctionSelector,
@@ -255,7 +255,7 @@ pub contract Parent {
         );
     }
     // Private function to enqueue a static call to the pub_entry_point function of another contract, passing the target arguments provided
-    #[private]
+    #[external("private")]
     fn enqueue_static_call_to_pub_function(
         target_contract: AztecAddress,
         target_selector: FunctionSelector,

--- a/noir-projects/noir-contracts/contracts/test/pending_note_hashes_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/pending_note_hashes_contract/src/main.nr
@@ -9,7 +9,7 @@ pub contract PendingNoteHashes {
     // Libs
     use aztec::{
         context::PrivateContext,
-        macros::{functions::private, storage::storage},
+        macros::{functions::external, storage::storage},
         messages::message_delivery::MessageDelivery,
         note::{note_emission::NoteEmission, note_getter_options::NoteGetterOptions},
         protocol_types::{
@@ -33,7 +33,7 @@ pub contract PendingNoteHashes {
     // Confirm can access pending note hashes by creating / inserting a note and then
     // getting / reading that note all in the same contract function
     // Realistic way to describe this test is "Mint note A, then burn note A in the same transaction"
-    #[private]
+    #[external("private")]
     fn test_insert_then_get_then_nullify_flat(
         amount: Field,
         owner: AztecAddress,
@@ -58,7 +58,7 @@ pub contract PendingNoteHashes {
     }
 
     // Confirm cannot access note hashes inserted later in same function
-    #[private]
+    #[external("private")]
     fn test_bad_get_then_insert_flat(amount: Field, owner: AztecAddress) -> Field {
         let owner_balance = storage.balances.at(owner);
 
@@ -76,11 +76,11 @@ pub contract PendingNoteHashes {
     }
 
     // Dummy nested/inner function (to pass a function which does nothing)
-    #[private]
+    #[external("private")]
     fn dummy(amount: Field, owner: AztecAddress, sender: AztecAddress) {}
 
     // Nested/inner function to create and insert a note
-    #[private]
+    #[external("private")]
     fn insert_note(amount: Field, owner: AztecAddress, sender: AztecAddress) {
         let owner_balance = storage.balances.at(owner);
 
@@ -93,7 +93,7 @@ pub contract PendingNoteHashes {
     // Nested/inner function to create and insert a note
     // TESTING: inserts a static randomness value to test notes with
     // the same note hash are dealt with correctly
-    #[private]
+    #[external("private")]
     fn insert_note_static_randomness(amount: Field, owner: AztecAddress, sender: AztecAddress) {
         let owner_balance = storage.balances.at(owner);
 
@@ -108,7 +108,7 @@ pub contract PendingNoteHashes {
 
     // Nested/inner function to create and insert a note
     // then emit another note log for the same note
-    #[private]
+    #[external("private")]
     fn insert_note_extra_emit(amount: Field, owner: AztecAddress, sender: AztecAddress) {
         let owner_balance = storage.balances.at(owner);
 
@@ -124,7 +124,7 @@ pub contract PendingNoteHashes {
     }
 
     // Nested/inner function to get a note and confirm it matches the expected value
-    #[private]
+    #[external("private")]
     fn get_then_nullify_note(expected_value: Field, owner: AztecAddress) -> Field {
         let owner_balance = storage.balances.at(owner);
 
@@ -137,7 +137,7 @@ pub contract PendingNoteHashes {
     }
 
     // Nested/inner function to get a note and confirms that none is returned
-    #[private]
+    #[external("private")]
     fn get_note_zero_balance(owner: AztecAddress) {
         let owner_balance = storage.balances.at(owner);
 
@@ -150,7 +150,7 @@ pub contract PendingNoteHashes {
     // Test pending note hashes with note insertion done in a nested call
     // and "read" / get of that pending note hash in another nested call
     // Realistic way to describe this test is "Mint note A, then burn note A in the same transaction"
-    #[private]
+    #[external("private")]
     fn test_insert_then_get_then_nullify_all_in_nested_calls(
         amount: Field,
         owner: AztecAddress,
@@ -173,7 +173,7 @@ pub contract PendingNoteHashes {
     }
 
     // same test as above, but insert 2, get 2, nullify 2
-    #[private]
+    #[external("private")]
     fn test_insert2_then_get2_then_nullify2_all_in_nested_calls(
         amount: Field,
         owner: AztecAddress,
@@ -213,7 +213,7 @@ pub contract PendingNoteHashes {
     }
 
     // same test as above, but insert 2, get 1, nullify 1
-    #[private]
+    #[external("private")]
     fn test_insert2_then_get2_then_nullify1_all_in_nested_calls(
         amount: Field,
         owner: AztecAddress,
@@ -247,7 +247,7 @@ pub contract PendingNoteHashes {
     // insert 1 note, then get 2 notes (one pending, one persistent) and nullify both.
     // one nullifier will be squashed with the pending note, one will become persistent.
     // ONLY WORKS IF THERE IS A PERSISTENT NOTE TO GET
-    #[private]
+    #[external("private")]
     fn test_insert1_then_get2_then_nullify2_all_in_nested_calls(
         amount: Field,
         owner: AztecAddress,
@@ -284,7 +284,7 @@ pub contract PendingNoteHashes {
     // nested call (later kernel iteration) should not be able to read the note hash despite
     // it being present at that stage in the kernel.
     // If we can somehow force the simulator to allow execution to succeed can ensure that this test fails in the kernel
-    // #[private]
+    // #[external("private")]
     // fn test_bad_get_in_nested_call_then_insert(
     //    amount: Field,
     //    owner: AztecAddress,
@@ -292,7 +292,7 @@ pub contract PendingNoteHashes {
     //) {
     //}
 
-    #[private]
+    #[external("private")]
     fn test_recursively_create_notes(
         owner: AztecAddress,
         sender: AztecAddress,
@@ -305,7 +305,7 @@ pub contract PendingNoteHashes {
             .call(&mut context);
     }
 
-    #[private]
+    #[external("private")]
     fn recursively_destroy_and_create_notes(
         owner: AztecAddress,
         sender: AztecAddress,
@@ -328,7 +328,7 @@ pub contract PendingNoteHashes {
     // TESTING: Forces the private context to accept a note log for a non-existent note
     // by using an existing note's counter via its header. This is used to check that
     // the pxe rejects the note log later.
-    #[private]
+    #[external("private")]
     fn test_emit_bad_note_log(owner: AztecAddress, sender: AztecAddress) {
         let owner_balance = storage.balances.at(owner);
 

--- a/noir-projects/noir-contracts/contracts/test/public_immutable_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/public_immutable_contract/src/main.nr
@@ -3,24 +3,24 @@ use aztec::macros::aztec;
 /// Used to test public immutable state variable.
 #[aztec]
 contract PublicImmutableContract {
-    use aztec::{macros::{functions::public, storage::storage}, state_vars::PublicImmutable};
+    use aztec::{macros::{functions::external, storage::storage}, state_vars::PublicImmutable};
 
     #[storage]
     struct Storage<Context> {
         immutable_value: PublicImmutable<Field, Context>,
     }
 
-    #[public]
+    #[external("public")]
     fn initialize_value(value: Field) {
         storage.immutable_value.initialize(value);
     }
 
-    #[public]
+    #[external("public")]
     fn read_value() -> pub Field {
         storage.immutable_value.read()
     }
 
-    #[public]
+    #[external("public")]
     fn read_value_unsafe() -> pub Field {
         storage.immutable_value.read_unsafe()
     }

--- a/noir-projects/noir-contracts/contracts/test/returning_tuple_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/returning_tuple_contract/src/main.nr
@@ -4,77 +4,77 @@ use aztec::macros::aztec;
 #[aztec]
 pub contract ReturningTuple {
     use aztec::{
-        macros::functions::{private, public, view},
+        macros::functions::{external, view},
         protocol_types::{address::AztecAddress, point::Point, traits::{Deserialize, FromField}},
     };
 
-    #[private]
+    #[external("private")]
     #[view]
     fn fn_that_returns_1() -> (bool,) {
         (true,)
     }
 
-    #[private]
+    #[external("private")]
     #[view]
     fn fn_that_returns_2() -> (Field, u32) {
         (1, 2)
     }
 
-    #[private]
+    #[external("private")]
     #[view]
     fn fn_that_returns_3() -> (Field, bool, str<4>) {
         (1, true, "test")
     }
 
-    #[private]
+    #[external("private")]
     #[view]
     fn fn_that_returns_4() -> (Field, u64, bool, str<3>) {
         (1, 2, false, "abc")
     }
 
-    #[private]
+    #[external("private")]
     #[view]
     fn fn_that_returns_5() -> (Field, u32, bool, str<2>, i64) {
         (1, 2, true, "hi", -5)
     }
 
-    #[private]
+    #[external("private")]
     #[view]
     fn fn_that_returns_6() -> (Field, u128, bool, str<3>, AztecAddress, Point) {
         (1, 2, false, "xyz", AztecAddress::from_field(1), Point::deserialize([1, 2, 3]))
     }
 
-    #[public]
+    #[external("public")]
     #[view]
     fn fn_that_returns_1_public() -> (bool,) {
         (true,)
     }
 
-    #[public]
+    #[external("public")]
     #[view]
     fn fn_that_returns_2_public() -> (Field, u32) {
         (1, 2)
     }
 
-    #[public]
+    #[external("public")]
     #[view]
     fn fn_that_returns_3_public() -> (Field, bool, str<4>) {
         (1, true, "test")
     }
 
-    #[public]
+    #[external("public")]
     #[view]
     fn fn_that_returns_4_public() -> (Field, u64, bool, str<3>) {
         (1, 2, false, "abc")
     }
 
-    #[public]
+    #[external("public")]
     #[view]
     fn fn_that_returns_5_public() -> (Field, u32, bool, str<2>, i64) {
         (1, 2, true, "hi", -5)
     }
 
-    #[public]
+    #[external("public")]
     #[view]
     fn fn_that_returns_6_public() -> (Field, u128, bool, str<3>, AztecAddress, Point) {
         (1, 2, false, "xyz", AztecAddress::from_field(1), Point::deserialize([1, 2, 3]))

--- a/noir-projects/noir-contracts/contracts/test/spam_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/spam_contract/src/main.nr
@@ -6,7 +6,7 @@ use aztec::macros::aztec;
 pub contract Spam {
 
     use aztec::{
-        macros::{functions::{internal, private, public}, storage::storage},
+        macros::{functions::{external, internal}, storage::storage},
         messages::message_delivery::MessageDelivery,
         protocol_types::{
             address::AztecAddress,
@@ -27,7 +27,7 @@ pub contract Spam {
         public_balances: Map<Field, PublicMutable<u128, Context>, Context>,
     }
 
-    #[private]
+    #[external("private")]
     fn spam(nullifier_seed: Field, nullifier_count: u32, call_public: bool) {
         let caller = context.msg_sender().unwrap();
         let amount = 1 as u128;
@@ -62,7 +62,7 @@ pub contract Spam {
         }
     }
 
-    #[public]
+    #[external("public")]
     #[internal]
     fn public_spam(start: u32, end: u32) {
         let one = 1 as u128;

--- a/noir-projects/noir-contracts/contracts/test/state_vars_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/state_vars_contract/src/main.nr
@@ -4,7 +4,7 @@ use aztec::macros::aztec;
 #[aztec]
 pub contract StateVars {
     use aztec::{
-        macros::{functions::{private, public, utility, view}, storage::{storage, storage_no_init}},
+        macros::{functions::{external, view}, storage::{storage, storage_no_init}},
         messages::message_delivery::MessageDelivery,
         protocol_types::{address::AztecAddress, traits::{Deserialize, Packable, Serialize}},
         state_vars::{PrivateImmutable, PrivateMutable, PublicImmutable, PublicMutable},
@@ -37,13 +37,13 @@ pub contract StateVars {
         }
     }
 
-    #[public]
+    #[external("public")]
     fn initialize_public_immutable(value: u8) {
         let mut new_mock_struct = MockStruct { account: context.msg_sender().unwrap(), value };
         storage.public_immutable.initialize(new_mock_struct);
     }
 
-    #[private]
+    #[external("private")]
     fn match_public_immutable(account: AztecAddress, value: u8) {
         let expected = MockStruct { account, value };
         let read = storage.public_immutable.read();
@@ -52,7 +52,7 @@ pub contract StateVars {
         assert(read.value == expected.value, "Invalid value");
     }
 
-    #[private]
+    #[external("private")]
     fn get_public_immutable_constrained_private_indirect() -> MockStruct {
         let mut mock_struct = StateVars::at(context.this_address())
             .get_public_immutable_constrained_private()
@@ -61,7 +61,7 @@ pub contract StateVars {
         mock_struct
     }
 
-    #[public]
+    #[external("public")]
     fn get_public_immutable_constrained_public_indirect() -> MockStruct {
         // This is a public function that calls another public function
         // and returns the response.
@@ -74,30 +74,30 @@ pub contract StateVars {
         mock_struct
     }
 
-    #[public]
+    #[external("public")]
     #[view]
     fn get_public_immutable_constrained_public() -> MockStruct {
         storage.public_immutable.read()
     }
 
-    #[public]
+    #[external("public")]
     fn get_public_immutable_constrained_public_multiple() -> [MockStruct; 5] {
         let a = storage.public_immutable.read();
         [a, a, a, a, a]
     }
 
-    #[private]
+    #[external("private")]
     #[view]
     fn get_public_immutable_constrained_private() -> MockStruct {
         storage.public_immutable.read()
     }
 
-    #[utility]
+    #[external("utility")]
     unconstrained fn get_public_immutable() -> MockStruct {
         storage.public_immutable.read()
     }
 
-    #[private]
+    #[external("private")]
     fn initialize_private_immutable(randomness: Field, value: Field) {
         let new_note = ValueNote::new(value, context.msg_sender().unwrap());
 
@@ -108,7 +108,7 @@ pub contract StateVars {
         );
     }
 
-    #[private]
+    #[external("private")]
     fn initialize_private(randomness: Field, value: Field) {
         let private_mutable = ValueNote::new(value, context.msg_sender().unwrap());
 
@@ -119,7 +119,7 @@ pub contract StateVars {
         );
     }
 
-    #[private]
+    #[external("private")]
     fn update_private_mutable(randomness: Field, value: Field) {
         storage
             .private_mutable
@@ -127,7 +127,7 @@ pub contract StateVars {
             .emit(&mut context, context.msg_sender().unwrap(), MessageDelivery.CONSTRAINED_ONCHAIN);
     }
 
-    #[private]
+    #[external("private")]
     fn increase_private_value() {
         // Replace existing note with new note containing incremented value
         storage
@@ -139,22 +139,22 @@ pub contract StateVars {
             .emit(&mut context, context.msg_sender().unwrap(), MessageDelivery.CONSTRAINED_ONCHAIN);
     }
 
-    #[utility]
+    #[external("utility")]
     unconstrained fn get_private_mutable() -> ValueNote {
         storage.private_mutable.view_note()
     }
 
-    #[utility]
+    #[external("utility")]
     unconstrained fn is_private_mutable_initialized() -> bool {
         storage.private_mutable.is_initialized()
     }
 
-    #[utility]
+    #[external("utility")]
     unconstrained fn view_private_immutable() -> ValueNote {
         storage.private_immutable.view_note()
     }
 
-    #[utility]
+    #[external("utility")]
     unconstrained fn is_priv_imm_initialized() -> bool {
         storage.private_immutable.is_initialized()
     }

--- a/noir-projects/noir-contracts/contracts/test/stateful_test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/stateful_test_contract/src/main.nr
@@ -5,8 +5,8 @@ use aztec::macros::aztec;
 pub contract StatefulTest {
     use aztec::macros::{
         functions::{
-            initialization_utils::assert_is_initialized_private, initializer, noinitcheck, private,
-            public, utility, view,
+            external, initialization_utils::assert_is_initialized_private, initializer, noinitcheck,
+            view,
         },
         storage::storage,
     };
@@ -24,7 +24,7 @@ pub contract StatefulTest {
         public_values: Map<AztecAddress, PublicMutable<Field, Context>, Context>,
     }
 
-    #[private]
+    #[external("private")]
     #[initializer]
     fn constructor(owner: AztecAddress, value: Field) {
         StatefulTest::at(context.this_address()).create_note_no_init_check(owner, value).call(
@@ -32,14 +32,14 @@ pub contract StatefulTest {
         );
     }
 
-    #[private]
+    #[external("private")]
     #[initializer]
     fn wrong_constructor() {
         let selector = FunctionSelector::from_signature("not_exists(Field)");
         let _res = context.call_public_function(context.this_address(), selector, [42], false);
     }
 
-    #[public]
+    #[external("public")]
     #[initializer]
     fn public_constructor(owner: AztecAddress, value: Field) {
         StatefulTest::at(context.this_address())
@@ -47,7 +47,7 @@ pub contract StatefulTest {
             .call(&mut context);
     }
 
-    #[private]
+    #[external("private")]
     fn create_note(owner: AztecAddress, value: Field) {
         if (value != 0) {
             let loc = storage.notes.at(owner);
@@ -56,7 +56,7 @@ pub contract StatefulTest {
         }
     }
 
-    #[private]
+    #[external("private")]
     #[noinitcheck]
     fn create_note_no_init_check(owner: AztecAddress, value: Field) {
         if (value != 0) {
@@ -66,7 +66,7 @@ pub contract StatefulTest {
         }
     }
 
-    #[private]
+    #[external("private")]
     fn destroy_and_create(recipient: AztecAddress) {
         assert_is_initialized_private(&mut context);
         let sender = context.msg_sender().unwrap();
@@ -81,7 +81,7 @@ pub contract StatefulTest {
         );
     }
 
-    #[private]
+    #[external("private")]
     #[noinitcheck]
     fn destroy_and_create_no_init_check(recipient: AztecAddress) {
         let sender = context.msg_sender().unwrap();
@@ -96,20 +96,20 @@ pub contract StatefulTest {
         );
     }
 
-    #[public]
+    #[external("public")]
     fn increment_public_value(owner: AztecAddress, value: Field) {
         let loc = storage.public_values.at(owner);
         loc.write(loc.read() + value);
     }
 
-    #[public]
+    #[external("public")]
     #[noinitcheck]
     fn increment_public_value_no_init_check(owner: AztecAddress, value: Field) {
         let loc = storage.public_values.at(owner);
         loc.write(loc.read() + value);
     }
 
-    #[utility]
+    #[external("utility")]
     unconstrained fn summed_values(owner: AztecAddress) -> Field {
         let owner_balance = storage.notes.at(owner);
 
@@ -117,7 +117,7 @@ pub contract StatefulTest {
         balance_utils::get_balance(owner_balance)
     }
 
-    #[public]
+    #[external("public")]
     #[noinitcheck]
     #[view]
     fn get_public_value(owner: AztecAddress) -> pub Field {

--- a/noir-projects/noir-contracts/contracts/test/static_child_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/static_child_contract/src/main.nr
@@ -4,7 +4,7 @@ use dep::aztec::macros::aztec;
 #[aztec]
 pub contract StaticChild {
     use dep::aztec::{
-        macros::{functions::{private, public, view}, storage::storage},
+        macros::{functions::{external, view}, storage::storage},
         messages::message_delivery::MessageDelivery,
         note::note_getter_options::NoteGetterOptions,
         protocol_types::address::AztecAddress,
@@ -21,7 +21,7 @@ pub contract StaticChild {
     }
 
     // Returns base_value + chain_id + version + block_number + timestamp statically
-    #[public]
+    #[external("public")]
     #[view]
     fn pub_get_value(base_value: Field) -> Field {
         let return_value = base_value
@@ -34,7 +34,7 @@ pub contract StaticChild {
     }
 
     // Sets `current_value` to `new_value`
-    #[public]
+    #[external("public")]
     fn pub_set_value(new_value: Field) -> Field {
         storage.current_value.write(new_value);
         context.emit_public_log(new_value);
@@ -42,7 +42,7 @@ pub contract StaticChild {
     }
 
     // View function that attempts to modify state. Should always fail regardless how it's called.
-    #[private]
+    #[external("private")]
     #[view]
     fn private_illegal_set_value(new_value: Field, owner: AztecAddress) -> Field {
         let note = ValueNote::new(new_value, owner);
@@ -55,7 +55,7 @@ pub contract StaticChild {
     }
 
     // Modify a note
-    #[private]
+    #[external("private")]
     fn private_set_value(new_value: Field, owner: AztecAddress, sender: AztecAddress) -> Field {
         let note = ValueNote::new(new_value, owner);
 
@@ -68,7 +68,7 @@ pub contract StaticChild {
     }
 
     // Retrieve note value statically
-    #[private]
+    #[external("private")]
     #[view]
     fn private_get_value(amount: Field, owner: AztecAddress) -> Field {
         let mut options = NoteGetterOptions::new();
@@ -81,7 +81,7 @@ pub contract StaticChild {
     }
 
     // Increments `current_value` by `new_value`
-    #[public]
+    #[external("public")]
     fn pub_inc_value(new_value: Field) -> Field {
         let old_value = storage.current_value.read();
         storage.current_value.write(old_value + new_value);
@@ -90,7 +90,7 @@ pub contract StaticChild {
     }
 
     // View function that attempts to modify state. Should always fail regardless how it's called.
-    #[public]
+    #[external("public")]
     #[view]
     fn pub_illegal_inc_value(new_value: Field) -> Field {
         let old_value = storage.current_value.read();

--- a/noir-projects/noir-contracts/contracts/test/static_parent_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/static_parent_contract/src/main.nr
@@ -3,14 +3,14 @@ use dep::aztec::macros::aztec;
 
 #[aztec]
 pub contract StaticParent {
-    use dep::aztec::{context::gas::GasOpts, macros::functions::{private, public}};
+    use dep::aztec::{context::gas::GasOpts, macros::functions::external};
     use dep::aztec::protocol_types::{
         abis::function_selector::FunctionSelector, address::AztecAddress,
     };
     use dep::static_child_contract::StaticChild;
 
     // Public function to directly call another public function to the target_contract using the selector and value provided
-    #[public]
+    #[external("public")]
     fn public_call(
         target_contract: AztecAddress,
         target_selector: FunctionSelector,
@@ -25,7 +25,7 @@ pub contract StaticParent {
     }
 
     // Private function to directly call another private function to the target_contract using the selector and args provided
-    #[private]
+    #[external("private")]
     fn private_call(
         target_contract: AztecAddress,
         target_selector: FunctionSelector,
@@ -35,7 +35,7 @@ pub contract StaticParent {
     }
 
     // Just like function above but with 3 args.
-    #[private]
+    #[external("private")]
     fn private_call_3_args(
         target_contract: AztecAddress,
         target_selector: FunctionSelector,
@@ -45,7 +45,7 @@ pub contract StaticParent {
     }
 
     // Private function to enqueue a call to a public function of another contract, passing the target arguments provided
-    #[private]
+    #[external("private")]
     fn enqueue_call(
         target_contract: AztecAddress,
         target_selector: FunctionSelector,
@@ -54,7 +54,7 @@ pub contract StaticParent {
         context.call_public_function(target_contract, target_selector, args, false);
     }
 
-    #[private]
+    #[external("private")]
     fn private_static_call(
         target_contract: AztecAddress,
         target_selector: FunctionSelector,
@@ -64,7 +64,7 @@ pub contract StaticParent {
     }
 
     // Private function to statically call another private function to the target_contract using the selector and values provided
-    #[private]
+    #[external("private")]
     fn private_static_call_3_args(
         target_contract: AztecAddress,
         target_selector: FunctionSelector,
@@ -74,7 +74,7 @@ pub contract StaticParent {
     }
 
     // Same as above but using a specific function from the interface
-    #[private]
+    #[external("private")]
     fn private_get_value_from_child(
         target_contract: AztecAddress,
         value: Field,
@@ -84,7 +84,7 @@ pub contract StaticParent {
     }
 
     // Private function to set a static context and verify correct propagation for nested private calls
-    #[private]
+    #[external("private")]
     fn private_nested_static_call(
         target_contract: AztecAddress,
         target_selector: FunctionSelector,
@@ -96,7 +96,7 @@ pub contract StaticParent {
     }
 
     // Just like function above but with 3 args.
-    #[private]
+    #[external("private")]
     fn private_nested_static_call_3_args(
         target_contract: AztecAddress,
         target_selector: FunctionSelector,
@@ -108,7 +108,7 @@ pub contract StaticParent {
     }
 
     // Public function to statically call another public function to the target_contract using the selector and value provided
-    #[public]
+    #[external("public")]
     fn public_static_call(
         target_contract: AztecAddress,
         target_selector: FunctionSelector,
@@ -123,13 +123,13 @@ pub contract StaticParent {
     }
 
     // Same as above but using a specific function from the interface
-    #[public]
+    #[external("public")]
     fn public_get_value_from_child(target_contract: AztecAddress, value: Field) -> Field {
         StaticChild::at(target_contract).pub_get_value(value).view(&mut context)
     }
 
     // Public function to set a static context and verify correct propagation for nested public calls
-    #[public]
+    #[external("public")]
     fn public_nested_static_call(
         target_contract: AztecAddress,
         target_selector: FunctionSelector,
@@ -142,7 +142,7 @@ pub contract StaticParent {
     }
 
     // Private function to enqueue a static call to a public function of another contract, passing the target arguments provided
-    #[private]
+    #[external("private")]
     fn enqueue_static_call_to_pub_function(
         target_contract: AztecAddress,
         target_selector: FunctionSelector,
@@ -152,13 +152,13 @@ pub contract StaticParent {
     }
 
     // Same as above but using a specific function from the interface
-    #[private]
+    #[external("private")]
     fn enqueue_public_get_value_from_child(target_contract: AztecAddress, value: Field) {
         StaticChild::at(target_contract).pub_get_value(value).enqueue_view(&mut context);
     }
 
     // Private function to set a static context and verify correct propagation of nested enqueuing of public calls
-    #[private]
+    #[external("private")]
     fn enqueue_static_nested_call_to_pub_function(
         target_contract: AztecAddress,
         target_selector: FunctionSelector,

--- a/noir-projects/noir-contracts/contracts/test/test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/test_contract/src/main.nr
@@ -45,7 +45,7 @@ pub contract Test {
         // Macros
         macros::{
             events::event,
-            functions::{initializer, internal, noinitcheck, private, public, utility},
+            functions::{initializer, internal, noinitcheck, external},
             storage::storage,
         },
         // Contract instance management
@@ -97,16 +97,16 @@ pub contract Test {
     }
 
     #[initializer]
-    #[private]
+    #[external("private")]
     // We can name our initializer anything we want as long as it's marked as aztec(initializer)
     fn initialize() {}
 
-    #[private]
+    #[external("private")]
     fn get_ovsk_app(ovpk_m_hash: Field) -> Field {
         context.request_ovsk_app(ovpk_m_hash)
     }
 
-    #[private]
+    #[external("private")]
     fn get_master_incoming_viewing_public_key(address: AztecAddress) -> [Field; 2] {
         let ivpk_m = get_public_keys(address).ivpk_m;
 
@@ -114,12 +114,12 @@ pub contract Test {
     }
 
     // Get the address of this contract (taken from the input context)
-    #[private]
+    #[external("private")]
     fn get_this_address() -> AztecAddress {
         context.this_address()
     }
 
-    #[private]
+    #[external("private")]
     fn set_include_by_timestamp(include_by_timestamp: u64, make_tx_hybrid: bool) {
         context.set_include_by_timestamp(include_by_timestamp);
 
@@ -128,11 +128,11 @@ pub contract Test {
         }
     }
 
-    #[public]
+    #[external("public")]
     #[internal]
     fn dummy_public_call() {}
 
-    #[private]
+    #[external("private")]
     fn call_create_note(
         value: u128,
         owner: AztecAddress,
@@ -151,7 +151,7 @@ pub contract Test {
         }
     }
 
-    #[private]
+    #[external("private")]
     fn call_create_partial_note(owner: AztecAddress, storage_slot: Field) -> PartialUintNote {
         UintNote::partial(
             owner,
@@ -162,12 +162,12 @@ pub contract Test {
         )
     }
 
-    #[public]
+    #[external("public")]
     fn call_complete_partial_note(partial_note: PartialUintNote, value: u128) {
         partial_note.complete(&mut context, context.this_address(), value);
     }
 
-    #[private]
+    #[external("private")]
     fn call_create_and_complete_partial_note(
         owner: AztecAddress,
         storage_slot: Field,
@@ -186,7 +186,7 @@ pub contract Test {
         );
     }
 
-    #[private]
+    #[external("private")]
     fn call_get_notes(storage_slot: Field, active_or_nullified: bool) -> u128 {
         let mut options = NoteGetterOptions::new();
         if (active_or_nullified) {
@@ -199,7 +199,7 @@ pub contract Test {
         retrieved_notes.get(0).note.get_value()
     }
 
-    #[private]
+    #[external("private")]
     fn call_get_notes_many(storage_slot: Field, active_or_nullified: bool) -> [u128; 2] {
         let mut options = NoteGetterOptions::new();
         if (active_or_nullified) {
@@ -212,7 +212,7 @@ pub contract Test {
         [retrieved_notes.get(0).note.get_value(), retrieved_notes.get(1).note.get_value()]
     }
 
-    #[utility]
+    #[external("utility")]
     unconstrained fn call_view_notes(storage_slot: Field, active_or_nullified: bool) -> u128 {
         let mut options = NoteViewerOptions::new();
         if (active_or_nullified) {
@@ -224,7 +224,7 @@ pub contract Test {
         notes.get(0).get_value()
     }
 
-    #[utility]
+    #[external("utility")]
     unconstrained fn call_view_notes_many(
         storage_slot: Field,
         active_or_nullified: bool,
@@ -239,7 +239,7 @@ pub contract Test {
         [notes.get(0).get_value(), notes.get(1).get_value()]
     }
 
-    #[private]
+    #[external("private")]
     fn call_destroy_note(storage_slot: Field) {
         let options = NoteGetterOptions::new();
         let (retrieved_notes, note_hashes): (BoundedVec<RetrievedNote<UintNote>, MAX_NOTE_HASH_READ_REQUESTS_PER_CALL>, BoundedVec<Field, MAX_NOTE_HASH_READ_REQUESTS_PER_CALL>) =
@@ -251,7 +251,7 @@ pub contract Test {
         destroy_note_unsafe(&mut context, retrieved_note, note_hash);
     }
 
-    #[private]
+    #[external("private")]
     fn test_note_inclusion(owner: AztecAddress, storage_slot: Field) {
         let mut options = NoteGetterOptions::new();
         options = options.set_limit(1);
@@ -264,7 +264,7 @@ pub contract Test {
         header.prove_note_inclusion(retrieved_notes.get(0), storage_slot);
     }
 
-    #[private]
+    #[external("private")]
     fn test_setting_teardown() {
         context.set_public_teardown_function(
             context.this_address(),
@@ -274,36 +274,36 @@ pub contract Test {
         );
     }
 
-    #[private]
+    #[external("private")]
     fn test_setting_fee_payer() {
         context.set_as_fee_payer();
     }
 
-    #[public]
+    #[external("public")]
     fn create_l2_to_l1_message_arbitrary_recipient_public(content: Field, recipient: EthAddress) {
         // Public oracle call to emit new commitment.
         context.message_portal(recipient, content);
     }
 
-    #[private]
+    #[external("private")]
     fn create_l2_to_l1_message_arbitrary_recipient_private(content: Field, recipient: EthAddress) {
         // Public oracle call to emit new commitment.
         context.message_portal(recipient, content);
     }
 
-    #[public]
+    #[external("public")]
     fn emit_nullifier_public(nullifier: Field) {
         context.push_nullifier(nullifier);
     }
 
-    #[private]
+    #[external("private")]
     #[noinitcheck]
     fn emit_nullifier(nullifier: Field) {
         context.push_nullifier(nullifier);
     }
 
     // For testing non-note encrypted logs
-    #[private]
+    #[external("private")]
     fn emit_array_as_encrypted_log(fields: [Field; 5], owner: AztecAddress, nest: bool) {
         let event = ExampleEvent {
             value0: fields[0],
@@ -333,14 +333,14 @@ pub contract Test {
         }
     }
 
-    #[public]
+    #[external("public")]
     fn emit_public(value: Field) {
         context.emit_public_log(/*message=*/ value);
         context.emit_public_log(/*message=*/ [10, 20, 30]);
         context.emit_public_log(/*message=*/ "Hello, world!");
     }
 
-    #[private]
+    #[external("private")]
     fn consume_mint_to_private_message(
         amount: u128,
         secret_for_L1_to_L2_message_consumption: Field,
@@ -357,7 +357,7 @@ pub contract Test {
         );
     }
 
-    #[public]
+    #[external("public")]
     fn consume_message_from_arbitrary_sender_public(
         content: Field,
         secret: Field,
@@ -368,7 +368,7 @@ pub contract Test {
         context.consume_l1_to_l2_message(content, secret, sender, message_leaf_index);
     }
 
-    #[private]
+    #[external("private")]
     fn consume_message_from_arbitrary_sender_private(
         content: Field,
         secret: Field,
@@ -379,24 +379,24 @@ pub contract Test {
         context.consume_l1_to_l2_message(content, secret, sender, message_leaf_index);
     }
 
-    #[private]
+    #[external("private")]
     fn assert_private_global_vars(chain_id: Field, version: Field) {
         assert(context.chain_id() == chain_id, "Invalid chain id");
         assert(context.version() == version, "Invalid version");
     }
 
-    #[private]
+    #[external("private")]
     fn assert_header_private(header_hash: Field) {
         assert(context.anchor_block_header.hash() == header_hash, "Invalid header hash");
     }
 
     // TODO(4840): add AVM opcodes for getting header (members)
-    //#[public]
+    //#[external("public")]
     //fn assert_header_public(header_hash: Field) {
     //    assert(context.anchor_block_header.hash() == header_hash, "Invalid header hash");
     //}
 
-    #[private]
+    #[external("private")]
     fn publish_contract_instance(target: AztecAddress) {
         publish_contract_instance_for_public_execution(&mut context, target);
     }

--- a/noir-projects/noir-contracts/contracts/test/test_log_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/test_log_contract/src/main.nr
@@ -4,7 +4,7 @@ use aztec::macros::aztec;
 pub contract TestLog {
     use aztec::{
         event::event_emission::{emit_event_in_private, emit_event_in_public},
-        macros::{events::event, functions::{private, public}, storage::storage},
+        macros::{events::event, functions::external, storage::storage},
         messages::message_delivery::MessageDelivery,
         oracle::random::random,
         protocol_types::{address::AztecAddress, traits::FromField},
@@ -29,7 +29,7 @@ pub contract TestLog {
         example_set: PrivateSet<ValueNote, Context>,
     }
 
-    #[private]
+    #[external("private")]
     fn emit_encrypted_events(other: AztecAddress, preimages: [Field; 4]) {
         let event0 = ExampleEvent0 { value0: preimages[0], value1: preimages[1] };
 
@@ -61,7 +61,7 @@ pub contract TestLog {
         );
     }
 
-    #[public]
+    #[external("public")]
     fn emit_unencrypted_events(preimages: [Field; 4]) {
         emit_event_in_public(
             ExampleEvent0 { value0: preimages[0], value1: preimages[1] },
@@ -77,7 +77,7 @@ pub contract TestLog {
         );
     }
 
-    #[private]
+    #[external("private")]
     fn emit_encrypted_events_nested(other: AztecAddress, num_nested_calls: u32) {
         // Safety: We use the following just as an arbitrary test value
         let random_value_0 = unsafe { random() };

--- a/noir-projects/noir-contracts/contracts/test/updatable_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/updatable_contract/src/main.nr
@@ -4,7 +4,7 @@ use aztec::macros::aztec;
 #[aztec]
 contract Updatable {
     use aztec::{
-        macros::{functions::{initializer, private, public, utility}, storage::storage},
+        macros::{functions::{external, initializer}, storage::storage},
         messages::message_delivery::MessageDelivery,
         protocol_types::{
             constants::CONTRACT_INSTANCE_REGISTRY_CONTRACT_ADDRESS,
@@ -22,7 +22,7 @@ contract Updatable {
     }
 
     #[initializer]
-    #[private]
+    #[external("private")]
     fn initialize(initial_value: Field) {
         let owner = context.msg_sender().unwrap();
         let new_value = ValueNote::new(initial_value, owner);
@@ -34,38 +34,38 @@ contract Updatable {
         Updatable::at(context.this_address()).set_public_value(initial_value).enqueue(&mut context);
     }
 
-    #[public]
+    #[external("public")]
     fn set_public_value(new_value: Field) {
         storage.public_value.write(new_value);
     }
 
-    #[private]
+    #[external("private")]
     fn update_to(new_class_id: ContractClassId) {
         ContractInstanceRegistry::at(CONTRACT_INSTANCE_REGISTRY_CONTRACT_ADDRESS)
             .update(new_class_id)
             .enqueue(&mut context);
     }
 
-    #[private]
+    #[external("private")]
     fn set_update_delay(new_delay: u64) {
         ContractInstanceRegistry::at(CONTRACT_INSTANCE_REGISTRY_CONTRACT_ADDRESS)
             .set_update_delay(new_delay)
             .enqueue(&mut context);
     }
 
-    #[public]
+    #[external("public")]
     fn get_update_delay() -> u64 {
         ContractInstanceRegistry::at(CONTRACT_INSTANCE_REGISTRY_CONTRACT_ADDRESS)
             .get_update_delay()
             .view(&mut context)
     }
 
-    #[utility]
+    #[external("utility")]
     unconstrained fn get_private_value() -> Field {
         storage.private_value.view_note().value()
     }
 
-    #[utility]
+    #[external("utility")]
     unconstrained fn get_public_value() -> Field {
         storage.public_value.read()
     }

--- a/noir-projects/noir-contracts/contracts/test/updated_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/updated_contract/src/main.nr
@@ -4,7 +4,7 @@ use aztec::macros::aztec;
 #[aztec]
 contract Updated {
     use aztec::{
-        macros::{functions::{private, public, utility}, storage::storage},
+        macros::{functions::external, storage::storage},
         messages::message_delivery::MessageDelivery,
         protocol_types::constants::CONTRACT_INSTANCE_REGISTRY_CONTRACT_ADDRESS,
         state_vars::{PrivateMutable, PublicMutable},
@@ -18,12 +18,12 @@ contract Updated {
         public_value: PublicMutable<Field, Context>,
     }
 
-    #[public]
+    #[external("public")]
     fn set_public_value() {
         storage.public_value.write(27);
     }
 
-    #[private]
+    #[external("private")]
     fn set_private_value() {
         let owner = context.msg_sender().unwrap();
 
@@ -34,19 +34,19 @@ contract Updated {
         );
     }
 
-    #[public]
+    #[external("public")]
     fn get_update_delay() -> u64 {
         ContractInstanceRegistry::at(CONTRACT_INSTANCE_REGISTRY_CONTRACT_ADDRESS)
             .get_update_delay()
             .view(&mut context)
     }
 
-    #[utility]
+    #[external("utility")]
     unconstrained fn get_private_value() -> Field {
         storage.private_value.view_note().value()
     }
 
-    #[utility]
+    #[external("utility")]
     unconstrained fn get_public_value() -> Field {
         storage.public_value.read()
     }

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/interfaces.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/interfaces.ts
@@ -34,13 +34,13 @@ export interface NoteData {
 }
 
 // These interfaces contain the list of oracles required by aztec-nr in order to simulate and execute transactions, i.e.
-// in order to call #[utility] and #[private] contract functions.
+// in order to call #[external("utility")] and #[external("private")] contract functions.
 // The full list of aztec-nr oracles is larger and includes the oracles also required to run Noir tests - these reside
 // in the TXE package.
 
 /**
  * Miscellaneous oracle methods, not very Aztec-specific and expected to be available all scenarios in which aztec-nr
- * code runs, except #[public] functions (since those are transpiled to AVM bytecode, where there are no oracles).
+ * code runs, except #[external("public")] functions (since those are transpiled to AVM bytecode, where there are no oracles).
  */
 export interface IMiscOracle {
   isMisc: true;
@@ -51,7 +51,7 @@ export interface IMiscOracle {
 }
 
 /**
- * Oracle methods associated with the execution of an Aztec #[utility] function. Note that the IMiscOracles are also
+ * Oracle methods associated with the execution of an Aztec #[external("utility")] function. Note that the IMiscOracles are also
  * expected to be available in these contexts.
  */
 export interface IUtilityExecutionOracle {
@@ -121,7 +121,7 @@ export interface IUtilityExecutionOracle {
 }
 
 /**
- * Oracle methods associated with the execution of an Aztec #[private] function. Note that both the IMiscOracles and
+ * Oracle methods associated with the execution of an Aztec #[external("private")] function. Note that both the IMiscOracles and
  * IUtilityExecutionOracle are also expected to be available in these contexts.
  */
 export interface IPrivateExecutionOracle {

--- a/yarn-project/txe/src/oracle/interfaces.ts
+++ b/yarn-project/txe/src/oracle/interfaces.ts
@@ -8,13 +8,13 @@ import type { AztecAddress } from '@aztec/stdlib/aztec-address';
 import type { UInt32, UInt64 } from '@aztec/stdlib/types';
 
 // These interfaces complement the ones defined in PXE, and combined with those contain the full list of oracles used by
-// aztec-nr. In particular, these include the ones needed to run Brillig code associated to #[public] functions that has
+// aztec-nr. In particular, these include the ones needed to run Brillig code associated to #[external("public")] functions that has
 // not been transpiled (e.g. in the context of a Noir test) as well as the ones associated with managing the state of
 // such a Noir test (deploying contracts, manipulating block time, making calls, etc) - the so called 'top level test
 // context'.
 
 /**
- * Oracle methods associated with the execution of an Aztec #[public] function.
+ * Oracle methods associated with the execution of an Aztec #[external("public")] function.
  *
  * Note that real contracts have their Brillig calls to these be transpiled into opcodes, the oracles are only executed
  * as such when running the original Brillig code, e.g. when invoking functions that interact with a PublicContext

--- a/yarn-project/txe/src/txe_session.ts
+++ b/yarn-project/txe/src/txe_session.ts
@@ -60,7 +60,7 @@ type SessionState =
       name: 'TOP_LEVEL';
     }
   /**
-   * The private state is entered via the `private_context` function. In this state the PXE oracles that `#[private]`
+   * The private state is entered via the `private_context` function. In this state the PXE oracles that `#[external("private")]`
    * functions use are available, such as those related to note retrieval, notification of side-effects, capsule access,
    * etc. */
   | {
@@ -71,13 +71,13 @@ type SessionState =
       taggingIndexCache: ExecutionTaggingIndexCache;
     }
   /**
-   * The public state is entered via the `public_context` function. In this state the AVM opcodes that `#[public]`
+   * The public state is entered via the `public_context` function. In this state the AVM opcodes that `#[external("public")]`
    * functions execute are resolved as oracles by TXE, since Noir tests are not transpiled. */
   | {
       name: 'PUBLIC';
     }
   /**
-   * The utility state is entered via the `utility_context` function. In this state the PXE oracles that `#[utility]`
+   * The utility state is entered via the `utility_context` function. In this state the PXE oracles that `#[external("utility")]`
    * functions use are available, such as those related to (unconstrained) note retrieval, capsule access, public
    * storage reads, etc.
    */


### PR DESCRIPTION
Closes https://linear.app/aztec-labs/issue/F-19/rename-privateorpublicorutility-to-externalprivateorpublicorutility

Having `#[private]` and `#[public]` macros was misleading because in Solidity these define function visibility while in Aztec's case they define the environment in which the functions are executed. For this reason I introduce `#[external(...)]` macro while the argument of the attribute defines the execution environment: `private`, `public` or `utility`.

## Notes for reviewer
- I did a refactor in a [PR up the stack](https://github.com/AztecProtocol/aztec-packages/pull/17840) which allowed me to drop a lot of the complexity introduced in this PR. For this reason I encourage you to check that one first to have context on what in this PR is a problem and what is not. It might make sense to just merge these 2 PRs into 1 but I think that would make it all harder to review.
- This PR touches a lot of files but all the juicy bits are in the `noir-projects/aztec-nr/aztec/src/macros/` directory so I encourage you to just check that first. The `noir-contracts` dir can be completely ignored as there I just update the imports and the macros.
- The new naming is now in conflict with the `#[internal]` macro as having both external and internal applied to a function is valid:

<img width="874" height="182" alt="image" src="https://github.com/user-attachments/assets/4582a51a-225c-4a4c-9b9a-d2c2d413d927" />

This issue will be tackled in the near future.