### PR TITLE
feat:  competitive priority fee pricing

### DIFF
--- a/spartan/aztec-network/templates/boot-node.yaml
+++ b/spartan/aztec-network/templates/boot-node.yaml
@@ -100,8 +100,18 @@ spec:
               value: "{{ .Values.aztec.proofSubmissionWindow }}"
             - name: L1_GAS_PRICE_MAX
               value: "{{ .Values.ethereum.l1GasPriceMax }}"
+            {{- if .Values.ethereum.l1FixedPriorityFeePerGas }}
             - name: L1_FIXED_PRIORITY_FEE_PER_GAS
               value: "{{ .Values.ethereum.l1FixedPriorityFeePerGas }}"
+            {{- end }}
+            {{- if .Values.ethereum.l1PriorityFeeBumpPercentage }}
+            - name: L1_PRIORITY_FEE_BUMP_PERCENTAGE
+              value: {{ .Values.ethereum.l1PriorityFeeBumpPercentage | quote }}
+            {{- end }}
+            {{- if .Values.ethereum.l1PriorityFeeRetryBumpPercentage }}
+            - name: L1_PRIORITY_FEE_RETRY_BUMP_PERCENTAGE
+              value: {{ .Values.ethereum.l1PriorityFeeRetryBumpPercentage | quote }}
+            {{- end }}
             - name: AZTEC_MANA_TARGET
               value: "{{ .Values.aztec.manaTarget }}"
             - name: REAL_VERIFIER

--- a/spartan/aztec-network/templates/prover-node.yaml
+++ b/spartan/aztec-network/templates/prover-node.yaml
@@ -159,8 +159,18 @@ spec:
               value: "{{ .Values.proverNode.failedEpochStore }}"
             - name: L1_CHAIN_ID
               value: "{{ .Values.ethereum.chainId }}"
+            {{- if .Values.proverNode.l1FixedPriorityFeePerGas }}
             - name: L1_FIXED_PRIORITY_FEE_PER_GAS
               value: {{ .Values.proverNode.l1FixedPriorityFeePerGas | quote }}
+            {{- end }}
+            {{- if .Values.proverNode.l1PriorityFeeBumpPercentage }}
+            - name: L1_PRIORITY_FEE_BUMP_PERCENTAGE
+              value: {{ .Values.proverNode.l1PriorityFeeBumpPercentage | quote }}
+            {{- end }}
+            {{- if .Values.proverNode.l1PriorityFeeRetryBumpPercentage }}
+            - name: L1_PRIORITY_FEE_RETRY_BUMP_PERCENTAGE
+              value: {{ .Values.proverNode.l1PriorityFeeRetryBumpPercentage | quote }}
+            {{- end }}
             - name: L1_GAS_LIMIT_BUFFER_PERCENTAGE
               value: {{ .Values.proverNode.l1GasLimitBufferPercentage | quote }}
             - name: L1_GAS_PRICE_MAX

--- a/spartan/aztec-network/templates/validator.yaml
+++ b/spartan/aztec-network/templates/validator.yaml
@@ -164,8 +164,18 @@ spec:
               value: {{ .Values.validator.viemPollingInterval | quote }}
             - name: SEQ_VIEM_POLLING_INTERVAL_MS
               value: {{ .Values.validator.viemPollingInterval | quote }}
+            {{- if .Values.validator.l1FixedPriorityFeePerGas }}
             - name: L1_FIXED_PRIORITY_FEE_PER_GAS
               value: {{ .Values.validator.l1FixedPriorityFeePerGas | quote }}
+            {{- end }}
+            {{- if .Values.validator.l1PriorityFeeBumpPercentage }}
+            - name: L1_PRIORITY_FEE_BUMP_PERCENTAGE
+              value: {{ .Values.validator.l1PriorityFeeBumpPercentage | quote }}
+            {{- end }}
+            {{- if .Values.validator.l1PriorityFeeRetryBumpPercentage }}
+            - name: L1_PRIORITY_FEE_RETRY_BUMP_PERCENTAGE
+              value: {{ .Values.validator.l1PriorityFeeRetryBumpPercentage | quote }}
+            {{- end }}
             - name: L1_GAS_LIMIT_BUFFER_PERCENTAGE
               value: {{ .Values.validator.l1GasLimitBufferPercentage | quote }}
             - name: L1_GAS_PRICE_MAX

