### PR TITLE
fix: Inject version searches for previous commit hash if not placeholder found

### DIFF
--- a/barretenberg/cpp/bootstrap.sh
+++ b/barretenberg/cpp/bootstrap.sh
@@ -23,10 +23,12 @@ function inject_version {
     echo_stderr "Error: version ($version) is longer than placeholder. Cannot update bb binaries."
     exit 1
   fi
+  # Try to find the default placeholder first
   local offset=$(grep -aobF "$placeholder" $binary | head -n 1 | cut -d: -f1)
   if [ -z "$offset" ]; then
-    echo "Placeholder not found in $binary, can't inject version."
-    exit 1
+    # Placeholder not found, try to find the current version (already injected)
+    local current_version=$(git rev-parse --short HEAD)
+    offset=$(grep -aobF "$current_version" $binary | head -n 1 | cut -d: -f1)
   fi
   printf "$version\0" | dd of=$binary bs=1 seek=$offset conv=notrunc 2>/dev/null
 }


### PR DESCRIPTION
The script `inject_version` searches for a placeholder hash. If a previous run has already injected a commit hash, the script fails on another call of `bootstrap.sh` because the placeholder is not there anymore. We modify the script to search for the previous commit hash if the placeholder is not found.