### PR TITLE
chore: blake2s cleanup 

### DIFF
--- a/barretenberg/cpp/src/barretenberg/stdlib/hash/blake2s/blake2s.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/hash/blake2s/blake2s.cpp
@@ -33,6 +33,9 @@ namespace bb::stdlib {
  *    f_1 = |
  *           \  0x000...00   otherwise
  *
+ * Note that although blake2s_state is a circuit constant, we use designated functions such as
+ * `ranged_less_than` to enforce constraints as appropriate.
+ *
  * Further, the internal state 4x4 matrix used by the compression function is denoted by v.
  * The input data is stored in the 16-word message m.
  */
@@ -41,9 +44,8 @@ template <typename Builder> void Blake2s<Builder>::increment_counter(blake2s_sta
 {
     field_ct inc_scalar(static_cast<uint256_t>(inc));
     S.t[0] = S.t[0] + inc_scalar;
-    // TODO: Secure!? Think so as inc is known at "compile" time as it's derived from the msg length.
-    const bool to_inc = uint32_t(uint256_t(S.t[0].get_value())) < inc;
-    S.t[1] = S.t[1] + (to_inc ? field_ct(1) : field_ct(0));
+    bool_ct to_inc = S.t[0].template ranged_less_than<32>(inc_scalar);
+    S.t[1] = S.t[1] + field_ct(to_inc);
 }
 
 template <typename Builder> void Blake2s<Builder>::compress(blake2s_state& S, byte_array_ct const& in)

--- a/barretenberg/cpp/src/barretenberg/stdlib/hash/blake2s/blake2s.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/hash/blake2s/blake2s.cpp
@@ -33,9 +33,6 @@ namespace bb::stdlib {
  *    f_1 = |
  *           \  0x000...00   otherwise
  *
- * Note that although blake2s_state is a circuit constant, we use designated functions such as
- * `ranged_less_than` to enforce constraints as appropriate.
- *
  * Further, the internal state 4x4 matrix used by the compression function is denoted by v.
  * The input data is stored in the 16-word message m.
  */
@@ -43,7 +40,12 @@ namespace bb::stdlib {
 template <typename Builder> void Blake2s<Builder>::increment_counter(blake2s_state& S, const uint32_t inc)
 {
     field_ct inc_scalar(static_cast<uint256_t>(inc));
+
+    // Note that the initial blake2s_state values are circuit constants.
     S.t[0] = S.t[0] + inc_scalar;
+
+    // Note that although blake2s_state is a circuit constant, we use designated functions such as
+    // `ranged_less_than` to enforce constraints as appropriate.
     bool_ct to_inc = S.t[0].template ranged_less_than<32>(inc_scalar);
     S.t[1] = S.t[1] + field_ct(to_inc);
 }

--- a/barretenberg/cpp/src/barretenberg/stdlib/hash/blake2s/blake2s.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/hash/blake2s/blake2s.hpp
@@ -16,6 +16,8 @@ namespace bb::stdlib {
 template <typename Builder> class Blake2s {
     using field_ct = field_t<Builder>;
     using byte_array_ct = byte_array<Builder>;
+    using bool_ct = bool_t<Builder>;
+    using witness_ct = witness_t<Builder>;
 
     static constexpr uint32_t blake2s_IV[8] = { 0x6A09E667UL, 0xBB67AE85UL, 0x3C6EF372UL, 0xA54FF53AUL,
                                                 0x510E527FUL, 0x9B05688CUL, 0x1F83D9ABUL, 0x5BE0CD19UL };

--- a/barretenberg/cpp/src/barretenberg/stdlib/hash/blake2s/blake2s.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/hash/blake2s/blake2s.test.cpp
@@ -1,5 +1,8 @@
 #include "barretenberg/crypto/blake2s/blake2s.hpp"
 #include "barretenberg/circuit_checker/circuit_checker.hpp"
+#include "barretenberg/flavor/ultra_flavor.hpp"
+#include "barretenberg/numeric/uint256/uint256.hpp"
+#include "barretenberg/ultra_honk/prover_instance.hpp"
 #include "blake2s.hpp"
 #include <gtest/gtest.h>
 
@@ -11,17 +14,31 @@ using Builder = UltraCircuitBuilder;
 using field_ct = field_t<Builder>;
 using witness_ct = witness_t<Builder>;
 using byte_array_ct = byte_array<Builder>;
-using byte_array_plookup = byte_array<Builder>;
 using public_witness_t = public_witness_t<Builder>;
 
-TEST(stdlib_blake2s, test_single_block_plookup)
+std::vector<std::string> test_vectors = { "",
+                                          "a",
+                                          "ab",
+                                          "abc",
+                                          "abcd",
+                                          "abcdefg",
+                                          "abcdefgh",
+                                          "abcdefghijklmnopqrstuvwxyz01234",
+                                          "abcdefghijklmnopqrstuvwxyz012345",
+                                          "abcdefghijklmnopqrstuvwxyz0123456",
+                                          "abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0",
+                                          "abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz01",
+                                          "abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz012",
+                                          "abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789" };
+
+TEST(stdlib_blake2s, test_single_block)
 {
     Builder builder;
     std::string input = "abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz01";
     std::vector<uint8_t> input_v(input.begin(), input.end());
 
-    byte_array_plookup input_arr(&builder, input_v);
-    byte_array_plookup output = stdlib::Blake2s<Builder>::hash(input_arr);
+    byte_array_ct input_arr(&builder, input_v);
+    byte_array_ct output = stdlib::Blake2s<Builder>::hash(input_arr);
 
     auto expected = crypto::blake2s(input_v);
 
@@ -33,14 +50,14 @@ TEST(stdlib_blake2s, test_single_block_plookup)
     EXPECT_EQ(proof_result, true);
 }
 
-TEST(stdlib_blake2s, test_double_block_plookup)
+TEST(stdlib_blake2s, test_double_block)
 {
     Builder builder;
     std::string input = "abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789";
     std::vector<uint8_t> input_v(input.begin(), input.end());
 
-    byte_array_plookup input_arr(&builder, input_v);
-    byte_array_plookup output = stdlib::Blake2s<Builder>::hash(input_arr);
+    byte_array_ct input_arr(&builder, input_v);
+    byte_array_ct output = stdlib::Blake2s<Builder>::hash(input_arr);
 
     auto expected = crypto::blake2s(input_v);
 
@@ -50,4 +67,68 @@ TEST(stdlib_blake2s, test_double_block_plookup)
 
     bool proof_result = CircuitChecker::check(builder);
     EXPECT_EQ(proof_result, true);
+}
+
+TEST(stdlib_blake2s, test_witness_and_constant)
+{
+    Builder builder;
+
+    // create a byte array that is a circuit witness
+    std::string witness_str = "abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz";
+    std::vector<uint8_t> witness_str_vec(witness_str.begin(), witness_str.end());
+    byte_array_ct witness_str_ct(&builder, witness_str_vec);
+
+    // create a byte array that is a circuit constant
+    std::vector<uint8_t> constant_vec = { '0', '1' };
+    std::vector<field_ct> constant_vec_field_ct;
+    for (auto b : constant_vec) {
+        constant_vec_field_ct.emplace_back(field_ct(bb::fr(b)));
+    }
+    byte_array_ct constant_vec_ct(&builder, constant_vec_field_ct);
+
+    // create a byte array that is part circuit witness and part circuit constant
+    byte_array_ct input_arr(&builder);
+    input_arr.write(witness_str_ct).write(constant_vec_ct);
+
+    // hash the combined byte array
+    byte_array_ct output = stdlib::Blake2s<Builder>::hash(input_arr);
+
+    // create expected input vector by concatenating witness and constant parts
+    std::vector<uint8_t> input_v;
+    input_v.insert(input_v.end(), witness_str_vec.begin(), witness_str_vec.end());
+    input_v.insert(input_v.end(), constant_vec.begin(), constant_vec.end());
+
+    // compute expected hash
+    auto expected = crypto::blake2s(input_v);
+
+    EXPECT_EQ(output.get_value(), std::vector<uint8_t>(expected.begin(), expected.end()));
+
+    info("builder gates = ", builder.get_num_finalized_gates_inefficient());
+
+    bool proof_result = CircuitChecker::check(builder);
+    EXPECT_EQ(proof_result, true);
+}
+
+TEST(stdlib_blake2s, test_multiple_sized_blocks)
+{
+
+    int i = 0;
+
+    for (auto v : test_vectors) {
+        Builder builder;
+
+        std::vector<uint8_t> input_v(v.begin(), v.end());
+
+        byte_array_ct input_arr(&builder, input_v);
+        byte_array_ct output = stdlib::Blake2s<Builder>::hash(input_arr);
+
+        auto expected = crypto::blake2s(input_v);
+
+        EXPECT_EQ(output.get_value(), std::vector<uint8_t>(expected.begin(), expected.end()));
+
+        info("test vector ", i++, ".: builder gates = ", builder.get_num_finalized_gates_inefficient());
+
+        bool proof_result = CircuitChecker::check(builder);
+        EXPECT_EQ(proof_result, true);
+    }
 }


### PR DESCRIPTION
Cleaning up the blake2s module. 
Remove unused instances of `byte_array_plookup`. 	
Modify [`increment_counter`](https://github.com/AztecProtocol/aztec-packages/blob/nk/blake2s_cleanup/barretenberg/cpp/src/barretenberg/stdlib/hash/blake2s/blake2s.cpp#L43-L49) to use `ranged_less_than` instead of out-of-circuit comparison to enforce circuit constraints when updating the `blake2s_state` counter. Although `blake2s_state` values are a constant and evaluate out-of-circuit internally, using the designated function ensures constraints are added where necessary. 
Add tests to (1) [hash different sized blocks](https://github.com/AztecProtocol/aztec-packages/blob/nk/blake2s_cleanup/barretenberg/cpp/src/barretenberg/stdlib/hash/blake2s/blake2s.test.cpp#L112), and (2) to [hash a mixed input](https://github.com/AztecProtocol/aztec-packages/blob/nk/blake2s_cleanup/barretenberg/cpp/src/barretenberg/stdlib/hash/blake2s/blake2s.test.cpp#L72) that comprises a circuit witness as well as a circuit constant. 
