### PR TITLE
feat(bb): add benchmarks for circuits just below and above 2^20 gates

### DIFF
--- a/barretenberg/cpp/src/barretenberg/benchmark/ultra_bench/ultra_honk.bench.cpp
+++ b/barretenberg/cpp/src/barretenberg/benchmark/ultra_bench/ultra_honk.bench.cpp
@@ -8,34 +8,6 @@ using namespace benchmark;
 using namespace bb;
 
 /**
- * @brief Generate test circuit with a specific target gate count (not power of 2)
- */
-static void generate_basic_arithmetic_circuit_with_target_gates(UltraCircuitBuilder& builder, size_t target_gate_count)
-{
-    stdlib::recursion::honk::DefaultIO<UltraCircuitBuilder>::add_default(builder);
-
-    stdlib::field_t a(stdlib::witness_t(&builder, fr::random_element()));
-    stdlib::field_t b(stdlib::witness_t(&builder, fr::random_element()));
-    stdlib::field_t c(&builder);
-
-    const size_t GATE_COUNT_BUFFER = 1000;
-    size_t current_gates = builder.get_num_finalized_gates_inefficient(/*ensure_nonzero=*/false);
-
-    if (target_gate_count <= current_gates + GATE_COUNT_BUFFER) {
-        throw_or_abort("Target gate count is too low.");
-    }
-
-    size_t passes = (target_gate_count - current_gates - GATE_COUNT_BUFFER) / 4;
-
-    for (size_t i = 0; i < passes; ++i) {
-        c = a + b;
-        c = a * c;
-        a = b * b;
-        b = c * c;
-    }
-}
-
-/**
  * @brief Benchmark: Construction of a Ultra Honk proof for a circuit determined by the provided circuit function
  */
 static void construct_proof_ultrahonk(State& state,
@@ -73,7 +45,7 @@ static void construct_proof_ultrahonk_just_below_2_20(State& state) noexcept
 {
     size_t num_gates = (1 << 20) - 1; // 2^20 - 1 = 1,048,575 gates
     bb::mock_circuits::construct_proof_with_specified_num_iterations<UltraProver>(
-        state, &generate_basic_arithmetic_circuit_with_target_gates, num_gates);
+        state, &bb::mock_circuits::generate_basic_arithmetic_circuit_with_target_gates<UltraCircuitBuilder>, num_gates);
 }
 
 /**
@@ -83,7 +55,7 @@ static void construct_proof_ultrahonk_just_above_2_20(State& state) noexcept
 {
     size_t num_gates = (1 << 20) + 1; // 2^20 + 1 = 1,048,577 gates
     bb::mock_circuits::construct_proof_with_specified_num_iterations<UltraProver>(
-        state, &generate_basic_arithmetic_circuit_with_target_gates, num_gates);
+        state, &bb::mock_circuits::generate_basic_arithmetic_circuit_with_target_gates<UltraCircuitBuilder>, num_gates);
 }
 
 // Define benchmarks

--- a/barretenberg/cpp/src/barretenberg/benchmark/ultra_bench/ultra_honk.bench.cpp
+++ b/barretenberg/cpp/src/barretenberg/benchmark/ultra_bench/ultra_honk.bench.cpp
@@ -1,10 +1,39 @@
 #include <benchmark/benchmark.h>
 
 #include "barretenberg/benchmark/ultra_bench/mock_circuits.hpp"
+#include "barretenberg/common/bb_bench.hpp"
 #include "barretenberg/stdlib_circuit_builders/ultra_circuit_builder.hpp"
 
 using namespace benchmark;
 using namespace bb;
+
+/**
+ * @brief Generate test circuit with a specific target gate count (not power of 2)
+ */
+static void generate_basic_arithmetic_circuit_with_target_gates(UltraCircuitBuilder& builder, size_t target_gate_count)
+{
+    stdlib::recursion::honk::DefaultIO<UltraCircuitBuilder>::add_default(builder);
+
+    stdlib::field_t a(stdlib::witness_t(&builder, fr::random_element()));
+    stdlib::field_t b(stdlib::witness_t(&builder, fr::random_element()));
+    stdlib::field_t c(&builder);
+
+    const size_t GATE_COUNT_BUFFER = 1000;
+    size_t current_gates = builder.get_num_finalized_gates_inefficient(/*ensure_nonzero=*/false);
+
+    if (target_gate_count <= current_gates + GATE_COUNT_BUFFER) {
+        throw_or_abort("Target gate count is too low.");
+    }
+
+    size_t passes = (target_gate_count - current_gates - GATE_COUNT_BUFFER) / 4;
+
+    for (size_t i = 0; i < passes; ++i) {
+        c = a + b;
+        c = a * c;
+        a = b * b;
+        b = c * c;
+    }
+}
 
 /**
  * @brief Benchmark: Construction of a Ultra Honk proof for a circuit determined by the provided circuit function
@@ -37,6 +66,26 @@ static void construct_proof_ultrahonk_zk_power_of_2(State& state) noexcept
         state, &bb::mock_circuits::generate_basic_arithmetic_circuit<UltraCircuitBuilder>, log2_of_gates);
 }
 
+/**
+ * @brief Benchmark: Construction of a Ultra Honk proof with gates just below 2^20
+ */
+static void construct_proof_ultrahonk_just_below_2_20(State& state) noexcept
+{
+    size_t num_gates = (1 << 20) - 1; // 2^20 - 1 = 1,048,575 gates
+    bb::mock_circuits::construct_proof_with_specified_num_iterations<UltraProver>(
+        state, &generate_basic_arithmetic_circuit_with_target_gates, num_gates);
+}
+
+/**
+ * @brief Benchmark: Construction of a Ultra Honk proof with gates just above 2^20
+ */
+static void construct_proof_ultrahonk_just_above_2_20(State& state) noexcept
+{
+    size_t num_gates = (1 << 20) + 1; // 2^20 + 1 = 1,048,577 gates
+    bb::mock_circuits::construct_proof_with_specified_num_iterations<UltraProver>(
+        state, &generate_basic_arithmetic_circuit_with_target_gates, num_gates);
+}
+
 // Define benchmarks
 BENCHMARK_CAPTURE(construct_proof_ultrahonk, sha256, &generate_sha256_test_circuit<UltraCircuitBuilder>)
     ->Unit(kMillisecond);
