### PR TITLE
feat: add TypeScript branded types for Noir's u32, u64 and u128

### DIFF
--- a/yarn-project/aztec.js/src/utils/abi_types.ts
+++ b/yarn-project/aztec.js/src/utils/abi_types.ts
@@ -1,5 +1,6 @@
 import type { EthAddress } from '@aztec/foundation/eth-address';
 import type { Fr } from '@aztec/foundation/fields';
+import type { U128 } from '@aztec/foundation/serialize';
 import type { EventSelector, FunctionSelector } from '@aztec/stdlib/abi';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
 
@@ -19,7 +20,7 @@ export type FunctionSelectorLike = FieldLike | FunctionSelector;
 export type EventSelectorLike = FieldLike | EventSelector;
 
 /** Any type that can be converted into a U128. */
-export type U128Like = bigint | number;
+export type U128Like = U128 | bigint | number;
 
 /** Any type that can be converted into a struct with a single `inner` field. */
 export type WrappedFieldLike = { /** Wrapped value */ inner: FieldLike } | FieldLike;

--- a/yarn-project/foundation/src/serialize/field_reader.test.ts
+++ b/yarn-project/foundation/src/serialize/field_reader.test.ts
@@ -1,4 +1,6 @@
 import { Fq, Fr } from '../fields/fields.js';
+import type { U32, U64, U128 } from './types.js';
+import { toU32 } from './types.js';
 import { FieldReader } from './field_reader.js';
 
 const FIELDS = [new Fr(0), new Fr(1), new Fr(23), new Fr(45), new Fr(6789)];
