### PR TITLE
fix: address dust + only sstore if non-zero change

### DIFF
--- a/l1-contracts/src/core/libraries/rollup/RewardLib.sol
+++ b/l1-contracts/src/core/libraries/rollup/RewardLib.sol
@@ -206,7 +206,11 @@ library RewardLib {
         uint256 sequenceCheckpointRewards = BpsLib.mul(checkpointRewardsAvailable, rewardStorage.config.sequencerBps);
         v.sequencerCheckpointReward = sequenceCheckpointRewards / added;
 
-        $er.rewards += (checkpointRewardsAvailable - sequenceCheckpointRewards).toUint128();
+        uint256 dust = sequenceCheckpointRewards - (v.sequencerCheckpointReward * added);
+        uint256 proverCheckpointRewards = checkpointRewardsAvailable - sequenceCheckpointRewards + dust;
+        if (proverCheckpointRewards > 0) {
+          $er.rewards += proverCheckpointRewards.toUint128();
+        }
       }
 
       bool isTxsEnabled = FeeLib.isTxsEnabled();
@@ -235,7 +239,10 @@ library RewardLib {
 
         {
           v.sequencer = fieldToAddress(_args.fees[i * 2]);
-          rewardStorage.sequencerRewards[v.sequencer] += (v.sequencerCheckpointReward + v.sequencerFee);
+          uint256 toSequencer = v.sequencerCheckpointReward + v.sequencerFee;
+          if (toSequencer > 0) {
+            rewardStorage.sequencerRewards[v.sequencer] += toSequencer;
+          }
         }
       }
 

--- a/l1-contracts/test/rollup/libraries/rewardlib/RewardLibBase.sol
+++ b/l1-contracts/test/rollup/libraries/rewardlib/RewardLibBase.sol
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024 Aztec Labs.
+pragma solidity >=0.8.27;
+
+import {TestBase} from "@test/base/Base.sol";
+import {RewardLibWrapper, FakeFeePortal} from "./RewardLibWrapper.sol";
+import {IERC20} from "@oz/token/ERC20/IERC20.sol";
+import {TestERC20} from "@aztec/mock/TestERC20.sol";
+import {SubmitEpochRootProofArgs, PublicInputArgs} from "@aztec/core/interfaces/IRollup.sol";
+import {Epoch} from "@aztec/core/libraries/TimeLib.sol";
+import {Errors} from "@aztec/core/libraries/Errors.sol";
+import {Math} from "@oz/utils/math/Math.sol";
+
+contract RewardLibBase is TestBase {
+  uint96 internal checkpointReward;
+  uint32 internal sequencerBps;
+  FakeFeePortal internal feePortal;
+  RewardLibWrapper internal wrapper;
+  IERC20 internal feeAsset;
+
+  address internal prover = makeAddr("prover");
+  address internal sequencer = makeAddr("sequencer");
+
+  SubmitEpochRootProofArgs internal args;
+
+  modifier prepare(uint96 _checkpointReward, uint32 _sequencerBps) {
+    checkpointReward = uint96(_bound(_checkpointReward, 0, 10_000e18));
+    sequencerBps = uint32(_bound(_sequencerBps, 0, 10_000));
+    feeAsset = IERC20(address(new TestERC20("test", "TEST", address(this))));
+    wrapper = new RewardLibWrapper(feeAsset, checkpointReward, sequencerBps);
+    feePortal = wrapper.feePortal();
+
+    deal(address(feeAsset), address(wrapper.rewardDistributor()), checkpointReward * 300);
+    deal(address(feeAsset), address(wrapper.feePortal()), checkpointReward * 100);
+
+    args.fees = _fees(1, sequencer);
+
+    args.args.proverId = prover;
+
+    _;
+  }
+
+  function _fees(uint256 _count, address _sequencer) internal pure returns (bytes32[] memory) {
+    return _fees(_count, _sequencer, 0);
+  }
+
+  function _fees(uint256 _count, address _sequencer, uint256 _amount) internal pure returns (bytes32[] memory) {
+    bytes32[] memory fees = new bytes32[](_count * 2);
+    for (uint256 i = 0; i < _count; i++) {
+      fees[i * 2] = bytes32(uint256(uint160(bytes20(_sequencer))));
+      fees[i * 2 + 1] = bytes32(uint256(_amount));
+    }
+    return fees;
+  }
+}

