### PR TITLE
chore(docs): fix latest version references in docs

### DIFF
--- a/docs/docs/the_aztec_network/operation/operator_faq.md
+++ b/docs/docs/the_aztec_network/operation/operator_faq.md
@@ -42,9 +42,7 @@ ERROR: world-state:database Call SYNC_BLOCK failed: Error: Can't synch block: bl
    rm -rf ~/.aztec/v2.0.4/data/archiver
    ```
 
-3. Update to the latest version (see the "Updating to Latest Version" section below)
-
-4. Restart your node:
+3. Restart your node:
 
    ```bash
    docker compose up -d
@@ -216,29 +214,9 @@ Sequencers with insufficient funds in their publisher account risk being slashed
 
 ## Updates and Maintenance
 
-### Updating to Latest Version
-
-**Issue**: You need to update your node to the latest Aztec version.
-
-**Solution**:
-
-```bash
-# Pull the latest image
-docker compose pull
-
-# Stop the current container
-docker compose down
-
-# Start with the new image
-docker compose up -d
-
-# Verify it's running
-docker compose logs -f aztec-sequencer
-```
-
 #### Version-Specific Updates:
 
-To update to a specific version instead of latest, update your `docker-compose.yml`:
+To update to a specific version , update your `docker-compose.yml`:
 
 ```yaml
 # Change the image tag from:

--- a/docs/versioned_docs/version-v2.1.4/developers/getting_started_on_testnet.md
+++ b/docs/versioned_docs/version-v2.1.4/developers/getting_started_on_testnet.md
@@ -49,7 +49,7 @@ bash -i <(curl -s https://install.aztec.network)
 3. The testnet version installed:
 
 ```bash
-aztec-up -v latest
+aztec-up -v 2.1.4
 ```
 
 :::warning

--- a/docs/versioned_docs/version-v2.1.4/the_aztec_network/operation/operator_faq.md
+++ b/docs/versioned_docs/version-v2.1.4/the_aztec_network/operation/operator_faq.md
@@ -41,13 +41,7 @@ ERROR: world-state:database Call SYNC_BLOCK failed: Error: Can't synch block: bl
    rm -rf ~/.aztec/v2.1.4/data/archiver
    ```
 
-3. Update to the latest version:
-
-   ```bash
-   aztec-up -v latest
-   ```
-
-4. Restart your node with your normal startup command
+3. Restart your node with your normal startup command
 
 :::warning Data Loss and Resync
 This process removes local state and requires full resynchronization. Consider using snapshot sync mode (`--sync-mode snapshot`) to speed up recovery. See the [syncing best practices guide](../setup/syncing_best_practices.md) for more information.
@@ -215,43 +209,9 @@ Sequencers with insufficient funds in their publisher account risk being slashed
 
 ## Updates and Maintenance
 
-### Updating to Latest Version
-
-**Issue**: You need to update your node to the latest Aztec version.
-
-**Solution**:
-
-#### For CLI Method:
-
-```bash
-# Update the Aztec binary
-aztec-up -v latest
-
-# Verify the new version
-aztec --version
-
-# Restart your node with your normal startup command
-```
-
-#### For Docker Compose Method:
-
-```bash
-# Pull the latest image
-docker compose pull
-
-# Stop the current container
-docker compose down
-
-# Start with the new image
-docker compose up -d
-
-# Verify it's running
-docker compose logs -f aztec-sequencer
-```
-
 #### Version-Specific Updates:
 
-To update to a specific version instead of latest:
+To update to a specific version:
 
 ```bash
 # CLI method

--- a/docs/versioned_docs/version-v2.1.5-ignition/developers/getting_started_on_testnet.md
+++ b/docs/versioned_docs/version-v2.1.5-ignition/developers/getting_started_on_testnet.md
@@ -49,7 +49,7 @@ bash -i <(curl -s https://install.aztec.network)
 3. The testnet version installed:
 
 ```bash
