### PR TITLE
chore: re-org merge and corresponding tests

### DIFF
--- a/barretenberg/cpp/src/barretenberg/boomerang_value_detection/graph_description_merge_recursive_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/boomerang_value_detection/graph_description_merge_recursive_verifier.test.cpp
@@ -2,10 +2,10 @@
 #include "barretenberg/circuit_checker/circuit_checker.hpp"
 #include "barretenberg/common/test.hpp"
 #include "barretenberg/ecc/fields/field_conversion.hpp"
+#include "barretenberg/goblin/merge_prover.hpp"
+#include "barretenberg/goblin/merge_verifier.hpp"
 #include "barretenberg/goblin/mock_circuits.hpp"
 #include "barretenberg/stdlib/primitives/curves/bn254.hpp"
-#include "barretenberg/ultra_honk/merge_prover.hpp"
-#include "barretenberg/ultra_honk/merge_verifier.hpp"
 #include "barretenberg/ultra_honk/ultra_prover.hpp"
 #include "barretenberg/ultra_honk/ultra_verifier.hpp"
 

--- a/barretenberg/cpp/src/barretenberg/goblin/goblin.cpp
+++ b/barretenberg/cpp/src/barretenberg/goblin/goblin.cpp
@@ -9,10 +9,10 @@
 #include "barretenberg/common/assert.hpp"
 #include "barretenberg/common/bb_bench.hpp"
 #include "barretenberg/eccvm/eccvm_verifier.hpp"
+#include "barretenberg/goblin/merge_verifier.hpp"
 #include "barretenberg/translator_vm/translator_prover.hpp"
 #include "barretenberg/translator_vm/translator_proving_key.hpp"
 #include "barretenberg/translator_vm/translator_verifier.hpp"
