### PR TITLE
chore: remove some unused code in ultra builder

### DIFF
--- a/barretenberg/cpp/src/barretenberg/benchmark/relations_bench/relations.bench.cpp
+++ b/barretenberg/cpp/src/barretenberg/benchmark/relations_bench/relations.bench.cpp
@@ -60,7 +60,7 @@ template <typename Flavor, typename Relation> void execute_relation_for_pg_univa
 }
 
 // Ultra relations (PG prover combiner work)
-BENCHMARK(execute_relation_for_pg_univariates<UltraFlavor, UltraArithmeticRelation<Fr>>);
+BENCHMARK(execute_relation_for_pg_univariates<UltraFlavor, ArithmeticRelation<Fr>>);
 BENCHMARK(execute_relation_for_pg_univariates<UltraFlavor, DeltaRangeConstraintRelation<Fr>>);
 BENCHMARK(execute_relation_for_pg_univariates<UltraFlavor, EllipticRelation<Fr>>);
 BENCHMARK(execute_relation_for_pg_univariates<UltraFlavor, MemoryRelation<Fr>>);
@@ -75,7 +75,7 @@ BENCHMARK(execute_relation_for_pg_univariates<MegaFlavor, Poseidon2ExternalRelat
 BENCHMARK(execute_relation_for_pg_univariates<MegaFlavor, Poseidon2InternalRelation<Fr>>);
 
 // Ultra relations (Sumcheck prover work)
-BENCHMARK(execute_relation_for_univariates<UltraFlavor, UltraArithmeticRelation<Fr>>);
+BENCHMARK(execute_relation_for_univariates<UltraFlavor, ArithmeticRelation<Fr>>);
 BENCHMARK(execute_relation_for_univariates<UltraFlavor, DeltaRangeConstraintRelation<Fr>>);
 BENCHMARK(execute_relation_for_univariates<UltraFlavor, EllipticRelation<Fr>>);
 BENCHMARK(execute_relation_for_univariates<UltraFlavor, MemoryRelation<Fr>>);
@@ -90,7 +90,7 @@ BENCHMARK(execute_relation_for_univariates<MegaFlavor, Poseidon2ExternalRelation
 BENCHMARK(execute_relation_for_univariates<MegaFlavor, Poseidon2InternalRelation<Fr>>);
 
 // Ultra relations (verifier work)
-BENCHMARK(execute_relation_for_values<UltraFlavor, UltraArithmeticRelation<Fr>>);
+BENCHMARK(execute_relation_for_values<UltraFlavor, ArithmeticRelation<Fr>>);
 BENCHMARK(execute_relation_for_values<UltraFlavor, DeltaRangeConstraintRelation<Fr>>);
 BENCHMARK(execute_relation_for_values<UltraFlavor, EllipticRelation<Fr>>);
 BENCHMARK(execute_relation_for_values<UltraFlavor, MemoryRelation<Fr>>);

--- a/barretenberg/cpp/src/barretenberg/benchmark/ultra_bench/mock_circuits.hpp
+++ b/barretenberg/cpp/src/barretenberg/benchmark/ultra_bench/mock_circuits.hpp
@@ -26,7 +26,9 @@ template <typename Builder> void generate_basic_arithmetic_circuit(Builder& buil
     // Ensure the circuit is filled but finalisation doesn't make the circuit size go to the next power of two
     size_t target_gate_count = (1UL << log2_num_gates);
     const size_t GATE_COUNT_BUFFER = 1000; // Since we're using an estimate, let's add an error term in case.
-    size_t passes = (target_gate_count - builder.get_estimated_num_finalized_gates() - GATE_COUNT_BUFFER) / 4;
+    size_t passes = (target_gate_count - builder.get_num_finalized_gates_inefficient(/*ensure_nonzero=*/false) -
+                     GATE_COUNT_BUFFER) /
+                    4;
     if (static_cast<int>(passes) <= 0) {
         throw_or_abort("We don't support low values of log2_num_gates.");
     }
@@ -38,7 +40,7 @@ template <typename Builder> void generate_basic_arithmetic_circuit(Builder& buil
         b = c * c;
     }
 
-    size_t est_gate_count = builder.get_estimated_num_finalized_gates();
+    size_t est_gate_count = builder.get_num_finalized_gates_inefficient(/*ensure_nonzero=*/false);
     BB_ASSERT_LTE(est_gate_count,
                   (1UL << log2_num_gates) - GATE_COUNT_BUFFER,
                   "Check that the finalized gate count won't exceed the desired gate count.");

--- a/barretenberg/cpp/src/barretenberg/boomerang_value_detection/graph_description_ultra_recursive_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/boomerang_value_detection/graph_description_ultra_recursive_verifier.test.cpp
@@ -129,7 +129,7 @@ template <typename RecursiveFlavor> class BoomerangRecursiveVerifierTest : publi
             output.ipa_claim.set_public();
             outer_circuit.ipa_proof = output.ipa_proof.get_value();
         }
-        info("Recursive Verifier: num gates = ", outer_circuit.get_estimated_num_finalized_gates());
+        info("Recursive Verifier: num gates = ", outer_circuit.get_num_finalized_gates_inefficient());
 
         // Check for a failure flag in the recursive verifier circuit
         EXPECT_EQ(outer_circuit.failed(), false) << outer_circuit.err();

--- a/barretenberg/cpp/src/barretenberg/circuit_checker/ultra_circuit_builder.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/circuit_checker/ultra_circuit_builder.test.cpp
@@ -39,7 +39,7 @@ TEST(UltraCircuitBuilder, CopyConstructor)
 
     UltraCircuitBuilder duplicate_builder{ builder };
 
-    EXPECT_EQ(duplicate_builder.get_estimated_num_finalized_gates(), builder.get_estimated_num_finalized_gates());
+    EXPECT_EQ(duplicate_builder.get_num_finalized_gates_inefficient(), builder.get_num_finalized_gates_inefficient());
     EXPECT_TRUE(CircuitChecker::check(duplicate_builder));
 }
 
@@ -935,7 +935,7 @@ TEST(UltraCircuitBuilder, Ram)
     // Test the builder copy constructor for a circuit with RAM gates
     UltraCircuitBuilder duplicate_builder{ builder };
 
-    EXPECT_EQ(duplicate_builder.get_estimated_num_finalized_gates(), builder.get_estimated_num_finalized_gates());
+    EXPECT_EQ(duplicate_builder.get_num_finalized_gates_inefficient(), builder.get_num_finalized_gates_inefficient());
     EXPECT_TRUE(CircuitChecker::check(duplicate_builder));
 }
 

