### PR TITLE
fix: Rename P2P logging identifier

### DIFF
--- a/yarn-project/p2p/src/client/p2p_client.ts
+++ b/yarn-project/p2p/src/client/p2p_client.ts
@@ -373,7 +373,7 @@ export class P2PClient<T extends P2PClientType = P2PClientType.Full>
   @trackSpan('p2pClient.broadcastProposal', async proposal => ({
     [Attributes.SLOT_NUMBER]: proposal.slotNumber.toNumber(),
     [Attributes.BLOCK_ARCHIVE]: proposal.archive.toString(),
-    [Attributes.P2P_ID]: (await proposal.p2pMessageIdentifier()).toString(),
+    [Attributes.P2P_ID]: (await proposal.p2pMessageLoggingIdentifier()).toString(),
   }))
   public broadcastProposal(proposal: BlockProposal): Promise<void> {
     this.log.verbose(`Broadcasting proposal for slot ${proposal.slotNumber.toNumber()} to peers`);

--- a/yarn-project/stdlib/src/p2p/gossipable.ts
+++ b/yarn-project/stdlib/src/p2p/gossipable.ts
@@ -35,7 +35,7 @@ export abstract class Gossipable {
    * A digest of the message information **used for logging only**.
    * The identifier used for deduplication is `getMsgIdFn` as defined in `encoding.ts` which is a hash over topic and data.
    */
-  async p2pMessageIdentifier(): Promise<Buffer32> {
+  async p2pMessageLoggingIdentifier(): Promise<Buffer32> {
     if (this.cachedId) {
       return this.cachedId;
     }


### PR DESCRIPTION
This PR address point 7.2.3 of the Cyfrin Node audit.
