### PR TITLE
fix: Do not allow txs in proposals if disableTransactions is set

### DIFF
--- a/.test_patterns.yml
+++ b/.test_patterns.yml
@@ -86,6 +86,11 @@ tests:
     error_regex: "combined_a.get_value() > fq_ct::modulus"
     owners:
       - *suyash
+  # http://ci.aztec-labs.com/1593f7c89e22b51b
+  - regex: stdlib_primitives_tests stdlibBiggroupSecp256k1/1.WnafSecp256k1StaggerOutOfRangeFails
+    error_regex: "biggroup_nafs: stagger fragment is not in range"
+    owners:
+      - *luke
 
   # noir
   # Something to do with how I run the tests now. Think these are fine in nextest.

--- a/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
+++ b/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
@@ -170,7 +170,7 @@ export class LibP2PService<T extends P2PClientType = P2PClientType.Full> extends
     );
 
     this.attestationValidator = new AttestationValidator(epochCache);
-    this.blockProposalValidator = new BlockProposalValidator(epochCache);
+    this.blockProposalValidator = new BlockProposalValidator(epochCache, { txsPermitted: !config.disableTransactions });
 
     this.gossipSubEventHandler = this.handleGossipSubEvent.bind(this);
 

--- a/yarn-project/stdlib/src/interfaces/aztec-node-admin.test.ts
+++ b/yarn-project/stdlib/src/interfaces/aztec-node-admin.test.ts
@@ -5,7 +5,7 @@ import { type Offense, OffenseType, type SlashPayloadRound } from '../slashing/i
 import { type AztecNodeAdmin, AztecNodeAdminApiSchema } from './aztec-node-admin.js';
 import type { SequencerConfig } from './configs.js';
 import type { ProverConfig } from './prover-client.js';
-import type { ValidatorClientConfig } from './server.js';
+import type { ValidatorClientFullConfig } from './server.js';
 import type { SlasherConfig } from './slasher.js';
 
 describe('AztecNodeAdminApiSchema', () => {
@@ -126,7 +126,7 @@ class MockAztecNodeAdmin implements AztecNodeAdmin {
     ]);
   }
   getConfig(): Promise<
