### PR TITLE
chore: Cleanup. Remove bootstrap fast full cmds.

### DIFF
--- a/avm-transpiler/bootstrap.sh
+++ b/avm-transpiler/bootstrap.sh
@@ -2,8 +2,6 @@
 # Use ci3 script base.
 source $(git rev-parse --show-toplevel)/ci3/source_bootstrap
 
-cmd=${1:-}
-
 hash=$(hash_str $(../noir/bootstrap.sh hash) $(cache_content_hash .rebuild_patterns))
 
 export GIT_COMMIT="$(cat ../noir/noir-repo-ref | head -n1)-aztec"
@@ -81,26 +79,13 @@ function build {
 }
 
 case "$cmd" in
-  "clean")
-    git clean -fdx
-    ;;
-  ""|"fast"|"full"|"ci")
+  "")
     build
-    ;;
-  build_native)
-    build_native
-    ;;
-  build_cross)
-    shift
-    build_cross "$@"
-    ;;
-  "test")
-    echo "No tests."
     ;;
   "hash")
     echo $hash
     ;;
   *)
-    echo "Unknown command: $cmd"
-    exit 1
+    default_cmd_handler "$@"
+    ;;
 esac

--- a/aztec-up/bootstrap.sh
+++ b/aztec-up/bootstrap.sh
@@ -1,10 +1,7 @@
 #!/usr/bin/env bash
 source $(git rev-parse --show-toplevel)/ci3/source_bootstrap
 
-cmd=${1:-}
-
 hash=$(hash_str $(cache_content_hash ^aztec-up/) $(../yarn-project/bootstrap.sh hash))
-
 
 function build_dind_image {
   echo_header "aztec-up build test image"
@@ -52,12 +49,9 @@ function release {
 }
 
 case "$cmd" in
-  ""|"full"|"fast")
-    ;;
-  test_cmds|test|release|build_dind_image|update_manifest)
-    $cmd
+  "")
     ;;
   *)
-    echo "Unknown command: $cmd"
-    exit 1
+    default_cmd_handler "$@"
+    ;;
 esac

--- a/barretenberg/acir_tests/bootstrap.sh
+++ b/barretenberg/acir_tests/bootstrap.sh
@@ -1,12 +1,11 @@
 #!/usr/bin/env bash
 source $(git rev-parse --show-toplevel)/ci3/source_bootstrap
 
-cmd=${1:-}
 export CRS_PATH=$HOME/.bb-crs
 export RAYON_NUM_THREADS=1
 
 tests_tar=barretenberg-acir-tests-$(hash_str \
-  $(../../noir/bootstrap.sh hash-tests) \
+  $(../../noir/bootstrap.sh tests) \
   $(cache_content_hash \
     ./.rebuild_patterns \
     ../cpp/.rebuild_patterns \
@@ -14,7 +13,7 @@ tests_tar=barretenberg-acir-tests-$(hash_str \
     )).tar.gz
 
 tests_hash=$(hash_str \
-  $(../../noir/bootstrap.sh hash-tests) \
+  $(../../noir/bootstrap.sh tests) \
   $(../cpp/bootstrap.sh hash) \
   $(cache_content_hash \
     ^barretenberg/acir_tests/ \
@@ -223,26 +222,13 @@ function bench {
 }
 
 case "$cmd" in
-  "clean")
-    git clean -fdx
-    ;;
-  "ci")
-    build
-    test
-    ;;
-  ""|"fast"|"full")
+  "")
     build
     ;;
   "hash")
     echo $tests_hash
     ;;
-  "compile")
-    compile
-    ;;
-  test|test_cmds|bench|bench_cmds)
-    $cmd
-    ;;
   *)
-    echo "Unknown command: $cmd"
-    exit 1
+    default_cmd_handler "$@"
+    ;;
 esac

--- a/barretenberg/bbup/bootstrap.sh
+++ b/barretenberg/bbup/bootstrap.sh
@@ -1,9 +1,6 @@
 #!/usr/bin/env bash
 source $(git rev-parse --show-toplevel)/ci3/source_bootstrap
 
-cmd=${1:-}
-[ -n "$cmd" ] && shift
-
 export hash=$(cache_content_hash .rebuild_patterns)
 
 # Print every individual test command. Can be fed into gnu parallel.
