### PR TITLE
chore: public processor commits/clears public contracts cache for tx rather than public tx simulator

### DIFF
--- a/yarn-project/simulator/src/public/public_processor/public_processor.test.ts
+++ b/yarn-project/simulator/src/public/public_processor/public_processor.test.ts
@@ -1,14 +1,19 @@
+import { CONTRACT_CLASS_PUBLISHED_MAGIC_VALUE, CONTRACT_CLASS_REGISTRY_CONTRACT_ADDRESS } from '@aztec/constants';
 import { timesParallel } from '@aztec/foundation/collection';
 import { Fr } from '@aztec/foundation/fields';
 import { sleep } from '@aztec/foundation/sleep';
 import { TestDateProvider } from '@aztec/foundation/timer';
 import { computeFeePayerBalanceLeafSlot } from '@aztec/protocol-contracts/fee-juice';
+import { bufferAsFields } from '@aztec/stdlib/abi';
 import { AvmCircuitInputs, PublicDataWrite, RevertCode } from '@aztec/stdlib/avm';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
+import type { ContractDataSource } from '@aztec/stdlib/contract';
 import { SimulationError } from '@aztec/stdlib/errors';
 import { Gas, GasFees } from '@aztec/stdlib/gas';
+import { LogHash } from '@aztec/stdlib/kernel';
+import { ContractClassLogFields } from '@aztec/stdlib/logs';
 import { ProvingRequestType } from '@aztec/stdlib/proofs';
-import { mockTx } from '@aztec/stdlib/testing';
+import { makeContractClassPublic, mockTx } from '@aztec/stdlib/testing';
 import { type MerkleTreeWriteOperations, PublicDataTreeLeaf, PublicDataTreeLeafPreimage } from '@aztec/stdlib/trees';
 import { GlobalVariables, StateReference, Tx, type TxValidator } from '@aztec/stdlib/tx';
 import { getTelemetryClient } from '@aztec/telemetry-client';