--- a/l1-contracts/test/rollup/libraries/rewardlib/RewardLibWrapper.sol
+++ b/l1-contracts/test/rollup/libraries/rewardlib/RewardLibWrapper.sol
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024 Aztec Labs.
+pragma solidity >=0.8.27;
+
+import {RewardLib, RewardConfig, RewardStorage} from "@aztec/core/libraries/rollup/RewardLib.sol";
+import {Timestamp, Slot, Epoch} from "@aztec/core/libraries/TimeLib.sol";
+import {RewardBooster, IBoosterCore, RewardBoostConfig} from "@aztec/core/reward-boost/RewardBooster.sol";
+import {IValidatorSelection} from "@aztec/core/interfaces/IValidatorSelection.sol";
+import {Bps} from "@aztec/core/libraries/rollup/RewardLib.sol";
+import {SubmitEpochRootProofArgs} from "@aztec/core/interfaces/IRollup.sol";
+import {STFLib, RollupStore} from "@aztec/core/libraries/rollup/STFLib.sol";
+import {IERC20} from "@oz/token/ERC20/IERC20.sol";
+import {IRewardDistributor} from "@aztec/governance/interfaces/IRewardDistributor.sol";
+
+import {TempCheckpointLog} from "@aztec/core/libraries/compressed-data/CheckpointLog.sol";
+import {FeeHeader} from "@aztec/core/libraries/compressed-data/fees/FeeStructs.sol";
+import {CompressedChainTips, ChainTipsLib} from "@aztec/core/libraries/compressed-data/Tips.sol";
+import {FeeLib} from "@aztec/core/libraries/rollup/FeeLib.sol";
+import {TimeLib} from "@aztec/core/libraries/TimeLib.sol";
+import {TestConstants} from "@test/harnesses/TestConstants.sol";
+import {IFeeJuicePortal} from "@aztec/core/interfaces/IFeeJuicePortal.sol";
+
+contract FakeFeePortal {
+  IERC20 public feeAsset;
+
+  constructor(IERC20 _feeAsset) {
+    feeAsset = _feeAsset;
+  }
+
+  function distributeFees(address _to, uint256 _amount) external {
+    feeAsset.transfer(_to, _amount);
+  }
+}
+
+contract FakeRewardDistributor {
+  address public canonicalRollup;
+  IERC20 public feeAsset;
+
+  constructor(IERC20 _feeAsset) {
+    canonicalRollup = msg.sender;
+    feeAsset = _feeAsset;
+  }
+
+  function claim(address _to, uint256 _amount) external {
+    feeAsset.transfer(_to, _amount);
+  }
+
+  function nuke() external {
+    canonicalRollup = address(0);
+  }
+}
+
+contract RewardLibWrapper {
+  using ChainTipsLib for CompressedChainTips;
+
+  RewardBooster internal booster;
+  Epoch internal currentEpoch;
+  FakeRewardDistributor public rewardDistributor;
+  FakeFeePortal public feePortal;
+
+  constructor(IERC20 _feeAsset, uint96 _checkpointReward, uint32 _sequencerBps) {
+    booster = new RewardBooster(
+      IValidatorSelection(address(this)),
+      RewardBoostConfig({increment: 125_000, maxScore: 15_000_000, a: 1000, minimum: 100_000, k: 1_000_000})
+    );
+
+    rewardDistributor = new FakeRewardDistributor(_feeAsset);
+    feePortal = new FakeFeePortal(_feeAsset);
+    RewardConfig memory config = RewardConfig({
+      rewardDistributor: IRewardDistributor(address(rewardDistributor)),
+      sequencerBps: Bps.wrap(_sequencerBps),
+      booster: IBoosterCore(address(booster)),
+      checkpointReward: _checkpointReward
+    });
+
+    RewardLib.setConfig(config);
+
+    RollupStore storage rollupStore = STFLib.getStorage();
+    rollupStore.config.feeAsset = _feeAsset;
+    rollupStore.config.feeAssetPortal = IFeeJuicePortal(address(feePortal));
+
+    TimeLib.initialize(
+      block.timestamp,
+      TestConstants.AZTEC_SLOT_DURATION,
+      TestConstants.AZTEC_EPOCH_DURATION,
+      TestConstants.AZTEC_PROOF_SUBMISSION_EPOCHS
+    );
+  }
+
+  function updateManaTarget(uint256 _manaLimit) external {
+    FeeLib.updateManaTarget(_manaLimit);
+  }
+
+  function nukeRewardDistributor() external {
+    FakeRewardDistributor(address(RewardLib.getStorage().config.rewardDistributor)).nuke();
+  }
+
+  function addFeeHeader(FeeHeader memory _feeHeader) external {
+    // Increase the pending checkpoint number.
+    RollupStore storage rollupStore = STFLib.getStorage();
+    CompressedChainTips tips = rollupStore.tips;
+    rollupStore.tips = tips.updatePending(tips.getPending() + 1);
+    STFLib.addTempCheckpointLog(
+      TempCheckpointLog({
+        headerHash: bytes32(0),
+        blobCommitmentsHash: bytes32(0),
+        attestationsHash: bytes32(0),
+        payloadDigest: bytes32(0),
+        slotNumber: Slot.wrap(0),
+        feeHeader: _feeHeader
+      })
+    );
+  }
+
+  function setCurrentEpoch(Epoch _epoch) external {
+    currentEpoch = _epoch;
+  }
+
+  function handleRewardsAndFees(SubmitEpochRootProofArgs memory _args, Epoch _endEpoch) external {
+    RewardLib.handleRewardsAndFees(_args, _endEpoch);
+  }
+
+  function getSequencerRewards(address _sequencer) external view returns (uint256) {
+    return RewardLib.getSequencerRewards(_sequencer);
+  }
+
+  function getCollectiveProverRewardsForEpoch(Epoch _epoch) external view returns (uint256) {
+    return RewardLib.getCollectiveProverRewardsForEpoch(_epoch);
+  }
+
+  function getHasSubmitted(Epoch _epoch, uint256 _length, address _prover) external view returns (bool) {
+    return RewardLib.getHasSubmitted(_epoch, _length, _prover);
+  }
+
+  function getCurrentEpoch() external view returns (Epoch) {
+    return currentEpoch;
+  }
+
+  function getLongestProvenLength(Epoch _epoch) external view returns (uint256) {
+    return RewardLib.getStorage().epochRewards[_epoch].longestProvenLength;
+  }
+
+  function getProverShares(Epoch _epoch, uint256 _length, address _prover) external view returns (uint256) {
+    return RewardLib.getStorage().epochRewards[_epoch].subEpoch[_length].shares[_prover];
+  }
+
+  function getSummedShares(Epoch _epoch, uint256 _length) external view returns (uint256) {
+    return RewardLib.getStorage().epochRewards[_epoch].subEpoch[_length].summedShares;
+  }
+}

