### PR TITLE
fix: pxe_oracle_interface test flake

### DIFF
--- a/yarn-project/pxe/src/contract_function_simulator/noir-structs/log_retrieval_response.test.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/noir-structs/log_retrieval_response.test.ts
@@ -116,7 +116,7 @@ describe('LogRetrievalResponse', () => {
   });
 
   it('serialization of some matches snapshots and output of Noir serialization', () => {
-    const serialized = LogRetrievalResponse.toSerializedOption();
+    const serialized = LogRetrievalResponse.toSerializedOption(null);
 
     // Test against snapshot
     expect(serialized.map(f => f.toString())).toMatchInlineSnapshot(`

--- a/yarn-project/pxe/src/contract_function_simulator/noir-structs/log_retrieval_response.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/noir-structs/log_retrieval_response.ts
@@ -42,7 +42,7 @@ export class LogRetrievalResponse {
     return range(serializationLen).map(_ => Fr.zero());
   }
 
-  static toSerializedOption(response?: LogRetrievalResponse): Fr[] {
+  static toSerializedOption(response: LogRetrievalResponse | null): Fr[] {
     if (response) {
       return [new Fr(1), ...response.toFields()];
     } else {

--- a/yarn-project/pxe/src/contract_function_simulator/pxe_oracle_interface.test.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/pxe_oracle_interface.test.ts
@@ -184,7 +184,7 @@ describe('PXEOracleInterface', () => {
       }
       aztecNode.getLogsByTags.mockReset();
       aztecNode.getTxEffect.mockResolvedValue({
-        ...randomInBlock(await TxEffect.random()),
+        ...randomInBlock(await TxEffect.random({ numNullifiers: 1 })),
         txIndexInBlock: 0,
       });
     });

--- a/yarn-project/pxe/src/contract_function_simulator/pxe_oracle_interface.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/pxe_oracle_interface.ts
@@ -756,7 +756,7 @@ export class PXEOracleInterface implements ExecutionDataProvider {
             privateLog.firstNullifierInTx,
           );
         } else {
-          null;
+          return null;
         }
       }),
     );


### PR DESCRIPTION
In this PR I (hopefully) fix [these flakes](http://ci.aztec-labs.com/list/history_ede44f6f60adaef4_next).

The issue was most likely caused by us producing an incorrect random TxEffect in a test. Incorrect because it had 0 nullifiers and a tx effect needs to always have at least 1 (tx hash nullifier).

Then [here](https://github.com/AztecProtocol/aztec-packages/blob/5b4f20de4dc0e85d71b226222e78d39be115c44b/yarn-project/pxe/src/contract_function_simulator/pxe_oracle_interface.ts#L573) we got undefined and then later one when the object was getting serialized we got the error.

All credit goes to AI 😆 🤖 