### PR TITLE
chore: Extend ECDSA test and remove unused argument

### DIFF
--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/ecdsa_constraints.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/ecdsa_constraints.test.cpp
@@ -66,7 +66,7 @@ template <class Curve> class EcdsaTestingFunctions {
 
         switch (invalid_witness_target) {
         case InvalidWitness::Target::HashIsNotAByteArray:
-            // Set all bytes of hash to 256 (invalid valid as it doesn't fit in one byte)
+            // Set all bytes of hash to 256 (invalid as it doesn't fit in one byte)
             for (size_t idx = 0; idx < 32; idx++) {
                 witness_values[ecdsa_constraints.hashed_message[idx]] = bb::fr(256);
             };

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/ecdsa_constraints.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/ecdsa_constraints.test.cpp
@@ -66,8 +66,10 @@ template <class Curve> class EcdsaTestingFunctions {
 
         switch (invalid_witness_target) {
         case InvalidWitness::Target::HashIsNotAByteArray:
-            // Set first byte of hash to 256 (invalid byte)
-            witness_values[ecdsa_constraints.hashed_message[0]] = bb::fr(256);
+            // Set all bytes of hash to 256 (invalid valid as it doesn't fit in one byte)
+            for (size_t idx = 0; idx < 32; idx++) {
+                witness_values[ecdsa_constraints.hashed_message[idx]] = bb::fr(256);
+            };
             break;
         case InvalidWitness::Target::ZeroR:
             // Set r = 0 (invalid ECDSA signature component)


### PR DESCRIPTION
- Made the test checking for failure if `hashed_message` is not made of bytes more robust
- Removed unused argument `force_invalidation`