### PR TITLE
fix: Bump failed viem install

### DIFF
--- a/yarn-project/archiver/package.json
+++ b/yarn-project/archiver/package.json
@@ -82,7 +82,7 @@
     "lodash.omit": "^4.5.0",
     "tsc-watch": "^6.0.0",
     "tslib": "^2.5.0",
-    "viem": "npm:@spalladino/viem@2.38.2-eip7594.1"
+    "viem": "npm:@spalladino/viem@2.38.2-eip7594.2"
   },
   "devDependencies": {
     "@jest/globals": "^30.0.0",

--- a/yarn-project/aztec-faucet/package.json
+++ b/yarn-project/aztec-faucet/package.json
@@ -70,7 +70,7 @@
     "koa": "^2.16.1",
     "koa-bodyparser": "^4.4.1",
     "koa-router": "^13.1.1",
-    "viem": "npm:@spalladino/viem@2.38.2-eip7594.1",
+    "viem": "npm:@spalladino/viem@2.38.2-eip7594.2",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/yarn-project/aztec-node/package.json
+++ b/yarn-project/aztec-node/package.json
@@ -92,7 +92,7 @@
     "koa": "^2.16.1",
     "koa-router": "^13.1.1",
     "tslib": "^2.4.0",
-    "viem": "npm:@spalladino/viem@2.38.2-eip7594.1"
+    "viem": "npm:@spalladino/viem@2.38.2-eip7594.2"
   },
   "devDependencies": {
     "@jest/globals": "^30.0.0",

--- a/yarn-project/aztec.js/package.json
+++ b/yarn-project/aztec.js/package.json
@@ -90,7 +90,7 @@
     "@aztec/stdlib": "workspace:^",
     "axios": "^1.12.0",
     "tslib": "^2.4.0",
-    "viem": "npm:@spalladino/viem@2.38.2-eip7594.1"
+    "viem": "npm:@spalladino/viem@2.38.2-eip7594.2"
   },
   "devDependencies": {
     "@jest/globals": "^30.0.0",

--- a/yarn-project/aztec/package.json
+++ b/yarn-project/aztec/package.json
@@ -65,7 +65,7 @@
     "commander": "^12.1.0",
     "koa": "^2.16.1",
     "koa-router": "^13.1.1",
-    "viem": "npm:@spalladino/viem@2.38.2-eip7594.1"
+    "viem": "npm:@spalladino/viem@2.38.2-eip7594.2"
   },
   "files": [
     "dest",

--- a/yarn-project/bb-prover/package.json
+++ b/yarn-project/bb-prover/package.json
@@ -99,7 +99,7 @@
     "jest-mock-extended": "^4.0.0",
     "ts-node": "^10.9.1",
     "typescript": "^5.3.3",
-    "viem": "npm:@spalladino/viem@2.38.2-eip7594.1"
+    "viem": "npm:@spalladino/viem@2.38.2-eip7594.2"
   },
   "files": [
     "dest",

--- a/yarn-project/blob-sink/package.json
+++ b/yarn-project/blob-sink/package.json
@@ -68,7 +68,7 @@
     "snappy": "^7.2.2",
     "source-map-support": "^0.5.21",
     "tslib": "^2.4.0",
-    "viem": "npm:@spalladino/viem@2.38.2-eip7594.1",
+    "viem": "npm:@spalladino/viem@2.38.2-eip7594.2",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/yarn-project/cli/package.json
+++ b/yarn-project/cli/package.json
@@ -93,7 +93,7 @@
     "semver": "^7.5.4",
     "source-map-support": "^0.5.21",
     "tslib": "^2.4.0",
-    "viem": "npm:@spalladino/viem@2.38.2-eip7594.1"
+    "viem": "npm:@spalladino/viem@2.38.2-eip7594.2"
   },
   "devDependencies": {
     "@aztec/accounts": "workspace:^",

--- a/yarn-project/end-to-end/package.json
+++ b/yarn-project/end-to-end/package.json
@@ -96,7 +96,7 @@
     "tslib": "^2.4.0",
     "typescript": "^5.3.3",
     "util": "^0.12.5",
-    "viem": "npm:@spalladino/viem@2.38.2-eip7594.1",
+    "viem": "npm:@spalladino/viem@2.38.2-eip7594.2",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/yarn-project/epoch-cache/package.json
+++ b/yarn-project/epoch-cache/package.json
@@ -35,7 +35,7 @@
     "get-port": "^7.1.0",
     "jest-mock-extended": "^4.0.0",
     "tslib": "^2.4.0",
-    "viem": "npm:@spalladino/viem@2.38.2-eip7594.1",
+    "viem": "npm:@spalladino/viem@2.38.2-eip7594.2",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/yarn-project/ethereum/package.json
+++ b/yarn-project/ethereum/package.json
@@ -40,7 +40,7 @@
     "lodash.chunk": "^4.2.0",
     "lodash.pickby": "^4.5.0",
     "tslib": "^2.4.0",
-    "viem": "npm:@spalladino/viem@2.38.2-eip7594.1",
+    "viem": "npm:@spalladino/viem@2.38.2-eip7594.2",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/yarn-project/foundation/package.json
+++ b/yarn-project/foundation/package.json
@@ -156,7 +156,7 @@
     "ts-node": "^10.9.1",
     "typescript": "^5.3.3",
     "typescript-eslint": "^8.32.1",
-    "viem": "npm:@spalladino/viem@2.38.2-eip7594.1"
+    "viem": "npm:@spalladino/viem@2.38.2-eip7594.2"
   },
   "files": [
     "dest",

--- a/yarn-project/node-keystore/package.json
+++ b/yarn-project/node-keystore/package.json
@@ -67,7 +67,7 @@
     "@aztec/stdlib": "workspace:^",
     "@ethersproject/wallet": "^5.7.0",
     "tslib": "^2.4.0",
-    "viem": "npm:@spalladino/viem@2.38.2-eip7594.1",
+    "viem": "npm:@spalladino/viem@2.38.2-eip7594.2",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/yarn-project/p2p/package.json
+++ b/yarn-project/p2p/package.json
@@ -117,7 +117,7 @@
     "ts-node": "^10.9.1",
     "typescript": "^5.3.3",
     "uint8arrays": "^5.0.3",
-    "viem": "npm:@spalladino/viem@2.38.2-eip7594.1"
+    "viem": "npm:@spalladino/viem@2.38.2-eip7594.2"
   },
   "files": [
     "dest",

--- a/yarn-project/prover-node/package.json
+++ b/yarn-project/prover-node/package.json
@@ -79,7 +79,7 @@
     "@aztec/world-state": "workspace:^",
     "source-map-support": "^0.5.21",
     "tslib": "^2.4.0",
-    "viem": "npm:@spalladino/viem@2.38.2-eip7594.1"
+    "viem": "npm:@spalladino/viem@2.38.2-eip7594.2"
   },
   "devDependencies": {
     "@jest/globals": "^30.0.0",

--- a/yarn-project/pxe/package.json
+++ b/yarn-project/pxe/package.json
@@ -82,7 +82,7 @@
     "lodash.omit": "^4.5.0",
     "sha3": "^2.1.4",
     "tslib": "^2.4.0",
-    "viem": "npm:@spalladino/viem@2.38.2-eip7594.1"
+    "viem": "npm:@spalladino/viem@2.38.2-eip7594.2"
   },
   "devDependencies": {
     "@aztec/merkle-tree": "workspace:^",

--- a/yarn-project/sequencer-client/package.json
+++ b/yarn-project/sequencer-client/package.json
@@ -52,7 +52,7 @@
     "@aztec/world-state": "workspace:^",
     "lodash.chunk": "^4.2.0",
     "tslib": "^2.4.0",
-    "viem": "npm:@spalladino/viem@2.38.2-eip7594.1"
+    "viem": "npm:@spalladino/viem@2.38.2-eip7594.2"
   },
   "devDependencies": {
     "@aztec/archiver": "workspace:^",

--- a/yarn-project/simulator/package.json
+++ b/yarn-project/simulator/package.json
@@ -91,7 +91,7 @@
     "jest-mock-extended": "^4.0.0",
     "ts-node": "^10.9.1",
     "typescript": "^5.3.3",
-    "viem": "npm:@spalladino/viem@2.38.2-eip7594.1"
+    "viem": "npm:@spalladino/viem@2.38.2-eip7594.2"
   },
   "files": [
     "dest",

--- a/yarn-project/slasher/package.json
+++ b/yarn-project/slasher/package.json
@@ -63,7 +63,7 @@
     "@aztec/telemetry-client": "workspace:^",
     "source-map-support": "^0.5.21",
     "tslib": "^2.4.0",
-    "viem": "npm:@spalladino/viem@2.38.2-eip7594.1",
+    "viem": "npm:@spalladino/viem@2.38.2-eip7594.2",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/yarn-project/stdlib/package.json
+++ b/yarn-project/stdlib/package.json
@@ -87,7 +87,7 @@
     "msgpackr": "^1.11.2",
     "pako": "^2.1.0",
     "tslib": "^2.4.0",
-    "viem": "npm:@spalladino/viem@2.38.2-eip7594.1",
+    "viem": "npm:@spalladino/viem@2.38.2-eip7594.2",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/yarn-project/telemetry-client/package.json
+++ b/yarn-project/telemetry-client/package.json
@@ -42,7 +42,7 @@
     "@opentelemetry/sdk-trace-node": "^1.28.0",
     "@opentelemetry/semantic-conventions": "^1.28.0",
     "prom-client": "^15.1.3",
-    "viem": "npm:@spalladino/viem@2.38.2-eip7594.1"
+    "viem": "npm:@spalladino/viem@2.38.2-eip7594.2"
   },
   "devDependencies": {
     "@jest/globals": "^30.0.0",

--- a/yarn-project/validator-client/package.json
+++ b/yarn-project/validator-client/package.json
@@ -77,7 +77,7 @@
     "koa": "^2.16.1",
     "koa-router": "^13.1.1",
     "tslib": "^2.4.0",
-    "viem": "npm:@spalladino/viem@2.38.2-eip7594.1"
+    "viem": "npm:@spalladino/viem@2.38.2-eip7594.2"
   },
   "devDependencies": {
     "@jest/globals": "^30.0.0",

--- a/yarn-project/yarn.lock
+++ b/yarn-project/yarn.lock
@@ -765,7 +765,7 @@ __metadata:
     tsc-watch: "npm:^6.0.0"
     tslib: "npm:^2.5.0"
     typescript: "npm:^5.3.3"
-    viem: "npm:@spalladino/viem@2.38.2-eip7594.1"
+    viem: "npm:@spalladino/viem@2.38.2-eip7594.2"
   languageName: unknown
   linkType: soft
 
@@ -787,7 +787,7 @@ __metadata:
     koa-router: "npm:^13.1.1"
     ts-node: "npm:^10.9.1"
     typescript: "npm:^5.3.3"
-    viem: "npm:@spalladino/viem@2.38.2-eip7594.1"
+    viem: "npm:@spalladino/viem@2.38.2-eip7594.2"
     zod: "npm:^3.23.8"
   bin:
     aztec-faucet: ./dest/bin/index.js
@@ -831,7 +831,7 @@ __metadata:
     ts-node: "npm:^10.9.1"
     tslib: "npm:^2.4.0"
     typescript: "npm:^5.3.3"
-    viem: "npm:@spalladino/viem@2.38.2-eip7594.1"
+    viem: "npm:@spalladino/viem@2.38.2-eip7594.2"
   bin:
     aztec-node: ./dest/bin/index.js
   languageName: unknown
@@ -864,7 +864,7 @@ __metadata:
     tslib: "npm:^2.4.0"
     typescript: "npm:^5.3.3"
     util: "npm:^0.12.5"
-    viem: "npm:@spalladino/viem@2.38.2-eip7594.1"
+    viem: "npm:@spalladino/viem@2.38.2-eip7594.2"
   languageName: unknown
   linkType: soft
 
@@ -934,7 +934,7 @@ __metadata:
     koa-router: "npm:^13.1.1"
     ts-node: "npm:^10.9.1"
     typescript: "npm:^5.3.3"
-    viem: "npm:@spalladino/viem@2.38.2-eip7594.1"
+    viem: "npm:@spalladino/viem@2.38.2-eip7594.2"
   bin:
     aztec: ./dest/bin/index.js
   languageName: unknown
@@ -971,7 +971,7 @@ __metadata:
     ts-node: "npm:^10.9.1"
     tslib: "npm:^2.4.0"
     typescript: "npm:^5.3.3"
-    viem: "npm:@spalladino/viem@2.38.2-eip7594.1"
+    viem: "npm:@spalladino/viem@2.38.2-eip7594.2"
   bin:
     bb-cli: ./dest/bb/index.js
   languageName: unknown
@@ -1035,7 +1035,7 @@ __metadata:
     ts-node: "npm:^10.9.1"
     tslib: "npm:^2.4.0"
     typescript: "npm:^5.3.3"
-    viem: "npm:@spalladino/viem@2.38.2-eip7594.1"
+    viem: "npm:@spalladino/viem@2.38.2-eip7594.2"
     zod: "npm:^3.23.8"
   bin:
     blob-sink-client: ./dest/client/bin/index.js
@@ -1165,7 +1165,7 @@ __metadata:
     ts-node: "npm:^10.9.1"
     tslib: "npm:^2.4.0"
     typescript: "npm:^5.3.3"
-    viem: "npm:@spalladino/viem@2.38.2-eip7594.1"
+    viem: "npm:@spalladino/viem@2.38.2-eip7594.2"
   peerDependencies:
     "@aztec/accounts": "workspace:^"
     "@aztec/bb-prover": "workspace:^"
@@ -1283,7 +1283,7 @@ __metadata:
     tslib: "npm:^2.4.0"
     typescript: "npm:^5.3.3"
     util: "npm:^0.12.5"
-    viem: "npm:@spalladino/viem@2.38.2-eip7594.1"
+    viem: "npm:@spalladino/viem@2.38.2-eip7594.2"
     zod: "npm:^3.23.8"
   languageName: unknown
   linkType: soft
@@ -1324,7 +1324,7 @@ __metadata:
     ts-node: "npm:^10.9.1"
     tslib: "npm:^2.4.0"
     typescript: "npm:^5.3.3"
-    viem: "npm:@spalladino/viem@2.38.2-eip7594.1"
+    viem: "npm:@spalladino/viem@2.38.2-eip7594.2"
     zod: "npm:^3.23.8"
   languageName: unknown
   linkType: soft
@@ -1353,7 +1353,7 @@ __metadata:
     ts-node: "npm:^10.9.1"
     tslib: "npm:^2.4.0"
     typescript: "npm:^5.3.3"
-    viem: "npm:@spalladino/viem@2.38.2-eip7594.1"
+    viem: "npm:@spalladino/viem@2.38.2-eip7594.2"
     zod: "npm:^3.23.8"
   languageName: unknown
   linkType: soft
@@ -1412,7 +1412,7 @@ __metadata:
     typescript: "npm:^5.3.3"
     typescript-eslint: "npm:^8.32.1"
     undici: "npm:^5.28.5"
-    viem: "npm:@spalladino/viem@2.38.2-eip7594.1"
+    viem: "npm:@spalladino/viem@2.38.2-eip7594.2"
     zod: "npm:^3.23.8"
   languageName: unknown
   linkType: soft
@@ -1577,7 +1577,7 @@ __metadata:
     ts-node: "npm:^10.9.1"
     tslib: "npm:^2.4.0"
     typescript: "npm:^5.3.3"
-    viem: "npm:@spalladino/viem@2.38.2-eip7594.1"
+    viem: "npm:@spalladino/viem@2.38.2-eip7594.2"
     zod: "npm:^3.23.8"
   languageName: unknown
   linkType: soft
@@ -1790,7 +1790,7 @@ __metadata:
     tslib: "npm:^2.4.0"
     typescript: "npm:^5.3.3"
     uint8arrays: "npm:^5.0.3"
-    viem: "npm:@spalladino/viem@2.38.2-eip7594.1"
+    viem: "npm:@spalladino/viem@2.38.2-eip7594.2"
     xxhash-wasm: "npm:^1.1.0"
   languageName: unknown
   linkType: soft
@@ -1890,7 +1890,7 @@ __metadata:
     ts-node: "npm:^10.9.1"
     tslib: "npm:^2.4.0"
     typescript: "npm:^5.3.3"
-    viem: "npm:@spalladino/viem@2.38.2-eip7594.1"
+    viem: "npm:@spalladino/viem@2.38.2-eip7594.2"
   languageName: unknown
   linkType: soft
 
@@ -1929,7 +1929,7 @@ __metadata:
     ts-node: "npm:^10.9.1"
     tslib: "npm:^2.4.0"
     typescript: "npm:^5.3.3"
-    viem: "npm:@spalladino/viem@2.38.2-eip7594.1"
+    viem: "npm:@spalladino/viem@2.38.2-eip7594.2"
   bin:
     pxe: ./dest/bin/index.js
   languageName: unknown
@@ -2000,7 +2000,7 @@ __metadata:
     ts-node: "npm:^10.9.1"
     tslib: "npm:^2.4.0"
     typescript: "npm:^5.3.3"
-    viem: "npm:@spalladino/viem@2.38.2-eip7594.1"
+    viem: "npm:@spalladino/viem@2.38.2-eip7594.2"
   languageName: unknown
   linkType: soft
 
@@ -2034,7 +2034,7 @@ __metadata:
     ts-node: "npm:^10.9.1"
     tslib: "npm:^2.4.0"
     typescript: "npm:^5.3.3"
-    viem: "npm:@spalladino/viem@2.38.2-eip7594.1"
+    viem: "npm:@spalladino/viem@2.38.2-eip7594.2"
   languageName: unknown
   linkType: soft
 
@@ -2060,7 +2060,7 @@ __metadata:
     ts-node: "npm:^10.9.1"
     tslib: "npm:^2.4.0"
     typescript: "npm:^5.3.3"
-    viem: "npm:@spalladino/viem@2.38.2-eip7594.1"
+    viem: "npm:@spalladino/viem@2.38.2-eip7594.2"
     zod: "npm:^3.23.8"
   languageName: unknown
   linkType: soft
@@ -2103,7 +2103,7 @@ __metadata:
     ts-node: "npm:^10.9.1"
     tslib: "npm:^2.4.0"
     typescript: "npm:^5.3.3"
-    viem: "npm:@spalladino/viem@2.38.2-eip7594.1"
+    viem: "npm:@spalladino/viem@2.38.2-eip7594.2"
     zod: "npm:^3.23.8"
   languageName: unknown
   linkType: soft
@@ -2135,7 +2135,7 @@ __metadata:
     prom-client: "npm:^15.1.3"
     ts-node: "npm:^10.9.1"
     typescript: "npm:^5.3.3"
-    viem: "npm:@spalladino/viem@2.38.2-eip7594.1"
+    viem: "npm:@spalladino/viem@2.38.2-eip7594.2"
   languageName: unknown
   linkType: soft
 
@@ -2194,7 +2194,7 @@ __metadata:
     ts-node: "npm:^10.9.1"
     tslib: "npm:^2.4.0"
     typescript: "npm:^5.3.3"
-    viem: "npm:@spalladino/viem@2.38.2-eip7594.1"
+    viem: "npm:@spalladino/viem@2.38.2-eip7594.2"
   bin:
     validator-client: ./dest/bin/index.js
   languageName: unknown
@@ -22201,9 +22201,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"viem@npm:@spalladino/viem@2.38.2-eip7594.1":
-  version: 2.38.2-eip7594.1
-  resolution: "@spalladino/viem@npm:2.38.2-eip7594.1"
+"viem@npm:@spalladino/viem@2.38.2-eip7594.2":
+  version: 2.38.2-eip7594.2
+  resolution: "@spalladino/viem@npm:2.38.2-eip7594.2"
   dependencies:
     "@noble/curves": "npm:1.9.1"
     "@noble/hashes": "npm:1.8.0"
@@ -22218,7 +22218,7 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 10/d5850b364cf0fb819c7cfd121f5770d53197b5e1f250bd3d818c6276f815e8ab00dca3e116bf49d5289069df3de35273e82613d6117ab0429a52d15a343b69f7
+  checksum: 10/c47611285e099fdeb8e3e28b2a4362edc5350d3ff54319cfdd94b1addc4e8ae8deff8d3c8efaaf1639d2ecd4ba87a06440f47bcd2a2be625815acc400ebde1b3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Version `.1` of the fork was published without building the js files. Release `.2` fixes it. This commits bumps to it.

See https://github.com/AztecProtocol/aztec-packages/pull/18431 for more context.