### PR TITLE
chore!: rename get senders

### DIFF
--- a/docs/docs/developers/migration_notes.md
+++ b/docs/docs/developers/migration_notes.md
@@ -9,6 +9,15 @@ Aztec is in full-speed development. Literally every version breaks compatibility
 
 ## TBD
 
+### `getSenders` renamed to `getAddressBook` in wallet interface
+
+An app could request "contacts" from the wallet, which don't necessarily have to be senders in the wallet's PXE. This method has been renamed to reflect that fact:
+
+```diff
+-wallet.getSenders();
++wallet.getAddressBook();
+```
+
 ### Removal of `proveTx` from `Wallet` interface
 
 Exposing this method on the interface opened the door for certain types of attacks, were an app could route proven transactions through malicious nodes (that stored them for later decryption, or collected user IPs for example). It also made transactions difficult to track for the wallet, since they could be sent without their knowledge at any time. This change also affects `ContractFunctionInteraction` and `DeployMethod`, which no longer expose a `prove()` method.

--- a/playground/src/components/common/FnParameter.tsx
+++ b/playground/src/components/common/FnParameter.tsx
@@ -69,12 +69,12 @@ export function FunctionParameter({ parameter, required, onParameterChange, defa
     const setAliases = async () => {
       setLoading(true);
       const accounts = await wallet.getAccounts();
-      const senders = await wallet.getSenders();
+      const contacts = await wallet.getAddressBook();
 
       const contracts = parseAliasedBuffersAsString(await playgroundDB.listAliases('contracts')).map(
         ({ alias, item }) => ({ alias, item: AztecAddress.fromString(item) }),
       );
-      setAliasedAddresses([...accounts, ...senders, ...contracts]);
+      setAliasedAddresses([...accounts, ...contacts, ...contracts]);
       setLoading(false);
     };
     if (wallet && playgroundDB) {

--- a/playground/src/wallet/embedded_wallet.ts
+++ b/playground/src/wallet/embedded_wallet.ts
@@ -198,7 +198,7 @@ export class EmbeddedWallet extends BaseWallet {
     return this.pxe.registerSender(address);
   }
 
-  override async getSenders(): Promise<Aliased<AztecAddress>[]> {
+  override async getAddressBook(): Promise<Aliased<AztecAddress>[]> {
     const senders = await this.pxe.getSenders();
     const storedSenders = await this.walletDB.listSenders();
     for (const storedSender of storedSenders) {

--- a/yarn-project/aztec.js/src/wallet/base_wallet.ts
+++ b/yarn-project/aztec.js/src/wallet/base_wallet.ts
@@ -87,7 +87,14 @@ export abstract class BaseWallet implements Wallet {
 
   abstract getAccounts(): Promise<Aliased<AztecAddress>[]>;
 
-  async getSenders(): Promise<Aliased<AztecAddress>[]> {
+  /**
+   * Returns the list of aliased contacts associated with the wallet.
+   * This base implementation directly returns PXE's senders, but note that in general contacts are a superset of senders.
+   *  - Senders: Addresses we check during synching in case they sent us notes,
+   *  - Contacts: more general concept akin to a phone's contact list.
+   * @returns The aliased collection of AztecAddresses that form this wallet's address book
+   */
+  async getAddressBook(): Promise<Aliased<AztecAddress>[]> {
     const senders: AztecAddress[] = await this.pxe.getSenders();
     return senders.map(sender => ({ item: sender, alias: '' }));
   }

--- a/yarn-project/aztec.js/src/wallet/wallet.test.ts
+++ b/yarn-project/aztec.js/src/wallet/wallet.test.ts
@@ -100,8 +100,8 @@ describe('WalletSchema', () => {
     expect(result).toBeInstanceOf(AztecAddress);
   });
 
-  it('getSenders', async () => {
-    const result = await context.client.getSenders();
+  it('getAddressBook', async () => {
+    const result = await context.client.getAddressBook();
     expect(result).toEqual([{ alias: 'sender1', item: expect.any(AztecAddress) }]);
   });
 
@@ -284,7 +284,7 @@ class MockWallet implements Wallet {
     return Promise.resolve(address);
   }
 
-  async getSenders(): Promise<Aliased<AztecAddress>[]> {
+  async getAddressBook(): Promise<Aliased<AztecAddress>[]> {
     return [{ alias: 'sender1', item: await AztecAddress.random() }];
   }
 

--- a/yarn-project/aztec.js/src/wallet/wallet.ts
+++ b/yarn-project/aztec.js/src/wallet/wallet.ts
@@ -161,7 +161,7 @@ export type Wallet = {
   getChainInfo(): Promise<ChainInfo>;
   getTxReceipt(txHash: TxHash): Promise<TxReceipt>;
   registerSender(address: AztecAddress, alias?: string): Promise<AztecAddress>;
-  getSenders(): Promise<Aliased<AztecAddress>[]>;
+  getAddressBook(): Promise<Aliased<AztecAddress>[]>;
   getAccounts(): Promise<Aliased<AztecAddress>[]>;
   registerContract(
     instanceData: AztecAddress | ContractInstanceWithAddress | ContractInstantiationData | ContractInstanceAndArtifact,
@@ -321,7 +321,7 @@ export const WalletSchema: ApiSchemaFor<Wallet> = {
     .args(schemas.AztecAddress, EventMetadataDefinitionSchema, z.number(), z.number(), z.array(schemas.AztecAddress))
     .returns(z.array(AbiDecodedSchema)),
   registerSender: z.function().args(schemas.AztecAddress, optional(z.string())).returns(schemas.AztecAddress),
-  getSenders: z
+  getAddressBook: z
     .function()
     .args()
     .returns(z.array(z.object({ alias: z.string(), item: schemas.AztecAddress }))),


### PR DESCRIPTION
Closes https://linear.app/aztec-labs/issue/F-72/renamegetsenders-to-getaddressbook

Build on top of https://github.com/AztecProtocol/aztec-packages/pull/17835, the diff should be pretty small