--- a/spartan/aztec-network/values/archival-node.yaml
+++ b/spartan/aztec-network/values/archival-node.yaml
@@ -12,7 +12,8 @@ network:
 ethereum:
   chainId: "11155111"
   l1GasPriceMax: 1000
-  l1FixedPriorityFeePerGas: 3
+  l1PriorityFeeBumpPercentage: 30
+  l1PriorityFeeRetryBumpPercentage: 80
 
 aztec:
   realProofs: true

--- a/spartan/aztec-network/values/ci-fast-epoch.yaml
+++ b/spartan/aztec-network/values/ci-fast-epoch.yaml
@@ -14,7 +14,8 @@ telemetry:
   enabled: false
 
 validator:
-  l1FixedPriorityFeePerGas: 1
+  l1PriorityFeeBumpPercentage: 30
+  l1PriorityFeeRetryBumpPercentage: 80
   replicas: 4
   gke:
     spotEnabled: false

--- a/spartan/aztec-network/values/ci-sepolia.yaml
+++ b/spartan/aztec-network/values/ci-sepolia.yaml
@@ -9,7 +9,8 @@ aztec:
 ethereum:
   chainId: "11155111"
   l1GasPriceMax: 500
-  l1FixedPriorityFeePerGas: 3
+  l1PriorityFeeBumpPercentage: 30
+  l1PriorityFeeRetryBumpPercentage: 80
   execution:
     externalHosts: ""
   beacon:
@@ -21,7 +22,8 @@ telemetry:
   enabled: false
 
 validator:
-  l1FixedPriorityFeePerGas: 3
+  l1PriorityFeeBumpPercentage: 30
+  l1PriorityFeeRetryBumpPercentage: 80
   l1GasLimitBufferPercentage: 15
   replicas: 8
   resources:

--- a/spartan/aztec-network/values/ignition-testnet.yaml
+++ b/spartan/aztec-network/values/ignition-testnet.yaml
@@ -23,13 +23,15 @@ bootNode:
   externalHost: "http://localhost:8080"
 
 proverNode:
-  l1FixedPriorityFeePerGas: 3
+  l1PriorityFeeBumpPercentage: 30
+  l1PriorityFeeRetryBumpPercentage: 80
   l1GasLimitBufferPercentage: 15
   l1GasPriceMax: 1000
 
 validator:
   replicas: 3
-  l1FixedPriorityFeePerGas: 3
+  l1PriorityFeeBumpPercentage: 30
+  l1PriorityFeeRetryBumpPercentage: 80
   l1GasLimitBufferPercentage: 15
   l1GasPriceMax: 1000
   sequencer:
@@ -55,4 +57,5 @@ proverAgent:
 ethereum:
   chainId: "11155111"
   l1GasPriceMax: 1000
-  l1FixedPriorityFeePerGas: 3
+  l1PriorityFeeBumpPercentage: 30
+  l1PriorityFeeRetryBumpPercentage: 80

--- a/spartan/aztec-network/values/rc-2.yaml
+++ b/spartan/aztec-network/values/rc-2.yaml
@@ -24,7 +24,8 @@ ethereum:
     apiKeyHeader: ""
 
 validator:
-  l1FixedPriorityFeePerGas: 2
+  l1PriorityFeeBumpPercentage: 30
+  l1PriorityFeeRetryBumpPercentage: 80
   l1GasLimitBufferPercentage: 15
   replicas: 48
   l1GasPriceMax: 500
@@ -63,4 +64,3 @@ bot:
       memory: "8Gi"
       cpu: "7"
       ephemeral-storage: "8Gi"
-

--- a/spartan/aztec-network/values/sepolia-3-validators-with-metrics.yaml
+++ b/spartan/aztec-network/values/sepolia-3-validators-with-metrics.yaml
@@ -19,7 +19,8 @@ ethereum:
     apiKeyHeader:
 
 validator:
