### PR TITLE
feat: add CRS initialization bbapi for bn254 and grumpkin

### DIFF
--- a/barretenberg/cpp/src/barretenberg/bbapi/bbapi_execute.hpp
+++ b/barretenberg/cpp/src/barretenberg/bbapi/bbapi_execute.hpp
@@ -66,6 +66,7 @@ using Command = NamedUnion<CircuitProve,
                            EcdsaSecp256r1VerifySignature,
                            SrsInitSrs,
                            SrsInitGrumpkinSrs,
+                           SrsInit,
                            Shutdown>;
 
 using CommandResponse = NamedUnion<ErrorResponse,
@@ -122,6 +123,7 @@ using CommandResponse = NamedUnion<ErrorResponse,
                                    EcdsaSecp256r1VerifySignature::Response,
                                    SrsInitSrs::Response,
                                    SrsInitGrumpkinSrs::Response,
+                                   SrsInit::Response,
                                    Shutdown::Response>;
 
 /**

--- a/barretenberg/cpp/src/barretenberg/bbapi/bbapi_srs.cpp
+++ b/barretenberg/cpp/src/barretenberg/bbapi/bbapi_srs.cpp
@@ -43,4 +43,44 @@ SrsInitGrumpkinSrs::Response SrsInitGrumpkinSrs::execute(BB_UNUSED BBApiRequest&
     return {};
 }
 
+SrsInit::Response SrsInit::execute(BB_UNUSED BBApiRequest& request) &&
+{
+    // Initialize BN254 if data is provided
+    bool bn254_has_buffer = !bn254_points_buf.empty() && !bn254_g2_point.empty() && bn254_num_points > 0;
+    bool bn254_has_path = !bn254_path.empty();
+
+    if (bn254_has_buffer) {
+        // Buffer takes precedence - initialize from memory
+        std::vector<g1::affine_element> g1_points(bn254_num_points);
+        for (size_t i = 0; i < bn254_num_points; ++i) {
+            g1_points[i] = from_buffer<g1::affine_element>(bn254_points_buf.data(), i * 64);
+        }
+
+        auto g2_point_elem = from_buffer<g2::affine_element>(bn254_g2_point.data());
+        bb::srs::init_bn254_mem_crs_factory(g1_points, g2_point_elem);
+    } else if (bn254_has_path) {
+        // Initialize from file
+        bb::srs::init_bn254_file_crs_factory(bn254_path);
+    }
+
+    // Initialize Grumpkin if data is provided
+    bool grumpkin_has_buffer = !grumpkin_points_buf.empty() && grumpkin_num_points > 0;
+    bool grumpkin_has_path = !grumpkin_path.empty();
+
+    if (grumpkin_has_buffer) {
+        // Buffer takes precedence - initialize from memory
+        std::vector<curve::Grumpkin::AffineElement> points(grumpkin_num_points);
+        for (uint32_t i = 0; i < grumpkin_num_points; ++i) {
+            points[i] = from_buffer<curve::Grumpkin::AffineElement>(grumpkin_points_buf.data(),
+                                                                    i * sizeof(curve::Grumpkin::AffineElement));
+        }
+        bb::srs::init_grumpkin_mem_crs_factory(points);
+    } else if (grumpkin_has_path) {
+        // Initialize from file
+        bb::srs::init_grumpkin_file_crs_factory(grumpkin_path);
+    }
+
+    return {};
+}
+
 } // namespace bb::bbapi

--- a/barretenberg/cpp/src/barretenberg/bbapi/bbapi_srs.hpp
+++ b/barretenberg/cpp/src/barretenberg/bbapi/bbapi_srs.hpp
@@ -56,4 +56,46 @@ struct SrsInitGrumpkinSrs {
     bool operator==(const SrsInitGrumpkinSrs&) const = default;
 };
 
+/**
+ * @struct SrsInit
+ * @brief Initialize BN254 and/or Grumpkin SRS from files or buffers
+ *
+ * This command allows flexible CRS initialization:
+ * - Initialize one or both curves (BN254 and Grumpkin)
+ * - Use file paths or raw buffers for each curve
+ * - If both path and buffer are provided for a curve, buffer takes precedence
+ * - If neither path nor buffer is provided for a curve, that curve is not initialized
+ */
+struct SrsInit {
+    static constexpr const char MSGPACK_SCHEMA_NAME[] = "SrsInit";
+
+    struct Response {
+        static constexpr const char MSGPACK_SCHEMA_NAME[] = "SrsInitResponse";
+        uint8_t dummy = 0; // Empty response needs a dummy field for msgpack
+        MSGPACK_FIELDS(dummy);
+        bool operator==(const Response&) const = default;
+    };
+
+    // BN254 parameters (optional - initialize if provided)
+    std::string bn254_path;                // File path to BN254 CRS (empty = not used)
+    std::vector<uint8_t> bn254_points_buf; // G1 points (64 bytes each, empty = not used)
+    uint32_t bn254_num_points = 0;         // Number of BN254 G1 points
+    std::vector<uint8_t> bn254_g2_point;   // G2 point (128 bytes, empty = not used)
+
+    // Grumpkin parameters (optional - initialize if provided)
+    std::string grumpkin_path;                // File path to Grumpkin CRS (empty = not used)
+    std::vector<uint8_t> grumpkin_points_buf; // Grumpkin affine elements (empty = not used)
+    uint32_t grumpkin_num_points = 0;         // Number of Grumpkin points
+
+    Response execute(BBApiRequest& request) &&;
+    MSGPACK_FIELDS(bn254_path,
+                   bn254_points_buf,
+                   bn254_num_points,
+                   bn254_g2_point,
+                   grumpkin_path,
+                   grumpkin_points_buf,
+                   grumpkin_num_points);
+    bool operator==(const SrsInit&) const = default;
+};
+
 } // namespace bb::bbapi


### PR DESCRIPTION
Implement a bbapi function for CRS (Common Reference String) initialization supporting both bn254 and grumpkin curves. The function accepts initialization parameters as either filenames or raw buffers, and allows setting one or both curves. This enables flexible curve initialization for cryptographic operations.