### PR TITLE
fix(l1): Revert if querying committee data for a future epoch

### DIFF
--- a/l1-contracts/src/core/Rollup.sol
+++ b/l1-contracts/src/core/Rollup.sol
@@ -123,6 +123,7 @@ contract Rollup is IStaking, IValidatorSelection, IRollup, RollupCore {
    * @param _ts - The timestamp to get the committee for
    *
    * @return The committee for the given timestamp
+   * @custom:reverts Errors.ValidatorSelection__EpochNotStable if the requested epoch is not stable
    */
   function getCommitteeAt(Timestamp _ts) external override(IValidatorSelection) returns (address[] memory) {
     return getEpochCommittee(getEpochAt(_ts));
@@ -135,6 +136,7 @@ contract Rollup is IStaking, IValidatorSelection, IRollup, RollupCore {
    *
    * @return The committee commitment for the given timestamp
    * @return The committee size for the given timestamp
+   * @custom:reverts Errors.ValidatorSelection__EpochNotStable if the requested epoch is not stable
    */
   function getCommitteeCommitmentAt(Timestamp _ts) external override(IValidatorSelection) returns (bytes32, uint256) {
     return ValidatorOperationsExtLib.getCommitteeCommitmentAt(getEpochAt(_ts));
@@ -147,6 +149,7 @@ contract Rollup is IStaking, IValidatorSelection, IRollup, RollupCore {
    *
    * @return The committee commitment for the given epoch
    * @return The committee size for the given epoch
+   * @custom:reverts Errors.ValidatorSelection__EpochNotStable if the requested epoch is not stable
    */
   function getEpochCommitteeCommitment(Epoch _epoch) external override(IValidatorSelection) returns (bytes32, uint256) {
     return ValidatorOperationsExtLib.getCommitteeCommitmentAt(_epoch);
@@ -172,6 +175,7 @@ contract Rollup is IStaking, IValidatorSelection, IRollup, RollupCore {
    *
    * @return uint256 - The slot at the given timestamp
    * @return uint256 - The block number at the given timestamp
+   * @custom:reverts Errors.ValidatorSelection__EpochNotStable if the requested epoch is not stable
    */
   function canProposeAtTime(Timestamp _ts, bytes32 _archive, address _who)
     external
@@ -372,11 +376,20 @@ contract Rollup is IStaking, IValidatorSelection, IRollup, RollupCore {
    * @param _ts - The timestamp to get the sample seed for
    *
    * @return The sample seed for the given timestamp
+   * @custom:reverts Errors.ValidatorSelection__EpochNotStable if the requested epoch is not stable
    */
   function getSampleSeedAt(Timestamp _ts) external view override(IValidatorSelection) returns (uint256) {
     return ValidatorOperationsExtLib.getSampleSeedAt(getEpochAt(_ts));
   }
 
+  /**
+   * @notice  Get the sampling size for a given timestamp
+   *
+   * @param _ts - The timestamp to get the sampling size for
+   *
+   * @return The sampling size for the given timestamp
+   * @custom:reverts Errors.ValidatorSelection__EpochNotStable if the requested epoch is not stable
+   */
   function getSamplingSizeAt(Timestamp _ts) external view override(IValidatorSelection) returns (uint256) {
     return ValidatorOperationsExtLib.getSamplingSizeAt(getEpochAt(_ts));
   }

--- a/l1-contracts/src/core/libraries/Errors.sol
+++ b/l1-contracts/src/core/libraries/Errors.sol
@@ -117,6 +117,7 @@ library Errors {
   error ValidatorSelection__InvalidCommitteeCommitment(bytes32 reconstructed, bytes32 expected); // 0xca8d5954
   error ValidatorSelection__InsufficientValidatorSetSize(uint256 actual, uint256 expected); // 0xf4f28e99
   error ValidatorSelection__ProposerIndexTooLarge(uint256 index);
+  error ValidatorSelection__EpochNotStable(uint256 queriedEpoch, uint32 currentTimestamp);
 
   // Staking
   error Staking__AlreadyQueued(address _attester);

--- a/l1-contracts/test/staking/move.t.sol
+++ b/l1-contracts/test/staking/move.t.sol
@@ -83,6 +83,10 @@ contract MoveTest is StakingBase {
     Epoch epoch = Epoch.wrap(5);
     Timestamp ts = newRollup.getTimestampForSlot(Slot.wrap(Epoch.unwrap(epoch) * newRollup.getEpochDuration()));
 
+    // Warp to the target epoch time so we can query epoch 5's committee
+    // With lagInEpochs=2, being at epoch 5 allows us to query epoch 5 (sample time is at epoch 3)
+    vm.warp(Timestamp.unwrap(ts));
+
     assertEq(gse.getAttesterCountAtTime(address(oldRollup), Timestamp.wrap(block.timestamp)), n);
     assertEq(gse.getAttesterCountAtTime(address(newRollup), Timestamp.wrap(block.timestamp)), 0);
 
@@ -96,8 +100,7 @@ contract MoveTest is StakingBase {
     );
     newRollup.getEpochCommittee(epoch);
 
-    // Jump to epoch and add the rollup.
-    vm.warp(Timestamp.unwrap(ts));
+    // Add the rollup (we're already at the epoch).
     vm.prank(gse.owner());
     gse.addRollup(address(newRollup));
 
@@ -117,6 +120,10 @@ contract MoveTest is StakingBase {
     newRollup.getEpochCommittee(epoch);
 
     Epoch epoch2 = epoch + Epoch.wrap(100);
+
+    // Warp to epoch2 so we can query its committee
+    Timestamp ts2 = newRollup.getTimestampForSlot(Slot.wrap(Epoch.unwrap(epoch2) * newRollup.getEpochDuration()));
+    vm.warp(Timestamp.unwrap(ts2));
 
     {
       address[] memory committee = oldRollup.getEpochCommittee(epoch2);

--- a/l1-contracts/test/validator-selection/setupEpoch.t.sol
+++ b/l1-contracts/test/validator-selection/setupEpoch.t.sol
@@ -220,4 +220,62 @@ contract SetupEpochTest is ValidatorSelectionTestBase {
     testERC20.mint(address(multiAdder), amount);
     multiAdder.addValidators(validators);
   }
+
+  /**
+   * @notice Test that getSampleSeedAt reverts when querying an epoch whose sample time is in the future
+   * @dev With lagInEpochs=2, if we're at the start of epoch 1 and query epoch 4:
+   *      - Epoch 4 sample time = genesis + 4*epochDuration - 2*epochDuration = genesis + 2*epochDuration
+   *      - Current time = genesis + 1*epochDuration
+   *      - Sample time > current time, so it should revert
+   */
+  function test_getSampleSeedRevertsWhenEpochInTheFuture() external setup(4, 4) {
+    uint256 epochDuration = TestConstants.AZTEC_EPOCH_DURATION * TestConstants.AZTEC_SLOT_DURATION;
+
+    // Move to the start of epoch 1
+    vm.warp(block.timestamp + epochDuration);
+
+    // Try to query epoch 4 - its sample time is in the future
+    Timestamp epoch4Timestamp = Timestamp.wrap(block.timestamp + 3 * epochDuration);
+
+    vm.expectRevert(
+      abi.encodeWithSelector(Errors.ValidatorSelection__EpochNotStable.selector, 4, uint32(block.timestamp))
+    );
+    rollup.getSampleSeedAt(epoch4Timestamp);
+  }
+
+  /**
+   * @notice Test that getSamplingSizeAt reverts when querying an epoch whose sample time is in the future
+   */
+  function test_getSamplingSizeRevertsWhenEpochInTheFuture() external setup(4, 4) {
+    uint256 epochDuration = TestConstants.AZTEC_EPOCH_DURATION * TestConstants.AZTEC_SLOT_DURATION;
+
+    // Move to the start of epoch 1
+    vm.warp(block.timestamp + epochDuration);
+
+    // Try to query epoch 4 - its sample time is in the future
+    Timestamp epoch4Timestamp = Timestamp.wrap(block.timestamp + 3 * epochDuration);
+
+    vm.expectRevert(
+      abi.encodeWithSelector(Errors.ValidatorSelection__EpochNotStable.selector, 4, uint32(block.timestamp))
+    );
+    rollup.getSamplingSizeAt(epoch4Timestamp);
+  }
+
+  /**
+   * @notice Test that getCommitteeAt reverts when querying an epoch whose sample time is in the future
+   */
+  function test_getCommitteeAtRevertsWhenEpochInTheFuture() external setup(4, 4) {
+    uint256 epochDuration = TestConstants.AZTEC_EPOCH_DURATION * TestConstants.AZTEC_SLOT_DURATION;
+
+    // Move to the start of epoch 1
+    vm.warp(block.timestamp + epochDuration);
+
+    // Try to query epoch 4 committee - its sample time is in the future
+    Timestamp epoch4Timestamp = Timestamp.wrap(block.timestamp + 3 * epochDuration);
+
+    vm.expectRevert(
+      abi.encodeWithSelector(Errors.ValidatorSelection__EpochNotStable.selector, 4, uint32(block.timestamp))
+    );
+    rollup.getCommitteeAt(epoch4Timestamp);
+  }
 }

--- a/l1-contracts/test/validator-selection/setupSampleSeed.t.sol
+++ b/l1-contracts/test/validator-selection/setupSampleSeed.t.sol
@@ -10,20 +10,28 @@ import {TestConstants} from "../harnesses/TestConstants.sol";
 
 contract SetupSampleSeedTest is ValidatorSelectionTestBase {
   function test_setupSampleSeed(uint16 _epochToTest) public setup(4, 4) {
-    // Check that the epoch is not set
-    _epochToTest = uint16(bound(_epochToTest, 2, type(uint16).max));
+    // Bound to a reasonable range
+    _epochToTest = uint16(bound(_epochToTest, 2, 1000));
 
-    uint256 timejump = _epochToTest * TestConstants.AZTEC_EPOCH_DURATION * TestConstants.AZTEC_SLOT_DURATION;
-    uint256 originalSampleSeed = rollup.getSampleSeedAt(Timestamp.wrap(block.timestamp + timejump + 1));
+    uint256 epochDuration = TestConstants.AZTEC_EPOCH_DURATION * TestConstants.AZTEC_SLOT_DURATION;
+    uint256 lagInEpochs = rollup.getLagInEpochs();
 
-    // Jump to just before the epoch we are testing
-    vm.warp(
-      block.timestamp + (_epochToTest - 1) * TestConstants.AZTEC_EPOCH_DURATION * TestConstants.AZTEC_SLOT_DURATION
-    );
+    // Jump to epoch _epochToTest - this gives us enough time for the lag
+    vm.warp(block.timestamp + _epochToTest * epochDuration);
+
+    // Get sample seed for current epoch
+    uint256 originalSampleSeed = rollup.getSampleSeedAt(Timestamp.wrap(block.timestamp));
+
+    // Update randao and checkpoint it
+    uint256 newRandao = uint256(keccak256(abi.encode("new randao")));
+    vm.prevrandao(newRandao);
     rollup.checkpointRandao();
 
-    // The sample seed should have been updated
-    uint256 newSampleSeed = rollup.getSampleSeedAt(Timestamp.wrap(block.timestamp + timejump));
+    // Jump to the next epoch where the update is visible
+    vm.warp(block.timestamp + lagInEpochs * epochDuration);
+
+    // The sample seed for the current epoch should now be different because we checkpointed new randao
+    uint256 newSampleSeed = rollup.getSampleSeedAt(Timestamp.wrap(block.timestamp));
     assertTrue(newSampleSeed != originalSampleSeed);
   }
 }


### PR DESCRIPTION
When querying committee data, we should never query beyond the epoch lag, since that data is bound to change in the future. This PR adds a check in `epochToSampleTime`, which is used in all getters for committee data, to prevent querying data that can still change.

This affects both off-chain queries and also rollup operations during block building. Note that the latter should not be impacted, since these methods are always queried for the current epoch.
