### PR TITLE
feat: valkeys staker --from keystore

### DIFF
--- a/yarn-project/cli/src/cmds/validator_keys/index.ts
+++ b/yarn-project/cli/src/cmds/validator_keys/index.ts
@@ -76,6 +76,21 @@ export function injectCommands(program: Command, log: LogFn) {
       await addValidatorKeys(existing, options, log);
     });
 
+  group
+    .command('staker')
+    .description('Print registration tuples for staking deposit')
+    .requiredOption('--from <keystore>', 'Path to keystore file')
+    .option('--password <string>', 'Password for encrypted keystore')
+    .requiredOption('--gse-address <address>', 'GSE contract address', parseEthereumAddress)
+    .option('--l1-rpc-urls <urls>', 'L1 RPC URLs (comma-separated)', value => value.split(','), [
+      'http://localhost:8545',
+    ])
+    .option('-c, --l1-chain-id <number>', 'L1 chain ID', value => parseInt(value), 31337)
+    .action(async options => {
+      const { stakerCommand } = await import('./staker.js');
+      await stakerCommand(options, log);
+    });
+
   // top-level convenience: aztec generate-bls-keypair
   program
     .command('generate-bls-keypair')

--- a/yarn-project/cli/src/cmds/validator_keys/staker.ts
+++ b/yarn-project/cli/src/cmds/validator_keys/staker.ts
@@ -1,0 +1,204 @@
+import { Fr } from '@aztec/aztec.js/fields';
+import { GSEContract, createEthereumChain } from '@aztec/ethereum';
+import { decryptBn254KeystoreFromObject, loadBn254Keystore } from '@aztec/foundation/crypto/bls/bn254_keystore';
+import type { EthAddress } from '@aztec/foundation/eth-address';
+import type { LogFn } from '@aztec/foundation/log';
+import { loadKeystoreFile } from '@aztec/node-keystore/loader';
+import type { BLSAccount, KeyStore, ValidatorKeyStore } from '@aztec/node-keystore/types';
+
+import { readFileSync } from 'fs';
+import { createPublicClient, fallback, http } from 'viem';
+
+export type StakerOptions = {
+  from: string;
+  password?: string;
+  gseAddress: EthAddress;
+  l1RpcUrls: string[];
+  chainId: number;
+};
+
+type RegistrationData = {
+  attester?: string;
+  publicKeyInG1: {
+    x: string;
+    y: string;
+  };
+  publicKeyInG2: {
+    x0: string;
+    x1: string;
+    y0: string;
+    y1: string;
+  };
+  proofOfPossession: {
+    x: string;
+    y: string;
+  };
+};
+
+type ValidatorEntry = {
+  blsPrivateKey: string;
+  attesterAddress?: string;
+};
+
+/**
+ * Extracts BLS private key from various account formats
+ */
+function extractBlsPrivateKey(blsAccount: BLSAccount, providedPassword?: string): string | undefined {
+  // Direct private key string
+  if (typeof blsAccount === 'string' && blsAccount.startsWith('0x')) {
+    return blsAccount;
+  }
+
+  // Encrypted keystore reference
+  if (typeof blsAccount === 'object' && 'path' in blsAccount) {
+    const keystorePath = blsAccount.path;
+    const password = blsAccount.password ?? providedPassword ?? '';
+
+    try {
+      // Try loading as BN254 keystore
+      const keystore = loadBn254Keystore(keystorePath);
+      return decryptBn254KeystoreFromObject(keystore, password);
+    } catch (error) {
+      throw new Error(`Failed to decrypt BLS keystore at ${keystorePath}: ${error}`);
+    }
+  }
+
+  return undefined;
+}
+
+/**
+ * Extracts ETH address from various account formats
+ */
+function extractEthAddress(ethAccount: any): string | undefined {
+  if (typeof ethAccount === 'string' && ethAccount.startsWith('0x')) {
+    // This is a private key, we can't easily get the address without deriving it
+    // But for the staker command, we only care about the address if it's explicitly provided
+    return undefined;
+  }
+
+  if (typeof ethAccount === 'object' && 'address' in ethAccount) {
+    return ethAccount.address.toString();
+  }
+
+  return undefined;
+}
+
+/**
+ * Processes a single validator entry to extract BLS key and optional attester address
+ */
+function processValidator(validator: ValidatorKeyStore, providedPassword?: string): ValidatorEntry | undefined {
+  const attester = validator.attester;
+
+  let blsPrivateKey: string | undefined;
+  let attesterAddress: string | undefined;
+
+  // Handle different attester shapes
+  if (typeof attester === 'object' && 'bls' in attester && attester.bls) {
+    // Format: { eth: ..., bls: ... }
+    blsPrivateKey = extractBlsPrivateKey(attester.bls, providedPassword);
+    if ('eth' in attester && attester.eth) {
+      attesterAddress = extractEthAddress(attester.eth);
+    }
+  } else if (typeof attester === 'object' && 'bls' in attester && !('eth' in attester)) {
+    // BLS-only format: { bls: ... }
+    blsPrivateKey = extractBlsPrivateKey((attester as any).bls, providedPassword);
+  } else {
+    // Plain ETH account, no BLS key
+    return undefined;
+  }
+
+  if (!blsPrivateKey) {
+    return undefined;
+  }
+
+  return {
+    blsPrivateKey,
+    attesterAddress,
+  };
+}
+
+export async function stakerCommand(options: StakerOptions, log: LogFn) {
+  const { from, password, gseAddress, l1RpcUrls, chainId } = options;
+
+  // Read and parse the keystore file
+  let keystoreContent: any;
+  try {
+    const content = readFileSync(from, 'utf-8');
+    keystoreContent = JSON.parse(content);
+  } catch (error) {
+    throw new Error(`Failed to read keystore file ${from}: ${error}`);
+  }
+
+  const validatorEntries: ValidatorEntry[] = [];
+
+  // Detect keystore format and extract validators
+  if ('schemaVersion' in keystoreContent && 'validators' in keystoreContent) {
+    // Full validator keystore format
+    const keystore: KeyStore = loadKeystoreFile(from);
+    if (keystore.validators) {
+      for (const validator of keystore.validators) {
+        const entry = processValidator(validator, password);
+        if (entry) {
+          validatorEntries.push(entry);
+        }
+      }
+    }
+  } else if ('crypto' in keystoreContent) {
+    // Encrypted BN254 keystore format
+    const decryptedKey = decryptBn254KeystoreFromObject(keystoreContent, password ?? '');
+    validatorEntries.push({ blsPrivateKey: decryptedKey });
+  } else if ('privateKey' in keystoreContent && 'publicKey' in keystoreContent) {
+    // Simple BLS keypair format (from generate-bls-keypair)
+    validatorEntries.push({ blsPrivateKey: keystoreContent.privateKey });
+  } else {
+    throw new Error('Unknown keystore format. Expected validator keystore, BN254 keystore, or BLS keypair JSON.');
+  }
+
+  if (validatorEntries.length === 0) {
+    throw new Error('No BLS keys found in keystore');
+  }
+
+  // Create GSE contract client
+  const chain = createEthereumChain(l1RpcUrls, chainId);
+  const publicClient = createPublicClient({
+    chain: chain.chainInfo,
+    transport: fallback(l1RpcUrls.map(url => http(url))),
+  });
+
+  const gseContract = new GSEContract(publicClient, gseAddress);
+
+  // Generate registration tuples for all validators
+  const registrationData: RegistrationData[] = [];
+
+  for (const entry of validatorEntries) {
+    const bn254SecretKeyFieldElement = Fr.fromString(entry.blsPrivateKey);
+    const registrationTuple = await gseContract.makeRegistrationTuple(bn254SecretKeyFieldElement.toBigInt());
+
+    const data: RegistrationData = {
+      publicKeyInG1: {
+        x: '0x' + registrationTuple.publicKeyInG1.x.toString(16),
+        y: '0x' + registrationTuple.publicKeyInG1.y.toString(16),
+      },
+      publicKeyInG2: {
+        x0: '0x' + registrationTuple.publicKeyInG2.x0.toString(16),
+        x1: '0x' + registrationTuple.publicKeyInG2.x1.toString(16),
+        y0: '0x' + registrationTuple.publicKeyInG2.y0.toString(16),
+        y1: '0x' + registrationTuple.publicKeyInG2.y1.toString(16),
+      },
+      proofOfPossession: {
+        x: '0x' + registrationTuple.proofOfPossession.x.toString(16),
+        y: '0x' + registrationTuple.proofOfPossession.y.toString(16),
+      },
+    };
+
+    // Only include attester field if we have an address
+    if (entry.attesterAddress) {
+      data.attester = entry.attesterAddress;
+    }
+
+    registrationData.push(data);
+  }
+
+  // Output as JSON array
+  log(JSON.stringify(registrationData, null, 2));
+}

