### PR TITLE
refactor!: new state var traits + Owned

### DIFF
--- a/boxes/boxes/react/src/contracts/src/main.nr
+++ b/boxes/boxes/react/src/contracts/src/main.nr
@@ -6,13 +6,13 @@ contract BoxReact {
         macros::{functions::{external, initializer}, storage::storage},
         messages::message_delivery::MessageDelivery,
         protocol_types::address::AztecAddress,
-        state_vars::PrivateMutable,
+        state_vars::{Owned, PrivateMutable},
     };
     use value_note::value_note::ValueNote;
 
     #[storage]
     struct Storage<Context> {
-        numbers: PrivateMutable<ValueNote, Context>,
+        numbers: Owned<PrivateMutable<ValueNote, Context>, Context>,
     }
 
     #[external("private")]

--- a/boxes/boxes/vite/src/contracts/src/main.nr
+++ b/boxes/boxes/vite/src/contracts/src/main.nr
@@ -6,13 +6,13 @@ contract BoxReact {
         macros::{functions::{external, initializer}, storage::storage},
         messages::message_delivery::MessageDelivery,
         protocol_types::address::AztecAddress,
-        state_vars::PrivateMutable,
+        state_vars::{Owned, PrivateMutable},
     };
     use value_note::value_note::ValueNote;
 
     #[storage]
     struct Storage<Context> {
-        numbers: PrivateMutable<ValueNote, Context>,
+        numbers: Owned<PrivateMutable<ValueNote, Context>, Context>,
     }
 
     #[external("private")]

--- a/docs/docs/developers/docs/resources/migration_notes.md
+++ b/docs/docs/developers/docs/resources/migration_notes.md
@@ -90,18 +90,25 @@ where
 ```
 
 `PrivateImmutable`, `PrivateMutable` and `PrivateSet` got modified to directly contain the owner instead of implicitly "containing it" by including it in the storage slot via a `Map`.
-Now the `Map` is redundant and the relevant state variable should be moved out of it:
+These state variables now implement a newly introduced `OwnedStateVariable` trait (see docs of `OwnedStateVariable` for explanation of what it is).
+These changes make the state variables incompatible with `Map` and now instead these should be wrapped in new `Owned` state variable:
 
 ```diff
 #[storage]
 struct Storage<Context> {
 -    private_nfts: Map<AztecAddress, PrivateSet<NFTNote, Context>, Context>,
-+    private_nfts: PrivateSet<NFTNote, Context>,
++    private_nfts: Owned<PrivateSet<NFTNote, Context>, Context>,
 }
 ```
 
-Now we have an `at` method on the private state variables that scopes it to a given owner.
-Given that we used to call `at` on the map and now we call it directly on the set if you so the above change it should not be required of you to do any further changes in your contract.
+Note that even though the types of your state variables are changing from `Map<AztecAddress, T, Context>` to `Owned<T, Context>`, usage remains unchanged:
+
+```
+let nft_notes = self.storage.private_nfts.at(from).pop_notes(NoteGetterOptions::new().select(NFTNote::properties().token_id, Comparator.EQ, token_id).set_limit(1));
+```
+
+With this change the underlying notes will inherit the storage slot of the `Owned` state variable.
+This is unlike `Map` where the nested state variable got the storage slot computed as `hash([map_storage_slot, key])`.
 
 if you had `PrivateImmutable` or `PrivateMutable` defined out of a `Map`, e.g.:
 
@@ -113,12 +120,23 @@ struct Storage<Context> {
 ```
 
 you were most likely dealing with some kind of admin flow where only the admin can modify the state variable.
-Now, unfortunately, there is a bit of a regression and you will need to call `at` on the state var:
+Now, unfortunately, there is a bit of a regression and you will need to wrap the state variable in `Owned` and call `at` on the state var:
 
 ```diff
-- self.storage.signing_public_key.initialize(pub_key_note)
-+ self.storage.signing_public_key.at(self.address).initialize(pub_key_note)
-    .emit(self.address, MessageDelivery.CONSTRAINED_ONCHAIN);
++ use aztec::state_vars::Owned;
+
+#[storage]
+struct Storage<Context> {
+-   signing_public_key: PrivateImmutable<PublicKeyNote, Context>,
++   signing_public_key: Owned<PrivateImmutable<PublicKeyNote, Context>, Context>,
+}
+
+#[external("private")]
+fn my_external_function() {
+-   self.storage.signing_public_key.initialize(pub_key_note)
++   self.storage.signing_public_key.at(self.address).initialize(pub_key_note)
+        .emit(self.address, MessageDelivery.CONSTRAINED_ONCHAIN);
+}
 ```
 
 We are likely to come up with a concept of admin state variables in the future.

--- a/noir-projects/aztec-nr/aztec/src/macros/storage.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/storage.nr
@@ -2,17 +2,19 @@ use poseidon::poseidon2::Poseidon2Hasher;
 use std::{collections::umap::UHashMap, hash::BuildHasherDefault};
 
 use super::utils::AsStrQuote;
-use super::utils::get_storage_size;
 
 /// Stores a map from a module to the name of the struct that describes its storage layout.
 /// This is then used when generating a `storage_layout()` getter on the contract struct.
 pub comptime mut global STORAGE_LAYOUT_NAME: UHashMap<Module, Quoted, BuildHasherDefault<Poseidon2Hasher>> =
     UHashMap::default();
 
-/// Marks a struct as the one describing the storage layout of a contract.
-///
-/// The contract's storage is accessed via the `storage` variable, which will will automatically be made available in
-/// all functions as an instance of the struct this macro was applied to.
+/// This function
+/// - marks the contract as having storage, so that `macros::utils::module_has_storage` will return true,
+/// - marks the struct `s` as the one describing the storage layout of a contract,
+/// - generates an `impl` block for the storage struct with an `init` function (call to `init` is then injected at the
+///   beginning of every `#[external(...)]` and `#[internal]` contract function and the storage is then available as
+///   `self.storage`),
+/// - creates a `StorageLayout` struct that is is exposed via the `abi(storage)` macro in the contract artifact.
 ///
 /// Only a single struct in the entire contract should have this macro (or `storage_no_init`) applied to it, and the
 /// struct has to be called 'Storage'.
@@ -29,56 +31,59 @@ pub comptime fn storage(s: TypeDefinition) -> Quoted {
         f"Only one of #[storage] and #[storage_no_init] can be applied to the Storage struct.",
     );
 
-    // This macro performs three things:
-    //  - it marks the contract as having storage, so that `macros::utils::module_has_storage` will return true and
-    //    functions will have the storage variable injected and initialized via the `init` function.
-    //  - it implements said `init` function by allocating appropriate storage slots to each state variable.
-    //  - it exposes the storage layout by creating a `StorageLayout` struct that is exposed via the `abi(storage)`
-    //    macro.
     let mut slot: u32 = 1;
     let mut storage_vars_constructors = &[];
-    let mut storage_layout_fields = &[];
+    let mut storage_layout_struct_members = &[];
     let mut storage_layout_constructors = &[];
 
