### PR TITLE
chore!: EC add from ACIR, part 1

### DIFF
--- a/barretenberg/cpp/scripts/test_chonk_standalone_vks_havent_changed.sh
+++ b/barretenberg/cpp/scripts/test_chonk_standalone_vks_havent_changed.sh
@@ -13,7 +13,7 @@ cd ..
 # - Generate a hash for versioning: sha256sum bb-chonk-inputs.tar.gz
 # - Upload the compressed results: aws s3 cp bb-chonk-inputs.tar.gz s3://aztec-ci-artifacts/protocol/bb-chonk-inputs-[hash(0:8)].tar.gz
 # Note: In case of the "Test suite failed to run ... Unexpected token 'with' " error, need to run: docker pull aztecprotocol/build:3.0
-pinned_short_hash="16dc4478"
+pinned_short_hash="d6e05a05"
 pinned_chonk_inputs_url="https://aztec-ci-artifacts.s3.us-east-2.amazonaws.com/protocol/bb-chonk-inputs-${pinned_short_hash}.tar.gz"
 
 function compress_and_upload {

--- a/barretenberg/cpp/scripts/test_chonk_standalone_vks_havent_changed.sh
+++ b/barretenberg/cpp/scripts/test_chonk_standalone_vks_havent_changed.sh
@@ -13,7 +13,7 @@ cd ..
 # - Generate a hash for versioning: sha256sum bb-chonk-inputs.tar.gz
 # - Upload the compressed results: aws s3 cp bb-chonk-inputs.tar.gz s3://aztec-ci-artifacts/protocol/bb-chonk-inputs-[hash(0:8)].tar.gz
 # Note: In case of the "Test suite failed to run ... Unexpected token 'with' " error, need to run: docker pull aztecprotocol/build:3.0
-pinned_short_hash="d6e05a05"
+pinned_short_hash="84c467db"
 pinned_chonk_inputs_url="https://aztec-ci-artifacts.s3.us-east-2.amazonaws.com/protocol/bb-chonk-inputs-${pinned_short_hash}.tar.gz"
 
 function compress_and_upload {

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/ec_operations.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/ec_operations.cpp
@@ -52,6 +52,8 @@ void create_ec_add_constraint(Builder& builder, const EcAdd& input, bool has_val
         input.input1_x, input.input1_y, input.input1_infinite, has_valid_witness_assignments, predicate, builder);
     cycle_group_ct input2_point = to_grumpkin_point(
         input.input2_x, input.input2_y, input.input2_infinite, has_valid_witness_assignments, predicate, builder);
+    // Note that input_result is computed by Noir and passed to bb via ACIR. Hence, it is always a valid point on
+    // Grumpkin.
     cycle_group_ct input_result =
         has_valid_witness_assignments
             ? cycle_group_ct(input_result_x, input_result_y, input_result_infinite, /*assert_on_curve=*/false)
@@ -65,7 +67,7 @@ void create_ec_add_constraint(Builder& builder, const EcAdd& input, bool has_val
         result.assert_equal(to_be_asserted_equal);
     } else {
         // The assert_equal method standardizes both points before comparing, so if either of them is the point at
-        // infinity, the coordinates will be assigned to be (0,0). This is OK as long as developers do not use the
+        // infinity, the coordinates will be assigned to be (0,0). This is OK as long as Noir developers do not use the
         // coordinates of a point at infinity (otherwise input_result might be the point at infinity different from (0,
         // 0, true), and the fact that assert_equal passes doesn't imply anything for the original coordinates of
         // input_result).

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/ec_operations.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/ec_operations.cpp
@@ -60,9 +60,11 @@ void create_ec_add_constraint(Builder& builder, const EcAdd& input, bool has_val
 
         // Note that we do not need to assign input_result because for an honest user it passed by Noir and is always a
         // point on the curve.
-        auto affine_one = bb::grumpkin::g1::affine_one;
-        input1 = cycle_group_ct::conditional_assign(predicate, input1, cycle_group_ct(affine_one));
-        input2 = cycle_group_ct::conditional_assign(predicate, input2, cycle_group_ct(affine_one));
+        cycle_group_ct affine_one(bb::grumpkin::g1::affine_one);
+        input1 = cycle_group_ct::conditional_assign(predicate, input1, affine_one);
+        input2 = cycle_group_ct::conditional_assign(predicate, input2, affine_one);
+    } else {
+        BB_ASSERT(input.predicate.value, "Creating EcAdd constraints with a constant predicate equal to false.");
     }
 
     // Step 4.

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/ec_operations.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/ec_operations.cpp
@@ -43,10 +43,18 @@ void create_ec_add_constraint(Builder& builder, const EcAdd& input, bool has_val
     using bool_ct = bb::stdlib::bool_t<Builder>;
 
     // Step 1.
+    // bool_ct predicate = bool_ct(to_field_ct(input.predicate, builder));
+    bool_ct predicate = bool_ct::from_witness_index_unsafe(&builder, input.predicate.index);
+
     field_ct input_result_x = field_ct::from_witness_index(&builder, input.result_x);
     field_ct input_result_y = field_ct::from_witness_index(&builder, input.result_y);
     bool_ct input_result_infinite = bool_ct(field_ct::from_witness_index(&builder, input.result_infinite));
-    bool_ct predicate = bool_ct(to_field_ct(input.predicate, builder));
+
+    if (!has_valid_witness_assignments) {
+        builder.set_variable(input_result_x.get_witness_index(), bb::grumpkin::g1::affine_one.x);
+        builder.set_variable(input_result_y.get_witness_index(), bb::grumpkin::g1::affine_one.y);
+        builder.set_variable(input_result_infinite.get_witness_index(), bb::fr(0));
+    }
 
     cycle_group_ct input1_point = to_grumpkin_point(
         input.input1_x, input.input1_y, input.input1_infinite, has_valid_witness_assignments, predicate, builder);
@@ -54,10 +62,7 @@ void create_ec_add_constraint(Builder& builder, const EcAdd& input, bool has_val
         input.input2_x, input.input2_y, input.input2_infinite, has_valid_witness_assignments, predicate, builder);
     // Note that input_result is computed by Noir and passed to bb via ACIR. Hence, it is always a valid point on
     // Grumpkin.
-    cycle_group_ct input_result =
-        has_valid_witness_assignments
-            ? cycle_group_ct(input_result_x, input_result_y, input_result_infinite, /*assert_on_curve=*/false)
-            : cycle_group_ct(bb::grumpkin::g1::affine_one);
+    cycle_group_ct input_result(input_result_x, input_result_y, input_result_infinite, /*assert_on_curve=*/false);
 
     // Step 2.
     cycle_group_ct result = input1_point + input2_point;

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/ec_operations.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/ec_operations.cpp
@@ -13,6 +13,25 @@
 
 namespace acir_format {
 
+/**
+ * @brief Create constraints for addition of two points on the Grumpkin curve.
+ *
+ * @details We proceed in 5 steps:
+ * 1. We reconstruct the Grumpkin points input1, input2 and input_result for which we must check input1 + input2 =
+ *    input_result. NOTE: This step does not enforce that input1 and input2 are valid points on Grumpkin.
+ * 2. If we are in write_vk mode (the builder was constructed without a valid assignment of a witness vector), we
+ *    populate the fields of input1, input2 and input_result with dummy data.
+ * 3. If the predicate is not constant, we conditionally assign the values of input1 and input2 to avoid failures when
+ *    the constraint appears in an inactive branch (predicate is witness false). When the predicate is witness false, we
+ *    set input1 = input2 equal to the generator of the Grumpkin curve.
+ * 4. We check that input1 and input2 are valid points on the Grumpkin curve.
+ * 5. We compute input1 + input2 and check that it agrees with input_result.
+ *
+ * @tparam Builder
+ * @param builder
+ * @param input
+ * @param has_valid_witness_assignments
+ */
 template <typename Builder>
 void create_ec_add_constraint(Builder& builder, const EcAdd& input, bool has_valid_witness_assignments)
 {
@@ -21,24 +40,69 @@ void create_ec_add_constraint(Builder& builder, const EcAdd& input, bool has_val
     using field_ct = bb::stdlib::field_t<Builder>;
     using bool_ct = bb::stdlib::bool_t<Builder>;
 
-    auto input1_point = to_grumpkin_point(
-        input.input1_x, input.input1_y, input.input1_infinite, has_valid_witness_assignments, input.predicate, builder);
-    auto input2_point = to_grumpkin_point(
-        input.input2_x, input.input2_y, input.input2_infinite, has_valid_witness_assignments, input.predicate, builder);
-
-    // Compute the result of the addition
-    cycle_group_ct result = input1_point + input2_point;
-    // AUDITTODO: Is this necessary? If so, ensure cycle_group addition always returns standard form. If not, clarify.
-    result.standardize();
-
-    // Create copy-constraints between the computed result and the expected result stored in the input witness indices
+    // Step 1.
     field_ct input_result_x = field_ct::from_witness_index(&builder, input.result_x);
     field_ct input_result_y = field_ct::from_witness_index(&builder, input.result_y);
-    bool_ct input_result_infinite = bool_ct(field_ct::from_witness_index(&builder, input.result_infinite));
+    field_ct input_result_infinite = field_ct::from_witness_index(&builder, input.result_infinite);
+    bool_ct predicate;
 
-    result.x().assert_equal(input_result_x);
-    result.y().assert_equal(input_result_y);
-    result.is_point_at_infinity().assert_equal(input_result_infinite);
+    cycle_group_ct input1 = to_grumpkin_point_unsafe(builder, input.input1_x, input.input1_y, input.input1_infinite);
+    cycle_group_ct input2 = to_grumpkin_point_unsafe(builder, input.input2_x, input.input2_y, input.input2_infinite);
+    cycle_group_ct input_result(
+        input_result_x, input_result_y, static_cast<bool_ct>(input_result_infinite), /*assert_on_curve=*/true);
+
+    // Step 2.
+    if (!has_valid_witness_assignments) {
+        create_dummy_ec_add_constraint(builder, input1, input2, input_result);
+    }
+
+    // Step 3.
+    if (!input.predicate.is_constant) {
+        predicate = static_cast<bool_ct>(to_field_ct(input.predicate, builder));
+
+        // SHOULD WE CONDITIONALLY ASSIGN INPUT_RESULT AS WELL? - NO BECAUSE INPUT RESULT IS PASSED BY NOIR, SO IT IS
+        // ALWAYS A POINT ON THE CURVE FOR HONEST USERS
+        auto affine_one = bb::grumpkin::g1::affine_one;
+        input1 = cycle_group_ct::conditional_assign(predicate, input1, cycle_group_ct(affine_one));
+        input2 = cycle_group_ct::conditional_assign(predicate, input2, cycle_group_ct(affine_one));
+    }
+
+    // Step 4.
+    // Q: DO WE WANT TO ALSO CHECK THAT THE COORDINATES ARE UNIQUE?
+    input1.validate_on_curve();
+    input2.validate_on_curve();
+
+    // Step 5.
+    cycle_group_ct result = input1 + input2;
+
+    if (!input.predicate.is_constant) {
+        cycle_group_ct to_be_asserted_equal = cycle_group_ct::conditional_assign(predicate, input_result, result);
+        result.assert_equal(to_be_asserted_equal);
+    } else {
+        // WHAT THIS METHOD DOES IS TO MAKE BOTH SIDES STANDARD (I.E. (0,0) IF INFINITY) AND THEN COMPARE X, Y, AND
+        // INFINITY FLAG. THIS IS OK AS LONG AS THE CALLER OF THIS METHOD DOES NOT DO ANYTHING WITH THE X AND Y
+        // COORDINATES OF THE POINT. THIS IS BECAUSE IF (X, Y, TRUE) IS PASSED AS RESULT AND THEN THE DEV USES (X, Y)
+        // EXPECTING THEM TO BE (0,0) WHEN THE POINT IS AT INFINITY, THIS MIGHT NOT BE THE CASE (EVEN THOUGH NOIR
+        // CURRENTLY SETS X = Y = 0 WHEN THE RESULT OF AN OPERATION IS THE POINT AT INFINITY)
+        result.assert_equal(input_result);
+    }
+}
+
+template <typename Builder>
+void create_dummy_ec_add_constraint(Builder& builder,
+                                    const bb::stdlib::cycle_group<Builder>& input1,
+                                    const bb::stdlib::cycle_group<Builder>& input2,
+                                    const bb::stdlib::cycle_group<Builder>& input_result)
+{
+    auto affine_one = bb::grumpkin::g1::affine_one;
+
+    for (auto const& input : { input1, input2, input_result }) {
+        if (!input.is_constant()) {
+            builder.set_variable(input1.x().get_witness_index(), affine_one.x);
+            builder.set_variable(input1.y().get_witness_index(), affine_one.y);
+            builder.set_variable(input1.is_point_at_infinity().get_witness_index(), false);
+        }
+    }
 }
 
 template void create_ec_add_constraint<bb::UltraCircuitBuilder>(bb::UltraCircuitBuilder& builder,
@@ -47,5 +111,17 @@ template void create_ec_add_constraint<bb::UltraCircuitBuilder>(bb::UltraCircuit
 template void create_ec_add_constraint<bb::MegaCircuitBuilder>(bb::MegaCircuitBuilder& builder,
                                                                const EcAdd& input,
                                                                bool has_valid_witness_assignments);
+
+template void create_dummy_ec_add_constraint<bb::UltraCircuitBuilder>(
+    bb::UltraCircuitBuilder& builder,
+    const bb::stdlib::cycle_group<bb::UltraCircuitBuilder>& input1,
+    const bb::stdlib::cycle_group<bb::UltraCircuitBuilder>& input2,
+    const bb::stdlib::cycle_group<bb::UltraCircuitBuilder>& input_result);
+
+template void create_dummy_ec_add_constraint<bb::MegaCircuitBuilder>(
+    bb::MegaCircuitBuilder& builder,
+    const bb::stdlib::cycle_group<bb::MegaCircuitBuilder>& input1,
+    const bb::stdlib::cycle_group<bb::MegaCircuitBuilder>& input2,
+    const bb::stdlib::cycle_group<bb::MegaCircuitBuilder>& input_result);
 
 } // namespace acir_format

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/ec_operations.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/ec_operations.cpp
@@ -35,7 +35,6 @@ namespace acir_format {
 template <typename Builder>
 void create_ec_add_constraint(Builder& builder, const EcAdd& input, bool has_valid_witness_assignments)
 {
-    // Input to cycle_group points
     using cycle_group_ct = bb::stdlib::cycle_group<Builder>;
     using field_ct = bb::stdlib::field_t<Builder>;
     using bool_ct = bb::stdlib::bool_t<Builder>;
@@ -43,13 +42,12 @@ void create_ec_add_constraint(Builder& builder, const EcAdd& input, bool has_val
     // Step 1.
     field_ct input_result_x = field_ct::from_witness_index(&builder, input.result_x);
     field_ct input_result_y = field_ct::from_witness_index(&builder, input.result_y);
-    field_ct input_result_infinite = field_ct::from_witness_index(&builder, input.result_infinite);
-    bool_ct predicate;
+    bool_ct input_result_infinite = static_cast<bool_ct>(field_ct::from_witness_index(&builder, input.result_infinite));
+    bool_ct predicate; // To be instantiated in Step 3 if needed.
 
     cycle_group_ct input1 = to_grumpkin_point_unsafe(builder, input.input1_x, input.input1_y, input.input1_infinite);
     cycle_group_ct input2 = to_grumpkin_point_unsafe(builder, input.input2_x, input.input2_y, input.input2_infinite);
-    cycle_group_ct input_result(
-        input_result_x, input_result_y, static_cast<bool_ct>(input_result_infinite), /*assert_on_curve=*/true);
+    cycle_group_ct input_result(input_result_x, input_result_y, input_result_infinite, /*assert_on_curve=*/true);
 
     // Step 2.
     if (!has_valid_witness_assignments) {
@@ -60,15 +58,15 @@ void create_ec_add_constraint(Builder& builder, const EcAdd& input, bool has_val
     if (!input.predicate.is_constant) {
         predicate = static_cast<bool_ct>(to_field_ct(input.predicate, builder));
 
-        // SHOULD WE CONDITIONALLY ASSIGN INPUT_RESULT AS WELL? - NO BECAUSE INPUT RESULT IS PASSED BY NOIR, SO IT IS
-        // ALWAYS A POINT ON THE CURVE FOR HONEST USERS
+        // Note that we do not need to assign input_result because for an honest user it passed by Noir and is always a
+        // point on the curve.
         auto affine_one = bb::grumpkin::g1::affine_one;
         input1 = cycle_group_ct::conditional_assign(predicate, input1, cycle_group_ct(affine_one));
         input2 = cycle_group_ct::conditional_assign(predicate, input2, cycle_group_ct(affine_one));
     }
 
     // Step 4.
-    // Q: DO WE WANT TO ALSO CHECK THAT THE COORDINATES ARE UNIQUE?
+    // AUDITTODO: Do we want also check that the coordinates are smaller than the field modulus?
     input1.validate_on_curve();
     input2.validate_on_curve();
 
@@ -79,11 +77,11 @@ void create_ec_add_constraint(Builder& builder, const EcAdd& input, bool has_val
         cycle_group_ct to_be_asserted_equal = cycle_group_ct::conditional_assign(predicate, input_result, result);
         result.assert_equal(to_be_asserted_equal);
     } else {
-        // WHAT THIS METHOD DOES IS TO MAKE BOTH SIDES STANDARD (I.E. (0,0) IF INFINITY) AND THEN COMPARE X, Y, AND
-        // INFINITY FLAG. THIS IS OK AS LONG AS THE CALLER OF THIS METHOD DOES NOT DO ANYTHING WITH THE X AND Y
-        // COORDINATES OF THE POINT. THIS IS BECAUSE IF (X, Y, TRUE) IS PASSED AS RESULT AND THEN THE DEV USES (X, Y)
-        // EXPECTING THEM TO BE (0,0) WHEN THE POINT IS AT INFINITY, THIS MIGHT NOT BE THE CASE (EVEN THOUGH NOIR
-        // CURRENTLY SETS X = Y = 0 WHEN THE RESULT OF AN OPERATION IS THE POINT AT INFINITY)
+        // The assert_equal method standardizes both points before comparing, so if either of them is the point at
+        // infinity, the coordinates will be assigned to be (0,0). This is OK as long as developers do not use the
+        // coordinates of a point at infinity (otherwise input_result might be the point at infinity different from (0,
+        // 0, true), and the fact that assert_equal passes doesn't imply anything for the original coordinates of
+        // input_result).
         result.assert_equal(input_result);
     }
 }
@@ -98,9 +96,9 @@ void create_dummy_ec_add_constraint(Builder& builder,
 
     for (auto const& input : { input1, input2, input_result }) {
         if (!input.is_constant()) {
-            builder.set_variable(input1.x().get_witness_index(), affine_one.x);
-            builder.set_variable(input1.y().get_witness_index(), affine_one.y);
-            builder.set_variable(input1.is_point_at_infinity().get_witness_index(), false);
+            builder.set_variable(input.x().get_witness_index(), affine_one.x);
+            builder.set_variable(input.y().get_witness_index(), affine_one.y);
+            builder.set_variable(input.is_point_at_infinity().get_witness_index(), false);
         }
     }
 }

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/ec_operations.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/ec_operations.cpp
@@ -19,9 +19,16 @@ namespace acir_format {
  * @details We proceed in 2 steps:
  * 1. We reconstruct the Grumpkin points input1, input2 and input_result for which we must check input1 + input2 =
  *    input_result. The reconstruction handles all cases: has_valid_witness_assignments equal to false (write_vk
- *    scenario) and a witness predicate. If either has_valid_witness_assignments if false or the predicate is witness
- *    false, we set input1 and input2 to be the generator of Grumpkin.
+ *    scenario) and a witness predicate. If:
+ *      - has_valid_witness_assignments is false, then we set input1 = input2 = input_result equal to the generator of
+ *        Grumpkin
+ *      - the predicate is witness false, we set input1 and input2 to be the generator of Grumpkin.
  * 2. We compute input1 + input2 and check that it agrees with input_result.
+ *
+ * @note We do not need to enforce in-circuit that input_result is on the curve because we check that input_result is
+ * equal to result, which we know is on the curve as it is the sum of two points on the curve. In the case of predicate
+ * equal to witness false, the constraint is supposed to be inactive, so we even if input_result is not checked to be on
+ * the curve in this case, it is OK.
  *
  * @tparam Builder
  * @param builder
@@ -45,7 +52,10 @@ void create_ec_add_constraint(Builder& builder, const EcAdd& input, bool has_val
         input.input1_x, input.input1_y, input.input1_infinite, has_valid_witness_assignments, predicate, builder);
     cycle_group_ct input2_point = to_grumpkin_point(
         input.input2_x, input.input2_y, input.input2_infinite, has_valid_witness_assignments, predicate, builder);
-    cycle_group_ct input_result(input_result_x, input_result_y, input_result_infinite, /*assert_on_curve=*/true);
+    cycle_group_ct input_result =
+        has_valid_witness_assignments
+            ? cycle_group_ct(input_result_x, input_result_y, input_result_infinite, /*assert_on_curve=*/false)
+            : cycle_group_ct(bb::grumpkin::g1::affine_one);
 
     // Step 2.
     cycle_group_ct result = input1_point + input2_point;

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/ec_operations.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/ec_operations.cpp
@@ -16,16 +16,12 @@ namespace acir_format {
 /**
  * @brief Create constraints for addition of two points on the Grumpkin curve.
  *
- * @details We proceed in 5 steps:
+ * @details We proceed in 2 steps:
  * 1. We reconstruct the Grumpkin points input1, input2 and input_result for which we must check input1 + input2 =
- *    input_result. NOTE: This step does not enforce that input1 and input2 are valid points on Grumpkin.
- * 2. If we are in write_vk mode (the builder was constructed without a valid assignment of a witness vector), we
- *    populate the fields of input1, input2 and input_result with dummy data.
- * 3. If the predicate is not constant, we conditionally assign the values of input1 and input2 to avoid failures when
- *    the constraint appears in an inactive branch (predicate is witness false). When the predicate is witness false, we
- *    set input1 = input2 equal to the generator of the Grumpkin curve.
- * 4. We check that input1 and input2 are valid points on the Grumpkin curve.
- * 5. We compute input1 + input2 and check that it agrees with input_result.
+ *    input_result. The reconstruction handles all cases: has_valid_witness_assignments equal to false (write_vk
+ *    scenario) and a witness predicate. If either has_valid_witness_assignments if false or the predicate is witness
+ *    false, we set input1 and input2 to be the generator of Grumpkin.
+ * 2. We compute input1 + input2 and check that it agrees with input_result.
  *
  * @tparam Builder
  * @param builder
@@ -42,40 +38,19 @@ void create_ec_add_constraint(Builder& builder, const EcAdd& input, bool has_val
     // Step 1.
     field_ct input_result_x = field_ct::from_witness_index(&builder, input.result_x);
     field_ct input_result_y = field_ct::from_witness_index(&builder, input.result_y);
-    bool_ct input_result_infinite = static_cast<bool_ct>(field_ct::from_witness_index(&builder, input.result_infinite));
-    bool_ct predicate; // To be instantiated in Step 3 if needed.
+    bool_ct input_result_infinite = bool_ct(field_ct::from_witness_index(&builder, input.result_infinite));
+    bool_ct predicate = bool_ct(to_field_ct(input.predicate, builder));
 
-    cycle_group_ct input1 = to_grumpkin_point_unsafe(builder, input.input1_x, input.input1_y, input.input1_infinite);
-    cycle_group_ct input2 = to_grumpkin_point_unsafe(builder, input.input2_x, input.input2_y, input.input2_infinite);
+    cycle_group_ct input1_point = to_grumpkin_point(
+        input.input1_x, input.input1_y, input.input1_infinite, has_valid_witness_assignments, predicate, builder);
+    cycle_group_ct input2_point = to_grumpkin_point(
+        input.input2_x, input.input2_y, input.input2_infinite, has_valid_witness_assignments, predicate, builder);
     cycle_group_ct input_result(input_result_x, input_result_y, input_result_infinite, /*assert_on_curve=*/true);
 
     // Step 2.
-    if (!has_valid_witness_assignments) {
-        create_dummy_ec_add_constraint(builder, input1, input2, input_result);
-    }
+    cycle_group_ct result = input1_point + input2_point;
 
-    // Step 3.
-    if (!input.predicate.is_constant) {
-        predicate = static_cast<bool_ct>(to_field_ct(input.predicate, builder));
-
-        // Note that we do not need to assign input_result because for an honest user it passed by Noir and is always a
-        // point on the curve.
-        cycle_group_ct affine_one(bb::grumpkin::g1::affine_one);
-        input1 = cycle_group_ct::conditional_assign(predicate, input1, affine_one);
-        input2 = cycle_group_ct::conditional_assign(predicate, input2, affine_one);
-    } else {
-        BB_ASSERT(input.predicate.value, "Creating EcAdd constraints with a constant predicate equal to false.");
-    }
-
-    // Step 4.
-    // AUDITTODO: Do we want also check that the coordinates are smaller than the field modulus?
-    input1.validate_on_curve();
-    input2.validate_on_curve();
-
-    // Step 5.
-    cycle_group_ct result = input1 + input2;
-
-    if (!input.predicate.is_constant) {
+    if (!predicate.is_constant()) {
         cycle_group_ct to_be_asserted_equal = cycle_group_ct::conditional_assign(predicate, input_result, result);
         result.assert_equal(to_be_asserted_equal);
     } else {
@@ -88,40 +63,11 @@ void create_ec_add_constraint(Builder& builder, const EcAdd& input, bool has_val
     }
 }
 
-template <typename Builder>
-void create_dummy_ec_add_constraint(Builder& builder,
-                                    const bb::stdlib::cycle_group<Builder>& input1,
-                                    const bb::stdlib::cycle_group<Builder>& input2,
-                                    const bb::stdlib::cycle_group<Builder>& input_result)
-{
-    auto affine_one = bb::grumpkin::g1::affine_one;
-
-    for (auto const& input : { input1, input2, input_result }) {
-        if (!input.is_constant()) {
-            builder.set_variable(input.x().get_witness_index(), affine_one.x);
-            builder.set_variable(input.y().get_witness_index(), affine_one.y);
-            builder.set_variable(input.is_point_at_infinity().get_witness_index(), false);
-        }
-    }
-}
-
 template void create_ec_add_constraint<bb::UltraCircuitBuilder>(bb::UltraCircuitBuilder& builder,
                                                                 const EcAdd& input,
                                                                 bool has_valid_witness_assignments);
 template void create_ec_add_constraint<bb::MegaCircuitBuilder>(bb::MegaCircuitBuilder& builder,
                                                                const EcAdd& input,
                                                                bool has_valid_witness_assignments);
-
-template void create_dummy_ec_add_constraint<bb::UltraCircuitBuilder>(
-    bb::UltraCircuitBuilder& builder,
-    const bb::stdlib::cycle_group<bb::UltraCircuitBuilder>& input1,
-    const bb::stdlib::cycle_group<bb::UltraCircuitBuilder>& input2,
-    const bb::stdlib::cycle_group<bb::UltraCircuitBuilder>& input_result);
-
-template void create_dummy_ec_add_constraint<bb::MegaCircuitBuilder>(
-    bb::MegaCircuitBuilder& builder,
-    const bb::stdlib::cycle_group<bb::MegaCircuitBuilder>& input1,
-    const bb::stdlib::cycle_group<bb::MegaCircuitBuilder>& input2,
-    const bb::stdlib::cycle_group<bb::MegaCircuitBuilder>& input_result);
 
 } // namespace acir_format

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/ec_operations.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/ec_operations.cpp
@@ -43,8 +43,7 @@ void create_ec_add_constraint(Builder& builder, const EcAdd& input, bool has_val
     using bool_ct = bb::stdlib::bool_t<Builder>;
 
     // Step 1.
-    // bool_ct predicate = bool_ct(to_field_ct(input.predicate, builder));
-    bool_ct predicate = bool_ct::from_witness_index_unsafe(&builder, input.predicate.index);
+    bool_ct predicate = bool_ct(to_field_ct(input.predicate, builder));
 
     field_ct input_result_x = field_ct::from_witness_index(&builder, input.result_x);
     field_ct input_result_y = field_ct::from_witness_index(&builder, input.result_y);

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/ec_operations.hpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/ec_operations.hpp
@@ -26,8 +26,8 @@ namespace acir_format {
  * - result_y: witness index for the y-coordinate of the resulting point
  * - result_infinite: witness index for the flag indicating if the result is the point at infinity
  *
- * The data related to input1 and input2 can either be given by witnesses or constants. However, data pertaining to the
- * same input must be either all witnesses or all constants.
+ * The data related to input1 and input2 can either be given by witnesses or constants. However, x and y coordinates
+ * pertaining to the same input must be either all witnesses or all constants.
  */
 struct EcAdd {
     WitnessOrConstant<bb::fr> input1_x;

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/ec_operations.hpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/ec_operations.hpp
@@ -60,10 +60,4 @@ struct EcAdd {
 
 template <typename Builder>
 void create_ec_add_constraint(Builder& builder, const EcAdd& input, bool has_valid_witness_assignments);
-
-template <typename Builder>
-void create_dummy_ec_add_constraint(Builder& builder,
-                                    const bb::stdlib::cycle_group<Builder>& input1,
-                                    const bb::stdlib::cycle_group<Builder>& input2,
-                                    const bb::stdlib::cycle_group<Builder>& input_result);
 } // namespace acir_format

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/ec_operations.hpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/ec_operations.hpp
@@ -17,10 +17,10 @@ namespace acir_format {
  * @details EcAdd constraints have 10 components:
  * - input1_x: x-coordinate of the first input point
  * - input1_y: y-coordinate of the first input point
- * - input1_infinite: flag indicating if the first input point is at infinity
+ * - input1_infinite: flag indicating if the first input point is the point at infinity
  * - input2_x: x-coordinate of the second input point
  * - input2_y: y-coordinate of the second input point
- * - input2_infinite: flag indicating if the second input point is at infinity
+ * - input2_infinite: flag indicating if the second input point is the point at infinity
  * - predicate: flag indicating whether the constraint is active
  * - result_x: witness index for the x-coordinate of the resulting point
  * - result_y: witness index for the y-coordinate of the resulting point

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/ec_operations.hpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/ec_operations.hpp
@@ -11,6 +11,24 @@
 
 namespace acir_format {
 
+/**
+ * @brief Constraints for addition of two points on the Grumpkin curve.
+ *
+ * @details EcAdd constraints have 10 components:
+ * - input1_x: x-coordinate of the first input point
+ * - input1_y: y-coordinate of the first input point
+ * - input1_infinite: flag indicating if the first input point is at infinity
+ * - input2_x: x-coordinate of the second input point
+ * - input2_y: y-coordinate of the second input point
+ * - input2_infinite: flag indicating if the second input point is at infinity
+ * - predicate: flag indicating whether the constraint is active
+ * - result_x: witness index for the x-coordinate of the resulting point
+ * - result_y: witness index for the y-coordinate of the resulting point
+ * - result_infinite: witness index for the flag indicating if the result is the point at infinity
+ *
+ * The data related to input1 and input2 can either be given by witnesses or constants. However, data pertaining to the
+ * same input must be either all witnesses or all constants.
+ */
 struct EcAdd {
     WitnessOrConstant<bb::fr> input1_x;
     WitnessOrConstant<bb::fr> input1_y;
@@ -42,4 +60,10 @@ struct EcAdd {
 
 template <typename Builder>
 void create_ec_add_constraint(Builder& builder, const EcAdd& input, bool has_valid_witness_assignments);
+
+template <typename Builder>
+void create_dummy_ec_add_constraint(Builder& builder,
+                                    const bb::stdlib::cycle_group<Builder>& input1,
+                                    const bb::stdlib::cycle_group<Builder>& input2,
+                                    const bb::stdlib::cycle_group<Builder>& input_result);
 } // namespace acir_format

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/ec_operations.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/ec_operations.test.cpp
@@ -75,6 +75,7 @@ TEST_F(EcOperations, TestECOperations)
 
 TEST_F(EcOperations, TestECPredicate)
 {
+    BB_DISABLE_ASSERTS();
     EcAdd ec_add_constraint;
 
     WitnessVector witness_values;

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/ec_operations.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/ec_operations.test.cpp
@@ -75,7 +75,6 @@ TEST_F(EcOperations, TestECOperations)
 
 TEST_F(EcOperations, TestECPredicate)
 {
-    BB_DISABLE_ASSERTS();
     EcAdd ec_add_constraint;
 
     WitnessVector witness_values;

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/multi_scalar_mul.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/multi_scalar_mul.cpp
@@ -26,6 +26,8 @@ void create_multi_scalar_mul_constraint(Builder& builder,
     using field_ct = stdlib::field_t<Builder>;
     using bool_ct = stdlib::bool_t<Builder>;
 
+    bool_ct predicate = bool_ct(to_field_ct(input.predicate, builder));
+
     std::vector<cycle_group_ct> points;
     std::vector<cycle_scalar_ct> scalars;
 
@@ -35,7 +37,7 @@ void create_multi_scalar_mul_constraint(Builder& builder,
                                                        input.points[i + 1],
                                                        input.points[i + 2],
                                                        has_valid_witness_assignments,
-                                                       input.predicate,
+                                                       predicate,
                                                        builder);
 
         //  Reconstruct the scalar from the low and high limbs

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/witness_constant.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/witness_constant.cpp
@@ -16,7 +16,7 @@ using namespace bb::stdlib;
  * @brief Convert inputs representing a Grumpkin point into a cycle_group element.
  * @details Inputs x, y, and is_infinite are used to construct the point. We handle two cases:
  *  1. has_valid_witness_assignments is false:  we are in a write_vk scenario. In this case, we set the point to be the
- * generator of Grumpink.
+ * generator of Grumpkin.
  *  2. predicate is a witness: we conditionally assign the point depending on the predicate; if it is witness true, we
  * use the witnesses provided, otherwise, we set the point to be the generator of Grumpkin.
  *

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/witness_constant.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/witness_constant.cpp
@@ -13,31 +13,12 @@ using namespace bb;
 using namespace bb::stdlib;
 
 /**
- * @brief Construct a Grumpkin point from WitnessOrConstants representing x and y coordinates, and the infinity flag. It
- * does NOT enforce that the resulting point is on the curve.
- */
-template <typename Builder>
-bb::stdlib::cycle_group<Builder> to_grumpkin_point_unsafe(Builder& builder,
-                                                          const WitnessOrConstant<typename Builder::FF>& input_x,
-                                                          const WitnessOrConstant<typename Builder::FF>& input_y,
-                                                          const WitnessOrConstant<typename Builder::FF>& input_infinite)
-{
-    using bool_ct = bb::stdlib::bool_t<Builder>;
-    using field_ct = bb::stdlib::field_t<Builder>;
-
-    field_ct point_x = to_field_ct(input_x, builder);
-    field_ct point_y = to_field_ct(input_y, builder);
-    bool_ct infinite = static_cast<bool_ct>(to_field_ct(input_infinite, builder));
-
-    return cycle_group<Builder>(point_x, point_y, infinite, /*assert_on_curve=*/false);
-}
-
-/**
  * @brief Convert inputs representing a Grumpkin point into a cycle_group element.
- * @details Inputs x, y, and is_infinite are used to construct the point. If no valid witness is provided or if the
- * predicate is constant false, the point is set to the generator point. If the predicate is a non-constant witness, the
- * point is conditionally assigned to the generator point based on the predicate value. This ensures that the point is
- * always valid and will not trigger any on_curve assertions.
+ * @details Inputs x, y, and is_infinite are used to construct the point. We handle two cases:
+ *  1. has_valid_witness_assignments is false:  we are in a write_vk scenario. In this case, we set the point to be the
+ * generator of Grumpink.
+ *  2. predicate is a witness: we conditionally assign the point depending on the predicate; if it is witness true, we
+ * use the witnesses provided, otherwise, we set the point to be the generator of Grumpkin.
  *
  * @tparam Builder
  * @tparam FF
@@ -54,75 +35,51 @@ bb::stdlib::cycle_group<Builder> to_grumpkin_point(const WitnessOrConstant<FF>& 
                                                    const WitnessOrConstant<FF>& input_y,
                                                    const WitnessOrConstant<FF>& input_infinite,
                                                    bool has_valid_witness_assignments,
-                                                   const WitnessOrConstant<FF>& predicate,
+                                                   const bb::stdlib::bool_t<Builder>& predicate,
                                                    Builder& builder)
 {
     using bool_ct = bb::stdlib::bool_t<Builder>;
     using field_ct = bb::stdlib::field_t<Builder>;
+
+    bool constant_coordinates = input_x.is_constant && input_y.is_constant;
+
     auto point_x = to_field_ct(input_x, builder);
     auto point_y = to_field_ct(input_y, builder);
     auto infinite = bool_ct(to_field_ct(input_infinite, builder));
 
-    // Coordinates should not have mixed constancy. In the case they do, convert constant coordinate to fixed witness.
-    BB_ASSERT_EQ(input_x.is_constant, input_y.is_constant, "to_grumpkin_point: Inconsistent constancy of coordinates");
-    // TODO(https://github.com/AztecProtocol/aztec-packages/issues/17514): Avoid mixing constant/witness coordinates
-    if (point_x.is_constant() != point_y.is_constant()) {
-        if (point_x.is_constant()) {
-            point_x.convert_constant_to_fixed_witness(&builder);
-        } else if (point_y.is_constant()) {
-            point_y.convert_constant_to_fixed_witness(&builder);
-        }
-    }
-
-    bool constant_coordinates = input_x.is_constant && input_y.is_constant;
-
-    // In a witness is not provided we ensure the coordinates correspond to a valid point to avoid erroneous failures
-    // during circuit construction. We only do this if the coordinates are non-constant since otherwise no variable
-    // indices exist.
+    // In a witness is not provided (we are in a write_vk scenario) we ensure the coordinates correspond to a valid
+    // point to avoid erroneous failures during circuit construction. We only do this if the coordinates are
+    // non-constant since otherwise no variable indices exist.
     if (!has_valid_witness_assignments && !constant_coordinates) {
-        auto one = bb::grumpkin::g1::affine_one;
-        builder.set_variable(input_x.index, one.x);
-        builder.set_variable(input_y.index, one.y);
+        builder.set_variable(input_x.index, bb::grumpkin::g1::affine_one.x);
+        builder.set_variable(input_y.index, bb::grumpkin::g1::affine_one.y);
     }
 
     // If the predicate is a non-constant witness, conditionally replace coordinates with a valid point.
-    // Note: this must be done before constructing the cycle_group to avoid triggering on_curve assertions
-    if (!predicate.is_constant) {
-        bool_ct predicate_witness = bool_ct::from_witness_index_unsafe(&builder, predicate.index);
-        auto generator = bb::grumpkin::g1::affine_one;
-        point_x = field_ct::conditional_assign(predicate_witness, point_x, generator.x);
-        point_y = field_ct::conditional_assign(predicate_witness, point_y, generator.y);
-        bool_ct generator_is_infinity = bool_ct(&builder, generator.is_point_at_infinity());
-        infinite = bool_ct::conditional_assign(predicate_witness, infinite, generator_is_infinity);
+    if (!predicate.is_constant()) {
+        point_x = field_ct::conditional_assign(predicate, point_x, field_ct(bb::grumpkin::g1::affine_one.x));
+        point_y = field_ct::conditional_assign(predicate, point_y, field_ct(bb::grumpkin::g1::affine_one.y));
+        infinite = bool_ct::conditional_assign(predicate, infinite, bool_ct(false));
+    } else {
+        BB_ASSERT(predicate.get_value(), "Creating Grumpkin point with a constant predicate equal to false.");
     }
 
     cycle_group<Builder> input_point(point_x, point_y, infinite, /*assert_on_curve=*/true);
     return input_point;
 }
 
-template bb::stdlib::cycle_group<UltraCircuitBuilder> to_grumpkin_point(const WitnessOrConstant<fr>& input_x,
-                                                                        const WitnessOrConstant<fr>& input_y,
-                                                                        const WitnessOrConstant<fr>& input_infinite,
-                                                                        bool has_valid_witness_assignments,
-                                                                        const WitnessOrConstant<fr>& predicate,
-                                                                        UltraCircuitBuilder& builder);
-template bb::stdlib::cycle_group<MegaCircuitBuilder> to_grumpkin_point(const WitnessOrConstant<fr>& input_x,
-                                                                       const WitnessOrConstant<fr>& input_y,
-                                                                       const WitnessOrConstant<fr>& input_infinite,
-                                                                       bool has_valid_witness_assignments,
-                                                                       const WitnessOrConstant<fr>& predicate,
-                                                                       MegaCircuitBuilder& builder);
-
-template bb::stdlib::cycle_group<UltraCircuitBuilder> to_grumpkin_point_unsafe(
-    UltraCircuitBuilder& builder,
+template bb::stdlib::cycle_group<UltraCircuitBuilder> to_grumpkin_point(
     const WitnessOrConstant<fr>& input_x,
     const WitnessOrConstant<fr>& input_y,
-    const WitnessOrConstant<fr>& input_infinite);
-
-template bb::stdlib::cycle_group<MegaCircuitBuilder> to_grumpkin_point_unsafe(
-    MegaCircuitBuilder& builder,
+    const WitnessOrConstant<fr>& input_infinite,
+    bool has_valid_witness_assignments,
+    const bb::stdlib::bool_t<UltraCircuitBuilder>& predicate,
+    UltraCircuitBuilder& builder);
+template bb::stdlib::cycle_group<MegaCircuitBuilder> to_grumpkin_point(
     const WitnessOrConstant<fr>& input_x,
     const WitnessOrConstant<fr>& input_y,
-    const WitnessOrConstant<fr>& input_infinite);
-
+    const WitnessOrConstant<fr>& input_infinite,
+    bool has_valid_witness_assignments,
+    const bb::stdlib::bool_t<MegaCircuitBuilder>& predicate,
+    MegaCircuitBuilder& builder);
 } // namespace acir_format

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/witness_constant.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/witness_constant.cpp
@@ -16,9 +16,9 @@ using namespace bb::stdlib;
  * @brief Convert inputs representing a Grumpkin point into a cycle_group element.
  * @details Inputs x, y, and is_infinite are used to construct the point. We handle two cases:
  *  1. has_valid_witness_assignments is false:  we are in a write_vk scenario. In this case, we set the point to be the
- * generator of Grumpkin.
+ *     generator of Grumpkin.
  *  2. predicate is a witness: we conditionally assign the point depending on the predicate; if it is witness true, we
- * use the witnesses provided, otherwise, we set the point to be the generator of Grumpkin.
+ *     use the witnesses provided, otherwise, we set the point to be the generator of Grumpkin.
  *
  * @tparam Builder
  * @tparam FF
@@ -49,7 +49,9 @@ bb::stdlib::cycle_group<Builder> to_grumpkin_point(const WitnessOrConstant<typen
 
     // If a witness is not provided (we are in a write_vk scenario) we ensure the coordinates correspond to a valid
     // point to avoid erroneous failures during circuit construction. We only do this if the coordinates are
-    // non-constant since otherwise no variable indices exist.
+    // non-constant since otherwise no variable indices exist. Note that there is no need to assign the infinite flag
+    // because native on-curve checks will always pass as long x and y coordinates correspond to a valid point on
+    // Grumpkin.
     if (!has_valid_witness_assignments && !constant_coordinates) {
         builder.set_variable(input_x.index, bb::grumpkin::g1::affine_one.x);
         builder.set_variable(input_y.index, bb::grumpkin::g1::affine_one.y);

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/witness_constant.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/witness_constant.cpp
@@ -13,6 +13,26 @@ using namespace bb;
 using namespace bb::stdlib;
 
 /**
+ * @brief Construct a Grumpkin point from WitnessOrConstants representing x and y coordinates, and the infinity flag. It
+ * does NOT enforce that the resulting point is on the curve.
+ */
+template <typename Builder>
+bb::stdlib::cycle_group<Builder> to_grumpkin_point_unsafe(Builder& builder,
+                                                          const WitnessOrConstant<typename Builder::FF>& input_x,
+                                                          const WitnessOrConstant<typename Builder::FF>& input_y,
+                                                          const WitnessOrConstant<typename Builder::FF>& input_infinite)
+{
+    using bool_ct = bb::stdlib::bool_t<Builder>;
+    using field_ct = bb::stdlib::field_t<Builder>;
+
+    field_ct point_x = to_field_ct(input_x, builder);
+    field_ct point_y = to_field_ct(input_y, builder);
+    bool_ct infinite = static_cast<bool_ct>(to_field_ct(input_infinite, builder));
+
+    return cycle_group<Builder>(point_x, point_y, infinite, /*assert_on_curve=*/false);
+}
+
+/**
  * @brief Convert inputs representing a Grumpkin point into a cycle_group element.
  * @details Inputs x, y, and is_infinite are used to construct the point. If no valid witness is provided or if the
  * predicate is constant false, the point is set to the generator point. If the predicate is a non-constant witness, the
@@ -56,11 +76,10 @@ bb::stdlib::cycle_group<Builder> to_grumpkin_point(const WitnessOrConstant<FF>& 
 
     bool constant_coordinates = input_x.is_constant && input_y.is_constant;
 
-    // In a witness is not provided, or the relevant predicate is constant false, we ensure the coordinates correspond
-    // to a valid point to avoid erroneous failures during circuit construction. We only do this if the coordinates are
-    // non-constant since otherwise no variable indices exist.
-    bool constant_false_predicate = predicate.is_constant && predicate.value == FF(0);
-    if ((!has_valid_witness_assignments || constant_false_predicate) && !constant_coordinates) {
+    // In a witness is not provided we ensure the coordinates correspond to a valid point to avoid erroneous failures
+    // during circuit construction. We only do this if the coordinates are non-constant since otherwise no variable
+    // indices exist.
+    if (!has_valid_witness_assignments && !constant_coordinates) {
         auto one = bb::grumpkin::g1::affine_one;
         builder.set_variable(input_x.index, one.x);
         builder.set_variable(input_y.index, one.y);
@@ -93,5 +112,17 @@ template bb::stdlib::cycle_group<MegaCircuitBuilder> to_grumpkin_point(const Wit
                                                                        bool has_valid_witness_assignments,
                                                                        const WitnessOrConstant<fr>& predicate,
                                                                        MegaCircuitBuilder& builder);
+
+template bb::stdlib::cycle_group<UltraCircuitBuilder> to_grumpkin_point_unsafe(
+    UltraCircuitBuilder& builder,
+    const WitnessOrConstant<fr>& input_x,
+    const WitnessOrConstant<fr>& input_y,
+    const WitnessOrConstant<fr>& input_infinite);
+
+template bb::stdlib::cycle_group<MegaCircuitBuilder> to_grumpkin_point_unsafe(
+    MegaCircuitBuilder& builder,
+    const WitnessOrConstant<fr>& input_x,
+    const WitnessOrConstant<fr>& input_y,
+    const WitnessOrConstant<fr>& input_infinite);
 
 } // namespace acir_format

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/witness_constant.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/witness_constant.cpp
@@ -30,10 +30,10 @@ using namespace bb::stdlib;
  * @param builder
  * @return bb::stdlib::cycle_group<Builder>
  */
-template <typename Builder, typename FF>
-bb::stdlib::cycle_group<Builder> to_grumpkin_point(const WitnessOrConstant<FF>& input_x,
-                                                   const WitnessOrConstant<FF>& input_y,
-                                                   const WitnessOrConstant<FF>& input_infinite,
+template <typename Builder>
+bb::stdlib::cycle_group<Builder> to_grumpkin_point(const WitnessOrConstant<typename Builder::FF>& input_x,
+                                                   const WitnessOrConstant<typename Builder::FF>& input_y,
+                                                   const WitnessOrConstant<typename Builder::FF>& input_infinite,
                                                    bool has_valid_witness_assignments,
                                                    const bb::stdlib::bool_t<Builder>& predicate,
                                                    Builder& builder)
@@ -47,7 +47,7 @@ bb::stdlib::cycle_group<Builder> to_grumpkin_point(const WitnessOrConstant<FF>& 
     auto point_y = to_field_ct(input_y, builder);
     auto infinite = bool_ct(to_field_ct(input_infinite, builder));
 
-    // In a witness is not provided (we are in a write_vk scenario) we ensure the coordinates correspond to a valid
+    // If a witness is not provided (we are in a write_vk scenario) we ensure the coordinates correspond to a valid
     // point to avoid erroneous failures during circuit construction. We only do this if the coordinates are
     // non-constant since otherwise no variable indices exist.
     if (!has_valid_witness_assignments && !constant_coordinates) {
@@ -69,16 +69,17 @@ bb::stdlib::cycle_group<Builder> to_grumpkin_point(const WitnessOrConstant<FF>& 
 }
 
 template bb::stdlib::cycle_group<UltraCircuitBuilder> to_grumpkin_point(
-    const WitnessOrConstant<fr>& input_x,
-    const WitnessOrConstant<fr>& input_y,
-    const WitnessOrConstant<fr>& input_infinite,
+    const WitnessOrConstant<UltraCircuitBuilder::FF>& input_x,
+    const WitnessOrConstant<UltraCircuitBuilder::FF>& input_y,
+    const WitnessOrConstant<UltraCircuitBuilder::FF>& input_infinite,
     bool has_valid_witness_assignments,
     const bb::stdlib::bool_t<UltraCircuitBuilder>& predicate,
     UltraCircuitBuilder& builder);
+
 template bb::stdlib::cycle_group<MegaCircuitBuilder> to_grumpkin_point(
-    const WitnessOrConstant<fr>& input_x,
-    const WitnessOrConstant<fr>& input_y,
-    const WitnessOrConstant<fr>& input_infinite,
+    const WitnessOrConstant<MegaCircuitBuilder::FF>& input_x,
+    const WitnessOrConstant<MegaCircuitBuilder::FF>& input_y,
+    const WitnessOrConstant<MegaCircuitBuilder::FF>& input_infinite,
     bool has_valid_witness_assignments,
     const bb::stdlib::bool_t<MegaCircuitBuilder>& predicate,
     MegaCircuitBuilder& builder);

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/witness_constant.hpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/witness_constant.hpp
@@ -46,10 +46,10 @@ bb::stdlib::field_t<Builder> to_field_ct(const WitnessOrConstant<typename Builde
     return field_ct::from_witness_index(&builder, input.index);
 }
 
-template <typename Builder, typename FF>
-bb::stdlib::cycle_group<Builder> to_grumpkin_point(const WitnessOrConstant<FF>& input_x,
-                                                   const WitnessOrConstant<FF>& input_y,
-                                                   const WitnessOrConstant<FF>& input_infinite,
+template <typename Builder>
+bb::stdlib::cycle_group<Builder> to_grumpkin_point(const WitnessOrConstant<typename Builder::FF>& input_x,
+                                                   const WitnessOrConstant<typename Builder::FF>& input_y,
+                                                   const WitnessOrConstant<typename Builder::FF>& input_infinite,
                                                    bool has_valid_witness_assignments,
                                                    const bb::stdlib::bool_t<Builder>& predicate,
                                                    Builder& builder);

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/witness_constant.hpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/witness_constant.hpp
@@ -46,19 +46,12 @@ bb::stdlib::field_t<Builder> to_field_ct(const WitnessOrConstant<typename Builde
     return field_ct::from_witness_index(&builder, input.index);
 }
 
-template <typename Builder>
-bb::stdlib::cycle_group<Builder> to_grumpkin_point_unsafe(
-    Builder& builder,
-    const WitnessOrConstant<typename Builder::FF>& input_x,
-    const WitnessOrConstant<typename Builder::FF>& input_y,
-    const WitnessOrConstant<typename Builder::FF>& input_infinite);
-
 template <typename Builder, typename FF>
 bb::stdlib::cycle_group<Builder> to_grumpkin_point(const WitnessOrConstant<FF>& input_x,
                                                    const WitnessOrConstant<FF>& input_y,
                                                    const WitnessOrConstant<FF>& input_infinite,
                                                    bool has_valid_witness_assignments,
-                                                   const WitnessOrConstant<FF>& predicate,
+                                                   const bb::stdlib::bool_t<Builder>& predicate,
                                                    Builder& builder);
 
 } // namespace acir_format

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/witness_constant.hpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/witness_constant.hpp
@@ -36,8 +36,8 @@ template <typename FF> struct WitnessOrConstant {
     }
 };
 
-template <typename Builder, typename FF>
-bb::stdlib::field_t<Builder> to_field_ct(const WitnessOrConstant<FF>& input, Builder& builder)
+template <typename Builder>
+bb::stdlib::field_t<Builder> to_field_ct(const WitnessOrConstant<typename Builder::FF>& input, Builder& builder)
 {
     using field_ct = bb::stdlib::field_t<Builder>;
     if (input.is_constant) {
@@ -45,6 +45,13 @@ bb::stdlib::field_t<Builder> to_field_ct(const WitnessOrConstant<FF>& input, Bui
     }
     return field_ct::from_witness_index(&builder, input.index);
 }
+
+template <typename Builder>
+bb::stdlib::cycle_group<Builder> to_grumpkin_point_unsafe(
+    Builder& builder,
+    const WitnessOrConstant<typename Builder::FF>& input_x,
+    const WitnessOrConstant<typename Builder::FF>& input_y,
+    const WitnessOrConstant<typename Builder::FF>& input_infinite);
 
 template <typename Builder, typename FF>
 bb::stdlib::cycle_group<Builder> to_grumpkin_point(const WitnessOrConstant<FF>& input_x,


### PR DESCRIPTION
### 🧾 Audit Context

This PR simply refactors the EC addition constraints. The aim is to simplify the structure of some functions, and add some documentation. The change in VK is explained below.

### 🛠️ Changes Made

The change of VKs comes from:
- casting `predicate` to bool_t
- the usage of `assert_equal` from `cycle_group` instead of individually checking the components; the change is due to the fact that the `cycle_group::assert_equal` method standardises both inputs, while previously we were standardising only the result computed (`input1 + input2`)

These changes make the constraints more restrictive (for the predicate) and ensure that the constraint are complete (if `input_result` is not standardised, checking all the components might fail as `result` is standardised)

### ✅ Checklist

- [ ] Audited all methods of the relevant module/class
- [ ] Audited the interface of the module/class with other (relevant) components
- [ ] Documented existing functionality and any changes made (as per Doxygen requirements)
- [ ] Resolved and/or closed all issues/TODOs pertaining to the audited files
- [ ] Confirmed and documented any security or other issues found (if applicable)
- [ ] Verified that tests cover all critical paths (and added tests if necessary)
- [ ] Updated audit tracking for the files audited (check the start of each file you audited)

### 📌 Notes for Reviewers
