### PR TITLE
chore(slasher): Add isRoundReadyToExecute check in tally slasher (#17656)

### DIFF
--- a/l1-contracts/test/slashing/TallySlashingProposer.t.sol
+++ b/l1-contracts/test/slashing/TallySlashingProposer.t.sol
@@ -184,12 +184,12 @@ contract TallySlashingProposerTest is TestBase {
 
   function _assertVoteCount(uint256 expectedCount) internal view {
     SlashRound slashRound = slashingProposer.getCurrentRound();
-    (,, uint256 voteCount) = slashingProposer.getRound(slashRound);
+    (, uint256 voteCount) = slashingProposer.getRound(slashRound);
     assertEq(voteCount, expectedCount, "Unexpected vote count");
   }
 
   function _assertVoteCount(SlashRound slashRound, uint256 expectedCount) internal view {
-    (,, uint256 voteCount) = slashingProposer.getRound(slashRound);
+    (, uint256 voteCount) = slashingProposer.getRound(slashRound);
     assertEq(voteCount, expectedCount, "Unexpected vote count");
   }
 
@@ -216,8 +216,9 @@ contract TallySlashingProposerTest is TestBase {
     // Verify round data was updated
     SlashRound currentSlashRound = slashingProposer.getCurrentRound();
     assertEq(SlashRound.unwrap(currentSlashRound), FIRST_SLASH_ROUND, "Unexpected current slash round");
-    (bool isExecuted, bool readyToExecute, uint256 voteCount) = slashingProposer.getRound(currentSlashRound);
+    (bool isExecuted, uint256 voteCount) = slashingProposer.getRound(currentSlashRound);
     assertFalse(isExecuted, "Round should not be executed yet");
+    bool readyToExecute = slashingProposer.isRoundReadyToExecute(currentSlashRound, rollup.getCurrentSlot());
     assertFalse(readyToExecute, "Should not be ready to execute until after execution delay");
     assertEq(voteCount, 1, "Unexpected vote count after casting vote");
   }
@@ -388,7 +389,7 @@ contract TallySlashingProposerTest is TestBase {
     assertEq(finalView.effectiveBalance, initialBalance - (3 * SLASHING_UNIT));
 
     // Verify round is marked as executed
-    (bool isExecuted,,) = slashingProposer.getRound(targetSlashRound);
+    (bool isExecuted,) = slashingProposer.getRound(targetSlashRound);
     assertTrue(isExecuted);
   }
 
@@ -452,7 +453,7 @@ contract TallySlashingProposerTest is TestBase {
     }
 
     // Verify round is marked as executed
-    (bool isExecuted,,) = slashingProposer.getRound(targetSlashRound);
+    (bool isExecuted,) = slashingProposer.getRound(targetSlashRound);
     assertTrue(isExecuted);
   }
 
@@ -490,8 +491,9 @@ contract TallySlashingProposerTest is TestBase {
     SlashRound targetSlashRound = slashingProposer.getCurrentRound();
 
     // Initially no votes, not ready to execute
-    (bool isExecuted, bool readyToExecute, uint256 voteCount) = slashingProposer.getRound(targetSlashRound);
+    (bool isExecuted, uint256 voteCount) = slashingProposer.getRound(targetSlashRound);
     assertFalse(isExecuted);
+    bool readyToExecute = slashingProposer.isRoundReadyToExecute(targetSlashRound, rollup.getCurrentSlot());
     assertFalse(readyToExecute);
     assertEq(voteCount, 0);
 
@@ -499,8 +501,9 @@ contract TallySlashingProposerTest is TestBase {
     _castVote();
 
     // After vote, should have vote count
-    (isExecuted, readyToExecute, voteCount) = slashingProposer.getRound(targetSlashRound);
+    (isExecuted, voteCount) = slashingProposer.getRound(targetSlashRound);
     assertFalse(isExecuted);
+    readyToExecute = slashingProposer.isRoundReadyToExecute(targetSlashRound, rollup.getCurrentSlot());
     assertFalse(readyToExecute); // Still not ready due to execution delay
     assertEq(voteCount, 1);
 
@@ -509,8 +512,9 @@ contract TallySlashingProposerTest is TestBase {
     timeCheater.cheat__jumpToSlot(targetSlot);
 
     // Now should be ready to execute
-    (isExecuted, readyToExecute, voteCount) = slashingProposer.getRound(targetSlashRound);
+    (isExecuted, voteCount) = slashingProposer.getRound(targetSlashRound);
     assertFalse(isExecuted);
+    readyToExecute = slashingProposer.isRoundReadyToExecute(targetSlashRound, rollup.getCurrentSlot());
     assertTrue(readyToExecute);
     assertEq(voteCount, 1);
   }
@@ -765,7 +769,7 @@ contract TallySlashingProposerTest is TestBase {
 
     // Verify vote count
     SlashRound currentRound = slashingProposer.getCurrentRound();
-    (,, uint256 voteCount) = slashingProposer.getRound(currentRound);
+    (, uint256 voteCount) = slashingProposer.getRound(currentRound);
     assertEq(voteCount, maxVotes, "Vote count incorrect");
 
     // Jump to execution time

--- a/yarn-project/ethereum/src/contracts/tally_slashing_proposer.test.ts
+++ b/yarn-project/ethereum/src/contracts/tally_slashing_proposer.test.ts
@@ -160,7 +160,6 @@ describe('TallySlashingProposer', () => {
       const roundInfo = await tallySlashingProposer.getRound(0n);
 
       expect(typeof roundInfo.isExecuted).toBe('boolean');
-      expect(typeof roundInfo.readyToExecute).toBe('boolean');
       expect(typeof roundInfo.voteCount).toBe('bigint');
       expect(roundInfo.voteCount).toBeGreaterThanOrEqual(0n);
     });

--- a/yarn-project/ethereum/src/contracts/tally_slashing_proposer.ts
+++ b/yarn-project/ethereum/src/contracts/tally_slashing_proposer.ts
@@ -85,11 +85,20 @@ export class TallySlashingProposerContract {
    */
   public async getRound(round: bigint): Promise<{
     isExecuted: boolean;
-    readyToExecute: boolean;
     voteCount: bigint;
   }> {
-    const [isExecuted, readyToExecute, voteCount] = await this.contract.read.getRound([round]);
-    return { isExecuted, readyToExecute, voteCount };
+    const [isExecuted, voteCount] = await this.contract.read.getRound([round]);
+    return { isExecuted, voteCount };
+  }
+
+  /**
+   * Check if a round is ready to execute at a given slot
+   * @param round - The round number to check
+   * @param slot - The slot number to check at
+   * @returns Whether the round is ready to execute
+   */
+  public async isRoundReadyToExecute(round: bigint, slot: bigint): Promise<boolean> {
+    return await this.contract.read.isRoundReadyToExecute([round, slot]);
   }
 
   /** Returns the slash actions and payload address for a given round (zero if no slash actions) */

--- a/yarn-project/slasher/src/tally_slasher_client.test.ts
+++ b/yarn-project/slasher/src/tally_slasher_client.test.ts
@@ -60,19 +60,16 @@ describe('TallySlasherClient', () => {
 
   const executableRoundData = {
     isExecuted: false,
-    readyToExecute: true,
     voteCount: 150n,
   };
 
   const executedRoundData = {
     isExecuted: true,
-    readyToExecute: false,
     voteCount: 150n,
   };
 
   const emptyRoundData = {
     isExecuted: false,
-    readyToExecute: false,
     voteCount: 0n,
   };
 
@@ -155,6 +152,7 @@ describe('TallySlasherClient', () => {
       address: EthAddress.random(),
       actions: [{ validator: committee[0], slashAmount: slashingUnit }],
     });
+    tallySlashingProposer.isRoundReadyToExecute.mockResolvedValue(true);
 
     // Setup rollup and slasher contract mocks
     rollup.getSlasherContract.mockResolvedValue(slasherContract);
@@ -458,7 +456,6 @@ describe('TallySlasherClient', () => {
         // Mock executable round
         tallySlashingProposer.getRound.mockResolvedValueOnce({
           isExecuted: false,
-          readyToExecute: true,
           voteCount: 120n,
         });
 

--- a/yarn-project/slasher/src/tally_slasher_client.ts
+++ b/yarn-project/slasher/src/tally_slasher_client.ts
@@ -216,7 +216,7 @@ export class TallySlasherClient implements ProposerSlashActionProvider, SlasherC
 
     // Iterate over all rounds, starting from the oldest, until we find one that is executable
     for (let roundToCheck = oldestExecutableRound; roundToCheck <= executableRound; roundToCheck++) {
-      const action = await this.tryGetRoundExecuteAction(roundToCheck);
+      const action = await this.tryGetRoundExecuteAction(roundToCheck, slotNumber);
       if (action) {
         return action;
       }
@@ -231,8 +231,11 @@ export class TallySlasherClient implements ProposerSlashActionProvider, SlasherC
    * Assumes round number has already been checked against lifetime and execution delay.
    * @param executableRound - The round to check for execution
    */
-  private async tryGetRoundExecuteAction(executableRound: bigint): Promise<ProposerSlashAction | undefined> {
-    let logData: Record<string, unknown> = { executableRound };
+  private async tryGetRoundExecuteAction(
+    executableRound: bigint,
+    slotNumber: bigint,
+  ): Promise<ProposerSlashAction | undefined> {
+    let logData: Record<string, unknown> = { executableRound, slotNumber };
     this.log.debug(`Testing if slashing round ${executableRound} is executable`, logData);
 
     try {
@@ -252,6 +255,16 @@ export class TallySlasherClient implements ProposerSlashActionProvider, SlasherC
         return undefined;
       } else if (roundInfo.voteCount < this.settings.slashingQuorumSize) {
         this.log.verbose(`Round ${executableRound} does not have enough votes to execute`, logData);
+        return undefined;
+      }
+
+      // Check if round is ready to execute at the given slot
+      const isReadyToExecute = await this.tallySlashingProposer.isRoundReadyToExecute(executableRound, slotNumber);
+      if (!isReadyToExecute) {
+        this.log.warn(
+          `Round ${executableRound} is not ready to execute at slot ${slotNumber} according to contract check`,
+          logData,
+        );
         return undefined;
       }
 

--- a/yarn-project/validator-client/src/validator.ts
+++ b/yarn-project/validator-client/src/validator.ts
@@ -451,7 +451,7 @@ export class ValidatorClient extends (EventEmitter as new () => WatcherEmitter) 
         throw new AttestationTimeoutError(attestations.length, required, slot);
       }
 
-      this.log.debug(`Collected ${attestations.length} attestations so far`);
+      this.log.debug(`Collected ${attestations.length} of ${required} attestations so far`);
       await sleep(this.config.attestationPollingIntervalMs);
     }
   }


### PR DESCRIPTION
The `isExecuted` field returned the status for the current block, which is often not what we wanted, as we usually want to query the executable state in an upcoming L1 slot. This PR adds a separate field to check executability at a specific slot.

- Updated `TallySlashingProposer.sol` ABI to separate readiness check into a new function
- `getRound()` now returns only `(isExecuted, voteCount)` (removed `readyToExecute` field)
- Added new `isRoundReadyToExecute(round, slot)` function for checking round execution readiness
- Updated TypeScript wrapper `TallySlashingProposerContract` to match the new ABI
- Added call to `isRoundReadyToExecute` in `tryGetRoundExecuteAction` with warning logging if check fails
