### PR TITLE
wip: add ci-release-test label for release testing

### DIFF
--- a/.github/workflows/ci3.yml
+++ b/.github/workflows/ci3.yml
@@ -78,6 +78,10 @@ jobs:
         if: contains(github.event.pull_request.labels.*.name, 'barretenberg-ci') || (github.event.pull_request.base.ref == 'merge-train/barretenberg')
         run: echo "CI_BARRETENBERG=1" >> $GITHUB_ENV
 
+      - name: CI Release Test Override
+        if: contains(github.event.pull_request.labels.*.name, 'ci-release-test')
+        run: echo "CI_RELEASE_TEST=1" >> $GITHUB_ENV
+
       # Allow full concurrency for merge-train PRs, one-run-per-branch for everything else.
       - name: Set Instance Postfix for merge-train
         if: startsWith(github.event.pull_request.head.ref, 'merge-train/')
@@ -142,6 +146,8 @@ jobs:
         run: |
           if [ "${{ github.event_name }}" == "merge_group" ] || [ "${CI_MERGE_QUEUE:-0}" -eq 1 ]; then
             exec ./ci.sh merge-queue
+          elif [ "${CI_RELEASE_TEST:-0}" -eq 1 ]; then
+            exec ./ci.sh release-test
           elif [ "${CI_FULL:-0}" -eq 1 ]; then
             exec ./ci.sh full
           elif [ "${CI_DOCS:-0}" -eq 1 ]; then

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -472,6 +472,17 @@ case "$cmd" in
     build
     release
     ;;
+  "ci-release-test")
+    export CI=1
+    export USE_TEST_CACHE=1
+    export RELEASE_TEST=1
+    # Generate a test version tag using commit hash
+    export REF_NAME="v0.0.1-test-$(git rev-parse --short=7 HEAD)"
+    echo "Running release test with fake version: $REF_NAME"
+    echo "Note: RELEASE_TEST=1 will prevent pushing tags starting with 'v'"
+    build
+    release
+    ;;
   "ci-docs")
     export CI=1
     export USE_TEST_CACHE=1

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -477,8 +477,8 @@ case "$cmd" in
     export USE_TEST_CACHE=1
     export RELEASE_TEST=1
     export AZTEC_RELEASE_REPO="${AZTEC_RELEASE_REPO:-aztec-dev}"
-    # Generate a test version tag using commit hash
-    export REF_NAME="v0.0.1-test-$(git rev-parse --short=7 HEAD)"
+    # Use a short fake version to avoid exceeding bb binary placeholder length
+    export REF_NAME="v0.0.1-fake"
     echo "Running release test with fake version: $REF_NAME"
     echo "Note: RELEASE_TEST=1 will prevent pushing tags starting with 'v'"
     echo "Publishing to namespace: @${AZTEC_RELEASE_REPO} and aztecprotocol/${AZTEC_RELEASE_REPO}"

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -476,7 +476,7 @@ case "$cmd" in
     export CI=1
     export USE_TEST_CACHE=1
     export RELEASE_TEST=1
-    export AZTEC_RELEASE_REPO="${AZTEC_RELEASE_REPO:-aztec-dev}"
+    export AZTEC_RELEASE_REPO="${AZTEC_RELEASE_REPO:-aztecdev}"
     # Use a short fake version to avoid exceeding bb binary placeholder length
     export REF_NAME="v0.0.1-fake"
     echo "Running release test with fake version: $REF_NAME"

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -477,11 +477,13 @@ case "$cmd" in
     export USE_TEST_CACHE=1
     export RELEASE_TEST=1
     export AZTEC_RELEASE_REPO="${AZTEC_RELEASE_REPO:-aztecdev}"
+    # Prep fake release tag.
     # Use a short fake version to avoid exceeding bb binary placeholder length
