### PR TITLE
feat!: Refactor Merge to optimise the number of rows used

### DIFF
--- a/barretenberg/cpp/scripts/test_chonk_standalone_vks_havent_changed.sh
+++ b/barretenberg/cpp/scripts/test_chonk_standalone_vks_havent_changed.sh
@@ -13,7 +13,7 @@ cd ..
 # - Generate a hash for versioning: sha256sum bb-chonk-inputs.tar.gz
 # - Upload the compressed results: aws s3 cp bb-chonk-inputs.tar.gz s3://aztec-ci-artifacts/protocol/bb-chonk-inputs-[hash(0:8)].tar.gz
 # Note: In case of the "Test suite failed to run ... Unexpected token 'with' " error, need to run: docker pull aztecprotocol/build:3.0
-pinned_short_hash="7450f0e4"
+pinned_short_hash="899b8b56"
 pinned_chonk_inputs_url="https://aztec-ci-artifacts.s3.us-east-2.amazonaws.com/protocol/bb-chonk-inputs-${pinned_short_hash}.tar.gz"
 
 function compress_and_upload {

--- a/barretenberg/cpp/scripts/test_chonk_standalone_vks_havent_changed.sh
+++ b/barretenberg/cpp/scripts/test_chonk_standalone_vks_havent_changed.sh
@@ -13,7 +13,7 @@ cd ..
 # - Generate a hash for versioning: sha256sum bb-chonk-inputs.tar.gz
 # - Upload the compressed results: aws s3 cp bb-chonk-inputs.tar.gz s3://aztec-ci-artifacts/protocol/bb-chonk-inputs-[hash(0:8)].tar.gz
 # Note: In case of the "Test suite failed to run ... Unexpected token 'with' " error, need to run: docker pull aztecprotocol/build:3.0
-pinned_short_hash="02961955"
+pinned_short_hash="7450f0e4"
 pinned_chonk_inputs_url="https://aztec-ci-artifacts.s3.us-east-2.amazonaws.com/protocol/bb-chonk-inputs-${pinned_short_hash}.tar.gz"
 
 function compress_and_upload {

--- a/barretenberg/cpp/src/barretenberg/boomerang_value_detection/graph_description_merge_recursive_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/boomerang_value_detection/graph_description_merge_recursive_verifier.test.cpp
@@ -91,7 +91,10 @@ template <class RecursiveBuilder> class BoomerangRecursiveMergeVerifierTest : pu
         auto merge_transcript = std::make_shared<StdlibTranscript<RecursiveBuilder>>();
         RecursiveMergeVerifier verifier{ settings, merge_transcript };
         const stdlib::Proof<RecursiveBuilder> stdlib_merge_proof(outer_circuit, merge_proof);
-        [[maybe_unused]] auto [pairing_points, recursive_merged_table_commitments, degree_check_verified] =
+        [[maybe_unused]] auto [pairing_points,
+                               recursive_merged_table_commitments,
+                               degree_check_verified,
+                               concatenation_check_verified] =
             verifier.verify_proof(stdlib_merge_proof, recursive_merge_commitments);
 
         // Check for a failure flag in the recursive verifier circuit

--- a/barretenberg/cpp/src/barretenberg/chonk/chonk.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/chonk/chonk.test.cpp
@@ -316,7 +316,7 @@ HEAVY_TEST(ChonkKernelCapacity, MaxCapacityPassing)
 {
     bb::srs::init_file_crs_factory(bb::srs::bb_crs_path());
 
-    const size_t NUM_APP_CIRCUITS = 28;
+    const size_t NUM_APP_CIRCUITS = 31;
     auto [proof, vk] = ChonkTests::accumulate_and_prove_ivc(NUM_APP_CIRCUITS);
 
     bool verified = Chonk::verify(proof, vk);

--- a/barretenberg/cpp/src/barretenberg/chonk/chonk.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/chonk/chonk.test.cpp
@@ -316,7 +316,7 @@ HEAVY_TEST(ChonkKernelCapacity, MaxCapacityPassing)
 {
     bb::srs::init_file_crs_factory(bb::srs::bb_crs_path());
 
-    const size_t NUM_APP_CIRCUITS = 27;
+    const size_t NUM_APP_CIRCUITS = 28;
     auto [proof, vk] = ChonkTests::accumulate_and_prove_ivc(NUM_APP_CIRCUITS);
 
     bool verified = Chonk::verify(proof, vk);

--- a/barretenberg/cpp/src/barretenberg/chonk/mock_circuit_producer.hpp
+++ b/barretenberg/cpp/src/barretenberg/chonk/mock_circuit_producer.hpp
@@ -220,9 +220,18 @@ class PrivateFunctionExecutionMockCircuitProducer {
                 }
             } else {
                 if (is_kernel) {
-                    BB_ASSERT_EQ(log2_dyadic_size,
-                                 18UL,
-                                 "There has been a change in the number of gates of a mock kernel circuit.");
+                    // Trailing kernels (reset, tail, hiding) are simpler than regular kernels
+                    if (is_trailing_kernel) {
+                        // Trailing kernels should be significantly smaller, with hiding kernel < 2^16
+                        BB_ASSERT_LTE(log2_dyadic_size,
+                                      16UL,
+                                      "Trailing kernel circuit size has exceeded expected bound (should be <= 2^16).");
+                        vinfo("Log number of gates in a trailing kernel circuit is: ", log2_dyadic_size);
+                    } else {
+                        BB_ASSERT_EQ(log2_dyadic_size,
+                                     18UL,
+                                     "There has been a change in the number of gates of a mock kernel circuit.");
+                    }
                 } else {
                     BB_ASSERT_EQ(log2_dyadic_size,
                                  use_large_circuit ? 19UL : 17UL,

--- a/barretenberg/cpp/src/barretenberg/chonk/mock_circuit_producer.hpp
+++ b/barretenberg/cpp/src/barretenberg/chonk/mock_circuit_producer.hpp
@@ -167,6 +167,8 @@ class PrivateFunctionExecutionMockCircuitProducer {
     {
         const bool is_kernel = is_kernel_flags[circuit_counter++];
         const bool use_large_circuit = large_first_app && (circuit_counter == 1); // first circuit is size 2^19
+        // Check if this is one of the trailing kernels (reset, tail, hiding)
+        const bool is_trailing_kernel = (ivc.num_circuits_accumulated >= ivc.get_num_circuits() - NUM_TRAILING_KERNELS);
 
         ClientCircuit circuit{ ivc.goblin.op_queue };
         // if the number of gates is specified we just add a number of arithmetic gates
@@ -179,8 +181,12 @@ class PrivateFunctionExecutionMockCircuitProducer {
         } else {
             // If the number of gates is not specified we create a structured mock circuit
             if (is_kernel) {
-                GoblinMockCircuits::construct_mock_folding_kernel(circuit); // construct mock base logic
-                mock_databus.populate_kernel_databus(circuit);              // populate databus inputs/outputs
+                // For trailing kernels (reset, tail, hiding), skip the expensive mock kernel logic to match real Noir
+                // flows. These kernels are simpler and mainly contain the completion logic added by Chonk.
+                if (!is_trailing_kernel) {
+                    GoblinMockCircuits::construct_mock_folding_kernel(circuit); // construct mock base logic
+                }
+                mock_databus.populate_kernel_databus(circuit); // populate databus inputs/outputs
             } else {
                 GoblinMockCircuits::construct_mock_app_circuit(circuit, use_large_circuit); // construct mock app
                 mock_databus.populate_app_databus(circuit);                                 // populate databus outputs

--- a/barretenberg/cpp/src/barretenberg/constants.hpp
+++ b/barretenberg/cpp/src/barretenberg/constants.hpp
@@ -48,7 +48,7 @@ static constexpr uint32_t NUM_LIBRA_COMMITMENTS = 3;
 // extra evaluations
 static constexpr uint32_t NUM_SMALL_IPA_EVALUATIONS = 4;
 
-static constexpr uint32_t MERGE_PROOF_SIZE = 34; // used to ensure mock proofs are generated correctly
+static constexpr uint32_t MERGE_PROOF_SIZE = 42; // used to ensure mock proofs are generated correctly
 
 // There are 5 distinguished wires in ECCVM that have to be opened as univariates to establish the connection between
 // ECCVM and Translator

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/mock_verifier_inputs.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/mock_verifier_inputs.cpp
@@ -340,16 +340,11 @@ Goblin::MergeProof create_mock_merge_proof()
     // Populate mock shift size
     populate_field_elements<fr>(proof, 1, /*value=*/fr{ mock_shift_size });
 
-    // There are 5 entities in the merge protocol (4 columns: T_j, one column g(X) = \sum_i alpha_i X^{l-1} t_j(X))
-    // and 5 evaluations (g(kappa), t_j(1/kappa))
-    const size_t NUM_TRANSCRIPT_ENTITIES = 5;
-    const size_t NUM_TRANSCRIPT_EVALUATIONS = 5;
+    // Populate mock merged table commitments and batched degree check polynomial commitment
+    populate_field_elements_for_mock_commitments(proof, 5);
 
-    // Transcript poly commitments
-    populate_field_elements_for_mock_commitments(proof, NUM_TRANSCRIPT_ENTITIES);
-
-    // Transcript poly evaluations
-    populate_field_elements(proof, NUM_TRANSCRIPT_EVALUATIONS);
+    // Populate evaluations (3 * NUM_WIRES + 1: left, right, and merged tables, plus batched degree check polynomial)
+    populate_field_elements(proof, 13);
 
     // Shplonk proof: commitment to the quotient
     populate_field_elements_for_mock_commitments(proof, 1);

--- a/barretenberg/cpp/src/barretenberg/goblin/goblin.cpp
+++ b/barretenberg/cpp/src/barretenberg/goblin/goblin.cpp
@@ -54,7 +54,7 @@ GoblinProof Goblin::prove(const MergeSettings merge_settings)
     BB_BENCH_NAME("Goblin::prove");
 
     prove_merge(transcript, merge_settings); // Use shared transcript for merge proving
-    info("Constructing a Goblin proof with num ultra ops = ", op_queue->get_ultra_ops_table_num_rows());
+    info("Goblin: num ultra ops = ", op_queue->get_ultra_ops_count());
 
     BB_ASSERT_EQ(merge_verification_queue.size(),
                  1U,

--- a/barretenberg/cpp/src/barretenberg/goblin/goblin.cpp
+++ b/barretenberg/cpp/src/barretenberg/goblin/goblin.cpp
@@ -82,7 +82,7 @@ std::pair<Goblin::PairingPoints, Goblin::RecursiveTableCommitments> Goblin::recu
     const stdlib::Proof<MegaBuilder> stdlib_merge_proof(builder, merge_proof);
 
     MergeRecursiveVerifier merge_verifier{ merge_settings, transcript };
-    auto [pairing_points, merged_table_commitments, degree_check_passed] =
+    auto [pairing_points, merged_table_commitments, degree_check_passed, concatenation_check_passed] =
         merge_verifier.verify_proof(stdlib_merge_proof, merge_commitments);
 
     merge_verification_queue.pop_front(); // remove the processed proof from the queue
@@ -96,9 +96,9 @@ bool Goblin::verify(const GoblinProof& proof,
                     const MergeSettings merge_settings)
 {
     MergeVerifier merge_verifier(merge_settings, transcript);
-    auto [merge_pairing_points, merged_table_commitments, degree_check_passed] =
+    auto [merge_pairing_points, merged_table_commitments, degree_check_passed, concatenation_check_passed] =
         merge_verifier.verify_proof(proof.merge_proof, merge_commitments);
-    bool merge_verified = merge_pairing_points.check() && degree_check_passed;
+    bool merge_verified = merge_pairing_points.check() && degree_check_passed && concatenation_check_passed;
 
     ECCVMVerifier eccvm_verifier(transcript);
     bool eccvm_verified = eccvm_verifier.verify_proof(proof.eccvm_proof);

--- a/barretenberg/cpp/src/barretenberg/op_queue/ecc_op_queue.hpp
+++ b/barretenberg/cpp/src/barretenberg/op_queue/ecc_op_queue.hpp
@@ -98,6 +98,7 @@ class ECCOpQueue {
     void construct_full_ultra_ops_table() { ultra_ops_reconstructed = ultra_ops_table.get_reconstructed(); }
 
     size_t get_ultra_ops_table_num_rows() const { return ultra_ops_table.ultra_table_size(); }
+    size_t get_ultra_ops_count() const { return ultra_ops_table.size(); } // actual operation count without padding
     size_t get_current_ultra_ops_subtable_num_rows() const { return ultra_ops_table.current_ultra_subtable_size(); }
     size_t get_previous_ultra_ops_table_num_rows() const { return ultra_ops_table.previous_ultra_table_size(); }
 

--- a/barretenberg/cpp/src/barretenberg/op_queue/ecc_ops_table.hpp
+++ b/barretenberg/cpp/src/barretenberg/op_queue/ecc_ops_table.hpp
@@ -302,6 +302,8 @@ class UltraEccOpsTable {
         if (has_fixed_append && fixed_append_offset.has_value()) {
             size_t current_size = reconstructed_table.size();
             size_t target_offset = fixed_append_offset.value();
+            BB_ASSERT_LTE(current_size, target_offset, "Current table size is larger than fixed append offset.");
+
             // Fill gap with no-ops if needed
             reconstructed_table.insert(reconstructed_table.end(), target_offset - current_size, UltraOp{ /*no-op*/ });
         }

--- a/barretenberg/cpp/src/barretenberg/stdlib/goblin_verifier/goblin_recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/goblin_verifier/goblin_recursive_verifier.cpp
@@ -36,9 +36,10 @@ GoblinRecursiveVerifierOutput GoblinRecursiveVerifier::verify(const StdlibProof&
 {
     // Verify the final merge step
     MergeVerifier merge_verifier{ merge_settings, transcript };
-    auto [merge_pairing_points, merged_table_commitments, degree_check_verified] =
+    auto [merge_pairing_points, merged_table_commitments, degree_check_verified, concatenation_check_passed] =
         merge_verifier.verify_proof(proof.merge_proof, merge_commitments);
     vinfo("Merge Verifier: degree check identity passed", degree_check_verified);
+    vinfo("Merge Verifier: concatenation identity passed", concatenation_check_passed);
     // Run the ECCVM recursive verifier
     ECCVMVerifier eccvm_verifier{ builder, verification_keys.eccvm_verification_key, transcript };
     auto [opening_claim, ipa_proof] = eccvm_verifier.verify_proof(proof.eccvm_proof);

--- a/barretenberg/cpp/src/barretenberg/stdlib/merge_verifier/merge_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/merge_verifier/merge_verifier.test.cpp
@@ -108,8 +108,10 @@ template <class RecursiveBuilder> class RecursiveMergeVerifierTest : public test
         recursive_transcript->enable_manifest();
         RecursiveMergeVerifier verifier{ settings, recursive_transcript };
         const stdlib::Proof<RecursiveBuilder> stdlib_merge_proof(outer_circuit, merge_proof);
-        auto [pairing_points, recursive_merged_table_commitments, recursive_degree_check] =
-            verifier.verify_proof(stdlib_merge_proof, recursive_merge_commitments);
+        auto [pairing_points,
+              recursive_merged_table_commitments,
+              recursive_degree_check,
+              recursive_concatenation_check] = verifier.verify_proof(stdlib_merge_proof, recursive_merge_commitments);
 
         // Check for a failure flag in the recursive verifier circuit
         EXPECT_EQ(outer_circuit.failed(), !expected) << outer_circuit.err();
@@ -119,12 +121,13 @@ template <class RecursiveBuilder> class RecursiveMergeVerifierTest : public test
         auto native_transcript = std::make_shared<NativeTranscript>();
         native_transcript->enable_manifest();
         MergeVerifier native_verifier{ settings, native_transcript };
-        auto [native_pairing_points, merged_table_commitments, native_degree_check] =
+        auto [native_pairing_points, merged_table_commitments, native_degree_check, native_concatenation_check] =
             native_verifier.verify_proof(merge_proof, merge_commitments);
-        bool verified_native = native_pairing_points.check() && native_degree_check;
+        bool verified_native = native_pairing_points.check() && native_degree_check && native_concatenation_check;
         VerifierCommitmentKey pcs_verification_key;
         bool verified_recursive =
-            pcs_verification_key.pairing_check(pairing_points.P0.get_value(), pairing_points.P1.get_value());
+            pcs_verification_key.pairing_check(pairing_points.P0.get_value(), pairing_points.P1.get_value()) &&
+            recursive_degree_check && recursive_concatenation_check;
         EXPECT_EQ(verified_native, verified_recursive);
         EXPECT_EQ(verified_recursive, expected);
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/merge_verifier/merge_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/merge_verifier/merge_verifier.test.cpp
@@ -37,7 +37,7 @@ template <class RecursiveBuilder> class RecursiveMergeVerifierTest : public test
     using TableCommitments = MergeVerifier::TableCommitments;
     using MergeCommitments = MergeVerifier::InputCommitments;
 
-    enum class TamperProofMode { None, Shift, MCommitment, LEval };
+    enum class TamperProofMode : uint8_t { None, Shift, MCommitment, LEval };
 
   public:
     static void SetUpTestSuite() { bb::srs::init_file_crs_factory(bb::srs::bb_crs_path()); }
@@ -46,7 +46,7 @@ template <class RecursiveBuilder> class RecursiveMergeVerifierTest : public test
     {
         const size_t shift_idx = 0;        // Index of shift_size in the merge proof
         const size_t m_commitment_idx = 1; // Index of first commitment to merged table in merge proof
-        const size_t l_eval_idx = 21;      // Index of first evaluation of l(1/kappa) in merge proof
+        const size_t l_eval_idx = 22;      // Index of first evaluation of l(1/kappa) in merge proof
 
         switch (tampering_mode) {
         case TamperProofMode::Shift:

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_goblin_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_goblin_impl.hpp
@@ -76,8 +76,10 @@ goblin_element<C, Fq, Fr, G> goblin_element<C, Fq, Fr, G>::batch_mul(const std::
         // Note: These constraints do not assume or enforce that the coordinates of the original point have been
         // asserted to be in the field, only that they are less than the smallest power of 2 greater than the field
         // modulus (a la the bigfield(lo, hi) constructor with can_overflow == false).
-        BB_ASSERT_LTE(uint1024_t(point._x.get_maximum_value()), Fq::DEFAULT_MAXIMUM_REMAINDER);
-        BB_ASSERT_LTE(uint1024_t(point._y.get_maximum_value()), Fq::DEFAULT_MAXIMUM_REMAINDER);
+        if (!point.get_value().is_point_at_infinity()) {
+            BB_ASSERT_LTE(uint1024_t(point._x.get_maximum_value()), Fq::DEFAULT_MAXIMUM_REMAINDER);
+            BB_ASSERT_LTE(uint1024_t(point._y.get_maximum_value()), Fq::DEFAULT_MAXIMUM_REMAINDER);
+        }
         x_lo.assert_equal(point._x.limbs[0]);
         x_hi.assert_equal(point._x.limbs[1]);
         y_lo.assert_equal(point._y.limbs[0]);

--- a/barretenberg/cpp/src/barretenberg/translator_vm/translator_proving_key.hpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/translator_proving_key.hpp
@@ -48,10 +48,11 @@ class TranslatorProvingKey {
     {
         BB_BENCH_NAME("TranslatorProvingKey(TranslatorCircuit&)");
         // Check that the Translator Circuit does not exceed the fixed upper bound, the current value amounts to
-        // a number of EccOps sufficient for 10 rounds of folding (so 20 circuits)
-        if (circuit.num_gates() > Flavor::MINI_CIRCUIT_SIZE) {
-            throw_or_abort("The Translator circuit size has exceeded the fixed upper bound");
-        }
+        // a number of EccOps sufficient for 28 app circuits
+        vinfo("Translator circuit size: ", circuit.num_gates());
+        BB_ASSERT_LTE(circuit.num_gates(),
+                      Flavor::MINI_CIRCUIT_SIZE,
+                      "The Translator circuit size has exceeded the fixed upper bound");
 
         proving_key = std::make_shared<ProvingKey>(std::move(commitment_key));
         auto wires = proving_key->polynomials.get_wires();

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/mega_honk.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/mega_honk.test.cpp
@@ -69,9 +69,10 @@ template <typename Flavor> class MegaHonkTests : public ::testing::Test {
 
         auto transcript = std::make_shared<NativeTranscript>();
         MergeVerifier merge_verifier{ settings, transcript };
-        auto [pairing_points, _, degree_check_passed] = merge_verifier.verify_proof(merge_proof, merge_commitments);
+        auto [pairing_points, _, degree_check_passed, concatenation_check_passed] =
+            merge_verifier.verify_proof(merge_proof, merge_commitments);
 
-        return pairing_points.check() && degree_check_passed;
+        return pairing_points.check() && degree_check_passed && concatenation_check_passed;
     }
 };
 

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/merge_prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/merge_prover.cpp
@@ -39,30 +39,27 @@ MergeProver::MergeProver(const std::shared_ptr<ECCOpQueue>& op_queue,
 
 /**
  * @brief Prove proper construction of the aggregate Goblin ECC op queue polynomials T_j, j = 1,2,3,4.
- * @details Let \f$l_j\f$, \f$r_j\f$, \f$m_j\f$ be three vectors. The Merge prover wants to convince the verifier that,
+ * @details Let \f$L_j\f$, \f$R_j\f$, \f$M_j\f$ be three vectors. The Merge prover wants to convince the verifier that,
  * for j = 1, 2, 3, 4:
- *      - m_j(X) = l_j(X) + X^l r_j(X)      (1)
- *      - deg(l_j(X)) < k                   (2)
+ *      - \f$M_j(X) = L_j(X) + X^l R_j(X)\f$      (1)
+ *      - \f$deg(L_j(X)) < k\f$                   (2)
  * where k = shift_size.
  *
- * Condition (1) is equivalent, up to negligible probability, to:
- *      l_j(kappa) + kappa^k r_j(kappa) - m_j(kappa) = 0
- * so the prover constructs the polynomial
- *      p_j(X) := l_j(X) + kappa^{k-1} r_j(X) - m_j(X)
- * and proves that it opens to 0 at kappa.
- *
- * To convince the verifier of (2), the prover commits to g_j(X) (allegedly equal to X^{k-1} l_j(1/X)) and provides
- * openings:
- *      c = l_j(1/kappa)     d = g_j(kappa)
- * The verifier then checks that: c * kappa^{k-1} = d. This check is equivalent, up to negligible probability, to
- * \f$g_j(X) = X^{k-1} l_j(1/X)\f$, which implies \f$deg(l_j) < k$.
+ * 1. The prover commits to \f$L_i, R_j, M_j\f$ and receives from the verifier batching challenges \f$alpha_1, \dots,
+ *    \alpha_4\f$
+ * 2. The prover computes \f$G(X) = X^{k-1}(\sum_i \alpha_i L_i(X))\f$ and commits to it.
+ * 3. The prover receives from the verifier an evaluation challenge \f$\kappa\f$ and sends evaluations
+ *    \f$l_j = L_j(\kappa), r_j = R_j(\kappa), m_j = M_j(\kappa), g = G(\kappa^{-1}\f$.
+ * 4. The prover uses Shplonk to open the commitments to the relevant points.
  *
  * In the Goblin scenario, we have:
- * - \f$l_j = t_j, r_j = T_{prev,j}, m_j = T_j\f$ if we are prepending the subtable
- * - \f$l_j = T_{prev,j}, r_j = t_j, m_j = T_j\f$ if we are appending the subtable
+ * - \f$L_i = t_j, R_j = T_{prev,j}, M_j = T_j\f$ if we are prepending the subtable
+ * - \f$L_j = T_{prev,j}, R_j = t_j, M_j = T_j\f$ if we are appending the subtable
  *
- * @note The prover doesn't commit to t_j because it shares a transcript with the HN instance that folds the present
- * circuit, and therefore t_j has already been added to the transcript by HN.
+ * @note The prover doesn't commit to t_j because it shares a transcript with the HN instance that folds
+ * the present circuit, and therefore t_j has already been added to the transcript by HN. Similarly, it doesn't commit
+ * to T_{prev, j} because the transcript is shared by entire recursive verification and therefore T_{prev, j} has been
+ * added to the transcript in the previous round of Merge verification.
  *
  * @return MergeProver::MergeProof
  */
@@ -82,13 +79,11 @@ MergeProver::MergeProof MergeProver::construct_proof()
         right_table = op_queue->construct_current_ultra_ops_subtable_columns(); // t
     }
 
-    const size_t merged_table_size = merged_table[0].size();
-
     // Send shift_size to the verifier
     const size_t shift_size = left_table[0].size();
     transcript->send_to_verifier("shift_size", static_cast<uint32_t>(shift_size));
 
-    // Compute commitments [m_j] and send to the verifier
+    // Compute commitments [M_j] and send to the verifier
     for (size_t idx = 0; idx < NUM_WIRES; ++idx) {
         transcript->send_to_verifier("MERGED_TABLE_" + std::to_string(idx),
                                      pcs_commitment_key.commit(merged_table[idx]));
@@ -111,46 +106,64 @@ MergeProver::MergeProof MergeProver::construct_proof()
     transcript->send_to_verifier("REVERSED_BATCHED_LEFT_TABLES",
                                  pcs_commitment_key.commit(reversed_batched_left_tables));
 
+    // Compute batching challenges
+    std::vector<std::string> labels_shplonk_batching_challenges((3 * NUM_WIRES) + 1);
+    for (size_t idx = 0; idx < 3 * NUM_WIRES + 1; idx++) {
+        labels_shplonk_batching_challenges[idx] = "SHPLONK_MERGE_BATCHING_CHALLENGE_" + std::to_string(idx);
+    }
+    std::vector<FF> shplonk_batching_challenges =
+        transcript->template get_challenges<FF>(labels_shplonk_batching_challenges);
+
     // Compute evaluation challenge
     const FF kappa = transcript->template get_challenge<FF>("kappa");
-    const FF pow_kappa = kappa.pow(shift_size);
     const FF kappa_inv = kappa.invert();
 
-    // Opening claims for each polynomial p_j, l_j, g_j
-    //
-    // The opening claims are sent in the following order:
-    // {kappa, 0}, {kappa, 0}, {kappa, 0}, {kappa, 0},
-    //   {1/kappa, l_1(1/kappa)}, {1/kappa, l_2(1/kappa)},
-    //      {1/kappa, l_3(1/kappa)}, {1/kappa, l_4(1/kappa)},
-    //          {kappa, g(kappa)}
-    std::vector<OpeningClaim> opening_claims;
-
-    // Set opening claims p_j(\kappa) = l_j(X) + kappa^l r_j(X) - m_j(X)
+    // Send evaluations of [L_i], [R_i], [M_i] at kappa
+    std::vector<FF> evals;
+    evals.reserve((3 * NUM_WIRES) + 1);
     for (size_t idx = 0; idx < NUM_WIRES; ++idx) {
-        Polynomial partially_evaluated_difference(merged_table_size);
-        partially_evaluated_difference += left_table[idx];
-        partially_evaluated_difference.add_scaled(right_table[idx], pow_kappa);
-        partially_evaluated_difference -= merged_table[idx];
-
-        opening_claims.emplace_back(OpeningClaim{ partially_evaluated_difference, { kappa, FF(0) } });
+        evals.emplace_back(left_table[idx].evaluate(kappa));
+        transcript->send_to_verifier("LEFT_TABLE_EVAL_" + std::to_string(idx), evals.back());
     }
-    // Compute evaluation l_j(1/kappa) send to verifier, and set opening claims
     for (size_t idx = 0; idx < NUM_WIRES; ++idx) {
-        FF evaluation;
-
-        // Evaluate l_j(1/kappa)
-        evaluation = left_table[idx].evaluate(kappa_inv);
-        transcript->send_to_verifier("left_table_eval_kappa_inv_" + std::to_string(idx), evaluation);
-        opening_claims.emplace_back(OpeningClaim{ left_table[idx], { kappa_inv, evaluation } });
+        evals.emplace_back(right_table[idx].evaluate(kappa));
+        transcript->send_to_verifier("RIGHT_TABLE_EVAL_" + std::to_string(idx), evals.back());
+    }
+    for (size_t idx = 0; idx < NUM_WIRES; ++idx) {
+        evals.emplace_back(merged_table[idx].evaluate(kappa));
+        transcript->send_to_verifier("MERGED_TABLE_EVAL_" + std::to_string(idx), evals.back());
     }
 
-    // Compute evaluation g(kappa) send to verifier, and set opening claim
-    FF evaluation = reversed_batched_left_tables.evaluate(kappa);
-    transcript->send_to_verifier("reversed_batched_left_tables_eval", evaluation);
-    opening_claims.emplace_back(OpeningClaim{ reversed_batched_left_tables, { kappa, evaluation } });
+    // Send evaluation of G at 1/kappa
+    evals.emplace_back(reversed_batched_left_tables.evaluate(kappa_inv));
+    transcript->send_to_verifier("REVERSED_BATCHED_LEFT_TABLES_EVAL", evals.back());
 
-    // Shplonk prover
-    OpeningClaim shplonk_opening_claim = ShplonkProver_<Curve>::prove(pcs_commitment_key, opening_claims, transcript);
+    // Compute Shplonk batched quotient
+    Polynomial shplonk_batched_quotient = compute_shplonk_batched_quotient(left_table,
+                                                                           right_table,
+                                                                           merged_table,
+                                                                           shplonk_batching_challenges,
+                                                                           kappa,
+                                                                           kappa_inv,
+                                                                           reversed_batched_left_tables,
+                                                                           evals);
+
+    transcript->send_to_verifier("SHPLONK_BATCHED_QUOTIENT", pcs_commitment_key.commit(shplonk_batched_quotient));
+
+    // Generate Shplonk opening challenge
+    FF shplonk_opening_challenge = transcript->template get_challenge<FF>("shplonk_opening_challenge");
+
+    // Compute Shplonk opening claim
+    OpeningClaim shplonk_opening_claim = compute_shplonk_opening_claim(shplonk_batched_quotient,
+                                                                       shplonk_opening_challenge,
+                                                                       left_table,
+                                                                       right_table,
+                                                                       merged_table,
+                                                                       shplonk_batching_challenges,
+                                                                       kappa,
+                                                                       kappa_inv,
+                                                                       reversed_batched_left_tables,
+                                                                       evals);
 
     // KZG prover
     PCS::compute_opening_proof(pcs_commitment_key, shplonk_opening_claim, transcript);

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/merge_prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/merge_prover.cpp
@@ -89,28 +89,14 @@ MergeProver::MergeProof MergeProver::construct_proof()
                                      pcs_commitment_key.commit(merged_table[idx]));
     }
 
-    // Generate degree check batching challenges
-    std::array<std::string, NUM_WIRES> labels_degree_check;
-    for (size_t idx = 0; idx < NUM_WIRES; ++idx) {
-        labels_degree_check[idx] = "LEFT_TABLE_DEGREE_CHECK_" + std::to_string(idx);
-    }
-    std::array<FF, NUM_WIRES> degree_check_challenges =
-        transcript->template get_challenges<FF, NUM_WIRES>(labels_degree_check);
-
-    // Batch polynomials, compute reversed polynomial, send commitment to the verifier
-    Polynomial reversed_batched_left_tables(left_table[0].size());
-    for (size_t idx = 0; idx < NUM_WIRES; idx++) {
-        reversed_batched_left_tables.add_scaled(left_table[idx], degree_check_challenges[idx]);
-    }
-    reversed_batched_left_tables = reversed_batched_left_tables.reverse();
+    // Generate degree check batching challenges, batch polynomials, compute reversed polynomial, send commitment to the
+    // verifier
+    std::vector<FF> degree_check_challenges = transcript->template get_challenges<FF>(labels_degree_check);
+    Polynomial reversed_batched_left_tables = compute_degree_check_polynomial(left_table, degree_check_challenges);
     transcript->send_to_verifier("REVERSED_BATCHED_LEFT_TABLES",
                                  pcs_commitment_key.commit(reversed_batched_left_tables));
 
     // Compute batching challenges
-    std::vector<std::string> labels_shplonk_batching_challenges((3 * NUM_WIRES) + 1);
-    for (size_t idx = 0; idx < 3 * NUM_WIRES + 1; idx++) {
-        labels_shplonk_batching_challenges[idx] = "SHPLONK_MERGE_BATCHING_CHALLENGE_" + std::to_string(idx);
-    }
     std::vector<FF> shplonk_batching_challenges =
         transcript->template get_challenges<FF>(labels_shplonk_batching_challenges);
 

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/merge_prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/merge_prover.cpp
@@ -47,7 +47,7 @@ MergeProver::MergeProver(const std::shared_ptr<ECCOpQueue>& op_queue,
  *
  * 1. The prover commits to \f$L_i, R_j, M_j\f$ and receives from the verifier batching challenges \f$alpha_1, \dots,
  *    \alpha_4\f$
- * 2. The prover computes \f$G(X) = X^{k-1}(\sum_i \alpha_i L_i(X))\f$ and commits to it.
+ * 2. The prover sends a commitment to \f$G(X) = X^{k-1}(\sum_i \alpha_i L_i(X))\f$.
  * 3. The prover receives from the verifier an evaluation challenge \f$\kappa\f$ and sends evaluations
  *    \f$l_j = L_j(\kappa), r_j = R_j(\kappa), m_j = M_j(\kappa), g = G(\kappa^{-1}\f$.
  * 4. The prover uses Shplonk to open the commitments to the relevant points.

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/merge_prover.hpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/merge_prover.hpp
@@ -48,6 +48,105 @@ class MergeProver {
     // Number of columns that jointly constitute the op_queue, should be the same as the number of wires in the
     // MegaCircuitBuilder
     static constexpr size_t NUM_WIRES = MegaExecutionTraceBlocks::NUM_WIRES;
+
+  private:
+    static Polynomial compute_shplonk_batched_quotient(const std::array<Polynomial, NUM_WIRES>& left_table,
+                                                       const std::array<Polynomial, NUM_WIRES>& right_table,
+                                                       const std::array<Polynomial, NUM_WIRES>& merged_table,
+                                                       const std::vector<FF>& shplonk_batching_challenges,
+                                                       const FF& kappa,
+                                                       const FF& kappa_inv,
+                                                       const Polynomial& reversed_batched_left_tables,
+                                                       const std::vector<FF>& evals)
+    {
+        // Q s.t. Q * (X - \kappa) * (X - \kappa^{-1}) =
+        //   (X - \kappa^{-1}) * (\sum_i \beta_i (L_i - l_i) + \sum_i \beta_i (R_i - r_i) + \sum_i \beta_i (M_i - m_i))
+        // + (X - \kappa) * \beta_i (G - g)
+        Polynomial shplonk_batched_quotient(merged_table[0].size());
+
+        // Handle polynomials opened at \kappa
+        for (size_t idx_table = 0; idx_table < 3; idx_table++) {
+            for (size_t idx = 0; idx < NUM_WIRES; idx++) {
+                FF challenge = shplonk_batching_challenges[(idx_table * NUM_WIRES) + idx];
+                FF eval = evals[(idx_table * NUM_WIRES) + idx];
+                if (idx_table == 0) {
+                    // Q += L_i * \beta_i
+                    shplonk_batched_quotient.add_scaled(left_table[idx], challenge);
+                } else if (idx_table == 1) {
+                    // Q += R_i * \beta_i
+                    shplonk_batched_quotient.add_scaled(right_table[idx], challenge);
+                } else {
+                    // Q += M_i * \beta_i
+                    shplonk_batched_quotient.add_scaled(merged_table[idx], challenge);
+                }
+                // Q -= eval * \beta_i
+                shplonk_batched_quotient.at(0) -= challenge * eval;
+            }
+        }
+        // Q /= (X - \kappa)
+        shplonk_batched_quotient.factor_roots(kappa);
+
+        // Q += (G - g) / (X - \kappa^{-1}) * \beta_i
+        Polynomial reversed_batched_left_tables_copy(reversed_batched_left_tables);
+        reversed_batched_left_tables_copy.at(0) -= evals.back();
+        reversed_batched_left_tables_copy.factor_roots(kappa_inv);
+        shplonk_batched_quotient.add_scaled(reversed_batched_left_tables_copy, shplonk_batching_challenges.back());
+
+        return shplonk_batched_quotient;
+    };
+
+    static OpeningClaim compute_shplonk_opening_claim(Polynomial& shplonk_batched_quotient,
+                                                      const FF& shplonk_opening_challenge,
+                                                      const std::array<Polynomial, NUM_WIRES>& left_table,
+                                                      const std::array<Polynomial, NUM_WIRES>& right_table,
+                                                      const std::array<Polynomial, NUM_WIRES>& merged_table,
+                                                      const std::vector<FF>& shplonk_batching_challenges,
+                                                      const FF& kappa,
+                                                      const FF& kappa_inv,
+                                                      Polynomial& reversed_batched_left_tables,
+                                                      const std::vector<FF>& evals)
+    {
+        // Q' (partially evaluated batched quotient) =
+        //  Q * (z - \kappa) +
+        //      - (\sum_i \beta_i (L_i - l_i) + \sum_i \beta_i (R_i - r_i) + \sum_i \beta_i (M_i - m_i))
+        //      - (z - \kappa) / (z - \kappa^{-1}) * \beta_i (G - g)
+
+        //
+        Polynomial shplonk_partially_evaluated_batched_quotient(std::move(shplonk_batched_quotient));
+        shplonk_partially_evaluated_batched_quotient *= (shplonk_opening_challenge - kappa);
+
+        // Handle polynomials opened at \kappa
+        for (size_t idx_table = 0; idx_table < 3; idx_table++) {
+            for (size_t idx = 0; idx < NUM_WIRES; idx++) {
+                FF challenge = shplonk_batching_challenges[(idx_table * NUM_WIRES) + idx];
+                FF eval = evals[(idx_table * NUM_WIRES) + idx];
+                if (idx_table == 0) {
+                    // Q' -= L_i * \beta_i
+                    shplonk_partially_evaluated_batched_quotient.add_scaled(left_table[idx], -challenge);
+                } else if (idx_table == 1) {
+                    // Q' -= R_i * \beta_i
+                    shplonk_partially_evaluated_batched_quotient.add_scaled(right_table[idx], -challenge);
+                } else {
+                    // Q' -= M_i * \beta_i
+                    shplonk_partially_evaluated_batched_quotient.add_scaled(merged_table[idx], -challenge);
+                }
+                // Q' += eval * \beta_i
+                shplonk_partially_evaluated_batched_quotient.at(0) += challenge * eval;
+            }
+        }
+
+        // Q' -= (G - g) / (z - \kappa^{-1}) * (z - \kappa) * \beta_i
+        reversed_batched_left_tables.at(0) -= evals.back();
+        shplonk_partially_evaluated_batched_quotient.add_scaled(reversed_batched_left_tables,
+                                                                -shplonk_batching_challenges.back() *
+                                                                    (shplonk_opening_challenge - kappa) *
+                                                                    (shplonk_opening_challenge - kappa_inv).invert());
+
+        OpeningClaim shplonk_opening_claim = { .polynomial = shplonk_partially_evaluated_batched_quotient,
+                                               .opening_pair = { shplonk_opening_challenge, FF(0) } };
+
+        return shplonk_opening_claim;
+    }
 };
 
 } // namespace bb

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/merge_prover.hpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/merge_prover.hpp
@@ -50,6 +50,54 @@ class MergeProver {
     static constexpr size_t NUM_WIRES = MegaExecutionTraceBlocks::NUM_WIRES;
 
   private:
+    std::vector<std::string> labels_degree_check = { "LEFT_TABLE_DEGREE_CHECK_0",
+                                                     "LEFT_TABLE_DEGREE_CHECK_1",
+                                                     "LEFT_TABLE_DEGREE_CHECK_2",
+                                                     "LEFT_TABLE_DEGREE_CHECK_3" };
+
+    std::vector<std::string> labels_shplonk_batching_challenges = {
+        "SHPLONK_MERGE_BATCHING_CHALLENGE_0",  "SHPLONK_MERGE_BATCHING_CHALLENGE_1",
+        "SHPLONK_MERGE_BATCHING_CHALLENGE_2",  "SHPLONK_MERGE_BATCHING_CHALLENGE_3",
+        "SHPLONK_MERGE_BATCHING_CHALLENGE_4",  "SHPLONK_MERGE_BATCHING_CHALLENGE_5",
+        "SHPLONK_MERGE_BATCHING_CHALLENGE_6",  "SHPLONK_MERGE_BATCHING_CHALLENGE_7",
+        "SHPLONK_MERGE_BATCHING_CHALLENGE_8",  "SHPLONK_MERGE_BATCHING_CHALLENGE_9",
+        "SHPLONK_MERGE_BATCHING_CHALLENGE_10", "SHPLONK_MERGE_BATCHING_CHALLENGE_11",
+        "SHPLONK_MERGE_BATCHING_CHALLENGE_12"
+    };
+
+    /**
+     * @brief Compute the batched polynomial for the degree check.
+     *
+     * @details To show that \f$\deg(L_j) < k\f$, the prover batches the \f$L_i\f$'s as \f$\sum_i \alpha_i L_i\f$ and
+     * computes \f$G(X) = (\sum_i \alpha_i L_i(X)) X^{k-1}\f$. The prover commits to \f$G\f$ and later opens \f$L_i\f$
+     * at \f$\kappa\f$ and \f$G\f$ at \f$\kappa^{-1}\f$, so to show that \f$G(\kappa^{-1}) = (\sum_i \alpha_i
+     * L_i(\kappa)) * \kappa^{-(k-1)}\f$.
+     *
+     * @param left_table
+     * @param degree_check_challenges
+     * @return Polynomial
+     */
+    static Polynomial compute_degree_check_polynomial(const std::array<Polynomial, NUM_WIRES>& left_table,
+                                                      const std::vector<FF>& degree_check_challenges)
+    {
+        Polynomial reversed_batched_left_tables(left_table[0].size());
+        for (size_t idx = 0; idx < NUM_WIRES; idx++) {
+            reversed_batched_left_tables.add_scaled(left_table[idx], degree_check_challenges[idx]);
+        }
+        return reversed_batched_left_tables.reverse();
+    }
+
+    /**
+     * @brief Compute the batched Shplonk quotient polynomial.
+     *
+     * @details This function computes the polynomial \f$Q(X)\f$ such that \f$Q(X) * (X - \kappa) * (X - \kappa^{-1}) =
+     * F(X)\f$, where \f$F(X)\f$ is defined as
+     * \f[
+     *  (X - \kappa^{-1}) * (\sum_i \beta_i (L_i - l_i) + \sum_i \beta_i (R_i - r_i) + \sum_i \beta_i (M_i - m_i))
+     *       + (X - \kappa) * \beta_i (G - g)
+     * \f]
+     *
+     */
     static Polynomial compute_shplonk_batched_quotient(const std::array<Polynomial, NUM_WIRES>& left_table,
                                                        const std::array<Polynomial, NUM_WIRES>& right_table,
                                                        const std::array<Polynomial, NUM_WIRES>& merged_table,
@@ -95,6 +143,18 @@ class MergeProver {
         return shplonk_batched_quotient;
     };
 
+    /**
+     * @brief Compute the partially evaluated Shplonk batched quotient and the resulting opening claim.
+     *
+     * @details Compute the partially evaluated batched quotient \f$Q'(X)\f$ defined as:
+     * \f[
+     *  Q * (z - \kappa) +
+     *      - (\sum_i \beta_i (L_i - l_i) + \sum_i \beta_i (R_i - r_i) + \sum_i \beta_i (M_i - m_i))
+     *      - (z - \kappa) / (z - \kappa^{-1}) * \beta_i (G - g)
+     * \f]
+     * and return the opening claim \f$\{ Q', (\kappa, 0) \}\f$.
+     *
+     */
     static OpeningClaim compute_shplonk_opening_claim(Polynomial& shplonk_batched_quotient,
                                                       const FF& shplonk_opening_challenge,
                                                       const std::array<Polynomial, NUM_WIRES>& left_table,

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/merge_prover.hpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/merge_prover.hpp
@@ -148,9 +148,9 @@ class MergeProver {
      *
      * @details Compute the partially evaluated batched quotient \f$Q'(X)\f$ defined as:
      * \f[
-     *  Q * (z - \kappa) +
-     *      - (\sum_i \beta_i (L_i - l_i) + \sum_i \beta_i (R_i - r_i) + \sum_i \beta_i (M_i - m_i))
-     *      - (z - \kappa) / (z - \kappa^{-1}) * \beta_i (G - g)
+     *  -Q * (z - \kappa) +
+     *      + (\sum_i \beta_i (L_i - l_i) + \sum_i \beta_i (R_i - r_i) + \sum_i \beta_i (M_i - m_i))
+     *      + (z - \kappa) / (z - \kappa^{-1}) * \beta_i (G - g)
      * \f]
      * and return the opening claim \f$\{ Q', (z, 0) \}\f$.
      *
@@ -167,13 +167,13 @@ class MergeProver {
                                                       const std::vector<FF>& evals)
     {
         // Q' (partially evaluated batched quotient) =
-        //  Q * (z - \kappa) +
-        //      - (\sum_i \beta_i (L_i - l_i) + \sum_i \beta_i (R_i - r_i) + \sum_i \beta_i (M_i - m_i))
-        //      - (z - \kappa) / (z - \kappa^{-1}) * \beta_i (G - g)
+        //  -Q * (z - \kappa) +
+        //      + (\sum_i \beta_i (L_i - l_i) + \sum_i \beta_i (R_i - r_i) + \sum_i \beta_i (M_i - m_i))
+        //      + (z - \kappa) / (z - \kappa^{-1}) * \beta_i (G - g)
 
         //
         Polynomial shplonk_partially_evaluated_batched_quotient(std::move(shplonk_batched_quotient));
-        shplonk_partially_evaluated_batched_quotient *= (shplonk_opening_challenge - kappa);
+        shplonk_partially_evaluated_batched_quotient *= -(shplonk_opening_challenge - kappa);
 
         // Handle polynomials opened at \kappa
         for (size_t idx_table = 0; idx_table < 3; idx_table++) {
@@ -181,24 +181,24 @@ class MergeProver {
                 FF challenge = shplonk_batching_challenges[(idx_table * NUM_WIRES) + idx];
                 FF eval = evals[(idx_table * NUM_WIRES) + idx];
                 if (idx_table == 0) {
-                    // Q' -= L_i * \beta_i
-                    shplonk_partially_evaluated_batched_quotient.add_scaled(left_table[idx], -challenge);
+                    // Q' += L_i * \beta_i
+                    shplonk_partially_evaluated_batched_quotient.add_scaled(left_table[idx], challenge);
                 } else if (idx_table == 1) {
-                    // Q' -= R_i * \beta_i
-                    shplonk_partially_evaluated_batched_quotient.add_scaled(right_table[idx], -challenge);
+                    // Q' += R_i * \beta_i
+                    shplonk_partially_evaluated_batched_quotient.add_scaled(right_table[idx], challenge);
                 } else {
-                    // Q' -= M_i * \beta_i
-                    shplonk_partially_evaluated_batched_quotient.add_scaled(merged_table[idx], -challenge);
+                    // Q' += M_i * \beta_i
+                    shplonk_partially_evaluated_batched_quotient.add_scaled(merged_table[idx], challenge);
                 }
-                // Q' += eval * \beta_i
-                shplonk_partially_evaluated_batched_quotient.at(0) += challenge * eval;
+                // Q' -= eval * \beta_i
+                shplonk_partially_evaluated_batched_quotient.at(0) -= challenge * eval;
             }
         }
 
-        // Q' -= (G - g) / (z - \kappa^{-1}) * (z - \kappa) * \beta_i
+        // Q' += (G - g) / (z - \kappa^{-1}) * (z - \kappa) * \beta_i
         reversed_batched_left_tables.at(0) -= evals.back();
         shplonk_partially_evaluated_batched_quotient.add_scaled(reversed_batched_left_tables,
-                                                                -shplonk_batching_challenges.back() *
+                                                                shplonk_batching_challenges.back() *
                                                                     (shplonk_opening_challenge - kappa) *
                                                                     (shplonk_opening_challenge - kappa_inv).invert());
 

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/merge_prover.hpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/merge_prover.hpp
@@ -152,7 +152,7 @@ class MergeProver {
      *      - (\sum_i \beta_i (L_i - l_i) + \sum_i \beta_i (R_i - r_i) + \sum_i \beta_i (M_i - m_i))
      *      - (z - \kappa) / (z - \kappa^{-1}) * \beta_i (G - g)
      * \f]
-     * and return the opening claim \f$\{ Q', (\kappa, 0) \}\f$.
+     * and return the opening claim \f$\{ Q', (z, 0) \}\f$.
      *
      */
     static OpeningClaim compute_shplonk_opening_claim(Polynomial& shplonk_batched_quotient,
@@ -202,7 +202,7 @@ class MergeProver {
                                                                     (shplonk_opening_challenge - kappa) *
                                                                     (shplonk_opening_challenge - kappa_inv).invert());
 
-        OpeningClaim shplonk_opening_claim = { .polynomial = shplonk_partially_evaluated_batched_quotient,
+        OpeningClaim shplonk_opening_claim = { .polynomial = std::move(shplonk_partially_evaluated_batched_quotient),
                                                .opening_pair = { shplonk_opening_challenge, FF(0) } };
 
         return shplonk_opening_claim;

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/merge_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/merge_verifier.cpp
@@ -13,42 +13,23 @@ namespace bb {
 
 /**
  * @brief Verify proper construction of the aggregate Goblin ECC op queue polynomials T_j, j = 1,2,3,4.
- * @details Let \f$l_j\f$, \f$r_j\f$, \f$m_j\f$ be three vectors. The Merge wants to convince the verifier that the
- * polynomials l_j, r_j, m_j for which they have sent commitments [l_j], [r_j], [m_j] satisfy
- *      - m_j(X) = l_j(X) + X^l r_j(X)      (1)
- *      - deg(l_j(X)) < k                   (2)
+ * @details Let \f$L_j\f$, \f$R_j\f$, \f$M_j\f$ be three vectors. The Merge prover wants to convince the verifier that,
+ * for j = 1, 2, 3, 4:
+ *      - \f$M_j(X) = L_j(X) + X^l R_j(X)\f$      (1)
+ *      - \f$deg(L_j(X)) < k\f$                   (2)
  * where k = shift_size.
  *
- * To check condition (1), the verifier samples a challenge kappa and request from the prover a proof that
- * the polynomial
- *      p_j(X) = l_j(kappa) + kappa^k r_j(kappa) - m_j(kappa)
- * opens to 0 at kappa.
+ * 1. The prover commits to \f$L_i, R_j, M_j\f$ and receives from the verifier batching challenges \f$alpha_1, \dots,
+ *    \alpha_4\f$
+ * 2. The prover computes \f$G(X) = X^{k-1}(\sum_i \alpha_i L_i(X))\f$ and commits to it.
+ * 3. The prover receives from the verifier an evaluation challenge \f$\kappa\f$ and sends evaluations
+ *    \f$l_j = L_j(\kappa), r_j = R_j(\kappa), m_j = M_j(\kappa), g = G(\kappa^{-1}\f$.
+ * 4. The prover uses Shplonk to open the commitments to the relevant points.
  *
- * To check condition (2), the verifier requests from the prover the commitment to a polynomial g_j, and
- * then requests proofs that
- *      l_j(1/kappa) = c     g_j(kappa) = d
- * Then, they verify c * kappa^{k-1} = d, which implies, up to negligible probability, that
- * g_j(X) = X^{l-1} l_j(1/X), which means that deg(l_j(X)) < l.
- *
- * The verifier must therefore check 12 opening claims: p_j(kappa) = 0, l_j(1/kappa), g_j(kappa)
- * We use Shplonk to verify the claims with a single MSM (instead of computing [p_j] from [l_j], [r_j], [m_j]
- * and then open it). We initialize the Shplonk verifier with the following commitments:
- *      [l_1], [r_1], [m_1], [g_1], ..., [l_4], [r_4], [m_4], [g_4]
- * Then, we verify the various claims:
- *     - p_j(kappa) = 0:     The commitment to p_j is constructed from the commitments to l_j, r_j, m_j, so
- *                           the claim passed to the Shplonk verifier specifies the indices of these commitments in
- *                           the above vector: {4 * (j-1), 4 * (j-1) + 1, 4 * (j-1) + 2}, the coefficients
- *                           reconstructing p_j from l_j, r_j, m_j: {1, kappa^k, -1}, and the claimed
- *                           evaluation: 0.
- *     - l_j(1/kappa) = v_j: The index in this case is {4 * (j-1)}, the coefficient is { 1 }, and the evaluation is
- *                           v_j.
- *     - g_j(kappa) = w_j:   The index is {3 + 4 * (j-1)}, the coefficient is { 1 }, and the evaluation is w_j.
- * The claims are passed in the following order:
- *   {kappa, 0}, {kappa, 0}, {kappa, 0}, {kappa, 0}, {1/kappa, v_1}, {kappa, w_1}, .., {1/kappa, v_4}, {kappa, w_4}
- *
- * In the Goblin scenario, we have:
- * - \f$l_j = t_j, r_j = T_{prev,j}, m_j = T_j\f$ if we are prepending the subtable
- * - \f$l_j = T_{prev,j}, r_j = t_j, m_j = T_j\f$ if we are appending the subtable
+ * @note The prover doesn't commit to t_j because it shares a transcript with the HN instance that folds
+ * the present circuit, and therefore t_j has already been added to the transcript by HN. Similarly, it doesn't commit
+ * to T_{prev, j} because the transcript is shared by entire recursive verification and therefore T_{prev, j} has been
+ * added to the transcript in the previous round of Merge verification.
  *
  * @tparam Curve_
  * @param proof

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/merge_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/merge_verifier.cpp
@@ -60,8 +60,6 @@ template <typename Curve>
 typename MergeVerifier_<Curve>::VerificationResult MergeVerifier_<Curve>::verify_proof(
     const Proof& proof, const InputCommitments& input_commitments)
 {
-    using Claims = typename ShplonkVerifier_<Curve>::LinearCombinationOfClaims;
-
     transcript->load_proof(proof);
 
     // Receive shift size from prover
@@ -76,19 +74,25 @@ typename MergeVerifier_<Curve>::VerificationResult MergeVerifier_<Curve>::verify
         BB_ASSERT_GT(shift_size, 0U, "Shift size should always be bigger than 0");
     }
 
-    // Vector of commitments to be passed to the Shplonk verifier
-    // The vector is composed of: [l_1], [r_1], [m_1],, ..., [l_4], [r_4], [m_4], [g]
-    std::vector<Commitment> table_commitments;
-    for (size_t idx = 0; idx < NUM_WIRES; ++idx) {
-        auto left_table = settings == MergeSettings::PREPEND ? input_commitments.t_commitments[idx]
-                                                             : input_commitments.T_prev_commitments[idx];
-        auto right_table = settings == MergeSettings::PREPEND ? input_commitments.T_prev_commitments[idx]
-                                                              : input_commitments.t_commitments[idx];
+    // Store T_commitments of the verifier
+    TableCommitments merged_table_commitments;
 
-        table_commitments.emplace_back(left_table);
-        table_commitments.emplace_back(right_table);
+    // Vector of commitments
+    // The vector is composed of: [L_1], .., [L_4], [R_1], .., [R_4], [M_1], .., [M_4], [G]
+    std::vector<Commitment> table_commitments;
+    table_commitments.reserve((3 * NUM_WIRES) + 1);
+    for (size_t idx = 0; idx < NUM_WIRES; ++idx) {
+        table_commitments.emplace_back(settings == MergeSettings::PREPEND ? input_commitments.t_commitments[idx]
+                                                                          : input_commitments.T_prev_commitments[idx]);
+    }
+    for (size_t idx = 0; idx < NUM_WIRES; ++idx) {
+        table_commitments.emplace_back(settings == MergeSettings::PREPEND ? input_commitments.T_prev_commitments[idx]
+                                                                          : input_commitments.t_commitments[idx]);
+    }
+    for (size_t idx = 0; idx < NUM_WIRES; ++idx) {
         table_commitments.emplace_back(
             transcript->template receive_from_prover<Commitment>("MERGED_TABLE_" + std::to_string(idx)));
+        merged_table_commitments[idx] = table_commitments.back();
     }
 
     // Generate degree check batching challenges
@@ -103,13 +107,13 @@ typename MergeVerifier_<Curve>::VerificationResult MergeVerifier_<Curve>::verify
     table_commitments.emplace_back(
         transcript->template receive_from_prover<Commitment>("REVERSED_BATCHED_LEFT_TABLES"));
 
-    // Store T_commitments of the verifier
-    TableCommitments merged_table_commitments;
-    size_t commitment_idx = 2; // Index of [m_j = T_j] in the vector of commitments
-    for (auto& commitment : merged_table_commitments) {
-        commitment = table_commitments[commitment_idx];
-        commitment_idx += NUM_WIRES - 1;
+    // Compute batching challenges
+    std::vector<std::string> labels_shplonk_batching_challenges((3 * NUM_WIRES) + 1);
+    for (size_t idx = 0; idx < 3 * NUM_WIRES + 1; idx++) {
+        labels_shplonk_batching_challenges[idx] = "SHPLONK_MERGE_BATCHING_CHALLENGE_" + std::to_string(idx);
     }
+    std::vector<FF> shplonk_batching_challenges =
+        transcript->template get_challenges<FF>(labels_shplonk_batching_challenges);
 
     // Evaluation challenge
     const FF kappa = transcript->template get_challenge<FF>("kappa");
@@ -117,83 +121,104 @@ typename MergeVerifier_<Curve>::VerificationResult MergeVerifier_<Curve>::verify
     const FF pow_kappa = kappa.pow(shift_size);
     const FF pow_kappa_minus_one = pow_kappa * kappa_inv;
 
-    // Opening claims to be passed to the Shplonk verifier
-    std::vector<Claims> opening_claims;
-
-    // Field element constants for constructing claims
-    const FF one(1);
-    const FF zero(0);
-    const FF neg_one(-1);
-
-    // Add opening claim for p_j(X) = l_j(X) + X^k r_j(X) - m_j(X)
-    commitment_idx = 0;
+    // Receive evaluations of [L_i], [R_i], [M_i] at kappa
+    std::vector<FF> evals;
+    evals.reserve((3 * NUM_WIRES) + 1);
     for (size_t idx = 0; idx < NUM_WIRES; ++idx) {
-        Claims claim{ { /*index of [l_j]*/ commitment_idx,
-                        /*index of [r_j]*/ commitment_idx + 1,
-                        /*index of [m_j]*/ commitment_idx + 2 },
-                      { one, pow_kappa, neg_one },
-                      { kappa, zero } };
-        opening_claims.emplace_back(claim);
-
-        // Move commitment_idx to the index of [l_{j+1}]
-        commitment_idx += NUM_WIRES - 1;
+        evals.emplace_back(transcript->template receive_from_prover<FF>("LEFT_TABLE_EVAL_" + std::to_string(idx)));
+    }
+    for (size_t idx = 0; idx < NUM_WIRES; ++idx) {
+        evals.emplace_back(transcript->template receive_from_prover<FF>("RIGHT_TABLE_EVAL_" + std::to_string(idx)));
+    }
+    for (size_t idx = 0; idx < NUM_WIRES; ++idx) {
+        evals.emplace_back(transcript->template receive_from_prover<FF>("MERGED_TABLE_EVAL_" + std::to_string(idx)));
     }
 
-    // Boolean keeping track of the degree identities (only used in native case)
+    // Receive evaluation of G at 1/kappa
+    evals.emplace_back(transcript->template receive_from_prover<FF>("REVERSED_BATCHED_LEFT_TABLES_EVAL"));
+
+    // Check concatenation identities
+    bool concatenation_verified = true;
+    FF concatenation_diff(0);
+    for (size_t idx = 0; idx < NUM_WIRES; idx++) {
+        concatenation_diff = evals[idx] + (pow_kappa * evals[idx + NUM_WIRES]) - evals[idx + (2 * NUM_WIRES)];
+        if constexpr (IsRecursive) {
+            concatenation_diff.assert_equal(FF(0),
+                                            "assert_equal: merge concatenation identity failed in Merge Verifier");
+            concatenation_verified &= concatenation_diff.get_value() == 0;
+        } else {
+            concatenation_verified &= concatenation_diff == 0;
+        }
+    }
+
+    // Check degree identity
     bool degree_check_verified = true;
-
-    // Add opening claim for l_j(1/kappa), g_j(kappa) and check g_j(kappa) = l_j(1/kappa) * kappa^{k-1}
-    commitment_idx = 0;
-    FF batched_left_tables_eval(0);
+    FF degree_check_diff(0);
     for (size_t idx = 0; idx < NUM_WIRES; ++idx) {
-        // Opening claim for l_j(1/kappa)
-        FF left_table_eval_kappa_inv =
-            transcript->template receive_from_prover<FF>("left_table_eval_kappa_inv_" + std::to_string(idx));
-        Claims claim = { { commitment_idx }, { one }, { kappa_inv, left_table_eval_kappa_inv } };
-        opening_claims.emplace_back(claim);
-
-        batched_left_tables_eval += left_table_eval_kappa_inv * degree_check_challenges[idx];
-
-        // Move commitment_idx to index of left_table_{j+1}
-        commitment_idx += NUM_WIRES - 1;
+        degree_check_diff += evals[idx] * degree_check_challenges[idx];
     }
-
-    // Opening claim for g(kappa)
-    FF reversed_batched_left_tables_eval =
-        transcript->template receive_from_prover<FF>("reversed_batched_left_tables_eval");
-    Claims claim = { { table_commitments.size() - 1 }, { one }, { kappa, reversed_batched_left_tables_eval } };
-    opening_claims.emplace_back(claim);
-
-    // Degree identity check
+    degree_check_diff -= evals.back() * pow_kappa_minus_one;
     if constexpr (IsRecursive) {
-        // For debugging purposes
-        degree_check_verified = (reversed_batched_left_tables_eval.get_value() ==
-                                 (batched_left_tables_eval.get_value() * pow_kappa_minus_one.get_value()));
-
-        // Constrain the equality in-circuit
-        reversed_batched_left_tables_eval.assert_equal(batched_left_tables_eval * pow_kappa_minus_one,
-                                                       "assert_equal: degree check identity failed in Merge Verifier");
-
+        degree_check_diff.assert_equal(FF(0), "assert_equal: merge degree identity failed in Merge Verifier");
+        degree_check_verified &= degree_check_diff.get_value() == 0;
     } else {
-        // In native case, track as a boolean
-        degree_check_verified = (reversed_batched_left_tables_eval == (batched_left_tables_eval * pow_kappa_minus_one));
+        degree_check_verified &= degree_check_diff == 0;
     }
 
-    // Initialize Shplonk verifier
-    ShplonkVerifier_<Curve> verifier(table_commitments, transcript, opening_claims.size());
-    verifier.reduce_verification_vector_claims_no_finalize(opening_claims);
+    // Receive Shplonk batched quotient
+    Commitment shplonk_batched_quotient =
+        transcript->template receive_from_prover<Commitment>("SHPLONK_BATCHED_QUOTIENT");
 
-    // Export batched claim
-    Commitment one_commitment;
+    // Generate Shplonk opening challenge
+    FF shplonk_opening_challenge = transcript->template get_challenge<FF>("shplonk_opening_challenge");
+
+    // Prepare batched opening claim to be passed to KZG
+    BatchOpeningClaim<Curve> batch_opening_claim;
+
+    batch_opening_claim.commitments = { shplonk_batched_quotient };
+    for (auto& commitment : table_commitments) {
+        batch_opening_claim.commitments.emplace_back(-std::move(commitment));
+    }
     if constexpr (IsRecursive) {
-        one_commitment = Commitment::one(kappa.get_context());
+        batch_opening_claim.commitments.emplace_back(Commitment::one(kappa.get_context()));
     } else {
-        one_commitment = Commitment::one();
+        batch_opening_claim.commitments.emplace_back(Commitment::one());
     }
-    auto batch_opening_claim = verifier.export_batch_opening_claim(one_commitment);
 
+    batch_opening_claim.scalars = { (shplonk_opening_challenge - kappa) };
+    for (auto& scalar : shplonk_batching_challenges) {
+        batch_opening_claim.scalars.emplace_back(std::move(scalar));
+    }
+    batch_opening_claim.scalars.back() *=
+        (shplonk_opening_challenge - kappa) * (shplonk_opening_challenge - kappa_inv).invert();
+
+    batch_opening_claim.scalars.emplace_back(FF(0));
+    for (size_t idx = 0; idx < evals.size(); idx++) {
+        if (idx < evals.size() - 1) {
+            batch_opening_claim.scalars.back() += evals[idx] * shplonk_batching_challenges[idx];
+        } else {
+            batch_opening_claim.scalars.back() += shplonk_batching_challenges.back() * evals.back() *
+                                                  (shplonk_opening_challenge - kappa) *
+                                                  (shplonk_opening_challenge - kappa_inv).invert();
+        }
+    }
+
+    batch_opening_claim.evaluation_point = { shplonk_opening_challenge };
+
+    size_t num_rows = 0;
+    if constexpr (IsRecursive) {
+        if constexpr (IsMegaBuilder<typename Curve::Builder>) {
+            num_rows = kappa.get_context()->op_queue->get_num_rows();
+        }
+    };
     // KZG verifier - returns PairingPoints directly
     PairingPoints pairing_points = PCS::reduce_verify_batch_opening_claim(batch_opening_claim, transcript);
+
+    if constexpr (IsRecursive) {
+        if constexpr (IsMegaBuilder<typename Curve::Builder>) {
+            info("NUM ROWS ADDED: ", kappa.get_context()->op_queue->get_num_rows() - num_rows);
+        }
+    };
 
     return { pairing_points, merged_table_commitments, degree_check_verified };
 }

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/merge_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/merge_verifier.cpp
@@ -77,22 +77,13 @@ typename MergeVerifier_<Curve>::VerificationResult MergeVerifier_<Curve>::verify
     }
 
     // Generate degree check batching challenges
-    std::array<std::string, NUM_WIRES> labels_degree_check;
-    for (size_t idx = 0; idx < NUM_WIRES; ++idx) {
-        labels_degree_check[idx] = "LEFT_TABLE_DEGREE_CHECK_" + std::to_string(idx);
-    }
-    std::array<FF, NUM_WIRES> degree_check_challenges =
-        transcript->template get_challenges<FF, NUM_WIRES>(labels_degree_check);
+    std::vector<FF> degree_check_challenges = transcript->template get_challenges<FF>(labels_degree_check);
 
     // Receive commitment to reversed batched left table
     table_commitments.emplace_back(
         transcript->template receive_from_prover<Commitment>("REVERSED_BATCHED_LEFT_TABLES"));
 
     // Compute batching challenges
-    std::vector<std::string> labels_shplonk_batching_challenges((3 * NUM_WIRES) + 1);
-    for (size_t idx = 0; idx < 3 * NUM_WIRES + 1; idx++) {
-        labels_shplonk_batching_challenges[idx] = "SHPLONK_MERGE_BATCHING_CHALLENGE_" + std::to_string(idx);
-    }
     std::vector<FF> shplonk_batching_challenges =
         transcript->template get_challenges<FF>(labels_shplonk_batching_challenges);
 
@@ -119,32 +110,10 @@ typename MergeVerifier_<Curve>::VerificationResult MergeVerifier_<Curve>::verify
     evals.emplace_back(transcript->template receive_from_prover<FF>("REVERSED_BATCHED_LEFT_TABLES_EVAL"));
 
     // Check concatenation identities
-    bool concatenation_verified = true;
-    FF concatenation_diff(0);
-    for (size_t idx = 0; idx < NUM_WIRES; idx++) {
-        concatenation_diff = evals[idx] + (pow_kappa * evals[idx + NUM_WIRES]) - evals[idx + (2 * NUM_WIRES)];
-        if constexpr (IsRecursive) {
-            concatenation_diff.assert_equal(FF(0),
-                                            "assert_equal: merge concatenation identity failed in Merge Verifier");
-            concatenation_verified &= concatenation_diff.get_value() == 0;
-        } else {
-            concatenation_verified &= concatenation_diff == 0;
-        }
-    }
+    bool concatenation_verified = check_concatenation_identities(evals, pow_kappa);
 
     // Check degree identity
-    bool degree_check_verified = true;
-    FF degree_check_diff(0);
-    for (size_t idx = 0; idx < NUM_WIRES; ++idx) {
-        degree_check_diff += evals[idx] * degree_check_challenges[idx];
-    }
-    degree_check_diff -= evals.back() * pow_kappa_minus_one;
-    if constexpr (IsRecursive) {
-        degree_check_diff.assert_equal(FF(0), "assert_equal: merge degree identity failed in Merge Verifier");
-        degree_check_verified &= degree_check_diff.get_value() == 0;
-    } else {
-        degree_check_verified &= degree_check_diff == 0;
-    }
+    bool degree_check_verified = check_degree_identity(evals, pow_kappa_minus_one, degree_check_challenges);
 
     // Receive Shplonk batched quotient
     Commitment shplonk_batched_quotient =
@@ -154,54 +123,18 @@ typename MergeVerifier_<Curve>::VerificationResult MergeVerifier_<Curve>::verify
     FF shplonk_opening_challenge = transcript->template get_challenge<FF>("shplonk_opening_challenge");
 
     // Prepare batched opening claim to be passed to KZG
-    BatchOpeningClaim<Curve> batch_opening_claim;
+    BatchOpeningClaim<Curve> batch_opening_claim = compute_shplonk_opening_claim(table_commitments,
+                                                                                 shplonk_batched_quotient,
+                                                                                 shplonk_opening_challenge,
+                                                                                 shplonk_batching_challenges,
+                                                                                 kappa,
+                                                                                 kappa_inv,
+                                                                                 evals);
 
-    batch_opening_claim.commitments = { shplonk_batched_quotient };
-    for (auto& commitment : table_commitments) {
-        batch_opening_claim.commitments.emplace_back(-std::move(commitment));
-    }
-    if constexpr (IsRecursive) {
-        batch_opening_claim.commitments.emplace_back(Commitment::one(kappa.get_context()));
-    } else {
-        batch_opening_claim.commitments.emplace_back(Commitment::one());
-    }
-
-    batch_opening_claim.scalars = { (shplonk_opening_challenge - kappa) };
-    for (auto& scalar : shplonk_batching_challenges) {
-        batch_opening_claim.scalars.emplace_back(std::move(scalar));
-    }
-    batch_opening_claim.scalars.back() *=
-        (shplonk_opening_challenge - kappa) * (shplonk_opening_challenge - kappa_inv).invert();
-
-    batch_opening_claim.scalars.emplace_back(FF(0));
-    for (size_t idx = 0; idx < evals.size(); idx++) {
-        if (idx < evals.size() - 1) {
-            batch_opening_claim.scalars.back() += evals[idx] * shplonk_batching_challenges[idx];
-        } else {
-            batch_opening_claim.scalars.back() += shplonk_batching_challenges.back() * evals.back() *
-                                                  (shplonk_opening_challenge - kappa) *
-                                                  (shplonk_opening_challenge - kappa_inv).invert();
-        }
-    }
-
-    batch_opening_claim.evaluation_point = { shplonk_opening_challenge };
-
-    size_t num_rows = 0;
-    if constexpr (IsRecursive) {
-        if constexpr (IsMegaBuilder<typename Curve::Builder>) {
-            num_rows = kappa.get_context()->op_queue->get_num_rows();
-        }
-    };
     // KZG verifier - returns PairingPoints directly
     PairingPoints pairing_points = PCS::reduce_verify_batch_opening_claim(batch_opening_claim, transcript);
 
-    if constexpr (IsRecursive) {
-        if constexpr (IsMegaBuilder<typename Curve::Builder>) {
-            info("NUM ROWS ADDED: ", kappa.get_context()->op_queue->get_num_rows() - num_rows);
-        }
-    };
-
-    return { pairing_points, merged_table_commitments, degree_check_verified };
+    return { pairing_points, merged_table_commitments, degree_check_verified, concatenation_verified };
 }
 
 // Explicit template instantiations

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/merge_verifier.hpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/merge_verifier.hpp
@@ -142,17 +142,17 @@ template <typename Curve> class MergeVerifier_ {
                                                            const std::vector<FF>& evals) const
     {
         // Claim {Q', (z, 0)} expressed as
-        // Q' = Q * (z - \kappa) +
-        //      - \sum_i \beta_i L_i - \sum_i \beta_i R_i - \sum_i \beta_i M_i
-        //      - (z - \kappa) / (z - \kappa^{-1}) * \beta_i G
-        //      + \sum_i \beta_i l_i + \sum_i \beta_i r_i + \sum_i \beta_i m_i
-        //      + (z - \kappa) / (z - \kappa^{-1}) * \beta_i * g
+        // Q' = -Q * (z - \kappa) +
+        //      + \sum_i \beta_i L_i - \sum_i \beta_i R_i - \sum_i \beta_i M_i
+        //      + (z - \kappa) / (z - \kappa^{-1}) * \beta_i G
+        //      - \sum_i \beta_i l_i - \sum_i \beta_i r_i - \sum_i \beta_i m_i
+        //      - (z - \kappa) / (z - \kappa^{-1}) * \beta_i * g
         BatchOpeningClaim<Curve> batch_opening_claim;
 
         // Commitment: [L_1], [L_2], ..., [L_n], [R_1], ..., [R_n], [M_1], ..., [M_n], [G], [1]
         batch_opening_claim.commitments = { std::move(shplonk_batched_quotient) };
         for (auto& commitment : table_commitments) {
-            batch_opening_claim.commitments.emplace_back(-std::move(commitment));
+            batch_opening_claim.commitments.emplace_back(std::move(commitment));
         }
         if constexpr (IsRecursive) {
             batch_opening_claim.commitments.emplace_back(Commitment::one(kappa.get_context()));
@@ -161,10 +161,11 @@ template <typename Curve> class MergeVerifier_ {
         }
 
         // Scalars:
-        // (shplonk_opening_challenge - kappa), \beta_1, ..., \beta_12,
+        // -(shplonk_opening_challenge - kappa), \beta_1, ..., \beta_12,
         // \beta_13 * (z - \kappa) / (z - \kappa^{-1})
-        // \sum_i \beta_i l_i + \sum_i \beta_i r_i + \sum_i \beta_i m_i + \beta_13 * (z - \kappa) / (z - \kappa^{-1})* g
-        batch_opening_claim.scalars = { (shplonk_opening_challenge - kappa) };
+        // - ( \sum_i \beta_i l_i + \sum_i \beta_i r_i + \sum_i \beta_i m_i
+        //          + \beta_13 * (z - \kappa) / (z - \kappa^{-1})* g )
+        batch_opening_claim.scalars = { -(shplonk_opening_challenge - kappa) };
         for (auto& scalar : shplonk_batching_challenges) {
             batch_opening_claim.scalars.emplace_back(std::move(scalar));
         }
@@ -174,9 +175,9 @@ template <typename Curve> class MergeVerifier_ {
         batch_opening_claim.scalars.emplace_back(FF(0));
         for (size_t idx = 0; idx < evals.size(); idx++) {
             if (idx < evals.size() - 1) {
-                batch_opening_claim.scalars.back() += evals[idx] * shplonk_batching_challenges[idx];
+                batch_opening_claim.scalars.back() -= evals[idx] * shplonk_batching_challenges[idx];
             } else {
-                batch_opening_claim.scalars.back() += shplonk_batching_challenges.back() * evals.back() *
+                batch_opening_claim.scalars.back() -= shplonk_batching_challenges.back() * evals.back() *
                                                       (shplonk_opening_challenge - kappa) *
                                                       (shplonk_opening_challenge - kappa_inv).invert();
             }

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/merge_verifier.hpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/merge_verifier.hpp
@@ -183,6 +183,8 @@ template <typename Curve> class MergeVerifier_ {
         }
 
         batch_opening_claim.evaluation_point = { shplonk_opening_challenge };
+
+        return batch_opening_claim;
     };
 };
 

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/merge_verifier.hpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/merge_verifier.hpp
@@ -57,6 +57,7 @@ template <typename Curve> class MergeVerifier_ {
         PairingPoints pairing_points;
         TableCommitments merged_commitments;
         bool degree_check_passed;
+        bool concatenation_check_passed;
     };
 
     MergeSettings settings;
@@ -78,6 +79,111 @@ template <typename Curve> class MergeVerifier_ {
      */
     [[nodiscard("Verification result should be checked")]] VerificationResult verify_proof(
         const Proof& proof, const InputCommitments& input_commitments);
+
+  private:
+    std::vector<std::string> labels_degree_check = { "LEFT_TABLE_DEGREE_CHECK_0",
+                                                     "LEFT_TABLE_DEGREE_CHECK_1",
+                                                     "LEFT_TABLE_DEGREE_CHECK_2",
+                                                     "LEFT_TABLE_DEGREE_CHECK_3" };
+
+    std::vector<std::string> labels_shplonk_batching_challenges = {
+        "SHPLONK_MERGE_BATCHING_CHALLENGE_0",  "SHPLONK_MERGE_BATCHING_CHALLENGE_1",
+        "SHPLONK_MERGE_BATCHING_CHALLENGE_2",  "SHPLONK_MERGE_BATCHING_CHALLENGE_3",
+        "SHPLONK_MERGE_BATCHING_CHALLENGE_4",  "SHPLONK_MERGE_BATCHING_CHALLENGE_5",
+        "SHPLONK_MERGE_BATCHING_CHALLENGE_6",  "SHPLONK_MERGE_BATCHING_CHALLENGE_7",
+        "SHPLONK_MERGE_BATCHING_CHALLENGE_8",  "SHPLONK_MERGE_BATCHING_CHALLENGE_9",
+        "SHPLONK_MERGE_BATCHING_CHALLENGE_10", "SHPLONK_MERGE_BATCHING_CHALLENGE_11",
+        "SHPLONK_MERGE_BATCHING_CHALLENGE_12"
+    };
+
+    bool check_concatenation_identities(std::vector<FF>& evals, const FF& pow_kappa) const
+    {
+        bool concatenation_verified = true;
+        FF concatenation_diff(0);
+        for (size_t idx = 0; idx < NUM_WIRES; idx++) {
+            concatenation_diff = evals[idx] + (pow_kappa * evals[idx + NUM_WIRES]) - evals[idx + (2 * NUM_WIRES)];
+            if constexpr (IsRecursive) {
+                concatenation_diff.assert_equal(FF(0),
+                                                "assert_equal: merge concatenation identity failed in Merge Verifier");
+                concatenation_verified &= concatenation_diff.get_value() == 0;
+            } else {
+                concatenation_verified &= concatenation_diff == 0;
+            }
+        }
+        return concatenation_verified;
+    };
+
+    bool check_degree_identity(std::vector<FF>& evals,
+                               const FF& pow_kappa_minus_one,
+                               const std::vector<FF>& degree_check_challenges) const
+    {
+        bool degree_check_verified = true;
+        FF degree_check_diff(0);
+        for (size_t idx = 0; idx < NUM_WIRES; ++idx) {
+            degree_check_diff += evals[idx] * degree_check_challenges[idx];
+        }
+        degree_check_diff -= evals.back() * pow_kappa_minus_one;
+        if constexpr (IsRecursive) {
+            degree_check_diff.assert_equal(FF(0), "assert_equal: merge degree identity failed in Merge Verifier");
+            degree_check_verified &= degree_check_diff.get_value() == 0;
+        } else {
+            degree_check_verified &= degree_check_diff == 0;
+        }
+
+        return degree_check_verified;
+    };
+
+    BatchOpeningClaim<Curve> compute_shplonk_opening_claim(const std::vector<Commitment>& table_commitments,
+                                                           const Commitment& shplonk_batched_quotient,
+                                                           const FF& shplonk_opening_challenge,
+                                                           const std::vector<FF>& shplonk_batching_challenges,
+                                                           const FF& kappa,
+                                                           const FF& kappa_inv,
+                                                           const std::vector<FF>& evals) const
+    {
+        // Claim {Q', (z, 0)} expressed as
+        // Q' = Q * (z - \kappa) +
+        //      - \sum_i \beta_i L_i - \sum_i \beta_i R_i - \sum_i \beta_i M_i
+        //      - (z - \kappa) / (z - \kappa^{-1}) * \beta_i G
+        //      + \sum_i \beta_i l_i + \sum_i \beta_i r_i + \sum_i \beta_i m_i
+        //      + (z - \kappa) / (z - \kappa^{-1}) * \beta_i * g
+        BatchOpeningClaim<Curve> batch_opening_claim;
+
+        // Commitment: [L_1], [L_2], ..., [L_n], [R_1], ..., [R_n], [M_1], ..., [M_n], [G], [1]
+        batch_opening_claim.commitments = { std::move(shplonk_batched_quotient) };
+        for (auto& commitment : table_commitments) {
+            batch_opening_claim.commitments.emplace_back(-std::move(commitment));
+        }
+        if constexpr (IsRecursive) {
+            batch_opening_claim.commitments.emplace_back(Commitment::one(kappa.get_context()));
+        } else {
+            batch_opening_claim.commitments.emplace_back(Commitment::one());
+        }
+
+        // Scalars:
+        // (shplonk_opening_challenge - kappa), \beta_1, ..., \beta_12,
+        // \beta_13 * (z - \kappa) / (z - \kappa^{-1})
+        // \sum_i \beta_i l_i + \sum_i \beta_i r_i + \sum_i \beta_i m_i + \beta_13 * (z - \kappa) / (z - \kappa^{-1})* g
+        batch_opening_claim.scalars = { (shplonk_opening_challenge - kappa) };
+        for (auto& scalar : shplonk_batching_challenges) {
+            batch_opening_claim.scalars.emplace_back(std::move(scalar));
+        }
+        batch_opening_claim.scalars.back() *=
+            (shplonk_opening_challenge - kappa) * (shplonk_opening_challenge - kappa_inv).invert();
+
+        batch_opening_claim.scalars.emplace_back(FF(0));
+        for (size_t idx = 0; idx < evals.size(); idx++) {
+            if (idx < evals.size() - 1) {
+                batch_opening_claim.scalars.back() += evals[idx] * shplonk_batching_challenges[idx];
+            } else {
+                batch_opening_claim.scalars.back() += shplonk_batching_challenges.back() * evals.back() *
+                                                      (shplonk_opening_challenge - kappa) *
+                                                      (shplonk_opening_challenge - kappa_inv).invert();
+            }
+        }
+
+        batch_opening_claim.evaluation_point = { shplonk_opening_challenge };
+    };
 };
 
 // Type aliases for convenience

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/merge_verifier.hpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/merge_verifier.hpp
@@ -103,9 +103,9 @@ template <typename Curve> class MergeVerifier_ {
         for (size_t idx = 0; idx < NUM_WIRES; idx++) {
             concatenation_diff = evals[idx] + (pow_kappa * evals[idx + NUM_WIRES]) - evals[idx + (2 * NUM_WIRES)];
             if constexpr (IsRecursive) {
+                concatenation_verified &= concatenation_diff.get_value() == 0;
                 concatenation_diff.assert_equal(FF(0),
                                                 "assert_equal: merge concatenation identity failed in Merge Verifier");
-                concatenation_verified &= concatenation_diff.get_value() == 0;
             } else {
                 concatenation_verified &= concatenation_diff == 0;
             }

--- a/noir-projects/noir-protocol-circuits/crates/types/src/constants.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/constants.nr
@@ -569,7 +569,7 @@ pub global ULTRA_KECCAK_PROOF_LENGTH: u32 = 350; // See UltraKeccakFlavor for fo
 pub global RECURSIVE_ROLLUP_HONK_PROOF_LENGTH: u32 =
     RECURSIVE_PROOF_LENGTH + IPA_CLAIM_SIZE + IPA_PROOF_LENGTH;
 pub global NESTED_RECURSIVE_ROLLUP_HONK_PROOF_LENGTH: u32 = RECURSIVE_ROLLUP_HONK_PROOF_LENGTH;
-pub global CHONK_PROOF_LENGTH: u32 = 2084;
+pub global CHONK_PROOF_LENGTH: u32 = 2077;
 
 pub global ULTRA_VK_LENGTH_IN_FIELDS: u32 = 115; // size of an Ultra verification key
 pub global MEGA_VK_LENGTH_IN_FIELDS: u32 = 127; // size of a Mega verification key


### PR DESCRIPTION
We refactor the Merge protocol to optimise the number of rows used. With the version implemented in this PR, one recursive merge verification requires `196` rows instead of `295` (as required once https://github.com/AztecProtocol/aztec-packages/pull/18113 gets in).

The refactoring does two things:
- Open the left, right, and merged tables at $\kappa$ (so the verifier checks the identities $l_i + \kappa^d r_i = m_i$, where $l_i, r_i, m_i$ are the purported openings)
- Open $G$ (the batched polynomial for the degree check) at $\kappa^{-1}$
- Rescale the Shplonk equation by $- (z - \kappa)$ so that the commitments to left, right, and merged tables have short scalars. 

The reason for $-(z - \kappa)$ and not $z - \kappa$ is to avoid having to manually mark some witnesses as used (if we scaled by $z - \kappa$ we would have to negate the commitments to left, right, and merged tables to leverage short scalars in the ECCVM; however, this would create some witnesses used only in one gate, which would alert the boomerang tools. To avoid this, we rescale the equation by $-(z - \kappa)$ ).

The rolled out protocol is here: https://hackmd.io/Hv1jZWj8RXeubCZ2ISsKKg?both