### PR TITLE
refactor: Migrate --update_inputs flag to --vk_policy option

### DIFF
--- a/barretenberg/cpp/scripts/test_chonk_standalone_vks_havent_changed.sh
+++ b/barretenberg/cpp/scripts/test_chonk_standalone_vks_havent_changed.sh
@@ -77,7 +77,7 @@ function check_circuit_vks {
   local exit_code=0
 
   if [[ "${2:-}" == "--update_inputs" ]]; then
-    output=$($bb check --update_inputs --scheme chonk --ivc_inputs_path "$flow_folder/ivc-inputs.msgpack" 2>&1) || exit_code=$?
+    output=$($bb check --vk_policy=rewrite --scheme chonk --ivc_inputs_path "$flow_folder/ivc-inputs.msgpack" 2>&1) || exit_code=$?
   else
     output=$($bb check --scheme chonk --ivc_inputs_path "$flow_folder/ivc-inputs.msgpack" 2>&1) || exit_code=$?
   fi

--- a/barretenberg/cpp/src/barretenberg/api/api.hpp
+++ b/barretenberg/cpp/src/barretenberg/api/api.hpp
@@ -23,7 +23,6 @@ class API {
         bool include_gates_per_opcode{ false }; // should we include gates_per_opcode in the gates command output
         bool slow_low_memory{ false };          // use file backed memory for polynomials
         std::string storage_budget;             // storage budget for file backed memory (e.g. "500m", "2g")
-        bool update_inputs{ false };            // update inputs when check fails
         std::string vk_policy{ "default" };     // policy for handling VKs during IVC accumulation
 
         bool optimized_solidity_verifier{ false }; // should we use the optimized sol verifier? (temp)

--- a/barretenberg/cpp/src/barretenberg/api/api_chonk.cpp
+++ b/barretenberg/cpp/src/barretenberg/api/api_chonk.cpp
@@ -151,6 +151,7 @@ bool ChonkAPI::check_precomputed_vks(const Flags& flags, const std::filesystem::
     bbapi::BBApiRequest request;
     std::vector<PrivateExecutionStepRaw> raw_steps = PrivateExecutionStepRaw::load_and_decompress(input_path);
 
+    bbapi::VkPolicy vk_policy = bbapi::parse_vk_policy(flags.vk_policy);
     bool check_failed = false;
     for (auto& step : raw_steps) {
         if (step.vk.empty()) {
@@ -163,7 +164,7 @@ bool ChonkAPI::check_precomputed_vks(const Flags& flags, const std::filesystem::
 
         if (!response.valid) {
             info("VK mismatch detected for function ", step.function_name);
-            if (!flags.update_inputs) {
+            if (vk_policy != bbapi::VkPolicy::REWRITE) {
                 info("Computed VK differs from precomputed VK in ivc-inputs.msgpack");
                 return false;
             }

--- a/barretenberg/cpp/src/barretenberg/api/api_chonk.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/api/api_chonk.test.cpp
@@ -320,8 +320,8 @@ TEST_F(ChonkAPITests, CheckPrecomputedVksMismatch)
     bool result = api.check_precomputed_vks(ChonkAPI::Flags{}, input_path);
     EXPECT_FALSE(result);
 
-    // Check with --update_input should still fail but update the VK in the input.
-    result = api.check_precomputed_vks(ChonkAPI::Flags{ .update_inputs = true }, input_path);
+    // Check with --vk_policy=rewrite should still fail but update the VK in the input.
+    result = api.check_precomputed_vks(ChonkAPI::Flags{ .vk_policy = "rewrite" }, input_path);
     EXPECT_FALSE(result);
 
     // Check again and it should succeed with the updated VK.

--- a/barretenberg/cpp/src/barretenberg/bb/cli.cpp
+++ b/barretenberg/cpp/src/barretenberg/bb/cli.cpp
@@ -280,18 +280,15 @@ int parse_and_run_cli_command(int argc, char* argv[])
                                       "back to RAM (requires --slow_low_memory).");
     };
 
-    const auto add_update_inputs_flag = [&](CLI::App* subcommand) {
-        return subcommand->add_flag("--update_inputs", flags.update_inputs, "Update inputs if vk check fails.");
-    };
-
     const auto add_vk_policy_option = [&](CLI::App* subcommand) {
         return subcommand
             ->add_option("--vk_policy",
                          flags.vk_policy,
-                         "Policy for handling verification keys during IVC accumulation. 'default' uses the provided "
-                         "VK as-is, 'check' verifies the provided VK matches the computed VK (throws error on "
-                         "mismatch), 'recompute' always ignores the provided VK and treats it as nullptr.")
-            ->check(CLI::IsMember({ "default", "check", "recompute" }).name("is_member"));
+                         "Policy for handling verification keys. 'default' uses the provided VK as-is, 'check' "
+                         "verifies the provided VK matches the computed VK (throws error on mismatch), 'recompute' "
+                         "always ignores the provided VK and treats it as nullptr, 'rewrite' checks the VK and "
+                         "rewrites the input file with the correct VK if there's a mismatch (for check command).")
+            ->check(CLI::IsMember({ "default", "check", "recompute", "rewrite" }).name("is_member"));
     };
 
     const auto add_optimized_solidity_verifier_flag = [&](CLI::App* subcommand) {
@@ -342,7 +339,7 @@ int parse_and_run_cli_command(int argc, char* argv[])
     add_bytecode_path_option(check);
     add_witness_path_option(check);
     add_ivc_inputs_path_options(check);
-    add_update_inputs_flag(check);
+    add_vk_policy_option(check);
 
     /***************************************************************************************************************
      * Subcommand: gates

--- a/barretenberg/cpp/src/barretenberg/bbapi/bbapi_shared.hpp
+++ b/barretenberg/cpp/src/barretenberg/bbapi/bbapi_shared.hpp
@@ -21,9 +21,10 @@ namespace bb::bbapi {
  * @brief Policy for handling verification keys during IVC accumulation
  */
 enum class VkPolicy {
-    DEFAULT,  // Use the provided VK as-is (default behavior)
-    CHECK,    // Verify the provided VK matches the computed VK, throw error if mismatch
-    RECOMPUTE // Always ignore the provided VK and treat it as nullptr
+    DEFAULT,   // Use the provided VK as-is (default behavior)
+    CHECK,     // Verify the provided VK matches the computed VK, throw error if mismatch
+    RECOMPUTE, // Always ignore the provided VK and treat it as nullptr
+    REWRITE    // Check the VK and rewrite the input file with correct VK if mismatch (for check command)
 };
 
 /**
@@ -136,6 +137,9 @@ inline VkPolicy parse_vk_policy(const std::string& policy)
     }
     if (policy == "recompute") {
         return VkPolicy::RECOMPUTE;
+    }
+    if (policy == "rewrite") {
+        return VkPolicy::REWRITE;
     }
     return VkPolicy::DEFAULT; // default
 }


### PR DESCRIPTION
## Summary

Replace the boolean `--update_inputs` flag with a new `--vk_policy=rewrite` option to provide more flexibility in handling verification keys.

## Changes

- Add `REWRITE` policy to `VkPolicy` enum
- Update CLI to accept 'rewrite' as a valid vk_policy value  
- Remove `update_inputs` field from `API::Flags`
- Update `check_precomputed_vks` to use `vk_policy` instead of `update_inputs`
- Update tests and scripts to use `--vk_policy=rewrite`

## Behavior

The new `--vk_policy=rewrite` provides the same functionality as the old `--update_inputs` flag: when a VK check fails, it rewrites the input file with the correct VK. This change provides better consistency with the existing vk_policy options (default, check, recompute).

## Testing

- Unit tests pass (`CheckPrecomputedVks` and `CheckPrecomputedVksMismatch`)
- Verified CLI accepts `--vk_policy=rewrite` and rejects old `--update_inputs` flag
- Scripts updated to use new flag

## Migration Guide

Replace `--update_inputs` with `--vk_policy=rewrite`:

**Before:**
```bash
bb check --update_inputs --scheme chonk --ivc_inputs_path inputs.msgpack
```

**After:**
```bash
bb check --vk_policy=rewrite --scheme chonk --ivc_inputs_path inputs.msgpack
```