### PR TITLE
feat: avm recursive verifier with short scalars

### DIFF
--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/utils/batch_mul_native.hpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/utils/batch_mul_native.hpp
@@ -17,13 +17,13 @@ namespace bb {
  * @note This is used only for native verification and is not optimized for efficiency
  */
 template <typename Commitment, typename FF>
-static Commitment batch_mul_native(const std::vector<Commitment>& _points, const std::vector<FF>& _scalars)
+static Commitment batch_mul_native(std::span<const Commitment> _points, std::span<const FF> _scalars)
 {
     std::vector<Commitment> points;
     std::vector<FF> scalars;
     for (size_t i = 0; i < _points.size(); ++i) {
-        const auto& point = _points[i];
-        const auto& scalar = _scalars[i];
+        auto point = _points[i];
+        auto scalar = _scalars[i];
 
         // TODO: Special handling of point at infinity here due to incorrect serialization.
         if (!scalar.is_zero() && !point.is_point_at_infinity() && !point.y.is_zero()) {
@@ -41,6 +41,24 @@ static Commitment batch_mul_native(const std::vector<Commitment>& _points, const
         result = result + points[idx] * scalars[idx];
     }
     return result;
+}
+
+/**
+ * @brief Wrapper for batch_mul_native that accepts vectors for backward compatibility
+ */
+template <typename Commitment, typename FF>
+static Commitment batch_mul_native(const std::vector<Commitment>& _points, const std::vector<FF>& _scalars)
+{
+    return batch_mul_native<Commitment, FF>(std::span<const Commitment>(_points), std::span<const FF>(_scalars));
+}
+
+/**
+ * @brief Wrapper for batch_mul_native that accepts span + vector (common pattern)
+ */
+template <typename Commitment, typename FF>
+static Commitment batch_mul_native(std::span<const Commitment> _points, const std::vector<FF>& _scalars)
+{
+    return batch_mul_native<Commitment, FF>(_points, std::span<const FF>(_scalars));
 }
 
 } // namespace bb

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/prover.cpp
@@ -184,15 +184,15 @@ void AvmProver::execute_pcs_rounds()
         shifted_batching_challenge_labels.push_back("rho_" + std::to_string(unshifted_polys.size() - 1 + idx));
     }
 
-    // Get short (128-bit) batching challenges from transcript (must match verifier)
-    auto unshifted_tail = transcript->template get_challenges<FF>(unshifted_batching_challenge_labels);
+    // Get short batching challenges from transcript
+    auto unshifted_challenges = transcript->template get_challenges<FF>(unshifted_batching_challenge_labels);
     auto shifted_challenges = transcript->template get_challenges<FF>(shifted_batching_challenge_labels);
 
     // Batch the polynomials
     Polynomial squashed_unshifted(key->circuit_size);
     squashed_unshifted += unshifted_polys[0]; // First polynomial has coefficient 1
-    for (size_t i = 0; i < unshifted_tail.size(); ++i) {
-        squashed_unshifted.add_scaled(unshifted_polys[i + 1], unshifted_tail[i]);
+    for (size_t i = 0; i < unshifted_challenges.size(); ++i) {
+        squashed_unshifted.add_scaled(unshifted_polys[i + 1], unshifted_challenges[i]);
     }
 
     Polynomial squashed_shifted(Polynomial::shiftable(key->circuit_size));

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/prover.cpp
@@ -168,10 +168,41 @@ void AvmProver::execute_pcs_rounds()
     using OpeningClaim = ProverOpeningClaim<Curve>;
     using PolynomialBatcher = GeminiProver_<Curve>::PolynomialBatcher;
 
+    // Batch polynomials using short scalars to reduce ECCVM circuit size
+    auto unshifted_polys = prover_polynomials.get_unshifted();
+    auto shifted_polys = prover_polynomials.get_to_be_shifted();
+
+    // Generate the same batching challenge labels as on the verifier side
+    std::vector<std::string> unshifted_batching_challenge_labels;
+    unshifted_batching_challenge_labels.reserve(unshifted_polys.size() - 1);
+    for (size_t idx = 0; idx < unshifted_polys.size() - 1; idx++) {
+        unshifted_batching_challenge_labels.push_back("rho_" + std::to_string(idx));
+    }
+    std::vector<std::string> shifted_batching_challenge_labels;
+    shifted_batching_challenge_labels.reserve(shifted_polys.size());
+    for (size_t idx = 0; idx < shifted_polys.size(); idx++) {
+        shifted_batching_challenge_labels.push_back("rho_" + std::to_string(unshifted_polys.size() - 1 + idx));
+    }
+
+    // Get short (128-bit) batching challenges from transcript (must match verifier)
+    auto unshifted_tail = transcript->template get_challenges<FF>(unshifted_batching_challenge_labels);
+    auto shifted_challenges = transcript->template get_challenges<FF>(shifted_batching_challenge_labels);
+
+    // Batch the polynomials
+    Polynomial squashed_unshifted(key->circuit_size);
+    squashed_unshifted += unshifted_polys[0]; // First polynomial has coefficient 1
+    for (size_t i = 0; i < unshifted_tail.size(); ++i) {
+        squashed_unshifted.add_scaled(unshifted_polys[i + 1], unshifted_tail[i]);
+    }
+
+    Polynomial squashed_shifted(Polynomial::shiftable(key->circuit_size));
+    for (size_t i = 0; i < shifted_challenges.size(); ++i) {
+        squashed_shifted.add_scaled(shifted_polys[i], shifted_challenges[i]);
+    }
+
     PolynomialBatcher polynomial_batcher(key->circuit_size);
-    polynomial_batcher.set_unshifted(RefVector<Polynomial>::from_span(prover_polynomials.get_unshifted()));
-    polynomial_batcher.set_to_be_shifted_by_one(
-        RefVector<Polynomial>::from_span(prover_polynomials.get_to_be_shifted()));
+    polynomial_batcher.set_unshifted(RefVector{ squashed_unshifted });
+    polynomial_batcher.set_to_be_shifted_by_one(RefVector{ squashed_shifted });
 
     const OpeningClaim prover_opening_claim = ShpleminiProver_<Curve>::prove(
         key->circuit_size, polynomial_batcher, sumcheck_output.challenge, commitment_key, transcript);

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/recursion/recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/recursion/recursive_verifier.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <cstddef>
 #include <memory>
+#include <numeric>
 
 #include "barretenberg/commitment_schemes/shplonk/shplemini.hpp"
 #include "barretenberg/honk/proof_system/types/proof.hpp"
@@ -179,15 +180,52 @@ AvmRecursiveVerifier::PairingPoints AvmRecursiveVerifier::verify_proof(
                                  format("public_input_evaluation failed at column ", i));
     }
 
-    // Execute Shplemini rounds.
-    ClaimBatcher claim_batcher{
-        .unshifted = ClaimBatch{ .commitments = RefVector<Commitment>::from_span(commitments.get_unshifted()),
-                                 .evaluations = RefVector<FF>::from_span(output.claimed_evaluations.get_unshifted()) },
-        .shifted = ClaimBatch{ .commitments = RefVector<Commitment>::from_span(commitments.get_to_be_shifted()),
-                               .evaluations = RefVector<FF>::from_span(output.claimed_evaluations.get_shifted()) }
-    };
+    // Batch commitments and evaluations using short (128-bit) scalars to reduce ECCVM circuit size
+    auto unshifted_comms = commitments.get_unshifted();
+    auto unshifted_evals = output.claimed_evaluations.get_unshifted();
+    auto shifted_comms = commitments.get_to_be_shifted();
+    auto shifted_evals = output.claimed_evaluations.get_shifted();
+
+    // Generate batching challenge labels
+    // Note: We get N-1 challenges for N unshifted commitments (first commitment has implicit coefficient 1)
+    std::vector<std::string> unshifted_batching_challenge_labels;
+    unshifted_batching_challenge_labels.reserve(unshifted_comms.size() - 1);
+    for (size_t idx = 0; idx < unshifted_comms.size() - 1; idx++) {
+        unshifted_batching_challenge_labels.push_back("rho_" + std::to_string(idx));
+    }
+    std::vector<std::string> shifted_batching_challenge_labels;
+    shifted_batching_challenge_labels.reserve(shifted_comms.size());
+    for (size_t idx = 0; idx < shifted_comms.size(); idx++) {
+        shifted_batching_challenge_labels.push_back("rho_" + std::to_string(unshifted_comms.size() - 1 + idx));
+    }
+
+    // Get short (128-bit) batching challenges from transcript
+    auto unshifted_challenges = transcript->template get_challenges<FF>(unshifted_batching_challenge_labels);
+    auto shifted_challenges = transcript->template get_challenges<FF>(shifted_batching_challenge_labels);
+
+    // Batch commitments: first commitment has coefficient 1, rest are batched with challenges
+    Commitment squashed_unshifted =
+        unshifted_comms[0] +
+        Commitment::batch_mul(
+            std::vector<Commitment>(unshifted_comms.begin() + 1, unshifted_comms.end()), unshifted_challenges, 128);
+
+    Commitment squashed_shifted = Commitment::batch_mul(
+        std::vector<Commitment>(shifted_comms.begin(), shifted_comms.end()), shifted_challenges, 128);
+
+    // Batch evaluations: compute inner product with first eval as initial value for unshifted
+    FF squashed_unshifted_eval = std::inner_product(
+        unshifted_challenges.begin(), unshifted_challenges.end(), unshifted_evals.begin() + 1, unshifted_evals[0]);
+
+    FF squashed_shifted_eval =
+        std::inner_product(shifted_challenges.begin(), shifted_challenges.end(), shifted_evals.begin(), FF(0));
+
+    // Execute Shplemini rounds with squashed claims
+    ClaimBatcher squashed_claim_batcher{ .unshifted = ClaimBatch{ .commitments = RefVector(squashed_unshifted),
+                                                                  .evaluations = RefVector(squashed_unshifted_eval) },
+                                         .shifted = ClaimBatch{ .commitments = RefVector(squashed_shifted),
+                                                                .evaluations = RefVector(squashed_shifted_eval) } };
     const BatchOpeningClaim<Curve> opening_claim = Shplemini::compute_batch_opening_claim(
-        padding_indicator_array, claim_batcher, output.challenge, Commitment::one(&builder), transcript);
+        padding_indicator_array, squashed_claim_batcher, output.challenge, Commitment::one(&builder), transcript);
 
     PairingPoints pairing_points(PCS::reduce_verify_batch_opening_claim(opening_claim, transcript));
 

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/recursion/recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/recursion/recursive_verifier.cpp
@@ -180,7 +180,7 @@ AvmRecursiveVerifier::PairingPoints AvmRecursiveVerifier::verify_proof(
                                  format("public_input_evaluation failed at column ", i));
     }
 
