### PR TITLE
chore: avoid fn capturing &mut PrivateContext

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/note/note_emission.nr
+++ b/noir-projects/aztec-nr/aztec/src/note/note_emission.nr
@@ -63,10 +63,12 @@ where
         // TODO(#14565): Add constrained tagging
         let _constrained_tagging = delivery_mode == MessageDelivery.CONSTRAINED_ONCHAIN;
 
+        let content_note = self.content.note;
+        let content_storage_slot = self.content.storage_slot;
         let ciphertext = remove_constraints_if(
             !constrained_encryption,
             || AES128::encrypt(
-                private_note_to_message_plaintext(self.content.note, self.content.storage_slot),
+                private_note_to_message_plaintext(content_note, content_storage_slot),
                 recipient,
             ),
         );


### PR DESCRIPTION
The lambda given to `remove_constraints_if` accesses `self`, which is a `NoteEmission` that has a `&mut PrivateContext` field. Then this mutable reference is being passed from constrained to unconstrained. There's no error because in the end the context isn't used by the lambda, but the compiler might eventually detect this and give an error here. So, this PR just fixes this in anticipation of future compiler changes.