### PR TITLE
fix!: Don't gossip txs with duplicate public inputs

### DIFF
--- a/yarn-project/bb-prover/src/prover/client/bb_private_kernel_prover.ts
+++ b/yarn-project/bb-prover/src/prover/client/bb_private_kernel_prover.ts
@@ -37,7 +37,7 @@ import type {
   PrivateKernelTailCircuitPublicInputs,
 } from '@aztec/stdlib/kernel';
 import type { NoirCompiledCircuitWithName } from '@aztec/stdlib/noir';
-import type { ClientIvcProof } from '@aztec/stdlib/proofs';
+import type { ClientIvcProofWithPublicInputs } from '@aztec/stdlib/proofs';
 import type { CircuitSimulationStats, CircuitWitnessGenerationStats } from '@aztec/stdlib/stats';
 
 export abstract class BBPrivateKernelProver implements PrivateKernelProver {
@@ -263,7 +263,7 @@ export abstract class BBPrivateKernelProver implements PrivateKernelProver {
     return kernelProofOutput;
   }
 
-  public createClientIvcProof(_executionSteps: PrivateExecutionStep[]): Promise<ClientIvcProof> {
+  public createClientIvcProof(_executionSteps: PrivateExecutionStep[]): Promise<ClientIvcProofWithPublicInputs> {
     throw new Error('Not implemented');
   }
 

--- a/yarn-project/bb-prover/src/prover/client/native/bb_native_private_kernel_prover.ts
+++ b/yarn-project/bb-prover/src/prover/client/native/bb_native_private_kernel_prover.ts
@@ -3,7 +3,7 @@ import { type Logger, createLogger } from '@aztec/foundation/log';
 import { BundleArtifactProvider } from '@aztec/noir-protocol-circuits-types/client/bundle';
 import type { CircuitSimulator } from '@aztec/simulator/server';
 import { type PrivateExecutionStep, serializePrivateExecutionSteps } from '@aztec/stdlib/kernel';
-import type { ClientIvcProof } from '@aztec/stdlib/proofs';
+import type { ClientIvcProofWithPublicInputs } from '@aztec/stdlib/proofs';
 
 import { promises as fs } from 'fs';
 import path from 'path';
@@ -41,7 +41,7 @@ export class BBNativePrivateKernelProver extends BBPrivateKernelProver {
   private async _createClientIvcProof(
     directory: string,
     executionSteps: PrivateExecutionStep[],
-  ): Promise<ClientIvcProof> {
+  ): Promise<ClientIvcProofWithPublicInputs> {
     const inputsPath = path.join(directory, 'ivc-inputs.msgpack');
     await fs.writeFile(inputsPath, serializePrivateExecutionSteps(executionSteps));
     const provingResult = await executeBbClientIvcProof(this.bbBinaryPath, directory, inputsPath, this.log.info);
@@ -61,7 +61,9 @@ export class BBNativePrivateKernelProver extends BBPrivateKernelProver {
     return proof;
   }
 
-  public override async createClientIvcProof(executionSteps: PrivateExecutionStep[]): Promise<ClientIvcProof> {
+  public override async createClientIvcProof(
+    executionSteps: PrivateExecutionStep[],
+  ): Promise<ClientIvcProofWithPublicInputs> {
     this.log.info(`Generating Client IVC proof`);
     const operation = async (directory: string) => {
       return await this._createClientIvcProof(directory, executionSteps);

--- a/yarn-project/bb-prover/src/prover/client/wasm/bb_wasm_private_kernel_prover.ts
+++ b/yarn-project/bb-prover/src/prover/client/wasm/bb_wasm_private_kernel_prover.ts
@@ -5,7 +5,7 @@ import { serializeWitness } from '@aztec/noir-noirc_abi';
 import type { ArtifactProvider } from '@aztec/noir-protocol-circuits-types/types';
 import type { CircuitSimulator } from '@aztec/simulator/client';
 import type { PrivateExecutionStep } from '@aztec/stdlib/kernel';
-import { ClientIvcProof } from '@aztec/stdlib/proofs';
+import { ClientIvcProofWithPublicInputs } from '@aztec/stdlib/proofs';
 
 import { ungzip } from 'pako';
 
@@ -21,7 +21,9 @@ export abstract class BBWASMPrivateKernelProver extends BBPrivateKernelProver {
     super(artifactProvider, simulator, log);
   }
 
-  public override async createClientIvcProof(executionSteps: PrivateExecutionStep[]): Promise<ClientIvcProof> {
+  public override async createClientIvcProof(
+    executionSteps: PrivateExecutionStep[],
+  ): Promise<ClientIvcProofWithPublicInputs> {
     const timer = new Timer();
     this.log.info(`Generating ClientIVC proof...`);
     const backend = new AztecClientBackend(
@@ -39,7 +41,7 @@ export abstract class BBWASMPrivateKernelProver extends BBPrivateKernelProver {
       duration: timer.ms(),
       proofSize: proof.length,
     });
-    return ClientIvcProof.fromBufferArray(proof);
+    return ClientIvcProofWithPublicInputs.fromBufferArray(proof);
   }
 
   public override async computeGateCountForCircuit(_bytecode: Buffer, _circuitName: string): Promise<number> {

--- a/yarn-project/bb-prover/src/prover/proof_utils.ts
+++ b/yarn-project/bb-prover/src/prover/proof_utils.ts
@@ -9,7 +9,7 @@ import {
 } from '@aztec/constants';
 import { Fr } from '@aztec/foundation/fields';
 import type { Logger } from '@aztec/foundation/log';
-import { ClientIvcProof, Proof, RecursiveProof } from '@aztec/stdlib/proofs';
+import { ClientIvcProofWithPublicInputs, Proof, RecursiveProof } from '@aztec/stdlib/proofs';
 import type { VerificationKeyData } from '@aztec/stdlib/vks';
 
 import assert from 'assert';
@@ -28,7 +28,7 @@ export async function readClientIVCProofFromOutputDirectory(directory: string) {
   const proofFilename = path.join(directory, PROOF_FILENAME);
   const binaryProof = await fs.readFile(proofFilename);
   const proofFields = splitBufferIntoFields(binaryProof);
-  return new ClientIvcProof(proofFields);
+  return new ClientIvcProofWithPublicInputs(proofFields);
 }
 
 /**
@@ -37,9 +37,9 @@ export async function readClientIVCProofFromOutputDirectory(directory: string) {
  * @param proof the ClientIvcProof from object
  * @param directory the directory to write in
  */
-export async function writeClientIVCProofToPath(clientIvcProof: ClientIvcProof, outputPath: string) {
+export async function writeClientIVCProofToPath(clientIvcProof: ClientIvcProofWithPublicInputs, outputPath: string) {
   // NB: Don't use clientIvcProof.toBuffer here because it will include the proof length.
-  const fieldsBuf = Buffer.concat(clientIvcProof.proof.map(field => field.toBuffer()));
+  const fieldsBuf = Buffer.concat(clientIvcProof.fieldsWithPublicInputs.map(field => field.toBuffer()));
   await fs.writeFile(outputPath, fieldsBuf);
 }
 

--- a/yarn-project/bb-prover/src/verifier/bb_verifier.ts
+++ b/yarn-project/bb-prover/src/verifier/bb_verifier.ts
@@ -104,7 +104,10 @@ export class BBCircuitVerifier implements ClientProtocolCircuitVerifier {
         };
 
         const proofPath = path.join(bbWorkingDirectory, PROOF_FILENAME);
-        await writeClientIVCProofToPath(tx.clientIvcProof, proofPath);
+        await writeClientIVCProofToPath(
+          tx.clientIvcProof.attachPublicInputs(tx.data.publicInputs().toFields()),
+          proofPath,
+        );
 
         const verificationKeyPath = path.join(bbWorkingDirectory, VK_FILENAME);
         const verificationKey = this.getVerificationKeyData(circuit);

--- a/yarn-project/ivc-integration/src/prove_wasm.ts
+++ b/yarn-project/ivc-integration/src/prove_wasm.ts
@@ -1,5 +1,5 @@
 import { createLogger } from '@aztec/foundation/log';
-import { ClientIvcProof } from '@aztec/stdlib/proofs';
+import { ClientIvcProofWithPublicInputs } from '@aztec/stdlib/proofs';
 
 import os from 'os';
 import { ungzip } from 'pako';
@@ -15,7 +15,7 @@ export async function proveClientIVC(
   witnessStack: Uint8Array[],
   vks: string[],
   threads?: number,
-): Promise<ClientIvcProof> {
+): Promise<ClientIvcProofWithPublicInputs> {
   const { AztecClientBackend } = await import('@aztec/bb.js');
   const backend = new AztecClientBackend(
     bytecodes.map(base64ToUint8Array).map((arr: Uint8Array) => ungzip(arr)),
@@ -26,7 +26,7 @@ export async function proveClientIVC(
       witnessStack.map((arr: Uint8Array) => ungzip(arr)),
       vks.map(hex => new Uint8Array(Buffer.from(hex, 'hex'))),
     );
-    return ClientIvcProof.fromBufferArray(proof);
+    return ClientIvcProofWithPublicInputs.fromBufferArray(proof);
   } finally {
     await backend.destroy();
   }

--- a/yarn-project/prover-client/src/orchestrator/block-building-helpers.ts
+++ b/yarn-project/prover-client/src/orchestrator/block-building-helpers.ts
@@ -210,11 +210,15 @@ export const insertSideEffectsAndBuildBaseRollupHints = runInSpan(
 );
 
 export function getCivcProofFromTx(tx: Tx | ProcessedTx) {
-  const proofFields = tx.clientIvcProof.proof;
-  const numPublicInputs = proofFields.length - CIVC_PROOF_LENGTH;
-  const binaryProof = new Proof(Buffer.concat(proofFields.map(field => field.toBuffer())), numPublicInputs);
-  const proofFieldsWithoutPublicInputs = proofFields.slice(numPublicInputs);
-  return new RecursiveProof(proofFieldsWithoutPublicInputs, binaryProof, true, CIVC_PROOF_LENGTH);
+  const publicInputs = tx.data.publicInputs().toFields();
+
+  const binaryProof = new Proof(
+    Buffer.concat(
+      tx.clientIvcProof.attachPublicInputs(publicInputs).fieldsWithPublicInputs.map(field => field.toBuffer()),
+    ),
+    publicInputs.length,
+  );
+  return new RecursiveProof(tx.clientIvcProof.fields, binaryProof, true, CIVC_PROOF_LENGTH);
 }
 
 export function getPublicTubePrivateInputsFromTx(tx: Tx | ProcessedTx, proverId: Fr) {

--- a/yarn-project/stdlib/src/interfaces/private_kernel_prover.ts
+++ b/yarn-project/stdlib/src/interfaces/private_kernel_prover.ts
@@ -10,7 +10,7 @@ import type {
   PrivateKernelTailCircuitPrivateInputs,
   PrivateKernelTailCircuitPublicInputs,
 } from '../kernel/index.js';
-import type { ClientIvcProof } from '../proofs/client_ivc_proof.js';
+import type { ClientIvcProofWithPublicInputs } from '../proofs/client_ivc_proof.js';
 
 /**
  * PrivateKernelProver provides functionality to simulate and validate circuits, and retrieve
@@ -110,7 +110,7 @@ export interface PrivateKernelProver {
    * @param acirs The program bytecode.
    * @param witnessStack The witnessses for each program bytecode.
    */
-  createClientIvcProof(executionSteps: PrivateExecutionStep[]): Promise<ClientIvcProof>;
+  createClientIvcProof(executionSteps: PrivateExecutionStep[]): Promise<ClientIvcProofWithPublicInputs>;
 
   /**
    * Compute the gate count for a given circuit.

--- a/yarn-project/stdlib/src/kernel/private_kernel_tail_circuit_public_inputs.ts
+++ b/yarn-project/stdlib/src/kernel/private_kernel_tail_circuit_public_inputs.ts
@@ -184,6 +184,12 @@ export class PrivateKernelTailCircuitPublicInputs {
     );
   }
 
+  publicInputs(): PrivateToPublicKernelCircuitPublicInputs | PrivateToRollupKernelCircuitPublicInputs {
+    return this.forPublic
+      ? this.toPrivateToPublicKernelCircuitPublicInputs()
+      : this.toPrivateToRollupKernelCircuitPublicInputs();
+  }
+
   numberOfPublicCallRequests() {
     return (
       this.numberOfNonRevertiblePublicCallRequests() +

--- a/yarn-project/stdlib/src/proofs/client_ivc_proof.test.ts
+++ b/yarn-project/stdlib/src/proofs/client_ivc_proof.test.ts
@@ -1,0 +1,80 @@
+import { CIVC_PROOF_LENGTH } from '@aztec/constants';
+import { Fr } from '@aztec/foundation/fields';
+
+import { ClientIvcProof, ClientIvcProofWithPublicInputs } from './client_ivc_proof.js';
+
+describe('ClientIvcProof', () => {
+  it('should throw error with incorrect length', () => {
+    const fields = Array.from({ length: CIVC_PROOF_LENGTH + 1 }, () => Fr.random());
+    expect(() => new ClientIvcProof(fields)).toThrow(`Invalid ClientIvcProof length: ${CIVC_PROOF_LENGTH + 1}`);
+  });
+
+  it('isEmpty should return true for empty proof', () => {
+    const proof = ClientIvcProof.empty();
+    expect(proof.isEmpty()).toBe(true);
+  });
+
+  it('should serialize and deserialize empty proof', () => {
+    const original = ClientIvcProof.empty();
+    const buffer = original.toBuffer();
+    const deserialized = ClientIvcProof.fromBuffer(buffer);
+
+    expect(deserialized.fields.length).toBe(original.fields.length);
+    expect(deserialized.fields).toEqual(original.fields);
+    expect(deserialized.isEmpty()).toBe(true);
+  });
+
+  it('should serialize and deserialize random proof', () => {
+    const original = ClientIvcProof.random();
+    const buffer = original.toBuffer();
+    const deserialized = ClientIvcProof.fromBuffer(buffer);
+
+    expect(deserialized.fields.length).toBe(original.fields.length);
+    expect(deserialized.fields).toEqual(original.fields);
+  });
+
+  it('should attach public inputs', () => {
+    const proof = ClientIvcProof.random();
+    const publicInput = Fr.random();
+    const withPublicInputs = proof.attachPublicInputs([publicInput]);
+
+    expect(withPublicInputs.fieldsWithPublicInputs.length).toBe(CIVC_PROOF_LENGTH + 1);
+    expect(withPublicInputs.fieldsWithPublicInputs[0]).toEqual(publicInput);
+    expect(withPublicInputs.fieldsWithPublicInputs.slice(1)).toEqual(proof.fields);
+  });
+});
+
+describe('ClientIvcProofWithPublicInputs', () => {
+  it('constructor should throw error with length less than CIVC_PROOF_LENGTH', () => {
+    const fields = Array.from({ length: CIVC_PROOF_LENGTH - 1 }, () => Fr.random());
+    expect(() => new ClientIvcProofWithPublicInputs(fields)).toThrow(
+      `Invalid ClientIvcProofWithPublicInputs length: ${CIVC_PROOF_LENGTH - 1}`,
+    );
+  });
+
+  it('isEmpty should return true for empty proof', () => {
+    const proof = ClientIvcProofWithPublicInputs.empty();
+    expect(proof.isEmpty()).toBe(true);
+  });
+
+  it('should serialize and deserialize proof with public inputs', () => {
+    const baseProof = ClientIvcProof.random();
+    const publicInputs = Array.from({ length: 5 }, () => Fr.random());
+    const original = baseProof.attachPublicInputs(publicInputs);
+    const buffer = original.toBuffer();
+    const deserialized = ClientIvcProofWithPublicInputs.fromBuffer(buffer);
+
+    expect(deserialized.fieldsWithPublicInputs.length).toBe(CIVC_PROOF_LENGTH + 5);
+    expect(deserialized.fieldsWithPublicInputs).toEqual(original.fieldsWithPublicInputs);
+  });
+
+  it('should be able to remove public inputs', () => {
+    const baseProof = ClientIvcProof.random();
+    const publicInputs = Array.from({ length: 10 }, () => Fr.random());
+    const withPublicInputs = baseProof.attachPublicInputs(publicInputs);
+    const removed = withPublicInputs.removePublicInputs();
+
+    expect(removed.fields.length).toBe(CIVC_PROOF_LENGTH);
+    expect(removed.fields).toEqual(baseProof.fields);
+  });
+});

--- a/yarn-project/stdlib/src/tx/tx.ts
+++ b/yarn-project/stdlib/src/tx/tx.ts
@@ -237,7 +237,7 @@ export class Tx extends Gossipable {
       classPublishedCount: this.data.getNonEmptyContractClassLogsHashes().length,
       contractClassLogSize: this.data.getEmittedContractClassLogsLength(),
 
-      proofSize: this.clientIvcProof.proof.length,
+      proofSize: this.clientIvcProof.fields.length,
       size: this.toBuffer().length,
 
       feePaymentMethod:
@@ -249,7 +249,7 @@ export class Tx extends Gossipable {
   getSize() {
     return (
       this.data.getSize() +
-      this.clientIvcProof.proof.length * Fr.SIZE_IN_BYTES +
+      this.clientIvcProof.fields.length * Fr.SIZE_IN_BYTES +
       arraySerializedSizeOfNonEmpty(this.contractClassLogFields) +
       this.publicFunctionCalldata.reduce((accum, cd) => accum + cd.getSize(), 0)
     );


### PR DESCRIPTION
Creates a new type for a CIVC proof with public inputs so cases like this are clear in the future. The Tx now uses the type without public inputs, and the public inputs are attached to it as needed.