### PR TITLE
chore!: use cycle_group::conditional_assign in place of component-wise version

### DIFF
--- a/barretenberg/cpp/src/barretenberg/stdlib/eccvm_verifier/eccvm_recursive_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/eccvm_verifier/eccvm_recursive_verifier.test.cpp
@@ -139,7 +139,7 @@ class ECCVMRecursiveTests : public ::testing::Test {
         }
 
         // Check that the size of the recursive verifier is consistent with historical expectation
-        uint32_t NUM_GATES_EXPECTED = 216315;
+        uint32_t NUM_GATES_EXPECTED = 216453;
         ASSERT_EQ(static_cast<uint32_t>(outer_circuit.get_num_finalized_gates()), NUM_GATES_EXPECTED)
             << "Ultra-arithmetized ECCVM Recursive verifier gate count changed! Update this value if you are sure this "
                "is expected.";

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/group/cycle_group.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/group/cycle_group.test.cpp
@@ -1441,9 +1441,9 @@ TYPED_TEST(CycleGroupTest, TestBatchMulGeneralMSM)
 
     // Gate count difference due to additional constants added by default in Mega builder
     if constexpr (std::is_same_v<TypeParam, bb::MegaCircuitBuilder>) {
-        check_circuit_and_gate_count(builder, 4393); // Mega
+        check_circuit_and_gate_count(builder, 4395); // Mega
     } else {
-        check_circuit_and_gate_count(builder, 4396); // Ultra
+        check_circuit_and_gate_count(builder, 4398); // Ultra
     }
 }
 
@@ -1473,9 +1473,9 @@ TYPED_TEST(CycleGroupTest, TestBatchMulProducesInfinity)
 
     // Gate count difference due to additional constants added by default in Mega builder
     if constexpr (std::is_same_v<TypeParam, bb::MegaCircuitBuilder>) {
-        check_circuit_and_gate_count(builder, 4019); // Mega
+        check_circuit_and_gate_count(builder, 4021); // Mega
     } else {
-        check_circuit_and_gate_count(builder, 4022); // Ultra
+        check_circuit_and_gate_count(builder, 4024); // Ultra
     }
 }
 
@@ -1500,9 +1500,9 @@ TYPED_TEST(CycleGroupTest, TestBatchMulMultiplyByZero)
 
     // Gate count difference due to additional constants added by default in Mega builder
     if constexpr (std::is_same_v<TypeParam, bb::MegaCircuitBuilder>) {
-        check_circuit_and_gate_count(builder, 3529); // Mega
+        check_circuit_and_gate_count(builder, 3530); // Mega
     } else {
-        check_circuit_and_gate_count(builder, 3532); // Ultra
+        check_circuit_and_gate_count(builder, 3533); // Ultra
     }
 }
 
@@ -1538,9 +1538,9 @@ TYPED_TEST(CycleGroupTest, TestBatchMulInputsAreInfinity)
 
     // Gate count difference due to additional constants added by default in Mega builder
     if constexpr (std::is_same_v<TypeParam, bb::MegaCircuitBuilder>) {
-        check_circuit_and_gate_count(builder, 3542); // Mega
+        check_circuit_and_gate_count(builder, 3543); // Mega
     } else {
-        check_circuit_and_gate_count(builder, 3545); // Ultra
+        check_circuit_and_gate_count(builder, 3546); // Ultra
     }
 }
 
@@ -1709,9 +1709,9 @@ TYPED_TEST(CycleGroupTest, TestMul)
 
     // Gate count difference due to additional constants added by default in Mega builder
     if constexpr (std::is_same_v<TypeParam, bb::MegaCircuitBuilder>) {
-        check_circuit_and_gate_count(builder, 12933); // Mega
+        check_circuit_and_gate_count(builder, 12943); // Mega
     } else {
-        check_circuit_and_gate_count(builder, 12936); // Ultra
+        check_circuit_and_gate_count(builder, 12946); // Ultra
     }
 }
 
@@ -1882,9 +1882,9 @@ TYPED_TEST(CycleGroupTest, TestBatchMulWithBn254Scalar)
 
     // Gate count difference due to additional constants added by default in Mega builder
     if constexpr (std::is_same_v<TypeParam, bb::MegaCircuitBuilder>) {
-        check_circuit_and_gate_count(builder, 4021); // Mega
+        check_circuit_and_gate_count(builder, 4023); // Mega
     } else {
-        check_circuit_and_gate_count(builder, 4024); // Ultra
+        check_circuit_and_gate_count(builder, 4026); // Ultra
     }
 }
 
