### PR TITLE
refactor: remove ABI decoding from pxe private events

### DIFF
--- a/yarn-project/pxe/src/contract_function_simulator/pxe_oracle_interface.test.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/pxe_oracle_interface.test.ts
@@ -611,7 +611,7 @@ describe('PXEOracleInterface', () => {
       );
 
       expect(result.length).toEqual(1);
-      expect(result[0].msgContent).toEqual(eventContent);
+      expect(result[0].packedEvent).toEqual(eventContent);
     });
   });
 

--- a/yarn-project/pxe/src/storage/private_event_data_provider/private_event_data_provider.ts
+++ b/yarn-project/pxe/src/storage/private_event_data_provider/private_event_data_provider.ts
@@ -7,6 +7,8 @@ import type { AztecAddress } from '@aztec/stdlib/aztec-address';
 import { L2BlockHash } from '@aztec/stdlib/block';
 import { TxHash } from '@aztec/stdlib/tx';
 
+import type { PrivateEvent } from '../../pxe.js';
+
 interface PrivateEventEntry {
   msgContent: Buffer;
   blockNumber: number;
@@ -14,14 +16,6 @@ interface PrivateEventEntry {
   eventCommitmentIndex: number;
   txHash: Buffer;
 }
-
-export type PrivateEvent = {
-  msgContent: Fr[];
-  blockNumber: number;
-  blockHash: L2BlockHash;
-  txHash: TxHash;
-  recipient: AztecAddress;
-};
 
 /**
  * Stores decrypted private event logs.
@@ -131,11 +125,12 @@ export class PrivateEventDataProvider {
         events.push({
           eventCommitmentIndex: entry.eventCommitmentIndex,
           event: {
-            msgContent,
+            packedEvent: msgContent,
             blockNumber: entry.blockNumber,
             recipient,
             txHash,
             blockHash,
+            eventSelector,
           },
         });
       }

--- a/yarn-project/test-wallet/package.json
+++ b/yarn-project/test-wallet/package.json
@@ -75,6 +75,7 @@
     "@types/jest": "^30.0.0",
     "@types/node": "^22.15.17",
     "jest": "^30.0.0",
+    "jest-mock-extended": "^4.0.0",
     "resolve-typescript-plugin": "^2.0.1",
     "ts-loader": "^9.5.4",
     "ts-node": "^10.9.1",

--- a/yarn-project/test-wallet/src/wallet/base_wallet.test.ts
+++ b/yarn-project/test-wallet/src/wallet/base_wallet.test.ts
@@ -1,0 +1,96 @@
+// Why test BaseWallet here and not at Aztec.js?
+// We need a PXE to instantiate a BaseWallet, and due to
+// circular dependencies we can't have it.
+// Current plans involve creating a Wallet SDK which would be
+// a natural new home for both BaseWallet and this test,
+// but that's out of scope for now.
+import type { Account } from '@aztec/aztec.js/account';
+import type { AztecNode } from '@aztec/aztec.js/node';
+import { type Aliased, BaseWallet } from '@aztec/aztec.js/wallet';
+import { Fr } from '@aztec/foundation/fields';
+import { TokenContract, type Transfer } from '@aztec/noir-contracts.js/Token';
+import { PXE, type PrivateEvent } from '@aztec/pxe/server';
+import { AztecAddress } from '@aztec/stdlib/aztec-address';
+import { L2BlockHash } from '@aztec/stdlib/block';
+import { TxHash } from '@aztec/stdlib/tx';
+
+import { type MockProxy, mock } from 'jest-mock-extended';
+
+/**
+ * Just a construct to test BaseWallet
+ */
+class BasicWallet extends BaseWallet {
+  constructor(pxe: PXE, node: AztecNode) {
+    super(pxe, node);
+  }
+
+  protected override getAccountFromAddress(_address: AztecAddress): Promise<Account> {
+    throw new Error('Method not implemented.');
+  }
+  override getAccounts(): Promise<Aliased<AztecAddress>[]> {
+    throw new Error('Method not implemented.');
+  }
+}
+
+describe('BaseWallet', () => {
+  let pxe: MockProxy<PXE>;
+  let node: MockProxy<AztecNode>;
+
+  // eslint-disable-next-line jsdoc/require-jsdoc
+  async function makeTransferEvent(amount: number): Promise<Transfer> {
+    return {
+      from: await AztecAddress.random(),
+      to: await AztecAddress.random(),
+      amount: BigInt(amount),
+    };
+  }
+
+  // eslint-disable-next-line jsdoc/require-jsdoc
+  function encodeTransfer(transfer: Transfer): Fr[] {
+    return [
+      (transfer.from as AztecAddress).toField(),
+      (transfer.to as AztecAddress).toField(),
+      new Fr(transfer.amount),
+    ];
+  }
+
+  // eslint-disable-next-line jsdoc/require-jsdoc
+  async function privateEventFor(serial: Fr[]): Promise<PrivateEvent> {
+    return {
+      packedEvent: serial,
+      recipient: await AztecAddress.random(),
+      blockHash: L2BlockHash.random(),
+      blockNumber: 42,
+      txHash: TxHash.random(),
+      eventSelector: TokenContract.events.Transfer.eventSelector,
+    };
+  }
+
+  it('decodes private events', async () => {
+    pxe = mock<PXE>();
+    node = mock<AztecNode>();
+
+    const transfer1: Transfer = await makeTransferEvent(120);
+    const transfer2: Transfer = await makeTransferEvent(235);
+
+    const transfer1Serialized: Fr[] = encodeTransfer(transfer1);
+    const transfer2Serialized: Fr[] = encodeTransfer(transfer2);
+
+    pxe.getPrivateEvents.mockResolvedValue([
+      await privateEventFor(transfer1Serialized),
+      await privateEventFor(transfer2Serialized),
+    ]);
+
+    const basicWallet = new BasicWallet(pxe, node);
+
+    const events = await basicWallet.getPrivateEvents<Transfer>(
+      await AztecAddress.random(),
+      TokenContract.events.Transfer,
+      42,
+      1,
+      [await AztecAddress.random()],
+    );
+
+    expect(events).toEqual([transfer1, transfer2]);
+  });
+});

--- a/yarn-project/yarn.lock
+++ b/yarn-project/yarn.lock
@@ -2156,6 +2156,7 @@ __metadata:
     "@types/jest": "npm:^30.0.0"
     "@types/node": "npm:^22.15.17"
     jest: "npm:^30.0.0"
+    jest-mock-extended: "npm:^4.0.0"
     resolve-typescript-plugin: "npm:^2.0.1"
     ts-loader: "npm:^9.5.4"
     ts-node: "npm:^10.9.1"


### PR DESCRIPTION
Part of F-96

This refactor moves the responsibility of ABI-decoding private events from PXE to wallet. There are some details/design decisions to iron out though, I'll try to summarize them below.

## `PrivateEvent`: to `InBlock` or not to `InBlock`

Before this change, `PXE#getPrivateEvents` was generic on the type of event, so we didn't need an explicit return type. After this change, PXE returns `PrivateEvent`'s that the wallet must ABI decode. 

There's an open conversation regarding whether `PrivateEvent` should be defined in terms of `InBlock`. I'm a bit on the fence about forcing an artificial `data` attribute on the structure, so I'm discussing potentially changing `InBlock<T>` from a generic to a plain type that can be used in intersections (hence more degrees of freedom for whoever is defining types on top of it). If that approach is blessed I'll probably tackle it in its own PR since `InBlock` is defined in stdlib and changing it could ripple. 

## Unit test for PXE#getPrivateEvents

I wanted to have some tests that don't require an e2e harness to check basic functioning. Most of the setup of the test is mocking context so that calling  `sync_private_state` doesn't blow up.

The rest of it leverages `PrivateDataEventDataProvider` to make sure some events are ready to be returned.

This at least works so if we break interfaces there's a quick unit test failing to show it. More granular behaviors can be better tested at the `PrivateDataEventDataProvider` unit suite, and less artificial examples can be exercised on e2e.

## Unit test for ABI decoding at BaseWallet#getPrivateEvents

Similarly, I wanted to have some unit test in place before proceeding to refactor these APIs further. At this layer I just wanted to have some checks that we're actually ABI-decoding. I couldn't find a straightforward/generic way to encode event data so I'm manually serializing it. If we prefer so, I can write an ad-hoc contract for this test but first I would like to validate the general approach. 