-    // TODO(#8658): uncomment the code below to inject the Context type parameter.
-    //let mut new_storage_fields = &[];
-    //let context_generic = s.add_generic("Context");
-    for field in s.fields_as_written() {
-        // FIXME: This doesn't handle field types with generics
-        let (name, typ, _) = field;
-        let slot_field = slot as Field;
-        let (storage_field_constructor, storage_size) =
-            generate_storage_field_constructor(typ, quote { $slot_field });
-        storage_vars_constructors =
-            storage_vars_constructors.push_back(quote { $name: $storage_field_constructor });
+    for storage_struct_member in s.fields_as_written() {
+        let (name, typ, _) = storage_struct_member;
+
+        let maybe_storage_size = std::meta::typ::fresh_type_variable();
+        let _maybe_context = std::meta::typ::fresh_type_variable();
+
+        if !typ.implements(
+            quote { crate::state_vars::state_variable::StateVariable<$maybe_storage_size, $_maybe_context> }
+                .as_trait_constraint(),
+        ) {
+            let _maybe_owned_context = std::meta::typ::fresh_type_variable();
+            if typ.implements(
+                quote { crate::state_vars::owned_state_variable::OwnedStateVariable<$_maybe_owned_context> }
+                    .as_trait_constraint(),
+            ) {
+                panic(
+                    f"Type {typ} implements OwnedStateVariable and hence cannot be placed in Storage struct without being wrapped in Owned. Define the type in storage as Owned<{typ}<..., Context>>, Context>.",
+                )
+            }
+
+            panic(
+                f"Type {typ} does not implement StateVariable and hence cannot be placed in Storage struct.",
+            )
+        }
+
+        let storage_size = maybe_storage_size.as_constant().unwrap();
+        let slot_as_field = slot as Field;
+
+        storage_vars_constructors = storage_vars_constructors.push_back(
+            quote { $name: aztec::state_vars::state_variable::StateVariable::<$storage_size, Context>::new(context, $slot_as_field) },
+        );
+
         // We have `Storable` in a separate `.nr` file instead of defining it in the last quote of this function
         // because that way a dev gets a more reasonable error if he defines a struct with the same name in
         // a contract.
-        storage_layout_fields = storage_layout_fields.push_back(
-            quote { pub $name: dep::aztec::state_vars::storage::Storable },
+        storage_layout_struct_members = storage_layout_struct_members.push_back(
+            quote { pub $name: aztec::state_vars::storage::Storable },
         );
         storage_layout_constructors = storage_layout_constructors.push_back(
-            quote { $name: dep::aztec::state_vars::storage::Storable { slot: $slot_field } },
+            quote { $name: aztec::state_vars::storage::Storable { slot: $slot_as_field } },
         );
-        //let with_context_generic = add_context_generic(typ, context_generic);
-        //println(with_context_generic);
-        //new_storage_fields = new_storage_fields.push_back((name,  with_context_generic ));
+
         slot += storage_size;
     }
 
-    //s.set_fields(new_storage_fields);
     let storage_vars_constructors = storage_vars_constructors.join(quote {,});
-    let storage_impl = quote {
-        impl<Context> Storage<Context> {
-            fn init(context: Context) -> Self {
-                Self {
-                    $storage_vars_constructors
-                }
-            }
-        }
-    };
 
-    let storage_layout_fields = storage_layout_fields.join(quote {,});
+    let storage_layout_struct_members = storage_layout_struct_members.join(quote {,});
     let storage_layout_constructors = storage_layout_constructors.join(quote {,});
 
     let module = s.module();
@@ -88,10 +93,16 @@ pub comptime fn storage(s: TypeDefinition) -> Quoted {
     STORAGE_LAYOUT_NAME.insert(module, storage_layout_name);
 
     quote {
-        $storage_impl
+        impl<Context> Storage<Context> {
+            fn init(context: Context) -> Self {
+                Self {
+                    $storage_vars_constructors
+                }
+            }
+        }
 
         pub struct StorageLayoutFields {
-            $storage_layout_fields
+            $storage_layout_struct_members
         }
 
         pub struct StorageLayout<let N: u32> {
@@ -134,63 +145,4 @@ pub comptime fn storage_no_init(s: TypeDefinition) {
         !s.has_named_attribute("storage"),
         f"Only one of #[storage] and #[storage_no_init] can be applied to the Storage struct.",
     );
-}
-
-/// Returns the expression required to initialize a state variable with a given slot, along with its serialization size,
-/// i.e. how many contiguous storage slots the variable requires.
-comptime fn generate_storage_field_constructor(typ: Type, slot: Quoted) -> (Quoted, u32) {
-    assert(
-        typ.as_data_type().is_some(),
-        "Storage containers must be generic structs of the form `Container<_, Context>`, or Map<Key, _, Context>",
-    );
-    let (container_struct, generics) = typ.as_data_type().unwrap();
-    let struct_name = container_struct.name();
-
-    let constructor = if is_storage_map(typ) {
-        // Map state variables recursively initialize their contents - this includes nested maps.
-        let (value_constructor, _) =
-            generate_storage_field_constructor(generics[1], quote { slot });
-
-        quote { $struct_name::new(context, $slot, | context, slot | { $value_constructor }) }
-    } else {
-        // We assume below that all state variables implement `fn new<Context>(context: Context, slot: Field) -> Self`.
-        quote { $struct_name::new(context, $slot)}
-    };
-
-    (constructor, get_storage_size(typ))
-}
-
-/// Returns true if `typ` is `state_vars::map::Map`.
-comptime fn is_storage_map(typ: Type) -> bool {
-    if typ.as_data_type().is_some() {
-        let (def, generics) = typ.as_data_type().unwrap();
-        let maybe_map = if (def.name() == quote { Map }) & (generics.len() == 3) {
-            let maybe_key = generics[0];
-            let maybe_value = generics[1];
-            let maybe_context = generics[2];
-            quote { crate::state_vars::map::Map<$maybe_key, $maybe_value, $maybe_context> }.as_type()
-        } else {
-            quote {()}.as_type()
-        };
-        typ == maybe_map
-    } else {
-        false
-    }
-}
-
-comptime fn add_context_generic(typ: Type, context_generic: Type) -> Type {
-    let (def, mut generics) = typ.as_data_type().expect(
-        f"Storage containers must be generic structs of the form `Container<..., Context>`",
-    );
-    let name = def.name();
-
-    if is_storage_map(typ) {
-        generics[generics.len() - 2] = add_context_generic(generics[1], context_generic);
-        generics[generics.len() - 1] = context_generic;
-    } else {
-        generics[generics.len() - 1] = context_generic;
-    }
-
-    let generics = generics.map(|typ: Type| quote {$typ}).join(quote {,});
-    quote { $name<$generics> }.as_type()
 }

--- a/noir-projects/aztec-nr/aztec/src/macros/utils.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/utils.nr
@@ -164,21 +164,6 @@ pub(crate) comptime fn compute_struct_selector(
     unquote!(computation_quote)
 }
 
-/// Returns how many storage slots a type needs to reserve for itself. State variables must implement the Storage trait
-/// for slots to be allocated for them.
-pub(crate) comptime fn get_storage_size(typ: Type) -> u32 {
-    // We create a type variable for the storage size. We can't simply read the value used in the implementation because
-    // it may not be a constant (e.g. N + 1). We then bind it to the implementation of the Storage trait.
-    let storage_size = std::meta::typ::fresh_type_variable();
-    assert(
-        typ.implements(quote { crate::state_vars::HasStorageSlot<$storage_size> }
-            .as_trait_constraint()),
-        f"Attempted to fetch storage size, but {typ} does not implement the HasStorageSlot trait",
-    );
-
-    storage_size.as_constant().unwrap()
-}
-
 pub(crate) comptime fn module_has_storage(m: Module) -> bool {
     m.structs().any(|s: TypeDefinition| {
         s.has_named_attribute("storage") | s.has_named_attribute("storage_no_init")

--- a/noir-projects/aztec-nr/aztec/src/state_vars/delayed_public_mutable.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/delayed_public_mutable.nr
@@ -10,7 +10,7 @@ use dep::protocol_types::{
 
 use crate::{
     context::{PrivateContext, PublicContext, UtilityContext},
-    state_vars::storage::HasStorageSlot,
+    state_vars::state_variable::StateVariable,
     utils::with_hash::WithHash,
 };
 
@@ -19,17 +19,6 @@ mod test;
 pub struct DelayedPublicMutable<T, let InitialDelay: u64, Context> {
     context: Context,
     storage_slot: Field,
-}
-
-// This will make the Aztec macros require that T implements the Packable and Eq traits, and allocate `M + 1` storage
-// slots to this state variable.
-impl<T, let InitialDelay: u64, Context, let M: u32> HasStorageSlot<M + 1> for DelayedPublicMutable<T, InitialDelay, Context>
-where
-    DelayedPublicMutableValues<T, InitialDelay>: Packable<N = M>,
-{
-    fn get_storage_slot(self) -> Field {
-        self.storage_slot
-    }
 }
 
 // DelayedPublicMutable<T> stores a value of type T that is:
@@ -43,10 +32,20 @@ where
 // too far into the future, so that they can guarantee the value will not have possibly changed by then (because of the
 // delay). The delay for changing a value is initially equal to InitialDelay, but can be changed by calling
 // `schedule_delay_change`.
-impl<T, let InitialDelay: u64, Context> DelayedPublicMutable<T, InitialDelay, Context> {
-    pub fn new(context: Context, storage_slot: Field) -> Self {
+//
+// This implementation requires that T implements the Packable and Eq traits, and allocates `M + 1` storage slots to
+// this state variable.
+impl<T, let InitialDelay: u64, Context, let M: u32> StateVariable<M + 1, Context> for DelayedPublicMutable<T, InitialDelay, Context>
+where
+    DelayedPublicMutableValues<T, InitialDelay>: Packable<N = M>,
+{
+    fn new(context: Context, storage_slot: Field) -> Self {
         assert(storage_slot != 0, "Storage slot 0 not allowed. Storage slots must start from 1.");
         Self { context, storage_slot }
+    }
+
+    fn get_storage_slot(self) -> Field {
+        self.storage_slot
     }
 }
 

--- a/noir-projects/aztec-nr/aztec/src/state_vars/delayed_public_mutable/test.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/delayed_public_mutable/test.nr
@@ -1,6 +1,6 @@
 use crate::{
     context::{PrivateContext, PublicContext, UtilityContext},
-    state_vars::delayed_public_mutable::DelayedPublicMutable,
+    state_vars::{delayed_public_mutable::DelayedPublicMutable, state_variable::StateVariable},
     test::{helpers::test_environment::TestEnvironment, mocks::mock_struct::MockStruct},
 };
 use protocol_types::traits::Empty;

--- a/noir-projects/aztec-nr/aztec/src/state_vars/map.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/map.nr
@@ -1,4 +1,4 @@
-use crate::state_vars::storage::HasStorageSlot;
+use crate::state_vars::state_variable::StateVariable;
 use dep::protocol_types::{storage::map::derive_storage_slot_in_map, traits::ToField};
 
 /// Map
@@ -15,7 +15,7 @@ use dep::protocol_types::{storage::map::derive_storage_slot_in_map, traits::ToFi
 /// #[storage] struct.
 ///
 /// For example, you might use
-/// `Map<AztecAddress, PrivateMutable<ValueNote, Context>, Context>` to track
+/// `Map<AztecAddress, PublicMutable<ValueNote, Context>, Context>` to track
 /// token balances for different users, similar to how you'd use
 /// `mapping(address => uint256)` in Solidity.
 ///
@@ -31,12 +31,9 @@ use dep::protocol_types::{storage::map::derive_storage_slot_in_map, traits::ToFi
 /// ## Generic Parameters
 /// - `K`: The key type (must implement `ToField` trait for hashing)
 /// - `V`: The value type:
-///   - any Aztec state variable:
+///   - any Aztec state variable (variable that implements the StateVariable trait):
 ///     - `PublicMutable`
 ///     - `PublicImmutable`
-///     - `PrivateMutable`
-///     - `PrivateImmutable`
-///     - `PrivateSet`
 ///     - `DelayedPublicMutable`
 ///     - `Map`
 /// - `Context`: The execution context (handles private/public function
@@ -48,6 +45,10 @@ use dep::protocol_types::{storage::map::derive_storage_slot_in_map, traits::ToFi
 /// using the `at(key)` method to get the state variable for a specific key.
 /// The resulting state variable can then be read from or written to using its
 /// own methods.
+///
+/// Note that maps cannot be used with owned state variables (variables that
+/// implement the OwnedStateVariable trait) - those need to be wrapped in an
+/// `Owned` state variable instead.
 ///
 /// ## Advanced
 /// Internally, `Map` uses a single base storage slot to represent the
@@ -69,7 +70,6 @@ use dep::protocol_types::{storage::map::derive_storage_slot_in_map, traits::ToFi
 pub struct Map<K, V, Context> {
     pub context: Context,
     storage_slot: Field,
-    state_var_constructor: fn(Context, Field) -> V,
 }
 
 // Map reserves a single storage slot regardless of what it stores because
@@ -77,43 +77,18 @@ pub struct Map<K, V, Context> {
 // of nested state variables, which is expected to never result in collisions
 // or slots being close to one another due to these being hashes. This mirrors
 // the strategy adopted by Solidity mappings.
-impl<K, T, Context> HasStorageSlot<1> for Map<K, T, Context> {
+impl<K, V, Context> StateVariable<1, Context> for Map<K, V, Context> {
+    fn new(context: Context, storage_slot: Field) -> Self {
+        assert(storage_slot != 0, "Storage slot 0 not allowed. Storage slots must start from 1.");
+        Map { context, storage_slot }
+    }
+
     fn get_storage_slot(self) -> Field {
         self.storage_slot
     }
 }
 
 impl<K, V, Context> Map<K, V, Context> {
-    /// Initializes a new Map state variable.
-    ///
-    /// This function is usually automatically called within the #[storage]
-    /// macro.
-    /// You typically don't need to call this directly when writing smart contracts.
-    ///
-    /// # Arguments
-    ///
-    /// * `context` - One of `PrivateContext`/`PublicContext`/`UtilityContext`.
-    ///               The Context determines which methods of this struct will
-    ///               be made available to the calling smart contract function.
-    /// * `storage_slot` - A unique identifier for this Map within the contract.
-    ///                    Usually, the #[storage] macro will determine an
-    ///                    appropriate storage_slot automatically. A smart
-    ///                    contract dev shouldn't have to worry about this, as
-    ///                    it's managed behind the scenes.
-    /// * `state_var_constructor` - A function that creates the value type (V)
-    ///                             given a context and storage slot. This is
-    ///                             typically the constructor of the state
-    ///                             variable type being stored in the Map.
-    ///
-    pub fn new(
-        context: Context,
-        storage_slot: Field,
-        state_var_constructor: fn(Context, Field) -> V,
-    ) -> Self {
-        assert(storage_slot != 0, "Storage slot 0 not allowed. Storage slots must start from 1.");
-        Map { context, storage_slot, state_var_constructor }
-    }
-
     /// Returns the state variable associated with the given key.
     ///
     /// This is equivalent to accessing `mapping[key]` in Solidity. It returns
@@ -121,7 +96,7 @@ impl<K, V, Context> Map<K, V, Context> {
     /// used to read or write the value at that key.
     ///
     /// Unlike Solidity mappings which return the value directly, this returns
-    /// the state variable wrapper (like PrivateMutable, PublicMutable, etc.)
+    /// the state variable wrapper (like PublicMutable, nested Map etc.)
     /// that you then call methods on to interact with the actual value.
     ///
     /// # Arguments
@@ -146,14 +121,14 @@ impl<K, V, Context> Map<K, V, Context> {
     /// user_balance.replace(new_note);
     /// ```
     ///
-    pub fn at(self, key: K) -> V
+    pub fn at<let N: u32>(self, key: K) -> V
     where
         K: ToField,
+        V: StateVariable<N, Context>,
     {
-        // TODO(#1204): use a generator index for the storage slot
-        let derived_storage_slot = derive_storage_slot_in_map(self.storage_slot, key);
-
-        let state_var_constructor = self.state_var_constructor;
-        state_var_constructor(self.context, derived_storage_slot)
+        V::new(
+            self.context,
+            derive_storage_slot_in_map(self.storage_slot, key),
+        )
     }
 }

--- a/noir-projects/aztec-nr/aztec/src/state_vars/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/mod.nr
@@ -1,17 +1,22 @@
 pub mod map;
+pub mod owned_state_variable;
+pub mod owned;
 pub mod private_immutable;
 pub mod private_mutable;
 pub mod public_immutable;
 pub mod public_mutable;
 pub mod private_set;
 pub mod delayed_public_mutable;
+pub mod state_variable;
 pub mod storage;
 
 pub use crate::state_vars::delayed_public_mutable::DelayedPublicMutable;
 pub use crate::state_vars::map::Map;
+pub use crate::state_vars::owned::Owned;
+pub use crate::state_vars::owned_state_variable::OwnedStateVariable;
 pub use crate::state_vars::private_immutable::PrivateImmutable;
 pub use crate::state_vars::private_mutable::PrivateMutable;
 pub use crate::state_vars::private_set::PrivateSet;
 pub use crate::state_vars::public_immutable::PublicImmutable;
 pub use crate::state_vars::public_mutable::PublicMutable;
-pub use crate::state_vars::storage::HasStorageSlot;
+pub use crate::state_vars::state_variable::StateVariable;

--- a/noir-projects/aztec-nr/aztec/src/state_vars/owned.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/owned.nr
@@ -1,0 +1,53 @@
+use crate::state_vars::{owned_state_variable::OwnedStateVariable, state_variable::StateVariable};
+use protocol_types::address::AztecAddress;
+
+/// A wrapper state variable that is to be used with variables that implement the `OwnedStateVariable` trait.
+///
+/// Example usage:
+///
+/// ```noir
+/// #[storage]
+/// struct Storage {
+///     balance: Owned<PrivateSet<UintNote, Context>, Context>,
+/// }
+/// ```
+///
+/// To access the underlying owned state variable for a specific owner, use the `at` method:
+///
+/// ```noir
+/// let user_balance = storage.balance.at(user_address);
+/// ```
+///
+/// For more information on ownership, see the documentation for the `OwnedStateVariable` trait.
+///
+/// # Type Parameters
+///
+/// * `V` - The underlying type that implements `OwnedStateVariable<Context>` (e.g., `PrivateSet`, `PrivateMutable`).
+/// * `Context` - The execution context type (e.g., `PublicContext`, `PrivateContext`, `UtilityContext`). The context
+///               determines which methods of the state variable are available.
+///
+pub struct Owned<V, Context> {
+    pub context: Context,
+    storage_slot: Field,
+}
+
+impl<V, Context> StateVariable<1, Context> for Owned<V, Context> {
+    fn new(context: Context, storage_slot: Field) -> Self {
+        assert(storage_slot != 0, "Storage slot 0 not allowed. Storage slots must start from 1.");
+        Owned { context, storage_slot }
+    }
+
+    fn get_storage_slot(self) -> Field {
+        self.storage_slot
+    }
+}
+
+impl<V, Context> Owned<V, Context> {
+    /// Returns an instance of the underlying owned state variable for a given owner.
+    pub fn at(self, owner: AztecAddress) -> V
+    where
+        V: OwnedStateVariable<Context>,
+    {
+        V::new(self.context, self.storage_slot, owner)
+    }
+}

--- a/noir-projects/aztec-nr/aztec/src/state_vars/owned_state_variable.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/owned_state_variable.nr
@@ -1,0 +1,38 @@
+use protocol_types::address::AztecAddress;
+
+/// A trait that defines the interface for Aztec state variables that have an owner. Unlike regular state variables,
+/// owned state variables need to be wrapped in `Owned` state variable when placed in storage:
+///
+/// ```noir
+/// #[storage]
+/// struct Storage {
+///     balance: Owned<PrivateSet<UintNote, Context>, Context>,
+/// }
+/// ```
+///
+/// Owned state variables are only used when working with private data because, in the public context, write permissions
+/// are solely defined by the contract logic, and anyone can read data. In private, however, modifying state (nullifying
+/// private notes) requires both knowledge of the note (the note commitment preimage) and possession of the
+/// corresponding nullifier secret key.
+///
+/// ## So what is an Owner?
+///
+/// An **owner** is generally the entity that:
+/// 1. Can decrypt the message in which the given note pertaining to the state variable was sent,
+/// 2. has the ability to nullify (spend/destroy) those notes.
+///
+/// (Note that point 1 does not necessarily have to be true; for example, the note message could be encrypted for a
+/// decrypting service address, which could then deliver the note to the actual owner via offchain communication.)
+///
+/// # Type Parameters
+///
+/// * `Context` - The execution context type (e.g., `PublicContext`, `PrivateContext`, `UtilityContext`). The context
+///               determines which methods of the state variable are available and controls whether the variable can
+///               be accessed in public, private or utility functions.
+///
+pub trait OwnedStateVariable<Context> {
+    /// Initializes a new owned state variable with a given storage slot and owner. The storage slot is inherited from
+    /// the `Owned` state variable unchanged. The `Owned` state variable calls this function when its `at` method is
+    /// invoked.
+    fn new(context: Context, storage_slot: Field, owner: AztecAddress) -> Self;
+}

--- a/noir-projects/aztec-nr/aztec/src/state_vars/private_immutable.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/private_immutable.nr
@@ -8,7 +8,7 @@ use crate::{
         note_interface::{NoteHash, NoteType},
     },
     oracle::notes::check_nullifier_exists,
-    state_vars::storage::HasStorageSlot,
+    state_vars::owned_state_variable::OwnedStateVariable,
 };
 
 use protocol_types::{
@@ -18,38 +18,29 @@ use protocol_types::{
     traits::{Hash, Packable},
 };
 
-/// PrivateImmutable
+/// PrivateImmutable is an owned state variable type that represents a private value that is set once and remains
+/// unchanged forever. Because it is "owned," you must wrap a PrivateImmutable inside an Owned state variable when
+/// storing it:
 ///
-/// PrivateImmutable is a private state variable type for values that are set once
-/// and remain permanently unchanged.
+/// ```noir
+/// #[storage]
+/// struct Storage<Context> {
+///     your_variable: Owned<PrivateImmutable<YourNote, Context>, Context>,
+/// }
+/// ```
 ///
-/// You can declare a state variable of type PrivateImmutable within your contract's
-/// #[storage] struct:
+/// For more details on what "owned" means, see the documentation for the [OwnedStateVariable] trait.
 ///
-/// E.g.:
-/// `your_variable: PrivateImmutable<YourNote, Context>`
+/// The value of a PrivateImmutable is stored in the Aztec's private state and hence is represented as a note.
 ///
-/// The values of a PrivateImmutable are stored in the Aztec's private state and hence
-/// are represented as notes. While any number of notes can be created within
-/// a PrivateImmutable, at any moment, only one note exists per "owner."
-/// To interact with a specific owner's note, call `PrivateImmutable::at(owner)`, which
-/// returns an OwnedPrivateImmutable handle for that owner.
-///
-/// The OwnedPrivateImmutable type facilitates: inserting the permanent note during
-/// initialization, and reading that note.
-///
-/// The methods of PrivateImmutable are:
-/// - `initialize`
-/// - `get_note`
-/// (see the methods' own doc comments for more info).
+/// The PrivateImmutable type facilitates: inserting the permanent note during initialization, and reading that note.
 ///
 /// ## Example.
 ///
 /// A contract's configuration parameters can be represented as a PrivateImmutable.
 /// Once set during contract deployment or initial setup, these parameters remain
-/// constant for the lifetime of the contract. To ensure there is only one configuration
-/// per contract you would consider valid only one view of the PrivateImmutable
-/// (most likely the view constructed with the contract's address).
+/// constant for the lifetime of the contract. The owner in this case would be an
+/// account with admin privileges.
 /// TODO(F-187): Update this ^
 ///
 /// # Generic Parameters:
@@ -61,60 +52,16 @@ use protocol_types::{
 pub struct PrivateImmutable<Note, Context> {
     context: Context,
     storage_slot: Field,
+    owner: AztecAddress,
 }
 
-// Private storage slots are not really 'slots' but rather a value in the note hash preimage, so there is no notion of a
-// value spilling over multiple slots. For this reason PrivateImmutable (and all other private state variables) needs
-// just one slot to be reserved, regardless of what it stores.
-impl<T, Context> HasStorageSlot<1> for PrivateImmutable<T, Context> {
-    fn get_storage_slot(self) -> Field {
-        self.storage_slot
+impl<Note, Context> OwnedStateVariable<Context> for PrivateImmutable<Note, Context> {
+    fn new(context: Context, storage_slot: Field, owner: AztecAddress) -> Self {
+        Self { context, storage_slot, owner }
     }
 }
 
 impl<Note, Context> PrivateImmutable<Note, Context> {
-    /// Initializes a new PrivateImmutable state variable.
-    ///
-    /// This function is usually automatically called within the #[storage] macro.
-    /// You typically don't need to call this directly when writing smart contracts.
-    ///
-    /// # Arguments
-    ///
-    /// * `context` - One of `PrivateContext`/`PublicContext`/`UtilityContext`. The
-    ///               Context determines which methods of this struct will be made
-    ///               available to the calling smart contract function.
-    /// * `storage_slot` - A unique identifier for this state variable within the
-    ///                    contract. The permanent note for this PrivateImmutable
-    ///                    state variable will have this `storage_slot`.
-    ///                    Usually, the #[storage] macro will determine an
-    ///                    appropriate storage_slot automatically. A smart contract
-    ///                    dev shouldn't have to worry about this, as it's managed
-    ///                    behind the scenes.
-    ///
-    pub fn new(context: Context, storage_slot: Field) -> Self {
-        assert(storage_slot != 0, "Storage slot 0 not allowed. Storage slots must start from 1.");
-        Self { context, storage_slot }
-    }
-
-    /// Returns an OwnedPrivateImmutable scoped to the given `owner`'s note.
-    pub fn at(self, owner: AztecAddress) -> OwnedPrivateImmutable<Note, Context> {
-        OwnedPrivateImmutable::new(self.context, owner, self.storage_slot)
-    }
-}
-
-/// A view of a note in a PrivateImmutable belonging to a specific `owner`.
-/// Obtained by calling `PrivateImmutable::at(owner)`.
-pub struct OwnedPrivateImmutable<Note, Context> {
-    context: Context,
-    owner: AztecAddress,
-    storage_slot: Field,
-}
-
-impl<Note, Context> OwnedPrivateImmutable<Note, Context> {
-    fn new(context: Context, owner: AztecAddress, storage_slot: Field) -> Self {
-        Self { context, owner, storage_slot }
-    }
-
     /// Computes the initialization nullifier using the provided secret.
     fn compute_initialization_nullifier(self, secret: Field) -> Field {
         poseidon2_hash_with_separator(
@@ -124,7 +71,7 @@ impl<Note, Context> OwnedPrivateImmutable<Note, Context> {
     }
 }
 
-impl<Note> OwnedPrivateImmutable<Note, &mut PrivateContext> {
+impl<Note> PrivateImmutable<Note, &mut PrivateContext> {
     /// Computes the nullifier that will be created when this PrivateImmutable is first initialized.
     ///
     /// This function is primarily used internally by the `initialize` method, but may also be useful for contracts that
@@ -137,36 +84,14 @@ impl<Note> OwnedPrivateImmutable<Note, &mut PrivateContext> {
         self.compute_initialization_nullifier(secret)
     }
 
-    /// Initializes an OwnedPrivateImmutable state variable instance with a permanent note.
+    /// Initializes a PrivateImmutable state variable instance with a permanent `note` and returns a [NoteEmission] that
+    /// allows you to decide whether to encrypt and send the note to someone.
     ///
-    /// This function inserts the single, permanent note for this state variable. It can
-    /// only be called once per OwnedPrivateImmutable. Subsequent calls will fail because
-    /// the initialization nullifier will already exist.
+    /// This function inserts the single, permanent note for this state variable. It can only be called once per
+    /// PrivateImmutable. Subsequent calls will fail because the initialization nullifier will already exist.
     ///
-    /// Unlike OwnedPrivateMutable, this note will never be nullified or replaced through
-    /// the state variable interface - it persists for the lifetime of the state variable.
-    ///
-    /// # Arguments
-    ///
-    /// * `note` - The permanent note to store in this PrivateImmutable. This note
-    ///            contains the unchanging value of the state variable.
-    ///
-    /// # Returns
-    ///
-    /// * `NoteEmission<Note>` - A type-safe wrapper that requires you to decide
-    ///                          whether to encrypt and send the note to someone.
-    ///                          You can call `.emit()` on it to encrypt and log
-    ///                          the note, or `.discard()` to skip emission.
-    ///                          See NoteEmission for more details.
-    ///
-    /// # Advanced
-    ///
-    /// This function performs the following operations:
-    /// - Creates and emits an initialization nullifier to mark this storage slot
-    ///   as initialized. This prevents double-initialization.
-    /// - Inserts the provided note into the protocol's Note Hash Tree.
-    /// - Returns a NoteEmission type that allows the caller to decide how to encrypt
-    ///   and deliver the note to its intended recipient.
+    /// Unlike PrivateMutable, this note will never be nullified or replaced through the state variable interface - it
+    /// persists for the lifetime of the state variable.
     ///
     pub fn initialize(self, note: Note) -> NoteEmission<Note>
     where
@@ -180,26 +105,13 @@ impl<Note> OwnedPrivateImmutable<Note, &mut PrivateContext> {
         create_note(self.context, self.owner, self.storage_slot, note)
     }
 
-    /// Reads the permanent note of an OwnedPrivateImmutable state variable instance.
+    /// Reads the permanent note of a PrivateImmutable state variable instance.
     ///
-    /// If this OwnedPrivateImmutable state variable has not yet been initialized,
-    /// no note will exist: the call will fail and the transaction will not
-    /// be provable.
+    /// If this PrivateImmutable state variable has not yet been initialized, no note will exist: the call will fail and
+    /// the transaction will not be provable.
     ///
-    /// # Returns
-    ///
-    /// * `Note` - The permanent note stored in this OwnedPrivateImmutable.
-    ///
-    /// # Advanced
-    ///
-    /// This function performs the following operations:
-    /// - Retrieves the note from the PXE via an oracle call
-    /// - Validates that the note exists and belongs to this contract address and
-    ///   storage slot by pushing a read request to the context
-    /// - Returns the note content directly without nullification
-    ///
-    /// Since the note is immutable, there's no risk of reading stale data or
-    /// race conditions - the note never changes after initialization.
+    /// Since the note is immutable, there's no risk of reading stale data or race conditions - the note never changes
+    /// after initialization.
     ///
     pub fn get_note(self) -> Note
     where
@@ -208,14 +120,14 @@ impl<Note> OwnedPrivateImmutable<Note, &mut PrivateContext> {
         let storage_slot = self.storage_slot;
         let retrieved_note = get_note(self.context, self.owner, storage_slot).0;
 
-        // Because the notes obtained from OwnedPrivateImmutable are not meant to be nullified and get_note(...) function
+        // Because the notes obtained from PrivateImmutable are not meant to be nullified and get_note(...) function
         // has already constrained the note (by pushing a read request to the context), we can return just the note
         // and skip the additional data in RetrievedNote.
         retrieved_note.note
     }
 }
 
-impl<Note> OwnedPrivateImmutable<Note, UtilityContext>
+impl<Note> PrivateImmutable<Note, UtilityContext>
 where
     Note: NoteType + NoteHash + Eq,
 {
@@ -227,30 +139,19 @@ where
         self.compute_initialization_nullifier(secret)
     }
 
-    /// Checks whether this OwnedPrivateImmutable has been initialized.
-    ///
-    /// # Returns
-    ///
-    /// * `bool` - `true` if the OwnedPrivateImmutable has been initialized (the initialization
-    ///            nullifier exists), `false` otherwise.
-    ///
+    /// Returns whether this PrivateImmutable has been initialized.
     pub unconstrained fn is_initialized(self) -> bool {
         let nullifier = self.get_initialization_nullifier();
         check_nullifier_exists(nullifier)
     }
 
-    /// Returns the permanent note in this OwnedPrivateImmutable without consuming it.
+    /// Returns the permanent note in this PrivateImmutable without consuming it.
     ///
-    /// This function is only available in a UtilityContext (unconstrained environment)
-    /// and is typically used for offchain queries, view functions, or testing.
+    /// This function is only available in a UtilityContext (unconstrained environment) and is typically used for
+    /// offchain queries, view functions, or testing.
     ///
-    /// Unlike the constrained `get_note()`, this function does not push read requests
-    /// or perform validation. It simply reads the note from the PXE's database.
-    ///
-    /// # Returns
-    ///
-    /// * `Note` - The permanent note stored in this OwnedPrivateImmutable.
-    ///
+    /// Unlike the constrained `get_note()`, this function does not push read requests or perform validation. It simply
+    /// reads the note from the PXE's database.
     pub unconstrained fn view_note(self) -> Note
     where
         Note: Packable,

--- a/noir-projects/aztec-nr/aztec/src/state_vars/private_mutable.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/private_mutable.nr
@@ -8,7 +8,7 @@ use crate::{
         note_interface::{NoteHash, NoteType},
     },
     oracle::notes::check_nullifier_exists,
-    state_vars::storage::HasStorageSlot,
+    state_vars::owned_state_variable::OwnedStateVariable,
 };
 
 use protocol_types::{
@@ -20,137 +20,69 @@ use protocol_types::{
 
 mod test;
 
-/// # PrivateMutable
-///
-/// PrivateMutable is a private state variable type, which enables you to read, mutate,
-/// and write private state within the #[external("private")] functions of your smart contract.
-///
-/// You can declare a state variable of type PrivateMutable within your contract's
-/// #[storage] struct:
+/// PrivateMutable is an owned state variable type that represents a private value that can be changed. Because it is
+/// "owned," you must wrap a PrivateMutable inside an Owned state variable when storing it:
 ///
 /// E.g.:
-/// `your_variable: PrivateMutable<YourNote, Context>`
+/// ```noir
+/// #[storage]
+/// struct Storage<Context> {
+///     your_variable: Owned<PrivateMutable<YourNote, Context>, Context>,
+/// }
+/// ```
 ///
-/// This is conceptually similar to how a regular variable works in Ethereum:
-/// the state variable has exactly one value at any point in time. However, the
-/// underlying implementation differs significantly because of Aztec's private
-/// state model.
+/// For more details on what "owned" means, see the documentation for the [OwnedStateVariable] trait.
 ///
-/// Private state is represented as notes, with each note having a distinct "owner."
-/// While any number of notes can be created within a PrivateMutable, at any moment,
-/// only one note exists per "owner."
-/// To interact with a specific owner's note, call `PrivateMutable::at(owner)`, which
-/// returns an OwnedPrivateMutable handle for that owner.
-///
-/// An OwnedPrivateMutable state variable is initialized by inserting a very first note.
-/// Subsequently, the OwnedPrivateMutable can make changes to the state variable's value by
-/// nullifying the current note and inserting a replacement note.
-///
-/// The methods of OwnedPrivateMutable are:
-/// - `initialize`
-/// - `replace`
-/// - `initialize_or_replace`
-/// - `get_note`
-/// (see the methods' own doc comments for more info).
+/// A PrivateMutable state variable is initialized by inserting a very first note. Subsequently, the PrivateMutable can
+/// make changes to the state variable's value by nullifying the current note and inserting a replacement note.
 ///
 /// ## Example
 ///
-/// A users' account nonce can be represented as a PrivateMutable<NonceNote>.
-/// The "current value" of the user's nonce is the value contained within the
-/// single not-yet-nullified note in the user's view of the PrivateMutable.
+/// A user's account nonce can be represented as a PrivateMutable<NonceNote>. The "current value" of the user's nonce is
+/// the value contained within the single not-yet-nullified note in the user's view of the PrivateMutable.
 ///
-/// When the nonce needs to be incremented, the current note gets nullified
-/// and a new note with the incremented nonce gets inserted. The new note then
-/// becomes the "current value" of the OwnedPrivateMutable state variable.
+/// When the nonce needs to be incremented, the current note gets nullified and a new note with the incremented nonce
+/// gets inserted. The new note then becomes the "current value" of the PrivateMutable state variable.
 ///
-/// This is similar to how `uint256 nonce` would work in Solidity: there's always
-/// exactly one current value, and updating it overwrites the previous value.
+/// This is similar to how `uint256 nonce` would work in Solidity: there's always exactly one current value, and
+/// updating it overwrites the previous value.
 ///
 /// ## When to choose PrivateMutable vs PrivateSet:
 ///
-/// - Use PrivateMutable when you want exactly one note to represent the state
-///   variable's current value, similar to regular variables in Ethereum.
-/// - Use PrivateMutable when you want only the 'owner' of the private state to
-///   be able to make changes to it.
-/// - Use PrivateSet when you want multiple notes to collectively represent the
-///   state variable's current value (like a collection of token balance notes).
-/// - Use PrivateSet when you want to allow "other people" (beyond the owner) to
-///   insert notes into the state variable.
+/// - Use PrivateMutable when you want exactly one note to represent the state variable's current value, similar to
+///   regular variables in Solidity.
+/// - Use PrivateMutable when you want only the 'owner' of the private state to be able to make changes to it.
+/// - Use PrivateSet when you want multiple notes to collectively represent the state variable's current value (like a
+///   collection of token balance notes).
+/// - Use PrivateSet when you want to allow "other people" (beyond the owner) to insert notes into the state variable.
 ///
-/// Only the 'owner' of the given OwnedPrivateMutable state variable can mutate it,
-/// because every mutation requires nullifying the current note, and only the owner
-/// knows the note's content and the secret necessary to compute its nullifier.
+/// Only the 'owner' of the given PrivateMutable state variable can mutate it, because every mutation requires
+/// nullifying the current note, and only the owner knows both the note's content and the secret necessary to compute
+/// its nullifier.
 ///
 /// ## Privacy
 ///
-/// The methods of a PrivateMutable are only executable in a PrivateContext, and are
-/// designed to not leak anything about _which_ state variable was read/modified/
-/// initialized, to the outside world.
+/// The methods of a PrivateMutable are only executable in a PrivateContext, and are designed to not leak anything about
+/// _which_ state variable was read/modified/initialized, to the outside world.
 ///
 /// # Generic Parameters:
 ///
-/// * `Note` - A single note of this type will represent the PrivateMutable's
-///            current value at the given storage_slot.
+/// * `Note` - A single note of this type will represent the PrivateMutable's current value at the given storage_slot.
 /// * `Context` - The execution context (PrivateContext or UtilityContext).
 ///
 pub struct PrivateMutable<Note, Context> {
     context: Context,
     storage_slot: Field,
+    owner: AztecAddress,
 }
 
-// Private storage slots are not really 'slots' but rather a value in the note hash preimage, so there is no notion of a
-// value spilling over multiple slots. For this reason PrivateMutable (and all other private state variables) needs just
-// one slot to be reserved, regardless of what it stores.
-impl<T, Context> HasStorageSlot<1> for PrivateMutable<T, Context> {
-    fn get_storage_slot(self) -> Field {
-        self.storage_slot
+impl<Note, Context> OwnedStateVariable<Context> for PrivateMutable<Note, Context> {
+    fn new(context: Context, storage_slot: Field, owner: AztecAddress) -> Self {
+        Self { context, storage_slot, owner }
     }
 }
 
 impl<Note, Context> PrivateMutable<Note, Context> {
-    /// Initializes a new PrivateMutable state variable.
-    ///
-    /// This function is usually automatically called within the #[storage] macro.
-    /// You typically don't need to call this directly when writing smart contracts.
-    ///
-    /// # Arguments
-    ///
-    /// * `context` - One of `PrivateContext`/`PublicContext`/`UtilityContext`. The
-    ///               Context determines which methods of this struct will be made
-    ///               available to the calling smart contract function.
-    /// * `storage_slot` - A unique identifier for this state variable within the
-    ///                    contract. Every replacement note for this PrivateMutable
-    ///                    state variable will have the same `storage_slot`.
-    ///                    Usually, the #[storage] macro will determine an
-    ///                    appropriate storage_slot automatically. A smart contract
-    ///                    dev shouldn't have to worry about this, as it's managed
-    ///                    behind the scenes.
-    ///
-    /// docs:start:new
-    pub fn new(context: Context, storage_slot: Field) -> Self {
-        assert(storage_slot != 0, "Storage slot 0 not allowed. Storage slots must start from 1.");
-        Self { context, storage_slot }
-    }
-
-    /// Returns an OwnedPrivateMutable scoped to the given `owner`'s note.
-    pub fn at(self, owner: AztecAddress) -> OwnedPrivateMutable<Note, Context> {
-        OwnedPrivateMutable::new(self.context, owner, self.storage_slot)
-    }
-}
-
-/// A view of notes in a PrivateMutable belonging to a specific `owner`.
-/// Obtained by calling `PrivateMutable::at(owner)`.
-pub struct OwnedPrivateMutable<Note, Context> {
-    context: Context,
-    owner: AztecAddress,
-    storage_slot: Field,
-}
-
-impl<Note, Context> OwnedPrivateMutable<Note, Context> {
-    fn new(context: Context, owner: AztecAddress, storage_slot: Field) -> Self {
-        Self { context, owner, storage_slot }
-    }
-
     /// Computes the initialization nullifier using the provided secret.
     fn compute_initialization_nullifier(self, secret: Field) -> Field {
         poseidon2_hash_with_separator(
@@ -160,7 +92,7 @@ impl<Note, Context> OwnedPrivateMutable<Note, Context> {
     }
 }
 
-impl<Note> OwnedPrivateMutable<Note, &mut PrivateContext>
+impl<Note> PrivateMutable<Note, &mut PrivateContext>
 where
     Note: NoteType + NoteHash,
 {
@@ -176,40 +108,11 @@ where
         self.compute_initialization_nullifier(secret)
     }
 
-    /// Initializes an OwnedPrivateMutable state variable instance with its first note.
+    /// Initializes a PrivateMutable state variable instance with its first `note` and returns a [NoteEmission] that
+    /// allows you to decide whether to encrypt and send the note to someone.
     ///
-    /// This function creates the very first note for this state variable. It can
-    /// only be called once per OwnedPrivateMutable. Subsequent calls will fail because
-    /// the initialization nullifier will already exist.
-    ///
-    /// This is conceptually similar to setting an initial value for a variable in
-    /// Ethereum smart contracts under a user's address in a mapping, except that in Aztec
-    /// the "value" is represented as a private note.
-    ///
-    /// ## Arguments
-    ///
-    /// * `note` - The initial note to store in this PrivateMutable. This note
-    ///            becomes the "current value" of the state variable.
-    ///
-    /// ## Returns
-    ///
-    /// * `NoteEmission<Note>` - A type-safe wrapper that requires you to decide
-    ///                          whether to encrypt and send the note to someone.
-    ///   You can call `.emit()` on it to encrypt and log the note, or `.discard()`
-    ///   to skip emission. See NoteEmission for more details.
-    ///
-    /// ## Advanced
-    ///
-    /// This function performs the following operations:
-    /// - Creates and emits an initialization nullifier to mark this storage slot
-    ///   as initialized. This prevents double-initialization.
-    /// - Inserts the provided note into the protocol's Note Hash Tree.
-    /// - Returns a NoteEmission type that allows the caller to decide how to encrypt
-    ///   and deliver the note to its intended recipient.
-    ///
-    /// The initialization nullifier is deterministically computed from the storage
-    /// slot and can leak privacy information (see `compute_initialization_nullifier`
-    /// documentation).
+    /// This function can only be called once per PrivateMutable. Subsequent calls will fail because the initialization
+    /// nullifier will already exist.
     ///
     pub fn initialize(self, note: Note) -> NoteEmission<Note>
     where
@@ -228,10 +131,6 @@ where
     /// This function implements a "read-and-replace" pattern for updating private state
     /// in Aztec. It first retrieves the current note, then nullifies it (marking it as spent),
     /// and finally inserts a `new_note` produced by the user-provided function `f`.
-    ///
-    /// This is conceptually similar to updating a variable in Ethereum smart contracts,
-    /// except that in Aztec we achieve this by consuming the old note and creating a
-    /// new one.
     ///
     /// This function can only be called after the PrivateMutable has been initialized.
     /// If called on an uninitialized PrivateMutable, it will fail because there is
@@ -406,7 +305,7 @@ where
     }
 }
 
-impl<Note> OwnedPrivateMutable<Note, UtilityContext>
+impl<Note> PrivateMutable<Note, UtilityContext>
 where
     Note: NoteType + NoteHash + Eq,
 {
@@ -441,9 +340,6 @@ where
     /// Unlike `get_note()`, this function does NOT nullify and recreate the note.
     /// It simply reads the current note from the PXE's database without modifying
     /// the state. This makes it suitable for read-only operations.
-    ///
-    /// This is conceptually similar to view functions in Ethereum that don't modify
-    /// state.
     ///
     /// ## Returns
     ///

--- a/noir-projects/aztec-nr/aztec/src/state_vars/private_mutable/test.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/private_mutable/test.nr
@@ -1,20 +1,25 @@
 use crate::{
     context::{PrivateContext, UtilityContext},
-    state_vars::private_mutable::PrivateMutable,
+    state_vars::{owned_state_variable::OwnedStateVariable, private_mutable::PrivateMutable},
     test::{helpers::test_environment::TestEnvironment, mocks::mock_note::MockNote},
 };
+use protocol_types::address::AztecAddress;
 
 global STORAGE_SLOT: Field = 17;
 global VALUE: Field = 23;
 
 unconstrained fn in_private(
     context: &mut PrivateContext,
+    owner: AztecAddress,
 ) -> PrivateMutable<MockNote, &mut PrivateContext> {
-    PrivateMutable::new(context, STORAGE_SLOT)
+    PrivateMutable::new(context, STORAGE_SLOT, owner)
 }
 
-unconstrained fn in_utility(context: UtilityContext) -> PrivateMutable<MockNote, UtilityContext> {
-    PrivateMutable::new(context, STORAGE_SLOT)
+unconstrained fn in_utility(
+    context: UtilityContext,
+    owner: AztecAddress,
+) -> PrivateMutable<MockNote, UtilityContext> {
+    PrivateMutable::new(context, STORAGE_SLOT, owner)
 }
 
 #[test(should_fail_with = "Failed to get a note")]
@@ -23,7 +28,7 @@ unconstrained fn get_uninitialized() {
     let owner = env.create_light_account();
 
     env.private_context(|context| {
-        let state_var = in_private(context).at(owner);
+        let state_var = in_private(context, owner);
         let _ = state_var.get_note();
     });
 }
@@ -34,7 +39,7 @@ unconstrained fn view_uninitialized() {
     let owner = env.create_light_account();
 
     env.utility_context(|context| {
-        let state_var = in_utility(context).at(owner);
+        let state_var = in_utility(context, owner);
         let _ = state_var.view_note();
     });
 }
@@ -45,7 +50,7 @@ unconstrained fn replace_uninitialized() {
     let owner = env.create_light_account();
 
     env.private_context(|context| {
-        let state_var = in_private(context).at(owner);
+        let state_var = in_private(context, owner);
 
         let _ = state_var.replace(|_old_note| {
             let note = MockNote::new(VALUE).build_note();
@@ -60,7 +65,7 @@ unconstrained fn initialize() {
     let owner = env.create_light_account();
 
     env.private_context(|context| {
-        let state_var = in_private(context).at(owner);
+        let state_var = in_private(context, owner);
 
         let note = MockNote::new(VALUE).build_note();
 
@@ -82,7 +87,7 @@ unconstrained fn initialize_and_get_pending() {
     let owner = env.create_light_account();
 
     env.private_context(|context| {
-        let state_var = in_private(context).at(owner);
+        let state_var = in_private(context, owner);
 
         let note = MockNote::new(VALUE).build_note();
 
@@ -115,7 +120,7 @@ unconstrained fn initialize_and_get_settled() {
     let note = MockNote::new(VALUE).build_note();
 
     let init_emission = env.private_context(|context| {
-        let state_var = in_private(context).at(owner);
+        let state_var = in_private(context, owner);
 
         state_var.initialize(note)
     });
@@ -123,7 +128,7 @@ unconstrained fn initialize_and_get_settled() {
     env.discover_note(init_emission);
 
     env.private_context(|context| {
-        let state_var = in_private(context).at(owner);
+        let state_var = in_private(context, owner);
 
         let get_emission = state_var.get_note();
 
@@ -148,7 +153,7 @@ unconstrained fn initialize_and_view_settled() {
     let note = MockNote::new(VALUE).build_note();
 
     let init_emission = env.private_context(|context| {
-        let state_var = in_private(context).at(owner);
+        let state_var = in_private(context, owner);
 
         state_var.initialize(note)
     });
@@ -156,7 +161,7 @@ unconstrained fn initialize_and_view_settled() {
     env.discover_note(init_emission);
 
     env.utility_context(|context| {
-        let state_var = in_utility(context).at(owner);
+        let state_var = in_utility(context, owner);
 
         assert_eq(state_var.view_note(), note);
     });
@@ -168,7 +173,7 @@ unconstrained fn initialize_and_replace_pending() {
     let owner = env.create_light_account();
 
     env.private_context(|context| {
-        let state_var = in_private(context).at(owner);
+        let state_var = in_private(context, owner);
 
         let note = MockNote::new(VALUE).build_note();
 
@@ -207,7 +212,7 @@ unconstrained fn initialize_and_replace_settled() {
     let note = MockNote::new(VALUE).build_note();
 
     let init_emission = env.private_context(|context| {
-        let state_var = in_private(context).at(owner);
+        let state_var = in_private(context, owner);
 
         state_var.initialize(note)
     });
@@ -215,7 +220,7 @@ unconstrained fn initialize_and_replace_settled() {
     env.discover_note(init_emission);
 
     env.private_context(|context| {
-        let state_var = in_private(context).at(owner);
+        let state_var = in_private(context, owner);
 
         let replacement_value = VALUE + 1;
         let replacement_note = MockNote::new(replacement_value).build_note();
@@ -243,7 +248,7 @@ unconstrained fn initialize_or_replace_uninitialized() {
     let owner = env.create_light_account();
 
     env.private_context(|context| {
-        let state_var = in_private(context).at(owner);
+        let state_var = in_private(context, owner);
 
         let init_note = MockNote::new(VALUE).build_note();
 
@@ -269,7 +274,7 @@ unconstrained fn initialize_or_replace_initialized_pending() {
     let owner = env.create_light_account();
 
     env.private_context(|context| {
-        let state_var = in_private(context).at(owner);
+        let state_var = in_private(context, owner);
 
         let note = MockNote::new(VALUE).build_note();
         let _ = state_var.initialize(note);
@@ -302,7 +307,7 @@ unconstrained fn initialize_or_replace_initialized_settled() {
     let note = MockNote::new(VALUE).build_note();
 
     let init_emission = env.private_context(|context| {
-        let state_var = in_private(context).at(owner);
+        let state_var = in_private(context, owner);
 
         state_var.initialize(note)
     });
@@ -310,7 +315,7 @@ unconstrained fn initialize_or_replace_initialized_settled() {
     env.discover_note(init_emission);
 
     env.private_context(|context| {
-        let state_var = in_private(context).at(owner);
+        let state_var = in_private(context, owner);
 
         let note_hash_read_requests_pre_replace = context.note_hash_read_requests.len();
         let nullifiers_pre_replace = context.nullifiers.len();
@@ -345,7 +350,7 @@ unconstrained fn get_replacement_note_has_unique_randomness() {
     let note = MockNote::new(VALUE).build_note();
 
     let init_emission = env.private_context(|context| {
-        let state_var = in_private(context).at(owner);
+        let state_var = in_private(context, owner);
 
         state_var.initialize(note)
     });
@@ -353,7 +358,7 @@ unconstrained fn get_replacement_note_has_unique_randomness() {
     env.discover_note(init_emission);
 
     env.private_context(|context| {
-        let state_var = in_private(context).at(owner);
+        let state_var = in_private(context, owner);
 
         let get_emission = state_var.get_note();
 

--- a/noir-projects/aztec-nr/aztec/src/state_vars/private_set.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/private_set.nr
@@ -11,7 +11,7 @@ use crate::{
         retrieved_note::RetrievedNote,
         utils::compute_note_hash_read,
     },
-    state_vars::storage::HasStorageSlot,
+    state_vars::owned_state_variable::OwnedStateVariable,
 };
 use protocol_types::{
     address::AztecAddress, constants::MAX_NOTE_HASH_READ_REQUESTS_PER_CALL, traits::Packable,
@@ -19,47 +19,31 @@ use protocol_types::{
 
 mod test;
 
-/// # PrivateSet
-///
-/// PrivateSet is a private state variable type, which enables you to read, mutate,
-/// and write private state within the #[external("private")] functions of your smart contract.
-///
-/// You can declare a state variable of type PrivateSet within your contract's
-/// #[storage] struct:
+/// PrivateSet is an owned state variable type, which enables you to read, mutate, and write private state. Because it
+/// is "owned," you must wrap a PrivateSet inside an Owned state variable when storing it:
 ///
 /// E.g.:
-/// `your_variable: PrivateSet<YourNote, Context>`
+/// ```noir
+/// #[storage]
+/// struct Storage<Context> {
+///     your_variable: Owned<PrivateSet<YourNote, Context>, Context>,
+/// }
 ///
-/// Since PrivateSet operates on notes that are visible only to a specific account (the "owner"
-/// of the notes), it is generally not possible to obtain a complete view of all the contract's
-/// notes stored within a PrivateSet. Therefore, PrivateSet primarily serves as a helper for
-/// constructing an OwnedPrivateSet, which represents a "view" of the notes belonging to
-/// a particular account within the PrivateSet.
+/// For more details on what "owned" means, see the documentation for the [OwnedStateVariable] trait.
 ///
-/// "Owner" of a note is generally considered to be the account that has the ability to nullify
-/// the note.
+/// The PrivateSet facilitates: the insertion of new notes, the reading of existing notes, and the nullification of
+/// existing notes.
 ///
-/// The OwnedPrivateSet facilitates: the insertion of new notes, the reading of existing notes,
-/// and the nullification of existing notes.
-///
-/// The methods of OwnedPrivateSet are:
-/// - `insert`
-/// - `pop_notes`
-/// - `get_notes`
-/// - `remove`
-/// (see the methods' own doc comments for more info).
-///
-/// The "current value" of an OwnedPrivateSet is the collection of all _not-yet-nullified_
-/// account's notes in the set.
+/// The "current value" of a PrivateSet is the collection of all _not-yet-nullified_ account's notes in the set.
 ///
 ///
 /// ## Example.
 ///
-/// A user's token balance can be represented as an OwnedPrivateSet of multiple notes,
+/// A user's token balance can be represented as a PrivateSet of multiple notes,
 /// where the note type contains a value.
-/// The "current value" of the user's token balance (the OwnedPrivateSet state variable)
+/// The "current value" of the user's token balance (the PrivateSet state variable)
 /// can be interpreted as the summation of the values contained within all
-/// not-yet-nullified notes (aka "current notes") in the OwnedPrivateSet.
+/// not-yet-nullified notes (aka "current notes") in the PrivateSet.
 ///
 /// This is similar to a physical wallet containing five $10 notes: the owner's
 /// wallet balance is the sum of all those $10 notes: $50.
@@ -67,7 +51,7 @@ mod test;
 /// change. Their new wallet balance will then be interpreted as the new summation: $48.
 ///
 /// The interpretation doesn't always have to be a "summation of values". When
-/// `get_notes` is called, OwnedPrivateSet does not attempt to interpret the notes at all;
+/// `get_notes` is called, PrivateSet does not attempt to interpret the notes at all;
 /// it's up to the custom code of the smart contract to make an interpretation.
 ///
 /// For example: a set of notes could instead represent a moving average; or a modal
@@ -76,8 +60,8 @@ mod test;
 /// which are housed under the same "storage slot".
 ///
 /// It's worth noting that a user can prove existence of _at least_ some subset
-/// of notes in an OwnedPrivateSet, but they cannot prove existence of _all_ notes
-/// in an OwnedPrivateSet.
+/// of notes in a PrivateSet, but they cannot prove existence of _all_ notes
+/// in a PrivateSet.
 /// The physical wallet is a good example: a user can prove that there are five
 /// $10 notes in their wallet by furnishing those notes. But because we cannot
 /// _see_ the entirety of their wallet, they might have many more notes that
@@ -112,15 +96,6 @@ mod test;
 /// designed to not leak anything about _which_ state variable was read/modified/
 /// inserted, to the outside world.
 ///
-/// The design of the Note does impact the privacy of the state variable: the note
-/// will need to contain a `randomness` field so that, when hashed, the contents of
-/// the note are private.
-///
-/// The design of the note's custom `compute_nullifier` method will also impact the
-/// privacy of the note at the time it is nullified. (Note: all Notes must implement
-/// `compute_nullifier` to be compatible with PrivateSet). See the docs.
-///
-///
 /// # Struct Fields:
 ///
 /// * context - The execution context (PrivateContext or UtilityContext).
@@ -140,64 +115,16 @@ mod test;
 pub struct PrivateSet<Note, Context> {
     pub context: Context,
     pub storage_slot: Field,
-}
-
-impl<Note, Context> HasStorageSlot<1> for PrivateSet<Note, Context> {
-    // Private storage slots are not really 'slots' but rather a value in the note
-    // hash preimage, so there is no notion of a value spilling over multiple slots.
-    // For this reason, PrivateSet (and all other private state variables) needs
-    // just one slot to be reserved, regardless of what it stores.
-    fn get_storage_slot(self) -> Field {
-        self.storage_slot
-    }
-}
-
-impl<Note, Context> PrivateSet<Note, Context> {
-    /// Initializes a new PrivateSet state variable.
-    ///
-    /// This function is usually automatically called within the #[storage] macro.
-    /// You typically don't need to call this directly when writing smart contracts.
-    ///
-    ///
-    /// # Arguments
-    ///
-    /// * `context` - One of `PrivateContext`/`PublicContext`/`UtilityContext`. The
-    ///               Context determines which methods of this struct will be made
-    ///               available to the calling smart contract function.
-    /// * `storage_slot` - A unique identifier for this state variable within the
-    ///                    contract. All notes that "belong" to a given PrivateSet
-    ///                    state variable are augmented with a common `storage_slot`
-    ///                    field, as a way of identifying which set they belong to.
-    ///                    Usually, the #[storage] macro will determine an appropriate
-    ///                    storage_slot automatically. A smart contract dev shouldn't
-    ///                    have to worry about this, as it's managed behind the scenes.
-    ///
-    pub fn new(context: Context, storage_slot: Field) -> Self {
-        PrivateSet { context, storage_slot }
-    }
-
-    /// Returns an OwnedPrivateSet scoped to the given `owner`'s notes.
-    pub fn at(self, owner: AztecAddress) -> OwnedPrivateSet<Note, Context> {
-        OwnedPrivateSet::new(self.context, owner, self.storage_slot)
-    }
-}
-
-/// A view of notes in a PrivateSet belonging to a specific `owner`.
-/// Obtained by calling `PrivateSet::at(owner)`.
-pub struct OwnedPrivateSet<Note, Context> {
-    pub context: Context,
     pub owner: AztecAddress,
-    pub storage_slot: Field,
 }
 
-impl<Note, Context> OwnedPrivateSet<Note, Context> {
-    fn new(context: Context, owner: AztecAddress, storage_slot: Field) -> Self {
-        assert(storage_slot != 0, "Storage slot 0 not allowed. Storage slots must start from 1.");
-        OwnedPrivateSet { context, owner, storage_slot }
+impl<Note, Context> OwnedStateVariable<Context> for PrivateSet<Note, Context> {
+    fn new(context: Context, storage_slot: Field, owner: AztecAddress) -> Self {
+        Self { context, storage_slot, owner }
     }
 }
 
-impl<Note> OwnedPrivateSet<Note, &mut PrivateContext>
+impl<Note> PrivateSet<Note, &mut PrivateContext>
 where
     Note: NoteType + NoteHash + Eq,
 {
@@ -406,7 +333,7 @@ where
         destroy_note_unsafe(self.context, retrieved_note, self.owner, note_hash_read);
     }
 
-    /// Returns a collection of which belong to this PrivateSet.
+    /// Returns a filtered collection of notes from the set.
     ///
     /// DANGER: the returned notes do not get nullified within this `get_notes`
     /// function, and so they cannot necessarily be considered "current" notes.
@@ -477,7 +404,7 @@ where
     }
 }
 
-impl<Note> OwnedPrivateSet<Note, UtilityContext>
+impl<Note> PrivateSet<Note, UtilityContext>
 where
     Note: NoteType + NoteHash + Eq,
 {

--- a/noir-projects/aztec-nr/aztec/src/state_vars/private_set/test.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/private_set/test.nr
@@ -1,7 +1,7 @@
 use crate::{
     context::{PrivateContext, UtilityContext},
     note::{note_getter_options::NoteGetterOptions, note_viewer_options::NoteViewerOptions},
-    state_vars::private_set::PrivateSet,
+    state_vars::{owned_state_variable::OwnedStateVariable, private_set::PrivateSet},
 };
 use crate::test::{helpers::test_environment::TestEnvironment, mocks::mock_note::MockNote};
 use protocol_types::{address::AztecAddress, traits::FromField};
@@ -13,11 +13,11 @@ global VALUE: Field = 23;
 unconstrained fn in_private(
     context: &mut PrivateContext,
 ) -> PrivateSet<MockNote, &mut PrivateContext> {
-    PrivateSet::new(context, STORAGE_SLOT)
+    PrivateSet::new(context, STORAGE_SLOT, OWNER)
 }
 
 unconstrained fn in_utility(context: UtilityContext) -> PrivateSet<MockNote, UtilityContext> {
-    PrivateSet::new(context, STORAGE_SLOT)
+    PrivateSet::new(context, STORAGE_SLOT, OWNER)
 }
 
 #[test]
@@ -25,7 +25,7 @@ unconstrained fn get_empty() {
     let env = TestEnvironment::new();
 
     env.private_context(|context| {
-        let state_var = in_private(context).at(OWNER);
+        let state_var = in_private(context);
         let notes = state_var.get_notes(NoteGetterOptions::new());
 
         assert_eq(notes.len(), 0);
@@ -39,7 +39,7 @@ unconstrained fn view_empty() {
     let env = TestEnvironment::new();
 
     env.utility_context(|context| {
-        let state_var = in_utility(context).at(OWNER);
+        let state_var = in_utility(context);
 
         let notes = state_var.view_notes(NoteViewerOptions::new());
         assert_eq(notes.len(), 0);
@@ -50,7 +50,7 @@ unconstrained fn view_empty() {
 unconstrained fn insert() {
     let env = TestEnvironment::new();
     env.private_context(|context| {
-        let state_var = in_private(context).at(OWNER);
+        let state_var = in_private(context);
 
         let value = 42;
         let new_note = MockNote::new(value).build_note();
@@ -70,7 +70,7 @@ unconstrained fn insert_and_get_pending() {
     let env = TestEnvironment::new();
 
     env.private_context(|context| {
-        let state_var = in_private(context).at(OWNER);
+        let state_var = in_private(context);
 
         let note = MockNote::new(VALUE).build_note();
         let _ = state_var.insert(note);
@@ -97,7 +97,7 @@ unconstrained fn insert_and_get_settled() {
     let note = MockNote::new(VALUE).build_note();
 
     let emission = env.private_context(|context| {
-        let state_var = in_private(context).at(OWNER);
+        let state_var = in_private(context);
 
         state_var.insert(note)
     });
@@ -105,7 +105,7 @@ unconstrained fn insert_and_get_settled() {
     env.discover_note(emission);
 
     env.private_context(|context| {
-        let state_var = in_private(context).at(OWNER);
+        let state_var = in_private(context);
 
         let notes = state_var.get_notes(NoteGetterOptions::new());
 
@@ -129,7 +129,7 @@ unconstrained fn insert_and_view_settled() {
     let note = MockNote::new(VALUE).build_note();
 
     let emission = env.private_context(|context| {
-        let state_var = in_private(context).at(OWNER);
+        let state_var = in_private(context);
 
         state_var.insert(note)
     });
@@ -137,7 +137,7 @@ unconstrained fn insert_and_view_settled() {
     env.discover_note(emission);
 
     env.utility_context(|context| {
-        let state_var = in_utility(context).at(OWNER);
+        let state_var = in_utility(context);
 
         let notes = state_var.view_notes(NoteViewerOptions::new());
 
@@ -151,7 +151,7 @@ unconstrained fn insert_and_pop_pending() {
     let env = TestEnvironment::new();
 
     env.private_context(|context| {
-        let state_var = in_private(context).at(OWNER);
+        let state_var = in_private(context);
 
         let note = MockNote::new(VALUE).build_note();
         let _ = state_var.insert(note);
@@ -174,7 +174,7 @@ unconstrained fn insert_and_pop_settled() {
     let note = MockNote::new(VALUE).build_note();
 
     let emission = env.private_context(|context| {
-        let state_var = in_private(context).at(OWNER);
+        let state_var = in_private(context);
 
         state_var.insert(note)
     });
@@ -182,7 +182,7 @@ unconstrained fn insert_and_pop_settled() {
     env.discover_note(emission);
 
     env.private_context(|context| {
-        let state_var = in_private(context).at(OWNER);
+        let state_var = in_private(context);
 
         let notes = state_var.pop_notes(NoteGetterOptions::new());
 
@@ -200,7 +200,7 @@ unconstrained fn insert_and_remove_pending() {
     let env = TestEnvironment::new();
 
     env.private_context(|context| {
-        let state_var = in_private(context).at(OWNER);
+        let state_var = in_private(context);
 
         let note = MockNote::new(VALUE).build_note();
         let _ = state_var.insert(note);
@@ -221,14 +221,14 @@ unconstrained fn insert_and_remove_settled() {
     let note = MockNote::new(VALUE).build_note();
 
     let emission = env.private_context(|context| {
-        let state_var = in_private(context).at(OWNER);
+        let state_var = in_private(context);
         state_var.insert(note)
     });
 
     env.discover_note(emission);
 
     env.private_context(|context| {
-        let state_var = in_private(context).at(OWNER);
+        let state_var = in_private(context);
 
         let retrieved = state_var.get_notes(NoteGetterOptions::new());
 
@@ -244,7 +244,7 @@ unconstrained fn insert_pop_and_read_again_pending() {
     let env = TestEnvironment::new();
 
     env.private_context(|context| {
-        let state_var = in_private(context).at(OWNER);
+        let state_var = in_private(context);
 
         let note = MockNote::new(VALUE).build_note();
         let _ = state_var.insert(note);
@@ -264,7 +264,7 @@ unconstrained fn insert_pop_and_read_again_settled() {
     let note = MockNote::new(VALUE).build_note();
 
     let emission = env.private_context(|context| {
-        let state_var = in_private(context).at(OWNER);
+        let state_var = in_private(context);
 
         state_var.insert(note)
     });
@@ -272,7 +272,7 @@ unconstrained fn insert_pop_and_read_again_settled() {
     env.discover_note(emission);
 
     env.private_context(|context| {
-        let state_var = in_private(context).at(OWNER);
+        let state_var = in_private(context);
 
         let _ = state_var.pop_notes(NoteGetterOptions::new());
 
@@ -287,7 +287,7 @@ unconstrained fn insert_remove_and_read_again_pending() {
     let env = TestEnvironment::new();
 
     env.private_context(|context| {
-        let state_var = in_private(context).at(OWNER);
+        let state_var = in_private(context);
 
         let note = MockNote::new(VALUE).build_note();
         let _ = state_var.insert(note);
@@ -308,7 +308,7 @@ unconstrained fn insert_remove_and_read_again_settled() {
     let note = MockNote::new(VALUE).build_note();
 
     let emission = env.private_context(|context| {
-        let state_var = in_private(context).at(OWNER);
+        let state_var = in_private(context);
 
         state_var.insert(note)
     });
@@ -316,7 +316,7 @@ unconstrained fn insert_remove_and_read_again_settled() {
     env.discover_note(emission);
 
     env.private_context(|context| {
-        let state_var = in_private(context).at(OWNER);
+        let state_var = in_private(context);
 
         let retrieved = state_var.get_notes(NoteGetterOptions::new());
         state_var.remove(retrieved.get(0));

--- a/noir-projects/aztec-nr/aztec/src/state_vars/public_immutable.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/public_immutable.nr
@@ -1,6 +1,6 @@
 use crate::{
     context::{PrivateContext, PublicContext, UtilityContext},
-    state_vars::storage::HasStorageSlot,
+    state_vars::state_variable::StateVariable,
     utils::with_hash::WithHash,
 };
 use protocol_types::{
@@ -69,42 +69,21 @@ pub struct PublicImmutable<T, Context> {
 
 /// `PublicImmutable` stores both the packed value (using M fields) and its hash (1 field), requiring M + 1 total
 /// fields.
-impl<T, Context, let M: u32> HasStorageSlot<M + 1> for PublicImmutable<T, Context>
+impl<T, Context, let M: u32> StateVariable<M + 1, Context> for PublicImmutable<T, Context>
 where
     T: Packable<N = M>,
 {
+    fn new(context: Context, storage_slot: Field) -> Self {
+        assert(storage_slot != 0, "Storage slot 0 not allowed. Storage slots must start from 1.");
+        PublicImmutable { context, storage_slot }
+    }
+
     fn get_storage_slot(self) -> Field {
         self.storage_slot
     }
 }
 
 impl<T, Context> PublicImmutable<T, Context> {
-    /// Initializes a new PublicImmutable state variable.
-    ///
-    /// This function is usually automatically called within the #[storage] macro.
-    /// You typically don't need to call this directly when writing smart contracts.
-    ///
-    /// # Arguments
-    ///
-    /// * `context` - One of `PublicContext`/`PrivateContext`/`UtilityContext`. The
-    ///               Context determines which methods of this struct will be made
-    ///               available to the calling smart contract function.
-    /// * `storage_slot` - A unique identifier for this state variable within the
-    ///                    contract. Usually, the #[storage] macro will determine an
-    ///                    appropriate storage_slot automatically. A smart contract
-    ///                    dev shouldn't have to worry about this, as it's managed
-    ///                    behind the scenes.
-    ///
-    /// docs:start:public_immutable_struct_new
-    pub fn new(
-        // Note: Passing the contexts to new(...) just to have an interface compatible with a Map.
-        context: Context,
-        storage_slot: Field,
-    ) -> Self {
-        assert(storage_slot != 0, "Storage slot 0 not allowed. Storage slots must start from 1.");
-        PublicImmutable { context, storage_slot }
-    }
-
     pub fn compute_initialization_nullifier(self) -> Field {
         poseidon2_hash_with_separator(
             [self.storage_slot],

--- a/noir-projects/aztec-nr/aztec/src/state_vars/public_mutable.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/public_mutable.nr
@@ -1,5 +1,5 @@
 use crate::context::{PublicContext, UtilityContext};
-use crate::state_vars::storage::HasStorageSlot;
+use crate::state_vars::state_variable::StateVariable;
 use dep::protocol_types::traits::Packable;
 
 /// # PublicMutable
@@ -43,40 +43,17 @@ pub struct PublicMutable<T, Context> {
     storage_slot: Field,
 }
 
-impl<T, Context, let M: u32> HasStorageSlot<M> for PublicMutable<T, Context>
+impl<T, Context, let M: u32> StateVariable<M, Context> for PublicMutable<T, Context>
 where
     T: Packable<N = M>,
 {
-    fn get_storage_slot(self) -> Field {
-        self.storage_slot
-    }
-}
-
-impl<T, Context> PublicMutable<T, Context> {
-    /// Initializes a new PublicMutable state variable.
-    ///
-    /// This function is usually automatically called within the #[storage] macro.
-    /// You typically don't need to call this directly when writing smart contracts.
-    ///
-    /// # Arguments
-    ///
-    /// * `context` - One of `PublicContext`/`UtilityContext`. The Context determines
-    ///               which methods of this struct will be made available to the calling
-    ///               smart contract function.
-    /// * `storage_slot` - A unique identifier for this state variable within the
-    ///                    contract. Usually, the #[storage] macro will determine an
-    ///                    appropriate storage_slot automatically. A smart contract
-    ///                    dev shouldn't have to worry about this, as it's managed
-    ///                    behind the scenes.
-    ///
-    /// docs:start:public_mutable_struct_new
-    pub fn new(
-        // Note: Passing the contexts to new(...) just to have an interface compatible with a Map.
-        context: Context,
-        storage_slot: Field,
-    ) -> Self {
+    fn new(context: Context, storage_slot: Field) -> Self {
         assert(storage_slot != 0, "Storage slot 0 not allowed. Storage slots must start from 1.");
         PublicMutable { context, storage_slot }
+    }
+
+    fn get_storage_slot(self) -> Field {
+        self.storage_slot
     }
 }
 

--- a/noir-projects/aztec-nr/aztec/src/state_vars/state_variable.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/state_variable.nr
@@ -1,0 +1,23 @@
+/// A trait that defines the common interface for all Aztec state variables. State variables are variables that can be
+/// stored in the contract's storage. Examples of state variables are `Owned`, `PublicMutable`, `Map` or
+/// `DelayedPublicMutable`.
+///
+/// # Type Parameters
+///
+/// * `N` - A compile-time constant that determines how many storage slots need to be reserved for this state variable.
+/// * `Context` - The execution context type (e.g., `PublicContext`, `PrivateContext`, `UtilityContext`). The context
+///               determines which methods of the state variable are available and controls whether the variable can
+///               be accessed in public, private or utility functions.
+///
+pub trait StateVariable<let N: u32, Context> {
+    /// Initializes a new state variable at a given storage slot.
+    ///
+    /// This function is automatically called within the #[storage] macro and needs to be manually called only when
+    /// #[storage_no_init] is used.
+    ///
+    fn new(context: Context, storage_slot: Field) -> Self;
+
+    /// Returns the storage slot at which the state variable is placed. Typically used only when testing the contract or
+    /// when using a lower-level API like `get_notes` function.
+    fn get_storage_slot(self) -> Field;
+}

--- a/noir-projects/aztec-nr/aztec/src/state_vars/storage.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/storage.nr
@@ -1,8 +1,5 @@
-/// State variables must implement this trait in order to placed in the storage struct (i.e. the one marked with the
-/// #[storage] attribute). The `N` value determines how many storage slots will be reserved for the state variable.
-pub trait HasStorageSlot<let N: u32> {
-    fn get_storage_slot(self) -> Field;
-}
+// TODO(benesjan): This is just for the macro-generated StorageLayout struct. It seems strange to have it here and
+// the file needs renaming to storable.nr.
 
 // Struct representing an exportable storage variable in the contract
 // Every entry in the storage struct will be exported in the compilation artifact as a

--- a/noir-projects/aztec-nr/easy-private-state/src/easy_private_uint.nr
+++ b/noir-projects/aztec-nr/easy-private-state/src/easy_private_uint.nr
@@ -3,7 +3,7 @@ use aztec::{
     messages::message_delivery::MessageDelivery,
     note::note_getter_options::NoteGetterOptions,
     protocol_types::address::AztecAddress,
-    state_vars::{PrivateSet, storage::HasStorageSlot},
+    state_vars::{Owned, PrivateSet, state_variable::StateVariable},
 };
 use value_note::{balance_utils, filter::filter_notes_min_sum, value_note::ValueNote};
 
@@ -19,19 +19,17 @@ use value_note::{balance_utils, filter::filter_notes_min_sum, value_note::ValueN
 /// - Decremented by the owner of the private state.
 pub struct EasyPrivateUint<Context> {
     context: Context,
-    set: PrivateSet<ValueNote, Context>,
+    set: Owned<PrivateSet<ValueNote, Context>, Context>,
 }
 
 // TODO(#13824): remove this impl once we allow structs to hold state variables.
-impl<Context> HasStorageSlot<1> for EasyPrivateUint<Context> {
+impl<Context> StateVariable<1, Context> for EasyPrivateUint<Context> {
+    fn new(context: Context, storage_slot: Field) -> Self {
+        EasyPrivateUint { context, set: Owned::new(context, storage_slot) }
+    }
+
     fn get_storage_slot(self) -> Field {
         self.set.get_storage_slot()
-    }
-}
-
-impl<Context> EasyPrivateUint<Context> {
-    pub fn new(context: Context, storage_slot: Field) -> Self {
-        EasyPrivateUint { context, set: PrivateSet::new(context, storage_slot) }
     }
 }
 

--- a/noir-projects/aztec-nr/value-note/src/balance_utils.nr
+++ b/noir-projects/aztec-nr/value-note/src/balance_utils.nr
@@ -3,12 +3,12 @@ use dep::aztec::{
     context::UtilityContext,
     note::note_viewer_options::NoteViewerOptions,
     protocol_types::address::AztecAddress,
-    state_vars::private_set::{OwnedPrivateSet, PrivateSet},
+    state_vars::{owned::Owned, private_set::PrivateSet},
 };
 
 // DEPRECATED: Having this functionality in the value note package is incorrect and will be removed in the future.
 pub unconstrained fn get_balance(
-    set: PrivateSet<ValueNote, UtilityContext>,
+    set: Owned<PrivateSet<ValueNote, UtilityContext>, UtilityContext>,
     owner: AztecAddress,
 ) -> Field {
     get_balance_with_offset(set.at(owner), 0)
@@ -16,7 +16,7 @@ pub unconstrained fn get_balance(
 
 // DEPRECATED: Having this functionality in the value note package is incorrect and will be removed in the future.
 unconstrained fn get_balance_with_offset(
-    set: OwnedPrivateSet<ValueNote, UtilityContext>,
+    set: PrivateSet<ValueNote, UtilityContext>,
     offset: u32,
 ) -> Field {
     let mut balance = 0;

--- a/noir-projects/noir-contracts-comp-failures/contracts/panic_on_non_state_var_in_storage/Nargo.toml
+++ b/noir-projects/noir-contracts-comp-failures/contracts/panic_on_non_state_var_in_storage/Nargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "panic_on_non_state_var_in_storage"
+authors = [""]
+compiler_version = ">=0.25.0"
+type = "contract"
+
+[dependencies]
+aztec = { path = "../../../aztec-nr/aztec" }

--- a/noir-projects/noir-contracts-comp-failures/contracts/panic_on_non_state_var_in_storage/expected_error
+++ b/noir-projects/noir-contracts-comp-failures/contracts/panic_on_non_state_var_in_storage/expected_error
@@ -1,0 +1,1 @@
+Type NonStateVar does not implement StateVariable and hence cannot be placed in Storage struct.

--- a/noir-projects/noir-contracts-comp-failures/contracts/panic_on_non_state_var_in_storage/src/main.nr
+++ b/noir-projects/noir-contracts-comp-failures/contracts/panic_on_non_state_var_in_storage/src/main.nr
@@ -1,0 +1,19 @@
+use aztec::macros::aztec;
+
+// Should fail to compile because only structs that implement StateVariable can be placed in storage.
+#[aztec]
+pub contract PanicOnNonStateVarInStorage {
+    use aztec::macros::{functions::external, storage::storage};
+
+    struct NonStateVar {
+        field: Field,
+    }
+
+    #[storage]
+    struct Storage<Context> {
+        non_state_var: NonStateVar,
+    }
+
+    #[external("private")]
+    fn arbitrary_external_function() {}
+}

--- a/noir-projects/noir-contracts-comp-failures/contracts/panic_on_owned_state_var_in_storage/Nargo.toml
+++ b/noir-projects/noir-contracts-comp-failures/contracts/panic_on_owned_state_var_in_storage/Nargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "panic_on_owned_state_var_in_storage"
+authors = [""]
+compiler_version = ">=0.25.0"
+type = "contract"
+
+[dependencies]
+aztec = { path = "../../../aztec-nr/aztec" }

--- a/noir-projects/noir-contracts-comp-failures/contracts/panic_on_owned_state_var_in_storage/expected_error
+++ b/noir-projects/noir-contracts-comp-failures/contracts/panic_on_owned_state_var_in_storage/expected_error
@@ -1,0 +1,1 @@
+Type PrivateImmutable<Field, Context> implements OwnedStateVariable and hence cannot be placed in Storage struct without being wrapped in Owned. Define the type in storage as Owned<PrivateImmutable<Field, Context><..., Context>>, Context>.

--- a/noir-projects/noir-contracts-comp-failures/contracts/panic_on_owned_state_var_in_storage/src/main.nr
+++ b/noir-projects/noir-contracts-comp-failures/contracts/panic_on_owned_state_var_in_storage/src/main.nr
@@ -1,0 +1,15 @@
+use aztec::macros::aztec;
+
+// Should fail to compile because OwnedStateVariable must be wrapped in Owned when placed in storage.
+#[aztec]
+pub contract PanicOnOwnedStateVarInStorage {
+    use aztec::{macros::{functions::external, storage::storage}, state_vars::PrivateImmutable};
+
+    #[storage]
+    struct Storage<Context> {
+        owned_state_var: PrivateImmutable<Field, Context>,
+    }
+
+    #[external("private")]
+    fn arbitrary_external_function() {}
+}

--- a/noir-projects/noir-contracts/contracts/account/ecdsa_k_account_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/account/ecdsa_k_account_contract/src/main.nr
@@ -13,14 +13,14 @@ pub contract EcdsaKAccount {
         },
         messages::message_delivery::MessageDelivery,
         oracle::{auth_witness::get_auth_witness, notes::{get_sender_for_tags, set_sender_for_tags}},
-        state_vars::PrivateImmutable,
+        state_vars::{Owned, PrivateImmutable},
     };
 
     use dep::ecdsa_public_key_note::EcdsaPublicKeyNote;
 
     #[storage]
     struct Storage<Context> {
-        signing_public_key: PrivateImmutable<EcdsaPublicKeyNote, Context>,
+        signing_public_key: Owned<PrivateImmutable<EcdsaPublicKeyNote, Context>, Context>,
     }
 
     // Creates a new account out of an ECDSA public key to use for signature verification

--- a/noir-projects/noir-contracts/contracts/account/ecdsa_r_account_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/account/ecdsa_r_account_contract/src/main.nr
@@ -12,14 +12,14 @@ pub contract EcdsaRAccount {
         },
         messages::message_delivery::MessageDelivery,
         oracle::{auth_witness::get_auth_witness, notes::{get_sender_for_tags, set_sender_for_tags}},
-        state_vars::PrivateImmutable,
+        state_vars::{Owned, PrivateImmutable},
     };
 
     use dep::ecdsa_public_key_note::EcdsaPublicKeyNote;
 
     #[storage]
     struct Storage<Context> {
-        signing_public_key: PrivateImmutable<EcdsaPublicKeyNote, Context>,
+        signing_public_key: Owned<PrivateImmutable<EcdsaPublicKeyNote, Context>, Context>,
     }
 
     // Creates a new account out of an ECDSA public key to use for signature verification

--- a/noir-projects/noir-contracts/contracts/account/schnorr_account_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/account/schnorr_account_contract/src/main.nr
@@ -25,7 +25,7 @@ pub contract SchnorrAccount {
             notes::{get_sender_for_tags, set_sender_for_tags},
         },
         protocol_types::address::AztecAddress,
-        state_vars::PrivateImmutable,
+        state_vars::{Owned, PrivateImmutable},
     };
 
     use crate::public_key_note::PublicKeyNote;
@@ -33,7 +33,7 @@ pub contract SchnorrAccount {
     #[storage]
     struct Storage<Context> {
         // docs:start:public_key
-        signing_public_key: PrivateImmutable<PublicKeyNote, Context>,
+        signing_public_key: Owned<PrivateImmutable<PublicKeyNote, Context>, Context>,
         // docs:end:public_key
     }
 

--- a/noir-projects/noir-contracts/contracts/app/app_subscription_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/app_subscription_contract/src/main.nr
@@ -48,7 +48,7 @@ pub contract AppSubscription {
         messages::message_delivery::MessageDelivery,
         oracle::notes::set_sender_for_tags,
         protocol_types::address::AztecAddress,
-        state_vars::{PrivateMutable, PublicImmutable},
+        state_vars::{Owned, PrivateMutable, PublicImmutable},
         utils::comparison::Comparator,
     };
     use router::utils::privately_check_block_number;
@@ -57,7 +57,7 @@ pub contract AppSubscription {
     #[storage]
     struct Storage<Context> {
         config: PublicImmutable<Config, Context>,
-        subscriptions: PrivateMutable<SubscriptionNote, Context>,
+        subscriptions: Owned<PrivateMutable<SubscriptionNote, Context>, Context>,
     }
 
     global SUBSCRIPTION_DURATION_IN_BLOCKS: u32 = 5;

--- a/noir-projects/noir-contracts/contracts/app/card_game_contract/src/cards.nr
+++ b/noir-projects/noir-contracts/contracts/app/card_game_contract/src/cards.nr
@@ -11,7 +11,7 @@ use aztec::{
         constants::MAX_NOTE_HASH_READ_REQUESTS_PER_CALL,
         traits::{FromField, Hash, Packable, Serialize, ToField},
     },
-    state_vars::{PrivateSet, storage::HasStorageSlot},
+    state_vars::{Owned, PrivateSet, StateVariable},
 };
 use std::meta::derive;
 use value_note::value_note::ValueNote;
@@ -66,13 +66,17 @@ impl CardNote {
 }
 
 pub struct Deck<Context> {
-    set: PrivateSet<ValueNote, Context>,
+    owned_set: Owned<PrivateSet<ValueNote, Context>, Context>,
 }
 
 // TODO(#13824): remove this impl once we allow structs to hold state variables.
-impl<Context> HasStorageSlot<1> for Deck<Context> {
+impl<Context> StateVariable<1, Context> for Deck<Context> {
+    fn new(context: Context, storage_slot: Field) -> Self {
+        Deck { owned_set: Owned::new(context, storage_slot) }
+    }
+
     fn get_storage_slot(self) -> Field {
-        self.set.get_storage_slot()
+        self.owned_set.get_storage_slot()
     }
 }
 
@@ -104,8 +108,8 @@ pub fn filter_cards<let N: u32>(
 
 impl<Context> Deck<Context> {
     pub fn new(context: Context, storage_slot: Field) -> Self {
-        let set = PrivateSet { context, storage_slot };
-        Deck { set }
+        let owned_set = Owned::new(context, storage_slot);
+        Deck { owned_set }
     }
 }
 
@@ -114,7 +118,7 @@ impl Deck<&mut PrivateContext> {
         let mut inserted_cards = &[];
         for card in cards {
             let card_note = CardNote::from_card(card);
-            self.set.at(owner).insert(card_note.note).emit(
+            self.owned_set.at(owner).insert(card_note.note).emit(
                 owner,
                 MessageDelivery.CONSTRAINED_ONCHAIN,
             );
@@ -126,7 +130,7 @@ impl Deck<&mut PrivateContext> {
 
     pub fn remove_cards<let N: u32>(&mut self, cards: [Card; N], owner: AztecAddress) {
         let options = NoteGetterOptions::with_filter(filter_cards, cards);
-        let notes = self.set.at(owner).pop_notes(options);
+        let notes = self.owned_set.at(owner).pop_notes(options);
         assert(notes.len() == N, "Not all cards were removed");
     }
 }
@@ -138,7 +142,7 @@ impl Deck<UtilityContext> {
         offset: u32,
     ) -> BoundedVec<Card, MAX_NOTES_PER_PAGE> {
         let mut options = NoteViewerOptions::new();
-        let notes = self.set.at(owner).view_notes(options.set_offset(offset));
+        let notes = self.owned_set.at(owner).view_notes(options.set_offset(offset));
 
         notes.map(|note| Card::from_field(note.value()))
     }

--- a/noir-projects/noir-contracts/contracts/app/crowdfunding_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/crowdfunding_contract/src/main.nr
@@ -9,7 +9,7 @@ pub contract Crowdfunding {
         macros::{events::event, functions::{external, initializer, only_self}, storage::storage},
         messages::message_delivery::MessageDelivery,
         protocol_types::address::AztecAddress,
-        state_vars::{PrivateSet, PublicImmutable, storage::HasStorageSlot},
+        state_vars::{Owned, PrivateSet, PublicImmutable, state_variable::StateVariable},
         utils::{array, comparison::Comparator},
     };
     use aztec::note::{
@@ -30,7 +30,7 @@ pub contract Crowdfunding {
     struct Storage<Context> {
         config: PublicImmutable<Config, Context>,
         // Notes emitted to donors when they donate (can be used as proof to obtain rewards, eg in Claim contracts)
-        donation_receipts: PrivateSet<UintNote, Context>,
+        donation_receipts: Owned<PrivateSet<UintNote, Context>, Context>,
     }
     // docs:end:storage
 

--- a/noir-projects/noir-contracts/contracts/app/escrow_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/escrow_contract/src/main.nr
@@ -7,7 +7,7 @@ pub contract Escrow {
         macros::{functions::{external, initializer}, storage::storage},
         messages::message_delivery::MessageDelivery,
         protocol_types::address::AztecAddress,
-        state_vars::PrivateImmutable,
+        state_vars::{Owned, PrivateImmutable},
     };
 
     use address_note::address_note::AddressNote;
@@ -15,7 +15,7 @@ pub contract Escrow {
 
     #[storage]
     struct Storage<Context> {
-        owner: PrivateImmutable<AddressNote, Context>,
+        owner: Owned<PrivateImmutable<AddressNote, Context>, Context>,
     }
 
     // Creates a new instance

--- a/noir-projects/noir-contracts/contracts/app/nft_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/nft_contract/src/main.nr
@@ -21,7 +21,7 @@ pub contract NFT {
             note_interface::NoteProperties, note_viewer_options::NoteViewerOptions,
         },
         protocol_types::{address::AztecAddress, traits::ToField},
-        state_vars::{Map, PrivateSet, PublicImmutable, PublicMutable},
+        state_vars::{Map, Owned, PrivateSet, PublicImmutable, PublicMutable},
         utils::comparison::Comparator,
     };
     use compressed_string::FieldCompressedString;
@@ -49,7 +49,7 @@ pub contract NFT {
         // Addresses that can mint
         minters: Map<AztecAddress, PublicMutable<bool, Context>, Context>,
         // Contains the NFTs owned by each address in private.
-        private_nfts: PrivateSet<NFTNote, Context>,
+        private_nfts: Owned<PrivateSet<NFTNote, Context>, Context>,
         // A map from token ID to a boolean indicating if the NFT exists.
         nft_exists: Map<Field, PublicMutable<bool, Context>, Context>,
         // A map from token ID to the public owner of the NFT.

--- a/noir-projects/noir-contracts/contracts/app/simple_token_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/simple_token_contract/src/main.nr
@@ -22,7 +22,7 @@ pub contract SimpleToken {
         },
         messages::message_delivery::MessageDelivery,
         protocol_types::address::AztecAddress,
-        state_vars::{Map, PublicImmutable, PublicMutable},
+        state_vars::{Map, Owned, PublicImmutable, PublicMutable, state_variable::StateVariable},
     };
 
     use uint_note::uint_note::{PartialUintNote, UintNote};
@@ -41,7 +41,7 @@ pub contract SimpleToken {
 
     #[storage]
     struct Storage<Context> {
-        balances: BalanceSet<Context>,
+        balances: Owned<BalanceSet<Context>, Context>,
         total_supply: PublicMutable<u128, Context>,
         public_balances: Map<AztecAddress, PublicMutable<u128, Context>, Context>,
         symbol: PublicImmutable<FieldCompressedString, Context>,
@@ -165,7 +165,7 @@ pub contract SimpleToken {
     fn _prepare_private_balance_increase(to: AztecAddress) -> PartialUintNote {
         let partial_note = UintNote::partial(
             to,
-            self.storage.balances.set.storage_slot,
+            self.storage.balances.get_storage_slot(),
             self.context,
             to,
             self.context.msg_sender().unwrap(),

--- a/noir-projects/noir-contracts/contracts/app/simple_token_contract/src/types/balance_set.nr
+++ b/noir-projects/noir-contracts/contracts/app/simple_token_contract/src/types/balance_set.nr
@@ -7,44 +7,22 @@ use dep::aztec::{
     protocol_types::{
         address::AztecAddress, constants::MAX_NOTE_HASH_READ_REQUESTS_PER_CALL, traits::Packable,
     },
-    state_vars::{private_set::OwnedPrivateSet, PrivateSet, storage::HasStorageSlot},
+    state_vars::{owned_state_variable::OwnedStateVariable, PrivateSet},
 };
 use dep::uint_note::uint_note::UintNote;
 use std::ops::Add;
 
 pub struct BalanceSet<Context> {
-    pub set: PrivateSet<UintNote, Context>,
+    set: PrivateSet<UintNote, Context>,
 }
 
-// TODO(#13824): remove this impl once we allow structs to hold state variables.
-impl<Context> HasStorageSlot<1> for BalanceSet<Context> {
-    fn get_storage_slot(self) -> Field {
-        self.set.get_storage_slot()
+impl<Context> OwnedStateVariable<Context> for BalanceSet<Context> {
+    fn new(context: Context, storage_slot: Field, owner: AztecAddress) -> Self {
+        Self { set: PrivateSet::new(context, storage_slot, owner) }
     }
 }
 
-impl<Context> BalanceSet<Context> {
-    pub fn new(context: Context, storage_slot: Field) -> Self {
-        assert(storage_slot != 0, "Storage slot 0 not allowed. Storage slots must start from 1.");
-        Self { set: PrivateSet::new(context, storage_slot) }
-    }
-
-    pub fn at(self, owner: AztecAddress) -> OwnedBalanceSet<Context> {
-        OwnedBalanceSet::new(self.set.at(owner))
-    }
-}
-
-pub struct OwnedBalanceSet<Context> {
-    owned_set: OwnedPrivateSet<UintNote, Context>,
-}
-
-impl<Context> OwnedBalanceSet<Context> {
-    pub fn new(owned_set: OwnedPrivateSet<UintNote, Context>) -> Self {
-        Self { owned_set }
-    }
-}
-
-impl OwnedBalanceSet<UtilityContext> {
+impl BalanceSet<UtilityContext> {
     pub unconstrained fn balance_of(self: Self) -> u128 {
         self.balance_of_with_offset(0)
     }
@@ -52,7 +30,7 @@ impl OwnedBalanceSet<UtilityContext> {
     pub unconstrained fn balance_of_with_offset(self: Self, offset: u32) -> u128 {
         let mut balance = 0 as u128;
         let mut options = NoteViewerOptions::<UintNote, <UintNote as Packable>::N>::new();
-        let notes = self.owned_set.view_notes(options.set_offset(offset));
+        let notes = self.set.view_notes(options.set_offset(offset));
         for i in 0..options.limit {
             if i < notes.len() {
                 balance = balance + notes.get_unchecked(i).get_value();
@@ -66,17 +44,17 @@ impl OwnedBalanceSet<UtilityContext> {
     }
 }
 
-impl OwnedBalanceSet<&mut PrivateContext> {
+impl BalanceSet<&mut PrivateContext> {
     pub fn add(self: Self, addend: u128) -> OuterNoteEmission<UintNote> {
         let content = if addend == 0 as u128 {
             Option::none()
         } else {
             let addend_note = UintNote::new(addend);
 
-            Option::some(self.owned_set.insert(addend_note).content)
+            Option::some(self.set.insert(addend_note).content)
         };
 
-        OuterNoteEmission::new(content, self.owned_set.context)
+        OuterNoteEmission::new(content, self.set.context)
     }
 
     pub fn sub(self: Self, amount: u128) -> OuterNoteEmission<UintNote> {
@@ -105,7 +83,7 @@ impl OwnedBalanceSet<&mut PrivateContext> {
         // about proving optimal note usage, we can save these constraints and make the circuit smaller.
         let options = NoteGetterOptions::with_preprocessor(preprocess_notes_min_sum, target_amount)
             .set_limit(max_notes);
-        let notes = self.owned_set.pop_notes(options);
+        let notes = self.set.pop_notes(options);
 
         let mut subtracted = 0 as u128;
         for i in 0..options.limit {

--- a/noir-projects/noir-contracts/contracts/app/token_blacklist_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_blacklist_contract/src/main.nr
@@ -31,7 +31,7 @@ pub contract TokenBlacklist {
             note_interface::{NoteHash, NoteProperties, NoteType},
         },
         protocol_types::traits::ToField,
-        state_vars::{DelayedPublicMutable, Map, PrivateSet, PublicMutable},
+        state_vars::{DelayedPublicMutable, Map, Owned, PrivateSet, PublicMutable, StateVariable},
         utils::comparison::Comparator,
     };
 
@@ -57,7 +57,7 @@ pub contract TokenBlacklist {
     struct Storage<Context> {
         balances: BalancesMap<TokenNote, Context>,
         total_supply: PublicMutable<u128, Context>,
-        pending_shields: PrivateSet<TransparentNote, Context>,
+        pending_shields: Owned<PrivateSet<TransparentNote, Context>, Context>,
         public_balances: Map<AztecAddress, PublicMutable<u128, Context>, Context>,
         roles: Map<AztecAddress, DelayedPublicMutable<UserFlags, CHANGE_ROLES_DELAY, Context>, Context>,
     }
@@ -128,7 +128,7 @@ pub contract TokenBlacklist {
         // by anyone who has the secret (preimage of the secret_hash stored in the note).
         let note_hash = note.compute_note_hash(
             AztecAddress::zero(),
-            self.storage.pending_shields.storage_slot,
+            self.storage.pending_shields.get_storage_slot(),
             TRANSPARENT_NOTE_RANDOMNESS,
         );
         self.context.push_note_hash(note_hash);
@@ -152,7 +152,7 @@ pub contract TokenBlacklist {
         // by anyone who has the secret (preimage of the secret_hash stored in the note).
         let note_hash = note.compute_note_hash(
             AztecAddress::zero(),
-            self.storage.pending_shields.storage_slot,
+            self.storage.pending_shields.get_storage_slot(),
             TRANSPARENT_NOTE_RANDOMNESS,
         );
         self.context.push_note_hash(note_hash);

--- a/noir-projects/noir-contracts/contracts/app/token_blacklist_contract/src/types/balances_map.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_blacklist_contract/src/types/balances_map.nr
@@ -5,7 +5,7 @@ use dep::aztec::{
     protocol_types::{
         address::AztecAddress, constants::MAX_NOTE_HASH_READ_REQUESTS_PER_CALL, traits::Packable,
     },
-    state_vars::{PrivateSet, storage::HasStorageSlot},
+    state_vars::{Owned, PrivateSet, state_variable::StateVariable},
 };
 use dep::aztec::note::{
     note_interface::{NoteHash, NoteType},
@@ -16,20 +16,18 @@ use dep::aztec::note::{
 use std::ops::Add;
 
 pub struct BalancesMap<Note, Context> {
-    set: PrivateSet<Note, Context>,
+    set: Owned<PrivateSet<Note, Context>, Context>,
 }
 
 // TODO(#13824): remove this impl once we allow structs to hold state variables.
-impl<Note, Context> HasStorageSlot<1> for BalancesMap<Note, Context> {
+impl<Note, Context> StateVariable<1, Context> for BalancesMap<Note, Context> {
+    fn new(context: Context, storage_slot: Field) -> Self {
+        assert(storage_slot != 0, "Storage slot 0 not allowed. Storage slots must start from 1.");
+        Self { set: Owned::new(context, storage_slot) }
+    }
+
     fn get_storage_slot(self) -> Field {
         self.set.get_storage_slot()
-    }
-}
-
-impl<Note, Context> BalancesMap<Note, Context> {
-    pub fn new(context: Context, storage_slot: Field) -> Self {
-        assert(storage_slot != 0, "Storage slot 0 not allowed. Storage slots must start from 1.");
-        Self { set: PrivateSet::new(context, storage_slot) }
     }
 }
 

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/main.nr
@@ -27,7 +27,7 @@ pub contract Token {
         },
         messages::message_delivery::MessageDelivery,
         protocol_types::{address::AztecAddress, traits::ToField},
-        state_vars::{Map, PublicImmutable, PublicMutable},
+        state_vars::{Map, Owned, PublicImmutable, PublicMutable, StateVariable},
     };
 
     use uint_note::uint_note::{PartialUintNote, UintNote};
@@ -57,7 +57,7 @@ pub contract Token {
     struct Storage<Context> {
         admin: PublicMutable<AztecAddress, Context>,
         minters: Map<AztecAddress, PublicMutable<bool, Context>, Context>,
-        balances: BalanceSet<Context>,
+        balances: Owned<BalanceSet<Context>, Context>,
         total_supply: PublicMutable<u128, Context>,
         public_balances: Map<AztecAddress, PublicMutable<u128, Context>, Context>,
         symbol: PublicImmutable<FieldCompressedString, Context>,
@@ -346,7 +346,7 @@ pub contract Token {
     fn _prepare_private_balance_increase(to: AztecAddress) -> PartialUintNote {
         let partial_note = UintNote::partial(
             to,
-            self.storage.balances.set.storage_slot,
+            self.storage.balances.get_storage_slot(),
             self.context,
             to,
             self.msg_sender().unwrap(),

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/types/balance_set.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/types/balance_set.nr
@@ -10,44 +10,23 @@ use dep::aztec::{
     protocol_types::{
         address::AztecAddress, constants::MAX_NOTE_HASH_READ_REQUESTS_PER_CALL, traits::Packable,
     },
-    state_vars::{private_set::OwnedPrivateSet, PrivateSet, storage::HasStorageSlot},
+    state_vars::{owned_state_variable::OwnedStateVariable, PrivateSet},
 };
 use dep::uint_note::uint_note::UintNote;
 use std::ops::Add;
 
 pub struct BalanceSet<Context> {
-    pub set: PrivateSet<UintNote, Context>,
+    set: PrivateSet<UintNote, Context>,
 }
 
 // TODO(#13824): remove this impl once we allow structs to hold state variables.
-impl<Context> HasStorageSlot<1> for BalanceSet<Context> {
-    fn get_storage_slot(self) -> Field {
-        self.set.get_storage_slot()
+impl<Context> OwnedStateVariable<Context> for BalanceSet<Context> {
+    fn new(context: Context, storage_slot: Field, owner: AztecAddress) -> Self {
+        Self { set: PrivateSet::new(context, storage_slot, owner) }
     }
 }
 
-impl<Context> BalanceSet<Context> {
-    pub fn new(context: Context, storage_slot: Field) -> Self {
-        assert(storage_slot != 0, "Storage slot 0 not allowed. Storage slots must start from 1.");
-        Self { set: PrivateSet::new(context, storage_slot) }
-    }
-
-    pub fn at(self, owner: AztecAddress) -> OwnedBalanceSet<Context> {
-        OwnedBalanceSet::new(self.set.at(owner))
-    }
-}
-
-pub struct OwnedBalanceSet<Context> {
-    owned_set: OwnedPrivateSet<UintNote, Context>,
-}
-
-impl<Context> OwnedBalanceSet<Context> {
-    pub fn new(owned_set: OwnedPrivateSet<UintNote, Context>) -> Self {
-        Self { owned_set }
-    }
-}
-
-impl OwnedBalanceSet<UtilityContext> {
+impl BalanceSet<UtilityContext> {
     pub unconstrained fn balance_of(self: Self) -> u128 {
         self.balance_of_with_offset(0)
     }
@@ -55,7 +34,7 @@ impl OwnedBalanceSet<UtilityContext> {
     pub unconstrained fn balance_of_with_offset(self: Self, offset: u32) -> u128 {
         let mut balance = 0 as u128;
         let mut options = NoteViewerOptions::<UintNote, <UintNote as Packable>::N>::new();
-        let notes = self.owned_set.view_notes(options.set_offset(offset));
+        let notes = self.set.view_notes(options.set_offset(offset));
         for i in 0..options.limit {
             if i < notes.len() {
                 balance = balance + notes.get_unchecked(i).get_value();
@@ -69,17 +48,17 @@ impl OwnedBalanceSet<UtilityContext> {
     }
 }
 
-impl OwnedBalanceSet<&mut PrivateContext> {
+impl BalanceSet<&mut PrivateContext> {
     pub fn add(self: Self, addend: u128) -> OuterNoteEmission<UintNote> {
         let content = if addend == 0 as u128 {
             Option::none()
         } else {
             let addend_note = UintNote::new(addend);
 
-            Option::some(self.owned_set.insert(addend_note).content)
+            Option::some(self.set.insert(addend_note).content)
         };
 
-        OuterNoteEmission::new(content, self.owned_set.context)
+        OuterNoteEmission::new(content, self.set.context)
     }
 
     pub fn sub(self: Self, amount: u128) -> OuterNoteEmission<UintNote> {
@@ -109,7 +88,7 @@ impl OwnedBalanceSet<&mut PrivateContext> {
         let options = NoteGetterOptions::with_preprocessor(preprocess_notes_min_sum, target_amount)
             .sort(UintNote::properties().value, SortOrder.DESC)
             .set_limit(max_notes);
-        let notes = self.owned_set.pop_notes(options);
+        let notes = self.set.pop_notes(options);
 
         let mut subtracted = 0 as u128;
         for i in 0..options.limit {
@@ -151,6 +130,7 @@ pub fn preprocess_notes_min_sum(
 mod test {
     use crate::{test::utils, Token};
     use super::BalanceSet;
+    use aztec::state_vars::owned_state_variable::OwnedStateVariable;
 
     #[test]
     unconstrained fn subtract_balance_small_note_first() {
@@ -187,13 +167,13 @@ mod test {
             first_note_value + second_note_value,
         );
 
-        // We now instantiate a OwnedBalanceSet state variable for the recipient and subtract an amount equal to the smallest
+        // We now instantiate a BalanceSet state variable for the recipient and subtract an amount equal to the smallest
         // of the two notes. Because large notes are consumed first, we should see that a change note is created with
         // amount equal to large - small, indicating that the larger note was consumed regardless of the order in which
         // the notes were created.
         env.private_context_at(token_contract_address, |context| {
             let recipient_balance_set =
-                BalanceSet::new(context, Token::storage_layout().balances.slot).at(recipient);
+                BalanceSet::new(context, Token::storage_layout().balances.slot, recipient);
 
             let smaller_note_value = std::cmp::min(first_note_value, second_note_value);
             let larger_note_value = std::cmp::max(first_note_value, second_note_value);

--- a/noir-projects/noir-contracts/contracts/docs/docs_example_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/docs/docs_example_contract/src/main.nr
@@ -14,7 +14,8 @@ pub contract DocsExample {
         note::{note_interface::NoteProperties, note_viewer_options::NoteViewerOptions},
         protocol_types::address::AztecAddress,
         state_vars::{
-            Map, PrivateImmutable, PrivateMutable, PrivateSet, PublicImmutable, PublicMutable,
+            Map, Owned, PrivateImmutable, PrivateMutable, PrivateSet, PublicImmutable,
+            PublicMutable, StateVariable,
         },
     };
 
@@ -25,9 +26,9 @@ pub contract DocsExample {
     struct Storage<Context> {
         // Shows how to create a custom struct in PublicMutable
         leader: PublicMutable<Leader, Context>,
-        legendary_card: PrivateMutable<CardNote, Context>,
-        set: PrivateSet<CardNote, Context>,
-        private_immutable: PrivateImmutable<CardNote, Context>,
+        legendary_card: Owned<PrivateMutable<CardNote, Context>, Context>,
+        set: Owned<PrivateSet<CardNote, Context>, Context>,
+        private_immutable: Owned<PrivateImmutable<CardNote, Context>, Context>,
         public_immutable: PublicImmutable<Leader, Context>,
         minters: Map<AztecAddress, PublicMutable<bool, Context>, Context>,
     }
@@ -38,14 +39,13 @@ pub contract DocsExample {
         fn init(context: Context) -> Self {
             Storage {
                 leader: PublicMutable::new(context, 1),
-                legendary_card: PrivateMutable::new(context, 3),
-                set: PrivateSet::new(context, 5),
-                private_immutable: PrivateImmutable::new(context, 6),
+                legendary_card: Owned::new(context, 3),
+                set: Owned::new(context, 5),
+                private_immutable: Owned::new(context, 6),
                 public_immutable: PublicImmutable::new(context, 7),
-                minters: Map::new(
+                minters: Map::<AztecAddress, PublicMutable<bool, Context>, Context>::new(
                     context,
                     8,
-                    |context, slot| PublicMutable::new(context, slot),
                 ),
             }
         }

--- a/noir-projects/noir-contracts/contracts/test/avm_test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/avm_test_contract/src/main.nr
@@ -39,7 +39,7 @@ pub contract AvmTest {
     };
     use dep::aztec::state_vars::Map;
     use dep::aztec::state_vars::PublicMutable;
-    use dep::aztec::state_vars::storage::HasStorageSlot;
+    use dep::aztec::state_vars::state_variable::StateVariable;
     use dep::compressed_string::CompressedString;
     use aztec::protocol_types::traits::Serialize;
     use std::embedded_curve_ops::{EmbeddedCurvePoint, multi_scalar_mul};

--- a/noir-projects/noir-contracts/contracts/test/benchmarking_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/benchmarking_contract/src/main.nr
@@ -12,13 +12,13 @@ pub contract Benchmarking {
         messages::message_delivery::MessageDelivery,
         note::note_getter_options::NoteGetterOptions,
         protocol_types::address::AztecAddress,
-        state_vars::{Map, PrivateSet, PublicMutable},
+        state_vars::{Map, Owned, PrivateSet, PublicMutable},
     };
     use value_note::value_note::ValueNote;
 
     #[storage]
     struct Storage<Context> {
-        notes: PrivateSet<ValueNote, Context>,
+        notes: Owned<PrivateSet<ValueNote, Context>, Context>,
         balances: Map<AztecAddress, PublicMutable<Field, Context>, Context>,
     }
 

--- a/noir-projects/noir-contracts/contracts/test/child_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/child_contract/src/main.nr
@@ -9,7 +9,7 @@ pub contract Child {
         macros::{functions::external, storage::storage},
         messages::message_delivery::MessageDelivery,
         note::{note_getter_options::NoteGetterOptions, note_interface::NoteProperties},
-        state_vars::{PrivateSet, PublicMutable},
+        state_vars::{Owned, PrivateSet, PublicMutable},
         utils::comparison::Comparator,
     };
     use dep::value_note::value_note::ValueNote;
@@ -17,7 +17,7 @@ pub contract Child {
     #[storage]
     struct Storage<Context> {
         current_value: PublicMutable<Field, Context>,
-        private_values: PrivateSet<ValueNote, Context>,
+        private_values: Owned<PrivateSet<ValueNote, Context>, Context>,
     }
 
     // Returns a sum of the input and the chain id and version of the contract in private circuit public input's return_values.

--- a/noir-projects/noir-contracts/contracts/test/no_constructor_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/no_constructor_contract/src/main.nr
@@ -8,14 +8,14 @@ pub contract NoConstructor {
         macros::{functions::external, storage::storage},
         messages::message_delivery::MessageDelivery,
         protocol_types::address::AztecAddress,
-        state_vars::PrivateMutable,
+        state_vars::{Owned, PrivateMutable},
     };
 
     use value_note::value_note::ValueNote;
 
     #[storage]
     struct Storage<Context> {
-        private_mutable: PrivateMutable<ValueNote, Context>,
+        private_mutable: Owned<PrivateMutable<ValueNote, Context>, Context>,
     }
 
     /// Arbitrary public method used to test that publishing for public execution works for a contract with no constructor.

--- a/noir-projects/noir-contracts/contracts/test/note_getter_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/note_getter_contract/src/main.nr
@@ -11,14 +11,14 @@ pub contract NoteGetter {
         macros::{functions::external, storage::storage},
         note::note_viewer_options::NoteViewerOptions,
         protocol_types::address::AztecAddress,
-        state_vars::PrivateSet,
+        state_vars::{Owned, PrivateSet},
     };
 
     use value_note::value_note::ValueNote;
 
     #[storage]
     struct Storage<Context> {
-        set: PrivateSet<ValueNote, Context>,
+        set: Owned<PrivateSet<ValueNote, Context>, Context>,
     }
 
     #[external("private")]

--- a/noir-projects/noir-contracts/contracts/test/offchain_effect_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/offchain_effect_contract/src/main.nr
@@ -9,7 +9,7 @@ contract OffchainEffect {
         note::note_viewer_options::NoteViewerOptions,
         oracle::offchain_effect::emit_offchain_effect,
         protocol_types::{address::AztecAddress, traits::Serialize},
-        state_vars::PrivateSet,
+        state_vars::{Owned, PrivateSet},
     };
     use uint_note::uint_note::UintNote;
 
@@ -28,7 +28,7 @@ contract OffchainEffect {
 
     #[storage]
     struct Storage<Context> {
-        balances: PrivateSet<UintNote, Context>,
+        balances: Owned<PrivateSet<UintNote, Context>, Context>,
     }
 
     #[external("private")]

--- a/noir-projects/noir-contracts/contracts/test/pending_note_hashes_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/pending_note_hashes_contract/src/main.nr
@@ -17,13 +17,13 @@ pub contract PendingNoteHashes {
             constants::{MAX_NOTE_HASH_READ_REQUESTS_PER_CALL, MAX_NOTE_HASHES_PER_CALL},
             traits::{Packable, ToField},
         },
-        state_vars::PrivateSet,
+        state_vars::{Owned, PrivateSet},
     };
     use value_note::{filter::filter_notes_min_sum, value_note::ValueNote};
 
     #[storage]
     struct Storage<Context> {
-        balances: PrivateSet<ValueNote, Context>,
+        balances: Owned<PrivateSet<ValueNote, Context>, Context>,
     }
 
     // TODO(dbanks12): consolidate code into internal helper functions

--- a/noir-projects/noir-contracts/contracts/test/spam_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/spam_contract/src/main.nr
@@ -15,14 +15,14 @@ pub contract Spam {
             },
             hash::poseidon2_hash_with_separator,
         },
-        state_vars::{Map, PublicMutable},
+        state_vars::{Map, Owned, PublicMutable},
     };
 
     use crate::types::balance_set::BalanceSet;
 
     #[storage]
     struct Storage<Context> {
-        balances: BalanceSet<Context>,
+        balances: Owned<BalanceSet<Context>, Context>,
         public_balances: Map<Field, PublicMutable<u128, Context>, Context>,
     }
 

--- a/noir-projects/noir-contracts/contracts/test/spam_contract/src/types/balance_set.nr
+++ b/noir-projects/noir-contracts/contracts/test/spam_contract/src/types/balance_set.nr
@@ -10,44 +10,23 @@ use dep::aztec::{
     protocol_types::{
         address::AztecAddress, constants::MAX_NOTE_HASH_READ_REQUESTS_PER_CALL, traits::Packable,
     },
-    state_vars::{private_set::OwnedPrivateSet, PrivateSet, storage::HasStorageSlot},
+    state_vars::{owned_state_variable::OwnedStateVariable, PrivateSet},
 };
 use dep::uint_note::uint_note::UintNote;
 use std::ops::Add;
 
 pub struct BalanceSet<Context> {
-    pub set: PrivateSet<UintNote, Context>,
+    set: PrivateSet<UintNote, Context>,
 }
 
 // TODO(#13824): remove this impl once we allow structs to hold state variables.
-impl<Context> HasStorageSlot<1> for BalanceSet<Context> {
-    fn get_storage_slot(self) -> Field {
-        self.set.get_storage_slot()
+impl<Context> OwnedStateVariable<Context> for BalanceSet<Context> {
+    fn new(context: Context, storage_slot: Field, owner: AztecAddress) -> Self {
+        Self { set: PrivateSet::new(context, storage_slot, owner) }
     }
 }
 
-impl<Context> BalanceSet<Context> {
-    pub fn new(context: Context, storage_slot: Field) -> Self {
-        assert(storage_slot != 0, "Storage slot 0 not allowed. Storage slots must start from 1.");
-        Self { set: PrivateSet::new(context, storage_slot) }
-    }
-
-    pub fn at(self, owner: AztecAddress) -> OwnedBalanceSet<Context> {
-        OwnedBalanceSet::new(self.set.at(owner))
-    }
-}
-
-pub struct OwnedBalanceSet<Context> {
-    owned_set: OwnedPrivateSet<UintNote, Context>,
-}
-
-impl<Context> OwnedBalanceSet<Context> {
-    pub fn new(owned_set: OwnedPrivateSet<UintNote, Context>) -> Self {
-        Self { owned_set }
-    }
-}
-
-impl OwnedBalanceSet<UtilityContext> {
+impl BalanceSet<UtilityContext> {
     pub unconstrained fn balance_of(self: Self) -> u128 {
         self.balance_of_with_offset(0)
     }
@@ -55,7 +34,7 @@ impl OwnedBalanceSet<UtilityContext> {
     pub unconstrained fn balance_of_with_offset(self: Self, offset: u32) -> u128 {
         let mut balance = 0 as u128;
         let mut options = NoteViewerOptions::<UintNote, <UintNote as Packable>::N>::new();
-        let notes = self.owned_set.view_notes(options.set_offset(offset));
+        let notes = self.set.view_notes(options.set_offset(offset));
         for i in 0..options.limit {
             if i < notes.len() {
                 balance = balance + notes.get_unchecked(i).get_value();
@@ -69,17 +48,17 @@ impl OwnedBalanceSet<UtilityContext> {
     }
 }
 
-impl OwnedBalanceSet<&mut PrivateContext> {
+impl BalanceSet<&mut PrivateContext> {
     pub fn add(self: Self, addend: u128) -> OuterNoteEmission<UintNote> {
         let content = if addend == 0 as u128 {
             Option::none()
         } else {
             let addend_note = UintNote::new(addend);
 
-            Option::some(self.owned_set.insert(addend_note).content)
+            Option::some(self.set.insert(addend_note).content)
         };
 
-        OuterNoteEmission::new(content, self.owned_set.context)
+        OuterNoteEmission::new(content, self.set.context)
     }
 
     pub fn sub(self: Self, amount: u128) -> OuterNoteEmission<UintNote> {
@@ -109,7 +88,7 @@ impl OwnedBalanceSet<&mut PrivateContext> {
         let options = NoteGetterOptions::with_preprocessor(preprocess_notes_min_sum, target_amount)
             .sort(UintNote::properties().value, SortOrder.DESC)
             .set_limit(max_notes);
-        let notes = self.owned_set.pop_notes(options);
+        let notes = self.set.pop_notes(options);
 
         let mut subtracted = 0 as u128;
         for i in 0..options.limit {

--- a/noir-projects/noir-contracts/contracts/test/state_vars_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/state_vars_contract/src/main.nr
@@ -7,7 +7,9 @@ pub contract StateVars {
         macros::{functions::{external, view}, storage::{storage, storage_no_init}},
         messages::message_delivery::MessageDelivery,
         protocol_types::{address::AztecAddress, traits::{Deserialize, Packable, Serialize}},
-        state_vars::{PrivateImmutable, PrivateMutable, PublicImmutable, PublicMutable},
+        state_vars::{
+            Owned, PrivateImmutable, PrivateMutable, PublicImmutable, PublicMutable, StateVariable,
+        },
     };
 
     use value_note::value_note::ValueNote;
@@ -21,8 +23,8 @@ pub contract StateVars {
     #[storage_no_init]
     struct Storage<Context> {
         mock_struct: PublicMutable<MockStruct, Context>,
-        private_mutable: PrivateMutable<ValueNote, Context>,
-        private_immutable: PrivateImmutable<ValueNote, Context>,
+        private_mutable: Owned<PrivateMutable<ValueNote, Context>, Context>,
+        private_immutable: Owned<PrivateImmutable<ValueNote, Context>, Context>,
         public_immutable: PublicImmutable<MockStruct, Context>,
     }
 
@@ -30,8 +32,8 @@ pub contract StateVars {
         fn init(context: Context) -> Self {
             Storage {
                 mock_struct: PublicMutable::new(context, 1),
-                private_mutable: PrivateMutable::new(context, 3),
-                private_immutable: PrivateImmutable::new(context, 6),
+                private_mutable: Owned::new(context, 3),
+                private_immutable: Owned::new(context, 6),
                 public_immutable: PublicImmutable::new(context, 7),
             }
         }

--- a/noir-projects/noir-contracts/contracts/test/stateful_test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/stateful_test_contract/src/main.nr
@@ -14,13 +14,13 @@ pub contract StatefulTest {
         messages::message_delivery::MessageDelivery,
         note::note_getter_options::NoteGetterOptions,
         protocol_types::{abis::function_selector::FunctionSelector, address::AztecAddress},
-        state_vars::{Map, PrivateSet, PublicMutable},
+        state_vars::{Map, Owned, PrivateSet, PublicMutable},
     };
     use value_note::{balance_utils, value_note::ValueNote};
 
     #[storage]
     struct Storage<Context> {
-        notes: PrivateSet<ValueNote, Context>,
+        notes: Owned<PrivateSet<ValueNote, Context>, Context>,
         public_values: Map<AztecAddress, PublicMutable<Field, Context>, Context>,
     }
 

--- a/noir-projects/noir-contracts/contracts/test/static_child_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/static_child_contract/src/main.nr
@@ -8,7 +8,7 @@ pub contract StaticChild {
         messages::message_delivery::MessageDelivery,
         note::note_getter_options::NoteGetterOptions,
         protocol_types::address::AztecAddress,
-        state_vars::{PrivateSet, PublicMutable},
+        state_vars::{Owned, PrivateSet, PublicMutable},
         utils::comparison::Comparator,
     };
     use dep::value_note::value_note::ValueNote;
@@ -17,7 +17,7 @@ pub contract StaticChild {
     #[storage]
     struct Storage<Context> {
         current_value: PublicMutable<Field, Context>,
-        a_private_value: PrivateSet<ValueNote, Context>,
+        a_private_value: Owned<PrivateSet<ValueNote, Context>, Context>,
     }
 
     // Returns base_value + chain_id + version + block_number + timestamp statically

--- a/noir-projects/noir-contracts/contracts/test/test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/test_contract/src/main.nr
@@ -23,7 +23,7 @@ pub contract Test {
         },
         // State variable types
         state_vars::{
-            DelayedPublicMutable, Map, PrivateImmutable, PrivateMutable, PrivateSet,
+            DelayedPublicMutable, Map, Owned, PrivateImmutable, PrivateMutable, PrivateSet,
             PublicImmutable,
         },
         // Protocol types and constants
@@ -83,17 +83,17 @@ pub contract Test {
     // test function must also be updated accordingly.
     #[storage]
     struct Storage<Context> {
-        note_in_private_immutable: PrivateImmutable<TestNote, Context>,
-        struct_in_private_immutable: PrivateImmutable<ExampleStruct, Context>,
-        note_in_private_mutable: PrivateMutable<TestNote, Context>,
-        struct_in_private_mutable: PrivateMutable<ExampleStruct, Context>,
-        note_in_private_set: PrivateSet<AddressNote, Context>,
-        struct_in_private_set: PrivateSet<ExampleStruct, Context>,
+        note_in_private_immutable: Owned<PrivateImmutable<TestNote, Context>, Context>,
+        struct_in_private_immutable: Owned<PrivateImmutable<ExampleStruct, Context>, Context>,
+        note_in_private_mutable: Owned<PrivateMutable<TestNote, Context>, Context>,
+        struct_in_private_mutable: Owned<PrivateMutable<ExampleStruct, Context>, Context>,
+        note_in_private_set: Owned<PrivateSet<AddressNote, Context>, Context>,
+        struct_in_private_set: Owned<PrivateSet<ExampleStruct, Context>, Context>,
         note_in_public_immutable: PublicImmutable<TestNote, Context>,
         struct_in_public_immutable: PublicImmutable<ExampleStruct, Context>,
-        struct_in_map: Map<AztecAddress, PrivateImmutable<ExampleStruct, Context>, Context>,
+        struct_in_map: Map<AztecAddress, PublicImmutable<ExampleStruct, Context>, Context>,
         struct_in_delayed_public_mutable: DelayedPublicMutable<ExampleStruct, DELAYED_PUBLIC_MUTABLE_INITIAL_DELAY, Context>,
-        dummy_variable: PrivateImmutable<TestNote, Context>,
+        dummy_variable: Owned<PrivateImmutable<TestNote, Context>, Context>,
     }
 
     #[initializer]

--- a/noir-projects/noir-contracts/contracts/test/test_log_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/test_log_contract/src/main.nr
@@ -7,7 +7,7 @@ pub contract TestLog {
         messages::message_delivery::MessageDelivery,
         oracle::random::random,
         protocol_types::{address::AztecAddress, traits::FromField},
-        state_vars::PrivateSet,
+        state_vars::{Owned, PrivateSet},
     };
     use value_note::value_note::ValueNote;
 
@@ -25,7 +25,7 @@ pub contract TestLog {
 
     #[storage]
     struct Storage<Context> {
-        example_set: PrivateSet<ValueNote, Context>,
+        example_set: Owned<PrivateSet<ValueNote, Context>, Context>,
     }
 
     #[external("private")]

--- a/noir-projects/noir-contracts/contracts/test/updatable_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/updatable_contract/src/main.nr
@@ -10,14 +10,14 @@ contract Updatable {
             address::AztecAddress, constants::CONTRACT_INSTANCE_REGISTRY_CONTRACT_ADDRESS,
             contract_class_id::ContractClassId,
         },
-        state_vars::{PrivateMutable, PublicMutable},
+        state_vars::{Owned, PrivateMutable, PublicMutable},
     };
     use contract_instance_registry::ContractInstanceRegistry;
     use value_note::value_note::ValueNote;
 
     #[storage]
     struct Storage<Context> {
-        private_value: PrivateMutable<ValueNote, Context>,
+        private_value: Owned<PrivateMutable<ValueNote, Context>, Context>,
         public_value: PublicMutable<Field, Context>,
     }
 

--- a/noir-projects/noir-contracts/contracts/test/updated_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/updated_contract/src/main.nr
@@ -9,14 +9,14 @@ contract Updated {
         protocol_types::{
             address::AztecAddress, constants::CONTRACT_INSTANCE_REGISTRY_CONTRACT_ADDRESS,
         },
-        state_vars::{PrivateMutable, PublicMutable},
+        state_vars::{Owned, PrivateMutable, PublicMutable},
     };
     use contract_instance_registry::ContractInstanceRegistry;
     use value_note::value_note::ValueNote;
 
     #[storage]
     struct Storage<Context> {
-        private_value: PrivateMutable<ValueNote, Context>,
+        private_value: Owned<PrivateMutable<ValueNote, Context>, Context>,
         public_value: PublicMutable<Field, Context>,
     }
 


### PR DESCRIPTION
Fixes F-189

In this PR I:
- Introduce new `StateVariable` trait that replaces the `HasStorageSlot` trait. The new trait has a `new` method on it that allowed me to significantly clean up the `#[storage]` macro - now I can directly construct the state var by calling this method instead of doing some crazy stuff with closures etc.,
- I introduce `OwnedStateVariable` trait that is used by state variables that have the concept of owner (`PrivateSet`, `PrivateMutable` etc.). These state vars need to be wrapped in new `Owned` state var before being placed in the `Storage` struct.