### PR TITLE
chore: ACIR audit - part 1

### DIFF
--- a/barretenberg/acir_tests/bootstrap.sh
+++ b/barretenberg/acir_tests/bootstrap.sh
@@ -115,7 +115,6 @@ function build {
     rm -rf acir_tests/{diamond_deps_0,workspace,workspace_default_member,regression_7323}
     # These use folding, which is not currently supported.
     rm -rf acir_tests/{fold_call_witness_condition,fold_after_inlined_calls,fold_complex_outputs,fold_basic_nested_call,fold_numeric_generic_poseidon,fold_fibonacci,fold_basic,fold_2_to_17,fold_distinct_return}
-    rm -rf acir_tests/{ecdsa_secp256k1_invalid_pub_key_in_inactive_branch,ecdsa_secp256r1_invalid_pub_key_in_inactive_branch}
     # These are breaking with:
     # Failed to solve program: 'Failed to solve blackbox function: embedded_curve_add, reason: Infinite input: embedded_curve_add(infinity, infinity)'
     rm -rf acir_tests/{regression_5045,regression_7744}

--- a/barretenberg/acir_tests/bootstrap.sh
+++ b/barretenberg/acir_tests/bootstrap.sh
@@ -113,7 +113,8 @@ function build {
     cp -R ../../noir/noir-repo/test_programs/execution_success acir_tests
     # Running these requires extra gluecode so they're skipped.
     rm -rf acir_tests/{diamond_deps_0,workspace,workspace_default_member,regression_7323}
-
+    # These use folding, which is not currently supported.
+    rm -rf acir_tests/{fold_call_witness_condition,fold_after_inlined_calls,fold_complex_outputs,fold_basic_nested_call,fold_numeric_generic_poseidon,fold_fibonacci,fold_basic,fold_2_to_17,fold_distinct_return}
     rm -rf acir_tests/{ecdsa_secp256k1_invalid_pub_key_in_inactive_branch,ecdsa_secp256r1_invalid_pub_key_in_inactive_branch}
     # These are breaking with:
     # Failed to solve program: 'Failed to solve blackbox function: embedded_curve_add, reason: Infinite input: embedded_curve_add(infinity, infinity)'

--- a/barretenberg/cpp/src/barretenberg/acir_formal_proofs/acir_loader.cpp
+++ b/barretenberg/cpp/src/barretenberg/acir_formal_proofs/acir_loader.cpp
@@ -30,7 +30,7 @@ AcirToSmtLoader::AcirToSmtLoader(std::string filename)
 {
     this->acir_program_buf = readFile(filename);
     this->instruction_name = filename;
-    this->constraint_system = acir_format::program_buf_to_acir_format(this->acir_program_buf, false).at(0);
+    this->constraint_system = acir_format::circuit_buf_to_acir_format(std::move(this->acir_program_buf));
     this->circuit_buf = this->get_circuit_builder().export_circuit();
 }
 

--- a/barretenberg/cpp/src/barretenberg/acir_formal_proofs/acir_loader.cpp
+++ b/barretenberg/cpp/src/barretenberg/acir_formal_proofs/acir_loader.cpp
@@ -28,9 +28,8 @@ std::vector<uint8_t> readFile(std::string filename)
 
 AcirToSmtLoader::AcirToSmtLoader(std::string filename)
 {
-    this->acir_program_buf = readFile(filename);
     this->instruction_name = filename;
-    this->constraint_system = acir_format::circuit_buf_to_acir_format(std::move(this->acir_program_buf));
+    this->constraint_system = acir_format::circuit_buf_to_acir_format(readFile(filename));
     this->circuit_buf = this->get_circuit_builder().export_circuit();
 }
 

--- a/barretenberg/cpp/src/barretenberg/acir_formal_proofs/acir_loader.hpp
+++ b/barretenberg/cpp/src/barretenberg/acir_formal_proofs/acir_loader.hpp
@@ -96,7 +96,6 @@ class AcirToSmtLoader {
 
   private:
     std::string instruction_name;              ///< Name of the instruction/filename being processed
-    std::vector<uint8_t> acir_program_buf;     ///< Buffer containing the raw ACIR program data read from file
     acir_format::AcirFormat constraint_system; ///< The parsed constraint system from the ACIR program
     msgpack::sbuffer circuit_buf;              ///< Buffer for circuit serialization using MessagePack
 };

--- a/barretenberg/cpp/src/barretenberg/api/acir_format_getters.cpp
+++ b/barretenberg/cpp/src/barretenberg/api/acir_format_getters.cpp
@@ -8,7 +8,7 @@ namespace bb {
 acir_format::WitnessVector get_witness(std::string const& witness_path)
 {
     auto witness_data = get_bytecode(witness_path);
-    return acir_format::witness_buf_to_witness_data(std::move(witness_data));
+    return acir_format::witness_buf_to_witness_vector(std::move(witness_data));
 }
 
 acir_format::AcirFormat get_constraint_system(std::string const& bytecode_path)

--- a/barretenberg/cpp/src/barretenberg/api/acir_format_getters.cpp
+++ b/barretenberg/cpp/src/barretenberg/api/acir_format_getters.cpp
@@ -17,16 +17,4 @@ acir_format::AcirFormat get_constraint_system(std::string const& bytecode_path)
     return acir_format::circuit_buf_to_acir_format(std::move(bytecode));
 }
 
-acir_format::WitnessVectorStack get_witness_stack(std::string const& witness_path)
-{
-    auto witness_data = get_bytecode(witness_path);
-    return acir_format::witness_buf_to_witness_stack(std::move(witness_data));
-}
-
-std::vector<acir_format::AcirFormat> get_constraint_systems(std::string const& bytecode_path)
-{
-    auto bytecode = get_bytecode(bytecode_path);
-    return acir_format::program_buf_to_acir_format(std::move(bytecode));
-}
-
 } // namespace bb

--- a/barretenberg/cpp/src/barretenberg/api/acir_format_getters.hpp
+++ b/barretenberg/cpp/src/barretenberg/api/acir_format_getters.hpp
@@ -5,6 +5,4 @@
 namespace bb {
 acir_format::WitnessVector get_witness(std::string const& witness_path);
 acir_format::AcirFormat get_constraint_system(std::string const& bytecode_path);
-acir_format::WitnessVectorStack get_witness_stack(std::string const& witness_path);
-std::vector<acir_format::AcirFormat> get_constraint_systems(std::string const& bytecode_path);
 } // namespace bb

--- a/barretenberg/cpp/src/barretenberg/bbapi/bbapi_chonk.cpp
+++ b/barretenberg/cpp/src/barretenberg/bbapi/bbapi_chonk.cpp
@@ -49,7 +49,7 @@ ChonkAccumulate::Response ChonkAccumulate::execute(BBApiRequest& request) &&
         throw_or_abort("No circuit loaded. Call ChonkLoad first.");
     }
 
-    acir_format::WitnessVector witness_data = acir_format::witness_buf_to_witness_data(std::move(witness));
+    acir_format::WitnessVector witness_data = acir_format::witness_buf_to_witness_vector(std::move(witness));
     acir_format::AcirProgram program{ std::move(request.loaded_circuit_constraints.value()), std::move(witness_data) };
 
     const acir_format::ProgramMetadata metadata{ .ivc = request.ivc_in_progress };

--- a/barretenberg/cpp/src/barretenberg/bbapi/bbapi_ultra_honk.cpp
+++ b/barretenberg/cpp/src/barretenberg/bbapi/bbapi_ultra_honk.cpp
@@ -46,7 +46,7 @@ Circuit _compute_circuit(std::vector<uint8_t>&& bytecode, std::vector<uint8_t>&&
     acir_format::AcirProgram program{ acir_format::circuit_buf_to_acir_format(std::move(bytecode)) };
 
     if (!witness.empty()) {
-        program.witness = acir_format::witness_buf_to_witness_data(std::move(witness));
+        program.witness = acir_format::witness_buf_to_witness_vector(std::move(witness));
     }
     return acir_format::create_circuit<Circuit>(program, metadata);
 }

--- a/barretenberg/cpp/src/barretenberg/chonk/private_execution_steps.cpp
+++ b/barretenberg/cpp/src/barretenberg/chonk/private_execution_steps.cpp
@@ -126,7 +126,7 @@ void PrivateExecutionSteps::parse(std::vector<PrivateExecutionStepRaw>&& steps)
         // TODO(#7371) there is a lot of copying going on in bincode. We need the generated bincode code to
         // use spans instead of vectors.
         acir_format::AcirFormat constraints = acir_format::circuit_buf_to_acir_format(std::move(step.bytecode));
