### PR TITLE
fix: Fix usage of `add_to_witness_and_track_indices`

### DIFF
--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/ecdsa_constraints.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/ecdsa_constraints.test.cpp
@@ -134,19 +134,19 @@ template <class Curve> class EcdsaTestingFunctions {
 
         // Create witness indices and witnesses
         std::array<uint32_t, 32> hashed_message_indices =
-            add_to_witness_and_track_indices<uint8_t, 32>(witness_values, std::span(hashed_message));
+            add_to_witness_and_track_indices<std::span<uint8_t>, 32>(witness_values, std::span(hashed_message));
 
         std::array<uint32_t, 32> pub_x_indices =
-            add_to_witness_and_track_indices<uint8_t, 32>(witness_values, std::span(buffer_x));
+            add_to_witness_and_track_indices<std::span<uint8_t>, 32>(witness_values, std::span(buffer_x));
 
         std::array<uint32_t, 32> pub_y_indices =
-            add_to_witness_and_track_indices<uint8_t, 32>(witness_values, std::span(buffer_y));
+            add_to_witness_and_track_indices<std::span<uint8_t>, 32>(witness_values, std::span(buffer_y));
 
         std::array<uint32_t, 32> r_indices =
-            add_to_witness_and_track_indices<uint8_t, 32>(witness_values, std::span(signature.r));
+            add_to_witness_and_track_indices<std::span<uint8_t>, 32>(witness_values, std::span(signature.r));
 
         std::array<uint32_t, 32> s_indices =
-            add_to_witness_and_track_indices<uint8_t, 32>(witness_values, std::span(signature.s));
+            add_to_witness_and_track_indices<std::span<uint8_t>, 32>(witness_values, std::span(signature.s));
 
         uint32_t result_index = add_to_witness_and_track_indices(witness_values, bb::fr(1));
 

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/utils.hpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/utils.hpp
@@ -106,7 +106,7 @@ inline uint32_t add_to_witness_and_track_indices(WitnessVector& witness, const b
  * @brief Add a span of values to the witness and track their indices, returning them as a fixed-size array.
  */
 template <typename T, size_t N>
-std::array<uint32_t, N> add_to_witness_and_track_indices(WitnessVector& witness, const std::span<T> input)
+std::array<uint32_t, N> add_to_witness_and_track_indices(WitnessVector& witness, const T& input)
 {
     std::vector<uint32_t> tracked_indices = add_to_witness_and_track_indices(witness, input);
     std::array<uint32_t, N> indices;

--- a/barretenberg/cpp/src/barretenberg/vm2/dsl/avm2_recursion_constraint.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/dsl/avm2_recursion_constraint.test.cpp
@@ -79,9 +79,9 @@ class AcirAvm2RecursionConstraint : public ::testing::Test {
             const std::vector<fr> public_inputs_witnesses = inner_circuit_data.public_inputs_flat;
 
             RecursionConstraint avm_recursion_constraint{
-                .key = add_to_witness_and_track_indices<bb::fr>(witness, key_witnesses),
-                .proof = add_to_witness_and_track_indices<bb::fr>(witness, proof_witnesses),
-                .public_inputs = add_to_witness_and_track_indices<bb::fr>(witness, public_inputs_witnesses),
+                .key = add_to_witness_and_track_indices(witness, key_witnesses),
+                .proof = add_to_witness_and_track_indices(witness, proof_witnesses),
+                .public_inputs = add_to_witness_and_track_indices(witness, public_inputs_witnesses),
                 .key_hash = 0, // not used
                 .proof_type = AVM,
             };


### PR DESCRIPTION
The new interface of `add_to_witness_and_track_indices` had a templating problem in the AVM tests. Fixed.