### PR TITLE
fix(avm)!: exec dispatch on bitwise error

### DIFF
--- a/barretenberg/cpp/pil/vm2/bitwise.pil
+++ b/barretenberg/cpp/pil/vm2/bitwise.pil
@@ -93,8 +93,9 @@ pol commit tag_a;
 pol commit tag_b;
 pol commit tag_c; // This is the tag of the result
 // Sufficient to set tag_c == tag_a because we check that tag_a == tag_b
+// If there is an error, we relax this constraint as we want the flexibility to set the register in execution to FF(0)
 #[RES_TAG_SHOULD_MATCH_INPUT]
-start * (tag_c - tag_a) = 0;
+(1 - err) * start * (tag_c - tag_a) = 0;
 
 // Check that tag_a is not FF
 pol commit tag_a_inv;

--- a/barretenberg/cpp/pil/vm2/execution.pil
+++ b/barretenberg/cpp/pil/vm2/execution.pil
@@ -672,7 +672,7 @@ sel_exec_dispatch_bitwise {
     register[0], mem_tag_reg[0],
     register[1], mem_tag_reg[1],
     register[2], mem_tag_reg[2]
-} in bitwise.sel {
+} in bitwise.start {
     bitwise.op_id, bitwise.err,
     bitwise.acc_ia, bitwise.tag_a,
     bitwise.acc_ib, bitwise.tag_b,

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/relations/bitwise.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/relations/bitwise.test.cpp
@@ -414,18 +414,18 @@ TEST(BitwiseConstrainingTest, BitwiseExecInteraction)
     TestTraceContainer trace({ {
         // Bitwise Entry
         { C::bitwise_err, 1 },
-        { C::bitwise_sel, 1 },
-        { C::bitwise_tag_a, static_cast<uint8_t>(ValueTag::FF) },
-        { C::bitwise_tag_b, static_cast<uint8_t>(ValueTag::U8) },
+        { C::bitwise_start, 1 },
+        { C::bitwise_tag_a, static_cast<uint8_t>(MemoryTag::FF) },
+        { C::bitwise_tag_b, static_cast<uint8_t>(MemoryTag::U8) },
         { C::bitwise_acc_ia, 0x01 },
-        { C::bitwise_tag_c, static_cast<uint8_t>(ValueTag::U8) },
+        { C::bitwise_tag_c, static_cast<uint8_t>(MemoryTag::U8) },
         { C::bitwise_acc_ib, 0x01 },
         { C::bitwise_acc_ic, 0x00 },
         // Execution Entry
-        { C::execution_mem_tag_reg_0_, static_cast<uint8_t>(ValueTag::FF) },
-        { C::execution_mem_tag_reg_1_, static_cast<uint8_t>(ValueTag::U8) },
+        { C::execution_mem_tag_reg_0_, static_cast<uint8_t>(MemoryTag::FF) },
+        { C::execution_mem_tag_reg_1_, static_cast<uint8_t>(MemoryTag::U8) },
         { C::bitwise_op_id, static_cast<uint8_t>(BitwiseOperation::AND) },
-        { C::execution_mem_tag_reg_2_, static_cast<uint8_t>(ValueTag::U8) },
+        { C::execution_mem_tag_reg_2_, static_cast<uint8_t>(MemoryTag::U8) },
         { C::execution_register_0_, 0x01 },
         { C::execution_register_1_, 0x01 },
         { C::execution_register_2_, 0x00 },
@@ -444,16 +444,16 @@ TEST(BitwiseConstrainingTest, InvalidBitwiseExecInteraction)
         { C::bitwise_sel, 1 },
         { C::bitwise_acc_ib, 0x01 },
         { C::bitwise_acc_ia, 0x01 },
-        { C::bitwise_tag_a, static_cast<uint8_t>(ValueTag::U8) },
-        { C::bitwise_tag_b, static_cast<uint8_t>(ValueTag::U8) },
+        { C::bitwise_tag_a, static_cast<uint8_t>(MemoryTag::U8) },
+        { C::bitwise_tag_b, static_cast<uint8_t>(MemoryTag::U8) },
         { C::bitwise_acc_ic, 0x00 },
-        { C::bitwise_tag_c, static_cast<uint8_t>(ValueTag::U8) },
+        { C::bitwise_tag_c, static_cast<uint8_t>(MemoryTag::U8) },
         { C::bitwise_op_id, static_cast<uint8_t>(BitwiseOperation::AND) },
 
         // Execution Entry
-        { C::execution_mem_tag_reg_0_, static_cast<uint8_t>(ValueTag::U8) },
-        { C::execution_mem_tag_reg_1_, static_cast<uint8_t>(ValueTag::U16) }, // Mismatch
-        { C::execution_mem_tag_reg_2_, static_cast<uint8_t>(ValueTag::U8) },
+        { C::execution_mem_tag_reg_0_, static_cast<uint8_t>(MemoryTag::U8) },
+        { C::execution_mem_tag_reg_1_, static_cast<uint8_t>(MemoryTag::U16) }, // Mismatch
+        { C::execution_mem_tag_reg_2_, static_cast<uint8_t>(MemoryTag::U8) },
         { C::execution_register_0_, 0x01 },
         { C::execution_register_1_, 0x01 },
         { C::execution_register_2_, 0x00 },
@@ -474,8 +474,8 @@ TEST(BitwiseConstrainingTest, ErrorHandlingInputFF)
 
     std::vector<simulation::BitwiseEvent> events = {
         { .operation = BitwiseOperation::XOR,
-          .a = MemoryValue::from_tag(ValueTag::FF, 1),
-          .b = MemoryValue::from_tag(ValueTag::FF, 1),
+          .a = MemoryValue::from_tag(MemoryTag::FF, 1),
+          .b = MemoryValue::from_tag(MemoryTag::FF, 1),
           .res = 0 },
     };
     builder.process(events, trace);
@@ -492,8 +492,8 @@ TEST(BitwiseConstrainingTest, ErrorHandlingInputTagMismatch)
 
     std::vector<simulation::BitwiseEvent> events = {
         { .operation = BitwiseOperation::AND,
-          .a = MemoryValue::from_tag(ValueTag::U8, 1),
-          .b = MemoryValue::from_tag(ValueTag::U16, 1),
+          .a = MemoryValue::from_tag(MemoryTag::U8, 1),
+          .b = MemoryValue::from_tag(MemoryTag::U16, 1),
           .res = 0 },
     };
     builder.process(events, trace);
@@ -509,13 +509,43 @@ TEST(BitwiseConstrainingTest, ErrorHandlingMultiple)
 
     std::vector<simulation::BitwiseEvent> events = {
         { .operation = BitwiseOperation::AND,
-          .a = MemoryValue::from_tag(ValueTag::FF, 1),
-          .b = MemoryValue::from_tag(ValueTag::U32, 1),
+          .a = MemoryValue::from_tag(MemoryTag::FF, 1),
+          .b = MemoryValue::from_tag(MemoryTag::U32, 1),
           .res = 0 },
     };
     builder.process(events, trace);
 
     check_relation<bitwise>(trace);
+}
+
+TEST(BitwiseConstrainingTest, ExecBitwiseDispatchOnError)
+{
+    // Bitwise operations on mismatch tags should error out and produce FF(0) result.
+    MemoryValue a = MemoryValue::from_tag(MemoryTag::U16, 45486);
+    MemoryValue b = MemoryValue::from_tag(MemoryTag::U8, 174);
+
+    TestTraceContainer trace({ {
+        // Execution Entry
+        { C::execution_sel_exec_dispatch_bitwise, 1 },
+        { C::execution_subtrace_operation_id, static_cast<uint8_t>(BitwiseOperation::AND) },
+        { C::execution_mem_tag_reg_0_, static_cast<uint8_t>(a.get_tag()) },
+        { C::execution_mem_tag_reg_1_, static_cast<uint8_t>(b.get_tag()) },
+        { C::execution_register_0_, a.as_ff() },
+        { C::execution_register_1_, b.as_ff() },
+
+        // Output is FF(0) due to error
+        { C::execution_mem_tag_reg_2_, static_cast<uint8_t>(MemoryTag::FF) },
+        { C::execution_register_2_, 0x00 },
+        { C::execution_sel_opcode_error, 1 },
+    } });
+
+    std::vector<simulation::BitwiseEvent> event = { { .operation = BitwiseOperation::AND, .a = a, .b = b, .res = 0 } };
+
+    BitwiseTraceBuilder builder;
+    builder.process(event, trace);
+
+    check_relation<bitwise>(trace);
+    check_interaction<ExecutionTraceBuilder, lookup_execution_dispatch_to_bitwise_settings>(trace);
 }
 
 } // namespace

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/bitwise.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/bitwise.hpp
@@ -14,7 +14,7 @@ template <typename FF_> class bitwiseImpl {
   public:
     using FF = FF_;
 
-    static constexpr std::array<size_t, 23> SUBRELATION_PARTIAL_LENGTHS = { 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 5, 5,
+    static constexpr std::array<size_t, 23> SUBRELATION_PARTIAL_LENGTHS = { 3, 3, 3, 3, 3, 3, 3, 3, 3, 4, 5, 5,
                                                                             3, 4, 4, 5, 3, 3, 3, 3, 3, 3, 3 };
 
     template <typename AllEntities> inline static bool skip(const AllEntities& in)

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/bitwise_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/bitwise_impl.hpp
@@ -73,7 +73,7 @@ void bitwiseImpl<FF_>::accumulate(ContainerOverSubrelations& evals,
     }
     { // RES_TAG_SHOULD_MATCH_INPUT
         using View = typename std::tuple_element_t<9, ContainerOverSubrelations>::View;
-        auto tmp = static_cast<View>(in.get(C::bitwise_start)) *
+        auto tmp = (FF(1) - static_cast<View>(in.get(C::bitwise_err))) * static_cast<View>(in.get(C::bitwise_start)) *
                    (static_cast<View>(in.get(C::bitwise_tag_c)) - static_cast<View>(in.get(C::bitwise_tag_a)));
         std::get<9>(evals) += (tmp * scaling_factor);
     }

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/lookups_execution.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/lookups_execution.hpp
@@ -369,7 +369,7 @@ struct lookup_execution_dispatch_to_bitwise_settings_ {
     static constexpr std::string_view RELATION_NAME = "execution";
     static constexpr size_t LOOKUP_TUPLE_SIZE = 8;
     static constexpr Column SRC_SELECTOR = Column::execution_sel_exec_dispatch_bitwise;
-    static constexpr Column DST_SELECTOR = Column::bitwise_sel;
+    static constexpr Column DST_SELECTOR = Column::bitwise_start;
     static constexpr Column COUNTS = Column::lookup_execution_dispatch_to_bitwise_counts;
     static constexpr Column INVERSES = Column::lookup_execution_dispatch_to_bitwise_inv;
     static constexpr std::array<ColumnAndShifts, LOOKUP_TUPLE_SIZE> SRC_COLUMNS = {

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/bitwise_trace.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/bitwise_trace.cpp
@@ -75,7 +75,7 @@ void BitwiseTraceBuilder::process(const simulation::EventEmitterInterface<simula
                           { C::bitwise_ic_byte, uint256_t::from_uint128(output_c) },
                           { C::bitwise_tag_a, tag_a_u8 },
                           { C::bitwise_tag_b, tag_b_u8 },
-                          { C::bitwise_tag_c, tag_a_u8 }, // same as tag_a
+                          { C::bitwise_tag_c, static_cast<uint8_t>(MemoryTag::FF) }, // Since error
                           // Err Flags
                           { C::bitwise_sel_tag_ff_err, is_tag_ff ? 1 : 0 },
                           { C::bitwise_sel_tag_mismatch_err, is_tag_mismatch ? 1 : 0 },

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/bitwise_trace.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/bitwise_trace.test.cpp
@@ -170,8 +170,8 @@ TEST(BitwiseTraceGenTest, ErrorInputFF)
 
     std::vector<simulation::BitwiseEvent> events = {
         { .operation = BitwiseOperation::AND,
-          .a = MemoryValue::from_tag(ValueTag::FF, 1),
-          .b = MemoryValue::from_tag(ValueTag::FF, 1),
+          .a = MemoryValue::from_tag(MemoryTag::FF, 1),
+          .b = MemoryValue::from_tag(MemoryTag::FF, 1),
           .res = 0 },
     };
     builder.process(events, trace);
@@ -196,9 +196,9 @@ TEST(BitwiseTraceGenTest, ErrorInputFF)
                                   ROW_FIELD_EQ(bitwise_ia_byte, 1),
                                   ROW_FIELD_EQ(bitwise_ib_byte, 1),
                                   ROW_FIELD_EQ(bitwise_ic_byte, 0),
-                                  ROW_FIELD_EQ(bitwise_tag_a, static_cast<int>(ValueTag::FF)),
-                                  ROW_FIELD_EQ(bitwise_tag_b, static_cast<int>(ValueTag::FF)),
-                                  ROW_FIELD_EQ(bitwise_tag_c, static_cast<int>(ValueTag::FF)),
+                                  ROW_FIELD_EQ(bitwise_tag_a, static_cast<int>(MemoryTag::FF)),
+                                  ROW_FIELD_EQ(bitwise_tag_b, static_cast<int>(MemoryTag::FF)),
+                                  ROW_FIELD_EQ(bitwise_tag_c, static_cast<int>(MemoryTag::FF)),
                                   ROW_FIELD_EQ(bitwise_ctr, 0),
                                   ROW_FIELD_EQ(bitwise_ctr_inv, 0),
                                   ROW_FIELD_EQ(bitwise_ctr_min_one_inv, 0),
@@ -217,58 +217,8 @@ TEST(BitwiseTraceGenTest, ErrorTagMismatch)
 
     std::vector<simulation::BitwiseEvent> events = {
         { .operation = BitwiseOperation::AND,
-          .a = MemoryValue::from_tag(ValueTag::U8, 1),
-          .b = MemoryValue::from_tag(ValueTag::U16, 1),
-          .res = 0 },
-    };
-    builder.process(events, trace);
-
-    EXPECT_THAT(
-        trace.as_rows(),
-        ElementsAre(AllOf(ROW_FIELD_EQ(bitwise_op_id, 0),
-                          ROW_FIELD_EQ(bitwise_acc_ia, 0),
-                          ROW_FIELD_EQ(bitwise_acc_ib, 0),
-                          ROW_FIELD_EQ(bitwise_acc_ic, 0),
-                          ROW_FIELD_EQ(bitwise_ia_byte, 0),
-                          ROW_FIELD_EQ(bitwise_ib_byte, 0),
-                          ROW_FIELD_EQ(bitwise_ic_byte, 0),
-                          ROW_FIELD_EQ(bitwise_ctr, 0),
-                          ROW_FIELD_EQ(bitwise_ctr_inv, 0),
-                          ROW_FIELD_EQ(bitwise_ctr_min_one_inv, 0),
-                          ROW_FIELD_EQ(bitwise_last, 1),
-                          ROW_FIELD_EQ(bitwise_sel, 0)),
-                    AllOf(ROW_FIELD_EQ(bitwise_op_id, static_cast<uint8_t>(BitwiseOperation::AND)),
-                          ROW_FIELD_EQ(bitwise_acc_ia, 1),
-                          ROW_FIELD_EQ(bitwise_acc_ib, 1),
-                          ROW_FIELD_EQ(bitwise_acc_ic, 0),
-                          ROW_FIELD_EQ(bitwise_ia_byte, 1),
-                          ROW_FIELD_EQ(bitwise_ib_byte, 1),
-                          ROW_FIELD_EQ(bitwise_ic_byte, 0),
-                          ROW_FIELD_EQ(bitwise_tag_a, static_cast<int>(ValueTag::U8)),
-                          ROW_FIELD_EQ(bitwise_tag_b, static_cast<int>(ValueTag::U16)),
-                          ROW_FIELD_EQ(bitwise_tag_c, static_cast<int>(ValueTag::U8)),
-                          ROW_FIELD_EQ(bitwise_ctr, 0),
-                          ROW_FIELD_EQ(bitwise_ctr_inv, 0),
-                          ROW_FIELD_EQ(bitwise_ctr_min_one_inv, 0),
-                          ROW_FIELD_EQ(bitwise_last, 1),
-                          // Err Flags
-                          ROW_FIELD_EQ(bitwise_sel_tag_ff_err, 0),
-                          ROW_FIELD_EQ(bitwise_sel_tag_mismatch_err, 1),
-                          ROW_FIELD_EQ(bitwise_err, 1),
-                          ROW_FIELD_EQ(
-                              bitwise_tag_ab_diff_inv,
-                              FF(static_cast<uint8_t>(ValueTag::U8) - static_cast<uint8_t>(ValueTag::U16)).invert()))));
-}
-
-TEST(BitwiseTraceGenTest, ErrorFFAndTagMismatch)
-{
-    TestTraceContainer trace;
-    BitwiseTraceBuilder builder;
-
-    std::vector<simulation::BitwiseEvent> events = {
-        { .operation = BitwiseOperation::AND,
-          .a = MemoryValue::from_tag(ValueTag::FF, 1),
-          .b = MemoryValue::from_tag(ValueTag::U16, 1),
+          .a = MemoryValue::from_tag(MemoryTag::U8, 1),
+          .b = MemoryValue::from_tag(MemoryTag::U16, 1),
           .res = 0 },
     };
     builder.process(events, trace);
@@ -295,9 +245,60 @@ TEST(BitwiseTraceGenTest, ErrorFFAndTagMismatch)
                   ROW_FIELD_EQ(bitwise_ia_byte, 1),
                   ROW_FIELD_EQ(bitwise_ib_byte, 1),
                   ROW_FIELD_EQ(bitwise_ic_byte, 0),
-                  ROW_FIELD_EQ(bitwise_tag_a, static_cast<int>(ValueTag::FF)),
-                  ROW_FIELD_EQ(bitwise_tag_b, static_cast<int>(ValueTag::U16)),
-                  ROW_FIELD_EQ(bitwise_tag_c, static_cast<int>(ValueTag::FF)),
+                  ROW_FIELD_EQ(bitwise_tag_a, static_cast<int>(MemoryTag::U8)),
+                  ROW_FIELD_EQ(bitwise_tag_b, static_cast<int>(MemoryTag::U16)),
+                  ROW_FIELD_EQ(bitwise_tag_c, static_cast<int>(MemoryTag::FF)),
+                  ROW_FIELD_EQ(bitwise_ctr, 0),
+                  ROW_FIELD_EQ(bitwise_ctr_inv, 0),
+                  ROW_FIELD_EQ(bitwise_ctr_min_one_inv, 0),
+                  ROW_FIELD_EQ(bitwise_last, 1),
+                  // Err Flags
+                  ROW_FIELD_EQ(bitwise_sel_tag_ff_err, 0),
+                  ROW_FIELD_EQ(bitwise_sel_tag_mismatch_err, 1),
+                  ROW_FIELD_EQ(bitwise_err, 1),
+                  ROW_FIELD_EQ(
+                      bitwise_tag_ab_diff_inv,
+                      FF(static_cast<uint8_t>(MemoryTag::U8) - static_cast<uint8_t>(MemoryTag::U16)).invert()))));
+}
+
+TEST(BitwiseTraceGenTest, ErrorFFAndTagMismatch)
+{
+    TestTraceContainer trace;
+    BitwiseTraceBuilder builder;
+
+    std::vector<simulation::BitwiseEvent> events = {
+        { .operation = BitwiseOperation::AND,
+          .a = MemoryValue::from_tag(MemoryTag::FF, 1),
+          .b = MemoryValue::from_tag(MemoryTag::U16, 1),
+          .res = 0 },
+    };
+    builder.process(events, trace);
+
+    EXPECT_THAT(
+        trace.as_rows(),
+        ElementsAre(
+            AllOf(ROW_FIELD_EQ(bitwise_op_id, 0),
+                  ROW_FIELD_EQ(bitwise_acc_ia, 0),
+                  ROW_FIELD_EQ(bitwise_acc_ib, 0),
+                  ROW_FIELD_EQ(bitwise_acc_ic, 0),
+                  ROW_FIELD_EQ(bitwise_ia_byte, 0),
+                  ROW_FIELD_EQ(bitwise_ib_byte, 0),
+                  ROW_FIELD_EQ(bitwise_ic_byte, 0),
+                  ROW_FIELD_EQ(bitwise_ctr, 0),
+                  ROW_FIELD_EQ(bitwise_ctr_inv, 0),
+                  ROW_FIELD_EQ(bitwise_ctr_min_one_inv, 0),
+                  ROW_FIELD_EQ(bitwise_last, 1),
+                  ROW_FIELD_EQ(bitwise_sel, 0)),
+            AllOf(ROW_FIELD_EQ(bitwise_op_id, static_cast<uint8_t>(BitwiseOperation::AND)),
+                  ROW_FIELD_EQ(bitwise_acc_ia, 1),
+                  ROW_FIELD_EQ(bitwise_acc_ib, 1),
+                  ROW_FIELD_EQ(bitwise_acc_ic, 0),
+                  ROW_FIELD_EQ(bitwise_ia_byte, 1),
+                  ROW_FIELD_EQ(bitwise_ib_byte, 1),
+                  ROW_FIELD_EQ(bitwise_ic_byte, 0),
+                  ROW_FIELD_EQ(bitwise_tag_a, static_cast<int>(MemoryTag::FF)),
+                  ROW_FIELD_EQ(bitwise_tag_b, static_cast<int>(MemoryTag::U16)),
+                  ROW_FIELD_EQ(bitwise_tag_c, static_cast<int>(MemoryTag::FF)),
                   ROW_FIELD_EQ(bitwise_ctr, 0),
                   ROW_FIELD_EQ(bitwise_ctr_inv, 0),
                   ROW_FIELD_EQ(bitwise_ctr_min_one_inv, 0),
@@ -309,7 +310,7 @@ TEST(BitwiseTraceGenTest, ErrorFFAndTagMismatch)
                   ROW_FIELD_EQ(bitwise_tag_a_inv, 0),
                   ROW_FIELD_EQ(
                       bitwise_tag_ab_diff_inv,
-                      (FF(static_cast<uint8_t>(ValueTag::FF)) - FF(static_cast<uint8_t>(ValueTag::U16))).invert()))));
+                      (FF(static_cast<uint8_t>(MemoryTag::FF)) - FF(static_cast<uint8_t>(MemoryTag::U16))).invert()))));
 }
 
 } // namespace


### PR DESCRIPTION
### Changes
- The target selector for `#[DISPATCH_TO_BITWISE]` changed from `bitwise.sel` to `bitwise.start`
- Gate the relation `#[RES_TAG_SHOULD_MATCH_INPUT]` by the error flag
 
### Issue (Repro in `TEST(BitwiseConstrainingTest, ExecBitwiseDispatchOnError)`)
1. In a tag mismatch, the values in the output register for execution remains at the default value - `FF(0)`
2. The circuit still expects the output tag to match the input tag
3. This causes a failure in the lookup from execution <> bitwise