### PR TITLE
feat(bb): add exception handling to bbapi C binding

### DIFF
--- a/barretenberg/cpp/src/barretenberg/bbapi/c_bind.cpp
+++ b/barretenberg/cpp/src/barretenberg/bbapi/c_bind.cpp
@@ -23,8 +23,16 @@ BBApiRequest global_request;
  */
 CommandResponse bbapi(Command&& command)
 {
-    // Execute the command using the global request and return the response
-    return execute(global_request, std::move(command));
+#ifndef BB_NO_EXCEPTIONS
+    try {
+#endif
+        // Execute the command using the global request and return the response
+        return execute(global_request, std::move(command));
+#ifndef BB_NO_EXCEPTIONS
+    } catch (const std::exception& e) {
+        return ErrorResponse{ .message = e.what() };
+    }
+#endif
 }
 
 } // namespace bb::bbapi

--- a/barretenberg/cpp/src/barretenberg/bbapi/c_bind_exception.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/bbapi/c_bind_exception.test.cpp
@@ -1,0 +1,67 @@
+#include "barretenberg/bbapi/bbapi_execute.hpp"
+#include "barretenberg/bbapi/bbapi_srs.hpp"
+#include "barretenberg/bbapi/c_bind.hpp"
+#include <gtest/gtest.h>
+#include <stdexcept>
+#include <string_view>
+
+using namespace bb::bbapi;
+
+#ifndef BB_NO_EXCEPTIONS
+
+// Test that exceptions thrown during command execution are caught and converted to ErrorResponse
+TEST(CBind, CatchesExceptionAndReturnsErrorResponse)
+{
+    // Create an SrsInitSrs command with invalid data that will cause an exception
+    // The from_buffer calls in bbapi_srs.cpp will read past buffer boundaries
+    SrsInitSrs cmd;
+    cmd.num_points = 100;                         // Request 100 points (6400 bytes needed)
+    cmd.points_buf = std::vector<uint8_t>(10, 0); // Only provide 10 bytes - will cause out of bounds access
+    cmd.g2_point = std::vector<uint8_t>(10, 0);   // Also too small (needs 128 bytes)
+
+    Command command = std::move(cmd);
+
+    // Call bbapi - exception should be caught and converted to ErrorResponse
+    CommandResponse response = bbapi(std::move(command));
+
+    // Check that we got an ErrorResponse using get_type_name()
+    std::string_view type_name = response.get_type_name();
+    EXPECT_EQ(type_name, "ErrorResponse") << "Expected ErrorResponse but got: " << type_name;
+
+    // Also verify using std::holds_alternative on the underlying variant
+    bool is_error = std::holds_alternative<ErrorResponse>(response.get());
+    EXPECT_TRUE(is_error) << "Expected ErrorResponse variant";
+
+    if (is_error) {
+        const auto& error = std::get<ErrorResponse>(response.get());
+        EXPECT_FALSE(error.message.empty()) << "Error message should not be empty";
+        std::cout << "Successfully caught exception with message: " << error.message << '\n';
+    }
+}
+
+// Test that valid operations still work correctly (no false positives)
+TEST(CBind, ValidOperationReturnsSuccess)
+{
+    // Create a Shutdown command which should succeed without throwing
+    Shutdown shutdown_cmd;
+    Command command = shutdown_cmd;
+
+    // Call bbapi - should return success response
+    CommandResponse response = bbapi(std::move(command));
+
+    // Check that we got a ShutdownResponse, not an ErrorResponse
+    std::string_view type_name = response.get_type_name();
+    EXPECT_NE(type_name, "ErrorResponse") << "Valid command should not return ErrorResponse";
+    EXPECT_EQ(type_name, "ShutdownResponse") << "Expected ShutdownResponse";
+
+    // Also verify using std::holds_alternative on the underlying variant
+    bool is_shutdown = std::holds_alternative<Shutdown::Response>(response.get());
+    EXPECT_TRUE(is_shutdown) << "Expected Shutdown::Response variant";
+}
+
+#else
+TEST(CBind, ExceptionsDisabled)
+{
+    GTEST_SKIP() << "Skipping exception handling tests when BB_NO_EXCEPTIONS is defined";
+}
+#endif

--- a/barretenberg/ts/src/bbapi/exception_handling.test.ts
+++ b/barretenberg/ts/src/bbapi/exception_handling.test.ts
@@ -1,0 +1,54 @@
+import { BarretenbergWasmSyncBackend } from '../bb_backends/wasm.js';
+import { SyncApi } from '../cbind/generated/sync.js';
+import { BBApiException } from '../bbapi_exception.js';
+
+describe('BBApi Exception Handling from bb.js', () => {
+  let backend: BarretenbergWasmSyncBackend;
+  let api: SyncApi;
+
+  beforeAll(async () => {
+    backend = await BarretenbergWasmSyncBackend.new();
+    api = new SyncApi(backend);
+  }, 60000);
+
+  afterAll(() => {
+    backend.destroy();
+  });
+
+  it('should catch CRS initialization exceptions from WASM', () => {
+    // Create an SrsInitSrs command with invalid data that will cause an exception in C++
+    // We pass buffers that are too small, which will cause validation to fail
+    const invalidCommand = {
+      numPoints: 100, // Request 100 points (requires 6400 bytes)
+      pointsBuf: new Uint8Array(10), // Only 10 bytes - will cause exception
+      g2Point: new Uint8Array(10), // Only 10 bytes (needs 128) - will cause exception
+    };
+
+    // In WASM builds, throw_or_abort calls abort directly which throws a generic Error
+    // In native builds with exceptions, our try-catch in bbapi converts it to ErrorResponse
+    // This test verifies that errors are catchable from bb.js (even if as generic Error in WASM)
+    expect(() => {
+      api.srsInitSrs(invalidCommand);
+    }).toThrow();
+  });
+
+  it('should return error message from caught exception', () => {
+    const invalidCommand = {
+      numPoints: 100,
+      pointsBuf: new Uint8Array(10),
+      g2Point: new Uint8Array(10),
+    };
+
+    try {
+      api.srsInitSrs(invalidCommand);
+      fail('Expected exception to be thrown');
+    } catch (error) {
+      // Error is catchable and contains a useful message
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).toBeTruthy();
+      expect((error as Error).message.length).toBeGreaterThan(0);
+      expect((error as Error).message).toContain('g1_identity');
+      console.log('Successfully caught exception from bb.js with message:', (error as Error).message);
+    }
+  });
+});


### PR DESCRIPTION
Adds exception handling to bbapi C binding to catch C++ exceptions and convert them to ErrorResponse.

Fixes https://github.com/AztecProtocol/barretenberg/issues/1588

## Changes
- Add try-catch block in bbapi() that catches std::exception
- Convert exceptions to ErrorResponse with error message
- Use conditional compilation for BB_NO_EXCEPTIONS builds

## Tests
C++ tests verify exceptions convert to ErrorResponse in native builds.
TypeScript tests verify errors are catchable from bb.js with proper messages.

All 19 C++ tests pass. Both TypeScript integration tests pass.