### PR TITLE
feat!: C++ to TS serialization changes

### DIFF
--- a/barretenberg/cpp/src/barretenberg/nodejs_module/avm_simulate/avm_simulate_napi.cpp
+++ b/barretenberg/cpp/src/barretenberg/nodejs_module/avm_simulate/avm_simulate_napi.cpp
@@ -101,8 +101,8 @@ struct ContractCallbacks {
 Napi::Value AvmSimulateNapi::simulate(const Napi::CallbackInfo& cb_info)
 {
     // TODO(dbanks12): configurable verbosity (maybe based on TS log level)
-    verbose_logging = true;
-    debug_logging = true;
+    // verbose_logging = true;
+    // debug_logging = true;
 
     Napi::Env env = cb_info.Env();
 

--- a/barretenberg/cpp/src/barretenberg/serialize/msgpack_impl/uint_128_t_adaptor.hpp
+++ b/barretenberg/cpp/src/barretenberg/serialize/msgpack_impl/uint_128_t_adaptor.hpp
@@ -2,6 +2,7 @@
 
 #include <msgpack.hpp>
 
+#include "barretenberg/common/log.hpp"
 #include "barretenberg/common/throw_or_abort.hpp"
 #include "barretenberg/numeric/uint128/uint128.hpp"
 
@@ -11,9 +12,11 @@ namespace msgpack::adaptor {
 template <> struct pack<uint128_t> {
     template <typename Stream> msgpack::packer<Stream>& operator()(msgpack::packer<Stream>& o, uint128_t const& v) const
     {
-        // Use the bin format for 16 bytes of data
-        o.pack_bin(16);
-        o.pack_bin_body(reinterpret_cast<const char*>(&v), 16);
+        // Convert to string and pack as a string.
+        // TODO(fcarreiro): Consider the bin format for 16 bytes of data for speed.
+        std::string str = format(v);
+        o.pack_str(static_cast<uint32_t>(str.size()));
+        o.pack_str_body(str.c_str(), static_cast<uint32_t>(str.size()));
         return o;
     }
 };

--- a/yarn-project/aztec.js/src/utils/authwit.ts
+++ b/yarn-project/aztec.js/src/utils/authwit.ts
@@ -22,7 +22,7 @@ export type IntentInnerHash = {
   /** The consumer   */
   consumer: AztecAddress;
   /** The action to approve */
-  innerHash: Buffer<ArrayBuffer> | Fr;
+  innerHash: Buffer | Fr;
 };
 
 /** Intent with a call */

--- a/yarn-project/aztec.js/src/utils/authwit.ts
+++ b/yarn-project/aztec.js/src/utils/authwit.ts
@@ -22,7 +22,7 @@ export type IntentInnerHash = {
   /** The consumer   */
   consumer: AztecAddress;
   /** The action to approve */
-  innerHash: Buffer | Fr;
+  innerHash: Fr;
 };
 
 /** Intent with a call */
@@ -43,7 +43,7 @@ export type ContractFunctionInteractionCallIntent = {
 
 /** Identifies ContractFunctionInteractionCallIntents */
 function isContractFunctionIntractionCallIntent(
-  messageHashOrIntent: Fr | Buffer | IntentInnerHash | CallIntent | ContractFunctionInteractionCallIntent,
+  messageHashOrIntent: Fr | IntentInnerHash | CallIntent | ContractFunctionInteractionCallIntent,
 ): messageHashOrIntent is ContractFunctionInteractionCallIntent {
   return (
     'caller' in messageHashOrIntent &&
@@ -102,14 +102,12 @@ export const computeAuthWitMessageHash = async (
  * @returns The message hash for the intent
  */
 export async function getMessageHashFromIntent(
-  messageHashOrIntent: Fr | Buffer | IntentInnerHash | CallIntent | ContractFunctionInteractionCallIntent,
+  messageHashOrIntent: Fr | IntentInnerHash | CallIntent | ContractFunctionInteractionCallIntent,
   chainInfo: ChainInfo,
 ) {
   let messageHash: Fr;
   const { chainId, version } = chainInfo;
-  if (Buffer.isBuffer(messageHashOrIntent)) {
-    messageHash = Fr.fromBuffer(messageHashOrIntent);
-  } else if (messageHashOrIntent instanceof Fr) {
+  if (messageHashOrIntent instanceof Fr) {
     messageHash = messageHashOrIntent;
   } else {
     messageHash = await computeAuthWitMessageHash(messageHashOrIntent, { chainId, version });
@@ -159,9 +157,6 @@ export async function lookupValidity(
     const call = isContractFunctionIntractionCallIntent(intent) ? await intent.action.getFunctionCall() : intent.call;
     innerHash = await computeInnerAuthWitHashFromAction(intent.caller, call);
     consumer = call.to;
-  } else if (Buffer.isBuffer(intent.innerHash)) {
-    innerHash = Fr.fromBuffer(intent.innerHash);
-    consumer = intent.consumer;
   } else {
     ({ innerHash, consumer } = intent);
   }
@@ -240,7 +235,7 @@ export class SetPublicAuthwitContractInteraction extends ContractFunctionInterac
   static async create(
     wallet: Wallet,
     from: AztecAddress,
-    messageHashOrIntent: Fr | Buffer | IntentInnerHash | CallIntent | ContractFunctionInteractionCallIntent,
+    messageHashOrIntent: Fr | IntentInnerHash | CallIntent | ContractFunctionInteractionCallIntent,
     authorized: boolean,
   ) {
     const chainInfo = await wallet.getChainInfo();

--- a/yarn-project/aztec.js/src/wallet/base_wallet.ts
+++ b/yarn-project/aztec.js/src/wallet/base_wallet.ts
@@ -124,7 +124,7 @@ export abstract class BaseWallet implements Wallet {
 
   public async createAuthWit(
     from: AztecAddress,
-    messageHashOrIntent: Fr | Buffer | IntentInnerHash | CallIntent,
+    messageHashOrIntent: Fr | IntentInnerHash | CallIntent,
   ): Promise<AuthWitness> {
     const account = await this.getAccountFromAddress(from);
     return account.createAuthWit(messageHashOrIntent);

--- a/yarn-project/aztec.js/src/wallet/wallet.ts
+++ b/yarn-project/aztec.js/src/wallet/wallet.ts
@@ -185,10 +185,7 @@ export type Wallet = {
   ): Promise<UtilitySimulationResult>;
   profileTx(exec: ExecutionPayload, opts: ProfileOptions): Promise<TxProfileResult>;
   sendTx(exec: ExecutionPayload, opts: SendOptions): Promise<TxHash>;
-  createAuthWit(
-    from: AztecAddress,
-    messageHashOrIntent: Fr | Buffer | IntentInnerHash | CallIntent,
-  ): Promise<AuthWitness>;
+  createAuthWit(from: AztecAddress, messageHashOrIntent: Fr | IntentInnerHash | CallIntent): Promise<AuthWitness>;
   batch<const T extends readonly BatchedMethod<keyof BatchableMethods>[]>(methods: T): Promise<BatchResults<T>>;
 };
 
@@ -267,8 +264,7 @@ export const InstanceDataSchema = z.union([
 
 export const MessageHashOrIntentSchema = z.union([
   schemas.Fr,
-  schemas.Buffer,
-  z.object({ consumer: schemas.AztecAddress, innerHash: z.union([schemas.Buffer, schemas.Fr]) }),
+  z.object({ consumer: schemas.AztecAddress, innerHash: schemas.Fr }),
   z.object({
     caller: schemas.AztecAddress,
     call: FunctionCallSchema,

--- a/yarn-project/aztec.js/src/wallet/wallet.ts
+++ b/yarn-project/aztec.js/src/wallet/wallet.ts
@@ -187,7 +187,7 @@ export type Wallet = {
   sendTx(exec: ExecutionPayload, opts: SendOptions): Promise<TxHash>;
   createAuthWit(
     from: AztecAddress,
-    messageHashOrIntent: Fr | Buffer<ArrayBuffer> | IntentInnerHash | CallIntent,
+    messageHashOrIntent: Fr | Buffer | IntentInnerHash | CallIntent,
   ): Promise<AuthWitness>;
   batch<const T extends readonly BatchedMethod<keyof BatchableMethods>[]>(methods: T): Promise<BatchResults<T>>;
 };

--- a/yarn-project/foundation/src/eth-address/index.ts
+++ b/yarn-project/foundation/src/eth-address/index.ts
@@ -1,4 +1,5 @@
 import { inspect } from 'util';
+import { z } from 'zod';
 
 import { keccak256String } from '../crypto/keccak/index.js';
 import { randomBytes } from '../crypto/random/index.js';
@@ -240,7 +241,12 @@ export class EthAddress {
   }
 
   static get schema() {
-    return hexSchemaFor(EthAddress, EthAddress.isAddress);
+    return z.union([
+      // Serialization from hex string.
+      hexSchemaFor(EthAddress, EthAddress.isAddress),
+      // Serialization from buffer.
+      Fr.schema.transform(EthAddress.fromField),
+    ]);
   }
 }
 

--- a/yarn-project/foundation/src/fields/fields.test.ts
+++ b/yarn-project/foundation/src/fields/fields.test.ts
@@ -103,6 +103,22 @@ describe('GrumpkinScalar Serialization', () => {
   });
 });
 
+describe('Fr Serialization via schema', () => {
+  it('should serialize and deserialize correctly (hex)', () => {
+    const original = Fr.random();
+    const string = original.toString();
+    const obtained = Fr.schema.parse(string);
+    expect(obtained).toEqual(original);
+  });
+
+  it('should serialize and deserialize correctly (buffer)', () => {
+    const original = Fr.random();
+    const buffer = original.toBuffer();
+    const obtained = Fr.schema.parse(buffer);
+    expect(obtained).toEqual(original);
+  });
+});
+
 describe('Bn254 arithmetic', () => {
   describe('Addition', () => {
     it('Low Boundary', () => {

--- a/yarn-project/foundation/src/fields/fields.ts
+++ b/yarn-project/foundation/src/fields/fields.ts
@@ -1,10 +1,11 @@
 import { BarretenbergSync } from '@aztec/bb.js';
 
 import { inspect } from 'util';
+import { z } from 'zod';
 
 import { toBigIntBE, toBufferBE } from '../bigint-buffer/index.js';
 import { randomBytes } from '../crypto/random/index.js';
-import { hexSchemaFor } from '../schemas/utils.js';
+import { bufferSchemaFor, hexSchemaFor } from '../schemas/utils.js';
 import { BufferReader } from '../serialize/buffer_reader.js';
 import { TypeRegistry } from '../serialize/type_registry.js';
 
@@ -336,7 +337,12 @@ export class Fr extends BaseField {
   }
 
   static get schema() {
-    return hexSchemaFor(Fr);
+    return z.union([
+      // Serialization from MessagePack as a buffer.
+      bufferSchemaFor(Fr),
+      // Serialization from hex string.
+      hexSchemaFor(Fr),
+    ]);
   }
 }
 

--- a/yarn-project/foundation/src/fields/fields.ts
+++ b/yarn-project/foundation/src/fields/fields.ts
@@ -338,10 +338,10 @@ export class Fr extends BaseField {
 
   static get schema() {
     return z.union([
-      // Serialization from MessagePack as a buffer.
-      bufferSchemaFor(Fr),
       // Serialization from hex string.
       hexSchemaFor(Fr),
+      // Serialization from MessagePack as a buffer.
+      bufferSchemaFor(Fr, buf => buf.length === BaseField.SIZE_IN_BYTES),
     ]);
   }
 }

--- a/yarn-project/foundation/src/fields/point.ts
+++ b/yarn-project/foundation/src/fields/point.ts
@@ -1,3 +1,5 @@
+import z from 'zod';
+
 import { toBigIntBE } from '../bigint-buffer/index.js';
 import { poseidon2Hash } from '../crypto/poseidon/index.js';
 import { randomBoolean } from '../crypto/random/index.js';
@@ -42,7 +44,17 @@ export class Point {
   }
 
   static get schema() {
-    return hexSchemaFor(Point);
+    return z.union([
+      // Serialization from hex string.
+      hexSchemaFor(Point),
+      // Serialization from MessagePack.
+      z
+        .object({
+          x: Fr.schema,
+          y: Fr.schema,
+        })
+        .transform(({ x, y }) => new Point(x, y, false)),
+    ]);
   }
 
   /**

--- a/yarn-project/foundation/src/schemas/schemas.ts
+++ b/yarn-project/foundation/src/schemas/schemas.ts
@@ -54,15 +54,7 @@ export const schemas = {
   Buffer32: z.string().refine(isHex, 'Not a valid hex string').transform(Buffer32.fromString),
 
   /** Accepts a base64 string or an object `{ type: 'Buffer', data: [byte, byte...] }` as a buffer. */
-  Buffer: z.union([
-    bufferSchema,
-    z
-      .object({
-        type: z.literal('Buffer'),
-        data: z.array(z.number().int().min(0).max(255)),
-      })
-      .transform(({ data }) => Buffer.from(data)),
-  ]),
+  Buffer: bufferSchema,
 
   /** Accepts a hex string as a buffer. */
   BufferHex: z

--- a/yarn-project/foundation/src/schemas/utils.ts
+++ b/yarn-project/foundation/src/schemas/utils.ts
@@ -100,12 +100,13 @@ export function hexSchemaFor<TClass extends { fromString(str: string): any } | {
  */
 export function bufferSchemaFor<TClass extends { fromBuffer(buf: Buffer): any }>(
   klazz: TClass,
+  refinement?: (buf: Buffer) => boolean,
 ): ZodType<
   TClass extends { fromBuffer(buf: Buffer): infer TInstance } ? ToJsonIs<TInstance, Buffer> : never,
   any,
   string
 > {
-  return bufferSchema.transform(klazz.fromBuffer.bind(klazz));
+  return bufferSchema.refine(refinement ?? (() => true), 'Not a valid buffer').transform(klazz.fromBuffer.bind(klazz));
 }
 
 /** Creates a schema for a js Map type that matches the serialization used in jsonStringify. */

--- a/yarn-project/foundation/src/schemas/utils.ts
+++ b/yarn-project/foundation/src/schemas/utils.ts
@@ -21,13 +21,25 @@ export const hexSchema = z.string().refine(isHex, 'Not a valid hex string').tran
 // Copied from zod internals, which was copied from https://stackoverflow.com/questions/7860392/determine-if-string-is-in-base64-using-javascript
 const base64Regex = /^([0-9a-zA-Z+/]{4})*(([0-9a-zA-Z+/]{2}==)|([0-9a-zA-Z+/]{3}=))?$/;
 
-/** Schema for a buffer represented as a base64 string. */
-export const bufferSchema = z
-  .string()
-  // We only test the str for base64 if it's shorter than 1024 bytes, otherwise we've run into maximum
-  // stack size exceeded errors when trying to validate excessively long strings (such as contract bytecode).
-  .refine(str => str.length > 1024 || base64Regex.test(str), 'Not a valid base64 string')
-  .transform(data => Buffer.from(data, 'base64'));
+/** Schema for a buffer represented as a base64 string or a Buffer object. */
+export const bufferSchema: ZodFor<Buffer> = z.union([
+  // Serialization from base64 string.
+  z
+    .string()
+    // We only test the str for base64 if it's shorter than 1024 bytes, otherwise we've run into maximum
+    // stack size exceeded errors when trying to validate excessively long strings (such as contract bytecode).
+    .refine(str => str.length > 1024 || base64Regex.test(str), 'Not a valid base64 string')
+    .transform(data => Buffer.from(data, 'base64')),
+  // Serialization from Buffer-annotated object.
+  z
+    .object({
+      type: z.literal('Buffer'),
+      data: z.array(z.number().int().min(0).max(255)),
+    })
+    .transform(({ data }) => Buffer.from(data)),
+  // Serialization from Buffer
+  z.instanceof(Buffer),
+]);
 
 export class ZodNullableOptional<T extends ZodTypeAny> extends ZodOptional<T> {
   _isNullableOptional = true;

--- a/yarn-project/stdlib/src/avm/avm.test.ts
+++ b/yarn-project/stdlib/src/avm/avm.test.ts
@@ -34,13 +34,13 @@ describe('Avm circuit inputs', () => {
     expect(buffer.equals(expected)).toBe(true);
   });
 
-  // TODO(fcarreiro): fix this test.
-  it.skip('serializes with MP and deserializes it back', async () => {
+  // This is a minimal requirement. It only tests that the MP serialization from TS
+  // works, but it doesn't say much about the C++ MP serialization.
+  it('serializes with MessagePack and deserializes it back', async () => {
     const avmCircuitInputs = await makeAvmCircuitInputs(/*seed=*/ 0x1234);
     const buffer = avmCircuitInputs.serializeWithMessagePack();
     const json = deserializeFromMessagePack(buffer);
-    // Parsing fails.
     const res = AvmCircuitInputs.schema.parse(json);
-    expect(res).toStrictEqual(avmCircuitInputs);
+    expect(res).toEqual(avmCircuitInputs);
   });
 });

--- a/yarn-project/stdlib/src/avm/avm.ts
+++ b/yarn-project/stdlib/src/avm/avm.ts
@@ -5,16 +5,16 @@ import { z } from 'zod';
 
 import { AztecAddress } from '../aztec-address/index.js';
 import { AllContractDeploymentData, ContractDeploymentData } from '../contract/index.js';
-import type { SimulationError } from '../errors/simulation_error.js';
+import { SimulationError } from '../errors/simulation_error.js';
 import { computeEffectiveGasFees } from '../fees/transaction_fee.js';
 import { Gas } from '../gas/gas.js';
 import { GasFees } from '../gas/gas_fees.js';
 import { GasSettings } from '../gas/gas_settings.js';
 import type { GasUsed } from '../gas/gas_used.js';
 import { PublicKeys } from '../keys/public_keys.js';
-import type { DebugLog } from '../logs/debug_log.js';
+import { DebugLog } from '../logs/debug_log.js';
 import { ScopedL2ToL1Message } from '../messaging/l2_to_l1_message.js';
-import { schemas } from '../schemas/schemas.js';
+import { NullishToUndefined, type ZodFor, schemas } from '../schemas/schemas.js';
 import { AppendOnlyTreeSnapshot } from '../trees/append_only_tree_snapshot.js';
 import { MerkleTreeId } from '../trees/merkle_tree_id.js';
 import { NullifierLeafPreimage } from '../trees/nullifier_leaf.js';
@@ -746,48 +746,31 @@ export class PublicTxResult {
     );
   }
 
-  /*
   static get schema(): ZodFor<PublicTxResult> {
     return z
       .object({
         gasUsed: schemas.GasUsed,
         revertCode: RevertCode.schema,
-        revertReason: SimulationError.schema.optional(),
-        appLogicReturnValue: Fr.schema.array().optional(),
-        logs: DebugLog.schema.array(),
-        hints: AvmExecutionHints.schema.optional(),
+        revertReason: NullishToUndefined(SimulationError.schema),
+        // TODO(fcarreiro): Use actual Phases type schema.
+        processedPhases: NullishToUndefined(z.any().array()),
+        logs: NullishToUndefined(DebugLog.schema.array()),
+        // For the proving request.
         publicInputs: AvmCircuitPublicInputs.schema,
+        hints: NullishToUndefined(AvmExecutionHints.schema),
       })
       .transform(
-        ({ gasUsed, revertCode, revertReason, appLogicReturnValue, logs, hints, publicInputs }) =>
+        ({ gasUsed, revertCode, revertReason, processedPhases, logs, hints, publicInputs }) =>
           new PublicTxResult(
             gasUsed,
             revertCode as RevertCode,
             revertReason,
-            appLogicReturnValue,
+            processedPhases,
             logs,
             hints,
             publicInputs,
           ),
       );
-  }*/
-
-  // TODO(fcarreiro): complete this.
-  static get partialSchema() {
-    return z.object({
-      gasUsed: schemas.GasUsed,
-      revertCode: RevertCode.schema,
-    });
-  }
-  static fromJSON(json: any) {
-    // console.log('json', json);
-    // console.log('PI.globalVariables.gasFees', json.publicInputs.globalVariables.gasFees);
-    const r = PublicTxResult.partialSchema.parse(json);
-    // console.log('after parse', r);
-    return r as {
-      gasUsed: GasUsed;
-      revertCode: RevertCode;
-    };
   }
 }
 

--- a/yarn-project/stdlib/src/aztec-address/index.ts
+++ b/yarn-project/stdlib/src/aztec-address/index.ts
@@ -142,7 +142,7 @@ export class AztecAddress {
       // Serialization from hex string.
       hexSchemaFor(AztecAddress, AztecAddress.isAddress),
       // Serialization from buffer.
-      bufferSchemaFor(AztecAddress),
+      bufferSchemaFor(AztecAddress, buf => buf.length === 32),
     ]);
   }
 }

--- a/yarn-project/stdlib/src/aztec-address/index.ts
+++ b/yarn-project/stdlib/src/aztec-address/index.ts
@@ -1,10 +1,11 @@
 /* eslint-disable @typescript-eslint/no-unsafe-declaration-merging */
 import { Fr, Point, fromBuffer } from '@aztec/foundation/fields';
-import { type ZodFor, hexSchemaFor } from '@aztec/foundation/schemas';
+import { type ZodFor, bufferSchemaFor, hexSchemaFor } from '@aztec/foundation/schemas';
 import { type BufferReader, FieldReader, TypeRegistry } from '@aztec/foundation/serialize';
 import { hexToBuffer } from '@aztec/foundation/string';
 
 import { inspect } from 'util';
+import { z } from 'zod';
 
 /** Branding to ensure fields are not interchangeable types. */
 export interface AztecAddress {
@@ -137,7 +138,12 @@ export class AztecAddress {
   }
 
   static get schema(): ZodFor<AztecAddress> {
-    return hexSchemaFor(AztecAddress, AztecAddress.isAddress);
+    return z.union([
+      // Serialization from hex string.
+      hexSchemaFor(AztecAddress, AztecAddress.isAddress),
+      // Serialization from buffer.
+      bufferSchemaFor(AztecAddress),
+    ]);
   }
 }
 

--- a/yarn-project/stdlib/src/schemas/schemas.ts
+++ b/yarn-project/stdlib/src/schemas/schemas.ts
@@ -81,6 +81,9 @@ export const AbiDecodedSchema: ZodFor<AbiDecoded> = z.union([
   z.record(z.lazy(() => AbiDecodedSchema)),
 ]);
 
+// C++ only supports null values, which we want to convert to undefined.
+export const NullishToUndefined = (schema: ZodFor<any>) => schema.nullish().transform(x => x ?? undefined);
+
 export {
   type ZodFor,
   bufferSchema,

--- a/yarn-project/test-wallet/src/wallet/test_wallet.ts
+++ b/yarn-project/test-wallet/src/wallet/test_wallet.ts
@@ -162,7 +162,7 @@ export abstract class BaseTestWallet extends BaseWallet {
    */
   public setPublicAuthWit(
     from: AztecAddress,
-    messageHashOrIntent: Fr | Buffer | IntentInnerHash | CallIntent | ContractFunctionInteractionCallIntent,
+    messageHashOrIntent: Fr | IntentInnerHash | CallIntent | ContractFunctionInteractionCallIntent,
     authorized: boolean,
   ): Promise<SetPublicAuthwitContractInteraction> {
     return SetPublicAuthwitContractInteraction.create(this, from, messageHashOrIntent, authorized);
@@ -177,7 +177,7 @@ export abstract class BaseTestWallet extends BaseWallet {
    */
   public override async createAuthWit(
     from: AztecAddress,
-    messageHashOrIntent: Fr | Buffer | IntentInnerHash | CallIntent | ContractFunctionInteractionCallIntent,
+    messageHashOrIntent: Fr | IntentInnerHash | CallIntent | ContractFunctionInteractionCallIntent,
   ): Promise<AuthWitness> {
     const account = await this.getAccountFromAddress(from);
     const chainInfo = await this.getChainInfo();


### PR DESCRIPTION
Changes needed to have Zod schemas support objects that come from MessagePack serialization.

Now we are serializing things from C++ and deserializing them back to TS using MP+Zod.

Gotchas:
* MP is fast both ways (single digit ms)
* Zod is terribly slow (~300ms)
* I'm using `any` and some dummy types that we are not (de)serializing yet.