### PR TITLE
fix(aztec-nr): Avoid relying on unquoted integers changing types

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/macros/notes.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/notes.nr
@@ -147,6 +147,7 @@ comptime fn generate_note_properties(s: TypeDefinition) -> Quoted {
     let mut properties_list = &[];
     for i in 0..note_fields.len() {
         let (name, _, _) = note_fields[i];
+        let i = i as u8;
         properties_list = properties_list.push_back(
             quote { $name: aztec::note::note_getter_options::PropertySelector { index: $i, offset: 0, length: 32 } },
         );

--- a/noir-projects/aztec-nr/aztec/src/macros/storage.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/storage.nr
@@ -46,8 +46,9 @@ pub comptime fn storage(s: TypeDefinition) -> Quoted {
     for field in s.fields_as_written() {
         // FIXME: This doesn't handle field types with generics
         let (name, typ, _) = field;
+        let slot_field = slot as Field;
         let (storage_field_constructor, storage_size) =
-            generate_storage_field_constructor(typ, quote { $slot });
+            generate_storage_field_constructor(typ, quote { $slot_field });
         storage_vars_constructors =
             storage_vars_constructors.push_back(quote { $name: $storage_field_constructor });
         // We have `Storable` in a separate `.nr` file instead of defining it in the last quote of this function
@@ -57,7 +58,7 @@ pub comptime fn storage(s: TypeDefinition) -> Quoted {
             quote { pub $name: dep::aztec::state_vars::storage::Storable },
         );
         storage_layout_constructors = storage_layout_constructors.push_back(
-            quote { $name: dep::aztec::state_vars::storage::Storable { slot: $slot } },
+            quote { $name: dep::aztec::state_vars::storage::Storable { slot: $slot_field } },
         );
         //let with_context_generic = add_context_generic(typ, context_generic);
         //println(with_context_generic);


### PR DESCRIPTION
After https://github.com/noir-lang/noir/pull/10330, noir will start enforcing the types of unquoted integers remain the same type. Before, when you unquoted an integer such as `let n: u32 = 4;` e.g. in `quote { let x = $n; }` the unquoted `n` would be a polymorphic integer literal of any type. With the above PR, it unquotes instead to `let x = 4u32;` - the type is preserved. We consider it a bug to rely on the previous behavior, and there were 3 instances of it in aztec-nr so this is a patch for those cases.
