### PR TITLE
refactor!: Remove randomness from built-in note types

### DIFF
--- a/docs/docs/developers/docs/resources/migration_notes.md
+++ b/docs/docs/developers/docs/resources/migration_notes.md
@@ -13,9 +13,14 @@ Aztec is in full-speed development. Literally every version breaks compatibility
 
 In order to prevent pre-image attacks, it is necessary to inject randomness to notes. Aztec.nr users were previously expected to add said randomness to their custom note types. From now on, Aztec.nr takes care of handling randomness as built-in note metadata, making it impossible to miss for library users. This change breaks backwards compatibility as we'll discuss below.
 
-#### Changes to ValueNote, UintNote and NFTNote
+#### Changes to Aztec.nr note types
 
-If you're using `ValueNote`, `UintNote` or `NFTNote`, please be aware that `randomness` no longer is an explicit attribute in them.
+If you're using any of the following note types, please be aware that `randomness` no longer is an explicit attribute in them.
+
+- ValueNote
+- UintNote
+- NFTNote
+- AddressNote
 
 #### Migrating your custom note types: refer to UintNote as an example of how to migrate
 

--- a/noir-projects/aztec-nr/address-note/src/address_note.nr
+++ b/noir-projects/aztec-nr/address-note/src/address_note.nr
@@ -1,6 +1,5 @@
 use dep::aztec::{
     macros::notes::note,
-    oracle::random::random,
     protocol_types::{address::AztecAddress, traits::{Deserialize, Packable, Serialize}},
 };
 
