### PR TITLE
fix: the path for the smart contract packages in the docs was wrong within the monorepo

### DIFF
--- a/docs/docs/developers/docs/aztec-nr/framework-description/how_to_implement_custom_notes.md
+++ b/docs/docs/developers/docs/aztec-nr/framework-description/how_to_implement_custom_notes.md
@@ -30,7 +30,7 @@ Aztec.nr provides pre-built note types for common use cases:
 
 ```toml
 # In Nargo.toml
-value_note = { git="https://github.com/AztecProtocol/aztec-packages/", tag="#include_aztec_version", directory="noir-projects/smart-contracts/value-note" }
+value_note = { git="https://github.com/AztecProtocol/aztec-packages/", tag="#include_aztec_version", directory="noir-projects/aztec-nr/value-note" }
 ```
 
 ```rust
@@ -42,7 +42,7 @@ let note = ValueNote::new(100, owner);
 
 ```toml
 # In Nargo.toml
-address_note = { git="https://github.com/AztecProtocol/aztec-packages/", tag="#include_aztec_version", directory="noir-projects/smart-contracts/address-note" }
+address_note = { git="https://github.com/AztecProtocol/aztec-packages/", tag="#include_aztec_version", directory="noir-projects/aztec-nr/address-note" }
 ```
 
 ```rust

--- a/docs/docs/developers/docs/aztec-nr/framework-description/how_to_use_authwit.md
+++ b/docs/docs/developers/docs/aztec-nr/framework-description/how_to_use_authwit.md
@@ -21,7 +21,7 @@ Add the `authwit` library to your `Nargo.toml` file:
 
 ```toml
 [dependencies]
-aztec = { git="https://github.com/AztecProtocol/aztec-packages/", tag="#include_aztec_version", directory="noir-projects/smart-contracts/aztec" }
+aztec = { git="https://github.com/AztecProtocol/aztec-packages/", tag="#include_aztec_version", directory="noir-projects/aztec-nr/aztec" }
 ```
 
 Import the authwit library in your contract:

--- a/docs/docs/developers/docs/aztec-nr/index.md
+++ b/docs/docs/developers/docs/aztec-nr/index.md
@@ -25,7 +25,7 @@ help you write Noir programs to deploy on the Aztec network.
 ```toml
 # Nargo.toml
 [dependencies]
-aztec = { git="https://github.com/AztecProtocol/aztec-packages/", tag="#include_aztec_version", directory="noir-projects/smart-contracts/aztec" }
+aztec = { git="https://github.com/AztecProtocol/aztec-packages/", tag="#include_aztec_version", directory="noir-projects/aztec-nr/aztec" }
 ```
 
 Update your `main.nr` contract file to use the Aztec.nr macros for writing contracts.

--- a/docs/versioned_docs/version-v3.0.0-devnet.5/developers/docs/guides/smart_contracts/how_to_implement_custom_notes.md
+++ b/docs/versioned_docs/version-v3.0.0-devnet.5/developers/docs/guides/smart_contracts/how_to_implement_custom_notes.md
@@ -31,7 +31,7 @@ Aztec.nr provides pre-built note types for common use cases:
 
 ```toml
 # In Nargo.toml
-value_note = { git="https://github.com/AztecProtocol/aztec-packages/", tag="v3.0.0-devnet.5", directory="noir-projects/smart-contracts/value-note" }
+value_note = { git="https://github.com/AztecProtocol/aztec-packages/", tag="v3.0.0-devnet.5", directory="noir-projects/aztec-nr/value-note" }
 ```
 
 ```rust
@@ -43,7 +43,7 @@ let note = ValueNote::new(100, owner);
 
 ```toml
 # In Nargo.toml
-address_note = { git="https://github.com/AztecProtocol/aztec-packages/", tag="v3.0.0-devnet.5", directory="noir-projects/smart-contracts/address-note" }
+address_note = { git="https://github.com/AztecProtocol/aztec-packages/", tag="v3.0.0-devnet.5", directory="noir-projects/aztec-nr/address-note" }
 ```
 
 ```rust

--- a/docs/versioned_docs/version-v3.0.0-devnet.5/developers/docs/guides/smart_contracts/how_to_use_authwit.md
+++ b/docs/versioned_docs/version-v3.0.0-devnet.5/developers/docs/guides/smart_contracts/how_to_use_authwit.md
@@ -21,7 +21,7 @@ Add the `authwit` library to your `Nargo.toml` file:
 
 ```toml
 [dependencies]
-aztec = { git="https://github.com/AztecProtocol/aztec-packages/", tag="v3.0.0-devnet.5", directory="noir-projects/smart-contracts/aztec" }
+aztec = { git="https://github.com/AztecProtocol/aztec-packages/", tag="v3.0.0-devnet.5", directory="noir-projects/aztec-nr/aztec" }
 ```
 
 Import the authwit library in your contract:

