### PR TITLE
refactor: InBlock

### DIFF
--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -49,7 +49,7 @@ import {
 import { PublicSimulatorConfig } from '@aztec/stdlib/avm';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import {
-  type InBlock,
+  type DataInBlock,
   type L2Block,
   L2BlockHash,
   type L2BlockNumber,
@@ -787,7 +787,7 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, Traceable {
     blockNumber: L2BlockNumber,
     treeId: MerkleTreeId,
     leafValues: Fr[],
-  ): Promise<(InBlock<bigint> | undefined)[]> {
+  ): Promise<(DataInBlock<bigint> | undefined)[]> {
     const committedDb = await this.#getWorldState(blockNumber);
     const maybeIndices = await committedDb.findLeafIndices(
       treeId,
@@ -824,7 +824,7 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, Traceable {
       }
     }
 
-    // Create InBlock objects by combining indices, blockNumbers and blockHashes and return them.
+    // Create DataInBlock objects by combining indices, blockNumbers and blockHashes and return them.
     return maybeIndices.map((index, i) => {
       if (index === undefined) {
         return undefined;

--- a/yarn-project/pxe/src/contract_function_simulator/pxe_oracle_interface.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/pxe_oracle_interface.ts
@@ -5,7 +5,7 @@ import { createLogger } from '@aztec/foundation/log';
 import type { KeyStore } from '@aztec/key-store';
 import { EventSelector, type FunctionArtifactWithContractName, FunctionSelector } from '@aztec/stdlib/abi';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
-import type { InBlock, L2Block, L2BlockNumber } from '@aztec/stdlib/block';
+import type { DataInBlock, L2Block, L2BlockNumber } from '@aztec/stdlib/block';
 import type { CompleteAddress, ContractInstance } from '@aztec/stdlib/contract';
 import { computeUniqueNoteHash, siloNoteHash, siloNullifier, siloPrivateLog } from '@aztec/stdlib/hash';
 import { type AztecNode, MAX_RPC_LEN } from '@aztec/stdlib/interfaces/client';
@@ -941,10 +941,10 @@ export class PXEOracleInterface implements ExecutionDataProvider {
     const foundNullifiers = nullifiersToCheck
       .map((nullifier, i) => {
         if (nullifierIndexes[i] !== undefined) {
-          return { ...nullifierIndexes[i], ...{ data: nullifier } } as InBlock<Fr>;
+          return { ...nullifierIndexes[i], ...{ data: nullifier } } as DataInBlock<Fr>;
         }
       })
-      .filter(nullifier => nullifier !== undefined) as InBlock<Fr>[];
+      .filter(nullifier => nullifier !== undefined) as DataInBlock<Fr>[];
 
     const nullifiedNotes = await this.noteDataProvider.applyNullifiers(foundNullifiers);
     nullifiedNotes.forEach(noteDao => {

--- a/yarn-project/pxe/src/storage/note_data_provider/note_data_provider.ts
+++ b/yarn-project/pxe/src/storage/note_data_provider/note_data_provider.ts
@@ -3,7 +3,7 @@ import type { Fr } from '@aztec/foundation/fields';
 import { toArray } from '@aztec/foundation/iterable';
 import type { AztecAsyncKVStore, AztecAsyncMap, AztecAsyncMultiMap } from '@aztec/kv-store';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
-import type { InBlock } from '@aztec/stdlib/block';
+import type { DataInBlock } from '@aztec/stdlib/block';
 import { NoteStatus, type NotesFilter } from '@aztec/stdlib/note';
 import { NoteDao } from '@aztec/stdlib/note';
 
@@ -333,7 +333,7 @@ export class NoteDataProvider {
    * @returns Promise resolving to array of nullified NoteDao objects
    * @throws Error if any nullifier is not found in the active notes
    */
-  applyNullifiers(nullifiers: InBlock<Fr>[]): Promise<NoteDao[]> {
+  applyNullifiers(nullifiers: DataInBlock<Fr>[]): Promise<NoteDao[]> {
     if (nullifiers.length === 0) {
       return Promise.resolve([]);
     }

--- a/yarn-project/stdlib/src/block/in_block.ts
+++ b/yarn-project/stdlib/src/block/in_block.ts
@@ -4,14 +4,17 @@ import { schemas } from '../schemas/index.js';
 import { L2BlockHash } from './block_hash.js';
 import type { L2Block } from './l2_block.js';
 
-// Note: If you expand this type with indexInBlock, then delete `IndexedTxEffect` and use this type instead.
-export type InBlock<T> = {
+export type InBlock = {
   l2BlockNumber: number;
   l2BlockHash: L2BlockHash;
-  data: T;
 };
 
-export function randomInBlock<T>(data: T): InBlock<T> {
+// Note: If you expand this type with indexInBlock, then delete `IndexedTxEffect` and use this type instead.
+export type DataInBlock<T> = {
+  data: T;
+} & InBlock;
+
+export function randomInBlock<T>(data: T): DataInBlock<T> {
   return {
     data,
     l2BlockNumber: Math.floor(Math.random() * 1000),
@@ -19,7 +22,7 @@ export function randomInBlock<T>(data: T): InBlock<T> {
   };
 }
 
-export async function wrapInBlock<T>(data: T, block: L2Block): Promise<InBlock<T>> {
+export async function wrapInBlock<T>(data: T, block: L2Block): Promise<DataInBlock<T>> {
   return {
     data,
     l2BlockNumber: block.number,

--- a/yarn-project/stdlib/src/interfaces/aztec-node.test.ts
+++ b/yarn-project/stdlib/src/interfaces/aztec-node.test.ts
@@ -21,7 +21,7 @@ import times from 'lodash.times';
 
 import type { ContractArtifact } from '../abi/abi.js';
 import { AztecAddress } from '../aztec-address/index.js';
-import type { InBlock } from '../block/in_block.js';
+import type { DataInBlock } from '../block/in_block.js';
 import { CommitteeAttestation, L2BlockHash, type L2BlockNumber } from '../block/index.js';
 import { L2Block } from '../block/l2_block.js';
 import type { L2Tips } from '../block/l2_block_source.js';
@@ -525,7 +525,7 @@ class MockAztecNode implements AztecNode {
     blockNumber: number | 'latest',
     treeId: MerkleTreeId,
     leafValues: Fr[],
-  ): Promise<(InBlock<bigint> | undefined)[]> {
+  ): Promise<(DataInBlock<bigint> | undefined)[]> {
     expect(leafValues).toHaveLength(2);
     expect(leafValues[0]).toBeInstanceOf(Fr);
     expect(leafValues[1]).toBeInstanceOf(Fr);

--- a/yarn-project/stdlib/src/interfaces/aztec-node.ts
+++ b/yarn-project/stdlib/src/interfaces/aztec-node.ts
@@ -16,7 +16,7 @@ import { MembershipWitness, SiblingPath } from '@aztec/foundation/trees';
 import { z } from 'zod';
 
 import type { AztecAddress } from '../aztec-address/index.js';
-import { type InBlock, inBlockSchemaFor } from '../block/in_block.js';
+import { type DataInBlock, inBlockSchemaFor } from '../block/in_block.js';
 import { L2Block } from '../block/l2_block.js';
 import { type L2BlockNumber, L2BlockNumberSchema } from '../block/l2_block_number.js';
 import { type L2BlockSource, type L2Tips, L2TipsSchema } from '../block/l2_block_source.js';
@@ -91,7 +91,7 @@ export interface AztecNode
     blockNumber: L2BlockNumber,
     treeId: MerkleTreeId,
     leafValues: Fr[],
-  ): Promise<(InBlock<bigint> | undefined)[]>;
+  ): Promise<(DataInBlock<bigint> | undefined)[]>;
 
   /**
    * Returns a sibling path for the given index in the nullifier tree.

--- a/yarn-project/stdlib/src/tx/indexed_tx_effect.ts
+++ b/yarn-project/stdlib/src/tx/indexed_tx_effect.ts
@@ -2,10 +2,10 @@ import { schemas } from '@aztec/foundation/schemas';
 import { BufferReader, serializeToBuffer } from '@aztec/foundation/serialize';
 
 import { L2BlockHash } from '../block/block_hash.js';
-import { type InBlock, inBlockSchemaFor, randomInBlock } from '../block/in_block.js';
+import { type DataInBlock, inBlockSchemaFor, randomInBlock } from '../block/in_block.js';
 import { TxEffect } from './tx_effect.js';
 
-export type IndexedTxEffect = InBlock<TxEffect> & { txIndexInBlock: number };
+export type IndexedTxEffect = DataInBlock<TxEffect> & { txIndexInBlock: number };
 
 export function indexedTxSchema() {
   return inBlockSchemaFor(TxEffect.schema).extend({ txIndexInBlock: schemas.Integer });


### PR DESCRIPTION
- Remove `data` from `InBlock` and make it non-generic
- Introduce `DataInBlock<T>` as an intersection type `{ data: T } & InBlock`

Motivation: we want to use coherent `InBlock` attributes throughout the codebase, but we don't want to force wrapper structures through `data`. At the same time, sometimes that's necessary/convenient:

1. When you want to represent a "scalar" value in the context of a block (eg: Fr, bigint, any primitive type).
2. When you want to annotate a class instance with those fields.  

Closes F-143