@@ -9,17 +8,11 @@ use dep::aztec::{
 pub struct AddressNote {
     address: AztecAddress,
     owner: AztecAddress,
-    randomness: Field,
 }
 
 impl AddressNote {
     pub fn new(address: AztecAddress, owner: AztecAddress) -> Self {
-        // Safety: we use the randomness to preserve the privacy of the note recipient by preventing brute-forcing, so a
-        // malicious sender could use non-random values to make the note less private. But they already know the full
-        // note pre-image anyway, and so the recipient already trusts them to not disclose this information. We can
-        // therefore assume that the sender will cooperate in the random value generation.
-        let randomness = unsafe { random() };
-        AddressNote { address, owner, randomness }
+        AddressNote { address, owner }
     }
 
     pub fn get_address(self) -> AztecAddress {

--- a/noir-projects/aztec-nr/aztec/src/macros/notes.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/notes.nr
@@ -305,6 +305,6 @@ comptime fn assert_has_owner(note: TypeDefinition) {
 
     assert(
         has_owner,
-        f"{note_name} does not have an 'owner' field. If your notes have no owner, use #[custom_note] insteadof #[note] and implement the NoteHashing trait manually.",
+        f"{note_name} does not have an 'owner' field. If your notes have no owner, use #[custom_note] instead of #[note] and implement the NoteHashing trait manually.",
     );
 }

--- a/noir-projects/noir-contracts/contracts/app/app_subscription_contract/src/subscription_note.nr
+++ b/noir-projects/noir-contracts/contracts/app/app_subscription_contract/src/subscription_note.nr
@@ -1,8 +1,4 @@
-use aztec::{
-    macros::notes::note,
-    oracle::random::random,
-    protocol_types::{address::AztecAddress, traits::Packable},
-};
+use aztec::{macros::notes::note, protocol_types::{address::AztecAddress, traits::Packable}};
 
 #[derive(Eq, Packable)]
 #[note]
@@ -10,17 +6,10 @@ pub struct SubscriptionNote {
     owner: AztecAddress,
     pub expiry_block_number: u32,
     pub remaining_txs: u32,
-    // Randomness of the note to protect against note hash preimage attacks
-    randomness: Field,
 }
 
 impl SubscriptionNote {
     pub fn new(owner: AztecAddress, expiry_block_number: u32, remaining_txs: u32) -> Self {
-        // Safety: We use the randomness to preserve the privacy of the note recipient by preventing brute-forcing,
-        // so a malicious sender could use non-random values to make the note less private. But they already know
-        // the full note pre-image anyway, and so the recipient already trusts them to not disclose this
-        // information. We can therefore assume that the sender will cooperate in the random value generation.
-        let randomness = unsafe { random() };
-        Self { owner, expiry_block_number, remaining_txs, randomness }
+        Self { owner, expiry_block_number, remaining_txs }
     }
 }

--- a/noir-projects/noir-contracts/contracts/app/token_blacklist_contract/src/types/token_note.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_blacklist_contract/src/types/token_note.nr
@@ -1,8 +1,4 @@
-use aztec::{
-    macros::notes::note,
-    oracle::random::random,
-    protocol_types::{address::AztecAddress, traits::Packable},
-};
+use aztec::{macros::notes::note, protocol_types::{address::AztecAddress, traits::Packable}};
 
 pub trait OwnedNote {
     fn new(amount: u128, owner: AztecAddress) -> Self;
@@ -15,18 +11,11 @@ pub struct TokenNote {
     // The amount of tokens in the note
     amount: u128,
     owner: AztecAddress,
-    // Randomness of the note to protect against note hash preimage attacks
-    randomness: Field,
 }
 
 impl OwnedNote for TokenNote {
     fn new(amount: u128, owner: AztecAddress) -> Self {
-        // Safety: We use the randomness to preserve the privacy of the note recipient by preventing brute-forcing,
-        // so a malicious sender could use non-random values to make the note less private. But they already know
-        // the full note pre-image anyway, and so the recipient already trusts them to not disclose this
-        // information. We can therefore assume that the sender will cooperate in the random value generation.
-        let randomness = unsafe { random() };
-        Self { amount, owner, randomness }
+        Self { amount, owner }
     }
 
     fn get_amount(self) -> u128 {

--- a/noir-projects/noir-contracts/contracts/docs/docs_example_contract/src/options.nr
+++ b/noir-projects/noir-contracts/contracts/docs/docs_example_contract/src/options.nr
@@ -27,17 +27,17 @@ where
 
 pub fn create_exact_card_getter_options<let M: u32>(
     points: u8,
-    secret: Field,
     account: AztecAddress,
 ) -> NoteGetterOptions<CardNote, M, Field, Field>
 where
     CardNote: Packable<N = M>,
 {
     let mut options = NoteGetterOptions::new();
-    options
-        .select(CardNote::properties().points, Comparator.EQ, points as Field)
-        .select(CardNote::properties().randomness, Comparator.EQ, secret)
-        .select(CardNote::properties().owner, Comparator.EQ, account)
+    options.select(CardNote::properties().points, Comparator.EQ, points as Field).select(
+        CardNote::properties().owner,
+        Comparator.EQ,
+        account,
+    )
 }
 
 pub fn filter_min_points(

--- a/noir-projects/noir-contracts/contracts/docs/docs_example_contract/src/types/card_note.nr
+++ b/noir-projects/noir-contracts/contracts/docs/docs_example_contract/src/types/card_note.nr
@@ -1,6 +1,5 @@
 use aztec::{
     macros::notes::note,
-    oracle::random::random,
     protocol_types::{address::AztecAddress, traits::{Deserialize, Packable, Serialize}},
 };
 
@@ -11,19 +10,12 @@ use aztec::{
 #[note]
 pub struct CardNote {
     points: u8,
-    randomness: Field,
     owner: AztecAddress,
 }
 
 impl CardNote {
     pub fn new(points: u8, owner: AztecAddress) -> Self {
-        // Safety: We use the randomness to preserve the privacy of the note recipient by preventing brute-forcing,
-        // so a malicious sender could use non-random values to make the note less private. But they already know
-        // the full note pre-image anyway, and so the recipient already trusts them to not disclose this
-        // information. We can therefore assume that the sender will cooperate in the random value generation.
-        let randomness = unsafe { random() };
-
-        CardNote { points, randomness, owner }
+        CardNote { points, owner }
     }
 
     pub fn get_points(self) -> u8 {

--- a/noir-projects/noir-contracts/contracts/test/spam_contract/src/types/token_note.nr
+++ b/noir-projects/noir-contracts/contracts/test/spam_contract/src/types/token_note.nr
@@ -1,8 +1,4 @@
-use aztec::{
-    macros::notes::note,
-    oracle::random::random,
-    protocol_types::{address::AztecAddress, traits::Packable},
-};
+use aztec::{macros::notes::note, protocol_types::{address::AztecAddress, traits::Packable}};
 
 pub trait OwnedNote {
     fn new(amount: u128, owner: AztecAddress) -> Self;
@@ -15,18 +11,11 @@ pub struct TokenNote {
     amount: u128,
     // The owner of the note
     owner: AztecAddress,
-    // Randomness of the note to protect against note hash preimage attacks
-    randomness: Field,
 }
 
 impl OwnedNote for TokenNote {
     fn new(amount: u128, owner: AztecAddress) -> Self {
-        // Safety: We use the randomness to preserve the privacy of the note recipient by preventing brute-forcing,
-        // so a malicious sender could use non-random values to make the note less private. But they already know
-        // the full note pre-image anyway, and so the recipient already trusts them to not disclose this
-        // information. We can therefore assume that the sender will cooperate in the random value generation.
-        let randomness = unsafe { random() };
-        Self { amount, owner, randomness }
+        Self { amount, owner }
     }
 
     fn get_amount(self) -> u128 {


### PR DESCRIPTION
We missed some note types when we enshrined randomness (#18471). This PR addresses that omission.

Closes F-177. 