### PR TITLE
chore: makefile cpp prep

### DIFF
--- a/barretenberg/bootstrap.sh
+++ b/barretenberg/bootstrap.sh
@@ -4,7 +4,7 @@ source $(git rev-parse --show-toplevel)/ci3/source
 function bootstrap_all {
   # To run bb we need a crs.
   # Download ignition up front to ensure no race conditions at runtime.
-  [ -n "${SKIP_BB_CRS:-}" ] || ./scripts/download_bb_crs.sh
+  [ -n "${SKIP_BB_CRS:-}" ] || ./crs/bootstrap.sh
   ./bbup/bootstrap.sh $@
   ./cpp/bootstrap.sh $@
   ./ts/bootstrap.sh $@

--- a/barretenberg/cpp/CMakePresets.json
+++ b/barretenberg/cpp/CMakePresets.json
@@ -412,7 +412,8 @@
       "binaryDir": "build-wasm-threads",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Release",
-        "MULTITHREADING": "ON"
+        "MULTITHREADING": "ON",
+        "ENABLE_WASM_BENCH": "ON"
       }
     },
     {
@@ -648,13 +649,7 @@
       "configurePreset": "wasm",
       "inheritConfigureEnvironment": true,
       "jobs": 0,
-      "targets": [
-        "barretenberg.wasm",
-        "barretenberg.wasm.gz",
-        "barretenberg",
-        "wasi",
-        "env"
-      ]
+      "targets": ["barretenberg.wasm.gz"]
     },
     {
       "name": "wasm-threads-dbg",
@@ -668,7 +663,7 @@
       "configurePreset": "wasm-threads",
       "inheritConfigureEnvironment": true,
       "jobs": 0,
-      "targets": ["barretenberg.wasm", "barretenberg.wasm.gz"]
+      "targets": ["barretenberg.wasm.gz", "ecc_tests"]
     },
     {
       "name": "xray",

--- a/barretenberg/cpp/bootstrap.sh
+++ b/barretenberg/cpp/bootstrap.sh
@@ -8,13 +8,6 @@ else
 fi
 export hash=$(hash_str $(../../avm-transpiler/bootstrap.sh hash) $(cache_content_hash .rebuild_patterns))
 
-# Mix whether we're building multi-arch or single-arch into the hash
-if semver check "$REF_NAME"; then
-  export hash="$hash-multiarch"
-else
-  export hash="$hash-singlearch"
-fi
-
 # Injects version number into a given bb binary.
 # Means we don't actually need to rebuild bb to release a new version if code hasn't changed.
 function inject_version {
@@ -46,12 +39,20 @@ function build_preset() {
   if [ "${AVM_TRANSPILER:-1}" -eq 0 ]; then
     cmake_args+=(-DAVM_TRANSPILER_LIB=)
   fi
-  # Auto-enable ENABLE_WASM_BENCH for wasm-threads preset on non-semver builds
-  if [[ "$preset" == "wasm-threads" ]] && ! semver check "$REF_NAME"; then
-    cmake_args+=(-DENABLE_WASM_BENCH=ON)
-  fi
-  cmake --fresh --preset "$preset" "${cmake_args[@]}"
+  cmake --preset "$preset" "${cmake_args[@]}"
   cmake --build --preset "$preset" "$@"
+}
+
+# Builds as many targets as possible that don't have any external dependencies, e.g. on avm_transpiler.
+# Allow the build system to get a head start on compilation while building dependencies.
+# This is a noop if the final artifacts exist in the cache.
+function build_native_objects {
+  set -eu
+  if ! cache_exists barretenberg-$native_preset-$hash.zst; then
+    cmake --preset "$native_preset"
+    targets=$(cmake --build --preset "$native_preset" --target help | awk -F: '$1 ~ /(_objects|_tests|_bench|_gen|.a)$/ && $1 !~ /^cmake_/{print $1}' | tr '\n' ' ')
+    cmake --build --preset "$native_preset" --target $targets nodejs_module
+  fi
 }
 
 # Build all native binaries, including bb, bb-avm, tests, benches and napi lib.
@@ -61,6 +62,18 @@ function build_native {
     ./format.sh check
     build_preset $native_preset
     cache_upload barretenberg-$native_preset-$hash.zst build/{bin,lib}
+  fi
+}
+
+# Builds as many targets as possible that don't have any external dependencies, e.g. on avm_transpiler.
+# Allow the build system to get a head start on compilation while building dependencies.
+# For cross compilation we're only building bb and napi module.
+# This is a noop if the final artifacts exist in the cache.
+function build_cross_objects {
+  set -eu
+  target=$1
+  if ! cache_exists barretenberg-$target-$hash.zst; then
+    build_preset zig-$target --target barretenberg nodejs_module vm2_stub circuit_checker honk
   fi
 }
 
@@ -100,8 +113,16 @@ function build_wasm {
 function build_wasm_threads {
   set -eu
   if ! cache_download barretenberg-wasm-threads-$hash.zst; then
-    build_preset wasm-threads --target barretenberg.wasm barretenberg.wasm.gz ecc_tests
+    build_preset wasm-threads
     cache_upload barretenberg-wasm-threads-$hash.zst build-wasm-threads/bin
+  fi
+}
+
+function build_wasm_threads_benches {
+  set -eu
+  if ! cache_download barretenberg-wasm-threads-benches-$hash.zst; then
+    build_preset wasm-threads --target ultra_honk_bench chonk_bench bb
+    cache_upload barretenberg-wasm-threads-benches-$hash.zst build-wasm-threads/bin/{ultra_honk_bench,chonk_bench,bb}
   fi
 }
 
@@ -194,7 +215,7 @@ function build_release_dir {
   tar -czf build-release/barretenberg-amd64-darwin.tar.gz -C build-release --remove-files bb
 }
 
-export -f build_preset build_native build_cross build_asan_fast build_wasm build_wasm_threads build_gcc_syntax_check_only build_fuzzing_syntax_check_only build_smt_verification
+export -f build_preset build_native_objects build_cross_objects build_native build_cross build_asan_fast build_wasm build_wasm_threads build_gcc_syntax_check_only build_fuzzing_syntax_check_only build_smt_verification
 
 function build {
   echo_header "bb cpp build"
@@ -232,12 +253,22 @@ function build {
   fi
 }
 
+function build_with_makefile {
+  if [ "$CI_FULL" -eq 1 ]; then
+    # Deletes all build dirs and build bb and wasms from scratch.
+    rm -rf build*
+  fi
+
+  (cd $root && make bb-cpp)
+}
+
 # Print every individual test command. Can be fed into gnu parallel.
 # Paths are relative to repo root.
 # We prefix the hash. This ensures the test harness and cache and skip future runs.
 function test_cmds {
   # E.g. build, build-debug or build-coverage
   cd $(scripts/native-preset-build-dir)
+
   for bin in ./bin/*_tests; do
     local bin_name=$(basename $bin)
 
@@ -318,13 +349,8 @@ function bench {
 
 # Upload assets to release.
 function release {
-  # ARM64 doesn't contribute to the build at all anymore.
-  if semver check "$REF_NAME" && [[ "$(arch)" == "amd64" ]]; then
-    echo_header "bb cpp release"
-    do_or_dryrun gh release upload $REF_NAME build-release/* --clobber
-  else
-    echo "bb/cpp/bootstraps.sh release - WARNING: Doing nothing. we only build on amd64, and if tagged as a release."
-  fi
+  echo_header "bb cpp release"
+  do_or_dryrun gh release upload $REF_NAME build-release/* --clobber
 }
 
 function bench_ivc {

--- a/barretenberg/cpp/cmake/avm-transpiler.cmake
+++ b/barretenberg/cpp/cmake/avm-transpiler.cmake
@@ -8,11 +8,6 @@ endif()
 set(AVM_TRANSPILER_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../avm-transpiler")
 set(AVM_TRANSPILER_INCLUDE "${AVM_TRANSPILER_DIR}")
 
-# Check if the library exists
-if(NOT EXISTS ${AVM_TRANSPILER_LIB})
-    message(FATAL_ERROR "avm-transpiler library not found at ${AVM_TRANSPILER_LIB}\nPlease run './bootstrap.sh' in ${AVM_TRANSPILER_DIR} to build libraries")
-endif()
-
 # Create imported library target
 add_library(avm_transpiler STATIC IMPORTED)
 set_target_properties(avm_transpiler PROPERTIES

--- a/barretenberg/cpp/cmake/module.cmake
+++ b/barretenberg/cpp/cmake/module.cmake
@@ -295,11 +295,6 @@ function(barretenberg_module_with_sources MODULE_NAME)
                 add_dependencies(${BENCHMARK_NAME}_bench_objects lmdb_repo)
                 add_dependencies(${BENCHMARK_NAME}_bench lmdb_repo)
             endif()
-            add_custom_target(
-                run_${BENCHMARK_NAME}_bench
-                COMMAND ${BENCHMARK_NAME}_bench
-                WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-            )
         endforeach()
     endif()
 

--- a/barretenberg/crs/bootstrap.sh
+++ b/barretenberg/crs/bootstrap.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+source $(git rev-parse --show-toplevel)/ci3/source_bootstrap
+
+# To run bb we need a crs.
+# Download ignition up front to ensure no race conditions at runtime.
+# 2^25 points + 1 because the first is the generator, *64 bytes per point, -1 because Range is inclusive.
+# We make the file read only to ensure no test can attempt to grow it any larger. 2^25 is already huge...
+# TODO: Make bb just download and append/overwrite required range, then it becomes idempotent.
+function build {
+  crs_path=$HOME/.bb-crs
+  crs_size=$((2**25+1))
+  crs_size_bytes=$((crs_size*64))
+  g1=$crs_path/bn254_g1.dat
+  g2=$crs_path/bn254_g2.dat
+  if [ ! -f "$g1" ] || [ $(stat -c%s "$g1") -lt $crs_size_bytes ]; then
+    echo "Downloading crs of size: ${crs_size} ($((crs_size_bytes/(1024*1024)))MB)"
+    mkdir -p $crs_path
+    curl -s -H "Range: bytes=0-$((crs_size_bytes-1))" -o $g1 \
+      https://crs.aztec.network/g1.dat
+    chmod a-w $crs_path/bn254_g1.dat
+  fi
+  if [ ! -f "$g2" ]; then
+    curl -s https://crs.aztec.network/g2.dat -o $g2
+  fi
+
+  # TODO: This grumpkin CRS in S3 still has the 28 byte header on it. Remove.
+  # And if we ever need more than transcript00.dat, concatenate to single file like we did with bn254 above.
+  crs_size=$((2**18))
+  crs_size_bytes=$((crs_size*64))
+  gg1=$crs_path/grumpkin_g1.flat.dat
+  if [ ! -f "$gg1" ] || [ $(stat -c%s "$gg1") -lt $crs_size_bytes ]; then
+    echo "Downloading grumpkin crs of size: ${crs_size} ($((crs_size_bytes/(1024*1024)))MB)"
+    curl -s -H "Range: bytes=0-$((crs_size_bytes-1))" -o $gg1 \
+      https://crs.aztec.network/grumpkin_g1.dat
+  fi
+}
+
+case "$cmd" in
+  "")
+    build
+    ;;
+  *)
+    default_cmd_handler "$@"
+    ;;
+esac

--- a/barretenberg/docs/.prettierrc.json
+++ b/barretenberg/docs/.prettierrc.json
@@ -1,0 +1,6 @@
+{
+  "singleQuote": true,
+  "trailingComma": "all",
+  "printWidth": 120,
+  "arrowParens": "avoid"
+}

--- a/barretenberg/docs/examples/recursive.test.ts
+++ b/barretenberg/docs/examples/recursive.test.ts
@@ -13,7 +13,7 @@ describe('Recursive Aggregation Example', () => {
   let recursiveNoir: Noir;
   let recursiveInputs: any;
 
-  before(async function() {
+  before(async function () {
     this.timeout(120000);
 
     // docs:start:setup
@@ -34,28 +34,20 @@ describe('Recursive Aggregation Example', () => {
 
     // docs:start:backend_setup
     // Setup backend for main circuit (inner circuit)
-    mainBackend = new UltraHonkBackend(
-      mainBytecode,
-      { threads: 8 },
-      { recursive: true }
-    );
+    mainBackend = new UltraHonkBackend(mainBytecode, { threads: 8 }, { recursive: true });
 
     // Setup backend for recursive circuit (outer circuit)
-    recursiveBackend = new UltraHonkBackend(
-      recursiveBytecode,
-      { threads: 8 },
-      { recursive: false }
-    );
+    recursiveBackend = new UltraHonkBackend(recursiveBytecode, { threads: 8 }, { recursive: false });
     // docs:end:backend_setup
   });
 
-  after(async function() {
+  after(async function () {
     // Clean up resources
     if (mainBackend) await mainBackend.destroy();
     if (recursiveBackend) await recursiveBackend.destroy();
   });
 
-  it('should execute witness generation for both circuits', async function() {
+  it('should execute witness generation for both circuits', async function () {
     this.timeout(60000);
 
     // docs:start:witness_generation
@@ -71,7 +63,7 @@ describe('Recursive Aggregation Example', () => {
     expect(mainWitness.length).to.be.greaterThan(0);
   });
 
-  it('should generate proof and verification key for main circuit', async function() {
+  it('should generate proof and verification key for main circuit', async function () {
     this.timeout(120000);
 
     // Generate witness for main circuit
@@ -79,10 +71,14 @@ describe('Recursive Aggregation Example', () => {
 
     // docs:start:proof_generation
     // Generate proof for main circuit with keccakZK for recursive verification
-    const mainProofData = await mainBackend.generateProof(mainWitness, { keccakZK: true });
+    const mainProofData = await mainBackend.generateProof(mainWitness, {
+      keccakZK: true,
+    });
 
     // Generate verification key for main circuit
-    const mainVerificationKey = await mainBackend.getVerificationKey({ keccakZK: true });
+    const mainVerificationKey = await mainBackend.getVerificationKey({
+      keccakZK: true,
+    });
     // docs:end:proof_generation
 
     // Test that proof and VK were generated
@@ -92,8 +88,7 @@ describe('Recursive Aggregation Example', () => {
     expect(mainVerificationKey.length).to.be.greaterThan(0);
   });
 
-
-  it('should prepare recursive inputs from proof and verification key', async function() {
+  it('should prepare recursive inputs from proof and verification key', async function () {
     this.timeout(120000);
 
     // Generate witness and proof for main circuit
@@ -104,13 +99,14 @@ describe('Recursive Aggregation Example', () => {
     // docs:start:recursive_inputs
     // Convert proof and VK to fields for recursive circuit
     const barretenbergAPI = await Barretenberg.new({ threads: 1 });
-    const vkAsFields = (await barretenbergAPI.acirVkAsFieldsUltraHonk(new RawBuffer(mainVerificationKey)))
-      .map(field => field.toString());
+    const vkAsFields = (await barretenbergAPI.acirVkAsFieldsUltraHonk(new RawBuffer(mainVerificationKey))).map(field =>
+      field.toString(),
+    );
 
     recursiveInputs = {
       proof: deflattenFields(mainProofData.proof),
       public_inputs: [2],
-      verification_key: vkAsFields
+      verification_key: vkAsFields,
     };
 
     await barretenbergAPI.destroy();
@@ -124,8 +120,8 @@ describe('Recursive Aggregation Example', () => {
     expect(recursiveInputs.public_inputs).to.deep.equal([2]);
   });
 
-  it('should generate recursive proof', async function() {
-    this.timeout(180000);
+  it('should generate recursive proof', async function () {
+    this.timeout(300000);
 
     // docs:start:recursive_proof
     // Generate witness for recursive circuit

--- a/barretenberg/sol/foundry.lock
+++ b/barretenberg/sol/foundry.lock
@@ -11,6 +11,9 @@
   "../../l1-contracts/lib/openzeppelin-contracts": {
     "rev": "448efeea6640bbbc09373f03fbc9c88e280147ba"
   },
+  "../../noir/noir-repo": {
+    "rev": "1fce7cac1b6b116b6af98875580b5122eb9fe051"
+  },
   "lib/forge-std": {
     "rev": "74cfb77e308dd188d2f58864aaf44963ae6b88b1"
   },

--- a/barretenberg/ts/bootstrap.sh
+++ b/barretenberg/ts/bootstrap.sh
@@ -52,7 +52,12 @@ function test {
 }
 
 function release {
+  cross_copy
   retry "deploy_npm $(dist_tag) ${REF_NAME#v}"
+}
+
+function cross_copy {
+  ./scripts/copy_cross.sh
 }
 
 case "$cmd" in

--- a/barretenberg/ts/scripts/copy_cross.sh
+++ b/barretenberg/ts/scripts/copy_cross.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Copies native bb binary and napi module to dest.
+set -e
+NO_CD=1 source $(git rev-parse --show-toplevel)/ci3/source
+
+cd $(dirname $0)/..
+
+if semver check "${REF_NAME:-}" && [[ "$(arch)" == "amd64" ]]; then
+  # We're building a release.
+  # We take host build for amd64-linux.
+  mkdir -p ./build/amd64-linux
+  cp ../cpp/build/bin/bb ./build/amd64-linux
+  cp ../cpp/build/lib/nodejs_module.node ./build/amd64-linux
+
+  # We also copy in all cross-compiled architectures for release builds.
+  for arch in arm64-linux amd64-macos arm64-macos; do
+    mkdir -p ./build/$arch
+    cp ../cpp/build-zig-$arch/bin/bb ./build/$arch
+    cp ../cpp/build-zig-$arch/lib/nodejs_module.node ./build/$arch
+  done
+
+  llvm-strip-20 ./build/*/*
+else
+  echo "This task is expected to be run in an x86 release context."
+  exit 1
+fi

--- a/barretenberg/ts/scripts/copy_native.sh
+++ b/barretenberg/ts/scripts/copy_native.sh
@@ -5,32 +5,14 @@ NO_CD=1 source $(git rev-parse --show-toplevel)/ci3/source
 
 cd $(dirname $0)/..
 
-if semver check "${REF_NAME:-}" && [[ "$(arch)" == "amd64" ]]; then
-  # We're building a release.
-  # We take host build for amd64-linux.
-  mkdir -p ./build/amd64-linux
-  cp ../cpp/build/bin/bb ./build/amd64-linux
-  cp ../cpp/build/lib/nodejs_module.node ./build/amd64-linux
+# Construct target suffix e.g. amd64-linux
+target="$(arch)-$(os)"
 
-  # We also copy in all cross-compiled architectures for release builds.
-  for arch in arm64-linux amd64-macos arm64-macos; do
-    mkdir -p ./build/$arch
-    cp ../cpp/build-zig-$arch/bin/bb ./build/$arch
-    cp ../cpp/build-zig-$arch/lib/nodejs_module.node ./build/$arch
-  done
-
-  llvm-strip-20 ./build/*/*
-else
-  # We're a regular bootstrap. Just copy in our host architecture as others may not be built.
-  # Construct target suffix e.g. amd64-linux
-  target="$(arch)-$(os)"
-
-  if [ "${BUILD_CPP:-0}" -eq 1 ]; then
-    ../cpp/bootstrap.sh build_preset clang20 --target bb --target nodejs_module
-  fi
-
-  mkdir -p ./build/$target
-
-  cp ../cpp/build/bin/bb ./build/$target
-  cp ../cpp/build/lib/nodejs_module.node ./build/$target
+if [ "${BUILD_CPP:-0}" -eq 1 ]; then
+  ../cpp/bootstrap.sh build_preset clang20 --target bb --target nodejs_module
 fi
+
+mkdir -p ./build/$target
+
+cp ../cpp/build/bin/bb ./build/$target
+cp ../cpp/build/lib/nodejs_module.node ./build/$target

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -379,13 +379,10 @@ function release {
     boxes
     aztec-up
     playground
-    # docs # released as part of ci
     release-image
   )
   if [ $(arch) == arm64 ]; then
-    echo "Only releasing packages with platform-specific binaries on arm64."
     projects=(
-      barretenberg/cpp
       release-image
     )
   fi

--- a/ci3/aws/ami_update.sh
+++ b/ci3/aws/ami_update.sh
@@ -49,7 +49,7 @@ ssh $ssh_args -F build_instance_ssh_config ubuntu@$ip '
 '
 
 # Download crs onto machine.
-ssh $ssh_args -F build_instance_ssh_config ubuntu@$ip < ../../barretenberg/scripts/download_bb_crs.sh
+ssh $ssh_args -F build_instance_ssh_config ubuntu@$ip < ../../barretenberg/crs/bootstrap.sh
 
 # Pull devbox onto host, and build into docker-in-docker volume.
 ssh $ssh_args -F build_instance_ssh_config ubuntu@$ip "

--- a/container-builds/fuzzing-container/src/Dockerfile
+++ b/container-builds/fuzzing-container/src/Dockerfile
@@ -33,7 +33,7 @@ RUN git clone https://github.com/AztecProtocol/aztec-packages.git && \
 
 # Download crs
 WORKDIR /home/fuzzer/aztec-packages/barretenberg
-RUN ./scripts/download_bb_crs.sh
+RUN ./crs/bootstrap.sh
 
 WORKDIR /home/fuzzer/aztec-packages/barretenberg/cpp
 

--- a/l1-contracts/foundry.lock
+++ b/l1-contracts/foundry.lock
@@ -11,6 +11,9 @@
   "../bb-pilcom/powdr": {
     "rev": "c3006c11819d9b53fb183c9c12a10b83481bb631"
   },
+  "../noir/noir-repo": {
+    "rev": "1fce7cac1b6b116b6af98875580b5122eb9fe051"
+  },
   "lib/circuits": {
     "rev": "e47bcd526f5e38f9603d07d0791984ec53efd254"
   },


### PR DESCRIPTION
Prep bb for building with makefile.
* Adds a few command functions to bb/cpp to enable more granular build targets.
* Make the CRS install a bit more like our other projects do (so makefile doesnt need special case).
* Enables WASM benching in wasm-threads. This simplifies the build but does mean we pay the cost. We should monitor if this is an issue. If the impact is too high, ideally we'd optimise the instrumentation rather than complicate the devops.
* We don't error out if transpiler lib isn't available as we maybe doing a "pre-link build".
* Add prettier.rc in `barretenberg/docs`.
* Split the copy scripts for bb.js into distinct "native" and "cross" for future build granularity.