### PR TITLE
fix: peer penalization when processing duplicates with different signatures

### DIFF
--- a/yarn-project/p2p/src/mem_pools/attestation_pool/attestation_pool.ts
+++ b/yarn-project/p2p/src/mem_pools/attestation_pool/attestation_pool.ts
@@ -94,6 +94,15 @@ export interface AttestationPool {
   getAttestationsForSlotAndProposal(slot: bigint, proposalId: string): Promise<BlockAttestation[]>;
 
   /**
+   * Get existing Attestation for slot, proposal and sender
+   *
+   * @param slot - The slot to query
+   * @param proposalId - The proposal to query
+   * @param sender - The sender to query
+   */
+  getAttestation(slot: bigint, proposalId: string, sender: string): Promise<BlockAttestation | undefined>;
+
+  /**
    * Check if a specific attestation exists in the pool
    *
    * @param attestation - The attestation to check

--- a/yarn-project/p2p/src/mem_pools/attestation_pool/attestation_pool_test_suite.ts
+++ b/yarn-project/p2p/src/mem_pools/attestation_pool/attestation_pool_test_suite.ts
@@ -134,6 +134,54 @@ export function describeAttestationPool(getAttestationPool: () => AttestationPoo
     expect(await ap.getAttestationsForSlotAndProposal(BigInt(slotNumber), archive.toString())).toHaveLength(1);
   });
 
+  it('should retrieve a specific attestation by slot, proposalId, and sender', async () => {
+    const slotNumber = 420;
+    const archive = Fr.random();
+    const attestations = signers.map(signer => mockAttestation(signer, slotNumber, archive));
+
+    await ap.addAttestations(attestations);
+
+    // Retrieve each attestation individually by sender
+    for (const attestation of attestations) {
+      const sender = attestation.getSender()!.toString();
+      const retrieved = await ap.getAttestation(BigInt(slotNumber), archive.toString(), sender);
+
+      expect(retrieved).toBeDefined();
+      expect(retrieved!.toBuffer()).toEqual(attestation.toBuffer());
+      expect(retrieved!.getSender()?.toString()).toEqual(sender);
+    }
+  });
+
+  it('should return undefined when getting non-existent attestation', async () => {
+    const slotNumber = 420;
+    const archive = Fr.random();
+    const nonExistentSender = '0x1234567890123456789012345678901234567890';
+
+    const retrieved = await ap.getAttestation(BigInt(slotNumber), archive.toString(), nonExistentSender);
+
+    expect(retrieved).toBeUndefined();
+  });
+
+  it('should return undefined for attestation after it is deleted', async () => {
+    const slotNumber = 420;
+    const archive = Fr.random();
+    const attestation = mockAttestation(signers[0], slotNumber, archive);
+    const sender = attestation.getSender()!.toString();
+
+    await ap.addAttestations([attestation]);
+
+    // Verify it exists
+    let retrieved = await ap.getAttestation(BigInt(slotNumber), archive.toString(), sender);
+    expect(retrieved).toBeDefined();
+
+    // Delete the attestation
+    await ap.deleteAttestations([attestation]);
+
+    // Should now return undefined
+    retrieved = await ap.getAttestation(BigInt(slotNumber), archive.toString(), sender);
+    expect(retrieved).toBeUndefined();
+  });
+
   it('should store attestations by differing slot', async () => {
     const slotNumbers = [1, 2, 3, 4];
     const attestations = signers.map((signer, i) => mockAttestation(signer, slotNumbers[i]));

--- a/yarn-project/p2p/src/mem_pools/attestation_pool/kv_attestation_pool.ts
+++ b/yarn-project/p2p/src/mem_pools/attestation_pool/kv_attestation_pool.ts
@@ -136,6 +136,15 @@ export class KvAttestationPool implements AttestationPool {
     return attestations;
   }
 
+  public async getAttestation(slot: bigint, proposalId: string, sender: string): Promise<BlockAttestation | undefined> {
+    const buffer = await this.attestations.getAsync(this.getAttestationKey(slot, proposalId, sender));
+    if (buffer) {
+      return BlockAttestation.fromBuffer(buffer);
+    }
+
+    return Promise.resolve(undefined);
+  }
+
   public async deleteAttestationsOlderThan(oldestSlot: bigint): Promise<void> {
     const olderThan = await toArray(this.proposalsForSlot.keysAsync({ end: new Fr(oldestSlot).toString() }));
     for (const oldSlot of olderThan) {

--- a/yarn-project/p2p/src/mem_pools/attestation_pool/memory_attestation_pool.ts
+++ b/yarn-project/p2p/src/mem_pools/attestation_pool/memory_attestation_pool.ts
@@ -50,6 +50,17 @@ export class InMemoryAttestationPool implements AttestationPool {
     return Promise.resolve([]);
   }
 
+  public getAttestation(slot: bigint, proposalId: string, sender: string): Promise<BlockAttestation | undefined> {
+    const slotAttestationMap = this.attestations.get(slot);
+    if (slotAttestationMap) {
+      const proposalAttestationMap = slotAttestationMap.get(proposalId);
+      if (proposalAttestationMap) {
+        return Promise.resolve(proposalAttestationMap.get(sender));
+      }
+    }
+    return Promise.resolve(undefined);
+  }
+
   public addAttestations(attestations: BlockAttestation[]): Promise<void> {
     for (const attestation of attestations) {
       // Perf: order and group by slot before insertion

--- a/yarn-project/p2p/src/services/libp2p/libp2p_service.test.ts
+++ b/yarn-project/p2p/src/services/libp2p/libp2p_service.test.ts
@@ -1,9 +1,19 @@
+import { Secp256k1Signer } from '@aztec/foundation/crypto';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { Fr } from '@aztec/foundation/fields';
 import { createLogger } from '@aztec/foundation/log';
 import { L2Block } from '@aztec/stdlib/block';
-import { PeerErrorSeverity } from '@aztec/stdlib/p2p';
+import {
+  BlockAttestation,
+  BlockProposal,
+  ConsensusPayload,
+  PeerErrorSeverity,
+  SignatureDomainSeparator,
+  getHashedSignaturePayloadEthSignedMessage,
+} from '@aztec/stdlib/p2p';
+import { makeL2BlockHeader } from '@aztec/stdlib/testing';
 import type { TxValidator } from '@aztec/stdlib/tx';
+import { TxHash } from '@aztec/stdlib/tx';
 import { getTelemetryClient } from '@aztec/telemetry-client';
 
 import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
@@ -11,6 +21,7 @@ import type { Message, PeerId } from '@libp2p/interface';
 import { TopicValidatorResult } from '@libp2p/interface';
 import { type MockProxy, mock } from 'jest-mock-extended';
 
+import type { AttestationPool } from '../../mem_pools/attestation_pool/attestation_pool.js';
 import type { PeerManagerInterface } from '../peer-manager/interface.js';
 import { BitVector } from '../reqresp/protocols/block_txs/bitvector.js';
 import type { BlockTxsRequest, BlockTxsResponse } from '../reqresp/protocols/block_txs/block_txs_reqresp.js';
@@ -403,6 +414,182 @@ describe('LibP2PService', () => {
 
       const ok = await service.validateRequestedBlockTxs(request, response, peerId);
       expect(ok).toBe(false);
+      expect(peerManager.penalizePeer).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('processAttestationFromPeer - duplicate signature detection', () => {
+    let service: any;
+    let peerManager: MockProxy<PeerManagerInterface>;
+    let attestationPool: MockProxy<AttestationPool>;
+    let peerId: PeerId;
+    let mockEpochCache: any;
+
+    beforeEach(() => {
+      peerManager = mock<PeerManagerInterface>();
+      attestationPool = mock<AttestationPool>();
+      peerId = mock<PeerId>({
+        toString: () => 'peer-id',
+      });
+
+      mockEpochCache = {
+        getCommittee: jest.fn(() => Promise.resolve({ committee: [EthAddress.random(), EthAddress.random()] })),
+      };
+
+      service = Object.create(LibP2PService.prototype);
+      service.peerManager = peerManager;
+      service.mempools = { attestationPool };
+      service.logger = createLogger('p2p:test');
+      service.tracer = getTelemetryClient().getTracer('p2p:test');
+      service.epochCache = mockEpochCache;
+      service.validateAttestation = jest.fn(() => Promise.resolve(true));
+      service.validateReceivedMessage = jest.fn(async (validationFunc: any) => {
+        const result = await validationFunc();
+        return result;
+      });
+    });
+
+    function createAttestation(signer: Secp256k1Signer, slotNumber: number, archive: Fr): BlockAttestation {
+      const header = makeL2BlockHeader(1, 2, slotNumber);
+      const payload = new ConsensusPayload(header.toCheckpointHeader(), archive, header.state);
+      const attestationHash = getHashedSignaturePayloadEthSignedMessage(
+        payload,
+        SignatureDomainSeparator.blockAttestation,
+      );
+      const attestationSignature = signer.sign(attestationHash);
+      const proposalHash = getHashedSignaturePayloadEthSignedMessage(payload, SignatureDomainSeparator.blockProposal);
+      const proposerSignature = signer.sign(proposalHash);
+      return new BlockAttestation(payload, attestationSignature, proposerSignature);
+    }
+
+    it('should penalize peer when receiving attestation with different signature for same slot/proposalId/sender', async () => {
+      const slotNumber = 100;
+      const archive = Fr.random();
+      const signer = Secp256k1Signer.random();
+
+      // Create the first attestation
+      const attestation1 = createAttestation(signer, slotNumber, archive);
+
+      // Create a second attestation with different signature
+      const differentSigner = Secp256k1Signer.random();
+      const attestation2 = createAttestation(differentSigner, slotNumber, archive);
+
+      // Verify they have different attestation signatures and different senders
+      expect(attestation1.signature.equals(attestation2.signature)).toBe(false);
+      const sender1 = attestation1.getSender()!.toString();
+      const sender2 = attestation2.getSender()!.toString();
+      expect(sender1).not.toBe(sender2);
+
+      // Mock: first attestation exists in the pool, return it when querying by sender2
+      // This simulates the edge case where somehow an attestation with sender2 already exists
+      // but with attestation1's signature (which shouldn't happen in practice but tests the defensive code)
+      attestationPool.hasAttestation.mockResolvedValue(true);
+      attestationPool.getAttestation.mockResolvedValue(attestation1);
+      attestationPool.canAddAttestation.mockResolvedValue(true);
+
+      // Process the second attestation (with different signature)
+      await service.processAttestationFromPeer(attestation2.toBuffer(), 'msg-id', peerId);
+
+      // Verify that the peer was penalized
+      expect(peerManager.penalizePeer).toHaveBeenCalledWith(peerId, PeerErrorSeverity.LowToleranceError);
+    });
+
+    it('should not penalize peer when receiving duplicate attestation with same signature', async () => {
+      const slotNumber = 100;
+      const archive = Fr.random();
+      const signer = Secp256k1Signer.random();
+
+      const attestation = createAttestation(signer, slotNumber, archive);
+
+      // Mock: attestation exists in the pool with the same signature
+      attestationPool.hasAttestation.mockResolvedValue(true);
+      attestationPool.getAttestation.mockResolvedValue(attestation);
+      attestationPool.canAddAttestation.mockResolvedValue(true);
+
+      // Process the same attestation again
+      await service.processAttestationFromPeer(attestation.toBuffer(), 'msg-id', peerId);
+
+      // Verify that the peer was NOT penalized
+      expect(peerManager.penalizePeer).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('processBlockFromPeer - duplicate signature detection', () => {
+    let service: any;
+    let peerManager: MockProxy<PeerManagerInterface>;
+    let attestationPool: MockProxy<AttestationPool>;
+    let peerId: PeerId;
+
+    beforeEach(() => {
+      peerManager = mock<PeerManagerInterface>();
+      attestationPool = mock<AttestationPool>();
+      peerId = mock<PeerId>({
+        toString: () => 'peer-id',
+      });
+
+      service = Object.create(LibP2PService.prototype);
+      service.peerManager = peerManager;
+      service.mempools = { attestationPool };
+      service.logger = createLogger('p2p:test');
+      service.tracer = getTelemetryClient().getTracer('p2p:test');
+      service.validateBlockProposal = jest.fn(() => Promise.resolve(true));
+      service.validateReceivedMessage = jest.fn(async (validationFunc: any) => {
+        const result = await validationFunc();
+        return result;
+      });
+      service.processValidBlockProposal = jest.fn(() => Promise.resolve());
+    });
+
+    function createBlockProposal(signer: Secp256k1Signer, slotNumber: number, archive: Fr): BlockProposal {
+      const header = makeL2BlockHeader(1, 2, slotNumber);
+      const payload = new ConsensusPayload(header.toCheckpointHeader(), archive, header.state);
+      const hash = getHashedSignaturePayloadEthSignedMessage(payload, SignatureDomainSeparator.blockProposal);
+      const signature = signer.sign(hash);
+      const txHashes = [TxHash.random(), TxHash.random()];
+      return new BlockProposal(payload, signature, txHashes);
+    }
+
+    it('should penalize peer when receiving block proposal with different signature for same archive', async () => {
+      const slotNumber = 100;
+      const archive = Fr.random();
+      const signer1 = Secp256k1Signer.random();
+      const signer2 = Secp256k1Signer.random();
+
+      // Create two block proposals with the same content but signed by different signers
+      const proposal1 = createBlockProposal(signer1, slotNumber, archive);
+      const proposal2 = createBlockProposal(signer2, slotNumber, archive);
+
+      // Verify they have different signatures
+      expect(proposal1.signature.equals(proposal2.signature)).toBe(false);
+
+      // Mock: first proposal exists in the pool
+      attestationPool.hasBlockProposal.mockResolvedValue(true);
+      attestationPool.getBlockProposal.mockResolvedValue(proposal1);
+      attestationPool.canAddProposal.mockResolvedValue(true);
+
+      // Process the second proposal (with different signature)
+      await service.processBlockFromPeer(proposal2.toBuffer(), 'msg-id', peerId);
+
+      // Verify that the peer was penalized
+      expect(peerManager.penalizePeer).toHaveBeenCalledWith(peerId, PeerErrorSeverity.LowToleranceError);
+    });
+
+    it('should not penalize peer when receiving duplicate block proposal with same signature', async () => {
+      const slotNumber = 100;
+      const archive = Fr.random();
+      const signer = Secp256k1Signer.random();
+
+      const proposal = createBlockProposal(signer, slotNumber, archive);
+
+      // Mock: proposal exists in the pool with the same signature
+      attestationPool.hasBlockProposal.mockResolvedValue(true);
+      attestationPool.getBlockProposal.mockResolvedValue(proposal);
+      attestationPool.canAddProposal.mockResolvedValue(true);
+
+      // Process the same proposal again
+      await service.processBlockFromPeer(proposal.toBuffer(), 'msg-id', peerId);
+
+      // Verify that the peer was NOT penalized
       expect(peerManager.penalizePeer).not.toHaveBeenCalled();
     });
   });

--- a/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
+++ b/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
@@ -824,6 +824,17 @@ export class LibP2PService<T extends P2PClientType = P2PClientType.Full> extends
       if (!isValid) {
         return { result: TopicValidatorResult.Reject };
       } else if (exists) {
+        const existingAttestation = await pool.getAttestation(
+          attestation.payload.header.slotNumber.toBigInt(),
+          attestation.archive.toString(),
+          attestation.getSender()!.toString(),
+        );
+        if (existingAttestation && !existingAttestation.signature.equals(attestation.signature)) {
+          this.logger.warn('Penalizing the peer for sending the same attestation with a different signature.');
+          this.peerManager.penalizePeer(source, PeerErrorSeverity.LowToleranceError);
+          return { result: TopicValidatorResult.Reject };
+        }
+
         return { result: TopicValidatorResult.Ignore, obj: attestation };
       } else if (!canAdd) {
         this.logger.warn(`Dropping block attestation due to per-(slot, proposalId) attestation cap`, {
@@ -883,6 +894,13 @@ export class LibP2PService<T extends P2PClientType = P2PClientType.Full> extends
       if (!isValid) {
         return { result: TopicValidatorResult.Reject };
       } else if (exists) {
+        const existingBlockProposal = await pool?.getBlockProposal(block.payload.archive.toString());
+        if (existingBlockProposal && !existingBlockProposal.signature.equals(block.signature)) {
+          this.logger.warn('Penalizing the peer for sending the same block proposal with a different signature.');
+          this.peerManager.penalizePeer(source, PeerErrorSeverity.LowToleranceError);
+          return { result: TopicValidatorResult.Reject };
+        }
+
         return { result: TopicValidatorResult.Ignore, obj: block };
       } else if (!canAdd) {
         this.peerManager.penalizePeer(source, PeerErrorSeverity.MidToleranceError);

--- a/yarn-project/p2p/src/testbench/p2p_client_testbench_worker.ts
+++ b/yarn-project/p2p/src/testbench/p2p_client_testbench_worker.ts
@@ -70,6 +70,7 @@ function mockAttestationPool(): AttestationPool {
     deleteAttestationsForSlotAndProposal: () => Promise.resolve(),
     getAttestationsForSlot: () => Promise.resolve([]),
     getAttestationsForSlotAndProposal: () => Promise.resolve([]),
+    getAttestation: () => Promise.resolve(undefined),
     addBlockProposal: () => Promise.resolve(),
     getBlockProposal: () => Promise.resolve(undefined),
     hasBlockProposal: () => Promise.resolve(false),


### PR DESCRIPTION
Added duplicate detection for attestations and block proposals with signature validation. When a duplicate message with a different signature is detected, the sender is now penalized.

BEFORE:
1. Validate attestation/proposal
2. Check for duplicates
3. Ignore duplicate messages without penalty

AFTER:
1. Validate attestation/proposal
2. Check for duplicates
3. Compare signature with existing attestation/proposal in pool:
   a. Same signature → message ignored, no penalty (unchanged behavior)
   b. Different signature → message rejected, peer penalized

**Rationale:**

Attestations and block proposals use `@noble/curves` `secp256k1.sign()`, which provides deterministic signatures per RFC 6979. Under normal operation, the same message will always produce the same signature.

A different signature on an identical attestation/proposal indicates deliberate abuse—an attacker exploiting ECDSA malleability by sending multiple valid messages with different k-values. Since gossipsub treats messages with different byte sequences as distinct, this allows an attacker to flood the network with valid but redundant messages without triggering existing duplicate detection. This change closes that vulnerability by penalizing peers that send duplicates with non-deterministic signatures.
