### PR TITLE
chore(spartan): (A-35) add pod-based network partition + pod-failure and slashing test

### DIFF
--- a/spartan/aztec-chaos-scenarios/templates/network-partition-explicit.yaml
+++ b/spartan/aztec-chaos-scenarios/templates/network-partition-explicit.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.networkPartition.enabled }}
+{{- $targetNamespace := .Values.global.targetNamespace | required ".Values.global.targetNamespace is required" }}
+{{- $groupAStr := .Values.networkPartition.groupA | default "" }}
+{{- $groupBStr := .Values.networkPartition.groupB | default "" }}
+{{- $groupA := splitList "," $groupAStr | compact }}
+{{- $groupB := splitList "," $groupBStr | compact }}
+{{- if and (gt (len $groupA) 0) (gt (len $groupB) 0) }}
+---
+apiVersion: chaos-mesh.org/v1alpha1
+kind: NetworkChaos
+metadata:
+  name: {{ include "aztec-chaos-scenarios.fullname" . }}-network-partition-explicit
+  labels:
+    {{- include "aztec-chaos-scenarios.labels" . | nindent 4 }}
+spec:
+  action: partition
+  mode: all
+  direction: both
+  duration: {{ .Values.networkPartition.duration }}
+  selector:
+    pods:
+      {{ $targetNamespace }}:
+{{- range $groupA }}
+        - {{ . | trim }}
+{{- end }}
+  target:
+    mode: all
+    selector:
+      pods:
+        {{ $targetNamespace }}:
+{{- range $groupB }}
+          - {{ . | trim }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+

--- a/spartan/aztec-chaos-scenarios/templates/validator-failure.yaml
+++ b/spartan/aztec-chaos-scenarios/templates/validator-failure.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.validatorFailure.enabled }}
+{{- $targetNamespace := .Values.global.targetNamespace | required ".Values.global.targetNamespace is required" }}
+{{- $podsStr := .Values.validatorFailure.podsCsv | default "" }}
+{{- $pods := splitList "," $podsStr | compact }}
+{{- if gt (len $pods) 0 }}
+---
+apiVersion: chaos-mesh.org/v1alpha1
+kind: PodChaos
+metadata:
+  name: {{ include "aztec-chaos-scenarios.fullname" . }}-validator-failure
+  labels:
+    {{- include "aztec-chaos-scenarios.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/resource-policy": keep
+spec:
+  action: pod-failure
+  mode: all
+  duration: {{ .Values.validatorFailure.duration }}
+  selector:
+    pods:
+      {{ $targetNamespace }}:
+{{- range $pods }}
+        - {{ . | trim }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+

--- a/spartan/aztec-chaos-scenarios/values/network-partition.yaml
+++ b/spartan/aztec-chaos-scenarios/values/network-partition.yaml
@@ -1,0 +1,10 @@
+global:
+  namespace: "scenario"
+
+networkPartition:
+  enabled: true
+  groupA: ""
+  groupB: ""
+  duration: "600s"
+
+

--- a/spartan/aztec-chaos-scenarios/values/validator-failure.yaml
+++ b/spartan/aztec-chaos-scenarios/values/validator-failure.yaml
@@ -1,0 +1,9 @@
+global:
+  namespace: "scenario"
+
+validatorFailure:
+  enabled: true
+  podsCsv: ""
+  duration: "300s"
+
+

--- a/yarn-project/end-to-end/src/spartan/slash_partitions.test.ts
+++ b/yarn-project/end-to-end/src/spartan/slash_partitions.test.ts
@@ -1,0 +1,158 @@
+import { EthAddress } from '@aztec/aztec.js/addresses';
+import { RollupContract, type ViemPublicClient } from '@aztec/ethereum';
+import { ChainMonitor } from '@aztec/ethereum/test';
+import { createLogger } from '@aztec/foundation/log';
+import { promiseWithResolvers } from '@aztec/foundation/promise';
+import { retryUntil } from '@aztec/foundation/retry';
+import { timeoutPromise } from '@aztec/foundation/timer';
+import { type TallySlasherSettings, getTallySlasherSettings } from '@aztec/slasher';
+import { type L1RollupConstants, getSlotRangeForEpoch, getStartTimestampForEpoch } from '@aztec/stdlib/epoch-helpers';
+
+import { jest } from '@jest/globals';
+import type { ChildProcess } from 'child_process';
+
+import {
+  applyNetworkPartition,
+  applyValidatorFailureForPods,
+  getGitProjectRoot,
+  getL1DeploymentAddresses,
+  getPublicViemClient,
+  getSequencers,
+  getSequencersConfig,
+  setupEnvironment,
+  updateSequencersConfig,
+} from './utils.js';
+
+describe('slash with partitions', () => {
+  jest.setTimeout(120 * 60 * 1000); // 120 minutes
+
+  const logger = createLogger('e2e:slash-partitions');
+  const config = setupEnvironment(process.env);
+  const forwardProcesses: ChildProcess[] = [];
+
+  let client: ViemPublicClient;
+  let rollup: RollupContract;
+  let slashSettings: TallySlasherSettings;
+  let constants: Omit<L1RollupConstants, 'ethereumSlotDuration'>;
+  let monitor: ChainMonitor;
+
+  beforeAll(async () => {
+    const deployAddresses = await getL1DeploymentAddresses(config);
+    ({ client } = await getPublicViemClient(config, forwardProcesses));
+    rollup = new RollupContract(client, deployAddresses.rollupAddress);
+    monitor = new ChainMonitor(rollup, undefined, logger.createChild('chain-monitor'), 500).start();
+    constants = await rollup.getRollupConstants();
+    slashSettings = await getTallySlasherSettings(rollup);
+  });
+
+  afterAll(async () => {
+    await updateSequencersConfig(config, { disabledValidators: [], slashValidatorsNever: [] });
+    monitor.removeAllListeners();
+    await monitor.stop();
+    forwardProcesses.forEach(p => p.kill());
+  });
+
+  const getNextEpochCommittee = async () => {
+    return await retryUntil(
+      async () => {
+        const nextEpoch = (await rollup.getCurrentEpoch()) + 1n;
+        const nextEpochStartTimestamp = getStartTimestampForEpoch(nextEpoch, constants);
+        const committee = await rollup.getCommitteeAt(nextEpochStartTimestamp);
+        if (committee && committee.length > 0) {
+          logger.warn(`Retrieved committee for epoch ${nextEpoch}`, { committee });
+          return { committee, epoch: nextEpoch };
+        }
+      },
+      'committee',
+      constants.epochDuration * constants.slotDuration * 4,
+      1,
+    );
+  };
+
+  const waitForSlash = async (who: EthAddress, timeoutSeconds: number) => {
+    const proposer = await rollup.getSlashingProposer();
+    if (!proposer || proposer.type !== 'tally') {
+      throw new Error('expected tally proposer');
+    }
+    proposer.listenToVoteCast(
+      args => void logger.warn(`Slash vote round ${args.round} by ${args.proposer.toString()}`),
+    );
+    const p = promiseWithResolvers<{ amount: bigint; attester: EthAddress }>();
+    const unsub = rollup.listenToSlash(data => {
+      if (data.attester.equals(who)) {
+        logger.warn(`Slashed ${who.toString()} for ${data.amount}`);
+        unsub();
+        p.resolve(data);
+      }
+    });
+    return Promise.race([p.promise, timeoutPromise(timeoutSeconds * 1000)]);
+  };
+
+  const getTotalSlashDelaySeconds = () => {
+    const { slashingOffsetInRounds, slashingExecutionDelayInRounds, slashingRoundSizeInEpochs } = slashSettings;
+    const epochSec = Number(constants.epochDuration * constants.slotDuration);
+    const totalEpochs = slashingRoundSizeInEpochs * (slashingOffsetInRounds + slashingExecutionDelayInRounds + 1);
+    return epochSec * totalEpochs;
+  };
+
+  it('slashes across network partitions and slashes the offline subset', async () => {
+    void getGitProjectRoot(); // ensure repo root is resolvable (used by helm paths in utils)
+
+    monitor.on('l2-epoch', args => logger.warn(`Current epoch is ${args.l2EpochNumber}`, args));
+    await monitor.run();
+
+    const configs = await getSequencersConfig(config);
+    configs.forEach(c => logger.info(`Loaded initial sequencer config`, c));
+
+    const pods = (await getSequencers(config.NAMESPACE)).filter(Boolean);
+    expect(pods.length).toBeGreaterThanOrEqual(3);
+    const oneThird = Math.max(1, Math.floor(pods.length / 3));
+    const groupA = pods.slice(0, oneThird);
+    const groupB = pods.slice(oneThird);
+    const groupA2 = groupA.slice(0, Math.max(1, Math.floor(groupA.length / 3)));
+
+    const { epoch } = await getNextEpochCommittee();
+    const lastSlotBeforeEpoch = getSlotRangeForEpoch(epoch, constants)[0] - 1n;
+    await monitor.waitUntilL2Slot(lastSlotBeforeEpoch);
+
+    const inactivityPenalty = slashSettings.slashingAmounts[0];
+    await updateSequencersConfig(config, {
+      slashSelfAllowed: true,
+      slashValidatorsNever: [],
+      slashInactivityPenalty: inactivityPenalty,
+      slashInactivityTargetPercentage: 0.7,
+    });
+
+    const epochsToPartition = 3;
+    const partitionDuration = Number(constants.epochDuration * constants.slotDuration) * epochsToPartition;
+    await applyNetworkPartition({
+      namespace: config.NAMESPACE,
+      spartanDir: `${getGitProjectRoot()}/spartan`,
+      logger,
+      groupA,
+      groupB,
+      durationSeconds: partitionDuration,
+    });
+
+    const offlineEpochs = 2;
+    const offlineDuration = Number(constants.epochDuration * constants.slotDuration) * offlineEpochs;
+    await applyValidatorFailureForPods({
+      namespace: config.NAMESPACE,
+      spartanDir: `${getGitProjectRoot()}/spartan`,
+      logger,
+      podNames: groupA2,
+      durationSeconds: offlineDuration,
+    });
+
+    const endOfPartitionSlot = getSlotRangeForEpoch(epoch + BigInt(epochsToPartition), constants)[0] - 1n;
+    await monitor.waitUntilL2Slot(endOfPartitionSlot);
+
+    const timeout = getTotalSlashDelaySeconds() + 60;
+    const { committee } = await getNextEpochCommittee();
+    const candidates = committee.slice(0, Math.min(3, committee.length)).map(EthAddress.fromString);
+
+    const results = await Promise.all(candidates.map(a => waitForSlash(a, timeout).catch(() => undefined)));
+    const anySlashed = results.some(r => r !== undefined);
+    expect(anySlashed).toBe(true);
+  });
+});

--- a/yarn-project/end-to-end/src/spartan/utils.ts
+++ b/yarn-project/end-to-end/src/spartan/utils.ts
@@ -491,6 +491,61 @@ export function applyNetworkShaping({
   });
 }
 
+export function applyNetworkPartition({
+  namespace,
+  spartanDir,
+  logger,
+  groupA,
+  groupB,
+  durationSeconds,
+}: {
+  namespace: string;
+  spartanDir: string;
+  logger: Logger;
+  groupA: string[];
+  groupB: string[];
+  durationSeconds: number;
+}) {
+  return installChaosMeshChart({
+    instanceName: 'network-partition',
+    targetNamespace: namespace,
+    valuesFile: 'network-partition.yaml',
+    helmChartDir: getChartDir(spartanDir, 'aztec-chaos-scenarios'),
+    logger,
+    values: {
+      'networkPartition.groupA': groupA.join(','),
+      'networkPartition.groupB': groupB.join(','),
+      'networkPartition.duration': `${durationSeconds}s`,
+    },
+  });
+}
+
+export function applyValidatorFailureForPods({
+  namespace,
+  spartanDir,
+  logger,
+  podNames,
+  durationSeconds,
+}: {
+  namespace: string;
+  spartanDir: string;
+  logger: Logger;
+  podNames: string[];
+  durationSeconds: number;
+}) {
+  return installChaosMeshChart({
+    instanceName: 'validator-failure',
+    targetNamespace: namespace,
+    valuesFile: 'validator-failure.yaml',
+    helmChartDir: getChartDir(spartanDir, 'aztec-chaos-scenarios'),
+    logger,
+    values: {
+      'validatorFailure.podsCsv': podNames.join(','),
+      'validatorFailure.duration': `${durationSeconds}s`,
+    },
+  });
+}
+
 export async function awaitL2BlockNumber(
   rollupCheatCodes: RollupCheatCodes,
   blockNumber: bigint,


### PR DESCRIPTION
- Helm: add network-partition-explicit and validator-failure templates + values
- Utils: add applyNetworkPartition/applyValidatorFailureForPods
- Tests: add slash_partitions.test.ts covering partition + offline subset slashing
