### PR TITLE
chore: witness tampering utility for failure testing

### DIFF
--- a/barretenberg/cpp/src/barretenberg/ultra_honk/failure_test_utils.hpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/failure_test_utils.hpp
@@ -1,0 +1,143 @@
+// === AUDIT STATUS ===
+// internal:    { status: not started, auditors: [], date: YYYY-MM-DD }
+// external_1:  { status: not started, auditors: [], date: YYYY-MM-DD }
+// external_2:  { status: not started, auditors: [], date: YYYY-MM-DD }
+// =====================
+
+#pragma once
+
+#include "barretenberg/ultra_honk/prover_instance.hpp"
+#include <memory>
+#include <unordered_map>
+#include <utility>
+
+namespace bb {
+
+/**
+ * @brief Test utility for injecting witness faults to create failing proofs
+ *
+ * @details This class allows tests to construct circuits with "malicious" variables that have
+ * different witness values in passing vs failing proofs. This enables systematic testing of
+ * constraint violations, particularly useful for validating that invalid witnesses correctly
+ * fail verification.
+ *
+ * Example usage:
+ * @code
+ *   FaultInjector<UltraFlavor> injector;
+ *
+ *   // Build circuit with a malicious witness
+ *   size_t rom_id = injector.builder.create_ROM_array(10);
+ *   auto bad_witness = injector.add_malicious_variable(42, 666); // good=42, bad=666
+ *   injector.builder.set_ROM_element(rom_id, 0, bad_witness);
+ *
+ *   // Create both instances
+ *   auto [good, bad] = injector.create_instances();
+ *
+ *   // Good instance should verify
+ *   prove_and_verify(good, true);
+ *
+ *   // Bad instance should fail
+ *   prove_and_verify(bad, false);
+ * @endcode
+ *
+ * @tparam Flavor The proving system flavor (UltraFlavor, MegaFlavor, etc.)
+ */
+template <typename Flavor> class FaultInjector {
+  public:
+    using Builder = typename Flavor::CircuitBuilder;
+    using FF = typename Flavor::FF;
+    using ProverInstance = ProverInstance_<Flavor>;
+
+    /**
+     * @brief The circuit builder - use this to construct your circuit
+     * @details All circuit construction should be done via this builder. Variables marked as malicious
+     * via add_malicious_variable will have different values in the good vs bad instances.
+     */
+    Builder builder;
+
+  private:
+    // Maps variable index to the "bad" value it should have in the faulty proof
+    std::unordered_map<uint32_t, FF> fault_map;
+
+  public:
+    /**
+     * @brief Add a variable with different values for good vs faulty proofs
+     *
+     * @details The variable will have `good_val` in the passing proof and `bad_val` in the failing proof.
+     * This allows testing constraint violations by providing invalid witnesses.
+     *
+     * @note If this variable is later involved in copy constraints (assert_equal), the fault will
+     * propagate to all variables in the equivalence class since they share the same real_variable_index.
+     *
+     * @param good_val The value for the passing proof
+     * @param bad_val The value for the failing proof
+     * @return The variable index (use this like any other circuit variable)
+     */
+    uint32_t add_malicious_variable(const FF& good_val, const FF& bad_val)
+    {
+        uint32_t idx = builder.add_variable(good_val);
+        fault_map[idx] = bad_val;
+        return idx;
+    }
+
+    /**
+     * @brief Create both good and bad prover instances
+     *
+     * @details Creates two ProverInstances:
+     * 1. Good instance: Built from the original builder with all "good" witness values
+     * 2. Bad instance: Built from a copy of the builder with faults injected
+     *
+     * The builder is finalized during the first instance construction. The second instance
+     * reuses the finalized circuit structure but with modified witness values.
+     *
+     * @return A pair of {good_instance, bad_instance}
+     */
+    std::pair<std::shared_ptr<ProverInstance>, std::shared_ptr<ProverInstance>> create_instances()
+    {
+        // Create good instance from original builder (this finalizes the circuit)
+        auto good_instance = std::make_shared<ProverInstance>(builder);
+
+        // Copy the builder for the bad instance
+        Builder bad_builder = builder;
+
+        // Inject faults into the copied builder's variables
+        auto& vars = const_cast<std::vector<FF>&>(bad_builder.get_variables());
+        for (const auto& [var_idx, bad_val] : fault_map) {
+            // Resolve through real_variable_index to handle copy constraints correctly
+            uint32_t real_idx = bad_builder.real_variable_index[var_idx];
+            vars[real_idx] = bad_val;
+        }
+
+        // Create bad instance from the modified copy
+        // Note: finalization is skipped since builder.circuit_finalized is already true
+        auto bad_instance = std::make_shared<ProverInstance>(bad_builder);
+
+        return { good_instance, bad_instance };
+    }
+
+    /**
+     * @brief Create a builder with faults injected for CircuitChecker testing
+     *
+     * @details Creates a copy of the builder with faults injected. Use this with CircuitChecker::check()
+     * to get precise information about which relation fails and at which row.
+     *
+     * @return A builder with malicious witness values
+     */
+    Builder create_faulty_builder()
+    {
+        // Copy the builder
+        Builder bad_builder = builder;
+
+        // Inject faults into the copied builder's variables
+        auto& vars = const_cast<std::vector<FF>&>(bad_builder.get_variables());
+        for (const auto& [var_idx, bad_val] : fault_map) {
+            // Resolve through real_variable_index to handle copy constraints correctly
+            uint32_t real_idx = bad_builder.real_variable_index[var_idx];
+            vars[real_idx] = bad_val;
+        }
+
+        return bad_builder;
+    }
+};
+
+} // namespace bb

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/failure_test_utils.hpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/failure_test_utils.hpp
@@ -14,81 +14,47 @@
 namespace bb {
 
 /**
- * @brief Test utility for injecting witness faults to create failing proofs
+ * @brief Test utility for injecting malicious witness values to test failure modes
  *
  * @details This class allows tests to construct circuits with "malicious" variables that have
  * different witness values in passing vs failing proofs. This enables systematic testing of
  * constraint violations, particularly useful for validating that invalid witnesses correctly
  * fail verification.
- *
- * Example usage:
- * @code
- *   FaultInjector<UltraFlavor> injector;
- *
- *   // Build circuit with a malicious witness
- *   size_t rom_id = injector.builder.create_ROM_array(10);
- *   auto bad_witness = injector.add_malicious_variable(42, 666); // good=42, bad=666
- *   injector.builder.set_ROM_element(rom_id, 0, bad_witness);
- *
- *   // Create both instances
- *   auto [good, bad] = injector.create_instances();
- *
- *   // Good instance should verify
- *   prove_and_verify(good, true);
- *
- *   // Bad instance should fail
- *   prove_and_verify(bad, false);
- * @endcode
- *
- * @tparam Flavor The proving system flavor (UltraFlavor, MegaFlavor, etc.)
  */
-template <typename Flavor> class FaultInjector {
+template <typename Flavor> class MaliciousWitnessInjector {
   public:
     using Builder = typename Flavor::CircuitBuilder;
     using FF = typename Flavor::FF;
     using ProverInstance = ProverInstance_<Flavor>;
 
-    /**
-     * @brief The circuit builder - use this to construct your circuit
-     * @details All circuit construction should be done via this builder. Variables marked as malicious
-     * via add_malicious_variable will have different values in the good vs bad instances.
-     */
     Builder builder;
 
   private:
-    // Maps variable index to the "bad" value it should have in the faulty proof
-    std::unordered_map<uint32_t, FF> fault_map;
+    // Maps variable index to the "bad" value to be injected
+    std::unordered_map<uint32_t, FF> malicious_variable_map;
 
   public:
     /**
-     * @brief Add a variable with different values for good vs faulty proofs
+     * @brief Add a "good" variable to the builder and specify a malicious value to inject later
+     * @details Equivalent to using builder.add_variable(good_val). The malicious value is simply stored to be injected
+     * later.
      *
-     * @details The variable will have `good_val` in the passing proof and `bad_val` in the failing proof.
-     * This allows testing constraint violations by providing invalid witnesses.
-     *
-     * @note If this variable is later involved in copy constraints (assert_equal), the fault will
-     * propagate to all variables in the equivalence class since they share the same real_variable_index.
-     *
-     * @param good_val The value for the passing proof
-     * @param bad_val The value for the failing proof
-     * @return The variable index (use this like any other circuit variable)
+     * @param good_val The honest value
+     * @param bad_val The malicious value to be injected for failure testing
+     * @return The variable index (same value returned by builder.add_variable)
      */
     uint32_t add_malicious_variable(const FF& good_val, const FF& bad_val)
     {
         uint32_t idx = builder.add_variable(good_val);
-        fault_map[idx] = bad_val;
+        malicious_variable_map[idx] = bad_val;
         return idx;
     }
 
     /**
-     * @brief Create both good and bad prover instances
+     * @brief Create two prover instances, one based on the good witness values and one based on the malicious values
      *
-     * @details Creates two ProverInstances:
-     * 1. Good instance: Built from the original builder with all "good" witness values
-     * 2. Bad instance: Built from a copy of the builder with faults injected
-     *
-     * The builder is finalized during the first instance construction. The second instance
-     * reuses the finalized circuit structure but with modified witness values.
+     * @note The builder is finalized during the first instance construction. The second instance reuses the finalized
+     * circuit structure but with modified witness values.
      *
      * @return A pair of {good_instance, bad_instance}
      */
@@ -97,40 +63,26 @@ template <typename Flavor> class FaultInjector {
         // Create good instance from original builder (this finalizes the circuit)
         auto good_instance = std::make_shared<ProverInstance>(builder);
 
-        // Copy the builder for the bad instance
-        Builder bad_builder = builder;
-
-        // Inject faults into the copied builder's variables
-        auto& vars = const_cast<std::vector<FF>&>(bad_builder.get_variables());
-        for (const auto& [var_idx, bad_val] : fault_map) {
-            // Resolve through real_variable_index to handle copy constraints correctly
-            uint32_t real_idx = bad_builder.real_variable_index[var_idx];
-            vars[real_idx] = bad_val;
-        }
-
-        // Create bad instance from the modified copy
-        // Note: finalization is skipped since builder.circuit_finalized is already true
+        // Create bad instance
+        Builder bad_builder = create_builder_with_malicious_witnesses();
         auto bad_instance = std::make_shared<ProverInstance>(bad_builder);
 
         return { good_instance, bad_instance };
     }
 
     /**
-     * @brief Create a builder with faults injected for CircuitChecker testing
-     *
-     * @details Creates a copy of the builder with faults injected. Use this with CircuitChecker::check()
-     * to get precise information about which relation fails and at which row.
-     *
-     * @return A builder with malicious witness values
+     * @brief Create a copy of the builder with malicious values injected
+     * @details Malicious values are injected based on real_variable_index which means that the entire copy cycle will
+     * be updated implicitly.
      */
-    Builder create_faulty_builder()
+    Builder create_builder_with_malicious_witnesses()
     {
         // Copy the builder
         Builder bad_builder = builder;
 
         // Inject faults into the copied builder's variables
         auto& vars = const_cast<std::vector<FF>&>(bad_builder.get_variables());
-        for (const auto& [var_idx, bad_val] : fault_map) {
+        for (const auto& [var_idx, bad_val] : malicious_variable_map) {
             // Resolve through real_variable_index to handle copy constraints correctly
             uint32_t real_idx = bad_builder.real_variable_index[var_idx];
             vars[real_idx] = bad_val;

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/rom_ram.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/rom_ram.test.cpp
@@ -1,4 +1,6 @@
 
+#include "barretenberg/circuit_checker/circuit_checker.hpp"
+#include "failure_test_utils.hpp"
 #include "ultra_honk.test.hpp"
 
 using namespace bb;
@@ -402,4 +404,91 @@ TYPED_TEST(UltraHonkTests, RomFailureSingleReadAtPair)
 
     TestFixture::set_default_pairing_points_and_ipa_claim_and_proof(circuit_builder);
     TestFixture::prove_and_verify(circuit_builder, /*expected_result=*/false);
+}
+
+// Tests using the FaultInjector utility for witness-level fault injection
+TYPED_TEST(UltraHonkTests, RomMaliciousInitValue)
+{
+    using Flavor = TypeParam;
+    using FF = typename Flavor::FF;
+    FaultInjector<Flavor> injector;
+
+    // Create a simple ROM with one malicious initialization value
+    size_t rom_id = injector.builder.create_ROM_array(5);
+
+    // This witness has value 42 in good proof, 666 in bad proof
+    auto malicious_witness = injector.add_malicious_variable(FF(42), FF(666));
+
+    // Initialize ROM with the malicious witness
+    injector.builder.set_ROM_element(rom_id, 0, malicious_witness);
+
+    // Initialize remaining elements with valid values
+    for (size_t i = 1; i < 5; ++i) {
+        auto good_witness = injector.builder.add_variable(FF(i));
+        injector.builder.set_ROM_element(rom_id, i, good_witness);
+    }
+
+    // Read the malicious element to create constraints
+    auto index = injector.builder.put_constant_variable(0);
+    injector.builder.read_ROM_array(rom_id, index);
+
+    TestFixture::set_default_pairing_points_and_ipa_claim_and_proof(injector.builder);
+
+    // Test 1: CircuitChecker - identifies exact relation failure
+    EXPECT_TRUE(CircuitChecker::check(injector.builder)); // good builder passes
+    auto bad_builder = injector.create_faulty_builder();
+    EXPECT_FALSE(CircuitChecker::check(bad_builder)); // bad builder fails (will print "Failed Memory relation")
+
+    // Test 2: Full proof system - end-to-end verification
+    auto [good_instance, bad_instance] = injector.create_instances();
+    TestFixture::prove_and_verify(good_instance, /*expected_result=*/true);
+    TestFixture::prove_and_verify(bad_instance, /*expected_result=*/false);
+}
+
+// Test out-of-bounds RAM access
+// NOTE: This failure is caught by the tag/permutation check, not the Memory relation!
+// Out-of-bounds reads reference non-existent memory locations, which breaks the
+// generalized permutation argument that ensures consistency between wire values.
+TYPED_TEST(UltraHonkTests, RamOutOfBoundsRead)
+{
+    using Flavor = TypeParam;
+    using FF = typename Flavor::FF;
+    FaultInjector<Flavor> injector;
+
+    // Create a RAM array of size 5 (valid indices: 0-4)
+    const size_t ram_size = 5;
+    size_t ram_id = injector.builder.create_RAM_array(ram_size);
+
+    // Initialize all elements
+    for (size_t i = 0; i < ram_size; ++i) {
+        auto init_val = injector.builder.add_variable(FF(100 + i));
+        injector.builder.init_RAM_element(ram_id, i, init_val);
+    }
+
+    // Create a malicious index witness:
+    // - Good proof: reads from index 2 (valid, within bounds)
+    // - Bad proof: reads from index 99 (invalid, out of bounds!)
+    auto malicious_index = injector.add_malicious_variable(FF(2), FF(99));
+
+    // Attempt to read using the malicious index
+    // In good proof: reads from RAM[2] = 102 ✓
+    // In bad proof: tries to read from RAM[99] (doesn't exist!) ✗
+    auto read_result = injector.builder.read_RAM_array(ram_id, malicious_index);
+
+    // Use the read result in a constraint to ensure it's checked
+    auto expected = injector.builder.add_variable(FF(102)); // value at index 2
+    injector.builder.assert_equal(read_result, expected);
+
+    TestFixture::set_default_pairing_points_and_ipa_claim_and_proof(injector.builder);
+
+    // Test with CircuitChecker
+    // Expected error: "Failed tag check." (not Memory relation!)
+    EXPECT_TRUE(CircuitChecker::check(injector.builder)); // good: reads RAM[2] ✓
+    auto bad_builder = injector.create_faulty_builder();
+    EXPECT_FALSE(CircuitChecker::check(bad_builder)); // bad: reads RAM[99] ✗ → tag check fails
+
+    // Test with full proof system
+    auto [good_instance, bad_instance] = injector.create_instances();
+    TestFixture::prove_and_verify(good_instance, /*expected_result=*/true);
+    TestFixture::prove_and_verify(bad_instance, /*expected_result=*/false);
 }

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/rom_ram.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/rom_ram.test.cpp
@@ -406,12 +406,12 @@ TYPED_TEST(UltraHonkTests, RomFailureSingleReadAtPair)
     TestFixture::prove_and_verify(circuit_builder, /*expected_result=*/false);
 }
 
-// Tests using the FaultInjector utility for witness-level fault injection
+// Test malicious initialization value in ROM
 TYPED_TEST(UltraHonkTests, RomMaliciousInitValue)
 {
     using Flavor = TypeParam;
     using FF = typename Flavor::FF;
-    FaultInjector<Flavor> injector;
+    MaliciousWitnessInjector<Flavor> injector;
 
     // Create a simple ROM with one malicious initialization value
     size_t rom_id = injector.builder.create_ROM_array(5);
@@ -422,9 +422,9 @@ TYPED_TEST(UltraHonkTests, RomMaliciousInitValue)
     // Initialize ROM with the malicious witness
     injector.builder.set_ROM_element(rom_id, 0, malicious_witness);
 
-    // Initialize remaining elements with valid values
+    // Initialize remaining elements with arbitrary values
     for (size_t i = 1; i < 5; ++i) {
-        auto good_witness = injector.builder.add_variable(FF(i));
+        auto good_witness = injector.builder.add_variable(FF::random_element());
         injector.builder.set_ROM_element(rom_id, i, good_witness);
     }
 
@@ -434,45 +434,40 @@ TYPED_TEST(UltraHonkTests, RomMaliciousInitValue)
 
     TestFixture::set_default_pairing_points_and_ipa_claim_and_proof(injector.builder);
 
-    // Test 1: CircuitChecker - identifies exact relation failure
+    // Run CircuitChecker; expect failure in Memory relation for malicious witness
     EXPECT_TRUE(CircuitChecker::check(injector.builder)); // good builder passes
-    auto bad_builder = injector.create_faulty_builder();
+    auto bad_builder = injector.create_builder_with_malicious_witnesses();
     EXPECT_FALSE(CircuitChecker::check(bad_builder)); // bad builder fails (will print "Failed Memory relation")
 
-    // Test 2: Full proof system - end-to-end verification
+    // Run full protocol
     auto [good_instance, bad_instance] = injector.create_instances();
     TestFixture::prove_and_verify(good_instance, /*expected_result=*/true);
     TestFixture::prove_and_verify(bad_instance, /*expected_result=*/false);
 }
 
-// Test out-of-bounds RAM access
-// NOTE: This failure is caught by the tag/permutation check, not the Memory relation!
-// Out-of-bounds reads reference non-existent memory locations, which breaks the
-// generalized permutation argument that ensures consistency between wire values.
+// Test malicious witness "out-of-bounds" RAM access
 TYPED_TEST(UltraHonkTests, RamOutOfBoundsRead)
 {
     using Flavor = TypeParam;
     using FF = typename Flavor::FF;
-    FaultInjector<Flavor> injector;
+    MaliciousWitnessInjector<Flavor> injector;
 
-    // Create a RAM array of size 5 (valid indices: 0-4)
+    // Create a RAM array of size 5
     const size_t ram_size = 5;
     size_t ram_id = injector.builder.create_RAM_array(ram_size);
 
     // Initialize all elements
     for (size_t i = 0; i < ram_size; ++i) {
-        auto init_val = injector.builder.add_variable(FF(100 + i));
+        auto init_val = injector.builder.add_variable(FF::random_element());
         injector.builder.init_RAM_element(ram_id, i, init_val);
     }
 
-    // Create a malicious index witness:
-    // - Good proof: reads from index 2 (valid, within bounds)
-    // - Bad proof: reads from index 99 (invalid, out of bounds!)
-    auto malicious_index = injector.add_malicious_variable(FF(2), FF(99));
+    // Create a malicious/invalid index witness:
+    FF good_index = FF(2);
+    FF bad_index = FF(99);
+    auto malicious_index = injector.add_malicious_variable(good_index, bad_index);
 
-    // Attempt to read using the malicious index
-    // In good proof: reads from RAM[2] = 102 ✓
-    // In bad proof: tries to read from RAM[99] (doesn't exist!) ✗
+    // Create a read using the malicious index
     auto read_result = injector.builder.read_RAM_array(ram_id, malicious_index);
 
     // Use the read result in a constraint to ensure it's checked
@@ -481,13 +476,13 @@ TYPED_TEST(UltraHonkTests, RamOutOfBoundsRead)
 
     TestFixture::set_default_pairing_points_and_ipa_claim_and_proof(injector.builder);
 
-    // Test with CircuitChecker
-    // Expected error: "Failed tag check." (not Memory relation!)
-    EXPECT_TRUE(CircuitChecker::check(injector.builder)); // good: reads RAM[2] ✓
-    auto bad_builder = injector.create_faulty_builder();
-    EXPECT_FALSE(CircuitChecker::check(bad_builder)); // bad: reads RAM[99] ✗ → tag check fails
+    // Run CircuitChecker
+    // Expected error: "Failed tag check."
+    EXPECT_TRUE(CircuitChecker::check(injector.builder));
+    auto bad_builder = injector.create_builder_with_malicious_witnesses();
+    EXPECT_FALSE(CircuitChecker::check(bad_builder));
 
-    // Test with full proof system
+    // Run full protocol
     auto [good_instance, bad_instance] = injector.create_instances();
     TestFixture::prove_and_verify(good_instance, /*expected_result=*/true);
     TestFixture::prove_and_verify(bad_instance, /*expected_result=*/false);


### PR DESCRIPTION
Introduces simple `MaliciousWitnessInjector` class to standardize/streamline malicious witness injection for failure tests. Adds two failure tests for RAM/ROM as proof of concept.