### PR TITLE
chore: BLS CLI - add --publisher option & default coinbase

### DIFF
--- a/yarn-project/cli/src/cmds/validator_keys/add.ts
+++ b/yarn-project/cli/src/cmds/validator_keys/add.ts
@@ -12,23 +12,28 @@ import {
   buildValidatorEntries,
   logValidatorSummaries,
   maybePrintJson,
-  validateBlsPathOptions,
   writeBlsBn254ToFile,
   writeEthJsonV3ToFile,
   writeKeystoreFile,
 } from './shared.js';
+import { validateBlsPathOptions, validatePublisherOptions, validateRemoteSignerOptions } from './utils.js';
 
 export type AddValidatorKeysOptions = NewValidatorKeystoreOptions;
 
 export async function addValidatorKeys(existing: string, options: AddValidatorKeysOptions, log: LogFn) {
   // validate bls-path inputs before proceeding with key generation
   validateBlsPathOptions(options);
+  // validate publisher options
+  validatePublisherOptions(options);
+  // validate remote signer options
+  validateRemoteSignerOptions(options);
 
   const {
     dataDir,
     file,
     count,
     publisherCount = 0,
+    publishers,
     mnemonic,
     accountIndex = 0,
     addressIndex,
@@ -73,6 +78,7 @@ export async function addValidatorKeys(existing: string, options: AddValidatorKe
   const { validators, summaries } = await buildValidatorEntries({
     validatorCount,
     publisherCount,
+    publishers,
     accountIndex,
     baseAddressIndex: effectiveBaseAddressIndex,
     mnemonic: mnemonicToUse,

--- a/yarn-project/cli/src/cmds/validator_keys/generate_bls_keypair.ts
+++ b/yarn-project/cli/src/cmds/validator_keys/generate_bls_keypair.ts
@@ -3,7 +3,8 @@ import type { LogFn } from '@aztec/foundation/log';
 
 import { writeFile } from 'fs/promises';
 
-import { computeBlsPublicKeyCompressed, defaultBlsPath, withValidatorIndex } from './shared.js';
+import { computeBlsPublicKeyCompressed, withValidatorIndex } from './shared.js';
+import { defaultBlsPath } from './utils.js';
 
 export type GenerateBlsKeypairOptions = {
   mnemonic?: string;

--- a/yarn-project/cli/src/cmds/validator_keys/index.ts
+++ b/yarn-project/cli/src/cmds/validator_keys/index.ts
@@ -3,7 +3,7 @@ import type { LogFn } from '@aztec/foundation/log';
 import { Command } from 'commander';
 
 import { parseAztecAddress, parseEthereumAddress, parseHex, parseOptionalInteger } from '../../utils/commands.js';
-import { defaultBlsPath } from './shared.js';
+import { defaultBlsPath } from './utils.js';
 
 export function injectCommands(program: Command, log: LogFn) {
   const group = program
@@ -18,14 +18,21 @@ export function injectCommands(program: Command, log: LogFn) {
     .option('--data-dir <path>', 'Directory to store keystore(s). Defaults to ~/.aztec/keystore')
     .option('--file <name>', 'Keystore file name. Defaults to key1.json (or keyN.json if key1.json exists)')
     .option('--count <N>', 'Number of validators to generate', parseOptionalInteger)
-    .option('--publisher-count <N>', 'Number of publisher accounts per validator (default 1)', value =>
+    .option('--publisher-count <N>', 'Number of publisher accounts per validator (default 0)', value =>
       parseOptionalInteger(value, 0),
+    )
+    .option('--publishers <privateKeys>', 'Comma-separated list of publisher private keys for all validators.', value =>
+      value.split(',').map((key: string) => key.trim()),
     )
     .option('--mnemonic <mnemonic>', 'Mnemonic for ETH/BLS derivation')
     .option('--passphrase <str>', 'Optional passphrase for mnemonic')
     .option('--account-index <N>', 'Base account index for ETH/BLS derivation', parseOptionalInteger)
     .option('--address-index <N>', 'Base address index for ETH/BLS derivation', parseOptionalInteger)
-    .option('--coinbase <address>', 'Coinbase ETH address to use when proposing', parseEthereumAddress)
+    .option(
+      '--coinbase <address>',
+      'Coinbase ETH address to use when proposing. Defaults to attester address.',
+      parseEthereumAddress,
+    )
     .option('--funding-account <address>', 'ETH account to fund publishers', parseEthereumAddress)
     .option('--remote-signer <url>', 'Default remote signer URL for accounts in this file')
     .option('--ikm <hex>', 'Initial keying material for BLS (alternative to mnemonic)', value => parseHex(value, 32))
@@ -62,14 +69,21 @@ export function injectCommands(program: Command, log: LogFn) {
     .option('--data-dir <path>', 'Directory where keystore(s) live. (default: ~/.aztec/keystore)')
     .option('--file <name>', 'Override output file name. (default: key<N>.json)')
     .option('--count <N>', 'Number of validators to add. (default: 1)', parseOptionalInteger)
-    .option('--publisher-count <N>', 'Number of publisher accounts per validator (default 1)', value =>
+    .option('--publisher-count <N>', 'Number of publisher accounts per validator (default 0)', value =>
       parseOptionalInteger(value, 0),
+    )
+    .option('--publishers <privateKeys>', 'Comma-separated list of publisher private keys for all validators.', value =>
+      value.split(',').map((key: string) => key.trim()),
     )
     .option('--mnemonic <mnemonic>', 'Mnemonic for ETH/BLS derivation')
     .option('--passphrase <str>', 'Optional passphrase for mnemonic')
     .option('--account-index <N>', 'Base account index for ETH/BLS derivation', parseOptionalInteger)
     .option('--address-index <N>', 'Base address index for ETH/BLS derivation', parseOptionalInteger)
-    .option('--coinbase <address>', 'Coinbase ETH address to use when proposing', parseEthereumAddress)
+    .option(
+      '--coinbase <address>',
+      'Coinbase ETH address to use when proposing. Defaults to attester address.',
+      parseEthereumAddress,
+    )
     .option('--funding-account <address>', 'ETH account to fund publishers', parseEthereumAddress)
     .option('--remote-signer <url>', 'Default remote signer URL for accounts in this file')
     .option('--ikm <hex>', 'Initial keying material for BLS (alternative to mnemonic)', value => parseHex(value, 32))

--- a/yarn-project/cli/src/cmds/validator_keys/utils.ts
+++ b/yarn-project/cli/src/cmds/validator_keys/utils.ts
@@ -1,0 +1,80 @@
+import type { EthAddress } from '@aztec/foundation/eth-address';
+import { type EthPrivateKey, ethPrivateKeySchema } from '@aztec/node-keystore';
+
+export const defaultBlsPath = 'm/12381/3600/0/0/0';
+
+export function validateBlsPathOptions(options: {
+  count?: number;
+  publisherCount?: number;
+  accountIndex?: number;
+  addressIndex?: number;
+  blsPath?: string;
+  ikm?: string;
+}) {
+  if (options.blsPath && options.blsPath !== defaultBlsPath) {
+    if (
+      (options.count && options.count !== 1) ||
+      (options.publisherCount && options.publisherCount > 0) ||
+      (options.accountIndex && options.accountIndex !== 0) ||
+      (options.addressIndex && options.addressIndex !== 0)
+    ) {
+      throw new Error('--bls-path cannot be used with --count, --publisher-count, --account-index, or --address-index');
+    }
+  }
+}
+
+export function validateStakerOutputOptions(options: {
+  stakerOutput?: boolean;
+  gseAddress?: EthAddress;
+  l1RpcUrls?: string[];
+  l1ChainId?: number;
+}) {
+  if (!options.stakerOutput) {
+    return;
+  }
+  // Required options for staker output
+  if (!options.gseAddress) {
+    throw new Error('--gse-address is required when using --staker-output');
+  }
+  if (!options.l1RpcUrls || options.l1RpcUrls.length === 0) {
+    throw new Error('--l1-rpc-urls is required when using --staker-output');
+  }
+
+  if (options.l1ChainId === undefined) {
+    throw new Error('--l1-chain-id is required when using --staker-output');
+  }
+}
+
+export function validateRemoteSignerOptions(options: { remoteSigner?: string; mnemonic?: string }) {
+  if (options.remoteSigner && !options.mnemonic) {
+    throw new Error(
+      'Using --remote-signer requires a deterministic key source. Provide --mnemonic to derive keys, or omit --remote-signer to write new private keys to keystore.',
+    );
+  }
+}
+
+export function validatePublisherOptions(options: { publishers?: string[]; publisherCount?: number }) {
+  if (options.publisherCount && options.publisherCount > 0 && options.publishers && options.publishers.length > 0) {
+    throw new Error('--publishers and --publisher-count cannot be used together');
+  }
+
+  if (options.publishers && options.publishers.length > 0) {
+    // Normalize each private key by adding 0x prefix if missing
+    const normalizedKeys: string[] = [];
+    for (const key of options.publishers) {
+      let privateKey = key.trim();
+      if (!privateKey.startsWith('0x')) {
+        privateKey = '0x' + privateKey;
+      }
+
+      try {
+        ethPrivateKeySchema.parse(privateKey);
+        normalizedKeys.push(privateKey);
+      } catch (error) {
+        throw new Error(`Invalid publisher private key: ${error instanceof Error ? error.message : String(error)}`);
+      }
+    }
+    // Update the options with the normalized keys
+    options.publishers = normalizedKeys as EthPrivateKey[];
+  }
+}


### PR DESCRIPTION
- adds `--publishers` option to the CLI tool
- defaults `coinbase` to the attester address if not provided as option

Fixes [A-288](https://linear.app/aztec-labs/issue/A-288/ux-improvements-for-keystores)