### PR TITLE
chore: add mainnet compatibility test

### DIFF
--- a/yarn-project/aztec/src/mainnet_compatibility.test.ts
+++ b/yarn-project/aztec/src/mainnet_compatibility.test.ts
@@ -1,0 +1,31 @@
+import { Fr } from '@aztec/aztec.js/fields';
+import { getVKTreeRoot } from '@aztec/noir-protocol-circuits-types/vk-tree';
+import { protocolContractsHash } from '@aztec/protocol-contracts';
+import { getGenesisValues } from '@aztec/world-state/testing';
+
+/**
+ * This test suit makes sure that the code in the monorepo is still compatible with the latest version of mainnet
+ * Only update these values after a governance update that changes the protocol is enacted
+ */
+describe('Mainnet compatibility', () => {
+  it('has expected VK tree root', () => {
+    const expectedRoots = [Fr.fromHexString('0x229eadb7c540c82204b5373633d3c25557f8264ad8fca760660fe853e5275e39')];
+    expect(expectedRoots).toContainEqual(getVKTreeRoot());
+  });
+  it('has expected Protocol Contracts tree root', () => {
+    expect(protocolContractsHash).toEqual(
+      Fr.fromHexString('0x12e9aa367b065eff3e48912b8cae62209970117d34a8c9ef1e9e4116e41bc8d6'),
+    );
+  });
+  it('has expected Genesis tree roots', async () => {
+    // initial accounts get initial fee juice added to their balance
+    const { genesisArchiveRoot } = await getGenesisValues(
+      /* initial accounts */ [],
+      /* initial fee juice */ Fr.ZERO,
+      /* initial public data leaves */ [],
+    );
+    expect(genesisArchiveRoot).toEqual(
+      Fr.fromHexString('0x1f9c798be7975bb34c3e605a4c92c75796eae7b9a08644bc9a6a55354ed470be'),
+    );
+  });
+});

--- a/yarn-project/bootstrap.sh
+++ b/yarn-project/bootstrap.sh
@@ -186,6 +186,7 @@ function test_cmds {
 
   if [[ "${TARGET_BRANCH:-}" =~ ^v[0-9]+$ ]]; then
     echo "$hash yarn-project/scripts/run_test.sh aztec/src/testnet_compatibility.test.ts"
+    echo "$hash yarn-project/scripts/run_test.sh aztec/src/mainnet_compatibility.test.ts"
   fi
 }
 


### PR DESCRIPTION
This has been sat in my stash for a long time. Ensure v2 remains mainnet-compatible