### PR TITLE
chore(avm): align some errors between C++ and TS simulators

### DIFF
--- a/barretenberg/cpp/src/barretenberg/vm2/common/tagged_value.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/common/tagged_value.cpp
@@ -277,7 +277,9 @@ TaggedValue TaggedValue::from_tag_truncating(ValueTag tag, FF value)
     case ValueTag::FF:
         return TaggedValue(value);
     default:
-        throw std::runtime_error("Invalid tag");
+        const auto msg =
+            format("Tag check failed: Tag value: " + std::to_string(static_cast<uint8_t>(tag)), " is invalid.");
+        throw std::runtime_error(msg);
     }
 }
 
@@ -414,7 +416,7 @@ std::string std::to_string(bb::avm2::ValueTag tag)
     case ValueTag::U128:
         return "U128";
     case ValueTag::FF:
-        return "FF";
+        return "FIELD";
     default:
         return "Unknown";
     }

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/relations/instr_fetching.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/relations/instr_fetching.test.cpp
@@ -33,7 +33,7 @@ using C = Column;
 using instr_fetching = instr_fetching<FF>;
 
 using simulation::BytecodeDecompositionEvent;
-using simulation::InstrDeserializationError;
+using simulation::InstrDeserializationEventError;
 using simulation::Instruction;
 using simulation::InstructionFetchingEvent;
 using simulation::Operand;
@@ -223,9 +223,10 @@ std::vector<RangeCheckEvent> gen_range_check_events(const std::vector<Instructio
 
     for (const auto& instr_event : instr_events) {
         range_check_events.emplace_back(RangeCheckEvent{
-            .value = instr_event.error == InstrDeserializationError::PC_OUT_OF_RANGE
-                         ? instr_event.pc - instr_event.bytecode->size()
-                         : instr_event.bytecode->size() - instr_event.pc - 1,
+            .value =
+                (instr_event.error.has_value() && instr_event.error == InstrDeserializationEventError::PC_OUT_OF_RANGE)
+                    ? instr_event.pc - instr_event.bytecode->size()
+                    : instr_event.bytecode->size() - instr_event.pc - 1,
             .num_bits = AVM_PC_SIZE_IN_BITS,
         });
     }
@@ -376,7 +377,7 @@ TEST(InstrFetchingConstrainingTest, SingleInstructionOutOfRange)
             .bytecode_id = 1,
             .pc = 0,
             .bytecode = bytecode_ptr,
-            .error = InstrDeserializationError::INSTRUCTION_OUT_OF_RANGE,
+            .error = InstrDeserializationEventError::INSTRUCTION_OUT_OF_RANGE,
         },
     };
 
@@ -413,7 +414,7 @@ TEST(InstrFetchingConstrainingTest, SingleInstructionOutOfRangeSplitOperand)
             .bytecode_id = 1,
             .pc = 0,
             .bytecode = bytecode_ptr,
-            .error = InstrDeserializationError::INSTRUCTION_OUT_OF_RANGE,
+            .error = InstrDeserializationEventError::INSTRUCTION_OUT_OF_RANGE,
         },
     };
 
@@ -451,7 +452,7 @@ TEST(InstrFetchingConstrainingTest, SingleInstructionPcOutOfRange)
             .bytecode_id = 1,
             .pc = static_cast<uint32_t>(bytecode_ptr->size() + 1),
             .bytecode = bytecode_ptr,
-            .error = InstrDeserializationError::PC_OUT_OF_RANGE,
+            .error = InstrDeserializationEventError::PC_OUT_OF_RANGE,
         },
     };
 
@@ -492,7 +493,7 @@ TEST(InstrFetchingConstrainingTest, SingleInstructionOpcodeOutOfRange)
             .bytecode_id = 1,
             .pc = 5, // We move pc to the beginning of the 128-bit immediate value.
             .bytecode = bytecode_ptr,
-            .error = InstrDeserializationError::OPCODE_OUT_OF_RANGE,
+            .error = InstrDeserializationEventError::OPCODE_OUT_OF_RANGE,
         },
     };
 
@@ -526,7 +527,7 @@ TEST(InstrFetchingConstrainingTest, SingleInstructionTagOutOfRange)
             .pc = 0,
             .instruction = set_16_instruction,
             .bytecode = bytecode_ptr,
