### PR TITLE
fix: opt blake sol tests in merge-train

### DIFF
--- a/barretenberg/sol/scripts/init_honk.sh
+++ b/barretenberg/sol/scripts/init_honk.sh
@@ -9,3 +9,11 @@ mkdir -p './src/honk/keys'
 ../cpp/build/bin/honk_solidity_key_gen blake $OUTPUT_PATH $SRS_PATH
 ../cpp/build/bin/honk_solidity_key_gen ecdsa $OUTPUT_PATH $SRS_PATH
 ../cpp/build/bin/honk_solidity_key_gen recursive $OUTPUT_PATH $SRS_PATH
+
+echo ""
+echo "✓ VK generation complete"
+
+# Sync blake-opt.sol with generated Blake VK
+echo ""
+echo "Syncing blake-opt.sol with generated Blake VK..."
+./scripts/sync_blake_opt_vk.sh

--- a/barretenberg/sol/scripts/sync_blake_opt_vk.sh
+++ b/barretenberg/sol/scripts/sync_blake_opt_vk.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+# Script to sync VK values from generated BlakeHonkVerificationKey.sol to blake-opt.sol
+# This ensures blake-opt.sol stays in sync when VK structure changes
+#
+# This script is IDEMPOTENT - safe to run multiple times, will only update if values differ
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VK_FILE="$SCRIPT_DIR/../src/honk/keys/BlakeHonkVerificationKey.sol"
+OPT_FILE="$SCRIPT_DIR/../src/honk/optimised/blake-opt.sol"
+
+if [ ! -f "$VK_FILE" ]; then
+    echo "Error: VK file not found at $VK_FILE"
+    exit 1
+fi
+
+if [ ! -f "$OPT_FILE" ]; then
+    echo "Error: blake-opt.sol not found at $OPT_FILE"
+    exit 1
+fi
+
+# Function to extract x,y coordinates from VK file for a given field name
+extract_coords() {
+    local field_name="$1"
+    local x=$(grep -A1 "$field_name: Honk.G1Point" "$VK_FILE" | grep " x:" | sed -E 's/.*uint256\((0x[0-9a-fA-F]+)\).*/\1/')
+    local y=$(grep -A2 "$field_name: Honk.G1Point" "$VK_FILE" | grep " y:" | sed -E 's/.*uint256\((0x[0-9a-fA-F]+)\).*/\1/')
+    echo "$x $y"
+}
+
+# Extract VK_HASH for idempotency check
+VK_HASH=$(grep "uint256 constant VK_HASH" "$VK_FILE" | sed -E 's/.*= (0x[0-9a-fA-F]+);/\1/')
+CURRENT_VK_HASH=$(grep "uint256 constant VK_HASH" "$OPT_FILE" | sed -E 's/.*= (0x[0-9a-fA-F]+);/\1/')
+
+if [ "$VK_HASH" = "$CURRENT_VK_HASH" ]; then
+    echo "✓ blake-opt.sol already in sync with VK (VK_HASH: $VK_HASH)"
+    exit 0
+fi
+
+echo "Syncing VK values from VK file to blake-opt.sol..."
+echo "  VK_HASH: $CURRENT_VK_HASH → $VK_HASH"
+
+# Extract circuit parameters
+CIRCUIT_SIZE=$(grep "uint256 constant N = " "$VK_FILE" | sed -E 's/.*= ([0-9]+);/\1/')
+LOG_N=$(grep "uint256 constant LOG_N" "$VK_FILE" | sed -E 's/.*= ([0-9]+);/\1/')
+NUM_PUBLIC_INPUTS=$(grep "uint256 constant NUMBER_OF_PUBLIC_INPUTS" "$VK_FILE" | sed -E 's/.*= ([0-9]+);/\1/')
+
+# Extract all polynomial commitments
+read Q_L_X Q_L_Y <<< $(extract_coords "ql")
+read Q_R_X Q_R_Y <<< $(extract_coords "qr")
+read Q_O_X Q_O_Y <<< $(extract_coords "qo")
+read Q_4_X Q_4_Y <<< $(extract_coords "q4")
+read Q_M_X Q_M_Y <<< $(extract_coords "qm")
+read Q_C_X Q_C_Y <<< $(extract_coords "qc")
+read Q_LOOKUP_X Q_LOOKUP_Y <<< $(extract_coords "qLookup")
+read Q_ARITH_X Q_ARITH_Y <<< $(extract_coords "qArith")
+read Q_DELTA_RANGE_X Q_DELTA_RANGE_Y <<< $(extract_coords "qDeltaRange")
+read Q_ELLIPTIC_X Q_ELLIPTIC_Y <<< $(extract_coords "qElliptic")
+read Q_MEMORY_X Q_MEMORY_Y <<< $(extract_coords "qMemory")
+read Q_NNF_X Q_NNF_Y <<< $(extract_coords "qNnf")
+read Q_POSEIDON_2_EXTERNAL_X Q_POSEIDON_2_EXTERNAL_Y <<< $(extract_coords "qPoseidon2External")
+read Q_POSEIDON_2_INTERNAL_X Q_POSEIDON_2_INTERNAL_Y <<< $(extract_coords "qPoseidon2Internal")
+
+# Extract permutation polynomials (SIGMA in blake-opt.sol, s in VK)
+read SIGMA_1_X SIGMA_1_Y <<< $(extract_coords "s1")
+read SIGMA_2_X SIGMA_2_Y <<< $(extract_coords "s2")
+read SIGMA_3_X SIGMA_3_Y <<< $(extract_coords "s3")
+read SIGMA_4_X SIGMA_4_Y <<< $(extract_coords "s4")
+
+# Extract TABLE polynomials
+read TABLE_1_X TABLE_1_Y <<< $(extract_coords "t1")
+read TABLE_2_X TABLE_2_Y <<< $(extract_coords "t2")
+read TABLE_3_X TABLE_3_Y <<< $(extract_coords "t3")
+read TABLE_4_X TABLE_4_Y <<< $(extract_coords "t4")
+
+# Extract ID polynomials
+read ID_1_X ID_1_Y <<< $(extract_coords "id1")
+read ID_2_X ID_2_Y <<< $(extract_coords "id2")
+read ID_3_X ID_3_Y <<< $(extract_coords "id3")
+read ID_4_X ID_4_Y <<< $(extract_coords "id4")
+
+# Extract Lagrange polynomials
+read LAGRANGE_FIRST_X LAGRANGE_FIRST_Y <<< $(extract_coords "lagrangeFirst")
+read LAGRANGE_LAST_X LAGRANGE_LAST_Y <<< $(extract_coords "lagrangeLast")
+
+# Create backup
+cp "$OPT_FILE" "${OPT_FILE}.bak"
+
+# Update VK_HASH
+sed -i "s/uint256 constant VK_HASH = 0x[0-9a-fA-F]\+;/uint256 constant VK_HASH = $VK_HASH;/" "$OPT_FILE"
+
+# Update circuit parameters
+sed -i "s/uint256 constant CIRCUIT_SIZE = [0-9]\+;/uint256 constant CIRCUIT_SIZE = $CIRCUIT_SIZE;/" "$OPT_FILE"
+sed -i "s/uint256 constant LOG_N = [0-9]\+;/uint256 constant LOG_N = $LOG_N;/" "$OPT_FILE"
+sed -i "s/uint256 constant NUMBER_PUBLIC_INPUTS = [0-9]\+;/uint256 constant NUMBER_PUBLIC_INPUTS = $NUM_PUBLIC_INPUTS;/" "$OPT_FILE"
+sed -i "s/uint256 constant REAL_NUMBER_PUBLIC_INPUTS = [0-9]\+ - 16;/uint256 constant REAL_NUMBER_PUBLIC_INPUTS = $NUM_PUBLIC_INPUTS - 16;/" "$OPT_FILE"
+
+# Update Q polynomial commitments
+sed -i "s/mstore(Q_L_X_LOC, 0x[0-9a-fA-F]\+)/mstore(Q_L_X_LOC, $Q_L_X)/" "$OPT_FILE"
+sed -i "s/mstore(Q_L_Y_LOC, 0x[0-9a-fA-F]\+)/mstore(Q_L_Y_LOC, $Q_L_Y)/" "$OPT_FILE"
+sed -i "s/mstore(Q_R_X_LOC, 0x[0-9a-fA-F]\+)/mstore(Q_R_X_LOC, $Q_R_X)/" "$OPT_FILE"
+sed -i "s/mstore(Q_R_Y_LOC, 0x[0-9a-fA-F]\+)/mstore(Q_R_Y_LOC, $Q_R_Y)/" "$OPT_FILE"
+sed -i "s/mstore(Q_O_X_LOC, 0x[0-9a-fA-F]\+)/mstore(Q_O_X_LOC, $Q_O_X)/" "$OPT_FILE"
+sed -i "s/mstore(Q_O_Y_LOC, 0x[0-9a-fA-F]\+)/mstore(Q_O_Y_LOC, $Q_O_Y)/" "$OPT_FILE"
+sed -i "s/mstore(Q_4_X_LOC, 0x[0-9a-fA-F]\+)/mstore(Q_4_X_LOC, $Q_4_X)/" "$OPT_FILE"
+sed -i "s/mstore(Q_4_Y_LOC, 0x[0-9a-fA-F]\+)/mstore(Q_4_Y_LOC, $Q_4_Y)/" "$OPT_FILE"
+sed -i "s/mstore(Q_M_X_LOC, 0x[0-9a-fA-F]\+)/mstore(Q_M_X_LOC, $Q_M_X)/" "$OPT_FILE"
+sed -i "s/mstore(Q_M_Y_LOC, 0x[0-9a-fA-F]\+)/mstore(Q_M_Y_LOC, $Q_M_Y)/" "$OPT_FILE"
+sed -i "s/mstore(Q_C_X_LOC, 0x[0-9a-fA-F]\+)/mstore(Q_C_X_LOC, $Q_C_X)/" "$OPT_FILE"
+sed -i "s/mstore(Q_C_Y_LOC, 0x[0-9a-fA-F]\+)/mstore(Q_C_Y_LOC, $Q_C_Y)/" "$OPT_FILE"
+sed -i "s/mstore(Q_LOOKUP_X_LOC, 0x[0-9a-fA-F]\+)/mstore(Q_LOOKUP_X_LOC, $Q_LOOKUP_X)/" "$OPT_FILE"
+sed -i "s/mstore(Q_LOOKUP_Y_LOC, 0x[0-9a-fA-F]\+)/mstore(Q_LOOKUP_Y_LOC, $Q_LOOKUP_Y)/" "$OPT_FILE"
+sed -i "s/mstore(Q_ARITH_X_LOC, 0x[0-9a-fA-F]\+)/mstore(Q_ARITH_X_LOC, $Q_ARITH_X)/" "$OPT_FILE"
+sed -i "s/mstore(Q_ARITH_Y_LOC, 0x[0-9a-fA-F]\+)/mstore(Q_ARITH_Y_LOC, $Q_ARITH_Y)/" "$OPT_FILE"
+sed -i "s/mstore(Q_DELTA_RANGE_X_LOC, 0x[0-9a-fA-F]\+)/mstore(Q_DELTA_RANGE_X_LOC, $Q_DELTA_RANGE_X)/" "$OPT_FILE"
+sed -i "s/mstore(Q_DELTA_RANGE_Y_LOC, 0x[0-9a-fA-F]\+)/mstore(Q_DELTA_RANGE_Y_LOC, $Q_DELTA_RANGE_Y)/" "$OPT_FILE"
+sed -i "s/mstore(Q_ELLIPTIC_X_LOC, 0x[0-9a-fA-F]\+)/mstore(Q_ELLIPTIC_X_LOC, $Q_ELLIPTIC_X)/" "$OPT_FILE"
+sed -i "s/mstore(Q_ELLIPTIC_Y_LOC, 0x[0-9a-fA-F]\+)/mstore(Q_ELLIPTIC_Y_LOC, $Q_ELLIPTIC_Y)/" "$OPT_FILE"
+sed -i "s/mstore(Q_MEMORY_X_LOC, 0x[0-9a-fA-F]\+)/mstore(Q_MEMORY_X_LOC, $Q_MEMORY_X)/" "$OPT_FILE"
+sed -i "s/mstore(Q_MEMORY_Y_LOC, 0x[0-9a-fA-F]\+)/mstore(Q_MEMORY_Y_LOC, $Q_MEMORY_Y)/" "$OPT_FILE"
+sed -i "s/mstore(Q_NNF_X_LOC, 0x[0-9a-fA-F]\+)/mstore(Q_NNF_X_LOC, $Q_NNF_X)/" "$OPT_FILE"
+sed -i "s/mstore(Q_NNF_Y_LOC, 0x[0-9a-fA-F]\+)/mstore(Q_NNF_Y_LOC, $Q_NNF_Y)/" "$OPT_FILE"
+sed -i "s/mstore(Q_POSEIDON_2_EXTERNAL_X_LOC, 0x[0-9a-fA-F]\+)/mstore(Q_POSEIDON_2_EXTERNAL_X_LOC, $Q_POSEIDON_2_EXTERNAL_X)/" "$OPT_FILE"
+sed -i "s/mstore(Q_POSEIDON_2_EXTERNAL_Y_LOC, 0x[0-9a-fA-F]\+)/mstore(Q_POSEIDON_2_EXTERNAL_Y_LOC, $Q_POSEIDON_2_EXTERNAL_Y)/" "$OPT_FILE"
+sed -i "s/mstore(Q_POSEIDON_2_INTERNAL_X_LOC, 0x[0-9a-fA-F]\+)/mstore(Q_POSEIDON_2_INTERNAL_X_LOC, $Q_POSEIDON_2_INTERNAL_X)/" "$OPT_FILE"
+sed -i "s/mstore(Q_POSEIDON_2_INTERNAL_Y_LOC, 0x[0-9a-fA-F]\+)/mstore(Q_POSEIDON_2_INTERNAL_Y_LOC, $Q_POSEIDON_2_INTERNAL_Y)/" "$OPT_FILE"
+
+# Update SIGMA (permutation) polynomial commitments
+sed -i "s/mstore(SIGMA_1_X_LOC, 0x[0-9a-fA-F]\+)/mstore(SIGMA_1_X_LOC, $SIGMA_1_X)/" "$OPT_FILE"
+sed -i "s/mstore(SIGMA_1_Y_LOC, 0x[0-9a-fA-F]\+)/mstore(SIGMA_1_Y_LOC, $SIGMA_1_Y)/" "$OPT_FILE"
+sed -i "s/mstore(SIGMA_2_X_LOC, 0x[0-9a-fA-F]\+)/mstore(SIGMA_2_X_LOC, $SIGMA_2_X)/" "$OPT_FILE"
+sed -i "s/mstore(SIGMA_2_Y_LOC, 0x[0-9a-fA-F]\+)/mstore(SIGMA_2_Y_LOC, $SIGMA_2_Y)/" "$OPT_FILE"
+sed -i "s/mstore(SIGMA_3_X_LOC, 0x[0-9a-fA-F]\+)/mstore(SIGMA_3_X_LOC, $SIGMA_3_X)/" "$OPT_FILE"
+sed -i "s/mstore(SIGMA_3_Y_LOC, 0x[0-9a-fA-F]\+)/mstore(SIGMA_3_Y_LOC, $SIGMA_3_Y)/" "$OPT_FILE"
+sed -i "s/mstore(SIGMA_4_X_LOC, 0x[0-9a-fA-F]\+)/mstore(SIGMA_4_X_LOC, $SIGMA_4_X)/" "$OPT_FILE"
+sed -i "s/mstore(SIGMA_4_Y_LOC, 0x[0-9a-fA-F]\+)/mstore(SIGMA_4_Y_LOC, $SIGMA_4_Y)/" "$OPT_FILE"
+
+# Update TABLE polynomial commitments
+sed -i "s/mstore(TABLE_1_X_LOC, 0x[0-9a-fA-F]\+)/mstore(TABLE_1_X_LOC, $TABLE_1_X)/" "$OPT_FILE"
+sed -i "s/mstore(TABLE_1_Y_LOC, 0x[0-9a-fA-F]\+)/mstore(TABLE_1_Y_LOC, $TABLE_1_Y)/" "$OPT_FILE"
+sed -i "s/mstore(TABLE_2_X_LOC, 0x[0-9a-fA-F]\+)/mstore(TABLE_2_X_LOC, $TABLE_2_X)/" "$OPT_FILE"
+sed -i "s/mstore(TABLE_2_Y_LOC, 0x[0-9a-fA-F]\+)/mstore(TABLE_2_Y_LOC, $TABLE_2_Y)/" "$OPT_FILE"
+sed -i "s/mstore(TABLE_3_X_LOC, 0x[0-9a-fA-F]\+)/mstore(TABLE_3_X_LOC, $TABLE_3_X)/" "$OPT_FILE"
+sed -i "s/mstore(TABLE_3_Y_LOC, 0x[0-9a-fA-F]\+)/mstore(TABLE_3_Y_LOC, $TABLE_3_Y)/" "$OPT_FILE"
+sed -i "s/mstore(TABLE_4_X_LOC, 0x[0-9a-fA-F]\+)/mstore(TABLE_4_X_LOC, $TABLE_4_X)/" "$OPT_FILE"
+sed -i "s/mstore(TABLE_4_Y_LOC, 0x[0-9a-fA-F]\+)/mstore(TABLE_4_Y_LOC, $TABLE_4_Y)/" "$OPT_FILE"
+
+# Update ID polynomial commitments
+sed -i "s/mstore(ID_1_X_LOC, 0x[0-9a-fA-F]\+)/mstore(ID_1_X_LOC, $ID_1_X)/" "$OPT_FILE"
+sed -i "s/mstore(ID_1_Y_LOC, 0x[0-9a-fA-F]\+)/mstore(ID_1_Y_LOC, $ID_1_Y)/" "$OPT_FILE"
+sed -i "s/mstore(ID_2_X_LOC, 0x[0-9a-fA-F]\+)/mstore(ID_2_X_LOC, $ID_2_X)/" "$OPT_FILE"
+sed -i "s/mstore(ID_2_Y_LOC, 0x[0-9a-fA-F]\+)/mstore(ID_2_Y_LOC, $ID_2_Y)/" "$OPT_FILE"
+sed -i "s/mstore(ID_3_X_LOC, 0x[0-9a-fA-F]\+)/mstore(ID_3_X_LOC, $ID_3_X)/" "$OPT_FILE"
+sed -i "s/mstore(ID_3_Y_LOC, 0x[0-9a-fA-F]\+)/mstore(ID_3_Y_LOC, $ID_3_Y)/" "$OPT_FILE"
+sed -i "s/mstore(ID_4_X_LOC, 0x[0-9a-fA-F]\+)/mstore(ID_4_X_LOC, $ID_4_X)/" "$OPT_FILE"
+sed -i "s/mstore(ID_4_Y_LOC, 0x[0-9a-fA-F]\+)/mstore(ID_4_Y_LOC, $ID_4_Y)/" "$OPT_FILE"
+
+# Update Lagrange polynomial commitments
+sed -i "s/mstore(LAGRANGE_FIRST_X_LOC, 0x[0-9a-fA-F]\+)/mstore(LAGRANGE_FIRST_X_LOC, $LAGRANGE_FIRST_X)/" "$OPT_FILE"
+sed -i "s/mstore(LAGRANGE_FIRST_Y_LOC, 0x[0-9a-fA-F]\+)/mstore(LAGRANGE_FIRST_Y_LOC, $LAGRANGE_FIRST_Y)/" "$OPT_FILE"
+sed -i "s/mstore(LAGRANGE_LAST_X_LOC, 0x[0-9a-fA-F]\+)/mstore(LAGRANGE_LAST_X_LOC, $LAGRANGE_LAST_X)/" "$OPT_FILE"
+sed -i "s/mstore(LAGRANGE_LAST_Y_LOC, 0x[0-9a-fA-F]\+)/mstore(LAGRANGE_LAST_Y_LOC, $LAGRANGE_LAST_Y)/" "$OPT_FILE"
+
+echo "✓ Successfully synced all VK values to blake-opt.sol"
+echo "  Updated: VK_HASH, circuit params, and all selector commitments"
+echo "  Backup saved at ${OPT_FILE}.bak"