-  l1FixedPriorityFeePerGas: 2
+  l1PriorityFeeBumpPercentage: 30
+  l1PriorityFeeRetryBumpPercentage: 80
   l1GasLimitBufferPercentage: 15
   l1GasPriceMax: 500
   replicas: 3

--- a/spartan/aztec-network/values/sepolia-48-validators-with-metrics.yaml
+++ b/spartan/aztec-network/values/sepolia-48-validators-with-metrics.yaml
@@ -19,7 +19,8 @@ ethereum:
     apiKeyHeader: ""
 
 validator:
-  l1FixedPriorityFeePerGas: 2
+  l1PriorityFeeBumpPercentage: 30
+  l1PriorityFeeRetryBumpPercentage: 80
   l1GasLimitBufferPercentage: 15
   l1GasPriceMax: 500
   replicas: 48

--- a/spartan/aztec-network/values/sepolia-48-validators-with-proving-and-metrics.yaml
+++ b/spartan/aztec-network/values/sepolia-48-validators-with-proving-and-metrics.yaml
@@ -24,7 +24,8 @@ ethereum:
     apiKeyHeader: ""
 
 validator:
-  l1FixedPriorityFeePerGas: 2
+  l1PriorityFeeBumpPercentage: 30
+  l1PriorityFeeRetryBumpPercentage: 80
   l1GasLimitBufferPercentage: 15
   replicas: 48
   l1GasPriceMax: 500
@@ -65,4 +66,3 @@ bot:
       memory: "8Gi"
       cpu: "7"
       ephemeral-storage: "8Gi"
-

--- a/spartan/terraform/deploy-aztec-infra/values/prover.yaml
+++ b/spartan/terraform/deploy-aztec-infra/values/prover.yaml
@@ -1,7 +1,8 @@
 node:
   node:
     env:
-      L1_FIXED_PRIORITY_FEE_PER_GAS: 3
+      L1_PRIORITY_FEE_BUMP_PERCENTAGE: 30
+      L1_PRIORITY_FEE_RETRY_BUMP_PERCENTAGE: 80
     preStartScript: |
       export TX_COLLECTION_NODE_RPC_URLS=$(bash /scripts/resolve-node-hosts.sh $NODE_HOSTS)
       source /scripts/setup-prover-keystore.sh

--- a/spartan/terraform/deploy-aztec-infra/values/validator.yaml
+++ b/spartan/terraform/deploy-aztec-infra/values/validator.yaml
@@ -15,7 +15,8 @@ validator:
       fi
 
     env:
-      L1_FIXED_PRIORITY_FEE_PER_GAS: 3
+      L1_PRIORITY_FEE_BUMP_PERCENTAGE: 30
+      L1_PRIORITY_FEE_RETRY_BUMP_PERCENTAGE: 80
 
   persistence:
     enabled: true

--- a/yarn-project/ethereum/src/deploy_l1_contracts.test.ts
+++ b/yarn-project/ethereum/src/deploy_l1_contracts.test.ts
@@ -85,11 +85,10 @@ describe('deploy_l1_contracts', () => {
         vkTreeRoot,
         protocolContractsHash,
         genesisArchiveRoot,
-        l1TxConfig: { checkIntervalMs: 100 },
         realVerifier: false,
         ...args,
       },
-      undefined,
+      { checkIntervalMs: 100, priorityFeeBumpPercentage: 0 },
       false,
     );
 
@@ -296,9 +295,9 @@ describe('deploy_l1_contracts', () => {
         vkTreeRoot,
         protocolContractsHash,
         genesisArchiveRoot,
-        l1TxConfig: { checkIntervalMs: 100 },
         realVerifier: false,
       },
+      { checkIntervalMs: 100, priorityFeeBumpPercentage: 0 },
     );
 
     const governance = new GovernanceContract(deployment.l1ContractAddresses.governanceAddress, client);

