### PR TITLE
fix(ci/release): always ensure github release exists

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -354,11 +354,9 @@ function release {
   echo_header "release all"
   set -x
 
-  # Ensure we have a github release for our REF_NAME, if not on latest.
-  # On latest we rely on release-please to create this for us.
-  if [ $(dist_tag) != latest ]; then
-    release_github
-  fi
+  # Ensure we have a github release for our REF_NAME.
+  # This is in case were are not going through release-please.
+  release_github
 
   projects=(
     barretenberg/cpp


### PR DESCRIPTION
Previously we didn't try this for non-prerelease dist_tag's, but there's no real reason not to support bypassing release-please.