@@ -23,21 +20,10 @@ function test {
 }
 
 case "$cmd" in
-  "clean")
-    git clean -fdx
-    ;;
-  ""|fast|full|bench|bench_cmds)
-    ;;
-  "ci")
-    test
-    ;;
   "hash")
     echo $hash
     ;;
-  test|test_cmds)
-    $cmd "$@"
-    ;;
   *)
-    echo "Unknown command: $cmd"
-    exit 1
+    default_cmd_handler "$@"
+    ;;
 esac

--- a/barretenberg/bootstrap.sh
+++ b/barretenberg/bootstrap.sh
@@ -20,12 +20,11 @@ function hash {
 }
 
 cmd=${1:-}
-
 case "$cmd" in
   hash)
     hash
     ;;
-  ""|clean|ci|fast|test|test_cmds|bench|bench_cmds|release)
+  ""|clean|ci|test|test_cmds|bench|bench_cmds|release)
     bootstrap_all $@
     ;;
   "release-preview")

--- a/barretenberg/docs/bootstrap.sh
+++ b/barretenberg/docs/bootstrap.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
 source $(git rev-parse --show-toplevel)/ci3/source_bootstrap
 
-cmd=${1:-}
-
 # We search the docs/*.md files to find included code, and use those as our rebuild dependencies.
 # We prefix the results with ^ to make them "not a file", otherwise they'd be interpreted as pattern files.
 hash=$(
@@ -48,22 +46,13 @@ function test {
 }
 
 case "$cmd" in
-  "clean")
-    git clean -fdx
-    ;;
-  ""|"full"|"fast"|"ci")
+  "")
     build
     ;;
   "hash")
     echo "$hash"
     ;;
-  "test_cmds")
-    test_cmds
-    ;;
-  "test")
-    test
-    ;;
   *)
-    echo "Unknown command: $cmd"
-    exit 1
+    default_cmd_handler "$@"
+    ;;
 esac

--- a/barretenberg/sol/bootstrap.sh
+++ b/barretenberg/sol/bootstrap.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 source $(git rev-parse --show-toplevel)/ci3/source_bootstrap
 
-cmd=${1:-}
 export CRS_PATH="../cpp/srs_db"
 
 export hash=$(cache_content_hash \
@@ -112,35 +111,14 @@ function bench {
   fi
 }
 
-
 case "$cmd" in
-  "clean")
-    git clean -fdx
-    ;;
-  "ci")
-    build
-    test
-    ;;
-  ""|"fast"|"full")
+  "")
     build
     ;;
   "hash")
     echo $hash
     ;;
-  test|test_cmds)
-    $cmd
-    ;;
-  "bench")
-    bench
-    ;;
-  "bench_cmds")
-    bench_cmds
-    ;;
-  "release")
-    # noop
-    exit 0
-    ;;
   *)
-    echo "Unknown command: $cmd"
-    exit 1
+    default_cmd_handler "$@"
+    ;;
 esac

--- a/barretenberg/ts/bootstrap.sh
+++ b/barretenberg/ts/bootstrap.sh
@@ -2,8 +2,6 @@
 # Use ci3 script base.
 source $(git rev-parse --show-toplevel)/ci3/source_bootstrap
 
-cmd=${1:-}
-
 # We mix if we're a release into the hash, as releases have all architectures built.
 hash=$(hash_str \
   $(../cpp/bootstrap.sh hash) \
@@ -58,26 +56,13 @@ function release {
 }
 
 case "$cmd" in
-  "clean")
-    git clean -fdx
-    ;;
-  "ci")
-    build
-    test
-    ;;
-  ""|"fast"|"full")
+  "")
     build
     ;;
   "hash")
     echo "$hash"
     ;;
-  bench|bench_cmds)
-    # Empty handling just to make this command valid.
-    ;;
-  test|test_cmds|release)
-    $cmd
-    ;;
   *)
-    echo "Unknown command: $cmd"
-    exit 1
+    default_cmd_handler "$@"
+    ;;
 esac

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -13,9 +13,6 @@ export DENOISE=${DENOISE:-1}
 # Number of TXE servers to run when testing.
 export NUM_TXES=8
 
