### PR TITLE
fix: improve shm impl

### DIFF
--- a/barretenberg/cpp/src/barretenberg/ipc/ipc_server.hpp
+++ b/barretenberg/cpp/src/barretenberg/ipc/ipc_server.hpp
@@ -129,11 +129,7 @@ class IpcServer {
      *
      * Note: Some transports (like shared memory) may not need explicit accept calls.
      */
-    virtual int accept(uint64_t timeout_ns)
-    {
-        (void)timeout_ns;
-        return -1;
-    }
+    virtual int accept() { return -1; }
 
     /**
      * @brief Run server event loop with handler
@@ -157,9 +153,9 @@ class IpcServer {
     {
         while (!shutdown_requested_.load(std::memory_order_acquire)) {
             // Try to accept new clients (non-blocking for socket servers)
-            accept(0);
+            accept();
 
-            int client_id = wait_for_data(100000000);
+            int client_id = wait_for_data(100000000); // 100ms timeout
             if (client_id < 0) {
                 // Timeout or error - check shutdown flag on next iteration
                 continue;

--- a/barretenberg/cpp/src/barretenberg/ipc/shm.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/ipc/shm.test.cpp
@@ -1,13 +1,17 @@
 #include "barretenberg/ipc/ipc_client.hpp"
 #include "barretenberg/ipc/ipc_server.hpp"
+#include "barretenberg/ipc/shm/spsc_shm.hpp"
 #include <array>
 #include <atomic>
 #include <chrono>
 #include <cstddef>
 #include <cstring>
+#include <functional>
 #include <gtest/gtest.h>
+#include <random>
 #include <sstream>
 #include <thread>
+#include <unistd.h>
 #include <vector>
 
 using namespace bb::ipc;
@@ -26,10 +30,13 @@ class ShmTest : public ::testing::Test {
 
     void SetUp() override
     {
-        // Generate unique SHM name based on test name for parallel execution
+        // Generate unique SHM name based on test name + PID for parallel execution
+        // Use short hash-based names (macOS has 31-char limit)
         const ::testing::TestInfo* test_info = ::testing::UnitTest::GetInstance()->current_test_info();
+        std::string full_name = std::string(test_info->test_suite_name()) + "_" + test_info->name();
+        std::hash<std::string> hasher;
         std::ostringstream oss;
-        oss << "test_shm_" << test_info->test_suite_name() << "_" << test_info->name();
+        oss << "shm_" << std::hex << (hasher(full_name) & 0xFFFFFF) << "_" << getpid();
         shm_name = oss.str();
 
         // Create server
@@ -43,7 +50,7 @@ class ShmTest : public ::testing::Test {
 
             while (server_running.load(std::memory_order_acquire)) {
                 // Try to accept connections first (non-blocking)
-                server->accept(0);
+                server->accept();
 
                 int client_id = server->wait_for_data(100000000);
                 if (client_id < 0) {
@@ -95,19 +102,19 @@ TEST_F(ShmTest, BasicEcho)
     std::cerr << "Client connected successfully" << '\n';
 
     std::vector<uint8_t> send_data = { 1, 2, 3, 4, 5 };
-    std::vector<uint8_t> recv_buffer(1024);
 
     std::cerr << "Sending data..." << '\n';
     ASSERT_TRUE(client->send(send_data.data(), send_data.size(), 1000000000)); // 1s timeout
     std::cerr << "Data sent, receiving..." << '\n';
 
-    ssize_t n = client->recv(recv_buffer.data(), recv_buffer.size(), 5000000000); // 5s timeout
-    std::cerr << "Received " << n << " bytes" << '\n';
+    auto response = client->recv(5000000000); // 5s timeout
+    std::cerr << "Received " << response.size() << " bytes" << '\n';
 
-    ASSERT_GT(n, 0) << "Failed to receive response";
-    ASSERT_EQ(static_cast<size_t>(n), send_data.size());
-    EXPECT_EQ(std::memcmp(recv_buffer.data(), send_data.data(), send_data.size()), 0);
+    ASSERT_FALSE(response.empty()) << "Failed to receive response";
+    ASSERT_EQ(response.size(), send_data.size());
+    EXPECT_EQ(std::memcmp(response.data(), send_data.data(), send_data.size()), 0);
 
+    client->release(response.size());
     client->close();
 }
 
@@ -116,8 +123,6 @@ TEST_F(ShmTest, VaryingMessageSizes)
 {
     auto client = IpcClient::create_shm(shm_name, MAX_CLIENTS);
     ASSERT_TRUE(client->connect()) << "Client failed to connect";
-
-    std::vector<uint8_t> recv_buffer(16UL * 1024 * 1024);
 
     // Test with different message sizes: 50, 100, 200, 400, 800, 1600 bytes
     // These sizes will cause the ring buffer head to advance to different positions
@@ -130,28 +135,28 @@ TEST_F(ShmTest, VaryingMessageSizes)
             send_data[i] = static_cast<uint8_t>(i & 0xFF);
         }
 
-        ASSERT_TRUE(client->send(send_data.data(), send_data.size(), 0)) << "Failed to send message of size " << size;
+        ASSERT_TRUE(client->send(send_data.data(), send_data.size(), 100000000))
+            << "Failed to send message of size " << size;
 
-        ssize_t n = client->recv(recv_buffer.data(), recv_buffer.size(), 0);
-        ASSERT_GT(n, 0) << "Failed to receive response for message size " << size;
-        ASSERT_EQ(static_cast<size_t>(n), size) << "Received size mismatch for message size " << size;
+        auto response = client->recv(100000000); // 100ms timeout
+        ASSERT_FALSE(response.empty()) << "Failed to receive response for message size " << size;
+        ASSERT_EQ(response.size(), size) << "Received size mismatch for message size " << size;
 
-        EXPECT_EQ(std::memcmp(recv_buffer.data(), send_data.data(), size), 0)
-            << "Data mismatch for message size " << size;
+        EXPECT_EQ(std::memcmp(response.data(), send_data.data(), size), 0) << "Data mismatch for message size " << size;
+
+        client->release(response.size());
     }
 
     client->close();
 }
 
-// This test reproduces the ring buffer wrapping issue from the TypeScript benchmark
-// By sending many messages repeatedly, we advance the ring buffer head position
-// Eventually, a message will hit the wrap boundary and fail with the unfixed implementation
-TEST_F(ShmTest, RingBufferWrapStressTest)
+// High-volume sequential message test
+// Single client sends 5000 messages (1000 iterations × 5 sizes) to validate
+// sustained high-throughput single-client workloads with natural ring buffer advancement
+TEST_F(ShmTest, HighVolumeSequentialMessages)
 {
     auto client = IpcClient::create_shm(shm_name, MAX_CLIENTS);
     ASSERT_TRUE(client->connect()) << "Client failed to connect";
-
-    std::vector<uint8_t> recv_buffer(16UL * 1024 * 1024);
 
     // Simulate the benchmark: many iterations with varying message sizes
     // This will advance the ring head and eventually hit a wrap boundary
@@ -174,14 +179,16 @@ TEST_F(ShmTest, RingBufferWrapStressTest)
             ASSERT_TRUE(send_ok) << "Failed to send at iteration " << iter << " size " << size
                                  << " (requests processed: " << requests_processed.load() << ")";
 
-            ssize_t n = client->recv(recv_buffer.data(), recv_buffer.size(), 100000000); // 100ms timeout
-            ASSERT_GT(n, 0) << "Failed to receive at iteration " << iter << " size " << size
-                            << " (requests processed: " << requests_processed.load() << ")";
+            auto response = client->recv(100000000); // 100ms timeout
+            ASSERT_FALSE(response.empty()) << "Failed to receive at iteration " << iter << " size " << size
+                                           << " (requests processed: " << requests_processed.load() << ")";
 
-            ASSERT_EQ(static_cast<size_t>(n), size) << "Size mismatch at iteration " << iter << " size " << size;
+            ASSERT_EQ(response.size(), size) << "Size mismatch at iteration " << iter << " size " << size;
 
-            EXPECT_EQ(std::memcmp(recv_buffer.data(), send_data.data(), size), 0)
+            EXPECT_EQ(std::memcmp(response.data(), send_data.data(), size), 0)
                 << "Data corruption at iteration " << iter << " size " << size;
+
+            client->release(response.size());
         }
     }
 
@@ -204,8 +211,6 @@ TEST_F(ShmTest, ConcurrentClients)
                 return;
             }
 
-            std::vector<uint8_t> recv_buffer(1024);
-
             // Each client sends 100 messages
             for (size_t i = 0; i < 100; i++) {
                 std::vector<uint8_t> send_data = { static_cast<uint8_t>(client_idx), static_cast<uint8_t>(i & 0xFF) };
@@ -215,16 +220,18 @@ TEST_F(ShmTest, ConcurrentClients)
                     break;
                 }
 
-                ssize_t n = client->recv(recv_buffer.data(), recv_buffer.size(), 100000000);
-                if (n < 0 || static_cast<size_t>(n) != send_data.size()) {
+                auto response = client->recv(100000000);
+                if (response.empty() || response.size() != send_data.size()) {
                     failures.fetch_add(1);
                     break;
                 }
 
-                if (std::memcmp(recv_buffer.data(), send_data.data(), send_data.size()) != 0) {
+                if (std::memcmp(response.data(), send_data.data(), send_data.size()) != 0) {
                     failures.fetch_add(1);
                     break;
                 }
+
+                client->release(response.size());
             }
 
             client->close();
@@ -236,6 +243,451 @@ TEST_F(ShmTest, ConcurrentClients)
     }
 
     EXPECT_EQ(failures.load(), 0) << failures.load() << " failures occurred in concurrent client test";
+}
+
+// Concurrent clients with constrained buffer size under high load
+// 4 concurrent clients sending large messages (8-18KB) to a small ring buffer (48KB)
+// Tests correctness under extreme concurrent stress with frequent buffer wrapping
+TEST_F(ShmTest, ConcurrentClientsSmallRingHighLoad)
+{
+    // AGGRESSIVE: Small ring buffers to force very frequent wrapping
+    // 48KB rings with up to 18KB messages = wraps every 2-3 messages
+    // Request/response are SEPARATE rings
+    constexpr size_t SMALL_RING_SIZE = 48 * 1024; // 48KB per ring
+    constexpr size_t NUM_PRODUCER_THREADS = 4;
+    constexpr size_t MESSAGES_PER_THREAD = 500;
+
+    // Create server with small ring buffers to trigger wrapping frequently
+    // Use short name for macOS compatibility (31-char limit)
+    std::string race_test_shm = "shm_race_" + std::to_string(getpid());
+    auto race_server = IpcServer::create_shm(race_test_shm, MAX_CLIENTS, SMALL_RING_SIZE, SMALL_RING_SIZE);
+    ASSERT_TRUE(race_server->listen()) << "Race test server failed to listen";
+
+    std::atomic<bool> server_running{ true };
+    std::atomic<size_t> messages_processed{ 0 };
+    std::atomic<size_t> data_corruption_detected{ 0 };
+
+    // Start aggressive echo server that reads as fast as possible
+    std::thread server_thread([&]() {
+        while (server_running.load(std::memory_order_acquire)) {
+            race_server->accept();
+
+            // Poll very aggressively - minimal timeout to maximize race window
+            int client_id = race_server->wait_for_data(1000000); // 1ms timeout
+            if (client_id < 0) {
+                continue;
+            }
+
+            auto request = race_server->receive(client_id);
+            if (!request.empty()) {
+                // Validate message integrity before echoing
+                // Each message should start with a magic header: [thread_id][msg_seq][pattern...]
+                if (request.size() >= 8) {
+                    uint32_t thread_id, msg_seq;
+                    std::memcpy(&thread_id, request.data(), sizeof(uint32_t));
+                    std::memcpy(&msg_seq, request.data() + 4, sizeof(uint32_t));
+
+                    // Validate the pattern in the rest of the message
+                    bool corrupted = false;
+                    for (size_t i = 8; i < request.size(); i += 4) {
+                        uint32_t expected = thread_id ^ msg_seq ^ static_cast<uint32_t>(i);
+                        uint32_t actual;
+                        std::memcpy(&actual, request.data() + i, sizeof(uint32_t));
+                        if (actual != expected) {
+                            corrupted = true;
+                            data_corruption_detected.fetch_add(1, std::memory_order_relaxed);
+                            std::cerr << "CORRUPTION DETECTED: thread=" << thread_id << " seq=" << msg_seq
+                                      << " offset=" << i << " expected=0x" << std::hex << expected << " actual=0x"
+                                      << actual << std::dec << '\n';
+                            break;
+                        }
+                    }
+
+                    if (!corrupted) {
+                        messages_processed.fetch_add(1, std::memory_order_relaxed);
+                    }
+                }
+
+                // Echo back regardless of corruption to unblock client
+                race_server->send(client_id, request.data(), request.size());
+                race_server->release(client_id, request.size());
+            }
+        }
+    });
+
+    // Give server time to initialize
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+
+    // Launch multiple producer threads that hammer the server
+    std::vector<std::thread> producer_threads;
+    std::atomic<size_t> send_failures{ 0 };
+    std::atomic<size_t> recv_failures{ 0 };
+    std::atomic<size_t> validation_failures{ 0 };
+
+    producer_threads.reserve(NUM_PRODUCER_THREADS);
+    for (size_t thread_id = 0; thread_id < NUM_PRODUCER_THREADS; thread_id++) {
+        producer_threads.emplace_back([&, thread_id]() {
+            auto client = IpcClient::create_shm(race_test_shm, MAX_CLIENTS);
+            if (!client->connect()) {
+                send_failures.fetch_add(1);
+                return;
+            }
+
+            // AGGRESSIVE message sizes to force wrapping constantly
+            // With 48KB ring, these sizes (8-18KB) will wrap every 2-5 messages
+            // Keep max size < ring size to ensure wrapping logic works
+            std::vector<size_t> message_sizes = { 8192, 12288, 14336, 16384, 18432 };
+
+            std::vector<uint8_t> send_buffer(24 * 1024); // Max size buffer
+
+            for (size_t msg_seq = 0; msg_seq < MESSAGES_PER_THREAD; msg_seq++) {
+                // Rotate through different sizes to create unpredictable wrap points
+                size_t msg_size = message_sizes[msg_seq % message_sizes.size()];
+
+                // Build message with validation header and pattern
+                uint32_t tid = static_cast<uint32_t>(thread_id);
+                uint32_t seq = static_cast<uint32_t>(msg_seq);
+
+                std::memcpy(send_buffer.data(), &tid, sizeof(uint32_t));
+                std::memcpy(send_buffer.data() + 4, &seq, sizeof(uint32_t));
+
+                // Fill rest with verifiable pattern
+                for (size_t i = 8; i < msg_size; i += 4) {
+                    uint32_t pattern = tid ^ seq ^ static_cast<uint32_t>(i);
+                    std::memcpy(send_buffer.data() + i, &pattern, sizeof(uint32_t));
+                }
+
+                // Send with timeout
+                if (!client->send(send_buffer.data(), msg_size, 100000000)) { // 100ms
+                    send_failures.fetch_add(1);
+                    std::cerr << "Send failed: thread=" << thread_id << " seq=" << msg_seq << '\n';
+                    break;
+                }
+
+                // Receive echo
+                auto response = client->recv(100000000);
+                if (response.empty() || response.size() != msg_size) {
+                    recv_failures.fetch_add(1);
+                    std::cerr << "Recv failed: thread=" << thread_id << " seq=" << msg_seq << " got=" << response.size()
+                              << " expected=" << msg_size << '\n';
+                    break;
+                }
+
+                // Validate echoed data
+                if (std::memcmp(response.data(), send_buffer.data(), msg_size) != 0) {
+                    validation_failures.fetch_add(1);
+                    std::cerr << "Validation failed: thread=" << thread_id << " seq=" << msg_seq << '\n';
+
+                    // Find first mismatch
+                    for (size_t i = 0; i < msg_size; i++) {
+                        if (response.data()[i] != send_buffer[i]) {
+                            std::cerr << "  First mismatch at offset " << i << ": expected=0x" << std::hex
+                                      << static_cast<int>(send_buffer[i]) << " actual=0x"
+                                      << static_cast<int>(response.data()[i]) << std::dec << '\n';
+                            break;
+                        }
+                    }
+                    break;
+                }
+
+                client->release(response.size());
+
+                // No delay - hammer the server as fast as possible to maximize race probability
+            }
+
+            client->close();
+        });
+    }
+
+    // Wait for all producers to finish
+    for (auto& t : producer_threads) {
+        t.join();
+    }
+
+    // Stop server
+    server_running.store(false, std::memory_order_release);
+    race_server->request_shutdown();
+    server_thread.join();
+    race_server->close();
+
+    // Report results
+    // size_t expected_messages = NUM_PRODUCER_THREADS * MESSAGES_PER_THREAD;
+    // std::cerr << "\n=== Concurrent Clients Small Ring High Load Test Results ===" << '\n';
+    // std::cerr << "Expected messages:        " << expected_messages << '\n';
+    // std::cerr << "Messages processed:       " << messages_processed.load() << '\n';
+    // std::cerr << "Data corruption detected: " << data_corruption_detected.load() << '\n';
+    // std::cerr << "Send failures:            " << send_failures.load() << '\n';
+    // std::cerr << "Recv failures:            " << recv_failures.load() << '\n';
+    // std::cerr << "Validation failures:      " << validation_failures.load() << '\n';
+
+    // Test expectations
+    // The PRIMARY goal is detecting corruption - that's the race condition bug
+    // Send/recv failures could indicate the bug OR just heavy load/timeouts
+    EXPECT_EQ(data_corruption_detected.load(), 0) << "*** DATA CORRUPTION DETECTED - RACE CONDITION TRIGGERED! ***";
+    EXPECT_EQ(validation_failures.load(), 0) << "Message validation failed";
+
+    // Report but don't fail on occasional timeouts (they could indicate load or the bug)
+    if (send_failures.load() > 0 || recv_failures.load() > 0) {
+        std::cerr << "WARNING: Some send/recv operations timed out - could indicate bug or just load\n";
+    }
+}
+
+// Single client with constrained buffer under high volume
+// Single client sends 3000 large messages (12-18KB) to a tiny ring buffer (40KB)
+// Tests buffer management under aggressive constraints isolated from concurrency issues
+TEST_F(ShmTest, SingleClientSmallRingHighVolume)
+{
+    // VERY AGGRESSIVE: Wrap on most messages
+    // 40KB ring with 12-18KB messages = wraps every 2-3 messages
+    constexpr size_t TINY_RING_SIZE = 40 * 1024; // 40KB per ring
+    constexpr size_t NUM_ITERATIONS = 3000;
+
+    // Use short name for macOS compatibility (31-char limit)
+    std::string wrap_test_shm = "shm_wrap_" + std::to_string(getpid());
+    auto wrap_server = IpcServer::create_shm(wrap_test_shm, MAX_CLIENTS, TINY_RING_SIZE, TINY_RING_SIZE);
+    ASSERT_TRUE(wrap_server->listen()) << "Wrap test server failed to listen";
+
+    std::atomic<bool> server_running{ true };
+    std::atomic<size_t> corruptions{ 0 };
+
+    // Echo server with validation
+    std::thread server_thread([&]() {
+        while (server_running.load(std::memory_order_acquire)) {
+            wrap_server->accept();
+
+            int client_id = wrap_server->wait_for_data(10000000); // 10ms
+            if (client_id < 0) {
+                continue;
+            }
+
+            auto request = wrap_server->receive(client_id);
+            if (!request.empty()) {
+                // Validate magic pattern
+                if (request.size() >= 4) {
+                    uint32_t magic;
+                    std::memcpy(&magic, request.data(), sizeof(uint32_t));
+                    if (magic != 0xDEADBEEF) {
+                        corruptions.fetch_add(1);
+                        std::cerr << "Magic mismatch: expected=0xDEADBEEF actual=0x" << std::hex << magic << std::dec
+                                  << '\n';
+                    }
+                }
+
+                wrap_server->send(client_id, request.data(), request.size());
+                wrap_server->release(client_id, request.size());
+            }
+        }
+    });
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(300));
+
+    auto client = IpcClient::create_shm(wrap_test_shm, MAX_CLIENTS);
+    ASSERT_TRUE(client->connect());
+
+    std::vector<uint8_t> send_buffer(24 * 1024);
+
+    // Fill with magic pattern
+    uint32_t magic = 0xDEADBEEF;
+    for (size_t i = 0; i < send_buffer.size(); i += 4) {
+        std::memcpy(send_buffer.data() + i, &magic, sizeof(uint32_t));
+    }
+
+    // AGGRESSIVE: Messages close to ring size = wrap every 2-3 messages
+    // 40KB ring with 12-18KB messages
+    std::vector<size_t> sizes = { 12288, 14336, 16384, 18432, 15360 };
+
+    for (size_t iter = 0; iter < NUM_ITERATIONS; iter++) {
+        size_t size = sizes[iter % sizes.size()];
+
+        ASSERT_TRUE(client->send(send_buffer.data(), size, 50000000)) // 50ms
+            << "Send failed at iteration " << iter;
+
+        auto response = client->recv(50000000);
+        ASSERT_FALSE(response.empty()) << "Recv failed at iteration " << iter;
+        ASSERT_EQ(response.size(), size) << "Size mismatch at iteration " << iter;
+
+        ASSERT_EQ(std::memcmp(response.data(), send_buffer.data(), size), 0) << "Data corruption at iteration " << iter;
+
+        client->release(response.size());
+    }
+
+    client->close();
+
+    server_running.store(false);
+    wrap_server->request_shutdown();
+    server_thread.join();
+    wrap_server->close();
+
+    EXPECT_EQ(corruptions.load(), 0) << "Corruptions detected in single-threaded wrap test";
+}
+
+// ================================================================================================
+// DIRECT SpscShm LOW-LEVEL API TEST
+// ================================================================================================
+// This test directly exercises the SpscShm ring buffer API (bypassing IpcClient/Server)
+// to validate low-level buffer operations with split claim/publish pattern.
+//
+// Tests the split operations pattern where length prefix and message data are
+// claimed and published separately, ensuring correct buffer management at the lowest level.
+//
+// 10,000 iterations with 24KB ring and RANDOM message sizes (9 bytes to 15KB) to exercise
+// many edge cases including small messages, large messages, and frequent wrap boundaries.
+//
+// You can really stress test this with:
+// $ ./ci3/start_interactive
+// $ while true; do
+//     echo 'dump_fail "build/bin/ipc_tests --gtest_filter='SpscShmDirectTest.*'" >/dev/null'
+//   done | parallel -j64 --halt now,fail=1
+// ================================================================================================
+
+TEST(SpscShmDirectTest, LowLevelSplitOperations)
+{
+    // Use VERY small ring to force wrapping on nearly every message
+    constexpr size_t RING_SIZE = 24 * 1024; // 24KB
+    constexpr size_t NUM_ITERATIONS = 100000;
+    constexpr size_t MIN_MESSAGE_SIZE = sizeof(uint64_t) + 1; // Minimum: iteration (8 bytes) + 1 pattern byte
+    constexpr size_t MAX_MESSAGE_SIZE = 15 * 1024;            // Maximum message size (15KB)
+
+    // Create unique shared memory name with PID
+    std::string shm_name = "direct_spsc_race_test_" + std::to_string(getpid());
+
+    // Create the ring buffer
+    auto producer_ring = SpscShm::create(shm_name, RING_SIZE);
+
+    std::atomic<size_t> corruption_detected{ 0 };
+    std::atomic<size_t> messages_validated{ 0 };
+
+    // Generate random message sizes ahead of time
+    // Use high-resolution clock + random_device for better entropy
+    std::random_device rd;
+    auto seed = rd() ^ static_cast<unsigned>(std::chrono::high_resolution_clock::now().time_since_epoch().count());
+    std::mt19937 gen(seed);
+    std::uniform_int_distribution<size_t> size_dist(MIN_MESSAGE_SIZE, MAX_MESSAGE_SIZE);
+
+    std::vector<size_t> message_sizes(NUM_ITERATIONS);
+    for (size_t i = 0; i < NUM_ITERATIONS; i++) {
+        message_sizes[i] = size_dist(gen);
+    }
+
+    // Log seed for reproducibility if needed
+    std::cerr << "Random seed: " << seed << " (save this to reproduce the exact sequence)\n";
+
+    // Consumer thread: Consume exactly NUM_ITERATIONS messages
+    std::thread consumer([&]() {
+        auto consumer_ring = SpscShm::connect(shm_name);
+
+        for (size_t expected_iteration = 0; expected_iteration < NUM_ITERATIONS; expected_iteration++) {
+            // Peek and release the length prefix (4 bytes) - retry on timeout
+            void* len_ptr = nullptr;
+            while ((len_ptr = consumer_ring.peek(sizeof(uint32_t), 100000000)) == nullptr) {
+                // Producer is behind, wait and retry
+            }
+
+            // Read message length
+            uint32_t msg_len;
+            std::memcpy(&msg_len, len_ptr, sizeof(uint32_t));
+
+            // Release the length prefix
+            consumer_ring.release(sizeof(uint32_t));
+
+            // Now peek the message data - retry on timeout
+            void* msg_ptr = nullptr;
+            while ((msg_ptr = consumer_ring.peek(msg_len, 100000000)) == nullptr) {
+                // Producer is behind, wait and retry
+            }
+
+            // Read iteration value (now at the start of message data)
+            uint64_t msg_iteration;
+            std::memcpy(&msg_iteration, msg_ptr, sizeof(uint64_t));
+
+            // CHECK: Iteration must match expected sequence!
+            if (msg_iteration != expected_iteration) {
+                corruption_detected.fetch_add(1, std::memory_order_relaxed);
+                std::cerr << "CORRUPTION: iteration mismatch expected=" << expected_iteration
+                          << " actual=" << msg_iteration << "\n";
+            }
+
+            // Validate pattern: starts after iteration
+            bool corrupted = false;
+            auto* bytes = static_cast<uint8_t*>(msg_ptr);
+
+            for (size_t i = sizeof(uint64_t); i < msg_len; i++) {
+                // XOR offset now relative to message data start (after length was released)
+                uint8_t expected = static_cast<uint8_t>((msg_iteration ^ i) & 0xFF);
+                if (bytes[i] != expected) {
+                    corrupted = true;
+                    corruption_detected.fetch_add(1, std::memory_order_relaxed);
+                    std::cerr << "CORRUPTION at iteration " << msg_iteration << " offset " << i << " expected=0x"
+                              << std::hex << (int)expected << " actual=0x" << (int)bytes[i] << std::dec << "\n";
+                    break;
+                }
+            }
+
+            if (!corrupted && msg_iteration == expected_iteration) {
+                messages_validated.fetch_add(1, std::memory_order_relaxed);
+            }
+
+            // Release the message data
+            consumer_ring.release(msg_len);
+        }
+    });
+
+    // Give consumer time to connect
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+    // Producer thread: Write messages with random sizes
+    // Allocate buffer for max message size
+    std::vector<uint8_t> message_buffer(MAX_MESSAGE_SIZE + sizeof(uint32_t));
+
+    for (size_t iter = 0; iter < NUM_ITERATIONS; iter++) {
+        // Get random message size for this iteration
+        size_t total_message_size = message_sizes[iter] + sizeof(uint32_t); // Include length prefix
+
+        // Prepare message pattern: [4-byte length][8-byte iteration][pattern bytes]
+        // Length excludes the length field itself
+        uint32_t data_len = static_cast<uint32_t>(message_sizes[iter]);
+        std::memcpy(message_buffer.data(), &data_len, sizeof(uint32_t));
+
+        uint64_t iteration_value = iter;
+        std::memcpy(message_buffer.data() + sizeof(uint32_t), &iteration_value, sizeof(uint64_t));
+
+        // Pattern starts after length+iteration
+        for (size_t i = sizeof(uint32_t) + sizeof(uint64_t); i < total_message_size; i++) {
+            message_buffer[i] = static_cast<uint8_t>((iter ^ (i - sizeof(uint32_t))) & 0xFF);
+        }
+
+        // Claim and publish length prefix separately (retry on timeout)
+        void* len_buf = nullptr;
+        while ((len_buf = producer_ring.claim(sizeof(uint32_t), 100000000)) == nullptr) {
+            // Consumer is behind, wait and retry
+        }
+        std::memcpy(len_buf, message_buffer.data(), sizeof(uint32_t));
+        producer_ring.publish(sizeof(uint32_t));
+
+        // Claim and publish message data separately (retry on timeout)
+        void* data_buf = nullptr;
+        while ((data_buf = producer_ring.claim(data_len, 100000000)) == nullptr) {
+            // Consumer is behind, wait and retry
+        }
+        std::memcpy(data_buf, message_buffer.data() + sizeof(uint32_t), data_len);
+        producer_ring.publish(data_len);
+    }
+
+    // Wait for consumer to finish processing all messages
+    consumer.join();
+
+    // Cleanup
+    SpscShm::unlink(shm_name);
+
+    // Report results
+    // std::cerr << "\n=== Low-Level Split Operations Test Results ===" << '\n';
+    // std::cerr << "Total iterations:         " << NUM_ITERATIONS << '\n';
+    // std::cerr << "Messages validated:       " << messages_validated.load() << '\n';
+    // std::cerr << "Corruption detected:      " << corruption_detected.load() << '\n';
+
+    // Test expectations
+    EXPECT_EQ(corruption_detected.load(), 0) << "*** DATA CORRUPTION DETECTED - WRAP RACE TRIGGERED! ***";
+    EXPECT_EQ(messages_validated.load(), NUM_ITERATIONS) << "Not all messages were validated";
 }
 
 } // namespace

--- a/barretenberg/cpp/src/barretenberg/ipc/shm/futex.hpp
+++ b/barretenberg/cpp/src/barretenberg/ipc/shm/futex.hpp
@@ -16,11 +16,13 @@
 // Forward declarations to avoid header dependency
 extern "C" {
 int os_sync_wait_on_address(void* addr, uint64_t value, size_t size, uint32_t flags);
-int os_sync_wait_on_address_with_timeout(void* addr, uint64_t value, size_t size, uint32_t flags, uint64_t timeout_ns);
+int os_sync_wait_on_address_with_timeout(
+    void* addr, uint64_t value, size_t size, uint32_t flags, uint32_t clockid, uint64_t timeout_ns);
 int os_sync_wake_by_address_any(void* addr, size_t size, uint32_t flags);
 }
 #define OS_SYNC_WAIT_ON_ADDRESS_SHARED 1u
 #define OS_SYNC_WAKE_BY_ADDRESS_SHARED 1u
+#define OS_CLOCK_MACH_ABSOLUTE_TIME 32u
 #else
 // Linux futex
 #include <cerrno>
@@ -68,10 +70,12 @@ inline int futex_wait_timeout(volatile uint32_t* addr, uint32_t expect, uint64_t
 {
 #ifdef __APPLE__
     // macOS: Use os_sync_wait_on_address_with_timeout with SHARED flag for cross-process
+    // Uses MACH_ABSOLUTE_TIME clock (monotonic, measures time since boot)
     return os_sync_wait_on_address_with_timeout(const_cast<uint32_t*>(addr),
                                                 static_cast<uint64_t>(expect),
                                                 sizeof(uint32_t),
                                                 OS_SYNC_WAIT_ON_ADDRESS_SHARED,
+                                                OS_CLOCK_MACH_ABSOLUTE_TIME,
                                                 timeout_ns);
 #else
     // Linux futex with timeout

--- a/barretenberg/cpp/src/barretenberg/ipc/shm/spsc_shm.hpp
+++ b/barretenberg/cpp/src/barretenberg/ipc/shm/spsc_shm.hpp
@@ -34,10 +34,15 @@ struct alignas(SPSC_CACHELINE) SpscCtrl {
     alignas(SPSC_CACHELINE) std::atomic<uint64_t> tail; // bytes consumed
     std::array<char, SPSC_CACHELINE - sizeof(tail)> _pad1;
 
-    // Futex sequencers (increment on empty→nonempty and full→has-space)
+    // Producer-owned sequencer and flag (written by producer in publish())
     alignas(SPSC_CACHELINE) std::atomic<uint32_t> data_seq;
+    std::atomic<bool> producer_blocked; // Written by producer in wait_for_space()
+    std::array<char, SPSC_CACHELINE - sizeof(data_seq) - sizeof(producer_blocked)> _pad2;
+
+    // Consumer-owned sequencer and flag (written by consumer)
     alignas(SPSC_CACHELINE) std::atomic<uint32_t> space_seq;
-    std::array<char, SPSC_CACHELINE - (sizeof(data_seq) + sizeof(space_seq))> _pad2;
+    std::atomic<bool> consumer_blocked; // Written by consumer in wait_for_data()
+    std::array<char, SPSC_CACHELINE - sizeof(space_seq) - sizeof(consumer_blocked)> _pad3;
 
     // Immutable capacity information
     alignas(SPSC_CACHELINE) uint64_t capacity; // power of two
@@ -54,6 +59,20 @@ static_assert(sizeof(SpscCtrl) % SPSC_CACHELINE == 0, "SpscCtrl size multiple of
  *
  * Provides zero-copy message passing between processes using shared memory.
  * Uses futex for efficient blocking when empty/full.
+ *
+ * CRITICAL USAGE REQUIREMENT:
+ * Each claim(n)/publish(n) pair by the producer MUST be perfectly matched by a corresponding
+ * peek(n)/release(n) pair by the consumer, with the EXACT same sizes.
+ *
+ * This is because the wrapping logic is completely stateless - it decides whether to wrap based
+ * solely on whether the requested size fits in the remaining space before the end of the buffer.
+ * If the producer and consumer use different sizes, they will make inconsistent wrap decisions
+ * and data corruption will occur.
+ *
+ * CORRECT usage example (framed messages):
+ *   Producer:                               Consumer:
+ *   claim(4), publish(4)             <--->  peek(4), release(4)              // length prefix
+ *   claim(msg_len), publish(msg_len) <--->  peek(msg_len), release(msg_len)  // message data
  */
 class SpscShm {
   public:
@@ -88,32 +107,75 @@ class SpscShm {
     ~SpscShm();
 
     // Introspection
-    uint64_t available() const;  // bytes ready to read
-    uint64_t free_space() const; // bytes free to write
+    uint64_t available() const; // bytes ready to read
 
-    // Producer API
-    void* claim(size_t want, size_t* granted); // claim contiguous space (may wrap)
-    void publish(size_t n);                    // publish n bytes
+    /**
+     * Producer API: claim() and publish() must be used in pairs
+     *
+     * @brief Claim contiguous space in the ring buffer (blocks until available)
+     * @param want Number of bytes to claim
+     * @param timeout_ns Timeout in nanoseconds
+     * @return Pointer to claimed space, or nullptr on timeout
+     *
+     * IMPORTANT: The size passed to claim(want) must exactly match the size passed to the
+     * corresponding peek(want) call by the consumer. Otherwise wrap decisions will be inconsistent.
+     */
+    void* claim(size_t want, uint32_t timeout_ns);
 
-    // Consumer API
-    void* peek(size_t* n);  // peek contiguous readable region (skips padding)
-    void release(size_t n); // release n bytes
+    /**
+     * @brief Publish n bytes previously claimed
+     * @param n Number of bytes to publish (must match what was claimed)
+     *
+     * IMPORTANT: The size passed to publish(n) must exactly match the size passed to the
+     * corresponding release(n) call by the consumer. Otherwise wrap decisions will be inconsistent.
+     */
+    void publish(size_t n);
 
-    // Adaptive wait (spin for spin_ns, then futex sleep)
-    bool wait_for_data(uint32_t spin_ns);               // returns true if data available
-    bool wait_for_space(size_t need, uint32_t spin_ns); // returns true if space available
+    /**
+     * Consumer API: peek() and release() must be used in pairs
+     *
+     * @brief Peek contiguous readable region (blocks until available)
+     * @param want Number of bytes to peek
+     * @param timeout_ns Timeout in nanoseconds
+     * @return Pointer to readable data, or nullptr on timeout
+     *
+     * IMPORTANT: The size passed to peek(want) must exactly match the size passed to the
+     * corresponding claim(want) call by the producer. Otherwise wrap decisions will be inconsistent.
+     */
+    void* peek(size_t want, uint32_t timeout_ns);
 
-    // Wake all blocked threads (for graceful shutdown)
+    /**
+     * @brief Release n bytes previously peeked
+     * @param n Number of bytes to release (must match what was peeked)
+     *
+     * IMPORTANT: The size passed to release(n) must exactly match the size passed to the
+     * corresponding publish(n) call by the producer. Otherwise wrap decisions will be inconsistent.
+     */
+    void release(size_t n);
+
+    /**
+     * @brief Wake all blocked threads (for graceful shutdown)
+     *
+     * Wakes both producers blocked on space and consumers blocked on data.
+     * Used for graceful shutdown of the communication channel.
+     */
     void wakeup_all();
 
   private:
     // Private constructor for create/connect factories
     SpscShm(int fd, size_t map_len, SpscCtrl* ctrl, uint8_t* buf);
 
+    // Internal helpers
+    uint64_t free_space() const;                        // bytes free to write
+    bool wait_for_data(size_t need, uint32_t spin_ns);  // returns true if data available
+    bool wait_for_space(size_t need, uint32_t spin_ns); // returns true if space available
+
     int fd_ = -1;
     size_t map_len_ = 0;
     SpscCtrl* ctrl_ = nullptr;
     uint8_t* buf_ = nullptr;
+    bool previous_had_data_ = false;  // Adaptive spinning: consumer only spins if previous call found data
+    bool previous_had_space_ = false; // Adaptive spinning: producer only spins if previous call found space
 };
 
 } // namespace bb::ipc

--- a/barretenberg/cpp/src/barretenberg/ipc/socket_client.hpp
+++ b/barretenberg/cpp/src/barretenberg/ipc/socket_client.hpp
@@ -3,8 +3,10 @@
 #include "barretenberg/ipc/ipc_client.hpp"
 #include <cstddef>
 #include <cstdint>
+#include <span>
 #include <string>
 #include <sys/types.h>
+#include <vector>
 
 namespace bb::ipc {
 
@@ -26,7 +28,8 @@ class SocketClient : public IpcClient {
 
     bool connect() override;
     bool send(const void* data, size_t len, uint64_t timeout_ns) override;
-    ssize_t recv(void* buffer, size_t max_len, uint64_t timeout_ns) override;
+    std::span<const uint8_t> recv(uint64_t timeout_ns) override;
+    void release(size_t message_size) override;
     void close() override;
 
   private:
@@ -34,6 +37,7 @@ class SocketClient : public IpcClient {
 
     std::string socket_path_;
     int fd_ = -1;
+    std::vector<uint8_t> recv_buffer_; // Internal buffer for socket recv
 };
 
 } // namespace bb::ipc

--- a/barretenberg/cpp/src/barretenberg/ipc/socket_server.cpp
+++ b/barretenberg/cpp/src/barretenberg/ipc/socket_server.cpp
@@ -2,6 +2,7 @@
 #include <cerrno>
 #include <cstdint>
 #include <cstring>
+#include <fcntl.h>
 #include <span>
 #include <string>
 #include <sys/socket.h>
@@ -33,309 +34,48 @@ SocketServer::~SocketServer()
     close_internal();
 }
 
-bool SocketServer::listen()
+void SocketServer::close()
 {
-    if (listen_fd_ >= 0) {
-        return true; // Already listening
-    }
-
-    // Remove any existing socket file
-    ::unlink(socket_path_.c_str());
-
-    // Create socket
-    listen_fd_ = socket(AF_UNIX, SOCK_STREAM, 0);
-    if (listen_fd_ < 0) {
-        return false;
-    }
-
-    // Bind to path
-    struct sockaddr_un addr;
-    std::memset(&addr, 0, sizeof(addr));
-    addr.sun_family = AF_UNIX;
-    std::strncpy(addr.sun_path, socket_path_.c_str(), sizeof(addr.sun_path) - 1);
-
-    if (bind(listen_fd_, reinterpret_cast<struct sockaddr*>(&addr), sizeof(addr)) < 0) {
-        ::close(listen_fd_);
-        listen_fd_ = -1;
-        return false;
-    }
-
-    // Listen with backlog
-    int backlog = initial_max_clients_ > 0 ? initial_max_clients_ : 10;
-    if (::listen(listen_fd_, backlog) < 0) {
-        ::close(listen_fd_);
-        listen_fd_ = -1;
-        ::unlink(socket_path_.c_str());
-        return false;
-    }
-
-#ifdef __APPLE__
-    // Create kqueue instance
-    kqueue_fd_ = kqueue();
-    if (kqueue_fd_ < 0) {
-        ::close(listen_fd_);
-        listen_fd_ = -1;
-        ::unlink(socket_path_.c_str());
-        return false;
-    }
-
-    // Add listen socket to kqueue
-    struct kevent ev;
-    EV_SET(&ev, listen_fd_, EVFILT_READ, EV_ADD | EV_ENABLE, 0, 0, nullptr);
-    if (kevent(kqueue_fd_, &ev, 1, nullptr, 0, nullptr) < 0) {
-        ::close(kqueue_fd_);
-        kqueue_fd_ = -1;
-        ::close(listen_fd_);
-        listen_fd_ = -1;
-        ::unlink(socket_path_.c_str());
-        return false;
-    }
-#else
-    // Create epoll instance
-    epoll_fd_ = epoll_create1(0);
-    if (epoll_fd_ < 0) {
-        ::close(listen_fd_);
-        listen_fd_ = -1;
-        ::unlink(socket_path_.c_str());
-        return false;
-    }
-
-    // Add listen socket to epoll
-    struct epoll_event ev;
-    ev.events = EPOLLIN;
-    ev.data.fd = listen_fd_;
-    if (epoll_ctl(epoll_fd_, EPOLL_CTL_ADD, listen_fd_, &ev) < 0) {
-        ::close(epoll_fd_);
-        epoll_fd_ = -1;
-        ::close(listen_fd_);
-        listen_fd_ = -1;
-        ::unlink(socket_path_.c_str());
-        return false;
-    }
-#endif
-
-    return true;
+    close_internal();
 }
 
-int SocketServer::accept(uint64_t timeout_ns)
+void SocketServer::close_internal()
 {
-    if (listen_fd_ < 0) {
-        errno = EINVAL;
-        return -1;
-    }
-
-#ifdef __APPLE__
-    // Wait for connection using kqueue
-    struct kevent ev;
-    struct timespec timeout;
-    struct timespec* timeout_ptr = nullptr;
-
-    if (timeout_ns > 0) {
-        timeout.tv_sec = static_cast<time_t>(timeout_ns / 1000000000ULL);
-        timeout.tv_nsec = static_cast<long>(timeout_ns % 1000000000ULL);
-        timeout_ptr = &timeout;
-    } else if (timeout_ns == 0) {
-        timeout.tv_sec = 0;
-        timeout.tv_nsec = 0;
-        timeout_ptr = &timeout;
-    }
-
-    int n = kevent(kqueue_fd_, nullptr, 0, &ev, 1, timeout_ptr);
-    if (n <= 0) {
-        return -1;
-    }
-
-    if (static_cast<int>(ev.ident) != listen_fd_) {
-        errno = EINVAL;
-        return -1;
-    }
-#else
-    // Wait for connection using epoll
-    struct epoll_event ev;
-    int timeout_ms = -1; // default: infinite
-    if (timeout_ns > 0) {
-        timeout_ms = static_cast<int>(timeout_ns / 1000000);
-    } else if (timeout_ns == 0) {
-        timeout_ms = 0;
-    }
-    int n = epoll_wait(epoll_fd_, &ev, 1, timeout_ms);
-    if (n <= 0) {
-        return -1;
-    }
-
-    if (ev.data.fd != listen_fd_) {
-        errno = EINVAL;
-        return -1;
-    }
-#endif
-
-    // Accept connection
-    int client_fd = ::accept(listen_fd_, nullptr, nullptr);
-    if (client_fd < 0) {
-        return -1;
-    }
-
-    // Find free slot (or allocate new one)
-    int client_id = find_free_slot();
-
-    // Store client fd
-    const auto client_id_unsigned = static_cast<size_t>(client_id);
-    if (client_id_unsigned >= client_fds_.size()) {
-        client_fds_.resize(client_id_unsigned + 1, -1);
-    }
-    client_fds_[static_cast<size_t>(client_id)] = client_fd;
-    fd_to_client_id_[client_fd] = client_id;
-    num_clients_++;
-
-#ifdef __APPLE__
-    // Add client to kqueue
-    struct kevent kev;
-    EV_SET(&kev, client_fd, EVFILT_READ, EV_ADD | EV_ENABLE, 0, 0, nullptr);
-    if (kevent(kqueue_fd_, &kev, 1, nullptr, 0, nullptr) < 0) {
-        disconnect_client(client_id);
-        return -1;
-    }
-#else
-    // Add client to epoll
-    ev.events = EPOLLIN;
-    ev.data.fd = client_fd;
-    if (epoll_ctl(epoll_fd_, EPOLL_CTL_ADD, client_fd, &ev) < 0) {
-        disconnect_client(client_id);
-        return -1;
-    }
-#endif
-
-    return client_id;
-}
-
-int SocketServer::wait_for_data(uint64_t timeout_ns)
-{
-#ifdef __APPLE__
-    if (kqueue_fd_ < 0) {
-        errno = EINVAL;
-        return -1;
-    }
-
-    struct kevent ev;
-    struct timespec timeout;
-    struct timespec* timeout_ptr = nullptr;
-
-    if (timeout_ns > 0) {
-        timeout.tv_sec = static_cast<time_t>(timeout_ns / 1000000000ULL);
-        timeout.tv_nsec = static_cast<long>(timeout_ns % 1000000000ULL);
-        timeout_ptr = &timeout;
-    } else if (timeout_ns == 0) {
-        timeout.tv_sec = 0;
-        timeout.tv_nsec = 0;
-        timeout_ptr = &timeout;
-    }
-
-    int n = kevent(kqueue_fd_, nullptr, 0, &ev, 1, timeout_ptr);
-    if (n <= 0) {
-        return -1;
-    }
-
-    int ready_fd = static_cast<int>(ev.ident);
-
-    // Check if it's listen socket (new connection) or client data
-    if (ready_fd == listen_fd_) {
-        errno = EAGAIN; // Signal caller to call accept
-        return -1;
-    }
-
-    // Find which client
-    auto it = fd_to_client_id_.find(ready_fd);
-    if (it == fd_to_client_id_.end()) {
-        errno = ENOENT;
-        return -1;
-    }
-
-    return it->second;
-#else
-    if (epoll_fd_ < 0) {
-        errno = EINVAL;
-        return -1;
-    }
-
-    struct epoll_event ev;
-    int timeout_ms = timeout_ns > 0 ? static_cast<int>(timeout_ns / 1000000) : -1;
-    int n = epoll_wait(epoll_fd_, &ev, 1, timeout_ms);
-    if (n <= 0) {
-        return -1;
-    }
-
-    // Check if it's listen socket (new connection) or client data
-    if (ev.data.fd == listen_fd_) {
-        errno = EAGAIN; // Signal caller to call accept
-        return -1;
-    }
-
-    // Find which client
-    auto it = fd_to_client_id_.find(ev.data.fd);
-    if (it == fd_to_client_id_.end()) {
-        errno = ENOENT;
-        return -1;
-    }
-
-    return it->second;
-#endif
-}
-
-std::span<const uint8_t> SocketServer::receive(int client_id)
-{
-    if (client_id < 0 || static_cast<size_t>(client_id) >= client_fds_.size() ||
-        client_fds_[static_cast<size_t>(client_id)] < 0) {
-        return {};
-    }
-
-    int fd = client_fds_[static_cast<size_t>(client_id)];
-    const auto client_idx = static_cast<size_t>(client_id);
-
-    // Ensure buffers are sized for this client
-    if (client_idx >= recv_buffers_.size()) {
-        recv_buffers_.resize(client_idx + 1);
-    }
-
-    // Read length prefix (4 bytes) atomically with data
-    uint32_t msg_len = 0;
-    ssize_t n = ::recv(fd, &msg_len, sizeof(msg_len), MSG_WAITALL);
-    if (n < 0 || static_cast<size_t>(n) != sizeof(msg_len)) {
-        if (n == 0) {
-            // Client disconnected
-            disconnect_client(client_id);
+    // Close all client connections
+    for (int fd : client_fds_) {
+        if (fd >= 0) {
+            ::close(fd);
         }
-        return {};
+    }
+    client_fds_.clear();
+    fd_to_client_id_.clear();
+    num_clients_ = 0;
+
+    if (fd_ >= 0) {
+        ::close(fd_);
+        fd_ = -1;
     }
 
-    // Resize buffer if needed to fit length prefix + message
-    size_t total_size = sizeof(uint32_t) + msg_len;
-    if (recv_buffers_[client_idx].size() < total_size) {
-        recv_buffers_[client_idx].resize(total_size);
+    if (listen_fd_ >= 0) {
+        ::close(listen_fd_);
+        listen_fd_ = -1;
     }
 
-    // Store length prefix in buffer
-    std::memcpy(recv_buffers_[client_idx].data(), &msg_len, sizeof(uint32_t));
-
-    // Read message data (skip length prefix in buffer)
-    n = ::recv(fd, recv_buffers_[client_idx].data() + sizeof(uint32_t), msg_len, MSG_WAITALL);
-    if (n < 0) {
-        disconnect_client(client_id);
-        return {};
-    }
-    const auto bytes_received = static_cast<size_t>(n);
-    if (bytes_received != msg_len) {
-        disconnect_client(client_id);
-        return {};
-    }
-
-    return std::span<const uint8_t>(recv_buffers_[client_idx].data() + sizeof(uint32_t), msg_len);
+    // Clean up socket file
+    ::unlink(socket_path_.c_str());
 }
 
-void SocketServer::release(int client_id, size_t message_size)
+int SocketServer::find_free_slot()
 {
-    // No-op for sockets - message already consumed from kernel buffer during receive()
-    (void)client_id;
-    (void)message_size;
+    // Look for existing free slot
+    for (size_t i = 0; i < client_fds_.size(); i++) {
+        if (client_fds_[i] == -1) {
+            return static_cast<int>(i);
+        }
+    }
+
+    // No free slot found, allocate new one at end
+    return static_cast<int>(client_fds_.size());
 }
 
 bool SocketServer::send(int client_id, const void* data, size_t len)
@@ -364,42 +104,256 @@ bool SocketServer::send(int client_id, const void* data, size_t len)
     return bytes_sent == len;
 }
 
-void SocketServer::close()
+void SocketServer::release(int client_id, size_t message_size)
 {
-    close_internal();
+    // No-op for sockets - message already consumed from kernel buffer during receive()
+    (void)client_id;
+    (void)message_size;
 }
 
-void SocketServer::close_internal()
+std::span<const uint8_t> SocketServer::receive(int client_id)
 {
-    // Close all client connections
-    for (int fd : client_fds_) {
-        if (fd >= 0) {
-            ::close(fd);
-        }
+    if (client_id < 0 || static_cast<size_t>(client_id) >= client_fds_.size() ||
+        client_fds_[static_cast<size_t>(client_id)] < 0) {
+        return {};
     }
-    client_fds_.clear();
-    fd_to_client_id_.clear();
-    num_clients_ = 0;
+
+    int fd = client_fds_[static_cast<size_t>(client_id)];
+    const auto client_idx = static_cast<size_t>(client_id);
+
+    // Ensure buffers are sized for this client
+    if (client_idx >= recv_buffers_.size()) {
+        recv_buffers_.resize(client_idx + 1);
+    }
+
+    // Read length prefix (4 bytes) - must loop until all bytes received (MSG_WAITALL unreliable on macOS)
+    uint32_t msg_len = 0;
+    size_t total_read = 0;
+    while (total_read < sizeof(msg_len)) {
+        ssize_t n = ::recv(fd, reinterpret_cast<uint8_t*>(&msg_len) + total_read, sizeof(msg_len) - total_read, 0);
+        if (n < 0) {
+            if (errno == EINTR) {
+                continue; // Interrupted, retry
+            }
+            return {};
+        }
+        if (n == 0) {
+            // Client disconnected
+            disconnect_client(client_id);
+            return {};
+        }
+        total_read += static_cast<size_t>(n);
+    }
+
+    // Resize buffer if needed to fit length prefix + message
+    size_t total_size = sizeof(uint32_t) + msg_len;
+    if (recv_buffers_[client_idx].size() < total_size) {
+        recv_buffers_[client_idx].resize(total_size);
+    }
+
+    // Store length prefix in buffer
+    std::memcpy(recv_buffers_[client_idx].data(), &msg_len, sizeof(uint32_t));
+
+    // Read message data - must loop until all bytes received (MSG_WAITALL unreliable on macOS)
+    total_read = 0;
+    while (total_read < msg_len) {
+        ssize_t n =
+            ::recv(fd, recv_buffers_[client_idx].data() + sizeof(uint32_t) + total_read, msg_len - total_read, 0);
+        if (n < 0) {
+            if (errno == EINTR) {
+                continue; // Interrupted, retry
+            }
+            disconnect_client(client_id);
+            return {};
+        }
+        if (n == 0) {
+            // Client disconnected mid-message
+            disconnect_client(client_id);
+            return {};
+        }
+        total_read += static_cast<size_t>(n);
+    }
+
+    return std::span<const uint8_t>(recv_buffers_[client_idx].data() + sizeof(uint32_t), msg_len);
+}
 
 #ifdef __APPLE__
-    if (kqueue_fd_ >= 0) {
-        ::close(kqueue_fd_);
-        kqueue_fd_ = -1;
-    }
-#else
-    if (epoll_fd_ >= 0) {
-        ::close(epoll_fd_);
-        epoll_fd_ = -1;
-    }
-#endif
+// ============================================================================
+// macOS Implementation (kqueue, blocking sockets, simple accept)
+// ============================================================================
 
+bool SocketServer::listen()
+{
     if (listen_fd_ >= 0) {
+        return true; // Already listening
+    }
+
+    // Remove any existing socket file
+    ::unlink(socket_path_.c_str());
+
+    // Create socket
+    listen_fd_ = socket(AF_UNIX, SOCK_STREAM, 0);
+    if (listen_fd_ < 0) {
+        return false;
+    }
+
+    // Set non-blocking mode (required for accept-until-EAGAIN pattern)
+    int flags = fcntl(listen_fd_, F_GETFL, 0);
+    if (flags < 0 || fcntl(listen_fd_, F_SETFL, flags | O_NONBLOCK) < 0) {
         ::close(listen_fd_);
         listen_fd_ = -1;
+        return false;
     }
 
-    // Clean up socket file
-    ::unlink(socket_path_.c_str());
+    // Bind to path
+    struct sockaddr_un addr;
+    std::memset(&addr, 0, sizeof(addr));
+    addr.sun_family = AF_UNIX;
+    std::strncpy(addr.sun_path, socket_path_.c_str(), sizeof(addr.sun_path) - 1);
+
+    if (bind(listen_fd_, reinterpret_cast<struct sockaddr*>(&addr), sizeof(addr)) < 0) {
+        ::close(listen_fd_);
+        listen_fd_ = -1;
+        return false;
+    }
+
+    // Listen with backlog
+    int backlog = initial_max_clients_ > 0 ? initial_max_clients_ : 10;
+    if (::listen(listen_fd_, backlog) < 0) {
+        ::close(listen_fd_);
+        listen_fd_ = -1;
+        ::unlink(socket_path_.c_str());
+        return false;
+    }
+
+    // Create kqueue instance
+    fd_ = kqueue();
+    if (fd_ < 0) {
+        ::close(listen_fd_);
+        listen_fd_ = -1;
+        ::unlink(socket_path_.c_str());
+        return false;
+    }
+
+    // Add listen socket to kqueue
+    struct kevent ev;
+    EV_SET(&ev, listen_fd_, EVFILT_READ, EV_ADD | EV_ENABLE, 0, 0, nullptr);
+    if (kevent(fd_, &ev, 1, nullptr, 0, nullptr) < 0) {
+        ::close(fd_);
+        fd_ = -1;
+        ::close(listen_fd_);
+        listen_fd_ = -1;
+        ::unlink(socket_path_.c_str());
+        return false;
+    }
+
+    return true;
+}
+
+int SocketServer::accept()
+{
+    if (listen_fd_ < 0) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    // Accept all pending connections (loop until EAGAIN)
+    // Non-blocking socket ensures this returns immediately
+    int last_client_id = -1;
+
+    while (true) {
+        int client_fd = ::accept(listen_fd_, nullptr, nullptr);
+
+        if (client_fd < 0) {
+            // Check if this is expected (no more connections) or a real error
+            if (errno == EAGAIN || errno == EWOULDBLOCK) {
+                // No more pending connections - expected, break
+                break;
+            }
+            // Real error - but if we already accepted some, return success
+            if (last_client_id >= 0) {
+                break;
+            }
+            // No connections accepted and got real error
+            return -1;
+        }
+
+        // Set client socket to BLOCKING mode (inherited non-blocking from listen socket)
+        // This avoids busy-waiting in recv() - we only recv after kqueue signals data ready
+        int flags = fcntl(client_fd, F_GETFL, 0);
+        if (flags >= 0) {
+            fcntl(client_fd, F_SETFL, flags & ~O_NONBLOCK);
+        }
+
+        // Find free slot (or allocate new one)
+        int client_id = find_free_slot();
+
+        // Store client fd
+        const auto client_id_unsigned = static_cast<size_t>(client_id);
+        if (client_id_unsigned >= client_fds_.size()) {
+            client_fds_.resize(client_id_unsigned + 1, -1);
+        }
+        client_fds_[static_cast<size_t>(client_id)] = client_fd;
+        fd_to_client_id_[client_fd] = client_id;
+        num_clients_++;
+
+        // Add client to kqueue
+        struct kevent kev;
+        EV_SET(&kev, client_fd, EVFILT_READ, EV_ADD | EV_ENABLE, 0, 0, nullptr);
+        if (kevent(fd_, &kev, 1, nullptr, 0, nullptr) < 0) {
+            disconnect_client(client_id);
+            // Continue trying to accept other pending connections
+            continue;
+        }
+
+        last_client_id = client_id;
+    }
+
+    return last_client_id;
+}
+
+int SocketServer::wait_for_data(uint64_t timeout_ns)
+{
+    if (fd_ < 0) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    struct kevent ev;
+    struct timespec timeout;
+    struct timespec* timeout_ptr = nullptr;
+
+    if (timeout_ns > 0) {
+        timeout.tv_sec = static_cast<time_t>(timeout_ns / 1000000000ULL);
+        timeout.tv_nsec = static_cast<long>(timeout_ns % 1000000000ULL);
+        timeout_ptr = &timeout;
+    } else if (timeout_ns == 0) {
+        timeout.tv_sec = 0;
+        timeout.tv_nsec = 0;
+        timeout_ptr = &timeout;
+    }
+
+    int n = kevent(fd_, nullptr, 0, &ev, 1, timeout_ptr);
+    if (n <= 0) {
+        return -1;
+    }
+
+    int ready_fd = static_cast<int>(ev.ident);
+
+    // Check if it's listen socket (new connection) or client data
+    if (ready_fd == listen_fd_) {
+        errno = EAGAIN; // Signal caller to call accept
+        return -1;
+    }
+
+    // Find which client
+    auto it = fd_to_client_id_.find(ready_fd);
+    if (it == fd_to_client_id_.end()) {
+        errno = ENOENT;
+        return -1;
+    }
+
+    return it->second;
 }
 
 void SocketServer::disconnect_client(int client_id)
@@ -410,15 +364,12 @@ void SocketServer::disconnect_client(int client_id)
 
     int fd = client_fds_[static_cast<size_t>(client_id)];
     if (fd >= 0) {
-#ifdef __APPLE__
         // For kqueue, we don't need explicit deletion - closing the fd removes it automatically
         // But we can explicitly remove it for clarity
         struct kevent ev;
         EV_SET(&ev, fd, EVFILT_READ, EV_DELETE, 0, 0, nullptr);
-        kevent(kqueue_fd_, &ev, 1, nullptr, 0, nullptr);
-#else
-        epoll_ctl(epoll_fd_, EPOLL_CTL_DEL, fd, nullptr);
-#endif
+        kevent(fd_, &ev, 1, nullptr, 0, nullptr);
+
         ::close(fd);
         fd_to_client_id_.erase(fd);
         client_fds_[static_cast<size_t>(client_id)] = -1;
@@ -426,17 +377,190 @@ void SocketServer::disconnect_client(int client_id)
     }
 }
 
-int SocketServer::find_free_slot()
+#else
+
+// ============================================================================
+// Linux Implementation (epoll, non-blocking sockets, accept-until-EAGAIN)
+// ============================================================================
+
+bool SocketServer::listen()
 {
-    // Look for existing free slot
-    for (size_t i = 0; i < client_fds_.size(); i++) {
-        if (client_fds_[i] == -1) {
-            return static_cast<int>(i);
-        }
+    if (listen_fd_ >= 0) {
+        return true; // Already listening
     }
 
-    // No free slot found, allocate new one at end
-    return static_cast<int>(client_fds_.size());
+    // Remove any existing socket file
+    ::unlink(socket_path_.c_str());
+
+    // Create socket
+    listen_fd_ = socket(AF_UNIX, SOCK_STREAM, 0);
+    if (listen_fd_ < 0) {
+        return false;
+    }
+
+    // Set non-blocking mode (required for accept-until-EAGAIN pattern)
+    int flags = fcntl(listen_fd_, F_GETFL, 0);
+    if (flags < 0 || fcntl(listen_fd_, F_SETFL, flags | O_NONBLOCK) < 0) {
+        ::close(listen_fd_);
+        listen_fd_ = -1;
+        return false;
+    }
+
+    // Bind to path
+    struct sockaddr_un addr;
+    std::memset(&addr, 0, sizeof(addr));
+    addr.sun_family = AF_UNIX;
+    std::strncpy(addr.sun_path, socket_path_.c_str(), sizeof(addr.sun_path) - 1);
+
+    if (bind(listen_fd_, reinterpret_cast<struct sockaddr*>(&addr), sizeof(addr)) < 0) {
+        ::close(listen_fd_);
+        listen_fd_ = -1;
+        return false;
+    }
+
+    // Listen with backlog
+    int backlog = initial_max_clients_ > 0 ? initial_max_clients_ : 10;
+    if (::listen(listen_fd_, backlog) < 0) {
+        ::close(listen_fd_);
+        listen_fd_ = -1;
+        ::unlink(socket_path_.c_str());
+        return false;
+    }
+
+    // Create epoll instance
+    fd_ = epoll_create1(0);
+    if (fd_ < 0) {
+        ::close(listen_fd_);
+        listen_fd_ = -1;
+        ::unlink(socket_path_.c_str());
+        return false;
+    }
+
+    // Add listen socket to epoll
+    struct epoll_event ev;
+    ev.events = EPOLLIN;
+    ev.data.fd = listen_fd_;
+    if (epoll_ctl(fd_, EPOLL_CTL_ADD, listen_fd_, &ev) < 0) {
+        ::close(fd_);
+        fd_ = -1;
+        ::close(listen_fd_);
+        listen_fd_ = -1;
+        ::unlink(socket_path_.c_str());
+        return false;
+    }
+
+    return true;
 }
+
+int SocketServer::accept()
+{
+    if (listen_fd_ < 0) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    // Accept all pending connections (loop until EAGAIN)
+    // Non-blocking socket ensures this returns immediately
+    int last_client_id = -1;
+
+    while (true) {
+        int client_fd = ::accept(listen_fd_, nullptr, nullptr);
+
+        if (client_fd < 0) {
+            // Check if this is expected (no more connections) or a real error
+            if (errno == EAGAIN || errno == EWOULDBLOCK) {
+                // No more pending connections - expected, break
+                break;
+            }
+            // Real error - but if we already accepted some, return success
+            if (last_client_id >= 0) {
+                break;
+            }
+            // No connections accepted and got real error
+            return -1;
+        }
+
+        // Set client socket to BLOCKING mode (inherited non-blocking from listen socket)
+        // This avoids busy-waiting in recv() - we only recv after epoll signals data ready
+        int flags = fcntl(client_fd, F_GETFL, 0);
+        if (flags >= 0) {
+            fcntl(client_fd, F_SETFL, flags & ~O_NONBLOCK);
+        }
+
+        // Find free slot (or allocate new one)
+        int client_id = find_free_slot();
+
+        // Store client fd
+        const auto client_id_unsigned = static_cast<size_t>(client_id);
+        if (client_id_unsigned >= client_fds_.size()) {
+            client_fds_.resize(client_id_unsigned + 1, -1);
+        }
+        client_fds_[static_cast<size_t>(client_id)] = client_fd;
+        fd_to_client_id_[client_fd] = client_id;
+        num_clients_++;
+
+        // Add client to epoll
+        struct epoll_event client_ev;
+        client_ev.events = EPOLLIN;
+        client_ev.data.fd = client_fd;
+        if (epoll_ctl(fd_, EPOLL_CTL_ADD, client_fd, &client_ev) < 0) {
+            disconnect_client(client_id);
+            // Continue trying to accept other pending connections
+            continue;
+        }
+
+        last_client_id = client_id;
+    }
+
+    return last_client_id;
+}
+
+int SocketServer::wait_for_data(uint64_t timeout_ns)
+{
+    if (fd_ < 0) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    struct epoll_event ev;
+    int timeout_ms = timeout_ns > 0 ? static_cast<int>(timeout_ns / 1000000) : -1;
+    int n = epoll_wait(fd_, &ev, 1, timeout_ms);
+    if (n <= 0) {
+        return -1;
+    }
+
+    // Check if it's listen socket (new connection) or client data
+    if (ev.data.fd == listen_fd_) {
+        errno = EAGAIN; // Signal caller to call accept
+        return -1;
+    }
+
+    // Find which client
+    auto it = fd_to_client_id_.find(ev.data.fd);
+    if (it == fd_to_client_id_.end()) {
+        errno = ENOENT;
+        return -1;
+    }
+
+    return it->second;
+}
+
+void SocketServer::disconnect_client(int client_id)
+{
+    if (client_id < 0 || static_cast<size_t>(client_id) >= client_fds_.size()) {
+        return;
+    }
+
+    int fd = client_fds_[static_cast<size_t>(client_id)];
+    if (fd >= 0) {
+        epoll_ctl(fd_, EPOLL_CTL_DEL, fd, nullptr);
+        ::close(fd);
+        fd_to_client_id_.erase(fd);
+        client_fds_[static_cast<size_t>(client_id)] = -1;
+        num_clients_--;
+    }
+}
+
+#endif
 
 } // namespace bb::ipc

--- a/barretenberg/cpp/src/barretenberg/ipc/socket_server.hpp
+++ b/barretenberg/cpp/src/barretenberg/ipc/socket_server.hpp
@@ -30,7 +30,7 @@ class SocketServer : public IpcServer {
     SocketServer& operator=(SocketServer&&) = delete;
 
     bool listen() override;
-    int accept(uint64_t timeout_ns) override;
+    int accept() override;
     int wait_for_data(uint64_t timeout_ns) override;
     std::span<const uint8_t> receive(int client_id) override;
     void release(int client_id, size_t message_size) override;
@@ -45,11 +45,7 @@ class SocketServer : public IpcServer {
     std::string socket_path_;
     int initial_max_clients_;
     int listen_fd_ = -1;
-#ifdef __APPLE__
-    int kqueue_fd_ = -1; // macOS: kqueue for event notification
-#else
-    int epoll_fd_ = -1; // Linux: epoll for event notification
-#endif
+    int fd_ = -1;                                    // kqueue or epoll fd
     std::vector<int> client_fds_;                    // client_id -> fd
     std::unordered_map<int, int> fd_to_client_id_;   // fd -> client_id (for fast lookup)
     std::vector<std::vector<uint8_t>> recv_buffers_; // client_id -> recv buffer

--- a/barretenberg/cpp/src/barretenberg/nodejs_module/msgpack_client/msgpack_client_wrapper.hpp
+++ b/barretenberg/cpp/src/barretenberg/nodejs_module/msgpack_client/msgpack_client_wrapper.hpp
@@ -33,7 +33,6 @@ class MsgpackClientWrapper : public Napi::ObjectWrap<MsgpackClientWrapper> {
 
   private:
     std::unique_ptr<bb::ipc::IpcClient> client_;
-    std::vector<uint8_t> response_buffer_;
     bool connected_ = false;
 };
 

--- a/barretenberg/ts/src/bb_backends/node/native_shm.ts
+++ b/barretenberg/ts/src/bb_backends/node/native_shm.ts
@@ -59,7 +59,7 @@ export class BarretenbergNativeShmSyncBackend implements IMsgpackBackendSync {
     }
 
     // Create a unique shared memory name
-    const shmName = `bb-${process.pid}-${Date.now()}`;
+    const shmName = `bb-${process.pid}`;
 
     // Default maxClients to 1 if not specified
     const clientCount = maxClients ?? 1;

--- a/ci.sh
+++ b/ci.sh
@@ -103,6 +103,7 @@ case "$cmd" in
     bootstrap_ec2 "./bootstrap.sh ci-barretenberg"
     ;;
   "grind")
+    prep_vars
     # Spin up ec2 instance and run the merge-queue flow.
     run() {
       JOB_ID=$1 INSTANCE_POSTFIX=$1 ARCH=$2 exec denoise "bootstrap_ec2 './bootstrap.sh $3'"
@@ -311,4 +312,3 @@ case "$cmd" in
     exit 1
     ;;
 esac
-


### PR DESCRIPTION
Fairly hefty re-engineering of shm ipc. Think there was some racey edge case in prior one. This version is:
* slightly cleaner
* slightly faster (less copies, less syscalls)
* stress tested overnight with no errors.
* sneaking in a socket deadlock fix.

```
---------------------------------------------------------------------------------------------------------
Benchmark                                                               Time             CPU   Iterations
---------------------------------------------------------------------------------------------------------
poseiden_hash_direct/iterations:10000                                12.3 us         12.3 us        10000
Poseidon2BBSocketSPSC/poseiden_hash_roundtrip/iterations:10000       30.8 us         12.1 us        10000
Poseidon2BBSocketMPSC/poseiden_hash_roundtrip/iterations:10000       66.9 us         12.5 us        10000
Poseidon2BBShmSPSC/poseiden_hash_roundtrip/iterations:10000          13.9 us         13.9 us        10000
Poseidon2BBShmMPSC/poseiden_hash_roundtrip/iterations:10000          81.0 us         34.1 us        10000
```