### PR TITLE
fix: Avoid txs with 0 nullifiers

### DIFF
--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/previous_kernel_for_tail_validator.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/previous_kernel_for_tail_validator.nr
@@ -100,6 +100,11 @@ pub fn validate_previous_kernel_for_tail(
 
     // --- claimed_first_nullifier ---
 
+    assert(
+        previous_kernel_public_inputs.end.nullifiers.length != 0,
+        "TX must create at least one nullifier",
+    );
+
     let claimed_first_nullifier = previous_kernel_public_inputs.claimed_first_nullifier;
 
     let first_nullifier = previous_kernel_public_inputs.end.nullifiers.array[0];

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/tests/private_kernel_tail/previous_kernel_validation_tests.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/tests/private_kernel_tail/previous_kernel_validation_tests.nr
@@ -66,6 +66,14 @@ fn is_not_private_only() {
 
 // --- claimed_first_nullifier ---
 
+#[test(should_fail_with = "TX must create at least one nullifier")]
+fn no_nullifiers() {
+    let mut builder = TestBuilder::new();
+    builder.previous_kernel.nullifiers = BoundedVec::new();
+    builder.previous_kernel.claimed_first_nullifier = 0;
+    let _ = builder.execute();
+}
+
 #[test(should_fail_with = "First nullifier claim was not satisfied")]
 fn first_nullifier_validation() {
     let mut builder = TestBuilder::new();


### PR DESCRIPTION
It was possible to create txs with 0 nullifiers by setting the `claimed_first_nullifier` to zero with a zero `first_nullifier_hint`