### PR TITLE
fix: ensure empty BlockConstraints are handled gracefully in dsl

### DIFF
--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/block_constraint.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/block_constraint.cpp
@@ -93,7 +93,7 @@ void create_block_constraints(MegaCircuitBuilder& builder,
         process_call_data_operations(builder, constraint, has_valid_witness_assignments, init);
     } break;
     case BlockType::ReturnData: {
-        process_return_data_operations(constraint, init);
+        process_return_data_operations(builder, constraint, init);
     } break;
     default:
         throw_or_abort("Unexpected block constraint type.");
@@ -169,6 +169,7 @@ void process_call_data_operations(Builder& builder,
 
     // Method for processing operations on a generic databus calldata array
     auto process_calldata = [&](auto& calldata_array) {
+        calldata_array.set_context(&builder);
         calldata_array.set_values(init); // Initialize the data in the bus array
 
         for (const auto& op : constraint.trace) {
@@ -195,11 +196,15 @@ void process_call_data_operations(Builder& builder,
 }
 
 template <typename Builder>
-void process_return_data_operations(const BlockConstraint& constraint, std::vector<bb::stdlib::field_t<Builder>>& init)
+void process_return_data_operations(Builder& builder,
+                                    const BlockConstraint& constraint,
+                                    std::vector<bb::stdlib::field_t<Builder>>& init)
 {
     using databus_ct = stdlib::databus<Builder>;
 
     databus_ct databus;
+
+    databus.return_data.set_context(&builder);
     // Populate the returndata in the databus
     databus.return_data.set_values(init);
     // For each entry of the return data, explicitly assert equality with the initialization value. This implicitly

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/block_constraint.hpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/block_constraint.hpp
@@ -52,7 +52,9 @@ void process_call_data_operations(Builder& builder,
                                   bool has_valid_witness_assignments,
                                   std::vector<bb::stdlib::field_t<Builder>>& init);
 template <typename Builder>
-void process_return_data_operations(const BlockConstraint& constraint, std::vector<bb::stdlib::field_t<Builder>>& init);
+void process_return_data_operations(Builder& builder,
+                                    const BlockConstraint& constraint,
+                                    std::vector<bb::stdlib::field_t<Builder>>& init);
 
 template <typename B> inline void read(B& buf, MemOp& mem_op)
 {

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/block_constraint.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/block_constraint.test.cpp
@@ -255,3 +255,36 @@ TEST_F(MegaHonk, DatabusReturn)
 
     EXPECT_TRUE(CircuitChecker::check(circuit));
 }
+
+// Test that all block constraint types handle empty initialization gracefully
+TEST_F(MegaHonk, EmptyBlockConstraints)
+{
+    // Test each block constraint type
+    std::vector<BlockType> types_to_test = {
+        BlockType::ROM, BlockType::RAM, BlockType::CallData, BlockType::ReturnData
+    };
+
+    // Create empty block constraint
+    for (auto block_type : types_to_test) {
+        BlockConstraint block{
+            .init = {},  // Empty initialization data
+            .trace = {}, // Empty trace
+            .type = block_type,
+        };
+
+        AcirProgram program;
+        program.constraints = {
+            .varnum = 0, // No variables needed for empty block constraints
+            .num_acir_opcodes = 1,
+            .public_inputs = {},
+            .block_constraints = { block },
+            .original_opcode_indices = create_empty_original_opcode_indices(),
+        };
+
+        mock_opcode_indices(program.constraints);
+
+        // Circuit construction should succeed without errors
+        auto circuit = create_circuit<Builder>(program);
+        EXPECT_TRUE(CircuitChecker::check(circuit));
+    }
+}

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/databus/databus.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/databus/databus.hpp
@@ -49,6 +49,7 @@ template <typename Builder> class databus {
 
         size_t size() const { return length; }
         Builder* get_context() const { return context; }
+        void set_context(Builder* builder_context) { context = builder_context; }
 
       private:
         mutable std::vector<field_pt> entries; // bus vector entries


### PR DESCRIPTION
Fixes reported assertion failure arising from processing empty `BlockConstraint`s. Observed in the wild with type `ReturnData` but issue was also present for `CallData`.

Observed in `wormhole::publish_message_in_private` function [here](https://github.com/wormhole-foundation/wormhole/blob/7060126e9d2d70bcaa9488d2659e9708a8d1f230/aztec/contracts/src/main.nr#L137).

 Details: Empty ReturnData constraint generated from noir program bytecode would crash with: `Assertion failed: (context != nullptr)`, specifically in `bus_vector::set_values()` which couldn't extract a Builder context from an empty initialization vector, leaving `context` as nullptr.

Solution: Explicitly set Builder context before calling `set_values()` in both ReturnData and CallData processing

Note: New test `EmptyBlockConstraints` verifies all 4 block types (ROM, RAM, CallData, ReturnData) handle empty init gracefully. (Fix was required for only CallData and ReturnData).