### PR TITLE
fix(p2p): (A-268) Defend against block proposal flooding

### DIFF
--- a/yarn-project/kv-store/src/indexeddb/multi_map.ts
+++ b/yarn-project/kv-store/src/indexeddb/multi_map.ts
@@ -61,6 +61,18 @@ export class IndexedDBAztecMultiMap<K extends Key, V extends Value>
     }
   }
 
+  getValueCountAsync(key: K): Promise<number> {
+    // Count entries over the keyCount index range for this key
+    const index = this.db.index('keyCount');
+    const rangeQuery = IDBKeyRange.bound(
+      [this.container, this.normalizeKey(key), 0],
+      [this.container, this.normalizeKey(key), Number.MAX_SAFE_INTEGER],
+      false,
+      false,
+    );
+    return index.count(rangeQuery);
+  }
+
   async deleteValue(key: K, val: V): Promise<void> {
     // Since we know the value, we can hash it and directly query the "hash" index
     // to avoid having to iterate over all the values

--- a/yarn-project/kv-store/src/interfaces/multi_map.ts
+++ b/yarn-project/kv-store/src/interfaces/multi_map.ts
@@ -30,6 +30,13 @@ export interface AztecAsyncMultiMap<K extends Key, V extends Value> extends Azte
   getValuesAsync(key: K): AsyncIterableIterator<V>;
 
   /**
+   * Gets the number of values at the given key.
+   * @param key - The key to get the number of values from
+   * @returns The number of values at the given key
+   */
+  getValueCountAsync(key: K): Promise<number>;
+
+  /**
    * Deletes a specific value at the given key.
    * @param key - The key to delete the value at
    * @param val - The value to delete

--- a/yarn-project/kv-store/src/lmdb-v2/multi_map.ts
+++ b/yarn-project/kv-store/src/lmdb-v2/multi_map.ts
@@ -1,8 +1,10 @@
 import { Encoder } from 'msgpackr/pack';
+import { MAXIMUM_KEY, toBufferKey } from 'ordered-binary';
 
 import type { Key, Range, Value } from '../interfaces/common.js';
 import type { AztecAsyncMultiMap } from '../interfaces/multi_map.js';
 import type { ReadTransaction } from './read_transaction.js';
+// eslint-disable-next-line import/no-cycle
 import { type AztecLMDBStoreV2, execInReadTx, execInWriteTx } from './store.js';
 import { deserializeKey, maxKey, minKey, serializeKey } from './utils.js';
 
@@ -137,5 +139,12 @@ export class LMDBMultiMap<K extends Key, V extends Value> implements AztecAsyncM
     for (const value of values) {
       yield this.encoder.unpack(value);
     }
+  }
+
+  getValueCountAsync(key: K): Promise<number> {
+    const startKey = serializeKey(this.prefix, key);
+    const endKey = toBufferKey([this.prefix, key, MAXIMUM_KEY]);
+
+    return execInReadTx(this.store, tx => tx.countEntriesIndex(startKey, endKey, false));
   }
 }

--- a/yarn-project/kv-store/src/lmdb/multi_map.ts
+++ b/yarn-project/kv-store/src/lmdb/multi_map.ts
@@ -29,6 +29,22 @@ export class LmdbAztecMultiMap<K extends Key, V extends Value>
     }
   }
 
+  getValueCountAsync(key: K): Promise<number> {
+    const transaction = this.db.useReadTransaction();
+    try {
+      const values = this.db.getValues(this.slot(key), {
+        transaction,
+      });
+      let count = 0;
+      for (const _ of values) {
+        count++;
+      }
+      return Promise.resolve(count);
+    } finally {
+      transaction.done();
+    }
+  }
+
   async deleteValue(key: K, val: V): Promise<void> {
     await this.db.remove(this.slot(key), [key, val]);
   }

--- a/yarn-project/p2p/src/errors/attestation-pool.error.ts
+++ b/yarn-project/p2p/src/errors/attestation-pool.error.ts
@@ -1,0 +1,13 @@
+export class AttestationPoolError extends Error {
+  constructor(message?: string) {
+    super(message);
+    this.name = 'AttestationPoolError';
+  }
+}
+
+export class ProposalSlotCapExceededError extends AttestationPoolError {
+  constructor(message?: string) {
+    super(message);
+    this.name = 'ProposalSlotCapExceededError';
+  }
+}

--- a/yarn-project/p2p/src/mem_pools/attestation_pool/attestation_pool.ts
+++ b/yarn-project/p2p/src/mem_pools/attestation_pool/attestation_pool.ts
@@ -101,6 +101,29 @@ export interface AttestationPool {
    */
   hasAttestation(attestation: BlockAttestation): Promise<boolean>;
 
+  /**
+   * Returns whether adding this proposal is permitted at current capacity:
+   * - True if the proposal already exists, allow overwrite to keep parity with tests.
+   * - True if the slot is below the proposal cap.
+   * - False if the slot is at/above cap and this would be a new unique proposal.
+   *
+   * @param block - The block proposal to check
+   * @returns True if the proposal can be added (or already exists), false otherwise.
+   */
+  canAddProposal(block: BlockProposal): Promise<boolean>;
+
+  /**
+   * Returns whether an attestation would be accepted for (slot, proposalId):
+   * - True if the attestation already exists for this sender.
+   * - True if the attestation cap for (slot, proposalId) has not been reached.
+   * - False if the cap is reached and this attestation would be a new unique entry.
+   *
+   * @param attestation - The attestation to check
+   * @param committeeSize - Committee size for the attestation's slot, implementation may add a small buffer
+   * @returns True if the attestation can be added, false otherwise.
+   */
+  canAddAttestation(attestation: BlockAttestation, committeeSize: number): Promise<boolean>;
+
   /** Returns whether the pool is empty. */
   isEmpty(): Promise<boolean>;
 }