-            .error = InstrDeserializationError::TAG_OUT_OF_RANGE,
+            .error = InstrDeserializationEventError::TAG_OUT_OF_RANGE,
         },
     };
 

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/events/addressing_event.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/events/addressing_event.hpp
@@ -36,8 +36,8 @@ inline std::string to_string(AddressingEventError e)
 }
 
 struct AddressingException : public std::runtime_error {
-    explicit AddressingException()
-        : std::runtime_error("Error resolving operands.")
+    explicit AddressingException(const std::string& message = "Error resolving operands.")
+        : std::runtime_error(message)
     {}
 };
 

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/events/bytecode_events.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/events/bytecode_events.hpp
@@ -47,7 +47,7 @@ struct InstructionFetchingEvent {
     // TODO: Do we want to have a dep on Instruction here or do we redefine what we need?
     Instruction instruction;
     std::shared_ptr<std::vector<uint8_t>> bytecode;
-    std::optional<InstrDeserializationError> error;
+    std::optional<InstrDeserializationEventError> error;
 
     // To be used with deduplicating event emitters.
     using Key = std::tuple<BytecodeId, uint32_t>;

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/bytecode_manager.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/bytecode_manager.cpp
@@ -121,15 +121,18 @@ Instruction TxBytecodeManager::read_instruction(const BytecodeId& bytecode_id,
     const auto& bytecode = *bytecode_ptr;
     instr_fetching_event.bytecode = std::move(bytecode_ptr);
 
+    // Keep full error for exception message, but only store enum in event
+    std::optional<InstrDeserializationError> deserialization_error;
+
     try {
         instr_fetching_event.instruction = deserialize_instruction(bytecode, pc);
 
         // If the following code is executed, no error was thrown in deserialize_instruction().
         if (!check_tag(instr_fetching_event.instruction)) {
-            instr_fetching_event.error = InstrDeserializationError::TAG_OUT_OF_RANGE;
+            instr_fetching_event.error = InstrDeserializationEventError::TAG_OUT_OF_RANGE;
         };
     } catch (const InstrDeserializationError& error) {
-        instr_fetching_event.error = error;
+        instr_fetching_event.error = error.type;
     }
 
     // We are showing whether bytecode_size > pc or not. If there is no fetching error,

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/emit_unencrypted_log.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/emit_unencrypted_log.cpp
@@ -71,7 +71,7 @@ void EmitUnencryptedLog::emit_unencrypted_log(MemoryInterface& memory,
         throw EmitUnencryptedLogException("Tag mismatch");
     }
     if (error_is_static) {
-        throw EmitUnencryptedLogException("Static context");
+        throw EmitUnencryptedLogException("Static call cannot update the state.");
     }
 }
 

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/execution.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/execution.cpp
@@ -75,7 +75,7 @@ void Execution::add(ContextInterface& context, MemoryAddress a_addr, MemoryAddre
         memory.set(dst_addr, c);
         set_output(opcode, c);
     } catch (AluException& e) {
-        throw OpcodeExecutionException("Alu add operation failed");
+        throw OpcodeExecutionException("Alu add operation failed: " + std::string(e.what()));
     }
 }
 
@@ -115,7 +115,7 @@ void Execution::mul(ContextInterface& context, MemoryAddress a_addr, MemoryAddre
         memory.set(dst_addr, c);
         set_output(opcode, c);
     } catch (AluException& e) {
-        throw OpcodeExecutionException("Alu mul operation failed");
+        throw OpcodeExecutionException("Alu mul operation failed: " + std::string(e.what()));
     }
 }
 
@@ -135,7 +135,7 @@ void Execution::div(ContextInterface& context, MemoryAddress a_addr, MemoryAddre
         memory.set(dst_addr, c);
         set_output(opcode, c);
     } catch (AluException& e) {
-        throw OpcodeExecutionException("Alu div operation failed");
+        throw OpcodeExecutionException("Alu div operation failed: " + std::string(e.what()));
     }
 }
 
@@ -155,7 +155,7 @@ void Execution::fdiv(ContextInterface& context, MemoryAddress a_addr, MemoryAddr
         memory.set(dst_addr, c);
         set_output(opcode, c);
     } catch (AluException& e) {
-        throw OpcodeExecutionException("Alu fdiv operation failed");
+        throw OpcodeExecutionException("Alu fdiv operation failed: " + std::string(e.what()));
     }
 }
 
@@ -175,7 +175,7 @@ void Execution::eq(ContextInterface& context, MemoryAddress a_addr, MemoryAddres
         memory.set(dst_addr, c);
         set_output(opcode, c);
     } catch (AluException& e) {
-        throw OpcodeExecutionException("Alu eq operation failed");
+        throw OpcodeExecutionException("Alu eq operation failed: " + std::string(e.what()));
     }
 }
 
@@ -195,7 +195,7 @@ void Execution::lt(ContextInterface& context, MemoryAddress a_addr, MemoryAddres
         memory.set(dst_addr, c);
         set_output(opcode, c);
     } catch (AluException& e) {
-        throw OpcodeExecutionException("Alu lt operation failed");
+        throw OpcodeExecutionException("Alu lt operation failed: " + std::string(e.what()));
     }
 }
 
@@ -215,7 +215,7 @@ void Execution::lte(ContextInterface& context, MemoryAddress a_addr, MemoryAddre
         memory.set(dst_addr, c);
         set_output(opcode, c);
     } catch (AluException& e) {
-        throw OpcodeExecutionException("Alu lte operation failed");
+        throw OpcodeExecutionException("Alu lte operation failed: " + std::string(e.what()));
     }
 }
 
@@ -234,7 +234,7 @@ void Execution::op_not(ContextInterface& context, MemoryAddress src_addr, Memory
         memory.set(dst_addr, b);
         set_output(opcode, b);
     } catch (AluException& e) {
-        throw OpcodeExecutionException("Alu not operation failed");
+        throw OpcodeExecutionException("Alu not operation failed: " + std::string(e.what()));
     }
 }
 