--- a/barretenberg/sol/src/honk/BaseZKHonkVerifier.sol
+++ b/barretenberg/sol/src/honk/BaseZKHonkVerifier.sol
@@ -546,9 +546,8 @@ abstract contract BaseZKHonkVerifier is IVerifier {
 
         mem.diff = mem.lagrangeFirst * libraPolyEvals[2];
 
-        mem.diff = mem.diff
-            + (geminiR - SUBGROUP_GENERATOR_INVERSE)
-                * (libraPolyEvals[1] - libraPolyEvals[2] - libraPolyEvals[0] * mem.challengePolyEval);
+        mem.diff = mem.diff + (geminiR - SUBGROUP_GENERATOR_INVERSE)
+            * (libraPolyEvals[1] - libraPolyEvals[2] - libraPolyEvals[0] * mem.challengePolyEval);
         mem.diff = mem.diff + mem.lagrangeLast * (libraPolyEvals[2] - libraEval) - vanishingPolyEval * libraPolyEvals[3];
 
         check = mem.diff == Fr.wrap(0);

--- a/barretenberg/sol/src/honk/CommitmentScheme.sol
+++ b/barretenberg/sol/src/honk/CommitmentScheme.sol
@@ -68,10 +68,8 @@ library CommitmentSchemeLib {
             Fr challengePower = geminiEvalChallengePowers[i - 1];
             Fr u = sumcheckUChallenges[i - 1];
 
-            Fr batchedEvalRoundAcc = (
-                (challengePower * batchedEvalAccumulator * Fr.wrap(2))
-                    - geminiEvaluations[i - 1] * (challengePower * (ONE - u) - u)
-            );
+            Fr batchedEvalRoundAcc = ((challengePower * batchedEvalAccumulator * Fr.wrap(2)) - geminiEvaluations[i - 1]
+                    * (challengePower * (ONE - u) - u));
             // Divide by the denominator
             batchedEvalRoundAcc = batchedEvalRoundAcc * (challengePower * (ONE - u) + u).invert();
 

--- a/barretenberg/sol/src/honk/Relations.sol
+++ b/barretenberg/sol/src/honk/Relations.sol
@@ -117,10 +117,8 @@ library RelationsLib {
             Fr acc = (wire(p, WIRE.Z_PERM) + wire(p, WIRE.LAGRANGE_FIRST)) * grand_product_numerator;
 
             acc = acc
-                - (
-                    (wire(p, WIRE.Z_PERM_SHIFT) + (wire(p, WIRE.LAGRANGE_LAST) * rp.publicInputsDelta))
-                        * grand_product_denominator
-                );
+                - ((wire(p, WIRE.Z_PERM_SHIFT) + (wire(p, WIRE.LAGRANGE_LAST) * rp.publicInputsDelta))
+                    * grand_product_denominator);
             acc = acc * domainSep;
             evals[2] = acc;
         }
@@ -160,7 +158,8 @@ library RelationsLib {
         Fr read_inverse = wire(p, WIRE.LOOKUP_INVERSES) * write_term;
         Fr write_inverse = wire(p, WIRE.LOOKUP_INVERSES) * read_term;
 
-        Fr inverse_exists_xor = wire(p, WIRE.LOOKUP_READ_TAGS) + wire(p, WIRE.Q_LOOKUP)
+        Fr inverse_exists_xor =
+        wire(p, WIRE.LOOKUP_READ_TAGS) + wire(p, WIRE.Q_LOOKUP)
             - (wire(p, WIRE.LOOKUP_READ_TAGS) * wire(p, WIRE.Q_LOOKUP));
 
         // Inverse calculated correctly relation
@@ -560,7 +559,7 @@ library RelationsLib {
         ap.non_native_field_gate_3 = ap.non_native_field_gate_3 * wire(p, WIRE.Q_M);
 
         Fr non_native_field_identity =
-            ap.non_native_field_gate_1 + ap.non_native_field_gate_2 + ap.non_native_field_gate_3;
+        ap.non_native_field_gate_1 + ap.non_native_field_gate_2 + ap.non_native_field_gate_3;
         non_native_field_identity = non_native_field_identity * wire(p, WIRE.Q_R);
 
         // ((((w2' * 2^14 + w1') * 2^14 + w3) * 2^14 + w2) * 2^14 + w1 - w4) * qm

--- a/barretenberg/sol/src/honk/optimised/blake-opt.sol
+++ b/barretenberg/sol/src/honk/optimised/blake-opt.sol
@@ -11,7 +11,7 @@ uint256 constant NUMBER_UNSHIFTED = 36;
 uint256 constant NUMBER_TO_BE_SHIFTED = 5;
 uint256 constant PAIRING_POINTS_SIZE = 16;
 
-uint256 constant VK_HASH = 0x23470b638ec3a004e3bb8a747e81abd8fdb31481b03622275a57470672d2d66a;
+uint256 constant VK_HASH = 0x2f024871d6c9792abfdaf9d701f4dfb8302924c2ab255e0bb05264fc56267c61;
 uint256 constant CIRCUIT_SIZE = 32768;
 uint256 constant LOG_N = 15;
 uint256 constant NUMBER_PUBLIC_INPUTS = 20;
@@ -1020,7 +1020,11 @@ contract BlakeOptHonkVerifier is IVerifier {
 
     constructor() {}
 
-    function verify(bytes calldata, /*proof*/ bytes32[] calldata /*public_inputs*/ )
+    function verify(
+        bytes calldata,
+        /*proof*/
+        bytes32[] calldata /*public_inputs*/
+    )
         public
         view
         override
@@ -1075,8 +1079,8 @@ contract BlakeOptHonkVerifier is IVerifier {
                 mstore(TABLE_1_Y_LOC, 0x17d3b0c8f579f153a87a831b7e4f4d5af79cb1cbee232a3590ea68445d8e8885)
                 mstore(TABLE_2_X_LOC, 0x288bca978add237e513115827263877d2879d70853ae1dc3bccc228f9297fdec)
                 mstore(TABLE_2_Y_LOC, 0x2091a8aa28ad5de84ea48d048d3472599a4a25b4001c9dc6488651ced23c4a8b)
-                mstore(TABLE_3_X_LOC, 0x03296b9b3e48783c61e8240b1c32d437dcb792296373cea232ce285e6f8f136f)
-                mstore(TABLE_3_Y_LOC, 0x1e2f73b3e35501c7dbf65fb885aa1e1e97a87d66a5a7a7b77e0a43e67ddbdcba)
+                mstore(TABLE_3_X_LOC, 0x1ca90fbf226a8241f127b4456105dbf74cd9dcd196b550033d50ae98808c5b27)
+                mstore(TABLE_3_Y_LOC, 0x077ced98ba89ffb9e959eafe7cf3ec685d3fda8833c346ad73702504e2159b8b)
                 mstore(TABLE_4_X_LOC, 0x2987794caaa7e3277da9e0fa04644cff19433f7e62178e98a18badf4ece924c4)
                 mstore(TABLE_4_Y_LOC, 0x0f2ebe1caa931ad968c79d2ad8713df60eae316d0b5f0dc0603e65adb8d79d5b)
                 mstore(ID_1_X_LOC, 0x26cca178117c77a332dd03c35b7504d40e164f95b2e1c83e66f1105c717b74a8)
@@ -1830,7 +1834,9 @@ contract BlakeOptHonkVerifier is IVerifier {
                             addmod(
                                 mload(QM_EVAL_LOC),
                                 addmod(
-                                    sub(p, mload(W1_SHIFT_EVAL_LOC)), addmod(mload(W1_EVAL_LOC), mload(W4_EVAL_LOC), p), p
+                                    sub(p, mload(W1_SHIFT_EVAL_LOC)),
+                                    addmod(mload(W1_EVAL_LOC), mload(W4_EVAL_LOC), p),
+                                    p
                                 ),
                                 p
                             ),
@@ -1877,55 +1883,51 @@ contract BlakeOptHonkVerifier is IVerifier {
                             p
                         )
                     let numerator := mulmod(t1, t2, p)
-                    t1 :=
-                        mulmod(
-                            add(add(mload(W1_EVAL_LOC), gamma), mulmod(beta, mload(SIGMA1_EVAL_LOC), p)),
-                            add(add(mload(W2_EVAL_LOC), gamma), mulmod(beta, mload(SIGMA2_EVAL_LOC), p)),
-                            p
-                        )
-                    t2 :=
-                        mulmod(
-                            add(add(mload(W3_EVAL_LOC), gamma), mulmod(beta, mload(SIGMA3_EVAL_LOC), p)),
-                            add(add(mload(W4_EVAL_LOC), gamma), mulmod(beta, mload(SIGMA4_EVAL_LOC), p)),
-                            p
-                        )
+                    t1 := mulmod(
+                        add(add(mload(W1_EVAL_LOC), gamma), mulmod(beta, mload(SIGMA1_EVAL_LOC), p)),
+                        add(add(mload(W2_EVAL_LOC), gamma), mulmod(beta, mload(SIGMA2_EVAL_LOC), p)),
+                        p
+                    )
+                    t2 := mulmod(
+                        add(add(mload(W3_EVAL_LOC), gamma), mulmod(beta, mload(SIGMA3_EVAL_LOC), p)),
+                        add(add(mload(W4_EVAL_LOC), gamma), mulmod(beta, mload(SIGMA4_EVAL_LOC), p)),
+                        p
+                    )
                     let denominator := mulmod(t1, t2, p)
 
                     {
                         let acc :=
                             mulmod(addmod(mload(Z_PERM_EVAL_LOC), mload(LAGRANGE_FIRST_EVAL_LOC), p), numerator, p)
 
-                        acc :=
-                            addmod(
-                                acc,
-                                sub(
-                                    p,
-                                    mulmod(
-                                        addmod(
-                                            mload(Z_PERM_SHIFT_EVAL_LOC),
-                                            mulmod(
-                                                mload(LAGRANGE_LAST_EVAL_LOC),
-                                                mload(PUBLIC_INPUTS_DELTA_NUMERATOR_CHALLENGE),
-                                                p
-                                            ),
+                        acc := addmod(
+                            acc,
+                            sub(
+                                p,
+                                mulmod(
+                                    addmod(
+                                        mload(Z_PERM_SHIFT_EVAL_LOC),
+                                        mulmod(
+                                            mload(LAGRANGE_LAST_EVAL_LOC),
+                                            mload(PUBLIC_INPUTS_DELTA_NUMERATOR_CHALLENGE),
                                             p
                                         ),
-                                        denominator,
                                         p
-                                    )
-                                ),
-                                p
-                            )
+                                    ),
+                                    denominator,
+                                    p
+                                )
+                            ),
+                            p
+                        )
 
                         acc := mulmod(acc, mload(POW_PARTIAL_EVALUATION_LOC), p)
                         mstore(SUBRELATION_EVAL_2_LOC, acc)
 
-                        acc :=
-                            mulmod(
-                                mulmod(mload(LAGRANGE_LAST_EVAL_LOC), mload(Z_PERM_SHIFT_EVAL_LOC), p),
-                                mload(POW_PARTIAL_EVALUATION_LOC),
-                                p
-                            )
+                        acc := mulmod(
+                            mulmod(mload(LAGRANGE_LAST_EVAL_LOC), mload(Z_PERM_SHIFT_EVAL_LOC), p),
+                            mload(POW_PARTIAL_EVALUATION_LOC),
+                            p
+                        )
                         mstore(SUBRELATION_EVAL_3_LOC, acc)
                     }
                 }
@@ -1944,13 +1946,18 @@ contract BlakeOptHonkVerifier is IVerifier {
                     let t0 :=
                         addmod(addmod(mload(TABLE1_EVAL_LOC), gamma, p), mulmod(mload(TABLE2_EVAL_LOC), eta, p), p)
                     let t1 :=
-                        addmod(mulmod(mload(TABLE3_EVAL_LOC), eta_two, p), mulmod(mload(TABLE4_EVAL_LOC), eta_three, p), p)
+                        addmod(
+                            mulmod(mload(TABLE3_EVAL_LOC), eta_two, p),
+                            mulmod(mload(TABLE4_EVAL_LOC), eta_three, p),
+                            p
+                        )
                     let write_term := addmod(t0, t1, p)
 
-                    t0 :=
-                        addmod(
-                            addmod(mload(W1_EVAL_LOC), gamma, p), mulmod(mload(QR_EVAL_LOC), mload(W1_SHIFT_EVAL_LOC), p), p
-                        )
+                    t0 := addmod(
+                        addmod(mload(W1_EVAL_LOC), gamma, p),
+                        mulmod(mload(QR_EVAL_LOC), mload(W1_SHIFT_EVAL_LOC), p),
+                        p
+                    )
                     t1 := addmod(mload(W2_EVAL_LOC), mulmod(mload(QM_EVAL_LOC), mload(W2_SHIFT_EVAL_LOC), p), p)
                     let t2 := addmod(mload(W3_EVAL_LOC), mulmod(mload(QC_EVAL_LOC), mload(W3_SHIFT_EVAL_LOC), p), p)
 
@@ -1962,20 +1969,22 @@ contract BlakeOptHonkVerifier is IVerifier {
                     let write_inverse := mulmod(mload(LOOKUP_INVERSES_EVAL_LOC), read_term, p)
 
                     let inverse_exists_xor := addmod(mload(LOOKUP_READ_TAGS_EVAL_LOC), mload(QLOOKUP_EVAL_LOC), p)
-                    inverse_exists_xor :=
-                        addmod(
-                            inverse_exists_xor,
-                            sub(p, mulmod(mload(LOOKUP_READ_TAGS_EVAL_LOC), mload(QLOOKUP_EVAL_LOC), p)),
-                            p
-                        )
+                    inverse_exists_xor := addmod(
+                        inverse_exists_xor,
+                        sub(p, mulmod(mload(LOOKUP_READ_TAGS_EVAL_LOC), mload(QLOOKUP_EVAL_LOC), p)),
+                        p
+                    )
 
                     let accumulator_none := mulmod(mulmod(read_term, write_term, p), mload(LOOKUP_INVERSES_EVAL_LOC), p)
                     accumulator_none := addmod(accumulator_none, sub(p, inverse_exists_xor), p)
                     accumulator_none := mulmod(accumulator_none, mload(POW_PARTIAL_EVALUATION_LOC), p)
 
                     let accumulator_one := mulmod(mload(QLOOKUP_EVAL_LOC), read_inverse, p)
-                    accumulator_one :=
-                        addmod(accumulator_one, sub(p, mulmod(mload(LOOKUP_READ_COUNTS_EVAL_LOC), write_inverse, p)), p)
+                    accumulator_one := addmod(
+                        accumulator_one,
+                        sub(p, mulmod(mload(LOOKUP_READ_COUNTS_EVAL_LOC), write_inverse, p)),
+                        p
+                    )
 
                     let read_tag := mload(LOOKUP_READ_TAGS_EVAL_LOC)
                     let read_tag_boolean_relation := mulmod(read_tag, addmod(read_tag, P_SUB_1, p), p)
@@ -2070,8 +2079,11 @@ contract BlakeOptHonkVerifier is IVerifier {
                         let y_diff := mulmod(mload(EC_Y_2), mload(EC_Q_SIGN), p)
                         y_diff := addmod(y_diff, sub(p, mload(EC_Y_1)), p)
                         let y_add_identity := mulmod(y1_plus_y3, x_diff, p)
-                        y_add_identity :=
-                            addmod(y_add_identity, mulmod(addmod(mload(EC_X_3), sub(p, mload(EC_X_1)), p), y_diff, p), p)
+                        y_add_identity := addmod(
+                            y_add_identity,
+                            mulmod(addmod(mload(EC_X_3), sub(p, mload(EC_X_1)), p), y_diff, p),
+                            p
+                        )
 
                         let eval := mulmod(y_add_identity, mload(POW_PARTIAL_EVALUATION_LOC), p)
                         eval := mulmod(eval, mload(QELLIPTIC_EVAL_LOC), p)
@@ -2103,17 +2115,18 @@ contract BlakeOptHonkVerifier is IVerifier {
                             mulmod(addmod(addmod(mload(EC_X_1), mload(EC_X_1), p), mload(EC_X_1), p), mload(EC_X_1), p)
                         let y_double_identity :=
                             mulmod(x1_sqr_mul_3, addmod(mload(EC_X_1), sub(p, mload(EC_X_3)), p), p)
-                        y_double_identity :=
-                            addmod(
-                                y_double_identity,
-                                sub(
-                                    p,
-                                    mulmod(
-                                        addmod(mload(EC_Y_1), mload(EC_Y_1), p), addmod(mload(EC_Y_1), mload(EC_Y_3), p), p
-                                    )
-                                ),
-                                p
-                            )
+                        y_double_identity := addmod(
+                            y_double_identity,
+                            sub(
+                                p,
+                                mulmod(
+                                    addmod(mload(EC_Y_1), mload(EC_Y_1), p),
+                                    addmod(mload(EC_Y_1), mload(EC_Y_3), p),
+                                    p
+                                )
+                            ),
+                            p
+                        )
 
                         let acc := mulmod(y_double_identity, mload(POW_PARTIAL_EVALUATION_LOC), p)
                         acc := mulmod(mulmod(acc, mload(QELLIPTIC_EVAL_LOC), p), mload(EC_Q_IS_DOUBLE), p)
@@ -2182,10 +2195,16 @@ contract BlakeOptHonkVerifier is IVerifier {
                          */
                         // TODO(md): update these - formula has changed with lower degree
                         let memory_record_check := mulmod(mload(W3_EVAL_LOC), mload(ETA_THREE_CHALLENGE), p)
-                        memory_record_check :=
-                            addmod(memory_record_check, mulmod(mload(W2_EVAL_LOC), mload(ETA_TWO_CHALLENGE), p), p)
-                        memory_record_check :=
-                            addmod(memory_record_check, mulmod(mload(W1_EVAL_LOC), mload(ETA_CHALLENGE), p), p)
+                        memory_record_check := addmod(
+                            memory_record_check,
+                            mulmod(mload(W2_EVAL_LOC), mload(ETA_TWO_CHALLENGE), p),
+                            p
+                        )
+                        memory_record_check := addmod(
+                            memory_record_check,
+                            mulmod(mload(W1_EVAL_LOC), mload(ETA_CHALLENGE), p),
+                            p
+                        )
                         memory_record_check := addmod(memory_record_check, mload(QC_EVAL_LOC), p)
 
                         let partial_record_check := memory_record_check
@@ -2289,12 +2308,16 @@ contract BlakeOptHonkVerifier is IVerifier {
                              * next_gate_access_type = w_4_omega - next_gate_access_type;
                              */
                             let next_gate_access_type := mulmod(mload(W3_SHIFT_EVAL_LOC), mload(ETA_THREE_CHALLENGE), p)
-                            next_gate_access_type :=
-                                addmod(
-                                    next_gate_access_type, mulmod(mload(W2_SHIFT_EVAL_LOC), mload(ETA_TWO_CHALLENGE), p), p
-                                )
-                            next_gate_access_type :=
-                                addmod(next_gate_access_type, mulmod(mload(W1_SHIFT_EVAL_LOC), mload(ETA_CHALLENGE), p), p)
+                            next_gate_access_type := addmod(
+                                next_gate_access_type,
+                                mulmod(mload(W2_SHIFT_EVAL_LOC), mload(ETA_TWO_CHALLENGE), p),
+                                p
+                            )
+                            next_gate_access_type := addmod(
+                                next_gate_access_type,
+                                mulmod(mload(W1_SHIFT_EVAL_LOC), mload(ETA_CHALLENGE), p),
+                                p
+                            )
                             next_gate_access_type := addmod(mload(W4_SHIFT_EVAL_LOC), sub(p, next_gate_access_type), p)
 
                             // value_delta = w_3_omega - w_3
@@ -2377,33 +2400,32 @@ contract BlakeOptHonkVerifier is IVerifier {
                              * auxiliary_identity *= alpha_base;
                              */
                             let memory_identity := mload(AUX_ROM_CONSISTENCY_CHECK_IDENTITY)
-                            memory_identity :=
-                                addmod(
-                                    memory_identity,
-                                    mulmod(
-                                        RAM_TIMESTAMP_CHECK_IDENTITY, mulmod(mload(Q4_EVAL_LOC), mload(QL_EVAL_LOC), p), p
-                                    ),
+                            memory_identity := addmod(
+                                memory_identity,
+                                mulmod(
+                                    RAM_TIMESTAMP_CHECK_IDENTITY,
+                                    mulmod(mload(Q4_EVAL_LOC), mload(QL_EVAL_LOC), p),
                                     p
-                                )
+                                ),
+                                p
+                            )
 
-                            memory_identity :=
-                                addmod(
-                                    memory_identity,
-                                    mulmod(
-                                        mload(AUX_MEMORY_CHECK_IDENTITY),
-                                        mulmod(mload(QM_EVAL_LOC), mload(QL_EVAL_LOC), p),
-                                        p
-                                    ),
+                            memory_identity := addmod(
+                                memory_identity,
+                                mulmod(
+                                    mload(AUX_MEMORY_CHECK_IDENTITY),
+                                    mulmod(mload(QM_EVAL_LOC), mload(QL_EVAL_LOC), p),
                                     p
-                                )
+                                ),
+                                p
+                            )
                             memory_identity := addmod(memory_identity, mload(AUX_RAM_CONSISTENCY_CHECK_IDENTITY), p)
 
-                            memory_identity :=
-                                mulmod(
-                                    memory_identity,
-                                    mulmod(mload(QMEMORY_EVAL_LOC), mload(POW_PARTIAL_EVALUATION_LOC), p),
-                                    p
-                                )
+                            memory_identity := mulmod(
+                                memory_identity,
+                                mulmod(mload(QMEMORY_EVAL_LOC), mload(POW_PARTIAL_EVALUATION_LOC), p),
+                                p
+                            )
                             mstore(SUBRELATION_EVAL_13_LOC, memory_identity)
                         }
                     }
@@ -2455,8 +2477,11 @@ contract BlakeOptHonkVerifier is IVerifier {
                     non_native_field_gate_2 := mulmod(non_native_field_gate_2, mload(Q4_EVAL_LOC), p)
 
                     limb_subproduct := mulmod(limb_subproduct, LIMB_SIZE, p)
-                    limb_subproduct :=
-                        addmod(limb_subproduct, mulmod(mload(W1_SHIFT_EVAL_LOC), mload(W2_SHIFT_EVAL_LOC), p), p)
+                    limb_subproduct := addmod(
+                        limb_subproduct,
+                        mulmod(mload(W1_SHIFT_EVAL_LOC), mload(W2_SHIFT_EVAL_LOC), p),
+                        p
+                    )
 
                     let non_native_field_gate_1 :=
                         mulmod(
@@ -2477,7 +2502,11 @@ contract BlakeOptHonkVerifier is IVerifier {
                         )
                     let non_native_field_identity :=
                         mulmod(
-                            addmod(addmod(non_native_field_gate_1, non_native_field_gate_2, p), non_native_field_gate_3, p),
+                            addmod(
+                                addmod(non_native_field_gate_1, non_native_field_gate_2, p),
+                                non_native_field_gate_3,
+                                p
+                            ),
                             mload(QR_EVAL_LOC),
                             p
                         )
@@ -2538,8 +2567,11 @@ contract BlakeOptHonkVerifier is IVerifier {
                     limb_accumulator_identity := mulmod(limb_accumulator_identity, mload(QO_EVAL_LOC), p)
 
                     let nnf_identity := addmod(mload(AUX_NON_NATIVE_FIELD_IDENTITY), limb_accumulator_identity, p)
-                    nnf_identity :=
-                        mulmod(nnf_identity, mulmod(mload(QNNF_EVAL_LOC), mload(POW_PARTIAL_EVALUATION_LOC), p), p)
+                    nnf_identity := mulmod(
+                        nnf_identity,
+                        mulmod(mload(QNNF_EVAL_LOC), mload(POW_PARTIAL_EVALUATION_LOC), p),
+                        p
+                    )
 
                     mstore(SUBRELATION_EVAL_19_LOC, nnf_identity)
                 }
@@ -2669,60 +2701,141 @@ contract BlakeOptHonkVerifier is IVerifier {
                 //     accumulator = accumulator + evaluations[i] * subrelationChallenges[i - 1];
                 // }
 
-                accumulator :=
-                    addmod(accumulator, mulmod(mload(SUBRELATION_EVAL_1_LOC), mload(ALPHA_CHALLENGE_0), p), p)
-                accumulator :=
-                    addmod(accumulator, mulmod(mload(SUBRELATION_EVAL_2_LOC), mload(ALPHA_CHALLENGE_1), p), p)
-                accumulator :=
-                    addmod(accumulator, mulmod(mload(SUBRELATION_EVAL_3_LOC), mload(ALPHA_CHALLENGE_2), p), p)
-                accumulator :=
-                    addmod(accumulator, mulmod(mload(SUBRELATION_EVAL_4_LOC), mload(ALPHA_CHALLENGE_3), p), p)
-                accumulator :=
-                    addmod(accumulator, mulmod(mload(SUBRELATION_EVAL_5_LOC), mload(ALPHA_CHALLENGE_4), p), p)
-                accumulator :=
-                    addmod(accumulator, mulmod(mload(SUBRELATION_EVAL_6_LOC), mload(ALPHA_CHALLENGE_5), p), p)
-                accumulator :=
-                    addmod(accumulator, mulmod(mload(SUBRELATION_EVAL_7_LOC), mload(ALPHA_CHALLENGE_6), p), p)
-                accumulator :=
-                    addmod(accumulator, mulmod(mload(SUBRELATION_EVAL_8_LOC), mload(ALPHA_CHALLENGE_7), p), p)
-                accumulator :=
-                    addmod(accumulator, mulmod(mload(SUBRELATION_EVAL_9_LOC), mload(ALPHA_CHALLENGE_8), p), p)
-                accumulator :=
-                    addmod(accumulator, mulmod(mload(SUBRELATION_EVAL_10_LOC), mload(ALPHA_CHALLENGE_9), p), p)
-                accumulator :=
-                    addmod(accumulator, mulmod(mload(SUBRELATION_EVAL_11_LOC), mload(ALPHA_CHALLENGE_10), p), p)
-                accumulator :=
-                    addmod(accumulator, mulmod(mload(SUBRELATION_EVAL_12_LOC), mload(ALPHA_CHALLENGE_11), p), p)
-                accumulator :=
-                    addmod(accumulator, mulmod(mload(SUBRELATION_EVAL_13_LOC), mload(ALPHA_CHALLENGE_12), p), p)
-                accumulator :=
-                    addmod(accumulator, mulmod(mload(SUBRELATION_EVAL_14_LOC), mload(ALPHA_CHALLENGE_13), p), p)
-                accumulator :=
-                    addmod(accumulator, mulmod(mload(SUBRELATION_EVAL_15_LOC), mload(ALPHA_CHALLENGE_14), p), p)
-                accumulator :=
-                    addmod(accumulator, mulmod(mload(SUBRELATION_EVAL_16_LOC), mload(ALPHA_CHALLENGE_15), p), p)
-                accumulator :=
-                    addmod(accumulator, mulmod(mload(SUBRELATION_EVAL_17_LOC), mload(ALPHA_CHALLENGE_16), p), p)
-                accumulator :=
-                    addmod(accumulator, mulmod(mload(SUBRELATION_EVAL_18_LOC), mload(ALPHA_CHALLENGE_17), p), p)
-                accumulator :=
-                    addmod(accumulator, mulmod(mload(SUBRELATION_EVAL_19_LOC), mload(ALPHA_CHALLENGE_18), p), p)
-                accumulator :=
-                    addmod(accumulator, mulmod(mload(SUBRELATION_EVAL_20_LOC), mload(ALPHA_CHALLENGE_19), p), p)
-                accumulator :=
-                    addmod(accumulator, mulmod(mload(SUBRELATION_EVAL_21_LOC), mload(ALPHA_CHALLENGE_20), p), p)
-                accumulator :=
-                    addmod(accumulator, mulmod(mload(SUBRELATION_EVAL_22_LOC), mload(ALPHA_CHALLENGE_21), p), p)
-                accumulator :=
-                    addmod(accumulator, mulmod(mload(SUBRELATION_EVAL_23_LOC), mload(ALPHA_CHALLENGE_22), p), p)
-                accumulator :=
-                    addmod(accumulator, mulmod(mload(SUBRELATION_EVAL_24_LOC), mload(ALPHA_CHALLENGE_23), p), p)
-                accumulator :=
-                    addmod(accumulator, mulmod(mload(SUBRELATION_EVAL_25_LOC), mload(ALPHA_CHALLENGE_24), p), p)
-                accumulator :=
-                    addmod(accumulator, mulmod(mload(SUBRELATION_EVAL_26_LOC), mload(ALPHA_CHALLENGE_25), p), p)
-                accumulator :=
-                    addmod(accumulator, mulmod(mload(SUBRELATION_EVAL_27_LOC), mload(ALPHA_CHALLENGE_26), p), p)
+                accumulator := addmod(
+                    accumulator,
+                    mulmod(mload(SUBRELATION_EVAL_1_LOC), mload(ALPHA_CHALLENGE_0), p),
+                    p
+                )
+                accumulator := addmod(
+                    accumulator,
+                    mulmod(mload(SUBRELATION_EVAL_2_LOC), mload(ALPHA_CHALLENGE_1), p),
+                    p
+                )
+                accumulator := addmod(
+                    accumulator,
+                    mulmod(mload(SUBRELATION_EVAL_3_LOC), mload(ALPHA_CHALLENGE_2), p),
+                    p
+                )
+                accumulator := addmod(
+                    accumulator,
+                    mulmod(mload(SUBRELATION_EVAL_4_LOC), mload(ALPHA_CHALLENGE_3), p),
+                    p
+                )
+                accumulator := addmod(
+                    accumulator,
+                    mulmod(mload(SUBRELATION_EVAL_5_LOC), mload(ALPHA_CHALLENGE_4), p),
+                    p
+                )
+                accumulator := addmod(
+                    accumulator,
+                    mulmod(mload(SUBRELATION_EVAL_6_LOC), mload(ALPHA_CHALLENGE_5), p),
+                    p
+                )
+                accumulator := addmod(
+                    accumulator,
+                    mulmod(mload(SUBRELATION_EVAL_7_LOC), mload(ALPHA_CHALLENGE_6), p),
+                    p
+                )
+                accumulator := addmod(
+                    accumulator,
+                    mulmod(mload(SUBRELATION_EVAL_8_LOC), mload(ALPHA_CHALLENGE_7), p),
+                    p
+                )
+                accumulator := addmod(
+                    accumulator,
+                    mulmod(mload(SUBRELATION_EVAL_9_LOC), mload(ALPHA_CHALLENGE_8), p),
+                    p
+                )
+                accumulator := addmod(
+                    accumulator,
+                    mulmod(mload(SUBRELATION_EVAL_10_LOC), mload(ALPHA_CHALLENGE_9), p),
+                    p
+                )
+                accumulator := addmod(
+                    accumulator,
+                    mulmod(mload(SUBRELATION_EVAL_11_LOC), mload(ALPHA_CHALLENGE_10), p),
+                    p
+                )
+                accumulator := addmod(
+                    accumulator,
+                    mulmod(mload(SUBRELATION_EVAL_12_LOC), mload(ALPHA_CHALLENGE_11), p),
+                    p
+                )
+                accumulator := addmod(
+                    accumulator,
+                    mulmod(mload(SUBRELATION_EVAL_13_LOC), mload(ALPHA_CHALLENGE_12), p),
+                    p
+                )
+                accumulator := addmod(
+                    accumulator,
+                    mulmod(mload(SUBRELATION_EVAL_14_LOC), mload(ALPHA_CHALLENGE_13), p),
+                    p
+                )
+                accumulator := addmod(
+                    accumulator,
+                    mulmod(mload(SUBRELATION_EVAL_15_LOC), mload(ALPHA_CHALLENGE_14), p),
+                    p
+                )
+                accumulator := addmod(
+                    accumulator,
+                    mulmod(mload(SUBRELATION_EVAL_16_LOC), mload(ALPHA_CHALLENGE_15), p),
+                    p
+                )
+                accumulator := addmod(
+                    accumulator,
+                    mulmod(mload(SUBRELATION_EVAL_17_LOC), mload(ALPHA_CHALLENGE_16), p),
+                    p
+                )
+                accumulator := addmod(
+                    accumulator,
+                    mulmod(mload(SUBRELATION_EVAL_18_LOC), mload(ALPHA_CHALLENGE_17), p),
+                    p
+                )
+                accumulator := addmod(
+                    accumulator,
+                    mulmod(mload(SUBRELATION_EVAL_19_LOC), mload(ALPHA_CHALLENGE_18), p),
+                    p
+                )
+                accumulator := addmod(
+                    accumulator,
+                    mulmod(mload(SUBRELATION_EVAL_20_LOC), mload(ALPHA_CHALLENGE_19), p),
+                    p
+                )
+                accumulator := addmod(
+                    accumulator,
+                    mulmod(mload(SUBRELATION_EVAL_21_LOC), mload(ALPHA_CHALLENGE_20), p),
+                    p
+                )
+                accumulator := addmod(
+                    accumulator,
+                    mulmod(mload(SUBRELATION_EVAL_22_LOC), mload(ALPHA_CHALLENGE_21), p),
+                    p
+                )
+                accumulator := addmod(
+                    accumulator,
+                    mulmod(mload(SUBRELATION_EVAL_23_LOC), mload(ALPHA_CHALLENGE_22), p),
+                    p
+                )
+                accumulator := addmod(
+                    accumulator,
+                    mulmod(mload(SUBRELATION_EVAL_24_LOC), mload(ALPHA_CHALLENGE_23), p),
+                    p
+                )
+                accumulator := addmod(
+                    accumulator,
+                    mulmod(mload(SUBRELATION_EVAL_25_LOC), mload(ALPHA_CHALLENGE_24), p),
+                    p
+                )
+                accumulator := addmod(
+                    accumulator,
+                    mulmod(mload(SUBRELATION_EVAL_26_LOC), mload(ALPHA_CHALLENGE_25), p),
+                    p
+                )
+                accumulator := addmod(
+                    accumulator,
+                    mulmod(mload(SUBRELATION_EVAL_27_LOC), mload(ALPHA_CHALLENGE_26), p),
+                    p
+                )
 
                 let sumcheck_valid := eq(accumulator, mload(FINAL_ROUND_TARGET_LOC))
 
@@ -2762,7 +2875,8 @@ contract BlakeOptHonkVerifier is IVerifier {
             )
 
             mstore(
-                POS_INVERTED_DENOM_0_LOC, addmod(eval_challenge, sub(p, mload(POWERS_OF_EVALUATION_CHALLENGE_0_LOC)), p)
+                POS_INVERTED_DENOM_0_LOC,
+                addmod(eval_challenge, sub(p, mload(POWERS_OF_EVALUATION_CHALLENGE_0_LOC)), p)
             )
             mstore(NEG_INVERTED_DENOM_0_LOC, addmod(eval_challenge, mload(POWERS_OF_EVALUATION_CHALLENGE_0_LOC), p))
 
@@ -3265,18 +3379,17 @@ contract BlakeOptHonkVerifier is IVerifier {
                 unshifted_scalar := addmod(pos_inverted_denominator, mulmod(shplonk_nu, neg_inverted_denominator, p), p)
 
                 // accumulator takes the value of `INVERTED_GEMINI_DENOMINATOR_0` here
-                shifted_scalar :=
-                    mulmod(
-                        accumulator, // (1 / gemini_r_challenge)
-                        // (inverse_vanishing_evals[0]) - (shplonk_nu * inverse_vanishing_evals[1])
-                        addmod(
-                            pos_inverted_denominator,
-                            // - (shplonk_nu * inverse_vanishing_evals[1])
-                            sub(p, mulmod(shplonk_nu, neg_inverted_denominator, p)),
-                            p
-                        ),
+                shifted_scalar := mulmod(
+                    accumulator, // (1 / gemini_r_challenge)
+                    // (inverse_vanishing_evals[0]) - (shplonk_nu * inverse_vanishing_evals[1])
+                    addmod(
+                        pos_inverted_denominator,
+                        // - (shplonk_nu * inverse_vanishing_evals[1])
+                        sub(p, mulmod(shplonk_nu, neg_inverted_denominator, p)),
                         p
-                    )
+                    ),
+                    p
+                )
             }
 
             // TODO: Write a comment that describes the process of accumulating commitments and scalars
@@ -3347,8 +3460,11 @@ contract BlakeOptHonkVerifier is IVerifier {
 
             // 9: QELLIPTIC_EVAL_LOC
             mstore(BATCH_SCALAR_10_LOC, mulmod(neg_unshifted_scalar, batching_challenge, p))
-            batched_evaluation :=
-                addmod(batched_evaluation, mulmod(mload(QELLIPTIC_EVAL_LOC), batching_challenge, p), p)
+            batched_evaluation := addmod(
+                batched_evaluation,
+                mulmod(mload(QELLIPTIC_EVAL_LOC), batching_challenge, p),
+                p
+            )
             batching_challenge := mulmod(batching_challenge, rho, p)
 
             // 10: QMEMORY_EVAL_LOC
@@ -3363,14 +3479,20 @@ contract BlakeOptHonkVerifier is IVerifier {
 
             // 12: QPOSEIDON2_EXTERNAL_EVAL_LOC
             mstore(BATCH_SCALAR_13_LOC, mulmod(neg_unshifted_scalar, batching_challenge, p))
-            batched_evaluation :=
-                addmod(batched_evaluation, mulmod(mload(QPOSEIDON2_EXTERNAL_EVAL_LOC), batching_challenge, p), p)
+            batched_evaluation := addmod(
+                batched_evaluation,
+                mulmod(mload(QPOSEIDON2_EXTERNAL_EVAL_LOC), batching_challenge, p),
+                p
+            )
             batching_challenge := mulmod(batching_challenge, rho, p)
 
             // 13: QPOSEIDON2_INTERNAL_EVAL_LOC
             mstore(BATCH_SCALAR_14_LOC, mulmod(neg_unshifted_scalar, batching_challenge, p))
-            batched_evaluation :=
-                addmod(batched_evaluation, mulmod(mload(QPOSEIDON2_INTERNAL_EVAL_LOC), batching_challenge, p), p)
+            batched_evaluation := addmod(
+                batched_evaluation,
+                mulmod(mload(QPOSEIDON2_INTERNAL_EVAL_LOC), batching_challenge, p),
+                p
+            )
             batching_challenge := mulmod(batching_challenge, rho, p)
 
             // 14: SIGMA1_EVAL_LOC
@@ -3435,14 +3557,20 @@ contract BlakeOptHonkVerifier is IVerifier {
 
             // 26: LAGRANGE_FIRST_EVAL_LOC
             mstore(BATCH_SCALAR_27_LOC, mulmod(neg_unshifted_scalar, batching_challenge, p))
-            batched_evaluation :=
-                addmod(batched_evaluation, mulmod(mload(LAGRANGE_FIRST_EVAL_LOC), batching_challenge, p), p)
+            batched_evaluation := addmod(
+                batched_evaluation,
+                mulmod(mload(LAGRANGE_FIRST_EVAL_LOC), batching_challenge, p),
+                p
+            )
             batching_challenge := mulmod(batching_challenge, rho, p)
 
             // 27: LAGRANGE_LAST_EVAL_LOC
             mstore(BATCH_SCALAR_28_LOC, mulmod(neg_unshifted_scalar, batching_challenge, p))
-            batched_evaluation :=
-                addmod(batched_evaluation, mulmod(mload(LAGRANGE_LAST_EVAL_LOC), batching_challenge, p), p)
+            batched_evaluation := addmod(
+                batched_evaluation,
+                mulmod(mload(LAGRANGE_LAST_EVAL_LOC), batching_challenge, p),
+                p
+            )
             batching_challenge := mulmod(batching_challenge, rho, p)
 
             // 28: W1_EVAL_LOC
@@ -3472,20 +3600,29 @@ contract BlakeOptHonkVerifier is IVerifier {
 
             // 33: LOOKUP_INVERSES_EVAL_LOC
             mstore(BATCH_SCALAR_34_LOC, mulmod(neg_unshifted_scalar, batching_challenge, p))
-            batched_evaluation :=
-                addmod(batched_evaluation, mulmod(mload(LOOKUP_INVERSES_EVAL_LOC), batching_challenge, p), p)
+            batched_evaluation := addmod(
+                batched_evaluation,
+                mulmod(mload(LOOKUP_INVERSES_EVAL_LOC), batching_challenge, p),
+                p
+            )
             batching_challenge := mulmod(batching_challenge, rho, p)
 
             // 34: LOOKUP_READ_COUNTS_EVAL_LOC
             mstore(BATCH_SCALAR_35_LOC, mulmod(neg_unshifted_scalar, batching_challenge, p))
-            batched_evaluation :=
-                addmod(batched_evaluation, mulmod(mload(LOOKUP_READ_COUNTS_EVAL_LOC), batching_challenge, p), p)
+            batched_evaluation := addmod(
+                batched_evaluation,
+                mulmod(mload(LOOKUP_READ_COUNTS_EVAL_LOC), batching_challenge, p),
+                p
+            )
             batching_challenge := mulmod(batching_challenge, rho, p)
 
             // 35: LOOKUP_READ_TAGS_EVAL_LOC
             mstore(BATCH_SCALAR_36_LOC, mulmod(neg_unshifted_scalar, batching_challenge, p))
-            batched_evaluation :=
-                addmod(batched_evaluation, mulmod(mload(LOOKUP_READ_TAGS_EVAL_LOC), batching_challenge, p), p)
+            batched_evaluation := addmod(
+                batched_evaluation,
+                mulmod(mload(LOOKUP_READ_TAGS_EVAL_LOC), batching_challenge, p),
+                p
+            )
             batching_challenge := mulmod(batching_challenge, rho, p)
 
             // Unrolled for NUMBER_OF_SHIFTED_ENTITIES = 5
@@ -3532,8 +3669,11 @@ contract BlakeOptHonkVerifier is IVerifier {
                 BATCH_SCALAR_33_LOC,
                 addmod(mload(BATCH_SCALAR_33_LOC), mulmod(neg_shifted_scalar, batching_challenge, p), p)
             )
-            batched_evaluation :=
-                addmod(batched_evaluation, mulmod(mload(Z_PERM_SHIFT_EVAL_LOC), batching_challenge, p), p)
+            batched_evaluation := addmod(
+                batched_evaluation,
+                mulmod(mload(Z_PERM_SHIFT_EVAL_LOC), batching_challenge, p),
+                p
+            )
             batching_challenge := mulmod(batching_challenge, rho, p)
 
             mstore(BATCHED_EVALUATION_LOC, batched_evaluation)
@@ -3558,17 +3698,18 @@ contract BlakeOptHonkVerifier is IVerifier {
                     // (challengePower * (ONE - u) - u)
                     let chall_pow_times_1_minus_u := mulmod(chall_pow, addmod(1, sub(p, sum_check_u), p), p)
 
-                    batchedEvalRoundAcc :=
-                        addmod(
-                            batchedEvalRoundAcc,
-                            sub(
-                                p,
-                                mulmod(
-                                    mload(mload(GEMINI_A_LOC)), addmod(chall_pow_times_1_minus_u, sub(p, sum_check_u), p), p
-                                )
-                            ),
-                            p
-                        )
+                    batchedEvalRoundAcc := addmod(
+                        batchedEvalRoundAcc,
+                        sub(
+                            p,
+                            mulmod(
+                                mload(mload(GEMINI_A_LOC)),
+                                addmod(chall_pow_times_1_minus_u, sub(p, sum_check_u), p),
+                                p
+                            )
+                        ),
+                        p
+                    )
 
                     batchedEvalRoundAcc := mulmod(batchedEvalRoundAcc, mload(inverted_chall_pow_minus_u_loc), p)
 
@@ -3587,12 +3728,11 @@ contract BlakeOptHonkVerifier is IVerifier {
             {
                 let shplonk_nu := mload(SHPLONK_NU_CHALLENGE)
 
-                constant_term_acc :=
-                    addmod(
-                        constant_term_acc,
-                        mulmod(mload(GEMINI_A_EVAL_0), mulmod(shplonk_nu, mload(NEG_INVERTED_DENOM_0_LOC), p), p),
-                        p
-                    )
+                constant_term_acc := addmod(
+                    constant_term_acc,
+                    mulmod(mload(GEMINI_A_EVAL_0), mulmod(shplonk_nu, mload(NEG_INVERTED_DENOM_0_LOC), p), p),
+                    p
+                )
 
                 let shplonk_nu_sqr := mulmod(shplonk_nu, shplonk_nu, p)
                 batching_challenge := shplonk_nu_sqr
@@ -3615,8 +3755,11 @@ contract BlakeOptHonkVerifier is IVerifier {
                     mstore(scalars_loc, addmod(sub(p, scaling_factor_neg), sub(p, scaling_factor_pos), p))
 
                     let accum_contribution := mulmod(scaling_factor_neg, mload(mload(SS_GEMINI_EVALS_LOC)), p)
-                    accum_contribution :=
-                        addmod(accum_contribution, mulmod(scaling_factor_pos, mload(fold_pos_evals_loc), p), p)
+                    accum_contribution := addmod(
+                        accum_contribution,
+                        mulmod(scaling_factor_pos, mload(fold_pos_evals_loc), p),
+                        p
+                    )
 
                     constant_term_acc := addmod(constant_term_acc, accum_contribution, p)
 
@@ -3642,8 +3785,10 @@ contract BlakeOptHonkVerifier is IVerifier {
                     let y := mload(SHPLONK_Q_Y_LOC)
                     let xx := mulmod(x, x, q)
                     // validate on curve
-                    precomp_success_flag :=
-                        and(eq(mulmod(y, y, q), addmod(mulmod(x, xx, q), 3, q)), precomp_success_flag)
+                    precomp_success_flag := and(
+                        eq(mulmod(y, y, q), addmod(mulmod(x, xx, q), 3, q)),
+                        precomp_success_flag
+                    )
                 }
                 mcopy(G1_LOCATION, SHPLONK_Q_X_LOC, 0x40)
                 precomp_success_flag := staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR, 0x40)
@@ -3655,278 +3800,408 @@ contract BlakeOptHonkVerifier is IVerifier {
                 // Acumulator = acumulator + scalar[1] * vk[0]
                 mcopy(G1_LOCATION, Q_M_X_LOC, 0x40)
                 mstore(SCALAR_LOCATION, mload(BATCH_SCALAR_1_LOC))
-                precomp_success_flag :=
-                    and(precomp_success_flag, staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40))
-                precomp_success_flag :=
-                    and(precomp_success_flag, staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40))
+                precomp_success_flag := and(
+                    precomp_success_flag,
+                    staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40)
+                )
+                precomp_success_flag := and(
+                    precomp_success_flag,
+                    staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40)
+                )
 
                 // Accumulator = accumulator + scalar[2] * vk[1]
                 mcopy(G1_LOCATION, Q_C_X_LOC, 0x40)
                 mstore(SCALAR_LOCATION, mload(BATCH_SCALAR_2_LOC))
-                precomp_success_flag :=
-                    and(precomp_success_flag, staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40))
-                precomp_success_flag :=
-                    and(precomp_success_flag, staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40))
+                precomp_success_flag := and(
+                    precomp_success_flag,
+                    staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40)
+                )
+                precomp_success_flag := and(
+                    precomp_success_flag,
+                    staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40)
+                )
 
                 // Accumulator = accumulator + scalar[3] * vk[2]
                 mcopy(G1_LOCATION, Q_L_X_LOC, 0x40)
                 mstore(SCALAR_LOCATION, mload(BATCH_SCALAR_3_LOC))
-                precomp_success_flag :=
-                    and(precomp_success_flag, staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40))
-                precomp_success_flag :=
-                    and(precomp_success_flag, staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40))
+                precomp_success_flag := and(
+                    precomp_success_flag,
+                    staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40)
+                )
+                precomp_success_flag := and(
+                    precomp_success_flag,
+                    staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40)
+                )
 
                 // Accumulator = accumulator + scalar[4] * vk[3]
                 mcopy(G1_LOCATION, Q_R_X_LOC, 0x40)
                 mstore(SCALAR_LOCATION, mload(BATCH_SCALAR_4_LOC))
-                precomp_success_flag :=
-                    and(precomp_success_flag, staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40))
-                precomp_success_flag :=
-                    and(precomp_success_flag, staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40))
+                precomp_success_flag := and(
+                    precomp_success_flag,
+                    staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40)
+                )
+                precomp_success_flag := and(
+                    precomp_success_flag,
+                    staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40)
+                )
 
                 // Accumulator = accumulator + scalar[5] * vk[4]
                 mcopy(G1_LOCATION, Q_O_X_LOC, 0x40)
                 mstore(SCALAR_LOCATION, mload(BATCH_SCALAR_5_LOC))
-                precomp_success_flag :=
-                    and(precomp_success_flag, staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40))
-                precomp_success_flag :=
-                    and(precomp_success_flag, staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40))
+                precomp_success_flag := and(
+                    precomp_success_flag,
+                    staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40)
+                )
+                precomp_success_flag := and(
+                    precomp_success_flag,
+                    staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40)
+                )
 
                 // Accumulator = accumulator + scalar[6] * vk[5]
                 mcopy(G1_LOCATION, Q_4_X_LOC, 0x40)
                 mstore(SCALAR_LOCATION, mload(BATCH_SCALAR_6_LOC))
-                precomp_success_flag :=
-                    and(precomp_success_flag, staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40))
-                precomp_success_flag :=
-                    and(precomp_success_flag, staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40))
+                precomp_success_flag := and(
+                    precomp_success_flag,
+                    staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40)
+                )
+                precomp_success_flag := and(
+                    precomp_success_flag,
+                    staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40)
+                )
 
                 // Accumulator = accumulator + scalar[7] * vk[6]
                 mcopy(G1_LOCATION, Q_LOOKUP_X_LOC, 0x40)
                 mstore(SCALAR_LOCATION, mload(BATCH_SCALAR_7_LOC))
