### PR TITLE
chore: pass cluster parameter

### DIFF
--- a/.github/workflows/deploy-network.yml
+++ b/.github/workflows/deploy-network.yml
@@ -138,6 +138,10 @@ jobs:
           ./scripts/install_deps.sh
           ./scripts/network_deploy.sh "${{ inputs.network }}"
 
+          if [ -n "$CLUSTER" ]; then
+            echo "CLUSTER=$CLUSTER" >> $GITHUB_OUTPUT
+          fi
+
       - name: Notify Slack on failure
         if: failure()
         env:
@@ -164,3 +168,4 @@ jobs:
     with:
       network: testnet
       l1_network: sepolia
+      cluster: ${{ env.CLUSTER }}


### PR DESCRIPTION
Update deployment workflow to pass the new `cluster` parameter to `deploy-irm`.