-    export REF_NAME="v0.0.1-fake"
-    echo "Running release test with fake version: $REF_NAME"
-    echo "Note: RELEASE_TEST=1 will prevent pushing tags starting with 'v'"
-    echo "Publishing to namespace: @${AZTEC_RELEASE_REPO} and aztecprotocol/${AZTEC_RELEASE_REPO}"
+    export REF_NAME="v0.0.1-fake-$(git rev-parse --short HEAD)"
+    # Be careful to not cause a real release flow to trigger.
+    git commit --allow-empty -m "Release test ${REF_NAME} [skip ci]"
+    git tag "${REF_NAME}"
+    git push origin tag "${REF_NAME}"
     build
     release
     ;;

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -476,10 +476,12 @@ case "$cmd" in
     export CI=1
     export USE_TEST_CACHE=1
     export RELEASE_TEST=1
+    export AZTEC_RELEASE_REPO="${AZTEC_RELEASE_REPO:-aztec-dev}"
     # Generate a test version tag using commit hash
     export REF_NAME="v0.0.1-test-$(git rev-parse --short=7 HEAD)"
     echo "Running release test with fake version: $REF_NAME"
     echo "Note: RELEASE_TEST=1 will prevent pushing tags starting with 'v'"
+    echo "Publishing to namespace: @${AZTEC_RELEASE_REPO} and aztecprotocol/${AZTEC_RELEASE_REPO}"
     build
     release
     ;;

--- a/ci.sh
+++ b/ci.sh
@@ -176,6 +176,18 @@ case "$cmd" in
       'run x-release amd64' \
       'run a-release arm64' | DUP=1 cache_log "Release CI run" $RUN_ID
     ;;
+  "release-test")
+    prep_vars
+    # Spin up ec2 instance and run the release test flow.
+    run() {
+      JOB_ID=$1 INSTANCE_POSTFIX=$1 ARCH=$2 exec denoise "bootstrap_ec2 './bootstrap.sh ci-release-test'"
+    }
+    export -f run
+    # We need to run the release test flow on both x86 and arm64.
+    parallel --termseq 'TERM,10000' --tagstring '{= $_=~s/run (\w+).*/$1/; =}' --line-buffered --halt now,fail=1 ::: \
+      'run x-release-test amd64' \
+      'run a-release-test arm64' | DUP=1 cache_log "Release test CI run" $RUN_ID
+    ;;
   "shell-new")
     # Spin up ec2 instance, clone, and drop into shell.
     # False triggers the shell on fail.

--- a/ci.sh
+++ b/ci.sh
@@ -180,13 +180,16 @@ case "$cmd" in
     prep_vars
     # Spin up ec2 instance and run the release test flow.
     run() {
-      JOB_ID=$1 INSTANCE_POSTFIX=$1 ARCH=$2 exec denoise "bootstrap_ec2 './bootstrap.sh ci-release-test'"
+      JOB_ID=$1 INSTANCE_POSTFIX=$1 ARCH=$2 exec denoise "bootstrap_ec2 './bootstrap.sh $3'"
     }
     export -f run
-    # We need to run the release test flow on both x86 and arm64.
+    # We need to run fast CI and release test flow on both x86 and arm64.
+    # The release flow doesn't run tests, so we run them too.
     parallel --termseq 'TERM,10000' --tagstring '{= $_=~s/run (\w+).*/$1/; =}' --line-buffered --halt now,fail=1 ::: \
-      'run x-release-test amd64' \
-      'run a-release-test arm64' | DUP=1 cache_log "Release test CI run" $RUN_ID
+      'run x-fast amd64 ci-fast' \
+      'run a-fast arm64 ci-fast' \
+      'run x-release-test amd64 ci-release-test' \
+      'run a-release-test arm64 ci-release-test' | DUP=1 cache_log "Release test CI run" $RUN_ID
     ;;
   "shell-new")
     # Spin up ec2 instance, clone, and drop into shell.

--- a/ci3/bootstrap_ec2
+++ b/ci3/bootstrap_ec2
@@ -54,7 +54,7 @@ else
   instance_name=$(echo -n "$REF_NAME" | head -c 50 | tr -c 'a-zA-Z0-9-' '_')_$arch
 fi
 