-        acir_format::WitnessVector witness = acir_format::witness_buf_to_witness_data(std::move(step.witness));
+        acir_format::WitnessVector witness = acir_format::witness_buf_to_witness_vector(std::move(step.witness));
 
         folding_stack[i] = { std::move(constraints), std::move(witness) };
         if (step.vk.empty()) {

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_integration.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_integration.test.cpp
@@ -1,4 +1,5 @@
 #include "barretenberg/chonk/chonk.hpp"
+#include "barretenberg/common/get_bytecode.hpp"
 #ifndef __wasm__
 #include "barretenberg/chonk/private_execution_steps.hpp"
 #include "barretenberg/circuit_checker/circuit_checker.hpp"
@@ -22,22 +23,18 @@ class AcirIntegrationTest : public ::testing::Test {
         return file.good();
     }
 
-    static acir_format::AcirProgramStack get_program_stack_data_from_test_file(const std::string& test_program_name)
+    static acir_format::AcirProgram get_program_data_from_test_file(const std::string& test_program_name)
     {
         std::string base_path = "../../acir_tests/acir_tests/" + test_program_name + "/target";
         std::string bytecode_path = base_path + "/program.json";
         std::string witness_path = base_path + "/witness.gz";
 
-        return acir_format::get_acir_program_stack(bytecode_path, witness_path);
-    }
+        std::vector<uint8_t> bytecode = get_bytecode(bytecode_path);
+        std::vector<uint8_t> witness = get_bytecode(witness_path);
+        acir_format::AcirFormat program = acir_format::circuit_buf_to_acir_format(std::move(bytecode));
+        acir_format::WitnessVector witness_vector = acir_format::witness_buf_to_witness_data(std::move(witness));
 
-    static acir_format::AcirProgram get_program_data_from_test_file(const std::string& test_program_name)
-    {
-        auto program_stack = get_program_stack_data_from_test_file(test_program_name);
-        BB_ASSERT_EQ(program_stack.size(),
-                     static_cast<size_t>(1)); // Otherwise this method will not return full stack data
-
-        return program_stack.back();
+        return { program, witness_vector };
     }
 
     template <class Flavor> bool prove_and_verify_honk(Flavor::CircuitBuilder& builder)
@@ -99,11 +96,6 @@ class AcirIntegrationTest : public ::testing::Test {
 };
 
 class AcirIntegrationSingleTest : public AcirIntegrationTest, public testing::WithParamInterface<std::string> {};
-
-class AcirIntegrationFoldingTest : public AcirIntegrationTest, public testing::WithParamInterface<std::string> {
-  protected:
-    static void SetUpTestSuite() { bb::srs::init_file_crs_factory(bb::srs::bb_crs_path()); }
-};
 
 TEST_P(AcirIntegrationSingleTest, DISABLED_ProveAndVerifyProgram)
 {
@@ -319,33 +311,6 @@ INSTANTIATE_TEST_SUITE_P(AcirTests,
                                          //  "workspace",
                                          //  "workspace_default_member",
                                          "xor"));
-
-TEST_P(AcirIntegrationFoldingTest, DISABLED_ProveAndVerifyProgramStack)
-{
-    using Flavor = MegaFlavor;
-    using Builder = Flavor::CircuitBuilder;
-
-    std::string test_name = GetParam();
-    info("Test: ", test_name);
-
-    auto program_stack = get_program_stack_data_from_test_file(test_name);
-
-    while (!program_stack.empty()) {
-        auto program = program_stack.back();
-
-        // Construct a bberg circuit from the acir representation
-        auto builder = acir_format::create_circuit<Builder>(program);
-
-        // Construct and verify Honk proof for the individidual circuit
-        EXPECT_TRUE(prove_and_verify_honk<Flavor>(builder));
-
-        program_stack.pop_back();
-    }
-}
-
-INSTANTIATE_TEST_SUITE_P(AcirTests,
-                         AcirIntegrationFoldingTest,
-                         testing::Values("fold_basic", "fold_basic_nested_call"));
 
 /**
  * @brief A basic test of a circuit generated in noir that makes use of the databus

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_integration.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_integration.test.cpp
@@ -32,7 +32,7 @@ class AcirIntegrationTest : public ::testing::Test {
         std::vector<uint8_t> bytecode = get_bytecode(bytecode_path);
         std::vector<uint8_t> witness = get_bytecode(witness_path);
         acir_format::AcirFormat program = acir_format::circuit_buf_to_acir_format(std::move(bytecode));
-        acir_format::WitnessVector witness_vector = acir_format::witness_buf_to_witness_data(std::move(witness));
+        acir_format::WitnessVector witness_vector = acir_format::witness_buf_to_witness_vector(std::move(witness));
 
         return { program, witness_vector };
     }

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_to_constraint_buf.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_to_constraint_buf.cpp
@@ -27,15 +27,17 @@ namespace acir_format {
 
 using namespace bb;
 
-/**
- * @brief Deserialize `buf` either based on the first byte interpreted as a
-          Noir serialization format byte, or falling back to `bincode` if
-          the format cannot be recognized. Currently only `msgpack` format
-          is expected, or the legacy `bincode` format.
- * @note Due to the lack of exception handling available to us in Wasm we can't
- *       try `bincode` format and if it fails try `msgpack`; instead we have to
- *       make a decision and commit to it.
- */
+uint256_t from_be_bytes(std::vector<uint8_t> const& bytes)
+{
+    BB_ASSERT_EQ(bytes.size(), 32U, "uint256 constructed from bytes array with invalid length");
+    uint256_t result = 0;
+    for (uint8_t byte : bytes) {
+        result <<= 8;
+        result |= byte;
+    }
+    return result;
+}
+
 template <typename T>
 T deserialize_any_format(std::vector<uint8_t>&& buf,
                          std::function<T(msgpack::object const&)> decode_msgpack,
@@ -70,6 +72,7 @@ T deserialize_any_format(std::vector<uint8_t>&& buf,
                 // In experiments bincode data was parsed as 0.
                 // All the top level formats we look for are MAP types.
                 if (o.type == msgpack::type::MAP) {
+                    BB_ASSERT(false, "Msgpack is not currently supported.");
                     return decode_msgpack(o);
                 }
             }
@@ -82,13 +85,60 @@ T deserialize_any_format(std::vector<uint8_t>&& buf,
     return decode_bincode(std::move(buf));
 }
 
-/**
- * @brief Deserializes a `Program` from bytes, trying `msgpack` or `bincode` formats.
- * @note Ignores the Brillig parts of the bytecode when using `msgpack`.
- */
-Acir::Program deserialize_program(std::vector<uint8_t>&& buf)
+AcirFormat circuit_serde_to_acir_format(Acir::Circuit const& circuit)
 {
-    return deserialize_any_format<Acir::Program>(
+    AcirFormat af;
+    // `varnum` is the true number of variables, thus we add one to the index which starts at zero
+    af.varnum = circuit.current_witness_index + 1;
+    af.num_acir_opcodes = static_cast<uint32_t>(circuit.opcodes.size());
+    af.public_inputs = join({ transform::map(circuit.public_parameters.value, [](auto e) { return e.value; }),
+                              transform::map(circuit.return_values.value, [](auto e) { return e.value; }) });
+    // Map to a pair of: BlockConstraint, and list of opcodes associated with that BlockConstraint
+    // NOTE: We want to deterministically visit this map, so unordered_map should not be used.
+    std::map<uint32_t, std::pair<BlockConstraint, std::vector<size_t>>> block_id_to_block_constraint;
+    for (size_t i = 0; i < circuit.opcodes.size(); ++i) {
+        const auto& gate = circuit.opcodes[i];
+        std::visit(
+            [&](auto&& arg) {
+                using T = std::decay_t<decltype(arg)>;
+                if constexpr (std::is_same_v<T, Acir::Opcode::AssertZero>) {
+                    handle_arithmetic(arg, af, i);
+                } else if constexpr (std::is_same_v<T, Acir::Opcode::BlackBoxFuncCall>) {
+                    handle_blackbox_func_call(arg, af, i);
+                } else if constexpr (std::is_same_v<T, Acir::Opcode::MemoryInit>) {
+                    auto block = handle_memory_init(arg);
+                    uint32_t block_id = arg.block_id.value;
+                    block_id_to_block_constraint[block_id] = { block, /*opcode_indices=*/{ i } };
+                } else if constexpr (std::is_same_v<T, Acir::Opcode::MemoryOp>) {
+                    auto block = block_id_to_block_constraint.find(arg.block_id.value);
+                    if (block == block_id_to_block_constraint.end()) {
+                        throw_or_abort("unitialized MemoryOp");
+                    }
+                    handle_memory_op(arg, af, block->second.first);
+                    block->second.second.push_back(i);
+                } else if constexpr (std::is_same_v<T, Acir::Opcode::BrilligCall>) {
+                    info("ENCOUNTERED BRILLIG CALL");
+                } else {
+                    bb::assert_failure("circuit_serde_to_acir_format: Unrecognized Acir Opcode.");
+                }
+            },
+            gate.value);
+    }
+    for (const auto& [block_id, block] : block_id_to_block_constraint) {
+        // Note: the trace will always be empty for ReturnData since it cannot be explicitly read from in noir
+        if (!block.first.trace.empty() || block.first.type == BlockType::ReturnData ||
+            block.first.type == BlockType::CallData) {
+            af.block_constraints.push_back(block.first);
+            af.original_opcode_indices.block_constraints.push_back(block.second);
+        }
+    }
+    return af;
+}
+
+AcirFormat circuit_buf_to_acir_format(std::vector<uint8_t>&& buf)
+{
+    // We need to deserialize into Acir::Program first because the buffer returned by Noir has this structure
+    auto program = deserialize_any_format<Acir::Program>(
         std::move(buf),
         [](auto o) -> Acir::Program {
             Acir::Program program;
@@ -105,14 +155,15 @@ Acir::Program deserialize_program(std::vector<uint8_t>&& buf)
             return program;
         },
         &Acir::Program::bincodeDeserialize);
+    BB_ASSERT_EQ(program.functions.size(), 1U, "circuit_buf_to_acir_format: expected single function in ACIR program");
+
+    return circuit_serde_to_acir_format(program.functions[0]);
 }
 
-/**
- * @brief Deserializes a `WitnessStack` from bytes, trying `msgpack` or `bincode` formats.
- */
-Witnesses::WitnessStack deserialize_witness_stack(std::vector<uint8_t>&& buf)
+WitnessVector witness_buf_to_witness_data(std::vector<uint8_t>&& buf)
 {
-    return deserialize_any_format<Witnesses::WitnessStack>(
+    // We need to deserialize into WitnessStack first because the buffer returned by Noir has this structure
+    auto witness_stack = deserialize_any_format<Witnesses::WitnessStack>(
         std::move(buf),
         [](auto o) {
             Witnesses::WitnessStack witness_stack;
@@ -125,17 +176,63 @@ Witnesses::WitnessStack deserialize_witness_stack(std::vector<uint8_t>&& buf)
             return witness_stack;
         },
         &Witnesses::WitnessStack::bincodeDeserialize);
+    BB_ASSERT_EQ(
+        witness_stack.stack.size(), 1U, "witness_buf_to_witness_data: expected single WitnessMap in WitnessStack");
+
+    return witness_map_to_witness_vector(witness_stack.stack[0].witness);
 }
 
-// TODO(tom): clean this up.
-uint256_t from_be_bytes(std::vector<uint8_t> const& bytes)
+WitnessVector witness_map_to_witness_vector(Witnesses::WitnessMap const& witness_map)
 {
-    BB_ASSERT_EQ(bytes.size(), 32U, "uint256 constructed from bytes array with invalid length");
-    uint256_t result = 0;
-    for (uint8_t byte : bytes) {
-        result <<= 8;
-        result |= byte;
+    // We need to enforce that:
+    //  - the witness map is in increasing order of witness index
+    //  - all the witness indices are positive
+    bool is_witness_map_increasing = true;
+    uint32_t previous_index = 0; // starting at 0 to check that witness indices are positive
+
+    WitnessVector witness_vector;
+    for (size_t index = 0; const auto& e : witness_map.value) {
+        is_witness_map_increasing &= previous_index <= e.first.value;
+        previous_index = e.first.value;
+
+        // ACIR uses a sparse format for WitnessMap where unused witness indices may be left unassigned.
+        // To ensure that witnesses sit at the correct indices in the `WitnessVector`, we fill any indices
+        // which do not exist within the `WitnessMap` with the dummy value of zero.
+        while (index < e.first.value) {
+            witness_vector.emplace_back(0);
+            index++;
+        }
+        witness_vector.emplace_back(from_be_bytes(e.second));
+        index++;
     }
+
+    BB_ASSERT(is_witness_map_increasing, "witness_map_to_witness_vector: WitnessMap is not ordered by witness index");
+
+    return witness_vector;
+}
+
+WitnessOrConstant<bb::fr> parse_input(Acir::FunctionInput input)
+{
+    WitnessOrConstant<bb::fr> result = std::visit(
+        [&](auto&& e) {
+            using T = std::decay_t<decltype(e)>;
+            if constexpr (std::is_same_v<T, Acir::FunctionInput::Witness>) {
+                return WitnessOrConstant<bb::fr>{
+                    .index = e.value.value,
+                    .value = bb::fr::zero(),
+                    .is_constant = false,
+                };
+            } else if constexpr (std::is_same_v<T, Acir::FunctionInput::Constant>) {
+                return WitnessOrConstant<bb::fr>{
+                    .index = bb::stdlib::IS_CONSTANT,
+                    .value = from_be_bytes(e.value),
+                    .is_constant = true,
+                };
+            } else {
+                bb::assert_failure("acir_format::parse_input: unrecognized Acir::FunctionInput variant.");
+            }
+        },
+        input.value);
     return result;
 }
 
@@ -216,10 +313,6 @@ poly_triple serialize_arithmetic_gate(Acir::Expression const& arg)
     return pt;
 }
 
-/// @brief
-
-/// @param scaling The scaling factor to apply to the linear term.
-/// @note This function is used internally to update the fields of a mul_quad_ gate with a linear term.
 /**
  * @brief Assigns a linear term to a specific index in a mul_quad_ gate.
  * @param gate The mul_quad_ gate to assign the linear term to.
@@ -552,36 +645,6 @@ uint32_t get_witness_from_function_input(Acir::FunctionInput input)
     return input_witness.value.value;
 }
 
-WitnessOrConstant<bb::fr> parse_input(Acir::FunctionInput input)
-{
-    WitnessOrConstant result = std::visit(
-        [&](auto&& e) {
-            using T = std::decay_t<decltype(e)>;
-            if constexpr (std::is_same_v<T, Acir::FunctionInput::Witness>) {
-                return WitnessOrConstant<bb::fr>{
-                    .index = e.value.value,
-                    .value = bb::fr::zero(),
-                    .is_constant = false,
-                };
-            } else if constexpr (std::is_same_v<T, Acir::FunctionInput::Constant>) {
-                return WitnessOrConstant<bb::fr>{
-                    .index = bb::stdlib::IS_CONSTANT,
-                    .value = from_be_bytes(e.value),
-                    .is_constant = true,
-                };
-            } else {
-                throw_or_abort("Unrecognized Acir::ConstantOrWitnessEnum variant.");
-            }
-            return WitnessOrConstant<bb::fr>{
-                .index = bb::stdlib::IS_CONSTANT,
-                .value = bb::fr::zero(),
-                .is_constant = true,
-            };
-        },
-        input.value);
-    return result;
-}
-
 void handle_blackbox_func_call(Acir::Opcode::BlackBoxFuncCall const& arg, AcirFormat& af, size_t opcode_index)
 {
     std::visit(
@@ -808,6 +871,8 @@ void handle_blackbox_func_call(Acir::Opcode::BlackBoxFuncCall const& arg, AcirFo
                     af.constrained_witness.insert(output);
                 }
                 af.original_opcode_indices.poseidon2_constraints.push_back(opcode_index);
+            } else {
+                bb::assert_failure("handle_blackbox_func_call: Unrecognized BlackBoxFuncCall variant.");
             }
         },
         arg.value.value);
@@ -900,143 +965,6 @@ void handle_memory_op(Acir::Opcode::MemoryOp const& mem_op, AcirFormat& af, Bloc
     MemOp acir_mem_op =
         MemOp{ .access_type = access_type, .index = index, .value = serialize_arithmetic_gate(mem_op.op.value) };
     block.trace.push_back(acir_mem_op);
-}
-
-AcirFormat circuit_serde_to_acir_format(Acir::Circuit const& circuit)
-{
-    AcirFormat af;
-    // `varnum` is the true number of variables, thus we add one to the index which starts at zero
-    af.varnum = circuit.current_witness_index + 1;
-    af.num_acir_opcodes = static_cast<uint32_t>(circuit.opcodes.size());
-    af.public_inputs = join({ transform::map(circuit.public_parameters.value, [](auto e) { return e.value; }),
-                              transform::map(circuit.return_values.value, [](auto e) { return e.value; }) });
-    // Map to a pair of: BlockConstraint, and list of opcodes associated with that BlockConstraint
-    // NOTE: We want to deterministically visit this map, so unordered_map should not be used.
-    std::map<uint32_t, std::pair<BlockConstraint, std::vector<size_t>>> block_id_to_block_constraint;
-    for (size_t i = 0; i < circuit.opcodes.size(); ++i) {
-        const auto& gate = circuit.opcodes[i];
-        std::visit(
-            [&](auto&& arg) {
-                using T = std::decay_t<decltype(arg)>;
-                if constexpr (std::is_same_v<T, Acir::Opcode::AssertZero>) {
-                    handle_arithmetic(arg, af, i);
-                } else if constexpr (std::is_same_v<T, Acir::Opcode::BlackBoxFuncCall>) {
-                    handle_blackbox_func_call(arg, af, i);
-                } else if constexpr (std::is_same_v<T, Acir::Opcode::MemoryInit>) {
-                    auto block = handle_memory_init(arg);
-                    uint32_t block_id = arg.block_id.value;
-                    block_id_to_block_constraint[block_id] = { block, /*opcode_indices=*/{ i } };
-                } else if constexpr (std::is_same_v<T, Acir::Opcode::MemoryOp>) {
-                    auto block = block_id_to_block_constraint.find(arg.block_id.value);
-                    if (block == block_id_to_block_constraint.end()) {
-                        throw_or_abort("unitialized MemoryOp");
-                    }
-                    handle_memory_op(arg, af, block->second.first);
-                    block->second.second.push_back(i);
-                }
-            },
-            gate.value);
-    }
-    for (const auto& [block_id, block] : block_id_to_block_constraint) {
-        // Note: the trace will always be empty for ReturnData since it cannot be explicitly read from in noir
-        if (!block.first.trace.empty() || block.first.type == BlockType::ReturnData ||
-            block.first.type == BlockType::CallData) {
-            af.block_constraints.push_back(block.first);
-            af.original_opcode_indices.block_constraints.push_back(block.second);
-        }
-    }
-    return af;
-}
-
-AcirFormat circuit_buf_to_acir_format(std::vector<uint8_t>&& buf)
-{
-    // TODO(https://github.com/AztecProtocol/barretenberg/issues/927): Move to using just
-    // `program_buf_to_acir_format` once Honk fully supports all ACIR test flows For now the backend still expects
-    // to work with a single ACIR function
-    auto program = deserialize_program(std::move(buf));
-    auto circuit = program.functions[0];
-
-    return circuit_serde_to_acir_format(circuit);
-}
-
-/**
- * @brief Converts from the ACIR-native `WitnessMap` format to Barretenberg's internal `WitnessVector` format.
- *
- * @param witness_map ACIR-native `WitnessMap` deserialized from a buffer
- * @return A `WitnessVector` equivalent to the passed `WitnessMap`.
- * @note This transformation results in all unassigned witnesses within the `WitnessMap` being assigned the value 0.
- *       Converting the `WitnessVector` back to a `WitnessMap` is unlikely to return the exact same `WitnessMap`.
- */
-WitnessVector witness_map_to_witness_vector(Witnesses::WitnessMap const& witness_map)
-{
-    WitnessVector wv;
-    size_t index = 0;
-    for (const auto& e : witness_map.value) {
-        // ACIR uses a sparse format for WitnessMap where unused witness indices may be left unassigned.
-        // To ensure that witnesses sit at the correct indices in the `WitnessVector`, we fill any indices
-        // which do not exist within the `WitnessMap` with the dummy value of zero.
-        while (index < e.first.value) {
-            wv.emplace_back(0);
-            index++;
-        }
-        wv.emplace_back(from_be_bytes(e.second));
-        index++;
-    }
-    return wv;
-}
-
-WitnessVector witness_buf_to_witness_data(std::vector<uint8_t>&& buf)
-{
-    // TODO(https://github.com/AztecProtocol/barretenberg/issues/927): Move to using just
-    // `witness_buf_to_witness_stack` once Honk fully supports all ACIR test flows. For now the backend still
-    // expects to work with the stop of the `WitnessStack`.
-    auto witness_stack = deserialize_witness_stack(std::move(buf));
-    auto w = witness_stack.stack[witness_stack.stack.size() - 1].witness;
-
-    return witness_map_to_witness_vector(w);
-}
-
-std::vector<AcirFormat> program_buf_to_acir_format(std::vector<uint8_t>&& buf)
-{
-    auto program = deserialize_program(std::move(buf));
-
-    std::vector<AcirFormat> constraint_systems;
-    constraint_systems.reserve(program.functions.size());
-    for (auto const& function : program.functions) {
-        constraint_systems.emplace_back(circuit_serde_to_acir_format(function));
-    }
-
-    return constraint_systems;
-}
-
-WitnessVectorStack witness_buf_to_witness_stack(std::vector<uint8_t>&& buf)
-{
-    auto witness_stack = deserialize_witness_stack(std::move(buf));
-    WitnessVectorStack witness_vector_stack;
-    witness_vector_stack.reserve(witness_stack.stack.size());
-    for (auto const& stack_item : witness_stack.stack) {
-        witness_vector_stack.emplace_back(stack_item.index, witness_map_to_witness_vector(stack_item.witness));
-    }
-    return witness_vector_stack;
-}
-
-AcirProgramStack get_acir_program_stack(std::string const& bytecode_path, std::string const& witness_path)
-{
-    vinfo("in get_acir_program_stack; witness path is ", witness_path);
-    std::vector<uint8_t> bytecode = get_bytecode(bytecode_path);
-    std::vector<AcirFormat> constraint_systems = program_buf_to_acir_format(std::move(bytecode));
-    WitnessVectorStack witness_stack = [&]() {
-        if (witness_path.empty()) {
-            info("producing a stack of empties");
-            WitnessVectorStack stack_of_empties{ constraint_systems.size(),
-                                                 std::make_pair(uint32_t(), WitnessVector()) };
-            return stack_of_empties;
-        }
-        std::vector<uint8_t> witness_data = get_bytecode(witness_path);
-        return witness_buf_to_witness_stack(std::move(witness_data));
-    }();
-
-    return { std::move(constraint_systems), std::move(witness_stack) };
 }
 
 } // namespace acir_format

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_to_constraint_buf.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_to_constraint_buf.cpp
@@ -27,6 +27,8 @@ namespace acir_format {
 
 using namespace bb;
 
+/// ========= HELPERS ========= ///
+
 uint256_t from_be_bytes(std::vector<uint8_t> const& bytes)
 {
     BB_ASSERT_EQ(bytes.size(), 32U, "uint256 constructed from bytes array with invalid length");
@@ -37,6 +39,42 @@ uint256_t from_be_bytes(std::vector<uint8_t> const& bytes)
     }
     return result;
 }