--- a/barretenberg/cpp/src/barretenberg/circuit_checker/ultra_circuit_checker.hpp
+++ b/barretenberg/cpp/src/barretenberg/circuit_checker/ultra_circuit_checker.hpp
@@ -18,7 +18,7 @@ namespace bb {
 class UltraCircuitChecker {
   public:
     using FF = bb::fr;
-    using Arithmetic = UltraArithmeticRelation<FF>;
+    using Arithmetic = ArithmeticRelation<FF>;
     using Elliptic = EllipticRelation<FF>;
     using Memory = MemoryRelation<FF>;
     using NonNativeField = NonNativeFieldRelation<FF>;

--- a/barretenberg/cpp/src/barretenberg/common/log.hpp
+++ b/barretenberg/cpp/src/barretenberg/common/log.hpp
@@ -11,10 +11,11 @@
 #define BENCHMARK_INFO_SEPARATOR "#"
 #define BENCHMARK_INFO_SUFFIX "##BENCHMARK_INFO_SUFFIX##"
 
-#define BENCH_GATE_COUNT_START(builder, op_name) uint64_t __bench_before = builder.get_estimated_num_finalized_gates();
+#define BENCH_GATE_COUNT_START(builder, op_name)                                                                       \
+    uint64_t __bench_before = builder.get_num_finalized_gates_inefficient();
 
 #define BENCH_GATE_COUNT_END(builder, op_name)                                                                         \
-    uint64_t __bench_after = builder.get_estimated_num_finalized_gates();                                              \
+    uint64_t __bench_after = builder.get_num_finalized_gates_inefficient();                                            \
     std::cerr << "num gates with " << op_name << " = " << __bench_after - __bench_before << std::endl;                 \
     benchmark_info(Builder::NAME_STRING, "Bigfield", op_name, "Gate Count", __bench_after - __bench_before);
 

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_format.hpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_format.hpp
@@ -235,7 +235,7 @@ template <typename Builder> class GateCounter {
         if (!collect_gates_per_opcode) {
             return 0;
         }
-        size_t new_gate_count = builder->get_estimated_num_finalized_gates();
+        size_t new_gate_count = builder->get_num_finalized_gates_inefficient();
         size_t diff = new_gate_count - prev_gate_count;
         prev_gate_count = new_gate_count;
         return diff;

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_format.hpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_format.hpp
@@ -235,7 +235,7 @@ template <typename Builder> class GateCounter {
         if (!collect_gates_per_opcode) {
             return 0;
         }
-        size_t new_gate_count = builder->get_num_finalized_gates_inefficient();
+        size_t new_gate_count = builder->get_num_finalized_gates_inefficient(/*ensure_nonzero=*/false);
         size_t diff = new_gate_count - prev_gate_count;
         prev_gate_count = new_gate_count;
         return diff;

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_integration.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_integration.test.cpp
@@ -51,7 +51,7 @@ class AcirIntegrationTest : public ::testing::Test {
         Prover prover{ prover_instance, verification_key };
 #ifdef LOG_SIZES
         builder.blocks.summarize();
-        info("num gates          = ", builder.get_estimated_num_finalized_gates());
+        info("num gates          = ", builder.get_num_finalized_gates_inefficient());
         info("total circuit size = ", builder.get_estimated_total_circuit_size());
         info("circuit size       = ", prover.prover_instance->dyadic_size());
         info("log circuit size   = ", prover.prover_instance->log_dyadic_size());

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/civc_recursion_constraints.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/civc_recursion_constraints.test.cpp
@@ -88,8 +88,6 @@ class CivcRecursionConstraintTest : public ::testing::Test {
         // Build constraints
         Builder builder = create_circuit(program, { .honk_recursion = 2 });
 
-        info("Estimate finalized number of gates: ", builder.get_estimated_num_finalized_gates());
-
         // Construct vk
         auto prover_instance = std::make_shared<ProverInstance>(builder);
 

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/ecdsa_constraints.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/ecdsa_constraints.test.cpp
@@ -153,7 +153,7 @@ TYPED_TEST(EcdsaConstraintsTest, GenerateVKFromConstraints)
     {
         AcirProgram program{ constraint_system, witness_values };
         auto builder = create_circuit<Builder>(program);
-        info("Num gates: ", builder.get_estimated_num_finalized_gates());
+        info("Num gates: ", builder.get_num_finalized_gates_inefficient());
 
         auto prover_instance = std::make_shared<ProvingKey>(builder);
         vk_from_witness = std::make_shared<VerificationKey>(prover_instance->get_precomputed());
@@ -194,7 +194,7 @@ TYPED_TEST(EcdsaConstraintsTest, EcdsaPredicate)
         AcirProgram program{ constraint_system, witness_values };
         auto builder = create_circuit<Builder>(program);
 
-        info("Num gates: ", builder.get_estimated_num_finalized_gates());
+        info("Num gates: ", builder.get_num_finalized_gates_inefficient());
 
         // Validate the builder
         EXPECT_TRUE(CircuitChecker::check(builder));
@@ -205,7 +205,7 @@ TYPED_TEST(EcdsaConstraintsTest, EcdsaPredicate)
         AcirProgram program{ constraint_system, witness_values };
         auto builder = create_circuit<Builder>(program);
 
-        info("Num gates: ", builder.get_estimated_num_finalized_gates());
+        info("Num gates: ", builder.get_num_finalized_gates_inefficient());
 
         // Validate the builder
         EXPECT_TRUE(CircuitChecker::check(builder));
@@ -216,7 +216,7 @@ TYPED_TEST(EcdsaConstraintsTest, EcdsaPredicate)
         AcirProgram program{ constraint_system, witness_values };
         auto builder = create_circuit<Builder>(program);
 
-        info("Num gates: ", builder.get_estimated_num_finalized_gates());
+        info("Num gates: ", builder.get_num_finalized_gates_inefficient());
 
         // Validate the builder
         EXPECT_TRUE(CircuitChecker::check(builder));
@@ -227,7 +227,7 @@ TYPED_TEST(EcdsaConstraintsTest, EcdsaPredicate)
         AcirProgram program{ constraint_system, witness_values };
         auto builder = create_circuit<Builder>(program);
 
-        info("Num gates: ", builder.get_estimated_num_finalized_gates());
+        info("Num gates: ", builder.get_num_finalized_gates_inefficient());
 
         EXPECT_TRUE(builder.failed());
     }

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/honk_recursion_constraint.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/honk_recursion_constraint.test.cpp
@@ -284,7 +284,7 @@ TYPED_TEST(AcirHonkRecursionConstraint, TestBasicSingleHonkRecursionConstraint)
                                                                                        /*dummy_witnesses=*/false,
                                                                                        /*predicate_val=*/true);
 
-    info("estimate finalized circuit gates = ", layer_2_circuit.get_estimated_num_finalized_gates());
+    info("estimate finalized circuit gates = ", layer_2_circuit.get_num_finalized_gates_inefficient());
 
     auto prover_instance = std::make_shared<typename TestFixture::OuterProverInstance>(layer_2_circuit);
     auto verification_key =
@@ -306,7 +306,7 @@ TYPED_TEST(AcirHonkRecursionConstraint, TestBasicDoubleHonkRecursionConstraints)
     auto layer_2_circuit =
         TestFixture::template create_outer_circuit<typename TestFixture::OuterBuilder>(layer_1_circuits, false, false);
 
-    info("circuit gates = ", layer_2_circuit.get_estimated_num_finalized_gates());
+    info("circuit gates = ", layer_2_circuit.get_num_finalized_gates_inefficient());
 
     auto prover_instance = std::make_shared<typename TestFixture::OuterProverInstance>(layer_2_circuit);
     auto verification_key =
@@ -372,7 +372,7 @@ TYPED_TEST(AcirHonkRecursionConstraint, TestOneOuterRecursiveCircuit)
                                                                                        /*dummy_witnesses=*/false,
                                                                                        /*predicate_val=*/true);
     info("created second outer circuit");
-    info("number of gates in layer 3 = ", layer_3_circuit.get_estimated_num_finalized_gates());
+    info("number of gates in layer 3 = ", layer_3_circuit.get_num_finalized_gates_inefficient());
 
     auto prover_instance = std::make_shared<typename TestFixture::OuterProverInstance>(layer_3_circuit);
     auto verification_key =
@@ -429,7 +429,7 @@ TYPED_TEST(AcirHonkRecursionConstraint, TestFullRecursiveComposition)
                                                                                        /*dummy_witnesses=*/false,
                                                                                        /*predicate_val=*/true);
     info("created third outer circuit");
-    info("number of gates in layer 3 circuit = ", layer_3_circuit.get_estimated_num_finalized_gates());
+    info("number of gates in layer 3 circuit = ", layer_3_circuit.get_num_finalized_gates_inefficient());
 
     auto prover_instance = std::make_shared<typename TestFixture::OuterProverInstance>(layer_3_circuit);
     auto verification_key =

--- a/barretenberg/cpp/src/barretenberg/flavor/flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/flavor.hpp
@@ -499,7 +499,7 @@ template <typename RelationsTuple> constexpr auto create_sumcheck_tuple_of_tuple
  *
  * @example if RelationsTuple = UltraFlavor::Relations_, then the tuple returned by the function is a tuple of length 9,
  * where the first element of the tuple is an array of length 2 (as the first relation in UltraFlavor::Relations_ is the
- * UltraArithmeticRelation, which is made up by two subrelations).
+ * ArithmeticRelation, which is made up by two subrelations).
  *
  * @tparam RelationsTuple
  */

--- a/barretenberg/cpp/src/barretenberg/flavor/mega_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/mega_flavor.hpp
@@ -76,7 +76,7 @@ class MegaFlavor {
     // define the tuple of Relations that comprise the Sumcheck relation
     // Note: made generic for use in MegaRecursive.
     template <typename FF>
-    using Relations_ = std::tuple<bb::UltraArithmeticRelation<FF>,
+    using Relations_ = std::tuple<bb::ArithmeticRelation<FF>,
                                   bb::UltraPermutationRelation<FF>,
                                   bb::LogDerivLookupRelation<FF>,
                                   bb::DeltaRangeConstraintRelation<FF>,

--- a/barretenberg/cpp/src/barretenberg/flavor/ultra_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/ultra_flavor.hpp
@@ -81,7 +81,7 @@ class UltraFlavor {
     // List of relations reflecting the Ultra arithmetisation. WARNING: As UltraKeccak flavor inherits from
     // Ultra flavor any change of ordering in this tuple needs to be reflected in the smart contract, otherwise
     // relation accumulation will not match.
-    using Relations_ = std::tuple<bb::UltraArithmeticRelation<FF>,
+    using Relations_ = std::tuple<bb::ArithmeticRelation<FF>,
                                   bb::UltraPermutationRelation<FF>,
                                   bb::LogDerivLookupRelation<FF>,
                                   bb::DeltaRangeConstraintRelation<FF>,

--- a/barretenberg/cpp/src/barretenberg/honk/relation_checker.hpp
+++ b/barretenberg/cpp/src/barretenberg/honk/relation_checker.hpp
@@ -93,7 +93,7 @@ template <> class RelationChecker<bb::UltraFlavor> : public RelationChecker<void
         using FF = UltraFlavor::FF;
 
         // Linearly independent relations (must be satisfied at each row)
-        Base::check<UltraArithmeticRelation<FF>>(polynomials, params, "UltraArithmetic");
+        Base::check<ArithmeticRelation<FF>>(polynomials, params, "UltraArithmetic");
         Base::check<UltraPermutationRelation<FF>>(polynomials, params, "UltraPermutation");
         Base::check<DeltaRangeConstraintRelation<FF>>(polynomials, params, "DeltaRangeConstraint");
         Base::check<EllipticRelation<FF>>(polynomials, params, "Elliptic");

--- a/barretenberg/cpp/src/barretenberg/protogalaxy/combiner.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/combiner.test.cpp
@@ -308,7 +308,7 @@ TEST(Protogalaxy, CombinerOn2Keys)
 TEST(Protogalaxy, CombinerOptimizationConsistency)
 {
     using ProverInstance = ProverInstance_<Flavor>;
-    using UltraArithmeticRelation = UltraArithmeticRelation<FF>;
+    using ArithmeticRelation = ArithmeticRelation<FF>;
 
     constexpr size_t UNIVARIATE_LENGTH = 12;
     const auto restrict_to_standard_arithmetic_relation = [](auto& polys) {
@@ -354,10 +354,10 @@ TEST(Protogalaxy, CombinerOptimizationConsistency)
 
             // Accumulate arithmetic relation over 2 rows on the second key
             for (size_t i = 0; i < 2; i++) {
-                UltraArithmeticRelation::accumulate(std::get<0>(temporary_accumulator),
-                                                    keys[bb::NUM_INSTANCES - 1]->polynomials.get_row(i),
-                                                    relation_parameters,
-                                                    gate_separators[i]);
+                ArithmeticRelation::accumulate(std::get<0>(temporary_accumulator),
+                                               keys[bb::NUM_INSTANCES - 1]->polynomials.get_row(i),
+                                               relation_parameters,
+                                               gate_separators[i]);
             }
             // Get the result of the 0th subrelation of the arithmetic relation
             FF key_offset = std::get<0>(temporary_accumulator)[0];
@@ -389,17 +389,17 @@ TEST(Protogalaxy, CombinerOptimizationConsistency)
                 TupleOfArraysOfValues accumulator{};
                 if (idx < bb::NUM_INSTANCES) {
                     for (size_t i = 0; i < 2; i++) {
-                        UltraArithmeticRelation::accumulate(std::get<0>(accumulator),
-                                                            keys[idx]->polynomials.get_row(i),
-                                                            relation_parameters,
-                                                            gate_separators[i]);
+                        ArithmeticRelation::accumulate(std::get<0>(accumulator),
+                                                       keys[idx]->polynomials.get_row(i),
+                                                       relation_parameters,
+                                                       gate_separators[i]);
                     }
                 } else {
                     for (size_t i = 0; i < 2; i++) {
-                        UltraArithmeticRelation::accumulate(std::get<0>(accumulator),
-                                                            extended_polynomials[idx - bb::NUM_INSTANCES].get_row(i),
-                                                            relation_parameters,
-                                                            gate_separators[i]);
+                        ArithmeticRelation::accumulate(std::get<0>(accumulator),
+                                                       extended_polynomials[idx - bb::NUM_INSTANCES].get_row(i),
+                                                       relation_parameters,
+                                                       gate_separators[i]);
                     }
                 }
                 precomputed_result[idx] = std::get<0>(accumulator)[0];

--- a/barretenberg/cpp/src/barretenberg/relations/ultra_arithmetic_relation.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/ultra_arithmetic_relation.hpp
@@ -9,7 +9,7 @@
 
 namespace bb {
 
-template <typename FF_> class UltraArithmeticRelationImpl {
+template <typename FF_> class ArithmeticRelationImpl {
   public:
     using FF = FF_;
 
@@ -124,5 +124,5 @@ template <typename FF_> class UltraArithmeticRelationImpl {
     };
 };
 
-template <typename FF> using UltraArithmeticRelation = Relation<UltraArithmeticRelationImpl<FF>>;
+template <typename FF> using ArithmeticRelation = Relation<ArithmeticRelationImpl<FF>>;
 } // namespace bb

--- a/barretenberg/cpp/src/barretenberg/relations/ultra_arithmetic_relation.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/ultra_arithmetic_relation.hpp
@@ -26,59 +26,44 @@ template <typename FF_> class ArithmeticRelationImpl {
 
     /**
      * @brief Expression for the Ultra Arithmetic gate.
-     * @details This relation encapsulates several idenitities, toggled by the value of q_arith in [0, 1, 2, 3, ...].
+     * @details This relation contains two subrelations and encapsulates several identities, toggled by the value of
+     * q_arith in [0, 1, 2, 3].
      *
-     * The whole formula is:
+     * Subrelation 1:
+     *      q_arith *
+     *         [ (-1/2) * (q_arith - 3) * (q_m * w_1 * w_2) + \sum_{i=1..4} q_i * w_i + q_c + (q_arith - 1) * w_4_shift]
      *
-     * q_arith * ( ( (-1/2) * (q_arith - 3) * q_m * w_1 * w_2 + q_1 * w_1 + q_2 * w_2 + q_3 * w_3 + q_4 * w_4 + q_c ) +
-     * (q_arith - 1)*( α * (q_arith - 2) * (w_1 + w_4 - w_1_omega + q_m) + w_4_omega) ) = 0
+     * Subrelation 2:
+     *      q_arith * (q_arith - 1) * (q_arith - 2) * (w_1 + w_4 - w_1_shift + q_m)
      *
-     * This formula results in several cases depending on q_arith:
-     * 1. q_arith == 0: Arithmetic gate is completely disabled
+     * These formulas result in several cases depending on q_arith:
      *
-     * 2. q_arith == 1: Everything in the minigate on the right is disabled. The equation is just a standard plonk
-     * equation with extra wires: q_m * w_1 * w_2 + q_1 * w_1 + q_2 * w_2 + q_3 * w_3 + q_4 * w_4 + q_c = 0
+     * CASE q_arith == 0: Arithmetic gate is completely disabled
      *
-     * 3. q_arith == 2: The (w_1 + w_4 - ...) term is disabled. The equation is:
-     * (1/2) * q_m * w_1 * w_2 + q_1 * w_1 + q_2 * w_2 + q_3 * w_3 + q_4 * w_4 + q_c + w_4_omega = 0
-     * It allows defining w_4 at next index (w_4_omega) in terms of current wire values
+     * CASE q_arith == 1: Conventional 4-wire Ultra arithmetic relation
+     *      Subrelation 1: q_m * w_1 * w_2 + \sum_{i=1..4} q_i * w_i + q_c
+     *      Subrelation 2: Disabled
      *
-     * 4. q_arith == 3: The product of w_1 and w_2 is disabled, but a mini addition gate is enabled. α² allows us to
-     * split the equation into two:
+     * CASE q_arith == 2: Same as above but with an additional term linear term: +w_4_shift
+     *      Subrelation 1: q_m * w_1 * w_2 + [ \sum_{i=1..4} q_i * w_i + q_c + w_4_shift ] * 2
+     *      Subrelation 2: Disabled
+     *      Note: Factor of 2 on the linear term must be accounted for when constructing inputs to the relation.
      *
-     * q_1 * w_1 + q_2 * w_2 + q_3 * w_3 + q_4 * w_4 + q_c + 2 * w_4_omega = 0
-     *
-     * w_1 + w_4 - w_1_omega + q_m = 0  (we are reusing q_m here)
-     *
-     * 5. q_arith > 3: The product of w_1 and w_2 is scaled by (q_arith - 3), while the w_4_omega term is scaled by
-     * (q_arith
-     * - 1). The equation can be split into two:
-     *
-     * (q_arith - 3)* q_m * w_1 * w_ 2 + q_1 * w_1 + q_2 * w_2 + q_3 * w_3 + q_4 * w_4 + q_c + (q_arith - 1) * w_4_omega
-     * = 0
-     *
-     * w_1 + w_4 - w_1_omega + q_m = 0
-     *
-     * The problem that q_m is used both in both equations can be dealt with by appropriately changing selector values
-     * at the next gate. Then we can treat (q_arith - 1) as a simulated q_6 selector and scale q_m to handle (q_arith -
-     * 3) at product.
-     *
-     * The relation is
-     * defined as C(in(X)...) = q_arith * [ -1/2(q_arith - 3)(q_m * w_r * w_l) + (q_l * w_l) + (q_r * w_r) +
-     * (q_o * w_o) + (q_4 * w_4) + q_c + (q_arith - 1)w_4_shift ]
-     *
-     *    q_arith *
-     *      (q_arith - 2) * (q_arith - 1) * (w_l + w_4 - w_l_shift + q_m)
+     * CASE q_arith == 3:
+     *      Subrelation 1: [ \sum_{i=1..4} q_i * w_i + q_c + (2 * w_4_shift) ] * 3
+     *      Subrelation 2: [ w_1 + w_4 - w_1_shift + q_m ] * 6
+     *      Note: We are repurposing q_m here as an additive term in the second subrelation.
+     *      Note: Factor of 2 on the w_4_shift term must be accounted for when constructing inputs to the relation.
      *
      * @param evals transformed to `evals + C(in(X)...)*scaling_factor`
-     * @param in an std::array containing the fully extended Univariate edges.
-     * @param parameters contains beta, gamma, and public_input_delta, ....
+     * @param in Inputs to the relation algebra
+     * @param parameters Unused in this relation
      * @param scaling_factor optional term to scale the evaluation before adding to evals.
      */
     template <typename ContainerOverSubrelations, typename AllEntities, typename Parameters>
     inline static void accumulate(ContainerOverSubrelations& evals,
                                   const AllEntities& in,
-                                  const Parameters&,
+                                  BB_UNUSED const Parameters& params,
                                   const FF& scaling_factor)
     {
         using Accumulator = std::tuple_element_t<0, ContainerOverSubrelations>;

--- a/barretenberg/cpp/src/barretenberg/relations/ultra_relation_consistency.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/relations/ultra_relation_consistency.test.cpp
@@ -108,10 +108,10 @@ class UltraRelationConsistency : public testing::Test {
     };
 };
 
-TEST_F(UltraRelationConsistency, UltraArithmeticRelation)
+TEST_F(UltraRelationConsistency, ArithmeticRelation)
 {
     const auto run_test = [](bool random_inputs, const FF& q_arith_value = FF::random_element()) {
-        using Relation = UltraArithmeticRelation<FF>;
+        using Relation = ArithmeticRelation<FF>;
         using SumcheckArrayOfValuesOverSubrelations = typename Relation::SumcheckArrayOfValuesOverSubrelations;
 
         InputElements input_elements = random_inputs ? InputElements::get_random() : InputElements::get_special();
@@ -140,14 +140,14 @@ TEST_F(UltraRelationConsistency, UltraArithmeticRelation)
         if (q_arith == FF(1)) {
             // Contribution 1
             contribution_1 = (q_m * w_2 * w_1) + (q_l * w_1) + (q_r * w_2) + (q_o * w_3) + (q_4 * w_4) + q_c;
-            // Contribution 2: None
 
+            // Contribution 2: None
         } else if (q_arith == FF(2)) {
             // Contribution 1
             contribution_1 = (q_m * w_2 * w_1);
             contribution_1 += ((q_l * w_1) + (q_r * w_2) + (q_o * w_3) + (q_4 * w_4) + w_4_shift + q_c) * FF(2);
-            // Contribution 2: None
 
+            // Contribution 2: None
         } else if (q_arith == FF(3)) {
             // Contribution 1
             contribution_1 = (q_l * w_1) + (q_r * w_2) + (q_o * w_3) + (q_4 * w_4) + q_c;
@@ -156,7 +156,6 @@ TEST_F(UltraRelationConsistency, UltraArithmeticRelation)
 
             // Contribution 2
             contribution_2 = (w_1 + w_4 - w_1_shift + q_m) * FF(6);
-
         } else {
             // Contribution 1
             contribution_1 = (q_arith - 3) * (q_m * w_2 * w_1) * neg_half;

--- a/barretenberg/cpp/src/barretenberg/relations/ultra_relation_consistency.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/relations/ultra_relation_consistency.test.cpp
@@ -110,11 +110,11 @@ class UltraRelationConsistency : public testing::Test {
 
 TEST_F(UltraRelationConsistency, UltraArithmeticRelation)
 {
-    const auto run_test = [](bool random_inputs) {
+    const auto run_test = [](bool random_inputs, const FF& q_arith_value = FF::random_element()) {
         using Relation = UltraArithmeticRelation<FF>;
         using SumcheckArrayOfValuesOverSubrelations = typename Relation::SumcheckArrayOfValuesOverSubrelations;
 
-        const InputElements input_elements = random_inputs ? InputElements::get_random() : InputElements::get_special();
+        InputElements input_elements = random_inputs ? InputElements::get_random() : InputElements::get_special();
         const auto& w_1 = input_elements.w_l;
         const auto& w_1_shift = input_elements.w_l_shift;
         const auto& w_2 = input_elements.w_r;
@@ -127,21 +127,49 @@ TEST_F(UltraRelationConsistency, UltraArithmeticRelation)
         const auto& q_o = input_elements.q_o;
         const auto& q_4 = input_elements.q_4;
         const auto& q_c = input_elements.q_c;
+
+        // Set specific q_arith value to enable testing different modes of the arithmetic relation
+        input_elements.q_arith = q_arith_value;
         const auto& q_arith = input_elements.q_arith;
 
         SumcheckArrayOfValuesOverSubrelations expected_values;
         static const FF neg_half = FF(-2).invert();
 
-        // Contribution 1
-        auto contribution_1 = (q_arith - 3) * (q_m * w_2 * w_1) * neg_half;
-        contribution_1 += (q_l * w_1) + (q_r * w_2) + (q_o * w_3) + (q_4 * w_4) + q_c;
-        contribution_1 += (q_arith - 1) * w_4_shift;
-        contribution_1 *= q_arith;
-        expected_values[0] = contribution_1;
+        FF contribution_1 = FF(0);
+        FF contribution_2 = FF(0);
+        if (q_arith == FF(1)) {
+            // Contribution 1
+            contribution_1 = (q_m * w_2 * w_1) + (q_l * w_1) + (q_r * w_2) + (q_o * w_3) + (q_4 * w_4) + q_c;
+            // Contribution 2: None
 
-        // Contribution 2
-        auto contribution_2 = (w_1 + w_4 - w_1_shift + q_m);
-        contribution_2 *= (q_arith - 2) * (q_arith - 1) * q_arith;
+        } else if (q_arith == FF(2)) {
+            // Contribution 1
+            contribution_1 = (q_m * w_2 * w_1);
+            contribution_1 += ((q_l * w_1) + (q_r * w_2) + (q_o * w_3) + (q_4 * w_4) + w_4_shift + q_c) * FF(2);
+            // Contribution 2: None
+
+        } else if (q_arith == FF(3)) {
+            // Contribution 1
+            contribution_1 = (q_l * w_1) + (q_r * w_2) + (q_o * w_3) + (q_4 * w_4) + q_c;
+            contribution_1 += w_4_shift * FF(2);
+            contribution_1 *= FF(3);
+
+            // Contribution 2
+            contribution_2 = (w_1 + w_4 - w_1_shift + q_m) * FF(6);
+
+        } else {
+            // Contribution 1
+            contribution_1 = (q_arith - 3) * (q_m * w_2 * w_1) * neg_half;
+            contribution_1 += (q_l * w_1) + (q_r * w_2) + (q_o * w_3) + (q_4 * w_4) + q_c;
+            contribution_1 += (q_arith - 1) * w_4_shift;
+            contribution_1 *= q_arith;
+
+            // Contribution 2
+            contribution_2 = (w_1 + w_4 - w_1_shift + q_m);
+            contribution_2 *= (q_arith - 2) * (q_arith - 1) * q_arith;
+        }
+
+        expected_values[0] = contribution_1;
         expected_values[1] = contribution_2;
 
         const auto parameters = RelationParameters<FF>::get_random();
@@ -150,6 +178,9 @@ TEST_F(UltraRelationConsistency, UltraArithmeticRelation)
     };
     run_test(/*random_inputs=*/false);
     run_test(/*random_inputs=*/true);
+    run_test(/*random_inputs=*/true, /*q_arith_value=*/FF(1));
+    run_test(/*random_inputs=*/true, /*q_arith_value=*/FF(2));
+    run_test(/*random_inputs=*/true, /*q_arith_value=*/FF(3));
 };
 
 TEST_F(UltraRelationConsistency, UltraPermutationRelation)

--- a/barretenberg/cpp/src/barretenberg/smt_verification/circuit/ultra_circuit.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/smt_verification/circuit/ultra_circuit.test.cpp
@@ -90,7 +90,7 @@ TEST(UltraCircuitSMT, ArithmeticRelation)
     auto circuit_info = unpack_from_buffer(builder.export_circuit());
     Solver s(circuit_info.modulus, ultra_solver_config);
     UltraCircuit cir(circuit_info, &s);
-    ASSERT_EQ(cir.get_num_gates(), builder.get_estimated_num_finalized_gates());
+    ASSERT_EQ(cir.get_num_gates(), builder.get_num_finalized_gates_inefficient());
 
     cir["a"] == a.get_value();
     cir["b"] == b.get_value();
@@ -122,7 +122,7 @@ TEST(UltraCircuitSMT, EllipticRelationADD)
     auto circuit_info = unpack_from_buffer(builder.export_circuit());
     Solver s(circuit_info.modulus, ultra_solver_config);
     UltraCircuit cir(circuit_info, &s);
-    ASSERT_EQ(cir.get_num_gates(), builder.get_estimated_num_finalized_gates());
+    ASSERT_EQ(cir.get_num_gates(), builder.get_num_finalized_gates_inefficient());
 
     cir["x1"] == p1.x.get_value();
     cir["x2"] == p2.x.get_value();
@@ -165,7 +165,7 @@ TEST(UltraCircuitSMT, EllipticRelationDBL)
     auto circuit_info = unpack_from_buffer(builder.export_circuit());
     Solver s(circuit_info.modulus, ultra_solver_config);
     UltraCircuit cir(circuit_info, &s);
-    ASSERT_EQ(cir.get_num_gates(), builder.get_estimated_num_finalized_gates());
+    ASSERT_EQ(cir.get_num_gates(), builder.get_num_finalized_gates_inefficient());
 
     cir["x1"] == p1.x.get_value();
     cir["y1"] == p1.y.get_value();
@@ -202,7 +202,7 @@ TEST(UltraCircuitSMT, OptimizedDeltaRangeRelation)
     auto circuit_info = unpack_from_buffer(builder.export_circuit());
     Solver s(circuit_info.modulus, ultra_solver_config);
     UltraCircuit cir(circuit_info, &s, TermType::BVTerm);
-    ASSERT_EQ(cir.get_num_gates(), builder.get_estimated_num_finalized_gates());
+    ASSERT_EQ(cir.get_num_gates(), builder.get_num_finalized_gates_inefficient());
 
     cir["a"] == a.get_value();
     s.print_assertions();
@@ -251,7 +251,7 @@ TEST(UltraCircuitSMT, LookupRelation2)
     auto circuit_info = unpack_from_buffer(builder.export_circuit());
     Solver s(circuit_info.modulus, ultra_solver_config, /*base=*/16, /*bvsize=*/256);
     UltraCircuit cir(circuit_info, &s, TermType::BVTerm);
-    ASSERT_EQ(cir.get_num_gates(), builder.get_estimated_num_finalized_gates());
+    ASSERT_EQ(cir.get_num_gates(), builder.get_num_finalized_gates_inefficient());
 
     cir["a"] == a.get_value();
     cir["b"] == b.get_value();

--- a/barretenberg/cpp/src/barretenberg/stdlib/eccvm_verifier/eccvm_recursive_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/eccvm_verifier/eccvm_recursive_verifier.test.cpp
@@ -95,7 +95,7 @@ class ECCVMRecursiveTests : public ::testing::Test {
         auto [opening_claim, ipa_transcript] = verifier.verify_proof(proof);
         stdlib::recursion::PairingPoints<OuterBuilder>::add_default_to_public_inputs(outer_circuit);
 
-        info("Recursive Verifier: num gates = ", outer_circuit.get_estimated_num_finalized_gates());
+        info("Recursive Verifier: num gates = ", outer_circuit.get_num_finalized_gates_inefficient());
 
         // Check for a failure flag in the recursive verifier circuit
         EXPECT_EQ(outer_circuit.failed(), false) << outer_circuit.err();
@@ -161,7 +161,7 @@ class ECCVMRecursiveTests : public ::testing::Test {
         RecursiveVerifier verifier{ &outer_circuit, verification_key, stdlib_verifier_transcript };
         [[maybe_unused]] auto output = verifier.verify_proof(proof);
         stdlib::recursion::PairingPoints<OuterBuilder>::add_default_to_public_inputs(outer_circuit);
-        info("Recursive Verifier: estimated num finalized gates = ", outer_circuit.get_estimated_num_finalized_gates());
+        info("Recursive Verifier: num finalized gates = ", outer_circuit.get_num_finalized_gates_inefficient());
 
         // Check for a failure flag in the recursive verifier circuit
         EXPECT_FALSE(CircuitChecker::check(outer_circuit));

--- a/barretenberg/cpp/src/barretenberg/stdlib/encryption/aes128/aes128.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/encryption/aes128/aes128.test.cpp
@@ -230,7 +230,7 @@ TEST(stdlib_aes128, encrypt_64_bytes_original)
         EXPECT_EQ(result[i].get_value(), expected[i]);
     }
 
-    std::cout << "num gates = " << builder.get_estimated_num_finalized_gates() << std::endl;
+    std::cout << "num gates = " << builder.get_num_finalized_gates_inefficient() << std::endl;
 
     bool proof_result = CircuitChecker::check(builder);
     EXPECT_EQ(proof_result, true);

--- a/barretenberg/cpp/src/barretenberg/stdlib/encryption/ecdsa/ecdsa.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/encryption/ecdsa/ecdsa.test.cpp
@@ -273,12 +273,12 @@ template <class Curve> class EcdsaTests : public ::testing::Test {
         EXPECT_EQ(signature_result.get_value(), signature_verification_result);
 
         // Log data
-        std::cerr << "num gates = " << builder.get_estimated_num_finalized_gates() << std::endl;
+        std::cerr << "num gates = " << builder.get_num_finalized_gates_inefficient() << std::endl;
         benchmark_info(Builder::NAME_STRING,
                        "ECDSA",
                        "Signature Verification Test",
                        "Gate Count",
-                       builder.get_estimated_num_finalized_gates());
+                       builder.get_num_finalized_gates_inefficient());
 
         // Circuit checker
         bool is_circuit_satisfied = CircuitChecker::check(builder);

--- a/barretenberg/cpp/src/barretenberg/stdlib/encryption/schnorr/schnorr.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/encryption/schnorr/schnorr.test.cpp
@@ -48,7 +48,7 @@ TEST(stdlib_schnorr, schnorr_verify_signature)
         byte_array_ct message(&builder, message_string);
         schnorr_verify_signature(message, pub_key, sig);
 
-        info("num gates = ", builder.get_estimated_num_finalized_gates());
+        info("num gates = ", builder.get_num_finalized_gates_inefficient());
         bool result = CircuitChecker::check(builder);
         EXPECT_EQ(result, true);
     }
@@ -90,7 +90,7 @@ TEST(stdlib_schnorr, verify_signature_failure)
     byte_array_ct message(&builder, message_string);
     schnorr_verify_signature(message, pub_key2_ct, sig);
 
-    info("num gates = ", builder.get_estimated_num_finalized_gates());
+    info("num gates = ", builder.get_num_finalized_gates_inefficient());
 
     bool verification_result = CircuitChecker::check(builder);
     EXPECT_EQ(verification_result, false);
@@ -125,7 +125,7 @@ TEST(stdlib_schnorr, schnorr_signature_verification_result)
     bool_ct signature_result = schnorr_signature_verification_result(message, pub_key, sig);
     EXPECT_EQ(signature_result.get_value(), true);
 
-    info("num gates = ", builder.get_estimated_num_finalized_gates());
+    info("num gates = ", builder.get_num_finalized_gates_inefficient());
 
     bool result = CircuitChecker::check(builder);
     EXPECT_EQ(result, true);
@@ -168,7 +168,7 @@ TEST(stdlib_schnorr, signature_verification_result_failure)
     bool_ct signature_result = schnorr_signature_verification_result(message, pub_key2_ct, sig);
     EXPECT_EQ(signature_result.get_value(), false);
 
-    info("num gates = ", builder.get_estimated_num_finalized_gates());
+    info("num gates = ", builder.get_num_finalized_gates_inefficient());
 
     bool verification_result = CircuitChecker::check(builder);
     EXPECT_EQ(verification_result, true);

--- a/barretenberg/cpp/src/barretenberg/stdlib/hash/blake2s/blake2s.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/hash/blake2s/blake2s.test.cpp
@@ -27,7 +27,7 @@ TEST(stdlib_blake2s, test_single_block_plookup)
 
     EXPECT_EQ(output.get_value(), std::vector<uint8_t>(expected.begin(), expected.end()));
 
-    info("builder gates = ", builder.get_estimated_num_finalized_gates());
+    info("builder gates = ", builder.get_num_finalized_gates_inefficient());
 
     bool proof_result = CircuitChecker::check(builder);
     EXPECT_EQ(proof_result, true);
@@ -46,7 +46,7 @@ TEST(stdlib_blake2s, test_double_block_plookup)
 
     EXPECT_EQ(output.get_value(), std::vector<uint8_t>(expected.begin(), expected.end()));
 
-    info("builder gates = ", builder.get_estimated_num_finalized_gates());
+    info("builder gates = ", builder.get_num_finalized_gates_inefficient());
 
     bool proof_result = CircuitChecker::check(builder);
     EXPECT_EQ(proof_result, true);

--- a/barretenberg/cpp/src/barretenberg/stdlib/hash/blake3s/blake3s.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/hash/blake3s/blake3s.test.cpp
@@ -24,7 +24,7 @@ TEST(stdlib_blake3s, test_single_block_plookup)
 
     EXPECT_EQ(output.get_value(), expected);
 
-    info("builder gates = ", builder.get_estimated_num_finalized_gates());
+    info("builder gates = ", builder.get_num_finalized_gates_inefficient());
 
     bool proof_result = CircuitChecker::check(builder);
     EXPECT_EQ(proof_result, true);
@@ -43,7 +43,7 @@ TEST(stdlib_blake3s, test_double_block_plookup)
 
     EXPECT_EQ(output.get_value(), expected);
 
-    info("builder gates = ", builder.get_estimated_num_finalized_gates());
+    info("builder gates = ", builder.get_num_finalized_gates_inefficient());
 
     bool proof_result = CircuitChecker::check(builder);
     EXPECT_EQ(proof_result, true);

--- a/barretenberg/cpp/src/barretenberg/stdlib/hash/keccak/keccak.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/hash/keccak/keccak.test.cpp
@@ -95,7 +95,7 @@ TEST(stdlib_keccak, keccak_rho_output_table)
         EXPECT_EQ(static_cast<uint256_t>(result_msb.get_value()), expected_msb);
     });
 
-    info("num gates = ", builder.get_estimated_num_finalized_gates());
+    info("num gates = ", builder.get_num_finalized_gates_inefficient());
     bool proof_result = CircuitChecker::check(builder);
     EXPECT_EQ(proof_result, true);
 }
@@ -131,7 +131,7 @@ TEST(stdlib_keccak, keccak_chi_output_table)
         EXPECT_EQ(static_cast<uint256_t>(normalized.get_value()), normalized_native);
         EXPECT_EQ(static_cast<uint256_t>(msb.get_value()), binary_native >> 63);
     }
-    info("num gates = n", builder.get_estimated_num_finalized_gates());
+    info("num gates = n", builder.get_num_finalized_gates_inefficient());
     bool proof_result = CircuitChecker::check(builder);
     EXPECT_EQ(proof_result, true);
 }
@@ -189,8 +189,6 @@ TEST(stdlib_keccak, test_single_block)
 
     EXPECT_EQ(output.get_value(), expected);
 
-    builder.print_num_estimated_finalized_gates();
-
     bool proof_result = CircuitChecker::check(builder);
     EXPECT_EQ(proof_result, true);
 }
@@ -214,8 +212,6 @@ TEST(stdlib_keccak, test_double_block)
 
     EXPECT_EQ(output.get_value(), expected);
 
-    builder.print_num_estimated_finalized_gates();
-
     bool proof_result = CircuitChecker::check(builder);
     EXPECT_EQ(proof_result, true);
 }
@@ -232,8 +228,6 @@ TEST(stdlib_keccak, test_permutation_opcode_single_block)
     std::vector<uint8_t> expected = stdlib::keccak<Builder>::hash_native(input_v);
 
     EXPECT_EQ(output.get_value(), expected);
-
-    builder.print_num_estimated_finalized_gates();
 
     bool proof_result = CircuitChecker::check(builder);
     EXPECT_EQ(proof_result, true);
@@ -254,8 +248,6 @@ TEST(stdlib_keccak, test_permutation_opcode_double_block)
     std::vector<uint8_t> expected = stdlib::keccak<Builder>::hash_native(input_v);
 
     EXPECT_EQ(output.get_value(), expected);
-
-    builder.print_num_estimated_finalized_gates();
 
     bool proof_result = CircuitChecker::check(builder);
     EXPECT_EQ(proof_result, true);

--- a/barretenberg/cpp/src/barretenberg/stdlib/hash/poseidon2/poseidon2.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/hash/poseidon2/poseidon2.test.cpp
@@ -59,12 +59,12 @@ template <typename Builder> class StdlibPoseidon2 : public testing::Test {
             inputs_native.emplace_back(element);
             inputs.emplace_back(field_ct(witness_ct(&builder, element)));
         }
-        size_t num_gates_start = builder.get_estimated_num_finalized_gates();
+        size_t num_gates_start = builder.get_num_finalized_gates_inefficient();
 
         auto result = stdlib::poseidon2<Builder>::hash(inputs);
         auto expected = crypto::Poseidon2<crypto::Poseidon2Bn254ScalarFieldParams>::hash(inputs_native);
 
-        EXPECT_EQ(gate_count(num_inputs), builder.get_estimated_num_finalized_gates() - num_gates_start);
+        EXPECT_EQ(gate_count(num_inputs), builder.get_num_finalized_gates_inefficient() - num_gates_start);
 
         EXPECT_EQ(result.get_value(), expected);
 
@@ -94,7 +94,7 @@ template <typename Builder> class StdlibPoseidon2 : public testing::Test {
 
         builder.set_public_input(left.witness_index);
 
-        info("num gates = ", builder.get_estimated_num_finalized_gates());
+        info("num gates = ", builder.get_num_finalized_gates_inefficient());
 
         bool result = CircuitChecker::check(builder);
         EXPECT_EQ(result, true);

--- a/barretenberg/cpp/src/barretenberg/stdlib/hash/sha256/sha256.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/hash/sha256/sha256.test.cpp
@@ -150,7 +150,7 @@ std::array<uint64_t, 8> inner_block(std::array<uint64_t, 64>& w)
 //         EXPECT_EQ(uint256_t(result[i].get_value()).data[0] & 0xffffffffUL,
 //                   uint256_t(expected[i]).data[0] & 0xffffffffUL);
 //     }
-//     info("num gates = %zu\n", builder.get_estimated_num_finalized_gates());
+//     info("num gates = %zu\n", builder.get_num_finalized_gates_inefficient());
 
 //     auto prover = composer.create_prover();
 
@@ -180,7 +180,7 @@ TEST(stdlib_sha256, test_plookup_55_bytes)
     EXPECT_EQ(uint256_t(output[5].get_value()), 0xbde22ab0U);
     EXPECT_EQ(uint256_t(output[6].get_value()), 0x54a8fac7U);
     EXPECT_EQ(uint256_t(output[7].get_value()), 0x93791fc7U);
-    info("num gates = ", builder.get_estimated_num_finalized_gates());
+    info("num gates = ", builder.get_num_finalized_gates_inefficient());
 
     bool proof_result = CircuitChecker::check(builder);
     EXPECT_EQ(proof_result, true);
@@ -205,7 +205,7 @@ TEST(stdlib_sha256, test_55_bytes)
     EXPECT_EQ(output[5].get_value(), fr(0xbde22ab0ULL));
     EXPECT_EQ(output[6].get_value(), fr(0x54a8fac7ULL));
     EXPECT_EQ(output[7].get_value(), fr(0x93791fc7ULL));
-    info("num gates = ", builder.get_estimated_num_finalized_gates());
+    info("num gates = ", builder.get_num_finalized_gates_inefficient());
 
     bool proof_result = CircuitChecker::check(builder);
     EXPECT_EQ(proof_result, true);
@@ -227,7 +227,7 @@ TEST(stdlib_sha256, test_NIST_vector_one_byte_array)
     EXPECT_EQ(uint256_t(output[5].get_value()).data[0], (uint64_t)0x96177A9CU);
     EXPECT_EQ(uint256_t(output[6].get_value()).data[0], (uint64_t)0xB410FF61U);
     EXPECT_EQ(uint256_t(output[7].get_value()).data[0], (uint64_t)0xF20015ADU);
-    info("num gates = ", builder.get_estimated_num_finalized_gates());
+    info("num gates = ", builder.get_num_finalized_gates_inefficient());
 
     bool proof_result = CircuitChecker::check(builder);
     EXPECT_EQ(proof_result, true);
@@ -252,7 +252,7 @@ TEST(stdlib_sha256, test_NIST_vector_one)
     EXPECT_EQ(output[5].get_value(), fr(0x96177A9CULL));
     EXPECT_EQ(output[6].get_value(), fr(0xB410FF61ULL));
     EXPECT_EQ(output[7].get_value(), fr(0xF20015ADULL));
-    info("num gates = ", builder.get_estimated_num_finalized_gates());
+    info("num gates = ", builder.get_num_finalized_gates_inefficient());
 
     bool proof_result = CircuitChecker::check(builder);
     EXPECT_EQ(proof_result, true);
@@ -276,7 +276,7 @@ TEST(stdlib_sha256, test_NIST_vector_two)
     EXPECT_EQ(output[5].get_value(), 0x64FF2167ULL);
     EXPECT_EQ(output[6].get_value(), 0xF6ECEDD4ULL);
     EXPECT_EQ(output[7].get_value(), 0x19DB06C1ULL);
-    info("num gates = ", builder.get_estimated_num_finalized_gates());
+    info("num gates = ", builder.get_num_finalized_gates_inefficient());
 
     bool proof_result = CircuitChecker::check(builder);
     EXPECT_EQ(proof_result, true);
@@ -301,7 +301,7 @@ TEST(stdlib_sha256, test_NIST_vector_three)
     EXPECT_EQ(output[5].get_value(), 0x7dc4b5aaULL);
     EXPECT_EQ(output[6].get_value(), 0xe11204c0ULL);
     EXPECT_EQ(output[7].get_value(), 0x8ffe732bULL);
-    info("num gates = ", builder.get_estimated_num_finalized_gates());
+    info("num gates = ", builder.get_num_finalized_gates_inefficient());
 
     bool proof_result = CircuitChecker::check(builder);
     EXPECT_EQ(proof_result, true);
@@ -327,7 +327,7 @@ TEST(stdlib_sha256, test_NIST_vector_four)
     EXPECT_EQ(output[6].get_value(), 0xbd56c61cULL);
     EXPECT_EQ(output[7].get_value(), 0xcccd9504ULL);
 
-    info("num gates = ", builder.get_estimated_num_finalized_gates());
+    info("num gates = ", builder.get_num_finalized_gates_inefficient());
 
     bool proof_result = CircuitChecker::check(builder);
     EXPECT_EQ(proof_result, true);
@@ -364,7 +364,7 @@ HEAVY_TEST(stdlib_sha256, test_NIST_vector_five)
     EXPECT_EQ(output[6].get_value(), 0xa519105aULL);
     EXPECT_EQ(output[7].get_value(), 0x1eadd6e4ULL);
 
-    info("num gates = ", builder.get_estimated_num_finalized_gates());
+    info("num gates = ", builder.get_num_finalized_gates_inefficient());
 
     bool proof_result = CircuitChecker::check(builder);
     EXPECT_EQ(proof_result, true);

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.test.cpp
@@ -1165,11 +1165,11 @@ template <typename BigField> class stdlib_bigfield : public testing::Test {
                 witness_ct(&builder, fr(uint256_t(P2.y).slice(0, fq_ct::NUM_LIMB_BITS * 2))),
                 witness_ct(&builder, fr(uint256_t(P2.y).slice(fq_ct::NUM_LIMB_BITS * 2, fq_ct::NUM_LIMB_BITS * 4))));
 
-            uint64_t before = builder.get_estimated_num_finalized_gates();
+            uint64_t before = builder.get_num_finalized_gates_inefficient();
             fq_ct lambda = (y2 - y1) / (x2 - x1);
             fq_ct x3 = lambda.sqr() - (x2 + x1);
             fq_ct y3 = (x1 - x3) * lambda - y1;
-            uint64_t after = builder.get_estimated_num_finalized_gates();
+            uint64_t after = builder.get_num_finalized_gates_inefficient();
             std::cerr << "added gates = " << after - before << std::endl;
 
             // Check the result against the native group addition

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup.test.cpp
@@ -49,7 +49,7 @@ template <typename TestType> class stdlib_biggroup : public testing::Test {
     using bool_ct = stdlib::bool_t<Builder>;
 
     static constexpr auto EXPECT_CIRCUIT_CORRECTNESS = [](Builder& builder, bool expected_result = true) {
-        info("num gates = ", builder.get_estimated_num_finalized_gates());
+        info("num gates = ", builder.get_num_finalized_gates_inefficient());
         EXPECT_EQ(CircuitChecker::check(builder), expected_result);
     };
 
@@ -96,9 +96,9 @@ template <typename TestType> class stdlib_biggroup : public testing::Test {
             a.set_origin_tag(submitted_value_origin_tag);
             b.set_origin_tag(challenge_origin_tag);
 
-            uint64_t before = builder.get_estimated_num_finalized_gates();
+            uint64_t before = builder.get_num_finalized_gates_inefficient();
             element_ct c = a + b;
-            uint64_t after = builder.get_estimated_num_finalized_gates();
+            uint64_t after = builder.get_num_finalized_gates_inefficient();
 
             // Check that the resulting tag is the union of inputs' tgs
             EXPECT_EQ(c.get_origin_tag(), first_two_merged_tag);
@@ -599,9 +599,9 @@ template <typename TestType> class stdlib_biggroup : public testing::Test {
             x.set_origin_tag(challenge_origin_tag);
             P.set_origin_tag(submitted_value_origin_tag);
 
-            std::cerr << "gates before mul " << builder.get_estimated_num_finalized_gates() << std::endl;
+            std::cerr << "gates before mul " << builder.get_num_finalized_gates_inefficient() << std::endl;
             element_ct c = P * x;
-            std::cerr << "builder aftr mul " << builder.get_estimated_num_finalized_gates() << std::endl;
+            std::cerr << "builder aftr mul " << builder.get_num_finalized_gates_inefficient() << std::endl;
             affine_element c_expected(element(input) * scalar);
 
             // Check the result of the multiplication has a tag that's the union of inputs' tags
@@ -643,10 +643,10 @@ template <typename TestType> class stdlib_biggroup : public testing::Test {
             x.set_origin_tag(challenge_origin_tag);
             P.set_origin_tag(submitted_value_origin_tag);
 
-            std::cerr << "gates before mul " << builder.get_estimated_num_finalized_gates() << std::endl;
+            std::cerr << "gates before mul " << builder.get_num_finalized_gates_inefficient() << std::endl;
             // Multiply using specified scalar length
             element_ct c = P.scalar_mul(x, i);
-            std::cerr << "builder aftr mul " << builder.get_estimated_num_finalized_gates() << std::endl;
+            std::cerr << "builder aftr mul " << builder.get_num_finalized_gates_inefficient() << std::endl;
             affine_element c_expected(element(input) * scalar);
 
             // Check the result of the multiplication has a tag that's the union of inputs' tags
@@ -683,10 +683,10 @@ template <typename TestType> class stdlib_biggroup : public testing::Test {
             x.set_origin_tag(challenge_origin_tag);
             P.set_origin_tag(submitted_value_origin_tag);
 
-            std::cerr << "gates before mul " << builder.get_estimated_num_finalized_gates() << std::endl;
+            std::cerr << "gates before mul " << builder.get_num_finalized_gates_inefficient() << std::endl;
             // Multiply using specified scalar length
             element_ct c = P.scalar_mul(x, i);
-            std::cerr << "builder aftr mul " << builder.get_estimated_num_finalized_gates() << std::endl;
+            std::cerr << "builder aftr mul " << builder.get_num_finalized_gates_inefficient() << std::endl;
             affine_element c_expected(element(input) * scalar);
 
             // Check the result of the multiplication has a tag that's the union of inputs' tags
@@ -736,10 +736,10 @@ template <typename TestType> class stdlib_biggroup : public testing::Test {
             x.set_origin_tag(challenge_origin_tag);
             P.set_origin_tag(submitted_value_origin_tag);
 
-            std::cerr << "gates before mul " << builder.get_estimated_num_finalized_gates() << std::endl;
+            std::cerr << "gates before mul " << builder.get_num_finalized_gates_inefficient() << std::endl;
             element_ct c = P.scalar_mul(x, max_num_bits);
-            std::cerr << "builder aftr mul " << builder.get_estimated_num_finalized_gates() << std::endl;
-            num_gates = builder.get_estimated_num_finalized_gates();
+            std::cerr << "builder aftr mul " << builder.get_num_finalized_gates_inefficient() << std::endl;
+            num_gates = builder.get_num_finalized_gates_inefficient();
             // Check the result of the multiplication has a tag that's the union of inputs' tags
             EXPECT_EQ(c.get_origin_tag(), first_two_merged_tag);
 
@@ -1465,9 +1465,9 @@ template <typename TestType> class stdlib_biggroup : public testing::Test {
                 union_tag = OriginTag(union_tag, element_tags[j], scalar_tags[j]);
             }
 
-            std::cerr << "gates before mul " << builder.get_estimated_num_finalized_gates() << std::endl;
+            std::cerr << "gates before mul " << builder.get_num_finalized_gates_inefficient() << std::endl;
             element_ct c = element_ct::batch_mul({ P1, P2, P3, P4 }, { x1, x2, x3, x4 }, 128);
-            std::cerr << "builder aftr mul " << builder.get_estimated_num_finalized_gates() << std::endl;
+            std::cerr << "builder aftr mul " << builder.get_num_finalized_gates_inefficient() << std::endl;
 
             // Check that the resulting tag is a union of inputs' tags
             EXPECT_EQ(c.get_origin_tag(), union_tag);

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_goblin.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_goblin.test.cpp
@@ -29,7 +29,7 @@ template <typename Curve> class stdlib_biggroup_goblin : public testing::Test {
     using Builder = typename Curve::Builder;
 
     static constexpr auto EXPECT_CIRCUIT_CORRECTNESS = [](Builder& builder, bool expected_result = true) {
-        info("builder gates = ", builder.get_estimated_num_finalized_gates());
+        info("builder gates = ", builder.get_num_finalized_gates_inefficient());
         EXPECT_EQ(CircuitChecker::check(builder), expected_result);
     };
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_secp256k1.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_secp256k1.test.cpp
@@ -37,7 +37,7 @@ template <typename Curve> class stdlibBiggroupSecp256k1 : public testing::Test {
     using bool_ct = stdlib::bool_t<Builder>;
 
     static constexpr auto EXPECT_CIRCUIT_CORRECTNESS = [](Builder& builder, bool expected_result = true) {
-        info("num gates = ", builder.get_estimated_num_finalized_gates());
+        info("num gates = ", builder.get_num_finalized_gates_inefficient());
         EXPECT_EQ(CircuitChecker::check(builder), expected_result);
     };
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bool/bool.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bool/bool.test.cpp
@@ -58,7 +58,7 @@ template <class Builder_> class BoolTest : public ::testing::Test {
                 bool_ct a = create_bool_ct(lhs, &builder);
                 bool_ct b = create_bool_ct(rhs, &builder);
 
-                size_t num_gates_start = builder.get_estimated_num_finalized_gates();
+                size_t num_gates_start = builder.get_num_finalized_gates_inefficient();
 
                 if (!a.is_constant() && !b.is_constant()) {
                     a.set_origin_tag(submitted_value_origin_tag);
@@ -84,7 +84,7 @@ template <class Builder_> class BoolTest : public ::testing::Test {
                     EXPECT_EQ(c.get_origin_tag(), first_two_merged_tag);
                 }
 
-                size_t diff = builder.get_estimated_num_finalized_gates() - num_gates_start;
+                size_t diff = builder.get_num_finalized_gates_inefficient() - num_gates_start;
                 // An extra gate is created iff both operands are witnesses
                 EXPECT_EQ(diff, static_cast<size_t>(!a.is_constant() && !b.is_constant()));
             }
@@ -96,7 +96,7 @@ template <class Builder_> class BoolTest : public ::testing::Test {
     void test_construct_from_const_bool()
     {
         Builder builder = Builder();
-        size_t num_gates_start = builder.get_estimated_num_finalized_gates();
+        size_t num_gates_start = builder.get_num_finalized_gates_inefficient();
         bool_ct a_true(true);
         bool_ct a_false(false);
         EXPECT_TRUE(a_true.get_value());
@@ -104,13 +104,13 @@ template <class Builder_> class BoolTest : public ::testing::Test {
         EXPECT_TRUE(a_true.is_constant() && a_false.is_constant());
         EXPECT_TRUE(!a_true.is_inverted() && !a_false.is_inverted());
         // No gates have been added
-        EXPECT_TRUE(num_gates_start == builder.get_estimated_num_finalized_gates());
+        EXPECT_TRUE(num_gates_start == builder.get_num_finalized_gates_inefficient());
     }
 
     void test_construct_from_witness_index()
     {
         Builder builder = Builder();
-        size_t num_gates_start = builder.get_estimated_num_finalized_gates();
+        size_t num_gates_start = builder.get_num_finalized_gates_inefficient();
         const size_t witness_idx_zero = builder.add_variable(bb::fr(0));
         const size_t witness_idx_one = builder.add_variable(bb::fr(1));
         const size_t non_bool_witness_idx = builder.add_variable(bb::fr(15));
@@ -121,7 +121,7 @@ template <class Builder_> class BoolTest : public ::testing::Test {
         bool_witness = bool_ct::from_witness_index_unsafe(&builder, witness_idx_one);
         EXPECT_EQ(bool_witness.get_value(), true);
         // No gates are added.
-        EXPECT_EQ(builder.get_estimated_num_finalized_gates() - num_gates_start, 0);
+        EXPECT_EQ(builder.get_num_finalized_gates_inefficient() - num_gates_start, 0);
 
         // Out-of-circuit failure when witness points to a non-bool value.
         EXPECT_THROW_OR_ABORT(bool_witness = bool_ct::from_witness_index_unsafe(&builder, non_bool_witness_idx),
@@ -130,7 +130,7 @@ template <class Builder_> class BoolTest : public ::testing::Test {
     void test_construct_from_witness()
     {
         Builder builder = Builder();
-        size_t num_gates_start = builder.get_estimated_num_finalized_gates();
+        size_t num_gates_start = builder.get_num_finalized_gates_inefficient();
 
         bool_ct a_true = witness_ct(&builder, 1);
         bool_ct a_false = witness_ct(&builder, 0);
@@ -139,7 +139,7 @@ template <class Builder_> class BoolTest : public ::testing::Test {
         EXPECT_TRUE(!a_true.is_constant() && !a_false.is_constant());
         EXPECT_TRUE(!a_true.is_inverted() && !a_false.is_inverted());
         // Each witness bool must be constrained => expect 2 gates being added
-        EXPECT_TRUE(builder.get_estimated_num_finalized_gates() - num_gates_start == 2);
+        EXPECT_TRUE(builder.get_num_finalized_gates_inefficient() - num_gates_start == 2);
         EXPECT_TRUE(CircuitChecker::check(builder));
 
         // Test failure
@@ -158,7 +158,7 @@ template <class Builder_> class BoolTest : public ::testing::Test {
 
         for (size_t num_inputs = 1; num_inputs < 50; num_inputs++) {
             Builder builder = Builder();
-            size_t num_gates_start = builder.get_estimated_num_finalized_gates();
+            size_t num_gates_start = builder.get_num_finalized_gates_inefficient();
 
             std::vector<uint32_t> indices;
             for (size_t idx = 0; idx < num_inputs; idx++) {
@@ -166,14 +166,18 @@ template <class Builder_> class BoolTest : public ::testing::Test {
                     bool_ct(witness_ct(&builder, idx % 2), use_range_constraint).get_normalized_witness_index());
             }
 
-            const size_t sorted_list_size = num_inputs + 2;
+            // Note: +2 comes from entries added in create_range_list for target_range == 1
+            size_t sorted_list_size = num_inputs + 2;
+            // sorted list is padded to minimum size of 8
+            sorted_list_size = std::max(sorted_list_size, 8UL);
+            // +4 for combination of unconstrained gates and add gates for fixing endpoints
+            size_t fixed_additional_gates = 4;
+            // Delta-range mechanism packs 4 values per gate
+            size_t expected = numeric::ceil_div(sorted_list_size, 4UL) + fixed_additional_gates;
 
-            // Pin down the gate numbers. The point is that it is more efficient to use this constructor to constrain a
-            // batch of bool_t elements. 4 is a special case, otherwise the number of gates is just
-            // ceil(sorted_list_size) + 2.
-            size_t expected = (sorted_list_size == 4) ? 4 : ((sorted_list_size + 3) / 4) + 2;
+            size_t actual = builder.get_num_finalized_gates_inefficient() - num_gates_start;
 
-            EXPECT_EQ(builder.get_estimated_num_finalized_gates() - num_gates_start, expected);
+            EXPECT_EQ(actual, expected);
 
             builder.create_unconstrained_gates(indices);
 
@@ -246,7 +250,7 @@ template <class Builder_> class BoolTest : public ::testing::Test {
                 } else {
                     bool result_is_constant = (!a || b).is_constant();
 
-                    size_t num_gates_start = builder.get_estimated_num_finalized_gates();
+                    size_t num_gates_start = builder.get_num_finalized_gates_inefficient();
 
                     if (!a.is_constant() && !b.is_constant()) {
                         a.set_origin_tag(submitted_value_origin_tag);
@@ -257,7 +261,7 @@ template <class Builder_> class BoolTest : public ::testing::Test {
                     // b = 1 =>
                     bool expected = !(lhs.value ^ lhs.is_inverted) || rhs.value ^ rhs.is_inverted;
 
-                    size_t diff = builder.get_estimated_num_finalized_gates() - num_gates_start;
+                    size_t diff = builder.get_num_finalized_gates_inefficient() - num_gates_start;
 
                     if (!a.is_constant() && !b.is_constant()) {
                         EXPECT_EQ(diff, 2);
@@ -296,7 +300,7 @@ template <class Builder_> class BoolTest : public ::testing::Test {
                     bool_ct b = create_bool_ct(rhs, &builder);
                     bool_ct condition = create_bool_ct(predicate, &builder);
 
-                    size_t num_gates_start = builder.get_estimated_num_finalized_gates();
+                    size_t num_gates_start = builder.get_num_finalized_gates_inefficient();
                     if (!a.is_constant() && !b.is_constant()) {
                         condition.set_origin_tag(submitted_value_origin_tag);
                         a.set_origin_tag(challenge_origin_tag);
@@ -304,7 +308,7 @@ template <class Builder_> class BoolTest : public ::testing::Test {
                     }
 
                     bool_ct result = bool_ct::conditional_assign(condition, a, b);
-                    size_t diff = builder.get_estimated_num_finalized_gates() - num_gates_start;
+                    size_t diff = builder.get_num_finalized_gates_inefficient() - num_gates_start;
                     if (!a.is_constant() && !b.is_constant()) {
                         EXPECT_EQ(result.get_origin_tag(), first_second_third_merged_tag);
                     }
@@ -328,7 +332,7 @@ template <class Builder_> class BoolTest : public ::testing::Test {
 
             bool_ct a = create_bool_ct(a_raw, &builder);
 
-            size_t num_gates_start = builder.get_estimated_num_finalized_gates();
+            size_t num_gates_start = builder.get_num_finalized_gates_inefficient();
             if (!a.is_constant()) {
                 a.set_origin_tag(submitted_value_origin_tag);
             }
@@ -338,7 +342,7 @@ template <class Builder_> class BoolTest : public ::testing::Test {
                 EXPECT_EQ(c.get_origin_tag(), submitted_value_origin_tag);
             }
             EXPECT_EQ(c.is_inverted(), false);
-            size_t diff = builder.get_estimated_num_finalized_gates() - num_gates_start;
+            size_t diff = builder.get_num_finalized_gates_inefficient() - num_gates_start;
             // Note that although `normalize()` returns value, it flips the `is_inverted()` flag of `a` if it was
             // `true`.
             EXPECT_EQ(diff, static_cast<size_t>(!a.is_constant() && a_raw.is_inverted));
@@ -379,7 +383,7 @@ template <class Builder_> class BoolTest : public ::testing::Test {
     {
         auto builder = Builder();
 
-        auto gates_before = builder.get_estimated_num_finalized_gates();
+        auto gates_before = builder.get_num_finalized_gates_inefficient();
 
         bool_ct a = witness_ct(&builder, bb::fr::one());
         bool_ct b = witness_ct(&builder, bb::fr::zero());
@@ -430,7 +434,7 @@ template <class Builder_> class BoolTest : public ::testing::Test {
         bool result = CircuitChecker::check(builder);
         EXPECT_EQ(result, true);
 
-        auto gates_after = builder.get_estimated_num_finalized_gates();
+        auto gates_after = builder.get_num_finalized_gates_inefficient();
         EXPECT_EQ(gates_after - gates_before, 6UL);
     }
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bool/bool.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bool/bool.test.cpp
@@ -264,7 +264,7 @@ template <class Builder_> class BoolTest : public ::testing::Test {
                     size_t diff = builder.get_num_finalized_gates_inefficient() - num_gates_start;
 
                     if (!a.is_constant() && !b.is_constant()) {
-                        EXPECT_EQ(diff, 2);
+                        EXPECT_EQ(diff, 1);
                     }
                     // Due to optimizations, the result of a => b can be a constant, in this case, the the assert_equal
                     // reduces to an out-of-circuit ASSERT
@@ -275,13 +275,13 @@ template <class Builder_> class BoolTest : public ::testing::Test {
                     if (!result_is_constant && a.is_constant() && !b.is_constant()) {
                         // we only add gates if the value `true` is not flipped to `false` and we need to add a new
                         // constant == 1, which happens iff `b` is not inverted.
-                        EXPECT_EQ(diff, static_cast<size_t>(!b.is_inverted()));
+                        EXPECT_EQ(diff, 0);
                     }
 
                     if (!result_is_constant && !a.is_constant() && b.is_constant()) {
                         // we only add gates if the value `true` is not flipped to `false` and we need to add a new
                         // constant == 1, which happens iff `a` is inverted.
-                        EXPECT_EQ(diff, static_cast<size_t>(a.is_inverted()));
+                        EXPECT_EQ(diff, 0);
                     }
                     EXPECT_EQ(CircuitChecker::check(builder), expected);
                 }

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/byte_array/byte_array.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/byte_array/byte_array.test.cpp
@@ -105,7 +105,7 @@ template <class Builder> class ByteArrayTest : public ::testing::Test {
     {
         for (size_t num_bytes = 1; num_bytes < 32; num_bytes++) {
             Builder builder;
-            size_t num_gates_start = builder.get_estimated_num_finalized_gates();
+            size_t num_gates_start = builder.get_num_finalized_gates_inefficient();
 
             uint256_t raw_val = engine.get_random_uint256();
             fr expected_val = slice_to_n_bytes(raw_val, num_bytes);
@@ -124,7 +124,7 @@ template <class Builder> class ByteArrayTest : public ::testing::Test {
             EXPECT_EQ(reconstructed_field.get_origin_tag(), submitted_value_origin_tag);
 
             // Make sure no gates are added
-            EXPECT_TRUE(builder.get_estimated_num_finalized_gates() - num_gates_start == 0);
+            EXPECT_TRUE(builder.get_num_finalized_gates_inefficient() - num_gates_start == 0);
         }
     }
 
@@ -172,7 +172,7 @@ template <class Builder> class ByteArrayTest : public ::testing::Test {
     {
 
         Builder builder;
-        size_t gates_start = builder.get_estimated_num_finalized_gates();
+        size_t gates_start = builder.get_num_finalized_gates_inefficient();
         field_ct test_val(&builder, fr::random_element());
 
         byte_array_ct arr(test_val, 32);
@@ -196,7 +196,7 @@ template <class Builder> class ByteArrayTest : public ::testing::Test {
                                   "byte_array: y_hi doesn't fit in 128 bits");
         }
         // Make sure no gates are added
-        EXPECT_TRUE(gates_start == builder.get_estimated_num_finalized_gates());
+        EXPECT_TRUE(gates_start == builder.get_num_finalized_gates_inefficient());
     }
 
     void test_byte_array_input_output_consistency()

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/field/array.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/field/array.test.cpp
@@ -38,7 +38,7 @@ template <typename Builder> class stdlib_array : public testing::Test {
         auto filled_len = array_length<Builder>(values_ct);
         EXPECT_EQ(filled_len.get_value(), filled);
 
-        info("num gates = ", builder.get_estimated_num_finalized_gates());
+        info("num gates = ", builder.get_num_finalized_gates_inefficient());
         bool proof_result = CircuitChecker::check(builder);
         EXPECT_EQ(proof_result, true);
     }
@@ -52,7 +52,7 @@ template <typename Builder> class stdlib_array : public testing::Test {
         EXPECT_EQ(filled_len.get_value(), 0);
         EXPECT_TRUE(filled_len.is_constant());
 
-        info("num gates = ", builder.get_estimated_num_finalized_gates());
+        info("num gates = ", builder.get_num_finalized_gates_inefficient());
         bool proof_result = CircuitChecker::check(builder);
         EXPECT_EQ(proof_result, true);
     }
@@ -97,7 +97,7 @@ template <typename Builder> class stdlib_array : public testing::Test {
         auto popped = array_pop<Builder>(values_ct);
         EXPECT_EQ(popped.get_value(), values[filled - 1]);
 
-        info("num gates = ", builder.get_estimated_num_finalized_gates());
+        info("num gates = ", builder.get_num_finalized_gates_inefficient());
         bool proof_result = CircuitChecker::check(builder);
         EXPECT_EQ(proof_result, true);
     };
@@ -149,7 +149,7 @@ template <typename Builder> class stdlib_array : public testing::Test {
         array_push<Builder>(values_ct, value_ct);
         EXPECT_EQ(value_ct.get_value(), values_ct[filled].get_value());
 
-        info("num gates = ", builder.get_estimated_num_finalized_gates());
+        info("num gates = ", builder.get_num_finalized_gates_inefficient());
         bool proof_result = CircuitChecker::check(builder);
         EXPECT_EQ(proof_result, true);
     }
@@ -189,7 +189,7 @@ template <typename Builder> class stdlib_array : public testing::Test {
 
         EXPECT_EQ(num_pushes, ARRAY_LEN);
 
-        info("num gates = ", builder.get_estimated_num_finalized_gates());
+        info("num gates = ", builder.get_num_finalized_gates_inefficient());
         bool proof_result = CircuitChecker::check(builder);
         EXPECT_EQ(proof_result, true);
     }
@@ -246,7 +246,7 @@ template <typename Builder> class stdlib_array : public testing::Test {
         is_empty = is_array_empty<Builder>(values_ct);
         EXPECT_EQ(is_empty.get_value(), true);
 
-        info("num gates = ", builder.get_estimated_num_finalized_gates());
+        info("num gates = ", builder.get_num_finalized_gates_inefficient());
         bool proof_result = CircuitChecker::check(builder);
         EXPECT_EQ(proof_result, true);
     };
@@ -278,7 +278,7 @@ template <typename Builder> class stdlib_array : public testing::Test {
 
         bool proof_result = false;
         if (!builder.failed()) {
-            info("num gates = ", builder.get_estimated_num_finalized_gates());
+            info("num gates = ", builder.get_num_finalized_gates_inefficient());
             proof_result = CircuitChecker::check(builder);
         }
 
@@ -567,7 +567,7 @@ template <typename Builder> class stdlib_array : public testing::Test {
         EXPECT_EQ(arr[2].get_values().first.get_value(), 3);
         EXPECT_EQ(arr[2].get_values().second.get_value(), 30);
 
-        info("num gates = ", builder.get_estimated_num_finalized_gates());
+        info("num gates = ", builder.get_num_finalized_gates_inefficient());
         bool proof_result = CircuitChecker::check(builder);
         EXPECT_EQ(proof_result, true);
     }

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/field/field.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/field/field.test.cpp
@@ -1195,7 +1195,7 @@ template <typename Builder> class stdlib_field : public testing::Test {
             size_t padding = (3 - (num_witnesses % 3)) % 3;
             size_t expected_num_gates = (num_witnesses + padding) / 3;
 
-            EXPECT_EQ(builder.get_num_finalized_gates_inefficient() - 1, expected_num_gates);
+            EXPECT_EQ(builder.get_num_finalized_gates_inefficient(/*ensure_nonzero=*/false) - 1, expected_num_gates);
 
             // Check that the accumulation of constant entries does not create a witness
             std::vector<field_ct> constant_input;

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/field/field.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/field/field.test.cpp
@@ -30,13 +30,13 @@ template <typename Builder> class stdlib_field : public testing::Test {
         field_ct a(public_witness_ct(&builder, fr::one())); // a is a legit wire value in our circuit
         field_ct b(&builder,
                    (fr::one())); // b is just a constant, and should not turn up as a wire value in our circuit
-        const size_t num_gates = builder.get_estimated_num_finalized_gates();
+        const size_t num_gates = builder.get_num_finalized_gates_inefficient();
 
         // This shouldn't create a constraint - we just need to scale the addition/multiplication gates that `a` is
         // involved in, `c` should have the same witness index as `a`, i.e. point to the same wire value
         field_ct c = a + b;
         EXPECT_TRUE(c.witness_index == a.witness_index);
-        EXPECT_TRUE(builder.get_estimated_num_finalized_gates() == num_gates);
+        EXPECT_TRUE(builder.get_num_finalized_gates_inefficient() == num_gates);
         field_ct d(&builder, fr::coset_generator<0>()); // like b, d is just a constant and not a wire value
 
         // by this point, we shouldn't have added any constraints in our circuit
@@ -209,7 +209,7 @@ template <typename Builder> class stdlib_field : public testing::Test {
 
         auto check_conditional_assign =
             [](auto& builder, bool_ct& predicate, field_ct& lhs, field_ct& rhs, bool same_elt) {
-                size_t num_gates_before = builder.get_estimated_num_finalized_gates();
+                size_t num_gates_before = builder.get_num_finalized_gates_inefficient();
                 field_ct result = field_ct::conditional_assign(predicate, lhs, rhs);
                 EXPECT_TRUE(result.get_value() == (predicate.get_value() ? lhs.get_value() : rhs.get_value()));
 
@@ -224,7 +224,7 @@ template <typename Builder> class stdlib_field : public testing::Test {
                     }
                 }
 
-                EXPECT_TRUE(builder.get_estimated_num_finalized_gates() - num_gates_before == expected_num_gates);
+                EXPECT_TRUE(builder.get_num_finalized_gates_inefficient() - num_gates_before == expected_num_gates);
             };
         // Populate predicate array, ensure that both constant and witness predicates are present
         std::array<bool_ct, 4> predicates{
@@ -371,44 +371,44 @@ template <typename Builder> class stdlib_field : public testing::Test {
         // Constant == witness
         {
             Builder builder;
-            size_t num_gates_start = builder.get_estimated_num_finalized_gates();
+            size_t num_gates_start = builder.get_num_finalized_gates_inefficient();
             field_ct a(&builder, 9);
             field_ct b = field_ct::from_witness(&builder, 9);
             a.assert_equal(b);
             EXPECT_TRUE(CircuitChecker::check(builder));
             // 1 gate is needed to fix the constant
-            EXPECT_EQ(builder.get_estimated_num_finalized_gates() - num_gates_start, 1);
+            EXPECT_EQ(builder.get_num_finalized_gates_inefficient() - num_gates_start, 1);
         }
 
         // Witness == constant
         {
             Builder builder;
-            size_t num_gates_start = builder.get_estimated_num_finalized_gates();
+            size_t num_gates_start = builder.get_num_finalized_gates_inefficient();
             field_ct a = field_ct::from_witness(&builder, 42);
             field_ct b(&builder, 42);
             a.assert_equal(b);
             EXPECT_TRUE(CircuitChecker::check(builder));
             // 1 gate is needed to fix the constant
-            EXPECT_EQ(builder.get_estimated_num_finalized_gates() - num_gates_start, 1);
+            EXPECT_EQ(builder.get_num_finalized_gates_inefficient() - num_gates_start, 1);
         }
 
         // Witness == witness (equal values)
         {
             Builder builder;
-            size_t num_gates_start = builder.get_estimated_num_finalized_gates();
+            size_t num_gates_start = builder.get_num_finalized_gates_inefficient();
 
             field_ct a = field_ct::from_witness(&builder, 11);
             field_ct b = field_ct::from_witness(&builder, 11);
             a.assert_equal(b);
             EXPECT_TRUE(CircuitChecker::check(builder));
             // Both witnesses are normalized, no gates are created, only a copy constraint
-            EXPECT_EQ(builder.get_estimated_num_finalized_gates() - num_gates_start, 0);
+            EXPECT_EQ(builder.get_num_finalized_gates_inefficient() - num_gates_start, 0);
         }
 
         // Witness != witness (both are not normalized)
         {
             Builder builder;
-            size_t num_gates_start = builder.get_estimated_num_finalized_gates();
+            size_t num_gates_start = builder.get_num_finalized_gates_inefficient();
             field_ct a = field_ct::from_witness(&builder, 10);
             a += 13;
             field_ct b = field_ct::from_witness(&builder, 15);
@@ -416,7 +416,7 @@ template <typename Builder> class stdlib_field : public testing::Test {
             a.assert_equal(b);
             EXPECT_FALSE(CircuitChecker::check(builder));
             // Both witnesses are not normalized, we use a single `add_gate` to ensure they are equal
-            EXPECT_EQ(builder.get_estimated_num_finalized_gates() - num_gates_start, 1);
+            EXPECT_EQ(builder.get_num_finalized_gates_inefficient() - num_gates_start, 1);
             EXPECT_EQ(builder.err(), "field_t::assert_equal");
         }
     }
@@ -424,9 +424,9 @@ template <typename Builder> class stdlib_field : public testing::Test {
     static void test_add_mul_with_constants()
     {
         Builder builder = Builder();
-        auto gates_before = builder.get_estimated_num_finalized_gates();
+        auto gates_before = builder.get_num_finalized_gates_inefficient();
         uint64_t expected = fidget(builder);
-        auto gates_after = builder.get_estimated_num_finalized_gates();
+        auto gates_after = builder.get_num_finalized_gates_inefficient();
         auto& block = builder.blocks.arithmetic;
         EXPECT_EQ(builder.get_variable(block.w_o()[block.size() - 1]), fr(expected));
         info("Number of gates added", gates_after - gates_before);
@@ -617,12 +617,12 @@ template <typename Builder> class stdlib_field : public testing::Test {
     static void test_equality()
     {
         Builder builder = Builder();
-        auto gates_before = builder.get_estimated_num_finalized_gates();
+        auto gates_before = builder.get_num_finalized_gates_inefficient();
         field_ct a(witness_ct(&builder, 4));
         field_ct b(witness_ct(&builder, 4));
         bool_ct r = a == b;
 
-        auto gates_after = builder.get_estimated_num_finalized_gates();
+        auto gates_after = builder.get_num_finalized_gates_inefficient();
         EXPECT_EQ(r.get_value(), true);
 
         fr x = r.get_value();
@@ -642,11 +642,11 @@ template <typename Builder> class stdlib_field : public testing::Test {
     {
         Builder builder = Builder();
 
-        auto gates_before = builder.get_estimated_num_finalized_gates();
+        auto gates_before = builder.get_num_finalized_gates_inefficient();
         field_ct a(witness_ct(&builder, 4));
         field_ct b(witness_ct(&builder, 3));
         bool_ct r = a == b;
-        auto gates_after = builder.get_estimated_num_finalized_gates();
+        auto gates_after = builder.get_num_finalized_gates_inefficient();
 
         EXPECT_FALSE(r.get_value());
 
@@ -664,18 +664,18 @@ template <typename Builder> class stdlib_field : public testing::Test {
         Builder builder = Builder();
         field_ct a(witness_ct(&builder, 4));
 
-        auto gates_before = builder.get_estimated_num_finalized_gates();
+        auto gates_before = builder.get_num_finalized_gates_inefficient();
         field_ct b = 3;
         field_ct c = 7;
         // Note that the lhs is constant, hence (rhs - lhs) can be computed without adding new gates, using == in
         // this case requires 3 constraints 1) ensure r is bool; 2) (a - b) * I + r - 1 = 0; 3) -I * r + r = 0
         bool_ct r = (a * c) == (b * c + c);
-        auto gates_after = builder.get_estimated_num_finalized_gates();
+        auto gates_after = builder.get_num_finalized_gates_inefficient();
         EXPECT_EQ(gates_after - gates_before, 3UL);
         r = r && (b + 1 == a);
         EXPECT_EQ(r.get_value(), true);
         // The situation is as above, but we also applied && to bool_t witnesses, which adds an extra gate.
-        EXPECT_EQ(builder.get_estimated_num_finalized_gates() - gates_after, 4UL);
+        EXPECT_EQ(builder.get_num_finalized_gates_inefficient() - gates_after, 4UL);
         EXPECT_TRUE(CircuitChecker::check(builder));
     }
 
@@ -697,10 +697,10 @@ template <typename Builder> class stdlib_field : public testing::Test {
         field_ct d(&builder, fr::zero());
         field_ct e(&builder, fr::one());
         // Validate that `is_zero()` check does not add any gates in this case
-        const size_t old_n = builder.get_estimated_num_finalized_gates();
+        const size_t old_n = builder.get_num_finalized_gates_inefficient();
         bool_ct d_zero = d.is_zero();
         bool_ct e_zero = e.is_zero();
-        const size_t new_n = builder.get_estimated_num_finalized_gates();
+        const size_t new_n = builder.get_num_finalized_gates_inefficient();
         EXPECT_EQ(old_n, new_n);
 
         // Create witnesses
@@ -740,17 +740,17 @@ template <typename Builder> class stdlib_field : public testing::Test {
     static void test_assert_is_not_zero()
     {
         Builder builder = Builder();
-        size_t num_gates_before = builder.get_estimated_num_finalized_gates();
+        size_t num_gates_before = builder.get_num_finalized_gates_inefficient();
         field_ct a(engine.get_random_uint256());
         if (a.get_value() == 0) {
             a += 1;
         }
         a.assert_is_not_zero();
         // a is a constant, so no gates should be added
-        EXPECT_TRUE(builder.get_estimated_num_finalized_gates() - num_gates_before == 0);
+        EXPECT_TRUE(builder.get_num_finalized_gates_inefficient() - num_gates_before == 0);
         a = witness_ct(&builder, 17);
         a.assert_is_not_zero();
-        EXPECT_TRUE(builder.get_estimated_num_finalized_gates() - num_gates_before == 1);
+        EXPECT_TRUE(builder.get_num_finalized_gates_inefficient() - num_gates_before == 1);
         // Ensure a is not normalized anymore
         a *= 2;
         a += 4;
@@ -846,15 +846,15 @@ template <typename Builder> class stdlib_field : public testing::Test {
             auto b = b_const ? make_constant(builder, 2) : make_witness(builder, 2);
             auto c = c_const ? make_constant(builder, 3) : make_witness(builder, 3);
 
-            size_t before = builder.get_estimated_num_finalized_gates();
+            size_t before = builder.get_num_finalized_gates_inefficient();
             a.madd(b, c);
-            size_t after = builder.get_estimated_num_finalized_gates();
+            size_t after = builder.get_num_finalized_gates_inefficient();
             bool gate_added = (after - before == 1);
             EXPECT_EQ(gate_added, expect_gate);
 
-            before = builder.get_estimated_num_finalized_gates();
+            before = builder.get_num_finalized_gates_inefficient();
             a.add_two(b, c);
-            after = builder.get_estimated_num_finalized_gates();
+            after = builder.get_num_finalized_gates_inefficient();
 
             gate_added = (after - before == 1);
             EXPECT_EQ(gate_added, expect_gate);
@@ -873,24 +873,24 @@ template <typename Builder> class stdlib_field : public testing::Test {
             const bool predicate_is_witness = !predicate.is_constant();
 
             // Conditionally negate a constant
-            size_t num_gates_before = builder.get_estimated_num_finalized_gates();
+            size_t num_gates_before = builder.get_num_finalized_gates_inefficient();
             auto result = constant_summand.conditional_negate(predicate);
             auto expected_result = predicate.get_value() ? -constant_summand.get_value() : constant_summand.get_value();
             EXPECT_TRUE(result.get_value() == expected_result);
             // Check that `result` is constant if and only if both the predicate and (*this) are constant.
             EXPECT_TRUE(result.is_constant() == predicate.is_constant());
             // A gate is only added if the predicate is a witness
-            EXPECT_TRUE(builder.get_estimated_num_finalized_gates() - num_gates_before == 0);
+            EXPECT_TRUE(builder.get_num_finalized_gates_inefficient() - num_gates_before == 0);
 
             // Conditionally negate a witness
-            num_gates_before = builder.get_estimated_num_finalized_gates();
+            num_gates_before = builder.get_num_finalized_gates_inefficient();
             result = witness_summand.conditional_negate(predicate);
             expected_result = predicate.get_value() ? -witness_summand.get_value() : witness_summand.get_value();
             EXPECT_TRUE(result.get_value() == expected_result);
             // The result must be a witness
             EXPECT_FALSE(result.is_constant());
             // A gate is only added if the predicate is a witness
-            EXPECT_TRUE(builder.get_estimated_num_finalized_gates() - num_gates_before == predicate_is_witness);
+            EXPECT_TRUE(builder.get_num_finalized_gates_inefficient() - num_gates_before == predicate_is_witness);
         }
     }
     static void test_two_bit_table()
@@ -1021,7 +1021,7 @@ template <typename Builder> class stdlib_field : public testing::Test {
         std::vector<field_ct> set = { a, b, c, d, e };
 
         a.assert_is_in_set(set);
-        info("num gates = ", builder.get_estimated_num_finalized_gates());
+        info("num gates = ", builder.get_num_finalized_gates_inefficient());
 
         bool result = CircuitChecker::check(builder);
         EXPECT_EQ(result, true);
@@ -1041,7 +1041,7 @@ template <typename Builder> class stdlib_field : public testing::Test {
         field_ct f(witness_ct(&builder, fr(6)));
         f.assert_is_in_set(set);
 
-        info("num gates = ", builder.get_estimated_num_finalized_gates());
+        info("num gates = ", builder.get_num_finalized_gates_inefficient());
         bool result = CircuitChecker::check(builder);
         EXPECT_EQ(result, false);
     }
@@ -1128,7 +1128,7 @@ template <typename Builder> class stdlib_field : public testing::Test {
 
         EXPECT_EQ(value_ct.get_witness_index() + 1, first_copy.get_witness_index());
         EXPECT_EQ(value_ct.get_witness_index() + 2, second_copy.get_witness_index());
-        info("num gates = ", builder.get_estimated_num_finalized_gates());
+        info("num gates = ", builder.get_num_finalized_gates_inefficient());
 
         bool result = CircuitChecker::check(builder);
         EXPECT_EQ(result, true);
@@ -1195,7 +1195,7 @@ template <typename Builder> class stdlib_field : public testing::Test {
             size_t padding = (3 - (num_witnesses % 3)) % 3;
             size_t expected_num_gates = (num_witnesses + padding) / 3;
 
-            EXPECT_EQ(builder.get_estimated_num_finalized_gates() - 1, expected_num_gates);
+            EXPECT_EQ(builder.get_num_finalized_gates_inefficient() - 1, expected_num_gates);
 
             // Check that the accumulation of constant entries does not create a witness
             std::vector<field_ct> constant_input;

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/padding_indicator_array/padding_indicator_array.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/padding_indicator_array/padding_indicator_array.test.cpp
@@ -33,7 +33,7 @@ template <typename Param> class PaddingIndicatorArrayTest : public testing::Test
             auto result = compute_padding_indicator_array<Curve, domain_size>(x);
             EXPECT_TRUE(result[idx - 1].get_value() == 1);
 
-            info("num gates = ", builder.get_estimated_num_finalized_gates());
+            info("num gates = ", builder.get_num_finalized_gates_inefficient());
             // Check that the sum of indicators is indeed x
             Fr sum_of_indicators = std::accumulate(result.begin(), result.end(), Fr{ 0 });
             EXPECT_TRUE((sum_of_indicators == x).get_value());
@@ -53,7 +53,7 @@ template <typename Param> class PaddingIndicatorArrayTest : public testing::Test
             Fr zero = Fr::from_witness(&builder, 0);
 
             compute_padding_indicator_array<Curve, domain_size>(zero);
-            info("num gates = ", builder.get_estimated_num_finalized_gates());
+            info("num gates = ", builder.get_num_finalized_gates_inefficient());
 
             EXPECT_FALSE(CircuitChecker::check(builder));
         }
@@ -65,7 +65,7 @@ template <typename Param> class PaddingIndicatorArrayTest : public testing::Test
             Fr N = Fr::from_witness(&builder, domain_size);
 
             compute_padding_indicator_array<Curve, domain_size>(N);
-            info("num gates = ", builder.get_estimated_num_finalized_gates());
+            info("num gates = ", builder.get_num_finalized_gates_inefficient());
 
             EXPECT_TRUE(CircuitChecker::check(builder));
         }
@@ -80,7 +80,7 @@ template <typename Param> class PaddingIndicatorArrayTest : public testing::Test
             Fr x = Fr::from_witness(&builder, scalar_raw);
 
             compute_padding_indicator_array<Curve, domain_size>(x);
-            info("num gates = ", builder.get_estimated_num_finalized_gates());
+            info("num gates = ", builder.get_num_finalized_gates_inefficient());
 
             EXPECT_FALSE(CircuitChecker::check(builder));
         }
@@ -93,7 +93,7 @@ template <typename Param> class PaddingIndicatorArrayTest : public testing::Test
             Fr x = Fr::from_witness(&builder, scalar_raw);
             auto result = compute_padding_indicator_array<Curve, domain_size>(x);
 
-            return builder.get_estimated_num_finalized_gates();
+            return builder.get_num_finalized_gates_inefficient();
         };
 
         // Valid input: x in [1, domain_size - 1]

--- a/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/protogalaxy_recursive_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/protogalaxy_recursive_verifier.test.cpp
@@ -569,7 +569,7 @@ TEST_F(ProtogalaxyRecursiveTests, FixedCircuitSize)
     auto [proof_size_2, circuit_2] = compute_circuit_size(12);
 
     EXPECT_EQ(proof_size_1, proof_size_2);
-    EXPECT_EQ(circuit_1.get_estimated_num_finalized_gates(), circuit_2.get_estimated_num_finalized_gates());
+    EXPECT_EQ(circuit_1.get_num_finalized_gates_inefficient(), circuit_2.get_num_finalized_gates_inefficient());
     EXPECT_EQ(circuit_1.blocks, circuit_2.blocks);
 }
 

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/circuit_builder_base.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/circuit_builder_base.hpp
@@ -84,8 +84,6 @@ template <typename FF_> class CircuitBuilderBase {
     bool operator==(const CircuitBuilderBase& other) const = default;
 
     virtual size_t get_num_finalized_gates() const;
-    virtual size_t get_estimated_num_finalized_gates() const;
-    virtual void print_num_estimated_finalized_gates() const;
     virtual size_t get_num_variables() const;
 
     // Non-owning getter for the index at which a fixed witness 0 is stored

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/circuit_builder_base_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/circuit_builder_base_impl.hpp
@@ -27,16 +27,6 @@ template <typename FF_> size_t CircuitBuilderBase<FF_>::get_num_finalized_gates(
     return num_gates;
 }
 
-template <typename FF_> size_t CircuitBuilderBase<FF_>::get_estimated_num_finalized_gates() const
-{
-    return num_gates;
-}
-
-template <typename FF_> void CircuitBuilderBase<FF_>::print_num_estimated_finalized_gates() const
-{
-    info(num_gates);
-}
-
 template <typename FF_> size_t CircuitBuilderBase<FF_>::get_num_variables() const
 {
     return variables.size();

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/mega_circuit_builder.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/mega_circuit_builder.hpp
@@ -128,44 +128,6 @@ template <typename FF> class MegaCircuitBuilder_ : public UltraCircuitBuilder_<M
     size_t get_num_constant_gates() const override { return 0; }
 
     /**
-     * @brief Get the final number of gates in a circuit, which consists of the sum of:
-     * 1) Current number number of actual gates
-     * 2) Number of public inputs, as we'll need to add a gate for each of them
-     * 3) Number of Rom array-associated gates
-     * 4) Number of range-list associated gates
-     * 5) Number of non-native field multiplication gates.
-     *
-     * @return size_t
-     */
-    size_t get_estimated_num_finalized_gates() const override
-    {
-        auto num_ultra_gates = UltraCircuitBuilder_<MegaExecutionTraceBlocks>::get_estimated_num_finalized_gates();
-        auto num_goblin_ecc_op_gates = this->blocks.ecc_op.size();
-        return num_ultra_gates + num_goblin_ecc_op_gates;
-    }
-
-    /**x
-     * @brief Print the number and composition of gates in the circuit
-     *
-     */
-    void print_num_estimated_finalized_gates() const override
-    {
-        size_t count = 0;
-        size_t rangecount = 0;
-        size_t romcount = 0;
-        size_t ramcount = 0;
-        size_t nnfcount = 0;
-        UltraCircuitBuilder_<MegaExecutionTraceBlocks>::get_num_estimated_gates_split_into_components(
-            count, rangecount, romcount, ramcount, nnfcount);
-        auto num_goblin_ecc_op_gates = this->blocks.ecc_op.size();
-
-        size_t total = count + romcount + ramcount + rangecount + num_goblin_ecc_op_gates;
-        std::cout << "gates = " << total << " (arith " << count << ", rom " << romcount << ", ram " << ramcount
-                  << ", range " << rangecount << ", non native field gates " << nnfcount << ", goblin ecc op gates "
-                  << num_goblin_ecc_op_gates << "), pubinp = " << this->num_public_inputs() << std::endl;
-    }
-
-    /**
      * @brief Add a witness variable to the public calldata.
      *
      */

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.cpp
@@ -251,7 +251,11 @@ void UltraCircuitBuilder_<ExecutionTrace>::create_big_mul_add_gate(const mul_qua
 {
     this->assert_valid_variables({ in.a, in.b, in.c, in.d });
     blocks.arithmetic.populate_wires(in.a, in.b, in.c, in.d);
-    blocks.arithmetic.q_m().emplace_back(include_next_gate_w_4 ? in.mul_scaling * FF(2) : in.mul_scaling);
+    // If include_next_gate_w_4 is true then we set q_arith = 2. In this case, the linear term in the ArithmeticRelation
+    // is scaled by a factor of 2. We compensate here by scaling the quadratic term by 2 to achieve the constraint:
+    //      q_m * w_1 * w_2 + \sum_{i=1..4} q_i * w_i + q_c + w_4_shift = 0
+    const FF mul_scaling = include_next_gate_w_4 ? in.mul_scaling * FF(2) : in.mul_scaling;
+    blocks.arithmetic.q_m().emplace_back(mul_scaling);
     blocks.arithmetic.q_1().emplace_back(in.a_scaling);
     blocks.arithmetic.q_2().emplace_back(in.b_scaling);
     blocks.arithmetic.q_3().emplace_back(in.c_scaling);

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.cpp
@@ -617,6 +617,7 @@ typename UltraCircuitBuilder_<ExecutionTrace>::RangeList UltraCircuitBuilder_<Ex
 
     uint64_t num_multiples_of_three = (target_range / DEFAULT_PLOOKUP_RANGE_STEP_SIZE);
 
+    // AUDITTODO: This is not reserving the correct amount of space. Ensure this isn't indicative of a larger issue.
     result.variable_indices.reserve((uint32_t)num_multiples_of_three);
     for (uint64_t i = 0; i <= num_multiples_of_three; ++i) {
         const uint32_t index = this->add_variable(i * DEFAULT_PLOOKUP_RANGE_STEP_SIZE);

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.cpp
@@ -1680,13 +1680,16 @@ std::array<uint32_t, 5> UltraCircuitBuilder_<ExecutionTrace>::evaluate_non_nativ
     block.populate_wires(x_2, y_2, z_2, z_1);
     block.populate_wires(x_3, y_3, z_3, this->zero_idx());
 
+    // When q_arith == 3, w_4_shift is scaled by 2 (see ArithmeticRelation for details). Therefore, for consistency we
+    // also scale each linear term by this factor of 2 so that the constraint is effectively:
+    //      (q_l * w_1) + (q_r * w_2) + (q_o * w_3) + (q_4 * w_4) + q_c + w_4_shift = 0
+    const FF linear_term_scale_factor = 2;
     block.q_m().emplace_back(addconstp);
     block.q_1().emplace_back(0);
-    block.q_2().emplace_back(-x_mulconst0 *
-                             2); // scale constants by 2. If q_arith = 3 then w_4_omega value (z0) gets scaled by 2x
-    block.q_3().emplace_back(-y_mulconst0 * 2); // z_0 - (x_0 * -xmulconst0) - (y_0 * ymulconst0) = 0 => z_0 = x_0 + y_0
+    block.q_2().emplace_back(-x_mulconst0 * linear_term_scale_factor);
+    block.q_3().emplace_back(-y_mulconst0 * linear_term_scale_factor);
     block.q_4().emplace_back(0);
-    block.q_c().emplace_back(-addconst0 * 2);
+    block.q_c().emplace_back(-addconst0 * linear_term_scale_factor);
     block.set_gate_selector(3);
 
     block.q_m().emplace_back(0);
@@ -1792,12 +1795,16 @@ std::array<uint32_t, 5> UltraCircuitBuilder_<ExecutionTrace>::evaluate_non_nativ
     block.populate_wires(x_2, y_2, z_2, z_1);
     block.populate_wires(x_3, y_3, z_3, this->zero_idx());
 
+    // When q_arith == 3, w_4_shift is scaled by 2 (see ArithmeticRelation for details). Therefore, for consistency we
+    // also scale each linear term by this factor of 2 so that the constraint is effectively:
+    //      (q_l * w_1) + (q_r * w_2) + (q_o * w_3) + (q_4 * w_4) + q_c + w_4_shift = 0
+    const FF linear_term_scale_factor = 2;
     block.q_m().emplace_back(-addconstp);
     block.q_1().emplace_back(0);
-    block.q_2().emplace_back(-x_mulconst0 * 2);
-    block.q_3().emplace_back(y_mulconst0 * 2); // z_0 + (x_0 * -xmulconst0) + (y_0 * ymulconst0) = 0 => z_0 = x_0 - y_0
+    block.q_2().emplace_back(-x_mulconst0 * linear_term_scale_factor);
+    block.q_3().emplace_back(y_mulconst0 * linear_term_scale_factor);
     block.q_4().emplace_back(0);
-    block.q_c().emplace_back(-addconst0 * 2);
+    block.q_c().emplace_back(-addconst0 * linear_term_scale_factor);
     block.set_gate_selector(3);
 
     block.q_m().emplace_back(0);

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.hpp
@@ -367,19 +367,6 @@ class UltraCircuitBuilder_ : public CircuitBuilderBase<typename ExecutionTrace_:
     }
 
     /**
-     * @brief Get total number of lookups used in circuit
-     *
-     */
-    size_t get_lookups_size() const
-    {
-        size_t lookups_size = 0;
-        for (const auto& table : lookup_tables) {
-            lookups_size += table.lookup_gates.size();
-        }
-        return lookups_size;
-    }
-
-    /**
      * @brief Get the actual finalized size of a circuit. Assumes the circuit is finalized already.
      *
      * @details This method calculates the size of the circuit without rounding up to the next power of 2. It takes into
@@ -454,10 +441,6 @@ class UltraCircuitBuilder_ : public CircuitBuilderBase<typename ExecutionTrace_:
     /**
      * Plookup Methods
      **/
-    void initialize_precomputed_table(const plookup::BasicTableId id,
-                                      bool (*generator)(std::vector<FF>&, std::vector<FF>&, std::vector<FF>&),
-                                      std::array<FF, 2> (*get_values_from_key)(const std::array<uint64_t, 2>));
-
     plookup::BasicTable& get_table(const plookup::BasicTableId id);
     plookup::MultiTable& get_multitable(const plookup::MultiTableId id);
 

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.hpp
@@ -342,106 +342,6 @@ class UltraCircuitBuilder_ : public CircuitBuilderBase<typename ExecutionTrace_:
     uint32_t put_constant_variable(const FF& variable);
 
     size_t get_num_constant_gates() const override { return 0; }
-    /**
-     * @brief Get the final number of gates in a circuit, which consists of the sum of:
-     * 1) Current number number of actual gates
-     * 2) Number of public inputs, as we'll need to add a gate for each of them
-     * 3) Number of Rom array-associated gates
-     * 4) Number of range-list associated gates
-     * 5) Number of non-native field multiplication gates.
-     *
-     *
-     * @param count return arument, number of existing gates
-     * @param rangecount return argument, extra gates due to range checks
-     * @param romcount return argument, extra gates due to rom reads
-     * @param ramcount return argument, extra gates due to ram read/writes
-     * @param nnfcount return argument, extra gates due to queued non native field gates
-     */
-    void get_num_estimated_gates_split_into_components(
-        size_t& count, size_t& rangecount, size_t& romcount, size_t& ramcount, size_t& nnfcount) const
-    {
-        static constexpr uint32_t UNINITIALIZED_MEMORY_RECORD = UINT32_MAX;
-        static constexpr size_t NUMBER_OF_GATES_PER_RAM_ACCESS = 2;
-        static constexpr size_t NUMBER_OF_ARITHMETIC_GATES_PER_RAM_ARRAY = 1;
-        // number of gates created per non-native field operation in process_non_native_field_multiplications
-        static constexpr size_t GATES_PER_NON_NATIVE_FIELD_MULTIPLICATION_ARITHMETIC = 7;
-        count = this->num_gates;
-
-        // each ROM gate adds +1 extra gate due to the rom reads being copied to a sorted list set
-        for (size_t i = 0; i < rom_ram_logic.rom_arrays.size(); ++i) {
-            for (size_t j = 0; j < rom_ram_logic.rom_arrays[i].state.size(); ++j) {
-                if (rom_ram_logic.rom_arrays[i].state[j][0] == UNINITIALIZED_MEMORY_RECORD) {
-                    romcount += 2;
-                }
-            }
-            romcount += (rom_ram_logic.rom_arrays[i].records.size());
-            romcount += 1; // we add an addition gate after procesing a rom array
-        }
-
-        // each RAM gate adds +2 extra gates due to the ram reads being copied to a sorted list set,
-        // as well as an extra gate to validate timestamps
-        std::vector<size_t> ram_timestamps;
-        std::vector<size_t> ram_range_sizes;
-        std::vector<size_t> ram_range_exists;
-        for (size_t i = 0; i < rom_ram_logic.ram_arrays.size(); ++i) {
-            for (size_t j = 0; j < rom_ram_logic.ram_arrays[i].state.size(); ++j) {
-                if (rom_ram_logic.ram_arrays[i].state[j] == UNINITIALIZED_MEMORY_RECORD) {
-                    ramcount += NUMBER_OF_GATES_PER_RAM_ACCESS;
-                }
-            }
-            ramcount += (rom_ram_logic.ram_arrays[i].records.size() * NUMBER_OF_GATES_PER_RAM_ACCESS);
-            ramcount += NUMBER_OF_ARITHMETIC_GATES_PER_RAM_ARRAY; // we add an addition gate after procesing a ram array
-
-            // there will be 'max_timestamp' number of range checks, need to calculate.
-            const auto max_timestamp = rom_ram_logic.ram_arrays[i].access_count - 1;
-
-            // if a range check of length `max_timestamp` already exists, we are double counting.
-            // We record `ram_timestamps` to detect and correct for this error when we process range lists.
-
-            ram_timestamps.push_back(max_timestamp);
-            size_t padding = (NUM_WIRES - (max_timestamp % NUM_WIRES)) % NUM_WIRES;
-            if (max_timestamp == NUM_WIRES) {
-                padding += NUM_WIRES;
-            }
-            const size_t ram_range_check_list_size = max_timestamp + padding;
-
-            size_t ram_range_check_gate_count = (ram_range_check_list_size / NUM_WIRES);
-            ram_range_check_gate_count += 1; // we need to add 1 extra addition gates for every distinct range list
-
-            ram_range_sizes.push_back(ram_range_check_gate_count);
-            ram_range_exists.push_back(false);
-        }
-        for (const auto& list : range_lists) {
-            auto list_size = list.second.variable_indices.size();
-            size_t padding = (NUM_WIRES - (list.second.variable_indices.size() % NUM_WIRES)) % NUM_WIRES;
-            if (list.second.variable_indices.size() == NUM_WIRES) {
-                padding += NUM_WIRES;
-            }
-            list_size += padding;
-
-            for (size_t i = 0; i < ram_timestamps.size(); ++i) {
-                if (list.second.target_range == ram_timestamps[i]) {
-                    ram_range_exists[i] = true;
-                }
-            }
-            rangecount += (list_size / NUM_WIRES);
-            rangecount += 1; // we need to add 1 extra addition gates for every distinct range list
-        }
-        // update rangecount to include the ram range checks the composer will eventually be creating
-        for (size_t i = 0; i < ram_range_sizes.size(); ++i) {
-            if (!ram_range_exists[i]) {
-                rangecount += ram_range_sizes[i];
-            }
-        }
-        std::vector<cached_partial_non_native_field_multiplication> nnf_copy(
-            cached_partial_non_native_field_multiplications);
-        // update nnfcount
-        std::sort(nnf_copy.begin(), nnf_copy.end());
-
-        auto last = std::unique(nnf_copy.begin(), nnf_copy.end());
-        const size_t num_nnf_ops = static_cast<size_t>(std::distance(nnf_copy.begin(), last));
-        nnfcount = num_nnf_ops * GATES_PER_NON_NATIVE_FIELD_MULTIPLICATION_ARITHMETIC;
-    }
 
     /**
      * @brief Get the number of gates in a finalized circuit.
@@ -451,36 +351,6 @@ class UltraCircuitBuilder_ : public CircuitBuilderBase<typename ExecutionTrace_:
     {
         BB_ASSERT(circuit_finalized);
         return this->num_gates;
-    }
-
-    /**
-     * @brief Get the final number of gates in a circuit, which consists of the sum of:
-     * 1) Current number number of actual gates
-     * 2) Number of public inputs, as we'll need to add a gate for each of them
-     * 3) Number of Rom array-associated gates
-     * 4) Number of range-list associated gates
-     * 5) Number of non-native field multiplication gates.
-     * !!! WARNING: This function is predictive and might report an incorrect number. Make sure to finalize the circuit
-     * and then check the number of gates for a precise result. Kesha: it's basically voodoo
-     *
-     * @return size_t
-     * TODO(https://github.com/AztecProtocol/barretenberg/issues/875): This method may return an incorrect value before
-     * the circuit is finalized due to a failure to account for "de-duplication" when computing how many
-     * non-native-field gates will be present.
-     */
-    size_t get_estimated_num_finalized_gates() const override
-    {
-        // if circuit finalized already added extra gates
-        if (circuit_finalized) {
-            return this->num_gates;
-        }
-        size_t count = 0;
-        size_t rangecount = 0;
-        size_t romcount = 0;
-        size_t ramcount = 0;
-        size_t nnfcount = 0;
-        get_num_estimated_gates_split_into_components(count, rangecount, romcount, ramcount, nnfcount);
-        return count + romcount + ramcount + rangecount + nnfcount;
     }
 
     /**
@@ -522,21 +392,6 @@ class UltraCircuitBuilder_ : public CircuitBuilderBase<typename ExecutionTrace_:
     {
         BB_ASSERT(circuit_finalized);
         auto num_filled_gates = get_num_finalized_gates() + this->num_public_inputs();
-        return std::max(get_tables_size(), num_filled_gates);
-    }
-
-    /**
-     * @brief Get the estimated size of the circuit if it was finalized now
-     *
-     * @details This method estimates the size of the circuit without rounding up to the next power of 2. It takes into
-     * account the possibility that the tables will dominate the size and checks both the estimated plookup argument
-     * size and the general circuit size
-     *
-     * @return size_t
-     */
-    size_t get_estimated_total_circuit_size() const
-    {
-        auto num_filled_gates = get_estimated_num_finalized_gates() + this->num_public_inputs();
         return std::max(get_tables_size(), num_filled_gates);
     }
 
@@ -585,25 +440,6 @@ class UltraCircuitBuilder_ : public CircuitBuilderBase<typename ExecutionTrace_:
         for (const auto& it : finalize_indices) {
             finalize_witnesses.insert(it);
         }
-    }
-
-    /**x
-     * @brief Print the number and composition of gates in the circuit
-     *
-     */
-    void print_num_estimated_finalized_gates() const override
-    {
-        size_t count = 0;
-        size_t rangecount = 0;
-        size_t romcount = 0;
-        size_t ramcount = 0;
-        size_t nnfcount = 0;
-        get_num_estimated_gates_split_into_components(count, rangecount, romcount, ramcount, nnfcount);
-
-        size_t total = count + romcount + ramcount + rangecount;
-        std::cout << "gates = " << total << " (arith " << count << ", rom " << romcount << ", ram " << ramcount
-                  << ", range " << rangecount << ", non native field gates " << nnfcount
-                  << "), pubinp = " << this->num_public_inputs() << std::endl;
     }
 
     void assert_equal_constant(const uint32_t a_idx, const FF& b, std::string const& msg = "assert equal constant")

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.hpp
@@ -183,15 +183,14 @@ class UltraCircuitBuilder_ : public CircuitBuilderBase<typename ExecutionTrace_:
     // Storage for wires and selectors for all gate types
     ExecutionTrace blocks;
 
-    // These are variables that we have used a gate on, to enforce that they are
-    // equal to a defined value.
+    // The set of variables which have been constrained to a particular value via an arithmetic gate
     std::map<FF, uint32_t> constant_variable_indices;
 
     // The set of lookup tables used by the circuit, plus the gate data for the lookups from each table
     std::vector<plookup::BasicTable> lookup_tables;
 
     // Rom/Ram logic
-    RomRamLogic rom_ram_logic = RomRamLogic();
+    RomRamLogic rom_ram_logic;
 
     // Stores gate index of ROM/RAM reads (required by proving key)
     std::vector<uint32_t> memory_read_records;

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.hpp
@@ -354,6 +354,21 @@ class UltraCircuitBuilder_ : public CircuitBuilderBase<typename ExecutionTrace_:
     }
 
     /**
+     * @brief Get the number of gates in the finalized version of the circuit.
+     * @warning This method makes a copy then finalizes it and returns the
+     * number of gates. It is therefore inefficient and should only be used in testing/debugging scenarios.
+     *
+     * @param ensure_nonzero Whether or not to add gates to ensure all polynomials are non-zero during finalization.
+     * @return size_t
+     */
+    size_t get_num_finalized_gates_inefficient(bool ensure_nonzero = true) const
+    {
+        UltraCircuitBuilder_ builder_copy = *this;
+        builder_copy.finalize_circuit(ensure_nonzero);
+        return builder_copy.get_num_finalized_gates();
+    }
+
+    /**
      * @brief Get combined size of all tables used in circuit
      *
      */


### PR DESCRIPTION
Deletion of unused code in UltraCircuitBuilder:
- old/unused methods related to lookups/tables
- Methods related to estimating post-finalization gate counts (without actually finalizing). These are complex, unused, and inferior to simply performing finalization to get the exact values