--- a/l1-contracts/test/rollup/libraries/rewardlib/handleRewards.t.sol
+++ b/l1-contracts/test/rollup/libraries/rewardlib/handleRewards.t.sol
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024 Aztec Labs.
+pragma solidity >=0.8.27;
+
+import {RewardLibBase} from "./RewardLibBase.sol";
+import {RewardLibWrapper, FakeFeePortal} from "./RewardLibWrapper.sol";
+import {IERC20} from "@oz/token/ERC20/IERC20.sol";
+import {TestERC20} from "@aztec/mock/TestERC20.sol";
+import {SubmitEpochRootProofArgs, PublicInputArgs} from "@aztec/core/interfaces/IRollup.sol";
+import {Epoch} from "@aztec/core/libraries/TimeLib.sol";
+import {Errors} from "@aztec/core/libraries/Errors.sol";
+import {Math} from "@oz/utils/math/Math.sol";
+
+contract HandleRewardsTest is RewardLibBase {
+  function test_GivenProverHasAlreadySubmitted() external prepare(400e18, 7000) {
+    // it reverts with {Rollup__ProverHaveAlreadySubmitted}
+    wrapper.handleRewardsAndFees(args, Epoch.wrap(0));
+
+    vm.expectRevert(abi.encodeWithSelector(Errors.Rollup__ProverHaveAlreadySubmitted.selector, prover, Epoch.wrap(0)));
+    wrapper.handleRewardsAndFees(args, Epoch.wrap(0));
+  }
+
+  modifier givenProverHasNotSubmitted() {
+    _;
+  }
+
+  function test_WhenLengthLELongestProven() external prepare(400e18, 7000) givenProverHasNotSubmitted {
+    // it store the prover shares
+    // it store summed shares
+
+    wrapper.handleRewardsAndFees(args, Epoch.wrap(0));
+
+    args.args.proverId = makeAddr("prover2");
+
+    assertFalse(wrapper.getHasSubmitted(Epoch.wrap(0), 1, args.args.proverId));
+
+    vm.record();
+    wrapper.handleRewardsAndFees(args, Epoch.wrap(0));
+
+    (, bytes32[] memory writes) = vm.accesses(address(wrapper));
+
+    assertEq(writes.length, 2);
+    assertGt(wrapper.getProverShares(Epoch.wrap(0), 1, args.args.proverId), 0);
+    assertGt(wrapper.getSummedShares(Epoch.wrap(0), 1), 0);
+  }
+
+  modifier whenLengthGTLongestProven() {
+    _;
+  }
+
+  function test_GivenCallerNEQCanonicalRollup()
+    external
+    prepare(400e18, 7000)
+    givenProverHasNotSubmitted
+    whenLengthGTLongestProven
+  {
+    // it store the prover shares
+    // it store summed shares
+    // it store longestProvenLength
+
+    wrapper.handleRewardsAndFees(args, Epoch.wrap(0));
+    assertEq(wrapper.getLongestProvenLength(Epoch.wrap(0)), 1);
+
+    wrapper.nukeRewardDistributor();
+
+    args.args.proverId = makeAddr("prover2");
+    args.end = args.start + 1;
+    args.fees = _fees(2, sequencer);
+
+    vm.record();
+    wrapper.handleRewardsAndFees(args, Epoch.wrap(0));
+    (, bytes32[] memory writes) = vm.accesses(address(wrapper));
+
+    assertEq(writes.length, 3);
+    assertGt(wrapper.getProverShares(Epoch.wrap(0), 2, args.args.proverId), 0);
+    assertGt(wrapper.getSummedShares(Epoch.wrap(0), 2), 0);
+    assertEq(wrapper.getLongestProvenLength(Epoch.wrap(0)), 2);
+  }
+
+  function test_GivenCallerEQCanonicalRollup(uint96 _checkpointReward, uint32 _sequencerBps)
+    external
+    prepare(_checkpointReward, _sequencerBps)
+    givenProverHasNotSubmitted
+    whenLengthGTLongestProven
+  {
+    // it store the prover shares
+    // it store summed shares
+    // it store updated prover rewards
+    // it store updated sequencer reward balance
+    // it store longestProvenLength
+
+    wrapper.handleRewardsAndFees(args, Epoch.wrap(0));
+    assertEq(wrapper.getLongestProvenLength(Epoch.wrap(0)), 1);
+
+    uint256 checkpointCount = 32;
+
+    args.args.proverId = makeAddr("prover2");
+    args.end = args.start + checkpointCount - 1;
+    args.fees = _fees(checkpointCount, sequencer);
+
+    uint256 initialSequencerRewards = wrapper.getSequencerRewards(sequencer);
+    uint256 initialProverRewards = wrapper.getCollectiveProverRewardsForEpoch(Epoch.wrap(0));
+
+    uint256 totalRewards =
+      Math.min(checkpointReward * (checkpointCount - 1), feeAsset.balanceOf(address(wrapper.rewardDistributor())));
+
+    vm.record();
+    wrapper.handleRewardsAndFees(args, Epoch.wrap(0));
+    (, bytes32[] memory writes) = vm.accesses(address(wrapper));
+
+    uint256 sequencerRewards = totalRewards * sequencerBps / 10_000;
+    uint256 sequencerRewardsPerBlock = sequencerRewards / (checkpointCount - 1);
+    uint256 proverRewards = totalRewards - sequencerRewards; // no dust
+    uint256 dust = sequencerRewards - (sequencerRewardsPerBlock * (checkpointCount - 1));
+
+    uint256 size = 3;
+
+    if (sequencerRewardsPerBlock > 0) {
+      size += (checkpointCount - 1); // the first was already updated, this is 30 repeat writes for 100 gas each.
+    }
+
+    if (proverRewards > 0) {
+      size += 1;
+    }
+
+    assertEq(writes.length, size, "writes.length");
+    assertGt(wrapper.getProverShares(Epoch.wrap(0), checkpointCount, args.args.proverId), 0, "prover shares");
+    assertGt(wrapper.getSummedShares(Epoch.wrap(0), checkpointCount), 0, "summed shares");
+    assertEq(wrapper.getLongestProvenLength(Epoch.wrap(0)), checkpointCount, "longest proven length");
+
+    assertEq(
+      wrapper.getSequencerRewards(sequencer),
+      initialSequencerRewards + sequencerRewardsPerBlock * (checkpointCount - 1),
+      "sequencer rewards"
+    );
+    assertEq(
+      wrapper.getCollectiveProverRewardsForEpoch(Epoch.wrap(0)),
+      initialProverRewards + proverRewards + dust,
+      "prover rewards"
+    );
+  }
+}

--- a/l1-contracts/test/rollup/libraries/rewardlib/handleRewards.tree
+++ b/l1-contracts/test/rollup/libraries/rewardlib/handleRewards.tree
@@ -1,0 +1,18 @@
+HandleRewards
+├── given prover has already submitted
+│   └── it reverts with {Rollup__ProverHaveAlreadySubmitted}
+└── given prover has not submitted
+    ├── when length LE longest proven
+    │   ├── it store the prover shares
+    │   └── it store summed shares
+    └── when length GT longest proven
+        ├── given caller NEQ canonical rollup
+        │   ├── it store the prover shares
+        │   ├── it store summed shares
+        │   └── it store longestProvenLength
+        └── given caller EQ canonical rollup
+            ├── it store the prover shares
+            ├── it store summed shares
+            ├── it store updated prover rewards
+            ├── it store updated sequencer reward balance
+            └── it store longestProvenLength


### PR DESCRIPTION
Updates the rewardlib to give dust to the provers + only update reward storage when non-zero changes.