### PR TITLE
chore: Avoid capturing a mutable reference in `remove_constraints_if`

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/note/note_emission.nr
+++ b/noir-projects/aztec-nr/aztec/src/note/note_emission.nr
@@ -68,13 +68,16 @@ where
         // TODO(#14565): Add constrained tagging
         let _constrained_tagging = delivery_mode == MessageDelivery.CONSTRAINED_ONCHAIN;
 
+        // Do not capture `self` in the lambda.
+        let content = self.content;
+
         let ciphertext = remove_constraints_if(
             !constrained_encryption,
             || AES128::encrypt(
                 private_note_to_message_plaintext(
-                    self.content.note,
-                    self.content.storage_slot,
-                    self.content.randomness,
+                    content.note,
+                    content.storage_slot,
+                    content.randomness,
                 ),
                 recipient,
             ),


### PR DESCRIPTION
This should unblock https://github.com/noir-lang/noir/pull/10497 to be merged into Noir. Thanks to @asterite for pointing out this simple fix.

Passing mutable references from ACIR to Brillig is invalid, however it slipped in by capturing `self` in a lambda, which is a `NoteEmission` that contains a `context: &mut PrivateContext` field.