### PR TITLE
fix: Ignore duplicate p2p messages post-validation

### DIFF
--- a/yarn-project/p2p/src/mem_pools/attestation_pool/attestation_pool.ts
+++ b/yarn-project/p2p/src/mem_pools/attestation_pool/attestation_pool.ts
@@ -22,6 +22,15 @@ export interface AttestationPool {
   getBlockProposal(id: string): Promise<BlockProposal | undefined>;
 
   /**
+   * Check if a block proposal exists in the pool
+   *
+   * @param idOrProposal - The ID of the block proposal or the block proposal itself to check. The ID is proposal.payload.archive
+   *
+   * @return True if the block proposal exists, false otherwise.
+   */
+  hasBlockProposal(idOrProposal: string | BlockProposal): Promise<boolean>;
+
+  /**
    * AddAttestations
    *
    * @param attestations - Attestations to add into the pool
@@ -83,6 +92,14 @@ export interface AttestationPool {
    * @return BlockAttestations
    */
   getAttestationsForSlotAndProposal(slot: bigint, proposalId: string): Promise<BlockAttestation[]>;
+
+  /**
+   * Check if a specific attestation exists in the pool
+   *
+   * @param attestation - The attestation to check
+   * @return True if the attestation exists, false otherwise
+   */
+  hasAttestation(attestation: BlockAttestation): Promise<boolean>;
 
   /** Returns whether the pool is empty. */
   isEmpty(): Promise<boolean>;

--- a/yarn-project/p2p/src/mem_pools/attestation_pool/kv_attestation_pool.ts
+++ b/yarn-project/p2p/src/mem_pools/attestation_pool/kv_attestation_pool.ts
@@ -213,6 +213,22 @@ export class KvAttestationPool implements AttestationPool {
     });
   }
 
