### PR TITLE
refactor(ci3): refactor common yaml into .github/ci3.sh

### DIFF
--- a/.github/ci3-post.sh
+++ b/.github/ci3-post.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+NO_CD=1 source $(git rev-parse --show-toplevel)/ci3/source
+
+function save_cache {
+  local github_repository="$1"
+  # CI_CACHE_NAME is set by ci3.sh with tree hash included
+  local cache_name="${CI_CACHE_NAME:-}"
+  if [ -z "$cache_name" ]; then
+    echo "CI_CACHE_NAME not set, skipping cache upload"
+    return
+  fi
+  # Save CI success marker for cache
+  local run_url="https://github.com/${github_repository}/actions/runs/${GITHUB_RUN_ID}"
+  echo "${run_url}" > ".ci-success.txt"
+  echo "Saved CI success marker: ${run_url}"
+  # Upload cache
+  cache_upload "$cache_name" ".ci-success.txt" 2>&1 | grep -v "^$" || true
+}
+
+function handle_squash_merge {
+  local github_repository="$1"
+  if [ "${SHOULD_SQUASH_MERGE:-0}" -eq 0 ]; then
+    return
+  fi
+  # If we have passed CI and labelled with ci-squash-and-merge, squash the PR.
+  # This will rerun CI on the squash commit - but is intended to be a no-op due to caching.
+  echo "Processing squash and merge..."
+  # Reauth the git repo with our GITHUB_TOKEN
+  git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/${github_repository}
+  # Get the base commit (merge-base) for the PR
+  ./scripts/merge-train/squash-pr.sh \
+    "${PR_NUMBER}" \
+    "${PR_HEAD_REF}" \
+    "${PR_BASE_REF}" \
+    "${PR_BASE_SHA}"
+  gh pr edit "${PR_NUMBER}" --remove-label "ci-squash-and-merge"
+  gh pr merge "${PR_NUMBER}" --auto -m || true
+  echo "Squash and merge completed"
+}
+
+function handle_benchmarks {
+  if [ "${SHOULD_UPLOAD_BENCHMARKS:-0}" -eq 0 ] || [ "${CI_INTERNAL:-0}" -eq 0 ]; then
+    return
+  fi
+  # Handle benchmarks download (internal only)
+  echo "Downloading benchmarks..."
+  if ./ci.sh gh-bench && [ -f "./bench-out/bench.json" ] && [ "$(cat ./bench-out/bench.json)" != "[]" ]; then
+    echo "Benchmarks downloaded successfully"
+    echo "SHOULD_UPLOAD_BENCHMARKS=1" >> $GITHUB_ENV
+  else
+    echo "No benchmarks to upload"
+    echo "SHOULD_UPLOAD_BENCHMARKS=0" >> $GITHUB_ENV
+  fi
+}
+
+function main {
+  echo_header "CI3 Post-Actions"
+  # Get repository from git remote
+  local github_repository=$(git remote get-url origin | sed -E 's|.*github\.com[/:]([^/]+/[^/]+)(\.git)?$|\1|')
+  save_cache "${github_repository}"
+  handle_squash_merge "${github_repository}"
+  handle_benchmarks
+  echo_header "Post-Actions Complete"
+}
+
+main

