### PR TITLE
chore: Default BLOB_ALLOW_EMPTY_SOURCES to true in testnet and stg ignition

### DIFF
--- a/yarn-project/cli/src/config/chain_l2_config.ts
+++ b/yarn-project/cli/src/config/chain_l2_config.ts
@@ -32,6 +32,7 @@ export type L2ChainConfig = L1ContractsConfig &
     publicMetricsCollectorUrl?: string;
     publicMetricsCollectFrom?: string[];
     skipArchiverInitialSync?: boolean;
+    blobAllowEmptySources?: boolean;
 
     // Control whether sentinel is enabled or not. Needed for slashing
     sentinelEnabled: boolean;
@@ -91,6 +92,7 @@ export const stagingIgnitionL2ChainConfig: L2ChainConfig = {
   publicMetricsCollectorUrl: 'https://telemetry.alpha-testnet.aztec-labs.com/v1/metrics',
   publicMetricsCollectFrom: ['sequencer'],
   txPoolDeleteTxsAfterReorg: false,
+  blobAllowEmptySources: true,
 
   /** How many seconds an L1 slot lasts. */
   ethereumSlotDuration: 12,
@@ -219,6 +221,7 @@ export const testnetL2ChainConfig: L2ChainConfig = {
   publicMetricsCollectFrom: ['sequencer'],
   txPoolDeleteTxsAfterReorg: true,
   skipArchiverInitialSync: true,
+  blobAllowEmptySources: true,
 
   // Deployment stuff
   /** How many seconds an L1 slot lasts. */
@@ -359,6 +362,10 @@ export async function enrichEnvironmentWithChainConfig(networkName: NetworkNames
 
   if (config.skipArchiverInitialSync !== undefined) {
     enrichVar('SKIP_ARCHIVER_INITIAL_SYNC', config.skipArchiverInitialSync.toString());
+  }
+
+  if (config.blobAllowEmptySources !== undefined) {
+    enrichVar('BLOB_ALLOW_EMPTY_SOURCES', config.blobAllowEmptySources.toString());
   }
 
   if (config.autoUpdate) {


### PR DESCRIPTION
In chain-l2-config
