### PR TITLE
feat: prover node processes multiple blocks per checkpoint

### DIFF
--- a/yarn-project/archiver/src/archiver/archiver.ts
+++ b/yarn-project/archiver/src/archiver/archiver.ts
@@ -1234,6 +1234,19 @@ export class Archiver extends (EventEmitter as new () => ArchiverEmitter) implem
     );
   }
 
+  public async getCheckpointsForEpoch(epochNumber: EpochNumber): Promise<Checkpoint[]> {
+    // TODO: Create store and apis for checkpoints.
+    // This only works when we have one block per checkpoint.
+    const blocks = await this.getBlocksForEpoch(epochNumber);
+    return blocks.map(b => b.toCheckpoint());
+  }
+
+  public getL1ToL2MessagesForCheckpoint(checkpointNumber: CheckpointNumber): Promise<Fr[]> {
+    // TODO: Create dedicated api for checkpoints.
+    // This only works when we have one block per checkpoint.
+    return this.getL1ToL2Messages(checkpointNumber);
+  }
+
   /**
    * Gets up to `limit` amount of L2 blocks starting from `from`.
    * @param from - Number of the first block to return (inclusive).

--- a/yarn-project/archiver/src/test/mock_archiver.ts
+++ b/yarn-project/archiver/src/test/mock_archiver.ts
@@ -1,3 +1,4 @@
+import type { CheckpointNumber } from '@aztec/foundation/branded-types';
 import type { Fr } from '@aztec/foundation/fields';
 import type { L2Block, L2BlockSource } from '@aztec/stdlib/block';
 import type { L1ToL2MessageSource } from '@aztec/stdlib/messaging';
@@ -21,6 +22,11 @@ export class MockArchiver extends MockL2BlockSource implements L2BlockSource, L1
 
   getL1ToL2MessageIndex(_l1ToL2Message: Fr): Promise<bigint | undefined> {
     return this.messageSource.getL1ToL2MessageIndex(_l1ToL2Message);
+  }
+
+  getL1ToL2MessagesForCheckpoint(checkpointNumber: CheckpointNumber): Promise<Fr[]> {
+    // TODO: Implement this properly. This only works when we have one block per checkpoint.
+    return this.messageSource.getL1ToL2Messages(checkpointNumber);
   }
 }
 

--- a/yarn-project/archiver/src/test/mock_l1_to_l2_message_source.ts
+++ b/yarn-project/archiver/src/test/mock_l1_to_l2_message_source.ts
@@ -1,3 +1,4 @@
+import type { CheckpointNumber } from '@aztec/foundation/branded-types';
 import { Fr } from '@aztec/foundation/fields';
 import type { L2Tips } from '@aztec/stdlib/block';
 import type { L1ToL2MessageSource } from '@aztec/stdlib/messaging';
@@ -16,6 +17,11 @@ export class MockL1ToL2MessageSource implements L1ToL2MessageSource {
 
   public setBlockNumber(blockNumber: number) {
     this.blockNumber = blockNumber;
+  }
+
+  getL1ToL2MessagesForCheckpoint(checkpointNumber: CheckpointNumber): Promise<Fr[]> {
+    // TODO: Implement this properly. This only works when we have one block per checkpoint.
+    return this.getL1ToL2Messages(checkpointNumber);
   }
 
   getL1ToL2Messages(blockNumber: number): Promise<Fr[]> {

--- a/yarn-project/archiver/src/test/mock_l2_block_source.ts
+++ b/yarn-project/archiver/src/test/mock_l2_block_source.ts
@@ -15,6 +15,7 @@ import {
   PublishedL2Block,
   type ValidateBlockResult,
 } from '@aztec/stdlib/block';
+import type { Checkpoint } from '@aztec/stdlib/checkpoint';
 import type { ContractClassPublic, ContractDataSource, ContractInstanceWithAddress } from '@aztec/stdlib/contract';
 import { EmptyL1RollupConstants, type L1RollupConstants, getSlotRangeForEpoch } from '@aztec/stdlib/epoch-helpers';
 import { type BlockHeader, TxHash, TxReceipt, TxStatus } from '@aztec/stdlib/tx';
@@ -113,6 +114,11 @@ export class MockL2BlockSource implements L2BlockSource, ContractDataSource {
     );
   }
 
+  public async getPublishedCheckpoints(from: number, limit: number) {
+    // TODO: Implement this properly. This only works when we have one block per checkpoint.
+    return (await this.getPublishedBlocks(from, limit)).map(block => block.toPublishedCheckpoint());
+  }
+
   public async getPublishedBlocks(from: number, limit: number, proven?: boolean) {
     const blocks = await this.getBlocks(from, limit, proven);
     return blocks.map(block =>
@@ -181,6 +187,11 @@ export class MockL2BlockSource implements L2BlockSource, ContractDataSource {
 
   getBlockHeader(number: number | 'latest'): Promise<BlockHeader | undefined> {
     return Promise.resolve(this.l2Blocks.at(typeof number === 'number' ? number - 1 : -1)?.getBlockHeader());
+  }
+
+  getCheckpointsForEpoch(epochNumber: EpochNumber): Promise<Checkpoint[]> {
+    // TODO: Implement this properly. This only works when we have one block per checkpoint.
+    return this.getBlocksForEpoch(epochNumber).then(blocks => blocks.map(b => b.toCheckpoint()));
   }
 
   getBlocksForEpoch(epochNumber: EpochNumber): Promise<L2Block[]> {

--- a/yarn-project/p2p/src/services/tx_collection/tx_collection.ts
+++ b/yarn-project/p2p/src/services/tx_collection/tx_collection.ts
@@ -2,7 +2,7 @@ import { compactArray } from '@aztec/foundation/collection';
 import { type Logger, createLogger } from '@aztec/foundation/log';
 import { type PromiseWithResolvers, RunningPromise } from '@aztec/foundation/promise';
 import { DateProvider } from '@aztec/foundation/timer';
-import type { L2Block, L2BlockInfo } from '@aztec/stdlib/block';
+import type { L2Block, L2BlockInfo, L2BlockNew } from '@aztec/stdlib/block';
 import type { L1RollupConstants } from '@aztec/stdlib/epoch-helpers';
 import type { BlockProposal } from '@aztec/stdlib/p2p';
 import { Tx, TxHash } from '@aztec/stdlib/tx';
@@ -24,7 +24,7 @@ export type CollectionMethod = 'fast-req-resp' | 'fast-node-rpc' | 'slow-req-res
 export type MissingTxInfo = { blockNumber: number; deadline: Date; readyForReqResp: boolean };
 
 export type FastCollectionRequestInput =
-  | { type: 'block'; block: L2Block }
+  | { type: 'block'; block: L2BlockNew }
   | { type: 'proposal'; blockProposal: BlockProposal; blockNumber: number };
 
 export type FastCollectionRequest = FastCollectionRequestInput & {
@@ -165,7 +165,7 @@ export class TxCollection {
     txHashes: TxHash[] | string[],
     opts: { deadline: Date; pinnedPeer?: PeerId },
   ) {
-    return this.collectFastFor({ type: 'block', block }, txHashes, opts);
+    return this.collectFastFor({ type: 'block', block: block.toL2Block() }, txHashes, opts);
   }
 
   /** Collects the set of txs for the given proposal or block as fast as possible */

--- a/yarn-project/p2p/src/services/tx_provider.ts
+++ b/yarn-project/p2p/src/services/tx_provider.ts
@@ -1,7 +1,7 @@
 import { compactArray } from '@aztec/foundation/collection';
 import { type Logger, createLogger } from '@aztec/foundation/log';
 import { elapsed } from '@aztec/foundation/timer';
-import type { L2Block, L2BlockInfo } from '@aztec/stdlib/block';
+import type { L2BlockInfo, L2BlockNew } from '@aztec/stdlib/block';
 import type { ITxProvider } from '@aztec/stdlib/interfaces/server';
 import type { BlockProposal } from '@aztec/stdlib/p2p';
 import { Tx, TxHash } from '@aztec/stdlib/tx';
@@ -67,7 +67,7 @@ export class TxProvider implements ITxProvider {
   }
 
   /** Gathers txs from the tx pool, remote rpc nodes, and reqresp. */
