### PR TITLE
chore: Unify `add_to_witness_and_track_indices`

### DIFF
--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/ec_operations.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/ec_operations.cpp
@@ -1,5 +1,5 @@
 // === AUDIT STATUS ===
-// internal:    { status: not started, auditors: [], date: YYYY-MM-DD }
+// internal:    { status: Completed, auditors: [Federico], date: 2025-11-03 }
 // external_1:  { status: not started, auditors: [], date: YYYY-MM-DD }
 // external_2:  { status: not started, auditors: [], date: YYYY-MM-DD }
 // =====================

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/ec_operations.hpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/ec_operations.hpp
@@ -1,5 +1,5 @@
 // === AUDIT STATUS ===
-// internal:    { status: not started, auditors: [], date: YYYY-MM-DD }
+// internal:    { status: Completed, auditors: [Federico], date: 2025-11-03 }
 // external_1:  { status: not started, auditors: [], date: YYYY-MM-DD }
 // external_2:  { status: not started, auditors: [], date: YYYY-MM-DD }
 // =====================

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/ec_operations.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/ec_operations.test.cpp
@@ -81,8 +81,7 @@ template <typename Builder_, InputConstancy Constancy> class EcOperationsTesting
 
         // Construct result and predicate as witnesses
         std::vector<uint32_t> result_indices = add_to_witness_and_track_indices(witness_values, result);
-        uint32_t predicate_index = static_cast<uint32_t>(witness_values.size());
-        witness_values.emplace_back(FF::one()); // predicate
+        uint32_t predicate_index = add_to_witness_and_track_indices(witness_values, FF(1));
 
         // Build the constraint
         ec_add_constraint = EcAdd{

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/ecdsa_constraints.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/ecdsa_constraints.test.cpp
@@ -148,13 +148,9 @@ template <class Curve> class EcdsaTestingFunctions {
         std::array<uint32_t, 32> s_indices =
             add_to_witness_and_track_indices<uint8_t, 32>(witness_values, std::span(signature.s));
 
-        uint32_t result_index = static_cast<uint32_t>(witness_values.size());
-        bb::fr result = bb::fr::one();
-        witness_values.emplace_back(result);
+        uint32_t result_index = add_to_witness_and_track_indices(witness_values, bb::fr(1));
 
-        uint32_t predicate_index = static_cast<uint32_t>(witness_values.size());
-        bb::fr predicate = bb::fr::one();
-        witness_values.emplace_back(predicate);
+        uint32_t predicate_index = add_to_witness_and_track_indices(witness_values, bb::fr(1));
 
         // Restructure vectors into array
         std::array<uint32_t, 64> signature_indices;

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/honk_recursion_constraint.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/honk_recursion_constraint.test.cpp
@@ -174,65 +174,60 @@ template <typename RecursiveFlavor> class AcirHonkRecursionConstraint : public :
 
             uint32_t predicate_index = add_to_witness_and_track_indices(witness, predicate_val ? fr(1) : fr(0));
             auto predicate = WitnessOrConstant<fr>::from_index(predicate_index);
+
+            RecursionConstraint honk_recursion_constraint{
+                .key = key_indices,
+                .proof = proof_indices,
+                .public_inputs = inner_public_inputs,
+                .key_hash = key_hash_index,
+                .proof_type = proof_type,
+                .predicate = predicate,
+            };
+            honk_recursion_constraints.push_back(honk_recursion_constraint);
         }
 
-        RecursionConstraint honk_recursion_constraint{
-            .key = key_indices,
-            .proof = proof_indices,
-            .public_inputs = inner_public_inputs,
-            .key_hash = key_hash_index,
-            .proof_type = proof_type,
-            .predicate = predicate,
-        };
-        honk_recursion_constraints.push_back(honk_recursion_constraint);
+        AcirFormat constraint_system{};
+        constraint_system.varnum = static_cast<uint32_t>(witness.size());
+        constraint_system.num_acir_opcodes = static_cast<uint32_t>(honk_recursion_constraints.size());
+        constraint_system.honk_recursion_constraints = honk_recursion_constraints;
+        constraint_system.original_opcode_indices = create_empty_original_opcode_indices();
+
+        mock_opcode_indices(constraint_system);
+        bool constexpr has_ipa_claim = IsAnyOf<InnerFlavor, UltraRollupFlavor>;
+
+        ProgramMetadata metadata{ .has_ipa_claim = has_ipa_claim };
+        if (dummy_witnesses) {
+            witness = {}; // set it all to 0
+        }
+        AcirProgram program{ constraint_system, witness };
+        BuilderType outer_circuit = create_circuit<BuilderType>(program, metadata);
+
+        return outer_circuit;
     }
