### PR TITLE
chore: default on-curve checks in biggroup constructors

### DIFF
--- a/barretenberg/cpp/scripts/test_chonk_standalone_vks_havent_changed.sh
+++ b/barretenberg/cpp/scripts/test_chonk_standalone_vks_havent_changed.sh
@@ -13,7 +13,7 @@ cd ..
 # - Generate a hash for versioning: sha256sum bb-chonk-inputs.tar.gz
 # - Upload the compressed results: aws s3 cp bb-chonk-inputs.tar.gz s3://aztec-ci-artifacts/protocol/bb-chonk-inputs-[hash(0:8)].tar.gz
 # Note: In case of the "Test suite failed to run ... Unexpected token 'with' " error, need to run: docker pull aztecprotocol/build:3.0
-pinned_short_hash="615dca4d"
+pinned_short_hash="1abc29c2"
 pinned_chonk_inputs_url="https://aztec-ci-artifacts.s3.us-east-2.amazonaws.com/protocol/bb-chonk-inputs-${pinned_short_hash}.tar.gz"
 
 function compress_and_upload {

--- a/barretenberg/cpp/scripts/test_chonk_standalone_vks_havent_changed.sh
+++ b/barretenberg/cpp/scripts/test_chonk_standalone_vks_havent_changed.sh
@@ -13,7 +13,7 @@ cd ..
 # - Generate a hash for versioning: sha256sum bb-chonk-inputs.tar.gz
 # - Upload the compressed results: aws s3 cp bb-chonk-inputs.tar.gz s3://aztec-ci-artifacts/protocol/bb-chonk-inputs-[hash(0:8)].tar.gz
 # Note: In case of the "Test suite failed to run ... Unexpected token 'with' " error, need to run: docker pull aztecprotocol/build:3.0
-pinned_short_hash="0ff98690"
+pinned_short_hash="615dca4d"
 pinned_chonk_inputs_url="https://aztec-ci-artifacts.s3.us-east-2.amazonaws.com/protocol/bb-chonk-inputs-${pinned_short_hash}.tar.gz"
 
 function compress_and_upload {

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/ecdsa_constraints.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/ecdsa_constraints.cpp
@@ -108,8 +108,8 @@ void create_ecdsa_verify_constraints(typename Curve::Builder& builder,
     Fq pub_x(pub_x_bytes);
     Fq pub_y(pub_y_bytes);
     // This constructor sets the infinity flag of public_key to false. This is OK because the point at infinity is not a
-    // point on the curve and we check tha public_key is on the curve.
-    G1 public_key(pub_x, pub_y);
+    // point on the curve and we check tha public_key is on the curve in the ecdsa verification circuit.
+    G1 public_key(pub_x, pub_y, /*assert_on_curve=*/false);
 
     // Step 4.
     bool_ct signature_result =

--- a/barretenberg/cpp/src/barretenberg/stdlib/encryption/ecdsa/ecdsa.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/encryption/ecdsa/ecdsa.test.cpp
@@ -221,7 +221,7 @@ template <class Curve> class EcdsaTests : public ::testing::Test {
         bool_t is_infinity(
             stdlib::witness_t<Builder>(&builder, account.public_key.is_point_at_infinity() ? fr::one() : fr::zero()),
             false);
-        G1 pub_key(x, y, is_infinity);
+        G1 pub_key(x, y, is_infinity, /*assert_on_curve=*/false);
         pub_key.set_free_witness_tag();
         BB_ASSERT_EQ(pub_key.is_point_at_infinity().get_value(), account.public_key.is_point_at_infinity());
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup.hpp
@@ -37,8 +37,11 @@ template <class Builder_, class Fq, class Fr, class NativeGroup> class element {
 
     element();
     element(const typename NativeGroup::affine_element& input);
-    element(const Fq& x, const Fq& y);
-    element(const Fq& x, const Fq& y, const bool_ct& is_infinity);
+
+    // Construct a biggroup element from its coordinates
+    // By default, we validate that the point is on the curve
+    element(const Fq& x, const Fq& y, const bool assert_on_curve = true);
+    element(const Fq& x, const Fq& y, const bool_ct& is_infinity, bool assert_on_curve = true);
 
     element(const element& other);
     element(element&& other) noexcept;
@@ -72,9 +75,7 @@ template <class Builder_, class Fq, class Fr, class NativeGroup> class element {
 
         const Fq x = Fq::reconstruct_from_public(x_limbs);
         const Fq y = Fq::reconstruct_from_public(y_limbs);
-        const element result = element(x, y);
-        result.validate_on_curve();
-        return result;
+        return element(x, y);
     }
 
     /**
@@ -178,7 +179,7 @@ template <class Builder_, class Fq, class Fr, class NativeGroup> class element {
         uint256_t y = uint256_t(NativeGroup::one.y);
         Fq x_fq(ctx, x);
         Fq y_fq(ctx, y);
-        return element(x_fq, y_fq);
+        return element(x_fq, y_fq, /*assert_on_curve=*/false);
     }
 
     static element point_at_infinity(Builder* ctx)
@@ -187,7 +188,7 @@ template <class Builder_, class Fq, class Fr, class NativeGroup> class element {
         zero.unset_free_witness_tag();
         Fq x_fq(zero, zero);
         Fq y_fq(zero, zero);
-        element result(x_fq, y_fq);
+        element result(x_fq, y_fq, /*assert_on_curve=*/false);
         result.set_point_at_infinity(true);
         return result;
     }

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup.hpp
@@ -971,7 +971,7 @@ class element_test_accessor {
 template <typename C, typename Fq, typename Fr, typename G>
 inline std::ostream& operator<<(std::ostream& os, element<C, Fq, Fr, G> const& v)
 {
-    return os << "{ " << v._x << " , " << v._y << " }";
+    return os << "{ " << v.x() << " , " << v.y() << " }";
 }
 } // namespace bb::stdlib::element_default
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup.test.cpp
@@ -226,7 +226,8 @@ template <typename TestType> class stdlib_biggroup : public testing::Test {
                 x_coord.binary_basis_limbs[3].element = field_ct::from_witness(&builder, bb::fr(uint256_t(1) << 68));
                 x_coord.binary_basis_limbs[3].maximum_value = uint256_t(1) << 68;
 
-                element_ct point(x_coord, y_coord, bool_ct(witness_ct(&builder, false)));
+                // Skip curve check since we're intentionally creating an invalid point
+                element_ct point(x_coord, y_coord, bool_ct(witness_ct(&builder, false)), /*assert_on_curve=*/false);
                 point.assert_coordinates_in_field();
 
                 // Circuit should fail because x coordinate is out of field
@@ -246,7 +247,8 @@ template <typename TestType> class stdlib_biggroup : public testing::Test {
                 y_coord.binary_basis_limbs[3].element = field_ct::from_witness(&builder, bb::fr(uint256_t(1) << 68));
                 y_coord.binary_basis_limbs[3].maximum_value = uint256_t(1) << 68;
 
-                element_ct point(x_coord, y_coord, bool_ct(witness_ct(&builder, false)));
+                // Skip curve check since we're intentionally creating an invalid point
+                element_ct point(x_coord, y_coord, bool_ct(witness_ct(&builder, false)), /*assert_on_curve=*/false);
                 point.assert_coordinates_in_field();
 
                 // Circuit should fail because y coordinate is out of field
@@ -678,7 +680,8 @@ template <typename TestType> class stdlib_biggroup : public testing::Test {
         // Create a point with y = 0 (may not be on curve, but tests the edge case)
         auto x_coord = element_ct::BaseField::from_witness(&builder, test_point.x);
         auto y_coord = element_ct::BaseField::from_witness(&builder, fq(0));
-        element_ct a(x_coord, y_coord, bool_ct(witness_ct(&builder, false)));
+        // Skip curve check since we're intentionally creating an invalid point to test edge case
+        element_ct a(x_coord, y_coord, bool_ct(witness_ct(&builder, false)), /*assert_on_curve=*/false);
 
         a.set_origin_tag(submitted_value_origin_tag);
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_goblin.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_goblin.hpp
@@ -453,7 +453,7 @@ using BiggroupGoblin = goblin_element<bb::MegaCircuitBuilder,
 template <typename C, typename Fq, typename Fr, typename G>
 inline std::ostream& operator<<(std::ostream& os, goblin_element<C, Fq, Fr, G> const& v)
 {
-    return os << "{ " << v._x << " , " << v._y << " }";
+    return os << "{ " << v.x() << " , " << v.y() << " }";
 }
 } // namespace bb::stdlib::element_goblin
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_goblin.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_goblin.hpp
@@ -51,16 +51,21 @@ template <class Builder_, class Fq, class Fr, class NativeGroup> class goblin_el
         , _y(input.y)
         , _is_infinity(input.is_point_at_infinity())
     {}
-    goblin_element(const Fq& x, const Fq& y)
+
+    // Construct a goblin biggroup element from its coordinates
+    // The on-curve check is skipped as it is performed in ECCVM (assert_on_curve is unused)
+    goblin_element(const Fq& x, const Fq& y, [[maybe_unused]] bool assert_on_curve = true)
         : _x(x)
         , _y(y)
         , _is_infinity(false)
     {}
-    goblin_element(const Fq& x, const Fq& y, const bool_ct is_infinity)
+
+    goblin_element(const Fq& x, const Fq& y, const bool_ct is_infinity, [[maybe_unused]] bool assert_on_curve = true)
         : _x(x)
         , _y(y)
         , _is_infinity(is_infinity)
     {}
+
     goblin_element(const goblin_element& other) = default;
     goblin_element(goblin_element&& other) noexcept = default;
     goblin_element& operator=(const goblin_element& other) = default;

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_tables.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_tables.hpp
@@ -94,7 +94,8 @@ element<C, Fq, Fr, G> element<C, Fq, Fr, G>::read_group_element_rom_tables(
     y_fq.binary_basis_limbs[2].maximum_value = limb_max[6];
     y_fq.binary_basis_limbs[3].maximum_value = limb_max[7];
 
-    const auto output = element(x_fq, y_fq);
+    // ROM table points are precomputed and known to be valid, skip curve check
+    const auto output = element(x_fq, y_fq, /*assert_on_curve=*/false);
     return output;
 }
 
@@ -157,7 +158,8 @@ element<C, Fq, Fr, G> element<C, Fq, Fr, G>::eight_bit_fixed_base_table::operato
         y = -y;
     }
 
-    return element(x, y);
+    // Points from precomputed tables are known to be on the curve
+    return element(x, y, /*assert_on_curve=*/false);
 }
 
 template <typename C, class Fq, class Fr, class G>

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/field/field_conversion.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/field/field_conversion.hpp
@@ -167,15 +167,10 @@ template <typename Field> class StdlibCodec {
             Basefield x = deserialize_from_fields<Basefield>(fr_vec.subspan(0, base_field_frs));
             Basefield y = deserialize_from_fields<Basefield>(fr_vec.subspan(base_field_frs, base_field_frs));
 
-            T out;
-            if constexpr (IsAnyOf<T, grumpkin_commitment>) {
-                out = T(x, y, check_point_at_infinity<T>(fr_vec), /*assert_on_curve=*/false);
-            } else {
-                out = T(x, y, check_point_at_infinity<T>(fr_vec));
-            }
-            // Note that in the case of bn254 with Mega arithmetization, the check is delegated to ECCVM, see
+            // Construct the group element, deriving the point_at_infinity flag (validates the point is on curve)
+            // For goblin_element (bn254 with Mega arithmetization), the on-curve check is delegated to ECCVM, see
             // `on_curve_check` in `ECCVMTranscriptRelationImpl`.
-            out.validate_on_curve();
+            T out = T(x, y, check_point_at_infinity<T>(fr_vec), /*assert_on_curve=*/true);
             return out;
         } else {
             // Case 6: Array or Univariate

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/pairing_points.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/pairing_points.hpp
@@ -248,8 +248,9 @@ template <typename Curve> struct PairingPoints {
         Fq x1(DEFAULT_PAIRING_POINTS_P1_X);
         Fq y1(DEFAULT_PAIRING_POINTS_P1_Y);
 
-        Group P0(x0, y0);
-        Group P1(x1, y1);
+        // These are known, valid points, so we can skip the curve checks.
+        Group P0(x0, y0, /*assert_on_curve=*/false);
+        Group P1(x1, y1, /*assert_on_curve=*/false);
 
         return { P0, P1 };
     }

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/pairing_points.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/pairing_points.test.cpp
@@ -38,8 +38,8 @@ TYPED_TEST(PairingPointsTests, TestDefault)
 
     Builder builder;
 
-    Group P0(DEFAULT_PAIRING_POINTS_P0_X, DEFAULT_PAIRING_POINTS_P0_Y);
-    Group P1(DEFAULT_PAIRING_POINTS_P1_X, DEFAULT_PAIRING_POINTS_P1_Y);
+    Group P0(DEFAULT_PAIRING_POINTS_P0_X, DEFAULT_PAIRING_POINTS_P0_Y, /*assert_on_curve=*/false);
+    Group P1(DEFAULT_PAIRING_POINTS_P1_X, DEFAULT_PAIRING_POINTS_P1_Y, /*assert_on_curve=*/false);
     P0.convert_constant_to_fixed_witness(&builder);
     P1.convert_constant_to_fixed_witness(&builder);
     PairingPoints<TypeParam> pp(P0, P1);


### PR DESCRIPTION
adds default curve-checks in biggroup. if you want to disable curve-checks (for efficiency), you have to opt-in