### PR TITLE
chore: bind P2P to public IP correctly

### DIFF
--- a/spartan/aztec-node/templates/_pod-template.yaml
+++ b/spartan/aztec-node/templates/_pod-template.yaml
@@ -72,13 +72,14 @@ spec:
         - /bin/bash
         - -c
         - |
-          {{- if or .Values.service.p2p.nodePortEnabled .Values.hostNetwork }}
           if [ -f /shared/init-nodeport ]; then
             source /shared/init-nodeport;
           fi
-          export P2P_QUERY_FOR_IP=true
+
+          {{- if .Values.service.p2p.publicIP }}
+            export P2P_QUERY_FOR_IP=true
           {{- else }}
-          export P2P_IP=$(hostname -i)
+            export P2P_IP=$(hostname -i)
           {{- end }}
 
           start_cmd=("node" "/usr/src/yarn-project/aztec/dest/bin/index.js" "start" {{ join " " .Values.node.startCmd }})

--- a/spartan/aztec-node/values.yaml
+++ b/spartan/aztec-node/values.yaml
@@ -188,6 +188,7 @@ service:
   p2p:
     enabled: true
     nodePortEnabled: false
+    publicIP: true
     port: 40400
     announcePort: 40400
 


### PR DESCRIPTION
I introduced a bug in #18599 when switching from `hostNetwork: true` to host-mapped ports where the pods no longer query for their public IP address. This PR fixes it.