@@ -1927,9 +1927,9 @@ TYPED_TEST(CycleGroupTest, TestBatchMulWithU256Witness)
 
     // Gate count difference due to additional constants added by default in Mega builder
     if constexpr (std::is_same_v<TypeParam, bb::MegaCircuitBuilder>) {
-        check_circuit_and_gate_count(builder, 1245); // Mega
+        check_circuit_and_gate_count(builder, 1247); // Mega
     } else {
-        check_circuit_and_gate_count(builder, 1248); // Ultra
+        check_circuit_and_gate_count(builder, 1250); // Ultra
     }
 }
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/group/straus_lookup_table.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/group/straus_lookup_table.cpp
@@ -70,10 +70,9 @@ straus_lookup_table<Builder>::straus_lookup_table(Builder* context,
     // 3: If point at infinity, conditionally (re)assign each entry in the table to be equal to the offset
     //    generator so that the final table is genuninely correct in all cases. (Otherwise, the table is unchanged
     //    from step 2)
-    cycle_group<Builder> fallback_point(Group::affine_one);
-    field_t modded_x = field_t::conditional_assign(base_point.is_point_at_infinity(), fallback_point.x, base_point.x);
-    field_t modded_y = field_t::conditional_assign(base_point.is_point_at_infinity(), fallback_point.y, base_point.y);
-    cycle_group<Builder> modded_base_point(modded_x, modded_y, false, /*assert_on_curve=*/false);
+    cycle_group<Builder> work_point =
+        cycle_group<Builder>::conditional_assign(base_point.is_point_at_infinity(), Group::affine_one, base_point);
+    context->update_used_witnesses(work_point.is_point_at_infinity().get_normalized_witness_index());
     // We assume that the native hints (if present) do not account for the point at infinity edge case in the same way
     // as above (i.e. replacing with "one") so we avoid using any provided hints in this case. (N.B. No efficiency is
     // lost here since native addition with the point at infinity is nearly free).
@@ -90,10 +89,10 @@ straus_lookup_table<Builder>::straus_lookup_table(Builder* context,
         // Case 1: if the input point is constant, it is cheaper to fix the point as a witness and then derive the
         // table, than it is to derive the table and fix its witnesses to be constant! (due to group additions = 1 gate,
         // and fixing x/y coords to be constant = 2 gates)
-        modded_base_point = cycle_group<Builder>::from_constant_witness(_context, modded_base_point.get_value());
+        work_point = cycle_group<Builder>::from_constant_witness(_context, work_point.get_value());
         point_table[0] = cycle_group<Builder>::from_constant_witness(_context, offset_generator.get_value());
         for (size_t i = 1; i < table_size; ++i) {
-            point_table[i] = point_table[i - 1].unconditional_add(modded_base_point, get_hint(i - 1));
+            point_table[i] = point_table[i - 1].unconditional_add(work_point, get_hint(i - 1));
         }
     } else {
         // Case 2: Point is non-constant so the table is derived via unconditional additions. We check the x_coordinates
@@ -101,9 +100,9 @@ straus_lookup_table<Builder>::straus_lookup_table(Builder* context,
         field_t coordinate_check_product = 1;
         point_table[0] = offset_generator;
         for (size_t i = 1; i < table_size; ++i) {
-            const field_t x_diff = point_table[i - 1].x - modded_base_point.x;
+            const field_t x_diff = point_table[i - 1].x - work_point.x;
             coordinate_check_product *= x_diff;
-            point_table[i] = point_table[i - 1].unconditional_add(modded_base_point, get_hint(i - 1));
+            point_table[i] = point_table[i - 1].unconditional_add(work_point, get_hint(i - 1));
         }
         coordinate_check_product.assert_is_not_zero("straus_lookup_table x-coordinate collision");
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/group/straus_lookup_table.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/group/straus_lookup_table.test.cpp
@@ -55,9 +55,9 @@ TYPED_TEST(StrausLookupTableTest, TestTableConstuction)
     straus_lookup_table table(&builder, base_point, offset_gen, table_bits);
 
     if constexpr (std::is_same_v<TypeParam, bb::UltraCircuitBuilder>) {
-        check_circuit_and_gate_count(builder, 184);
+        check_circuit_and_gate_count(builder, 185);
     } else {
-        check_circuit_and_gate_count(builder, 181);
+        check_circuit_and_gate_count(builder, 182);
     }
 }
 
@@ -99,9 +99,9 @@ TYPED_TEST(StrausLookupTableTest, TestTableRead)
     // Mega pre-adds constants {0, 3, 4, 8} for ECC op codes during construction. When setting ROM elements at indices
     // {3, 4, 8}, Mega doesn't need to add a corresponding gate for the constant value, whereas Ultra does.
     if constexpr (std::is_same_v<TypeParam, bb::UltraCircuitBuilder>) {
-        check_circuit_and_gate_count(builder, 216);
+        check_circuit_and_gate_count(builder, 217);
     } else {
-        check_circuit_and_gate_count(builder, 213);
+        check_circuit_and_gate_count(builder, 214);
     }
 }
 
@@ -151,9 +151,9 @@ TYPED_TEST(StrausLookupTableTest, TestWithProvidedHints)
     // Gate count difference explanation:
     // Same as TestTableRead - ROM with 8 elements (indices 0-7).
     if constexpr (std::is_same_v<TypeParam, bb::UltraCircuitBuilder>) {
-        check_circuit_and_gate_count(builder, 98);
+        check_circuit_and_gate_count(builder, 99);
     } else {
-        check_circuit_and_gate_count(builder, 96);
+        check_circuit_and_gate_count(builder, 97);
     }
 }
 
@@ -191,8 +191,8 @@ TYPED_TEST(StrausLookupTableTest, TestInfinityBasePoint)
     // Gate count difference explanation:
     // Same as TestTableRead - ROM with 4 elements (indices 0-3).
     if constexpr (std::is_same_v<TypeParam, bb::UltraCircuitBuilder>) {
-        check_circuit_and_gate_count(builder, 60);
+        check_circuit_and_gate_count(builder, 61);
     } else {
-        check_circuit_and_gate_count(builder, 59);
+        check_circuit_and_gate_count(builder, 60);
     }
 }


### PR DESCRIPTION
Use `cycle_group::conditional_assign` in `straus_lookup_table` when constructing a `work_point` that is constructed to avoid the point at infinity, rather than conditionally assigning the values of the coordinates and setting is_infinity to constant false.