-cmd=${1:-}
-[ -n "$cmd" ] && shift
-
 if [ ! -v NOIR_HASH ] && [ "$cmd" != "clean" ]; then
   export NOIR_HASH=$(./noir/bootstrap.sh hash)
   [ -n "$NOIR_HASH" ]
@@ -278,7 +275,7 @@ function build {
 function bench_cmds {
   if [ "$#" -eq 0 ]; then
     # Ordered with longest running first, to ensure they get scheduled earliest.
-    set -- yarn-project/end-to-end yarn-project barretenberg/cpp barretenberg/sol barretenberg/acir_tests noir-projects/noir-protocol-circuits l1-contracts
+    set -- yarn-project/end-to-end yarn-project barretenberg/cpp barretenberg/sol noir-projects/noir-protocol-circuits l1-contracts
   fi
   parallel -k --line-buffer './{}/bootstrap.sh bench_cmds' ::: $@ | sort_by_cpus
 }
@@ -415,7 +412,7 @@ case "$cmd" in
     check_toolchains
     echo "Toolchains look good! 🎉"
   ;;
-  ""|"fast"|"full")
+  "")
     install_hooks
     build
   ;;
@@ -474,11 +471,7 @@ case "$cmd" in
     export AVM_TRANSPILER=0
     barretenberg/cpp/bootstrap.sh ci
     ;;
-  test|test_cmds|build_bench|bench|bench_cmds|bench_merge|release|release_dryrun)
-    $cmd "$@"
-    ;;
   *)
-    echo "Unknown command: $cmd"
-    exit 1
-  ;;
+    default_cmd_handler $cmd "$@"
+    ;;
 esac

--- a/boxes/bootstrap.sh
+++ b/boxes/bootstrap.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
 source $(git rev-parse --show-toplevel)/ci3/source_bootstrap
 
-cmd=${1:-}
-
 # We set container name to "" to avoid container name collisions when building boxes
 export CONTAINER_NAME=""
 export AZTEC=$PWD/../aztec-up/bin/aztec
@@ -30,15 +28,21 @@ function test {
 }
 
 function test_cmds {
-  for browser in chromium webkit firefox; do
-    for box in react vite; do
-      echo "$hash:ONLY_TERM_PARENT=1 BOX=$box BROWSER=$browser run_compose_test $box-$browser box boxes"
-    done
+  # Until we get these boxes stable again - just testing on chromium.
+  local browser=chromium
+  for box in react vite vanilla; do
+    echo "$hash:ONLY_TERM_PARENT=1 BOX=$box BROWSER=$browser run_compose_test $box-$browser box boxes"
   done
 
-  # The vanilla app works with deployed contracts configured during the build.
-  # To avoid building the app three times, we test it with one local network and multiple browsers.
-  echo "$hash:ONLY_TERM_PARENT=1 BOX=vanilla BROWSER=* run_compose_test vanilla-all-browsers box boxes"
+  # for browser in chromium webkit firefox; do
+  #   for box in react vite; do
+  #     echo "$hash:ONLY_TERM_PARENT=1 BOX=$box BROWSER=$browser run_compose_test $box-$browser box boxes"
+  #   done
+  # done
+
+  # # The vanilla app works with deployed contracts configured during the build.
+  # # To avoid building the app three times, we test it with one sandbox and multiple browsers.
+  # echo "$hash:ONLY_TERM_PARENT=1 BOX=vanilla BROWSER=* run_compose_test vanilla-all-browsers box boxes"
 }
 
 # First argument is a branch name (e.g. master, or the latest version e.g. 1.2.3) to push to the head of.
@@ -106,23 +110,13 @@ function release {
 }
 
 case "$cmd" in
-  "clean")
-    git clean -fdx
-    ;;
-  "ci")
+  "")
     build
-    test
-    ;;
-  ""|"fast"|"full")
-    build
-    ;;
-  test|test_cmds|release)
-    $cmd
     ;;
   "hash")
     echo $hash
     ;;
   *)
-    echo "Unknown command: $cmd"
-    exit 1
+    default_cmd_handler "$@"
+    ;;
 esac

--- a/build-images/bootstrap.sh
+++ b/build-images/bootstrap.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 source $(git rev-parse --show-toplevel)/ci3/source_bootstrap
 
-cmd=${1:-}
 version="3.0"
 arch=$(arch)
 branch=${BRANCH:-$(git rev-parse --abbrev-ref HEAD)}

