### PR TITLE
allow passing args when using `aztec-postprocess-contracts`

### DIFF
--- a/aztec-postprocess-contract/transpile_contract_and_gen_vks.sh
+++ b/aztec-postprocess-contract/transpile_contract_and_gen_vks.sh
@@ -12,6 +12,6 @@ BB_BINARY_PATH=${BB_BINARY_PATH:-"$dir/../barretenberg/cpp/build/bin/bb"}
 
 # No arguments provided - let bb auto-discover and process all artifacts
 echo "Searching for contract artifacts in target/ directories..."
-$BB_BINARY_PATH aztec_process
+$BB_BINARY_PATH aztec_process $*
 
 echo "Contract postprocessing complete!"


### PR DESCRIPTION
`transpile_contract_and_gen_vks.sh` currently ignores any provided args. This PR updates the script so that arguments are passed to the `bb aztec_process`, enabling things like

```sh
aztec-postprocess-contracts --input target/mycontract.json
```

using the `aztec-postprocess-contracts` helper instead of needing to run `bb` manually with:

```sh
docker run [...] \
  --entrypoint=/path/to/bb \
  aztecprotocol/aztec:3.0.0-devnet.4 \
  aztec_process --input target/mycontract.json
```