-
-    AcirFormat constraint_system{};
-    constraint_system.varnum = static_cast<uint32_t>(witness.size());
-    constraint_system.num_acir_opcodes = static_cast<uint32_t>(honk_recursion_constraints.size());
-    constraint_system.honk_recursion_constraints = honk_recursion_constraints;
-    constraint_system.original_opcode_indices = create_empty_original_opcode_indices();
-
-    mock_opcode_indices(constraint_system);
-    bool constexpr has_ipa_claim = IsAnyOf<InnerFlavor, UltraRollupFlavor>;
-
-    ProgramMetadata metadata{ .has_ipa_claim = has_ipa_claim };
-    if (dummy_witnesses) {
-        witness = {}; // set it all to 0
-    }
-    AcirProgram program{ constraint_system, witness };
-    BuilderType outer_circuit = create_circuit<BuilderType>(program, metadata);
-
-    return outer_circuit;
-}
 
     bool verify_proof(const std::shared_ptr<OuterProverInstance>& prover_instance,
                       const std::shared_ptr<OuterVerificationKey>& verification_key,
                       const HonkProof& proof)
-{
-    using IO = std::conditional_t<HasIPAAccumulator<RecursiveFlavor>, RollupIO, DefaultIO>;
+    {
+        using IO = std::conditional_t<HasIPAAccumulator<RecursiveFlavor>, RollupIO, DefaultIO>;
 
-    bool result = false;
+        bool result = false;
 
-    if constexpr (HasIPAAccumulator<RecursiveFlavor>) {
-        VerifierCommitmentKey<curve::Grumpkin> ipa_verification_key(1 << CONST_ECCVM_LOG_N);
-        OuterVerifier verifier(verification_key, ipa_verification_key);
-        result = verifier.template verify_proof<IO>(proof, prover_instance->ipa_proof).result;
-    } else {
-        OuterVerifier verifier(verification_key);
-        result = verifier.template verify_proof<IO>(proof).result;
+        if constexpr (HasIPAAccumulator<RecursiveFlavor>) {
+            VerifierCommitmentKey<curve::Grumpkin> ipa_verification_key(1 << CONST_ECCVM_LOG_N);
+            OuterVerifier verifier(verification_key, ipa_verification_key);
+            result = verifier.template verify_proof<IO>(proof, prover_instance->ipa_proof).result;
+        } else {
+            OuterVerifier verifier(verification_key);
+            result = verifier.template verify_proof<IO>(proof).result;
+        }
+
+        return result;
     }
 
-    return result;
-}
-
-protected:
-static void SetUpTestSuite()
-{
-    bb::srs::init_file_crs_factory(bb::srs::bb_crs_path());
-}
-}
-;
+  protected:
+    static void SetUpTestSuite() { bb::srs::init_file_crs_factory(bb::srs::bb_crs_path()); }
+};
 
 using Flavors = testing::Types<UltraRecursiveFlavor_<UltraCircuitBuilder>,
                                UltraRollupRecursiveFlavor_<UltraCircuitBuilder>,

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/honk_recursion_constraint.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/honk_recursion_constraint.test.cpp
@@ -1,6 +1,7 @@
 #include "honk_recursion_constraint.hpp"
 #include "acir_format.hpp"
 #include "acir_format_mocks.hpp"
+#include "barretenberg/dsl/acir_format/utils.hpp"
 #include "barretenberg/dsl/acir_format/witness_constant.hpp"
 #include "barretenberg/numeric/uint256/uint256.hpp"
 #include "barretenberg/special_public_inputs/special_public_inputs.hpp"