-#include "barretenberg/ultra_honk/merge_verifier.hpp"
 #include <utility>
 
 namespace bb {

--- a/barretenberg/cpp/src/barretenberg/goblin/goblin.hpp
+++ b/barretenberg/cpp/src/barretenberg/goblin/goblin.hpp
@@ -10,12 +10,12 @@
 #include "barretenberg/eccvm/eccvm_flavor.hpp"
 #include "barretenberg/eccvm/eccvm_prover.hpp"
 #include "barretenberg/flavor/mega_flavor.hpp"
+#include "barretenberg/goblin/merge_prover.hpp"
+#include "barretenberg/goblin/merge_verifier.hpp"
 #include "barretenberg/goblin/types.hpp"
 #include "barretenberg/stdlib/proof/proof.hpp"
 #include "barretenberg/translator_vm/translator_circuit_builder.hpp"
 #include "barretenberg/translator_vm/translator_flavor.hpp"
-#include "barretenberg/ultra_honk/merge_prover.hpp"
-#include "barretenberg/ultra_honk/merge_verifier.hpp"
 #include "barretenberg/ultra_honk/prover_instance.hpp"
 
 namespace bb {

--- a/barretenberg/cpp/src/barretenberg/goblin/merge.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/goblin/merge.test.cpp
@@ -1,0 +1,267 @@
+#include <cstddef>
+#include <cstdint>
+#include <gtest/gtest.h>
+
+#include "barretenberg/goblin/merge_prover.hpp"
+#include "barretenberg/goblin/merge_verifier.hpp"
+#include "barretenberg/goblin/mock_circuits.hpp"
+#include "barretenberg/stdlib_circuit_builders/mega_circuit_builder.hpp"
+#include "barretenberg/ultra_honk/ultra_prover.hpp"
+#include "barretenberg/ultra_honk/ultra_verifier.hpp"
+
+using namespace bb;
+
+auto& engine = numeric::get_debug_randomness();
+
+using FlavorTypes = ::testing::Types<MegaFlavor, MegaZKFlavor>;
+
+template <typename Flavor> class MergeTests : public ::testing::Test {
+  public:
+    static void SetUpTestSuite() { bb::srs::init_file_crs_factory(bb::srs::bb_crs_path()); }
+
+    using Curve = curve::BN254;
+    using FF = Curve::ScalarField;
+    using Point = Curve::AffineElement;
+    using CommitmentKey = bb::CommitmentKey<Curve>;
+    using Prover = UltraProver_<Flavor>;
+    using Verifier = UltraVerifier_<Flavor>;
+    using VerificationKey = typename Flavor::VerificationKey;
+    using ProverInstance = ProverInstance_<Flavor>;
+    using VerifierInstance = VerifierInstance_<Flavor>;
+
+    /**
+     * @brief Construct and a verify a Honk proof
+     *
+     */
+    bool construct_and_verify_honk_proof(auto& builder)
+    {
+        auto prover_instance = std::make_shared<ProverInstance>(builder);
+        auto verification_key = std::make_shared<VerificationKey>(prover_instance->get_precomputed());
+        Prover prover(prover_instance, verification_key);
+        Verifier verifier(verification_key);
+        auto proof = prover.construct_proof();
+        bool verified = verifier.template verify_proof<DefaultIO>(proof).result;
+
+        return verified;
+    }
+
+    /**
+     * @brief Construct and verify a Goblin ECC op queue merge proof
+     *
+     */
+    bool construct_and_verify_merge_proof(auto& op_queue, MergeSettings settings = MergeSettings::PREPEND)
+    {
+        MergeProver merge_prover{ op_queue, settings };
+        auto merge_proof = merge_prover.construct_proof();
+
+        // Construct Merge commitments
+        MergeVerifier::InputCommitments merge_commitments;
+        auto t_current = op_queue->construct_current_ultra_ops_subtable_columns();
+        auto T_prev = op_queue->construct_previous_ultra_ops_table_columns();
+        for (size_t idx = 0; idx < Flavor::NUM_WIRES; idx++) {
+            merge_commitments.t_commitments[idx] = merge_prover.pcs_commitment_key.commit(t_current[idx]);
+            merge_commitments.T_prev_commitments[idx] = merge_prover.pcs_commitment_key.commit(T_prev[idx]);
+        }
+
+        auto transcript = std::make_shared<NativeTranscript>();
+        MergeVerifier merge_verifier{ settings, transcript };
+        auto [pairing_points, _, degree_check_passed, concatenation_check_passed] =
+            merge_verifier.verify_proof(merge_proof, merge_commitments);
+
+        return pairing_points.check() && degree_check_passed && concatenation_check_passed;
+    }
+};
+
+TYPED_TEST_SUITE(MergeTests, FlavorTypes);
+
+/**
+ * @brief Check that size of a merge proof matches the corresponding constant
+ * @details This is useful for ensuring correct construction of mock merge proofs
+ *
+ */
+TYPED_TEST(MergeTests, MergeProofSizeCheck)
+{
+    using Flavor = TypeParam;
+
+    auto builder = typename Flavor::CircuitBuilder{};
+    GoblinMockCircuits::construct_simple_circuit(builder);
+
+    // Construct a merge proof and ensure its size matches expectation; if not, the constant may need to be updated
+    MergeProver merge_prover{ builder.op_queue };
+    auto merge_proof = merge_prover.construct_proof();
+
+    EXPECT_EQ(merge_proof.size(), MERGE_PROOF_SIZE);
+}
+
+/**
+ * @brief Test proof construction/verification for a circuit with ECC op gates, public inputs, and basic arithmetic
+ * gates
+ * @note We simulate op queue interactions with a previous circuit so the actual circuit under test utilizes an op queue
+ * with non-empty 'previous' data. This avoid complications with zero-commitments etc.
+ *
+ */
+TYPED_TEST(MergeTests, SingleCircuit)
+{
+    using Flavor = TypeParam;
+    auto builder = typename Flavor::CircuitBuilder{};
+
+    GoblinMockCircuits::construct_simple_circuit(builder);
+
+    // Construct and verify Honk proof
+    bool honk_verified = this->construct_and_verify_honk_proof(builder);
+    EXPECT_TRUE(honk_verified);
+
+    // Construct and verify Goblin ECC op queue Merge proof
+    auto merge_verified = this->construct_and_verify_merge_proof(builder.op_queue);
+    EXPECT_TRUE(merge_verified);
+}
+
+/**
+ * @brief Test Merge proof construction/verification for multiple circuits with ECC op gates, public inputs, and
+ * basic arithmetic gates
+ *
+ */
+TYPED_TEST(MergeTests, MultipleCircuitsMergeOnly)
+{
+    using Flavor = TypeParam;
+    // Instantiate EccOpQueue. This will be shared across all circuits in the series
+    auto op_queue = std::make_shared<bb::ECCOpQueue>();
+    // Construct multiple test circuits that share an ECC op queue. Generate and verify a proof for each.
+    size_t NUM_CIRCUITS = 3;
+    for (size_t i = 0; i < NUM_CIRCUITS; ++i) {
+        auto builder = typename Flavor::CircuitBuilder{ op_queue };
+
+        GoblinMockCircuits::construct_simple_circuit(builder);
+
+        // Construct and verify Goblin ECC op queue Merge proof
+        auto merge_verified = this->construct_and_verify_merge_proof(op_queue);
+        EXPECT_TRUE(merge_verified);
+    }
+}
+
+/**
+ * @brief Test Honk proof construction/verification for multiple circuits with ECC op gates, public inputs, and
+ * basic arithmetic gates
+ *
+ */
+TYPED_TEST(MergeTests, MultipleCircuitsHonkOnly)
+{
+    using Flavor = TypeParam;
+
+    // Instantiate EccOpQueue. This will be shared across all circuits in the series
+    auto op_queue = std::make_shared<bb::ECCOpQueue>();
+    // Construct multiple test circuits that share an ECC op queue. Generate and verify a proof for each.
+    size_t NUM_CIRCUITS = 3;
+    for (size_t i = 0; i < NUM_CIRCUITS; ++i) {
+        auto builder = typename Flavor::CircuitBuilder{ op_queue };
+        GoblinMockCircuits::construct_simple_circuit(builder);
+        // Construct and verify Honk proof
+        bool honk_verified = this->construct_and_verify_honk_proof(builder);
+        EXPECT_TRUE(honk_verified);
+        // Artificially merge the op queue sincer we're not running the merge protocol in this test
+        builder.op_queue->merge();
+    }
+}
+
+TYPED_TEST(MergeTests, MultipleCircuitsMergeOnlyPrependThenAppend)
+{
+    using Flavor = TypeParam;
+    // Instantiate EccOpQueue. This will be shared across all circuits in the series
+    auto op_queue = std::make_shared<bb::ECCOpQueue>();
+    // Construct multiple test circuits that share an ECC op queue. Generate and verify a proof for each.
+    size_t NUM_CIRCUITS = 3;
+    for (size_t i = 0; i < NUM_CIRCUITS; ++i) {
+        auto builder = typename Flavor::CircuitBuilder{ op_queue };
+
+        GoblinMockCircuits::construct_simple_circuit(builder);
+
+        // Construct and verify Goblin ECC op queue Merge proof
+        auto merge_verified = this->construct_and_verify_merge_proof(op_queue);
+        EXPECT_TRUE(merge_verified);
+    }
+
+    // Construct a final circuit and append its ecc ops to the op queue
+    auto builder = typename Flavor::CircuitBuilder{ op_queue };
+
+    GoblinMockCircuits::construct_simple_circuit(builder);
+
+    // Construct and verify Goblin ECC op queue Merge proof
+    auto merge_verified = this->construct_and_verify_merge_proof(op_queue, MergeSettings::APPEND);
+    EXPECT_TRUE(merge_verified);
+}
+
+/**
+ * @brief Test Honk and Merge proof construction/verification for multiple circuits with ECC op gates, public inputs,
+ * and basic arithmetic gates
+ *
+ */
+TYPED_TEST(MergeTests, MultipleCircuitsHonkAndMerge)
+{
+    using Flavor = TypeParam;
+
+    // Instantiate EccOpQueue. This will be shared across all circuits in the series
+    auto op_queue = std::make_shared<bb::ECCOpQueue>();
+    // Construct multiple test circuits that share an ECC op queue. Generate and verify a proof for each.
+    size_t NUM_CIRCUITS = 3;
+    for (size_t i = 0; i < NUM_CIRCUITS; ++i) {
+        auto builder = typename Flavor::CircuitBuilder{ op_queue };
+
+        GoblinMockCircuits::construct_simple_circuit(builder);
+
+        // Construct and verify Honk proof
+        bool honk_verified = this->construct_and_verify_honk_proof(builder);
+        EXPECT_TRUE(honk_verified);
+
+        // Construct and verify Goblin ECC op queue Merge proof
+        auto merge_verified = this->construct_and_verify_merge_proof(op_queue);
+        EXPECT_TRUE(merge_verified);
+    }
+
+    // Construct a final circuit whose ecc ops will be appended rather than prepended to the op queue
+    auto builder = typename Flavor::CircuitBuilder{ op_queue };
+
+    GoblinMockCircuits::construct_simple_circuit(builder);
+
+    // Construct and verify Honk proof
+    bool honk_verified = this->construct_and_verify_honk_proof(builder);
+    EXPECT_TRUE(honk_verified);
+
+    // Construct and verify Goblin ECC op queue Merge proof
+    auto merge_verified = this->construct_and_verify_merge_proof(op_queue, MergeSettings::APPEND);
+    EXPECT_TRUE(merge_verified);
+}
+
+/**
+ * @brief To ensure the Merge proof sent to the rollup is ZK we have to randomise the commitments and evaluation of
+ * column polynomials. We achieve this by adding some randomness to the op queue via random ops in builders. As we
+ * produce a MegaHonk proof for such builders, this test ensure random ops do not alter the correctness of such proof
+ * (which only asserts that the data in ecc_op_wires has been compied correctly from the other wires).
+ *
+ */
+TYPED_TEST(MergeTests, OpQueueWithRandomValues)
+{
+    using Flavor = TypeParam;
+    using Builder = Flavor::CircuitBuilder;
+
+    // Test for randomness added at the beginning
+    {
+        Builder builder;
+        GoblinMockCircuits::randomise_op_queue(builder, 2);
+        GoblinMockCircuits::construct_simple_circuit(builder);
+
+        // Construct and verify Honk proof
+        bool honk_verified = this->construct_and_verify_honk_proof(builder);
+        EXPECT_TRUE(honk_verified);
+    }
+
+    // Test for randomness added at the end
+    {
+        Builder builder;
+        GoblinMockCircuits::construct_simple_circuit(builder);
+        GoblinMockCircuits::randomise_op_queue(builder, 2);
+
+        // Construct and verify Honk proof
+        bool honk_verified = this->construct_and_verify_honk_proof(builder);
+        EXPECT_TRUE(honk_verified);
+    }
+}

--- a/barretenberg/cpp/src/barretenberg/goblin/merge_prover.hpp
+++ b/barretenberg/cpp/src/barretenberg/goblin/merge_prover.hpp
@@ -78,14 +78,7 @@ class MergeProver {
      * @return Polynomial
      */
     static Polynomial compute_degree_check_polynomial(const std::array<Polynomial, NUM_WIRES>& left_table,
-                                                      const std::vector<FF>& degree_check_challenges)
-    {
-        Polynomial reversed_batched_left_tables(left_table[0].size());
-        for (size_t idx = 0; idx < NUM_WIRES; idx++) {
-            reversed_batched_left_tables.add_scaled(left_table[idx], degree_check_challenges[idx]);
-        }
-        return reversed_batched_left_tables.reverse();
-    }
+                                                      const std::vector<FF>& degree_check_challenges);
 
     /**
      * @brief Compute the batched Shplonk quotient polynomial.
@@ -105,43 +98,7 @@ class MergeProver {
                                                        const FF& kappa,
                                                        const FF& kappa_inv,
                                                        const Polynomial& reversed_batched_left_tables,
-                                                       const std::vector<FF>& evals)
-    {
-        // Q s.t. Q * (X - \kappa) * (X - \kappa^{-1}) =
-        //   (X - \kappa^{-1}) * (\sum_i \beta_i (L_i - l_i) + \sum_i \beta_i (R_i - r_i) + \sum_i \beta_i (M_i - m_i))
-        // + (X - \kappa) * \beta_i (G - g)
-        Polynomial shplonk_batched_quotient(merged_table[0].size());
-
-        // Handle polynomials opened at \kappa
-        for (size_t idx_table = 0; idx_table < 3; idx_table++) {
-            for (size_t idx = 0; idx < NUM_WIRES; idx++) {
-                FF challenge = shplonk_batching_challenges[(idx_table * NUM_WIRES) + idx];
-                FF eval = evals[(idx_table * NUM_WIRES) + idx];
-                if (idx_table == 0) {
-                    // Q += L_i * \beta_i
-                    shplonk_batched_quotient.add_scaled(left_table[idx], challenge);
-                } else if (idx_table == 1) {
-                    // Q += R_i * \beta_i
-                    shplonk_batched_quotient.add_scaled(right_table[idx], challenge);
-                } else {
-                    // Q += M_i * \beta_i
-                    shplonk_batched_quotient.add_scaled(merged_table[idx], challenge);
-                }
-                // Q -= eval * \beta_i
-                shplonk_batched_quotient.at(0) -= challenge * eval;
-            }
-        }
-        // Q /= (X - \kappa)
-        shplonk_batched_quotient.factor_roots(kappa);
-
-        // Q += (G - g) / (X - \kappa^{-1}) * \beta_i
-        Polynomial reversed_batched_left_tables_copy(reversed_batched_left_tables);
-        reversed_batched_left_tables_copy.at(0) -= evals.back();
-        reversed_batched_left_tables_copy.factor_roots(kappa_inv);
-        shplonk_batched_quotient.add_scaled(reversed_batched_left_tables_copy, shplonk_batching_challenges.back());
-
-        return shplonk_batched_quotient;
-    };
+                                                       const std::vector<FF>& evals);
 
     /**
      * @brief Compute the partially evaluated Shplonk batched quotient and the resulting opening claim.
@@ -164,49 +121,7 @@ class MergeProver {
                                                       const FF& kappa,
                                                       const FF& kappa_inv,
                                                       Polynomial& reversed_batched_left_tables,
-                                                      const std::vector<FF>& evals)
-    {
-        // Q' (partially evaluated batched quotient) =
-        //  -Q * (z - \kappa) +
-        //      + (\sum_i \beta_i (L_i - l_i) + \sum_i \beta_i (R_i - r_i) + \sum_i \beta_i (M_i - m_i))
-        //      + (z - \kappa) / (z - \kappa^{-1}) * \beta_i (G - g)
-
-        //
-        Polynomial shplonk_partially_evaluated_batched_quotient(std::move(shplonk_batched_quotient));
-        shplonk_partially_evaluated_batched_quotient *= -(shplonk_opening_challenge - kappa);
-
-        // Handle polynomials opened at \kappa
-        for (size_t idx_table = 0; idx_table < 3; idx_table++) {
-            for (size_t idx = 0; idx < NUM_WIRES; idx++) {
-                FF challenge = shplonk_batching_challenges[(idx_table * NUM_WIRES) + idx];
-                FF eval = evals[(idx_table * NUM_WIRES) + idx];
-                if (idx_table == 0) {
-                    // Q' += L_i * \beta_i
-                    shplonk_partially_evaluated_batched_quotient.add_scaled(left_table[idx], challenge);
-                } else if (idx_table == 1) {
-                    // Q' += R_i * \beta_i
-                    shplonk_partially_evaluated_batched_quotient.add_scaled(right_table[idx], challenge);
-                } else {
-                    // Q' += M_i * \beta_i
-                    shplonk_partially_evaluated_batched_quotient.add_scaled(merged_table[idx], challenge);
-                }
-                // Q' -= eval * \beta_i
-                shplonk_partially_evaluated_batched_quotient.at(0) -= challenge * eval;
-            }
-        }
-
-        // Q' += (G - g) / (z - \kappa^{-1}) * (z - \kappa) * \beta_i
-        reversed_batched_left_tables.at(0) -= evals.back();
-        shplonk_partially_evaluated_batched_quotient.add_scaled(reversed_batched_left_tables,
-                                                                shplonk_batching_challenges.back() *
-                                                                    (shplonk_opening_challenge - kappa) *
-                                                                    (shplonk_opening_challenge - kappa_inv).invert());
-
-        OpeningClaim shplonk_opening_claim = { .polynomial = std::move(shplonk_partially_evaluated_batched_quotient),
-                                               .opening_pair = { shplonk_opening_challenge, FF(0) } };
-
-        return shplonk_opening_claim;
-    }
+                                                      const std::vector<FF>& evals);
 };
 
 } // namespace bb

--- a/barretenberg/cpp/src/barretenberg/goblin/merge_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/goblin/merge_verifier.cpp
@@ -11,6 +11,102 @@
 
 namespace bb {
 
+template <typename Curve>
+bool MergeVerifier_<Curve>::check_concatenation_identities(std::vector<FF>& evals, const FF& pow_kappa) const
+{
+    bool concatenation_verified = true;
+    FF concatenation_diff(0);
+    for (size_t idx = 0; idx < NUM_WIRES; idx++) {
+        concatenation_diff = evals[idx] + (pow_kappa * evals[idx + NUM_WIRES]) - evals[idx + (2 * NUM_WIRES)];
+        if constexpr (IsRecursive) {
+            concatenation_verified &= concatenation_diff.get_value() == 0;
+            concatenation_diff.assert_equal(FF(0),
+                                            "assert_equal: merge concatenation identity failed in Merge Verifier");
+        } else {
+            concatenation_verified &= concatenation_diff == 0;
+        }
+    }
+    return concatenation_verified;
+}
+
+template <typename Curve>
+bool MergeVerifier_<Curve>::check_degree_identity(std::vector<FF>& evals,
+                                                  const FF& pow_kappa_minus_one,
+                                                  const std::vector<FF>& degree_check_challenges) const
+{
+    bool degree_check_verified = true;
+    FF degree_check_diff(0);
+    for (size_t idx = 0; idx < NUM_WIRES; ++idx) {
+        degree_check_diff += evals[idx] * degree_check_challenges[idx];
+    }
+    degree_check_diff -= evals.back() * pow_kappa_minus_one;
+    if constexpr (IsRecursive) {
+        degree_check_diff.assert_equal(FF(0), "assert_equal: merge degree identity failed in Merge Verifier");
+        degree_check_verified &= degree_check_diff.get_value() == 0;
+    } else {
+        degree_check_verified &= degree_check_diff == 0;
+    }
+
+    return degree_check_verified;
+}
+
+template <typename Curve>
+BatchOpeningClaim<Curve> MergeVerifier_<Curve>::compute_shplonk_opening_claim(
+    const std::vector<Commitment>& table_commitments,
+    const Commitment& shplonk_batched_quotient,
+    const FF& shplonk_opening_challenge,
+    const std::vector<FF>& shplonk_batching_challenges,
+    const FF& kappa,
+    const FF& kappa_inv,
+    const std::vector<FF>& evals) const
+{
+    // Claim {Q', (z, 0)} expressed as
+    // Q' = -Q * (z - \kappa) +
+    //      + \sum_i \beta_i L_i - \sum_i \beta_i R_i - \sum_i \beta_i M_i
+    //      + (z - \kappa) / (z - \kappa^{-1}) * \beta_i G
+    //      - \sum_i \beta_i l_i - \sum_i \beta_i r_i - \sum_i \beta_i m_i
+    //      - (z - \kappa) / (z - \kappa^{-1}) * \beta_i * g
+    BatchOpeningClaim<Curve> batch_opening_claim;
+
+    // Commitment: [L_1], [L_2], ..., [L_n], [R_1], ..., [R_n], [M_1], ..., [M_n], [G], [1]
+    batch_opening_claim.commitments = { std::move(shplonk_batched_quotient) };
+    for (auto& commitment : table_commitments) {
+        batch_opening_claim.commitments.emplace_back(std::move(commitment));
+    }
+    if constexpr (IsRecursive) {
+        batch_opening_claim.commitments.emplace_back(Commitment::one(kappa.get_context()));
+    } else {
+        batch_opening_claim.commitments.emplace_back(Commitment::one());
+    }
+
+    // Scalars:
+    // -(shplonk_opening_challenge - kappa), \beta_1, ..., \beta_12,
+    // \beta_13 * (z - \kappa) / (z - \kappa^{-1})
+    // - ( \sum_i \beta_i l_i + \sum_i \beta_i r_i + \sum_i \beta_i m_i
+    //          + \beta_13 * (z - \kappa) / (z - \kappa^{-1})* g )
+    batch_opening_claim.scalars = { -(shplonk_opening_challenge - kappa) };
+    for (auto& scalar : shplonk_batching_challenges) {
+        batch_opening_claim.scalars.emplace_back(std::move(scalar));
+    }
+    batch_opening_claim.scalars.back() *=
+        (shplonk_opening_challenge - kappa) * (shplonk_opening_challenge - kappa_inv).invert();
+
+    batch_opening_claim.scalars.emplace_back(FF(0));
+    for (size_t idx = 0; idx < evals.size(); idx++) {
+        if (idx < evals.size() - 1) {
+            batch_opening_claim.scalars.back() -= evals[idx] * shplonk_batching_challenges[idx];
+        } else {
+            batch_opening_claim.scalars.back() -= shplonk_batching_challenges.back() * evals.back() *
+                                                  (shplonk_opening_challenge - kappa) *
+                                                  (shplonk_opening_challenge - kappa_inv).invert();
+        }
+    }
+
+    batch_opening_claim.evaluation_point = { shplonk_opening_challenge };
+
+    return batch_opening_claim;
+}
+
 /**
  * @brief Verify proper construction of the aggregate Goblin ECC op queue polynomials T_j, j = 1,2,3,4.
  * @details Let \f$L_j\f$, \f$R_j\f$, \f$M_j\f$ be three vectors. The Merge prover wants to convince the verifier that,

--- a/barretenberg/cpp/src/barretenberg/goblin/merge_verifier.hpp
+++ b/barretenberg/cpp/src/barretenberg/goblin/merge_verifier.hpp
@@ -96,42 +96,11 @@ template <typename Curve> class MergeVerifier_ {
         "SHPLONK_MERGE_BATCHING_CHALLENGE_12"
     };
 
-    bool check_concatenation_identities(std::vector<FF>& evals, const FF& pow_kappa) const
-    {
-        bool concatenation_verified = true;
-        FF concatenation_diff(0);
-        for (size_t idx = 0; idx < NUM_WIRES; idx++) {
-            concatenation_diff = evals[idx] + (pow_kappa * evals[idx + NUM_WIRES]) - evals[idx + (2 * NUM_WIRES)];
-            if constexpr (IsRecursive) {
-                concatenation_verified &= concatenation_diff.get_value() == 0;
-                concatenation_diff.assert_equal(FF(0),
-                                                "assert_equal: merge concatenation identity failed in Merge Verifier");
-            } else {
-                concatenation_verified &= concatenation_diff == 0;
-            }
-        }
-        return concatenation_verified;
-    };
+    bool check_concatenation_identities(std::vector<FF>& evals, const FF& pow_kappa) const;
 
     bool check_degree_identity(std::vector<FF>& evals,
                                const FF& pow_kappa_minus_one,
-                               const std::vector<FF>& degree_check_challenges) const
-    {
-        bool degree_check_verified = true;
-        FF degree_check_diff(0);
-        for (size_t idx = 0; idx < NUM_WIRES; ++idx) {
-            degree_check_diff += evals[idx] * degree_check_challenges[idx];
-        }
-        degree_check_diff -= evals.back() * pow_kappa_minus_one;
-        if constexpr (IsRecursive) {
-            degree_check_diff.assert_equal(FF(0), "assert_equal: merge degree identity failed in Merge Verifier");
-            degree_check_verified &= degree_check_diff.get_value() == 0;
-        } else {
-            degree_check_verified &= degree_check_diff == 0;
-        }
-
-        return degree_check_verified;
-    };
+                               const std::vector<FF>& degree_check_challenges) const;
 
     BatchOpeningClaim<Curve> compute_shplonk_opening_claim(const std::vector<Commitment>& table_commitments,
                                                            const Commitment& shplonk_batched_quotient,
@@ -139,54 +108,7 @@ template <typename Curve> class MergeVerifier_ {
                                                            const std::vector<FF>& shplonk_batching_challenges,
                                                            const FF& kappa,
                                                            const FF& kappa_inv,
-                                                           const std::vector<FF>& evals) const
-    {
-        // Claim {Q', (z, 0)} expressed as
-        // Q' = -Q * (z - \kappa) +
-        //      + \sum_i \beta_i L_i - \sum_i \beta_i R_i - \sum_i \beta_i M_i
-        //      + (z - \kappa) / (z - \kappa^{-1}) * \beta_i G
-        //      - \sum_i \beta_i l_i - \sum_i \beta_i r_i - \sum_i \beta_i m_i
-        //      - (z - \kappa) / (z - \kappa^{-1}) * \beta_i * g
-        BatchOpeningClaim<Curve> batch_opening_claim;
-
-        // Commitment: [L_1], [L_2], ..., [L_n], [R_1], ..., [R_n], [M_1], ..., [M_n], [G], [1]
-        batch_opening_claim.commitments = { std::move(shplonk_batched_quotient) };
-        for (auto& commitment : table_commitments) {
-            batch_opening_claim.commitments.emplace_back(std::move(commitment));
-        }
-        if constexpr (IsRecursive) {
-            batch_opening_claim.commitments.emplace_back(Commitment::one(kappa.get_context()));
-        } else {
-            batch_opening_claim.commitments.emplace_back(Commitment::one());
-        }
-
-        // Scalars:
-        // -(shplonk_opening_challenge - kappa), \beta_1, ..., \beta_12,
-        // \beta_13 * (z - \kappa) / (z - \kappa^{-1})
-        // - ( \sum_i \beta_i l_i + \sum_i \beta_i r_i + \sum_i \beta_i m_i
-        //          + \beta_13 * (z - \kappa) / (z - \kappa^{-1})* g )
-        batch_opening_claim.scalars = { -(shplonk_opening_challenge - kappa) };
-        for (auto& scalar : shplonk_batching_challenges) {
-            batch_opening_claim.scalars.emplace_back(std::move(scalar));
-        }
-        batch_opening_claim.scalars.back() *=
-            (shplonk_opening_challenge - kappa) * (shplonk_opening_challenge - kappa_inv).invert();
-
-        batch_opening_claim.scalars.emplace_back(FF(0));
-        for (size_t idx = 0; idx < evals.size(); idx++) {
-            if (idx < evals.size() - 1) {
-                batch_opening_claim.scalars.back() -= evals[idx] * shplonk_batching_challenges[idx];
-            } else {
-                batch_opening_claim.scalars.back() -= shplonk_batching_challenges.back() * evals.back() *
-                                                      (shplonk_opening_challenge - kappa) *
-                                                      (shplonk_opening_challenge - kappa_inv).invert();
-            }
-        }
-
-        batch_opening_claim.evaluation_point = { shplonk_opening_challenge };
-
-        return batch_opening_claim;
-    };
+                                                           const std::vector<FF>& evals) const;
 };
 
 // Type aliases for convenience

--- a/barretenberg/cpp/src/barretenberg/stdlib/goblin_verifier/goblin_recursive_verifier.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/goblin_verifier/goblin_recursive_verifier.hpp
@@ -6,9 +6,9 @@
 
 #pragma once
 #include "barretenberg/goblin/goblin.hpp"
+#include "barretenberg/goblin/merge_verifier.hpp"
 #include "barretenberg/stdlib/eccvm_verifier/eccvm_recursive_verifier.hpp"
 #include "barretenberg/stdlib/translator_vm_verifier/translator_recursive_verifier.hpp"
-#include "barretenberg/ultra_honk/merge_verifier.hpp"
 
 namespace bb::stdlib::recursion::honk {
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/merge_verifier/CMakeLists.txt
+++ b/barretenberg/cpp/src/barretenberg/stdlib/merge_verifier/CMakeLists.txt
@@ -1,5 +1,6 @@
 barretenberg_module(
     stdlib_merge_verifier
+    goblin
     transcript
     stdlib_poseidon2
     stdlib_circuit_builders

--- a/barretenberg/cpp/src/barretenberg/stdlib/merge_verifier/merge_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/merge_verifier/merge_verifier.test.cpp
@@ -1,10 +1,10 @@
-#include "barretenberg/ultra_honk/merge_verifier.hpp"
+#include "barretenberg/goblin/merge_verifier.hpp"
 #include "barretenberg/circuit_checker/circuit_checker.hpp"
 #include "barretenberg/common/test.hpp"
 #include "barretenberg/ecc/fields/field_conversion.hpp"
+#include "barretenberg/goblin/merge_prover.hpp"
 #include "barretenberg/goblin/mock_circuits.hpp"
 #include "barretenberg/stdlib/primitives/curves/bn254.hpp"
-#include "barretenberg/ultra_honk/merge_prover.hpp"
 #include "barretenberg/ultra_honk/ultra_prover.hpp"
 #include "barretenberg/ultra_honk/ultra_verifier.hpp"
 

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/CMakeLists.txt
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/CMakeLists.txt
@@ -1,1 +1,1 @@
-barretenberg_module(ultra_honk honk sumcheck commitment_schemes stdlib_primitives stdlib_keccak stdlib_sha256)
+barretenberg_module(ultra_honk goblin honk sumcheck commitment_schemes stdlib_primitives stdlib_keccak stdlib_sha256)

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/CMakeLists.txt
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/CMakeLists.txt
@@ -1,1 +1,1 @@
-barretenberg_module(ultra_honk goblin honk sumcheck commitment_schemes stdlib_primitives stdlib_keccak stdlib_sha256)
+barretenberg_module(ultra_honk honk sumcheck commitment_schemes stdlib_primitives stdlib_keccak stdlib_sha256)

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/mega_honk.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/mega_honk.test.cpp
@@ -4,8 +4,6 @@
 
 #include "barretenberg/circuit_checker/circuit_checker.hpp"
 #include "barretenberg/common/log.hpp"
-#include "barretenberg/goblin/merge_prover.hpp"
-#include "barretenberg/goblin/merge_verifier.hpp"
 #include "barretenberg/goblin/mock_circuits.hpp"
 #include "barretenberg/honk/relation_checker.hpp"
 #include "barretenberg/stdlib_circuit_builders/mega_circuit_builder.hpp"
@@ -48,32 +46,6 @@ template <typename Flavor> class MegaHonkTests : public ::testing::Test {
 
         return verified;
     }
-
-    /**
-     * @brief Construct and verify a Goblin ECC op queue merge proof
-     *
-     */
-    bool construct_and_verify_merge_proof(auto& op_queue, MergeSettings settings = MergeSettings::PREPEND)
-    {
-        MergeProver merge_prover{ op_queue, settings };
-        auto merge_proof = merge_prover.construct_proof();
-
-        // Construct Merge commitments
-        MergeVerifier::InputCommitments merge_commitments;
-        auto t_current = op_queue->construct_current_ultra_ops_subtable_columns();
-        auto T_prev = op_queue->construct_previous_ultra_ops_table_columns();
-        for (size_t idx = 0; idx < Flavor::NUM_WIRES; idx++) {
-            merge_commitments.t_commitments[idx] = merge_prover.pcs_commitment_key.commit(t_current[idx]);
-            merge_commitments.T_prev_commitments[idx] = merge_prover.pcs_commitment_key.commit(T_prev[idx]);
-        }
-
-        auto transcript = std::make_shared<NativeTranscript>();
-        MergeVerifier merge_verifier{ settings, transcript };
-        auto [pairing_points, _, degree_check_passed, concatenation_check_passed] =
-            merge_verifier.verify_proof(merge_proof, merge_commitments);
-
-        return pairing_points.check() && degree_check_passed && concatenation_check_passed;
-    }
 };
 
 TYPED_TEST_SUITE(MegaHonkTests, FlavorTypes);
@@ -102,25 +74,6 @@ TYPED_TEST(MegaHonkTests, ProofLengthCheck)
     UltraProver_<Flavor> prover(prover_instance, verification_key);
     HonkProof mega_proof = prover.construct_proof();
     EXPECT_EQ(mega_proof.size(), Flavor::PROOF_LENGTH_WITHOUT_PUB_INPUTS() + DefaultIO::PUBLIC_INPUTS_SIZE);
-}
-
-/**
- * @brief Check that size of a merge proof matches the corresponding constant
- * @details This is useful for ensuring correct construction of mock merge proofs
- *
- */
-TYPED_TEST(MegaHonkTests, MergeProofSizeCheck)
-{
-    using Flavor = TypeParam;
-
-    auto builder = typename Flavor::CircuitBuilder{};
-    GoblinMockCircuits::construct_simple_circuit(builder);
-
-    // Construct a merge proof and ensure its size matches expectation; if not, the constant may need to be updated
-    MergeProver merge_prover{ builder.op_queue };
-    auto merge_proof = merge_prover.construct_proof();
-
-    EXPECT_EQ(merge_proof.size(), MERGE_PROOF_SIZE);
 }
 
 /**
@@ -202,144 +155,6 @@ TYPED_TEST(MegaHonkTests, DynamicVirtualSizeIncrease)
 }
 
 /**
- * @brief Test proof construction/verification for a circuit with ECC op gates, public inputs, and basic arithmetic
- * gates
- * @note We simulate op queue interactions with a previous circuit so the actual circuit under test utilizes an op queue
- * with non-empty 'previous' data. This avoid complications with zero-commitments etc.
- *
- */
-TYPED_TEST(MegaHonkTests, SingleCircuit)
-{
-    using Flavor = TypeParam;
-    auto builder = typename Flavor::CircuitBuilder{};
-
-    GoblinMockCircuits::construct_simple_circuit(builder);
-
-    // Construct and verify Honk proof
-    bool honk_verified = this->construct_and_verify_honk_proof(builder);
-    EXPECT_TRUE(honk_verified);
-
-    // Construct and verify Goblin ECC op queue Merge proof
-    auto merge_verified = this->construct_and_verify_merge_proof(builder.op_queue);
-    EXPECT_TRUE(merge_verified);
-}
-
-/**
- * @brief Test Merge proof construction/verification for multiple circuits with ECC op gates, public inputs, and
- * basic arithmetic gates
- *
- */
-TYPED_TEST(MegaHonkTests, MultipleCircuitsMergeOnly)
-{
-    using Flavor = TypeParam;
-    // Instantiate EccOpQueue. This will be shared across all circuits in the series
-    auto op_queue = std::make_shared<bb::ECCOpQueue>();
-    // Construct multiple test circuits that share an ECC op queue. Generate and verify a proof for each.
-    size_t NUM_CIRCUITS = 3;
-    for (size_t i = 0; i < NUM_CIRCUITS; ++i) {
-        auto builder = typename Flavor::CircuitBuilder{ op_queue };
-
-        GoblinMockCircuits::construct_simple_circuit(builder);
-
-        // Construct and verify Goblin ECC op queue Merge proof
-        auto merge_verified = this->construct_and_verify_merge_proof(op_queue);
-        EXPECT_TRUE(merge_verified);
-    }
-}
-
-TYPED_TEST(MegaHonkTests, MultipleCircuitsMergeOnlyPrependThenAppend)
-{
-    using Flavor = TypeParam;
-    // Instantiate EccOpQueue. This will be shared across all circuits in the series
-    auto op_queue = std::make_shared<bb::ECCOpQueue>();
-    // Construct multiple test circuits that share an ECC op queue. Generate and verify a proof for each.
-    size_t NUM_CIRCUITS = 3;
-    for (size_t i = 0; i < NUM_CIRCUITS; ++i) {
-        auto builder = typename Flavor::CircuitBuilder{ op_queue };
-
-        GoblinMockCircuits::construct_simple_circuit(builder);
-
-        // Construct and verify Goblin ECC op queue Merge proof
-        auto merge_verified = this->construct_and_verify_merge_proof(op_queue);
-        EXPECT_TRUE(merge_verified);
-    }
-
-    // Construct a final circuit and append its ecc ops to the op queue
-    auto builder = typename Flavor::CircuitBuilder{ op_queue };
-
-    GoblinMockCircuits::construct_simple_circuit(builder);
-
-    // Construct and verify Goblin ECC op queue Merge proof
-    auto merge_verified = this->construct_and_verify_merge_proof(op_queue, MergeSettings::APPEND);
-    EXPECT_TRUE(merge_verified);
-}
-
-/**
- * @brief Test Honk proof construction/verification for multiple circuits with ECC op gates, public inputs, and
- * basic arithmetic gates
- *
- */
-TYPED_TEST(MegaHonkTests, MultipleCircuitsHonkOnly)
-{
-    using Flavor = TypeParam;
-
-    // Instantiate EccOpQueue. This will be shared across all circuits in the series
-    auto op_queue = std::make_shared<bb::ECCOpQueue>();
-    // Construct multiple test circuits that share an ECC op queue. Generate and verify a proof for each.
-    size_t NUM_CIRCUITS = 3;
-    for (size_t i = 0; i < NUM_CIRCUITS; ++i) {
-        auto builder = typename Flavor::CircuitBuilder{ op_queue };
-        GoblinMockCircuits::construct_simple_circuit(builder);
-        // Construct and verify Honk proof
-        bool honk_verified = this->construct_and_verify_honk_proof(builder);
-        EXPECT_TRUE(honk_verified);
-        // Artificially merge the op queue sincer we're not running the merge protocol in this test
-        builder.op_queue->merge();
-    }
-}
-
-/**
- * @brief Test Honk and Merge proof construction/verification for multiple circuits with ECC op gates, public inputs,
- * and basic arithmetic gates
- *
- */
-TYPED_TEST(MegaHonkTests, MultipleCircuitsHonkAndMerge)
-{
-    using Flavor = TypeParam;
-
-    // Instantiate EccOpQueue. This will be shared across all circuits in the series
-    auto op_queue = std::make_shared<bb::ECCOpQueue>();
-    // Construct multiple test circuits that share an ECC op queue. Generate and verify a proof for each.
-    size_t NUM_CIRCUITS = 3;
-    for (size_t i = 0; i < NUM_CIRCUITS; ++i) {
-        auto builder = typename Flavor::CircuitBuilder{ op_queue };
-
-        GoblinMockCircuits::construct_simple_circuit(builder);
-
-        // Construct and verify Honk proof
-        bool honk_verified = this->construct_and_verify_honk_proof(builder);
-        EXPECT_TRUE(honk_verified);
-
-        // Construct and verify Goblin ECC op queue Merge proof
-        auto merge_verified = this->construct_and_verify_merge_proof(op_queue);
-        EXPECT_TRUE(merge_verified);
-    }
-
-    // Construct a final circuit whose ecc ops will be appended rather than prepended to the op queue
-    auto builder = typename Flavor::CircuitBuilder{ op_queue };
-
-    GoblinMockCircuits::construct_simple_circuit(builder);
-
-    // Construct and verify Honk proof
-    bool honk_verified = this->construct_and_verify_honk_proof(builder);
-    EXPECT_TRUE(honk_verified);
-
-    // Construct and verify Goblin ECC op queue Merge proof
-    auto merge_verified = this->construct_and_verify_merge_proof(op_queue, MergeSettings::APPEND);
-    EXPECT_TRUE(merge_verified);
-}
-
-/**
  * @brief A sanity check that a simple std::swap on a ProverPolynomials object works as expected
  * @details Constuct two valid proving keys. Tamper with the prover_polynomials of one key then swap the
  * prover_polynomials of the two keys. The key who received the tampered polys leads to a failed verification while the
@@ -394,40 +209,5 @@ TYPED_TEST(MegaHonkTests, PolySwap)
         auto proof = prover.construct_proof();
         bool result = verifier.template verify_proof<DefaultIO>(proof).result;
         EXPECT_FALSE(result);
-    }
-}
-
-/**
- * @brief To ensure the Merge proof sent to the rollup is ZK we have to randomise the commitments and evaluation of
- * column polynomials. We achieve this by adding some randomness to the op queue via random ops in builders. As we
- * produce a MegaHonk proof for such builders, this test ensure random ops do not alter the correctness of such proof
- * (which only asserts that the data in ecc_op_wires has been compied correctly from the other wires).
- *
- */
-TYPED_TEST(MegaHonkTests, OpQueueWithRandomValues)
-{
-    using Flavor = TypeParam;
-    using Builder = Flavor::CircuitBuilder;
-
-    // Test for randomness added at the beginning
-    {
-        Builder builder;
-        GoblinMockCircuits::randomise_op_queue(builder, 2);
-        GoblinMockCircuits::construct_simple_circuit(builder);
-
-        // Construct and verify Honk proof
-        bool honk_verified = this->construct_and_verify_honk_proof(builder);
-        EXPECT_TRUE(honk_verified);
-    }
-
-    // Test for randomness added at the end
-    {
-        Builder builder;
-        GoblinMockCircuits::construct_simple_circuit(builder);
-        GoblinMockCircuits::randomise_op_queue(builder, 2);
-
-        // Construct and verify Honk proof
-        bool honk_verified = this->construct_and_verify_honk_proof(builder);
-        EXPECT_TRUE(honk_verified);
     }
 }

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/mega_honk.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/mega_honk.test.cpp
@@ -4,12 +4,12 @@
 
 #include "barretenberg/circuit_checker/circuit_checker.hpp"
 #include "barretenberg/common/log.hpp"