-    // Batch commitments and evaluations using short (128-bit) scalars to reduce ECCVM circuit size
+    // Batch commitments and evaluations using short scalars to reduce ECCVM circuit size
     auto unshifted_comms = commitments.get_unshifted();
     auto unshifted_evals = output.claimed_evaluations.get_unshifted();
     auto shifted_comms = commitments.get_to_be_shifted();

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/verifier.cpp
@@ -5,6 +5,7 @@
 #include "barretenberg/numeric/bitop/get_msb.hpp"
 #include "barretenberg/transcript/transcript.hpp"
 #include "barretenberg/vm2/common/constants.hpp"
+#include <numeric>
 
 namespace bb::avm2 {
 
@@ -127,14 +128,49 @@ bool AvmVerifier::verify_proof(const HonkProof& proof, const std::vector<std::ve
         }
     }
 
-    ClaimBatcher claim_batcher{
-        .unshifted = ClaimBatch{ .commitments = RefVector<Commitment>::from_span(commitments.get_unshifted()),
-                                 .evaluations = RefVector<FF>::from_span(output.claimed_evaluations.get_unshifted()) },
-        .shifted = ClaimBatch{ .commitments = RefVector<Commitment>::from_span(commitments.get_to_be_shifted()),
-                               .evaluations = RefVector<FF>::from_span(output.claimed_evaluations.get_shifted()) }
-    };
+    // Batch commitments and evaluations using short scalars to reduce ECCVM circuit size
+    std::span<const Commitment> unshifted_comms = commitments.get_unshifted();
+    std::span<const FF> unshifted_evals = output.claimed_evaluations.get_unshifted();
+    std::span<const Commitment> shifted_comms = commitments.get_to_be_shifted();
+    std::span<const FF> shifted_evals = output.claimed_evaluations.get_shifted();
+
+    // Generate batching challenge labels
+    // Note: We get N-1 challenges for N unshifted commitments (first commitment has implicit coefficient 1)
+    std::vector<std::string> unshifted_batching_challenge_labels;
+    unshifted_batching_challenge_labels.reserve(unshifted_comms.size() - 1);
+    for (size_t idx = 0; idx < unshifted_comms.size() - 1; idx++) {
+        unshifted_batching_challenge_labels.push_back("rho_" + std::to_string(idx));
+    }
+    std::vector<std::string> shifted_batching_challenge_labels;
+    shifted_batching_challenge_labels.reserve(shifted_comms.size());
+    for (size_t idx = 0; idx < shifted_comms.size(); idx++) {
+        shifted_batching_challenge_labels.push_back("rho_" + std::to_string(unshifted_comms.size() - 1 + idx));
+    }
+
+    // Get short (128-bit) batching challenges from transcript
+    auto unshifted_challenges = transcript->template get_challenges<FF>(unshifted_batching_challenge_labels);
+    auto shifted_challenges = transcript->template get_challenges<FF>(shifted_batching_challenge_labels);
+
+    // Batch commitments: first commitment has coefficient 1, rest are batched with challenges
+    Commitment squashed_unshifted =
+        unshifted_comms[0] + batch_mul_native(unshifted_comms.subspan(1), unshifted_challenges);
+
+    Commitment squashed_shifted = batch_mul_native(shifted_comms, shifted_challenges);
+
+    // Batch evaluations: compute inner product with first eval as initial value for unshifted
+    FF squashed_unshifted_eval = std::inner_product(
+        unshifted_challenges.begin(), unshifted_challenges.end(), unshifted_evals.begin() + 1, unshifted_evals[0]);
+
+    FF squashed_shifted_eval =
+        std::inner_product(shifted_challenges.begin(), shifted_challenges.end(), shifted_evals.begin(), FF(0));
+
+    // Execute Shplemini rounds with squashed claims
+    ClaimBatcher squashed_claim_batcher{ .unshifted = ClaimBatch{ .commitments = RefVector(squashed_unshifted),
+                                                                  .evaluations = RefVector(squashed_unshifted_eval) },
+                                         .shifted = ClaimBatch{ .commitments = RefVector(squashed_shifted),
+                                                                .evaluations = RefVector(squashed_shifted_eval) } };
     const BatchOpeningClaim<Curve> opening_claim = Shplemini::compute_batch_opening_claim(
-        padding_indicator_array, claim_batcher, output.challenge, Commitment::one(), transcript);
+        padding_indicator_array, squashed_claim_batcher, output.challenge, Commitment::one(), transcript);
 
     const auto pairing_points = PCS::reduce_verify_batch_opening_claim(opening_claim, transcript);
     VerifierCommitmentKey pcs_vkey{};

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/verifier.cpp
@@ -147,7 +147,7 @@ bool AvmVerifier::verify_proof(const HonkProof& proof, const std::vector<std::ve
         shifted_batching_challenge_labels.push_back("rho_" + std::to_string(unshifted_comms.size() - 1 + idx));
     }
 
-    // Get short (128-bit) batching challenges from transcript
+    // Get short batching challenges from transcript
     auto unshifted_challenges = transcript->template get_challenges<FF>(unshifted_batching_challenge_labels);
     auto shifted_challenges = transcript->template get_challenges<FF>(shifted_batching_challenge_labels);
 


### PR DESCRIPTION
We halve the size of the ECCVM circuit produced by AVM rec verifier. Now it's under $2^{15}$. 