### PR TITLE
fix: biggroup `batch_mul` fixes and cleanup

### DIFF
--- a/barretenberg/cpp/scripts/test_chonk_standalone_vks_havent_changed.sh
+++ b/barretenberg/cpp/scripts/test_chonk_standalone_vks_havent_changed.sh
@@ -13,7 +13,7 @@ cd ..
 # - Generate a hash for versioning: sha256sum bb-chonk-inputs.tar.gz
 # - Upload the compressed results: aws s3 cp bb-chonk-inputs.tar.gz s3://aztec-ci-artifacts/protocol/bb-chonk-inputs-[hash(0:8)].tar.gz
 # Note: In case of the "Test suite failed to run ... Unexpected token 'with' " error, need to run: docker pull aztecprotocol/build:3.0
-pinned_short_hash="07b5558d"
+pinned_short_hash="fde8277f"
 pinned_chonk_inputs_url="https://aztec-ci-artifacts.s3.us-east-2.amazonaws.com/protocol/bb-chonk-inputs-${pinned_short_hash}.tar.gz"
 
 function compress_and_upload {

--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/kzg/kzg.hpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/kzg/kzg.hpp
@@ -127,6 +127,9 @@ template <typename Curve_> class KZG {
     {
         auto quotient_commitment = transcript->template receive_from_prover<Commitment>("KZG:W");
 
+        // This challenge is used to compute offset generators in the batch_mul call below
+        const Fr masking_challenge = transcript->template get_challenge<Fr>("KZG:masking_challenge");
+
         // The pairing check can be expressed as
         // e(C + [W]₁ ⋅ z, [1]₂) * e(−[W]₁, [X]₂) = 1, where C = ∑ commitmentsᵢ ⋅ scalarsᵢ.
         GroupElement P_0;
@@ -139,7 +142,8 @@ template <typename Curve_> class KZG {
             P_0 = GroupElement::batch_mul(batch_opening_claim.commitments,
                                           batch_opening_claim.scalars,
                                           /*max_num_bits=*/0,
-                                          /*with_edgecases=*/true);
+                                          /*with_edgecases=*/true,
+                                          /*masking_scalar=*/masking_challenge);
         } else {
             P_0 = batch_mul_native(batch_opening_claim.commitments, batch_opening_claim.scalars);
         }

--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/kzg/kzg.hpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/kzg/kzg.hpp
@@ -62,6 +62,10 @@ template <typename Curve_> class KZG {
         // future we might need to adjust this to use the incoming alternative to work queue (i.e. variation of
         // pthreads) or even the work queue itself
         prover_trancript->send_to_verifier("KZG:W", quotient_commitment);
+
+        // Masking challenge is used in the recursive setting to perform batch_mul. This is not used
+        // by the prover directly, we just need it for consistent transcript state with the verifier.
+        prover_trancript->template get_challenge<Fr>("KZG:masking_challenge");
     };
 
     /**

--- a/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/ultra_recursive_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/ultra_recursive_verifier.test.cpp
@@ -293,7 +293,7 @@ template <typename RecursiveFlavor> class RecursiveVerifierTest : public testing
         }
         // Check the size of the recursive verifier
         if constexpr (std::same_as<RecursiveFlavor, MegaZKRecursiveFlavor_<UltraCircuitBuilder>>) {
-            uint32_t NUM_GATES_EXPECTED = 808534;
+            uint32_t NUM_GATES_EXPECTED = 859706;
             ASSERT_EQ(static_cast<uint32_t>(outer_circuit.get_num_finalized_gates()), NUM_GATES_EXPECTED)
                 << "MegaZKHonk Recursive verifier changed in Ultra gate count! Update this value if you "
                    "are sure this is expected.";

--- a/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/ultra_recursive_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/ultra_recursive_verifier.test.cpp
@@ -293,7 +293,7 @@ template <typename RecursiveFlavor> class RecursiveVerifierTest : public testing
         }
         // Check the size of the recursive verifier
         if constexpr (std::same_as<RecursiveFlavor, MegaZKRecursiveFlavor_<UltraCircuitBuilder>>) {
-            uint32_t NUM_GATES_EXPECTED = 859706;
+            uint32_t NUM_GATES_EXPECTED = 857654;
             ASSERT_EQ(static_cast<uint32_t>(outer_circuit.get_num_finalized_gates()), NUM_GATES_EXPECTED)
                 << "MegaZKHonk Recursive verifier changed in Ultra gate count! Update this value if you "
                    "are sure this is expected.";

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/README.md
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/README.md
@@ -488,17 +488,19 @@ R &= 2 \cdot \textcolor{violet}{Q_{1}} + \textcolor{violet}{Q_{2}} =
 \end{aligned}
 $$
 
-Our Montmogomery ladder implementation requires that the two points being added have distinct $x$-coordinates, which is not the case here since $\textcolor{violet}{Q_{2}} = -\textcolor{violet}{Q_{1}}$. So an honest prover would fail to generate a valid proof. To prevent this, we can add a random multiple of the generator point to the first column output before adding it to the accumulator:
+Our Montmogomery ladder implementation requires that the two points being added have distinct $x$-coordinates, which is not the case here since $\textcolor{violet}{Q_{2}} = -\textcolor{violet}{Q_{1}}$. So an honest prover would fail to generate a valid proof. To prevent this, we can add a random offset generator to the first column output before adding it to the accumulator:
 
 $$
 \begin{aligned}
-R &= 2 \cdot (\textcolor{violet}{Q_{1}} + \delta \cdot \textcolor{olive}{G}) + \textcolor{violet}{Q_{2}} \\
+R &= 2 \cdot (\textcolor{violet}{Q_{1}} + \windex{G_{\textsf{offset}}}) + \textcolor{violet}{Q_{2}} \\
 \end{aligned}
 $$
 
-Here, $\delta$ is a verifier-chosen random scalar in $\mathbb{F}_r$. This randomization ensures that the two points being added have distinct $x$-coordinates during the addition operation in the Montgomery ladder. We choose the same random scalar $\delta$ that was used for randomizing the input points to avoid the overhead of computing $\delta' \cdot \textcolor{olive}{G}$ in the circuit if $\delta' \neq \delta$.
+Adding this offset generator ensures that the two points being added have distinct $x$-coordinates during the addition operation in the Montgomery ladder.
 
-Effectively, the modified MSM computation becomes:
+> Note that we do not choose the offset generator to be dependent on the random scalar $\delta$ used for point randomization. This is safe when we are masking the points with random multiples of the generator, as a malicious prover cannot control the randomization applied to the masked points. However, this could be a vulnerability if the input points were not masked, as a malicious prover could potentially exploit knowledge of the offset generator to create points at infinity. In our usage of the `batch_mul` implementation in the recursive circuit, we always mask the input points, so using a fixed offset generator is secure. When using `scalar_mul` to aggregate pairing points in the recursive verifier, we do not apply masking to the input point. However, since the pairing points themselves are derived using verifier-chosen randomness, there is no risk of a malicious prover exploiting the offset generator in this context.
+
+In summary, the modified MSM computation becomes:
 
 $$
 \begin{aligned}
@@ -515,8 +517,8 @@ $$
 A &= \sum_{j=1}^{m+1} \left( -\mathfrak{s}_{j} + \sum_{i=0}^{n-1} \windex{2^{i}} \cdot a_{j, n-1-i} \right) \cdot \textcolor{olive}{P'_j} \\
 &= \sum_{j=1}^{m+1} \left( \sum_{i=0}^{n-1} \windex{2^{i}} \cdot a_{j, n-1-i} \right) \cdot \textcolor{olive}{P'_j} - \sum_{j=1}^{m+1} \mathfrak{s}_{j} \cdot \textcolor{olive}{P'_j} \\
 &= \windex{2^{n - 1}} \cdot \underbrace{\left(\sum_{j=1}^{m+1}  a_{j, 0} \cdot \textcolor{olive}{P'_j}\right)}_{=: \ \textcolor{violet}{Q_1}} + \sum_{i=1}^{n-1} \windex{2^{i}} \cdot \underbrace{\left( \sum_{j=1}^{m+1} a_{j, n-1-i} \cdot \textcolor{olive}{P'_j} \right)}_{\textcolor{violet}{Q_i}} - \sum_{j=1}^{m+1} \mathfrak{s}_{j} \cdot \textcolor{olive}{P'_j} \\
-&= \windex{2^{n-1}} \cdot \left( \textcolor{violet}{Q_1} + \textcolor{olive}{\delta G} \right) - \windex{2^{n-1}} \cdot \textcolor{olive}{\delta G} + \left(\sum_{i=1}^{n-1} \windex{2^{i}} \cdot \textcolor{violet}{Q_i}\right) - \left(\sum_{j=1}^{m+1} \mathfrak{s}_{j} \cdot \textcolor{olive}{P'_j}\right). \\
+&= \windex{2^{n-1}} \cdot \left( \textcolor{violet}{Q_1} + \windex{G_{\textsf{offset}}} \right) - \windex{2^{n-1}} \cdot \windex{G_{\textsf{offset}}} + \left(\sum_{i=1}^{n-1} \windex{2^{i}} \cdot \textcolor{violet}{Q_i}\right) - \left(\sum_{j=1}^{m+1} \mathfrak{s}_{j} \cdot \textcolor{olive}{P'_j}\right). \\
 \end{aligned}
 $$
 
-Thus, we need to subtract the term $\windex{2^{n-1}} \cdot \textcolor{olive}{\delta G}$ from the final MSM result to account for the randomization added during the accumulation of NAF column outputs. This ensures that the final MSM result is correct and unaffected by the randomization used to prevent points at infinity during intermediate computations.
+Thus, we need to subtract the term $\windex{2^{n-1}} \cdot \windex{G_{\textsf{offset}}}$ from the final MSM result to account for the offset generator added to the first NAF column output. This ensures that the final MSM result is correct and unaffected by the offset generator used to prevent points at infinity during intermediate computations.

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/README.md
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/README.md
@@ -305,3 +305,218 @@ a &= -\mathfrak{s}_a + \sum_{i=0}^{n-1} (1 - 2 \cdot a'_{i+1}) \cdot \windex{2^{
 $$
 
 Note that the positive and negative parts are both non-negative and can be computed in a circuit without any conditional logic.
+
+### Strauss MSM with NAF
+
+Given scalars $a_1, a_2, \dots, a_m \in \mathbb{F}_r$ and group elements $P_1, P_2, \dots, P_m \in \mathbb{G}$, the multi-scalar multiplication (MSM) is defined as:
+
+$$
+A = \sum_{j=1}^{m} a_j \cdot P_j
+$$
+
+In the Strauss MSM algorithm using NAF representation, we decompose each scalar $a_j$ into its NAF slices as follows:
+
+$$
+\begin{aligned}
+a_j &= -\mathfrak{s}_j + \sum_{i=0}^{n-1} a_{j,n-1-i} \cdot \windex{2^{i}} \\
+\end{aligned}
+$$
+
+where $a_{j,n-1-i} \in \{-1, 1\}$ are the NAF slices for scalar $a_j$ and $\mathfrak{s}_j \in \{0, 1\}$ is the skew factor for $a_j$. Note that $a_{j, 0}$ is the most-significant NAF slice. Let us draw a table of the NAF slices for all scalars along with the generator points:
+
+$$
+\begin{aligned}
+\def\arraystretch{2}
+\def\arraycolsep{40pt}
+   \begin{array}{|c||c:c:c:c||c:c:c:c|}
+   \hline
+    \textcolor{olive}{P_1} & a_{1,0} & a_{1,1} & a_{1,2} & a_{1,3} & a_{1, 4} & \cdots & a_{1,n-2} & a_{1,n-1} \\ \hline
+    \textcolor{olive}{P_2} & a_{2,0} & a_{2,1} & a_{2,2} & a_{2,3} & a_{2, 4} & \cdots & a_{2,n-2} & a_{2,n-1} \\ \hline
+    \textcolor{olive}{P_3} & a_{3,0} & a_{3,1} & a_{3,2} & a_{3,3} & a_{3, 4} & \cdots & a_{3,n-2} & a_{3,n-1} \\ \hline
+    \textcolor{olive}{P_4} & a_{4,0} & a_{4,1} & a_{4,2} & a_{4,3} & a_{4, 4} & \cdots & a_{4,n-2} & a_{4,n-1} \\ \hline
+    \textcolor{olive}{P_5} & a_{5,0} & a_{5,1} & a_{5,2} & a_{5,3} & a_{5, 4} & \cdots & a_{5,n-2} & a_{5,n-1} \\ \hline
+    \vdots & \vdots & \vdots & \vdots & \vdots & \vdots & \qquad \ddots \qquad  & \vdots & \vdots \\ \hline
+    \textcolor{olive}{P_m} & a_{m,0} & a_{m,1} & a_{m,2} & a_{m,3} & a_{m, 4} & \cdots &  a_{m,n-2} & a_{m,n-1} \\
+    \hline
+\end{array}
+\end{aligned}
+$$
+
+We group the generator points in sizes of 5 points each (the last group can have less than 5 points). We sometimes use 6 points per group if the net number of tables can be reduced for optimization purposes. In this case, for the first 5 points, we compute the following ROM lookup table:
+
+$$
+\begin{aligned}
+\def\arraystretch{2}
+\def\arraycolsep{40pt}
+   \begin{array}{|c||c|}
+   \hline
+    \textsf{Index} & \textsf{Group Element} \\ \hline \hline
+    0 & \textcolor{olive}{P_1} + \textcolor{olive}{P_2} + \textcolor{olive}{P_3} + \textcolor{olive}{P_4} + \textcolor{olive}{P_5} \\ \hline
+    1 & \textcolor{olive}{P_1} + \textcolor{olive}{P_2} + \textcolor{olive}{P_3} + \textcolor{olive}{P_4} - \textcolor{olive}{P_5} \\ \hline
+    2 & \textcolor{olive}{P_1} + \textcolor{olive}{P_2} + \textcolor{olive}{P_3} - \textcolor{olive}{P_4} - \textcolor{olive}{P_5} \\ \hline
+    \vdots & \vdots \\ \hline
+    15 & \textcolor{olive}{P_1} - \textcolor{olive}{P_2} - \textcolor{olive}{P_3} - \textcolor{olive}{P_4} - \textcolor{olive}{P_5} \\ \hline
+    16 & -\textcolor{olive}{P_1} + \textcolor{olive}{P_2} + \textcolor{olive}{P_3} + \textcolor{olive}{P_4} + \textcolor{olive}{P_5} \\ \hline
+    17 & -\textcolor{olive}{P_1} + \textcolor{olive}{P_2} + \textcolor{olive}{P_3} + \textcolor{olive}{P_4} - \textcolor{olive}{P_5} \\ \hline
+    \vdots & \vdots \\ \hline
+    31 & -\textcolor{olive}{P_1} - \textcolor{olive}{P_2} - \textcolor{olive}{P_3} - \textcolor{olive}{P_4} - \textcolor{olive}{P_5} \\ \hline
+\end{array}
+\end{aligned}
+$$
+
+Going back to the NAF slice table, we can see that each column (i.e., each NAF slice index) corresponds to one of the entries in the above ROM table. For instance, the first column corresponds to the group element selected from the ROM table based on the signs of $a_{1,0}, a_{2,0}, a_{3,0}, a_{4,0}, a_{5,0}$. For example, since the first column always has values $(1, 1, 1, 1, 1)$, then we select the group element $(\textcolor{olive}{P_1} + \textcolor{olive}{P_2} + \textcolor{olive}{P_3} + \textcolor{olive}{P_4} + \textcolor{olive}{P_5})$ from the ROM table (which corresponds to index 0). We do this for all groups of 5 points in a given column and sum the selected group elements to get the total group element for that NAF slice column.
+
+$$
+\begin{aligned}
+\def\arraystretch{1.6}
+\begin{array}{c}
+\begin{array}{|c||c|}
+\hline
+\textcolor{olive}{P_1} & a_{1,i} \\ \hline
+\textcolor{olive}{P_2} & a_{2,i} \\ \hline
+\textcolor{olive}{P_3} & a_{3,i} \\ \hline
+\textcolor{olive}{P_4} & a_{4,i} \\ \hline
+\textcolor{olive}{P_5} & a_{5,i} \\ \hline
+\end{array}
+\left.
+\begin{array}{c}
+\\ \\ \\ \\ \\
+\end{array}
+\right\} \xrightarrow{\text{lookup from ROM table 1}} \ \textcolor{orange}{Q_{i,1}}
+\end{array}
+\\
+\def\arraystretch{1.6}
+\begin{array}{c}
+\begin{array}{|c||c|}
+\hline
+\textcolor{olive}{P_6} & a_{6,i} \\ \hline
+\textcolor{olive}{P_7} & a_{7,i} \\ \hline
+\textcolor{olive}{P_8} & a_{8,i} \\ \hline
+\textcolor{olive}{P_9} & a_{9,i} \\ \hline
+\textcolor{olive}{P_{10}} & a_{10,i} \\ \hline
+\end{array}
+\left.
+\begin{array}{c}
+\\ \\ \\ \\ \\
+\end{array}
+\right\} \xrightarrow{\text{lookup from ROM table 2}} \ \textcolor{orange}{Q_{i,2}}
+\end{array}
+\\
+\vdots \\
+\def\arraystretch{1.6}
+\begin{array}{c}
+\begin{array}{|c||c|}
+\hline
+\textcolor{olive}{P_{m-2}} & a_{m-2,i} \\ \hline
+\textcolor{olive}{P_{m-1}} & a_{m-1,i} \\ \hline
+\textcolor{olive}{P_{m}} & a_{m,i} \\ \hline
+\end{array}
+\left.
+\begin{array}{c}
+\\ \\ \\
+\end{array}
+\right\} \xrightarrow{\text{lookup from ROM table k}} \ \textcolor{orange}{Q_{i,k}}
+\end{array}
+\end{aligned}
+$$
+
+Here, $\textcolor{orange}{Q_{i,1}}, \textcolor{orange}{Q_{i,2}}, \dots, \textcolor{orange}{Q_{i,k}}$ are the selected group elements from each ROM table for the $i^{th}$ NAF slice column. We then sum these group elements to get the total group element for the $i^{th}$ NAF slice column:
+
+$$
+\textcolor{violet}{Q_{i}} = \textcolor{orange}{Q_{i,1}} + \textcolor{orange}{Q_{i,2}} + \dots + \textcolor{orange}{Q_{i,k}}
+$$
+
+To accumulate results from all columns, we iterate over the NAF columns in groups of 4 columns at a time. For each group of 4 columns, we perform the following steps:
+
+1. For each NAF column in the group, we compute the accumulated group element $\textcolor{violet}{Q_i}$ as described above by performing ROM lookups and additions.
+2. Suppose the accumulated group elements for the 4 columns are $\textcolor{violet}{Q_0}, \textcolor{violet}{Q_1}, \textcolor{violet}{Q_2}, \textcolor{violet}{Q_3}$. We then add these group elements to the overall accumulator with appropriate doublings. Specifically, we perform the following operation on the accumulator $R$:
+
+$$
+R = 2 \cdot \Big( \big(2\cdot (2 \cdot R + \textcolor{violet}{Q_0}) + \textcolor{violet}{Q_1}\big) + \textcolor{violet}{Q_2}\Big) + \textcolor{violet}{Q_3}
+$$
+
+3. Lastly, after processing all NAF columns, we need to account for the skew factors $\mathfrak{s}_j$ for each scalar $a_j$:
+   - If $\mathfrak{s}_j = 1$, we subtract the corresponding group element $P_j$ from the accumulator $R$.
+   - If $\mathfrak{s}_j = 0$, we do nothing.
+
+Thus, the final result of the Strauss MSM using NAF representation is given by:
+
+$$
+A = R - \sum_{j=1}^{m} \mathfrak{s}_j \cdot \textcolor{olive}{P_j}.
+$$
+
+#### Handling Points at Infinity
+
+In the above Strauss MSM algorithm using NAF representation, if any of the group elements $P_j$ is the point at infinity (denoted as $\mathcal{O}$), we replace the pair $(\textcolor{olive}{P_j}, a_j)$ with $(\textcolor{olive}{G}, 0)$ in the input. This ensures that the contribution of that point to the MSM is effectively nullified, as multiplying any point by zero results in the point at infinity. Here, $\textcolor{olive}{G}$ is the generator point on the curve. This substitution allows us to maintain the structure of the MSM algorithm without introducing special cases for points at infinity.
+
+Once we replace all points at infinity with $(\textcolor{olive}{G}, 0)$, we can proceed with the Strauss MSM algorithm as described above. However, when we construct the ROM tables, one of the entries can lead to a point at infinity if the group elements are linearly dependent. For instance, given distinct points $\textcolor{olive}{P_1}, \textcolor{olive}{P_2}, \textcolor{olive}{P_3}, \textcolor{olive}{P_4}, \textcolor{olive}{P_5} \in \mathbb{G}$, if we have $\textcolor{olive}{P_5} = (\textcolor{olive}{P_1} + \textcolor{olive}{P_2} + \textcolor{olive}{P_3} + \textcolor{olive}{P_4})$, then the entry at index $1$ in the ROM table will be the point at infinity. Our circuit implementation does not allow for such cases and will throw an error asserting that the $x$-coordinates of two points being added are equal (which happens when adding a point to its negation). Therefore, it is crucial to ensure that the input points are linearly independent to avoid points at infinity in the ROM tables. To achieve this, we can perform a pre-processing step on the input points to add a small random multiple of the generator point to each input point.
+
+$$
+\begin{aligned}
+\textcolor{olive}{P_j} &\leftarrow \textcolor{olive}{P_j} + 2^{j} \cdot \delta \cdot \textcolor{olive}{G} \\
+\end{aligned}
+$$
+
+where $\delta$ is a verifier-chosen, 128-bit random scalar in $\mathbb{F}_r$. This randomization helps in breaking any linear dependencies among the points, thereby preventing the occurrence of points at infinity in the ROM tables during the MSM computation. The reason we need to use a verifier-chosen scalar is to ensure that a malicious prover cannot manipulate input points to create linear dependencies that could lead to inability to generate valid proofs. We choose powers of 2 multiples of $\delta$ to ensure that the randomization does not add significant overhead to the recursive circuit. Specifically, we need to compute $\delta \cdot \textcolor{olive}{G}$ just once, and then we can obtain $2^{j} \cdot \delta \cdot \textcolor{olive}{G}$ by performing $j$ doublings, which is efficient in terms of circuit complexity. This approach effectively mitigates the risk of points at infinity while keeping the overhead manageable.
+
+Even after randomization, we can still encounter points at infinity while accumulating the outputs of the ROM lookups for the first two NAF columns. For example, suppose the NAF slices for for a 5-point MSM in the first two rounds are as follows:
+
+$$
+\begin{aligned}
+\def\arraystretch{1.6}
+\begin{array}{c}
+\begin{array}{|c||c|c|c|c|}
+\hline
+& \textsf{round 1} & \textsf{round 2} \\ \hline \hline
+\textcolor{olive}{P_1} & +1 & -1 \\ \hline
+\textcolor{olive}{P_2} & +1 & -1 \\ \hline
+\textcolor{olive}{P_3} & +1 & -1 \\ \hline
+\textcolor{olive}{P_4} & +1 & -1 \\ \hline
+\textcolor{olive}{P_5} & +1 & -1 \\ \hline \hline
+\textsf{column output} & \textcolor{violet}{Q_{1}} & \textcolor{violet}{Q_{2}} \\ \hline
+\end{array}
+\end{array}
+\end{aligned}
+$$
+
+In this case, since $\textcolor{violet}{Q_{i, 2}} = -\textcolor{violet}{Q_{i, 1}}$, while initialising the accumulator $R$:
+
+$$
+\begin{aligned}
+R &= 2 \cdot \textcolor{violet}{Q_{1}} + \textcolor{violet}{Q_{2}} =
+\underbrace{(\textcolor{violet}{Q_{1}} + \textcolor{violet}{Q_{2}})}_{= \ \mathcal{O}} + (\textcolor{violet}{Q_{1}}) \\
+\end{aligned}
+$$
+
+Our Montmogomery ladder implementation requires that the two points being added have distinct $x$-coordinates, which is not the case here since $\textcolor{violet}{Q_{2}} = -\textcolor{violet}{Q_{1}}$. So an honest prover would fail to generate a valid proof. To prevent this, we can add a random multiple of the generator point to the first column output before adding it to the accumulator:
+
+$$
+\begin{aligned}
+R &= 2 \cdot (\textcolor{violet}{Q_{1}} + \delta \cdot \textcolor{olive}{G}) + \textcolor{violet}{Q_{2}} \\
+\end{aligned}
+$$
+
+Here, $\delta$ is a verifier-chosen random scalar in $\mathbb{F}_r$. This randomization ensures that the two points being added have distinct $x$-coordinates during the addition operation in the Montgomery ladder. We choose the same random scalar $\delta$ that was used for randomizing the input points to avoid the overhead of computing $\delta' \cdot \textcolor{olive}{G}$ in the circuit if $\delta' \neq \delta$.
+
+Effectively, the modified MSM computation becomes:
+
+$$
+\begin{aligned}
+A &= \sum_{j=1}^{m} a_j \cdot (\textcolor{olive}{P_j} + 2^{j} \cdot \textcolor{olive}{\delta G}) - \left(\sum_{j=1}^{m} 2^{j} \cdot a_j \right) \cdot \textcolor{olive}{\delta G} \\
+&= \sum_{j=1}^{m} a_j \cdot \underbrace{(\textcolor{olive}{P_j} + 2^{j} \cdot \textcolor{olive}{\delta G})}_{=: \ \textcolor{olive}{P'_j}} - \underbrace{\left(\sum_{j=1}^{m} \frac{2^{j} \cdot a_j}{2^{m+1}} \right)}_{=: \ a_{m+1}} \cdot \underbrace{(2^{m+1} \cdot \textcolor{olive}{\delta G})}_{=: \ \textcolor{olive}{P'_{m+1}}} \\
+&= \sum_{j=1}^{m+1} a_j \cdot \textcolor{olive}{P'_j}
+\end{aligned}
+$$
+
+Substituting the NAF representation of each scalar $a_j, j \in [1, m+1]$ into the MSM computation, we get:
+
+$$
+\begin{aligned}
+A &= \sum_{j=1}^{m+1} \left( -\mathfrak{s}_{j} + \sum_{i=0}^{n-1} \windex{2^{i}} \cdot a_{j, n-1-i} \right) \cdot \textcolor{olive}{P'_j} \\
+&= \sum_{j=1}^{m+1} \left( \sum_{i=0}^{n-1} \windex{2^{i}} \cdot a_{j, n-1-i} \right) \cdot \textcolor{olive}{P'_j} - \sum_{j=1}^{m+1} \mathfrak{s}_{j} \cdot \textcolor{olive}{P'_j} \\
+&= \windex{2^{n - 1}} \cdot \underbrace{\left(\sum_{j=1}^{m+1}  a_{j, 0} \cdot \textcolor{olive}{P'_j}\right)}_{=: \ \textcolor{violet}{Q_1}} + \sum_{i=1}^{n-1} \windex{2^{i}} \cdot \underbrace{\left( \sum_{j=1}^{m+1} a_{j, n-1-i} \cdot \textcolor{olive}{P'_j} \right)}_{\textcolor{violet}{Q_i}} - \sum_{j=1}^{m+1} \mathfrak{s}_{j} \cdot \textcolor{olive}{P'_j} \\
+&= \windex{2^{n-1}} \cdot \left( \textcolor{violet}{Q_1} + \textcolor{olive}{\delta G} \right) - \windex{2^{n-1}} \cdot \textcolor{olive}{\delta G} + \left(\sum_{i=1}^{n-1} \windex{2^{i}} \cdot \textcolor{violet}{Q_i}\right) - \left(\sum_{j=1}^{m+1} \mathfrak{s}_{j} \cdot \textcolor{olive}{P'_j}\right). \\
+\end{aligned}
+$$
+
+Thus, we need to subtract the term $\windex{2^{n-1}} \cdot \textcolor{olive}{\delta G}$ from the final MSM result to account for the randomization added during the accumulation of NAF column outputs. This ensures that the final MSM result is correct and unaffected by the randomization used to prevent points at infinity during intermediate computations.

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/README.md
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/README.md
@@ -432,7 +432,7 @@ To accumulate results from all columns, we iterate over the NAF columns in group
 2. Suppose the accumulated group elements for the 4 columns are $\textcolor{violet}{Q_0}, \textcolor{violet}{Q_1}, \textcolor{violet}{Q_2}, \textcolor{violet}{Q_3}$. We then add these group elements to the overall accumulator with appropriate doublings. Specifically, we perform the following operation on the accumulator $R$:
 
 $$
-R = 2 \cdot \Big( \big(2\cdot (2 \cdot R + \textcolor{violet}{Q_0}) + \textcolor{violet}{Q_1}\big) + \textcolor{violet}{Q_2}\Big) + \textcolor{violet}{Q_3}
+R = 2 \cdot \Big( 2 \cdot \big(2\cdot (2 \cdot R + \textcolor{violet}{Q_0}) + \textcolor{violet}{Q_1}\big) + \textcolor{violet}{Q_2}\Big) + \textcolor{violet}{Q_3}
 $$
 
 3. Lastly, after processing all NAF columns, we need to account for the skew factors $\mathfrak{s}_j$ for each scalar $a_j$:
@@ -479,7 +479,7 @@ $$
 \end{aligned}
 $$
 
-In this case, since $\textcolor{violet}{Q_{i, 2}} = -\textcolor{violet}{Q_{i, 1}}$, while initialising the accumulator $R$:
+In this case, since $\textcolor{violet}{Q_{2}} = -\textcolor{violet}{Q_{1}}$, while initialising the accumulator $R$:
 
 $$
 \begin{aligned}

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup.hpp
@@ -397,32 +397,11 @@ template <class Builder_, class Fq, class Fr, class NativeGroup> class element {
     template <size_t wnaf_size, size_t staggered_lo_offset = 0, size_t staggered_hi_offset = 0>
     static secp256k1_wnaf_pair compute_secp256k1_endo_wnaf(const Fr& scalar, const bool range_constrain_wnaf = true);
 
-    Builder* get_context() const
-    {
-        if (_x.context != nullptr) {
-            return _x.context;
-        }
-        if (_y.context != nullptr) {
-            return _y.context;
-        }
-        return nullptr;
-    }
+    Builder* get_context() const { return validate_context<Builder>(_x.get_context(), _y.get_context()); }
 
     Builder* get_context(const element& other) const
     {
-        if (_x.context != nullptr) {
-            return _x.context;
-        }
-        if (_y.context != nullptr) {
-            return _y.context;
-        }
-        if (other._x.context != nullptr) {
-            return other._x.context;
-        }
-        if (other._y.context != nullptr) {
-            return other._y.context;
-        }
-        return nullptr;
+        return validate_context<Builder>(get_context(), other.get_context());
     }
 
     // Coordinate accessors (non-owning, const reference)

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup.hpp
@@ -27,6 +27,7 @@ template <class Builder_, class Fq, class Fr, class NativeGroup> class element {
   public:
     using Builder = Builder_;
     using bool_ct = stdlib::bool_t<Builder>;
+    using field_ct = stdlib::field_t<Builder>;
     using witness_ct = stdlib::witness_t<Builder>;
     using biggroup_tag = element; // Facilitates a constexpr check IsBigGroup
     using BaseField = Fq;
@@ -34,10 +35,10 @@ template <class Builder_, class Fq, class Fr, class NativeGroup> class element {
     // Number of bb::fr field elements used to represent a goblin element in the public inputs
     static constexpr size_t PUBLIC_INPUTS_SIZE = BIGGROUP_PUBLIC_INPUTS_SIZE;
     struct secp256k1_wnaf {
-        std::vector<field_t<Builder>> wnaf;
+        std::vector<field_ct> wnaf;
         bool_ct positive_skew;
         bool_ct negative_skew;
-        field_t<Builder> least_significant_wnaf_fragment;
+        field_ct least_significant_wnaf_fragment;
         bool has_wnaf_fragment = false;
     };
     struct secp256k1_wnaf_pair {
@@ -525,18 +526,18 @@ template <class Builder_, class Fq, class Fr, class NativeGroup> class element {
      * @param wnaf_values
      * @param is_negative
      * @param rounds
-     * @return std::vector<field_t<Builder>>
+     * @return std::vector<field_ct>
      *
      * @details For 4-bit window, each wNAF value is in the range [-15, 15]. We convert these to the range [0, 30] by
      * adding 15 if `is_negative = false` and by subtracting from 15 if `is_negative = true`. This ensures that all
      * values are non-negative, which is required for the ROM table lookup.
      */
     template <size_t wnaf_size>
-    static std::vector<field_t<Builder>> convert_wnaf_values_to_witnesses(Builder* builder,
-                                                                          const uint64_t* wnaf_values,
-                                                                          bool is_negative,
-                                                                          size_t rounds,
-                                                                          const bool range_constrain_wnaf = true);
+    static std::vector<field_ct> convert_wnaf_values_to_witnesses(Builder* builder,
+                                                                  const uint64_t* wnaf_values,
+                                                                  bool is_negative,
+                                                                  size_t rounds,
+                                                                  const bool range_constrain_wnaf = true);
 
     /**
      * @brief Reconstruct a scalar from its wNAF representation in circuit
@@ -551,10 +552,10 @@ template <class Builder_, class Fq, class Fr, class NativeGroup> class element {
      */
     template <size_t wnaf_size>
     static Fr reconstruct_bigfield_from_wnaf(Builder* builder,
-                                             const std::vector<field_t<Builder>>& wnaf,
+                                             const std::vector<field_ct>& wnaf,
                                              const bool_ct& positive_skew,
                                              const bool_ct& negative_skew,
-                                             const field_t<Builder>& stagger_fragment,
+                                             const field_ct& stagger_fragment,
                                              const size_t stagger,
                                              const size_t rounds);
 
@@ -564,7 +565,7 @@ template <class Builder_, class Fq, class Fr, class NativeGroup> class element {
 
     template <size_t num_elements>
     static element read_group_element_rom_tables(const std::array<twin_rom_table<Builder>, Fq::NUM_LIMBS + 1>& tables,
-                                                 const field_t<Builder>& index,
+                                                 const field_ct& index,
                                                  const std::array<uint256_t, Fq::NUM_LIMBS * 2>& limb_max);
 
     static std::pair<element, element> compute_offset_generators(const size_t num_rounds);
@@ -585,7 +586,7 @@ template <class Builder_, class Fq, class Fr, class NativeGroup> class element {
         four_bit_table_plookup& operator=(four_bit_table_plookup&& other) noexcept = default;
         ~four_bit_table_plookup() = default;
 
-        element operator[](const field_t<Builder>& index) const;
+        element operator[](const field_ct& index) const;
         element operator[](const size_t idx) const { return element_table[idx]; }
         std::array<element, 16> element_table;
 
@@ -613,7 +614,7 @@ template <class Builder_, class Fq, class Fr, class NativeGroup> class element {
         eight_bit_fixed_base_table& operator=(eight_bit_fixed_base_table&& other) noexcept = default;
         ~eight_bit_fixed_base_table() = default;
 
-        element operator[](const field_t<Builder>& index) const;
+        element operator[](const field_ct& index) const;
 
         element operator[](const size_t index) const;
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup.hpp
@@ -379,7 +379,8 @@ template <class Builder_, class Fq, class Fr, class NativeGroup> class element {
     }
 
     static std::pair<std::vector<element>, std::vector<Fr>> mask_points(const std::vector<element>& _points,
-                                                                        const std::vector<Fr>& _scalars);
+                                                                        const std::vector<Fr>& _scalars,
+                                                                        const Fr& masking_scalar = Fr(1));
 
     static std::pair<std::vector<element>, std::vector<Fr>> handle_points_at_infinity(
         const std::vector<element>& _points, const std::vector<Fr>& _scalars);
@@ -387,7 +388,8 @@ template <class Builder_, class Fq, class Fr, class NativeGroup> class element {
     static element batch_mul(const std::vector<element>& points,
                              const std::vector<Fr>& scalars,
                              const size_t max_num_bits = 0,
-                             const bool with_edgecases = false);
+                             const bool with_edgecases = false,
+                             const Fr& masking_scalar = Fr(1));
 
     template <typename X = NativeGroup, typename = typename std::enable_if_t<std::is_same<X, secp256k1::g1>::value>>
     static element secp256k1_ecdsa_mul(const element& pubkey, const Fr& u1, const Fr& u2);

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup.hpp
@@ -918,6 +918,36 @@ template <class Builder_, class Fq, class Fr, class NativeGroup> class element {
     };
 
     using batch_lookup_table = batch_lookup_table_plookup;
+
+    struct strauss_msm_data {
+        std::vector<element> points; // Points for msm
+        std::vector<Fr> scalars;     // Scalars for msm
+        size_t num_bits;             // Max number of bits in scalars
+        size_t msm_size;             // Number of points/scalars in msm
+
+        strauss_msm_data(const std::vector<element>& _points,
+                         const std::vector<Fr>& _scalars,
+                         const size_t max_num_bits)
+        {
+            // Sanity checks
+            BB_ASSERT_GT(_points.size(), 0ULL, "strauss_msm_data: points cannot be empty");
+            BB_ASSERT_EQ(_points.size(), _scalars.size(), "strauss_msm_data: points and scalars size mismatch");
+
+            // Check that all scalars are in range
+            for (const auto& scalar : _scalars) {
+                const size_t num_scalar_bits = uint512_t(scalar.get_value()).get_msb() + 1;
+                BB_ASSERT_LTE(num_scalar_bits, max_num_bits, "strauss_msm_data: scalar out of range");
+            }
+
+            // Store the input data
+            points = _points;
+            scalars = _scalars;
+            num_bits = max_num_bits;
+            msm_size = _points.size();
+        }
+    };
+
+    static element process_strauss_msm(const strauss_msm_data& msm_data);
 };
 
 // For testing purposes only

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup.hpp
@@ -757,35 +757,6 @@ template <class Builder_, class Fq, class Fr, class NativeGroup> class element {
             }
         }
 
-        element get_initial_entry() const
-        {
-            std::vector<element> add_accumulator;
-            for (size_t i = 0; i < num_sixes; ++i) {
-                add_accumulator.push_back(six_tables[i][0]);
-            }
-            for (size_t i = 0; i < num_fives; ++i) {
-                add_accumulator.push_back(five_tables[i][0]);
-            }
-            if (has_quad) {
-                add_accumulator.push_back(quad_tables[0][0]);
-            }
-            if (has_twin) {
-                add_accumulator.push_back(twin_tables[0][0]);
-            }
-            if (has_triple) {
-                add_accumulator.push_back(triple_tables[0][0]);
-            }
-            if (has_singleton) {
-                add_accumulator.push_back(singletons[0]);
-            }
-
-            element accumulator = add_accumulator[0];
-            for (size_t i = 1; i < add_accumulator.size(); ++i) {
-                accumulator = accumulator + add_accumulator[i];
-            }
-            return accumulator;
-        }
-
         chain_add_accumulator get_chain_initial_entry() const
         {
             std::vector<element> add_accumulator;
@@ -855,7 +826,6 @@ template <class Builder_, class Fq, class Fr, class NativeGroup> class element {
                 round_accumulator.push_back(singletons[0].conditional_negate(naf_entries[num_points - 1]));
             }
 
-            element::chain_add_accumulator accumulator;
             if (round_accumulator.size() == 1) {
                 return element::chain_add_accumulator(round_accumulator[0]);
             }
@@ -865,7 +835,8 @@ template <class Builder_, class Fq, class Fr, class NativeGroup> class element {
             }
 
             // Use chain add for at least 3 elements
-            accumulator = element::chain_add_start(round_accumulator[0], round_accumulator[1]);
+            element::chain_add_accumulator accumulator =
+                element::chain_add_start(round_accumulator[0], round_accumulator[1]);
             for (size_t j = 2; j < round_accumulator.size(); ++j) {
                 accumulator = element::chain_add(round_accumulator[j], accumulator);
             }

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup.hpp
@@ -919,35 +919,9 @@ template <class Builder_, class Fq, class Fr, class NativeGroup> class element {
 
     using batch_lookup_table = batch_lookup_table_plookup;
 
-    struct strauss_msm_data {
-        std::vector<element> points; // Points for msm
-        std::vector<Fr> scalars;     // Scalars for msm
-        size_t num_bits;             // Max number of bits in scalars
-        size_t msm_size;             // Number of points/scalars in msm
-
-        strauss_msm_data(const std::vector<element>& _points,
-                         const std::vector<Fr>& _scalars,
-                         const size_t max_num_bits)
-        {
-            // Sanity checks
-            BB_ASSERT_GT(_points.size(), 0ULL, "strauss_msm_data: points cannot be empty");
-            BB_ASSERT_EQ(_points.size(), _scalars.size(), "strauss_msm_data: points and scalars size mismatch");
-
-            // Check that all scalars are in range
-            for (const auto& scalar : _scalars) {
-                const size_t num_scalar_bits = uint512_t(scalar.get_value()).get_msb() + 1;
-                BB_ASSERT_LTE(num_scalar_bits, max_num_bits, "strauss_msm_data: scalar out of range");
-            }
-
-            // Store the input data
-            points = _points;
-            scalars = _scalars;
-            num_bits = max_num_bits;
-            msm_size = _points.size();
-        }
-    };
-
-    static element process_strauss_msm(const strauss_msm_data& msm_data);
+    static element process_strauss_msm_rounds(const std::vector<element>& points,
+                                              const std::vector<Fr>& scalars,
+                                              const size_t max_num_bits);
 };
 
 // For testing purposes only

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup.test.cpp
@@ -920,8 +920,8 @@ template <typename TestType> class stdlib_biggroup : public testing::Test {
             element input_c = (element(input_a) * scalar_a);
             element input_d = (element(input_b) * scalar_b);
             affine_element expected(input_c + input_d);
-            fq c_x_result(c.x.get_value().lo);
-            fq c_y_result(c.y.get_value().lo);
+            fq c_x_result(c.x().get_value().lo);
+            fq c_y_result(c.y().get_value().lo);
 
             EXPECT_EQ(c_x_result, expected.x);
             EXPECT_EQ(c_y_result, expected.y);
@@ -1000,8 +1000,8 @@ template <typename TestType> class stdlib_biggroup : public testing::Test {
             element input_g = (element(input_P_c) * scalar_c);
 
             affine_element expected(input_e + input_f + input_g);
-            fq c_x_result(c.x.get_value().lo);
-            fq c_y_result(c.y.get_value().lo);
+            fq c_x_result(c.x().get_value().lo);
+            fq c_y_result(c.y().get_value().lo);
 
             EXPECT_EQ(c_x_result, expected.x);
             EXPECT_EQ(c_y_result, expected.y);

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup.test.cpp
@@ -883,6 +883,180 @@ template <typename TestType> class stdlib_biggroup : public testing::Test {
         EXPECT_CIRCUIT_CORRECTNESS(builder);
     }
 
+    static void test_twin_mul_edge_case()
+    {
+        Builder builder;
+        affine_element input_a(element::random_element());
+        affine_element input_b(element::random_element());
+
+        fr scalar_a(fr::random_element());
+        fr scalar_b(fr::random_element());
+        if ((uint256_t(scalar_a).get_bit(0) & 1) == 1) {
+            scalar_a -= fr(1); // skew bit is 1
+        }
+        if ((uint256_t(scalar_b).get_bit(0) & 1) == 0) {
+            scalar_b += fr(1); // skew bit is 0
+        }
+
+        // [+1, ....]
+        // [+1, ....]
+        scalar_ct x_a = scalar_ct::from_witness(&builder, scalar_a);   // s_1
+        scalar_ct x_b = scalar_ct::from_witness(&builder, scalar_b);   // s_2
+        element_ct P_a = element_ct::from_witness(&builder, input_a);  // A
+        element_ct P_b = element_ct::from_witness(&builder, -input_a); // -A
+
+        // Set tags
+        P_a.set_origin_tag(submitted_value_origin_tag);
+        x_a.set_origin_tag(challenge_origin_tag);
+        P_b.set_origin_tag(next_submitted_value_origin_tag);
+        x_b.set_origin_tag(next_challenge_tag);
+
+        element_ct c = element_ct::batch_mul({ P_a, P_b }, { x_a, x_b });
+
+        // Check that the resulting tag is a union of all tags
+        EXPECT_EQ(c.get_origin_tag(), first_to_fourth_merged_tag);
+        element input_c = (element(input_a) * scalar_a);
+        element input_d = (element(input_b) * scalar_b);
+        affine_element expected(input_c + input_d);
+        fq c_x_result(c.x.get_value().lo);
+        fq c_y_result(c.y.get_value().lo);
+
+        std::cout << "builder err = " << builder.err() << std::endl;
+
+        EXPECT_EQ(c_x_result, expected.x);
+        EXPECT_EQ(c_y_result, expected.y);
+
+        EXPECT_CIRCUIT_CORRECTNESS(builder);
+    }
+
+    static void test_twin_mul_with_infinity()
+    {
+        Builder builder;
+        size_t num_repetitions = 1;
+        for (size_t i = 0; i < num_repetitions; ++i) {
+            affine_element input_a(element::random_element());
+            affine_element input_b(element::random_element());
+            input_b.self_set_infinity();
+
+            // Get two 128-bit scalars
+            const size_t max_num_bits = 128;
+            uint256_t scalar_raw_a = engine.get_random_uint256();
+            scalar_raw_a = scalar_raw_a >> (256 - max_num_bits);
+            fr scalar_a = fr(scalar_raw_a);
+
+            uint256_t scalar_raw_b = engine.get_random_uint256();
+            scalar_raw_b = scalar_raw_b >> (256 - max_num_bits);
+            fr scalar_b = fr(scalar_raw_b);
+
+            element_ct P_a = element_ct::from_witness(&builder, input_a); // A
+            scalar_ct x_a = scalar_ct::from_witness(&builder, scalar_a);  // s_1 (128 bits)
+            element_ct P_b = element_ct::from_witness(&builder, input_b); // ∞
+            scalar_ct x_b = scalar_ct::from_witness(&builder, scalar_b);  // s_2 (128 bits)
+
+            // (A, s_1), (G, 0)
+            // batch_mul: (A, s_1), (G, 1), (-G, 1)
+            // later subtract -G
+
+            std::cout << "P_b is infinity: " << P_b.is_point_at_infinity().get_value() << std::endl;
+
+            // Set tags
+            P_a.set_origin_tag(submitted_value_origin_tag);
+            x_a.set_origin_tag(challenge_origin_tag);
+            P_b.set_origin_tag(next_submitted_value_origin_tag);
+            x_b.set_origin_tag(next_challenge_tag);
+
+            element_ct c = element_ct::batch_mul({ P_a, P_b }, { x_a, x_b }, 128);
+
+            // Check that the resulting tag is a union of all tags
+            EXPECT_EQ(c.get_origin_tag(), first_to_fourth_merged_tag);
+            element input_c = (element(input_a) * scalar_a);
+            element input_d = (element(input_b) * scalar_b);
+            affine_element expected(input_c + input_d);
+            fq c_x_result(c.x.get_value().lo);
+            fq c_y_result(c.y.get_value().lo);
+
+            std::cout << "builder err = " << builder.err() << std::endl;
+
+            EXPECT_EQ(c_x_result, expected.x);
+            EXPECT_EQ(c_y_result, expected.y);
+        }
+        EXPECT_CIRCUIT_CORRECTNESS(builder);
+    }
+
+    static void test_triple_edge_case()
+    {
+        Builder builder;
+        affine_element input_P(element::random_element());
+
+        affine_element input_P_a = affine_element(element(input_P) + element(input_P));     // 2P
+        affine_element input_P_b = affine_element(element(input_P_a) + element(input_P));   // 3P
+        affine_element input_P_c = affine_element(element(input_P_a) + element(input_P_b)); // 5P
+
+        // Choose scalars such that their NAF representations are:
+        //    skew msd          lsd
+        // a: 0    [+1, +1, -1, +1] = -0 + 2^3 + 2^2 - 2^1 + 2^0 = 11
+        // b: 1    [+1, +1, +1, +1] = -1 + 2^3 + 2^2 + 2^1 + 2^0 = 14
+        // c: 1    [+1, -1, +1, +1] = -1 + 2^3 - 2^2 + 2^1 + 2^0 = 6
+        fr scalar_a(11);
+        fr scalar_b(14);
+        fr scalar_c(6);
+
+        // A, B, C
+        // 0: A + B + C
+        // 1: A + B - C
+        // 2: A - B + C
+        // 3: A - B - C
+
+        OriginTag tag_union{};
+
+        element_ct P_a = element_ct::from_witness(&builder, input_P_a);
+        // Set all element tags to submitted tags from sequential rounds
+        P_a.set_origin_tag(OriginTag(/*parent_index=*/0, /*child_index=*/0, /*is_submitted=*/true));
+        tag_union = OriginTag(tag_union, P_a.get_origin_tag());
+
+        scalar_ct x_a = scalar_ct::from_witness(&builder, scalar_a);
+        // Set all scalar tags to challenge tags from sequential rounds
+        x_a.set_origin_tag(OriginTag(/*parent_index=*/0, /*child_index=*/0, /*is_submitted=*/false));
+        tag_union = OriginTag(tag_union, x_a.get_origin_tag());
+
+        element_ct P_b = element_ct::from_witness(&builder, input_P_b);
+        P_b.set_origin_tag(OriginTag(/*parent_index=*/0, /*child_index=*/1, /*is_submitted=*/true));
+        tag_union = OriginTag(tag_union, P_b.get_origin_tag());
+
+        scalar_ct x_b = scalar_ct::from_witness(&builder, scalar_b);
+        x_b.set_origin_tag(OriginTag(/*parent_index=*/0, /*child_index=*/1, /*is_submitted=*/false));
+        tag_union = OriginTag(tag_union, x_b.get_origin_tag());
+
+        element_ct P_c = element_ct::from_witness(&builder, input_P_c);
+        P_c.set_origin_tag(OriginTag(/*parent_index=*/0, /*child_index=*/2, /*is_submitted=*/true));
+        tag_union = OriginTag(tag_union, P_c.get_origin_tag());
+
+        scalar_ct x_c = scalar_ct::from_witness(&builder, scalar_c);
+        x_c.set_origin_tag(OriginTag(/*parent_index=*/0, /*child_index=*/2, /*is_submitted=*/false));
+        tag_union = OriginTag(tag_union, x_c.get_origin_tag());
+
+        std::cout << "builder err = " << builder.err() << std::endl;
+
+        element_ct c = element_ct::batch_mul({ P_a, P_b, P_c }, { x_a, x_b, x_c }, 4);
+
+        std::cout << "builder err = " << builder.err() << std::endl;
+
+        // Check that the result tag is a union of inputs' tags
+        EXPECT_EQ(c.get_origin_tag(), tag_union);
+        element input_e = (element(input_P_a) * scalar_a);
+        element input_f = (element(input_P_b) * scalar_b);
+        element input_g = (element(input_P_c) * scalar_c);
+
+        affine_element expected(input_e + input_f + input_g);
+        fq c_x_result(c.x.get_value().lo);
+        fq c_y_result(c.y.get_value().lo);
+
+        EXPECT_EQ(c_x_result, expected.x);
+        EXPECT_EQ(c_y_result, expected.y);
+
+        EXPECT_CIRCUIT_CORRECTNESS(builder);
+    }
+
     static void test_triple_mul()
     {
         Builder builder;
@@ -1730,6 +1904,34 @@ HEAVY_TYPED_TEST(stdlib_biggroup, twin_mul)
         TestFixture::test_twin_mul();
     };
 }
+
+HEAVY_TYPED_TEST(stdlib_biggroup, twin_mul_edge_case)
+{
+    if constexpr (HasGoblinBuilder<TypeParam>) {
+        GTEST_SKIP() << "https://github.com/AztecProtocol/barretenberg/issues/1290";
+    } else {
+        TestFixture::test_twin_mul_edge_case();
+    };
+}
+
+HEAVY_TYPED_TEST(stdlib_biggroup, twin_mul_with_infinity)
+{
+    if constexpr (HasGoblinBuilder<TypeParam>) {
+        GTEST_SKIP() << "https://github.com/AztecProtocol/barretenberg/issues/1290";
+    } else {
+        TestFixture::test_twin_mul_with_infinity();
+    };
+}
+
+HEAVY_TYPED_TEST(stdlib_biggroup, triple_edge_case)
+{
+    if constexpr (HasGoblinBuilder<TypeParam>) {
+        GTEST_SKIP() << "https://github.com/AztecProtocol/barretenberg/issues/1290";
+    } else {
+        TestFixture::test_triple_edge_case();
+    };
+}
+
 HEAVY_TYPED_TEST(stdlib_biggroup, triple_mul)
 {
     if constexpr (HasGoblinBuilder<TypeParam>) {

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup.test.cpp
@@ -793,7 +793,7 @@ template <typename TestType> class stdlib_biggroup : public testing::Test {
     static void test_short_scalar_mul_infinity()
     {
         // We check that a point at infinity preserves `is_point_at_infinity()` flag after being multiplied against a
-        // short scalar and also check that the number of gates in this case is equal to the number of gates spent on a
+        // short scalar and also check that the number of gates in this case is more than the number of gates spent on a
         // finite point.
 
         // Populate test points.
@@ -1176,7 +1176,19 @@ template <typename TestType> class stdlib_biggroup : public testing::Test {
             x_d.set_origin_tag(OriginTag(/*parent_index=*/0, /*child_index=*/3, /*is_submitted=*/false));
             tag_union = OriginTag(tag_union, x_d.get_origin_tag());
 
-            element_ct c = element_ct::batch_mul({ P_a, P_b, P_c, P_d }, { x_a, x_b, x_c, x_d });
+            // Define masking scalar (128 bits)
+            const auto get_128_bit_scalar = []() {
+                uint256_t scalar_u256(0, 0, 0, 0);
+                scalar_u256.data[0] = engine.get_random_uint64();
+                scalar_u256.data[1] = engine.get_random_uint64();
+                fr scalar(scalar_u256);
+                return scalar;
+            };
+            fr masking_scalar = get_128_bit_scalar();
+            scalar_ct masking_scalar_ct = scalar_ct::from_witness(&builder, masking_scalar);
+
+            element_ct c =
+                element_ct::batch_mul({ P_a, P_b, P_c, P_d }, { x_a, x_b, x_c, x_d }, 0, true, masking_scalar_ct);
 
             // Check that the tag of the batched product is the union of inputs' tags
             EXPECT_EQ(c.get_origin_tag(), tag_union);

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup.test.cpp
@@ -883,52 +883,6 @@ template <typename TestType> class stdlib_biggroup : public testing::Test {
         EXPECT_CIRCUIT_CORRECTNESS(builder);
     }
 
-    static void test_twin_mul_edge_case()
-    {
-        Builder builder;
-        affine_element input_a(element::random_element());
-        affine_element input_b(element::random_element());
-
-        fr scalar_a(fr::random_element());
-        fr scalar_b(fr::random_element());
-        if ((uint256_t(scalar_a).get_bit(0) & 1) == 1) {
-            scalar_a -= fr(1); // skew bit is 1
-        }
-        if ((uint256_t(scalar_b).get_bit(0) & 1) == 0) {
-            scalar_b += fr(1); // skew bit is 0
-        }
-
-        // [+1, ....]
-        // [+1, ....]
-        scalar_ct x_a = scalar_ct::from_witness(&builder, scalar_a);   // s_1
-        scalar_ct x_b = scalar_ct::from_witness(&builder, scalar_b);   // s_2
-        element_ct P_a = element_ct::from_witness(&builder, input_a);  // A
-        element_ct P_b = element_ct::from_witness(&builder, -input_a); // -A
-
-        // Set tags
-        P_a.set_origin_tag(submitted_value_origin_tag);
-        x_a.set_origin_tag(challenge_origin_tag);
-        P_b.set_origin_tag(next_submitted_value_origin_tag);
-        x_b.set_origin_tag(next_challenge_tag);
-
-        element_ct c = element_ct::batch_mul({ P_a, P_b }, { x_a, x_b });
-
-        // Check that the resulting tag is a union of all tags
-        EXPECT_EQ(c.get_origin_tag(), first_to_fourth_merged_tag);
-        element input_c = (element(input_a) * scalar_a);
-        element input_d = (element(input_b) * scalar_b);
-        affine_element expected(input_c + input_d);
-        fq c_x_result(c.x.get_value().lo);
-        fq c_y_result(c.y.get_value().lo);
-
-        std::cout << "builder err = " << builder.err() << std::endl;
-
-        EXPECT_EQ(c_x_result, expected.x);
-        EXPECT_EQ(c_y_result, expected.y);
-
-        EXPECT_CIRCUIT_CORRECTNESS(builder);
-    }
-
     static void test_twin_mul_with_infinity()
     {
         Builder builder;
@@ -953,12 +907,6 @@ template <typename TestType> class stdlib_biggroup : public testing::Test {
             element_ct P_b = element_ct::from_witness(&builder, input_b); // ∞
             scalar_ct x_b = scalar_ct::from_witness(&builder, scalar_b);  // s_2 (128 bits)
 
-            // (A, s_1), (G, 0)
-            // batch_mul: (A, s_1), (G, 1), (-G, 1)
-            // later subtract -G
-
-            std::cout << "P_b is infinity: " << P_b.is_point_at_infinity().get_value() << std::endl;
-
             // Set tags
             P_a.set_origin_tag(submitted_value_origin_tag);
             x_a.set_origin_tag(challenge_origin_tag);
@@ -975,15 +923,13 @@ template <typename TestType> class stdlib_biggroup : public testing::Test {
             fq c_x_result(c.x.get_value().lo);
             fq c_y_result(c.y.get_value().lo);
 
-            std::cout << "builder err = " << builder.err() << std::endl;
-
             EXPECT_EQ(c_x_result, expected.x);
             EXPECT_EQ(c_y_result, expected.y);
         }
         EXPECT_CIRCUIT_CORRECTNESS(builder);
     }
 
-    static void test_triple_edge_case()
+    static void test_batch_mul_linearly_dependent_generators()
     {
         Builder builder;
         affine_element input_P(element::random_element());
@@ -1000,12 +946,6 @@ template <typename TestType> class stdlib_biggroup : public testing::Test {
         fr scalar_a(11);
         fr scalar_b(14);
         fr scalar_c(6);
-
-        // A, B, C
-        // 0: A + B + C
-        // 1: A + B - C
-        // 2: A - B + C
-        // 3: A - B - C
 
         OriginTag tag_union{};
 
@@ -1035,26 +975,51 @@ template <typename TestType> class stdlib_biggroup : public testing::Test {
         x_c.set_origin_tag(OriginTag(/*parent_index=*/0, /*child_index=*/2, /*is_submitted=*/false));
         tag_union = OriginTag(tag_union, x_c.get_origin_tag());
 
-        std::cout << "builder err = " << builder.err() << std::endl;
+        {
+            // If with_edgecases = true, should handle linearly dependent points correctly
+            // Define masking scalar (128 bits)
+            const auto get_128_bit_scalar = []() {
+                uint256_t scalar_u256(0, 0, 0, 0);
+                scalar_u256.data[0] = engine.get_random_uint64();
+                scalar_u256.data[1] = engine.get_random_uint64();
+                fr scalar(scalar_u256);
+                return scalar;
+            };
+            fr masking_scalar = get_128_bit_scalar();
+            scalar_ct masking_scalar_ct = scalar_ct::from_witness(&builder, masking_scalar);
+            element_ct c = element_ct::batch_mul({ P_a, P_b, P_c },
+                                                 { x_a, x_b, x_c },
+                                                 /*max_num_bits*/ 128,
+                                                 /*with_edgecases*/ true,
+                                                 /*masking_scalar*/ masking_scalar_ct);
 
-        element_ct c = element_ct::batch_mul({ P_a, P_b, P_c }, { x_a, x_b, x_c }, 4);
+            // Check that the result tag is a union of inputs' tags
+            EXPECT_EQ(c.get_origin_tag(), tag_union);
+            element input_e = (element(input_P_a) * scalar_a);
+            element input_f = (element(input_P_b) * scalar_b);
+            element input_g = (element(input_P_c) * scalar_c);
 
-        std::cout << "builder err = " << builder.err() << std::endl;
+            affine_element expected(input_e + input_f + input_g);
+            fq c_x_result(c.x.get_value().lo);
+            fq c_y_result(c.y.get_value().lo);
 
-        // Check that the result tag is a union of inputs' tags
-        EXPECT_EQ(c.get_origin_tag(), tag_union);
-        element input_e = (element(input_P_a) * scalar_a);
-        element input_f = (element(input_P_b) * scalar_b);
-        element input_g = (element(input_P_c) * scalar_c);
+            EXPECT_EQ(c_x_result, expected.x);
+            EXPECT_EQ(c_y_result, expected.y);
 
-        affine_element expected(input_e + input_f + input_g);
-        fq c_x_result(c.x.get_value().lo);
-        fq c_y_result(c.y.get_value().lo);
+            EXPECT_CIRCUIT_CORRECTNESS(builder);
+        }
+        {
+            // If with_edgecases = false, the lookup table cannot be created as we encounter
+            // a point at infinity during the table construction.
+            element_ct c = element_ct::batch_mul(
+                { P_a, P_b, P_c }, { x_a, x_b, x_c }, /*max_num_bits*/ 4, /*with_edgecases*/ false);
 
-        EXPECT_EQ(c_x_result, expected.x);
-        EXPECT_EQ(c_y_result, expected.y);
+            // Check that the result tag is a union of inputs' tags
+            EXPECT_EQ(c.get_origin_tag(), tag_union);
 
-        EXPECT_CIRCUIT_CORRECTNESS(builder);
+            EXPECT_CIRCUIT_CORRECTNESS(builder, false);
+            EXPECT_EQ(builder.err(), "bigfield: prime limb diff is zero, but expected non-zero");
+        }
     }
 
     static void test_triple_mul()
@@ -1917,15 +1882,6 @@ HEAVY_TYPED_TEST(stdlib_biggroup, twin_mul)
     };
 }
 
-HEAVY_TYPED_TEST(stdlib_biggroup, twin_mul_edge_case)
-{
-    if constexpr (HasGoblinBuilder<TypeParam>) {
-        GTEST_SKIP() << "https://github.com/AztecProtocol/barretenberg/issues/1290";
-    } else {
-        TestFixture::test_twin_mul_edge_case();
-    };
-}
-
 HEAVY_TYPED_TEST(stdlib_biggroup, twin_mul_with_infinity)
 {
     if constexpr (HasGoblinBuilder<TypeParam>) {
@@ -1935,12 +1891,12 @@ HEAVY_TYPED_TEST(stdlib_biggroup, twin_mul_with_infinity)
     };
 }
 
-HEAVY_TYPED_TEST(stdlib_biggroup, triple_edge_case)
+HEAVY_TYPED_TEST(stdlib_biggroup, batch_mul_linearly_dependent_generators)
 {
     if constexpr (HasGoblinBuilder<TypeParam>) {
         GTEST_SKIP() << "https://github.com/AztecProtocol/barretenberg/issues/1290";
     } else {
-        TestFixture::test_triple_edge_case();
+        TestFixture::test_batch_mul_linearly_dependent_generators();
     };
 }
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_edgecase_handling.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_edgecase_handling.hpp
@@ -33,7 +33,8 @@ typename G::affine_element element<C, Fq, Fr, G>::compute_table_offset_generator
 /**
  * @brief Given two lists of points that need to be multiplied by scalars, create a new list of length +1 with original
  * points masked, but the same scalar product sum
- * @details Add (δ)G, (δ²)G, (δ³)G etc to the original points and adds a new point (δⁿ⁺¹)⋅G and scalar x to the lists.
+ *
+ * @details Add (δ)G, (2δ)G, (4δ)G etc to the original points and adds a new point (2ⁿ)⋅G and scalar x to the lists.
  * By doubling the point every time, we ensure that no +-1 combination of 6 sequential elements run into edgecases.
  * Since the challenge δ not known to the prover ahead of time, it is not possible to create points that cancel out
  * the offset generators.
@@ -52,32 +53,39 @@ std::pair<std::vector<element<C, Fq, Fr, G>>, std::vector<Fr>> element<C, Fq, Fr
     const element offset_generator_element = element::from_witness(builder, native_offset_generator);
     offset_generator_element.set_origin_tag(OriginTag());
 
-    // Start the running scalar at δ
-    Fr running_scalar = masking_scalar;
+    // Compute initial point to be added: (δ)⋅G_offset
+    element running_point = offset_generator_element.scalar_mul(masking_scalar, 128);
+
+    // Start the running scalar at 1
+    Fr running_scalar = Fr(1);
     Fr last_scalar = Fr(0);
 
     // For each point and scalar
     for (size_t i = 0; i < _points.size(); i++) {
         scalars.push_back(_scalars[i]);
-        // Convert point into point + (δⁱ⁺¹)⋅G_offset
-        points.push_back(_points[i] + (offset_generator_element * running_scalar));
-        // Add \frac{2ⁱ⋅scalar}{2ⁿ} to the last scalar
+
+        // Convert point into point + (2ⁱ)⋅(δG_offset)
+        points.push_back(_points[i] + running_point);
+
+        // Add 2ⁱ⋅scalar_i to the last scalar
         last_scalar += _scalars[i] * running_scalar;
-        // Double the running scalar
-        running_scalar *= running_scalar;
+
+        // Double the running scalar and point for next iteration
+        running_scalar += running_scalar;
+        running_point = running_point.dbl();
     }
 
-    // Add a scalar -(<(δ, δ², δ³,...,δⁿ),(scalar₀,...,scalarₙ₋₁)> / δⁿ⁺¹)
+    // Add a scalar -(<δ(1, 2, 2²,...,2ⁿ⁻¹),(scalar₀,...,scalarₙ₋₁)> / 2ⁿ)
     const uint32_t n = static_cast<uint32_t>(_points.size());
-    const Fr masking_coefficient = masking_scalar.pow(n + 1);
-    const Fr masking_coefficient_inverse = masking_coefficient.invert();
-    last_scalar *= masking_coefficient_inverse;
+    const Fr two_power_n = Fr(2).pow(n);
+    const Fr two_power_n_inverse = two_power_n.invert();
+    last_scalar *= two_power_n_inverse;
     scalars.push_back(-last_scalar);
     if constexpr (Fr::is_composite) {
         scalars.back().self_reduce();
     }
-    // Add in-circuit G_offset to points
-    points.push_back(element(offset_generator_element * masking_coefficient));
+    // Add in-circuit 2ⁿ.(δ.G_offset) to points
+    points.push_back(running_point);
 
     return { points, scalars };
 }

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_edgecase_handling.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_edgecase_handling.hpp
@@ -81,7 +81,7 @@ template <typename C, class Fq, class Fr, class G>
 std::pair<std::vector<element<C, Fq, Fr, G>>, std::vector<Fr>> element<C, Fq, Fr, G>::handle_points_at_infinity(
     const std::vector<element>& _points, const std::vector<Fr>& _scalars)
 {
-    auto builder = _points[0].get_context();
+    C* builder = validate_context<C>(validate_context<C>(_points), validate_context<C>(_scalars));
     std::vector<element> points;
     std::vector<Fr> scalars;
     element one = element::one(builder);

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_edgecase_handling.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_edgecase_handling.hpp
@@ -33,42 +33,51 @@ typename G::affine_element element<C, Fq, Fr, G>::compute_table_offset_generator
 /**
  * @brief Given two lists of points that need to be multiplied by scalars, create a new list of length +1 with original
  * points masked, but the same scalar product sum
- * @details Add +1G, +2G, +4G etc to the original points and adds a new point 2ⁿ⋅G and scalar x to the lists. By
- * doubling the point every time, we ensure that no +-1 combination of 6 sequential elements run into edgecases, unless
- * the points are deliberately constructed to trigger it.
+ * @details Add (δ)G, (δ²)G, (δ³)G etc to the original points and adds a new point (δⁿ⁺¹)⋅G and scalar x to the lists.
+ * By doubling the point every time, we ensure that no +-1 combination of 6 sequential elements run into edgecases.
+ * Since the challenge δ not known to the prover ahead of time, it is not possible to create points that cancel out
+ * the offset generators.
  */
 template <typename C, class Fq, class Fr, class G>
 std::pair<std::vector<element<C, Fq, Fr, G>>, std::vector<Fr>> element<C, Fq, Fr, G>::mask_points(
-    const std::vector<element>& _points, const std::vector<Fr>& _scalars)
+    const std::vector<element>& _points, const std::vector<Fr>& _scalars, const Fr& masking_scalar)
 {
     std::vector<element> points;
     std::vector<Fr> scalars;
     BB_ASSERT_EQ(_points.size(), _scalars.size());
-    using NativeFr = typename Fr::native;
-    auto running_scalar = NativeFr::one();
+
     // Get the offset generator G_offset in native and in-circuit form
-    auto native_offset_generator = element::compute_table_offset_generator();
+    const typename G::affine_element native_offset_generator = element::compute_table_offset_generator();
+    C* builder = validate_context<C>(validate_context<C>(_points), validate_context<C>(_scalars));
+    const element offset_generator_element = element::from_witness(builder, native_offset_generator);
+    offset_generator_element.set_origin_tag(OriginTag());
+
+    // Start the running scalar at δ
+    Fr running_scalar = masking_scalar;
     Fr last_scalar = Fr(0);
-    NativeFr generator_coefficient = NativeFr(2).pow(_points.size());
-    auto generator_coefficient_inverse = generator_coefficient.invert();
+
     // For each point and scalar
     for (size_t i = 0; i < _points.size(); i++) {
         scalars.push_back(_scalars[i]);
-        // Convert point into point + 2ⁱ⋅G_offset
-        points.push_back(_points[i] + (native_offset_generator * running_scalar));
+        // Convert point into point + (δⁱ⁺¹)⋅G_offset
+        points.push_back(_points[i] + (offset_generator_element * running_scalar));
         // Add \frac{2ⁱ⋅scalar}{2ⁿ} to the last scalar
-        last_scalar += _scalars[i] * (running_scalar * generator_coefficient_inverse);
+        last_scalar += _scalars[i] * running_scalar;
         // Double the running scalar
-        running_scalar += running_scalar;
+        running_scalar *= running_scalar;
     }
 
-    // Add a scalar -(<(1,2,4,...,2ⁿ⁻¹ ),(scalar₀,...,scalarₙ₋₁)> / 2ⁿ)
+    // Add a scalar -(<(δ, δ², δ³,...,δⁿ),(scalar₀,...,scalarₙ₋₁)> / δⁿ⁺¹)
+    const uint32_t n = static_cast<uint32_t>(_points.size());
+    const Fr masking_coefficient = masking_scalar.pow(n + 1);
+    const Fr masking_coefficient_inverse = masking_coefficient.invert();
+    last_scalar *= masking_coefficient_inverse;
     scalars.push_back(-last_scalar);
     if constexpr (Fr::is_composite) {
         scalars.back().self_reduce();
     }
     // Add in-circuit G_offset to points
-    points.push_back(element(native_offset_generator * generator_coefficient));
+    points.push_back(element(offset_generator_element * masking_coefficient));
 
     return { points, scalars };
 }

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_goblin.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_goblin.hpp
@@ -295,7 +295,8 @@ template <class Builder_, class Fq, class Fr, class NativeGroup> class goblin_el
     static goblin_element batch_mul(const std::vector<goblin_element>& points,
                                     const std::vector<Fr>& scalars,
                                     const size_t max_num_bits = 0,
-                                    const bool handle_edge_cases = false);
+                                    const bool handle_edge_cases = false,
+                                    const Fr& masking_scalar = Fr(1));
 
     // we use this data structure to add together a sequence of points.
     // By tracking the previous values of x_1, y_1, \lambda, we can avoid

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_goblin_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_goblin_impl.hpp
@@ -38,7 +38,8 @@ template <typename C, class Fq, class Fr, class G>
 goblin_element<C, Fq, Fr, G> goblin_element<C, Fq, Fr, G>::batch_mul(const std::vector<goblin_element>& points,
                                                                      const std::vector<Fr>& scalars,
                                                                      [[maybe_unused]] const size_t max_num_bits,
-                                                                     [[maybe_unused]] const bool handle_edge_cases)
+                                                                     [[maybe_unused]] const bool handle_edge_cases,
+                                                                     [[maybe_unused]] const Fr& masking_scalar)
 {
     auto builder = points[0].get_context();
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_impl.hpp
@@ -691,7 +691,7 @@ element<C, Fq, Fr, G> element<C, Fq, Fr, G>::process_strauss_msm_rounds(const st
 
     // Check that all scalars are in range
     for (const auto& scalar : scalars) {
-        const size_t num_scalar_bits = uint512_t(scalar.get_value()).get_msb() + 1ULL;
+        const size_t num_scalar_bits = static_cast<size_t>(uint512_t(scalar.get_value()).get_msb()) + 1ULL;
         BB_ASSERT_LTE(num_scalar_bits, max_num_bits, "process_strauss_msm: scalar out of range");
     }
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_impl.hpp
@@ -720,30 +720,43 @@ element<C, Fq, Fr, G> element<C, Fq, Fr, G>::batch_mul(const std::vector<element
                                                        const bool with_edgecases,
                                                        const Fr& masking_scalar)
 {
+    // Sanity check input sizes
+    BB_ASSERT_GT(_points.size(), 0ULL, "biggroup batch_mul: no points provided for batch multiplication");
+    BB_ASSERT_EQ(_points.size(), _scalars.size(), "biggroup batch_mul: points and scalars size mismatch");
+
+    // Replace (∞, scalar) pairs by the pair (G, 0).
     auto [points, scalars] = handle_points_at_infinity(_points, _scalars);
+
+    BB_ASSERT_LTE(points.size(), _points.size());
+    BB_ASSERT_EQ(points.size(),
+                 scalars.size(),
+                 "biggroup batch_mul: points and scalars size mismatch after handling points at infinity");
+
+    // If batch_mul actually performs batch multiplication on the points and scalars, subprocedures can do
+    // operations like addition or subtraction of points, which can trigger OriginTag security mechanisms
+    // even though the final result satisfies the security logic. For example
+    // result = submitted_in_round_0 * challenge_from_round_0 + submitted_in_round_1 * challenge_in_round_1
+    // will trigger it, because the addition of submitted_in_round_0 to submitted_in_round_1 is dangerous by itself.
+    // To avoid this, we remove the tags, merge them separately and set the result appropriately
     OriginTag tag{};
     const auto empty_tag = OriginTag();
-
     for (size_t i = 0; i < _points.size(); i++) {
         tag = OriginTag(tag, OriginTag(_points[i].get_origin_tag(), _scalars[i].get_origin_tag()));
     }
     for (size_t i = 0; i < scalars.size(); i++) {
-        // If batch_mul actually performs batch multiplication on the points and scalars, subprocedures can do
-        // operations like addition or subtraction of points, which can trigger OriginTag security mechanisms
-        // even though the final result satisfies the security logic For example
-        // result = submitted_in_round_0 * challenge_from_round_0 + submitted_in_round_1 * challenge_in_round_1
-        // will trigger it, because the addition of submitted_in_round_0 to submitted_in_round_1 is dangerous by itself.
-        // To avoid this, we remove the tags, merge them separately and set the result appropriately
         points[i].set_origin_tag(empty_tag);
         scalars[i].set_origin_tag(empty_tag);
     }
 
-    // Perform goblinized batched mul if available; supported only for BN254
     if (with_edgecases) {
+        // If points are linearly dependent, we randomise them using a masking scalar.
+        // We do this to ensure that the x-coordinates of the points are all distinct. This is required
+        // while creating the ROM lookup table with the points.
         std::tie(points, scalars) = mask_points(points, scalars, masking_scalar);
     }
-    const size_t num_points = points.size();
-    BB_ASSERT_EQ(scalars.size(), num_points);
+
+    BB_ASSERT_EQ(
+        points.size(), scalars.size(), "biggroup batch_mul: points and scalars size mismatch after handling edgecases");
 
     // TODO: problem if there is a point at infinity, size of NAF(0) => 254 but rest of scalars will be < 254
     // TODO: problem if get_chain_initial_entry itself is point at infinity (example: (+1).6P + (-1).2P + (-1).3P = O)
@@ -762,19 +775,34 @@ element<C, Fq, Fr, G> element<C, Fq, Fr, G>::batch_mul(const std::vector<element
     // └───────┴─────────────────┘
     batch_lookup_table point_table(points);
 
+    // Determine number of rounds based on max_num_bits.
+    // Since NAf representation of 0 is not well-defined, we use the NAF representation of the field modulus
+    // for scalar 0. So if any scalar is 0, we must use the bit-length of the field modulus.
+    // This is inefficient, but 0 scalars should be rare in practice.
+    bool has_zero_scalar = false;
+    for (const auto& scalar : scalars) {
+        has_zero_scalar = has_zero_scalar || (scalar.get_value() == 0);
+    }
+    const size_t num_rounds = (max_num_bits == 0 || has_zero_scalar) ? Fr::modulus.get_msb() + 1 : max_num_bits;
+
+    // Compute NAF representations of scalars
+    const size_t num_points = points.size();
     std::vector<std::vector<bool_ct>> naf_entries;
     for (size_t i = 0; i < num_points; ++i) {
-        naf_entries.emplace_back(compute_naf(scalars[i], max_num_bits));
+        naf_entries.emplace_back(compute_naf(scalars[i], num_rounds));
     }
+
+    std::cout << "biggroup batch_mul: number of rounds = " << num_rounds << std::endl;
 
     // We choose a deterministic offset generator based on the number of rounds.
     // We compute both the initial and final offset generators: G_offset, 2ⁿ⁻¹ * G_offset.
-    const size_t num_rounds = (max_num_bits == 0) ? Fr::modulus.get_msb() + 1 : max_num_bits;
     const auto [offset_generator_start, offset_generator_end] = compute_offset_generators(num_rounds);
+
+    // Initialize accumulator with offset generator + first NAF column.
     element accumulator =
         element::chain_add_end(element::chain_add(offset_generator_start, point_table.get_chain_initial_entry()));
 
-    // Process 4 NAF entries per iteration (for the remaining [num_rounds - 1] rounds)
+    // Process 4 NAF entries per iteration (for the remaining (num_rounds - 1) rounds)
     constexpr size_t num_rounds_per_iteration = 4;
     const size_t num_iterations = numeric::ceil_div((num_rounds - 1), num_rounds_per_iteration);
     const size_t num_rounds_per_final_iteration = (num_rounds - 1) - ((num_iterations - 1) * num_rounds_per_iteration);
@@ -784,12 +812,17 @@ element<C, Fq, Fr, G> element<C, Fq, Fr, G>::batch_mul(const std::vector<element
         const size_t inner_num_rounds =
             (i != num_iterations - 1) ? num_rounds_per_iteration : num_rounds_per_final_iteration;
         for (size_t j = 0; j < inner_num_rounds; ++j) {
+            // Gather the NAF columns for this iteration
             std::vector<bool_ct> nafs(num_points);
             for (size_t k = 0; k < num_points; ++k) {
                 nafs[k] = (naf_entries[k][(i * num_rounds_per_iteration) + j + 1]);
             }
             to_add.emplace_back(point_table.get_chain_add_accumulator(nafs));
         }
+
+        // Once we have looked-up all points from the four NAF columns, we update the accumulator as:
+        // accumulator = 2.(2.(2.(2.accumulator + to_add[0]) + to_add[1]) + to_add[2]) + to_add[3]
+        //             = 2⁴.accumulator + 2³.to_add[0] + 2².to_add[1] + 2¹.to_add[2] + to_add[3]
         accumulator = accumulator.multiple_montgomery_ladder(to_add);
     }
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_impl.hpp
@@ -692,6 +692,26 @@ std::pair<element<C, Fq, Fr, G>, element<C, Fq, Fr, G>> element<C, Fq, Fr, G>::c
  * @param max_num_bits The max of the bit lengths of the scalars.
  * @param with_edgecases Use when points are linearly dependent. Randomises them.
  * @return element<C, Fq, Fr, G>
+ *
+ * @details This is an implementation of the Strauss algorithm for multi-scalar-multiplication (MSM).
+ *          It uses the Non-Adjacent Form (NAF) representation of scalars and ROM lookups to
+ *          efficiently compute the MSM. The algorithm processes 4 bits of each scalar per iteration,
+ *          accumulating the results in an accumulator point. The first NAF entry (I, see below) is used to
+ *          -------------------------------
+ *          Point  NAF(scalar)
+ *          G1    [+1, -1, -1, -1, +1, ...]
+ *          G2    [+1, +1, -1, -1, +1, ...]
+ *          G3    [-1, +1, +1, -1, +1, ...]
+ *                  ↑  ↑____________↑
+ *                  I    Iteration 1
+ *          -------------------------------
+ *          select the initial point to add to the offset generator. Thereafter, we process 4 NAF entries
+ *          per iteration. For one NAF entry, we lookup the corresponding points to add, and accumulate
+ *          them using `chain_add_accumulator`. After processing 4 NAF entries, we perform a single
+ *          `multiple_montgomery_ladder` call to update the accumulator. For example, in iteration 1 above,
+ *          for the second NAF entry, the lookup output is:
+ *          table(-1, +1, +1) = (-G1 + G2 + G3)
+ *          This lookup output is accumulated with the lookup outputs from the other 3 NAF entries.
  */
 template <typename C, class Fq, class Fr, class G>
 element<C, Fq, Fr, G> element<C, Fq, Fr, G>::batch_mul(const std::vector<element>& _points,
@@ -727,45 +747,44 @@ element<C, Fq, Fr, G> element<C, Fq, Fr, G>::batch_mul(const std::vector<element
 
     // TODO: problem if there is a point at infinity, size of NAF(0) => 254 but rest of scalars will be < 254
     // TODO: problem if get_chain_initial_entry itself is point at infinity (example: (+1).6P + (-1).2P + (-1).3P = O)
+    // ROM lookup table for points. Example if we have 3 points G1, G2, G3:
+    // ┌───────┬─────────────────┐
+    // │ Index │ Point           │
+    // ├───────┼─────────────────┤
+    // │   0   │  G1 + G2 + G3   │
+    // │   1   │  G1 + G2 - G3   │
+    // │   2   │  G1 - G2 + G3   │
+    // │   3   │  G1 - G2 - G3   │
+    // │   4   │ -G1 + G2 + G3   │
+    // │   5   │ -G1 + G2 - G3   │
+    // │   6   │ -G1 - G2 + G3   │
+    // │   7   │ -G1 - G2 - G3   │
+    // └───────┴─────────────────┘
     batch_lookup_table point_table(points);
-    const size_t num_rounds = (max_num_bits == 0) ? Fr::modulus.get_msb() + 1 : max_num_bits;
 
     std::vector<std::vector<bool_ct>> naf_entries;
     for (size_t i = 0; i < num_points; ++i) {
         naf_entries.emplace_back(compute_naf(scalars[i], max_num_bits));
     }
-    const auto offset_generators = compute_offset_generators(num_rounds);
-    element accumulator =
-        element::chain_add_end(element::chain_add(offset_generators.first, point_table.get_chain_initial_entry()));
 
-    // We use the Strauss algorithm to perform the MSM.
-    // Point  NAF(scalar)
-    // G1    [+1, -1, -1, -1, +1, ...]
-    // G2    [+1, +1, -1, -1, +1, ...]
-    // G3    [-1, +1, +1, -1, +1, ...]
-    //         ↑  ↑____________↑
-    //         I    Iteration 1
-    //
-    // The first NAF entry (I) is used to select the initial point to add to the offset generator.
-    // Thereafter, we process 4 NAF entries per iteration. For one NAF entry, we lookup the
-    // corresponding points to add, and accumulate them using `chain_add_accumulator`.
-    // After processing 4 NAF entries, we perform a single `multiple_montgomery_ladder` call to
-    // update the accumulator. For example, in iteration 1 above, for the second NAF entry, the lookup output is:
-    //
-    // table(-1, +1, +1) = (-G1 + G2 + G3)
-    //
-    // This lookup output is accumulated with the lookup outputs from the other 3 NAF entries.
-    //
+    // We choose a deterministic offset generator based on the number of rounds.
+    // We compute both the initial and final offset generators: G_offset, 2ⁿ⁻¹ * G_offset.
+    const size_t num_rounds = (max_num_bits == 0) ? Fr::modulus.get_msb() + 1 : max_num_bits;
+    const auto [offset_generator_start, offset_generator_end] = compute_offset_generators(num_rounds);
+    element accumulator =
+        element::chain_add_end(element::chain_add(offset_generator_start, point_table.get_chain_initial_entry()));
+
+    // Process 4 NAF entries per iteration (for the remaining [num_rounds - 1] rounds)
     constexpr size_t num_rounds_per_iteration = 4;
     const size_t num_iterations = numeric::ceil_div((num_rounds - 1), num_rounds_per_iteration);
     const size_t num_rounds_per_final_iteration = (num_rounds - 1) - ((num_iterations - 1) * num_rounds_per_iteration);
 
     for (size_t i = 0; i < num_iterations; ++i) {
-        std::vector<bool_ct> nafs(num_points);
         std::vector<element::chain_add_accumulator> to_add;
         const size_t inner_num_rounds =
             (i != num_iterations - 1) ? num_rounds_per_iteration : num_rounds_per_final_iteration;
         for (size_t j = 0; j < inner_num_rounds; ++j) {
+            std::vector<bool_ct> nafs(num_points);
             for (size_t k = 0; k < num_points; ++k) {
                 nafs[k] = (naf_entries[k][(i * num_rounds_per_iteration) + j + 1]);
             }
@@ -780,8 +799,8 @@ element<C, Fq, Fr, G> element<C, Fq, Fr, G>::batch_mul(const std::vector<element
         accumulator = accumulator.conditional_select(skew, naf_entries[i][num_rounds]);
     }
 
-    // Subtrac the scaled offset generator
-    accumulator = accumulator - offset_generators.second;
+    // Subtract the scaled offset generator
+    accumulator = accumulator - offset_generator_end;
 
     accumulator.set_origin_tag(tag);
     return accumulator;

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_impl.hpp
@@ -691,7 +691,7 @@ element<C, Fq, Fr, G> element<C, Fq, Fr, G>::process_strauss_msm_rounds(const st
 
     // Check that all scalars are in range
     for (const auto& scalar : scalars) {
-        const size_t num_scalar_bits = uint512_t(scalar.get_value()).get_msb() + 1;
+        const size_t num_scalar_bits = uint512_t(scalar.get_value()).get_msb() + 1ULL;
         BB_ASSERT_LTE(num_scalar_bits, max_num_bits, "process_strauss_msm: scalar out of range");
     }
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_impl.hpp
@@ -681,12 +681,22 @@ std::pair<element<C, Fq, Fr, G>, element<C, Fq, Fr, G>> element<C, Fq, Fr, G>::c
 }
 
 template <typename C, class Fq, class Fr, class G>
-element<C, Fq, Fr, G> element<C, Fq, Fr, G>::process_strauss_msm(const strauss_msm_data& msm_data)
+element<C, Fq, Fr, G> element<C, Fq, Fr, G>::process_strauss_msm_rounds(const std::vector<element>& points,
+                                                                        const std::vector<Fr>& scalars,
+                                                                        const size_t max_num_bits)
 {
-    // Unpack msm data
-    const std::vector<element>& points = msm_data.points;
-    const std::vector<Fr>& scalars = msm_data.scalars;
-    const size_t num_rounds = msm_data.num_bits;
+    // Sanity checks
+    BB_ASSERT_GT(points.size(), 0ULL, "process_strauss_msm: points cannot be empty");
+    BB_ASSERT_EQ(points.size(), scalars.size(), "process_strauss_msm: points and scalars size mismatch");
+
+    // Check that all scalars are in range
+    for (const auto& scalar : scalars) {
+        const size_t num_scalar_bits = uint512_t(scalar.get_value()).get_msb() + 1;
+        BB_ASSERT_LTE(num_scalar_bits, max_num_bits, "process_strauss_msm: scalar out of range");
+    }
+
+    // Constant parameters
+    const size_t num_rounds = max_num_bits;
     const size_t msm_size = scalars.size();
 
     // Compute ROM lookup table for points. Example if we have 3 points G1, G2, G3:
@@ -874,18 +884,18 @@ element<C, Fq, Fr, G> element<C, Fq, Fr, G>::batch_mul(const std::vector<element
                  small_scalars.size(),
                  "biggroup batch_mul: small points and scalars size mismatch after separating big scalars");
 
+    const size_t max_num_bits_in_field = Fr::modulus.get_msb() + 1;
     element accumulator;
     if (!big_points.empty()) {
         // Process big scalars separately
-        strauss_msm_data big_msm_data(big_points, big_scalars, /*max_num_bits*/ Fr::modulus.get_msb() + 1);
-        element big_result = element::process_strauss_msm(big_msm_data);
+        element big_result = element::process_strauss_msm_rounds(big_points, big_scalars, max_num_bits_in_field);
         accumulator = big_result;
     }
 
     if (!small_points.empty()) {
-        const size_t effective_max_num_bits = (max_num_bits == 0) ? (Fr::modulus.get_msb() + 1) : max_num_bits;
-        strauss_msm_data small_msm_data(small_points, small_scalars, effective_max_num_bits);
-        element small_result = element::process_strauss_msm(small_msm_data);
+        // Process small scalars
+        const size_t effective_max_num_bits = (max_num_bits == 0) ? max_num_bits_in_field : max_num_bits;
+        element small_result = element::process_strauss_msm_rounds(small_points, small_scalars, effective_max_num_bits);
         accumulator = (big_points.size() > 0) ? accumulator + small_result : small_result;
     }
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_impl.hpp
@@ -680,6 +680,80 @@ std::pair<element<C, Fq, Fr, G>, element<C, Fq, Fr, G>> element<C, Fq, Fr, G>::c
     return std::make_pair<element, element>(offset_generator, offset_generator_end);
 }
 
+template <typename C, class Fq, class Fr, class G>
+element<C, Fq, Fr, G> element<C, Fq, Fr, G>::process_strauss_msm(const strauss_msm_data& msm_data)
+{
+    // Unpack msm data
+    const std::vector<element>& points = msm_data.points;
+    const std::vector<Fr>& scalars = msm_data.scalars;
+    const size_t num_rounds = msm_data.num_bits;
+    const size_t msm_size = scalars.size();
+
+    // Compute ROM lookup table for points. Example if we have 3 points G1, G2, G3:
+    // ┌───────┬─────────────────┐
+    // │ Index │ Point           │
+    // ├───────┼─────────────────┤
+    // │   0   │  G1 + G2 + G3   │
+    // │   1   │  G1 + G2 - G3   │
+    // │   2   │  G1 - G2 + G3   │
+    // │   3   │  G1 - G2 - G3   │
+    // │   4   │ -G1 + G2 + G3   │
+    // │   5   │ -G1 + G2 - G3   │
+    // │   6   │ -G1 - G2 + G3   │
+    // │   7   │ -G1 - G2 - G3   │
+    // └───────┴─────────────────┘
+    batch_lookup_table point_table(points);
+
+    // Compute NAF representations of scalars
+    std::vector<std::vector<bool_ct>> naf_entries;
+    for (size_t i = 0; i < msm_size; ++i) {
+        naf_entries.emplace_back(compute_naf(scalars[i], num_rounds));
+    }
+
+    // We choose a deterministic offset generator based on the number of rounds.
+    // We compute both the initial and final offset generators: G_offset, 2ⁿ⁻¹ * G_offset.
+    const auto [offset_generator_start, offset_generator_end] = compute_offset_generators(num_rounds);
+
+    // Initialize accumulator with offset generator + first NAF column.
+    element accumulator =
+        element::chain_add_end(element::chain_add(offset_generator_start, point_table.get_chain_initial_entry()));
+
+    // Process 4 NAF entries per iteration (for the remaining (num_rounds - 1) rounds)
+    constexpr size_t num_rounds_per_iteration = 4;
+    const size_t num_iterations = numeric::ceil_div((num_rounds - 1), num_rounds_per_iteration);
+    const size_t num_rounds_per_final_iteration = (num_rounds - 1) - ((num_iterations - 1) * num_rounds_per_iteration);
+
+    for (size_t i = 0; i < num_iterations; ++i) {
+        std::vector<element::chain_add_accumulator> to_add;
+        const size_t inner_num_rounds =
+            (i != num_iterations - 1) ? num_rounds_per_iteration : num_rounds_per_final_iteration;
+        for (size_t j = 0; j < inner_num_rounds; ++j) {
+            // Gather the NAF columns for this iteration
+            std::vector<bool_ct> nafs(msm_size);
+            for (size_t k = 0; k < msm_size; ++k) {
+                nafs[k] = (naf_entries[k][(i * num_rounds_per_iteration) + j + 1]);
+            }
+            to_add.emplace_back(point_table.get_chain_add_accumulator(nafs));
+        }
+
+        // Once we have looked-up all points from the four NAF columns, we update the accumulator as:
+        // accumulator = 2.(2.(2.(2.accumulator + to_add[0]) + to_add[1]) + to_add[2]) + to_add[3]
+        //             = 2⁴.accumulator + 2³.to_add[0] + 2².to_add[1] + 2¹.to_add[2] + to_add[3]
+        accumulator = accumulator.multiple_montgomery_ladder(to_add);
+    }
+
+    // Subtract the skew factors (if any)
+    for (size_t i = 0; i < msm_size; ++i) {
+        element skew = accumulator - points[i];
+        accumulator = accumulator.conditional_select(skew, naf_entries[i][num_rounds]);
+    }
+
+    // Subtract the scaled offset generator
+    accumulator = accumulator - offset_generator_end;
+
+    return accumulator;
+}
+
 /**
  * @brief Generic batch multiplication that works for all elliptic curve types.
  *
@@ -748,6 +822,14 @@ element<C, Fq, Fr, G> element<C, Fq, Fr, G>::batch_mul(const std::vector<element
         scalars[i].set_origin_tag(empty_tag);
     }
 
+    // If with_edgecases is false, masking_scalar must be constant and equal to 1 (as it is unused).
+    if (!with_edgecases) {
+        BB_ASSERT_EQ(
+            masking_scalar.is_constant() && masking_scalar.get_value() == 1,
+            true,
+            "biggroup batch_mul: masking_scalar must be constant (and equal to 1) when with_edgecases is false");
+    }
+
     if (with_edgecases) {
         // If points are linearly dependent, we randomise them using a masking scalar.
         // We do this to ensure that the x-coordinates of the points are all distinct. This is required
@@ -758,82 +840,54 @@ element<C, Fq, Fr, G> element<C, Fq, Fr, G>::batch_mul(const std::vector<element
     BB_ASSERT_EQ(
         points.size(), scalars.size(), "biggroup batch_mul: points and scalars size mismatch after handling edgecases");
 
-    // TODO: problem if there is a point at infinity, size of NAF(0) => 254 but rest of scalars will be < 254
-    // TODO: problem if get_chain_initial_entry itself is point at infinity (example: (+1).6P + (-1).2P + (-1).3P = O)
-    // ROM lookup table for points. Example if we have 3 points G1, G2, G3:
-    // ┌───────┬─────────────────┐
-    // │ Index │ Point           │
-    // ├───────┼─────────────────┤
-    // │   0   │  G1 + G2 + G3   │
-    // │   1   │  G1 + G2 - G3   │
-    // │   2   │  G1 - G2 + G3   │
-    // │   3   │  G1 - G2 - G3   │
-    // │   4   │ -G1 + G2 + G3   │
-    // │   5   │ -G1 + G2 - G3   │
-    // │   6   │ -G1 - G2 + G3   │
-    // │   7   │ -G1 - G2 - G3   │
-    // └───────┴─────────────────┘
-    batch_lookup_table point_table(points);
-
-    // Determine number of rounds based on max_num_bits.
-    // Since NAf representation of 0 is not well-defined, we use the NAF representation of the field modulus
-    // for scalar 0. So if any scalar is 0, we must use the bit-length of the field modulus.
-    // This is inefficient, but 0 scalars should be rare in practice.
-    bool has_zero_scalar = false;
-    for (const auto& scalar : scalars) {
-        has_zero_scalar = has_zero_scalar || (scalar.get_value() == 0);
-    }
-    const size_t num_rounds = (max_num_bits == 0 || has_zero_scalar) ? Fr::modulus.get_msb() + 1 : max_num_bits;
-
-    // Compute NAF representations of scalars
-    const size_t num_points = points.size();
-    std::vector<std::vector<bool_ct>> naf_entries;
-    for (size_t i = 0; i < num_points; ++i) {
-        naf_entries.emplace_back(compute_naf(scalars[i], num_rounds));
-    }
-
-    std::cout << "biggroup batch_mul: number of rounds = " << num_rounds << std::endl;
-
-    // We choose a deterministic offset generator based on the number of rounds.
-    // We compute both the initial and final offset generators: G_offset, 2ⁿ⁻¹ * G_offset.
-    const auto [offset_generator_start, offset_generator_end] = compute_offset_generators(num_rounds);
-
-    // Initialize accumulator with offset generator + first NAF column.
-    element accumulator =
-        element::chain_add_end(element::chain_add(offset_generator_start, point_table.get_chain_initial_entry()));
-
-    // Process 4 NAF entries per iteration (for the remaining (num_rounds - 1) rounds)
-    constexpr size_t num_rounds_per_iteration = 4;
-    const size_t num_iterations = numeric::ceil_div((num_rounds - 1), num_rounds_per_iteration);
-    const size_t num_rounds_per_final_iteration = (num_rounds - 1) - ((num_iterations - 1) * num_rounds_per_iteration);
-
-    for (size_t i = 0; i < num_iterations; ++i) {
-        std::vector<element::chain_add_accumulator> to_add;
-        const size_t inner_num_rounds =
-            (i != num_iterations - 1) ? num_rounds_per_iteration : num_rounds_per_final_iteration;
-        for (size_t j = 0; j < inner_num_rounds; ++j) {
-            // Gather the NAF columns for this iteration
-            std::vector<bool_ct> nafs(num_points);
-            for (size_t k = 0; k < num_points; ++k) {
-                nafs[k] = (naf_entries[k][(i * num_rounds_per_iteration) + j + 1]);
+    // Separate out zero scalars and corresponding points (because NAF(0) = NAF(modulus) which is 254 bits long)
+    // Also add the last point and scalar to big_points and big_scalars (because its a 254-bit scalar)
+    // We do this only if max_num_bits != 0 (i.e. we are not forced to use 254 bits anyway)
+    const size_t original_size = scalars.size();
+    std::vector<Fr> big_scalars;
+    std::vector<element> big_points;
+    std::vector<Fr> small_scalars;
+    std::vector<element> small_points;
+    for (size_t i = 0; i < original_size; ++i) {
+        if (max_num_bits == 0) {
+            big_points.emplace_back(points[i]);
+            big_scalars.emplace_back(scalars[i]);
+        } else {
+            const bool is_last_scalar_big = ((i == original_size - 1) && with_edgecases);
+            if (scalars[i].get_value() == 0 || is_last_scalar_big) {
+                big_points.emplace_back(points[i]);
+                big_scalars.emplace_back(scalars[i]);
+            } else {
+                small_points.emplace_back(points[i]);
+                small_scalars.emplace_back(scalars[i]);
             }
-            to_add.emplace_back(point_table.get_chain_add_accumulator(nafs));
         }
-
-        // Once we have looked-up all points from the four NAF columns, we update the accumulator as:
-        // accumulator = 2.(2.(2.(2.accumulator + to_add[0]) + to_add[1]) + to_add[2]) + to_add[3]
-        //             = 2⁴.accumulator + 2³.to_add[0] + 2².to_add[1] + 2¹.to_add[2] + to_add[3]
-        accumulator = accumulator.multiple_montgomery_ladder(to_add);
     }
 
-    // Subtract the skew factors (if any)
-    for (size_t i = 0; i < num_points; ++i) {
-        element skew = accumulator - points[i];
-        accumulator = accumulator.conditional_select(skew, naf_entries[i][num_rounds]);
+    BB_ASSERT_EQ(original_size,
+                 small_points.size() + big_points.size(),
+                 "biggroup batch_mul: points size mismatch after separating big scalars");
+    BB_ASSERT_EQ(big_points.size(),
+                 big_scalars.size(),
+                 "biggroup batch_mul: big points and scalars size mismatch after separating big scalars");
+    BB_ASSERT_EQ(small_points.size(),
+                 small_scalars.size(),
+                 "biggroup batch_mul: small points and scalars size mismatch after separating big scalars");
+
+    element accumulator;
+    if (!big_points.empty()) {
+        // Process big scalars separately
+        strauss_msm_data big_msm_data(big_points, big_scalars, /*max_num_bits*/ Fr::modulus.get_msb() + 1);
+        element big_result = element::process_strauss_msm(big_msm_data);
+        accumulator = big_result;
     }
 
-    // Subtract the scaled offset generator
-    accumulator = accumulator - offset_generator_end;
+    if (!small_points.empty()) {
+        const size_t effective_max_num_bits = (max_num_bits == 0) ? (Fr::modulus.get_msb() + 1) : max_num_bits;
+        strauss_msm_data small_msm_data(small_points, small_scalars, effective_max_num_bits);
+        element small_result = element::process_strauss_msm(small_msm_data);
+        accumulator = (big_points.size() > 0) ? accumulator + small_result : small_result;
+    }
 
     accumulator.set_origin_tag(tag);
     return accumulator;

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_impl.hpp
@@ -697,7 +697,8 @@ template <typename C, class Fq, class Fr, class G>
 element<C, Fq, Fr, G> element<C, Fq, Fr, G>::batch_mul(const std::vector<element>& _points,
                                                        const std::vector<Fr>& _scalars,
                                                        const size_t max_num_bits,
-                                                       const bool with_edgecases)
+                                                       const bool with_edgecases,
+                                                       const Fr& masking_scalar)
 {
     auto [points, scalars] = handle_points_at_infinity(_points, _scalars);
     OriginTag tag{};
@@ -719,7 +720,7 @@ element<C, Fq, Fr, G> element<C, Fq, Fr, G>::batch_mul(const std::vector<element
 
     // Perform goblinized batched mul if available; supported only for BN254
     if (with_edgecases) {
-        std::tie(points, scalars) = mask_points(points, scalars);
+        std::tie(points, scalars) = mask_points(points, scalars, masking_scalar);
     }
     const size_t num_points = points.size();
     BB_ASSERT_EQ(scalars.size(), num_points);

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_impl.hpp
@@ -725,6 +725,8 @@ element<C, Fq, Fr, G> element<C, Fq, Fr, G>::batch_mul(const std::vector<element
     const size_t num_points = points.size();
     BB_ASSERT_EQ(scalars.size(), num_points);
 
+    // TODO: problem if there is a point at infinity, size of NAF(0) => 254 but rest of scalars will be < 254
+    // TODO: problem if get_chain_initial_entry itself is point at infinity (example: (+1).6P + (-1).2P + (-1).3P = O)
     batch_lookup_table point_table(points);
     const size_t num_rounds = (max_num_bits == 0) ? Fr::modulus.get_msb() + 1 : max_num_bits;
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_impl.hpp
@@ -10,6 +10,7 @@
 #include "../plookup/plookup.hpp"
 #include "barretenberg/common/assert.hpp"
 #include "barretenberg/ecc/groups/precomputed_generators.hpp"
+#include "barretenberg/numeric/general/general.hpp"
 #include "barretenberg/stdlib/primitives/biggroup/biggroup.hpp"
 #include "barretenberg/transcript/origin_tag.hpp"
 
@@ -138,10 +139,10 @@ element<C, Fq, Fr, G> element<C, Fq, Fr, G>::operator+(const element& other) con
 }
 
 /**
- * @brief Enforce x and y coordinates of a point to be (0,0) in the case of point at infinity
+ * @brief Enforce x and y coordinates of a point to be (0, 0) in the case of point at infinity
  *
  * @details We need to have a standard witness in Noir and the point at infinity can have non-zero random
- * coefficients when we get it as output from our optimized algorithms. This function returns a (0,0) point, if
+ * coefficients when we get it as output from our optimized algorithms. This function returns a (0, 0) point, if
  * it is a point at infinity
  */
 template <typename C, class Fq, class Fr, class G>
@@ -708,10 +709,10 @@ element<C, Fq, Fr, G> element<C, Fq, Fr, G>::batch_mul(const std::vector<element
     for (size_t i = 0; i < scalars.size(); i++) {
         // If batch_mul actually performs batch multiplication on the points and scalars, subprocedures can do
         // operations like addition or subtraction of points, which can trigger OriginTag security mechanisms
-        // even though the final result satisfies the security logic For example result = submitted_in_round_0
-        // *challenge_from_round_0 +submitted_in_round_1 * challenge_in_round_1 will trigger it, because the
-        // addition of submitted_in_round_0 to submitted_in_round_1 is dangerous by itself. To avoid this, we
-        // remove the tags, merge them separately and set the result appropriately
+        // even though the final result satisfies the security logic For example
+        // result = submitted_in_round_0 * challenge_from_round_0 + submitted_in_round_1 * challenge_in_round_1
+        // will trigger it, because the addition of submitted_in_round_0 to submitted_in_round_1 is dangerous by itself.
+        // To avoid this, we remove the tags, merge them separately and set the result appropriately
         points[i].set_origin_tag(empty_tag);
         scalars[i].set_origin_tag(empty_tag);
     }
@@ -734,28 +735,49 @@ element<C, Fq, Fr, G> element<C, Fq, Fr, G>::batch_mul(const std::vector<element
     element accumulator =
         element::chain_add_end(element::chain_add(offset_generators.first, point_table.get_chain_initial_entry()));
 
+    // We use the Strauss algorithm to perform the MSM.
+    // Point  NAF(scalar)
+    // G1    [+1, -1, -1, -1, +1, ...]
+    // G2    [+1, +1, -1, -1, +1, ...]
+    // G3    [-1, +1, +1, -1, +1, ...]
+    //         ↑  ↑____________↑
+    //         I    Iteration 1
+    //
+    // The first NAF entry (I) is used to select the initial point to add to the offset generator.
+    // Thereafter, we process 4 NAF entries per iteration. For one NAF entry, we lookup the
+    // corresponding points to add, and accumulate them using `chain_add_accumulator`.
+    // After processing 4 NAF entries, we perform a single `multiple_montgomery_ladder` call to
+    // update the accumulator. For example, in iteration 1 above, for the second NAF entry, the lookup output is:
+    //
+    // table(-1, +1, +1) = (-G1 + G2 + G3)
+    //
+    // This lookup output is accumulated with the lookup outputs from the other 3 NAF entries.
+    //
     constexpr size_t num_rounds_per_iteration = 4;
-    size_t num_iterations = num_rounds / num_rounds_per_iteration;
-    num_iterations += ((num_iterations * num_rounds_per_iteration) == num_rounds) ? 0 : 1;
+    const size_t num_iterations = numeric::ceil_div((num_rounds - 1), num_rounds_per_iteration);
     const size_t num_rounds_per_final_iteration = (num_rounds - 1) - ((num_iterations - 1) * num_rounds_per_iteration);
-    for (size_t i = 0; i < num_iterations; ++i) {
 
+    for (size_t i = 0; i < num_iterations; ++i) {
         std::vector<bool_ct> nafs(num_points);
         std::vector<element::chain_add_accumulator> to_add;
         const size_t inner_num_rounds =
             (i != num_iterations - 1) ? num_rounds_per_iteration : num_rounds_per_final_iteration;
         for (size_t j = 0; j < inner_num_rounds; ++j) {
             for (size_t k = 0; k < num_points; ++k) {
-                nafs[k] = (naf_entries[k][i * num_rounds_per_iteration + j + 1]);
+                nafs[k] = (naf_entries[k][(i * num_rounds_per_iteration) + j + 1]);
             }
             to_add.emplace_back(point_table.get_chain_add_accumulator(nafs));
         }
         accumulator = accumulator.multiple_montgomery_ladder(to_add);
     }
+
+    // Subtract the skew factors (if any)
     for (size_t i = 0; i < num_points; ++i) {
         element skew = accumulator - points[i];
         accumulator = accumulator.conditional_select(skew, naf_entries[i][num_rounds]);
     }
+
+    // Subtrac the scaled offset generator
     accumulator = accumulator - offset_generators.second;
 
     accumulator.set_origin_tag(tag);

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_nafs.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_nafs.hpp
@@ -351,7 +351,7 @@ typename element<C, Fq, Fr, G>::secp256k1_wnaf_pair element<C, Fq, Fr, G>::compu
      * This is more efficient than the non-staggered approach as we save 1 non-native field multiplication when we
      * replace a DBL, ADD subroutine with a call to the montgomery ladder
      */
-    C* ctx = scalar.context;
+    C* builder = scalar.get_context();
 
     constexpr size_t num_bits = 129;
 
@@ -383,11 +383,11 @@ typename element<C, Fq, Fr, G>::secp256k1_wnaf_pair element<C, Fq, Fr, G>::compu
 
     const auto [klo_reconstructed, klo_out] =
         element<C, Fq, Fr, G>::compute_secp256k1_single_wnaf<num_bits, wnaf_size, lo_stagger, hi_stagger>(
-            ctx, klo, lo_stagger, klo_negative, range_constrain_wnaf, true);
+            builder, klo, lo_stagger, klo_negative, range_constrain_wnaf, true);
 
     const auto [khi_reconstructed, khi_out] =
         element<C, Fq, Fr, G>::compute_secp256k1_single_wnaf<num_bits, wnaf_size, lo_stagger, hi_stagger>(
-            ctx, khi, hi_stagger, khi_negative, range_constrain_wnaf, false);
+            builder, khi, hi_stagger, khi_negative, range_constrain_wnaf, false);
 
     uint256_t minus_lambda_val(-secp256k1::fr::cube_root_of_unity());
     Fr minus_lambda(bb::fr(minus_lambda_val.slice(0, 136)), bb::fr(minus_lambda_val.slice(136, 256)), false);
@@ -404,7 +404,7 @@ template <typename C, class Fq, class Fr, class G>
 std::vector<bool_t<C>> element<C, Fq, Fr, G>::compute_naf(const Fr& scalar, const size_t max_num_bits)
 {
     // Get the circuit builder
-    C* ctx = scalar.context;
+    C* builder = scalar.get_context();
 
     // To compute the NAF representation, we first reduce the scalar modulo r (the scalar field modulus).
     uint512_t scalar_multiplier_512 = uint512_t(scalar.get_value()) % uint512_t(Fr::modulus);
@@ -433,7 +433,7 @@ std::vector<bool_t<C>> element<C, Fq, Fr, G>::compute_naf(const Fr& scalar, cons
     // Sidenote: we apply range constraints to the boolean witnesses instead of full 1-bit range gates.
     const bool skew_value = !scalar_multiplier.get_bit(0);
     scalar_multiplier += uint256_t(static_cast<uint64_t>(skew_value));
-    naf_entries[num_rounds] = bool_ct(witness_ct(ctx, skew_value), /*use_range_constraint*/ true);
+    naf_entries[num_rounds] = bool_ct(witness_ct(builder, skew_value), /*use_range_constraint*/ true);
 
     // We need to manually propagate the origin tag
     naf_entries[num_rounds].set_origin_tag(scalar.get_origin_tag());
@@ -443,7 +443,7 @@ std::vector<bool_t<C>> element<C, Fq, Fr, G>::compute_naf(const Fr& scalar, cons
         // Apply a basic range constraint per bool, and not a full 1-bit range gate. Results in ~`num_rounds`/4 gates
         // per scalar.
         const bool next_entry = scalar_multiplier.get_bit(i + 1);
-        naf_entries[num_rounds - i - 1] = bool_ct(witness_ct(ctx, !next_entry), /*use_range_constraint*/ true);
+        naf_entries[num_rounds - i - 1] = bool_ct(witness_ct(builder, !next_entry), /*use_range_constraint*/ true);
 
         // We need to manually propagate the origin tag
         naf_entries[num_rounds - i - 1].set_origin_tag(scalar.get_origin_tag());
@@ -451,7 +451,7 @@ std::vector<bool_t<C>> element<C, Fq, Fr, G>::compute_naf(const Fr& scalar, cons
 
     // The most significant NAF entry is always (+1) as we are working with scalars < 2^{max_num_bits}.
     // Recall that true represents (-1) and false represents (+1).
-    naf_entries[0] = bool_ct(witness_ct(ctx, false), /*use_range_constraint*/ true);
+    naf_entries[0] = bool_ct(witness_ct(builder, false), /*use_range_constraint*/ true);
     naf_entries[0].set_origin_tag(scalar.get_origin_tag());
 
     // validate correctness of NAF
@@ -488,7 +488,7 @@ std::vector<bool_t<C>> element<C, Fq, Fr, G>::compute_naf(const Fr& scalar, cons
             lo_accumulators = reconstruct_half_naf(&naf_entries[midpoint], num_rounds - midpoint);
         } else {
             // If the number of rounds is ≤ (2 * Fr::NUM_LIMB_BITS), the high bits of the resulting Fr element are 0.
-            const field_ct zero = field_ct::from_witness_index(ctx, ctx->zero_idx());
+            const field_ct zero = field_ct::from_witness_index(builder, builder->zero_idx());
             lo_accumulators = reconstruct_half_naf(&naf_entries[0], num_rounds);
             hi_accumulators = std::make_pair(zero, zero);
         }

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_nafs.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_nafs.hpp
@@ -73,7 +73,7 @@ std::vector<field_t<C>> element<C, Fq, Fr, G>::convert_wnaf_values_to_witnesses(
 {
     constexpr uint64_t wnaf_window_size = (1ULL << (wnaf_size - 1));
 
-    std::vector<field_t<C>> wnaf_entries;
+    std::vector<field_ct> wnaf_entries;
     for (size_t i = 0; i < rounds; ++i) {
         // Predicate == sign of current wnaf value
         const bool predicate = (wnaf_values[i] >> 31U) & 1U;            // sign bit (32nd bit)
@@ -88,7 +88,7 @@ std::vector<field_t<C>> element<C, Fq, Fr, G>::convert_wnaf_values_to_witnesses(
         } else {
             offset_wnaf_entry = wnaf_window_size - wnaf_magnitude - 1;
         }
-        field_t<C> wnaf_entry(witness_ct(builder, offset_wnaf_entry));
+        field_ct wnaf_entry(witness_ct(builder, offset_wnaf_entry));
 
         // In some cases we may want to skip range constraining the wnaf entries. For example when we use these
         // entries to lookup in a ROM or regular table, it implicitly enforces the range constraint.
@@ -111,22 +111,22 @@ Fr element<C, Fq, Fr, G>::reconstruct_bigfield_from_wnaf(Builder* builder,
                                                          const size_t rounds)
 {
     // Collect positive wnaf entries for accumulation
-    std::vector<field_t<C>> accumulator;
+    std::vector<field_ct> accumulator;
     for (size_t i = 0; i < rounds; ++i) {
-        field_t<C> entry = wnaf[rounds - 1 - i];
-        entry *= field_t<C>(uint256_t(1) << (i * wnaf_size));
+        field_ct entry = wnaf[rounds - 1 - i];
+        entry *= field_ct(uint256_t(1) << (i * wnaf_size));
         accumulator.emplace_back(entry);
     }
 
     // Accumulate entries, shift by stagger and add the stagger itself
-    field_t<C> sum = field_t<C>::accumulate(accumulator);
-    sum = sum * field_t<C>(bb::fr(1ULL << stagger));
+    field_ct sum = field_ct::accumulate(accumulator);
+    sum = sum * field_ct(bb::fr(1ULL << stagger));
     sum += (stagger_fragment);
     sum = sum.normalize();
 
     // Convert this value to bigfield element
     Fr reconstructed_positive_part =
-        Fr(sum, field_t<C>::from_witness_index(builder, builder->zero_idx()), /*can_overflow*/ false);
+        Fr(sum, field_ct::from_witness_index(builder, builder->zero_idx()), /*can_overflow*/ false);
 
     // Double the final value and add the positive skew
     reconstructed_positive_part =
@@ -199,7 +199,7 @@ std::pair<Fr, typename element<C, Fq, Fr, G>::secp256k1_wnaf> element<C, Fq, Fr,
 
     // Get wnaf witnesses
     // Note that we only range constrain the wnaf entries if range_constrain_wnaf is set to true.
-    std::vector<field_t<C>> wnaf = convert_wnaf_values_to_witnesses<wnaf_size>(
+    std::vector<field_ct> wnaf = convert_wnaf_values_to_witnesses<wnaf_size>(
         builder, &wnaf_values[0], is_negative, num_rounds_excluding_stagger_bits, range_constrain_wnaf);
 
     // Compute and constrain skews
@@ -212,7 +212,7 @@ std::pair<Fr, typename element<C, Fq, Fr, G>::secp256k1_wnaf> element<C, Fq, Fr,
         bool_ct(builder, true), "biggroup_nafs: both positive and negative skews cannot be set at the same time");
 
     // Initialize stagger witness
-    field_t<C> stagger_fragment = witness_ct(builder, first_fragment);
+    field_ct stagger_fragment = witness_ct(builder, first_fragment);
 
     // We only range constrain the stagger fragment if range_constrain_wnaf is set. This is because in some cases
     // we may use the stagger fragment to lookup in a ROM/regular table, which implicitly enforces the range constraint.
@@ -420,6 +420,13 @@ std::vector<bool_t<C>> element<C, Fq, Fr, G>::compute_naf(const Fr& scalar, cons
     }
 
     // NAF representation consists of num_rounds bits and a skew bit.
+    // Given a scalar k, we compute the NAF representation as follows:
+    //
+    // k = -skew + ₀∑ⁿ⁻¹ (1 - 2 * naf_i) * 2^i
+    //
+    // where naf_i = (1 - k_{i + 1}) ∈ {0, 1} and k_{i + 1} is the (i + 1)-th bit of the scalar k.
+    // If naf_i = 0, then the i-th NAF entry is +1, otherwise it is -1. See the README for more details.
+    //
     std::vector<bool_ct> naf_entries(num_rounds + 1);
 
     // If the scalar is even, we set the skew flag to true and add 1 to the scalar.
@@ -458,38 +465,36 @@ std::vector<bool_t<C>> element<C, Fq, Fr, G>::compute_naf(const Fr& scalar, cons
             entry *= static_cast<Fr>(uint256_t(1) << (i));
             accumulators.emplace_back(entry);
         }
-        accumulators.emplace_back(Fr(naf_entries[num_rounds]) * -1); // skew
+        accumulators.emplace_back(-Fr(naf_entries[num_rounds])); // -skew
         Fr accumulator_result = Fr::accumulate(accumulators);
         scalar.assert_equal(accumulator_result);
     } else {
         const auto reconstruct_half_naf = [](bool_ct* nafs, const size_t half_round_length) {
-            field_t<C> negative_accumulator(0);
-            field_t<C> positive_accumulator(0);
+            field_ct negative_accumulator(0);
+            field_ct positive_accumulator(0);
             for (size_t i = 0; i < half_round_length; ++i) {
-                negative_accumulator = negative_accumulator + negative_accumulator + field_t<C>(nafs[i]);
-                positive_accumulator =
-                    positive_accumulator + positive_accumulator + field_t<C>(1) - field_t<C>(nafs[i]);
+                negative_accumulator = negative_accumulator + negative_accumulator + field_ct(nafs[i]);
+                positive_accumulator = positive_accumulator + positive_accumulator + field_ct(1) - field_ct(nafs[i]);
             }
             return std::make_pair(positive_accumulator, negative_accumulator);
         };
 
-        std::pair<field_t<C>, field_t<C>> hi_accumulators;
-        std::pair<field_t<C>, field_t<C>> lo_accumulators;
+        std::pair<field_ct, field_ct> hi_accumulators;
+        std::pair<field_ct, field_ct> lo_accumulators;
 
         if (num_rounds > Fr::NUM_LIMB_BITS * 2) {
             const size_t midpoint = num_rounds - (Fr::NUM_LIMB_BITS * 2);
             hi_accumulators = reconstruct_half_naf(&naf_entries[0], midpoint);
             lo_accumulators = reconstruct_half_naf(&naf_entries[midpoint], num_rounds - midpoint);
         } else {
-            // If the number of rounds is smaller than Fr::NUM_LIMB_BITS, the high bits of the resulting Fr element are
-            // 0.
-            const field_t<C> zero = field_t<C>::from_witness_index(ctx, 0);
+            // If the number of rounds is ≤ (2 * Fr::NUM_LIMB_BITS), the high bits of the resulting Fr element are 0.
+            const field_ct zero = field_ct::from_witness_index(ctx, ctx->zero_idx());
             lo_accumulators = reconstruct_half_naf(&naf_entries[0], num_rounds);
             hi_accumulators = std::make_pair(zero, zero);
         }
 
         // Add the skew bit to the low accumulator's negative part
-        lo_accumulators.second = lo_accumulators.second + field_t<C>(naf_entries[num_rounds]);
+        lo_accumulators.second = lo_accumulators.second + field_ct(naf_entries[num_rounds]);
 
         Fr reconstructed_positive = Fr(lo_accumulators.first, hi_accumulators.first);
         Fr reconstructed_negative = Fr(lo_accumulators.second, hi_accumulators.second);

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_tables.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_tables.hpp
@@ -33,11 +33,11 @@ template <size_t num_elements>
 std::array<twin_rom_table<C>, Fq::NUM_LIMBS + 1> element<C, Fq, Fr, G>::create_group_element_rom_tables(
     const std::array<element, num_elements>& rom_data, std::array<uint256_t, Fq::NUM_LIMBS * 2>& limb_max)
 {
-    std::vector<std::array<field_t<C>, 2>> x_lo_limbs;
-    std::vector<std::array<field_t<C>, 2>> x_hi_limbs;
-    std::vector<std::array<field_t<C>, 2>> y_lo_limbs;
-    std::vector<std::array<field_t<C>, 2>> y_hi_limbs;
-    std::vector<std::array<field_t<C>, 2>> prime_limbs;
+    std::vector<std::array<field_ct, 2>> x_lo_limbs;
+    std::vector<std::array<field_ct, 2>> x_hi_limbs;
+    std::vector<std::array<field_ct, 2>> y_lo_limbs;
+    std::vector<std::array<field_ct, 2>> y_hi_limbs;
+    std::vector<std::array<field_ct, 2>> prime_limbs;
 
     for (size_t i = 0; i < num_elements; ++i) {
         limb_max[0] = std::max(limb_max[0], rom_data[i]._x.binary_basis_limbs[0].maximum_value);
@@ -49,16 +49,16 @@ std::array<twin_rom_table<C>, Fq::NUM_LIMBS + 1> element<C, Fq, Fr, G>::create_g
         limb_max[6] = std::max(limb_max[6], rom_data[i]._y.binary_basis_limbs[2].maximum_value);
         limb_max[7] = std::max(limb_max[7], rom_data[i]._y.binary_basis_limbs[3].maximum_value);
 
-        x_lo_limbs.emplace_back(std::array<field_t<C>, 2>{ rom_data[i]._x.binary_basis_limbs[0].element,
-                                                           rom_data[i]._x.binary_basis_limbs[1].element });
-        x_hi_limbs.emplace_back(std::array<field_t<C>, 2>{ rom_data[i]._x.binary_basis_limbs[2].element,
-                                                           rom_data[i]._x.binary_basis_limbs[3].element });
-        y_lo_limbs.emplace_back(std::array<field_t<C>, 2>{ rom_data[i]._y.binary_basis_limbs[0].element,
-                                                           rom_data[i]._y.binary_basis_limbs[1].element });
-        y_hi_limbs.emplace_back(std::array<field_t<C>, 2>{ rom_data[i]._y.binary_basis_limbs[2].element,
-                                                           rom_data[i]._y.binary_basis_limbs[3].element });
+        x_lo_limbs.emplace_back(std::array<field_ct, 2>{ rom_data[i].x.binary_basis_limbs[0].element,
+                                                         rom_data[i].x.binary_basis_limbs[1].element });
+        x_hi_limbs.emplace_back(std::array<field_ct, 2>{ rom_data[i].x.binary_basis_limbs[2].element,
+                                                         rom_data[i].x.binary_basis_limbs[3].element });
+        y_lo_limbs.emplace_back(std::array<field_ct, 2>{ rom_data[i].y.binary_basis_limbs[0].element,
+                                                         rom_data[i].y.binary_basis_limbs[1].element });
+        y_hi_limbs.emplace_back(std::array<field_ct, 2>{ rom_data[i].y.binary_basis_limbs[2].element,
+                                                         rom_data[i].y.binary_basis_limbs[3].element });
         prime_limbs.emplace_back(
-            std::array<field_t<C>, 2>{ rom_data[i]._x.prime_basis_limb, rom_data[i]._y.prime_basis_limb });
+            std::array<field_ct, 2>{ rom_data[i].x.prime_basis_limb, rom_data[i].y.prime_basis_limb });
     }
     std::array<twin_rom_table<C>, Fq::NUM_LIMBS + 1> output_tables;
     output_tables[0] = twin_rom_table<C>(x_lo_limbs);
@@ -73,7 +73,7 @@ template <typename C, class Fq, class Fr, class G>
 template <size_t>
 element<C, Fq, Fr, G> element<C, Fq, Fr, G>::read_group_element_rom_tables(
     const std::array<twin_rom_table<C>, Fq::NUM_LIMBS + 1>& tables,
-    const field_t<C>& index,
+    const field_ct& index,
     const std::array<uint256_t, Fq::NUM_LIMBS * 2>& limb_max)
 {
     const auto xlo = tables[0][index];
@@ -115,13 +115,13 @@ element<C, Fq, Fr, G>::four_bit_table_plookup::four_bit_table_plookup(const elem
 }
 
 template <typename C, class Fq, class Fr, class G>
-element<C, Fq, Fr, G> element<C, Fq, Fr, G>::four_bit_table_plookup::operator[](const field_t<C>& index) const
+element<C, Fq, Fr, G> element<C, Fq, Fr, G>::four_bit_table_plookup::operator[](const field_ct& index) const
 {
     return read_group_element_rom_tables<16>(coordinates, index, limb_max);
 }
 
 template <class C, class Fq, class Fr, class G>
-element<C, Fq, Fr, G> element<C, Fq, Fr, G>::eight_bit_fixed_base_table::operator[](const field_t<C>& index) const
+element<C, Fq, Fr, G> element<C, Fq, Fr, G>::eight_bit_fixed_base_table::operator[](const field_ct& index) const
 {
     const auto get_plookup_tags = [this]() {
         switch (curve_type) {
@@ -178,7 +178,7 @@ element<C, Fq, Fr, G> element<C, Fq, Fr, G>::eight_bit_fixed_base_table::operato
 template <typename C, class Fq, class Fr, class G>
 element<C, Fq, Fr, G> element<C, Fq, Fr, G>::eight_bit_fixed_base_table::operator[](const size_t index) const
 {
-    return operator[](field_t<C>(index));
+    return operator[](field_ct(index));
 }
 
 /**
@@ -331,11 +331,11 @@ template <size_t length>
 element<C, Fq, Fr, G> element<C, Fq, Fr, G>::lookup_table_plookup<length>::get(
     const std::array<bool_ct, length>& bits) const
 {
-    std::vector<field_t<C>> accumulators;
+    std::vector<field_ct> accumulators;
     for (size_t i = 0; i < length; ++i) {
-        accumulators.emplace_back(field_t<C>(bits[i]) * (1ULL << i));
+        accumulators.emplace_back(field_ct(bits[i]) * (1ULL << i));
     }
-    field_t<C> index = field_t<C>::accumulate(accumulators);
+    field_ct index = field_ct::accumulate(accumulators);
     return read_group_element_rom_tables<table_size>(coordinates, index, limb_max);
 }
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_tables.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_tables.hpp
@@ -49,16 +49,16 @@ std::array<twin_rom_table<C>, Fq::NUM_LIMBS + 1> element<C, Fq, Fr, G>::create_g
         limb_max[6] = std::max(limb_max[6], rom_data[i]._y.binary_basis_limbs[2].maximum_value);
         limb_max[7] = std::max(limb_max[7], rom_data[i]._y.binary_basis_limbs[3].maximum_value);
 
-        x_lo_limbs.emplace_back(std::array<field_ct, 2>{ rom_data[i].x.binary_basis_limbs[0].element,
-                                                         rom_data[i].x.binary_basis_limbs[1].element });
-        x_hi_limbs.emplace_back(std::array<field_ct, 2>{ rom_data[i].x.binary_basis_limbs[2].element,
-                                                         rom_data[i].x.binary_basis_limbs[3].element });
-        y_lo_limbs.emplace_back(std::array<field_ct, 2>{ rom_data[i].y.binary_basis_limbs[0].element,
-                                                         rom_data[i].y.binary_basis_limbs[1].element });
-        y_hi_limbs.emplace_back(std::array<field_ct, 2>{ rom_data[i].y.binary_basis_limbs[2].element,
-                                                         rom_data[i].y.binary_basis_limbs[3].element });
+        x_lo_limbs.emplace_back(std::array<field_ct, 2>{ rom_data[i]._x.binary_basis_limbs[0].element,
+                                                         rom_data[i]._x.binary_basis_limbs[1].element });
+        x_hi_limbs.emplace_back(std::array<field_ct, 2>{ rom_data[i]._x.binary_basis_limbs[2].element,
+                                                         rom_data[i]._x.binary_basis_limbs[3].element });
+        y_lo_limbs.emplace_back(std::array<field_ct, 2>{ rom_data[i]._y.binary_basis_limbs[0].element,
+                                                         rom_data[i]._y.binary_basis_limbs[1].element });
+        y_hi_limbs.emplace_back(std::array<field_ct, 2>{ rom_data[i]._y.binary_basis_limbs[2].element,
+                                                         rom_data[i]._y.binary_basis_limbs[3].element });
         prime_limbs.emplace_back(
-            std::array<field_ct, 2>{ rom_data[i].x.prime_basis_limb, rom_data[i].y.prime_basis_limb });
+            std::array<field_ct, 2>{ rom_data[i]._x.prime_basis_limb, rom_data[i]._y.prime_basis_limb });
     }
     std::array<twin_rom_table<C>, Fq::NUM_LIMBS + 1> output_tables;
     output_tables[0] = twin_rom_table<C>(x_lo_limbs);

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/mega_transcript.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/mega_transcript.test.cpp
@@ -142,6 +142,7 @@ template <typename Flavor> class MegaTranscriptTests : public ::testing::Test {
 
         round++;
         manifest_expected.add_entry(round, "KZG:W", frs_per_G);
+        manifest_expected.add_challenge(round, "KZG:masking_challenge");
 
         return manifest_expected;
     }

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_transcript.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_transcript.test.cpp
@@ -163,6 +163,7 @@ template <typename Flavor> class UltraTranscriptTests : public ::testing::Test {
 
         round++;
         manifest_expected.add_entry(round, "KZG:W", data_types_per_G);
+        manifest_expected.add_challenge(round, "KZG:masking_challenge");
 
         return manifest_expected;
     }


### PR DESCRIPTION
### 🧾 Audit Context

Cleanup in `batch_mul` of biggroup, makes the masking of points dependent on a challenge.

### 🛠️ Changes Made

- In ultra recursive verifier, the masking of points (before we perform MSM) in `batch_mul` is now done with a generator that's dependent on a challenge. This avoids a malicious prover from supplying linearly dependent group elements to intentionally cause a circuit failure in `batch_mul`. 
- Minor cosmetic cleanup like: `field_t<C>` → `field_ct`, usage of `validate_context`, and so on.
- Bug fixes in `batch_mul` (described in PR comments)

### ✅ Checklist

- [x] Audited all methods of the relevant module/class
- [x] Audited the interface of the module/class with other (relevant) components
- [x] Documented existing functionality and any changes made (as per Doxygen requirements)
- [x] Resolved and/or closed all issues/TODOs pertaining to the audited files
- [x] Confirmed and documented any security or other issues found (if applicable)
- [x] Verified that tests cover all critical paths (and added tests if necessary)
- [ ] Updated audit tracking for the files audited (check the start of each file you audited)

### 📌 Notes for Reviewers

- Check the Strauss documentation in README (in `biggroup`)
- Check the `batch_mul` changes carefully, there is one minor bug fix, and one minor refactor.
