### PR TITLE
fix(docs): Fix nightly version builds

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -46,6 +46,29 @@ You can add the aztec version to a docs page without the `v` prefix with `#inclu
 
 When docusaurus builds, it looks for the `versions.json` file, and builds the versions in there, together with the version in `docs`.
 
+### Version Configuration
+
+The `docusaurus.config.js` file uses dynamic version lookup instead of hard-coded array indices to gracefully handle version changes. This is critical for the nightly docs cleanup workflow, which removes old nightly versions from `versions.json`.
+
+This means that the docs versions must contain the following strings to be picked up correctly. This happens automatically for "nightly" and "devnet" versions with version tagging scheme, but "ignition" must be added manually when cutting an ignition release.
+
+**Dynamic Lookup Approach:**
+
+```javascript
+const nightlyVersion = versions.find((v) => v.includes("nightly"));
+const devnetVersion = versions.find((v) => v.includes("devnet"));
+const ignitionVersion = versions.find((v) => v.includes("ignition"));
+```
+
+This ensures that:
+
+- When nightly versions are removed by the cleanup script, the build doesn't break
+- Version configurations are conditionally included only if they exist
+- Array index shifts don't cause mismatched version configurations
+- The llms.txt plugin always points to the correct version (devnet)
+
+**Why this matters:** The [nightly docs workflow](../.github/workflows/nightly-docs-release.yml) runs `cleanup_nightly_versions.sh` before creating new versioned docs. Without dynamic lookup, removing versions from `versions.json` would cause array indices like `versions[0]` and `versions[1]` to point to wrong versions, breaking the build.
+
 ## Releases
 
 A new docs site is published on every merge to the next branch.

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -19,6 +19,11 @@ const fs = require("fs");
 const macros = require("./src/katex-macros.js");
 const versions = require("./versions.json");
 
+// Find specific versions dynamically to avoid array index issues
+const nightlyVersion = versions.find(v => v.includes("nightly"));
+const devnetVersion = versions.find(v => v.includes("devnet"));
+const ignitionVersion = versions.find(v => v.includes("ignition"));
+
 const config = {
   title: "Privacy-first zkRollup | Aztec Documentation",
   tagline:
@@ -58,7 +63,7 @@ const config = {
           sidebarPath: "./sidebars.js",
           editUrl: (params) => {
             return (
-              `https://github.com/AztecProtocol/aztec-packages/edit/master/docs/docs/` +
+              `https://github.com/AztecProtocol/aztec-packages/edit/next/docs/docs/` +
               params.docPath
             );
           },
@@ -69,19 +74,21 @@ const config = {
           // Netlify sets CONTEXT
           includeCurrentVersion: process.env.CONTEXT !== "production",
           // Ignition should be the default version
-          lastVersion: versions[3],
+          lastVersion: ignitionVersion,
           versions: {
-            [versions[0]]: {
-              ...(versions[0].includes("nightly") && {
+            ...(nightlyVersion && {
+              [nightlyVersion]: {
                 path: "nightly",
                 banner: "unreleased",
-              }),
-            },
-            [versions[1]]: {
-              label: "Devnet (v3.0.0-devnet.5)",
-              path: "devnet",
-              banner: "none",
-            },
+              },
+            }),
+            ...(devnetVersion && {
+              [devnetVersion]: {
+                label: "Devnet (v3.0.0-devnet.5)",
+                path: "devnet",
+                banner: "none",
+              },
+            }),
             "v2.1.4": {
               path: "testnet",
               label: "Testnet (v2.1.4)",
@@ -132,10 +139,10 @@ const config = {
       {
         generateLLMsTxt: true,
         generateLLMsFullTxt: true,
-        docsDir: `versioned_docs/version-${versions[0]}/`,
+        docsDir: devnetVersion ? `versioned_docs/version-${devnetVersion}/` : `versioned_docs/version-${versions[0]}/`,
         title: "Aztec Protocol Documentation",
         excludeImports: true,
-        version: versions[0],
+        version: devnetVersion || versions[0],
         pathTransformation: {
           ignorePaths: ["docs"],
         },


### PR DESCRIPTION
There was a broken url between versions that was causeing the build to fail. This should fix it.
