### PR TITLE
refactor: not re-adding note that is already present

### DIFF
--- a/yarn-project/pxe/src/storage/note_data_provider/note_data_provider.test.ts
+++ b/yarn-project/pxe/src/storage/note_data_provider/note_data_provider.test.ts
@@ -1,4 +1,6 @@
+import { toBufferBE } from '@aztec/foundation/bigint-buffer';
 import { Fr } from '@aztec/foundation/fields';
+import { toArray } from '@aztec/foundation/iterable';
 import { AztecLMDBStoreV2, openTmpStore } from '@aztec/kv-store/lmdb-v2';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import { L2BlockHash } from '@aztec/stdlib/block';
@@ -309,6 +311,45 @@ describe('NoteDataProvider', () => {
 
       const res = await provider.getNotes(filter);
       expect(res).toHaveLength(0);
+    });
+  });
+
+  describe('NoteDataProvider.addNotes duplicate handling', () => {
+    let store: AztecLMDBStoreV2;
+    let provider: NoteDataProvider;
+    let note1: NoteDao;
+
+    beforeEach(async () => {
+      ({ store, provider, note1 } = await setupProviderWithNotes('note_data_provider_duplicates'));
+    });
+
+    afterEach(async () => {
+      await store.close();
+    });
+
+    it('skips re-adding active notes and avoids duplicate scope entries', async () => {
+      await provider.addNotes([note1], SCOPE_1);
+
+      const noteIndexHex = toBufferBE(note1.index, 32).toString('hex');
+      const notesToScopeIndex = store.openMultiMap<string, string>('notes_to_scope');
+      const storedScopes = await toArray(notesToScopeIndex.getValuesAsync(noteIndexHex));
+
+      expect(storedScopes).toEqual([SCOPE_1.toString()]);
+    });
+
+    it('skips re-adding nullified notes so they remain inactive', async () => {
+      await provider.applyNullifiers([mkNullifier(note1)]);
+
+      await provider.addNotes([note1], SCOPE_1);
+
+      const activeNotes = await provider.getNotes({ contractAddress: CONTRACT_A });
+      expect(new Set(getIndexes(activeNotes))).toEqual(new Set([2n]));
+
+      const allNotes = await provider.getNotes({
+        contractAddress: CONTRACT_A,
+        status: NoteStatus.ACTIVE_OR_NULLIFIED,
+      });
+      expect(new Set(getIndexes(allNotes))).toEqual(new Set([1n, 2n]));
     });
   });
 

--- a/yarn-project/pxe/src/storage/note_data_provider/note_data_provider.test.ts
+++ b/yarn-project/pxe/src/storage/note_data_provider/note_data_provider.test.ts
@@ -1,6 +1,4 @@
-import { toBufferBE } from '@aztec/foundation/bigint-buffer';
 import { Fr } from '@aztec/foundation/fields';
-import { toArray } from '@aztec/foundation/iterable';
 import { AztecLMDBStoreV2, openTmpStore } from '@aztec/kv-store/lmdb-v2';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import { L2BlockHash } from '@aztec/stdlib/block';
@@ -327,29 +325,14 @@ describe('NoteDataProvider', () => {
       await store.close();
     });
 
-    it('skips re-adding active notes and avoids duplicate scope entries', async () => {
-      await provider.addNotes([note1], SCOPE_1);
-
-      const noteIndexHex = toBufferBE(note1.index, 32).toString('hex');
-      const notesToScopeIndex = store.openMultiMap<string, string>('notes_to_scope');
-      const storedScopes = await toArray(notesToScopeIndex.getValuesAsync(noteIndexHex));
-
-      expect(storedScopes).toEqual([SCOPE_1.toString()]);
-    });
-
     it('skips re-adding nullified notes so they remain inactive', async () => {
+      // We nullify the note and then add it again and then we check it is not returned as active.
       await provider.applyNullifiers([mkNullifier(note1)]);
-
       await provider.addNotes([note1], SCOPE_1);
 
+      // Setup adds 2 notes for contractA - below we check that only note2 is active.
       const activeNotes = await provider.getNotes({ contractAddress: CONTRACT_A });
-      expect(new Set(getIndexes(activeNotes))).toEqual(new Set([2n]));
-
-      const allNotes = await provider.getNotes({
-        contractAddress: CONTRACT_A,
-        status: NoteStatus.ACTIVE_OR_NULLIFIED,
-      });
-      expect(new Set(getIndexes(allNotes))).toEqual(new Set([1n, 2n]));
+      expect(getIndexes(activeNotes)).toEqual([2n]);
     });
   });
 

--- a/yarn-project/pxe/src/storage/note_data_provider/note_data_provider.ts
+++ b/yarn-project/pxe/src/storage/note_data_provider/note_data_provider.ts
@@ -1,6 +1,7 @@
 import { toBufferBE } from '@aztec/foundation/bigint-buffer';
 import type { Fr } from '@aztec/foundation/fields';
 import { toArray } from '@aztec/foundation/iterable';
