### PR TITLE
Revert "chore: refactor `sumcheck` methods to remove cluttering due to ZK and ECCVM differences"

### DIFF
--- a/barretenberg/cpp/src/barretenberg/eccvm/eccvm.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/eccvm/eccvm.test.cpp
@@ -265,9 +265,7 @@ TEST_F(ECCVMTests, CommittedSumcheck)
 
     // Execute Sumcheck Verifier
     SumcheckVerifier<Flavor> sumcheck_verifier(verifier_transcript, alpha, CONST_ECCVM_LOG_N);
-    std::vector<FF> padding_indicator_array(CONST_ECCVM_LOG_N, FF(1));
-    SumcheckOutput<ECCVMFlavor> verifier_output =
-        sumcheck_verifier.verify(relation_parameters, gate_challenges, padding_indicator_array);
+    SumcheckOutput<ECCVMFlavor> verifier_output = sumcheck_verifier.verify(relation_parameters, gate_challenges);
 
     // Evaluate prover's round univariates at corresponding challenges and compare them with the claimed evaluations
     // computed by the verifier

--- a/barretenberg/cpp/src/barretenberg/eccvm/eccvm_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/eccvm/eccvm_verifier.cpp
@@ -76,9 +76,8 @@ bool ECCVMVerifier::verify_proof(const ECCVMProof& proof)
     std::array<Commitment, NUM_LIBRA_COMMITMENTS> libra_commitments = {};
 
     libra_commitments[0] = transcript->template receive_from_prover<Commitment>("Libra:concatenation_commitment");
-    std::vector<FF> padding_indicator_array(CONST_ECCVM_LOG_N, FF(1));
 
-    auto sumcheck_output = sumcheck.verify(relation_parameters, gate_challenges, padding_indicator_array);
+    auto sumcheck_output = sumcheck.verify(relation_parameters, gate_challenges);
 
     libra_commitments[1] = transcript->template receive_from_prover<Commitment>("Libra:grand_sum_commitment");
     libra_commitments[2] = transcript->template receive_from_prover<Commitment>("Libra:quotient_commitment");
@@ -90,6 +89,9 @@ bool ECCVMVerifier::verify_proof(const ECCVMProof& proof)
         .unshifted = ClaimBatch{ commitments.get_unshifted(), sumcheck_output.claimed_evaluations.get_unshifted() },
         .shifted = ClaimBatch{ commitments.get_to_be_shifted(), sumcheck_output.claimed_evaluations.get_shifted() }
     };
+
+    std::array<FF, CONST_ECCVM_LOG_N> padding_indicator_array;
+    std::ranges::fill(padding_indicator_array, FF{ 1 });
 
     BatchOpeningClaim<Curve> sumcheck_batch_opening_claims =
         Shplemini::compute_batch_opening_claim(padding_indicator_array,

--- a/barretenberg/cpp/src/barretenberg/multilinear_batching/multilinear_batching_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/multilinear_batching/multilinear_batching_verifier.cpp
@@ -142,9 +142,7 @@ std::pair<bool, typename MultilinearBatchingVerifier<Flavor_>::VerifierClaim> Mu
                                            accumulator_evaluations[1]);
 
     Sumcheck sumcheck(transcript, alpha, Flavor::VIRTUAL_LOG_N, target_sum);
-    // MultilinearBatchingFlavor doesn't use gate challenges, and all rounds are non-padding
-    std::vector<FF> padding_indicator_array(Flavor::VIRTUAL_LOG_N, FF(1));
-    const auto sumcheck_result = sumcheck.verify({}, {}, padding_indicator_array);
+    const auto sumcheck_result = sumcheck.verify();
 
     // Construct new claim
     auto claim_batching_challenge = transcript->template get_challenge<FF>("claim_batching_challenge");

--- a/barretenberg/cpp/src/barretenberg/polynomials/barycentric.hpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/barycentric.hpp
@@ -8,7 +8,7 @@
 #include "barretenberg/ecc/fields/field.hpp"
 #include <array>
 
-// TODO(#674): We need the functionality of BarycentricData for both field (native) and field_t (stdlib). The former
+// TODO(#674): We need the functionality of BarycentricData for both field (native) and field_t (stdlib). The former is
 // is compatible with constexpr operations, and the former is not. The functions for computing the
 // pre-computable arrays in BarycentricData need to be constexpr and it takes some trickery to share these functions
 // with the non-constexpr setting. Right now everything is more or less duplicated across BarycentricDataCompileTime and

