### PR TITLE
fix: acir tests build failure due to yarn.lock

### DIFF
--- a/barretenberg/acir_tests/yarn.lock
+++ b/barretenberg/acir_tests/yarn.lock
@@ -1167,13 +1167,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"base64-js@npm:^1.3.1":
-  version: 1.5.1
-  resolution: "base64-js@npm:1.5.1"
-  checksum: 10c0/f23823513b63173a001030fae4f2dabe283b99a9d324ade3ad3d148e218134676f1ee8568c877cd79ec1c53158dcf2d2ba527a97c606618928ba99dd930102bf
-  languageName: node
-  linkType: hard
-
 "basic-ftp@npm:^5.0.2":
   version: 5.0.5
   resolution: "basic-ftp@npm:5.0.5"
@@ -1292,7 +1285,6 @@ __metadata:
   dependencies:
     "@aztec/bb.js": "portal:../../ts"
     "@types/pako": "npm:^2.0.3"
-    buffer: "npm:^6.0.3"
     html-webpack-plugin: "npm:^5.6.0"
     pako: "npm:^2.1.0"
     pino: "npm:^9.5.0"
@@ -1331,16 +1323,6 @@ __metadata:
   version: 1.1.2
   resolution: "buffer-from@npm:1.1.2"
   checksum: 10c0/124fff9d66d691a86d3b062eff4663fe437a9d9ee4b47b1b9e97f5a5d14f6d5399345db80f796827be7c95e70a8e765dd404b7c3ff3b3324f98e9b0c8826cc34
-  languageName: node
-  linkType: hard
-
-"buffer@npm:^6.0.3":
-  version: 6.0.3
-  resolution: "buffer@npm:6.0.3"
-  dependencies:
-    base64-js: "npm:^1.3.1"
-    ieee754: "npm:^1.2.1"
-  checksum: 10c0/2a905fbbcde73cc5d8bd18d1caa23715d5f83a5935867c2329f0ac06104204ba7947be098fe1317fbd8830e26090ff8e764f08cd14fefc977bb248c3487bcbd0
   languageName: node
   linkType: hard
 
@@ -2852,13 +2834,6 @@ __metadata:
   version: 6.2.2
   resolution: "idb-keyval@npm:6.2.2"
   checksum: 10c0/b52f0d2937cc2ec9f1da536b0b5c0875af3043ca210714beaffead4ec1f44f2ad322220305fd024596203855224d9e3523aed83e971dfb62ddc21b5b1721aeef
-  languageName: node
-  linkType: hard
-
-"ieee754@npm:^1.2.1":
-  version: 1.2.1
-  resolution: "ieee754@npm:1.2.1"
-  checksum: 10c0/b0782ef5e0935b9f12883a2e2aa37baa75da6e66ce6515c168697b42160807d9330de9a32ec1ed73149aea02e0d822e572bca6f1e22bdcbd2149e13b050b17bb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
For some reason I got yarn.lock build issue when bootstraping clean `next`:


> --- acir_tests build ---
> Cache download and extraction of barretenberg-acir-tests-fd69b7e5d005178c.tar.gz complete in 1s.
> Executing: yarn install (http://ci.aztec-labs.com/ae5c63ab6bfd9e23)
> ...
> ➤ YN0000: │  "import-fresh@npm:^3.3.0":
> ➤ YN0000: │    version: 3.3.1
> ➤ YN0000: │    resolution: "import-fresh@npm:3.3.1"
> ➤ YN0000: │    dependencies:
> ➤ YN0000: │ 
> ➤ YN0028: │ The lockfile would have been modified by this install, which is explicitly forbidden.
> ➤ YN0000: └ Completed
> ➤ YN0000: · Failed with errors in 0s 183ms

In this PR I update the lock file.