### PR TITLE
fix: Only consider past epochs for inactivity check

### DIFF
--- a/yarn-project/aztec-node/src/sentinel/sentinel.test.ts
+++ b/yarn-project/aztec-node/src/sentinel/sentinel.test.ts
@@ -270,6 +270,16 @@ describe('sentinel', () => {
       expect(stats.totalSlots).toEqual(5);
       expect(stats.missedProposals.count).toEqual(5);
     });
+
+    it('filters history by toSlot parameter', () => {
+      const history = times(20, i => ({ slot: BigInt(i), status: 'block-missed' }) as const);
+      const stats = sentinel.computeStatsForValidator(validator, history, 5n, 10n);
+
+      expect(stats.address.toString()).toEqual(validator);
+      expect(stats.totalSlots).toEqual(6); // Slots 5-10 inclusive
+      expect(stats.missedProposals.count).toEqual(6);
+      expect(stats.missedProposals.rate).toEqual(1);
+    });
   });
 
   describe('slot range validation', () => {
@@ -551,6 +561,20 @@ describe('sentinel', () => {
         expect(result).toBe(false);
       });
 
+      it('should return false on first inactive epoch', async () => {
+        const mockPerformance = [
+          { epoch: 5n, missed: 8, total: 10 }, // 80% missed (inactive)
+          { epoch: 4n, missed: 9, total: 10 }, // 90% missed (inactive)
+        ];
+
+        jest.spyOn(store, 'getProvenPerformance').mockResolvedValue(mockPerformance);
+
+        // We are checking at epoch 4, so no past epochs
+        const result = await sentinel.checkPastInactivity(validator1, 4n, 2);
+
+        expect(result).toBe(false);
+      });
+
       it('should return true when there is a gap in epochs since validators are not chosen for every committee', async () => {
         // Mock performance data: gap in epoch 4
         const mockPerformance = [
@@ -689,8 +713,9 @@ class TestSentinel extends Sentinel {
     address: `0x${string}`,
     history: ValidatorStatusHistory,
     fromSlot?: bigint,
+    toSlot?: bigint,
   ): ValidatorStats {
-    return super.computeStatsForValidator(address, history, fromSlot);
+    return super.computeStatsForValidator(address, history, fromSlot, toSlot);
   }
 
   public override handleChainProven(event: L2BlockStreamEvent) {

--- a/yarn-project/aztec-node/src/sentinel/sentinel.ts
+++ b/yarn-project/aztec-node/src/sentinel/sentinel.ts
@@ -175,18 +175,19 @@ export class Sentinel extends (EventEmitter as new () => WatcherEmitter) impleme
     // Get all historical performance for this validator
     const allPerformance = await this.store.getProvenPerformance(validator);
 
+    // Sort by epoch descending to get most recent first, keep only epochs strictly before the current one, and get the first N
+    const pastEpochs = allPerformance.sort((a, b) => Number(b.epoch - a.epoch)).filter(p => p.epoch < currentEpoch);
+
     // If we don't have enough historical data, don't slash
-    if (allPerformance.length < requiredConsecutiveEpochs) {
+    if (pastEpochs.length < requiredConsecutiveEpochs) {
       this.logger.debug(
         `Not enough historical data for slashing ${validator} for inactivity (${allPerformance.length} epochs < ${requiredConsecutiveEpochs} required)`,
       );
       return false;
     }
 
-    // Sort by epoch descending to get most recent first, keep only epochs strictly before the current one, and get the first N
-    return allPerformance
-      .sort((a, b) => Number(b.epoch - a.epoch))
-      .filter(p => p.epoch < currentEpoch)
+    // Check that we have at least requiredConsecutiveEpochs and that all of them are above the inactivity threshold
+    return pastEpochs
       .slice(0, requiredConsecutiveEpochs)
       .every(p => p.missed / p.total >= this.config.slashInactivityTargetPercentage);
   }


### PR DESCRIPTION
We were checking all epoch activity data for a validator when counting if there was enough historic data to consider to slash, when we should be filtering by past epochs only.