### PR TITLE
feat: Store txHash and blockHash in private event storage

### DIFF
--- a/yarn-project/pxe/src/contract_function_simulator/pxe_oracle_interface.test.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/pxe_oracle_interface.test.ts
@@ -611,7 +611,7 @@ describe('PXEOracleInterface', () => {
       );
 
       expect(result.length).toEqual(1);
-      expect(result[0]).toEqual(eventContent);
+      expect(result[0].msgContent).toEqual(eventContent);
     });
   });
 

--- a/yarn-project/pxe/src/contract_function_simulator/pxe_oracle_interface.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/pxe_oracle_interface.ts
@@ -833,7 +833,8 @@ export class PXEOracleInterface implements ExecutionDataProvider {
       content,
       txHash,
       Number(nullifierIndex.data), // Index of the event commitment in the nullifier tree
-      nullifierIndex.l2BlockNumber, // Block in which the event was emitted
+      nullifierIndex.l2BlockNumber, // Block number in which the event was emitted
+      nullifierIndex.l2BlockHash, // Block hash in which the event was emitted
     );
   }
 

--- a/yarn-project/pxe/src/pxe.ts
+++ b/yarn-project/pxe/src/pxe.ts
@@ -73,7 +73,10 @@ import { AddressDataProvider } from './storage/address_data_provider/address_dat
 import { CapsuleDataProvider } from './storage/capsule_data_provider/capsule_data_provider.js';
 import { ContractDataProvider } from './storage/contract_data_provider/contract_data_provider.js';
 import { NoteDataProvider } from './storage/note_data_provider/note_data_provider.js';
-import { PrivateEventDataProvider } from './storage/private_event_data_provider/private_event_data_provider.js';
+import {
+  type PrivateEvent,
+  PrivateEventDataProvider,
+} from './storage/private_event_data_provider/private_event_data_provider.js';
 import { SyncDataProvider } from './storage/sync_data_provider/sync_data_provider.js';
 import { TaggingDataProvider } from './storage/tagging_data_provider/tagging_data_provider.js';
 import { Synchronizer } from './synchronizer/index.js';
@@ -1094,7 +1097,9 @@ export class PXE {
       eventMetadataDef.eventSelector,
     );
 
-    const decodedEvents = events.map((event: Fr[]): T => decodeFromAbi([eventMetadataDef.abiType], event) as T);
+    const decodedEvents = events.map(
+      (event: PrivateEvent): T => decodeFromAbi([eventMetadataDef.abiType], event.msgContent) as T,
+    );
 
     return decodedEvents;
   }


### PR DESCRIPTION
First part of F-96 (about returning event metadata)

We want the PXE to expose some event metadata (mainly tx hash, block number, and block hash) to wallets.

I plan to tackle this in little self contained PR's. This first PR only affects internals, but not APIs: it modifies the PXE's private event store to store tx hash and block hash for later consumption.

I'm introducing a `PrivateEvent` type which for now is an implementation detail as it is swallowed by PXE. But eventually it could be lifted to the PXE API. 

I'm not yet familliarized enough with criteria for types to be defined and made available by stdlib or Aztec.js, it might make sense to eventually have a re-usable `PrivateEvent` type _somewhere over there_, but one thing at a time.

There's also a very mildly annoying amount of duplication in `private_event_data_provider.test.ts` which I'm contributing to with this PR, but I'm opting to tackle that in subsequent PRs as I work on a more mature API.

 