@@ -171,66 +172,67 @@ template <typename RecursiveFlavor> class AcirHonkRecursionConstraint : public :
                 ProofSurgeon<fr>::populate_recursion_witness_data(
                     witness, proof_witnesses, key_witnesses, key_hash_witness, num_public_inputs_to_extract);
 
-            auto predicate = WitnessOrConstant<fr>::from_index(static_cast<uint32_t>(witness.size()));
-            if (predicate_val) {
-                witness.push_back(fr(1));
-            } else {
-                witness.push_back(fr(0));
-            }
-
-            RecursionConstraint honk_recursion_constraint{
-                .key = key_indices,
-                .proof = proof_indices,
-                .public_inputs = inner_public_inputs,
-                .key_hash = key_hash_index,
-                .proof_type = proof_type,
-                .predicate = predicate,
-            };
-            honk_recursion_constraints.push_back(honk_recursion_constraint);
+            uint32_t predicate_index = add_to_witness_and_track_indices(witness, predicate_val ? fr(1) : fr(0));
+            auto predicate = WitnessOrConstant<fr>::from_index(predicate_index);
         }
 
-        AcirFormat constraint_system{};
-        constraint_system.varnum = static_cast<uint32_t>(witness.size());
-        constraint_system.num_acir_opcodes = static_cast<uint32_t>(honk_recursion_constraints.size());
-        constraint_system.honk_recursion_constraints = honk_recursion_constraints;
-        constraint_system.original_opcode_indices = create_empty_original_opcode_indices();
-
-        mock_opcode_indices(constraint_system);
-        bool constexpr has_ipa_claim = IsAnyOf<InnerFlavor, UltraRollupFlavor>;
-
-        ProgramMetadata metadata{ .has_ipa_claim = has_ipa_claim };
-        if (dummy_witnesses) {
-            witness = {}; // set it all to 0
-        }
-        AcirProgram program{ constraint_system, witness };
-        BuilderType outer_circuit = create_circuit<BuilderType>(program, metadata);
-
-        return outer_circuit;
+        RecursionConstraint honk_recursion_constraint{
+            .key = key_indices,
+            .proof = proof_indices,
+            .public_inputs = inner_public_inputs,
+            .key_hash = key_hash_index,
+            .proof_type = proof_type,
+            .predicate = predicate,
+        };
+        honk_recursion_constraints.push_back(honk_recursion_constraint);
     }
+
+    AcirFormat constraint_system{};
+    constraint_system.varnum = static_cast<uint32_t>(witness.size());
+    constraint_system.num_acir_opcodes = static_cast<uint32_t>(honk_recursion_constraints.size());
+    constraint_system.honk_recursion_constraints = honk_recursion_constraints;
+    constraint_system.original_opcode_indices = create_empty_original_opcode_indices();
+
+    mock_opcode_indices(constraint_system);
+    bool constexpr has_ipa_claim = IsAnyOf<InnerFlavor, UltraRollupFlavor>;
+
+    ProgramMetadata metadata{ .has_ipa_claim = has_ipa_claim };
+    if (dummy_witnesses) {
+        witness = {}; // set it all to 0
+    }
+    AcirProgram program{ constraint_system, witness };
+    BuilderType outer_circuit = create_circuit<BuilderType>(program, metadata);
+
+    return outer_circuit;
+}
 
     bool verify_proof(const std::shared_ptr<OuterProverInstance>& prover_instance,
                       const std::shared_ptr<OuterVerificationKey>& verification_key,
                       const HonkProof& proof)
