### PR TITLE
fix: Don't throw for unknown network option

### DIFF
--- a/yarn-project/cli/src/config/network_config.test.ts
+++ b/yarn-project/cli/src/config/network_config.test.ts
@@ -1,0 +1,140 @@
+import { mkdir, rm, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import { enrichEnvironmentWithNetworkConfig, getNetworkConfig } from './network_config.js';
+
+describe('Network Config', () => {
+  let tempDir: string;
+  const originalEnv = { ...process.env };
+
+  beforeEach(async () => {
+    // Create a temporary directory for test config files
+    tempDir = join(tmpdir(), `network-config-test-${Date.now()}`);
+    await mkdir(tempDir, { recursive: true });
+
+    // Reset environment
+    process.env = { ...originalEnv };
+    delete process.env.NETWORK_CONFIG_LOCATION;
+    delete process.env.BOOTSTRAP_NODES;
+    delete process.env.L1_CHAIN_ID;
+  });
+
+  afterEach(async () => {
+    // Clean up temp directory
+    await rm(tempDir, { recursive: true, force: true });
+    process.env = { ...originalEnv };
+  });
+
+  describe('enrichEnvironmentWithNetworkConfig', () => {
+    it('should not throw when network does not exist in valid config', async () => {
+      const validConfigWithoutNetwork = {
+        'some-other-network': {
+          bootnodes: ['enr:-test1'],
+          snapshots: ['https://example.com/snapshot.tar.gz'],
+          registryAddress: '0x1234567890123456789012345678901234567890',
+          l1ChainId: 11155111,
+        },
+      };
+
+      const configPath = join(tempDir, 'network_config.json');
+      await writeFile(configPath, JSON.stringify(validConfigWithoutNetwork));
+      process.env.NETWORK_CONFIG_LOCATION = `file://${configPath}`;
+
+      // Should not throw - network 'testnet' doesn't exist in the config but config is valid
+      await expect(enrichEnvironmentWithNetworkConfig('testnet')).resolves.toBeUndefined();
+
+      // Environment should not be enriched since network doesn't exist
+      expect(process.env.BOOTSTRAP_NODES).toBeUndefined();
+      expect(process.env.L1_CHAIN_ID).toBeUndefined();
+    });
+
+    it('should throw when config file does not exist', async () => {
+      process.env.NETWORK_CONFIG_LOCATION = `file://${join(tempDir, 'nonexistent.json')}`;
+
+      // Should throw because file doesn't exist
+      await expect(enrichEnvironmentWithNetworkConfig('testnet')).rejects.toThrow();
+    });
+
+    it('should throw when config parsing fails', async () => {
+      const configPath = join(tempDir, 'invalid_config.json');
+      await writeFile(configPath, '{ invalid json');
+      process.env.NETWORK_CONFIG_LOCATION = `file://${configPath}`;
+
+      // Should throw because config is invalid JSON
+      await expect(enrichEnvironmentWithNetworkConfig('testnet')).rejects.toThrow();
+    });
+
+    it('should skip local network', async () => {
+      // Should return early without fetching
+      await expect(enrichEnvironmentWithNetworkConfig('local')).resolves.toBeUndefined();
+    });
+
+    it('should enrich environment when network exists in config', async () => {
+      const validConfig = {
+        testnet: {
+          bootnodes: ['enr:-test1', 'enr:-test2'],
+          snapshots: ['https://example.com/snapshot.tar.gz'],
+          registryAddress: '0x1234567890123456789012345678901234567890',
+          l1ChainId: 11155111,
+        },
+      };
+
+      const configPath = join(tempDir, 'network_config.json');
+      await writeFile(configPath, JSON.stringify(validConfig));
+      process.env.NETWORK_CONFIG_LOCATION = `file://${configPath}`;
+
+      await enrichEnvironmentWithNetworkConfig('testnet');
+
+      // Environment should be enriched
+      expect(process.env.BOOTSTRAP_NODES).toBe('enr:-test1,enr:-test2');
+      expect(process.env.L1_CHAIN_ID).toBe('11155111');
+      expect(process.env.REGISTRY_CONTRACT_ADDRESS).toBe('0x1234567890123456789012345678901234567890');
+    });
+  });
+
+  describe('getNetworkConfig', () => {
+    it('should return config when network exists', async () => {
+      const validConfig = {
+        testnet: {
+          bootnodes: ['enr:-test1'],
+          snapshots: ['https://example.com/snapshot.tar.gz'],
+          registryAddress: '0x1234567890123456789012345678901234567890',
+          l1ChainId: 11155111,
+        },
+      };
+
+      const configPath = join(tempDir, 'network_config.json');
+      await writeFile(configPath, JSON.stringify(validConfig));
+      process.env.NETWORK_CONFIG_LOCATION = `file://${configPath}`;
+
+      const result = await getNetworkConfig('testnet');
+      expect(result).toBeDefined();
+      expect(result?.bootnodes).toEqual(['enr:-test1']);
+    });
+
+    it('should return undefined when network not in config', async () => {
+      const validConfig = {
+        'other-network': {
+          bootnodes: ['enr:-test1'],
+          snapshots: ['https://example.com/snapshot.tar.gz'],
+          registryAddress: '0x1234567890123456789012345678901234567890',
+          l1ChainId: 11155111,
+        },
+      };
+
+      const configPath = join(tempDir, 'network_config.json');
+      await writeFile(configPath, JSON.stringify(validConfig));
+      process.env.NETWORK_CONFIG_LOCATION = `file://${configPath}`;
+
+      const result = await getNetworkConfig('testnet');
+      expect(result).toBeUndefined();
+    });
+
+    it('should throw when config file does not exist', async () => {
+      process.env.NETWORK_CONFIG_LOCATION = `file://${join(tempDir, 'nonexistent.json')}`;
+
+      await expect(getNetworkConfig('testnet')).rejects.toThrow();
+    });
+  });
+});

--- a/yarn-project/cli/src/config/network_config.ts
+++ b/yarn-project/cli/src/config/network_config.ts
@@ -17,7 +17,8 @@ const NETWORK_CONFIG_CACHE_DURATION_MS = 60 * 60 * 1000; // 1 hour
  *
  * @param networkName - The network name to fetch config for
  * @param cacheDir - Optional cache directory for storing fetched config
- * @returns Remote configuration for the specified network, or undefined if not found/error
+ * @returns Remote configuration for the specified network, or undefined if network not found in config
+ * @throws Error if both primary and fallback URLs fail to fetch
  */
 export async function getNetworkConfig(
   networkName: NetworkNames,
@@ -26,12 +27,29 @@ export async function getNetworkConfig(
   // Try with the primary URL (env var or default)
   const configLocation = process.env.NETWORK_CONFIG_LOCATION || DEFAULT_CONFIG_URL;
 
+  let primaryError: Error | undefined;
+  let config: NetworkConfig | undefined;
+
   // First try the primary config location
-  let config = await fetchNetworkConfigFromUrl(configLocation, networkName, cacheDir);
+  try {
+    config = await fetchNetworkConfigFromUrl(configLocation, networkName, cacheDir);
+  } catch (error) {
+    primaryError = error as Error;
+  }
 
   // If primary fails and we were using the default URL, try the fallback
   if (!config && configLocation === DEFAULT_CONFIG_URL) {
-    config = await fetchNetworkConfigFromUrl(FALLBACK_CONFIG_URL, networkName, cacheDir);
+    try {
+      config = await fetchNetworkConfigFromUrl(FALLBACK_CONFIG_URL, networkName, cacheDir);
+    } catch {
+      // Both failed - throw the primary error
+      if (primaryError) {
+        throw primaryError;
+      }
+    }
+  } else if (primaryError) {
+    // Primary failed and no fallback to try
+    throw primaryError;
   }
 
   return config;
@@ -42,7 +60,8 @@ export async function getNetworkConfig(
  * @param configLocation - The URL or file path to fetch from
  * @param networkName - The network name to fetch config for
  * @param cacheDir - Optional cache directory for storing fetched config
- * @returns Remote configuration for the specified network, or undefined if not found/error
+ * @returns Remote configuration for the specified network, or undefined if network not found in config, or undefined if URL invalid
+ * @throws Error if fetch/parse fails
  */
 async function fetchNetworkConfigFromUrl(
   configLocation: string,
@@ -64,31 +83,27 @@ async function fetchNetworkConfigFromUrl(
     return undefined;
   }
 
-  try {
-    let rawConfig: any;
+  let rawConfig: any;
 
-    if (url.protocol === 'http:' || url.protocol === 'https:') {
-      rawConfig = await cachedFetch(url.href, {
-        cacheDurationMs: NETWORK_CONFIG_CACHE_DURATION_MS,
-        cacheFile: cacheDir ? join(cacheDir, networkName, 'network_config.json') : undefined,
-      });
-    } else if (url.protocol === 'file:') {
-      rawConfig = JSON.parse(await readFile(url.pathname, 'utf-8'));
-    } else {
-      throw new Error('Unsupported Aztec network config protocol: ' + url.href);
-    }
+  if (url.protocol === 'http:' || url.protocol === 'https:') {
+    rawConfig = await cachedFetch(url.href, {
+      cacheDurationMs: NETWORK_CONFIG_CACHE_DURATION_MS,
+      cacheFile: cacheDir ? join(cacheDir, networkName, 'network_config.json') : undefined,
+    });
+  } else if (url.protocol === 'file:') {
+    rawConfig = JSON.parse(await readFile(url.pathname, 'utf-8'));
+  } else {
+    throw new Error('Unsupported Aztec network config protocol: ' + url.href);
+  }
 
-    if (!rawConfig) {
-      return undefined;
-    }
+  if (!rawConfig) {
+    return undefined;
+  }
 
-    const networkConfigMap = NetworkConfigMapSchema.parse(rawConfig);
-    if (networkName in networkConfigMap) {
-      return networkConfigMap[networkName];
-    } else {
-      return undefined;
-    }
-  } catch {
+  const networkConfigMap = NetworkConfigMapSchema.parse(rawConfig);
+  if (networkName in networkConfigMap) {
+    return networkConfigMap[networkName];
+  } else {
     return undefined;
   }
 }
@@ -99,6 +114,8 @@ async function fetchNetworkConfigFromUrl(
  * from the remote config, following the same pattern as enrichEnvironmentWithChainConfig().
  *
  * @param networkName - The network name to fetch remote config for
+ * @throws Error if network config fetch fails (network errors, parse errors, etc.)
+ * Does not throw if the network simply doesn't exist in the config - just returns without enriching
  */
 export async function enrichEnvironmentWithNetworkConfig(networkName: NetworkNames) {
   if (networkName === 'local') {
@@ -109,7 +126,7 @@ export async function enrichEnvironmentWithNetworkConfig(networkName: NetworkNam
   const networkConfig = await getNetworkConfig(networkName, cacheDir);
 
   if (!networkConfig) {
-    throw new Error(`Failed to fetch network config for network: ${networkName}`);
+    return; // Network not found in config, continue without enriching
   }
 
   enrichVar('BOOTSTRAP_NODES', networkConfig.bootnodes.join(','));


### PR DESCRIPTION
We are currently failing on `next-net` deployments with:
```
Failed to fetch network config for network: next-net
```

When a network that's not part of our config is used, we shouldn't throw if the fetch is successful. Instead we just don't hydrate any env and keep going.