### PR TITLE
fix: Remove block number from p2p proposals and attestations

### DIFF
--- a/yarn-project/archiver/src/archiver/archiver.test.ts
+++ b/yarn-project/archiver/src/archiver/archiver.test.ts
@@ -106,7 +106,7 @@ describe('Archiver', () => {
   let blobSinkClient: MockProxy<BlobSinkClientInterface>;
   let epochCache: MockProxy<EpochCache>;
   let archiverStore: ArchiverDataStore;
-  let l1Constants: L1RollupConstants & { l1StartBlockHash: Buffer32 };
+  let l1Constants: L1RollupConstants & { l1StartBlockHash: Buffer32; genesisArchiveRoot: Fr };
   let now: number;
 
   let mockRollupRead: MockProxy<MockRollupContractRead>;
@@ -167,6 +167,7 @@ describe('Archiver', () => {
       slotDuration: 24,
       ethereumSlotDuration: 12,
       proofSubmissionEpochs: 1,
+      genesisArchiveRoot: new Fr(GENESIS_ARCHIVE_ROOT),
     };
 
     archiver = new Archiver(

--- a/yarn-project/archiver/src/archiver/archiver_store.ts
+++ b/yarn-project/archiver/src/archiver/archiver_store.ts
@@ -62,6 +62,18 @@ export interface ArchiverDataStore {
   getPublishedBlock(number: number): Promise<PublishedL2Block | undefined>;
 
   /**
+   * Returns the block for the given hash, or undefined if not exists.
+   * @param blockHash - The block hash to return.
+   */
+  getPublishedBlockByHash(blockHash: Fr): Promise<PublishedL2Block | undefined>;
+
+  /**
+   * Returns the block for the given archive root, or undefined if not exists.
+   * @param archive - The archive root to return.
+   */
+  getPublishedBlockByArchive(archive: Fr): Promise<PublishedL2Block | undefined>;
+
+  /**
    * Gets up to `limit` amount of published L2 blocks starting from `from`.
    * @param from - Number of the first block to return (inclusive).
    * @param limit - The number of blocks to return.
@@ -76,6 +88,18 @@ export interface ArchiverDataStore {
    * @returns The requested L2 block headers.
    */
   getBlockHeaders(from: number, limit: number): Promise<BlockHeader[]>;
+
+  /**
+   * Returns the block header for the given hash, or undefined if not exists.
+   * @param blockHash - The block hash to return.
+   */
+  getBlockHeaderByHash(blockHash: Fr): Promise<BlockHeader | undefined>;
+
+  /**
+   * Returns the block header for the given archive root, or undefined if not exists.
+   * @param archive - The archive root to return.
+   */
+  getBlockHeaderByArchive(archive: Fr): Promise<BlockHeader | undefined>;
 
   /**
    * Gets a tx effect.

--- a/yarn-project/archiver/src/archiver/kv_archiver_store/kv_archiver_store.ts
+++ b/yarn-project/archiver/src/archiver/kv_archiver_store/kv_archiver_store.ts
@@ -5,7 +5,7 @@ import { createLogger } from '@aztec/foundation/log';
 import type { AztecAsyncKVStore, CustomRange, StoreSize } from '@aztec/kv-store';
 import { FunctionSelector } from '@aztec/stdlib/abi';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
-import type { L2Block, ValidateBlockResult } from '@aztec/stdlib/block';
+import { type L2Block, L2BlockHash, type ValidateBlockResult } from '@aztec/stdlib/block';
 import type {
   ContractClassPublic,
   ContractDataSource,
@@ -204,6 +204,14 @@ export class KVArchiverDataStore implements ArchiverDataStore, ContractDataSourc
     return this.#blockStore.getBlock(number);
   }
 
+  getPublishedBlockByHash(blockHash: Fr): Promise<PublishedL2Block | undefined> {
+    return this.#blockStore.getBlockByHash(L2BlockHash.fromField(blockHash));
+  }
+
+  getPublishedBlockByArchive(archive: Fr): Promise<PublishedL2Block | undefined> {
+    return this.#blockStore.getBlockByArchive(archive);
+  }
+
   /**
    * Gets up to `limit` amount of L2 blocks starting from `from`.
    *
@@ -224,6 +232,14 @@ export class KVArchiverDataStore implements ArchiverDataStore, ContractDataSourc
    */
   getBlockHeaders(start: number, limit: number): Promise<BlockHeader[]> {
     return toArray(this.#blockStore.getBlockHeaders(start, limit));
+  }
+
+  getBlockHeaderByHash(blockHash: Fr): Promise<BlockHeader | undefined> {
+    return this.#blockStore.getBlockHeaderByHash(L2BlockHash.fromField(blockHash));
+  }
+
+  getBlockHeaderByArchive(archive: Fr): Promise<BlockHeader | undefined> {
+    return this.#blockStore.getBlockHeaderByArchive(archive);
   }
 
   /**

--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -554,6 +554,26 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, Traceable {
   }
 
   /**
+   * Get a block specified by its hash.
+   * @param blockHash - The block hash being requested.
+   * @returns The requested block.
+   */
+  public async getBlockByHash(blockHash: Fr): Promise<L2Block | undefined> {
+    const publishedBlock = await this.blockSource.getPublishedBlockByHash(blockHash);
+    return publishedBlock?.block;
+  }
+
+  /**
+   * Get a block specified by its archive root.
+   * @param archive - The archive root being requested.
+   * @returns The requested block.
+   */
+  public async getBlockByArchive(archive: Fr): Promise<L2Block | undefined> {
+    const publishedBlock = await this.blockSource.getPublishedBlockByArchive(archive);
+    return publishedBlock?.block;
+  }
+
+  /**
    * Method to request blocks. Will attempt to return all requested blocks but will return only those available.
    * @param from - The start of the range of blocks to return.
    * @param limit - The maximum number of blocks to obtain.
@@ -1059,6 +1079,24 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, Traceable {
     return blockNumber === 0 || (blockNumber === 'latest' && (await this.blockSource.getBlockNumber()) === 0)
       ? this.worldStateSynchronizer.getCommitted().getInitialHeader()
       : this.blockSource.getBlockHeader(blockNumber);
+  }
+
+  /**
+   * Get a block header specified by its hash.
+   * @param blockHash - The block hash being requested.
+   * @returns The requested block header.
+   */
+  public async getBlockHeaderByHash(blockHash: Fr): Promise<BlockHeader | undefined> {
+    return await this.blockSource.getBlockHeaderByHash(blockHash);
+  }
+
+  /**
+   * Get a block header specified by its archive root.
+   * @param archive - The archive root being requested.
+   * @returns The requested block header.
+   */
+  public async getBlockHeaderByArchive(archive: Fr): Promise<BlockHeader | undefined> {
+    return await this.blockSource.getBlockHeaderByArchive(archive);
   }
 
   /**

--- a/yarn-project/end-to-end/src/e2e_multi_validator/e2e_multi_validator_node.test.ts
+++ b/yarn-project/end-to-end/src/e2e_multi_validator/e2e_multi_validator_node.test.ts
@@ -134,7 +134,7 @@ describe('e2e_multi_validator_node', () => {
     const payload = ConsensusPayload.fromBlock(block.block);
     const attestations = block.attestations
       .filter(a => !a.signature.isEmpty())
-      .map(a => new BlockAttestation(block.block.number, payload, a.signature, Signature.empty()));
+      .map(a => new BlockAttestation(payload, a.signature, Signature.empty()));
 
     expect(attestations.length).toBeGreaterThanOrEqual((COMMITTEE_SIZE * 2) / 3 + 1);
 
@@ -193,7 +193,7 @@ describe('e2e_multi_validator_node', () => {
     const payload = ConsensusPayload.fromBlock(block.block);
     const attestations = block.attestations
       .filter(a => !a.signature.isEmpty())
-      .map(a => new BlockAttestation(block.block.number, payload, a.signature, Signature.empty()));
+      .map(a => new BlockAttestation(payload, a.signature, Signature.empty()));
 
     expect(attestations.length).toBeGreaterThanOrEqual((COMMITTEE_SIZE * 2) / 3 + 1);
 

--- a/yarn-project/end-to-end/src/e2e_p2p/gossip_network.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/gossip_network.test.ts
@@ -175,7 +175,7 @@ describe('e2e_p2p_network', () => {
     const payload = ConsensusPayload.fromBlock(block.block);
     const attestations = block.attestations
       .filter(a => !a.signature.isEmpty())
-      .map(a => new BlockAttestation(blockNumber, payload, a.signature, Signature.empty()));
+      .map(a => new BlockAttestation(payload, a.signature, Signature.empty()));
     const signers = await Promise.all(attestations.map(att => att.getSender()!.toString()));
     t.logger.info(`Attestation signers`, { signers });
 

--- a/yarn-project/end-to-end/src/e2e_p2p/gossip_network_no_cheat.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/gossip_network_no_cheat.test.ts
@@ -229,7 +229,7 @@ describe('e2e_p2p_network', () => {
     const payload = ConsensusPayload.fromBlock(block.block);
     const attestations = block.attestations
       .filter(a => !a.signature.isEmpty())
-      .map(a => new BlockAttestation(blockNumber, payload, a.signature, Signature.empty()));
+      .map(a => new BlockAttestation(payload, a.signature, Signature.empty()));
     const signers = await Promise.all(attestations.map(att => att.getSender()!.toString()));
     t.logger.info(`Attestation signers`, { signers });
 

--- a/yarn-project/end-to-end/src/e2e_p2p/preferred_gossip_network.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/preferred_gossip_network.test.ts
@@ -359,7 +359,7 @@ describe('e2e_p2p_preferred_network', () => {
     const payload = ConsensusPayload.fromBlock(block.block);
     const attestations = block.attestations
       .filter(a => !a.signature.isEmpty())
-      .map(a => new BlockAttestation(blockNumber, payload, a.signature, Signature.empty()));
+      .map(a => new BlockAttestation(payload, a.signature, Signature.empty()));
     const signers = await Promise.all(attestations.map(att => att.getSender()!.toString()));
     t.logger.info(`Attestation signers`, { signers });
 

--- a/yarn-project/p2p/src/mem_pools/attestation_pool/attestation_pool_test_suite.ts
+++ b/yarn-project/p2p/src/mem_pools/attestation_pool/attestation_pool_test_suite.ts
@@ -41,7 +41,6 @@ export function describeAttestationPool(getAttestationPool: () => AttestationPoo
   };
 
   const mockBlockProposal = (signer: Secp256k1Signer, slotNumber: number, archive: Fr = Fr.random()): BlockProposal => {
-    const blockNumber = 1;
     const header = makeL2BlockHeader(1, 2, slotNumber);
     const payload = new ConsensusPayload(header.toCheckpointHeader(), archive, header.state);
 
@@ -50,7 +49,7 @@ export function describeAttestationPool(getAttestationPool: () => AttestationPoo
 
     const txHashes = [TxHash.random(), TxHash.random()]; // Mock tx hashes
 
-    return new BlockProposalClass(blockNumber, payload, signature, txHashes);
+    return new BlockProposalClass(payload, signature, txHashes);
   };
 
   // We compare buffers as the objects can have cached values attached to them which are not serialised

--- a/yarn-project/p2p/src/mem_pools/attestation_pool/mocks.ts
+++ b/yarn-project/p2p/src/mem_pools/attestation_pool/mocks.ts
@@ -41,5 +41,5 @@ export const mockAttestation = (
   const proposalHash = getHashedSignaturePayloadEthSignedMessage(payload, SignatureDomainSeparator.blockProposal);
   const proposerSignature = signer.sign(proposalHash);
 
-  return new BlockAttestation(header.globalVariables.blockNumber, payload, attestationSignature, proposerSignature);
+  return new BlockAttestation(payload, attestationSignature, proposerSignature);
 };

--- a/yarn-project/p2p/src/msg_validators/attestation_validator/attestation_validator.ts
+++ b/yarn-project/p2p/src/msg_validators/attestation_validator/attestation_validator.ts
@@ -46,6 +46,10 @@ export class AttestationValidator implements P2PValidator<BlockAttestation> {
         this.logger.warn(`No proposer defined for slot ${slotNumberBigInt}`);
         return PeerErrorSeverity.HighToleranceError;
       }
+      if (!proposer) {
+        this.logger.warn(`Invalid proposer signature in attestation for slot ${slotNumberBigInt}`);
+        return PeerErrorSeverity.LowToleranceError;
+      }
       if (!proposer.equals(expectedProposer)) {
         this.logger.warn(
           `Proposer signature mismatch in attestation. ` +

--- a/yarn-project/p2p/src/services/tx_collection/fast_tx_collection.ts
+++ b/yarn-project/p2p/src/services/tx_collection/fast_tx_collection.ts
@@ -55,7 +55,9 @@ export class FastTxCollection {
     }
 
     const blockInfo: L2BlockInfo =
-      input.type === 'proposal' ? input.blockProposal.toBlockInfo() : input.block.toBlockInfo();
+      input.type === 'proposal'
+        ? { ...input.blockProposal.toBlockInfo(), blockNumber: input.blockNumber }
+        : { ...input.block.toBlockInfo() };
 
     // This promise is used to await for the collection to finish during the main collectFast method.
     // It gets resolved in `foundTxs` when all txs have been collected, or rejected if the request is aborted or hits the deadline.

--- a/yarn-project/p2p/src/services/tx_collection/tx_collection.ts
+++ b/yarn-project/p2p/src/services/tx_collection/tx_collection.ts
@@ -25,7 +25,7 @@ export type MissingTxInfo = { blockNumber: number; deadline: Date; readyForReqRe
 
 export type FastCollectionRequestInput =
   | { type: 'block'; block: L2Block }
-  | { type: 'proposal'; blockProposal: BlockProposal };
+  | { type: 'proposal'; blockProposal: BlockProposal; blockNumber: number };
 
 export type FastCollectionRequest = FastCollectionRequestInput & {
   missingTxHashes: Set<string>;
@@ -152,10 +152,11 @@ export class TxCollection {
   /** Collects the set of txs for the given block proposal as fast as possible */
   public collectFastForProposal(
     blockProposal: BlockProposal,
+    blockNumber: number,
     txHashes: TxHash[] | string[],
     opts: { deadline: Date; pinnedPeer?: PeerId },
   ) {
-    return this.collectFastFor({ type: 'proposal', blockProposal }, txHashes, opts);
+    return this.collectFastFor({ type: 'proposal', blockProposal, blockNumber }, txHashes, opts);
   }
 
   /** Collects the set of txs for the given mined block as fast as possible */

--- a/yarn-project/p2p/src/services/tx_provider.test.ts
+++ b/yarn-project/p2p/src/services/tx_provider.test.ts
@@ -37,7 +37,7 @@ describe('TxProvider', () => {
 
   const buildProposal = (txs: Tx[], txHashes: TxHash[]) => {
     const payload = new ConsensusPayload(CheckpointHeader.empty(), Fr.random(), StateReference.empty());
-    return new BlockProposal(1, payload, Signature.empty(), txHashes, txs);
+    return new BlockProposal(payload, Signature.empty(), txHashes, txs);
   };
 
   const setupTxPools = (txsInPool: number, txsOnP2P: number, txs: Tx[]) => {
@@ -74,6 +74,8 @@ describe('TxProvider', () => {
       .sort((a, b) => a.sort - b.sort)
       .map(({ value }) => value);
   };
+
+  const blockNumber = 1;
 
   beforeEach(() => {
     txPools.clear();
@@ -117,7 +119,7 @@ describe('TxProvider', () => {
     const txs = shuffleTxs(original);
     const hashes = await Promise.all(txs.map(tx => tx.getTxHash()));
     const proposal = buildProposal([], hashes);
-    const results = await txProvider.getTxsForBlockProposal(proposal, opts);
+    const results = await txProvider.getTxsForBlockProposal(proposal, blockNumber, opts);
     const expected: TxResults = { txs, missingTxs: [] };
     await checkResults(results, expected);
     expect(txPools.size).toEqual(10);
@@ -132,7 +134,7 @@ describe('TxProvider', () => {
     const hashes = await Promise.all(txs.map(tx => tx.getTxHash()));
 
     const proposal = buildProposal([], hashes);
-    const results = await txProvider.getTxsForBlockProposal(proposal, opts);
+    const results = await txProvider.getTxsForBlockProposal(proposal, blockNumber, opts);
     const expected: TxResults = { txs: txs.slice(0, 5), missingTxs: originalHashes.slice(5) };
     await checkResults(results, expected);
     expect(txPools.size).toEqual(5);
@@ -146,7 +148,7 @@ describe('TxProvider', () => {
     const txs = original;
     const hashes = await Promise.all(txs.map(tx => tx.getTxHash()));
     const proposal = buildProposal([], hashes);
-    const results = await txProvider.getTxsForBlockProposal(proposal, opts);
+    const results = await txProvider.getTxsForBlockProposal(proposal, blockNumber, opts);
     const expected: TxResults = { txs: txs.slice(0, 6), missingTxs: originalHashes.slice(6) };
     await checkResults(results, expected);
     expect(txPools.size).toEqual(6);
@@ -160,7 +162,7 @@ describe('TxProvider', () => {
     const txs = shuffleTxs([...original]);
     const hashes = await Promise.all(txs.map(tx => tx.getTxHash()));
     const proposal = buildProposal(original.slice(6), hashes);
-    const results = await txProvider.getTxsForBlockProposal(proposal, opts);
+    const results = await txProvider.getTxsForBlockProposal(proposal, blockNumber, opts);
     const expected: TxResults = { txs, missingTxs: [] };
     await checkResults(results, expected);
     // all txs should be in the pool
@@ -187,7 +189,7 @@ describe('TxProvider', () => {
     ).map(method => jest.spyOn(txProvider.instrumentation, method));
 
     // Check result is correct
-    const results = await txProvider.getTxsForBlockProposal(proposal, opts);
+    const results = await txProvider.getTxsForBlockProposal(proposal, blockNumber, opts);
     const expected: TxResults = { txs: txs.slice(0, 8), missingTxs: txs.slice(8).map(t => t.txHash) };
     await checkResults(results, expected);
     expect(txPools.size).toEqual(8);
@@ -213,7 +215,7 @@ describe('TxProvider', () => {
     const txs = original;
     const hashes = await Promise.all(txs.map(tx => tx.getTxHash()));
     const proposal = buildProposal(txs.slice(4, 8), hashes);
-    const results = await txProvider.getTxsForBlockProposal(proposal, opts);
+    const results = await txProvider.getTxsForBlockProposal(proposal, blockNumber, opts);
     const expected: TxResults = { txs: txs.slice(0, 8), missingTxs: originalHashes.slice(8) };
     await checkResults(results, expected);
     // all txs should be in the pool
@@ -232,7 +234,7 @@ describe('TxProvider', () => {
 
     // Add additional txs and these should not be added to the pool and not in the results
     const proposal = buildProposal(txs.slice(4, 8).concat(additional), hashes);
-    const results = await txProvider.getTxsForBlockProposal(proposal, opts);
+    const results = await txProvider.getTxsForBlockProposal(proposal, blockNumber, opts);
     const expected: TxResults = { txs: txs.slice(0, 8), missingTxs: originalHashes.slice(8) };
     await checkResults(results, expected);
     // all txs should be in the pool

--- a/yarn-project/p2p/src/services/tx_provider.ts
+++ b/yarn-project/p2p/src/services/tx_provider.ts
@@ -55,11 +55,12 @@ export class TxProvider implements ITxProvider {
   /** Gathers txs from the tx pool, proposal body, remote rpc nodes, and reqresp. */
   public getTxsForBlockProposal(
     blockProposal: BlockProposal,
+    blockNumber: number,
     opts: { pinnedPeer: PeerId | undefined; deadline: Date },
   ): Promise<{ txs: Tx[]; missingTxs: TxHash[] }> {
     return this.getOrderedTxsFromAllSources(
-      { type: 'proposal', blockProposal },
-      blockProposal.toBlockInfo(),
+      { type: 'proposal', blockProposal, blockNumber },
+      { ...blockProposal.toBlockInfo(), blockNumber },
       blockProposal.txHashes,
       { ...opts, pinnedPeer: opts.pinnedPeer },
     );

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
@@ -98,12 +98,7 @@ describe('sequencer', () => {
 
   const getAttestations = () => {
     const consensusPayload = ConsensusPayload.fromBlock(block);
-    const attestation = new BlockAttestation(
-      block.header.globalVariables.blockNumber,
-      consensusPayload,
-      mockedSig,
-      mockedSig,
-    );
+    const attestation = new BlockAttestation(consensusPayload, mockedSig, mockedSig);
     (attestation as any).sender = committee[0];
     return [attestation];
   };
@@ -111,7 +106,7 @@ describe('sequencer', () => {
   const createBlockProposal = () => {
     const consensusPayload = ConsensusPayload.fromBlock(block);
     const txHashes = block.body.txEffects.map(tx => tx.txHash);
-    return new BlockProposal(block.header.globalVariables.blockNumber, consensusPayload, mockedSig, txHashes);
+    return new BlockProposal(consensusPayload, mockedSig, txHashes);
   };
 
   const processTxs = async (txs: Tx[]) => {

--- a/yarn-project/stdlib/src/block/l2_block_source.ts
+++ b/yarn-project/stdlib/src/block/l2_block_source.ts
@@ -1,4 +1,5 @@
 import type { EthAddress } from '@aztec/foundation/eth-address';
+import type { Fr } from '@aztec/foundation/fields';
 import type { TypedEventEmitter } from '@aztec/foundation/types';
 
 import { z } from 'zod';
@@ -67,6 +68,34 @@ export interface L2BlockSource {
   getPublishedBlocks(from: number, limit: number, proven?: boolean): Promise<PublishedL2Block[]>;
 
   /**
+   * Gets a published block by its hash.
+   * @param blockHash - The block hash to retrieve.
+   * @returns The requested published block (or undefined if not found).
+   */
+  getPublishedBlockByHash(blockHash: Fr): Promise<PublishedL2Block | undefined>;
+
+  /**
+   * Gets a published block by its archive root.
+   * @param archive - The archive root to retrieve.
+   * @returns The requested published block (or undefined if not found).
+   */
+  getPublishedBlockByArchive(archive: Fr): Promise<PublishedL2Block | undefined>;
+
+  /**
+   * Gets a block header by its hash.
+   * @param blockHash - The block hash to retrieve.
+   * @returns The requested block header (or undefined if not found).
+   */
+  getBlockHeaderByHash(blockHash: Fr): Promise<BlockHeader | undefined>;
+
+  /**
+   * Gets a block header by its archive root.
+   * @param archive - The archive root to retrieve.
+   * @returns The requested block header (or undefined if not found).
+   */
+  getBlockHeaderByArchive(archive: Fr): Promise<BlockHeader | undefined>;
+
+  /**
    * Gets a tx effect.
    * @param txHash - The hash of the tx corresponding to the tx effect.
    * @returns The requested tx effect with block info (or undefined if not found).
@@ -119,6 +148,9 @@ export interface L2BlockSource {
    * Returns the rollup constants for the current chain.
    */
   getL1Constants(): Promise<L1RollupConstants>;
+
+  /** Returns values for the genesis block */
+  getGenesisValues(): Promise<{ genesisArchiveRoot: Fr }>;
 
   /** Latest synced L1 timestamp. */
   getL1Timestamp(): Promise<bigint>;

--- a/yarn-project/stdlib/src/interfaces/archiver.test.ts
+++ b/yarn-project/stdlib/src/interfaces/archiver.test.ts
@@ -91,6 +91,16 @@ describe('ArchiverApiSchema', () => {
     expect(result).toBeInstanceOf(BlockHeader);
   });
 
+  it('getBlockHeaderByArchive', async () => {
+    const result = await context.client.getBlockHeaderByArchive(Fr.random());
+    expect(result).toBeInstanceOf(BlockHeader);
+  });
+
+  it('getBlockHeaderByHash', async () => {
+    const result = await context.client.getBlockHeaderByHash(Fr.random());
+    expect(result).toBeInstanceOf(BlockHeader);
+  });
+
   it('getBlocks', async () => {
     const result = await context.client.getBlocks(1, 1);
     expect(result).toEqual([expect.any(L2Block)]);
@@ -102,6 +112,22 @@ describe('ArchiverApiSchema', () => {
     expect(response[0].block.constructor.name).toEqual('L2Block');
     expect(response[0].attestations[0]).toBeInstanceOf(CommitteeAttestation);
     expect(response[0].l1).toBeDefined();
+  });
+
+  it('getPublishedBlockByArchive', async () => {
+    const result = await context.client.getPublishedBlockByArchive(Fr.random());
+    expect(result).toBeDefined();
+    expect(result!.block.constructor.name).toEqual('L2Block');
+    expect(result!.attestations[0]).toBeInstanceOf(CommitteeAttestation);
+    expect(result!.l1).toBeDefined();
+  });
+
+  it('getPublishedBlockByHash', async () => {
+    const result = await context.client.getPublishedBlockByHash(Fr.random());
+    expect(result).toBeDefined();
+    expect(result!.block.constructor.name).toEqual('L2Block');
+    expect(result!.attestations[0]).toBeInstanceOf(CommitteeAttestation);
+    expect(result!.l1).toBeDefined();
   });
 
   it('getTxEffect', async () => {
@@ -256,11 +282,19 @@ describe('ArchiverApiSchema', () => {
     const result = await context.client.isPendingChainInvalid();
     expect(result).toBe(false);
   });
+
+  it('getGenesisValues', async () => {
+    const result = await context.client.getGenesisValues();
+    expect(result).toEqual({ genesisArchiveRoot: expect.any(Fr) });
+  });
 });
 
 class MockArchiver implements ArchiverApi {
   constructor(private artifact: ContractArtifact) {}
 
+  getGenesisValues(): Promise<{ genesisArchiveRoot: Fr }> {
+    return Promise.resolve({ genesisArchiveRoot: Fr.random() });
+  }
   isPendingChainInvalid(): Promise<boolean> {
     return Promise.resolve(false);
   }
@@ -299,6 +333,26 @@ class MockArchiver implements ArchiverApi {
         l1: { blockHash: `0x`, blockNumber: 1n, timestamp: 0n },
       }),
     ];
+  }
+  async getPublishedBlockByHash(_blockHash: Fr): Promise<PublishedL2Block | undefined> {
+    return PublishedL2Block.fromFields({
+      block: await L2Block.random(1),
+      attestations: [CommitteeAttestation.random()],
+      l1: { blockHash: `0x`, blockNumber: 1n, timestamp: 0n },
+    });
+  }
+  async getPublishedBlockByArchive(_archive: Fr): Promise<PublishedL2Block | undefined> {
+    return PublishedL2Block.fromFields({
+      block: await L2Block.random(1),
+      attestations: [CommitteeAttestation.random()],
+      l1: { blockHash: `0x`, blockNumber: 1n, timestamp: 0n },
+    });
+  }
+  getBlockHeaderByHash(_blockHash: Fr): Promise<BlockHeader | undefined> {
+    return Promise.resolve(BlockHeader.empty());
+  }
+  getBlockHeaderByArchive(_archive: Fr): Promise<BlockHeader | undefined> {
+    return Promise.resolve(BlockHeader.empty());
   }
   async getTxEffect(_txHash: TxHash): Promise<IndexedTxEffect | undefined> {
     expect(_txHash).toBeInstanceOf(TxHash);

--- a/yarn-project/stdlib/src/interfaces/archiver.ts
+++ b/yarn-project/stdlib/src/interfaces/archiver.ts
@@ -83,6 +83,10 @@ export const ArchiverApiSchema: ApiSchemaFor<ArchiverApi> = {
     .function()
     .args(schemas.Integer, schemas.Integer, optional(z.boolean()))
     .returns(z.array(PublishedL2Block.schema)),
+  getPublishedBlockByHash: z.function().args(schemas.Fr).returns(PublishedL2Block.schema.optional()),
+  getPublishedBlockByArchive: z.function().args(schemas.Fr).returns(PublishedL2Block.schema.optional()),
+  getBlockHeaderByHash: z.function().args(schemas.Fr).returns(BlockHeader.schema.optional()),
+  getBlockHeaderByArchive: z.function().args(schemas.Fr).returns(BlockHeader.schema.optional()),
   getTxEffect: z.function().args(TxHash.schema).returns(indexedTxSchema().optional()),
   getSettledTxReceipt: z.function().args(TxHash.schema).returns(TxReceipt.schema.optional()),
   getL2SlotNumber: z.function().args().returns(schemas.BigInt),
@@ -110,6 +114,10 @@ export const ArchiverApiSchema: ApiSchemaFor<ArchiverApi> = {
   getL1ToL2MessageIndex: z.function().args(schemas.Fr).returns(schemas.BigInt.optional()),
   getDebugFunctionName: z.function().args(schemas.AztecAddress, schemas.FunctionSelector).returns(optional(z.string())),
   getL1Constants: z.function().args().returns(L1RollupConstantsSchema),
+  getGenesisValues: z
+    .function()
+    .args()
+    .returns(z.object({ genesisArchiveRoot: schemas.Fr })),
   getL1Timestamp: z.function().args().returns(schemas.BigInt),
   syncImmediate: z.function().args().returns(z.void()),
   isPendingChainInvalid: z.function().args().returns(z.boolean()),

--- a/yarn-project/stdlib/src/interfaces/aztec-node.test.ts
+++ b/yarn-project/stdlib/src/interfaces/aztec-node.test.ts
@@ -175,6 +175,26 @@ describe('AztecNodeApiSchema', () => {
     expect(response).toBeInstanceOf(L2Block);
   });
 
+  it('getBlockByHash', async () => {
+    const response = await context.client.getBlockByHash(Fr.random());
+    expect(response).toBeInstanceOf(L2Block);
+  });
+
+  it('getBlockByArchive', async () => {
+    const response = await context.client.getBlockByArchive(Fr.random());
+    expect(response).toBeInstanceOf(L2Block);
+  });
+
+  it('getBlockHeaderByHash', async () => {
+    const response = await context.client.getBlockHeaderByHash(Fr.random());
+    expect(response).toBeInstanceOf(BlockHeader);
+  });
+
+  it('getBlockHeaderByArchive', async () => {
+    const response = await context.client.getBlockHeaderByArchive(Fr.random());
+    expect(response).toBeInstanceOf(BlockHeader);
+  });
+
   it('getCurrentBaseFees', async () => {
     const response = await context.client.getCurrentBaseFees();
     expect(response).toEqual(GasFees.empty());
@@ -590,6 +610,18 @@ class MockAztecNode implements AztecNode {
   }
   getBlock(number: number): Promise<L2Block | undefined> {
     return Promise.resolve(L2Block.random(number));
+  }
+  getBlockByHash(_blockHash: Fr): Promise<L2Block | undefined> {
+    return Promise.resolve(L2Block.random(1));
+  }
+  getBlockByArchive(_archive: Fr): Promise<L2Block | undefined> {
+    return Promise.resolve(L2Block.random(1));
+  }
+  getBlockHeaderByHash(_blockHash: Fr): Promise<BlockHeader | undefined> {
+    return Promise.resolve(BlockHeader.empty());
+  }
+  getBlockHeaderByArchive(_archive: Fr): Promise<BlockHeader | undefined> {
+    return Promise.resolve(BlockHeader.empty());
   }
   getCurrentBaseFees(): Promise<GasFees> {
     return Promise.resolve(GasFees.empty());

--- a/yarn-project/stdlib/src/interfaces/aztec-node.ts
+++ b/yarn-project/stdlib/src/interfaces/aztec-node.ts
@@ -226,6 +226,20 @@ export interface AztecNode
   getBlock(number: L2BlockNumber): Promise<L2Block | undefined>;
 
   /**
+   * Get a block specified by its hash.
+   * @param blockHash - The block hash being requested.
+   * @returns The requested block.
+   */
+  getBlockByHash(blockHash: Fr): Promise<L2Block | undefined>;
+
+  /**
+   * Get a block specified by its archive root.
+   * @param archive - The archive root being requested.
+   * @returns The requested block.
+   */
+  getBlockByArchive(archive: Fr): Promise<L2Block | undefined>;
+
+  /**
    * Method to fetch the latest block number synchronized by the node.
    * @returns The block number.
    */
@@ -400,6 +414,20 @@ export interface AztecNode
    */
   getBlockHeader(blockNumber?: L2BlockNumber): Promise<BlockHeader | undefined>;
 
+  /**
+   * Get a block header specified by its hash.
+   * @param blockHash - The block hash being requested.
+   * @returns The requested block header.
+   */
+  getBlockHeaderByHash(blockHash: Fr): Promise<BlockHeader | undefined>;
+
+  /**
+   * Get a block header specified by its archive root.
+   * @param archive - The archive root being requested.
+   * @returns The requested block header.
+   */
+  getBlockHeaderByArchive(archive: Fr): Promise<BlockHeader | undefined>;
+
   /** Returns stats for validators if enabled. */
   getValidatorsStats(): Promise<ValidatorsStats>;
 
@@ -523,6 +551,10 @@ export const AztecNodeApiSchema: ApiSchemaFor<AztecNode> = {
 
   getBlock: z.function().args(L2BlockNumberSchema).returns(L2Block.schema.optional()),
 
+  getBlockByHash: z.function().args(schemas.Fr).returns(L2Block.schema.optional()),
+
+  getBlockByArchive: z.function().args(schemas.Fr).returns(L2Block.schema.optional()),
+
   getBlockNumber: z.function().returns(z.number()),
 
   getProvenBlockNumber: z.function().returns(z.number()),
@@ -595,6 +627,10 @@ export const AztecNodeApiSchema: ApiSchemaFor<AztecNode> = {
   getPublicStorageAt: z.function().args(L2BlockNumberSchema, schemas.AztecAddress, schemas.Fr).returns(schemas.Fr),
 
   getBlockHeader: z.function().args(optional(L2BlockNumberSchema)).returns(BlockHeader.schema.optional()),
+
+  getBlockHeaderByHash: z.function().args(schemas.Fr).returns(BlockHeader.schema.optional()),
+
+  getBlockHeaderByArchive: z.function().args(schemas.Fr).returns(BlockHeader.schema.optional()),
 
   getValidatorsStats: z.function().returns(ValidatorsStatsSchema),
 

--- a/yarn-project/stdlib/src/interfaces/tx_provider.ts
+++ b/yarn-project/stdlib/src/interfaces/tx_provider.ts
@@ -9,6 +9,7 @@ export interface ITxProvider {
 
   getTxsForBlockProposal(
     blockProposal: BlockProposal,
+    blockNumber: number,
     opts: { pinnedPeer: PeerId | undefined; deadline: Date },
   ): Promise<{ txs: Tx[]; missingTxs: TxHash[] }>;
 

--- a/yarn-project/stdlib/src/p2p/block_proposal.test.ts
+++ b/yarn-project/stdlib/src/p2p/block_proposal.test.ts
@@ -11,17 +11,16 @@ import { ConsensusPayload } from './consensus_payload.js';
 
 class BackwardsCompatibleBlockProposal extends BlockProposal {
   constructor(payload: ConsensusPayload, signature: Signature) {
-    super(1, payload, signature, [], undefined);
+    super(payload, signature, [], undefined);
   }
 
   oldToBuffer(): Buffer {
-    return serializeToBuffer([this.blockNumber, this.payload, this.signature, 0, []]);
+    return serializeToBuffer([this.payload, this.signature, 0, []]);
   }
 
   static oldFromBuffer(buf: Buffer | BufferReader): BlockProposal {
     const reader = BufferReader.asReader(buf);
     return new BlockProposal(
-      reader.readNumber(),
       reader.readObject(ConsensusPayload),
       reader.readObject(Signature),
       reader.readArray(0, TxHash),

--- a/yarn-project/stdlib/src/tests/mocks.ts
+++ b/yarn-project/stdlib/src/tests/mocks.ts
@@ -270,12 +270,9 @@ export const makeAndSignCommitteeAttestationsAndSigners = (
 };
 
 export const makeBlockProposal = (options?: MakeConsensusPayloadOptions): BlockProposal => {
-  const { blockNumber, payload, signature } = makeAndSignConsensusPayload(
-    SignatureDomainSeparator.blockProposal,
-    options,
-  );
+  const { payload, signature } = makeAndSignConsensusPayload(SignatureDomainSeparator.blockProposal, options);
   const txHashes = options?.txHashes ?? [0, 1, 2, 3, 4, 5].map(() => TxHash.random());
-  return new BlockProposal(blockNumber, payload, signature, txHashes, options?.txs ?? []);
+  return new BlockProposal(payload, signature, txHashes, options?.txs ?? []);
 };
 
 // TODO(https://github.com/AztecProtocol/aztec-packages/issues/8028)
@@ -303,7 +300,7 @@ export const makeBlockAttestation = (options?: MakeConsensusPayloadOptions): Blo
   const proposalHash = getHashedSignaturePayloadEthSignedMessage(payload, SignatureDomainSeparator.blockProposal);
   const proposerSignature = proposerSigner.sign(proposalHash);
 
-  return new BlockAttestation(header.globalVariables.blockNumber, payload, attestationSignature, proposerSignature);
+  return new BlockAttestation(payload, attestationSignature, proposerSignature);
 };
 
 export const makeBlockAttestationFromBlock = (
@@ -331,7 +328,7 @@ export const makeBlockAttestationFromBlock = (
   const proposalSignerToUse = proposerSigner ?? Secp256k1Signer.random();
   const proposerSignature = proposalSignerToUse.sign(proposalHash);
 
-  return new BlockAttestation(header.globalVariables.blockNumber, payload, attestationSignature, proposerSignature);
+  return new BlockAttestation(payload, attestationSignature, proposerSignature);
 };
 
 export async function randomPublishedL2Block(

--- a/yarn-project/txe/src/state_machine/archiver.ts
+++ b/yarn-project/txe/src/state_machine/archiver.ts
@@ -1,5 +1,7 @@
 import { ArchiverStoreHelper, KVArchiverDataStore, type PublishedL2Block } from '@aztec/archiver';
+import { GENESIS_ARCHIVE_ROOT } from '@aztec/constants';
 import type { EthAddress } from '@aztec/foundation/eth-address';
+import { Fr } from '@aztec/foundation/fields';
 import type { AztecAsyncKVStore } from '@aztec/kv-store';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
 import type { L2Block, L2BlockSource, L2Tips, ValidateBlockResult } from '@aztec/stdlib/block';
@@ -113,6 +115,10 @@ export class TXEArchiver extends ArchiverStoreHelper implements L2BlockSource {
 
   public getL1Constants(): Promise<L1RollupConstants> {
     throw new Error('TXE Archiver does not implement "getL2Constants"');
+  }
+
+  public getGenesisValues(): Promise<{ genesisArchiveRoot: Fr }> {
+    return Promise.resolve({ genesisArchiveRoot: new Fr(GENESIS_ARCHIVE_ROOT) });
   }
 
   public syncImmediate(): Promise<void> {

--- a/yarn-project/validator-client/src/duties/validation_service.test.ts
+++ b/yarn-project/validator-client/src/duties/validation_service.test.ts
@@ -25,20 +25,11 @@ describe('ValidationService', () => {
   it('creates a proposal with txs appended', async () => {
     const txs = await Promise.all([Tx.random(), Tx.random()]);
     const {
-      blockNumber,
       payload: { header, archive, stateReference },
     } = makeBlockProposal({ txs });
-    const proposal = await service.createBlockProposal(
-      blockNumber,
-      header,
-      archive,
-      stateReference,
-      txs,
-      addresses[0],
-      {
-        publishFullTxs: true,
-      },
-    );
+    const proposal = await service.createBlockProposal(header, archive, stateReference, txs, addresses[0], {
+      publishFullTxs: true,
+    });
     expect(proposal.getSender()).toEqual(store.getAddress(0));
     expect(proposal.txs).toBeDefined();
     expect(proposal.txs).toBe(txs);
@@ -47,20 +38,11 @@ describe('ValidationService', () => {
   it('creates a proposal without txs appended', async () => {
     const txs = await Promise.all([Tx.random(), Tx.random()]);
     const {
-      blockNumber,
       payload: { header, archive, stateReference },
     } = makeBlockProposal({ txs });
-    const proposal = await service.createBlockProposal(
-      blockNumber,
-      header,
-      archive,
-      stateReference,
-      txs,
-      addresses[0],
-      {
-        publishFullTxs: false,
-      },
-    );
+    const proposal = await service.createBlockProposal(header, archive, stateReference, txs, addresses[0], {
+      publishFullTxs: false,
+    });
     expect(proposal.getSender()).toEqual(addresses[0]);
     expect(proposal.txs).toBeUndefined();
   });

--- a/yarn-project/validator-client/src/duties/validation_service.ts
+++ b/yarn-project/validator-client/src/duties/validation_service.ts
@@ -28,7 +28,6 @@ export class ValidationService {
   /**
    * Create a block proposal with the given header, archive, and transactions
    *
-   * @param blockNumber - The block number this proposal is for
    * @param header - The block header
    * @param archive - The archive of the current block
    * @param txs - TxHash[] ordered list of transactions
@@ -37,7 +36,6 @@ export class ValidationService {
    * @returns A block proposal signing the above information (not the current implementation!!!)
    */
   async createBlockProposal(
-    blockNumber: number,
     header: CheckpointHeader,
     archive: Fr,
     stateReference: StateReference,
@@ -59,11 +57,10 @@ export class ValidationService {
     // For testing: corrupt the state reference to trigger state_mismatch validation failure
     if (options.broadcastInvalidBlockProposal) {
       unfreeze(stateReference.partial).noteHashTree = AppendOnlyTreeSnapshot.random();
-      this.log.warn(`Creating INVALID block proposal for block ${blockNumber} at slot ${header.slotNumber.toBigInt()}`);
+      this.log.warn(`Creating INVALID block proposal for slot ${header.slotNumber.toBigInt()}`);
     }
 
     return BlockProposal.createProposalFromSigner(
-      blockNumber,
       new ConsensusPayload(header, archive, stateReference),
       txHashes,
       options.publishFullTxs ? txs : undefined,
@@ -88,7 +85,7 @@ export class ValidationService {
     const signatures = await Promise.all(
       attestors.map(attestor => this.keyStore.signMessageWithAddress(attestor, buf)),
     );
-    return signatures.map(sig => new BlockAttestation(proposal.blockNumber, proposal.payload, sig, proposal.signature));
+    return signatures.map(sig => new BlockAttestation(proposal.payload, sig, proposal.signature));
   }
 
   async signAttestationsAndSigners(


### PR DESCRIPTION
Block number was NOT being signed over, this meant any node could tweak it and cause receiving nodes to consider the proposal incorrect. We fix this by fetching the parent node using the last archive root (which required adding new indices to the archiver) and computing the block number by adding one to it.

As for attestations, the block number was not used at all, so we could remove it.

Fixes A-128