--- a/.github/ci3.sh
+++ b/.github/ci3.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${AWS_ACCESS_KEY_ID:?required}"
+: "${AWS_SECRET_ACCESS_KEY:?required}"
+: "${GITHUB_TOKEN:?required}"
+
+NO_CD=1 source $(git rev-parse --show-toplevel)/ci3/source
+
+function setup_environment {
+  echo_header "Setup"
+  # Store GCP key
+  if [ -n "${GCP_SA_KEY:-}" ] && [ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]; then
+    set +x
+    umask 077
+    printf '%s' "$GCP_SA_KEY" > "$GOOGLE_APPLICATION_CREDENTIALS"
+    jq -e . "$GOOGLE_APPLICATION_CREDENTIALS" >/dev/null
+    echo "GCP key stored"
+  fi
+  # Compute target branch
+  local target_branch
+  if [ "${GITHUB_EVENT_NAME:-}" == "merge_group" ]; then
+    target_branch="${MERGE_GROUP_BASE_REF:-}"
+  elif [ "${GITHUB_EVENT_NAME:-}" == "pull_request" ]; then
+    target_branch="${PR_BASE_REF:-}"
+  else
+    target_branch="${GITHUB_REF_NAME:-}"
+  fi
+  target_branch="${target_branch#refs/heads/}"
+  export TARGET_BRANCH=$target_branch
+  echo "TARGET_BRANCH=$TARGET_BRANCH" >> $GITHUB_ENV
+  echo "Target branch: $TARGET_BRANCH"
+  # To allow full concurrency, we set instance postfix for merge-train PRs
+  if [[ "${PR_HEAD_REF:-}" == merge-train/* ]]; then
+    export INSTANCE_POSTFIX=${PR_COMMITS:-}
+    echo "INSTANCE_POSTFIX=$INSTANCE_POSTFIX" >> $GITHUB_ENV
+    echo "Instance postfix set to: $INSTANCE_POSTFIX"
+  fi
+  # Setup SSH key (internal only)
+  if [ "${CI_INTERNAL:-0}" -eq 1 ] && [ -n "${BUILD_INSTANCE_SSH_KEY:-}" ]; then
+    mkdir -p ~/.ssh
+    echo "${BUILD_INSTANCE_SSH_KEY}" | base64 --decode > ~/.ssh/build_instance_key
+    chmod 600 ~/.ssh/build_instance_key
+    echo "SSH key configured"
+  fi
+}
+
+function has_label {
+  local label="$1"
+  if [[ ",$LABELS," == *",$label,"* ]]; then
+    echo "Label '$label' found" >&2
+    return 0
+  fi
+  return 1
+}
+
+function determine_ci_mode {
+  echo_header "CI Mode Determination"
+  echo "Labels: ${LABELS}"
+  # Handle fail-fast override
+  if has_label "ci-no-fail-fast"; then
+    export NO_FAIL_FAST=1
+    echo "NO_FAIL_FAST=$NO_FAIL_FAST" >> $GITHUB_ENV
+  fi
+  # Determine CI mode based on event, labels, and target branch
+  if [ "${GITHUB_EVENT_NAME:-}" == "merge_group" ] || has_label "ci-merge-queue"; then
+    CI_MODE="merge-queue"
+  elif has_label "ci-release-pr"; then
+    CI_MODE="release-pr"
+  elif has_label "ci-full"; then
+    CI_MODE="full"
+  elif has_label "ci-full-no-test-cache"; then
+    CI_MODE="full-no-test-cache"
+  elif has_label "ci-docs" || [ "${TARGET_BRANCH:-}" == "merge-train/docs" ]; then
+    CI_MODE="docs"
+  elif has_label "ci-barretenberg" || [ "${TARGET_BRANCH:-}" == "merge-train/barretenberg" ]; then
+    CI_MODE="barretenberg"
+  elif [[ "${GITHUB_REF:-}" == *"-nightly."* ]] || [[ "${GITHUB_REF:-}" == *"-rc."* ]]; then
+    CI_MODE="nightly"
+  elif [[ "${GITHUB_REF:-}" == refs/tags/v* ]]; then
+    CI_MODE="release"
+  else
+    CI_MODE="fast"
+  fi
+  echo "CI_MODE=$CI_MODE" >> $GITHUB_ENV
+  echo "CI mode: $CI_MODE"
+  # Determine if benchmarks should be uploaded (merge-queue, full, or full-no-test-cache modes)
+  if [[ "$CI_MODE" == "merge-queue" || "$CI_MODE" == "full" || "$CI_MODE" == "full-no-test-cache" ]]; then
+    echo "SHOULD_UPLOAD_BENCHMARKS=1" >> $GITHUB_ENV
+  fi
+}
+
+function check_cache {
+  echo_header "Cache Check"
+  local tree_hash=$(git rev-parse HEAD^{tree})
+  local cache_name="ci-success-${CI_MODE}-${tree_hash}.tar.gz"
+  # Export for use by ci3-post.sh
+  echo "CI_CACHE_NAME=$cache_name" >> $GITHUB_ENV
+  if has_label "no-cache"; then
+    export NO_CACHE=1
+    echo "NO_CACHE=$NO_CACHE" >> $GITHUB_ENV
+    echo "Cache disabled by label"
+    return
+  fi
+  if cache_download "$cache_name" . 2>/dev/null && [ -f ".ci-success.txt" ]; then
+    echo "Cache hit! Previous run: $(cat ".ci-success.txt")"
+    exit 0
+  fi
+  echo "Cache miss, running CI in ${CI_MODE} mode..."
+}
+
+function handle_release_pr {
+  echo_header "Release PR"
+  # Create and push a tag for release PR testing
+  local github_repository
+  github_repository=$(git remote get-url origin | sed -E 's|.*github\.com[/:]([^/]+/[^/]+)(\.git)?$|\1|')
+  git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${github_repository}"
+  local tag_name="v0.0.1-commit.$(git rev-parse --short HEAD)"
+  git tag "${tag_name}"
+  git push origin "${tag_name}"
+  echo "Created and pushed tag: ${tag_name}"
+}
+
+function main {
+  LABELS="${1:-}"
+  echo_header "CI3 Main Script"
+  setup_environment
+  determine_ci_mode
+  # Handle release-pr mode separately (creates tag instead of running CI)
+  if [ "${CI_MODE}" == "release-pr" ]; then
+    handle_release_pr
+    exit 0
+  fi
+  check_cache
+  echo_header "Run CI"
+  exec ./ci.sh "${CI_MODE}"
+}
+
+main "$@"

--- a/.github/workflows/ci3-external.yml
+++ b/.github/workflows/ci3-external.yml
@@ -23,9 +23,6 @@ jobs:
     # exclusive with ci3.yml, only run on forks.
     if: github.event.pull_request.head.repo.fork
     steps:
-      #############
-      # Prepare Env
-      #############
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
@@ -40,7 +37,6 @@ jobs:
         run: echo "CI is not run on drafts." && exit 1
 
       - name: External Contributor Checks
-        # Run only if a pull request event type and we have a forked repository origin.
         run: |
           set -o pipefail
           git fetch origin ${{ github.event.pull_request.base.ref }} --depth=1 &>/dev/null
@@ -61,89 +57,35 @@ jobs:
             echo "External PRs need the 'ci-external' or 'ci-external-once' labels to run."
             exit 1
           fi
-          # Remove any ci-external-once labels.
           GITHUB_TOKEN=${{ secrets.AZTEC_BOT_GITHUB_TOKEN }} gh pr edit ${{ github.event.pull_request.number }} --remove-label "ci-external-once"
 
-      - name: CI Merge Queue Override (grind on PR)
-        if: contains(github.event.pull_request.labels.*.name, 'ci-merge-queue')
-        run: echo "CI_MERGE_QUEUE=1" >> $GITHUB_ENV
-
-      - name: CI Full Override
-        if: contains(github.event.pull_request.labels.*.name, 'ci-full')
-        run: echo "CI_FULL=1" >> $GITHUB_ENV
-
-      - name: Cache Override
-        if: contains(github.event.pull_request.labels.*.name, 'ci-no-cache')
-        run: echo "NO_CACHE=1" >> $GITHUB_ENV
-
-      - name: Fail Fast Override
-        if: contains(github.event.pull_request.labels.*.name, 'ci-no-fail-fast')
-        run: echo "NO_FAIL_FAST=1" >> $GITHUB_ENV
-
-      - name: Setup
-        run: |
-          # Ensure we can SSH into the spot instances we request.
-          mkdir -p ~/.ssh
-          echo ${{ secrets.BUILD_INSTANCE_SSH_KEY }} | base64 --decode > ~/.ssh/build_instance_key
-          chmod 600 ~/.ssh/build_instance_key
-
-      - name: Get Tree Hash
-        run: echo "TREE_HASH=$(git rev-parse HEAD^{tree})" >> $GITHUB_ENV
-
-      - name: Check CI Cache
-        id: ci_cache
-        uses: actions/cache@v3
-        with:
-          path: ci-success.txt
-          key: ci-external-${{ env.CI_MERGE_QUEUE == '1' && 'merge-queue' }}-${{ env.CI_FULL == '1' && 'full' }}-${{ env.NO_CACHE == '1' && 'no-cache' }}-${{ env.NO_FAIL_FAST == '1' && 'no-fail-fast' }}-${{ env.TREE_HASH }}
-
-      - name: CI Cached
-        if: steps.ci_cache.outputs.cache-hit == 'true'
-        run: |
-          echo "Previous run: $(cat ci-success.txt)"
-
-      #############
-      # Run
-      #############
       - name: Run
-        if: steps.ci_cache.outputs.cache-hit != 'true'
         env:
+          REF_NAME: repo-fork/${{ github.repository }}/${{ github.head_ref }}
+          # We only test on amd64.
+          ARCH: amd64
           # We need to pass these creds to start the AWS ec2 instance.
           # They are not injected into that instance. Instead, it has minimal
           # creds for being able to upload to cache.
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          REF_NAME: repo-fork/${{ github.repository }}/${{ github.head_ref }}
-          # We only test on amd64.
-          ARCH: amd64
-          RUN_ID: ${{ github.run_id }}
-        run: |
-          if [ "${CI_MERGE_QUEUE:-0}" -eq 1 ]; then
-            exec ./ci.sh merge-queue
-          elif [ "${CI_FULL:-0}" -eq 1 ]; then
-            exec ./ci.sh full
-          else
-            exec ./ci.sh fast
-          fi
-
-      - name: Save CI Success
-        if: steps.ci_cache.outputs.cache-hit != 'true'
-        run: echo "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" > ci-success.txt
-
-      # If we have passed CI and labelled with ci-squash-and-merge, squash the PR.
-      # This will rerun CI on the squash commit - but is intended to be a no-op due to caching.
-      - name: CI Squash and Merge
-        if: contains(github.event.pull_request.labels.*.name, 'ci-squash-and-merge')
-        env:
           GITHUB_TOKEN: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
-        run: |
-          # Reauth the git repo with our GITHUB_TOKEN
-          git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}
-          # Get the base commit (merge-base) for the PR
-          ./scripts/merge-train/squash-pr.sh \
-            "${{ github.event.pull_request.number }}" \
-            "${{ github.event.pull_request.head.ref }}" \
-            "${{ github.event.pull_request.base.ref }}" \
-            "${{ github.event.pull_request.base.sha }}"
-          gh pr edit "${{ github.event.pull_request.number }}" --remove-label "ci-squash-and-merge"
-          gh pr merge "${{ github.event.pull_request.number }}" --auto -m || true
+          BUILD_INSTANCE_SSH_KEY: ${{ secrets.BUILD_INSTANCE_SSH_KEY }}
+          MERGE_GROUP_BASE_REF: ${{ github.event.merge_group.base_ref }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PR_COMMITS: ${{ github.event.pull_request.commits }}
+          GITHUB_REF_NAME: ${{ github.ref_name }}
+        run: ./.github/ci3.sh "${{ join(github.event.pull_request.labels.*.name, ',') }}"
+
+      - name: Post-Actions
+        if: always()
+        env:
+          SHOULD_SQUASH_MERGE: ${{ contains(github.event.pull_request.labels.*.name, 'ci-squash-and-merge') && '1' || '0' }}
+          SHOULD_UPLOAD_BENCHMARKS: "0"
+          GITHUB_TOKEN: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: ./.github/ci3-post.sh

--- a/.github/workflows/ci3.yml
+++ b/.github/workflows/ci3.yml
@@ -28,9 +28,6 @@ jobs:
     env:
       GOOGLE_APPLICATION_CREDENTIALS: /tmp/gcp-key.json
     steps:
-      #############
-      # Prepare Env
-      #############
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
@@ -40,99 +37,15 @@ jobs:
           fetch-depth: ${{ github.event.pull_request.commits || 0 }}
           persist-credentials: false
 
-      - name: CI Merge Queue Override (grind on PR)
-        if: contains(github.event.pull_request.labels.*.name, 'ci-merge-queue')
-        run: echo "CI_MERGE_QUEUE=1" >> $GITHUB_ENV
-
-      - name: CI Full Override
-        if: contains(github.event.pull_request.labels.*.name, 'ci-full')
-        run: echo "CI_FULL=1" >> $GITHUB_ENV
-
-      - name: CI Full No Test Cache Override
-        if: contains(github.event.pull_request.labels.*.name, 'ci-full-no-test-cache')
-        run: echo "CI_FULL_NO_TEST_CACHE=1" >> $GITHUB_ENV
-
-      - name: Cache Override
-        if: contains(github.event.pull_request.labels.*.name, 'ci-no-cache')
-        run: echo "NO_CACHE=1" >> $GITHUB_ENV
-
-      - name: Fail Fast Override
-        if: contains(github.event.pull_request.labels.*.name, 'ci-no-fail-fast')
-        run: echo "NO_FAIL_FAST=1" >> $GITHUB_ENV
-
-      - name: Compute Target Branch
-        id: target_branch
-        run: |
-          if [ "${{ github.event_name }}" == "merge_group" ]; then
-            target_branch=${{ github.event.merge_group.base_ref }}
-          elif [ "${{ github.event_name }}" == "pull_request" ]; then
-            target_branch=${{ github.event.pull_request.base.ref }}
-          else
-            target_branch=${{ github.ref_name }}
-          fi
-          target_branch=${target_branch#refs/heads/}
-          echo "target_branch=$target_branch" >> $GITHUB_OUTPUT
-          echo "TARGET_BRANCH=${target_branch}" >> $GITHUB_ENV
-
-      - name: Docs CI Override
-        if: contains(github.event.pull_request.labels.*.name, 'ci-docs') || (steps.target_branch.outputs.target_branch == 'merge-train/docs')
-        run: echo "CI_DOCS=1" >> $GITHUB_ENV
-
-      - name: Barretenberg CI Override
-        if: contains(github.event.pull_request.labels.*.name, 'barretenberg-ci') || (github.event.pull_request.base.ref == 'merge-train/barretenberg')
-        run: echo "CI_BARRETENBERG=1" >> $GITHUB_ENV
-
-      - name: CI Release PR Override
-        if: contains(github.event.pull_request.labels.*.name, 'ci-release-pr')
-        run: echo "CI_RELEASE_PR=1" >> $GITHUB_ENV
-
-      # Allow full concurrency for merge-train PRs, one-run-per-branch for everything else.
-      - name: Set Instance Postfix for merge-train
-        if: startsWith(github.event.pull_request.head.ref, 'merge-train/')
-        run: echo "INSTANCE_POSTFIX=${{ github.event.pull_request.commits }}" >> $GITHUB_ENV
-
-      - name: Setup
-        run: |
-          # Ensure we can SSH into the spot instances we request.
-          mkdir -p ~/.ssh
-          echo ${{ secrets.BUILD_INSTANCE_SSH_KEY }} | base64 --decode > ~/.ssh/build_instance_key
-          chmod 600 ~/.ssh/build_instance_key
-
-      - name: Store the GCP key in a file
-        env:
-          GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
-        run: |
-          set +x
-          umask 077
-          printf '%s' "$GCP_SA_KEY" > "$GOOGLE_APPLICATION_CREDENTIALS"
-          jq -e . "$GOOGLE_APPLICATION_CREDENTIALS" >/dev/null
-
-      - name: Get Tree Hash
-        run: echo "TREE_HASH=$(git rev-parse HEAD^{tree})" >> $GITHUB_ENV
-
-      - name: Check CI Cache
-        id: ci_cache
-        uses: actions/cache@v3
-        if: env.CI_MERGE_QUEUE != '1' && github.event_name != 'merge_group' && env.CI_FULL_NO_TEST_CACHE != '1'
-        with:
-          path: ci-success.txt
-          key: ci-${{ env.CI_FULL == '1' && 'full' || env.CI_DOCS == '1' && 'docs' || env.CI_BARRETENBERG == '1' && 'barretenberg' || 'fast' }}-${{ env.TREE_HASH }}
-
-      - name: CI Cached
-        if: steps.ci_cache.outputs.cache-hit == 'true'
-        run: |
-          echo "Previous run: $(cat ci-success.txt)"
-
-      #############
-      # Run
-      #############
       - name: Run
-        if: steps.ci_cache.outputs.cache-hit != 'true'
         env:
+          CI_INTERNAL: "1"
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           GITHUB_TOKEN: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
-          RUN_ID: ${{ github.run_id }}
+          BUILD_INSTANCE_SSH_KEY: ${{ secrets.BUILD_INSTANCE_SSH_KEY }}
+          GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
+          GOOGLE_APPLICATION_CREDENTIALS: ${{ env.GOOGLE_APPLICATION_CREDENTIALS }}
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
@@ -142,70 +55,37 @@ jobs:
           # Enable disk logging for internal CI
           CI_ENABLE_DISK_LOGS: "1"
           # Nightly test env vars.
-          GOOGLE_APPLICATION_CREDENTIALS: ${{ env.GOOGLE_APPLICATION_CREDENTIALS }}
           EXTERNAL_ETHEREUM_HOSTS: "https://json-rpc.${{ secrets.GCP_SEPOLIA_URL }}?key=${{ secrets.GCP_SEPOLIA_API_KEY }},${{ secrets.INFURA_SEPOLIA_URL }}"
           EXTERNAL_ETHEREUM_CONSENSUS_HOST: "https://beacon.${{ secrets.GCP_SEPOLIA_URL }}"
           EXTERNAL_ETHEREUM_CONSENSUS_HOST_API_KEY: ${{ secrets.GCP_SEPOLIA_API_KEY }}
           EXTERNAL_ETHEREUM_CONSENSUS_HOST_API_KEY_HEADER: "X-goog-api-key"
           GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+          MERGE_GROUP_BASE_REF: ${{ github.event.merge_group.base_ref }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PR_COMMITS: ${{ github.event.pull_request.commits }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          if [ "${{ github.event_name }}" == "merge_group" ] || [ "${CI_MERGE_QUEUE:-0}" -eq 1 ]; then
-            exec ./ci.sh merge-queue
-          elif [ "${CI_RELEASE_PR:-0}" -eq 1 ]; then
-            git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}
-            tag_name="v0.0.1-commit.$(git rev-parse --short HEAD)"
-            git tag ${tag_name}
-            git push origin ${tag_name}
-          elif [ "${CI_FULL:-0}" -eq 1 ]; then
-            exec ./ci.sh full
-          elif [ "${CI_FULL_NO_TEST_CACHE:-0}" -eq 1 ]; then
-            exec ./ci.sh full-no-test-cache
-          elif [ "${CI_DOCS:-0}" -eq 1 ]; then
-            exec ./ci.sh docs
-          elif [ "${CI_BARRETENBERG:-0}" -eq 1 ]; then
-            exec ./ci.sh barretenberg
-          elif [ "${{ startsWith(github.ref, 'refs/tags/v') }}" == "true" ]; then
-            exec ./ci.sh release
-          else
-            exec ./ci.sh fast
-          fi
+          GITHUB_REF_NAME: ${{ github.ref_name }}
+        run: ./.github/ci3.sh "${{ join(github.event.pull_request.labels.*.name, ',') }}"
 
-      - name: Save CI Success
-        if: steps.ci_cache.outputs.cache-hit != 'true'
-        run: echo "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" > ci-success.txt
-
-      # If we have passed CI and labelled with ci-squash-and-merge, squash the PR.
-      # This will rerun CI on the squash commit - but is intended to be a no-op due to caching.
-      - name: CI Squash and Merge
-        if: contains(github.event.pull_request.labels.*.name, 'ci-squash-and-merge')
+      - name: Post-Actions
+        if: always()
         env:
+          CI_INTERNAL: "1"
+          SHOULD_SQUASH_MERGE: ${{ contains(github.event.pull_request.labels.*.name, 'ci-squash-and-merge') && '1' || '0' }}
           GITHUB_TOKEN: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
-        run: |
-          # Reauth the git repo with our GITHUB_TOKEN
-          git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}
-          # Get the base commit (merge-base) for the PR
-          ./scripts/merge-train/squash-pr.sh \
-            "${{ github.event.pull_request.number }}" \
-            "${{ github.event.pull_request.head.ref }}" \
-            "${{ github.event.pull_request.base.ref }}" \
-            "${{ github.event.pull_request.base.sha }}"
-          gh pr edit "${{ github.event.pull_request.number }}" --remove-label "ci-squash-and-merge"
-          gh pr merge "${{ github.event.pull_request.number }}" --auto -m || true
-
-      - name: Download benchmarks
-        if: github.event_name == 'merge_group' || env.CI_FULL == '1' || env.CI_FULL_NO_TEST_CACHE == '1'
-        run: |
-          if ./ci.sh gh-bench && [ "$(cat ./bench-out/bench.json)" != "[]" ]; then
-            echo "ENABLE_BENCH=1" >> $GITHUB_ENV
-          fi
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: ./.github/ci3-post.sh
 
       - name: Upload benchmarks
-        if: env.ENABLE_BENCH == '1'
+        if: env.SHOULD_UPLOAD_BENCHMARKS == '1'
         uses: benchmark-action/github-action-benchmark@4de1bed97a47495fc4c5404952da0499e31f5c29
         with:
           name: Aztec Benchmarks
-          benchmark-data-dir-path: "bench/${{ steps.target_branch.outputs.target_branch }}"
+          benchmark-data-dir-path: "bench/${{ env.TARGET_BRANCH }}"
           tool: "customSmallerIsBetter"
           output-file-path: ./bench-out/bench.json
           github-token: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -169,7 +169,7 @@ function sort_by_cpus {
 function test_cmds {
   if [ "$#" -eq 0 ]; then
     # Ordered with longest running first, to ensure they get scheduled earliest.
-    set -- yarn-project/end-to-end aztec-up yarn-project noir-projects boxes playground barretenberg l1-contracts docs
+    set -- yarn-project/end-to-end aztec-up yarn-project noir-projects boxes playground barretenberg l1-contracts docs ci3
   fi
   parallel -k --line-buffer './{}/bootstrap.sh test_cmds' ::: $@ | filter_test_cmds | sort_by_cpus
 }

--- a/ci3/bootstrap.sh
+++ b/ci3/bootstrap.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+source $(git rev-parse --show-toplevel)/ci3/source_bootstrap
+
+hash=$(cache_content_hash ^ci3)
+
+function test_cmds {
+  echo "$hash $ci3/tests/redact_test"
+  echo "$hash $ci3/semver test"
+}
+
+function test {
+  echo_header "ci3 tests"
+  test_cmds | filter_test_cmds | parallelize
+}
+
+case "$cmd" in
+  "")
+    test
+    ;;
+  *)
+    default_cmd_handler "$@"
+    ;;
+esac

--- a/ci3/redact
+++ b/ci3/redact
@@ -1,12 +1,28 @@
 #!/bin/bash
-sed_expr=""
+# Redacts sensitive environment variables from stdin.
+# Matches env vars containing: KEY, TOKEN, PASSWORD, SECRET, MNEMONIC
+patterns=""
 for var in $(compgen -e); do
   if [[ "$var" =~ (KEY|TOKEN|PASSWORD|SECRET|MNEMONIC) ]]; then
     val="${!var}"
-    if [[ -n "$val" ]]; then
-      esc=$(printf '%s\n' "$val" | sed 's/[][\/.^$*]/\\&/g')
-      sed_expr+="s/${esc}/***/g;"
-    fi
+    [[ -z "$val" ]] && continue
+    while IFS= read -r line; do
+      [[ -n "$line" ]] && patterns+="$line"$'\n'
+    done <<< "$val"
   fi
 done
-sed -u "$sed_expr"
+
+if [[ -z "$patterns" ]]; then
+  exec cat
+fi
+
+# Use ENVIRON to avoid awk -v escape sequence interpretation
+export __REDACT_PATTERNS="$patterns"
+awk '
+BEGIN { n = split(ENVIRON["__REDACT_PATTERNS"], p, "\n") }
+{
+  for (i = 1; i <= n; i++)
+    if (p[i] != "") while ((j = index($0, p[i])) > 0)
+      $0 = substr($0, 1, j-1) "***" substr($0, j + length(p[i]))
+  print
+}'

--- a/ci3/tests/redact_test
+++ b/ci3/tests/redact_test
@@ -1,0 +1,85 @@
+#!/bin/bash
+# Tests for the redact script
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REDACT="$SCRIPT_DIR/../redact"
+
+RED=$'\033[0;31m'
+GREEN=$'\033[0;32m'
+NC=$'\033[0m'
+
+TESTS_PASSED=0
+TESTS_FAILED=0
+CLEAN_PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
+pass() { echo "${GREEN}✓${NC} $1"; ((TESTS_PASSED++)) || true; }
+fail() {
+  echo "${RED}✗${NC} $1"
+  echo "  Expected: '$2'"
+  echo "  Actual:   '$3'"
+  ((TESTS_FAILED++)) || true
+}
+
+# Test helper - args: name expected input env_vars...
+T() {
+  local name=$1 expected=$2 input=$3
+  shift 3
+  local actual
+  actual=$(env -i PATH="$CLEAN_PATH" "$@" bash -c "printf '%s\n' '$input' | '$REDACT'" 2>&1) || true
+  [[ "$actual" == "$expected" ]] && pass "$name" || fail "$name" "$expected" "$actual"
+}
+
+echo "=== Redact Tests ==="
+
+echo "--- Basic ---"
+T "Simple secret" "pw is ***" "pw is supersecret1" "MY_PASSWORD=supersecret1"
+T "Multiple occurrences" "a *** b ***" "a secretval b secretval" "API_SECRET=secretval"
+T "Two secrets" "a=*** b=***" "a=apikey123 b=token456" "API_KEY=apikey123" "AUTH_TOKEN=token456"
+
+echo "--- Var Names ---"
+T "KEY match" "x ***" "x myapikey9" "API_KEY=myapikey9"
+T "TOKEN match" "x ***" "x mytoken99" "AUTH_TOKEN=mytoken99"
+T "PASSWORD match" "x ***" "x secretpw1" "DB_PASSWORD=secretpw1"
+T "SECRET match" "x ***" "x topsecret" "MY_SECRET=topsecret"
+T "MNEMONIC match" "x ***" "x mnemonic1" "WALLET_MNEMONIC=mnemonic1"
+T "No match passthrough" "x notsecret" "x notsecret" "MY_DATA=notsecret"
+
+echo "--- Special Chars ---"
+T "Dots" "x ***" "x a.b.c.d.e" "API_KEY=a.b.c.d.e"
+T "Slashes" "x ***" "x /a/b/c/d" "SECRET_PATH=/a/b/c/d"
+T "Plus" "x ***" "x a+b+c+d+e" "API_KEY=a+b+c+d+e"
+T "Equals" "x ***" "x abc123==" "API_KEY=abc123=="
+
+echo "--- Edge Cases ---"
+T "Empty not redacted" "x here" "x here" "API_KEY="
+T "Short secret redacted" "x ***" "x abc" "API_KEY=abc"
+T "Single char redacted" "x ***" "x Z" "API_KEY=Z"
+
+echo "--- No Secrets ---"
+T "No matching vars" "plain text" "plain text" "MY_VAR=value"
+
+echo "--- Binary-like ---"
+T "Base64" "x ***" "x SGVsbG9Xb3JsZA==" "API_KEY=SGVsbG9Xb3JsZA=="
+T "Hex" "x ***" "x deadbeef1234" "API_KEY=deadbeef1234"
+
+echo "--- Substring ---"
+T "Secret in middle" "pre***suf" "presecret99suf" "API_KEY=secret99"
+
+echo "--- Multiline Secret ---"
+T "Line 1 redacted" "x ***" "x firstline" $'MULTI_SECRET=firstline\nsecondline'
+T "Line 2 redacted" "x ***" "x secondline" $'MULTI_SECRET=firstline\nsecondline'
+
+echo "--- Regex Special Chars ---"
+T "Asterisk" "x ***" "x sec*ret99" "API_KEY=sec*ret99"
+T "Backslash" "x ***" 'x sec\ret99' 'API_KEY=sec\ret99'
+T "Caret" "x ***" "x sec^ret99" "API_KEY=sec^ret99"
+T "Dollar" "x ***" 'x sec$ret99' 'API_KEY=sec$ret99'
+T "Parens" "x ***" "x sec(ret)9" "API_KEY=sec(ret)9"
+T "Brackets" "x ***" "x sec[ret]9" "API_KEY=sec[ret]9"
+T "Pipe" "x ***" "x sec|ret99" "API_KEY=sec|ret99"
+T "Question" "x ***" "x sec?ret99" "API_KEY=sec?ret99"
+
+echo
+echo "=== Results: ${GREEN}$TESTS_PASSED passed${NC}, ${RED}$TESTS_FAILED failed${NC} ==="
+[[ $TESTS_FAILED -eq 0 ]]


### PR DESCRIPTION
Refactors ci3.yml to extract shared CI logic into a `github/ci3.sh` that can be securely called by both ci3.yml and ci3-external.yml.

Refactors redact to support multiline secrets due to GCP_SA_KEY