-    {
-        using IO = std::conditional_t<HasIPAAccumulator<RecursiveFlavor>, RollupIO, DefaultIO>;
+{
+    using IO = std::conditional_t<HasIPAAccumulator<RecursiveFlavor>, RollupIO, DefaultIO>;
 
-        bool result = false;
+    bool result = false;
 
-        if constexpr (HasIPAAccumulator<RecursiveFlavor>) {
-            VerifierCommitmentKey<curve::Grumpkin> ipa_verification_key(1 << CONST_ECCVM_LOG_N);
-            OuterVerifier verifier(verification_key, ipa_verification_key);
-            result = verifier.template verify_proof<IO>(proof, prover_instance->ipa_proof).result;
-        } else {
-            OuterVerifier verifier(verification_key);
-            result = verifier.template verify_proof<IO>(proof).result;
-        }
-
-        return result;
+    if constexpr (HasIPAAccumulator<RecursiveFlavor>) {
+        VerifierCommitmentKey<curve::Grumpkin> ipa_verification_key(1 << CONST_ECCVM_LOG_N);
+        OuterVerifier verifier(verification_key, ipa_verification_key);
+        result = verifier.template verify_proof<IO>(proof, prover_instance->ipa_proof).result;
+    } else {
+        OuterVerifier verifier(verification_key);
+        result = verifier.template verify_proof<IO>(proof).result;
     }
 
-  protected:
-    static void SetUpTestSuite() { bb::srs::init_file_crs_factory(bb::srs::bb_crs_path()); }
-};
+    return result;
+}
+
+protected:
+static void SetUpTestSuite()
+{
+    bb::srs::init_file_crs_factory(bb::srs::bb_crs_path());
+}
+}
+;
 
 using Flavors = testing::Types<UltraRecursiveFlavor_<UltraCircuitBuilder>,
                                UltraRollupRecursiveFlavor_<UltraCircuitBuilder>,

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/multi_scalar_mul.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/multi_scalar_mul.test.cpp
@@ -1,7 +1,6 @@
 #include "multi_scalar_mul.hpp"
 #include "acir_format.hpp"
 #include "acir_format_mocks.hpp"
