### PR TITLE
feat: enforce non-empty PR descriptions without template text

### DIFF
--- a/.github/workflows/pull-request-title.yml
+++ b/.github/workflows/pull-request-title.yml
@@ -1,4 +1,4 @@
-name: Pull Request Title
+name: Pull Request Validation
 
 on:
   # This check is skipped in merge queue, but we need it to run (even skipped) for status checks.
@@ -31,3 +31,30 @@ jobs:
             refactor
             docs
             test
+
+  validate-description:
+    name: Validate PR description
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github/pull_request_template.md
+          sparse-checkout-cone-mode: false
+      - name: Check PR description
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          if [ -z "$PR_BODY" ]; then
+            echo "::error::PR description cannot be empty"
+            exit 1
+          fi
+
+          TEMPLATE_CONTENT=$(cat .github/pull_request_template.md)
+          if [ "$PR_BODY" = "$TEMPLATE_CONTENT" ]; then
+            echo "::error::Please update the PR description - it still contains the default template"
+            exit 1
+          fi
+
+          echo "PR description is valid"


### PR DESCRIPTION
Add validation to ensure pull request descriptions are not empty and do not contain the default template placeholder text. This check will be integrated into the existing PR title validation logic. Improving PR quality by requiring authors to provide meaningful descriptions.