### PR TITLE
feat: Implement PairingPoints tagging mechanism

### DIFF
--- a/barretenberg/cpp/src/barretenberg/boomerang_value_detection/graph_description_goblin.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/boomerang_value_detection/graph_description_goblin.test.cpp
@@ -85,7 +85,11 @@ TEST_F(BoomerangGoblinRecursiveVerifierTests, graph_description_basic)
 
     GoblinRecursiveVerifier verifier{ &builder, verifier_input };
     GoblinRecursiveVerifierOutput output = verifier.verify(proof, recursive_merge_commitments, MergeSettings::APPEND);
-    output.points_accumulator.set_public();
+
+    stdlib::recursion::honk::DefaultIO<Builder> inputs;
+    inputs.pairing_inputs = output.points_accumulator;
+    inputs.set_public();
+
     // Construct and verify a proof for the Goblin Recursive Verifier circuit
     {
         auto prover_instance = std::make_shared<OuterProverInstance>(builder);

--- a/barretenberg/cpp/src/barretenberg/commitment_schemes_recursion/shplemini.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes_recursion/shplemini.test.cpp
@@ -10,6 +10,7 @@
 #include "barretenberg/stdlib/primitives/curves/bn254.hpp"
 #include "barretenberg/stdlib/primitives/curves/grumpkin.hpp"
 #include "barretenberg/stdlib/primitives/padding_indicator_array/padding_indicator_array.hpp"
+#include "barretenberg/stdlib/primitives/pairing_points.hpp"
 #include "barretenberg/stdlib/proof/proof.hpp"
 #include "barretenberg/stdlib_circuit_builders/ultra_circuit_builder.hpp"
 #include <gtest/gtest.h>
@@ -136,11 +137,12 @@ TEST(ShpleminiRecursionTest, ProveAndVerifySingle)
                                                                                   u_challenge_in_circuit,
                                                                                   Commitment::one(&builder),
                                                                                   stdlib_verifier_transcript);
-        auto pairing_points = KZG<Curve>::reduce_verify_batch_opening_claim(opening_claim, stdlib_verifier_transcript);
+        stdlib::recursion::PairingPoints<Builder> pairing_points(
+            KZG<Curve>::reduce_verify_batch_opening_claim(opening_claim, stdlib_verifier_transcript));
         EXPECT_TRUE(CircuitChecker::check(builder));
 
         VerifierCommitmentKey<NativeCurve> vk;
-        EXPECT_EQ(vk.pairing_check(pairing_points[0].get_value(), pairing_points[1].get_value()), true);
+        EXPECT_EQ(vk.pairing_check(pairing_points.P0.get_value(), pairing_points.P1.get_value()), true);
 
         // Return finalized number of gates;
         return builder.num_gates();

--- a/barretenberg/cpp/src/barretenberg/hypernova/hypernova_decider_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/hypernova/hypernova_decider_verifier.cpp
@@ -32,11 +32,11 @@ HypernovaDeciderVerifier<Flavor>::PairingPoints HypernovaDeciderVerifier<Flavor>
     const auto opening_claim = ShpleminiVerifier::compute_batch_opening_claim(
         padding_indicator_array, claim_batcher, accumulator.challenge, generator, transcript);
 
-    auto pairing_points = PCS::reduce_verify_batch_opening_claim(opening_claim, transcript);
-
     if constexpr (IsRecursiveFlavor<Flavor>) {
+        PairingPoints pairing_points(PCS::reduce_verify_batch_opening_claim(opening_claim, transcript));
         return pairing_points;
     } else {
+        auto pairing_points = PCS::reduce_verify_batch_opening_claim(opening_claim, transcript);
         // Native pairing points contain affine elements
         return { typename Curve::AffineElement(pairing_points[0]), typename Curve::AffineElement(pairing_points[1]) };
     }

--- a/barretenberg/cpp/src/barretenberg/solidity_helpers/circuits/recursive_circuit.hpp
+++ b/barretenberg/cpp/src/barretenberg/solidity_helpers/circuits/recursive_circuit.hpp
@@ -92,7 +92,10 @@ class RecursiveCircuit {
 
         StdlibProof stdlib_inner_proof(outer_circuit, inner_proof);
         VerifierOutput output = verifier.template verify_proof<OuterIO>(stdlib_inner_proof);
-        output.points_accumulator.set_public();
+
+        stdlib::recursion::honk::DefaultIO<OuterBuilder> public_inputs;
+        public_inputs.pairing_inputs = output.points_accumulator;
+        public_inputs.set_public();
 
         return outer_circuit;
     }

--- a/barretenberg/cpp/src/barretenberg/stdlib/goblin_verifier/goblin_recursive_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/goblin_verifier/goblin_recursive_verifier.test.cpp
@@ -145,7 +145,10 @@ TEST_F(GoblinRecursiveVerifierTests, Basic)
 
     GoblinRecursiveVerifier verifier{ &builder, verifier_input };
     GoblinRecursiveVerifierOutput output = verifier.verify(proof, recursive_merge_commitments, MergeSettings::APPEND);
-    output.points_accumulator.set_public();
+
+    stdlib::recursion::honk::DefaultIO<Builder> inputs;
+    inputs.pairing_inputs = output.points_accumulator;
+    inputs.set_public();
 
     info("Recursive Verifier: num gates = ", builder.num_gates());
 
@@ -181,7 +184,10 @@ TEST_F(GoblinRecursiveVerifierTests, IndependentVKHash)
         GoblinRecursiveVerifier verifier{ &builder, verifier_input };
         GoblinRecursiveVerifierOutput output =
             verifier.verify(proof, recursive_merge_commitments, MergeSettings::APPEND);
-        output.points_accumulator.set_public();
+
+        stdlib::recursion::honk::DefaultIO<Builder> inputs;
+        inputs.pairing_inputs = output.points_accumulator;
+        inputs.set_public();
 
         info("Recursive Verifier: num gates = ", builder.num_gates());
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/decider_recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/decider_recursive_verifier.cpp
@@ -63,9 +63,9 @@ DeciderRecursiveVerifier_<Flavor>::PairingPoints DeciderRecursiveVerifier_<Flavo
                                                                       transcript,
                                                                       Flavor::REPEATED_COMMITMENTS,
                                                                       Flavor::HasZK);
-    auto pairing_points = PCS::reduce_verify_batch_opening_claim(opening_claim, transcript);
+    PairingPoints pairing_points(PCS::reduce_verify_batch_opening_claim(opening_claim, transcript));
 
-    return { pairing_points[0], pairing_points[1] };
+    return pairing_points;
 }
 
 template class DeciderRecursiveVerifier_<bb::MegaRecursiveFlavor_<MegaCircuitBuilder>>;

--- a/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/ultra_recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/ultra_recursive_verifier.cpp
@@ -120,7 +120,8 @@ UltraRecursiveVerifier_<Flavor>::Output UltraRecursiveVerifier_<Flavor>::verify_
                                                libra_commitments,
                                                sumcheck_output.claimed_libra_evaluation);
 
-    auto pairing_points = PCS::reduce_verify_batch_opening_claim(opening_claim, transcript);
+    PairingPoints<typename Curve::Builder> pairing_points(
+        PCS::reduce_verify_batch_opening_claim(opening_claim, transcript));
 
     // Reconstruct the public inputs
     IO inputs;

