### PR TITLE
feat: valkeys new --staker-output

### DIFF
--- a/docs/docs/the_aztec_network/operation/keystore/creating_keystores.md
+++ b/docs/docs/the_aztec_network/operation/keystore/creating_keystores.md
@@ -250,6 +250,7 @@ aztec generate-bls-keypair [options]
 | `--count` | Number of sequencers | `1` |
 | `--publisher-count` | Publishers per sequencer | `0` |
 | `--bls-path` | EIP-2334 derivation path for BLS keys | `m/12381/3600/0/0/0` |
+| `--staker-output` | View BLS info needed to register stakers | None |
 
 For the complete list of options, run:
 

--- a/yarn-project/cli/src/cmds/validator_keys/index.ts
+++ b/yarn-project/cli/src/cmds/validator_keys/index.ts
@@ -36,6 +36,12 @@ export function injectCommands(program: Command, log: LogFn) {
     )
     .option('--out-dir <dir>', 'Output directory for generated keystore file(s)')
     .option('--json', 'Echo resulting JSON to stdout')
+    .option('--staker-output', 'Output staker registration data (G1/G2 pubkeys and proof of possession)')
+    .option('--gse-address <address>', 'GSE contract address (required with --staker-output)', parseEthereumAddress)
+    .option('--l1-rpc-urls <urls>', 'L1 RPC URLs (comma-separated)', value => value.split(','), [
+      'http://localhost:8545',
+    ])
+    .option('-c, --l1-chain-id <number>', 'L1 chain ID', value => parseInt(value), 31337)
     .requiredOption('--fee-recipient <address>', 'Aztec address that will receive fees', parseAztecAddress)
     .action(async options => {
       const { newValidatorKeystore } = await import('./new.js');

--- a/yarn-project/cli/src/cmds/validator_keys/new.ts
+++ b/yarn-project/cli/src/cmds/validator_keys/new.ts
@@ -1,3 +1,4 @@
+import { decryptBn254KeystoreFromObject, loadBn254Keystore } from '@aztec/foundation/crypto/bls/bn254_keystore';
 import type { EthAddress } from '@aztec/foundation/eth-address';
 import type { LogFn } from '@aztec/foundation/log';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
@@ -15,6 +16,7 @@ import {
   writeEthJsonV3ToFile,
   writeKeystoreFile,
 } from './shared.js';
+import { generateRegistrationData } from './staker.js';
 
 export type NewValidatorKeystoreOptions = {
   dataDir?: string;
@@ -36,6 +38,10 @@ export type NewValidatorKeystoreOptions = {
   coinbase?: EthAddress;
   remoteSigner?: string;
   fundingAccount?: EthAddress;
+  stakerOutput?: boolean;
+  gseAddress?: EthAddress;
+  l1RpcUrls?: string[];
+  chainId?: number;
 };
 
 export async function newValidatorKeystore(options: NewValidatorKeystoreOptions, log: LogFn) {
@@ -116,5 +122,76 @@ export async function newValidatorKeystore(options: NewValidatorKeystoreOptions,
       });
       log(`attester address: ${acct.address} remoteSignerUrl: ${remoteSigner}`);
     }
+  }
+
+  // Generate staker output if requested
+  if (options.stakerOutput) {
+    if (!options.gseAddress) {
+      throw new Error('--gse-address is required when --staker-output is used');
+    }
+
+    const l1RpcUrls = options.l1RpcUrls ?? ['http://localhost:8545'];
+    const chainId = options.chainId ?? 31337;
+
+    // Extract BLS private keys from validators
+    const blsPrivateKeys: Array<{ privateKey: string; attesterAddress?: string }> = [];
+
+    for (const validator of validators) {
+      const attester = (validator as any).attester;
+
+      // Handle different attester shapes
+      if (typeof attester === 'object' && 'bls' in attester && attester.bls) {
+        let blsKey: string | undefined;
+
+        // Check if it's a plaintext key (string)
+        if (typeof attester.bls === 'string' && attester.bls.startsWith('0x')) {
+          blsKey = attester.bls;
+        }
+        // Check if it's an encrypted keystore reference
+        else if (typeof attester.bls === 'object' && 'path' in attester.bls) {
+          const keystorePath = attester.bls.path;
+          const keystorePassword = attester.bls.password ?? password ?? '';
+
+          try {
+            // Load and decrypt the BN254 keystore
+            const keystore = loadBn254Keystore(keystorePath);
+            blsKey = decryptBn254KeystoreFromObject(keystore, keystorePassword);
+          } catch (error) {
+            throw new Error(`Failed to decrypt BLS keystore at ${keystorePath}: ${error}`);
+          }
+        }
+
+        if (blsKey) {
+          let attesterAddress: string | undefined;
+
+          // If we have ETH account, try to extract or derive the address
+          if ('eth' in attester && attester.eth) {
+            if (typeof attester.eth === 'object' && 'address' in attester.eth) {
+              // ETH account is an object with address (e.g., remote signer)
+              attesterAddress = (attester.eth as any).address.toString();
+            } else if (!blsOnly && mnemonic) {
+              // Derive address from mnemonic (works for both plaintext and encrypted keys)
+              const acct = mnemonicToAccount(mnemonic, {
+                accountIndex,
+                addressIndex: addressIndex + blsPrivateKeys.length,
+              });
+              attesterAddress = acct.address as unknown as string;
+            }
+          }
+
+          blsPrivateKeys.push({ privateKey: blsKey, attesterAddress });
+        }
+      }
+    }
+
+    if (blsPrivateKeys.length === 0) {
+      throw new Error('No BLS keys found in generated validators. Use --mnemonic or --ikm to generate BLS keys.');
+    }
+
+    // Generate and output registration data
+    const registrationData = await generateRegistrationData(blsPrivateKeys, options.gseAddress, l1RpcUrls, chainId);
+
+    log('\nStaker Registration Data:');
+    log(JSON.stringify(registrationData, null, 2));
   }
 }