+  public async hasAttestation(attestation: BlockAttestation): Promise<boolean> {
+    const slotNumber = attestation.payload.header.slotNumber;
+    const proposalId = attestation.archive;
+    const sender = attestation.getSender();
+
+    // Attestations with invalid signatures are never in the pool
+    if (!sender) {
+      return false;
+    }
+
+    const address = sender.toString();
+    const key = this.getAttestationKey(slotNumber, proposalId, address);
+
+    return await this.attestations.hasAsync(key);
+  }
+
   public async getBlockProposal(id: string): Promise<BlockProposal | undefined> {
     const buffer = await this.proposals.getAsync(id);
     try {
@@ -224,6 +240,11 @@ export class KvAttestationPool implements AttestationPool {
     }
 
     return Promise.resolve(undefined);
+  }
+
+  public async hasBlockProposal(idOrProposal: string | BlockProposal): Promise<boolean> {
+    const id = typeof idOrProposal === 'string' ? idOrProposal : idOrProposal.payload.archive.toString();
+    return await this.proposals.hasAsync(id);
   }
 
   public async addBlockProposal(blockProposal: BlockProposal): Promise<void> {

--- a/yarn-project/p2p/src/mem_pools/tx_pool/aztec_kv_tx_pool.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool/aztec_kv_tx_pool.ts
@@ -273,6 +273,11 @@ export class AztecKVTxPool extends (EventEmitter as new () => TypedEventEmitter<
     return await Promise.all(txHashes.map(txHash => this.#txs.hasAsync(txHash.toString())));
   }
 
+  async hasTx(txHash: TxHash): Promise<boolean> {
+    const result = await this.hasTxs([txHash]);
+    return result[0];
+  }
+
   /**
    * Checks if an archived tx exists and returns it.
    * @param txHash - The tx hash.

--- a/yarn-project/p2p/src/mem_pools/tx_pool/memory_tx_pool.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool/memory_tx_pool.ts
@@ -151,6 +151,11 @@ export class InMemoryTxPool extends (EventEmitter as new () => TypedEventEmitter
     return Promise.resolve(txHashes.map(txHash => this.txs.has(txHash.toBigInt())));
   }
 
+  async hasTx(txHash: TxHash): Promise<boolean> {
+    const result = await this.hasTxs([txHash]);
+    return result[0];
+  }
+
   public getArchivedTxByHash(): Promise<Tx | undefined> {
     return Promise.resolve(undefined);
   }

--- a/yarn-project/p2p/src/mem_pools/tx_pool/tx_pool.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool/tx_pool.ts
@@ -44,6 +44,13 @@ export interface TxPool extends TypedEventEmitter<TxPoolEvents> {
   hasTxs(txHashes: TxHash[]): Promise<boolean[]>;
 
   /**
+   * Checks if a transaction exists in the pool
+   * @param txHash - The hash of the transaction to check for
+   * @returns True if the transaction exists, false otherwise
+   */
+  hasTx(txHash: TxHash): Promise<boolean>;
+
+  /**
    * Checks if an archived transaction exists in the pool and returns it.
    * @param txHash - The hash of the transaction, used as an ID.
    * @returns The transaction, if found, 'undefined' otherwise.

--- a/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
+++ b/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
@@ -97,6 +97,11 @@ interface ValidationResult {
 
 type ValidationOutcome = { allPassed: true } | { allPassed: false; failure: ValidationResult };
 
+// REFACTOR: Unify with the type above
+type ReceivedMessageValidationResult<T> =
+  | { obj: T; result: Exclude<TopicValidatorResult, TopicValidatorResult.Reject> }
+  | { obj?: undefined; result: TopicValidatorResult.Reject };
+
 /**
  * Lib P2P implementation of the P2PService interface.
  */
@@ -604,6 +609,11 @@ export class LibP2PService<T extends P2PClientType = P2PClientType.Full> extends
     return result.recipients.length;
   }
 
+  /**
+   * Checks if this message has already been seen, based on its msgId computed from hashing the message data.
+   * Note that we do not rely on the seenCache from gossipsub since we want to keep a longer history of seen
+   * messages to avoid tx echoes across the network.
+   */
   protected preValidateReceivedMessage(
     msg: Message,
     msgId: string,
@@ -667,42 +677,57 @@ export class LibP2PService<T extends P2PClientType = P2PClientType.Full> extends
   }
 
   protected async validateReceivedMessage<T>(
-    validationFunc: () => Promise<{ result: boolean; obj: T }>,
+    validationFunc: () => Promise<ReceivedMessageValidationResult<T>>,
     msgId: string,
     source: PeerId,
     topicType: TopicType,
-  ): Promise<{ result: boolean; obj: T | undefined }> {
-    let resultAndObj: { result: boolean; obj: T | undefined } = { result: false, obj: undefined };
+  ): Promise<ReceivedMessageValidationResult<T>> {
+    let resultAndObj: ReceivedMessageValidationResult<T> = { result: TopicValidatorResult.Reject };
     const timer = new Timer();
     try {
       resultAndObj = await validationFunc();
     } catch (err) {
-      this.logger.error(`Error deserializing and validating message `, err);
+      this.logger.error(`Error deserializing and validating gossipsub message`, err, {
+        msgId,
+        source: source.toString(),
+        topicType,
+      });
     }
 
-    if (resultAndObj.result) {
+    if (resultAndObj.result === TopicValidatorResult.Accept) {
       this.instrumentation.recordMessageValidation(topicType, timer);
     }
 
-    this.node.services.pubsub.reportMessageValidationResult(
-      msgId,
-      source.toString(),
-      resultAndObj.result && resultAndObj.obj ? TopicValidatorResult.Accept : TopicValidatorResult.Reject,
-    );
+    this.node.services.pubsub.reportMessageValidationResult(msgId, source.toString(), resultAndObj.result);
     return resultAndObj;
   }
 
   protected async handleGossipedTx(payloadData: Buffer, msgId: string, source: PeerId) {
-    const validationFunc = async () => {
+    const validationFunc: () => Promise<ReceivedMessageValidationResult<Tx>> = async () => {
       const tx = Tx.fromBuffer(payloadData);
-      const result = await this.validatePropagatedTx(tx, source);
-      return { result, obj: tx };
+      const isValid = await this.validatePropagatedTx(tx, source);
+      const exists = isValid && (await this.mempools.txPool.hasTx(tx.getTxHash()));
+
+      this.logger.trace(`Validate propagated tx`, {
+        isValid,
+        exists,
+        [Attributes.P2P_ID]: source.toString(),
+      });
+
+      if (!isValid) {
+        return { result: TopicValidatorResult.Reject };
+      } else if (exists) {
+        return { result: TopicValidatorResult.Ignore, obj: tx };
+      } else {
+        return { result: TopicValidatorResult.Accept, obj: tx };
+      }
     };
 
     const { result, obj: tx } = await this.validateReceivedMessage<Tx>(validationFunc, msgId, source, TopicType.tx);
-    if (!result || !tx) {
+    if (result !== TopicValidatorResult.Accept || !tx) {
       return;
     }
+
     const txHash = tx.getTxHash();
     const txHashString = txHash.toString();
     this.logger.verbose(`Received tx ${txHashString} from external peer ${source.toString()} via gossip`, {
@@ -711,7 +736,7 @@ export class LibP2PService<T extends P2PClientType = P2PClientType.Full> extends
     });
 
     if (this.config.dropTransactions && randomInt(1000) < this.config.dropTransactionsProbability * 1000) {
-      this.logger.debug(`Intentionally dropping tx ${txHashString} (probability rule)`);
+      this.logger.warn(`Intentionally dropping tx ${txHashString} (probability rule)`);
       return;
     }
 
@@ -725,14 +750,25 @@ export class LibP2PService<T extends P2PClientType = P2PClientType.Full> extends
    * @param attestation - The attestation to process.
    */
   private async processAttestationFromPeer(payloadData: Buffer, msgId: string, source: PeerId): Promise<void> {
-    const validationFunc = async () => {
+    const validationFunc: () => Promise<ReceivedMessageValidationResult<BlockAttestation>> = async () => {
       const attestation = BlockAttestation.fromBuffer(payloadData);
-      const result = await this.validateAttestation(source, attestation);
-      this.logger.trace(`validatePropagatedAttestation: ${result}`, {
+      const isValid = await this.validateAttestation(source, attestation);
+      const exists = isValid && (await this.mempools.attestationPool!.hasAttestation(attestation));
+
+      this.logger.trace(`Validate propagated block attestation`, {
+        isValid,
+        exists,
         [Attributes.SLOT_NUMBER]: attestation.payload.header.slotNumber.toString(),
         [Attributes.P2P_ID]: source.toString(),
       });
-      return { result, obj: attestation };
+
+      if (!isValid) {
+        return { result: TopicValidatorResult.Reject };
+      } else if (exists) {
+        return { result: TopicValidatorResult.Ignore, obj: attestation };
+      } else {
+        return { result: TopicValidatorResult.Accept, obj: attestation };
+      }
     };
 
     const { result, obj: attestation } = await this.validateReceivedMessage<BlockAttestation>(
@@ -741,9 +777,11 @@ export class LibP2PService<T extends P2PClientType = P2PClientType.Full> extends
       source,
       TopicType.block_attestation,
     );
-    if (!result || !attestation) {
+
+    if (result !== TopicValidatorResult.Accept || !attestation) {
       return;
     }
+
     this.logger.debug(
       `Received attestation for slot ${attestation.slotNumber.toNumber()} from external peer ${source.toString()}`,
       {
@@ -753,18 +791,30 @@ export class LibP2PService<T extends P2PClientType = P2PClientType.Full> extends
         source: source.toString(),
       },
     );
+
     await this.mempools.attestationPool!.addAttestations([attestation]);
   }
 
   private async processBlockFromPeer(payloadData: Buffer, msgId: string, source: PeerId): Promise<void> {
-    const validationFunc = async () => {
+    const validationFunc: () => Promise<ReceivedMessageValidationResult<BlockProposal>> = async () => {
       const block = BlockProposal.fromBuffer(payloadData);
-      const result = await this.validateBlockProposal(source, block);
-      this.logger.trace(`validatePropagatedBlock: ${result}`, {
+      const isValid = await this.validateBlockProposal(source, block);
+      const exists = isValid && (await this.mempools.attestationPool!.hasBlockProposal(block));
+
+      this.logger.trace(`Validate propagated block proposal`, {
+        isValid,
+        exists,
         [Attributes.SLOT_NUMBER]: block.payload.header.slotNumber.toString(),
         [Attributes.P2P_ID]: source.toString(),
       });
-      return { result, obj: block };
+
+      if (!isValid) {
+        return { result: TopicValidatorResult.Reject };
+      } else if (exists) {
+        return { result: TopicValidatorResult.Ignore, obj: block };
+      } else {
+        return { result: TopicValidatorResult.Accept, obj: block };
+      }
     };
 
     const { result, obj: block } = await this.validateReceivedMessage<BlockProposal>(
@@ -773,6 +823,7 @@ export class LibP2PService<T extends P2PClientType = P2PClientType.Full> extends
       source,
       TopicType.block_proposal,
     );
+
     if (!result || !block) {
       return;
     }

--- a/yarn-project/p2p/src/testbench/p2p_client_testbench_worker.ts
+++ b/yarn-project/p2p/src/testbench/p2p_client_testbench_worker.ts
@@ -52,6 +52,7 @@ function mockTxPool(): TxPool {
     getTxStatus: () => Promise.resolve(TxStatus.PENDING),
     getTxsByHash: () => Promise.resolve([]),
     hasTxs: () => Promise.resolve([]),
+    hasTx: () => Promise.resolve(false),
     updateConfig: () => {},
     markTxsAsNonEvictable: () => Promise.resolve(),
     cleanupDeletedMinedTxs: () => Promise.resolve(0),
@@ -71,6 +72,8 @@ function mockAttestationPool(): AttestationPool {
     getAttestationsForSlotAndProposal: () => Promise.resolve([]),
     addBlockProposal: () => Promise.resolve(),
     getBlockProposal: () => Promise.resolve(undefined),
+    hasBlockProposal: () => Promise.resolve(false),
+    hasAttestation: () => Promise.resolve(false),
   };
 }
 

--- a/yarn-project/stdlib/src/p2p/gossipable.ts
+++ b/yarn-project/stdlib/src/p2p/gossipable.ts
@@ -28,15 +28,12 @@ export class P2PMessage {
  */
 export abstract class Gossipable {
   private cachedId: Buffer32 | undefined;
-  /** p2p Topic
-   *
-   * - The p2p topic identifier, this determines how the message is handled
-   */
+  /** The p2p topic identifier, this determines how the message is handled */
   static p2pTopic: TopicType;
 
-  /** p2p Message Identifier
-   *
-   *  - A digest of the message information, this key is used for deduplication
+  /**
+   * A digest of the message information **used for logging only**.
+   * The identifier used for deduplication is `getMsgIdFn` as defined in `encoding.ts` which is a hash over topic and data.
    */
   async p2pMessageIdentifier(): Promise<Buffer32> {
     if (this.cachedId) {
@@ -48,10 +45,6 @@ export abstract class Gossipable {
 
   abstract generateP2PMessageIdentifier(): Promise<Buffer32>;
 
-  /** To Buffer
-   *
-   * - Serialization method
-   */
   abstract toBuffer(): Buffer;
 
   toMessage(): Buffer {
@@ -60,7 +53,6 @@ export abstract class Gossipable {
 
   /**
    * Get the size of the gossipable object.
-   *
    * This is used for metrics recording.
    */
   abstract getSize(): number;


### PR DESCRIPTION
Today we have 3 deduplication mechanisms for messages:

1. The `fastMsgId` cache, where gossipsub deduplicates messages based on a hash computed over the compressed message buffer:

```ts
export function fastMsgIdFn(rpcMsg: RPC.Message): string {
  if (rpcMsg.data) {
    return xxhash.h64Raw(rpcMsg.data, h64Seed).toString(16);
  }
  return '0000000000000000';
}
```

2. The `msgId` cache, where gossipsub deduplicates messages based on a hash computed over the topic and the decompressed message buffer:

```ts
export function getMsgIdFn(message: Message) {
  const { topic } = message;

  const vec = [Buffer.from(topic), message.data];
  return sha256(Buffer.concat(vec)).subarray(0, 20);
}
```

3. The `msgIdSeenValidators` we manually implement in `LibP2PService`, where we deduplicate based on the `msgId` again  (**not** using the custom `p2pMessageIdentifier` from `Gossipable`), but with a larger cache, based on capacity instead of TTL:

```ts
    const validator = topicType ? this.msgIdSeenValidators[topicType] : undefined;

    if (!validator || !validator.addMessage(msgId)) {
      this.instrumentation.incMessagePrevalidationStatus(false, topicType);
      this.node.services.pubsub.reportMessageValidationResult(msgId, source.toString(), TopicValidatorResult.Ignore);
      return { result: false, topicType };
    }
```

All of these deduplications run **after** any validation is done. This PR adds an additional check for duplicates after validation, where we deduplicate against the attestation and tx pools, using the object identifiers:

```ts
  const validationFunc: () => Promise<ReceivedMessageValidationResult<BlockProposal>> = async () => {
      const block = BlockProposal.fromBuffer(payloadData);
      const isValid = await this.validateBlockProposal(source, block);
      const exists = isValid && (await this.mempools.attestationPool!.hasBlockProposal(block));

      this.logger.trace(`Validate propagated block proposal`, {
        isValid,
        exists,
        [Attributes.SLOT_NUMBER]: block.payload.header.slotNumber.toString(),
        [Attributes.P2P_ID]: source.toString(),
      });

      if (!isValid) {
        return { result: TopicValidatorResult.Reject };
      } else if (exists) {
        return { result: TopicValidatorResult.Ignore, obj: block };
      } else {
        return { result: TopicValidatorResult.Accept, obj: block };
      }
    };
```

Returning `Ignore` to gossipsub causes it to delete the message from its `mcache` (but not from its `seenCache`) without penalizing the sender, and instructs it to not re-broadcast the message.

Note that we cannot rely on the identifiers before validation since they could be forged: eg an attacker could pick up an identifier for a valid message, change its data with garbage, and forward it so it fails validation. When the real message is received afterwards, it gets rejected because it had previously failed. We need to run these id-based deduplications after validation so we know that the identifier corresponds to the payload.

This change prevents a malicious message originator from slightly modifying part of its message and broadcasting it across the network repeatedly, causing it to be re-processed and re-broadcasted. Eg a malicious attester could rely on non-deterministic ecdsa signatures to produce different valid signatures for the same attestation and broadcast them all. This change would only accept the first attestation and reject all others.

Fixes A-206