-if semver check $REF_NAME; then
+if semver check $REF_NAME && [ "${AZTEC_RELEASE_REPO:-aztec}" = "aztec" ]; then
   # Override the public key that aws will load into ~/.ssh/authorized_keys on the launched instance.
   # This requires the restricted key only available in release environments.
   key_name="super-build-instance"

--- a/ci3/do_or_dryrun
+++ b/ci3/do_or_dryrun
@@ -1,6 +1,16 @@
 #!/usr/bin/env bash
-if [ ${DRY_RUN:-0} = 0 ]; then
-  exec "$@"
-else
+if [ ${DRY_RUN:-0} = 1 ]; then
   echo "DRY: $@"
+  exit 0
 fi
+
+# In RELEASE_TEST mode, prevent pushing tags or creating releases that start with 'v'
+if [ ${RELEASE_TEST:-0} = 1 ]; then
+  # Check if this is a git push with a tag starting with 'v', or a gh release create with a tag starting with 'v'
+  if [[ "$*" =~ git\ push.*\ v[0-9] ]] || [[ "$*" =~ gh\ release\ create\ v[0-9] ]]; then
+    echo "RELEASE_TEST: Skipping command that would push/create tag starting with 'v': $@"
+    exit 0
+  fi
+fi
+
+exec "$@"

--- a/ci3/npm/release_prep_package_json
+++ b/ci3/npm/release_prep_package_json
@@ -2,39 +2,22 @@
 # Used before releases to write version and rewrite 'workspace:^' URLs.
 NO_CD=1 source $(git rev-parse --show-toplevel)/ci3/source
 version=$1
-repo=${AZTEC_RELEASE_REPO:-aztec}
 
 tmp=$(mktemp)
 
-# If AZTEC_RELEASE_REPO is set to something other than 'aztec', update package scope
-if [ "$repo" != "aztec" ]; then
-  jq --arg v $version --arg repo "$repo" '
-    .version = $v |
-    if .name | startswith("@aztec/") then
-      .name = "@" + $repo + "/" + (.name | sub("^@aztec/"; ""))
-    else . end
-  ' package.json >$tmp && mv $tmp package.json
-else
-  jq --arg v $version '.version = $v' package.json >$tmp && mv $tmp package.json
-fi
+jq --arg v $version '.version = $v' package.json >$tmp && mv $tmp package.json
 
 # We update every category of dependency.
 # While we don't strictly need to update devDependencies, 'workspace:^' is not a valid URL in npm.
 for deps in dependencies devDependencies peerDependencies; do
   # Update each dependency @aztec package version in package.json.
   for pkg in $(jq --raw-output "(.$deps // {}) | keys[] | select(contains(\"@aztec/\"))" package.json); do
-    if [ "$repo" != "aztec" ]; then
-      # Rename @aztec dependencies to @{repo}
-      new_pkg="@${repo}/${pkg#@aztec/}"
-      jq --arg v "$version" --arg old "$pkg" --arg new "$new_pkg" ".$deps[\$new] = \$v | del(.$deps[\$old])" package.json >$tmp
-    else
-      jq --arg v $version ".$deps[\"$pkg\"] = \$v" package.json >$tmp
-    fi
+    jq --arg v $version ".$deps[\"$pkg\"] = \$v" package.json >$tmp
     mv $tmp package.json
   done
   # Update each dependency @noir-lang package version in package.json to point to renamed packages and versions.
   for pkg in $(jq --raw-output '(.'$deps' // {}) | keys[] | select(startswith("@noir-lang/"))' package.json); do
-    new_pkg="@${repo}/noir-${pkg#@noir-lang/}"
+    new_pkg="@aztec/noir-${pkg#@noir-lang/}"
     jq --arg v "$version" --arg old "$pkg" --arg new "$new_pkg" '.'$deps'[$new] = $v | del(.'$deps'[$old])' package.json > tmp.json
     mv tmp.json package.json
   done