-  public getTxsForBlock(block: L2Block, opts: { deadline: Date }): Promise<{ txs: Tx[]; missingTxs: TxHash[] }> {
+  public getTxsForBlock(block: L2BlockNew, opts: { deadline: Date }): Promise<{ txs: Tx[]; missingTxs: TxHash[] }> {
     return this.getOrderedTxsFromAllSources(
       { type: 'block', block },
       block.toBlockInfo(),

--- a/yarn-project/prover-node/src/job/epoch-proving-job-data.test.ts
+++ b/yarn-project/prover-node/src/job/epoch-proving-job-data.test.ts
@@ -1,8 +1,10 @@
-import { EpochNumber } from '@aztec/foundation/branded-types';
+import { CheckpointNumber, EpochNumber } from '@aztec/foundation/branded-types';
 import { times, timesAsync } from '@aztec/foundation/collection';
+import { randomInt } from '@aztec/foundation/crypto';
 import { Fr } from '@aztec/foundation/fields';
-import { CommitteeAttestation, L2Block } from '@aztec/stdlib/block';
-import { Tx } from '@aztec/stdlib/tx';
+import { CommitteeAttestation } from '@aztec/stdlib/block';
+import { Checkpoint } from '@aztec/stdlib/checkpoint';
+import { BlockHeader, Tx } from '@aztec/stdlib/tx';
 
 import {
   type EpochProvingJobData,
@@ -17,15 +19,17 @@ describe('EpochProvingJobData', () => {
 
     const jobData: EpochProvingJobData = {
       epochNumber: EpochNumber.fromBigInt(3n),
-      blocks: await timesAsync(4, i => L2Block.random(i + 1)),
+      checkpoints: await timesAsync(4, i =>
+        Checkpoint.random(CheckpointNumber(i + 1), { numBlocks: 1 + randomInt(5) }),
+      ),
       txs,
       l1ToL2Messages: {
-        0: [Fr.random(), Fr.random()],
-        1: [Fr.random()],
-        2: [Fr.random(), Fr.random(), Fr.random()],
-        3: [Fr.random()],
+        [CheckpointNumber(0)]: [Fr.random(), Fr.random()],
+        [CheckpointNumber(1)]: [Fr.random()],
+        [CheckpointNumber(2)]: [Fr.random(), Fr.random(), Fr.random()],
+        [CheckpointNumber(3)]: [Fr.random()],
       },
-      previousBlockHeader: await L2Block.random(0).then(b => b.getBlockHeader()),
+      previousBlockHeader: BlockHeader.random(),
       attestations: times(3, CommitteeAttestation.random),
     };
 

--- a/yarn-project/prover-node/src/job/epoch-proving-job-data.ts
+++ b/yarn-project/prover-node/src/job/epoch-proving-job-data.ts
@@ -1,40 +1,45 @@
-import { EpochNumber } from '@aztec/foundation/branded-types';
+import { CheckpointNumber, EpochNumber } from '@aztec/foundation/branded-types';
 import { Fr } from '@aztec/foundation/fields';
 import { BufferReader, serializeToBuffer } from '@aztec/foundation/serialize';
-import { CommitteeAttestation, L2Block } from '@aztec/stdlib/block';
+import { CommitteeAttestation } from '@aztec/stdlib/block';
+import { Checkpoint } from '@aztec/stdlib/checkpoint';
 import { BlockHeader, Tx } from '@aztec/stdlib/tx';
 
 /** All data from an epoch used in proving. */
 export type EpochProvingJobData = {
   epochNumber: EpochNumber;
-  blocks: L2Block[];
+  checkpoints: Checkpoint[];
   txs: Map<string, Tx>;
-  l1ToL2Messages: Record<number, Fr[]>;
+  l1ToL2Messages: Record<CheckpointNumber, Fr[]>;
   previousBlockHeader: BlockHeader;
   attestations: CommitteeAttestation[];
 };
 
 export function validateEpochProvingJobData(data: EpochProvingJobData) {
-  if (data.blocks.length > 0 && data.previousBlockHeader.getBlockNumber() + 1 !== data.blocks[0].number) {
+  if (data.checkpoints.length === 0) {
+    throw new Error('No checkpoints to prove');
+  }
+
+  const firstBlockNumber = data.checkpoints[0].blocks[0].number;
+  const previousBlockNumber = data.previousBlockHeader.getBlockNumber();
+  if (previousBlockNumber + 1 !== firstBlockNumber) {
     throw new Error(
-      `Initial block number ${
-        data.blocks[0].number
-      } does not match previous block header ${data.previousBlockHeader.getBlockNumber()}`,
+      `Initial block number ${firstBlockNumber} does not match previous block header ${previousBlockNumber}`,
     );
   }
 
-  for (const blockNumber of data.blocks.map(block => block.number)) {
-    if (!(blockNumber in data.l1ToL2Messages)) {
-      throw new Error(`Missing L1 to L2 messages for block number ${blockNumber}`);
+  for (const checkpoint of data.checkpoints) {
+    if (!(checkpoint.number in data.l1ToL2Messages)) {
+      throw new Error(`Missing L1 to L2 messages for checkpoint number ${checkpoint.number}`);
     }
   }
 }
 
 export function serializeEpochProvingJobData(data: EpochProvingJobData): Buffer {
-  const blocks = data.blocks.map(block => block.toBuffer());
+  const checkpoints = data.checkpoints.map(checkpoint => checkpoint.toBuffer());
   const txs = Array.from(data.txs.values()).map(tx => tx.toBuffer());
-  const l1ToL2Messages = Object.entries(data.l1ToL2Messages).map(([blockNumber, messages]) => [
-    Number(blockNumber),
+  const l1ToL2Messages = Object.entries(data.l1ToL2Messages).map(([checkpointNumber, messages]) => [
+    Number(checkpointNumber),
     messages.length,
     ...messages,
   ]);
@@ -43,8 +48,8 @@ export function serializeEpochProvingJobData(data: EpochProvingJobData): Buffer 
   return serializeToBuffer(
     data.epochNumber,
     data.previousBlockHeader,
-    blocks.length,
-    ...blocks,
+    checkpoints.length,
+    ...checkpoints,
     txs.length,
     ...txs,
     l1ToL2Messages.length,
@@ -58,20 +63,20 @@ export function deserializeEpochProvingJobData(buf: Buffer): EpochProvingJobData
   const reader = BufferReader.asReader(buf);
   const epochNumber = EpochNumber(reader.readNumber());
   const previousBlockHeader = reader.readObject(BlockHeader);
-  const blocks = reader.readVector(L2Block);
+  const checkpoints = reader.readVector(Checkpoint);
   const txArray = reader.readVector(Tx);
 
-  const l1ToL2MessageBlockCount = reader.readNumber();
+  const l1ToL2MessageCheckpointCount = reader.readNumber();
   const l1ToL2Messages: Record<number, Fr[]> = {};
-  for (let i = 0; i < l1ToL2MessageBlockCount; i++) {
-    const blockNumber = reader.readNumber();
+  for (let i = 0; i < l1ToL2MessageCheckpointCount; i++) {
+    const checkpointNumber = CheckpointNumber(reader.readNumber());
     const messages = reader.readVector(Fr);
-    l1ToL2Messages[blockNumber] = messages;
+    l1ToL2Messages[checkpointNumber] = messages;
   }
 
   const attestations = reader.readVector(CommitteeAttestation);
 
   const txs = new Map<string, Tx>(txArray.map(tx => [tx.getTxHash().toString(), tx]));
 
-  return { epochNumber, previousBlockHeader, blocks, txs, l1ToL2Messages, attestations };
+  return { epochNumber, previousBlockHeader, checkpoints, txs, l1ToL2Messages, attestations };
 }

--- a/yarn-project/prover-node/src/job/epoch-proving-job.test.ts
+++ b/yarn-project/prover-node/src/job/epoch-proving-job.test.ts
@@ -1,12 +1,13 @@
 import { BatchedBlob } from '@aztec/blob-lib/types';
-import { EpochNumber } from '@aztec/foundation/branded-types';
+import { CheckpointNumber, EpochNumber } from '@aztec/foundation/branded-types';
 import { fromEntries, times, timesParallel } from '@aztec/foundation/collection';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { toArray } from '@aztec/foundation/iterable';
 import { sleep } from '@aztec/foundation/sleep';
 import type { PublicProcessor, PublicProcessorFactory } from '@aztec/simulator/server';
 import { PublicSimulatorConfig } from '@aztec/stdlib/avm';
-import { CommitteeAttestation, L2Block, type L2BlockSource, PublishedL2Block } from '@aztec/stdlib/block';
+import { CommitteeAttestation, type L2BlockSource } from '@aztec/stdlib/block';
+import { Checkpoint, PublishedCheckpoint } from '@aztec/stdlib/checkpoint';
 import type { L1RollupConstants } from '@aztec/stdlib/epoch-helpers';
 import type { EpochProver, MerkleTreeWriteOperations, WorldStateSynchronizer } from '@aztec/stdlib/interfaces/server';
 import { Proof } from '@aztec/stdlib/proofs';
@@ -39,16 +40,17 @@ describe('epoch-proving-job', () => {
   let publicInputs: RootRollupPublicInputs;
   let proof: Proof;
   let batchedBlobInputs: BatchedBlob;
-  let blocks: L2Block[];
+  let checkpoints: Checkpoint[];
   let txs: Tx[];
   let initialHeader: BlockHeader;
   let epochNumber: number;
   let attestations: CommitteeAttestation[];
 
   // Constants
-  const NUM_BLOCKS = 3;
+  const NUM_CHECKPOINTS = 3;
+  const BLOCKS_PER_CHECKPOINT = 2;
   const TXS_PER_BLOCK = 2;
-  const NUM_TXS = NUM_BLOCKS * TXS_PER_BLOCK;
+  const NUM_BLOCKS = NUM_CHECKPOINTS * BLOCKS_PER_CHECKPOINT;
   const proverId = EthAddress.random();
 
   // Subject factory
@@ -56,10 +58,10 @@ describe('epoch-proving-job', () => {
     const txsMap = new Map<string, Tx>(txs.map(tx => [tx.getTxHash().toString(), tx]));
 
     const data: EpochProvingJobData = {
-      blocks,
+      checkpoints,
       txs: txsMap,
       epochNumber: EpochNumber(epochNumber),
-      l1ToL2Messages: fromEntries(blocks.map(b => [b.number, []])),
+      l1ToL2Messages: fromEntries(checkpoints.map(c => [c.number, []])),
       previousBlockHeader: initialHeader,
       attestations,
     };
@@ -100,16 +102,24 @@ describe('epoch-proving-job', () => {
     );
     epochNumber = 1;
     initialHeader = BlockHeader.empty();
-    blocks = await timesParallel(NUM_BLOCKS, i => L2Block.random(i + 1, TXS_PER_BLOCK));
+    checkpoints = await timesParallel(NUM_CHECKPOINTS, i =>
+      Checkpoint.random(CheckpointNumber(i + 1), {
+        numBlocks: BLOCKS_PER_CHECKPOINT,
+        startBlockNumber: i * BLOCKS_PER_CHECKPOINT + 1,
+        txsPerBlock: TXS_PER_BLOCK,
+      }),
+    );
     attestations = times(3, CommitteeAttestation.random);
 
-    const txHashes = times(NUM_TXS, i => blocks[i % NUM_BLOCKS].body.txEffects[i % TXS_PER_BLOCK].txHash);
+    const txHashes = checkpoints.map(c => c.blocks.map(b => b.body.txEffects.map(tx => tx.txHash))).flat(2);
     txs = txHashes.map(txHash => ({ txHash, getTxHash: () => txHash }) as Tx);
 
     l2BlockSource.getBlockHeader.mockResolvedValue(initialHeader);
     l2BlockSource.getL1Constants.mockResolvedValue({ ethereumSlotDuration: 0.1 } as L1RollupConstants);
-    l2BlockSource.getBlockHeadersForEpoch.mockResolvedValue(blocks.map(b => b.getBlockHeader()));
-    l2BlockSource.getPublishedBlocks.mockResolvedValue([{ block: blocks.at(-1)!, attestations } as PublishedL2Block]);
+    l2BlockSource.getBlockHeadersForEpoch.mockResolvedValue(checkpoints.map(c => c.blocks.map(b => b.header)).flat());
+    l2BlockSource.getPublishedCheckpoints.mockResolvedValue([
+      { checkpoint: checkpoints.at(-1)!, attestations } as PublishedCheckpoint,
+    ]);
     publicProcessorFactory.create.mockReturnValue(publicProcessor);
     db.getInitialHeader.mockReturnValue(initialHeader);
     worldState.fork.mockResolvedValue(db);
@@ -157,7 +167,7 @@ describe('epoch-proving-job', () => {
 
     const firstBlockProcessedTxs = publicProcessor.process.mock.calls[0][0] as Tx[];
     expect(firstBlockProcessedTxs.map(tx => tx.txHash.toString())).toEqual(
-      blocks[0].body.txEffects.map(tx => tx.txHash.toString()),
+      checkpoints[0].blocks[0].body.txEffects.map(tx => tx.txHash.toString()),
     );
   });
 
@@ -206,8 +216,7 @@ describe('epoch-proving-job', () => {
   });
 
   it('halts if a new block for the epoch is found', async () => {
-    const newBlocks = await timesParallel(NUM_BLOCKS + 1, i => L2Block.random(i + 1, TXS_PER_BLOCK));
-    const newHeaders = newBlocks.map(b => b.getBlockHeader());
+    const newHeaders = times(NUM_BLOCKS + 1, i => BlockHeader.random({ blockNumber: i + 1 }));
     l2BlockSource.getBlockHeadersForEpoch.mockResolvedValue(newHeaders);
 
     const job = createJob();

--- a/yarn-project/prover-node/src/job/epoch-proving-job.ts
+++ b/yarn-project/prover-node/src/job/epoch-proving-job.ts
@@ -11,7 +11,8 @@ import { protocolContractsHash } from '@aztec/protocol-contracts';
 import { buildFinalBlobChallenges } from '@aztec/prover-client/helpers';
 import type { PublicProcessor, PublicProcessorFactory } from '@aztec/simulator/server';
 import { PublicSimulatorConfig } from '@aztec/stdlib/avm';
-import type { L2Block, L2BlockSource } from '@aztec/stdlib/block';
+import type { L2BlockNew, L2BlockSource } from '@aztec/stdlib/block';
+import type { Checkpoint } from '@aztec/stdlib/checkpoint';
 import {
   type EpochProver,
   type EpochProvingJobState,
@@ -91,8 +92,8 @@ export class EpochProvingJob implements Traceable {
     return this.data.epochNumber;
   }
 
-  private get blocks() {
-    return this.data.blocks;
+  private get checkpoints() {
+    return this.data.checkpoints;
   }
 
   private get txs() {
@@ -117,13 +118,21 @@ export class EpochProvingJob implements Traceable {
 
     const attestations = this.attestations.map(attestation => attestation.toViem());
     const epochNumber = this.epochNumber;
-    const epochSizeBlocks = this.blocks.length;
-    const epochSizeTxs = this.blocks.reduce((total, current) => total + current.body.txEffects.length, 0);
-    const [fromBlock, toBlock] = [this.blocks[0].number, this.blocks.at(-1)!.number];
-    this.log.info(`Starting epoch ${epochNumber} proving job with blocks ${fromBlock} to ${toBlock}`, {
+    const epochSizeCheckpoints = this.checkpoints.length;
+    const epochSizeBlocks = this.checkpoints.reduce((accum, checkpoint) => accum + checkpoint.blocks.length, 0);
+    const epochSizeTxs = this.checkpoints.reduce(
+      (accum, checkpoint) =>
+        accum + checkpoint.blocks.reduce((accumC, block) => accumC + block.body.txEffects.length, 0),
+      0,
+    );
+    const fromCheckpoint = this.checkpoints[0].number;
+    const toCheckpoint = this.checkpoints.at(-1)!.number;
+    const fromBlock = this.checkpoints[0].blocks[0].number;
+    const toBlock = this.checkpoints.at(-1)!.blocks.at(-1)!.number;
+    this.log.info(`Starting epoch ${epochNumber} proving job with checkpoints ${fromCheckpoint} to ${toCheckpoint}`, {
       fromBlock,
       toBlock,
-      epochSizeBlocks,
+      epochSizeTxs,
       epochNumber,
       uuid: this.uuid,
     });
@@ -134,86 +143,93 @@ export class EpochProvingJob implements Traceable {
     this.runPromise = promise;
 
     try {
-      const blobFieldsPerCheckpoint = this.blocks.map(block => block.getCheckpointBlobFields());
+      const blobFieldsPerCheckpoint = this.checkpoints.map(checkpoint => checkpoint.toBlobFields());
       const finalBlobBatchingChallenges = await buildFinalBlobChallenges(blobFieldsPerCheckpoint);
 
-      // TODO(#17027): Enable multiple blocks per checkpoint.
-      // Total number of checkpoints equals number of blocks because we currently build a checkpoint with only one block.
-      const totalNumCheckpoints = epochSizeBlocks;
-
-      this.prover.startNewEpoch(epochNumber, totalNumCheckpoints, finalBlobBatchingChallenges);
+      this.prover.startNewEpoch(epochNumber, epochSizeCheckpoints, finalBlobBatchingChallenges);
       await this.prover.startChonkVerifierCircuits(Array.from(this.txs.values()));
 
-      await asyncPool(this.config.parallelBlockLimit ?? 32, this.blocks, async block => {
+      // Everything in the epoch should have the same chainId and version.
+      const { chainId, version } = this.checkpoints[0].blocks[0].header.globalVariables;
+
+      const previousBlockHeaders = this.gatherPreviousBlockHeaders();
+
+      await asyncPool(this.config.parallelBlockLimit ?? 32, this.checkpoints, async checkpoint => {
         this.checkState();
 
-        const globalVariables = block.header.globalVariables;
-        const txs = this.getTxs(block);
-        const l1ToL2Messages = this.getL1ToL2Messages(block);
-        const previousHeader = this.getBlockHeader(block.number - 1)!;
-
-        this.log.verbose(`Starting processing block ${block.number}`, {
-          number: block.number,
-          blockHash: (await block.hash()).toString(),
-          lastArchive: block.header.lastArchive.root,
-          noteHashTreeRoot: block.header.state.partial.noteHashTree.root,
-          nullifierTreeRoot: block.header.state.partial.nullifierTree.root,
-          publicDataTreeRoot: block.header.state.partial.publicDataTree.root,
-          previousHeader: previousHeader.hash(),
-          uuid: this.uuid,
-          ...globalVariables,
-        });
-
+        const checkpointIndex = checkpoint.number - fromCheckpoint;
         const checkpointConstants = CheckpointConstantData.from({
-          chainId: globalVariables.chainId,
-          version: globalVariables.version,
+          chainId,
+          version,
           vkTreeRoot: getVKTreeRoot(),
           protocolContractsHash: protocolContractsHash,
           proverId: this.prover.getProverId().toField(),
-          slotNumber: globalVariables.slotNumber,
-          coinbase: globalVariables.coinbase,
-          feeRecipient: globalVariables.feeRecipient,
-          gasFees: globalVariables.gasFees,
+          slotNumber: checkpoint.header.slotNumber,
+          coinbase: checkpoint.header.coinbase,
+          feeRecipient: checkpoint.header.feeRecipient,
+          gasFees: checkpoint.header.gasFees,
+        });
+        const previousHeader = previousBlockHeaders[checkpointIndex];
+        const l1ToL2Messages = this.getL1ToL2Messages(checkpoint);
+
+        this.log.verbose(`Starting processing checkpoint ${checkpoint.number}`, {
+          number: checkpoint.number,
+          checkpointHash: checkpoint.hash().toString(),
+          lastArchive: checkpoint.header.lastArchiveRoot,
+          previousHeader: previousHeader.hash(),
+          uuid: this.uuid,
         });
 
-        // TODO(#17027): Enable multiple blocks per checkpoint.
-        // Each checkpoint has only one block.
-        const totalNumBlocks = 1;
-        const checkpointIndex = block.number - fromBlock;
         await this.prover.startNewCheckpoint(
           checkpointIndex,
           checkpointConstants,
           l1ToL2Messages,
-          totalNumBlocks,
+          checkpoint.blocks.length,
           previousHeader,
         );
 
-        // Start block proving
-        await this.prover.startNewBlock(block.number, globalVariables.timestamp, txs.length);
+        for (const block of checkpoint.blocks) {
+          const globalVariables = block.header.globalVariables;
+          const txs = this.getTxs(block);
 
-        // Process public fns
-        const db = await this.createFork(block.number - 1, l1ToL2Messages);
-        const config = PublicSimulatorConfig.from({
-          proverId: this.prover.getProverId().toField(),
-          skipFeeEnforcement: false,
-          collectDebugLogs: false,
-          collectHints: true,
-          maxDebugLogMemoryReads: 0,
-          collectStatistics: false,
-        });
-        const publicProcessor = this.publicProcessorFactory.create(db, globalVariables, config);
-        const processed = await this.processTxs(publicProcessor, txs);
-        await this.prover.addTxs(processed);
-        await db.close();
-        this.log.verbose(`Processed all ${txs.length} txs for block ${block.number}`, {
-          blockNumber: block.number,
-          blockHash: (await block.hash()).toString(),
-          uuid: this.uuid,
-        });
+          this.log.verbose(`Starting processing block ${block.number}`, {
+            number: block.number,
+            blockHash: (await block.hash()).toString(),
+            lastArchive: block.header.lastArchive.root,
+            noteHashTreeRoot: block.header.state.partial.noteHashTree.root,
+            nullifierTreeRoot: block.header.state.partial.nullifierTree.root,
+            publicDataTreeRoot: block.header.state.partial.publicDataTree.root,
+            ...globalVariables,
+            numTxs: txs.length,
+          });
 
-        // Mark block as completed to pad it
-        const expectedBlockHeader = block.getBlockHeader();
-        await this.prover.setBlockCompleted(block.number, expectedBlockHeader);
+          // Start block proving
+          await this.prover.startNewBlock(block.number, globalVariables.timestamp, txs.length);
+
+          // Process public fns
+          const db = await this.createFork(block.number - 1, l1ToL2Messages);
+          const config = PublicSimulatorConfig.from({
+            proverId: this.prover.getProverId().toField(),
+            skipFeeEnforcement: false,
+            collectDebugLogs: false,
+            collectHints: true,
+            maxDebugLogMemoryReads: 0,
+            collectStatistics: false,
+          });
+          const publicProcessor = this.publicProcessorFactory.create(db, globalVariables, config);
+          const processed = await this.processTxs(publicProcessor, txs);
+          await this.prover.addTxs(processed);
+          await db.close();
+          this.log.verbose(`Processed all ${txs.length} txs for block ${block.number}`, {
+            blockNumber: block.number,
+            blockHash: (await block.hash()).toString(),
+            uuid: this.uuid,
+          });
+
+          // Mark block as completed to pad it
+          const expectedBlockHeader = block.header;
+          await this.prover.setBlockCompleted(block.number, expectedBlockHeader);
+        }
       });
 
       const executionTime = timer.ms();
@@ -226,16 +242,16 @@ export class EpochProvingJob implements Traceable {
 
       if (this.config.skipSubmitProof) {
         this.log.info(
-          `Proof publishing is disabled. Dropping valid proof for epoch ${epochNumber} (blocks ${fromBlock} to ${toBlock})`,
+          `Proof publishing is disabled. Dropping valid proof for epoch ${epochNumber} (checkpoints ${fromCheckpoint} to ${toCheckpoint})`,
         );
         this.state = 'completed';
-        this.metrics.recordProvingJob(executionTime, timer.ms(), epochSizeBlocks, epochSizeTxs);
+        this.metrics.recordProvingJob(executionTime, timer.ms(), epochSizeCheckpoints, epochSizeBlocks, epochSizeTxs);
         return;
       }
 
       const success = await this.publisher.submitEpochProof({
-        fromBlock,
-        toBlock,
+        fromCheckpoint,
+        toCheckpoint,
         epochNumber,
         publicInputs,
         proof,
@@ -246,12 +262,12 @@ export class EpochProvingJob implements Traceable {
         throw new Error('Failed to submit epoch proof to L1');
       }
 
-      this.log.info(`Submitted proof for epoch ${epochNumber} (blocks ${fromBlock} to ${toBlock})`, {
+      this.log.info(`Submitted proof for epoch ${epochNumber} (checkpoints ${fromCheckpoint} to ${toCheckpoint})`, {
         epochNumber,
         uuid: this.uuid,
       });
       this.state = 'completed';
-      this.metrics.recordProvingJob(executionTime, timer.ms(), epochSizeBlocks, epochSizeTxs);
+      this.metrics.recordProvingJob(executionTime, timer.ms(), epochSizeCheckpoints, epochSizeBlocks, epochSizeTxs);
     } catch (err: any) {
       if (err && err.name === 'HaltExecutionError') {
         this.log.warn(`Halted execution of epoch ${epochNumber} prover job`, {
@@ -348,11 +364,9 @@ export class EpochProvingJob implements Traceable {
       async () => {
         const blocks = await l2BlockSource.getBlockHeadersForEpoch(this.epochNumber);
         const blockHashes = await Promise.all(blocks.map(block => block.hash()));
-        const thisBlockHashes = await Promise.all(this.blocks.map(block => block.hash()));
-        if (
-          blocks.length !== this.blocks.length ||
-          !blockHashes.every((block, i) => block.equals(thisBlockHashes[i]))
-        ) {
+        const thisBlocks = this.checkpoints.flatMap(checkpoint => checkpoint.blocks);
+        const thisBlockHashes = await Promise.all(thisBlocks.map(block => block.hash()));
+        if (blocks.length !== thisBlocks.length || !blockHashes.every((block, i) => block.equals(thisBlockHashes[i]))) {
           this.log.warn('Epoch blocks changed underfoot', {
             uuid: this.uuid,
             epochNumber: this.epochNumber,
@@ -368,30 +382,18 @@ export class EpochProvingJob implements Traceable {
     this.log.verbose(`Scheduled epoch check for epoch ${this.epochNumber} every ${intervalMs}ms`);
   }
 
-  /* Returns the header for the given block number based on the epoch proving job data. */
-  private getBlockHeader(blockNumber: number) {
-    const block = this.blocks.find(b => b.number === blockNumber);
-    if (block) {
-      return block.getBlockHeader();
-    }
-
-    if (blockNumber === Number(this.data.previousBlockHeader.getBlockNumber())) {
-      return this.data.previousBlockHeader;
-    }
-
-    throw new Error(
-      `Block header not found for block number ${blockNumber} (got ${this.blocks
-        .map(b => b.number)
-        .join(', ')} and previous header ${this.data.previousBlockHeader.getBlockNumber()})`,
-    );
+  /* Returns the last block header in the previous checkpoint for all checkpoints in the epoch */
+  private gatherPreviousBlockHeaders() {
+    const lastBlocks = this.checkpoints.map(checkpoint => checkpoint.blocks.at(-1)!);
+    return [this.data.previousBlockHeader, ...lastBlocks.map(block => block.header).slice(0, -1)];
   }
 
-  private getTxs(block: L2Block): Tx[] {
+  private getTxs(block: L2BlockNew): Tx[] {
     return block.body.txEffects.map(txEffect => this.txs.get(txEffect.txHash.toString())!);
   }
 
-  private getL1ToL2Messages(block: L2Block) {
-    return this.data.l1ToL2Messages[block.number];
+  private getL1ToL2Messages(checkpoint: Checkpoint) {
+    return this.data.l1ToL2Messages[checkpoint.number];
   }
 
   private async processTxs(publicProcessor: PublicProcessor, txs: Tx[]): Promise<ProcessedTx[]> {

--- a/yarn-project/prover-node/src/metrics.ts
+++ b/yarn-project/prover-node/src/metrics.ts
@@ -21,6 +21,7 @@ import { formatEther, formatUnits } from 'viem';
 export class ProverNodeJobMetrics {
   proverEpochExecutionDuration: Histogram;
   provingJobDuration: Histogram;
+  provingJobCheckpoints: Gauge;
   provingJobBlocks: Gauge;
   provingJobTransactions: Gauge;
 
@@ -39,6 +40,10 @@ export class ProverNodeJobMetrics {
       unit: 's',
       valueType: ValueType.DOUBLE,
     });
+    this.provingJobCheckpoints = this.meter.createGauge(Metrics.PROVER_NODE_JOB_CHECKPOINTS, {
+      description: 'Number of checkpoints in a proven epoch',
+      valueType: ValueType.INT,
+    });
     this.provingJobBlocks = this.meter.createGauge(Metrics.PROVER_NODE_JOB_BLOCKS, {
       description: 'Number of blocks in a proven epoch',
       valueType: ValueType.INT,
@@ -49,9 +54,16 @@ export class ProverNodeJobMetrics {
     });
   }
 
-  public recordProvingJob(executionTimeMs: number, totalTimeMs: number, numBlocks: number, numTxs: number) {
+  public recordProvingJob(
+    executionTimeMs: number,
+    totalTimeMs: number,
+    numCheckpoints: number,
+    numBlocks: number,
+    numTxs: number,
+  ) {
     this.proverEpochExecutionDuration.record(Math.ceil(executionTimeMs));
     this.provingJobDuration.record(totalTimeMs / 1000);
+    this.provingJobCheckpoints.record(Math.floor(numCheckpoints));
     this.provingJobBlocks.record(Math.floor(numBlocks));
     this.provingJobTransactions.record(Math.floor(numTxs));
   }

--- a/yarn-project/prover-node/src/prover-node-publisher.test.ts
+++ b/yarn-project/prover-node/src/prover-node-publisher.test.ts
@@ -54,91 +54,91 @@ describe('prover-node-publisher', () => {
 
   const testCases = [
     // Usual case of proving full epoch
-    { pendingBlockNumber: 65n, provenBlockNumber: 32n, fromBlock: 33, toBlock: 64, expectedPublish: true, message: '' },
+    { pending: 65n, proven: 32n, fromCheckpoint: 33, toCheckpoint: 64, expectedPublish: true, message: '' },
     // Failure case of proving beyond the pending chain
     {
-      pendingBlockNumber: 65n,
-      provenBlockNumber: 32n,
-      fromBlock: 33,
-      toBlock: 66,
+      pending: 65n,
+      proven: 32n,
+      fromCheckpoint: 33,
+      toCheckpoint: 66,
       expectedPublish: false,
-      message: 'Cannot submit epoch proof for 33-66 as pending block is 65',
+      message: 'Cannot submit epoch proof for 33-66 as pending checkpoint is 65',
     },
     // Some successful partial epochs
-    { pendingBlockNumber: 33n, provenBlockNumber: 32n, fromBlock: 33, toBlock: 33, expectedPublish: true, message: '' },
-    { pendingBlockNumber: 65n, provenBlockNumber: 32n, fromBlock: 33, toBlock: 38, expectedPublish: true, message: '' },
-    { pendingBlockNumber: 40n, provenBlockNumber: 32n, fromBlock: 33, toBlock: 33, expectedPublish: true, message: '' },
+    { pending: 33n, proven: 32n, fromCheckpoint: 33, toCheckpoint: 33, expectedPublish: true, message: '' },
+    { pending: 65n, proven: 32n, fromCheckpoint: 33, toCheckpoint: 38, expectedPublish: true, message: '' },
+    { pending: 40n, proven: 32n, fromCheckpoint: 33, toCheckpoint: 33, expectedPublish: true, message: '' },
 
     // Somebody else proved the entire epoch already
 
     // We try and prove the full epoch - succeeds
-    { pendingBlockNumber: 65n, provenBlockNumber: 64n, fromBlock: 33, toBlock: 64, expectedPublish: true, message: '' },
+    { pending: 65n, proven: 64n, fromCheckpoint: 33, toCheckpoint: 64, expectedPublish: true, message: '' },
 
     // We try and prove a partial epoch that falls short of the end - fails as pointless to publish
     {
-      pendingBlockNumber: 65n,
-      provenBlockNumber: 64n,
-      fromBlock: 33,
-      toBlock: 35,
+      pending: 65n,
+      proven: 64n,
+      fromCheckpoint: 33,
+      toCheckpoint: 35,
       expectedPublish: false,
-      message: 'Cannot submit epoch proof for 33-35 as proven block is 64',
+      message: 'Cannot submit epoch proof for 33-35 as proven checkpoint is 64',
     },
 
     // Somebody else partially proved the epoch already
 
     // We try and prove the rest of the epoch - succeeds
-    { pendingBlockNumber: 65n, provenBlockNumber: 40n, fromBlock: 41, toBlock: 64, expectedPublish: true, message: '' },
+    { pending: 65n, proven: 40n, fromCheckpoint: 41, toCheckpoint: 64, expectedPublish: true, message: '' },
 
     // We try and prove all of the epoch - succeeds
-    { pendingBlockNumber: 65n, provenBlockNumber: 40n, fromBlock: 33, toBlock: 64, expectedPublish: true, message: '' },
+    { pending: 65n, proven: 40n, fromCheckpoint: 33, toCheckpoint: 64, expectedPublish: true, message: '' },
 
     // We try and partially prove the epoch after their proof - succeeds again
-    { pendingBlockNumber: 65n, provenBlockNumber: 40n, fromBlock: 41, toBlock: 45, expectedPublish: true, message: '' },
+    { pending: 65n, proven: 40n, fromCheckpoint: 41, toCheckpoint: 45, expectedPublish: true, message: '' },
 
     // We try and partially prove the epoch on top of their proof - succeeds again
-    { pendingBlockNumber: 65n, provenBlockNumber: 40n, fromBlock: 33, toBlock: 45, expectedPublish: true, message: '' },
+    { pending: 65n, proven: 40n, fromCheckpoint: 33, toCheckpoint: 45, expectedPublish: true, message: '' },
 
     // We try and partially prove the epoch and partially on top of their proof - succeeds again
-    { pendingBlockNumber: 65n, provenBlockNumber: 40n, fromBlock: 35, toBlock: 45, expectedPublish: true, message: '' },
+    { pending: 65n, proven: 40n, fromCheckpoint: 35, toCheckpoint: 45, expectedPublish: true, message: '' },
 
     // We try and partially prove the epoch but less than was already proven - fails as pointless
     {
-      pendingBlockNumber: 65n,
-      provenBlockNumber: 40n,
-      fromBlock: 33,
-      toBlock: 39,
+      pending: 65n,
+      proven: 40n,
+      fromCheckpoint: 33,
+      toCheckpoint: 39,
       expectedPublish: false,
-      message: 'Cannot submit epoch proof for 33-39 as proven block is 40',
+      message: 'Cannot submit epoch proof for 33-39 as proven checkpoint is 40',
     },
 
     // We try and partially prove the epoch but the same as was already proven - should possibly fail but succeeds for now, quite an edge case
     {
-      pendingBlockNumber: 65n,
-      provenBlockNumber: 40n,
-      fromBlock: 33,
-      toBlock: 40,
+      pending: 65n,
+      proven: 40n,
+      fromCheckpoint: 33,
+      toCheckpoint: 40,
       expectedPublish: true,
     },
   ];
 
   test.each(testCases)(
-    'submits proof for epoch with pendingBlock: $pendingBlockNumber, provenBlock: $provenBlockNumber, fromBlock: $fromBlock, toBlock: $toBlock',
-    async ({ pendingBlockNumber, provenBlockNumber, fromBlock, toBlock, expectedPublish, message }) => {
-      // Create public inputs for every block
-      const blocks = Array.from({ length: 100 }, () => {
+    'submits proof for epoch with pending checkpoint: $pending, proven checkpoint: $proven, fromCheckpoint: $fromCheckpoint, toCheckpoint: $toCheckpoint',
+    async ({ pending, proven, fromCheckpoint, toCheckpoint, expectedPublish, message }) => {
+      // Create public inputs for every checkpoint
+      const checkpoints = Array.from({ length: 100 }, () => {
         return RootRollupPublicInputs.random();
       });
 
       // Return the tips specified by the test
       rollup.getTips.mockResolvedValue({
-        pending: pendingBlockNumber,
-        proven: provenBlockNumber,
+        pending: pending,
+        proven: proven,
       });
 
       // Return the requested checkpoint
       rollup.getCheckpoint.mockImplementation((checkpointNumber: CheckpointNumber) =>
         Promise.resolve({
-          archive: blocks[checkpointNumber - 1].endArchiveRoot.toString(),
+          archive: checkpoints[checkpointNumber - 1].endArchiveRoot.toString(),
           attestationsHash: '0x', // unused,
           payloadDigest: '0x', // unused,
           headerHash: '0x', // unused,
@@ -154,11 +154,11 @@ describe('prover-node-publisher', () => {
         }),
       );
 
-      // We have built a rollup proof of the range fromBlock - toBlock
+      // We have built a rollup proof of the range fromCheckpoint - toCheckpoint
       // so we need to set our archives and hashes accordingly
       const ourPublicInputs = RootRollupPublicInputs.random();
-      ourPublicInputs.previousArchiveRoot = blocks[fromBlock - 2]?.endArchiveRoot ?? Fr.ZERO;
-      ourPublicInputs.endArchiveRoot = blocks[toBlock - 1]?.endArchiveRoot ?? Fr.ZERO;
+      ourPublicInputs.previousArchiveRoot = checkpoints[fromCheckpoint - 2]?.endArchiveRoot ?? Fr.ZERO;
+      ourPublicInputs.endArchiveRoot = checkpoints[toCheckpoint - 1]?.endArchiveRoot ?? Fr.ZERO;
 
       const ourBatchedBlob = new BatchedBlob(
         ourPublicInputs.blobPublicInputs.blobCommitmentsHash,
@@ -175,8 +175,8 @@ describe('prover-node-publisher', () => {
       const result = await publisher
         .submitEpochProof({
           epochNumber: EpochNumber(2),
-          fromBlock,
-          toBlock,
+          fromCheckpoint: CheckpointNumber(fromCheckpoint),
+          toCheckpoint: CheckpointNumber(toCheckpoint),
           publicInputs: ourPublicInputs,
           proof: Proof.empty(),
           batchedBlobInputs: ourBatchedBlob,
@@ -196,7 +196,7 @@ describe('prover-node-publisher', () => {
   );
 
   it('handles reverted txs correctly', async () => {
-    const blocks = [RootRollupPublicInputs.random(), RootRollupPublicInputs.random()];
+    const checkpoints = [RootRollupPublicInputs.random(), RootRollupPublicInputs.random()];
 
     // Return the tips specified by the test
     rollup.getTips.mockResolvedValue({
@@ -204,10 +204,10 @@ describe('prover-node-publisher', () => {
       proven: 1n,
     });
 
-    // Return the requested block
+    // Return the requested checkpoint
     rollup.getCheckpoint.mockImplementation((checkpointNumber: CheckpointNumber) =>
       Promise.resolve({
-        archive: blocks[checkpointNumber - 1].endArchiveRoot.toString(),
+        archive: checkpoints[checkpointNumber - 1].endArchiveRoot.toString(),
         attestationsHash: '0x', // unused,
         payloadDigest: '0x', // unused,
         headerHash: '0x', // unused,
@@ -223,11 +223,11 @@ describe('prover-node-publisher', () => {
       }),
     );
 
-    // We have built a rollup proof of the range fromBlock - toBlock
+    // We have built a rollup proof of the range fromCheckpoint - toCheckpoint
     // so we need to set our archives and hashes accordingly
     const ourPublicInputs = RootRollupPublicInputs.random();
-    ourPublicInputs.previousArchiveRoot = blocks[0].endArchiveRoot ?? Fr.ZERO;
-    ourPublicInputs.endArchiveRoot = blocks[1].endArchiveRoot ?? Fr.ZERO;
+    ourPublicInputs.previousArchiveRoot = checkpoints[0].endArchiveRoot ?? Fr.ZERO;
+    ourPublicInputs.endArchiveRoot = checkpoints[1].endArchiveRoot ?? Fr.ZERO;
 
     const ourBatchedBlob = new BatchedBlob(
       ourPublicInputs.blobPublicInputs.blobCommitmentsHash,
@@ -267,8 +267,8 @@ describe('prover-node-publisher', () => {
 
     const result = await publisher.submitEpochProof({
       epochNumber: EpochNumber(2),
-      fromBlock: 2,
-      toBlock: 2,
+      fromCheckpoint: CheckpointNumber(2),
+      toCheckpoint: CheckpointNumber(2),
       publicInputs: ourPublicInputs,
       proof: Proof.empty(),
       batchedBlobInputs: ourBatchedBlob,

--- a/yarn-project/prover-node/src/prover-node-publisher.ts
+++ b/yarn-project/prover-node/src/prover-node-publisher.ts
@@ -87,15 +87,15 @@ export class ProverNodePublisher {
 
   public async submitEpochProof(args: {
     epochNumber: EpochNumber;
-    fromBlock: number;
-    toBlock: number;
+    fromCheckpoint: CheckpointNumber;
+    toCheckpoint: CheckpointNumber;
     publicInputs: RootRollupPublicInputs;
     proof: Proof;
     batchedBlobInputs: BatchedBlob;
     attestations: ViemCommitteeAttestation[];
   }): Promise<boolean> {
-    const { epochNumber, fromBlock, toBlock } = args;
-    const ctx = { epochNumber, fromBlock, toBlock };
+    const { epochNumber, fromCheckpoint, toCheckpoint } = args;
+    const ctx = { epochNumber, fromCheckpoint, toCheckpoint };
 
     if (!this.interrupted) {
       const timer = new Timer();
@@ -139,45 +139,48 @@ export class ProverNodePublisher {
       this.log.error(`Rollup.submitEpochProof tx status failed ${txReceipt.transactionHash}`, undefined, ctx);
     }
 
-    this.log.verbose('L2 block data syncing interrupted', ctx);
+    this.log.verbose('Checkpoint data syncing interrupted', ctx);
     return false;
   }
 
   private async validateEpochProofSubmission(args: {
-    fromBlock: number;
-    toBlock: number;
+    fromCheckpoint: CheckpointNumber;
+    toCheckpoint: CheckpointNumber;
     publicInputs: RootRollupPublicInputs;
     proof: Proof;
     batchedBlobInputs: BatchedBlob;
     attestations: ViemCommitteeAttestation[];
   }) {
-    const { fromBlock, toBlock, publicInputs, batchedBlobInputs } = args;
+    const { fromCheckpoint, toCheckpoint, publicInputs, batchedBlobInputs } = args;
 
-    // Check that the block numbers match the expected epoch to be proven
-    // TODO: These are checkpoint numbers, not block numbers. Fix when we decouple them properly.
+    // Check that the checkpoint numbers match the expected epoch to be proven
     const { pending, proven } = await this.rollupContract.getTips();
-    // Don't publish if proven is beyond our toBlock, pointless to do so
-    if (proven > BigInt(toBlock)) {
-      throw new Error(`Cannot submit epoch proof for ${fromBlock}-${toBlock} as proven block is ${proven}`);
-    }
-    // toBlock can't be greater than pending
-    if (toBlock > pending) {
-      throw new Error(`Cannot submit epoch proof for ${fromBlock}-${toBlock} as pending block is ${pending}`);
-    }
-
-    // Check the archive for the immediate block before the epoch
-    const blockLog = await this.rollupContract.getCheckpoint(CheckpointNumber.fromBlockNumber(fromBlock - 1));
-    if (publicInputs.previousArchiveRoot.toString() !== blockLog.archive) {
+    // Don't publish if proven is beyond our toCheckpoint, pointless to do so
+    if (proven > BigInt(toCheckpoint)) {
       throw new Error(
-        `Previous archive root mismatch: ${publicInputs.previousArchiveRoot.toString()} !== ${blockLog.archive}`,
+        `Cannot submit epoch proof for ${fromCheckpoint}-${toCheckpoint} as proven checkpoint is ${proven}`,
+      );
+    }
+    // toCheckpoint can't be greater than pending
+    if (toCheckpoint > pending) {
+      throw new Error(
+        `Cannot submit epoch proof for ${fromCheckpoint}-${toCheckpoint} as pending checkpoint is ${pending}`,
       );
     }
 
-    // Check the archive for the last block in the epoch
-    const endBlockLog = await this.rollupContract.getCheckpoint(CheckpointNumber.fromBlockNumber(toBlock));
-    if (publicInputs.endArchiveRoot.toString() !== endBlockLog.archive) {
+    // Check the archive for the immediate checkpoint before the epoch
+    const checkpointLog = await this.rollupContract.getCheckpoint(CheckpointNumber(fromCheckpoint - 1));
+    if (publicInputs.previousArchiveRoot.toString() !== checkpointLog.archive) {
       throw new Error(
-        `End archive root mismatch: ${publicInputs.endArchiveRoot.toString()} !== ${endBlockLog.archive}`,
+        `Previous archive root mismatch: ${publicInputs.previousArchiveRoot.toString()} !== ${checkpointLog.archive}`,
+      );
+    }
+
+    // Check the archive for the last checkpoint in the epoch
+    const endCheckpointLog = await this.rollupContract.getCheckpoint(toCheckpoint);
+    if (publicInputs.endArchiveRoot.toString() !== endCheckpointLog.archive) {
+      throw new Error(
+        `End archive root mismatch: ${publicInputs.endArchiveRoot.toString()} !== ${endCheckpointLog.archive}`,
       );
     }
 
@@ -204,8 +207,8 @@ export class ProverNodePublisher {
   }
 
   private async sendSubmitEpochProofTx(args: {
-    fromBlock: number;
-    toBlock: number;
+    fromCheckpoint: CheckpointNumber;
+    toCheckpoint: CheckpointNumber;
     publicInputs: RootRollupPublicInputs;
     proof: Proof;
     batchedBlobInputs: BatchedBlob;
@@ -215,8 +218,8 @@ export class ProverNodePublisher {
 
     this.log.info(`Submitting epoch proof to L1 rollup contract`, {
       proofSize: args.proof.withoutPublicInputs().length,
-      fromBlock: args.fromBlock,
-      toBlock: args.toBlock,
+      fromCheckpoint: args.fromCheckpoint,
+      toCheckpoint: args.toCheckpoint,
     });
     const data = encodeFunctionData({
       abi: RollupAbi,
@@ -245,16 +248,16 @@ export class ProverNodePublisher {
   }
 
   private getEpochProofPublicInputsArgs(args: {
-    fromBlock: number;
-    toBlock: number;
+    fromCheckpoint: CheckpointNumber;
+    toCheckpoint: CheckpointNumber;
     publicInputs: RootRollupPublicInputs;
     batchedBlobInputs: BatchedBlob;
     attestations: ViemCommitteeAttestation[];
   }) {
     // Returns arguments for EpochProofLib.sol -> getEpochProofPublicInputs()
     return [
-      BigInt(args.fromBlock) /*_start*/,
-      BigInt(args.toBlock) /*_end*/,
+      BigInt(args.fromCheckpoint) /*_start*/,
+      BigInt(args.toCheckpoint) /*_end*/,
       {
         previousArchive: args.publicInputs.previousArchiveRoot.toString(),
         endArchive: args.publicInputs.endArchiveRoot.toString(),
@@ -270,8 +273,8 @@ export class ProverNodePublisher {
   }
 
   private getSubmitEpochProofArgs(args: {
-    fromBlock: number;
-    toBlock: number;
+    fromCheckpoint: CheckpointNumber;
+    toCheckpoint: CheckpointNumber;
     publicInputs: RootRollupPublicInputs;
     proof: Proof;
     batchedBlobInputs: BatchedBlob;

--- a/yarn-project/prover-node/src/prover-node.test.ts
+++ b/yarn-project/prover-node/src/prover-node.test.ts
@@ -1,5 +1,5 @@
 import { RollupContract } from '@aztec/ethereum';
-import { EpochNumber } from '@aztec/foundation/branded-types';
+import { CheckpointNumber, EpochNumber } from '@aztec/foundation/branded-types';
 import { timesParallel } from '@aztec/foundation/collection';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { promiseWithResolvers } from '@aztec/foundation/promise';
@@ -7,7 +7,8 @@ import { retryUntil } from '@aztec/foundation/retry';
 import { sleep } from '@aztec/foundation/sleep';
 import type { P2PClient, TxProvider } from '@aztec/p2p';
 import type { PublicProcessorFactory } from '@aztec/simulator/server';
-import { CommitteeAttestation, L2Block, type L2BlockSource, PublishedL2Block } from '@aztec/stdlib/block';
+import { CommitteeAttestation, type L2BlockSource } from '@aztec/stdlib/block';
+import { Checkpoint, type PublishedCheckpoint } from '@aztec/stdlib/checkpoint';
 import type { ContractDataSource } from '@aztec/stdlib/contract';
 import { EmptyL1RollupConstants } from '@aztec/stdlib/epoch-helpers';
 import {
@@ -18,7 +19,7 @@ import {
   type WorldStateSynchronizer,
 } from '@aztec/stdlib/interfaces/server';
 import type { L1ToL2MessageSource } from '@aztec/stdlib/messaging';
-import { type BlockHeader, type Tx, TxHash } from '@aztec/stdlib/tx';
+import { BlockHeader, type Tx, TxHash } from '@aztec/stdlib/tx';
 import { L1Metrics } from '@aztec/telemetry-client';
 
 import { type MockProxy, mock } from 'jest-mock-extended';
@@ -53,9 +54,9 @@ describe('prover-node', () => {
   // Subject under test
   let proverNode: TestProverNode;
 
-  // Blocks returned by the archiver
-  let blocks: L2Block[];
-  let lastBlock: PublishedL2Block;
+  // Checkpoints returned by the archiver
+  let checkpoints: Checkpoint[];
+  let lastPublishedCheckpoint: PublishedCheckpoint;
   let previousBlockHeader: BlockHeader;
 
   // Address of the publisher
@@ -130,36 +131,34 @@ describe('prover-node', () => {
     address = EthAddress.random();
     publisher.getSenderAddress.mockReturnValue(address);
 
-    // We create 3 fake blocks with 1 tx effect each
-    blocks = await timesParallel(3, async i => await L2Block.random(i + 20, 1));
-    previousBlockHeader = await L2Block.random(19).then(b => b.getBlockHeader());
-    lastBlock = { block: blocks.at(-1)!, attestations: [CommitteeAttestation.random()] } as PublishedL2Block;
-
-    // Archiver returns a bunch of fake blocks
-    l2BlockSource.getBlocks.mockImplementation((from, limit) => {
-      const startBlockIndex = blocks.findIndex(b => b.number === from);
-      if (startBlockIndex > -1) {
-        return Promise.resolve(blocks.slice(startBlockIndex, startBlockIndex + limit));
-      } else {
-        return Promise.resolve([]);
-      }
-    });
+    // We create 3 fake checkpoints with 1 block and 1 tx effect each
+    const startBlockNumber = 20;
+    checkpoints = await timesParallel(
+      3,
+      async i =>
+        await Checkpoint.random(CheckpointNumber(i + 1), { numBlocks: 1, startBlockNumber: startBlockNumber + i }),
+    );
+    previousBlockHeader = BlockHeader.random({ blockNumber: startBlockNumber - 1 });
+    lastPublishedCheckpoint = {
+      checkpoint: checkpoints.at(-1)!,
+      attestations: [CommitteeAttestation.random()],
+    } as PublishedCheckpoint;
 
     l1GenesisTime = Math.floor(Date.now() / 1000) - 3600;
     l2BlockSource.getL1Constants.mockResolvedValue({ ...EmptyL1RollupConstants, l1GenesisTime: BigInt(l1GenesisTime) });
-    l2BlockSource.getBlocksForEpoch.mockResolvedValue(blocks);
-    l2BlockSource.getPublishedBlocks.mockResolvedValue([lastBlock]);
+    l2BlockSource.getCheckpointsForEpoch.mockResolvedValue(checkpoints);
+    l2BlockSource.getPublishedCheckpoints.mockResolvedValue([lastPublishedCheckpoint]);
     l2BlockSource.getL2Tips.mockResolvedValue({
-      latest: { number: blocks.at(-1)!.number, hash: (await blocks.at(-1)!.hash()).toString() },
+      latest: { number: checkpoints.at(-1)!.number, hash: checkpoints.at(-1)!.hash().toString() },
       proven: { number: 0, hash: undefined },
       finalized: { number: 0, hash: undefined },
     });
     l2BlockSource.getBlockHeader.mockImplementation(number =>
-      Promise.resolve(number === blocks[0].number - 1 ? previousBlockHeader : undefined),
+      Promise.resolve(number === checkpoints[0].blocks[0].number - 1 ? previousBlockHeader : undefined),
     );
 
     // L1 to L2 message source returns no messages
-    l1ToL2MessageSource.getL1ToL2Messages.mockResolvedValue([]);
+    l1ToL2MessageSource.getL1ToL2MessagesForCheckpoint.mockResolvedValue([]);
 
     // Tx provider plays along and returns a tx whenever requested
     txProvider.getTxsForBlock.mockImplementation(block =>
@@ -191,8 +190,8 @@ describe('prover-node', () => {
     expect(publisherFactory.create).toHaveBeenCalledTimes(1);
   });
 
-  it('does not start a proof if there are no blocks in the epoch', async () => {
-    l2BlockSource.getBlocksForEpoch.mockResolvedValue([]);
+  it('does not start a proof if there are no checkpoints in the epoch', async () => {
+    l2BlockSource.getCheckpointsForEpoch.mockResolvedValue([]);
     await proverNode.handleEpochReadyToProve(EpochNumber.fromBigInt(10n));
     expect(proverNode.totalJobCount).toEqual(0);
   });

--- a/yarn-project/prover-node/src/prover-node.ts
+++ b/yarn-project/prover-node/src/prover-node.ts
@@ -1,6 +1,6 @@
 import type { Archiver } from '@aztec/archiver';
 import type { RollupContract } from '@aztec/ethereum';
-import { EpochNumber } from '@aztec/foundation/branded-types';
+import { CheckpointNumber, EpochNumber } from '@aztec/foundation/branded-types';
 import { assertRequired, compact, pick, sum } from '@aztec/foundation/collection';
 import { memoize } from '@aztec/foundation/decorators';
 import type { Fr } from '@aztec/foundation/fields';
@@ -9,7 +9,8 @@ import { DateProvider } from '@aztec/foundation/timer';
 import type { DataStoreConfig } from '@aztec/kv-store/config';
 import type { P2PClient } from '@aztec/p2p';
 import { PublicProcessorFactory } from '@aztec/simulator/server';
-import type { L2Block, L2BlockSource } from '@aztec/stdlib/block';
+import type { L2BlockSource } from '@aztec/stdlib/block';
+import type { Checkpoint } from '@aztec/stdlib/checkpoint';
 import type { ChainConfig } from '@aztec/stdlib/config';
 import type { ContractDataSource } from '@aztec/stdlib/contract';
 import { getProofSubmissionDeadlineTimestamp } from '@aztec/stdlib/epoch-helpers';
@@ -271,10 +272,13 @@ export class ProverNode implements EpochMonitorHandler, ProverNodeApi, Traceable
 
     // Gather all data for this epoch
     const epochData = await this.gatherEpochData(epochNumber);
-
-    const fromBlock = epochData.blocks[0].number;
-    const toBlock = epochData.blocks.at(-1)!.number;
-    this.log.verbose(`Creating proving job for epoch ${epochNumber} for block range ${fromBlock} to ${toBlock}`);
+    const fromCheckpoint = epochData.checkpoints[0].number;
+    const toCheckpoint = epochData.checkpoints.at(-1)!.number;
+    const fromBlock = epochData.checkpoints[0].blocks[0].number;
+    const toBlock = epochData.checkpoints.at(-1)!.blocks.at(-1)!.number;
+    this.log.verbose(
+      `Creating proving job for epoch ${epochNumber} for checkpoint range ${fromCheckpoint} to ${toCheckpoint} and block range ${fromBlock} to ${toBlock}`,
+    );
 
     // Fast forward world state to right before the target block and get a fork
     await this.worldState.syncImmediate(toBlock);
@@ -289,7 +293,6 @@ export class ProverNode implements EpochMonitorHandler, ProverNodeApi, Traceable
     // Set deadline for this job to run. It will abort if it takes too long.
     const deadlineTs = getProofSubmissionDeadlineTimestamp(epochNumber, await this.getL1Constants());
     const deadline = new Date(Number(deadlineTs) * 1000);
-
     const job = this.doCreateEpochProvingJob(epochData, deadline, publicProcessorFactory, this.publisher, opts);
     this.jobs.set(job.getId(), job);
     return job;
@@ -302,28 +305,30 @@ export class ProverNode implements EpochMonitorHandler, ProverNodeApi, Traceable
 
   @trackSpan('ProverNode.gatherEpochData', epochNumber => ({ [Attributes.EPOCH_NUMBER]: epochNumber }))
   private async gatherEpochData(epochNumber: EpochNumber): Promise<EpochProvingJobData> {
-    const blocks = await this.gatherBlocks(epochNumber);
-    const txArray = await this.gatherTxs(epochNumber, blocks);
+    const checkpoints = await this.gatherCheckpoints(epochNumber);
+    const txArray = await this.gatherTxs(epochNumber, checkpoints);
     const txs = new Map<string, Tx>(txArray.map(tx => [tx.getTxHash().toString(), tx]));
-    const l1ToL2Messages = await this.gatherMessages(epochNumber, blocks);
-    const previousBlockHeader = await this.gatherPreviousBlockHeader(epochNumber, blocks[0]);
-    const [lastBlock] = await this.l2BlockSource.getPublishedBlocks(blocks.at(-1)!.number, 1);
-    const attestations = lastBlock?.attestations ?? [];
+    const l1ToL2Messages = await this.gatherMessages(epochNumber, checkpoints);
+    const [firstBlock] = checkpoints[0].blocks;
+    const previousBlockHeader = await this.gatherPreviousBlockHeader(epochNumber, firstBlock.number - 1);
+    const [lastPublishedCheckpoint] = await this.l2BlockSource.getPublishedCheckpoints(checkpoints.at(-1)!.number, 1);
+    const attestations = lastPublishedCheckpoint?.attestations ?? [];
 
-    return { blocks, txs, l1ToL2Messages, epochNumber, previousBlockHeader, attestations };
+    return { checkpoints, txs, l1ToL2Messages, epochNumber, previousBlockHeader, attestations };
   }
 
-  private async gatherBlocks(epochNumber: EpochNumber) {
-    const blocks = await this.l2BlockSource.getBlocksForEpoch(epochNumber);
-    if (blocks.length === 0) {
+  private async gatherCheckpoints(epochNumber: EpochNumber) {
+    const checkpoints = await this.l2BlockSource.getCheckpointsForEpoch(epochNumber);
+    if (checkpoints.length === 0) {
       throw new EmptyEpochError(epochNumber);
     }
-    return blocks;
+    return checkpoints;
   }
 
-  private async gatherTxs(epochNumber: EpochNumber, blocks: L2Block[]) {
+  private async gatherTxs(epochNumber: EpochNumber, checkpoints: Checkpoint[]) {
     const deadline = new Date(this.dateProvider.now() + this.config.txGatheringTimeoutMs);
     const txProvider = this.p2pClient.getTxProvider();
+    const blocks = checkpoints.flatMap(checkpoint => checkpoint.blocks);
     const txsByBlock = await Promise.all(blocks.map(block => txProvider.getTxsForBlock(block, { deadline })));
     const txs = txsByBlock.map(({ txs }) => txs).flat();
     const missingTxs = txsByBlock.map(({ missingTxs }) => missingTxs).flat();
@@ -336,25 +341,26 @@ export class ProverNode implements EpochMonitorHandler, ProverNodeApi, Traceable
     throw new Error(`Txs not found for epoch ${epochNumber}: ${missingTxs.map(hash => hash.toString()).join(', ')}`);
   }
 
-  private async gatherMessages(epochNumber: EpochNumber, blocks: L2Block[]) {
-    const messages = await Promise.all(blocks.map(b => this.l1ToL2MessageSource.getL1ToL2Messages(b.number)));
+  private async gatherMessages(epochNumber: EpochNumber, checkpoints: Checkpoint[]) {
+    const messages = await Promise.all(
+      checkpoints.map(c => this.l1ToL2MessageSource.getL1ToL2MessagesForCheckpoint(c.number)),
+    );
     const messageCount = sum(messages.map(m => m.length));
     this.log.verbose(`Gathered all ${messageCount} messages for epoch ${epochNumber}`, { epochNumber });
-    const messagesByBlock: Record<number, Fr[]> = {};
-    for (let i = 0; i < blocks.length; i++) {
-      messagesByBlock[blocks[i].number] = messages[i];
+    const messagesByCheckpoint: Record<CheckpointNumber, Fr[]> = {};
+    for (let i = 0; i < checkpoints.length; i++) {
+      messagesByCheckpoint[checkpoints[i].number] = messages[i];
     }
-    return messagesByBlock;
+    return messagesByCheckpoint;
   }
 
-  private async gatherPreviousBlockHeader(epochNumber: EpochNumber, initialBlock: L2Block) {
-    const previousBlockNumber = initialBlock.number - 1;
+  private async gatherPreviousBlockHeader(epochNumber: EpochNumber, previousBlockNumber: number) {
     const header = await (previousBlockNumber === 0
       ? this.worldState.getCommitted().getInitialHeader()
       : this.l2BlockSource.getBlockHeader(previousBlockNumber));
 
     if (!header) {
-      throw new Error(`Previous block header ${initialBlock.number} not found for proving epoch ${epochNumber}`);
+      throw new Error(`Previous block header ${previousBlockNumber} not found for proving epoch ${epochNumber}`);
     }
 
     this.log.verbose(`Gathered previous block header ${header.getBlockNumber()} for epoch ${epochNumber}`);

--- a/yarn-project/stdlib/src/block/l2_block_source.ts
+++ b/yarn-project/stdlib/src/block/l2_block_source.ts
@@ -5,6 +5,8 @@ import type { TypedEventEmitter } from '@aztec/foundation/types';
 
 import { z } from 'zod';
 
+import type { Checkpoint } from '../checkpoint/checkpoint.js';
+import type { PublishedCheckpoint } from '../checkpoint/published_checkpoint.js';
 import type { L1RollupConstants } from '../epoch-helpers/index.js';
 import type { BlockHeader } from '../tx/block_header.js';
 import type { IndexedTxEffect } from '../tx/indexed_tx_effect.js';
@@ -65,6 +67,8 @@ export interface L2BlockSource {
    */
   getBlocks(from: number, limit: number, proven?: boolean): Promise<L2Block[]>;
 
+  getPublishedCheckpoints(from: number, limit: number): Promise<PublishedCheckpoint[]>;
+
   /** Equivalent to getBlocks but includes publish data. */
   getPublishedBlocks(from: number, limit: number, proven?: boolean): Promise<PublishedL2Block[]>;
 
@@ -119,6 +123,13 @@ export interface L2BlockSource {
    * Returns the current L2 epoch number based on the currently synced L1 timestamp.
    */
   getL2EpochNumber(): Promise<EpochNumber | undefined>;
+
+  /**
+   * Returns all checkpoints for a given epoch.
+   * @dev Use this method only with recent epochs, since it walks the checkpoint list backwards.
+   * @param epochNumber - The epoch number to return checkpoints for.
+   */
+  getCheckpointsForEpoch(epochNumber: EpochNumber): Promise<Checkpoint[]>;
 
   /**
    * Returns all blocks for a given epoch.

--- a/yarn-project/stdlib/src/interfaces/archiver.test.ts
+++ b/yarn-project/stdlib/src/interfaces/archiver.test.ts
@@ -1,4 +1,4 @@
-import { EpochNumber, SlotNumber } from '@aztec/foundation/branded-types';
+import { CheckpointNumber, EpochNumber, SlotNumber } from '@aztec/foundation/branded-types';
 import { randomInt } from '@aztec/foundation/crypto';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { Fr } from '@aztec/foundation/fields';
@@ -14,6 +14,8 @@ import { L2Block } from '../block/l2_block.js';
 import type { L2Tips } from '../block/l2_block_source.js';
 import { PublishedL2Block } from '../block/published_l2_block.js';
 import type { ValidateBlockResult } from '../block/validate_block_result.js';
+import { Checkpoint } from '../checkpoint/checkpoint.js';
+import { PublishedCheckpoint } from '../checkpoint/published_checkpoint.js';
 import { getContractClassFromArtifact } from '../contract/contract_class.js';
 import {
   type ContractClassPublic,
@@ -107,6 +109,14 @@ describe('ArchiverApiSchema', () => {
     expect(result).toEqual([expect.any(L2Block)]);
   });
 
+  it('getPublishedCheckpoints', async () => {
+    const response = await context.client.getPublishedCheckpoints(1, 1);
+    expect(response).toHaveLength(1);
+    expect(response[0].checkpoint.constructor.name).toEqual('Checkpoint');
+    expect(response[0].attestations[0]).toBeInstanceOf(CommitteeAttestation);
+    expect(response[0].l1).toBeDefined();
+  });
+
   it('getPublishedBlocks', async () => {
     const response = await context.client.getPublishedBlocks(1, 1);
     expect(response).toHaveLength(1);
@@ -149,6 +159,11 @@ describe('ArchiverApiSchema', () => {
   it('getL2EpochNumber', async () => {
     const result = await context.client.getL2EpochNumber();
     expect(result).toBe(EpochNumber(1));
+  });
+
+  it('getCheckpointsForEpoch', async () => {
+    const result = await context.client.getCheckpointsForEpoch(EpochNumber(1));
+    expect(result).toEqual([expect.any(Checkpoint)]);
   });
 
   it('getBlocksForEpoch', async () => {
@@ -228,6 +243,11 @@ describe('ArchiverApiSchema', () => {
 
   it('getContractClassIds', async () => {
     const result = await context.client.getContractClassIds();
+    expect(result).toEqual([expect.any(Fr)]);
+  });
+
+  it('getL1ToL2MessagesForCheckpoint', async () => {
+    const result = await context.client.getL1ToL2MessagesForCheckpoint(CheckpointNumber(1));
     expect(result).toEqual([expect.any(Fr)]);
   });
 
@@ -326,6 +346,15 @@ class MockArchiver implements ArchiverApi {
   async getBlocks(from: number, _limit: number, _proven?: boolean): Promise<L2Block[]> {
     return [await L2Block.random(from)];
   }
+  async getPublishedCheckpoints(from: number, _limit: number): Promise<PublishedCheckpoint[]> {
+    return [
+      PublishedCheckpoint.from({
+        checkpoint: await Checkpoint.random(CheckpointNumber(from)),
+        attestations: [CommitteeAttestation.random()],
+        l1: { blockHash: `0x`, blockNumber: 1n, timestamp: 0n },
+      }),
+    ];
+  }
   async getPublishedBlocks(from: number, _limit: number, _proven?: boolean): Promise<PublishedL2Block[]> {
     return [
       PublishedL2Block.fromFields({
@@ -373,6 +402,10 @@ class MockArchiver implements ArchiverApi {
   }
   getL2EpochNumber(): Promise<EpochNumber | undefined> {
     return Promise.resolve(EpochNumber(1));
+  }
+  async getCheckpointsForEpoch(epochNumber: EpochNumber): Promise<Checkpoint[]> {
+    expect(epochNumber).toEqual(EpochNumber(1));
+    return [await Checkpoint.random(CheckpointNumber(1))];
   }
   async getBlocksForEpoch(epochNumber: EpochNumber): Promise<L2Block[]> {
     expect(epochNumber).toEqual(EpochNumber(1));
@@ -459,6 +492,10 @@ class MockArchiver implements ArchiverApi {
   registerContractFunctionSignatures(signatures: string[]): Promise<void> {
     expect(Array.isArray(signatures)).toBe(true);
     return Promise.resolve();
+  }
+  getL1ToL2MessagesForCheckpoint(checkpointNumber: CheckpointNumber): Promise<Fr[]> {
+    expect(checkpointNumber).toEqual(CheckpointNumber(1));
+    return Promise.resolve([Fr.random()]);
   }
   getL1ToL2Messages(blockNumber: number): Promise<Fr[]> {
     expect(blockNumber).toEqual(1);

--- a/yarn-project/stdlib/src/interfaces/archiver.ts
+++ b/yarn-project/stdlib/src/interfaces/archiver.ts
@@ -1,5 +1,5 @@
 import type { L1ContractAddresses } from '@aztec/ethereum';
-import { EpochNumberSchema } from '@aztec/foundation/branded-types';
+import { CheckpointNumberSchema, EpochNumberSchema } from '@aztec/foundation/branded-types';
 import type { ApiSchemaFor } from '@aztec/foundation/schemas';
 
 import { z } from 'zod';
@@ -8,6 +8,8 @@ import { L2Block } from '../block/l2_block.js';
 import { type L2BlockSource, L2TipsSchema } from '../block/l2_block_source.js';
 import { PublishedL2Block } from '../block/published_l2_block.js';
 import { ValidateBlockResultSchema } from '../block/validate_block_result.js';
+import { Checkpoint } from '../checkpoint/checkpoint.js';
+import { PublishedCheckpoint } from '../checkpoint/published_checkpoint.js';
 import {
   ContractClassPublicSchema,
   type ContractDataSource,
@@ -84,6 +86,10 @@ export const ArchiverApiSchema: ApiSchemaFor<ArchiverApi> = {
     .function()
     .args(schemas.Integer, schemas.Integer, optional(z.boolean()))
     .returns(z.array(L2Block.schema)),
+  getPublishedCheckpoints: z
+    .function()
+    .args(schemas.Integer, schemas.Integer)
+    .returns(z.array(PublishedCheckpoint.schema)),
   getPublishedBlocks: z
     .function()
     .args(schemas.Integer, schemas.Integer, optional(z.boolean()))
@@ -96,6 +102,7 @@ export const ArchiverApiSchema: ApiSchemaFor<ArchiverApi> = {
   getSettledTxReceipt: z.function().args(TxHash.schema).returns(TxReceipt.schema.optional()),
   getL2SlotNumber: z.function().args().returns(schemas.SlotNumber.optional()),
   getL2EpochNumber: z.function().args().returns(EpochNumberSchema.optional()),
+  getCheckpointsForEpoch: z.function().args(EpochNumberSchema).returns(z.array(Checkpoint.schema)),
   getBlocksForEpoch: z.function().args(EpochNumberSchema).returns(z.array(L2Block.schema)),
   getBlockHeadersForEpoch: z.function().args(EpochNumberSchema).returns(z.array(BlockHeader.schema)),
   isEpochComplete: z.function().args(EpochNumberSchema).returns(z.boolean()),
@@ -115,6 +122,7 @@ export const ArchiverApiSchema: ApiSchemaFor<ArchiverApi> = {
     .returns(ContractInstanceWithAddressSchema.optional()),
   getContractClassIds: z.function().args().returns(z.array(schemas.Fr)),
   registerContractFunctionSignatures: z.function().args(z.array(z.string())).returns(z.void()),
+  getL1ToL2MessagesForCheckpoint: z.function().args(CheckpointNumberSchema).returns(z.array(schemas.Fr)),
   getL1ToL2Messages: z.function().args(schemas.Integer).returns(z.array(schemas.Fr)),
   getL1ToL2MessageIndex: z.function().args(schemas.Fr).returns(schemas.BigInt.optional()),
   getDebugFunctionName: z.function().args(schemas.AztecAddress, schemas.FunctionSelector).returns(optional(z.string())),

--- a/yarn-project/stdlib/src/interfaces/tx_provider.ts
+++ b/yarn-project/stdlib/src/interfaces/tx_provider.ts
@@ -1,4 +1,4 @@
-import type { L2Block } from '@aztec/stdlib/block';
+import type { L2BlockNew } from '@aztec/stdlib/block';
 import type { BlockProposal } from '@aztec/stdlib/p2p';
 import { type Tx, TxHash } from '@aztec/stdlib/tx';
 
@@ -13,5 +13,5 @@ export interface ITxProvider {
     opts: { pinnedPeer: PeerId | undefined; deadline: Date },
   ): Promise<{ txs: Tx[]; missingTxs: TxHash[] }>;
 
-  getTxsForBlock(block: L2Block, opts: { deadline: Date }): Promise<{ txs: Tx[]; missingTxs: TxHash[] }>;
+  getTxsForBlock(block: L2BlockNew, opts: { deadline: Date }): Promise<{ txs: Tx[]; missingTxs: TxHash[] }>;
 }

--- a/yarn-project/stdlib/src/messaging/l1_to_l2_message_source.ts
+++ b/yarn-project/stdlib/src/messaging/l1_to_l2_message_source.ts
@@ -1,3 +1,4 @@
+import type { CheckpointNumber } from '@aztec/foundation/branded-types';
 import type { Fr } from '@aztec/foundation/fields';
 
 import type { L2Tips } from '../block/l2_block_source.js';
@@ -6,6 +7,13 @@ import type { L2Tips } from '../block/l2_block_source.js';
  * Interface of classes allowing for the retrieval of L1 to L2 messages.
  */
 export interface L1ToL2MessageSource {
+  /**
+   * Gets new L1 to L2 message (to be) included in a given checkpoint.
+   * @param checkpointNumber - Checkpoint number to get messages for.
+   * @returns The L1 to L2 messages/leaves of the messages subtree (throws if not found).
+   */
+  getL1ToL2MessagesForCheckpoint(checkpointNumber: CheckpointNumber): Promise<Fr[]>;
+
   /**
    * Gets new L1 to L2 message (to be) included in a given block.
    * @param blockNumber - L2 block number to get messages for.

--- a/yarn-project/telemetry-client/src/metrics.ts
+++ b/yarn-project/telemetry-client/src/metrics.ts
@@ -192,6 +192,7 @@ export const PROVING_AGENT_IDLE = 'aztec.proving_queue.agent.idle';
 
 export const PROVER_NODE_EXECUTION_DURATION = 'aztec.prover_node.execution.duration';
 export const PROVER_NODE_JOB_DURATION = 'aztec.prover_node.job_duration';
+export const PROVER_NODE_JOB_CHECKPOINTS = 'aztec.prover_node.job_checkpoints';
 export const PROVER_NODE_JOB_BLOCKS = 'aztec.prover_node.job_blocks';
 export const PROVER_NODE_JOB_TRANSACTIONS = 'aztec.prover_node.job_transactions';
 export const PROVER_NODE_REWARDS_TOTAL = 'aztec.prover_node.rewards_total';

--- a/yarn-project/txe/src/state_machine/archiver.ts
+++ b/yarn-project/txe/src/state_machine/archiver.ts
@@ -1,11 +1,12 @@
 import { ArchiverStoreHelper, KVArchiverDataStore, type PublishedL2Block } from '@aztec/archiver';
 import { GENESIS_ARCHIVE_ROOT } from '@aztec/constants';
-import { EpochNumber, SlotNumber } from '@aztec/foundation/branded-types';
+import { CheckpointNumber, EpochNumber, SlotNumber } from '@aztec/foundation/branded-types';
 import type { EthAddress } from '@aztec/foundation/eth-address';
 import { Fr } from '@aztec/foundation/fields';
 import type { AztecAsyncKVStore } from '@aztec/kv-store';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
 import type { L2Block, L2BlockSource, L2Tips, ValidateBlockResult } from '@aztec/stdlib/block';
+import type { Checkpoint, PublishedCheckpoint } from '@aztec/stdlib/checkpoint';
 import type { ContractInstanceWithAddress } from '@aztec/stdlib/contract';
 import type { L1RollupConstants } from '@aztec/stdlib/epoch-helpers';
 import type { BlockHeader } from '@aztec/stdlib/tx';
@@ -90,6 +91,10 @@ export class TXEArchiver extends ArchiverStoreHelper implements L2BlockSource {
     return this.getPublishedBlocks(from, limit).then(blocks => blocks.map(b => b.block));
   }
 
+  public getPublishedCheckpoints(_from: CheckpointNumber, _limit: number): Promise<PublishedCheckpoint[]> {
+    throw new Error('TXE Archiver does not implement "getPublishedCheckpoints"');
+  }
+
   public getL2SlotNumber(): Promise<SlotNumber | undefined> {
     throw new Error('TXE Archiver does not implement "getL2SlotNumber"');
   }
@@ -98,12 +103,20 @@ export class TXEArchiver extends ArchiverStoreHelper implements L2BlockSource {
     throw new Error('TXE Archiver does not implement "getL2EpochNumber"');
   }
 
+  public getCheckpointsForEpoch(_epochNumber: EpochNumber): Promise<Checkpoint[]> {
+    throw new Error('TXE Archiver does not implement "getCheckpointsForEpoch"');
+  }
+
   public getBlocksForEpoch(_epochNumber: EpochNumber): Promise<L2Block[]> {
     throw new Error('TXE Archiver does not implement "getBlocksForEpoch"');
   }
 
   public getBlockHeadersForEpoch(_epochNumber: EpochNumber): Promise<BlockHeader[]> {
     throw new Error('TXE Archiver does not implement "getBlockHeadersForEpoch"');
+  }
+
+  public getL1ToL2MessagesForCheckpoint(_checkpointNumber: CheckpointNumber): Promise<Fr[]> {
+    throw new Error('TXE Archiver does not implement "getL1ToL2MessagesForCheckpoint"');
   }
 
   public isEpochComplete(_epochNumber: EpochNumber): Promise<boolean> {


### PR DESCRIPTION
Prover node can now prepare data for proving multiple blocks per checkpoint. 
However, the archiver/block source apis it uses currently return one block per checkpoint.