### PR TITLE
Clarify publisher private key in documentation and convert hex in che…

### DIFF
--- a/docs/docs/the_aztec_network/operation/sequencer_management/running_delegated_stake.md
+++ b/docs/docs/the_aztec_network/operation/sequencer_management/running_delegated_stake.md
@@ -296,7 +296,7 @@ Update the `coinbase` field in your sequencer node's keystore configuration to t
         "eth": "0x...",  // Your Ethereum sequencer private key
         "bls": "0x..."   // Your BLS sequencer private key
       },
-      "publisher": ["0x..."],  // Address that submits blocks to L1
+      "publisher": ["0x..."],  // Your publisher private key that submits blocks to L1
       "coinbase": "0x[SPLIT_CONTRACT_ADDRESS]",  // Split contract for this delegation
       "feeRecipient": "0x..."  // Your Aztec address for L2 fees
     }
@@ -383,10 +383,10 @@ RPC_URL="[YOUR_RPC_URL]"
 WEBHOOK_URL="[YOUR_WEBHOOK_URL]"  # Optional: for Slack/Discord notifications
 
 # Gets current queue length
-QUEUE_LENGTH=$(cast call "$REGISTRY_ADDRESS" \
+QUEUE_LENGTH=$(cast to-dec $(cast call "$REGISTRY_ADDRESS" \
   "getProviderQueueLength(uint256)" \
   "$PROVIDER_ID" \
-  --rpc-url "$RPC_URL")
+  --rpc-url "$RPC_URL"))
 
 echo "Queue length: $QUEUE_LENGTH"
 


### PR DESCRIPTION
…ck-keystore.sh

Updated comments to clarify private key usage for publisher. Convert hex to dec in check-keystore.sh to fix error.

Please read [contributing guidelines](CONTRIBUTING.md) and remove this line.

For audit-related pull requests, please use the [audit PR template](?expand=1&template=audit.md).
