### PR TITLE
chore: remove state reference from consensus payload

### DIFF
--- a/l1-contracts/src/core/libraries/rollup/ProposeLib.sol
+++ b/l1-contracts/src/core/libraries/rollup/ProposeLib.sol
@@ -14,21 +14,17 @@ import {ValidatorSelectionLib} from "@aztec/core/libraries/rollup/ValidatorSelec
 import {Timestamp, Slot, Epoch, TimeLib} from "@aztec/core/libraries/TimeLib.sol";
 import {CompressedSlot, CompressedTimeMath} from "@aztec/shared/libraries/CompressedTimeMath.sol";
 import {Signature} from "@aztec/shared/libraries/SignatureLib.sol";
-import {ProposedHeader, ProposedHeaderLib, StateReference} from "./ProposedHeaderLib.sol";
+import {ProposedHeader, ProposedHeaderLib} from "./ProposedHeaderLib.sol";
 import {STFLib} from "./STFLib.sol";
 
 struct ProposeArgs {
   bytes32 archive;
-  // TODO: Remove the `stateReference` as it's not part of the checkpoint header. And we don't need to get it from the
-  // calldata to validate the world state (only the new archive root is needed).
-  StateReference stateReference;
   OracleInput oracleInput;
   ProposedHeader header;
 }
 
 struct ProposePayload {
   bytes32 archive;
-  StateReference stateReference;
   OracleInput oracleInput;
   bytes32 headerHash;
 }
@@ -212,14 +208,8 @@ library ProposeLib {
     }
 
     // Create payload digest signed by the committee members
