### PR TITLE
feat: Debug infra for Honk recursion constraint

### DIFF
--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/honk_recursion_constraint.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/honk_recursion_constraint.cpp
@@ -252,10 +252,28 @@ HonkRecursionConstraintOutput<typename Flavor::CircuitBuilder> create_honk_recur
     UltraRecursiveVerifierOutput<Builder> verifier_output = verifier.template verify_proof<IO>(proof_fields);
 
 #ifndef NDEBUG
+    native_verification_debug<Flavor>(vkey, proof_fields);
+#endif
+
+    // TODO(https://github.com/AztecProtocol/barretenberg/issues/996): investigate whether
+    // assert_equal on public inputs is important, like what the plonk recursion constraint does.
+    return verifier_output;
+}
+
+#ifndef NDEBUG
+/**
+ * @brief Natively verify the stdlib proof for debugging
+ */
+template <typename Flavor>
+void native_verification_debug(const std::shared_ptr<typename Flavor::VerificationKey> vkey,
+                               const bb::stdlib::Proof<typename Flavor::CircuitBuilder>& proof_fields)
+{
     using NativeVerificationKey = typename Flavor::NativeFlavor::VerificationKey;
     using NativeIO = std::conditional_t<HasIPAAccumulator<Flavor>, bb::RollupIO, bb::DefaultIO>;
+
     auto native_vkey = std::make_shared<NativeVerificationKey>(vkey->get_value());
     HonkProof native_proof = proof_fields.get_value();
+
     HonkProof honk_proof;
     HonkProof ipa_proof;
     if constexpr (HasIPAAccumulator<Flavor>) {
@@ -264,9 +282,11 @@ HonkRecursionConstraintOutput<typename Flavor::CircuitBuilder> create_honk_recur
     } else {
         honk_proof = native_proof;
     }
+
     UltraVerifier_<typename Flavor::NativeFlavor> native_verifier(
         native_vkey, VerifierCommitmentKey<curve::Grumpkin>(1 << CONST_ECCVM_LOG_N));
     bool is_valid_proof(native_verifier.template verify_proof<NativeIO>(honk_proof, ipa_proof));
+
     info("===== HONK RECURSION CONSTRAINT DEBUG INFO =====");
     std::string flavor;
     if constexpr (HasIPAAccumulator<Flavor>) {
@@ -277,39 +297,38 @@ HonkRecursionConstraintOutput<typename Flavor::CircuitBuilder> create_honk_recur
         flavor = "Ultra Flavor";
     }
     info("Flavor used: ", flavor);
-    info("Honk recursion constraint: is the native proof corresponding to the in-circuit proof valid? ",
-         is_valid_proof ? "true" : "false");
+    info("Honk recursion constraint: input proof verifies natively: ", is_valid_proof ? "true" : "false");
     info("===== END OF HONK RECURSION CONSTRAINT DEBUG INFO =====");
+}
 #endif
 
-    // TODO(https://github.com/AztecProtocol/barretenberg/issues/996): investigate whether
-    // assert_equal on public inputs is important, like what the plonk recursion constraint does.
-    return verifier_output;
-}
+#define INSTANTIATE_HONK_RECURSION_CONSTRAINT(Flavor)                                                                  \
+    template HonkRecursionConstraintOutput<typename Flavor::CircuitBuilder> create_honk_recursion_constraints<Flavor>( \
+        typename Flavor::CircuitBuilder & builder,                                                                     \
+        const RecursionConstraint& input,                                                                              \
+        bool has_valid_witness_assignments);
 
-template HonkRecursionConstraintOutput<UltraCircuitBuilder> create_honk_recursion_constraints<
-    UltraRecursiveFlavor_<UltraCircuitBuilder>>(UltraCircuitBuilder& builder,
-                                                const RecursionConstraint& input,
-                                                bool has_valid_witness_assignments);
+INSTANTIATE_HONK_RECURSION_CONSTRAINT(UltraRecursiveFlavor_<UltraCircuitBuilder>)
+INSTANTIATE_HONK_RECURSION_CONSTRAINT(UltraRollupRecursiveFlavor_<UltraCircuitBuilder>)
+INSTANTIATE_HONK_RECURSION_CONSTRAINT(UltraRecursiveFlavor_<MegaCircuitBuilder>)
+INSTANTIATE_HONK_RECURSION_CONSTRAINT(UltraZKRecursiveFlavor_<MegaCircuitBuilder>)
+INSTANTIATE_HONK_RECURSION_CONSTRAINT(UltraZKRecursiveFlavor_<UltraCircuitBuilder>)
 
-template HonkRecursionConstraintOutput<UltraCircuitBuilder> create_honk_recursion_constraints<
-    UltraRollupRecursiveFlavor_<UltraCircuitBuilder>>(UltraCircuitBuilder& builder,
-                                                      const RecursionConstraint& input,
-                                                      bool has_valid_witness_assignments);
+#undef INSTANTIATE_HONK_RECURSION_CONSTRAINT
 