-aztec-up -v latest
+aztec-up -v 2.1.5
 ```
 
 :::warning

--- a/docs/versioned_docs/version-v2.1.5-ignition/the_aztec_network/operation/operator_faq.md
+++ b/docs/versioned_docs/version-v2.1.5-ignition/the_aztec_network/operation/operator_faq.md
@@ -41,13 +41,7 @@ ERROR: world-state:database Call SYNC_BLOCK failed: Error: Can't synch block: bl
    rm -rf ~/.aztec/v2.1.5/data/archiver
    ```
 
-3. Update to the latest version:
-
-   ```bash
-   aztec-up -v latest
-   ```
-
-4. Restart your node with your normal startup command
+3. Restart your node with your normal startup command
 
 :::warning Data Loss and Resync
 This process removes local state and requires full resynchronization. Consider using snapshot sync mode (`--sync-mode snapshot`) to speed up recovery. See the [syncing best practices guide](../setup/syncing_best_practices.md) for more information.
@@ -217,43 +211,9 @@ Sequencers with insufficient funds in their publisher account risk being slashed
 
 ## Updates and Maintenance
 
-### Updating to Latest Version
-
-**Issue**: You need to update your node to the latest Aztec version.
-
-**Solution**:
-
-#### For CLI Method:
-
-```bash
-# Update the Aztec binary
-aztec-up -v latest
-
-# Verify the new version
-aztec --version
-
-# Restart your node with your normal startup command
-```
-
-#### For Docker Compose Method:
-
-```bash
-# Pull the latest image
-docker compose pull
-
-# Stop the current container
-docker compose down
-
-# Start with the new image
-docker compose up -d
-
-# Verify it's running
-docker compose logs -f aztec-sequencer
-```
-
 #### Version-Specific Updates:
 
-To update to a specific version instead of latest:
+To update to a specific version:
 
 ```bash
 # CLI method

--- a/docs/versioned_docs/version-v3.0.0-devnet.5/the_aztec_network/operation/operator_faq.md
+++ b/docs/versioned_docs/version-v3.0.0-devnet.5/the_aztec_network/operation/operator_faq.md
@@ -38,16 +38,10 @@ ERROR: world-state:database Call SYNC_BLOCK failed: Error: Can't synch block: bl
 2. Remove the archiver data directory:
 
    ```bash
-   rm -rf ~/.aztec/v2.0.4/data/archiver
+   rm -rf ~/.aztec/v3.0.0-devnet.5/data/archiver
    ```
 
-3. Update to the latest version:
-
-   ```bash
-   aztec-up -v latest
-   ```
-
-4. Restart your node with your normal startup command
+3. Restart your node with your normal startup command
 
 :::warning Data Loss and Resync
 This process removes local state and requires full resynchronization. Consider using snapshot sync mode (`--sync-mode snapshot`) to speed up recovery. See the [syncing best practices guide](../setup/syncing_best_practices.md) for more information.
@@ -215,43 +209,9 @@ Sequencers with insufficient funds in their publisher account risk being slashed
 
 ## Updates and Maintenance
 
-### Updating to Latest Version
-
-**Issue**: You need to update your node to the latest Aztec version.
-
-**Solution**:
-
-#### For CLI Method:
-
-```bash
-# Update the Aztec binary
-aztec-up -v latest
-
-# Verify the new version
-aztec --version
-
-# Restart your node with your normal startup command
-```
-
-#### For Docker Compose Method:
-
-```bash
-# Pull the latest image
-docker compose pull
-
-# Stop the current container
-docker compose down
-
-# Start with the new image
-docker compose up -d
-
-# Verify it's running
-docker compose logs -f aztec-sequencer
-```
-
 #### Version-Specific Updates:
 
-To update to a specific version instead of latest:
+To update to a specific version:
 
 ```bash
 # CLI method


### PR DESCRIPTION
We have versioned docs so we should not be using latest in the versioned docs as install directions