-    v.payloadDigest = digest(
-      ProposePayload({
-        archive: _args.archive,
-        stateReference: _args.stateReference,
-        oracleInput: _args.oracleInput,
-        headerHash: v.headerHash
-      })
-    );
+    v.payloadDigest =
+      digest(ProposePayload({archive: _args.archive, oracleInput: _args.oracleInput, headerHash: v.headerHash}));
 
     // Validate checkpoint header
     validateHeader(

--- a/l1-contracts/src/core/libraries/rollup/ProposedHeaderLib.sol
+++ b/l1-contracts/src/core/libraries/rollup/ProposedHeaderLib.sol
@@ -12,18 +12,6 @@ struct AppendOnlyTreeSnapshot {
   uint32 nextAvailableLeafIndex;
 }
 
-struct PartialStateReference {
-  AppendOnlyTreeSnapshot noteHashTree;
-  AppendOnlyTreeSnapshot nullifierTree;
-  AppendOnlyTreeSnapshot publicDataTree;
-}
-
-struct StateReference {
-  AppendOnlyTreeSnapshot l1ToL2MessageTree;
-  // Note: Can't use "partial" name here as in protocol specs because it is a reserved solidity keyword
-  PartialStateReference partialStateReference;
-}
-
 struct GasFees {
   uint128 feePerDaGas;
   uint128 feePerL2Gas;

--- a/l1-contracts/test/Rollup.t.sol
+++ b/l1-contracts/test/Rollup.t.sol
@@ -235,9 +235,7 @@ contract RollupTest is RollupBase {
     bytes32[] memory blobHashes = new bytes32[](1);
     blobHashes[0] = bytes32(uint256(1));
     vm.blobhashes(blobHashes);
-    ProposeArgs memory args = ProposeArgs({
-      header: data.header, archive: data.archive, stateReference: EMPTY_STATE_REFERENCE, oracleInput: OracleInput(0)
-    });
+    ProposeArgs memory args = ProposeArgs({header: data.header, archive: data.archive, oracleInput: OracleInput(0)});
     bytes32 realBlobHash = this.getBlobHashes(data.blobCommitments)[0];
     vm.expectRevert(abi.encodeWithSelector(Errors.Rollup__InvalidBlobHash.selector, blobHashes[0], realBlobHash));
     rollup.propose(
@@ -326,9 +324,7 @@ contract RollupTest is RollupBase {
     skipBlobCheck(address(rollup));
 
     vm.expectRevert(abi.encodeWithSelector(Errors.Rollup__NonZeroDaFee.selector));
-    ProposeArgs memory args = ProposeArgs({
-      header: header, archive: data.archive, stateReference: EMPTY_STATE_REFERENCE, oracleInput: OracleInput(0)
-    });
+    ProposeArgs memory args = ProposeArgs({header: header, archive: data.archive, oracleInput: OracleInput(0)});
     rollup.propose(
       args,
       AttestationLibHelper.packAttestations(attestations),
@@ -355,9 +351,7 @@ contract RollupTest is RollupBase {
 
     // When not canonical, we expect the fee to be 0
     vm.expectRevert(abi.encodeWithSelector(Errors.Rollup__InvalidManaBaseFee.selector, expectedFee, 1));
-    ProposeArgs memory args = ProposeArgs({
-      header: header, archive: data.archive, stateReference: EMPTY_STATE_REFERENCE, oracleInput: OracleInput(0)
-    });
+    ProposeArgs memory args = ProposeArgs({header: header, archive: data.archive, oracleInput: OracleInput(0)});
     rollup.propose(
       args,
       AttestationLibHelper.packAttestations(attestations),
@@ -462,9 +456,7 @@ contract RollupTest is RollupBase {
       interim.feeAmount = interim.manaUsed * interim.baseFee + interim.portalBalance;
 
       // Assert that balance have NOT been increased by proposing the checkpoint
-      ProposeArgs memory args = ProposeArgs({
-        header: header, archive: data.archive, stateReference: EMPTY_STATE_REFERENCE, oracleInput: OracleInput(0)
-      });
+      ProposeArgs memory args = ProposeArgs({header: header, archive: data.archive, oracleInput: OracleInput(0)});
       rollup.propose(
         args,
         AttestationLibHelper.packAttestations(attestations),
@@ -690,9 +682,7 @@ contract RollupTest is RollupBase {
 
     skipBlobCheck(address(rollup));
     vm.expectRevert(abi.encodeWithSelector(Errors.Rollup__InvalidTimestamp.selector, realTs, badTs));
-    ProposeArgs memory args = ProposeArgs({
-      header: header, archive: archive, stateReference: EMPTY_STATE_REFERENCE, oracleInput: OracleInput(0)
-    });
+    ProposeArgs memory args = ProposeArgs({header: header, archive: archive, oracleInput: OracleInput(0)});
     rollup.propose(
       args,
       AttestationLibHelper.packAttestations(attestations),
@@ -718,9 +708,7 @@ contract RollupTest is RollupBase {
     vm.blobhashes(blobHashes);
     skipBlobCheck(address(rollup));
     vm.expectRevert(abi.encodeWithSelector(Errors.Rollup__InvalidCoinbase.selector));
-    ProposeArgs memory args = ProposeArgs({
-      header: header, archive: archive, stateReference: EMPTY_STATE_REFERENCE, oracleInput: OracleInput(0)
-    });
+    ProposeArgs memory args = ProposeArgs({header: header, archive: archive, oracleInput: OracleInput(0)});
     rollup.propose(
       args,
       AttestationLibHelper.packAttestations(attestations),
@@ -782,9 +770,7 @@ contract RollupTest is RollupBase {
     header.gasFees.feePerL2Gas = uint128(rollup.getManaBaseFeeAt(Timestamp.wrap(block.timestamp), true));
 
     vm.expectRevert(abi.encodeWithSelector(Errors.Rollup__NoBlobsInCheckpoint.selector));
-    ProposeArgs memory args = ProposeArgs({
-      header: header, archive: archive, stateReference: EMPTY_STATE_REFERENCE, oracleInput: OracleInput(0)
-    });
+    ProposeArgs memory args = ProposeArgs({header: header, archive: archive, oracleInput: OracleInput(0)});
     rollup.propose(
       args,
       AttestationLibHelper.packAttestations(attestations),

--- a/l1-contracts/test/base/Base.sol
+++ b/l1-contracts/test/base/Base.sol
@@ -5,11 +5,7 @@ import {Timestamp, Slot, Epoch} from "@aztec/core/libraries/TimeLib.sol";
 import {Test} from "forge-std/Test.sol";
 import {stdStorage, StdStorage} from "forge-std/Test.sol";
 import {AttesterView, Exit, Status, AttesterConfig} from "@aztec/core/libraries/rollup/StakingLib.sol";
-import {
-  AppendOnlyTreeSnapshot,
-  PartialStateReference,
-  StateReference
-} from "@aztec/core/libraries/rollup/ProposedHeaderLib.sol";
+import {AppendOnlyTreeSnapshot} from "@aztec/core/libraries/rollup/ProposedHeaderLib.sol";
 
 contract TestBase is Test {
   using stdStorage for StdStorage;
@@ -17,16 +13,6 @@ contract TestBase is Test {
   // Empty values
   AppendOnlyTreeSnapshot EMPTY_APPENDONLY_TREE_SNAPSHOT =
     AppendOnlyTreeSnapshot({root: bytes32(0), nextAvailableLeafIndex: 0});
-
-  PartialStateReference EMPTY_PARTIALSTATE_REFERENCE = PartialStateReference({
-    noteHashTree: EMPTY_APPENDONLY_TREE_SNAPSHOT,
-    nullifierTree: EMPTY_APPENDONLY_TREE_SNAPSHOT,
-    publicDataTree: EMPTY_APPENDONLY_TREE_SNAPSHOT
-  });
-
-  StateReference EMPTY_STATE_REFERENCE = StateReference({
-    l1ToL2MessageTree: EMPTY_APPENDONLY_TREE_SNAPSHOT, partialStateReference: EMPTY_PARTIALSTATE_REFERENCE
-  });
 
   function assertGt(Timestamp a, Timestamp b) internal {
     if (a <= b) {

--- a/l1-contracts/test/base/RollupBase.sol
+++ b/l1-contracts/test/base/RollupBase.sol
@@ -187,12 +187,8 @@ contract RollupBase is DecoderBase {
       }
     }
 
-    ProposeArgs memory args = ProposeArgs({
-      header: full.checkpoint.header,
-      archive: full.checkpoint.archive,
-      stateReference: EMPTY_STATE_REFERENCE,
-      oracleInput: OracleInput(0)
-    });
+    ProposeArgs memory args =
+      ProposeArgs({header: full.checkpoint.header, archive: full.checkpoint.archive, oracleInput: OracleInput(0)});
 
     if (_revertMsg.length > 0) {
       vm.expectRevert(_revertMsg);

--- a/l1-contracts/test/benchmark/happy.t.sol
+++ b/l1-contracts/test/benchmark/happy.t.sol
@@ -304,7 +304,6 @@ contract BenchmarkRollupTest is FeeModelTestPoints, DecoderBase {
     ProposeArgs memory proposeArgs = ProposeArgs({
       header: header,
       archive: archiveRoot,
-      stateReference: EMPTY_STATE_REFERENCE,
       oracleInput: OracleInput({feeAssetPriceModifier: point.oracle_input.fee_asset_price_modifier})
     });
 
@@ -319,12 +318,8 @@ contract BenchmarkRollupTest is FeeModelTestPoints, DecoderBase {
 
       bytes32 headerHash = ProposedHeaderLib.hash(proposeArgs.header);
 
-      ProposePayload memory proposePayload = ProposePayload({
-        archive: proposeArgs.archive,
-        stateReference: proposeArgs.stateReference,
-        oracleInput: proposeArgs.oracleInput,
-        headerHash: headerHash
-      });
+      ProposePayload memory proposePayload =
+        ProposePayload({archive: proposeArgs.archive, oracleInput: proposeArgs.oracleInput, headerHash: headerHash});
 
       bytes32 digest = ProposeLib.digest(proposePayload);
 

--- a/l1-contracts/test/compression/PreHeating.t.sol
+++ b/l1-contracts/test/compression/PreHeating.t.sol
@@ -341,7 +341,6 @@ contract PreHeatingTest is FeeModelTestPoints, DecoderBase {
     ProposeArgs memory proposeArgs = ProposeArgs({
       header: header,
       archive: archiveRoot,
-      stateReference: EMPTY_STATE_REFERENCE,
       oracleInput: OracleInput({feeAssetPriceModifier: point.oracle_input.fee_asset_price_modifier})
     });
 
@@ -356,12 +355,8 @@ contract PreHeatingTest is FeeModelTestPoints, DecoderBase {
 
       bytes32 headerHash = ProposedHeaderLib.hash(proposeArgs.header);
 
-      ProposePayload memory proposePayload = ProposePayload({
-        archive: proposeArgs.archive,
-        stateReference: proposeArgs.stateReference,
-        oracleInput: proposeArgs.oracleInput,
-        headerHash: headerHash
-      });
+      ProposePayload memory proposePayload =
+        ProposePayload({archive: proposeArgs.archive, oracleInput: proposeArgs.oracleInput, headerHash: headerHash});
 
       bytes32 digest = ProposeLib.digest(proposePayload);
 

--- a/l1-contracts/test/fees/FeeRollup.t.sol
+++ b/l1-contracts/test/fees/FeeRollup.t.sol
@@ -195,7 +195,6 @@ contract FeeRollupTest is FeeModelTestPoints, DecoderBase {
           ProposeArgs({
             header: b.header,
             archive: b.archive,
-            stateReference: EMPTY_STATE_REFERENCE,
             oracleInput: OracleInput({feeAssetPriceModifier: point.oracle_input.fee_asset_price_modifier})
           }),
           AttestationLibHelper.packAttestations(b.attestations),
@@ -286,7 +285,6 @@ contract FeeRollupTest is FeeModelTestPoints, DecoderBase {
           ProposeArgs({
             header: b.header,
             archive: b.archive,
-            stateReference: EMPTY_STATE_REFERENCE,
             oracleInput: OracleInput({feeAssetPriceModifier: point.oracle_input.fee_asset_price_modifier})
           }),
           AttestationLibHelper.packAttestations(b.attestations),

--- a/l1-contracts/test/ignition/tmnt223.t.sol
+++ b/l1-contracts/test/ignition/tmnt223.t.sol
@@ -159,12 +159,8 @@ contract Tmnt223Test is RollupBase {
       header.totalManaUsed = 0;
     }
 
-    ProposeArgs memory proposeArgs = ProposeArgs({
-      header: header,
-      archive: archiveRoot,
-      stateReference: EMPTY_STATE_REFERENCE,
-      oracleInput: OracleInput({feeAssetPriceModifier: 0})
-    });
+    ProposeArgs memory proposeArgs =
+      ProposeArgs({header: header, archive: archiveRoot, oracleInput: OracleInput({feeAssetPriceModifier: 0})});
 
     CommitteeAttestation[] memory attestations = new CommitteeAttestation[](0);
     address[] memory signers = new address[](0);

--- a/l1-contracts/test/tmnt419.t.sol
+++ b/l1-contracts/test/tmnt419.t.sol
@@ -177,12 +177,8 @@ contract Tmnt419Test is RollupBase {
       header.totalManaUsed = 0;
     }
 
-    ProposeArgs memory proposeArgs = ProposeArgs({
-      header: header,
-      archive: archiveRoot,
-      stateReference: EMPTY_STATE_REFERENCE,
-      oracleInput: OracleInput({feeAssetPriceModifier: 0})
-    });
+    ProposeArgs memory proposeArgs =
+      ProposeArgs({header: header, archive: archiveRoot, oracleInput: OracleInput({feeAssetPriceModifier: 0})});
 
     CommitteeAttestation[] memory attestations = new CommitteeAttestation[](0);
     address[] memory signers = new address[](0);

--- a/l1-contracts/test/validator-selection/ValidatorSelection.t.sol
+++ b/l1-contracts/test/validator-selection/ValidatorSelection.t.sol
@@ -543,12 +543,7 @@ contract ValidatorSelectionTest is ValidatorSelectionTestBase {
       header.gasFees.feePerL2Gas = manaBaseFee;
     }
 
-    ree.proposeArgs = ProposeArgs({
-      header: header,
-      archive: full.checkpoint.archive,
-      stateReference: EMPTY_STATE_REFERENCE,
-      oracleInput: OracleInput(0)
-    });
+    ree.proposeArgs = ProposeArgs({header: header, archive: full.checkpoint.archive, oracleInput: OracleInput(0)});
 
     skipBlobCheck(address(rollup));
 
@@ -557,7 +552,6 @@ contract ValidatorSelectionTest is ValidatorSelectionTestBase {
       ree.attestationsCount = _attestationCount;
       ree.proposePayload = ProposePayload({
         archive: ree.proposeArgs.archive,
-        stateReference: ree.proposeArgs.stateReference,
         oracleInput: ree.proposeArgs.oracleInput,
         headerHash: ProposedHeaderLib.hash(header)
       });

--- a/l1-contracts/test/validator-selection/tmnt207.t.sol
+++ b/l1-contracts/test/validator-selection/tmnt207.t.sol
@@ -263,12 +263,8 @@ contract Tmnt207Test is RollupBase {
       header.totalManaUsed = 0;
     }
 
-    ProposeArgs memory proposeArgs = ProposeArgs({
-      header: header,
-      archive: archiveRoot,
-      stateReference: EMPTY_STATE_REFERENCE,
-      oracleInput: OracleInput({feeAssetPriceModifier: 0})
-    });
+    ProposeArgs memory proposeArgs =
+      ProposeArgs({header: header, archive: archiveRoot, oracleInput: OracleInput({feeAssetPriceModifier: 0})});
 
     CommitteeAttestation[] memory attestations;
     address[] memory signers;
@@ -281,12 +277,8 @@ contract Tmnt207Test is RollupBase {
 
       bytes32 headerHash = ProposedHeaderLib.hash(proposeArgs.header);
 
-      ProposePayload memory proposePayload = ProposePayload({
-        archive: proposeArgs.archive,
-        stateReference: proposeArgs.stateReference,
-        oracleInput: proposeArgs.oracleInput,
-        headerHash: headerHash
-      });
+      ProposePayload memory proposePayload =
+        ProposePayload({archive: proposeArgs.archive, oracleInput: proposeArgs.oracleInput, headerHash: headerHash});
 
       bytes32 digest = ProposeLib.digest(proposePayload);
 

--- a/yarn-project/archiver/src/archiver/archiver.test.ts
+++ b/yarn-project/archiver/src/archiver/archiver.test.ts
@@ -1171,7 +1171,6 @@ describe('Archiver', () => {
     const header = checkpoint.header.toViem();
     const blobInput = getPrefixedEthBlobCommitments(getBlobsPerL1Block(checkpoint.toBlobFields()));
     const archive = toHex(checkpoint.archive.root.toBuffer());
-    const stateReference = checkpoint.getState().toViem();
     const attestationsAndSigners = new CommitteeAttestationsAndSigners(
       attestations.map(attestation => CommitteeAttestation.fromViem(attestation)),
     );
@@ -1187,7 +1186,6 @@ describe('Archiver', () => {
         {
           header,
           archive,
-          stateReference,
           oracleInput: { feeAssetPriceModifier: 0n },
         },
         attestationsAndSigners.getPackedAttestations(),

--- a/yarn-project/archiver/src/archiver/data_retrieval.ts
+++ b/yarn-project/archiver/src/archiver/data_retrieval.ts
@@ -12,7 +12,6 @@ import type {
   ViemCommitteeAttestations,
   ViemHeader,
   ViemPublicClient,
-  ViemStateReference,
 } from '@aztec/ethereum';
 import { asyncPool } from '@aztec/foundation/async-pool';
 import { Buffer16, Buffer32 } from '@aztec/foundation/buffer';
@@ -46,7 +45,6 @@ import type { L1PublishedData } from './structs/published.js';
 export type RetrievedCheckpoint = {
   checkpointNumber: number;
   archiveRoot: Fr;
-  stateReference: StateReference;
   header: CheckpointHeader;
   checkpointBlobData: CheckpointBlobData;
   l1: L1PublishedData;
@@ -58,7 +56,6 @@ export type RetrievedCheckpoint = {
 export async function retrievedToPublishedCheckpoint({
   checkpointNumber,
   archiveRoot,
-  stateReference,
   header: checkpointHeader,
   checkpointBlobData,
   l1,
@@ -133,12 +130,6 @@ export async function retrievedToPublishedCheckpoint({
   }
 
   const lastBlock = l2Blocks.at(-1)!;
-  if (!lastBlock.header.state.equals(stateReference)) {
-    throw new Error(
-      'The claimed state reference submitted to L1 does not match the state reference of the last block.',
-    );
-  }
-
   const checkpoint = Checkpoint.from({
     archive: new AppendOnlyTreeSnapshot(archiveRoot, lastBlock.number + 1),
     header: checkpointHeader,
@@ -371,7 +362,6 @@ async function getCheckpointFromRollupTx(
   const [decodedArgs, packedAttestations, _signers, _blobInput] = rollupArgs! as readonly [
     {
       archive: Hex;
-      stateReference: ViemStateReference;
       oracleInput: {
         feeAssetPriceModifier: bigint;
       };
@@ -389,7 +379,6 @@ async function getCheckpointFromRollupTx(
   logger.trace(`Recovered propose calldata from tx ${txHash}`, {
     checkpointNumber,
     archive: decodedArgs.archive,
-    stateReference: decodedArgs.stateReference,
     header: decodedArgs.header,
     l1BlockHash: blockHash,
     blobHashes,
@@ -419,12 +408,9 @@ async function getCheckpointFromRollupTx(
 
   const archiveRoot = new Fr(Buffer.from(hexToBytes(decodedArgs.archive)));
 
-  const stateReference = StateReference.fromViem(decodedArgs.stateReference);
-
   return {
     checkpointNumber,
     archiveRoot,
-    stateReference,
     header,
     checkpointBlobData,
     attestations,

--- a/yarn-project/end-to-end/src/composed/web3signer/e2e_multi_validator_node_key_store.test.ts
+++ b/yarn-project/end-to-end/src/composed/web3signer/e2e_multi_validator_node_key_store.test.ts
@@ -19,7 +19,7 @@ import type { Sequencer, SequencerClient, SequencerPublisherFactory } from '@azt
 import type { TestSequencer, TestSequencerClient } from '@aztec/sequencer-client/test';
 import type { BlockProposalOptions } from '@aztec/stdlib/p2p';
 import type { CheckpointHeader } from '@aztec/stdlib/rollup';
-import type { StateReference, Tx } from '@aztec/stdlib/tx';
+import type { Tx } from '@aztec/stdlib/tx';
 import { NodeKeystoreAdapter, ValidatorClient } from '@aztec/validator-client';
 
 import { jest } from '@jest/globals';
@@ -365,7 +365,6 @@ describe('e2e_multi_validator_node', () => {
       blockNumber: number,
       header: CheckpointHeader,
       archive: Fr,
-      stateReference: StateReference,
       txs: Tx[],
       proposerAddress: EthAddress | undefined,
       options: BlockProposalOptions,
@@ -381,7 +380,7 @@ describe('e2e_multi_validator_node', () => {
         );
       }
 
-      return originalCreateProposal(blockNumber, header, archive, stateReference, txs, proposerAddress, options);
+      return originalCreateProposal(blockNumber, header, archive, txs, proposerAddress, options);
     };
     validatorClient.createBlockProposal = jest.fn(createBlockProposal);
 

--- a/yarn-project/end-to-end/src/e2e_l1_publisher/e2e_l1_publisher.test.ts
+++ b/yarn-project/end-to-end/src/e2e_l1_publisher/e2e_l1_publisher.test.ts
@@ -485,7 +485,6 @@ describe('L1Publisher integration', () => {
             {
               header: block.getCheckpointHeader().toViem(),
               archive: `0x${block.archive.root.toBuffer().toString('hex')}`,
-              stateReference: block.header.state.toViem(),
               oracleInput: {
                 feeAssetPriceModifier: 0n,
               },

--- a/yarn-project/ethereum/src/contracts/rollup.ts
+++ b/yarn-project/ethereum/src/contracts/rollup.ts
@@ -83,22 +83,6 @@ export type ViemGasFees = {
   feePerL2Gas: bigint;
 };
 
-export type ViemStateReference = {
-  l1ToL2MessageTree: ViemAppendOnlyTreeSnapshot;
-  partialStateReference: ViemPartialStateReference;
-};
-
-export type ViemPartialStateReference = {
-  noteHashTree: ViemAppendOnlyTreeSnapshot;
-  nullifierTree: ViemAppendOnlyTreeSnapshot;
-  publicDataTree: ViemAppendOnlyTreeSnapshot;
-};
-
-export type ViemAppendOnlyTreeSnapshot = {
-  root: `0x${string}`;
-  nextAvailableLeafIndex: number;
-};
-
 export enum SlashingProposerType {
   None = 0,
   Tally = 1,

--- a/yarn-project/p2p/src/mem_pools/attestation_pool/attestation_pool_test_suite.ts
+++ b/yarn-project/p2p/src/mem_pools/attestation_pool/attestation_pool_test_suite.ts
@@ -42,7 +42,7 @@ export function describeAttestationPool(getAttestationPool: () => AttestationPoo
 
   const mockBlockProposal = (signer: Secp256k1Signer, slotNumber: number, archive: Fr = Fr.random()): BlockProposal => {
     const header = makeL2BlockHeader(1, 2, slotNumber);
-    const payload = new ConsensusPayload(header.toCheckpointHeader(), archive, header.state);
+    const payload = new ConsensusPayload(header.toCheckpointHeader(), archive);
 
     const hash = getHashedSignaturePayloadEthSignedMessage(payload, SignatureDomainSeparator.blockProposal);
     const signature = signer.sign(hash);

--- a/yarn-project/p2p/src/mem_pools/attestation_pool/mocks.ts
+++ b/yarn-project/p2p/src/mem_pools/attestation_pool/mocks.ts
@@ -33,7 +33,7 @@ export const mockAttestation = (
 ): BlockAttestation => {
   // Use arbitrary numbers for all other than slot
   const header = makeL2BlockHeader(1, 2, slot);
-  const payload = new ConsensusPayload(header.toCheckpointHeader(), archive, header.state);
+  const payload = new ConsensusPayload(header.toCheckpointHeader(), archive);
 
   const attestationHash = getHashedSignaturePayloadEthSignedMessage(payload, SignatureDomainSeparator.blockAttestation);
   const attestationSignature = signer.sign(attestationHash);

--- a/yarn-project/p2p/src/msg_validators/attestation_validator/fisherman_attestation_validator.test.ts
+++ b/yarn-project/p2p/src/msg_validators/attestation_validator/fisherman_attestation_validator.test.ts
@@ -190,7 +190,6 @@ describe('FishermanAttestationValidator', () => {
       const differentPayload = new ConsensusPayload(
         header.toCheckpointHeader(),
         Fr.random(), // Different archive
-        mockAttestation.payload.stateReference,
       );
       const mockProposal = new BlockProposal(differentPayload, mockAttestation.proposerSignature, []);
 

--- a/yarn-project/p2p/src/services/tx_provider.test.ts
+++ b/yarn-project/p2p/src/services/tx_provider.test.ts
@@ -5,7 +5,7 @@ import { P2PClient, type PeerId, type TxPool, TxProvider } from '@aztec/p2p';
 import { BlockProposal, ConsensusPayload } from '@aztec/stdlib/p2p';
 import { CheckpointHeader } from '@aztec/stdlib/rollup';
 import { mockTx } from '@aztec/stdlib/testing';
-import { StateReference, Tx, type TxHash } from '@aztec/stdlib/tx';
+import { Tx, type TxHash } from '@aztec/stdlib/tx';
 
 import { jest } from '@jest/globals';
 import { type MockProxy, mock } from 'jest-mock-extended';
@@ -36,7 +36,7 @@ describe('TxProvider', () => {
   };
 
   const buildProposal = (txs: Tx[], txHashes: TxHash[]) => {
-    const payload = new ConsensusPayload(CheckpointHeader.empty(), Fr.random(), StateReference.empty());
+    const payload = new ConsensusPayload(CheckpointHeader.empty(), Fr.random());
     return new BlockProposal(payload, Signature.empty(), txHashes, txs);
   };
 

--- a/yarn-project/sequencer-client/src/publisher/sequencer-publisher.test.ts
+++ b/yarn-project/sequencer-client/src/publisher/sequencer-publisher.test.ts
@@ -277,7 +277,6 @@ describe('SequencerPublisher', () => {
       {
         header: header.toViem(),
         archive: toHex(archive),
-        stateReference: l2Block.header.state.toViem(),
         oracleInput: {
           feeAssetPriceModifier: 0n,
         },

--- a/yarn-project/sequencer-client/src/publisher/sequencer-publisher.ts
+++ b/yarn-project/sequencer-client/src/publisher/sequencer-publisher.ts
@@ -18,7 +18,6 @@ import {
   type TransactionStats,
   type ViemCommitteeAttestations,
   type ViemHeader,
-  type ViemStateReference,
   WEI_CONST,
   formatViemError,
   tryExtractEvent,
@@ -38,7 +37,6 @@ import { CommitteeAttestation, CommitteeAttestationsAndSigners, type ValidateBlo
 import { SlashFactoryContract } from '@aztec/stdlib/l1-contracts';
 import type { CheckpointHeader } from '@aztec/stdlib/rollup';
 import type { L1PublishBlockStats } from '@aztec/stdlib/stats';
-import { StateReference } from '@aztec/stdlib/tx';
 import { type TelemetryClient, getTelemetryClient } from '@aztec/telemetry-client';
 
 import { type StateOverride, type TransactionReceipt, type TypedDataDefinition, encodeFunctionData, toHex } from 'viem';
@@ -52,8 +50,6 @@ type L1ProcessArgs = {
   header: CheckpointHeader;
   /** A root of the archive tree after the L2 block is applied. */
   archive: Buffer;
-  /** State reference after the L2 block is applied. */
-  stateReference: StateReference;
   /** L2 block blobs containing all tx effects. */
   blobs: Blob[];
   /** Attestations */
@@ -539,7 +535,6 @@ export class SequencerPublisher {
       {
         header: block.getCheckpointHeader().toViem(),
         archive: toHex(block.archive.root.toBuffer()),
-        stateReference: block.header.state.toViem(),
         oracleInput: {
           feeAssetPriceModifier: 0n,
         },
@@ -807,7 +802,6 @@ export class SequencerPublisher {
     const proposeTxArgs = {
       header: checkpointHeader,
       archive: block.archive.root.toBuffer(),
-      stateReference: block.header.state,
       body: block.body.toBuffer(),
       blobs,
       attestationsAndSigners,
@@ -985,7 +979,6 @@ export class SequencerPublisher {
       {
         header: encodedData.header.toViem(),
         archive: toHex(encodedData.archive),
-        stateReference: encodedData.stateReference.toViem(),
         oracleInput: {
           // We are currently not modifying these. See #9963
           feeAssetPriceModifier: 0n,
@@ -1013,7 +1006,6 @@ export class SequencerPublisher {
       {
         readonly header: ViemHeader;
         readonly archive: `0x${string}`;
-        readonly stateReference: ViemStateReference;
         readonly oracleInput: {
           readonly feeAssetPriceModifier: 0n;
         };

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.ts
@@ -779,7 +779,6 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
       block.header.globalVariables.blockNumber,
       block.getCheckpointHeader(),
       block.archive.root,
-      block.header.state,
       txs,
       proposerAddress,
       blockProposalOptions,

--- a/yarn-project/stdlib/src/interfaces/validator.ts
+++ b/yarn-project/stdlib/src/interfaces/validator.ts
@@ -5,7 +5,7 @@ import { Fr } from '@aztec/foundation/fields';
 import { type ZodFor, schemas } from '@aztec/foundation/schemas';
 import type { SequencerConfig, SlasherConfig } from '@aztec/stdlib/interfaces/server';
 import type { BlockAttestation, BlockProposal, BlockProposalOptions } from '@aztec/stdlib/p2p';
-import type { StateReference, Tx } from '@aztec/stdlib/tx';
+import type { Tx } from '@aztec/stdlib/tx';
 
 import type { PeerId } from '@libp2p/interface';
 import { z } from 'zod';
@@ -83,7 +83,6 @@ export interface Validator {
     blockNumber: number,
     header: CheckpointHeader,
     archive: Fr,
-    stateReference: StateReference,
     txs: Tx[],
     proposerAddress: EthAddress | undefined,
     options: BlockProposalOptions,

--- a/yarn-project/stdlib/src/p2p/consensus_payload.ts
+++ b/yarn-project/stdlib/src/p2p/consensus_payload.ts
@@ -10,7 +10,6 @@ import { z } from 'zod';
 import type { L2Block } from '../block/l2_block.js';
 import type { Checkpoint } from '../checkpoint/checkpoint.js';
 import { CheckpointHeader } from '../rollup/checkpoint_header.js';
-import { StateReference } from '../tx/state_reference.js';
 import type { Signable, SignatureDomainSeparator } from './signature_utils.js';
 
 export class ConsensusPayload implements Signable {
@@ -21,8 +20,6 @@ export class ConsensusPayload implements Signable {
     public readonly header: CheckpointHeader,
     /** The archive root after the block is added */
     public readonly archive: Fr,
-    /** The state reference after the block is added */
-    public readonly stateReference: StateReference,
   ) {}
 
   static get schema() {
@@ -30,13 +27,12 @@ export class ConsensusPayload implements Signable {
       .object({
         header: CheckpointHeader.schema,
         archive: schemas.Fr,
-        stateReference: StateReference.schema,
       })
-      .transform(obj => new ConsensusPayload(obj.header, obj.archive, obj.stateReference));
+      .transform(obj => new ConsensusPayload(obj.header, obj.archive));
   }
 
   static getFields(fields: FieldsOf<ConsensusPayload>) {
-    return [fields.header, fields.archive, fields.stateReference] as const;
+    return [fields.header, fields.archive] as const;
   }
 
   getPayloadToSign(domainSeparator: SignatureDomainSeparator): Buffer {
@@ -44,64 +40,53 @@ export class ConsensusPayload implements Signable {
       'uint8, ' + //domainSeperator
         '(' +
         'bytes32, ' + // archive
-        '((bytes32,uint32),((bytes32,uint32),(bytes32,uint32),(bytes32,uint32))), ' + // stateReference
         '(int256), ' + // oracleInput
         'bytes32' + // headerHash
         ')',
     );
     const archiveRoot = this.archive.toString();
-    const stateReference = this.stateReference.toAbi();
 
     const headerHash = this.header.hash().toString();
     const encodedData = encodeAbiParameters(abi, [
       domainSeparator,
-      [archiveRoot, stateReference, [0n] /* @todo See #9963 */, headerHash],
+      [archiveRoot, [0n] /* @todo See #9963 */, headerHash],
     ] as const);
 
     return hexToBuffer(encodedData);
   }
 
   toBuffer(): Buffer {
-    return serializeToBuffer([this.header, this.archive, this.stateReference]);
+    return serializeToBuffer([this.header, this.archive]);
   }
 
   public equals(other: ConsensusPayload): boolean {
-    return (
-      this.header.equals(other.header) &&
-      this.archive.equals(other.archive) &&
-      this.stateReference.equals(other.stateReference)
-    );
+    return this.header.equals(other.header) && this.archive.equals(other.archive);
   }
 
   static fromBuffer(buf: Buffer | BufferReader): ConsensusPayload {
     const reader = BufferReader.asReader(buf);
-    const payload = new ConsensusPayload(
-      reader.readObject(CheckpointHeader),
-      reader.readObject(Fr),
-      reader.readObject(StateReference),
-    );
+    const payload = new ConsensusPayload(reader.readObject(CheckpointHeader), reader.readObject(Fr));
     return payload;
   }
 
   static fromFields(fields: FieldsOf<ConsensusPayload>): ConsensusPayload {
-    return new ConsensusPayload(fields.header, fields.archive, fields.stateReference);
+    return new ConsensusPayload(fields.header, fields.archive);
   }
 
   static fromBlock(block: L2Block): ConsensusPayload {
-    return new ConsensusPayload(block.header.toCheckpointHeader(), block.archive.root, block.header.state);
+    return new ConsensusPayload(block.header.toCheckpointHeader(), block.archive.root);
   }
 
   static fromCheckpoint(checkpoint: Checkpoint): ConsensusPayload {
-    const lastBlock = checkpoint.blocks.at(-1)!;
-    return new ConsensusPayload(checkpoint.header, checkpoint.archive.root, lastBlock.header.state);
+    return new ConsensusPayload(checkpoint.header, checkpoint.archive.root);
   }
 
   static empty(): ConsensusPayload {
-    return new ConsensusPayload(CheckpointHeader.empty(), Fr.ZERO, StateReference.empty());
+    return new ConsensusPayload(CheckpointHeader.empty(), Fr.ZERO);
   }
 
   static random(): ConsensusPayload {
-    return new ConsensusPayload(CheckpointHeader.random(), Fr.random(), StateReference.random());
+    return new ConsensusPayload(CheckpointHeader.random(), Fr.random());
   }
 
   /**
@@ -121,11 +106,10 @@ export class ConsensusPayload implements Signable {
     return {
       header: this.header.toInspect(),
       archive: this.archive.toString(),
-      stateReference: this.stateReference.toInspect(),
     };
   }
 
   toString() {
-    return `header: ${this.header.toString()}, archive: ${this.archive.toString()}, stateReference: ${this.stateReference.l1ToL2MessageTree.root.toString()}`;
+    return `header: ${this.header.toString()}, archive: ${this.archive.toString()}}`;
   }
 }

--- a/yarn-project/stdlib/src/tests/mocks.ts
+++ b/yarn-project/stdlib/src/tests/mocks.ts
@@ -56,7 +56,6 @@ import {
   PrivateCallExecutionResult,
   PrivateExecutionResult,
   ProtocolContracts,
-  StateReference,
   Tx,
   TxConstantData,
   makeProcessedTxFromPrivateOnlyTx,
@@ -408,7 +407,6 @@ export interface MakeConsensusPayloadOptions {
   proposerSigner?: Secp256k1Signer;
   header?: L2BlockHeader;
   archive?: Fr;
-  stateReference?: StateReference;
   txHashes?: TxHash[];
   txs?: Tx[];
 }
@@ -418,12 +416,11 @@ const makeAndSignConsensusPayload = (
   options?: MakeConsensusPayloadOptions,
 ) => {
   const header = options?.header ?? makeL2BlockHeader(1);
-  const { signer = Secp256k1Signer.random(), archive = Fr.random(), stateReference = header.state } = options ?? {};
+  const { signer = Secp256k1Signer.random(), archive = Fr.random() } = options ?? {};
 
   const payload = ConsensusPayload.fromFields({
     header: header.toCheckpointHeader(),
     archive,
-    stateReference,
   });
 
   const hash = getHashedSignaturePayloadEthSignedMessage(payload, domainSeparator);
@@ -452,18 +449,11 @@ export const makeBlockProposal = (options?: MakeConsensusPayloadOptions): BlockP
 // TODO(https://github.com/AztecProtocol/aztec-packages/issues/8028)
 export const makeBlockAttestation = (options: MakeConsensusPayloadOptions = {}): BlockAttestation => {
   const header = options.header ?? makeL2BlockHeader(1);
-  const {
-    signer,
-    attesterSigner = signer,
-    proposerSigner = signer,
-    archive = Fr.random(),
-    stateReference = header.state,
-  } = options;
+  const { signer, attesterSigner = signer, proposerSigner = signer, archive = Fr.random() } = options;
 
   const payload = ConsensusPayload.fromFields({
     header: header.toCheckpointHeader(),
     archive,
-    stateReference,
   });
 
   return makeBlockAttestationFromPayload(payload, attesterSigner, proposerSigner);
@@ -476,12 +466,10 @@ export const makeAttestationFromCheckpoint = (
 ): BlockAttestation => {
   const header = checkpoint.header;
   const archive = checkpoint.archive.root;
-  const stateReference = checkpoint.blocks.at(-1)!.header.state;
 
   const payload = ConsensusPayload.fromFields({
     header,
     archive,
-    stateReference,
   });
 
   return makeBlockAttestationFromPayload(payload, attesterSigner, proposerSigner);
@@ -494,12 +482,10 @@ export const makeBlockAttestationFromBlock = (
 ): BlockAttestation => {
   const header = block.header;
   const archive = block.archive.root;
-  const stateReference = block.header.state;
 
   const payload = ConsensusPayload.fromFields({
     header: header.toCheckpointHeader(),
     archive,
-    stateReference,
   });
 
   return makeBlockAttestationFromPayload(payload, attesterSigner, proposerSigner);

--- a/yarn-project/stdlib/src/trees/append_only_tree_snapshot.ts
+++ b/yarn-project/stdlib/src/trees/append_only_tree_snapshot.ts
@@ -1,4 +1,3 @@
-import type { ViemAppendOnlyTreeSnapshot } from '@aztec/ethereum';
 import { Fr } from '@aztec/foundation/fields';
 import { schemas } from '@aztec/foundation/schemas';
 import { BufferReader, FieldReader, serializeToBuffer } from '@aztec/foundation/serialize';
@@ -70,17 +69,6 @@ export class AppendOnlyTreeSnapshot {
     const reader = FieldReader.asReader(fields);
 
     return new AppendOnlyTreeSnapshot(reader.readField(), Number(reader.readField().toBigInt()));
-  }
-
-  static fromViem(snapshot: ViemAppendOnlyTreeSnapshot) {
-    return new AppendOnlyTreeSnapshot(Fr.fromString(snapshot.root), snapshot.nextAvailableLeafIndex);
-  }
-
-  toViem(): ViemAppendOnlyTreeSnapshot {
-    return {
-      root: this.root.toString(),
-      nextAvailableLeafIndex: this.nextAvailableLeafIndex,
-    };
   }
 
   toAbi(): [`0x${string}`, number] {

--- a/yarn-project/stdlib/src/tx/partial_state_reference.ts
+++ b/yarn-project/stdlib/src/tx/partial_state_reference.ts
@@ -1,5 +1,4 @@
 import { PARTIAL_STATE_REFERENCE_LENGTH } from '@aztec/constants';
-import type { ViemPartialStateReference } from '@aztec/ethereum';
 import type { Fr } from '@aztec/foundation/fields';
 import { BufferReader, FieldReader, serializeToBuffer } from '@aztec/foundation/serialize';
 import type { FieldsOf } from '@aztec/foundation/types';
@@ -65,28 +64,12 @@ export class PartialStateReference {
     return new PartialStateReference(noteHashTree, nullifierTree, publicDataTree);
   }
 
-  static fromViem(stateReference: ViemPartialStateReference) {
-    return new PartialStateReference(
-      AppendOnlyTreeSnapshot.fromViem(stateReference.noteHashTree),
-      AppendOnlyTreeSnapshot.fromViem(stateReference.nullifierTree),
-      AppendOnlyTreeSnapshot.fromViem(stateReference.publicDataTree),
-    );
-  }
-
   static random(): PartialStateReference {
     return new PartialStateReference(
       AppendOnlyTreeSnapshot.random(),
       AppendOnlyTreeSnapshot.random(),
       AppendOnlyTreeSnapshot.random(),
     );
-  }
-
-  toViem(): ViemPartialStateReference {
-    return {
-      noteHashTree: this.noteHashTree.toViem(),
-      nullifierTree: this.nullifierTree.toViem(),
-      publicDataTree: this.publicDataTree.toViem(),
-    };
   }
 
   toAbi(): [

--- a/yarn-project/stdlib/src/tx/state_reference.ts
+++ b/yarn-project/stdlib/src/tx/state_reference.ts
@@ -4,7 +4,6 @@ import {
   NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP,
   STATE_REFERENCE_LENGTH,
 } from '@aztec/constants';
-import type { ViemStateReference } from '@aztec/ethereum';
 import type { Fr } from '@aztec/foundation/fields';
 import { BufferReader, FieldReader, serializeToBuffer } from '@aztec/foundation/serialize';
 import type { FieldsOf } from '@aztec/foundation/types';
@@ -76,26 +75,12 @@ export class StateReference {
     return new StateReference(l1ToL2MessageTree, partial);
   }
 
-  static fromViem(stateReference: ViemStateReference) {
-    return new StateReference(
-      AppendOnlyTreeSnapshot.fromViem(stateReference.l1ToL2MessageTree),
-      PartialStateReference.fromViem(stateReference.partialStateReference),
-    );
-  }
-
   static empty(): StateReference {
     return new StateReference(AppendOnlyTreeSnapshot.empty(), PartialStateReference.empty());
   }
 
   static random(): StateReference {
     return new StateReference(AppendOnlyTreeSnapshot.random(), PartialStateReference.random());
-  }
-
-  toViem(): ViemStateReference {
-    return {
-      l1ToL2MessageTree: this.l1ToL2MessageTree.toViem(),
-      partialStateReference: this.partial.toViem(),
-    };
   }
 
   toAbi(): [ReturnType<AppendOnlyTreeSnapshot['toAbi']>, ReturnType<PartialStateReference['toAbi']>] {

--- a/yarn-project/stdlib/src/validators/errors.ts
+++ b/yarn-project/stdlib/src/validators/errors.ts
@@ -1,5 +1,5 @@
 import type { Fr } from '@aztec/foundation/fields';
-import type { StateReference, TxHash } from '@aztec/stdlib/tx';
+import type { TxHash } from '@aztec/stdlib/tx';
 
 export class ValidatorError extends Error {
   constructor(message: string) {
@@ -39,8 +39,6 @@ export class ReExStateMismatchError extends ValidatorError {
   constructor(
     public readonly expectedArchiveRoot: Fr,
     public readonly actualArchiveRoot: Fr,
-    public readonly expectedStateReference?: StateReference,
-    public readonly actualStateReference?: StateReference,
   ) {
     super('Re-execution state mismatch');
   }

--- a/yarn-project/validator-client/src/block_proposal_handler.ts
+++ b/yarn-project/validator-client/src/block_proposal_handler.ts
@@ -322,12 +322,7 @@ export class BlockProposalHandler {
         actual: proposal.payload.toInspect(),
       });
       this.metrics?.recordFailedReexecution(proposal);
-      throw new ReExStateMismatchError(
-        proposal.archive,
-        block.archive.root,
-        proposal.payload.stateReference,
-        block.header.state,
-      );
+      throw new ReExStateMismatchError(proposal.archive, block.archive.root);
     }
 
     const reexecutionTimeMs = timer.ms();

--- a/yarn-project/validator-client/src/duties/validation_service.test.ts
+++ b/yarn-project/validator-client/src/duties/validation_service.test.ts
@@ -25,9 +25,9 @@ describe('ValidationService', () => {
   it('creates a proposal with txs appended', async () => {
     const txs = await Promise.all([Tx.random(), Tx.random()]);
     const {
-      payload: { header, archive, stateReference },
+      payload: { header, archive },
     } = makeBlockProposal({ txs });
-    const proposal = await service.createBlockProposal(header, archive, stateReference, txs, addresses[0], {
+    const proposal = await service.createBlockProposal(header, archive, txs, addresses[0], {
       publishFullTxs: true,
     });
     expect(proposal.getSender()).toEqual(store.getAddress(0));
@@ -38,9 +38,9 @@ describe('ValidationService', () => {
   it('creates a proposal without txs appended', async () => {
     const txs = await Promise.all([Tx.random(), Tx.random()]);
     const {
-      payload: { header, archive, stateReference },
+      payload: { header, archive },
     } = makeBlockProposal({ txs });
-    const proposal = await service.createBlockProposal(header, archive, stateReference, txs, addresses[0], {
+    const proposal = await service.createBlockProposal(header, archive, txs, addresses[0], {
       publishFullTxs: false,
     });
     expect(proposal.getSender()).toEqual(addresses[0]);

--- a/yarn-project/validator-client/src/duties/validation_service.ts
+++ b/yarn-project/validator-client/src/duties/validation_service.ts
@@ -4,7 +4,6 @@ import type { EthAddress } from '@aztec/foundation/eth-address';
 import type { Signature } from '@aztec/foundation/eth-signature';
 import { Fr } from '@aztec/foundation/fields';
 import { createLogger } from '@aztec/foundation/log';
-import { unfreeze } from '@aztec/foundation/types';
 import type { CommitteeAttestationsAndSigners } from '@aztec/stdlib/block';
 import {
   BlockAttestation,
@@ -14,8 +13,7 @@ import {
   SignatureDomainSeparator,
 } from '@aztec/stdlib/p2p';
 import type { CheckpointHeader } from '@aztec/stdlib/rollup';
-import { AppendOnlyTreeSnapshot } from '@aztec/stdlib/trees';
-import { StateReference, type Tx } from '@aztec/stdlib/tx';
+import type { Tx } from '@aztec/stdlib/tx';
 
 import type { ValidatorKeyStore } from '../key_store/interface.js';
 
@@ -38,7 +36,6 @@ export class ValidationService {
   async createBlockProposal(
     header: CheckpointHeader,
     archive: Fr,
-    stateReference: StateReference,
     txs: Tx[],
     proposerAttesterAddress: EthAddress | undefined,
     options: BlockProposalOptions,
@@ -54,14 +51,14 @@ export class ValidationService {
     // TODO: check if this is calculated earlier / can not be recomputed
     const txHashes = await Promise.all(txs.map(tx => tx.getTxHash()));
 
-    // For testing: corrupt the state reference to trigger state_mismatch validation failure
+    // For testing: change the new archive to trigger state_mismatch validation failure
     if (options.broadcastInvalidBlockProposal) {
-      unfreeze(stateReference.partial).noteHashTree = AppendOnlyTreeSnapshot.random();
+      archive = Fr.random();
       this.log.warn(`Creating INVALID block proposal for slot ${header.slotNumber.toBigInt()}`);
     }
 
     return BlockProposal.createProposalFromSigner(
-      new ConsensusPayload(header, archive, stateReference),
+      new ConsensusPayload(header, archive),
       txHashes,
       options.publishFullTxs ? txs : undefined,
       payloadSigner,

--- a/yarn-project/validator-client/src/validator.test.ts
+++ b/yarn-project/validator-client/src/validator.test.ts
@@ -8,7 +8,6 @@ import { EthAddress } from '@aztec/foundation/eth-address';
 import { Fr } from '@aztec/foundation/fields';
 import type { Hex } from '@aztec/foundation/string';
 import { TestDateProvider, Timer } from '@aztec/foundation/timer';
-import { unfreeze } from '@aztec/foundation/types';
 import { type KeyStore, KeystoreManager } from '@aztec/node-keystore';
 import {
   AuthRequest,
@@ -121,7 +120,6 @@ describe('ValidatorClient', () => {
         header.globalVariables.blockNumber,
         header.toCheckpointHeader(),
         archive,
-        header.state,
         txs,
         EthAddress.fromString(validatorAccounts[0].address),
         { publishFullTxs: false },
@@ -340,9 +338,9 @@ describe('ValidatorClient', () => {
     });
 
     it('should not attest to proposal if a random field in the proposal does not match', async () => {
-      // Block builder returns a block with a different nullifier tree root
+      // Block builder returns a block with a different archive root
       enableReexecution();
-      unfreeze(blockBuildResult.block.header.state.partial).nullifierTree.root = Fr.random();
+      blockBuildResult.block.archive.root = Fr.random();
 
       // We should not attest to the proposal
       const attestations = await validatorClient.attestToProposal(proposal, sender);

--- a/yarn-project/validator-client/src/validator.ts
+++ b/yarn-project/validator-client/src/validator.ts
@@ -17,7 +17,7 @@ import type { IFullNodeBlockBuilder, Validator, ValidatorClientFullConfig } from
 import type { L1ToL2MessageSource } from '@aztec/stdlib/messaging';
 import type { BlockAttestation, BlockProposal, BlockProposalOptions } from '@aztec/stdlib/p2p';
 import type { CheckpointHeader } from '@aztec/stdlib/rollup';
-import type { StateReference, Tx } from '@aztec/stdlib/tx';
+import type { Tx } from '@aztec/stdlib/tx';
 import { AttestationTimeoutError } from '@aztec/stdlib/validators';
 import { type TelemetryClient, type Tracer, getTelemetryClient } from '@aztec/telemetry-client';
 
@@ -404,7 +404,6 @@ export class ValidatorClient extends (EventEmitter as new () => WatcherEmitter) 
     blockNumber: number,
     header: CheckpointHeader,
     archive: Fr,
-    stateReference: StateReference,
     txs: Tx[],
     proposerAddress: EthAddress | undefined,
     options: BlockProposalOptions,
@@ -414,14 +413,10 @@ export class ValidatorClient extends (EventEmitter as new () => WatcherEmitter) 
       return Promise.resolve(undefined);
     }
 
-    const newProposal = await this.validationService.createBlockProposal(
-      header,
-      archive,
-      stateReference,
-      txs,
-      proposerAddress,
-      { ...options, broadcastInvalidBlockProposal: this.config.broadcastInvalidBlockProposal },
-    );
+    const newProposal = await this.validationService.createBlockProposal(header, archive, txs, proposerAddress, {
+      ...options,
+      broadcastInvalidBlockProposal: this.config.broadcastInvalidBlockProposal,
+    });
     this.previousProposal = newProposal;
     return newProposal;
   }


### PR DESCRIPTION
We don't need the committee to sign it, or get it from the calldata to validate the world state. We have the new archive root for that.