### PR TITLE
feat: panicking on incorrectly performed calls

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/context/call_interfaces.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/call_interfaces.nr
@@ -18,6 +18,7 @@ pub trait CallInterface<let N: u32> {
 
 // PrivateCallInterface
 
+#[must_use = "Your private call needs to be passed into the `self.call(...)` method to be executed (e.g. `self.call(MyContract::at(address).my_private_function(...args))`"]
 pub struct PrivateCallInterface<let M: u32, T> {
     target_contract: AztecAddress,
     selector: FunctionSelector,
@@ -94,6 +95,7 @@ impl<let M: u32, T> CallInterface<M> for PrivateCallInterface<M, T> {
 
 // PrivateStaticCallInterface
 
+#[must_use = "Your private static call needs to be passed into the `self.view(...)` method to be executed (e.g. `self.view(MyContract::at(address).my_private_static_function(...args))`"]
 pub struct PrivateStaticCallInterface<let M: u32, T> {
     target_contract: AztecAddress,
     selector: FunctionSelector,
@@ -166,6 +168,7 @@ impl<let M: u32, T> CallInterface<M> for PrivateStaticCallInterface<M, T> {
 
 // PublicCallInterface
 
+#[must_use = "Your public call needs to be passed into the `self.call(...)`, `self.enqueue(...)` or `self.enqueue_incognito(...)` method to be executed (e.g. `self.call(MyContract::at(address).my_public_function(...args))`"]
 pub struct PublicCallInterface<let M: u32, T> {
     target_contract: AztecAddress,
     selector: FunctionSelector,
@@ -306,6 +309,7 @@ impl<let M: u32, T> CallInterface<M> for PublicCallInterface<M, T> {
 
 // PublicStaticCallInterface
 
+#[must_use = "Your public static call needs to be passed into the `self.view(...)`, `self.enqueue_view(...)` or `self.enqueue_view_incognito(...)` method to be executed (e.g. `self.view(MyContract::at(address).my_public_static_function(...args))`"]
 pub struct PublicStaticCallInterface<let M: u32, T> {
     target_contract: AztecAddress,
     selector: FunctionSelector,

--- a/noir-projects/noir-contracts-comp-failures/contracts/panic_on_incorrectly_performed_private_call/Nargo.toml
+++ b/noir-projects/noir-contracts-comp-failures/contracts/panic_on_incorrectly_performed_private_call/Nargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "panic_on_incorrectly_performed_private_call"
+authors = [""]
+compiler_version = ">=0.25.0"
+type = "contract"
+
+[dependencies]
+aztec = { path = "../../../aztec-nr/aztec" }

--- a/noir-projects/noir-contracts-comp-failures/contracts/panic_on_incorrectly_performed_private_call/expected_error
+++ b/noir-projects/noir-contracts-comp-failures/contracts/panic_on_incorrectly_performed_private_call/expected_error
@@ -1,0 +1,1 @@
+Your private call needs to be passed into the `self.call(...)` method to be executed (e.g. `self.call(MyContract::at(address).my_private_function(...args))`

--- a/noir-projects/noir-contracts-comp-failures/contracts/panic_on_incorrectly_performed_private_call/src/main.nr
+++ b/noir-projects/noir-contracts-comp-failures/contracts/panic_on_incorrectly_performed_private_call/src/main.nr
@@ -1,0 +1,11 @@
+use aztec::macros::aztec;
+
+#[aztec]
+pub contract PanicOnIncorrectlyPerformedPrivateCall {
+    use aztec::{macros::functions::external, protocol_types::address::AztecAddress};
+
+    #[external("private")]
+    fn arbitrary_external_function() {
+        PanicOnIncorrectlyPerformedPrivateCall::at(AztecAddress::ZERO).arbitrary_external_function();
+    }
+}

--- a/noir-projects/noir-contracts-comp-failures/contracts/panic_on_incorrectly_performed_private_static_call/Nargo.toml
+++ b/noir-projects/noir-contracts-comp-failures/contracts/panic_on_incorrectly_performed_private_static_call/Nargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "panic_on_incorrectly_performed_private_static_call"
+authors = [""]
+compiler_version = ">=0.25.0"
+type = "contract"
+
+[dependencies]
+aztec = { path = "../../../aztec-nr/aztec" }
+

--- a/noir-projects/noir-contracts-comp-failures/contracts/panic_on_incorrectly_performed_private_static_call/expected_error
+++ b/noir-projects/noir-contracts-comp-failures/contracts/panic_on_incorrectly_performed_private_static_call/expected_error
@@ -1,0 +1,2 @@
+Your private static call needs to be passed into the `self.view(...)` method to be executed (e.g. `self.view(MyContract::at(address).my_private_static_function(...args))`
+

--- a/noir-projects/noir-contracts-comp-failures/contracts/panic_on_incorrectly_performed_private_static_call/src/main.nr
+++ b/noir-projects/noir-contracts-comp-failures/contracts/panic_on_incorrectly_performed_private_static_call/src/main.nr
@@ -1,0 +1,22 @@
+use aztec::macros::aztec;
+
+#[aztec]
+pub contract PanicOnIncorrectlyPerformedPrivateStaticCall {
+    use aztec::{
+        macros::functions::{external, view},
+        protocol_types::address::AztecAddress,
+    };
+
+    #[external("private")]
+    #[view]
+    fn arbitrary_view_function() -> Field {
+        0
+    }
+
+    #[external("private")]
+    fn call_static_function_without_view() {
+        PanicOnIncorrectlyPerformedPrivateStaticCall::at(AztecAddress::ZERO)
+            .arbitrary_view_function();
+    }
+}
+

--- a/noir-projects/noir-contracts-comp-failures/contracts/panic_on_incorrectly_performed_public_call/Nargo.toml
+++ b/noir-projects/noir-contracts-comp-failures/contracts/panic_on_incorrectly_performed_public_call/Nargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "panic_on_incorrectly_performed_public_call"
+authors = [""]
+compiler_version = ">=0.25.0"
+type = "contract"
+
+[dependencies]
+aztec = { path = "../../../aztec-nr/aztec" }
+

--- a/noir-projects/noir-contracts-comp-failures/contracts/panic_on_incorrectly_performed_public_call/expected_error
+++ b/noir-projects/noir-contracts-comp-failures/contracts/panic_on_incorrectly_performed_public_call/expected_error
@@ -1,0 +1,2 @@
+Your public call needs to be passed into the `self.call(...)`, `self.enqueue(...)` or `self.enqueue_incognito(...)` method to be executed (e.g. `self.call(MyContract::at(address).my_public_function(...args))`
+

--- a/noir-projects/noir-contracts-comp-failures/contracts/panic_on_incorrectly_performed_public_call/src/main.nr
+++ b/noir-projects/noir-contracts-comp-failures/contracts/panic_on_incorrectly_performed_public_call/src/main.nr
@@ -1,0 +1,15 @@
+use aztec::macros::aztec;
+
+#[aztec]
+pub contract PanicOnIncorrectlyPerformedPublicCall {
+    use aztec::{macros::functions::external, protocol_types::address::AztecAddress};
+
+    #[external("public")]
+    fn arbitrary_public_function() {}
+
+    #[external("public")]
+    fn call_public_function_without_call() {
+        PanicOnIncorrectlyPerformedPublicCall::at(AztecAddress::ZERO).arbitrary_public_function();
+    }
+}
+

--- a/noir-projects/noir-contracts-comp-failures/contracts/panic_on_incorrectly_performed_public_static_call/Nargo.toml
+++ b/noir-projects/noir-contracts-comp-failures/contracts/panic_on_incorrectly_performed_public_static_call/Nargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "panic_on_incorrectly_performed_public_static_call"
+authors = [""]
+compiler_version = ">=0.25.0"
+type = "contract"
+
+[dependencies]
+aztec = { path = "../../../aztec-nr/aztec" }
+

--- a/noir-projects/noir-contracts-comp-failures/contracts/panic_on_incorrectly_performed_public_static_call/expected_error
+++ b/noir-projects/noir-contracts-comp-failures/contracts/panic_on_incorrectly_performed_public_static_call/expected_error
@@ -1,0 +1,2 @@
+Your public static call needs to be passed into the `self.view(...)`, `self.enqueue_view(...)` or `self.enqueue_view_incognito(...)` method to be executed (e.g. `self.view(MyContract::at(address).my_public_static_function(...args))`
+

--- a/noir-projects/noir-contracts-comp-failures/contracts/panic_on_incorrectly_performed_public_static_call/src/main.nr
+++ b/noir-projects/noir-contracts-comp-failures/contracts/panic_on_incorrectly_performed_public_static_call/src/main.nr
@@ -1,0 +1,22 @@
+use aztec::macros::aztec;
+
+#[aztec]
+pub contract PanicOnIncorrectlyPerformedPublicStaticCall {
+    use aztec::{
+        macros::functions::{external, view},
+        protocol_types::address::AztecAddress,
+    };
+
+    #[external("public")]
+    #[view]
+    fn arbitrary_public_static_function() -> Field {
+        0
+    }
+
+    #[external("public")]
+    fn call_public_static_function_without_view() {
+        PanicOnIncorrectlyPerformedPublicStaticCall::at(AztecAddress::ZERO)
+            .arbitrary_public_static_function();
+    }
+}
+


### PR DESCRIPTION
Getting a nice error message when a dev does this:

```noir
MyContract::at(address).my_private_function(...);
```

instead of this:

```noir
self.call(MyContract::at(address).my_private_function(...));
```

by using the new `#[must_use = "..."]` thingy which I slap onto the `CallInterface` structs.