### PR TITLE
chore(ci): cache PR tests based on merge-queue

### DIFF
--- a/ci3/run_test_cmd
+++ b/ci3/run_test_cmd
@@ -151,16 +151,14 @@ code=$?
 if [ "$code" -eq 143 ] || [ "$code" -eq 130 ]; then
   exit $code
 fi
-
+  
 if [ "$CI_REDIS_AVAILABLE" -eq 1 ]; then
-  # If the test succeeded and we're using the test cache, set success flag for test. This key is unique to the test.
+  # If the test succeeded and we're in CI, set success flag for test. This key is unique to the test.
   # If the test succeeded and we're in CI, save the test log.
-  # If the test failed, save the test log.
+  # If the test failed, regardless of CI state, save the test log.
   if [ $code -eq 0 ]; then
-    if [ "${USE_TEST_CACHE:-0}" -eq 1 ]; then
-      redis_cli SETEX $key 604800 $log_key &>/dev/null
-    fi
     if [ "$CI" -eq 1 ]; then
+      redis_cli SETEX $key 604800 $log_key &>/dev/null
       publish_log
     else
       log_info=""


### PR DESCRIPTION
There's no reason a fast build shouldn't learn from all types of cache. The trust assumption is if someone has CI=1 locally, they are running the full CI process.