### PR TITLE
feat!: return metadata associated to private events

### DIFF
--- a/docs/docs/developers/docs/resources/migration_notes.md
+++ b/docs/docs/developers/docs/resources/migration_notes.md
@@ -535,6 +535,66 @@ Return value of `getNotes` used to be defined as `Promise<UniqueNote[]>` and now
 `NoteDao` is mostly a super-set of `UniqueNote` but it doesn't contain a `recipient`.
 Having the recipient in the return value has been redundant as the same outcome can be achieved by populating the `scopes` array in `NoteFilter` with the `recipient` value.
 
+#### Changes to `getPrivateEvents`
+
+The signature of `getPrivateEvents` has changed for two reasons:
+1. To align it with how other query methods that include filtering by block range work (for example, `AztecNode#getPublicLogs`)
+2. To enrich the returned private events with metadata.
+
+```diff
+getPrivateEvents<T>(
+-    contractAddress: AztecAddress,
+-    eventMetadata: EventMetadataDefinition,
+-    from: number,
+-    numBlocks: number,
+-    recipients: AztecAddress[],
+-  ): Promise<T[]>;
++    eventFilter: PrivateEventFilter,
++  ): Promise<PrivateEvent<T>[]>;
+```
+
+`PrivateEvent<T>` bundles together an ABI decoded event of type `T`, with `metadata` of type `InTx`:
+
+```ts
+export type InBlock = {
+  l2BlockNumber: BlockNumber;
+  l2BlockHash: L2BlockHash;
+};
+
+export type InTx = InBlock & {
+  txHash: TxHash;
+};
+
+export type PrivateEvent<T> = {
+  event: T;
+  metadata: InTx;
+};
+```
+
+You will need to update any calls to `Wallet#getPrivateEvents` accordingly. See below for before/after comparison which conserves
+semantics.
+
+Pay special attention to the fact that the old method expects a `numBlocks` parameter that instructs it to
+return `numBlocks` blocks after `fromBlock`, whereas the new version expects an (exclusive) `toBlock` block number.
+
+Also note we're replacing _recipient_ terminology with _scope_. While underlying data types are equivalent (they are Aztec addresses), they have different semantics. Messages have a recipient who will be able to receive and process them. As a result of processing messages for a given recipient address, PXE might discover events. Those events are then said to be _in scope_ for that address.
+
+```diff
+- const events = await context.client.getPrivateEvents(contractAddress, eventMetadata, 42, 10, [recipient]);
+- doSomethingWithAnEvent(events[0]);
+
++ const events = await context.client.getPrivateEvents(eventMetadata, {
++   contractAddress,
++   fromBlock: BlockNumber(42),
++   toBlock: BlockNumber(42 + 10),
++   scopes: [scope],
++ });
++ doSomethingWithAnEvent(events[0].event);
+```
+
+Please refer to the wallet interface js-docs for further details.
+
+
 ### [CLI] Command refactor
 
 The sandbox command has been renamed and remapped to "local network". We believe this conveys better what is actually being spun up when running it.