--- a/yarn-project/cli/src/cmds/validator_keys/staker.ts
+++ b/yarn-project/cli/src/cmds/validator_keys/staker.ts
@@ -17,7 +17,7 @@ export type StakerOptions = {
   chainId: number;
 };
 
-type RegistrationData = {
+export type RegistrationData = {
   attester?: string;
   publicKeyInG1: {
     x: string;
@@ -117,6 +117,59 @@ function processValidator(validator: ValidatorKeyStore, providedPassword?: strin
   };
 }
 
+/**
+ * Generate registration data for staking from BLS private keys
+ */
+export async function generateRegistrationData(
+  blsPrivateKeys: Array<{ privateKey: string; attesterAddress?: string }>,
+  gseAddress: EthAddress,
+  l1RpcUrls: string[],
+  chainId: number,
+): Promise<RegistrationData[]> {
+  // Create GSE contract client
+  const chain = createEthereumChain(l1RpcUrls, chainId);
+  const publicClient = createPublicClient({
+    chain: chain.chainInfo,
+    transport: fallback(l1RpcUrls.map(url => http(url))),
+  });
+
+  const gseContract = new GSEContract(publicClient, gseAddress);
+
+  // Generate registration tuples for all validators
+  const registrationData: RegistrationData[] = [];
+
+  for (const entry of blsPrivateKeys) {
+    const bn254SecretKeyFieldElement = Fr.fromString(entry.privateKey);
+    const registrationTuple = await gseContract.makeRegistrationTuple(bn254SecretKeyFieldElement.toBigInt());
+
+    const data: RegistrationData = {
+      publicKeyInG1: {
+        x: '0x' + registrationTuple.publicKeyInG1.x.toString(16),
+        y: '0x' + registrationTuple.publicKeyInG1.y.toString(16),
+      },
+      publicKeyInG2: {
+        x0: '0x' + registrationTuple.publicKeyInG2.x0.toString(16),
+        x1: '0x' + registrationTuple.publicKeyInG2.x1.toString(16),
+        y0: '0x' + registrationTuple.publicKeyInG2.y0.toString(16),
+        y1: '0x' + registrationTuple.publicKeyInG2.y1.toString(16),
+      },
+      proofOfPossession: {
+        x: '0x' + registrationTuple.proofOfPossession.x.toString(16),
+        y: '0x' + registrationTuple.proofOfPossession.y.toString(16),
+      },
+    };
+
+    // Only include attester field if we have an address
+    if (entry.attesterAddress) {
+      data.attester = entry.attesterAddress;
+    }
+
+    registrationData.push(data);
+  }
+
+  return registrationData;
+}
+
 export async function stakerCommand(options: StakerOptions, log: LogFn) {
   const { from, password, gseAddress, l1RpcUrls, chainId } = options;
 
@@ -158,46 +211,16 @@ export async function stakerCommand(options: StakerOptions, log: LogFn) {
     throw new Error('No BLS keys found in keystore');
   }
 
-  // Create GSE contract client
-  const chain = createEthereumChain(l1RpcUrls, chainId);
-  const publicClient = createPublicClient({
-    chain: chain.chainInfo,
-    transport: fallback(l1RpcUrls.map(url => http(url))),
-  });
-
-  const gseContract = new GSEContract(publicClient, gseAddress);
-
-  // Generate registration tuples for all validators
-  const registrationData: RegistrationData[] = [];
-
-  for (const entry of validatorEntries) {
-    const bn254SecretKeyFieldElement = Fr.fromString(entry.blsPrivateKey);
-    const registrationTuple = await gseContract.makeRegistrationTuple(bn254SecretKeyFieldElement.toBigInt());
-
-    const data: RegistrationData = {
-      publicKeyInG1: {
-        x: '0x' + registrationTuple.publicKeyInG1.x.toString(16),
-        y: '0x' + registrationTuple.publicKeyInG1.y.toString(16),
-      },
-      publicKeyInG2: {
-        x0: '0x' + registrationTuple.publicKeyInG2.x0.toString(16),
-        x1: '0x' + registrationTuple.publicKeyInG2.x1.toString(16),
-        y0: '0x' + registrationTuple.publicKeyInG2.y0.toString(16),
-        y1: '0x' + registrationTuple.publicKeyInG2.y1.toString(16),
-      },
-      proofOfPossession: {
-        x: '0x' + registrationTuple.proofOfPossession.x.toString(16),
-        y: '0x' + registrationTuple.proofOfPossession.y.toString(16),
-      },
-    };
-
-    // Only include attester field if we have an address
-    if (entry.attesterAddress) {
-      data.attester = entry.attesterAddress;
-    }
-
-    registrationData.push(data);
-  }
+  // Generate registration data using the shared function
+  const registrationData = await generateRegistrationData(
+    validatorEntries.map(entry => ({
+      privateKey: entry.blsPrivateKey,
+      attesterAddress: entry.attesterAddress,
+    })),
+    gseAddress,
+    l1RpcUrls,
+    chainId,
+  );
 
   // Output as JSON array
   log(JSON.stringify(registrationData, null, 2));


### PR DESCRIPTION
# Add `--staker-output` option to BLS key generation

This PR adds a new `--staker-output` option to the `aztec generate-bls-keypair` command that allows users to view the BLS information needed to register stakers directly when generating keys.

The implementation:

1. Adds the `--staker-output` option to the CLI command documentation
2. Adds new CLI options to support staker registration:
   - `--staker-output` - Flag to output staker registration data
   - `--gse-address` - GSE contract address (required with staker output)
   - `--l1-rpc-urls` - L1 RPC URLs for contract interaction
   - `--l1-chain-id` - L1 chain ID for contract interaction

3. Refactors the staker registration data generation into a reusable function that can be used both by the dedicated staker command and the new validator key generation flow

This enhancement streamlines the validator setup process by allowing operators to generate keys and obtain staker registration data in a single step.