+
+WitnessOrConstant<bb::fr> parse_input(Acir::FunctionInput input)
+{
+    WitnessOrConstant<bb::fr> result = std::visit(
+        [&](auto&& e) {
+            using T = std::decay_t<decltype(e)>;
+            if constexpr (std::is_same_v<T, Acir::FunctionInput::Witness>) {
+                return WitnessOrConstant<bb::fr>{
+                    .index = e.value.value,
+                    .value = bb::fr::zero(),
+                    .is_constant = false,
+                };
+            } else if constexpr (std::is_same_v<T, Acir::FunctionInput::Constant>) {
+                return WitnessOrConstant<bb::fr>{
+                    .index = bb::stdlib::IS_CONSTANT,
+                    .value = from_be_bytes(e.value),
+                    .is_constant = true,
+                };
+            } else {
+                bb::assert_failure("acir_format::parse_input: unrecognized Acir::FunctionInput variant.");
+            }
+        },
+        input.value);
+    return result;
+}
+
+uint32_t get_witness_from_function_input(Acir::FunctionInput input)
+{
+    BB_ASSERT(std::holds_alternative<Acir::FunctionInput::Witness>(input.value),
+              "get_witness_from_function_input: input must be a Witness variant");
+
+    auto input_witness = std::get<Acir::FunctionInput::Witness>(input.value);
+    return input_witness.value.value;
+}
+
+/// ========= BYTES TO BARRETENBERG'S REPRESENTATION  ========= ///
 
 template <typename T>
 T deserialize_any_format(std::vector<uint8_t>&& buf,
@@ -160,7 +198,7 @@ AcirFormat circuit_buf_to_acir_format(std::vector<uint8_t>&& buf)
     return circuit_serde_to_acir_format(program.functions[0]);
 }
 
