### PR TITLE
chore: suppress git clone stderr in cmake dependency installation

### DIFF
--- a/barretenberg/cpp/cmake/backward-cpp.cmake
+++ b/barretenberg/cpp/cmake/backward-cpp.cmake
@@ -13,7 +13,7 @@ if(ENABLE_STACKTRACES)
         PREFIX ${BACKWARD_PREFIX}
         # We need to go through some hoops to do a shallow clone of a fixed commit (as opposed to a tag).
         DOWNLOAD_COMMAND
-            sh -c "mkdir -p ${BACKWARD_PREFIX}/src/backward && cd ${BACKWARD_PREFIX}/src/backward && git init . && (git remote add origin https://github.com/bombela/backward-cpp || true) && git fetch --depth 1 origin 51f0700452cf71c57d43c2d028277b24cde32502 && git checkout FETCH_HEAD"
+            sh -c "mkdir -p ${BACKWARD_PREFIX}/src/backward && cd ${BACKWARD_PREFIX}/src/backward && git init . 2>/dev/null && (git remote add origin https://github.com/bombela/backward-cpp 2>/dev/null || true) && git fetch --depth 1 origin 51f0700452cf71c57d43c2d028277b24cde32502 2>/dev/null && git checkout FETCH_HEAD 2>/dev/null"
         SOURCE_DIR ${BACKWARD_PREFIX}/src/backward
         CONFIGURE_COMMAND ""
         BUILD_COMMAND ""

--- a/barretenberg/cpp/cmake/lmdb.cmake
+++ b/barretenberg/cpp/cmake/lmdb.cmake
@@ -11,7 +11,7 @@ ExternalProject_Add(
     PREFIX ${LMDB_PREFIX}
     # We need to go through some hoops to do a shallow clone of a fixed commit (as opposed to a tag).
     DOWNLOAD_COMMAND
-        sh -c "mkdir -p ${LMDB_PREFIX}/src/lmdb_repo && cd ${LMDB_PREFIX}/src/lmdb_repo && git init . && (git remote add origin https://github.com/LMDB/lmdb.git || true) && git fetch --depth 1 origin ddd0a773e2f44d38e4e31ec9ed81af81f4e4ccbb && git checkout FETCH_HEAD"
+        sh -c "mkdir -p ${LMDB_PREFIX}/src/lmdb_repo && cd ${LMDB_PREFIX}/src/lmdb_repo && git init . 2>/dev/null && (git remote add origin https://github.com/LMDB/lmdb.git 2>/dev/null || true) && git fetch --depth 1 origin ddd0a773e2f44d38e4e31ec9ed81af81f4e4ccbb 2>/dev/null && git checkout FETCH_HEAD 2>/dev/null"
     SOURCE_DIR ${LMDB_PREFIX}/src/lmdb_repo
     BUILD_IN_SOURCE YES
     CONFIGURE_COMMAND "" # No configure step

--- a/barretenberg/cpp/cmake/msgpack.cmake
+++ b/barretenberg/cpp/cmake/msgpack.cmake
@@ -9,7 +9,7 @@ ExternalProject_Add(
     PREFIX ${MSGPACK_PREFIX}
     # We need to go through some hoops to do a shallow clone of a fixed commit (as opposed to a tag).
     DOWNLOAD_COMMAND
-        sh -c "mkdir -p ${MSGPACK_PREFIX}/src/msgpack-c && cd ${MSGPACK_PREFIX}/src/msgpack-c && git init . && (git remote add origin https://github.com/AztecProtocol/msgpack-c.git || true) && git fetch --depth 1 origin 5ee9a1c8c325658b29867829677c7eb79c433a98 && git checkout FETCH_HEAD"
+        sh -c "mkdir -p ${MSGPACK_PREFIX}/src/msgpack-c && cd ${MSGPACK_PREFIX}/src/msgpack-c && git init . 2>/dev/null && (git remote add origin https://github.com/AztecProtocol/msgpack-c.git 2>/dev/null || true) && git fetch --depth 1 origin 5ee9a1c8c325658b29867829677c7eb79c433a98 2>/dev/null && git checkout FETCH_HEAD 2>/dev/null"
     SOURCE_DIR ${MSGPACK_PREFIX}/src/msgpack-c
     CONFIGURE_COMMAND ""  # No configure step
     BUILD_COMMAND ""      # No build step

--- a/barretenberg/cpp/cmake/nlohmann_json.cmake
+++ b/barretenberg/cpp/cmake/nlohmann_json.cmake
@@ -3,7 +3,7 @@ set(NLOHMANN_JSON_SOURCE_DIR "${CMAKE_BINARY_DIR}/_deps/nlohmann_json-src")
 set(NLOHMANN_JSON_COMMIT_HASH "9cca280a4d0ccf0c08f47a99aa71d1b0e52f8d03")
 
 execute_process(
-    COMMAND sh -c "mkdir -p ${NLOHMANN_JSON_SOURCE_DIR} && cd ${NLOHMANN_JSON_SOURCE_DIR} && git init . && (git remote add origin https://github.com/nlohmann/json.git || true) && git fetch --depth 1 origin ${NLOHMANN_JSON_COMMIT_HASH} && git checkout FETCH_HEAD"
+    COMMAND sh -c "mkdir -p ${NLOHMANN_JSON_SOURCE_DIR} && cd ${NLOHMANN_JSON_SOURCE_DIR} && git init . 2>/dev/null && (git remote add origin https://github.com/nlohmann/json.git 2>/dev/null || true) && git fetch --depth 1 origin ${NLOHMANN_JSON_COMMIT_HASH} 2>/dev/null && git checkout FETCH_HEAD 2>/dev/null"
     RESULT_VARIABLE result
 )
 if(result)

--- a/barretenberg/cpp/cmake/tracy.cmake
+++ b/barretenberg/cpp/cmake/tracy.cmake
@@ -3,7 +3,7 @@ set(TRACY_SOURCE_DIR "${CMAKE_BINARY_DIR}/_deps/tracy-src")
 set(TRACY_COMMIT_HASH "5d542dc09f3d9378d005092a4ad446bd405f819a")
 
 execute_process(
-    COMMAND sh -c "mkdir -p ${TRACY_SOURCE_DIR} && cd ${TRACY_SOURCE_DIR} && git init . && (git remote add origin https://github.com/wolfpld/tracy.git || true) && git fetch --depth 1 origin ${TRACY_COMMIT_HASH} && git checkout FETCH_HEAD"
+    COMMAND sh -c "mkdir -p ${TRACY_SOURCE_DIR} && cd ${TRACY_SOURCE_DIR} && git init . 2>/dev/null && (git remote add origin https://github.com/wolfpld/tracy.git 2>/dev/null || true) && git fetch --depth 1 origin ${TRACY_COMMIT_HASH} 2>/dev/null && git checkout FETCH_HEAD 2>/dev/null"
     RESULT_VARIABLE result
 )
 if(result)


### PR DESCRIPTION
Less confusing messages. Follow-on from faster dependency download work