### PR TITLE
fix(avm_fuzzing): hotfix ts sim empty response

### DIFF
--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/simulator.cpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/simulator.cpp
@@ -82,8 +82,21 @@ SimulatorResult CppSimulator::simulate(const std::vector<uint8_t>& bytecode, con
 
 JsSimulator* JsSimulator::instance = nullptr;
 JsSimulator::JsSimulator(std::string& simulator_path)
-    : process("LOG_LEVEL=silent node " + simulator_path + " 2>/dev/null")
+    : simulator_path(simulator_path), process("LOG_LEVEL=silent node " + simulator_path + " 2>/dev/null")
 {}
+
+
+
+
+void JsSimulator::restart_simulator()
+{
+    if (instance == nullptr) {
+        throw std::runtime_error("JsSimulator should be initialized before restarting");
+    }
+    std::string simulator_path = instance->simulator_path;
+    delete instance;
+    instance = new JsSimulator(simulator_path);
+}
 
 JsSimulator* JsSimulator::getInstance()
 {
@@ -113,9 +126,19 @@ SimulatorResult JsSimulator::simulate(const std::vector<uint8_t>& bytecode, cons
     // Remove the newline character
     response.erase(response.find_last_not_of('\n') + 1);
 
-    // HACK
-    // decode_bytecode decodes base64 and ungzips it
-    std::vector<uint8_t> decoded_response = decode_bytecode(response);
+    std::vector<uint8_t> decoded_response;
+    // for some reason, the typescript simulator responds with an empty response (invalid gzip) one time in ~500k runs
+    // restarting the process if this happens
+    try {
+        // HACK: decode_bytecode decodes base64 and ungzips it
+        decoded_response = decode_bytecode(response);
+    } catch (const std::exception& e) {
+        std::cout << "Error decoding response: " << e.what() << std::endl;
+        std::cout << "Response: " << response << std::endl;
+        restart_simulator();
+
+        return simulate(bytecode, calldata);
+    }
     std::string response_string(decoded_response.begin(), decoded_response.end());
     json response_json = json::parse(response_string);
     bool reverted = response_json["reverted"];

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/simulator.cpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/simulator.cpp
@@ -82,11 +82,9 @@ SimulatorResult CppSimulator::simulate(const std::vector<uint8_t>& bytecode, con
 
 JsSimulator* JsSimulator::instance = nullptr;
 JsSimulator::JsSimulator(std::string& simulator_path)
-    : simulator_path(simulator_path), process("LOG_LEVEL=silent node " + simulator_path + " 2>/dev/null")
+    : simulator_path(simulator_path)
+    , process("LOG_LEVEL=silent node " + simulator_path + " 2>/dev/null")
 {}
-
-
-
 
 void JsSimulator::restart_simulator()
 {

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/simulator.hpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/simulator.hpp
@@ -36,6 +36,7 @@ class CppSimulator : public Simulator {
 class JsSimulator : public Simulator {
   protected:
     static JsSimulator* instance;
+    std::string simulator_path;
     JsSimulator(std::string& simulator_path);
     Process process;
 
@@ -48,6 +49,7 @@ class JsSimulator : public Simulator {
 
     static JsSimulator* getInstance();
     static void initialize(std::string& simulator_path);
+    static void restart_simulator();
 
     SimulatorResult simulate(const std::vector<uint8_t>& bytecode, const std::vector<FF>& calldata) override;
 };


### PR DESCRIPTION
I don't really know why this happens and I cannot catch it, because it happens ~1 time in 100k runs, so I just restart process, if the output of ts sim is not valid gzip