### PR TITLE
fix: Throw if invalid TxArray

### DIFF
--- a/yarn-project/stdlib/src/tx/tx.test.ts
+++ b/yarn-project/stdlib/src/tx/tx.test.ts
@@ -1,7 +1,8 @@
+import { randomBytes } from '@aztec/foundation/crypto';
 import { jsonStringify } from '@aztec/foundation/json-rpc';
 
 import { mockTx } from '../tests/mocks.js';
-import { Tx } from './tx.js';
+import { Tx, TxArray } from './tx.js';
 
 describe('Tx', () => {
   it('convert to and from buffer', async () => {
@@ -14,5 +15,32 @@ describe('Tx', () => {
     const tx = await mockTx();
     const json = jsonStringify(tx);
     expect(await Tx.schema.parseAsync(JSON.parse(json))).toEqual(tx);
+  });
+});
+
+describe('TxArray', () => {
+  it('converts to and from buffer', async () => {
+    const tx1 = await mockTx();
+    const tx2 = await mockTx();
+    const txArray = new TxArray(tx1, tx2);
+    expect(txArray.length).toBe(2);
+    const buf = txArray.toBuffer();
+    const deserializedTxArray = TxArray.fromBuffer(buf);
+    expect(deserializedTxArray).toEqual(txArray);
+    expect(deserializedTxArray).not.toBe(txArray);
+  });
+
+  it('convert empty TxArray to and from buffer', () => {
+    const txArray = new TxArray();
+    expect(txArray.length).toBe(0);
+    const buf = txArray.toBuffer();
+    const deserializedTxArray = TxArray.fromBuffer(buf);
+    expect(deserializedTxArray).toEqual(txArray);
+    expect(deserializedTxArray).not.toBe(txArray);
+  });
+
+  it('throws when deserializing invalid buffer', () => {
+    const invalidBuffer = randomBytes(10);
+    expect(() => TxArray.fromBuffer(invalidBuffer)).toThrow('Failed to deserialize TxArray from buffer');
   });
 });

--- a/yarn-project/stdlib/src/tx/tx.ts
+++ b/yarn-project/stdlib/src/tx/tx.ts
@@ -317,13 +317,12 @@ export class Tx extends Gossipable {
  */
 export class TxArray extends Array<Tx> {
   static fromBuffer(buffer: Buffer | BufferReader): TxArray {
+    const reader = BufferReader.asReader(buffer);
     try {
-      const reader = BufferReader.asReader(buffer);
       const txs = reader.readVector(Tx);
-
       return new TxArray(...txs);
     } catch {
-      return new TxArray();
+      throw new Error('Failed to deserialize TxArray from buffer');
     }
   }
 


### PR DESCRIPTION
This PR addresses point 7.2.2 of the Cyfin Node audit
