### PR TITLE
fix(bb): Improve VK check error handling to distinguish VK changes from other failures

### DIFF
--- a/barretenberg/cpp/scripts/test_chonk_standalone_vks_havent_changed.sh
+++ b/barretenberg/cpp/scripts/test_chonk_standalone_vks_havent_changed.sh
@@ -73,11 +73,33 @@ fi
 function check_circuit_vks {
   set -eu
   local flow_folder="$inputs_tmp_dir/$1"
+  local output
+  local exit_code=0
 
   if [[ "${2:-}" == "--update_inputs" ]]; then
-    $bb check --update_inputs --scheme chonk --ivc_inputs_path "$flow_folder/ivc-inputs.msgpack" || { echo_stderr "Error: Likely VK change detected in $flow_folder! Updating inputs."; exit 1; }
+    output=$($bb check --update_inputs --scheme chonk --ivc_inputs_path "$flow_folder/ivc-inputs.msgpack" 2>&1) || exit_code=$?
   else
-    $bb check --scheme chonk --ivc_inputs_path "$flow_folder/ivc-inputs.msgpack" || { echo_stderr "Error: Likely VK change detected in $flow_folder!"; exit 1; }
+    output=$($bb check --scheme chonk --ivc_inputs_path "$flow_folder/ivc-inputs.msgpack" 2>&1) || exit_code=$?
+  fi
+
+  if [[ $exit_code -ne 0 ]]; then
+    # Check if this is actually a VK change
+    if echo "$output" | grep -q "VK mismatch detected\|Expected precomputed vk"; then
+      echo_stderr "Error: VK change detected in $flow_folder!"
+      if [[ "${2:-}" == "--update_inputs" ]]; then
+        echo_stderr "Updating inputs with new VK."
+      fi
+      echo_stderr "$output"
+      exit 1
+    else
+      # Some other error occurred (file corruption, crash, etc.)
+      echo_stderr "Error: bb check failed in $flow_folder (not a VK change):"
+      echo_stderr "$output"
+      echo_stderr ""
+      echo_stderr "This indicates a bug or regression that is not related to VK changes."
+      echo_stderr "If this failure wasn't caught by other tests, please add a test case to prevent this regression."
+      exit 2
+    fi
   fi
 }
 
@@ -87,11 +109,32 @@ export -f check_circuit_vks
 ls "$inputs_tmp_dir"
 
 if [[ "${1:-}" == "--update_fast" ]]; then
-  parallel -v --line-buffer --tag check_circuit_vks {} --update_inputs ::: $(ls "$inputs_tmp_dir") \
-    && echo "No VK changes detected. Short hash is: ${pinned_short_hash}" \
-    || compress_and_upload $inputs_tmp_dir
+  exit_code=0
+  parallel -v --line-buffer --tag check_circuit_vks {} --update_inputs ::: $(ls "$inputs_tmp_dir") || exit_code=$?
+  if [[ $exit_code -eq 0 ]]; then
+    echo "No VK changes detected. Short hash is: ${pinned_short_hash}"
+  elif [[ $exit_code -eq 1 ]]; then
+    compress_and_upload $inputs_tmp_dir
+  else
+    echo_stderr "Error: bb check failed for reasons other than VK changes. See output above."
+    echo_stderr ""
+    echo_stderr "This indicates a bug or regression in bb check itself."
+    echo_stderr "If this wasn't caught by other tests, please add a test case to prevent this regression."
+    exit $exit_code
+  fi
 else
-  parallel -v --line-buffer --tag check_circuit_vks {} ::: $(ls "$inputs_tmp_dir") \
-    && echo "No VK changes detected. Short hash is: ${pinned_short_hash}" \
-    || (echo "VK changes detected. Please re-run the script with --update_fast or --update_inputs" && exit 1)
+  exit_code=0
+  parallel -v --line-buffer --tag check_circuit_vks {} ::: $(ls "$inputs_tmp_dir") || exit_code=$?
+  if [[ $exit_code -eq 0 ]]; then
+    echo "No VK changes detected. Short hash is: ${pinned_short_hash}"
+  elif [[ $exit_code -eq 1 ]]; then
+    echo "VK changes detected. Please re-run the script with --update_fast or --update_inputs"
+    exit 1
+  else
+    echo_stderr "Error: bb check failed for reasons other than VK changes. See output above."
+    echo_stderr ""
+    echo_stderr "This indicates a bug or regression in bb check itself."
+    echo_stderr "If this wasn't caught by other tests, please add a test case to prevent this regression."
+    exit $exit_code
+  fi
 fi

--- a/barretenberg/cpp/src/barretenberg/api/api_chonk.cpp
+++ b/barretenberg/cpp/src/barretenberg/api/api_chonk.cpp
@@ -162,9 +162,12 @@ bool ChonkAPI::check_precomputed_vks(const Flags& flags, const std::filesystem::
         }.execute();
 
         if (!response.valid) {
+            info("VK mismatch detected for function ", step.function_name);
             if (!flags.update_inputs) {
+                info("Computed VK differs from precomputed VK in ivc-inputs.msgpack");
                 return false;
             }
+            info("Updating VK in ivc-inputs.msgpack with computed value");
             step.vk = response.actual_vk;
             check_failed = true;
         }


### PR DESCRIPTION
## Summary
- Improve `bb check` error reporting to distinguish VK changes from other failures
- Add specific error messages when VK mismatches are detected
- Update test script to parse output and handle different error types appropriately

## Problem
Previously, the `bb check` command and test script reported "Likely VK change detected" for **any** failure, making it unclear whether the issue was:
- An actual VK change (needs updating) ✓
- File corruption ✗
- Binary crash ✗
- Memory issues ✗
- Other bugs/regressions ✗

## Solution

### C++ Changes (api_chonk.cpp)
Added clear error messages when VK mismatches occur:
- `"VK mismatch detected for function [name]"`
- `"Computed VK differs from precomputed VK in ivc-inputs.msgpack"`
- `"Updating VK in ivc-inputs.msgpack with computed value"` (when using --update_inputs)

### Shell Script Changes (test_chonk_standalone_vks_havent_changed.sh)
- Capture and parse `bb check` output
- Check for VK-specific error messages
- Exit with different codes:
  - Exit 1: VK change detected (original behavior)
  - Exit 2: Other failure (new - helps identify bugs)
- Show helpful messages reminding developers to add tests for non-VK failures

## Benefits
- Developers can immediately tell if they need to update VKs or fix a bug
- Clear error messages explain what went wrong
- Encourages better test coverage for regressions caught by this check
- Prevents confusion when non-VK issues are mistaken for protocol changes

## Test plan
- [x] Test with VK mismatch scenario
- [x] Test with missing VK scenario
- [x] Test with file corruption/other errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)