### PR TITLE
chore: remove `GetParameterView`

### DIFF
--- a/barretenberg/cpp/src/barretenberg/relations/databus_lookup_relation.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/databus_lookup_relation.hpp
@@ -207,8 +207,7 @@ template <typename FF_> class DatabusLookupRelationImpl {
     static Accumulator compute_write_term(const AllEntities& in, const Parameters& params)
     {
         using CoefficientAccumulator = typename Accumulator::CoefficientAccumulator;
-        using ParameterCoefficientAccumulator =
-            typename GetParameterView<Parameters, typename Accumulator::View>::CoefficientAccumulator;
+        using ParameterCoefficientAccumulator = typename Parameters::DataType::CoefficientAccumulator;
 
         const auto& id = CoefficientAccumulator(in.databus_id);
         const auto& value = CoefficientAccumulator(BusData<bus_idx, AllEntities>::values(in));
@@ -229,9 +228,7 @@ template <typename FF_> class DatabusLookupRelationImpl {
     static Accumulator compute_read_term(const AllEntities& in, const Parameters& params)
     {
         using CoefficientAccumulator = typename Accumulator::CoefficientAccumulator;
-        using View = typename Accumulator::View;
-        using ParameterView = GetParameterView<Parameters, View>;
-        using ParameterCoefficientAccumulator = typename ParameterView::CoefficientAccumulator;
+        using ParameterCoefficientAccumulator = typename Parameters::DataType::CoefficientAccumulator;
 
         // Bus value stored in w_1, index into bus column stored in w_2
         const auto& w_1 = CoefficientAccumulator(in.w_l);

--- a/barretenberg/cpp/src/barretenberg/relations/logderiv_lookup_relation.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/logderiv_lookup_relation.hpp
@@ -140,9 +140,7 @@ template <typename FF_> class LogDerivLookupRelationImpl {
     template <typename Accumulator, typename AllEntities, typename Parameters>
     static Accumulator compute_write_term(const AllEntities& in, const Parameters& params)
     {
-        using View = typename Accumulator::View;
-        using ParameterView = GetParameterView<Parameters, View>;
-        using ParameterCoefficientAccumulator = typename ParameterView::CoefficientAccumulator;
+        using ParameterCoefficientAccumulator = typename Parameters::DataType::CoefficientAccumulator;
         using CoefficientAccumulator = typename Accumulator::CoefficientAccumulator;
 
         const auto gamma = ParameterCoefficientAccumulator(params.gamma);
@@ -165,9 +163,7 @@ template <typename FF_> class LogDerivLookupRelationImpl {
     template <typename Accumulator, typename AllEntities, typename Parameters>
     static Accumulator compute_read_term(const AllEntities& in, const Parameters& params)
     {
-        using View = typename Accumulator::View;
-        using ParameterView = GetParameterView<Parameters, View>;
-        using ParameterCoefficientAccumulator = typename ParameterView::CoefficientAccumulator;
+        using ParameterCoefficientAccumulator = typename Parameters::DataType::CoefficientAccumulator;
         using CoefficientAccumulator = typename Accumulator::CoefficientAccumulator;
 
         const auto gamma = ParameterCoefficientAccumulator(params.gamma);

--- a/barretenberg/cpp/src/barretenberg/relations/memory_relation.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/memory_relation.hpp
@@ -65,11 +65,9 @@ template <typename FF_> class MemoryRelationImpl {
         // if there were one that were shorter, we could also profitably use a `ShortAccumulator` type. however,
         // that is not the case here.
         using Accumulator = typename std::tuple_element_t<0, ContainerOverSubrelations>;
-        using View = typename Accumulator::View;
         using CoefficientAccumulator = typename Accumulator::CoefficientAccumulator;
 
-        using ParameterView = GetParameterView<Parameters, View>;
-        using ParameterCoefficientAccumulator = typename ParameterView::CoefficientAccumulator;
+        using ParameterCoefficientAccumulator = typename Parameters::DataType::CoefficientAccumulator;
 
         const auto& eta_m = ParameterCoefficientAccumulator(params.eta);
         const auto& eta_two_m = ParameterCoefficientAccumulator(params.eta_two);

--- a/barretenberg/cpp/src/barretenberg/relations/permutation_relation.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/permutation_relation.hpp
@@ -54,7 +54,7 @@ template <typename FF_> class UltraPermutationRelationImpl {
     inline static Accumulator compute_grand_product_numerator(const AllEntities& in, const Parameters& params)
     {
         using View = typename Accumulator::View;
-        using ParameterView = GetParameterView<Parameters, View>;
+        using ParameterView = Parameters::DataType;
 
         auto w_1 = View(in.w_l);
         auto w_2 = View(in.w_r);
@@ -77,7 +77,7 @@ template <typename FF_> class UltraPermutationRelationImpl {
     inline static Accumulator compute_grand_product_denominator(const AllEntities& in, const Parameters& params)
     {
         using View = typename Accumulator::View;
-        using ParameterView = GetParameterView<Parameters, View>;
+        using ParameterView = Parameters::DataType;
 
         auto w_1 = View(in.w_l);
         auto w_2 = View(in.w_r);
@@ -121,9 +121,8 @@ template <typename FF_> class UltraPermutationRelationImpl {
     {
         // Contribution (1)
         using Accumulator = std::tuple_element_t<0, ContainerOverSubrelations>;
-        using View = typename Accumulator::View;
         using CoefficientAccumulator = typename Accumulator::CoefficientAccumulator;
-        using ParameterView = GetParameterView<Parameters, View>;
+        using ParameterView = Parameters::DataType;
         using ParameterCoefficientAccumulator = typename ParameterView::CoefficientAccumulator;
 
         const CoefficientAccumulator w_1_m(in.w_l);

--- a/barretenberg/cpp/src/barretenberg/relations/relation_types.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/relation_types.hpp
@@ -14,19 +14,6 @@ concept IsField = std::same_as<T, bb::fr> /* || std::same_as<T, grumpkin::fr> */
 
 namespace bb {
 
-/**
- * @brief A type to optionally extract a view of a relation parameter in a relation.
- *
- * @details In sumcheck, challenges in relations are always field elements, but in folding we need univariate
- * challenges. This template inspecting the underlying type of a RelationParameters instance. When this type is a field
- * type, do nothing, otherwise apply the provided view type.
- * @tparam Params
- * @tparam View
- * @todo TODO(https://github.com/AztecProtocol/barretenberg/issues/759): Optimize
- */
-template <typename Params, typename View>
-using GetParameterView = std::conditional_t<IsField<typename Params::DataType>, typename Params::DataType, View>;
-
 template <typename T>
 concept HasSubrelationLinearlyIndependentMember = requires(T) {
     { std::get<0>(T::SUBRELATION_LINEARLY_INDEPENDENT) } -> std::convertible_to<bool>;

--- a/barretenberg/cpp/src/barretenberg/relations/translator_vm/translator_permutation_relation.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/translator_vm/translator_permutation_relation.hpp
@@ -38,7 +38,7 @@ template <typename FF_> class TranslatorPermutationRelationImpl {
     inline static Accumulator compute_grand_product_numerator(const AllEntities& in, const Parameters& params)
     {
         using View = typename Accumulator::View;
-        using ParameterView = GetParameterView<Parameters, View>;
+        using ParameterView = Parameters::DataType;
 
         auto interleaved_range_constraints_0 = View(in.interleaved_range_constraints_0);
         auto interleaved_range_constraints_1 = View(in.interleaved_range_constraints_1);
@@ -61,7 +61,7 @@ template <typename FF_> class TranslatorPermutationRelationImpl {
     inline static Accumulator compute_grand_product_denominator(const AllEntities& in, const Parameters& params)
     {
         using View = typename Accumulator::View;
-        using ParameterView = GetParameterView<Parameters, View>;
+        using ParameterView = Parameters::DataType;
 
         auto ordered_range_constraints_0 = View(in.ordered_range_constraints_0);
         auto ordered_range_constraints_1 = View(in.ordered_range_constraints_1);


### PR DESCRIPTION
No longer necessary now that Protogalaxy is gone. In particular, I think [759](https://github.com/AztecProtocol/barretenberg/issues/759) has resolved itself.