--- a/barretenberg/cpp/src/barretenberg/polynomials/gate_separator.hpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/gate_separator.hpp
@@ -90,12 +90,7 @@ template <typename FF> struct GateSeparatorPolynomial {
      * @param idx
      * @return FF const&
      */
-    FF const& operator[](size_t idx) const
-    {
-        // At round i, we only iterate over beta_products of indices that are multiples of 2^i,
-        // Hence for the idx-th element we need to get the (idx * 2^i)-th element in #beta_products.
-        return beta_products.at((idx >> 1) * periodicity);
-    }
+    FF const& operator[](size_t idx) const { return beta_products.at(idx); }
     /**
      * @brief Computes the component  at index #current_element_idx in #betas.
      *

--- a/barretenberg/cpp/src/barretenberg/polynomials/gate_separator.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/gate_separator.test.cpp
@@ -16,17 +16,17 @@ TEST(GateSeparatorPolynomial, FullPowConsistency)
     std::array<fr, d> variables{};
     for (auto& u_i : variables) {
         u_i = fr::random_element();
+        poly.partially_evaluate(u_i);
     }
 
     size_t beta_idx = 0;
     fr expected_eval = 1;
     for (auto& u_i : variables) {
-        poly.partially_evaluate(u_i);
         expected_eval *= fr(1) - u_i + u_i * poly.betas[beta_idx];
         beta_idx++;
-        // Check that current partial evaluation result is equal to the expected evaluation
-        EXPECT_EQ(poly.partial_evaluation_result, expected_eval);
     }
+
+    EXPECT_EQ(poly.partial_evaluation_result, expected_eval);
 }
 
 TEST(GateSeparatorPolynomial, GateSeparatorPolynomialsOnPowers)
@@ -35,25 +35,4 @@ TEST(GateSeparatorPolynomial, GateSeparatorPolynomialsOnPowers)
     GateSeparatorPolynomial<fr> poly(betas, betas.size());
     std::vector<fr> expected_values{ 1, 2, 4, 8, 16, 32, 64, 128 };
     EXPECT_EQ(bb::Polynomial<fr>(expected_values), bb::Polynomial<fr>(poly.beta_products));
-}
-
-TEST(GateSeparatorPolynomial, GateSeparatorPolynomialsOnPowersWithDifferentBeta)
-{
-    constexpr size_t d = 5;
-    std::vector<fr> betas(d);
-    for (auto& beta : betas) {
-        beta = fr::random_element();
-    }
-    // Compute the beta products
-    std::vector<fr> expected_beta_products(1 << d);
-    for (size_t i = 0; i < (1 << d); i++) {
-        expected_beta_products[i] = 1;
-        for (size_t j = 0; j < d; j++) {
-            if (i & (1 << j)) {
-                expected_beta_products[i] *= betas[j];
-            }
-        }
-    }
-    GateSeparatorPolynomial<fr> poly(betas, betas.size());
-    EXPECT_EQ(bb::Polynomial<fr>(expected_beta_products), bb::Polynomial<fr>(poly.beta_products));
 }

--- a/barretenberg/cpp/src/barretenberg/polynomials/row_disabling_polynomial.hpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/row_disabling_polynomial.hpp
@@ -43,15 +43,15 @@ namespace bb {
  *
  * Recall:
  * - \f$ n-1 = 2^d - 1 = (1,1, \ldots, 1) \f$
- * - \f$ n-2 = (0,1,1,\ldots,1) \f$
- * - \f$ n-3 = (1,0,1,\ldots,1) \f$
- * - \f$ n-4 = (0,0,1,\ldots,1) \f$
+ * - \f$ n-2 = (0,1,\ldots,1) \f$
+ * - \f$ n-3 = (1,0,\ldots,1) \f$
+ * - \f$ n-4 = (0,0,\ldots,1) \f$
  *
  * ### Round 0:
  * \f[
  * \begin{aligned}
  * S' &=
- * S_{H,0} - \Big(L_{n-1}(X, 1,1, \ldots, 1) + L_{n-2}(X, 1,1,\ldots,1)\Big) H(X,1,1,\ldots, 1) \\
+ * S_{H,0} - \Big(L_{n-1}(X, 1, \ldots, 1) + L_{n-2}(X, 1,\ldots,1)\Big) H(X,1,\ldots, 1) \\
  * &\quad - \Big(L_{n-3}(X, 0,1,\ldots,1) + L_{n-4}(X,0,1,\ldots,1)\Big) H(X,0,1,\ldots,1)
  * \end{aligned}
  * \f]
@@ -182,11 +182,10 @@ template <typename FF> struct RowDisablingPolynomial {
     }
 
     /**
-     * @brief Compute the evaluation of \f$ 1 - L \f$ at the sumcheck challenge
+     * @brief A variant of the above that uses `padding_indicator_array`.
      *
      * @param multivariate_challenge Sumcheck evaluation challenge
      * @param padding_indicator_array An array with first log_n entries equal to 1, and the remaining entries are 0.
-     * @return FF
      */
     static FF evaluate_at_challenge(std::span<FF> multivariate_challenge,
                                     const std::vector<FF>& padding_indicator_array)

--- a/barretenberg/cpp/src/barretenberg/polynomials/univariate.hpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/univariate.hpp
@@ -361,11 +361,6 @@ template <class Fr, size_t domain_end> class Univariate {
 
         static constexpr Fr inverse_two = Fr(2).invert();
         if constexpr (LENGTH == 2) {
-            // f = b x + c
-            // f(0) = c
-            // f(1) = b + c
-            // Hence, b = f(1) - f(0)
-            // f(i + 1) = f(i) + b
             Fr delta = value_at(1) - value_at(0);
             static_assert(EXTENDED_LENGTH != 0);
             for (size_t idx = domain_end - 1; idx < EXTENDED_DOMAIN_END - 1; idx++) {
@@ -374,19 +369,10 @@ template <class Fr, size_t domain_end> class Univariate {
         } else if constexpr (LENGTH == 3) {
             // Based off https://hackmd.io/@aztec-network/SyR45cmOq?type=view
             // The technique used here is the same as the length == 3 case below.
-            // f = a x^2 + b x + c
-            // f(0) = c
-            // f(1) = a + b + c
-            // f(2) = 4a + 2b + c
-            // f(2) + f(0) - 2f(1) = 2a
-            // Hence, a = (f(2) + f(0) - 2f(1)) / 2
-            // b = f(1) - a - f(0)
-            // f(i+1) = f(i) + 2a * i + b + a
             Fr a = (value_at(2) + value_at(0)) * inverse_two - value_at(1);
             Fr b = value_at(1) - a - value_at(0);
             Fr a2 = a + a;
             Fr a_mul = a2;
-            // compute 2a * domain_end - 2
             for (size_t i = 0; i < domain_end - 2; i++) {
                 a_mul += a2;
             }

--- a/barretenberg/cpp/src/barretenberg/stdlib/eccvm_verifier/eccvm_recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/eccvm_verifier/eccvm_recursive_verifier.cpp
@@ -106,9 +106,7 @@ ECCVMRecursiveVerifier::IpaClaimAndProof ECCVMRecursiveVerifier::verify_proof(co
 
     libra_commitments[0] = transcript->template receive_from_prover<Commitment>("Libra:concatenation_commitment");
 
-    std::vector<FF> padding_indicator_array(CONST_ECCVM_LOG_N, FF(1));
-
-    auto sumcheck_output = sumcheck.verify(relation_parameters, gate_challenges, padding_indicator_array);
+    auto sumcheck_output = sumcheck.verify(relation_parameters, gate_challenges);
 
     libra_commitments[1] = transcript->template receive_from_prover<Commitment>("Libra:grand_sum_commitment");
     libra_commitments[2] = transcript->template receive_from_prover<Commitment>("Libra:quotient_commitment");
@@ -123,6 +121,9 @@ ECCVMRecursiveVerifier::IpaClaimAndProof ECCVMRecursiveVerifier::verify_proof(co
 
     FF one{ 1 };
     one.convert_constant_to_fixed_witness(builder);
+
+    std::array<FF, CONST_ECCVM_LOG_N> padding_indicator_array;
+    std::ranges::fill(padding_indicator_array, one);
 
     BatchOpeningClaim<Curve> sumcheck_batch_opening_claims =
         Shplemini::compute_batch_opening_claim(padding_indicator_array,

--- a/barretenberg/cpp/src/barretenberg/stdlib/eccvm_verifier/eccvm_recursive_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/eccvm_verifier/eccvm_recursive_verifier.test.cpp
@@ -140,7 +140,7 @@ class ECCVMRecursiveTests : public ::testing::Test {
         }
 
         // Check that the size of the recursive verifier is consistent with historical expectation
-        uint32_t NUM_GATES_EXPECTED = 213683;
+        uint32_t NUM_GATES_EXPECTED = 213303;
         ASSERT_EQ(static_cast<uint32_t>(outer_circuit.get_num_finalized_gates()), NUM_GATES_EXPECTED)
             << "Ultra-arithmetized ECCVM Recursive verifier gate count changed! Update this value if you are sure this "
                "is expected.";

--- a/barretenberg/cpp/src/barretenberg/sumcheck/sumcheck.hpp
+++ b/barretenberg/cpp/src/barretenberg/sumcheck/sumcheck.hpp
@@ -17,169 +17,6 @@
 
 namespace bb {
 
-/**
- * @brief Handler for processing round univariates in sumcheck.
- * Default implementation: send evaluations directly to transcript.
- */
-template <typename Flavor, bool IsGrumpkin = IsGrumpkinFlavor<Flavor>> struct RoundUnivariateHandler {
-    using FF = typename Flavor::FF;
-    using Transcript = typename Flavor::Transcript;
-    using CommitmentKey = typename Flavor::CommitmentKey;
-    static constexpr size_t BATCHED_RELATION_PARTIAL_LENGTH = Flavor::BATCHED_RELATION_PARTIAL_LENGTH;
-
-    std::shared_ptr<Transcript> transcript;
-
-    RoundUnivariateHandler(std::shared_ptr<Transcript> transcript)
-        : transcript(std::move(transcript))
-    {}
-
-    void process_round_univariate(size_t round_idx,
-                                  bb::Univariate<FF, BATCHED_RELATION_PARTIAL_LENGTH>& round_univariate)
-    {
-        transcript->send_to_verifier("Sumcheck:univariate_" + std::to_string(round_idx), round_univariate);
-    }
-
-    void finalize_last_round(size_t /*multivariate_d*/,
-                             const bb::Univariate<FF, BATCHED_RELATION_PARTIAL_LENGTH>& /*round_univariate*/,
-                             const FF& /*last_challenge*/)
-    {}
-
-    std::vector<std::array<FF, 3>> get_evaluations() { return {}; }
-    std::vector<Polynomial<FF>> get_univariates() { return {}; }
-};
-
-/**
- * @brief Specialization for Grumpkin flavors: commit to round univariates.
- */
-template <typename Flavor> struct RoundUnivariateHandler<Flavor, true> {
-    using FF = typename Flavor::FF;
-    using Transcript = typename Flavor::Transcript;
-    using CommitmentKey = typename Flavor::CommitmentKey;
-    static constexpr size_t BATCHED_RELATION_PARTIAL_LENGTH = Flavor::BATCHED_RELATION_PARTIAL_LENGTH;
-
-    std::shared_ptr<Transcript> transcript;
-    CommitmentKey ck;
-    std::vector<FF> eval_domain;
-    std::vector<std::array<FF, 3>> round_evaluations;
-    std::vector<Polynomial<FF>> round_univariates;
-
-    RoundUnivariateHandler(std::shared_ptr<Transcript> transcript)
-        : transcript(std::move(transcript))
-        , ck(BATCHED_RELATION_PARTIAL_LENGTH)
-    {
-        // Compute the vector {0, 1, \ldots, BATCHED_RELATION_PARTIAL_LENGTH-1} needed to transform
-        // the round univariates from Lagrange to monomial basis
-        for (size_t idx = 0; idx < BATCHED_RELATION_PARTIAL_LENGTH; idx++) {
-            eval_domain.push_back(FF(idx));
-        }
-    }
-
-    void process_round_univariate(size_t round_idx,
-                                  bb::Univariate<FF, BATCHED_RELATION_PARTIAL_LENGTH>& round_univariate)
-    {
-        const std::string idx = std::to_string(round_idx);
-
-        // Transform to monomial form and commit to it
-        Polynomial<FF> round_poly_monomial(
-            eval_domain, std::span<FF>(round_univariate.evaluations), BATCHED_RELATION_PARTIAL_LENGTH);
-        transcript->send_to_verifier("Sumcheck:univariate_comm_" + idx, ck.commit(round_poly_monomial));
-
-        // Store round univariate in monomial, as it is required by Shplemini
-        round_univariates.push_back(std::move(round_poly_monomial));
-
-        // Send the evaluations of the round univariate at 0 and 1
-        transcript->send_to_verifier("Sumcheck:univariate_" + idx + "_eval_0", round_univariate.value_at(0));
-        transcript->send_to_verifier("Sumcheck:univariate_" + idx + "_eval_1", round_univariate.value_at(1));
-
-        // Store the evaluations to be used by ShpleminiProver.
-        round_evaluations.push_back({ round_univariate.value_at(0), round_univariate.value_at(1), FF(0) });
-        if (round_idx > 0) {
-            round_evaluations[round_idx - 1][2] = round_univariate.value_at(0) + round_univariate.value_at(1);
-        }
-    }
-
-    void finalize_last_round(size_t multivariate_d,
-                             const bb::Univariate<FF, BATCHED_RELATION_PARTIAL_LENGTH>& round_univariate,
-                             const FF& last_challenge)
-    {
-        round_evaluations[multivariate_d - 1][2] = round_univariate.evaluate(last_challenge);
-    }
-
-    std::vector<std::array<FF, 3>> get_evaluations() { return round_evaluations; }
-    std::vector<Polynomial<FF>> get_univariates() { return round_univariates; }
-};
-
-/**
- * @brief Handler for ZK-related verification adjustments in sumcheck.
- * Default implementation: no ZK adjustments needed.
- */
-template <typename Flavor, bool HasZK = Flavor::HasZK> struct VerifierZKCorrectionHandler {
-    using FF = typename Flavor::FF;
-    using Transcript = typename Flavor::Transcript;
-    using SumcheckRound = SumcheckVerifierRound<Flavor>;
-
-    std::shared_ptr<Transcript> transcript;
-    FF libra_challenge = FF{ 0 };
-    FF libra_evaluation = FF{ 0 };
-
-    // Construct a handler which will handle all the evaluations/
-    VerifierZKCorrectionHandler(std::shared_ptr<Transcript> transcript)
-        : transcript(std::move(transcript))
-    {}
-
-    void initialize_target_sum(SumcheckRound& /*round*/) {}
-
-    void apply_zk_corrections(FF& /*full_honk_purported_value*/,
-                              const std::vector<FF>& /*multivariate_challenge*/,
-                              const std::vector<FF>& /*padding_indicator_array*/)
-    {}
-
-    FF get_libra_evaluation() const { return libra_evaluation; }
-};
-
-/**
- * @brief Specialization for ZK flavors: handle Libra masking and row disabling.
- */
-template <typename Flavor> struct VerifierZKCorrectionHandler<Flavor, true> {
-    using FF = typename Flavor::FF;
-    using Transcript = typename Flavor::Transcript;
-    using SumcheckRound = SumcheckVerifierRound<Flavor>;
-
-    std::shared_ptr<Transcript> transcript;
-    FF libra_total_sum = FF{ 0 };
-    FF libra_challenge = FF{ 0 };
-    FF libra_evaluation = FF{ 0 };
-
-    // If running zero-knowledge sumcheck the target total sum is corrected by the claimed sum of libra masking
-    // multivariate over the hypercube
-    VerifierZKCorrectionHandler(std::shared_ptr<Transcript> transcript)
-        : transcript(std::move(transcript))
-        , libra_total_sum(this->transcript->template receive_from_prover<FF>("Libra:Sum"))
-        , libra_challenge(this->transcript->template get_challenge<FF>("Libra:Challenge"))
-    {}
-
-    void initialize_target_sum(SumcheckRound& round) { round.target_total_sum = libra_total_sum * libra_challenge; }
-
-    void apply_zk_corrections(FF& full_honk_purported_value,
-                              std::vector<FF>& multivariate_challenge,
-                              const std::vector<FF>& padding_indicator_array)
-    {
-        if constexpr (UseRowDisablingPolynomial<Flavor>) {
-            // Compute the evaluations of the polynomial (1 - \sum L_i) where the sum is for i corresponding to the
-            // rows where all sumcheck relations are disabled
-            // i.e. compute the term $1 - \prod_{i=2}^{d-1} u_i$
-            full_honk_purported_value *=
-                RowDisablingPolynomial<FF>::evaluate_at_challenge(multivariate_challenge, padding_indicator_array);
-        }
-
-        // Get the claimed evaluation of the Libra multivariate evaluated at the sumcheck challenge
-        libra_evaluation = transcript->template receive_from_prover<FF>("Libra:claimed_evaluation");
-        full_honk_purported_value += libra_evaluation * libra_challenge;
-    }
-
-    FF get_libra_evaluation() const { return libra_evaluation; }
-};
-
 /*! \brief The implementation of the sumcheck Prover for statements of the form \f$\sum_{\vec \ell \in \{0,1\}^d}
 pow_{\beta}(\vec \ell) \cdot F \left(P_1(\vec \ell),\ldots, P_N(\vec \ell) \right)  = 0 \f$ for multilinear polynomials
 \f$P_1, \ldots, P_N \f$.
@@ -334,6 +171,10 @@ template <typename Flavor> class SumcheckProver {
 
     std::vector<FF> multivariate_challenge;
 
+    std::vector<typename Flavor::Commitment> round_univariate_commitments = {};
+    std::vector<std::array<FF, 3>> round_evaluations = {};
+    std::vector<Polynomial<FF>> round_univariates = {};
+    std::vector<FF> eval_domain = {};
     // For computing eq polymomials in Multilinear Batching Flavor
     std::vector<FF> accumulator_challenge = {};
     std::vector<FF> instance_challenge = {};
@@ -524,7 +365,17 @@ template <typename Flavor> class SumcheckProver {
     SumcheckOutput<Flavor> prove(ZKData& zk_sumcheck_data)
         requires Flavor::HasZK
     {
-        RoundUnivariateHandler<Flavor> handler(transcript);
+        CommitmentKey ck;
+
+        if constexpr (IsGrumpkinFlavor<Flavor>) {
+            ck = CommitmentKey(BATCHED_RELATION_PARTIAL_LENGTH);
+            // Compute the vector {0, 1, \ldots, BATCHED_RELATION_PARTIAL_LENGTH-1} needed to transform the round
+            // univariates from Lagrange to monomial basis
+            for (size_t idx = 0; idx < BATCHED_RELATION_PARTIAL_LENGTH; idx++) {
+                eval_domain.push_back(FF(idx));
+            }
+        }
+
         vinfo("starting sumcheck rounds...");
         // Given gate challenges β = (β₀, ..., β_{d−1}) and d = `multivariate_d`, compute the evaluations of
         // GateSeparator_β (X₀, ..., X_{d−1}) = ∏ₖ₌₀^{d−1} (1 − Xₖ + Xₖ · βₖ)
@@ -535,20 +386,16 @@ template <typename Flavor> class SumcheckProver {
         size_t round_idx = 0;
         // In the first round, we compute the first univariate polynomial and populate the book-keeping table of
         // #partially_evaluated_polynomials, which has \f$ n/2 \f$ rows and \f$ N \f$ columns.
-
-        // Compute the round univariate
+        auto hiding_univariate = round.compute_hiding_univariate(round_idx,
+                                                                 full_polynomials,
+                                                                 relation_parameters,
+                                                                 gate_separators,
+                                                                 alphas,
+                                                                 zk_sumcheck_data,
+                                                                 row_disabling_polynomial);
         auto round_univariate =
             round.compute_univariate(full_polynomials, relation_parameters, gate_separators, alphas);
-
-        // Add the contribution from the Libra univariates
-        auto hiding_univariate = round.compute_libra_univariate(zk_sumcheck_data, round_idx);
         round_univariate += hiding_univariate;
-
-        // Subtract the contribution from the disabled rows
-        if constexpr (UseRowDisablingPolynomial<Flavor>) {
-            round_univariate -= round.compute_disabled_contribution(
-                full_polynomials, relation_parameters, gate_separators, alphas, round_idx, row_disabling_polynomial);
-        }
 
         // Initialize the partially evaluated polynomials which will be used in the following rounds.
         // This will use the information in the structured full polynomials to save memory if possible.
@@ -557,7 +404,15 @@ template <typename Flavor> class SumcheckProver {
         {
             BB_BENCH_NAME("rest of sumcheck round 1");
 
-            handler.process_round_univariate(round_idx, round_univariate);
+            if constexpr (!IsGrumpkinFlavor<Flavor>) {
+                // Place the evaluations of the round univariate into transcript.
+                transcript->send_to_verifier("Sumcheck:univariate_0", round_univariate);
+            } else {
+
+                // Compute monomial coefficients of the round univariate, commit to it, populate an auxiliary structure
+                // needed in the PCS round
+                commit_to_round_univariate(round_idx, round_univariate, ck);
+            }
 
             const FF round_challenge = transcript->template get_challenge<FF>("Sumcheck:u_0");
 
@@ -579,23 +434,26 @@ template <typename Flavor> class SumcheckProver {
             // account for having randomness at the end of the trace and then the contribution from the full
             // relation. Note: we compute the hiding univariate first as the `compute_univariate` method prepares
             // relevant data structures for the next round
+            hiding_univariate = round.compute_hiding_univariate(round_idx,
+                                                                partially_evaluated_polynomials,
+                                                                relation_parameters,
+                                                                gate_separators,
+                                                                alphas,
+                                                                zk_sumcheck_data,
+                                                                row_disabling_polynomial);
             round_univariate =
                 round.compute_univariate(partially_evaluated_polynomials, relation_parameters, gate_separators, alphas);
-            hiding_univariate = round.compute_libra_univariate(zk_sumcheck_data, round_idx);
-            // Add the contribution from the Libra univariates
             round_univariate += hiding_univariate;
-            // Subtract the contribution from the disabled rows
-            if constexpr (UseRowDisablingPolynomial<Flavor>) {
-                round_univariate -= round.compute_disabled_contribution(partially_evaluated_polynomials,
-                                                                        relation_parameters,
-                                                                        gate_separators,
-                                                                        alphas,
-                                                                        round_idx,
-                                                                        row_disabling_polynomial);
+
+            if constexpr (!IsGrumpkinFlavor<Flavor>) {
+                // Place evaluations of Sumcheck Round Univariate in the transcript
+                transcript->send_to_verifier("Sumcheck:univariate_" + std::to_string(round_idx), round_univariate);
+            } else {
+
+                // Compute monomial coefficients of the round univariate, commit to it, populate an auxiliary structure
+                // needed in the PCS round
+                commit_to_round_univariate(round_idx, round_univariate, ck);
             }
-
-            handler.process_round_univariate(round_idx, round_univariate);
-
             const FF round_challenge =
                 transcript->template get_challenge<FF>("Sumcheck:u_" + std::to_string(round_idx));
             multivariate_challenge.emplace_back(round_challenge);
@@ -609,8 +467,10 @@ template <typename Flavor> class SumcheckProver {
             round.round_size = round.round_size >> 1;
         }
 
-        handler.finalize_last_round(multivariate_d, round_univariate, multivariate_challenge[multivariate_d - 1]);
-
+        if constexpr (IsGrumpkinFlavor<Flavor>) {
+            round_evaluations[multivariate_d - 1][2] =
+                round_univariate.evaluate(multivariate_challenge[multivariate_d - 1]);
+        }
         vinfo("completed ", multivariate_d, " rounds of sumcheck");
 
         // Zero univariates are used to pad the proof to the fixed size virtual_log_n.
@@ -637,15 +497,22 @@ template <typename Flavor> class SumcheckProver {
 
         // The sum of the Libra constant term and the evaluations of Libra univariates at corresponding sumcheck
         // challenges is included in the Sumcheck Output
-        return SumcheckOutput<Flavor>{ .challenge = multivariate_challenge,
-                                       .claimed_evaluations = multivariate_evaluations,
-                                       .claimed_libra_evaluation = libra_evaluation,
-                                       .round_univariates = handler.get_univariates(),
-                                       .round_univariate_evaluations = handler.get_evaluations() };
+        if constexpr (!IsGrumpkinFlavor<Flavor>) {
+            return SumcheckOutput<Flavor>{ .challenge = multivariate_challenge,
+                                           .claimed_evaluations = multivariate_evaluations,
+                                           .claimed_libra_evaluation = libra_evaluation };
+        } else {
+            return SumcheckOutput<Flavor>{ .challenge = multivariate_challenge,
+                                           .claimed_evaluations = multivariate_evaluations,
+                                           .claimed_libra_evaluation = libra_evaluation,
+                                           .round_univariates = round_univariates,
+                                           .round_univariate_evaluations = round_evaluations };
+        }
         vinfo("finished sumcheck");
     };
 
     /**
+     *
      @brief Evaluate Honk polynomials at the round challenge and prepare class for next round.
      @details At initialization, \ref ProverPolynomials "Prover Polynomials"
      are submitted by reference into \p full_polynomials, which is a two-dimensional array defined as \f{align}{
@@ -746,6 +613,44 @@ template <typename Flavor> class SumcheckProver {
         };
         return multivariate_evaluations;
     };
+
+    /**
+     * @brief  Compute monomial coefficients of the round univariate, commit to it, populate an auxiliary structure
+     * needed in the PCS round
+     *
+     * @param round_idx
+     * @param round_univariate Sumcheck Round Univariate
+     * @param eval_domain {0, 1, ... , BATCHED_RELATION_PARTIAL_LENGTH-1}
+     * @param transcript
+     * @param ck Commitment key of size BATCHED_RELATION_PARTIAL_LENGTH
+     * @param round_univariates Auxiliary container to be fed to Shplemini
+     * @param round_univariate_evaluations  Auxiliary container to be fed to Shplemini
+     */
+    void commit_to_round_univariate(const size_t round_idx,
+                                    bb::Univariate<FF, BATCHED_RELATION_PARTIAL_LENGTH>& round_univariate,
+                                    const CommitmentKey& ck)
+
+    {
+        const std::string idx = std::to_string(round_idx);
+
+        // Transform to monomial form and commit to it
+        Polynomial<FF> round_poly_monomial(
+            eval_domain, std::span<FF>(round_univariate.evaluations), BATCHED_RELATION_PARTIAL_LENGTH);
+        transcript->send_to_verifier("Sumcheck:univariate_comm_" + idx, ck.commit(round_poly_monomial));
+
+        // Store round univariate in monomial, as it is required by Shplemini
+        round_univariates.push_back(std::move(round_poly_monomial));
+
+        // Send the evaluations of the round univariate at 0 and 1
+        transcript->send_to_verifier("Sumcheck:univariate_" + idx + "_eval_0", round_univariate.value_at(0));
+        transcript->send_to_verifier("Sumcheck:univariate_" + idx + "_eval_1", round_univariate.value_at(1));
+
+        // Store the evaluations to be used by ShpleminiProver.
+        round_evaluations.push_back({ round_univariate.value_at(0), round_univariate.value_at(1), FF(0) });
+        if (round_idx > 0) {
+            round_evaluations[round_idx - 1][2] = round_univariate.value_at(0) + round_univariate.value_at(1);
+        };
+    }
 };
 /*! \brief Implementation of the sumcheck Verifier for statements of the form \f$\sum_{\vec \ell \in \{0,1\}^d}
  pow_{\beta}(\vec \ell) \cdot F \left(P_1(\vec \ell),\ldots, P_N(\vec \ell) \right)  = 0 \f$ for multilinear
@@ -821,6 +726,14 @@ template <typename Flavor> class SumcheckVerifier {
     // An array of size NUM_SUBRELATIONS-1 containing challenges or consecutive powers of a single challenge that
     // separate linearly independent subrelation.
     SubrelationSeparators alphas;
+    FF libra_evaluation{ 0 };
+    FF libra_challenge;
+    FF libra_total_sum;
+
+    FF correcting_factor;
+
+    std::vector<Commitment> round_univariate_commitments = {};
+    std::vector<std::array<FF, 3>> round_univariate_evaluations = {};
 
     explicit SumcheckVerifier(std::shared_ptr<Transcript> transcript,
                               const FF& alpha,
@@ -831,43 +744,59 @@ template <typename Flavor> class SumcheckVerifier {
         , virtual_log_n(virtual_log_n)
         , alphas(initialize_relation_separator<FF, Flavor::NUM_SUBRELATIONS - 1>(alpha)) {};
     /**
-     * @brief The Sumcheck verification method. First it extracts round univariate, checks sum (the sumcheck univariate
-     * consistency check), generate challenge, compute next target sum..., repeat until final round, then use purported
-     * evaluations to generate purported full Honk relation value and check against final target sum.
+     * @brief Extract round univariate, check sum, generate challenge, compute next target sum..., repeat until
+     * final round, then use purported evaluations to generate purported full Honk relation value and check against
+     * final target sum.
      *
      * @details If verification fails, returns std::nullopt, otherwise returns SumcheckOutput
      * @param relation_parameters
-     * @param gate_challenges
-     * @param padding_indicator Optional padding indicator (only used for non-Grumpkin flavors)
-     * @return SumcheckOutput
+     * @param transcript
      */
-    SumcheckOutput<Flavor> verify(const bb::RelationParameters<FF>& relation_parameters,
-                                  const std::vector<FF>& gate_challenges,
-                                  const std::vector<FF>& padding_indicator_array)
+    SumcheckOutput<Flavor> verify(const bb::RelationParameters<FF>& relation_parameters = {},
+                                  const std::vector<FF>& gate_challenges = {},
+                                  const std::vector<FF>& padding_indicator = {})
+        requires(!IsGrumpkinFlavor<Flavor>)
     {
-        bb::GateSeparatorPolynomial<FF> gate_separators(gate_challenges);
-        // Construct a ZKHandler to handle all the libra related information in the transcript
-        VerifierZKCorrectionHandler<Flavor> zk_correction_handler(transcript);
+        bool verified(true);
 
-        // Correct the target sum in the round in the ZK case
-        zk_correction_handler.initialize_target_sum(round);
+        bb::GateSeparatorPolynomial<FF> gate_separators(gate_challenges);
+
+        // Initialize padding indicator to all 1s if not provided
+        std::vector<FF> padding_indicator_array =
+            padding_indicator.empty() ? std::vector<FF>(virtual_log_n, FF(1)) : padding_indicator;
+
+        // All but final round.
+        // target_total_sum is initialized to zero then mutated in place.
+
+        bb::Univariate<FF, BATCHED_RELATION_PARTIAL_LENGTH> round_univariate;
+
+        if constexpr (Flavor::HasZK) {
+            // If running zero-knowledge sumcheck the target total sum is corrected by the claimed sum of libra masking
+            // multivariate over the hypercube
+            libra_total_sum = transcript->template receive_from_prover<FF>("Libra:Sum");
+            libra_challenge = transcript->template get_challenge<FF>("Libra:Challenge");
+            round.target_total_sum = libra_total_sum * libra_challenge;
+        }
 
         std::vector<FF> multivariate_challenge;
         multivariate_challenge.reserve(virtual_log_n);
-
-        // Process univariate consistancy check rounds
-        // For ECCVM we ensure the consistencies by populating an vector of claimed evaluations that will be checked in
-        // the PCS rounds
-        // For other flavors, we perform the sumcheck univariate consistency check
-
-        bool verified = true;
         for (size_t round_idx = 0; round_idx < virtual_log_n; round_idx++) {
-            round.process_round(
-                transcript, multivariate_challenge, gate_separators, padding_indicator_array[round_idx], round_idx);
-            verified = verified && !round.round_failed;
-        }
+            // Obtain the round univariate from the transcript
+            std::string round_univariate_label = "Sumcheck:univariate_" + std::to_string(round_idx);
+            round_univariate =
+                transcript->template receive_from_prover<bb::Univariate<FF, BATCHED_RELATION_PARTIAL_LENGTH>>(
+                    round_univariate_label);
+            FF round_challenge = transcript->template get_challenge<FF>("Sumcheck:u_" + std::to_string(round_idx));
+            multivariate_challenge.emplace_back(round_challenge);
 
-        // Populate claimed evaluations at the challenge
+            const bool checked = round.check_sum(round_univariate, padding_indicator_array[round_idx]);
+            round.compute_next_target_sum(round_univariate, round_challenge, padding_indicator_array[round_idx]);
+            gate_separators.partially_evaluate(round_challenge, padding_indicator_array[round_idx]);
+
+            verified = verified && checked;
+        }
+        // Extract claimed evaluations of Libra univariates and compute their sum multiplied by the Libra challenge
+        // Final round
         ClaimedEvaluations purported_evaluations;
         auto transcript_evaluations =
             transcript->template receive_from_prover<std::array<FF, NUM_POLYNOMIALS>>("Sumcheck:evaluations");
@@ -882,19 +811,156 @@ template <typename Flavor> class SumcheckVerifier {
 
         // For ZK Flavors: compute the evaluation of the Row Disabling Polynomial at the sumcheck challenge and of the
         // libra univariate used to hide the contribution from the actual Honk relation
-        zk_correction_handler.apply_zk_corrections(
-            full_honk_purported_value, multivariate_challenge, padding_indicator_array);
+        if constexpr (Flavor::HasZK) {
+            if constexpr (UseRowDisablingPolynomial<Flavor>) {
+                // Compute the evaluations of the polynomial (1 - \sum L_i) where the sum is for i corresponding to the
+                // rows where all sumcheck relations are disabled
+                full_honk_purported_value *=
+                    RowDisablingPolynomial<FF>::evaluate_at_challenge(multivariate_challenge, padding_indicator_array);
+            }
+
+            libra_evaluation = transcript->template receive_from_prover<FF>("Libra:claimed_evaluation");
+            full_honk_purported_value += libra_evaluation * libra_challenge;
+        }
 
         //! [Final Verification Step]
-        verified = round.perform_final_verification(full_honk_purported_value) && verified;
+        bool final_check(false);
+        if constexpr (IsRecursiveFlavor<Flavor>) {
+            // These booleans are only needed for debugging
+            final_check = (full_honk_purported_value.get_value() == round.target_total_sum.get_value());
+            verified = verified && final_check;
 
+            full_honk_purported_value.assert_equal(round.target_total_sum);
+        } else {
+            final_check = (full_honk_purported_value == round.target_total_sum);
+            verified = verified && final_check;
+        }
+
+        return SumcheckOutput<Flavor>{ .challenge = multivariate_challenge,
+                                       .claimed_evaluations = purported_evaluations,
+                                       .verified = verified,
+                                       .claimed_libra_evaluation = libra_evaluation };
+    };
+
+    /**
+     * @brief Sumcheck Verifier for ECCVM and ECCVMRecursive.
+     * @details The verifier receives commitments to RoundUnivariates, along with their evaluations at 0 and 1. These
+     * evaluations will be proved as a part of Shplemini. The only check that the Verifier performs in this version is
+     * the comparison of the target sumcheck sum with the claimed evaluations of the first sumcheck round univariate at
+     * 0 and 1.
+     *
+     * Note that the SumcheckOutput in this case contains a vector of commitments and a vector of arrays (of size 3) of
+     * evaluations at 0, 1, and a round challenge.
+     *
+     * @param relation_parameters
+     * @param alpha
+     * @param gate_challenges
+     * @return SumcheckOutput<Flavor>
+     */
+    SumcheckOutput<Flavor> verify(const bb::RelationParameters<FF>& relation_parameters,
+                                  const std::vector<FF>& gate_challenges)
+        requires IsGrumpkinFlavor<Flavor>
+    {
+        bool verified(false);
+
+        bb::GateSeparatorPolynomial<FF> gate_separators(gate_challenges);
+
+        // get the claimed sum of libra masking multivariate over the hypercube
+        libra_total_sum = transcript->template receive_from_prover<FF>("Libra:Sum");
+        // get the challenge for the ZK Sumcheck claim
+        const FF libra_challenge = transcript->template get_challenge<FF>("Libra:Challenge");
+
+        std::vector<FF> multivariate_challenge;
+        multivariate_challenge.reserve(virtual_log_n);
+        // if Flavor has ZK, the target total sum is corrected by Libra total sum multiplied by the Libra
+        // challenge
+        round.target_total_sum = libra_total_sum * libra_challenge;
+
+        for (size_t round_idx = 0; round_idx < virtual_log_n; round_idx++) {
+            // Obtain the round univariate from the transcript
+            const std::string round_univariate_comm_label = "Sumcheck:univariate_comm_" + std::to_string(round_idx);
+            const std::string univariate_eval_label_0 = "Sumcheck:univariate_" + std::to_string(round_idx) + "_eval_0";
+            const std::string univariate_eval_label_1 = "Sumcheck:univariate_" + std::to_string(round_idx) + "_eval_1";
+
+            // Receive the commitment to the round univariate
+            round_univariate_commitments.push_back(
+                transcript->template receive_from_prover<Commitment>(round_univariate_comm_label));
+            // Receive evals at 0 and 1
+            round_univariate_evaluations.push_back(
+                { transcript->template receive_from_prover<FF>(univariate_eval_label_0),
+                  transcript->template receive_from_prover<FF>(univariate_eval_label_1) });
+
+            const FF round_challenge =
+                transcript->template get_challenge<FF>("Sumcheck:u_" + std::to_string(round_idx));
+            multivariate_challenge.emplace_back(round_challenge);
+
+            gate_separators.partially_evaluate(round_challenge);
+        }
+
+        FF first_sumcheck_round_evaluations_sum =
+            round_univariate_evaluations[0][0] + round_univariate_evaluations[0][1];
+
+        // Populate claimed evaluations at the challenge
+        ClaimedEvaluations purported_evaluations;
+        auto transcript_evaluations =
+            transcript->template receive_from_prover<std::array<FF, NUM_POLYNOMIALS>>("Sumcheck:evaluations");
+        for (auto [eval, transcript_eval] : zip_view(purported_evaluations.get_all(), transcript_evaluations)) {
+            eval = transcript_eval;
+        }
+        // For ZK Flavors: the evaluation of the Row Disabling Polynomial at the sumcheck challenge
+        // Evaluate the Honk relation at the point (u_0, ..., u_{d-1}) using claimed evaluations of prover polynomials.
+        // In ZK Flavors, the evaluation is corrected by full_libra_purported_value
+        FF full_honk_purported_value = round.compute_full_relation_purported_value(
+            purported_evaluations, relation_parameters, gate_separators, alphas);
+
+        // Compute the evaluations of the polynomial (1 - \sum L_i) where the sum is for i corresponding to the rows
+        // where all sumcheck relations are disabled
+        full_honk_purported_value *=
+            RowDisablingPolynomial<FF>::evaluate_at_challenge(multivariate_challenge, virtual_log_n);
+
+        // Extract claimed evaluations of Libra univariates and compute their sum multiplied by the Libra challenge
+        const FF libra_evaluation = transcript->template receive_from_prover<FF>("Libra:claimed_evaluation");
+        // Verifier computes full ZK Honk value, taking into account the contribution from the disabled row and the
+        // Libra polynomials
+        full_honk_purported_value += libra_evaluation * libra_challenge;
+
+        // Populate claimed evaluations of Sumcheck Round Unviariates at the round challenges. These will be checked as
+        // a part of Shplemini.
+        for (size_t round_idx = 1; round_idx < virtual_log_n; round_idx++) {
+            round_univariate_evaluations[round_idx - 1][2] =
+                round_univariate_evaluations[round_idx][0] + round_univariate_evaluations[round_idx][1];
+        };
+
+        if constexpr (IsRecursiveFlavor<Flavor>) {
+
+            first_sumcheck_round_evaluations_sum.self_reduce();
+            round.target_total_sum.self_reduce();
+
+            // This bool is only needed for debugging
+            verified = (first_sumcheck_round_evaluations_sum.get_value() == round.target_total_sum.get_value());
+            // Ensure that the sum of the evaluations of the first Sumcheck Round Univariate is equal to the claimed
+            // target total sum
+            first_sumcheck_round_evaluations_sum.assert_equal(round.target_total_sum);
+
+            // TODO(https://github.com/AztecProtocol/barretenberg/issues/1197)
+            full_honk_purported_value.self_reduce();
+
+        } else {
+            // Ensure that the sum of the evaluations of the first Sumcheck Round Univariate is equal to the claimed
+            // target total sum
+            verified = (first_sumcheck_round_evaluations_sum == round.target_total_sum);
+        }
+
+        round_univariate_evaluations[virtual_log_n - 1][2] = full_honk_purported_value;
+
+        //! [Final Verification Step]
         // For ZK Flavors: the evaluations of Libra univariates are included in the Sumcheck Output
         return SumcheckOutput<Flavor>{ .challenge = multivariate_challenge,
                                        .claimed_evaluations = purported_evaluations,
                                        .verified = verified,
-                                       .claimed_libra_evaluation = zk_correction_handler.get_libra_evaluation(),
-                                       .round_univariate_commitments = round.get_round_univariate_commitments(),
-                                       .round_univariate_evaluations = round.get_round_univariate_evaluations() };
+                                       .claimed_libra_evaluation = libra_evaluation,
+                                       .round_univariate_commitments = round_univariate_commitments,
+                                       .round_univariate_evaluations = round_univariate_evaluations };
     };
 };
 

--- a/barretenberg/cpp/src/barretenberg/sumcheck/sumcheck_round.hpp
+++ b/barretenberg/cpp/src/barretenberg/sumcheck/sumcheck_round.hpp
@@ -294,7 +294,7 @@ template <typename Flavor> class SumcheckProverRound {
                     accumulate_relation_univariates(thread_univariate_accumulators[thread_idx],
                                                     lazy_extended_edges,
                                                     relation_parameters,
-                                                    gate_separators[edge_idx]);
+                                                    gate_separators[(edge_idx >> 1) * gate_separators.periodicity]);
                 }
             }
         });
@@ -478,7 +478,7 @@ template <typename Flavor> class SumcheckProverRound {
                     // All subrelation in MultilinearBatchingFlavor are linearly dependent, i.e. they are not scaled by
                     // `pow`-polynomial, hence we don't need to initialize `scaling_factor`.
                     if constexpr (!isMultilinearBatchingFlavor<Flavor>) {
-                        scaling_factor = gate_separators[edge_idx];
+                        scaling_factor = gate_separators[(edge_idx >> 1) * gate_separators.periodicity];
                     }
                     accumulate_relation_univariates(thread_univariate_accumulators[chunk.thread_index],
                                                     extended_edges,
@@ -500,6 +500,24 @@ template <typename Flavor> class SumcheckProverRound {
 
         return round_univariate;
     };
+    template <typename ProverPolynomialsOrPartiallyEvaluatedMultivariates>
+    SumcheckRoundUnivariate compute_hiding_univariate(
+        const size_t round_idx,
+        const ProverPolynomialsOrPartiallyEvaluatedMultivariates& polynomials,
+        const bb::RelationParameters<FF>& relation_parameters,
+        const bb::GateSeparatorPolynomial<FF>& gate_separators,
+        const SubrelationSeparators& alpha,
+        const ZKData& zk_sumcheck_data,
+        const RowDisablingPolynomial<FF> row_disabling_polynomial)
+        requires Flavor::HasZK
+    {
+        auto hiding_univariate = compute_libra_univariate(zk_sumcheck_data, round_idx);
+        if constexpr (UseRowDisablingPolynomial<Flavor>) {
+            hiding_univariate -= compute_disabled_contribution(
+                polynomials, relation_parameters, gate_separators, alpha, round_idx, row_disabling_polynomial);
+        }
+        return hiding_univariate;
+    }
 
     /*!
      * @brief For ZK Flavors: A method disabling the last 4 rows of the ProverPolynomials
@@ -528,8 +546,10 @@ template <typename Flavor> class SumcheckProverRound {
 
         for (size_t edge_idx = start_edge_idx; edge_idx < round_size; edge_idx += 2) {
             extend_edges(extended_edges, polynomials, edge_idx);
-            accumulate_relation_univariates(
-                univariate_accumulator, extended_edges, relation_parameters, gate_separators[edge_idx]);
+            accumulate_relation_univariates(univariate_accumulator,
+                                            extended_edges,
+                                            relation_parameters,
+                                            gate_separators[(edge_idx >> 1) * gate_separators.periodicity]);
         }
         result = batch_over_relations<SumcheckRoundUnivariate>(univariate_accumulator, alphas, gate_separators);
         bb::Univariate<FF, 2> row_disabling_factor =
@@ -693,7 +713,7 @@ template <typename Flavor> class SumcheckProverRound {
      * @brief In Round \f$ i \f$, for a given point \f$ \vec \ell \in \{0,1\}^{d-1 - i}\f$, calculate the contribution
      * of each sub-relation to \f$ T^i(X_i) \f$.
      *
-     * @details In Round \f$ i \f$, this method computes the univariate \f$ T^i(X_i) \f$ defined in \ref
+     * @details In Round \f$ i \f$, this method computes the univariate \f$ T^i(X_i) \f$ deined in \ref
      *SumcheckProverContributionsofPow "this section". It is done  as follows:
      *   - Outer loop: iterate through the "edge" points \f$ (0,\vec \ell) \f$ on the boolean hypercube
      *\f$\{0,1\}\times
@@ -755,7 +775,7 @@ template <typename Flavor> class SumcheckProverRound {
  \left(P_1(u_0,\ldots, u_{d-1}), \ldots, P_N(u_0,\ldots, u_{d-1}) \right) \f$ implemented as
  * - \ref compute_full_relation_purported_value method needed at the last verification step.
  */
-template <typename Flavor, bool IsGrumpkin = IsGrumpkinFlavor<Flavor>> class SumcheckVerifierRound {
+template <typename Flavor> class SumcheckVerifierRound {
     using FF = typename Flavor::FF;
     using Utils = bb::RelationUtils<Flavor>;
     using Relations = typename Flavor::Relations;
@@ -765,17 +785,24 @@ template <typename Flavor, bool IsGrumpkin = IsGrumpkinFlavor<Flavor>> class Sum
   public:
     using ClaimedEvaluations = typename Flavor::AllValues;
     using ClaimedLibraEvaluations = typename std::vector<FF>;
-    using Transcript = typename Flavor::Transcript;
-    using Commitment = typename Flavor::Commitment;
 
     bool round_failed = false;
+    /**
+     * @brief Number of batched sub-relations in \f$F\f$ specified by Flavor.
+     *
+     */
     static constexpr size_t NUM_RELATIONS = Flavor::NUM_RELATIONS;
+    /**
+     * @brief The partial algebraic degree of the relation  \f$\tilde F = pow \cdot F \f$, i.e. \ref
+     * MAX_PARTIAL_RELATION_LENGTH "MAX_PARTIAL_RELATION_LENGTH + 1".
+     */
     static constexpr size_t BATCHED_RELATION_PARTIAL_LENGTH = Flavor::BATCHED_RELATION_PARTIAL_LENGTH;
     using SumcheckRoundUnivariate = bb::Univariate<FF, BATCHED_RELATION_PARTIAL_LENGTH>;
 
     FF target_total_sum = 0;
-    TupleOfArraysOfValues relation_evaluations;
 
+    TupleOfArraysOfValues relation_evaluations;
+    // Verifier constructor
     explicit SumcheckVerifierRound(FF target_total_sum = 0)
         : target_total_sum(target_total_sum)
     {
@@ -784,232 +811,66 @@ template <typename Flavor, bool IsGrumpkin = IsGrumpkinFlavor<Flavor>> class Sum
 
     /**
      * @brief Check that the round target sum is correct
+     * @details The verifier receives the claimed evaluations of the round univariate \f$ \tilde{S}^i \f$ at \f$X_i
+     * = 0,\ldots, D \f$ and checks \f$\sigma_i = \tilde{S}^{i-1}(u_{i-1}) \stackrel{?}{=} \tilde{S}^i(0) +
+     * \tilde{S}^i(1) \f$
+     * @param univariate Round univariate \f$\tilde{S}^{i}\f$ represented by its evaluations over \f$0,\ldots,D\f$.
+     *
      */
-    void check_sum(bb::Univariate<FF, BATCHED_RELATION_PARTIAL_LENGTH>& univariate, const FF& indicator)
+    bool check_sum(bb::Univariate<FF, BATCHED_RELATION_PARTIAL_LENGTH>& univariate, const FF& indicator)
     {
         FF total_sum =
             (FF(1) - indicator) * target_total_sum + indicator * (univariate.value_at(0) + univariate.value_at(1));
         bool sumcheck_round_failed(false);
         if constexpr (IsRecursiveFlavor<Flavor>) {
+            // This bool is only needed for debugging
             if (indicator.get_value() == FF{ 1 }.get_value()) {
                 sumcheck_round_failed = (target_total_sum.get_value() != total_sum.get_value());
             }
+
             target_total_sum.assert_equal(total_sum);
         } else {
             sumcheck_round_failed = (target_total_sum != total_sum);
         }
+
         round_failed = round_failed || sumcheck_round_failed;
+        return !sumcheck_round_failed;
     };
 
     /**
-     * @brief Compute the next target sum
+     * @brief After checking that the univariate is good for this round, compute the next target sum given by the
+     * evaluation \f$ \tilde{S}^i(u_i) \f$.
+     *
+     * @param univariate \f$ \tilde{S}^i(X) \f$, given by its evaluations over \f$ \{0,1,2,\ldots, D\}\f$.
+     * @param round_challenge \f$ u_i\f$
+     *
      */
     void compute_next_target_sum(bb::Univariate<FF, BATCHED_RELATION_PARTIAL_LENGTH>& univariate,
                                  FF& round_challenge,
                                  const FF& indicator)
     {
+        // Evaluate \f$\tilde{S}^{i}(u_{i}) \f$
         target_total_sum = (FF(1) - indicator) * target_total_sum + indicator * univariate.evaluate(round_challenge);
     }
 
     /**
-     * @brief Compute the full relation purported value
+     * @brief Given the evaluations  \f$P_1(u_0,\ldots, u_{d-1}), \ldots, P_N(u_0,\ldots, u_{d-1}) \f$ of the
+     * ProverPolynomials at the challenge point \f$(u_0,\ldots, u_{d-1})\f$ stored in \p purported_evaluations, this
+     * method computes the evaluation of \f$ \tilde{F} \f$ taking these values as arguments.
+     *
      */
     FF compute_full_relation_purported_value(const ClaimedEvaluations& purported_evaluations,
                                              const bb::RelationParameters<FF>& relation_parameters,
                                              const bb::GateSeparatorPolynomial<FF>& gate_separators,
                                              const SubrelationSeparators& alphas)
     {
+        // The verifier should never skip computation of contributions from any relation
         Utils::template accumulate_relation_evaluations_without_skipping<>(purported_evaluations,
                                                                            relation_evaluations,
                                                                            relation_parameters,
                                                                            gate_separators.partial_evaluation_result);
+
         return Utils::scale_and_batch_elements(relation_evaluations, alphas);
     }
-
-    /**
-     * @brief Process a single sumcheck round: receive univariate from transcript, verify sum, generate challenge.
-     * 1. gets the round univariate and round challenge
-     * 2. checks the consistency of the new round univariate with respect to the one from the previous round
-     * 3. updates the target for the next consistency check
-     */
-    void process_round(const std::shared_ptr<Transcript>& transcript,
-                       std::vector<FF>& multivariate_challenge,
-                       bb::GateSeparatorPolynomial<FF>& gate_separators,
-                       const FF& padding_indicator,
-                       size_t round_idx)
-    {
-        // Obtain the round univariate from the transcript
-        std::string round_univariate_label = "Sumcheck:univariate_" + std::to_string(round_idx);
-        auto round_univariate =
-            transcript->template receive_from_prover<bb::Univariate<FF, BATCHED_RELATION_PARTIAL_LENGTH>>(
-                round_univariate_label);
-        FF round_challenge = transcript->template get_challenge<FF>("Sumcheck:u_" + std::to_string(round_idx));
-        multivariate_challenge.emplace_back(round_challenge);
-        // Check that $\tilde{S}^{i-1}(u_{i-1}) == \tilde{S}^{i}(0) + \tilde{S}^{i}(1)$
-        // For i = 0, check that $\tilde{S}^0(u_0) == target_total_sum$
-        check_sum(round_univariate, padding_indicator);
-        // Evaluate $\tilde{S}^{i}(u_i)$
-        compute_next_target_sum(round_univariate, round_challenge, padding_indicator);
-        gate_separators.partially_evaluate(round_challenge, padding_indicator);
-    }
-
-    /**
-     * @brief Perform final verification: check that the computed target sum matches the full relation evaluation. i.e.
-     * the final evaluation check
-     */
-    bool perform_final_verification(const FF& full_honk_purported_value)
-    {
-        bool verified = false;
-        if constexpr (IsRecursiveFlavor<Flavor>) {
-            verified = (full_honk_purported_value.get_value() == target_total_sum.get_value());
-            full_honk_purported_value.assert_equal(target_total_sum);
-        } else {
-            verified = (full_honk_purported_value == target_total_sum);
-        }
-        return verified;
-    }
-
-    /**
-     * @brief Get round univariate commitments (only used for Grumpkin flavors).
-     */
-    std::vector<Commitment> get_round_univariate_commitments() { return {}; }
-
-    /**
-     * @brief Get round univariate evaluations (only used for Grumpkin flavors).
-     */
-    std::vector<std::array<FF, 3>> get_round_univariate_evaluations() { return {}; }
-};
-
-/**
- * @brief Specialization for Grumpkin flavors: receive commitments and evaluations,
- * defer per-round verification to Shplemini.
- */
-template <typename Flavor> class SumcheckVerifierRound<Flavor, true> {
-    using FF = typename Flavor::FF;
-    using Utils = bb::RelationUtils<Flavor>;
-    using Relations = typename Flavor::Relations;
-    using TupleOfArraysOfValues = decltype(create_tuple_of_arrays_of_values<typename Flavor::Relations>());
-    using SubrelationSeparators = std::array<FF, Flavor::NUM_SUBRELATIONS - 1>;
-
-  public:
-    using ClaimedEvaluations = typename Flavor::AllValues;
-    using ClaimedLibraEvaluations = typename std::vector<FF>;
-    using Transcript = typename Flavor::Transcript;
-    using Commitment = typename Flavor::Commitment;
-
-    bool round_failed = false;
-    static constexpr size_t NUM_RELATIONS = Flavor::NUM_RELATIONS;
-    static constexpr size_t BATCHED_RELATION_PARTIAL_LENGTH = Flavor::BATCHED_RELATION_PARTIAL_LENGTH;
-    using SumcheckRoundUnivariate = bb::Univariate<FF, BATCHED_RELATION_PARTIAL_LENGTH>;
-
-    FF target_total_sum = 0;
-    TupleOfArraysOfValues relation_evaluations;
-
-    // Grumpkin-specific state for Shplemini
-    std::vector<Commitment> round_univariate_commitments;
-    std::vector<std::array<FF, 3>> round_univariate_evaluations;
-
-    explicit SumcheckVerifierRound(FF target_total_sum = 0)
-        : target_total_sum(target_total_sum)
-    {
-        Utils::zero_elements(relation_evaluations);
-    };
-
-    /**
-     * @brief Compute the full relation purported value
-     */
-    FF compute_full_relation_purported_value(const ClaimedEvaluations& purported_evaluations,
-                                             const bb::RelationParameters<FF>& relation_parameters,
-                                             const bb::GateSeparatorPolynomial<FF>& gate_separators,
-                                             const SubrelationSeparators& alphas)
-    {
-        Utils::template accumulate_relation_evaluations_without_skipping<>(purported_evaluations,
-                                                                           relation_evaluations,
-                                                                           relation_parameters,
-                                                                           gate_separators.partial_evaluation_result);
-        return Utils::scale_and_batch_elements(relation_evaluations, alphas);
-    }
-
-    /**
-     * @brief Process a single sumcheck round for Grumpkin: receive commitment and evaluations,
-     * defer per-round verification to Shplemini.
-     */
-    void process_round(const std::shared_ptr<Transcript>& transcript,
-                       std::vector<FF>& multivariate_challenge,
-                       bb::GateSeparatorPolynomial<FF>& gate_separators,
-                       const FF& /*padding_indicator*/,
-                       size_t round_idx)
-    {
-        // For Grumpkin, we don't use padding_indicator
-        const std::string round_univariate_comm_label = "Sumcheck:univariate_comm_" + std::to_string(round_idx);
-        const std::string univariate_eval_label_0 = "Sumcheck:univariate_" + std::to_string(round_idx) + "_eval_0";
-        const std::string univariate_eval_label_1 = "Sumcheck:univariate_" + std::to_string(round_idx) + "_eval_1";
-
-        // Receive the commitment to the round univariate
-        round_univariate_commitments.push_back(
-            transcript->template receive_from_prover<Commitment>(round_univariate_comm_label));
-        // Receive evals at 0 and 1
-        round_univariate_evaluations.push_back(
-            { transcript->template receive_from_prover<FF>(univariate_eval_label_0),
-              transcript->template receive_from_prover<FF>(univariate_eval_label_1),
-              FF(0) }); // Third element will be populated in perform_final_verification
-
-        const FF round_challenge = transcript->template get_challenge<FF>("Sumcheck:u_" + std::to_string(round_idx));
-        multivariate_challenge.emplace_back(round_challenge);
-
-        gate_separators.partially_evaluate(round_challenge);
-
-        // For Grumpkin, we don't perform per-round verification here
-        // It will be deferred to the final check
-    }
-
-    /**
-     * @brief Perform final verification for Grumpkin: check first round sum, populate Shplemini data, and store final
-     * evaluation.
-     */
-    bool perform_final_verification(const FF& full_honk_purported_value)
-    {
-        // Compute the sum of evaluations at 0 and 1 for the first round
-        FF first_sumcheck_round_evaluations_sum =
-            round_univariate_evaluations[0][0] + round_univariate_evaluations[0][1];
-
-        bool verified = false;
-        if constexpr (IsRecursiveFlavor<Flavor>) {
-            first_sumcheck_round_evaluations_sum.self_reduce();
-            target_total_sum.self_reduce();
-            // This bool is only needed for debugging
-            verified = (first_sumcheck_round_evaluations_sum.get_value() == target_total_sum.get_value());
-            // Ensure that the sum of the evaluations of the first Sumcheck Round Univariate is equal to the claimed
-            // target total sum
-            first_sumcheck_round_evaluations_sum.assert_equal(target_total_sum);
-
-            full_honk_purported_value.self_reduce();
-        } else {
-            // Ensure that the sum of the evaluations of the first Sumcheck Round Univariate is equal to the claimed
-            // target total sum
-            verified = (first_sumcheck_round_evaluations_sum == target_total_sum);
-        }
-
-        // Populate claimed evaluations of Sumcheck Round Univariates at the round challenges.
-        // These will be checked as a part of Shplemini.
-        for (size_t round_idx = 1; round_idx < round_univariate_evaluations.size(); round_idx++) {
-            round_univariate_evaluations[round_idx - 1][2] =
-                round_univariate_evaluations[round_idx][0] + round_univariate_evaluations[round_idx][1];
-        }
-
-        // Store the final evaluation for Shplemini
-        round_univariate_evaluations[round_univariate_evaluations.size() - 1][2] = full_honk_purported_value;
-        return verified;
-    }
-
-    /**
-     * @brief Get round univariate commitments for Shplemini.
-     */
-    std::vector<Commitment> get_round_univariate_commitments() { return round_univariate_commitments; }
-
-    /**
-     * @brief Get round univariate evaluations for Shplemini.
-     */
-    std::vector<std::array<FF, 3>> get_round_univariate_evaluations() { return round_univariate_evaluations; }
 };
 } // namespace bb

--- a/barretenberg/cpp/src/barretenberg/sumcheck/zk_sumcheck_data.hpp
+++ b/barretenberg/cpp/src/barretenberg/sumcheck/zk_sumcheck_data.hpp
@@ -263,7 +263,9 @@ template <typename Flavor> struct ZKSumcheckData {
      last univariate in the table \f$\texttt{libra_univariates}\f$ and dividing the result by \f$
      \texttt{libra_challenge} \f$.
         -  update the table of Libra univariates by multiplying every term by \f$\texttt{libra_challenge}^{-1}\f$.
-
+     @todo Refactor once the Libra univariates are extracted from the Proving Key. Then the prover does not need to
+        update the first round_idx - 1 univariates and could release the memory. Also, use batch_invert / reduce
+        the number of divisions by 2.
      * @param libra_univariates
      * @param round_challenge
      * @param round_idx


### PR DESCRIPTION
Reverts AztecProtocol/aztec-packages#18549