@@ -23,7 +28,7 @@ import { PublicProcessor } from './public_processor.js';
 
 describe('public_processor', () => {
   let merkleTree: MockProxy<MerkleTreeWriteOperations>;
-  let contractsDB: MockProxy<PublicContractsDB>;
+  let contractsDB: PublicContractsDB;
   let publicTxSimulator: MockProxy<PublicTxSimulator>;
 
   let mockedEnqueuedCallsResult: PublicTxResult;
@@ -39,9 +44,41 @@ describe('public_processor', () => {
   const mockTxWithPublicCalls = ({ seed = 1, feePayer }: { seed?: number; feePayer?: AztecAddress } = {}) =>
     mockTx(seed, { numberOfNonRevertiblePublicCallRequests: 1, numberOfRevertiblePublicCallRequests: 1, feePayer });
 
+  const mockContractClassForTx = async (tx: Tx, revertible = true) => {
+    const publicContractClass = await makeContractClassPublic(42);
+    const contractClassLogFields = [
+      new Fr(CONTRACT_CLASS_PUBLISHED_MAGIC_VALUE),
+      publicContractClass.id,
+      new Fr(publicContractClass.version),
+      publicContractClass.artifactHash,
+      publicContractClass.privateFunctionsRoot,
+      ...bufferAsFields(
+        publicContractClass.packedBytecode,
+        Math.ceil(publicContractClass.packedBytecode.length / 31) + 1,
+      ),
+    ];
+    const contractAddress = new AztecAddress(new Fr(CONTRACT_CLASS_REGISTRY_CONTRACT_ADDRESS));
+    const emittedLength = contractClassLogFields.length;
+    const logFields = ContractClassLogFields.fromEmittedFields(contractClassLogFields);
+
+    tx.contractClassLogFields.push(logFields);
+
+    const contractClassLogHash = LogHash.from({
+      value: await logFields.hash(),
+      length: emittedLength,
+    }).scope(contractAddress);
+    if (revertible) {
+      tx.data.forPublic!.revertibleAccumulatedData.contractClassLogsHashes[0] = contractClassLogHash;
+    } else {
+      tx.data.forPublic!.nonRevertibleAccumulatedData.contractClassLogsHashes[0] = contractClassLogHash;
+    }
+
+    return publicContractClass.id;
+  };
+
   beforeEach(() => {
     merkleTree = mock<MerkleTreeWriteOperations>();
-    contractsDB = mock<PublicContractsDB>();
+    contractsDB = new PublicContractsDB(mock<ContractDataSource>());
     publicTxSimulator = mock();
 
     const stateReference = StateReference.empty();
@@ -281,5 +318,66 @@ describe('public_processor', () => {
       expect(merkleTree.revertCheckpoint).toHaveBeenCalledTimes(1);
       expect(merkleTree.sequentialInsert).toHaveBeenCalledTimes(0);
     });
+  });
+
+  describe('contract class logs', () => {
+    it.each([
+      [' not', 'revertible'],
+      ['', 'non-revertible'],
+    ])('after a revert, does%s retain contract classes emitted from %s logs', async (_, kind) => {
+      const tx = await mockTxWithPublicCalls();
+
+      const contractClassId = await mockContractClassForTx(tx, kind === 'revertible');
+
+      // Mock the simulator to return a reverted result
+      mockedEnqueuedCallsResult.revertCode = RevertCode.APP_LOGIC_REVERTED;
+      mockedEnqueuedCallsResult.revertReason = new SimulationError('Simulation Failed in app logic', []);
+
+      // Mock the simulator to add contracts to the DB (simulating what the real simulator does)
+      publicTxSimulator.simulate.mockImplementation(async (simulatedTx: Tx) => {
+        // Add contracts from the tx to the contractsDB's revertible and non-revertible tx-level caches
+        await contractsDB.addNewContracts(simulatedTx);
+        return Promise.resolve(mockedEnqueuedCallsResult);
+      });
+
+      const [processed, failed] = await processor.process([tx]);
+
+      // Transaction should be processed but with revert
+      expect(processed.length).toBe(1);
+      expect(failed).toEqual([]);
+
+      // Check whether the contract class is in the DB based on whether it was revertible
+      const contractClass = await contractsDB.getContractClass(contractClassId);
+      // On revert, the public processor only commits non-revertible contracts to the block-level cache
+      // On success, it commits both revertible and non-revertible contracts to the block-level cache
+      if (kind === 'revertible') {
+        expect(contractClass).toBeUndefined();
+      } else {
+        expect(contractClass).toBeDefined();
+      }
+    });
+  });
+
+  // on uncaught error, public processor clears the tx-level cache entirely
+  it('clears the tx-level cache entirely on uncaught error (like SETUP failure)', async function () {
+    const tx = await mockTxWithPublicCalls();
+
+    // we want to confirm that even non-revertibles get cleared
+    const contractClassId = await mockContractClassForTx(tx, /*revertible=*/ false);
+
+    publicTxSimulator.simulate.mockImplementation(async (simulatedTx: Tx) => {
+      await contractsDB.addNewContracts(simulatedTx);
+      throw new Error('Uncaught error');
+    });
+
+    const [processed, failed] = await processor.process([tx]);
+
+    expect(processed).toEqual([]);
+    expect(failed).toEqual([expect.objectContaining({ error: new Error(`Uncaught error`) })]);
+
+    // Check whether the contract class is in the DB based on whether it was revertible
+    const contractClass = await contractsDB.getContractClass(contractClassId);
+    // On uncaught error, the public processor clears the tx-level cache entirely
+    expect(contractClass).toBeUndefined();
   });
 });

--- a/yarn-project/simulator/src/public/public_processor/public_processor.ts
+++ b/yarn-project/simulator/src/public/public_processor/public_processor.ts
@@ -319,6 +319,9 @@ export class PublicProcessor implements Traceable {
         // Base case is we always commit the checkpoint. Using the ForkCheckpoint means this has no effect if the tx was previously reverted
         await checkpoint.commit();
         // The tx-level contracts cache should not live on to the next tx
+        // On tx success (inclusion in block), created contracts should have been committed down too the block-level cache,
+        // in which case this clear should be a no-op, but is good for sanity.
+        // On failure (error and no inclusion in block), this clears the tx-level cache of any contracts that were created.
         this.contractsDB.clearContractsForTx();
       }
     }
@@ -523,6 +526,11 @@ export class PublicProcessor implements Traceable {
 
     const { avmProvingRequest, gasUsed, revertCode, revertReason, processedPhases } =
       await this.publicTxSimulator.simulate(tx);
+    // Commit contracts from this TX to the block-level cache and clear tx cache
+    // If the tx reverted, only commit non-revertible contracts.
+    // This commit function also clears the tx-level caches (both non-revertible and revertible caches).
+    this.contractsDB.commitContractsForTx(/*onlyNonRevertibles=*/ !revertCode.isOK());
+    // NOTE: You can't create contracts in public, so this just adds contracts from the TX's private section.
 
     if (!avmProvingRequest) {
       this.metrics.recordFailedTx();

--- a/yarn-project/simulator/src/public/public_tx_simulator/cpp_public_tx_simulator.ts
+++ b/yarn-project/simulator/src/public/public_tx_simulator/cpp_public_tx_simulator.ts
@@ -51,17 +51,10 @@ export class CppPublicTxSimulatorHintedDbs extends PublicTxSimulator implements 
     // First, run TS simulation to generate hints and public inputs
     this.log.debug(`Running TS simulation for tx ${txHash}`);
 
-    let tsResult: PublicTxResult;
-    try {
-      // Run the full TypeScript simulation using the parent class
-      // This will modify the merkle tree with the transaction's state changes
-      tsResult = await super.simulate(tx);
-      this.log.debug(`TS simulation succeeded for tx ${txHash}`);
-    } catch (error: any) {
-      // If TS simulation fails, clear any partial contract additions and re-throw the error
-      this.contractsDB.clearContractsForTx();
-      throw error;
-    }
+    // Run the full TypeScript simulation using the parent class
+    // This will modify the merkle tree with the transaction's state changes
+    const tsResult = await super.simulate(tx);
+    this.log.debug(`TS simulation succeeded for tx ${txHash}`);
 
     // Extract the full AvmCircuitInputs from the TS result
     const avmCircuitInputs = tsResult.avmProvingRequest.inputs;

--- a/yarn-project/simulator/src/public/public_tx_simulator/public_tx_simulator.ts
+++ b/yarn-project/simulator/src/public/public_tx_simulator/public_tx_simulator.ts
@@ -129,136 +129,121 @@ export class PublicTxSimulator implements PublicTxSimulatorInterface {
    * @returns The result of the transaction's public execution.
    */
   public async simulate(tx: Tx): Promise<PublicTxResult> {
-    try {
-      const txHash = this.computeTxHash(tx);
-      this.log.debug(`Simulating ${tx.publicFunctionCalldata.length} public calls for tx ${txHash}`, { txHash });
+    const txHash = this.computeTxHash(tx);
+    this.log.debug(`Simulating ${tx.publicFunctionCalldata.length} public calls for tx ${txHash}`, { txHash });
 
-      // Create hinting DBs.
-      const hints = new AvmExecutionHints(
-        this.globalVariables,
-        AvmTxHint.fromTx(tx, this.globalVariables.gasFees),
-        ProtocolContractsList, // imported from file
-      );
-      const hintingMerkleTree = await HintingMerkleWriteOperations.create(this.merkleTree, hints);
-      const hintingTreesDB = new PublicTreesDB(hintingMerkleTree);
-      const hintingContractsDB = new HintingPublicContractsDB(this.contractsDB, hints);
+    // Create hinting DBs.
+    const hints = new AvmExecutionHints(
+      this.globalVariables,
+      AvmTxHint.fromTx(tx, this.globalVariables.gasFees),
+      ProtocolContractsList, // imported from file
+    );
+    const hintingMerkleTree = await HintingMerkleWriteOperations.create(this.merkleTree, hints);
+    const hintingTreesDB = new PublicTreesDB(hintingMerkleTree);
+    const hintingContractsDB = new HintingPublicContractsDB(this.contractsDB, hints);
 
-      const context = await PublicTxContext.create(
-        hintingTreesDB,
-        hintingContractsDB,
-        tx,
-        this.globalVariables,
-        ProtocolContractsList, // imported from file
-        this.config.doMerkleOperations,
-        this.config.proverId,
-      );
+    const context = await PublicTxContext.create(
+      hintingTreesDB,
+      hintingContractsDB,
+      tx,
+      this.globalVariables,
+      ProtocolContractsList, // imported from file
+      this.config.doMerkleOperations,
+      this.config.proverId,
+    );
 
-      // This will throw if there is a nullifier collision.
+    // This will throw if there is a nullifier collision.
+    // In that case the transaction will be thrown out.
+    await this.insertNonRevertiblesFromPrivate(context);
+
+    const processedPhases: ProcessedPhase[] = [];
+    if (context.hasPhase(TxExecutionPhase.SETUP)) {
+      // This will throw if the setup phase reverts.
       // In that case the transaction will be thrown out.
-      await this.insertNonRevertiblesFromPrivate(context);
-
-      const processedPhases: ProcessedPhase[] = [];
-      if (context.hasPhase(TxExecutionPhase.SETUP)) {
-        // This will throw if the setup phase reverts.
-        // In that case the transaction will be thrown out.
-        const setupResult = await this.simulatePhase(TxExecutionPhase.SETUP, context);
-        if (setupResult.reverted) {
-          throw new Error(
-            `Setup phase reverted! The transaction will be thrown out. ${setupResult.revertReason?.message}`,
-          );
-        }
-        processedPhases.push(setupResult);
+      const setupResult = await this.simulatePhase(TxExecutionPhase.SETUP, context);
+      if (setupResult.reverted) {
+        throw new Error(
+          `Setup phase reverted! The transaction will be thrown out. ${setupResult.revertReason?.message}`,
+        );
       }
-
-      // The checkpoint we should go back to if anything from now on reverts.
-      await context.state.fork();
-
-      try {
-        // This will throw if there is a nullifier collision or other insertion error (limit reached).
-        await this.insertRevertiblesFromPrivate(context);
-
-        // Only proceed with app logic if there was no revert during revertible insertion.
-        if (context.hasPhase(TxExecutionPhase.APP_LOGIC)) {
-          const appLogicResult = await this.simulatePhase(TxExecutionPhase.APP_LOGIC, context);
-          processedPhases.push(appLogicResult);
-          if (appLogicResult.reverted) {
-            throw new TxSimAppLogicRevert();
-          }
-        }
-      } catch (e: any) {
-        if (e instanceof TxSimRevertibleInsertionsRevert || e instanceof TxSimAppLogicRevert) {
-          // We revert to the post-setup state.
-          await context.state.discardForkedState();
-          // But we also create a new fork so that the teardown phase can transparently
-          // commit or rollback at the end of teardown.
-          await context.state.fork();
-        } else {
-          // Unchecked/unknown error - re-throw as-is
-          throw e;
-        }
-      }
-
-      try {
-        if (context.hasPhase(TxExecutionPhase.TEARDOWN)) {
-          const teardownResult = await this.simulatePhase(TxExecutionPhase.TEARDOWN, context);
-          processedPhases.push(teardownResult);
-          if (teardownResult.reverted) {
-            throw new TxSimTeardownRevert();
-          }
-        }
-        // We commit the forked state and we are done.
-        await context.state.mergeForkedState();
-      } catch (e: any) {
-        if (e instanceof TxSimTeardownRevert) {
-          // We revert to the post-setup state and we are done.
-          await context.state.discardForkedState();
-        } else {
-          // Unchecked/unknown error - re-throw as-is
-          throw e;
-        }
-      }
-
-      context.halt();
-
-      // Such transactions should be filtered by GasTxValidator.
-      assert(
-        context.getActualGasUsed().l2Gas <= AVM_MAX_PROCESSABLE_L2_GAS,
-        `Transaction consumes ${context.getActualGasUsed().l2Gas} L2 gas, which exceeds the AVM maximum processable gas of ${AVM_MAX_PROCESSABLE_L2_GAS}`,
-      );
-      await this.payFee(context);
-
-      const publicInputs = await context.generateAvmCircuitPublicInputs();
-      const avmProvingRequest = PublicTxSimulator.generateProvingRequest(publicInputs, hints);
-
-      const revertCode = context.getFinalRevertCode();
-
-      // Commit contracts from this TX to the block-level cache and clear tx cache
-      // If the tx reverted, only commit non-revertible contracts
-      // NOTE: You can't create contracts in public, so this is only relevant for private-created contracts
-      // FIXME(fcarreiro): this should conceptually use the hinting contracts db.
-      // However things should work as they are now because the hinting db would still pick up the new contracts.
-      this.contractsDB.commitContractsForTx(/*onlyNonRevertibles=*/ !revertCode.isOK());
-
-      return {
-        avmProvingRequest,
-        gasUsed: {
-          totalGas: context.getActualGasUsed(),
-          teardownGas: context.teardownGasUsed,
-          publicGas: context.getActualPublicGasUsed(),
-          billedGas: context.getTotalGasUsed(),
-        },
-        revertCode,
-        revertReason: context.revertReason,
-        processedPhases: processedPhases,
-        logs: context.state.getActiveStateManager().getLogs(),
-      };
-    } finally {
-      // Make sure there are no new contracts in the tx-level cache.
-      // They should either be committed to block-level cache or cleared.
-      // FIXME(fcarreiro): this should conceptually use the hinting contracts db.
-      // However things should work as they are now because the hinting db would still pick up the new contracts.
-      this.contractsDB.clearContractsForTx();
+      processedPhases.push(setupResult);
     }
+
+    // The checkpoint we should go back to if anything from now on reverts.
+    await context.state.fork();
+
+    try {
+      // This will throw if there is a nullifier collision or other insertion error (limit reached).
+      await this.insertRevertiblesFromPrivate(context);
+
+      // Only proceed with app logic if there was no revert during revertible insertion.
+      if (context.hasPhase(TxExecutionPhase.APP_LOGIC)) {
+        const appLogicResult = await this.simulatePhase(TxExecutionPhase.APP_LOGIC, context);
+        processedPhases.push(appLogicResult);
+        if (appLogicResult.reverted) {
+          throw new TxSimAppLogicRevert();
+        }
+      }
+    } catch (e: any) {
+      if (e instanceof TxSimRevertibleInsertionsRevert || e instanceof TxSimAppLogicRevert) {
+        // We revert to the post-setup state.
+        await context.state.discardForkedState();
+        // But we also create a new fork so that the teardown phase can transparently
+        // commit or rollback at the end of teardown.
+        await context.state.fork();
+      } else {
+        // Unchecked/unknown error - re-throw as-is
+        throw e;
+      }
+    }
+
+    try {
+      if (context.hasPhase(TxExecutionPhase.TEARDOWN)) {
+        const teardownResult = await this.simulatePhase(TxExecutionPhase.TEARDOWN, context);
+        processedPhases.push(teardownResult);
+        if (teardownResult.reverted) {
+          throw new TxSimTeardownRevert();
+        }
+      }
+      // We commit the forked state and we are done.
+      await context.state.mergeForkedState();
+    } catch (e: any) {
+      if (e instanceof TxSimTeardownRevert) {
+        // We revert to the post-setup state and we are done.
+        await context.state.discardForkedState();
+      } else {
+        // Unchecked/unknown error - re-throw as-is
+        throw e;
+      }
+    }
+
+    context.halt();
+
+    // Such transactions should be filtered by GasTxValidator.
+    assert(
+      context.getActualGasUsed().l2Gas <= AVM_MAX_PROCESSABLE_L2_GAS,
+      `Transaction consumes ${context.getActualGasUsed().l2Gas} L2 gas, which exceeds the AVM maximum processable gas of ${AVM_MAX_PROCESSABLE_L2_GAS}`,
+    );
+    await this.payFee(context);
+
+    const publicInputs = await context.generateAvmCircuitPublicInputs();
+    const avmProvingRequest = PublicTxSimulator.generateProvingRequest(publicInputs, hints);
+
+    const revertCode = context.getFinalRevertCode();
+
+    return {
+      avmProvingRequest,
+      gasUsed: {
+        totalGas: context.getActualGasUsed(),
+        teardownGas: context.teardownGasUsed,
+        publicGas: context.getActualPublicGasUsed(),
+        billedGas: context.getTotalGasUsed(),
+      },
+      revertCode,
+      revertReason: context.revertReason,
+      processedPhases: processedPhases,
+      logs: context.state.getActiveStateManager().getLogs(),
+    };
   }
 
   protected computeTxHash(tx: Tx) {


### PR DESCRIPTION
### State of things today
#### In the `PublicTxSimulator`
1. After non-revertible insertions, calls `contractsDb.addNewNonRevertibleContracts()` which adds to the TX-level cache.
2. After revertible insertions, calls `contractsDb.addNewRevertibleContracts()` which adds to the TX-level cache.
3. After public simulation is done, calls `contractsDb.commitContractsForTx(onlyRevertibles: bool)`, indicating whether or not revertible execution failed. This commits TX-level caches down to block-level and clears the TX caches.
4. All of this is wrapped in a `try-finally`, and the finally block runs `contractsDb.clearContractsForTx()` which clears the TX-level caches. If an unknown error occurs that prevents the TX's inclusion in a block, this makes sure that the TX cache is cleared. Otherwise, this is just a sanity check.

#### In the `PublicProcessor`
1. For private-only TXs, after successful processing, runs `contractsDb.addNewContracts()` and `contractsDb.commitContractsForTx()` to commit all of the TX's  new contracts to the block-level cache.
2. It _also_ wraps its main loop body in a `try-finally`, and runs `contractsDb.clearContractsForTx()` in the finally block to clear the TX-level caches on error (sanity check otherwise).

### State of things after this PR
1. No changes to calls to any `contractsDb.add*()` functions..
2. `PublicTxSimulator` never calls `commit*/clear*`
3. In the `PublicProcessor`, when `PublicTxSimulator`'s simulation returns, calls `contractsDb.commitContractsForTx(onlyRevertibles: bool)` exactly as was done in tx simulator before.
4. `PublicProcessor` still has that `try-finally` block to ensure that we clear the TX-level cache in case of errors (and for sanity).