### PR TITLE
feat!: ECDSA audit 9

### DIFF
--- a/barretenberg/cpp/scripts/test_civc_standalone_vks_havent_changed.sh
+++ b/barretenberg/cpp/scripts/test_civc_standalone_vks_havent_changed.sh
@@ -13,7 +13,7 @@ cd ..
 # - Generate a hash for versioning: sha256sum bb-civc-inputs.tar.gz
 # - Upload the compressed results: aws s3 cp bb-civc-inputs.tar.gz s3://aztec-ci-artifacts/protocol/bb-civc-inputs-[hash(0:8)].tar.gz
 # Note: In case of the "Test suite failed to run ... Unexpected token 'with' " error, need to run: docker pull aztecprotocol/build:3.0
-pinned_short_hash="56c57f0b"
+pinned_short_hash="47b70739"
 pinned_civc_inputs_url="https://aztec-ci-artifacts.s3.us-east-2.amazonaws.com/protocol/bb-civc-inputs-${pinned_short_hash}.tar.gz"
 
 function compress_and_upload {

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/ecdsa_constraints.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/ecdsa_constraints.cpp
@@ -122,6 +122,8 @@ void create_ecdsa_verify_constraints(typename Curve::Builder& builder,
     // Step 4.
     // Ensure uniqueness of the public key by asserting each of its coordinates is smaller than the modulus of the base
     // field
+    // TODO(https://github.com/AztecProtocol/barretenberg/issues/1562) remove this check, it is a duplicate of the check
+    // in the verification function.
     pub_x.assert_is_in_field("ECDSA input validation: the x coordinate of the public key is larger than Fq::modulus");
     pub_y.assert_is_in_field("ECDSA input validation: the y coordinate of the public key is larger than Fq::modulus");
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/encryption/ecdsa/ecdsa.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/encryption/ecdsa/ecdsa.test.cpp
@@ -37,6 +37,8 @@ template <class Curve> class EcdsaTests : public ::testing::Test {
         FrNative("0xd67abee717b3fc725adf59e2cc8cd916435c348b277dd814a34e3ceb279436c2");
 
     enum class TamperingMode : std::uint8_t {
+        HighXCoordinate,
+        HighYCoordinate,
         InvalidR,
         InvalidS,
         HighS,
@@ -75,6 +77,20 @@ template <class Curve> class EcdsaTests : public ::testing::Test {
         std::string failure_msg;
 
         switch (mode) {
+        case TamperingMode::HighXCoordinate: {
+            // Invalidate the circuit by passing a public key with x >= q
+            // Do nothing here, tampering happens in circuit
+            failure_msg = "ECDSA input validation: the x coordinate of the public key is bigger than the base field "
+                          "modulus.: hi limb.";
+            break;
+        }
+        case TamperingMode::HighYCoordinate: {
+            // Invalidate the circuit by passing a public key with y >= q
+            // Do nothing here, tampering happens in circuit
+            failure_msg = "ECDSA input validation: the y coordinate of the public key is bigger than the base field "
+                          "modulus.: hi limb.";
+            break;
+        }
         case TamperingMode::InvalidR: {
             // Invalidate the signature by changing r.
             FrNative r = FrNative::serialize_from_buffer(&signature.r[0]);
@@ -165,6 +181,11 @@ template <class Curve> class EcdsaTests : public ::testing::Test {
             // verification function raises an error, we treat it as an invalid signature
             is_signature_valid = false;
         }
+        if (mode == TamperingMode::HighXCoordinate || mode == TamperingMode::HighYCoordinate) {
+            // In these tampering modes nothing has changed and the tampering happens in circuit, so we override the
+            // result and set it to false
+            is_signature_valid = false;
+        }
 
         bool expected = mode == TamperingMode::None;
         BB_ASSERT_EQ(is_signature_valid,
@@ -176,12 +197,26 @@ template <class Curve> class EcdsaTests : public ::testing::Test {
     }
 
     std::pair<G1, stdlib::ecdsa_signature<Builder>> create_stdlib_ecdsa_data(
-        Builder& builder, const ecdsa_key_pair<FrNative, G1Native>& account, const ecdsa_signature& signature)
+        Builder& builder,
+        const ecdsa_key_pair<FrNative, G1Native>& account,
+        const ecdsa_signature& signature,
+        const TamperingMode mode)
     {
         // We construct the point via its x,y-coordinates to avoid the on curve check of G1::from_witness. In this way
         // we test the on curve check of the ecdsa verification function
         Fq x = Fq::from_witness(&builder, account.public_key.x);
         Fq y = Fq::from_witness(&builder, account.public_key.y);
+        if (mode == TamperingMode::HighXCoordinate || mode == TamperingMode::HighYCoordinate) {
+            // To test the case in which one of the two coordinates is above the modulus of the base field, we need to
+            // override the limbs of the coordinates
+            uint256_t max_uint = (static_cast<uint256_t>(1) << 256) - 1;
+            for (size_t idx = 0; idx < 4; idx++) {
+                builder.set_variable(mode == TamperingMode::HighXCoordinate
+                                         ? x.binary_basis_limbs[idx].element.get_witness_index()
+                                         : y.binary_basis_limbs[idx].element.get_witness_index(),
+                                     bb::fr(max_uint.slice(64 * idx, 64 * (idx + 1))));
+            }
+        }
         bool_t is_infinity(
             stdlib::witness_t<Builder>(&builder, account.public_key.is_point_at_infinity() ? fr::one() : fr::zero()),
             false);
@@ -204,10 +239,11 @@ template <class Curve> class EcdsaTests : public ::testing::Test {
                                     const ecdsa_signature& signature,
                                     const bool signature_verification_result,
                                     const bool circuit_checker_result,
-                                    const std::string failure_msg)
+                                    const std::string failure_msg,
+                                    const TamperingMode mode)
 
     {
-        auto [public_key, sig] = create_stdlib_ecdsa_data(builder, account, signature);
+        auto [public_key, sig] = create_stdlib_ecdsa_data(builder, account, signature, mode);
 
         // Verify signature
         stdlib::bool_t<Builder> signature_result =
@@ -266,7 +302,8 @@ template <class Curve> class EcdsaTests : public ::testing::Test {
                                    signature,
                                    signature_verification_result,
                                    circuit_checker_result,
-                                   failure_msg);
+                                   failure_msg,
+                                   mode);
     }
 
     /**
@@ -304,7 +341,8 @@ template <class Curve> class EcdsaTests : public ::testing::Test {
                                        { r, s, v },
                                        test.is_valid_signature,
                                        test.is_circuit_satisfied,
-                                       test.failure_msg);
+                                       test.failure_msg,
+                                       TamperingMode::None);
         }
     }
 };
@@ -324,6 +362,18 @@ TYPED_TEST(EcdsaTests, VerifyRandomSignature)
 TYPED_TEST(EcdsaTests, VerifySignature)
 {
     TestFixture::test_verify_signature(/*random_signature=*/false, TestFixture::TamperingMode::None);
+}
+
+TYPED_TEST(EcdsaTests, HighXCoordinate)
+{
+    BB_DISABLE_ASSERTS();
+    TestFixture::test_verify_signature(/*random_signature=*/false, TestFixture::TamperingMode::HighXCoordinate);
+}
+
+TYPED_TEST(EcdsaTests, HighYCoordinate)
+{
+    BB_DISABLE_ASSERTS();
+    TestFixture::test_verify_signature(/*random_signature=*/false, TestFixture::TamperingMode::HighYCoordinate);
 }
 
 TYPED_TEST(EcdsaTests, InvalidR)

--- a/barretenberg/cpp/src/barretenberg/stdlib/encryption/ecdsa/ecdsa.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/encryption/ecdsa/ecdsa.test.cpp
@@ -37,8 +37,8 @@ template <class Curve> class EcdsaTests : public ::testing::Test {
         FrNative("0xd67abee717b3fc725adf59e2cc8cd916435c348b277dd814a34e3ceb279436c2");
 
     enum class TamperingMode : std::uint8_t {
-        HighXCoordinate,
-        HighYCoordinate,
+        XCoordinateOverflow,
+        YCoordinateOverflow,
         InvalidR,
         InvalidS,
         HighS,
@@ -77,14 +77,14 @@ template <class Curve> class EcdsaTests : public ::testing::Test {
         std::string failure_msg;
 
         switch (mode) {
-        case TamperingMode::HighXCoordinate: {
+        case TamperingMode::XCoordinateOverflow: {
             // Invalidate the circuit by passing a public key with x >= q
             // Do nothing here, tampering happens in circuit
             failure_msg = "ECDSA input validation: the x coordinate of the public key is bigger than the base field "
                           "modulus.: hi limb.";
             break;
         }
-        case TamperingMode::HighYCoordinate: {
+        case TamperingMode::YCoordinateOverflow: {
             // Invalidate the circuit by passing a public key with y >= q
             // Do nothing here, tampering happens in circuit
             failure_msg = "ECDSA input validation: the y coordinate of the public key is bigger than the base field "
@@ -181,7 +181,7 @@ template <class Curve> class EcdsaTests : public ::testing::Test {
             // verification function raises an error, we treat it as an invalid signature
             is_signature_valid = false;
         }
-        if (mode == TamperingMode::HighXCoordinate || mode == TamperingMode::HighYCoordinate) {
+        if (mode == TamperingMode::XCoordinateOverflow || mode == TamperingMode::YCoordinateOverflow) {
             // In these tampering modes nothing has changed and the tampering happens in circuit, so we override the
             // result and set it to false
             is_signature_valid = false;
@@ -206,12 +206,12 @@ template <class Curve> class EcdsaTests : public ::testing::Test {
         // we test the on curve check of the ecdsa verification function
         Fq x = Fq::from_witness(&builder, account.public_key.x);
         Fq y = Fq::from_witness(&builder, account.public_key.y);
-        if (mode == TamperingMode::HighXCoordinate || mode == TamperingMode::HighYCoordinate) {
+        if (mode == TamperingMode::XCoordinateOverflow || mode == TamperingMode::YCoordinateOverflow) {
             // To test the case in which one of the two coordinates is above the modulus of the base field, we need to
             // override the limbs of the coordinates
             uint256_t max_uint = (static_cast<uint256_t>(1) << 256) - 1;
             for (size_t idx = 0; idx < 4; idx++) {
-                builder.set_variable(mode == TamperingMode::HighXCoordinate
+                builder.set_variable(mode == TamperingMode::XCoordinateOverflow
                                          ? x.binary_basis_limbs[idx].element.get_witness_index()
                                          : y.binary_basis_limbs[idx].element.get_witness_index(),
                                      bb::fr(max_uint.slice(64 * idx, 64 * (idx + 1))));
@@ -292,8 +292,7 @@ template <class Curve> class EcdsaTests : public ::testing::Test {
 
         // Compute H(m)
         stdlib::byte_array<Builder> message(&builder, message_bytes);
-        stdlib::byte_array<Builder> hashed_message =
-            static_cast<stdlib::byte_array<Builder>>(stdlib::SHA256<Builder>::hash(message));
+        stdlib::byte_array<Builder> hashed_message = stdlib::SHA256<Builder>::hash(message);
 
         // ECDSA verification
         ecdsa_verification_circuit(builder,
@@ -331,8 +330,7 @@ template <class Curve> class EcdsaTests : public ::testing::Test {
 
             // Compute H(m)
             stdlib::byte_array<Builder> message(&builder, test.message);
-            stdlib::byte_array<Builder> hashed_message =
-                static_cast<stdlib::byte_array<Builder>>(stdlib::SHA256<Builder>::hash(message));
+            stdlib::byte_array<Builder> hashed_message = stdlib::SHA256<Builder>::hash(message);
 
             // ECDSA verification
             ecdsa_verification_circuit(builder,
@@ -364,16 +362,16 @@ TYPED_TEST(EcdsaTests, VerifySignature)
     TestFixture::test_verify_signature(/*random_signature=*/false, TestFixture::TamperingMode::None);
 }
 
-TYPED_TEST(EcdsaTests, HighXCoordinate)
+TYPED_TEST(EcdsaTests, XCoordinateOverflow)
 {
     BB_DISABLE_ASSERTS();
-    TestFixture::test_verify_signature(/*random_signature=*/false, TestFixture::TamperingMode::HighXCoordinate);
+    TestFixture::test_verify_signature(/*random_signature=*/false, TestFixture::TamperingMode::XCoordinateOverflow);
 }
 
-TYPED_TEST(EcdsaTests, HighYCoordinate)
+TYPED_TEST(EcdsaTests, YCoordinateOverflow)
 {
     BB_DISABLE_ASSERTS();
-    TestFixture::test_verify_signature(/*random_signature=*/false, TestFixture::TamperingMode::HighYCoordinate);
+    TestFixture::test_verify_signature(/*random_signature=*/false, TestFixture::TamperingMode::YCoordinateOverflow);
 }
 
 TYPED_TEST(EcdsaTests, InvalidR)

--- a/barretenberg/cpp/src/barretenberg/stdlib/encryption/ecdsa/ecdsa.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/encryption/ecdsa/ecdsa.test.cpp
@@ -40,7 +40,6 @@ template <class Curve> class EcdsaTests : public ::testing::Test {
         InvalidR,
         InvalidS,
         HighS,
-        OutOfBoundsHash,
         ZeroR,
         ZeroS,
         InfinityScalarMul,
@@ -66,49 +65,6 @@ template <class Curve> class EcdsaTests : public ::testing::Test {
         }
 
         return { account, signature };
-    }
-
-    /**
-     * @brief Generate valid signature for the message Fr(1)
-     *
-     * @return ecdsa_signature
-     */
-    ecdsa_signature generate_signature_out_of_bounds_hash()
-    {
-        // Generate signature
-        ecdsa_signature signature;
-
-        FrNative fr_hash = FrNative::one();
-        FrNative k = FrNative::random_element();
-        typename G1Native::affine_element R = G1Native::one * k;
-        FqNative::serialize_to_buffer(R.x, &signature.r[0]);
-
-        FrNative r = FrNative::serialize_from_buffer(&signature.r[0]);
-        FrNative k_inverse = k.invert();
-        FrNative s = k_inverse * (fr_hash + r * private_key);
-        bool is_s_low = (static_cast<uint256_t>(s) < (FrNative::modulus + 1) / 2);
-        s = is_s_low ? s : -s;
-        FrNative::serialize_to_buffer(s, &signature.s[0]);
-
-        FqNative r_fq(R.x);
-        bool is_r_finite = (uint256_t(r_fq) == uint256_t(r));
-        bool y_parity = uint256_t(R.y).get_bit(0);
-        bool recovery_bit = y_parity ^ is_s_low;
-        constexpr uint8_t offset = 27;
-
-        int value =
-            offset + static_cast<int>(recovery_bit) + (static_cast<uint8_t>(2) * static_cast<int>(!is_r_finite));
-        BB_ASSERT_LTE(value, UINT8_MAX);
-        signature.v = static_cast<uint8_t>(value);
-
-        // Natively verify signature
-        FrNative s_inverse = s.invert();
-        typename G1Native::affine_element Q = G1Native::one * ((fr_hash * s_inverse) + (r * s_inverse * private_key));
-        BB_ASSERT_EQ(static_cast<uint512_t>(Q.x),
-                     static_cast<uint512_t>(r),
-                     "Signature with out of bounds message failed verification");
-
-        return signature;
     }
 
     std::string tampering(std::string message_string,
@@ -143,15 +99,6 @@ template <class Curve> class EcdsaTests : public ::testing::Test {
             FrNative::serialize_to_buffer(s, &signature.s[0]);
             failure_msg = "ECDSA input validation: the s component of the signature is bigger than Fr::modulus - s.: "
                           "hi limb."; // The second part of the message is added by the range constraint
-            break;
-        }
-        case TamperingMode::OutOfBoundsHash: {
-            // Invalidate the circuit by passing a message whose hash is bigger than n
-            // (the message will be hard-coded in the circuit at a later point)
-            signature = generate_signature_out_of_bounds_hash();
-
-            failure_msg = "ECDSA input validation: the hash of the message is bigger than the order of the elliptic "
-                          "curve.: hi limb."; // The second part of the message is added by the range constraint
             break;
         }
         case TamperingMode::ZeroR: {
@@ -288,40 +235,10 @@ template <class Curve> class EcdsaTests : public ::testing::Test {
         EXPECT_EQ(builder.err(), failure_msg);
     }
 
-    stdlib::byte_array<Builder> construct_hashed_message(Builder& builder,
-                                                         std::vector<uint8_t>& message_bytes,
-                                                         TamperingMode mode)
-    {
-        stdlib::byte_array<Builder> message(&builder, message_bytes);
-        stdlib::byte_array<Builder> hashed_message;
-
-        if (mode == TamperingMode::OutOfBoundsHash) {
-            // In this case the message is already hashed, so we mock the hashing constraints for consistency but
-            // hard-code the message
-            [[maybe_unused]] stdlib::byte_array<Builder> _ =
-                static_cast<stdlib::byte_array<Builder>>(stdlib::SHA256<Builder>::hash(message));
-
-            // Hard-coded witness
-            std::array<uint8_t, 32> hashed_message_witness;
-
-            // The hashed message is FrNative::modulus + 1
-            FqNative fr_hash = FqNative(FrNative::modulus + 1);
-            FqNative::serialize_to_buffer(fr_hash, &hashed_message_witness[0]);
-
-            hashed_message = stdlib::byte_array<Builder>(
-                &builder, std::vector<uint8_t>(hashed_message_witness.begin(), hashed_message_witness.end()));
-        } else {
-            hashed_message = static_cast<stdlib::byte_array<Builder>>(stdlib::SHA256<Builder>::hash(message));
-        }
-
-        return hashed_message;
-    }
-
     void test_verify_signature(bool random_signature, TamperingMode mode)
     {
         // Map tampering mode to signature verification result
-        bool signature_verification_result =
-            (mode == TamperingMode::None) || (mode == TamperingMode::HighS) || (mode == TamperingMode::OutOfBoundsHash);
+        bool signature_verification_result = (mode == TamperingMode::None) || (mode == TamperingMode::HighS);
         // Map tampering mode to circuit checker result
         bool circuit_checker_result =
             (mode == TamperingMode::None) || (mode == TamperingMode::InvalidR) || (mode == TamperingMode::InvalidS);
@@ -338,7 +255,9 @@ template <class Curve> class EcdsaTests : public ::testing::Test {
         Builder builder;
 
         // Compute H(m)
-        stdlib::byte_array<Builder> hashed_message = construct_hashed_message(builder, message_bytes, mode);
+        stdlib::byte_array<Builder> message(&builder, message_bytes);
+        stdlib::byte_array<Builder> hashed_message =
+            static_cast<stdlib::byte_array<Builder>>(stdlib::SHA256<Builder>::hash(message));
 
         // ECDSA verification
         ecdsa_verification_circuit(builder,
@@ -374,8 +293,9 @@ template <class Curve> class EcdsaTests : public ::testing::Test {
             Builder builder;
 
             // Compute H(m)
+            stdlib::byte_array<Builder> message(&builder, test.message);
             stdlib::byte_array<Builder> hashed_message =
-                construct_hashed_message(builder, test.message, TamperingMode::None);
+                static_cast<stdlib::byte_array<Builder>>(stdlib::SHA256<Builder>::hash(message));
 
             // ECDSA verification
             ecdsa_verification_circuit(builder,
@@ -446,11 +366,6 @@ TYPED_TEST(EcdsaTests, InfinityPubKey)
     // Disable asserts to avoid errors trying to invert zero
     BB_DISABLE_ASSERTS();
     TestFixture::test_verify_signature(/*random_signature=*/false, TestFixture::TamperingMode::InfinityPubKey);
-}
-
-TYPED_TEST(EcdsaTests, OutOfBoundsHash)
-{
-    TestFixture::test_verify_signature(/*random_signature=*/false, TestFixture::TamperingMode::OutOfBoundsHash);
 }
 
 TYPED_TEST(EcdsaTests, InfinityScalarMul)

--- a/barretenberg/cpp/src/barretenberg/stdlib/encryption/ecdsa/ecdsa_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/encryption/ecdsa/ecdsa_impl.hpp
@@ -27,17 +27,15 @@ auto& engine = numeric::get_debug_randomness();
  *  4. \f$\mathbf{H}\f$ is a hash function
  *
  * Given a message \f$m\f$, a couple \f$(r,s)\f$ is a valid signature for the message \f$m\f$ with respect to the public
- * key \f$P\f$ if:
+ * key \f$P\f$ if (following https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.186-5.pdf):
  *  1. \f$P\f$ is a point on \f$E\f$
- *  2. \f$P\f$ is not the point at infinity
- *  3. \f$0 < r < n\f$
- *  4. \f$0 < s < (n+1) / 2\f$
- *  5. Define \f$e := \mathbf{H}(m) \mod n\f$ and \f$Q := e s^{-1} G + r s^{-1} P \f$
- *  6. \f$Q\f$ is not the point at infinity
- *  7. \f$Q_x = r \mod n\f$ (note that \f$Q_x \in \mathbb{F}_q\f$)
- *
- * We implement these verification algorithm following the implementation of OpenSSL
- * https://github.com/openssl/openssl/blob/94cc3b7995d82c23b3449708f03f7bff0ba98e92/crypto/ec/ecdsa_ossl.c#L442.
+ *  2. \f$P = (x,y)\f$, then x < q, y < q
+ *  3. \f$P\f$ is not the point at infinity
+ *  4. \f$0 < r < n\f$
+ *  5. \f$0 < s < (n+1) / 2\f$
+ *  6. Define \f$e := \mathbf{H}(m) \mod n\f$ and \f$Q := e s^{-1} G + r s^{-1} P \f$
+ *  7. \f$Q\f$ is not the point at infinity
+ *  8. \f$Q_x = r \mod n\f$ (note that \f$Q_x \in \mathbb{F}_q\f$)
  *
  * @note The requirement of step 4. is to avoid signature malleability: if \f$(r,s)\f$ is a valid signature for
  * message \f$m\f$ and public key \f$P\f$, so is \f$(r,n-s)\f$. We protect against malleability by enforcing that
@@ -53,17 +51,15 @@ auto& engine = numeric::get_debug_randomness();
  * boolean is NOT constrained to be equal to bool_t(true).
  *
  * @note The circuit introduces constraints for the following assertions:
- *          1. \f$P\f$ is on the curve
- *          2. \f$P\f$ is on the point at infinity
- *          3. \f$0 < r < n\f$
- *          4. \f$0 < s < (n+1)/2\f$
- *          5. \f$Q := H(m) s^{-1} G + r s^{-1} P\f$ is not the point at infinity
+ *          1. \f$P = (x,y)\f$, then x < q, y < q
+ *          2. \f$P\f$ is on the curve
+ *          3. \f$P\f$ is on the point at infinity
+ *          4. \f$0 < r < n\f$
+ *          5. \f$0 < s < (n+1)/2\f$
+ *          6. \f$Q := H(m) s^{-1} G + r s^{-1} P\f$ is not the point at infinity
  * Therefore, if the witnesses passed to this function do not satisfy these constraints, the resulting circuit
  * will be unsatisfied. If a user wants to use the verification inside a in-circuit branch, then they need to supply
  * valid data for \f$P, r, s\f$, even though \f$(r,s)\f$ doesn't need to be a valid signature.
- *
- * @note We don't need to trim the length of the output of the hash function because the bit length of the scalar fields
- * we work with (secp256k1, secp256r1) are equal to 256.
  *
  * @tparam Builder
  * @tparam Curve
@@ -89,29 +85,39 @@ bool_t<Builder> ecdsa_verify_signature(const stdlib::byte_array<Builder>& hashed
     BB_ASSERT_EQ(builder != nullptr, true, "At least one of the inputs should be non-constant.");
 
     // Turn the hashed message into an element of Fr
+    // Note that we don't need to trim the length of the output of the hash function because the bit length of the
+    // scalar fields we work with (secp256k1, secp256r1) are equal to 256.
     Fr z(hashed_message);
 
     // Step 1.
-    public_key.validate_on_curve("ECDSA input validation: the public key is not a point on the elliptic curve.");
+    public_key.x.assert_less_than(
+        Fq::modulus,
+        "ECDSA input validation: the x coordinate of the public key is bigger than the base field modulus."); // x < q
+    public_key.y.assert_less_than(
+        Fq::modulus,
+        "ECDSA input validation: the y coordinate of the public key is bigger than the base field modulus."); // y < q
 
     // Step 2.
+    public_key.validate_on_curve("ECDSA input validation: the public key is not a point on the elliptic curve.");
+
+    // Step 3.
     public_key.is_point_at_infinity().assert_equal(bool_t<Builder>(false),
                                                    "ECDSA input validation: the public key is the point at infinity.");
 
-    // Step 3.
+    // Step 4.
     Fr r(sig.r);
     r.assert_is_in_field("ECDSA input validation: the r component of the signature is bigger than the order of the "
                          "elliptic curve.");                                                                // r < n
     r.assert_is_not_equal(Fr::zero(), "ECDSA input validation: the r component of the signature is zero."); // 0 < r
 
-    // Step 4.
+    // Step 5.
     Fr s(sig.s);
     s.assert_less_than(
         (Fr::modulus + 1) / 2,
         "ECDSA input validation: the s component of the signature is bigger than Fr::modulus - s."); // s < (n+1)/2
     s.assert_is_not_equal(Fr::zero(), "ECDSA input validation: the s component of the signature is zero."); // 0 < s
 
-    // Step 5.
+    // Step 6.
     Fr u1 = z.div_without_denominator_check(s);
     Fr u2 = r.div_without_denominator_check(s);
 
@@ -128,11 +134,11 @@ bool_t<Builder> ecdsa_verify_signature(const stdlib::byte_array<Builder>& hashed
         result = G1::batch_mul({ G1::one(builder), public_key }, { u1, u2 });
     }
 
-    // Step 6.
+    // Step 7.
     result.is_point_at_infinity().assert_equal(
         bool_t<Builder>(false), "ECDSA validation: the result of the batch multiplication is the point at infinity.");
 
-    // Step 7.
+    // Step 8.
     // We reduce result.x to 2^s, where s is the smallest s.t. 2^s > q. It is cheap in terms of constraints, and avoids
     // possible edge cases
     result.x.self_reduce();

--- a/barretenberg/cpp/src/barretenberg/stdlib/encryption/ecdsa/ecdsa_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/encryption/ecdsa/ecdsa_impl.hpp
@@ -90,11 +90,9 @@ bool_t<Builder> ecdsa_verify_signature(const stdlib::byte_array<Builder>& hashed
     Fr z(hashed_message);
 
     // Step 1.
-    public_key.x.assert_less_than(
-        Fq::modulus,
+    public_key.x.assert_is_in_field(
         "ECDSA input validation: the x coordinate of the public key is bigger than the base field modulus."); // x < q
-    public_key.y.assert_less_than(
-        Fq::modulus,
+    public_key.y.assert_is_in_field(
         "ECDSA input validation: the y coordinate of the public key is bigger than the base field modulus."); // y < q
 
     // Step 2.

--- a/barretenberg/cpp/src/barretenberg/stdlib/encryption/ecdsa/ecdsa_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/encryption/ecdsa/ecdsa_impl.hpp
@@ -36,6 +36,9 @@ auto& engine = numeric::get_debug_randomness();
  *  6. \f$Q\f$ is not the point at infinity
  *  7. \f$Q_x = r \mod n\f$ (note that \f$Q_x \in \mathbb{F}_q\f$)
  *
+ * We implement these verification algorithm following the implementation of OpenSSL
+ * https://github.com/openssl/openssl/blob/94cc3b7995d82c23b3449708f03f7bff0ba98e92/crypto/ec/ecdsa_ossl.c#L442.
+ *
  * @note The requirement of step 4. is to avoid signature malleability: if \f$(r,s)\f$ is a valid signature for
  * message \f$m\f$ and public key \f$P\f$, so is \f$(r,n-s)\f$. We protect against malleability by enforcing that
  * \f$s\f$ is always the lowest of the two possible values.
@@ -52,13 +55,15 @@ auto& engine = numeric::get_debug_randomness();
  * @note The circuit introduces constraints for the following assertions:
  *          1. \f$P\f$ is on the curve
  *          2. \f$P\f$ is on the point at infinity
- *          3. \f$H(m) < n\f$
- *          4. \f$0 < r < n\f$
- *          5. \f$0 < s < (n+1)/2\f$
- *          6. \f$Q := H(m) s^{-1} G + r s^{-1} P\f$ is not the point at infinity
+ *          3. \f$0 < r < n\f$
+ *          4. \f$0 < s < (n+1)/2\f$
+ *          5. \f$Q := H(m) s^{-1} G + r s^{-1} P\f$ is not the point at infinity
  * Therefore, if the witnesses passed to this function do not satisfy these constraints, the resulting circuit
  * will be unsatisfied. If a user wants to use the verification inside a in-circuit branch, then they need to supply
- * valid data for \f$m, P, r, s\f$, even though \f$(r,s)\f$ doesn't need to be a valid signature.
+ * valid data for \f$P, r, s\f$, even though \f$(r,s)\f$ doesn't need to be a valid signature.
+ *
+ * @note We don't need to trim the length of the output of the hash function because the bit length of the scalar fields
+ * we work with (secp256k1, secp256r1) are equal to 256.
  *
  * @tparam Builder
  * @tparam Curve
@@ -75,6 +80,8 @@ bool_t<Builder> ecdsa_verify_signature(const stdlib::byte_array<Builder>& hashed
                                        const G1& public_key,
                                        const ecdsa_signature<Builder>& sig)
 {
+    BB_ASSERT_EQ(Fr::modulus.get_msb() + 1, 256UL, "The implementation assumes that the bit-length of Fr is 256 bits.");
+
     // Fetch the context
     Builder* builder = hashed_message.get_context();
     builder = validate_context(builder, public_key.get_context());
@@ -82,13 +89,7 @@ bool_t<Builder> ecdsa_verify_signature(const stdlib::byte_array<Builder>& hashed
     BB_ASSERT_EQ(builder != nullptr, true, "At least one of the inputs should be non-constant.");
 
     // Turn the hashed message into an element of Fr
-    // The assertion means that an honest prover has a small probability of not being able to generate a valid proof if
-    // H(m) >= n. Enforcing this condition introduces a small number of gates, and ensures that signatures cannot be
-    // forged by finding a collision of H modulo n. While finding such a collision is supposed to be hard even modulo n,
-    // we protect against this case with this cheap check.
     Fr z(hashed_message);
-    z.assert_is_in_field(
-        "ECDSA input validation: the hash of the message is bigger than the order of the elliptic curve.");
 
     // Step 1.
     public_key.validate_on_curve("ECDSA input validation: the public key is not a point on the elliptic curve.");

--- a/barretenberg/cpp/src/barretenberg/stdlib/encryption/ecdsa/ecdsa_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/encryption/ecdsa/ecdsa_impl.hpp
@@ -86,7 +86,7 @@ bool_t<Builder> ecdsa_verify_signature(const stdlib::byte_array<Builder>& hashed
 
     // Turn the hashed message into an element of Fr
     // Note that we don't need to trim the length of the output of the hash function because the bit length of the
-    // scalar fields we work with (secp256k1, secp256r1) are equal to 256.
+    // scalar fields we work with (secp256k1, secp256r1) is equal to 256.
     Fr z(hashed_message);
 
     // Step 1.

--- a/barretenberg/cpp/src/barretenberg/stdlib/encryption/ecdsa/ecdsa_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/encryption/ecdsa/ecdsa_impl.hpp
@@ -53,7 +53,7 @@ auto& engine = numeric::get_debug_randomness();
  * @note The circuit introduces constraints for the following assertions:
  *          1. \f$P = (x,y)\f$, then x < q, y < q
  *          2. \f$P\f$ is on the curve
- *          3. \f$P\f$ is on the point at infinity
+ *          3. \f$P\f$ is not the point at infinity
  *          4. \f$0 < r < n\f$
  *          5. \f$0 < s < (n+1)/2\f$
  *          6. \f$Q := H(m) s^{-1} G + r s^{-1} P\f$ is not the point at infinity


### PR DESCRIPTION
### 🧾 Audit Context

ECDSA audit, testing and refactoring.

### 🛠️ Changes Made

- Removed overconstraining in ECDSA verification: we don't check anymore that `Hash(m) < Fr::modulus`
- Duplicated constraints that check `P = (x, y)`, `x < Fq::modulus` and `y < Fq::modulus` from `ecdsa_constraints.cpp` to the ECDSA verification function. The ones in `acir_format` are to be removed to avoid this duplication.
- Refactored tests according to the above changes.

The changes trigger a VK.

### ✅ Checklist

- [ ] Audited all methods of the relevant module/class
- [ ] Audited the interface of the module/class with other (relevant) components
- [ ] Documented existing functionality and any changes made (as per Doxygen requirements)
- [ ] Resolved and/or closed all issues/TODOs pertaining to the audited files
- [ ] Confirmed and documented any security or other issues found (if applicable)
- [X] Verified that tests cover all critical paths (and added tests if necessary)
- [ ] Updated audit tracking for the files audited (check the start of each file you audited)

### 📌 Notes for Reviewers