--- a/docs/versioned_docs/version-v3.0.0-devnet.5/developers/docs/guides/smart_contracts/index.md
+++ b/docs/versioned_docs/version-v3.0.0-devnet.5/developers/docs/guides/smart_contracts/index.md
@@ -25,7 +25,7 @@ help you write Noir programs to deploy on the Aztec network.
 ```toml
 # Nargo.toml
 [dependencies]
-aztec = { git="https://github.com/AztecProtocol/aztec-packages/", tag="v3.0.0-devnet.5", directory="noir-projects/smart-contracts/aztec" }
+aztec = { git="https://github.com/AztecProtocol/aztec-packages/", tag="v3.0.0-devnet.5", directory="noir-projects/aztec-nr/aztec" }
 ```
 
 Update your `main.nr` contract file to use the Aztec.nr macros for writing contracts.

--- a/docs/versioned_docs/version-v3.0.0-nightly.20251114/developers/docs/aztec-nr/framework-description/how_to_implement_custom_notes.md
+++ b/docs/versioned_docs/version-v3.0.0-nightly.20251114/developers/docs/aztec-nr/framework-description/how_to_implement_custom_notes.md
@@ -30,7 +30,7 @@ Aztec.nr provides pre-built note types for common use cases:
 
 ```toml
 # In Nargo.toml
-value_note = { git="https://github.com/AztecProtocol/aztec-packages/", tag="v3.0.0-nightly.20251114", directory="noir-projects/smart-contracts/value-note" }
+value_note = { git="https://github.com/AztecProtocol/aztec-packages/", tag="v3.0.0-nightly.20251114", directory="noir-projects/aztec-nr/value-note" }
 ```
 
 ```rust
@@ -42,7 +42,7 @@ let note = ValueNote::new(100, owner);
 
 ```toml
 # In Nargo.toml
-address_note = { git="https://github.com/AztecProtocol/aztec-packages/", tag="v3.0.0-nightly.20251114", directory="noir-projects/smart-contracts/address-note" }
+address_note = { git="https://github.com/AztecProtocol/aztec-packages/", tag="v3.0.0-nightly.20251114", directory="noir-projects/aztec-nr/address-note" }
 ```
 
 ```rust

--- a/docs/versioned_docs/version-v3.0.0-nightly.20251114/developers/docs/aztec-nr/framework-description/how_to_use_authwit.md
+++ b/docs/versioned_docs/version-v3.0.0-nightly.20251114/developers/docs/aztec-nr/framework-description/how_to_use_authwit.md
@@ -21,7 +21,7 @@ Add the `authwit` library to your `Nargo.toml` file:
 
 ```toml
 [dependencies]
-aztec = { git="https://github.com/AztecProtocol/aztec-packages/", tag="v3.0.0-nightly.20251114", directory="noir-projects/smart-contracts/aztec" }
+aztec = { git="https://github.com/AztecProtocol/aztec-packages/", tag="v3.0.0-nightly.20251114", directory="noir-projects/aztec-nr/aztec" }
 ```
 
 Import the authwit library in your contract:

--- a/docs/versioned_docs/version-v3.0.0-nightly.20251114/developers/docs/aztec-nr/index.md
+++ b/docs/versioned_docs/version-v3.0.0-nightly.20251114/developers/docs/aztec-nr/index.md
@@ -25,12 +25,12 @@ help you write Noir programs to deploy on the Aztec network.
 ```toml
 # Nargo.toml
 [dependencies]
-aztec = { git="https://github.com/AztecProtocol/aztec-packages/", tag="v3.0.0-nightly.20251114", directory="noir-projects/smart-contracts/aztec" }
+aztec = { git="https://github.com/AztecProtocol/aztec-packages/", tag="v3.0.0-nightly.20251114", directory="noir-projects/aztec-nr/aztec" }
 ```
 
 Update your `main.nr` contract file to use the Aztec.nr macros for writing contracts.
 
-```rust title="setup" showLineNumbers 
+```rust title="setup" showLineNumbers
 use dep::aztec::macros::aztec;
 
 #[aztec]
@@ -41,7 +41,7 @@ pub contract Counter {
 
 and import dependencies from the Aztec.nr library.
 
-```rust title="imports" showLineNumbers 
+```rust title="imports" showLineNumbers
 use aztec::{
     macros::{functions::{external, initializer}, storage::storage},
     oracle::debug_log::debug_log_format, protocol_types::{address::AztecAddress, traits::ToField},


### PR DESCRIPTION
In the docs, the path for importing packages form the aztec-packages monorepo was /noir-projects/smart-contracts, which doesn't exist. The updated path is noir-projects/aztec-nr