@@ -55,4 +104,24 @@ BENCHMARK(construct_proof_ultrahonk_zk_power_of_2)
     ->DenseRange(15, 20)
     ->Unit(kMillisecond);
 
-BENCHMARK_MAIN();
+BENCHMARK(construct_proof_ultrahonk_just_below_2_20)->Unit(kMillisecond);
+BENCHMARK(construct_proof_ultrahonk_just_above_2_20)->Unit(kMillisecond);
+
+int main(int argc, char** argv)
+{
+    // Enable BB_BENCH profiling
+    bb::detail::use_bb_bench = true;
+
+    // Run benchmarks
+    ::benchmark::Initialize(&argc, argv);
+    if (::benchmark::ReportUnrecognizedArguments(argc, argv))
+        return 1;
+    ::benchmark::RunSpecifiedBenchmarks();
+    ::benchmark::Shutdown();
+
+    // Print detailed profiling stats
+    std::cout << "\n=== Detailed BB_BENCH Profiling Stats ===\n";
+    bb::detail::GLOBAL_BENCH_STATS.print_aggregate_counts_hierarchical(std::cout);
+
+    return 0;
+}

--- a/barretenberg/cpp/src/barretenberg/benchmark/ultra_bench/ultra_honk.bench.cpp
+++ b/barretenberg/cpp/src/barretenberg/benchmark/ultra_bench/ultra_honk.bench.cpp
@@ -39,21 +39,51 @@ static void construct_proof_ultrahonk_zk_power_of_2(State& state) noexcept
 }
 
 /**
- * @brief Benchmark: Construction of a Ultra Honk proof with gates just below 2^20
+ * @brief Benchmark: Construction of a Ultra Honk proof with dyadic size at 2^19
+ * Target gates such that after buffer and rounding, dyadic size = 2^19 = 524,288
  */