-    ValidatorClientConfig & SequencerConfig & ProverConfig & SlasherConfig & { maxTxPoolSize: number }
+    ValidatorClientFullConfig & SequencerConfig & ProverConfig & SlasherConfig & { maxTxPoolSize: number }
   > {
     return Promise.resolve({
       realProofs: false,
@@ -164,6 +164,7 @@ class MockAztecNodeAdmin implements AztecNodeAdmin {
       attestationPollingIntervalMs: 1000,
       validatorReexecute: true,
       validatorReexecuteDeadlineMs: 1000,
+      disableTransactions: false,
     });
   }
   startSnapshotUpload(_location: string): Promise<void> {

--- a/yarn-project/stdlib/src/interfaces/aztec-node-admin.ts
+++ b/yarn-project/stdlib/src/interfaces/aztec-node-admin.ts
@@ -9,7 +9,7 @@ import { type ArchiverSpecificConfig, ArchiverSpecificConfigSchema } from './arc
 import { type SequencerConfig, SequencerConfigSchema } from './configs.js';
 import { type ProverConfig, ProverConfigSchema } from './prover-client.js';
 import { type SlasherConfig, SlasherConfigSchema } from './slasher.js';
-import { ValidatorClientConfigSchema, type ValidatorClientFullConfig } from './validator.js';
+import { type ValidatorClientFullConfig, ValidatorClientFullConfigSchema } from './validator.js';
 
 /**
  * Aztec node admin API.
@@ -62,7 +62,7 @@ export type AztecNodeAdminConfig = ValidatorClientFullConfig &
 
 export const AztecNodeAdminConfigSchema = SequencerConfigSchema.merge(ProverConfigSchema)
   .merge(SlasherConfigSchema)
-  .merge(ValidatorClientConfigSchema)
+  .merge(ValidatorClientFullConfigSchema)
   .merge(
     ArchiverSpecificConfigSchema.pick({
       archiverPollingIntervalMS: true,

--- a/yarn-project/validator-client/src/factory.ts
+++ b/yarn-project/validator-client/src/factory.ts
@@ -24,7 +24,9 @@ export function createBlockProposalHandler(
   },
 ) {
   const metrics = new ValidatorMetrics(deps.telemetry);
-  const blockProposalValidator = new BlockProposalValidator(deps.epochCache);
+  const blockProposalValidator = new BlockProposalValidator(deps.epochCache, {
+    txsPermitted: !config.disableTransactions,
+  });
   return new BlockProposalHandler(
     deps.blockBuilder,
     deps.blockSource,

--- a/yarn-project/validator-client/src/validator.test.ts
+++ b/yarn-project/validator-client/src/validator.test.ts
@@ -38,7 +38,8 @@ import { type ValidatorClientConfig, validatorClientConfigMappings } from './con
 import { ValidatorClient } from './validator.js';
 
 describe('ValidatorClient', () => {
-  let config: ValidatorClientConfig & Pick<SlasherConfig, 'slashBroadcastedInvalidBlockPenalty'>;
+  let config: ValidatorClientConfig &
+    Pick<SlasherConfig, 'slashBroadcastedInvalidBlockPenalty'> & { disableTransactions: boolean };
   let validatorClient: ValidatorClient;
   let p2pClient: MockProxy<P2P>;
   let blockSource: MockProxy<L2BlockSource>;
@@ -75,6 +76,7 @@ describe('ValidatorClient', () => {
       validatorReexecute: false,
       validatorReexecuteDeadlineMs: 6000,
       slashBroadcastedInvalidBlockPenalty: 1n,
+      disableTransactions: false,
     };
 
     const keyStore: KeyStore = {

--- a/yarn-project/validator-client/src/validator.ts
+++ b/yarn-project/validator-client/src/validator.ts
@@ -9,13 +9,7 @@ import { DateProvider } from '@aztec/foundation/timer';
 import type { KeystoreManager } from '@aztec/node-keystore';
 import type { P2P, PeerId, TxProvider } from '@aztec/p2p';
 import { AuthRequest, AuthResponse, BlockProposalValidator, ReqRespSubProtocol } from '@aztec/p2p';
-import {
-  OffenseType,
-  type SlasherConfig,
-  WANT_TO_SLASH_EVENT,
-  type Watcher,
-  type WatcherEmitter,
-} from '@aztec/slasher';
+import { OffenseType, WANT_TO_SLASH_EVENT, type Watcher, type WatcherEmitter } from '@aztec/slasher';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
 import type { CommitteeAttestationsAndSigners, L2BlockSource } from '@aztec/stdlib/block';
 import type { IFullNodeBlockBuilder, Validator, ValidatorClientFullConfig } from '@aztec/stdlib/interfaces/server';
@@ -30,7 +24,6 @@ import { EventEmitter } from 'events';
 import type { TypedDataDefinition } from 'viem';
 
 import { BlockProposalHandler, type BlockProposalValidationFailureReason } from './block_proposal_handler.js';
-import type { ValidatorClientConfig } from './config.js';
 import { ValidationService } from './duties/validation_service.js';
 import { NodeKeystoreAdapter } from './key_store/node_keystore_adapter.js';
 import { ValidatorMetrics } from './metrics.js';
@@ -140,7 +133,7 @@ export class ValidatorClient extends (EventEmitter as new () => WatcherEmitter) 
   }
 
   static new(
-    config: ValidatorClientConfig & Pick<SlasherConfig, 'slashBroadcastedInvalidBlockPenalty'>,
+    config: ValidatorClientFullConfig,
     blockBuilder: IFullNodeBlockBuilder,
     epochCache: EpochCache,
     p2pClient: P2P,
@@ -152,7 +145,9 @@ export class ValidatorClient extends (EventEmitter as new () => WatcherEmitter) 
     telemetry: TelemetryClient = getTelemetryClient(),
   ) {
     const metrics = new ValidatorMetrics(telemetry);
-    const blockProposalValidator = new BlockProposalValidator(epochCache);
+    const blockProposalValidator = new BlockProposalValidator(epochCache, {
+      txsPermitted: !config.disableTransactions,
+    });
     const blockProposalHandler = new BlockProposalHandler(
       blockBuilder,
       blockSource,


### PR DESCRIPTION
Reuses the `disableTransactions` flag used in p2p to also reject block proposals that have non-empty tx hashes.