--- a/ci3/source_bootstrap
+++ b/ci3/source_bootstrap
@@ -4,16 +4,10 @@ source $(git rev-parse --show-toplevel)/ci3/source
 source $ci3/source_refname
 source $ci3/source_redis
 
-case "${1:-}" in
-  "ci")
-    # Forces yarn immutability, jest snapshot immutability, etc.
-    export CI=1
-    # Being in CI implies use of cache, and enables denoising.
-    export DENOISE=${DENOISE:-1}
-    ;;
-  "full")
-    export NO_CACHE=${NO_CACHE:-1}
-    ;;
+cmd=${1:-}
+[ -n "$cmd" ] && shift
+
+case "$cmd" in
   release)
     if ! semver check $REF_NAME; then
       echo_stderr -e "${yellow}Not deploying $REF_NAME because it is not a release tag.${reset}"
@@ -23,3 +17,20 @@ case "${1:-}" in
     set -x
     ;;
 esac
+
+# Default clean function available to all bootstrap scripts.
+function clean {
+  git clean -fdx
+  exit 0
+}
+
+# Default command handler available to all bootstrap scripts.
+# If the bootstrap scripts command handler doesn't specifically specify, we will execute a matching function.
+function default_cmd_handler {
+  if declare -f $cmd >/dev/null 2>&1; then
+    $cmd "$@"
+  else
+    echo "Unknown command: $cmd"
+    exit 1
+  fi
+}

--- a/docs/bootstrap.sh
+++ b/docs/bootstrap.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
 source $(git rev-parse --show-toplevel)/ci3/source_bootstrap
 
-cmd=${1:-}
-
 export BB=${BB:-../barretenberg/cpp/build/bin/bb}
 export NARGO=${NARGO:-../noir/noir-repo/target/release/nargo}
 export TRANSPILER=${TRANSPILER:-../avm-transpiler/target/release/avm-transpiler}
@@ -64,16 +62,13 @@ function build_examples {
 }
 
 case "$cmd" in
-  "clean")
-    git clean -fdx
-    ;;
   "ci")
     build_examples
     build_docs
     test
     check_references
     ;;
-  ""|"full"|"fast")
+  "")
     build_examples
     build_docs
     check_references
@@ -82,13 +77,9 @@ case "$cmd" in
     echo "$hash"
     ;;
   "compile")
-    shift
     build_examples compile "$@"
     ;;
-  test|test_cmds)
-    $cmd
-    ;;
   *)
-    echo "Unknown command: $cmd"
-    exit 1
+    default_cmd_handler "$@"
+    ;;
 esac

--- a/docs/examples/bootstrap.sh
+++ b/docs/examples/bootstrap.sh
@@ -1,9 +1,6 @@
 #!/usr/bin/env bash
 source $(git rev-parse --show-toplevel)/ci3/source_bootstrap
 
-cmd=${1:-}
-shift || true
-
 # Get repo root for absolute paths
 REPO_ROOT=$(git rev-parse --show-toplevel)
 
@@ -14,34 +11,24 @@ export STRIP_AZTEC_NR_PREFIX=${STRIP_AZTEC_NR_PREFIX:-"$REPO_ROOT/noir-projects/
 export BB_HASH=${BB_HASH:-$("$REPO_ROOT/barretenberg/cpp/bootstrap.sh" hash)}
 export NOIR_HASH=${NOIR_HASH:-$("$REPO_ROOT/noir/bootstrap.sh" hash)}
 
-function compile_contracts {
-    echo_header "Compiling example contracts"
-    # Use noir-contracts bootstrap with DOCS_WORKING_DIR pointing to parent (docs/)
-    DOCS_WORKING_DIR="$(cd .. && pwd)" \
-        $REPO_ROOT/noir-projects/noir-contracts/bootstrap.sh compile "$@"
+function compile {
+  echo_header "Compiling example contracts"
+  # Use noir-contracts bootstrap with DOCS_WORKING_DIR pointing to parent (docs/)
+  DOCS_WORKING_DIR="$(cd .. && pwd)" \
+    $REPO_ROOT/noir-projects/noir-contracts/bootstrap.sh compile "$@"
 }
 
-function validate_ts_projects {
-    echo_header "Validating TypeScript examples"
-    (cd ts && ./bootstrap.sh "$@")
+function validate-ts {
+  echo_header "Validating TypeScript examples"
+  (cd ts && ./bootstrap.sh "$@")
 }
 
 case "$cmd" in
-    "clean")
-        git clean -fdx
-        ;;
-    "compile")
-        compile_contracts "$@"
-        ;;
-    "validate-ts")
-        validate_ts_projects "$@"
-        ;;
-    ""|"full"|"fast")
-        compile_contracts
-        validate_ts_projects
-        ;;
-    *)
-        echo_stderr "ERROR: Unknown command '${cmd}'"
-        echo_stderr "Usage: bootstrap.sh [clean|compile|validate-ts|full|fast]"
-        exit 1
+  "")
+    compile
+    validate-ts
+    ;;
+  *)
+    default_cmd_handler "$@"
+    ;;
 esac