-                precomp_success_flag :=
-                    and(precomp_success_flag, staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40))
-                precomp_success_flag :=
-                    and(precomp_success_flag, staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40))
+                precomp_success_flag := and(
+                    precomp_success_flag,
+                    staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40)
+                )
+                precomp_success_flag := and(
+                    precomp_success_flag,
+                    staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40)
+                )
 
                 // Accumulator = accumulator + scalar[8] * vk[7]
                 mcopy(G1_LOCATION, Q_ARITH_X_LOC, 0x40)
                 mstore(SCALAR_LOCATION, mload(BATCH_SCALAR_8_LOC))
-                precomp_success_flag :=
-                    and(precomp_success_flag, staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40))
-                precomp_success_flag :=
-                    and(precomp_success_flag, staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40))
+                precomp_success_flag := and(
+                    precomp_success_flag,
+                    staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40)
+                )
+                precomp_success_flag := and(
+                    precomp_success_flag,
+                    staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40)
+                )
 
                 // Accumulator = accumulator + scalar[9] * vk[8]
                 mcopy(G1_LOCATION, Q_DELTA_RANGE_X_LOC, 0x40)
                 mstore(SCALAR_LOCATION, mload(BATCH_SCALAR_9_LOC))
-                precomp_success_flag :=
-                    and(precomp_success_flag, staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40))
-                precomp_success_flag :=
-                    and(precomp_success_flag, staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40))
+                precomp_success_flag := and(
+                    precomp_success_flag,
+                    staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40)
+                )
+                precomp_success_flag := and(
+                    precomp_success_flag,
+                    staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40)
+                )
 
                 // Accumulator = accumulator + scalar[10] * vk[9]
                 mcopy(G1_LOCATION, Q_ELLIPTIC_X_LOC, 0x40)
                 mstore(SCALAR_LOCATION, mload(BATCH_SCALAR_10_LOC))
