### PR TITLE
feat: allow batching of simulatetx

### DIFF
--- a/yarn-project/aztec.js/src/wallet/wallet.test.ts
+++ b/yarn-project/aztec.js/src/wallet/wallet.test.ts
@@ -214,6 +214,9 @@ describe('WalletSchema', () => {
     const opts: SendOptions = {
       from: await AztecAddress.random(),
     };
+    const simulateOpts: SimulateOptions = {
+      from: await AztecAddress.random(),
+    };
 
     const call = {
       name: 'testFunction',
@@ -231,10 +234,11 @@ describe('WalletSchema', () => {
       { name: 'registerContract', args: [address2, undefined, undefined] },
       { name: 'sendTx', args: [exec, opts] },
       { name: 'simulateUtility', args: [call, [AuthWitness.random()], undefined] },
+      { name: 'simulateTx', args: [exec, simulateOpts] },
     ];
 
     const results = await context.client.batch(methods);
-    expect(results).toHaveLength(4);
+    expect(results).toHaveLength(5);
     expect(results[0]).toEqual({ name: 'registerSender', result: expect.any(AztecAddress) });
     expect(results[1]).toEqual({
       name: 'registerContract',
@@ -242,6 +246,7 @@ describe('WalletSchema', () => {
     });
     expect(results[2]).toEqual({ name: 'sendTx', result: expect.any(TxHash) });
     expect(results[3]).toEqual({ name: 'simulateUtility', result: expect.any(UtilitySimulationResult) });
+    expect(results[4]).toEqual({ name: 'simulateTx', result: expect.any(TxSimulationResult) });
   });
 });
 

--- a/yarn-project/aztec.js/src/wallet/wallet.ts
+++ b/yarn-project/aztec.js/src/wallet/wallet.ts
@@ -97,7 +97,10 @@ export type SendOptions = Omit<SendInteractionOptions, 'fee'> & {
 /**
  * Helper type that represents all methods that can be batched.
  */
-export type BatchableMethods = Pick<Wallet, 'registerContract' | 'sendTx' | 'registerSender' | 'simulateUtility'>;
+export type BatchableMethods = Pick<
+  Wallet,
+  'registerContract' | 'sendTx' | 'registerSender' | 'simulateUtility' | 'simulateTx'
+>;
 
 /**
  * From the batchable methods, we create a type that represents a method call with its name and arguments.
@@ -276,6 +279,10 @@ export const BatchedMethodSchema = z.union([
     name: z.literal('simulateUtility'),
     args: z.tuple([FunctionCallSchema, optional(z.array(AuthWitness.schema)), optional(z.array(schemas.AztecAddress))]),
   }),
+  z.object({
+    name: z.literal('simulateTx'),
+    args: z.tuple([ExecutionPayloadSchema, SimulateOptionsSchema]),
+  }),
 ]);
 
 export const ContractMetadataSchema = z.object({
@@ -340,6 +347,7 @@ export const WalletSchema: ApiSchemaFor<Wallet> = {
           z.object({ name: z.literal('registerContract'), result: ContractInstanceWithAddressSchema }),
           z.object({ name: z.literal('sendTx'), result: TxHash.schema }),
           z.object({ name: z.literal('simulateUtility'), result: UtilitySimulationResult.schema }),
+          z.object({ name: z.literal('simulateTx'), result: TxSimulationResult.schema }),
         ]),
       ),
     ),


### PR DESCRIPTION
Extends the `.batch` method of the wallet interface to support `.simulateTx`, since there's no good reason not to and it enables more meaningful interactions.

Also tweaked `BatchCall` to use it, so the feature is immediately available to the ecosystem...but again, it's probably going to be dead soon.
