### PR TITLE
feat!: Efficient MSM in Hypernova

### DIFF
--- a/barretenberg/cpp/scripts/test_chonk_standalone_vks_havent_changed.sh
+++ b/barretenberg/cpp/scripts/test_chonk_standalone_vks_havent_changed.sh
@@ -13,7 +13,7 @@ cd ..
 # - Generate a hash for versioning: sha256sum bb-chonk-inputs.tar.gz
 # - Upload the compressed results: aws s3 cp bb-chonk-inputs.tar.gz s3://aztec-ci-artifacts/protocol/bb-chonk-inputs-[hash(0:8)].tar.gz
 # Note: In case of the "Test suite failed to run ... Unexpected token 'with' " error, need to run: docker pull aztecprotocol/build:3.0
-pinned_short_hash="d99ed82f"
+pinned_short_hash="4e9e8017"
 pinned_chonk_inputs_url="https://aztec-ci-artifacts.s3.us-east-2.amazonaws.com/protocol/bb-chonk-inputs-${pinned_short_hash}.tar.gz"
 
 function compress_and_upload {

--- a/barretenberg/cpp/src/barretenberg/chonk/chonk.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/chonk/chonk.test.cpp
@@ -316,7 +316,7 @@ HEAVY_TEST(ChonkKernelCapacity, MaxCapacityPassing)
 {
     bb::srs::init_file_crs_factory(bb::srs::bb_crs_path());
 
-    const size_t NUM_APP_CIRCUITS = 31;
+    const size_t NUM_APP_CIRCUITS = 35;
     auto [proof, vk] = ChonkTests::accumulate_and_prove_ivc(NUM_APP_CIRCUITS);
 
     bool verified = Chonk::verify(proof, vk);

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/mock_verifier_inputs.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/mock_verifier_inputs.cpp
@@ -106,14 +106,14 @@ HonkProof create_mock_multilinear_batch_proof()
     using FF = typename Flavor::FF;
     HonkProof proof;
 
-    // Populate mock witness polynomial commitments
-    populate_field_elements_for_mock_commitments(proof, Flavor::NUM_WITNESS_ENTITIES);
+    // Populate mock witness accumulator commitments
+    populate_field_elements_for_mock_commitments(proof, Flavor::NUM_WITNESS_ENTITIES / 2);
 
-    // Accumulator and instance multivariate challenges
-    populate_field_elements<FF>(proof, Flavor::VIRTUAL_LOG_N * 2);
+    // Accumulator multivariate challenges
+    populate_field_elements<FF>(proof, Flavor::VIRTUAL_LOG_N);
 
-    // Witness polynomial evaluations
-    populate_field_elements<FF>(proof, Flavor::NUM_WITNESS_ENTITIES);
+    // Witness accumulator polynomial evaluations
+    populate_field_elements<FF>(proof, Flavor::NUM_WITNESS_ENTITIES / 2);
 
     // Sumcheck proof
     HonkProof sumcheck_proof = create_mock_sumcheck_proof<Flavor>();

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/mock_verifier_inputs.hpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/mock_verifier_inputs.hpp
@@ -16,6 +16,8 @@ namespace acir_format {
 
 template <typename Flavor, class PublicInputs>
 bb::HonkProof create_mock_oink_proof(const size_t inner_public_inputs_size = 0);
+template <typename Flavor> bb::HonkProof create_mock_sumcheck_proof();
+bb::HonkProof create_mock_multilinear_batch_proof();
 template <typename Flavor> bb::HonkProof create_mock_decider_proof();
 template <typename Flavor, class PublicInputs>
 bb::HonkProof create_mock_honk_proof(const size_t inner_public_inputs_size = 0);

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/mock_verifier_inputs.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/mock_verifier_inputs.test.cpp
@@ -2,8 +2,14 @@
 #include "acir_format.hpp"
 #include "acir_format_mocks.hpp"
 #include "barretenberg/chonk/chonk.hpp"
+#include "barretenberg/eccvm/eccvm_flavor.hpp"
+#include "barretenberg/flavor/mega_flavor.hpp"
 #include "barretenberg/flavor/multilinear_batching_flavor.hpp"
+#include "barretenberg/flavor/ultra_flavor.hpp"
+#include "barretenberg/flavor/ultra_rollup_flavor.hpp"
+#include "barretenberg/flavor/ultra_zk_flavor.hpp"
 #include "barretenberg/goblin/mock_circuits.hpp"
+#include "barretenberg/honk/types/public_inputs_type.hpp"
 #include "barretenberg/stdlib/chonk_verifier/chonk_recursive_verifier.hpp"
 #include "barretenberg/stdlib/special_public_inputs/special_public_inputs.hpp"
 #include "barretenberg/ultra_honk/prover_instance.hpp"
@@ -32,6 +38,9 @@ TYPED_TEST_SUITE(MockVerifierInputsTest, FlavorTypes);
  */
 TEST(MockVerifierInputsTest, MockMergeProofSize)
 {
+    size_t CURRENT_MERGE_PROOF_SIZE = 42;
+    EXPECT_EQ(CURRENT_MERGE_PROOF_SIZE, MERGE_PROOF_SIZE) << "The length of the Merge proof changed.";
+
     Goblin::MergeProof merge_proof = create_mock_merge_proof();
     EXPECT_EQ(merge_proof.size(), MERGE_PROOF_SIZE);
 }
@@ -41,6 +50,10 @@ TEST(MockVerifierInputsTest, MockMergeProofSize)
  */
 TEST(MockVerifierInputsTest, MockPreIpaProofSize)
 {
+    size_t CURRENT_PRE_IPA_PROOF_SIZE = 616;
+    EXPECT_EQ(ECCVMFlavor::PROOF_LENGTH_WITHOUT_PUB_INPUTS - IPA_PROOF_LENGTH, CURRENT_PRE_IPA_PROOF_SIZE)
+        << "The length of the Pre-IPA proof changed.";
+
     HonkProof pre_ipa_proof = create_mock_pre_ipa_proof();
     EXPECT_EQ(pre_ipa_proof.size(), ECCVMFlavor::PROOF_LENGTH_WITHOUT_PUB_INPUTS - IPA_PROOF_LENGTH);
 }
@@ -50,6 +63,9 @@ TEST(MockVerifierInputsTest, MockPreIpaProofSize)
  */
 TEST(MockVerifierInputsTest, MockIPAProofSize)
 {
+    size_t CURRENT_IPA_PROOF_SIZE = 68;
+    EXPECT_EQ(IPA_PROOF_LENGTH, CURRENT_IPA_PROOF_SIZE) << "The length of the IPA proof changed.";
+
     HonkProof ipa_proof = create_mock_ipa_proof();
     EXPECT_EQ(ipa_proof.size(), IPA_PROOF_LENGTH);
 }
@@ -59,6 +75,10 @@ TEST(MockVerifierInputsTest, MockIPAProofSize)
  */
 TEST(MockVerifierInputsTest, MockTranslatorProofSize)
 {
+    size_t CURRENT_TRANSLATOR_PROOF_SIZE = 818;
+    EXPECT_EQ(TranslatorFlavor::PROOF_LENGTH_WITHOUT_PUB_INPUTS, CURRENT_TRANSLATOR_PROOF_SIZE)
+        << "The length of the Translator proof changed.";
+
     HonkProof translator_proof = create_mock_translator_proof();
     EXPECT_EQ(translator_proof.size(), TranslatorFlavor::PROOF_LENGTH_WITHOUT_PUB_INPUTS);
 }
@@ -71,6 +91,10 @@ TEST(MockVerifierInputsTest, MockMegaOinkProofSize)
 {
     using Flavor = MegaFlavor;
     using Builder = MegaCircuitBuilder;
+
+    size_t CURRENT_OINK_PROOF_SIZE_WITHOUT_PUB_INPUTS = 96;
+    EXPECT_EQ(Flavor::OINK_PROOF_LENGTH_WITHOUT_PUB_INPUTS, CURRENT_OINK_PROOF_SIZE_WITHOUT_PUB_INPUTS)
+        << "The length of the Mega Oink proof changed.";
 
     {
         // AppIO
@@ -107,6 +131,10 @@ TYPED_TEST(MockVerifierInputsTest, MockUltraOinkProofSize)
                                   stdlib::recursion::honk::DefaultIO<Builder>>;
 
     if (!std::is_same_v<Flavor, MegaFlavor>) {
+        size_t CURRENT_OINK_PROOF_SIZE_WITHOUT_PUB_INPUTS = 32;
+        EXPECT_EQ(Flavor::OINK_PROOF_LENGTH_WITHOUT_PUB_INPUTS, CURRENT_OINK_PROOF_SIZE_WITHOUT_PUB_INPUTS)
+            << "The length of the Ultra Oink proof changed.";
+
         const size_t NUM_PUBLIC_INPUTS = IO::PUBLIC_INPUTS_SIZE;
         HonkProof honk_proof = create_mock_oink_proof<Flavor, IO>();
         EXPECT_EQ(honk_proof.size(), Flavor::OINK_PROOF_LENGTH_WITHOUT_PUB_INPUTS + NUM_PUBLIC_INPUTS);
@@ -124,6 +152,10 @@ TYPED_TEST(MockVerifierInputsTest, MockDeciderProofSize)
     using Flavor = TypeParam;
 
     if (!std::is_same_v<Flavor, UltraZKFlavor>) {
+        size_t CURRENT_DECIDER_ULTRAZK_PROOF_SIZE = IsMegaFlavor<Flavor> ? 337 : 409;
+        EXPECT_EQ(Flavor::DECIDER_PROOF_LENGTH(), CURRENT_DECIDER_ULTRAZK_PROOF_SIZE)
+            << "The length of the Decider UltraZK proof changed.";
+
         HonkProof honk_proof = create_mock_decider_proof<Flavor>();
         EXPECT_EQ(honk_proof.size(), Flavor::DECIDER_PROOF_LENGTH());
     } else {
@@ -139,6 +171,12 @@ TEST(MockVerifierInputsTest, MockMegaHonkProofSize)
 {
     using Flavor = MegaFlavor;
     using Builder = MegaCircuitBuilder;
+
+    // If this value changes, we need to update the corresponding constants in noir and in yarn-project. Also, we need
+    // to update the Prover.toml file for rollup-tx-private to reflect the new length of the MegaHonk proof.
+    size_t CURRENT_MEGA_PROOF_SIZE_WITHOUT_PUB_INPUTS = 433;
+    EXPECT_EQ(Flavor::PROOF_LENGTH_WITHOUT_PUB_INPUTS(), CURRENT_MEGA_PROOF_SIZE_WITHOUT_PUB_INPUTS)
+        << "The length of the Mega Honk proof changed.";
 
     {
         // AppIO
@@ -175,9 +213,21 @@ TYPED_TEST(MockVerifierInputsTest, MockUltraHonkProofSize)
                                   stdlib::recursion::honk::DefaultIO<Builder>>;
 
     if (!std::is_same_v<Flavor, MegaFlavor>) {
+        // If this value changes, we need to update the corresponding constants in noir and in yarn-project. Also, we
+        // need to update the relevant Prover.toml files to reflect the new length of the Ultra Honk proof.
+        size_t CURRENT_ULTRA_HONK_PROOF_SIZE_WITHOUT_PUB_INPUTS = 0;
+        if constexpr (std::is_same_v<Flavor, UltraFlavor>) {
+            CURRENT_ULTRA_HONK_PROOF_SIZE_WITHOUT_PUB_INPUTS = 441;
+        } else if constexpr (std::is_same_v<Flavor, UltraRollupFlavor>) {
+            CURRENT_ULTRA_HONK_PROOF_SIZE_WITHOUT_PUB_INPUTS = 509;
+        } else if constexpr (std::is_same_v<Flavor, UltraZKFlavor>) {
+            CURRENT_ULTRA_HONK_PROOF_SIZE_WITHOUT_PUB_INPUTS = 492;
+        }
         const size_t NUM_PUBLIC_INPUTS = IO::PUBLIC_INPUTS_SIZE;
         HonkProof honk_proof = create_mock_honk_proof<Flavor, IO>();
         EXPECT_EQ(honk_proof.size(), Flavor::PROOF_LENGTH_WITHOUT_PUB_INPUTS() + NUM_PUBLIC_INPUTS);
+        EXPECT_EQ(Flavor::PROOF_LENGTH_WITHOUT_PUB_INPUTS(), CURRENT_ULTRA_HONK_PROOF_SIZE_WITHOUT_PUB_INPUTS)
+            << "The length of the Ultra Honk proof changed.";
     } else {
         GTEST_SKIP();
     }
@@ -191,8 +241,15 @@ TEST(MockVerifierInputsTest, MockChonkProofSize)
 {
     using Builder = MegaCircuitBuilder;
 
+    // If this value changes, we need to update the corresponding constants in noir and in yarn-project. Also, we need
+    // to update the Prover.toml file for rollup-tx-private to reflect the new length of the Chonk proof.
+    size_t CURRENT_CHONK_PROOF_SIZE_WITHOUT_PUB_INPUTS = 2021;
     HonkProof chonk_proof = create_mock_chonk_proof<Builder>();
     EXPECT_EQ(chonk_proof.size(), Chonk::Proof::PROOF_LENGTH());
+    EXPECT_EQ(chonk_proof.size(),
+              CURRENT_CHONK_PROOF_SIZE_WITHOUT_PUB_INPUTS +
+                  stdlib::recursion::honk::HidingKernelIO<Builder>::PUBLIC_INPUTS_SIZE)
+        << "The length of the Chonk proof changed.";
 }
 
 /**
@@ -200,6 +257,9 @@ TEST(MockVerifierInputsTest, MockChonkProofSize)
  */
 TEST(MockVerifierInputsTest, MockMultilinearBatchingProofSize)
 {
+    size_t CURRENT_MULTILINEAR_BATCHING_PROOF_SIZE_WITHOUT_PUB_INPUTS = 121;
     HonkProof batching_proof = create_mock_multilinear_batch_proof();
     EXPECT_EQ(batching_proof.size(), MultilinearBatchingFlavor::PROOF_LENGTH_WITHOUT_PUB_INPUTS());
+    EXPECT_EQ(batching_proof.size(), CURRENT_MULTILINEAR_BATCHING_PROOF_SIZE_WITHOUT_PUB_INPUTS)
+        << "The length of the MultiLinearBatching proof changed.";
 }

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/mock_verifier_inputs.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/mock_verifier_inputs.test.cpp
@@ -2,6 +2,7 @@
 #include "acir_format.hpp"
 #include "acir_format_mocks.hpp"
 #include "barretenberg/chonk/chonk.hpp"
+#include "barretenberg/flavor/multilinear_batching_flavor.hpp"
 #include "barretenberg/goblin/mock_circuits.hpp"
 #include "barretenberg/stdlib/chonk_verifier/chonk_recursive_verifier.hpp"
 #include "barretenberg/stdlib/special_public_inputs/special_public_inputs.hpp"
@@ -192,4 +193,13 @@ TEST(MockVerifierInputsTest, MockChonkProofSize)
 
     HonkProof chonk_proof = create_mock_chonk_proof<Builder>();
     EXPECT_EQ(chonk_proof.size(), Chonk::Proof::PROOF_LENGTH());
+}
+
+/**
+ * @brief Check that the size of a mock MultiLinearBatching proof matches expectation
+ */
+TEST(MockVerifierInputsTest, MockMultilinearBatchingProofSize)
+{
+    HonkProof batching_proof = create_mock_multilinear_batch_proof();
+    EXPECT_EQ(batching_proof.size(), MultilinearBatchingFlavor::PROOF_LENGTH_WITHOUT_PUB_INPUTS());
 }

--- a/barretenberg/cpp/src/barretenberg/flavor/multilinear_batching_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/multilinear_batching_flavor.hpp
@@ -76,8 +76,8 @@ class MultilinearBatchingFlavor {
         DEFINE_FLAVOR_MEMBERS(DataType,
                               w_non_shifted_accumulator, // column 0
                               w_non_shifted_instance,    // column 1
-                              w_evaluations_accumulator, // column 2
-                              w_evaluations_instance);   // column 3
+                              w_evaluations_accumulator, // column 2, eq(Sumcheck::alpha, accumulator_challenge)
+                              w_evaluations_instance);   // column 3, eq(Sumcheck::alpha, instance_challenge)
     };
 
     /**
@@ -90,8 +90,8 @@ class MultilinearBatchingFlavor {
         DEFINE_FLAVOR_MEMBERS(DataType,
                               w_non_shifted_accumulator, // column 0
                               w_non_shifted_instance,    // column 1
-                              w_evaluations_accumulator, // column 2
-                              w_evaluations_instance);   // column 3
+                              w_evaluations_accumulator, // column 2, eq(Sumcheck::alpha, accumulator_challenge)
+                              w_evaluations_instance);   // column 3, eq(Sumcheck::alpha, instance_challenge)
 
         MSGPACK_FIELDS(this->w_non_shifted_accumulator,
                        this->w_non_shifted_instance,

--- a/barretenberg/cpp/src/barretenberg/flavor/multilinear_batching_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/multilinear_batching_flavor.hpp
@@ -70,6 +70,18 @@ class MultilinearBatchingFlavor {
     // Whether or not the first row of the execution trace is reserved for 0s to enable shifts
     static constexpr bool has_zero_row = false;
 
+    static constexpr size_t num_frs_comm = FrCodec::calc_num_fields<Commitment>();
+    static constexpr size_t num_frs_fr = FrCodec::calc_num_fields<FF>();
+
+    static constexpr size_t PROOF_LENGTH_WITHOUT_PUB_INPUTS()
+    {
+        return /*accumulator commitments*/ (NUM_WITNESS_ENTITIES / 2 * num_frs_comm) +
+               /*multivariate challenges*/ (VIRTUAL_LOG_N * num_frs_fr) +
+               /*witness evaluations*/ (NUM_WITNESS_ENTITIES / 2 * num_frs_fr) +
+               /*sumcheck univariates*/ (VIRTUAL_LOG_N * BATCHED_RELATION_PARTIAL_LENGTH * num_frs_fr) +
+               /*sumcheck evaluations*/ (NUM_ALL_ENTITIES * num_frs_fr);
+    }
+
     // WireEntities for basic witness entities
     template <typename DataType> class WireEntities {
       public:

--- a/barretenberg/cpp/src/barretenberg/hypernova/hypernova_prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/hypernova/hypernova_prover.cpp
@@ -17,18 +17,7 @@ HypernovaFoldingProver::Accumulator HypernovaFoldingProver::sumcheck_output_to_a
     BB_BENCH();
 
     // Generate challenges to batch shifted and unshifted polynomials/commitments/evaluation
-    std::array<std::string, Flavor::NUM_UNSHIFTED_ENTITIES> labels_unshifted_entities;
-    std::array<std::string, Flavor::NUM_SHIFTED_ENTITIES> labels_shifted_witnesses;
-    for (size_t idx = 0; idx < Flavor::NUM_UNSHIFTED_ENTITIES; idx++) {
-        labels_unshifted_entities[idx] = "unshifted_challenge_" + std::to_string(idx);
-    }
-    for (size_t idx = 0; idx < Flavor::NUM_SHIFTED_ENTITIES; idx++) {
-        labels_shifted_witnesses[idx] = "shifted_challenge_" + std::to_string(idx);
-    }
-    std::array<FF, Flavor::NUM_UNSHIFTED_ENTITIES> unshifted_challenges =
-        transcript->template get_challenges<FF>(labels_unshifted_entities);
-    std::array<FF, Flavor::NUM_SHIFTED_ENTITIES> shifted_challenges =
-        transcript->template get_challenges<FF>(labels_shifted_witnesses);
+    auto [unshifted_challenges, shifted_challenges] = get_batching_challenges();
 
     // Batch polynomials
     Polynomial<FF> batched_unshifted_polynomial = batch_polynomials<Flavor::NUM_UNSHIFTED_ENTITIES>(
@@ -50,31 +39,14 @@ HypernovaFoldingProver::Accumulator HypernovaFoldingProver::sumcheck_output_to_a
     // Batch commitments
     VerifierCommitments verifier_commitments(honk_vk, instance->commitments);
 
-    Commitment batched_unshifted_commitment;
-    Commitment batched_shifted_commitment;
-
-    std::vector<Commitment> points;
-    std::vector<FF> scalars;
-    for (auto [commitment, scalar] : zip_view(verifier_commitments.get_unshifted(), unshifted_challenges)) {
-        points.emplace_back(commitment);
-        scalars.emplace_back(scalar);
-    }
     // TODO(https://github.com/AztecProtocol/barretenberg/issues/1552): Optimize batch_mul_native
-    batched_unshifted_commitment = batch_mul_native(points, scalars);
-
-    points.clear();
-    scalars.clear();
-    for (auto [commitment, scalar] : zip_view(verifier_commitments.get_to_be_shifted(), shifted_challenges)) {
-        points.emplace_back(commitment);
-        scalars.emplace_back(scalar);
-    }
-    // TODO(https://github.com/AztecProtocol/barretenberg/issues/1552): Optimize batch_mul_native
-    batched_shifted_commitment = batch_mul_native(points, scalars);
+    Commitment batched_unshifted_commitment = batch_mul(verifier_commitments.get_unshifted(), unshifted_challenges);
+    Commitment batched_shifted_commitment = batch_mul(verifier_commitments.get_to_be_shifted(), shifted_challenges);
 
     return Accumulator{
         .challenge = std::move(sumcheck_output.challenge),
-        .shifted_evaluation = batched_shifted_evaluation,
         .non_shifted_evaluation = batched_unshifted_evaluation,
+        .shifted_evaluation = batched_shifted_evaluation,
         .non_shifted_polynomial = std::move(batched_unshifted_polynomial),
         .shifted_polynomial = std::move(batched_shifted_polynomial),
         .non_shifted_commitment = batched_unshifted_commitment,
@@ -87,12 +59,14 @@ template <size_t N>
 Polynomial<HypernovaFoldingProver::FF> HypernovaFoldingProver::batch_polynomials(
     RefArray<Polynomial<FF>, N> polynomials_to_batch,
     const size_t& full_batched_size,
-    const std::array<FF, N>& challenges)
+    const std::vector<FF>& challenges)
 {
     BB_BENCH();
     BB_ASSERT_EQ(full_batched_size,
                  polynomials_to_batch[0].virtual_size(),
                  "The virtual size of the first polynomial is different from the full batched size.");
+    BB_ASSERT_EQ(
+        challenges.size(), N, "The number of challenges provided does not match the number of polynomials to batch.");
 
     size_t challenge_idx = 0;
 
@@ -136,7 +110,12 @@ HypernovaFoldingProver::Accumulator HypernovaFoldingProver::instance_to_accumula
 
     Accumulator accumulator = sumcheck_output_to_accumulator(sumcheck_output, instance, precomputed_vk);
 
-    vinfo("HypernovaFoldingProver: accumulator constructed.");
+    if (sumcheck_output.verified) {
+        vinfo("HypernovaFoldingProver: accumulator constructed.");
+    } else {
+        vinfo("HypernovaFoldingProver: Failed to prove Sumcheck to turn instance into an accumulator. "
+              "Ignore if generating the VKs");
+    }
 
     return accumulator;
 }
@@ -154,8 +133,7 @@ std::pair<HonkProof, HypernovaFoldingProver::Accumulator> HypernovaFoldingProver
                                               transcript);
 
     HonkProof proof = batching_prover.construct_proof();
-    batching_prover.compute_new_claim();
 
-    return { proof, batching_prover.get_new_claim() };
+    return { proof, batching_prover.compute_new_claim() };
 }
 } // namespace bb

--- a/barretenberg/cpp/src/barretenberg/hypernova/hypernova_prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/hypernova/hypernova_prover.cpp
@@ -9,6 +9,36 @@
 #include "barretenberg/multilinear_batching/multilinear_batching_prover.hpp"
 
 namespace bb {
+
+std::pair<std::vector<HypernovaFoldingProver::FF>, std::vector<HypernovaFoldingProver::FF>> HypernovaFoldingProver::
+    get_batching_challenges()
+{
+    std::vector<std::string> labels_unshifted_entities(NUM_UNSHIFTED_ENTITIES);
+    std::vector<std::string> labels_shifted_witnesses(NUM_SHIFTED_ENTITIES);
+    for (size_t idx = 0; idx < NUM_UNSHIFTED_ENTITIES; idx++) {
+        labels_unshifted_entities[idx] = "unshifted_challenge_" + std::to_string(idx);
+    }
+    for (size_t idx = 0; idx < NUM_SHIFTED_ENTITIES; idx++) {
+        labels_shifted_witnesses[idx] = "shifted_challenge_" + std::to_string(idx);
+    }
+    auto unshifted_challenges = transcript->template get_challenges<FF>(labels_unshifted_entities);
+    auto shifted_challenges = transcript->template get_challenges<FF>(labels_shifted_witnesses);
+
+    return { unshifted_challenges, shifted_challenges };
+}
+
+template <size_t N>
+HypernovaFoldingProver::Commitment HypernovaFoldingProver::batch_mul(const RefArray<Commitment, N>& _points,
+                                                                     const std::vector<FF>& scalars)
+{
+    std::vector<Commitment> points(N);
+    for (size_t idx = 0; auto point : _points) {
+        points[idx++] = point;
+    }
+
+    return batch_mul_native(points, scalars);
+}
+
 HypernovaFoldingProver::Accumulator HypernovaFoldingProver::sumcheck_output_to_accumulator(
     HypernovaFoldingProver::MegaSumcheckOutput& sumcheck_output,
     const std::shared_ptr<typename HypernovaFoldingProver::ProverInstance>& instance,

--- a/barretenberg/cpp/src/barretenberg/hypernova/hypernova_prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/hypernova/hypernova_prover.cpp
@@ -110,12 +110,7 @@ HypernovaFoldingProver::Accumulator HypernovaFoldingProver::instance_to_accumula
 
     Accumulator accumulator = sumcheck_output_to_accumulator(sumcheck_output, instance, precomputed_vk);
 
-    if (sumcheck_output.verified) {
-        vinfo("HypernovaFoldingProver: accumulator constructed.");
-    } else {
-        vinfo("HypernovaFoldingProver: Failed to prove Sumcheck to turn instance into an accumulator. "
-              "Ignore if generating the VKs");
-    }
+    vinfo("HypernovaFoldingProver: accumulator constructed.");
 
     return accumulator;
 }

--- a/barretenberg/cpp/src/barretenberg/hypernova/hypernova_prover.hpp
+++ b/barretenberg/cpp/src/barretenberg/hypernova/hypernova_prover.hpp
@@ -26,6 +26,9 @@ class HypernovaFoldingProver {
     using MegaSumcheckOutput = SumcheckOutput<Flavor>;
     using Transcript = Flavor::Transcript;
 
+    static constexpr size_t NUM_UNSHIFTED_ENTITIES = MegaFlavor::NUM_UNSHIFTED_ENTITIES;
+    static constexpr size_t NUM_SHIFTED_ENTITIES = MegaFlavor::NUM_SHIFTED_ENTITIES;
+
     std::shared_ptr<Transcript> transcript;
 
     HypernovaFoldingProver(std::shared_ptr<Transcript>& transcript)
@@ -59,6 +62,9 @@ class HypernovaFoldingProver {
     HonkProof export_proof() { return transcript->export_proof(); };
 
   private:
+    /**
+     * @brief Convert the output of the sumcheck run on the incoming instance into an accumulator.
+     */
     Accumulator sumcheck_output_to_accumulator(MegaSumcheckOutput& sumcheck_output,
                                                const std::shared_ptr<ProverInstance>& instance,
                                                const std::shared_ptr<VerificationKey>& honk_vk);
@@ -72,7 +78,39 @@ class HypernovaFoldingProver {
     template <size_t N>
     static Polynomial<FF> batch_polynomials(RefArray<Polynomial<FF>, N> polynomials_to_batch,
                                             const size_t& full_batched_size,
-                                            const std::array<FF, N>& challenges);
+                                            const std::vector<FF>& challenges);
+
+    /**
+     * @brief Generate the challenges required to batch the incoming instance with the accumulator
+     */
+    std::pair<std::vector<FF>, std::vector<FF>> get_batching_challenges()
+    {
+        std::vector<std::string> labels_unshifted_entities(NUM_UNSHIFTED_ENTITIES);
+        std::vector<std::string> labels_shifted_witnesses(NUM_SHIFTED_ENTITIES);
+        for (size_t idx = 0; idx < NUM_UNSHIFTED_ENTITIES; idx++) {
+            labels_unshifted_entities[idx] = "unshifted_challenge_" + std::to_string(idx);
+        }
+        for (size_t idx = 0; idx < NUM_SHIFTED_ENTITIES; idx++) {
+            labels_shifted_witnesses[idx] = "shifted_challenge_" + std::to_string(idx);
+        }
+        auto unshifted_challenges = transcript->template get_challenges<FF>(labels_unshifted_entities);
+        auto shifted_challenges = transcript->template get_challenges<FF>(labels_shifted_witnesses);
+
+        return { unshifted_challenges, shifted_challenges };
+    }
+
+    /**
+     * @brief Utility to perform batch mul of commitments.
+     */
+    template <size_t N> Commitment batch_mul(const RefArray<Commitment, N>& _points, const std::vector<FF>& scalars)
+    {
+        std::vector<Commitment> points(N);
+        for (size_t idx = 0; auto point : _points) {
+            points[idx++] = point;
+        }
+
+        return batch_mul_native(points, scalars);
+    }
 };
 
 } // namespace bb

--- a/barretenberg/cpp/src/barretenberg/hypernova/hypernova_prover.hpp
+++ b/barretenberg/cpp/src/barretenberg/hypernova/hypernova_prover.hpp
@@ -83,34 +83,12 @@ class HypernovaFoldingProver {
     /**
      * @brief Generate the challenges required to batch the incoming instance with the accumulator
      */
-    std::pair<std::vector<FF>, std::vector<FF>> get_batching_challenges()
-    {
-        std::vector<std::string> labels_unshifted_entities(NUM_UNSHIFTED_ENTITIES);
-        std::vector<std::string> labels_shifted_witnesses(NUM_SHIFTED_ENTITIES);
-        for (size_t idx = 0; idx < NUM_UNSHIFTED_ENTITIES; idx++) {
-            labels_unshifted_entities[idx] = "unshifted_challenge_" + std::to_string(idx);
-        }
-        for (size_t idx = 0; idx < NUM_SHIFTED_ENTITIES; idx++) {
-            labels_shifted_witnesses[idx] = "shifted_challenge_" + std::to_string(idx);
-        }
-        auto unshifted_challenges = transcript->template get_challenges<FF>(labels_unshifted_entities);
-        auto shifted_challenges = transcript->template get_challenges<FF>(labels_shifted_witnesses);
-
-        return { unshifted_challenges, shifted_challenges };
-    }
+    std::pair<std::vector<FF>, std::vector<FF>> get_batching_challenges();
 
     /**
      * @brief Utility to perform batch mul of commitments.
      */
-    template <size_t N> Commitment batch_mul(const RefArray<Commitment, N>& _points, const std::vector<FF>& scalars)
-    {
-        std::vector<Commitment> points(N);
-        for (size_t idx = 0; auto point : _points) {
-            points[idx++] = point;
-        }
-
-        return batch_mul_native(points, scalars);
-    }
+    template <size_t N> Commitment batch_mul(const RefArray<Commitment, N>& _points, const std::vector<FF>& scalars);
 };
 
 } // namespace bb

--- a/barretenberg/cpp/src/barretenberg/hypernova/hypernova_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/hypernova/hypernova_verifier.cpp
@@ -8,6 +8,42 @@
 
 namespace bb {
 
+template <typename Flavor_>
+std::pair<std::vector<typename HypernovaFoldingVerifier<Flavor_>::FF>,
+          std::vector<typename HypernovaFoldingVerifier<Flavor_>::FF>>
+HypernovaFoldingVerifier<Flavor_>::get_batching_challenges()
+{
+    std::vector<std::string> labels_unshifted_entities(NUM_UNSHIFTED_ENTITIES);
+    std::vector<std::string> labels_shifted_witnesses(NUM_SHIFTED_ENTITIES);
+    for (size_t idx = 0; idx < NUM_UNSHIFTED_ENTITIES; idx++) {
+        labels_unshifted_entities[idx] = "unshifted_challenge_" + std::to_string(idx);
+    }
+    for (size_t idx = 0; idx < NUM_SHIFTED_ENTITIES; idx++) {
+        labels_shifted_witnesses[idx] = "shifted_challenge_" + std::to_string(idx);
+    }
+    auto unshifted_challenges = transcript->template get_challenges<FF>(labels_unshifted_entities);
+    auto shifted_challenges = transcript->template get_challenges<FF>(labels_shifted_witnesses);
+
+    return { unshifted_challenges, shifted_challenges };
+}
+
+template <typename Flavor_>
+template <size_t N>
+HypernovaFoldingVerifier<Flavor_>::Commitment HypernovaFoldingVerifier<Flavor_>::batch_mul(
+    const RefArray<Commitment, N>& _points, const std::vector<FF>& scalars)
+{
+    std::vector<Commitment> points(N);
+    for (size_t idx = 0; const auto& point : _points) {
+        points[idx++] = point;
+    }
+
+    if constexpr (IsRecursiveFlavor<Flavor>) {
+        return Curve::Group::batch_mul(points, scalars);
+    } else {
+        return batch_mul_native(points, scalars);
+    }
+}
+
 template <typename Flavor>
 HypernovaFoldingVerifier<Flavor>::Accumulator HypernovaFoldingVerifier<Flavor>::sumcheck_output_to_accumulator(
     HypernovaFoldingVerifier<Flavor>::MegaSumcheckOutput& sumcheck_output,

--- a/barretenberg/cpp/src/barretenberg/hypernova/hypernova_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/hypernova/hypernova_verifier.cpp
@@ -16,16 +16,7 @@ HypernovaFoldingVerifier<Flavor>::Accumulator HypernovaFoldingVerifier<Flavor>::
     BB_BENCH();
 
     // Generate challenges to batch shifted and unshifted polynomials/commitments/evaluation
-    std::array<std::string, NUM_UNSHIFTED_ENTITIES> labels_unshifted_entities;
-    std::array<std::string, NUM_SHIFTED_ENTITIES> labels_shifted_witnesses;
-    for (size_t idx = 0; idx < NUM_UNSHIFTED_ENTITIES; idx++) {
-        labels_unshifted_entities[idx] = "unshifted_challenge_" + std::to_string(idx);
-    }
-    for (size_t idx = 0; idx < NUM_SHIFTED_ENTITIES; idx++) {
-        labels_shifted_witnesses[idx] = "shifted_challenge_" + std::to_string(idx);
-    }
-    auto unshifted_challenges = transcript->template get_challenges<FF>(labels_unshifted_entities);
-    auto shifted_challenges = transcript->template get_challenges<FF>(labels_shifted_witnesses);
+    auto [unshifted_challenges, shifted_challenges] = get_batching_challenges();
 
     // Batch evaluations
     FF batched_unshifted_evaluation(0);
@@ -41,36 +32,19 @@ HypernovaFoldingVerifier<Flavor>::Accumulator HypernovaFoldingVerifier<Flavor>::
     // Batch commitments
     VerifierCommitments verifier_commitments(instance->get_vk(), instance->witness_commitments);
 
-    Commitment batched_unshifted_commitment;
-    Commitment batched_shifted_commitment;
+    Commitment batched_unshifted_commitment = batch_mul(verifier_commitments.get_unshifted(), unshifted_challenges);
+    Commitment batched_shifted_commitment = batch_mul(verifier_commitments.get_to_be_shifted(), shifted_challenges);
 
-    std::vector<Commitment> points;
-    std::vector<FF> scalars;
-    for (auto [commitment, scalar] : zip_view(verifier_commitments.get_unshifted(), unshifted_challenges)) {
-        points.emplace_back(commitment);
-        scalars.emplace_back(scalar);
-    }
-    batched_unshifted_commitment = batch_mul(points, scalars);
-
-    points.clear();
-    scalars.clear();
-    for (auto [commitment, scalar] : zip_view(verifier_commitments.get_to_be_shifted(), shifted_challenges)) {
-        points.emplace_back(commitment);
-        scalars.emplace_back(scalar);
-    }
-    batched_shifted_commitment = batch_mul(points, scalars);
-
-    return Accumulator(sumcheck_output.challenge,
-                       batched_shifted_evaluation,
-                       batched_unshifted_evaluation,
-                       batched_unshifted_commitment,
-                       batched_shifted_commitment);
+    return Accumulator{ .challenge = sumcheck_output.challenge,
+                        .non_shifted_evaluation = batched_unshifted_evaluation,
+                        .shifted_evaluation = batched_shifted_evaluation,
+                        .non_shifted_commitment = batched_unshifted_commitment,
+                        .shifted_commitment = batched_shifted_commitment };
 };
 
 template <typename Flavor>
-std::pair<bool, typename HypernovaFoldingVerifier<Flavor>::Accumulator> HypernovaFoldingVerifier<Flavor>::
-    instance_to_accumulator(const std::shared_ptr<typename HypernovaFoldingVerifier::VerifierInstance>& instance,
-                            const Proof& proof)
+SumcheckOutput<Flavor> HypernovaFoldingVerifier<Flavor>::sumcheck_on_incoming_instance(
+    const std::shared_ptr<typename HypernovaFoldingVerifier::VerifierInstance>& instance, const Proof& proof)
 {
     BB_BENCH();
 
@@ -90,19 +64,32 @@ std::pair<bool, typename HypernovaFoldingVerifier<Flavor>::Accumulator> Hypernov
 
     // Sumcheck verification
     vinfo("HypernovaFoldingVerifier: verifying Sumcheck to turn instance into an accumulator...");
+
     std::vector<FF> padding_indicator_array(Flavor::VIRTUAL_LOG_N, 1);
     SumcheckVerifier sumcheck(transcript, instance->alpha, Flavor::VIRTUAL_LOG_N, instance->target_sum);
     SumcheckOutput<Flavor> sumcheck_output =
         sumcheck.verify(instance->relation_parameters, instance->gate_challenges, padding_indicator_array);
 
-    if (!sumcheck_output.verified) {
-        vinfo("HypernovaFoldingVerifier: Failed to recursively verify Sumcheck to turn instance into an accumulator. "
-              "Ignore if generating the VKs");
-    }
+    return sumcheck_output;
+};
+
+template <typename Flavor>
+std::pair<bool, typename HypernovaFoldingVerifier<Flavor>::Accumulator> HypernovaFoldingVerifier<Flavor>::
+    instance_to_accumulator(const std::shared_ptr<typename HypernovaFoldingVerifier::VerifierInstance>& instance,
+                            const Proof& proof)
+{
+    BB_BENCH();
+
+    auto sumcheck_output = sumcheck_on_incoming_instance(instance, proof);
 
     auto accumulator = sumcheck_output_to_accumulator(sumcheck_output, instance);
 
-    vinfo("HypernovaFoldingVerifier: Successfully turned instance into accumulator.");
+    if (sumcheck_output.verified) {
+        vinfo("HypernovaFoldingVerifier: Successfully turned instance into accumulator.");
+    } else {
+        vinfo("HypernovaFoldingVerifier: Failed to recursively verify Sumcheck to turn instance into an accumulator. "
+              "Ignore if generating the VKs");
+    }
 
     return { sumcheck_output.verified, accumulator };
 };
@@ -116,18 +103,28 @@ std::tuple<bool, bool, typename HypernovaFoldingVerifier<Flavor>::Accumulator> H
 
     vinfo("HypernovaFoldingVerifier: verifying folding proof...");
 
-    auto [sumcheck_result, incoming_accumulator] = instance_to_accumulator(instance, proof);
+    auto sumcheck_output = sumcheck_on_incoming_instance(instance, proof);
+
+    // Generate challenges to batch shifted and unshifted polynomials/commitments/evaluation
+    auto [unshifted_challenges, shifted_challenges] = get_batching_challenges();
+
+    VerifierCommitments verifier_commitments(instance->get_vk(), instance->witness_commitments);
 
     MultilinearBatchingVerifier batching_verifier(transcript);
-    auto [sumcheck_batching_result, new_accumulator] = batching_verifier.verify_proof();
-    if (!sumcheck_batching_result) {
+    auto [sumcheck_batching_result, new_accumulator] =
+        batching_verifier.verify_proof(sumcheck_output, verifier_commitments, unshifted_challenges, shifted_challenges);
+
+    if (sumcheck_output.verified && sumcheck_batching_result) {
+        vinfo("HypernovaFoldingVerifier: successfully verified folding proof.");
+    } else if (!sumcheck_output.verified) {
+        vinfo("HypernovaFoldingVerifier: Failed to recursively verify Sumcheck to turn instance into an accumulator. "
+              "Ignore if generating the VKs");
+    } else {
         vinfo("HypernovaFoldingVerifier: Failed to recursively verify Sumcheck to batch two accumulators. Ignore if "
               "generating the VKs");
     }
 
-    vinfo("HypernovaFoldingVerifier: successfully verified folding proof.");
-
-    return { sumcheck_result, sumcheck_batching_result, new_accumulator };
+    return { sumcheck_output.verified, sumcheck_batching_result, new_accumulator };
 };
 
 template class HypernovaFoldingVerifier<MegaRecursiveFlavor_<MegaCircuitBuilder>>;

--- a/barretenberg/cpp/src/barretenberg/hypernova/hypernova_verifier.hpp
+++ b/barretenberg/cpp/src/barretenberg/hypernova/hypernova_verifier.hpp
@@ -5,6 +5,7 @@
 // =====================
 #pragma once
 
+#include "barretenberg/common/ref_array.hpp"
 #include "barretenberg/flavor/flavor.hpp"
 #include "barretenberg/flavor/mega_recursive_flavor.hpp"
 #include "barretenberg/hypernova/types.hpp"
@@ -68,11 +69,50 @@ template <typename Flavor_> class HypernovaFoldingVerifier {
         const std::shared_ptr<typename HypernovaFoldingVerifier::VerifierInstance>& instance, const Proof& proof);
 
   private:
+    /**
+     * @brief Perform sumcheck on the incoming instance.
+     *
+     * @details Executing this sumcheck we generate the random challenges at which the polynomial commitments have to be
+     * opened.
+     */
+    SumcheckOutput<Flavor> sumcheck_on_incoming_instance(const std::shared_ptr<VerifierInstance>& instance,
+                                                         const Proof& proof);
+
+    /**
+     * @brief Generate the challenges required to batch the incoming instance with the accumulator
+     */
+    std::pair<std::vector<FF>, std::vector<FF>> get_batching_challenges()
+    {
+        std::vector<std::string> labels_unshifted_entities(NUM_UNSHIFTED_ENTITIES);
+        std::vector<std::string> labels_shifted_witnesses(NUM_SHIFTED_ENTITIES);
+        for (size_t idx = 0; idx < NUM_UNSHIFTED_ENTITIES; idx++) {
+            labels_unshifted_entities[idx] = "unshifted_challenge_" + std::to_string(idx);
+        }
+        for (size_t idx = 0; idx < NUM_SHIFTED_ENTITIES; idx++) {
+            labels_shifted_witnesses[idx] = "shifted_challenge_" + std::to_string(idx);
+        }
+        auto unshifted_challenges = transcript->template get_challenges<FF>(labels_unshifted_entities);
+        auto shifted_challenges = transcript->template get_challenges<FF>(labels_shifted_witnesses);
+
+        return { unshifted_challenges, shifted_challenges };
+    }
+
+    /**
+     * @brief Convert the output of the sumcheck run on the incoming instance into an accumulator.
+     */
     Accumulator sumcheck_output_to_accumulator(MegaSumcheckOutput& sumcheck_output,
                                                const std::shared_ptr<VerifierInstance>& instance);
 
-    Commitment batch_mul(const std::vector<Commitment>& points, const std::vector<FF>& scalars)
+    /**
+     * @brief Utility to perform batch mul of commitments.
+     */
+    template <size_t N> Commitment batch_mul(const RefArray<Commitment, N>& _points, const std::vector<FF>& scalars)
     {
+        std::vector<Commitment> points(N);
+        for (size_t idx = 0; auto point : _points) {
+            points[idx++] = point;
+        }
+
         if constexpr (IsRecursiveFlavor<Flavor>) {
             return Curve::Group::batch_mul(points, scalars);
         } else {

--- a/barretenberg/cpp/src/barretenberg/hypernova/hypernova_verifier.hpp
+++ b/barretenberg/cpp/src/barretenberg/hypernova/hypernova_verifier.hpp
@@ -81,21 +81,7 @@ template <typename Flavor_> class HypernovaFoldingVerifier {
     /**
      * @brief Generate the challenges required to batch the incoming instance with the accumulator
      */
-    std::pair<std::vector<FF>, std::vector<FF>> get_batching_challenges()
-    {
-        std::vector<std::string> labels_unshifted_entities(NUM_UNSHIFTED_ENTITIES);
-        std::vector<std::string> labels_shifted_witnesses(NUM_SHIFTED_ENTITIES);
-        for (size_t idx = 0; idx < NUM_UNSHIFTED_ENTITIES; idx++) {
-            labels_unshifted_entities[idx] = "unshifted_challenge_" + std::to_string(idx);
-        }
-        for (size_t idx = 0; idx < NUM_SHIFTED_ENTITIES; idx++) {
-            labels_shifted_witnesses[idx] = "shifted_challenge_" + std::to_string(idx);
-        }
-        auto unshifted_challenges = transcript->template get_challenges<FF>(labels_unshifted_entities);
-        auto shifted_challenges = transcript->template get_challenges<FF>(labels_shifted_witnesses);
-
-        return { unshifted_challenges, shifted_challenges };
-    }
+    std::pair<std::vector<FF>, std::vector<FF>> get_batching_challenges();
 
     /**
      * @brief Convert the output of the sumcheck run on the incoming instance into an accumulator.
@@ -106,18 +92,6 @@ template <typename Flavor_> class HypernovaFoldingVerifier {
     /**
      * @brief Utility to perform batch mul of commitments.
      */
-    template <size_t N> Commitment batch_mul(const RefArray<Commitment, N>& _points, const std::vector<FF>& scalars)
-    {
-        std::vector<Commitment> points(N);
-        for (size_t idx = 0; auto point : _points) {
-            points[idx++] = point;
-        }
-
-        if constexpr (IsRecursiveFlavor<Flavor>) {
-            return Curve::Group::batch_mul(points, scalars);
-        } else {
-            return batch_mul_native(points, scalars);
-        }
-    }
+    template <size_t N> Commitment batch_mul(const RefArray<Commitment, N>& _points, const std::vector<FF>& scalars);
 };
 } // namespace bb

--- a/barretenberg/cpp/src/barretenberg/multilinear_batching/multilinear_batching_claims.hpp
+++ b/barretenberg/cpp/src/barretenberg/multilinear_batching/multilinear_batching_claims.hpp
@@ -9,8 +9,8 @@ struct MultilinearBatchingProverClaim {
     using Commitment = MultilinearBatchingFlavor::Commitment;
     using Polynomial = MultilinearBatchingFlavor::Polynomial;
     std::vector<FF> challenge;
-    FF shifted_evaluation;
     FF non_shifted_evaluation;
+    FF shifted_evaluation;
     Polynomial non_shifted_polynomial;
     Polynomial shifted_polynomial;
     Commitment non_shifted_commitment;
@@ -22,24 +22,10 @@ template <typename Curve> struct MultilinearBatchingVerifierClaim {
     using FF = Curve::ScalarField;
     using Commitment = Curve::AffineElement;
     std::vector<FF> challenge;
-    FF shifted_evaluation;
     FF non_shifted_evaluation;
+    FF shifted_evaluation;
     Commitment non_shifted_commitment;
     Commitment shifted_commitment;
-
-    MultilinearBatchingVerifierClaim() = default;
-
-    MultilinearBatchingVerifierClaim(const std::vector<FF>& challenge,
-                                     const FF& shifted_evaluation,
-                                     const FF& non_shifted_evaluation,
-                                     const Commitment& non_shifted_commitment,
-                                     const Commitment& shifted_commitment)
-        : challenge(challenge)
-        , shifted_evaluation(shifted_evaluation)
-        , non_shifted_evaluation(non_shifted_evaluation)
-        , non_shifted_commitment(non_shifted_commitment)
-        , shifted_commitment(shifted_commitment)
-    {}
 
     /**
      * @brief Constructor for instantiating a recursive claim from a native one
@@ -61,8 +47,8 @@ template <typename Curve> struct MultilinearBatchingVerifierClaim {
             result.challenge.emplace_back(FF::from_witness(builder, element));
         }
 
-        result.shifted_evaluation = FF::from_witness(builder, native_claim.shifted_evaluation);
         result.non_shifted_evaluation = FF::from_witness(builder, native_claim.non_shifted_evaluation);
+        result.shifted_evaluation = FF::from_witness(builder, native_claim.shifted_evaluation);
         result.non_shifted_commitment = Commitment::from_witness(builder, native_claim.non_shifted_commitment);
         result.shifted_commitment = Commitment::from_witness(builder, native_claim.shifted_commitment);
 

--- a/barretenberg/cpp/src/barretenberg/multilinear_batching/multilinear_batching_prover.hpp
+++ b/barretenberg/cpp/src/barretenberg/multilinear_batching/multilinear_batching_prover.hpp
@@ -36,17 +36,13 @@ class MultilinearBatchingProver {
     BB_PROFILE void execute_commitments_round();
     BB_PROFILE void execute_challenges_and_evaluations_round();
     BB_PROFILE void execute_relation_check_rounds();
-    BB_PROFILE void compute_new_claim();
+    BB_PROFILE MultilinearBatchingProverClaim compute_new_claim();
     HonkProof export_proof();
     HonkProof construct_proof();
-
-    MultilinearBatchingProverClaim get_new_claim() { return new_claim; };
 
     std::shared_ptr<Transcript> transcript;
 
     std::shared_ptr<MultilinearBatchingProvingKey> key;
-
-    MultilinearBatchingProverClaim new_claim;
 
     SumcheckOutput<Flavor> sumcheck_output;
 };

--- a/barretenberg/cpp/src/barretenberg/multilinear_batching/multilinear_batching_prover.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/multilinear_batching/multilinear_batching_prover.test.cpp
@@ -66,25 +66,5 @@ TEST(MultilinearBatchingProver, ConstructProof)
     auto proof = prover.construct_proof();
     EXPECT_FALSE(proof.empty());
 }
-
-TEST(MultilinearBatchingVerifier, VerifyProof)
-{
-    auto prover_transcript = std::make_shared<Transcript>();
-    auto accumulator_claim = std::make_shared<MultilinearBatchingProverClaim>(create_valid_claim());
-    auto instance_claim = std::make_shared<MultilinearBatchingProverClaim>(create_valid_claim());
-    MultilinearBatchingProver prover{ accumulator_claim, instance_claim, prover_transcript };
-
-    auto proof = prover.construct_proof();
-    EXPECT_FALSE(proof.empty());
-    auto verifier_transcript = std::make_shared<Transcript>();
-    verifier_transcript->load_proof(proof);
-    MultilinearBatchingVerifier<MultilinearBatchingFlavor> verifier{ verifier_transcript };
-
-    auto [verified, sumcheck_output] = verifier.verify_proof();
-    EXPECT_TRUE(verified);
-    auto challenge = sumcheck_output.challenge;
-    auto new_challenge = std::vector<FF>(MultilinearBatchingFlavor::VIRTUAL_LOG_N);
-}
-
 } // namespace
 } // namespace bb

--- a/barretenberg/cpp/src/barretenberg/multilinear_batching/multilinear_batching_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/multilinear_batching/multilinear_batching_verifier.cpp
@@ -19,6 +19,94 @@ MultilinearBatchingVerifier<Flavor_>::MultilinearBatchingVerifier(const std::sha
 {}
 
 template <typename Flavor_>
+MultilinearBatchingVerifier<Flavor_>::FF MultilinearBatchingVerifier<Flavor_>::compute_new_target_sum(
+    const FF& alpha,
+    SumcheckOutput<InstanceFlavor>& instance_sumcheck,
+    const std::vector<InstanceFF>& unshifted_challenges,
+    const std::vector<InstanceFF>& shifted_challenges,
+    const FF& accumulator_non_shifted_evaluation,
+    const FF& accumulator_shifted_evaluation) const
+{
+    // Compute new target sum as:
+    // accumulator_non_shifted_evaluation
+    //  + alpha * accumulator_shifted_evaluation
+    //     + alpha^2 sum( instance_sumcheck.claimed_unshifted_evals * unshifted_challenges )
+    //       + alpha^3 sum( instance_sumcheck.claimed_shifted_evals * shifted_challenges )
+    FF target_sum(0);
+    for (auto [eval, challenge] : zip_view(instance_sumcheck.claimed_evaluations.get_shifted(), shifted_challenges)) {
+        target_sum += eval * challenge;
+    }
+    target_sum *= alpha;
+    for (auto [eval, challenge] :
+         zip_view(instance_sumcheck.claimed_evaluations.get_unshifted(), unshifted_challenges)) {
+        target_sum += eval * challenge;
+    }
+    target_sum *= alpha;
+    target_sum += accumulator_shifted_evaluation; // Accumulator shifted evaluation
+    target_sum *= alpha;
+    target_sum += accumulator_non_shifted_evaluation; // Accumulator non-shifted evaluation
+
+    return target_sum;
+}
+
+template <typename Flavor_>
+template <size_t N>
+MultilinearBatchingVerifier<Flavor_>::Commitment MultilinearBatchingVerifier<Flavor_>::batch_mul(
+    RefArray<Commitment, N> instance_commitments,
+    const Commitment& accumulator_commitment,
+    std::vector<FF>& scalars,
+    const FF& batching_challenge)
+{
+    std::vector<Commitment> points(N + 1);
+    for (size_t idx = 0; auto point : instance_commitments) {
+        points[idx++] = point;
+    }
+    points.back() = accumulator_commitment;
+    scalars.emplace_back(batching_challenge);
+
+    if constexpr (IsRecursiveFlavor<Flavor>) {
+        return Curve::Group::batch_mul(points, scalars);
+    } else {
+        return batch_mul_native(points, scalars);
+    }
+}
+
+template <typename Flavor_>
+MultilinearBatchingVerifier<Flavor_>::VerifierClaim MultilinearBatchingVerifier<Flavor_>::compute_new_claim(
+    const SumcheckOutput<Flavor>& sumcheck_result,
+    InstanceCommitments& verifier_commitments,
+    std::vector<InstanceFF>& unshifted_challenges,
+    std::vector<InstanceFF>& shifted_challenges,
+    const Commitment& non_shifted_accumulator_commitment,
+    const Commitment& shifted_accumulator_commitment,
+    const FF& batching_challenge)
+{
+    // Compute new claim as instance + challenge * accumulator
+    Commitment non_shifted_commitment = batch_mul<NUM_UNSHIFTED_ENTITIES>(verifier_commitments.get_unshifted(),
+                                                                          non_shifted_accumulator_commitment,
+                                                                          unshifted_challenges,
+                                                                          batching_challenge);
+    Commitment shifted_commitment = batch_mul<NUM_SHIFTED_ENTITIES>(verifier_commitments.get_to_be_shifted(),
+                                                                    shifted_accumulator_commitment,
+                                                                    shifted_challenges,
+                                                                    batching_challenge);
+
+    FF shifted_evaluation = sumcheck_result.claimed_evaluations.w_shifted_instance +
+                            sumcheck_result.claimed_evaluations.w_shifted_accumulator * batching_challenge;
+    FF non_shifted_evaluation = sumcheck_result.claimed_evaluations.w_non_shifted_instance +
+                                sumcheck_result.claimed_evaluations.w_non_shifted_accumulator * batching_challenge;
+    std::vector<FF> challenge = sumcheck_result.challenge;
+
+    return VerifierClaim{
+        .challenge = challenge,
+        .non_shifted_evaluation = non_shifted_evaluation,
+        .shifted_evaluation = shifted_evaluation,
+        .non_shifted_commitment = non_shifted_commitment,
+        .shifted_commitment = shifted_commitment,
+    };
+};
+
+template <typename Flavor_>
 std::pair<bool, typename MultilinearBatchingVerifier<Flavor_>::VerifierClaim> MultilinearBatchingVerifier<
     Flavor_>::verify_proof(SumcheckOutput<InstanceFlavor>& instance_sumcheck,
                            InstanceCommitments& verifier_commitments,

--- a/barretenberg/cpp/src/barretenberg/multilinear_batching/multilinear_batching_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/multilinear_batching/multilinear_batching_verifier.cpp
@@ -5,7 +5,11 @@
 // =====================
 
 #include "multilinear_batching_verifier.hpp"
+#include "barretenberg/flavor/mega_recursive_flavor.hpp"
+#include "barretenberg/flavor/multilinear_batching_flavor.hpp"
 #include "barretenberg/flavor/multilinear_batching_recursive_flavor.hpp"
+#include "barretenberg/stdlib/primitives/circuit_builders/circuit_builders_fwd.hpp"
+#include "barretenberg/sumcheck/sumcheck_output.hpp"
 
 namespace bb {
 
@@ -16,72 +20,59 @@ MultilinearBatchingVerifier<Flavor_>::MultilinearBatchingVerifier(const std::sha
 
 template <typename Flavor_>
 std::pair<bool, typename MultilinearBatchingVerifier<Flavor_>::VerifierClaim> MultilinearBatchingVerifier<
-    Flavor_>::verify_proof()
+    Flavor_>::verify_proof(SumcheckOutput<InstanceFlavor>& instance_sumcheck,
+                           InstanceCommitments& verifier_commitments,
+                           std::vector<InstanceFF>& unshifted_challenges,
+                           std::vector<InstanceFF>& shifted_challenges)
 {
     // Receive commitments
     auto non_shifted_accumulator_commitment =
         transcript->template receive_from_prover<Commitment>("non_shifted_accumulator_commitment");
     auto shifted_accumulator_commitment =
         transcript->template receive_from_prover<Commitment>("shifted_accumulator_commitment");
-    auto non_shifted_instance_commitment =
-        transcript->template receive_from_prover<Commitment>("non_shifted_instance_commitment");
-    auto shifted_instance_commitment =
-        transcript->template receive_from_prover<Commitment>("shifted_instance_commitment");
-    std::vector<FF> accumulator_challenges(Flavor::VIRTUAL_LOG_N);
-    std::vector<FF> instance_challenges(Flavor::VIRTUAL_LOG_N);
-    std::vector<FF> accumulator_evaluations(2);
-    std::vector<FF> instance_evaluations(2);
+
     // Receive challenges and evaluations
+    std::vector<FF> accumulator_challenges(Flavor::VIRTUAL_LOG_N);
+    std::vector<FF> accumulator_evaluations(2);
     for (size_t i = 0; i < Flavor::VIRTUAL_LOG_N; i++) {
         accumulator_challenges[i] =
             transcript->template receive_from_prover<FF>("accumulator_challenge_" + std::to_string(i));
-        instance_challenges[i] =
-            transcript->template receive_from_prover<FF>("instance_challenge_" + std::to_string(i));
     }
     for (size_t i = 0; i < 2; i++) {
         accumulator_evaluations[i] =
             transcript->template receive_from_prover<FF>("accumulator_evaluation_" + std::to_string(i));
-        instance_evaluations[i] =
-            transcript->template receive_from_prover<FF>("instance_evaluation_" + std::to_string(i));
     }
 
-    auto accumulator_non_shifted_evaluation = accumulator_evaluations[0];
-    auto accumulator_shifted_evaluation = accumulator_evaluations[1];
-    auto instance_non_shifted_evaluation = instance_evaluations[0];
-    auto instance_shifted_evaluation = instance_evaluations[1];
-
+    // Run sumcheck
     const FF alpha = transcript->template get_challenge<FF>("Sumcheck:alpha");
 
-    auto target_sum = (((instance_shifted_evaluation * alpha + instance_non_shifted_evaluation) * alpha +
-                        accumulator_shifted_evaluation) *
-                           alpha +
-                       accumulator_non_shifted_evaluation);
+    FF target_sum = compute_new_target_sum(alpha,
+                                           instance_sumcheck,
+                                           unshifted_challenges,
+                                           shifted_challenges,
+                                           accumulator_evaluations[0],
+                                           accumulator_evaluations[1]);
+
     Sumcheck sumcheck(transcript, alpha, Flavor::VIRTUAL_LOG_N, target_sum);
     const auto sumcheck_result = sumcheck.verify();
 
     // Construct new claim
     auto claim_batching_challenge = transcript->template get_challenge<FF>("claim_batching_challenge");
-    VerifierClaim verifier_claim;
-    // TODO(https://github.com/AztecProtocol/barretenberg/issues/1558): perform a single MSM to batch incoming instance
-    // commitments and accumulator commitment
-    verifier_claim.non_shifted_commitment =
-        non_shifted_accumulator_commitment + non_shifted_instance_commitment * claim_batching_challenge;
-    verifier_claim.shifted_commitment =
-        shifted_accumulator_commitment + shifted_instance_commitment * claim_batching_challenge;
-    verifier_claim.shifted_evaluation =
-        sumcheck_result.claimed_evaluations.w_shifted_accumulator +
-        sumcheck_result.claimed_evaluations.w_shifted_instance * claim_batching_challenge;
-    verifier_claim.non_shifted_evaluation =
-        sumcheck_result.claimed_evaluations.w_non_shifted_accumulator +
-        sumcheck_result.claimed_evaluations.w_non_shifted_instance * claim_batching_challenge;
-    verifier_claim.challenge = sumcheck_result.challenge;
+    VerifierClaim verifier_claim = compute_new_claim(sumcheck_result,
+                                                     verifier_commitments,
+                                                     unshifted_challenges,
+                                                     shifted_challenges,
+                                                     non_shifted_accumulator_commitment,
+                                                     shifted_accumulator_commitment,
+                                                     claim_batching_challenge);
 
-    // Verification
+    // Verify that the sumcheck claimed evaluations match the evaluations computed from the verifier for the eq
+    // polynomials
     bool verified = true;
     auto equality_verified = sumcheck_result.claimed_evaluations.w_evaluations_accumulator ==
                                  VerifierEqPolynomial<FF>::eval(accumulator_challenges, sumcheck_result.challenge) &&
                              sumcheck_result.claimed_evaluations.w_evaluations_instance ==
-                                 VerifierEqPolynomial<FF>::eval(instance_challenges, sumcheck_result.challenge);
+                                 VerifierEqPolynomial<FF>::eval(instance_sumcheck.challenge, sumcheck_result.challenge);
 
     if constexpr (IsRecursiveFlavor<Flavor>) {
         equality_verified.assert_equal(stdlib::bool_t(equality_verified.get_context(), true));

--- a/barretenberg/cpp/src/barretenberg/multilinear_batching/multilinear_batching_verifier.hpp
+++ b/barretenberg/cpp/src/barretenberg/multilinear_batching/multilinear_batching_verifier.hpp
@@ -59,30 +59,7 @@ template <typename Flavor_> class MultilinearBatchingVerifier {
                               const std::vector<InstanceFF>& unshifted_challenges,
                               const std::vector<InstanceFF>& shifted_challenges,
                               const FF& accumulator_non_shifted_evaluation,
-                              const FF& accumulator_shifted_evaluation) const
-    {
-        // Compute new target sum as:
-        // accumulator_non_shifted_evaluation
-        //  + alpha * accumulator_shifted_evaluation
-        //     + alpha^2 sum( instance_sumcheck.claimed_unshifted_evals * unshifted_challenges )
-        //       + alpha^3 sum( instance_sumcheck.claimed_shifted_evals * shifted_challenges )
-        FF target_sum(0);
-        for (auto [eval, challenge] :
-             zip_view(instance_sumcheck.claimed_evaluations.get_shifted(), shifted_challenges)) {
-            target_sum += eval * challenge;
-        }
-        target_sum *= alpha;
-        for (auto [eval, challenge] :
-             zip_view(instance_sumcheck.claimed_evaluations.get_unshifted(), unshifted_challenges)) {
-            target_sum += eval * challenge;
-        }
-        target_sum *= alpha;
-        target_sum += accumulator_shifted_evaluation; // Accumulator shifted evaluation
-        target_sum *= alpha;
-        target_sum += accumulator_non_shifted_evaluation; // Accumulator non-shifted evaluation
-
-        return target_sum;
-    }
+                              const FF& accumulator_shifted_evaluation) const;
 
     /**
      * @brief Utility to perform batch mul of commitments.
@@ -91,21 +68,7 @@ template <typename Flavor_> class MultilinearBatchingVerifier {
     Commitment batch_mul(RefArray<Commitment, N> instance_commitments,
                          const Commitment& accumulator_commitment,
                          std::vector<FF>& scalars,
-                         const FF& batching_challenge)
-    {
-        std::vector<Commitment> points(N + 1);
-        for (size_t idx = 0; auto point : instance_commitments) {
-            points[idx++] = point;
-        }
-        points.back() = accumulator_commitment;
-        scalars.emplace_back(batching_challenge);
-
-        if constexpr (IsRecursiveFlavor<Flavor>) {
-            return Curve::Group::batch_mul(points, scalars);
-        } else {
-            return batch_mul_native(points, scalars);
-        }
-    }
+                         const FF& batching_challenge);
 
     /**
      * @brief Utility to compute the new claim after the batching sumcheck.
@@ -116,32 +79,7 @@ template <typename Flavor_> class MultilinearBatchingVerifier {
                                     std::vector<InstanceFF>& shifted_challenges,
                                     const Commitment& non_shifted_accumulator_commitment,
                                     const Commitment& shifted_accumulator_commitment,
-                                    const FF& batching_challenge)
-    {
-        // Compute new claim as instance + challenge * accumulator
-        Commitment non_shifted_commitment = batch_mul<NUM_UNSHIFTED_ENTITIES>(verifier_commitments.get_unshifted(),
-                                                                              non_shifted_accumulator_commitment,
-                                                                              unshifted_challenges,
-                                                                              batching_challenge);
-        Commitment shifted_commitment = batch_mul<NUM_SHIFTED_ENTITIES>(verifier_commitments.get_to_be_shifted(),
-                                                                        shifted_accumulator_commitment,
-                                                                        shifted_challenges,
-                                                                        batching_challenge);
-
-        FF shifted_evaluation = sumcheck_result.claimed_evaluations.w_shifted_instance +
-                                sumcheck_result.claimed_evaluations.w_shifted_accumulator * batching_challenge;
-        FF non_shifted_evaluation = sumcheck_result.claimed_evaluations.w_non_shifted_instance +
-                                    sumcheck_result.claimed_evaluations.w_non_shifted_accumulator * batching_challenge;
-        std::vector<FF> challenge = sumcheck_result.challenge;
-
-        return VerifierClaim{
-            .challenge = challenge,
-            .non_shifted_evaluation = non_shifted_evaluation,
-            .shifted_evaluation = shifted_evaluation,
-            .non_shifted_commitment = non_shifted_commitment,
-            .shifted_commitment = shifted_commitment,
-        };
-    };
+                                    const FF& batching_challenge);
 };
 
 } // namespace bb

--- a/barretenberg/cpp/src/barretenberg/multilinear_batching/multilinear_batching_verifier.hpp
+++ b/barretenberg/cpp/src/barretenberg/multilinear_batching/multilinear_batching_verifier.hpp
@@ -5,12 +5,15 @@
 // =====================
 
 #pragma once
+#include "barretenberg/flavor/mega_recursive_flavor.hpp"
 #include "barretenberg/flavor/multilinear_batching_flavor.hpp"
 #include "barretenberg/flavor/multilinear_batching_recursive_flavor.hpp"
 #include "barretenberg/honk/proof_system/types/proof.hpp"
 #include "barretenberg/multilinear_batching/multilinear_batching_claims.hpp"
 #include "barretenberg/relations/relation_parameters.hpp"
+#include "barretenberg/stdlib/primitives/circuit_builders/circuit_builders_fwd.hpp"
 #include "barretenberg/sumcheck/sumcheck.hpp"
+#include "barretenberg/sumcheck/sumcheck_output.hpp"
 
 #include <vector>
 
@@ -28,14 +31,117 @@ template <typename Flavor_> class MultilinearBatchingVerifier {
     using VerifierClaim = MultilinearBatchingVerifierClaim<Curve>;
     using Proof = std::vector<FF>;
 
+    using InstanceFlavor = std::conditional_t<std::is_same_v<Flavor, MultilinearBatchingFlavor>,
+                                              MegaFlavor,
+                                              MegaRecursiveFlavor_<MegaCircuitBuilder>>;
+    using InstanceCommitments = InstanceFlavor::VerifierCommitments;
+    using InstanceFF = InstanceFlavor::FF;
+    static constexpr size_t NUM_UNSHIFTED_ENTITIES = MegaFlavor::NUM_UNSHIFTED_ENTITIES;
+    static constexpr size_t NUM_SHIFTED_ENTITIES = MegaFlavor::NUM_SHIFTED_ENTITIES;
+
     explicit MultilinearBatchingVerifier(const std::shared_ptr<Transcript>& transcript);
 
-    std::pair<bool, VerifierClaim> verify_proof();
+    std::pair<bool, VerifierClaim> verify_proof(SumcheckOutput<InstanceFlavor>& instance_sumcheck,
+                                                InstanceCommitments& verifier_commitments,
+                                                std::vector<InstanceFF>& unshifted_challenges,
+                                                std::vector<InstanceFF>& shifted_challenges);
 
   private:
     std::shared_ptr<Transcript> transcript;
     std::shared_ptr<VerifierClaim> accumulator_claim;
     std::shared_ptr<VerifierClaim> instance_claim;
+
+    /**
+     * @brief Utility to compute the new target sum for the batching sumcheck.
+     */
+    FF compute_new_target_sum(const FF& alpha,
+                              SumcheckOutput<InstanceFlavor>& instance_sumcheck,
+                              const std::vector<InstanceFF>& unshifted_challenges,
+                              const std::vector<InstanceFF>& shifted_challenges,
+                              const FF& accumulator_non_shifted_evaluation,
+                              const FF& accumulator_shifted_evaluation) const
+    {
+        // Compute new target sum as:
+        // accumulator_non_shifted_evaluation
+        //  + alpha * accumulator_shifted_evaluation
+        //     + alpha^2 sum( instance_sumcheck.claimed_unshifted_evals * unshifted_challenges )
+        //       + alpha^3 sum( instance_sumcheck.claimed_shifted_evals * shifted_challenges )
+        FF target_sum(0);
+        for (auto [eval, challenge] :
+             zip_view(instance_sumcheck.claimed_evaluations.get_shifted(), shifted_challenges)) {
+            target_sum += eval * challenge;
+        }
+        target_sum *= alpha;
+        for (auto [eval, challenge] :
+             zip_view(instance_sumcheck.claimed_evaluations.get_unshifted(), unshifted_challenges)) {
+            target_sum += eval * challenge;
+        }
+        target_sum *= alpha;
+        target_sum += accumulator_shifted_evaluation; // Accumulator shifted evaluation
+        target_sum *= alpha;
+        target_sum += accumulator_non_shifted_evaluation; // Accumulator non-shifted evaluation
+
+        return target_sum;
+    }
+
+    /**
+     * @brief Utility to perform batch mul of commitments.
+     */
+    template <size_t N>
+    Commitment batch_mul(RefArray<Commitment, N> instance_commitments,
+                         const Commitment& accumulator_commitment,
+                         std::vector<FF>& scalars,
+                         const FF& batching_challenge)
+    {
+        std::vector<Commitment> points(N + 1);
+        for (size_t idx = 0; auto point : instance_commitments) {
+            points[idx++] = point;
+        }
+        points.back() = accumulator_commitment;
+        scalars.emplace_back(batching_challenge);
+
+        if constexpr (IsRecursiveFlavor<Flavor>) {
+            return Curve::Group::batch_mul(points, scalars);
+        } else {
+            return batch_mul_native(points, scalars);
+        }
+    }
+
+    /**
+     * @brief Utility to compute the new claim after the batching sumcheck.
+     */
+    VerifierClaim compute_new_claim(const SumcheckOutput<Flavor>& sumcheck_result,
+                                    InstanceCommitments& verifier_commitments,
+                                    std::vector<InstanceFF>& unshifted_challenges,
+                                    std::vector<InstanceFF>& shifted_challenges,
+                                    const Commitment& non_shifted_accumulator_commitment,
+                                    const Commitment& shifted_accumulator_commitment,
+                                    const FF& batching_challenge)
+    {
+        // Compute new claim as instance + challenge * accumulator
+        Commitment non_shifted_commitment = batch_mul<NUM_UNSHIFTED_ENTITIES>(verifier_commitments.get_unshifted(),
+                                                                              non_shifted_accumulator_commitment,
+                                                                              unshifted_challenges,
+                                                                              batching_challenge);
+        Commitment shifted_commitment = batch_mul<NUM_SHIFTED_ENTITIES>(verifier_commitments.get_to_be_shifted(),
+                                                                        shifted_accumulator_commitment,
+                                                                        shifted_challenges,
+                                                                        batching_challenge);
+
+        FF shifted_evaluation = sumcheck_result.claimed_evaluations.w_shifted_instance +
+                                sumcheck_result.claimed_evaluations.w_shifted_accumulator * batching_challenge;
+        FF non_shifted_evaluation = sumcheck_result.claimed_evaluations.w_non_shifted_instance +
+                                    sumcheck_result.claimed_evaluations.w_non_shifted_accumulator * batching_challenge;
+        std::vector<FF> challenge = sumcheck_result.challenge;
+
+        return VerifierClaim{
+            .challenge = challenge,
+            .non_shifted_evaluation = non_shifted_evaluation,
+            .shifted_evaluation = shifted_evaluation,
+            .non_shifted_commitment = non_shifted_commitment,
+            .shifted_commitment = shifted_commitment,
+        };
+    };
 };
 
 } // namespace bb


### PR DESCRIPTION
This PR closes https://github.com/AztecProtocol/barretenberg/issues/1558 by implementing an efficient MSM in Hypernova: to fold the incoming instance with the accumulator, instead of performing first an MSM for the instance and then batch with the accumulator, we perform a single MSM.

For non-shifted entities the new MSM is a size 56 MSM with short scalars (vs a size 55 MSM plus a size 2 MSM)
For shifted entities the new MSM is a size 6 MSM with short scalars (vs a size 5 MSM plus a size 2 MSM).

This change saves `128` rows per recursive folding verification.

The PR also introduces some mocking tests for MultilinearBatchingProver.

**NOTE:** From this PR onward, the MultilinearBatchingVerifier must share the transcript with the sumcheck that comes before it (as the instance commitments are not added to the transcript of the MultinearBatchingVerifier). This is ok as long as we only use the MultilinearBatchingVerifier via Hypernova.