### PR TITLE
fix: restore BB_WASM_PATH handling in yarn-project

### DIFF
--- a/yarn-project/foundation/src/crypto/aes128/index.ts
+++ b/yarn-project/foundation/src/crypto/aes128/index.ts
@@ -22,7 +22,7 @@ export class Aes128 {
     paddingBuffer.fill(numPaddingBytes);
     const input = Buffer.concat([data, paddingBuffer]);
 
-    await BarretenbergSync.initSingleton();
+    await BarretenbergSync.initSingleton({ wasmPath: process.env.BB_WASM_PATH });
     const api = BarretenbergSync.getSingleton();
     const response = api.aesEncrypt({
       plaintext: input,
@@ -42,7 +42,7 @@ export class Aes128 {
    * @returns Decrypted data.
    */
   public async decryptBufferCBCKeepPadding(data: Uint8Array, iv: Uint8Array, key: Uint8Array): Promise<Buffer> {
-    await BarretenbergSync.initSingleton();
+    await BarretenbergSync.initSingleton({ wasmPath: process.env.BB_WASM_PATH });
     const api = BarretenbergSync.getSingleton();
     const response = api.aesDecrypt({
       ciphertext: data,

--- a/yarn-project/foundation/src/crypto/ecdsa/index.ts
+++ b/yarn-project/foundation/src/crypto/ecdsa/index.ts
@@ -16,7 +16,7 @@ export class Ecdsa {
    * @returns A secp256k1 public key.
    */
   public async computePublicKey(privateKey: Buffer): Promise<Buffer> {
-    await BarretenbergSync.initSingleton();
+    await BarretenbergSync.initSingleton({ wasmPath: process.env.BB_WASM_PATH });
     const api = BarretenbergSync.getSingleton();
     const response =
       this.curve === 'secp256r1'
@@ -32,7 +32,7 @@ export class Ecdsa {
    * @returns An ECDSA signature of the form (r, s, v).
    */
   public async constructSignature(msg: Uint8Array, privateKey: Buffer) {
-    await BarretenbergSync.initSingleton();
+    await BarretenbergSync.initSingleton({ wasmPath: process.env.BB_WASM_PATH });
     const api = BarretenbergSync.getSingleton();
     const response =
       this.curve === 'secp256r1'
@@ -48,7 +48,7 @@ export class Ecdsa {
    * @returns The secp256k1 public key of the signer.
    */
   public async recoverPublicKey(msg: Uint8Array, sig: EcdsaSignature): Promise<Buffer> {
-    await BarretenbergSync.initSingleton();
+    await BarretenbergSync.initSingleton({ wasmPath: process.env.BB_WASM_PATH });
     const api = BarretenbergSync.getSingleton();
     const response =
       this.curve === 'secp256r1'
@@ -65,7 +65,7 @@ export class Ecdsa {
    * @returns True or false.
    */
   public async verifySignature(msg: Uint8Array, pubKey: Buffer, sig: EcdsaSignature) {
-    await BarretenbergSync.initSingleton();
+    await BarretenbergSync.initSingleton({ wasmPath: process.env.BB_WASM_PATH });
     const api = BarretenbergSync.getSingleton();
     const response =
       this.curve === 'secp256r1'

--- a/yarn-project/foundation/src/crypto/grumpkin/index.ts
+++ b/yarn-project/foundation/src/crypto/grumpkin/index.ts
@@ -28,7 +28,7 @@ export class Grumpkin {
    * @returns Result of the multiplication.
    */
   public async mul(point: Point, scalar: GrumpkinScalar): Promise<Point> {
-    await BarretenbergSync.initSingleton();
+    await BarretenbergSync.initSingleton({ wasmPath: process.env.BB_WASM_PATH });
     const api = BarretenbergSync.getSingleton();
     const response = api.grumpkinMul({
       point: { x: point.x.toBuffer(), y: point.y.toBuffer() },
@@ -44,7 +44,7 @@ export class Grumpkin {
    * @returns Result of the addition.
    */
   public async add(a: Point, b: Point): Promise<Point> {
-    await BarretenbergSync.initSingleton();
+    await BarretenbergSync.initSingleton({ wasmPath: process.env.BB_WASM_PATH });
     const api = BarretenbergSync.getSingleton();
     const response = api.grumpkinAdd({
       pointA: { x: a.x.toBuffer(), y: a.y.toBuffer() },
@@ -60,7 +60,7 @@ export class Grumpkin {
    * @returns Points multiplied by the scalar.
    */
   public async batchMul(points: Point[], scalar: GrumpkinScalar) {
-    await BarretenbergSync.initSingleton();
+    await BarretenbergSync.initSingleton({ wasmPath: process.env.BB_WASM_PATH });
     const api = BarretenbergSync.getSingleton();
     const response = api.grumpkinBatchMul({
       points: points.map(p => ({ x: p.x.toBuffer(), y: p.y.toBuffer() })),
@@ -75,7 +75,7 @@ export class Grumpkin {
    * @returns Random field element.
    */
   public async getRandomFr(): Promise<Fr> {
-    await BarretenbergSync.initSingleton();
+    await BarretenbergSync.initSingleton({ wasmPath: process.env.BB_WASM_PATH });
     const api = BarretenbergSync.getSingleton();
     const response = api.grumpkinGetRandomFr({ dummy: 0 });
     return Fr.fromBuffer(Buffer.from(response.value));
@@ -87,7 +87,7 @@ export class Grumpkin {
    * @returns Buffer representation of the field element.
    */
   public async reduce512BufferToFr(uint512Buf: Buffer): Promise<Fr> {
-    await BarretenbergSync.initSingleton();
+    await BarretenbergSync.initSingleton({ wasmPath: process.env.BB_WASM_PATH });
     const api = BarretenbergSync.getSingleton();
     const response = api.grumpkinReduce512({ input: uint512Buf });
     return Fr.fromBuffer(Buffer.from(response.value));

--- a/yarn-project/foundation/src/crypto/keys/index.ts
+++ b/yarn-project/foundation/src/crypto/keys/index.ts
@@ -3,7 +3,7 @@ import { BarretenbergSync } from '@aztec/bb.js';
 import { Fr } from '../../fields/fields.js';
 
 export async function vkAsFieldsMegaHonk(input: Buffer): Promise<Fr[]> {
-  await BarretenbergSync.initSingleton();
+  await BarretenbergSync.initSingleton({ wasmPath: process.env.BB_WASM_PATH });
   const api = BarretenbergSync.getSingleton();
   const response = api.megaVkAsFields({ verificationKey: input });
   return response.fields.map(field => Fr.fromBuffer(Buffer.from(field)));

--- a/yarn-project/foundation/src/crypto/pedersen/index.test.ts
+++ b/yarn-project/foundation/src/crypto/pedersen/index.test.ts
@@ -6,7 +6,7 @@ import { pedersenCommit, pedersenHash, pedersenHashBuffer } from './index.js';
 
 describe('pedersen', () => {
   beforeAll(async () => {
-    await BarretenbergSync.initSingleton({ threads: 1 });
+    await BarretenbergSync.initSingleton({ threads: 1, wasmPath: process.env.BB_WASM_PATH });
     setupCustomSnapshotSerializers(expect);
   });
 

--- a/yarn-project/foundation/src/crypto/pedersen/pedersen.wasm.ts
+++ b/yarn-project/foundation/src/crypto/pedersen/pedersen.wasm.ts
@@ -12,7 +12,7 @@ export async function pedersenCommit(input: Buffer[], offset = 0) {
     throw new Error('All Pedersen Commit input buffers must be <= 32 bytes.');
   }
   input = input.map(i => (i.length < 32 ? Buffer.concat([Buffer.alloc(32 - i.length, 0), i]) : i));
-  await BarretenbergSync.initSingleton();
+  await BarretenbergSync.initSingleton({ wasmPath: process.env.BB_WASM_PATH });
   const api = BarretenbergSync.getSingleton();
   const response = api.pedersenCommit({
     inputs: input,
@@ -29,7 +29,7 @@ export async function pedersenCommit(input: Buffer[], offset = 0) {
  */
 export async function pedersenHash(input: Fieldable[], index = 0): Promise<Fr> {
   const inputFields = serializeToFields(input);
-  await BarretenbergSync.initSingleton();
+  await BarretenbergSync.initSingleton({ wasmPath: process.env.BB_WASM_PATH });
   const api = BarretenbergSync.getSingleton();
   const response = api.pedersenHash({
     inputs: inputFields.map(i => i.toBuffer()),
@@ -42,7 +42,7 @@ export async function pedersenHash(input: Fieldable[], index = 0): Promise<Fr> {
  * Create a pedersen hash from an arbitrary length buffer.
  */
 export async function pedersenHashBuffer(input: Buffer, index = 0) {
-  await BarretenbergSync.initSingleton();
+  await BarretenbergSync.initSingleton({ wasmPath: process.env.BB_WASM_PATH });
   const api = BarretenbergSync.getSingleton();
   const response = api.pedersenHashBuffer({
     input,

--- a/yarn-project/foundation/src/crypto/poseidon/index.test.ts
+++ b/yarn-project/foundation/src/crypto/poseidon/index.test.ts
@@ -5,7 +5,7 @@ import { poseidon2Permutation } from './index.js';
 
 describe('poseidon2Permutation', () => {
   beforeAll(async () => {
-    await BarretenbergSync.initSingleton({ threads: 1 });
+    await BarretenbergSync.initSingleton({ threads: 1, wasmPath: process.env.BB_WASM_PATH });
   });
 
   it('test vectors from cpp should match', async () => {

--- a/yarn-project/foundation/src/crypto/poseidon/index.ts
+++ b/yarn-project/foundation/src/crypto/poseidon/index.ts
@@ -10,7 +10,7 @@ import { type Fieldable, serializeToFields } from '../../serialize/serialize.js'
  */
 export async function poseidon2Hash(input: Fieldable[]): Promise<Fr> {
   const inputFields = serializeToFields(input);
-  await BarretenbergSync.initSingleton();
+  await BarretenbergSync.initSingleton({ wasmPath: process.env.BB_WASM_PATH });
   const api = BarretenbergSync.getSingleton();
   const response = api.poseidon2Hash({
     inputs: inputFields.map(i => i.toBuffer()),
@@ -27,7 +27,7 @@ export async function poseidon2Hash(input: Fieldable[]): Promise<Fr> {
 export async function poseidon2HashWithSeparator(input: Fieldable[], separator: number): Promise<Fr> {
   const inputFields = serializeToFields(input);
   inputFields.unshift(new Fr(separator));
-  await BarretenbergSync.initSingleton();
+  await BarretenbergSync.initSingleton({ wasmPath: process.env.BB_WASM_PATH });
   const api = BarretenbergSync.getSingleton();
   const response = api.poseidon2Hash({
     inputs: inputFields.map(i => i.toBuffer()),
@@ -37,7 +37,7 @@ export async function poseidon2HashWithSeparator(input: Fieldable[], separator: 
 
 export async function poseidon2HashAccumulate(input: Fieldable[]): Promise<Fr> {
   const inputFields = serializeToFields(input);
-  await BarretenbergSync.initSingleton();
+  await BarretenbergSync.initSingleton({ wasmPath: process.env.BB_WASM_PATH });
   const api = BarretenbergSync.getSingleton();
   const response = api.poseidon2HashAccumulate({
     inputs: inputFields.map(i => i.toBuffer()),
@@ -54,7 +54,7 @@ export async function poseidon2Permutation(input: Fieldable[]): Promise<Fr[]> {
   const inputFields = serializeToFields(input);
   // We'd like this assertion but it's not possible to use it in the browser.
   // assert(input.length === 4, 'Input state must be of size 4');
-  await BarretenbergSync.initSingleton();
+  await BarretenbergSync.initSingleton({ wasmPath: process.env.BB_WASM_PATH });
   const api = BarretenbergSync.getSingleton();
   const response = api.poseidon2Permutation({
     inputs: inputFields.map(i => i.toBuffer()),
@@ -75,7 +75,7 @@ export async function poseidon2HashBytes(input: Buffer): Promise<Fr> {
     inputFields.push(Fr.fromBuffer(fieldBytes));
   }
 
-  await BarretenbergSync.initSingleton();
+  await BarretenbergSync.initSingleton({ wasmPath: process.env.BB_WASM_PATH });
   const api = BarretenbergSync.getSingleton();
   const response = api.poseidon2Hash({
     inputs: inputFields.map(i => i.toBuffer()),

--- a/yarn-project/foundation/src/crypto/schnorr/index.ts
+++ b/yarn-project/foundation/src/crypto/schnorr/index.ts
@@ -15,7 +15,7 @@ export class Schnorr {
    * @returns A grumpkin public key.
    */
   public async computePublicKey(privateKey: GrumpkinScalar): Promise<Point> {
-    await BarretenbergSync.initSingleton();
+    await BarretenbergSync.initSingleton({ wasmPath: process.env.BB_WASM_PATH });
     const api = BarretenbergSync.getSingleton();
     const response = api.schnorrComputePublicKey({ privateKey: privateKey.toBuffer() });
     return Point.fromBuffer(Buffer.concat([Buffer.from(response.publicKey.x), Buffer.from(response.publicKey.y)]));
@@ -28,7 +28,7 @@ export class Schnorr {
    * @returns A Schnorr signature of the form (s, e).
    */
   public async constructSignature(msg: Uint8Array, privateKey: GrumpkinScalar) {
-    await BarretenbergSync.initSingleton();
+    await BarretenbergSync.initSingleton({ wasmPath: process.env.BB_WASM_PATH });
     const api = BarretenbergSync.getSingleton();
     const response = api.schnorrConstructSignature({
       message: msg,
@@ -45,7 +45,7 @@ export class Schnorr {
    * @returns True or false.
    */
   public async verifySignature(msg: Uint8Array, pubKey: Point, sig: SchnorrSignature) {
-    await BarretenbergSync.initSingleton();
+    await BarretenbergSync.initSingleton({ wasmPath: process.env.BB_WASM_PATH });
     const api = BarretenbergSync.getSingleton();
     const response = api.schnorrVerifySignature({
       message: msg,

--- a/yarn-project/foundation/src/crypto/secp256k1/index.ts
+++ b/yarn-project/foundation/src/crypto/secp256k1/index.ts
@@ -27,7 +27,7 @@ export class Secp256k1 {
    * @returns Result of the multiplication.
    */
   public async mul(point: Uint8Array, scalar: Uint8Array) {
-    await BarretenbergSync.initSingleton();
+    await BarretenbergSync.initSingleton({ wasmPath: process.env.BB_WASM_PATH });
     const api = BarretenbergSync.getSingleton();
     const response = api.secp256k1Mul({
       point: { x: point.subarray(0, 32), y: point.subarray(32, 64) },
@@ -41,7 +41,7 @@ export class Secp256k1 {
    * @returns Random field element.
    */
   public async getRandomFr() {
-    await BarretenbergSync.initSingleton();
+    await BarretenbergSync.initSingleton({ wasmPath: process.env.BB_WASM_PATH });
     const api = BarretenbergSync.getSingleton();
     const response = api.secp256k1GetRandomFr({ dummy: 0 });
     return Buffer.from(response.value);
@@ -53,7 +53,7 @@ export class Secp256k1 {
    * @returns Buffer representation of the field element.
    */
   public async reduce512BufferToFr(uint512Buf: Buffer) {
-    await BarretenbergSync.initSingleton();
+    await BarretenbergSync.initSingleton({ wasmPath: process.env.BB_WASM_PATH });
     const api = BarretenbergSync.getSingleton();
     const response = api.secp256k1Reduce512({ input: uint512Buf });
     return Buffer.from(response.value);

--- a/yarn-project/foundation/src/crypto/sync/index.ts
+++ b/yarn-project/foundation/src/crypto/sync/index.ts
@@ -3,4 +3,4 @@ import { BarretenbergSync } from '@aztec/bb.js';
 export * from './poseidon/index.js';
 export * from './pedersen/index.js';
 
-await BarretenbergSync.initSingleton();
+await BarretenbergSync.initSingleton({ wasmPath: process.env.BB_WASM_PATH });

--- a/yarn-project/foundation/src/crypto/sync/pedersen/index.test.ts
+++ b/yarn-project/foundation/src/crypto/sync/pedersen/index.test.ts
@@ -6,7 +6,7 @@ import { pedersenCommit, pedersenHash, pedersenHashBuffer } from './index.js';
 
 describe('pedersen', () => {
   beforeAll(async () => {
-    await BarretenbergSync.initSingleton();
+    await BarretenbergSync.initSingleton({ wasmPath: process.env.BB_WASM_PATH });
     setupCustomSnapshotSerializers(expect);
   });
 

--- a/yarn-project/foundation/src/crypto/sync/poseidon/index.test.ts
+++ b/yarn-project/foundation/src/crypto/sync/poseidon/index.test.ts
@@ -5,7 +5,7 @@ import { poseidon2Permutation } from './index.js';
 
 describe('poseidon2Permutation', () => {
   beforeAll(async () => {
-    await BarretenbergSync.initSingleton();
+    await BarretenbergSync.initSingleton({ wasmPath: process.env.BB_WASM_PATH });
   });
 
   it('test vectors from cpp should match', () => {

--- a/yarn-project/foundation/src/fields/fields.ts
+++ b/yarn-project/foundation/src/fields/fields.ts
@@ -321,7 +321,7 @@ export class Fr extends BaseField {
    * @returns A square root of the field element (null if it does not exist).
    */
   async sqrt(): Promise<Fr | null> {
-    await BarretenbergSync.initSingleton();
+    await BarretenbergSync.initSingleton({ wasmPath: process.env.BB_WASM_PATH });
     const api = BarretenbergSync.getSingleton();
     const response = api.bn254FrSqrt({ input: this.toBuffer() });
     if (!response.isSquareRoot) {

--- a/yarn-project/ivc-integration/src/prove_wasm.ts
+++ b/yarn-project/ivc-integration/src/prove_wasm.ts
@@ -19,7 +19,7 @@ export async function proveClientIVC(
   const { AztecClientBackend } = await import('@aztec/bb.js');
   const backend = new AztecClientBackend(
     bytecodes.map(base64ToUint8Array).map((arr: Uint8Array) => ungzip(arr)),
-    { threads: threads || Math.min(os.cpus().length, 16), logger: logger.info },
+    { threads: threads || Math.min(os.cpus().length, 16), logger: logger.info, wasmPath: process.env.BB_WASM_PATH },
   );
   try {
     const [proof] = await backend.prove(
@@ -41,7 +41,7 @@ export async function proveThenVerifyAztecClient(
   const { AztecClientBackend } = await import('@aztec/bb.js');
   const backend = new AztecClientBackend(
     bytecodes.map(base64ToUint8Array).map((arr: Uint8Array) => ungzip(arr)),
-    { threads: threads || Math.min(os.cpus().length, 16), logger: logger.info },
+    { threads: threads || Math.min(os.cpus().length, 16), logger: logger.info, wasmPath: process.env.BB_WASM_PATH },
   );
   try {
     // These are optional - easier not to pass them.

--- a/yarn-project/ivc-integration/src/wasm_client_ivc_integration.test.ts
+++ b/yarn-project/ivc-integration/src/wasm_client_ivc_integration.test.ts
@@ -64,7 +64,7 @@ describe('Client IVC Integration', () => {
     // Initialize AztecClientBackend with the given bytecodes
     const backend = new AztecClientBackend(
       bytecodes.map(base64ToUint8Array).map((arr: Uint8Array) => ungzip(arr)),
-      { threads: 1, logger: logger.info },
+      { threads: 1, logger: logger.info, wasmPath: process.env.BB_WASM_PATH },
     );
 
     // Compute the numbers of gates in each circuit


### PR DESCRIPTION
Restore BB_WASM_PATH environment variable handling throughout yarn-project after it was removed during the msgpack migration 6 days ago. This ensures the WASM path is properly passed through all necessary components. The fix systematically re-adds BB_WASM_PATH support to maintain compatibility with the build system.