### PR TITLE
fix: Handle revert errors from Nethermind nodes

### DIFF
--- a/yarn-project/archiver/package.json
+++ b/yarn-project/archiver/package.json
@@ -82,7 +82,7 @@
     "lodash.omit": "^4.5.0",
     "tsc-watch": "^6.0.0",
     "tslib": "^2.5.0",
-    "viem": "npm:@spalladino/viem@2.38.2-eip7594.0"
+    "viem": "npm:@spalladino/viem@2.38.2-eip7594.1"
   },
   "devDependencies": {
     "@jest/globals": "^30.0.0",

--- a/yarn-project/aztec-faucet/package.json
+++ b/yarn-project/aztec-faucet/package.json
@@ -70,7 +70,7 @@
     "koa": "^2.16.1",
     "koa-bodyparser": "^4.4.1",
     "koa-router": "^13.1.1",
-    "viem": "npm:@spalladino/viem@2.38.2-eip7594.0",
+    "viem": "npm:@spalladino/viem@2.38.2-eip7594.1",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/yarn-project/aztec-node/package.json
+++ b/yarn-project/aztec-node/package.json
@@ -92,7 +92,7 @@
     "koa": "^2.16.1",
     "koa-router": "^13.1.1",
     "tslib": "^2.4.0",
-    "viem": "npm:@spalladino/viem@2.38.2-eip7594.0"
+    "viem": "npm:@spalladino/viem@2.38.2-eip7594.1"
   },
   "devDependencies": {
     "@jest/globals": "^30.0.0",

--- a/yarn-project/aztec.js/package.json
+++ b/yarn-project/aztec.js/package.json
@@ -90,7 +90,7 @@
     "@aztec/stdlib": "workspace:^",
     "axios": "^1.12.0",
     "tslib": "^2.4.0",
-    "viem": "npm:@spalladino/viem@2.38.2-eip7594.0"
+    "viem": "npm:@spalladino/viem@2.38.2-eip7594.1"
   },
   "devDependencies": {
     "@jest/globals": "^30.0.0",

--- a/yarn-project/aztec/package.json
+++ b/yarn-project/aztec/package.json
@@ -65,7 +65,7 @@
     "commander": "^12.1.0",
     "koa": "^2.16.1",
     "koa-router": "^13.1.1",
-    "viem": "npm:@spalladino/viem@2.38.2-eip7594.0"
+    "viem": "npm:@spalladino/viem@2.38.2-eip7594.1"
   },
   "files": [
     "dest",

--- a/yarn-project/bb-prover/package.json
+++ b/yarn-project/bb-prover/package.json
@@ -99,7 +99,7 @@
     "jest-mock-extended": "^4.0.0",
     "ts-node": "^10.9.1",
     "typescript": "^5.3.3",
-    "viem": "npm:@spalladino/viem@2.38.2-eip7594.0"
+    "viem": "npm:@spalladino/viem@2.38.2-eip7594.1"
   },
   "files": [
     "dest",

--- a/yarn-project/blob-sink/package.json
+++ b/yarn-project/blob-sink/package.json
@@ -68,7 +68,7 @@
     "snappy": "^7.2.2",
     "source-map-support": "^0.5.21",
     "tslib": "^2.4.0",
-    "viem": "npm:@spalladino/viem@2.38.2-eip7594.0",
+    "viem": "npm:@spalladino/viem@2.38.2-eip7594.1",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/yarn-project/cli/package.json
+++ b/yarn-project/cli/package.json
@@ -93,7 +93,7 @@
     "semver": "^7.5.4",
     "source-map-support": "^0.5.21",
     "tslib": "^2.4.0",
-    "viem": "npm:@spalladino/viem@2.38.2-eip7594.0"
+    "viem": "npm:@spalladino/viem@2.38.2-eip7594.1"
   },
   "devDependencies": {
     "@aztec/accounts": "workspace:^",

--- a/yarn-project/end-to-end/package.json
+++ b/yarn-project/end-to-end/package.json
@@ -96,7 +96,7 @@
     "tslib": "^2.4.0",
     "typescript": "^5.3.3",
     "util": "^0.12.5",
-    "viem": "npm:@spalladino/viem@2.38.2-eip7594.0",
+    "viem": "npm:@spalladino/viem@2.38.2-eip7594.1",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/yarn-project/epoch-cache/package.json
+++ b/yarn-project/epoch-cache/package.json
@@ -35,7 +35,7 @@
     "get-port": "^7.1.0",
     "jest-mock-extended": "^4.0.0",
     "tslib": "^2.4.0",
-    "viem": "npm:@spalladino/viem@2.38.2-eip7594.0",
+    "viem": "npm:@spalladino/viem@2.38.2-eip7594.1",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/yarn-project/ethereum/package.json
+++ b/yarn-project/ethereum/package.json
@@ -40,7 +40,7 @@
     "lodash.chunk": "^4.2.0",
     "lodash.pickby": "^4.5.0",
     "tslib": "^2.4.0",
-    "viem": "npm:@spalladino/viem@2.38.2-eip7594.0",
+    "viem": "npm:@spalladino/viem@2.38.2-eip7594.1",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/yarn-project/foundation/package.json
+++ b/yarn-project/foundation/package.json
@@ -156,7 +156,7 @@
     "ts-node": "^10.9.1",
     "typescript": "^5.3.3",
     "typescript-eslint": "^8.32.1",
-    "viem": "npm:@spalladino/viem@2.38.2-eip7594.0"
+    "viem": "npm:@spalladino/viem@2.38.2-eip7594.1"
   },
   "files": [
     "dest",

--- a/yarn-project/node-keystore/package.json
+++ b/yarn-project/node-keystore/package.json
@@ -67,7 +67,7 @@
     "@aztec/stdlib": "workspace:^",
     "@ethersproject/wallet": "^5.7.0",
     "tslib": "^2.4.0",
-    "viem": "npm:@spalladino/viem@2.38.2-eip7594.0",
+    "viem": "npm:@spalladino/viem@2.38.2-eip7594.1",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/yarn-project/p2p/package.json
+++ b/yarn-project/p2p/package.json
@@ -117,7 +117,7 @@
     "ts-node": "^10.9.1",
     "typescript": "^5.3.3",
     "uint8arrays": "^5.0.3",
-    "viem": "npm:@spalladino/viem@2.38.2-eip7594.0"
+    "viem": "npm:@spalladino/viem@2.38.2-eip7594.1"
   },
   "files": [
     "dest",

--- a/yarn-project/prover-node/package.json
+++ b/yarn-project/prover-node/package.json
@@ -79,7 +79,7 @@
     "@aztec/world-state": "workspace:^",
     "source-map-support": "^0.5.21",
     "tslib": "^2.4.0",
-    "viem": "npm:@spalladino/viem@2.38.2-eip7594.0"
+    "viem": "npm:@spalladino/viem@2.38.2-eip7594.1"
   },
   "devDependencies": {
     "@jest/globals": "^30.0.0",

--- a/yarn-project/pxe/package.json
+++ b/yarn-project/pxe/package.json
@@ -82,7 +82,7 @@
     "lodash.omit": "^4.5.0",
     "sha3": "^2.1.4",
     "tslib": "^2.4.0",
-    "viem": "npm:@spalladino/viem@2.38.2-eip7594.0"
+    "viem": "npm:@spalladino/viem@2.38.2-eip7594.1"
   },
   "devDependencies": {
     "@aztec/merkle-tree": "workspace:^",

--- a/yarn-project/sequencer-client/package.json
+++ b/yarn-project/sequencer-client/package.json
@@ -52,7 +52,7 @@
     "@aztec/world-state": "workspace:^",
     "lodash.chunk": "^4.2.0",
     "tslib": "^2.4.0",
-    "viem": "npm:@spalladino/viem@2.38.2-eip7594.0"
+    "viem": "npm:@spalladino/viem@2.38.2-eip7594.1"
   },
   "devDependencies": {
     "@aztec/archiver": "workspace:^",

--- a/yarn-project/simulator/package.json
+++ b/yarn-project/simulator/package.json
@@ -91,7 +91,7 @@
     "jest-mock-extended": "^4.0.0",
     "ts-node": "^10.9.1",
     "typescript": "^5.3.3",
-    "viem": "npm:@spalladino/viem@2.38.2-eip7594.0"
+    "viem": "npm:@spalladino/viem@2.38.2-eip7594.1"
   },
   "files": [
     "dest",

--- a/yarn-project/slasher/package.json
+++ b/yarn-project/slasher/package.json
@@ -63,7 +63,7 @@
     "@aztec/telemetry-client": "workspace:^",
     "source-map-support": "^0.5.21",
     "tslib": "^2.4.0",
-    "viem": "npm:@spalladino/viem@2.38.2-eip7594.0",
+    "viem": "npm:@spalladino/viem@2.38.2-eip7594.1",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/yarn-project/stdlib/package.json
+++ b/yarn-project/stdlib/package.json
@@ -87,7 +87,7 @@
     "msgpackr": "^1.11.2",
     "pako": "^2.1.0",
     "tslib": "^2.4.0",
-    "viem": "npm:@spalladino/viem@2.38.2-eip7594.0",
+    "viem": "npm:@spalladino/viem@2.38.2-eip7594.1",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/yarn-project/telemetry-client/package.json
+++ b/yarn-project/telemetry-client/package.json
@@ -42,7 +42,7 @@
     "@opentelemetry/sdk-trace-node": "^1.28.0",
     "@opentelemetry/semantic-conventions": "^1.28.0",
     "prom-client": "^15.1.3",
-    "viem": "npm:@spalladino/viem@2.38.2-eip7594.0"
+    "viem": "npm:@spalladino/viem@2.38.2-eip7594.1"
   },
   "devDependencies": {
     "@jest/globals": "^30.0.0",

--- a/yarn-project/validator-client/package.json
+++ b/yarn-project/validator-client/package.json
@@ -77,7 +77,7 @@
     "koa": "^2.16.1",
     "koa-router": "^13.1.1",
     "tslib": "^2.4.0",
-    "viem": "npm:@spalladino/viem@2.38.2-eip7594.0"
+    "viem": "npm:@spalladino/viem@2.38.2-eip7594.1"
   },
   "devDependencies": {
     "@jest/globals": "^30.0.0",

--- a/yarn-project/yarn.lock
+++ b/yarn-project/yarn.lock
@@ -765,7 +765,7 @@ __metadata:
     tsc-watch: "npm:^6.0.0"
     tslib: "npm:^2.5.0"
     typescript: "npm:^5.3.3"
-    viem: "npm:@spalladino/viem@2.38.2-eip7594.0"
+    viem: "npm:@spalladino/viem@2.38.2-eip7594.1"
   languageName: unknown
   linkType: soft
 
@@ -787,7 +787,7 @@ __metadata:
     koa-router: "npm:^13.1.1"
     ts-node: "npm:^10.9.1"
     typescript: "npm:^5.3.3"
-    viem: "npm:@spalladino/viem@2.38.2-eip7594.0"
+    viem: "npm:@spalladino/viem@2.38.2-eip7594.1"
     zod: "npm:^3.23.8"
   bin:
     aztec-faucet: ./dest/bin/index.js
@@ -831,7 +831,7 @@ __metadata:
     ts-node: "npm:^10.9.1"
     tslib: "npm:^2.4.0"
     typescript: "npm:^5.3.3"
-    viem: "npm:@spalladino/viem@2.38.2-eip7594.0"
+    viem: "npm:@spalladino/viem@2.38.2-eip7594.1"
   bin:
     aztec-node: ./dest/bin/index.js
   languageName: unknown
@@ -864,7 +864,7 @@ __metadata:
     tslib: "npm:^2.4.0"
     typescript: "npm:^5.3.3"
     util: "npm:^0.12.5"
-    viem: "npm:@spalladino/viem@2.38.2-eip7594.0"
+    viem: "npm:@spalladino/viem@2.38.2-eip7594.1"
   languageName: unknown
   linkType: soft
 
@@ -934,7 +934,7 @@ __metadata:
     koa-router: "npm:^13.1.1"
     ts-node: "npm:^10.9.1"
     typescript: "npm:^5.3.3"
-    viem: "npm:@spalladino/viem@2.38.2-eip7594.0"
+    viem: "npm:@spalladino/viem@2.38.2-eip7594.1"
   bin:
     aztec: ./dest/bin/index.js
   languageName: unknown
@@ -971,7 +971,7 @@ __metadata:
     ts-node: "npm:^10.9.1"
     tslib: "npm:^2.4.0"
     typescript: "npm:^5.3.3"
-    viem: "npm:@spalladino/viem@2.38.2-eip7594.0"
+    viem: "npm:@spalladino/viem@2.38.2-eip7594.1"
   bin:
     bb-cli: ./dest/bb/index.js
   languageName: unknown
@@ -1035,7 +1035,7 @@ __metadata:
     ts-node: "npm:^10.9.1"
     tslib: "npm:^2.4.0"
     typescript: "npm:^5.3.3"
-    viem: "npm:@spalladino/viem@2.38.2-eip7594.0"
+    viem: "npm:@spalladino/viem@2.38.2-eip7594.1"
     zod: "npm:^3.23.8"
   bin:
     blob-sink-client: ./dest/client/bin/index.js
@@ -1165,7 +1165,7 @@ __metadata:
     ts-node: "npm:^10.9.1"
     tslib: "npm:^2.4.0"
     typescript: "npm:^5.3.3"
-    viem: "npm:@spalladino/viem@2.38.2-eip7594.0"
+    viem: "npm:@spalladino/viem@2.38.2-eip7594.1"
   peerDependencies:
     "@aztec/accounts": "workspace:^"
     "@aztec/bb-prover": "workspace:^"
@@ -1283,7 +1283,7 @@ __metadata:
     tslib: "npm:^2.4.0"
     typescript: "npm:^5.3.3"
     util: "npm:^0.12.5"
-    viem: "npm:@spalladino/viem@2.38.2-eip7594.0"
+    viem: "npm:@spalladino/viem@2.38.2-eip7594.1"
     zod: "npm:^3.23.8"
   languageName: unknown
   linkType: soft
@@ -1324,7 +1324,7 @@ __metadata:
     ts-node: "npm:^10.9.1"
     tslib: "npm:^2.4.0"
     typescript: "npm:^5.3.3"
-    viem: "npm:@spalladino/viem@2.38.2-eip7594.0"
+    viem: "npm:@spalladino/viem@2.38.2-eip7594.1"
     zod: "npm:^3.23.8"
   languageName: unknown
   linkType: soft
@@ -1353,7 +1353,7 @@ __metadata:
     ts-node: "npm:^10.9.1"
     tslib: "npm:^2.4.0"
     typescript: "npm:^5.3.3"
-    viem: "npm:@spalladino/viem@2.38.2-eip7594.0"
+    viem: "npm:@spalladino/viem@2.38.2-eip7594.1"
     zod: "npm:^3.23.8"
   languageName: unknown
   linkType: soft
@@ -1412,7 +1412,7 @@ __metadata:
     typescript: "npm:^5.3.3"
     typescript-eslint: "npm:^8.32.1"
     undici: "npm:^5.28.5"
-    viem: "npm:@spalladino/viem@2.38.2-eip7594.0"
+    viem: "npm:@spalladino/viem@2.38.2-eip7594.1"
     zod: "npm:^3.23.8"
   languageName: unknown
   linkType: soft
@@ -1577,7 +1577,7 @@ __metadata:
     ts-node: "npm:^10.9.1"
     tslib: "npm:^2.4.0"
     typescript: "npm:^5.3.3"
-    viem: "npm:@spalladino/viem@2.38.2-eip7594.0"
+    viem: "npm:@spalladino/viem@2.38.2-eip7594.1"
     zod: "npm:^3.23.8"
   languageName: unknown
   linkType: soft
@@ -1790,7 +1790,7 @@ __metadata:
     tslib: "npm:^2.4.0"
     typescript: "npm:^5.3.3"
     uint8arrays: "npm:^5.0.3"
-    viem: "npm:@spalladino/viem@2.38.2-eip7594.0"
+    viem: "npm:@spalladino/viem@2.38.2-eip7594.1"
     xxhash-wasm: "npm:^1.1.0"
   languageName: unknown
   linkType: soft
@@ -1890,7 +1890,7 @@ __metadata:
     ts-node: "npm:^10.9.1"
     tslib: "npm:^2.4.0"
     typescript: "npm:^5.3.3"
-    viem: "npm:@spalladino/viem@2.38.2-eip7594.0"
+    viem: "npm:@spalladino/viem@2.38.2-eip7594.1"
   languageName: unknown
   linkType: soft
 
@@ -1929,7 +1929,7 @@ __metadata:
     ts-node: "npm:^10.9.1"
     tslib: "npm:^2.4.0"
     typescript: "npm:^5.3.3"
-    viem: "npm:@spalladino/viem@2.38.2-eip7594.0"
+    viem: "npm:@spalladino/viem@2.38.2-eip7594.1"
   bin:
     pxe: ./dest/bin/index.js
   languageName: unknown
@@ -2000,7 +2000,7 @@ __metadata:
     ts-node: "npm:^10.9.1"
     tslib: "npm:^2.4.0"
     typescript: "npm:^5.3.3"
-    viem: "npm:@spalladino/viem@2.38.2-eip7594.0"
+    viem: "npm:@spalladino/viem@2.38.2-eip7594.1"
   languageName: unknown
   linkType: soft
 
@@ -2034,7 +2034,7 @@ __metadata:
     ts-node: "npm:^10.9.1"
     tslib: "npm:^2.4.0"
     typescript: "npm:^5.3.3"
-    viem: "npm:@spalladino/viem@2.38.2-eip7594.0"
+    viem: "npm:@spalladino/viem@2.38.2-eip7594.1"
   languageName: unknown
   linkType: soft
 
@@ -2060,7 +2060,7 @@ __metadata:
     ts-node: "npm:^10.9.1"
     tslib: "npm:^2.4.0"
     typescript: "npm:^5.3.3"
-    viem: "npm:@spalladino/viem@2.38.2-eip7594.0"
+    viem: "npm:@spalladino/viem@2.38.2-eip7594.1"
     zod: "npm:^3.23.8"
   languageName: unknown
   linkType: soft
@@ -2103,7 +2103,7 @@ __metadata:
     ts-node: "npm:^10.9.1"
     tslib: "npm:^2.4.0"
     typescript: "npm:^5.3.3"
-    viem: "npm:@spalladino/viem@2.38.2-eip7594.0"
+    viem: "npm:@spalladino/viem@2.38.2-eip7594.1"
     zod: "npm:^3.23.8"
   languageName: unknown
   linkType: soft
@@ -2135,7 +2135,7 @@ __metadata:
     prom-client: "npm:^15.1.3"
     ts-node: "npm:^10.9.1"
     typescript: "npm:^5.3.3"
-    viem: "npm:@spalladino/viem@2.38.2-eip7594.0"
+    viem: "npm:@spalladino/viem@2.38.2-eip7594.1"
   languageName: unknown
   linkType: soft
 
@@ -2194,7 +2194,7 @@ __metadata:
     ts-node: "npm:^10.9.1"
     tslib: "npm:^2.4.0"
     typescript: "npm:^5.3.3"
-    viem: "npm:@spalladino/viem@2.38.2-eip7594.0"
+    viem: "npm:@spalladino/viem@2.38.2-eip7594.1"
   bin:
     validator-client: ./dest/bin/index.js
   languageName: unknown
@@ -22201,9 +22201,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"viem@npm:@spalladino/viem@2.38.2-eip7594.0":
-  version: 2.38.2-eip7594.0
-  resolution: "@spalladino/viem@npm:2.38.2-eip7594.0"
+"viem@npm:@spalladino/viem@2.38.2-eip7594.1":
+  version: 2.38.2-eip7594.1
+  resolution: "@spalladino/viem@npm:2.38.2-eip7594.1"
   dependencies:
     "@noble/curves": "npm:1.9.1"
     "@noble/hashes": "npm:1.8.0"
@@ -22218,7 +22218,7 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 10/ba922b7f02536d3aa86b0cafe4051f4decaec510894a0f133e0d92488f6edeff4f45c6fe84540719a95d4e988f67227acc2eb0349031e1a20ebbf8506e0574b2
+  checksum: 10/d5850b364cf0fb819c7cfd121f5770d53197b5e1f250bd3d818c6276f815e8ab00dca3e116bf49d5289069df3de35273e82613d6117ab0429a52d15a343b69f7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Updates viem to include [this commit](https://github.com/spalladino/viem/commit/211c19497ad2af93767bcb7382cb1c092010fbf4).

This fixes viem so it can handle revert errors from Nethermind nodes. See also https://github.com/wevm/viem/pull/4092.

This was causing validator clients to crash during startup, since it queries the committee via the epoch cache, but if there was no committee due to not enough validators staked, then the node would not recognise that revert reason and fail on startup:

```
ERROR: cli Error in command execution
ERROR: cli ContractFunctionExecutionError: Execution reverted for an unknown reason.

Raw Call Arguments:
  to:    0x603bb2c05d474794ea97805e8de69bccfb3bca12
  data:  0x1cfe2878000000000000000000000000000000000000000000000000000000006917a96b

Contract Call:
  address:   0x603bb2c05d474794ea97805e8de69bccfb3bca12
  function:  getCommitteeAt(uint256 _ts)
  args:                    (1763158379)

Docs: https://viem.sh/docs/contract/simulateContract
Details: execution reverted
Version: viem@2.38.2
ContractFunctionExecutionError: Execution reverted for an unknown reason.

Raw Call Arguments:
  to:    0x603bb2c05d474794ea97805e8de69bccfb3bca12
  data:  0x1cfe2878000000000000000000000000000000000000000000000000000000006917a96b

Contract Call:
  address:   0x603bb2c05d474794ea97805e8de69bccfb3bca12
  function:  getCommitteeAt(uint256 _ts)
  args:                    (1763158379)

Docs: https://viem.sh/docs/contract/simulateContract
Details: execution reverted
Version: viem@2.38.2
    at getContractError (file:///usr/src/yarn-project/node_modules/viem/_esm/utils/errors/getContractError.js:30:12)
    at simulateContract (file:///usr/src/yarn-project/node_modules/viem/_esm/actions/public/simulateContract.js:73:15)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async RollupContract.getCommitteeAt (file:///usr/src/yarn-project/ethereum/dest/contracts/rollup.js:223:28)
    at async Promise.all (index 0)
    at async EpochCache.computeCommittee (file:///usr/src/yarn-project/epoch-cache/dest/epoch_cache.js:150:51)
    at async EpochCache.getCommittee (file:///usr/src/yarn-project/epoch-cache/dest/epoch_cache.js:126:27)
    at async EpochCache.filterInCommittee (file:///usr/src/yarn-project/epoch-cache/dest/epoch_cache.js:260:31)
    at async ValidatorClient.start (file:///usr/src/yarn-project/validator-client/dest/validator.js:136:29)
    at async SequencerClient.start (file:///usr/src/yarn-project/sequencer-client/dest/client/sequencer-client.js:110:9)
node:internal/process/promises:394
    triggerUncaughtException(err, true /* fromPromise */);
... (646 lines left)
```

See [here](https://github.com/AztecProtocol/aztec-packages/blob/3d9dccdae863a72c0c4ba91019e504d778f21e3c/yarn-project/ethereum/src/contracts/rollup.ts#L365-L370) for reference.
