### PR TITLE
feat: Batch degree check in the merge

### DIFF
--- a/barretenberg/cpp/scripts/test_chonk_standalone_vks_havent_changed.sh
+++ b/barretenberg/cpp/scripts/test_chonk_standalone_vks_havent_changed.sh
@@ -13,7 +13,7 @@ cd ..
 # - Generate a hash for versioning: sha256sum bb-chonk-inputs.tar.gz
 # - Upload the compressed results: aws s3 cp bb-chonk-inputs.tar.gz s3://aztec-ci-artifacts/protocol/bb-chonk-inputs-[hash(0:8)].tar.gz
 # Note: In case of the "Test suite failed to run ... Unexpected token 'with' " error, need to run: docker pull aztecprotocol/build:3.0
-pinned_short_hash="c72a0487"
+pinned_short_hash="02961955"
 pinned_chonk_inputs_url="https://aztec-ci-artifacts.s3.us-east-2.amazonaws.com/protocol/bb-chonk-inputs-${pinned_short_hash}.tar.gz"
 
 function compress_and_upload {

--- a/barretenberg/cpp/src/barretenberg/constants.hpp
+++ b/barretenberg/cpp/src/barretenberg/constants.hpp
@@ -48,7 +48,7 @@ static constexpr uint32_t NUM_LIBRA_COMMITMENTS = 3;
 // extra evaluations
 static constexpr uint32_t NUM_SMALL_IPA_EVALUATIONS = 4;
 
-static constexpr uint32_t MERGE_PROOF_SIZE = 49; // used to ensure mock proofs are generated correctly
+static constexpr uint32_t MERGE_PROOF_SIZE = 34; // used to ensure mock proofs are generated correctly
 
 // There are 5 distinguished wires in ECCVM that have to be opened as univariates to establish the connection between
 // ECCVM and Translator

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/mock_verifier_inputs.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/mock_verifier_inputs.cpp
@@ -340,10 +340,10 @@ Goblin::MergeProof create_mock_merge_proof()
     // Populate mock shift size
     populate_field_elements<fr>(proof, 1, /*value=*/fr{ mock_shift_size });
 
-    // There are 8 entities in the merge protocol (4 columns x 2 components: T_j, g_j(X) = X^{l-1} t_j(X))
-    // and 8 evaluations (4 columns x 2 components: g_j(kappa), t_j(1/kappa))
-    const size_t NUM_TRANSCRIPT_ENTITIES = 8;
-    const size_t NUM_TRANSCRIPT_EVALUATIONS = 8;
+    // There are 5 entities in the merge protocol (4 columns: T_j, one column g(X) = \sum_i alpha_i X^{l-1} t_j(X))
+    // and 5 evaluations (g(kappa), t_j(1/kappa))
+    const size_t NUM_TRANSCRIPT_ENTITIES = 5;
+    const size_t NUM_TRANSCRIPT_EVALUATIONS = 5;
 
     // Transcript poly commitments
     populate_field_elements_for_mock_commitments(proof, NUM_TRANSCRIPT_ENTITIES);

--- a/barretenberg/cpp/src/barretenberg/stdlib/merge_verifier/merge_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/merge_verifier/merge_verifier.test.cpp
@@ -46,7 +46,7 @@ template <class RecursiveBuilder> class RecursiveMergeVerifierTest : public test
     {
         const size_t shift_idx = 0;        // Index of shift_size in the merge proof
         const size_t m_commitment_idx = 1; // Index of first commitment to merged table in merge proof
-        const size_t l_eval_idx = 34;      // Index of first evaluation of l(1/kappa) in merge proof
+        const size_t l_eval_idx = 21;      // Index of first evaluation of l(1/kappa) in merge proof
 
         switch (tampering_mode) {
         case TamperProofMode::Shift:


### PR DESCRIPTION
First PR to turn the current version of the Merge in the [optimised](https://hackmd.io/Hv1jZWj8RXeubCZ2ISsKKg?view) (for number of ECC rows) version.

This performs the degree check on the left tables via batching: instead of checking the degree of each left table in the merge, we batch them with random challenges, and check that the degree of the batched polynomial is smaller than some given constant. This saves 33 rows per Merge.