### PR TITLE
feat(bb): add hierarchical benchmark output with --bench_out_hierarchical

### DIFF
--- a/barretenberg/cpp/src/barretenberg/bb/cli.cpp
+++ b/barretenberg/cpp/src/barretenberg/bb/cli.cpp
@@ -306,6 +306,13 @@ int parse_and_run_cli_command(int argc, char* argv[])
     const auto add_bench_out_option = [&](CLI::App* subcommand) {
         return subcommand->add_option("--bench_out", bench_out, "Path to write the op counts in a json.");
     };
+    std::string bench_out_hierarchical;
+    const auto add_bench_out_hierarchical_option = [&](CLI::App* subcommand) {
+        return subcommand->add_option("--bench_out_hierarchical",
+                                      bench_out_hierarchical,
+                                      "Path to write the hierarchical benchmark data (op counts and timings with "
+                                      "parent-child relationships) as json.");
+    };
 
     /***************************************************************************************************************
      * Top-level flags
@@ -370,6 +377,7 @@ int parse_and_run_cli_command(int argc, char* argv[])
     add_slow_low_memory_flag(prove);
     add_print_bench_flag(prove);
     add_bench_out_option(prove);
+    add_bench_out_hierarchical_option(prove);
     add_storage_budget_option(prove);
 
     prove->add_flag("--verify", "Verify the proof natively, resulting in a boolean output. Useful for testing.");
@@ -548,7 +556,7 @@ int parse_and_run_cli_command(int argc, char* argv[])
     if (!flags.storage_budget.empty()) {
         storage_budget = parse_size_string(flags.storage_budget);
     }
-    if (print_bench || !bench_out.empty()) {
+    if (print_bench || !bench_out.empty() || !bench_out_hierarchical.empty()) {
         bb::detail::use_bb_bench = true;
     }
 #endif
@@ -656,6 +664,10 @@ int parse_and_run_cli_command(int argc, char* argv[])
                     std::ofstream file(bench_out);
                     bb::detail::GLOBAL_BENCH_STATS.print_aggregate_counts(file, 2);
                 }
+                if (!bench_out_hierarchical.empty()) {
+                    std::ofstream file(bench_out_hierarchical);
+                    bb::detail::GLOBAL_BENCH_STATS.serialize_aggregate_data_json(file);
+                }
 #endif
                 return 0;
             }
@@ -679,6 +691,10 @@ int parse_and_run_cli_command(int argc, char* argv[])
                 if (!bench_out.empty()) {
                     std::ofstream file(bench_out);
                     bb::detail::GLOBAL_BENCH_STATS.print_aggregate_counts(file, 2);
+                }
+                if (!bench_out_hierarchical.empty()) {
+                    std::ofstream file(bench_out_hierarchical);
+                    bb::detail::GLOBAL_BENCH_STATS.serialize_aggregate_data_json(file);
                 }
 #endif
                 return 0;

--- a/barretenberg/cpp/src/barretenberg/common/bb_bench.cpp
+++ b/barretenberg/cpp/src/barretenberg/common/bb_bench.cpp
@@ -2,6 +2,7 @@
 #include <cstdint>
 #include <sys/types.h>
 #ifndef __wasm__
+#include "barretenberg/serialize/msgpack_impl.hpp"
 #include "bb_bench.hpp"
 #include <algorithm>
 #include <cassert>
@@ -296,78 +297,55 @@ void GlobalBenchStatsContainer::print_aggregate_counts(std::ostream& os, size_t 
     os << '}' << "\n";
 }
 
+// Serializable structure for a single benchmark entry (msgpack-compatible)
+struct SerializableEntry {
+    std::string parent;
+    std::size_t time;
+    std::size_t time_max;
+    double time_mean;
+    double time_stddev;
+    std::size_t count;
+    std::size_t num_threads;
+
+    MSGPACK_FIELDS(parent, time, time_max, time_mean, time_stddev, count, num_threads);
+};
+
 void GlobalBenchStatsContainer::serialize_aggregate_data_json(std::ostream& os) const
 {
     AggregateData data = aggregate();
 
-    os << "{\n";
-    bool first_key = true;
+    // Convert AggregateData to a msgpack-serializable map
+    std::map<std::string, std::vector<SerializableEntry>> serializable_data;
 
     for (const auto& [key, parent_map] : data) {
-        // Escape quotes in key
-        std::string escaped_key;
-        for (char c : std::string(key)) {
-            if (c == '"' || c == '\\') {
-                escaped_key += '\\';
-            }
-            escaped_key += c;
-        }
+        std::vector<SerializableEntry> entries;
 
-        // Collect non-empty parent entries (skip _root entries with no data)
-        std::vector<const AggregateEntry*> non_empty_entries;
         for (const auto& [parent_key, entry] : parent_map) {
             // Skip _root entries that have zero time (never called at root level)
             if (parent_key.empty() && entry.time == 0) {
                 continue;
             }
-            non_empty_entries.push_back(&entry);
+
+            entries.push_back(SerializableEntry{ .parent = parent_key.empty() ? "_root" : std::string(parent_key),
+                                                 .time = entry.time,
+                                                 .time_max = entry.time_max,
+                                                 .time_mean = entry.time_mean,
+                                                 .time_stddev = entry.get_std_dev(),
+                                                 .count = entry.count,
+                                                 .num_threads = entry.num_threads });
         }
 
-        // Skip this key entirely if it has no non-empty entries
-        if (non_empty_entries.empty()) {
-            continue;
+        // Only add functions that have non-empty entries
+        if (!entries.empty()) {
+            serializable_data[std::string(key)] = entries;
         }
-
-        if (!first_key) {
-            os << ",\n";
-        }
-        first_key = false;
-
-        os << "  \"" << escaped_key << "\": [\n";
-
-        bool first_entry = true;
-        for (const AggregateEntry* entry_ptr : non_empty_entries) {
-            if (!first_entry) {
-                os << ",\n";
-            }
-            first_entry = false;
-
-            const AggregateEntry& entry = *entry_ptr;
-
-            // Escape quotes in parent key
-            std::string escaped_parent;
-            for (char c : std::string(entry.parent)) {
-                if (c == '"' || c == '\\') {
-                    escaped_parent += '\\';
-                }
-                escaped_parent += c;
-            }
-
-            os << "    {\n";
-            os << "      \"parent\": \"" << (escaped_parent.empty() ? "_root" : escaped_parent) << "\",\n";
-            os << "      \"time\": " << entry.time << ",\n";
-            os << "      \"time_max\": " << entry.time_max << ",\n";
-            os << "      \"time_mean\": " << entry.time_mean << ",\n";
-            os << "      \"time_stddev\": " << entry.get_std_dev() << ",\n";
-            os << "      \"count\": " << entry.count << ",\n";
-            os << "      \"num_threads\": " << entry.num_threads << "\n";
-            os << "    }";
-        }
-
-        os << "\n  ]";
     }
 
-    os << "\n}\n";
+    // Use msgpack to serialize and convert to JSON
+    msgpack::sbuffer buffer;
+    msgpack::pack(buffer, serializable_data);
+    msgpack::object_handle oh = msgpack::unpack(buffer.data(), buffer.size());
+    os << oh.get() << std::endl;
 }
 
 void GlobalBenchStatsContainer::print_aggregate_counts_hierarchical(std::ostream& os) const

--- a/barretenberg/cpp/src/barretenberg/common/bb_bench.cpp
+++ b/barretenberg/cpp/src/barretenberg/common/bb_bench.cpp
@@ -296,6 +296,80 @@ void GlobalBenchStatsContainer::print_aggregate_counts(std::ostream& os, size_t 
     os << '}' << "\n";
 }
 
+void GlobalBenchStatsContainer::serialize_aggregate_data_json(std::ostream& os) const
+{
+    AggregateData data = aggregate();
+
+    os << "{\n";
+    bool first_key = true;
+
+    for (const auto& [key, parent_map] : data) {
+        // Escape quotes in key
+        std::string escaped_key;
+        for (char c : std::string(key)) {
+            if (c == '"' || c == '\\') {
+                escaped_key += '\\';
+            }
+            escaped_key += c;
+        }
+
+        // Collect non-empty parent entries (skip _root entries with no data)
+        std::vector<const AggregateEntry*> non_empty_entries;
+        for (const auto& [parent_key, entry] : parent_map) {
+            // Skip _root entries that have zero time (never called at root level)
+            if (parent_key.empty() && entry.time == 0) {
+                continue;
+            }
+            non_empty_entries.push_back(&entry);
+        }
+
+        // Skip this key entirely if it has no non-empty entries
+        if (non_empty_entries.empty()) {
+            continue;
+        }
+
+        if (!first_key) {
+            os << ",\n";
+        }
+        first_key = false;
+
+        os << "  \"" << escaped_key << "\": [\n";
+
+        bool first_entry = true;
+        for (const AggregateEntry* entry_ptr : non_empty_entries) {
+            if (!first_entry) {
+                os << ",\n";
+            }
+            first_entry = false;
+
+            const AggregateEntry& entry = *entry_ptr;
+
+            // Escape quotes in parent key
+            std::string escaped_parent;
+            for (char c : std::string(entry.parent)) {
+                if (c == '"' || c == '\\') {
+                    escaped_parent += '\\';
+                }
+                escaped_parent += c;
+            }
+
+            os << "    {\n";
+            os << "      \"parent\": \"" << (escaped_parent.empty() ? "_root" : escaped_parent) << "\",\n";
+            os << "      \"time\": " << entry.time << ",\n";
+            os << "      \"time_max\": " << entry.time_max << ",\n";
+            os << "      \"time_mean\": " << entry.time_mean << ",\n";
+            os << "      \"time_stddev\": " << entry.get_std_dev() << ",\n";
+            os << "      \"count\": " << entry.count << ",\n";
+            os << "      \"num_threads\": " << entry.num_threads << "\n";
+            os << "    }";
+        }
+
+        os << "\n  ]";
+    }
+
+    os << "\n}\n";
+}
+
 void GlobalBenchStatsContainer::print_aggregate_counts_hierarchical(std::ostream& os) const
 {
     AggregateData aggregated = aggregate();

--- a/barretenberg/cpp/src/barretenberg/common/bb_bench.hpp
+++ b/barretenberg/cpp/src/barretenberg/common/bb_bench.hpp
@@ -91,6 +91,7 @@ struct GlobalBenchStatsContainer {
     void print_stats_recursive(const OperationKey& key, const TimeStats* stats, const std::string& indent) const;
     void print_aggregate_counts(std::ostream&, size_t) const;
     void print_aggregate_counts_hierarchical(std::ostream&) const;
+    void serialize_aggregate_data_json(std::ostream&) const;
 
     // Normalize the raw benchmark data into a clean structure for display
     AggregateData aggregate() const;


### PR DESCRIPTION
## Summary
- Adds new `--bench_out_hierarchical` CLI flag that outputs benchmark data with parent-child relationships preserved
- Complements existing `--bench_out` flag (backward compatible - no changes to existing behavior)
- Uses msgpack serialization for clean, automatic JSON conversion
- Automatically filters empty `_root` entries for functions never called at top level
- Includes timing statistics (mean, max, stddev) and thread count per parent context

## Format
Outputs compact JSON with function names as keys and arrays of parent context objects:
```json
{
  "FunctionName": [
    {
      "parent": "ParentName",
      "time": 123,
      "time_max": 456,
      "time_mean": 789.5,
      "time_stddev": 12.3,
      "count": 10,
      "num_threads": 1
    }
  ]
}
```

## Implementation
- `SerializableEntry` struct with `MSGPACK_FIELDS` for automatic serialization
- Uses `msgpack::pack` + `msgpack::unpack` pattern for JSON conversion
- Filters empty `_root` entries during data transformation
- Compact single-line output for efficient storage and transmission

🤖 Generated with [Claude Code](https://claude.com/claude-code)