--- a/yarn-project/p2p/src/mem_pools/attestation_pool/kv_attestation_pool.test.ts
+++ b/yarn-project/p2p/src/mem_pools/attestation_pool/kv_attestation_pool.test.ts
@@ -1,8 +1,13 @@
+import { Secp256k1Signer } from '@aztec/foundation/crypto';
+import { Fr } from '@aztec/foundation/fields';
 import type { AztecAsyncKVStore } from '@aztec/kv-store';
 import { openTmpStore } from '@aztec/kv-store/lmdb-v2';
+import { makeBlockProposal, makeL2BlockHeader } from '@aztec/stdlib/testing';
 
+import { ProposalSlotCapExceededError } from '../../errors/attestation-pool.error.js';
 import { describeAttestationPool } from './attestation_pool_test_suite.js';
-import { KvAttestationPool } from './kv_attestation_pool.js';
+import { ATTESTATION_CAP_BUFFER, KvAttestationPool, MAX_PROPOSALS_PER_SLOT } from './kv_attestation_pool.js';
+import { mockAttestation } from './mocks.js';
 
 describe('KV Attestation Pool', () => {
   let kvAttestationPool: KvAttestationPool;
@@ -16,4 +21,55 @@ describe('KV Attestation Pool', () => {
   afterEach(() => store.close());
 
   describeAttestationPool(() => kvAttestationPool);
+
+  describe('BlockProposal cap exceeded', () => {
+    it('should throw when adding more than capped unique proposals for the same slot; duplicates are idempotent', async () => {
+      const slotNumber = 100;
+      const header = makeL2BlockHeader(1, 2, slotNumber);
+
+      // Add 1 proposal and re-add it (duplicate) → should not count against cap and not throw
+      const p0 = makeBlockProposal({ header, archive: Fr.random() });
+      await kvAttestationPool.addBlockProposal(p0);
+      await kvAttestationPool.addBlockProposal(p0); // idempotent
+
+      // Add up to the cap: add (MAX_PROPOSALS_PER_SLOT - 1) more unique proposals
+      for (let i = 0; i < MAX_PROPOSALS_PER_SLOT - 1; i++) {
+        const p = makeBlockProposal({ header, archive: Fr.random() });
+        await kvAttestationPool.addBlockProposal(p);
+      }
+
+      // Adding one more unique proposal for same slot should throw (exceeds cap)
+      const overflow = makeBlockProposal({ header, archive: Fr.random() });
+      await expect(kvAttestationPool.addBlockProposal(overflow)).rejects.toBeInstanceOf(ProposalSlotCapExceededError);
+    });
+  });
+
+  describe('Attestation cap exceeded', () => {
+    it('should cap unique attestations per (slot, proposalId) at committeeSize + buffer', async () => {
+      const slotNumber = 100;
+      const archive = Fr.random();
+
+      // Committee size and buffer (buffer is enforced inside the pool; here we pass only committeeSize)
+      const committeeSize = 5;
+      const buffer = ATTESTATION_CAP_BUFFER;
+      const limit = committeeSize + buffer;
+
+      // Create 'limit' distinct attestations for the same (slot, proposalId)
+      const signers = Array.from({ length: limit }, () => Secp256k1Signer.random());
+      const attestations = signers.map(s => mockAttestation(s, slotNumber, archive));
+      await kvAttestationPool.addAttestations(attestations);
+
+      // We should now be at cap
+      expect(
+        await kvAttestationPool.hasReachedAttestationCap(BigInt(slotNumber), archive.toString(), committeeSize),
+      ).toBe(true);
+
+      // A new attestation from a new signer should not be accepted (per validation helper semantics)
+      const extra = mockAttestation(Secp256k1Signer.random(), slotNumber, archive);
+      expect(await kvAttestationPool.canAddAttestation(extra, committeeSize)).toBe(false);
+
+      // Re-adding an existing attestation should be allowed
+      expect(await kvAttestationPool.canAddAttestation(attestations[0], committeeSize)).toBe(true);
+    });
+  });
 });

--- a/yarn-project/p2p/src/testbench/p2p_client_testbench_worker.ts
+++ b/yarn-project/p2p/src/testbench/p2p_client_testbench_worker.ts
@@ -74,6 +74,8 @@ function mockAttestationPool(): AttestationPool {
     getBlockProposal: () => Promise.resolve(undefined),
     hasBlockProposal: () => Promise.resolve(false),
     hasAttestation: () => Promise.resolve(false),
+    canAddProposal: () => Promise.resolve(true),
+    canAddAttestation: () => Promise.resolve(true),
   };
 }
 


### PR DESCRIPTION
1. Enforce tx inclusion invariants in BlockProposalValidator:
- Reject proposals that embed txs not listed in txHashes
- Forbid embedded txs when txHashes is empty
2. Cap proposals and attestations per slot in KvAttestationPool:
- Add MAX_PROPOSALS_PER_SLOT = 5 and ATTESTATION_CAP_BUFFER = 10 constant
- On proposal add, check value count per key, throw if cap exceeds and log/penalize early
- On attestation add, check value count per key, reject attestation if
  cap exceeds and log
- Add respective test for proposal and attestation capping
3. Introduce getValueCountAsync for multimap:
- Add implementation for indexeddb, lmdb (legacy), and lmdbv2 using count
  entries

Note: 
We don't penalize or throw on attestation cap exceed, we can just drop. 