### PR TITLE
fix: allow mixing of network and custom network settings

### DIFF
--- a/.github/workflows/test-network-scenarios.yml
+++ b/.github/workflows/test-network-scenarios.yml
@@ -114,7 +114,7 @@ jobs:
           mkdir -p ~/.ssh
           echo ${{ secrets.BUILD_INSTANCE_SSH_KEY }} | base64 --decode > ~/.ssh/build_instance_key
           chmod 600 ~/.ssh/build_instance_key
-          sudo apt install -y --no-install-recommends redis-tools parallel
+          sudo apt update && sudo apt install -y --no-install-recommends redis-tools parallel
 
       - name: Store the GCP key in a file
         if: env.SEMVER != '' || env.DOCKER_IMAGE != ''

--- a/spartan/aztec-node/templates/_pod-template.yaml
+++ b/spartan/aztec-node/templates/_pod-template.yaml
@@ -137,16 +137,23 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        {{- if .Values.global.customAztecNetwork.enabled }}
+        {{- if .Values.global.customAztecNetwork.l1ChainId }}
         - name: L1_CHAIN_ID
           value: "{{ .Values.global.customAztecNetwork.l1ChainId }}"
+        {{- end }}
+        {{- if .Values.global.customAztecNetwork.registryContractAddress }}
         - name: REGISTRY_CONTRACT_ADDRESS
           value: "{{ .Values.global.customAztecNetwork.registryContractAddress }}"
+        {{- end }}
+        {{- if .Values.global.customAztecNetwork.slashFactoryContractAddress }}
         - name: SLASH_FACTORY_CONTRACT_ADDRESS
           value: "{{ .Values.global.customAztecNetwork.slashFactoryContractAddress }}"
+        {{- end }}
+        {{- if .Values.global.customAztecNetwork.feeAssetHandlerContractAddress }}
         - name: FEE_ASSET_HANDLER_CONTRACT_ADDRESS
           value: "{{ .Values.global.customAztecNetwork.feeAssetHandlerContractAddress }}"
-        {{- else if .Values.global.aztecNetwork }}
+        {{- end }}
+        {{- if .Values.global.aztecNetwork }}
         - name: NETWORK
           value: "{{ .Values.global.aztecNetwork }}"
         {{- end }}

--- a/spartan/aztec-node/values.yaml
+++ b/spartan/aztec-node/values.yaml
@@ -17,7 +17,6 @@ global:
   aztecNetwork: ""
   # -- Custom network - (not recommended) - Only for custom testnet usecases, (must have deployed your own protocol contracts first)
   customAztecNetwork:
-    enabled: false
     l1ChainId:
     registryContractAddress:
     slashFactoryContractAddress:

--- a/spartan/terraform/deploy-aztec-infra/main.tf
+++ b/spartan/terraform/deploy-aztec-infra/main.tf
@@ -73,7 +73,6 @@ locals {
     "global.aztecImage.repository"                             = local.aztec_image.repository
     "global.aztecImage.tag"                                    = local.aztec_image.tag
     "global.useGcloudLogging"                                  = true
-    "global.customAztecNetwork.enabled"                        = var.NETWORK == null || var.NETWORK == ""
     "global.aztecNetwork"                                      = var.NETWORK
     "global.customAztecNetwork.registryContractAddress"        = var.REGISTRY_CONTRACT_ADDRESS
     "global.customAztecNetwork.slashFactoryContractAddress"    = var.SLASH_FACTORY_CONTRACT_ADDRESS


### PR DESCRIPTION
For next-net we were mixing the `NETWORK` env var with some custom settings. The chart did not allow that (it read either `network` or `customNetwork`) and this PR merges the two settings