-                precomp_success_flag :=
-                    and(precomp_success_flag, staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40))
-                precomp_success_flag :=
-                    and(precomp_success_flag, staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40))
+                precomp_success_flag := and(
+                    precomp_success_flag,
+                    staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40)
+                )
+                precomp_success_flag := and(
+                    precomp_success_flag,
+                    staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40)
+                )
 
                 // Accumulator = accumulator + scalar[11] * vk[10]
                 mcopy(G1_LOCATION, Q_MEMORY_X_LOC, 0x40)
                 mstore(SCALAR_LOCATION, mload(BATCH_SCALAR_11_LOC))
-                precomp_success_flag :=
-                    and(precomp_success_flag, staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40))
-                precomp_success_flag :=
-                    and(precomp_success_flag, staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40))
+                precomp_success_flag := and(
+                    precomp_success_flag,
+                    staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40)
+                )
+                precomp_success_flag := and(
+                    precomp_success_flag,
+                    staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40)
+                )
 
                 // Accumulator = accumulator + scalar[12] * vk[11]
                 mcopy(G1_LOCATION, Q_NNF_X_LOC, 0x40)
                 mstore(SCALAR_LOCATION, mload(BATCH_SCALAR_12_LOC))
-                precomp_success_flag :=
-                    and(precomp_success_flag, staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40))
-                precomp_success_flag :=
-                    and(precomp_success_flag, staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40))
+                precomp_success_flag := and(
+                    precomp_success_flag,
+                    staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40)
+                )
+                precomp_success_flag := and(
+                    precomp_success_flag,
+                    staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40)
+                )
 
                 // Accumulator = accumulator + scalar[13] * vk[12]
                 mcopy(G1_LOCATION, Q_POSEIDON_2_EXTERNAL_X_LOC, 0x40)
                 mstore(SCALAR_LOCATION, mload(BATCH_SCALAR_13_LOC))
