### PR TITLE
fix: pass along proof submission disabled flag

### DIFF
--- a/yarn-project/prover-node/src/factory.ts
+++ b/yarn-project/prover-node/src/factory.ts
@@ -181,6 +181,7 @@ export async function createProverNode(
       'txGatheringIntervalMs',
       'txGatheringTimeoutMs',
       'proverNodeFailedEpochStore',
+      'proverNodeDisableProofPublish',
       'dataDirectory',
       'l1ChainId',
       'rollupVersion',


### PR DESCRIPTION
This wasn't being forwarded to the prover-node instance so it was always attempting to submit a proof