--- a/ci3/npm/release_prep_package_json
+++ b/ci3/npm/release_prep_package_json
@@ -2,22 +2,39 @@
 # Used before releases to write version and rewrite 'workspace:^' URLs.
 NO_CD=1 source $(git rev-parse --show-toplevel)/ci3/source
 version=$1
+repo=${AZTEC_RELEASE_REPO:-aztec}
 
 tmp=$(mktemp)
 
-jq --arg v $version '.version = $v' package.json >$tmp && mv $tmp package.json
+# If AZTEC_RELEASE_REPO is set to something other than 'aztec', update package scope
+if [ "$repo" != "aztec" ]; then
+  jq --arg v $version --arg repo "$repo" '
+    .version = $v |
+    if .name | startswith("@aztec/") then
+      .name = "@" + $repo + "/" + (.name | sub("^@aztec/"; ""))
+    else . end
+  ' package.json >$tmp && mv $tmp package.json
+else
+  jq --arg v $version '.version = $v' package.json >$tmp && mv $tmp package.json
+fi
 
 # We update every category of dependency.
 # While we don't strictly need to update devDependencies, 'workspace:^' is not a valid URL in npm.
 for deps in dependencies devDependencies peerDependencies; do
   # Update each dependency @aztec package version in package.json.
   for pkg in $(jq --raw-output "(.$deps // {}) | keys[] | select(contains(\"@aztec/\"))" package.json); do
-    jq --arg v $version ".$deps[\"$pkg\"] = \$v" package.json >$tmp
+    if [ "$repo" != "aztec" ]; then
+      # Rename @aztec dependencies to @{repo}
+      new_pkg="@${repo}/${pkg#@aztec/}"
+      jq --arg v "$version" --arg old "$pkg" --arg new "$new_pkg" ".$deps[\$new] = \$v | del(.$deps[\$old])" package.json >$tmp
+    else
+      jq --arg v $version ".$deps[\"$pkg\"] = \$v" package.json >$tmp
+    fi
     mv $tmp package.json
   done
   # Update each dependency @noir-lang package version in package.json to point to renamed packages and versions.
   for pkg in $(jq --raw-output '(.'$deps' // {}) | keys[] | select(startswith("@noir-lang/"))' package.json); do
-    new_pkg="@aztec/noir-${pkg#@noir-lang/}"
+    new_pkg="@${repo}/noir-${pkg#@noir-lang/}"
     jq --arg v "$version" --arg old "$pkg" --arg new "$new_pkg" '.'$deps'[$new] = $v | del(.'$deps'[$old])' package.json > tmp.json
     mv tmp.json package.json
   done

