### PR TITLE
feat(avm): callstack metadata collection limits are properly plumbed to cpp simulator

### DIFF
--- a/barretenberg/cpp/src/barretenberg/vm2/common/avm_io.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/common/avm_io.hpp
@@ -427,6 +427,7 @@ struct AvmProvingInputs {
 struct CollectionLimitsConfig {
     uint32_t max_debug_log_memory_reads = 0;
     uint32_t max_calldata_size_in_fields = 0;
+    uint32_t max_returndata_size_in_fields = 0;
     uint32_t max_call_stack_depth = 0;
     uint32_t max_call_stack_items = 0;
 
@@ -434,6 +435,7 @@ struct CollectionLimitsConfig {
 
     MSGPACK_CAMEL_CASE_FIELDS(max_debug_log_memory_reads,
                               max_calldata_size_in_fields,
+                              max_returndata_size_in_fields,
                               max_call_stack_depth,
                               max_call_stack_items);
 };

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/lib/call_stack_metadata_collector.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/lib/call_stack_metadata_collector.cpp
@@ -12,6 +12,19 @@ void CallStackMetadataCollector::set_phase(CoarseTransactionPhase phase)
     current_phase = phase;
 }
 
+bool CallStackMetadataCollector::should_skip_collection() const
+{
+    // Check call stack depth limit (size - 1 because we have a dummy root).
+    if (limits.max_call_stack_depth > 0 && (call_stack_metadata.size() - 1) >= limits.max_call_stack_depth) {
+        return true;
+    }
+    // Check total call stack items limit.
+    if (limits.max_call_stack_items > 0 && total_call_stack_items >= limits.max_call_stack_items) {
+        return true;
+    }
+    return false;
+}
+
 void CallStackMetadataCollector::notify_enter_call(const AztecAddress& contract_address,
                                                    uint32_t caller_pc,
                                                    const CalldataProvider& calldata_provider,
@@ -19,9 +32,17 @@ void CallStackMetadataCollector::notify_enter_call(const AztecAddress& contract_
                                                    const Gas& gas_limit)
 {
     assert(!call_stack_metadata.empty());
-    call_stack_metadata.top().num_nested_calls++;
 
-    uint32_t max_calldata_size = 1024; // TODO: make this configurable.
+    // Check if we should stop collecting due to limits.
+    if (should_skip_collection()) {
+        return;
+    }
+
+    call_stack_metadata.top().num_nested_calls++;
+    total_call_stack_items++;
+
+    // Use configured limit or default.
+    uint32_t max_calldata_size = limits.max_calldata_size_in_fields > 0 ? limits.max_calldata_size_in_fields : 1024;
     std::vector<FF> calldata = calldata_provider(max_calldata_size);
 
     call_stack_metadata.push({
@@ -46,7 +67,14 @@ void CallStackMetadataCollector::notify_exit_call(bool success,
                                                   const ReturnDataProvider& return_data_provider,
                                                   const InternalCallStackProvider& internal_call_stack_provider)
 {
-    uint32_t max_return_data_size = 1024; // TODO: make this configurable.
+    // If we only have the dummy root, we skipped collection for this call.
+    if (call_stack_metadata.size() <= 1) {
+        return;
+    }
+
+    // Use configured limit or default.
+    uint32_t max_return_data_size =
+        limits.max_returndata_size_in_fields > 0 ? limits.max_returndata_size_in_fields : 1024;
     std::vector<FF> return_data = return_data_provider(max_return_data_size);
     std::vector<PC> internal_call_stack = internal_call_stack_provider();
     internal_call_stack.push_back(pc);

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/lib/call_stack_metadata_collector.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/lib/call_stack_metadata_collector.hpp
@@ -3,6 +3,7 @@
 #include <stack>
 #include <vector>
 
+#include "barretenberg/vm2/common/avm_io.hpp"
 #include "barretenberg/vm2/simulation/interfaces/call_stack_metadata_collector.hpp"
 
 namespace bb::avm2::simulation {
@@ -14,6 +15,9 @@ class InternalCallStackManagerInterface;
 class CallStackMetadataCollector : public CallStackMetadataCollectorInterface {
   public:
     CallStackMetadataCollector() = default;
+    explicit CallStackMetadataCollector(const CollectionLimitsConfig& limits)
+        : limits(limits)
+    {}
 
     void set_phase(CoarseTransactionPhase phase) override;
     void notify_enter_call(const AztecAddress& contract_address,
@@ -30,13 +34,21 @@ class CallStackMetadataCollector : public CallStackMetadataCollectorInterface {
     std::vector<CallStackMetadata> dump_call_stack_metadata() override;
 
   private:
+    // Collection limits configuration.
+    CollectionLimitsConfig limits;
+
     // It is incremented by 1 for each new call.
     uint32_t timestamp = 0;
+    // Total number of call stack items collected.
+    uint32_t total_call_stack_items = 0;
     // We start with a dummy call stack metadata. This is not a real call,
     // we use it as a placeholder "root call" that corresponds to the whole TX.
     // We store the enqueued calls in the nested vector of this root call.
     std::stack<CallStackMetadata> call_stack_metadata{ { {} } };
     CoarseTransactionPhase current_phase = CoarseTransactionPhase::SETUP;
+
+    // Returns true if we should skip collection due to limits being exceeded.
+    bool should_skip_collection() const;
 };
 
 // These factories return an object that is only valid for the lifetime of the context.

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation_helper.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation_helper.cpp
@@ -412,11 +412,11 @@ TxSimulationResult AvmSimulationHelper::simulate_fast(ContractDBInterface& raw_c
             return std::make_unique<NoopDebugLogger>();
         }
     }();
-    auto call_stack_metadata_collector = config.collect_call_metadata
-                                             ? static_cast<std::unique_ptr<CallStackMetadataCollectorInterface>>(
-                                                   std::make_unique<CallStackMetadataCollector>())
-                                             : static_cast<std::unique_ptr<CallStackMetadataCollectorInterface>>(
-                                                   std::make_unique<NoopCallStackMetadataCollector>());
+    auto call_stack_metadata_collector =
+        config.collect_call_metadata ? static_cast<std::unique_ptr<CallStackMetadataCollectorInterface>>(
+                                           std::make_unique<CallStackMetadataCollector>(config.collection_limits))
+                                     : static_cast<std::unique_ptr<CallStackMetadataCollectorInterface>>(
+                                           std::make_unique<NoopCallStackMetadataCollector>());
 
     HybridExecution execution(alu,
                               bitwise,

--- a/yarn-project/stdlib/src/avm/avm.ts
+++ b/yarn-project/stdlib/src/avm/avm.ts
@@ -1283,6 +1283,7 @@ export class CollectionLimitsConfig {
   constructor(
     public readonly maxDebugLogMemoryReads: number,
     public readonly maxCalldataSizeInFields: number,
+    public readonly maxReturndataSizeInFields: number,
     public readonly maxCallStackDepth: number,
     public readonly maxCallStackItems: number,
   ) {}
@@ -1291,6 +1292,7 @@ export class CollectionLimitsConfig {
     return new CollectionLimitsConfig(
       obj.maxDebugLogMemoryReads ?? DEFAULT_MAX_DEBUG_LOG_MEMORY_READS,
       obj.maxCalldataSizeInFields ?? 300,
+      obj.maxReturndataSizeInFields ?? 300,
       obj.maxCallStackDepth ?? 5,
       obj.maxCallStackItems ?? 100,
     );
@@ -1305,14 +1307,22 @@ export class CollectionLimitsConfig {
       .object({
         maxDebugLogMemoryReads: z.number(),
         maxCalldataSizeInFields: z.number(),
+        maxReturndataSizeInFields: z.number(),
         maxCallStackDepth: z.number(),
         maxCallStackItems: z.number(),
       })
       .transform(
-        ({ maxDebugLogMemoryReads, maxCalldataSizeInFields, maxCallStackDepth, maxCallStackItems }) =>
+        ({
+          maxDebugLogMemoryReads,
+          maxCalldataSizeInFields,
+          maxReturndataSizeInFields,
+          maxCallStackDepth,
+          maxCallStackItems,
+        }) =>
           new CollectionLimitsConfig(
             maxDebugLogMemoryReads,
             maxCalldataSizeInFields,
+            maxReturndataSizeInFields,
             maxCallStackDepth,
             maxCallStackItems,
           ),


### PR DESCRIPTION
Plumb callstack metadata collection limits from TS to C++ sim down into the collector. Add returndata limit to config.