--- a/yarn-project/archiver/src/archiver/archiver_store_test_suite.ts
+++ b/yarn-project/archiver/src/archiver/archiver_store_test_suite.ts
@@ -20,7 +20,7 @@ import {
   PublishedL2Block,
   type ValidateBlockResult,
   randomBlockInfo,
-  wrapInBlock,
+  wrapDataInBlock,
 } from '@aztec/stdlib/block';
 import {
   type ContractClassPublic,
@@ -413,11 +413,11 @@ export function describeArchiverDataStore(
       });
 
       it.each([
-        () => wrapInBlock(blocks[0].block.body.txEffects[0], blocks[0].block),
-        () => wrapInBlock(blocks[9].block.body.txEffects[3], blocks[9].block),
-        () => wrapInBlock(blocks[3].block.body.txEffects[1], blocks[3].block),
-        () => wrapInBlock(blocks[5].block.body.txEffects[2], blocks[5].block),
-        () => wrapInBlock(blocks[1].block.body.txEffects[0], blocks[1].block),
+        () => wrapDataInBlock(blocks[0].block.body.txEffects[0], blocks[0].block),
+        () => wrapDataInBlock(blocks[9].block.body.txEffects[3], blocks[9].block),
+        () => wrapDataInBlock(blocks[3].block.body.txEffects[1], blocks[3].block),
+        () => wrapDataInBlock(blocks[5].block.body.txEffects[2], blocks[5].block),
+        () => wrapDataInBlock(blocks[1].block.body.txEffects[0], blocks[1].block),
       ])('tries to retrieves a previously stored transaction after deleted', async getExpectedTx => {
         await store.unwindBlocks(BlockNumber(blocks.length), blocks.length);
 
@@ -431,7 +431,7 @@ export function describeArchiverDataStore(
       });
 
       it('does not fail if the block is unwound while requesting a tx', async () => {
-        const expectedTx = await wrapInBlock(blocks[1].block.body.txEffects[0], blocks[1].block);
+        const expectedTx = await wrapDataInBlock(blocks[1].block.body.txEffects[0], blocks[1].block);
         let done = false;
         void (async () => {
           while (!done) {

--- a/yarn-project/aztec.js/src/api/wallet.ts
+++ b/yarn-project/aztec.js/src/api/wallet.ts
@@ -9,6 +9,8 @@ export {
   type BatchedMethodResultWrapper,
   type BatchResults,
   type Wallet,
+  type PrivateEvent,
+  type PrivateEventFilter,
   FunctionCallSchema,
   ExecutionPayloadSchema,
   GasSettingsOptionSchema,
@@ -21,6 +23,8 @@ export {
   ContractMetadataSchema,
   ContractClassMetadataSchema,
   EventMetadataDefinitionSchema,
+  PrivateEventSchema,
+  PrivateEventFilterSchema,
   WalletSchema,
 } from '../wallet/wallet.js';
 

--- a/yarn-project/aztec.js/src/wallet/wallet.test.ts
+++ b/yarn-project/aztec.js/src/wallet/wallet.test.ts
@@ -1,10 +1,12 @@
 import type { ChainInfo } from '@aztec/entrypoints/interfaces';
+import { BlockNumber } from '@aztec/foundation/branded-types';
 import { Fr } from '@aztec/foundation/fields';
 import { type JsonRpcTestContext, createJsonRpcTestSetup } from '@aztec/foundation/json-rpc/test';
 import type { ContractArtifact, EventMetadataDefinition } from '@aztec/stdlib/abi';
 import { EventSelector, FunctionSelector, FunctionType } from '@aztec/stdlib/abi';
 import { AuthWitness } from '@aztec/stdlib/auth-witness';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
+import { L2BlockHash } from '@aztec/stdlib/block';
 import type { ContractClassMetadata, ContractInstanceWithAddress, ContractMetadata } from '@aztec/stdlib/contract';
 import { PublicKeys } from '@aztec/stdlib/keys';
 import {
@@ -21,6 +23,8 @@ import type {
   BatchResults,
   BatchableMethods,
   BatchedMethod,
+  PrivateEvent,
+  PrivateEventFilter,
   ProfileOptions,
   SendOptions,
   SimulateOptions,
@@ -94,9 +98,14 @@ describe('WalletSchema', () => {
       abiType: { kind: 'field' },
       fieldNames: ['field1'],
     };
-    const result = await context.client.getPrivateEvents(await AztecAddress.random(), eventMetadata, 0, 10, [
-      await AztecAddress.random(),
-    ]);
+
+    const result = await context.client.getPrivateEvents(eventMetadata, {
+      contractAddress: await AztecAddress.random(),
+      fromBlock: BlockNumber(1),
+      toBlock: BlockNumber(10),
+      scopes: [await AztecAddress.random()],
+    });
+
     expect(result).toHaveLength(1);
     expect(result[0]).toBeDefined();
   });
@@ -334,13 +343,21 @@ class MockWallet implements Wallet {
   }
 
   getPrivateEvents<T>(
-    _contractAddress: AztecAddress,
     _eventMetadata: EventMetadataDefinition,
-    _from: number,
-    _numBlocks: number,
-    _recipients: AztecAddress[],
-  ): Promise<T[]> {
-    return Promise.resolve([{ field1: Fr.random() }] as T[]);
+    _filter: PrivateEventFilter,
+  ): Promise<PrivateEvent<T>[]> {
+    return Promise.resolve([
+      {
+        event: {
+          field1: Fr.random(),
+        },
+        metadata: {
+          l2BlockNumber: BlockNumber(1),
+          l2BlockHash: L2BlockHash.random(),
+          txHash: TxHash.random(),
+        },
+      },
+    ] as PrivateEvent<T>[]);
   }
 
   getTxReceipt(_txHash: TxHash): Promise<TxReceipt> {

--- a/yarn-project/aztec.js/src/wallet/wallet.ts
+++ b/yarn-project/aztec.js/src/wallet/wallet.ts
@@ -1,6 +1,8 @@
 import type { ChainInfo } from '@aztec/entrypoints/interfaces';
+import { BlockNumber, BlockNumberPositiveSchema } from '@aztec/foundation/branded-types';
 import type { Fr } from '@aztec/foundation/fields';
 import {
+  type AbiDecoded,
   AbiTypeSchema,
   type ContractArtifact,
   ContractArtifactSchema,
@@ -27,8 +29,9 @@ import {
   TxReceipt,
   TxSimulationResult,
   UtilitySimulationResult,
+  inTxSchema,
 } from '@aztec/stdlib/tx';
-import type { ExecutionPayload } from '@aztec/stdlib/tx';
+import type { ExecutionPayload, InTx } from '@aztec/stdlib/tx';
 
 import { z } from 'zod';
 
@@ -130,18 +133,47 @@ export type BatchResults<T extends readonly BatchedMethod<keyof BatchableMethods
 };
 
 /**
+ * Filter options when querying private events.
+ */
+export type PrivateEventFilter = {
+  /** The address of the contract that emitted the events. */
+  contractAddress: AztecAddress;
+  /** Addresses of accounts that are in scope for this filter. */
+  scopes: AztecAddress[];
+  /** Transaction in which the events were emitted. */
+  txHash?: TxHash;
+  /** The block number from which to start fetching events (inclusive).
+   * Optional. If provided, it must be greater or equal than 1.
+   * Defaults to the initial L2 block number (INITIAL_L2_BLOCK_NUM).
+   * */
+  fromBlock?: BlockNumber;
+  /** The block number until which to fetch logs (not inclusive).
+   * Optional. If provided, it must be greater than fromBlock.
+   * Defaults to the latest known block to PXE + 1.
+   */
+  toBlock?: BlockNumber;
+};
+
+/**
+ * An ABI decoded private event with associated metadata.
+ */
+export type PrivateEvent<T> = {
+  /** The ABI decoded event */
+  event: T;
+  /** Metadata describing event context information such as tx and block */
+  metadata: InTx;
+};
+
+/**
  * The wallet interface.
  */
 export type Wallet = {
   getContractClassMetadata(id: Fr, includeArtifact?: boolean): Promise<ContractClassMetadata>;
   getContractMetadata(address: AztecAddress): Promise<ContractMetadata>;
   getPrivateEvents<T>(
-    contractAddress: AztecAddress,
     eventMetadata: EventMetadataDefinition,
-    from: number,
-    numBlocks: number,
-    recipients: AztecAddress[],
-  ): Promise<T[]>;
+    eventFilter: PrivateEventFilter,
+  ): Promise<PrivateEvent<T>[]>;
   getChainInfo(): Promise<ChainInfo>;
   getTxReceipt(txHash: TxHash): Promise<TxReceipt>;
   registerSender(address: AztecAddress, alias?: string): Promise<AztecAddress>;
@@ -267,6 +299,19 @@ export const EventMetadataDefinitionSchema = z.object({
   fieldNames: z.array(z.string()),
 });
 
+export const PrivateEventSchema: ZodFor<PrivateEvent<AbiDecoded>> = z.object({
+  event: AbiDecodedSchema,
+  metadata: inTxSchema(),
+});
+
+export const PrivateEventFilterSchema = z.object({
+  contractAddress: schemas.AztecAddress,
+  scopes: z.array(schemas.AztecAddress),
+  txHash: optional(TxHash.schema),
+  fromBlock: optional(BlockNumberPositiveSchema),
+  toBlock: optional(BlockNumberPositiveSchema),
+});
+
 export const WalletSchema: ApiSchemaFor<Wallet> = {
   getChainInfo: z
     .function()
@@ -277,8 +322,8 @@ export const WalletSchema: ApiSchemaFor<Wallet> = {
   getTxReceipt: z.function().args(TxHash.schema).returns(TxReceipt.schema),
   getPrivateEvents: z
     .function()
-    .args(schemas.AztecAddress, EventMetadataDefinitionSchema, z.number(), z.number(), z.array(schemas.AztecAddress))
-    .returns(z.array(AbiDecodedSchema)),
+    .args(EventMetadataDefinitionSchema, PrivateEventFilterSchema)
+    .returns(z.array(PrivateEventSchema)),
   registerSender: z.function().args(schemas.AztecAddress, optional(z.string())).returns(schemas.AztecAddress),
   getAddressBook: z
     .function()

--- a/yarn-project/end-to-end/src/e2e_block_building.test.ts
+++ b/yarn-project/end-to-end/src/e2e_block_building.test.ts
@@ -438,15 +438,15 @@ describe('e2e_block_building', () => {
       expect(privateLogs.length).toBe(3);
 
       // The first two logs are encrypted.
-      const events = await wallet.getPrivateEvents(
-        testContract.address,
-        TestContract.events.ExampleEvent,
-        rct.blockNumber!,
-        1,
-        [ownerAddress],
-      );
-      expect(events[0]).toEqual(values);
-      expect(events[1]).toEqual(nestedValues);
+      const events = await wallet.getPrivateEvents(TestContract.events.ExampleEvent, {
+        contractAddress: testContract.address,
+        fromBlock: BlockNumber(rct.blockNumber!),
+        toBlock: BlockNumber(rct.blockNumber! + 1),
+        scopes: [ownerAddress],
+      });
+
+      expect(events[0].event).toEqual(values);
+      expect(events[1].event).toEqual(nestedValues);
 
       // The last log is not encrypted.
       // The first field is the first value and is siloed with contract address by the kernel circuit.

--- a/yarn-project/end-to-end/src/e2e_event_logs.test.ts
+++ b/yarn-project/end-to-end/src/e2e_event_logs.test.ts
@@ -3,8 +3,9 @@ import { getDecodedPublicEvents } from '@aztec/aztec.js/events';
 import { Fr } from '@aztec/aztec.js/fields';
 import type { Logger } from '@aztec/aztec.js/log';
 import type { AztecNode } from '@aztec/aztec.js/node';
-import type { Wallet } from '@aztec/aztec.js/wallet';
+import type { PrivateEventFilter, Wallet } from '@aztec/aztec.js/wallet';
 import { makeTuple } from '@aztec/foundation/array';
+import { BlockNumber } from '@aztec/foundation/branded-types';
 import { timesParallel } from '@aztec/foundation/collection';
 import type { Tuple } from '@aztec/foundation/serialize';
 import { type ExampleEvent0, type ExampleEvent1, TestLogContract } from '@aztec/noir-test-contracts.js/TestLog';
@@ -61,49 +62,50 @@ describe('Logs', () => {
 
       const firstBlockNumber = Math.min(...txs.map(tx => tx.blockNumber!));
       const lastBlockNumber = Math.max(...txs.map(tx => tx.blockNumber!));
-      const numBlocks = lastBlockNumber - firstBlockNumber + 1;
+
+      const eventFilter: PrivateEventFilter = {
+        contractAddress: testLogContract.address,
+        fromBlock: BlockNumber(firstBlockNumber),
+        toBlock: BlockNumber(lastBlockNumber + 1),
+        scopes: [account1Address, account2Address],
+      };
 
       // Each emit_encrypted_events call emits 2 ExampleEvent0s and 1 ExampleEvent1
       // So with 5 calls we expect 10 ExampleEvent0s and 5 ExampleEvent1s
       const collectedEvent0s = await wallet.getPrivateEvents<ExampleEvent0>(
-        testLogContract.address,
         TestLogContract.events.ExampleEvent0,
-        firstBlockNumber,
-        numBlocks,
-        [account1Address, account2Address],
+        eventFilter,
       );
 
       const collectedEvent1s = await wallet.getPrivateEvents<ExampleEvent1>(
-        testLogContract.address,
         TestLogContract.events.ExampleEvent1,
-        firstBlockNumber,
-        numBlocks,
-        [account1Address, account2Address],
+        eventFilter,
       );
 
       expect(collectedEvent0s.length).toBe(10); // 2 events per tx * 5 txs
       expect(collectedEvent1s.length).toBe(5); // 1 event per tx * 5 txs
 
       const emptyEvent1s = await wallet.getPrivateEvents<ExampleEvent1>(
-        testLogContract.address,
         TestLogContract.events.ExampleEvent1,
-        firstBlockNumber,
-        numBlocks,
-        [account1Address],
+        eventFilter,
       );
 
       expect(emptyEvent1s.length).toBe(5); // Events sent to msg_sender()
 
       const exampleEvent0Sort = (a: ExampleEvent0, b: ExampleEvent0) => (a.value0 > b.value0 ? 1 : -1);
+
       // Each preimage is used twice for ExampleEvent0
-      const expectedEvent0s = [...preimages, ...preimages].map(preimage => ({
+      const expectedEvent0s: ExampleEvent0[] = [...preimages, ...preimages].map(preimage => ({
         value0: preimage[0].toBigInt(),
         value1: preimage[1].toBigInt(),
       }));
-      expect(collectedEvent0s.sort(exampleEvent0Sort)).toStrictEqual(expectedEvent0s.sort(exampleEvent0Sort));
+      expect(collectedEvent0s.map(ev => ev.event).sort(exampleEvent0Sort)).toStrictEqual(
+        expectedEvent0s.sort(exampleEvent0Sort),
+      );
 
       const exampleEvent1Sort = (a: ExampleEvent1, b: ExampleEvent1) => (a.value2 > b.value2 ? 1 : -1);
-      expect(collectedEvent1s.sort(exampleEvent1Sort)).toStrictEqual(
+
+      expect(collectedEvent1s.map(ev => ev.event).sort(exampleEvent1Sort)).toStrictEqual(
         preimages
           .map(preimage => ({
             value2: new AztecAddress(preimage[2]),

--- a/yarn-project/end-to-end/src/e2e_event_only.test.ts
+++ b/yarn-project/end-to-end/src/e2e_event_only.test.ts
@@ -1,6 +1,7 @@
 import { AztecAddress } from '@aztec/aztec.js/addresses';
 import { Fr } from '@aztec/aztec.js/fields';
 import type { Wallet } from '@aztec/aztec.js/wallet';
+import { BlockNumber } from '@aztec/foundation/branded-types';
 import { EventOnlyContract, type TestEvent } from '@aztec/noir-test-contracts.js/EventOnly';
 
 import { jest } from '@jest/globals';
@@ -37,15 +38,14 @@ describe('EventOnly', () => {
       .send({ from: defaultAccountAddress })
       .wait();
 
-    const events = await wallet.getPrivateEvents<TestEvent>(
-      eventOnlyContract.address,
-      EventOnlyContract.events.TestEvent,
-      tx.blockNumber!,
-      1,
-      [defaultAccountAddress],
-    );
+    const events = await wallet.getPrivateEvents<TestEvent>(EventOnlyContract.events.TestEvent, {
+      contractAddress: eventOnlyContract.address,
+      fromBlock: BlockNumber(tx.blockNumber!),
+      toBlock: BlockNumber(tx.blockNumber! + 1),
+      scopes: [defaultAccountAddress],
+    });
 
     expect(events.length).toBe(1);
-    expect(events[0].value).toBe(value.toBigInt());
+    expect(events[0].event.value).toBe(value.toBigInt());
   });
 });

--- a/yarn-project/end-to-end/src/e2e_offchain_effect.test.ts
+++ b/yarn-project/end-to-end/src/e2e_offchain_effect.test.ts
@@ -2,6 +2,7 @@ import { AztecAddress } from '@aztec/aztec.js/addresses';
 import { Fr } from '@aztec/aztec.js/fields';
 import type { AztecNode } from '@aztec/aztec.js/node';
 import { PRIVATE_LOG_CIPHERTEXT_LEN } from '@aztec/constants';
+import { BlockNumber } from '@aztec/foundation/branded-types';
 import { OffchainEffectContract, type TestEvent } from '@aztec/noir-test-contracts.js/OffchainEffect';
 import { MessageContext } from '@aztec/stdlib/logs';
 import { OFFCHAIN_MESSAGE_IDENTIFIER } from '@aztec/stdlib/tx';
@@ -77,7 +78,7 @@ describe('e2e_offchain_effect', () => {
       contract1.methods.emit_event_as_offchain_message_for_msg_sender(a, b, c),
       { from: defaultAccountAddress },
     );
-    const { txHash, blockNumber } = await provenTx.send().wait();
+    const { txHash, blockNumber, blockHash } = await provenTx.send().wait();
 
     const offchainEffects = provenTx.offchainEffects;
     expect(offchainEffects).toHaveLength(1);
@@ -106,19 +107,25 @@ describe('e2e_offchain_effect', () => {
       .simulate({ from: defaultAccountAddress });
 
     // Get the event from PXE
-    const events = await wallet.getPrivateEvents<TestEvent>(
-      contract1.address,
-      OffchainEffectContract.events.TestEvent,
-      blockNumber!,
-      1,
-      [recipient],
-    );
+    const events = await wallet.getPrivateEvents<TestEvent>(OffchainEffectContract.events.TestEvent, {
+      contractAddress: contract1.address,
+      fromBlock: BlockNumber(blockNumber!),
+      toBlock: BlockNumber(blockNumber! + 1),
+      scopes: [recipient],
+    });
 
     expect(events.length).toBe(1);
     expect(events[0]).toEqual({
-      a,
-      b,
-      c,
+      event: {
+        a,
+        b,
+        c,
+      },
+      metadata: {
+        l2BlockNumber: blockNumber,
+        l2BlockHash: blockHash,
+        txHash,
+      },
     });
   });
 

--- a/yarn-project/end-to-end/src/e2e_token_contract/private_transfer_recursion.test.ts
+++ b/yarn-project/end-to-end/src/e2e_token_contract/private_transfer_recursion.test.ts
@@ -1,3 +1,4 @@
+import { BlockNumber } from '@aztec/foundation/branded-types';
 import { TokenContract, type Transfer } from '@aztec/noir-contracts.js/Token';
 
 import { mintNotes } from '../fixtures/token_utils.js';
@@ -30,18 +31,24 @@ describe('e2e_token_contract private transfer recursion', () => {
     // We should have created a single new note, for the recipient
     expect(txEffects!.data.noteHashes.length).toBe(1);
 
-    const events = await wallet.getPrivateEvents<Transfer>(
-      asset.address,
-      TokenContract.events.Transfer,
-      tx.blockNumber!,
-      1,
-      [account1Address],
-    );
+    const events = await wallet.getPrivateEvents<Transfer>(TokenContract.events.Transfer, {
+      contractAddress: asset.address,
+      fromBlock: BlockNumber(tx.blockNumber!),
+      toBlock: BlockNumber(tx.blockNumber! + 1),
+      scopes: [account1Address],
+    });
 
     expect(events[0]).toEqual({
-      from: adminAddress,
-      to: account1Address,
-      amount: totalBalance,
+      event: {
+        from: adminAddress,
+        to: account1Address,
+        amount: totalBalance,
+      },
+      metadata: {
+        l2BlockNumber: BlockNumber(tx.blockNumber!),
+        l2BlockHash: tx.blockHash,
+        txHash: tx.txHash,
+      },
     });
   });
 
@@ -63,18 +70,24 @@ describe('e2e_token_contract private transfer recursion', () => {
     const senderBalance = await asset.methods.balance_of_private(adminAddress).simulate({ from: adminAddress });
     expect(senderBalance).toEqual(expectedChange);
 
-    const events = await wallet.getPrivateEvents<Transfer>(
-      asset.address,
-      TokenContract.events.Transfer,
-      tx.blockNumber!,
-      1,
-      [account1Address],
-    );
+    const events = await wallet.getPrivateEvents<Transfer>(TokenContract.events.Transfer, {
+      contractAddress: asset.address,
+      fromBlock: BlockNumber(tx.blockNumber!),
+      toBlock: BlockNumber(tx.blockNumber! + 1),
+      scopes: [account1Address],
+    });
 
     expect(events[0]).toEqual({
-      from: adminAddress,
-      to: account1Address,
-      amount: toSend,
+      event: {
+        from: adminAddress,
+        to: account1Address,
+        amount: toSend,
+      },
+      metadata: {
+        l2BlockNumber: BlockNumber(tx.blockNumber!),
+        l2BlockHash: tx.blockHash,
+        txHash: tx.txHash,
+      },
     });
   });
 

--- a/yarn-project/end-to-end/src/e2e_token_contract/transfer.test.ts
+++ b/yarn-project/end-to-end/src/e2e_token_contract/transfer.test.ts
@@ -1,4 +1,5 @@
 import { AztecAddress, CompleteAddress } from '@aztec/aztec.js/addresses';
+import { BlockNumber } from '@aztec/foundation/branded-types';
 import { TokenContract, type Transfer } from '@aztec/noir-contracts.js/Token';
 
 import { TokenContractTest } from './token_contract_test.js';
@@ -30,18 +31,24 @@ describe('e2e_token_contract transfer private', () => {
     const tx = await asset.methods.transfer(account1Address, amount).send({ from: adminAddress }).wait();
     tokenSim.transferPrivate(adminAddress, account1Address, amount);
 
-    const events = await wallet.getPrivateEvents<Transfer>(
-      asset.address,
-      TokenContract.events.Transfer,
-      tx.blockNumber!,
-      1,
-      [account1Address],
-    );
+    const events = await wallet.getPrivateEvents<Transfer>(TokenContract.events.Transfer, {
+      contractAddress: asset.address,
+      fromBlock: tx.blockNumber!,
+      toBlock: BlockNumber(tx.blockNumber! + 1),
+      scopes: [account1Address],
+    });
 
     expect(events[0]).toEqual({
-      from: adminAddress,
-      to: account1Address,
-      amount: amount,
+      event: {
+        from: adminAddress,
+        to: account1Address,
+        amount: amount,
+      },
+      metadata: {
+        l2BlockNumber: tx.blockNumber,
+        l2BlockHash: tx.blockHash,
+        txHash: tx.txHash,
+      },
     });
   });
 

--- a/yarn-project/pxe/src/contract_function_simulator/pxe_oracle_interface.test.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/pxe_oracle_interface.test.ts
@@ -6,7 +6,7 @@ import { KeyStore } from '@aztec/key-store';
 import { openTmpStore } from '@aztec/kv-store/lmdb-v2';
 import { EventSelector } from '@aztec/stdlib/abi';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
-import { L2BlockHash, randomInBlock } from '@aztec/stdlib/block';
+import { L2BlockHash, randomDataInBlock } from '@aztec/stdlib/block';
 import { CompleteAddress } from '@aztec/stdlib/contract';
 import { computeUniqueNoteHash, siloNoteHash, siloNullifier, siloPrivateLog } from '@aztec/stdlib/hash';
 import type { AztecNode } from '@aztec/stdlib/interfaces/client';
@@ -185,7 +185,7 @@ describe('PXEOracleInterface', () => {
       }
       aztecNode.getLogsByTags.mockReset();
       aztecNode.getTxEffect.mockResolvedValue({
-        ...randomInBlock(await TxEffect.random({ numNullifiers: 1 })),
+        ...randomDataInBlock(await TxEffect.random({ numNullifiers: 1 })),
         txIndexInBlock: 0,
       });
     });
@@ -602,13 +602,12 @@ describe('PXEOracleInterface', () => {
       await deliverEvent();
 
       // I should be able to retrieve the private event I just saved using getPrivateEvents
-      const result = await privateEventDataProvider.getPrivateEvents(
+      const result = await privateEventDataProvider.getPrivateEvents(eventSelector, {
         contractAddress,
-        blockNumber,
-        1,
-        [recipient.address],
-        eventSelector,
-      );
+        fromBlock: blockNumber,
+        toBlock: blockNumber + 1,
+        scopes: [recipient.address],
+      });
 
       expect(result.length).toEqual(1);
       expect(result[0].packedEvent).toEqual(eventContent);
@@ -644,7 +643,7 @@ describe('PXEOracleInterface', () => {
       // Mock note exists in tree
       aztecNode.findLeavesIndexes.mockImplementation((_blockNum, treeId, leaves) => {
         if (treeId === MerkleTreeId.NOTE_HASH_TREE && leaves[0].equals(uniqueNoteHash)) {
-          return Promise.resolve([randomInBlock(0n)]);
+          return Promise.resolve([randomDataInBlock(0n)]);
         }
         return Promise.resolve([undefined]);
       });
@@ -696,10 +695,10 @@ describe('PXEOracleInterface', () => {
       // Mock note exists and is nullified
       aztecNode.findLeavesIndexes.mockImplementation((_blockNum, treeId, leaves) => {
         if (treeId === MerkleTreeId.NOTE_HASH_TREE && leaves[0].equals(uniqueNoteHash)) {
-          return Promise.resolve([randomInBlock(0n)]);
+          return Promise.resolve([randomDataInBlock(0n)]);
         }
         if (treeId === MerkleTreeId.NULLIFIER_TREE && leaves[0].equals(siloedNullifier)) {
-          return Promise.resolve([randomInBlock(0n)]);
+          return Promise.resolve([randomDataInBlock(0n)]);
         }
         return Promise.resolve([undefined]);
       });
@@ -734,7 +733,7 @@ describe('PXEOracleInterface', () => {
       aztecNode.findLeavesIndexes.mockImplementation((blockNum, treeId, leaves) => {
         if (treeId === MerkleTreeId.NOTE_HASH_TREE && leaves[0].equals(uniqueNoteHash)) {
           if (typeof blockNum === 'number' && blockNum > syncedBlockNumber) {
-            return Promise.resolve([randomInBlock(0n)]);
+            return Promise.resolve([randomDataInBlock(0n)]);
           }
         }
         return Promise.resolve([undefined]);
@@ -768,11 +767,11 @@ describe('PXEOracleInterface', () => {
       // Mock note exists in synced blocks but nullifier only exists after
       aztecNode.findLeavesIndexes.mockImplementation((blockNum, treeId, leaves) => {
         if (treeId === MerkleTreeId.NOTE_HASH_TREE && leaves[0].equals(uniqueNoteHash)) {
-          return Promise.resolve([randomInBlock(0n)]);
+          return Promise.resolve([randomDataInBlock(0n)]);
         }
         if (treeId === MerkleTreeId.NULLIFIER_TREE && leaves[0].equals(siloedNullifier)) {
           if (typeof blockNum === 'number' && blockNum > syncedBlockNumber) {
-            return Promise.resolve([randomInBlock(0n)]);
+            return Promise.resolve([randomDataInBlock(0n)]);
           }
         }
         return Promise.resolve([undefined]);
@@ -1033,7 +1032,7 @@ describe('PXEOracleInterface', () => {
       await noteDataProvider.addNotes([noteDao], recipient);
 
       // Set up the nullifier in the merkle tree
-      const nullifierIndex = randomInBlock(123n);
+      const nullifierIndex = randomDataInBlock(123n);
       aztecNode.findLeavesIndexes.mockResolvedValue([nullifierIndex]);
 
       // Call the function under test
@@ -1089,7 +1088,7 @@ describe('PXEOracleInterface', () => {
       // Mock nullifier to only exist after synced block
       aztecNode.findLeavesIndexes.mockImplementation(blockNum => {
         if (typeof blockNum === 'number' && blockNum > syncedBlockNumber) {
-          return Promise.resolve([randomInBlock(0n)]);
+          return Promise.resolve([randomDataInBlock(0n)]);
         }
         return Promise.resolve([undefined]);
       });

--- a/yarn-project/pxe/src/contract_function_simulator/pxe_oracle_interface.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/pxe_oracle_interface.ts
@@ -793,7 +793,7 @@ export class PXEOracleInterface implements ExecutionDataProvider {
     content: Fr[],
     eventCommitment: Fr,
     txHash: TxHash,
-    recipient: AztecAddress,
+    scope: AztecAddress,
   ): Promise<void> {
     // While using 'latest' block number would be fine for private events since they cannot be accessed from Aztec.nr
     // (and thus we're less concerned about being ahead of the synced block), we use the synced block number to
@@ -831,14 +831,16 @@ export class PXEOracleInterface implements ExecutionDataProvider {
     }
 
     return this.privateEventDataProvider.storePrivateEventLog(
-      contractAddress,
-      recipient,
       selector,
       content,
-      txHash,
       Number(nullifierIndex.data), // Index of the event commitment in the nullifier tree
-      nullifierIndex.l2BlockNumber, // Block number in which the event was emitted
-      nullifierIndex.l2BlockHash, // Block hash in which the event was emitted
+      {
+        contractAddress,
+        scope,
+        txHash,
+        l2BlockNumber: nullifierIndex.l2BlockNumber, // Block number in which the event was emitted
+        l2BlockHash: nullifierIndex.l2BlockHash, // Block hash in which the event was emitted
+      },
     );
   }
 

--- a/yarn-project/pxe/src/events/index.ts
+++ b/yarn-project/pxe/src/events/index.ts
@@ -1,0 +1,1 @@
+export * from './private_event_filter_validator.js';

--- a/yarn-project/pxe/src/events/private_event_filter_validator.test.ts
+++ b/yarn-project/pxe/src/events/private_event_filter_validator.test.ts
@@ -1,0 +1,123 @@
+import { INITIAL_L2_BLOCK_NUM } from '@aztec/constants';
+import { BlockNumber } from '@aztec/foundation/branded-types';
+import { AztecAddress } from '@aztec/stdlib/aztec-address';
+import { TxHash } from '@aztec/stdlib/tx';
+
+import { mock } from 'jest-mock-extended';
+import type { MockProxy } from 'jest-mock-extended/lib/Mock.js';
+
+import { SyncDataProvider } from '../storage/index.js';
+import { PrivateEventFilterValidator } from './private_event_filter_validator.js';
+
+describe('PrivateEventFilterValidator', () => {
+  let contractAddress: AztecAddress;
+  let lastKnownBlockNumber: BlockNumber;
+  let scope: AztecAddress;
+  let syncDataProvider: MockProxy<SyncDataProvider>;
+  let validator: PrivateEventFilterValidator;
+
+  beforeEach(async () => {
+    lastKnownBlockNumber = BlockNumber(42);
+    contractAddress = await AztecAddress.random();
+    scope = await AztecAddress.random();
+    syncDataProvider = mock<SyncDataProvider>();
+    syncDataProvider.getBlockNumber.mockResolvedValue(lastKnownBlockNumber);
+    validator = new PrivateEventFilterValidator(syncDataProvider);
+  });
+
+  it('rejects empty scope', async () => {
+    await expect(validator.validate({ contractAddress, fromBlock: lastKnownBlockNumber, scopes: [] })).rejects.toThrow(
+      /At least one scope is required to get private events/,
+    );
+  });
+
+  it('defaults to whole range', async () => {
+    const dataProviderFilter = await validator.validate({ contractAddress, scopes: [scope] });
+    expect(dataProviderFilter).toEqual({
+      contractAddress,
+      scopes: [scope],
+      fromBlock: INITIAL_L2_BLOCK_NUM,
+      toBlock: lastKnownBlockNumber + 1,
+      txHash: undefined,
+    });
+  });
+
+  it('toBlock defaults to lastKnownBlock + 1', async () => {
+    const dataProviderFilter = await validator.validate({
+      contractAddress,
+      scopes: [scope],
+      fromBlock: INITIAL_L2_BLOCK_NUM,
+    });
+    expect(dataProviderFilter).toEqual({
+      contractAddress,
+      scopes: [scope],
+      fromBlock: INITIAL_L2_BLOCK_NUM,
+      toBlock: BlockNumber(lastKnownBlockNumber + 1),
+    });
+  });
+
+  it('toBlock without fromBlock defaults to [INITIAL_L2_BLOCK_NUM, toBlock)', async () => {
+    const dataProviderFilter = await validator.validate({
+      contractAddress,
+      scopes: [scope],
+      toBlock: BlockNumber(lastKnownBlockNumber + 1),
+    });
+    expect(dataProviderFilter).toEqual({
+      contractAddress,
+      scopes: [scope],
+      fromBlock: INITIAL_L2_BLOCK_NUM,
+      toBlock: BlockNumber(lastKnownBlockNumber + 1),
+    });
+  });
+
+  it('rejects fromBlock >= toBlock', async () => {
+    await expect(
+      validator.validate({
+        contractAddress,
+        scopes: [scope],
+        fromBlock: lastKnownBlockNumber,
+        toBlock: lastKnownBlockNumber,
+      }),
+    ).rejects.toThrow(/toBlock must be strictly greater than fromBlock/);
+
+    await expect(
+      validator.validate({
+        contractAddress,
+        scopes: [scope],
+        fromBlock: lastKnownBlockNumber,
+        toBlock: BlockNumber(lastKnownBlockNumber - 1),
+      }),
+    ).rejects.toThrow(/toBlock must be strictly greater than fromBlock/);
+  });
+
+  it('preserves txHash', async () => {
+    let dataProviderFilter = await validator.validate({
+      contractAddress,
+      scopes: [scope],
+      fromBlock: INITIAL_L2_BLOCK_NUM,
+      toBlock: BlockNumber(lastKnownBlockNumber + 1),
+    });
+    expect(dataProviderFilter).toEqual({
+      contractAddress,
+      scopes: [scope],
+      fromBlock: INITIAL_L2_BLOCK_NUM,
+      toBlock: BlockNumber(lastKnownBlockNumber + 1),
+    });
+
+    const txHash = TxHash.random();
+    dataProviderFilter = await validator.validate({
+      contractAddress,
+      scopes: [scope],
+      fromBlock: INITIAL_L2_BLOCK_NUM,
+      toBlock: BlockNumber(lastKnownBlockNumber + 1),
+      txHash,
+    });
+    expect(dataProviderFilter).toEqual({
+      contractAddress,
+      scopes: [scope],
+      fromBlock: INITIAL_L2_BLOCK_NUM,
+      toBlock: BlockNumber(lastKnownBlockNumber + 1),
+      txHash,
+    });
+  });
+});

--- a/yarn-project/pxe/src/events/private_event_filter_validator.ts
+++ b/yarn-project/pxe/src/events/private_event_filter_validator.ts
@@ -1,0 +1,47 @@
+import type { PrivateEventFilter } from '@aztec/aztec.js/wallet';
+import { INITIAL_L2_BLOCK_NUM } from '@aztec/constants';
+import { BlockNumber } from '@aztec/foundation/branded-types';
+
+import type { PrivateEventDataProviderFilter, SyncDataProvider } from '../storage/index.js';
+
+export class PrivateEventFilterValidator {
+  constructor(private syncDataProvider: SyncDataProvider) {}
+
+  async validate(filter: PrivateEventFilter): Promise<PrivateEventDataProviderFilter> {
+    let { fromBlock, toBlock } = filter;
+
+    // Block range filters in Aztec Node are defined as closed-open intervals [fromBlock, toBlock), so
+    // we respect that convention here for consistency.
+    // We then default to [INITIAL_L2_BLOCK_NUM, latestKnownBlock + 1), ie: by default return events from
+    // the first block to the latest known block.
+    if (!fromBlock || !toBlock) {
+      const lastKnownBlock = await this.syncDataProvider.getBlockNumber();
+      fromBlock = fromBlock ?? BlockNumber(INITIAL_L2_BLOCK_NUM);
+      toBlock = toBlock ?? BlockNumber(lastKnownBlock + 1);
+    }
+
+    if (filter.scopes.length === 0) {
+      throw new Error('At least one scope is required to get private events');
+    }
+
+    if (fromBlock < 1) {
+      throw new Error('fromBlock must be greater than or equal to 1');
+    }
+
+    if (toBlock < 1) {
+      throw new Error('toBlock must be greater than or equal to 1');
+    }
+
+    if (fromBlock >= toBlock) {
+      throw new Error('toBlock must be strictly greater than fromBlock');
+    }
+
+    return {
+      contractAddress: filter.contractAddress,
+      scopes: filter.scopes,
+      txHash: filter.txHash,
+      toBlock,
+      fromBlock,
+    };
+  }
+}

--- a/yarn-project/pxe/src/pxe.test.ts
+++ b/yarn-project/pxe/src/pxe.test.ts
@@ -24,7 +24,7 @@ import { mock } from 'jest-mock-extended';
 import type { MockProxy } from 'jest-mock-extended/lib/Mock.js';
 
 import type { PXEConfig } from './config/index.js';
-import { PXE, type PrivateEvent } from './pxe.js';
+import { PXE, type PackedPrivateEvent } from './pxe.js';
 import { PrivateEventDataProvider } from './storage/index.js';
 
 describe('PXE', () => {
@@ -157,16 +157,17 @@ describe('PXE', () => {
   describe('getPrivateEvents', () => {
     let contractAddress: AztecAddress;
     let eventSelector: EventSelector;
-    let blockNumber: BlockNumber;
-    let blockHash: L2BlockHash;
-    let recipient: AztecAddress;
+    let lastKnownBlockNumber: BlockNumber;
+    let l2BlockHash: L2BlockHash;
+    let scope: AztecAddress;
     let privateEventDataProvider: PrivateEventDataProvider;
+    let eventIndex = 0;
 
     beforeEach(async () => {
       // Set up basic state
-      blockNumber = BlockNumber(42);
+      lastKnownBlockNumber = BlockNumber(42);
       const globalVariables = GlobalVariables.empty({
-        blockNumber,
+        blockNumber: lastKnownBlockNumber,
       });
       const blockHeader = BlockHeader.empty({
         globalVariables,
@@ -191,63 +192,101 @@ describe('PXE', () => {
 
       contractAddress = contractInstance.address;
       eventSelector = EventSelector.random();
-      blockHash = L2BlockHash.random();
+      l2BlockHash = L2BlockHash.random();
 
-      recipient = await AztecAddress.random();
+      scope = await AztecAddress.random();
 
       privateEventDataProvider = new PrivateEventDataProvider(kvStore);
     });
 
-    async function storeEvent(index: number): Promise<PrivateEvent> {
+    async function storeEvent(blockNumber?: number): Promise<PackedPrivateEvent> {
       const event = {
         packedEvent: [Fr.random(), Fr.random()],
-        blockNumber,
-        blockHash,
+        l2BlockNumber: BlockNumber(blockNumber ?? lastKnownBlockNumber),
+        l2BlockHash,
         txHash: TxHash.random(),
-        recipient,
         eventSelector,
       };
 
-      await privateEventDataProvider.storePrivateEventLog(
+      await privateEventDataProvider.storePrivateEventLog(eventSelector, event.packedEvent, eventIndex++, {
         contractAddress,
-        recipient,
-        eventSelector,
-        event.packedEvent,
-        event.txHash,
-        index,
-        blockNumber,
-        blockHash,
-      );
+        scope,
+        txHash: event.txHash,
+        l2BlockNumber: event.l2BlockNumber,
+        l2BlockHash: event.l2BlockHash,
+      });
 
       return event;
     }
 
     it('returns private events', async () => {
       // Store a couple of events to exercise `getPrivateEvents`
-      const event1 = await storeEvent(0);
-      const event2 = await storeEvent(1);
+      const event1 = await storeEvent();
+      const event2 = await storeEvent();
 
-      const events = await pxe.getPrivateEvents(contractAddress, eventSelector, blockNumber, 1, [recipient]);
+      const events = await pxe.getPrivateEvents(eventSelector, {
+        contractAddress,
+        fromBlock: lastKnownBlockNumber,
+        scopes: [scope],
+      });
 
       expect(events).toEqual([event1, event2]);
     });
 
     it('returns no events', async () => {
-      const events = await pxe.getPrivateEvents(contractAddress, eventSelector, blockNumber, 1, [recipient]);
+      const events = await pxe.getPrivateEvents(eventSelector, {
+        contractAddress,
+        fromBlock: lastKnownBlockNumber,
+        scopes: [scope],
+      });
 
       expect(events).toEqual([]);
     });
 
-    it('rejects empty recipient lists', async () => {
-      await storeEvent(0);
-      await storeEvent(1);
+    describe('filtering', () => {
+      let eventsInPastBlocks: PackedPrivateEvent[];
+      let eventsInLatestKnownBlock: PackedPrivateEvent[];
+      let _eventsInNotYetSyncedBlocks: PackedPrivateEvent[];
 
-      await expect(pxe.getPrivateEvents(contractAddress, eventSelector, blockNumber, 1, [])).rejects.toThrow(
-        /Recipients are required/,
-      );
+      beforeEach(async () => {
+        eventsInPastBlocks = await Promise.all([
+          storeEvent(lastKnownBlockNumber - 1),
+          storeEvent(lastKnownBlockNumber - 1),
+        ]);
+
+        eventsInLatestKnownBlock = await Promise.all([
+          storeEvent(lastKnownBlockNumber),
+          storeEvent(lastKnownBlockNumber),
+        ]);
+
+        _eventsInNotYetSyncedBlocks = await Promise.all([
+          storeEvent(lastKnownBlockNumber + 1),
+          storeEvent(lastKnownBlockNumber + 1),
+        ]);
+      });
+
+      it('filters by txHash', async () => {
+        const events = await pxe.getPrivateEvents(eventSelector, {
+          contractAddress,
+          scopes: [scope],
+          txHash: eventsInLatestKnownBlock[1].txHash,
+        });
+
+        expect(events).toEqual([eventsInLatestKnownBlock[1]]);
+      });
+
+      it('filters by block', async () => {
+        const events = await pxe.getPrivateEvents(eventSelector, {
+          contractAddress,
+          scopes: [scope],
+          fromBlock: BlockNumber(lastKnownBlockNumber - 1),
+          toBlock: lastKnownBlockNumber,
+        });
+
+        expect(events).toEqual([...eventsInPastBlocks]);
+      });
     });
   });
-
   // Note: Not testing a successful run of `proveTx`, `sendTx`, `getTxReceipt` and `simulateUtility` here as it
   //       requires a larger setup and it's sufficiently tested in the e2e tests.
 });

--- a/yarn-project/pxe/src/pxe.ts
+++ b/yarn-project/pxe/src/pxe.ts
@@ -1,3 +1,4 @@
+import type { PrivateEventFilter } from '@aztec/aztec.js/wallet';
 import { Fr } from '@aztec/foundation/fields';
 import { type Logger, createLogger } from '@aztec/foundation/log';
 import { SerialQueue } from '@aztec/foundation/queue';
@@ -18,7 +19,6 @@ import {
 } from '@aztec/stdlib/abi';
 import type { AuthWitness } from '@aztec/stdlib/auth-witness';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
-import type { L2BlockHash } from '@aztec/stdlib/block';
 import {
   CompleteAddress,
   type ContractClassWithId,
@@ -39,6 +39,7 @@ import type { NotesFilter } from '@aztec/stdlib/note';
 import { NoteDao } from '@aztec/stdlib/note';
 import {
   type ContractOverrides,
+  type InTx,
   PrivateExecutionResult,
   PrivateSimulationResult,
   type ProvingTimings,
@@ -47,7 +48,6 @@ import {
   type SimulationTimings,
   Tx,
   TxExecutionRequest,
-  TxHash,
   TxProfileResult,
   TxProvingResult,
   TxSimulationResult,
@@ -66,6 +66,7 @@ import { ProxiedContractDataProviderFactory } from './contract_function_simulato
 import { ProxiedNodeFactory } from './contract_function_simulator/proxied_node.js';
 import { PXEOracleInterface } from './contract_function_simulator/pxe_oracle_interface.js';
 import { enrichPublicSimulationError, enrichSimulationError } from './error_enriching.js';
+import { PrivateEventFilterValidator } from './events/private_event_filter_validator.js';
 import {
   PrivateKernelExecutionProver,
   type PrivateKernelExecutionProverConfig,
@@ -80,12 +81,8 @@ import { SyncDataProvider } from './storage/sync_data_provider/sync_data_provide
 import { TaggingDataProvider } from './storage/tagging_data_provider/tagging_data_provider.js';
 import { Synchronizer } from './synchronizer/index.js';
 
-export type PrivateEvent = {
+export type PackedPrivateEvent = InTx & {
   packedEvent: Fr[];
-  blockNumber: number;
-  blockHash: L2BlockHash;
-  txHash: TxHash;
-  recipient: AztecAddress;
   eventSelector: EventSelector;
 };
 
@@ -1049,31 +1046,32 @@ export class PXE {
 
   /**
    * Returns the private events given search parameters.
-   * @param contractAddress - The address of the contract to get events from.
    * @param eventSelector - Event selector to search for.
-   * @param from - The block number to search from.
-   * @param numBlocks - The amount of blocks to search.
-   * @param recipients - The addresses that decrypted the logs.
+   * @param filter
+   *  contractAddress - The address of the contract to get events from. Required.
+   *  scopes - One or more event scope addresses to filter by. Required.
+   *  fromBlock - The block number to search from (inclusive). Optional. If provided, it must be >= 0.
+   *    Defaults to 0.
+   *    If toBlock is defined but fromBlock is not, fromBlock defaults to toBlock - 1.
+   *  toBlock - The block number to search up to (exclusive). Optional. If provided, it must be > 0.
+   *    Defaults to the latest known block to PXE + 1.
    * @returns - The packed events with block and tx metadata.
    */
   public async getPrivateEvents(
-    contractAddress: AztecAddress,
     eventSelector: EventSelector,
-    from: number,
-    numBlocks: number,
-    recipients: AztecAddress[],
-  ): Promise<PrivateEvent[]> {
-    if (recipients.length === 0) {
-      throw new Error('Recipients are required to get private events');
-    }
-
-    this.log.verbose(`Getting private events for ${contractAddress.toString()} from ${from} to ${from + numBlocks}`);
-
+    filter: PrivateEventFilter,
+  ): Promise<PackedPrivateEvent[]> {
     // We need to manually trigger private state sync to have a guarantee that all the events are available.
-    const call = await this.#getFunctionCall('sync_private_state', [], contractAddress);
+    const call = await this.#getFunctionCall('sync_private_state', [], filter.contractAddress);
     await this.simulateUtility(call);
 
-    return this.privateEventDataProvider.getPrivateEvents(contractAddress, from, numBlocks, recipients, eventSelector);
+    const sanitizedFilter = await new PrivateEventFilterValidator(this.syncDataProvider).validate(filter);
+
+    this.log.error(
+      `Getting private events for ${sanitizedFilter.contractAddress.toString()} from ${sanitizedFilter.fromBlock} to ${sanitizedFilter.toBlock}`,
+    );
+
+    return this.privateEventDataProvider.getPrivateEvents(eventSelector, sanitizedFilter);
   }
 
   /**

--- a/yarn-project/pxe/src/storage/private_event_data_provider/private_event_data_provider.test.ts
+++ b/yarn-project/pxe/src/storage/private_event_data_provider/private_event_data_provider.test.ts
@@ -1,3 +1,4 @@
+import { BlockNumber } from '@aztec/foundation/branded-types';
 import { randomInt } from '@aztec/foundation/crypto';
 import { Fr } from '@aztec/foundation/fields';
 import { openTmpStore } from '@aztec/kv-store/lmdb-v2';
@@ -6,7 +7,7 @@ import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import { L2BlockHash } from '@aztec/stdlib/block';
 import { TxHash } from '@aztec/stdlib/tx';
 
-import type { PrivateEvent } from '../../pxe.js';
+import type { PackedPrivateEvent } from '../../pxe.js';
 import { PrivateEventDataProvider } from './private_event_data_provider.js';
 
 const getRandomMsgContent = () => {
@@ -16,118 +17,97 @@ const getRandomMsgContent = () => {
 describe('PrivateEventDataProvider', () => {
   let privateEventDataProvider: PrivateEventDataProvider;
   let contractAddress: AztecAddress;
-  let recipient: AztecAddress;
+  let scope: AztecAddress;
   let msgContent: Fr[];
-  let blockNumber: number;
-  let blockHash: L2BlockHash;
+  let l2BlockNumber: BlockNumber;
+  let l2BlockHash: L2BlockHash;
   let eventSelector: EventSelector;
   let txHash: TxHash;
   let eventCommitmentIndex: number;
-  let expectedEvent: PrivateEvent;
+  let expectedEvent: PackedPrivateEvent;
 
   beforeEach(async () => {
     const store = await openTmpStore('private_event_data_provider_test');
     privateEventDataProvider = new PrivateEventDataProvider(store);
     contractAddress = await AztecAddress.random();
-    recipient = await AztecAddress.random();
+    scope = await AztecAddress.random();
     msgContent = getRandomMsgContent();
-    blockNumber = 123;
-    blockHash = L2BlockHash.random();
+    l2BlockNumber = BlockNumber(123);
+    l2BlockHash = L2BlockHash.random();
     eventSelector = EventSelector.random();
     txHash = TxHash.random();
     eventCommitmentIndex = randomInt(10);
 
     expectedEvent = {
-      recipient,
       packedEvent: msgContent,
       txHash,
-      blockNumber,
-      blockHash,
+      l2BlockNumber,
+      l2BlockHash,
       eventSelector,
     };
   });
 
   it('stores and retrieves private events', async () => {
-    await privateEventDataProvider.storePrivateEventLog(
+    await privateEventDataProvider.storePrivateEventLog(eventSelector, msgContent, eventCommitmentIndex, {
       contractAddress,
-      recipient,
-      eventSelector,
-      msgContent,
+      scope,
       txHash,
-      eventCommitmentIndex,
-      blockNumber,
-      blockHash,
-    );
-    const events = await privateEventDataProvider.getPrivateEvents(
+      l2BlockNumber,
+      l2BlockHash,
+    });
+    const events = await privateEventDataProvider.getPrivateEvents(eventSelector, {
       contractAddress,
-      blockNumber,
-      1,
-      [recipient],
-      eventSelector,
-    );
+      fromBlock: l2BlockNumber,
+      toBlock: l2BlockNumber + 1,
+      scopes: [scope],
+    });
     expect(events).toEqual([expectedEvent]);
   });
 
   it('ignores duplicate events with same eventCommitmentIndex', async () => {
-    await privateEventDataProvider.storePrivateEventLog(
+    await privateEventDataProvider.storePrivateEventLog(eventSelector, msgContent, eventCommitmentIndex, {
       contractAddress,
-      recipient,
-      eventSelector,
-      msgContent,
+      scope,
       txHash,
-      eventCommitmentIndex,
-      blockNumber,
-      blockHash,
-    );
-    await privateEventDataProvider.storePrivateEventLog(
+      l2BlockNumber,
+      l2BlockHash,
+    });
+
+    const events = await privateEventDataProvider.getPrivateEvents(eventSelector, {
       contractAddress,
-      recipient,
-      eventSelector,
-      msgContent,
-      txHash,
-      eventCommitmentIndex,
-      blockNumber,
-      blockHash,
-    );
-    const events = await privateEventDataProvider.getPrivateEvents(
-      contractAddress,
-      blockNumber,
-      1,
-      [recipient],
-      eventSelector,
-    );
+      fromBlock: l2BlockNumber,
+      toBlock: l2BlockNumber + 1,
+      scopes: [scope],
+    });
+
     expect(events).toEqual([expectedEvent]);
   });
 
   it('allows multiple events with same content but different eventCommitmentIndex', async () => {
     const otherEventCommitmentIndex = eventCommitmentIndex + 1;
-    await privateEventDataProvider.storePrivateEventLog(
+
+    await privateEventDataProvider.storePrivateEventLog(eventSelector, msgContent, eventCommitmentIndex, {
       contractAddress,
-      recipient,
-      eventSelector,
-      msgContent,
+      scope,
       txHash,
-      eventCommitmentIndex,
-      blockNumber,
-      blockHash,
-    );
-    await privateEventDataProvider.storePrivateEventLog(
+      l2BlockNumber,
+      l2BlockHash,
+    });
+    await privateEventDataProvider.storePrivateEventLog(eventSelector, msgContent, otherEventCommitmentIndex, {
       contractAddress,
-      recipient,
-      eventSelector,
-      msgContent,
+      scope,
       txHash,
-      otherEventCommitmentIndex,
-      blockNumber,
-      blockHash,
-    );
-    const events = await privateEventDataProvider.getPrivateEvents(
+      l2BlockNumber,
+      l2BlockHash,
+    });
+
+    const events = await privateEventDataProvider.getPrivateEvents(eventSelector, {
       contractAddress,
-      blockNumber,
-      1,
-      [recipient],
-      eventSelector,
-    );
+      fromBlock: l2BlockNumber,
+      toBlock: l2BlockNumber + 1,
+      scopes: [scope],
+    });
+
     expect(events).toEqual([expectedEvent, expectedEvent]);
   });
 
@@ -135,92 +115,77 @@ describe('PrivateEventDataProvider', () => {
     expectedEvent = {
       ...expectedEvent,
       txHash: TxHash.random(),
-      blockNumber: 200,
+      l2BlockNumber: BlockNumber(200),
     };
 
-    await privateEventDataProvider.storePrivateEventLog(
+    await privateEventDataProvider.storePrivateEventLog(eventSelector, getRandomMsgContent(), 0, {
       contractAddress,
-      recipient,
-      eventSelector,
-      getRandomMsgContent(),
-      TxHash.random(),
-      0,
-      100,
-      blockHash,
-    );
-    await privateEventDataProvider.storePrivateEventLog(
+      scope,
+      txHash: TxHash.random(),
+      l2BlockNumber: BlockNumber(100),
+      l2BlockHash,
+    });
+    await privateEventDataProvider.storePrivateEventLog(eventSelector, msgContent, 1, {
       contractAddress,
-      recipient,
-      eventSelector,
-      msgContent,
-      expectedEvent.txHash,
-      1,
-      expectedEvent.blockNumber,
-      blockHash,
-    );
-    await privateEventDataProvider.storePrivateEventLog(
+      scope,
+      txHash: expectedEvent.txHash,
+      l2BlockNumber: expectedEvent.l2BlockNumber,
+      l2BlockHash: expectedEvent.l2BlockHash,
+    });
+    await privateEventDataProvider.storePrivateEventLog(eventSelector, getRandomMsgContent(), 2, {
       contractAddress,
-      recipient,
-      eventSelector,
-      getRandomMsgContent(),
-      TxHash.random(),
-      2,
-      300,
-      blockHash,
-    );
+      scope,
+      txHash: TxHash.random(),
+      l2BlockNumber: BlockNumber(300),
+      l2BlockHash,
+    });
 
-    const events = await privateEventDataProvider.getPrivateEvents(
+    const events = await privateEventDataProvider.getPrivateEvents(eventSelector, {
       contractAddress,
-      150,
-      100,
-      [recipient],
-      eventSelector,
-    );
+      fromBlock: 150,
+      toBlock: 150 + 100,
+      scopes: [scope],
+    });
 
     expect(events).toEqual([expectedEvent]); // Only includes event from block 200
   });
 
   it('filters events by recipient', async () => {
-    const otherRecipient = await AztecAddress.random();
-    await privateEventDataProvider.storePrivateEventLog(
-      contractAddress,
-      recipient,
-      eventSelector,
-      msgContent,
-      txHash,
-      eventCommitmentIndex,
-      blockNumber,
-      blockHash,
-    );
-    await privateEventDataProvider.storePrivateEventLog(
-      contractAddress,
-      otherRecipient,
-      eventSelector,
-      msgContent,
-      TxHash.random(),
-      eventCommitmentIndex + 1,
-      blockNumber,
-      blockHash,
-    );
+    const otherScope = await AztecAddress.random();
 
-    const events = await privateEventDataProvider.getPrivateEvents(
+    await privateEventDataProvider.storePrivateEventLog(eventSelector, msgContent, eventCommitmentIndex, {
       contractAddress,
-      blockNumber,
-      1,
-      [recipient],
-      eventSelector,
-    );
+      scope,
+      txHash,
+      l2BlockNumber,
+      l2BlockHash,
+    });
+    await privateEventDataProvider.storePrivateEventLog(eventSelector, msgContent, eventCommitmentIndex + 1, {
+      contractAddress,
+      scope: otherScope,
+      txHash: TxHash.random(),
+      l2BlockNumber,
+      l2BlockHash,
+    });
+
+    const events = await privateEventDataProvider.getPrivateEvents(eventSelector, {
+      contractAddress,
+      fromBlock: l2BlockNumber,
+      toBlock: l2BlockNumber + 1,
+      scopes: [scope],
+    });
+
     expect(events).toEqual([expectedEvent]);
   });
 
   it('returns empty array when no events match criteria', async () => {
-    const events = await privateEventDataProvider.getPrivateEvents(
+    const events = await privateEventDataProvider.getPrivateEvents(eventSelector, {
       contractAddress,
-      blockNumber,
-      1,
-      [recipient],
-      eventSelector,
-    );
+      fromBlock: l2BlockNumber,
+      toBlock: l2BlockNumber + 1,
+      scopes: [scope],
+    });
+
     expect(events).toEqual([]);
   });
 
@@ -236,46 +201,36 @@ describe('PrivateEventDataProvider', () => {
     });
 
     it('returns events in order by eventCommitmentIndex', async () => {
-      await privateEventDataProvider.storePrivateEventLog(
+      await privateEventDataProvider.storePrivateEventLog(eventSelector, msgContent2, 1, {
         contractAddress,
-        recipient,
-        eventSelector,
-        msgContent2,
-        TxHash.random(),
-        1, // eventCommitmentIndex
-        200,
-        blockHash,
-      );
+        scope,
+        txHash: TxHash.random(),
+        l2BlockNumber: BlockNumber(200),
+        l2BlockHash,
+      });
 
-      await privateEventDataProvider.storePrivateEventLog(
+      await privateEventDataProvider.storePrivateEventLog(eventSelector, msgContent1, 0, {
         contractAddress,
-        recipient,
-        eventSelector,
-        msgContent1,
-        TxHash.random(),
-        0, // eventCommitmentIndex
-        100,
-        blockHash,
-      );
+        scope,
+        txHash: TxHash.random(),
+        l2BlockNumber: BlockNumber(100),
+        l2BlockHash,
+      });
 
-      await privateEventDataProvider.storePrivateEventLog(
+      await privateEventDataProvider.storePrivateEventLog(eventSelector, msgContent3, 2, {
         contractAddress,
-        recipient,
-        eventSelector,
-        msgContent3,
-        TxHash.random(),
-        2, // eventCommitmentIndex
-        300,
-        blockHash,
-      );
+        scope,
+        txHash: TxHash.random(),
+        l2BlockNumber: BlockNumber(300),
+        l2BlockHash,
+      });
 
-      const events = await privateEventDataProvider.getPrivateEvents(
+      const events = await privateEventDataProvider.getPrivateEvents(eventSelector, {
         contractAddress,
-        0,
-        1000,
-        [recipient],
-        eventSelector,
-      );
+        fromBlock: 0,
+        toBlock: 0 + 1000,
+        scopes: [scope],
+      });
 
       expect(events.map(e => e.packedEvent)).toEqual([msgContent1, msgContent2, msgContent3]);
     });

--- a/yarn-project/pxe/src/storage/private_event_data_provider/private_event_data_provider.ts
+++ b/yarn-project/pxe/src/storage/private_event_data_provider/private_event_data_provider.ts
@@ -1,3 +1,4 @@
+import { BlockNumber } from '@aztec/foundation/branded-types';
 import { Fr } from '@aztec/foundation/fields';
 import { createLogger } from '@aztec/foundation/log';
 import { BufferReader, serializeToBuffer } from '@aztec/foundation/serialize';
@@ -5,17 +6,30 @@ import type { AztecAsyncArray, AztecAsyncKVStore, AztecAsyncMap } from '@aztec/k
 import type { EventSelector } from '@aztec/stdlib/abi';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
 import { L2BlockHash } from '@aztec/stdlib/block';
-import { TxHash } from '@aztec/stdlib/tx';
+import { type InTx, TxHash } from '@aztec/stdlib/tx';
 
-import type { PrivateEvent } from '../../pxe.js';
+import type { PackedPrivateEvent } from '../../pxe.js';
 
-interface PrivateEventEntry {
+export type PrivateEventDataProviderFilter = {
+  contractAddress: AztecAddress;
+  fromBlock: number;
+  toBlock: number;
+  scopes: AztecAddress[];
+  txHash?: TxHash;
+};
+
+type PrivateEventEntry = {
   msgContent: Buffer;
-  blockNumber: number;
-  blockHash: Buffer;
   eventCommitmentIndex: number;
+  l2BlockNumber: number;
+  l2BlockHash: Buffer;
   txHash: Buffer;
-}
+};
+
+type PrivateEventMetadata = InTx & {
+  contractAddress: AztecAddress;
+  scope: AztecAddress;
+};
 
 /**
  * Stores decrypted private event logs.
@@ -24,7 +38,7 @@ export class PrivateEventDataProvider {
   #store: AztecAsyncKVStore;
   /** Array storing the actual private event log entries containing the log content and block number */
   #eventLogs: AztecAsyncArray<PrivateEventEntry>;
-  /** Map from contract_address_recipient_eventSelector to array of indices into #eventLogs for efficient lookup */
+  /** Map from contract_address_scope_eventSelector to array of indices into #eventLogs for efficient lookup */
   #eventLogIndex: AztecAsyncMap<string, number[]>;
   /** Map from eventCommitmentIndex to boolean indicating if log has been seen. */
   #seenLogs: AztecAsyncMap<number, boolean>;
@@ -38,28 +52,31 @@ export class PrivateEventDataProvider {
     this.#seenLogs = this.#store.openMap('seen_logs');
   }
 
+  #keyFor(contractAddress: AztecAddress, scope: AztecAddress, eventSelector: EventSelector): string {
+    return `${contractAddress.toString()}_${scope.toString()}_${eventSelector.toString()}`;
+  }
+
   /**
    * Store a private event log.
-   * @param contractAddress - The address of the contract that emitted the event.
-   * @param recipient - The recipient of the event.
    * @param eventSelector - The event selector of the event.
    * @param msgContent - The content of the event.
-   * @param txHash - The transaction hash of the event log.
    * @param eventCommitmentIndex - The index of the event commitment in the nullifier tree.
-   * @param blockNumber - The block number in which the event was emitted.
+   * @param metadata
+   *  contractAddress - The address of the contract that emitted the event.
+   *  scope - The address to which the event is scoped.
+   *  txHash - The transaction hash of the event log.
+   *  blockNumber - The block number in which the event was emitted.
    */
   storePrivateEventLog(
-    contractAddress: AztecAddress,
-    recipient: AztecAddress,
     eventSelector: EventSelector,
     msgContent: Fr[],
-    txHash: TxHash,
     eventCommitmentIndex: number,
-    blockNumber: number,
-    blockHash: L2BlockHash,
+    metadata: PrivateEventMetadata,
   ): Promise<void> {
+    const { contractAddress, scope, txHash, l2BlockNumber, l2BlockHash } = metadata;
+
     return this.#store.transactionAsync(async () => {
-      const key = `${contractAddress.toString()}_${recipient.toString()}_${eventSelector.toString()}`;
+      const key = this.#keyFor(contractAddress, scope, eventSelector);
 
       // Check if this exact log has already been stored using eventCommitmentIndex as unique identifier
       const hasBeenSeen = await this.#seenLogs.getAsync(eventCommitmentIndex);
@@ -68,13 +85,13 @@ export class PrivateEventDataProvider {
         return;
       }
 
-      this.logger.verbose('storing private event log', { contractAddress, recipient, msgContent, blockNumber });
+      this.logger.verbose('storing private event log', { contractAddress, scope, msgContent, l2BlockNumber });
 
       const index = await this.#eventLogs.lengthAsync();
       await this.#eventLogs.push({
         msgContent: serializeToBuffer(msgContent),
-        blockNumber,
-        blockHash: blockHash.toBuffer(),
+        l2BlockNumber,
+        l2BlockHash: l2BlockHash.toBuffer(),
         eventCommitmentIndex,
         txHash: txHash.toBuffer(),
       });
@@ -89,29 +106,28 @@ export class PrivateEventDataProvider {
 
   /**
    * Returns the private events given search parameters.
-   * @param contractAddress - The address of the contract to get events from.
-   * @param from - The block number to search from.
-   * @param numBlocks - The amount of blocks to search.
-   * @param recipients - The addresses that decrypted the logs.
    * @param eventSelector - The event selector to filter by.
-   * @returns - The event log contents.
+   * @param filter - Filtering criteria:
+   *  contractAddress: The address of the contract to get events from.
+   *  fromBlock: The block number to search from (inclusive).
+   *  toBlock: The block number to search upto (exclusive).
+   *  scope: - The addresses that decrypted the logs.
+   * @returns - The event log contents, augmented with metadata about
+   *  the transaction and block it the event was included in .
    */
   public async getPrivateEvents(
-    contractAddress: AztecAddress,
-    from: number,
-    numBlocks: number,
-    recipients: AztecAddress[],
     eventSelector: EventSelector,
-  ): Promise<PrivateEvent[]> {
-    const events: Array<{ eventCommitmentIndex: number; event: PrivateEvent }> = [];
+    filter: PrivateEventDataProviderFilter,
+  ): Promise<PackedPrivateEvent[]> {
+    const events: Array<{ eventCommitmentIndex: number; event: PackedPrivateEvent }> = [];
 
-    for (const recipient of recipients) {
-      const key = `${contractAddress.toString()}_${recipient.toString()}_${eventSelector.toString()}`;
+    for (const scope of filter.scopes) {
+      const key = this.#keyFor(filter.contractAddress, scope, eventSelector);
       const indices = (await this.#eventLogIndex.getAsync(key)) || [];
 
       for (const index of indices) {
         const entry = await this.#eventLogs.atAsync(index);
-        if (!entry || entry.blockNumber < from || entry.blockNumber >= from + numBlocks) {
+        if (!entry || entry.l2BlockNumber < filter.fromBlock || entry.l2BlockNumber >= filter.toBlock) {
           continue;
         }
 
@@ -120,16 +136,19 @@ export class PrivateEventDataProvider {
         const numFields = entry.msgContent.length / Fr.SIZE_IN_BYTES;
         const msgContent = reader.readArray(numFields, Fr);
         const txHash = TxHash.fromBuffer(entry.txHash);
-        const blockHash = L2BlockHash.fromBuffer(entry.blockHash);
+        const l2BlockHash = L2BlockHash.fromBuffer(entry.l2BlockHash);
+
+        if (filter.txHash && !txHash.equals(filter.txHash)) {
+          continue;
+        }
 
         events.push({
           eventCommitmentIndex: entry.eventCommitmentIndex,
           event: {
             packedEvent: msgContent,
-            blockNumber: entry.blockNumber,
-            recipient,
+            l2BlockNumber: BlockNumber(entry.l2BlockNumber),
             txHash,
-            blockHash,
+            l2BlockHash,
             eventSelector,
           },
         });

--- a/yarn-project/stdlib/src/block/in_block.ts
+++ b/yarn-project/stdlib/src/block/in_block.ts
@@ -15,15 +15,21 @@ export type DataInBlock<T> = {
   data: T;
 } & InBlock;
 
-export function randomInBlock<T>(data: T): DataInBlock<T> {
+export function randomInBlock(): InBlock {
   return {
-    data,
     l2BlockNumber: BlockNumber(Math.floor(Math.random() * 1000)),
     l2BlockHash: L2BlockHash.random(),
   };
 }
 
-export async function wrapInBlock<T>(data: T, block: L2Block): Promise<DataInBlock<T>> {
+export function randomDataInBlock<T>(data: T): DataInBlock<T> {
+  return {
+    ...randomInBlock(),
+    data,
+  };
+}
+
+export async function wrapDataInBlock<T>(data: T, block: L2Block): Promise<DataInBlock<T>> {
   return {
     data,
     l2BlockNumber: block.number,
@@ -31,10 +37,13 @@ export async function wrapInBlock<T>(data: T, block: L2Block): Promise<DataInBlo
   };
 }
 
-export function inBlockSchemaFor<T extends ZodTypeAny>(schema: T) {
+export function inBlockSchema() {
   return z.object({
-    data: schema,
     l2BlockNumber: BlockNumberSchema,
     l2BlockHash: L2BlockHash.schema,
   });
+}
+
+export function dataInBlockSchemaFor<T extends ZodTypeAny>(schema: T) {
+  return inBlockSchema().extend({ data: schema });
 }

--- a/yarn-project/stdlib/src/interfaces/aztec-node.ts
+++ b/yarn-project/stdlib/src/interfaces/aztec-node.ts
@@ -21,7 +21,7 @@ import { z } from 'zod';
 
 import type { AztecAddress } from '../aztec-address/index.js';
 import { type BlockParameter, BlockParameterSchema } from '../block/block_parameter.js';
-import { type DataInBlock, inBlockSchemaFor } from '../block/in_block.js';
+import { type DataInBlock, dataInBlockSchemaFor } from '../block/in_block.js';
 import { L2Block } from '../block/l2_block.js';
 import { type L2BlockSource, type L2Tips, L2TipsSchema } from '../block/l2_block_source.js';
 import { PublishedL2Block } from '../block/published_l2_block.js';
@@ -502,7 +502,7 @@ export const AztecNodeApiSchema: ApiSchemaFor<AztecNode> = {
   findLeavesIndexes: z
     .function()
     .args(BlockParameterSchema, z.nativeEnum(MerkleTreeId), z.array(schemas.Fr).max(MAX_RPC_LEN))
-    .returns(z.array(optional(inBlockSchemaFor(schemas.BigInt)))),
+    .returns(z.array(optional(dataInBlockSchemaFor(schemas.BigInt)))),
 
   getNullifierSiblingPath: z
     .function()

--- a/yarn-project/stdlib/src/tx/in_tx.ts
+++ b/yarn-project/stdlib/src/tx/in_tx.ts
@@ -1,0 +1,24 @@
+import { z } from 'zod';
+
+import { type InBlock, inBlockSchema, randomInBlock } from '../block/in_block.js';
+import { TxHash } from './tx_hash.js';
+
+export type InTx = InBlock & {
+  txHash: TxHash;
+};
+
+export function randomInTx(): InTx {
+  return {
+    ...randomInBlock(),
+    txHash: TxHash.random(),
+  };
+}
+
+export function inTxSchema() {
+  return z.intersection(
+    inBlockSchema(),
+    z.object({
+      txHash: TxHash.schema,
+    }),
+  );
+}

--- a/yarn-project/stdlib/src/tx/index.ts
+++ b/yarn-project/stdlib/src/tx/index.ts
@@ -32,3 +32,4 @@ export * from './offchain_effect.js';
 export * from './profiling.js';
 export * from './protocol_contracts.js';
 export * from './execution_payload.js';
+export * from './in_tx.js';

--- a/yarn-project/stdlib/src/tx/indexed_tx_effect.ts
+++ b/yarn-project/stdlib/src/tx/indexed_tx_effect.ts
@@ -3,18 +3,18 @@ import { schemas } from '@aztec/foundation/schemas';
 import { BufferReader, serializeToBuffer } from '@aztec/foundation/serialize';
 
 import { L2BlockHash } from '../block/block_hash.js';
-import { type DataInBlock, inBlockSchemaFor, randomInBlock } from '../block/in_block.js';
+import { type DataInBlock, dataInBlockSchemaFor, randomDataInBlock } from '../block/in_block.js';
 import { TxEffect } from './tx_effect.js';
 
 export type IndexedTxEffect = DataInBlock<TxEffect> & { txIndexInBlock: number };
 
 export function indexedTxSchema() {
-  return inBlockSchemaFor(TxEffect.schema).extend({ txIndexInBlock: schemas.Integer });
+  return dataInBlockSchemaFor(TxEffect.schema).extend({ txIndexInBlock: schemas.Integer });
 }
 
 export async function randomIndexedTxEffect(): Promise<IndexedTxEffect> {
   return {
-    ...randomInBlock(await TxEffect.random({ numNullifiers: 1 + Math.floor(Math.random() * 64) })),
+    ...randomDataInBlock(await TxEffect.random({ numNullifiers: 1 + Math.floor(Math.random() * 64) })),
     txIndexInBlock: Math.floor(Math.random() * 1000),
   };
 }

--- a/yarn-project/wallet-sdk/src/base-wallet/base_wallet.test.ts
+++ b/yarn-project/wallet-sdk/src/base-wallet/base_wallet.test.ts
@@ -1,9 +1,10 @@
 import type { Account } from '@aztec/aztec.js/account';
 import type { AztecNode } from '@aztec/aztec.js/node';
-import type { Aliased } from '@aztec/aztec.js/wallet';
+import type { Aliased, PrivateEvent } from '@aztec/aztec.js/wallet';
+import { BlockNumber } from '@aztec/foundation/branded-types';
 import { Fr } from '@aztec/foundation/fields';
 import { TokenContract, type Transfer } from '@aztec/noir-contracts.js/Token';
-import { PXE, type PrivateEvent } from '@aztec/pxe/server';
+import { PXE, type PackedPrivateEvent } from '@aztec/pxe/server';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import { L2BlockHash } from '@aztec/stdlib/block';
 import { TxHash } from '@aztec/stdlib/tx';
@@ -51,12 +52,11 @@ describe('BaseWallet', () => {
   }
 
   // eslint-disable-next-line jsdoc/require-jsdoc
-  async function privateEventFor(serial: Fr[]): Promise<PrivateEvent> {
+  function privateEventFor(serial: Fr[]): PackedPrivateEvent {
     return {
       packedEvent: serial,
-      recipient: await AztecAddress.random(),
-      blockHash: L2BlockHash.random(),
-      blockNumber: 42,
+      l2BlockHash: L2BlockHash.random(),
+      l2BlockNumber: BlockNumber(42),
       txHash: TxHash.random(),
       eventSelector: TokenContract.events.Transfer.eventSelector,
     };
@@ -72,21 +72,38 @@ describe('BaseWallet', () => {
     const transfer1Serialized: Fr[] = encodeTransfer(transfer1);
     const transfer2Serialized: Fr[] = encodeTransfer(transfer2);
 
-    pxe.getPrivateEvents.mockResolvedValue([
-      await privateEventFor(transfer1Serialized),
-      await privateEventFor(transfer2Serialized),
-    ]);
+    const packedPrivateEventTransfer1: PackedPrivateEvent = privateEventFor(transfer1Serialized);
+    const packedPrivateEventTransfer2: PackedPrivateEvent = privateEventFor(transfer2Serialized);
+
+    const privateEventTransfer1: PrivateEvent<Transfer> = {
+      event: transfer1,
+      metadata: {
+        l2BlockNumber: packedPrivateEventTransfer1.l2BlockNumber,
+        l2BlockHash: packedPrivateEventTransfer1.l2BlockHash,
+        txHash: packedPrivateEventTransfer1.txHash,
+      },
+    };
+
+    const privateEventTransfer2: PrivateEvent<Transfer> = {
+      event: transfer2,
+      metadata: {
+        l2BlockNumber: packedPrivateEventTransfer2.l2BlockNumber,
+        l2BlockHash: packedPrivateEventTransfer2.l2BlockHash,
+        txHash: packedPrivateEventTransfer2.txHash,
+      },
+    };
+
+    pxe.getPrivateEvents.mockResolvedValue([packedPrivateEventTransfer1, packedPrivateEventTransfer2]);
 
     const basicWallet = new BasicWallet(pxe, node);
 
-    const events = await basicWallet.getPrivateEvents<Transfer>(
-      await AztecAddress.random(),
-      TokenContract.events.Transfer,
-      42,
-      1,
-      [await AztecAddress.random()],
-    );
+    const events = await basicWallet.getPrivateEvents<Transfer>(TokenContract.events.Transfer, {
+      contractAddress: await AztecAddress.random(),
+      fromBlock: BlockNumber(42),
+      toBlock: BlockNumber(43),
+      scopes: [await AztecAddress.random()],
+    });
 
-    expect(events).toEqual([transfer1, transfer2]);
+    expect(events).toEqual([privateEventTransfer1, privateEventTransfer2]);
   });
 });

--- a/yarn-project/wallet-sdk/src/base-wallet/base_wallet.ts
+++ b/yarn-project/wallet-sdk/src/base-wallet/base_wallet.ts
@@ -6,6 +6,8 @@ import type {
   BatchResults,
   BatchableMethods,
   BatchedMethod,
+  PrivateEvent,
+  PrivateEventFilter,
   ProfileOptions,
   SendOptions,
   SimulateOptions,
@@ -22,7 +24,7 @@ import type { ChainInfo } from '@aztec/entrypoints/interfaces';
 import { Fr } from '@aztec/foundation/fields';
 import { createLogger } from '@aztec/foundation/log';
 import type { FieldsOf } from '@aztec/foundation/types';
-import type { PXE } from '@aztec/pxe/server';
+import type { PXE, PackedPrivateEvent } from '@aztec/pxe/server';
 import {
   type ContractArtifact,
   type EventMetadataDefinition,
@@ -325,17 +327,21 @@ export abstract class BaseWallet implements Wallet {
   }
 
   async getPrivateEvents<T>(
-    contractAddress: AztecAddress,
     eventDef: EventMetadataDefinition,
-    from: number,
-    limit: number,
-    recipients: AztecAddress[] = [],
-  ): Promise<T[]> {
-    const events = await this.pxe.getPrivateEvents(contractAddress, eventDef.eventSelector, from, limit, recipients);
+    eventFilter: PrivateEventFilter,
+  ): Promise<PrivateEvent<T>[]> {
+    const pxeEvents = await this.pxe.getPrivateEvents(eventDef.eventSelector, eventFilter);
 
-    const decodedEvents = events.map(
-      (event: any /** PrivateEvent */): T => decodeFromAbi([eventDef.abiType], event.packedEvent) as T,
-    );
+    const decodedEvents = pxeEvents.map((pxeEvent: PackedPrivateEvent): PrivateEvent<T> => {
+      return {
+        event: decodeFromAbi([eventDef.abiType], pxeEvent.packedEvent) as T,
+        metadata: {
+          l2BlockNumber: pxeEvent.l2BlockNumber,
+          l2BlockHash: pxeEvent.l2BlockHash,
+          txHash: pxeEvent.txHash,
+        },
+      };
+    });
 
     return decodedEvents;
   }


### PR DESCRIPTION
Related to https://github.com/AztecProtocol/aztec-packages/issues/16245
Part of F-96

## New types

### Wallet interface
  - `PrivateEvent<T>`: bundles together an ABI decoded event and contextual metadata.
  - `PrivateEventFilter`: weaker version of `PrivateEvent` to represent filters. Takes some hints from Aztec Node's `LogFilter` for consistency.

### PXE
 - `PackedPrivateEvent`: private event contents in its Field array representation plus metadata.

## Quirks

Aztec Node's `LogFilter` establishes `fromBlock` to be inclusive, and `toBlock` exclusive, so I'm leaning towards respecting that convention here to keep a consistent approach. It results in some idiosyncratic choices when defining defaults. At a first approximation, I think defaulting to "returns events emitted in the latest known block" is reasonable, but open to other ideas.