-                precomp_success_flag :=
-                    and(precomp_success_flag, staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40))
-                precomp_success_flag :=
-                    and(precomp_success_flag, staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40))
+                precomp_success_flag := and(
+                    precomp_success_flag,
+                    staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40)
+                )
+                precomp_success_flag := and(
+                    precomp_success_flag,
+                    staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40)
+                )
 
                 // Accumulator = accumulator + scalar[14] * vk[13]
                 mcopy(G1_LOCATION, Q_POSEIDON_2_INTERNAL_X_LOC, 0x40)
                 mstore(SCALAR_LOCATION, mload(BATCH_SCALAR_14_LOC))
-                precomp_success_flag :=
-                    and(precomp_success_flag, staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40))
-                precomp_success_flag :=
-                    and(precomp_success_flag, staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40))
+                precomp_success_flag := and(
+                    precomp_success_flag,
+                    staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40)
+                )
+                precomp_success_flag := and(
+                    precomp_success_flag,
+                    staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40)
+                )
 
                 // Accumulator = accumulator + scalar[15] * vk[14]
                 mcopy(G1_LOCATION, SIGMA_1_X_LOC, 0x40)
                 mstore(SCALAR_LOCATION, mload(BATCH_SCALAR_15_LOC))
-                precomp_success_flag :=
-                    and(precomp_success_flag, staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40))
-                precomp_success_flag :=
-                    and(precomp_success_flag, staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40))
+                precomp_success_flag := and(
+                    precomp_success_flag,
+                    staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40)
+                )
+                precomp_success_flag := and(
+                    precomp_success_flag,
+                    staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40)
+                )
 
                 // Accumulator = accumulator + scalar[16] * vk[15]
                 mcopy(G1_LOCATION, SIGMA_2_X_LOC, 0x40)
                 mstore(SCALAR_LOCATION, mload(BATCH_SCALAR_16_LOC))
