### PR TITLE
docs(bb): fix output path in Solidity verifier example

### DIFF
--- a/barretenberg/docs/docs/how_to_guides/how-to-solidity-verifier.md
+++ b/barretenberg/docs/docs/how_to_guides/how-to-solidity-verifier.md
@@ -41,7 +41,7 @@ Generating a Solidity Verifier with Barretenberg contract is actually a one-comm
 bb write_vk -b ./target/<noir_artifact_name>.json -o ./target --oracle_hash keccak
 
 # Generate the Solidity verifier from the vkey
-bb write_solidity_verifier -k ./target/vk -o ../target/Verifier.sol
+bb write_solidity_verifier -k ./target/vk -o ./target/Verifier.sol
 ```
 
 replacing `<noir_artifact_name>` with the name of your Noir project. A `Verifier.sol` contract is now in the target folder and can be deployed to any EVM blockchain acting as a verifier smart contract.

--- a/barretenberg/docs/versioned_docs/version-v0.87.0/how_to_guides/how-to-solidity-verifier.md
+++ b/barretenberg/docs/versioned_docs/version-v0.87.0/how_to_guides/how-to-solidity-verifier.md
@@ -41,7 +41,7 @@ Generating a Solidity Verifier with Barretenberg contract is actually a one-comm
 bb write_vk -b ./target/<noir_artifact_name>.json -o ./target --oracle_hash keccak
 
 # Generate the Solidity verifier from the vkey
-bb write_solidity_verifier -k ./target/vk -o ../target/Verifier.sol
+bb write_solidity_verifier -k ./target/vk -o ./target/Verifier.sol
 ```
 
 replacing `<noir_artifact_name>` with the name of your Noir project. A `Verifier.sol` contract is now in the target folder and can be deployed to any EVM blockchain acting as a verifier smart contract.

--- a/barretenberg/docs/versioned_docs/version-v3.0.0-nightly.20251121/how_to_guides/how-to-solidity-verifier.md
+++ b/barretenberg/docs/versioned_docs/version-v3.0.0-nightly.20251121/how_to_guides/how-to-solidity-verifier.md
@@ -41,7 +41,7 @@ Generating a Solidity Verifier with Barretenberg contract is actually a one-comm
 bb write_vk -b ./target/<noir_artifact_name>.json -o ./target --oracle_hash keccak
 
 # Generate the Solidity verifier from the vkey
-bb write_solidity_verifier -k ./target/vk -o ../target/Verifier.sol
+bb write_solidity_verifier -k ./target/vk -o ./target/Verifier.sol
 ```
 
 replacing `<noir_artifact_name>` with the name of your Noir project. A `Verifier.sol` contract is now in the target folder and can be deployed to any EVM blockchain acting as a verifier smart contract.


### PR DESCRIPTION
Corrected the output path for `write_solidity_verifier` from `../target/Verifier.sol` to `./target/Verifier.sol` to match the working directory context established by the previous command.