### PR TITLE
refactor: dropping recipient from `NoteDao` and `UniqueNote`

### DIFF
--- a/docs/docs/developers/docs/resources/migration_notes.md
+++ b/docs/docs/developers/docs/resources/migration_notes.md
@@ -314,6 +314,12 @@ The method now only accepts:
 - `artifact` (optional): A `ContractArtifact` object
 - `secretKey` (optional): A secret key for privacy keys registration
 
+#### Return value of `getNotes` no longer contains a recipient
+
+Return value of `getNotes` is defined as `Promise<UniqueNote[]>` and recipient has been dropped from `UniqueNote`.
+This change has been done because the value has been redundant as the same outcome can be achieved by populating the `scopes` array in `NoteFilter` with the `recipient` value.
+(Having the recipient in the `UniqueNote` was also logically incorrect because a note does not have a recipient - it's the message containing the note that has a recipient.)
+
 ### [CLI] Command refactor
 
 The sandbox command has been renamed and remapped to "local network". We believe this conveys better what is actually being spun up when running it.

--- a/yarn-project/cli-wallet/src/cmds/check_tx.ts
+++ b/yarn-project/cli-wallet/src/cmds/check_tx.ts
@@ -125,7 +125,6 @@ function inspectNote(note: UniqueNote, artifactMap: ArtifactMap, log: LogFn, tex
   const artifact = artifactMap[note.contractAddress.toString()];
   const contract = artifact?.name ?? note.contractAddress.toString();
   log(`  ${text} at ${contract}`);
-  log(`    Recipient: ${toFriendlyAddress(note.recipient, artifactMap)}`);
   for (const field of note.note.items) {
     log(`    ${field.toString()}`);
   }

--- a/yarn-project/pxe/src/contract_function_simulator/pxe_oracle_interface.test.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/pxe_oracle_interface.test.ts
@@ -657,11 +657,10 @@ describe('PXEOracleInterface', () => {
       );
 
       // Verify note was stored
-      const notes = await noteDataProvider.getNotes({ contractAddress });
+      const notes = await noteDataProvider.getNotes({ contractAddress, scopes: [recipient.address] });
 
-      const matchingNotes = notes.filter(n => n.recipient.equals(recipient.address));
-      expect(matchingNotes).toHaveLength(1);
-      expect(matchingNotes[0].noteHash.equals(noteHash)).toBe(true);
+      expect(notes).toHaveLength(1);
+      expect(notes[0].noteHash.equals(noteHash)).toBe(true);
     });
 
     it('should throw if note does not exist in note hash tree', async () => {
@@ -711,9 +710,8 @@ describe('PXEOracleInterface', () => {
       );
 
       // Verify note was removed
-      const notes = await noteDataProvider.getNotes({ contractAddress });
-      const matchingNotes = notes.filter(n => n.recipient.equals(recipient.address));
-      expect(matchingNotes).toHaveLength(0);
+      const notes = await noteDataProvider.getNotes({ contractAddress, scopes: [recipient.address] });
+      expect(notes).toHaveLength(0);
     });
 
     // Verifies that notes are only accepted from blocks that have been synced by PXE. We mock
@@ -787,10 +785,10 @@ describe('PXEOracleInterface', () => {
       const notes = await noteDataProvider.getNotes({
         contractAddress,
         status: NoteStatus.ACTIVE,
+        scopes: [recipient.address],
       });
-      const matchingNotes = notes.filter(n => n.recipient.equals(recipient.address));
-      expect(matchingNotes).toHaveLength(1);
-      expect(matchingNotes[0].noteHash.equals(noteHash)).toBe(true);
+      expect(notes).toHaveLength(1);
+      expect(notes[0].noteHash.equals(noteHash)).toBe(true);
     });
   });
 