-                precomp_success_flag :=
-                    and(precomp_success_flag, staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40))
-                precomp_success_flag :=
-                    and(precomp_success_flag, staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40))
+                precomp_success_flag := and(
+                    precomp_success_flag,
+                    staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40)
+                )
+                precomp_success_flag := and(
+                    precomp_success_flag,
+                    staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40)
+                )
 
                 // Accumulator = accumulator + scalar[17] * vk[16]
                 mcopy(G1_LOCATION, SIGMA_3_X_LOC, 0x40)
                 mstore(SCALAR_LOCATION, mload(BATCH_SCALAR_17_LOC))
-                precomp_success_flag :=
-                    and(precomp_success_flag, staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40))
-                precomp_success_flag :=
-                    and(precomp_success_flag, staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40))
+                precomp_success_flag := and(
+                    precomp_success_flag,
+                    staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40)
+                )
+                precomp_success_flag := and(
+                    precomp_success_flag,
+                    staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40)
+                )
 
                 // Accumulator = accumulator + scalar[18] * vk[17]
                 mcopy(G1_LOCATION, SIGMA_4_X_LOC, 0x40)
                 mstore(SCALAR_LOCATION, mload(BATCH_SCALAR_18_LOC))
-                precomp_success_flag :=
-                    and(precomp_success_flag, staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40))
-                precomp_success_flag :=
-                    and(precomp_success_flag, staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40))
+                precomp_success_flag := and(
+                    precomp_success_flag,
+                    staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40)
+                )
+                precomp_success_flag := and(
+                    precomp_success_flag,
+                    staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40)
+                )
 
                 // Accumulator = accumulator + scalar[19] * vk[18]
                 mcopy(G1_LOCATION, ID_1_X_LOC, 0x40)
                 mstore(SCALAR_LOCATION, mload(BATCH_SCALAR_19_LOC))
-                precomp_success_flag :=
-                    and(precomp_success_flag, staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40))
-                precomp_success_flag :=
-                    and(precomp_success_flag, staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40))
+                precomp_success_flag := and(
+                    precomp_success_flag,
+                    staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40)
+                )
+                precomp_success_flag := and(
+                    precomp_success_flag,
+                    staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40)
+                )
 
                 // Accumulator = accumulator + scalar[20] * vk[19]
                 mcopy(G1_LOCATION, ID_2_X_LOC, 0x40)
                 mstore(SCALAR_LOCATION, mload(BATCH_SCALAR_20_LOC))
-                precomp_success_flag :=
-                    and(precomp_success_flag, staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40))
-                precomp_success_flag :=
-                    and(precomp_success_flag, staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40))
+                precomp_success_flag := and(
+                    precomp_success_flag,
+                    staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40)
+                )
+                precomp_success_flag := and(
+                    precomp_success_flag,
+                    staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40)
+                )
 
                 // Accumulator = accumulator + scalar[21] * vk[20]
                 mcopy(G1_LOCATION, ID_3_X_LOC, 0x40)
                 mstore(SCALAR_LOCATION, mload(BATCH_SCALAR_21_LOC))
-                precomp_success_flag :=
-                    and(precomp_success_flag, staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40))
-                precomp_success_flag :=
-                    and(precomp_success_flag, staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40))
+                precomp_success_flag := and(
+                    precomp_success_flag,
+                    staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40)
+                )
+                precomp_success_flag := and(
+                    precomp_success_flag,
+                    staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40)
+                )
 
                 // Accumulator = accumulator + scalar[22] * vk[21]
                 mcopy(G1_LOCATION, ID_4_X_LOC, 0x40)
                 mstore(SCALAR_LOCATION, mload(BATCH_SCALAR_22_LOC))
-                precomp_success_flag :=
-                    and(precomp_success_flag, staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40))
-                precomp_success_flag :=
-                    and(precomp_success_flag, staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40))
+                precomp_success_flag := and(
+                    precomp_success_flag,
+                    staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40)
+                )
+                precomp_success_flag := and(
+                    precomp_success_flag,
+                    staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40)
+                )
 
                 // Accumulator = accumulator + scalar[23] * vk[22]
                 mcopy(G1_LOCATION, TABLE_1_X_LOC, 0x40)
                 mstore(SCALAR_LOCATION, mload(BATCH_SCALAR_23_LOC))
-                precomp_success_flag :=
-                    and(precomp_success_flag, staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40))
-                precomp_success_flag :=
-                    and(precomp_success_flag, staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40))
+                precomp_success_flag := and(
+                    precomp_success_flag,
+                    staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40)
+                )
+                precomp_success_flag := and(
+                    precomp_success_flag,
+                    staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40)
+                )
 
                 // Accumulator = accumulator + scalar[24] * vk[23]
                 mcopy(G1_LOCATION, TABLE_2_X_LOC, 0x40)
                 mstore(SCALAR_LOCATION, mload(BATCH_SCALAR_24_LOC))
-                precomp_success_flag :=
-                    and(precomp_success_flag, staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40))
-                precomp_success_flag :=
-                    and(precomp_success_flag, staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40))
+                precomp_success_flag := and(
+                    precomp_success_flag,
+                    staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40)
+                )
+                precomp_success_flag := and(
+                    precomp_success_flag,
+                    staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40)
+                )
 
                 // Accumulator = accumulator + scalar[25] * vk[24]
                 mcopy(G1_LOCATION, TABLE_3_X_LOC, 0x40)
                 mstore(SCALAR_LOCATION, mload(BATCH_SCALAR_25_LOC))
-                precomp_success_flag :=
-                    and(precomp_success_flag, staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40))
-                precomp_success_flag :=
-                    and(precomp_success_flag, staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40))
+                precomp_success_flag := and(
+                    precomp_success_flag,
+                    staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40)
+                )
+                precomp_success_flag := and(
+                    precomp_success_flag,
+                    staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40)
+                )
 
                 // Accumulator = accumulator + scalar[26] * vk[25]
                 mcopy(G1_LOCATION, TABLE_4_X_LOC, 0x40)
                 mstore(SCALAR_LOCATION, mload(BATCH_SCALAR_26_LOC))
-                precomp_success_flag :=
-                    and(precomp_success_flag, staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40))
-                precomp_success_flag :=
-                    and(precomp_success_flag, staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40))
+                precomp_success_flag := and(
+                    precomp_success_flag,
+                    staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40)
+                )
+                precomp_success_flag := and(
+                    precomp_success_flag,
+                    staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40)
+                )
 
                 // Accumulator = accumulator + scalar[27] * vk[26]
                 mcopy(G1_LOCATION, LAGRANGE_FIRST_X_LOC, 0x40)
                 mstore(SCALAR_LOCATION, mload(BATCH_SCALAR_27_LOC))
-                precomp_success_flag :=
-                    and(precomp_success_flag, staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40))
-                precomp_success_flag :=
-                    and(precomp_success_flag, staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40))
+                precomp_success_flag := and(
+                    precomp_success_flag,
+                    staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40)
+                )
+                precomp_success_flag := and(
+                    precomp_success_flag,
+                    staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40)
+                )
 
                 // Accumulator = accumulator + scalar[28] * vk[27]
                 mcopy(G1_LOCATION, LAGRANGE_LAST_X_LOC, 0x40)
                 mstore(SCALAR_LOCATION, mload(BATCH_SCALAR_28_LOC))
-                precomp_success_flag :=
-                    and(precomp_success_flag, staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40))
-                precomp_success_flag :=
-                    and(precomp_success_flag, staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40))
+                precomp_success_flag := and(
+                    precomp_success_flag,
+                    staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40)
+                )
+                precomp_success_flag := and(
+                    precomp_success_flag,
+                    staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40)
+                )
 
                 {
                     let x := mload(W_L_X_LOC)
                     let y := mload(W_L_Y_LOC)
                     let xx := mulmod(x, x, q)
                     // validate on curve
-                    precomp_success_flag :=
-                        and(eq(mulmod(y, y, q), addmod(mulmod(x, xx, q), 3, q)), precomp_success_flag)
+                    precomp_success_flag := and(
+                        eq(mulmod(y, y, q), addmod(mulmod(x, xx, q), 3, q)),
+                        precomp_success_flag
+                    )
                 }
 
                 // Accumulate proof points
                 // Accumulator = accumulator + scalar[29] * w_l
                 mcopy(G1_LOCATION, W_L_X_LOC, 0x40)
                 mstore(SCALAR_LOCATION, mload(BATCH_SCALAR_29_LOC))
-                precomp_success_flag :=
-                    and(precomp_success_flag, staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40))
-                precomp_success_flag :=
-                    and(precomp_success_flag, staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40))
+                precomp_success_flag := and(
+                    precomp_success_flag,
+                    staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40)
+                )
+                precomp_success_flag := and(
+                    precomp_success_flag,
+                    staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40)
+                )
 
                 {
                     let x := mload(W_R_X_LOC)
                     let y := mload(W_R_Y_LOC)
                     let xx := mulmod(x, x, q)
                     // validate on curve
-                    precomp_success_flag :=
-                        and(eq(mulmod(y, y, q), addmod(mulmod(x, xx, q), 3, q)), precomp_success_flag)
+                    precomp_success_flag := and(
+                        eq(mulmod(y, y, q), addmod(mulmod(x, xx, q), 3, q)),
+                        precomp_success_flag
+                    )
                 }
 
                 // Accumulator = accumulator + scalar[30] * w_r
                 mcopy(G1_LOCATION, W_R_X_LOC, 0x40)
                 mstore(SCALAR_LOCATION, mload(BATCH_SCALAR_30_LOC))
-                precomp_success_flag :=
-                    and(precomp_success_flag, staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40))
-                precomp_success_flag :=
-                    and(precomp_success_flag, staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40))
+                precomp_success_flag := and(
+                    precomp_success_flag,
+                    staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40)
+                )
+                precomp_success_flag := and(
+                    precomp_success_flag,
+                    staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40)
+                )
 
                 {
                     let x := mload(W_O_X_LOC)
                     let y := mload(W_O_Y_LOC)
                     let xx := mulmod(x, x, q)
                     // validate on curve
-                    precomp_success_flag :=
-                        and(eq(mulmod(y, y, q), addmod(mulmod(x, xx, q), 3, q)), precomp_success_flag)
+                    precomp_success_flag := and(
+                        eq(mulmod(y, y, q), addmod(mulmod(x, xx, q), 3, q)),
+                        precomp_success_flag
+                    )
                 }
 
                 // Accumulator = accumulator + scalar[31] * w_o
                 mcopy(G1_LOCATION, W_O_X_LOC, 0x40)
                 mstore(SCALAR_LOCATION, mload(BATCH_SCALAR_31_LOC))
