### PR TITLE
fix: add fallback to legacy bb-civc URL for backward compatibility

### DIFF
--- a/barretenberg/cpp/scripts/test_chonk_standalone_vks_havent_changed.sh
+++ b/barretenberg/cpp/scripts/test_chonk_standalone_vks_havent_changed.sh
@@ -57,9 +57,20 @@ fi
 export inputs_tmp_dir=$(mktemp -d)
 trap 'rm -rf "$inputs_tmp_dir" bb-chonk-inputs.tar.gz' EXIT SIGINT
 
-echo "Downloading pinned IVC inputs from: $pinned_chonk_inputs_url"
-if ! curl -s -f "$pinned_chonk_inputs_url" -o bb-chonk-inputs.tar.gz; then
-    echo_stderr "Error: Failed to download pinned IVC inputs from $pinned_chonk_inputs_url"
+# TODO: Remove the bb-civc fallback URL once all old artifacts have expired
+# Try the new bb-chonk naming first, then fall back to the old bb-civc naming
+pinned_chonk_url="https://aztec-ci-artifacts.s3.us-east-2.amazonaws.com/protocol/bb-chonk-inputs-${pinned_short_hash}.tar.gz"
+pinned_civc_url="https://aztec-ci-artifacts.s3.us-east-2.amazonaws.com/protocol/bb-civc-inputs-${pinned_short_hash}.tar.gz"
+
+echo "Downloading pinned IVC inputs (trying bb-chonk naming first)..."
+if curl -s -f "$pinned_chonk_url" -o bb-chonk-inputs.tar.gz; then
+    echo "Successfully downloaded from bb-chonk URL"
+elif curl -s -f "$pinned_civc_url" -o bb-chonk-inputs.tar.gz; then
+    echo "Successfully downloaded from bb-civc URL (legacy)"
+else
+    echo_stderr "Error: Failed to download pinned IVC inputs from either URL:"
+    echo_stderr "  - $pinned_chonk_url"
+    echo_stderr "  - $pinned_civc_url"
     echo_stderr "The pinned short hash '$pinned_short_hash' may be invalid or the file may not exist in S3."
     exit 1
 fi


### PR DESCRIPTION
## Summary
- Adds fallback logic to try both bb-chonk and bb-civc URL naming conventions
- Ensures backward compatibility with existing artifacts during naming transition
- Includes TODO to remove legacy fallback once old artifacts expire

## Problem
The script was updated to upload artifacts with the `bb-chonk-inputs-*` naming convention, but still only downloads from the legacy `bb-civc-inputs-*` naming. This creates an inconsistency where:
- New artifacts are uploaded as `bb-chonk-inputs-{hash}.tar.gz`
- The script only tries to download from `bb-civc-inputs-{hash}.tar.gz`
- This causes failures when the hash points to a newer artifact using the new naming

## Solution
Implement a fallback mechanism that:
1. First tries the new `bb-chonk-inputs` URL (matching the upload naming)
2. Falls back to the legacy `bb-civc-inputs` URL if the new one doesn't exist
3. Provides clear messages about which URL was successful
4. Includes a TODO comment to remove the legacy fallback once old artifacts expire

This ensures smooth operation during the transition period while maintaining compatibility with existing artifacts.