### PR TITLE
feat(avm)!: returndata in C++ simulation

### DIFF
--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/tx_execution.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/tx_execution.cpp
@@ -162,8 +162,12 @@ TxExecutionResult TxExecution::simulate(const Tx& tx)
                 // This call should not throw unless it's an unexpected unrecoverable failure.
                 EnqueuedCallResult result = call_execution.execute(std::move(context));
                 tx_context.gas_used = result.gas_used;
-                app_logic_return_values.push_back(
-                    CallStackMetadata{ .calldata = call.calldata, .values = std::move(result.output) });
+
+                if (collect_call_metadata) {
+                    app_logic_return_values.push_back(
+                        CallStackMetadata{ .calldata = call.calldata, .values = std::move(result.output) });
+                }
+
                 emit_public_call_request(call,
                                          TransactionPhase::APP_LOGIC,
                                          /*transaction_fee=*/FF(0),

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/tx_execution.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/tx_execution.cpp
@@ -64,7 +64,11 @@ TxExecutionResult TxExecution::simulate(const Tx& tx)
     const Gas& gas_limit = tx.gas_settings.gas_limits;
     const Gas& teardown_gas_limit = tx.gas_settings.teardown_gas_limits;
     tx_context.gas_used = tx.gas_used_by_private;
-    std::optional<std::vector<FF>> app_logic_return_value;
+
+    // NOTE: This vector will be populated with one CallStackMetadata per app logic enqueued call.
+    // IMPORTANT: The nesting will only be 1 level deep! You will get one result per enqueued call
+    // but no information about nested calls. This can be added later.
+    std::vector<CallStackMetadata> app_logic_return_values;
 
     events.emit(TxStartupEvent{
         .state = tx_context.serialize_tx_context_event(),
@@ -158,7 +162,8 @@ TxExecutionResult TxExecution::simulate(const Tx& tx)
                 // This call should not throw unless it's an unexpected unrecoverable failure.
                 EnqueuedCallResult result = call_execution.execute(std::move(context));
                 tx_context.gas_used = result.gas_used;
-                app_logic_return_value = std::move(result.output);
+                app_logic_return_values.push_back(
+                    CallStackMetadata{ .calldata = call.calldata, .values = std::move(result.output) });
                 emit_public_call_request(call,
                                          TransactionPhase::APP_LOGIC,
                                          /*transaction_fee=*/FF(0),
@@ -199,9 +204,6 @@ TxExecutionResult TxExecution::simulate(const Tx& tx)
             emit_empty_phase(TransactionPhase::TEARDOWN);
         } else {
             const auto& teardown_enqueued_call = tx.teardown_enqueued_call.value();
-
-            std::string fn_name = get_debug_function_name(teardown_enqueued_call.request.contract_address,
-                                                          teardown_enqueued_call.calldata);
             vinfo("[TEARDOWN] Executing enqueued call to ",
                   teardown_enqueued_call.request.contract_address,
                   "::",
@@ -265,7 +267,7 @@ TxExecutionResult TxExecution::simulate(const Tx& tx)
             .billed_gas = { 0, 0 },
         },
         .revert_code = tx_context.revert_code,
-        .app_logic_return_value = std::move(app_logic_return_value),
+        .app_logic_return_values = std::move(app_logic_return_values),
     };
 }
 

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/tx_execution.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/tx_execution.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <optional>
 #include <string>
 #include <vector>
 
@@ -27,7 +26,7 @@ namespace bb::avm2::simulation {
 struct TxExecutionResult {
     GasUsed gas_used;
     RevertCode revert_code = RevertCode::OK;
-    std::optional<std::vector<FF>> app_logic_return_value;
+    std::vector<CallStackMetadata> app_logic_return_values;
 };
 
 // In charge of executing a transaction.

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/tx_execution.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/tx_execution.hpp
@@ -41,7 +41,8 @@ class TxExecution final {
                 SideEffectTrackerInterface& side_effect_tracker,
                 FieldGreaterThanInterface& field_gt,
                 Poseidon2Interface& poseidon2,
-                EventEmitterInterface<TxEvent>& event_emitter)
+                EventEmitterInterface<TxEvent>& event_emitter,
+                bool collect_call_metadata = false)
         : call_execution(call_execution)
         , context_provider(context_provider)
         , contract_db(contract_db)
@@ -54,6 +55,7 @@ class TxExecution final {
                      retrieved_bytecodes_tree,
                      context_provider,
                      side_effect_tracker)
+        , collect_call_metadata(collect_call_metadata)
     {}
 
     TxExecutionResult simulate(const Tx& tx);
@@ -70,6 +72,7 @@ class TxExecution final {
     EventEmitterInterface<TxEvent>& events;
 
     TxContext tx_context;
+    bool collect_call_metadata;
 
     // This function can throw if there is a nullifier collision.
     void insert_non_revertibles(const Tx& tx);

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation_helper.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation_helper.cpp
@@ -453,11 +453,11 @@ TxSimulationResult AvmSimulationHelper::simulate_fast(ContractDBInterface& raw_c
         // Simulation.
         .gas_used = tx_execution_result.gas_used,
         .revert_code = tx_execution_result.revert_code,
-        .app_logic_return_value = tx_execution_result.app_logic_return_value,
+        .app_logic_return_values = std::move(tx_execution_result.app_logic_return_values),
         .logs = debug_log_component->dump_logs(),
         // Proving request data.
         .public_inputs = public_inputs_builder.build(),
-        .hints = std::nullopt, // TODO: add execution hints, optionally.
+        .hints = std::nullopt, // NOTE: hints are injected by the caller.
     };
 }
 

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation_helper.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation_helper.cpp
@@ -433,7 +433,8 @@ TxSimulationResult AvmSimulationHelper::simulate_fast(ContractDBInterface& raw_c
                              side_effect_tracker,
                              field_gt,
                              poseidon2,
-                             tx_event_emitter);
+                             tx_event_emitter,
+                             config.collect_call_metadata);
 
     PublicInputsBuilder public_inputs_builder;
     public_inputs_builder.extract_inputs(tx, global_variables, protocol_contracts, config.prover_id, raw_merkle_db);

--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -1154,6 +1154,7 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, Traceable {
         skipFeeEnforcement,
         collectDebugLogs: true,
         collectHints: false,
+        collectCallMetadata: true,
         maxDebugLogMemoryReads: this.config.rpcSimulatePublicMaxDebugLogMemoryReads,
         collectStatistics: false,
       });

