### PR TITLE
refactor!: prohibiting static calls via non-static interface

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/context/call_interfaces.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/call_interfaces.nr
@@ -68,20 +68,6 @@ where
         // returns hash is empty as per the protocol rules.
         returns_hash.get_preimage()
     }
-
-    /// TODO(F-130): Drop this function. This should be present only on PrivateStaticCallInterface.
-    pub fn view(self, context: &mut PrivateContext) -> T {
-        execution_cache::store(self.args, self.args_hash);
-        let returns_hash = context.call_private_function_with_args_hash(
-            self.target_contract,
-            self.selector,
-            self.args_hash,
-            true,
-        );
-        // If T is () (i.e. if the function does not return anything) then `get_preimage` will constrain that the
-        // returns hash is empty as per the protocol rules.
-        returns_hash.get_preimage()
-    }
 }
 
 impl<let M: u32, T> CallInterface<M> for PrivateCallInterface<M, T> {
@@ -234,19 +220,6 @@ where
         Deserialize::deserialize(returns.as_array())
     }
 
-    /// TODO(F-130): Drop this function. This should be present only on PublicStaticCallInterface.
-    pub unconstrained fn view(self, context: PublicContext) -> T {
-        let returns = context.static_call_public_function(
-            self.target_contract,
-            self.selector,
-            self.args,
-            self.gas_opts,
-        );
-        // If T is () (i.e. if the function does not return anything) then `as_array` will constrain that `returns` has
-        // a length of 0 (since that is ()'s deserialization length).
-        Deserialize::deserialize(returns.as_array())
-    }
-
     /// **[DEPRECATED]**
     /// This function is deprecated. Please use the new contract API:
     /// `self.enqueue(MyContract::at(address).my_public_function(...args))`
@@ -261,16 +234,6 @@ where
     /// instead of manually constructing and calling `PublicCallInterface`.
     pub fn enqueue_incognito(self, context: &mut PrivateContext) {
         self.enqueue_impl(context, false, true)
-    }
-
-    /// TODO(F-130): Drop this function. This should be present only on PublicStaticCallInterface.
-    pub fn enqueue_view(self, context: &mut PrivateContext) {
-        self.enqueue_impl(context, true, false)
-    }
-
-    /// TODO(F-130): Drop this function. This should be present only on PublicStaticCallInterface.
-    pub fn enqueue_view_incognito(self, context: &mut PrivateContext) {
-        self.enqueue_impl(context, true, true)
     }
 
     fn enqueue_impl(

--- a/noir-projects/noir-contracts/contracts/test/avm_test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/avm_test_contract/src/main.nr
@@ -827,13 +827,27 @@ pub contract AvmTest {
         arg_a: Field,
         arg_b: Field,
     ) -> Field {
-        AvmTest::at(address).add_args_return(arg_a, arg_b).view(context)
+        let selector =
+            comptime { FunctionSelector::from_signature("add_args_return(Field,Field)") };
+        context.static_call_public_function(
+            address,
+            selector,
+            [arg_a, arg_b].as_slice(),
+            GasOpts::default(),
+        )[0]
     }
 
     // Indirectly call_static `set_storage_single`. Should revert since it's accessing self.storage.
     #[external("public")]
     fn nested_static_call_to_set_storage() {
-        AvmTest::at(self.address).set_storage_single(20).view(self.context);
+        let selector = comptime { FunctionSelector::from_signature("set_storage_single(Field)") };
+        let args = [20 as Field];
+        let _ = self.context.static_call_public_function(
+            self.address,
+            selector,
+            args.as_slice(),
+            GasOpts::default(),
+        );
     }
 
     #[external("public")]

--- a/noir-projects/noir-contracts/contracts/test/static_parent_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/static_parent_contract/src/main.nr
@@ -5,7 +5,7 @@ use dep::aztec::macros::aztec;
 pub contract StaticParent {
     use dep::aztec::{context::gas::GasOpts, macros::functions::{external, view}};
     use dep::aztec::protocol_types::{
-        abis::function_selector::FunctionSelector, address::AztecAddress,
+        abis::function_selector::FunctionSelector, address::AztecAddress, traits::ToField,
     };
     use dep::static_child_contract::StaticChild;
 
@@ -98,12 +98,18 @@ pub contract StaticParent {
         target_selector: FunctionSelector,
         args: [Field; 2],
     ) -> Field {
-        // Not using the new self.view(...) API because that doesn't allow for static calls to non-static functions
-        // which this test seems to rely on. TODO(F-130): Address this and replace e2e_static_calls.test.ts with Noir
-        // tests.
-        StaticParent::at(self.address).private_call(target_contract, target_selector, args).view(
-            self.context,
-        )
+        // Not using the high-level self.view(...) API because that doesn't allow for static calls to non-static
+        // functions which this test seems to relies on.
+        let private_call_selector =
+            FunctionSelector::from_signature("private_call((Field),(u32),[Field;2])");
+        self
+            .context
+            .static_call_private_function(
+                self.address,
+                private_call_selector,
+                [target_contract.to_field(), target_selector.to_field(), args[0], args[1]],
+            )
+            .get_preimage()
     }
 
     // Just like function above but with 3 args.


### PR DESCRIPTION
Fixes F-130

Allowing for this was sad and ugly so I dropped it.