@@ -660,7 +660,7 @@ void Execution::and_op(ContextInterface& context, MemoryAddress a_addr, MemoryAd
         memory.set(dst_addr, c);
         set_output(opcode, c);
     } catch (const BitwiseException& e) {
-        throw OpcodeExecutionException("Bitwise AND Exeception");
+        throw OpcodeExecutionException("Bitwise AND Exeception: " + std::string(e.what()));
     }
 }
 
@@ -682,7 +682,7 @@ void Execution::or_op(ContextInterface& context, MemoryAddress a_addr, MemoryAdd
         memory.set(dst_addr, c);
         set_output(opcode, c);
     } catch (const BitwiseException& e) {
-        throw OpcodeExecutionException("Bitwise OR Exception");
+        throw OpcodeExecutionException("Bitwise OR Exception: " + std::string(e.what()));
     }
 }
 
@@ -704,7 +704,7 @@ void Execution::xor_op(ContextInterface& context, MemoryAddress a_addr, MemoryAd
         memory.set(dst_addr, c);
         set_output(opcode, c);
     } catch (const BitwiseException& e) {
-        throw OpcodeExecutionException("Bitwise XOR Exception");
+        throw OpcodeExecutionException("Bitwise XOR Exception: " + std::string(e.what()));
     }
 }
 