--- a/docs/examples/ts/bootstrap.sh
+++ b/docs/examples/ts/bootstrap.sh
@@ -217,12 +217,8 @@ get_all_projects() {
     done
 }
 
-# Main logic
-cmd=${1:-}
-shift || true
-
 case "$cmd" in
-    ""|"full"|"fast")
+    "")
         # Validate all projects in parallel
         echo_header "Validating TypeScript examples"
 

--- a/l1-contracts/bootstrap.sh
+++ b/l1-contracts/bootstrap.sh
@@ -1,9 +1,6 @@
 #!/usr/bin/env bash
 source $(git rev-parse --show-toplevel)/ci3/source_bootstrap
 
-cmd=${1:-}
-
-
 # We rely on noir-projects for the verifier contract.
 export hash=$(cache_content_hash \
   .rebuild_patterns \
@@ -401,35 +398,13 @@ function release {
 }
 
 case "$cmd" in
-  "clean")
-    git clean -fdx
-    ;;
-  "ci")
+  "")
     build
-    test
-    ;;
-  ""|"fast"|"full")
-    build
-    ;;
-  "gas_report")
-    shift
-    gas_report "$@"
-    ;;
-  "gas_benchmark")
-    shift
-    gas_benchmark "$@"
-    ;;
-  "coverage")
-    shift
-    coverage "$@"
-    ;;
-  test|test_cmds|bench|bench_cmds|inspect|release|build_src|build_verifier)
-    $cmd
     ;;
   "hash")
     echo $hash
     ;;
   *)
-    echo "Unknown command: $cmd"
-    exit 1
+    default_cmd_handler "$@"
+    ;;
 esac

--- a/noir-projects/aztec-nr/bootstrap.sh
+++ b/noir-projects/aztec-nr/bootstrap.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
 source $(git rev-parse --show-toplevel)/ci3/source_bootstrap
 
-cmd=${1:-}
-
 export RAYON_NUM_THREADS=${RAYON_NUM_THREADS:-16}
 export HARDWARE_CONCURRENCY=${HARDWARE_CONCURRENCY:-16}
 export NARGO=${NARGO:-../../noir/noir-repo/target/release/nargo}
@@ -112,20 +110,13 @@ function release_git_push {
 }
 
 case "$cmd" in
-  ""|"fast"|"full")
+  "")
     build
-    ;;
-  "ci")
-    build
-    test
-    ;;
-  test|test_cmds|format|release)
-    $cmd
     ;;
   "test-macro-compilation-failure")
     ./macro_compilation_failure_tests/assert_macro_compilation_failure.sh
     ;;
   *)
-    echo_stderr "Unknown command: $cmd"
-    exit 1
+    default_cmd_handler "$@"
+    ;;
 esac

--- a/noir-projects/bootstrap.sh
+++ b/noir-projects/bootstrap.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
 source $(git rev-parse --show-toplevel)/ci3/source_bootstrap
 
-cmd=${1:-}
-
 export NOIR_HASH=${NOIR_HASH-$(../noir/bootstrap.sh hash)}
 
 function build {
@@ -43,16 +41,13 @@ function format {
 }
 
 case "$cmd" in
-  full|fast|ci|"")
+  "")
     build
-    ;;
-  test|test_cmds|format)
-    $cmd
     ;;
   "hash")
     hash_str $(../noir/bootstrap.sh hash) $(cache_content_hash .rebuild_patterns)
     ;;
   *)