-WitnessVector witness_buf_to_witness_data(std::vector<uint8_t>&& buf)
+WitnessVector witness_buf_to_witness_vector(std::vector<uint8_t>&& buf)
 {
     // We need to deserialize into WitnessStack first because the buffer returned by Noir has this structure
     auto witness_stack = deserialize_any_format<Witnesses::WitnessStack>(
@@ -177,7 +215,7 @@ WitnessVector witness_buf_to_witness_data(std::vector<uint8_t>&& buf)
         },
         &Witnesses::WitnessStack::bincodeDeserialize);
     BB_ASSERT_EQ(
-        witness_stack.stack.size(), 1U, "witness_buf_to_witness_data: expected single WitnessMap in WitnessStack");
+        witness_stack.stack.size(), 1U, "witness_buf_to_witness_vector: expected single WitnessMap in WitnessStack");
 
     return witness_map_to_witness_vector(witness_stack.stack[0].witness);
 }
@@ -211,30 +249,7 @@ WitnessVector witness_map_to_witness_vector(Witnesses::WitnessMap const& witness
     return witness_vector;
 }
 
-WitnessOrConstant<bb::fr> parse_input(Acir::FunctionInput input)
-{
-    WitnessOrConstant<bb::fr> result = std::visit(
-        [&](auto&& e) {
-            using T = std::decay_t<decltype(e)>;
-            if constexpr (std::is_same_v<T, Acir::FunctionInput::Witness>) {
-                return WitnessOrConstant<bb::fr>{
-                    .index = e.value.value,
-                    .value = bb::fr::zero(),
-                    .is_constant = false,
-                };
-            } else if constexpr (std::is_same_v<T, Acir::FunctionInput::Constant>) {
-                return WitnessOrConstant<bb::fr>{
-                    .index = bb::stdlib::IS_CONSTANT,
-                    .value = from_be_bytes(e.value),
-                    .is_constant = true,
-                };
-            } else {
-                bb::assert_failure("acir_format::parse_input: unrecognized Acir::FunctionInput variant.");
-            }
-        },
-        input.value);
-    return result;
-}
+/// ========= ACIR OPCODE HANDLERS ========= ///
 
 /**
  * @brief Construct a poly_tuple for a standard width-3 arithmetic gate from its acir representation
@@ -638,11 +653,6 @@ void handle_arithmetic(Acir::Opcode::AssertZero const& arg, AcirFormat& af, size
         }
     }
     constrain_witnesses(arg, af);
-}
-uint32_t get_witness_from_function_input(Acir::FunctionInput input)
-{
-    auto input_witness = std::get<Acir::FunctionInput::Witness>(input.value);
-    return input_witness.value.value;
 }
 
 void handle_blackbox_func_call(Acir::Opcode::BlackBoxFuncCall const& arg, AcirFormat& af, size_t opcode_index)

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_to_constraint_buf.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_to_constraint_buf.cpp
@@ -29,7 +29,7 @@ using namespace bb;
 
 /// ========= HELPERS ========= ///
 
-uint256_t from_be_bytes(std::vector<uint8_t> const& bytes)
+uint256_t from_big_endian_bytes(std::vector<uint8_t> const& bytes)
 {
     BB_ASSERT_EQ(bytes.size(), 32U, "uint256 constructed from bytes array with invalid length");
     uint256_t result = 0;
@@ -54,7 +54,7 @@ WitnessOrConstant<bb::fr> parse_input(Acir::FunctionInput input)
             } else if constexpr (std::is_same_v<T, Acir::FunctionInput::Constant>) {
                 return WitnessOrConstant<bb::fr>{
                     .index = bb::stdlib::IS_CONSTANT,
-                    .value = from_be_bytes(e.value),
+                    .value = from_big_endian_bytes(e.value),
                     .is_constant = true,
                 };
             } else {
@@ -155,7 +155,8 @@ AcirFormat circuit_serde_to_acir_format(Acir::Circuit const& circuit)
                     handle_memory_op(arg, af, block->second.first);
                     block->second.second.push_back(i);
                 } else if constexpr (std::is_same_v<T, Acir::Opcode::BrilligCall>) {
-                    info("ENCOUNTERED BRILLIG CALL");
+                    vinfo("acir_format:circuit_serde_to_acir_format: Encountered unhadled BrillingCall. Barretenberg "
+                          "treats this as a no-op.");
                 } else {
                     bb::assert_failure("circuit_serde_to_acir_format: Unrecognized Acir Opcode.");
                 }
@@ -222,17 +223,11 @@ WitnessVector witness_buf_to_witness_vector(std::vector<uint8_t>&& buf)
 
 WitnessVector witness_map_to_witness_vector(Witnesses::WitnessMap const& witness_map)
 {
-    // We need to enforce that:
-    //  - the witness map is in increasing order of witness index
-    //  - all the witness indices are positive
-    bool is_witness_map_increasing = true;
-    uint32_t previous_index = 0; // starting at 0 to check that witness indices are positive
+    // Note that the WitnessMap is in increasing order of witness indices because the comparator for the Acir::Witness
+    // is defined in terms of the witness index.
 
     WitnessVector witness_vector;
     for (size_t index = 0; const auto& e : witness_map.value) {
-        is_witness_map_increasing &= previous_index <= e.first.value;
-        previous_index = e.first.value;
-
         // ACIR uses a sparse format for WitnessMap where unused witness indices may be left unassigned.
         // To ensure that witnesses sit at the correct indices in the `WitnessVector`, we fill any indices
         // which do not exist within the `WitnessMap` with the dummy value of zero.
@@ -240,11 +235,9 @@ WitnessVector witness_map_to_witness_vector(Witnesses::WitnessMap const& witness
             witness_vector.emplace_back(0);
             index++;
         }
-        witness_vector.emplace_back(from_be_bytes(e.second));
+        witness_vector.emplace_back(from_big_endian_bytes(e.second));
         index++;
     }
-
-    BB_ASSERT(is_witness_map_increasing, "witness_map_to_witness_vector: WitnessMap is not ordered by witness index");
 
     return witness_vector;
 }
@@ -282,7 +275,7 @@ poly_triple serialize_arithmetic_gate(Acir::Expression const& arg)
     // Note: mul_terms are tuples of the form {selector_value, witness_idx_1, witness_idx_2}
     if (!arg.mul_terms.empty()) {
         const auto& mul_term = arg.mul_terms[0];
-        pt.q_m = from_be_bytes(std::get<0>(mul_term));
+        pt.q_m = from_big_endian_bytes(std::get<0>(mul_term));
         pt.a = std::get<1>(mul_term).value;
         pt.b = std::get<2>(mul_term).value;
         a_set = true;
@@ -292,7 +285,7 @@ poly_triple serialize_arithmetic_gate(Acir::Expression const& arg)
     // If necessary, set values for linears terms q_l * w_l, q_r * w_r and q_o * w_o
     BB_ASSERT_LTE(arg.linear_combinations.size(), 3U, "We can only accommodate 3 linear terms");
     for (const auto& linear_term : arg.linear_combinations) {
-        fr selector_value(from_be_bytes(std::get<0>(linear_term)));
+        fr selector_value(from_big_endian_bytes(std::get<0>(linear_term)));
         uint32_t witness_idx = std::get<1>(linear_term).value;
 
         // If the witness index has not yet been set or if the corresponding linear term is active, set the witness
@@ -324,7 +317,7 @@ poly_triple serialize_arithmetic_gate(Acir::Expression const& arg)
     }
 
     // Set constant value q_c
-    pt.q_c = from_be_bytes(arg.q_c);
+    pt.q_c = from_big_endian_bytes(arg.q_c);
     return pt;
 }
 
@@ -380,7 +373,7 @@ std::vector<mul_quad_<fr>> split_into_mul_quad_gates(Acir::Expression const& arg
                                .b_scaling = fr::zero(),
                                .c_scaling = fr::zero(),
                                .d_scaling = fr::zero(),
-                               .const_scaling = fr(from_be_bytes(arg.q_c)) };
+                               .const_scaling = fr(from_big_endian_bytes(arg.q_c)) };
 
     // list of witnesses that are part of mul terms
     std::set<uint32_t> all_mul_terms;
@@ -396,7 +389,7 @@ std::vector<mul_quad_<fr>> split_into_mul_quad_gates(Acir::Expression const& arg
 
         // we add a mul term (if there are some) to every intermediate gate
         if (current_mul_term != arg.mul_terms.end()) {
-            mul_gate.mul_scaling = fr(from_be_bytes(std::get<0>(*current_mul_term)));
+            mul_gate.mul_scaling = fr(from_big_endian_bytes(std::get<0>(*current_mul_term)));
             mul_gate.a = std::get<1>(*current_mul_term).value;
             mul_gate.b = std::get<2>(*current_mul_term).value;
             mul_gate.a_scaling = fr::zero();
@@ -407,7 +400,7 @@ std::vector<mul_quad_<fr>> split_into_mul_quad_gates(Acir::Expression const& arg
             bool b_processed = false;
             for (auto lin_term : arg.linear_combinations) {
                 auto w = std::get<1>(lin_term).value;
-                fr coeff = fr(from_be_bytes(std::get<0>(lin_term)));
+                fr coeff = fr(from_big_endian_bytes(std::get<0>(lin_term)));
 
                 if (w == mul_gate.a && !processed_mul_terms.contains(mul_gate.a)) {
                     mul_gate.a_scaling += coeff; // Accumulate
@@ -443,7 +436,7 @@ std::vector<mul_quad_<fr>> split_into_mul_quad_gates(Acir::Expression const& arg
             if (!all_mul_terms.contains(w)) {
                 if (i < max_size) {
                     assign_linear_term(
-                        mul_gate, i, w, fr(from_be_bytes(std::get<0>(*current_linear_term)))); // * fr(-1)));
+                        mul_gate, i, w, fr(from_big_endian_bytes(std::get<0>(*current_linear_term)))); // * fr(-1)));
                     ++i;
                 } else {
                     // No more available wire, but there is still some linear terms; we need another mul_gate
@@ -494,7 +487,7 @@ mul_quad_<fr> serialize_mul_quad_gate(Acir::Expression const& arg)
     // Note: mul_terms are tuples of the form {selector_value, witness_idx_1, witness_idx_2}
     if (!arg.mul_terms.empty()) {
         const auto& mul_term = arg.mul_terms[0];
-        quad.mul_scaling = from_be_bytes(std::get<0>(mul_term));
+        quad.mul_scaling = from_big_endian_bytes(std::get<0>(mul_term));
         quad.a = std::get<1>(mul_term).value;
         quad.b = std::get<2>(mul_term).value;
         a_set = true;
@@ -502,7 +495,7 @@ mul_quad_<fr> serialize_mul_quad_gate(Acir::Expression const& arg)
     }
     // If necessary, set values for linears terms q_l * w_l, q_r * w_r and q_o * w_o
     for (const auto& linear_term : arg.linear_combinations) {
-        fr selector_value(from_be_bytes(std::get<0>(linear_term)));
+        fr selector_value(from_big_endian_bytes(std::get<0>(linear_term)));
         uint32_t witness_idx = std::get<1>(linear_term).value;
 
         // If the witness index has not yet been set or if the corresponding linear term is active, set the witness
@@ -539,7 +532,7 @@ mul_quad_<fr> serialize_mul_quad_gate(Acir::Expression const& arg)
     }
 
     // Set constant value q_c
-    quad.const_scaling = from_be_bytes(arg.q_c);
+    quad.const_scaling = from_big_endian_bytes(arg.q_c);
     return quad;
 }
 
@@ -923,7 +916,7 @@ BlockConstraint handle_memory_init(Acir::Opcode::MemoryInit const& mem_init)
 bool is_rom(Acir::MemOp const& mem_op)
 {
     return mem_op.operation.mul_terms.empty() && mem_op.operation.linear_combinations.empty() &&
-           from_be_bytes(mem_op.operation.q_c) == 0;
+           from_big_endian_bytes(mem_op.operation.q_c) == 0;
 }
 
 uint32_t poly_to_witness(const poly_triple poly)

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_to_constraint_buf.hpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_to_constraint_buf.hpp
@@ -10,34 +10,51 @@
 
 namespace acir_format {
 
+/// ========= HELPERS ========= ///
+
+/// The functions below are helpers for converting data between ACIR representations and Barretenberg's internal
+/// representations.
+
 uint256_t from_be_bytes(std::vector<uint8_t> const& bytes);
 
 /**
- * The functions below handle the transition from serialized ACIR formats (msgpack and bincode), which is the output of
- * compiling a Noir program, to Barretenberg's internal formats.
- *
- * The flow is as follows:
- *  - A buffer of bytes is deserialised according to either msgpack or bincode into an Acir::Circuit, which is just the
- *    representation of a function in terms of Acir::Opcodes, Acir::Witness, Acir::PublicInputs. As of now (Nov 2025)
- *    only bincode is supported.
- *  - The Acir::Circuit is transformed into AcirFormat, which is Barretenberg's internal representation of a circuit, in
- *    terms of constraints that have to be added to the Builder
- *  - A buffer of bytes is deserialised into a WitnessVector, which is the list of witness values used by the prover to
- *    generate a proof. This conversion takes a WitnessMap (which is a list of couples (witness_index, witness_value))
- *    and converts it to a vector of bb::fr elements. ACIR optimizes away some witnesss, so the WitnessMap may have
- *    holes: witness indices go up, but not necessarily by one. The conversion accounts for these holes and fills them
- *    with zeros.
- *  - The AcirFormat representation of the circuit and the WitnessVector are passed to acir_format::create_circuit,
- *    which constructs a circuit by adding the relevant constraints and witnesses to a Builder
+ * @brief Parse an Acir::FunctionInput (which can either be a witness or a constant) into a WitnessOrConstant.
  */