+#include "barretenberg/goblin/merge_prover.hpp"
+#include "barretenberg/goblin/merge_verifier.hpp"
 #include "barretenberg/goblin/mock_circuits.hpp"
 #include "barretenberg/honk/relation_checker.hpp"
 #include "barretenberg/stdlib_circuit_builders/mega_circuit_builder.hpp"
 #include "barretenberg/stdlib_circuit_builders/ultra_circuit_builder.hpp"
-#include "barretenberg/ultra_honk/merge_prover.hpp"
-#include "barretenberg/ultra_honk/merge_verifier.hpp"
 #include "barretenberg/ultra_honk/ultra_prover.hpp"
 #include "barretenberg/ultra_honk/ultra_verifier.hpp"
 


### PR DESCRIPTION
 This PR reorganizes the merge protocol code to better reflect the architecture and improve code organization.

  ### Changes

  1. **Moved merge protocol to goblin module**
     - Relocated `merge_prover.{hpp,cpp}` and `merge_verifier.{hpp,cpp}` from `ultra_honk/` to `goblin/`
     - The merge protocol is part of Goblin, so this placement better reflects the architecture
     - Separated interface from implementation by moving inline code from headers to .cpp files
     - This improves compilation times when only implementations change

  2. **Extracted merge tests to dedicated file**
     - Created `goblin/merge.test.cpp` with all merge-specific tests
     - Removed merge tests from `mega_honk.test.cpp`
     - Removed goblin dependency from ultra_honk tests (cleaner module boundaries)

  3. **Fixed module dependencies**
     - Added goblin dependency to `stdlib_merge_verifier` module
     - Updated all include paths across the codebase
     
   Closes https://github.com/AztecProtocol/barretenberg/issues/1469