-template HonkRecursionConstraintOutput<MegaCircuitBuilder> create_honk_recursion_constraints<
-    UltraRecursiveFlavor_<MegaCircuitBuilder>>(MegaCircuitBuilder& builder,
-                                               const RecursionConstraint& input,
-                                               bool has_valid_witness_assignments);
+#ifndef NDEBUG
+#define INSTANTIATE_NATIVE_VERIFICATION_DEBUG(Flavor)                                                                  \
+    template void native_verification_debug<Flavor>(const std::shared_ptr<typename Flavor::VerificationKey>,           \
+                                                    const bb::stdlib::Proof<typename Flavor::CircuitBuilder>&);
 
-template HonkRecursionConstraintOutput<MegaCircuitBuilder> create_honk_recursion_constraints<
-    UltraZKRecursiveFlavor_<MegaCircuitBuilder>>(MegaCircuitBuilder& builder,
-                                                 const RecursionConstraint& input,
-                                                 bool has_valid_witness_assignments);
+INSTANTIATE_NATIVE_VERIFICATION_DEBUG(UltraRecursiveFlavor_<UltraCircuitBuilder>)
+INSTANTIATE_NATIVE_VERIFICATION_DEBUG(UltraRollupRecursiveFlavor_<UltraCircuitBuilder>)
+INSTANTIATE_NATIVE_VERIFICATION_DEBUG(UltraRecursiveFlavor_<MegaCircuitBuilder>)
+INSTANTIATE_NATIVE_VERIFICATION_DEBUG(UltraZKRecursiveFlavor_<MegaCircuitBuilder>)
+INSTANTIATE_NATIVE_VERIFICATION_DEBUG(UltraZKRecursiveFlavor_<UltraCircuitBuilder>)
 
-template HonkRecursionConstraintOutput<UltraCircuitBuilder> create_honk_recursion_constraints<
-    UltraZKRecursiveFlavor_<UltraCircuitBuilder>>(UltraCircuitBuilder& builder,
-                                                  const RecursionConstraint& input,
-                                                  bool has_valid_witness_assignments);
+#undef INSTANTIATE_NATIVE_VERIFICATION_DEBUG
+
+#endif
 
 } // namespace acir_format

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/honk_recursion_constraint.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/honk_recursion_constraint.cpp
@@ -250,8 +250,40 @@ HonkRecursionConstraintOutput<typename Flavor::CircuitBuilder> create_honk_recur
     auto vk_and_hash = std::make_shared<RecursiveVKAndHash>(vkey, vk_hash);
     RecursiveVerifier verifier(&builder, vk_and_hash);
     UltraRecursiveVerifierOutput<Builder> verifier_output = verifier.template verify_proof<IO>(proof_fields);
-    // TODO(https://github.com/AztecProtocol/barretenberg/issues/996): investigate whether assert_equal on public inputs
-    // is important, like what the plonk recursion constraint does.
+
+#ifndef NDEBUG
+    using NativeVerificationKey = typename Flavor::NativeFlavor::VerificationKey;
+    using NativeIO = std::conditional_t<HasIPAAccumulator<Flavor>, bb::RollupIO, bb::DefaultIO>;
+    auto native_vkey = std::make_shared<NativeVerificationKey>(vkey->get_value());
+    HonkProof native_proof = proof_fields.get_value();
+    HonkProof honk_proof;
+    HonkProof ipa_proof;
+    if constexpr (HasIPAAccumulator<Flavor>) {
+        honk_proof = HonkProof(native_proof.begin(), native_proof.end() - IPA_PROOF_LENGTH);
+        ipa_proof = HonkProof(native_proof.end() - IPA_PROOF_LENGTH, native_proof.end());
+    } else {
+        honk_proof = native_proof;
+    }
+    UltraVerifier_<typename Flavor::NativeFlavor> native_verifier(
+        native_vkey, VerifierCommitmentKey<curve::Grumpkin>(1 << CONST_ECCVM_LOG_N));
+    bool is_valid_proof(native_verifier.template verify_proof<NativeIO>(honk_proof, ipa_proof));
+    info("===== HONK RECURSION CONSTRAINT DEBUG INFO =====");
+    std::string flavor;
+    if constexpr (HasIPAAccumulator<Flavor>) {
+        flavor = "Ultra Rollup Flavor";
+    } else if constexpr (Flavor::HasZK) {
+        flavor = "Ultra ZK Flavor";
+    } else {
+        flavor = "Ultra Flavor";
+    }
+    info("Flavor used: ", flavor);
+    info("Honk recursion constraint: is the native proof corresponding to the in-circuit proof valid? ",
+         is_valid_proof ? "true" : "false");
+    info("===== END OF HONK RECURSION CONSTRAINT DEBUG INFO =====");
+#endif
+
+    // TODO(https://github.com/AztecProtocol/barretenberg/issues/996): investigate whether
+    // assert_equal on public inputs is important, like what the plonk recursion constraint does.
     return verifier_output;
 }
 

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/honk_recursion_constraint.hpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/honk_recursion_constraint.hpp
@@ -29,4 +29,10 @@ create_honk_recursion_constraints(typename Flavor::CircuitBuilder& builder,
                                   bool has_valid_witness_assignments = false)
     requires(IsRecursiveFlavor<Flavor> && IsUltraHonk<typename Flavor::NativeFlavor>);
 
