### PR TITLE
fix: reject unkown fields in keystore

### DIFF
--- a/yarn-project/node-keystore/src/schemas.test.ts
+++ b/yarn-project/node-keystore/src/schemas.test.ts
@@ -143,4 +143,137 @@ describe('Keystore Schema Validation', () => {
 
     expect(() => keystoreSchema.parse(keystore)).toThrow();
   });
+
+  it('should reject keystore with unexpected top-level fields', () => {
+    const keystore = {
+      schemaVersion: 1,
+      validators: [
+        {
+          attester: '0x1234567890123456789012345678901234567890123456789012345678901234',
+          feeRecipient: '0x1234567890123456789012345678901234567890123456789012345678901234',
+        },
+      ],
+      publisher: '0x1234567890123456789012345678901234567890123456789012345678901234',
+    };
+
+    expect(() => keystoreSchema.parse(keystore)).toThrow(/unrecognized/i);
+  });
+
+  it('should reject validator config with unexpected fields', () => {
+    const keystore = {
+      schemaVersion: 1,
+      validators: [
+        {
+          attester: '0x1234567890123456789012345678901234567890123456789012345678901234',
+          feeRecipient: '0x1234567890123456789012345678901234567890123456789012345678901234',
+          unexpectedField: 'should fail',
+        },
+      ],
+    };
+
+    expect(() => keystoreSchema.parse(keystore)).toThrow(/unrecognized/i);
+  });
+
+  it('should reject attester object with unexpected fields', () => {
+    const keystore = {
+      schemaVersion: 1,
+      validators: [
+        {
+          attester: {
+            eth: '0x1234567890123456789012345678901234567890123456789012345678901234',
+            bls: '0x1234567890123456789012345678901234567890123456789012345678901234',
+            unexpectedField: 'should fail',
+          },
+          feeRecipient: '0x1234567890123456789012345678901234567890123456789012345678901234',
+        },
+      ],
+    };
+
+    expect(() => keystoreSchema.parse(keystore)).toThrow(/unrecognized/i);
+  });
+
+  it('should reject remote signer config object with unexpected fields', () => {
+    const keystore = {
+      schemaVersion: 1,
+      validators: [
+        {
+          attester: '0x1234567890123456789012345678901234567890123456789012345678901234',
+          feeRecipient: '0x1234567890123456789012345678901234567890123456789012345678901234',
+        },
+      ],
+      remoteSigner: {
+        remoteSignerUrl: 'https://localhost:8080',
+        unexpectedField: 'should fail',
+      },
+    };
+
+    expect(() => keystoreSchema.parse(keystore)).toThrow(/unrecognized/i);
+  });
+
+  it('should reject encrypted key file config with unexpected fields', () => {
+    const keystore = {
+      schemaVersion: 1,
+      validators: [
+        {
+          attester: {
+            path: '/path/to/keystore.json',
+            password: 'secret',
+            unexpectedField: 'should fail',
+          },
+          feeRecipient: '0x1234567890123456789012345678901234567890123456789012345678901234',
+        },
+      ],
+    };
+
+    expect(() => keystoreSchema.parse(keystore)).toThrow(/unrecognized/i);
+  });
+
+  it('should reject mnemonic config with unexpected fields', () => {
+    const keystore = {
+      schemaVersion: 1,
+      validators: [
+        {
+          attester: {
+            mnemonic: 'test test test test test test test test test test test junk',
+            addressCount: 3,
+            unexpectedField: 'should fail',
+          },
+          feeRecipient: '0x1234567890123456789012345678901234567890123456789012345678901234',
+        },
+      ],
+    };
+
+    expect(() => keystoreSchema.parse(keystore)).toThrow(/unrecognized/i);
+  });
+
+  it('should reject prover config object with unexpected fields', () => {
+    const keystore = {
+      schemaVersion: 1,
+      prover: {
+        id: '0x1234567890123456789012345678901234567890',
+        publisher: '0x1234567890123456789012345678901234567890123456789012345678901234',
+        unexpectedField: 'should fail',
+      },
+    };
+
+    expect(() => keystoreSchema.parse(keystore)).toThrow(/unrecognized/i);
+  });
+
+  it('should reject remote signer account object with unexpected fields', () => {
+    const keystore = {
+      schemaVersion: 1,
+      validators: [
+        {
+          attester: {
+            address: '0x1234567890123456789012345678901234567890',
+            remoteSignerUrl: 'https://localhost:8080',
+            unexpectedField: 'should fail',
+          },
+          feeRecipient: '0x1234567890123456789012345678901234567890123456789012345678901234',
+        },
+      ],
+    };
+
+    expect(() => keystoreSchema.parse(keystore)).toThrow(/unrecognized/i);
+  });
 });