+WitnessOrConstant<bb::fr> parse_input(Acir::FunctionInput input);
 
 /**
- * @brief Deserialize `buf` either based on the first byte interpreted as a Noir serialization format byte, or falling
- * back to `bincode` if the format cannot be recognized. Currently only `msgpack` format is expected, or the legacy
- * `bincode` format.
+ * @brief Extract the witness index from an Acir::FunctionInput representing a witness.
  *
- * @note Due to the lack of exception handling available to us in Wasm we can't try `bincode` format and if it fails try
- * `msgpack`; instead we have to make a decision and commit to it.
+ * @note The function asserts that the input is indeed a witness variant.
+ */
+uint32_t get_witness_from_function_input(Acir::FunctionInput input);
+
+/// ========= BYTES TO BARRETENBERG'S REPRESENTATION  ========= ///
+
+/// The functions below handle the transition from serialized ACIR formats (msgpack and bincode), which is the output of
+/// compiling a Noir program, to Barretenberg's internal formats.
+///
+/// The flow is as follows:
+/// - A buffer of bytes is deserialised according to either msgpack or bincode into an Acir::Circuit, which is just the
+///   representation of a function in terms of Acir::Opcodes, Acir::Witness, Acir::PublicInputs. As of now (Nov 2025)
+///   only bincode is supported.
+/// - The Acir::Circuit is transformed into AcirFormat, which is Barretenberg's internal representation of a circuit,
+///   in terms of constraints that have to be added to the Builder
+/// - A buffer of bytes is deserialised into a WitnessVector, which is the list of witness values used by the prover to
+///   generate a proof. This conversion takes a WitnessMap (which is a list of couples (witness_index, witness_value))
+///   and converts it to a vector of bb::fr elements. ACIR optimizes away some witnesss, so the WitnessMap may have
+///   holes: witness indices go up, but not necessarily by one. The conversion accounts for these holes and fills them
+///   with zeros.
+/// - The AcirFormat representation of the circuit and the WitnessVector are passed to acir_format::create_circuit,
+///   which constructs a circuit by adding the relevant constraints and witnesses to a Builder
+
+/**
+ * @brief Deserialize `buf` either based on the first byte interpreted as a Noir serialization format byte, or
+ * falling back to `bincode` if the format cannot be recognized. Currently only `msgpack` format is expected, or the
+ * legacy `bincode` format.
+ *
+ * @note Due to the lack of exception handling available to us in Wasm we can't try `bincode` format and if it fails
+ * try `msgpack`; instead we have to make a decision and commit to it.
  */
 template <typename T>
 T deserialize_any_format(std::vector<uint8_t>&& buf,
@@ -65,16 +82,10 @@ AcirFormat circuit_buf_to_acir_format(std::vector<uint8_t>&& buf);
 /**
  * @brief Convert a buffer representing a witness vector into Barretenberg's internal `WitnessVector` format.
  */
-WitnessVector witness_buf_to_witness_data(std::vector<uint8_t>&& buf);
+WitnessVector witness_buf_to_witness_vector(std::vector<uint8_t>&& buf);
 
-//////////
-
-/**
- * @brief Parse an Acir::FunctionInput (which can either be a witness or a constant) into a WitnessOrConstant.
- */
-WitnessOrConstant<bb::fr> parse_input(Acir::FunctionInput input);
-
-//////////
+/// ========= ACIR OPCODE HANDLERS ========= ///
+/// AUDITTODO(federico): Restructure the functions below so that it is clear how they are used
 
 /**
  * @brief Construct a poly_tuple for a standard width-3 arithmetic gate from its acir representation.
@@ -100,8 +111,6 @@ std::pair<uint32_t, uint32_t> is_assert_equal(Acir::Opcode::AssertZero const& ar
                                               AcirFormat const& af);
 
 void handle_arithmetic(Acir::Opcode::AssertZero const& arg, AcirFormat& af, size_t opcode_index);
-
-uint32_t get_witness_from_function_input(Acir::FunctionInput input);
 
 void handle_blackbox_func_call(Acir::Opcode::BlackBoxFuncCall const& arg, AcirFormat& af, size_t opcode_index);
 

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_to_constraint_buf.hpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_to_constraint_buf.hpp
@@ -15,7 +15,14 @@ namespace acir_format {
 /// The functions below are helpers for converting data between ACIR representations and Barretenberg's internal
 /// representations.
 
-uint256_t from_be_bytes(std::vector<uint8_t> const& bytes);
+/**
+ * @brief Convert an array of 32 bytes into a uint256_t by interpreting the bytes as the big-endian
+ * (most-significant-byte first) representation of that number.
+ *
+ * @param bytes
+ * @return uint256_t
+ */
+uint256_t from_big_endian_bytes(std::vector<uint8_t> const& bytes);
 
 /**
  * @brief Parse an Acir::FunctionInput (which can either be a witness or a constant) into a WitnessOrConstant.
@@ -38,23 +45,25 @@ uint32_t get_witness_from_function_input(Acir::FunctionInput input);
 /// - A buffer of bytes is deserialised according to either msgpack or bincode into an Acir::Circuit, which is just the
 ///   representation of a function in terms of Acir::Opcodes, Acir::Witness, Acir::PublicInputs. As of now (Nov 2025)
 ///   only bincode is supported.
-/// - The Acir::Circuit is transformed into AcirFormat, which is Barretenberg's internal representation of a circuit,
-///   in terms of constraints that have to be added to the Builder
-/// - A buffer of bytes is deserialised into a WitnessVector, which is the list of witness values used by the prover to
-///   generate a proof. This conversion takes a WitnessMap (which is a list of couples (witness_index, witness_value))
-///   and converts it to a vector of bb::fr elements. ACIR optimizes away some witnesss, so the WitnessMap may have
-///   holes: witness indices go up, but not necessarily by one. The conversion accounts for these holes and fills them
-///   with zeros.
-/// - The AcirFormat representation of the circuit and the WitnessVector are passed to acir_format::create_circuit,
-///   which constructs a circuit by adding the relevant constraints and witnesses to a Builder
+/// - The Acir::Circuit is transformed into AcirFormat, which is Barretenberg's internal representation of the Acir
+///   constraints that have to be added to the Builder.
+/// - A buffer of bytes is deserialised into a WitnessVector, which is the list of witness values known at the time of
+///   noir program execution. This conversion takes a WitnessMap (which is a list of couples (witness_index,
+///   witness_value)) and converts it to a vector of bb::fr elements. ACIR optimizes away some witnesses, so the
+///   WitnessMap may have holes: witness indices go up, but not necessarily by one. The conversion accounts for these
+///   holes and fills them with zeros. NOTE: The witness vector does NOT contain all the witnesses that will be present
+///   in the builder by the end of circuit construction.
+/// - The AcirFormat structure and the WitnessVector are passed to acir_format::create_circuit,
+///   which constructs a barretenberg circuit by adding the relevant constraints and witnesses to a Builder
 
 /**
  * @brief Deserialize `buf` either based on the first byte interpreted as a Noir serialization format byte, or
- * falling back to `bincode` if the format cannot be recognized. Currently only `msgpack` format is expected, or the
- * legacy `bincode` format.
+ * falling back to `bincode` if the format cannot be recognized. Currently only `bincode` is expected.
  *
- * @note Due to the lack of exception handling available to us in Wasm we can't try `bincode` format and if it fails
- * try `msgpack`; instead we have to make a decision and commit to it.
+ * @note The function is written so that it can deserialize either `msgpack` or `bincode` depending on the first byte
+ * of the buffer. However, at the moment only `bincode` is supported, so we fail in case `msgpack` is encountered. Note
+ * that due to the lack of exception handling available in Wasm, the code cannot be structured to try `bincode` and
+ * fall back to `msgpack` if that fails. Therefore, we look at the first byte and commit to a format based on that.
  */
 template <typename T>
 T deserialize_any_format(std::vector<uint8_t>&& buf,

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_to_constraint_buf.hpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_to_constraint_buf.hpp
@@ -10,28 +10,107 @@
 
 namespace acir_format {
 
+uint256_t from_be_bytes(std::vector<uint8_t> const& bytes);
+
 /**
- * @brief Converts from the ACIR-native `WitnessStack` format to Barretenberg's internal `WitnessVector` format.
+ * The functions below handle the transition from serialized ACIR formats (msgpack and bincode), which is the output of
+ * compiling a Noir program, to Barretenberg's internal formats.
  *
- * @param buf Serialized representation of a `WitnessStack`.
- * @return A `WitnessVector` equivalent to the last `WitnessMap` in the stack.
- * @note This transformation results in all unassigned witnesses within the `WitnessMap` being assigned the value 0.
- *       Converting the `WitnessVector` back to a `WitnessMap` is unlikely to return the exact same `WitnessMap`.
+ * The flow is as follows:
+ *  - A buffer of bytes is deserialised according to either msgpack or bincode into an Acir::Circuit, which is just the
+ *    representation of a function in terms of Acir::Opcodes, Acir::Witness, Acir::PublicInputs. As of now (Nov 2025)
+ *    only bincode is supported.
+ *  - The Acir::Circuit is transformed into AcirFormat, which is Barretenberg's internal representation of a circuit, in
+ *    terms of constraints that have to be added to the Builder
+ *  - A buffer of bytes is deserialised into a WitnessVector, which is the list of witness values used by the prover to
+ *    generate a proof. This conversion takes a WitnessMap (which is a list of couples (witness_index, witness_value))
+ *    and converts it to a vector of bb::fr elements. ACIR optimizes away some witnesss, so the WitnessMap may have
+ *    holes: witness indices go up, but not necessarily by one. The conversion accounts for these holes and fills them
+ *    with zeros.
+ *  - The AcirFormat representation of the circuit and the WitnessVector are passed to acir_format::create_circuit,
+ *    which constructs a circuit by adding the relevant constraints and witnesses to a Builder
  */
-WitnessVector witness_buf_to_witness_data(std::vector<uint8_t>&& buf);
-
-AcirFormat circuit_buf_to_acir_format(std::vector<uint8_t>&& buf);
 
 /**
- * @brief Converts an ACIR Circuit object directly to AcirFormat (exposed for fuzzing)
- * @param circuit The ACIR circuit object
- * @return AcirFormat representation of the circuit
+ * @brief Deserialize `buf` either based on the first byte interpreted as a Noir serialization format byte, or falling
+ * back to `bincode` if the format cannot be recognized. Currently only `msgpack` format is expected, or the legacy
+ * `bincode` format.
+ *
+ * @note Due to the lack of exception handling available to us in Wasm we can't try `bincode` format and if it fails try
+ * `msgpack`; instead we have to make a decision and commit to it.
+ */
+template <typename T>
+T deserialize_any_format(std::vector<uint8_t>&& buf,
+                         std::function<T(msgpack::object const&)> decode_msgpack,
+                         std::function<T(std::vector<uint8_t>)> decode_bincode);
+
+/**
+ * @brief Convert an Acir::Circuit into an AcirFormat by processing all the opcodes.
  */
 AcirFormat circuit_serde_to_acir_format(Acir::Circuit const& circuit);
 
-std::vector<AcirFormat> program_buf_to_acir_format(std::vector<uint8_t>&& buf);
+/**
+ * @brief Convert from the ACIR-native `WitnessMap` format to Barretenberg's internal `WitnessVector` format.
+ *
+ * @note This transformation results in all unassigned witnesses within the `WitnessMap` being assigned the value 0.
+ * Converting the `WitnessVector` back to a `WitnessMap` is unlikely to return the exact same `WitnessMap`.
+ */
+WitnessVector witness_map_to_witness_vector(Witnesses::WitnessMap const& witness_map);
 
-WitnessVectorStack witness_buf_to_witness_stack(std::vector<uint8_t>&& buf);
+/**
+ * @brief Convert a buffer representing a circuit into Barretenberg's internal `AcirFormat` representation.
+ */
+AcirFormat circuit_buf_to_acir_format(std::vector<uint8_t>&& buf);
 
-AcirProgramStack get_acir_program_stack(std::string const& bytecode_path, std::string const& witness_path);
+/**
+ * @brief Convert a buffer representing a witness vector into Barretenberg's internal `WitnessVector` format.
+ */
+WitnessVector witness_buf_to_witness_data(std::vector<uint8_t>&& buf);
+
+//////////
+
+/**
+ * @brief Parse an Acir::FunctionInput (which can either be a witness or a constant) into a WitnessOrConstant.
+ */
+WitnessOrConstant<bb::fr> parse_input(Acir::FunctionInput input);
+
+//////////
+
+/**
+ * @brief Construct a poly_tuple for a standard width-3 arithmetic gate from its acir representation.
+ */
+poly_triple serialize_arithmetic_gate(Acir::Expression const& arg);
+
+/**
+ * @brief Assigns a linear term to a specific index in a mul_quad_ gate.
+ */
+void assign_linear_term(mul_quad_<bb::fr>& gate, int index, uint32_t witness_index, bb::fr const& scaling);
+
+/**
+ * @brief Accumulate the input expression into a series of quad gates.
+ */
+std::vector<mul_quad_<bb::fr>> split_into_mul_quad_gates(Acir::Expression const& arg);
+
+mul_quad_<bb::fr> serialize_mul_quad_gate(Acir::Expression const& arg);
+
+void constrain_witnesses(Acir::Opcode::AssertZero const& arg, AcirFormat& af);
+
+std::pair<uint32_t, uint32_t> is_assert_equal(Acir::Opcode::AssertZero const& arg,
+                                              poly_triple const& pt,
+                                              AcirFormat const& af);
+
+void handle_arithmetic(Acir::Opcode::AssertZero const& arg, AcirFormat& af, size_t opcode_index);
+
+uint32_t get_witness_from_function_input(Acir::FunctionInput input);
+
+void handle_blackbox_func_call(Acir::Opcode::BlackBoxFuncCall const& arg, AcirFormat& af, size_t opcode_index);
+
+BlockConstraint handle_memory_init(Acir::Opcode::MemoryInit const& mem_init);
+
+bool is_rom(Acir::MemOp const& mem_op);
+
+uint32_t poly_to_witness(const poly_triple poly);
+
+void handle_memory_op(Acir::Opcode::MemoryOp const& mem_op, AcirFormat& af, BlockConstraint& block);
+
 } // namespace acir_format

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/serde/acir.hpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/serde/acir.hpp
@@ -4495,6 +4495,10 @@ struct PublicInputs {
     }
 };
 
+/**
+ * @brief The intermediate representation of a function when being transformed from a vector of bytes into a series of
+ * constraints.
+ */
 struct Circuit {
     std::string function_name;
     uint32_t current_witness_index;

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_proofs/c_bind.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_proofs/c_bind.cpp
@@ -39,7 +39,7 @@ WASM_EXPORT void acir_prove_and_verify_ultra_honk(uint8_t const* acir_vec, uint8
 {
     acir_format::AcirProgram program{
         acir_format::circuit_buf_to_acir_format(from_buffer<std::vector<uint8_t>>(acir_vec)),
-        acir_format::witness_buf_to_witness_data(from_buffer<std::vector<uint8_t>>(witness_vec))
+        acir_format::witness_buf_to_witness_vector(from_buffer<std::vector<uint8_t>>(witness_vec))
     };
 
     auto builder = acir_format::create_circuit<UltraCircuitBuilder>(program);
@@ -59,7 +59,7 @@ WASM_EXPORT void acir_prove_and_verify_mega_honk(uint8_t const* acir_vec, uint8_
 {
     acir_format::AcirProgram program{
         acir_format::circuit_buf_to_acir_format(from_buffer<std::vector<uint8_t>>(acir_vec)),
-        acir_format::witness_buf_to_witness_data(from_buffer<std::vector<uint8_t>>(witness_vec))
+        acir_format::witness_buf_to_witness_vector(from_buffer<std::vector<uint8_t>>(witness_vec))
     };
 
     auto builder = acir_format::create_circuit<MegaCircuitBuilder>(program);
@@ -123,7 +123,7 @@ WASM_EXPORT void acir_prove_ultra_zk_honk(uint8_t const* acir_vec,
     UltraZKProver prover = [&] {
         acir_format::AcirProgram program{
             acir_format::circuit_buf_to_acir_format(from_buffer<std::vector<uint8_t>>(acir_vec)),
-            acir_format::witness_buf_to_witness_data(from_buffer<std::vector<uint8_t>>(witness_vec))
+            acir_format::witness_buf_to_witness_vector(from_buffer<std::vector<uint8_t>>(witness_vec))
         };
         auto builder = acir_format::create_circuit<UltraCircuitBuilder>(program);
         auto prover_instance = std::make_shared<ProverInstance_<UltraZKFlavor>>(builder);
@@ -146,7 +146,7 @@ WASM_EXPORT void acir_prove_ultra_keccak_honk(uint8_t const* acir_vec,
     UltraKeccakProver prover = [&] {
         acir_format::AcirProgram program{
             acir_format::circuit_buf_to_acir_format(from_buffer<std::vector<uint8_t>>(acir_vec)),
-            acir_format::witness_buf_to_witness_data(from_buffer<std::vector<uint8_t>>(witness_vec))
+            acir_format::witness_buf_to_witness_vector(from_buffer<std::vector<uint8_t>>(witness_vec))
         };
         auto builder = acir_format::create_circuit<UltraCircuitBuilder>(program);
 
@@ -168,7 +168,7 @@ WASM_EXPORT void acir_prove_ultra_keccak_zk_honk(uint8_t const* acir_vec,
     UltraKeccakZKProver prover = [&] {
         acir_format::AcirProgram program{
             acir_format::circuit_buf_to_acir_format(from_buffer<std::vector<uint8_t>>(acir_vec)),
-            acir_format::witness_buf_to_witness_data(from_buffer<std::vector<uint8_t>>(witness_vec))
+            acir_format::witness_buf_to_witness_vector(from_buffer<std::vector<uint8_t>>(witness_vec))
         };
         auto builder = acir_format::create_circuit<UltraCircuitBuilder>(program);
 
@@ -191,7 +191,7 @@ WASM_EXPORT void acir_prove_ultra_starknet_honk([[maybe_unused]] uint8_t const* 
     UltraStarknetProver prover = [&] {
         acir_format::AcirProgram program{
             acir_format::circuit_buf_to_acir_format(from_buffer<std::vector<uint8_t>>(acir_vec)),
-            acir_format::witness_buf_to_witness_data(from_buffer<std::vector<uint8_t>>(witness_vec))
+            acir_format::witness_buf_to_witness_vector(from_buffer<std::vector<uint8_t>>(witness_vec))
         };
         auto builder = acir_format::create_circuit<UltraCircuitBuilder>(program);
 
@@ -214,7 +214,7 @@ WASM_EXPORT void acir_prove_ultra_starknet_zk_honk([[maybe_unused]] uint8_t cons
     UltraStarknetZKProver prover = [&] {
         acir_format::AcirProgram program{
             acir_format::circuit_buf_to_acir_format(from_buffer<std::vector<uint8_t>>(acir_vec)),
-            acir_format::witness_buf_to_witness_data(from_buffer<std::vector<uint8_t>>(witness_vec))
+            acir_format::witness_buf_to_witness_vector(from_buffer<std::vector<uint8_t>>(witness_vec))
         };
         auto builder = acir_format::create_circuit<UltraCircuitBuilder>(program);
 

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/mega_circuit_builder.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/mega_circuit_builder.hpp
@@ -75,14 +75,11 @@ template <typename FF> class MegaCircuitBuilder_ : public UltraCircuitBuilder_<M
      * @param public_inputs indices of public inputs in witness array
      * @param varnum number of known witness
      *
-     * @note The size of witness_values may be less than varnum. The former is the set of actual witness values known at
-     * the time of acir generation. The former may be larger and essentially acounts for placeholders for witnesses that
-     * we know will exist but whose values are not known during acir generation. Both are in general less than the total
-     * number of variables/witnesses that might be present for a circuit generated from acir, since many gates will
-     * depend on the details of the bberg implementation (or more generally on the backend used to process acir).
+     * @note When the witness values are reconstructed from ACIR, they are padded with zeros in those position for which
+     * the value of the witness is not known at compile time. Hence, we always expect varnum == witness_values.size()
      */
     MegaCircuitBuilder_(std::shared_ptr<ECCOpQueue> op_queue_in,
-                        auto& witness_values,
+                        SlabVector<FF>& witness_values,
                         const std::vector<uint32_t>& public_inputs,
                         size_t varnum)
         : UltraCircuitBuilder_<MegaExecutionTraceBlocks>(/*size_hint=*/0, witness_values, public_inputs, varnum)

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/mega_circuit_builder.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/mega_circuit_builder.hpp
@@ -86,7 +86,7 @@ template <typename FF> class MegaCircuitBuilder_ : public UltraCircuitBuilder_<M
      * on the backend used to process acir).
      */
     MegaCircuitBuilder_(std::shared_ptr<ECCOpQueue> op_queue_in,
-                        std::vector<FF>& witness_values,
+                        const std::vector<FF>& witness_values,
                         const std::vector<uint32_t>& public_inputs,
                         size_t varnum)
         : UltraCircuitBuilder_<MegaExecutionTraceBlocks>(/*size_hint=*/0, witness_values, public_inputs, varnum)

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/mega_circuit_builder.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/mega_circuit_builder.hpp
@@ -86,7 +86,7 @@ template <typename FF> class MegaCircuitBuilder_ : public UltraCircuitBuilder_<M
      * on the backend used to process acir).
      */
     MegaCircuitBuilder_(std::shared_ptr<ECCOpQueue> op_queue_in,
-                        SlabVector<FF>& witness_values,
+                        std::vector<FF>& witness_values,
                         const std::vector<uint32_t>& public_inputs,
                         size_t varnum)
         : UltraCircuitBuilder_<MegaExecutionTraceBlocks>(/*size_hint=*/0, witness_values, public_inputs, varnum)

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/mega_circuit_builder.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/mega_circuit_builder.hpp
@@ -75,8 +75,15 @@ template <typename FF> class MegaCircuitBuilder_ : public UltraCircuitBuilder_<M
      * @param public_inputs indices of public inputs in witness array
      * @param varnum number of known witness
      *
-     * @note When the witness values are reconstructed from ACIR, they are padded with zeros in those position for which
-     * the value of the witness is not known at compile time. Hence, we always expect varnum == witness_values.size()
+     * @note witness_values is the vector of witness values known at the time of acir generation. It is filled with
+     * witness values which are interleaved with zeros when witnesses are optimized away. Not all witness values are
+     * known at the time of acir generation. The number of values that are not known is given by varnum -
+     * witness_values.size(). For each of these witnesses with unknown value, we add to the builder a variable with
+     * value equal to zero.
+     *
+     * @note varnum is in general less than total number of variables/witnesses that might be present for a circuit
+     * generated from acir, since many gates will depend on the details of the bberg implementation (or more generally
+     * on the backend used to process acir).
      */
     MegaCircuitBuilder_(std::shared_ptr<ECCOpQueue> op_queue_in,
                         SlabVector<FF>& witness_values,

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.hpp
@@ -235,7 +235,7 @@ class UltraCircuitBuilder_ : public CircuitBuilderBase<typename ExecutionTrace_:
      *
      */
     UltraCircuitBuilder_(const size_t size_hint,
-                         SlabVector<FF>& witness_values,
+                         std::vector<FF>& witness_values,
                          const std::vector<uint32_t>& public_inputs,
                          size_t varnum)
         : CircuitBuilderBase<FF>(size_hint, witness_values.empty())

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.hpp
@@ -223,8 +223,15 @@ class UltraCircuitBuilder_ : public CircuitBuilderBase<typename ExecutionTrace_:
      * @param public_inputs indices of public inputs in witness array
      * @param varnum number of known witness
      *
-     * @note When the witness values are reconstructed from ACIR, they are padded with zeros in those position for which
-     * the value of the witness is not known at compile time. Hence, we always expect varnum == witness_values.size()
+     * @note witness_values is the vector of witness values known at the time of acir generation. It is filled with
+     * witness values which are interleaved with zeros when witnesses are optimized away. Not all witness values are
+     * known at the time of acir generation. The number of values that are not known is given by varnum -
+     * witness_values.size(). For each of these witnesses with unknown value, we add to the builder a variable with
+     * value equal to zero.
+     *
+     * @note varnum is in general less than total number of variables/witnesses that might be present for a circuit
+     * generated from acir, since many gates will depend on the details of the bberg implementation (or more generally
+     * on the backend used to process acir).
      *
      */
     UltraCircuitBuilder_(const size_t size_hint,
@@ -233,10 +240,16 @@ class UltraCircuitBuilder_ : public CircuitBuilderBase<typename ExecutionTrace_:
                          size_t varnum)
         : CircuitBuilderBase<FF>(size_hint, witness_values.empty())
     {
-        BB_ASSERT_EQ(
-            varnum, witness_values.size(), "UltraCircuitBuilder_: varnum does not match size of witness_values vector");
+        BB_ASSERT_LTE(
+            witness_values.size(),
+            varnum,
+            "UltraCircuitBuilder_: varnum should be bigger or equal than the size of the witness_values vector");
         for (const auto value : witness_values) {
             this->add_variable(value);
+        }
+        for (size_t idx = witness_values.size(); idx < varnum; ++idx) {
+            // Add dummy variables for the witnesses with unknown value at acir generation time
+            this->add_variable(FF::zero());
         }
 
         // Initialize the builder public_inputs directly from the acir public inputs.

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.hpp
@@ -223,22 +223,19 @@ class UltraCircuitBuilder_ : public CircuitBuilderBase<typename ExecutionTrace_:
      * @param public_inputs indices of public inputs in witness array
      * @param varnum number of known witness
      *
-     * @note The size of witness_values may be less than varnum. The former is the set of actual witness values known at
-     * the time of acir generation. The latter may be larger and essentially acounts for placeholders for witnesses that
-     * we know will exist but whose values are not known during acir generation. Both are in general less than the total
-     * number of variables/witnesses that might be present for a circuit generated from acir, since many gates will
-     * depend on the details of the bberg implementation (or more generally on the backend used to process acir).
+     * @note When the witness values are reconstructed from ACIR, they are padded with zeros in those position for which
+     * the value of the witness is not known at compile time. Hence, we always expect varnum == witness_values.size()
+     *
      */
     UltraCircuitBuilder_(const size_t size_hint,
-                         auto& witness_values,
+                         SlabVector<FF>& witness_values,
                          const std::vector<uint32_t>& public_inputs,
                          size_t varnum)
         : CircuitBuilderBase<FF>(size_hint, witness_values.empty())
     {
-        for (size_t idx = 0; idx < varnum; ++idx) {
-            // Zeros are added for variables whose existence is known but whose values are not yet known. The values may
-            // be "set" later on via the assert_equal mechanism.
-            auto value = idx < witness_values.size() ? witness_values[idx] : 0;
+        BB_ASSERT_EQ(
+            varnum, witness_values.size(), "UltraCircuitBuilder_: varnum does not match size of witness_values vector");
+        for (const auto value : witness_values) {
             this->add_variable(value);
         }
 

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.hpp
@@ -235,7 +235,7 @@ class UltraCircuitBuilder_ : public CircuitBuilderBase<typename ExecutionTrace_:
      *
      */
     UltraCircuitBuilder_(const size_t size_hint,
-                         std::vector<FF>& witness_values,
+                         const std::vector<FF>& witness_values,
                          const std::vector<uint32_t>& public_inputs,
                          size_t varnum)
         : CircuitBuilderBase<FF>(size_hint, witness_values.empty())


### PR DESCRIPTION
### 🧾 Audit Context

This PR is the first in the audit thread covering `acir_to_constraint_buf` (converting bytes into Barretenberg's constraints). It is a refactoring to clarify that flow of the data from bytes to a circuit.

### 🛠️ Changes Made

- Remove support for deserialisation of multiple circuits/witness vectors. The relevant test in acir_tests have been added to the skipped list.
- Add checks to enforce that the witness vector is in increasing order of witness index (something that is being implicitly used in the codebase) and that the witnesses indices are positive
- Added an assertion to catch if deserialisation encounters msgpack. This is not currently in use and it should not be encountered.

### ✅ Checklist

- [ ] Audited all methods of the relevant module/class
- [ ] Audited the interface of the module/class with other (relevant) components
- [ ] Documented existing functionality and any changes made (as per Doxygen requirements)
- [ ] Resolved and/or closed all issues/TODOs pertaining to the audited files
- [ ] Confirmed and documented any security or other issues found (if applicable)
- [ ] Verified that tests cover all critical paths (and added tests if necessary)
- [ ] Updated audit tracking for the files audited (check the start of each file you audited)

### 📌 Notes for Reviewers