--- a/yarn-project/ethereum/src/l1_tx_utils/config.ts
+++ b/yarn-project/ethereum/src/l1_tx_utils/config.ts
@@ -69,14 +69,14 @@ export const l1TxUtilsConfigMappings: ConfigMappingsType<L1TxUtilsConfig> = {
     ...numberConfigHelper(20),
   },
   maxGwei: {
-    description: 'Maximum gas price in gwei',
+    description: 'Maximum gas price in gwei to be used for transactions.',
     env: 'L1_GAS_PRICE_MAX',
-    ...bigintConfigHelper(500n),
+    ...bigintConfigHelper(2000n),
   },
   maxBlobGwei: {
     description: 'Maximum blob fee per gas in gwei',
     env: 'L1_BLOB_FEE_PER_GAS_MAX',
-    ...bigintConfigHelper(1_500n),
+    ...bigintConfigHelper(3000n),
   },
   priorityFeeBumpPercentage: {
     description: 'How much to increase priority fee by each attempt (percentage)',
@@ -106,7 +106,7 @@ export const l1TxUtilsConfigMappings: ConfigMappingsType<L1TxUtilsConfig> = {
   stallTimeMs: {
     description: 'How long before considering tx stalled',
     env: 'L1_TX_MONITOR_STALL_TIME_MS',
-    ...numberConfigHelper(24_000), // 24s, 2 ethereum slots
+    ...numberConfigHelper(12_000), // 12s, 1 ethereum slot
   },
   txTimeoutMs: {
     description: 'How long to wait for a tx to be mined before giving up. Set to 0 to disable.',

--- a/yarn-project/foundation/src/collection/array.test.ts
+++ b/yarn-project/foundation/src/collection/array.test.ts
@@ -172,6 +172,21 @@ describe('mean', () => {
 });
 
 describe('median', () => {
+  it('calculates the median of an array of bigints', () => {
+    expect(median([1n, 2n, 3n, 4n, 5n])).toBe(3n);
+    expect(median([10n, 20n, 30n, 40n, 50n])).toBe(30n);
+    expect(median([-1n, 0n, 1n])).toBe(0n);
+    expect(
+      median([
+        1000000000000000000n,
+        2000000000000000000n,
+        3000000000000000000n,
+        4000000000000000000n,
+        5000000000000000000n,
+      ]),
+    ).toBe(3000000000000000000n);
+  });
+
   it('calculates the median of an array of numbers', () => {
     expect(median([1, 2, 3, 4, 5])).toBe(3);
     expect(median([10, 20, 30, 40, 50])).toBe(30);

--- a/yarn-project/foundation/src/collection/array.ts
+++ b/yarn-project/foundation/src/collection/array.ts
@@ -178,13 +178,25 @@ export function sum(arr: number[]): number {
 }
 
 /** Computes the median of a numeric array. Returns undefined if array is empty. */
-export function median(arr: number[]) {
+export function median(arr: number[]): number | undefined;
+/** Computes the median of a bigint array. Returns undefined if array is empty. */
+export function median(arr: bigint[]): bigint | undefined;
+export function median(arr: number[] | bigint[]): number | bigint | undefined {
   if (arr.length === 0) {
     return undefined;
   }
-  const sorted = [...arr].sort((a, b) => a - b);
+
+  // Handle number array
+  if (typeof arr[0] === 'number') {
+    const sorted = [...(arr as number[])].sort((a, b) => a - b);
+    const mid = Math.floor(sorted.length / 2);
+    return sorted.length % 2 !== 0 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
+  }
+
+  // Handle bigint array
+  const sorted = [...(arr as bigint[])].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
   const mid = Math.floor(sorted.length / 2);
-  return sorted.length % 2 !== 0 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
+  return sorted.length % 2 !== 0 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2n;
 }
 
 /** Computes the mean of a numeric array. Returns undefined if the array is empty. */


### PR DESCRIPTION
In order to avoid getting priced-out during priority fee spikes, we now check historical block fees as well as pending block fees, in order to make sure we are competitive.

Also updating our deployment values to stop using fixed priority fee and use aggressive bump percentages instead in order to test this

Fixes [A-138](https://linear.app/aztec-labs/issue/A-138/more-aggressive-priority-fee-and-retries-on-block-submissions)