### PR TITLE
chore: resolve biggroup AUDITTODOs

### DIFF
--- a/barretenberg/cpp/src/barretenberg/boomerang_value_detection/graph_description_goblin.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/boomerang_value_detection/graph_description_goblin.test.cpp
@@ -105,10 +105,8 @@ TEST_F(BoomerangGoblinRecursiveVerifierTests, graph_description_basic)
     auto translator_pairing_points = output.points_accumulator;
     // BIGGROUP_AUDITTODO: It seems suspicious that we have to fix these witnesses here to make this test pass. Seems to
     // defeat the purpose of the test.
-    translator_pairing_points.P0.x().fix_witness();
-    translator_pairing_points.P0.y().fix_witness();
-    translator_pairing_points.P1.x().fix_witness();
-    translator_pairing_points.P1.y().fix_witness();
+    translator_pairing_points.P0.fix_witness();
+    translator_pairing_points.P1.fix_witness();
     info("Recursive Verifier: num gates = ", builder.num_gates());
     auto graph = cdg::StaticAnalyzer(builder, false);
     auto variables_in_one_gate = graph.get_variables_in_one_gate();

--- a/barretenberg/cpp/src/barretenberg/boomerang_value_detection/graph_description_goblin.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/boomerang_value_detection/graph_description_goblin.test.cpp
@@ -103,8 +103,13 @@ TEST_F(BoomerangGoblinRecursiveVerifierTests, graph_description_basic)
         ASSERT_TRUE(verified);
     }
     auto translator_pairing_points = output.points_accumulator;
-    // BIGGROUP_AUDITTODO: It seems suspicious that we have to fix these witnesses here to make this test pass. Seems to
-    // defeat the purpose of the test.
+
+    // The pairing points are public outputs from the recursive verifier that will be verified externally via a pairing
+    // check. While they are computed within the circuit (via batch_mul for P0 and negation for P1), their output
+    // coordinates may not appear in multiple constraint gates. Calling fix_witness() adds explicit constraints on these
+    // values. Without these constraints, the StaticAnalyzer detects 20 variables (the coordinate limbs) that appear in
+    // only one gate. This ensures the pairing point coordinates are properly constrained within the circuit itself,
+    // rather than relying solely on them being public outputs.
     translator_pairing_points.P0.fix_witness();
     translator_pairing_points.P1.fix_witness();
     info("Recursive Verifier: num gates = ", builder.num_gates());

--- a/barretenberg/cpp/src/barretenberg/boomerang_value_detection/graph_description_ultra_recursive_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/boomerang_value_detection/graph_description_ultra_recursive_verifier.test.cpp
@@ -118,8 +118,13 @@ template <typename RecursiveFlavor> class BoomerangRecursiveVerifierTest : publi
         StdlibProof stdlib_inner_proof(outer_circuit, inner_proof);
         VerifierOutput output = verifier.template verify_proof<DefaultIO<OuterBuilder>>(stdlib_inner_proof);
         PairingObject pairing_points = output.points_accumulator;
