### PR TITLE
refactor: `CallInterface` cleanup

### DIFF
--- a/.test_patterns.yml
+++ b/.test_patterns.yml
@@ -83,6 +83,9 @@ tests:
   - regex: "barretenberg/acir_tests/scripts/browser_prove.sh .* webkit"
     owners:
       - *luke
+  - regex: "barretenberg/cpp/scripts/run_bench.sh wasm bb-micro-bench/wasm/chonk build-wasm-threads/bin/chonk_bench"
+    owners:
+      - *luke
 
   # noir
   # Something to do with how I run the tests now. Think these are fine in nextest.

--- a/noir-projects/aztec-nr/aztec/src/context/calls.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/calls.nr
@@ -8,54 +8,38 @@ use crate::context::{gas::GasOpts, private_context::PrivateContext, public_conte
 use crate::hash::{hash_args, hash_calldata};
 use crate::oracle::execution_cache;
 
-pub trait CallInterface<let N: u32> {
-    fn get_args(self) -> [Field];
-    fn get_selector(self) -> FunctionSelector;
-    fn get_name(self) -> str<N>;
-    fn get_contract_address(self) -> AztecAddress;
-    fn get_is_static(self) -> bool;
-}
-
-// PrivateCallInterface
+// PrivateCall
 
 #[must_use = "Your private call needs to be passed into the `self.call(...)` method to be executed (e.g. `self.call(MyContract::at(address).my_private_function(...args))`"]
-pub struct PrivateCallInterface<let M: u32, T> {
-    target_contract: AztecAddress,
-    selector: FunctionSelector,
-    name: str<M>,
+pub struct PrivateCall<let M: u32, T> {
+    pub target_contract: AztecAddress,
+    pub selector: FunctionSelector,
+    pub name: str<M>,
     args_hash: Field,
-    args: [Field],
+    pub args: [Field],
     return_type: T,
-    is_static: bool,
 }
 
-impl<let M: u32, T> PrivateCallInterface<M, T>
-where
-    T: Deserialize,
-{
+impl<let M: u32, T> PrivateCall<M, T> {
     pub fn new(
         target_contract: AztecAddress,
         selector: FunctionSelector,
         name: str<M>,
         args: [Field],
-        is_static: bool,
     ) -> Self {
         let args_hash = hash_args(args);
-        Self {
-            target_contract,
-            selector,
-            name,
-            args_hash,
-            args,
-            return_type: std::mem::zeroed(),
-            is_static,
-        }
+        Self { target_contract, selector, name, args_hash, args, return_type: std::mem::zeroed() }
     }
+}
 
+impl<let M: u32, T> PrivateCall<M, T>
+where
+    T: Deserialize,
+{
     /// **[DEPRECATED]**
     /// This function is deprecated. Please use the new contract API:
     /// `self.call(MyContract::at(address).my_private_function(...args))`
-    /// instead of manually constructing and calling `PrivateCallInterface`.
+    /// instead of manually constructing and calling `PrivateCall`.
     pub fn call(self, context: &mut PrivateContext) -> T {
         execution_cache::store(self.args, self.args_hash);
         let returns_hash = context.call_private_function_with_args_hash(
@@ -71,42 +55,19 @@ where
     }
 }
 
-impl<let M: u32, T> CallInterface<M> for PrivateCallInterface<M, T> {
-    fn get_args(self) -> [Field] {
-        self.args
-    }
-
-    fn get_selector(self) -> FunctionSelector {
-        self.selector
-    }
-
-    fn get_name(self) -> str<M> {
-        self.name
-    }
-
-    fn get_contract_address(self) -> AztecAddress {
-        self.target_contract
-    }
-
-    fn get_is_static(self) -> bool {
-        self.is_static
-    }
-}
-
-// PrivateStaticCallInterface
+// PrivateStaticCall
 
 #[must_use = "Your private static call needs to be passed into the `self.view(...)` method to be executed (e.g. `self.view(MyContract::at(address).my_private_static_function(...args))`"]
-pub struct PrivateStaticCallInterface<let M: u32, T> {
-    target_contract: AztecAddress,
-    selector: FunctionSelector,
-    name: str<M>,
+pub struct PrivateStaticCall<let M: u32, T> {
+    pub target_contract: AztecAddress,
+    pub selector: FunctionSelector,
+    pub name: str<M>,
     args_hash: Field,
-    args: [Field],
+    pub args: [Field],
     return_type: T,
-    is_static: bool,
 }
 
-impl<let M: u32, T> PrivateStaticCallInterface<M, T> {
+impl<let M: u32, T> PrivateStaticCall<M, T> {
     pub fn new(
         target_contract: AztecAddress,
         selector: FunctionSelector,
@@ -114,21 +75,13 @@ impl<let M: u32, T> PrivateStaticCallInterface<M, T> {
         args: [Field],
     ) -> Self {
         let args_hash = hash_args(args);
-        Self {
-            target_contract,
-            selector,
-            name,
-            args_hash,
-            args,
-            return_type: std::mem::zeroed(),
-            is_static: true,
-        }
+        Self { target_contract, selector, name, args_hash, args, return_type: std::mem::zeroed() }
     }
 
     /// **[DEPRECATED]**
     /// This function is deprecated. Please use the new contract API:
     /// `self.view(MyContract::at(address).my_private_static_function(...args))`
-    /// instead of manually constructing and calling `PrivateCallInterface`.
+    /// instead of manually constructing and calling `PrivateCall`.
     pub fn view(self, context: &mut PrivateContext) -> T
     where
         T: Deserialize,
@@ -144,52 +97,25 @@ impl<let M: u32, T> PrivateStaticCallInterface<M, T> {
     }
 }
 
-impl<let M: u32, T> CallInterface<M> for PrivateStaticCallInterface<M, T> {
-    fn get_args(self) -> [Field] {
-        self.args
-    }
-
-    fn get_selector(self) -> FunctionSelector {
-        self.selector
-    }
-
-    fn get_name(self) -> str<M> {
-        self.name
-    }
-
-    fn get_contract_address(self) -> AztecAddress {
-        self.target_contract
-    }
-
-    fn get_is_static(self) -> bool {
-        self.is_static
-    }
-}
-
-// PublicCallInterface
+// PublicCall
 
 #[must_use = "Your public call needs to be passed into the `self.call(...)`, `self.enqueue(...)` or `self.enqueue_incognito(...)` method to be executed (e.g. `self.call(MyContract::at(address).my_public_function(...args))`"]
-pub struct PublicCallInterface<let M: u32, T> {
-    target_contract: AztecAddress,
-    selector: FunctionSelector,
-    name: str<M>,
+pub struct PublicCall<let M: u32, T> {
+    pub target_contract: AztecAddress,
+    pub selector: FunctionSelector,
+    pub name: str<M>,
     // TODO(F-131): Determine the length at comptime and drop the use of slices.
-    args: [Field],
+    pub args: [Field],
     gas_opts: GasOpts,
     return_type: T,
-    is_static: bool,
 }
 
-impl<let M: u32, T> PublicCallInterface<M, T>
-where
-    T: Deserialize,
-{
+impl<let M: u32, T> PublicCall<M, T> {
     pub fn new(
         target_contract: AztecAddress,
         selector: FunctionSelector,
         name: str<M>,
         args: [Field],
-        is_static: bool,
     ) -> Self {
         Self {
             target_contract,
@@ -198,7 +124,6 @@ where
             args,
             gas_opts: GasOpts::default(),
             return_type: std::mem::zeroed(),
-            is_static,
         }
     }
 
@@ -210,8 +135,11 @@ where
     /// **[DEPRECATED]**
     /// This function is deprecated. Please use the new contract API:
     /// `self.call(MyContract::at(address).my_public_function(...args))`
-    /// instead of manually constructing and calling `PublicCallInterface`.
-    pub unconstrained fn call(self, context: PublicContext) -> T {
+    /// instead of manually constructing and calling `PublicCall`.
+    pub unconstrained fn call(self, context: PublicContext) -> T
+    where
+        T: Deserialize,
+    {
         let returns = context.call_public_function(
             self.target_contract,
             self.selector,
@@ -226,7 +154,7 @@ where
     /// **[DEPRECATED]**
     /// This function is deprecated. Please use the new contract API:
     /// `self.enqueue(MyContract::at(address).my_public_function(...args))`
-    /// instead of manually constructing and calling `PublicCallInterface`.
+    /// instead of manually constructing and calling `PublicCall`.
     pub fn enqueue(self, context: &mut PrivateContext) {
         self.enqueue_impl(context, false, false)
     }
@@ -234,7 +162,7 @@ where
     /// **[DEPRECATED]**
     /// This function is deprecated. Please use the new contract API:
     /// `self.enqueue_incognito(MyContract::at(address).my_public_function(...args))`
-    /// instead of manually constructing and calling `PublicCallInterface`.
+    /// instead of manually constructing and calling `PublicCall`.
     pub fn enqueue_incognito(self, context: &mut PrivateContext) {
         self.enqueue_impl(context, false, true)
     }
@@ -259,7 +187,7 @@ where
     /// **[DEPRECATED]**
     /// This function is deprecated. Please use the new contract API:
     /// `self.set_as_teardown(MyContract::at(address).my_public_function(...args))`
-    /// instead of manually constructing and setting the teardown function `PublicCallInterface`.
+    /// instead of manually constructing and setting the teardown function `PublicCall`.
     pub fn set_as_teardown(self, context: &mut PrivateContext) {
         self.set_as_teardown_impl(context, false);
     }
@@ -267,7 +195,7 @@ where
     /// **[DEPRECATED]**
     /// This function is deprecated. Please use the new contract API:
     /// `self.set_as_teardown_incognito(MyContract::at(address).my_public_function(...args))`
-    /// instead of manually constructing and setting the teardown function `PublicCallInterface`.
+    /// instead of manually constructing and setting the teardown function `PublicCall`.
     pub fn set_as_teardown_incognito(self, context: &mut PrivateContext) {
         self.set_as_teardown_impl(context, true);
     }
@@ -285,45 +213,19 @@ where
     }
 }
 
-impl<let M: u32, T> CallInterface<M> for PublicCallInterface<M, T> {
-    fn get_args(self) -> [Field] {
-        self.args
-    }
-
-    fn get_selector(self) -> FunctionSelector {
-        self.selector
-    }
-
-    fn get_name(self) -> str<M> {
-        self.name
-    }
-
-    fn get_contract_address(self) -> AztecAddress {
-        self.target_contract
-    }
-
-    fn get_is_static(self) -> bool {
-        self.is_static
-    }
-}
-
-// PublicStaticCallInterface
+// PublicStaticCall
 
 #[must_use = "Your public static call needs to be passed into the `self.view(...)`, `self.enqueue_view(...)` or `self.enqueue_view_incognito(...)` method to be executed (e.g. `self.view(MyContract::at(address).my_public_static_function(...args))`"]
-pub struct PublicStaticCallInterface<let M: u32, T> {
-    target_contract: AztecAddress,
-    selector: FunctionSelector,
-    name: str<M>,
-    args: [Field],
+pub struct PublicStaticCall<let M: u32, T> {
+    pub target_contract: AztecAddress,
+    pub selector: FunctionSelector,
+    pub name: str<M>,
+    pub args: [Field],
     return_type: T,
-    is_static: bool,
     gas_opts: GasOpts,
 }
 
-impl<let M: u32, T> PublicStaticCallInterface<M, T>
-where
-    T: Deserialize,
-{
+impl<let M: u32, T> PublicStaticCall<M, T> {
     pub fn new(
         target_contract: AztecAddress,
         selector: FunctionSelector,
@@ -336,7 +238,6 @@ where
             name,
             args,
             return_type: std::mem::zeroed(),
-            is_static: true,
             gas_opts: GasOpts::default(),
         }
     }
@@ -349,8 +250,11 @@ where
     /// **[DEPRECATED]**
     /// This function is deprecated. Please use the new contract API:
     /// `self.view(MyContract::at(address).my_public_static_function(...args))`
-    /// instead of manually constructing and calling `PublicStaticCallInterface`.
-    pub unconstrained fn view(self, context: PublicContext) -> T {
+    /// instead of manually constructing and calling `PublicStaticCall`.
+    pub unconstrained fn view(self, context: PublicContext) -> T
+    where
+        T: Deserialize,
+    {
         let returns = context.static_call_public_function(
             self.target_contract,
             self.selector,
@@ -363,7 +267,7 @@ where
     /// **[DEPRECATED]**
     /// This function is deprecated. Please use the new contract API:
     /// `self.enqueue_view(MyContract::at(address).my_public_static_function(...args))`
-    /// instead of manually constructing and calling `PublicStaticCallInterface`.
+    /// instead of manually constructing and calling `PublicStaticCall`.
     pub fn enqueue_view(self, context: &mut PrivateContext) {
         let calldata = self.args.push_front(self.selector.to_field());
         let calldata_hash = hash_calldata(calldata);
@@ -380,7 +284,7 @@ where
     /// **[DEPRECATED]**
     /// This function is deprecated. Please use the new contract API:
     /// `self.enqueue_view_incognito(MyContract::at(address).my_public_static_function(...args))`
-    /// instead of manually constructing and calling `PublicStaticCallInterface`.
+    /// instead of manually constructing and calling `PublicStaticCall`.
     pub fn enqueue_view_incognito(self, context: &mut PrivateContext) {
         let calldata = self.args.push_front(self.selector.to_field());
         let calldata_hash = hash_calldata(calldata);
@@ -395,62 +299,18 @@ where
     }
 }
 
-impl<let M: u32, T> CallInterface<M> for PublicStaticCallInterface<M, T> {
-    fn get_args(self) -> [Field] {
-        self.args
-    }
+// UtilityCall
 
-    fn get_selector(self) -> FunctionSelector {
-        self.selector
-    }
-
-    fn get_name(self) -> str<M> {
-        self.name
-    }
-
-    fn get_contract_address(self) -> AztecAddress {
-        self.target_contract
-    }
-
-    fn get_is_static(self) -> bool {
-        self.is_static
-    }
-}
-
-// UtilityCallInterface
-
-pub struct UtilityCallInterface<let M: u32, T> {
-    target_contract: AztecAddress,
-    selector: FunctionSelector,
-    name: str<M>,
+pub struct UtilityCall<let M: u32, T> {
+    pub target_contract: AztecAddress,
+    pub selector: FunctionSelector,
+    pub name: str<M>,
     args_hash: Field,
-    args: [Field],
+    pub args: [Field],
     return_type: T,
 }
 
-impl<let M: u32, T> CallInterface<M> for UtilityCallInterface<M, T> {
-    fn get_args(self) -> [Field] {
-        self.args
-    }
-
-    fn get_selector(self) -> FunctionSelector {
-        self.selector
-    }
-
-    fn get_name(self) -> str<M> {
-        self.name
-    }
-
-    fn get_contract_address(self) -> AztecAddress {
-        self.target_contract
-    }
-
-    fn get_is_static(self) -> bool {
-        false
-    }
-}
-
-impl<let M: u32, T> UtilityCallInterface<M, T> {
+impl<let M: u32, T> UtilityCall<M, T> {
     pub fn new(
         target_contract: AztecAddress,
         selector: FunctionSelector,
@@ -459,21 +319,5 @@ impl<let M: u32, T> UtilityCallInterface<M, T> {
     ) -> Self {
         let args_hash = hash_args(args);
         Self { target_contract, selector, name, args_hash, args, return_type: std::mem::zeroed() }
-    }
-
-    pub fn get_args(self) -> [Field] {
-        self.args
-    }
-
-    pub fn get_selector(self) -> FunctionSelector {
-        self.selector
-    }
-
-    pub fn get_name(self) -> str<M> {
-        self.name
-    }
-
-    pub fn get_contract_address(self) -> AztecAddress {
-        self.target_contract
     }
 }

--- a/noir-projects/aztec-nr/aztec/src/context/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/mod.nr
@@ -6,13 +6,10 @@ pub mod private_context;
 pub mod public_context;
 pub mod utility_context;
 
-pub mod call_interfaces;
+pub mod calls;
 pub mod gas;
 
-pub use call_interfaces::{
-    PrivateCallInterface, PrivateStaticCallInterface, PublicCallInterface,
-    PublicStaticCallInterface, UtilityCallInterface,
-};
+pub use calls::{PrivateCall, PrivateStaticCall, PublicCall, PublicStaticCall, UtilityCall};
 pub use private_context::PrivateContext;
 pub use public_context::PublicContext;
 pub use returns_hash::ReturnsHash;

--- a/noir-projects/aztec-nr/aztec/src/contract_self.nr
+++ b/noir-projects/aztec-nr/aztec/src/contract_self.nr
@@ -1,9 +1,6 @@
 use crate::{
     context::{
-        call_interfaces::{
-            PrivateCallInterface, PrivateStaticCallInterface, PublicCallInterface,
-            PublicStaticCallInterface,
-        },
+        calls::{PrivateCall, PrivateStaticCall, PublicCall, PublicStaticCall},
         private_context::PrivateContext,
         public_context::PublicContext,
     },
@@ -265,7 +262,7 @@ impl<Storage, CallSelf, EnqueueSelf, CallSelfStatic, EnqueueSelfStatic, CallInte
     /// * Side effects from the called function are included in this transaction
     /// * The call inherits the current transaction's context and gas limits
     ///
-    pub fn call<let M: u32, T>(&mut self, call: PrivateCallInterface<M, T>) -> T
+    pub fn call<let M: u32, T>(&mut self, call: PrivateCall<M, T>) -> T
     where
         T: Deserialize,
     {
@@ -288,7 +285,7 @@ impl<Storage, CallSelf, EnqueueSelf, CallSelfStatic, EnqueueSelfStatic, CallInte
     /// ```noir
     /// self.view(Token::at(address).balance_of_private(recipient));
     /// ```
-    pub fn view<let M: u32, T>(&mut self, call: PrivateStaticCallInterface<M, T>) -> T
+    pub fn view<let M: u32, T>(&mut self, call: PrivateStaticCall<M, T>) -> T
     where
         T: Deserialize,
     {
@@ -324,9 +321,9 @@ impl<Storage, CallSelf, EnqueueSelf, CallSelfStatic, EnqueueSelfStatic, CallInte
     /// * `call` - The interface representing the public function to enqueue.
     ///
     /// TODO(F-131): We should drop T from here because it is strange as there
-    /// is no return value. The PublicCallInterface type seems to be defined
+    /// is no return value. The PublicCall type seems to be defined
     /// incorrectly.
-    pub fn enqueue<let M: u32, T>(&mut self, call: PublicCallInterface<M, T>)
+    pub fn enqueue<let M: u32, T>(&mut self, call: PublicCall<M, T>)
     where
         T: Deserialize,
     {
@@ -348,9 +345,9 @@ impl<Storage, CallSelf, EnqueueSelf, CallSelfStatic, EnqueueSelfStatic, CallInte
     /// ```
     ///
     /// TODO(F-131): We should drop T from here because it is strange as there
-    /// is no return value. The PublicCallInterface type seems to be defined
+    /// is no return value. The PublicCall type seems to be defined
     /// incorrectly.
-    pub fn enqueue_view<let M: u32, T>(&mut self, call: PublicStaticCallInterface<M, T>)
+    pub fn enqueue_view<let M: u32, T>(&mut self, call: PublicStaticCall<M, T>)
     where
         T: Deserialize,
     {
@@ -401,9 +398,9 @@ impl<Storage, CallSelf, EnqueueSelf, CallSelfStatic, EnqueueSelfStatic, CallInte
     ///   `Option<AztecAddress>::none` for familiarity to devs.
     ///
     /// TODO(F-131): We should drop T from here because it is strange as there
-    /// is no return value. The PublicCallInterface type seems to be defined
+    /// is no return value. The PublicCall type seems to be defined
     /// incorrectly.
-    pub fn enqueue_incognito<let M: u32, T>(&mut self, call: PublicCallInterface<M, T>)
+    pub fn enqueue_incognito<let M: u32, T>(&mut self, call: PublicCall<M, T>)
     where
         T: Deserialize,
     {
@@ -426,9 +423,9 @@ impl<Storage, CallSelf, EnqueueSelf, CallSelfStatic, EnqueueSelfStatic, CallInte
     /// ```
     ///
     /// TODO(F-131): We should drop T from here because it is strange as there
-    /// is no return value. The PublicCallInterface type seems to be defined
+    /// is no return value. The PublicCall type seems to be defined
     /// incorrectly.
-    pub fn enqueue_view_incognito<let M: u32, T>(&mut self, call: PublicStaticCallInterface<M, T>)
+    pub fn enqueue_view_incognito<let M: u32, T>(&mut self, call: PublicStaticCall<M, T>)
     where
         T: Deserialize,
     {
@@ -465,9 +462,9 @@ impl<Storage, CallSelf, EnqueueSelf, CallSelfStatic, EnqueueSelfStatic, CallInte
     /// * `call` - The object representing the public function to designate as teardown.
     ///
     /// TODO(F-131): We should drop T from here because it is strange as there
-    /// is no return value. The PublicCallInterface type seems to be defined
+    /// is no return value. The PublicCall type seems to be defined
     /// incorrectly.
-    pub fn set_as_teardown<let M: u32, T>(&mut self, call: PublicCallInterface<M, T>)
+    pub fn set_as_teardown<let M: u32, T>(&mut self, call: PublicCall<M, T>)
     where
         T: Deserialize,
     {
@@ -484,9 +481,9 @@ impl<Storage, CallSelf, EnqueueSelf, CallSelfStatic, EnqueueSelfStatic, CallInte
     /// See `enqueue_incognito` for more details relating to hiding msg_sender.
     ///
     /// TODO(F-131): We should drop T from here because it is strange as there
-    /// is no return value. The PublicCallInterface type seems to be defined
+    /// is no return value. The PublicCall type seems to be defined
     /// incorrectly.
-    pub fn set_as_teardown_incognito<let M: u32, T>(&mut self, call: PublicCallInterface<M, T>)
+    pub fn set_as_teardown_incognito<let M: u32, T>(&mut self, call: PublicCall<M, T>)
     where
         T: Deserialize,
     {
@@ -587,7 +584,7 @@ impl<Storage, CallSelf, CallSelfStatic, CallInternal> ContractSelf<PublicContext
     /// self.call(Token::at(address).transfer_in_public(recipient, amount));
     /// ```
     ///
-    pub unconstrained fn call<let M: u32, T>(self, call: PublicCallInterface<M, T>) -> T
+    pub unconstrained fn call<let M: u32, T>(self, call: PublicCall<M, T>) -> T
     where
         T: Deserialize,
     {
@@ -613,7 +610,7 @@ impl<Storage, CallSelf, CallSelfStatic, CallInternal> ContractSelf<PublicContext
     /// self.view(Token::at(address).balance_of_public(recipient));
     /// ```
     ///
-    pub unconstrained fn view<let M: u32, T>(self, call: PublicStaticCallInterface<M, T>) -> T
+    pub unconstrained fn view<let M: u32, T>(self, call: PublicStaticCall<M, T>) -> T
     where
         T: Deserialize,
     {

--- a/noir-projects/aztec-nr/aztec/src/macros/calls_generation/external_functions_stubs.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/calls_generation/external_functions_stubs.nr
@@ -62,15 +62,14 @@ pub(crate) comptime fn create_private_stub(f: FunctionDefinition) -> Quoted {
     let fn_return_type = f.return_type();
 
     quote {
-        pub fn $fn_name(self, $fn_parameters_list) -> dep::aztec::context::call_interfaces::PrivateCallInterface<$fn_name_len, $fn_return_type> {
+        pub fn $fn_name(self, $fn_parameters_list) -> dep::aztec::context::calls::PrivateCall<$fn_name_len, $fn_return_type> {
             $serialized_args_array_construction
             let selector = $FROM_FIELD($fn_selector);
-            dep::aztec::context::call_interfaces::PrivateCallInterface::new(
+            dep::aztec::context::calls::PrivateCall::new(
                 self.target_contract,
                 selector,
                 $fn_name_str,
                 $serialized_args_array_name,
-                false
             )
         }
     }
@@ -82,10 +81,10 @@ pub(crate) comptime fn create_private_static_stub(f: FunctionDefinition) -> Quot
     let fn_return_type = f.return_type();
 
     quote {
-        pub fn $fn_name(self, $fn_parameters_list) -> dep::aztec::context::call_interfaces::PrivateStaticCallInterface<$fn_name_len, $fn_return_type> {
+        pub fn $fn_name(self, $fn_parameters_list) -> dep::aztec::context::calls::PrivateStaticCall<$fn_name_len, $fn_return_type> {
             $serialized_args_array_construction
             let selector = $FROM_FIELD($fn_selector);
-            dep::aztec::context::call_interfaces::PrivateStaticCallInterface::new(
+            dep::aztec::context::calls::PrivateStaticCall::new(
                 self.target_contract,
                 selector,
                 $fn_name_str,
@@ -101,15 +100,14 @@ pub(crate) comptime fn create_public_stub(f: FunctionDefinition) -> Quoted {
     let fn_return_type = f.return_type();
 
     quote {
-        pub fn $fn_name(self, $fn_parameters_list) -> dep::aztec::context::call_interfaces::PublicCallInterface<$fn_name_len, $fn_return_type> {
+        pub fn $fn_name(self, $fn_parameters_list) -> dep::aztec::context::calls::PublicCall<$fn_name_len, $fn_return_type> {
             $serialized_args_array_construction
             let selector = $FROM_FIELD($fn_selector);
-            dep::aztec::context::call_interfaces::PublicCallInterface::new(
+            dep::aztec::context::calls::PublicCall::new(
                 self.target_contract,
                 selector,
                 $fn_name_str,
                 $serialized_args_array_name,
-                false
             )
         }
     }
@@ -121,10 +119,10 @@ pub(crate) comptime fn create_public_static_stub(f: FunctionDefinition) -> Quote
     let fn_return_type = f.return_type();
 
     quote {
-        pub fn $fn_name(self, $fn_parameters_list) -> dep::aztec::context::call_interfaces::PublicStaticCallInterface<$fn_name_len, $fn_return_type> {
+        pub fn $fn_name(self, $fn_parameters_list) -> dep::aztec::context::calls::PublicStaticCall<$fn_name_len, $fn_return_type> {
             $serialized_args_array_construction
             let selector = $FROM_FIELD($fn_selector);
-            dep::aztec::context::call_interfaces::PublicStaticCallInterface::new(
+            dep::aztec::context::calls::PublicStaticCall::new(
                 self.target_contract,
                 selector,
                 $fn_name_str,
@@ -140,10 +138,10 @@ pub(crate) comptime fn create_utility_stub(f: FunctionDefinition) -> Quoted {
     let fn_return_type = f.return_type();
 
     quote {
-        pub fn $fn_name(self, $fn_parameters_list) -> dep::aztec::context::call_interfaces::UtilityCallInterface<$fn_name_len, $fn_return_type> {
+        pub fn $fn_name(self, $fn_parameters_list) -> dep::aztec::context::calls::UtilityCall<$fn_name_len, $fn_return_type> {
             $serialized_args_array_construction
             let selector = $FROM_FIELD($fn_selector);
-            dep::aztec::context::call_interfaces::UtilityCallInterface::new(
+            dep::aztec::context::calls::UtilityCall::new(
                 self.target_contract,
                 selector,
                 $fn_name_str,
@@ -183,7 +181,7 @@ pub comptime fn create_private_self_call_stub(f: FunctionDefinition, is_static: 
     }
 }
 
-// TODO(F-131): Drop the use of the CallInterface in the following 4 functions - it doesn't make sense to not not
+// TODO(F-131): Drop the use of the Call in the following 4 functions - it doesn't make sense to not not
 // perform the call directly using the context. I tried doing this already but it became a lot of pain due to the use of
 // slices and them being illegal to return from unconstrained functions. Makes sense to tackle this when cleaning up the
 // call interface code.
@@ -200,12 +198,11 @@ pub comptime fn create_public_self_call_stub(f: FunctionDefinition) -> Quoted {
             $serialized_args_array_construction
             let selector = $FROM_FIELD($fn_selector);
             unsafe {
-                aztec::context::call_interfaces::PublicCallInterface::new(
+                aztec::context::calls::PublicCall::new(
                     self.address,
                     selector,
                     $fn_name_str,
                     $serialized_args_array_name,
-                    false
                 ).call(self.context)
             }
         }
@@ -223,7 +220,7 @@ pub comptime fn create_public_self_call_static_stub(f: FunctionDefinition) -> Qu
             $serialized_args_array_construction
             let selector = $FROM_FIELD($fn_selector);
             unsafe {
-                aztec::context::call_interfaces::PublicStaticCallInterface::new(
+                aztec::context::calls::PublicStaticCall::new(
                     self.address,
                     selector,
                     $fn_name_str,
@@ -243,7 +240,7 @@ pub comptime fn create_public_self_enqueue_static_stub(f: FunctionDefinition) ->
         pub fn $fn_name(self, $fn_parameters_list) {
             $serialized_args_array_construction
             let selector = $FROM_FIELD($fn_selector);
-            let interface: aztec::context::call_interfaces::PublicStaticCallInterface<$fn_name_len, ()> = aztec::context::call_interfaces::PublicStaticCallInterface::new(
+            let interface: aztec::context::calls::PublicStaticCall<$fn_name_len, ()> = aztec::context::calls::PublicStaticCall::new(
                 self.address,
                 selector,
                 $fn_name_str,
@@ -263,12 +260,11 @@ pub comptime fn create_public_self_enqueue_stub(f: FunctionDefinition) -> Quoted
         pub fn $fn_name(self, $fn_parameters_list) {
             $serialized_args_array_construction
             let selector = $FROM_FIELD($fn_selector);
-            let interface: aztec::context::call_interfaces::PublicCallInterface<$fn_name_len, ()> = aztec::context::call_interfaces::PublicCallInterface::new(
+            let interface: aztec::context::calls::PublicCall<$fn_name_len, ()> = aztec::context::calls::PublicCall::new(
                 self.address,
                 selector,
                 $fn_name_str,
                 $serialized_args_array_name,
-                false
             );
             interface.enqueue(self.context);
         }

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/authwit.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/authwit.nr
@@ -1,6 +1,6 @@
 use crate::{
     authwit::auth::{compute_authwit_message_hash, compute_inner_authwit_hash},
-    context::call_interfaces::{CallInterface, PublicCallInterface},
+    context::{PrivateCall, PublicCall},
     hash::hash_args,
     test::helpers::{test_environment::TestEnvironment, txe_oracles},
 };
@@ -10,15 +10,12 @@ use protocol_types::{
     constants::CANONICAL_AUTH_REGISTRY_ADDRESS, traits::ToField,
 };
 
-pub unconstrained fn add_private_authwit_from_call_interface<C, let M: u32>(
+pub unconstrained fn add_private_authwit_from_call<T, let M: u32>(
     env: TestEnvironment,
     on_behalf_of: AztecAddress,
     caller: AztecAddress,
-    call_interface: C,
-)
-where
-    C: CallInterface<M>,
-{
+    call: PrivateCall<M, T>,
+) {
     // The creation of this utility context results in the TXE session needing to keep track of authwits over its
     // lifetime, as we'd otherwise be unable to store more than one authwit due to them getting reset when restoring the
     // top-level TXE context.
@@ -26,42 +23,40 @@ where
     let (chain_id, version) =
         env.utility_context(|context| (context.chain_id(), context.version()));
 
-    let target = call_interface.get_contract_address();
-    let args_hash = hash_args(call_interface.get_args());
-    let selector = call_interface.get_selector();
+    let target = call.target_contract;
+    let args = call.args;
+    let selector = call.selector;
+    let args_hash = hash_args(args);
     let inner_hash =
         compute_inner_authwit_hash([caller.to_field(), selector.to_field(), args_hash]);
     let message_hash = compute_authwit_message_hash(target, chain_id, version, inner_hash);
     txe_oracles::add_authwit(on_behalf_of, message_hash);
 }
 
-pub unconstrained fn add_public_authwit_from_call_interface<C, let M: u32>(
+pub unconstrained fn add_public_authwit_from_call<T, let M: u32>(
     env: TestEnvironment,
     on_behalf_of: AztecAddress,
     caller: AztecAddress,
-    call_interface: C,
-)
-where
-    C: CallInterface<M>,
-{
+    call: PublicCall<M, T>,
+) {
     let (chain_id, version) =
         env.utility_context(|context| (context.chain_id(), context.version()));
 
-    let target = call_interface.get_contract_address();
-    let args_hash = hash_args(call_interface.get_args());
-    let selector = call_interface.get_selector();
+    let target = call.target_contract;
+    let args = call.args;
+    let selector = call.selector;
+    let args_hash = hash_args(args);
     let inner_hash =
         compute_inner_authwit_hash([caller.to_field(), selector.to_field(), args_hash]);
     let message_hash = compute_authwit_message_hash(target, chain_id, version, inner_hash);
 
     env.call_public(
         on_behalf_of,
-        PublicCallInterface::<_, ()>::new(
+        PublicCall::<_, ()>::new(
             CANONICAL_AUTH_REGISTRY_ADDRESS,
             comptime { FunctionSelector::from_signature("set_authorized(Field,bool)") },
             "set_authorized",
             [message_hash, true as Field].as_slice(),
-            false,
         ),
     );
 }

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
@@ -6,9 +6,8 @@ use protocol_types::{
 
 use crate::{
     context::{
-        call_interfaces::CallInterface, PrivateCallInterface, PrivateContext,
-        PrivateStaticCallInterface, PublicCallInterface, PublicContext, PublicStaticCallInterface,
-        UtilityCallInterface, UtilityContext,
+        PrivateCall, PrivateContext, PrivateStaticCall, PublicCall, PublicContext, PublicStaticCall,
+        UtilityCall, UtilityContext,
     },
     hash::hash_args,
     messages::{
@@ -386,7 +385,7 @@ impl TestEnvironment {
     ///
     /// The returned account has a full set of privacy keys, so it can nullify notes, receive messages, etc. It also has
     /// an associated `SchnorrAccount` contract that can process authwit requests - the authwits can be added via the
-    /// `add_private_authwit_from_call_interface` and `add_public_authwit_from_call_interface` helper functions. If
+    /// `add_private_authwit_from_call` and `add_public_authwit_from_call` helper functions. If
     /// authwits are not required, consider using `create_light_account` instead, which is a faster variant of this
     /// function.
     ///
@@ -399,12 +398,11 @@ impl TestEnvironment {
 
         let _ = self.call_private(
             AztecAddress::zero(),
-            PrivateCallInterface::<_, ()>::new(
+            PrivateCall::<_, ()>::new(
                 address,
                 comptime { FunctionSelector::from_signature("constructor(Field,Field)") },
                 "constructor",
                 [test_account.keys.ivpk_m.inner.x, test_account.keys.ivpk_m.inner.y],
-                false,
             ),
         );
 
@@ -489,7 +487,7 @@ impl TestEnvironment {
     /// mined by the time `call_private` returns. It is therefore possible to chain multiple private or public function
     /// calls that operate on the result of prior calls.
     ///
-    /// The `call_interface` value can be obtained by calling the appropriate method on a contract type. E.g.:
+    /// The `call` value can be obtained by calling the appropriate method on a contract type. E.g.:
     ///
     /// ```noir
     /// let caller = env.create_light_account();
@@ -499,21 +497,18 @@ impl TestEnvironment {
     pub unconstrained fn call_private<T, let M: u32>(
         _self: Self,
         from: AztecAddress,
-        call_interface: PrivateCallInterface<M, T>,
+        call: PrivateCall<M, T>,
     ) -> T
     where
         T: Deserialize,
     {
-        let args = call_interface.get_args();
-        let args_hash = hash_args(args);
-
         let serialized_return_values = txe_oracles::private_call_new_flow(
             from,
-            call_interface.get_contract_address(),
-            call_interface.get_selector(),
-            args,
-            args_hash,
-            call_interface.get_is_static(),
+            call.target_contract,
+            call.selector,
+            call.args,
+            hash_args(call.args),
+            /*is_static=*/ false,
         );
 
         T::deserialize(serialized_return_values)
@@ -525,21 +520,18 @@ impl TestEnvironment {
     /// executable in a static context, and these produce no side effects).
     pub unconstrained fn view_private<T, let M: u32>(
         _self: Self,
-        call_interface: PrivateStaticCallInterface<M, T>,
+        call: PrivateStaticCall<M, T>,
     ) -> T
     where
         T: Deserialize,
     {
-        let args = call_interface.get_args();
-        let args_hash = hash_args(args);
-
         let serialized_return_values = txe_oracles::private_call_new_flow(
             std::mem::zeroed(), // The 'from' address is currently not manually set
-            call_interface.get_contract_address(),
-            call_interface.get_selector(),
-            args,
-            args_hash,
-            call_interface.get_is_static(),
+            call.target_contract,
+            call.selector,
+            call.args,
+            hash_args(call.args),
+            /*is_static=*/ true,
         );
 
         T::deserialize(serialized_return_values)
@@ -547,25 +539,19 @@ impl TestEnvironment {
 
     /// Performs a utility contract function call and returns the result of the called function.
     ///
-    /// The `call_interface` value can be obtained by calling the appropriate method on a contract type. E.g.:
+    /// The `call` value can be obtained by calling the appropriate method on a contract type. E.g.:
     ///
     /// ```noir
     /// let caller = env.create_light_account();
     /// let contract_addr = env.deploy("SampleContract").without_initializer();
     /// let return_value = env.simulate_utility(SampleContract::at(contract_addr).sample_utility_function());
     /// ```
-    pub unconstrained fn simulate_utility<T, let M: u32>(
-        _self: Self,
-        call_interface: UtilityCallInterface<M, T>,
-    ) -> T
+    pub unconstrained fn simulate_utility<T, let M: u32>(_self: Self, call: UtilityCall<M, T>) -> T
     where
         T: Deserialize,
     {
-        let serialized_return_values = txe_oracles::simulate_utility_function(
-            call_interface.get_contract_address(),
-            call_interface.get_selector(),
-            call_interface.get_args(),
-        );
+        let serialized_return_values =
+            txe_oracles::simulate_utility_function(call.target_contract, call.selector, call.args);
 
         T::deserialize(serialized_return_values)
     }
@@ -581,7 +567,7 @@ impl TestEnvironment {
     /// mined by the time `call_public` returns. It is therefore possible to chain multiple private or public function
     /// calls that operate on the result of prior calls.
     ///
-    /// The `call_interface` value can be obtained by calling the appropriate method on a contract type. E.g.:
+    /// The `call` value can be obtained by calling the appropriate method on a contract type. E.g.:
     ///
     /// ```noir
     /// let caller = env.create_light_account();
@@ -591,16 +577,16 @@ impl TestEnvironment {
     pub unconstrained fn call_public<T, let M: u32>(
         _self: Self,
         from: AztecAddress,
-        call_interface: PublicCallInterface<M, T>,
+        call: PublicCall<M, T>,
     ) -> T
     where
         T: Deserialize,
     {
         let serialized_return_values = txe_oracles::public_call_new_flow(
             Option::some(from),
-            call_interface.get_contract_address(),
-            call_interface.get_selector(),
-            call_interface.get_args(),
+            call.target_contract,
+            call.selector,
+            call.args,
             false,
         );
         T::deserialize(serialized_return_values)
@@ -612,16 +598,16 @@ impl TestEnvironment {
     pub unconstrained fn call_public_incognito<T, let M: u32>(
         _self: Self,
         from: AztecAddress,
-        call_interface: PublicCallInterface<M, T>,
+        call: PublicCall<M, T>,
     ) -> T
     where
         T: Deserialize,
     {
         let serialized_return_values = txe_oracles::public_call_new_flow(
             Option::some(from),
-            call_interface.get_contract_address(),
-            call_interface.get_selector(),
-            call_interface.get_args(),
+            call.target_contract,
+            call.selector,
+            call.args,
             false,
         );
 
@@ -632,18 +618,15 @@ impl TestEnvironment {
     ///
     /// Unlike `call_public`, no transaction is created and no block is mined (since `#[view]` functions are only
     /// executable in a static context, and these produce no side effects).
-    pub unconstrained fn view_public<T, let M: u32>(
-        _self: Self,
-        call_interface: PublicStaticCallInterface<M, T>,
-    ) -> T
+    pub unconstrained fn view_public<T, let M: u32>(_self: Self, call: PublicStaticCall<M, T>) -> T
     where
         T: Deserialize,
     {
         let serialized_return_values = txe_oracles::public_call_new_flow(
             Option::some(AztecAddress::zero()),
-            call_interface.get_contract_address(),
-            call_interface.get_selector(),
-            call_interface.get_args(),
+            call.target_contract,
+            call.selector,
+            call.args,
             true,
         );
 
@@ -656,16 +639,16 @@ impl TestEnvironment {
     /// executable in a static context, and these produce no side effects).
     pub unconstrained fn view_public_incognito<T, let M: u32>(
         _self: Self,
-        call_interface: PublicStaticCallInterface<M, T>,
+        call: PublicStaticCall<M, T>,
     ) -> T
     where
         T: Deserialize,
     {
         let serialized_return_values = txe_oracles::public_call_new_flow(
             Option::none(),
-            call_interface.get_contract_address(),
-            call_interface.get_selector(),
-            call_interface.get_args(),
+            call.target_contract,
+            call.selector,
+            call.args,
             true,
         );
 

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment/test/accounts.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment/test/accounts.nr
@@ -1,6 +1,6 @@
 use crate::{
     authwit::auth::{compute_authwit_message_hash, IS_VALID_SELECTOR},
-    context::call_interfaces::PrivateCallInterface,
+    context::calls::PrivateStaticCall,
     keys::getters::get_public_keys,
     test::helpers::{test_environment::TestEnvironment, txe_oracles},
 };
@@ -58,18 +58,13 @@ unconstrained fn light_accounts_fail_on_private_authwit_checks() {
     let light_account = env.create_light_account();
 
     let inner_hash = 13;
-    let caller = AztecAddress::zero();
 
-    env.call_private(
-        caller,
-        PrivateCallInterface::new(
-            light_account,
-            comptime { FunctionSelector::from_signature("verify_private_authwit(Field)") },
-            "verify_private_authwit",
-            [inner_hash],
-            true,
-        ),
-    );
+    env.view_private(PrivateStaticCall::new(
+        light_account,
+        comptime { FunctionSelector::from_signature("verify_private_authwit(Field)") },
+        "verify_private_authwit",
+        [inner_hash],
+    ));
 }
 
 #[test(should_fail_with = "Unknown auth witness")]
@@ -78,18 +73,13 @@ unconstrained fn contract_accounts_reject_invalid_private_authwits() {
     let contract_account = env.create_contract_account();
 
     let inner_hash = 13;
-    let caller = AztecAddress::zero();
 
-    env.call_private(
-        caller,
-        PrivateCallInterface::new(
-            contract_account,
-            comptime { FunctionSelector::from_signature("verify_private_authwit(Field)") },
-            "verify_private_authwit",
-            [inner_hash],
-            true,
-        ),
-    );
+    env.view_private(PrivateStaticCall::new(
+        contract_account,
+        comptime { FunctionSelector::from_signature("verify_private_authwit(Field)") },
+        "verify_private_authwit",
+        [inner_hash],
+    ));
 }
 
 #[test]
@@ -106,15 +96,11 @@ unconstrained fn contract_accounts_accept_valid_private_authwits() {
 
     txe_oracles::add_authwit(contract_account, message_hash);
 
-    let result = env.call_private(
-        caller,
-        PrivateCallInterface::new(
-            contract_account,
-            comptime { FunctionSelector::from_signature("verify_private_authwit(Field)") },
-            "verify_private_authwit",
-            [inner_hash],
-            true,
-        ),
-    );
+    let result = env.view_private(PrivateStaticCall::new(
+        contract_account,
+        comptime { FunctionSelector::from_signature("verify_private_authwit(Field)") },
+        "verify_private_authwit",
+        [inner_hash],
+    ));
     assert_eq(result, IS_VALID_SELECTOR);
 }

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/utils.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/utils.nr
@@ -1,5 +1,5 @@
 use crate::{
-    context::call_interfaces::{CallInterface, PrivateCallInterface, PublicCallInterface},
+    context::{PrivateCall, PublicCall},
     test::helpers::{test_environment::TestEnvironment, txe_oracles},
 };
 use protocol_types::{
@@ -37,17 +37,15 @@ impl<let N: u32> ContractDeployment<N> {
     pub unconstrained fn with_private_initializer<T, let P: u32>(
         self,
         from: AztecAddress,
-        initializer_call: PrivateCallInterface<P, T>,
+        initializer_call: PrivateCall<P, T>,
     ) -> AztecAddress
     where
         T: Deserialize,
     {
-        let instance = txe_oracles::deploy(
-            self.path,
-            initializer_call.get_name(),
-            initializer_call.get_args(),
-            self.secret,
-        );
+        let name = initializer_call.name;
+        let selector = initializer_call.selector;
+        let args = initializer_call.args;
+        let instance = txe_oracles::deploy(self.path, name, args, self.secret);
 
         // initializer_call does not actually have the target_contract value set - it is created with the helper
         // `interface` function created by `generate_contract_interface` in the aztec macros - it represents a call to
@@ -56,13 +54,7 @@ impl<let N: u32> ContractDeployment<N> {
         // We probably want to introduce an intermediate struct to represent this, if we're going to keep this API.
         let _ = self.env.call_private::<T, _>(
             from,
-            PrivateCallInterface::new(
-                instance.to_address(),
-                initializer_call.get_selector(),
-                initializer_call.get_name(),
-                initializer_call.get_args(),
-                initializer_call.get_is_static(),
-            ),
+            PrivateCall::new(instance.to_address(), selector, name, args),
         );
 
         instance.to_address()
@@ -89,17 +81,15 @@ impl<let N: u32> ContractDeployment<N> {
     pub unconstrained fn with_public_initializer<let P: u32, T>(
         self,
         from: AztecAddress,
-        initializer_call: PublicCallInterface<P, T>,
+        initializer_call: PublicCall<P, T>,
     ) -> AztecAddress
     where
         T: Deserialize,
     {
-        let instance = txe_oracles::deploy(
-            self.path,
-            initializer_call.get_name(),
-            initializer_call.get_args(),
-            self.secret,
-        );
+        let name = initializer_call.name;
+        let selector = initializer_call.selector;
+        let args = initializer_call.args;
+        let instance = txe_oracles::deploy(self.path, name, args, self.secret);
 
         // initializer_call does not actually have the target_contract value set - it is created with the helper
         // `interface` function created by `generate_contract_interface` in the aztec macros - it represents a call to
@@ -108,13 +98,7 @@ impl<let N: u32> ContractDeployment<N> {
         // We probably want to introduce an intermediate struct to represent this, if we're going to keep this API.
         let _ = self.env.call_public::<T, _>(
             from,
-            PublicCallInterface::new(
-                instance.to_address(),
-                initializer_call.get_selector(),
-                initializer_call.get_name(),
-                initializer_call.get_args(),
-                initializer_call.get_is_static(),
-            ),
+            PublicCall::new(instance.to_address(), selector, name, args),
         );
 
         instance.to_address()

--- a/noir-projects/noir-contracts/contracts/app/amm_contract/src/test/test.nr
+++ b/noir-projects/noir-contracts/contracts/app/amm_contract/src/test/test.nr
@@ -1,7 +1,7 @@
 use crate::{AMM, test::utils::{add_liquidity, remove_liquidity, setup}};
 use aztec::{
     protocol_types::{address::AztecAddress, traits::FromField},
-    test::helpers::authwit::add_private_authwit_from_call_interface,
+    test::helpers::authwit::add_private_authwit_from_call,
 };
 use token::Token;
 
@@ -163,7 +163,7 @@ unconstrained fn swap_exact_tokens_for_tokens() {
     env.call_private(minter, token0.mint_to_private(swapper, amount_in));
 
     // Create authwit for transferring tokens to AMM
-    add_private_authwit_from_call_interface(
+    add_private_authwit_from_call(
         env,
         swapper,
         amm_address,
@@ -223,13 +223,13 @@ unconstrained fn swap_tokens_for_exact_tokens() {
     env.call_private(minter, token0.mint_to_private(swapper, amount_in_max));
 
     // Create authwit for transferring tokens to AMM
-    let transfer_call_interface = token0.transfer_to_public_and_prepare_private_balance_increase(
+    let transfer_call = token0.transfer_to_public_and_prepare_private_balance_increase(
         swapper,
         amm_address,
         amount_in_max,
         AUTHWIT_NONCE,
     );
-    add_private_authwit_from_call_interface(env, swapper, amm_address, transfer_call_interface);
+    add_private_authwit_from_call(env, swapper, amm_address, transfer_call);
 
     env.call_private(
         swapper,

--- a/noir-projects/noir-contracts/contracts/app/amm_contract/src/test/utils.nr
+++ b/noir-projects/noir-contracts/contracts/app/amm_contract/src/test/utils.nr
@@ -1,9 +1,7 @@
 use crate::AMM;
 use aztec::{
     protocol_types::address::AztecAddress,
-    test::helpers::{
-        authwit::add_private_authwit_from_call_interface, test_environment::TestEnvironment,
-    },
+    test::helpers::{authwit::add_private_authwit_from_call, test_environment::TestEnvironment},
 };
 use token::Token;
 
@@ -82,31 +80,21 @@ pub(crate) unconstrained fn add_liquidity(
     env.call_private(minter, token0.mint_to_private(liquidity_provider, amount0_max));
     env.call_private(minter, token1.mint_to_private(liquidity_provider, amount1_max));
 
-    let transfer0_call_interface = token0.transfer_to_public_and_prepare_private_balance_increase(
+    let transfer0_call = token0.transfer_to_public_and_prepare_private_balance_increase(
         liquidity_provider,
         amm_address,
         amount0_max,
         AUTHWIT_NONCE,
     );
-    add_private_authwit_from_call_interface(
-        env,
-        liquidity_provider,
-        amm_address,
-        transfer0_call_interface,
-    );
+    add_private_authwit_from_call(env, liquidity_provider, amm_address, transfer0_call);
 
-    let transfer1_call_interface = token1.transfer_to_public_and_prepare_private_balance_increase(
+    let transfer1_call = token1.transfer_to_public_and_prepare_private_balance_increase(
         liquidity_provider,
         amm_address,
         amount1_max,
         AUTHWIT_NONCE,
     );
-    add_private_authwit_from_call_interface(
-        env,
-        liquidity_provider,
-        amm_address,
-        transfer1_call_interface,
-    );
+    add_private_authwit_from_call(env, liquidity_provider, amm_address, transfer1_call);
 
     env.call_private(
         liquidity_provider,
@@ -126,17 +114,17 @@ pub(crate) unconstrained fn remove_liquidity(
     let liquidity_token = Token::at(liquidity_token_address);
     let amm = AMM::at(amm_address);
 
-    let transfer_liquidity_call_interface = liquidity_token.transfer_to_public(
+    let transfer_liquidity_call = liquidity_token.transfer_to_public(
         liquidity_provider,
         amm_address,
         liquidity_amount,
         AUTHWIT_NONCE,
     );
-    add_private_authwit_from_call_interface(
+    add_private_authwit_from_call(
         env,
         liquidity_provider,
         amm_address,
-        transfer_liquidity_call_interface,
+        transfer_liquidity_call,
     );
 
     env.call_private(

--- a/noir-projects/noir-contracts/contracts/app/auth_contract/src/test.nr
+++ b/noir-projects/noir-contracts/contracts/app/auth_contract/src/test.nr
@@ -11,10 +11,9 @@ unconstrained fn setup() -> (TestEnvironment, AztecAddress, AztecAddress, AztecA
     let to_authorize = env.create_light_account();
     let other = env.create_light_account();
 
-    let initializer_call_interface = Auth::interface().constructor(admin);
+    let initializer_call = Auth::interface().constructor(admin);
 
-    let auth_contract_address =
-        env.deploy("Auth").with_public_initializer(admin, initializer_call_interface);
+    let auth_contract_address = env.deploy("Auth").with_public_initializer(admin, initializer_call);
 
     (env, auth_contract_address, admin, to_authorize, other)
 }

--- a/noir-projects/noir-contracts/contracts/app/nft_contract/src/test/transfer_in_private.nr
+++ b/noir-projects/noir-contracts/contracts/app/nft_contract/src/test/transfer_in_private.nr
@@ -1,8 +1,6 @@
 use crate::NFT;
 use crate::test::utils;
-use aztec::{
-    oracle::random::random, test::helpers::authwit::add_private_authwit_from_call_interface,
-};
+use aztec::{oracle::random::random, test::helpers::authwit::add_private_authwit_from_call};
 
 #[test]
 unconstrained fn transfer_in_private() {
@@ -60,17 +58,12 @@ unconstrained fn transfer_in_private_on_behalf_of_other() {
         utils::setup_mint_and_transfer_to_private(/* with_account_contracts */ true);
 
     // Transfer the NFT to the recipient
-    let transfer_in_private_call_interface =
+    let transfer_in_private_call =
         NFT::at(nft_contract_address).transfer_in_private(sender, recipient, token_id, 1);
-    add_private_authwit_from_call_interface(
-        env,
-        sender,
-        recipient,
-        transfer_in_private_call_interface,
-    );
+    add_private_authwit_from_call(env, sender, recipient, transfer_in_private_call);
 
     // Transfer the NFT to the recipient
-    env.call_private(recipient, transfer_in_private_call_interface);
+    env.call_private(recipient, transfer_in_private_call);
 
     // Recipient should be the private NFT owner
     utils::assert_owns_private_nft(env, nft_contract_address, recipient, token_id);
@@ -135,15 +128,10 @@ unconstrained fn transfer_in_private_failure_on_behalf_of_other_wrong_caller() {
     // We set random value for the token_id as the authwit nonce check is before we use the value.
     let token_id = random();
 
-    let transfer_in_private_from_call_interface =
+    let transfer_in_private_from_call =
         NFT::at(nft_contract_address).transfer_in_private(sender, recipient, token_id, 1);
-    add_private_authwit_from_call_interface(
-        env,
-        sender,
-        sender,
-        transfer_in_private_from_call_interface,
-    );
+    add_private_authwit_from_call(env, sender, sender, transfer_in_private_from_call);
 
     // Try transferring the NFT
-    env.call_private(recipient, transfer_in_private_from_call_interface);
+    env.call_private(recipient, transfer_in_private_from_call);
 }

--- a/noir-projects/noir-contracts/contracts/app/nft_contract/src/test/transfer_in_public.nr
+++ b/noir-projects/noir-contracts/contracts/app/nft_contract/src/test/transfer_in_public.nr
@@ -1,6 +1,6 @@
 use crate::NFT;
 use crate::test::utils;
-use aztec::test::helpers::authwit::add_public_authwit_from_call_interface;
+use aztec::test::helpers::authwit::add_public_authwit_from_call;
 
 #[test]
 unconstrained fn transfer_in_public() {
@@ -36,17 +36,12 @@ unconstrained fn transfer_in_public_on_behalf_of_other() {
     let (env, nft_contract_address, sender, recipient, token_id) =
         utils::setup_and_mint(/* with_account_contracts */ true);
 
-    let transfer_in_public_from_call_interface =
+    let transfer_in_public_from_call =
         NFT::at(nft_contract_address).transfer_in_public(sender, recipient, token_id, 1);
-    add_public_authwit_from_call_interface(
-        env,
-        sender,
-        recipient,
-        transfer_in_public_from_call_interface,
-    );
+    add_public_authwit_from_call(env, sender, recipient, transfer_in_public_from_call);
 
     // Transfer the NFT
-    env.call_public(recipient, transfer_in_public_from_call_interface);
+    env.call_public(recipient, transfer_in_public_from_call);
 
     // Check the is recipient is the new public owner
     utils::assert_owns_public_nft(env, nft_contract_address, recipient, token_id);
@@ -97,15 +92,10 @@ unconstrained fn transfer_in_public_failure_on_behalf_of_other_wrong_caller() {
     // Setup with account contracts. Slower since we actually deploy them, but needed for authwits.
     let (env, nft_contract_address, sender, recipient, token_id) =
         utils::setup_and_mint(/* with_account_contracts */ true);
-    let transfer_in_public_from_call_interface =
+    let transfer_in_public_from_call =
         NFT::at(nft_contract_address).transfer_in_public(sender, recipient, token_id, 1);
-    add_public_authwit_from_call_interface(
-        env,
-        sender,
-        sender,
-        transfer_in_public_from_call_interface,
-    );
+    add_public_authwit_from_call(env, sender, sender, transfer_in_public_from_call);
 
     // Try to transfer tokens
-    env.call_public(recipient, transfer_in_public_from_call_interface);
+    env.call_public(recipient, transfer_in_public_from_call);
 }

--- a/noir-projects/noir-contracts/contracts/app/nft_contract/src/test/transfer_to_public.nr
+++ b/noir-projects/noir-contracts/contracts/app/nft_contract/src/test/transfer_to_public.nr
@@ -1,8 +1,6 @@
 use crate::NFT;
 use crate::test::utils;
-use aztec::{
-    oracle::random::random, test::helpers::authwit::add_private_authwit_from_call_interface,
-};
+use aztec::{oracle::random::random, test::helpers::authwit::add_private_authwit_from_call};
 
 #[test]
 unconstrained fn transfer_to_public() {
@@ -36,17 +34,12 @@ unconstrained fn transfer_to_public_on_behalf_of_other() {
     let (env, nft_contract_address, sender, recipient, token_id) =
         utils::setup_mint_and_transfer_to_private(/* with_account_contracts */ true);
 
-    let transfer_to_public_call_interface =
+    let transfer_to_public_call =
         NFT::at(nft_contract_address).transfer_to_public(sender, recipient, token_id, 0);
-    add_private_authwit_from_call_interface(
-        env,
-        sender,
-        recipient,
-        transfer_to_public_call_interface,
-    );
+    add_private_authwit_from_call(env, sender, recipient, transfer_to_public_call);
 
     // transfer_to_public the NFT
-    env.call_private(recipient, transfer_to_public_call_interface);
+    env.call_private(recipient, transfer_to_public_call);
 
     // Recipient should be the public owner
     utils::assert_owns_public_nft(env, nft_contract_address, recipient, token_id);
@@ -81,12 +74,12 @@ unconstrained fn transfer_to_public_failure_on_behalf_of_other_invalid_designate
     let (env, nft_contract_address, sender, recipient, token_id) =
         utils::setup_mint_and_transfer_to_private(/* with_account_contracts */ true);
 
-    let transfer_to_public_call_interface =
+    let transfer_to_public_call =
         NFT::at(nft_contract_address).transfer_to_public(sender, recipient, token_id, 0);
-    add_private_authwit_from_call_interface(env, sender, sender, transfer_to_public_call_interface);
+    add_private_authwit_from_call(env, sender, sender, transfer_to_public_call);
 
     // transfer_to_public the NFT
-    env.call_private(recipient, transfer_to_public_call_interface);
+    env.call_private(recipient, transfer_to_public_call);
 }
 
 #[test(should_fail_with = "Unknown auth witness for message hash")]

--- a/noir-projects/noir-contracts/contracts/app/nft_contract/src/test/utils.nr
+++ b/noir-projects/noir-contracts/contracts/app/nft_contract/src/test/utils.nr
@@ -20,13 +20,12 @@ pub unconstrained fn setup(
     };
 
     // Deploy token contract
-    let initializer_call_interface = NFT::interface().constructor(
+    let initializer_call = NFT::interface().constructor(
         owner,
         "TestNFT000000000000000000000000",
         "TN00000000000000000000000000000",
     );
-    let nft_contract_address =
-        env.deploy("NFT").with_public_initializer(owner, initializer_call_interface);
+    let nft_contract_address = env.deploy("NFT").with_public_initializer(owner, initializer_call);
 
     (env, nft_contract_address, owner, recipient)
 }

--- a/noir-projects/noir-contracts/contracts/app/orderbook_contract/src/test/test.nr
+++ b/noir-projects/noir-contracts/contracts/app/orderbook_contract/src/test/test.nr
@@ -1,7 +1,7 @@
 use crate::{Orderbook, test::utils::setup};
 use aztec::{
     protocol_types::{address::AztecAddress, traits::FromField},
-    test::helpers::authwit::add_private_authwit_from_call_interface,
+    test::helpers::authwit::add_private_authwit_from_call,
 };
 use token::Token;
 use uint_note::uint_note::PartialUintNote;
@@ -29,9 +29,9 @@ unconstrained fn full_flow() {
     env.call_private(minter, token1.mint_to_private(taker, ASK_AMOUNT));
 
     // ORDER CREATION
-    let transfer_call_interface =
+    let transfer_call =
         token0.transfer_to_public(maker, orderbook_address, BID_AMOUNT, CREATE_ORDER_AUTHWIT_NONCE);
-    add_private_authwit_from_call_interface(env, maker, orderbook_address, transfer_call_interface);
+    add_private_authwit_from_call(env, maker, orderbook_address, transfer_call);
 
     let order_id = env.call_private(
         maker,
@@ -61,18 +61,13 @@ unconstrained fn full_flow() {
     // Convert order_id back to PartialUintNote as the orderbook does and then create authwit for taker to transfer ask
     // tokens.
     let maker_partial_note = PartialUintNote::from_field(order_id);
-    let fulfill_transfer_call_interface = token1.finalize_transfer_to_private_from_private(
+    let fulfill_transfer_call = token1.finalize_transfer_to_private_from_private(
         taker,
         maker_partial_note,
         ASK_AMOUNT,
         FULFILL_ORDER_AUTHWIT_NONCE,
     );
-    add_private_authwit_from_call_interface(
-        env,
-        taker,
-        orderbook_address,
-        fulfill_transfer_call_interface,
-    );
+    add_private_authwit_from_call(env, taker, orderbook_address, fulfill_transfer_call);
 
     env.call_private(taker, orderbook.fulfill_order(order_id, FULFILL_ORDER_AUTHWIT_NONCE));
 

--- a/noir-projects/noir-contracts/contracts/app/private_voting_contract/src/test/utils.nr
+++ b/noir-projects/noir-contracts/contracts/app/private_voting_contract/src/test/utils.nr
@@ -9,9 +9,9 @@ pub unconstrained fn setup() -> (TestEnvironment, AztecAddress, AztecAddress) {
 
     let admin = env.create_light_account();
 
-    let initializer_call_interface = PrivateVoting::interface().constructor(admin);
+    let initializer_call = PrivateVoting::interface().constructor(admin);
     let voting_contract_address =
-        env.deploy("PrivateVoting").with_public_initializer(admin, initializer_call_interface);
+        env.deploy("PrivateVoting").with_public_initializer(admin, initializer_call);
 
     (env, voting_contract_address, admin)
 }

--- a/noir-projects/noir-contracts/contracts/app/simple_token_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/simple_token_contract/src/main.nr
@@ -14,7 +14,7 @@ pub contract SimpleToken {
 
     use aztec::{
         authwit::auth::compute_authwit_nullifier,
-        context::{PrivateCallInterface, PrivateContext},
+        context::{PrivateCall, PrivateContext},
         macros::{
             events::event,
             functions::{authorize_once, external, initializer, internal, only_self, view},
@@ -298,7 +298,7 @@ pub contract SimpleToken {
         context: PrivateContext,
         account: AztecAddress,
         remaining: u128,
-    ) -> PrivateCallInterface<25, u128> {
+    ) -> PrivateCall<25, u128> {
         SimpleToken::at(context.this_address())._recurse_subtract_balance(account, remaining)
     }
 

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/main.nr
@@ -19,7 +19,7 @@ pub contract Token {
 
     use aztec::{
         authwit::auth::compute_authwit_nullifier,
-        context::{PrivateCallInterface, PrivateContext},
+        context::{PrivateCall, PrivateContext},
         macros::{
             events::event,
             functions::{authorize_once, external, initializer, internal, only_self, view},
@@ -283,7 +283,7 @@ pub contract Token {
         context: PrivateContext,
         account: AztecAddress,
         remaining: u128,
-    ) -> PrivateCallInterface<25, u128> {
+    ) -> PrivateCall<25, u128> {
         Token::at(context.this_address())._recurse_subtract_balance(account, remaining)
     }
 

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/test/burn_private.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/test/burn_private.nr
@@ -1,6 +1,6 @@
 use crate::test::utils;
 use crate::Token;
-use aztec::test::helpers::authwit::add_private_authwit_from_call_interface;
+use aztec::test::helpers::authwit::add_private_authwit_from_call;
 
 global AUTHWIT_NONCE: Field = 7;
 
@@ -27,11 +27,11 @@ unconstrained fn burn_private_on_behalf_of_other() {
     let burn_amount = mint_amount / (10 as u128);
 
     // Burn on behalf of other
-    let burn_call_interface =
+    let burn_call =
         Token::at(token_contract_address).burn_private(owner, burn_amount, AUTHWIT_NONCE);
-    add_private_authwit_from_call_interface(env, owner, recipient, burn_call_interface);
+    add_private_authwit_from_call(env, owner, recipient, burn_call);
     // Burn tokens
-    env.call_private(recipient, burn_call_interface);
+    env.call_private(recipient, burn_call);
     utils::check_private_balance(
         env,
         token_contract_address,
@@ -67,11 +67,11 @@ unconstrained fn burn_private_failure_on_behalf_of_other_more_than_balance() {
     // Burn more than balance
     let burn_amount = mint_amount * (10 as u128);
     // Burn on behalf of other
-    let burn_call_interface =
+    let burn_call =
         Token::at(token_contract_address).burn_private(owner, burn_amount, AUTHWIT_NONCE);
-    add_private_authwit_from_call_interface(env, owner, recipient, burn_call_interface);
+    add_private_authwit_from_call(env, owner, recipient, burn_call);
 
-    env.call_private(recipient, burn_call_interface);
+    env.call_private(recipient, burn_call);
 }
 
 #[test(should_fail_with = "Unknown auth witness for message hash")]
@@ -82,10 +82,10 @@ unconstrained fn burn_private_failure_on_behalf_of_other_without_approval() {
     // Burn more than balance
     let burn_amount = mint_amount / (10 as u128);
     // Burn on behalf of other
-    let burn_call_interface =
+    let burn_call =
         Token::at(token_contract_address).burn_private(owner, burn_amount, AUTHWIT_NONCE);
 
-    env.call_private(recipient, burn_call_interface);
+    env.call_private(recipient, burn_call);
 }
 
 #[test(should_fail_with = "Unknown auth witness for message hash")]
@@ -96,9 +96,9 @@ unconstrained fn burn_private_failure_on_behalf_of_other_wrong_designated_caller
     // Burn more than balance
     let burn_amount = mint_amount / (10 as u128);
     // Burn on behalf of other
-    let burn_call_interface =
+    let burn_call =
         Token::at(token_contract_address).burn_private(owner, burn_amount, AUTHWIT_NONCE);
-    add_private_authwit_from_call_interface(env, owner, owner, burn_call_interface);
+    add_private_authwit_from_call(env, owner, owner, burn_call);
 
-    env.call_private(recipient, burn_call_interface);
+    env.call_private(recipient, burn_call);
 }

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/test/burn_public.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/test/burn_public.nr
@@ -1,6 +1,6 @@
 use crate::test::utils;
 use crate::Token;
-use aztec::{oracle::random::random, test::helpers::authwit::add_public_authwit_from_call_interface};
+use aztec::{oracle::random::random, test::helpers::authwit::add_public_authwit_from_call};
 
 #[test]
 unconstrained fn burn_public_success() {
@@ -25,12 +25,11 @@ unconstrained fn burn_public_on_behalf_of_other() {
     let burn_amount = mint_amount / (10 as u128);
 
     // Burn on behalf of other
-    let burn_call_interface =
-        Token::at(token_contract_address).burn_public(owner, burn_amount, random());
-    add_public_authwit_from_call_interface(env, owner, recipient, burn_call_interface);
+    let burn_call = Token::at(token_contract_address).burn_public(owner, burn_amount, random());
+    add_public_authwit_from_call(env, owner, recipient, burn_call);
 
     // Burn tokens
-    env.call_public(recipient, burn_call_interface);
+    env.call_public(recipient, burn_call);
 
     utils::check_public_balance(
         env,
@@ -72,10 +71,9 @@ unconstrained fn burn_public_failure_on_behalf_of_other_without_approval() {
 
     // Burn on behalf of other without approval
     let burn_amount = mint_amount / (10 as u128);
-    let burn_call_interface =
-        Token::at(token_contract_address).burn_public(owner, burn_amount, random());
+    let burn_call = Token::at(token_contract_address).burn_public(owner, burn_amount, random());
 
-    env.call_public(recipient, burn_call_interface);
+    env.call_public(recipient, burn_call);
 }
 
 #[test(should_fail_with = "unauthorized")]
@@ -85,9 +83,8 @@ unconstrained fn burn_public_failure_on_behalf_of_other_wrong_caller() {
 
     // Burn on behalf of other, wrong designated caller
     let burn_amount = mint_amount / (10 as u128);
-    let burn_call_interface =
-        Token::at(token_contract_address).burn_public(owner, burn_amount, random());
-    add_public_authwit_from_call_interface(env, owner, owner, burn_call_interface);
+    let burn_call = Token::at(token_contract_address).burn_public(owner, burn_amount, random());
+    add_public_authwit_from_call(env, owner, owner, burn_call);
 
-    env.call_public(recipient, burn_call_interface);
+    env.call_public(recipient, burn_call);
 }

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/test/transfer_in_private.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/test/transfer_in_private.nr
@@ -1,6 +1,6 @@
 use crate::test::utils;
 use crate::Token;
-use aztec::test::helpers::authwit::add_private_authwit_from_call_interface;
+use aztec::test::helpers::authwit::add_private_authwit_from_call;
 
 #[test]
 unconstrained fn transfer_private_on_behalf_of_other() {
@@ -9,16 +9,11 @@ unconstrained fn transfer_private_on_behalf_of_other() {
         utils::setup_and_mint_to_private(/* with_account_contracts */ true);
     // Add authwit
     let transfer_amount = 1000 as u128;
-    let transfer_private_from_call_interface =
+    let transfer_private_from_call =
         Token::at(token_contract_address).transfer_in_private(owner, recipient, transfer_amount, 1);
-    add_private_authwit_from_call_interface(
-        env,
-        owner,
-        recipient,
-        transfer_private_from_call_interface,
-    );
+    add_private_authwit_from_call(env, owner, recipient, transfer_private_from_call);
     // Transfer tokens
-    env.call_private(recipient, transfer_private_from_call_interface);
+    env.call_private(recipient, transfer_private_from_call);
     // Check balances
     utils::check_private_balance(
         env,
@@ -36,16 +31,11 @@ unconstrained fn transfer_private_failure_on_behalf_of_self_non_zero_nonce() {
         utils::setup_and_mint_to_private(/* with_account_contracts */ false);
     // Add authwit
     let transfer_amount = 1000 as u128;
-    let transfer_private_from_call_interface =
+    let transfer_private_from_call =
         Token::at(token_contract_address).transfer_in_private(owner, recipient, transfer_amount, 1);
-    add_private_authwit_from_call_interface(
-        env,
-        owner,
-        recipient,
-        transfer_private_from_call_interface,
-    );
+    add_private_authwit_from_call(env, owner, recipient, transfer_private_from_call);
     // Transfer tokens
-    env.call_private(owner, transfer_private_from_call_interface);
+    env.call_private(owner, transfer_private_from_call);
 }
 
 #[test(should_fail_with = "Balance too low")]
@@ -55,16 +45,11 @@ unconstrained fn transfer_private_failure_on_behalf_of_more_than_balance() {
         utils::setup_and_mint_to_private(/* with_account_contracts */ true);
     // Add authwit
     let transfer_amount = mint_amount + (1 as u128);
-    let transfer_private_from_call_interface =
+    let transfer_private_from_call =
         Token::at(token_contract_address).transfer_in_private(owner, recipient, transfer_amount, 1);
-    add_private_authwit_from_call_interface(
-        env,
-        owner,
-        recipient,
-        transfer_private_from_call_interface,
-    );
+    add_private_authwit_from_call(env, owner, recipient, transfer_private_from_call);
     // Transfer tokens
-    env.call_private(recipient, transfer_private_from_call_interface);
+    env.call_private(recipient, transfer_private_from_call);
 }
 
 #[test(should_fail_with = "Unknown auth witness for message hash")]
@@ -74,10 +59,10 @@ unconstrained fn transfer_private_failure_on_behalf_of_other_without_approval() 
         utils::setup_and_mint_to_private(/* with_account_contracts */ true);
     // Add authwit
     let transfer_amount = 1000 as u128;
-    let transfer_private_from_call_interface =
+    let transfer_private_from_call =
         Token::at(token_contract_address).transfer_in_private(owner, recipient, transfer_amount, 1);
     // Transfer tokens
-    env.call_private(recipient, transfer_private_from_call_interface);
+    env.call_private(recipient, transfer_private_from_call);
 }
 
 #[test(should_fail_with = "Unknown auth witness for message hash")]
@@ -87,14 +72,9 @@ unconstrained fn transfer_private_failure_on_behalf_of_other_wrong_caller() {
         utils::setup_and_mint_to_private(/* with_account_contracts */ true);
     // Add authwit
     let transfer_amount = 1000 as u128;
-    let transfer_private_from_call_interface =
+    let transfer_private_from_call =
         Token::at(token_contract_address).transfer_in_private(owner, recipient, transfer_amount, 1);
-    add_private_authwit_from_call_interface(
-        env,
-        owner,
-        owner,
-        transfer_private_from_call_interface,
-    );
+    add_private_authwit_from_call(env, owner, owner, transfer_private_from_call);
     // Transfer tokens
-    env.call_private(recipient, transfer_private_from_call_interface);
+    env.call_private(recipient, transfer_private_from_call);
 }

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/test/transfer_in_public.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/test/transfer_in_public.nr
@@ -1,6 +1,6 @@
 use crate::test::utils;
 use crate::Token;
-use aztec::test::helpers::authwit::add_public_authwit_from_call_interface;
+use aztec::test::helpers::authwit::add_public_authwit_from_call;
 
 #[test]
 unconstrained fn public_transfer() {
@@ -45,16 +45,11 @@ unconstrained fn public_transfer_on_behalf_of_other() {
     let (env, token_contract_address, owner, recipient, mint_amount) =
         utils::setup_and_mint_to_public(/* with_account_contracts */ true);
     let transfer_amount = mint_amount / (10 as u128);
-    let public_transfer_in_private_call_interface =
+    let public_transfer_in_private_call =
         Token::at(token_contract_address).transfer_in_public(owner, recipient, transfer_amount, 1);
-    add_public_authwit_from_call_interface(
-        env,
-        owner,
-        recipient,
-        public_transfer_in_private_call_interface,
-    );
+    add_public_authwit_from_call(env, owner, recipient, public_transfer_in_private_call);
     // Transfer tokens
-    env.call_public(recipient, public_transfer_in_private_call_interface);
+    env.call_public(recipient, public_transfer_in_private_call);
     // Check balances
     utils::check_public_balance(
         env,
@@ -72,10 +67,10 @@ unconstrained fn public_transfer_failure_more_than_balance() {
         utils::setup_and_mint_to_public(/* with_account_contracts */ false);
     // Transfer tokens
     let transfer_amount = mint_amount + (1 as u128);
-    let public_transfer_call_interface =
+    let public_transfer_call =
         Token::at(token_contract_address).transfer_in_public(owner, recipient, transfer_amount, 0);
     // Try to transfer tokens
-    env.call_public(owner, public_transfer_call_interface);
+    env.call_public(owner, public_transfer_call);
 }
 
 #[test(should_fail_with = "Assertion failed: Invalid authwit nonce. When 'from' and 'msg_sender' are the same, 'authwit_nonce' must be zero")]
@@ -85,11 +80,11 @@ unconstrained fn public_transfer_failure_on_behalf_of_self_non_zero_nonce() {
         utils::setup_and_mint_to_public(/* with_account_contracts */ false);
     // Transfer tokens
     let transfer_amount = mint_amount / (10 as u128);
-    let public_transfer_call_interface =
+    let public_transfer_call =
         Token::at(token_contract_address).transfer_in_public(owner, recipient, transfer_amount, 1);
-    add_public_authwit_from_call_interface(env, owner, recipient, public_transfer_call_interface);
+    add_public_authwit_from_call(env, owner, recipient, public_transfer_call);
     // Try to transfer tokens
-    env.call_public(owner, public_transfer_call_interface);
+    env.call_public(owner, public_transfer_call);
 }
 
 #[test(should_fail_with = "unauthorized")]
@@ -98,11 +93,11 @@ unconstrained fn public_transfer_failure_on_behalf_of_other_without_approval() {
     let (env, token_contract_address, owner, recipient, mint_amount) =
         utils::setup_and_mint_to_public(/* with_account_contracts */ true);
     let transfer_amount = mint_amount / (10 as u128);
-    let public_transfer_in_private_call_interface =
+    let public_transfer_in_private_call =
         Token::at(token_contract_address).transfer_in_public(owner, recipient, transfer_amount, 1);
 
     // Try to transfer tokens
-    env.call_public(recipient, public_transfer_in_private_call_interface);
+    env.call_public(recipient, public_transfer_in_private_call);
 }
 
 #[test(should_fail_with = "Assertion failed: attempt to subtract with overflow")]
@@ -111,17 +106,12 @@ unconstrained fn public_transfer_failure_on_behalf_of_other_more_than_balance() 
     let (env, token_contract_address, owner, recipient, mint_amount) =
         utils::setup_and_mint_to_public(/* with_account_contracts */ true);
     let transfer_amount = mint_amount + (1 as u128);
-    let public_transfer_in_private_call_interface =
+    let public_transfer_in_private_call =
         Token::at(token_contract_address).transfer_in_public(owner, recipient, transfer_amount, 1);
-    add_public_authwit_from_call_interface(
-        env,
-        owner,
-        recipient,
-        public_transfer_in_private_call_interface,
-    );
+    add_public_authwit_from_call(env, owner, recipient, public_transfer_in_private_call);
 
     // Try to transfer tokens
-    env.call_public(recipient, public_transfer_in_private_call_interface);
+    env.call_public(recipient, public_transfer_in_private_call);
 }
 
 #[test(should_fail_with = "unauthorized")]
@@ -130,15 +120,10 @@ unconstrained fn public_transfer_failure_on_behalf_of_other_wrong_caller() {
     let (env, token_contract_address, owner, recipient, mint_amount) =
         utils::setup_and_mint_to_public(/* with_account_contracts */ true);
     let transfer_amount = mint_amount / (10 as u128);
-    let public_transfer_in_private_call_interface =
+    let public_transfer_in_private_call =
         Token::at(token_contract_address).transfer_in_public(owner, recipient, transfer_amount, 1);
-    add_public_authwit_from_call_interface(
-        env,
-        owner,
-        owner,
-        public_transfer_in_private_call_interface,
-    );
+    add_public_authwit_from_call(env, owner, owner, public_transfer_in_private_call);
 
     // Try to transfer tokens
-    env.call_public(recipient, public_transfer_in_private_call_interface);
+    env.call_public(recipient, public_transfer_in_private_call);
 }

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/test/transfer_to_public.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/test/transfer_to_public.nr
@@ -1,8 +1,6 @@
 use crate::test::utils;
 use crate::Token;
-use aztec::{
-    oracle::random::random, test::helpers::authwit::add_private_authwit_from_call_interface,
-};
+use aztec::{oracle::random::random, test::helpers::authwit::add_private_authwit_from_call};
 
 #[test]
 unconstrained fn transfer_to_public_on_behalf_of_self() {
@@ -40,20 +38,15 @@ unconstrained fn transfer_to_public_on_behalf_of_other() {
         utils::setup_and_mint_to_private(/* with_account_contracts */ true);
 
     let transfer_to_public_amount = mint_amount / (10 as u128);
-    let transfer_to_public_call_interface = Token::at(token_contract_address).transfer_to_public(
+    let transfer_to_public_call = Token::at(token_contract_address).transfer_to_public(
         owner,
         recipient,
         transfer_to_public_amount,
         0,
     );
-    add_private_authwit_from_call_interface(
-        env,
-        owner,
-        recipient,
-        transfer_to_public_call_interface,
-    );
+    add_private_authwit_from_call(env, owner, recipient, transfer_to_public_call);
     // transfer_to_public tokens
-    env.call_private(recipient, transfer_to_public_call_interface);
+    env.call_private(recipient, transfer_to_public_call);
     utils::check_private_balance(
         env,
         token_contract_address,
@@ -110,21 +103,16 @@ unconstrained fn transfer_to_public_failure_on_behalf_of_other_more_than_balance
         utils::setup_and_mint_to_private(/* with_account_contracts */ true);
 
     let transfer_to_public_amount = mint_amount + (1 as u128);
-    let transfer_to_public_call_interface = Token::at(token_contract_address).transfer_to_public(
+    let transfer_to_public_call = Token::at(token_contract_address).transfer_to_public(
         owner,
         recipient,
         transfer_to_public_amount,
         0,
     );
-    add_private_authwit_from_call_interface(
-        env,
-        owner,
-        recipient,
-        transfer_to_public_call_interface,
-    );
+    add_private_authwit_from_call(env, owner, recipient, transfer_to_public_call);
 
     // transfer_to_public tokens
-    env.call_private(recipient, transfer_to_public_call_interface);
+    env.call_private(recipient, transfer_to_public_call);
 }
 
 #[test(should_fail_with = "Unknown auth witness for message hash")]
@@ -133,16 +121,16 @@ unconstrained fn transfer_to_public_failure_on_behalf_of_other_invalid_designate
         utils::setup_and_mint_to_private(/* with_account_contracts */ true);
 
     let transfer_to_public_amount = mint_amount + (1 as u128);
-    let transfer_to_public_call_interface = Token::at(token_contract_address).transfer_to_public(
+    let transfer_to_public_call = Token::at(token_contract_address).transfer_to_public(
         owner,
         recipient,
         transfer_to_public_amount,
         0,
     );
-    add_private_authwit_from_call_interface(env, owner, owner, transfer_to_public_call_interface);
+    add_private_authwit_from_call(env, owner, owner, transfer_to_public_call);
 
     // transfer_to_public tokens
-    env.call_private(recipient, transfer_to_public_call_interface);
+    env.call_private(recipient, transfer_to_public_call);
 }
 
 #[test(should_fail_with = "Unknown auth witness for message hash")]
@@ -151,7 +139,7 @@ unconstrained fn transfer_to_public_failure_on_behalf_of_other_no_approval() {
         utils::setup_and_mint_to_private(/* with_account_contracts */ true);
 
     let transfer_to_public_amount = mint_amount + (1 as u128);
-    let transfer_to_public_call_interface = Token::at(token_contract_address).transfer_to_public(
+    let transfer_to_public_call = Token::at(token_contract_address).transfer_to_public(
         owner,
         recipient,
         transfer_to_public_amount,
@@ -159,5 +147,5 @@ unconstrained fn transfer_to_public_failure_on_behalf_of_other_no_approval() {
     );
 
     // transfer_to_public tokens
-    env.call_private(recipient, transfer_to_public_call_interface);
+    env.call_private(recipient, transfer_to_public_call);
 }

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/test/transfer_to_public_and_prepare_private_balance_increase.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/test/transfer_to_public_and_prepare_private_balance_increase.nr
@@ -1,8 +1,6 @@
 use crate::test::utils;
 use crate::Token;
-use aztec::{
-    oracle::random::random, test::helpers::authwit::add_private_authwit_from_call_interface,
-};
+use aztec::{oracle::random::random, test::helpers::authwit::add_private_authwit_from_call};
 
 // Tests the typical scenario in which transfer_to_public_and_prepare_private_balance_increase is to be used:
 // 1. The liquidity provider calls private AMM::add_liquidity function,
@@ -18,7 +16,7 @@ unconstrained fn transfer_to_public_and_prepare_private_balance_increase_and_fin
         utils::setup_and_mint_to_private(/* with_account_contracts */ true);
 
     let deposit_amount: u128 = mint_amount / (10 as u128);
-    let transfer_call_interface = Token::at(token_contract_address)
+    let transfer_call = Token::at(token_contract_address)
         .transfer_to_public_and_prepare_private_balance_increase(
             liquidity_provider,
             amm_contract,
@@ -28,15 +26,10 @@ unconstrained fn transfer_to_public_and_prepare_private_balance_increase_and_fin
 
     // Add authwit such that the AMM can transfer the deposit amount of the liquidity provider to the public balance of
     // itself.
-    add_private_authwit_from_call_interface(
-        env,
-        liquidity_provider,
-        amm_contract,
-        transfer_call_interface,
-    );
+    add_private_authwit_from_call(env, liquidity_provider, amm_contract, transfer_call);
 
     // Impersonate the AMM and initiate the transfer
-    let partial_note = env.call_private(amm_contract, transfer_call_interface);
+    let partial_note = env.call_private(amm_contract, transfer_call);
 
     // Check balances before the partial note is finalized
     utils::check_private_balance(

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/test/utils.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/test/utils.nr
@@ -20,14 +20,14 @@ pub unconstrained fn setup(
     };
 
     // Deploy token contract
-    let initializer_call_interface = Token::interface().constructor(
+    let initializer_call = Token::interface().constructor(
         owner,
         "TestToken0000000000000000000000",
         "TT00000000000000000000000000000",
         18,
     );
     let token_contract_address =
-        env.deploy("Token").with_public_initializer(owner, initializer_call_interface);
+        env.deploy("Token").with_public_initializer(owner, initializer_call);
     (env, token_contract_address, owner, recipient)
 }
 


### PR DESCRIPTION
The complexity of the changes in this PR has been low so I decided to do a few things in one go:
1. Drop the `CallInterface` trait as it was not needed,
2. drop the call interface name and just use call,
3. dropped `is_static` from the static as its presence was bizarre (why does `PrivateCall` have `is_static` when there is another `PrivateStaticCall` struct?)