### PR TITLE
refactor: PXE note data structures and indexing logic

### DIFF
--- a/yarn-project/pxe/src/contract_function_simulator/execution_data_provider.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/execution_data_provider.ts
@@ -6,7 +6,7 @@ import type { L2Block } from '@aztec/stdlib/block';
 import type { CompleteAddress, ContractInstance } from '@aztec/stdlib/contract';
 import type { KeyValidationRequest } from '@aztec/stdlib/kernel';
 import type { DirectionalAppTaggingSecret } from '@aztec/stdlib/logs';
-import type { NoteStatus } from '@aztec/stdlib/note';
+import type { NoteStatusFilter } from '@aztec/stdlib/note';
 import { type MerkleTreeId, type NullifierMembershipWitness, PublicDataWitness } from '@aztec/stdlib/trees';
 import type { BlockHeader, NodeStats } from '@aztec/stdlib/tx';
 
@@ -82,7 +82,7 @@ export interface ExecutionDataProvider {
   getNotes(
     contractAddress: AztecAddress,
     storageSlot: Fr,
-    status: NoteStatus,
+    status: NoteStatusFilter,
     scopes?: AztecAddress[],
   ): Promise<NoteData[]>;
 

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/interfaces.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/interfaces.ts
@@ -5,7 +5,7 @@ import type { AztecAddress } from '@aztec/stdlib/aztec-address';
 import type { CompleteAddress, ContractInstance } from '@aztec/stdlib/contract';
 import type { KeyValidationRequest } from '@aztec/stdlib/kernel';
 import type { ContractClassLog } from '@aztec/stdlib/logs';
-import type { Note, NoteStatus } from '@aztec/stdlib/note';
+import type { Note, NoteStatusFilter } from '@aztec/stdlib/note';
 import { type MerkleTreeId, type NullifierMembershipWitness, PublicDataWitness } from '@aztec/stdlib/trees';
 import type { BlockHeader } from '@aztec/stdlib/tx';
 
@@ -87,7 +87,7 @@ export interface IUtilityExecutionOracle {
     sortOrder: number[],
     limit: number,
     offset: number,
-    status: NoteStatus,
+    status: NoteStatusFilter,
   ): Promise<NoteData[]>;
   utilityCheckNullifierExists(innerNullifier: Fr): Promise<boolean>;
   utilityGetL1ToL2MembershipWitness(

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution_oracle.ts
@@ -15,7 +15,7 @@ import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import { computeUniqueNoteHash, siloNoteHash, siloNullifier } from '@aztec/stdlib/hash';
 import { PrivateContextInputs } from '@aztec/stdlib/kernel';
 import type { ContractClassLog, DirectionalAppTaggingSecret, PreTag } from '@aztec/stdlib/logs';
-import { Note, type NoteStatus } from '@aztec/stdlib/note';
+import { Note, type NoteStatusFilter } from '@aztec/stdlib/note';
 import {
   type BlockHeader,
   CallContext,
@@ -308,7 +308,7 @@ export class PrivateExecutionOracle extends UtilityExecutionOracle implements IP
     sortOrder: number[],
     limit: number,
     offset: number,
-    status: NoteStatus,
+    status: NoteStatusFilter,
   ): Promise<NoteData[]> {
     // Nullified pending notes are already removed from the list.
     const pendingNotes = this.noteCache.getNotes(this.callContext.contractAddress, storageSlot);

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
@@ -6,7 +6,7 @@ import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import type { CompleteAddress, ContractInstance } from '@aztec/stdlib/contract';
 import { siloNullifier } from '@aztec/stdlib/hash';
 import type { KeyValidationRequest } from '@aztec/stdlib/kernel';
-import type { NoteStatus } from '@aztec/stdlib/note';
+import type { NoteStatusFilter } from '@aztec/stdlib/note';
 import { type MerkleTreeId, type NullifierMembershipWitness, PublicDataWitness } from '@aztec/stdlib/trees';
 import type { BlockHeader, Capsule } from '@aztec/stdlib/tx';
 
@@ -190,7 +190,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
     sortOrder: number[],
     limit: number,
     offset: number,
-    status: NoteStatus,
+    status: NoteStatusFilter,
   ): Promise<NoteData[]> {
     const dbNotes = await this.executionDataProvider.getNotes(this.contractAddress, storageSlot, status, this.scopes);
     return pickNotes<NoteData>(dbNotes, {

--- a/yarn-project/pxe/src/contract_function_simulator/pxe_oracle_interface.test.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/pxe_oracle_interface.test.ts
@@ -80,7 +80,7 @@ describe('PXEOracleInterface', () => {
 
     addressDataProvider = new AddressDataProvider(store);
     privateEventDataProvider = new PrivateEventDataProvider(store);
-    noteDataProvider = await NoteDataProvider.create(store);
+    noteDataProvider = NoteDataProvider.create(store);
     syncDataProvider = new SyncDataProvider(store);
     taggingDataProvider = new TaggingDataProvider(store);
     capsuleDataProvider = new CapsuleDataProvider(store);

--- a/yarn-project/pxe/src/contract_function_simulator/pxe_oracle_interface.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/pxe_oracle_interface.ts
@@ -25,7 +25,7 @@ import {
   deriveEcdhSharedSecret,
 } from '@aztec/stdlib/logs';
 import { getNonNullifiedL1ToL2MessageWitness } from '@aztec/stdlib/messaging';
-import { Note, type NoteStatus } from '@aztec/stdlib/note';
+import { Note, type NoteStatusFilter } from '@aztec/stdlib/note';
 import { MerkleTreeId, type NullifierMembershipWitness, PublicDataWitness } from '@aztec/stdlib/trees';
 import type { BlockHeader } from '@aztec/stdlib/tx';
 import { TxHash } from '@aztec/stdlib/tx';
@@ -95,7 +95,7 @@ export class PXEOracleInterface implements ExecutionDataProvider {
     return instance;
   }
 
-  async getNotes(contractAddress: AztecAddress, storageSlot: Fr, status: NoteStatus, scopes?: AztecAddress[]) {
+  async getNotes(contractAddress: AztecAddress, storageSlot: Fr, status: NoteStatusFilter, scopes?: AztecAddress[]) {
     const noteDaos = await this.noteDataProvider.getNotes({
       contractAddress,
       storageSlot,

--- a/yarn-project/pxe/src/pxe.ts
+++ b/yarn-project/pxe/src/pxe.ts
@@ -473,7 +473,6 @@ export class PXE {
     }
 
     await this.addressDataProvider.addCompleteAddress(accountCompleteAddress);
-    await this.noteDataProvider.addScope(accountCompleteAddress.address);
     return accountCompleteAddress;
   }
 

--- a/yarn-project/pxe/src/storage/note_data_provider/note_dao.test.ts
+++ b/yarn-project/pxe/src/storage/note_data_provider/note_dao.test.ts
@@ -6,4 +6,11 @@ describe('Note DAO', () => {
     const buf = note.toBuffer();
     expect(NoteDao.fromBuffer(buf)).toEqual(note);
   });
+
+  it('equality check', async () => {
+    const noteA = await NoteDao.random();
+    const noteB = await NoteDao.random();
+    expect(noteA.equals(noteA)).toBe(true);
+    expect(noteA.equals(noteB)).toBe(false);
+  });
 });

--- a/yarn-project/pxe/src/storage/note_data_provider/note_dao.ts
+++ b/yarn-project/pxe/src/storage/note_data_provider/note_dao.ts
@@ -59,6 +59,22 @@ export class NoteDao implements NoteData {
     public recipient: AztecAddress,
   ) {}
 
+  public equals(other: NoteDao): boolean {
+    return (
+      this.note.equals(other.note) &&
+      this.contractAddress.equals(other.contractAddress) &&
+      this.storageSlot.equals(other.storageSlot) &&
+      this.noteNonce.equals(other.noteNonce) &&
+      this.noteHash.equals(other.noteHash) &&
+      this.siloedNullifier.equals(other.siloedNullifier) &&
+      this.txHash.equals(other.txHash) &&
+      this.l2BlockNumber === other.l2BlockNumber &&
+      this.l2BlockHash === other.l2BlockHash &&
+      this.index === other.index
+      // this.recipient.equals(other.recipient) // F-92: this is going to be removed so don't compare it
+    );
+  }
+
   toBuffer(): Buffer {
     return serializeToBuffer([
       this.note,

--- a/yarn-project/pxe/src/storage/note_data_provider/note_data_provider.test.ts
+++ b/yarn-project/pxe/src/storage/note_data_provider/note_data_provider.test.ts
@@ -1,8 +1,9 @@
 import { Fr } from '@aztec/foundation/fields';
 import { AztecLMDBStoreV2, openTmpStore } from '@aztec/kv-store/lmdb-v2';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
-import { L2BlockHash } from '@aztec/stdlib/block';
-import { NoteStatus } from '@aztec/stdlib/note';
+
+// import { L2BlockHash } from '@aztec/stdlib/block';
+// import { type NotesFilter, StoredNoteStatus } from '@aztec/stdlib/note';
 
 import { NoteDao } from './note_dao.js';
 import { NoteDataProvider } from './note_data_provider.js';
@@ -52,10 +53,10 @@ describe('NoteDataProvider', () => {
   // Sets up a fresh NoteDataProvider with two scopes and three notes.
   async function setupProviderWithNotes(storeName: string) {
     const store = await openTmpStore(storeName);
-    const provider = await NoteDataProvider.create(store);
+    const provider = NoteDataProvider.create(store);
 
-    await provider.addScope(SCOPE_1);
-    await provider.addScope(SCOPE_2);
+    // await provider.addScope(SCOPE_1);
+    // await provider.addScope(SCOPE_2);
 
     const note1 = await mkNote({
       contractAddress: CONTRACT_A,
@@ -86,13 +87,13 @@ describe('NoteDataProvider', () => {
   }
 
   // Helper to create a nullifier object matching a given note.
-  function mkNullifier(note: NoteDao, blockNumber?: number) {
-    return {
-      data: note.siloedNullifier,
-      l2BlockNumber: blockNumber ?? note.l2BlockNumber,
-      l2BlockHash: L2BlockHash.fromString(note.l2BlockHash),
-    };
-  }
+  // function mkNullifier(note: NoteDao, blockNumber?: number) {
+  //   return {
+  //     data: note.siloedNullifier,
+  //     l2BlockNumber: blockNumber ?? note.l2BlockNumber,
+  //     l2BlockHash: L2BlockHash.fromString(note.l2BlockHash),
+  //   };
+  // }
 
   // Extracts the `index` field from an array of notes for easy comparison in tests.
   function getIndexes(notes: NoteDao[]) {
@@ -103,7 +104,7 @@ describe('NoteDataProvider', () => {
   describe('NoteDataProvider.create', () => {
     it('creates provider on an empty store and confirms getNotes returns an empty array', async () => {
       const store = await openTmpStore('note_data_provider_fresh_store');
-      const provider = await NoteDataProvider.create(store);
+      const provider = NoteDataProvider.create(store);
 
       const res = await provider.getNotes({ contractAddress: CONTRACT_A });
       expect(Array.isArray(res)).toBe(true);
@@ -116,16 +117,16 @@ describe('NoteDataProvider', () => {
       const store = await openTmpStore('note_data_provider_re-init_test');
 
       // First provider populates the store; second reopens it to verify persistence
-      const provider1 = await NoteDataProvider.create(store);
+      const provider1 = NoteDataProvider.create(store);
 
-      await provider1.addScope(SCOPE_1);
-      await provider1.addScope(SCOPE_2);
+      // await provider1.addScope(SCOPE_1);
+      // await provider1.addScope(SCOPE_2);
 
       const noteA = await mkNote({ contractAddress: CONTRACT_A, recipient: SCOPE_1, index: 1n });
       const noteB = await mkNote({ contractAddress: CONTRACT_B, recipient: SCOPE_2, index: 2n });
       await provider1.addNotes([noteA, noteB], FAKE_ADDRESS);
 
-      const provider2 = await NoteDataProvider.create(store);
+      const provider2 = NoteDataProvider.create(store);
 
       const notesA = await provider2.getNotes({ contractAddress: CONTRACT_A });
       const notesB = await provider2.getNotes({ contractAddress: CONTRACT_B });
@@ -137,15 +138,35 @@ describe('NoteDataProvider', () => {
     });
   });
 
+  describe('NoteDataProvider.addNotes same note twice!!! NEW TEST TO COMPLETE', () => {
+    it('adds notes under different scopes and retrieves them correctly', () => {
+      expect(true);
+    });
+
+    it('not happy path placeholder', () => {
+      //       it('rolls back entire batch on duplicate conflict', async () => {
+      //   const provider = await NoteDataProvider.create(store);
+
+      //   const notes = [noteA, noteB, conflictingNote];
+      //   await expect(provider.addNotes(notes, scope)).rejects.toThrow();
+
+      //   for (const note of notes) {
+      //     expect(await provider.#notes.has(toNoteId(note.index))).toBe(false);
+      //   }
+      // });
+      expect(true);
+    });
+  });
+
   describe('NoteDataProvider.getNotes filtering happy path', () => {
     let store: AztecLMDBStoreV2;
     let provider: NoteDataProvider;
     let note1: NoteDao;
     let note2: NoteDao;
-    let note3: NoteDao;
+    // let note3: NoteDao;
 
     beforeEach(async () => {
-      ({ store, provider, note1, note2, note3 } = await setupProviderWithNotes('note_data_provider_get_notes_happy'));
+      ({ store, provider, note1, note2 } = await setupProviderWithNotes('note_data_provider_get_notes_happy'));
     });
 
     afterEach(async () => {
@@ -186,19 +207,19 @@ describe('NoteDataProvider', () => {
       expect(new Set(getIndexes(res))).toEqual(new Set([1n, 2n, 4n])); // note1, note2, and note4
     });
 
-    it('filters notes by status, returning ACTIVE by default and both ACTIVE and NULLIFIED when requested', async () => {
-      const nullifiers = [mkNullifier(note2)];
-      await expect(provider.applyNullifiers(nullifiers)).resolves.toEqual([note2]);
+    // it('filters notes by status, returning ACTIVE by default and both ACTIVE and NULLIFIED when requested', async () => {
+    //   const nullifiers = [mkNullifier(note2)];
+    //   await expect(provider.applyNullifiers(nullifiers)).resolves.toEqual([note2]);
 
-      const resActive = await provider.getNotes({ contractAddress: CONTRACT_A });
-      expect(new Set(getIndexes(resActive))).toEqual(new Set([1n]));
+    //   const resActive = await provider.getNotes({ contractAddress: CONTRACT_A });
+    //   expect(new Set(getIndexes(resActive))).toEqual(new Set([1n]));
 
-      const resAll = await provider.getNotes({
-        contractAddress: CONTRACT_A,
-        status: NoteStatus.ACTIVE_OR_NULLIFIED,
-      });
-      expect(new Set(getIndexes(resAll))).toEqual(new Set([1n, 2n]));
-    });
+    //   const resAll = await provider.getNotes({
+    //     contractAddress: CONTRACT_A,
+    //     status: NoteStatus.ALL,
+    //   });
+    //   expect(new Set(getIndexes(resAll))).toEqual(new Set([1n, 2n]));
+    // });
 
     it('returns only notes that match all provided filters', async () => {
       const res = await provider.getNotes({
@@ -210,28 +231,28 @@ describe('NoteDataProvider', () => {
       expect(new Set(getIndexes(res))).toEqual(new Set([1n]));
     });
 
-    it('applies scope filtering to nullified notes', async () => {
-      const nullifiers = [mkNullifier(note3)];
-      await expect(provider.applyNullifiers(nullifiers)).resolves.toEqual([note3]);
+    // it('applies scope filtering to nullified notes', async () => {
+    //   const nullifiers = [mkNullifier(note3)];
+    //   await expect(provider.applyNullifiers(nullifiers)).resolves.toEqual([note3]);
 
-      // Query for contractB, but with the wrong scope (scope1)
-      const res = await provider.getNotes({
-        contractAddress: CONTRACT_B,
-        scopes: [SCOPE_1],
-        status: NoteStatus.ACTIVE_OR_NULLIFIED,
-      });
+    //   // Query for contractB, but with the wrong scope (scope1)
+    //   const res = await provider.getNotes({
+    //     contractAddress: CONTRACT_B,
+    //     scopes: [SCOPE_1],
+    //     status: NoteStatus.ALL,
+    //   });
 
-      expect(res).toHaveLength(0);
+    //   expect(res).toHaveLength(0);
 
-      // Query for contractB with the correct scope (scope2)
-      const res2 = await provider.getNotes({
-        contractAddress: CONTRACT_B,
-        scopes: [SCOPE_2],
-        status: NoteStatus.ACTIVE_OR_NULLIFIED,
-      });
+    //   // Query for contractB with the correct scope (scope2)
+    //   const res2 = await provider.getNotes({
+    //     contractAddress: CONTRACT_B,
+    //     scopes: [SCOPE_2],
+    //     status: NoteStatus.ALL,
+    //   });
 
-      expect(new Set(getIndexes(res2))).toEqual(new Set([3n]));
-    });
+    //   expect(new Set(getIndexes(res2))).toEqual(new Set([3n]));
+    // });
 
     it('filters notes by siloedNullifier', async () => {
       const filter = {
@@ -285,10 +306,16 @@ describe('NoteDataProvider', () => {
       );
     });
 
+    // TODO: Linear Issue: F-XX - Remove this test once scopes are mandatory in the filter.
     it('throws when called with an empty scopes array', async () => {
       await expect(provider.getNotes({ contractAddress: CONTRACT_A, scopes: [] })).rejects.toThrow(
         'Trying to get notes with an empty scopes array',
       );
+    });
+
+    // TODO: What happens if there's nothing in the scopes set?
+    it('nothing in scopes set and do getNotes', () => {
+      expect(true);
     });
 
     it('returns no notes when filtering by a non-existent siloedNullifier', async () => {
@@ -312,331 +339,331 @@ describe('NoteDataProvider', () => {
     });
   });
 
-  describe('NoteDataProvider.applyNullifiers happy path', () => {
-    let store: AztecLMDBStoreV2;
-    let provider: NoteDataProvider;
-    let note1: NoteDao;
-    let note2: NoteDao;
-    let note3: NoteDao;
+  // describe('NoteDataProvider.applyNullifiers happy path', () => {
+  //   let store: AztecLMDBStoreV2;
+  //   let provider: NoteDataProvider;
+  //   let note1: NoteDao;
+  //   let note2: NoteDao;
+  //   let note3: NoteDao;
 
-    beforeEach(async () => {
-      ({ store, provider, note1, note2, note3 } = await setupProviderWithNotes(
-        'note_data_provider_apply_nullifiers_happy',
-      ));
-    });
+  //   beforeEach(async () => {
+  //     ({ store, provider, note1, note2, note3 } = await setupProviderWithNotes(
+  //       'note_data_provider_apply_nullifiers_happy',
+  //     ));
+  //   });
 
-    afterEach(async () => {
-      await store.close();
-    });
+  //   afterEach(async () => {
+  //     await store.close();
+  //   });
 
-    it('returns empty array when given empty nullifiers array', async () => {
-      const result = await provider.applyNullifiers([]);
-      expect(result).toEqual([]);
-    });
+  //   it('returns empty array when given empty nullifiers array', async () => {
+  //     const result = await provider.applyNullifiers([]);
+  //     expect(result).toEqual([]);
+  //   });
 
-    it('nullifies a single note and moves it from active to nullified', async () => {
-      const result = await provider.applyNullifiers([mkNullifier(note1)]);
-      expect(result).toEqual([note1]);
+  //   it('nullifies a single note and moves it from active to nullified', async () => {
+  //     const result = await provider.applyNullifiers([mkNullifier(note1)]);
+  //     expect(result).toEqual([note1]);
 
-      const active = await provider.getNotes({ contractAddress: CONTRACT_A });
-      const all = await provider.getNotes({
-        contractAddress: CONTRACT_A,
-        status: NoteStatus.ACTIVE_OR_NULLIFIED,
-      });
+  //     const active = await provider.getNotes({ contractAddress: CONTRACT_A });
+  //     const all = await provider.getNotes({
+  //       contractAddress: CONTRACT_A,
+  //       status: NoteStatus.ACTIVE_OR_NULLIFIED,
+  //     });
 
-      expect(new Set(getIndexes(active))).toEqual(new Set([2n]));
-      expect(new Set(getIndexes(all))).toEqual(new Set([1n, 2n]));
-    });
+  //     expect(new Set(getIndexes(active))).toEqual(new Set([2n]));
+  //     expect(new Set(getIndexes(all))).toEqual(new Set([1n, 2n]));
+  //   });
 
-    it('nullifies multiple notes and returns them', async () => {
-      const nullifiers = [mkNullifier(note1), mkNullifier(note3)];
-      const result = await provider.applyNullifiers(nullifiers);
+  //   it('nullifies multiple notes and returns them', async () => {
+  //     const nullifiers = [mkNullifier(note1), mkNullifier(note3)];
+  //     const result = await provider.applyNullifiers(nullifiers);
 
-      const activeA = await provider.getNotes({ contractAddress: CONTRACT_A });
-      const activeB = await provider.getNotes({ contractAddress: CONTRACT_B });
+  //     const activeA = await provider.getNotes({ contractAddress: CONTRACT_A });
+  //     const activeB = await provider.getNotes({ contractAddress: CONTRACT_B });
 
-      expect(result).toEqual([note1, note3]); // returned nullified notes
-      expect(new Set(getIndexes(activeA))).toEqual(new Set([2n])); // note2 remains active
-      expect(getIndexes(activeB)).toHaveLength(0); // no active notes in contractB
-    });
+  //     expect(result).toEqual([note1, note3]); // returned nullified notes
+  //     expect(new Set(getIndexes(activeA))).toEqual(new Set([2n])); // note2 remains active
+  //     expect(getIndexes(activeB)).toHaveLength(0); // no active notes in contractB
+  //   });
 
-    it('retrieves a nullified note by its siloedNullifier when status is ACTIVE_OR_NULLIFIED', async () => {
-      await provider.applyNullifiers([mkNullifier(note2)]);
+  //   it('retrieves a nullified note by its siloedNullifier when status is ACTIVE_OR_NULLIFIED', async () => {
+  //     await provider.applyNullifiers([mkNullifier(note2)]);
 
-      const filter = {
-        contractAddress: CONTRACT_A,
-        siloedNullifier: note2.siloedNullifier,
-        status: NoteStatus.ACTIVE_OR_NULLIFIED,
-      };
+  //     const filter = {
+  //       contractAddress: CONTRACT_A,
+  //       siloedNullifier: note2.siloedNullifier,
+  //       status: NoteStatus.ACTIVE_OR_NULLIFIED,
+  //     };
 
-      const res = await provider.getNotes(filter);
-      expect(new Set(getIndexes(res))).toEqual(new Set([2n]));
-    });
-  });
+  //     const res = await provider.getNotes(filter);
+  //     expect(new Set(getIndexes(res))).toEqual(new Set([2n]));
+  //   });
+  // });
 
-  describe('NoteDataProvider.applyNullifiers edge cases', () => {
-    let store: AztecLMDBStoreV2;
-    let provider: NoteDataProvider;
-    let note1: NoteDao;
-    let note2: NoteDao;
+  // describe('NoteDataProvider.applyNullifiers edge cases', () => {
+  //   let store: AztecLMDBStoreV2;
+  //   let provider: NoteDataProvider;
+  //   let note1: NoteDao;
+  //   let note2: NoteDao;
 
-    beforeEach(async () => {
-      ({ store, provider, note1, note2 } = await setupProviderWithNotes('note_data_provider_apply_nullifiers_edge'));
-    });
+  //   beforeEach(async () => {
+  //     ({ store, provider, note1, note2 } = await setupProviderWithNotes('note_data_provider_apply_nullifiers_edge'));
+  //   });
 
-    afterEach(async () => {
-      await store.close();
-    });
+  //   afterEach(async () => {
+  //     await store.close();
+  //   });
 
-    it('throws error when nullifier is not found', async () => {
-      const fakeNullifier = {
-        data: Fr.random(),
-        l2BlockNumber: 999,
-        l2BlockHash: L2BlockHash.random(),
-      };
+  //   it('throws error when nullifier is not found', async () => {
+  //     const fakeNullifier = {
+  //       data: Fr.random(),
+  //       l2BlockNumber: 999,
+  //       l2BlockHash: L2BlockHash.random(),
+  //     };
 
-      await expect(provider.applyNullifiers([fakeNullifier])).rejects.toThrow('Nullifier not found in applyNullifiers');
-    });
+  //     await expect(provider.applyNullifiers([fakeNullifier])).rejects.toThrow('Nullifier not found in applyNullifiers');
+  //   });
 
-    it('preserves scope information when nullifying notes', async () => {
-      const nullifiers = [mkNullifier(note1)];
-      await provider.applyNullifiers(nullifiers);
+  //   it('preserves scope information when nullifying notes', async () => {
+  //     const nullifiers = [mkNullifier(note1)];
+  //     await provider.applyNullifiers(nullifiers);
 
-      // Verify nullified note remains visible only within its original scope
-      const wrongScopeNotes = await provider.getNotes({
-        contractAddress: CONTRACT_A,
-        scopes: [SCOPE_2],
-        status: NoteStatus.ACTIVE_OR_NULLIFIED,
-      });
-      expect(getIndexes(wrongScopeNotes)).not.toContain(1n);
+  //     // Verify nullified note remains visible only within its original scope
+  //     const wrongScopeNotes = await provider.getNotes({
+  //       contractAddress: CONTRACT_A,
+  //       scopes: [SCOPE_2],
+  //       status: NoteStatus.ACTIVE_OR_NULLIFIED,
+  //     });
+  //     expect(getIndexes(wrongScopeNotes)).not.toContain(1n);
 
-      const correctScopeNotes = await provider.getNotes({
-        contractAddress: CONTRACT_A,
-        scopes: [SCOPE_1],
-        status: NoteStatus.ACTIVE_OR_NULLIFIED,
-      });
-      expect(getIndexes(correctScopeNotes)).toContain(1n);
-    });
+  //     const correctScopeNotes = await provider.getNotes({
+  //       contractAddress: CONTRACT_A,
+  //       scopes: [SCOPE_1],
+  //       status: NoteStatus.ACTIVE_OR_NULLIFIED,
+  //     });
+  //     expect(getIndexes(correctScopeNotes)).toContain(1n);
+  //   });
 
-    it('is atomic - fails entirely if any nullifier is invalid', async () => {
-      // Should fail entirely: note1 remains active because transaction is atomic.
-      const nullifiers = [
-        mkNullifier(note2),
-        {
-          data: Fr.random(), // Invalid
-          l2BlockNumber: 999,
-          l2BlockHash: L2BlockHash.random(),
-        },
-      ];
+  //   it('is atomic - fails entirely if any nullifier is invalid', async () => {
+  //     // Should fail entirely: note1 remains active because transaction is atomic.
+  //     const nullifiers = [
+  //       mkNullifier(note2),
+  //       {
+  //         data: Fr.random(), // Invalid
+  //         l2BlockNumber: 999,
+  //         l2BlockHash: L2BlockHash.random(),
+  //       },
+  //     ];
 
-      await expect(provider.applyNullifiers(nullifiers)).rejects.toThrow();
+  //     await expect(provider.applyNullifiers(nullifiers)).rejects.toThrow();
 
-      // Verify note1 is still active (transaction rolled back)
-      const activeNotes = await provider.getNotes({ contractAddress: CONTRACT_A });
-      expect(new Set(getIndexes(activeNotes))).toEqual(new Set([1n, 2n]));
-    });
+  //     // Verify note1 is still active (transaction rolled back)
+  //     const activeNotes = await provider.getNotes({ contractAddress: CONTRACT_A });
+  //     expect(new Set(getIndexes(activeNotes))).toEqual(new Set([1n, 2n]));
+  //   });
 
-    it('updates all relevant indexes when nullifying notes', async () => {
-      const nullifiers = [mkNullifier(note1)];
-      await provider.applyNullifiers(nullifiers);
+  //   it('updates all relevant indexes when nullifying notes', async () => {
+  //     const nullifiers = [mkNullifier(note1)];
+  //     await provider.applyNullifiers(nullifiers);
 
-      // Test various filter combinations still work
-      const byContract = await provider.getNotes({
-        contractAddress: CONTRACT_A,
-        status: NoteStatus.ACTIVE_OR_NULLIFIED,
-      });
-      expect(new Set(getIndexes(byContract))).toEqual(new Set([1n, 2n]));
+  //     // Test various filter combinations still work
+  //     const byContract = await provider.getNotes({
+  //       contractAddress: CONTRACT_A,
+  //       status: NoteStatus.ACTIVE_OR_NULLIFIED,
+  //     });
+  //     expect(new Set(getIndexes(byContract))).toEqual(new Set([1n, 2n]));
 
-      const bySlot = await provider.getNotes({
-        contractAddress: CONTRACT_A,
-        storageSlot: note1.storageSlot,
-        status: NoteStatus.ACTIVE_OR_NULLIFIED,
-      });
-      expect(new Set(getIndexes(bySlot))).toEqual(new Set([1n]));
+  //     const bySlot = await provider.getNotes({
+  //       contractAddress: CONTRACT_A,
+  //       storageSlot: note1.storageSlot,
+  //       status: NoteStatus.ACTIVE_OR_NULLIFIED,
+  //     });
+  //     expect(new Set(getIndexes(bySlot))).toEqual(new Set([1n]));
 
-      const byScope = await provider.getNotes({
-        contractAddress: CONTRACT_A,
-        scopes: [note1.recipient],
-        status: NoteStatus.ACTIVE_OR_NULLIFIED,
-      });
-      expect(new Set(getIndexes(byScope))).toEqual(new Set([1n, 2n]));
-    });
+  //     const byScope = await provider.getNotes({
+  //       contractAddress: CONTRACT_A,
+  //       scopes: [note1.recipient],
+  //       status: NoteStatus.ACTIVE_OR_NULLIFIED,
+  //     });
+  //     expect(new Set(getIndexes(byScope))).toEqual(new Set([1n, 2n]));
+  //   });
 
-    it('attempts to nullify the same note twice in succession results in error', async () => {
-      await provider.applyNullifiers([mkNullifier(note1)]); // First application should succeed
-      const activeNotes = await provider.getNotes({ contractAddress: CONTRACT_A });
-      expect(new Set(getIndexes(activeNotes))).toEqual(new Set([2n]));
+  //   it('attempts to nullify the same note twice in succession results in error', async () => {
+  //     await provider.applyNullifiers([mkNullifier(note1)]); // First application should succeed
+  //     const activeNotes = await provider.getNotes({ contractAddress: CONTRACT_A });
+  //     expect(new Set(getIndexes(activeNotes))).toEqual(new Set([2n]));
 
-      // should throw on second attempt as note1 is already nullified
-      await expect(provider.applyNullifiers([mkNullifier(note1)])).rejects.toThrow(
-        'Nullifier already applied in applyNullifiers',
-      );
-    });
+  //     // should throw on second attempt as note1 is already nullified
+  //     await expect(provider.applyNullifiers([mkNullifier(note1)])).rejects.toThrow(
+  //       'Nullifier already applied in applyNullifiers',
+  //     );
+  //   });
 
-    it('attempts to nullify the same note twice in same call results in error', async () => {
-      const nullifiers = [mkNullifier(note1), mkNullifier(note1)];
-      await expect(provider.applyNullifiers(nullifiers)).rejects.toThrow(
-        'Nullifier already applied in applyNullifiers',
-      );
-    });
-  });
+  //   it('attempts to nullify the same note twice in same call results in error', async () => {
+  //     const nullifiers = [mkNullifier(note1), mkNullifier(note1)];
+  //     await expect(provider.applyNullifiers(nullifiers)).rejects.toThrow(
+  //       'Nullifier already applied in applyNullifiers',
+  //     );
+  //   });
+  // });
 
-  describe('NoteDataProvider.rollbackNotesAndNullifiers', () => {
-    let provider: NoteDataProvider;
-    let store: AztecLMDBStoreV2;
+  // describe('NoteDataProvider.rollbackNotesAndNullifiers', () => {
+  //   let provider: NoteDataProvider;
+  //   let store: AztecLMDBStoreV2;
 
-    beforeEach(async () => {
-      store = await openTmpStore('note_data_provider_rollback_test');
-      provider = await NoteDataProvider.create(store);
-      await provider.addScope(SCOPE_1);
-      await provider.addScope(SCOPE_2);
-    });
+  //   beforeEach(async () => {
+  //     store = await openTmpStore('note_data_provider_rollback_test');
+  //     provider = await NoteDataProvider.create(store);
+  //     await provider.addScope(SCOPE_1);
+  //     await provider.addScope(SCOPE_2);
+  //   });
 
-    afterEach(async () => {
-      await store.close();
-    });
+  //   afterEach(async () => {
+  //     await store.close();
+  //   });
 
-    describe('rewind nullifications happy path', () => {
-      async function setupRollbackScenario() {
-        const noteBlock1 = await mkNote({ index: 1n, l2BlockNumber: 1 }); // Nullified at block 2
-        const noteBlock2 = await mkNote({ index: 2n, l2BlockNumber: 2 }); // Never nullified
-        const noteBlock3 = await mkNote({ index: 3n, l2BlockNumber: 3 }); // Nullified at block 4
-        const noteBlock5 = await mkNote({ index: 5n, l2BlockNumber: 5 }); // Created after rollback block 3
+  //   describe('rewind nullifications happy path', () => {
+  //     async function setupRollbackScenario() {
+  //       const noteBlock1 = await mkNote({ index: 1n, l2BlockNumber: 1 }); // Nullified at block 2
+  //       const noteBlock2 = await mkNote({ index: 2n, l2BlockNumber: 2 }); // Never nullified
+  //       const noteBlock3 = await mkNote({ index: 3n, l2BlockNumber: 3 }); // Nullified at block 4
+  //       const noteBlock5 = await mkNote({ index: 5n, l2BlockNumber: 5 }); // Created after rollback block 3
 
-        await provider.addNotes([noteBlock1, noteBlock2, noteBlock3, noteBlock5], SCOPE_1);
+  //       await provider.addNotes([noteBlock1, noteBlock2, noteBlock3, noteBlock5], SCOPE_1);
 
-        const nullifiers = [mkNullifier(noteBlock1, 2), mkNullifier(noteBlock3, 4), mkNullifier(noteBlock5, 6)];
+  //       const nullifiers = [mkNullifier(noteBlock1, 2), mkNullifier(noteBlock3, 4), mkNullifier(noteBlock5, 6)];
 
-        // Apply nullifiers and rollback to block 3
-        // - should restore noteBlock3 (nullified at block 4) and preserve noteBlock1 (nullified at block 2)
-        await provider.applyNullifiers(nullifiers);
-        await provider.rollbackNotesAndNullifiers(3, 6);
-      }
+  //       // Apply nullifiers and rollback to block 3
+  //       // - should restore noteBlock3 (nullified at block 4) and preserve noteBlock1 (nullified at block 2)
+  //       await provider.applyNullifiers(nullifiers);
+  //       await provider.rollbackNotesAndNullifiers(3, 6);
+  //     }
 
-      beforeEach(async () => {
-        await setupRollbackScenario();
-      });
+  //     beforeEach(async () => {
+  //       await setupRollbackScenario();
+  //     });
 
-      it('restores notes that were nullified after the rollback block', async () => {
-        // noteBlock2 remains active, noteBlock3 was nullified at block 4 should be restored
-        const activeNotes = await provider.getNotes({ contractAddress: CONTRACT_A });
-        expect(new Set(getIndexes(activeNotes))).toEqual(new Set([2n, 3n]));
-      });
+  //     it('restores notes that were nullified after the rollback block', async () => {
+  //       // noteBlock2 remains active, noteBlock3 was nullified at block 4 should be restored
+  //       const activeNotes = await provider.getNotes({ contractAddress: CONTRACT_A });
+  //       expect(new Set(getIndexes(activeNotes))).toEqual(new Set([2n, 3n]));
+  //     });
 
-      it('preserves nullification of notes nullified at or before the rollback block', async () => {
-        const allNotes = await provider.getNotes({
-          contractAddress: CONTRACT_A,
-          status: NoteStatus.ACTIVE_OR_NULLIFIED,
-        });
+  //     it('preserves nullification of notes nullified at or before the rollback block', async () => {
+  //       const allNotes = await provider.getNotes({
+  //         contractAddress: CONTRACT_A,
+  //         status: NoteStatus.ACTIVE_OR_NULLIFIED,
+  //       });
 
-        // Should contain noteBlock1 (nullified), noteBlock2 (active), and noteBlock3 (restored)
-        expect(new Set(getIndexes(allNotes))).toEqual(new Set([1n, 2n, 3n]));
+  //       // Should contain noteBlock1 (nullified), noteBlock2 (active), and noteBlock3 (restored)
+  //       expect(new Set(getIndexes(allNotes))).toEqual(new Set([1n, 2n, 3n]));
 
-        // Verify noteBlock1 is not in active notes
-        const activeNotes = await provider.getNotes({ contractAddress: CONTRACT_A });
-        const activeIndexes = getIndexes(activeNotes);
-        expect(activeIndexes).not.toEqual(expect.arrayContaining([1n]));
-      });
+  //       // Verify noteBlock1 is not in active notes
+  //       const activeNotes = await provider.getNotes({ contractAddress: CONTRACT_A });
+  //       const activeIndexes = getIndexes(activeNotes);
+  //       expect(activeIndexes).not.toEqual(expect.arrayContaining([1n]));
+  //     });
 
-      it('preserves active notes created before the rollback block that were never nullified', async () => {
-        // noteBlock2 was created at block 2 (before rollback block 3) and never nullified
-        const activeNotes = await provider.getNotes({ contractAddress: CONTRACT_A });
-        expect(new Set(getIndexes(activeNotes))).toEqual(new Set([2n, 3n]));
-      });
+  //     it('preserves active notes created before the rollback block that were never nullified', async () => {
+  //       // noteBlock2 was created at block 2 (before rollback block 3) and never nullified
+  //       const activeNotes = await provider.getNotes({ contractAddress: CONTRACT_A });
+  //       expect(new Set(getIndexes(activeNotes))).toEqual(new Set([2n, 3n]));
+  //     });
 
-      it('deletes notes created after the rollback block', async () => {
-        const allNotes = await provider.getNotes({
-          contractAddress: CONTRACT_A,
-          status: NoteStatus.ACTIVE_OR_NULLIFIED,
-        });
+  //     it('deletes notes created after the rollback block', async () => {
+  //       const allNotes = await provider.getNotes({
+  //         contractAddress: CONTRACT_A,
+  //         status: NoteStatus.ACTIVE_OR_NULLIFIED,
+  //       });
 
-        // noteBlock5 was created at block 5, which is after rollback block 3, should be deleted
-        const indexes = getIndexes(allNotes);
-        expect(new Set(indexes)).toEqual(new Set([1n, 2n, 3n]));
-        expect(indexes).not.toEqual(expect.arrayContaining([5n]));
-      });
-    });
+  //       // noteBlock5 was created at block 5, which is after rollback block 3, should be deleted
+  //       const indexes = getIndexes(allNotes);
+  //       expect(new Set(indexes)).toEqual(new Set([1n, 2n, 3n]));
+  //       expect(indexes).not.toEqual(expect.arrayContaining([5n]));
+  //     });
+  //   });
 
-    describe('rewind nullifications edge cases', () => {
-      it('handles rollback when blockNumber equals synchedBlockNumber', async () => {
-        const note = await mkNote({ index: 10n, l2BlockNumber: 5 });
-        await provider.addNotes([note], SCOPE_1);
+  //   describe('rewind nullifications edge cases', () => {
+  //     it('handles rollback when blockNumber equals synchedBlockNumber', async () => {
+  //       const note = await mkNote({ index: 10n, l2BlockNumber: 5 });
+  //       await provider.addNotes([note], SCOPE_1);
 
-        const nullifiers = [
-          {
-            data: note.siloedNullifier,
-            l2BlockNumber: 5,
-            l2BlockHash: L2BlockHash.fromString(note.l2BlockHash),
-          },
-        ];
-        await provider.applyNullifiers(nullifiers);
+  //       const nullifiers = [
+  //         {
+  //           data: note.siloedNullifier,
+  //           l2BlockNumber: 5,
+  //           l2BlockHash: L2BlockHash.fromString(note.l2BlockHash),
+  //         },
+  //       ];
+  //       await provider.applyNullifiers(nullifiers);
 
-        // Since nullification happened at block 5 (not after), it should stay nullified
-        // The rewind loop processes blocks (blockNumber+1) to synchedBlockNumber = 6 to 5 = no iterations
-        await provider.rollbackNotesAndNullifiers(5, 5);
+  //       // Since nullification happened at block 5 (not after), it should stay nullified
+  //       // The rewind loop processes blocks (blockNumber+1) to synchedBlockNumber = 6 to 5 = no iterations
+  //       await provider.rollbackNotesAndNullifiers(5, 5);
 
-        const activeNotes = await provider.getNotes({ contractAddress: CONTRACT_A });
-        expect(activeNotes).toHaveLength(0);
+  //       const activeNotes = await provider.getNotes({ contractAddress: CONTRACT_A });
+  //       expect(activeNotes).toHaveLength(0);
 
-        const allNotes = await provider.getNotes({
-          contractAddress: CONTRACT_A,
-          status: NoteStatus.ACTIVE_OR_NULLIFIED,
-        });
-        expect(new Set(getIndexes(allNotes))).toEqual(new Set([10n]));
-      });
+  //       const allNotes = await provider.getNotes({
+  //         contractAddress: CONTRACT_A,
+  //         status: NoteStatus.ACTIVE_OR_NULLIFIED,
+  //       });
+  //       expect(new Set(getIndexes(allNotes))).toEqual(new Set([10n]));
+  //     });
 
-      it('handles rollback when synchedBlockNumber < blockNumber', async () => {
-        const note = await mkNote({ index: 20n, l2BlockNumber: 3 });
-        await provider.addNotes([note], SCOPE_1);
+  //     it('handles rollback when synchedBlockNumber < blockNumber', async () => {
+  //       const note = await mkNote({ index: 20n, l2BlockNumber: 3 });
+  //       await provider.addNotes([note], SCOPE_1);
 
-        const nullifiers = [
-          {
-            data: note.siloedNullifier,
-            l2BlockNumber: 4,
-            l2BlockHash: L2BlockHash.fromString(note.l2BlockHash),
-          },
-        ];
-        await provider.applyNullifiers(nullifiers);
+  //       const nullifiers = [
+  //         {
+  //           data: note.siloedNullifier,
+  //           l2BlockNumber: 4,
+  //           l2BlockHash: L2BlockHash.fromString(note.l2BlockHash),
+  //         },
+  //       ];
+  //       await provider.applyNullifiers(nullifiers);
 
-        // blockNumber=6, synchedBlockNumber=4 therefore no nullifications to rewind
-        await provider.rollbackNotesAndNullifiers(6, 4);
+  //       // blockNumber=6, synchedBlockNumber=4 therefore no nullifications to rewind
+  //       await provider.rollbackNotesAndNullifiers(6, 4);
 
-        const activeNotes = await provider.getNotes({ contractAddress: CONTRACT_A });
-        expect(activeNotes).toHaveLength(0);
+  //       const activeNotes = await provider.getNotes({ contractAddress: CONTRACT_A });
+  //       expect(activeNotes).toHaveLength(0);
 
-        const allNotes = await provider.getNotes({
-          contractAddress: CONTRACT_A,
-          status: NoteStatus.ACTIVE_OR_NULLIFIED,
-        });
-        expect(new Set(getIndexes(allNotes))).toEqual(new Set([20n]));
-      });
+  //       const allNotes = await provider.getNotes({
+  //         contractAddress: CONTRACT_A,
+  //         status: NoteStatus.ACTIVE_OR_NULLIFIED,
+  //       });
+  //       expect(new Set(getIndexes(allNotes))).toEqual(new Set([20n]));
+  //     });
 
-      it('handles rollback with a large block gap', async () => {
-        const note1 = await mkNote({ index: 30n, l2BlockNumber: 5 });
-        const note2 = await mkNote({ index: 31n, l2BlockNumber: 10 });
-        await provider.addNotes([note1, note2], SCOPE_1);
+  //     it('handles rollback with a large block gap', async () => {
+  //       const note1 = await mkNote({ index: 30n, l2BlockNumber: 5 });
+  //       const note2 = await mkNote({ index: 31n, l2BlockNumber: 10 });
+  //       await provider.addNotes([note1, note2], SCOPE_1);
 
-        const nullifiers = [
-          {
-            data: note1.siloedNullifier,
-            l2BlockNumber: 7,
-            l2BlockHash: L2BlockHash.fromString(note1.l2BlockHash),
-          },
-        ];
-        await provider.applyNullifiers(nullifiers);
-        await provider.rollbackNotesAndNullifiers(5, 100);
+  //       const nullifiers = [
+  //         {
+  //           data: note1.siloedNullifier,
+  //           l2BlockNumber: 7,
+  //           l2BlockHash: L2BlockHash.fromString(note1.l2BlockHash),
+  //         },
+  //       ];
+  //       await provider.applyNullifiers(nullifiers);
+  //       await provider.rollbackNotesAndNullifiers(5, 100);
 
-        // note1 should be restored (nullified at block 7 > rollback block 5)
-        // note2 should be deleted (created at block 10 > rollback block 5)
-        const activeNotes = await provider.getNotes({ contractAddress: CONTRACT_A });
-        expect(new Set(getIndexes(activeNotes))).toEqual(new Set([30n]));
-      });
+  //       // note1 should be restored (nullified at block 7 > rollback block 5)
+  //       // note2 should be deleted (created at block 10 > rollback block 5)
+  //       const activeNotes = await provider.getNotes({ contractAddress: CONTRACT_A });
+  //       expect(new Set(getIndexes(activeNotes))).toEqual(new Set([30n]));
+  //     });
 
-      it('handles rollback on empty PXE database gracefully', async () => {
-        await expect(provider.rollbackNotesAndNullifiers(10, 20)).resolves.not.toThrow();
-        const notes = await provider.getNotes({ contractAddress: CONTRACT_A });
-        expect(notes).toHaveLength(0);
-      });
-    });
-  });
+  //     it('handles rollback on empty PXE database gracefully', async () => {
+  //       await expect(provider.rollbackNotesAndNullifiers(10, 20)).resolves.not.toThrow();
+  //       const notes = await provider.getNotes({ contractAddress: CONTRACT_A });
+  //       expect(notes).toHaveLength(0);
+  //     });
+  //   });
+  // });
 });

--- a/yarn-project/pxe/src/storage/note_data_provider/note_data_provider.test.ts
+++ b/yarn-project/pxe/src/storage/note_data_provider/note_data_provider.test.ts
@@ -502,164 +502,136 @@ describe('NoteDataProvider', () => {
     });
   });
 
-  // describe('NoteDataProvider.rollbackNotesAndNullifiers', () => {
-  //   let provider: NoteDataProvider;
-  //   let store: AztecLMDBStoreV2;
+  describe('NoteDataProvider.rollbackNotesAndNullifiers', () => {
+    let provider: NoteDataProvider;
+    let store: AztecLMDBStoreV2;
 
-  //   beforeEach(async () => {
-  //     store = await openTmpStore('note_data_provider_rollback_test');
-  //     provider = await NoteDataProvider.create(store);
-  //     await provider.addScope(SCOPE_1);
-  //     await provider.addScope(SCOPE_2);
-  //   });
+    beforeEach(async () => {
+      store = await openTmpStore('note_data_provider_rollback_test');
+      provider = NoteDataProvider.create(store);
+    });
 
-  //   afterEach(async () => {
-  //     await store.close();
-  //   });
+    afterEach(async () => {
+      await store.close();
+    });
 
-  //   describe('rewind nullifications happy path', () => {
-  //     async function setupRollbackScenario() {
-  //       const noteBlock1 = await mkNote({ index: 1n, l2BlockNumber: 1 }); // Nullified at block 2
-  //       const noteBlock2 = await mkNote({ index: 2n, l2BlockNumber: 2 }); // Never nullified
-  //       const noteBlock3 = await mkNote({ index: 3n, l2BlockNumber: 3 }); // Nullified at block 4
-  //       const noteBlock5 = await mkNote({ index: 5n, l2BlockNumber: 5 }); // Created after rollback block 3
+    describe('rewind nullifications happy path', () => {
+      async function setupRollbackScenario() {
+        const noteBlock1 = await mkNote({ index: 1n, l2BlockNumber: 1 }); // Nullified at block 2
+        const noteBlock2 = await mkNote({ index: 2n, l2BlockNumber: 2 }); // Never nullified
+        const noteBlock3 = await mkNote({ index: 3n, l2BlockNumber: 3 }); // Nullified at block 4
+        const noteBlock5 = await mkNote({ index: 5n, l2BlockNumber: 5 }); // Created after rollback block 3
 
-  //       await provider.addNotes([noteBlock1, noteBlock2, noteBlock3, noteBlock5], SCOPE_1);
+        await provider.addNotes([noteBlock1, noteBlock2, noteBlock3, noteBlock5], SCOPE_1);
 
-  //       const nullifiers = [mkNullifier(noteBlock1, 2), mkNullifier(noteBlock3, 4), mkNullifier(noteBlock5, 6)];
+        const nullifiers = [mkNullifier(noteBlock1, 2), mkNullifier(noteBlock3, 4), mkNullifier(noteBlock5, 6)];
 
-  //       // Apply nullifiers and rollback to block 3
-  //       // - should restore noteBlock3 (nullified at block 4) and preserve noteBlock1 (nullified at block 2)
-  //       await provider.applyNullifiers(nullifiers);
-  //       await provider.rollbackNotesAndNullifiers(3, 6);
-  //     }
+        // Apply nullifiers and rollback to block 3
+        // - should restore noteBlock3 (nullified at block 4) and preserve noteBlock1 (nullified at block 2)
+        await provider.applyNullifiers(nullifiers);
+        await provider.rollbackNotesAndNullifiers(3);
+      }
 
-  //     beforeEach(async () => {
-  //       await setupRollbackScenario();
-  //     });
+      beforeEach(async () => {
+        await setupRollbackScenario();
+      });
 
-  //     it('restores notes that were nullified after the rollback block', async () => {
-  //       // noteBlock2 remains active, noteBlock3 was nullified at block 4 should be restored
-  //       const activeNotes = await provider.getNotes({ contractAddress: CONTRACT_A });
-  //       expect(new Set(getIndexes(activeNotes))).toEqual(new Set([2n, 3n]));
-  //     });
+      it('restores notes that were nullified after the rollback block', async () => {
+        // noteBlock2 remains active, noteBlock3 was nullified at block 4 should be restored
+        const activeNotes = await provider.getNotes({ contractAddress: CONTRACT_A });
+        expect(new Set(getIndexes(activeNotes))).toEqual(new Set([2n, 3n]));
+      });
 
-  //     it('preserves nullification of notes nullified at or before the rollback block', async () => {
-  //       const allNotes = await provider.getNotes({
-  //         contractAddress: CONTRACT_A,
-  //         status: NoteStatus.ACTIVE_OR_NULLIFIED,
-  //       });
+      it('preserves nullification of notes nullified at or before the rollback block', async () => {
+        const allNotes = await provider.getNotes({
+          contractAddress: CONTRACT_A,
+          status: 'ALL',
+        });
 
-  //       // Should contain noteBlock1 (nullified), noteBlock2 (active), and noteBlock3 (restored)
-  //       expect(new Set(getIndexes(allNotes))).toEqual(new Set([1n, 2n, 3n]));
+        // Should contain noteBlock1 (nullified), noteBlock2 (active), and noteBlock3 (restored)
+        expect(new Set(getIndexes(allNotes))).toEqual(new Set([1n, 2n, 3n]));
 
-  //       // Verify noteBlock1 is not in active notes
-  //       const activeNotes = await provider.getNotes({ contractAddress: CONTRACT_A });
-  //       const activeIndexes = getIndexes(activeNotes);
-  //       expect(activeIndexes).not.toEqual(expect.arrayContaining([1n]));
-  //     });
+        // Verify noteBlock1 is not in active notes
+        const activeNotes = await provider.getNotes({ contractAddress: CONTRACT_A });
+        const activeIndexes = getIndexes(activeNotes);
+        expect(activeIndexes).not.toEqual(expect.arrayContaining([1n]));
+      });
 
-  //     it('preserves active notes created before the rollback block that were never nullified', async () => {
-  //       // noteBlock2 was created at block 2 (before rollback block 3) and never nullified
-  //       const activeNotes = await provider.getNotes({ contractAddress: CONTRACT_A });
-  //       expect(new Set(getIndexes(activeNotes))).toEqual(new Set([2n, 3n]));
-  //     });
+      it('preserves active notes created before the rollback block that were never nullified', async () => {
+        // noteBlock2 was created at block 2 (before rollback block 3) and never nullified
+        const activeNotes = await provider.getNotes({ contractAddress: CONTRACT_A });
+        expect(new Set(getIndexes(activeNotes))).toEqual(new Set([2n, 3n]));
+      });
 
-  //     it('deletes notes created after the rollback block', async () => {
-  //       const allNotes = await provider.getNotes({
-  //         contractAddress: CONTRACT_A,
-  //         status: NoteStatus.ACTIVE_OR_NULLIFIED,
-  //       });
+      it('deletes notes created after the rollback block', async () => {
+        const allNotes = await provider.getNotes({
+          contractAddress: CONTRACT_A,
+          status: 'ALL',
+        });
 
-  //       // noteBlock5 was created at block 5, which is after rollback block 3, should be deleted
-  //       const indexes = getIndexes(allNotes);
-  //       expect(new Set(indexes)).toEqual(new Set([1n, 2n, 3n]));
-  //       expect(indexes).not.toEqual(expect.arrayContaining([5n]));
-  //     });
-  //   });
+        // noteBlock5 was created at block 5, which is after rollback block 3, should be deleted
+        const indexes = getIndexes(allNotes);
+        expect(new Set(indexes)).toEqual(new Set([1n, 2n, 3n]));
+        expect(indexes).not.toEqual(expect.arrayContaining([5n]));
+      });
+    });
 
-  //   describe('rewind nullifications edge cases', () => {
-  //     it('handles rollback when blockNumber equals synchedBlockNumber', async () => {
-  //       const note = await mkNote({ index: 10n, l2BlockNumber: 5 });
-  //       await provider.addNotes([note], SCOPE_1);
+    describe('rewind nullifications edge cases', () => {
+      it('handles rollback when blockNumber equals synchedBlockNumber', async () => {
+        const note = await mkNote({ index: 10n, l2BlockNumber: 5 });
+        await provider.addNotes([note], SCOPE_1);
 
-  //       const nullifiers = [
-  //         {
-  //           data: note.siloedNullifier,
-  //           l2BlockNumber: 5,
-  //           l2BlockHash: L2BlockHash.fromString(note.l2BlockHash),
-  //         },
-  //       ];
-  //       await provider.applyNullifiers(nullifiers);
+        const nullifiers = [
+          {
+            data: note.siloedNullifier,
+            l2BlockNumber: 5,
+            l2BlockHash: L2BlockHash.fromString(note.l2BlockHash),
+          },
+        ];
+        await provider.applyNullifiers(nullifiers);
 
-  //       // Since nullification happened at block 5 (not after), it should stay nullified
-  //       // The rewind loop processes blocks (blockNumber+1) to synchedBlockNumber = 6 to 5 = no iterations
-  //       await provider.rollbackNotesAndNullifiers(5, 5);
+        // Since nullification happened at block 5 (not after), it should stay nullified
+        // The rewind loop processes blocks (blockNumber+1) to synchedBlockNumber = 6 to 5 = no iterations
+        await provider.rollbackNotesAndNullifiers(5);
 
-  //       const activeNotes = await provider.getNotes({ contractAddress: CONTRACT_A });
-  //       expect(activeNotes).toHaveLength(0);
+        const activeNotes = await provider.getNotes({ contractAddress: CONTRACT_A });
+        expect(activeNotes).toHaveLength(0);
 
-  //       const allNotes = await provider.getNotes({
-  //         contractAddress: CONTRACT_A,
-  //         status: NoteStatus.ACTIVE_OR_NULLIFIED,
-  //       });
-  //       expect(new Set(getIndexes(allNotes))).toEqual(new Set([10n]));
-  //     });
+        const allNotes = await provider.getNotes({
+          contractAddress: CONTRACT_A,
+          status: 'ALL',
+        });
+        expect(new Set(getIndexes(allNotes))).toEqual(new Set([10n]));
+      });
 
-  //     it('handles rollback when synchedBlockNumber < blockNumber', async () => {
-  //       const note = await mkNote({ index: 20n, l2BlockNumber: 3 });
-  //       await provider.addNotes([note], SCOPE_1);
+      it('handles rollback with a large block gap', async () => {
+        const note1 = await mkNote({ index: 30n, l2BlockNumber: 5 });
+        const note2 = await mkNote({ index: 31n, l2BlockNumber: 10 });
+        await provider.addNotes([note1, note2], SCOPE_1);
 
-  //       const nullifiers = [
-  //         {
-  //           data: note.siloedNullifier,
-  //           l2BlockNumber: 4,
-  //           l2BlockHash: L2BlockHash.fromString(note.l2BlockHash),
-  //         },
-  //       ];
-  //       await provider.applyNullifiers(nullifiers);
+        const nullifiers = [
+          {
+            data: note1.siloedNullifier,
+            l2BlockNumber: 7,
+            l2BlockHash: L2BlockHash.fromString(note1.l2BlockHash),
+          },
+        ];
+        await provider.applyNullifiers(nullifiers);
+        await provider.rollbackNotesAndNullifiers(5);
 
-  //       // blockNumber=6, synchedBlockNumber=4 therefore no nullifications to rewind
-  //       await provider.rollbackNotesAndNullifiers(6, 4);
+        // note1 should be restored (nullified at block 7 > rollback block 5)
+        // note2 should be deleted (created at block 10 > rollback block 5)
+        const activeNotes = await provider.getNotes({ contractAddress: CONTRACT_A });
+        expect(new Set(getIndexes(activeNotes))).toEqual(new Set([30n]));
+      });
 
-  //       const activeNotes = await provider.getNotes({ contractAddress: CONTRACT_A });
-  //       expect(activeNotes).toHaveLength(0);
-
-  //       const allNotes = await provider.getNotes({
-  //         contractAddress: CONTRACT_A,
-  //         status: NoteStatus.ACTIVE_OR_NULLIFIED,
-  //       });
-  //       expect(new Set(getIndexes(allNotes))).toEqual(new Set([20n]));
-  //     });
-
-  //     it('handles rollback with a large block gap', async () => {
-  //       const note1 = await mkNote({ index: 30n, l2BlockNumber: 5 });
-  //       const note2 = await mkNote({ index: 31n, l2BlockNumber: 10 });
-  //       await provider.addNotes([note1, note2], SCOPE_1);
-
-  //       const nullifiers = [
-  //         {
-  //           data: note1.siloedNullifier,
-  //           l2BlockNumber: 7,
-  //           l2BlockHash: L2BlockHash.fromString(note1.l2BlockHash),
-  //         },
-  //       ];
-  //       await provider.applyNullifiers(nullifiers);
-  //       await provider.rollbackNotesAndNullifiers(5, 100);
-
-  //       // note1 should be restored (nullified at block 7 > rollback block 5)
-  //       // note2 should be deleted (created at block 10 > rollback block 5)
-  //       const activeNotes = await provider.getNotes({ contractAddress: CONTRACT_A });
-  //       expect(new Set(getIndexes(activeNotes))).toEqual(new Set([30n]));
-  //     });
-
-  //     it('handles rollback on empty PXE database gracefully', async () => {
-  //       await expect(provider.rollbackNotesAndNullifiers(10, 20)).resolves.not.toThrow();
-  //       const notes = await provider.getNotes({ contractAddress: CONTRACT_A });
-  //       expect(notes).toHaveLength(0);
-  //     });
-  //   });
-  // });
+      it('handles rollback on empty PXE database gracefully', async () => {
+        await expect(provider.rollbackNotesAndNullifiers(10)).resolves.not.toThrow();
+        const notes = await provider.getNotes({ contractAddress: CONTRACT_A });
+        expect(notes).toHaveLength(0);
+      });
+    });
+  });
 });
 
 // TODO:

--- a/yarn-project/pxe/src/storage/note_data_provider/note_data_provider.test.ts
+++ b/yarn-project/pxe/src/storage/note_data_provider/note_data_provider.test.ts
@@ -1,9 +1,8 @@
 import { Fr } from '@aztec/foundation/fields';
 import { AztecLMDBStoreV2, openTmpStore } from '@aztec/kv-store/lmdb-v2';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
-
-// import { L2BlockHash } from '@aztec/stdlib/block';
-// import { type NotesFilter, StoredNoteStatus } from '@aztec/stdlib/note';
+import { L2BlockHash } from '@aztec/stdlib/block';
+import type { NotesFilter } from '@aztec/stdlib/note';
 
 import { NoteDao } from './note_dao.js';
 import { NoteDataProvider } from './note_data_provider.js';
@@ -55,9 +54,6 @@ describe('NoteDataProvider', () => {
     const store = await openTmpStore(storeName);
     const provider = NoteDataProvider.create(store);
 
-    // await provider.addScope(SCOPE_1);
-    // await provider.addScope(SCOPE_2);
-
     const note1 = await mkNote({
       contractAddress: CONTRACT_A,
       storageSlot: SLOT_X,
@@ -87,13 +83,13 @@ describe('NoteDataProvider', () => {
   }
 
   // Helper to create a nullifier object matching a given note.
-  // function mkNullifier(note: NoteDao, blockNumber?: number) {
-  //   return {
-  //     data: note.siloedNullifier,
-  //     l2BlockNumber: blockNumber ?? note.l2BlockNumber,
-  //     l2BlockHash: L2BlockHash.fromString(note.l2BlockHash),
-  //   };
-  // }
+  function mkNullifier(note: NoteDao, blockNumber?: number) {
+    return {
+      data: note.siloedNullifier,
+      l2BlockNumber: blockNumber ?? note.l2BlockNumber,
+      l2BlockHash: L2BlockHash.fromString(note.l2BlockHash),
+    };
+  }
 
   // Extracts the `index` field from an array of notes for easy comparison in tests.
   function getIndexes(notes: NoteDao[]) {
@@ -119,9 +115,6 @@ describe('NoteDataProvider', () => {
       // First provider populates the store; second reopens it to verify persistence
       const provider1 = NoteDataProvider.create(store);
 
-      // await provider1.addScope(SCOPE_1);
-      // await provider1.addScope(SCOPE_2);
-
       const noteA = await mkNote({ contractAddress: CONTRACT_A, recipient: SCOPE_1, index: 1n });
       const noteB = await mkNote({ contractAddress: CONTRACT_B, recipient: SCOPE_2, index: 2n });
       await provider1.addNotes([noteA, noteB], FAKE_ADDRESS);
@@ -138,6 +131,7 @@ describe('NoteDataProvider', () => {
     });
   });
 
+  // TODO: Complete these tests
   describe('NoteDataProvider.addNotes same note twice!!! NEW TEST TO COMPLETE', () => {
     it('adds notes under different scopes and retrieves them correctly', () => {
       expect(true);
@@ -163,10 +157,10 @@ describe('NoteDataProvider', () => {
     let provider: NoteDataProvider;
     let note1: NoteDao;
     let note2: NoteDao;
-    // let note3: NoteDao;
+    let note3: NoteDao;
 
     beforeEach(async () => {
-      ({ store, provider, note1, note2 } = await setupProviderWithNotes('note_data_provider_get_notes_happy'));
+      ({ store, provider, note1, note2, note3 } = await setupProviderWithNotes('note_data_provider_get_notes_happy'));
     });
 
     afterEach(async () => {
@@ -207,19 +201,19 @@ describe('NoteDataProvider', () => {
       expect(new Set(getIndexes(res))).toEqual(new Set([1n, 2n, 4n])); // note1, note2, and note4
     });
 
-    // it('filters notes by status, returning ACTIVE by default and both ACTIVE and NULLIFIED when requested', async () => {
-    //   const nullifiers = [mkNullifier(note2)];
-    //   await expect(provider.applyNullifiers(nullifiers)).resolves.toEqual([note2]);
+    it('filters notes by status, returning ACTIVE by default and both ACTIVE and NULLIFIED when requested', async () => {
+      const nullifiers = [mkNullifier(note2)];
+      await expect(provider.applyNullifiers(nullifiers)).resolves.toEqual([note2]);
 
-    //   const resActive = await provider.getNotes({ contractAddress: CONTRACT_A });
-    //   expect(new Set(getIndexes(resActive))).toEqual(new Set([1n]));
+      const resActive = await provider.getNotes({ contractAddress: CONTRACT_A });
+      expect(new Set(getIndexes(resActive))).toEqual(new Set([1n]));
 
-    //   const resAll = await provider.getNotes({
-    //     contractAddress: CONTRACT_A,
-    //     status: NoteStatus.ALL,
-    //   });
-    //   expect(new Set(getIndexes(resAll))).toEqual(new Set([1n, 2n]));
-    // });
+      const resAll = await provider.getNotes({
+        contractAddress: CONTRACT_A,
+        status: 'ALL',
+      });
+      expect(new Set(getIndexes(resAll))).toEqual(new Set([1n, 2n]));
+    });
 
     it('returns only notes that match all provided filters', async () => {
       const res = await provider.getNotes({
@@ -231,28 +225,28 @@ describe('NoteDataProvider', () => {
       expect(new Set(getIndexes(res))).toEqual(new Set([1n]));
     });
 
-    // it('applies scope filtering to nullified notes', async () => {
-    //   const nullifiers = [mkNullifier(note3)];
-    //   await expect(provider.applyNullifiers(nullifiers)).resolves.toEqual([note3]);
+    it('applies scope filtering to nullified notes', async () => {
+      const nullifiers = [mkNullifier(note3)];
+      await expect(provider.applyNullifiers(nullifiers)).resolves.toEqual([note3]);
 
-    //   // Query for contractB, but with the wrong scope (scope1)
-    //   const res = await provider.getNotes({
-    //     contractAddress: CONTRACT_B,
-    //     scopes: [SCOPE_1],
-    //     status: NoteStatus.ALL,
-    //   });
+      // Query for contractB, but with the wrong scope (scope1)
+      const res = await provider.getNotes({
+        contractAddress: CONTRACT_B,
+        scopes: [SCOPE_1],
+        status: 'ALL',
+      });
 
-    //   expect(res).toHaveLength(0);
+      expect(res).toHaveLength(0);
 
-    //   // Query for contractB with the correct scope (scope2)
-    //   const res2 = await provider.getNotes({
-    //     contractAddress: CONTRACT_B,
-    //     scopes: [SCOPE_2],
-    //     status: NoteStatus.ALL,
-    //   });
+      // Query for contractB with the correct scope (scope2)
+      const res2 = await provider.getNotes({
+        contractAddress: CONTRACT_B,
+        scopes: [SCOPE_2],
+        status: 'ALL',
+      });
 
-    //   expect(new Set(getIndexes(res2))).toEqual(new Set([3n]));
-    // });
+      expect(new Set(getIndexes(res2))).toEqual(new Set([3n]));
+    });
 
     it('filters notes by siloedNullifier', async () => {
       const filter = {
@@ -339,174 +333,174 @@ describe('NoteDataProvider', () => {
     });
   });
 
-  // describe('NoteDataProvider.applyNullifiers happy path', () => {
-  //   let store: AztecLMDBStoreV2;
-  //   let provider: NoteDataProvider;
-  //   let note1: NoteDao;
-  //   let note2: NoteDao;
-  //   let note3: NoteDao;
+  describe('NoteDataProvider.applyNullifiers happy path', () => {
+    let store: AztecLMDBStoreV2;
+    let provider: NoteDataProvider;
+    let note1: NoteDao;
+    let note2: NoteDao;
+    let note3: NoteDao;
 
-  //   beforeEach(async () => {
-  //     ({ store, provider, note1, note2, note3 } = await setupProviderWithNotes(
-  //       'note_data_provider_apply_nullifiers_happy',
-  //     ));
-  //   });
+    beforeEach(async () => {
+      ({ store, provider, note1, note2, note3 } = await setupProviderWithNotes(
+        'note_data_provider_apply_nullifiers_happy',
+      ));
+    });
 
-  //   afterEach(async () => {
-  //     await store.close();
-  //   });
+    afterEach(async () => {
+      await store.close();
+    });
 
-  //   it('returns empty array when given empty nullifiers array', async () => {
-  //     const result = await provider.applyNullifiers([]);
-  //     expect(result).toEqual([]);
-  //   });
+    it('returns empty array when given empty nullifiers array', async () => {
+      const result = await provider.applyNullifiers([]);
+      expect(result).toEqual([]);
+    });
 
-  //   it('nullifies a single note and moves it from active to nullified', async () => {
-  //     const result = await provider.applyNullifiers([mkNullifier(note1)]);
-  //     expect(result).toEqual([note1]);
+    it('nullifies a single note and moves it from active to nullified', async () => {
+      const result = await provider.applyNullifiers([mkNullifier(note1)]);
+      expect(result).toEqual([note1]);
 
-  //     const active = await provider.getNotes({ contractAddress: CONTRACT_A });
-  //     const all = await provider.getNotes({
-  //       contractAddress: CONTRACT_A,
-  //       status: NoteStatus.ACTIVE_OR_NULLIFIED,
-  //     });
+      const active = await provider.getNotes({ contractAddress: CONTRACT_A });
+      const all = await provider.getNotes({
+        contractAddress: CONTRACT_A,
+        status: 'ALL',
+      });
 
-  //     expect(new Set(getIndexes(active))).toEqual(new Set([2n]));
-  //     expect(new Set(getIndexes(all))).toEqual(new Set([1n, 2n]));
-  //   });
+      expect(new Set(getIndexes(active))).toEqual(new Set([2n]));
+      expect(new Set(getIndexes(all))).toEqual(new Set([1n, 2n]));
+    });
 
-  //   it('nullifies multiple notes and returns them', async () => {
-  //     const nullifiers = [mkNullifier(note1), mkNullifier(note3)];
-  //     const result = await provider.applyNullifiers(nullifiers);
+    it('nullifies multiple notes and returns them', async () => {
+      const nullifiers = [mkNullifier(note1), mkNullifier(note3)];
+      const result = await provider.applyNullifiers(nullifiers);
 
-  //     const activeA = await provider.getNotes({ contractAddress: CONTRACT_A });
-  //     const activeB = await provider.getNotes({ contractAddress: CONTRACT_B });
+      const activeA = await provider.getNotes({ contractAddress: CONTRACT_A });
+      const activeB = await provider.getNotes({ contractAddress: CONTRACT_B });
 
-  //     expect(result).toEqual([note1, note3]); // returned nullified notes
-  //     expect(new Set(getIndexes(activeA))).toEqual(new Set([2n])); // note2 remains active
-  //     expect(getIndexes(activeB)).toHaveLength(0); // no active notes in contractB
-  //   });
+      expect(result).toEqual([note1, note3]); // returned nullified notes
+      expect(new Set(getIndexes(activeA))).toEqual(new Set([2n])); // note2 remains active
+      expect(getIndexes(activeB)).toHaveLength(0); // no active notes in contractB
+    });
 
-  //   it('retrieves a nullified note by its siloedNullifier when status is ACTIVE_OR_NULLIFIED', async () => {
-  //     await provider.applyNullifiers([mkNullifier(note2)]);
+    it('retrieves a nullified note by its siloedNullifier when status is ACTIVE_OR_NULLIFIED', async () => {
+      await provider.applyNullifiers([mkNullifier(note2)]);
 
-  //     const filter = {
-  //       contractAddress: CONTRACT_A,
-  //       siloedNullifier: note2.siloedNullifier,
-  //       status: NoteStatus.ACTIVE_OR_NULLIFIED,
-  //     };
+      const filter: NotesFilter = {
+        contractAddress: CONTRACT_A,
+        siloedNullifier: note2.siloedNullifier,
+        status: 'ALL',
+      };
 
-  //     const res = await provider.getNotes(filter);
-  //     expect(new Set(getIndexes(res))).toEqual(new Set([2n]));
-  //   });
-  // });
+      const res = await provider.getNotes(filter);
+      expect(new Set(getIndexes(res))).toEqual(new Set([2n]));
+    });
+  });
 
-  // describe('NoteDataProvider.applyNullifiers edge cases', () => {
-  //   let store: AztecLMDBStoreV2;
-  //   let provider: NoteDataProvider;
-  //   let note1: NoteDao;
-  //   let note2: NoteDao;
+  describe('NoteDataProvider.applyNullifiers edge cases', () => {
+    let store: AztecLMDBStoreV2;
+    let provider: NoteDataProvider;
+    let note1: NoteDao;
+    let note2: NoteDao;
 
-  //   beforeEach(async () => {
-  //     ({ store, provider, note1, note2 } = await setupProviderWithNotes('note_data_provider_apply_nullifiers_edge'));
-  //   });
+    beforeEach(async () => {
+      ({ store, provider, note1, note2 } = await setupProviderWithNotes('note_data_provider_apply_nullifiers_edge'));
+    });
 
-  //   afterEach(async () => {
-  //     await store.close();
-  //   });
+    afterEach(async () => {
+      await store.close();
+    });
 
-  //   it('throws error when nullifier is not found', async () => {
-  //     const fakeNullifier = {
-  //       data: Fr.random(),
-  //       l2BlockNumber: 999,
-  //       l2BlockHash: L2BlockHash.random(),
-  //     };
+    it('throws error when nullifier is not found', async () => {
+      const fakeNullifier = {
+        data: Fr.random(),
+        l2BlockNumber: 999,
+        l2BlockHash: L2BlockHash.random(),
+      };
 
-  //     await expect(provider.applyNullifiers([fakeNullifier])).rejects.toThrow('Nullifier not found in applyNullifiers');
-  //   });
+      await expect(provider.applyNullifiers([fakeNullifier])).rejects.toThrow(/Nullifier not found in applyNullifiers/);
+    });
 
-  //   it('preserves scope information when nullifying notes', async () => {
-  //     const nullifiers = [mkNullifier(note1)];
-  //     await provider.applyNullifiers(nullifiers);
+    it('preserves scope information when nullifying notes', async () => {
+      const nullifiers = [mkNullifier(note1)];
+      await provider.applyNullifiers(nullifiers);
 
-  //     // Verify nullified note remains visible only within its original scope
-  //     const wrongScopeNotes = await provider.getNotes({
-  //       contractAddress: CONTRACT_A,
-  //       scopes: [SCOPE_2],
-  //       status: NoteStatus.ACTIVE_OR_NULLIFIED,
-  //     });
-  //     expect(getIndexes(wrongScopeNotes)).not.toContain(1n);
+      // Verify nullified note remains visible only within its original scope
+      const wrongScopeNotes = await provider.getNotes({
+        contractAddress: CONTRACT_A,
+        scopes: [SCOPE_2],
+        status: 'ALL',
+      });
+      expect(getIndexes(wrongScopeNotes)).not.toContain(1n);
 
-  //     const correctScopeNotes = await provider.getNotes({
-  //       contractAddress: CONTRACT_A,
-  //       scopes: [SCOPE_1],
-  //       status: NoteStatus.ACTIVE_OR_NULLIFIED,
-  //     });
-  //     expect(getIndexes(correctScopeNotes)).toContain(1n);
-  //   });
+      const correctScopeNotes = await provider.getNotes({
+        contractAddress: CONTRACT_A,
+        scopes: [SCOPE_1],
+        status: 'ALL',
+      });
+      expect(getIndexes(correctScopeNotes)).toContain(1n);
+    });
 
-  //   it('is atomic - fails entirely if any nullifier is invalid', async () => {
-  //     // Should fail entirely: note1 remains active because transaction is atomic.
-  //     const nullifiers = [
-  //       mkNullifier(note2),
-  //       {
-  //         data: Fr.random(), // Invalid
-  //         l2BlockNumber: 999,
-  //         l2BlockHash: L2BlockHash.random(),
-  //       },
-  //     ];
+    it('is atomic - fails entirely if any nullifier is invalid', async () => {
+      // Should fail entirely: note1 remains active because transaction is atomic.
+      const nullifiers = [
+        mkNullifier(note2),
+        {
+          data: Fr.random(), // Invalid
+          l2BlockNumber: 999,
+          l2BlockHash: L2BlockHash.random(),
+        },
+      ];
 
-  //     await expect(provider.applyNullifiers(nullifiers)).rejects.toThrow();
+      await expect(provider.applyNullifiers(nullifiers)).rejects.toThrow();
 
-  //     // Verify note1 is still active (transaction rolled back)
-  //     const activeNotes = await provider.getNotes({ contractAddress: CONTRACT_A });
-  //     expect(new Set(getIndexes(activeNotes))).toEqual(new Set([1n, 2n]));
-  //   });
+      // Verify note1 is still active (transaction rolled back)
+      const activeNotes = await provider.getNotes({ contractAddress: CONTRACT_A });
+      expect(new Set(getIndexes(activeNotes))).toEqual(new Set([1n, 2n]));
+    });
 
-  //   it('updates all relevant indexes when nullifying notes', async () => {
-  //     const nullifiers = [mkNullifier(note1)];
-  //     await provider.applyNullifiers(nullifiers);
+    it('updates all relevant indexes when nullifying notes', async () => {
+      const nullifiers = [mkNullifier(note1)];
+      await provider.applyNullifiers(nullifiers);
 
-  //     // Test various filter combinations still work
-  //     const byContract = await provider.getNotes({
-  //       contractAddress: CONTRACT_A,
-  //       status: NoteStatus.ACTIVE_OR_NULLIFIED,
-  //     });
-  //     expect(new Set(getIndexes(byContract))).toEqual(new Set([1n, 2n]));
+      // Test various filter combinations still work
+      const byContract = await provider.getNotes({
+        contractAddress: CONTRACT_A,
+        status: 'ALL',
+      });
+      expect(new Set(getIndexes(byContract))).toEqual(new Set([1n, 2n]));
 
-  //     const bySlot = await provider.getNotes({
-  //       contractAddress: CONTRACT_A,
-  //       storageSlot: note1.storageSlot,
-  //       status: NoteStatus.ACTIVE_OR_NULLIFIED,
-  //     });
-  //     expect(new Set(getIndexes(bySlot))).toEqual(new Set([1n]));
+      const bySlot = await provider.getNotes({
+        contractAddress: CONTRACT_A,
+        storageSlot: note1.storageSlot,
+        status: 'ALL',
+      });
+      expect(new Set(getIndexes(bySlot))).toEqual(new Set([1n]));
 
-  //     const byScope = await provider.getNotes({
-  //       contractAddress: CONTRACT_A,
-  //       scopes: [note1.recipient],
-  //       status: NoteStatus.ACTIVE_OR_NULLIFIED,
-  //     });
-  //     expect(new Set(getIndexes(byScope))).toEqual(new Set([1n, 2n]));
-  //   });
+      const byScope = await provider.getNotes({
+        contractAddress: CONTRACT_A,
+        scopes: [note1.recipient],
+        status: 'ALL',
+      });
+      expect(new Set(getIndexes(byScope))).toEqual(new Set([1n, 2n]));
+    });
 
-  //   it('attempts to nullify the same note twice in succession results in error', async () => {
-  //     await provider.applyNullifiers([mkNullifier(note1)]); // First application should succeed
-  //     const activeNotes = await provider.getNotes({ contractAddress: CONTRACT_A });
-  //     expect(new Set(getIndexes(activeNotes))).toEqual(new Set([2n]));
+    it('attempts to nullify the same note twice in succession results in error', async () => {
+      await provider.applyNullifiers([mkNullifier(note1)]); // First application should succeed
+      const activeNotes = await provider.getNotes({ contractAddress: CONTRACT_A });
+      expect(new Set(getIndexes(activeNotes))).toEqual(new Set([2n]));
 
-  //     // should throw on second attempt as note1 is already nullified
-  //     await expect(provider.applyNullifiers([mkNullifier(note1)])).rejects.toThrow(
-  //       'Nullifier already applied in applyNullifiers',
-  //     );
-  //   });
+      // should throw on second attempt as note1 is already nullified
+      await expect(provider.applyNullifiers([mkNullifier(note1)])).rejects.toThrow(
+        'Nullifier already applied in applyNullifiers',
+      );
+    });
 
-  //   it('attempts to nullify the same note twice in same call results in error', async () => {
-  //     const nullifiers = [mkNullifier(note1), mkNullifier(note1)];
-  //     await expect(provider.applyNullifiers(nullifiers)).rejects.toThrow(
-  //       'Nullifier already applied in applyNullifiers',
-  //     );
-  //   });
-  // });
+    it('attempts to nullify the same note twice in same call results in error', async () => {
+      const nullifiers = [mkNullifier(note1), mkNullifier(note1)];
+      await expect(provider.applyNullifiers(nullifiers)).rejects.toThrow(
+        'Nullifier already applied in applyNullifiers',
+      );
+    });
+  });
 
   // describe('NoteDataProvider.rollbackNotesAndNullifiers', () => {
   //   let provider: NoteDataProvider;
@@ -667,3 +661,6 @@ describe('NoteDataProvider', () => {
   //   });
   // });
 });
+
+// TODO:
+// haven't tests explicitly setting notesFilter to 'ACTIVE' or 'NULLIFIED'

--- a/yarn-project/pxe/src/storage/note_data_provider/note_data_provider.ts
+++ b/yarn-project/pxe/src/storage/note_data_provider/note_data_provider.ts
@@ -165,37 +165,83 @@ export class NoteDataProvider {
    * and deletes any active notes created after that block.
    *
    * @param blockNumber - The new chain tip after a reorg
-   * @param synchedBlockNumber - The block number up to which PXE managed to sync before the reorg happened.
    */
-  public async rollbackNotesAndNullifiers(blockNumber: number, synchedBlockNumber: number): Promise<void> {
-    await this.#rewindNullifiersAfterBlock(blockNumber, synchedBlockNumber);
-    await this.#deleteActiveNotesAfterBlock(blockNumber);
+  public async rollbackNotesAndNullifiers(blockNumber: number): Promise<void> {
+    await this.#store.transactionAsync(async () => {
+      const highestKnownBlock = await this.#getHighestKnownBlockNumber();
+      if (highestKnownBlock === undefined || highestKnownBlock <= blockNumber) {
+        return;
+      }
+
+      // Walk blocks in descending order and revert events
+      for (let block = highestKnownBlock; block > blockNumber; block--) {
+        const events = await toArray(this.#noteEventsByBlock.getValuesAsync(block as BlockNumber));
+        if (events.length === 0) {
+          continue;
+        }
+
+        for (const event of events) {
+          switch (event.kind) {
+            // Undo nullification → restore the note to ACTIVE
+            case 'NULLIFY': {
+              const noteId = event.noteId as NoteId;
+              const noteBuffer = await this.#notes.getAsync(noteId);
+              if (!noteBuffer) {
+                continue;
+              }
+
+              await this.#noteStatusById.set(noteId, NoteStatus.ACTIVE);
+              const compositeKey = await this.#compositeKeyByNoteId.getAsync(noteId);
+              if (compositeKey) {
+                await this.#noteIdsByCompositeKey.set(compositeKey, noteId);
+              }
+              break;
+            }
+
+            // Delete note created after rollback height
+            case 'CREATE': {
+              const noteId = event.noteId as NoteId;
+              const noteBuffer = await this.#notes.getAsync(noteId);
+              if (!noteBuffer) {
+                continue;
+              }
+
+              const compositeKey = await this.#compositeKeyByNoteId.getAsync(noteId);
+              if (compositeKey) {
+                await this.#noteIdsByCompositeKey.deleteValue(compositeKey, noteId);
+                await this.#compositeKeyByNoteId.delete(noteId);
+              }
+
+              // Remove from all other indexes
+              await this.#notes.delete(noteId);
+              await this.#noteStatusById.delete(noteId);
+
+              // Remove reverse mapping to nullifier (if exists)
+              const nullifierEntries = await toArray(this.#nullifierToNoteId.entriesAsync());
+              for (const [nullifier, id] of nullifierEntries) {
+                if (id === noteId) {
+                  await this.#nullifierToNoteId.delete(nullifier);
+                }
+              }
+              break;
+            }
+          }
+        }
+
+        // Once this block’s events are reverted, remove them from the index
+        await this.#noteEventsByBlock.delete(block as BlockNumber);
+      }
+    });
   }
 
   /**
-   * Deletes (removes) all active notes created after the specified block number.
-   *
-   * Permanently delete notes from the active notes store, e.g. during a reorg.
-   * Note: This only affects #notes (active notes), not #nullifiedNotes.
-   *
-   * @param blockNumber - Notes created after this block number will be deleted
+   * Returns the highest known block number present in noteEventsByBlock.
+   * Uses a reverse range to efficiently fetch the last (largest) key.
    */
-  #deleteActiveNotesAfterBlock(blockNumber: number): Promise<void> {
-    throw new Error('Method not implemented.');
-  }
-
-  /**
-   * Rewinds nullifications after a given block number.
-   *
-   * This operation "unnullifies" notes, rolling back nullifications that occurred
-   * in orphaned blocks, e.g. during a reorg.  The notes are restored to the
-   * active notes store and removed from the nullified store.
-   *
-   * @param blockNumber - Revert nullifications that occurred after this block
-   * @param synchedBlockNumber - Upper bound for the block range to process
-   */
-  async #rewindNullifiersAfterBlock(blockNumber: number, synchedBlockNumber: number): Promise<void> {
-    throw new Error('Method not implemented.');
+  async #getHighestKnownBlockNumber(): Promise<number | undefined> {
+    const keys = await toArray(this.#noteEventsByBlock.keysAsync({ reverse: true, limit: 1 }));
+    const [lastKey] = keys;
+    return lastKey !== undefined ? Number(lastKey) : undefined;
   }
 
   /**

--- a/yarn-project/pxe/src/storage/note_data_provider/note_data_provider.ts
+++ b/yarn-project/pxe/src/storage/note_data_provider/note_data_provider.ts
@@ -347,7 +347,7 @@ export class NoteDataProvider {
   }
 
   /**
-   * Transitions notes from "active" to "nullified" state.
+   * Marks notes as nullified based on the provided nullifiers.
    *
    * This operation processes a batch of nullifiers to mark the corresponding notes
    * as spent/nullified.  The operation is atomic - if any nullifier is not found,
@@ -358,6 +358,72 @@ export class NoteDataProvider {
    * @throws Error if any nullifier is not found in the active notes
    */
   applyNullifiers(nullifiers: InBlock<Fr>[]): Promise<NoteDao[]> {
-    throw new Error('Method not implemented.');
+    if (nullifiers.length === 0) {
+      return Promise.resolve([]);
+    }
+
+    return this.#store.transactionAsync(async () => {
+      const nullifiedNotes: NoteDao[] = [];
+
+      for (const { data: nullifier, l2BlockNumber } of nullifiers) {
+        const nullifierKey = toNullifier(nullifier);
+
+        // Lookup the note ID by nullifier (must exist - if not, check if it was already applied)
+        const noteId = await this.#nullifierToNoteId.getAsync(nullifierKey);
+        if (!noteId) {
+          const alreadyApplied = await this.#wasNullifierAlreadyApplied(nullifier);
+          if (alreadyApplied) {
+            throw new Error(`Nullifier already applied in applyNullifiers: ${nullifier.toString()}`);
+          }
+          throw new Error(`Nullifier not found in applyNullifiers: ${nullifier.toString()}`);
+        }
+
+        // Retrieve the note
+        const noteBuffer = await this.#notes.getAsync(noteId);
+        if (!noteBuffer) {
+          throw new Error(`Note not found in applyNullifiers for nullifier: ${nullifier.toString()}`);
+        }
+
+        const note = NoteDao.fromBuffer(noteBuffer);
+
+        // Verify status is ACTIVE
+        const status = await this.#noteStatusById.getAsync(noteId);
+        if (status !== NoteStatus.ACTIVE) {
+          throw new Error(`Attempted to nullify note ${noteId} which is not ACTIVE (status=${status})`);
+        }
+
+        // Update Indexes and status
+        await this.#noteStatusById.set(noteId, NoteStatus.NULLIFIED);
+        await this.#noteEventsByBlock.set(toBlockNumber(l2BlockNumber), { noteId, kind: 'NULLIFY' });
+        await this.#nullifierToNoteId.delete(nullifierKey);
+
+        nullifiedNotes.push(note);
+      }
+
+      return nullifiedNotes;
+    });
+  }
+
+  /**
+   * Checks whether a given nullifier has already been applied (i.e.
+   * a corresponding note was previously nullified).
+   */
+  async #wasNullifierAlreadyApplied(nullifier: Fr): Promise<boolean> {
+    for await (const [, event] of this.#noteEventsByBlock.entriesAsync()) {
+      if (event.kind !== 'NULLIFY') {
+        continue;
+      }
+
+      const serialized = await this.#notes.getAsync(event.noteId as NoteId);
+      if (!serialized) {
+        continue;
+      }
+
+      const note = NoteDao.fromBuffer(serialized);
+      if (note.siloedNullifier.equals(nullifier)) {
+        return true;
+      }
+    }
+    return false;
   }
 }

--- a/yarn-project/pxe/src/storage/note_data_provider/note_data_provider.ts
+++ b/yarn-project/pxe/src/storage/note_data_provider/note_data_provider.ts
@@ -1,12 +1,65 @@
-import { toBufferBE } from '@aztec/foundation/bigint-buffer';
-import type { Fr } from '@aztec/foundation/fields';
+import { toHex } from '@aztec/foundation/bigint-buffer';
+import { Fr } from '@aztec/foundation/fields';
 import { toArray } from '@aztec/foundation/iterable';
-import type { AztecAsyncKVStore, AztecAsyncMap, AztecAsyncMultiMap } from '@aztec/kv-store';
+import type { AztecAsyncKVStore, AztecAsyncMap, AztecAsyncMultiMap, AztecAsyncSet } from '@aztec/kv-store';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import type { InBlock } from '@aztec/stdlib/block';
 import { NoteStatus, type NotesFilter } from '@aztec/stdlib/note';
 
 import { NoteDao } from './note_dao.js';
+
+type NoteEvent = {
+  noteId: string;
+  kind: 'CREATE' | 'NULLIFY';
+};
+
+type CompositeKeyOrRange = { kind: 'exact'; key: CompositeKey } | { kind: 'prefix'; prefix: string };
+
+export type NoteId = string & { __brand: 'NoteId' };
+export type Nullifier = string & { __brand: 'Nullifier' };
+export type BlockNumber = number & { __brand: 'BlockNumber' };
+export type CompositeKey = string & { __brand: 'CompositeKey' };
+export type AztecAddressString = string & { readonly __brand: 'AztecAddress' };
+
+// --- Helpers -------------------------------------------------
+
+export function encodeCompositeKey(contract: AztecAddress, scope: AztecAddress, slot: Fr): CompositeKey {
+  return `${contract.toString()}:${scope.toString()}:${slot.toString()}` as CompositeKey;
+}
+
+export function decodeCompositeKey(key: string): [AztecAddress, AztecAddress, Fr] {
+  const [contractHex, scopeHex, slotHex] = key.split(':');
+  if (!contractHex || !scopeHex || !slotHex) {
+    throw new Error(`Invalid composite key format: ${key}`);
+  }
+
+  return [AztecAddress.fromString(contractHex), AztecAddress.fromString(scopeHex), Fr.fromString(slotHex)];
+}
+
+function encodeCompositeKeyPrefix(contract: AztecAddress, scope: AztecAddress): string {
+  return `${contract.toString()}:${scope.toString()}:`;
+}
+
+function prefixRange(prefix: string) {
+  return {
+    start: prefix as CompositeKey,
+    end: (prefix + '\uffff') as CompositeKey,
+  };
+}
+
+// --- Branding helpers ---
+
+// export const toNoteId = (value: string): NoteId => value as NoteId;
+// export const toNullifier = (value: string): Nullifier => value as Nullifier;
+export const toBlockNumber = (value: number): BlockNumber => value as BlockNumber;
+export const toCompositeKey = (value: string): CompositeKey => value as CompositeKey;
+export const toAztecAddressString = (value: string): AztecAddressString => value as AztecAddressString;
+export const fromAztecAddressString = (value: AztecAddressString): AztecAddress => AztecAddress.fromString(value);
+
+export const toNoteId = (index: bigint): NoteId => toHex(index, true) as NoteId;
+// export const fromNoteId = (id: NoteId): bigint => BigInt(id);  not sure if I will need this.
+export const toNullifier = (fr: Fr): Nullifier => fr.toString() as Nullifier;
+// export const fromNullifier = (n: Nullifier): Fr => Fr.fromString(n); again not sure if I will need this.
 
 /**
  * NoteDataProvider manages the storage and retrieval of notes.
@@ -16,37 +69,27 @@ import { NoteDao } from './note_dao.js';
  **/
 export class NoteDataProvider {
   #store: AztecAsyncKVStore;
-  #notes: AztecAsyncMap<string, Buffer>;
-  #nullifiedNotes: AztecAsyncMap<string, Buffer>;
-  #nullifierToNoteId: AztecAsyncMap<string, string>;
-  #nullifiersByBlockNumber: AztecAsyncMultiMap<number, string>;
 
-  #nullifiedNotesToScope: AztecAsyncMultiMap<string, string>;
-  #nullifiedNotesByContract: AztecAsyncMultiMap<string, string>;
-  #nullifiedNotesByStorageSlot: AztecAsyncMultiMap<string, string>;
-  #nullifiedNotesByNullifier: AztecAsyncMap<string, string>;
+  #notes: AztecAsyncMap<NoteId, Buffer>;
+  #noteStatusById: AztecAsyncMap<NoteId, NoteStatus>;
+  #noteEventsByBlock: AztecAsyncMultiMap<BlockNumber, NoteEvent>;
+  #nullifierToNoteId: AztecAsyncMap<Nullifier, NoteId>;
+  #noteIdsByCompositeKey: AztecAsyncMultiMap<CompositeKey, NoteId>;
+  #compositeKeyByNoteId: AztecAsyncMap<NoteId, CompositeKey>;
 
-  #scopes: AztecAsyncMap<string, true>;
-  #notesToScope: AztecAsyncMultiMap<string, string>;
-  #notesByContractAndScope: Map<string, AztecAsyncMultiMap<string, string>>;
-  #notesByStorageSlotAndScope: Map<string, AztecAsyncMultiMap<string, string>>;
+  // I need to keep track of scopes right now which is rubbish.  In the future maybe this can be removed.
+  // TODO: link to ISSUE in LINEAR
+  #knownScopes: AztecAsyncSet<AztecAddressString>;
 
   private constructor(store: AztecAsyncKVStore) {
     this.#store = store;
-    this.#notes = store.openMap('notes');
-    this.#nullifiedNotes = store.openMap('nullified_notes');
-    this.#nullifierToNoteId = store.openMap('nullifier_to_note');
-    this.#nullifiersByBlockNumber = store.openMultiMap('nullifier_to_block_number');
-
-    this.#nullifiedNotesToScope = store.openMultiMap('nullified_notes_to_scope');
-    this.#nullifiedNotesByContract = store.openMultiMap('nullified_notes_by_contract');
-    this.#nullifiedNotesByStorageSlot = store.openMultiMap('nullified_notes_by_storage_slot');
-    this.#nullifiedNotesByNullifier = store.openMap('nullified_notes_by_nullifier');
-
-    this.#scopes = store.openMap('scopes');
-    this.#notesToScope = store.openMultiMap('notes_to_scope');
-    this.#notesByContractAndScope = new Map<string, AztecAsyncMultiMap<string, string>>();
-    this.#notesByStorageSlotAndScope = new Map<string, AztecAsyncMultiMap<string, string>>();
+    this.#notes = store.openMap<NoteId, Buffer>('notes');
+    this.#noteStatusById = store.openMap<NoteId, NoteStatus>('note_status_by_id');
+    this.#noteEventsByBlock = store.openMultiMap<BlockNumber, NoteEvent>('note_events_by_block');
+    this.#nullifierToNoteId = store.openMap<Nullifier, NoteId>('nullifier_to_note_id');
+    this.#noteIdsByCompositeKey = store.openMultiMap<CompositeKey, NoteId>('note_ids_by_composite_key');
+    this.#compositeKeyByNoteId = store.openMap<NoteId, CompositeKey>('composite_key_by_note_id');
+    this.#knownScopes = store.openSet<AztecAddressString>('known_scopes');
   }
 
   /**
@@ -58,62 +101,58 @@ export class NoteDataProvider {
    * @param store - The key-value store to use for persistence
    * @returns Promise resolving to a fully initialized NoteDataProvider instance
    */
-  public static async create(store: AztecAsyncKVStore): Promise<NoteDataProvider> {
+  public static create(store: AztecAsyncKVStore): NoteDataProvider {
     const pxeDB = new NoteDataProvider(store);
-    for await (const scope of pxeDB.#scopes.keysAsync()) {
-      pxeDB.#notesByContractAndScope.set(scope, store.openMultiMap(`${scope}:notes_by_contract`));
-      pxeDB.#notesByStorageSlotAndScope.set(scope, store.openMultiMap(`${scope}:notes_by_storage_slot`));
-    }
+    // for now, nothing to restore.
+
     return pxeDB;
-  }
-
-  /**
-   * Adds a new scope to the note data provider.
-   *
-   * Scopes provide privacy isolation by creating separate indexes for each user.
-   * Each scope gets its own set of indexes for efficient note retrieval by various criteria.
-   *
-   * @param scope - The AztecAddress representing the scope/user to add
-   * @returns Promise resolving to true if scope was added, false if it already existed
-   */
-  public async addScope(scope: AztecAddress): Promise<boolean> {
-    const scopeString = scope.toString();
-
-    if (await this.#scopes.hasAsync(scopeString)) {
-      return false;
-    }
-
-    await this.#scopes.set(scopeString, true);
-    this.#notesByContractAndScope.set(scopeString, this.#store.openMultiMap(`${scopeString}:notes_by_contract`));
-    this.#notesByStorageSlotAndScope.set(scopeString, this.#store.openMultiMap(`${scopeString}:notes_by_storage_slot`));
-
-    return true;
   }
 
   /**
    * Adds multiple notes to the data provider under the specified scope.
    *
-   * Notes are stored using their index from the notes hash tree as the key, which provides
-   * uniqueness and maintains creation order. Each note is indexed by multiple criteria
-   * for efficient retrieval.
+   * Runs as a single atomic transaction: if any note in the batch conflicts with an
+   * existing note at the same index (i.e. same noteID but different data), the entire
+   * batch is rolled back and no changes are applied.
    *
    * @param notes - Notes to store
    * @param scope - The scope (user/account) under which to store the notes
+   * @throws Error if a conflicting note already exists at the same index
    */
-  addNotes(notes: NoteDao[], scope: AztecAddress): Promise<void> {
-    return this.#store.transactionAsync(async () => {
-      if (!(await this.#scopes.hasAsync(scope.toString()))) {
-        await this.addScope(scope);
-      }
+  async addNotes(notes: NoteDao[], scope: AztecAddress): Promise<void> {
+    const scopeKey = toAztecAddressString(scope.toString());
 
-      for (const dao of notes) {
-        const noteIndex = toBufferBE(dao.index, 32).toString('hex');
-        await this.#notes.set(noteIndex, dao.toBuffer());
-        await this.#notesToScope.set(noteIndex, scope.toString());
-        await this.#nullifierToNoteId.set(dao.siloedNullifier.toString(), noteIndex);
+    await this.#store.transactionAsync(async () => {
+      await this.#knownScopes.add(scopeKey);
 
-        await this.#notesByContractAndScope.get(scope.toString())!.set(dao.contractAddress.toString(), noteIndex);
-        await this.#notesByStorageSlotAndScope.get(scope.toString())!.set(dao.storageSlot.toString(), noteIndex);
+      for (const noteDao of notes) {
+        const noteID = toNoteId(noteDao.index);
+        const key = encodeCompositeKey(noteDao.contractAddress, scope, noteDao.storageSlot);
+
+        // Check for duplicates before inserting
+        const existing = await this.#notes.getAsync(noteID);
+        if (existing) {
+          const existingNoteDao = NoteDao.fromBuffer(existing);
+          if (existingNoteDao.equals(noteDao)) {
+            continue;
+          } else {
+            throw new Error(
+              `Conflicting note detected: detected at index ${noteDao.index} for scope ${scopeKey} ${noteID}`,
+            );
+          }
+        }
+
+        // Primary storage
+        await this.#notes.set(noteID, noteDao.toBuffer());
+        await this.#noteStatusById.set(noteID, NoteStatus.ACTIVE);
+
+        // Cross-indexes
+        await this.#noteIdsByCompositeKey.set(key, noteID);
+        await this.#compositeKeyByNoteId.set(noteID, key);
+        await this.#nullifierToNoteId.set(toNullifier(noteDao.siloedNullifier), noteID);
+
+        // Event tracking
+        await this.#noteEventsByBlock.set(toBlockNumber(noteDao.l2BlockNumber), { noteId: noteID, kind: 'CREATE' });
       }
     });
   }
@@ -142,23 +181,7 @@ export class NoteDataProvider {
    * @param blockNumber - Notes created after this block number will be deleted
    */
   #deleteActiveNotesAfterBlock(blockNumber: number): Promise<void> {
-    return this.#store.transactionAsync(async () => {
-      const notes = await toArray(this.#notes.valuesAsync());
-      for (const note of notes) {
-        const noteDao = NoteDao.fromBuffer(note);
-        if (noteDao.l2BlockNumber > blockNumber) {
-          const noteIndex = toBufferBE(noteDao.index, 32).toString('hex');
-          await this.#notes.delete(noteIndex);
-          await this.#notesToScope.delete(noteIndex);
-          await this.#nullifierToNoteId.delete(noteDao.siloedNullifier.toString());
-          const scopes = await toArray(this.#scopes.keysAsync());
-          for (const scope of scopes) {
-            await this.#notesByContractAndScope.get(scope)!.deleteValue(noteDao.contractAddress.toString(), noteIndex);
-            await this.#notesByStorageSlotAndScope.get(scope)!.deleteValue(noteDao.storageSlot.toString(), noteIndex);
-          }
-        }
-      }
-    });
+    throw new Error('Method not implemented.');
   }
 
   /**
@@ -172,48 +195,7 @@ export class NoteDataProvider {
    * @param synchedBlockNumber - Upper bound for the block range to process
    */
   async #rewindNullifiersAfterBlock(blockNumber: number, synchedBlockNumber: number): Promise<void> {
-    await this.#store.transactionAsync(async () => {
-      const nullifiersToUndo: string[] = [];
-      const currentBlockNumber = blockNumber + 1;
-      for (let i = currentBlockNumber; i <= synchedBlockNumber; i++) {
-        nullifiersToUndo.push(...(await toArray(this.#nullifiersByBlockNumber.getValuesAsync(i))));
-      }
-      const notesIndexesToReinsert = await Promise.all(
-        nullifiersToUndo.map(nullifier => this.#nullifiedNotesByNullifier.getAsync(nullifier)),
-      );
-      const notNullNoteIndexes = notesIndexesToReinsert.filter(noteIndex => noteIndex != undefined);
-      const nullifiedNoteBuffers = await Promise.all(
-        notNullNoteIndexes.map(noteIndex => this.#nullifiedNotes.getAsync(noteIndex!)),
-      );
-      const noteDaos = nullifiedNoteBuffers
-        .filter(buffer => buffer != undefined)
-        .map(buffer => NoteDao.fromBuffer(buffer!));
-
-      for (const dao of noteDaos) {
-        const noteIndex = toBufferBE(dao.index, 32).toString('hex');
-        await this.#notes.set(noteIndex, dao.toBuffer());
-        await this.#nullifierToNoteId.set(dao.siloedNullifier.toString(), noteIndex);
-
-        let scopes = (await toArray(this.#nullifiedNotesToScope.getValuesAsync(noteIndex))) ?? [];
-
-        if (scopes.length === 0) {
-          scopes = [dao.recipient.toString()];
-        }
-
-        for (const scope of scopes) {
-          await this.#notesByContractAndScope.get(scope.toString())!.set(dao.contractAddress.toString(), noteIndex);
-          await this.#notesByStorageSlotAndScope.get(scope.toString())!.set(dao.storageSlot.toString(), noteIndex);
-          await this.#notesToScope.set(noteIndex, scope);
-        }
-
-        await this.#nullifiedNotes.delete(noteIndex);
-        await this.#nullifiedNotesToScope.delete(noteIndex);
-        await this.#nullifiersByBlockNumber.deleteValue(dao.l2BlockNumber, dao.siloedNullifier.toString());
-        await this.#nullifiedNotesByContract.deleteValue(dao.contractAddress.toString(), noteIndex);
-        await this.#nullifiedNotesByStorageSlot.deleteValue(dao.storageSlot.toString(), noteIndex);
-        await this.#nullifiedNotesByNullifier.delete(dao.siloedNullifier.toString());
-      }
-    });
+    throw new Error('Method not implemented.');
   }
 
   /**
@@ -228,97 +210,140 @@ export class NoteDataProvider {
    * @throws If filtering by an empty scopes array. Scopes have to be set to undefined or to a non-empty array.
    */
   async getNotes(filter: NotesFilter): Promise<NoteDao[]> {
-    filter.status = filter.status ?? NoteStatus.ACTIVE;
+    const preparedFilter = await this.#prepareFilter(filter);
 
-    // throw early if scopes is an empty array
-    if (filter.scopes !== undefined && filter.scopes.length === 0) {
-      throw new Error(
-        'Trying to get notes with an empty scopes array. Scopes have to be set to undefined if intending on not filtering by scopes.',
-      );
-    }
+    const compositeKeys: CompositeKeyOrRange[] = [];
 
-    const candidateNoteSources = [];
-
-    filter.scopes ??= (await toArray(this.#scopes.keysAsync())).map(addressString =>
-      AztecAddress.fromString(addressString),
-    );
-
-    const activeNoteIdsPerScope: string[][] = [];
-
-    for (const scope of new Set(filter.scopes)) {
-      const formattedScopeString = scope.toString();
-      if (!(await this.#scopes.hasAsync(formattedScopeString))) {
-        throw new Error('Trying to get incoming notes of a scope that is not in the PXE database');
-      }
-
-      activeNoteIdsPerScope.push(
-        filter.storageSlot
-          ? await toArray(
-              this.#notesByStorageSlotAndScope.get(formattedScopeString)!.getValuesAsync(filter.storageSlot.toString()),
-            )
-          : await toArray(
-              this.#notesByContractAndScope
-                .get(formattedScopeString)!
-                .getValuesAsync(filter.contractAddress.toString()),
-            ),
-      );
-    }
-
-    candidateNoteSources.push({
-      ids: new Set(activeNoteIdsPerScope.flat()),
-      notes: this.#notes,
-    });
-
-    // If status is ACTIVE_OR_NULLIFIED we add nullified notes as candidates on top of the default active ones.
-    if (filter.status === NoteStatus.ACTIVE_OR_NULLIFIED) {
-      const nullifiedIds = filter.storageSlot
-        ? await toArray(this.#nullifiedNotesByStorageSlot.getValuesAsync(filter.storageSlot.toString()))
-        : await toArray(this.#nullifiedNotesByContract.getValuesAsync(filter.contractAddress.toString()));
-
-      const setOfScopes = new Set(filter.scopes.map(s => s.toString() as string));
-      const filteredNullifiedIds = new Set<string>();
-
-      for (const noteId of nullifiedIds) {
-        const scopeList = await toArray(this.#nullifiedNotesToScope.getValuesAsync(noteId));
-        if (scopeList.some(scope => setOfScopes.has(scope))) {
-          filteredNullifiedIds.add(noteId);
-        }
-      }
-
-      if (filteredNullifiedIds.size > 0) {
-        candidateNoteSources.push({
-          ids: filteredNullifiedIds,
-          notes: this.#nullifiedNotes,
+    for (const scope of preparedFilter.scopes) {
+      if (preparedFilter.storageSlot) {
+        compositeKeys.push({
+          kind: 'exact',
+          key: encodeCompositeKey(preparedFilter.contractAddress, scope, preparedFilter.storageSlot),
+        });
+      } else {
+        compositeKeys.push({
+          kind: 'prefix',
+          prefix: encodeCompositeKeyPrefix(preparedFilter.contractAddress, scope),
         });
       }
     }
 
-    const result: NoteDao[] = [];
-    for (const { ids, notes } of candidateNoteSources) {
-      for (const id of ids) {
-        const serializedNote = await notes.getAsync(id);
-        if (!serializedNote) {
-          continue;
-        }
+    // Collect candidate note IDs
+    const candidateNoteIds = await this.#getNoteIdsForKeys(compositeKeys);
 
-        const note = NoteDao.fromBuffer(serializedNote);
-        if (!note.contractAddress.equals(filter.contractAddress)) {
-          continue;
-        }
+    // Filter and materialize notes
+    return this.#getFilteredNotes(candidateNoteIds, preparedFilter);
+  }
 
-        if (filter.storageSlot && !note.storageSlot.equals(filter.storageSlot!)) {
-          continue;
-        }
+  /**
+   * Prepares and normalizes a NotesFilter for internal use
+   * by filling in missing defaults and resolving undefined scopes.
+   *
+   * @param filter - The original NotesFilter provided by the caller
+   * @returns A fully resolved filter ready for querying notes
+   * @throws If `filter.scopes` is an empty array
+   */
+  async #prepareFilter(filter: NotesFilter): Promise<Required<NotesFilter>> {
+    const resolved = { ...filter };
 
-        if (filter.siloedNullifier && !note.siloedNullifier.equals(filter.siloedNullifier)) {
-          continue;
-        }
+    resolved.status ??= NoteStatus.ACTIVE;
 
-        result.push(note);
+    // TODO: Linear Issue: F-XX - Remove this check once scopes are mandatory in the filter.
+    if (filter.scopes !== undefined && filter.scopes.length === 0) {
+      throw new Error(
+        'Trying to get notes with an empty scopes array. If you want "all scopes", pass scopes: undefined.',
+      );
+    }
+
+    // TODO: Linear Issue: F-XX - once scopes are mandatory in the filter, remove this block.
+    // If no scopes provided, use all known scopes
+    if (filter.scopes === undefined) {
+      const scopes: AztecAddress[] = [];
+      for await (const scopeStr of this.#knownScopes.entriesAsync()) {
+        scopes.push(fromAztecAddressString(scopeStr));
+      }
+      resolved.scopes = scopes;
+    } else {
+      resolved.scopes = filter.scopes;
+    }
+
+    // Validate all provided scopes exist in knownScopes
+    for (const scope of resolved.scopes) {
+      const scopeKey = toAztecAddressString(scope.toString());
+      const exists = await this.#knownScopes.hasAsync(scopeKey);
+      if (!exists) {
+        throw new Error(`Trying to get incoming notes of a scope that is not in the PXE database: ${scope.toString()}`);
       }
     }
 
-    return result;
+    return resolved as Required<NotesFilter>;
+  }
+
+  /**
+   * Collects all note IDs associated with the given composite keys.
+   */
+  async #getNoteIdsForKeys(keys: CompositeKeyOrRange[]): Promise<Set<string>> {
+    const ids = new Set<string>();
+
+    for (const k of keys) {
+      if (k.kind === 'exact') {
+        const found = await toArray(this.#noteIdsByCompositeKey.getValuesAsync(k.key));
+        for (const id of found) {
+          ids.add(id);
+        }
+      } else {
+        const range = prefixRange(k.prefix);
+        for await (const id of this.#noteIdsByCompositeKey.valuesAsync(range)) {
+          ids.add(id);
+        }
+      }
+    }
+
+    return ids;
+  }
+
+  /**
+   * Collects NoteDao objects for the given candidate note IDs,
+   * applying status filtering and any final field filters.
+   *
+   * @param noteIds - Set of candidate note IDs
+   * @param filter - Fully-resolved filter (status, siloedNullifier, etc.)
+   */
+  async #getFilteredNotes(noteIds: Set<string>, filter: Required<NotesFilter>): Promise<NoteDao[]> {
+    const results: NoteDao[] = [];
+
+    const getAll = filter.status === 'ALL';
+
+    for (const id of noteIds) {
+      // Status filter (skip early if it doesn't match)
+      if (!getAll) {
+        const storedStatus = await this.#noteStatusById.getAsync(id as NoteId);
+        // if (storedStatus === undefined) {
+        //   // This should never happen — if it does, our indexes are inconsistent
+        //   throw new Error(`Missing note status for note ID ${id}`);
+        // }
+
+        if (storedStatus !== filter.status) {
+          continue;
+        }
+      }
+
+      // Fetch the note data
+      const serialized = await this.#notes.getAsync(id as NoteId);
+      if (!serialized) {
+        continue;
+      }
+
+      const note = NoteDao.fromBuffer(serialized);
+
+      // Final filter: siloedNullifier
+      if (filter.siloedNullifier && !note.siloedNullifier.equals(filter.siloedNullifier)) {
+        continue;
+      }
+      results.push(note);
+    }
+
+    return results;
   }
 
   /**
@@ -333,61 +358,6 @@ export class NoteDataProvider {
    * @throws Error if any nullifier is not found in the active notes
    */
   applyNullifiers(nullifiers: InBlock<Fr>[]): Promise<NoteDao[]> {
-    if (nullifiers.length === 0) {
-      return Promise.resolve([]);
-    }
-
-    return this.#store.transactionAsync(async () => {
-      const nullifiedNotes: NoteDao[] = [];
-
-      for (const blockScopedNullifier of nullifiers) {
-        const { data: nullifier, l2BlockNumber: blockNumber } = blockScopedNullifier;
-        const nullifierKey = nullifier.toString();
-
-        const noteIndex = await this.#nullifierToNoteId.getAsync(nullifierKey);
-        if (!noteIndex) {
-          // Check if already nullified?
-          const alreadyNullified = await this.#nullifiedNotesByNullifier.getAsync(nullifierKey);
-          if (alreadyNullified) {
-            throw new Error(`Nullifier already applied in applyNullifiers`);
-          }
-          throw new Error('Nullifier not found in applyNullifiers');
-        }
-
-        const noteBuffer = noteIndex ? await this.#notes.getAsync(noteIndex) : undefined;
-
-        if (!noteBuffer) {
-          throw new Error('Note not found in applyNullifiers');
-        }
-        const noteScopes = (await toArray(this.#notesToScope.getValuesAsync(noteIndex))) ?? [];
-        const note = NoteDao.fromBuffer(noteBuffer);
-
-        nullifiedNotes.push(note);
-
-        await this.#notes.delete(noteIndex);
-        await this.#notesToScope.delete(noteIndex);
-
-        const scopes = await toArray(this.#scopes.keysAsync());
-
-        for (const scope of scopes) {
-          await this.#notesByContractAndScope.get(scope)!.deleteValue(note.contractAddress.toString(), noteIndex);
-          await this.#notesByStorageSlotAndScope.get(scope)!.deleteValue(note.storageSlot.toString(), noteIndex);
-        }
-
-        if (noteScopes !== undefined) {
-          for (const scope of noteScopes) {
-            await this.#nullifiedNotesToScope.set(noteIndex, scope);
-          }
-        }
-        await this.#nullifiedNotes.set(noteIndex, note.toBuffer());
-        await this.#nullifiersByBlockNumber.set(blockNumber, nullifier.toString());
-        await this.#nullifiedNotesByContract.set(note.contractAddress.toString(), noteIndex);
-        await this.#nullifiedNotesByStorageSlot.set(note.storageSlot.toString(), noteIndex);
-        await this.#nullifiedNotesByNullifier.set(nullifier.toString(), noteIndex);
-
-        await this.#nullifierToNoteId.delete(nullifier.toString());
-      }
-      return nullifiedNotes;
-    });
+    throw new Error('Method not implemented.');
   }
 }

--- a/yarn-project/stdlib/src/note/note_status.ts
+++ b/yarn-project/stdlib/src/note/note_status.ts
@@ -1,8 +1,12 @@
 /**
- * The status of notes to retrieve.
+ * The status of notes stored in the database.
  */
 export enum NoteStatus {
   ACTIVE = 1,
-  ACTIVE_OR_NULLIFIED = 2,
-  // TODO(#4217): add 'NULLIFIED'
+  NULLIFIED = 2,
 }
+
+/**
+ * The status filter used when querying notes.
+ */
+export type NoteStatusFilter = NoteStatus | 'ALL';

--- a/yarn-project/stdlib/src/note/notes_filter.ts
+++ b/yarn-project/stdlib/src/note/notes_filter.ts
@@ -4,7 +4,7 @@ import { z } from 'zod';
 
 import type { AztecAddress } from '../aztec-address/index.js';
 import { type ZodFor, schemas } from '../schemas/index.js';
-import { NoteStatus } from './note_status.js';
+import { NoteStatus, type NoteStatusFilter } from './note_status.js';
 
 /**
  * A filter used to fetch notes.
@@ -19,7 +19,7 @@ export type NotesFilter = {
   /** The specific storage location of the note on the contract. */
   storageSlot?: Fr;
   /** The status of the note. Defaults to 'ACTIVE'. */
-  status?: NoteStatus;
+  status?: NoteStatusFilter;
   /** The siloed nullifier for the note. */
   siloedNullifier?: Fr;
   /** The scopes in which to get notes from. This defaults to all scopes. */
@@ -29,7 +29,7 @@ export type NotesFilter = {
 export const NotesFilterSchema: ZodFor<NotesFilter> = z.object({
   contractAddress: schemas.AztecAddress,
   storageSlot: schemas.Fr.optional(),
-  status: z.nativeEnum(NoteStatus).optional(),
+  status: z.union([z.nativeEnum(NoteStatus), z.literal('ALL')]).optional(),
   siloedNullifier: schemas.Fr.optional(),
   scopes: z.array(schemas.AztecAddress).optional(),
 });


### PR DESCRIPTION
### Summary

This PR restructures the NoteDataProvider storage model.

### Goals
- Cut down the number of indices we maintain.
- Remove duplication between “active” and “nullified” notes.
- Make reorg/rollback predictable.
- Reduce potential of indices becoming inconsistent

**Before**
We were maintaining ~12 structures:
- Separate maps for active vs nullified notes (`#notes`, `#nullifiedNotes`) 
- Parallel indices by contract / scope / storageSlot for both active and nullified (`#notesByContractAndScope`, `#notesByStorageAndScope`, `#nullifiedNotesByContract`, `#nullifiedNotesByStorageSlot`,...)
- Ad-hoc per-scope maps in memory
- Event history split across different places (`#nullifiersByBlockNumber`,...)

This was high-overhead, and hard to reason about in rollback, with potential for indexes becoming inconsistent. 

 **After**
We now maintain 7 persistent indices (NB: soon to be 6)
```ts
#notes: AztecAsyncMap<NoteId, NoteDao>;
#noteStatusById: AztecAsyncMap<NoteId, NoteStatus>;
#noteEventsByBlock: AztecAsyncMultiMap<BlockNumber, NoteEvent>;
#nullifierToNoteId: AztecAsyncMap<Nullifier, NoteId>;
#noteIdsByScopeContract: AztecAsyncMultiMap<CompositeKey, NoteId>;
#scopeContractByNoteId: AztecAsyncMap<NoteId, CompositeKey>;
#knownScopes: AztecAsyncSet<Scope>; // temporary
```
NB: #knownScopes is temporary. A future PR will make scope a mandatory parameter for `getNotes()`, at which point this index can be removed. 

**Key changes:**
- There is now a single `#notes` store. We do not move notes between “active” and “nullified” stores anymore.
- Lifecycle state (ACTIVE / NULLIFIED) lives in `#noteStatusById,` not by moving data between maps.
- Lookups for `getNotes()` now go through a CompositeKey index instead of multiple ad-hoc structures.
- Rollback walks a single `#noteEventsByBlock` timeline and reverses the event sequence.  Previously rollback worked by inferring whether a note should be deleted, ignored or restored by cross-checking the overlapping indexes. The new approach is much more deterministic. 

**Note status**

We track _lifecycle_ separately from the _note content_:

```
#notes: AztecAsyncMap<NoteId, NoteDao>;
#noteStatusById: AztecAsyncMap<NoteId, NoteStatus>;
```

Rationale:
- We don't duplicate the full note in "active" vs "nullified" stores anymore.
- We don't rewrite the full {note, status} object just to flip a status bit.
- Rollback can restore status without having to reconstruct the full note.

NoteStatus now standardised as:
```
export enum NoteStatus {
  ACTIVE = 1,
  NULLIFIED = 2,
}

export type NoteStatusFilter = NoteStatus | 'ALL';
```

The old `ACTIVE` / `ACTIVE_OR_NULLIFIED` flags have been replaced:
- `NoteStatus` now just represents the actual store state (`ACTIVE`, `NULLIFIED`).
- `NoteStatusFilter` adds '`ALL`' for queries that include both.

This cleanly separates **stored state** from **filter behaviour**, allowing TypeScript to enforce that the database only contains valid states (`ACTIVE` or `NULLIFIED`), while `NoteDataProvider` clients can still request '`ALL`' when querying.