+#ifndef NDEBUG
+template <typename Flavor>
+void native_verification_debug(const std::shared_ptr<typename Flavor::VerificationKey> vkey,
+                               const bb::stdlib::Proof<typename Flavor::CircuitBuilder>& proof_fields);
+#endif
+
 } // namespace acir_format

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/honk_recursion_constraint.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/honk_recursion_constraint.test.cpp
@@ -239,6 +239,9 @@ TYPED_TEST_SUITE(AcirHonkRecursionConstraint, Flavors);
 
 TYPED_TEST(AcirHonkRecursionConstraint, TestHonkRecursionConstraintVKGeneration)
 {
+#ifndef NDEBUG
+    BB_DISABLE_ASSERTS();
+#endif
     std::vector<typename TestFixture::InnerBuilder> layer_1_circuits;
     layer_1_circuits.push_back(TestFixture::create_inner_circuit());
 

--- a/barretenberg/cpp/src/barretenberg/flavor/mega_recursive_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/mega_recursive_flavor.hpp
@@ -187,6 +187,25 @@ template <typename BuilderType> class MegaRecursiveFlavor_ {
                 commitment.fix_witness();
             }
         }
+
+#ifndef NDEBUG
+        /**
+         * @brief Get the native verification key corresponding to this stdlib verification key
+         *
+         * @return NativeVerificationKey
+         */
+        NativeVerificationKey get_value() const
+        {
+            NativeVerificationKey native_vk;
+            native_vk.log_circuit_size = static_cast<uint64_t>(this->log_circuit_size.get_value());
+            native_vk.num_public_inputs = static_cast<uint64_t>(this->num_public_inputs.get_value());
+            native_vk.pub_inputs_offset = static_cast<uint64_t>(this->pub_inputs_offset.get_value());
+            for (auto [commitment, native_commitment] : zip_view(this->get_all(), native_vk.get_all())) {
+                native_commitment = commitment.get_value();
+            }
+            return native_vk;
+        }
+#endif
     };
 
     /**

--- a/barretenberg/cpp/src/barretenberg/flavor/ultra_recursive_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/ultra_recursive_flavor.hpp
@@ -154,6 +154,25 @@ template <typename BuilderType> class UltraRecursiveFlavor_ {
             }
             return VerificationKey(vk_fields);
         }
+
+#ifndef NDEBUG
+        /**
+         * @brief Get the native verification key corresponding to this stdlib verification key
+         *
+         * @return NativeVerificationKey
+         */
+        NativeVerificationKey get_value() const
+        {
+            NativeVerificationKey native_vk;
+            native_vk.log_circuit_size = static_cast<uint64_t>(this->log_circuit_size.get_value());
+            native_vk.num_public_inputs = static_cast<uint64_t>(this->num_public_inputs.get_value());
+            native_vk.pub_inputs_offset = static_cast<uint64_t>(this->pub_inputs_offset.get_value());
+            for (auto [commitment, native_commitment] : zip_view(this->get_all(), native_vk.get_all())) {
+                native_commitment = commitment.get_value();
+            }
+            return native_vk;
+        }
+#endif
     };
 
     /**

--- a/barretenberg/cpp/src/barretenberg/flavor/ultra_rollup_recursive_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/ultra_rollup_recursive_flavor.hpp
@@ -117,6 +117,25 @@ template <typename BuilderType> class UltraRollupRecursiveFlavor_ : public Ultra
             }
             return VerificationKey(vk_fields);
         }
+
+#ifndef NDEBUG
+        /**
+         * @brief Get the native verification key corresponding to this stdlib verification key
+         *
+         * @return NativeVerificationKey
+         */
+        NativeVerificationKey get_value() const
+        {
+            NativeVerificationKey native_vk;
+            native_vk.log_circuit_size = static_cast<uint64_t>(this->log_circuit_size.get_value());
+            native_vk.num_public_inputs = static_cast<uint64_t>(this->num_public_inputs.get_value());
+            native_vk.pub_inputs_offset = static_cast<uint64_t>(this->pub_inputs_offset.get_value());
+            for (auto [commitment, native_commitment] : zip_view(this->get_all(), native_vk.get_all())) {
+                native_commitment = commitment.get_value();
+            }
+            return native_vk;
+        }
+#endif
     };
 
     // Reuse the VerifierCommitments from Ultra

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/pairing_points.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/pairing_points.hpp
@@ -178,7 +178,7 @@ template <typename Curve> struct PairingPoints {
 
 #ifndef NDEBUG
         bb::PairingPoints<typename Curve::NativeCurve> native_pp(P0.get_value(), P1.get_value());
-        info("Are Pairing Points with tag ", tag_index, " valid? ", native_pp.check() ? "true" : "false");
+        info("Aggregated Pairing Points with tag ", tag_index, ": valid: ", native_pp.check() ? "true" : "false");
 #endif
     }
 


### PR DESCRIPTION
Added a native check for the proof being recursively verified in an Honk recursion constraint. The check is active only in debug builds.