### PR TITLE
fix: TxEffect.random + related test fix

### DIFF
--- a/yarn-project/stdlib/src/tx/tx_effect.ts
+++ b/yarn-project/stdlib/src/tx/tx_effect.ts
@@ -194,7 +194,7 @@ export class TxEffect {
 
   static async random({
     numNoteHashes,
-    numNullifiers,
+    numNullifiers = 1,
     numL2ToL1Msgs,
     numPublicDataWrites,
     numPrivateLogs,
@@ -213,6 +213,9 @@ export class TxEffect {
     numContractClassLogs?: number;
     maxEffects?: number;
   } = {}): Promise<TxEffect> {
+    if (numNullifiers < 1) {
+      throw new Error(`A tx effect must have at least one nullifier. Only ${numNullifiers} got requested.`);
+    }
     const count = (max: number, num?: number) => num ?? Math.min(maxEffects ?? randomInt(max), max);
     return new TxEffect(
       RevertCode.random(),

--- a/yarn-project/world-state/src/native/native_bench.test.ts
+++ b/yarn-project/world-state/src/native/native_bench.test.ts
@@ -157,10 +157,9 @@ describe('Native World State: benchmarks', () => {
     op: (treeId: MerkleTreeId, value: Buffer | Fr, fork: MerkleTreeReadOperations) => Promise<any>,
   ) => {
     const fork = await worldState.fork();
-    const treeInfo = await fork.getTreeInfo(treeId);
-    const indices = Array.from({ length: numRetrievals }, () =>
-      Math.floor(Math.random() * Number(treeInfo.size - 1n)),
-    ).map(m => BigInt(m));
+    const indices = Array.from({ length: numRetrievals }, () => Math.floor(Math.random() * values.length)).map(m =>
+      BigInt(m),
+    );
 
     const startTime = performance.now();
 


### PR DESCRIPTION
I tried to include the changes done to the `tx_effect.ts` file in a PR down the stack but it caused the `native_bench.test.ts` to fail.

The failure is caused by the default `numNullifiers` value changing to 1 which the test seems to fail to handle. I told AI to fix the issue and it managed to make it pass and the fix seems fine. I don't have that much context there so please review the fix thoroughly.