### PR TITLE
fix(bb.js): pass console.log logger in tests to avoid Jest noise

### DIFF
--- a/barretenberg/acir_tests/bbjs-test/src/index.ts
+++ b/barretenberg/acir_tests/bbjs-test/src/index.ts
@@ -29,7 +29,7 @@ async function generateProof({
   logger.debug(`Generating proof for ${bytecodePath}...`);
   const circuitArtifact = await fs.readFile(bytecodePath);
   const bytecode = JSON.parse(circuitArtifact.toString()).bytecode;
-  const bb = await Barretenberg.new({ threads: multiThreaded ? 8 : 1 });
+  const bb = await Barretenberg.new({ threads: multiThreaded ? 8 : 1, logger: console.log });
   const backend = new UltraHonkBackend(bytecode, bb);
 
   const witness = await fs.readFile(witnessPath);
@@ -64,7 +64,7 @@ async function generateProof({
 async function verifyProof({ directory }: { directory: string }) {
   const { UltraHonkVerifierBackend, Barretenberg } = await import('@aztec/bb.js');
 
-  const bb = await Barretenberg.new({ threads: 1 });
+  const bb = await Barretenberg.new({ threads: 1, logger: console.log });
   const verifier = new UltraHonkVerifierBackend(bb);
 
   const proof = await fs.readFile(proofPath(directory));

--- a/barretenberg/docs/examples/basic.test.ts
+++ b/barretenberg/docs/examples/basic.test.ts
@@ -170,7 +170,7 @@ describe('Basic Barretenberg Example', () => {
     this.timeout(60000);
 
     // docs:start:low_level_api
-    const api = await Barretenberg.new({ threads: 1 });
+    const api = await Barretenberg.new({ threads: 1, logger: console.log });
 
     // Blake2s hashing
     const input = Buffer.from('hello world!');

--- a/barretenberg/docs/examples/recursive.test.ts
+++ b/barretenberg/docs/examples/recursive.test.ts
@@ -98,7 +98,7 @@ describe('Recursive Aggregation Example', () => {
 
     // docs:start:recursive_inputs
     // Convert proof and VK to fields for recursive circuit
-    const barretenbergAPI = await Barretenberg.new({ threads: 1 });
+    const barretenbergAPI = await Barretenberg.new({ threads: 1, logger: console.log });
     const vkAsFields = (await barretenbergAPI.acirVkAsFieldsUltraHonk(new RawBuffer(mainVerificationKey))).map(field =>
       field.toString(),
     );

--- a/barretenberg/ts/src/barretenberg/blake2s.test.ts
+++ b/barretenberg/ts/src/barretenberg/blake2s.test.ts
@@ -6,7 +6,7 @@ describe('blake2s async', () => {
 
   beforeAll(async () => {
     // We're going to test over a worker backend to cover more code paths.
-    api = await Barretenberg.new({ threads: 1, backend: BackendType.WasmWorker });
+    api = await Barretenberg.new({ threads: 1, backend: BackendType.WasmWorker, logger: console.log });
   });
 
   afterAll(async () => {
@@ -41,7 +41,7 @@ describe('blake2s sync', () => {
   let api: BarretenbergSync;
 
   beforeAll(async () => {
-    api = await BarretenbergSync.initSingleton();
+    api = await BarretenbergSync.initSingleton({ logger: console.log });
   });
 
   it('blake2s', () => {

--- a/barretenberg/ts/src/barretenberg/poseidon.bench.test.ts
+++ b/barretenberg/ts/src/barretenberg/poseidon.bench.test.ts
@@ -25,8 +25,8 @@ describe('poseidon2Hash benchmark (Async API): WASM vs Native', () => {
   beforeAll(async () => {
     // Setup direct WASM access for baseline benchmark (always required)
     wasm = new BarretenbergWasmMain();
-    const { module } = await fetchModuleAndThreads(1);
-    await wasm.init(module, 1);
+    const { module } = await fetchModuleAndThreads(1, undefined, console.log);
+    await wasm.init(module, 1, console.log);
 
     // Setup WASM API
     try {
@@ -65,6 +65,14 @@ describe('poseidon2Hash benchmark (Async API): WASM vs Native', () => {
       );
     }
   }, 20000);
+
+  afterAll(async () => {
+    await wasm.destroy();
+    await wasmApi?.destroy();
+    await nativeSocketApi?.destroy();
+    await nativeShmApi?.destroy();
+    await nativeShmSyncApi?.destroy();
+  });
 
   it.each(SIZES)(
     'benchmark with %p field elements',

--- a/barretenberg/ts/src/barretenberg/poseidon.bench.test.ts
+++ b/barretenberg/ts/src/barretenberg/poseidon.bench.test.ts
@@ -30,14 +30,14 @@ describe('poseidon2Hash benchmark (Async API): WASM vs Native', () => {
 
     // Setup WASM API
     try {
-      wasmApi = await Barretenberg.new({ backend: BackendType.Wasm, threads: 1 });
+      wasmApi = await Barretenberg.new({ backend: BackendType.Wasm, threads: 1, logger: console.log });
     } catch (error) {
       console.warn('Failed to initialize WASM backend:', error instanceof Error ? error.message : String(error));
     }
 
     // Setup native socket API
     try {
-      nativeSocketApi = await Barretenberg.new({ backend: BackendType.NativeUnixSocket, threads: 1 });
+      nativeSocketApi = await Barretenberg.new({ backend: BackendType.NativeUnixSocket, threads: 1, logger: console.log });
     } catch (error) {
       console.warn(
         'Failed to initialize Native Socket backend:',
@@ -47,7 +47,7 @@ describe('poseidon2Hash benchmark (Async API): WASM vs Native', () => {
 
     // Setup native shared memory API (async)
     try {
-      nativeShmApi = await Barretenberg.new({ backend: BackendType.NativeSharedMemory, threads: 1 });
+      nativeShmApi = await Barretenberg.new({ backend: BackendType.NativeSharedMemory, threads: 1, logger: console.log });
     } catch (error) {
       console.warn(
         'Failed to initialize Native Shared Memory (async) backend:',
@@ -57,7 +57,7 @@ describe('poseidon2Hash benchmark (Async API): WASM vs Native', () => {
 
     // Setup native shared memory API (sync)
     try {
-      nativeShmSyncApi = await BarretenbergSync.new({ backend: BackendType.NativeSharedMemory, threads: 1 });
+      nativeShmSyncApi = await BarretenbergSync.new({ backend: BackendType.NativeSharedMemory, threads: 1, logger: console.log });
     } catch (error) {
       console.warn(
         'Failed to initialize Native Shared Memory (sync) backend:',

--- a/barretenberg/ts/src/bb_backends/node/native_socket.ts
+++ b/barretenberg/ts/src/bb_backends/node/native_socket.ts
@@ -41,6 +41,10 @@ export class BarretenbergNativeSocketAsyncBackend implements IMsgpackBackendAsyn
   private responseBuffer: Buffer | null = null;
   private responseBytesRead: number = 0;
 
+  // Readline interfaces for stdout/stderr - stored so we can close them on destroy
+  private stdoutReader: readline.Interface | null = null;
+  private stderrReader: readline.Interface | null = null;
+
   constructor(bbBinaryPath: string, threads?: number, logger?: (msg: string) => void) {
     // Create a unique socket path in temp directory
     this.socketPath = path.join(os.tmpdir(), `bb-${process.pid}-${Date.now()}.sock`);
@@ -76,8 +80,10 @@ export class BarretenbergNativeSocketAsyncBackend implements IMsgpackBackendAsyn
 
     if (logger) {
       logger("Logger attached to bb process. DON'T FORGET TO DESTROY THE BACKEND to allow Node.js to exit.");
-      readline.createInterface({ input: this.process.stdout! }).on('line', logger);
-      readline.createInterface({ input: this.process.stderr! }).on('line', logger);
+      this.stdoutReader = readline.createInterface({ input: this.process.stdout! });
+      this.stderrReader = readline.createInterface({ input: this.process.stderr! });
+      this.stdoutReader.on('line', logger);
+      this.stderrReader.on('line', logger);
     }
 
     this.process.on('error', err => {
@@ -319,6 +325,11 @@ export class BarretenbergNativeSocketAsyncBackend implements IMsgpackBackendAsyn
   }
 
   async destroy(): Promise<void> {
+    // Close readline interfaces first to prevent "Cannot log after tests are done" warnings
+    // This stops forwarding bb's shutdown logs to the logger after Jest has finished
+    this.stdoutReader?.close();
+    this.stderrReader?.close();
+
     this.cleanup();
     this.process.kill('SIGTERM');
     this.process.removeAllListeners();

--- a/barretenberg/ts/src/log/logger.ts
+++ b/barretenberg/ts/src/log/logger.ts
@@ -1,13 +1,10 @@
 /**
  * Create a logger function with a specific name prefix.
- * Outputs to stderr to avoid interfering with stdout-based command pipelines.
  * @param name - The name to prefix log messages with
  * @returns A logger function
  */
 export function createDebugLogger(name: string): (msg: string) => void {
   return (msg: string) => {
-    // Use console.error to write to stderr, not stdout
-    // This prevents logger output from interfering with command output parsing
-    console.error(`[${name}] ${msg}`);
+    console.log(`[${name}] ${msg}`);
   };
 }

--- a/barretenberg/ts/src/log/logger.ts
+++ b/barretenberg/ts/src/log/logger.ts
@@ -1,10 +1,13 @@
 /**
  * Create a logger function with a specific name prefix.
+ * Outputs to stderr to avoid interfering with stdout-based command pipelines.
  * @param name - The name to prefix log messages with
  * @returns A logger function
  */
 export function createDebugLogger(name: string): (msg: string) => void {
   return (msg: string) => {
-    console.log(`[${name}] ${msg}`);
+    // Use console.error to write to stderr, not stdout
+    // This prevents logger output from interfering with command output parsing
+    console.error(`[${name}] ${msg}`);
   };
 }


### PR DESCRIPTION
Pass `console.log` as custom logger in bb.js tests instead of relying on the default `console.error` logger.

Jest adds stack traces to `console.error` output, making test logs verbose and hard to read. Using `console.log` avoids this while keeping `console.error` as the default for production (to avoid stdout pipeline interference).

Also adds `afterAll` cleanup to poseidon benchmark test to properly destroy backends and prevent "Jest did not exit" warnings.