### PR TITLE
fix: drop overly broad flake rule

### DIFF
--- a/.test_patterns.yml
+++ b/.test_patterns.yml
@@ -238,18 +238,8 @@ tests:
     owners:
       - *saleel
 
-  - regex: "run_compose_test react-[a-z]* box boxes"
-    error_regex: "toBeVisible" # http://ci.aztec-labs.com/b7b10b95167d5ed6
-    owners:
-      - *saleel
-
   - regex: "tests/browser.spec.ts"
     error_regex: "Error: locator\\.click: Test timeout of"
-    owners:
-      - *saleel
-
-  - regex: "run_compose_test vanilla-all-browsers box boxes" # http://ci.aztec-labs.com/49f9945bc00aeef9
-    error_regex: "create account and cast vote"
     owners:
       - *saleel
 

--- a/boxes/boxes/react/tests/browser.spec.ts
+++ b/boxes/boxes/react/tests/browser.spec.ts
@@ -7,8 +7,16 @@ test('test', async ({ page }) => {
     if (msg.type() === 'error') {
       console.error(text);
       // Fail immediately on JavaScript errors to avoid timeout
+
+      // Firefox-specific: Check if this is an "Error:" message that should fail the test
+      // We exclude "Error: Timed out" and MIME type errors in Firefox
+      // Note: It's unclear why Firefox shows MIME type errors for index.js in some cases
+      const isErrorThatShouldFail = text.includes("Error: ") &&
+        !text.includes("Error: Timed out ") &&
+        !text.includes('was blocked because of a disallowed MIME type');
+
       if (
-        (text.includes("Error: ") && !text.includes("Error: Timed out ")) ||
+        isErrorThatShouldFail ||
         text.includes('Uncaught') ||
         text.includes('TypeError') ||
         text.includes('ReferenceError') ||


### PR DESCRIPTION
Also drops an error rule that oddly was 'expected' on react firefox. hopefully if this really is an issue in the future it does not just cause a timeout