### PR TITLE
chore: copy bb-avm into the release-image

### DIFF
--- a/.test_patterns.yml
+++ b/.test_patterns.yml
@@ -291,3 +291,8 @@ tests:
     flake_group_id: e2e-p2p-epoch-flakes
     owners:
       - *palla
+
+  - regex: "bb-prover/src/avm_proving_tests/avm_bulk.test.ts"
+    error_regex: "Exceeded timeout"
+    owners:
+      - *alex

--- a/aztec-postprocess-contract/transpile_contract_and_gen_vks.sh
+++ b/aztec-postprocess-contract/transpile_contract_and_gen_vks.sh
@@ -8,10 +8,10 @@
 set -euo pipefail
 
 dir=$(dirname $0)
-BB=${BB:-"$dir/../barretenberg/cpp/build/bin/bb"}
+BB_BINARY_PATH=${BB_BINARY_PATH:-"$dir/../barretenberg/cpp/build/bin/bb"}
 
 # No arguments provided - let bb auto-discover and process all artifacts
 echo "Searching for contract artifacts in target/ directories..."
-$BB aztec_process
+$BB_BINARY_PATH aztec_process
 
 echo "Contract postprocessing complete!"

--- a/release-image/Dockerfile.dockerignore
+++ b/release-image/Dockerfile.dockerignore
@@ -2,7 +2,7 @@
 !/.release-please-manifest.json
 !/avm-transpiler/target/release/avm-transpiler
 !/aztec-postprocess-contract/transpile_contract_and_gen_vks.sh
-!/barretenberg/cpp/build/bin/bb
+!/barretenberg/cpp/build/bin/bb-avm
 !/barretenberg/ts/dest/
 !/barretenberg/ts/package.json
 !/noir/noir-repo/target/release/nargo

--- a/yarn-project/cli-wallet/src/bin/index.ts
+++ b/yarn-project/cli-wallet/src/bin/index.ts
@@ -101,7 +101,8 @@ async function main() {
 
       const bbBinaryPath =
         prover === 'native'
-          ? resolve(dirname(fileURLToPath(import.meta.url)), '../../../../barretenberg/cpp/build/bin/bb')
+          ? (process.env.BB_BINARY_PATH ??
+            resolve(dirname(fileURLToPath(import.meta.url)), '../../../../barretenberg/cpp/build/bin/bb'))
           : undefined;
       const bbWorkingDirectory = dataDir + '/bb';
       mkdirSync(bbWorkingDirectory, { recursive: true });


### PR DESCRIPTION
Copy `bb-avm` instead of `bb` into the release image