### PR TITLE
fix: Do not allow txs in proposals if disableTransactions is set (#17882)

### DIFF
--- a/.test_patterns.yml
+++ b/.test_patterns.yml
@@ -78,6 +78,11 @@ tests:
     error_regex: "ultra_circuit_builder.test.cpp:631: Failure"
     owners:
       - *luke
+  # http://ci.aztec-labs.com/1593f7c89e22b51b
+  - regex: stdlib_primitives_tests stdlibBiggroupSecp256k1/1.WnafSecp256k1StaggerOutOfRangeFails
+    error_regex: "biggroup_nafs: stagger fragment is not in range"
+    owners:
+      - *luke
 
   # noir
   # Something to do with how I run the tests now. Think these are fine in nextest.

--- a/yarn-project/p2p/src/msg_validators/block_proposal_validator/block_proposal_validator.test.ts
+++ b/yarn-project/p2p/src/msg_validators/block_proposal_validator/block_proposal_validator.test.ts
@@ -3,6 +3,7 @@ import { Secp256k1Signer } from '@aztec/foundation/crypto';
 import { Fr } from '@aztec/foundation/fields';
 import { PeerErrorSeverity } from '@aztec/stdlib/p2p';
 import { makeBlockProposal, makeHeader } from '@aztec/stdlib/testing';
+import { TxHash } from '@aztec/stdlib/tx';
 
 import { mock } from 'jest-mock-extended';
 
@@ -14,7 +15,7 @@ describe('BlockProposalValidator', () => {
 
   beforeEach(() => {
     epochCache = mock<EpochCache>();
-    validator = new BlockProposalValidator(epochCache);
+    validator = new BlockProposalValidator(epochCache, { txsPermitted: true });
   });
 
   it('returns high tolerance error if slot number is not current or next slot', async () => {
@@ -145,5 +146,76 @@ describe('BlockProposalValidator', () => {
 
     const result = await validator.validate(mockProposal);
     expect(result).toBeUndefined();
+  });
+
+  describe('transaction permission validation', () => {
+    it('returns mid tolerance error if txs not permitted and proposal contains txHashes', async () => {
+      const currentProposer = Secp256k1Signer.random();
+      const validatorWithTxsDisabled = new BlockProposalValidator(epochCache, { txsPermitted: false });
+
+      // Create a block proposal with transaction hashes
+      const mockProposal = makeBlockProposal({
+        header: makeHeader(1, 100, 100),
+        signer: currentProposer,
+        txHashes: [TxHash.random(), TxHash.random()], // Include some tx hashes
+      });
+
+      // Mock epoch cache to return valid proposer (so only tx permission check fails)
+      (epochCache.getProposerAttesterAddressInCurrentOrNextSlot as jest.Mock).mockResolvedValue({
+        currentSlot: 100n,
+        nextSlot: 101n,
+        currentProposer: currentProposer.address,
+        nextProposer: Fr.random(),
+      });
+
+      const result = await validatorWithTxsDisabled.validate(mockProposal);
+      expect(result).toBe(PeerErrorSeverity.MidToleranceError);
+    });
+
+    it('returns undefined if txs not permitted but proposal has no txHashes', async () => {
+      const currentProposer = Secp256k1Signer.random();
+      const validatorWithTxsDisabled = new BlockProposalValidator(epochCache, { txsPermitted: false });
+
+      // Create a block proposal without transaction hashes
+      const mockProposal = makeBlockProposal({
+        header: makeHeader(1, 100, 100),
+        signer: currentProposer,
+        txHashes: [], // Empty tx hashes array
+      });
+
+      // Mock epoch cache for valid case
+      (epochCache.getProposerAttesterAddressInCurrentOrNextSlot as jest.Mock).mockResolvedValue({
+        currentSlot: 100n,
+        nextSlot: 101n,
+        currentProposer: currentProposer.address,
+        nextProposer: Fr.random(),
+      });
+
+      const result = await validatorWithTxsDisabled.validate(mockProposal);
+      expect(result).toBeUndefined();
+    });
+
+    it('returns undefined if txs permitted and proposal contains txHashes', async () => {
+      const currentProposer = Secp256k1Signer.random();
+      // validator already created with txsPermitted = true in beforeEach
+
+      // Create a block proposal with transaction hashes
+      const mockProposal = makeBlockProposal({
+        header: makeHeader(1, 100, 100),
+        signer: currentProposer,
+        txHashes: [TxHash.random(), TxHash.random()], // Include some tx hashes
+      });
+
+      // Mock epoch cache for valid case
+      (epochCache.getProposerAttesterAddressInCurrentOrNextSlot as jest.Mock).mockResolvedValue({
+        currentSlot: 100n,
+        nextSlot: 101n,
+        currentProposer: currentProposer.address,
+        nextProposer: Fr.random(),
+      });
+
+      const result = await validator.validate(mockProposal);
+      expect(result).toBeUndefined();
+    });
   });
 });

--- a/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
+++ b/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
@@ -160,7 +160,7 @@ export class LibP2PService<T extends P2PClientType = P2PClientType.Full> extends
     );
 
     this.attestationValidator = new AttestationValidator(epochCache);
-    this.blockProposalValidator = new BlockProposalValidator(epochCache);
+    this.blockProposalValidator = new BlockProposalValidator(epochCache, { txsPermitted: !config.disableTransactions });
 
     this.gossipSubEventHandler = this.handleGossipSubEvent.bind(this);
 

--- a/yarn-project/stdlib/src/interfaces/aztec-node-admin.test.ts
+++ b/yarn-project/stdlib/src/interfaces/aztec-node-admin.test.ts
@@ -5,7 +5,7 @@ import { type Offense, OffenseType, type SlashPayloadRound } from '../slashing/i
 import { type AztecNodeAdmin, AztecNodeAdminApiSchema } from './aztec-node-admin.js';
 import type { SequencerConfig } from './configs.js';
 import type { ProverConfig } from './prover-client.js';
-import type { ValidatorClientConfig } from './server.js';
+import type { ValidatorClientFullConfig } from './server.js';
 import type { SlasherConfig } from './slasher.js';
 
 describe('AztecNodeAdminApiSchema', () => {
@@ -126,7 +126,7 @@ class MockAztecNodeAdmin implements AztecNodeAdmin {
     ]);
   }
   getConfig(): Promise<
-    ValidatorClientConfig & SequencerConfig & ProverConfig & SlasherConfig & { maxTxPoolSize: number }
+    ValidatorClientFullConfig & SequencerConfig & ProverConfig & SlasherConfig & { maxTxPoolSize: number }
   > {
     return Promise.resolve({
       realProofs: false,
@@ -164,6 +164,7 @@ class MockAztecNodeAdmin implements AztecNodeAdmin {
       attestationPollingIntervalMs: 1000,
       validatorReexecute: true,
       validatorReexecuteDeadlineMs: 1000,
+      disableTransactions: false,
     });
   }
   startSnapshotUpload(_location: string): Promise<void> {

--- a/yarn-project/stdlib/src/interfaces/aztec-node-admin.ts
+++ b/yarn-project/stdlib/src/interfaces/aztec-node-admin.ts
@@ -9,7 +9,7 @@ import { type ArchiverSpecificConfig, ArchiverSpecificConfigSchema } from './arc
 import { type SequencerConfig, SequencerConfigSchema } from './configs.js';
 import { type ProverConfig, ProverConfigSchema } from './prover-client.js';
 import { type SlasherConfig, SlasherConfigSchema } from './slasher.js';
-import { ValidatorClientConfigSchema, type ValidatorClientFullConfig } from './validator.js';
+import { type ValidatorClientFullConfig, ValidatorClientFullConfigSchema } from './validator.js';
 
 /**
  * Aztec node admin API.
@@ -62,7 +62,7 @@ export type AztecNodeAdminConfig = ValidatorClientFullConfig &
 
 export const AztecNodeAdminConfigSchema = SequencerConfigSchema.merge(ProverConfigSchema)
   .merge(SlasherConfigSchema)
-  .merge(ValidatorClientConfigSchema)
+  .merge(ValidatorClientFullConfigSchema)
   .merge(
     ArchiverSpecificConfigSchema.pick({
       archiverPollingIntervalMS: true,

--- a/yarn-project/stdlib/src/interfaces/validator.ts
+++ b/yarn-project/stdlib/src/interfaces/validator.ts
@@ -11,6 +11,7 @@ import type { PeerId } from '@libp2p/interface';
 import { z } from 'zod';
 
 import type { CommitteeAttestationsAndSigners } from '../block/index.js';
+import { AllowedElementSchema } from './allowed_element.js';
 
 /**
  * Validator client configuration
@@ -43,7 +44,13 @@ export interface ValidatorClientConfig {
 
 export type ValidatorClientFullConfig = ValidatorClientConfig &
   Pick<SequencerConfig, 'txPublicSetupAllowList'> &
-  Pick<SlasherConfig, 'slashBroadcastedInvalidBlockPenalty'>;
+  Pick<SlasherConfig, 'slashBroadcastedInvalidBlockPenalty'> & {
+    /**
+     * Whether transactions are disabled for this node
+     * @remarks This should match the property in P2PConfig. It's not picked from there to avoid circular dependencies.
+     */
+    disableTransactions?: boolean;
+  };
 
 export const ValidatorClientConfigSchema = z.object({
   validatorAddresses: z.array(schemas.EthAddress).optional(),
@@ -54,6 +61,12 @@ export const ValidatorClientConfigSchema = z.object({
   validatorReexecuteDeadlineMs: z.number().min(0),
   alwaysReexecuteBlockProposals: z.boolean().optional(),
 }) satisfies ZodFor<Omit<ValidatorClientConfig, 'validatorPrivateKeys'>>;
+
+export const ValidatorClientFullConfigSchema = ValidatorClientConfigSchema.extend({
+  txPublicSetupAllowList: z.array(AllowedElementSchema).optional(),
+  slashBroadcastedInvalidBlockPenalty: schemas.BigInt,
+  disableTransactions: z.boolean().optional(),
+}) satisfies ZodFor<Omit<ValidatorClientFullConfig, 'validatorPrivateKeys'>>;
 
 export interface Validator {
   start(): Promise<void>;

--- a/yarn-project/validator-client/src/factory.ts
+++ b/yarn-project/validator-client/src/factory.ts
@@ -24,7 +24,9 @@ export function createBlockProposalHandler(
   },
 ) {
   const metrics = new ValidatorMetrics(deps.telemetry);
-  const blockProposalValidator = new BlockProposalValidator(deps.epochCache);
+  const blockProposalValidator = new BlockProposalValidator(deps.epochCache, {
+    txsPermitted: !config.disableTransactions,
+  });
   return new BlockProposalHandler(
     deps.blockBuilder,
     deps.blockSource,

--- a/yarn-project/validator-client/src/validator.test.ts
+++ b/yarn-project/validator-client/src/validator.test.ts
@@ -39,7 +39,8 @@ import { type ValidatorClientConfig, validatorClientConfigMappings } from './con
 import { ValidatorClient } from './validator.js';
 
 describe('ValidatorClient', () => {
-  let config: ValidatorClientConfig & Pick<SlasherConfig, 'slashBroadcastedInvalidBlockPenalty'>;
+  let config: ValidatorClientConfig &
+    Pick<SlasherConfig, 'slashBroadcastedInvalidBlockPenalty'> & { disableTransactions: boolean };
   let validatorClient: ValidatorClient;
   let p2pClient: MockProxy<P2P>;
   let blockSource: MockProxy<L2BlockSource>;
@@ -76,6 +77,7 @@ describe('ValidatorClient', () => {
       validatorReexecute: false,
       validatorReexecuteDeadlineMs: 6000,
       slashBroadcastedInvalidBlockPenalty: 1n,
+      disableTransactions: false,
     };
 
     const keyStore: KeyStore = {

--- a/yarn-project/validator-client/src/validator.ts
+++ b/yarn-project/validator-client/src/validator.ts
@@ -9,13 +9,7 @@ import { DateProvider } from '@aztec/foundation/timer';
 import type { KeystoreManager } from '@aztec/node-keystore';
 import type { P2P, PeerId, TxProvider } from '@aztec/p2p';
 import { AuthRequest, AuthResponse, BlockProposalValidator, ReqRespSubProtocol } from '@aztec/p2p';
-import {
-  OffenseType,
-  type SlasherConfig,
-  WANT_TO_SLASH_EVENT,
-  type Watcher,
-  type WatcherEmitter,
-} from '@aztec/slasher';
+import { OffenseType, WANT_TO_SLASH_EVENT, type Watcher, type WatcherEmitter } from '@aztec/slasher';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
 import type { CommitteeAttestationsAndSigners, L2BlockSource } from '@aztec/stdlib/block';
 import type { IFullNodeBlockBuilder, Validator, ValidatorClientFullConfig } from '@aztec/stdlib/interfaces/server';
@@ -29,7 +23,6 @@ import { EventEmitter } from 'events';
 import type { TypedDataDefinition } from 'viem';
 
 import { BlockProposalHandler, type BlockProposalValidationFailureReason } from './block_proposal_handler.js';
-import type { ValidatorClientConfig } from './config.js';
 import { ValidationService } from './duties/validation_service.js';
 import { NodeKeystoreAdapter } from './key_store/node_keystore_adapter.js';
 import { ValidatorMetrics } from './metrics.js';
@@ -134,7 +127,7 @@ export class ValidatorClient extends (EventEmitter as new () => WatcherEmitter) 
   }
 
   static new(
-    config: ValidatorClientConfig & Pick<SlasherConfig, 'slashBroadcastedInvalidBlockPenalty'>,
+    config: ValidatorClientFullConfig,
     blockBuilder: IFullNodeBlockBuilder,
     epochCache: EpochCache,
     p2pClient: P2P,
@@ -146,7 +139,9 @@ export class ValidatorClient extends (EventEmitter as new () => WatcherEmitter) 
     telemetry: TelemetryClient = getTelemetryClient(),
   ) {
     const metrics = new ValidatorMetrics(telemetry);
-    const blockProposalValidator = new BlockProposalValidator(epochCache);
+    const blockProposalValidator = new BlockProposalValidator(epochCache, {
+      txsPermitted: !config.disableTransactions,
+    });
     const blockProposalHandler = new BlockProposalHandler(
       blockBuilder,
       blockSource,


### PR DESCRIPTION
Reuses the `disableTransactions` flag used in p2p to also reject block proposals that have non-empty tx hashes.

Backport of #17882