### PR TITLE
fix(sync): Do not crash on snapshot download error

### DIFF
--- a/yarn-project/bb-prover/src/verifier/bb_verifier.ts
+++ b/yarn-project/bb-prover/src/verifier/bb_verifier.ts
@@ -40,6 +40,9 @@ export class BBCircuitVerifier implements ClientProtocolCircuitVerifier {
   }
 
   public static async new(config: BBConfig, logger = createLogger('bb-prover:verifier')) {
+    if (!config.bbWorkingDirectory) {
+      throw new Error(`Barretenberg working directory (BB_WORKING_DIRECTORY) is not set`);
+    }
     await fs.mkdir(config.bbWorkingDirectory, { recursive: true });
     return new BBCircuitVerifier(config, logger);
   }

--- a/yarn-project/node-lib/src/actions/snapshot-sync.ts
+++ b/yarn-project/node-lib/src/actions/snapshot-sync.ts
@@ -163,7 +163,7 @@ export async function trySnapshotSync(config: SnapshotSyncConfig, log: Logger) {
   }
 
   if (snapshotCandidates.length === 0) {
-    log.verbose(`No valid snapshots found from any URL. Skipping snapshot sync.`, { ...indexMetadata, snapshotsUrls });
+    log.verbose(`No valid snapshots found from any URL, skipping snapshot sync`, { ...indexMetadata, snapshotsUrls });
     return false;
   }
 
@@ -190,7 +190,7 @@ export async function trySnapshotSync(config: SnapshotSyncConfig, log: Logger) {
       });
       return true;
     } catch (err) {
-      log.error(`Failed to download snapshot from ${url}. Trying next candidate.`, err, {
+      log.error(`Failed to download snapshot from ${url}, trying next candidate`, err, {
         snapshot,
         snapshotsUrl: url,
       });
@@ -198,7 +198,7 @@ export async function trySnapshotSync(config: SnapshotSyncConfig, log: Logger) {
     }
   }
 
-  log.error(`Failed to download snapshot from all URLs.`, { snapshotsUrls });
+  log.error(`Failed to download snapshot from all URLs`, { snapshotsUrls });
   return false;
 }
 


### PR DESCRIPTION
Fixes issue where the node would just crash when there was a stream error downloading a snapshot archive. This was caused by `.pipe` not properly managing exceptions, `stream.pipeline` is the preferred method instead.

We now log the error and correctly move to the next snapshot location:
```
[18:53:45.761] ERROR: node Failed to download snapshot from https://files5.blacknodes.net/Aztec/, trying next candidate: Error: Error fetching file from https://files5.blacknodes.net/Aztec/aztec-11155111-845231713-0xebd99ff0ff6677205509ae73f93d0ca52ac85d67/archiver-20251110190001-0x1a5fcd7038f3e7a4b48b90c42a4d2158c9ecddb7a5da10dc617b4a57f8a8551a.db
    at HttpFileStore.download (file:///home/santiago/Projects/aztec-4/yarn-project/stdlib/dest/file-store/http.js:44:19)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async file:///home/santiago/Projects/aztec-4/yarn-project/stdlib/dest/snapshots/download.js:79:13
    at async Promise.all (index 0)
    at async downloadSnapshot (file:///home/santiago/Projects/aztec-4/yarn-project/stdlib/dest/snapshots/download.js:74:5)
    at async snapshotSync (file:///home/santiago/Projects/aztec-4/yarn-project/node-lib/dest/actions/snapshot-sync.js:158:9)
    at async trySnapshotSync (file:///home/santiago/Projects/aztec-4/yarn-project/node-lib/dest/actions/snapshot-sync.js:120:13)
    at async AztecNodeService.createAndSync (file:///home/santiago/Projects/aztec-4/yarn-project/aztec-node/dest/aztec-node/server.js:176:13)
    at async createAztecNode (file:///home/santiago/Projects/aztec-4/yarn-project/aztec/dest/sandbox/sandbox.js:159:18)
    at async startNode (file:///home/santiago/Projects/aztec-4/yarn-project/aztec/dest/cli/cmds/start_node.js:78:18) {
  [cause]: Error: aborted
      at TLSSocket.socketCloseListener (node:_http_client:478:19)
      at TLSSocket.emit (node:events:530:35)
      at node:net:351:12
      at TCP.done (node:_tls_wrap:650:7) {
    code: 'ECONNRESET'
  }
} {"snapshot":{"l2BlockNumber":5147,"l2BlockHash":"0x1a5fcd7038f3e7a4b48b90c42a4d2158c9ecddb7a5da10dc617b4a57f8a8551a","l1BlockNumber":9601672,"timestamp":1762801201751,"schemaVersions":{"archiver":3,"worldState":2},"dataUrls":{"l1-to-l2-message-tree":"https://files5.blacknodes.net/Aztec/aztec-11155111-845231713-0xebd99ff0ff6677205509ae73f93d0ca52ac85d67/l1-to-l2-message-tree-20251110190001-0x1a5fcd7038f3e7a4b48b90c42a4d2158c9ecddb7a5da10dc617b4a57f8a8551a.db","archive-tree":"https://files5.blacknodes.net/Aztec/aztec-11155111-845231713-0xebd99ff0ff6677205509ae73f93d0ca52ac85d67/archive-tree-20251110190001-0x1a5fcd7038f3e7a4b48b90c42a4d2158c9ecddb7a5da10dc617b4a57f8a8551a.db","public-data-tree":"https://files5.blacknodes.net/Aztec/aztec-11155111-845231713-0xebd99ff0ff6677205509ae73f93d0ca52ac85d67/public-data-tree-20251110190001-0x1a5fcd7038f3e7a4b48b90c42a4d2158c9ecddb7a5da10dc617b4a57f8a8551a.db","note-hash-tree":"https://files5.blacknodes.net/Aztec/aztec-11155111-845231713-0xebd99ff0ff6677205509ae73f93d0ca52ac85d67/note-hash-tree-20251110190001-0x1a5fcd7038f3e7a4b48b90c42a4d2158c9ecddb7a5da10dc617b4a57f8a8551a.db","nullifier-tree":"https://files5.blacknodes.net/Aztec/aztec-11155111-845231713-0xebd99ff0ff6677205509ae73f93d0ca52ac85d67/nullifier-tree-20251110190001-0x1a5fcd7038f3e7a4b48b90c42a4d2158c9ecddb7a5da10dc617b4a57f8a8551a.db","archiver":"https://files5.blacknodes.net/Aztec/aztec-11155111-845231713-0xebd99ff0ff6677205509ae73f93d0ca52ac85d67/archiver-20251110190001-0x1a5fcd7038f3e7a4b48b90c42a4d2158c9ecddb7a5da10dc617b4a57f8a8551a.db"}},"snapshotsUrl":"https://files5.blacknodes.net/Aztec/"}
```