### PR TITLE
feat!: cleanup contract.at and registerContract

### DIFF
--- a/boxes/boxes/vanilla/app/main.ts
+++ b/boxes/boxes/vanilla/app/main.ts
@@ -147,7 +147,7 @@ voteButton.addEventListener('click', async (e) => {
     }
 
     // Prepare contract interaction
-    const votingContract = await PrivateVotingContract.at(
+    const votingContract = PrivateVotingContract.at(
       AztecAddress.fromString(contractAddress),
       wallet
     );
@@ -181,7 +181,7 @@ async function updateVoteTally(wallet: Wallet, from: AztecAddress) {
   displayStatusMessage('Updating vote tally...');
 
   // Prepare contract interaction
-  const votingContract = await PrivateVotingContract.at(
+  const votingContract = PrivateVotingContract.at(
     AztecAddress.fromString(contractAddress),
     wallet
   );

--- a/boxes/boxes/vanilla/scripts/deploy.ts
+++ b/boxes/boxes/vanilla/scripts/deploy.ts
@@ -1,5 +1,6 @@
 import { AztecAddress } from '@aztec/aztec.js/addresses';
 import {
+  type ContractInstanceWithAddress,
   DeployMethod,
   getContractInstanceFromInstantiationParams,
 } from '@aztec/aztec.js/contracts';
@@ -101,8 +102,8 @@ async function deployContract(wallet: Wallet, deployer: AztecAddress) {
     contract.publicKeys,
     wallet,
     PrivateVotingContract.artifact,
-    (address: AztecAddress, wallet: Wallet) =>
-      PrivateVotingContract.at(address, wallet),
+    (instance: ContractInstanceWithAddress, wallet: Wallet) =>
+      PrivateVotingContract.at(instance.address, wallet),
     [deployer.toField()],
     getDefaultInitializer(PrivateVotingContract.artifact)?.name
   );

--- a/playground/src/components/contract/Contract.tsx
+++ b/playground/src/components/contract/Contract.tsx
@@ -1,6 +1,11 @@
 import { css } from '@mui/styled-engine';
 import { useContext, useEffect, useState } from 'react';
-import { type ContractInstanceWithAddress, type DeployOptions, Contract, DeployMethod } from '@aztec/aztec.js/contracts';
+import {
+  type ContractInstanceWithAddress,
+  type DeployOptions,
+  Contract,
+  DeployMethod,
+} from '@aztec/aztec.js/contracts';
 import { TxStatus } from '@aztec/aztec.js/tx';
 import { type FunctionAbi, getAllFunctionAbis, FunctionType } from '@aztec/stdlib/abi';
 import { AztecContext } from '../../aztecContext';
@@ -115,14 +120,6 @@ const contractName = css({
   '@media (max-width: 900px)': {
     fontSize: '1.5rem',
   },
-});
-
-const contractClassIdCss = css({
-  marginBottom: '1rem',
-  marginTop: '0.5rem',
-  backgroundColor: 'rgba(255, 255, 255, 0.22)',
-  padding: '0px 5px',
-  borderRadius: '3px',
 });
 
 const deployedContractCss = css({
@@ -289,10 +286,6 @@ export function ContractComponent() {
                   </div>
                 )}
               </Box>
-
-              <Typography variant="caption" css={contractClassIdCss}>
-                Contract Class ID: {currentContract?.instance?.currentContractClassId.toString()}
-              </Typography>
 
               {!!ContractDescriptions[currentContractArtifact.name] && (
                 <Typography variant="body2" css={{ marginBottom: '2rem' }}>

--- a/playground/src/components/contract/components/CreateContractDialog.tsx
+++ b/playground/src/components/contract/components/CreateContractDialog.tsx
@@ -1,5 +1,11 @@
 import { AztecAddress } from '@aztec/aztec.js/addresses';
-import { type ContractInstanceWithAddress, type DeployOptions, DeployMethod, getContractInstanceFromInstantiationParams, Contract } from '@aztec/aztec.js/contracts';
+import {
+  type ContractInstanceWithAddress,
+  type DeployOptions,
+  DeployMethod,
+  getContractInstanceFromInstantiationParams,
+  Contract,
+} from '@aztec/aztec.js/contracts';
 import { Fr } from '@aztec/aztec.js/fields';
 import { PublicKeys } from '@aztec/aztec.js/keys';
 import type { Wallet } from '@aztec/aztec.js/wallet';
@@ -107,8 +113,8 @@ export function CreateContractDialog({
       let deployMethod: DeployMethod;
       let opts: DeployOptions;
       if (publiclyDeploy) {
-        const postDeployCtor = (address: AztecAddress, wallet: Wallet) =>
-          Contract.at(address, contractArtifact, wallet);
+        const postDeployCtor = (instance: ContractInstanceWithAddress, wallet: Wallet) =>
+          Contract.at(instance.address, contractArtifact, wallet);
         deployMethod = new DeployMethod(
           contract.publicKeys,
           wallet,

--- a/yarn-project/aztec.js/src/api/contract.ts
+++ b/yarn-project/aztec.js/src/api/contract.ts
@@ -15,7 +15,7 @@
  * ```
  *
  * ```ts
- * const contract = await Contract.at(address, MyContractArtifact, wallet);
+ * const contract = Contract.at(address, MyContractArtifact, wallet);
  * await contract.methods.mint(1000, owner).send().wait();
  * console.log(`Total supply is now ${await contract.methods.totalSupply().simulate()}`);
  * ```

--- a/yarn-project/aztec.js/src/api/wallet.ts
+++ b/yarn-project/aztec.js/src/api/wallet.ts
@@ -1,6 +1,5 @@
 export {
   type Aliased,
-  type ContractInstanceAndArtifact,
   type SimulateOptions,
   type ProfileOptions,
   type SendOptions,

--- a/yarn-project/aztec.js/src/contract/contract.test.ts
+++ b/yarn-project/aztec.js/src/contract/contract.test.ts
@@ -143,7 +143,7 @@ describe('Contract Class', () => {
   });
 
   it('should create and send a contract method tx', async () => {
-    const fooContract = await Contract.at(contractAddress, defaultArtifact, wallet);
+    const fooContract = Contract.at(contractAddress, defaultArtifact, wallet);
     const param0 = 12;
     const param1 = 345n;
     const sentTx = fooContract.methods.bar(param0, param1).send({ from: account.getAddress() });
@@ -156,7 +156,7 @@ describe('Contract Class', () => {
   });
 
   it('should call view on a utility function', async () => {
-    const fooContract = await Contract.at(contractAddress, defaultArtifact, wallet);
+    const fooContract = Contract.at(contractAddress, defaultArtifact, wallet);
     const result = await fooContract.methods.qux(123n).simulate({ from: account.getAddress() });
     expect(wallet.simulateUtility).toHaveBeenCalledTimes(1);
     expect(wallet.simulateUtility).toHaveBeenCalledWith(

--- a/yarn-project/aztec.js/src/contract/contract.ts
+++ b/yarn-project/aztec.js/src/contract/contract.ts
@@ -1,5 +1,6 @@
 import type { ContractArtifact } from '@aztec/stdlib/abi';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
+import type { ContractInstanceWithAddress } from '@aztec/stdlib/contract';
 import { PublicKeys } from '@aztec/stdlib/keys';
 
 import type { Wallet } from '../wallet/wallet.js';
@@ -21,9 +22,8 @@ export class Contract extends ContractBase {
    * @param wallet - The wallet to use when interacting with the contract.
    * @returns A promise that resolves to a new Contract instance.
    */
-  public static async at(address: AztecAddress, artifact: ContractArtifact, wallet: Wallet): Promise<Contract> {
-    const instance = await wallet.registerContract(address, artifact);
-    return new Contract(instance, artifact, wallet);
+  public static at(address: AztecAddress, artifact: ContractArtifact, wallet: Wallet): Contract {
+    return new Contract(address, artifact, wallet);
   }
 
   /**
@@ -34,7 +34,8 @@ export class Contract extends ContractBase {
    * @param constructorName - The name of the constructor function to call.
    */
   public static deploy(wallet: Wallet, artifact: ContractArtifact, args: any[], constructorName?: string) {
-    const postDeployCtor = (address: AztecAddress, wallet: Wallet) => Contract.at(address, artifact, wallet);
+    const postDeployCtor = (instance: ContractInstanceWithAddress, wallet: Wallet) =>
+      Contract.at(instance.address, artifact, wallet);
     return new DeployMethod(PublicKeys.default(), wallet, artifact, postDeployCtor, args, constructorName);
   }
 
@@ -54,7 +55,8 @@ export class Contract extends ContractBase {
     args: any[],
     constructorName?: string,
   ) {
-    const postDeployCtor = (address: AztecAddress, wallet: Wallet) => Contract.at(address, artifact, wallet);
+    const postDeployCtor = (instance: ContractInstanceWithAddress, wallet: Wallet) =>
+      Contract.at(instance.address, artifact, wallet);
     return new DeployMethod(publicKeys, wallet, artifact, postDeployCtor, args, constructorName);
   }
 }

--- a/yarn-project/aztec.js/src/contract/contract_base.ts
+++ b/yarn-project/aztec.js/src/contract/contract_base.ts
@@ -5,7 +5,7 @@ import {
   FunctionSelector,
   getAllFunctionAbis,
 } from '@aztec/stdlib/abi';
-import { type ContractInstanceWithAddress, computePartialAddress } from '@aztec/stdlib/contract';
+import type { AztecAddress } from '@aztec/stdlib/aztec-address';
 
 import type { Wallet } from '../wallet/wallet.js';
 import { ContractFunctionInteraction } from './contract_function_interaction.js';
@@ -38,8 +38,8 @@ export class ContractBase {
   public methods: { [name: string]: ContractMethod } = {};
 
   protected constructor(
-    /** The deployed contract instance definition. */
-    public readonly instance: ContractInstanceWithAddress,
+    /** The contract's address. */
+    public readonly address: AztecAddress,
     /** The Application Binary Interface for the contract. */
     public readonly artifact: ContractArtifact,
     /** The wallet used for interacting with this contract. */
@@ -47,7 +47,7 @@ export class ContractBase {
   ) {
     getAllFunctionAbis(artifact).forEach((f: FunctionAbi) => {
       const interactionFunction = (...args: any[]) => {
-        return new ContractFunctionInteraction(this.wallet, this.instance.address, f, args);
+        return new ContractFunctionInteraction(this.wallet, this.address, f, args);
       };
 
       this.methods[f.name] = Object.assign(interactionFunction, {
@@ -62,22 +62,12 @@ export class ContractBase {
     });
   }
 
-  /** Address of the contract. */
-  public get address() {
-    return this.instance.address;
-  }
-
-  /** Partial address of the contract. */
-  public get partialAddress() {
-    return computePartialAddress(this.instance);
-  }
-
   /**
    * Creates a new instance of the contract wrapper attached to a different wallet.
    * @param wallet - Wallet to use for sending txs.
    * @returns A new contract instance.
    */
   public withWallet(wallet: Wallet): this {
-    return new ContractBase(this.instance, this.artifact, wallet) as this;
+    return new ContractBase(this.address, this.artifact, wallet) as this;
   }
 }

--- a/yarn-project/aztec.js/src/contract/unsafe_contract.ts
+++ b/yarn-project/aztec.js/src/contract/unsafe_contract.ts
@@ -14,6 +14,6 @@ export class UnsafeContract extends ContractBase {
     /** The wallet used for interacting with this contract. */
     wallet: Wallet,
   ) {
-    super(instance, artifact, wallet);
+    super(instance.address, artifact, wallet);
   }
 }

--- a/yarn-project/aztec.js/src/deployment/contract_deployer.ts
+++ b/yarn-project/aztec.js/src/deployment/contract_deployer.ts
@@ -1,5 +1,5 @@
 import type { ContractArtifact } from '@aztec/stdlib/abi';
-import { AztecAddress } from '@aztec/stdlib/aztec-address';
+import type { ContractInstanceWithAddress } from '@aztec/stdlib/contract';
 import { PublicKeys } from '@aztec/stdlib/keys';
 
 import { Contract } from '../contract/contract.js';
@@ -28,7 +28,8 @@ export class ContractDeployer {
    * @returns A DeployMethod instance configured with the ABI, PXE, and constructor arguments.
    */
   public deploy(...args: any[]) {
-    const postDeployCtor = (address: AztecAddress, wallet: Wallet) => Contract.at(address, this.artifact, wallet);
+    const postDeployCtor = (instance: ContractInstanceWithAddress, wallet: Wallet) =>
+      Contract.at(instance.address, this.artifact, wallet);
     return new DeployMethod(
       this.publicKeys ?? PublicKeys.default(),
       this.wallet,

--- a/yarn-project/aztec.js/src/wallet/account_manager.ts
+++ b/yarn-project/aztec.js/src/wallet/account_manager.ts
@@ -138,7 +138,7 @@ export class AccountManager {
       this.getPublicKeys(),
       this.wallet,
       artifact,
-      address => Contract.at(address, artifact, this.wallet),
+      instance => Contract.at(instance.address, artifact, this.wallet),
       new Fr(this.salt),
       constructorArgs,
       constructorName,

--- a/yarn-project/aztec.js/src/wallet/deploy_account_method.ts
+++ b/yarn-project/aztec.js/src/wallet/deploy_account_method.ts
@@ -1,6 +1,7 @@
 import { Fr } from '@aztec/foundation/fields';
 import type { ContractArtifact, FunctionArtifact } from '@aztec/stdlib/abi';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
+import type { ContractInstanceWithAddress } from '@aztec/stdlib/contract';
 import type { PublicKeys } from '@aztec/stdlib/keys';
 import { ExecutionPayload, mergeExecutionPayloads } from '@aztec/stdlib/tx';
 
@@ -44,7 +45,7 @@ export class DeployAccountMethod<TContract extends ContractBase = Contract> exte
     publicKeys: PublicKeys,
     wallet: Wallet,
     artifact: ContractArtifact,
-    postDeployCtor: (address: AztecAddress, wallet: Wallet) => Promise<TContract>,
+    postDeployCtor: (instance: ContractInstanceWithAddress, wallet: Wallet) => TContract,
     private salt: Fr,
     args: any[] = [],
     constructorNameOrArtifact?: string | FunctionArtifact,

--- a/yarn-project/aztec.js/src/wallet/wallet.test.ts
+++ b/yarn-project/aztec.js/src/wallet/wallet.test.ts
@@ -125,7 +125,17 @@ describe('WalletSchema', () => {
       fileMap: {},
       storageLayout: {},
     };
-    const result = await context.client.registerContract(await AztecAddress.random(), mockArtifact, Fr.random());
+    const mockInstance: ContractInstanceWithAddress = {
+      address: await AztecAddress.random(),
+      version: 1,
+      salt: Fr.random(),
+      deployer: await AztecAddress.random(),
+      currentContractClassId: Fr.random(),
+      originalContractClassId: Fr.random(),
+      initializationHash: Fr.random(),
+      publicKeys: PublicKeys.default(),
+    };
+    const result = await context.client.registerContract(mockInstance, mockArtifact, Fr.random());
     expect(result).toEqual({
       address: expect.any(AztecAddress),
       currentContractClassId: expect.any(Fr),
@@ -229,9 +239,29 @@ describe('WalletSchema', () => {
       returnTypes: [],
     };
 
+    const mockInstance: ContractInstanceWithAddress = {
+      address: address2,
+      version: 1,
+      salt: Fr.random(),
+      deployer: await AztecAddress.random(),
+      currentContractClassId: Fr.random(),
+      originalContractClassId: Fr.random(),
+      initializationHash: Fr.random(),
+      publicKeys: PublicKeys.default(),
+    };
+
+    const mockArtifact: ContractArtifact = {
+      name: 'TestContract',
+      functions: [],
+      nonDispatchPublicFunctions: [],
+      outputs: { structs: {}, globals: {} },
+      fileMap: {},
+      storageLayout: {},
+    };
+
     const methods: BatchedMethod<keyof BatchableMethods>[] = [
       { name: 'registerSender', args: [address1, 'alias1'] },
-      { name: 'registerContract', args: [address2, undefined, undefined] },
+      { name: 'registerContract', args: [mockInstance, mockArtifact, undefined] },
       { name: 'sendTx', args: [exec, opts] },
       { name: 'simulateUtility', args: [call, [AuthWitness.random()], undefined] },
       { name: 'simulateTx', args: [exec, simulateOpts] },

--- a/yarn-project/aztec.js/src/wallet/wallet.ts
+++ b/yarn-project/aztec.js/src/wallet/wallet.ts
@@ -16,7 +16,6 @@ import {
   ContractClassWithIdSchema,
   type ContractInstanceWithAddress,
   ContractInstanceWithAddressSchema,
-  type ContractInstantiationData,
   type ContractMetadata,
 } from '@aztec/stdlib/contract';
 import { Gas } from '@aztec/stdlib/gas';
@@ -35,7 +34,6 @@ import type { ExecutionPayload } from '@aztec/stdlib/tx';
 
 import { z } from 'zod';
 
-import type { Contract } from '../contract/contract.js';
 import type {
   FeeEstimationOptions,
   GasSettingsOption,
@@ -58,11 +56,6 @@ export type Aliased<T> = {
    */
   item: T;
 };
-
-/**
- * A reduced representation of a Contract, only including its instance and artifact
- */
-export type ContractInstanceAndArtifact = Pick<Contract, 'artifact' | 'instance'>;
 
 /**
  * Options for simulating interactions with the wallet. Overrides the fee settings of an interaction with
@@ -157,17 +150,9 @@ export type Wallet = {
   getAddressBook(): Promise<Aliased<AztecAddress>[]>;
   getAccounts(): Promise<Aliased<AztecAddress>[]>;
   registerContract(
-    instanceData: AztecAddress | ContractInstanceWithAddress | ContractInstantiationData | ContractInstanceAndArtifact,
-  ): Promise<ContractInstanceWithAddress>;
-  // Overloaded definition to avoid zod issues
-  registerContract(
-    instanceData: AztecAddress | ContractInstanceWithAddress | ContractInstantiationData | ContractInstanceAndArtifact,
-    artifact: ContractArtifact,
-  ): Promise<ContractInstanceWithAddress>;
-  registerContract(
-    instanceData: AztecAddress | ContractInstanceWithAddress | ContractInstantiationData | ContractInstanceAndArtifact,
-    artifact: ContractArtifact | undefined,
-    secretKey: Fr | undefined,
+    instance: ContractInstanceWithAddress,
+    artifact?: ContractArtifact,
+    secretKey?: Fr,
   ): Promise<ContractInstanceWithAddress>;
   simulateTx(exec: ExecutionPayload, opts: SimulateOptions): Promise<TxSimulationResult>;
   simulateUtility(
@@ -326,7 +311,7 @@ export const WalletSchema: ApiSchemaFor<Wallet> = {
     .returns(z.array(z.object({ alias: z.string(), item: schemas.AztecAddress }))),
   registerContract: z
     .function()
-    .args(InstanceDataSchema, optional(ContractArtifactSchema), optional(schemas.Fr))
+    .args(ContractInstanceWithAddressSchema, optional(ContractArtifactSchema), optional(schemas.Fr))
     .returns(ContractInstanceWithAddressSchema),
   simulateTx: z.function().args(ExecutionPayloadSchema, SimulateOptionsSchema).returns(TxSimulationResult.schema),
   simulateUtility: z

--- a/yarn-project/cli-wallet/src/cmds/authorize_action.ts
+++ b/yarn-project/cli-wallet/src/cmds/authorize_action.ts
@@ -30,7 +30,7 @@ export async function authorizeAction(
     );
   }
 
-  const contract = await Contract.at(contractAddress, contractArtifact, wallet);
+  const contract = Contract.at(contractAddress, contractArtifact, wallet);
   const action = contract.methods[functionName](...functionArgs);
 
   const setAuthwitnessInteraction = await SetPublicAuthwitContractInteraction.create(

--- a/yarn-project/cli-wallet/src/cmds/create_authwit.ts
+++ b/yarn-project/cli-wallet/src/cmds/create_authwit.ts
@@ -28,7 +28,7 @@ export async function createAuthwit(
     );
   }
 
-  const contract = await Contract.at(contractAddress, contractArtifact, wallet);
+  const contract = Contract.at(contractAddress, contractArtifact, wallet);
   const call = await contract.methods[functionName](...functionArgs).getFunctionCall();
 
   const witness = await wallet.createAuthWit(from, { caller, call });

--- a/yarn-project/cli-wallet/src/cmds/profile.ts
+++ b/yarn-project/cli-wallet/src/cmds/profile.ts
@@ -28,7 +28,7 @@ export async function profile(
 ) {
   const { functionArgs, contractArtifact } = await prepTx(contractArtifactPath, functionName, functionArgsIn, log);
 
-  const contract = await Contract.at(contractAddress, contractArtifact, wallet);
+  const contract = Contract.at(contractAddress, contractArtifact, wallet);
   const call = contract.methods[functionName](...functionArgs);
 
   const { paymentMethod, gasSettings } = await feeOpts.toUserFeeOptions(node, wallet, from);

--- a/yarn-project/cli-wallet/src/cmds/send.ts
+++ b/yarn-project/cli-wallet/src/cmds/send.ts
@@ -27,7 +27,7 @@ export async function send(
 ) {
   const { functionArgs, contractArtifact } = await prepTx(contractArtifactPath, functionName, functionArgsIn, log);
 
-  const contract = await Contract.at(contractAddress, contractArtifact, wallet);
+  const contract = Contract.at(contractAddress, contractArtifact, wallet);
   const call = contract.methods[functionName](...functionArgs);
 
   const { paymentMethod, gasSettings } = await feeOpts.toUserFeeOptions(node, wallet, from);

--- a/yarn-project/cli-wallet/src/cmds/simulate.ts
+++ b/yarn-project/cli-wallet/src/cmds/simulate.ts
@@ -27,7 +27,7 @@ export async function simulate(
 ) {
   const { functionArgs, contractArtifact } = await prepTx(contractArtifactPath, functionName, functionArgsIn, log);
 
-  const contract = await Contract.at(contractAddress, contractArtifact, wallet);
+  const contract = Contract.at(contractAddress, contractArtifact, wallet);
   const call = contract.methods[functionName](...functionArgs);
   const { paymentMethod, gasSettings } = await feeOpts.toUserFeeOptions(node, wallet, from);
   const simulationResult = await call.simulate({

--- a/yarn-project/end-to-end/src/bench/client_flows/account_deployments.test.ts
+++ b/yarn-project/end-to-end/src/bench/client_flows/account_deployments.test.ts
@@ -2,7 +2,8 @@ import { EcdsaRAccountContractArtifact } from '@aztec/accounts/ecdsa';
 import { AztecAddress } from '@aztec/aztec.js/addresses';
 import { publishContractClass } from '@aztec/aztec.js/deployment';
 import type { DeployAccountOptions, Wallet } from '@aztec/aztec.js/wallet';
-import type { SponsoredFPCContract } from '@aztec/noir-contracts.js/SponsoredFPC';
+import { SponsoredFPCContract } from '@aztec/noir-contracts.js/SponsoredFPC';
+import type { ContractInstanceWithAddress } from '@aztec/stdlib/contract';
 import type { TestWallet } from '@aztec/test-wallet/server';
 
 import { jest } from '@jest/globals';
@@ -19,7 +20,7 @@ describe('Deployment benchmark', () => {
   // The admin that aids in the setup of the test
   let adminAddress: AztecAddress;
   // Sponsored FPC contract
-  let sponsoredFPC: SponsoredFPCContract;
+  let sponsoredFPCInstance: ContractInstanceWithAddress;
   // Benchmarking configuration
   const config = t.config.accountDeployments;
   // Benchmarking user's Wallet
@@ -28,7 +29,7 @@ describe('Deployment benchmark', () => {
   beforeAll(async () => {
     await t.applyBaseSnapshots();
     await t.applyDeploySponsoredFPCSnapshot();
-    ({ adminWallet, adminAddress, sponsoredFPC, userWallet } = await t.setup());
+    ({ adminWallet, adminAddress, userWallet, sponsoredFPCInstance } = await t.setup());
     // Ensure the ECDSAR1 contract is already registered, to avoid benchmarking an extra call to the ContractClassRegistry
     // The typical interaction would be for a user to deploy an account contract that is already registered in the
     // network.
@@ -51,7 +52,7 @@ describe('Deployment benchmark', () => {
           const benchysAccountManager = await t.createBenchmarkingAccountManager(userWallet, accountType);
 
           if (benchmarkingPaymentMethod === 'sponsored_fpc') {
-            await userWallet.registerContract(sponsoredFPC);
+            await userWallet.registerContract(sponsoredFPCInstance, SponsoredFPCContract.artifact);
           }
 
           const benchysAddress = benchysAccountManager.address;

--- a/yarn-project/end-to-end/src/bench/client_flows/amm.test.ts
+++ b/yarn-project/end-to-end/src/bench/client_flows/amm.test.ts
@@ -1,10 +1,10 @@
 import { AztecAddress } from '@aztec/aztec.js/addresses';
-import type { SimulateInteractionOptions } from '@aztec/aztec.js/contracts';
+import type { ContractInstanceWithAddress, SimulateInteractionOptions } from '@aztec/aztec.js/contracts';
 import { Fr } from '@aztec/aztec.js/fields';
 import type { Wallet } from '@aztec/aztec.js/wallet';
-import type { AMMContract } from '@aztec/noir-contracts.js/AMM';
-import type { FPCContract } from '@aztec/noir-contracts.js/FPC';
-import type { SponsoredFPCContract } from '@aztec/noir-contracts.js/SponsoredFPC';
+import { AMMContract } from '@aztec/noir-contracts.js/AMM';
+import { FPCContract } from '@aztec/noir-contracts.js/FPC';
+import { SponsoredFPCContract } from '@aztec/noir-contracts.js/SponsoredFPC';
 import { TokenContract } from '@aztec/noir-contracts.js/Token';
 import type { TestWallet } from '@aztec/test-wallet/server';
 
@@ -29,17 +29,20 @@ describe('AMM benchmark', () => {
   // The admin that aids in the setup of the test
   let adminAddress: AztecAddress;
   // FPC that accepts bananas
-  let bananaFPC: FPCContract;
+  let bananaFPCInstance: ContractInstanceWithAddress;
   // BananaCoin Token contract, just used to pay fees in this scenario
   let bananaCoin: TokenContract;
+  let bananaCoinInstance: ContractInstanceWithAddress;
   // CandyBarCoin Token contract, which we want to amm
   let candyBarCoin: TokenContract;
+  let candyBarCoinInstance: ContractInstanceWithAddress;
   // AMM contract
   let amm: AMMContract;
+  let ammInstance: ContractInstanceWithAddress;
   // Liquidity contract for the AMM
-  let liquidityToken: TokenContract;
+  let liquidityTokenInstance: ContractInstanceWithAddress;
   // Sponsored FPC contract
-  let sponsoredFPC: SponsoredFPCContract;
+  let sponsoredFPCInstance: ContractInstanceWithAddress;
   // Benchmarking configuration
   const config = t.config.amm;
 
@@ -50,8 +53,20 @@ describe('AMM benchmark', () => {
     await t.applyDeployCandyBarTokenSnapshot();
     await t.applyDeployAmmSnapshot();
     await t.applyDeploySponsoredFPCSnapshot();
-    ({ adminWallet, userWallet, adminAddress, bananaFPC, bananaCoin, candyBarCoin, amm, liquidityToken, sponsoredFPC } =
-      await t.setup());
+    ({
+      adminWallet,
+      userWallet,
+      adminAddress,
+      amm,
+      bananaFPCInstance,
+      bananaCoin,
+      bananaCoinInstance,
+      candyBarCoin,
+      candyBarCoinInstance,
+      ammInstance,
+      liquidityTokenInstance,
+      sponsoredFPCInstance,
+    } = await t.setup());
   });
 
   afterAll(async () => {
@@ -76,15 +91,15 @@ describe('AMM benchmark', () => {
         // Register admin as sender in benchy's wallet, since we need it to discover the minted bananas
         await userWallet.registerSender(adminAddress);
         // Register both FPC and BananCoin on the user's Wallet so we can simulate and prove
-        await userWallet.registerContract(bananaFPC);
-        await userWallet.registerContract(bananaCoin);
+        await userWallet.registerContract(bananaFPCInstance, FPCContract.artifact);
+        await userWallet.registerContract(bananaCoinInstance, TokenContract.artifact);
         // Register the CandyBarCoin on the user's Wallet so we can simulate and prove
-        await userWallet.registerContract(candyBarCoin);
+        await userWallet.registerContract(candyBarCoinInstance);
         // Register the AMM and liquidity token on the user's Wallet so we can simulate and prove
-        await userWallet.registerContract(amm);
-        await userWallet.registerContract(liquidityToken);
+        await userWallet.registerContract(ammInstance, AMMContract.artifact);
+        await userWallet.registerContract(liquidityTokenInstance);
         // Register the sponsored FPC on the user's PXE so we can simulate and prove
-        await userWallet.registerContract(sponsoredFPC);
+        await userWallet.registerContract(sponsoredFPCInstance, SponsoredFPCContract.artifact);
       });
 
       function addLiquidityTest(benchmarkingPaymentMethod: BenchmarkingFeePaymentMethod) {

--- a/yarn-project/end-to-end/src/bench/client_flows/bridging.test.ts
+++ b/yarn-project/end-to-end/src/bench/client_flows/bridging.test.ts
@@ -1,8 +1,8 @@
 import { AztecAddress } from '@aztec/aztec.js/addresses';
 import type { SimulateInteractionOptions } from '@aztec/aztec.js/contracts';
 import type { Wallet } from '@aztec/aztec.js/wallet';
-import type { FPCContract } from '@aztec/noir-contracts.js/FPC';
-import type { SponsoredFPCContract } from '@aztec/noir-contracts.js/SponsoredFPC';
+import { FPCContract } from '@aztec/noir-contracts.js/FPC';
+import { SponsoredFPCContract } from '@aztec/noir-contracts.js/SponsoredFPC';
 import { TokenContract } from '@aztec/noir-contracts.js/Token';
 
 import { jest } from '@jest/globals';
@@ -19,12 +19,6 @@ describe('Bridging benchmark', () => {
   let userWallet: Wallet;
   // The admin that aids in the setup of the test
   let adminAddress: AztecAddress;
-  // FPC that accepts bananas
-  let bananaFPC: FPCContract;
-  // BananaCoin Token contract, which we want to use to pay for the bridging
-  let bananaCoin: TokenContract;
-  // Sponsored FPC contract
-  let sponsoredFPC: SponsoredFPCContract;
   // Benchmarking configuration
   const config = t.config.bridging;
 
@@ -33,7 +27,7 @@ describe('Bridging benchmark', () => {
     await t.applyDeployBananaTokenSnapshot();
     await t.applyFPCSetupSnapshot();
     await t.applyDeploySponsoredFPCSnapshot();
-    ({ userWallet, bananaFPC, bananaCoin, adminAddress, sponsoredFPC } = await t.setup());
+    ({ userWallet, adminAddress } = await t.setup());
   });
 
   afterAll(async () => {
@@ -52,6 +46,7 @@ describe('Bridging benchmark', () => {
       let crossChainTestHarness: CrossChainTestHarness;
 
       beforeEach(async () => {
+        const { bananaFPCInstance, bananaCoinInstance, sponsoredFPCInstance } = t;
         benchysAddress = await t.createAndFundBenchmarkingAccountOnUserWallet(accountType);
         // Benchy has FeeJuice now, so it can deploy the Token and bridge. This is required because
         // the brigde has an owner, which is the only one that can claim
@@ -61,10 +56,10 @@ describe('Bridging benchmark', () => {
         // Register admin as sender in benchy's wallet, since we need it to discover the minted bananas
         await userWallet.registerSender(adminAddress);
         // Register both FPC and BananCoin on the user's PXE so we can simulate and prove
-        await userWallet.registerContract(bananaFPC);
-        await userWallet.registerContract(bananaCoin);
+        await userWallet.registerContract(bananaFPCInstance, FPCContract.artifact);
+        await userWallet.registerContract(bananaCoinInstance, TokenContract.artifact);
         // Register the sponsored FPC on the user's PXE so we can simulate and prove
-        await userWallet.registerContract(sponsoredFPC);
+        await userWallet.registerContract(sponsoredFPCInstance, SponsoredFPCContract.artifact);
       });
 
       function privateClaimTest(benchmarkingPaymentMethod: BenchmarkingFeePaymentMethod) {

--- a/yarn-project/end-to-end/src/bench/client_flows/deployments.test.ts
+++ b/yarn-project/end-to-end/src/bench/client_flows/deployments.test.ts
@@ -1,9 +1,9 @@
 import { AztecAddress } from '@aztec/aztec.js/addresses';
-import type { SimulateInteractionOptions } from '@aztec/aztec.js/contracts';
+import type { ContractInstanceWithAddress, SimulateInteractionOptions } from '@aztec/aztec.js/contracts';
 import type { AztecNode } from '@aztec/aztec.js/node';
 import type { Wallet } from '@aztec/aztec.js/wallet';
 import { PrivateVotingContract } from '@aztec/noir-contracts.js/PrivateVoting';
-import type { SponsoredFPCContract } from '@aztec/noir-contracts.js/SponsoredFPC';
+import { SponsoredFPCContract } from '@aztec/noir-contracts.js/SponsoredFPC';
 import { getContractClassFromArtifact } from '@aztec/stdlib/contract';
 
 import { jest } from '@jest/globals';
@@ -20,7 +20,7 @@ describe('Deployment benchmark', () => {
   // The wallet used by the user to interact
   let userWallet: Wallet;
   // Sponsored FPC contract
-  let sponsoredFPC: SponsoredFPCContract;
+  let sponsoredFPCInstance: ContractInstanceWithAddress;
   // Benchmarking configuration
   const config = t.config.deployments;
 
@@ -28,7 +28,7 @@ describe('Deployment benchmark', () => {
     await t.applyBaseSnapshots();
     await t.applyDeploySponsoredFPCSnapshot();
 
-    ({ aztecNode: node, sponsoredFPC, userWallet } = await t.setup());
+    ({ aztecNode: node, userWallet, sponsoredFPCInstance } = await t.setup());
   });
 
   afterAll(async () => {
@@ -46,7 +46,7 @@ describe('Deployment benchmark', () => {
 
       beforeAll(async () => {
         benchysAddress = await t.createAndFundBenchmarkingAccountOnUserWallet(accountType);
-        await userWallet.registerContract(sponsoredFPC);
+        await userWallet.registerContract(sponsoredFPCInstance, SponsoredFPCContract.artifact);
       });
 
       function deploymentTest(benchmarkingPaymentMethod: BenchmarkingFeePaymentMethod) {

--- a/yarn-project/end-to-end/src/composed/docs_examples.test.ts
+++ b/yarn-project/end-to-end/src/composed/docs_examples.test.ts
@@ -43,7 +43,7 @@ describe('docs_examples', () => {
       .send({ from: defaultAccountAddress })
       .deployed();
 
-    const contract = await Contract.at(deployedContract.address, TokenContractArtifact, wallet);
+    const contract = Contract.at(deployedContract.address, TokenContractArtifact, wallet);
 
     await contract.methods.mint_to_public(newAccountAddress, 1).send({ from: defaultAccountAddress }).wait();
 

--- a/yarn-project/end-to-end/src/composed/e2e_local_network_example.test.ts
+++ b/yarn-project/end-to-end/src/composed/e2e_local_network_example.test.ts
@@ -66,7 +66,7 @@ describe('e2e_local_network_example', () => {
 
     const initialSupply = 1_000_000n;
 
-    const tokenContract = await deployToken(wallet, alice, initialSupply, logger);
+    const { contract: tokenContract } = await deployToken(wallet, alice, initialSupply, logger);
 
     ////////////// QUERYING THE TOKEN BALANCE FOR EACH ACCOUNT //////////////
 
@@ -174,7 +174,7 @@ describe('e2e_local_network_example', () => {
 
     ////////////// FUND A NEW ACCOUNT WITH BANANA COIN //////////////
     const bananaCoinAddress = await registerDeployedBananaCoinInWalletAndGetAddress(wallet);
-    const bananaCoin = await TokenContract.at(bananaCoinAddress, wallet);
+    const bananaCoin = TokenContract.at(bananaCoinAddress, wallet);
     const mintAmount = 10n ** 20n;
     await bananaCoin.methods.mint_to_private(alice, mintAmount).send({ from: fundedAccount }).wait();
 

--- a/yarn-project/end-to-end/src/devnet/e2e_smoke.test.ts
+++ b/yarn-project/end-to-end/src/devnet/e2e_smoke.test.ts
@@ -172,7 +172,7 @@ describe('End-to-end tests for devnet', () => {
     // );
 
     expect(txReceipt.status).toBe(TxStatus.SUCCESS);
-    const feeJuice = await FeeJuiceContract.at((await node.getNodeInfo()).protocolContractAddresses.feeJuice, wallet);
+    const feeJuice = FeeJuiceContract.at((await node.getNodeInfo()).protocolContractAddresses.feeJuice, wallet);
     const balance = await feeJuice.methods.balance_of_public(l2AccountAddress).simulate({ from: l2AccountAddress });
     expect(balance).toEqual(amount - txReceipt.transactionFee!);
   });

--- a/yarn-project/end-to-end/src/e2e_amm.test.ts
+++ b/yarn-project/end-to-end/src/e2e_amm.test.ts
@@ -45,9 +45,9 @@ describe('AMM', () => {
       logger,
     } = await setup(4));
 
-    token0 = await deployToken(wallet, adminAddress, 0n, logger);
-    token1 = await deployToken(wallet, adminAddress, 0n, logger);
-    liquidityToken = await deployToken(wallet, adminAddress, 0n, logger);
+    ({ contract: token0 } = await deployToken(wallet, adminAddress, 0n, logger));
+    ({ contract: token1 } = await deployToken(wallet, adminAddress, 0n, logger));
+    ({ contract: liquidityToken } = await deployToken(wallet, adminAddress, 0n, logger));
 
     amm = await AMMContract.deploy(wallet, token0.address, token1.address, liquidityToken.address)
       .send({ from: adminAddress })

--- a/yarn-project/end-to-end/src/e2e_authwit.test.ts
+++ b/yarn-project/end-to-end/src/e2e_authwit.test.ts
@@ -157,7 +157,7 @@ describe('e2e_authwit_tests', () => {
           isValidInPublic: true,
         });
 
-        const registry = await AuthRegistryContract.at(ProtocolContractAddress.AuthRegistry, wallet);
+        const registry = AuthRegistryContract.at(ProtocolContractAddress.AuthRegistry, wallet);
         await registry.methods.consume(account1Address, innerHash).send({ from: account2Address }).wait();
 
         expect(await wallet.lookupValidity(account1Address, intent, witness)).toEqual({
@@ -194,7 +194,7 @@ describe('e2e_authwit_tests', () => {
             isValidInPublic: false,
           });
 
-          const registry = await AuthRegistryContract.at(ProtocolContractAddress.AuthRegistry, wallet);
+          const registry = AuthRegistryContract.at(ProtocolContractAddress.AuthRegistry, wallet);
           await expect(
             registry.methods.consume(account1Address, innerHash).simulate({ from: account2Address }),
           ).rejects.toThrow(/unauthorized/);

--- a/yarn-project/end-to-end/src/e2e_avm_simulator.test.ts
+++ b/yarn-project/end-to-end/src/e2e_avm_simulator.test.ts
@@ -1,5 +1,5 @@
 import { AztecAddress } from '@aztec/aztec.js/addresses';
-import { BatchCall } from '@aztec/aztec.js/contracts';
+import { BatchCall, type ContractInstanceWithAddress } from '@aztec/aztec.js/contracts';
 import { Fr } from '@aztec/aztec.js/fields';
 import { TxStatus } from '@aztec/aztec.js/tx';
 import type { Wallet } from '@aztec/aztec.js/wallet';
@@ -32,10 +32,13 @@ describe('e2e_avm_simulator', () => {
 
   describe('AvmTestContract', () => {
     let avmContract: AvmTestContract;
+    let avmContractInstance: ContractInstanceWithAddress;
     let secondAvmContract: AvmTestContract;
 
     beforeEach(async () => {
-      avmContract = await AvmTestContract.deploy(wallet).send({ from: defaultAccountAddress }).deployed();
+      ({ contract: avmContract, instance: avmContractInstance } = await AvmTestContract.deploy(wallet)
+        .send({ from: defaultAccountAddress })
+        .wait());
       secondAvmContract = await AvmTestContract.deploy(wallet).send({ from: defaultAccountAddress }).deployed();
     });
 
@@ -146,9 +149,9 @@ describe('e2e_avm_simulator', () => {
         const tx = await avmContract.methods
           .test_get_contract_instance_matches(
             avmContract.address,
-            avmContract.instance.deployer,
-            avmContract.instance.currentContractClassId,
-            avmContract.instance.initializationHash,
+            avmContractInstance.deployer,
+            avmContractInstance.currentContractClassId,
+            avmContractInstance.initializationHash,
           )
           .send({ from: defaultAccountAddress })
           .wait();

--- a/yarn-project/end-to-end/src/e2e_blacklist_token_contract/blacklist_token_contract_test.ts
+++ b/yarn-project/end-to-end/src/e2e_blacklist_token_contract/blacklist_token_contract_test.ts
@@ -130,7 +130,7 @@ export class BlacklistTokenContractTest {
       },
       async ({ tokenContractAddress, badAccountAddress }) => {
         // Restore the token contract state.
-        this.asset = await TokenBlacklistContract.at(tokenContractAddress, this.wallet);
+        this.asset = TokenBlacklistContract.at(tokenContractAddress, this.wallet);
         this.logger.verbose(`Token contract address: ${this.asset.address}`);
 
         this.tokenSim = new TokenSimulator(
@@ -141,7 +141,7 @@ export class BlacklistTokenContractTest {
           [this.adminAddress, this.otherAddress, this.blacklistedAddress],
         );
 
-        this.badAccount = await InvalidAccountContract.at(badAccountAddress, this.wallet);
+        this.badAccount = InvalidAccountContract.at(badAccountAddress, this.wallet);
         this.logger.verbose(`Bad account address: ${this.badAccount.address}`);
 
         expect(await this.asset.methods.get_roles(this.adminAddress).simulate({ from: this.adminAddress })).toEqual(

--- a/yarn-project/end-to-end/src/e2e_cross_chain_messaging/cross_chain_messaging_test.ts
+++ b/yarn-project/end-to-end/src/e2e_cross_chain_messaging/cross_chain_messaging_test.ts
@@ -134,9 +134,9 @@ export class CrossChainMessagingTest {
 
         return this.crossChainTestHarness.toCrossChainContext();
       },
-      async crossChainContext => {
-        this.l2Token = await TokenContract.at(crossChainContext.l2Token, this.wallet);
-        this.l2Bridge = await TokenBridgeContract.at(crossChainContext.l2Bridge, this.wallet);
+      crossChainContext => {
+        this.l2Token = TokenContract.at(crossChainContext.l2Token, this.wallet);
+        this.l2Bridge = TokenBridgeContract.at(crossChainContext.l2Bridge, this.wallet);
 
         // There is an issue with the reviver so we are getting strings sometimes. Working around it here.
         this.ethAccount = EthAddress.fromString(crossChainContext.ethAccount.toString());
@@ -172,6 +172,7 @@ export class CrossChainMessagingTest {
         this.l1Client = l1Client;
         this.inbox = inbox;
         this.outbox = outbox;
+        return Promise.resolve();
       },
     );
   }

--- a/yarn-project/end-to-end/src/e2e_deploy_contract/contract_class_registration.test.ts
+++ b/yarn-project/end-to-end/src/e2e_deploy_contract/contract_class_registration.test.ts
@@ -167,7 +167,7 @@ describe('e2e_deploy_contract contract class registration', () => {
           deployer: opts.deployer,
         });
         expect(registered.address).toEqual(instance.address);
-        const contract = await StatefulTestContract.at(instance.address, wallet);
+        const contract = StatefulTestContract.at(instance.address, wallet);
         return { contract, initArgs, instance, publicKeys };
       };
 
@@ -297,7 +297,7 @@ describe('e2e_deploy_contract contract class registration', () => {
 
   testDeployingAnInstance('from a contract', async instance => {
     // Register the instance to be deployed in the pxe
-    await wallet.registerContract({ artifact, instance });
+    await wallet.registerContract(instance, artifact);
     // Set up the contract that calls the deployer (which happens to be the TestContract) and call it
     const deployer = await TestContract.deploy(wallet).send({ from: defaultAccountAddress }).deployed();
     await deployer.methods.publish_contract_instance(instance.address).send({ from: defaultAccountAddress }).wait();

--- a/yarn-project/end-to-end/src/e2e_deploy_contract/deploy_method.test.ts
+++ b/yarn-project/end-to-end/src/e2e_deploy_contract/deploy_method.test.ts
@@ -46,9 +46,9 @@ describe('e2e_deploy_contract deploy method', () => {
     logger.debug(`Calling public method on stateful test contract at ${contract.address.toString()}`);
     await contract.methods.increment_public_value(owner, 84).send({ from: defaultAccountAddress }).wait();
     expect(await contract.methods.get_public_value(owner).simulate({ from: defaultAccountAddress })).toEqual(84n);
+    const instance = (await wallet.getContractMetadata(contract.address)).contractInstance!;
     expect(
-      (await wallet.getContractClassMetadata(contract.instance.currentContractClassId))
-        .isContractClassPubliclyRegistered,
+      (await wallet.getContractClassMetadata(instance.currentContractClassId)).isContractClassPubliclyRegistered,
     ).toBeTrue();
   });
 

--- a/yarn-project/end-to-end/src/e2e_deploy_contract/deploy_test.ts
+++ b/yarn-project/end-to-end/src/e2e_deploy_contract/deploy_test.ts
@@ -73,6 +73,6 @@ export class DeployTest {
 export type StatefulContractCtorArgs = Parameters<StatefulTestContract['methods']['constructor']>;
 
 export type ContractArtifactClass<T extends ContractBase> = {
-  at(address: AztecAddress, wallet: Wallet): Promise<T>;
+  at(address: AztecAddress, wallet: Wallet): T;
   artifact: ContractArtifact;
 };

--- a/yarn-project/end-to-end/src/e2e_fees/fees_test.ts
+++ b/yarn-project/end-to-end/src/e2e_fees/fees_test.ts
@@ -197,7 +197,7 @@ export class FeesTest {
         this.fpcAdmin = this.aliceAddress;
 
         const canonicalFeeJuice = await getCanonicalFeeJuice();
-        this.feeJuiceContract = await FeeJuiceContract.at(canonicalFeeJuice.address, this.wallet);
+        this.feeJuiceContract = FeeJuiceContract.at(canonicalFeeJuice.address, this.wallet);
       },
     );
   }
@@ -215,7 +215,7 @@ export class FeesTest {
       async (_data, context) => {
         this.context = context;
 
-        this.feeJuiceContract = await FeeJuiceContract.at(ProtocolContractAddress.FeeJuice, this.wallet);
+        this.feeJuiceContract = FeeJuiceContract.at(ProtocolContractAddress.FeeJuice, this.wallet);
 
         this.getGasBalanceFn = getBalancesFn(
           '⛽',
@@ -245,8 +245,8 @@ export class FeesTest {
         this.logger.info(`BananaCoin deployed at ${bananaCoin.address}`);
         return { bananaCoinAddress: bananaCoin.address };
       },
-      async ({ bananaCoinAddress }) => {
-        this.bananaCoin = await BananaCoin.at(bananaCoinAddress, this.wallet);
+      ({ bananaCoinAddress }) => {
+        this.bananaCoin = BananaCoin.at(bananaCoinAddress, this.wallet);
         const logger = this.logger;
         this.getBananaPublicBalanceFn = getBalancesFn(
           '🍌.public',
@@ -260,6 +260,7 @@ export class FeesTest {
           this.aliceAddress,
           logger,
         );
+        return Promise.resolve();
       },
     );
   }
@@ -287,8 +288,8 @@ export class FeesTest {
           rollupAddress: context.deployL1ContractsValues.l1ContractAddresses.rollupAddress,
         };
       },
-      async (data, context) => {
-        const bananaFPC = await FPCContract.at(data.bananaFPCAddress, this.wallet);
+      (data, context) => {
+        const bananaFPC = FPCContract.at(data.bananaFPCAddress, this.wallet);
         this.bananaFPC = bananaFPC;
 
         this.getCoinbaseBalance = async () => {
@@ -328,6 +329,7 @@ export class FeesTest {
           const mana = block!.header.totalManaUsed.toBigInt();
           return mulDiv(mana * proverCost, price, 10n ** 9n);
         };
+        return Promise.resolve();
       },
     );
   }
@@ -346,8 +348,9 @@ export class FeesTest {
           sponsoredFPCAddress: sponsoredFPC.address,
         };
       },
-      async data => {
-        this.sponsoredFPC = await SponsoredFPCContract.at(data.sponsoredFPCAddress, this.wallet);
+      data => {
+        this.sponsoredFPC = SponsoredFPCContract.at(data.sponsoredFPCAddress, this.wallet);
+        return Promise.resolve();
       },
     );
   }

--- a/yarn-project/end-to-end/src/e2e_kernelless_simulation.test.ts
+++ b/yarn-project/end-to-end/src/e2e_kernelless_simulation.test.ts
@@ -45,9 +45,9 @@ describe('Kernelless simulation', () => {
       logger,
     } = await setup(2));
 
-    token0 = await deployToken(wallet, adminAddress, 0n, logger);
-    token1 = await deployToken(wallet, adminAddress, 0n, logger);
-    liquidityToken = await deployToken(wallet, adminAddress, 0n, logger);
+    ({ contract: token0 } = await deployToken(wallet, adminAddress, 0n, logger));
+    ({ contract: token1 } = await deployToken(wallet, adminAddress, 0n, logger));
+    ({ contract: liquidityToken } = await deployToken(wallet, adminAddress, 0n, logger));
 
     amm = await AMMContract.deploy(wallet, token0.address, token1.address, liquidityToken.address)
       .send({ from: adminAddress })

--- a/yarn-project/end-to-end/src/e2e_multiple_accounts_1_enc_key.test.ts
+++ b/yarn-project/end-to-end/src/e2e_multiple_accounts_1_enc_key.test.ts
@@ -41,7 +41,7 @@ describe('e2e_multiple_accounts_1_enc_key', () => {
     ({ teardown, logger, wallet, accounts } = await setup(numAccounts, { initialFundedAccounts }));
     logger.info('Account contracts deployed');
 
-    token = await deployToken(wallet, accounts[0], initialBalance, logger);
+    ({ contract: token } = await deployToken(wallet, accounts[0], initialBalance, logger));
   });
 
   afterEach(() => teardown());
@@ -57,7 +57,7 @@ describe('e2e_multiple_accounts_1_enc_key', () => {
     const sender = accounts[senderIndex];
     const receiver = accounts[receiverIndex];
 
-    const contractWithWallet = await TokenContract.at(token.address, wallet);
+    const contractWithWallet = TokenContract.at(token.address, wallet);
 
     await contractWithWallet.methods.transfer(receiver, transferAmount).send({ from: accounts[senderIndex] }).wait();
 

--- a/yarn-project/end-to-end/src/e2e_nested_contract/nested_contract_test.ts
+++ b/yarn-project/end-to-end/src/e2e_nested_contract/nested_contract_test.ts
@@ -86,9 +86,10 @@ export class NestedContractTest {
           .deployed();
         return { parentContractAddress: parentContract.address, childContractAddress: childContract.address };
       },
-      async ({ parentContractAddress, childContractAddress }) => {
-        this.parentContract = await ParentContract.at(parentContractAddress, this.wallet);
-        this.childContract = await ChildContract.at(childContractAddress, this.wallet);
+      ({ parentContractAddress, childContractAddress }) => {
+        this.parentContract = ParentContract.at(parentContractAddress, this.wallet);
+        this.childContract = ChildContract.at(childContractAddress, this.wallet);
+        return Promise.resolve();
       },
     );
   }

--- a/yarn-project/end-to-end/src/e2e_orderbook.test.ts
+++ b/yarn-project/end-to-end/src/e2e_orderbook.test.ts
@@ -49,8 +49,8 @@ describe('Orderbook', () => {
       logger,
     } = await setup(3));
 
-    token0 = await deployToken(wallet, adminAddress, 0n, logger);
-    token1 = await deployToken(wallet, adminAddress, 0n, logger);
+    ({ contract: token0 } = await deployToken(wallet, adminAddress, 0n, logger));
+    ({ contract: token1 } = await deployToken(wallet, adminAddress, 0n, logger));
 
     orderbook = await OrderbookContract.deploy(wallet, token0.address, token1.address)
       .send({ from: adminAddress })

--- a/yarn-project/end-to-end/src/e2e_p2p/p2p_network.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/p2p_network.ts
@@ -326,11 +326,12 @@ export class P2PNetworkTest {
           .deployed();
         return { contractAddress: spamContract.address };
       },
-      async ({ contractAddress }) => {
+      ({ contractAddress }) => {
         if (!this.wallet) {
           throw new Error('Call snapshot t.setupAccount before deploying account contract');
         }
-        this.spamContract = await SpamContract.at(contractAddress, this.wallet);
+        this.spamContract = SpamContract.at(contractAddress, this.wallet);
+        return Promise.resolve();
       },
     );
   }

--- a/yarn-project/end-to-end/src/e2e_p2p/shared.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/shared.ts
@@ -80,7 +80,7 @@ export async function prepareTransactions(
     salt: Fr.random(),
   });
   await wallet.registerContract(testContractInstance, TestContractArtifact);
-  const contract = await TestContract.at(testContractInstance.address, wallet);
+  const contract = TestContract.at(testContractInstance.address, wallet);
 
   return timesAsync(numTxs, async () => {
     const tx = await proveInteraction(wallet, contract.methods.emit_nullifier(Fr.random()), {

--- a/yarn-project/end-to-end/src/e2e_partial_notes.test.ts
+++ b/yarn-project/end-to-end/src/e2e_partial_notes.test.ts
@@ -34,7 +34,8 @@ describe('partial notes', () => {
       logger,
     } = await setup(2));
 
-    token0 = await deployToken(wallet, adminAddress, 0n, logger);
+    const { contract } = await deployToken(wallet, adminAddress, 0n, logger);
+    token0 = contract;
   });
 
   afterAll(() => teardown());

--- a/yarn-project/end-to-end/src/e2e_token_contract/token_contract_test.ts
+++ b/yarn-project/end-to-end/src/e2e_token_contract/token_contract_test.ts
@@ -90,7 +90,7 @@ export class TokenContractTest {
       },
       async ({ tokenContractAddress, badAccountAddress }) => {
         // Restore the token contract state.
-        this.asset = await TokenContract.at(tokenContractAddress, this.wallet);
+        this.asset = TokenContract.at(tokenContractAddress, this.wallet);
         this.logger.verbose(`Token contract address: ${this.asset.address}`);
 
         this.tokenSim = new TokenSimulator(this.asset, this.wallet, this.adminAddress, this.logger, [
@@ -98,7 +98,7 @@ export class TokenContractTest {
           this.account1Address,
         ]);
 
-        this.badAccount = await InvalidAccountContract.at(badAccountAddress, this.wallet);
+        this.badAccount = InvalidAccountContract.at(badAccountAddress, this.wallet);
         this.logger.verbose(`Bad account address: ${this.badAccount.address}`);
 
         expect(await this.asset.methods.get_admin().simulate({ from: this.adminAddress })).toBe(

--- a/yarn-project/end-to-end/src/fixtures/token_utils.ts
+++ b/yarn-project/end-to-end/src/fixtures/token_utils.ts
@@ -6,9 +6,9 @@ import { TokenContract } from '@aztec/noir-contracts.js/Token';
 
 export async function deployToken(wallet: Wallet, admin: AztecAddress, initialAdminBalance: bigint, logger: Logger) {
   logger.info(`Deploying Token contract...`);
-  const contract = await TokenContract.deploy(wallet, admin, 'TokenName', 'TokenSymbol', 18)
+  const { contract, instance } = await TokenContract.deploy(wallet, admin, 'TokenName', 'TokenSymbol', 18)
     .send({ from: admin })
-    .deployed();
+    .wait();
 
   if (initialAdminBalance > 0n) {
     await mintTokensToPrivate(contract, admin, admin, initialAdminBalance);
@@ -16,7 +16,7 @@ export async function deployToken(wallet: Wallet, admin: AztecAddress, initialAd
 
   logger.info('L2 contract deployed');
 
-  return contract;
+  return { contract, instance };
 }
 
 export async function mintTokensToPrivate(
@@ -36,7 +36,7 @@ export async function expectTokenBalance(
   logger: Logger,
 ) {
   // Then check the balance
-  const contractWithWallet = await TokenContract.at(token.address, wallet);
+  const contractWithWallet = TokenContract.at(token.address, wallet);
   const balance = await contractWithWallet.methods.balance_of_private(owner).simulate({ from: owner });
   logger.info(`Account ${owner} balance: ${balance}`);
   expect(balance).toBe(expectedBalance);

--- a/yarn-project/end-to-end/src/fixtures/utils.ts
+++ b/yarn-project/end-to-end/src/fixtures/utils.ts
@@ -858,7 +858,7 @@ export async function setupSponsoredFPC(wallet: Wallet) {
     salt: new Fr(SPONSORED_FPC_SALT),
   });
 
-  await wallet.registerContract({ instance, artifact: SponsoredFPCContract.artifact });
+  await wallet.registerContract(instance, SponsoredFPCContract.artifact);
   getLogger().info(`SponsoredFPC: ${instance.address}`);
   return instance;
 }
@@ -868,7 +868,7 @@ export async function setupSponsoredFPC(wallet: Wallet) {
  * @param wallet - The wallet
  */
 export async function registerSponsoredFPC(wallet: Wallet): Promise<void> {
-  await wallet.registerContract({ instance: await getSponsoredFPCInstance(), artifact: SponsoredFPCContract.artifact });
+  await wallet.registerContract(await getSponsoredFPCInstance(), SponsoredFPCContract.artifact);
 }
 
 export async function waitForProvenChain(node: AztecNode, targetBlock?: number, timeoutSec = 60, intervalSec = 1) {

--- a/yarn-project/end-to-end/src/shared/gas_portal_test_harness.ts
+++ b/yarn-project/end-to-end/src/shared/gas_portal_test_harness.ts
@@ -43,7 +43,7 @@ export class FeeJuicePortalTestingHarnessFactory {
       throw new Error('Fee Juice portal not deployed on L1');
     }
 
-    const gasL2 = await FeeJuiceContract.at(ProtocolContractAddress.FeeJuice, wallet);
+    const gasL2 = FeeJuiceContract.at(ProtocolContractAddress.FeeJuice, wallet);
 
     return new GasBridgingTestHarness(
       aztecNode,

--- a/yarn-project/end-to-end/src/spartan/setup_test_wallets.ts
+++ b/yarn-project/end-to-end/src/spartan/setup_test_wallets.ts
@@ -49,7 +49,7 @@ export async function setupTestAccountsWithTokens(
 
   const tokenAdmin = accounts[0];
   const tokenAddress = await deployTokenAndMint(wallet, accounts, tokenAdmin, mintAmount, undefined, logger);
-  const tokenContract = await TokenContract.at(tokenAddress, wallet);
+  const tokenContract = TokenContract.at(tokenAddress, wallet);
 
   return {
     aztecNode,
@@ -96,7 +96,7 @@ export async function deploySponsoredTestAccounts(
     new SponsoredFeePaymentMethod(await getSponsoredFPCAddress()),
     logger,
   );
-  const tokenContract = await TokenContract.at(tokenAddress, wallet);
+  const tokenContract = TokenContract.at(tokenAddress, wallet);
 
   return {
     aztecNode,
@@ -152,7 +152,7 @@ export async function deployTestAccountsWithTokens(
     undefined,
     logger,
   );
-  const tokenContract = await TokenContract.at(tokenAddress, wallet);
+  const tokenContract = TokenContract.at(tokenAddress, wallet);
 
   return {
     aztecNode,
@@ -228,9 +228,9 @@ async function deployTokenAndMint(
   logger.verbose(`Minting ${mintAmount} public assets to the ${accounts.length} accounts...`);
 
   await Promise.all(
-    accounts.map(async acc =>
-      (await TokenContract.at(tokenAddress, wallet)).methods
-        .mint_to_public(acc, mintAmount)
+    accounts.map(acc =>
+      TokenContract.at(tokenAddress, wallet)
+        .methods.mint_to_public(acc, mintAmount)
         .send({ from: admin, fee: { paymentMethod } })
         .wait({ timeout: 600 }),
     ),
@@ -260,8 +260,8 @@ export async function performTransfers({
   // Default to sponsored fee payment if no fee method is provided
   const defaultFeePaymentMethod = feePaymentMethod || new SponsoredFeePaymentMethod(await getSponsoredFPCAddress());
   for (let i = 0; i < rounds; i++) {
-    const txs = testAccounts.accounts.map(async acc => {
-      const token = await TokenContract.at(testAccounts.tokenAddress, testAccounts.wallet);
+    const txs = testAccounts.accounts.map(acc => {
+      const token = TokenContract.at(testAccounts.tokenAddress, testAccounts.wallet);
       return proveInteraction(wallet, token.methods.transfer_in_public(acc, recipient, transferAmount, 0), {
         from: acc,
         fee: {

--- a/yarn-project/end-to-end/src/spartan/transfer.test.ts
+++ b/yarn-project/end-to-end/src/spartan/transfer.test.ts
@@ -75,7 +75,7 @@ describe('token transfer test', () => {
     // For each round, make both private and public transfers
     for (let i = 1n; i <= ROUNDS; i++) {
       const txs = testAccounts.accounts.map(async a => {
-        const token = await TokenContract.at(testAccounts.tokenAddress, testAccounts.wallet);
+        const token = TokenContract.at(testAccounts.tokenAddress, testAccounts.wallet);
         return proveInteraction(wallet, token.methods.transfer_in_public(a, recipient, transferAmount, 0), {
           from: a,
           fee: {

--- a/yarn-project/pxe/src/contract_function_simulator/execution_data_provider.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/execution_data_provider.ts
@@ -1,6 +1,6 @@
 import type { L1_TO_L2_MSG_TREE_HEIGHT } from '@aztec/constants';
 import type { Fr, Point } from '@aztec/foundation/fields';
-import type { FunctionArtifact, FunctionArtifactWithContractName, FunctionSelector } from '@aztec/stdlib/abi';
+import type { FunctionArtifactWithContractName, FunctionSelector } from '@aztec/stdlib/abi';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
 import type { L2Block } from '@aztec/stdlib/block';
 import type { CompleteAddress, ContractInstance } from '@aztec/stdlib/contract';
@@ -105,16 +105,6 @@ export interface ExecutionDataProvider {
    * @param selector - The corresponding function selector.
    */
   getDebugFunctionName(contractAddress: AztecAddress, selector: FunctionSelector): Promise<string>;
-
-  /**
-   * Retrieves the artifact of a specified function within a given contract.
-   * The function is identified by its name, which is unique within a contract.
-   *
-   * @param contractAddress - The AztecAddress representing the contract containing the function.
-   * @param functionName - The name of the function.
-   * @returns The corresponding function's artifact as an object.
-   */
-  getFunctionArtifactByName(contractAddress: AztecAddress, functionName: string): Promise<FunctionArtifact | undefined>;
 
   /**
    * Gets the index of a nullifier in the nullifier tree.

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution.test.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution.test.ts
@@ -316,18 +316,6 @@ describe('Private Execution test suite', () => {
       return Promise.resolve(artifact);
     });
 
-    executionDataProvider.getFunctionArtifactByName.mockImplementation((address, name) => {
-      const contract = contracts[address.toString()];
-      if (!contract) {
-        throw new Error(`Contract not found: ${address}`);
-      }
-      const artifact = getFunctionArtifactByName(contract, name);
-      if (!artifact) {
-        throw new Error(`Function not found: ${name} in contract ${address}`);
-      }
-      return Promise.resolve(artifact);
-    });
-
     executionDataProvider.syncTaggedLogs.mockImplementation((_, __) => Promise.resolve());
     // Provide tagging-related mocks expected by private log emission
     executionDataProvider.calculateDirectionalAppTaggingSecret.mockImplementation((_contract, _sender, _recipient) => {

--- a/yarn-project/pxe/src/contract_function_simulator/pxe_oracle_interface.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/pxe_oracle_interface.ts
@@ -3,12 +3,7 @@ import { timesParallel } from '@aztec/foundation/collection';
 import { Fr, Point } from '@aztec/foundation/fields';
 import { createLogger } from '@aztec/foundation/log';
 import type { KeyStore } from '@aztec/key-store';
-import {
-  EventSelector,
-  type FunctionArtifactWithContractName,
-  FunctionSelector,
-  getFunctionArtifact,
-} from '@aztec/stdlib/abi';
+import { EventSelector, type FunctionArtifactWithContractName, FunctionSelector } from '@aztec/stdlib/abi';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import type { InBlock, L2Block, L2BlockNumber } from '@aztec/stdlib/block';
 import type { CompleteAddress, ContractInstance } from '@aztec/stdlib/contract';
@@ -127,18 +122,6 @@ export class PXEOracleInterface implements ExecutionDataProvider {
       ...artifact,
       debug,
     };
-  }
-
-  async getFunctionArtifactByName(
-    contractAddress: AztecAddress,
-    functionName: string,
-  ): Promise<FunctionArtifactWithContractName | undefined> {
-    const instance = await this.contractDataProvider.getContractInstance(contractAddress);
-    if (!instance) {
-      return;
-    }
-    const artifact = await this.contractDataProvider.getContractArtifact(instance.currentContractClassId);
-    return artifact && getFunctionArtifact(artifact, functionName);
   }
 
   /**

--- a/yarn-project/pxe/src/storage/contract_data_provider/contract_data_provider.ts
+++ b/yarn-project/pxe/src/storage/contract_data_provider/contract_data_provider.ts
@@ -184,23 +184,6 @@ export class ContractDataProvider {
     return fnArtifact && { ...fnArtifact, contractName: artifact.name };
   }
 
-  /**
-   * Retrieves the artifact of a specified function within a given contract.
-   * The function is identified by its name, which is unique within a contract.
-   * Throws if the contract has not been added to the database.
-   *
-   * @param contractAddress - The AztecAddress representing the contract containing the function.
-   * @param functionName - The name of the function.
-   * @returns The corresponding function's artifact as an object
-   */
-  public async getFunctionArtifactByName(
-    contractAddress: AztecAddress,
-    functionName: string,
-  ): Promise<FunctionArtifact | undefined> {
-    const artifact = await this.#getContractArtifactByAddress(contractAddress);
-    return artifact?.functions.find(fn => fn.name === functionName);
-  }
-
   public async getFunctionAbi(
     contractAddress: AztecAddress,
     selector: FunctionSelector,


### PR DESCRIPTION
Closes: https://linear.app/aztec-labs/issue/F-73/refactor-registercontract, https://linear.app/aztec-labs/issue/F-134/cannot-registercontract-and-simulatesend-on-the-same-walletbatch-using

This PR greatly simplifies `registerContract` on the wallet interface, while at the same time makes the registering flow more explicit. In the past we were just spamming registrations, which is a no-go for real wallets due to the size of artifacts. 

Furthermore, it simplifies our contract interfaces by removing the instance from them. They were previously always retrieved from the wallet (again, very costly) while instances are only required:

* When an app first registers a contract
* When an app tries to update a contract

If an app needs a contract instance, it can use any of these methods (which it was inadvertedly doing before!)
* Generate it via `getContractInstanceFromInstantiationParams`
* Get it from the node provided the instance is published
* Get it from the result of `Contract.deploy().send().wait()` (if you deploy you know the instance already!)