### PR TITLE
fix(bb.js): forward worker thread logs through user-provided logger

### DIFF
--- a/barretenberg/ts/src/barretenberg_wasm/barretenberg_wasm_thread/index.ts
+++ b/barretenberg/ts/src/barretenberg_wasm/barretenberg_wasm_thread/index.ts
@@ -5,9 +5,10 @@ import { BarretenbergWasmBase } from '../barretenberg_wasm_base/index.js';
 export class BarretenbergWasmThread extends BarretenbergWasmBase {
   /**
    * Init as worker thread.
+   * @param useCustomLogger - If true, logs will be posted back to main thread for custom logger routing
    */
-  public async initThread(module: WebAssembly.Module, memory: WebAssembly.Memory) {
-    this.logger = threadLogger() || this.logger;
+  public async initThread(module: WebAssembly.Module, memory: WebAssembly.Memory, useCustomLogger = false) {
+    this.logger = threadLogger(useCustomLogger) || this.logger;
     this.memory = memory;
     this.instance = await WebAssembly.instantiate(module, this.getImportObj(this.memory));
   }

--- a/barretenberg/ts/src/barretenberg_wasm/helpers/browser/index.ts
+++ b/barretenberg/ts/src/barretenberg_wasm/helpers/browser/index.ts
@@ -13,7 +13,14 @@ export function getNumCpu() {
   return navigator.hardwareConcurrency;
 }
 
-export function threadLogger(): ((msg: string) => void) | undefined {
+export function threadLogger(useCustomLogger: boolean): ((msg: string) => void) | undefined {
+  if (useCustomLogger) {
+    // Post log messages back to main thread for routing through user-provided logger
+    return (msg: string) => {
+      postMessage({ type: 'log', msg });
+    };
+  }
+  // Use console.log directly when no custom logger is provided
   return console.log;
 }
 


### PR DESCRIPTION
## Summary
- Custom loggers passed to `Barretenberg.new()` were only honored on the main thread
- Worker threads always used `console.log` (browser) or `writeSync` to stdout (node), ignoring the user's logger
- This adds message passing so worker logs are forwarded to the main thread and routed through the user-provided logger