### PR TITLE
feat: bump bignum and bigcurve versions

### DIFF
--- a/noir-projects/noir-protocol-circuits/crates/blob/Nargo.toml
+++ b/noir-projects/noir-protocol-circuits/crates/blob/Nargo.toml
@@ -5,7 +5,7 @@ authors = [""]
 compiler_version = ">=0.30.0"
 
 [dependencies]
-bignum = { tag = "v0.8.0", git = "https://github.com/noir-lang/noir-bignum" }
-bigcurve = { tag = "v0.11.0", git = "https://github.com/noir-lang/noir_bigcurve" }
+bignum = { git = "https://github.com/noir-lang/noir-bignum", tag = "v0.8.2" }
+bigcurve = { git = "https://github.com/noir-lang/noir_bigcurve", tag = "v0.12.0" }
 types = { path = "../types" }
-poseidon = { tag = "v0.1.1", git = "https://github.com/noir-lang/poseidon" }
+poseidon = { git = "https://github.com/noir-lang/poseidon", tag = "v0.1.1" }

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/Nargo.toml
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/Nargo.toml
@@ -5,9 +5,9 @@ authors = [""]
 compiler_version = ">=0.18.0"
 
 [dependencies]
-bignum = { tag = "v0.8.0", git = "https://github.com/noir-lang/noir-bignum" }
-bigcurve = { tag = "v0.11.0", git = "https://github.com/noir-lang/noir_bigcurve" }
+bignum = { git = "https://github.com/noir-lang/noir-bignum", tag = "v0.8.2" }
+bigcurve = { git = "https://github.com/noir-lang/noir_bigcurve", tag = "v0.12.0" }
 types = { path = "../types" }
 parity_lib = { path = "../parity-lib" }
 blob = { path = "../blob" }
-poseidon = { tag = "v0.1.1", git = "https://github.com/noir-lang/poseidon" }
+poseidon = { git = "https://github.com/noir-lang/poseidon", tag = "v0.1.1" }


### PR DESCRIPTION
This PR updates the bignum/bigcurve versions in use.

I've benchmarked the differences in compilation/execution time in https://github.com/noir-lang/noir/pull/10508/ which shows a significant drop in compilation time + moderate execution time drop.

cc @LeilaWang 