### PR TITLE
chore: minor contract fixes

### DIFF
--- a/l1-contracts/src/core/interfaces/IRollup.sol
+++ b/l1-contracts/src/core/interfaces/IRollup.sol
@@ -85,7 +85,6 @@ struct RollupConfig {
   uint32 version;
   IERC20 feeAsset;
   IFeeJuicePortal feeAssetPortal;
-  IRewardDistributor rewardDistributor;
   IVerifier epochProofVerifier;
   IInbox inbox;
   IOutbox outbox;

--- a/l1-contracts/src/core/libraries/rollup/BlobLib.sol
+++ b/l1-contracts/src/core/libraries/rollup/BlobLib.sol
@@ -22,7 +22,8 @@ import {Vm} from "forge-std/Vm.sol";
  *      The VM_ADDRESS (0x7109709ECfa91a80626fF3989D68f67F5b1DD12D) is a special address used to detect
  *      when the contract is running in a Foundry test environment. This address is derived from
  *      keccak256("hevm cheat code") and corresponds to Foundry's VM contract that provides testing utilities.
- *      When VM_ADDRESS.code.length > 0, it indicates we're in a test environment, allowing the library to:
+ *      When block.chainid == 31337 &&  VM_ADDRESS.code.length > 0, it indicates we're in a test environment,
+ *      allowing the library to:
  *      - Use Foundry's getBlobBaseFee() cheatcode instead of block.blobbasefee
  *      - Use Foundry's getBlobhashes() cheatcode instead of the blobhash() opcode
  *      This enables comprehensive testing of blob functionality without requiring actual blob transactions.
@@ -47,7 +48,7 @@ library BlobLib {
    * @return uint256 - The blob base fee
    */
   function getBlobBaseFee() internal view returns (uint256) {
-    if (VM_ADDRESS.code.length > 0) {
+    if (block.chainid == 31_337 && VM_ADDRESS.code.length > 0) {
       return Vm(VM_ADDRESS).getBlobBaseFee();
     }
     return block.blobbasefee;
@@ -62,7 +63,7 @@ library BlobLib {
    * @return blobHash - The blob hash
    */
   function getBlobHash(uint256 _index) internal view returns (bytes32 blobHash) {
-    if (VM_ADDRESS.code.length > 0) {
+    if (block.chainid == 31_337 && VM_ADDRESS.code.length > 0) {
       // We know that this one is ABHORRENT. But it should not exists, and only will
       // be hit in testing.
       bytes32[] memory blobHashes = Vm(VM_ADDRESS).getBlobhashes();

--- a/l1-contracts/src/core/messagebridge/Inbox.sol
+++ b/l1-contracts/src/core/messagebridge/Inbox.sol
@@ -114,7 +114,7 @@ contract Inbox is IInbox {
 
     bytes16 updatedRollingHash = bytes16(keccak256(abi.encodePacked(rollingHash, leaf)));
     state = InboxState({
-      rollingHash: bytes16(updatedRollingHash),
+      rollingHash: updatedRollingHash,
       totalMessagesInserted: totalMessagesInserted + 1,
       inProgress: inProgress
     });

--- a/l1-contracts/src/core/reward-boost/RewardBooster.sol
+++ b/l1-contracts/src/core/reward-boost/RewardBooster.sol
@@ -115,7 +115,7 @@ contract RewardBooster is IBooster {
   }
 
   function _toShares(uint256 _value) internal view returns (uint256) {
-    if (_value > CONFIG_MAX_SCORE) {
+    if (_value >= CONFIG_MAX_SCORE) {
       return CONFIG_K;
     }
     uint256 t = (CONFIG_MAX_SCORE - _value);


### PR DESCRIPTION
Addresses minor issues.

- Adds check for chainid on the bloblib before allowing the test lookup
- Removes unnecessary `RewardDistributor` storage on the rollup config (was not properly removed when the reward configuration was separated).
- Return early in `RewardLib:_toShares` when result would be the same as in full execution
- Removes unnecessary cast to bytes16 of value that is already bytes16