### PR TITLE
chore: remove unnecessary Buffer polyfill from browser-test-app

### DIFF
--- a/barretenberg/acir_tests/browser-test-app/package.json
+++ b/barretenberg/acir_tests/browser-test-app/package.json
@@ -11,7 +11,6 @@
   "devDependencies": {
     "@aztec/bb.js": "portal:../../ts",
     "@types/pako": "^2.0.3",
-    "buffer": "^6.0.3",
     "html-webpack-plugin": "^5.6.0",
     "pako": "^2.1.0",
     "pino": "^9.5.0",

--- a/barretenberg/acir_tests/browser-test-app/webpack.config.js
+++ b/barretenberg/acir_tests/browser-test-app/webpack.config.js
@@ -1,10 +1,7 @@
 import { resolve, dirname } from 'path';
-import { createRequire } from 'module';
 import { fileURLToPath } from 'url';
 import HtmlWebpackPlugin from 'html-webpack-plugin';
 import webpack from 'webpack';
-
-const require = createRequire(import.meta.url);
 
 export default {
   target: 'web',
@@ -26,13 +23,9 @@ export default {
   plugins: [
     new HtmlWebpackPlugin({ inject: false, template: './src/index.html' }),
     new webpack.DefinePlugin({ 'process.env.NODE_DEBUG': false }),
-    new webpack.ProvidePlugin({ Buffer: ['buffer', 'Buffer'] }),
   ],
   resolve: {
     extensions: ['.tsx', '.ts', '.js'],
-    fallback: {
-      buffer: require.resolve('buffer/'),
-    },
   },
   devServer: {
     hot: false,


### PR DESCRIPTION
## Summary

Remove the Buffer polyfill from browser-test-app webpack config.

## Finding

bb.js doesn't actually require Buffer polyfill for browser bundling:
- msgpackr (the main dependency) gracefully falls back to `Uint8Array` when `Buffer` is unavailable: https://github.com/kriszyp/msgpackr/blob/v1.11.4/unpack.js#L74
- The browser build excludes Node.js-specific code that uses Buffer
- Testing utilities that use Buffer are only used by test files, which are excluded from the browser build

## Changes

- Remove `buffer` dependency from browser-test-app/package.json
- Remove Buffer polyfill configuration from webpack.config.js

## Verification

Browser test (`test_console_capture`) passes successfully without the polyfill.