### PR TITLE
chore: loudly fail in network config

### DIFF
--- a/yarn-project/cli/src/config/network_config.ts
+++ b/yarn-project/cli/src/config/network_config.ts
@@ -109,7 +109,7 @@ export async function enrichEnvironmentWithNetworkConfig(networkName: NetworkNam
   const networkConfig = await getNetworkConfig(networkName, cacheDir);
 
   if (!networkConfig) {
-    return;
+    throw new Error(`Failed to fetch network config for network: ${networkName}`);
   }
 
   enrichVar('BOOTSTRAP_NODES', networkConfig.bootnodes.join(','));


### PR DESCRIPTION
The original intent of https://linear.app/aztec-labs/issue/A-202/fail-loudly-when-failing-to-get-network-config, missed this on first pass