-                precomp_success_flag :=
-                    and(precomp_success_flag, staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40))
-                precomp_success_flag :=
-                    and(precomp_success_flag, staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40))
+                precomp_success_flag := and(
+                    precomp_success_flag,
+                    staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40)
+                )
+                precomp_success_flag := and(
+                    precomp_success_flag,
+                    staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40)
+                )
 
                 // Accumulator = accumulator + scalar[32] * w_4
                 {
@@ -3934,79 +4209,109 @@ contract BlakeOptHonkVerifier is IVerifier {
                     let y := mload(W_4_Y_LOC)
                     let xx := mulmod(x, x, q)
                     // validate on curve
-                    precomp_success_flag :=
-                        and(eq(mulmod(y, y, q), addmod(mulmod(x, xx, q), 3, q)), precomp_success_flag)
+                    precomp_success_flag := and(
+                        eq(mulmod(y, y, q), addmod(mulmod(x, xx, q), 3, q)),
+                        precomp_success_flag
+                    )
                 }
                 mcopy(G1_LOCATION, W_4_X_LOC, 0x40)
                 mstore(SCALAR_LOCATION, mload(BATCH_SCALAR_32_LOC))
-                precomp_success_flag :=
-                    and(precomp_success_flag, staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40))
-                precomp_success_flag :=
-                    and(precomp_success_flag, staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40))
+                precomp_success_flag := and(
+                    precomp_success_flag,
+                    staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40)
+                )
+                precomp_success_flag := and(
+                    precomp_success_flag,
+                    staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40)
+                )
 
                 {
                     let x := mload(Z_PERM_X_LOC)
                     let y := mload(Z_PERM_Y_LOC)
                     let xx := mulmod(x, x, q)
                     // validate on curve
-                    precomp_success_flag :=
-                        and(eq(mulmod(y, y, q), addmod(mulmod(x, xx, q), 3, q)), precomp_success_flag)
+                    precomp_success_flag := and(
+                        eq(mulmod(y, y, q), addmod(mulmod(x, xx, q), 3, q)),
+                        precomp_success_flag
+                    )
                 }
                 // Accumulator = accumulator + scalar[33] * z_perm
                 mcopy(G1_LOCATION, Z_PERM_X_LOC, 0x40)
                 mstore(SCALAR_LOCATION, mload(BATCH_SCALAR_33_LOC))
-                precomp_success_flag :=
-                    and(precomp_success_flag, staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40))
-                precomp_success_flag :=
-                    and(precomp_success_flag, staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40))
+                precomp_success_flag := and(
+                    precomp_success_flag,
+                    staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40)
+                )
+                precomp_success_flag := and(
+                    precomp_success_flag,
+                    staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40)
+                )
 
                 {
                     let x := mload(LOOKUP_INVERSES_X_LOC)
                     let y := mload(LOOKUP_INVERSES_Y_LOC)
                     let xx := mulmod(x, x, q)
                     // validate on curve
-                    precomp_success_flag :=
-                        and(eq(mulmod(y, y, q), addmod(mulmod(x, xx, q), 3, q)), precomp_success_flag)
+                    precomp_success_flag := and(
+                        eq(mulmod(y, y, q), addmod(mulmod(x, xx, q), 3, q)),
+                        precomp_success_flag
+                    )
                 }
                 // Accumulator = accumulator + scalar[34] * lookup_inverses
                 mcopy(G1_LOCATION, LOOKUP_INVERSES_X_LOC, 0x40)
                 mstore(SCALAR_LOCATION, mload(BATCH_SCALAR_34_LOC))
-                precomp_success_flag :=
-                    and(precomp_success_flag, staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40))
-                precomp_success_flag :=
-                    and(precomp_success_flag, staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40))
+                precomp_success_flag := and(
+                    precomp_success_flag,
+                    staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40)
+                )
+                precomp_success_flag := and(
+                    precomp_success_flag,
+                    staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40)
+                )
 
                 {
                     let x := mload(LOOKUP_READ_COUNTS_X_LOC)
                     let y := mload(LOOKUP_READ_COUNTS_Y_LOC)
                     let xx := mulmod(x, x, q)
                     // validate on curve
-                    precomp_success_flag :=
-                        and(eq(mulmod(y, y, q), addmod(mulmod(x, xx, q), 3, q)), precomp_success_flag)
+                    precomp_success_flag := and(
+                        eq(mulmod(y, y, q), addmod(mulmod(x, xx, q), 3, q)),
+                        precomp_success_flag
+                    )
                 }
                 // Accumulator = accumulator + scalar[35] * lookup_read_counts
                 mcopy(G1_LOCATION, LOOKUP_READ_COUNTS_X_LOC, 0x40)
                 mstore(SCALAR_LOCATION, mload(BATCH_SCALAR_35_LOC))
-                precomp_success_flag :=
-                    and(precomp_success_flag, staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40))
-                precomp_success_flag :=
-                    and(precomp_success_flag, staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40))
+                precomp_success_flag := and(
+                    precomp_success_flag,
+                    staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40)
+                )
+                precomp_success_flag := and(
+                    precomp_success_flag,
+                    staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40)
+                )
 
                 {
                     let x := mload(LOOKUP_READ_TAGS_X_LOC)
                     let y := mload(LOOKUP_READ_TAGS_Y_LOC)
                     let xx := mulmod(x, x, q)
                     // validate on curve
-                    precomp_success_flag :=
-                        and(eq(mulmod(y, y, q), addmod(mulmod(x, xx, q), 3, q)), precomp_success_flag)
+                    precomp_success_flag := and(
+                        eq(mulmod(y, y, q), addmod(mulmod(x, xx, q), 3, q)),
+                        precomp_success_flag
+                    )
                 }
                 // Accumulator = accumulator + scalar[36] * lookup_read_tags
                 mcopy(G1_LOCATION, LOOKUP_READ_TAGS_X_LOC, 0x40)
                 mstore(SCALAR_LOCATION, mload(BATCH_SCALAR_36_LOC))
-                precomp_success_flag :=
-                    and(precomp_success_flag, staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40))
-                precomp_success_flag :=
-                    and(precomp_success_flag, staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40))
+                precomp_success_flag := and(
+                    precomp_success_flag,
+                    staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40)
+                )
+                precomp_success_flag := and(
+                    precomp_success_flag,
+                    staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40)
+                )
 
                 // Accumulate these LOG_N scalars with the gemini fold univariates
                 {
@@ -4017,80 +4322,110 @@ contract BlakeOptHonkVerifier is IVerifier {
                             let y := mload(GEMINI_FOLD_UNIVARIATE_0_Y_LOC)
                             let xx := mulmod(x, x, q)
                             // validate on curve
-                            precomp_success_flag :=
-                                and(eq(mulmod(y, y, q), addmod(mulmod(x, xx, q), 3, q)), precomp_success_flag)
+                            precomp_success_flag := and(
+                                eq(mulmod(y, y, q), addmod(mulmod(x, xx, q), 3, q)),
+                                precomp_success_flag
+                            )
                         }
                         // accumulator = accumulator + scalar[37] * gemini_fold_univariates[0]
                         mcopy(G1_LOCATION, GEMINI_FOLD_UNIVARIATE_0_X_LOC, 0x40)
                         mstore(SCALAR_LOCATION, mload(BATCH_SCALAR_37_LOC))
-                        precomp_success_flag :=
-                            and(precomp_success_flag, staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40))
-                        precomp_success_flag :=
-                            and(precomp_success_flag, staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40))
+                        precomp_success_flag := and(
+                            precomp_success_flag,
+                            staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40)
+                        )
+                        precomp_success_flag := and(
+                            precomp_success_flag,
+                            staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40)
+                        )
 
                         {
                             let x := mload(GEMINI_FOLD_UNIVARIATE_1_X_LOC)
                             let y := mload(GEMINI_FOLD_UNIVARIATE_1_Y_LOC)
                             let xx := mulmod(x, x, q)
                             // validate on curve
-                            precomp_success_flag :=
-                                and(eq(mulmod(y, y, q), addmod(mulmod(x, xx, q), 3, q)), precomp_success_flag)
+                            precomp_success_flag := and(
+                                eq(mulmod(y, y, q), addmod(mulmod(x, xx, q), 3, q)),
+                                precomp_success_flag
+                            )
                         }
                         // accumulator = accumulator + scalar[38] * gemini_fold_univariates[1]
                         mcopy(G1_LOCATION, GEMINI_FOLD_UNIVARIATE_1_X_LOC, 0x40)
                         mstore(SCALAR_LOCATION, mload(BATCH_SCALAR_38_LOC))
-                        precomp_success_flag :=
-                            and(precomp_success_flag, staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40))
-                        precomp_success_flag :=
-                            and(precomp_success_flag, staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40))
+                        precomp_success_flag := and(
+                            precomp_success_flag,
+                            staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40)
+                        )
+                        precomp_success_flag := and(
+                            precomp_success_flag,
+                            staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40)
+                        )
 
                         {
                             let x := mload(GEMINI_FOLD_UNIVARIATE_2_X_LOC)
                             let y := mload(GEMINI_FOLD_UNIVARIATE_2_Y_LOC)
                             let xx := mulmod(x, x, q)
                             // validate on curve
-                            precomp_success_flag :=
-                                and(eq(mulmod(y, y, q), addmod(mulmod(x, xx, q), 3, q)), precomp_success_flag)
+                            precomp_success_flag := and(
+                                eq(mulmod(y, y, q), addmod(mulmod(x, xx, q), 3, q)),
+                                precomp_success_flag
+                            )
                         }
                         // accumulator = accumulator + scalar[39] * gemini_fold_univariates[2]
                         mcopy(G1_LOCATION, GEMINI_FOLD_UNIVARIATE_2_X_LOC, 0x40)
                         mstore(SCALAR_LOCATION, mload(BATCH_SCALAR_39_LOC))
-                        precomp_success_flag :=
-                            and(precomp_success_flag, staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40))
-                        precomp_success_flag :=
-                            and(precomp_success_flag, staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40))
+                        precomp_success_flag := and(
+                            precomp_success_flag,
+                            staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40)
+                        )
+                        precomp_success_flag := and(
+                            precomp_success_flag,
+                            staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40)
+                        )
 
                         {
                             let x := mload(GEMINI_FOLD_UNIVARIATE_3_X_LOC)
                             let y := mload(GEMINI_FOLD_UNIVARIATE_3_Y_LOC)
                             let xx := mulmod(x, x, q)
                             // validate on curve
-                            precomp_success_flag :=
-                                and(eq(mulmod(y, y, q), addmod(mulmod(x, xx, q), 3, q)), precomp_success_flag)
+                            precomp_success_flag := and(
+                                eq(mulmod(y, y, q), addmod(mulmod(x, xx, q), 3, q)),
+                                precomp_success_flag
+                            )
                         }
                         // accumulator = accumulator + scalar[40] * gemini_fold_univariates[3]
                         mcopy(G1_LOCATION, GEMINI_FOLD_UNIVARIATE_3_X_LOC, 0x40)
                         mstore(SCALAR_LOCATION, mload(BATCH_SCALAR_40_LOC))
-                        precomp_success_flag :=
-                            and(precomp_success_flag, staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40))
-                        precomp_success_flag :=
-                            and(precomp_success_flag, staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40))
+                        precomp_success_flag := and(
+                            precomp_success_flag,
+                            staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40)
+                        )
+                        precomp_success_flag := and(
+                            precomp_success_flag,
+                            staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40)
+                        )
 
                         {
                             let x := mload(GEMINI_FOLD_UNIVARIATE_4_X_LOC)
                             let y := mload(GEMINI_FOLD_UNIVARIATE_4_Y_LOC)
                             let xx := mulmod(x, x, q)
                             // validate on curve
-                            precomp_success_flag :=
-                                and(eq(mulmod(y, y, q), addmod(mulmod(x, xx, q), 3, q)), precomp_success_flag)
+                            precomp_success_flag := and(
+                                eq(mulmod(y, y, q), addmod(mulmod(x, xx, q), 3, q)),
+                                precomp_success_flag
+                            )
                         }
                         // accumulator = accumulator + scalar[41] * gemini_fold_univariates[4]
                         mcopy(G1_LOCATION, GEMINI_FOLD_UNIVARIATE_4_X_LOC, 0x40)
                         mstore(SCALAR_LOCATION, mload(BATCH_SCALAR_41_LOC))
-                        precomp_success_flag :=
-                            and(precomp_success_flag, staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40))
-                        precomp_success_flag :=
-                            and(precomp_success_flag, staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40))
+                        precomp_success_flag := and(
+                            precomp_success_flag,
+                            staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40)
+                        )
+                        precomp_success_flag := and(
+                            precomp_success_flag,
+                            staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40)
+                        )
                     }
 
                     {
@@ -4099,96 +4434,132 @@ contract BlakeOptHonkVerifier is IVerifier {
                             let y := mload(GEMINI_FOLD_UNIVARIATE_5_Y_LOC)
                             let xx := mulmod(x, x, q)
                             // validate on curve
-                            precomp_success_flag :=
-                                and(eq(mulmod(y, y, q), addmod(mulmod(x, xx, q), 3, q)), precomp_success_flag)
+                            precomp_success_flag := and(
+                                eq(mulmod(y, y, q), addmod(mulmod(x, xx, q), 3, q)),
+                                precomp_success_flag
+                            )
                         }
                         // accumulator = accumulator + scalar[42] * gemini_fold_univariates[5]
                         mcopy(G1_LOCATION, GEMINI_FOLD_UNIVARIATE_5_X_LOC, 0x40)
                         mstore(SCALAR_LOCATION, mload(BATCH_SCALAR_42_LOC))
-                        precomp_success_flag :=
-                            and(precomp_success_flag, staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40))
-                        precomp_success_flag :=
-                            and(precomp_success_flag, staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40))
+                        precomp_success_flag := and(
+                            precomp_success_flag,
+                            staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40)
+                        )
+                        precomp_success_flag := and(
+                            precomp_success_flag,
+                            staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40)
+                        )
 
                         {
                             let x := mload(GEMINI_FOLD_UNIVARIATE_6_X_LOC)
                             let y := mload(GEMINI_FOLD_UNIVARIATE_6_Y_LOC)
                             let xx := mulmod(x, x, q)
                             // validate on curve
-                            precomp_success_flag :=
-                                and(eq(mulmod(y, y, q), addmod(mulmod(x, xx, q), 3, q)), precomp_success_flag)
+                            precomp_success_flag := and(
+                                eq(mulmod(y, y, q), addmod(mulmod(x, xx, q), 3, q)),
+                                precomp_success_flag
+                            )
                         }
                         // accumulator = accumulator + scalar[43] * gemini_fold_univariates[6]
                         mcopy(G1_LOCATION, GEMINI_FOLD_UNIVARIATE_6_X_LOC, 0x40)
                         mstore(SCALAR_LOCATION, mload(BATCH_SCALAR_43_LOC))
