### PR TITLE
feat: implement disk-based CI logging with SSH transfer

### DIFF
--- a/.github/workflows/ci3.yml
+++ b/.github/workflows/ci3.yml
@@ -130,6 +130,8 @@ jobs:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          # Enable disk logging for internal CI
+          CI_ENABLE_DISK_LOGS: "1"
           # Nightly test env vars.
           GOOGLE_APPLICATION_CREDENTIALS: ${{ env.GOOGLE_APPLICATION_CREDENTIALS }}
           EXTERNAL_ETHEREUM_HOSTS: "https://json-rpc.${{ secrets.GCP_SEPOLIA_URL }}?key=${{ secrets.GCP_SEPOLIA_API_KEY }},${{ secrets.INFURA_SEPOLIA_URL }}"

--- a/ci3/aws/build_instance_ssh_config
+++ b/ci3/aws/build_instance_ssh_config
@@ -3,3 +3,8 @@ StrictHostKeyChecking no
 User ubuntu
 ServerAliveInterval 60
 ServerAliveCountMax 5
+
+# SSH multiplexing for persistent connections
+ControlMaster auto
+ControlPath /tmp/ssh_mux_%h_%p_%r
+ControlPersist 10m

--- a/ci3/bootstrap_ec2
+++ b/ci3/bootstrap_ec2
@@ -135,6 +135,7 @@ container_script=$(
   source ci3/source
   source ci3/source_refname
   source ci3/source_redis
+  source ci3/source_cache
   ci_log_id=\$(log_ci_run)
   export PARENT_LOG_URL=${PARENT_LOG_URL:-http://ci.aztec-labs.com/\$ci_log_id}
 
@@ -210,6 +211,17 @@ function run {
   if [ -f ${NETWORK_ENV_FILE} ]; then
     export NETWORK_ENV_FILE_B64=$(cat ${NETWORK_ENV_FILE} | base64 -w 0)
   fi
+  # Only pass SSH keys if disk logging is enabled (internal CI only)
+  if [ "${CI_ENABLE_DISK_LOGS:-0}" -eq 1 ]; then
+    # if the build instance key exists, load it into a base64 encoded string
+    if [ -f ~/.ssh/build_instance_key ]; then
+      export BUILD_INSTANCE_KEY_B64=$(cat ~/.ssh/build_instance_key | base64 -w 0)
+    fi
+    # if the build instance ssh config exists, load it into a base64 encoded string
+    if [ -f $ci3/aws/build_instance_ssh_config ]; then
+      export BUILD_INSTANCE_SSH_CONFIG_B64=$(cat $ci3/aws/build_instance_ssh_config | base64 -w 0)
+    fi
+  fi
 
   ssh ${ssh_args:-} -F $ci3/aws/build_instance_ssh_config ubuntu@$ip "
     # TODO: This should *not* be needed in a CI run. Remove watching code, e.g. in boxes.
@@ -237,6 +249,21 @@ function run {
       echo "NETWORK_ENV_FILE decoded and saved to ${NETWORK_ENV_FILE}"
     fi
 
+    # Save BUILD_INSTANCE_KEY to a file if set
+    if [ -n "${BUILD_INSTANCE_KEY_B64:-}" ]; then
+      mkdir -p \$HOME/.ssh
+      echo "${BUILD_INSTANCE_KEY_B64:-}" | base64 -d > \$HOME/.ssh/build_instance_key
+      chmod 600 \$HOME/.ssh/build_instance_key
+      echo "BUILD_INSTANCE_KEY decoded and saved to \$HOME/.ssh/build_instance_key"
+    fi
+
+    # Save BUILD_INSTANCE_SSH_CONFIG to a file if set
+    if [ -n "${BUILD_INSTANCE_SSH_CONFIG_B64:-}" ]; then
+      mkdir -p \$HOME/.ssh
+      echo "${BUILD_INSTANCE_SSH_CONFIG_B64:-}" | base64 -d > \$HOME/.ssh/build_instance_ssh_config
+      echo "BUILD_INSTANCE_SSH_CONFIG decoded and saved to \$HOME/.ssh/build_instance_ssh_config"
+    fi
+
     start_build() {
       echo Starting devbox...
       docker run --privileged --rm \${docker_args:-} \
@@ -245,6 +272,7 @@ function run {
         -v bootstrap_ci_local_docker:/var/lib/docker \
         -v bootstrap_ci_repo:/home/aztec-dev/aztec-packages \
         -v \$HOME/.aws:/home/aztec-dev/.aws:ro \
+        -v \$HOME/.ssh:/home/aztec-dev/.ssh:ro \
         -v /mnt/bb-crs:/home/aztec-dev/.bb-crs \
         -v /dev/kmsg:/dev/kmsg \
         -v /tmp:/tmp \
@@ -260,6 +288,7 @@ function run {
         -e PARENT_LOG_URL=${PARENT_LOG_URL:-} \
         -e NO_CACHE=${NO_CACHE:-} \
         -e NO_FAIL_FAST=${NO_FAIL_FAST:-} \
+        -e CI_ENABLE_DISK_LOGS=${CI_ENABLE_DISK_LOGS:-} \
         -e CI_REDIS='ci-redis-tiered.lzka0i.ng.0001.use2.cache.amazonaws.com' \
         -e SSH_CONNECTION=' ' \
         -e LOCAL_USER_ID=\$(id -u) \

--- a/ci3/cache_log
+++ b/ci3/cache_log
@@ -4,6 +4,7 @@
 # If DUP=1 then we duplicate input also to stdout.
 NO_CD=1 source $(git rev-parse --show-toplevel)/ci3/source
 source $ci3/source_redis
+source $ci3/source_cache
 
 name=$1
 
@@ -15,6 +16,10 @@ echo -e "Parent Log: ${PARENT_LOG_URL:-none}\n" >$outfile
 
 function publish_log {
   cat $outfile | redis_setexz $key $CI_REDIS_EXPIRE
+}
+
+function publish_log_final {
+  cat $outfile | cache_persistent $key $CI_REDIS_EXPIRE
 }
 
 function live_publish_log {
@@ -43,7 +48,7 @@ if [ "$CI_REDIS_AVAILABLE" -eq 1 ]; then
   else
     redact | cat >>$outfile
   fi
-  publish_log
+  publish_log_final
 else
   if [ "$dup" -eq 1 ]; then
     redact | cat

--- a/ci3/denoise
+++ b/ci3/denoise
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 NO_CD=1 source ${root:-$(git rev-parse --show-toplevel)}/ci3/source
 source $ci3/source_redis
+source $ci3/source_cache
 
 # Ensure a command is passed
 if [ "$#" != 1 ]; then
@@ -71,6 +72,26 @@ function publish_log {
   } | redis_setexz $key $CI_REDIS_EXPIRE
 }
 
+function _format_log_output {
+  echo "Parent Log: ${PARENT_LOG_URL:-none}"
+  echo "Command: $cmd"
+  echo "Date: $(date)"
+  echo "Status: $status"
+  echo "Took: ${time}"
+  echo
+  cat $outfile
+}
+
+function publish_log {
+  [ "$CI_REDIS_AVAILABLE" -eq 0 ] && return
+  _format_log_output | redis_setexz $key $CI_REDIS_EXPIRE
+}
+
+function publish_log_final {
+  [ "$CI_REDIS_AVAILABLE" -eq 0 ] && return
+  _format_log_output | cache_persistent $key $CI_REDIS_EXPIRE
+}
+
 function live_publish_log {
   while [ -f $outfile ]; do
     if [ $(( $(date +%s) - $(stat -c %Y "$outfile") )) -le 5 ]; then
@@ -112,7 +133,7 @@ status=$?
 
 time="${SECONDS}s"
 [ -n "${publish_pid:-}" ] && kill $publish_pid &>/dev/null || true
-publish_log
+publish_log_final
 
 # Handle non-zero exit status
 if [ "$status" -ne 0 ]; then

--- a/ci3/run_test_cmd
+++ b/ci3/run_test_cmd
@@ -2,6 +2,7 @@
 # Called by 'parallelize' to execute a given test cmd.
 NO_CD=1 source $(git rev-parse --show-toplevel)/ci3/source
 source $ci3/source_redis
+source $ci3/source_cache
 source $ci3/source_refname
 
 # We must enable job control to ensure our test runs in it's own process group.
@@ -95,7 +96,13 @@ History: http://ci.aztec-labs.com/list/history_$test_hash${TARGET_BRANCH:+_$TARG
 EOF
 
 function publish_log {
-  cat $tmp_file 2>/dev/null | redis_setexz $log_key ${1:-$CI_REDIS_EXPIRE}
+  local expire=${1:-$CI_REDIS_EXPIRE}
+  cat $tmp_file 2>/dev/null | redis_setexz $log_key $expire
+}
+
+function publish_log_final {
+  local expire=${1:-$CI_REDIS_EXPIRE}
+  cat $tmp_file 2>/dev/null | cache_persistent $log_key $expire
 }
 
 function live_publish_log {
@@ -159,13 +166,13 @@ if [ "$CI_REDIS_AVAILABLE" -eq 1 ]; then
   if [ $code -eq 0 ]; then
     if [ "$CI" -eq 1 ]; then
       redis_cli SETEX $key 604800 $log_key &>/dev/null
-      publish_log
+      publish_log_final
     else
       log_info=""
     fi
   else
     # Extend lifetime of failed test logs to 12 weeks.
-    publish_log $((60 * 60 * 24 * 7 * 12))
+    publish_log_final $((60 * 60 * 24 * 7 * 12))
   fi
 fi
 

--- a/ci3/source_cache
+++ b/ci3/source_cache
@@ -1,0 +1,43 @@
+# Disk-based cache system for CI logs.
+# Logs are written to /logs-disk on bastion via SSH.
+# NOTE: This file depends on source_redis being sourced first.
+
+# Transfer log to bastion via SSH (accepts gzipped data on stdin)
+# Usage: cat file.gz | cache_disk_transfer <key>
+function cache_disk_transfer {
+  local key="$1"
+  local prefix="${key:0:4}"
+
+  # Transfer via SSH pipe using persistent multiplexed connection
+  # Use first 4 chars as subdirectory to avoid too many files in one dir
+  ssh -F "${ci3}/aws/build_instance_ssh_config" \
+      -o ConnectTimeout=5 \
+      ci-bastion.aztecprotocol.com \
+      "mkdir -p /logs-disk/${prefix} && cat > /logs-disk/${prefix}/${key}.log.gz" &>/dev/null
+}
+
+# Persistent cache function that writes to both Redis and disk
+function cache_persistent {
+  local key="$1"
+  local expire="$2"
+  local tmpfile="/tmp/cache_log_$$_${key}.gz"
+
+  # Save gzipped data to temp file (synchronous - must complete first)
+  cat | gzip > "$tmpfile"
+
+  # Write to Redis (synchronous - must complete before returning)
+  cat "$tmpfile" | redis_cli -x SETEX "$key" "$expire" &>/dev/null
+
+  # Transfer to bastion disk in background (only if disk logging enabled)
+  if [ "${CI_ENABLE_DISK_LOGS:-0}" -eq 1 ]; then
+    {
+      cat "$tmpfile" | cache_disk_transfer "$key"
+      rm -f "$tmpfile"
+    } &
+  else
+    rm -f "$tmpfile"
+  fi
+}
+
+# Export functions
+export -f cache_disk_transfer cache_persistent


### PR DESCRIPTION
## Summary

Implement disk-based CI logging system that writes logs to both Redis and persistent disk storage on bastion, solving the problem of 120GB+ compressed logs overwhelming Redis (which has only 2-week retention).

## Changes

### Infrastructure
- 1TB EBS volume mounted at `/logs-disk` on CI bastion in us-east-2

### Core Implementation
- **`ci3/source_cache`**: New module with `cache_persistent()` function for dual Redis+disk writes
- **`ci3/cache_log`**, **`ci3/run_test_cmd`**, **`ci3/denoise`**: Updated to use `cache_persistent()` for final log writes
- **`ci3/bootstrap_ec2`**: SSH key passing via base64 encoding (following GCP_SA_KEY pattern)
- **`ci3/aws/build_instance_ssh_config`**: SSH multiplexing config for efficient persistent connections
- **`rkapp/rk.py`**: In [iac](https://github.com/AztecProtocol/iac/pull/18). Disk fallback when Redis key expires

### Architecture
- **Write path**: Live updates (every 5s) → Redis only. Final write → Redis + SSH to bastion disk
- **Read path**: Try Redis first, fall back to `/logs-disk` on bastion if expired
- **SSH transfer**: Background SSH pipe using multiplexed connections (ControlMaster, ControlPersist 10m)
- **Efficiency**: Single long-lived SSH connection shared across all log writes (zero latency after first connect)