-    echo_stderr "Unknown command: $cmd"
-    exit 1
+    default_cmd_handler "$@"
+    ;;
 esac

--- a/noir-projects/noir-contracts-comp-failures/bootstrap.sh
+++ b/noir-projects/noir-contracts-comp-failures/bootstrap.sh
@@ -1,8 +1,5 @@
 #!/usr/bin/env bash
-
 source $(git rev-parse --show-toplevel)/ci3/source_bootstrap
-
-cmd=${1:-}
 
 # nargo command path relative to the individual contract directory
 export NARGO=${NARGO:-../../../../noir/noir-repo/target/release/nargo}
@@ -60,10 +57,7 @@ function test_cmds {
 }
 
 case "$cmd" in
-  test|test_cmds)
-    $cmd
-    ;;
   *)
-    echo_stderr "Unknown command: $cmd"
-    exit 1
+    default_cmd_handler "$@"
+    ;;
 esac

--- a/noir-projects/noir-contracts/bootstrap.sh
+++ b/noir-projects/noir-contracts/bootstrap.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# TODO: THIS SCRIPT SHOULD NOW BE ABLE TO REPLACE TRANSPILATION AND VK GENERATION WITH 'bb aztec_process'.
+#
 # Some notes if you have to work on this script.
 # - First of all, I'm sorry (edit: not sorry). It's a beautiful script but it's no fun to debug. I got carried away.
 # - You can enable BUILD_SYSTEM_DEBUG=1 but the output is quite verbose that it's not much use by default.
@@ -17,7 +19,6 @@
 # - We could perhaps make it less tricky to work with by leveraging more tempfiles and less stdin/stdout.
 source $(git rev-parse --show-toplevel)/ci3/source_bootstrap
 
-cmd=${1:-}
 # entrypoint for docs
 if [ -n "${DOCS_WORKING_DIR:-}" ]; then
   cd "$DOCS_WORKING_DIR"
@@ -258,9 +259,6 @@ function format {
 }
 
 case "$cmd" in
