### PR TITLE
chore: revert serialization workaround

### DIFF
--- a/noir-projects/noir-protocol-circuits/crates/types/src/type_serialization.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/type_serialization.nr
@@ -239,9 +239,8 @@ where
         let mut result: [Field; _] = std::mem::zeroed();
         for i in 0..M {
             let serialized_t = self[i].serialize();
-            let T_N = serialized_t.len();
-            for j in 0..T_N {
-                result[i * T_N + j] = serialized_t[j];
+            for j in 0..<T as Serialize>::N {
+                result[i * <T as Serialize>::N + j] = serialized_t[j];
             }
         }
         result


### PR DESCRIPTION
Closes: https://linear.app/aztec-labs/issue/F-155/recover-serialize-impl-with-associated-constants

As this is fixed by noir