+import { type Logger, createLogger } from '@aztec/foundation/log';
 import type { AztecAsyncKVStore, AztecAsyncMap, AztecAsyncMultiMap } from '@aztec/kv-store';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import type { InBlock } from '@aztec/stdlib/block';
@@ -31,6 +32,8 @@ export class NoteDataProvider {
   #notesByContractAndScope: Map<string, AztecAsyncMultiMap<string, string>>;
   #notesByStorageSlotAndScope: Map<string, AztecAsyncMultiMap<string, string>>;
 
+  #log: Logger;
+
   private constructor(store: AztecAsyncKVStore) {
     this.#store = store;
     this.#notes = store.openMap('notes');
@@ -47,6 +50,8 @@ export class NoteDataProvider {
     this.#notesToScope = store.openMultiMap('notes_to_scope');
     this.#notesByContractAndScope = new Map<string, AztecAsyncMultiMap<string, string>>();
     this.#notesByStorageSlotAndScope = new Map<string, AztecAsyncMultiMap<string, string>>();
+
+    this.#log = createLogger('pxe:note_data_provider');
   }
 
   /**
@@ -102,18 +107,39 @@ export class NoteDataProvider {
    */
   addNotes(notes: NoteDao[], scope: AztecAddress): Promise<void> {
     return this.#store.transactionAsync(async () => {
-      if (!(await this.#scopes.hasAsync(scope.toString()))) {
+      const scopeString = scope.toString();
+      if (!(await this.#scopes.hasAsync(scopeString))) {
         await this.addScope(scope);
       }
 
       for (const dao of notes) {
         const noteIndex = toBufferBE(dao.index, 32).toString('hex');
+        if (await this.#notes.hasAsync(noteIndex)) {
+          this.#log.info('Skipping note already present in active notes', {
+            noteIndex,
+            scope: scopeString,
+            contractAddress: dao.contractAddress.toString(),
+            siloedNullifier: dao.siloedNullifier.toString(),
+          });
+          continue;
+        }
+
+        if (await this.#nullifiedNotes.hasAsync(noteIndex)) {
+          this.#log.info('Skipping note already present in nullified notes', {
+            noteIndex,
+            scope: scopeString,
+            contractAddress: dao.contractAddress.toString(),
+            siloedNullifier: dao.siloedNullifier.toString(),
+          });
+          continue;
+        }
+
         await this.#notes.set(noteIndex, dao.toBuffer());
-        await this.#notesToScope.set(noteIndex, scope.toString());
+        await this.#notesToScope.set(noteIndex, scopeString);
         await this.#nullifierToNoteId.set(dao.siloedNullifier.toString(), noteIndex);
 
-        await this.#notesByContractAndScope.get(scope.toString())!.set(dao.contractAddress.toString(), noteIndex);
-        await this.#notesByStorageSlotAndScope.get(scope.toString())!.set(dao.storageSlot.toString(), noteIndex);
+        await this.#notesByContractAndScope.get(scopeString)!.set(dao.contractAddress.toString(), noteIndex);
+        await this.#notesByStorageSlotAndScope.get(scopeString)!.set(dao.storageSlot.toString(), noteIndex);
       }
     });
   }

--- a/yarn-project/pxe/src/storage/note_data_provider/note_data_provider.ts
+++ b/yarn-project/pxe/src/storage/note_data_provider/note_data_provider.ts
@@ -115,6 +115,10 @@ export class NoteDataProvider {
       for (const dao of notes) {
         const noteIndex = toBufferBE(dao.index, 32).toString('hex');
         if (await this.#notes.hasAsync(noteIndex)) {
+          // Without this check, we would simply overwrite the existing value with the same data, which would not cause
+          // any issues. However, for clarity, we log a message here and skip further processing. This is expected
+          // because, due to the mechanics of tagging synchronization, the same private log may be processed multiple
+          // times.
           this.#log.info('Skipping note already present in active notes', {
             noteIndex,
             scope: scopeString,
@@ -125,6 +129,10 @@ export class NoteDataProvider {
         }
 
         if (await this.#nullifiedNotes.hasAsync(noteIndex)) {
+          // Without this check, the note would exist in both the active and nullified notes upon re-adding it. While
+          // this wouldn't cause a bug—since private state sync would identify the note as nullified and remove it from
+          // the active notes — it would be inefficient, as in case there would be no other active notes this would
+          // result in one extra call to the node.
           this.#log.info('Skipping note already present in nullified notes', {
             noteIndex,
             scope: scopeString,


### PR DESCRIPTION
Before this PR when a note data provider received a note on the input it didn't check if the note already exists in the notes store or in the nullified notes store. This is very inefficient in case the note was already in the nullified notes because it forces us to look again for the note nullifiers upon private state sync [here](https://github.com/AztecProtocol/aztec-packages/blob/af8bd166d6da88884677bca22248d49ef6b60600/yarn-project/pxe/src/contract_function_simulator/pxe_oracle_interface.ts#L921).

I originally reported this issue on some of Josie's PRs but she never got to implementing this.