@@ -742,7 +742,8 @@ void Execution::sstore(ContextInterface& context, MemoryAddress src_addr, Memory
     get_gas_tracker().consume_gas({ .l2_gas = 0, .da_gas = da_gas_factor });
 
     if (context.get_is_static()) {
-        throw OpcodeExecutionException("SSTORE: Cannot write to storage in static context");
+        throw OpcodeExecutionException(
+            "SSTORE: Static call cannot update the state. Cannot write to storage in static context");
     }
 
     if (!was_slot_written_before &&
@@ -822,7 +823,8 @@ void Execution::emit_nullifier(ContextInterface& context, MemoryAddress nullifie
     get_gas_tracker().consume_gas();
 
     if (context.get_is_static()) {
-        throw OpcodeExecutionException("EMITNULLIFIER: Cannot emit nullifier in static context");
+        throw OpcodeExecutionException(
+            "EMITNULLIFIER: Static call cannot update the state. Cannot emit nullifier in static context");
     }
 
     if (merkle_db.get_tree_state().nullifier_tree.counter == MAX_NULLIFIERS_PER_TX) {
@@ -858,7 +860,7 @@ void Execution::get_contract_instance(ContextInterface& context,
     try {
         get_contract_instance_component.get_contract_instance(memory, contract_address, dst_offset, member_enum);
     } catch (const GetContractInstanceException& e) {
-        throw OpcodeExecutionException("GetContractInstance Exception");
+        throw OpcodeExecutionException("GetContractInstance Exception: " + std::string(e.what()));
     }
 
     // No `set_output` here since the dedicated component handles memory writes.
@@ -876,7 +878,8 @@ void Execution::emit_note_hash(ContextInterface& context, MemoryAddress note_has
     get_gas_tracker().consume_gas();
 
     if (context.get_is_static()) {
-        throw OpcodeExecutionException("EMITNOTEHASH: Cannot emit note hash in static context");
+        throw OpcodeExecutionException(
+            "EMITNOTEHASH: Static call cannot update the state. Cannot emit note hash in static context");
     }
 
     if (merkle_db.get_tree_state().note_hash_tree.counter == MAX_NOTE_HASHES_PER_TX) {
@@ -1041,7 +1044,7 @@ void Execution::emit_unencrypted_log(ContextInterface& context, MemoryAddress lo
         emit_unencrypted_log_component.emit_unencrypted_log(
             memory, context, context.get_address(), log_offset, log_size_int);
     } catch (const EmitUnencryptedLogException& e) {
-        throw OpcodeExecutionException("EmitUnencryptedLog Exception");
+        throw OpcodeExecutionException("EmitUnencryptedLog Exception: " + std::string(e.what()));
     }
 }
 
@@ -1058,7 +1061,8 @@ void Execution::send_l2_to_l1_msg(ContextInterface& context, MemoryAddress recip
     get_gas_tracker().consume_gas();
 
     if (context.get_is_static()) {
-        throw OpcodeExecutionException("SENDL2TOL1MSG: Cannot send L2 to L1 message in static context");
+        throw OpcodeExecutionException(
+            "SENDL2TOL1MSG: Static call cannot update the state. Cannot send L2 to L1 message in static context");
     }
 
     auto& side_effect_tracker = context.get_side_effect_tracker();

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/execution.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/execution.test.cpp
@@ -670,8 +670,7 @@ TEST_F(ExecutionSimulationTest, SStoreDuringStaticCall)
     EXPECT_CALL(gas_tracker, consume_gas(Gas{ 0, 1 }));
 
     EXPECT_CALL(context, get_is_static).WillOnce(Return(true));
-    EXPECT_THROW_WITH_MESSAGE(execution.sstore(context, value_addr, slot_addr),
-                              "SSTORE: Cannot write to storage in static context");
+    EXPECT_THROW_WITH_MESSAGE(execution.sstore(context, value_addr, slot_addr), "Static call cannot update the state");
 }
 
 TEST_F(ExecutionSimulationTest, SStoreLimitReached)
@@ -805,8 +804,7 @@ TEST_F(ExecutionSimulationTest, EmitNoteHashDuringStaticCall)
     EXPECT_CALL(gas_tracker, consume_gas(Gas{ 0, 0 }));
 
     EXPECT_CALL(context, get_is_static).WillOnce(Return(true));
-    EXPECT_THROW_WITH_MESSAGE(execution.emit_note_hash(context, note_hash_addr),
-                              "EMITNOTEHASH: Cannot emit note hash in static context");
+    EXPECT_THROW_WITH_MESSAGE(execution.emit_note_hash(context, note_hash_addr), "Static call cannot update the state");
 }
 
 TEST_F(ExecutionSimulationTest, EmitNoteHashLimitReached)
@@ -934,8 +932,7 @@ TEST_F(ExecutionSimulationTest, EmitNullifierDuringStaticCall)
     EXPECT_CALL(gas_tracker, consume_gas(Gas{ 0, 0 }));
 
     EXPECT_CALL(context, get_is_static).WillOnce(Return(true));
-    EXPECT_THROW_WITH_MESSAGE(execution.emit_nullifier(context, nullifier_addr),
-                              "EMITNULLIFIER: Cannot emit nullifier in static context");
+    EXPECT_THROW_WITH_MESSAGE(execution.emit_nullifier(context, nullifier_addr), "Static call cannot update the state");
 }
 
 TEST_F(ExecutionSimulationTest, EmitNullifierLimitReached)
@@ -1172,7 +1169,7 @@ TEST_F(ExecutionSimulationTest, SendL2ToL1MsgStaticCall)
     EXPECT_CALL(context, get_is_static).WillOnce(Return(true));
 
     EXPECT_THROW_WITH_MESSAGE(execution.send_l2_to_l1_msg(context, recipient_addr, content_addr),
-                              "SENDL2TOL1MSG: Cannot send L2 to L1 message in static context");
+                              "Static call cannot update the state");
 }
 
 TEST_F(ExecutionSimulationTest, SendL2ToL1MsgLimitReached)

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/lib/serialization.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/lib/serialization.cpp
@@ -10,6 +10,7 @@
 #include <variant>
 #include <vector>
 
+#include "barretenberg/common/log.hpp"
 #include "barretenberg/common/serialize.hpp"
 #include "barretenberg/numeric/uint256/uint256.hpp"
 #include "barretenberg/vm2/common/addressing.hpp"
@@ -233,15 +234,23 @@ Instruction deserialize_instruction(std::span<const uint8_t> bytecode, size_t po
     const auto bytecode_length = bytecode.size();
 
     if (pos >= bytecode_length) {
-        vinfo("PC is out of range. Position: ", pos, " Bytecode length: ", bytecode_length);
-        throw InstrDeserializationError::PC_OUT_OF_RANGE;
+        std::string error_msg = format("Invalid program counter ", pos, ", max is ", bytecode_length - 1);
+        vinfo(error_msg);
+        throw InstrDeserializationError(InstrDeserializationEventError::PC_OUT_OF_RANGE, error_msg);
     }
 
     const uint8_t opcode_byte = bytecode[pos];
 
     if (!is_wire_opcode_valid(opcode_byte)) {
-        vinfo("Invalid wire opcode byte: 0x", to_hex(opcode_byte), " at position: ", pos);
-        throw InstrDeserializationError::OPCODE_OUT_OF_RANGE;
+        std::string error_msg = format("Opcode ",
+                                       static_cast<uint32_t>(opcode_byte),
+                                       " (0x",
+                                       to_hex(opcode_byte),
+                                       ") value is not in the range of valid opcodes (at PC ",
+                                       pos,
+                                       ").");
+        vinfo(error_msg);
+        throw InstrDeserializationError(InstrDeserializationEventError::OPCODE_OUT_OF_RANGE, error_msg);
     }
 
     const auto opcode = static_cast<WireOpCode>(opcode_byte);
@@ -254,15 +263,15 @@ Instruction deserialize_instruction(std::span<const uint8_t> bytecode, size_t po
     // We know we will encounter a parsing error, but continue processing because
     // we need the partial instruction to be parsed for witness generation.
     if (pos + instruction_size > bytecode_length) {
-        vinfo("Instruction does not fit in remaining bytecode. Wire opcode: ",
-              opcode,
-              " pos: ",
-              pos,
-              " instruction size: ",
-              instruction_size,
-              " bytecode length: ",
-              bytecode_length);
-        throw InstrDeserializationError::INSTRUCTION_OUT_OF_RANGE;
+        std::string error_msg = format("Instruction at PC ",
+                                       pos,
+                                       " does not fit in bytecode (instruction size: ",
+                                       instruction_size,
+                                       ", remaining: ",
+                                       bytecode_length - pos,
+                                       ")");
+        vinfo(error_msg);
+        throw InstrDeserializationError(InstrDeserializationEventError::INSTRUCTION_OUT_OF_RANGE, error_msg);
     }
 
     pos++; // move after opcode byte

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/lib/serialization.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/lib/serialization.hpp
@@ -8,6 +8,8 @@
 
 #include <cstdint>
 #include <memory>
+#include <optional>
+#include <string>
 #include <variant>
 #include <vector>
 
@@ -47,7 +49,7 @@ struct Instruction {
     bool operator==(const Instruction& other) const = default;
 };
 
-enum class InstrDeserializationError : uint8_t {
+enum class InstrDeserializationEventError : uint8_t {
     PC_OUT_OF_RANGE,
     OPCODE_OUT_OF_RANGE,
     INSTRUCTION_OUT_OF_RANGE,
@@ -55,6 +57,25 @@ enum class InstrDeserializationError : uint8_t {
     // FIXME: remove this once all execution opcodes are supported.
     // Also uncomment proper constraining of error in instr_fetching.pil.
     INVALID_EXECUTION_OPCODE,
+};
+
+struct InstrDeserializationError {
+    InstrDeserializationEventError type;
+    std::optional<std::string> message;
+
+    // Constructor from error type only
+    InstrDeserializationError(InstrDeserializationEventError t)
+        : type(t)
+        , message(std::nullopt)
+    {}
+
+    // Constructor with error type and message
+    InstrDeserializationError(InstrDeserializationEventError t, const std::string& msg)
+        : type(t)
+        , message(msg)
+    {}
+
+    bool operator==(const InstrDeserializationError& other) const = default;
 };
 
 /**

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/lib/serialization.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/lib/serialization.test.cpp
@@ -10,6 +10,7 @@ namespace {
 using simulation::check_tag;
 using simulation::deserialize_instruction;
 using simulation::InstrDeserializationError;
+using simulation::InstrDeserializationEventError;
 using simulation::Instruction;
 using simulation::Operand;
 
@@ -119,7 +120,8 @@ TEST(SerializationTest, PCOutOfRange)
     try {
         deserialize_instruction(bytecode, bytecode.size() + 1);
     } catch (const InstrDeserializationError& error) {
-        EXPECT_EQ(error, InstrDeserializationError::PC_OUT_OF_RANGE);
+        EXPECT_EQ(error.type, InstrDeserializationEventError::PC_OUT_OF_RANGE);
+        EXPECT_TRUE(error.message.has_value());
     }
 }
 
@@ -132,7 +134,8 @@ TEST(SerializationTest, OpcodeOutOfRange)
     try {
         deserialize_instruction(bytecode, 0);
     } catch (const InstrDeserializationError& error) {
-        EXPECT_EQ(error, InstrDeserializationError::OPCODE_OUT_OF_RANGE);
+        EXPECT_EQ(error.type, InstrDeserializationEventError::OPCODE_OUT_OF_RANGE);
+        EXPECT_TRUE(error.message.has_value());
     }
 }
 
@@ -154,7 +157,8 @@ TEST(SerializationTest, InstructionOutOfRange)
     try {
         deserialize_instruction(bytecode, 0);
     } catch (const InstrDeserializationError& error) {
-        EXPECT_EQ(error, InstrDeserializationError::INSTRUCTION_OUT_OF_RANGE);
+        EXPECT_EQ(error.type, InstrDeserializationEventError::INSTRUCTION_OUT_OF_RANGE);
+        EXPECT_TRUE(error.message.has_value());
     }
 }
 

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/standalone/concrete_dbs.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/standalone/concrete_dbs.cpp
@@ -127,7 +127,13 @@ void PureMerkleDB::nullifier_write_internal(std::optional<AztecAddress> contract
         raw_merkle_db.get_low_indexed_leaf(MerkleTreeId::NULLIFIER_TREE, siloed_nullifier);
 
     if (present) {
-        throw NullifierCollisionException(format("Nullifier ", nullifier, " already exists"));
+        throw NullifierCollisionException(
+            contract_address.has_value() ? format("Attempted to emit duplicate nullifier ",
+                                                  nullifier,
+                                                  " (contract address: ",
+                                                  contract_address.value(),
+                                                  ").")
+                                         : format("Attempted to emit duplicate siloed nullifier ", nullifier, "."));
     }
 
     raw_merkle_db.insert_indexed_leaves_nullifier_tree(siloed_nullifier);

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/standalone/pure_addressing.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/standalone/pure_addressing.cpp
@@ -44,14 +44,20 @@ std::vector<Operand> PureAddressing::resolve(const Instruction& instruction, Mem
             if (!base_address) {
                 MemoryValue maybe_base_address = memory.get(0);
                 if (!memory.is_valid_address(maybe_base_address)) {
-                    throw AddressingException();
+                    throw AddressingException(
+                        format("Addressing error: Base address (mem[0]) is not a valid address (has tag ",
+                               std::to_string(maybe_base_address.get_tag()),
+                               ")"));
                 }
                 base_address = maybe_base_address.as<MemoryAddress>();
             }
-            uint64_t offset = operand.as<MemoryAddress>();
-            offset += *base_address;
+            const uint64_t rel_offset = operand.as<MemoryAddress>();
+            const uint64_t offset = rel_offset + *base_address;
             if (offset > AVM_HIGHEST_MEM_ADDRESS) {
-                throw AddressingException();
+                throw AddressingException(format("Addressing error: Relative address out of range. Base address ",
+                                                 *base_address,
+                                                 ", relative offset ",
+                                                 rel_offset));
             }
             operand = Operand::from(static_cast<MemoryAddress>(offset));
         }
@@ -60,7 +66,12 @@ std::vector<Operand> PureAddressing::resolve(const Instruction& instruction, Mem
         if (is_operand_indirect(instruction.indirect, i)) {
             const MemoryValue& indirect_value = memory.get(operand.as<MemoryAddress>());
             if (!memory.is_valid_address(indirect_value)) {
-                throw AddressingException();
+                throw AddressingException(
+                    format("Addressing error: Address after indirection is not a valid address (address ",
+                           operand.to_string(),
+                           ") has tag ",
+                           std::to_string(indirect_value.get_tag()),
+                           ")"));
             }
             operand = indirect_value;
         }

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/standalone/pure_bytecode_manager.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/standalone/pure_bytecode_manager.cpp
@@ -115,12 +115,17 @@ Instruction PureTxBytecodeManager::read_instruction(const BytecodeId&,
     try {
         instruction = deserialize_instruction(bytecode, pc);
     } catch (const InstrDeserializationError& error) {
-        throw InstructionFetchingError("Instruction fetching error: " + std::to_string(static_cast<int>(error)));
+        std::string error_msg = format("Instruction fetching error at pc ", pc);
+        if (error.message.has_value()) {
+            error_msg = format(error_msg, ": ", error.message.value());
+        }
+        throw InstructionFetchingError(error_msg);
     }
 
     // If the following code is executed, no error was thrown in deserialize_instruction().
     if (!check_tag(instruction)) {
-        throw InstructionFetchingError("Tag check failed");
+        std::string error_msg = format("Instruction fetching error at pc ", pc, ": Tag check failed");
+        throw InstructionFetchingError(error_msg);
     };
 
     // Save the instruction to the cache.

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/bytecode_trace.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/bytecode_trace.cpp
@@ -270,10 +270,10 @@ void BytecodeTraceBuilder::process_instruction_fetching(
 {
     using C = Column;
     using simulation::InstructionFetchingEvent;
-    using simulation::InstrDeserializationError::INSTRUCTION_OUT_OF_RANGE;
-    using simulation::InstrDeserializationError::OPCODE_OUT_OF_RANGE;
-    using simulation::InstrDeserializationError::PC_OUT_OF_RANGE;
-    using simulation::InstrDeserializationError::TAG_OUT_OF_RANGE;
+    using simulation::InstrDeserializationEventError::INSTRUCTION_OUT_OF_RANGE;
+    using simulation::InstrDeserializationEventError::OPCODE_OUT_OF_RANGE;
+    using simulation::InstrDeserializationEventError::PC_OUT_OF_RANGE;
+    using simulation::InstrDeserializationEventError::TAG_OUT_OF_RANGE;
 
     // We start from row 1 because we need a row of zeroes for the shifts.
     uint32_t row = 1;

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/bytecode_trace.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/bytecode_trace.test.cpp
@@ -606,19 +606,19 @@ TEST(BytecodeTraceGenTest, InstrFetchingParsingErrors)
         .bytecode_id = bytecode_id,
         .pc = 0,
         .bytecode = bytecode_ptr,
-        .error = simulation::InstrDeserializationError::OPCODE_OUT_OF_RANGE,
+        .error = simulation::InstrDeserializationEventError::OPCODE_OUT_OF_RANGE,
     });
     events.emplace_back(InstructionFetchingEvent{
         .bytecode_id = bytecode_id,
         .pc = 19,
         .bytecode = bytecode_ptr,
-        .error = simulation::InstrDeserializationError::INSTRUCTION_OUT_OF_RANGE,
+        .error = simulation::InstrDeserializationEventError::INSTRUCTION_OUT_OF_RANGE,
     });
     events.emplace_back(InstructionFetchingEvent{
         .bytecode_id = bytecode_id,
         .pc = 38,
         .bytecode = bytecode_ptr,
-        .error = simulation::InstrDeserializationError::PC_OUT_OF_RANGE,
+        .error = simulation::InstrDeserializationEventError::PC_OUT_OF_RANGE,
     });
 
     builder.process_instruction_fetching(events, trace);
@@ -697,7 +697,7 @@ TEST(BytecodeTraceGenTest, InstrFetchingErrorTagOutOfRange)
         .pc = 0,
         .instruction = deserialize_instruction(bytecode, 0), // Reflect more the real code path than passing instr_cast.
         .bytecode = bytecode_ptr,
-        .error = simulation::InstrDeserializationError::TAG_OUT_OF_RANGE,
+        .error = simulation::InstrDeserializationEventError::TAG_OUT_OF_RANGE,
     });
 
     events.emplace_back(InstructionFetchingEvent{
@@ -706,7 +706,7 @@ TEST(BytecodeTraceGenTest, InstrFetchingErrorTagOutOfRange)
         .instruction =
             deserialize_instruction(bytecode, cast_size), // Reflect more the real code path than passing instr_set.
         .bytecode = bytecode_ptr,
-        .error = simulation::InstrDeserializationError::TAG_OUT_OF_RANGE,
+        .error = simulation::InstrDeserializationEventError::TAG_OUT_OF_RANGE,
     });
 
     builder.process_instruction_fetching(events, trace);

--- a/yarn-project/end-to-end/src/e2e_fees/failures.test.ts
+++ b/yarn-project/end-to-end/src/e2e_fees/failures.test.ts
@@ -234,7 +234,7 @@ describe('e2e_fees failures', () => {
             paymentMethod: new BuggedSetupFeePaymentMethod(bananaFPC.address, aliceAddress, wallet, gasSettings),
           },
         }),
-    ).rejects.toThrow(/Setup phase reverted/);
+    ).rejects.toThrow(/\[SETUP\] UNRECOVERABLE ERROR/);
 
     // so does the sequencer
     await expect(

--- a/yarn-project/end-to-end/src/e2e_private_voting_contract.test.ts
+++ b/yarn-project/end-to-end/src/e2e_private_voting_contract.test.ts
@@ -41,7 +41,7 @@ describe('e2e_voting_contract', () => {
       // We try voting again, but our TX is dropped due to trying to emit duplicate nullifiers
       // first confirm that it fails simulation
       await expect(votingContract.methods.cast_vote(candidate).simulate({ from: owner })).rejects.toThrow(
-        /Nullifier collision/,
+        /Nullifier collision|duplicate.*nullifier/,
       );
       // if we skip simulation, tx fails
       await expect(votingContract.methods.cast_vote(candidate).send({ from: owner }).wait()).rejects.toThrow(

--- a/yarn-project/end-to-end/src/fixtures/fixtures.ts
+++ b/yarn-project/end-to-end/src/fixtures/fixtures.ts
@@ -22,8 +22,7 @@ export const BITSIZE_TOO_BIG_ERROR = "Assertion failed: call to assert_max_bit_s
 export const DUPLICATE_NULLIFIER_ERROR = /dropped|nullifier|reverted/i;
 export const NO_L1_TO_L2_MSG_ERROR =
   /No non-nullified L1 to L2 message found for message hash|Tried to consume nonexistent L1-to-L2 message/;
-export const STATIC_CALL_STATE_MODIFICATION_ERROR =
-  /Static call cannot update the state, emit L2->L1 messages or generate logs.*/;
+export const STATIC_CALL_STATE_MODIFICATION_ERROR = /Static call cannot update the state.*/;
 export const STATIC_CONTEXT_ASSERTION_ERROR = /Assertion failed: Function .* can only be called statically.*/;
 
 export const DEFAULT_BLOB_SINK_PORT = '5052';

--- a/yarn-project/simulator/src/public/avm/errors.ts
+++ b/yarn-project/simulator/src/public/avm/errors.ts
@@ -58,7 +58,7 @@ export class AvmParsingError extends AvmExecutionError {
  */
 export class InvalidTagValueError extends AvmExecutionError {
   constructor(tagValue: number) {
-    super(`Tag value ${tagValue} is invalid.`);
+    super(`Tag check failed: Tag value ${tagValue} is invalid.`);
     this.name = 'InvalidTagValueError';
   }
 }
@@ -77,6 +77,12 @@ export class InstructionExecutionError extends AvmExecutionError {
  * Error thrown on failed AVM memory tag check.
  */
 export class TagCheckError extends AvmExecutionError {
+  public static forBaseAddress(gotTag: string): TagCheckError {
+    return new TagCheckError(`Base address (mem[0]) is not a valid address (has tag ${gotTag})`);
+  }
+  public static forIndirectAddress(address: number, gotTag: string): TagCheckError {
+    return new TagCheckError(`Address after indirection is not a valid address (address ${address} has tag ${gotTag})`);
+  }
   public static forOffset(offset: number, gotTag: string, expectedTag: string): TagCheckError {
     return new TagCheckError(`Tag mismatch at offset ${offset}, got ${gotTag}, expected ${expectedTag}`);
   }
@@ -97,7 +103,7 @@ export class TagCheckError extends AvmExecutionError {
  */
 export class RelativeAddressOutOfRangeError extends AvmExecutionError {
   constructor(baseAddr: number, relOffset: number) {
-    super(`Address out of range. Base address ${baseAddr}, relative offset ${relOffset}`);
+    super(`Relative address out of range. Base address ${baseAddr}, relative offset ${relOffset}`);
     this.name = 'RelativeAddressOutOfRangeError';
   }
 }
@@ -160,4 +166,12 @@ export class AvmRevertReason extends ExecutionError {
   constructor(message: string, failingFunction: FailingFunction, noirCallStack: NoirCallStack, options?: ErrorOptions) {
     super(message, failingFunction, noirCallStack, options);
   }
+}
+
+/**
+ * Helper to annotate errors occurring during instruction fetching.
+ */
+export function duringInstrFetch(error: Error, pc: number) {
+  error.message = `Instruction fetching error at pc ${pc}: ${error.message}`;
+  return error;
 }

--- a/yarn-project/simulator/src/public/avm/opcodes/addressing_mode.ts
+++ b/yarn-project/simulator/src/public/avm/opcodes/addressing_mode.ts
@@ -83,7 +83,7 @@ export class Addressing {
           baseAddr = mem.get(0);
           const baseAddrTag = baseAddr.getTag();
           if (!TaggedMemory.isValidMemoryAddressTag(baseAddrTag!)) {
-            throw TagCheckError.forOffset(0, TypeTag[baseAddrTag!], TypeTag[TypeTag.UINT32]);
+            throw TagCheckError.forBaseAddress(TypeTag[baseAddrTag!]);
           }
         }
         // Here we know that resolved[i] is at most 32 bits and baseAddr is at most 32 bits.
@@ -100,7 +100,7 @@ export class Addressing {
 
         // Final check.
         if (!TaggedMemory.isValidMemoryAddressTag(resolvedTag)) {
-          throw TagCheckError.forOffset(resolved[i], TypeTag[resolvedTag], TypeTag[TypeTag.UINT32]);
+          throw TagCheckError.forIndirectAddress(resolved[i], TypeTag[resolvedTag]);
         }
 
         resolved[i] = Number(resolvedValue.toBigInt());

--- a/yarn-project/simulator/src/public/avm/serialization/bytecode_serialization.ts
+++ b/yarn-project/simulator/src/public/avm/serialization/bytecode_serialization.ts
@@ -1,6 +1,13 @@
 import { type Bufferable, serializeToBuffer } from '@aztec/foundation/serialize';
 
-import { AvmExecutionError, AvmParsingError, InvalidOpcodeError, InvalidProgramCounterError } from '../errors.js';
+import {
+  AvmExecutionError,
+  AvmParsingError,
+  InvalidOpcodeError,
+  InvalidProgramCounterError,
+  InvalidTagValueError,
+  duringInstrFetch,
+} from '../errors.js';
 import {
   Add,
   And,
@@ -172,7 +179,7 @@ export function decodeInstructionFromBytecode(
   instructionSet: InstructionSet = INSTRUCTION_SET,
 ): [Instruction, number] {
   if (pc >= bytecode.length) {
-    throw new InvalidProgramCounterError(pc, bytecode.length);
+    throw new InvalidProgramCounterError(pc, bytecode.length - 1);
   }
 
   try {
@@ -182,7 +189,7 @@ export function decodeInstructionFromBytecode(
 
     if (opcode > MAX_OPCODE_VALUE) {
       throw new InvalidOpcodeError(
-        `Opcode ${opcode} (0x${opcode.toString(16)}) value is not in the range of valid opcodes.`,
+        `Opcode ${opcode} (0x${opcode.toString(16)}) value is not in the range of valid opcodes (at PC ${pc}).`,
       );
     }
 
@@ -192,13 +199,17 @@ export function decodeInstructionFromBytecode(
     }
 
     const instructionDeserializer: InstructionDeserializer = instructionDeserializerOrUndef;
+
     const instruction = instructionDeserializer(cursor);
     return [instruction, cursor.position() - startingPosition];
   } catch (error) {
-    if (error instanceof InvalidOpcodeError || error instanceof AvmExecutionError) {
-      throw error;
+    if (error instanceof InvalidTagValueError || error instanceof InvalidOpcodeError) {
+      throw duringInstrFetch(error, pc);
+    } else if (error instanceof AvmExecutionError) {
+      throw new AvmParsingError(`Instruction parsing error at pc ${pc}: ${error.message}`);
     } else {
-      throw new AvmParsingError(`${error}`);
+      const msg = error instanceof Error ? `: ${error.message}` : '';
+      throw new AvmParsingError(`Instruction fetching error at pc ${pc}${msg}`);
     }
   }
 }

--- a/yarn-project/simulator/src/public/public_tx_simulator/public_tx_simulator.ts
+++ b/yarn-project/simulator/src/public/public_tx_simulator/public_tx_simulator.ts
@@ -129,7 +129,7 @@ export class PublicTxSimulator implements PublicTxSimulatorInterface {
       const setupResult = await this.simulatePhase(TxExecutionPhase.SETUP, context);
       if (setupResult.reverted) {
         throw new Error(
-          `Setup phase reverted! The transaction will be thrown out. ${setupResult.revertReason?.message}`,
+          `[SETUP] UNRECOVERABLE ERROR! The transaction will be thrown out. ${setupResult.revertReason?.message}`,
         );
       }
       processedPhases.push(setupResult);


### PR DESCRIPTION
Plumb more verbose errors up from lower level C++ simulator gadgets/modules. Specifically for pure sim. Align some errors between TS and C++ (and otherwise update tests) to get all tests passing wtih new simulator.