--- a/yarn-project/sequencer-client/src/sequencer/block_builder.ts
+++ b/yarn-project/sequencer-client/src/sequencer/block_builder.ts
@@ -132,6 +132,7 @@ export class FullNodeBlockBuilder implements IFullNodeBlockBuilder {
         collectHints: false,
         maxDebugLogMemoryReads: 0,
         collectStatistics: false,
+        collectCallMetadata: false,
       }),
     );
 

--- a/yarn-project/simulator/src/public/avm/fixtures/avm_simulation_tester.ts
+++ b/yarn-project/simulator/src/public/avm/fixtures/avm_simulation_tester.ts
@@ -86,6 +86,7 @@ export class AvmSimulationTester extends BaseAvmSimulationTester {
       collectDebugLogs: true,
       collectHints: false,
       collectStatistics: false,
+      collectCallMetadata: true,
     });
     const environment = initExecutionEnvironment({
       calldata,

--- a/yarn-project/simulator/src/public/fixtures/token_test.ts
+++ b/yarn-project/simulator/src/public/fixtures/token_test.ts
@@ -133,8 +133,7 @@ async function checkBalance(
   );
   expectToBeTrue(balResult.revertCode.isOK());
   // should be 1 call with 1 return value that is expectedBalance
-  expectToBeTrue(balResult.processedPhases?.length == 1);
-  expectToBeTrue(balResult.processedPhases![0].returnValues.length == 1);
-  expectToBeTrue(balResult.processedPhases![0].returnValues[0].values!.length == 1);
-  expectToBeTrue(balResult.processedPhases![0].returnValues[0].values![0].toBigInt() == expectedBalance);
+  expectToBeTrue(balResult.appLogicReturnValues.length == 1);
+  expectToBeTrue(balResult.appLogicReturnValues[0].values!.length == 1);
+  expectToBeTrue(balResult.appLogicReturnValues[0].values![0].toBigInt() == expectedBalance);
 }

--- a/yarn-project/simulator/src/public/public_tx_simulator/cpp_public_tx_simulator.ts
+++ b/yarn-project/simulator/src/public/public_tx_simulator/cpp_public_tx_simulator.ts
@@ -143,6 +143,8 @@ export class CppPublicTxSimulator extends PublicTxSimulator implements PublicTxS
     // TODO(fcarreiro): complete this.
     assert(cppResult.revertCode.equals(tsResult.revertCode));
     assert(cppResult.gasUsed.totalGas.equals(tsResult.gasUsed.totalGas));
+    // FIXME(https://github.com/AztecProtocol/aztec-packages/issues/18441): a few but not all keccaks fail!
+    // expect(cppResult.appLogicReturnValues).toEqual(tsResult.appLogicReturnValues);
 
     // Confirm that tree roots match
     const cppStateRef = await this.merkleTree.getStateReference();

--- a/yarn-project/simulator/src/public/public_tx_simulator/measured_public_tx_simulator.ts
+++ b/yarn-project/simulator/src/public/public_tx_simulator/measured_public_tx_simulator.ts
@@ -1,6 +1,6 @@
 import type { Fr } from '@aztec/foundation/fields';
 import { Timer } from '@aztec/foundation/timer';
-import type { ProcessedPhase, PublicSimulatorConfig, PublicTxResult } from '@aztec/stdlib/avm';
+import type { PublicSimulatorConfig, PublicTxResult } from '@aztec/stdlib/avm';
 import type { Gas } from '@aztec/stdlib/gas';
 import type { AvmSimulationStats } from '@aztec/stdlib/stats';
 import type { MerkleTreeWriteOperations } from '@aztec/stdlib/trees';
@@ -51,7 +51,7 @@ export class MeasuredPublicTxSimulator extends PublicTxSimulator implements Meas
     this.metrics.recordPrivateEffectsInsertion(timer.us(), 'revertible');
   }
 