--- a/yarn-project/cli/src/cmds/validator_keys/valkeys.test.ts
+++ b/yarn-project/cli/src/cmds/validator_keys/valkeys.test.ts
@@ -1,9 +1,11 @@
+import { GSEContract } from '@aztec/ethereum';
 import { deriveBlsPrivateKey } from '@aztec/foundation/crypto';
 import { decryptBn254Keystore } from '@aztec/foundation/crypto/bls/bn254_keystore';
 import { loadKeystoreFile } from '@aztec/node-keystore/loader';
 import type { KeyStore } from '@aztec/node-keystore/types';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
 
+import { jest } from '@jest/globals';
 import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
@@ -417,6 +419,243 @@ describe('validator keys utilities', () => {
       const parsed = JSON.parse(logs[0]);
       expect(parsed).toHaveProperty('privateKey');
       expect(parsed).toHaveProperty('publicKey');
+    });
+  });
+
+  describe('stakerCommand (integration test)', () => {
+    // Mock GSEContract to avoid requiring L1 connection
+    const mockRegistrationTuple = {
+      publicKeyInG1: {
+        x: BigInt('0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef'),
+        y: BigInt('0xfedcba0987654321fedcba0987654321fedcba0987654321fedcba0987654321'),
+      },
+      publicKeyInG2: {
+        x0: BigInt('0x1111111111111111111111111111111111111111111111111111111111111111'),
+        x1: BigInt('0x2222222222222222222222222222222222222222222222222222222222222222'),
+        y0: BigInt('0x3333333333333333333333333333333333333333333333333333333333333333'),
+        y1: BigInt('0x4444444444444444444444444444444444444444444444444444444444444444'),
+      },
+      proofOfPossession: {
+        x: BigInt('0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'),
+        y: BigInt('0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'),
+      },
+    };
+
+    beforeAll(() => {
+      // Mock GSEContract.makeRegistrationTuple
+      jest.spyOn(GSEContract.prototype, 'makeRegistrationTuple').mockResolvedValue(mockRegistrationTuple);
+    });
+
+    afterAll(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('generates registration tuples from simple BLS keypair file', async () => {
+      const { stakerCommand } = await import('./staker.js');
+      const blsKeypairFile = join(tmp, 'test-bls-keypair.json');
+
+      // Generate a BLS keypair
+      await generateBlsKeypair({ mnemonic: TEST_MNEMONIC, out: blsKeypairFile }, () => {});
+
+      const logs: string[] = [];
+      const log = (s: string) => logs.push(s);
+
+      await stakerCommand(
+        {
+          from: blsKeypairFile,
+          gseAddress: '0x1234567890123456789012345678901234567890' as any,
+          l1RpcUrls: ['http://localhost:8545'],
+          chainId: 31337,
+        },
+        log,
+      );
+
+      expect(logs.length).toBe(1);
+      const result = JSON.parse(logs[0]);
+      expect(Array.isArray(result)).toBe(true);
+      expect(result.length).toBe(1);
+      expect(result[0]).toHaveProperty('publicKeyInG1');
+      expect(result[0]).toHaveProperty('publicKeyInG2');
+      expect(result[0]).toHaveProperty('proofOfPossession');
+      expect(result[0]).not.toHaveProperty('attester'); // No attester in simple keypair
+    });
+
+    it('generates registration tuples from full validator keystore with attester addresses', async () => {
+      const { stakerCommand } = await import('./staker.js');
+      const keystorePath = join(tmp, 'test-validator-keystore.json');
+
+      // Create a validator keystore with 2 validators
+      await newValidatorKeystore(
+        {
+          dataDir: tmp,
+          file: 'test-validator-keystore.json',
+          count: 2,
+          publisherCount: 0,
+          mnemonic: TEST_MNEMONIC,
+          feeRecipient: ('0x' + '99'.repeat(32)) as unknown as AztecAddress,
+        },
+        () => {},
+      );
+
+      const logs: string[] = [];
+      const log = (s: string) => logs.push(s);
+
+      await stakerCommand(
+        {
+          from: keystorePath,
+          gseAddress: '0x1234567890123456789012345678901234567890' as any,
+          l1RpcUrls: ['http://localhost:8545'],
+          chainId: 31337,
+        },
+        log,
+      );
+
+      expect(logs.length).toBe(1);
+      const result = JSON.parse(logs[0]);
+      expect(Array.isArray(result)).toBe(true);
+      expect(result.length).toBe(2); // Two validators
+
+      for (const entry of result) {
+        expect(entry).toHaveProperty('publicKeyInG1');
+        expect(entry).toHaveProperty('publicKeyInG2');
+        expect(entry).toHaveProperty('proofOfPossession');
+        // attester should NOT be present because ETH addresses are stored as private keys, not addresses
+        // in the default keystore format (no remote signer)
+      }
+    });
+
+    it('generates registration tuples from encrypted BN254 keystore', async () => {
+      const { stakerCommand } = await import('./staker.js');
+      const password = 'test-password-456';
+
+      // Create a validator keystore with encrypted BLS keys
+      await newValidatorKeystore(
+        {
+          dataDir: tmp,
+          file: 'test-encrypted-keystore.json',
+          count: 1,
+          publisherCount: 0,
+          mnemonic: TEST_MNEMONIC,
+          password,
+          outDir: tmp,
+          feeRecipient: ('0x' + 'aa'.repeat(32)) as unknown as AztecAddress,
+        },
+        () => {},
+      );
+
+      // Load the created keystore to find the BLS keystore path
+      const mainKeystore: KeyStore = loadKeystoreFile(join(tmp, 'test-encrypted-keystore.json'));
+      const validator = mainKeystore.validators![0];
+      const att = typeof validator.attester === 'object' && 'bls' in validator.attester ? validator.attester : null;
+      expect(att).not.toBeNull();
+      const blsKeystorePath = (att!.bls as any).path;
+
+      const logs: string[] = [];
+      const log = (s: string) => logs.push(s);
+
+      await stakerCommand(
+        {
+          from: blsKeystorePath,
+          password,
+          gseAddress: '0x1234567890123456789012345678901234567890' as any,
+          l1RpcUrls: ['http://localhost:8545'],
+          chainId: 31337,
+        },
+        log,
+      );
+
+      expect(logs.length).toBe(1);
+      const result = JSON.parse(logs[0]);
+      expect(Array.isArray(result)).toBe(true);
+      expect(result.length).toBe(1);
+      expect(result[0]).toHaveProperty('publicKeyInG1');
+      expect(result[0]).toHaveProperty('publicKeyInG2');
+      expect(result[0]).toHaveProperty('proofOfPossession');
+    });
+
+    it('generates registration tuples from BLS-only keystore', async () => {
+      const { stakerCommand } = await import('./staker.js');
+      const keystorePath = join(tmp, 'test-bls-only-keystore.json');
+
+      // Create a BLS-only validator keystore
+      await newValidatorKeystore(
+        {
+          dataDir: tmp,
+          file: 'test-bls-only-keystore.json',
+          count: 1,
+          publisherCount: 0,
+          mnemonic: TEST_MNEMONIC,
+          blsOnly: true,
+          feeRecipient: ('0x' + 'bb'.repeat(32)) as unknown as AztecAddress,
+        },
+        () => {},
+      );
+
+      const logs: string[] = [];
+      const log = (s: string) => logs.push(s);
+
+      await stakerCommand(
+        {
+          from: keystorePath,
+          gseAddress: '0x1234567890123456789012345678901234567890' as any,
+          l1RpcUrls: ['http://localhost:8545'],
+          chainId: 31337,
+        },
+        log,
+      );
+
+      expect(logs.length).toBe(1);
+      const result = JSON.parse(logs[0]);
+      expect(Array.isArray(result)).toBe(true);
+      expect(result.length).toBe(1);
+      expect(result[0]).toHaveProperty('publicKeyInG1');
+      expect(result[0]).toHaveProperty('publicKeyInG2');
+      expect(result[0]).toHaveProperty('proofOfPossession');
+      expect(result[0]).not.toHaveProperty('attester'); // BLS-only, no ETH address
+    });
+
+    it('verifies registration tuple structure matches expected format', async () => {
+      const { stakerCommand } = await import('./staker.js');
+      const blsKeypairFile = join(tmp, 'test-structure-keypair.json');
+
+      await generateBlsKeypair({ mnemonic: TEST_MNEMONIC, out: blsKeypairFile }, () => {});
+
+      const logs: string[] = [];
+      const log = (s: string) => logs.push(s);
+
+      await stakerCommand(
+        {
+          from: blsKeypairFile,
+          gseAddress: '0x1234567890123456789012345678901234567890' as any,
+          l1RpcUrls: ['http://localhost:8545'],
+          chainId: 31337,
+        },
+        log,
+      );
+
+      const result = JSON.parse(logs[0]);
+      const entry = result[0];
+
+      // Verify G1 point structure
+      expect(entry.publicKeyInG1).toHaveProperty('x');
+      expect(entry.publicKeyInG1).toHaveProperty('y');
+      expect(typeof entry.publicKeyInG1.x).toBe('string');
+      expect(typeof entry.publicKeyInG1.y).toBe('string');
+      expect(entry.publicKeyInG1.x.startsWith('0x')).toBe(true);
+
+      // Verify G2 point structure
+      expect(entry.publicKeyInG2).toHaveProperty('x0');
+      expect(entry.publicKeyInG2).toHaveProperty('x1');
+      expect(entry.publicKeyInG2).toHaveProperty('y0');
+      expect(entry.publicKeyInG2).toHaveProperty('y1');
+      expect(typeof entry.publicKeyInG2.x0).toBe('string');
+      expect(entry.publicKeyInG2.x0.startsWith('0x')).toBe(true);
+
+      // Verify proof of possession structure
+      expect(entry.proofOfPossession).toHaveProperty('x');
+      expect(entry.proofOfPossession).toHaveProperty('y');
+      expect(typeof entry.proofOfPossession.x).toBe('string');
+      expect(entry.proofOfPossession.x.startsWith('0x')).toBe(true);
     });
   });
 });

