### PR TITLE
chore: blake3s cleanup and add tests

### DIFF
--- a/barretenberg/cpp/src/barretenberg/stdlib/hash/blake3s/blake3s.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/hash/blake3s/blake3s.cpp
@@ -19,7 +19,7 @@ using namespace blake_util;
  */
 template <typename Builder>
 void Blake3s<Builder>::compress_pre(field_ct state[BLAKE3_STATE_SIZE],
-                                    const field_ct cv[8],
+                                    const field_ct cv[BLAKE3_CV_WORDS],
                                     const byte_array_ct& block,
                                     uint8_t block_len,
                                     uint8_t flags)
@@ -52,7 +52,10 @@ void Blake3s<Builder>::compress_pre(field_ct state[BLAKE3_STATE_SIZE],
 }
 
 template <typename Builder>
-void Blake3s<Builder>::compress_in_place(field_ct cv[8], const byte_array_ct& block, uint8_t block_len, uint8_t flags)
+void Blake3s<Builder>::compress_in_place(field_ct cv[BLAKE3_CV_WORDS],
+                                         const byte_array_ct& block,
+                                         uint8_t block_len,
+                                         uint8_t flags)
 {
     field_ct state[BLAKE3_STATE_SIZE];
     compress_pre(state, cv, block, block_len, flags);
@@ -71,8 +74,11 @@ void Blake3s<Builder>::compress_in_place(field_ct cv[8], const byte_array_ct& bl
 }
 
 template <typename Builder>
-void Blake3s<Builder>::compress_xof(
-    const field_ct cv[8], const byte_array_ct& block, uint8_t block_len, uint8_t flags, byte_array_ct& out)
+void Blake3s<Builder>::compress_xof(const field_ct cv[BLAKE3_CV_WORDS],
+                                    const byte_array_ct& block,
+                                    uint8_t block_len,
+                                    uint8_t flags,
+                                    byte_array_ct& out)
 {
     field_ct state[BLAKE3_STATE_SIZE];
 
@@ -98,7 +104,7 @@ void Blake3s<Builder>::compress_xof(
 }
 
 template <typename Builder>
-Blake3s<Builder>::output_t Blake3s<Builder>::make_output(const field_ct input_cv[8],
+Blake3s<Builder>::output_t Blake3s<Builder>::make_output(const field_ct input_cv[BLAKE3_CV_WORDS],
                                                          const byte_array_ct& block,
                                                          uint8_t block_len,
                                                          uint8_t flags)

--- a/barretenberg/cpp/src/barretenberg/stdlib/hash/blake3s/blake3s.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/hash/blake3s/blake3s.cpp
@@ -18,9 +18,9 @@ using namespace blake_util;
  *
  */
 template <typename Builder>
-void Blake3s<Builder>::compress_pre(field_t<Builder> state[BLAKE3_STATE_SIZE],
-                                    const field_t<Builder> cv[8],
-                                    const byte_array<Builder>& block,
+void Blake3s<Builder>::compress_pre(field_ct state[BLAKE3_STATE_SIZE],
+                                    const field_ct cv[8],
+                                    const byte_array_ct& block,
                                     uint8_t block_len,
                                     uint8_t flags)
 {
@@ -52,10 +52,7 @@ void Blake3s<Builder>::compress_pre(field_t<Builder> state[BLAKE3_STATE_SIZE],
 }
 
 template <typename Builder>
-void Blake3s<Builder>::compress_in_place(field_t<Builder> cv[8],
-                                         const byte_array<Builder>& block,
-                                         uint8_t block_len,
-                                         uint8_t flags)
+void Blake3s<Builder>::compress_in_place(field_ct cv[8], const byte_array_ct& block, uint8_t block_len, uint8_t flags)
 {
     field_ct state[BLAKE3_STATE_SIZE];
     compress_pre(state, cv, block, block_len, flags);
@@ -65,7 +62,7 @@ void Blake3s<Builder>::compress_in_place(field_t<Builder> cv[8],
      * create unexpected overflow in the state matrix. At the end of the `compress_pre()` function, there might be
      * overflows in the elements of the first and third rows of the state matrix. But this wouldn't be a problem because
      * in the below loop, while reading from the lookup table, we ensure that the overflow is ignored and the result is
-     * contrained to 32 bits.
+     * constrained to 32 bits.
      */
     for (size_t i = 0; i < (BLAKE3_STATE_SIZE >> 1); i++) {
         const auto lookup = plookup_read<Builder>::get_lookup_accumulators(BLAKE_XOR, state[i], state[i + 8], true);
@@ -74,11 +71,8 @@ void Blake3s<Builder>::compress_in_place(field_t<Builder> cv[8],
 }
 
 template <typename Builder>
-void Blake3s<Builder>::compress_xof(const field_t<Builder> cv[8],
-                                    const byte_array<Builder>& block,
-                                    uint8_t block_len,
-                                    uint8_t flags,
-                                    byte_array<Builder>& out)
+void Blake3s<Builder>::compress_xof(
+    const field_ct cv[8], const byte_array_ct& block, uint8_t block_len, uint8_t flags, byte_array_ct& out)
 {
     field_ct state[BLAKE3_STATE_SIZE];
 
@@ -91,21 +85,21 @@ void Blake3s<Builder>::compress_xof(const field_t<Builder> cv[8],
     for (size_t i = 0; i < (BLAKE3_STATE_SIZE >> 1); i++) {
         const auto lookup_1 = plookup_read<Builder>::get_lookup_accumulators(BLAKE_XOR, state[i], state[i + 8], true);
         // byte_array(field, num_bytes) constructor adds range constraints for each byte
-        byte_array<Builder> out_bytes_1(lookup_1[ColumnIdx::C3][0], 4);
+        byte_array_ct out_bytes_1(lookup_1[ColumnIdx::C3][0], 4);
         // Safe write: both out and out_bytes_1 are constrained
         out.write_at(out_bytes_1.reverse(), i * 4);
 
         const auto lookup_2 = plookup_read<Builder>::get_lookup_accumulators(BLAKE_XOR, state[i + 8], cv[i], true);
         // byte_array(field, num_bytes) constructor adds range constraints for each byte
-        byte_array<Builder> out_bytes_2(lookup_2[ColumnIdx::C3][0], 4);
+        byte_array_ct out_bytes_2(lookup_2[ColumnIdx::C3][0], 4);
         // Safe write: both out and out_bytes_2 are constrained
         out.write_at(out_bytes_2.reverse(), (i + 8) * 4);
     }
 }
 
 template <typename Builder>
-Blake3s<Builder>::output_t Blake3s<Builder>::make_output(const field_t<Builder> input_cv[8],
-                                                         const byte_array<Builder>& block,
+Blake3s<Builder>::output_t Blake3s<Builder>::make_output(const field_ct input_cv[8],
+                                                         const byte_array_ct& block,
                                                          uint8_t block_len,
                                                          uint8_t flags)
 {
@@ -138,7 +132,7 @@ template <typename Builder> void Blake3s<Builder>::hasher_init(blake3_hasher* se
 }
 
 template <typename Builder>
-void Blake3s<Builder>::hasher_update(blake3_hasher* self, const byte_array<Builder>& input, size_t input_len)
+void Blake3s<Builder>::hasher_update(blake3_hasher* self, const byte_array_ct& input, size_t input_len)
 {
     if (input_len == 0) {
         return;
@@ -160,14 +154,14 @@ void Blake3s<Builder>::hasher_update(blake3_hasher* self, const byte_array<Build
         take = input_len;
     }
     // Copy bytes from input to buf (input is constrained)
-    byte_array<Builder> input_slice = input.slice(start_counter, take);
+    byte_array_ct input_slice = input.slice(start_counter, take);
     self->buf.write_at(input_slice, self->buf_len);
 
     self->buf_len = static_cast<uint8_t>(self->buf_len + (uint8_t)take);
     input_len -= take;
 }
 
-template <typename Builder> void Blake3s<Builder>::hasher_finalize(const blake3_hasher* self, byte_array<Builder>& out)
+template <typename Builder> void Blake3s<Builder>::hasher_finalize(const blake3_hasher* self, byte_array_ct& out)
 {
     uint8_t block_flags = self->flags | maybe_start_flag(self) | CHUNK_END;
     output_t output = make_output(self->cv, self->buf, self->buf_len, block_flags);
@@ -179,7 +173,7 @@ template <typename Builder> void Blake3s<Builder>::hasher_finalize(const blake3_
     out = wide_buf.slice(0, BLAKE3_OUT_LEN);
 }
 
-template <typename Builder> byte_array<Builder> Blake3s<Builder>::hash(const byte_array<Builder>& input)
+template <typename Builder> byte_array<Builder> Blake3s<Builder>::hash(const byte_array_ct& input)
 {
     BB_ASSERT(input.size() <= BLAKE3_CHUNK_LEN,
               "Barretenberg does not support blake3s with input lengths greater than 1024 bytes.");

--- a/barretenberg/cpp/src/barretenberg/stdlib/hash/blake3s/blake3s.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/hash/blake3s/blake3s.hpp
@@ -15,11 +15,9 @@ template <typename Builder> class Blake3s {
     using byte_array_ct = byte_array<Builder>;
     using field_ct = field_t<Builder>;
 
-/*
- * Constants and more.
- */
-#define BLAKE3_VERSION_STRING "0.3.7"
-
+    /*
+     * Constants and more.
+     */
     // internal flags
     enum blake3_flags {
         CHUNK_START = 1 << 0,
@@ -38,9 +36,9 @@ template <typename Builder> class Blake3s {
                                                  0x510E527FUL, 0x9B05688CUL, 0x1F83D9ABUL, 0x5BE0CD19UL };
 
     struct blake3_hasher {
-        field_t<Builder> key[8];
-        field_t<Builder> cv[8];
-        byte_array<Builder> buf;
+        field_ct key[8];
+        field_ct cv[8];
+        byte_array_ct buf;
         uint8_t buf_len;
         uint8_t blocks_compressed;
         uint8_t flags;
@@ -48,21 +46,21 @@ template <typename Builder> class Blake3s {
     };
 
     struct output_t {
-        field_t<Builder> input_cv[8];
-        byte_array<Builder> block;
+        field_ct input_cv[8];
+        byte_array_ct block;
         uint8_t block_len;
         uint8_t flags;
     };
-    static void compress_pre(field_t<Builder> state[BLAKE3_STATE_SIZE],
-                             const field_t<Builder> cv[8],
+    static void compress_pre(field_ct state[BLAKE3_STATE_SIZE],
+                             const field_ct cv[8],
                              const byte_array_ct& block,
                              uint8_t block_len,
                              uint8_t flags);
 
-    static void compress_in_place(field_t<Builder> cv[8], const byte_array_ct& block, uint8_t block_len, uint8_t flags);
+    static void compress_in_place(field_ct cv[8], const byte_array_ct& block, uint8_t block_len, uint8_t flags);
 
     static void compress_xof(
-        const field_t<Builder> cv[8], const byte_array_ct& block, uint8_t block_len, uint8_t flags, byte_array_ct& out);
+        const field_ct cv[8], const byte_array_ct& block, uint8_t block_len, uint8_t flags, byte_array_ct& out);
 
     /*
      * Blake3s helper functions.
@@ -76,7 +74,7 @@ template <typename Builder> class Blake3s {
             return 0;
         }
     }
-    static output_t make_output(const field_t<Builder> input_cv[8],
+    static output_t make_output(const field_ct input_cv[8],
                                 const byte_array_ct& block,
                                 uint8_t block_len,
                                 uint8_t flags);

--- a/barretenberg/cpp/src/barretenberg/stdlib/hash/blake3s/blake3s.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/hash/blake3s/blake3s.hpp
@@ -29,6 +29,9 @@ template <typename Builder> class Blake3s {
         DERIVE_KEY_MATERIAL = 1 << 6,
     };
     static constexpr size_t BLAKE3_STATE_SIZE = stdlib::blake_util::BLAKE_STATE_SIZE;
+
+    static constexpr size_t BLAKE3_CV_WORDS = 8;
+
     // constants
     enum blake3s_constant { BLAKE3_KEY_LEN = 32, BLAKE3_OUT_LEN = 32, BLAKE3_BLOCK_LEN = 64, BLAKE3_CHUNK_LEN = 1024 };
 
@@ -36,8 +39,8 @@ template <typename Builder> class Blake3s {
                                                  0x510E527FUL, 0x9B05688CUL, 0x1F83D9ABUL, 0x5BE0CD19UL };
 
     struct blake3_hasher {
-        field_ct key[8];
-        field_ct cv[8];
+        field_ct key[BLAKE3_CV_WORDS];
+        field_ct cv[BLAKE3_CV_WORDS];
         byte_array_ct buf;
         uint8_t buf_len;
         uint8_t blocks_compressed;
@@ -46,21 +49,27 @@ template <typename Builder> class Blake3s {
     };
 
     struct output_t {
-        field_ct input_cv[8];
+        field_ct input_cv[BLAKE3_CV_WORDS];
         byte_array_ct block;
         uint8_t block_len;
         uint8_t flags;
     };
     static void compress_pre(field_ct state[BLAKE3_STATE_SIZE],
-                             const field_ct cv[8],
+                             const field_ct cv[BLAKE3_CV_WORDS],
                              const byte_array_ct& block,
                              uint8_t block_len,
                              uint8_t flags);
 
-    static void compress_in_place(field_ct cv[8], const byte_array_ct& block, uint8_t block_len, uint8_t flags);
+    static void compress_in_place(field_ct cv[BLAKE3_CV_WORDS],
+                                  const byte_array_ct& block,
+                                  uint8_t block_len,
+                                  uint8_t flags);
 
-    static void compress_xof(
-        const field_ct cv[8], const byte_array_ct& block, uint8_t block_len, uint8_t flags, byte_array_ct& out);
+    static void compress_xof(const field_ct cv[BLAKE3_CV_WORDS],
+                             const byte_array_ct& block,
+                             uint8_t block_len,
+                             uint8_t flags,
+                             byte_array_ct& out);
 
     /*
      * Blake3s helper functions.
@@ -74,7 +83,7 @@ template <typename Builder> class Blake3s {
             return 0;
         }
     }
-    static output_t make_output(const field_ct input_cv[8],
+    static output_t make_output(const field_ct input_cv[BLAKE3_CV_WORDS],
                                 const byte_array_ct& block,
                                 uint8_t block_len,
                                 uint8_t flags);

--- a/barretenberg/cpp/src/barretenberg/stdlib/hash/blake3s/blake3s.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/hash/blake3s/blake3s.test.cpp
@@ -7,18 +7,32 @@
 
 using namespace bb;
 
-using byte_array_plookup = stdlib::byte_array<bb::UltraCircuitBuilder>;
-using public_witness_t_plookup = stdlib::public_witness_t<bb::UltraCircuitBuilder>;
+using byte_array_ct = stdlib::byte_array<bb::UltraCircuitBuilder>;
 using UltraBuilder = UltraCircuitBuilder;
 
-TEST(stdlib_blake3s, test_single_block_plookup)
+std::vector<std::string> test_vectors = { std::string{},
+                                          "a",
+                                          "ab",
+                                          "abc",
+                                          "abcd",
+                                          "abcdefg",
+                                          "abcdefgh",
+                                          "abcdefghijklmnopqrstuvwxyz01234",
+                                          "abcdefghijklmnopqrstuvwxyz012345",
+                                          "abcdefghijklmnopqrstuvwxyz0123456",
+                                          "abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0",
+                                          "abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz01",
+                                          "abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz012",
+                                          "abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789" };
+
+TEST(stdlib_blake3s, test_single_block)
 {
     auto builder = UltraBuilder();
     std::string input = "abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz01";
     std::vector<uint8_t> input_v(input.begin(), input.end());
 
-    byte_array_plookup input_arr(&builder, input_v);
-    byte_array_plookup output = stdlib::Blake3s<UltraBuilder>::hash(input_arr);
+    byte_array_ct input_arr(&builder, input_v);
+    byte_array_ct output = stdlib::Blake3s<UltraBuilder>::hash(input_arr);
 
     std::vector<uint8_t> expected = blake3::blake3s(input_v);
 
@@ -30,14 +44,14 @@ TEST(stdlib_blake3s, test_single_block_plookup)
     EXPECT_EQ(proof_result, true);
 }
 
-TEST(stdlib_blake3s, test_double_block_plookup)
+TEST(stdlib_blake3s, test_double_block)
 {
     auto builder = UltraBuilder();
     std::string input = "abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789";
     std::vector<uint8_t> input_v(input.begin(), input.end());
 
-    byte_array_plookup input_arr(&builder, input_v);
-    byte_array_plookup output = stdlib::Blake3s<UltraBuilder>::hash(input_arr);
+    byte_array_ct input_arr(&builder, input_v);
+    byte_array_ct output = stdlib::Blake3s<UltraBuilder>::hash(input_arr);
 
     std::vector<uint8_t> expected = blake3::blake3s(input_v);
 
@@ -49,13 +63,75 @@ TEST(stdlib_blake3s, test_double_block_plookup)
     EXPECT_EQ(proof_result, true);
 }
 
-TEST(stdlib_blake3s, test_too_large_input_plookup)
+TEST(stdlib_blake3s, test_too_large_input)
 {
     auto builder = UltraBuilder();
 
     std::vector<uint8_t> input_v(1025, 0);
 
-    byte_array_plookup input_arr(&builder, input_v);
+    byte_array_ct input_arr(&builder, input_v);
     EXPECT_THROW_OR_ABORT(stdlib::Blake3s<UltraBuilder>::hash(input_arr),
                           "Barretenberg does not support blake3s with input lengths greater than 1024 bytes.");
+}
+
+TEST(stdlib_blake3s, test_witness_and_constant)
+{
+    UltraBuilder builder;
+
+    // create a byte array that is a circuit witness
+    std::string witness_str = "abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz";
+    std::vector<uint8_t> witness_str_vec(witness_str.begin(), witness_str.end());
+
+    // create a byte array that is part circuit witness and part circuit constant
+    // start with the witness part, then append constant padding
+    byte_array_ct input_arr(&builder, witness_str_vec);
+    input_arr.write(byte_array_ct::constant_padding(&builder, 1, '0'))
+        .write(byte_array_ct::constant_padding(&builder, 1, '1'));
+
+    // for expected value calculation
+    std::vector<uint8_t> constant_vec = { '0', '1' };
+
+    // create expected input vector by concatenating witness and constant parts
+    std::vector<uint8_t> input_v;
+    input_v.insert(input_v.end(), witness_str_vec.begin(), witness_str_vec.end());
+    input_v.insert(input_v.end(), constant_vec.begin(), constant_vec.end());
+
+    // Verify the circuit input matches the expected input
+    EXPECT_EQ(input_arr.get_value(), input_v);
+
+    // hash the combined byte array
+    byte_array_ct output = stdlib::Blake3s<UltraBuilder>::hash(input_arr);
+
+    // compute expected hash
+    auto expected = blake3::blake3s(input_v);
+
+    EXPECT_EQ(output.get_value(), std::vector<uint8_t>(expected.begin(), expected.end()));
+
+    info("builder gates = ", builder.get_num_finalized_gates_inefficient());
+
+    bool proof_result = CircuitChecker::check(builder);
+    EXPECT_EQ(proof_result, true);
+}
+
+TEST(stdlib_blake3s, test_multiple_sized_blocks)
+{
+    int i = 0;
+
+    for (auto v : test_vectors) {
+        UltraBuilder builder;
+
+        std::vector<uint8_t> input_v(v.begin(), v.end());
+
+        byte_array_ct input_arr(&builder, input_v);
+        byte_array_ct output = stdlib::Blake3s<UltraBuilder>::hash(input_arr);
+
+        auto expected = blake3::blake3s(input_v);
+
+        EXPECT_EQ(output.get_value(), std::vector<uint8_t>(expected.begin(), expected.end()));
+
+        info("test vector ", i++, ".: builder gates = ", builder.get_num_finalized_gates_inefficient());
+
+        bool proof_result = CircuitChecker::check(builder);
+        EXPECT_EQ(proof_result, true);
+    }
 }


### PR DESCRIPTION
Cleanup of the blake3s module. 

- Remove the unused constant `BLAKE_VERSION_STRING`.
- Remove occurrences of `plookup` in string identifiers. 
- Make the use of `field_ct`, `byte_array_ct` consistent given their `using` aliases.
- Add additional tests for varied-sized inputs, including a case with mixed circuit and constant input.  