### PR TITLE
fix: stale internal naming

### DIFF
--- a/playground/src/components/contract/Contract.tsx
+++ b/playground/src/components/contract/Contract.tsx
@@ -318,7 +318,7 @@ export function ContractComponent() {
           {functionAbis
             .filter(
               fn =>
-                !fn.isInternal &&
+                !fn.isOnlySelf &&
                 !FORBIDDEN_FUNCTIONS.includes(fn.name) &&
                 ((filters.private && fn.functionType === FunctionType.PRIVATE) ||
                   (filters.public && fn.functionType === FunctionType.PUBLIC) ||

--- a/yarn-project/aztec.js/src/contract/contract.test.ts
+++ b/yarn-project/aztec.js/src/contract/contract.test.ts
@@ -39,7 +39,7 @@ describe('Contract Class', () => {
         name: 'bar',
         isInitializer: false,
         functionType: FunctionType.PRIVATE,
-        isInternal: false,
+        isOnlySelf: false,
         isStatic: false,
         debugSymbols: '',
         parameters: [
@@ -68,7 +68,7 @@ describe('Contract Class', () => {
         isInitializer: false,
         isStatic: false,
         functionType: FunctionType.PUBLIC,
-        isInternal: false,
+        isOnlySelf: false,
         parameters: [
           {
             name: 'selector',
@@ -88,7 +88,7 @@ describe('Contract Class', () => {
         isInitializer: false,
         isStatic: false,
         functionType: FunctionType.UTILITY,
-        isInternal: false,
+        isOnlySelf: false,
         parameters: [
           {
             name: 'value',

--- a/yarn-project/aztec.js/src/fee/private_fee_payment_method.ts
+++ b/yarn-project/aztec.js/src/fee/private_fee_payment_method.ts
@@ -49,7 +49,7 @@ export class PrivateFeePaymentMethod implements FeePaymentMethod {
       const abi = {
         name: 'get_accepted_asset',
         functionType: FunctionType.PRIVATE,
-        isInternal: false,
+        isOnlySelf: false,
         isStatic: false,
         parameters: [],
         returnTypes: [

--- a/yarn-project/aztec.js/src/fee/public_fee_payment_method.ts
+++ b/yarn-project/aztec.js/src/fee/public_fee_payment_method.ts
@@ -43,7 +43,7 @@ export class PublicFeePaymentMethod implements FeePaymentMethod {
       const abi = {
         name: 'get_accepted_asset',
         functionType: FunctionType.PRIVATE,
-        isInternal: false,
+        isOnlySelf: false,
         isStatic: false,
         parameters: [],
         returnTypes: [

--- a/yarn-project/aztec.js/src/utils/authwit.ts
+++ b/yarn-project/aztec.js/src/utils/authwit.ts
@@ -169,7 +169,7 @@ export async function lookupValidity(
     name: 'lookup_validity',
     isInitializer: false,
     functionType: FunctionType.UTILITY,
-    isInternal: false,
+    isOnlySelf: false,
     isStatic: false,
     parameters: [{ name: 'message_hash', type: { kind: 'field' }, visibility: 'private' as ABIParameterVisibility }],
     returnTypes: [{ kind: 'boolean' }],
@@ -189,7 +189,7 @@ export async function lookupValidity(
     name: 'utility_is_consumable',
     isInitializer: false,
     functionType: FunctionType.UTILITY,
-    isInternal: false,
+    isOnlySelf: false,
     isStatic: false,
     parameters: [
       {
@@ -286,7 +286,7 @@ export class SetPublicAuthwitContractInteraction extends ContractFunctionInterac
       name: 'set_authorized',
       isInitializer: false,
       functionType: FunctionType.PUBLIC,
-      isInternal: true,
+      isOnlySelf: true,
       isStatic: false,
       parameters: [
         {

--- a/yarn-project/builder/src/contract-interface-gen/typescript.ts
+++ b/yarn-project/builder/src/contract-interface-gen/typescript.ts
@@ -284,7 +284,7 @@ async function generateEvents(events: any[] | undefined) {
  */
 export async function generateTypescriptContractInterface(input: ContractArtifact, artifactImportPath?: string) {
   const methods = getAllFunctionAbis(input)
-    .filter(f => !f.isInternal)
+    .filter(f => !f.isOnlySelf)
     .sort((a, b) => a.name.localeCompare(b.name))
     .map(generateMethod);
   const deploy = artifactImportPath && generateDeploy(input);

--- a/yarn-project/cli/src/cmds/contracts/inspect_contract.ts
+++ b/yarn-project/cli/src/cmds/contracts/inspect_contract.ts
@@ -29,16 +29,9 @@ export async function inspectContract(contractArtifactFile: string, debugLogger:
   log(`\tpublic bytecode commitment: ${contractClass.publicBytecodeCommitment.toString()}`);
   log(`\tpublic bytecode length: ${contractClass.packedBytecode.length} bytes (${bytecodeLengthInFields} fields)`);
 
-  const externalFunctions = contractFns.filter(f => !f.isInternal);
-  if (externalFunctions.length > 0) {
-    log(`\nExternal functions:`);
-    await Promise.all(externalFunctions.map(f => logFunction(f, log)));
-  }
-
-  const internalFunctions = contractFns.filter(f => f.isInternal);
-  if (internalFunctions.length > 0) {
-    log(`\nInternal functions:`);
-    await Promise.all(internalFunctions.map(f => logFunction(f, log)));
+  if (contractFns.length > 0) {
+    log(`\nExternal contract functions:`);
+    await Promise.all(contractFns.map(f => logFunction(f, log)));
   }
 }
 

--- a/yarn-project/entrypoints/src/account_entrypoint.ts
+++ b/yarn-project/entrypoints/src/account_entrypoint.ts
@@ -104,7 +104,7 @@ export class DefaultAccountEntrypoint implements EntrypointInterface {
       name: 'entrypoint',
       isInitializer: false,
       functionType: 'private',
-      isInternal: false,
+      isOnlySelf: false,
       isStatic: false,
       parameters: [
         {

--- a/yarn-project/entrypoints/src/default_multi_call_entrypoint.ts
+++ b/yarn-project/entrypoints/src/default_multi_call_entrypoint.ts
@@ -50,7 +50,7 @@ export class DefaultMultiCallEntrypoint implements EntrypointInterface {
       name: 'entrypoint',
       isInitializer: false,
       functionType: 'private',
-      isInternal: false,
+      isOnlySelf: false,
       isStatic: false,
       parameters: [
         {

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution.test.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution.test.ts
@@ -797,11 +797,11 @@ describe('Private Execution test suite', () => {
   });
 
   describe('enqueued calls', () => {
-    it.each([false, true])('parent should enqueue call to child (internal %p)', async isInternal => {
+    it.each([false, true])('parent should enqueue call to child (is #[only_self]: %p)', async isOnlySelf => {
       const childContractArtifact = structuredClone(ChildContractArtifact);
       const childFunctionArtifact = childContractArtifact.functions.find(fn => fn.name === 'public_dispatch')!;
       expect(childFunctionArtifact).toBeDefined();
-      childFunctionArtifact.isInternal = isInternal;
+      childFunctionArtifact.isOnlySelf = isOnlySelf;
 
       const childAddress = await AztecAddress.random();
       await mockContractInstance(childContractArtifact, childAddress);

--- a/yarn-project/stdlib/src/abi/abi.ts
+++ b/yarn-project/stdlib/src/abi/abi.ts
@@ -173,8 +173,8 @@ export interface FunctionAbi {
   name: string;
   /** Whether the function is secret. */
   functionType: FunctionType;
-  /** Whether the function is internal. */
-  isInternal: boolean;
+  /** Whether the function is marked as `#[only_self]` and hence callable only from within the contract. */
+  isOnlySelf: boolean;
   /** Whether the function can alter state or not */
   isStatic: boolean;
   /** Function parameters. */
@@ -190,7 +190,7 @@ export interface FunctionAbi {
 export const FunctionAbiSchema = z.object({
   name: z.string(),
   functionType: z.nativeEnum(FunctionType),
-  isInternal: z.boolean(),
+  isOnlySelf: z.boolean(),
   isStatic: z.boolean(),
   isInitializer: z.boolean(),
   parameters: z.array(z.object({ name: z.string(), type: AbiTypeSchema, visibility: z.enum(ABIParameterVisibility) })),
@@ -501,7 +501,7 @@ export function emptyFunctionAbi(): FunctionAbi {
   return {
     name: '',
     functionType: FunctionType.PRIVATE,
-    isInternal: false,
+    isOnlySelf: false,
     isStatic: false,
     parameters: [],
     returnTypes: [],

--- a/yarn-project/stdlib/src/abi/contract_artifact.ts
+++ b/yarn-project/stdlib/src/abi/contract_artifact.ts
@@ -17,7 +17,7 @@ import {
 } from '../abi/index.js';
 import {
   AZTEC_INITIALIZER_ATTRIBUTE,
-  AZTEC_INTERNAL_ATTRIBUTE,
+  AZTEC_ONLY_SELF_ATTRIBUTE,
   AZTEC_PRIVATE_ATTRIBUTE,
   AZTEC_PUBLIC_ATTRIBUTE,
   AZTEC_UTILITY_ATTRIBUTE,
@@ -152,7 +152,7 @@ function generateFunctionAbi(fn: NoirCompiledContractFunction, contract: NoirCom
     );
   }
   const functionType = getFunctionType(fn);
-  const isInternal = fn.custom_attributes.includes(AZTEC_INTERNAL_ATTRIBUTE);
+  const isOnlySelf = fn.custom_attributes.includes(AZTEC_ONLY_SELF_ATTRIBUTE);
   const isStatic = fn.custom_attributes.includes(AZTEC_VIEW_ATTRIBUTE);
 
   // If the function is not a utility function, the first item is inputs or CallContext which we should omit
@@ -185,7 +185,7 @@ function generateFunctionAbi(fn: NoirCompiledContractFunction, contract: NoirCom
   return {
     name: fn.name,
     functionType,
-    isInternal,
+    isOnlySelf,
     isStatic,
     isInitializer: fn.custom_attributes.includes(AZTEC_INITIALIZER_ATTRIBUTE),
     parameters,

--- a/yarn-project/stdlib/src/abi/encoder.test.ts
+++ b/yarn-project/stdlib/src/abi/encoder.test.ts
@@ -11,7 +11,7 @@ describe('abi/encoder', () => {
     const abi: FunctionAbi = {
       name: 'constructor',
       functionType: FunctionType.PRIVATE,
-      isInternal: false,
+      isOnlySelf: false,
       isInitializer: true,
       isStatic: false,
       parameters: [
@@ -39,7 +39,7 @@ describe('abi/encoder', () => {
       name: 'constructor',
       isInitializer: true,
       functionType: FunctionType.PRIVATE,
-      isInternal: false,
+      isOnlySelf: false,
       isStatic: false,
       parameters: [
         {
@@ -65,7 +65,7 @@ describe('abi/encoder', () => {
       name: 'constructor',
       isInitializer: true,
       functionType: FunctionType.PRIVATE,
-      isInternal: false,
+      isOnlySelf: false,
       isStatic: false,
       parameters: [
         {
@@ -92,7 +92,7 @@ describe('abi/encoder', () => {
       name: 'constructor',
       isInitializer: true,
       functionType: FunctionType.PRIVATE,
-      isInternal: false,
+      isOnlySelf: false,
       isStatic: false,
       parameters: [
         {
@@ -131,7 +131,7 @@ describe('abi/encoder', () => {
       name: 'constructor',
       isInitializer: true,
       functionType: FunctionType.PRIVATE,
-      isInternal: false,
+      isOnlySelf: false,
       isStatic: false,
       parameters: [
         {
@@ -164,7 +164,7 @@ describe('abi/encoder', () => {
       name: 'constructor',
       isInitializer: true,
       functionType: FunctionType.PRIVATE,
-      isInternal: false,
+      isOnlySelf: false,
       isStatic: false,
       parameters: [
         {
@@ -188,7 +188,7 @@ describe('abi/encoder', () => {
       name: 'constructor',
       isInitializer: true,
       functionType: FunctionType.PRIVATE,
-      isInternal: false,
+      isOnlySelf: false,
       isStatic: false,
       parameters: [
         {
@@ -213,7 +213,7 @@ describe('abi/encoder', () => {
       name: 'constructor',
       isInitializer: true,
       functionType: FunctionType.PRIVATE,
-      isInternal: false,
+      isOnlySelf: false,
       isStatic: false,
       parameters: [
         {
@@ -240,7 +240,7 @@ describe('abi/encoder', () => {
     const testFunctionAbi: FunctionAbi = {
       name: 'test',
       functionType: FunctionType.PRIVATE,
-      isInternal: false,
+      isOnlySelf: false,
       isInitializer: false,
       isStatic: false,
       parameters: [
@@ -305,7 +305,7 @@ describe('abi/encoder', () => {
     const testFunctionAbi: FunctionAbi = {
       name: 'test',
       functionType: FunctionType.PRIVATE,
-      isInternal: false,
+      isOnlySelf: false,
       isInitializer: false,
       isStatic: false,
       parameters: [
@@ -394,7 +394,7 @@ describe('abi/encoder', () => {
     const testFunctionAbi: FunctionAbi = {
       name: 'test',
       functionType: FunctionType.PRIVATE,
-      isInternal: false,
+      isOnlySelf: false,
       isInitializer: false,
       isStatic: false,
       parameters: [

--- a/yarn-project/stdlib/src/contract/contract_address.test.ts
+++ b/yarn-project/stdlib/src/contract/contract_address.test.ts
@@ -36,7 +36,7 @@ describe('ContractAddress', () => {
     const mockInitFn: FunctionAbi = {
       functionType: FunctionType.PRIVATE,
       isInitializer: false,
-      isInternal: false,
+      isOnlySelf: false,
       isStatic: false,
       name: 'fun',
       parameters: [{ name: 'param1', type: { kind: 'boolean' }, visibility: 'private' }],

--- a/yarn-project/stdlib/src/noir/index.ts
+++ b/yarn-project/stdlib/src/noir/index.ts
@@ -11,8 +11,7 @@ import type {
 export const AZTEC_PRIVATE_ATTRIBUTE = 'abi_private';
 export const AZTEC_PUBLIC_ATTRIBUTE = 'abi_public';
 export const AZTEC_UTILITY_ATTRIBUTE = 'abi_utility';
-// TODO(F-142): Fix the naming here.
-export const AZTEC_INTERNAL_ATTRIBUTE = 'abi_only_self';
+export const AZTEC_ONLY_SELF_ATTRIBUTE = 'abi_only_self';
 export const AZTEC_INITIALIZER_ATTRIBUTE = 'abi_initializer';
 export const AZTEC_VIEW_ATTRIBUTE = 'abi_view';
 


### PR DESCRIPTION
In this PR I fix a stale naming where `only_self` was referred to as `internal`.