### PR TITLE
fix: internal gt assert

### DIFF
--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/gt.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/gt.cpp
@@ -1,5 +1,6 @@
 #include "barretenberg/vm2/simulation/gadgets/gt.hpp"
 
+#include "barretenberg/common/assert.hpp"
 #include "barretenberg/numeric/uint128/uint128.hpp"
 #include "barretenberg/numeric/uint256/uint256.hpp"
 #include "barretenberg/vm2/common/field.hpp"
@@ -35,8 +36,8 @@ bool GreaterThan::gt(const MemoryValue& a, const MemoryValue& b)
         return gt(a_ff, b_ff);
     }
     // It is a precondition that the memory value is <= 128 bits.
-    assert(get_tag_bits(a.get_tag()) <= get_tag_bits(ValueTag::U128));
-    assert(get_tag_bits(b.get_tag()) <= get_tag_bits(ValueTag::U128));
+    BB_ASSERT(a.get_tag() != MemoryTag::FF);
+    BB_ASSERT(b.get_tag() != MemoryTag::FF);
     return gt(static_cast<uint128_t>(a_ff), static_cast<uint128_t>(b_ff));
 }
 

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/range_check.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/range_check.cpp
@@ -1,13 +1,13 @@
 #include "barretenberg/vm2/simulation/gadgets/range_check.hpp"
+#include "barretenberg/common/assert.hpp"
 
-#include <cassert>
 #include <cstdint>
 
 namespace bb::avm2::simulation {
 
 void RangeCheck::assert_range(uint128_t value, uint8_t num_bits)
 {
-    assert(num_bits <= 128 && "Range checks aren't supported for bit-sizes > 128");
+    BB_ASSERT(num_bits <= 128 && "Range checks aren't supported for bit-sizes > 128");
 
     events.emit({ .value = value, .num_bits = num_bits });
 }


### PR DESCRIPTION
At some point we changed it so that `get_tag_bits(FF) = 0`, but that meant this assert was passing for all input. It's now more explicit.

Also moved some things to `BB_ASSERT`