### PR TITLE
chore: track snapshot duration

### DIFF
--- a/yarn-project/telemetry-client/src/metrics.ts
+++ b/yarn-project/telemetry-client/src/metrics.ts
@@ -63,6 +63,9 @@ export const ARCHIVER_TOTAL_TXS = 'aztec.archiver.tx_count';
 export const NODE_RECEIVE_TX_DURATION = 'aztec.node.receive_tx.duration';
 export const NODE_RECEIVE_TX_COUNT = 'aztec.node.receive_tx.count';
 
+export const NODE_SNAPSHOT_DURATION = 'aztec.node.snapshot_duration';
+export const NODE_SNAPSHOT_ERROR_COUNT = 'aztec.node.snapshot_error_count';
+
 export const SEQUENCER_STATE_TRANSITION_BUFFER_DURATION = 'aztec.sequencer.state_transition_buffer.duration';
 export const SEQUENCER_BLOCK_BUILD_DURATION = 'aztec.sequencer.block.build_duration';
 export const SEQUENCER_BLOCK_BUILD_MANA_PER_SECOND = 'aztec.sequencer.block.build_mana_per_second';


### PR DESCRIPTION
This PR adds new metrics to track snapshot success/errors. This needs to be backported to v2.

I'll open a separate PR to define an alert on the `snapshot_error_count` metric but this one doesn't need to be backported to v2 and I don't want to risk merge conflicts because of it.

Fix A-201