@@ -1015,7 +1013,7 @@ describe('PXEOracleInterface', () => {
 
     it('should remove notes that have been nullified', async () => {
       // Set up initial state with a note
-      const noteDao = await NoteDao.random({ contractAddress, recipient });
+      const noteDao = await NoteDao.random({ contractAddress });
 
       // Spy on the noteDataProvider.applyNullifiers to later on have additional guarantee that we really removed
       // the note.
@@ -1032,9 +1030,12 @@ describe('PXEOracleInterface', () => {
       await pxeOracleInterface.syncNoteNullifiers(contractAddress);
 
       // Verify the note was removed by checking storage
-      const remainingNotes = await noteDataProvider.getNotes({ contractAddress, status: NoteStatus.ACTIVE });
-      const matchingNotes = remainingNotes.filter(n => n.recipient.equals(recipient));
-      expect(matchingNotes).toHaveLength(0);
+      const remainingNotes = await noteDataProvider.getNotes({
+        contractAddress,
+        status: NoteStatus.ACTIVE,
+        scopes: [recipient],
+      });
+      expect(remainingNotes).toHaveLength(0);
 
       // Verify the note was removed by checking the spy
       expect(noteDataProvider.applyNullifiers).toHaveBeenCalledTimes(1);
@@ -1042,7 +1043,7 @@ describe('PXEOracleInterface', () => {
 
     it('should keep notes that have not been nullified', async () => {
       // Set up initial state with a note
-      const noteDao = await NoteDao.random({ contractAddress, recipient });
+      const noteDao = await NoteDao.random({ contractAddress });
 
       // Add the note to storage
       await noteDataProvider.addNotes([noteDao], recipient);
@@ -1054,10 +1055,13 @@ describe('PXEOracleInterface', () => {
       await pxeOracleInterface.syncNoteNullifiers(contractAddress);
 
       // Verify note still exists
-      const remainingNotes = await noteDataProvider.getNotes({ contractAddress, status: NoteStatus.ACTIVE });
-      const matchingNotes = remainingNotes.filter(n => n.recipient.equals(recipient));
-      expect(matchingNotes).toHaveLength(1);
-      expect(matchingNotes[0]).toEqual(noteDao);
+      const remainingNotes = await noteDataProvider.getNotes({
+        contractAddress,
+        status: NoteStatus.ACTIVE,
+        scopes: [recipient],
+      });
+      expect(remainingNotes).toHaveLength(1);
+      expect(remainingNotes[0]).toEqual(noteDao);
     });
 
     // Verifies that notes are not marked as nullified when their nullifier only exists in blocks that haven't been
@@ -1065,7 +1069,7 @@ describe('PXEOracleInterface', () => {
     // is not removed by applyNullifiers.
     it('should not remove notes if nullifier is in unsynced blocks', async () => {
       // Set up initial state with a note
-      const noteDao = await NoteDao.random({ contractAddress, recipient });
+      const noteDao = await NoteDao.random({ contractAddress });
       const syncedBlockNumber = 100;
       await setSyncedBlockNumber(syncedBlockNumber);
 
@@ -1084,10 +1088,13 @@ describe('PXEOracleInterface', () => {
       await pxeOracleInterface.syncNoteNullifiers(contractAddress);
 
       // Verify note still exists
-      const remainingNotes = await noteDataProvider.getNotes({ contractAddress, status: NoteStatus.ACTIVE });
-      const matchingNotes = remainingNotes.filter(n => n.recipient.equals(recipient));
-      expect(matchingNotes).toHaveLength(1);
-      expect(matchingNotes[0]).toEqual(noteDao);
+      const remainingNotes = await noteDataProvider.getNotes({
+        contractAddress,
+        status: NoteStatus.ACTIVE,
+        scopes: [recipient],
+      });
+      expect(remainingNotes).toHaveLength(1);
+      expect(remainingNotes[0]).toEqual(noteDao);
     });
 
     it('should search for notes from all accounts', async () => {

--- a/yarn-project/pxe/src/contract_function_simulator/pxe_oracle_interface.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/pxe_oracle_interface.ts
@@ -691,9 +691,9 @@ export class PXEOracleInterface implements ExecutionDataProvider {
       uniqueNoteHashTreeIndexInBlock?.l2BlockNumber,
       uniqueNoteHashTreeIndexInBlock?.l2BlockHash.toString(),
       uniqueNoteHashTreeIndexInBlock?.data,
-      recipient,
     );
 
+    // The note was found by `recipient`, so we use that as the scope when storing the note.
     await this.noteDataProvider.addNotes([noteDao], recipient);
     this.log.verbose('Added note', {
       index: noteDao.index,

--- a/yarn-project/pxe/src/pxe.ts
+++ b/yarn-project/pxe/src/pxe.ts
@@ -679,19 +679,9 @@ export class PXE {
 
     const noteDaos = await this.noteDataProvider.getNotes(filter);
 
-    const uniqueNotes = noteDaos.map(async dao => {
-      const completeAddresses = await this.addressDataProvider.getCompleteAddresses();
-      const completeAddressIndex = completeAddresses.findIndex(completeAddress =>
-        completeAddress.address.equals(dao.recipient),
-      );
-      const completeAddress = completeAddresses[completeAddressIndex];
-      if (completeAddress === undefined) {
-        throw new Error(`Cannot find complete address for recipient ${dao.recipient.toString()}`);
-      }
-      const recipient = completeAddress.address;
-      return new UniqueNote(dao.note, recipient, dao.contractAddress, dao.storageSlot, dao.txHash, dao.noteNonce);
+    return noteDaos.map(dao => {
+      return new UniqueNote(dao.note, dao.contractAddress, dao.storageSlot, dao.txHash, dao.noteNonce);
     });
-    return Promise.all(uniqueNotes);
   }
 
   /**

--- a/yarn-project/pxe/src/storage/note_data_provider/note_dao.ts
+++ b/yarn-project/pxe/src/storage/note_data_provider/note_dao.ts
@@ -56,11 +56,6 @@ export class NoteDao implements NoteData {
     public l2BlockHash: string,
     /** The index of the leaf in the global note hash tree the note is stored at */
     public index: bigint,
-    /**
-     * The address whose public key was used to encrypt the note log during delivery.
-     * (This is the x-coordinate of the public key.)
-     */
-    public recipient: AztecAddress,
   ) {}
 
   toBuffer(): Buffer {
@@ -76,7 +71,6 @@ export class NoteDao implements NoteData {
       this.l2BlockNumber,
       Fr.fromHexString(this.l2BlockHash),
       this.index,
-      this.recipient,
     ]);
   }
 
@@ -94,7 +88,6 @@ export class NoteDao implements NoteData {
     const l2BlockNumber = reader.readNumber();
     const l2BlockHash = Fr.fromBuffer(reader).toString();
     const index = toBigIntBE(reader.readBytes(32));
-    const recipient = AztecAddress.fromBuffer(reader);
 
     return new NoteDao(
       note,
@@ -108,7 +101,6 @@ export class NoteDao implements NoteData {
       l2BlockNumber,
       l2BlockHash,
       index,
-      recipient,
     );
   }
 
@@ -143,7 +135,6 @@ export class NoteDao implements NoteData {
     l2BlockNumber = Math.floor(Math.random() * 1000),
     l2BlockHash = Fr.random().toString(),
     index = Fr.random().toBigInt(),
-    recipient = undefined,
   }: Partial<NoteDao> = {}) {
     return new NoteDao(
       note,
@@ -157,7 +148,6 @@ export class NoteDao implements NoteData {
       l2BlockNumber,
       l2BlockHash,
       index,
-      recipient ?? (await AztecAddress.random()),
     );
   }
 }

--- a/yarn-project/pxe/src/storage/note_data_provider/note_data_provider.test.ts
+++ b/yarn-project/pxe/src/storage/note_data_provider/note_data_provider.test.ts
@@ -41,7 +41,6 @@ describe('NoteDataProvider', () => {
     return NoteDao.random({
       contractAddress: overrides.contractAddress ?? CONTRACT_A,
       storageSlot: overrides.storageSlot ?? SLOT_X,
-      recipient: overrides.recipient ?? SCOPE_1,
       index: overrides.index ?? 0n,
       l2BlockNumber: overrides.l2BlockNumber ?? 1,
       siloedNullifier: overrides.siloedNullifier ?? Fr.random(),
@@ -60,21 +59,18 @@ describe('NoteDataProvider', () => {
     const note1 = await mkNote({
       contractAddress: CONTRACT_A,
       storageSlot: SLOT_X,
-      recipient: SCOPE_1,
       siloedNullifier: DUMMY_SILOED_NULLIFIER_1,
       index: 1n,
     });
     const note2 = await mkNote({
       contractAddress: CONTRACT_A,
       storageSlot: SLOT_Y,
-      recipient: SCOPE_1,
       siloedNullifier: DUMMY_SILOED_NULLIFIER_2,
       index: 2n,
     });
     const note3 = await mkNote({
       contractAddress: CONTRACT_B,
       storageSlot: SLOT_X,
-      recipient: SCOPE_2,
       siloedNullifier: DUMMY_SILOED_NULLIFIER_3,
       index: 3n,
     });
@@ -121,8 +117,8 @@ describe('NoteDataProvider', () => {
       await provider1.addScope(SCOPE_1);
       await provider1.addScope(SCOPE_2);
 
-      const noteA = await mkNote({ contractAddress: CONTRACT_A, recipient: SCOPE_1, index: 1n });
-      const noteB = await mkNote({ contractAddress: CONTRACT_B, recipient: SCOPE_2, index: 2n });
+      const noteA = await mkNote({ contractAddress: CONTRACT_A, index: 1n });
+      const noteB = await mkNote({ contractAddress: CONTRACT_B, index: 2n });
       await provider1.addNotes([noteA, noteB], FAKE_ADDRESS);
 
       const provider2 = await NoteDataProvider.create(store);
@@ -173,7 +169,6 @@ describe('NoteDataProvider', () => {
       const note4 = await mkNote({
         contractAddress: CONTRACT_A,
         storageSlot: SLOT_X,
-        recipient: SCOPE_2,
         index: 4n,
       });
       await provider.addNotes([note4], SCOPE_2);
@@ -456,7 +451,7 @@ describe('NoteDataProvider', () => {
 
       const byScope = await provider.getNotes({
         contractAddress: CONTRACT_A,
-        scopes: [note1.recipient],
+        scopes: [SCOPE_1],
         status: NoteStatus.ACTIVE_OR_NULLIFIED,
       });
       expect(new Set(getIndexes(byScope))).toEqual(new Set([1n, 2n]));

--- a/yarn-project/pxe/src/storage/note_data_provider/note_data_provider.ts
+++ b/yarn-project/pxe/src/storage/note_data_provider/note_data_provider.ts
@@ -194,10 +194,12 @@ export class NoteDataProvider {
         await this.#notes.set(noteIndex, dao.toBuffer());
         await this.#nullifierToNoteId.set(dao.siloedNullifier.toString(), noteIndex);
 
-        let scopes = (await toArray(this.#nullifiedNotesToScope.getValuesAsync(noteIndex))) ?? [];
+        const scopes = await toArray(this.#nullifiedNotesToScope.getValuesAsync(noteIndex));
 
         if (scopes.length === 0) {
-          scopes = [dao.recipient.toString()];
+          // We should never run into this error because notes always have a scope assigned to them - either on initial
+          // insertion via `addNotes` or when removing their nullifiers.
+          throw new Error(`No scopes found for nullified note with index ${noteIndex}`);
         }
 
         for (const scope of scopes) {
@@ -359,7 +361,14 @@ export class NoteDataProvider {
         if (!noteBuffer) {
           throw new Error('Note not found in applyNullifiers');
         }
-        const noteScopes = (await toArray(this.#notesToScope.getValuesAsync(noteIndex))) ?? [];
+
+        const noteScopes = await toArray(this.#notesToScope.getValuesAsync(noteIndex));
+        if (noteScopes.length === 0) {
+          // We should never run into this error because notes always have a scope assigned to them - either on initial
+          // insertion via `addNotes` or when removing their nullifiers.
+          throw new Error('Note scopes are missing in applyNullifiers');
+        }
+
         const note = NoteDao.fromBuffer(noteBuffer);
 
         nullifiedNotes.push(note);
@@ -374,10 +383,8 @@ export class NoteDataProvider {
           await this.#notesByStorageSlotAndScope.get(scope)!.deleteValue(note.storageSlot.toString(), noteIndex);
         }
 
-        if (noteScopes !== undefined) {
-          for (const scope of noteScopes) {
-            await this.#nullifiedNotesToScope.set(noteIndex, scope);
-          }
+        for (const scope of noteScopes) {
+          await this.#nullifiedNotesToScope.set(noteIndex, scope);
         }
         await this.#nullifiedNotes.set(noteIndex, note.toBuffer());
         await this.#nullifiersByBlockNumber.set(blockNumber, nullifier.toString());

--- a/yarn-project/stdlib/src/note/unique_note.ts
+++ b/yarn-project/stdlib/src/note/unique_note.ts
@@ -16,8 +16,6 @@ export class UniqueNote {
   constructor(
     /** The note as emitted from the Noir contract. */
     public note: Note,
-    /** The recipient whose public key was used to encrypt the note. */
-    public recipient: AztecAddress,
     /** The contract address this note is created in. */
     public contractAddress: AztecAddress,
     /** The specific storage location of the note on the contract. */
@@ -32,50 +30,34 @@ export class UniqueNote {
     return z
       .object({
         note: Note.schema,
-        recipient: schemas.AztecAddress,
         contractAddress: schemas.AztecAddress,
         storageSlot: schemas.Fr,
         txHash: TxHash.schema,
         noteNonce: schemas.Fr,
       })
-      .transform(({ note, recipient, contractAddress, storageSlot, txHash, noteNonce }) => {
-        return new UniqueNote(note, recipient, contractAddress, storageSlot, txHash, noteNonce);
+      .transform(({ note, contractAddress, storageSlot, txHash, noteNonce }) => {
+        return new UniqueNote(note, contractAddress, storageSlot, txHash, noteNonce);
       });
   }
 
   toBuffer(): Buffer {
-    return serializeToBuffer([
-      this.note,
-      this.recipient,
-      this.contractAddress,
-      this.storageSlot,
-      this.txHash,
-      this.noteNonce,
-    ]);
+    return serializeToBuffer([this.note, this.contractAddress, this.storageSlot, this.txHash, this.noteNonce]);
   }
 
   static async random() {
-    return new UniqueNote(
-      Note.random(),
-      await AztecAddress.random(),
-      await AztecAddress.random(),
-      Fr.random(),
-      TxHash.random(),
-      Fr.random(),
-    );
+    return new UniqueNote(Note.random(), await AztecAddress.random(), Fr.random(), TxHash.random(), Fr.random());
   }
 
   static fromBuffer(buffer: Buffer | BufferReader) {
     const reader = BufferReader.asReader(buffer);
 
     const note = reader.readObject(Note);
-    const recipient = reader.readObject(AztecAddress);
     const contractAddress = reader.readObject(AztecAddress);
     const storageSlot = reader.readObject(Fr);
     const txHash = reader.readObject(TxHash);
     const noteNonce = reader.readObject(Fr);
 
-    return new UniqueNote(note, recipient, contractAddress, storageSlot, txHash, noteNonce);
+    return new UniqueNote(note, contractAddress, storageSlot, txHash, noteNonce);
   }
 
   static fromString(str: string) {

--- a/yarn-project/stdlib/src/tests/mocks.ts
+++ b/yarn-project/stdlib/src/tests/mocks.ts
@@ -84,20 +84,12 @@ export const randomTxHash = (): TxHash => TxHash.random();
 
 export const randomUniqueNote = async ({
   note = Note.random(),
-  recipient = undefined,
   contractAddress = undefined,
   txHash = randomTxHash(),
   storageSlot = Fr.random(),
   noteNonce = Fr.random(),
 }: Partial<UniqueNote> = {}) => {
-  return new UniqueNote(
-    note,
-    recipient ?? (await AztecAddress.random()),
-    contractAddress ?? (await AztecAddress.random()),
-    storageSlot,
-    txHash,
-    noteNonce,
-  );
+  return new UniqueNote(note, contractAddress ?? (await AztecAddress.random()), storageSlot, txHash, noteNonce);
 };
 
 export const mockTx = async (


### PR DESCRIPTION
Fixes F-92

The issue description describes the motivation for this well:

> NoteDao contains a recipient value. This is no longer used as there is no filtering by recipient. It is also incorrect as notes don't technically have a recipient, they're just data. It is the note message that has a recipient.
> 
> As recipient gets removed from the object, we'll no longer be able to use it to determine the note's scope. We should therefore ask the caller to specify the scope, which they can just do with the recipient field they used when creating the NoteDao (the message recipient).