### PR TITLE
feat(avm): Follow up: C++ simulator hint collecting dbs

### DIFF
--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/lib/hinting_dbs.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/lib/hinting_dbs.cpp
@@ -54,7 +54,8 @@ std::optional<ContractClass> HintingContractsDB::get_contract_class(const Contra
             .classId = class_id,
             .artifactHash = klass->artifact_hash,
             .privateFunctionsRoot = klass->private_functions_root,
-            .packedBytecode = std::move(klass->packed_bytecode),
+            // TODO(fcarreiro): find out why moving things here breaks things
+            .packedBytecode = klass->packed_bytecode,
         };
     }
 

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation_helper.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation_helper.cpp
@@ -479,7 +479,7 @@ TxSimulationResult AvmSimulationHelper::simulate_fast_with_existing_ws(
         auto starting_tree_roots = raw_merkle_db.get_tree_roots();
         HintingContractsDB hinting_contract_db(raw_contract_db);
         HintingRawDB hinting_merkle_db(raw_merkle_db);
-        auto result = simulate_fast(raw_contract_db, raw_merkle_db, tx, global_variables, protocol_contracts);
+        auto result = simulate_fast(hinting_contract_db, hinting_merkle_db, tx, global_variables, protocol_contracts);
         // TODO(MW): move to simulate_fast?
         ExecutionHints collected_hints = ExecutionHints{ .globalVariables = global_variables,
                                                          .tx = tx,


### PR DESCRIPTION
Follow-up to #18130:

- Actually use `hinting_dbs` in `simulate_fast_with_existing_ws` (whoops)
- No longer use `std::move` for the contract class hint (this made the minimal tx revert)

