### PR TITLE
fix(cli): bls account index behaviour 

### DIFF
--- a/yarn-project/cli/src/cmds/validator_keys/shared.ts
+++ b/yarn-project/cli/src/cmds/validator_keys/shared.ts
@@ -30,10 +30,11 @@ export type BuildValidatorsInput = {
   fundingAccount?: EthAddress;
 };
 
-export function withValidatorIndex(path: string, index: number) {
+export function withValidatorIndex(path: string, accountIndex: number = 0, addressIndex: number = 0) {
   const parts = path.split('/');
-  if (parts.length >= 4 && parts[0] === 'm' && parts[1] === '12381' && parts[2] === '3600') {
-    parts[3] = String(index);
+  if (parts.length == 6 && parts[0] === 'm' && parts[1] === '12381' && parts[2] === '3600') {
+    parts[3] = String(accountIndex);
+    parts[5] = String(addressIndex);
     return parts.join('/');
   }
   return path;
@@ -83,7 +84,7 @@ export async function buildValidatorEntries(input: BuildValidatorsInput) {
     Array.from({ length: validatorCount }, async (_unused, i) => {
       const addressIndex = baseAddressIndex + i;
       const basePath = blsPath ?? defaultBlsPath;
-      const perValidatorPath = withValidatorIndex(basePath, addressIndex);
+      const perValidatorPath = withValidatorIndex(basePath, accountIndex, addressIndex);
 
       const blsPrivKey = blsOnly || ikm || mnemonic ? deriveBlsPrivateKey(mnemonic, ikm, perValidatorPath) : undefined;
       const blsPubCompressed = blsPrivKey ? await computeBlsPublicKeyCompressed(blsPrivKey) : undefined;


### PR DESCRIPTION
## Overview

Generating bls keys was only taking into account address-index, however it should take into account both address and account index when generating keypaths