### PR TITLE
fix: preserve parent context for unary minus to correctly parenthesize additions

### DIFF
--- a/bb-pilcom/bb-pil-backend/src/expression_evaluation.rs
+++ b/bb-pilcom/bb-pil-backend/src/expression_evaluation.rs
@@ -306,7 +306,7 @@ fn compute_expression_<F: FieldElement>(
             expr: rec_expr,
         }) => match operator {
             AlgebraicUnaryOperator::Minus => {
-                let e = compute_expression_(rec_expr, alias_names, None);
+                let e = compute_expression_(rec_expr, alias_names, Some(current_expr));
                 PolynomialExpression {
                     pattern_with_placeholders: format!("-{}", e.pattern_with_placeholders),
                     placeholders: e.placeholders,


### PR DESCRIPTION
The unary minus formatting in compute_expression_() previously called the child formatter with no parent context, preventing 
has_parent_priority() from recognizing that an addition under a unary minus must be parenthesized. As a consequence, expressions like -(a + b) were rendered as -a + b, which changes semantics when injected into C++ templates due to operator precedence. This change passes the current unary minus node as the parent to the child, aligning the unary case with how binary operations already propagate parent context. With this, has_parent_priority() correctly adds parentheses around additions under a unary minus, ensuring the generated C++ code preserves the intended meaning without introducing unnecessary parentheses for multiplication or other cases.