### PR TITLE
fix(docs): update links in how_to_define_storage.md to include aztec version

### DIFF
--- a/docs/docs/developers/docs/guides/smart_contracts/how_to_define_storage.md
+++ b/docs/docs/developers/docs/guides/smart_contracts/how_to_define_storage.md
@@ -98,7 +98,7 @@ All private storage operates on note types rather than arbitrary data types. Lea
 
 PrivateMutable is a private state variable that is unique in a way. When a PrivateMutable is initialized, a note is created to represent its value. Updating the value means to destroy the current note, and to create a new one with the updated value.
 
-Like for public state, we define the struct to have context and a storage slot. You can view the implementation [here](https://github.com/AztecProtocol/aztec-packages/blob/master/noir-projects/smart-contracts/aztec/src/state_vars/private_mutable.nr).
+Like for public state, we define the struct to have context and a storage slot. You can view the implementation [here](https://github.com/AztecProtocol/aztec-packages/blob/#include_aztec_version/noir-projects/aztec-nr/aztec/src/state_vars/private_mutable.nr).
 
 An example of `PrivateMutable` usage in contracts is keeping track of important values. The `PrivateMutable` is added to the `Storage` struct as follows:
 
@@ -116,17 +116,18 @@ Unlike public states, which have a default initial value of `0` (or many zeros, 
 
 #### `is_initialized`
 
-An unconstrained method to check whether the PrivateMutable has been initialized or not. It takes an optional owner and returns a boolean. You can view the implementation [here (GitHub link)](https://github.com/AztecProtocol/aztec-packages/blob/#include_aztec_version/noir-projects/smart-contracts/aztec/src/state_vars/private_mutable.nr).
+An unconstrained method to check whether the PrivateMutable has been initialized or not. It takes an optional owner and returns a boolean. You can view the implementation [here (GitHub link)](https://github.com/AztecProtocol/aztec-packages/blob/#include_aztec_version/noir-projects/aztec-nr/aztec/src/state_vars/private_mutable.nr).
 
 ```rust
 let is_initialized = my_value.is_initialized();
 ```
-s
+
 #### `replace`
 
 To update the value of a `PrivateMutable`, we can use the `replace` method. The method takes a function (or closure) that transforms the current note into a new one.
 
 When called, the method will:
+
 - Nullify the old note
 - Apply the transform function to produce a new note
 - Insert the new note into the data tree
@@ -168,7 +169,7 @@ Functionally similar to [`get_note`](#get_note), but executed in unconstrained f
 
 ### PrivateImmutable
 
-`PrivateImmutable` represents a unique private state variable that, as the name suggests, is immutable. Once initialized, its value cannot be altered. You can view the implementation [here (GitHub link)](https://github.com/AztecProtocol/aztec-packages/blob/#include_aztec_version/noir-projects/smart-contracts/aztec/src/state_vars/private_immutable.nr).
+`PrivateImmutable` represents a unique private state variable that, as the name suggests, is immutable. Once initialized, its value cannot be altered. You can view the implementation [here (GitHub link)](https://github.com/AztecProtocol/aztec-packages/blob/#include_aztec_version/noir-projects/aztec-nr/aztec/src/state_vars/private_immutable.nr).
 
 #### `initialize`
 
@@ -198,7 +199,7 @@ Once initialized, an PrivateImmutable's value remains unchangeable. This method 
 
 #### `is_initialized`
 
-An unconstrained method to check if the PrivateImmutable has been initialized. Takes an optional owner and returns a boolean. You can find the implementation [here (GitHub link)](https://github.com/AztecProtocol/aztec-packages/blob/#include_aztec_version/noir-projects/smart-contracts/aztec/src/state_vars/private_immutable.nr).
+An unconstrained method to check if the PrivateImmutable has been initialized. Takes an optional owner and returns a boolean. You can find the implementation [here (GitHub link)](https://github.com/AztecProtocol/aztec-packages/blob/#include_aztec_version/noir-projects/aztec-nr/aztec/src/state_vars/private_immutable.nr).
 
 #### `get_note`
 
@@ -284,7 +285,7 @@ let mut options = NoteViewerOptions::new();
 let notes = set.view_notes(options.set_offset(offset));
 ```
 
-There's also a limit on the maximum number of notes that can be returned in one go. To find the current limit, refer to [this file (GitHub link)](https://github.com/AztecProtocol/aztec-packages/blob/#include_aztec_version/noir-projects/smart-contracts/aztec/src/note/constants.nr) and look for `MAX_NOTES_PER_PAGE`.
+There's also a limit on the maximum number of notes that can be returned in one go. To find the current limit, refer to [this file (GitHub link)](https://github.com/AztecProtocol/aztec-packages/blob/#include_aztec_version/noir-projects/aztec-nr/aztec/src/note/constants.nr) and look for `MAX_NOTES_PER_PAGE`.
 
 The key distinction is that this method is unconstrained. It does not perform a check to verify if the notes actually exist, which is something the [`get_notes`](#get_notes) method does under the hood. Therefore, it should only be used in an unconstrained contract function.
 
@@ -304,7 +305,7 @@ Both types are generic over any serializable type `T`, allowing you to store sim
 Store mutable public state using `PublicMutable<T>` for values that need to be updated throughout the contract's lifecycle.
 
 :::info
-An example using a larger struct can be found in the [lending example](https://github.com/AztecProtocol/aztec-packages/tree/master/noir-projects/noir-contracts/contracts/app/lending_contract)'s use of an [`Asset`](https://github.com/AztecProtocol/aztec-packages/tree/#include_aztec_version/noir-projects/noir-contracts/contracts/app/lending_contract/src/asset.nr).
+An example using a larger struct can be found in the [lending example](https://github.com/AztecProtocol/aztec-packages/tree/#include_aztec_version/noir-projects/noir-contracts/contracts/app/lending_contract)'s use of an [`Asset`](https://github.com/AztecProtocol/aztec-packages/tree/#include_aztec_version/noir-projects/noir-contracts/contracts/app/lending_contract/src/asset.nr).
 :::
 
 For example, to add `config_value` public state variable into our storage struct, we can define it as:
@@ -346,7 +347,7 @@ Just like the `PublicMutable` it is generic over the variable type `T`. The type
 my_public_immutable: PublicImmutable<MyStruct, Context>,
 ```
 
-You can find the details of `PublicImmutable` in the implementation [here (GitHub link)](https://github.com/AztecProtocol/aztec-packages/blob/#include_aztec_version/noir-projects/smart-contracts/aztec/src/state_vars/public_immutable.nr).
+You can find the details of `PublicImmutable` in the implementation [here (GitHub link)](https://github.com/AztecProtocol/aztec-packages/blob/#include_aztec_version/noir-projects/aztec-nr/aztec/src/state_vars/public_immutable.nr).
 
 #### `new`
 
@@ -405,7 +406,7 @@ Delayed Public Mutable state works around this by introducing **delays**:
 
 - Instead, a value change is be scheduled ahead of time, and some minimum amount of time must pass between the scheduling and the new value taking effect.
 - This means that we can privately prove that a historical public value cannot possibly change before some point in the future (due to the minimum delay), and therefore that our transaction will be valid **as long as it gets included before this future time**.
-- In other words, we're saying "this value is public but can't change until ___".
+- In other words, we're saying "this value is public but can't change until \_\_\_".
 
 This results in the following key properties of `DelayedPublicMutable` state:
 


### PR DESCRIPTION
Updated multiple implementation links in the documentation for `PrivateMutable`, `PrivateImmutable`, and `PublicImmutable` to include the aztec version in the URL structure for better clarity and consistency.