--- a/barretenberg/cpp/src/barretenberg/stdlib/merge_verifier/merge_recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/merge_verifier/merge_recursive_verifier.cpp
@@ -154,7 +154,7 @@ MergeRecursiveVerifier_<CircuitBuilder>::verify_proof(const stdlib::Proof<Circui
     auto batch_opening_claim = verifier.export_batch_opening_claim(Commitment::one(kappa.get_context()));
 
     // KZG verifier
-    auto pairing_points = KZG::reduce_verify_batch_opening_claim(batch_opening_claim, transcript);
+    PairingPoints pairing_points(KZG::reduce_verify_batch_opening_claim(batch_opening_claim, transcript));
 
     return { pairing_points, merged_table_commitments };
 }

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/pairing_points.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/pairing_points.hpp
@@ -40,7 +40,7 @@ template <typename Builder_> struct PairingPoints {
     Group P1;
 
     bool has_data = false;
-    uint32_t tag = 0; // Tag for tracking pairing point aggregation
+    uint32_t tag_index = 0; // Index of the tag for tracking pairing point aggregation
 
     // Number of bb::fr field elements used to represent a goblin element in the public inputs
     static constexpr size_t PUBLIC_INPUTS_SIZE = PAIRING_POINTS_SIZE;
@@ -55,7 +55,7 @@ template <typename Builder_> struct PairingPoints {
         // Get the builder from the group elements and assign a new tag
         Builder* builder = P0.get_context();
         if (builder != nullptr) {
-            tag = builder->create_pairing_point_tag();
+            tag_index = builder->create_pairing_point_tag();
         }
     }
 
@@ -102,7 +102,17 @@ template <typename Builder_> struct PairingPoints {
         auto P0 = Group::batch_mul(first_components, challenges);
         auto P1 = Group::batch_mul(second_components, challenges);
 
-        return { P0, P1 };
+        PairingPoints aggregated_points(P0, P1);
+
+        // Merge tags
+        Builder* builder = P0.get_context();
+        if (builder != nullptr) {
+            for (const auto& points : pairing_points) {
+                builder->merge_pairing_point_tags(aggregated_points.tag_index, points.tag_index);
+            }
+        }
+
+        return aggregated_points;
     }
 
     /**
@@ -146,7 +156,7 @@ template <typename Builder_> struct PairingPoints {
         // Merge the tags in the builder
         Builder* builder = P0.get_context();
         if (builder != nullptr) {
-            builder->merge_pairing_point_tags(this->tag, other.tag);
+            builder->merge_pairing_point_tags(this->tag_index, other.tag_index);
         }
     }
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/pairing_points.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/pairing_points.hpp
@@ -40,6 +40,7 @@ template <typename Builder_> struct PairingPoints {
     Group P1;
 
     bool has_data = false;
+    uint32_t tag = 0; // Tag for tracking pairing point aggregation
 
     // Number of bb::fr field elements used to represent a goblin element in the public inputs
     static constexpr size_t PUBLIC_INPUTS_SIZE = PAIRING_POINTS_SIZE;
@@ -50,7 +51,13 @@ template <typename Builder_> struct PairingPoints {
         : P0(P0)
         , P1(P1)
         , has_data(true)
-    {}
+    {
+        // Get the builder from the group elements and assign a new tag
+        Builder* builder = P0.get_context();
+        if (builder != nullptr) {
+            tag = builder->create_pairing_point_tag();
+        }
+    }
 
     PairingPoints(std::array<Group, 2> const& points)
         : PairingPoints(points[0], points[1])
@@ -134,6 +141,12 @@ template <typename Builder_> struct PairingPoints {
             P0 += point_to_aggregate;
             point_to_aggregate = other.P1.scalar_mul(recursion_separator, 128);
             P1 += point_to_aggregate;
+        }
+
+        // Merge the tags in the builder
+        Builder* builder = P0.get_context();
+        if (builder != nullptr) {
+            builder->merge_pairing_point_tags(this->tag, other.tag);
         }
     }
 
@@ -236,6 +249,7 @@ template <typename Builder> void read(uint8_t const*& it, PairingPoints<Builder>
     read(it, as.P0);
     read(it, as.P1);
     read(it, as.has_data);
+    read(it, as.tag);
 };
 
 template <typename Builder> void write(std::vector<uint8_t>& buf, PairingPoints<Builder> const& as)
@@ -245,13 +259,15 @@ template <typename Builder> void write(std::vector<uint8_t>& buf, PairingPoints<
     write(buf, as.P0);
     write(buf, as.P1);
     write(buf, as.has_data);
+    write(buf, as.tag);
 };
 
 template <typename NCT> std::ostream& operator<<(std::ostream& os, PairingPoints<NCT> const& as)
 {
     return os << "P0: " << as.P0 << "\n"
               << "P1: " << as.P1 << "\n"
-              << "has_data: " << as.has_data << "\n";
+              << "has_data: " << as.has_data << "\n"
+              << "tag: " << as.tag << "\n";
 }
 
 } // namespace bb::stdlib::recursion

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/pairing_points.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/pairing_points.hpp
@@ -55,7 +55,7 @@ template <typename Builder_> struct PairingPoints {
         // Get the builder from the group elements and assign a new tag
         Builder* builder = P0.get_context();
         if (builder != nullptr) {
-            tag_index = builder->create_pairing_point_tag();
+            tag_index = builder->pairing_points_tagging.create_pairing_point_tag();
         }
     }
 
@@ -108,7 +108,7 @@ template <typename Builder_> struct PairingPoints {
         Builder* builder = P0.get_context();
         if (builder != nullptr) {
             for (const auto& points : pairing_points) {
-                builder->merge_pairing_point_tags(aggregated_points.tag_index, points.tag_index);
+                builder->pairing_points_tagging.merge_pairing_point_tags(aggregated_points.tag_index, points.tag_index);
             }
         }
 
@@ -156,7 +156,7 @@ template <typename Builder_> struct PairingPoints {
         // Merge the tags in the builder
         Builder* builder = P0.get_context();
         if (builder != nullptr) {
-            builder->merge_pairing_point_tags(this->tag_index, other.tag_index);
+            builder->pairing_points_tagging.merge_pairing_point_tags(this->tag_index, other.tag_index);
         }
     }
 
@@ -252,32 +252,12 @@ template <typename Builder_> struct PairingPoints {
     }
 };
 
-template <typename Builder> void read(uint8_t const*& it, PairingPoints<Builder>& as)
-{
-    using serialize::read;
-
-    read(it, as.P0);
-    read(it, as.P1);
-    read(it, as.has_data);
-    read(it, as.tag);
-};
-
-template <typename Builder> void write(std::vector<uint8_t>& buf, PairingPoints<Builder> const& as)
-{
-    using serialize::write;
-
-    write(buf, as.P0);
-    write(buf, as.P1);
-    write(buf, as.has_data);
-    write(buf, as.tag);
-};
-
 template <typename NCT> std::ostream& operator<<(std::ostream& os, PairingPoints<NCT> const& as)
 {
     return os << "P0: " << as.P0 << "\n"
               << "P1: " << as.P1 << "\n"
               << "has_data: " << as.has_data << "\n"
-              << "tag: " << as.tag << "\n";
+              << "tag_index: " << as.tag_index << "\n";
 }
 
 } // namespace bb::stdlib::recursion

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/pairing_points.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/pairing_points.test.cpp
@@ -1,6 +1,7 @@
 #include "barretenberg/stdlib/primitives/pairing_points.hpp"
 #include "barretenberg/commitment_schemes/pairing_points.hpp"
 #include "barretenberg/srs/global_crs.hpp"
+#include "barretenberg/ultra_honk/prover_instance.hpp"
 #include <gtest/gtest.h>
 
 namespace bb::stdlib::recursion {
@@ -47,5 +48,84 @@ TYPED_TEST(PairingPointsTests, TestDefault)
     CommitmentKey commitment_key;
     bb::PairingPoints native_pp(P0.get_value(), P1.get_value());
     EXPECT_TRUE(native_pp.check()) << "Default PairingPoints are not valid pairing points.";
+}
+
+TYPED_TEST(PairingPointsTests, TaggingMechanismWorks)
+{
+    using Builder = TypeParam;
+    using PairingPoints = PairingPoints<Builder>;
+    using Group = PairingPoints::Group;
+    using Fr = PairingPoints::Curve::ScalarField;
+    using NativeFr = PairingPoints::Curve::ScalarFieldNative;
+
+    Builder builder;
+
+    Fr scalar_one = Fr::from_witness(&builder, NativeFr::random_element());
+    Fr scalar_two = Fr::from_witness(&builder, NativeFr::random_element());
+    Group P0 = Group::batch_mul({ Group::one(&builder) }, { scalar_one });
+    Group P1 = Group::batch_mul({ Group::one(&builder) }, { scalar_two });
+
+    PairingPoints pp_one = { P0, P1 };
+    PairingPoints pp_two = { P0, P1 };
+
+    // Check the tags
+    BB_ASSERT_EQ(pp_one.tag, 0U);
+    BB_ASSERT_EQ(pp_two.tag, 1U);
+
+    // Check that there are two different pairing points in the builder
+    EXPECT_FALSE(builder.has_single_pairing_point_tag());
+
+    // Merge the tags
+    pp_one.aggregate(pp_two);
+
+    // Check that the tags have been merged
+    EXPECT_TRUE(builder.has_single_pairing_point_tag());
+}
+
+TYPED_TEST(PairingPointsTests, TaggingMechanismFails)
+{
+    BB_DISABLE_ASSERTS();
+
+    using Builder = TypeParam;
+    using PairingPoints = PairingPoints<Builder>;
+    using Group = PairingPoints::Group;
+    using Fr = PairingPoints::Curve::ScalarField;
+    using NativeFr = PairingPoints::Curve::ScalarFieldNative;
+    using Flavor = std::conditional_t<IsMegaBuilder<Builder>, MegaFlavor, UltraFlavor>;
+    using ProverInstance = ProverInstance_<Flavor>;
+
+    Builder builder;
+
+    Fr scalar_one = Fr::from_witness(&builder, NativeFr::random_element());
+    Fr scalar_two = Fr::from_witness(&builder, NativeFr::random_element());
+    Group P0 = Group::batch_mul({ Group::one(&builder) }, { scalar_one });
+    Group P1 = Group::batch_mul({ Group::one(&builder) }, { scalar_two });
+
+    PairingPoints pp_one = { P0, P1 };
+    PairingPoints pp_two = { P0, P1 };
+    PairingPoints pp_three = { P0, P1 };
+
+    // Check the tags
+    BB_ASSERT_EQ(pp_one.tag, 0U);
+    BB_ASSERT_EQ(pp_two.tag, 1U);
+    BB_ASSERT_EQ(pp_three.tag, 2U);
+
+    // Check that there are different pairing points in the builder
+    EXPECT_FALSE(builder.has_single_pairing_point_tag());
+
+    // Merge the tags
+    pp_one.aggregate(pp_two);
+
+    // Check that the tags have not been merged
+    EXPECT_FALSE(builder.has_single_pairing_point_tag());
+
+    // Create a ProverInstance, expect failure
+    try {
+        ProverInstance prover_instance(builder);
+    } catch (std::exception& e) {
+        BB_ASSERT_EQ(e.what(),
+                     "Pairing points must all be aggregated together. Either no pairing points should be created, or "
+                     "all created pairing points must be aggregated into a single pairing point.");
+    }
 }
 } // namespace bb::stdlib::recursion

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/pairing_points.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/pairing_points.test.cpp
@@ -66,47 +66,47 @@ TYPED_TEST(PairingPointsTests, TaggingMechanismWorks)
     Group P1 = Group::batch_mul({ Group::one(&builder) }, { scalar_two });
 
     // Check that no pairing points exist
-    EXPECT_TRUE(builder.has_single_pairing_point_tag());
+    EXPECT_TRUE(builder.pairing_points_tagging.has_single_pairing_point_tag());
 
     PairingPoints pp_one = { P0, P1 };
     PairingPoints pp_two = { P0, P1 };
 
     // Check the tags
-    BB_ASSERT_EQ(builder.get_tag(pp_one.tag_index), 0U);
-    BB_ASSERT_EQ(builder.get_tag(pp_two.tag_index), 1U);
+    BB_ASSERT_EQ(builder.pairing_points_tagging.get_tag(pp_one.tag_index), 0U);
+    BB_ASSERT_EQ(builder.pairing_points_tagging.get_tag(pp_two.tag_index), 1U);
 
     // Check that there are two different pairing points in the builder
-    EXPECT_FALSE(builder.has_single_pairing_point_tag());
+    EXPECT_FALSE(builder.pairing_points_tagging.has_single_pairing_point_tag());
 
     // Merge the tags
     pp_one.aggregate(pp_two);
 
     // Check that the tags have been merged
-    BB_ASSERT_EQ(builder.get_tag(pp_two.tag_index), 0U);
-    EXPECT_TRUE(builder.has_single_pairing_point_tag());
+    BB_ASSERT_EQ(builder.pairing_points_tagging.get_tag(pp_two.tag_index), 0U);
+    EXPECT_TRUE(builder.pairing_points_tagging.has_single_pairing_point_tag());
 
     // Create two new pairing points and aggregate with aggregate_multiple
     PairingPoints pp_three = { P0, P1 };
     PairingPoints pp_four = { P0, P1 };
 
     // Check the tags
-    BB_ASSERT_EQ(builder.get_tag(pp_three.tag_index), 2U);
-    BB_ASSERT_EQ(builder.get_tag(pp_four.tag_index), 3U);
+    BB_ASSERT_EQ(builder.pairing_points_tagging.get_tag(pp_three.tag_index), 2U);
+    BB_ASSERT_EQ(builder.pairing_points_tagging.get_tag(pp_four.tag_index), 3U);
 
     // Check that there are two different pairing points in the builder
-    EXPECT_FALSE(builder.has_single_pairing_point_tag());
+    EXPECT_FALSE(builder.pairing_points_tagging.has_single_pairing_point_tag());
 
     // Merge the tags
     std::vector<PairingPoints> pp_to_be_aggregated = { pp_one, pp_three, pp_four };
     PairingPoints aggregated_pp = PairingPoints::aggregate_multiple(pp_to_be_aggregated);
 
     // Check that the tags have been merged
-    BB_ASSERT_EQ(builder.get_tag(pp_one.tag_index), 4U);
-    BB_ASSERT_EQ(builder.get_tag(pp_two.tag_index), 4U);
-    BB_ASSERT_EQ(builder.get_tag(pp_three.tag_index), 4U);
-    BB_ASSERT_EQ(builder.get_tag(pp_four.tag_index), 4U);
-    BB_ASSERT_EQ(builder.get_tag(aggregated_pp.tag_index), 4U);
-    EXPECT_TRUE(builder.has_single_pairing_point_tag());
+    BB_ASSERT_EQ(builder.pairing_points_tagging.get_tag(pp_one.tag_index), 4U);
+    BB_ASSERT_EQ(builder.pairing_points_tagging.get_tag(pp_two.tag_index), 4U);
+    BB_ASSERT_EQ(builder.pairing_points_tagging.get_tag(pp_three.tag_index), 4U);
+    BB_ASSERT_EQ(builder.pairing_points_tagging.get_tag(pp_four.tag_index), 4U);
+    BB_ASSERT_EQ(builder.pairing_points_tagging.get_tag(aggregated_pp.tag_index), 4U);
+    EXPECT_TRUE(builder.pairing_points_tagging.has_single_pairing_point_tag());
 }
 
 TYPED_TEST(PairingPointsTests, TaggingMechanismFails)
@@ -133,18 +133,18 @@ TYPED_TEST(PairingPointsTests, TaggingMechanismFails)
     PairingPoints pp_three = { P0, P1 };
 
     // Check the tags
-    BB_ASSERT_EQ(builder.get_tag(pp_one.tag_index), 0U);
-    BB_ASSERT_EQ(builder.get_tag(pp_two.tag_index), 1U);
-    BB_ASSERT_EQ(builder.get_tag(pp_three.tag_index), 2U);
+    BB_ASSERT_EQ(builder.pairing_points_tagging.get_tag(pp_one.tag_index), 0U);
+    BB_ASSERT_EQ(builder.pairing_points_tagging.get_tag(pp_two.tag_index), 1U);
+    BB_ASSERT_EQ(builder.pairing_points_tagging.get_tag(pp_three.tag_index), 2U);
 
     // Check that there are different pairing points in the builder
-    EXPECT_FALSE(builder.has_single_pairing_point_tag());
+    EXPECT_FALSE(builder.pairing_points_tagging.has_single_pairing_point_tag());
 
     // Merge the tags
     pp_one.aggregate(pp_two);
 
     // Check that the tags have not been merged
-    EXPECT_FALSE(builder.has_single_pairing_point_tag());
+    EXPECT_FALSE(builder.pairing_points_tagging.has_single_pairing_point_tag());
 
     // Create a ProverInstance, expect failure
     try {

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/pairing_points.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/pairing_points.test.cpp
@@ -72,8 +72,8 @@ TYPED_TEST(PairingPointsTests, TaggingMechanismWorks)
     PairingPoints pp_two = { P0, P1 };
 
     // Check the tags
-    BB_ASSERT_EQ(pp_one.tag, 0U);
-    BB_ASSERT_EQ(pp_two.tag, 1U);
+    BB_ASSERT_EQ(builder.get_tag(pp_one.tag_index), 0U);
+    BB_ASSERT_EQ(builder.get_tag(pp_two.tag_index), 1U);
 
     // Check that there are two different pairing points in the builder
     EXPECT_FALSE(builder.has_single_pairing_point_tag());
@@ -82,6 +82,30 @@ TYPED_TEST(PairingPointsTests, TaggingMechanismWorks)
     pp_one.aggregate(pp_two);
 
     // Check that the tags have been merged
+    BB_ASSERT_EQ(builder.get_tag(pp_two.tag_index), 0U);
+    EXPECT_TRUE(builder.has_single_pairing_point_tag());
+
+    // Create two new pairing points and aggregate with aggregate_multiple
+    PairingPoints pp_three = { P0, P1 };
+    PairingPoints pp_four = { P0, P1 };
+
+    // Check the tags
+    BB_ASSERT_EQ(builder.get_tag(pp_three.tag_index), 2U);
+    BB_ASSERT_EQ(builder.get_tag(pp_four.tag_index), 3U);
+
+    // Check that there are two different pairing points in the builder
+    EXPECT_FALSE(builder.has_single_pairing_point_tag());
+
+    // Merge the tags
+    std::vector<PairingPoints> pp_to_be_aggregated = { pp_one, pp_three, pp_four };
+    PairingPoints aggregated_pp = PairingPoints::aggregate_multiple(pp_to_be_aggregated);
+
+    // Check that the tags have been merged
+    BB_ASSERT_EQ(builder.get_tag(pp_one.tag_index), 4U);
+    BB_ASSERT_EQ(builder.get_tag(pp_two.tag_index), 4U);
+    BB_ASSERT_EQ(builder.get_tag(pp_three.tag_index), 4U);
+    BB_ASSERT_EQ(builder.get_tag(pp_four.tag_index), 4U);
+    BB_ASSERT_EQ(builder.get_tag(aggregated_pp.tag_index), 4U);
     EXPECT_TRUE(builder.has_single_pairing_point_tag());
 }
 
@@ -109,9 +133,9 @@ TYPED_TEST(PairingPointsTests, TaggingMechanismFails)
     PairingPoints pp_three = { P0, P1 };
 
     // Check the tags
-    BB_ASSERT_EQ(pp_one.tag, 0U);
-    BB_ASSERT_EQ(pp_two.tag, 1U);
-    BB_ASSERT_EQ(pp_three.tag, 2U);
+    BB_ASSERT_EQ(builder.get_tag(pp_one.tag_index), 0U);
+    BB_ASSERT_EQ(builder.get_tag(pp_two.tag_index), 1U);
+    BB_ASSERT_EQ(builder.get_tag(pp_three.tag_index), 2U);
 
     // Check that there are different pairing points in the builder
     EXPECT_FALSE(builder.has_single_pairing_point_tag());

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/pairing_points.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/pairing_points.test.cpp
@@ -65,6 +65,9 @@ TYPED_TEST(PairingPointsTests, TaggingMechanismWorks)
     Group P0 = Group::batch_mul({ Group::one(&builder) }, { scalar_one });
     Group P1 = Group::batch_mul({ Group::one(&builder) }, { scalar_two });
 
+    // Check that no pairing points exist
+    EXPECT_TRUE(builder.has_single_pairing_point_tag());
+
     PairingPoints pp_one = { P0, P1 };
     PairingPoints pp_two = { P0, P1 };
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/special_public_inputs/special_public_inputs.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/special_public_inputs/special_public_inputs.hpp
@@ -115,6 +115,8 @@ class KernelIO {
         }
         output_hn_accum_hash.set_public();
 
+        // Record that pairing points have been set to public
+        builder->pairing_points_tagging.set_public_pairing_points();
         // Finalize the public inputs to ensure no more public inputs can be added hereafter.
         builder->finalize_public_inputs();
     }
@@ -180,6 +182,8 @@ template <typename Builder_> class DefaultIO {
 
         pairing_inputs.set_public();
 
+        // Record that pairing points have been set to public
+        builder->pairing_points_tagging.set_public_pairing_points();
         // Finalize the public inputs to ensure no more public inputs can be added hereafter.
         builder->finalize_public_inputs();
     }
@@ -239,11 +243,14 @@ template <typename Builder_> class GoblinAvmIO {
      */
     void set_public()
     {
+        Builder* builder = pairing_inputs.P0.get_context();
+
         mega_hash.set_public();
         pairing_inputs.set_public();
 
+        // Record that pairing points have been set to public
+        builder->pairing_points_tagging.set_public_pairing_points();
         // Finalize the public inputs to ensure no more public inputs can be added hereafter.
-        Builder* builder = pairing_inputs.P0.get_context();
         builder->finalize_public_inputs();
     }
 };
