### PR TITLE
fix(p2p): gate BLOCK_TXS req/resp behind TRANSACTIONS_DISABLED

### DIFF
--- a/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
+++ b/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
@@ -478,7 +478,7 @@ export class LibP2PService<T extends P2PClientType = P2PClientType.Full> extends
     };
 
     // Only handle block transactions request if attestation pool is available to the client
-    if (this.mempools.attestationPool) {
+    if (this.mempools.attestationPool && !this.config.disableTransactions) {
       const blockTxsHandler = reqRespBlockTxsHandler(this.mempools.attestationPool, this.mempools.txPool);
       requestResponseHandlers[ReqRespSubProtocol.BLOCK_TXS] = blockTxsHandler.bind(this);
     }


### PR DESCRIPTION
Only register BLOCK_TXS handler when attestationPool exists and transactions are enabled.

Reduces req/resp surface on tx-disabled networks.