### PR TITLE
fix: Add AVM build to ci-barretenberg

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -481,7 +481,6 @@ case "$cmd" in
   "ci-barretenberg")
     export CI=1
     export USE_TEST_CACHE=1
-    export AVM=0
     export AVM_TRANSPILER=0
     barretenberg/cpp/bootstrap.sh ci
     ;;


### PR DESCRIPTION
`node_js` requires the AVM, but `ci-barretenberg` is currently building with `AVM=0`, so we get an error. This PR removes `AVM=0`, so `ci-barretenberg` now builds the AVM.