-                        precomp_success_flag :=
-                            and(precomp_success_flag, staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40))
-                        precomp_success_flag :=
-                            and(precomp_success_flag, staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40))
+                        precomp_success_flag := and(
+                            precomp_success_flag,
+                            staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40)
+                        )
+                        precomp_success_flag := and(
+                            precomp_success_flag,
+                            staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40)
+                        )
 
                         {
                             let x := mload(GEMINI_FOLD_UNIVARIATE_7_X_LOC)
                             let y := mload(GEMINI_FOLD_UNIVARIATE_7_Y_LOC)
                             let xx := mulmod(x, x, q)
                             // validate on curve
-                            precomp_success_flag :=
-                                and(eq(mulmod(y, y, q), addmod(mulmod(x, xx, q), 3, q)), precomp_success_flag)
+                            precomp_success_flag := and(
+                                eq(mulmod(y, y, q), addmod(mulmod(x, xx, q), 3, q)),
+                                precomp_success_flag
+                            )
                         }
                         // accumulator = accumulator + scalar[44] * gemini_fold_univariates[7]
                         mcopy(G1_LOCATION, GEMINI_FOLD_UNIVARIATE_7_X_LOC, 0x40)
                         mstore(SCALAR_LOCATION, mload(BATCH_SCALAR_44_LOC))
-                        precomp_success_flag :=
-                            and(precomp_success_flag, staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40))
-                        precomp_success_flag :=
-                            and(precomp_success_flag, staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40))
+                        precomp_success_flag := and(
+                            precomp_success_flag,
+                            staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40)
+                        )
+                        precomp_success_flag := and(
+                            precomp_success_flag,
+                            staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40)
+                        )
 
                         {
                             let x := mload(GEMINI_FOLD_UNIVARIATE_8_X_LOC)
                             let y := mload(GEMINI_FOLD_UNIVARIATE_8_Y_LOC)
                             let xx := mulmod(x, x, q)
                             // validate on curve
-                            precomp_success_flag :=
-                                and(eq(mulmod(y, y, q), addmod(mulmod(x, xx, q), 3, q)), precomp_success_flag)
+                            precomp_success_flag := and(
+                                eq(mulmod(y, y, q), addmod(mulmod(x, xx, q), 3, q)),
+                                precomp_success_flag
+                            )
                         }
                         // accumulator = accumulator + scalar[45] * gemini_fold_univariates[8]
                         mcopy(G1_LOCATION, GEMINI_FOLD_UNIVARIATE_8_X_LOC, 0x40)
                         mstore(SCALAR_LOCATION, mload(BATCH_SCALAR_45_LOC))
-                        precomp_success_flag :=
-                            and(precomp_success_flag, staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40))
-                        precomp_success_flag :=
-                            and(precomp_success_flag, staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40))
+                        precomp_success_flag := and(
+                            precomp_success_flag,
+                            staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40)
+                        )
+                        precomp_success_flag := and(
+                            precomp_success_flag,
+                            staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40)
+                        )
 
                         {
                             let x := mload(GEMINI_FOLD_UNIVARIATE_9_X_LOC)
                             let y := mload(GEMINI_FOLD_UNIVARIATE_9_Y_LOC)
                             let xx := mulmod(x, x, q)
                             // validate on curve
-                            precomp_success_flag :=
-                                and(eq(mulmod(y, y, q), addmod(mulmod(x, xx, q), 3, q)), precomp_success_flag)
+                            precomp_success_flag := and(
+                                eq(mulmod(y, y, q), addmod(mulmod(x, xx, q), 3, q)),
+                                precomp_success_flag
+                            )
                         }
                         // accumulator = accumulator + scalar[46] * gemini_fold_univariates[9]
                         mcopy(G1_LOCATION, GEMINI_FOLD_UNIVARIATE_9_X_LOC, 0x40)
                         mstore(SCALAR_LOCATION, mload(BATCH_SCALAR_46_LOC))
-                        precomp_success_flag :=
-                            and(precomp_success_flag, staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40))
-                        precomp_success_flag :=
-                            and(precomp_success_flag, staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40))
+                        precomp_success_flag := and(
+                            precomp_success_flag,
+                            staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40)
+                        )
+                        precomp_success_flag := and(
+                            precomp_success_flag,
+                            staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40)
+                        )
 
                         {
                             let x := mload(GEMINI_FOLD_UNIVARIATE_10_X_LOC)
                             let y := mload(GEMINI_FOLD_UNIVARIATE_10_Y_LOC)
                             let xx := mulmod(x, x, q)
                             // validate on curve
-                            precomp_success_flag :=
-                                and(eq(mulmod(y, y, q), addmod(mulmod(x, xx, q), 3, q)), precomp_success_flag)
+                            precomp_success_flag := and(
+                                eq(mulmod(y, y, q), addmod(mulmod(x, xx, q), 3, q)),
+                                precomp_success_flag
+                            )
                         }
                         // accumulator = accumulator + scalar[47] * gemini_fold_univariates[10]
                         mcopy(G1_LOCATION, GEMINI_FOLD_UNIVARIATE_10_X_LOC, 0x40)
                         mstore(SCALAR_LOCATION, mload(BATCH_SCALAR_47_LOC))
-                        precomp_success_flag :=
-                            and(precomp_success_flag, staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40))
-                        precomp_success_flag :=
-                            and(precomp_success_flag, staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40))
+                        precomp_success_flag := and(
+                            precomp_success_flag,
+                            staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40)
+                        )
+                        precomp_success_flag := and(
+                            precomp_success_flag,
+                            staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40)
+                        )
                     }
 
                     {
@@ -4197,48 +4568,66 @@ contract BlakeOptHonkVerifier is IVerifier {
                             let y := mload(GEMINI_FOLD_UNIVARIATE_11_Y_LOC)
                             let xx := mulmod(x, x, q)
                             // validate on curve
-                            precomp_success_flag :=
-                                and(eq(mulmod(y, y, q), addmod(mulmod(x, xx, q), 3, q)), precomp_success_flag)
+                            precomp_success_flag := and(
+                                eq(mulmod(y, y, q), addmod(mulmod(x, xx, q), 3, q)),
+                                precomp_success_flag
+                            )
                         }
                         // accumulator = accumulator + scalar[48] * gemini_fold_univariates[11]
                         mcopy(G1_LOCATION, GEMINI_FOLD_UNIVARIATE_11_X_LOC, 0x40)
                         mstore(SCALAR_LOCATION, mload(BATCH_SCALAR_48_LOC))
-                        precomp_success_flag :=
-                            and(precomp_success_flag, staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40))
-                        precomp_success_flag :=
-                            and(precomp_success_flag, staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40))
+                        precomp_success_flag := and(
+                            precomp_success_flag,
+                            staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40)
+                        )
+                        precomp_success_flag := and(
+                            precomp_success_flag,
+                            staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40)
+                        )
 
                         {
                             let x := mload(GEMINI_FOLD_UNIVARIATE_12_X_LOC)
                             let y := mload(GEMINI_FOLD_UNIVARIATE_12_Y_LOC)
                             let xx := mulmod(x, x, q)
                             // validate on curve
-                            precomp_success_flag :=
-                                and(eq(mulmod(y, y, q), addmod(mulmod(x, xx, q), 3, q)), precomp_success_flag)
+                            precomp_success_flag := and(
+                                eq(mulmod(y, y, q), addmod(mulmod(x, xx, q), 3, q)),
+                                precomp_success_flag
+                            )
                         }
                         // accumulator = accumulator + scalar[49] * gemini_fold_univariates[12]
                         mcopy(G1_LOCATION, GEMINI_FOLD_UNIVARIATE_12_X_LOC, 0x40)
                         mstore(SCALAR_LOCATION, mload(BATCH_SCALAR_49_LOC))
-                        precomp_success_flag :=
-                            and(precomp_success_flag, staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40))
-                        precomp_success_flag :=
-                            and(precomp_success_flag, staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40))
+                        precomp_success_flag := and(
+                            precomp_success_flag,
+                            staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40)
+                        )
+                        precomp_success_flag := and(
+                            precomp_success_flag,
+                            staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40)
+                        )
 
                         {
                             let x := mload(GEMINI_FOLD_UNIVARIATE_13_X_LOC)
                             let y := mload(GEMINI_FOLD_UNIVARIATE_13_Y_LOC)
                             let xx := mulmod(x, x, q)
                             // validate on curve
-                            precomp_success_flag :=
-                                and(eq(mulmod(y, y, q), addmod(mulmod(x, xx, q), 3, q)), precomp_success_flag)
+                            precomp_success_flag := and(
+                                eq(mulmod(y, y, q), addmod(mulmod(x, xx, q), 3, q)),
+                                precomp_success_flag
+                            )
                         }
                         // accumulator = accumulator + scalar[50] * gemini_fold_univariates[13]
                         mcopy(G1_LOCATION, GEMINI_FOLD_UNIVARIATE_13_X_LOC, 0x40)
                         mstore(SCALAR_LOCATION, mload(BATCH_SCALAR_50_LOC))
-                        precomp_success_flag :=
-                            and(precomp_success_flag, staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40))
-                        precomp_success_flag :=
-                            and(precomp_success_flag, staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40))
+                        precomp_success_flag := and(
+                            precomp_success_flag,
+                            staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40)
+                        )
+                        precomp_success_flag := and(
+                            precomp_success_flag,
+                            staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40)
+                        )
 
                         /// {{ UNROLL_SECTION_END ACCUMULATE_GEMINI_FOLD_UNIVARIATE }}
                     }
@@ -4250,10 +4639,14 @@ contract BlakeOptHonkVerifier is IVerifier {
                     mstore(G1_LOCATION, 0x01)
                     mstore(G1_Y_LOCATION, 0x02)
                     mstore(SCALAR_LOCATION, constant_term_acc)
-                    precomp_success_flag :=
-                        and(precomp_success_flag, staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40))
-                    precomp_success_flag :=
-                        and(precomp_success_flag, staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40))
+                    precomp_success_flag := and(
+                        precomp_success_flag,
+                        staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40)
+                    )
+                    precomp_success_flag := and(
+                        precomp_success_flag,
+                        staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40)
+                    )
 
                     // Accumlate final quotient commitment into shplonk check
                     // Accumulator = accumulator + shplonkZ * quotient commitment
@@ -4262,16 +4655,22 @@ contract BlakeOptHonkVerifier is IVerifier {
                         let y := mload(KZG_QUOTIENT_Y_LOC)
                         let xx := mulmod(x, x, q)
                         // validate on curve
-                        precomp_success_flag :=
-                            and(eq(mulmod(y, y, q), addmod(mulmod(x, xx, q), 3, q)), precomp_success_flag)
+                        precomp_success_flag := and(
+                            eq(mulmod(y, y, q), addmod(mulmod(x, xx, q), 3, q)),
+                            precomp_success_flag
+                        )
                     }
                     mcopy(G1_LOCATION, KZG_QUOTIENT_X_LOC, 0x40)
 
                     mstore(SCALAR_LOCATION, mload(SHPLONK_Z_CHALLENGE))
-                    precomp_success_flag :=
-                        and(precomp_success_flag, staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40))
-                    precomp_success_flag :=
-                        and(precomp_success_flag, staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40))
+                    precomp_success_flag := and(
+                        precomp_success_flag,
+                        staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR_2, 0x40)
+                    )
+                    precomp_success_flag := and(
+                        precomp_success_flag,
+                        staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40)
+                    )
                 }
 
                 if iszero(precomp_success_flag) {

--- a/barretenberg/sol/src/honk/utils.sol
+++ b/barretenberg/sol/src/honk/utils.sol
@@ -34,8 +34,7 @@ function bytesToFr(bytes calldata proofSection) pure returns (Fr scalar) {
 // EC Point utilities
 function bytesToG1Point(bytes calldata proofSection) pure returns (Honk.G1Point memory point) {
     point = Honk.G1Point({
-        x: uint256(bytes32(proofSection[0x00:0x20])) % Q,
-        y: uint256(bytes32(proofSection[0x20:0x40])) % Q
+        x: uint256(bytes32(proofSection[0x00:0x20])) % Q, y: uint256(bytes32(proofSection[0x20:0x40])) % Q
     });
 }
 

--- a/barretenberg/sol/test/base/TestBase.sol
+++ b/barretenberg/sol/test/base/TestBase.sol
@@ -47,7 +47,12 @@ contract TestBase is Test {
         assembly {
             pop(
                 staticcall(
-                    gas(), 0x4, add(_proofData, add(0x20, mul(0x20, _numberOfPublicInputs))), len, add(proof, 0x20), len
+                    gas(),
+                    0x4,
+                    add(_proofData, add(0x20, mul(0x20, _numberOfPublicInputs))),
+                    len,
+                    add(proof, 0x20),
+                    len
                 )
             )
         }
@@ -71,7 +76,12 @@ contract TestBase is Test {
         assembly {
             pop(
                 staticcall(
-                    gas(), 0x4, add(_proofData, add(0x20, mul(0x20, _numberOfPublicInputs))), len, add(proof, 0x20), len
+                    gas(),
+                    0x4,
+                    add(_proofData, add(0x20, mul(0x20, _numberOfPublicInputs))),
+                    len,
+                    add(proof, 0x20),
+                    len
                 )
             )
         }


### PR DESCRIPTION
BlakeOptTest was failing after commit ee1187a (biggroup cleanup) due to
stale VK values in blake-opt.sol. The hand-optimized verifier had outdated
VK_HASH and polynomial commitments that didn't match the generated VK.

Changes:
- Update blake-opt.sol with current VK values from BlakeHonkVerificationKey.sol
- Add sync_blake_opt_vk.sh script to automatically extract and update ALL VK
  fields from generated VK to optimized verifier:
  * Circuit parameters (VK_HASH, CIRCUIT_SIZE, LOG_N, etc.)
  * Q polynomial commitments (14 selectors)
  * SIGMA polynomial commitments (4 permutation polynomials)
  * TABLE polynomial commitments (4 lookup tables)
  * ID polynomial commitments (4 identity polynomials)
  * Lagrange polynomial commitments (first/last)
- Update init_honk.sh to automatically call sync script after VK generation
- Sync script is idempotent - exits early if VK_HASH already matches
- Code formatting after sol bootstrapping

This ensures blake-opt.sol stays in sync when VK structure changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

Please read [contributing guidelines](CONTRIBUTING.md) and remove this line.

For audit-related pull requests, please use the [audit PR template](?expand=1&template=audit.md).