-  "clean")
-    git clean -fdx
-    ;;
   "clean-keys")
     for artifact in target/*.json; do
       echo_stderr "Scrubbing vk from $artifact..."
@@ -268,21 +266,13 @@ case "$cmd" in
       mv "${artifact}.tmp" "$artifact"
     done
     ;;
-  ""|"fast"|"full")
+  "")
     build
-    ;;
-  "ci")
-    build
-    test
     ;;
   "compile")
-    shift
     VERBOSE=${VERBOSE:-1} build "$@"
     ;;
-  test|test_cmds|format)
-    $cmd
-    ;;
   *)
-    echo_stderr "Unknown command: $cmd"
-    exit 1
+    default_cmd_handler "$@"
+    ;;
 esac

--- a/noir-projects/noir-protocol-circuits/bootstrap.sh
+++ b/noir-projects/noir-protocol-circuits/bootstrap.sh
@@ -2,7 +2,6 @@
 # Look at noir-contracts bootstrap.sh for some tips r.e. bash.
 source $(git rev-parse --show-toplevel)/ci3/source_bootstrap
 
-cmd=${1:-}
 # entrypoint for mock circuits
 if [ -n "${NOIR_PROTOCOL_CIRCUITS_WORKING_DIR:-}" ]; then
   cd "$NOIR_PROTOCOL_CIRCUITS_WORKING_DIR"
@@ -258,30 +257,13 @@ function bench {
 }
 
 case "$cmd" in
-  "bench")
-    bench
-    ;;
-  "clean")
-    git clean -fdx
-    ;;
   "clean-keys")
     rm -rf $key_dir
     ;;
-  "ci")
+  "")
     build
-    test
-    ;;
-  ""|"fast"|"full")
-    build
-    ;;
-  "compile")
-    shift
-    compile $1
-    ;;
-  test|test_cmds|bench_cmds|format)
-    $cmd
     ;;
   *)
-    echo_stderr "Unknown command: $cmd"
-    exit 1
+    default_cmd_handler "$@"
+    ;;
 esac

--- a/noir/bootstrap.sh
+++ b/noir/bootstrap.sh
@@ -3,9 +3,6 @@ source $(git rev-parse --show-toplevel)/ci3/source_bootstrap
 
 set -eou pipefail
 
-cmd=${1:-}
-[ -n "$cmd" ] && shift
-
 # Must be in dependency order for releasing.
 export js_projects="
   @noir-lang/types
@@ -51,7 +48,7 @@ function noir_content_hash {
   fi
 }
 
-if [ ! -v NOIR_HASH ] && [ "$cmd" != "clean" ]; then
+if [ ! -v NOIR_HASH ] && [ "${1:-}" != "clean" ]; then
   noir_sync
   export NOIR_HASH=$(noir_content_hash)
 fi
@@ -254,32 +251,25 @@ case "$cmd" in
     # Double `f` needed to delete the nested git repository.
     git clean -ffdx
     ;;
-  "ci")
+  "")
     build
-    test
-    ;;
-  ""|"fast"|"full")
-    build
-    ;;
-  test_cmds|build_native|build_packages|format|test|release)
-    $cmd "$@"
     ;;
   "hash")
-    echo $NOIR_HASH
-    ;;
-  "hash-tests")
     echo $NOIR_HASH
     ;;
   "make-patch")
     scripts/sync.sh make-patch
     ;;
-  "bump-noir-repo-ref")
-    bump_noir_repo_ref $@
+  "noir-sync")
+    # Noop, we synced above.
+    ;;
+  "noir-sync")
+    # Noop, we synced above.
     ;;
   "noir-sync")
     # Noop, we synced above.
     ;;
   *)
-    echo "Unknown command: $cmd"
-    exit 1
+    default_cmd_handler "$@"
+    ;;
 esac

--- a/playground/bootstrap.sh
+++ b/playground/bootstrap.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
 source $(git rev-parse --show-toplevel)/ci3/source_bootstrap
 
-cmd=${1:-}
-
 hash=$(hash_str $(cache_content_hash .rebuild_patterns) $(../yarn-project/bootstrap.sh hash))
 
 function build {
@@ -45,23 +43,13 @@ function invalidate_cloudfront {
 }
 
 case "$cmd" in
-  "clean")
-    git clean -fdx
-    ;;
-  "ci")
+  "")
     build
-    test
-    ;;
-  ""|"fast"|"full")
-    build
-    ;;
-  test|test_cmds|release|invalidate_cloudfront)
-    $cmd
     ;;
   "hash")
     echo $hash
     ;;
   *)
-    echo "Unknown command: $cmd"
-    exit 1
+    default_cmd_handler "$@"
+    ;;
 esac

--- a/release-image/bootstrap.sh
+++ b/release-image/bootstrap.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
 source $(git rev-parse --show-toplevel)/ci3/source_bootstrap
 
-cmd=${1:-}
-
 hash=$(cache_content_hash ^release-image/Dockerfile ^build-images/src/Dockerfile ^yarn-project/yarn.lock)
 
 function build_image {
@@ -90,10 +88,10 @@ function push {
 }
 
 case "$cmd" in
-  ""|"fast"|"full")
+  "")
     build
     ;;
   *)
-    $cmd "$@"
+    default_cmd_handler "$@"
     ;;
 esac

--- a/spartan/bootstrap.sh
+++ b/spartan/bootstrap.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
 source $(git rev-parse --show-toplevel)/ci3/source_bootstrap
 
-cmd=${1:-}
-
 hash=$(hash_str $(cache_content_hash .rebuild_patterns) $(../yarn-project/bootstrap.sh hash))
 
 dump_fail "flock scripts/logs/install_deps.lock retry scripts/install_deps.sh >&2"
@@ -125,7 +123,6 @@ case "$cmd" in
     # do nothing but the install_deps.sh above
     ;;
   "ensure_eth_balances")
-    shift
     env_file="$1"
     amount="$2"
 
@@ -141,7 +138,6 @@ case "$cmd" in
     ensure_eth_balances "$amount"
     ;;
   "ensure_funded_environment")
-    shift
     env_file="$1"
     low_watermark="${2:-0.5}"
     high_watermark="${3:-1.0}"
@@ -149,7 +145,6 @@ case "$cmd" in
     ./scripts/ensure_funded_environment.sh "$env_file" "$FUNDING_PRIVATE_KEY" "$low_watermark" "$high_watermark"
     ;;
   "network_deploy")
-    shift
     env_file="$1"
 
     #Sets up basic env vars like RUN_TESTS
@@ -164,7 +159,6 @@ case "$cmd" in
     fi
     ;;
   "single_test")
-    shift
     env_file="$1"
     test_file="$2"
     source_network_env $env_file
@@ -174,7 +168,6 @@ case "$cmd" in
     ;;
 
   "network_tests")
-    shift
     env_file="$1"
     network_tests $env_file
     ;;
@@ -203,7 +196,6 @@ case "$cmd" in
     metrics/install-prod.sh
     ;;
   "network-shaping")
-    shift
     namespace="$1"
     chaos_values="$2"
     if network_shaping "$namespace" "$chaos_values"; then
@@ -281,7 +273,6 @@ case "$cmd" in
       ./scripts/test_k8s.sh kind src/spartan/upgrade_via_cli.test.ts 1-validators.yaml upgrade-via-cli${NAME_POSTFIX:-}
     ;;
   "test-gke-transfer")
-    shift
     execution_client="$1"
     # TODO(#12163) reenable bot once not conflicting with transfer
     OVERRIDES="blobSink.enabled=true,bot.enabled=false"

--- a/yarn-project/bootstrap.sh
+++ b/yarn-project/bootstrap.sh
@@ -1,9 +1,6 @@
 #!/usr/bin/env bash
 source $(git rev-parse --show-toplevel)/ci3/source_bootstrap
 
-cmd=${1:-}
-[ -n "$cmd" ] && shift
-
 function hash {
   hash_str \
     $(../noir/bootstrap.sh hash) \
@@ -240,7 +237,7 @@ function release {
 
 case "$cmd" in
   "clean")
-    [ -n "${2:-}" ] && cd $2
+    [ -n "${1:-}" ] && cd $1
     git clean -fdx
     ;;
   "clean-lite")
@@ -249,11 +246,7 @@ case "$cmd" in
       echo "$files" | xargs rm -rf
     fi
     ;;
-  "ci")
-    build
-    test
-    ;;
-  ""|"fast")
+  "")
     build
     ;;
   "full")
@@ -295,14 +288,7 @@ case "$cmd" in
     trap cleanup_instrumentation EXIT
     eval "$cmd"
     ;;
-  lint|format)
-    $cmd "$@"
-    ;;
-  test|test_cmds|bench_cmds|hash|release|format)
-    $cmd
-    ;;
   *)
-    echo "Unknown command: $cmd"
-    exit 1
-  ;;
+    default_cmd_handler "$@"
+    ;;
 esac

--- a/yarn-project/end-to-end/bootstrap.sh
+++ b/yarn-project/end-to-end/bootstrap.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
 source $(git rev-parse --show-toplevel)/ci3/source_bootstrap
 
-cmd=${1:-}
-
 hash=$(../bootstrap.sh hash)
 bench_fixtures_dir=example-app-ivc-inputs-out
 
@@ -135,14 +133,7 @@ function bench {
 }
 
 case "$cmd" in
-  "clean")
-    git clean -fdx
-    ;;
-  test|test_cmds|bench|bench_cmds|build_bench)
-    $cmd
-    ;;
   *)
-    echo "Unknown command: $cmd"
-    exit 1
-  ;;
+    default_cmd_handler "$@"
+    ;;
 esac

--- a/yarn-project/p2p/bootstrap.sh
+++ b/yarn-project/p2p/bootstrap.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
 source $(git rev-parse --show-toplevel)/ci3/source_bootstrap
 
-cmd=${1:-}
-
 hash=$(../bootstrap.sh hash)
 
 function bench {
@@ -17,14 +15,10 @@ function bench {
 }
 
 case "$cmd" in
-  "clean")
-    git clean -fdx
-    ;;
   bench)
-    $cmd > /dev/null
+    bench > /dev/null
     ;;
   *)
-    echo "Unknown command: $cmd"
-    exit 1
-  ;;
+    default_cmd_handler "$@"
+    ;;
 esac


### PR DESCRIPTION
* We don't need these distinct fast/full commands. We use CI_FULL flag to distinguish.
* We only need the `ci` command on merge trains as it got repurposed there. Otherwise never used.
* We have a default command handler so we don't need to maintain supported commands anymore.
* Provide default `clean` command and override in special cases.