@@ -308,6 +315,8 @@ template <class Builder_> class HidingKernelIO {
             commitment.set_public();
         }
 
+        // Record that pairing points have been set to public
+        builder->pairing_points_tagging.set_public_pairing_points();
         // Finalize the public inputs to ensure no more public inputs can be added hereafter.
         builder->finalize_public_inputs();
     }
@@ -380,6 +389,8 @@ class RollupIO {
         }
         ipa_claim.set_public();
 
+        // Record that pairing points have been set to public
+        builder->pairing_points_tagging.set_public_pairing_points();
         // Finalize the public inputs to ensure no more public inputs can be added hereafter.
         builder->finalize_public_inputs();
     }

--- a/barretenberg/cpp/src/barretenberg/stdlib/translator_vm_verifier/translator_recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/translator_vm_verifier/translator_recursive_verifier.cpp
@@ -183,9 +183,9 @@ TranslatorRecursiveVerifier::PairingPoints TranslatorRecursiveVerifier::verify_p
                                                libra_commitments,
                                                sumcheck_output.claimed_libra_evaluation);
 
-    auto pairing_points = PCS::reduce_verify_batch_opening_claim(opening_claim, transcript);
+    PairingPoints pairing_points(PCS::reduce_verify_batch_opening_claim(opening_claim, transcript));
 
