### PR TITLE
chore(ci): bump aztec-up dind test timeout

### DIFF
--- a/aztec-up/bootstrap.sh
+++ b/aztec-up/bootstrap.sh
@@ -24,7 +24,7 @@ function update_manifest {
 }
 
 function test_cmds {
-  echo "$hash aztec-up/scripts/run_test.sh amm_flow"
+  echo "$hash:TIMEOUT=15m aztec-up/scripts/run_test.sh amm_flow"
   echo "$hash aztec-up/scripts/run_test.sh bridge_and_claim"
   echo "$hash aztec-up/scripts/run_test.sh basic_install"
   echo "$hash aztec-up/scripts/run_test.sh counter_contract"


### PR DESCRIPTION
A longer term solution would be preloading this somehow