### PR TITLE
chore: ACIR audit - part 5

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -98,6 +98,21 @@
       "initCommands": [
         "command script import ${workspaceFolder}/barretenberg/cpp/scripts/lldb_format.py"
       ],
+    },
+    {
+      // Debug bb write_vk for a contract function
+      // Modify the "Extract contract bytecode" task in tasks.json to change the contract/function
+      "name": "Debug BB write_vk contract",
+      "type": "lldb",
+      "request": "launch",
+      "program": "${workspaceFolder}/barretenberg/cpp/build-debug/bin/bb",
+      "args": ["write_vk", "--scheme", "chonk", "--verifier_type", "standalone", "-b", "./target/bytecode.bin", "-o", "./target/vk_output", "-v"],
+      "cwd": "${workspaceFolder}/noir-projects/noir-contracts",
+      "preLaunchTask": "Extract contract bytecode",
+      "postDebugTask": "Cleanup contract bytecode",
+      "initCommands": [
+        "command script import ${workspaceFolder}/barretenberg/cpp/scripts/lldb_format.py"
+      ],
     }
   ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,29 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Extract contract bytecode",
+      "type": "shell",
+      "command": "${workspaceFolder}/barretenberg/cpp/scripts/extract_bytecode.sh",
+      "args": [
+        "./target/schnorr_hardcoded_account_contract-SchnorrHardcodedAccount.json",
+        "entrypoint",
+        "./target/bytecode.bin"
+      ],
+      "options": {
+        "cwd": "${workspaceFolder}/noir-projects/noir-contracts"
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "Cleanup contract bytecode",
+      "type": "shell",
+      "command": "rm",
+      "args": ["-f", "./target/bytecode.bin"],
+      "options": {
+        "cwd": "${workspaceFolder}/noir-projects/noir-contracts"
+      },
+      "problemMatcher": []
+    }
+  ]
+}

--- a/barretenberg/acir_tests/bootstrap.sh
+++ b/barretenberg/acir_tests/bootstrap.sh
@@ -118,6 +118,8 @@ function build {
     # These are breaking with:
     # Failed to solve program: 'Failed to solve blackbox function: embedded_curve_add, reason: Infinite input: embedded_curve_add(infinity, infinity)'
     rm -rf acir_tests/{regression_5045,regression_7744}
+    # The following test fails because it uses CallData/ReturnData with UltraBuilder, which is not supported
+    rm -rf acir_tests/{regression_7612}
     # Merge the internal test programs with the acir tests.
     cp -R ./internal_test_programs/* acir_tests
 

--- a/barretenberg/acir_tests/bootstrap.sh
+++ b/barretenberg/acir_tests/bootstrap.sh
@@ -119,7 +119,7 @@ function build {
     # Failed to solve program: 'Failed to solve blackbox function: embedded_curve_add, reason: Infinite input: embedded_curve_add(infinity, infinity)'
     rm -rf acir_tests/{regression_5045,regression_7744}
     # The following test fails because it uses CallData/ReturnData with UltraBuilder, which is not supported
-    rm -rf acir_tests/{regression_7612}
+    rm -rf acir_tests/{regression_7612,regression_7143,databus_composite_calldata,databus_two_calldata_simple,databus_two_calldata,databus}
     # Merge the internal test programs with the acir tests.
     cp -R ./internal_test_programs/* acir_tests
 

--- a/barretenberg/cpp/scripts/extract_bytecode.sh
+++ b/barretenberg/cpp/scripts/extract_bytecode.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Extract bytecode from a compiled contract JSON for debugging bb
+# Usage: ./extract_bytecode.sh <contract_json> <function_name> <output_file>
+# Example: ./extract_bytecode.sh ./target/schnorr_hardcoded_account_contract-SchnorrHardcodedAccount.json entrypoint /tmp/bytecode.bin
+
+set -euo pipefail
+
+if [ $# -lt 3 ]; then
+    echo "Usage: $0 <contract_json> <function_name> <output_file>"
+    echo "Example: $0 ./target/schnorr_hardcoded_account_contract-SchnorrHardcodedAccount.json entrypoint /tmp/bytecode.bin"
+    exit 1
+fi
+
+CONTRACT_JSON=$1
+FUNCTION_NAME=$2
+OUTPUT_FILE=$3
+
+# Extract bytecode for the specified function (keep gzipped - bb handles decompression)
+jq -r --arg name "$FUNCTION_NAME" '.functions[] | select(.name == $name) | .bytecode' "$CONTRACT_JSON" | base64 -d > "$OUTPUT_FILE"
+
+echo "Bytecode extracted to $OUTPUT_FILE"

--- a/barretenberg/cpp/src/barretenberg/boomerang_value_detection/graph_description_ram_rom.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/boomerang_value_detection/graph_description_ram_rom.test.cpp
@@ -119,11 +119,13 @@ TEST(boomerang_rom_ram_table, graph_description_ram_table_write)
     const size_t table_size = 10;
 
     std::vector<fr> table_values(table_size);
-    ram_table_ct table(&builder, table_size);
+    std::vector<field_ct> zeros(table_size, field_ct(0));
+    ram_table_ct table(&builder, zeros);
 
     for (size_t i = 0; i < table_size; ++i) {
         table.write(i, 0);
     }
+
     std::unordered_set<uint32_t> safety_variables;
     field_ct result(0);
     safety_variables.insert(result.get_witness_index());

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_dsl.fuzzer.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_dsl.fuzzer.cpp
@@ -134,7 +134,7 @@ bool solve_witnesses(std::vector<Acir::Expression>& expressions,
             // TIER 2: If no linear-only witness found, adjust q_c to force equation to zero
             if (!solved) {
                 // Set q_c = -value to make: q_c + value = 0
-                fr::serialize_to_buffer(fr::serialize_from_buffer(&expr.q_c[0]) - value, &expr.q_c[0]);
+                expr.q_c = (fr::serialize_from_buffer(&expr.q_c[0]) - value).to_buffer();
             }
         }
 
@@ -458,7 +458,7 @@ bool test_acir_circuit(const uint8_t* data, size_t size)
             remaining -= 3;
 
             std::vector<uint8_t> coeff(32);
-            fr::serialize_to_buffer(coeff_state[coeff_reg], &coeff[0]);
+            coeff = coeff_state[coeff_reg].to_buffer();
             Acir::Witness w1, w2;
             w1.value = w1_idx;
             w2.value = w2_idx;
@@ -482,7 +482,7 @@ bool test_acir_circuit(const uint8_t* data, size_t size)
             prev_witness = w_idx;
 
             std::vector<uint8_t> coeff(32);
-            fr::serialize_to_buffer(coeff_state[coeff_reg], &coeff[0]);
+            coeff = coeff_state[coeff_reg].to_buffer();
             Acir::Witness w;
             w.value = w_idx;
             expr.linear_combinations.push_back(std::make_tuple(coeff, w));
@@ -493,7 +493,7 @@ bool test_acir_circuit(const uint8_t* data, size_t size)
             uint8_t const_reg = ptr[0] % INTERNAL_STATE_SIZE;
             ptr++;
             remaining--;
-            fr::serialize_to_buffer(coeff_state[const_reg], &expr.q_c[0]);
+            expr.q_c = coeff_state[const_reg].to_buffer();
         } else {
             expr.q_c = std::vector<uint8_t>(32, 0);
         }

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_format.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_format.test.cpp
@@ -1225,6 +1225,10 @@ TYPED_TEST(OpcodeGateCountTests, BlockRamWrite)
 
 TYPED_TEST(OpcodeGateCountTests, BlockCallData)
 {
+    if constexpr (!IsMegaBuilder<TypeParam>) {
+        GTEST_SKIP() << "CallData only supported on MegaCircuitBuilder";
+    }
+
     WitnessVector witness{ 0, 10, 20, 0, 10 };
 
     // Create a simple CallData block with 2 elements and 1 read
@@ -1270,7 +1274,7 @@ TYPED_TEST(OpcodeGateCountTests, BlockCallData)
             .init = init,
             .trace = trace,
             .type = BlockType::CallData,
-            .calldata_id = CallDataType::Primary,
+            .calldata_id = CallDataType::Secondary,
         };
 
         AcirFormat constraint_system{
@@ -1292,9 +1296,13 @@ TYPED_TEST(OpcodeGateCountTests, BlockCallData)
 
 TYPED_TEST(OpcodeGateCountTests, BlockReturnData)
 {
+    if constexpr (!IsMegaBuilder<TypeParam>) {
+        GTEST_SKIP() << "ReturnData only supported on MegaCircuitBuilder";
+    }
+
     WitnessVector witness{ 0, 10, 20 };
 
-    // Create a simple ReturnData block with 2 elements and 1 read
+    // Create a simple ReturnData block with 2 elements
     std::vector<uint32_t> init;
     init.push_back(1); // 10
     init.push_back(2); // 20
@@ -1307,7 +1315,7 @@ TYPED_TEST(OpcodeGateCountTests, BlockReturnData)
     };
 
     AcirFormat constraint_system{
-        .varnum = 5,
+        .varnum = 3,
         .num_acir_opcodes = 1,
         .public_inputs = {},
         .block_constraints = { block_constraint },
@@ -1316,8 +1324,11 @@ TYPED_TEST(OpcodeGateCountTests, BlockReturnData)
     mock_opcode_indices(constraint_system);
 
     AcirProgram program{ constraint_system, witness };
-    const ProgramMetadata metadata{ .collect_gates_per_opcode = true };
+    const ProgramMetadata metadata{
+        .collect_gates_per_opcode = false
+    }; // We need to set it to false because ReturnData BlockConstraints do not have any trace, so we would be dividing
+       // by zero, and this would throw an error.
     auto builder = create_circuit<TypeParam>(program, metadata);
 
-    EXPECT_EQ(program.constraints.gates_per_opcode, std::vector<size_t>({ BLOCK_RETURNDATA<TypeParam> }));
+    EXPECT_EQ(builder.get_num_finalized_gates_inefficient(/*ensure_nonzero=*/false), BLOCK_RETURNDATA<TypeParam>);
 }

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_format.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_format.test.cpp
@@ -1108,60 +1108,25 @@ TYPED_TEST(OpcodeGateCountTests, EcAdd)
 
 TYPED_TEST(OpcodeGateCountTests, BlockRomRead)
 {
+    WitnessVector witness{ 0, 10, 20, 0, 10 };
+
     // Create a simple ROM block with 2 elements and 1 read
-    std::vector<arithmetic_triple> init;
-    init.push_back(arithmetic_triple{
-        .a = 1,
-        .b = 0,
-        .c = 0,
-        .q_m = 0,
-        .q_l = 1,
-        .q_r = 0,
-        .q_o = 0,
-        .q_c = 0,
-    });
-    init.push_back(arithmetic_triple{
-        .a = 2,
-        .b = 0,
-        .c = 0,
-        .q_m = 0,
-        .q_l = 1,
-        .q_r = 0,
-        .q_o = 0,
-        .q_c = 0,
-    });
+    std::vector<uint32_t> init;
+    init.push_back(1); // 10
+    init.push_back(2); // 20
 
     std::vector<MemOp> trace;
     trace.push_back(MemOp{
-        .access_type = 0, // READ
-        .index =
-            arithmetic_triple{
-                .a = 3,
-                .b = 0,
-                .c = 0,
-                .q_m = 0,
-                .q_l = 1,
-                .q_r = 0,
-                .q_o = 0,
-                .q_c = 0,
-            },
-        .value =
-            arithmetic_triple{
-                .a = 4,
-                .b = 0,
-                .c = 0,
-                .q_m = 0,
-                .q_l = 1,
-                .q_r = 0,
-                .q_o = 0,
-                .q_c = 0,
-            },
+        .access_type = AccessType::Read,
+        .index = WitnessOrConstant<bb::fr>::from_index(3), // 0
+        .value = WitnessOrConstant<bb::fr>::from_index(4), // 10
     });
 
     BlockConstraint block_constraint{
         .init = init,
         .trace = trace,
         .type = BlockType::ROM,
+        .calldata_id = CallDataType::None,
     };
 
     AcirFormat constraint_system{
@@ -1173,11 +1138,186 @@ TYPED_TEST(OpcodeGateCountTests, BlockRomRead)
     };
     mock_opcode_indices(constraint_system);
 
-    WitnessVector witness{ 0, 10, 20, 0, 10 };
-
     AcirProgram program{ constraint_system, witness };
     const ProgramMetadata metadata{ .collect_gates_per_opcode = true };
     auto builder = create_circuit<TypeParam>(program, metadata);
 
     EXPECT_EQ(program.constraints.gates_per_opcode, std::vector<size_t>({ BLOCK_ROM_READ<TypeParam> }));
+}
+
+TYPED_TEST(OpcodeGateCountTests, BlockRamRead)
+{
+    WitnessVector witness{ 0, 10, 20, 0, 10 };
+
+    // Create a simple RAM block with 2 elements and 1 read
+    std::vector<uint32_t> init;
+    init.push_back(1); // 10
+    init.push_back(2); // 20
+
+    std::vector<MemOp> trace;
+    trace.push_back(MemOp{
+        .access_type = AccessType::Read,
+        .index = WitnessOrConstant<bb::fr>::from_index(3), // 0
+        .value = WitnessOrConstant<bb::fr>::from_index(4), // 10
+    });
+
+    BlockConstraint block_constraint{
+        .init = init,
+        .trace = trace,
+        .type = BlockType::RAM,
+        .calldata_id = CallDataType::None,
+    };
+
+    AcirFormat constraint_system{
+        .varnum = 5,
+        .num_acir_opcodes = 1,
+        .public_inputs = {},
+        .block_constraints = { block_constraint },
+        .original_opcode_indices = create_empty_original_opcode_indices(),
+    };
+    mock_opcode_indices(constraint_system);
+
+    AcirProgram program{ constraint_system, witness };
+    const ProgramMetadata metadata{ .collect_gates_per_opcode = true };
+    auto builder = create_circuit<TypeParam>(program, metadata);
+
+    EXPECT_EQ(program.constraints.gates_per_opcode, std::vector<size_t>({ BLOCK_RAM_READ<TypeParam> }));
+}
+
+TYPED_TEST(OpcodeGateCountTests, BlockRamWrite)
+{
+    WitnessVector witness{ 0, 10, 20, 0, 10 };
+
+    // Create a simple RAM block with 2 elements and 1 read
+    std::vector<uint32_t> init;
+    init.push_back(1); // 10
+    init.push_back(2); // 20
+
+    std::vector<MemOp> trace;
+    trace.push_back(MemOp{
+        .access_type = AccessType::Read,
+        .index = WitnessOrConstant<bb::fr>::from_index(3), // 0
+        .value = WitnessOrConstant<bb::fr>::from_index(4), // 10
+    });
+
+    BlockConstraint block_constraint{
+        .init = init,
+        .trace = trace,
+        .type = BlockType::RAM,
+        .calldata_id = CallDataType::None,
+    };
+
+    AcirFormat constraint_system{
+        .varnum = 5,
+        .num_acir_opcodes = 1,
+        .public_inputs = {},
+        .block_constraints = { block_constraint },
+        .original_opcode_indices = create_empty_original_opcode_indices(),
+    };
+    mock_opcode_indices(constraint_system);
+
+    AcirProgram program{ constraint_system, witness };
+    const ProgramMetadata metadata{ .collect_gates_per_opcode = true };
+    auto builder = create_circuit<TypeParam>(program, metadata);
+
+    EXPECT_EQ(program.constraints.gates_per_opcode, std::vector<size_t>({ BLOCK_RAM_WRITE<TypeParam> }));
+}
+
+TYPED_TEST(OpcodeGateCountTests, BlockCallData)
+{
+    WitnessVector witness{ 0, 10, 20, 0, 10 };
+
+    // Create a simple CallData block with 2 elements and 1 read
+    std::vector<uint32_t> init;
+    init.push_back(1); // 10
+    init.push_back(2); // 20
+
+    std::vector<MemOp> trace;
+    trace.push_back(MemOp{
+        .access_type = AccessType::Read,
+        .index = WitnessOrConstant<bb::fr>::from_index(3), // 0
+        .value = WitnessOrConstant<bb::fr>::from_index(4), // 10
+    });
+
+    // Primary calldata
+    {
+        BlockConstraint block_constraint{
+            .init = init,
+            .trace = trace,
+            .type = BlockType::CallData,
+            .calldata_id = CallDataType::Primary,
+        };
+
+        AcirFormat constraint_system{
+            .varnum = 5,
+            .num_acir_opcodes = 1,
+            .public_inputs = {},
+            .block_constraints = { block_constraint },
+            .original_opcode_indices = create_empty_original_opcode_indices(),
+        };
+        mock_opcode_indices(constraint_system);
+
+        AcirProgram program{ constraint_system, witness };
+        const ProgramMetadata metadata{ .collect_gates_per_opcode = true };
+        auto builder = create_circuit<TypeParam>(program, metadata);
+
+        EXPECT_EQ(program.constraints.gates_per_opcode, std::vector<size_t>({ BLOCK_CALLDATA<TypeParam> }));
+    }
+
+    // Secondary calldata
+    {
+        BlockConstraint block_constraint{
+            .init = init,
+            .trace = trace,
+            .type = BlockType::CallData,
+            .calldata_id = CallDataType::Primary,
+        };
+
+        AcirFormat constraint_system{
+            .varnum = 5,
+            .num_acir_opcodes = 1,
+            .public_inputs = {},
+            .block_constraints = { block_constraint },
+            .original_opcode_indices = create_empty_original_opcode_indices(),
+        };
+        mock_opcode_indices(constraint_system);
+
+        AcirProgram program{ constraint_system, witness };
+        const ProgramMetadata metadata{ .collect_gates_per_opcode = true };
+        auto builder = create_circuit<TypeParam>(program, metadata);
+
+        EXPECT_EQ(program.constraints.gates_per_opcode, std::vector<size_t>({ BLOCK_CALLDATA<TypeParam> }));
+    }
+}
+
+TYPED_TEST(OpcodeGateCountTests, BlockReturnData)
+{
+    WitnessVector witness{ 0, 10, 20 };
+
+    // Create a simple ReturnData block with 2 elements and 1 read
+    std::vector<uint32_t> init;
+    init.push_back(1); // 10
+    init.push_back(2); // 20
+
+    BlockConstraint block_constraint{
+        .init = init,
+        .trace = {},
+        .type = BlockType::ReturnData,
+        .calldata_id = CallDataType::None,
+    };
+
+    AcirFormat constraint_system{
+        .varnum = 5,
+        .num_acir_opcodes = 1,
+        .public_inputs = {},
+        .block_constraints = { block_constraint },
+        .original_opcode_indices = create_empty_original_opcode_indices(),
+    };
+    mock_opcode_indices(constraint_system);
+
+    AcirProgram program{ constraint_system, witness };
+    const ProgramMetadata metadata{ .collect_gates_per_opcode = true };
+    auto builder = create_circuit<TypeParam>(program, metadata);
+
+    EXPECT_EQ(program.constraints.gates_per_opcode, std::vector<size_t>({ BLOCK_RETURNDATA<TypeParam> }));
 }

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_to_constraint_buf.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_to_constraint_buf.cpp
@@ -408,7 +408,9 @@ std::vector<mul_quad_<fr>> split_into_mul_quad_gates(Acir::Expression const& arg
         result.emplace_back(mul_quad);
     }
 
