### PR TITLE
fix: Do not query committee data in the future

### DIFF
--- a/yarn-project/aztec-node/src/aztec-node/server.test.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.test.ts
@@ -150,7 +150,7 @@ describe('aztec node', () => {
     // on the epoch cache is used so a simple mock will suffice.
     const rollupContract = mock<RollupContract>();
     // We pass MockDateProvider to the epoch cache to have control over the next slot timestamp
-    epochCache = new EpochCache(rollupContract, EmptyL1RollupConstants, new MockDateProvider());
+    epochCache = new EpochCache(rollupContract, { ...EmptyL1RollupConstants, lagInEpochs: 0 }, new MockDateProvider());
 
     node = new AztecNodeService(
       nodeConfig,


### PR DESCRIPTION
Fixes epoch-cache in the node to throw when attempting to query an epoch that is in the future wrt the current node L1 timestamp. This ensures we do not cache spurious data that will change in the future.