@@ -6,7 +8,7 @@ const FIELDS = [new Fr(0), new Fr(1), new Fr(23), new Fr(45), new Fr(6789)];
 class Something {
   constructor(
     public id: Fr,
-    public value: number,
+    public value: U32,
   ) {}
 
   static fromFields(reader: FieldReader): Something {
@@ -90,17 +92,45 @@ describe('field reader', () => {
   });
 
   describe('readU32', () => {
-    it('should return number', () => {
-      expect(reader.readU32()).toBe(0);
-      expect(reader.readU32()).toBe(1);
-      expect(reader.readU32()).toBe(23);
-      expect(reader.readU32()).toBe(45);
-      expect(reader.readU32()).toBe(6789);
+    it('should return U32 branded type', () => {
+      expect(Number(reader.readU32())).toBe(0);
+      expect(Number(reader.readU32())).toBe(1);
+      expect(Number(reader.readU32())).toBe(23);
+      expect(Number(reader.readU32())).toBe(45);
+      expect(Number(reader.readU32())).toBe(6789);
     });
 
     it('should throw if reading a value larger than u32', () => {
       const reader = new FieldReader([new Fr(2n ** 32n)]);
       expect(() => reader.readU32()).toThrow('Field is not a u32.');
+    });
+  });
+
+  describe('readU64', () => {
+    it('should return U64 branded type', () => {
+      const reader = new FieldReader([new Fr(0n), new Fr(1n), new Fr(1234567890123456789n)]);
+      expect(Number(reader.readU64())).toBe(0);
+      expect(Number(reader.readU64())).toBe(1);
+      expect(reader.readU64()).toBe(1234567890123456789n);
+    });
+
+    it('should throw if reading a value larger than u64', () => {
+      const reader = new FieldReader([new Fr(2n ** 64n)]);
+      expect(() => reader.readU64()).toThrow('Field is not a u64.');
+    });
+  });
+
+  describe('readU128', () => {
+    it('should return U128 branded type', () => {
+      const reader = new FieldReader([new Fr(0n), new Fr(1n), new Fr(123456789012345678901234567890n)]);
+      expect(Number(reader.readU128())).toBe(0);
+      expect(Number(reader.readU128())).toBe(1);
+      expect(reader.readU128()).toBe(123456789012345678901234567890n);
+    });
+
+    it('should throw if reading a value larger than u128', () => {
+      const reader = new FieldReader([new Fr(2n ** 128n)]);
+      expect(() => reader.readU128()).toThrow('Field is not a u128.');
     });
   });
 
@@ -117,7 +147,7 @@ describe('field reader', () => {
   describe('readArray', () => {
     it('should read array of custom type', () => {
       const things = reader.readArray(2, Something);
-      expect(things).toEqual([new Something(new Fr(0), 1), new Something(new Fr(23), 45)]);
+      expect(things).toEqual([new Something(new Fr(0), toU32(1)), new Something(new Fr(23), toU32(45))]);
     });
 
     it('should throw if reading more fields than in the reader', () => {
@@ -127,8 +157,8 @@ describe('field reader', () => {
 
   describe('readObject', () => {
     it('should read object from buffer', () => {
-      expect(reader.readObject(Something)).toEqual(new Something(new Fr(0), 1));
-      expect(reader.readObject(Something)).toEqual(new Something(new Fr(23), 45));
+      expect(reader.readObject(Something)).toEqual(new Something(new Fr(0), toU32(1)));
+      expect(reader.readObject(Something)).toEqual(new Something(new Fr(23), toU32(45)));
 
       expect(() => reader.readObject(Something)).toThrow('Not enough fields to be consumed.');
     });

--- a/yarn-project/foundation/src/serialize/field_reader.ts
+++ b/yarn-project/foundation/src/serialize/field_reader.ts
@@ -1,5 +1,6 @@
 import { Fq, type Fr } from '../fields/fields.js';
-import type { Tuple } from './types.js';
+import type { Tuple, U32, U64, U128 } from './types.js';
+import { toU32, toU64, toU128 } from './types.js';
 
 /**
  * The FieldReader class provides a utility for reading various data types from a field array.
@@ -118,15 +119,15 @@ export class FieldReader {
    * Updates the index position by 1 after reading the number.
    * Throw if the value is greater than 2 ** 32.
    *
-   * @returns The read 32-bit unsigned integer value.
+   * @returns The read 32-bit unsigned integer value as a branded U32 type.
    */
-  public readU32(): number {
+  public readU32(): U32 {
     const field = this.readField();
     const value = field.toBigInt();
     if (value >= 1n << 32n) {
       throw new Error('Field is not a u32.');
     }
-    return Number(value);
+    return toU32(Number(value));
   }
 
   /**
@@ -134,15 +135,31 @@ export class FieldReader {
    * Updates the index position by 1 after reading the number.
    * Throw if the value is greater than 2 ** 64.
    *
-   * @returns The read 64-bit unsigned integer value as a bigint.
+   * @returns The read 64-bit unsigned integer value as a branded U64 type.
    */
-  public readU64(): bigint {
+  public readU64(): U64 {
     const field = this.readField();
     const value = field.toBigInt();
     if (value >= 1n << 64n) {
       throw new Error('Field is not a u64.');
     }
-    return value;
+    return toU64(value);
+  }
+
+  /**
+   * Reads a 128-bit unsigned integer from the field array at the current index position.
+   * Updates the index position by 1 after reading the number.
+   * Throw if the value is greater than 2 ** 128.
+   *
+   * @returns The read 128-bit unsigned integer value as a branded U128 type.
+   */
+  public readU128(): U128 {
+    const field = this.readField();
+    const value = field.toBigInt();
+    if (value >= 1n << 128n) {
+      throw new Error('Field is not a u128.');
+    }
+    return toU128(value);
   }
 
   /**

--- a/yarn-project/foundation/src/serialize/types.ts
+++ b/yarn-project/foundation/src/serialize/types.ts
@@ -1,4 +1,64 @@
 /**
+ * Branded type for Noir's u32 (32-bit unsigned integer).
+ * This ensures type safety at compile time and prevents mixing u32 with other integer types.
+ */
+export type U32 = number & { readonly __brand: 'U32' };
+
+/**
+ * Branded type for Noir's u64 (64-bit unsigned integer).
+ * This ensures type safety at compile time and prevents mixing u64 with other integer types.
+ */
+export type U64 = bigint & { readonly __brand: 'U64' };
+
+/**
+ * Branded type for Noir's u128 (128-bit unsigned integer).
+ * This ensures type safety at compile time and prevents mixing u128 with other integer types.
+ */
+export type U128 = bigint & { readonly __brand: 'U128' };
+
+/**
+ * Creates a U32 branded type from a number.
+ * Validates that the value is within the u32 range (0 to 2^32 - 1).
+ * @param value - The number value to convert to U32.
+ * @returns The value as U32.
+ * @throws Error if the value is out of range.
+ */
+export function toU32(value: number): U32 {
+  if (value < 0 || value >= 2 ** 32 || !Number.isInteger(value)) {
+    throw new Error(`Value ${value} is not a valid u32.`);
+  }
+  return value as U32;
+}
+
+/**
+ * Creates a U64 branded type from a bigint.
+ * Validates that the value is within the u64 range (0 to 2^64 - 1).
+ * @param value - The bigint value to convert to U64.
+ * @returns The value as U64.
+ * @throws Error if the value is out of range.
+ */
+export function toU64(value: bigint): U64 {
+  if (value < 0n || value >= 1n << 64n) {
+    throw new Error(`Value ${value} is not a valid u64.`);
+  }
+  return value as U64;
+}
+
+/**
+ * Creates a U128 branded type from a bigint.
+ * Validates that the value is within the u128 range (0 to 2^128 - 1).
+ * @param value - The bigint value to convert to U128.
+ * @returns The value as U128.
+ * @throws Error if the value is out of range.
+ */
+export function toU128(value: bigint): U128 {
+  if (value < 0n || value >= 1n << 128n) {
+    throw new Error(`Value ${value} is not a valid u128.`);
+  }
+  return value as U128;
+}
+
+/**
  * Represents a fixed-length array.
  */
 export type Tuple<T, N extends number> = N extends N ? (number extends N ? T[] : _Tuple<T, N, []>) : never;

--- a/yarn-project/stdlib/src/kernel/utils/optional_number.ts
+++ b/yarn-project/stdlib/src/kernel/utils/optional_number.ts
@@ -37,7 +37,7 @@ export class OptionalNumber {
 
   static fromFields(fields: Fr[] | FieldReader): OptionalNumber {
     const reader = FieldReader.asReader(fields);
-    return new OptionalNumber(reader.readBoolean(), reader.readU32());
+    return new OptionalNumber(reader.readBoolean(), Number(reader.readU32()));
   }
 
   isEmpty(): boolean {


### PR DESCRIPTION
Fixes #17587

Adds TypeScript branded types for Noir's u32, u64, u128 to enable compile-time type safety.

- Adds `U32`, `U64`, `U128` branded types with validation helpers
- Updates `FieldReader` methods to return branded types
- Adds `readU128()` method
- Updates tests and type definitions