### PR TITLE
chore: Try deflake inactivity slash tests

### DIFF
--- a/yarn-project/end-to-end/src/e2e_p2p/inactivity_slash_test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/inactivity_slash_test.ts
@@ -150,8 +150,9 @@ export class P2PInactivityTest {
     // This prevents race conditions where validators propose blocks before the network is ready
     await this.test.waitForP2PMeshConnectivity(this.nodes, NUM_NODES);
 
-    this.test.logger.warn(`Advancing to epoch ${SETUP_EPOCH_DURATION + 1} to start slashing`);
-    await this.test.ctx.cheatCodes.rollup.advanceToEpoch(SETUP_EPOCH_DURATION + 1);
+    const ethereumSlotDuration = this.test.ctx.aztecNodeConfig.ethereumSlotDuration!;
+    this.test.logger.warn(`Advancing to the L1 slot before epoch ${SETUP_EPOCH_DURATION + 1} to start slashing`);
+    await this.test.ctx.cheatCodes.rollup.advanceToEpoch(SETUP_EPOCH_DURATION + 1, { offset: -ethereumSlotDuration });
 
     return this;
   }


### PR DESCRIPTION
We were slashing an online validator due to inactivity beacause it failed to assemble the first block in the first slot of the epoch, because we were warping to when the epoch was already started, not before.

This should give the validator enough time to assemble the block and get the proposal broadcasted.
