### PR TITLE
feat: Add debugging infra for Chonk

### DIFF
--- a/barretenberg/cpp/src/barretenberg/chonk/chonk.cpp
+++ b/barretenberg/cpp/src/barretenberg/chonk/chonk.cpp
@@ -361,6 +361,10 @@ void Chonk::accumulate(ClientCircuit& circuit, const std::shared_ptr<MegaVerific
     // Construct the prover instance for circuit
     std::shared_ptr<ProverInstance> prover_instance = std::make_shared<ProverInstance>(circuit);
 
+#ifndef NDEBUG
+    debug_incoming_circuit(circuit, prover_instance, precomputed_vk);
+#endif
+
     // If the current circuit exceeds the current size of the commitment key, reinitialize accordingly.
     // TODO(https://github.com/AztecProtocol/barretenberg/issues/1319)
     if (prover_instance->dyadic_size() > bn254_commitment_key.dyadic_size) {
@@ -735,6 +739,26 @@ void Chonk::update_native_verifier_accumulator(const VerifierInputs& queue_entry
 
     info("DEBUG: Hash of verifier accumulator computed natively ",
          native_verifier_accum.hash_through_transcript("", *verifier_transcript));
+}
+
+void Chonk::debug_incoming_circuit(ClientCircuit& circuit,
+                                   const std::shared_ptr<ProverInstance>& prover_instance,
+                                   const std::shared_ptr<MegaVerificationKey>& precomputed_vk)
+{
+    info("-------- DEBUGGING INFO FOR INCOMING CIRCUIT --------");
+    info("Accumulating circuit ", num_circuits_accumulated + 1, " of ", num_circuits);
+    info("Is the circuit valid? ", CircuitChecker::check(circuit) ? "true" : "false");
+    info("Did we find a failure? ", circuit.failed() ? "true" : "false");
+    if (circuit.failed()) {
+        info("\t\t\tError message? ", circuit.err());
+    }
+
+    // Compare precomputed VK with the one generated during accumulation
+    auto vk = std::make_shared<MegaVerificationKey>(prover_instance->get_precomputed());
+    info("Does the precomputed vk match with the one generated during accumulation? ",
+         *vk == *precomputed_vk ? "true" : "false");
+
+    info("-------- END OF DEBUGGING INFO FOR INCOMING CIRCUIT --------");
 }
 #endif
 

--- a/barretenberg/cpp/src/barretenberg/chonk/chonk.cpp
+++ b/barretenberg/cpp/src/barretenberg/chonk/chonk.cpp
@@ -725,20 +725,40 @@ Chonk::VerificationKey Chonk::get_vk() const
 void Chonk::update_native_verifier_accumulator(const VerifierInputs& queue_entry,
                                                const std::shared_ptr<Transcript>& verifier_transcript)
 {
+    info("-------- DEBUGGING INFO FOR NATIVE FOLDING STEP --------");
+
     auto verifier_inst = std::make_shared<VerifierInstance>(queue_entry.honk_vk);
 
     FoldingVerifier native_verifier(verifier_transcript);
     if (queue_entry.type == QUEUE_TYPE::OINK) {
-        auto [_, new_accumulator] = native_verifier.instance_to_accumulator(verifier_inst, queue_entry.proof);
+        auto [_first_verified, new_accumulator] =
+            native_verifier.instance_to_accumulator(verifier_inst, queue_entry.proof);
         native_verifier_accum = std::move(new_accumulator);
+
+        info("Was the Sumcheck turning an instance into an accumulator verified? ", _first_verified ? "true" : "false");
     } else {
         auto [_first_verified, _second_verified, new_accumulator] =
             native_verifier.verify_folding_proof(verifier_inst, queue_entry.proof);
         native_verifier_accum = std::move(new_accumulator);
+
+        info("Was the Sumcheck turning an instance into an accumulator verified? ", _first_verified ? "true" : "false");
+        info("Was the Sumcheck to batch two accumulators verified? ", _second_verified ? "true" : "false");
+
+        if (queue_entry.type == QUEUE_TYPE::HN_FINAL) {
+            HypernovaDeciderVerifier<MegaFlavor> decider_verifier(verifier_transcript);
+            bb::PairingPoints<curve::BN254> pairing_points =
+                decider_verifier.verify_proof(native_verifier_accum, decider_proof);
+
+            info("Were the pairing points from the decider verified? ", pairing_points.check() ? "true" : "false");
+        }
     }
 
-    info("DEBUG: Hash of verifier accumulator computed natively ",
+    info("Do the prover and verifier accumulators match? ",
+         prover_accumulator.compare_with_verifier_claim(native_verifier_accum) ? "true" : "false");
+    info("Hash of verifier accumulator computed natively ",
          native_verifier_accum.hash_through_transcript("", *verifier_transcript));
+
+    info("-------- END OF DEBUGGING INFO FOR NATIVE FOLDING STEP --------");
 }
 
 void Chonk::debug_incoming_circuit(ClientCircuit& circuit,
@@ -746,6 +766,7 @@ void Chonk::debug_incoming_circuit(ClientCircuit& circuit,
                                    const std::shared_ptr<MegaVerificationKey>& precomputed_vk)
 {
     info("-------- DEBUGGING INFO FOR INCOMING CIRCUIT --------");
+
     info("Accumulating circuit ", num_circuits_accumulated + 1, " of ", num_circuits);
     info("Is the circuit valid? ", CircuitChecker::check(circuit) ? "true" : "false");
     info("Did we find a failure? ", circuit.failed() ? "true" : "false");

--- a/barretenberg/cpp/src/barretenberg/chonk/chonk.cpp
+++ b/barretenberg/cpp/src/barretenberg/chonk/chonk.cpp
@@ -113,7 +113,7 @@ Chonk::perform_recursive_verification_and_databus_consistency_checks(
     std::optional<StdlibFF> prev_accum_hash = std::nullopt;
 
     // Update previous accumulator hash so that we can check it against the one extracted from the public inputs
-    if (verifier_inputs.is_kernel && verifier_inputs.type != QUEUE_TYPE::OINK) {
+    if (verifier_inputs.is_kernel) {
         prev_accum_hash = input_verifier_accumulator->hash_through_transcript("", *accumulation_recursive_transcript);
     }
 
@@ -309,6 +309,11 @@ void Chonk::complete_kernel_circuit_logic(ClientCircuit& circuit)
         kernel_output.output_hn_accum_hash =
             current_stdlib_verifier_accumulator->hash_through_transcript("", hash_transcript);
         info("Kernel output accumulator hash: ", kernel_output.output_hn_accum_hash);
+#ifndef NDEBUG
+        info("Chonk recursive verification: accumulator hash set in the public inputs matches the one "
+             "computed natively: ",
+             kernel_output.output_hn_accum_hash.get_value() == native_verifier_accum_hash ? "true" : "false");
+#endif
         kernel_output.set_public();
     }
 }
@@ -725,7 +730,7 @@ Chonk::VerificationKey Chonk::get_vk() const
 void Chonk::update_native_verifier_accumulator(const VerifierInputs& queue_entry,
                                                const std::shared_ptr<Transcript>& verifier_transcript)
 {
-    info("-------- DEBUGGING INFO FOR NATIVE FOLDING STEP --------");
+    info("======= DEBUGGING INFO FOR NATIVE FOLDING STEP =======");
 
     auto verifier_inst = std::make_shared<VerifierInstance>(queue_entry.honk_vk);
 
@@ -735,37 +740,40 @@ void Chonk::update_native_verifier_accumulator(const VerifierInputs& queue_entry
             native_verifier.instance_to_accumulator(verifier_inst, queue_entry.proof);
         native_verifier_accum = std::move(new_accumulator);
 
-        info("Was the Sumcheck turning an instance into an accumulator verified? ", _first_verified ? "true" : "false");
+        info("Sumcheck: instance to accumulator verified: ", _first_verified ? "true" : "false");
     } else {
         auto [_first_verified, _second_verified, new_accumulator] =
             native_verifier.verify_folding_proof(verifier_inst, queue_entry.proof);
         native_verifier_accum = std::move(new_accumulator);
 
-        info("Was the Sumcheck turning an instance into an accumulator verified? ", _first_verified ? "true" : "false");
-        info("Was the Sumcheck to batch two accumulators verified? ", _second_verified ? "true" : "false");
+        info("Sumcheck: instance to accumulator verified: ", _first_verified ? "true" : "false");
+        info("Sumcheck: batch two accumulators verified: ", _second_verified ? "true" : "false");
 
         if (queue_entry.type == QUEUE_TYPE::HN_FINAL) {
             HypernovaDeciderVerifier<MegaFlavor> decider_verifier(verifier_transcript);
             bb::PairingPoints<curve::BN254> pairing_points =
                 decider_verifier.verify_proof(native_verifier_accum, decider_proof);
 
-            info("Were the pairing points from the decider verified? ", pairing_points.check() ? "true" : "false");
+            info("Decider: pairing points verified? ", pairing_points.check() ? "true" : "false");
         }
     }
 
-    info("Do the prover and verifier accumulators match? ",
-         prover_accumulator.compare_with_verifier_claim(native_verifier_accum) ? "true" : "false");
-    info("Hash of verifier accumulator computed natively ",
-         native_verifier_accum.hash_through_transcript("", *verifier_transcript));
+    if (!queue_entry.is_kernel) {
+        native_verifier_accum_hash = native_verifier_accum.hash_through_transcript("", *verifier_transcript);
+    }
 
-    info("-------- END OF DEBUGGING INFO FOR NATIVE FOLDING STEP --------");
+    info("Chonk accumulate: prover and verifier accumulators match: ",
+         prover_accumulator.compare_with_verifier_claim(native_verifier_accum) ? "true" : "false");
+    info("Chonk accumulate: hash of verifier accumulator computed natively ", native_verifier_accum_hash);
+
+    info("======= END OF DEBUGGING INFO FOR NATIVE FOLDING STEP =======");
 }
 
 void Chonk::debug_incoming_circuit(ClientCircuit& circuit,
                                    const std::shared_ptr<ProverInstance>& prover_instance,
                                    const std::shared_ptr<MegaVerificationKey>& precomputed_vk)
 {
-    info("-------- DEBUGGING INFO FOR INCOMING CIRCUIT --------");
+    info("======= DEBUGGING INFO FOR INCOMING CIRCUIT =======");
 
     info("Accumulating circuit ", num_circuits_accumulated + 1, " of ", num_circuits);
     info("Is the circuit valid? ", CircuitChecker::check(circuit) ? "true" : "false");
@@ -777,9 +785,9 @@ void Chonk::debug_incoming_circuit(ClientCircuit& circuit,
     // Compare precomputed VK with the one generated during accumulation
     auto vk = std::make_shared<MegaVerificationKey>(prover_instance->get_precomputed());
     info("Does the precomputed vk match with the one generated during accumulation? ",
-         *vk == *precomputed_vk ? "true" : "false");
+         vk->compare(*precomputed_vk) ? "true" : "false");
 
-    info("-------- END OF DEBUGGING INFO FOR INCOMING CIRCUIT --------");
+    info("======= END OF DEBUGGING INFO FOR INCOMING CIRCUIT =======");
 }
 #endif
 

--- a/barretenberg/cpp/src/barretenberg/chonk/chonk.hpp
+++ b/barretenberg/cpp/src/barretenberg/chonk/chonk.hpp
@@ -264,7 +264,10 @@ class Chonk : public IVCBase {
     HonkProof decider_proof; // decider proof to be verified in the hiding circuit
 
     VerifierAccumulator recursive_verifier_native_accum; // native verifier accumulator used in recursive folding
-    VerifierAccumulator native_verifier_accum;           //  native verifier accumulator used in prover folding
+#ifndef NDEBUG
+    VerifierAccumulator native_verifier_accum; //  native verifier accumulator used in prover folding
+    FF native_verifier_accum_hash; // hash of the native verifier accumulator when entering recursive verification
+#endif
 
     // Set of tuples {proof, verification_key, type (Oink/HN)} to be recursively verified
     VerificationQueue verification_queue;

--- a/barretenberg/cpp/src/barretenberg/chonk/chonk.hpp
+++ b/barretenberg/cpp/src/barretenberg/chonk/chonk.hpp
@@ -19,6 +19,9 @@
 #include "barretenberg/stdlib/special_public_inputs/special_public_inputs.hpp"
 #include "barretenberg/ultra_honk/ultra_prover.hpp"
 #include "barretenberg/ultra_honk/ultra_verifier.hpp"
+#ifndef NDEBUG
+#include "barretenberg/circuit_checker/circuit_checker.hpp"
+#endif
 #include <algorithm>
 
 namespace bb {
@@ -328,6 +331,10 @@ class Chonk : public IVCBase {
      */
     void update_native_verifier_accumulator(const VerifierInputs& queue_entry,
                                             const std::shared_ptr<Transcript>& verifier_transcript);
+
+    void debug_incoming_circuit(ClientCircuit& circuit,
+                                const std::shared_ptr<ProverInstance>& prover_instance,
+                                const std::shared_ptr<MegaVerificationKey>& precomputed_vk);
 #endif
 
     HonkProof construct_honk_proof_for_hiding_kernel(ClientCircuit& circuit,

--- a/barretenberg/cpp/src/barretenberg/circuit_checker/ultra_circuit_checker.cpp
+++ b/barretenberg/cpp/src/barretenberg/circuit_checker/ultra_circuit_checker.cpp
@@ -39,7 +39,9 @@ MegaCircuitBuilder_<bb::fr> UltraCircuitChecker::prepare_circuit<MegaCircuitBuil
     // Deepcopy the opqueue to avoid modifying the original one
     builder.op_queue = std::make_shared<ECCOpQueue>(*builder.op_queue);
 
-    builder.finalize_circuit(/*ensure_nonzero=*/true); // Test the ensure_nonzero gates as well
+    if (!builder.circuit_finalized) { // avoid warnings about finalizing an already finalized circuit
+        builder.finalize_circuit(/*ensure_nonzero=*/true); // Test the ensure_nonzero gates as well
+    }
 
     return builder;
 }

--- a/barretenberg/cpp/src/barretenberg/flavor/flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/flavor.hpp
@@ -164,9 +164,12 @@ class NativeVerificationKey_ : public PrecomputedCommitments {
     uint64_t log_circuit_size = 0;
     uint64_t num_public_inputs = 0;
     uint64_t pub_inputs_offset = 0;
+    bool operator==(const NativeVerificationKey_&) const = default;
 
 #ifndef NDEBUG
-    bool operator==(const NativeVerificationKey_& other) const
+    template <size_t NUM_PRECOMPUTED_ENTITIES, typename StringType>
+    bool compare(const NativeVerificationKey_& other,
+                 RefArray<StringType, NUM_PRECOMPUTED_ENTITIES> commitment_labels) const
     {
         bool is_equal = true;
 
@@ -185,17 +188,14 @@ class NativeVerificationKey_ : public PrecomputedCommitments {
             is_equal = false;
         }
 
-        for (size_t idx = 0; auto [this_comm, other_comm] : zip_view(this->get_all(), other.get_all())) {
+        for (auto [this_comm, other_comm, label] : zip_view(this->get_all(), other.get_all(), commitment_labels)) {
             if (this_comm != other_comm) {
-                info("Commitment mismatch at index ", idx);
+                info("Commitment mismatch: ", label);
                 is_equal = false;
             }
-            ++idx;
         }
         return is_equal;
     }
-#else
-    bool operator==(const NativeVerificationKey_&) const = default;
 #endif
 
     virtual ~NativeVerificationKey_() = default;

--- a/barretenberg/cpp/src/barretenberg/flavor/flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/flavor.hpp
@@ -165,7 +165,39 @@ class NativeVerificationKey_ : public PrecomputedCommitments {
     uint64_t num_public_inputs = 0;
     uint64_t pub_inputs_offset = 0;
 
+#ifndef NDEBUG
+    bool operator==(const NativeVerificationKey_& other) const
+    {
+        bool is_equal = true;
+
+        if (this->log_circuit_size != other.log_circuit_size) {
+            info("Log circuit size mismatch: ", this->log_circuit_size, " vs ", other.log_circuit_size);
+            is_equal = false;
+        }
+
+        if (this->num_public_inputs != other.num_public_inputs) {
+            info("Num public inputs mismatch: ", this->num_public_inputs, " vs ", other.num_public_inputs);
+            is_equal = false;
+        }
+
+        if (this->pub_inputs_offset != other.pub_inputs_offset) {
+            info("Pub inputs offset mismatch: ", this->pub_inputs_offset, " vs ", other.pub_inputs_offset);
+            is_equal = false;
+        }
+
+        for (size_t idx = 0; auto [this_comm, other_comm] : zip_view(this->get_all(), other.get_all())) {
+            if (this_comm != other_comm) {
+                info("Commitment mismatch at index ", idx);
+                is_equal = false;
+            }
+            ++idx;
+        }
+        return is_equal;
+    }
+#else
     bool operator==(const NativeVerificationKey_&) const = default;
+#endif
+
     virtual ~NativeVerificationKey_() = default;
     NativeVerificationKey_() = default;
     NativeVerificationKey_(const size_t circuit_size, const size_t num_public_inputs)

--- a/barretenberg/cpp/src/barretenberg/flavor/mega_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/mega_flavor.hpp
@@ -448,6 +448,14 @@ class MegaFlavor {
                 commitment = commitment_key.commit(polynomial);
             }
         }
+
+#ifndef NDEBUG
+        bool compare(const VerificationKey& other)
+        {
+            return NativeVerificationKey_<PrecomputedEntities<Commitment>, Transcript>::compare<
+                NUM_PRECOMPUTED_ENTITIES>(other, CommitmentLabels().get_precomputed());
+        }
+#endif
     };
 
     /**

--- a/barretenberg/cpp/src/barretenberg/flavor/ultra_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/ultra_flavor.hpp
@@ -477,6 +477,14 @@ class UltraFlavor {
                 commitment = commitment_key.commit(polynomial);
             }
         }
+
+#ifndef NDEBUG
+        bool compare(const VerificationKey& other)
+        {
+            return NativeVerificationKey_<PrecomputedEntities<Commitment>, Transcript>::compare<
+                NUM_PRECOMPUTED_ENTITIES>(other, CommitmentLabels().get_precomputed());
+        }
+#endif
     };
 
     /**

--- a/barretenberg/cpp/src/barretenberg/flavor/ultra_keccak_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/ultra_keccak_flavor.hpp
@@ -71,6 +71,14 @@ class UltraKeccakFlavor : public bb::UltraFlavor {
                 commitment = commitment_key.commit(polynomial);
             }
         }
+
+#ifndef NDEBUG
+        bool compare(const VerificationKey& other)
+        {
+            return NativeVerificationKey_<PrecomputedEntities<Commitment>, Transcript>::compare<
+                NUM_PRECOMPUTED_ENTITIES>(other, CommitmentLabels().get_precomputed());
+        }
+#endif
     };
 
     // Specialize for Ultra (general case used in UltraRecursive).

--- a/barretenberg/cpp/src/barretenberg/flavor/ultra_rollup_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/ultra_rollup_flavor.hpp
@@ -52,6 +52,14 @@ class UltraRollupFlavor : public bb::UltraFlavor {
                 commitment = commitment_key.commit(polynomial);
             }
         }
+
+#ifndef NDEBUG
+        bool compare(const VerificationKey& other)
+        {
+            return NativeVerificationKey_<PrecomputedEntities<Commitment>, Transcript>::compare<
+                NUM_PRECOMPUTED_ENTITIES>(other, CommitmentLabels().get_precomputed());
+        }
+#endif
     };
 
     using VerifierCommitments = VerifierCommitments_<Commitment, VerificationKey>;

--- a/barretenberg/cpp/src/barretenberg/multilinear_batching/multilinear_batching_claims.hpp
+++ b/barretenberg/cpp/src/barretenberg/multilinear_batching/multilinear_batching_claims.hpp
@@ -91,6 +91,7 @@ struct MultilinearBatchingProverClaim {
     Commitment shifted_commitment;
     size_t dyadic_size;
 
+#ifndef NDEBUG
     bool compare_with_verifier_claim(const MultilinearBatchingVerifierClaim<curve::BN254>& verifier_claim)
     {
         bool is_a_match = true;
@@ -131,6 +132,7 @@ struct MultilinearBatchingProverClaim {
 
         return is_a_match;
     }
+#endif
 };
 
 } // namespace bb

--- a/barretenberg/cpp/src/barretenberg/multilinear_batching/multilinear_batching_claims.hpp
+++ b/barretenberg/cpp/src/barretenberg/multilinear_batching/multilinear_batching_claims.hpp
@@ -3,21 +3,6 @@
 #include "barretenberg/flavor/multilinear_batching_flavor.hpp"
 
 namespace bb {
-
-struct MultilinearBatchingProverClaim {
-    using FF = MultilinearBatchingFlavor::FF;
-    using Commitment = MultilinearBatchingFlavor::Commitment;
-    using Polynomial = MultilinearBatchingFlavor::Polynomial;
-    std::vector<FF> challenge;
-    FF non_shifted_evaluation;
-    FF shifted_evaluation;
-    Polynomial non_shifted_polynomial;
-    Polynomial shifted_polynomial;
-    Commitment non_shifted_commitment;
-    Commitment shifted_commitment;
-    size_t dyadic_size;
-};
-
 template <typename Curve> struct MultilinearBatchingVerifierClaim {
     using FF = Curve::ScalarField;
     using Commitment = Curve::AffineElement;
@@ -90,6 +75,61 @@ template <typename Curve> struct MultilinearBatchingVerifierClaim {
         transcript.add_to_independent_hash_buffer(domain_separator + "shifted_commmitment", shifted_commitment);
 
         return transcript.hash_independent_buffer();
+    }
+};
+
+struct MultilinearBatchingProverClaim {
+    using FF = MultilinearBatchingFlavor::FF;
+    using Commitment = MultilinearBatchingFlavor::Commitment;
+    using Polynomial = MultilinearBatchingFlavor::Polynomial;
+    std::vector<FF> challenge;
+    FF non_shifted_evaluation;
+    FF shifted_evaluation;
+    Polynomial non_shifted_polynomial;
+    Polynomial shifted_polynomial;
+    Commitment non_shifted_commitment;
+    Commitment shifted_commitment;
+    size_t dyadic_size;
+
+    bool compare_with_verifier_claim(const MultilinearBatchingVerifierClaim<curve::BN254>& verifier_claim)
+    {
+        bool is_a_match = true;
+        CommitmentKey<curve::BN254> bn254_commitment_key(dyadic_size);
+
+        for (size_t idx = 0;
+             auto [prover_challenge, verifier_challenge] : zip_view(challenge, verifier_claim.challenge)) {
+            if (prover_challenge != verifier_challenge) {
+                info("Challenge mismatch at index ", idx);
+                is_a_match = false;
+            }
+            idx++;
+        }
+
+        if (verifier_claim.non_shifted_commitment != bn254_commitment_key.commit(non_shifted_polynomial)) {
+            info("Non-shifted commitment mismatch");
+            is_a_match = false;
+        }
+
+        if (verifier_claim.shifted_commitment != bn254_commitment_key.commit(shifted_polynomial)) {
+            info("Shifted commitment mismatch");
+            is_a_match = false;
+        }
+
+        // Bump the virtual size to compute mle evaluations
+        non_shifted_polynomial.increase_virtual_size(1 << challenge.size());
+        shifted_polynomial.increase_virtual_size(1 << challenge.size());
+
+        if (verifier_claim.non_shifted_evaluation != non_shifted_polynomial.evaluate_mle(verifier_claim.challenge)) {
+            info("Non-shifted evaluation mismatch");
+            is_a_match = false;
+        }
+
+        if (verifier_claim.shifted_evaluation != shifted_polynomial.evaluate_mle(verifier_claim.challenge, true)) {
+            info("Shifted evaluation mismatch");
+            is_a_match = false;
+        }
+
+        return is_a_match;
     }
 };
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/pairing_points.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/pairing_points.hpp
@@ -5,6 +5,7 @@
 // =====================
 
 #pragma once
+#include "barretenberg/commitment_schemes/pairing_points.hpp"
 #include "barretenberg/common/assert.hpp"
 #include "barretenberg/stdlib/primitives/curves/bn254.hpp"
 #include "barretenberg/stdlib/primitives/field/field.hpp"
@@ -56,6 +57,14 @@ template <typename Curve> struct PairingPoints {
         if (builder != nullptr) {
             tag_index = builder->pairing_points_tagging.create_pairing_point_tag();
         }
+
+#ifndef NDEBUG
+        bb::PairingPoints<typename Curve::NativeCurve> native_pp(P0.get_value(), P1.get_value());
+        info("Are Pairing Points with tag ",
+             builder->pairing_points_tagging.get_tag(tag_index),
+             " valid? ",
+             native_pp.check() ? "true" : "false");
+#endif
     }
 
     PairingPoints(std::array<Group, 2> const& points)
@@ -169,6 +178,14 @@ template <typename Curve> struct PairingPoints {
         if (builder != nullptr) {
             builder->pairing_points_tagging.merge_pairing_point_tags(this->tag_index, other.tag_index);
         }
+
+#ifndef NDEBUG
+        bb::PairingPoints<typename Curve::NativeCurve> native_pp(P0.get_value(), P1.get_value());
+        info("Are Pairing Points with tag ",
+             builder->pairing_points_tagging.get_tag(this->tag_index),
+             " valid? ",
+             native_pp.check() ? "true" : "false");
+#endif
     }
 
     /**

--- a/barretenberg/cpp/src/barretenberg/translator_vm/translator_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/translator_flavor.hpp
@@ -811,6 +811,14 @@ class TranslatorFlavor {
         {
             throw_or_abort("Not intended to be used because vk is hardcoded in circuit.");
         }
+
+#ifndef NDEBUG
+        bool compare(const VerificationKey& other)
+        {
+            return NativeVerificationKey_<PrecomputedEntities<Commitment>, Transcript>::compare<
+                NUM_PRECOMPUTED_ENTITIES>(other, CommitmentLabels().get_precomputed());
+        }
+#endif
     };
 
     /**


### PR DESCRIPTION
- Added a function `debug_incoming_circuit` that can be used when debugging a Chonk transaction (it checks that the incoming circuit is valid and it compares its vk with the precomputed one)
- Defined a `compare` operator for verification keys in debug mode that returns which elements (if any) differ
- Defined a method `compare_with_verifier_claim` in debug mode for a `MultilinearBatchingProverClaim` (our accumulator in Chonk) that allows to compare a prover accumulator to a verifier one to check their consistency
- Added validity check for each PairingPoint generated in circuit