### PR TITLE
feat!: better simulateutility typings

### DIFF
--- a/yarn-project/aztec.js/src/contract/batch_call.ts
+++ b/yarn-project/aztec.js/src/contract/batch_call.ts
@@ -84,7 +84,7 @@ export class BatchCall extends BaseContractInteraction {
         ? this.wallet.batch(
             utility.map(([call]) => ({
               name: 'simulateUtility' as const,
-              args: [call.name, call.args, call.to, options?.authWitnesses] as const,
+              args: [call, options?.authWitnesses, undefined] as const,
             })),
           )
         : Promise.resolve([]);
@@ -99,8 +99,10 @@ export class BatchCall extends BaseContractInteraction {
     const results: any[] = [];
 
     utilityBatchResults.forEach((wrappedResult, utilityIndex) => {
-      const [, originalIndex] = utility[utilityIndex];
-      results[originalIndex] = wrappedResult.result.result;
+      const [call, originalIndex] = utility[utilityIndex];
+      // Decode the raw field elements to the actual return type
+      const rawReturnValues = wrappedResult.result.result;
+      results[originalIndex] = rawReturnValues ? decodeFromAbi(call.returnTypes, rawReturnValues) : [];
     });
 
     if (simulatedTx) {

--- a/yarn-project/aztec.js/src/contract/contract.test.ts
+++ b/yarn-project/aztec.js/src/contract/contract.test.ts
@@ -1,3 +1,4 @@
+import { Fr } from '@aztec/foundation/fields';
 import { type ContractArtifact, FunctionType } from '@aztec/stdlib/abi';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import {
@@ -30,7 +31,7 @@ describe('Contract Class', () => {
   const mockTxHash = { type: 'TxHash' } as any as TxHash;
   const mockTxReceipt = { type: 'TxReceipt' } as any as TxReceipt;
   const mockTxSimulationResult = { type: 'TxSimulationResult', result: 1n } as any as TxSimulationResult;
-  const mockUtilityResultValue = { type: 'UtilitySimulationResult' } as any as UtilitySimulationResult;
+  const mockUtilityResultValue = { result: [new Fr(42)] } as any as UtilitySimulationResult;
 
   const defaultArtifact: ContractArtifact = {
     name: 'FooContract',
@@ -158,7 +159,10 @@ describe('Contract Class', () => {
     const fooContract = await Contract.at(contractAddress, defaultArtifact, wallet);
     const result = await fooContract.methods.qux(123n).simulate({ from: account.getAddress() });
     expect(wallet.simulateUtility).toHaveBeenCalledTimes(1);
-    expect(wallet.simulateUtility).toHaveBeenCalledWith('qux', [123n], contractAddress, []);
-    expect(result).toBe(mockUtilityResultValue.result);
+    expect(wallet.simulateUtility).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'qux', to: contractAddress }),
+      [],
+    );
+    expect(result).toBe(42n);
   });
 });

--- a/yarn-project/aztec.js/src/contract/contract_function_interaction.ts
+++ b/yarn-project/aztec.js/src/contract/contract_function_interaction.ts
@@ -103,20 +103,19 @@ export class ContractFunctionInteraction extends BaseContractInteraction {
   ): Promise<SimulationReturn<typeof options.includeMetadata>> {
     // docs:end:simulate
     if (this.functionDao.functionType == FunctionType.UTILITY) {
-      const utilityResult = await this.wallet.simulateUtility(
-        this.functionDao.name,
-        this.args,
-        this.contractAddress,
-        options.authWitnesses ?? [],
-      );
+      const call = await this.getFunctionCall();
+      const utilityResult = await this.wallet.simulateUtility(call, options.authWitnesses ?? []);
+
+      // Decode the raw field elements to the actual return type
+      const returnValue = utilityResult.result ? decodeFromAbi(this.functionDao.returnTypes, utilityResult.result) : [];
 
       if (options.includeMetadata) {
         return {
           stats: utilityResult.stats,
-          result: utilityResult.result,
+          result: returnValue,
         };
       } else {
-        return utilityResult.result;
+        return returnValue;
       }
     }
 

--- a/yarn-project/aztec.js/src/utils/authwit.ts
+++ b/yarn-project/aztec.js/src/utils/authwit.ts
@@ -171,7 +171,18 @@ export async function lookupValidity(
     functionType: FunctionType.UTILITY,
     isInternal: false,
     isStatic: false,
-    parameters: [{ name: 'message_hash', type: { kind: 'field' }, visibility: 'private' as ABIParameterVisibility }],
+    parameters: [
+      {
+        name: 'consumer',
+        type: {
+          fields: [{ name: 'inner', type: { kind: 'field' } }],
+          kind: 'struct',
+          path: 'aztec::protocol_types::address::aztec_address::AztecAddress',
+        },
+        visibility: 'private' as ABIParameterVisibility,
+      },
+      { name: 'inner_hash', type: { kind: 'field' }, visibility: 'private' as ABIParameterVisibility },
+    ],
     returnTypes: [{ kind: 'boolean' }],
     errorTypes: {},
   } as FunctionAbi;

--- a/yarn-project/aztec.js/src/wallet/base_wallet.ts
+++ b/yarn-project/aztec.js/src/wallet/base_wallet.ts
@@ -9,7 +9,12 @@ import type { ChainInfo } from '@aztec/entrypoints/interfaces';
 import { ExecutionPayload, mergeExecutionPayloads } from '@aztec/entrypoints/payload';
 import { Fr } from '@aztec/foundation/fields';
 import { createLogger } from '@aztec/foundation/log';
-import { type ContractArtifact, type EventMetadataDefinition, decodeFromAbi } from '@aztec/stdlib/abi';
+import {
+  type ContractArtifact,
+  type EventMetadataDefinition,
+  type FunctionCall,
+  decodeFromAbi,
+} from '@aztec/stdlib/abi';
 import type { AuthWitness } from '@aztec/stdlib/auth-witness';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
 import {
@@ -318,13 +323,11 @@ export abstract class BaseWallet implements Wallet {
   }
 
   simulateUtility(
-    functionName: string,
-    args: any[],
-    to: AztecAddress,
+    call: FunctionCall,
     authwits?: AuthWitness[],
-    from?: AztecAddress,
+    scopes?: AztecAddress[],
   ): Promise<UtilitySimulationResult> {
-    return this.pxe.simulateUtility(functionName, args, to, authwits, from);
+    return this.pxe.simulateUtility(call, authwits, scopes);
   }
 
   getContractClassMetadata(id: Fr, includeArtifact: boolean = false): Promise<ContractClassMetadata> {

--- a/yarn-project/aztec.js/src/wallet/wallet.ts
+++ b/yarn-project/aztec.js/src/wallet/wallet.ts
@@ -7,6 +7,7 @@ import {
   ContractArtifactSchema,
   type EventMetadataDefinition,
   FunctionAbiSchema,
+  type FunctionCall,
   FunctionType,
 } from '@aztec/stdlib/abi';
 import { AuthWitness } from '@aztec/stdlib/auth-witness';
@@ -178,10 +179,9 @@ export type Wallet = {
   ): Promise<ContractInstanceWithAddress>;
   simulateTx(exec: ExecutionPayload, opts: SimulateOptions): Promise<TxSimulationResult>;
   simulateUtility(
-    functionName: string,
-    args: any[],
-    to: AztecAddress,
+    call: FunctionCall,
     authwits?: AuthWitness[],
+    scopes?: AztecAddress[],
   ): Promise<UtilitySimulationResult>;
   profileTx(exec: ExecutionPayload, opts: ProfileOptions): Promise<TxProfileResult>;
   sendTx(exec: ExecutionPayload, opts: SendOptions): Promise<TxHash>;
@@ -286,7 +286,7 @@ export const BatchedMethodSchema = z.union([
   }),
   z.object({
     name: z.literal('simulateUtility'),
-    args: z.tuple([z.string(), z.array(z.any()), schemas.AztecAddress, optional(z.array(AuthWitness.schema))]),
+    args: z.tuple([FunctionCallSchema, optional(z.array(AuthWitness.schema)), optional(z.array(schemas.AztecAddress))]),
   }),
 ]);
 
@@ -336,7 +336,7 @@ export const WalletSchema: ApiSchemaFor<Wallet> = {
   simulateTx: z.function().args(ExecutionPayloadSchema, SimulateOptionsSchema).returns(TxSimulationResult.schema),
   simulateUtility: z
     .function()
-    .args(z.string(), z.array(z.any()), schemas.AztecAddress, optional(z.array(AuthWitness.schema)))
+    .args(FunctionCallSchema, optional(z.array(AuthWitness.schema)), optional(z.array(schemas.AztecAddress)))
     .returns(UtilitySimulationResult.schema),
   profileTx: z.function().args(ExecutionPayloadSchema, ProfileOptionsSchema).returns(TxProfileResult.schema),
   sendTx: z.function().args(ExecutionPayloadSchema, SendOptionsSchema).returns(TxHash.schema),

--- a/yarn-project/pxe/src/contract_function_simulator/contract_function_simulator.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/contract_function_simulator.ts
@@ -32,8 +32,8 @@ import {
   toACVMWitness,
   witnessMapToFields,
 } from '@aztec/simulator/client';
-import type { AbiDecoded, FunctionCall } from '@aztec/stdlib/abi';
-import { FunctionSelector, FunctionType, decodeFromAbi } from '@aztec/stdlib/abi';
+import type { FunctionCall } from '@aztec/stdlib/abi';
+import { FunctionSelector, FunctionType } from '@aztec/stdlib/abi';
 import type { AuthWitness } from '@aztec/stdlib/auth-witness';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import { Gas } from '@aztec/stdlib/gas';
@@ -215,9 +215,9 @@ export class ContractFunctionSimulator {
    * @param authwits - Authentication witnesses required for the function call.
    * @param scopes - Optional array of account addresses whose notes can be accessed in this call. Defaults to all
    * accounts if not specified.
-   * @returns A decoded ABI value containing the function's return data.
+   * @returns A return value of the utility function in a form as returned by the simulator (Noir fields)
    */
-  public async runUtility(call: FunctionCall, authwits: AuthWitness[], scopes?: AztecAddress[]): Promise<AbiDecoded> {
+  public async runUtility(call: FunctionCall, authwits: AuthWitness[], scopes?: AztecAddress[]): Promise<Fr[]> {
     await verifyCurrentClassId(call.to, this.executionDataProvider);
 
     const entryPointArtifact = await this.executionDataProvider.getFunctionArtifact(call.to, call.selector);
@@ -250,9 +250,8 @@ export class ContractFunctionSimulator {
           );
         });
 
-      const returnWitness = witnessMapToFields(acirExecutionResult.returnWitness);
       this.log.verbose(`Utility simulation for ${call.to}.${call.selector} completed`);
-      return decodeFromAbi(entryPointArtifact.returnTypes, returnWitness);
+      return witnessMapToFields(acirExecutionResult.returnWitness);
     } catch (err) {
       throw createSimulationError(err instanceof Error ? err : new Error('Unknown error during private execution'));
     }

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution.test.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution.test.ts
@@ -83,6 +83,6 @@ describe('Utility Execution test suite', () => {
 
     const result = await acirSimulator.runUtility(execRequest, [], []);
 
-    expect(result).toEqual(9n);
+    expect(result).toEqual([new Fr(9)]);
   }, 30_000);
 });

--- a/yarn-project/stdlib/src/tx/profiling.ts
+++ b/yarn-project/stdlib/src/tx/profiling.ts
@@ -1,12 +1,10 @@
 import { Fr } from '@aztec/foundation/fields';
-import { type ZodFor, optional } from '@aztec/foundation/schemas';
+import { type ZodFor, optional, schemas } from '@aztec/foundation/schemas';
 
 import { z } from 'zod';
 
-import type { AbiDecoded } from '../abi/decoder.js';
 import type { AztecNode } from '../interfaces/aztec-node.js';
 import { type PrivateExecutionStep, PrivateExecutionStepSchema } from '../kernel/private_kernel_prover_output.js';
-import { AbiDecodedSchema } from '../schemas/schemas.js';
 
 export type NodeStats = Partial<Record<keyof AztecNode, { times: number[] }>>;
 
@@ -127,21 +125,21 @@ export class TxProfileResult {
 
 export class UtilitySimulationResult {
   constructor(
-    public result: AbiDecoded,
+    public result: Fr[],
     public stats?: SimulationStats,
   ) {}
 
   static get schema(): ZodFor<UtilitySimulationResult> {
     return z
       .object({
-        result: AbiDecodedSchema,
+        result: z.array(schemas.Fr),
         stats: optional(SimulationStatsSchema),
       })
       .transform(({ result, stats }) => new UtilitySimulationResult(result, stats));
   }
 
   static random(): UtilitySimulationResult {
-    return new UtilitySimulationResult(Fr.random().toBigInt(), {
+    return new UtilitySimulationResult([Fr.random()], {
       nodeRPCCalls: { getBlockHeader: { times: [1] } },
       timings: {
         sync: 1,


### PR DESCRIPTION
Closes: https://linear.app/aztec-labs/issue/F-74/simulateutility-typings, https://github.com/AztecProtocol/aztec-packages/issues/11275

Improves the typings for utilities, both in PXE and in the wallet interface. Makes sure only encoded data goes through the wire (mimicking how simulateTx works) and lets the "consumers" do the decoding.
