### PR TITLE
chore: update naming in bb_proof_verification lib

### DIFF
--- a/barretenberg/acir_tests/internal_test_programs/double_verify_honk_proof/src/main.nr
+++ b/barretenberg/acir_tests/internal_test_programs/double_verify_honk_proof/src/main.nr
@@ -1,5 +1,5 @@
 // This circuit aggregates two Honk proof from `assert_statement`.
-use bb_proof_verification::{UltraHonkVerificationKey, UltraHonkProof, verify_ultrahonk_proof};
+use bb_proof_verification::{UltraHonkVerificationKey, UltraHonkProof, verify_honk_proof_non_zk};
 
 fn main(
     verification_key: UltraHonkVerificationKey,
@@ -11,13 +11,13 @@ fn main(
     // The second proof, currently set to be identical
     proof_b: UltraHonkProof,
 ) {
-    verify_ultrahonk_proof(
+    verify_honk_proof_non_zk(
         verification_key,
         proof,
         public_inputs,
         key_hash,
     );
-    verify_ultrahonk_proof(
+    verify_honk_proof_non_zk(
         verification_key,
         proof_b,
         public_inputs,

--- a/barretenberg/acir_tests/internal_test_programs/double_verify_honk_zk_proof/src/main.nr
+++ b/barretenberg/acir_tests/internal_test_programs/double_verify_honk_zk_proof/src/main.nr
@@ -1,5 +1,5 @@
 // This circuit aggregates two ZK-Honk proofs from `assert_statement`.
-use bb_proof_verification::{UltraHonkVerificationKey, UltraHonkZKProof, verify_ultrahonkzk_proof};
+use bb_proof_verification::{UltraHonkVerificationKey, UltraHonkZKProof, verify_honk_proof};
 
 fn main(
     verification_key: UltraHonkVerificationKey,
@@ -11,13 +11,13 @@ fn main(
     // The second proof, currently set to be identical
     proof_b: UltraHonkZKProof,
 ) {
-    verify_ultrahonkzk_proof(
+    verify_honk_proof(
         verification_key,
         proof,
         public_inputs,
         key_hash,
     );
-    verify_ultrahonkzk_proof(
+    verify_honk_proof(
         verification_key,
         proof_b,
         public_inputs,

--- a/barretenberg/acir_tests/internal_test_programs/verify_honk_proof/src/main.nr
+++ b/barretenberg/acir_tests/internal_test_programs/verify_honk_proof/src/main.nr
@@ -1,5 +1,5 @@
 // This circuit aggregates a single Honk proof from `assert_statement`.
-use bb_proof_verification::{UltraHonkVerificationKey, UltraHonkProof, verify_ultrahonk_proof};
+use bb_proof_verification::{UltraHonkVerificationKey, UltraHonkProof, verify_honk_proof_non_zk};
 
 fn main(
     verification_key: UltraHonkVerificationKey,
@@ -11,7 +11,7 @@ fn main(
     // I believe we want to eventually make it public too though.
     key_hash: Field,
 ) {
-    verify_ultrahonk_proof(
+    verify_honk_proof_non_zk(
         verification_key,
         proof,
         public_inputs,

--- a/barretenberg/acir_tests/internal_test_programs/verify_honk_zk_proof/src/main.nr
+++ b/barretenberg/acir_tests/internal_test_programs/verify_honk_zk_proof/src/main.nr
@@ -1,5 +1,5 @@
 // This circuit aggregates a single ZK-Honk proof from `assert_statement`.
-use bb_proof_verification::{UltraHonkVerificationKey, UltraHonkZKProof, verify_ultrahonkzk_proof};
+use bb_proof_verification::{UltraHonkVerificationKey, UltraHonkZKProof, verify_honk_proof};
 
 fn main(
     verification_key: UltraHonkVerificationKey,
@@ -10,7 +10,7 @@ fn main(
     // This is currently not public. It is fine given that the vk is a part of the circuit definition.
     key_hash: Field,
 ) {
-    verify_ultrahonkzk_proof(
+    verify_honk_proof(
         verification_key,
         proof,
         public_inputs,

--- a/barretenberg/noir/bb_proof_verification/src/lib.nr
+++ b/barretenberg/noir/bb_proof_verification/src/lib.nr
@@ -21,11 +21,15 @@ pub global RECURSIVE_ZK_PROOF_LENGTH: u32 = 492 + 16;
 
 pub type UltraHonkZKProof = [Field; RECURSIVE_ZK_PROOF_LENGTH];
 
-pub fn verify_ultrahonk_proof<let N: u32>(
+// Verifies a non-zero-knowledge UltraHonk proof.
+//
+// Represents standard UltraHonk recursive verification for proofs that do not hide the witness.
+// Use this only in situations where zero-knowledge is not required.
+pub fn verify_honk_proof_non_zk<let N: u32>(
     verification_key: UltraHonkVerificationKey,
     proof: UltraHonkProof,
     public_inputs: [Field; N],
-    key_hash: Field,
+    key_hash: Field, // Hash of the verification key
 ) {
     std::verify_proof_with_type(
         verification_key,
@@ -36,11 +40,15 @@ pub fn verify_ultrahonk_proof<let N: u32>(
     );
 }
 
+// Verifies a non-zero-knowledge Rollup UltraHonk proof with IPA (Inner Product Argument).
+//
+// This variant includes an IPA claim and proof appended to the standard UltraHonk proof,
+// used to amortize IPA recursive verification costs in rollup circuits.
 pub fn verify_rolluphonk_proof<let N: u32>(
     verification_key: RollupHonkVerificationKey,
     proof: RollupHonkProof,
     public_inputs: [Field; N],
-    key_hash: Field,
+    key_hash: Field, // Hash of the verification key
 ) {
     std::verify_proof_with_type(
         verification_key,
@@ -51,11 +59,17 @@ pub fn verify_rolluphonk_proof<let N: u32>(
     );
 }
 
-pub fn verify_ultrahonkzk_proof<let N: u32>(
+// Verifies a zero-knowledge UltraHonk proof.
+//
+// This verifier is for UltraHonk proofs constructed with zero-knowledge, which hide the witness
+// values from the verifier.
+// Note: We intentionally choose the generic name "verify_honk_proof" for this function, as we 
+// want ZK to be the default unless the user explicitly opts out.
+pub fn verify_honk_proof<let N: u32>(
     verification_key: UltraHonkVerificationKey,
     proof: UltraHonkZKProof,
     public_inputs: [Field; N],
-    key_hash: Field,
+    key_hash: Field, // Hash of the verification key
 ) {
     std::verify_proof_with_type(
         verification_key,


### PR DESCRIPTION
Update the naming in `bb_proof_verification` lib so that we guide users towards ZK by default (`verify_honk_proof`) and non-ZK is more opt-in (`verify_honk_proof_non_zk`)