### PR TITLE
fix: add proper error handling for invalid short hash in VK test script

### DIFF
--- a/barretenberg/cpp/scripts/test_chonk_standalone_vks_havent_changed.sh
+++ b/barretenberg/cpp/scripts/test_chonk_standalone_vks_havent_changed.sh
@@ -57,7 +57,18 @@ fi
 export inputs_tmp_dir=$(mktemp -d)
 trap 'rm -rf "$inputs_tmp_dir" bb-chonk-inputs.tar.gz' EXIT SIGINT
 
-curl -s -f "$pinned_chonk_inputs_url" | tar -xzf - -C "$inputs_tmp_dir" &>/dev/null
+echo "Downloading pinned IVC inputs from: $pinned_chonk_inputs_url"
+if ! curl -s -f "$pinned_chonk_inputs_url" -o bb-chonk-inputs.tar.gz; then
+    echo_stderr "Error: Failed to download pinned IVC inputs from $pinned_chonk_inputs_url"
+    echo_stderr "The pinned short hash '$pinned_short_hash' may be invalid or the file may not exist in S3."
+    exit 1
+fi
+
+echo "Extracting IVC inputs..."
+if ! tar -xzf bb-chonk-inputs.tar.gz -C "$inputs_tmp_dir"; then
+    echo_stderr "Error: Failed to extract IVC inputs archive"
+    exit 1
+fi
 
 function check_circuit_vks {
   set -eu


### PR DESCRIPTION
## Summary
- Fixes silent failure when the pinned short hash is invalid in the VK test script
- Adds explicit error checking for curl download and tar extraction
- Provides clear error messages to help diagnose issues

## Problem
The script was failing silently when the pinned short hash was invalid because:
1. The `curl | tar` pipeline with `&>/dev/null` suppressed all error messages
2. No error checking was performed on the curl command
3. Pipeline exit status only reflected tar, not curl failures

This made it very difficult to diagnose why the script was failing when the S3 artifact didn't exist.

## Solution
- Split curl and tar into separate operations with individual error checking
- Added descriptive error messages that indicate the likely cause (invalid hash)
- Removed silent output redirection to allow visibility into failures
- Added progress messages during download and extraction