### PR TITLE
fix: Enforce max uncompressed size for p2p messages

### DIFF
--- a/yarn-project/p2p/src/services/encoding.test.ts
+++ b/yarn-project/p2p/src/services/encoding.test.ts
@@ -1,0 +1,507 @@
+import { TopicType } from '@aztec/stdlib/p2p';
+
+import { compressSync, uncompressSync } from 'snappy';
+
+import { SnappyTransform, readSnappyPreamble } from './encoding.js';
+
+describe('readSnappyPreamble', () => {
+  describe('basic varint decoding', () => {
+    it('should read single-byte varint (64)', () => {
+      // 64 = 0x40, fits in 7 bits, so it's just 0x40
+      const data = new Uint8Array([0x40]);
+      const result = readSnappyPreamble(data);
+      expect(result.decompressedSize).toBe(64);
+      expect(result.bytesRead).toBe(1);
+    });
+
+    it('should read single-byte varint (127)', () => {
+      // 127 = 0x7F, maximum value for single byte
+      const data = new Uint8Array([0x7f]);
+      const result = readSnappyPreamble(data);
+      expect(result.decompressedSize).toBe(127);
+      expect(result.bytesRead).toBe(1);
+    });
+
+    it('should read multi-byte varint (2097150)', () => {
+      // 2097150 = 0x1FFFFE
+      // Encoded as: 0xFE 0xFF 0x7F
+      // Byte 1: 0xFE = 11111110 -> data: 1111110 (0x7E), continue: 1
+      // Byte 2: 0xFF = 11111111 -> data: 1111111 (0x7F), continue: 1
+      // Byte 3: 0x7F = 01111111 -> data: 1111111 (0x7F), continue: 0
+      // Result: 0x7F << 14 | 0x7F << 7 | 0x7E = 0x1FFFFE = 2097150
+      const data = new Uint8Array([0xfe, 0xff, 0x7f]);
+      const result = readSnappyPreamble(data);
+      expect(result.decompressedSize).toBe(2097150);
+      expect(result.bytesRead).toBe(3);
+    });
+
+    it('should read two-byte varint (128)', () => {
+      // 128 = 0x80
+      // Encoded as: 0x80 0x01
+      // Byte 1: 0x80 = 10000000 -> data: 0000000 (0x00), continue: 1
+      // Byte 2: 0x01 = 00000001 -> data: 0000001 (0x01), continue: 0
+      // Result: 0x01 << 7 | 0x00 = 128
+      const data = new Uint8Array([0x80, 0x01]);
+      const result = readSnappyPreamble(data);
+      expect(result.decompressedSize).toBe(128);
+      expect(result.bytesRead).toBe(2);
+    });
+
+    it('should read maximum 32-bit value', () => {
+      // 2^32 - 1 = 4294967295 = 0xFFFFFFFF
+      // Encoded as 5 bytes: 0xFF 0xFF 0xFF 0xFF 0x0F
+      const data = new Uint8Array([0xff, 0xff, 0xff, 0xff, 0x0f]);
+      const result = readSnappyPreamble(data);
+      expect(result.decompressedSize).toBe(4294967295);
+      expect(result.bytesRead).toBe(5);
+    });
+  });
+
+  describe('with actual snappy compression', () => {
+    it('should correctly read preamble from compressed data (small)', () => {
+      // Create uncompressed data of known size
+      const originalSize = 100;
+      const uncompressed = Buffer.alloc(originalSize, 'a');
+
+      // Compress it
+      const compressed = compressSync(uncompressed);
+
+      // Read the preamble
+      const result = readSnappyPreamble(compressed);
+
+      // Verify the decompressed size matches
+      expect(result.decompressedSize).toBe(originalSize);
+
+      // Verify by actually decompressing
+      const decompressed = uncompressSync(compressed, { asBuffer: true });
+      expect(decompressed.length).toBe(originalSize);
+    });
+
+    it('should correctly read preamble from compressed data (1KB)', () => {
+      const originalSize = 1024;
+      const uncompressed = Buffer.alloc(originalSize, 'b');
+      const compressed = compressSync(uncompressed);
+
+      const result = readSnappyPreamble(compressed);
+      expect(result.decompressedSize).toBe(originalSize);
+
+      const decompressed = uncompressSync(compressed, { asBuffer: true });
+      expect(decompressed.length).toBe(originalSize);
+    });
+
+    it('should correctly read preamble from compressed data (64KB)', () => {
+      const originalSize = 65536;
+      const uncompressed = Buffer.alloc(originalSize, 'c');
+      const compressed = compressSync(uncompressed);
+
+      const result = readSnappyPreamble(compressed);
+      expect(result.decompressedSize).toBe(originalSize);
+
+      const decompressed = uncompressSync(compressed, { asBuffer: true });
+      expect(decompressed.length).toBe(originalSize);
+    });
+
+    it('should correctly read preamble from compressed data (1MB)', () => {
+      const originalSize = 1024 * 1024;
+      const uncompressed = Buffer.alloc(originalSize, 'd');
+      const compressed = compressSync(uncompressed);
+
+      const result = readSnappyPreamble(compressed);
+      expect(result.decompressedSize).toBe(originalSize);
+
+      const decompressed = uncompressSync(compressed, { asBuffer: true });
+      expect(decompressed.length).toBe(originalSize);
+    });
+
+    it('should correctly read preamble from compressed random data', () => {
+      // Random data compresses differently than repeated bytes
+      const originalSize = 10000;
+      const uncompressed = Buffer.alloc(originalSize);
+      for (let i = 0; i < originalSize; i++) {
+        uncompressed[i] = Math.floor(Math.random() * 256);
+      }
+
+      const compressed = compressSync(uncompressed);
+      const result = readSnappyPreamble(compressed);
+
+      expect(result.decompressedSize).toBe(originalSize);
+
+      const decompressed = Buffer.from(uncompressSync(compressed, { asBuffer: true }));
+      expect(decompressed.length).toBe(originalSize);
+      expect(Buffer.compare(decompressed, uncompressed)).toBe(0);
+    });
+
+    it('should correctly read preamble from compressed structured data', () => {
+      // Test with JSON data
+      const data = {
+        users: Array.from({ length: 100 }, (_, i) => ({
+          id: i,
+          name: `User ${i}`,
+          email: `user${i}@example.com`,
+        })),
+      };
+      const uncompressed = Buffer.from(JSON.stringify(data));
+      const originalSize = uncompressed.length;
+
+      const compressed = compressSync(uncompressed);
+      const result = readSnappyPreamble(compressed);
+
+      expect(result.decompressedSize).toBe(originalSize);
+
+      const decompressed = uncompressSync(compressed, { asBuffer: true });
+      expect(decompressed.length).toBe(originalSize);
+      expect(JSON.parse(decompressed.toString())).toEqual(data);
+    });
+  });
+
+  describe('edge cases and errors', () => {
+    it('should throw error for empty data', () => {
+      const data = new Uint8Array([]);
+      expect(() => readSnappyPreamble(data)).toThrow('Cannot read preamble from empty data');
+    });
+
+    it('should throw error for incomplete varint', () => {
+      // Start of a multi-byte varint but incomplete
+      const data = new Uint8Array([0x80]); // Continue bit set, but no next byte
+      expect(() => readSnappyPreamble(data)).toThrow('Incomplete varint');
+    });
+
+    it('should throw error for varint that is too long', () => {
+      // 6 bytes with all continue bits set (invalid)
+      const data = new Uint8Array([0xff, 0xff, 0xff, 0xff, 0xff, 0xff]);
+      expect(() => readSnappyPreamble(data)).toThrow('Varint is too long');
+    });
+
+    it('should handle data with extra bytes after preamble', () => {
+      // Single-byte varint followed by random data
+      const data = new Uint8Array([0x40, 0xaa, 0xbb, 0xcc]);
+      const result = readSnappyPreamble(data);
+      expect(result.decompressedSize).toBe(64);
+      expect(result.bytesRead).toBe(1);
+    });
+
+    it('should read zero-length size', () => {
+      // Zero is a valid size (empty compressed data)
+      const data = new Uint8Array([0x00]);
+      const result = readSnappyPreamble(data);
+      expect(result.decompressedSize).toBe(0);
+      expect(result.bytesRead).toBe(1);
+    });
+  });
+
+  describe('various size boundaries', () => {
+    // Test various boundary conditions for varint encoding
+    const testSizes = [
+      { size: 1, expectedBytes: 1 },
+      { size: 127, expectedBytes: 1 }, // Max 1-byte
+      { size: 128, expectedBytes: 2 }, // Min 2-byte
+      { size: 16383, expectedBytes: 2 }, // Max 2-byte
+      { size: 16384, expectedBytes: 3 }, // Min 3-byte
+      { size: 2097151, expectedBytes: 3 }, // Max 3-byte
+      { size: 2097152, expectedBytes: 4 }, // Min 4-byte
+      { size: 268435455, expectedBytes: 4 }, // Max 4-byte
+      { size: 268435456, expectedBytes: 5 }, // Min 5-byte
+    ];
+
+    testSizes.forEach(({ size, expectedBytes }) => {
+      it(`should read preamble for size ${size} (${expectedBytes} bytes)`, () => {
+        const uncompressed = Buffer.alloc(size, 'x');
+        const compressed = compressSync(uncompressed);
+
+        const result = readSnappyPreamble(compressed);
+        expect(result.decompressedSize).toBe(size);
+        expect(result.bytesRead).toBe(expectedBytes);
+      });
+    });
+  });
+});
+
+describe('SnappyTransform', () => {
+  describe('max size validation', () => {
+    describe('with default max sizes', () => {
+      let transform: SnappyTransform;
+
+      beforeEach(() => {
+        transform = new SnappyTransform();
+      });
+
+      it('should accept tx payload within 512kb limit', () => {
+        const size = 400 * 1024; // 400kb
+        const data = Buffer.alloc(size, 'a');
+        const compressed = compressSync(data);
+
+        const result = transform.inboundTransformData(compressed, TopicType.tx);
+        expect(result.length).toBe(size);
+      });
+
+      it('should reject tx payload exceeding 512kb limit', () => {
+        const size = 600 * 1024; // 600kb (exceeds 512kb limit)
+        const data = Buffer.alloc(size, 'a');
+        const compressed = compressSync(data);
+
+        expect(() => transform.inboundTransformData(compressed, TopicType.tx)).toThrow(
+          'Decompressed size 614400 exceeds maximum allowed size of 512kb',
+        );
+      });
+
+      it('should accept block_attestation payload within 5kb limit', () => {
+        const size = 4 * 1024; // 4kb
+        const data = Buffer.alloc(size, 'b');
+        const compressed = compressSync(data);
+
+        const result = transform.inboundTransformData(compressed, TopicType.block_attestation);
+        expect(result.length).toBe(size);
+      });
+
+      it('should reject block_attestation payload exceeding 5kb limit', () => {
+        const size = 6 * 1024; // 6kb (exceeds 5kb limit)
+        const data = Buffer.alloc(size, 'b');
+        const compressed = compressSync(data);
+
+        expect(() => transform.inboundTransformData(compressed, TopicType.block_attestation)).toThrow(
+          'Decompressed size 6144 exceeds maximum allowed size of 5kb',
+        );
+      });
+
+      it('should accept block_proposal payload within 10MB limit', () => {
+        const size = 8 * 1024 * 1024; // 8MB
+        const data = Buffer.alloc(size, 'c');
+        const compressed = compressSync(data);
+
+        const result = transform.inboundTransformData(compressed, TopicType.block_proposal);
+        expect(result.length).toBe(size);
+      });
+
+      it('should reject block_proposal payload exceeding 10MB limit', () => {
+        const size = 11 * 1024 * 1024; // 11MB (exceeds 10MB limit)
+        const data = Buffer.alloc(size, 'c');
+        const compressed = compressSync(data);
+
+        expect(() => transform.inboundTransformData(compressed, TopicType.block_proposal)).toThrow(
+          'Decompressed size 11534336 exceeds maximum allowed size of 10240kb',
+        );
+      });
+
+      it('should use default max size (10MB) for undefined topic', () => {
+        const size = 9 * 1024 * 1024; // 9MB
+        const data = Buffer.alloc(size, 'd');
+        const compressed = compressSync(data);
+
+        const result = transform.inboundTransformData(compressed, undefined);
+        expect(result.length).toBe(size);
+      });
+
+      it('should reject payload exceeding default max size (10MB) for undefined topic', () => {
+        const size = 11 * 1024 * 1024; // 11MB
+        const data = Buffer.alloc(size, 'd');
+        const compressed = compressSync(data);
+
+        expect(() => transform.inboundTransformData(compressed, undefined)).toThrow(
+          'Decompressed size 11534336 exceeds maximum allowed size of 10240kb',
+        );
+      });
+    });
+
+    describe('with custom max sizes', () => {
+      it('should respect custom max sizes for each topic', () => {
+        const customMaxSizes = {
+          [TopicType.tx]: 100, // 100kb
+          [TopicType.block_attestation]: 10, // 10kb
+          [TopicType.block_proposal]: 500, // 500kb
+        };
+        const transform = new SnappyTransform(customMaxSizes);
+
+        // Test tx at boundary
+        const txData = Buffer.alloc(90 * 1024, 'a'); // 90kb
+        const txCompressed = compressSync(txData);
+        expect(() => transform.inboundTransformData(txCompressed, TopicType.tx)).not.toThrow();
+
+        // Test tx exceeding limit
+        const txDataLarge = Buffer.alloc(110 * 1024, 'a'); // 110kb
+        const txCompressedLarge = compressSync(txDataLarge);
+        expect(() => transform.inboundTransformData(txCompressedLarge, TopicType.tx)).toThrow(
+          'exceeds maximum allowed size of 100kb',
+        );
+      });
+
+      it('should respect custom default max size', () => {
+        const customMaxSizes = {
+          [TopicType.tx]: 100,
+          [TopicType.block_attestation]: 10,
+          [TopicType.block_proposal]: 500,
+        };
+        const customDefaultMaxSize = 200; // 200kb
+        const transform = new SnappyTransform(customMaxSizes, customDefaultMaxSize);
+
+        // Test undefined topic with custom default
+        const data = Buffer.alloc(150 * 1024, 'a'); // 150kb
+        const compressed = compressSync(data);
+        expect(() => transform.inboundTransformData(compressed, undefined)).not.toThrow();
+
+        // Test undefined topic exceeding custom default
+        const dataLarge = Buffer.alloc(250 * 1024, 'a'); // 250kb
+        const compressedLarge = compressSync(dataLarge);
+        expect(() => transform.inboundTransformData(compressedLarge, undefined)).toThrow(
+          'exceeds maximum allowed size of 200kb',
+        );
+      });
+    });
+
+    describe('exact boundary conditions', () => {
+      let transform: SnappyTransform;
+
+      beforeEach(() => {
+        transform = new SnappyTransform();
+      });
+
+      it('should accept payload at exact limit (512kb for tx)', () => {
+        const size = 512 * 1024; // Exactly 512kb
+        const data = Buffer.alloc(size, 'a');
+        const compressed = compressSync(data);
+
+        const result = transform.inboundTransformData(compressed, TopicType.tx);
+        expect(result.length).toBe(size);
+      });
+
+      it('should reject payload one byte over limit', () => {
+        const size = 512 * 1024 + 1; // 512kb + 1 byte
+        const data = Buffer.alloc(size, 'a');
+        const compressed = compressSync(data);
+
+        expect(() => transform.inboundTransformData(compressed, TopicType.tx)).toThrow(
+          'exceeds maximum allowed size of 512kb',
+        );
+      });
+
+      it('should accept payload one byte under limit', () => {
+        const size = 512 * 1024 - 1; // 512kb - 1 byte
+        const data = Buffer.alloc(size, 'a');
+        const compressed = compressSync(data);
+
+        const result = transform.inboundTransformData(compressed, TopicType.tx);
+        expect(result.length).toBe(size);
+      });
+    });
+  });
+
+  describe('compression and decompression', () => {
+    let transform: SnappyTransform;
+
+    beforeEach(() => {
+      transform = new SnappyTransform();
+    });
+
+    it('should compress and decompress data correctly', () => {
+      const original = Buffer.from('Hello, World! This is a test message.');
+      const compressed = transform.outboundTransformData(original);
+      const decompressed = transform.inboundTransformData(compressed, TopicType.tx);
+
+      expect(Buffer.compare(decompressed, original)).toBe(0);
+    });
+
+    it('should handle empty data', () => {
+      const empty = Buffer.alloc(0);
+      const compressed = transform.outboundTransformData(empty);
+      const decompressed = transform.inboundTransformData(compressed, TopicType.tx);
+
+      expect(compressed.length).toBe(0);
+      expect(decompressed.length).toBe(0);
+    });
+
+    it('should compress large repetitive data efficiently', () => {
+      const size = 100 * 1024; // 100kb of repeated data
+      const original = Buffer.alloc(size, 'a');
+      const compressed = transform.outboundTransformData(original);
+
+      // Compressed size should be significantly smaller
+      expect(compressed.length).toBeLessThan(original.length / 10);
+
+      const decompressed = transform.inboundTransformData(compressed, TopicType.tx);
+      expect(Buffer.compare(decompressed, original)).toBe(0);
+    });
+
+    it('should handle random data (less compressible)', () => {
+      const size = 10 * 1024; // 10kb
+      const original = Buffer.alloc(size);
+      for (let i = 0; i < size; i++) {
+        original[i] = Math.floor(Math.random() * 256);
+      }
+
+      const compressed = transform.outboundTransformData(original);
+      const decompressed = transform.inboundTransformData(compressed, TopicType.tx);
+
+      expect(Buffer.compare(decompressed, original)).toBe(0);
+    });
+  });
+
+  describe('inboundTransform with topic string', () => {
+    let transform: SnappyTransform;
+
+    beforeEach(() => {
+      transform = new SnappyTransform();
+    });
+
+    it('should parse topic string and apply correct size limit', () => {
+      const size = 400 * 1024; // 400kb
+      const data = Buffer.alloc(size, 'a');
+      const compressed = compressSync(data);
+
+      // Should work with valid tx topic string
+      const result = transform.inboundTransform('/aztec/tx/0.1.0', compressed);
+      expect(result.length).toBe(size);
+    });
+
+    it('should reject payload when topic string indicates size limit exceeded', () => {
+      const size = 6 * 1024; // 6kb (exceeds block_attestation limit of 5kb)
+      const data = Buffer.alloc(size, 'a');
+      const compressed = compressSync(data);
+
+      expect(() => transform.inboundTransform('/aztec/block_attestation/0.1.0', compressed)).toThrow(
+        'exceeds maximum allowed size of 5kb',
+      );
+    });
+
+    it('should use default max size for invalid topic string', () => {
+      const size = 9 * 1024 * 1024; // 9MB (under default 10MB)
+      const data = Buffer.alloc(size, 'a');
+      const compressed = compressSync(data);
+
+      // Invalid topic string should fall back to default limit
+      const result = transform.inboundTransform('/invalid/topic/string', compressed);
+      expect(result.length).toBe(size);
+    });
+
+    it('should reject when invalid topic string and exceeds default limit', () => {
+      const size = 11 * 1024 * 1024; // 11MB (exceeds default 10MB)
+      const data = Buffer.alloc(size, 'a');
+      const compressed = compressSync(data);
+
+      expect(() => transform.inboundTransform('/invalid/topic/string', compressed)).toThrow(
+        'exceeds maximum allowed size of 10240kb',
+      );
+    });
+  });
+
+  describe('outboundTransform', () => {
+    let transform: SnappyTransform;
+
+    beforeEach(() => {
+      transform = new SnappyTransform();
+    });
+
+    it('should compress data via outboundTransform', () => {
+      const original = new Uint8Array(Buffer.from('Test data for compression'));
+      const compressed = transform.outboundTransform('/aztec/tx/0.1.0', original);
+
+      expect(compressed.length).toBeGreaterThan(0);
+      expect(compressed.length).not.toBe(original.length);
+    });
+
+    it('should handle empty data in outboundTransform', () => {
+      const empty = new Uint8Array(0);
+      const result = transform.outboundTransform('/aztec/tx/0.1.0', empty);
+
+      expect(result.length).toBe(0);
+    });
+  });
+});

