### PR TITLE
chore: cycle_group fuzzer cleanup

### DIFF
--- a/barretenberg/cpp/src/barretenberg/common/fuzzer.hpp
+++ b/barretenberg/cpp/src/barretenberg/common/fuzzer.hpp
@@ -643,7 +643,8 @@ class ArithmeticFuzzHelper {
                 if constexpr (InstructionWeightsEnabled<T>) {                                                          \
                     if (!((total_instruction_weight + T::InstructionWeights::name) > T::InstructionWeights::_LIMIT)) { \
                         total_instruction_weight += T::InstructionWeights::name;                                       \
-                        if (T::ExecutionHandler::execute_##name(&composer, state, instruction)) {                      \
+                        if (T::ExecutionHandler::execute_##name(&composer, state, instruction) ==                      \
+                            T::ExecutionHandler::ExecutionStatus::Stop) {                                              \
                             return;                                                                                    \
                         }                                                                                              \
                     } else {                                                                                           \
@@ -651,7 +652,8 @@ class ArithmeticFuzzHelper {
                     }                                                                                                  \
                 } else {                                                                                               \
                                                                                                                        \
-                    if (T::ExecutionHandler::execute_##name(&composer, state, instruction)) {                          \
+                    if (T::ExecutionHandler::execute_##name(&composer, state, instruction) ==                          \
+                        T::ExecutionHandler::ExecutionStatus::Stop) {                                                  \
                         return;                                                                                        \
                     }                                                                                                  \
                 }                                                                                                      \

--- a/barretenberg/cpp/src/barretenberg/common/fuzzer.hpp
+++ b/barretenberg/cpp/src/barretenberg/common/fuzzer.hpp
@@ -643,8 +643,7 @@ class ArithmeticFuzzHelper {
                 if constexpr (InstructionWeightsEnabled<T>) {                                                          \
                     if (!((total_instruction_weight + T::InstructionWeights::name) > T::InstructionWeights::_LIMIT)) { \
                         total_instruction_weight += T::InstructionWeights::name;                                       \
-                        if (T::ExecutionHandler::execute_##name(&composer, state, instruction) ==                      \
-                            T::ExecutionHandler::ExecutionStatus::Stop) {                                              \
+                        if (T::ExecutionHandler::execute_##name(&composer, state, instruction)) {                      \
                             return;                                                                                    \
                         }                                                                                              \
                     } else {                                                                                           \
@@ -652,8 +651,7 @@ class ArithmeticFuzzHelper {
                     }                                                                                                  \
                 } else {                                                                                               \
                                                                                                                        \
-                    if (T::ExecutionHandler::execute_##name(&composer, state, instruction) ==                          \
-                        T::ExecutionHandler::ExecutionStatus::Stop) {                                                  \
+                    if (T::ExecutionHandler::execute_##name(&composer, state, instruction)) {                          \
                         return;                                                                                        \
                     }                                                                                                  \
                 }                                                                                                      \

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/group/cycle_group.fuzzer.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/group/cycle_group.fuzzer.hpp
@@ -20,10 +20,10 @@
  *        │
  *        v
  *   ExecutionHandler (maintains parallel state):
- *   ┌──────────────────────────────────────────────────┐
- *   │ Native:     GroupElement + ScalarField           │  (ground truth)
- *   │ Circuit:    cycle_group + cycle_scalar           │
- *   └──────────────────────────────────────────────────┘
+ *   ┌─────────────────────────────────────────┐
+ *   │ Native:     GroupElement + ScalarField  │ (ground truth)
+ *   │ Circuit:    cycle_group + cycle_scalar  │
+ *   └─────────────────────────────────────────┘
  *        │
  *        ├──> Execute each instruction in both representations
  *        │

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/group/cycle_group.fuzzer.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/group/cycle_group.fuzzer.hpp
@@ -92,6 +92,63 @@ constexpr size_t MAXIMUM_MUL_ELEMENTS = 8;
 extern "C" size_t LLVMFuzzerMutate(uint8_t* Data, size_t Size, size_t MaxSize);
 
 /**
+ * @brief Special scalar field values used for mutation testing
+ *
+ * @note: Zero is placed LAST to allow easy exclusion:
+ * - Use `rng.next() % SPECIAL_VALUE_COUNT` for all values
+ * - Use `rng.next() % SPECIAL_VALUE_COUNT_NO_ZERO` for values excluding Zero (One through HalfModulus)
+ */
+enum class SpecialScalarValue : uint8_t {
+    One = 0,
+    MinusOne,
+    SquareRootOfOne,
+    InverseSquareRootOfOne,
+    RootOfUnity13, // 13th root of unity (arbitrary small root)
+    Two,           // Small even number
+    HalfModulus,   // (p-1)/2
+    Zero,
+    COUNT // Sentinel value for total count
+};
+
+// Number of special values excluding Zero
+constexpr uint8_t SPECIAL_VALUE_COUNT_NO_ZERO = static_cast<uint8_t>(SpecialScalarValue::Zero);
+
+// Number of special values including Zero
+constexpr uint8_t SPECIAL_VALUE_COUNT = static_cast<uint8_t>(SpecialScalarValue::COUNT);
+
+/**
+ * @brief Generate a special scalar field value for testing
+ * @tparam FF Field type (e.g., ScalarField)
+ * @param type Which special value to generate
+ * @return The special field element
+ */
+template <typename FF> inline FF get_special_scalar_value(SpecialScalarValue type)
+{
+    switch (type) {
+    case SpecialScalarValue::One:
+        return FF::one();
+    case SpecialScalarValue::MinusOne:
+        return -FF::one();
+    case SpecialScalarValue::SquareRootOfOne:
+        return FF::one().sqrt().second;
+    case SpecialScalarValue::InverseSquareRootOfOne:
+        return FF::one().sqrt().second.invert();
+    case SpecialScalarValue::RootOfUnity13:
+        return FF::get_root_of_unity(13);
+    case SpecialScalarValue::Two:
+        return FF(2);
+    case SpecialScalarValue::HalfModulus:
+        return FF((FF::modulus - 1) / 2);
+    case SpecialScalarValue::Zero:
+        return FF::zero();
+    case SpecialScalarValue::COUNT:
+        // Fallthrough to abort - COUNT should never be used as a value
+    default:
+        abort(); // Invalid enum value
+    }
+}
+
+/**
  * @brief The class parametrizing CycleGroup fuzzing instructions, execution, etc
  */
 template <typename Builder> class CycleGroupBase {
@@ -365,35 +422,8 @@ template <typename Builder> class CycleGroupBase {
                     e.scalar = e.scalar.to_montgomery_form();
                 }
                 // Substitute scalar element with a special value
-                switch (rng.next() % 8) {
-                case 0:
-                    e.scalar = ScalarField::zero();
-                    break;
-                case 1:
-                    e.scalar = ScalarField::one();
-                    break;
-                case 2:
-                    e.scalar = -ScalarField::one();
-                    break;
-                case 3:
-                    e.scalar = ScalarField::one().sqrt().second;
-                    break;
-                case 4:
-                    e.scalar = ScalarField::one().sqrt().second.invert();
-                    break;
-                case 5:
-                    e.scalar = ScalarField::get_root_of_unity(13);
-                    break;
-                case 6:
-                    e.scalar = ScalarField(2);
-                    break;
-                case 7:
-                    e.scalar = ScalarField((ScalarField::modulus - 1) / 2);
-                    break;
-                default:
-                    abort();
-                    break;
-                }
+                auto special_value = static_cast<SpecialScalarValue>(rng.next() % SPECIAL_VALUE_COUNT);
+                e.scalar = get_special_scalar_value<ScalarField>(special_value);
                 if (convert_to_montgomery) {
                     e.scalar = e.scalar.to_montgomery_form();
                 }
@@ -475,32 +505,8 @@ template <typename Builder> class CycleGroupBase {
                 }
                 // Substitute scalar element with a special value
                 // I think that zeros from mutateGroupElement are enough zeros produced
-                switch (rng.next() % 7) {
-                case 0:
-                    e = ScalarField::one();
-                    break;
-                case 1:
-                    e = -ScalarField::one();
-                    break;
-                case 2:
-                    e = ScalarField::one().sqrt().second;
-                    break;
-                case 3:
-                    e = ScalarField::one().sqrt().second.invert();
-                    break;
-                case 4:
-                    e = ScalarField::get_root_of_unity(13);
-                    break;
-                case 5:
-                    e = ScalarField(2);
-                    break;
-                case 6:
-                    e = ScalarField((ScalarField::modulus - 1) / 2);
-                    break;
-                default:
-                    abort();
-                    break;
-                }
+                auto special_value = static_cast<SpecialScalarValue>(rng.next() % SPECIAL_VALUE_COUNT_NO_ZERO);
+                e = get_special_scalar_value<ScalarField>(special_value);
                 if (convert_to_montgomery) {
                     e = e.to_montgomery_form();
                 }

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/group/cycle_group.fuzzer.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/group/cycle_group.fuzzer.hpp
@@ -32,22 +32,55 @@ bool circuit_should_fail = false;
 // #define DISABLE_BATCH_MUL
 
 #ifdef FUZZING_SHOW_INFORMATION
-#define PREP_SINGLE_ARG(stack, first_index, output_index)                                                              \
-    std::string rhs = stack[first_index].cycle_group.is_constant() ? "c" : "w";                                        \
-    std::string out = rhs;                                                                                             \
-    rhs += std::to_string(first_index);                                                                                \
-    out += std::to_string(output_index >= stack.size() ? stack.size() : output_index);                                 \
-    out = (output_index >= stack.size() ? "auto " : "") + out;
+/**
+ * @brief Formatted strings for debugging output
+ * Used to generate readable C++ code showing operation being performed
+ */
+struct FormattedArgs {
+    std::string lhs;
+    std::string rhs;
+    std::string out;
+};
 
-#define PREP_TWO_ARG(stack, first_index, second_index, output_index)                                                   \
-    std::string lhs = stack[first_index].cycle_group.is_constant() ? "c" : "w";                                        \
-    std::string rhs = stack[second_index].cycle_group.is_constant() ? "c" : "w";                                       \
-    std::string out =                                                                                                  \
-        (stack[first_index].cycle_group.is_constant() && stack[second_index].cycle_group.is_constant()) ? "c" : "w";   \
-    lhs += std::to_string(first_index);                                                                                \
-    rhs += std::to_string(second_index);                                                                               \
-    out += std::to_string(output_index >= stack.size() ? stack.size() : output_index);                                 \
+/**
+ * @brief Format a single-argument operation for debug output
+ * @param stack The execution stack
+ * @param first_index Index of the input argument
+ * @param output_index Index where result will be written
+ * @return FormattedArgs with rhs (input) and out (output) populated
+ */
+template <typename Stack>
+inline FormattedArgs format_single_arg(const Stack& stack, size_t first_index, size_t output_index)
+{
+    std::string rhs = stack[first_index].cycle_group.is_constant() ? "c" : "w";
+    std::string out = rhs;
+    rhs += std::to_string(first_index);
+    out += std::to_string(output_index >= stack.size() ? stack.size() : output_index);
     out = (output_index >= stack.size() ? "auto " : "") + out;
+    return FormattedArgs{ .lhs = "", .rhs = rhs, .out = out };
+}
+
+/**
+ * @brief Format a two-argument operation for debug output
+ * @param stack The execution stack
+ * @param first_index Index of the first argument
+ * @param second_index Index of the second argument
+ * @param output_index Index where result will be written
+ * @return FormattedArgs with lhs, rhs (inputs) and out (output) populated
+ */
+template <typename Stack>
+inline FormattedArgs format_two_arg(const Stack& stack, size_t first_index, size_t second_index, size_t output_index)
+{
+    std::string lhs = stack[first_index].cycle_group.is_constant() ? "c" : "w";
+    std::string rhs = stack[second_index].cycle_group.is_constant() ? "c" : "w";
+    std::string out =
+        (stack[first_index].cycle_group.is_constant() && stack[second_index].cycle_group.is_constant()) ? "c" : "w";
+    lhs += std::to_string(first_index);
+    rhs += std::to_string(second_index);
+    out += std::to_string(output_index >= stack.size() ? stack.size() : output_index);
+    out = (output_index >= stack.size() ? "auto " : "") + out;
+    return FormattedArgs{ .lhs = lhs, .rhs = rhs, .out = out };
+}
 #endif
 
 FastRandom VarianceRNG(0);
@@ -1227,8 +1260,8 @@ template <typename Builder> class CycleGroupBase {
             size_t output_index = instruction.arguments.twoArgs.out;
 
 #ifdef FUZZING_SHOW_INFORMATION
-            PREP_SINGLE_ARG(stack, first_index, output_index)
-            std::cout << out << " = " << rhs << ".dbl();" << std::endl;
+            auto args = format_single_arg(stack, first_index, output_index);
+            std::cout << args.out << " = " << args.rhs << ".dbl();" << std::endl;
 #endif
             ExecutionHandler result;
             result = stack[first_index].dbl();
@@ -1261,8 +1294,8 @@ template <typename Builder> class CycleGroupBase {
             size_t output_index = instruction.arguments.twoArgs.out;
 
 #ifdef FUZZING_SHOW_INFORMATION
-            PREP_SINGLE_ARG(stack, first_index, output_index)
-            std::cout << out << " = -" << rhs << ";" << std::endl;
+            auto args = format_single_arg(stack, first_index, output_index);
+            std::cout << args.out << " = -" << args.rhs << ";" << std::endl;
 #endif
             ExecutionHandler result;
             result = -stack[first_index];
@@ -1294,8 +1327,8 @@ template <typename Builder> class CycleGroupBase {
             size_t second_index = instruction.arguments.twoArgs.out % stack.size();
 
 #ifdef FUZZING_SHOW_INFORMATION
-            PREP_TWO_ARG(stack, first_index, second_index, 0)
-            std::cout << "assert_equal(" << lhs << ", " << rhs << ", builder);" << std::endl;
+            auto args = format_two_arg(stack, first_index, second_index, 0);
+            std::cout << "assert_equal(" << args.lhs << ", " << args.rhs << ", builder);" << std::endl;
 #endif
             stack[first_index].assert_equal(builder, stack[second_index]);
             return 0;
@@ -1322,12 +1355,12 @@ template <typename Builder> class CycleGroupBase {
             ExecutionHandler result;
 
 #ifdef FUZZING_SHOW_INFORMATION
-            PREP_SINGLE_ARG(stack, first_index, output_index)
-            std::cout << out << " = ";
+            auto args = format_single_arg(stack, first_index, output_index);
+            std::cout << args.out << " = ";
 #endif
             result = stack[first_index].set(builder);
 #ifdef FUZZING_SHOW_INFORMATION
-            std::cout << rhs << ");" << std::endl;
+            std::cout << args.rhs << ");" << std::endl;
 #endif
             // If the output index is larger than the number of elements in stack, append
             if (output_index >= stack.size()) {
@@ -1359,8 +1392,8 @@ template <typename Builder> class CycleGroupBase {
             ExecutionHandler result;
 
 #ifdef FUZZING_SHOW_INFORMATION
-            PREP_SINGLE_ARG(stack, first_index, output_index)
-            std::cout << out << " = " << rhs << std::endl;
+            auto args = format_single_arg(stack, first_index, output_index);
+            std::cout << args.out << " = " << args.rhs << std::endl;
 #endif
             result = stack[first_index].set_inf(builder);
             // If the output index is larger than the number of elements in stack, append
@@ -1393,8 +1426,8 @@ template <typename Builder> class CycleGroupBase {
             size_t output_index = instruction.arguments.threeArgs.out;
 
 #ifdef FUZZING_SHOW_INFORMATION
-            PREP_TWO_ARG(stack, first_index, second_index, output_index)
-            std::cout << out << " = " << lhs << " + " << rhs << ";" << std::endl;
+            auto args = format_two_arg(stack, first_index, second_index, output_index);
+            std::cout << args.out << " = " << args.lhs << " + " << args.rhs << ";" << std::endl;
 #endif
             ExecutionHandler result;
             result = stack[first_index].operator_add(builder, stack[second_index]);
@@ -1428,8 +1461,8 @@ template <typename Builder> class CycleGroupBase {
             size_t output_index = instruction.arguments.threeArgs.out;
 
 #ifdef FUZZING_SHOW_INFORMATION
-            PREP_TWO_ARG(stack, first_index, second_index, output_index)
-            std::cout << out << " = " << lhs << " - " << rhs << ";" << std::endl;
+            auto args = format_two_arg(stack, first_index, second_index, output_index);
+            std::cout << args.out << " = " << args.lhs << " - " << args.rhs << ";" << std::endl;
 #endif
             ExecutionHandler result;
             result = stack[first_index].operator_sub(builder, stack[second_index]);
@@ -1466,12 +1499,12 @@ template <typename Builder> class CycleGroupBase {
             ExecutionHandler result;
 
 #ifdef FUZZING_SHOW_INFORMATION
-            PREP_TWO_ARG(stack, first_index, second_index, output_index)
-            std::cout << out << " = cycle_group_t::conditional_assign(";
+            auto args = format_two_arg(stack, first_index, second_index, output_index);
+            std::cout << args.out << " = cycle_group_t::conditional_assign(";
 #endif
             result = stack[first_index].conditional_assign(builder, stack[second_index], predicate);
 #ifdef FUZZING_SHOW_INFORMATION
-            std::cout << rhs << ", " << lhs << ");" << std::endl;
+            std::cout << args.rhs << ", " << args.lhs << ");" << std::endl;
 #endif
             // If the output index is larger than the number of elements in stack, append
             if (output_index >= stack.size()) {
@@ -1503,8 +1536,8 @@ template <typename Builder> class CycleGroupBase {
             ScalarField scalar = instruction.arguments.mulArgs.scalar;
 
 #ifdef FUZZING_SHOW_INFORMATION
-            PREP_SINGLE_ARG(stack, first_index, output_index)
-            std::cout << out << " = " << rhs << std::endl;
+            auto args = format_single_arg(stack, first_index, output_index);
+            std::cout << args.out << " = " << args.rhs << std::endl;
 #endif
             ExecutionHandler result;
             result = stack[first_index].mul(builder, scalar);

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/group/cycle_group.fuzzer.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/group/cycle_group.fuzzer.hpp
@@ -59,6 +59,21 @@ bool circuit_should_fail = false;
 // #define DISABLE_MULTIPLICATION
 // #define DISABLE_BATCH_MUL
 
+// Convert preprocessor flag to constexpr for cleaner call sites
+#ifdef FUZZING_SHOW_INFORMATION
+constexpr bool SHOW_FUZZING_INFO = true;
+#else
+constexpr bool SHOW_FUZZING_INFO = false;
+#endif
+
+/** @brief Compile-time debug logging helper */
+template <typename... Args> inline void debug_log(Args&&... args)
+{
+    if constexpr (SHOW_FUZZING_INFO) {
+        (std::cout << ... << std::forward<Args>(args));
+    }
+}
+
 #ifdef FUZZING_SHOW_INFORMATION
 /**
  * @brief Formatted strings for debugging output
@@ -855,15 +870,10 @@ template <typename Builder> class CycleGroupBase {
             const bool predicate_is_const = static_cast<bool>(VarianceRNG.next() & 1);
             if (predicate_is_const) {
                 const bool predicate_has_ctx = static_cast<bool>(VarianceRNG.next() % 2);
-#ifdef FUZZING_SHOW_INFORMATION
-                std::cout << "bool_t(" << (predicate_has_ctx ? "&builder," : "nullptr,")
-                          << (predicate ? "true)" : "false)");
-#endif
+                debug_log("bool_t(", (predicate_has_ctx ? "&builder," : "nullptr,"), (predicate ? "true)" : "false)"));
                 return bool_t(predicate_has_ctx ? builder : nullptr, predicate);
             }
-#ifdef FUZZING_SHOW_INFORMATION
-            std::cout << "bool_t(witness_t(&builder, " << (predicate ? "true));" : "false))");
-#endif
+            debug_log("bool_t(witness_t(&builder, ", (predicate ? "true));" : "false))"));
             return bool_t(witness_t(builder, predicate));
         }
 
@@ -897,7 +907,7 @@ template <typename Builder> class CycleGroupBase {
          * @param base_res Result point for native computation
          * @return ExecutionHandler with doubled point via various code paths
          */
-        ExecutionHandler handle_add_doubling_case(Builder* builder,
+        ExecutionHandler handle_add_doubling_case([[maybe_unused]] Builder* builder,
                                                   const ExecutionHandler& other,
                                                   const ScalarField& base_scalar_res,
                                                   const GroupElement& base_res)
@@ -905,14 +915,10 @@ template <typename Builder> class CycleGroupBase {
             uint8_t dbl_path = VarianceRNG.next() % 4;
             switch (dbl_path) {
             case 0:
-#ifdef FUZZING_SHOW_INFORMATION
-                std::cout << "left.dbl" << std::endl;
-#endif
+                debug_log("left.dbl", "\n");
                 return ExecutionHandler(base_scalar_res, base_res, this->cg().dbl());
             case 1:
-#ifdef FUZZING_SHOW_INFORMATION
-                std::cout << "right.dbl" << std::endl;
-#endif
+                debug_log("right.dbl", "\n");
                 return ExecutionHandler(base_scalar_res, base_res, other.cg().dbl());
             case 2:
                 return ExecutionHandler(base_scalar_res, base_res, this->cg() + other.cg());
@@ -939,24 +945,14 @@ template <typename Builder> class CycleGroupBase {
             cycle_group_t res;
             switch (inf_path) {
             case 0:
-#ifdef FUZZING_SHOW_INFORMATION
-                std::cout << "left.set_point_at_infinity(";
-#endif
+                debug_log("left.set_point_at_infinity();", "\n");
                 res = this->cg();
                 res.set_point_at_infinity(this->construct_predicate(builder, true));
-#ifdef FUZZING_SHOW_INFORMATION
-                std::cout << ");" << std::endl;
-#endif
                 return ExecutionHandler(base_scalar_res, base_res, res);
             case 1:
-#ifdef FUZZING_SHOW_INFORMATION
-                std::cout << "right.set_point_at_infinity(";
-#endif
+                debug_log("right.set_point_at_infinity();", "\n");
                 res = other.cg();
                 res.set_point_at_infinity(this->construct_predicate(builder, true));
-#ifdef FUZZING_SHOW_INFORMATION
-                std::cout << ");" << std::endl;
-#endif
                 return ExecutionHandler(base_scalar_res, base_res, res);
             case 2:
                 return ExecutionHandler(base_scalar_res, base_res, this->cg() + other.cg());
@@ -983,24 +979,16 @@ template <typename Builder> class CycleGroupBase {
 
             switch (add_option) {
             case 0:
-#ifdef FUZZING_SHOW_INFORMATION
-                std::cout << "left.unconditional_add(right);" << std::endl;
-#endif
+                debug_log("left.unconditional_add(right);", "\n");
                 return ExecutionHandler(base_scalar_res, base_res, this->cg().unconditional_add(other.cg()));
             case 1:
-#ifdef FUZZING_SHOW_INFORMATION
-                std::cout << "right.unconditional_add(left);" << std::endl;
-#endif
+                debug_log("right.unconditional_add(left);", "\n");
                 return ExecutionHandler(base_scalar_res, base_res, other.cg().unconditional_add(this->cg()));
             case 2:
-#ifdef FUZZING_SHOW_INFORMATION
-                std::cout << "left.checked_unconditional_add(right);" << std::endl;
-#endif
+                debug_log("left.checked_unconditional_add(right);", "\n");
                 return ExecutionHandler(base_scalar_res, base_res, this->cg().checked_unconditional_add(other.cg()));
             case 3:
-#ifdef FUZZING_SHOW_INFORMATION
-                std::cout << "right.checked_unconditional_add(left);" << std::endl;
-#endif
+                debug_log("right.checked_unconditional_add(left);", "\n");
                 return ExecutionHandler(base_scalar_res, base_res, other.cg().checked_unconditional_add(this->cg()));
             case 4:
                 return ExecutionHandler(base_scalar_res, base_res, this->cg() + other.cg());
@@ -1034,7 +1022,7 @@ template <typename Builder> class CycleGroupBase {
         /**
          * @brief Handle subtraction when points are negations: x - (-x) = 2x (doubling case)
          */
-        ExecutionHandler handle_sub_doubling_case(Builder* builder,
+        ExecutionHandler handle_sub_doubling_case([[maybe_unused]] Builder* builder,
                                                   const ExecutionHandler& other,
                                                   const ScalarField& base_scalar_res,
                                                   const GroupElement& base_res)
@@ -1043,14 +1031,10 @@ template <typename Builder> class CycleGroupBase {
 
             switch (dbl_path) {
             case 0:
-#ifdef FUZZING_SHOW_INFORMATION
-                std::cout << "left.dbl();" << std::endl;
-#endif
+                debug_log("left.dbl();", "\n");
                 return ExecutionHandler(base_scalar_res, base_res, this->cg().dbl());
             case 1:
-#ifdef FUZZING_SHOW_INFORMATION
-                std::cout << "-right.dbl();" << std::endl;
-#endif
+                debug_log("-right.dbl();", "\n");
                 return ExecutionHandler(base_scalar_res, base_res, -other.cg().dbl());
             case 2:
                 return ExecutionHandler(base_scalar_res, base_res, this->cg() - other.cg());
@@ -1071,24 +1055,14 @@ template <typename Builder> class CycleGroupBase {
 
             switch (inf_path) {
             case 0:
-#ifdef FUZZING_SHOW_INFORMATION
-                std::cout << "left.set_point_at_infinity(";
-#endif
+                debug_log("left.set_point_at_infinity();", "\n");
                 res = this->cg();
                 res.set_point_at_infinity(this->construct_predicate(builder, true));
-#ifdef FUZZING_SHOW_INFORMATION
-                std::cout << ");" << std::endl;
-#endif
                 return ExecutionHandler(base_scalar_res, base_res, res);
             case 1:
-#ifdef FUZZING_SHOW_INFORMATION
-                std::cout << "right.set_point_at_infinity(";
-#endif
+                debug_log("right.set_point_at_infinity();", "\n");
                 res = other.cg();
                 res.set_point_at_infinity(this->construct_predicate(builder, true));
-#ifdef FUZZING_SHOW_INFORMATION
-                std::cout << ");" << std::endl;
-#endif
                 return ExecutionHandler(base_scalar_res, base_res, res);
             case 2:
                 return ExecutionHandler(base_scalar_res, base_res, this->cg() - other.cg());
@@ -1109,14 +1083,10 @@ template <typename Builder> class CycleGroupBase {
 
             switch (add_option) {
             case 0:
-#ifdef FUZZING_SHOW_INFORMATION
-                std::cout << "left.unconditional_subtract(right);" << std::endl;
-#endif
+                debug_log("left.unconditional_subtract(right);", "\n");
                 return ExecutionHandler(base_scalar_res, base_res, this->cg().unconditional_subtract(other.cg()));
             case 1:
-#ifdef FUZZING_SHOW_INFORMATION
-                std::cout << "left.checked_unconditional_subtract(right);" << std::endl;
-#endif
+                debug_log("left.checked_unconditional_subtract(right);", "\n");
                 return ExecutionHandler(
                     base_scalar_res, base_res, this->cg().checked_unconditional_subtract(other.cg()));
             case 2:
@@ -1146,10 +1116,11 @@ template <typename Builder> class CycleGroupBase {
         ExecutionHandler mul(Builder* builder, const ScalarField& multiplier)
         {
             bool is_witness = VarianceRNG.next() & 1;
-#ifdef FUZZING_SHOW_INFORMATION
-            std::cout << " * cycle_scalar_t" << (is_witness ? "::from_witness(&builder, " : "(") << "ScalarField(\""
-                      << multiplier << "\"));";
-#endif
+            debug_log(" * cycle_scalar_t",
+                      (is_witness ? "::from_witness(&builder, " : "("),
+                      "ScalarField(\"",
+                      multiplier,
+                      "\"));");
             auto scalar = is_witness ? cycle_scalar_t::from_witness(builder, multiplier) : cycle_scalar_t(multiplier);
             return ExecutionHandler(this->base_scalar * multiplier, this->base * multiplier, this->cg() * scalar);
         }
@@ -1170,10 +1141,11 @@ template <typename Builder> class CycleGroupBase {
                 to_add_cg.push_back(to_add[i].cycle_group);
 
                 bool is_witness = VarianceRNG.next() & 1;
-#ifdef FUZZING_SHOW_INFORMATION
-                std::cout << "cycle_scalar_t" << (is_witness ? "::from_witness(&builder, " : "(") << "ScalarField(\""
-                          << to_mul[i] << "\")), ";
-#endif
+                debug_log("cycle_scalar_t",
+                          (is_witness ? "::from_witness(&builder, " : "("),
+                          "ScalarField(\"",
+                          to_mul[i],
+                          "\")), ");
                 auto scalar = is_witness ? cycle_scalar_t::from_witness(builder, to_mul[i]) : cycle_scalar_t(to_mul[i]);
                 to_mul_cs.push_back(scalar);
 
@@ -1235,16 +1207,13 @@ template <typename Builder> class CycleGroupBase {
             uint32_t switch_case = VarianceRNG.next() % 4;
             switch (switch_case) {
             case 0:
-#ifdef FUZZING_SHOW_INFORMATION
-                std::cout << "cycle_group_t(" << std::endl;
-#endif
+                debug_log("cycle_group_t(", "\n");
                 /* construct via cycle_group_t */
                 return ExecutionHandler(this->base_scalar, this->base, cycle_group_t(this->cycle_group));
             case 1: {
-#ifdef FUZZING_SHOW_INFORMATION
-                std::cout << "cycle_group_t::from" << (this->cycle_group.is_constant() ? "" : "_constant")
-                          << "_witness(&builder, e.get_value());";
-#endif
+                debug_log("cycle_group_t::from",
+                          (this->cycle_group.is_constant() ? "" : "_constant"),
+                          "_witness(&builder, e.get_value());");
                 /* construct via AffineElement */
                 AffineElement e = this->cycle_group.get_value();
                 if (this->cycle_group.is_constant()) {
@@ -1254,20 +1223,16 @@ template <typename Builder> class CycleGroupBase {
                 return ExecutionHandler(this->base_scalar, this->base, cycle_group_t::from_witness(builder, e));
             }
             case 2: {
-#ifdef FUZZING_SHOW_INFORMATION
-                std::cout << "tmp = el;" << std::endl;
-                std::cout << "res = cycle_group_t(tmp);" << std::endl;
-#endif
+                debug_log("tmp = el;", "\n");
+                debug_log("res = cycle_group_t(tmp);", "\n");
                 /* Invoke assigment operator */
                 cycle_group_t cg_new(builder);
                 cg_new = this->cg();
                 return ExecutionHandler(this->base_scalar, this->base, cycle_group_t(cg_new));
             }
             case 3: {
-#ifdef FUZZING_SHOW_INFORMATION
-                std::cout << "tmp = el;" << std::endl;
-                std::cout << "res = cycle_group_t(std::move(tmp));" << std::endl;
-#endif
+                debug_log("tmp = el;", "\n");
+                debug_log("res = cycle_group_t(std::move(tmp));", "\n");
                 /* Invoke move constructor */
                 cycle_group_t cg_copy = this->cg();
                 return ExecutionHandler(this->base_scalar, this->base, cycle_group_t(std::move(cg_copy)));
@@ -1282,13 +1247,8 @@ template <typename Builder> class CycleGroupBase {
             auto res = this->set(builder);
             const bool set_inf =
                 res.cycle_group.is_point_at_infinity().get_value() ? true : static_cast<bool>(VarianceRNG.next() & 1);
-#ifdef FUZZING_SHOW_INFORMATION
-            std::cout << "el.set_point_at_infinty(";
-#endif
+            debug_log("el.set_point_at_infinty();", "\n");
             res.set_point_at_infinity(this->construct_predicate(builder, set_inf));
-#ifdef FUZZING_SHOW_INFORMATION
-            std::cout << ");" << std::endl;
-#endif
             return res;
         }
 
@@ -1316,10 +1276,8 @@ template <typename Builder> class CycleGroupBase {
                 ExecutionHandler(instruction.arguments.element.scalar,
                                  instruction.arguments.element.value,
                                  cycle_group_t(static_cast<AffineElement>(instruction.arguments.element.value))));
-#ifdef FUZZING_SHOW_INFORMATION
-            std::cout << "auto c" << stack.size() - 1 << " = cycle_group_t(ae(\""
-                      << instruction.arguments.element.scalar << "\"));" << std::endl;
-#endif
+            debug_log(
+                "auto c", stack.size() - 1, " = cycle_group_t(ae(\"", instruction.arguments.element.scalar, "\"));\n");
             return ExecutionStatus::Continue;
         };
 
@@ -1339,10 +1297,11 @@ template <typename Builder> class CycleGroupBase {
                 instruction.arguments.element.scalar,
                 instruction.arguments.element.value,
                 cycle_group_t::from_witness(builder, static_cast<AffineElement>(instruction.arguments.element.value))));
-#ifdef FUZZING_SHOW_INFORMATION
-            std::cout << "auto w" << stack.size() - 1 << " = cycle_group_t::from_witness(&builder, ae(\""
-                      << instruction.arguments.element.scalar << "\"));" << std::endl;
-#endif
+            debug_log("auto w",
+                      stack.size() - 1,
+                      " = cycle_group_t::from_witness(&builder, ae(\"",
+                      instruction.arguments.element.scalar,
+                      "\"));\n");
             return ExecutionStatus::Continue;
         }
 
@@ -1364,10 +1323,11 @@ template <typename Builder> class CycleGroupBase {
                                  instruction.arguments.element.value,
                                  cycle_group_t::from_constant_witness(
                                      builder, static_cast<AffineElement>(instruction.arguments.element.value))));
-#ifdef FUZZING_SHOW_INFORMATION
-            std::cout << "auto cw" << stack.size() - 1 << " = cycle_group_t::from_constant_witness(&builder, ae(\""
-                      << instruction.arguments.element.scalar << "\"));" << std::endl;
-#endif
+            debug_log("auto cw",
+                      stack.size() - 1,
+                      " = cycle_group_t::from_constant_witness(&builder, ae(\"",
+                      instruction.arguments.element.scalar,
+                      "\"));\n");
             return ExecutionStatus::Continue;
         }
 
@@ -1390,12 +1350,11 @@ template <typename Builder> class CycleGroupBase {
             size_t first_index = instruction.arguments.twoArgs.in % stack.size();
             size_t output_index = instruction.arguments.twoArgs.out;
 
-#ifdef FUZZING_SHOW_INFORMATION
-            auto args = format_single_arg(stack, first_index, output_index);
-            std::cout << args.out << " = " << args.rhs << ".dbl();" << std::endl;
-#endif
-            ExecutionHandler result;
-            result = stack[first_index].dbl();
+            if constexpr (SHOW_FUZZING_INFO) {
+                auto args = format_single_arg(stack, first_index, output_index);
+                debug_log(args.out, " = ", args.rhs, ".dbl();", "\n");
+            }
+            ExecutionHandler result = stack[first_index].dbl();
             // If the output index is larger than the number of elements in stack, append
             if (output_index >= stack.size()) {
                 stack.push_back(result);
@@ -1424,12 +1383,11 @@ template <typename Builder> class CycleGroupBase {
             size_t first_index = instruction.arguments.twoArgs.in % stack.size();
             size_t output_index = instruction.arguments.twoArgs.out;
 
-#ifdef FUZZING_SHOW_INFORMATION
-            auto args = format_single_arg(stack, first_index, output_index);
-            std::cout << args.out << " = -" << args.rhs << ";" << std::endl;
-#endif
-            ExecutionHandler result;
-            result = -stack[first_index];
+            if constexpr (SHOW_FUZZING_INFO) {
+                auto args = format_single_arg(stack, first_index, output_index);
+                debug_log(args.out, " = -", args.rhs, ";", "\n");
+            }
+            ExecutionHandler result = -stack[first_index];
             // If the output index is larger than the number of elements in stack, append
             if (output_index >= stack.size()) {
                 stack.push_back(result);
@@ -1457,10 +1415,10 @@ template <typename Builder> class CycleGroupBase {
             size_t first_index = instruction.arguments.twoArgs.in % stack.size();
             size_t second_index = instruction.arguments.twoArgs.out % stack.size();
 
-#ifdef FUZZING_SHOW_INFORMATION
-            auto args = format_two_arg(stack, first_index, second_index, 0);
-            std::cout << "assert_equal(" << args.lhs << ", " << args.rhs << ", builder);" << std::endl;
-#endif
+            if constexpr (SHOW_FUZZING_INFO) {
+                auto args = format_two_arg(stack, first_index, second_index, 0);
+                debug_log("assert_equal(", args.lhs, ", ", args.rhs, ", builder);", "\n");
+            }
             stack[first_index].assert_equal(builder, stack[second_index]);
             return ExecutionStatus::Continue;
         };
@@ -1483,16 +1441,11 @@ template <typename Builder> class CycleGroupBase {
             }
             size_t first_index = instruction.arguments.twoArgs.in % stack.size();
             size_t output_index = instruction.arguments.twoArgs.out;
-            ExecutionHandler result;
-
-#ifdef FUZZING_SHOW_INFORMATION
-            auto args = format_single_arg(stack, first_index, output_index);
-            std::cout << args.out << " = ";
-#endif
-            result = stack[first_index].set(builder);
-#ifdef FUZZING_SHOW_INFORMATION
-            std::cout << args.rhs << ");" << std::endl;
-#endif
+            if constexpr (SHOW_FUZZING_INFO) {
+                auto args = format_single_arg(stack, first_index, output_index);
+                debug_log(args.out, " = ", args.rhs, ");", "\n");
+            }
+            ExecutionHandler result = stack[first_index].set(builder);
             // If the output index is larger than the number of elements in stack, append
             if (output_index >= stack.size()) {
                 stack.push_back(result);
@@ -1520,13 +1473,12 @@ template <typename Builder> class CycleGroupBase {
             }
             size_t first_index = instruction.arguments.twoArgs.in % stack.size();
             size_t output_index = instruction.arguments.twoArgs.out;
-            ExecutionHandler result;
 
-#ifdef FUZZING_SHOW_INFORMATION
-            auto args = format_single_arg(stack, first_index, output_index);
-            std::cout << args.out << " = " << args.rhs << std::endl;
-#endif
-            result = stack[first_index].set_inf(builder);
+            if constexpr (SHOW_FUZZING_INFO) {
+                auto args = format_single_arg(stack, first_index, output_index);
+                debug_log(args.out, " = ", args.rhs, "\n");
+            }
+            ExecutionHandler result = stack[first_index].set_inf(builder);
             // If the output index is larger than the number of elements in stack, append
             if (output_index >= stack.size()) {
                 stack.push_back(result);
@@ -1556,12 +1508,11 @@ template <typename Builder> class CycleGroupBase {
             size_t second_index = instruction.arguments.threeArgs.in2 % stack.size();
             size_t output_index = instruction.arguments.threeArgs.out;
 
-#ifdef FUZZING_SHOW_INFORMATION
-            auto args = format_two_arg(stack, first_index, second_index, output_index);
-            std::cout << args.out << " = " << args.lhs << " + " << args.rhs << ";" << std::endl;
-#endif
-            ExecutionHandler result;
-            result = stack[first_index].operator_add(builder, stack[second_index]);
+            if constexpr (SHOW_FUZZING_INFO) {
+                auto args = format_two_arg(stack, first_index, second_index, output_index);
+                debug_log(args.out, " = ", args.lhs, " + ", args.rhs, ";", "\n");
+            }
+            ExecutionHandler result = stack[first_index].operator_add(builder, stack[second_index]);
             // If the output index is larger than the number of elements in stack, append
             if (output_index >= stack.size()) {
                 stack.push_back(result);
@@ -1591,12 +1542,11 @@ template <typename Builder> class CycleGroupBase {
             size_t second_index = instruction.arguments.threeArgs.in2 % stack.size();
             size_t output_index = instruction.arguments.threeArgs.out;
 
-#ifdef FUZZING_SHOW_INFORMATION
-            auto args = format_two_arg(stack, first_index, second_index, output_index);
-            std::cout << args.out << " = " << args.lhs << " - " << args.rhs << ";" << std::endl;
-#endif
-            ExecutionHandler result;
-            result = stack[first_index].operator_sub(builder, stack[second_index]);
+            if constexpr (SHOW_FUZZING_INFO) {
+                auto args = format_two_arg(stack, first_index, second_index, output_index);
+                debug_log(args.out, " = ", args.lhs, " - ", args.rhs, ";", "\n");
+            }
+            ExecutionHandler result = stack[first_index].operator_sub(builder, stack[second_index]);
             // If the output index is larger than the number of elements in stack, append
             if (output_index >= stack.size()) {
                 stack.push_back(result);
@@ -1627,16 +1577,12 @@ template <typename Builder> class CycleGroupBase {
             size_t output_index = instruction.arguments.fourArgs.out % stack.size();
             bool predicate = instruction.arguments.fourArgs.in3 % 2;
 
-            ExecutionHandler result;
+            if constexpr (SHOW_FUZZING_INFO) {
+                auto args = format_two_arg(stack, first_index, second_index, output_index);
+                debug_log(args.out, " = cycle_group_t::conditional_assign(", args.rhs, ", ", args.lhs, ");", "\n");
+            }
 
-#ifdef FUZZING_SHOW_INFORMATION
-            auto args = format_two_arg(stack, first_index, second_index, output_index);
-            std::cout << args.out << " = cycle_group_t::conditional_assign(";
-#endif
-            result = stack[first_index].conditional_assign(builder, stack[second_index], predicate);
-#ifdef FUZZING_SHOW_INFORMATION
-            std::cout << args.rhs << ", " << args.lhs << ");" << std::endl;
-#endif
+            ExecutionHandler result = stack[first_index].conditional_assign(builder, stack[second_index], predicate);
             // If the output index is larger than the number of elements in stack, append
             if (output_index >= stack.size()) {
                 stack.push_back(result);
@@ -1666,12 +1612,11 @@ template <typename Builder> class CycleGroupBase {
             size_t output_index = instruction.arguments.mulArgs.out;
             ScalarField scalar = instruction.arguments.mulArgs.scalar;
 
-#ifdef FUZZING_SHOW_INFORMATION
-            auto args = format_single_arg(stack, first_index, output_index);
-            std::cout << args.out << " = " << args.rhs << std::endl;
-#endif
-            ExecutionHandler result;
-            result = stack[first_index].mul(builder, scalar);
+            if constexpr (SHOW_FUZZING_INFO) {
+                auto args = format_single_arg(stack, first_index, output_index);
+                debug_log(args.out, " = ", args.rhs, "\n");
+            }
+            ExecutionHandler result = stack[first_index].mul(builder, scalar);
             // If the output index is larger than the number of elements in stack, append
             if (output_index >= stack.size()) {
                 stack.push_back(result);
@@ -1705,26 +1650,22 @@ template <typename Builder> class CycleGroupBase {
             }
             size_t output_index = (size_t)instruction.arguments.batchMulArgs.output_index;
 
-#ifdef FUZZING_SHOW_INFORMATION
-            std::string res = "";
-            bool is_const = true;
-            for (size_t i = 0; i < instruction.arguments.batchMulArgs.add_elements_count; i++) {
-                size_t idx = instruction.arguments.batchMulArgs.inputs[i] % stack.size();
-                std::string el = stack[idx].cycle_group.is_constant() ? "c" : "w";
-                el += std::to_string(idx);
-                res += el + ", ";
-                is_const &= stack[idx].cycle_group.is_constant();
+            if constexpr (SHOW_FUZZING_INFO) {
+                std::string res = "";
+                bool is_const = true;
+                for (size_t i = 0; i < instruction.arguments.batchMulArgs.add_elements_count; i++) {
+                    size_t idx = instruction.arguments.batchMulArgs.inputs[i] % stack.size();
+                    std::string el = stack[idx].cycle_group.is_constant() ? "c" : "w";
+                    el += std::to_string(idx);
+                    res += el + ", ";
+                    is_const &= stack[idx].cycle_group.is_constant();
+                }
+                std::string out = is_const ? "c" : "w";
+                out = ((output_index >= stack.size()) ? "auto " : "") + out;
+                out += std::to_string(output_index >= stack.size() ? stack.size() : output_index);
+                debug_log(out, " = cycle_group_t::batch_mul({", res, "}, {});", "\n");
             }
-            std::string out = is_const ? "c" : "w";
-            out = ((output_index >= stack.size()) ? "auto " : "") + out;
-            out += std::to_string(output_index >= stack.size() ? stack.size() : output_index);
-            std::cout << out << " = cycle_group_t::batch_mul({" << res << "}, {";
-#endif
-            auto result = ExecutionHandler::batch_mul(builder, to_add, to_mul);
-
-#ifdef FUZZING_SHOW_INFORMATION
-            std::cout << "});" << std::endl;
-#endif
+            ExecutionHandler result = ExecutionHandler::batch_mul(builder, to_add, to_mul);
             // If the output index is larger than the number of elements in stack, append
             if (output_index >= stack.size()) {
                 stack.push_back(result);

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/group/cycle_group.fuzzer.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/group/cycle_group.fuzzer.hpp
@@ -366,6 +366,28 @@ template <typename Builder> class CycleGroupBase {
         }
 
         /**
+         * @brief Convert a scalar field element to uint256_t, optionally using Montgomery form
+         */
+        template <typename FF> inline static uint256_t to_uint256_montgomery(const FF& value, bool as_montgomery)
+        {
+            if (as_montgomery) {
+                return uint256_t(value.to_montgomery_form());
+            }
+            return uint256_t(value);
+        }
+
+        /**
+         * @brief Convert uint256_t back to scalar field element, optionally from Montgomery form
+         */
+        template <typename FF> inline static FF from_uint256_montgomery(const uint256_t& data, bool from_montgomery)
+        {
+            if (from_montgomery) {
+                return FF(data).from_montgomery_form();
+            }
+            return FF(data);
+        }
+
+        /**
          * @brief Mutate the value of a group element
          *
          * @tparam T PRNG class
@@ -392,20 +414,6 @@ template <typename Builder> class CycleGroupBase {
                                             havoc_config.VAL_MUT_NON_MONTGOMERY_PROBABILITY)) <
                              havoc_config.VAL_MUT_MONTGOMERY_PROBABILITY;
             uint256_t value_data;
-            // Conversion at the start
-#define MONT_CONVERSION                                                                                                \
-    if (convert_to_montgomery) {                                                                                       \
-        value_data = uint256_t(e.scalar.to_montgomery_form());                                                         \
-    } else {                                                                                                           \
-        value_data = uint256_t(e.scalar);                                                                              \
-    }
-            // Inverse conversion at the end
-#define INV_MONT_CONVERSION                                                                                            \
-    if (convert_to_montgomery) {                                                                                       \
-        e.scalar = ScalarField(value_data).from_montgomery_form();                                                     \
-    } else {                                                                                                           \
-        e.scalar = ScalarField(value_data);                                                                            \
-    }
 
             // Pick the last value from the mutation distrivution vector
             const size_t mutation_type_count = havoc_config.value_mutation_distribution.size();
@@ -413,9 +421,9 @@ template <typename Builder> class CycleGroupBase {
             const size_t choice = rng.next() % havoc_config.value_mutation_distribution[mutation_type_count - 1];
             if (choice < havoc_config.value_mutation_distribution[0]) {
                 // Delegate mutation to libfuzzer (bit/byte mutations, autodictionary, etc)
-                MONT_CONVERSION
+                value_data = to_uint256_montgomery(e.scalar, convert_to_montgomery);
                 LLVMFuzzerMutate((uint8_t*)&value_data, sizeof(uint256_t), sizeof(uint256_t));
-                INV_MONT_CONVERSION
+                e.scalar = from_uint256_montgomery<ScalarField>(value_data, convert_to_montgomery);
                 e.value = GroupElement::one() * e.scalar;
             } else if (choice < havoc_config.value_mutation_distribution[1]) {
                 // Small addition/subtraction
@@ -481,20 +489,6 @@ template <typename Builder> class CycleGroupBase {
                                                         havoc_config.VAL_MUT_NON_MONTGOMERY_PROBABILITY)) <
                                          havoc_config.VAL_MUT_MONTGOMERY_PROBABILITY;
             uint256_t value_data;
-            // Conversion at the start
-#define MONT_CONVERSION_SCALAR                                                                                         \
-    if (convert_to_montgomery) {                                                                                       \
-        value_data = uint256_t(e.to_montgomery_form());                                                                \
-    } else {                                                                                                           \
-        value_data = uint256_t(e);                                                                                     \
-    }
-            // Inverse conversion at the end
-#define INV_MONT_CONVERSION_SCALAR                                                                                     \
-    if (convert_to_montgomery) {                                                                                       \
-        e = ScalarField(value_data).from_montgomery_form();                                                            \
-    } else {                                                                                                           \
-        e = ScalarField(value_data);                                                                                   \
-    }
 
             // Pick the last value from the mutation distrivution vector
             const size_t mutation_type_count = havoc_config.value_mutation_distribution.size();
@@ -502,9 +496,9 @@ template <typename Builder> class CycleGroupBase {
             const size_t choice = rng.next() % havoc_config.value_mutation_distribution[mutation_type_count - 1];
             if (choice < havoc_config.value_mutation_distribution[0]) {
                 // Delegate mutation to libfuzzer (bit/byte mutations, autodictionary, etc)
-                MONT_CONVERSION_SCALAR
+                value_data = to_uint256_montgomery(e, convert_to_montgomery);
                 LLVMFuzzerMutate((uint8_t*)&value_data, sizeof(uint256_t), sizeof(uint256_t));
-                INV_MONT_CONVERSION_SCALAR
+                e = from_uint256_montgomery<ScalarField>(value_data, convert_to_montgomery);
             } else if (choice < havoc_config.value_mutation_distribution[1]) {
                 // Small addition/subtraction
                 if (convert_to_montgomery) {

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/group/cycle_group.fuzzer.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/group/cycle_group.fuzzer.hpp
@@ -888,59 +888,95 @@ template <typename Builder> class CycleGroupBase {
             , cycle_group(w_g)
         {}
 
-        ExecutionHandler operator_add(Builder* builder, const ExecutionHandler& other)
+      private:
+        /**
+         * @brief Handle addition when points are equal (requires doubling)
+         * @param builder Circuit builder
+         * @param other The other execution handler
+         * @param base_scalar_res Result scalar for native computation
+         * @param base_res Result point for native computation
+         * @return ExecutionHandler with doubled point via various code paths
+         */
+        ExecutionHandler handle_add_doubling_case(Builder* builder,
+                                                  const ExecutionHandler& other,
+                                                  const ScalarField& base_scalar_res,
+                                                  const GroupElement& base_res)
         {
-            ScalarField base_scalar_res = this->base_scalar + other.base_scalar;
-            GroupElement base_res = this->base + other.base;
-
-            if (other.cg().get_value() == this->cg().get_value()) {
-                uint8_t dbl_path = VarianceRNG.next() % 4;
-                switch (dbl_path) {
-                case 0:
+            uint8_t dbl_path = VarianceRNG.next() % 4;
+            switch (dbl_path) {
+            case 0:
 #ifdef FUZZING_SHOW_INFORMATION
-                    std::cout << "left.dbl" << std::endl;
+                std::cout << "left.dbl" << std::endl;
 #endif
-                    return ExecutionHandler(base_scalar_res, base_res, this->cg().dbl());
-                case 1:
+                return ExecutionHandler(base_scalar_res, base_res, this->cg().dbl());
+            case 1:
 #ifdef FUZZING_SHOW_INFORMATION
-                    std::cout << "right.dbl" << std::endl;
+                std::cout << "right.dbl" << std::endl;
 #endif
-                    return ExecutionHandler(base_scalar_res, base_res, other.cg().dbl());
-                case 2:
-                    return ExecutionHandler(base_scalar_res, base_res, this->cg() + other.cg());
-                case 3:
-                    return ExecutionHandler(base_scalar_res, base_res, other.cg() + this->cg());
-                }
-            } else if (other.cg().get_value() == -this->cg().get_value()) {
-                uint8_t inf_path = VarianceRNG.next() % 4;
-                cycle_group_t res;
-                switch (inf_path) {
-                case 0:
-#ifdef FUZZING_SHOW_INFORMATION
-                    std::cout << "left.set_point_at_infinity(";
-#endif
-                    res = this->cg();
-                    res.set_point_at_infinity(this->construct_predicate(builder, true));
-#ifdef FUZZING_SHOW_INFORMATION
-                    std::cout << ");" << std::endl;
-#endif
-                    return ExecutionHandler(base_scalar_res, base_res, res);
-                case 1:
-#ifdef FUZZING_SHOW_INFORMATION
-                    std::cout << "right.set_point_at_infinity(";
-#endif
-                    res = other.cg();
-                    res.set_point_at_infinity(this->construct_predicate(builder, true));
-#ifdef FUZZING_SHOW_INFORMATION
-                    std::cout << ");" << std::endl;
-#endif
-                    return ExecutionHandler(base_scalar_res, base_res, res);
-                case 2:
-                    return ExecutionHandler(base_scalar_res, base_res, this->cg() + other.cg());
-                case 3:
-                    return ExecutionHandler(base_scalar_res, base_res, other.cg() + this->cg());
-                }
+                return ExecutionHandler(base_scalar_res, base_res, other.cg().dbl());
+            case 2:
+                return ExecutionHandler(base_scalar_res, base_res, this->cg() + other.cg());
+            case 3:
+                return ExecutionHandler(base_scalar_res, base_res, other.cg() + this->cg());
             }
+            return {};
+        }
+
+        /**
+         * @brief Handle addition when points are negations (result is point at infinity)
+         * @param builder Circuit builder
+         * @param other The other execution handler
+         * @param base_scalar_res Result scalar for native computation
+         * @param base_res Result point for native computation
+         * @return ExecutionHandler with point at infinity via various code paths
+         */
+        ExecutionHandler handle_add_infinity_case(Builder* builder,
+                                                  const ExecutionHandler& other,
+                                                  const ScalarField& base_scalar_res,
+                                                  const GroupElement& base_res)
+        {
+            uint8_t inf_path = VarianceRNG.next() % 4;
+            cycle_group_t res;
+            switch (inf_path) {
+            case 0:
+#ifdef FUZZING_SHOW_INFORMATION
+                std::cout << "left.set_point_at_infinity(";
+#endif
+                res = this->cg();
+                res.set_point_at_infinity(this->construct_predicate(builder, true));
+#ifdef FUZZING_SHOW_INFORMATION
+                std::cout << ");" << std::endl;
+#endif
+                return ExecutionHandler(base_scalar_res, base_res, res);
+            case 1:
+#ifdef FUZZING_SHOW_INFORMATION
+                std::cout << "right.set_point_at_infinity(";
+#endif
+                res = other.cg();
+                res.set_point_at_infinity(this->construct_predicate(builder, true));
+#ifdef FUZZING_SHOW_INFORMATION
+                std::cout << ");" << std::endl;
+#endif
+                return ExecutionHandler(base_scalar_res, base_res, res);
+            case 2:
+                return ExecutionHandler(base_scalar_res, base_res, this->cg() + other.cg());
+            case 3:
+                return ExecutionHandler(base_scalar_res, base_res, other.cg() + this->cg());
+            }
+            return {};
+        }
+
+        /**
+         * @brief Handle normal addition (no special edge cases)
+         * @param other The other execution handler
+         * @param base_scalar_res Result scalar for native computation
+         * @param base_res Result point for native computation
+         * @return ExecutionHandler with addition via various code paths
+         */
+        ExecutionHandler handle_add_normal_case(const ExecutionHandler& other,
+                                                const ScalarField& base_scalar_res,
+                                                const GroupElement& base_res)
+        {
             bool smth_inf = this->cycle_group.is_point_at_infinity().get_value() ||
                             other.cycle_group.is_point_at_infinity().get_value();
             uint8_t add_option = smth_inf ? 4 + (VarianceRNG.next() % 2) : VarianceRNG.next() % 6;
@@ -974,57 +1010,99 @@ template <typename Builder> class CycleGroupBase {
             return {};
         }
 
-        ExecutionHandler operator_sub(Builder* builder, const ExecutionHandler& other)
+      public:
+        ExecutionHandler operator_add(Builder* builder, const ExecutionHandler& other)
         {
-            ScalarField base_scalar_res = this->base_scalar - other.base_scalar;
-            GroupElement base_res = this->base - other.base;
+            ScalarField base_scalar_res = this->base_scalar + other.base_scalar;
+            GroupElement base_res = this->base + other.base;
 
-            if (other.cg().get_value() == -this->cg().get_value()) {
-                uint8_t dbl_path = VarianceRNG.next() % 3;
-
-                switch (dbl_path) {
-                case 0:
-#ifdef FUZZING_SHOW_INFORMATION
-                    std::cout << "left.dbl();" << std::endl;
-#endif
-                    return ExecutionHandler(base_scalar_res, base_res, this->cg().dbl());
-                case 1:
-#ifdef FUZZING_SHOW_INFORMATION
-                    std::cout << "-right.dbl();" << std::endl;
-#endif
-                    return ExecutionHandler(base_scalar_res, base_res, -other.cg().dbl());
-                case 2:
-                    return ExecutionHandler(base_scalar_res, base_res, this->cg() - other.cg());
-                }
-            } else if (other.cg().get_value() == this->cg().get_value()) {
-                uint8_t inf_path = VarianceRNG.next() % 3;
-                cycle_group_t res;
-
-                switch (inf_path) {
-                case 0:
-#ifdef FUZZING_SHOW_INFORMATION
-                    std::cout << "left.set_point_at_infinity(";
-#endif
-                    res = this->cg();
-                    res.set_point_at_infinity(this->construct_predicate(builder, true));
-#ifdef FUZZING_SHOW_INFORMATION
-                    std::cout << ");" << std::endl;
-#endif
-                    return ExecutionHandler(base_scalar_res, base_res, res);
-                case 1:
-#ifdef FUZZING_SHOW_INFORMATION
-                    std::cout << "right.set_point_at_infinity(";
-#endif
-                    res = other.cg();
-                    res.set_point_at_infinity(this->construct_predicate(builder, true));
-#ifdef FUZZING_SHOW_INFORMATION
-                    std::cout << ");" << std::endl;
-#endif
-                    return ExecutionHandler(base_scalar_res, base_res, res);
-                case 2:
-                    return ExecutionHandler(base_scalar_res, base_res, this->cg() - other.cg());
-                }
+            // Test doubling path when points are equal
+            if (other.cg().get_value() == this->cg().get_value()) {
+                return handle_add_doubling_case(builder, other, base_scalar_res, base_res);
             }
+
+            // Test infinity path when points are negations
+            if (other.cg().get_value() == -this->cg().get_value()) {
+                return handle_add_infinity_case(builder, other, base_scalar_res, base_res);
+            }
+
+            // Test normal addition paths
+            return handle_add_normal_case(other, base_scalar_res, base_res);
+        }
+
+      private:
+        /**
+         * @brief Handle subtraction when points are negations: x - (-x) = 2x (doubling case)
+         */
+        ExecutionHandler handle_sub_doubling_case(Builder* builder,
+                                                  const ExecutionHandler& other,
+                                                  const ScalarField& base_scalar_res,
+                                                  const GroupElement& base_res)
+        {
+            uint8_t dbl_path = VarianceRNG.next() % 3;
+
+            switch (dbl_path) {
+            case 0:
+#ifdef FUZZING_SHOW_INFORMATION
+                std::cout << "left.dbl();" << std::endl;
+#endif
+                return ExecutionHandler(base_scalar_res, base_res, this->cg().dbl());
+            case 1:
+#ifdef FUZZING_SHOW_INFORMATION
+                std::cout << "-right.dbl();" << std::endl;
+#endif
+                return ExecutionHandler(base_scalar_res, base_res, -other.cg().dbl());
+            case 2:
+                return ExecutionHandler(base_scalar_res, base_res, this->cg() - other.cg());
+            }
+            return {};
+        }
+
+        /**
+         * @brief Handle subtraction when points are equal: x - x = 0 (point at infinity)
+         */
+        ExecutionHandler handle_sub_infinity_case(Builder* builder,
+                                                  const ExecutionHandler& other,
+                                                  const ScalarField& base_scalar_res,
+                                                  const GroupElement& base_res)
+        {
+            uint8_t inf_path = VarianceRNG.next() % 3;
+            cycle_group_t res;
+
+            switch (inf_path) {
+            case 0:
+#ifdef FUZZING_SHOW_INFORMATION
+                std::cout << "left.set_point_at_infinity(";
+#endif
+                res = this->cg();
+                res.set_point_at_infinity(this->construct_predicate(builder, true));
+#ifdef FUZZING_SHOW_INFORMATION
+                std::cout << ");" << std::endl;
+#endif
+                return ExecutionHandler(base_scalar_res, base_res, res);
+            case 1:
+#ifdef FUZZING_SHOW_INFORMATION
+                std::cout << "right.set_point_at_infinity(";
+#endif
+                res = other.cg();
+                res.set_point_at_infinity(this->construct_predicate(builder, true));
+#ifdef FUZZING_SHOW_INFORMATION
+                std::cout << ");" << std::endl;
+#endif
+                return ExecutionHandler(base_scalar_res, base_res, res);
+            case 2:
+                return ExecutionHandler(base_scalar_res, base_res, this->cg() - other.cg());
+            }
+            return {};
+        }
+
+        /**
+         * @brief Handle normal subtraction case (no special edge cases)
+         */
+        ExecutionHandler handle_sub_normal_case(const ExecutionHandler& other,
+                                                const ScalarField& base_scalar_res,
+                                                const GroupElement& base_res)
+        {
             bool smth_inf = this->cycle_group.is_point_at_infinity().get_value() ||
                             other.cycle_group.is_point_at_infinity().get_value();
             uint8_t add_option = smth_inf ? 2 : VarianceRNG.next() % 3;
@@ -1045,6 +1123,24 @@ template <typename Builder> class CycleGroupBase {
                 return ExecutionHandler(base_scalar_res, base_res, this->cg() - other.cg());
             }
             return {};
+        }
+
+      public:
+        /**
+         * @brief Subtract two ExecutionHandlers, exploring different code paths for edge cases
+         */
+        ExecutionHandler operator_sub(Builder* builder, const ExecutionHandler& other)
+        {
+            ScalarField base_scalar_res = this->base_scalar - other.base_scalar;
+            GroupElement base_res = this->base - other.base;
+
+            if (other.cg().get_value() == -this->cg().get_value()) {
+                return handle_sub_doubling_case(builder, other, base_scalar_res, base_res);
+            }
+            if (other.cg().get_value() == this->cg().get_value()) {
+                return handle_sub_infinity_case(builder, other, base_scalar_res, base_res);
+            }
+            return handle_sub_normal_case(other, base_scalar_res, base_res);
         }
 
         ExecutionHandler mul(Builder* builder, const ScalarField& multiplier)

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/group/cycle_group.fuzzer.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/group/cycle_group.fuzzer.hpp
@@ -4,6 +4,34 @@
 // external_2:  { status: not started, auditors: [], date: YYYY-MM-DD }
 // =====================
 
+/**
+ * @file cycle_group.fuzzer.hpp
+ * @brief Differential fuzzer for cycle_group elliptic curve operations
+ * @details Implements an instruction-based differential fuzzer that validates the cycle_group implementation by
+ * executing random sequences of operations both in-circuit (using cycle_group) and natively, then comparing the
+ * results. The architecture is as follows:
+ *
+ * ┌─────────────┐
+ * │ Fuzzer Input│
+ * │ (raw bytes) │
+ * └──────┬──────┘
+ *        │
+ *        ├──> Parser ──> Instruction Sequence
+ *        │
+ *        v
+ *   ExecutionHandler (maintains parallel state):
+ *   ┌──────────────────────────────────────────────────┐
+ *   │ Native:     GroupElement + ScalarField           │  (ground truth)
+ *   │ Circuit:    cycle_group + cycle_scalar           │
+ *   └──────────────────────────────────────────────────┘
+ *        │
+ *        ├──> Execute each instruction in both representations
+ *        │
+ *        v
+ *   Verify: cycle_group.get_value() == native_result
+ *   CircuitChecker::check(circuit)
+ */
+
 #pragma once
 #include "barretenberg/circuit_checker/circuit_checker.hpp"
 #include "barretenberg/numeric/random/engine.hpp"

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/group/cycle_group.fuzzer.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/group/cycle_group.fuzzer.hpp
@@ -1253,23 +1253,16 @@ template <typename Builder> class CycleGroupBase {
         }
 
         /**
-         * @brief Execution status for instruction execution
-         * @details Used by execute_* functions to indicate whether to continue processing instructions or stop
-         * execution (e.g., due to insufficient stack size).
-         */
-        enum class ExecutionStatus : uint8_t { Continue = 0, Stop = 1 };
-
-        /**
          * @brief Execute the constant instruction (push constant cycle group to the stack)
          *
          * @param builder
          * @param stack
          * @param instruction
-         * @return ExecutionStatus::Continue/Stop
+         * @return 0 to continue, 1 to stop
          */
-        static inline ExecutionStatus execute_CONSTANT(Builder* builder,
-                                                       std::vector<ExecutionHandler>& stack,
-                                                       Instruction& instruction)
+        static inline size_t execute_CONSTANT(Builder* builder,
+                                              std::vector<ExecutionHandler>& stack,
+                                              Instruction& instruction)
         {
             (void)builder;
             stack.push_back(
@@ -1278,7 +1271,7 @@ template <typename Builder> class CycleGroupBase {
                                  cycle_group_t(static_cast<AffineElement>(instruction.arguments.element.value))));
             debug_log(
                 "auto c", stack.size() - 1, " = cycle_group_t(ae(\"", instruction.arguments.element.scalar, "\"));\n");
-            return ExecutionStatus::Continue;
+            return 0;
         };
 
         /**
@@ -1287,11 +1280,11 @@ template <typename Builder> class CycleGroupBase {
          * @param builder
          * @param stack
          * @param instruction
-         * @return ExecutionStatus::Continue/Stop
+         * @return 0 to continue, 1 to stop
          */
-        static inline ExecutionStatus execute_WITNESS(Builder* builder,
-                                                      std::vector<ExecutionHandler>& stack,
-                                                      Instruction& instruction)
+        static inline size_t execute_WITNESS(Builder* builder,
+                                             std::vector<ExecutionHandler>& stack,
+                                             Instruction& instruction)
         {
             stack.push_back(ExecutionHandler(
                 instruction.arguments.element.scalar,
@@ -1302,7 +1295,7 @@ template <typename Builder> class CycleGroupBase {
                       " = cycle_group_t::from_witness(&builder, ae(\"",
                       instruction.arguments.element.scalar,
                       "\"));\n");
-            return ExecutionStatus::Continue;
+            return 0;
         }
 
         /**
@@ -1312,11 +1305,11 @@ template <typename Builder> class CycleGroupBase {
          * @param builder
          * @param stack
          * @param instruction
-         * @return ExecutionStatus::Continue/Stop
+         * @return 0 to continue, 1 to stop
          */
-        static inline ExecutionStatus execute_CONSTANT_WITNESS(Builder* builder,
-                                                               std::vector<ExecutionHandler>& stack,
-                                                               Instruction& instruction)
+        static inline size_t execute_CONSTANT_WITNESS(Builder* builder,
+                                                      std::vector<ExecutionHandler>& stack,
+                                                      Instruction& instruction)
         {
             stack.push_back(
                 ExecutionHandler(instruction.arguments.element.scalar,
@@ -1328,7 +1321,7 @@ template <typename Builder> class CycleGroupBase {
                       " = cycle_group_t::from_constant_witness(&builder, ae(\"",
                       instruction.arguments.element.scalar,
                       "\"));\n");
-            return ExecutionStatus::Continue;
+            return 0;
         }
 
         /**
@@ -1337,15 +1330,15 @@ template <typename Builder> class CycleGroupBase {
          * @param builder
          * @param stack
          * @param instruction
-         * @return ExecutionStatus::Continue/Stop
+         * @return 0 to continue, 1 to stop
          */
-        static inline ExecutionStatus execute_DBL(Builder* builder,
-                                                  std::vector<ExecutionHandler>& stack,
-                                                  Instruction& instruction)
+        static inline size_t execute_DBL(Builder* builder,
+                                         std::vector<ExecutionHandler>& stack,
+                                         Instruction& instruction)
         {
             (void)builder;
             if (stack.size() == 0) {
-                return ExecutionStatus::Stop;
+                return 1;
             }
             size_t first_index = instruction.arguments.twoArgs.in % stack.size();
             size_t output_index = instruction.arguments.twoArgs.out;
@@ -1361,7 +1354,7 @@ template <typename Builder> class CycleGroupBase {
             } else {
                 stack[output_index] = result;
             }
-            return ExecutionStatus::Continue;
+            return 0;
         };
 
         /**
@@ -1370,15 +1363,15 @@ template <typename Builder> class CycleGroupBase {
          * @param builder
          * @param stack
          * @param instruction
-         * @return ExecutionStatus::Continue/Stop
+         * @return 0 to continue, 1 to stop
          */
-        static inline ExecutionStatus execute_NEG(Builder* builder,
-                                                  std::vector<ExecutionHandler>& stack,
-                                                  Instruction& instruction)
+        static inline size_t execute_NEG(Builder* builder,
+                                         std::vector<ExecutionHandler>& stack,
+                                         Instruction& instruction)
         {
             (void)builder;
             if (stack.size() == 0) {
-                return ExecutionStatus::Stop;
+                return 1;
             }
             size_t first_index = instruction.arguments.twoArgs.in % stack.size();
             size_t output_index = instruction.arguments.twoArgs.out;
@@ -1394,7 +1387,7 @@ template <typename Builder> class CycleGroupBase {
             } else {
                 stack[output_index] = result;
             }
-            return ExecutionStatus::Continue;
+            return 0;
         };
 
         /**
@@ -1403,14 +1396,14 @@ template <typename Builder> class CycleGroupBase {
          * @param builder
          * @param stack
          * @param instruction
-         * @return ExecutionStatus::Continue/Stop
+         * @return 0 to continue, 1 to stop
          */
-        static inline ExecutionStatus execute_ASSERT_EQUAL(Builder* builder,
-                                                           std::vector<ExecutionHandler>& stack,
-                                                           Instruction& instruction)
+        static inline size_t execute_ASSERT_EQUAL(Builder* builder,
+                                                  std::vector<ExecutionHandler>& stack,
+                                                  Instruction& instruction)
         {
             if (stack.size() == 0) {
-                return ExecutionStatus::Stop;
+                return 1;
             }
             size_t first_index = instruction.arguments.twoArgs.in % stack.size();
             size_t second_index = instruction.arguments.twoArgs.out % stack.size();
@@ -1420,7 +1413,7 @@ template <typename Builder> class CycleGroupBase {
                 debug_log("assert_equal(", args.lhs, ", ", args.rhs, ", builder);", "\n");
             }
             stack[first_index].assert_equal(builder, stack[second_index]);
-            return ExecutionStatus::Continue;
+            return 0;
         };
 
         /**
@@ -1429,15 +1422,15 @@ template <typename Builder> class CycleGroupBase {
          * @param builder
          * @param stack
          * @param instruction
-         * @return ExecutionStatus::Continue/Stop
+         * @return 0 to continue, 1 to stop
          */
-        static inline ExecutionStatus execute_SET(Builder* builder,
-                                                  std::vector<ExecutionHandler>& stack,
-                                                  Instruction& instruction)
+        static inline size_t execute_SET(Builder* builder,
+                                         std::vector<ExecutionHandler>& stack,
+                                         Instruction& instruction)
         {
             (void)builder;
             if (stack.size() == 0) {
-                return ExecutionStatus::Stop;
+                return 1;
             }
             size_t first_index = instruction.arguments.twoArgs.in % stack.size();
             size_t output_index = instruction.arguments.twoArgs.out;
@@ -1452,7 +1445,7 @@ template <typename Builder> class CycleGroupBase {
             } else {
                 stack[output_index] = result;
             }
-            return ExecutionStatus::Continue;
+            return 0;
         };
 
         /**
@@ -1461,15 +1454,15 @@ template <typename Builder> class CycleGroupBase {
          * @param builder
          * @param stack
          * @param instruction
-         * @return ExecutionStatus::Continue/Stop
+         * @return 0 to continue, 1 to stop
          */
-        static inline ExecutionStatus execute_SET_INF(Builder* builder,
-                                                      std::vector<ExecutionHandler>& stack,
-                                                      Instruction& instruction)
+        static inline size_t execute_SET_INF(Builder* builder,
+                                             std::vector<ExecutionHandler>& stack,
+                                             Instruction& instruction)
         {
             (void)builder;
             if (stack.size() == 0) {
-                return ExecutionStatus::Stop;
+                return 1;
             }
             size_t first_index = instruction.arguments.twoArgs.in % stack.size();
             size_t output_index = instruction.arguments.twoArgs.out;
@@ -1485,7 +1478,7 @@ template <typename Builder> class CycleGroupBase {
             } else {
                 stack[output_index] = result;
             }
-            return ExecutionStatus::Continue;
+            return 0;
         };
 
         /**
@@ -1494,15 +1487,15 @@ template <typename Builder> class CycleGroupBase {
          * @param builder
          * @param stack
          * @param instruction
-         * @return ExecutionStatus::Continue/Stop
+         * @return 0 to continue, 1 to stop
          */
-        static inline ExecutionStatus execute_ADD(Builder* builder,
-                                                  std::vector<ExecutionHandler>& stack,
-                                                  Instruction& instruction)
+        static inline size_t execute_ADD(Builder* builder,
+                                         std::vector<ExecutionHandler>& stack,
+                                         Instruction& instruction)
         {
             (void)builder;
             if (stack.size() == 0) {
-                return ExecutionStatus::Stop;
+                return 1;
             }
             size_t first_index = instruction.arguments.threeArgs.in1 % stack.size();
             size_t second_index = instruction.arguments.threeArgs.in2 % stack.size();
@@ -1519,7 +1512,7 @@ template <typename Builder> class CycleGroupBase {
             } else {
                 stack[output_index] = result;
             }
-            return ExecutionStatus::Continue;
+            return 0;
         };
 
         /**
@@ -1528,15 +1521,15 @@ template <typename Builder> class CycleGroupBase {
          * @param builder
          * @param stack
          * @param instruction
-         * @return ExecutionStatus::Continue/Stop
+         * @return 0 to continue, 1 to stop
          */
-        static inline ExecutionStatus execute_SUBTRACT(Builder* builder,
-                                                       std::vector<ExecutionHandler>& stack,
-                                                       Instruction& instruction)
+        static inline size_t execute_SUBTRACT(Builder* builder,
+                                              std::vector<ExecutionHandler>& stack,
+                                              Instruction& instruction)
         {
             (void)builder;
             if (stack.size() == 0) {
-                return ExecutionStatus::Stop;
+                return 1;
             }
             size_t first_index = instruction.arguments.threeArgs.in1 % stack.size();
             size_t second_index = instruction.arguments.threeArgs.in2 % stack.size();
@@ -1553,7 +1546,7 @@ template <typename Builder> class CycleGroupBase {
             } else {
                 stack[output_index] = result;
             }
-            return ExecutionStatus::Continue;
+            return 0;
         };
 
         /**
@@ -1562,15 +1555,15 @@ template <typename Builder> class CycleGroupBase {
          * @param builder
          * @param stack
          * @param instruction
-         * @return ExecutionStatus::Continue/Stop
+         * @return 0 to continue, 1 to stop
          */
-        static inline ExecutionStatus execute_COND_ASSIGN(Builder* builder,
-                                                          std::vector<ExecutionHandler>& stack,
-                                                          Instruction& instruction)
+        static inline size_t execute_COND_ASSIGN(Builder* builder,
+                                                 std::vector<ExecutionHandler>& stack,
+                                                 Instruction& instruction)
         {
             (void)builder;
             if (stack.size() == 0) {
-                return ExecutionStatus::Stop;
+                return 1;
             }
             size_t first_index = instruction.arguments.fourArgs.in1 % stack.size();
             size_t second_index = instruction.arguments.fourArgs.in2 % stack.size();
@@ -1589,7 +1582,7 @@ template <typename Builder> class CycleGroupBase {
             } else {
                 stack[output_index] = result;
             }
-            return ExecutionStatus::Continue;
+            return 0;
         };
 
         /**
@@ -1598,15 +1591,15 @@ template <typename Builder> class CycleGroupBase {
          * @param builder
          * @param stack
          * @param instruction
-         * @return ExecutionStatus::Continue/Stop
+         * @return 0 to continue, 1 to stop
          */
-        static inline ExecutionStatus execute_MULTIPLY(Builder* builder,
-                                                       std::vector<ExecutionHandler>& stack,
-                                                       Instruction& instruction)
+        static inline size_t execute_MULTIPLY(Builder* builder,
+                                              std::vector<ExecutionHandler>& stack,
+                                              Instruction& instruction)
         {
 
             if (stack.size() == 0) {
-                return ExecutionStatus::Stop;
+                return 1;
             }
             size_t first_index = instruction.arguments.mulArgs.in % stack.size();
             size_t output_index = instruction.arguments.mulArgs.out;
@@ -1623,7 +1616,7 @@ template <typename Builder> class CycleGroupBase {
             } else {
                 stack[output_index] = result;
             }
-            return ExecutionStatus::Continue;
+            return 0;
         };
 
         /**
@@ -1632,15 +1625,15 @@ template <typename Builder> class CycleGroupBase {
          * @param builder
          * @param stack
          * @param instruction
-         * @return ExecutionStatus::Continue/Stop
+         * @return 0 to continue, 1 to stop
          */
-        static inline ExecutionStatus execute_BATCH_MUL(Builder* builder,
-                                                        std::vector<ExecutionHandler>& stack,
-                                                        Instruction& instruction)
+        static inline size_t execute_BATCH_MUL(Builder* builder,
+                                               std::vector<ExecutionHandler>& stack,
+                                               Instruction& instruction)
         {
             (void)builder;
             if (stack.size() == 0) {
-                return ExecutionStatus::Stop;
+                return 1;
             }
             std::vector<ExecutionHandler> to_add;
             std::vector<ScalarField> to_mul;
@@ -1672,7 +1665,7 @@ template <typename Builder> class CycleGroupBase {
             } else {
                 stack[output_index] = result;
             }
-            return ExecutionStatus::Continue;
+            return 0;
         };
 
         /**
@@ -1681,17 +1674,17 @@ template <typename Builder> class CycleGroupBase {
          * @param builder
          * @param stack
          * @param instruction
-         * @return ExecutionStatus::Continue/Stop
+         * @return 0 to continue, 1 to stop
          */
-        static inline ExecutionStatus execute_RANDOMSEED(Builder* builder,
-                                                         std::vector<ExecutionHandler>& stack,
-                                                         Instruction& instruction)
+        static inline size_t execute_RANDOMSEED(Builder* builder,
+                                                std::vector<ExecutionHandler>& stack,
+                                                Instruction& instruction)
         {
             (void)builder;
             (void)stack;
 
             VarianceRNG.reseed(instruction.arguments.randomseed);
-            return ExecutionStatus::Continue;
+            return 0;
         };
     };
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/group/cycle_group.fuzzer.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/group/cycle_group.fuzzer.hpp
@@ -540,7 +540,7 @@ template <typename Builder> class CycleGroupBase {
                 if (convert_to_montgomery) {
                     e = e.to_montgomery_form();
                 }
-                // Substitute scalar element with a special value
+                // Substitute scalar element with a special value excluding zero
                 // I think that zeros from mutateGroupElement are enough zeros produced
                 auto special_value = static_cast<SpecialScalarValue>(rng.next() % SPECIAL_VALUE_COUNT_NO_ZERO);
                 e = get_special_scalar_value<ScalarField>(special_value);
@@ -945,9 +945,11 @@ template <typename Builder> class CycleGroupBase {
             cycle_group_t res;
             switch (inf_path) {
             case 0:
-                debug_log("left.set_point_at_infinity();", "\n");
+                debug_log("left.set_point_at_infinity(");
                 res = this->cg();
+                // Need to split logs here, since `set_point_at_infinity` produces extra logs
                 res.set_point_at_infinity(this->construct_predicate(builder, true));
+                debug_log(");", "\n");
                 return ExecutionHandler(base_scalar_res, base_res, res);
             case 1:
                 debug_log("right.set_point_at_infinity();", "\n");
@@ -1434,11 +1436,17 @@ template <typename Builder> class CycleGroupBase {
             }
             size_t first_index = instruction.arguments.twoArgs.in % stack.size();
             size_t output_index = instruction.arguments.twoArgs.out;
+
+            ExecutionHandler result;
             if constexpr (SHOW_FUZZING_INFO) {
                 auto args = format_single_arg(stack, first_index, output_index);
-                debug_log(args.out, " = ", args.rhs, ");", "\n");
+                debug_log(args.out, " = ");
+                // Need to split logs here, since `set` produces extra logs
+                result = stack[first_index].set(builder);
+                debug_log(args.rhs, ");", "\n");
+            } else {
+                result = stack[first_index].set(builder);
             }
-            ExecutionHandler result = stack[first_index].set(builder);
             // If the output index is larger than the number of elements in stack, append
             if (output_index >= stack.size()) {
                 stack.push_back(result);
@@ -1570,12 +1578,17 @@ template <typename Builder> class CycleGroupBase {
             size_t output_index = instruction.arguments.fourArgs.out % stack.size();
             bool predicate = instruction.arguments.fourArgs.in3 % 2;
 
+            ExecutionHandler result;
             if constexpr (SHOW_FUZZING_INFO) {
                 auto args = format_two_arg(stack, first_index, second_index, output_index);
-                debug_log(args.out, " = cycle_group_t::conditional_assign(", args.rhs, ", ", args.lhs, ");", "\n");
+                debug_log(args.out, " = cycle_group_t::conditional_assign(");
+                // Need to split logs here, since `conditional_assign` produces extra logs
+                result = stack[first_index].conditional_assign(builder, stack[second_index], predicate);
+                debug_log(args.rhs, ", ", args.lhs, ");", "\n");
+            } else {
+                result = stack[first_index].conditional_assign(builder, stack[second_index], predicate);
             }
 
-            ExecutionHandler result = stack[first_index].conditional_assign(builder, stack[second_index], predicate);
             // If the output index is larger than the number of elements in stack, append
             if (output_index >= stack.size()) {
                 stack.push_back(result);
@@ -1607,7 +1620,7 @@ template <typename Builder> class CycleGroupBase {
 
             if constexpr (SHOW_FUZZING_INFO) {
                 auto args = format_single_arg(stack, first_index, output_index);
-                debug_log(args.out, " = ", args.rhs, "\n");
+                debug_log(args.out, " = ", args.rhs);
             }
             ExecutionHandler result = stack[first_index].mul(builder, scalar);
             // If the output index is larger than the number of elements in stack, append
@@ -1643,6 +1656,7 @@ template <typename Builder> class CycleGroupBase {
             }
             size_t output_index = (size_t)instruction.arguments.batchMulArgs.output_index;
 
+            ExecutionHandler result;
             if constexpr (SHOW_FUZZING_INFO) {
                 std::string res = "";
                 bool is_const = true;
@@ -1656,9 +1670,13 @@ template <typename Builder> class CycleGroupBase {
                 std::string out = is_const ? "c" : "w";
                 out = ((output_index >= stack.size()) ? "auto " : "") + out;
                 out += std::to_string(output_index >= stack.size() ? stack.size() : output_index);
-                debug_log(out, " = cycle_group_t::batch_mul({", res, "}, {});", "\n");
+                debug_log(out, " = cycle_group_t::batch_mul({", res, "}, {");
+                // Need to split logs here, since `conditional_assign` produces extra logs
+                result = ExecutionHandler::batch_mul(builder, to_add, to_mul);
+                debug_log("});", "\n");
+            } else {
+                result = ExecutionHandler::batch_mul(builder, to_add, to_mul);
             }
-            ExecutionHandler result = ExecutionHandler::batch_mul(builder, to_add, to_mul);
             // If the output index is larger than the number of elements in stack, append
             if (output_index >= stack.size()) {
                 stack.push_back(result);

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/group/cycle_group.fuzzer.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/group/cycle_group.fuzzer.hpp
@@ -1197,16 +1197,23 @@ template <typename Builder> class CycleGroupBase {
         }
 
         /**
+         * @brief Execution status for instruction execution
+         * @details Used by execute_* functions to indicate whether to continue processing instructions or stop
+         * execution (e.g., due to insufficient stack size).
+         */
+        enum class ExecutionStatus : uint8_t { Continue = 0, Stop = 1 };
+
+        /**
          * @brief Execute the constant instruction (push constant cycle group to the stack)
          *
          * @param builder
          * @param stack
          * @param instruction
-         * @return 0 if everything is ok, 1 if we should stop execution, since an expected error was encountered
+         * @return ExecutionStatus::Continue/Stop
          */
-        static inline size_t execute_CONSTANT(Builder* builder,
-                                              std::vector<ExecutionHandler>& stack,
-                                              Instruction& instruction)
+        static inline ExecutionStatus execute_CONSTANT(Builder* builder,
+                                                       std::vector<ExecutionHandler>& stack,
+                                                       Instruction& instruction)
         {
             (void)builder;
             stack.push_back(
@@ -1217,7 +1224,7 @@ template <typename Builder> class CycleGroupBase {
             std::cout << "auto c" << stack.size() - 1 << " = cycle_group_t(ae(\""
                       << instruction.arguments.element.scalar << "\"));" << std::endl;
 #endif
-            return 0;
+            return ExecutionStatus::Continue;
         };
 
         /**
@@ -1226,11 +1233,11 @@ template <typename Builder> class CycleGroupBase {
          * @param builder
          * @param stack
          * @param instruction
-         * @return if everything is ok, 1 if we should stop execution, since an expected error was encountered
+         * @return ExecutionStatus::Continue/Stop
          */
-        static inline size_t execute_WITNESS(Builder* builder,
-                                             std::vector<ExecutionHandler>& stack,
-                                             Instruction& instruction)
+        static inline ExecutionStatus execute_WITNESS(Builder* builder,
+                                                      std::vector<ExecutionHandler>& stack,
+                                                      Instruction& instruction)
         {
             stack.push_back(ExecutionHandler(
                 instruction.arguments.element.scalar,
@@ -1240,7 +1247,7 @@ template <typename Builder> class CycleGroupBase {
             std::cout << "auto w" << stack.size() - 1 << " = cycle_group_t::from_witness(&builder, ae(\""
                       << instruction.arguments.element.scalar << "\"));" << std::endl;
 #endif
-            return 0;
+            return ExecutionStatus::Continue;
         }
 
         /**
@@ -1250,11 +1257,11 @@ template <typename Builder> class CycleGroupBase {
          * @param builder
          * @param stack
          * @param instruction
-         * @return 0 if everything is ok, 1 if we should stop execution, since an expected error was encountered
+         * @return ExecutionStatus::Continue/Stop
          */
-        static inline size_t execute_CONSTANT_WITNESS(Builder* builder,
-                                                      std::vector<ExecutionHandler>& stack,
-                                                      Instruction& instruction)
+        static inline ExecutionStatus execute_CONSTANT_WITNESS(Builder* builder,
+                                                               std::vector<ExecutionHandler>& stack,
+                                                               Instruction& instruction)
         {
             stack.push_back(
                 ExecutionHandler(instruction.arguments.element.scalar,
@@ -1265,7 +1272,7 @@ template <typename Builder> class CycleGroupBase {
             std::cout << "auto cw" << stack.size() - 1 << " = cycle_group_t::from_constant_witness(&builder, ae(\""
                       << instruction.arguments.element.scalar << "\"));" << std::endl;
 #endif
-            return 0;
+            return ExecutionStatus::Continue;
         }
 
         /**
@@ -1274,15 +1281,15 @@ template <typename Builder> class CycleGroupBase {
          * @param builder
          * @param stack
          * @param instruction
-         * @return if everything is ok, 1 if we should stop execution, since an expected error was encountered
+         * @return ExecutionStatus::Continue/Stop
          */
-        static inline size_t execute_DBL(Builder* builder,
-                                         std::vector<ExecutionHandler>& stack,
-                                         Instruction& instruction)
+        static inline ExecutionStatus execute_DBL(Builder* builder,
+                                                  std::vector<ExecutionHandler>& stack,
+                                                  Instruction& instruction)
         {
             (void)builder;
             if (stack.size() == 0) {
-                return 1;
+                return ExecutionStatus::Stop;
             }
             size_t first_index = instruction.arguments.twoArgs.in % stack.size();
             size_t output_index = instruction.arguments.twoArgs.out;
@@ -1299,7 +1306,7 @@ template <typename Builder> class CycleGroupBase {
             } else {
                 stack[output_index] = result;
             }
-            return 0;
+            return ExecutionStatus::Continue;
         };
 
         /**
@@ -1308,15 +1315,15 @@ template <typename Builder> class CycleGroupBase {
          * @param builder
          * @param stack
          * @param instruction
-         * @return if everything is ok, 1 if we should stop execution, since an expected error was encountered
+         * @return ExecutionStatus::Continue/Stop
          */
-        static inline size_t execute_NEG(Builder* builder,
-                                         std::vector<ExecutionHandler>& stack,
-                                         Instruction& instruction)
+        static inline ExecutionStatus execute_NEG(Builder* builder,
+                                                  std::vector<ExecutionHandler>& stack,
+                                                  Instruction& instruction)
         {
             (void)builder;
             if (stack.size() == 0) {
-                return 1;
+                return ExecutionStatus::Stop;
             }
             size_t first_index = instruction.arguments.twoArgs.in % stack.size();
             size_t output_index = instruction.arguments.twoArgs.out;
@@ -1333,7 +1340,7 @@ template <typename Builder> class CycleGroupBase {
             } else {
                 stack[output_index] = result;
             }
-            return 0;
+            return ExecutionStatus::Continue;
         };
 
         /**
@@ -1342,14 +1349,14 @@ template <typename Builder> class CycleGroupBase {
          * @param builder
          * @param stack
          * @param instruction
-         * @return if everything is ok, 1 if we should stop execution, since an expected error was encountered
+         * @return ExecutionStatus::Continue/Stop
          */
-        static inline size_t execute_ASSERT_EQUAL(Builder* builder,
-                                                  std::vector<ExecutionHandler>& stack,
-                                                  Instruction& instruction)
+        static inline ExecutionStatus execute_ASSERT_EQUAL(Builder* builder,
+                                                           std::vector<ExecutionHandler>& stack,
+                                                           Instruction& instruction)
         {
             if (stack.size() == 0) {
-                return 1;
+                return ExecutionStatus::Stop;
             }
             size_t first_index = instruction.arguments.twoArgs.in % stack.size();
             size_t second_index = instruction.arguments.twoArgs.out % stack.size();
@@ -1359,7 +1366,7 @@ template <typename Builder> class CycleGroupBase {
             std::cout << "assert_equal(" << args.lhs << ", " << args.rhs << ", builder);" << std::endl;
 #endif
             stack[first_index].assert_equal(builder, stack[second_index]);
-            return 0;
+            return ExecutionStatus::Continue;
         };
 
         /**
@@ -1368,15 +1375,15 @@ template <typename Builder> class CycleGroupBase {
          * @param builder
          * @param stack
          * @param instruction
-         * @return if everything is ok, 1 if we should stop execution, since an expected error was encountered
+         * @return ExecutionStatus::Continue/Stop
          */
-        static inline size_t execute_SET(Builder* builder,
-                                         std::vector<ExecutionHandler>& stack,
-                                         Instruction& instruction)
+        static inline ExecutionStatus execute_SET(Builder* builder,
+                                                  std::vector<ExecutionHandler>& stack,
+                                                  Instruction& instruction)
         {
             (void)builder;
             if (stack.size() == 0) {
-                return 1;
+                return ExecutionStatus::Stop;
             }
             size_t first_index = instruction.arguments.twoArgs.in % stack.size();
             size_t output_index = instruction.arguments.twoArgs.out;
@@ -1396,7 +1403,7 @@ template <typename Builder> class CycleGroupBase {
             } else {
                 stack[output_index] = result;
             }
-            return 0;
+            return ExecutionStatus::Continue;
         };
 
         /**
@@ -1405,15 +1412,15 @@ template <typename Builder> class CycleGroupBase {
          * @param builder
          * @param stack
          * @param instruction
-         * @return if everything is ok, 1 if we should stop execution, since an expected error was encountered
+         * @return ExecutionStatus::Continue/Stop
          */
-        static inline size_t execute_SET_INF(Builder* builder,
-                                             std::vector<ExecutionHandler>& stack,
-                                             Instruction& instruction)
+        static inline ExecutionStatus execute_SET_INF(Builder* builder,
+                                                      std::vector<ExecutionHandler>& stack,
+                                                      Instruction& instruction)
         {
             (void)builder;
             if (stack.size() == 0) {
-                return 1;
+                return ExecutionStatus::Stop;
             }
             size_t first_index = instruction.arguments.twoArgs.in % stack.size();
             size_t output_index = instruction.arguments.twoArgs.out;
@@ -1430,7 +1437,7 @@ template <typename Builder> class CycleGroupBase {
             } else {
                 stack[output_index] = result;
             }
-            return 0;
+            return ExecutionStatus::Continue;
         };
 
         /**
@@ -1439,15 +1446,15 @@ template <typename Builder> class CycleGroupBase {
          * @param builder
          * @param stack
          * @param instruction
-         * @return if everything is ok, 1 if we should stop execution, since an expected error was encountered
+         * @return ExecutionStatus::Continue/Stop
          */
-        static inline size_t execute_ADD(Builder* builder,
-                                         std::vector<ExecutionHandler>& stack,
-                                         Instruction& instruction)
+        static inline ExecutionStatus execute_ADD(Builder* builder,
+                                                  std::vector<ExecutionHandler>& stack,
+                                                  Instruction& instruction)
         {
             (void)builder;
             if (stack.size() == 0) {
-                return 1;
+                return ExecutionStatus::Stop;
             }
             size_t first_index = instruction.arguments.threeArgs.in1 % stack.size();
             size_t second_index = instruction.arguments.threeArgs.in2 % stack.size();
@@ -1465,7 +1472,7 @@ template <typename Builder> class CycleGroupBase {
             } else {
                 stack[output_index] = result;
             }
-            return 0;
+            return ExecutionStatus::Continue;
         };
 
         /**
@@ -1474,15 +1481,15 @@ template <typename Builder> class CycleGroupBase {
          * @param builder
          * @param stack
          * @param instruction
-         * @return if everything is ok, 1 if we should stop execution, since an expected error was encountered
+         * @return ExecutionStatus::Continue/Stop
          */
-        static inline size_t execute_SUBTRACT(Builder* builder,
-                                              std::vector<ExecutionHandler>& stack,
-                                              Instruction& instruction)
+        static inline ExecutionStatus execute_SUBTRACT(Builder* builder,
+                                                       std::vector<ExecutionHandler>& stack,
+                                                       Instruction& instruction)
         {
             (void)builder;
             if (stack.size() == 0) {
-                return 1;
+                return ExecutionStatus::Stop;
             }
             size_t first_index = instruction.arguments.threeArgs.in1 % stack.size();
             size_t second_index = instruction.arguments.threeArgs.in2 % stack.size();
@@ -1500,7 +1507,7 @@ template <typename Builder> class CycleGroupBase {
             } else {
                 stack[output_index] = result;
             }
-            return 0;
+            return ExecutionStatus::Continue;
         };
 
         /**
@@ -1509,15 +1516,15 @@ template <typename Builder> class CycleGroupBase {
          * @param builder
          * @param stack
          * @param instruction
-         * @return if everything is ok, 1 if we should stop execution, since an expected error was encountered
+         * @return ExecutionStatus::Continue/Stop
          */
-        static inline size_t execute_COND_ASSIGN(Builder* builder,
-                                                 std::vector<ExecutionHandler>& stack,
-                                                 Instruction& instruction)
+        static inline ExecutionStatus execute_COND_ASSIGN(Builder* builder,
+                                                          std::vector<ExecutionHandler>& stack,
+                                                          Instruction& instruction)
         {
             (void)builder;
             if (stack.size() == 0) {
-                return 1;
+                return ExecutionStatus::Stop;
             }
             size_t first_index = instruction.arguments.fourArgs.in1 % stack.size();
             size_t second_index = instruction.arguments.fourArgs.in2 % stack.size();
@@ -1540,7 +1547,7 @@ template <typename Builder> class CycleGroupBase {
             } else {
                 stack[output_index] = result;
             }
-            return 0;
+            return ExecutionStatus::Continue;
         };
 
         /**
@@ -1549,15 +1556,15 @@ template <typename Builder> class CycleGroupBase {
          * @param builder
          * @param stack
          * @param instruction
-         * @return if everything is ok, 1 if we should stop execution, since an expected error was encountered
+         * @return ExecutionStatus::Continue/Stop
          */
-        static inline size_t execute_MULTIPLY(Builder* builder,
-                                              std::vector<ExecutionHandler>& stack,
-                                              Instruction& instruction)
+        static inline ExecutionStatus execute_MULTIPLY(Builder* builder,
+                                                       std::vector<ExecutionHandler>& stack,
+                                                       Instruction& instruction)
         {
 
             if (stack.size() == 0) {
-                return 1;
+                return ExecutionStatus::Stop;
             }
             size_t first_index = instruction.arguments.mulArgs.in % stack.size();
             size_t output_index = instruction.arguments.mulArgs.out;
@@ -1575,7 +1582,7 @@ template <typename Builder> class CycleGroupBase {
             } else {
                 stack[output_index] = result;
             }
-            return 0;
+            return ExecutionStatus::Continue;
         };
 
         /**
@@ -1584,15 +1591,15 @@ template <typename Builder> class CycleGroupBase {
          * @param builder
          * @param stack
          * @param instruction
-         * @return if everything is ok, 1 if we should stop execution, since an expected error was encountered
+         * @return ExecutionStatus::Continue/Stop
          */
-        static inline size_t execute_BATCH_MUL(Builder* builder,
-                                               std::vector<ExecutionHandler>& stack,
-                                               Instruction& instruction)
+        static inline ExecutionStatus execute_BATCH_MUL(Builder* builder,
+                                                        std::vector<ExecutionHandler>& stack,
+                                                        Instruction& instruction)
         {
             (void)builder;
             if (stack.size() == 0) {
-                return 1;
+                return ExecutionStatus::Stop;
             }
             std::vector<ExecutionHandler> to_add;
             std::vector<ScalarField> to_mul;
@@ -1628,7 +1635,7 @@ template <typename Builder> class CycleGroupBase {
             } else {
                 stack[output_index] = result;
             }
-            return 0;
+            return ExecutionStatus::Continue;
         };
 
         /**
@@ -1637,17 +1644,17 @@ template <typename Builder> class CycleGroupBase {
          * @param builder
          * @param stack
          * @param instruction
-         * @return if everything is ok, 1 if we should stop execution, since an expected error was encountered
+         * @return ExecutionStatus::Continue/Stop
          */
-        static inline size_t execute_RANDOMSEED(Builder* builder,
-                                                std::vector<ExecutionHandler>& stack,
-                                                Instruction& instruction)
+        static inline ExecutionStatus execute_RANDOMSEED(Builder* builder,
+                                                         std::vector<ExecutionHandler>& stack,
+                                                         Instruction& instruction)
         {
             (void)builder;
             (void)stack;
 
             VarianceRNG.reseed(instruction.arguments.randomseed);
-            return 0;
+            return ExecutionStatus::Continue;
         };
     };
 


### PR DESCRIPTION
Minor refactoring and cleanup in cycle_group fuzzer; no logic changes:
  - Split `operator_add` and `operator_sub` into smaller methods for improved readability
  - Replaced switch statements with enums for better type safety
  - Replaced macros with inline methods (including Montgomery field operations)
  - Cleaned up debug logging throughout