--- a/yarn-project/node-keystore/src/schemas.ts
+++ b/yarn-project/node-keystore/src/schemas.ts
@@ -22,38 +22,46 @@ const urlSchema = z.string().url('Invalid URL');
 // Remote signer config schema
 const remoteSignerConfigSchema = z.union([
   urlSchema,
-  z.object({
-    remoteSignerUrl: urlSchema,
-    certPath: optional(z.string()),
-    certPass: optional(z.string()),
-  }),
+  z
+    .object({
+      remoteSignerUrl: urlSchema,
+      certPath: optional(z.string()),
+      certPass: optional(z.string()),
+    })
+    .strict(),
 ]);
 
 // Remote signer account schema
 const remoteSignerAccountSchema = z.union([
   schemas.EthAddress,
-  z.object({
-    address: schemas.EthAddress,
-    remoteSignerUrl: urlSchema,
-    certPath: optional(z.string()),
-    certPass: optional(z.string()),
-  }),
+  z
+    .object({
+      address: schemas.EthAddress,
+      remoteSignerUrl: urlSchema,
+      certPath: optional(z.string()),
+      certPass: optional(z.string()),
+    })
+    .strict(),
 ]);
 
 // Encrypted keystore file schema (used for both JSON V3 ETH keys and EIP-2335 BLS keys)
-const encryptedKeyFileSchema = z.object({
-  path: z.string(),
-  password: optional(z.string()),
-});
+const encryptedKeyFileSchema = z
+  .object({
+    path: z.string(),
+    password: optional(z.string()),
+  })
+  .strict();
 
 // Mnemonic config schema
-const mnemonicConfigSchema = z.object({
-  mnemonic: z.string().min(1, 'Mnemonic cannot be empty'),
-  addressIndex: z.number().int().min(0).default(0),
-  accountIndex: z.number().int().min(0).default(0),
-  addressCount: z.number().int().min(1).default(1),
-  accountCount: z.number().int().min(1).default(1),
-});
+const mnemonicConfigSchema = z
+  .object({
+    mnemonic: z.string().min(1, 'Mnemonic cannot be empty'),
+    addressIndex: z.number().int().min(0).default(0),
+    accountIndex: z.number().int().min(0).default(0),
+    addressCount: z.number().int().min(1).default(1),
+    accountCount: z.number().int().min(1).default(1),
+  })
+  .strict();
 
 // EthAccount schema
 const ethAccountSchema = z.union([ethPrivateKeySchema, remoteSignerAccountSchema, encryptedKeyFileSchema]);
@@ -67,10 +75,12 @@ const blsAccountSchema = z.union([blsPrivateKeySchema, encryptedKeyFileSchema]);
 // AttesterAccount schema: either EthAccount or { eth: EthAccount, bls?: BLSAccount }
 const attesterAccountSchema = z.union([
   ethAccountSchema,
-  z.object({
-    eth: ethAccountSchema,
-    bls: optional(blsAccountSchema),
-  }),
+  z
+    .object({
+      eth: ethAccountSchema,
+      bls: optional(blsAccountSchema),
+    })
+    .strict(),
 ]);
 
 // AttesterAccounts schema: AttesterAccount | AttesterAccount[] | MnemonicConfig
@@ -79,21 +89,25 @@ const attesterAccountsSchema = z.union([attesterAccountSchema, z.array(attesterA
 // Prover keystore schema
 const proverKeyStoreSchema = z.union([
   ethAccountSchema,
-  z.object({
-    id: schemas.EthAddress,
-    publisher: ethAccountsSchema,
-  }),
+  z
+    .object({
+      id: schemas.EthAddress,
+      publisher: ethAccountsSchema,
+    })
+    .strict(),
 ]);
 
 // Validator keystore schema
-const validatorKeyStoreSchema = z.object({
-  attester: attesterAccountsSchema,
-  coinbase: optional(schemas.EthAddress),
-  publisher: optional(ethAccountsSchema),
-  feeRecipient: AztecAddress.schema,
-  remoteSigner: optional(remoteSignerConfigSchema),
-  fundingAccount: optional(ethAccountSchema),
-});
+const validatorKeyStoreSchema = z
+  .object({
+    attester: attesterAccountsSchema,
+    coinbase: optional(schemas.EthAddress),
+    publisher: optional(ethAccountsSchema),
+    feeRecipient: AztecAddress.schema,
+    remoteSigner: optional(remoteSignerConfigSchema),
+    fundingAccount: optional(ethAccountSchema),
+  })
+  .strict();
 
 // Main keystore schema
 export const keystoreSchema = z
@@ -105,6 +119,7 @@ export const keystoreSchema = z
     prover: optional(proverKeyStoreSchema),
     fundingAccount: optional(ethAccountSchema),
   })
+  .strict()
   .refine(data => data.validators || data.prover, {
     message: 'Keystore must have at least validators or prover configuration',
     path: ['root'],


### PR DESCRIPTION
Fixes [A-291](https://linear.app/aztec-labs/issue/A-291/v2-the-keystore-schema-does-not-reject-unknown-fields)