### PR TITLE
chore: Remove test pattern for blobs stack overflow

### DIFF
--- a/.test_patterns.yml
+++ b/.test_patterns.yml
@@ -99,10 +99,6 @@ tests:
     skip: true
     owners:
       - *charlie
-  - regex: "noir-protocol-circuits blob blob_batching::tests::"
-    error_regex: "core dumped"
-    owners:
-      - *tom
 
   # AD: hit this flake
   # 18:04:38 thread 'arb_program_freqs_in_expected_range' panicked at tooling/ast_fuzzer/tests/calibration.rs:75:5:


### PR DESCRIPTION
I've run this test ~30 times with the suspect commit reverted and it's never overflowed.