-  protected override async simulatePhase(phase: TxExecutionPhase, context: PublicTxContext): Promise<ProcessedPhase> {
+  protected override async simulatePhase(phase: TxExecutionPhase, context: PublicTxContext) {
     const timer = new Timer();
     const result = await super.simulatePhase(phase, context);
     result.durationMs = timer.ms();

--- a/yarn-project/stdlib/src/avm/avm.ts
+++ b/yarn-project/stdlib/src/avm/avm.ts
@@ -27,7 +27,6 @@ import {
   PublicCallRequestWithCalldata,
   TreeSnapshots,
   type Tx,
-  TxExecutionPhase,
 } from '../tx/index.js';
 import { WorldStateRevision } from '../world-state/world_state_revision.js';
 import { AvmCircuitPublicInputs } from './avm_circuit_public_inputs.js';
@@ -1043,14 +1042,6 @@ export class AvmCircuitInputs {
   }
 }
 
-export type ProcessedPhase = {
-  phase: TxExecutionPhase;
-  durationMs?: number;
-  returnValues: NestedProcessReturnValues[];
-  reverted: boolean;
-  revertReason?: SimulationError;
-};
-
 export class PublicTxResult {
   constructor(
     // Simulation result.
@@ -1058,7 +1049,10 @@ export class PublicTxResult {
     public revertCode: RevertCode,
     public revertReason: SimulationError | undefined, // Revert reason, if any
     // These are only guaranteed to be present if the simulator is configured to collect them.
-    public processedPhases: ProcessedPhase[] | undefined,
+    // NOTE: This list will be populated with one NestedProcessReturnValues per app logic enqueued call.
+    // IMPORTANT: The nesting will only be 1 level deep! You will get one result per enqueued call
+    // but no information about nested calls. This can be added later.
+    public appLogicReturnValues: NestedProcessReturnValues[], // One per enqueued call.
     public logs: DebugLog[] | undefined,
     // For the proving request.
     public hints: AvmExecutionHints | undefined,
@@ -1075,7 +1069,7 @@ export class PublicTxResult {
       },
       RevertCode.OK,
       /*revertReason=*/ undefined,
-      /*processedPhases=*/ [],
+      /*appLogicReturnValues=*/ [],
       /*logs=*/ [],
       /*hints=*/ AvmExecutionHints.empty(),
       /*publicInputs=*/ AvmCircuitPublicInputs.empty(),
@@ -1088,20 +1082,19 @@ export class PublicTxResult {
         gasUsed: schemas.GasUsed,
         revertCode: RevertCode.schema,
         revertReason: NullishToUndefined(SimulationError.schema),
-        // TODO(fcarreiro): Use actual Phases type schema.
-        processedPhases: NullishToUndefined(z.any().array()),
+        appLogicReturnValues: NestedProcessReturnValues.schema.array(),
         logs: NullishToUndefined(DebugLog.schema.array()),
         // For the proving request.
         publicInputs: AvmCircuitPublicInputs.schema,
         hints: NullishToUndefined(AvmExecutionHints.schema),
       })
       .transform(
-        ({ gasUsed, revertCode, revertReason, processedPhases, logs, hints, publicInputs }) =>
+        ({ gasUsed, revertCode, revertReason, appLogicReturnValues, logs, hints, publicInputs }) =>
           new PublicTxResult(
             gasUsed,
             revertCode as RevertCode,
             revertReason,
-            processedPhases,
+            appLogicReturnValues,
             logs,
             hints,
             publicInputs,
@@ -1114,7 +1107,7 @@ export class PublicTxResult {
       GasUsed.fromPlainObject(obj.gasUsed),
       RevertCode.fromPlainObject(obj.revertCode),
       /*revertReason=*/ undefined, // TODO(fcarreiro/mwood): add.
-      /*processedPhases=*/ [], // TODO(fcarreiro/mwood): add.
+      /*appLogicReturnValues=*/ obj.appLogicReturnValues.map(NestedProcessReturnValues.fromPlainObject),
       obj.logs?.map(DebugLog.fromPlainObject),
       obj.hints ? AvmExecutionHints.fromPlainObject(obj.hints) : undefined,
       AvmCircuitPublicInputs.fromPlainObject(obj.publicInputs),
@@ -1126,7 +1119,7 @@ export class PublicSimulatorConfig {
   constructor(
     public readonly proverId: Fr,
     public readonly skipFeeEnforcement: boolean,
-    public readonly collectCallMetadata: boolean, // processedPhases.
+    public readonly collectCallMetadata: boolean, // appLogicReturnValues.
     public readonly collectHints: boolean, // hints.
     public readonly collectDebugLogs: boolean, // logs.
     public readonly maxDebugLogMemoryReads: number,

--- a/yarn-project/txe/src/oracle/txe_oracle_top_level_context.ts
+++ b/yarn-project/txe/src/oracle/txe_oracle_top_level_context.ts
@@ -379,6 +379,7 @@ export class TXEOracleTopLevelContext implements IMiscOracle, ITxeExecutionOracl
       collectDebugLogs: true,
       collectHints: false,
       collectStatistics: false,
+      collectCallMetadata: true,
     });
     const processor = new PublicProcessor(
       globals,
@@ -495,6 +496,7 @@ export class TXEOracleTopLevelContext implements IMiscOracle, ITxeExecutionOracl
       collectDebugLogs: true,
       collectHints: false,
       collectStatistics: false,
+      collectCallMetadata: true,
     });
     const simulator = new PublicTxSimulator(guardedMerkleTrees, contractsDB, globals, config);
     const processor = new PublicProcessor(globals, guardedMerkleTrees, contractsDB, simulator, new TestDateProvider());


### PR DESCRIPTION
This PR is the "quick" version of what I had in mind.

This PR collects the information needed to populate `NestedProcessReturnValues` from C++. Some design decisions and warnings
* I realized that in TS we only return only 1 level of the structure, that is, the results for enqueued calls, but not for external calls. So that's what I implemented.
* I left the C++ side slightly prepared for extension and even added `calldata` (which is not used in TS).
* The DOS attack vector is still there: to avoid it we should likely do this collection via a component that can be NOOPed. I might do it, time permitting, after we are feature complete. In the same way, if we want to add more data, we should avoid expanding return types and should probably do it via an injected component (similar to the SideEffectsTrace in TS).
* I slightly restricted PublicTxSimulator and PublicProcessor's interfaces (return types).

Keccak return values differ, we have to look into it: https://github.com/AztecProtocol/aztec-packages/issues/18441