-static void construct_proof_ultrahonk_just_below_2_20(State& state) noexcept
+static void construct_proof_ultrahonk_dyadic_2_19(State& state) noexcept
 {
-    size_t num_gates = (1 << 20) - 1; // 2^20 - 1 = 1,048,575 gates
+    // Target slightly below 2^19 so that after finalization it rounds to exactly 2^19
+    size_t num_gates = (1 << 19) - 2000; // ~522,288 gates
+
+    // Verify actual dyadic size
+    UltraCircuitBuilder builder;
+    bb::mock_circuits::generate_basic_arithmetic_circuit_with_target_gates<UltraCircuitBuilder>(builder, num_gates);
+    auto instance = std::make_shared<ProverInstance_<UltraFlavor>>(builder);
+    size_t dyadic_size = instance->dyadic_size();
+    info("construct_proof_ultrahonk_dyadic_2_19: requested=",
+         num_gates,
+         ", actual_gates=",
+         builder.num_gates(),
+         ", dyadic_size=",
+         dyadic_size);
+
     bb::mock_circuits::construct_proof_with_specified_num_iterations<UltraProver>(
         state, &bb::mock_circuits::generate_basic_arithmetic_circuit_with_target_gates<UltraCircuitBuilder>, num_gates);
 }
 
 /**
- * @brief Benchmark: Construction of a Ultra Honk proof with gates just above 2^20
+ * @brief Benchmark: Construction of a Ultra Honk proof with dyadic size at 2^20
+ * Target gates such that after buffer and rounding, dyadic size = 2^20 = 1,048,576
  */
-static void construct_proof_ultrahonk_just_above_2_20(State& state) noexcept
+static void construct_proof_ultrahonk_dyadic_2_20(State& state) noexcept
 {
-    size_t num_gates = (1 << 20) + 1; // 2^20 + 1 = 1,048,577 gates
+    // Target above 2^19 so that after finalization it rounds to 2^20
+    size_t num_gates = (1 << 19) + 2000; // ~526,288 gates
+
+    // Verify actual dyadic size
+    UltraCircuitBuilder builder;
+    bb::mock_circuits::generate_basic_arithmetic_circuit_with_target_gates<UltraCircuitBuilder>(builder, num_gates);
+    auto instance = std::make_shared<ProverInstance_<UltraFlavor>>(builder);
+    size_t dyadic_size = instance->dyadic_size();
+    info("construct_proof_ultrahonk_dyadic_2_20: requested=",
+         num_gates,
+         ", actual_gates=",
+         builder.num_gates(),
+         ", dyadic_size=",
+         dyadic_size);
+
     bb::mock_circuits::construct_proof_with_specified_num_iterations<UltraProver>(
         state, &bb::mock_circuits::generate_basic_arithmetic_circuit_with_target_gates<UltraCircuitBuilder>, num_gates);
 }
@@ -76,8 +106,8 @@ BENCHMARK(construct_proof_ultrahonk_zk_power_of_2)
     ->DenseRange(15, 20)
     ->Unit(kMillisecond);
 
-BENCHMARK(construct_proof_ultrahonk_just_below_2_20)->Unit(kMillisecond);
-BENCHMARK(construct_proof_ultrahonk_just_above_2_20)->Unit(kMillisecond);
+BENCHMARK(construct_proof_ultrahonk_dyadic_2_19)->Unit(kMillisecond);
+BENCHMARK(construct_proof_ultrahonk_dyadic_2_20)->Unit(kMillisecond);
 
 int main(int argc, char** argv)
 {

--- a/barretenberg/cpp/src/barretenberg/benchmark/ultra_bench/ultra_honk.bench.cpp
+++ b/barretenberg/cpp/src/barretenberg/benchmark/ultra_bench/ultra_honk.bench.cpp
@@ -39,20 +39,20 @@ static void construct_proof_ultrahonk_zk_power_of_2(State& state) noexcept
 }
 
 /**
- * @brief Benchmark: Construction of a Ultra Honk proof with dyadic size at 2^19
- * Target gates such that after buffer and rounding, dyadic size = 2^19 = 524,288
+ * @brief Benchmark: Ultra Honk proof with ~1M gates that rounds to dyadic circuit size 2^20
+ * Actual gates: ~1,047,000 → Dyadic size: 2^20 = 1,048,576
  */
