### PR TITLE
fix(archiver): Validate signatures are in order

### DIFF
--- a/yarn-project/sequencer-client/src/config.ts
+++ b/yarn-project/sequencer-client/src/config.ts
@@ -153,6 +153,10 @@ export const sequencerConfigMappings: ConfigMappingsType<SequencerConfig> = {
     description: 'Inject a fake attestation (for testing only)',
     ...booleanConfigHelper(false),
   },
+  shuffleAttestationOrdering: {
+    description: 'Shuffle attestation ordering to create invalid ordering (for testing only)',
+    ...booleanConfigHelper(false),
+  },
   ...pickConfigMappings(p2pConfigMappings, ['txPublicSetupAllowList']),
 };
 

--- a/yarn-project/stdlib/src/block/proposal/attestations_and_signers.ts
+++ b/yarn-project/stdlib/src/block/proposal/attestations_and_signers.ts
@@ -5,7 +5,7 @@ import { encodeAbiParameters, parseAbiParameters } from 'viem';
 import { z } from 'zod';
 
 import type { Signable, SignatureDomainSeparator } from '../../p2p/signature_utils.js';
-import { CommitteeAttestation } from './committee_attestation.js';
+import { CommitteeAttestation, EthAddress } from './committee_attestation.js';
 
 export class CommitteeAttestationsAndSigners implements Signable {
   constructor(public attestations: CommitteeAttestation[]) {}
@@ -117,5 +117,24 @@ export class CommitteeAttestationsAndSigners implements Signable {
       signatureIndices: `0x${Buffer.from(signatureIndices).toString('hex')}`,
       signaturesOrAddresses: `0x${Buffer.from(signaturesOrAddresses).toString('hex')}`,
     };
+  }
+}
+
+/**
+ * Malicious extension of CommitteeAttestationsAndSigners that keeps separate attestations and
+ * signers. Used for tricking the L1 contract into accepting attestations by reconstructing
+ * the correct committee commitment (which relies on the signers, ignoring the signatures)
+ * with an invalid set of attestation signatures.
+ */
+export class MaliciousCommitteeAttestationsAndSigners extends CommitteeAttestationsAndSigners {
+  constructor(
+    attestations: CommitteeAttestation[],
+    private signers: EthAddress[],
+  ) {
+    super(attestations);
+  }
+
+  override getSigners(): EthAddress[] {
+    return this.signers;
   }
 }

--- a/yarn-project/stdlib/src/interfaces/configs.ts
+++ b/yarn-project/stdlib/src/interfaces/configs.ts
@@ -56,6 +56,8 @@ export interface SequencerConfig {
   broadcastInvalidBlockProposal?: boolean;
   /** Inject a fake attestation (for testing only) */
   injectFakeAttestation?: boolean;
+  /** Shuffle attestation ordering to create invalid ordering (for testing only) */
+  shuffleAttestationOrdering?: boolean;
 }
 
 export const SequencerConfigSchema = z.object({
@@ -81,4 +83,5 @@ export const SequencerConfigSchema = z.object({
   secondsBeforeInvalidatingBlockAsNonCommitteeMember: z.number(),
   broadcastInvalidBlockProposal: z.boolean().optional(),
   injectFakeAttestation: z.boolean().optional(),
+  shuffleAttestationOrdering: z.boolean().optional(),
 }) satisfies ZodFor<SequencerConfig>;


### PR DESCRIPTION
The rollup contracts rely on block attestation signatures being in the same order as the committee, but we were not checking that the ordering was correct in the archiver. This fixes it so the archiver validation is aligned with the validation from the rollup contracts.