-
 #include "barretenberg/dsl/acir_format/test_class_predicate.hpp"
 #include "barretenberg/dsl/acir_format/utils.hpp"
 #include "barretenberg/stdlib/primitives/group/cycle_group.hpp"

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/proof_surgeon.hpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/proof_surgeon.hpp
@@ -120,11 +120,12 @@ template <typename FF> class ProofSurgeon {
             cut_public_inputs_from_proof(proof_witnesses, num_public_inputs_to_extract);
 
         // Append key, proof, and public inputs while storing the associated witness indices
-        std::vector<uint32_t> key_indices = add_to_witness_and_track_indices<FF>(witness, key_witnesses);
-        uint32_t key_hash_index = add_to_witness_and_track_indices<FF>(witness, { key_hash_witness });
-        std::vector<uint32_t> proof_indices = add_to_witness_and_track_indices<FF>(witness, proof_witnesses);
+        std::vector<uint32_t> key_indices = add_to_witness_and_track_indices<std::vector<FF>>(witness, key_witnesses);
+        uint32_t key_hash_index = add_to_witness_and_track_indices(witness, key_hash_witness);
+        std::vector<uint32_t> proof_indices =
+            add_to_witness_and_track_indices<std::vector<FF>>(witness, proof_witnesses);
         std::vector<uint32_t> public_input_indices =
-            add_to_witness_and_track_indices<FF>(witness, public_input_witnesses);
+            add_to_witness_and_track_indices<std::vector<FF>>(witness, public_input_witnesses);
 
         return { key_indices, key_hash_index, proof_indices, public_input_indices };
     }

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/proof_surgeon.hpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/proof_surgeon.hpp
@@ -121,8 +121,7 @@ template <typename FF> class ProofSurgeon {
 
         // Append key, proof, and public inputs while storing the associated witness indices
         std::vector<uint32_t> key_indices = add_to_witness_and_track_indices<FF>(witness, key_witnesses);
-        uint32_t key_hash_index = static_cast<uint32_t>(witness.size());
-        witness.emplace_back(key_hash_witness);
+        uint32_t key_hash_index = add_to_witness_and_track_indices<FF>(witness, { key_hash_witness });
         std::vector<uint32_t> proof_indices = add_to_witness_and_track_indices<FF>(witness, proof_witnesses);
         std::vector<uint32_t> public_input_indices =
             add_to_witness_and_track_indices<FF>(witness, public_input_witnesses);

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/test_class.hpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/test_class.hpp
@@ -166,10 +166,12 @@ template <TestBase Base> class TestClass {
      *
      * @tparam Flavor
      */
-    template <typename Flavor> static void test_vk_independence()
+    template <typename Flavor> static size_t test_vk_independence()
     {
         using ProverInstance = ProverInstance_<Flavor>;
         using VerificationKey = Flavor::VerificationKey;
+
+        size_t num_gates = 0;
 
         // Generate the constraint system
         auto [constraint, witness_values] = generate_constraints();
@@ -190,7 +192,7 @@ template <TestBase Base> class TestClass {
         {
             AcirProgram program{ constraint_system, witness_values };
             auto builder = create_circuit<Builder>(program);
-            info("Num gates: ", builder.get_num_finalized_gates_inefficient());
+            num_gates = builder.get_num_finalized_gates_inefficient();
 
             auto prover_instance = std::make_shared<ProverInstance>(builder);
             vk_from_witness = std::make_shared<VerificationKey>(prover_instance->get_precomputed());
@@ -208,6 +210,8 @@ template <TestBase Base> class TestClass {
         }
 
         EXPECT_EQ(*vk_from_witness, *vk_from_constraint) << "Mismatch in the vks";
+
+        return num_gates;
     }
 
     /**

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/test_class_predicate.hpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/test_class_predicate.hpp
@@ -205,7 +205,7 @@ template <TestBaseWithPredicate Base> class TestClassWithPredicate {
         using ProverInstance = ProverInstance_<Flavor>;
         using VerificationKey = Flavor::VerificationKey;
 
-        std::vector<size_t> num_rows;
+        std::vector<size_t> num_gates;
 
         for (auto [predicate_case, label] :
              zip_view(Predicate<WitnessOverrideCase>::get_all(), Predicate<WitnessOverrideCase>::get_labels())) {
@@ -232,7 +232,7 @@ template <TestBaseWithPredicate Base> class TestClassWithPredicate {
             {
                 AcirProgram program{ constraint_system, witness_values };
                 auto builder = create_circuit<Builder>(program);
-                num_rows.emplace_back(builder.get_num_finalized_gates_inefficient());
+                num_gates.emplace_back(builder.get_num_finalized_gates_inefficient());
 
                 auto prover_instance = std::make_shared<ProverInstance>(builder);
                 vk_from_witness = std::make_shared<VerificationKey>(prover_instance->get_precomputed());
@@ -253,7 +253,7 @@ template <TestBaseWithPredicate Base> class TestClassWithPredicate {
             vinfo("VK independence passed for predicate case: ", label);
         }
 
-        return num_rows;
+        return num_gates;
     }
 
     /**

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/test_class_predicate.hpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/test_class_predicate.hpp
@@ -200,10 +200,12 @@ template <TestBaseWithPredicate Base> class TestClassWithPredicate {
      *
      * @tparam Flavor
      */
-    template <typename Flavor> static void test_vk_independence()
+    template <typename Flavor> static std::vector<size_t> test_vk_independence()
     {
         using ProverInstance = ProverInstance_<Flavor>;
         using VerificationKey = Flavor::VerificationKey;
+
+        std::vector<size_t> num_rows;
 
         for (auto [predicate_case, label] :
              zip_view(Predicate<WitnessOverrideCase>::get_all(), Predicate<WitnessOverrideCase>::get_labels())) {
@@ -230,7 +232,7 @@ template <TestBaseWithPredicate Base> class TestClassWithPredicate {
             {
                 AcirProgram program{ constraint_system, witness_values };
                 auto builder = create_circuit<Builder>(program);
-                info("Num gates: ", builder.get_num_finalized_gates_inefficient());
+                num_rows.emplace_back(builder.get_num_finalized_gates_inefficient());
 
                 auto prover_instance = std::make_shared<ProverInstance>(builder);
                 vk_from_witness = std::make_shared<VerificationKey>(prover_instance->get_precomputed());
@@ -250,6 +252,8 @@ template <TestBaseWithPredicate Base> class TestClassWithPredicate {
             EXPECT_EQ(*vk_from_witness, *vk_from_constraint) << "Mismatch in the vks for predicate case " << label;
             vinfo("VK independence passed for predicate case: ", label);
         }
+
+        return num_rows;
     }
 
     /**

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/utils.hpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/utils.hpp
@@ -62,52 +62,10 @@ template <typename Builder> byte_array<Builder> fields_to_bytes(Builder& builder
  * @brief Append values to a witness vector and track their indices.
  *
  * @details This function is useful in mocking situations, when we need to add dummy variables to a builder.
- * @tparam T
- * @param witness
- * @param input
- * @return std::vector<uint32_t>
- */
-template <typename T>
-std::vector<uint32_t> add_to_witness_and_track_indices(WitnessVector& witness, std::span<const T> input)
-{
-    std::vector<uint32_t> indices;
-    indices.reserve(input.size());
-    auto witness_idx = static_cast<uint32_t>(witness.size());
-    for (const auto& value : input) {
-        witness.push_back(bb::fr(value));
-        indices.push_back(witness_idx++);
-    }
-    return indices;
-};
-
-/**
- * @brief Append values to a witness vector and track their indices.
- *
- * @details This function is useful in mocking situations, when we need to add dummy variables to a builder.
- *
- * @tparam T
- * @tparam N
- * @param witness
- * @param input
- * @return std::array<uint32_t, N>
- */
-template <typename T, std::size_t N>
-std::array<uint32_t, N> add_to_witness_and_track_indices(WitnessVector& witness, std::span<const T> input)
-{
-    std::array<uint32_t, N> indices;
-    auto witness_idx = static_cast<uint32_t>(witness.size());
-    size_t idx = 0;
-    for (const auto& value : input) {
-        witness.push_back(bb::fr(value));
-        indices[idx++] = witness_idx++;
-    }
-    return indices;
-};
-
-/**
- * @brief Append input to a witness vector and track indices
- *
- * @details This function is useful in testing situations, it is meant to be extended to support the types required.
+ * @tparam T The input type
+ * @param witness The witness vector to append to
+ * @param input The input value(s) - either a span of values or a single special type
+ * @return std::vector<uint32_t> The witness indices of the appended values
  */
 template <typename T> std::vector<uint32_t> add_to_witness_and_track_indices(WitnessVector& witness, const T& input)
 {
@@ -120,8 +78,39 @@ template <typename T> std::vector<uint32_t> add_to_witness_and_track_indices(Wit
         witness.emplace_back(input.y);
         indices.emplace_back(witness.size());
         witness.emplace_back(input.is_point_at_infinity() ? bb::fr(1) : bb::fr(0));
+    } else {
+        // If no other type is matched, we assume T is a span of values
+        indices.reserve(input.size());
+        auto witness_idx = static_cast<uint32_t>(witness.size());
+        for (const auto& value : input) {
+            witness.push_back(bb::fr(value));
+            indices.push_back(witness_idx++);
+        }
     }
 
+    return indices;
+};
+
+/**
+ * @brief Add a single value to the witness vector and track its index.
+ */
+inline uint32_t add_to_witness_and_track_indices(WitnessVector& witness, const bb::fr& input)
+{
+    uint32_t index = static_cast<uint32_t>(witness.size());
+    witness.emplace_back(input);
+
+    return index;
+}
+
+/**
+ * @brief Add a span of values to the witness and track their indices, returning them as a fixed-size array.
+ */
+template <typename T, size_t N>
+std::array<uint32_t, N> add_to_witness_and_track_indices(WitnessVector& witness, const std::span<T> input)
+{
+    std::vector<uint32_t> tracked_indices = add_to_witness_and_track_indices(witness, input);
+    std::array<uint32_t, N> indices;
+    std::ranges::copy(tracked_indices, indices.begin());
     return indices;
 };
 


### PR DESCRIPTION
Unify the methods `add_to_witness_and_track_indices`, add audit tracking to `ec_operations`, remove `num_gates` info and return the counts instead
