### PR TITLE
refactor: replace ad-hoc thread range calculations with ThreadChunk

### DIFF
--- a/barretenberg/cpp/src/barretenberg/ecc/scalar_multiplication/scalar_multiplication.cpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/scalar_multiplication/scalar_multiplication.cpp
@@ -57,27 +57,23 @@ void MSM<Curve>::transform_scalar_and_get_nonzero_scalar_indices(std::span<typen
 {
     const size_t num_cpus = get_num_cpus();
 
-    const size_t scalars_per_thread = numeric::ceil_div(scalars.size(), num_cpus);
     std::vector<std::vector<uint32_t>> thread_indices(num_cpus);
-    parallel_for(num_cpus, [&](size_t thread_idx) {
-        bool empty_thread = (thread_idx * scalars_per_thread >= scalars.size());
-        bool last_thread = ((thread_idx + 1) * scalars_per_thread) >= scalars.size();
-        const size_t start = thread_idx * scalars_per_thread;
-        const size_t end = last_thread ? scalars.size() : (thread_idx + 1) * scalars_per_thread;
-        if (!empty_thread) {
-            BB_ASSERT_DEBUG(end > start);
-            std::vector<uint32_t>& thread_scalar_indices = thread_indices[thread_idx];
-            thread_scalar_indices.reserve(end - start);
-            for (size_t i = start; i < end; ++i) {
-                BB_ASSERT_DEBUG(i < scalars.size());
-                auto& scalar = scalars[i];
-                scalar.self_from_montgomery_form();
+    parallel_for([&](const ThreadChunk& chunk) {
+        auto range = chunk.range(scalars.size());
+        if (range.empty()) {
+            return;
+        }
+        std::vector<uint32_t>& thread_scalar_indices = thread_indices[chunk.thread_index];
+        thread_scalar_indices.reserve(range.size());
+        for (size_t i : range) {
+            BB_ASSERT_DEBUG(i < scalars.size());
+            auto& scalar = scalars[i];
+            scalar.self_from_montgomery_form();
 
-                bool is_zero =
-                    (scalar.data[0] == 0) && (scalar.data[1] == 0) && (scalar.data[2] == 0) && (scalar.data[3] == 0);
-                if (!is_zero) {
-                    thread_scalar_indices.push_back(static_cast<uint32_t>(i));
-                }
+            bool is_zero =
+                (scalar.data[0] == 0) && (scalar.data[1] == 0) && (scalar.data[2] == 0) && (scalar.data[3] == 0);
+            if (!is_zero) {
+                thread_scalar_indices.push_back(static_cast<uint32_t>(i));
             }
         }
     });
@@ -89,15 +85,15 @@ void MSM<Curve>::transform_scalar_and_get_nonzero_scalar_indices(std::span<typen
     }
     consolidated_indices.resize(num_entries);
 
-    parallel_for(num_cpus, [&](size_t thread_idx) {
+    parallel_for([&](const ThreadChunk& chunk) {
         size_t offset = 0;
-        for (size_t i = 0; i < thread_idx; ++i) {
+        for (size_t i = 0; i < chunk.thread_index; ++i) {
             BB_ASSERT_LT(i, thread_indices.size());
             offset += thread_indices[i].size();
         }
-        for (size_t i = offset; i < offset + thread_indices[thread_idx].size(); ++i) {
+        for (size_t i = offset; i < offset + thread_indices[chunk.thread_index].size(); ++i) {
             BB_ASSERT_LT(i, scalars.size());
-            consolidated_indices[i] = thread_indices[thread_idx][i - offset];
+            consolidated_indices[i] = thread_indices[chunk.thread_index][i - offset];
         }
     });
 }

--- a/barretenberg/cpp/src/barretenberg/ecc/scalar_multiplication/scalar_multiplication.cpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/scalar_multiplication/scalar_multiplication.cpp
@@ -55,10 +55,11 @@ template <typename Curve>
 void MSM<Curve>::transform_scalar_and_get_nonzero_scalar_indices(std::span<typename Curve::ScalarField> scalars,
                                                                  std::vector<uint32_t>& consolidated_indices) noexcept
 {
-    const size_t num_cpus = get_num_cpus();
+    std::vector<std::vector<uint32_t>> thread_indices(get_num_cpus());
 
-    std::vector<std::vector<uint32_t>> thread_indices(num_cpus);
     parallel_for([&](const ThreadChunk& chunk) {
+        // parallel_for with ThreadChunk uses get_num_cpus() threads
+        BB_ASSERT_EQ(chunk.total_threads, thread_indices.size());
         auto range = chunk.range(scalars.size());
         if (range.empty()) {
             return;
@@ -79,20 +80,19 @@ void MSM<Curve>::transform_scalar_and_get_nonzero_scalar_indices(std::span<typen
     });
 
     size_t num_entries = 0;
-    for (size_t i = 0; i < num_cpus; ++i) {
-        BB_ASSERT_LT(i, thread_indices.size());
-        num_entries += thread_indices[i].size();
+    for (const auto& indices : thread_indices) {
+        num_entries += indices.size();
     }
     consolidated_indices.resize(num_entries);
 
     parallel_for([&](const ThreadChunk& chunk) {
+        // parallel_for with ThreadChunk uses get_num_cpus() threads
+        BB_ASSERT_EQ(chunk.total_threads, thread_indices.size());
         size_t offset = 0;
         for (size_t i = 0; i < chunk.thread_index; ++i) {
-            BB_ASSERT_LT(i, thread_indices.size());
             offset += thread_indices[i].size();
         }
         for (size_t i = offset; i < offset + thread_indices[chunk.thread_index].size(); ++i) {
-            BB_ASSERT_LT(i, scalars.size());
             consolidated_indices[i] = thread_indices[chunk.thread_index][i - offset];
         }
     });

--- a/barretenberg/cpp/src/barretenberg/honk/composer/permutation_lib.hpp
+++ b/barretenberg/cpp/src/barretenberg/honk/composer/permutation_lib.hpp
@@ -84,16 +84,11 @@ template <size_t NUM_WIRES> struct PermutationMapping {
             ids[wire_idx] = Mapping(circuit_size);
         }
 
-        const size_t num_threads = calculate_num_threads_pow2(circuit_size, /*min_iterations_per_thread=*/1 << 10);
-        size_t iterations_per_thread = circuit_size / num_threads; // actual iterations per thread
-
-        parallel_for(num_threads, [&](size_t thread_idx) {
-            uint32_t start = static_cast<uint32_t>(thread_idx * iterations_per_thread);
-            uint32_t end = static_cast<uint32_t>((thread_idx + 1) * iterations_per_thread);
-
+        parallel_for([&](const ThreadChunk& chunk) {
             // Initialize every element to point to itself
             for (uint8_t col_idx = 0; col_idx < NUM_WIRES; ++col_idx) {
-                for (uint32_t row_idx = start; row_idx < end; ++row_idx) {
+                for (size_t i : chunk.range(circuit_size)) {
+                    auto row_idx = static_cast<uint32_t>(i);
                     auto idx = static_cast<ptrdiff_t>(row_idx);
                     // sigma polynomials
                     sigmas[col_idx].row_idx[idx] = row_idx;

--- a/barretenberg/cpp/src/barretenberg/honk/proof_system/logderivative_library.hpp
+++ b/barretenberg/cpp/src/barretenberg/honk/proof_system/logderivative_library.hpp
@@ -74,7 +74,7 @@ void compute_logderivative_inverse(Polynomials& polynomials, auto& relation_para
     };
     if constexpr (UseMultithreading) {
         parallel_for([&](const ThreadChunk& chunk) {
-            auto range = chunk.range(inverse_polynomial.size());
+            auto range = chunk.range(circuit_size);
             if (!range.empty()) {
                 size_t start = *range.begin();
                 size_t end = start + range.size();
@@ -82,7 +82,7 @@ void compute_logderivative_inverse(Polynomials& polynomials, auto& relation_para
             }
         });
     } else {
-        compute_inverses(0, inverse_polynomial.size());
+        compute_inverses(0, circuit_size);
     }
 }
 

--- a/barretenberg/cpp/src/barretenberg/honk/proof_system/logderivative_library.hpp
+++ b/barretenberg/cpp/src/barretenberg/honk/proof_system/logderivative_library.hpp
@@ -82,7 +82,7 @@ void compute_logderivative_inverse(Polynomials& polynomials, auto& relation_para
             }
         });
     } else {
-        compute_inverses(0, circuit_size);
+        compute_inverses(0, inverse_polynomial.size());
     }
 }
 

--- a/barretenberg/cpp/src/barretenberg/honk/proof_system/logderivative_library.hpp
+++ b/barretenberg/cpp/src/barretenberg/honk/proof_system/logderivative_library.hpp
@@ -73,13 +73,13 @@ void compute_logderivative_inverse(Polynomials& polynomials, auto& relation_para
         FF::batch_invert(to_invert);
     };
     if constexpr (UseMultithreading) {
-        const size_t min_iterations_per_thread = 128;
-        size_t num_threads = bb::calculate_num_threads_pow2(inverse_polynomial.size(), min_iterations_per_thread);
-        const size_t rows_per_thread = inverse_polynomial.size() / num_threads;
-        parallel_for(num_threads, [&](size_t thread_idx) {
-            const size_t start = thread_idx * rows_per_thread;
-            const size_t end = (thread_idx == num_threads - 1) ? circuit_size : (thread_idx + 1) * rows_per_thread;
-            compute_inverses(start, end);
+        parallel_for([&](const ThreadChunk& chunk) {
+            auto range = chunk.range(inverse_polynomial.size());
+            if (!range.empty()) {
+                size_t start = *range.begin();
+                size_t end = start + range.size();
+                compute_inverses(start, end);
+            }
         });
     } else {
         compute_inverses(0, inverse_polynomial.size());

--- a/barretenberg/cpp/src/barretenberg/polynomials/polynomial.cpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/polynomial.cpp
@@ -74,16 +74,15 @@ template <typename Fr> Polynomial<Fr>::Polynomial(size_t size, size_t virtual_si
     BB_BENCH_NAME("Polynomial::Polynomial(size_t, size_t, size_t)");
     allocate_backing_memory(size, virtual_size, start_index);
 
-    size_t num_threads = calculate_num_threads(size);
-    size_t range_per_thread = size / num_threads;
-    size_t leftovers = size - (range_per_thread * num_threads);
-
-    parallel_for(num_threads, [&](size_t j) {
-        size_t offset = j * range_per_thread;
-        size_t range = (j == num_threads - 1) ? range_per_thread + leftovers : range_per_thread;
-        BB_ASSERT(offset < size || size == 0);
-        BB_ASSERT_LTE((offset + range), size);
-        memset(static_cast<void*>(coefficients_.data() + offset), 0, sizeof(Fr) * range);
+    parallel_for([&](const ThreadChunk& chunk) {
+        auto range = chunk.range(size);
+        if (!range.empty()) {
+            size_t start = *range.begin();
+            size_t range_size = range.size();
+            BB_ASSERT(start < size || size == 0);
+            BB_ASSERT_LTE((start + range_size), size);
+            memset(static_cast<void*>(coefficients_.data() + start), 0, sizeof(Fr) * range_size);
+        }
     });
 }
 
@@ -176,13 +175,9 @@ template <typename Fr> Polynomial<Fr>& Polynomial<Fr>::operator+=(PolynomialSpan
 {
     BB_ASSERT_LTE(start_index(), other.start_index);
     BB_ASSERT_GTE(end_index(), other.end_index());
-    size_t num_threads = calculate_num_threads(other.size());
-    size_t range_per_thread = other.size() / num_threads;
-    size_t leftovers = other.size() - (range_per_thread * num_threads);
-    parallel_for(num_threads, [&](size_t j) {
-        size_t offset = j * range_per_thread + other.start_index;
-        size_t end = (j == num_threads - 1) ? offset + range_per_thread + leftovers : offset + range_per_thread;
-        for (size_t i = offset; i < end; ++i) {
+    parallel_for([&](const ThreadChunk& chunk) {
+        for (size_t offset : chunk.range(other.size())) {
+            size_t i = offset + other.start_index;
             at(i) += other[i];
         }
     });
@@ -217,13 +212,9 @@ template <typename Fr> Polynomial<Fr>& Polynomial<Fr>::operator-=(PolynomialSpan
 {
     BB_ASSERT_LTE(start_index(), other.start_index);
     BB_ASSERT_GTE(end_index(), other.end_index());
-    const size_t num_threads = calculate_num_threads(other.size());
-    const size_t range_per_thread = other.size() / num_threads;
-    const size_t leftovers = other.size() - (range_per_thread * num_threads);
-    parallel_for(num_threads, [&](size_t j) {
-        const size_t offset = j * range_per_thread + other.start_index;
-        const size_t end = (j == num_threads - 1) ? offset + range_per_thread + leftovers : offset + range_per_thread;
-        for (size_t i = offset; i < end; ++i) {
+    parallel_for([&](const ThreadChunk& chunk) {
+        for (size_t offset : chunk.range(other.size())) {
+            size_t i = offset + other.start_index;
             at(i) -= other[i];
         }
     });

--- a/barretenberg/cpp/src/barretenberg/polynomials/polynomial_arithmetic.cpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/polynomial_arithmetic.cpp
@@ -501,17 +501,17 @@ void coset_ifft(std::vector<Fr*> coeffs, const EvaluationDomain<Fr>& domain)
 
 template <typename Fr> Fr evaluate(const Fr* coeffs, const Fr& z, const size_t n)
 {
-    size_t num_threads = get_num_cpus();
-    Fr* evaluations = new Fr[num_threads];
+    const size_t num_threads = get_num_cpus();
+    std::vector<Fr> evaluations(num_threads, Fr::zero());
     parallel_for([&](const ThreadChunk& chunk) {
+        // parallel_for with ThreadChunk uses get_num_cpus() threads
+        BB_ASSERT_EQ(chunk.total_threads, evaluations.size());
         auto range = chunk.range(n);
         if (range.empty()) {
-            evaluations[chunk.thread_index] = Fr::zero();
             return;
         }
         size_t start = *range.begin();
         Fr z_acc = z.pow(static_cast<uint64_t>(start));
-        evaluations[chunk.thread_index] = Fr::zero();
         for (size_t i : range) {
             Fr work_var = z_acc * coeffs[i];
             evaluations[chunk.thread_index] += work_var;
@@ -520,10 +520,9 @@ template <typename Fr> Fr evaluate(const Fr* coeffs, const Fr& z, const size_t n
     });
 
     Fr r = Fr::zero();
-    for (size_t j = 0; j < num_threads; ++j) {
-        r += evaluations[j];
+    for (const auto& eval : evaluations) {
+        r += eval;
     }
-    delete[] evaluations;
     return r;
 }
 
@@ -533,17 +532,17 @@ template <typename Fr> Fr evaluate(const std::vector<Fr*> coeffs, const Fr& z, c
     const size_t poly_size = large_n / num_polys;
     BB_ASSERT(is_power_of_two(poly_size));
     const size_t log2_poly_size = (size_t)numeric::get_msb(poly_size);
-    size_t num_threads = get_num_cpus();
-    Fr* evaluations = new Fr[num_threads];
+    const size_t num_threads = get_num_cpus();
+    std::vector<Fr> evaluations(num_threads, Fr::zero());
     parallel_for([&](const ThreadChunk& chunk) {
+        // parallel_for with ThreadChunk uses get_num_cpus() threads
+        BB_ASSERT_EQ(chunk.total_threads, evaluations.size());
         auto range = chunk.range(large_n);
         if (range.empty()) {
-            evaluations[chunk.thread_index] = Fr::zero();
             return;
         }
         size_t start = *range.begin();
         Fr z_acc = z.pow(static_cast<uint64_t>(start));
-        evaluations[chunk.thread_index] = Fr::zero();
         for (size_t i : range) {
             Fr work_var = z_acc * coeffs[i >> log2_poly_size][i & (poly_size - 1)];
             evaluations[chunk.thread_index] += work_var;
@@ -552,10 +551,9 @@ template <typename Fr> Fr evaluate(const std::vector<Fr*> coeffs, const Fr& z, c
     });
 
     Fr r = Fr::zero();
-    for (size_t j = 0; j < num_threads; ++j) {
-        r += evaluations[j];
+    for (const auto& eval : evaluations) {
+        r += eval;
     }
-    delete[] evaluations;
     return r;
 }
 

--- a/barretenberg/cpp/src/barretenberg/polynomials/polynomial_arithmetic.cpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/polynomial_arithmetic.cpp
@@ -501,18 +501,20 @@ void coset_ifft(std::vector<Fr*> coeffs, const EvaluationDomain<Fr>& domain)
 
 template <typename Fr> Fr evaluate(const Fr* coeffs, const Fr& z, const size_t n)
 {
-    size_t num_threads = get_num_cpus_pow2();
-    size_t range_per_thread = n / num_threads;
-    size_t leftovers = n - (range_per_thread * num_threads);
+    size_t num_threads = get_num_cpus();
     Fr* evaluations = new Fr[num_threads];
-    parallel_for(num_threads, [&](size_t j) {
-        Fr z_acc = z.pow(static_cast<uint64_t>(j * range_per_thread));
-        size_t offset = j * range_per_thread;
-        evaluations[j] = Fr::zero();
-        size_t end = (j == num_threads - 1) ? offset + range_per_thread + leftovers : offset + range_per_thread;
-        for (size_t i = offset; i < end; ++i) {
+    parallel_for([&](const ThreadChunk& chunk) {
+        auto range = chunk.range(n);
+        if (range.empty()) {
+            evaluations[chunk.thread_index] = Fr::zero();
+            return;
+        }
+        size_t start = *range.begin();
+        Fr z_acc = z.pow(static_cast<uint64_t>(start));
+        evaluations[chunk.thread_index] = Fr::zero();
+        for (size_t i : range) {
             Fr work_var = z_acc * coeffs[i];
-            evaluations[j] += work_var;
+            evaluations[chunk.thread_index] += work_var;
             z_acc *= z;
         }
     });
@@ -531,18 +533,20 @@ template <typename Fr> Fr evaluate(const std::vector<Fr*> coeffs, const Fr& z, c
     const size_t poly_size = large_n / num_polys;
     BB_ASSERT(is_power_of_two(poly_size));
     const size_t log2_poly_size = (size_t)numeric::get_msb(poly_size);
-    size_t num_threads = get_num_cpus_pow2();
-    size_t range_per_thread = large_n / num_threads;
-    size_t leftovers = large_n - (range_per_thread * num_threads);
+    size_t num_threads = get_num_cpus();
     Fr* evaluations = new Fr[num_threads];
-    parallel_for(num_threads, [&](size_t j) {
-        Fr z_acc = z.pow(static_cast<uint64_t>(j * range_per_thread));
-        size_t offset = j * range_per_thread;
-        evaluations[j] = Fr::zero();
-        size_t end = (j == num_threads - 1) ? offset + range_per_thread + leftovers : offset + range_per_thread;
-        for (size_t i = offset; i < end; ++i) {
+    parallel_for([&](const ThreadChunk& chunk) {
+        auto range = chunk.range(large_n);
+        if (range.empty()) {
+            evaluations[chunk.thread_index] = Fr::zero();
+            return;
+        }
+        size_t start = *range.begin();
+        Fr z_acc = z.pow(static_cast<uint64_t>(start));
+        evaluations[chunk.thread_index] = Fr::zero();
+        for (size_t i : range) {
             Fr work_var = z_acc * coeffs[i >> log2_poly_size][i & (poly_size - 1)];
-            evaluations[j] += work_var;
+            evaluations[chunk.thread_index] += work_var;
             z_acc *= z;
         }
     });

--- a/barretenberg/cpp/src/barretenberg/sumcheck/sumcheck_round.hpp
+++ b/barretenberg/cpp/src/barretenberg/sumcheck/sumcheck_round.hpp
@@ -382,9 +382,14 @@ template <typename Flavor> class SumcheckProverRound {
         if constexpr (can_skip_rows) {
             std::vector<std::vector<BlockOfContiguousRows>> all_thread_blocks(num_threads);
             parallel_for(num_threads, [&](size_t thread_idx) {
+                ThreadChunk chunk{ .thread_index = thread_idx, .total_threads = num_threads };
+                auto range = chunk.range(effective_round_size);
+                if (range.empty()) {
+                    return;
+                }
                 size_t current_block_size = 0;
-                size_t start = thread_idx * iterations_per_thread;
-                size_t end = (thread_idx + 1) * iterations_per_thread;
+                size_t start = *range.begin();
+                size_t end = start + range.size();
                 std::vector<BlockOfContiguousRows> thread_blocks;
                 for (size_t edge_idx = start; edge_idx < end; edge_idx += 2) {
                     if (!Flavor::skip_entire_row(polynomials, edge_idx)) {

--- a/barretenberg/cpp/src/barretenberg/sumcheck/sumcheck_round.hpp
+++ b/barretenberg/cpp/src/barretenberg/sumcheck/sumcheck_round.hpp
@@ -374,7 +374,6 @@ template <typename Flavor> class SumcheckProverRound {
 
         const size_t min_iterations_per_thread = 1 << 10; // min number of iterations for which we'll spin up a unique
         const size_t num_threads = bb::calculate_num_threads_pow2(effective_round_size, min_iterations_per_thread);
-        const size_t iterations_per_thread = effective_round_size / num_threads; // actual iterations per thread
 
         std::vector<BlockOfContiguousRows> result;
         constexpr bool can_skip_rows = (isRowSkippable<Flavor, decltype(polynomials), size_t>);

--- a/barretenberg/cpp/src/barretenberg/translator_vm/translator_proving_key.hpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/translator_proving_key.hpp
@@ -114,19 +114,8 @@ class TranslatorProvingKey {
             // The value we have to end polynomials with, 2¹⁴ - 1
             const size_t max_value = (1 << Flavor::MICRO_LIMB_BITS) - 1;
 
-            // min number of iterations for which we'll spin up a unique thread
-            const size_t min_iterations_per_thread = 1 << 6;
-            const size_t num_threads =
-                bb::calculate_num_threads_pow2(Flavor::SORTED_STEPS_COUNT, min_iterations_per_thread);
-            // actual iterations per thread
-            const size_t iterations_per_thread = Flavor::SORTED_STEPS_COUNT / num_threads;
-            const size_t leftovers = Flavor::SORTED_STEPS_COUNT % num_threads;
-
-            parallel_for(num_threads, [&](size_t thread_idx) {
-                const size_t start = thread_idx * iterations_per_thread;
-                const size_t end =
-                    (thread_idx + 1) * iterations_per_thread + (thread_idx == num_threads - 1 ? leftovers : 0);
-                for (size_t idx = start; idx < end; ++idx) {
+            parallel_for([&](const ThreadChunk& chunk) {
+                for (size_t idx : chunk.range(Flavor::SORTED_STEPS_COUNT)) {
                     inner_array[idx] = max_value - Flavor::SORT_STEP * idx;
                 }
             });


### PR DESCRIPTION
## Summary
- Systematically replace ad-hoc thread range calculation patterns with the cleaner `ThreadChunk` abstraction
- Addresses https://github.com/AztecProtocol/barretenberg/issues/1550

## Changes
- `polynomial.cpp`: Refactor constructor, `operator+=`, `operator-=`
- `polynomial_arithmetic.cpp`: Refactor `evaluate` functions
- `scalar_multiplication.cpp`: Refactor `transform_scalar_and_get_nonzero_scalar_indices`
- `logderivative_library.hpp`: Refactor `compute_logderivative_inverse`
- `sumcheck_round.hpp`: Refactor `compute_contiguous_round_size`
- `permutation_lib.hpp`: Refactor `PermutationMapping` constructor
- `translator_proving_key.hpp`: Refactor `get_sorted_steps`

## Benefits
- Cleaner, more readable code
- Consistent remainder handling (`ThreadChunk` distributes remainders evenly across threads rather than dumping leftovers on the last thread)
- Better load balancing across threads

## Test plan
- [x] CI passes
- [x] Existing tests verify correctness