-        // BIGGROUP_AUDITTODO: It seems suspicious that we have to fix these witnesses here to make this test pass.
-        // Seems to defeat the purpose of the test.
+
+        // The pairing points are public outputs from the recursive verifier that will be verified externally via a
+        // pairing check. While they are computed within the circuit (via batch_mul for P0 and negation for P1), their
+        // output coordinates may not appear in multiple constraint gates. Calling fix_witness() adds explicit
+        // constraints on these values. Without these constraints, the StaticAnalyzer detects unconstrained variables
+        // (coordinate limbs) that appear in only one gate. This ensures the pairing point coordinates are properly
+        // constrained within the circuit itself, rather than relying solely on them being public outputs.
         pairing_points.P0.fix_witness();
         pairing_points.P1.fix_witness();
         if constexpr (HasIPAAccumulator<OuterFlavor>) {

--- a/barretenberg/cpp/src/barretenberg/boomerang_value_detection/graph_description_ultra_recursive_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/boomerang_value_detection/graph_description_ultra_recursive_verifier.test.cpp
@@ -120,10 +120,8 @@ template <typename RecursiveFlavor> class BoomerangRecursiveVerifierTest : publi
         PairingObject pairing_points = output.points_accumulator;
         // BIGGROUP_AUDITTODO: It seems suspicious that we have to fix these witnesses here to make this test pass.
         // Seems to defeat the purpose of the test.
-        pairing_points.P0.x().fix_witness();
-        pairing_points.P0.y().fix_witness();
-        pairing_points.P1.x().fix_witness();
-        pairing_points.P1.y().fix_witness();
+        pairing_points.P0.fix_witness();
+        pairing_points.P1.fix_witness();
         if constexpr (HasIPAAccumulator<OuterFlavor>) {
             output.ipa_claim.set_public();
             outer_circuit.ipa_proof = output.ipa_proof.get_value();

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/ecdsa_constraints.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/ecdsa_constraints.cpp
@@ -78,6 +78,9 @@ void create_ecdsa_verify_constraints(typename Curve::Builder& builder,
         }
 
         // Set public key to 2*generator when predicate is false
+        // The choice of 2*generator is arbitrary; it just needs to be a valid point on the curve and different from G
+        // or (-G). For secp256r1, the batch multiplication requires that the two points do not have the same x
+        // coordinate (so as to create a valid lookup table).
         // Compute as native type to get byte representation
         typename Curve::AffineElementNative default_point_native(Curve::g1::one + Curve::g1::one);
         std::array<uint8_t, 32> default_x_bytes;

--- a/barretenberg/cpp/src/barretenberg/stdlib/encryption/ecdsa/ecdsa_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/encryption/ecdsa/ecdsa_impl.hpp
@@ -137,7 +137,6 @@ bool_t<Builder> ecdsa_verify_signature(const stdlib::byte_array<Builder>& hashed
     // Step 8.
     // We reduce result.x() to 2^s, where s is the smallest s.t. 2^s > q. It is cheap in terms of constraints, and
     // avoids possible edge cases
-    // BIGGROUP_AUDITTODO: mutable accessor needed for self_reduce()
     result.x().reduce_mod_target_modulus();
 
     // Transfer Fq value result.x() to Fr (this is just moving from a C++ class to another)

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
@@ -578,6 +578,15 @@ template <typename Builder, typename T> class bigfield {
     void assert_is_not_equal(const bigfield& other,
                              std::string const& msg = "bigfield: prime limb diff is zero, but expected non-zero") const;
 
+    /**
+     * @brief Reduce the bigfield element modulo the target modulus.
+     * @details This function modifies the bigfield element in place to ensure that it is reduced modulo the target
+     * modulus. It is marked as `const` because it modifies the internal state of the bigfield element without changing
+     * its logical value.
+     *
+     * @warning This function does not enforce that the reduced value is < p (the target modulus), it instead enforces
+     * that the reduced value < 2^s for smallest s with 2^s > p.
+     */
     void self_reduce() const;
 
     /**

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup.hpp
@@ -384,9 +384,6 @@ template <class Builder_, class Fq, class Fr, class NativeGroup> class element {
     // Coordinate accessors (non-owning, const reference)
     const Fq& x() const { return _x; }
     const Fq& y() const { return _y; }
-    // BIGGROUP_AUDITTODO: Remove these non-const accessors by adding explicit methods for mutation where required.
-    Fq& x() { return _x; }
-    Fq& y() { return _y; }
 
     bool_ct is_point_at_infinity() const { return _is_infinity; }
     void set_point_at_infinity(const bool_ct& is_infinity, const bool& add_to_used_witnesses = false)


### PR DESCRIPTION
Resolves/removes biggroup audit-todos:
- Removed mutable `x()` and `y()` accessors from `element<>` class
    - Replaced direct coordinate manipulation with `conditional_select()` method
- Clarified why `fix_witness()` is needed in recursive verifier tests (because the pairing points need to be explicitly constrained to avoid appearing in only one gate)

