### PR TITLE
fix: Do not verify contracts if not deployed in that run

### DIFF
--- a/spartan/scripts/deploy_network.sh
+++ b/spartan/scripts/deploy_network.sh
@@ -278,7 +278,7 @@ EOF
 tf_run "${DEPLOY_ROLLUP_CONTRACTS_DIR}" "${DESTROY_ROLLUP_CONTRACTS}" "${CREATE_ROLLUP_CONTRACTS}"
 log "Deployed rollup contracts"
 
-if [[ "${VERIFY_CONTRACTS:-}" == "true" ]]; then
+if [[ "${VERIFY_CONTRACTS:-}" == "true" && "${CREATE_ROLLUP_CONTRACTS}" == "true" ]]; then
   terraform -chdir="${DEPLOY_ROLLUP_CONTRACTS_DIR}" output -raw verification_json_b64 | base64 -d > $HOME/l1-verify.json
   ${REPO_ROOT}/l1-contracts/scripts/verify-from-json.sh $HOME/l1-verify.json --api-key $ETHERSCAN_API_KEY
 fi


### PR DESCRIPTION
Attempt at fixing the error from [this run](https://github.com/AztecProtocol/aztec-packages/actions/runs/18787851531/job/53610628682) where the verification failed due to a non-existing contract. In this run, CREATE_ROLLUP_CONTRACTS was set to false, so the `DEPLOY_ROLLUP_CONTRACTS_DIR` template did not run. My guess is that the `tf output` loaded the output from a different run on a different version which had this contract that no longer exists. In particular, `RewardDeploymentExtLib` exists in 2.0 but not in 2.1, the deployment that failed.