-    return { pairing_points[0], pairing_points[1] };
+    return pairing_points;
 }
 
 void TranslatorRecursiveVerifier::verify_translation(const TranslationEvaluations_<BF>& translation_evaluations,

--- a/barretenberg/cpp/src/barretenberg/stdlib/translator_vm_verifier/translator_recursive_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/translator_vm_verifier/translator_recursive_verifier.test.cpp
@@ -2,6 +2,7 @@
 #include "barretenberg/circuit_checker/translator_circuit_checker.hpp"
 #include "barretenberg/common/log.hpp"
 #include "barretenberg/stdlib/honk_verifier/ultra_verification_keys_comparator.hpp"
+#include "barretenberg/stdlib/special_public_inputs/special_public_inputs.hpp"
 #include "barretenberg/translator_vm/translator_verifier.hpp"
 #include "barretenberg/ultra_honk/ultra_prover.hpp"
 #include "barretenberg/ultra_honk/ultra_verifier.hpp"
@@ -115,7 +116,10 @@ class TranslatorRecursiveTests : public ::testing::Test {
         RecursiveVerifier verifier{ &outer_circuit, verification_key, transcript };
         typename RecursiveVerifier::PairingPoints pairing_points =
             verifier.verify_proof(proof, evaluation_challenge_x, batching_challenge_v);
-        pairing_points.set_public();
+
+        stdlib::recursion::honk::DefaultIO<OuterBuilder> inputs;
+        inputs.pairing_inputs = pairing_points;
+        inputs.set_public();
         info("Recursive Verifier: num gates = ", outer_circuit.num_gates());
 
         // Check for a failure flag in the recursive verifier circuit
@@ -198,7 +202,10 @@ class TranslatorRecursiveTests : public ::testing::Test {
             transcript->add_to_hash_buffer("batching_challenge_v", stdlib_batching_challenge_v);
             typename RecursiveVerifier::PairingPoints pairing_points =
                 verifier.verify_proof(inner_proof, stdlib_evaluation_challenge_x, stdlib_batching_challenge_v);
-            pairing_points.set_public();
+
+            stdlib::recursion::honk::DefaultIO<OuterBuilder> inputs;
+            inputs.pairing_inputs = pairing_points;
+            inputs.set_public();
 
             auto outer_proving_key = std::make_shared<OuterProverInstance>(outer_circuit);
             auto outer_verification_key =

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/circuit_builder_base.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/circuit_builder_base.hpp
@@ -88,10 +88,13 @@ template <typename FF_> class CircuitBuilderBase {
      */
     std::unordered_map<uint32_t, uint32_t> _tau;
 
-    // Pairing point tag tracking
-    mutable PairingPointsTagging pairing_points_tagging;
-
   public:
+    /**
+     * @brief PairingPoints tagging tool, used to ensure that all pairing points created in this circuit are aggregated
+     * together. This is not related to circuit logic.
+     */
+    PairingPointsTagging pairing_points_tagging;
+
     /**
      * @brief Map from witness index to real variable index
      * @details The "real_variable_index" acts as a map from a "witness index" (e.g. the one stored by a stdlib
@@ -240,35 +243,6 @@ template <typename FF_> class CircuitBuilderBase {
     const std::string& err() const;
 
     void failure(std::string msg);
-
-    /**
-     * @brief Create a new unique pairing point tag
-     */
-    uint32_t create_pairing_point_tag() const { return pairing_points_tagging.create_pairing_point_tag(); }
-
-    /**
-     * @brief Merge two pairing point tags
-     */
-    void merge_pairing_point_tags(uint32_t tag1_index, uint32_t tag2_index) const
-    {
-        pairing_points_tagging.merge_pairing_point_tags(tag1_index, tag2_index);
-    }
-
-    /**
-     * @brief Check if all pairing point tags belong to a single equivalence class
-     * @return true if there's only one equivalence class (or no tags at all)
-     */
-    bool has_single_pairing_point_tag() const { return pairing_points_tagging.has_single_pairing_point_tag(); }
-
-    /**
-     * @brief Return the number of unique pairing point tags
-     */
-    uint32_t num_unique_pairing_points() const { return pairing_points_tagging.num_unique_pairing_points(); }
-
-    /**
-     * @brief Get the pairing points tagging object
-     */
-    uint32_t get_tag(uint32_t tag_index) const { return pairing_points_tagging.get_tag(tag_index); }
 };
 
 /**

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/circuit_builder_base.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/circuit_builder_base.hpp
@@ -14,6 +14,7 @@
 #include "barretenberg/serialize/msgpack.hpp"
 #include <utility>
 
+#include <algorithm>
 #include <unordered_map>
 
 namespace bb {
@@ -85,6 +86,11 @@ template <typename FF_> class CircuitBuilderBase {
      * DOCTODO(#231): replace with the relevant wiki link
      */
     std::unordered_map<uint32_t, uint32_t> _tau;
+
+    // Pairing point tag tracking (union-find structure)
+    mutable std::vector<std::pair<uint32_t, uint32_t>> pairing_points_tags;
+    mutable uint32_t next_pairing_point_tag = 0;
+    mutable bool has_pairing_points = false;
 
   public:
     /**
@@ -235,6 +241,74 @@ template <typename FF_> class CircuitBuilderBase {
     const std::string& err() const;
 
     void failure(std::string msg);
+
+    /**
+     * @brief Pairing point tag management methods
+     * @details These methods implement a union-find structure to track pairing point tag equivalences
+     */
+
+    /**
+     * @brief Create a new unique pairing point tag
+     * @return The new tag
+     */
+    uint32_t create_pairing_point_tag() const
+    {
+        has_pairing_points = true;
+        uint32_t new_tag = next_pairing_point_tag++;
+        pairing_points_tags.emplace_back(
+            std::make_pair(new_tag, new_tag)); // Each PairingPoint tag starts as a couple (tag, tag)
+        return new_tag;
+    }
+
+    /**
+     * @brief Merge two pairing point tags
+     * @param tag1 First tag
+     * @param tag2 Second tag
+     */
+    void merge_pairing_point_tags(uint32_t tag1, uint32_t tag2) const
+    {
+        uint32_t root1 = pairing_points_tags[tag1].first;
+        uint32_t root2 = pairing_points_tags[tag2].first;
+        if (root1 != root2) {
+            for (auto& tag : pairing_points_tags) {
+                if (tag.first == root2) {
+                    tag.first = root1;
+                }
+            }
+        }
+    }
+
+    /**
+     * @brief Check if all pairing point tags belong to a single equivalence class
+     * @return true if there's only one equivalence class (or no tags at all)
+     */
+    bool has_single_pairing_point_tag() const
+    {
+        if (!has_pairing_points) {
+            return true; // No pairing points created
+        }
+        // Check that there is only one tag
+        uint32_t unique_tag = pairing_points_tags[0].first;
+        return std::ranges::all_of(pairing_points_tags,
+                                   [unique_tag](auto const& tag) { return tag.first == unique_tag; });
+    }
+
+    /**
+     * @brief Return the number of unique pairing point tags
+     */
+    uint32_t unique_pairing_points() const
+    {
+        std::vector<uint32_t> unique_tags;
+        unique_tags.resize(pairing_points_tags.size());
+        for (auto const& tag : pairing_points_tags) {
+            unique_tags[tag.first] = 1;
+        }
+        uint32_t sum = 0;
+        for (auto v : unique_tags) {
+            sum += v;
+        }
+        return sum;
+    }
 };
 
 /**

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/circuit_builder_base.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/circuit_builder_base.hpp
@@ -87,10 +87,10 @@ template <typename FF_> class CircuitBuilderBase {
      */
     std::unordered_map<uint32_t, uint32_t> _tau;
 
-    // Pairing point tag tracking (union-find structure)
-    mutable std::vector<std::pair<uint32_t, uint32_t>> pairing_points_tags;
-    mutable uint32_t next_pairing_point_tag = 0;
-    mutable bool has_pairing_points = false;
+    // Pairing point tag tracking
+    mutable std::vector<uint32_t> _pairing_points_tags;
+    mutable uint32_t _next_pairing_point_tag = 0;
+    mutable bool _has_pairing_points = false;
 
   public:
     /**
@@ -243,20 +243,14 @@ template <typename FF_> class CircuitBuilderBase {
     void failure(std::string msg);
 
     /**
-     * @brief Pairing point tag management methods
-     * @details These methods implement a union-find structure to track pairing point tag equivalences
-     */
-
-    /**
      * @brief Create a new unique pairing point tag
-     * @return The new tag
      */
     uint32_t create_pairing_point_tag() const
     {
-        has_pairing_points = true;
-        uint32_t new_tag = next_pairing_point_tag++;
-        pairing_points_tags.emplace_back(
-            std::make_pair(new_tag, new_tag)); // Each PairingPoint tag starts as a couple (tag, tag)
+        _has_pairing_points = true;
+        uint32_t new_tag = _next_pairing_point_tag++;
+        _pairing_points_tags.emplace_back(
+            new_tag); // Each PairingPoints starts with tag equal to the number of PairingPoints created before it
         return new_tag;
     }
 
@@ -267,13 +261,10 @@ template <typename FF_> class CircuitBuilderBase {
      */
     void merge_pairing_point_tags(uint32_t tag1, uint32_t tag2) const
     {
-        uint32_t root1 = pairing_points_tags[tag1].first;
-        uint32_t root2 = pairing_points_tags[tag2].first;
-        if (root1 != root2) {
-            for (auto& tag : pairing_points_tags) {
-                if (tag.first == root2) {
-                    tag.first = root1;
-                }
+        // If different tags, override tag2 with tag1
+        if (tag1 != tag2) {
+            for (auto& tag : _pairing_points_tags) {
+                tag = tag == tag2 ? tag1 : tag;
             }
         }
     }
@@ -284,13 +275,12 @@ template <typename FF_> class CircuitBuilderBase {
      */
     bool has_single_pairing_point_tag() const
     {
-        if (!has_pairing_points) {
+        if (!_has_pairing_points) {
             return true; // No pairing points created
         }
         // Check that there is only one tag
-        uint32_t unique_tag = pairing_points_tags[0].first;
-        return std::ranges::all_of(pairing_points_tags,
-                                   [unique_tag](auto const& tag) { return tag.first == unique_tag; });
+        uint32_t unique_tag = _pairing_points_tags[0];
+        return std::ranges::all_of(_pairing_points_tags, [unique_tag](auto const& tag) { return tag == unique_tag; });
     }
 
     /**
@@ -299,9 +289,9 @@ template <typename FF_> class CircuitBuilderBase {
     uint32_t unique_pairing_points() const
     {
         std::vector<uint32_t> unique_tags;
-        unique_tags.resize(pairing_points_tags.size());
-        for (auto const& tag : pairing_points_tags) {
-            unique_tags[tag.first] = 1;
+        unique_tags.resize(_pairing_points_tags.size());
+        for (auto const& tag : _pairing_points_tags) {
+            unique_tags[tag] = 1;
         }
         uint32_t sum = 0;
         for (auto v : unique_tags) {

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/circuit_builder_base.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/circuit_builder_base.hpp
@@ -12,6 +12,7 @@
 #include "barretenberg/honk/execution_trace/gate_data.hpp"
 #include "barretenberg/public_input_component/public_component_key.hpp"
 #include "barretenberg/serialize/msgpack.hpp"
+#include "pairing_points_tagging.hpp"
 #include <utility>
 
 #include <algorithm>
@@ -88,9 +89,7 @@ template <typename FF_> class CircuitBuilderBase {
     std::unordered_map<uint32_t, uint32_t> _tau;
 
     // Pairing point tag tracking
-    mutable std::vector<uint32_t> _pairing_points_tags;
-    mutable uint32_t _next_pairing_point_tag = 0;
-    mutable bool _has_pairing_points = false;
+    mutable PairingPointsTagging pairing_points_tagging;
 
   public:
     /**
@@ -245,60 +244,26 @@ template <typename FF_> class CircuitBuilderBase {
     /**
      * @brief Create a new unique pairing point tag
      */
-    uint32_t create_pairing_point_tag() const
-    {
-        _has_pairing_points = true;
-        uint32_t new_tag = _next_pairing_point_tag++;
-        _pairing_points_tags.emplace_back(
-            new_tag); // Each PairingPoints starts with tag equal to the number of PairingPoints created before it
-        return new_tag;
-    }
+    uint32_t create_pairing_point_tag() const { return pairing_points_tagging.create_pairing_point_tag(); }
 
     /**
      * @brief Merge two pairing point tags
-     * @param tag1 First tag
-     * @param tag2 Second tag
      */
     void merge_pairing_point_tags(uint32_t tag1, uint32_t tag2) const
     {
-        // If different tags, override tag2 with tag1
-        if (tag1 != tag2) {
-            for (auto& tag : _pairing_points_tags) {
-                tag = tag == tag2 ? tag1 : tag;
-            }
-        }
+        pairing_points_tagging.merge_pairing_point_tags(tag1, tag2);
     }
 
     /**
      * @brief Check if all pairing point tags belong to a single equivalence class
      * @return true if there's only one equivalence class (or no tags at all)
      */
-    bool has_single_pairing_point_tag() const
-    {
-        if (!_has_pairing_points) {
-            return true; // No pairing points created
-        }
-        // Check that there is only one tag
-        uint32_t unique_tag = _pairing_points_tags[0];
-        return std::ranges::all_of(_pairing_points_tags, [unique_tag](auto const& tag) { return tag == unique_tag; });
-    }
+    bool has_single_pairing_point_tag() const { return pairing_points_tagging.has_single_pairing_point_tag(); }
 
     /**
      * @brief Return the number of unique pairing point tags
      */
-    uint32_t unique_pairing_points() const
-    {
-        std::vector<uint32_t> unique_tags;
-        unique_tags.resize(_pairing_points_tags.size());
-        for (auto const& tag : _pairing_points_tags) {
-            unique_tags[tag] = 1;
-        }
-        uint32_t sum = 0;
-        for (auto v : unique_tags) {
-            sum += v;
-        }
-        return sum;
-    }
+    uint32_t num_unique_pairing_points() const { return pairing_points_tagging.num_unique_pairing_points(); }
 };
 
 /**

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/circuit_builder_base.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/circuit_builder_base.hpp
@@ -249,9 +249,9 @@ template <typename FF_> class CircuitBuilderBase {
     /**
      * @brief Merge two pairing point tags
      */
-    void merge_pairing_point_tags(uint32_t tag1, uint32_t tag2) const
+    void merge_pairing_point_tags(uint32_t tag1_index, uint32_t tag2_index) const
     {
-        pairing_points_tagging.merge_pairing_point_tags(tag1, tag2);
+        pairing_points_tagging.merge_pairing_point_tags(tag1_index, tag2_index);
     }
 
     /**
@@ -264,6 +264,11 @@ template <typename FF_> class CircuitBuilderBase {
      * @brief Return the number of unique pairing point tags
      */
     uint32_t num_unique_pairing_points() const { return pairing_points_tagging.num_unique_pairing_points(); }
+
+    /**
+     * @brief Get the pairing points tagging object
+     */
+    uint32_t get_tag(uint32_t tag_index) const { return pairing_points_tagging.get_tag(tag_index); }
 };
 
 /**

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/circuit_builder_base.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/circuit_builder_base.hpp
@@ -93,7 +93,7 @@ template <typename FF_> class CircuitBuilderBase {
      * @brief PairingPoints tagging tool, used to ensure that all pairing points created in this circuit are aggregated
      * together. This is not related to circuit logic.
      */
-    PairingPointsTagging pairing_points_tagging;
+    mutable PairingPointsTagging pairing_points_tagging;
 
     /**
      * @brief Map from witness index to real variable index

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/pairing_points_tagging.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/pairing_points_tagging.hpp
@@ -1,0 +1,110 @@
+// === AUDIT STATUS ===
+// internal:    { status: not started, auditors: [], date: YYYY-MM-DD }
+// external_1:  { status: not started, auditors: [], date: YYYY-MM-DD }
+// external_2:  { status: not started, auditors: [], date: YYYY-MM-DD }
+// =====================
+
+#pragma once
+#include <algorithm>
+#include <cstdint>
+#include <vector>
+
+namespace bb {
+
+/**
+ * @brief Class to manage pairing point tagging
+ * @details This class tracks pairing points and their tags, providing functionality
+ * to create new tags, merge tags, and query tag properties. Tags are used to track
+ * which pairing points can be safely merged together.
+ */
+class PairingPointsTagging {
+  private:
+    std::vector<uint32_t> pairing_points_tags_;
+    uint32_t next_pairing_point_tag_ = 0;
+    bool has_pairing_points_ = false;
+
+  public:
+    PairingPointsTagging() = default;
+    PairingPointsTagging(const PairingPointsTagging& other) = default;
+    PairingPointsTagging(PairingPointsTagging&& other) noexcept = default;
+    PairingPointsTagging& operator=(const PairingPointsTagging& other) = default;
+    PairingPointsTagging& operator=(PairingPointsTagging&& other) noexcept = default;
+    ~PairingPointsTagging() = default;
+
+    bool operator==(const PairingPointsTagging& other) const = default;
+
+    /**
+     * @brief Create a new unique pairing point tag
+     * @return The new tag value
+     */
+    uint32_t create_pairing_point_tag()
+    {
+        has_pairing_points_ = true;
+        uint32_t new_tag = next_pairing_point_tag_++;
+        pairing_points_tags_.emplace_back(
+            new_tag); // Each PairingPoints starts with tag equal to the number of PairingPoints created before it
+        return new_tag;
+    }
+
+    /**
+     * @brief Merge two pairing point tags
+     * @param tag1 First tag
+     * @param tag2 Second tag
+     * @details If the tags are different, all instances of tag2 are replaced with tag1
+     */
+    void merge_pairing_point_tags(uint32_t tag1, uint32_t tag2)
+    {
+        // If different tags, override tag2 with tag1
+        if (tag1 != tag2) {
+            for (auto& tag : pairing_points_tags_) {
+                tag = tag == tag2 ? tag1 : tag;
+            }
+        }
+    }
+
+    /**
+     * @brief Check if all pairing point tags belong to a single equivalence class
+     * @return true if there's only one equivalence class (or no tags at all)
+     */
+    bool has_single_pairing_point_tag() const
+    {
+        if (!has_pairing_points_) {
+            return true; // No pairing points created
+        }
+        // Check that there is only one tag
+        uint32_t unique_tag = pairing_points_tags_[0];
+        return std::ranges::all_of(pairing_points_tags_, [unique_tag](auto const& tag) { return tag == unique_tag; });
+    }
+
+    /**
+     * @brief Return the number of unique pairing point tags
+     * @return The count of unique tags
+     */
+    uint32_t num_unique_pairing_points() const
+    {
+        std::vector<uint32_t> unique_tags;
+        unique_tags.resize(pairing_points_tags_.size());
+        for (auto const& tag : pairing_points_tags_) {
+            unique_tags[tag] = 1;
+        }
+        uint32_t sum = 0;
+        for (auto v : unique_tags) {
+            sum += v;
+        }
+        return sum;
+    }
+
+    /**
+     * @brief Check if any pairing points have been created
+     * @return true if pairing points have been created
+     */
+    bool has_pairing_points() const { return has_pairing_points_; }
+
+    /**
+     * @brief Get the pairing points tags vector
+     * @return const reference to the tags vector
+     */
+    const std::vector<uint32_t>& get_pairing_points_tags() const { return pairing_points_tags_; }
+};
+
+} // namespace bb

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/pairing_points_tagging.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/pairing_points_tagging.hpp
@@ -27,6 +27,13 @@ class PairingPointsTagging {
 
   public:
     PairingPointsTagging() = default;
+    PairingPointsTagging(const PairingPointsTagging& other) = default;
+    PairingPointsTagging(PairingPointsTagging&& other) noexcept = default;
+    PairingPointsTagging& operator=(const PairingPointsTagging& other) = default;
+    PairingPointsTagging& operator=(PairingPointsTagging&& other) noexcept = default;
+    ~PairingPointsTagging() = default;
+
+    bool operator==(const PairingPointsTagging& other) const = default;
 
     /**
      * @brief Create a new unique pairing point tag

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/pairing_points_tagging.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/pairing_points_tagging.hpp
@@ -27,13 +27,6 @@ class PairingPointsTagging {
 
   public:
     PairingPointsTagging() = default;
-    PairingPointsTagging(const PairingPointsTagging& other) = delete;
-    PairingPointsTagging(PairingPointsTagging&& other) noexcept = delete;
-    PairingPointsTagging& operator=(const PairingPointsTagging& other) = delete;
-    PairingPointsTagging& operator=(PairingPointsTagging&& other) noexcept = delete;
-    ~PairingPointsTagging() = default;
-
-    bool operator==(const PairingPointsTagging& other) const = default;
 
     /**
      * @brief Create a new unique pairing point tag

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/pairing_points_tagging.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/pairing_points_tagging.hpp
@@ -5,6 +5,7 @@
 // =====================
 
 #pragma once
+#include "barretenberg/common/assert.hpp"
 #include <algorithm>
 #include <cstdint>
 #include <vector>
@@ -13,22 +14,23 @@ namespace bb {
 
 /**
  * @brief Class to manage pairing point tagging
- * @details This class tracks pairing points and their tags, providing functionality
- * to create new tags, merge tags, and query tag properties. Tags are used to track
- * which pairing points can be safely merged together.
+ * @details This class tracks pairing points and their tags, providing functionality to create new tags, merge tags, and
+ * query tag properties. Tags are used to ensure that all the pairing points created in a circuit are aggregated
+ * together and set to public (after aggregation).
  */
 class PairingPointsTagging {
   private:
     std::vector<uint32_t> pairing_points_tags_;
     uint32_t next_pairing_point_tag_ = 0;
     bool has_pairing_points_ = false;
+    bool has_public_pairing_points_ = false;
 
   public:
     PairingPointsTagging() = default;
-    PairingPointsTagging(const PairingPointsTagging& other) = default;
-    PairingPointsTagging(PairingPointsTagging&& other) noexcept = default;
-    PairingPointsTagging& operator=(const PairingPointsTagging& other) = default;
-    PairingPointsTagging& operator=(PairingPointsTagging&& other) noexcept = default;
+    PairingPointsTagging(const PairingPointsTagging& other) = delete;
+    PairingPointsTagging(PairingPointsTagging&& other) noexcept = delete;
+    PairingPointsTagging& operator=(const PairingPointsTagging& other) = delete;
+    PairingPointsTagging& operator=(PairingPointsTagging&& other) noexcept = delete;
     ~PairingPointsTagging() = default;
 
     bool operator==(const PairingPointsTagging& other) const = default;
@@ -50,10 +52,14 @@ class PairingPointsTagging {
      * @brief Merge two pairing point tags
      * @param tag1 First tag
      * @param tag2 Second tag
-     * @details If the tags are different, all instances of tag2 are replaced with tag1
+     * @details If the tags are different, all instances of tag2 are replaced with tag1. We also check that the pairing
+     * points have not been set to public yet.
      */
     void merge_pairing_point_tags(uint32_t tag1_index, uint32_t tag2_index)
     {
+        BB_ASSERT(!has_public_pairing_points_,
+                  "Cannot merge pairing point tags after pairing points have been set to public.");
+
         // If different tags, override tag2 with tag1
         uint32_t tag1 = pairing_points_tags_[tag1_index];
         uint32_t tag2 = pairing_points_tags_[tag2_index];
@@ -104,9 +110,25 @@ class PairingPointsTagging {
     bool has_pairing_points() const { return has_pairing_points_; }
 
     /**
+     * @brief Check if pairings points have been set to public
+     * @return true if pairing points have been set to public
+     */
+    bool has_public_pairing_points() const { return has_public_pairing_points_; }
+
+    /**
      * @brief Get the tag for a specific pairing point index
      */
     uint32_t get_tag(uint32_t tag_index) const { return pairing_points_tags_.at(tag_index); }
+
+    /**
+     * @brief Record that pairing points have been set to public
+     */
+    void set_public_pairing_points()
+    {
+        BB_ASSERT(!has_public_pairing_points_,
+                  "Trying to set pairing points to public for a circuit that already has public pairing points.");
+        has_public_pairing_points_ = true;
+    }
 };
 
 } // namespace bb

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/pairing_points_tagging.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/pairing_points_tagging.hpp
@@ -52,9 +52,12 @@ class PairingPointsTagging {
      * @param tag2 Second tag
      * @details If the tags are different, all instances of tag2 are replaced with tag1
      */
-    void merge_pairing_point_tags(uint32_t tag1, uint32_t tag2)
+    void merge_pairing_point_tags(uint32_t tag1_index, uint32_t tag2_index)
     {
         // If different tags, override tag2 with tag1
+        uint32_t tag1 = pairing_points_tags_[tag1_index];
+        uint32_t tag2 = pairing_points_tags_[tag2_index];
+
         if (tag1 != tag2) {
             for (auto& tag : pairing_points_tags_) {
                 tag = tag == tag2 ? tag1 : tag;
@@ -101,10 +104,9 @@ class PairingPointsTagging {
     bool has_pairing_points() const { return has_pairing_points_; }
 
     /**
-     * @brief Get the pairing points tags vector
-     * @return const reference to the tags vector
+     * @brief Get the tag for a specific pairing point index
      */
-    const std::vector<uint32_t>& get_pairing_points_tags() const { return pairing_points_tags_; }
+    uint32_t get_tag(uint32_t tag_index) const { return pairing_points_tags_.at(tag_index); }
 };
 
 } // namespace bb

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/prover_instance.hpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/prover_instance.hpp
@@ -134,6 +134,15 @@ template <IsUltraOrMegaHonk Flavor_> class ProverInstance_ {
         BB_BENCH_NAME("ProverInstance(Circuit&)");
         vinfo("Constructing ProverInstance");
         auto start = std::chrono::steady_clock::now();
+
+        // Check pairing point tagging invariant: either no pairing points were created,
+        // or all pairing points have been aggregated into a single equivalence class
+        BB_ASSERT(circuit.has_single_pairing_point_tag(),
+                  "Pairing points must all be aggregated together. Either no pairing points should be created, or "
+                  "all created pairing points must be aggregated into a single pairing point. Found ",
+                  circuit.unique_pairing_points(),
+                  " different pairing points.");
+
         // Decider proving keys can be constructed multiple times, hence, we check whether the circuit has been
         // finalized
         if (!circuit.circuit_finalized) {

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/prover_instance.hpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/prover_instance.hpp
@@ -135,13 +135,16 @@ template <IsUltraOrMegaHonk Flavor_> class ProverInstance_ {
         vinfo("Constructing ProverInstance");
         auto start = std::chrono::steady_clock::now();
 
-        // Check pairing point tagging invariant: either no pairing points were created,
+        // Check pairing point tagging: either no pairing points were created,
         // or all pairing points have been aggregated into a single equivalence class
-        BB_ASSERT(circuit.has_single_pairing_point_tag(),
+        BB_ASSERT(circuit.pairing_points_tagging.has_single_pairing_point_tag(),
                   "Pairing points must all be aggregated together. Either no pairing points should be created, or "
                   "all created pairing points must be aggregated into a single pairing point. Found ",
-                  circuit.num_unique_pairing_points(),
+                  circuit.pairing_points_tagging.num_unique_pairing_points(),
                   " different pairing points.");
+        // Check pairing point tagging: check that the pairing points have been set to public
+        BB_ASSERT(circuit.pairing_points_tagging.has_public_pairing_points(),
+                  "Pairing points must be set to public in the circuit before constructing the ProverInstance.");
 
         // Decider proving keys can be constructed multiple times, hence, we check whether the circuit has been
         // finalized

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/prover_instance.hpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/prover_instance.hpp
@@ -140,7 +140,7 @@ template <IsUltraOrMegaHonk Flavor_> class ProverInstance_ {
         BB_ASSERT(circuit.has_single_pairing_point_tag(),
                   "Pairing points must all be aggregated together. Either no pairing points should be created, or "
                   "all created pairing points must be aggregated into a single pairing point. Found ",
-                  circuit.unique_pairing_points(),
+                  circuit.num_unique_pairing_points(),
                   " different pairing points.");
 
         // Decider proving keys can be constructed multiple times, hence, we check whether the circuit has been

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/prover_instance.hpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/prover_instance.hpp
@@ -143,7 +143,8 @@ template <IsUltraOrMegaHonk Flavor_> class ProverInstance_ {
                   circuit.pairing_points_tagging.num_unique_pairing_points(),
                   " different pairing points.");
         // Check pairing point tagging: check that the pairing points have been set to public
-        BB_ASSERT(circuit.pairing_points_tagging.has_public_pairing_points(),
+        BB_ASSERT(circuit.pairing_points_tagging.has_public_pairing_points() ||
+                      !circuit.pairing_points_tagging.has_pairing_points(),
                   "Pairing points must be set to public in the circuit before constructing the ProverInstance.");
 
         // Decider proving keys can be constructed multiple times, hence, we check whether the circuit has been

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/recursion/recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/recursion/recursive_verifier.cpp
@@ -189,7 +189,7 @@ AvmRecursiveVerifier::PairingPoints AvmRecursiveVerifier::verify_proof(
     const BatchOpeningClaim<Curve> opening_claim = Shplemini::compute_batch_opening_claim(
         padding_indicator_array, claim_batcher, output.challenge, Commitment::one(&builder), transcript);
 
-    auto pairing_points = PCS::reduce_verify_batch_opening_claim(opening_claim, transcript);
+    PairingPoints pairing_points(PCS::reduce_verify_batch_opening_claim(opening_claim, transcript));
 
     if (builder.failed()) {
         info("AVM Recursive verifier builder failed with error: ", builder.err());

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/recursion/recursive_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/recursion/recursive_verifier.test.cpp
@@ -127,8 +127,10 @@ TEST_F(AvmRecursiveTests, GoblinRecursion)
         return result;
     }();
 
-    verifier_output.points_accumulator.set_public();
-    verifier_output.ipa_claim.set_public();
+    stdlib::recursion::honk::RollupIO inputs;
+    inputs.pairing_inputs = verifier_output.points_accumulator;
+    inputs.ipa_claim = verifier_output.ipa_claim;
+    inputs.set_public();
     outer_circuit.ipa_proof = verifier_output.ipa_proof.get_value();
 
     // Ensure that the pairing check is satisfied on the outputs of the recursive verifier
@@ -226,8 +228,10 @@ TEST_F(AvmRecursiveTests, GoblinRecursionWithoutPIValidation)
         return result;
     }();
 
-    verifier_output.points_accumulator.set_public();
-    verifier_output.ipa_claim.set_public();
+    stdlib::recursion::honk::RollupIO inputs;
+    inputs.pairing_inputs = verifier_output.points_accumulator;
+    inputs.ipa_claim = verifier_output.ipa_claim;
+    inputs.set_public();
     outer_circuit.ipa_proof = verifier_output.ipa_proof.get_value();
 
     // Ensure that the pairing check is satisfied on the outputs of the recursive verifier


### PR DESCRIPTION
This PR implements a simple tagging mechanism for PairingPoints. We leverage this mechanism to be sure that when a ProverInstance is built from a builder all the PairingPoints that have been constructed in the builder have been aggregated into one (we always return a single pairing point) and the aggregated point has been set to public.

Closes https://github.com/AztecProtocol/barretenberg/issues/1571