-static void construct_proof_ultrahonk_dyadic_2_19(State& state) noexcept
+static void construct_proof_ultrahonk_1M_gates_dyadic_2_20(State& state) noexcept
 {
-    // Target slightly below 2^19 so that after finalization it rounds to exactly 2^19
-    size_t num_gates = (1 << 19) - 2000; // ~522,288 gates
+    // Target just below 2^20 so that after finalization it rounds to exactly 2^20
+    size_t num_gates = (1 << 20) - 1000; // ~1,047,576 gates
 
     // Verify actual dyadic size
     UltraCircuitBuilder builder;
     bb::mock_circuits::generate_basic_arithmetic_circuit_with_target_gates<UltraCircuitBuilder>(builder, num_gates);
     auto instance = std::make_shared<ProverInstance_<UltraFlavor>>(builder);
     size_t dyadic_size = instance->dyadic_size();
-    info("construct_proof_ultrahonk_dyadic_2_19: requested=",
+    info("construct_proof_ultrahonk_1M_gates_dyadic_2_20: requested=",
          num_gates,
          ", actual_gates=",
          builder.num_gates(),
@@ -64,20 +64,20 @@ static void construct_proof_ultrahonk_dyadic_2_19(State& state) noexcept
 }
 
 /**
- * @brief Benchmark: Construction of a Ultra Honk proof with dyadic size at 2^20
- * Target gates such that after buffer and rounding, dyadic size = 2^20 = 1,048,576
+ * @brief Benchmark: Ultra Honk proof with ~1M gates that rounds to dyadic circuit size 2^21
+ * Actual gates: ~1,050,000 → Dyadic size: 2^21 = 2,097,152
  */
-static void construct_proof_ultrahonk_dyadic_2_20(State& state) noexcept
+static void construct_proof_ultrahonk_1M_gates_dyadic_2_21(State& state) noexcept
 {
-    // Target above 2^19 so that after finalization it rounds to 2^20
-    size_t num_gates = (1 << 19) + 2000; // ~526,288 gates
+    // Target above 2^20 so that after finalization it rounds to 2^21
+    size_t num_gates = (1 << 20) + 1000; // ~1,049,576 gates
 
     // Verify actual dyadic size
     UltraCircuitBuilder builder;
     bb::mock_circuits::generate_basic_arithmetic_circuit_with_target_gates<UltraCircuitBuilder>(builder, num_gates);
     auto instance = std::make_shared<ProverInstance_<UltraFlavor>>(builder);
     size_t dyadic_size = instance->dyadic_size();
-    info("construct_proof_ultrahonk_dyadic_2_20: requested=",
+    info("construct_proof_ultrahonk_1M_gates_dyadic_2_21: requested=",
          num_gates,
          ", actual_gates=",
          builder.num_gates(),
@@ -106,8 +106,8 @@ BENCHMARK(construct_proof_ultrahonk_zk_power_of_2)
     ->DenseRange(15, 20)
     ->Unit(kMillisecond);
 
-BENCHMARK(construct_proof_ultrahonk_dyadic_2_19)->Unit(kMillisecond);
-BENCHMARK(construct_proof_ultrahonk_dyadic_2_20)->Unit(kMillisecond);
+BENCHMARK(construct_proof_ultrahonk_1M_gates_dyadic_2_20)->Unit(kMillisecond);
+BENCHMARK(construct_proof_ultrahonk_1M_gates_dyadic_2_21)->Unit(kMillisecond);
 
 int main(int argc, char** argv)
 {


### PR DESCRIPTION
## Summary

This PR adds two new Ultra Honk benchmarks to test performance across the dyadic size boundary:
- `construct_proof_ultrahonk_1M_gates_dyadic_2_20`: ~1.047M gates → rounds to dyadic size 2^20 = 1,048,576
- `construct_proof_ultrahonk_1M_gates_dyadic_2_21`: ~1.049M gates → rounds to dyadic size 2^21 = 2,097,152

## Benchmark Results (Remote EC2, 16 cores)

### Dyadic 2^20 (~1.047M actual gates → 1,048,576 dyadic):
- **Requested gates**: 1,047,576 → **Actual gates**: 1,046,590 → **Dyadic size**: 1,048,576 (2^20)
- **Total time**: 4472 ms (4386 ms CPU)
- **sumcheck.prove**: 560.5ms
  - **sumcheck loop** (19 rounds): 274.5ms total, **14.45ms per iteration**
    - `compute_univariate_with_row_skipping` (in loop): 223.3ms, **11.75ms per iteration** (81.4% of loop time)
  - `compute_univariate_with_row_skipping` (first round): 206.7ms

### Dyadic 2^21 (~1.049M actual gates → 2,097,152 dyadic):
- **Requested gates**: 1,049,576 → **Actual gates**: 1,048,590 → **Dyadic size**: 2,097,152 (2^21)
- **Total time**: 5353 ms (4594 ms CPU)
- **sumcheck.prove**: 837.4ms
  - **sumcheck loop** (20 rounds): 440.0ms total, **22.00ms per iteration**
    - `compute_univariate_with_row_skipping` (in loop): 365.7ms, **18.28ms per iteration** (83.1% of loop time)
  - `compute_univariate_with_row_skipping` (first round): 290.7ms

## Key Findings

1. **Per-iteration scaling is near-linear with dyadic size**: 
   - 2^20: 11.75ms per iteration
   - 2^21: 18.28ms per iteration (1.56x increase for 2x dyadic size)
3. **Total sumcheck time increases by ~49%**: 560.5ms → 837.4ms (due to one extra round: 19 → 20 rounds)

4. **Overall time increase of ~20%**: Despite 2x dyadic circuit size, total time only increases 4472ms → 5353ms, showing excellent sublinear scaling due to other fixed costs (commitments, Oink prover work, etc. remain similar)

## Implementation Details

- Refactored circuit generation: `generate_basic_arithmetic_circuit_with_target_gates()` accepts arbitrary gate counts, with `generate_basic_arithmetic_circuit()` calling it with `1UL << log2_num_gates`
- Added logging to verify actual dyadic sizes at runtime
- Enabled BB_BENCH profiling via custom main() function for detailed timing breakdown
- Clear benchmark names indicate both actual gate count (~1M) and dyadic size (2^20 vs 2^21)
- Benchmarks can be run remotely (combined or individually):
  ```bash
  # Both benchmarks together
  ./scripts/benchmark_remote.sh ultra_honk_bench 'BB_BENCH=1 ./ultra_honk_bench --benchmark_filter="construct_proof_ultrahonk_1M_gates"' clang20-no-avm build
  
  # Individual benchmarks for separate profiling
  ./scripts/benchmark_remote.sh ultra_honk_bench 'BB_BENCH=1 ./ultra_honk_bench --benchmark_filter="construct_proof_ultrahonk_1M_gates_dyadic_2_20$"' clang20-no-avm build
  ./scripts/benchmark_remote.sh ultra_honk_bench 'BB_BENCH=1 ./ultra_honk_bench --benchmark_filter="construct_proof_ultrahonk_1M_gates_dyadic_2_21$"' clang20-no-avm build
  ```

## Test Plan

Run the benchmarks:
```bash
cd barretenberg/cpp
./scripts/benchmark_remote.sh ultra_honk_bench './ultra_honk_bench --benchmark_filter="construct_proof_ultrahonk_1M_gates"' clang20-no-avm build
```