### PR TITLE
refactor(ci): ci-full uses test cache, add ci-full-no-test-cache label

### DIFF
--- a/.github/workflows/ci3.yml
+++ b/.github/workflows/ci3.yml
@@ -48,6 +48,10 @@ jobs:
         if: contains(github.event.pull_request.labels.*.name, 'ci-full')
         run: echo "CI_FULL=1" >> $GITHUB_ENV
 
+      - name: CI Full No Test Cache Override
+        if: contains(github.event.pull_request.labels.*.name, 'ci-full-no-test-cache')
+        run: echo "CI_FULL_NO_TEST_CACHE=1" >> $GITHUB_ENV
+
       - name: Cache Override
         if: contains(github.event.pull_request.labels.*.name, 'ci-no-cache')
         run: echo "NO_CACHE=1" >> $GITHUB_ENV
@@ -154,6 +158,8 @@ jobs:
             git push origin ${tag_name}
           elif [ "${CI_FULL:-0}" -eq 1 ]; then
             exec ./ci.sh full
+          elif [ "${CI_FULL_NO_TEST_CACHE:-0}" -eq 1 ]; then
+            exec ./ci.sh full-no-test-cache
           elif [ "${CI_DOCS:-0}" -eq 1 ]; then
             exec ./ci.sh docs
           elif [ "${CI_BARRETENBERG:-0}" -eq 1 ]; then
@@ -187,11 +193,15 @@ jobs:
           gh pr merge "${{ github.event.pull_request.number }}" --auto -m || true
 
       - name: Download benchmarks
-        if: github.event_name == 'merge_group' || env.CI_FULL == '1'
-        run: ./ci.sh gh-bench
+        if: github.event_name == 'merge_group' || env.CI_FULL == '1' || env.CI_FULL_NO_TEST_CACHE == '1'
+        run: |
+          ./ci.sh gh-bench
+          if [ "$(cat ./bench-out/bench.json)" != "[]" ]; then
+            echo "ENABLE_BENCH=1" >> $GITHUB_ENV
+          fi
 
       - name: Upload benchmarks
-        if: github.event_name == 'merge_group' || env.CI_FULL == '1'
+        if: env.ENABLE_BENCH == '1'
         uses: benchmark-action/github-action-benchmark@4de1bed97a47495fc4c5404952da0499e31f5c29
         with:
           name: Aztec Benchmarks

--- a/.test_patterns.yml
+++ b/.test_patterns.yml
@@ -186,10 +186,6 @@ tests:
     error_regex: "delays a transaction until a given L1 timestamp"
     owners:
       - *esau
-  - regex: "ivc-integration/src/rollup_ivc_integration.test.ts"
-    error_regex: "Exceeded timeout of"
-    owners:
-      - *luke
   - regex: "slasher/src/slasher_client.test.ts"
     error_regex: "ContractFunctionExecutionError: The contract function"
     owners:
@@ -227,6 +223,20 @@ tests:
     error_regex: "Error: Timed out [0-9]+ms waiting for expect\\(locator\\)"
     owners:
       - *saleel
+
+  # Example http://ci.aztec-labs.com/18db8adf0db50928
+  # This seems to be an error in acvm wasm/js
+  - regex: "run_compose_test [a-z]*-[a-z]* box boxes"
+    error_regex: "call_indirect to a null table entry"
+    owners:
+      - *adam
+
+  # Example http://ci.aztec-labs.com/cd76b19670ab613f
+  # related to wasm proving browser flakes potentially
+  - regex: "run_compose_test [a-z]*-[a-z]* box boxes"
+    error_regex: "Out of bounds memory access (evaluating 'this.exports"
+    owners:
+      - *adam
 
   - regex: "run_compose_test vite-[a-z]* box boxes"
     error_regex: "Test timeout of [0-9]+ms exceeded."

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -301,7 +301,8 @@ function bench_merge {
     dir=${dir#./}; \
     dir=${dir%/bench-out*}; \
     jq --arg prefix "$dir/" '\''map(.name |= "\($prefix)\(.)")'\'' "$1"
-  ' _ {} | jq -s add > bench-out/bench.json
+  ' _ {} | jq -s "add // []" > bench-out/bench.json
+
 }
 
 function bench {
@@ -426,6 +427,14 @@ case "$cmd" in
     test
     ;;
   "ci-full")
+    export CI=1
+    export USE_TEST_CACHE=1
+    export CI_FULL=1
+    build
+    test
+    bench
+    ;;
+  "ci-full-no-test-cache")
     export CI=1
     export USE_TEST_CACHE=0
     export CI_FULL=1


### PR DESCRIPTION
Most people were not even aware ci-full skipped test cache. You have two options now: ci-full-no-test-cache and ci-merge-queue if you want to 'grind' tests that have already passed for their rebuild pattern