--- a/yarn-project/node-keystore/src/schemas.ts
+++ b/yarn-project/node-keystore/src/schemas.ts
@@ -64,12 +64,15 @@ const ethAccountsSchema = z.union([ethAccountSchema, z.array(ethAccountSchema), 
 // BLSAccount schema
 const blsAccountSchema = z.union([blsPrivateKeySchema, encryptedKeyFileSchema]);
 
-// AttesterAccount schema: either EthAccount or { eth: EthAccount, bls?: BLSAccount }
+// AttesterAccount schema: either EthAccount or { eth: EthAccount, bls?: BLSAccount } or { bls: BLSAccount } (BLS-only)
 const attesterAccountSchema = z.union([
   ethAccountSchema,
   z.object({
     eth: ethAccountSchema,
     bls: optional(blsAccountSchema),
+  }),
+  z.object({
+    bls: blsAccountSchema,
   }),
 ]);
 

--- a/yarn-project/node-keystore/src/types.ts
+++ b/yarn-project/node-keystore/src/types.ts
@@ -77,8 +77,8 @@ export type ProverKeyStore = ProverKeyStoreWithId | EthAccount;
 /** A BLS account is either a private key, or an EIP-2335 encrypted keystore file */
 export type BLSAccount = BLSPrivateKey | EncryptedKeyFileConfig;
 
-/** An AttesterAccount is a combined EthAccount and optional BLSAccount */
-export type AttesterAccount = { eth: EthAccount; bls?: BLSAccount } | EthAccount;
+/** An AttesterAccount is a combined EthAccount and optional BLSAccount, or BLS-only */
+export type AttesterAccount = { eth: EthAccount; bls?: BLSAccount } | { bls: BLSAccount } | EthAccount;
 
 /** One or more attester accounts combining ETH and BLS keys */
 export type AttesterAccounts = AttesterAccount | AttesterAccount[] | MnemonicConfig;


### PR DESCRIPTION
# Add `validator-keys staker` command for generating staking deposit tuples

This PR adds a new CLI command `validator-keys staker` that generates registration tuples needed for staking deposits. The command extracts BLS private keys from various keystore formats and produces the necessary data for validator registration.

Key features:
- Supports multiple keystore formats (validator keystore, BN254 keystore, BLS keypair)
- Generates registration tuples with proper proof of possession
- Includes attester addresses when available
- Outputs JSON-formatted data ready for staking deposits

The PR also extends the node-keystore schema to support BLS-only attesters (without ETH keys).

## Example usage:
```
aztec validator-keys staker --from keystore.json --gse-address 0x1234... --l1-rpc-urls https://ethereum-rpc
```