--- a/release-image/bootstrap.sh
+++ b/release-image/bootstrap.sh
@@ -8,6 +8,11 @@ hash=$(cache_content_hash ^release-image/Dockerfile ^build-images/src/Dockerfile
 function build_image {
   set -euo pipefail
   cd ..
+
+  # Use AZTEC_RELEASE_REPO for image name (defaults to aztec)
+  local repo=${AZTEC_RELEASE_REPO:-aztec}
+  local image_name="aztecprotocol/$repo"
+
   if semver check $REF_NAME; then
     # We are a tagged release. Use the version from the tag.
     # We strip leading 'v' so that this is a valid semver.
@@ -16,12 +21,12 @@ function build_image {
     # Otherwise, use the commit hash as the version.
     local version=$(git rev-parse HEAD)
   fi
-  local previous_ids=$(docker images aztecprotocol/aztec --format "{{.ID}}" | uniq)
-  docker build -f release-image/Dockerfile --build-arg VERSION=$version -t aztecprotocol/aztec:$(git rev-parse HEAD) .
-  docker tag aztecprotocol/aztec:$(git rev-parse HEAD) aztecprotocol/aztec:latest
+  local previous_ids=$(docker images $image_name --format "{{.ID}}" | uniq)
+  docker build -f release-image/Dockerfile --build-arg VERSION=$version -t $image_name:$(git rev-parse HEAD) .
+  docker tag $image_name:$(git rev-parse HEAD) $image_name:latest
 
   # If we actually built a new image (not from cache), remove all but the just-built image.
-  local new_ids=$(docker images aztecprotocol/aztec --format "{{.ID}}" | uniq)
+  local new_ids=$(docker images $image_name --format "{{.ID}}" | uniq)
   if [ "$previous_ids" != "$new_ids" ]; then
     echo "$previous_ids" | xargs -r docker rmi -f
   fi
@@ -49,15 +54,23 @@ case "$cmd" in
   "push")
     echo_header "release-image push"
 
+    # Use AZTEC_RELEASE_REPO for image name (defaults to aztec)
+    repo=${AZTEC_RELEASE_REPO:-aztec}
+    image_name="aztecprotocol/$repo"
+
     if [ -z "${DOCKERHUB_PASSWORD:-}" ]; then
       echo "Missing DOCKERHUB_PASSWORD."
       exit 1
     fi
     echo $DOCKERHUB_PASSWORD | docker login -u ${DOCKERHUB_USERNAME:-aztecprotocolci} --password-stdin
-    do_or_dryrun docker push aztecprotocol/aztec:$COMMIT_HASH
+    do_or_dryrun docker push $image_name:$COMMIT_HASH
     ;;
   "release")
     echo_header "release-image release"
+
+    # Use AZTEC_RELEASE_REPO for image name (defaults to aztec)
+    repo=${AZTEC_RELEASE_REPO:-aztec}
+    image_name="aztecprotocol/$repo"
 
     if [ -z "${DOCKERHUB_PASSWORD:-}" ]; then
       echo "Missing DOCKERHUB_PASSWORD."
@@ -67,28 +80,28 @@ case "$cmd" in
 
     # We strip leading 'v' so that this is a valid semver.
     tag=${REF_NAME#v}
-    docker tag aztecprotocol/aztec:$COMMIT_HASH aztecprotocol/aztec:$tag-$(arch)
-    do_or_dryrun docker push aztecprotocol/aztec:$tag-$(arch)
+    docker tag $image_name:$COMMIT_HASH $image_name:$tag-$(arch)
+    do_or_dryrun docker push $image_name:$tag-$(arch)
 
     # If doing a release in CI, update the remote manifest if we're the arm build.
     if [ "${DRY_RUN:-0}" == 0 ] && [ "$(arch)" == "arm64" ] && [ "${CI:-0}" -eq 1 ]; then
       # Wait for amd64 image to be available.
-      while ! docker manifest inspect aztecprotocol/aztec:$tag-amd64 &>/dev/null; do
+      while ! docker manifest inspect $image_name:$tag-amd64 &>/dev/null; do
         echo "Waiting for amd64 image to be pushed..."
         sleep 10
       done
 
       # We release with our tag, e.g. 1.0.0
-      docker manifest create aztecprotocol/aztec:$tag \
-        --amend aztecprotocol/aztec:$tag-amd64 \
-        --amend aztecprotocol/aztec:$tag-arm64
-      docker manifest push aztecprotocol/aztec:$tag
+      docker manifest create $image_name:$tag \
+        --amend $image_name:$tag-amd64 \
+        --amend $image_name:$tag-arm64
+      docker manifest push $image_name:$tag
 
       # We also release with our dist_tag, e.g. 'latest', 'staging' or 'nightly'.
-      docker manifest create aztecprotocol/aztec:$(dist_tag) \
-        --amend aztecprotocol/aztec:$tag-amd64 \
-        --amend aztecprotocol/aztec:$tag-arm64
-      docker manifest push aztecprotocol/aztec:$(dist_tag)
+      docker manifest create $image_name:$(dist_tag) \
+        --amend $image_name:$tag-amd64 \
+        --amend $image_name:$tag-arm64
+      docker manifest push $image_name:$(dist_tag)
     fi
     ;;
   build)


### PR DESCRIPTION
Add a ci-release-test label that simulates a tagged release in CI workflows by setting e.g. REF_NAME=v0.0.1-test-a6bf126. The label will be handled in both ci.sh and bootstrap.sh to enable testing of release pipelines without pushing actual release tags