--- a/yarn-project/p2p/src/services/encoding.ts
+++ b/yarn-project/p2p/src/services/encoding.ts
@@ -1,5 +1,7 @@
 // Taken from lodestar: https://github.com/ChainSafe/lodestar
 import { sha256 } from '@aztec/foundation/crypto';
+import { createLogger } from '@aztec/foundation/log';
+import { TopicType, getTopicFromString } from '@aztec/stdlib/p2p';
 
 import type { RPC } from '@chainsafe/libp2p-gossipsub/message';
 import type { DataTransform } from '@chainsafe/libp2p-gossipsub/types';
@@ -49,31 +51,104 @@ export function getMsgIdFn(message: Message) {
   return sha256(Buffer.concat(vec)).subarray(0, 20);
 }
 
+const DefaultMaxSizesKb: Record<TopicType, number> = {
+  // Tx effects should not exceed 128kb, so 512kb for the full tx obj should be sufficient
+  [TopicType.tx]: 512,
+  // An attestation has roughly 30 fields, which is 1kb, so 5x is plenty
+  [TopicType.block_attestation]: 5,
+  // Proposals may carry some tx objects, so we allow a larger size capped at 10mb
+  // Note this may not be enough for carrying all tx objects in a block
+  [TopicType.block_proposal]: 1024 * 10,
+};
+
 /**
  * Snappy transform for libp2p gossipsub
  */
 export class SnappyTransform implements DataTransform {
+  constructor(
+    private maxSizesKb: Record<TopicType, number> = DefaultMaxSizesKb,
+    private defaultMaxSizeKb: number = 10 * 1024,
+    private logger = createLogger('p2p:snappy-transform'),
+  ) {}
+
   // Topic string included to satisfy DataTransform interface
-  inboundTransform(_topicStr: string, data: Uint8Array): Uint8Array {
-    return this.inboundTransformNoTopic(Buffer.from(data));
+  inboundTransform(topicStr: string, data: Uint8Array): Uint8Array {
+    const topic = getTopicFromString(topicStr);
+    return this.inboundTransformData(Buffer.from(data), topic);
   }
 
-  public inboundTransformNoTopic(data: Buffer): Buffer {
+  public inboundTransformData(data: Buffer, topic?: TopicType): Buffer {
     if (data.length === 0) {
       return data;
     }
+    const maxSizeKb = this.maxSizesKb[topic!] ?? this.defaultMaxSizeKb;
+    const { decompressedSize } = readSnappyPreamble(data);
+    if (decompressedSize > maxSizeKb * 1024) {
+      this.logger.warn(`Decompressed size ${decompressedSize} exceeds maximum allowed size of ${maxSizeKb}kb`);
+      throw new Error(`Decompressed size ${decompressedSize} exceeds maximum allowed size of ${maxSizeKb}kb`);
+    }
+
     return Buffer.from(uncompressSync(data, { asBuffer: true }));
   }
 
   // Topic string included to satisfy DataTransform interface
   outboundTransform(_topicStr: string, data: Uint8Array): Uint8Array {
-    return this.outboundTransformNoTopic(Buffer.from(data));
+    return this.outboundTransformData(Buffer.from(data));
   }
 
-  public outboundTransformNoTopic(data: Buffer): Buffer {
+  public outboundTransformData(data: Buffer): Buffer {
     if (data.length === 0) {
       return data;
     }
     return Buffer.from(compressSync(data));
   }
+}
+
+/**
+ * Reads the Snappy preamble from compressed data and returns the expected decompressed size.
+ *
+ * The Snappy format starts with a little-endian varint encoding the uncompressed length.
+ * Varints consist of a series of bytes where:
+ * - Lower 7 bits contain data
+ * - Upper bit (0x80) is set if more bytes follow
+ *
+ * @param data - The compressed data starting with the Snappy preamble
+ * @returns Object containing the decompressed size and the number of bytes read from the preamble
+ * @throws Error if the data is too short or the varint is invalid
+ */
+export function readSnappyPreamble(data: Uint8Array): { decompressedSize: number; bytesRead: number } {
+  if (data.length === 0) {
+    throw new Error('Cannot read preamble from empty data');
+  }
+
+  let result = 0;
+  let shift = 0;
+  let bytesRead = 0;
+
+  // Maximum varint length for 32-bit value is 5 bytes
+  // (7 bits per byte, so 5 bytes = 35 bits, enough for 2^32 - 1)
+  const maxBytes = 5;
+
+  for (let i = 0; i < Math.min(data.length, maxBytes); i++) {
+    const byte = data[i];
+    bytesRead++;
+
+    // Extract lower 7 bits and add to result with appropriate shift
+    // Use >>> 0 to convert to unsigned 32-bit integer to avoid sign issues
+    result = (result | ((byte & 0x7f) << shift)) >>> 0;
+
+    // If upper bit is not set, we're done
+    if ((byte & 0x80) === 0) {
+      return { decompressedSize: result, bytesRead };
+    }
+
+    shift += 7;
+  }
+
+  // If we get here, either we ran out of data or the varint is too long
+  if (bytesRead >= maxBytes) {
+    throw new Error('Varint is too long (max 5 bytes for 32-bit value)');
+  }
+
+  throw new Error('Incomplete varint: data ended before varint termination');
 }

--- a/yarn-project/p2p/src/services/reqresp/reqresp.ts
+++ b/yarn-project/p2p/src/services/reqresp/reqresp.ts
@@ -489,7 +489,7 @@ export class ReqResp implements ReqRespInterface {
       }
 
       const messageData = Buffer.concat(chunks);
-      const message: Buffer = this.snappyTransform.inboundTransformNoTopic(messageData);
+      const message: Buffer = this.snappyTransform.inboundTransformData(messageData);
 
       return {
         status: status ?? ReqRespStatus.UNKNOWN,
@@ -618,7 +618,7 @@ export class ReqResp implements ReqRespInterface {
           stream.metadata.written = true; // Mark the stream as written to;
 
           yield SUCCESS;
-          yield snappy.outboundTransformNoTopic(response);
+          yield snappy.outboundTransformData(response);
         }
       },
       stream.sink,

--- a/yarn-project/stdlib/src/p2p/topic_type.ts
+++ b/yarn-project/stdlib/src/p2p/topic_type.ts
@@ -1,18 +1,25 @@
 import { P2PClientType } from './client_type.js';
 
-/** Create Topic String
- *
- * The topic channel identifier
- * @param topicType
- * @returns
+/**
+ * Creates the topic channel identifier string from a given topic type
  */
 export function createTopicString(topicType: TopicType, protocolVersion: string) {
   return `/aztec/${TopicType[topicType]}/${protocolVersion}`;
 }
 
-/**
- *
- */
+/** Extracts the topic type from a topic string */
+export function getTopicFromString(topicStr: string): TopicType | undefined {
+  const parts = topicStr.split('/');
+  if (parts.length < 4 || parts[1] !== 'aztec') {
+    return undefined;
+  }
+  const topic = parts[2];
+  if (Object.values(TopicType).includes(topic as TopicType)) {
+    return topic as TopicType;
+  }
+  return undefined;
+}
+
 export enum TopicType {
   tx = 'tx',
   block_proposal = 'block_proposal',

--- a/yarn-project/stdlib/src/p2p/topics.test.ts
+++ b/yarn-project/stdlib/src/p2p/topics.test.ts
@@ -1,5 +1,5 @@
 import { P2PClientType } from './client_type.js';
-import { getTopicsForClientAndConfig } from './topic_type.js';
+import { TopicType, getTopicFromString, getTopicsForClientAndConfig } from './topic_type.js';
 
 describe('Gossip topic retrieval', () => {
   it.each([
@@ -13,4 +13,125 @@ describe('Gossip topic retrieval', () => {
       expect(getTopicsForClientAndConfig(clientType, !transactionsEnabled)).toEqual(expectedTopics);
     },
   );
+});
+
+describe('getTopicFromString', () => {
+  describe('valid topic strings', () => {
+    it('should parse tx topic with version 0.1.0', () => {
+      const result = getTopicFromString('/aztec/tx/0.1.0');
+      expect(result).toBe(TopicType.tx);
+    });
+
+    it('should parse block_proposal topic with version 0.1.0', () => {
+      const result = getTopicFromString('/aztec/block_proposal/0.1.0');
+      expect(result).toBe(TopicType.block_proposal);
+    });
+
+    it('should parse block_attestation topic with version 0.1.0', () => {
+      const result = getTopicFromString('/aztec/block_attestation/0.1.0');
+      expect(result).toBe(TopicType.block_attestation);
+    });
+
+    it('should parse topic with different protocol version', () => {
+      const result = getTopicFromString('/aztec/tx/1.2.3');
+      expect(result).toBe(TopicType.tx);
+    });
+
+    it('should parse topic with complex version string', () => {
+      const result = getTopicFromString('/aztec/block_proposal/v2.0.0-alpha.1');
+      expect(result).toBe(TopicType.block_proposal);
+    });
+
+    it('should parse topic with extra path segments', () => {
+      // Even if there are extra segments, should still extract the topic
+      const result = getTopicFromString('/aztec/tx/0.1.0/extra');
+      expect(result).toBe(TopicType.tx);
+    });
+  });
+
+  describe('invalid topic strings', () => {
+    it('should return undefined for empty string', () => {
+      const result = getTopicFromString('');
+      expect(result).toBeUndefined();
+    });
+
+    it('should return undefined for string without leading slash', () => {
+      const result = getTopicFromString('aztec/tx/0.1.0');
+      expect(result).toBeUndefined();
+    });
+
+    it('should return undefined for wrong protocol name', () => {
+      const result = getTopicFromString('/ethereum/tx/0.1.0');
+      expect(result).toBeUndefined();
+    });
+
+    it('should return undefined for unknown topic type', () => {
+      const result = getTopicFromString('/aztec/unknown_topic/0.1.0');
+      expect(result).toBeUndefined();
+    });
+
+    it('should return undefined for malformed topic (no version)', () => {
+      const result = getTopicFromString('/aztec/tx');
+      expect(result).toBeUndefined();
+    });
+
+    it('should return undefined for malformed topic (only protocol)', () => {
+      const result = getTopicFromString('/aztec');
+      expect(result).toBeUndefined();
+    });
+
+    it('should return undefined for malformed topic (missing parts)', () => {
+      const result = getTopicFromString('/aztec//0.1.0');
+      expect(result).toBeUndefined();
+    });
+
+    it('should return undefined for topic with case mismatch', () => {
+      const result = getTopicFromString('/aztec/TX/0.1.0');
+      expect(result).toBeUndefined();
+    });
+
+    it('should return undefined for topic with protocol case mismatch', () => {
+      const result = getTopicFromString('/Aztec/tx/0.1.0');
+      expect(result).toBeUndefined();
+    });
+
+    it('should return undefined for random string', () => {
+      const result = getTopicFromString('random-string');
+      expect(result).toBeUndefined();
+    });
+
+    it('should return undefined for single slash', () => {
+      const result = getTopicFromString('/');
+      expect(result).toBeUndefined();
+    });
+
+    it('should return undefined for topic with spaces', () => {
+      const result = getTopicFromString('/aztec/tx /0.1.0');
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle topic string with trailing slash', () => {
+      const result = getTopicFromString('/aztec/tx/0.1.0/');
+      expect(result).toBe(TopicType.tx);
+    });
+
+    it('should handle topic string with multiple trailing slashes', () => {
+      const result = getTopicFromString('/aztec/tx/0.1.0//');
+      expect(result).toBe(TopicType.tx);
+    });
+
+    it('should handle all valid topic types', () => {
+      const topicStrings = [
+        ['/aztec/tx/0.1.0', TopicType.tx],
+        ['/aztec/block_proposal/0.1.0', TopicType.block_proposal],
+        ['/aztec/block_attestation/0.1.0', TopicType.block_attestation],
+      ] as const;
+
+      topicStrings.forEach(([topicStr, expectedType]) => {
+        expect(getTopicFromString(topicStr)).toBe(expectedType);
+      });
+    });
+  });
 });


### PR DESCRIPTION
See https://eips.ethereum.org/EIPS/eip-706#avoiding-dos-attacks

Fixes A-209