### PR TITLE
fix: qol for running fuzzer

### DIFF
--- a/yarn-project/simulator/package.json
+++ b/yarn-project/simulator/package.json
@@ -20,7 +20,8 @@
     "build": "yarn clean && tsc -b",
     "build:dev": "tsc -b --watch",
     "clean": "rm -rf ./dest .tsbuildinfo",
-    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --passWithNoTests --maxWorkers=${JEST_MAX_WORKERS:-8}"
+    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --passWithNoTests --maxWorkers=${JEST_MAX_WORKERS:-8}",
+    "build:fuzzer": "tsc scripts/fuzzing/avm_simulator_bin.ts --outDir dest/scripts/fuzzing --module commonjs --target es2022 --esModuleInterop --allowSyntheticDefaultImports --resolveJsonModule --skipLibCheck"
   },
   "inherits": [
     "../package.common.json"

--- a/yarn-project/simulator/scripts/fuzzing/README.md
+++ b/yarn-project/simulator/scripts/fuzzing/README.md
@@ -2,6 +2,10 @@
 
 Coverage based fuzzing AVM vs Brillig based on [ssa_fuzzer](https://github.com/noir-lang/noir/tree/master/tooling/ssa_fuzzer)
 
+# Requirements
+1) Cargo Fuzz: `cargo install cargo-fuzz`
+2) Rust Nightly compiler: `rustup install nightly`
+
 ## Overview
 How fuzz loop looks like:
 1) Fuzzer generates Noir [SSA](https://en.wikipedia.org/wiki/Static_single-assignment_form), compiles it into Brillig bytecode and executes it

--- a/yarn-project/simulator/scripts/run_avm_brilling_fuzz.sh
+++ b/yarn-project/simulator/scripts/run_avm_brilling_fuzz.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Get the git root directory
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GIT_ROOT="$(cd "$SCRIPT_DIR" && git rev-parse --show-toplevel 2>/dev/null || echo "")"
+
+# Default paths (relative to git root)
+DEFAULT_NOIR_ROOT="$GIT_ROOT/noir/noir-repo"
+DEFAULT_TRANSPILER_BIN="$GIT_ROOT/avm-transpiler/target/release/avm-transpiler"
+DEFAULT_SIMULATOR_BIN="$GIT_ROOT/yarn-project/simulator/dest/scripts/fuzzing/avm_simulator_bin.cjs"
+
+# Usage information
+usage() {
+    echo "Usage: $0 [OPTIONS]"
+    echo ""
+    echo "Options:"
+    echo "  --noir-path PATH        Path to the Noir repository root"
+    echo "                          Default: $DEFAULT_NOIR_ROOT"
+    echo ""
+    echo "  --transpiler-path PATH  Path to the avm_transpiler binary"
+    echo "                          Default: $DEFAULT_TRANSPILER_BIN"
+    echo ""
+    echo "  --simulator-path PATH   Path to the avm_simulator_bin.cjs file"
+    echo "                          Default: $DEFAULT_SIMULATOR_BIN"
+    echo ""
+    echo "  -h, --help             Show this help message"
+    echo ""
+    echo "Example:"
+    echo "  $0"
+    echo "  $0 --noir-path /path/to/noir"
+    echo "  $0 --transpiler-path /path/to/avm_transpiler --simulator-path /path/to/simulator.cjs"
+    exit 1
+}
+
+# Initialize with defaults
+NOIR_ROOT_DIR="$DEFAULT_NOIR_ROOT"
+TRANSPILER_BIN="$DEFAULT_TRANSPILER_BIN"
+SIMULATOR_BIN="$DEFAULT_SIMULATOR_BIN"
+
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --noir-path)
+            NOIR_ROOT_DIR="$2"
+            shift 2
+            ;;
+        --transpiler-path)
+            TRANSPILER_BIN="$2"
+            shift 2
+            ;;
+        --simulator-path)
+            SIMULATOR_BIN="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            ;;
+        *)
+            echo -e "${RED}Error: Unknown option: $1${NC}"
+            echo ""
+            usage
+            ;;
+    esac
+done
+
+# Validate paths
+if [ ! -d "$NOIR_ROOT_DIR" ]; then
+    echo -e "${RED}Error: Noir root directory does not exist: $NOIR_ROOT_DIR${NC}"
+    exit 1
+fi
+
+if [ ! -f "$TRANSPILER_BIN" ]; then
+    echo -e "${RED}Error: AVM transpiler binary does not exist: $TRANSPILER_BIN${NC}"
+    exit 1
+fi
+
+if [ ! -f "$SIMULATOR_BIN" ]; then
+    echo -e "${RED}Error: AVM simulator binary does not exist: $SIMULATOR_BIN${NC}"
+    exit 1
+fi
+
+# Check for ssa_fuzzer directory in noir-repo
+FUZZER_DIR="$NOIR_ROOT_DIR/tooling/ssa_fuzzer/fuzzer"
+if [ ! -d "$FUZZER_DIR" ]; then
+    echo -e "${RED}Error: Fuzzer directory does not exist: $FUZZER_DIR${NC}"
+    echo -e "${YELLOW}Make sure PATH_TO_NOIR_ROOT_DIR points to the Noir repository root.${NC}"
+    exit 1
+fi
+
+echo -e "${GREEN}Building fuzzer...${NC}"
+yarn build:fuzzer
+
+echo -e "${GREEN}Checking for cargo-fuzz installation...${NC}"
+
+# Check if cargo-fuzz is installed
+if ! cargo fuzz --version &> /dev/null; then
+    echo -e "${RED}Error: cargo-fuzz is not installed.${NC}"
+    echo ""
+    echo -e "${YELLOW}To install cargo-fuzz, run:${NC}"
+    echo -e "  ${GREEN}cargo install cargo-fuzz${NC}"
+    echo ""
+    echo -e "${YELLOW}Note: cargo-fuzz requires a nightly Rust toolchain.${NC}"
+    echo -e "If you don't have it, install with:${NC}"
+    echo -e "  ${GREEN}rustup install nightly${NC}"
+    echo ""
+    exit 1
+fi
+
+echo -e "${GREEN}cargo-fuzz is installed: $(cargo fuzz --version)${NC}"
+echo -e "${GREEN}Build complete!${NC}"
+echo ""
+echo -e "${GREEN}Starting fuzzer with:${NC}"
+echo -e "  Noir root:    $NOIR_ROOT_DIR"
+echo -e "  Transpiler:   $TRANSPILER_BIN"
+echo -e "  Simulator:    $SIMULATOR_BIN"
+echo ""
+
+# Run the fuzzer
+cd "$FUZZER_DIR"
+SIMULATOR_BIN_PATH="$SIMULATOR_BIN" TRANSPILER_BIN_PATH="$TRANSPILER_BIN" cargo +nightly fuzz run --fuzz-dir . brillig -- -max_len=10000

--- a/yarn-project/simulator/tsconfig.json
+++ b/yarn-project/simulator/tsconfig.json
@@ -44,5 +44,7 @@
       "path": "../noir-test-contracts.js"
     }
   ],
-  "include": ["src"]
+  "include": ["src"],
+  // Note(ilyas): This exclude kinda redundant now, but a reminder for when we move the fuzzer into /src/avm
+  "exclude": ["scripts/fuzzing/avm_simulator_bin.ts"]
 }


### PR DESCRIPTION
This (hopefully) makes it easier to run the avm<>brillig fuzzer via the magic of a claude-cobbled script.

The script (optionally) takes in 3 paths to the `noir-repo`, `avm-transpiler`, and `fuzzer-binary` respectively. If not provided the default should work for a standard aztec-packages layout.