### PR TITLE
chore: remove --funding-account option until it's implemented

### DIFF
--- a/yarn-project/cli/src/cmds/validator_keys/add.ts
+++ b/yarn-project/cli/src/cmds/validator_keys/add.ts
@@ -42,7 +42,6 @@ export async function addValidatorKeys(existing: string, options: AddValidatorKe
     json,
     feeRecipient: feeRecipientOpt,
     coinbase: coinbaseOpt,
-    fundingAccount: fundingAccountOpt,
     remoteSigner: remoteSignerOpt,
     password,
     encryptedKeystoreDir,
@@ -63,8 +62,6 @@ export async function addValidatorKeys(existing: string, options: AddValidatorKe
     throw new Error('feeRecipient is required (either present in existing file or via --fee-recipient)');
   }
   const coinbase = (coinbaseOpt as EthAddress | undefined) ?? (first.coinbase as EthAddress | undefined);
-  const fundingAccount =
-    (fundingAccountOpt as EthAddress | undefined) ?? (first.fundingAccount as EthAddress | undefined);
   const derivedRemoteSigner = (first.attester as any)?.remoteSignerUrl || (first.attester as any)?.eth?.remoteSignerUrl;
   const remoteSigner = remoteSignerOpt ?? derivedRemoteSigner;
 
@@ -87,7 +84,6 @@ export async function addValidatorKeys(existing: string, options: AddValidatorKe
     feeRecipient,
     coinbase,
     remoteSigner,
-    fundingAccount,
   });
 
   keystore.validators.push(...validators);

--- a/yarn-project/cli/src/cmds/validator_keys/index.ts
+++ b/yarn-project/cli/src/cmds/validator_keys/index.ts
@@ -33,7 +33,8 @@ export function injectCommands(program: Command, log: LogFn) {
       'Coinbase ETH address to use when proposing. Defaults to attester address.',
       parseEthereumAddress,
     )
-    .option('--funding-account <address>', 'ETH account to fund publishers', parseEthereumAddress)
+    // TODO: add funding account back in when implemented
+    // .option('--funding-account <privateKey|address>', 'ETH private key (or address for remote signer setup) to fund publishers')
     .option('--remote-signer <url>', 'Default remote signer URL for accounts in this file')
     .option('--ikm <hex>', 'Initial keying material for BLS (alternative to mnemonic)', value => parseHex(value, 32))
     .option('--bls-path <path>', `EIP-2334 path (default ${defaultBlsPath})`)
@@ -84,7 +85,8 @@ export function injectCommands(program: Command, log: LogFn) {
       'Coinbase ETH address to use when proposing. Defaults to attester address.',
       parseEthereumAddress,
     )
-    .option('--funding-account <address>', 'ETH account to fund publishers', parseEthereumAddress)
+    // TODO: add funding account back in when implemented
+    // .option('--funding-account <privateKey|address>', 'ETH private key (or address for remote signer setup) to fund publishers')
     .option('--remote-signer <url>', 'Default remote signer URL for accounts in this file')
     .option('--ikm <hex>', 'Initial keying material for BLS (alternative to mnemonic)', value => parseHex(value, 32))
     .option('--bls-path <path>', `EIP-2334 path (default ${defaultBlsPath})`)

--- a/yarn-project/cli/src/cmds/validator_keys/new.ts
+++ b/yarn-project/cli/src/cmds/validator_keys/new.ts
@@ -46,7 +46,6 @@ export type NewValidatorKeystoreOptions = {
   feeRecipient: AztecAddress;
   coinbase?: EthAddress;
   remoteSigner?: string;
-  fundingAccount?: EthAddress;
   stakerOutput?: boolean;
   gseAddress?: EthAddress;
   l1RpcUrls?: string[];
@@ -75,7 +74,6 @@ export async function newValidatorKeystore(options: NewValidatorKeystoreOptions,
     addressIndex = 0,
     feeRecipient,
     remoteSigner,
-    fundingAccount,
     blsPath,
     ikm,
     mnemonic: _mnemonic,
@@ -113,7 +111,6 @@ export async function newValidatorKeystore(options: NewValidatorKeystoreOptions,
     feeRecipient,
     coinbase,
     remoteSigner,
-    fundingAccount,
   });
 
   // If password provided, write ETH JSON V3 and BLS BN254 keystores and replace plaintext

--- a/yarn-project/cli/src/cmds/validator_keys/shared.ts
+++ b/yarn-project/cli/src/cmds/validator_keys/shared.ts
@@ -29,7 +29,6 @@ export type BuildValidatorsInput = {
   feeRecipient: AztecAddress;
   coinbase?: EthAddress;
   remoteSigner?: string;
-  fundingAccount?: EthAddress;
 };
 
 export function withValidatorIndex(path: string, accountIndex: number = 0, addressIndex: number = 0) {
@@ -89,7 +88,6 @@ export async function buildValidatorEntries(input: BuildValidatorsInput) {
     feeRecipient,
     coinbase,
     remoteSigner,
-    fundingAccount,
   } = input;
 
   const summaries: ValidatorSummary[] = [];
@@ -143,7 +141,6 @@ export async function buildValidatorEntries(input: BuildValidatorsInput) {
         ...(publisherField !== undefined ? { publisher: publisherField } : {}),
         feeRecipient,
         coinbase: coinbase ?? attesterEthAddress,
-        fundingAccount,
       } as ValidatorKeyStore;
     }),
   );
@@ -323,11 +320,6 @@ export async function writeEthJsonV3ToFile(
       } else if (pub !== undefined) {
         (v as any).publisher = await maybeEncryptEth(pub, `publisher_${i + 1}`);
       }
-    }
-
-    // Optional fundingAccount within validator
-    if ('fundingAccount' in v) {
-      (v as any).fundingAccount = await maybeEncryptEth((v as any).fundingAccount, `funding_${i + 1}`);
     }
   }
 }


### PR DESCRIPTION
some users are confused by the `--funding-account` option which currently populates the `fundingAccount` field in the keystore which does nothing.
Removing until funding account functionality is implemented

Tracked at [A-16](https://linear.app/aztec-labs/issue/A-16/multi-eoa-add-account-funding-to-multi-eoa-pulishers)