### PR TITLE
fix: stricter checks at config update

### DIFF
--- a/l1-contracts/src/core/libraries/Errors.sol
+++ b/l1-contracts/src/core/libraries/Errors.sol
@@ -168,6 +168,7 @@ library Errors {
   // FeeLib
   error FeeLib__InvalidFeeAssetPriceModifier(); // 0xf2fb32ad
   error FeeLib__AlreadyPreheated();
+  error FeeLib__InvalidManaLimit(uint256 maximum, uint256 provided);
 
   // SignatureLib (duplicated)
   error SignatureLib__InvalidSignature(address, address); // 0xd9cbae6c

--- a/l1-contracts/src/core/libraries/compressed-data/fees/FeeConfig.sol
+++ b/l1-contracts/src/core/libraries/compressed-data/fees/FeeConfig.sol
@@ -50,11 +50,12 @@ library PriceLib {
 library FeeConfigLib {
   using SafeCast for uint256;
 
+  uint256 private constant MASK_32_BITS = 0xFFFFFFFF;
   uint256 private constant MASK_64_BITS = 0xFFFFFFFFFFFFFFFF;
   uint256 private constant MASK_128_BITS = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF;
 
   function getManaTarget(CompressedFeeConfig _compressedFeeConfig) internal pure returns (uint256) {
-    return (CompressedFeeConfig.unwrap(_compressedFeeConfig) >> 192) & MASK_64_BITS;
+    return (CompressedFeeConfig.unwrap(_compressedFeeConfig) >> 192) & MASK_32_BITS;
   }
 
   function getCongestionUpdateFraction(CompressedFeeConfig _compressedFeeConfig) internal pure returns (uint256) {
@@ -69,7 +70,7 @@ library FeeConfigLib {
     uint256 value = 0;
     value |= uint256(EthValue.unwrap(_config.provingCostPerMana).toUint64());
     value |= uint256(_config.congestionUpdateFraction.toUint128()) << 64;
-    value |= uint256(_config.manaTarget.toUint64()) << 192;
+    value |= uint256(_config.manaTarget.toUint32()) << 192;
 
     return CompressedFeeConfig.wrap(value);
   }

--- a/l1-contracts/src/core/libraries/rollup/FeeLib.sol
+++ b/l1-contracts/src/core/libraries/rollup/FeeLib.sol
@@ -92,6 +92,9 @@ library FeeLib {
   function initialize(uint256 _manaTarget, EthValue _provingCostPerMana) internal {
     FeeStore storage feeStore = getStorage();
 
+    // Computes and ensures that limit is within sane bounds
+    computeManaLimit(_manaTarget);
+
     feeStore.config = FeeConfig({
         manaTarget: _manaTarget,
         congestionUpdateFraction: _manaTarget * MAGIC_CONGESTION_VALUE_MULTIPLIER / MAGIC_CONGESTION_VALUE_DIVISOR,
@@ -106,6 +109,9 @@ library FeeLib {
   }
 
   function updateManaTarget(uint256 _manaTarget) internal {
+    // Computes and ensures that limit is within sane bounds
+    computeManaLimit(_manaTarget);
+
     FeeStore storage feeStore = getStorage();
 
     FeeConfig memory config = feeStore.config.decompress();
@@ -245,7 +251,7 @@ library FeeLib {
 
   function getManaLimit() internal view returns (uint256) {
     FeeStore storage feeStore = getStorage();
-    return feeStore.config.getManaTarget() * 2;
+    return computeManaLimit(feeStore.config.getManaTarget());
   }
 
   function getProvingCostPerMana() internal view returns (EthValue) {
@@ -264,6 +270,15 @@ library FeeLib {
   function congestionMultiplier(uint256 _numerator) internal view returns (uint256) {
     FeeStore storage feeStore = getStorage();
     return fakeExponential(MINIMUM_CONGESTION_MULTIPLIER, _numerator, feeStore.config.getCongestionUpdateFraction());
+  }
+
+  function computeManaLimit(uint256 _manaTarget) internal pure returns (uint256) {
+    uint256 manaLimit = _manaTarget * 2;
+
+    // Ensure that the maximum spent mana can fit in the fee header
+    require(manaLimit <= type(uint32).max, Errors.FeeLib__InvalidManaLimit(type(uint32).max, manaLimit));
+
+    return manaLimit;
   }
 
   function getFeeAssetPerEth(uint256 _numerator) internal pure returns (FeeAssetPerEthE9) {

--- a/l1-contracts/test/Rollup.t.sol
+++ b/l1-contracts/test/Rollup.t.sol
@@ -128,8 +128,8 @@ contract RollupTest is RollupBase {
     setUpFor("mixed_block_1")
   {
     // we can increase the mana target
-    uint256 initialManaTarget = bound(_initialManaTarget, 0, type(uint64).max);
-    uint256 newManaTarget = bound(_newManaTarget, initialManaTarget, type(uint64).max);
+    uint256 initialManaTarget = bound(_initialManaTarget, 0, type(uint32).max / 2);
+    uint256 newManaTarget = bound(_newManaTarget, initialManaTarget, type(uint32).max / 2);
 
     RollupBuilder builder = new RollupBuilder(address(this)).setManaTarget(initialManaTarget).deploy();
 
@@ -150,7 +150,7 @@ contract RollupTest is RollupBase {
     setUpFor("mixed_block_1")
   {
     // we cannot decrease the mana target
-    uint256 initialManaTarget = bound(_initialManaTarget, 1, type(uint64).max);
+    uint256 initialManaTarget = bound(_initialManaTarget, 1, type(uint32).max / 2);
     uint256 newManaTarget = bound(_newManaTarget, 0, initialManaTarget - 1);
 
     RollupBuilder builder = new RollupBuilder(address(this)).setManaTarget(initialManaTarget).deploy();

--- a/l1-contracts/test/compression/FeeConfig.t.sol
+++ b/l1-contracts/test/compression/FeeConfig.t.sol
@@ -15,7 +15,7 @@ contract FeeConfigTest is Test {
   using FeeConfigLib for CompressedFeeConfig;
 
   function test_compressAndDecompress(
-    uint64 _manaTarget,
+    uint32 _manaTarget,
     uint128 _congestionUpdateFraction,
     uint64 _provingCostPerMana
   ) public pure {

--- a/l1-contracts/test/rollup/libraries/feelib/FeeLibWrapper.sol
+++ b/l1-contracts/test/rollup/libraries/feelib/FeeLibWrapper.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024 Aztec Labs.
+pragma solidity >=0.8.27;
+
+import {FeeStore, FeeLib, EthValue} from "@aztec/core/libraries/rollup/FeeLib.sol";
+import {BlobLib} from "@aztec/core/libraries/rollup/BlobLib.sol";
+import {FeeConfigLib, FeeConfig, CompressedFeeConfig} from "@aztec/core/libraries/compressed-data/fees/FeeConfig.sol";
+import {L1GasOracleValues, FeeStructsLib} from "@aztec/core/libraries/compressed-data/fees/FeeStructs.sol";
+
+contract FeeLibWrapper {
+  using FeeConfigLib for FeeConfig;
+  using FeeConfigLib for CompressedFeeConfig;
+
+  function initialize(uint256 _manaTarget) external {
+    FeeLib.initialize(_manaTarget, EthValue.wrap(100));
+  }
+
+  function updateManaTarget(uint256 _manaTarget) external {
+    FeeLib.updateManaTarget(_manaTarget);
+  }
+
+  function getManaTarget() external view returns (uint256) {
+    return FeeLib.getManaTarget();
+  }
+
+  function getManaLimit() external view returns (uint256) {
+    return FeeLib.getManaLimit();
+  }
+
+  function getConfig() external view returns (FeeConfig memory) {
+    return FeeLib.getStorage().config.decompress();
+  }
+
+  function getL1GasOracleValues() external view returns (L1GasOracleValues memory) {
+    return FeeLib.getStorage().l1GasOracleValues;
+  }
+}

--- a/l1-contracts/test/rollup/libraries/feelib/initialize.t.sol
+++ b/l1-contracts/test/rollup/libraries/feelib/initialize.t.sol
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024 Aztec Labs.
+pragma solidity >=0.8.27;
+
+import {
+  MAGIC_CONGESTION_VALUE_MULTIPLIER,
+  MAGIC_CONGESTION_VALUE_DIVISOR,
+  EthValue
+} from "@aztec/core/libraries/rollup/FeeLib.sol";
+import {FeeLibWrapper} from "./FeeLibWrapper.sol";
+import {TestBase} from "@test/base/Base.sol";
+import {Errors} from "@aztec/core/libraries/Errors.sol";
+import {FeeConfig} from "@aztec/core/libraries/compressed-data/fees/FeeConfig.sol";
+import {
+  L1GasOracleValues,
+  CompressedL1FeeData,
+  FeeStructsLib
+} from "@aztec/core/libraries/compressed-data/fees/FeeStructs.sol";
+import {Slot} from "@aztec/core/libraries/TimeLib.sol";
+import {CompressedSlot, CompressedTimeMath} from "@aztec/shared/libraries/CompressedTimeMath.sol";
+
+contract InitializeTest is TestBase {
+  using FeeStructsLib for CompressedL1FeeData;
+
+  FeeLibWrapper private feeLibWrapper = new FeeLibWrapper();
+
+  function test_WhenManaLimitGTUint32(uint256 _manaTarget) external {
+    // it reverts with {FeeLib__InvalidManaLimit}
+
+    uint256 manaTarget = bound(_manaTarget, uint256(type(uint32).max) / 2 + 1, type(uint256).max / 2);
+    emit log_named_uint("manaTarget", manaTarget);
+
+    vm.expectRevert(abi.encodeWithSelector(Errors.FeeLib__InvalidManaLimit.selector, type(uint32).max, manaTarget * 2));
+    feeLibWrapper.initialize(manaTarget);
+  }
+
+  function test_WhenManaLimitLEUint32(uint256 _manaTarget) external {
+    // it store the config
+    // it store the l1 gas oracle values
+
+    uint256 manaTarget = bound(_manaTarget, 0, type(uint32).max / 2);
+
+    feeLibWrapper.initialize(manaTarget);
+
+    assertEq(feeLibWrapper.getManaTarget(), manaTarget);
+    assertEq(feeLibWrapper.getManaLimit(), manaTarget * 2);
+
+    FeeConfig memory config = feeLibWrapper.getConfig();
+    assertEq(config.manaTarget, manaTarget);
+    assertEq(
+      config.congestionUpdateFraction, manaTarget * MAGIC_CONGESTION_VALUE_MULTIPLIER / MAGIC_CONGESTION_VALUE_DIVISOR
+    );
+    assertEq(EthValue.unwrap(config.provingCostPerMana), 100);
+
+    L1GasOracleValues memory l1GasOracleValues = feeLibWrapper.getL1GasOracleValues();
+    assertEq(l1GasOracleValues.pre.getBaseFee(), 1 gwei, "Pre base fee");
+    assertEq(l1GasOracleValues.pre.getBlobFee(), 1, "Pre blob fee");
+    assertEq(l1GasOracleValues.post.getBaseFee(), block.basefee, "Post base fee");
+    assertEq(l1GasOracleValues.post.getBlobFee(), vm.getBlobBaseFee(), "Post blob fee");
+    assertEq(Slot.unwrap(CompressedTimeMath.decompress(l1GasOracleValues.slotOfChange)), 5, "Slot of change");
+  }
+}

--- a/l1-contracts/test/rollup/libraries/feelib/initialize.tree
+++ b/l1-contracts/test/rollup/libraries/feelib/initialize.tree
@@ -1,0 +1,6 @@
+InitializeTest
+├── when mana limit GT uint32
+│   └── it reverts with {FeeLib__InvalidManaLimitTarget}
+└── when mana limit LE uint32
+    ├── it store the config
+    └── it store the l1 gas oracle values

--- a/l1-contracts/test/rollup/libraries/feelib/updateManaTarget.t.sol
+++ b/l1-contracts/test/rollup/libraries/feelib/updateManaTarget.t.sol
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024 Aztec Labs.
+pragma solidity >=0.8.27;
+
+import {
+  MAGIC_CONGESTION_VALUE_MULTIPLIER,
+  MAGIC_CONGESTION_VALUE_DIVISOR,
+  EthValue
+} from "@aztec/core/libraries/rollup/FeeLib.sol";
+import {FeeLibWrapper} from "./FeeLibWrapper.sol";
+import {TestBase} from "@test/base/Base.sol";
+import {Errors} from "@aztec/core/libraries/Errors.sol";
+import {FeeConfig} from "@aztec/core/libraries/compressed-data/fees/FeeConfig.sol";
+import {
+  L1GasOracleValues,
+  CompressedL1FeeData,
+  FeeStructsLib
+} from "@aztec/core/libraries/compressed-data/fees/FeeStructs.sol";
+import {Slot} from "@aztec/core/libraries/TimeLib.sol";
+import {CompressedSlot, CompressedTimeMath} from "@aztec/shared/libraries/CompressedTimeMath.sol";
+
+contract UpdateManaTargetTest is TestBase {
+  FeeLibWrapper private feeLibWrapper = new FeeLibWrapper();
+
+  function setUp() external {
+    feeLibWrapper.initialize(100_000_000);
+  }
+
+  function test_WhenManaLimitGTUint32(uint256 _manaTarget) external {
+    // it reverts with {FeeLib__InvalidManaLimitTarget}
+
+    uint256 manaTarget = bound(_manaTarget, uint256(type(uint32).max) / 2 + 1, type(uint256).max / 2);
+    emit log_named_uint("manaTarget", manaTarget);
+
+    vm.expectRevert(abi.encodeWithSelector(Errors.FeeLib__InvalidManaLimit.selector, type(uint32).max, manaTarget * 2));
+    feeLibWrapper.updateManaTarget(manaTarget);
+  }
+
+  function test_WhenManaLimitLEUint32(uint256 _manaTarget) external {
+    // it store the mana target
+    // it store the congestion update fraction
+
+    uint256 manaTarget = bound(_manaTarget, 0, type(uint32).max / 2);
+
+    feeLibWrapper.updateManaTarget(manaTarget);
+
+    assertEq(feeLibWrapper.getManaTarget(), manaTarget);
+    assertEq(feeLibWrapper.getManaLimit(), manaTarget * 2);
+
+    FeeConfig memory config = feeLibWrapper.getConfig();
+    assertEq(config.manaTarget, manaTarget);
+    assertEq(
+      config.congestionUpdateFraction, manaTarget * MAGIC_CONGESTION_VALUE_MULTIPLIER / MAGIC_CONGESTION_VALUE_DIVISOR
+    );
+    assertEq(EthValue.unwrap(config.provingCostPerMana), 100);
+  }
+}

--- a/l1-contracts/test/rollup/libraries/feelib/updateManaTarget.tree
+++ b/l1-contracts/test/rollup/libraries/feelib/updateManaTarget.tree
@@ -1,0 +1,6 @@
+UpdateManaTargetTest
+├── when mana limit GT uint32
+│   └── it reverts with {FeeLib__InvalidManaLimitTarget}
+└── when mana limit LE uint32
+    ├── it store the mana target
+    └── it store the congestion update fraction

--- a/yarn-project/end-to-end/src/e2e_sequencer_config.test.ts
+++ b/yarn-project/end-to-end/src/e2e_sequencer_config.test.ts
@@ -29,7 +29,7 @@ describe('e2e_sequencer_config', () => {
 
   describe('Sequencer config', () => {
     // Sane targets < 64 bits.
-    const manaTarget = 21e10;
+    const manaTarget = 200e6;
     beforeAll(async () => {
       const initialFundedAccounts = await getInitialTestAccountsData();
       ({ teardown, sequencer, aztecNode, logger, wallet } = await setup(1, {

--- a/yarn-project/ethereum/src/config.ts
+++ b/yarn-project/ethereum/src/config.ts
@@ -90,7 +90,7 @@ export const DefaultL1ContractsConfig = {
   slashingExecutionDelayInRounds: 0, // round N may be submitted in round N + 1
   slashingVetoer: EthAddress.ZERO,
   governanceProposerRoundSize: 300,
-  manaTarget: BigInt(1e10),
+  manaTarget: BigInt(100e6),
   provingCostPerMana: BigInt(100),
   exitDelaySeconds: 2 * 24 * 60 * 60,
   slasherFlavor: 'tally' as const,


### PR DESCRIPTION
This pr addresses an issue where it was possible to configure the mana targets such that it would revert if the full limit was actually used by a block.

In practice the block builder could just build smaller blocks and avoid it. But it should not be possible to configure something that makes little sense, so here we are adding checks at the time of update to handle it. 

Also deletes an unused constant.