### PR TITLE
fix(sentinel): base inactivity sufficiency on prior epochs to prevent false positives

### DIFF
--- a/yarn-project/aztec-node/src/sentinel/sentinel.ts
+++ b/yarn-project/aztec-node/src/sentinel/sentinel.ts
@@ -175,18 +175,20 @@ export class Sentinel extends (EventEmitter as new () => WatcherEmitter) impleme
     // Get all historical performance for this validator
     const allPerformance = await this.store.getProvenPerformance(validator);
 
-    // If we don't have enough historical data, don't slash
-    if (allPerformance.length < requiredConsecutiveEpochs) {
+    // Consider only epochs strictly before the current one
+    const prior = allPerformance.filter(p => p.epoch < currentEpoch);
+
+    // If we don't have enough historical data in prior epochs, don't slash
+    if (prior.length < requiredConsecutiveEpochs) {
       this.logger.debug(
-        `Not enough historical data for slashing ${validator} for inactivity (${allPerformance.length} epochs < ${requiredConsecutiveEpochs} required)`,
+        `Not enough historical data for slashing ${validator} for inactivity in prior epochs (${prior.length} epochs < ${requiredConsecutiveEpochs} required)`,
       );
       return false;
     }
 
-    // Sort by epoch descending to get most recent first, keep only epochs strictly before the current one, and get the first N
-    return allPerformance
+    // Sort by epoch descending to get most recent first within prior epochs, and get the first N
+    return prior
       .sort((a, b) => Number(b.epoch - a.epoch))
-      .filter(p => p.epoch < currentEpoch)
       .slice(0, requiredConsecutiveEpochs)
       .every(p => p.missed / p.total >= this.config.slashInactivityTargetPercentage);
   }


### PR DESCRIPTION
Adjust checkPastInactivity to measure data sufficiency using only epochs strictly before the current one, ensuring the consecutive inactivity threshold cannot be met by including current-epoch data. Previously, the code compared the total length of allPerformance against the required consecutive epochs and only then filtered out current epochs, which could allow .every to run on an empty or too-short slice and return true, causing false-positive slashing when threshold > 1 and the validator lacks enough prior epochs. The new logic filters prior epochs up front, validates sufficiency on that filtered set, and evaluates only those entries, aligning the behavior with tests and documentation that mandate considering past epochs exclusively.