+    BB_ASSERT(!result.empty(), "split_into_mul_quad_gates: resulted in zero gates.");
     result.shrink_to_fit();
+
     return result;
 }
 
@@ -678,17 +680,13 @@ BlockConstraint handle_memory_init(Acir::Opcode::MemoryInit const& mem_init)
 
 void handle_memory_op(Acir::Opcode::MemoryOp const& mem_op, BlockConstraint& block)
 {
-    // Lambda to convert the Acir::Expression representing a memory operation into a mul_quad_ gate
-    auto serialize_mul_quad_gate = [](const Acir::Expression& expr) {
-        std::map<uint32_t, bb::fr> linear_terms = process_linear_terms(expr);
-        std::vector<mul_quad_<fr>> mul_quads = split_into_mul_quad_gates(expr, linear_terms);
-        BB_ASSERT_EQ(mul_quads.size(), 1U, "MemoryOp expression must fit in a single mul_quad_ gate");
-        return mul_quads[0];
-    };
-
     // Lambda to convert an Acir::Expression to a witness index
     auto acir_expression_to_witness_or_constant = [&](const Acir::Expression& expr) {
-        mul_quad_<fr> quad = serialize_mul_quad_gate(expr);
+        std::map<uint32_t, bb::fr> linear_terms = process_linear_terms(expr);
+        std::vector<mul_quad_<fr>> mul_quads = split_into_mul_quad_gates(expr, linear_terms);
+
+        BB_ASSERT_EQ(mul_quads.size(), 1U, "MemoryOp expression should result in a single mul_quad_ gate");
+        mul_quad_<fr> quad = mul_quads.front();
 
         // Noir gives us witnesses or constants for read/write operations. We use the following assertions to ensure
         // that the data coming from Noir is in the correct form.
@@ -712,15 +710,15 @@ void handle_memory_op(Acir::Opcode::MemoryOp const& mem_op, BlockConstraint& blo
     auto is_read_operation = [&](const Acir::Expression& expr) {
         bool is_read = true;
 
-        mul_quad_<fr> quad = serialize_mul_quad_gate(expr);
+        BB_ASSERT(expr.mul_terms.empty(), "MemoryOp expression should not have multiplication terms");
+        BB_ASSERT(expr.linear_combinations.empty(), "MemoryOp expression should not have linear terms");
 
-        // A ROM operation is given by a zero Expression
-        is_read &= quad.mul_scaling == fr::zero();
-        is_read &= quad.a_scaling == fr::zero();
-        is_read &= quad.b_scaling == fr::zero();
-        is_read &= quad.c_scaling == fr::zero();
-        is_read &= quad.d_scaling == fr::zero();
-        is_read &= quad.const_scaling == fr::zero();
+        fr const_term = fr::serialize_from_buffer(&expr.q_c[0]);
+
+        // A read operation is given by a zero Expression
+        BB_ASSERT((const_term == fr::one()) || (const_term == fr::zero()),
+                  "MemoryOp expression should be either zero or a constant");
+        is_read &= const_term == fr::zero();
 
         return is_read;
     };

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_to_constraint_buf.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_to_constraint_buf.cpp
@@ -708,24 +708,24 @@ void handle_memory_op(Acir::Opcode::MemoryOp const& mem_op, BlockConstraint& blo
         };
     };
 
-    // Lambda to determine whether a memory operation is a ROM or RAM operation
-    auto is_rom_operation = [&](const Acir::Expression& expr) {
-        bool is_rom = true;
+    // Lambda to determine whether a memory operation is a read or write operation
+    auto is_read_operation = [&](const Acir::Expression& expr) {
+        bool is_read = true;
 
         mul_quad_<fr> quad = serialize_mul_quad_gate(expr);
 
         // A ROM operation is given by a zero Expression
-        is_rom &= quad.mul_scaling == fr::zero();
-        is_rom &= quad.a_scaling == fr::zero();
-        is_rom &= quad.b_scaling == fr::zero();
-        is_rom &= quad.c_scaling == fr::zero();
-        is_rom &= quad.d_scaling == fr::zero();
-        is_rom &= quad.const_scaling == fr::zero();
+        is_read &= quad.mul_scaling == fr::zero();
+        is_read &= quad.a_scaling == fr::zero();
+        is_read &= quad.b_scaling == fr::zero();
+        is_read &= quad.c_scaling == fr::zero();
+        is_read &= quad.d_scaling == fr::zero();
+        is_read &= quad.const_scaling == fr::zero();
 
-        return is_rom;
+        return is_read;
     };
 
-    AccessType access_type = is_rom_operation(mem_op.op.operation) ? AccessType::Read : AccessType::Write;
+    AccessType access_type = is_read_operation(mem_op.op.operation) ? AccessType::Read : AccessType::Write;
     if (access_type == AccessType::Write) {
         // We are not allowed to write on the databus
         BB_ASSERT((block.type != BlockType::CallData) && (block.type != BlockType::ReturnData));

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_to_constraint_buf.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_to_constraint_buf.cpp
@@ -708,19 +708,16 @@ void handle_memory_op(Acir::Opcode::MemoryOp const& mem_op, BlockConstraint& blo
 
     // Lambda to determine whether a memory operation is a read or write operation
     auto is_read_operation = [&](const Acir::Expression& expr) {
-        bool is_read = true;
-
         BB_ASSERT(expr.mul_terms.empty(), "MemoryOp expression should not have multiplication terms");
         BB_ASSERT(expr.linear_combinations.empty(), "MemoryOp expression should not have linear terms");
 
-        fr const_term = fr::serialize_from_buffer(&expr.q_c[0]);
+        const fr const_term = fr::serialize_from_buffer(&expr.q_c[0]);
+
+        BB_ASSERT((const_term == fr::one()) || (const_term == fr::zero()),
+                  "MemoryOp expression should be either zero or one");
 
         // A read operation is given by a zero Expression
-        BB_ASSERT((const_term == fr::one()) || (const_term == fr::zero()),
-                  "MemoryOp expression should be either zero or a constant");
-        is_read &= const_term == fr::zero();
-
-        return is_read;
+        return const_term == fr::zero();
     };
 
     AccessType access_type = is_read_operation(mem_op.op.operation) ? AccessType::Read : AccessType::Write;

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_to_constraint_buf.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_to_constraint_buf.cpp
@@ -676,10 +676,18 @@ BlockConstraint handle_memory_init(Acir::Opcode::MemoryInit const& mem_init)
     return block;
 }
 
-void handle_memory_op(Acir::Opcode::MemoryOp const& mem_op, AcirFormat& af, BlockConstraint& block)
+void handle_memory_op(Acir::Opcode::MemoryOp const& mem_op, BlockConstraint& block)
 {
+    // Lambda to convert the Acir::Expression representing a memory operation into a mul_quad_ gate
+    auto serialize_mul_quad_gate = [](const Acir::Expression& expr) {
+        std::map<uint32_t, bb::fr> linear_terms = process_linear_terms(expr);
+        std::vector<mul_quad_<fr>> mul_quads = split_into_mul_quad_gates(expr, linear_terms);
+        BB_ASSERT_EQ(mul_quads.size(), 1U, "MemoryOp expression must fit in a single mul_quad_ gate");
+        return mul_quads[0];
+    };
+
     // Lambda to convert an Acir::Expression to a witness index
-    auto acir_expression_to_witness_or_constant = [](const Acir::Expression& expr) {
+    auto acir_expression_to_witness_or_constant = [&](const Acir::Expression& expr) {
         mul_quad_<fr> quad = serialize_mul_quad_gate(expr);
 
         // Noir gives us witnesses or constants for read/write operations. We use the following assertions to ensure
@@ -701,7 +709,7 @@ void handle_memory_op(Acir::Opcode::MemoryOp const& mem_op, AcirFormat& af, Bloc
     };
 
     // Lambda to determine whether a memory operation is a ROM or RAM operation
-    auto is_rom_operation = [](const Acir::Expression& expr) {
+    auto is_rom_operation = [&](const Acir::Expression& expr) {
         bool is_rom = true;
 
         mul_quad_<fr> quad = serialize_mul_quad_gate(expr);

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_to_constraint_buf.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_to_constraint_buf.cpp
@@ -121,6 +121,8 @@ AcirFormat circuit_serde_to_acir_format(Acir::Circuit const& circuit)
     af.public_inputs = join({ transform::map(circuit.public_parameters.value, [](auto e) { return e.value; }),
                               transform::map(circuit.return_values.value, [](auto e) { return e.value; }) });
     // Map to a pair of: BlockConstraint, and list of opcodes associated with that BlockConstraint
+    // Block constraints are built as we process the opcodes, so we store them in this map and we add them to the
+    // AcirFormat struct at the end
     // NOTE: We want to deterministically visit this map, so unordered_map should not be used.
     std::map<uint32_t, std::pair<BlockConstraint, std::vector<size_t>>> block_id_to_block_constraint;
 
@@ -152,13 +154,10 @@ AcirFormat circuit_serde_to_acir_format(Acir::Circuit const& circuit)
             },
             gate.value);
     }
-    for (const auto& [block_id, block] : block_id_to_block_constraint) {
-        // Note: the trace will always be empty for ReturnData since it cannot be explicitly read from in noir
-        if (!block.first.trace.empty() || block.first.type == BlockType::ReturnData ||
-            block.first.type == BlockType::CallData) {
-            af.block_constraints.push_back(block.first);
-            af.original_opcode_indices.block_constraints.push_back(block.second);
-        }
+    // Add the block constraints to the AcirFormat struct
+    for (const auto& [_, block] : block_id_to_block_constraint) {
+        af.block_constraints.push_back(block.first);
+        af.original_opcode_indices.block_constraints.push_back(block.second);
     }
 
     return af;
@@ -649,29 +648,27 @@ void handle_blackbox_func_call(Acir::Opcode::BlackBoxFuncCall const& arg, AcirFo
 
 BlockConstraint handle_memory_init(Acir::Opcode::MemoryInit const& mem_init)
 {
-    BlockConstraint block{ .init = {}, .trace = {}, .type = BlockType::ROM };
-    std::vector<arithmetic_triple> init;
-    std::vector<MemOp> trace;
+    // Noir doesn't distinguish between ROM and RAM table. Therefore, we initialize every table as a ROM table, and
+    // then we make it a RAM table if there is at least one write operation
+    BlockConstraint block{
+        .init = {},
+        .trace = {},
+        .type = BlockType::ROM,
+        .calldata_id = CallDataType::None,
+    };
 
-    auto len = mem_init.init.size();
-    for (size_t i = 0; i < len; ++i) {
-        block.init.push_back(arithmetic_triple{
-            .a = mem_init.init[i].value,
-            .b = 0,
-            .c = 0,
-            .q_m = 0,
-            .q_l = 1,
-            .q_r = 0,
-            .q_o = 0,
-            .q_c = 0,
-        });
+    for (const auto& init : mem_init.init) {
+        block.init.push_back(init.value);
     }
 
     // Databus is only supported for Goblin, non Goblin builders will treat call_data and return_data as normal
     // array.
     if (std::holds_alternative<Acir::BlockType::CallData>(mem_init.block_type.value)) {
+        uint32_t calldata_id = std::get<Acir::BlockType::CallData>(mem_init.block_type.value).value;
+        BB_ASSERT(calldata_id == 0 || calldata_id == 1, "acir_format::handle_memory_init: Unsupported calldata id");
+
         block.type = BlockType::CallData;
-        block.calldata_id = std::get<Acir::BlockType::CallData>(mem_init.block_type.value).value;
+        block.calldata_id = calldata_id == 0 ? CallDataType::Primary : CallDataType::Secondary;
     } else if (std::holds_alternative<Acir::BlockType::ReturnData>(mem_init.block_type.value)) {
         block.type = BlockType::ReturnData;
     }
@@ -679,36 +676,60 @@ BlockConstraint handle_memory_init(Acir::Opcode::MemoryInit const& mem_init)
     return block;
 }
 
-bool is_rom(Acir::MemOp const& mem_op)
+void handle_memory_op(Acir::Opcode::MemoryOp const& mem_op, AcirFormat& af, BlockConstraint& block)
 {
-    return mem_op.operation.mul_terms.empty() && mem_op.operation.linear_combinations.empty() &&
-           fr::serialize_from_buffer(&mem_op.operation.q_c[0]) == fr::zero();
-}
+    // Lambda to convert an Acir::Expression to a witness index
+    auto acir_expression_to_witness_or_constant = [](const Acir::Expression& expr) {
+        mul_quad_<fr> quad = serialize_mul_quad_gate(expr);
 
-uint32_t poly_to_witness(const arithmetic_triple poly)
-{
-    if (poly.q_m == 0 && poly.q_r == 0 && poly.q_o == 0 && poly.q_l == 1 && poly.q_c == 0) {
-        return poly.a;
-    }
-    return 0;
-}
+        // Noir gives us witnesses or constants for read/write operations. We use the following assertions to ensure
+        // that the data coming from Noir is in the correct form.
+        BB_ASSERT_EQ(quad.mul_scaling, fr::zero(), "MemoryOp should not have a mul term");
+        BB_ASSERT_EQ(quad.b_scaling, fr::zero(), "MemoryOp should only have one linear term");
+        BB_ASSERT_EQ(quad.c_scaling, fr::zero(), "MemoryOp should only have one linear term");
+        BB_ASSERT_EQ(quad.d_scaling, fr::zero(), "MemoryOp should only have one linear term");
 
-void handle_memory_op(Acir::Opcode::MemoryOp const& mem_op, BlockConstraint& block)
-{
-    uint8_t access_type = 1;
-    if (is_rom(mem_op.op)) {
-        access_type = 0;
-    }
-    if (access_type == 1) {
+        bool is_witness = quad.a_scaling == fr::one() && quad.const_scaling == fr::zero();
+        bool is_constant = quad.a_scaling == fr::zero();
+        BB_ASSERT(is_witness || is_constant, "MemoryOp expression must be a witness or a constant");
+
+        return WitnessOrConstant<bb::fr>{
+            .index = is_witness ? quad.a : bb::stdlib::IS_CONSTANT,
+            .value = is_constant ? quad.const_scaling : bb::fr::zero(),
+            .is_constant = is_constant,
+        };
+    };
+
+    // Lambda to determine whether a memory operation is a ROM or RAM operation
+    auto is_rom_operation = [](const Acir::Expression& expr) {
+        bool is_rom = true;
+
+        mul_quad_<fr> quad = serialize_mul_quad_gate(expr);
+
+        // A ROM operation is given by a zero Expression
+        is_rom &= quad.mul_scaling == fr::zero();
+        is_rom &= quad.a_scaling == fr::zero();
+        is_rom &= quad.b_scaling == fr::zero();
+        is_rom &= quad.c_scaling == fr::zero();
+        is_rom &= quad.d_scaling == fr::zero();
+        is_rom &= quad.const_scaling == fr::zero();
+
+        return is_rom;
+    };
+
+    AccessType access_type = is_rom_operation(mem_op.op.operation) ? AccessType::Read : AccessType::Write;
+    if (access_type == AccessType::Write) {
         // We are not allowed to write on the databus
         BB_ASSERT((block.type != BlockType::CallData) && (block.type != BlockType::ReturnData));
+        // Mark the table as a RAM table
         block.type = BlockType::RAM;
     }
 
     // Update the ranges of the index using the array length
-    arithmetic_triple index = serialize_arithmetic_gate(mem_op.op.index);
-    MemOp acir_mem_op =
-        MemOp{ .access_type = access_type, .index = index, .value = serialize_arithmetic_gate(mem_op.op.value) };
+    WitnessOrConstant<bb::fr> index = acir_expression_to_witness_or_constant(mem_op.op.index);
+    WitnessOrConstant<bb::fr> value = acir_expression_to_witness_or_constant(mem_op.op.value);
+
+    MemOp acir_mem_op = MemOp{ .access_type = access_type, .index = index, .value = value };
     block.trace.push_back(acir_mem_op);
 }
 

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/block_constraint.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/block_constraint.cpp
@@ -46,6 +46,7 @@ void create_block_constraints(UltraCircuitBuilder& builder,
     case BlockType::ReturnData:
         bb::assert_failure("UltraCircuitBuilder does not support CallData/ReturnData block constraints. Use "
                            "MegaCircuitBuilder or fall back to RAM and ROM operations.");
+        break;
     default:
         bb::assert_failure("Unexpected block constraint type.");
         break;
@@ -114,6 +115,7 @@ void process_ROM_operations(Builder& builder,
             break;
         default:
             bb::assert_failure("Invalid AccessType for ROM memory operation.");
+            break;
         }
     }
 }
@@ -147,6 +149,7 @@ void process_RAM_operations(Builder& builder,
             break;
         default:
             bb::assert_failure("Invalid AccessType for RAM memory operation.");
+            break;
         }
     }
 }

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/block_constraint.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/block_constraint.cpp
@@ -44,8 +44,9 @@ void create_block_constraints(UltraCircuitBuilder& builder,
         break;
     case BlockType::CallData:
     case BlockType::ReturnData:
-        bb::assert_failure("UltraCircuitBuilder does not support CallData/ReturnData block constraints. Use "
-                           "MegaCircuitBuilder or fall back to RAM and ROM operations.");
+        bb::assert_failure(
+            "UltraCircuitBuilder (standalone Noir application) does not support CallData/ReturnData "
+            "block constraints. Use MegaCircuitBuilder (Aztec app) or fall back to RAM and ROM operations.");
         break;
     default:
         bb::assert_failure("Unexpected block constraint type.");

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/block_constraint.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/block_constraint.cpp
@@ -97,14 +97,14 @@ void process_ROM_operations(Builder& builder,
     using field_ct = stdlib::field_t<Builder>;
     using rom_table_ct = stdlib::rom_table<Builder>;
 
-    rom_table_ct table(init);
+    rom_table_ct table(&builder, init);
     for (const auto& op : constraint.trace) {
         field_ct value = to_field_ct(op.value, builder);
         field_ct index = to_field_ct(op.index, builder);
 
         // In case of invalid witness assignment, we set the value of index value to zero to not hit out of bound in
         // ROM table
-        if (!has_valid_witness_assignments) {
+        if (!has_valid_witness_assignments && !index.is_constant()) {
             builder.set_variable(index.get_witness_index(), 0);
         }
 
@@ -127,14 +127,14 @@ void process_RAM_operations(Builder& builder,
     using field_ct = stdlib::field_t<Builder>;
     using ram_table_ct = stdlib::ram_table<Builder>;
 
-    ram_table_ct table(init);
+    ram_table_ct table(&builder, init);
     for (const auto& op : constraint.trace) {
         field_ct value = to_field_ct(op.value, builder);
         field_ct index = to_field_ct(op.index, builder);
 
         // In case of invalid witness assignment, we set the value of index value to zero to not hit an out-of-bounds
         // index in the RAM table
-        if (!has_valid_witness_assignments) {
+        if (!has_valid_witness_assignments && !index.is_constant()) {
             builder.set_variable(index.get_witness_index(), 0);
         }
 
@@ -173,13 +173,14 @@ void process_call_data_operations(Builder& builder,
 
             // In case of invalid witness assignment, we set the value of index value to zero to not hit out of bound in
             // ROM table
-            if (!has_valid_witness_assignments) {
+            if (!has_valid_witness_assignments && !index.is_constant()) {
                 builder.set_variable(index.get_witness_index(), 0);
             }
 
             switch (op.access_type) {
             case AccessType::Read:
                 value.assert_equal(calldata_array[index]);
+                break;
             default:
                 bb::assert_failure("Invalid AccessType for CallData memory operation.");
                 break;

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/block_constraint.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/block_constraint.cpp
@@ -15,26 +15,9 @@ namespace acir_format {
 
 using namespace bb;
 
-template <typename Builder>
-stdlib::field_t<Builder> arithmetic_triple_to_field_ct(const arithmetic_triple poly, Builder& builder)
-{
-    using field_ct = stdlib::field_t<Builder>;
-
-    BB_ASSERT_EQ(poly.q_m, 0);
-    BB_ASSERT_EQ(poly.q_r, 0);
-    BB_ASSERT_EQ(poly.q_o, 0);
-    if (poly.q_l == 0) {
-        return field_ct(poly.q_c);
-    }
-    field_ct x = field_ct::from_witness_index(&builder, poly.a);
-    x.additive_constant = poly.q_c;
-    x.multiplicative_constant = poly.q_l;
-    return x;
-}
-
 /**
  * @brief Create block constraints; Specialization for Ultra arithmetization
- * @details Ultra does not support DataBus operations so calldata/returndata are treated as ROM ops
+ * @details Ultra does not support DataBus operations
  *
  */
 template <>
@@ -45,24 +28,26 @@ void create_block_constraints(UltraCircuitBuilder& builder,
     using field_ct = bb::stdlib::field_t<UltraCircuitBuilder>;
 
     std::vector<field_ct> init;
-    for (auto i : constraint.init) {
-        field_ct value = arithmetic_triple_to_field_ct(i, builder);
-        init.push_back(value);
+    init.reserve(constraint.init.size());
+    for (const auto idx : constraint.init) {
+        init.push_back(field_ct::from_witness_index(&builder, idx));
     }
 
     switch (constraint.type) {
     // Note: CallData/ReturnData require DataBus, which is only available in Mega and in particular is _not_ supported
-    // by Ultra. They are therefore interpreted as ROM calls instead.
-    case BlockType::CallData:
-    case BlockType::ReturnData:
+    // by Ultra. If we encounter them in an Ultra circuit, we return an error.
     case BlockType::ROM:
         process_ROM_operations(builder, constraint, has_valid_witness_assignments, init);
         break;
     case BlockType::RAM:
         process_RAM_operations(builder, constraint, has_valid_witness_assignments, init);
         break;
+    case BlockType::CallData:
+    case BlockType::ReturnData:
+        bb::assert_failure("UltraCircuitBuilder does not support CallData/ReturnData block constraints. Use "
+                           "MegaCircuitBuilder or fall back to RAM and ROM operations.");
     default:
-        throw_or_abort("Unexpected block constraint type.");
+        bb::assert_failure("Unexpected block constraint type.");
         break;
     }
 }
@@ -79,9 +64,9 @@ void create_block_constraints(MegaCircuitBuilder& builder,
     using field_ct = stdlib::field_t<MegaCircuitBuilder>;
 
     std::vector<field_ct> init;
-    for (auto i : constraint.init) {
-        field_ct value = arithmetic_triple_to_field_ct(i, builder);
-        init.push_back(value);
+    init.reserve(constraint.init.size());
+    for (const auto idx : constraint.init) {
+        init.push_back(field_ct::from_witness_index(&builder, idx));
     }
 
     switch (constraint.type) {
@@ -98,7 +83,7 @@ void create_block_constraints(MegaCircuitBuilder& builder,
         process_return_data_operations(builder, constraint, init);
     } break;
     default:
-        throw_or_abort("Unexpected block constraint type.");
+        bb::assert_failure("Unexpected block constraint type.");
         break;
     }
 }
@@ -114,20 +99,22 @@ void process_ROM_operations(Builder& builder,
 
     rom_table_ct table(init);
     for (const auto& op : constraint.trace) {
-        BB_ASSERT_EQ(op.access_type, 0);
-        field_ct value = arithmetic_triple_to_field_ct(op.value, builder);
-        field_ct index = arithmetic_triple_to_field_ct(op.index, builder);
-        // For a ROM table, constant read should be already optimized out by the Noir compiler. Note that the
-        // `rom_table` indeed can perform constant reads, so this assert is present just to make sure the Noir compiler
-        // is acting as-it-should.
-        BB_ASSERT(op.index.q_l != 0, "witness index should be non-constant.");
+        field_ct value = to_field_ct(op.value, builder);
+        field_ct index = to_field_ct(op.index, builder);
 
         // In case of invalid witness assignment, we set the value of index value to zero to not hit out of bound in
         // ROM table
         if (!has_valid_witness_assignments) {
             builder.set_variable(index.get_witness_index(), 0);
         }
-        value.assert_equal(table[index]);
+
+        switch (op.access_type) {
+        case AccessType::Read:
+            value.assert_equal(table[index]);
+            break;
+        default:
+            bb::assert_failure("Invalid AccessType for ROM memory operation.");
+        }
     }
 }
 
@@ -142,19 +129,24 @@ void process_RAM_operations(Builder& builder,
 
     ram_table_ct table(init);
     for (const auto& op : constraint.trace) {
-        field_ct value = arithmetic_triple_to_field_ct(op.value, builder);
-        field_ct index = arithmetic_triple_to_field_ct(op.index, builder);
+        field_ct value = to_field_ct(op.value, builder);
+        field_ct index = to_field_ct(op.index, builder);
+
         // In case of invalid witness assignment, we set the value of index value to zero to not hit an out-of-bounds
         // index in the RAM table
         if (!has_valid_witness_assignments) {
             builder.set_variable(index.get_witness_index(), 0);
         }
 
-        if (op.access_type == 0) {
+        switch (op.access_type) {
+        case AccessType::Read:
             value.assert_equal(table.read(index));
-        } else {
-            BB_ASSERT_EQ(op.access_type, 1);
+            break;
+        case AccessType::Write:
             table.write(index, value);
+            break;
+        default:
+            bb::assert_failure("Invalid AccessType for RAM memory operation.");
         }
     }
 }
@@ -176,25 +168,36 @@ void process_call_data_operations(Builder& builder,
         calldata_array.set_values(init); // Initialize the data in the bus array
 
         for (const auto& op : constraint.trace) {
-            BB_ASSERT_EQ(op.access_type, 0);
-            field_ct value = arithmetic_triple_to_field_ct(op.value, builder);
-            field_ct index = arithmetic_triple_to_field_ct(op.index, builder);
+            field_ct value = to_field_ct(op.value, builder);
+            field_ct index = to_field_ct(op.index, builder);
+
             // In case of invalid witness assignment, we set the value of index value to zero to not hit out of bound in
-            // calldata-array
+            // ROM table
             if (!has_valid_witness_assignments) {
                 builder.set_variable(index.get_witness_index(), 0);
             }
-            value.assert_equal(calldata_array[index]);
+
+            switch (op.access_type) {
+            case AccessType::Read:
+                value.assert_equal(calldata_array[index]);
+            default:
+                bb::assert_failure("Invalid AccessType for CallData memory operation.");
+                break;
+            }
         }
     };
 
     // Process primary or secondary calldata based on calldata_id
-    if (constraint.calldata_id == 0) {
+    switch (constraint.calldata_id) {
+    case CallDataType::Primary:
         process_calldata(databus.calldata);
-    } else if (constraint.calldata_id == 1) {
+        break;
+    case CallDataType::Secondary:
         process_calldata(databus.secondary_calldata);
-    } else {
-        throw_or_abort("Databus only supports two calldata arrays.");
+        break;
+    default:
+        bb::assert_failure("Databus only supports two calldata arrays.");
+        break;
     }
 }
 
@@ -204,6 +207,9 @@ void process_return_data_operations(Builder& builder,
                                     std::vector<bb::stdlib::field_t<Builder>>& init)
 {
     using databus_ct = stdlib::databus<Builder>;
+    // Return data opcodes simply copy the data from the initialization vector to the return data vector in the databus.
+    // There is no operation happening.
+    BB_ASSERT_EQ(constraint.trace.size(), 0U, "Return data opcodes should have empty traces");
 
     databus_ct databus;
 
@@ -218,7 +224,6 @@ void process_return_data_operations(Builder& builder,
         value.assert_equal(databus.return_data[c]);
         c++;
     }
-    BB_ASSERT_EQ(constraint.trace.size(), 0U);
 }
 
 } // namespace acir_format

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/block_constraint.hpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/block_constraint.hpp
@@ -46,7 +46,7 @@ enum BlockType : std::uint8_t {
  * @details 1. init holds the initial values of the RAM/ROM/CallData/ReturnData table
  *          2. trace holds the sequence of memory operations (reads/writes) performed on the table
  *          3. type indicates the type of memory being constrained (RAM/ROM/CallData/ReturnData)
- *          4. calldata_id (used only for CallData) indicates whether we are operation on primary (kernel) or secondary
+ *          4. calldata_id (used only for CallData) indicates whether we are operating on primary (kernel) or secondary
  *             (app) calldata
  */
 struct BlockConstraint {

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/block_constraint.hpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/block_constraint.hpp
@@ -5,16 +5,32 @@
 // =====================
 
 #pragma once
+#include "barretenberg/dsl/acir_format/witness_constant.hpp"
 #include "barretenberg/stdlib/primitives/field/field.hpp"
 #include <cstdint>
 #include <vector>
 
 namespace acir_format {
 
+enum AccessType : std::uint8_t {
+    Read = 0,
+    Write = 1,
+};
+
+enum CallDataType : std::uint8_t {
+    None = 0,
+    Primary = 1,
+    Secondary = 2,
+};
+
+/**
+ * @brief Memory operation. Index and value store the index of the memory location, and value is the value to be read or
+ * written.
+ */
 struct MemOp {
-    uint8_t access_type; // always binary: `0` corresponds to a READ and `1` corresponds to a WRITE.
-    bb::arithmetic_triple index;
-    bb::arithmetic_triple value;
+    AccessType access_type;
+    WitnessOrConstant<bb::fr> index;
+    WitnessOrConstant<bb::fr> value;
 };
 
 enum BlockType : std::uint8_t {
@@ -24,11 +40,20 @@ enum BlockType : std::uint8_t {
     ReturnData = 3,
 };
 
+/**
+ * @brief Struct holding the data required to add memory constraints to a circuit.
+ *
+ * @details 1. init holds the initial values of the RAM/ROM/CallData/ReturnData table
+ *          2. trace holds the sequence of memory operations (reads/writes) performed on the table
+ *          3. type indicates the type of memory being constrained (RAM/ROM/CallData/ReturnData)
+ *          4. calldata_id (used only for CallData) indicates whether we are operation on primary (kernel) or secondary
+ *             (app) calldata
+ */
 struct BlockConstraint {
-    std::vector<bb::arithmetic_triple> init;
+    std::vector<uint32_t> init;
     std::vector<MemOp> trace;
     BlockType type;
-    uint32_t calldata_id{ 0 };
+    CallDataType calldata_id;
 };
 
 template <typename Builder>

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/block_constraint.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/block_constraint.test.cpp
@@ -399,12 +399,19 @@ TYPED_TEST(RAMTest, Tampering)
     TestFixture::test_tampering();
 }
 
-template <CallDataType calldata_type> class CallDataTestingFunctions {
+template <CallDataType CallDataType_, size_t CallDataSize_, size_t NumReads_, bool PerformConstantOps_>
+struct CallDataTestParams {
+    static constexpr CallDataType calldata_type = CallDataType_;
+    static constexpr size_t calldata_size = CallDataSize_;
+    static constexpr size_t num_reads = NumReads_;
+    static constexpr bool perform_constant_ops = PerformConstantOps_;
+};
+
+template <CallDataType calldata_type, size_t calldata_size, size_t num_reads, bool perform_constant_ops>
+class CallDataTestingFunctions {
   public:
     using AcirConstraint = BlockConstraint;
     using Builder = MegaCircuitBuilder;
-    static constexpr size_t CALLDATA_SIZE = 10;
-    static constexpr size_t NUM_READ = 5;
 
     class InvalidWitness {
       public:
@@ -420,14 +427,14 @@ template <CallDataType calldata_type> class CallDataTestingFunctions {
 
         // Create initial memory values "natively". Memory tables always start out initialized.
         std::vector<bb::fr> calldata_values;
-        calldata_values.reserve(CALLDATA_SIZE);
-        for (size_t _i = 0; _i < CALLDATA_SIZE; _i++) {
+        calldata_values.reserve(calldata_size);
+        for (size_t _i = 0; _i < calldata_size; _i++) {
             calldata_values.push_back(bb::fr::random_element());
         }
 
         // `init_indices` contains the initial values of the circuit.
         std::vector<uint32_t> init_indices;
-        for (size_t i = 0; i < CALLDATA_SIZE; ++i) {
+        for (size_t i = 0; i < calldata_size; ++i) {
             uint32_t value_index = add_to_witness_and_track_indices(witness_values, calldata_values[i]);
             init_indices.push_back(value_index);
         }
@@ -435,9 +442,9 @@ template <CallDataType calldata_type> class CallDataTestingFunctions {
         std::vector<MemOp> trace;
 
         // Add read operations
-        for (size_t idx = 0; idx < NUM_READ; ++idx) {
+        for (size_t idx = 0; idx < num_reads; ++idx) {
             MemOp mem_op;
-            const size_t calldata_idx_to_read = static_cast<size_t>(engine.get_random_uint32() % CALLDATA_SIZE);
+            const size_t calldata_idx_to_read = static_cast<size_t>(engine.get_random_uint32() % calldata_size);
             const uint32_t index_for_read =
                 add_to_witness_and_track_indices(witness_values, bb::fr(calldata_idx_to_read));
             bb::fr read_value = calldata_values[calldata_idx_to_read];
@@ -448,7 +455,9 @@ template <CallDataType calldata_type> class CallDataTestingFunctions {
                        .value = WitnessOrConstant<bb::fr>::from_index(value_for_read) };
             trace.push_back(mem_op);
         }
-        add_constant_ops<AccessType::Read>(CALLDATA_SIZE, calldata_values, witness_values, trace);
+        if constexpr (perform_constant_ops) {
+            add_constant_ops<AccessType::Read>(calldata_size, calldata_values, witness_values, trace);
+        }
 
         // Create the MemoryConstraint
         memory_constraint = AcirConstraint{
@@ -465,7 +474,7 @@ template <CallDataType calldata_type> class CallDataTestingFunctions {
             break;
         case InvalidWitness::Target::ReadValueIncremented:
             // Tamper with a random read value using the recorded witness index
-            const size_t random_read_idx = static_cast<size_t>(engine.get_random_uint32() % NUM_READ);
+            const size_t random_read_idx = static_cast<size_t>(engine.get_random_uint32() % num_reads);
             const uint32_t witness_idx = memory_constraint.trace[random_read_idx].index.index;
             witness_values[witness_idx] += bb::fr(1);
             break;
@@ -473,42 +482,37 @@ template <CallDataType calldata_type> class CallDataTestingFunctions {
     }
 };
 
-class PrimaryCallDataTests : public ::testing::Test, public TestClass<CallDataTestingFunctions<CallDataType::Primary>> {
+using CallDataTestConfigs = testing::Types<CallDataTestParams<CallDataType::Primary, 10, 5, false>,
+                                           CallDataTestParams<CallDataType::Primary, 10, 5, true>>;
+
+template <typename Params>
+class CallDataTests : public ::testing::Test,
+                      public TestClass<CallDataTestingFunctions<Params::calldata_type,
+                                                                Params::calldata_size,
+                                                                Params::num_reads,
+                                                                Params::perform_constant_ops>> {
   protected:
     static void SetUpTestSuite() { bb::srs::init_file_crs_factory(bb::srs::bb_crs_path()); }
 };
 
-TEST_F(PrimaryCallDataTests, GenerateVKFromConstraints)
+TYPED_TEST_SUITE(CallDataTests, CallDataTestConfigs);
+
+TYPED_TEST(CallDataTests, GenerateVKFromConstraints)
 {
-    test_vk_independence<MegaFlavor>();
+    TestFixture::template test_vk_independence<MegaFlavor>();
 }
 
-TEST_F(PrimaryCallDataTests, Tampering)
+TYPED_TEST(CallDataTests, Tampering)
 {
-    test_tampering();
+    TestFixture::test_tampering();
 }
 
-class SecondaryCallDataTests : public ::testing::Test,
-                               public TestClass<CallDataTestingFunctions<CallDataType::Secondary>> {
-  protected:
-    static void SetUpTestSuite() { bb::srs::init_file_crs_factory(bb::srs::bb_crs_path()); }
-};
-
-TEST_F(SecondaryCallDataTests, GenerateVKFromConstraints)
-{
-    test_vk_independence<MegaFlavor>();
-}
-
-TEST_F(SecondaryCallDataTests, Tampering)
-{
-    test_tampering();
-}
+template <size_t returndata_size>
 
 class ReturnDataTestingFunctions {
   public:
     using AcirConstraint = BlockConstraint;
     using Builder = MegaCircuitBuilder;
-    static constexpr size_t RETURNDATA_SIZE = 10;
 
     // There is no tampering that can be done for ReturnData as the only thing that a return data opcode does is
     // adding data to the return data bus vector and constraining such data to be equal to the data with which the
@@ -526,14 +530,14 @@ class ReturnDataTestingFunctions {
     {
         // Create initial memory values "natively". Memory tables always start out initialized.
         std::vector<bb::fr> returndata_values;
-        returndata_values.reserve(RETURNDATA_SIZE);
-        for (size_t _i = 0; _i < RETURNDATA_SIZE; _i++) {
+        returndata_values.reserve(returndata_size);
+        for (size_t _i = 0; _i < returndata_size; _i++) {
             returndata_values.push_back(bb::fr::random_element());
         }
 
         // `init_indices` contains the initial values of the circuit.
         std::vector<uint32_t> init_indices;
-        for (size_t i = 0; i < RETURNDATA_SIZE; ++i) {
+        for (size_t i = 0; i < returndata_size; ++i) {
             uint32_t value_index = add_to_witness_and_track_indices(witness_values, returndata_values[i]);
             init_indices.push_back(value_index);
         }
@@ -553,7 +557,8 @@ class ReturnDataTestingFunctions {
     }
 };
 
-class ReturnDataTests : public ::testing::Test, public TestClass<ReturnDataTestingFunctions> {
+static constexpr size_t RETURNDATA_SIZE = 10;
+class ReturnDataTests : public ::testing::Test, public TestClass<ReturnDataTestingFunctions<RETURNDATA_SIZE>> {
   protected:
     static void SetUpTestSuite() { bb::srs::init_file_crs_factory(bb::srs::bb_crs_path()); }
 };

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/block_constraint.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/block_constraint.test.cpp
@@ -19,23 +19,60 @@ using namespace acir_format;
 
 namespace {
 auto& engine = numeric::get_debug_randomness();
-// returns a `arithmetic_triple` from the value index corresponding to a witness.
-[[maybe_unused]] arithmetic_triple arithmetic_triple_from_witness(uint32_t value_index)
-{
-    return arithmetic_triple{ .a = value_index, .b = 0, .c = 0, .q_m = 0, .q_l = 1, .q_r = 0, .q_o = 0, .q_c = 0 };
-}
-// returns a `arithmetic_triple` from a constant.
-[[maybe_unused]] arithmetic_triple arithmetic_triple_from_constant(bb::fr constant_value)
-{
-    return arithmetic_triple{ .a = 0, .b = 0, .c = 0, .q_m = 0, .q_l = 0, .q_r = 0, .q_o = 0, .q_c = constant_value };
-}
 } // namespace
-template <typename Builder_, size_t TableSize_, size_t NumReads_> struct ROMTestParams {
+
+/**
+ * @brief Utility method to add read/write operations with constant indices/values
+ */
+template <AccessType access_type>
+void add_constant_ops(const size_t table_size,
+                      const std::vector<bb::fr>& table_values,
+                      WitnessVector& witness_values,
+                      std::vector<MemOp>& trace)
+{
+    const size_t table_index = static_cast<size_t>(engine.get_random_uint32() % table_size);
+    bb::fr value_fr =
+        access_type == AccessType::Read ? table_values[table_index] : table_values[table_index] + bb::fr(1);
+
+    // Index constant, value witness
+    {
+        WitnessOrConstant<bb::fr> index = WitnessOrConstant<bb::fr>::from_constant(table_index);
+        WitnessOrConstant<bb::fr> value =
+            WitnessOrConstant<bb::fr>::from_index(add_to_witness_and_track_indices(witness_values, value_fr));
+
+        const MemOp read_op = { .access_type = access_type, .index = index, .value = value };
+
+        trace.push_back(read_op);
+    }
+    // Index witness, value constant
+    {
+        WitnessOrConstant<bb::fr> index = WitnessOrConstant<bb::fr>::from_index(
+            add_to_witness_and_track_indices(witness_values, bb::fr(table_index)));
+        WitnessOrConstant<bb::fr> value = WitnessOrConstant<bb::fr>::from_constant(value_fr);
+
+        const MemOp read_op = { .access_type = access_type, .index = index, .value = value };
+
+        trace.push_back(read_op);
+    }
+    // Index constant, value constant
+    {
+        WitnessOrConstant<bb::fr> index = WitnessOrConstant<bb::fr>::from_constant(table_index);
+        WitnessOrConstant<bb::fr> value = WitnessOrConstant<bb::fr>::from_constant(value_fr);
+
+        const MemOp read_op = { .access_type = access_type, .index = index, .value = value };
+
+        trace.push_back(read_op);
+    }
+}
+
+template <typename Builder_, size_t TableSize_, size_t NumReads_, bool PerformConstantOps_> struct ROMTestParams {
     using Builder = Builder_;
     static constexpr size_t table_size = TableSize_;
     static constexpr size_t num_reads = NumReads_;
+    static constexpr bool perform_constant_ops = PerformConstantOps_;
 };
-template <typename Builder_, size_t table_size, size_t num_reads> class ROMTestingFunctions {
+
+template <typename Builder_, size_t table_size, size_t num_reads, bool perform_constant_ops> class ROMTestingFunctions {
   public:
     using AcirConstraint = BlockConstraint;
     using Builder = Builder_;
@@ -70,11 +107,11 @@ template <typename Builder_, size_t table_size, size_t num_reads> class ROMTesti
         }
 
         // `init_poly` represents the _initial values_ of the circuit.
-        std::vector<arithmetic_triple> init_polys;
+        std::vector<uint32_t> init_indices;
         for (const auto& val : table_values) {
             uint32_t value_index = add_to_witness_and_track_indices(witness_values, val);
-            // push the circuit incarnation of the value in `init_polys`
-            init_polys.push_back(arithmetic_triple_from_witness(value_index));
+            // push the circuit incarnation of the value in `init_indices`
+            init_indices.push_back(value_index);
         }
 
         // Initialize and create memory operations
@@ -84,23 +121,28 @@ template <typename Builder_, size_t table_size, size_t num_reads> class ROMTesti
         if constexpr (table_size > 0) {
             for (size_t _i = 0; _i < num_reads; ++_i) {
                 const size_t rom_index_to_read = static_cast<size_t>(engine.get_random_uint32() % table_size);
-
-                // Add index witness
-                const uint32_t index_for_read =
-                    add_to_witness_and_track_indices(witness_values, bb::fr(rom_index_to_read));
                 // Add value witness
                 bb::fr read_value = table_values[rom_index_to_read];
-                const uint32_t value_for_read = add_to_witness_and_track_indices(witness_values, read_value);
 
-                const MemOp read_op = { .access_type = 0, // READ
-                                        .index = arithmetic_triple_from_witness(index_for_read),
-                                        .value = arithmetic_triple_from_witness(value_for_read) };
+                WitnessOrConstant<bb::fr> index_for_read = WitnessOrConstant<bb::fr>::from_index(
+                    add_to_witness_and_track_indices(witness_values, bb::fr(rom_index_to_read)));
+                WitnessOrConstant<bb::fr> value_for_read =
+                    WitnessOrConstant<bb::fr>::from_index(add_to_witness_and_track_indices(witness_values, read_value));
+
+                const MemOp read_op = { .access_type = AccessType::Read,
+                                        .index = index_for_read,
+                                        .value = value_for_read };
+
                 trace.push_back(read_op);
+            }
+            if constexpr (perform_constant_ops) {
+                add_constant_ops<AccessType::Read>(table_size, table_values, witness_values, trace);
             }
         }
         // Create the MemoryConstraint
-        memory_constraint = AcirConstraint{ .init = init_polys, .trace = trace, .type = BlockType::ROM };
+        memory_constraint = AcirConstraint{ .init = init_indices, .trace = trace, .type = BlockType::ROM };
     }
+
     static void invalidate_witness([[maybe_unused]] AcirConstraint& memory_constraint,
                                    WitnessVector& witness_values,
                                    const InvalidWitness::Target& invalid_witness_target)
@@ -123,15 +165,20 @@ template <typename Builder_, size_t table_size, size_t num_reads> class ROMTesti
 };
 template <typename Params>
 class ROMTest : public ::testing::Test,
-                public TestClass<ROMTestingFunctions<typename Params::Builder, Params::table_size, Params::num_reads>> {
+                public TestClass<ROMTestingFunctions<typename Params::Builder,
+                                                     Params::table_size,
+                                                     Params::num_reads,
+                                                     Params::perform_constant_ops>> {
   protected:
     static void SetUpTestSuite() { bb::srs::init_file_crs_factory(bb::srs::bb_crs_path()); }
 };
 
-using ROMTestConfigs = testing::Types<ROMTestParams<UltraCircuitBuilder, 0, 0>,
-                                      ROMTestParams<UltraCircuitBuilder, 10, 0>,
-                                      ROMTestParams<MegaCircuitBuilder, 10, 10>,
-                                      ROMTestParams<MegaCircuitBuilder, 10, 20>>;
+using ROMTestConfigs = testing::Types<ROMTestParams<UltraCircuitBuilder, 0, 0, false>,
+                                      ROMTestParams<UltraCircuitBuilder, 10, 0, false>,
+                                      ROMTestParams<UltraCircuitBuilder, 10, 0, true>, // Test the case in which there
+                                                                                       // are only constant operations
+                                      ROMTestParams<MegaCircuitBuilder, 10, 10, true>,
+                                      ROMTestParams<MegaCircuitBuilder, 10, 20, true>>;
 
 TYPED_TEST_SUITE(ROMTest, ROMTestConfigs);
 
@@ -147,18 +194,20 @@ TYPED_TEST(ROMTest, Tampering)
     TestFixture::test_tampering();
 }
 
-template <typename Builder_, size_t TableSize_, size_t NumReads_, size_t NumWrites_> struct RAMTestParams {
+template <typename Builder_, size_t TableSize_, size_t NumReads_, size_t NumWrites_, bool PerformConstantOps_>
+struct RAMTestParams {
     using Builder = Builder_;
     static constexpr size_t table_size = TableSize_;
     static constexpr size_t num_reads = NumReads_;
     static constexpr size_t num_writes = NumWrites_;
+    static constexpr bool perform_constant_ops = PerformConstantOps_;
 };
 
-template <typename Builder_, size_t table_size, size_t num_reads, size_t num_writes> class RAMTestingFunctions {
+template <typename Builder_, size_t table_size, size_t num_reads, size_t num_writes, bool perform_constant_ops>
+class RAMTestingFunctions {
   public:
     using AcirConstraint = BlockConstraint;
     using Builder = Builder_;
-    enum class AccessType : std::uint8_t { READ, WRITE };
 
     // Track witness value and its index in witness_values
     struct WitnessValue {
@@ -202,17 +251,12 @@ template <typename Builder_, size_t table_size, size_t num_reads, size_t num_wri
             table_values.push_back(bb::fr::random_element());
         }
 
-        // `init_polys` contains the initial values of the circuit. we set half of them to be constants and half to be
-        // witnesses.
-        std::vector<arithmetic_triple> init_polys;
+        // `init_indices` contains the initial values of the circuit.
+        std::vector<uint32_t> init_indices;
         for (size_t i = 0; i < table_size; ++i) {
             const auto val = table_values[i];
-            if (i % 2 == 0) {
-                uint32_t value_index = add_to_witness_and_track_indices(witness_values, val);
-                init_polys.push_back(arithmetic_triple_from_witness(value_index));
-            } else {
-                init_polys.push_back(arithmetic_triple_from_constant(val));
-            }
+            uint32_t value_index = add_to_witness_and_track_indices(witness_values, val);
+            init_indices.push_back(value_index);
         }
         // Initialize and create memory operations
         std::vector<MemOp> trace;
@@ -224,15 +268,15 @@ template <typename Builder_, size_t table_size, size_t num_reads, size_t num_wri
         while (num_reads_remaining + num_writes_remaining > 0) {
             bool try_read = (engine.get_random_uint32() & 1) != 0;
             if (try_read && (num_reads_remaining > 0)) {
-                read_write_sequence.push_back(AccessType::READ);
+                read_write_sequence.push_back(AccessType::Read);
                 num_reads_remaining--;
             } else if (num_writes_remaining > 0) {
-                read_write_sequence.push_back(AccessType::WRITE);
+                read_write_sequence.push_back(AccessType::Write);
                 num_writes_remaining--;
             } else {
                 // writes exhausted, hence only reads left
                 for (size_t _j = 0; _j < num_reads_remaining; _j++) {
-                    read_write_sequence.push_back(AccessType::READ);
+                    read_write_sequence.push_back(AccessType::Read);
                 }
                 num_reads_remaining = 0;
             }
@@ -243,7 +287,7 @@ template <typename Builder_, size_t table_size, size_t num_reads, size_t num_wri
             for (auto& access_type : read_write_sequence) {
                 MemOp mem_op;
                 switch (access_type) {
-                case AccessType::READ: {
+                case AccessType::Read: {
                     const size_t ram_index_to_read = static_cast<size_t>(engine.get_random_uint32() % table_size);
                     const uint32_t index_for_read =
                         add_to_witness_and_track_indices(witness_values, bb::fr(ram_index_to_read));
@@ -253,13 +297,13 @@ template <typename Builder_, size_t table_size, size_t num_reads, size_t num_wri
                     // Record this read value and its witness index
                     read_values.push_back({ .value = read_value, .witness_index = value_for_read });
 
-                    mem_op = { .access_type = 0, // READ
-                               .index = arithmetic_triple_from_witness(index_for_read),
-                               .value = arithmetic_triple_from_witness(value_for_read) };
+                    mem_op = { .access_type = AccessType::Read,
+                               .index = WitnessOrConstant<bb::fr>::from_index(index_for_read),
+                               .value = WitnessOrConstant<bb::fr>::from_index(value_for_read) };
                     trace.push_back(mem_op);
                     break;
                 }
-                case AccessType::WRITE: {
+                case AccessType::Write: {
                     const size_t ram_index_to_write = static_cast<size_t>(engine.get_random_uint32() % table_size);
                     const uint32_t index_to_write =
                         add_to_witness_and_track_indices(witness_values, bb::fr(ram_index_to_write));
@@ -269,18 +313,23 @@ template <typename Builder_, size_t table_size, size_t num_reads, size_t num_wri
                     // Update the table_values to reflect this write
                     table_values[ram_index_to_write] = write_value;
 
-                    mem_op = { .access_type = 1, // WRITE
-                               .index = arithmetic_triple_from_witness(index_to_write),
-                               .value = arithmetic_triple_from_witness(value_to_write) };
+                    mem_op = { .access_type = AccessType::Write,
+                               .index = WitnessOrConstant<bb::fr>::from_index(index_to_write),
+                               .value = WitnessOrConstant<bb::fr>::from_index(value_to_write) };
                     trace.push_back(mem_op);
                     break;
                 }
                 }
             }
+            if constexpr (perform_constant_ops) {
+                add_constant_ops<AccessType::Read>(table_size, table_values, witness_values, trace);
+                add_constant_ops<AccessType::Write>(table_size, table_values, witness_values, trace);
+            }
+
+            BB_ASSERT_EQ(read_values.size(), num_reads); // sanity check to make sure the number of reads is correct.
+            // Create the MemoryConstraint
         }
-        BB_ASSERT_EQ(read_values.size(), num_reads); // sanity check to make sure the number of reads is correct.
-        // Create the MemoryConstraint
-        memory_constraint = AcirConstraint{ .init = init_polys, .trace = trace, .type = BlockType::RAM };
+        memory_constraint = AcirConstraint{ .init = init_indices, .trace = trace, .type = BlockType::RAM };
     }
 
     void invalidate_witness([[maybe_unused]] AcirConstraint& memory_constraint,
@@ -305,21 +354,36 @@ template <typename Builder_, size_t table_size, size_t num_reads, size_t num_wri
 };
 
 template <typename Params>
-class RAMTest
-    : public ::testing::Test,
-      public TestClass<
-          RAMTestingFunctions<typename Params::Builder, Params::table_size, Params::num_reads, Params::num_writes>> {
+class RAMTest : public ::testing::Test,
+                public TestClass<RAMTestingFunctions<typename Params::Builder,
+                                                     Params::table_size,
+                                                     Params::num_reads,
+                                                     Params::num_writes,
+                                                     Params::perform_constant_ops>> {
   protected:
     static void SetUpTestSuite() { bb::srs::init_file_crs_factory(bb::srs::bb_crs_path()); }
 };
 
 // Failure tests are impossible in the scenario with only writes.
-using RAMTestConfigs = testing::Types<RAMTestParams<UltraCircuitBuilder, 0, 0, 0>,
-                                      RAMTestParams<UltraCircuitBuilder, 10, 10, 0>,
-                                      RAMTestParams<UltraCircuitBuilder, 10, 20, 10>,
-                                      RAMTestParams<MegaCircuitBuilder, 0, 0, 0>,
-                                      RAMTestParams<MegaCircuitBuilder, 10, 10, 0>,
-                                      RAMTestParams<MegaCircuitBuilder, 10, 20, 10>>;
+using RAMTestConfigs =
+    testing::Types<RAMTestParams<UltraCircuitBuilder, 0, 0, 0, false>,
+                   RAMTestParams<UltraCircuitBuilder, 10, 0, 0, false>,
+                   RAMTestParams<UltraCircuitBuilder, 10, 0, 0, true>, // Test the case in which there are only
+                                                                       // constant operations
+                   RAMTestParams<UltraCircuitBuilder, 10, 0, 10, false>,
+                   RAMTestParams<UltraCircuitBuilder, 10, 0, 10, true>,
+                   RAMTestParams<UltraCircuitBuilder, 10, 10, 0, false>,
+                   RAMTestParams<UltraCircuitBuilder, 10, 10, 0, true>,
+                   RAMTestParams<UltraCircuitBuilder, 10, 20, 10, true>,
+                   RAMTestParams<MegaCircuitBuilder, 0, 0, 0, false>,
+                   RAMTestParams<MegaCircuitBuilder, 10, 0, 0, false>,
+                   RAMTestParams<MegaCircuitBuilder, 10, 0, 0, true>, // Test the case in which there are only
+                                                                      // constant operations
+                   RAMTestParams<MegaCircuitBuilder, 10, 0, 10, false>,
+                   RAMTestParams<MegaCircuitBuilder, 10, 0, 10, true>,
+                   RAMTestParams<MegaCircuitBuilder, 10, 10, 0, false>,
+                   RAMTestParams<MegaCircuitBuilder, 10, 10, 0, true>,
+                   RAMTestParams<MegaCircuitBuilder, 10, 20, 10, true>>;
 
 TYPED_TEST_SUITE(RAMTest, RAMTestConfigs);
 
@@ -335,241 +399,200 @@ TYPED_TEST(RAMTest, Tampering)
     TestFixture::test_tampering();
 }
 
-class MegaHonk : public ::testing::Test {
+template <CallDataType calldata_type> class CallDataTestingFunctions {
   public:
-    using Flavor = MegaFlavor;
-    using Builder = Flavor::CircuitBuilder;
-    using Prover = UltraProver_<Flavor>;
-    using Verifier = UltraVerifier_<Flavor>;
-    using VerificationKey = Flavor::VerificationKey;
+    using AcirConstraint = BlockConstraint;
+    using Builder = MegaCircuitBuilder;
+    static constexpr size_t CALLDATA_SIZE = 10;
+    static constexpr size_t NUM_READ = 5;
 
-    // Construct and verify an MegaHonk proof for the provided circuit
-    static bool prove_and_verify(Builder& circuit)
+    class InvalidWitness {
+      public:
+        enum class Target : uint8_t { None, ReadValueIncremented };
+
+        static std::vector<Target> get_all() { return { Target::None, Target::ReadValueIncremented }; };
+
+        static std::vector<std::string> get_labels() { return { "None", "ReadValueIncremented" }; };
+    };
+
+    void generate_constraints(AcirConstraint& memory_constraint, WitnessVector& witness_values)
     {
-        auto prover_instance = std::make_shared<ProverInstance_<Flavor>>(circuit);
-        auto verification_key = std::make_shared<VerificationKey>(prover_instance->get_precomputed());
-        Prover prover{ prover_instance, verification_key };
-        auto proof = prover.construct_proof();
 
-        Verifier verifier{ verification_key };
+        // Create initial memory values "natively". Memory tables always start out initialized.
+        std::vector<bb::fr> calldata_values;
+        calldata_values.reserve(CALLDATA_SIZE);
+        for (size_t _i = 0; _i < CALLDATA_SIZE; _i++) {
+            calldata_values.push_back(bb::fr::random_element());
+        }
 
-        bool result = verifier.template verify_proof<DefaultIO>(proof).result;
-        return result;
+        // `init_indices` contains the initial values of the circuit.
+        std::vector<uint32_t> init_indices;
+        for (size_t i = 0; i < CALLDATA_SIZE; ++i) {
+            uint32_t value_index = add_to_witness_and_track_indices(witness_values, calldata_values[i]);
+            init_indices.push_back(value_index);
+        }
+        // Initialize and create memory operations
+        std::vector<MemOp> trace;
+
+        // Add read operations
+        for (size_t idx = 0; idx < NUM_READ; ++idx) {
+            MemOp mem_op;
+            const size_t calldata_idx_to_read = static_cast<size_t>(engine.get_random_uint32() % CALLDATA_SIZE);
+            const uint32_t index_for_read =
+                add_to_witness_and_track_indices(witness_values, bb::fr(calldata_idx_to_read));
+            bb::fr read_value = calldata_values[calldata_idx_to_read];
+            const uint32_t value_for_read = add_to_witness_and_track_indices(witness_values, read_value);
+
+            mem_op = { .access_type = AccessType::Read,
+                       .index = WitnessOrConstant<bb::fr>::from_index(index_for_read),
+                       .value = WitnessOrConstant<bb::fr>::from_index(value_for_read) };
+            trace.push_back(mem_op);
+        }
+        add_constant_ops<AccessType::Read>(CALLDATA_SIZE, calldata_values, witness_values, trace);
+
+        // Create the MemoryConstraint
+        memory_constraint = AcirConstraint{
+            .init = init_indices, .trace = trace, .type = BlockType::CallData, .calldata_id = calldata_type
+        };
     }
 
+    void invalidate_witness(AcirConstraint& memory_constraint,
+                            WitnessVector& witness_values,
+                            const InvalidWitness::Target& invalid_witness_target)
+    {
+        switch (invalid_witness_target) {
+        case InvalidWitness::Target::None:
+            break;
+        case InvalidWitness::Target::ReadValueIncremented:
+            // Tamper with a random read value using the recorded witness index
+            const size_t random_read_idx = static_cast<size_t>(engine.get_random_uint32() % NUM_READ);
+            const uint32_t witness_idx = memory_constraint.trace[random_read_idx].index.index;
+            witness_values[witness_idx] += bb::fr(1);
+            break;
+        }
+    }
+};
+
+class PrimaryCallDataTests : public ::testing::Test, public TestClass<CallDataTestingFunctions<CallDataType::Primary>> {
   protected:
     static void SetUpTestSuite() { bb::srs::init_file_crs_factory(bb::srs::bb_crs_path()); }
 };
-size_t generate_block_constraint(BlockConstraint& constraint, WitnessVector& witness_values)
+
+TEST_F(PrimaryCallDataTests, GenerateVKFromConstraints)
 {
-    size_t witness_len = 0;
-    witness_values.emplace_back(1);
-    witness_len++;
-
-    fr two = fr::one() + fr::one();
-    arithmetic_triple a0{
-        .a = 0,
-        .b = 0,
-        .c = 0,
-        .q_m = 0,
-        .q_l = two,
-        .q_r = 0,
-        .q_o = 0,
-        .q_c = 0,
-    };
-    fr three = fr::one() + two;
-    arithmetic_triple a1{
-        .a = 0,
-        .b = 0,
-        .c = 0,
-        .q_m = 0,
-        .q_l = 0,
-        .q_r = 0,
-        .q_o = 0,
-        .q_c = three,
-    };
-    arithmetic_triple r1{
-        .a = 0,
-        .b = 0,
-        .c = 0,
-        .q_m = 0,
-        .q_l = fr::one(),
-        .q_r = 0,
-        .q_o = 0,
-        .q_c = fr::neg_one(),
-    };
-    arithmetic_triple r2{
-        .a = 0,
-        .b = 0,
-        .c = 0,
-        .q_m = 0,
-        .q_l = two,
-        .q_r = 0,
-        .q_o = 0,
-        .q_c = fr::neg_one(),
-    };
-    arithmetic_triple y{
-        .a = 1,
-        .b = 0,
-        .c = 0,
-        .q_m = 0,
-        .q_l = fr::one(),
-        .q_r = 0,
-        .q_o = 0,
-        .q_c = 0,
-    };
-    witness_values.emplace_back(2);
-    witness_len++;
-    arithmetic_triple z{
-        .a = 2,
-        .b = 0,
-        .c = 0,
-        .q_m = 0,
-        .q_l = fr::one(),
-        .q_r = 0,
-        .q_o = 0,
-        .q_c = 0,
-    };
-    witness_values.emplace_back(3);
-    witness_len++;
-    MemOp op1{
-        .access_type = 0,
-        .index = r1,
-        .value = y,
-    };
-    MemOp op2{
-        .access_type = 0,
-        .index = r2,
-        .value = z,
-    };
-    constraint = BlockConstraint{
-        .init = { a0, a1 },
-        .trace = { op1, op2 },
-        .type = BlockType::ROM,
-    };
-
-    return witness_len;
+    test_vk_independence<MegaFlavor>();
 }
 
-TEST_F(MegaHonk, Databus)
+TEST_F(PrimaryCallDataTests, Tampering)
 {
-    BlockConstraint block;
-    AcirProgram program;
-    size_t num_variables = generate_block_constraint(block, program.witness);
-    block.type = BlockType::CallData;
-
-    program.constraints = {
-        .varnum = static_cast<uint32_t>(num_variables),
-        .num_acir_opcodes = 1,
-        .public_inputs = {},
-        .block_constraints = { block },
-        .original_opcode_indices = create_empty_original_opcode_indices(),
-    };
-
-    mock_opcode_indices(program.constraints);
-
-    // Construct a bberg circuit from the acir representation
-    auto circuit = create_circuit<Builder>(program);
-
-    EXPECT_TRUE(CircuitChecker::check(circuit));
+    test_tampering();
 }
 
-TEST_F(MegaHonk, DatabusReturn)
+class SecondaryCallDataTests : public ::testing::Test,
+                               public TestClass<CallDataTestingFunctions<CallDataType::Secondary>> {
+  protected:
+    static void SetUpTestSuite() { bb::srs::init_file_crs_factory(bb::srs::bb_crs_path()); }
+};
+
+TEST_F(SecondaryCallDataTests, GenerateVKFromConstraints)
 {
-    BlockConstraint block;
-    AcirProgram program;
-    size_t num_variables = generate_block_constraint(block, program.witness);
-    block.type = BlockType::CallData;
-
-    arithmetic_triple rd_index{
-        .a = static_cast<uint32_t>(num_variables),
-        .b = 0,
-        .c = 0,
-        .q_m = 0,
-        .q_l = 1,
-        .q_r = 0,
-        .q_o = 0,
-        .q_c = 0,
-    };
-    program.witness.emplace_back(0);
-    ++num_variables;
-    auto fr_five = fr(5);
-    arithmetic_triple rd_read{
-        .a = static_cast<uint32_t>(num_variables),
-        .b = 0,
-        .c = 0,
-        .q_m = 0,
-        .q_l = 1,
-        .q_r = 0,
-        .q_o = 0,
-        .q_c = 0,
-    };
-    program.witness.emplace_back(fr_five);
-    arithmetic_triple five{
-        .a = 0,
-        .b = 0,
-        .c = 0,
-        .q_m = 0,
-        .q_l = 0,
-        .q_r = 0,
-        .q_o = 0,
-        .q_c = fr(fr_five),
-    };
-    ++num_variables;
-    MemOp op_rd{
-        .access_type = 0,
-        .index = rd_index,
-        .value = rd_read,
-    };
-    // Initialize the data_bus as [5] and read its value into rd_read
-    auto return_data = BlockConstraint{
-        .init = { five },
-        .trace = { op_rd },
-        .type = BlockType::ReturnData,
-    };
-
-    // Assert that call_data[0]+call_data[1] == return_data[0]
-    arithmetic_triple assert_equal{
-        .a = 1,
-        .b = 2,
-        .c = rd_read.a,
-        .q_m = 0,
-        .q_l = 1,
-        .q_r = 1,
-        .q_o = fr::neg_one(),
-        .q_c = 0,
-    };
-
-    program.constraints = {
-        .varnum = static_cast<uint32_t>(num_variables),
-        .num_acir_opcodes = 2,
-        .public_inputs = {},
-        .arithmetic_triple_constraints = { assert_equal },
-        .block_constraints = { block },
-        .original_opcode_indices = create_empty_original_opcode_indices(),
-    };
-    mock_opcode_indices(program.constraints);
-
-    // Construct a bberg circuit from the acir representation
-    auto circuit = create_circuit<Builder>(program);
-
-    EXPECT_TRUE(CircuitChecker::check(circuit));
+    test_vk_independence<MegaFlavor>();
 }
+
+TEST_F(SecondaryCallDataTests, Tampering)
+{
+    test_tampering();
+}
+
+class ReturnDataTestingFunctions {
+  public:
+    using AcirConstraint = BlockConstraint;
+    using Builder = MegaCircuitBuilder;
+    static constexpr size_t RETURNDATA_SIZE = 10;
+
+    // There is no tampering that can be done for ReturnData as the only thing that a return data opcode does is
+    // adding data to the return data bus vector and constraining such data to be equal to the data with which the
+    // memory operation was initialized
+    class InvalidWitness {
+      public:
+        enum class Target : uint8_t { None };
+
+        static std::vector<Target> get_all() { return { Target::None }; };
+
+        static std::vector<std::string> get_labels() { return { "None" }; };
+    };
+
+    void generate_constraints(AcirConstraint& memory_constraint, WitnessVector& witness_values)
+    {
+        // Create initial memory values "natively". Memory tables always start out initialized.
+        std::vector<bb::fr> returndata_values;
+        returndata_values.reserve(RETURNDATA_SIZE);
+        for (size_t _i = 0; _i < RETURNDATA_SIZE; _i++) {
+            returndata_values.push_back(bb::fr::random_element());
+        }
+
+        // `init_indices` contains the initial values of the circuit.
+        std::vector<uint32_t> init_indices;
+        for (size_t i = 0; i < RETURNDATA_SIZE; ++i) {
+            uint32_t value_index = add_to_witness_and_track_indices(witness_values, returndata_values[i]);
+            init_indices.push_back(value_index);
+        }
+
+        // Create the MemoryConstraint
+        memory_constraint = AcirConstraint{ .init = init_indices, .trace = {}, .type = BlockType::ReturnData };
+    }
+
+    void invalidate_witness([[maybe_unused]] AcirConstraint& memory_constraint,
+                            [[maybe_unused]] WitnessVector& witness_values,
+                            const InvalidWitness::Target& invalid_witness_target)
+    {
+        switch (invalid_witness_target) {
+        case InvalidWitness::Target::None:
+            break;
+        }
+    }
+};
+
+class ReturnDataTests : public ::testing::Test, public TestClass<ReturnDataTestingFunctions> {
+  protected:
+    static void SetUpTestSuite() { bb::srs::init_file_crs_factory(bb::srs::bb_crs_path()); }
+};
+
+TEST_F(ReturnDataTests, GenerateVKFromConstraints)
+{
+    test_vk_independence<MegaFlavor>();
+}
+
+template <typename Builder> class EmptyBlockConstraintTests : public ::testing::Test {};
+
+using BuilderTypes = testing::Types<UltraCircuitBuilder, MegaCircuitBuilder>;
+TYPED_TEST_SUITE(EmptyBlockConstraintTests, BuilderTypes);
 
 // Test that all block constraint types handle empty initialization gracefully
-TEST_F(MegaHonk, EmptyBlockConstraints)
+TYPED_TEST(EmptyBlockConstraintTests, EmptyBlockConstraints)
 {
+    using Builder = TypeParam;
+
+    std::vector<std::pair<BlockType, CallDataType>> types_to_test;
+
     // Test each block constraint type
-    std::vector<BlockType> types_to_test = {
-        BlockType::ROM, BlockType::RAM, BlockType::CallData, BlockType::ReturnData
-    };
+    if constexpr (IsUltraBuilder<Builder>) {
+        types_to_test = { { BlockType::ROM, CallDataType::None }, { BlockType::RAM, CallDataType::None } };
+    } else {
+        types_to_test = { { BlockType::ROM, CallDataType::None },
+                          { BlockType::RAM, CallDataType::None },
+                          { BlockType::CallData, CallDataType::Primary },
+                          { BlockType::CallData, CallDataType::Secondary },
+                          { BlockType::ReturnData, CallDataType::None } };
+    }
 
     // Create empty block constraint
-    for (auto block_type : types_to_test) {
+    for (auto type : types_to_test) {
         BlockConstraint block{
             .init = {},  // Empty initialization data
             .trace = {}, // Empty trace
-            .type = block_type,
+            .type = type.first,
+            .calldata_id = type.second,
         };
 
         AcirProgram program;

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/gate_count_constants.hpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/gate_count_constants.hpp
@@ -43,6 +43,11 @@ template <typename Builder> inline constexpr size_t POSEIDON2_PERMUTATION = 73 +
 template <typename Builder> inline constexpr size_t MULTI_SCALAR_MUL = 3550 + ZERO_GATE;
 template <typename Builder> inline constexpr size_t EC_ADD = 66 + ZERO_GATE + MEGA_OFFSET<Builder>;
 template <typename Builder> inline constexpr size_t BLOCK_ROM_READ = 9 + ZERO_GATE + MEGA_OFFSET<Builder>;
+template <typename Builder> inline constexpr size_t BLOCK_RAM_READ = 18 + ZERO_GATE + MEGA_OFFSET<Builder>;
+template <typename Builder> inline constexpr size_t BLOCK_RAM_WRITE = 18 + ZERO_GATE + MEGA_OFFSET<Builder>;
+template <typename Builder> inline constexpr size_t BLOCK_CALLDATA = 1 + ZERO_GATE + MEGA_OFFSET<Builder>;
+template <typename Builder> inline constexpr size_t BLOCK_RETURNDATA = 23 + ZERO_GATE + MEGA_OFFSET<Builder>;
+template <typename Builder> inline constexpr size_t ASSERT_EQUALITY = ZERO_GATE + MEGA_OFFSET<Builder>;
 
 // ========================================
 // Honk Recursion Constants

--- a/barretenberg/cpp/src/barretenberg/smt_verification/circuit/ultra_circuit.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/smt_verification/circuit/ultra_circuit.test.cpp
@@ -378,7 +378,8 @@ TEST(UltraCircuitSMT, RAMTables)
     Builder builder;
 
     size_t table_size = 3;
-    ram_table_t table(&builder, table_size);
+    std::vector<field_t> zeros(table_size, field_t(0));
+    ram_table_t table(&builder, zeros);
     for (size_t i = 0; i < table_size; ++i) {
         table.write(i, 0);
     }
@@ -420,7 +421,8 @@ TEST(UltraCircuitSMT, RAMTablesRelaxed)
     Builder builder;
 
     size_t table_size = 3;
-    ram_table_t table(&builder, table_size);
+    std::vector<field_t> zeros(table_size, field_t(0));
+    ram_table_t table(&builder, zeros);
     for (size_t i = 0; i < table_size; ++i) {
         table.write(i, 0);
     }

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/ram_table.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/ram_table.hpp
@@ -13,13 +13,13 @@ namespace bb::stdlib {
 
 // A runtime-defined read-write memory table. Table entries must be initialized in the constructor.
 // Works with UltraBuilder and MegaBuilder.
-template <typename Builder> class ram_table {
+template <IsUltraOrMegaBuilder Builder> class ram_table {
   private:
     typedef field_t<Builder> field_pt;
 
   public:
     ram_table() {}
-    ram_table(Builder* builder, const size_t table_size);
+    ram_table(Builder* builder, const std::vector<field_pt>& table_entries);
     ram_table(const std::vector<field_pt>& table_entries);
     ram_table(const ram_table& other);
     ram_table(ram_table&& other);

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/ram_table.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/ram_table.test.cpp
@@ -125,8 +125,8 @@ TYPED_TEST(RamTableTests, RamTableReadWriteConsistency)
     const size_t num_reads = 2 * table_size;
 
     std::vector<fr> table_values(table_size);
-
-    ram_table_ct table(&builder, table_size);
+    std::vector<field_ct> zeros(table_size, field_ct(0));
+    ram_table_ct table(&builder, zeros);
 
     for (size_t i = 0; i < table_size; ++i) {
         table.write(i, 0);

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/rom_table.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/rom_table.cpp
@@ -13,12 +13,42 @@ using namespace bb;
 
 namespace bb::stdlib {
 
-template <typename Builder>
+/**
+ * @brief Construct a new ROM table (read only array)
+ *
+ * @details This constructor is used in DSL, where we need to initialize a table with a builder to prevent the case in
+ * which a read operation happens before the context has been set.
+ *
+ */
+template <IsUltraOrMegaBuilder Builder>
+rom_table<Builder>::rom_table(Builder* builder, const std::vector<field_pt>& table_entries)
+    : raw_entries(table_entries)
+    , length(raw_entries.size())
+    , context(builder)
+{
+    // For consistency with the other constructor, we delegate the initialization of the table to the first read
+    // operation.
+
+    //  Initialize tags
+    _tags.resize(raw_entries.size());
+    for (size_t i = 0; i < length; ++i) {
+        _tags[i] = raw_entries[i].get_origin_tag();
+    }
+}
+
+/**
+ * @brief Construct a new ROM table (read only array)
+ *
+ * @details This constructor is used internally in barretenberg to construct tables without the need to specify the
+ * builder. It is especially useful when methods create new rom tables operating on in-circuit values which a priori we
+ * don't know whether they are constant or witnesses.
+ *
+ */
+template <IsUltraOrMegaBuilder Builder>
 rom_table<Builder>::rom_table(const std::vector<field_pt>& table_entries)
     : raw_entries(table_entries)
     , length(raw_entries.size())
 {
-    static_assert(IsUltraOrMegaBuilder<Builder>);
     // get the builder context
     for (const auto& entry : table_entries) {
         if (entry.get_context() != nullptr) {
@@ -27,7 +57,7 @@ rom_table<Builder>::rom_table(const std::vector<field_pt>& table_entries)
         }
     }
 
-    // do not initialize the table yet. The input entries might all be constant,
+    // Do not initialize the table yet. The input entries might all be constant,
     // if this is the case we might not have a valid pointer to a Builder
     // We get around this, by initializing the table when `operator[]` is called
     // with a non-const field element.
@@ -40,14 +70,14 @@ rom_table<Builder>::rom_table(const std::vector<field_pt>& table_entries)
 }
 
 /**
- * @brief initialize the table once we perform a read. This ensures we always have a valid pointer to a Builder.
+ * @brief Initialize the table once we perform a read.
  * @tparam Builder
  *
- * @note if both the table entries and the index are constant, we don't need a builder as we can directly extract the
- * desired value from `raw_entries`. in particular, we simply _don't use_ the ROM table mechanism under the hood.
+ * @note If both the table entries and the index are constant, we don't need a builder as we can directly extract the
+ * desired value from `raw_entries`. In particular, we simply _don't use_ the ROM table mechanism under the hood.
  * @note using this API, ROM tables are always fully initialized.
  */
-template <typename Builder> void rom_table<Builder>::initialize_table() const
+template <IsUltraOrMegaBuilder Builder> void rom_table<Builder>::initialize_table() const
 {
     if (initialized) {
         return;
@@ -79,12 +109,13 @@ template <typename Builder> void rom_table<Builder>::initialize_table() const
     initialized = true;
 }
 
-template <typename Builder> rom_table<Builder>::rom_table(const rom_table& other) = default;
-template <typename Builder> rom_table<Builder>::rom_table(rom_table&& other) = default;
-template <typename Builder> rom_table<Builder>& rom_table<Builder>::operator=(const rom_table& other) = default;
-template <typename Builder> rom_table<Builder>& rom_table<Builder>::operator=(rom_table&& other) = default;
+template <IsUltraOrMegaBuilder Builder> rom_table<Builder>::rom_table(const rom_table& other) = default;
+template <IsUltraOrMegaBuilder Builder> rom_table<Builder>::rom_table(rom_table&& other) = default;
+template <IsUltraOrMegaBuilder Builder>
+rom_table<Builder>& rom_table<Builder>::operator=(const rom_table& other) = default;
+template <IsUltraOrMegaBuilder Builder> rom_table<Builder>& rom_table<Builder>::operator=(rom_table&& other) = default;
 
-template <typename Builder> field_t<Builder> rom_table<Builder>::operator[](const size_t index) const
+template <IsUltraOrMegaBuilder Builder> field_t<Builder> rom_table<Builder>::operator[](const size_t index) const
 {
     if (index >= length) {
         BB_ASSERT(context != nullptr);
@@ -94,16 +125,23 @@ template <typename Builder> field_t<Builder> rom_table<Builder>::operator[](cons
     return entries[index];
 }
 
-template <typename Builder> field_t<Builder> rom_table<Builder>::operator[](const field_pt& index) const
+template <IsUltraOrMegaBuilder Builder> field_t<Builder> rom_table<Builder>::operator[](const field_pt& index) const
 {
+    if (context == nullptr) {
+        context = index.get_context();
+        BB_ASSERT_NEQ(
+            context,
+            nullptr,
+            "rom_table: Performing a read operation without providing a context. We cannot initialize the table.");
+    }
+
+    // When we perform the first read operation, we initialize the table
+    initialize_table();
+
     if (index.is_constant()) {
         return operator[](static_cast<size_t>(uint256_t(index.get_value()).data[0]));
     }
-    if (context == nullptr) {
-        context = index.get_context();
-    }
 
-    initialize_table();
     const auto native_index = uint256_t(index.get_value());
     if (native_index >= length) {
         context->failure("rom_table: ROM array access out of bounds");

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/rom_table.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/rom_table.hpp
@@ -13,13 +13,14 @@ namespace bb::stdlib {
 
 // A runtime-defined read-only memory table. Table entries must be initialized in the constructor.
 // Works with UltraBuilder and MegaBuilder.
-template <typename Builder> class rom_table {
+template <IsUltraOrMegaBuilder Builder> class rom_table {
   private:
     using field_pt = field_t<Builder>;
 
   public:
     rom_table() {};
     rom_table(const std::vector<field_pt>& table_entries);
+    rom_table(Builder* builder, const std::vector<field_pt>& table_entries);
     rom_table(const rom_table& other);
     rom_table(rom_table&& other);
 


### PR DESCRIPTION
### 🧾 Audit Context

This PR is the second in the audit thread covering `acir_to_constraint_buf` (converting bytes into Barretenberg's constraints). It refactors the handling of memory operations.

### 🛠️ Changes Made

Memory operations from Noir arrive in barretenberg in two types:
- MemoryInit, which is the initialisation operation. In this case Noir gives barretenberg a list of witnesses indices with which to initialise the table
- MemoryOp, which can be either a read or write operation. At the moment Noir passes us witnesses. However, in the future it might be possible that Noir passes us witnesses or constants.

Before this PR, the data contained in the memory opcodes was being treated as a `poly_triple`. In this PR, we restructure the relevant memory-related structure to hold:
- witness indices for MemoryInit operations
- WitnessOrConstant for MemoryOp operations
The rationale is that this better reflects the information passed to us by Noir, and it also simplifies the code.

There is no change in circuits. However, note that after this PR Noir can send us constants to read from. This was not supported before because of an assertion in the code. The assertion clearly stated that the only reason why we had it was that Noir is supposed to optimise those reads away, so I removed it given the conversation that pre-dated this PR.

Other changes:
- Introduction of a constructor for ROM/RAM tables that takes in a builder. This allows reading from a constant index before reading from a witness index (the table is initialised at the first read, and at the point of initialisation it needs a builder)
- Fail if calldata/returndata appers in an UltraBuilder (disable respective acir_tests)
- Extend test suite for block constraints to also test for constant read/writes
- Extend test suite for block constraints to also test CallData and ReturnData

### ✅ Checklist

- [ ] Audited all methods of the relevant module/class
- [ ] Audited the interface of the module/class with other (relevant) components
- [ ] Documented existing functionality and any changes made (as per Doxygen requirements)
- [ ] Resolved and/or closed all issues/TODOs pertaining to the audited files
- [ ] Confirmed and documented any security or other issues found (if applicable)
- [ ] Verified that tests cover all critical paths (and added tests if necessary)
- [ ] Updated audit tracking for the files audited (check the start of each file you audited)

### 📌 Notes for Reviewers
