### PR TITLE
feat(bb): Add stateful keygen and proving exports

### DIFF
--- a/barretenberg/cpp/cmake/module.cmake
+++ b/barretenberg/cpp/cmake/module.cmake
@@ -243,6 +243,11 @@ function(barretenberg_module_with_sources MODULE_NAME)
     if(BENCH_SOURCE_FILES AND NOT FUZZING)
         foreach(BENCHMARK_SOURCE ${BENCH_SOURCE_FILES})
             get_filename_component(BENCHMARK_NAME ${BENCHMARK_SOURCE} NAME_WE) # extract name without extension
+            if("${BENCHMARK_NAME}" STREQUAL "")
+                message(WARNING "Skipping benchmark source with empty name: ${BENCHMARK_SOURCE}")
+                continue()
+            endif()
+            message(STATUS "BENCH_SOURCE: ${BENCHMARK_SOURCE} -> NAME: ${BENCHMARK_NAME}")
             add_library(
                 ${BENCHMARK_NAME}_bench_objects
                 OBJECT

--- a/barretenberg/cpp/src/CMakeLists.txt
+++ b/barretenberg/cpp/src/CMakeLists.txt
@@ -149,6 +149,7 @@ set(BARRETENBERG_TARGET_OBJECTS
     $<TARGET_OBJECTS:bbapi_objects>
     $<TARGET_OBJECTS:chonk_objects>
     $<TARGET_OBJECTS:commitment_schemes_objects>
+    $<TARGET_OBJECTS:circuit_checker_objects>
     $<TARGET_OBJECTS:common_objects>
     $<TARGET_OBJECTS:crypto_aes128_objects>
     $<TARGET_OBJECTS:crypto_blake2s_objects>

--- a/barretenberg/cpp/src/barretenberg/bbapi/bbapi_execute.hpp
+++ b/barretenberg/cpp/src/barretenberg/bbapi/bbapi_execute.hpp
@@ -66,6 +66,8 @@ using Command = NamedUnion<CircuitProve,
                            EcdsaSecp256r1VerifySignature,
                            SrsInitSrs,
                            SrsInitGrumpkinSrs,
+                           AcirGetProvingKey,
+                           AcirProveWithPk,
                            Shutdown>;
 
 using CommandResponse = NamedUnion<ErrorResponse,
@@ -122,6 +124,8 @@ using CommandResponse = NamedUnion<ErrorResponse,
                                    EcdsaSecp256r1VerifySignature::Response,
                                    SrsInitSrs::Response,
                                    SrsInitGrumpkinSrs::Response,
+                                   AcirGetProvingKey::Response,
+                                   AcirProveWithPk::Response,
                                    Shutdown::Response>;
 
 /**

--- a/barretenberg/cpp/src/barretenberg/bbapi/bbapi_flavor_dispatch.hpp
+++ b/barretenberg/cpp/src/barretenberg/bbapi/bbapi_flavor_dispatch.hpp
@@ -42,14 +42,17 @@ enum class UltraFlavorType : std::uint8_t {
  */
 inline UltraFlavorType select_ultra_flavor(const ProofSystemSettings& settings)
 {
+    // IPA accumulation takes precedence - this selects UltraRollup
+    if (settings.ipa_accumulation) {
+        return UltraFlavorType::UltraRollup;
+    }
+
     // Keccak-based flavors (for EVM verification)
     if (settings.oracle_hash_type == "keccak") {
         return settings.disable_zk ? UltraFlavorType::UltraKeccak : UltraFlavorType::UltraKeccakZK;
     }
 
     // Poseidon2-based flavors (default)
-    // Note: UltraRollup also uses Poseidon2 but with different circuit constraints.
-    // For now, we treat it as standard Ultra. Future: add explicit rollup flag.
     if (settings.oracle_hash_type == "poseidon2") {
         return settings.disable_zk ? UltraFlavorType::Ultra : UltraFlavorType::UltraZK;
     }

--- a/barretenberg/cpp/src/barretenberg/bbapi/bbapi_flavor_dispatch.hpp
+++ b/barretenberg/cpp/src/barretenberg/bbapi/bbapi_flavor_dispatch.hpp
@@ -1,10 +1,7 @@
 #pragma once
 /**
  * @file bbapi_flavor_dispatch.hpp
- * @brief Flavor selection logic for stateful proving key operations.
- *
- * This file contains utilities to dispatch to the correct Ultra* flavor
- * based on ProofSystemSettings (oracle hash type, ZK mode, etc.).
+ * @brief Flavor selection for stateful proving key operations.
  */
 
 #include "barretenberg/bbapi/bbapi_shared.hpp"
@@ -18,27 +15,12 @@
 namespace bb::bbapi {
 
 /**
- * @brief Enumeration of supported Ultra flavor types for stateful proving.
- * @details Each flavor represents a different proving system configuration.
+ * @brief Supported Ultra flavor types for stateful proving.
  */
-enum class UltraFlavorType : std::uint8_t {
-    Ultra,         ///< Standard UltraHonk (non-ZK, Poseidon2)
-    UltraZK,       ///< Zero-knowledge UltraHonk (Poseidon2)
-    UltraKeccak,   ///< UltraHonk with Keccak hash (for EVM verification, non-ZK)
-    UltraKeccakZK, ///< UltraHonk with Keccak hash (ZK variant)
-    UltraRollup    ///< Rollup-optimized UltraHonk
-};
+enum class UltraFlavorType : std::uint8_t { Ultra, UltraZK, UltraKeccak, UltraKeccakZK, UltraRollup };
 
 /**
- * @brief Select the appropriate Ultra flavor based on proof system settings.
- * @param settings The proof system configuration (hash type, ZK mode, etc.)
- * @return The corresponding UltraFlavorType enum value
- *
- * @details Selection logic:
- *   - If oracle_hash_type == "keccak": UltraKeccak or UltraKeccakZK
- *   - If oracle_hash_type == "poseidon2": Ultra or UltraZK
- *   - UltraRollup is selected based on explicit flag (future extension)
- *   - disable_zk determines ZK vs non-ZK variant
+ * @brief Select Ultra flavor based on proof system settings.
  */
 inline UltraFlavorType select_ultra_flavor(const ProofSystemSettings& settings)
 {

--- a/barretenberg/cpp/src/barretenberg/bbapi/bbapi_flavor_dispatch.hpp
+++ b/barretenberg/cpp/src/barretenberg/bbapi/bbapi_flavor_dispatch.hpp
@@ -1,0 +1,61 @@
+#pragma once
+/**
+ * @file bbapi_flavor_dispatch.hpp
+ * @brief Flavor selection logic for stateful proving key operations.
+ *
+ * This file contains utilities to dispatch to the correct Ultra* flavor
+ * based on ProofSystemSettings (oracle hash type, ZK mode, etc.).
+ */
+
+#include "barretenberg/bbapi/bbapi_shared.hpp"
+#include "barretenberg/flavor/ultra_flavor.hpp"
+#include "barretenberg/flavor/ultra_keccak_flavor.hpp"
+#include "barretenberg/flavor/ultra_keccak_zk_flavor.hpp"
+#include "barretenberg/flavor/ultra_rollup_flavor.hpp"
+#include "barretenberg/flavor/ultra_zk_flavor.hpp"
+#include <cstdint>
+
+namespace bb::bbapi {
+
+/**
+ * @brief Enumeration of supported Ultra flavor types for stateful proving.
+ * @details Each flavor represents a different proving system configuration.
+ */
+enum class UltraFlavorType : std::uint8_t {
+    Ultra,         ///< Standard UltraHonk (non-ZK, Poseidon2)
+    UltraZK,       ///< Zero-knowledge UltraHonk (Poseidon2)
+    UltraKeccak,   ///< UltraHonk with Keccak hash (for EVM verification, non-ZK)
+    UltraKeccakZK, ///< UltraHonk with Keccak hash (ZK variant)
+    UltraRollup    ///< Rollup-optimized UltraHonk
+};
+
+/**
+ * @brief Select the appropriate Ultra flavor based on proof system settings.
+ * @param settings The proof system configuration (hash type, ZK mode, etc.)
+ * @return The corresponding UltraFlavorType enum value
+ *
+ * @details Selection logic:
+ *   - If oracle_hash_type == "keccak": UltraKeccak or UltraKeccakZK
+ *   - If oracle_hash_type == "poseidon2": Ultra or UltraZK
+ *   - UltraRollup is selected based on explicit flag (future extension)
+ *   - disable_zk determines ZK vs non-ZK variant
+ */
+inline UltraFlavorType select_ultra_flavor(const ProofSystemSettings& settings)
+{
+    // Keccak-based flavors (for EVM verification)
+    if (settings.oracle_hash_type == "keccak") {
+        return settings.disable_zk ? UltraFlavorType::UltraKeccak : UltraFlavorType::UltraKeccakZK;
+    }
+
+    // Poseidon2-based flavors (default)
+    // Note: UltraRollup also uses Poseidon2 but with different circuit constraints.
+    // For now, we treat it as standard Ultra. Future: add explicit rollup flag.
+    if (settings.oracle_hash_type == "poseidon2") {
+        return settings.disable_zk ? UltraFlavorType::Ultra : UltraFlavorType::UltraZK;
+    }
+
+    // Default to Poseidon2 non-ZK if oracle_hash_type is unrecognized
+    return settings.disable_zk ? UltraFlavorType::Ultra : UltraFlavorType::UltraZK;
+}
+
+} // namespace bb::bbapi

--- a/barretenberg/cpp/src/barretenberg/bbapi/bbapi_stateful.hpp
+++ b/barretenberg/cpp/src/barretenberg/bbapi/bbapi_stateful.hpp
@@ -175,9 +175,11 @@ std::vector<uint8_t> get_proving_key_serialized(const CircuitInput& circuit, con
     // Compute bytecode hash for cache validation
     auto bytecode_hash_arr = blake3::blake3s(circuit.bytecode);
 
-    // Build proving key from circuit
+    // Build proving key from circuit (with proper metadata for CRS initialization)
+    bool constexpr has_ipa_claim = HasIPAAccumulator<Flavor>;
+    acir_format::ProgramMetadata metadata{ .has_ipa_claim = has_ipa_claim };
     acir_format::AcirProgram program{ acir_format::circuit_buf_to_acir_format(std::vector<uint8_t>(circuit.bytecode)) };
-    auto builder = acir_format::create_circuit<CircuitBuilder>(program);
+    auto builder = acir_format::create_circuit<CircuitBuilder>(program, metadata);
     auto prover_instance = std::make_shared<ProverInstance>(builder);
 
     DeciderProvingKeyExportView export_view;
@@ -236,12 +238,12 @@ std::vector<uint8_t> prove_with_pk(const CircuitInput& circuit,
                        "Please regenerate the proving key with the current bytecode.");
     }
 
-    // Reconstruct circuit from bytecode and witness
+    // Reconstruct circuit from bytecode and witness (with proper metadata for CRS initialization)
+    bool constexpr has_ipa_claim = HasIPAAccumulator<Flavor>;
+    acir_format::ProgramMetadata program_metadata{ .has_ipa_claim = has_ipa_claim };
     acir_format::AcirProgram program{ acir_format::circuit_buf_to_acir_format(std::vector<uint8_t>(circuit.bytecode)) };
     program.witness = acir_format::witness_buf_to_witness_vector(std::vector<uint8_t>(witness));
-    // Note: Assuming UltraCircuitBuilder is compatible with the Flavor's builder requirement
-    // For Mega, we might need MegaCircuitBuilder. Flavor::CircuitBuilder handles this.
-    auto builder = acir_format::create_circuit<CircuitBuilder>(program);
+    auto builder = acir_format::create_circuit<CircuitBuilder>(program, program_metadata);
 
     // Reconstruct metadata from proving key
     MetaData metadata;

--- a/barretenberg/cpp/src/barretenberg/bbapi/bbapi_stateful.hpp
+++ b/barretenberg/cpp/src/barretenberg/bbapi/bbapi_stateful.hpp
@@ -5,6 +5,9 @@
  *
  * This file contains templated structures and functions to support stateful keygen
  * across different flavors (Ultra, UltraZK, Mega, MegaZK).
+ *
+ * Memory optimization: Uses view-based serialization to avoid copying polynomial
+ * coefficients during export. The wire format is identical to owning containers.
  */
 
 #include "barretenberg/bbapi/bbapi_shared.hpp"
@@ -23,16 +26,14 @@
 #include "barretenberg/special_public_inputs/special_public_inputs.hpp"
 #include "barretenberg/ultra_honk/prover_instance.hpp"
 #include "barretenberg/ultra_honk/ultra_prover.hpp"
+#include <span>
 #include <vector>
 
 namespace bb::bbapi {
 
 /**
- * @brief Serializable polynomial data for proving key export.
- * @details Captures all metadata needed to reconstruct a polynomial:
- *   - coefficients: The actual coefficient data
- *   - start_index: The starting index of the memory-backed range (used for shifts)
- *   - virtual_size: The total logical size of the polynomial
+ * @brief Polynomial data for DESERIALIZATION (owning).
+ * @details Used when loading a cached proving key back into memory.
  */
 struct PolynomialExport {
     std::vector<bb::fr> coefficients;
@@ -43,13 +44,36 @@ struct PolynomialExport {
 };
 
 /**
- * @brief Serializable proving key data generic over Flavor.
- * @details Contains circuit-specific precomputed data that can becached and reused.
- * Matches the structure of Flavor::PrecomputedEntities.
+ * @brief Polynomial view for SERIALIZATION (non-owning, zero-copy).
+ * @details References polynomial data directly from ProverInstance memory.
+ * Serializes to the same wire format as PolynomialExport.
+ */
+struct PolynomialExportView {
+    std::span<const bb::fr> coefficients; // View into ProverInstance memory
+    uint64_t start_index;
+    uint64_t virtual_size;
+
+    // Custom msgpack serialization - serializes directly from view, no copy
+    template <typename Packer> void msgpack_pack(Packer& pk) const
+    {
+        pk.pack_array(3);
+        // Pack coefficients array
+        pk.pack_array(static_cast<uint32_t>(coefficients.size()));
+        for (const auto& coeff : coefficients) {
+            pk.pack(coeff);
+        }
+        pk.pack(start_index);
+        pk.pack(virtual_size);
+    }
+};
+
+/**
+ * @brief Proving key data for DESERIALIZATION (owning).
+ * @details Used when loading a cached proving key back into memory.
  */
 struct DeciderProvingKeyExport {
     std::vector<PolynomialExport> polynomials;
-    std::vector<bb::fr> public_inputs; // Can be empty if not part of PK
+    std::vector<bb::fr> public_inputs;
     bb::RelationParameters<bb::fr> relation_parameters;
     std::vector<bb::fr> gate_challenges;
     bb::fr target_sum;
@@ -59,9 +83,7 @@ struct DeciderProvingKeyExport {
     uint64_t pub_inputs_offset;
     uint64_t overflow_size;
     uint64_t final_active_wire_idx;
-    // Bytecode hash for cache validation
     std::vector<uint8_t> bytecode_hash;
-    // Memory records for RAM/ROM lookup arguments
     std::vector<uint32_t> memory_read_records;
     std::vector<uint32_t> memory_write_records;
 
@@ -82,56 +104,132 @@ struct DeciderProvingKeyExport {
 };
 
 /**
- * @brief Generic implementation of proving key extraction and export.
+ * @brief Proving key view for SERIALIZATION (non-owning, zero-copy).
+ * @details References data directly from ProverInstance memory.
+ * Serializes to the same wire format as DeciderProvingKeyExport.
+ */
+struct DeciderProvingKeyExportView {
+    std::vector<PolynomialExportView> polynomials; // Views, not copies
+    std::span<const bb::fr> public_inputs;
+    bb::RelationParameters<bb::fr> relation_parameters;
+    std::span<const bb::fr> gate_challenges;
+    bb::fr target_sum;
+    bool is_structured;
+    uint64_t dyadic_size;
+    uint64_t num_public_inputs;
+    uint64_t pub_inputs_offset;
+    uint64_t overflow_size;
+    uint64_t final_active_wire_idx;
+    std::span<const uint8_t> bytecode_hash;
+    std::span<const uint32_t> memory_read_records;
+    std::span<const uint32_t> memory_write_records;
+
+    // Custom msgpack serialization - zero-copy, serializes directly from views
+    template <typename Packer> void msgpack_pack(Packer& pk) const
+    {
+        pk.pack_array(14);
+
+        // Pack polynomials array
+        pk.pack_array(static_cast<uint32_t>(polynomials.size()));
+        for (const auto& poly : polynomials) {
+            poly.msgpack_pack(pk);
+        }
+
+        // Pack public_inputs
+        pk.pack_array(static_cast<uint32_t>(public_inputs.size()));
+        for (const auto& pi : public_inputs) {
+            pk.pack(pi);
+        }
+
+        pk.pack(relation_parameters);
+
+        // Pack gate_challenges
+        pk.pack_array(static_cast<uint32_t>(gate_challenges.size()));
+        for (const auto& gc : gate_challenges) {
+            pk.pack(gc);
+        }
+
+        pk.pack(target_sum);
+        pk.pack(is_structured);
+        pk.pack(dyadic_size);
+        pk.pack(num_public_inputs);
+        pk.pack(pub_inputs_offset);
+        pk.pack(overflow_size);
+        pk.pack(final_active_wire_idx);
+
+        // Pack bytecode_hash
+        pk.pack_array(static_cast<uint32_t>(bytecode_hash.size()));
+        for (const auto& b : bytecode_hash) {
+            pk.pack(b);
+        }
+
+        // Pack memory_read_records
+        pk.pack_array(static_cast<uint32_t>(memory_read_records.size()));
+        for (const auto& r : memory_read_records) {
+            pk.pack(r);
+        }
+
+        // Pack memory_write_records
+        pk.pack_array(static_cast<uint32_t>(memory_write_records.size()));
+        for (const auto& w : memory_write_records) {
+            pk.pack(w);
+        }
+    }
+};
+
+/**
+ * @brief Generic implementation of proving key extraction and serialization.
  * @tparam Flavor The proving system flavor (e.g. UltraFlavor, UltraZKFlavor)
  * @param circuit The circuit input containing bytecode
  * @param settings Proof system settings (unused but kept for API consistency)
- * @return Serializable proving key data with bytecode hash
+ * @return Serialized proving key as byte vector
  *
- * @details Extracts precomputed polynomials and metadata from a ProverInstance,
- * packages them into a DeciderProvingKeyExport structure, and computes a
- * bytecode hash for cache validation.
+ * @details Uses zero-copy serialization: creates views into ProverInstance memory
+ * and serializes directly to the output buffer. No polynomial coefficient copies.
  */
 template <typename Flavor>
-DeciderProvingKeyExport get_proving_key(const CircuitInput& circuit, const ProofSystemSettings& /*settings*/)
+std::vector<uint8_t> get_proving_key_serialized(const CircuitInput& circuit, const ProofSystemSettings& /*settings*/)
 {
     using ProverInstance = ProverInstance_<Flavor>;
     using CircuitBuilder = typename Flavor::CircuitBuilder;
 
     // Compute bytecode hash for cache validation
     auto bytecode_hash_arr = blake3::blake3s(circuit.bytecode);
-    std::vector<uint8_t> bytecode_hash_vec(bytecode_hash_arr.begin(), bytecode_hash_arr.end());
 
     // Build proving key from circuit
     acir_format::AcirProgram program{ acir_format::circuit_buf_to_acir_format(std::vector<uint8_t>(circuit.bytecode)) };
     auto builder = acir_format::create_circuit<CircuitBuilder>(program);
     auto prover_instance = std::make_shared<ProverInstance>(builder);
 
-    // Export proving key data
-    DeciderProvingKeyExport export_data;
+    // Create view-based export (ZERO-COPY: references prover_instance memory)
+    DeciderProvingKeyExportView export_view;
 
-    // Extract precomputed polynomials
-    for (auto& poly : prover_instance->polynomials.get_precomputed()) {
-        PolynomialExport poly_export;
-        poly_export.coefficients = std::vector<bb::fr>(poly.data(), poly.data() + poly.size());
-        poly_export.start_index = poly.start_index();
-        poly_export.virtual_size = poly.virtual_size();
-        export_data.polynomials.push_back(std::move(poly_export));
+    // Create views into precomputed polynomials (no coefficient copies!)
+    for (const auto& poly : prover_instance->polynomials.get_precomputed()) {
+        export_view.polynomials.push_back(
+            PolynomialExportView{ .coefficients = std::span<const bb::fr>(poly.data(), poly.size()),
+                                  .start_index = poly.start_index(),
+                                  .virtual_size = poly.virtual_size() });
     }
 
-    // Extract metadata
-    export_data.public_inputs = prover_instance->public_inputs;
-    export_data.relation_parameters = prover_instance->relation_parameters;
-    export_data.gate_challenges = prover_instance->gate_challenges;
-    export_data.dyadic_size = prover_instance->dyadic_size();
-    export_data.num_public_inputs = prover_instance->num_public_inputs();
-    export_data.pub_inputs_offset = prover_instance->pub_inputs_offset();
-    export_data.final_active_wire_idx = prover_instance->get_final_active_wire_idx();
-    export_data.bytecode_hash = std::move(bytecode_hash_vec);
-    export_data.memory_read_records = prover_instance->memory_read_records;
-    export_data.memory_write_records = prover_instance->memory_write_records;
+    // Create views into other data (no copies!)
+    export_view.public_inputs = std::span<const bb::fr>(prover_instance->public_inputs);
+    export_view.relation_parameters = prover_instance->relation_parameters;
+    export_view.gate_challenges = std::span<const bb::fr>(prover_instance->gate_challenges);
+    export_view.dyadic_size = prover_instance->dyadic_size();
+    export_view.num_public_inputs = prover_instance->num_public_inputs();
+    export_view.pub_inputs_offset = prover_instance->pub_inputs_offset();
+    export_view.final_active_wire_idx = prover_instance->get_final_active_wire_idx();
+    export_view.bytecode_hash = std::span<const uint8_t>(bytecode_hash_arr);
+    export_view.memory_read_records = std::span<const uint32_t>(prover_instance->memory_read_records);
+    export_view.memory_write_records = std::span<const uint32_t>(prover_instance->memory_write_records);
 
-    return export_data;
+    // Serialize directly from views (prover_instance still alive, memory valid)
+    msgpack::sbuffer buffer;
+    msgpack::pack(buffer, export_view);
+
+    // prover_instance goes out of scope AFTER serialization completes
+    return std::vector<uint8_t>(buffer.data(), buffer.data() + buffer.size());
 }
 
 template <typename Flavor>

--- a/barretenberg/cpp/src/barretenberg/bbapi/bbapi_stateful.hpp
+++ b/barretenberg/cpp/src/barretenberg/bbapi/bbapi_stateful.hpp
@@ -1,13 +1,7 @@
 #pragma once
 /**
  * @file bbapi_stateful.hpp
- * @brief Generic abstraction for stateful proving key hydration and proving.
- *
- * This file contains templated structures and functions to support stateful keygen
- * across different flavors (Ultra, UltraZK, Mega, MegaZK).
- *
- * Memory optimization: Uses view-based serialization to avoid copying polynomial
- * coefficients during export. The wire format is identical to owning containers.
+ * @brief Stateful proving key caching for UltraHonk flavors.
  */
 
 #include "barretenberg/bbapi/bbapi_shared.hpp"
@@ -32,8 +26,7 @@
 namespace bb::bbapi {
 
 /**
- * @brief Polynomial data for DESERIALIZATION (owning).
- * @details Used when loading a cached proving key back into memory.
+ * @brief Polynomial data for deserialization (owning).
  */
 struct PolynomialExport {
     std::vector<bb::fr> coefficients;
@@ -44,20 +37,16 @@ struct PolynomialExport {
 };
 
 /**
- * @brief Polynomial view for SERIALIZATION (non-owning, zero-copy).
- * @details References polynomial data directly from ProverInstance memory.
- * Serializes to the same wire format as PolynomialExport.
+ * @brief Polynomial view for serialization (non-owning, zero-copy).
  */
 struct PolynomialExportView {
-    std::span<const bb::fr> coefficients; // View into ProverInstance memory
+    std::span<const bb::fr> coefficients;
     uint64_t start_index;
     uint64_t virtual_size;
 
-    // Custom msgpack serialization - serializes directly from view, no copy
     template <typename Packer> void msgpack_pack(Packer& pk) const
     {
         pk.pack_array(3);
-        // Pack coefficients array
         pk.pack_array(static_cast<uint32_t>(coefficients.size()));
         for (const auto& coeff : coefficients) {
             pk.pack(coeff);
@@ -68,8 +57,7 @@ struct PolynomialExportView {
 };
 
 /**
- * @brief Proving key data for DESERIALIZATION (owning).
- * @details Used when loading a cached proving key back into memory.
+ * @brief Proving key data for deserialization (owning).
  */
 struct DeciderProvingKeyExport {
     std::vector<PolynomialExport> polynomials;
@@ -104,12 +92,10 @@ struct DeciderProvingKeyExport {
 };
 
 /**
- * @brief Proving key view for SERIALIZATION (non-owning, zero-copy).
- * @details References data directly from ProverInstance memory.
- * Serializes to the same wire format as DeciderProvingKeyExport.
+ * @brief Proving key view for serialization (non-owning, zero-copy).
  */
 struct DeciderProvingKeyExportView {
-    std::vector<PolynomialExportView> polynomials; // Views, not copies
+    std::vector<PolynomialExportView> polynomials;
     std::span<const bb::fr> public_inputs;
     bb::RelationParameters<bb::fr> relation_parameters;
     std::span<const bb::fr> gate_challenges;
@@ -178,14 +164,7 @@ struct DeciderProvingKeyExportView {
 };
 
 /**
- * @brief Generic implementation of proving key extraction and serialization.
- * @tparam Flavor The proving system flavor (e.g. UltraFlavor, UltraZKFlavor)
- * @param circuit The circuit input containing bytecode
- * @param settings Proof system settings (unused but kept for API consistency)
- * @return Serialized proving key as byte vector
- *
- * @details Uses zero-copy serialization: creates views into ProverInstance memory
- * and serializes directly to the output buffer. No polynomial coefficient copies.
+ * @brief Extract and serialize proving key from circuit (zero-copy).
  */
 template <typename Flavor>
 std::vector<uint8_t> get_proving_key_serialized(const CircuitInput& circuit, const ProofSystemSettings& /*settings*/)
@@ -201,10 +180,8 @@ std::vector<uint8_t> get_proving_key_serialized(const CircuitInput& circuit, con
     auto builder = acir_format::create_circuit<CircuitBuilder>(program);
     auto prover_instance = std::make_shared<ProverInstance>(builder);
 
-    // Create view-based export (ZERO-COPY: references prover_instance memory)
     DeciderProvingKeyExportView export_view;
 
-    // Create views into precomputed polynomials (no coefficient copies!)
     for (const auto& poly : prover_instance->polynomials.get_precomputed()) {
         export_view.polynomials.push_back(
             PolynomialExportView{ .coefficients = std::span<const bb::fr>(poly.data(), poly.size()),
@@ -212,7 +189,6 @@ std::vector<uint8_t> get_proving_key_serialized(const CircuitInput& circuit, con
                                   .virtual_size = poly.virtual_size() });
     }
 
-    // Create views into other data (no copies!)
     export_view.public_inputs = std::span<const bb::fr>(prover_instance->public_inputs);
     export_view.relation_parameters = prover_instance->relation_parameters;
     export_view.gate_challenges = std::span<const bb::fr>(prover_instance->gate_challenges);
@@ -224,11 +200,8 @@ std::vector<uint8_t> get_proving_key_serialized(const CircuitInput& circuit, con
     export_view.memory_read_records = std::span<const uint32_t>(prover_instance->memory_read_records);
     export_view.memory_write_records = std::span<const uint32_t>(prover_instance->memory_write_records);
 
-    // Serialize directly from views (prover_instance still alive, memory valid)
     msgpack::sbuffer buffer;
     msgpack::pack(buffer, export_view);
-
-    // prover_instance goes out of scope AFTER serialization completes
     return std::vector<uint8_t>(buffer.data(), buffer.data() + buffer.size());
 }
 

--- a/barretenberg/cpp/src/barretenberg/bbapi/bbapi_stateful.hpp
+++ b/barretenberg/cpp/src/barretenberg/bbapi/bbapi_stateful.hpp
@@ -1,0 +1,241 @@
+#pragma once
+/**
+ * @file bbapi_stateful.hpp
+ * @brief Generic abstraction for stateful proving key hydration and proving.
+ *
+ * This file contains templated structures and functions to support stateful keygen
+ * across different flavors (Ultra, UltraZK, Mega, MegaZK).
+ */
+
+#include "barretenberg/bbapi/bbapi_shared.hpp"
+#include "barretenberg/common/log.hpp"
+#include "barretenberg/common/serialize.hpp"
+#include "barretenberg/common/throw_or_abort.hpp"
+#include "barretenberg/crypto/blake3s/blake3s.hpp"
+#include "barretenberg/dsl/acir_format/acir_format.hpp"
+#include "barretenberg/dsl/acir_format/acir_to_constraint_buf.hpp"
+#include "barretenberg/dsl/acir_format/serde/witness_stack.hpp"
+#include "barretenberg/ecc/curves/bn254/fr.hpp"
+#include "barretenberg/numeric/uint256/uint256.hpp"
+#include "barretenberg/relations/relation_parameters.hpp"
+#include "barretenberg/serialize/msgpack.hpp"
+#include "barretenberg/ultra_honk/prover_instance.hpp"
+#include "barretenberg/ultra_honk/ultra_prover.hpp"
+#include <vector>
+
+namespace bb::bbapi {
+
+/**
+ * @brief Serializable polynomial data for proving key export.
+ * @details Captures all metadata needed to reconstruct a polynomial:
+ *   - coefficients: The actual coefficient data
+ *   - start_index: The starting index of the memory-backed range (used for shifts)
+ *   - virtual_size: The total logical size of the polynomial
+ */
+struct PolynomialExport {
+    std::vector<bb::fr> coefficients;
+    uint64_t start_index;
+    uint64_t virtual_size;
+
+    MSGPACK_FIELDS(coefficients, start_index, virtual_size);
+};
+
+/**
+ * @brief Serializable proving key data generic over Flavor.
+ * @details Contains circuit-specific precomputed data that can becached and reused.
+ * Matches the structure of Flavor::PrecomputedEntities.
+ */
+struct DeciderProvingKeyExport {
+    std::vector<PolynomialExport> polynomials;
+    std::vector<bb::fr> public_inputs; // Can be empty if not part of PK
+    bb::RelationParameters<bb::fr> relation_parameters;
+    std::vector<bb::fr> gate_challenges;
+    bb::fr target_sum;
+    bool is_structured;
+    uint64_t dyadic_size;
+    uint64_t num_public_inputs;
+    uint64_t pub_inputs_offset;
+    uint64_t overflow_size;
+    uint64_t final_active_wire_idx;
+    // Bytecode hash for cache validation
+    std::vector<uint8_t> bytecode_hash;
+    // Memory records for RAM/ROM lookup arguments
+    std::vector<uint32_t> memory_read_records;
+    std::vector<uint32_t> memory_write_records;
+
+    MSGPACK_FIELDS(polynomials,
+                   public_inputs,
+                   relation_parameters,
+                   gate_challenges,
+                   target_sum,
+                   is_structured,
+                   dyadic_size,
+                   num_public_inputs,
+                   pub_inputs_offset,
+                   overflow_size,
+                   final_active_wire_idx,
+                   bytecode_hash,
+                   memory_read_records,
+                   memory_write_records);
+};
+
+/**
+ * @brief Generic implementation of proving key extraction and export.
+ * @tparam Flavor The proving system flavor (e.g. UltraFlavor, UltraZKFlavor)
+ * @param circuit The circuit input containing bytecode
+ * @param settings Proof system settings (unused but kept for API consistency)
+ * @return Serializable proving key data with bytecode hash
+ *
+ * @details Extracts precomputed polynomials and metadata from a ProverInstance,
+ * packages them into a DeciderProvingKeyExport structure, and computes a
+ * bytecode hash for cache validation.
+ */
+template <typename Flavor>
+DeciderProvingKeyExport get_proving_key(const CircuitInput& circuit, const ProofSystemSettings& /*settings*/)
+{
+    using ProverInstance = ProverInstance_<Flavor>;
+    using CircuitBuilder = typename Flavor::CircuitBuilder;
+
+    // Compute bytecode hash for cache validation
+    auto bytecode_hash_arr = blake3::blake3s(circuit.bytecode);
+    std::vector<uint8_t> bytecode_hash_vec(bytecode_hash_arr.begin(), bytecode_hash_arr.end());
+
+    // Build proving key from circuit
+    acir_format::AcirProgram program{ acir_format::circuit_buf_to_acir_format(std::vector<uint8_t>(circuit.bytecode)) };
+    auto builder = acir_format::create_circuit<CircuitBuilder>(program);
+    auto prover_instance = std::make_shared<ProverInstance>(builder);
+
+    // Export proving key data
+    DeciderProvingKeyExport export_data;
+
+    // Extract precomputed polynomials
+    for (auto& poly : prover_instance->polynomials.get_precomputed()) {
+        PolynomialExport poly_export;
+        poly_export.coefficients = std::vector<bb::fr>(poly.data(), poly.data() + poly.size());
+        poly_export.start_index = poly.start_index();
+        poly_export.virtual_size = poly.virtual_size();
+        export_data.polynomials.push_back(std::move(poly_export));
+    }
+
+    // Extract metadata
+    export_data.public_inputs = prover_instance->public_inputs;
+    export_data.relation_parameters = prover_instance->relation_parameters;
+    export_data.gate_challenges = prover_instance->gate_challenges;
+    export_data.dyadic_size = prover_instance->dyadic_size();
+    export_data.num_public_inputs = prover_instance->num_public_inputs();
+    export_data.pub_inputs_offset = prover_instance->pub_inputs_offset();
+    export_data.final_active_wire_idx = prover_instance->get_final_active_wire_idx();
+    export_data.bytecode_hash = std::move(bytecode_hash_vec);
+    export_data.memory_read_records = prover_instance->memory_read_records;
+    export_data.memory_write_records = prover_instance->memory_write_records;
+
+    return export_data;
+}
+
+template <typename Flavor>
+std::vector<uint8_t> prove_with_pk(const CircuitInput& circuit,
+                                   const std::vector<uint8_t>& witness,
+                                   const std::vector<uint8_t>& proving_key,
+                                   const ProofSystemSettings& /*settings*/)
+{
+    using ProverInstance = ProverInstance_<Flavor>;
+    using VerificationKey = typename Flavor::VerificationKey;
+    using CircuitBuilder = typename Flavor::CircuitBuilder;
+    using Prover = UltraProver_<Flavor>; // UltraProver handles both Ultra and ZK flavors if template arguments match
+
+    // Compute bytecode hash for cache validation
+    auto current_bytecode_hash = blake3::blake3s(circuit.bytecode);
+
+    // Deserialize proving key
+    DeciderProvingKeyExport pk_data;
+    msgpack::object_handle oh = msgpack::unpack((const char*)proving_key.data(), proving_key.size());
+    msgpack::object obj = oh.get();
+    obj.convert(pk_data);
+
+    // Validate bytecode hash matches proving key
+    bool hash_matches =
+        (pk_data.bytecode_hash.size() == current_bytecode_hash.size()) &&
+        std::equal(pk_data.bytecode_hash.begin(), pk_data.bytecode_hash.end(), current_bytecode_hash.begin());
+
+    if (!hash_matches) {
+        throw_or_abort("AcirProveWithPk: Bytecode hash mismatch. "
+                       "The proving key was generated for a different circuit. "
+                       "Please regenerate the proving key with the current bytecode.");
+    }
+
+    // Reconstruct circuit from bytecode and witness
+    acir_format::AcirProgram program{ acir_format::circuit_buf_to_acir_format(std::vector<uint8_t>(circuit.bytecode)) };
+    program.witness = acir_format::witness_buf_to_witness_vector(std::vector<uint8_t>(witness));
+    // Note: Assuming UltraCircuitBuilder is compatible with the Flavor's builder requirement
+    // For Mega, we might need MegaCircuitBuilder. Flavor::CircuitBuilder handles this.
+    auto builder = acir_format::create_circuit<CircuitBuilder>(program);
+
+    // Reconstruct metadata from proving key
+    MetaData metadata;
+    metadata.dyadic_size = static_cast<size_t>(pk_data.dyadic_size);
+    metadata.num_public_inputs = static_cast<size_t>(pk_data.num_public_inputs);
+    metadata.pub_inputs_offset = static_cast<size_t>(pk_data.pub_inputs_offset);
+
+    // Convert PolynomialExport to ProverInstance::PolynomialData
+    std::vector<typename ProverInstance::PolynomialData> poly_data_vec;
+    poly_data_vec.reserve(pk_data.polynomials.size());
+    for (auto& poly_export : pk_data.polynomials) {
+        typename ProverInstance::PolynomialData poly_data;
+        poly_data.coefficients = std::move(poly_export.coefficients);
+        poly_data.start_index = static_cast<size_t>(poly_export.start_index);
+        poly_data.virtual_size = static_cast<size_t>(poly_export.virtual_size);
+        poly_data_vec.push_back(std::move(poly_data));
+    }
+
+    // HYDRATION: Create ProverInstance using precomputed polynomials from proving key
+    auto instance = std::make_shared<ProverInstance>(builder,
+                                                     std::move(poly_data_vec),
+                                                     metadata,
+                                                     static_cast<size_t>(pk_data.final_active_wire_idx),
+                                                     std::move(pk_data.memory_read_records),
+                                                     std::move(pk_data.memory_write_records));
+
+    // Construct verification key and prove
+    auto verification_key = std::make_shared<VerificationKey>(instance->get_precomputed());
+    Prover prover{ instance, verification_key };
+
+    auto proof = prover.construct_proof();
+
+    // Calculate inner public inputs (excluding pairing point accumulator)
+    size_t num_inner_public_inputs = [&]() {
+        size_t num_public_inputs = instance->num_public_inputs();
+        // Assuming PAIRING_POINT_SIZE is standard across flavors for now
+        // UltraFlavor uses DefaultIO::PUBLIC_INPUTS_SIZE = 16
+        constexpr size_t PAIRING_POINT_SIZE = 16;
+        BB_ASSERT(num_public_inputs >= PAIRING_POINT_SIZE, "Public inputs should contain a pairing point accumulator.");
+        return num_public_inputs - PAIRING_POINT_SIZE;
+    }();
+
+    // Create the combined result [num_inputs][inputs...][proof...]
+    std::vector<uint8_t> result_vec;
+    size_t total_size = 4 + (num_inner_public_inputs * 32) + (proof.size() * 32);
+    result_vec.resize(total_size);
+
+    uint8_t* ptr = result_vec.data();
+
+    // Pack num_inner_public_inputs (4 bytes, big endian)
+    uint32_t num_pub_inputs_be = htonl(static_cast<uint32_t>(num_inner_public_inputs));
+    std::memcpy(ptr, &num_pub_inputs_be, 4);
+    ptr += 4;
+
+    // Pack inner public inputs (first N elements of proof)
+    for (size_t i = 0; i < num_inner_public_inputs; ++i) {
+        bb::fr::serialize_to_buffer(proof[i], ptr);
+        ptr += 32;
+    }
+
+    // Pack proof (remaining elements)
+    for (size_t i = num_inner_public_inputs; i < proof.size(); ++i) {
+        bb::fr::serialize_to_buffer(proof[i], ptr);
+        ptr += 32;
+    }
+
+    return result_vec;
+}
+
+} // namespace bb::bbapi

--- a/barretenberg/cpp/src/barretenberg/bbapi/bbapi_stateful.hpp
+++ b/barretenberg/cpp/src/barretenberg/bbapi/bbapi_stateful.hpp
@@ -16,9 +16,11 @@
 #include "barretenberg/dsl/acir_format/acir_to_constraint_buf.hpp"
 #include "barretenberg/dsl/acir_format/serde/witness_stack.hpp"
 #include "barretenberg/ecc/curves/bn254/fr.hpp"
+#include "barretenberg/flavor/flavor_concepts.hpp"
 #include "barretenberg/numeric/uint256/uint256.hpp"
 #include "barretenberg/relations/relation_parameters.hpp"
 #include "barretenberg/serialize/msgpack.hpp"
+#include "barretenberg/special_public_inputs/special_public_inputs.hpp"
 #include "barretenberg/ultra_honk/prover_instance.hpp"
 #include "barretenberg/ultra_honk/ultra_prover.hpp"
 #include <vector>
@@ -202,13 +204,22 @@ std::vector<uint8_t> prove_with_pk(const CircuitInput& circuit,
     auto proof = prover.construct_proof();
 
     // Calculate inner public inputs (excluding pairing point accumulator)
+    // Use flavor-specific constants for correct public input size
     size_t num_inner_public_inputs = [&]() {
         size_t num_public_inputs = instance->num_public_inputs();
-        // Assuming PAIRING_POINT_SIZE is standard across flavors for now
-        // UltraFlavor uses DefaultIO::PUBLIC_INPUTS_SIZE = 16
-        constexpr size_t PAIRING_POINT_SIZE = 16;
-        BB_ASSERT(num_public_inputs >= PAIRING_POINT_SIZE, "Public inputs should contain a pairing point accumulator.");
-        return num_public_inputs - PAIRING_POINT_SIZE;
+        if constexpr (HasIPAAccumulator<Flavor>) {
+            // UltraRollup includes both pairing points and IPA claim
+            constexpr size_t ROLLUP_SPECIAL_SIZE = RollupIO::PUBLIC_INPUTS_SIZE;
+            BB_ASSERT(num_public_inputs >= ROLLUP_SPECIAL_SIZE,
+                      "Public inputs should contain pairing points and IPA claim.");
+            return num_public_inputs - ROLLUP_SPECIAL_SIZE;
+        } else {
+            // Standard Ultra flavors only have pairing points
+            constexpr size_t DEFAULT_SPECIAL_SIZE = DefaultIO::PUBLIC_INPUTS_SIZE;
+            BB_ASSERT(num_public_inputs >= DEFAULT_SPECIAL_SIZE,
+                      "Public inputs should contain a pairing point accumulator.");
+            return num_public_inputs - DEFAULT_SPECIAL_SIZE;
+        }
     }();
 
     // Create the combined result [num_inputs][inputs...][proof...]

--- a/barretenberg/cpp/src/barretenberg/bbapi/bbapi_stateful_keygen.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/bbapi/bbapi_stateful_keygen.test.cpp
@@ -11,44 +11,39 @@ namespace bb::bbapi {
 class StatefulKeygenTest : public ::testing::Test {
   protected:
     static void SetUpTestSuite() { bb::srs::init_file_crs_factory(bb::srs::bb_crs_path()); }
+
+    // All flavor settings to test
+    static std::vector<ProofSystemSettings> all_settings()
+    {
+        return {
+            { .ipa_accumulation = true, .oracle_hash_type = "poseidon2", .disable_zk = false },  // UltraRollup
+            { .ipa_accumulation = false, .oracle_hash_type = "poseidon2", .disable_zk = false }, // UltraZK
+            { .ipa_accumulation = false, .oracle_hash_type = "poseidon2", .disable_zk = true },  // Ultra
+            { .ipa_accumulation = false, .oracle_hash_type = "keccak", .disable_zk = false },    // UltraKeccakZK
+            { .ipa_accumulation = false, .oracle_hash_type = "keccak", .disable_zk = true }      // UltraKeccak
+        };
+    }
+
+    static std::string settings_to_string(const ProofSystemSettings& s)
+    {
+        return "ipa=" + std::to_string(s.ipa_accumulation) + ",hash=" + s.oracle_hash_type +
+               ",zk=" + std::to_string(!s.disable_zk);
+    }
 };
 
-/**
- * @brief Test AcirGetProvingKey command
- * @details Verifies that we can generate a proving key from circuit bytecode
- */
-TEST_F(StatefulKeygenTest, AcirGetProvingKey)
-{
-    auto [bytecode, _witness] = acir_bincode_mocks::create_simple_circuit_bytecode();
-
-    bbapi::ProofSystemSettings settings{ .ipa_accumulation = false,
-                                         .oracle_hash_type = "poseidon2",
-                                         .disable_zk = true }; // UltraFlavor
-
-    // Generate proving key
-    auto pk_response =
-        AcirGetProvingKey{ .circuit = { .name = "test_circuit", .bytecode = bytecode }, .settings = settings }
-            .execute();
-
-    // Verify proving key was generated
-    EXPECT_FALSE(pk_response.proving_key.empty()) << "Proving key should not be empty";
-    EXPECT_GT(pk_response.proving_key.size(), 100) << "Proving key should be reasonably sized";
-}
-
-// Helper to unpack combined result from vector<uint8_t>
+// Helper to unpack combined result
 std::pair<std::vector<uint256_t>, std::vector<uint256_t>> unpack_combined(const std::vector<uint8_t>& combined)
 {
     if (combined.size() < 4) {
         throw std::runtime_error("Combined result too small");
     }
 
-    // Read num_public_inputs (first 4 bytes, big endian)
     uint32_t num_pub_inputs_be;
     std::memcpy(&num_pub_inputs_be, combined.data(), 4);
     uint32_t num_pub_inputs = ntohl(num_pub_inputs_be);
 
     size_t offset = 4;
-    size_t element_size = 32;
+    constexpr size_t element_size = 32;
     size_t pub_inputs_bytes = num_pub_inputs * element_size;
 
     if (combined.size() < offset + pub_inputs_bytes) {
@@ -67,195 +62,152 @@ std::pair<std::vector<uint256_t>, std::vector<uint256_t>> unpack_combined(const 
     if (remaining_bytes % element_size != 0) {
         throw std::runtime_error("Invalid proof size in combined result");
     }
-    size_t num_proof_elements = remaining_bytes / element_size;
 
     std::vector<uint256_t> proof;
-    for (size_t i = 0; i < num_proof_elements; ++i) {
+    for (size_t i = 0; i < remaining_bytes / element_size; ++i) {
         uint64_t bin_data[4];
         std::memcpy(bin_data, &combined[offset + i * element_size], element_size);
         proof.emplace_back(ntohll(bin_data[3]), ntohll(bin_data[2]), ntohll(bin_data[1]), ntohll(bin_data[0]));
     }
 
-    return std::make_pair(public_inputs, proof);
+    return { public_inputs, proof };
 }
 
 /**
- * @brief Test AcirProveWithPk command
- * @details Verifies that we can prove using a pre-computed proving key
+ * @brief Core test: stateful workflow produces verifiable proofs across all flavors
  */
-TEST_F(StatefulKeygenTest, AcirProveWithPk)
+TEST_F(StatefulKeygenTest, StatefulProveAndVerify)
 {
     auto [bytecode, witness] = acir_bincode_mocks::create_simple_circuit_bytecode();
 
-    bbapi::ProofSystemSettings settings{ .ipa_accumulation = false,
-                                         .oracle_hash_type = "poseidon2",
-                                         .disable_zk = true }; // UltraFlavor
+    for (const auto& settings : all_settings()) {
+        SCOPED_TRACE(settings_to_string(settings));
 
-    // Step 1: Generate proving key
-    auto pk_response =
-        AcirGetProvingKey{ .circuit = { .name = "test_circuit", .bytecode = bytecode }, .settings = settings }
-            .execute();
+        // Get proving key
+        auto pk_response =
+            AcirGetProvingKey{ .circuit = { .name = "test", .bytecode = bytecode }, .settings = settings }.execute();
+        ASSERT_FALSE(pk_response.proving_key.empty());
 
-    // Step 2: Prove with pre-computed key
-    auto prove_response = AcirProveWithPk{ .circuit = { .name = "test_circuit", .bytecode = bytecode },
-                                           .witness = witness,
-                                           .proving_key = pk_response.proving_key,
-                                           .settings = settings }
-                              .execute();
+        // Prove with cached key
+        auto prove_response = AcirProveWithPk{ .circuit = { .name = "test", .bytecode = bytecode },
+                                               .witness = witness,
+                                               .proving_key = pk_response.proving_key,
+                                               .settings = settings }
+                                  .execute();
 
-    // Verify proof was generated
-    auto [public_inputs, proof] = unpack_combined(prove_response.combined_result);
-    EXPECT_FALSE(proof.empty()) << "Proof should not be empty";
-    // Note: public_inputs may be empty for simple circuits with no declared public inputs
-    // The 16-element pairing point accumulator is internal and not included in inner public inputs
+        auto [public_inputs, proof] = unpack_combined(prove_response.combined_result);
+        ASSERT_FALSE(proof.empty());
+
+        // Verify proof
+        auto vk_response =
+            CircuitComputeVk{ .circuit = { .name = "test", .bytecode = bytecode }, .settings = settings }.execute();
+
+        auto verify_response = CircuitVerify{ .verification_key = vk_response.bytes,
+                                              .public_inputs = public_inputs,
+                                              .proof = proof,
+                                              .settings = settings }
+                                   .execute();
+
+        EXPECT_TRUE(verify_response.verified);
+    }
 }
 
 /**
- * @brief Test stateful workflow: Generate key once, prove multiple times
- * @details This is the key use case for stateful keygen - reusing the proving key
- */
-TEST_F(StatefulKeygenTest, MultipleProofsWithSameKey)
-{
-    // Create ONE circuit bytecode
-    auto [bytecode, witness1] = acir_bincode_mocks::create_simple_circuit_bytecode();
-
-    // Create a SECOND witness for the SAME circuit (different a,b values: 4*5=20 instead of 2*3=6)
-    auto witness2 = acir_bincode_mocks::create_witness_for_simple_circuit(bb::fr(4), bb::fr(5));
-
-    bbapi::ProofSystemSettings settings{ .ipa_accumulation = false,
-                                         .oracle_hash_type = "poseidon2",
-                                         .disable_zk = true };
-
-    // Generate proving key ONCE
-    auto pk_response =
-        AcirGetProvingKey{ .circuit = { .name = "test_circuit", .bytecode = bytecode }, .settings = settings }
-            .execute();
-
-    // Prove MULTIPLE times with different witnesses (same circuit structure)
-    auto proof1 = AcirProveWithPk{ .circuit = { .name = "test_circuit", .bytecode = bytecode },
-                                   .witness = witness1,
-                                   .proving_key = pk_response.proving_key,
-                                   .settings = settings }
-                      .execute();
-
-    auto proof2 = AcirProveWithPk{ .circuit = { .name = "test_circuit", .bytecode = bytecode },
-                                   .witness = witness2,
-                                   .proving_key = pk_response.proving_key,
-                                   .settings = settings }
-                      .execute();
-
-    // Both proofs should be valid but different (different witnesses)
-    auto [public_inputs1, proof1_vec] = unpack_combined(proof1.combined_result);
-    auto [public_inputs2, proof2_vec] = unpack_combined(proof2.combined_result);
-
-    EXPECT_FALSE(proof1_vec.empty());
-    EXPECT_FALSE(proof2_vec.empty());
-    // Proofs should differ because witnesses differ
-    EXPECT_NE(proof1_vec, proof2_vec) << "Different witnesses should produce different proofs";
-}
-
-/**
- * @brief Test that stateful keygen produces same proof as one-shot proving
- * @details Verifies correctness by comparing against CircuitProve
+ * @brief Equivalence: stateful and one-shot produce matching public inputs
  */
 TEST_F(StatefulKeygenTest, EquivalenceWithCircuitProve)
 {
     auto [bytecode, witness] = acir_bincode_mocks::create_simple_circuit_bytecode();
 
-    bbapi::ProofSystemSettings settings{ .ipa_accumulation = false,
-                                         .oracle_hash_type = "poseidon2",
-                                         .disable_zk = true };
+    for (const auto& settings : all_settings()) {
+        SCOPED_TRACE(settings_to_string(settings));
 
-    // Method 1: Stateful (get key + prove with key)
-    auto pk_response =
-        AcirGetProvingKey{ .circuit = { .name = "test_circuit", .bytecode = bytecode }, .settings = settings }
-            .execute();
+        // Stateful path
+        auto pk_response =
+            AcirGetProvingKey{ .circuit = { .name = "test", .bytecode = bytecode }, .settings = settings }.execute();
 
-    auto stateful_proof = AcirProveWithPk{ .circuit = { .name = "test_circuit", .bytecode = bytecode },
-                                           .witness = witness,
-                                           .proving_key = pk_response.proving_key,
-                                           .settings = settings }
-                              .execute();
+        auto stateful_proof = AcirProveWithPk{ .circuit = { .name = "test", .bytecode = bytecode },
+                                               .witness = witness,
+                                               .proving_key = pk_response.proving_key,
+                                               .settings = settings }
+                                  .execute();
 
-    // Method 2: One-shot (CircuitProve)
-    auto vk_response =
-        CircuitComputeVk{ .circuit = { .name = "test_circuit", .bytecode = bytecode }, .settings = settings }.execute();
+        // One-shot path
+        auto vk_response =
+            CircuitComputeVk{ .circuit = { .name = "test", .bytecode = bytecode }, .settings = settings }.execute();
 
-    auto oneshot_proof = CircuitProve{ .circuit = { .name = "test_circuit",
-                                                    .bytecode = bytecode,
-                                                    .verification_key = vk_response.bytes },
-                                       .witness = witness,
-                                       .settings = settings }
-                             .execute();
+        auto oneshot_proof =
+            CircuitProve{ .circuit = { .name = "test", .bytecode = bytecode, .verification_key = vk_response.bytes },
+                          .witness = witness,
+                          .settings = settings }
+                .execute();
 
-    auto [stateful_public_inputs, stateful_proof_data] = unpack_combined(stateful_proof.combined_result);
+        auto [stateful_pub, _] = unpack_combined(stateful_proof.combined_result);
+        auto [oneshot_pub, __] = unpack_combined(oneshot_proof.combined_result);
 
-    // Both methods should produce valid proofs with same public inputs
-    auto [oneshot_public_inputs, oneshot_proof_data] = unpack_combined(oneshot_proof.combined_result);
-    EXPECT_EQ(stateful_public_inputs, oneshot_public_inputs) << "Public inputs mismatch";
-    EXPECT_FALSE(stateful_proof_data.empty()) << "Proof should not be empty";
-
-    auto verify_stateful =
-        CircuitVerify{
-            .verification_key = vk_response.bytes, // Assuming vk_response.bytes is the intended verification key
-            .public_inputs = stateful_public_inputs,
-            .proof = stateful_proof_data,
-            .settings = settings,
-        }
-            .execute();
-
-    auto verify_oneshot = CircuitVerify{ .verification_key = vk_response.bytes,
-                                         .public_inputs = oneshot_public_inputs,
-                                         .proof = oneshot_proof_data,
-                                         .settings = settings }
-                              .execute();
-
-    EXPECT_TRUE(verify_stateful.verified) << "Stateful proof should verify";
-    EXPECT_TRUE(verify_oneshot.verified) << "One-shot proof should verify";
+        EXPECT_EQ(stateful_pub, oneshot_pub) << "Public inputs must match between stateful and one-shot";
+    }
 }
 
 /**
- * @brief Test that bytecode hash mismatch is detected
- * @details Verifies that using a proving key generated for one circuit
- * with a different circuit's bytecode throws an appropriate error
+ * @brief Security: bytecode hash mismatch is caught
  */
 TEST_F(StatefulKeygenTest, BytecodeHashMismatch)
 {
-    // Create two different circuits
     auto [bytecode1, witness1] = acir_bincode_mocks::create_simple_circuit_bytecode(1);
     auto [bytecode2, witness2] = acir_bincode_mocks::create_simple_circuit_bytecode(2);
 
-    bbapi::ProofSystemSettings settings{ .ipa_accumulation = false,
-                                         .oracle_hash_type = "poseidon2",
-                                         .disable_zk = true };
+    // Test with one representative flavor (the validation logic is flavor-agnostic)
+    ProofSystemSettings settings{ .ipa_accumulation = false, .oracle_hash_type = "poseidon2", .disable_zk = true };
 
-    // Generate proving key for circuit 1
     auto pk_response =
-        AcirGetProvingKey{ .circuit = { .name = "test_circuit", .bytecode = bytecode1 }, .settings = settings }
-            .execute();
+        AcirGetProvingKey{ .circuit = { .name = "test", .bytecode = bytecode1 }, .settings = settings }.execute();
 
-    // Try to use it with circuit 2's bytecode - should fail
-    // Note: EXPECT_THROW doesn't work with brace-enclosed initializer lists,
-    // so we use a lambda and manual exception checking
-    bool threw_expected_exception = false;
+    bool threw = false;
     try {
-        AcirProveWithPk prove_cmd;
-        prove_cmd.circuit = { .name = "test_circuit", .bytecode = bytecode2 };
-        prove_cmd.witness = witness2;
-        prove_cmd.proving_key = pk_response.proving_key;
-        prove_cmd.settings = settings;
-        std::move(prove_cmd).execute();
+        AcirProveWithPk cmd;
+        cmd.circuit = { .name = "test", .bytecode = bytecode2 };
+        cmd.witness = witness2;
+        cmd.proving_key = pk_response.proving_key;
+        cmd.settings = settings;
+        std::move(cmd).execute();
     } catch (const std::runtime_error& e) {
-        threw_expected_exception = true;
-        // Verify the error message mentions bytecode hash mismatch
-        std::string error_msg = e.what();
-        EXPECT_TRUE(error_msg.find("Bytecode hash mismatch") != std::string::npos ||
-                    error_msg.find("bytecode") != std::string::npos)
-            << "Error message should mention bytecode hash mismatch, got: " << error_msg;
-    } catch (...) {
-        FAIL() << "Expected std::runtime_error but got different exception type";
+        threw = true;
+        EXPECT_TRUE(std::string(e.what()).find("Bytecode hash") != std::string::npos);
     }
-    EXPECT_TRUE(threw_expected_exception) << "Using proving key with mismatched bytecode should throw";
+    EXPECT_TRUE(threw) << "Mismatched bytecode should throw";
+}
+
+/**
+ * @brief Key reuse: same key, multiple witnesses
+ */
+TEST_F(StatefulKeygenTest, MultipleProofsWithSameKey)
+{
+    auto [bytecode, witness1] = acir_bincode_mocks::create_simple_circuit_bytecode();
+    auto witness2 = acir_bincode_mocks::create_witness_for_simple_circuit(bb::fr(4), bb::fr(5));
+
+    // Test with one representative flavor
+    ProofSystemSettings settings{ .ipa_accumulation = false, .oracle_hash_type = "poseidon2", .disable_zk = false };
+
+    auto pk_response =
+        AcirGetProvingKey{ .circuit = { .name = "test", .bytecode = bytecode }, .settings = settings }.execute();
+
+    auto proof1 = AcirProveWithPk{ .circuit = { .name = "test", .bytecode = bytecode },
+                                   .witness = witness1,
+                                   .proving_key = pk_response.proving_key,
+                                   .settings = settings }
+                      .execute();
+
+    auto proof2 = AcirProveWithPk{ .circuit = { .name = "test", .bytecode = bytecode },
+                                   .witness = witness2,
+                                   .proving_key = pk_response.proving_key,
+                                   .settings = settings }
+                      .execute();
+
+    auto [_, proof1_vec] = unpack_combined(proof1.combined_result);
+    auto [__, proof2_vec] = unpack_combined(proof2.combined_result);
+
+    EXPECT_NE(proof1_vec, proof2_vec) << "Different witnesses should produce different proofs";
 }
 
 } // namespace bb::bbapi

--- a/barretenberg/cpp/src/barretenberg/bbapi/bbapi_stateful_keygen.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/bbapi/bbapi_stateful_keygen.test.cpp
@@ -1,0 +1,261 @@
+#include "barretenberg/bbapi/bbapi_ultra_honk.hpp"
+#include "barretenberg/chonk/acir_bincode_mocks.hpp"
+#include "barretenberg/common/net.hpp"
+#include "barretenberg/common/serialize.hpp"
+#include "barretenberg/dsl/acir_format/acir_format.hpp"
+#include <cstring>
+#include <gtest/gtest.h>
+
+namespace bb::bbapi {
+
+class StatefulKeygenTest : public ::testing::Test {
+  protected:
+    static void SetUpTestSuite() { bb::srs::init_file_crs_factory(bb::srs::bb_crs_path()); }
+};
+
+/**
+ * @brief Test AcirGetProvingKey command
+ * @details Verifies that we can generate a proving key from circuit bytecode
+ */
+TEST_F(StatefulKeygenTest, AcirGetProvingKey)
+{
+    auto [bytecode, _witness] = acir_bincode_mocks::create_simple_circuit_bytecode();
+
+    bbapi::ProofSystemSettings settings{ .ipa_accumulation = false,
+                                         .oracle_hash_type = "poseidon2",
+                                         .disable_zk = true }; // UltraFlavor
+
+    // Generate proving key
+    auto pk_response =
+        AcirGetProvingKey{ .circuit = { .name = "test_circuit", .bytecode = bytecode }, .settings = settings }
+            .execute();
+
+    // Verify proving key was generated
+    EXPECT_FALSE(pk_response.proving_key.empty()) << "Proving key should not be empty";
+    EXPECT_GT(pk_response.proving_key.size(), 100) << "Proving key should be reasonably sized";
+}
+
+// Helper to unpack combined result from vector<uint8_t>
+std::pair<std::vector<uint256_t>, std::vector<uint256_t>> unpack_combined(const std::vector<uint8_t>& combined)
+{
+    if (combined.size() < 4) {
+        throw std::runtime_error("Combined result too small");
+    }
+
+    // Read num_public_inputs (first 4 bytes, big endian)
+    uint32_t num_pub_inputs_be;
+    std::memcpy(&num_pub_inputs_be, combined.data(), 4);
+    uint32_t num_pub_inputs = ntohl(num_pub_inputs_be);
+
+    size_t offset = 4;
+    size_t element_size = 32;
+    size_t pub_inputs_bytes = num_pub_inputs * element_size;
+
+    if (combined.size() < offset + pub_inputs_bytes) {
+        throw std::runtime_error("Combined result too small for public inputs");
+    }
+
+    std::vector<uint256_t> public_inputs;
+    for (size_t i = 0; i < num_pub_inputs; ++i) {
+        uint64_t bin_data[4];
+        std::memcpy(bin_data, &combined[offset + i * element_size], element_size);
+        public_inputs.emplace_back(ntohll(bin_data[3]), ntohll(bin_data[2]), ntohll(bin_data[1]), ntohll(bin_data[0]));
+    }
+
+    offset += pub_inputs_bytes;
+    size_t remaining_bytes = combined.size() - offset;
+    if (remaining_bytes % element_size != 0) {
+        throw std::runtime_error("Invalid proof size in combined result");
+    }
+    size_t num_proof_elements = remaining_bytes / element_size;
+
+    std::vector<uint256_t> proof;
+    for (size_t i = 0; i < num_proof_elements; ++i) {
+        uint64_t bin_data[4];
+        std::memcpy(bin_data, &combined[offset + i * element_size], element_size);
+        proof.emplace_back(ntohll(bin_data[3]), ntohll(bin_data[2]), ntohll(bin_data[1]), ntohll(bin_data[0]));
+    }
+
+    return std::make_pair(public_inputs, proof);
+}
+
+/**
+ * @brief Test AcirProveWithPk command
+ * @details Verifies that we can prove using a pre-computed proving key
+ */
+TEST_F(StatefulKeygenTest, AcirProveWithPk)
+{
+    auto [bytecode, witness] = acir_bincode_mocks::create_simple_circuit_bytecode();
+
+    bbapi::ProofSystemSettings settings{ .ipa_accumulation = false,
+                                         .oracle_hash_type = "poseidon2",
+                                         .disable_zk = true }; // UltraFlavor
+
+    // Step 1: Generate proving key
+    auto pk_response =
+        AcirGetProvingKey{ .circuit = { .name = "test_circuit", .bytecode = bytecode }, .settings = settings }
+            .execute();
+
+    // Step 2: Prove with pre-computed key
+    auto prove_response = AcirProveWithPk{ .circuit = { .name = "test_circuit", .bytecode = bytecode },
+                                           .witness = witness,
+                                           .proving_key = pk_response.proving_key,
+                                           .settings = settings }
+                              .execute();
+
+    // Verify proof was generated
+    auto [public_inputs, proof] = unpack_combined(prove_response.combined_result);
+    EXPECT_FALSE(proof.empty()) << "Proof should not be empty";
+    // Note: public_inputs may be empty for simple circuits with no declared public inputs
+    // The 16-element pairing point accumulator is internal and not included in inner public inputs
+}
+
+/**
+ * @brief Test stateful workflow: Generate key once, prove multiple times
+ * @details This is the key use case for stateful keygen - reusing the proving key
+ */
+TEST_F(StatefulKeygenTest, MultipleProofsWithSameKey)
+{
+    // Create ONE circuit bytecode
+    auto [bytecode, witness1] = acir_bincode_mocks::create_simple_circuit_bytecode();
+
+    // Create a SECOND witness for the SAME circuit (different a,b values: 4*5=20 instead of 2*3=6)
+    auto witness2 = acir_bincode_mocks::create_witness_for_simple_circuit(bb::fr(4), bb::fr(5));
+
+    bbapi::ProofSystemSettings settings{ .ipa_accumulation = false,
+                                         .oracle_hash_type = "poseidon2",
+                                         .disable_zk = true };
+
+    // Generate proving key ONCE
+    auto pk_response =
+        AcirGetProvingKey{ .circuit = { .name = "test_circuit", .bytecode = bytecode }, .settings = settings }
+            .execute();
+
+    // Prove MULTIPLE times with different witnesses (same circuit structure)
+    auto proof1 = AcirProveWithPk{ .circuit = { .name = "test_circuit", .bytecode = bytecode },
+                                   .witness = witness1,
+                                   .proving_key = pk_response.proving_key,
+                                   .settings = settings }
+                      .execute();
+
+    auto proof2 = AcirProveWithPk{ .circuit = { .name = "test_circuit", .bytecode = bytecode },
+                                   .witness = witness2,
+                                   .proving_key = pk_response.proving_key,
+                                   .settings = settings }
+                      .execute();
+
+    // Both proofs should be valid but different (different witnesses)
+    auto [public_inputs1, proof1_vec] = unpack_combined(proof1.combined_result);
+    auto [public_inputs2, proof2_vec] = unpack_combined(proof2.combined_result);
+
+    EXPECT_FALSE(proof1_vec.empty());
+    EXPECT_FALSE(proof2_vec.empty());
+    // Proofs should differ because witnesses differ
+    EXPECT_NE(proof1_vec, proof2_vec) << "Different witnesses should produce different proofs";
+}
+
+/**
+ * @brief Test that stateful keygen produces same proof as one-shot proving
+ * @details Verifies correctness by comparing against CircuitProve
+ */
+TEST_F(StatefulKeygenTest, EquivalenceWithCircuitProve)
+{
+    auto [bytecode, witness] = acir_bincode_mocks::create_simple_circuit_bytecode();
+
+    bbapi::ProofSystemSettings settings{ .ipa_accumulation = false,
+                                         .oracle_hash_type = "poseidon2",
+                                         .disable_zk = true };
+
+    // Method 1: Stateful (get key + prove with key)
+    auto pk_response =
+        AcirGetProvingKey{ .circuit = { .name = "test_circuit", .bytecode = bytecode }, .settings = settings }
+            .execute();
+
+    auto stateful_proof = AcirProveWithPk{ .circuit = { .name = "test_circuit", .bytecode = bytecode },
+                                           .witness = witness,
+                                           .proving_key = pk_response.proving_key,
+                                           .settings = settings }
+                              .execute();
+
+    // Method 2: One-shot (CircuitProve)
+    auto vk_response =
+        CircuitComputeVk{ .circuit = { .name = "test_circuit", .bytecode = bytecode }, .settings = settings }.execute();
+
+    auto oneshot_proof = CircuitProve{ .circuit = { .name = "test_circuit",
+                                                    .bytecode = bytecode,
+                                                    .verification_key = vk_response.bytes },
+                                       .witness = witness,
+                                       .settings = settings }
+                             .execute();
+
+    auto [stateful_public_inputs, stateful_proof_data] = unpack_combined(stateful_proof.combined_result);
+
+    // Both methods should produce valid proofs with same public inputs
+    auto [oneshot_public_inputs, oneshot_proof_data] = unpack_combined(oneshot_proof.combined_result);
+    EXPECT_EQ(stateful_public_inputs, oneshot_public_inputs) << "Public inputs mismatch";
+    EXPECT_FALSE(stateful_proof_data.empty()) << "Proof should not be empty";
+
+    auto verify_stateful =
+        CircuitVerify{
+            .verification_key = vk_response.bytes, // Assuming vk_response.bytes is the intended verification key
+            .public_inputs = stateful_public_inputs,
+            .proof = stateful_proof_data,
+            .settings = settings,
+        }
+            .execute();
+
+    auto verify_oneshot = CircuitVerify{ .verification_key = vk_response.bytes,
+                                         .public_inputs = oneshot_public_inputs,
+                                         .proof = oneshot_proof_data,
+                                         .settings = settings }
+                              .execute();
+
+    EXPECT_TRUE(verify_stateful.verified) << "Stateful proof should verify";
+    EXPECT_TRUE(verify_oneshot.verified) << "One-shot proof should verify";
+}
+
+/**
+ * @brief Test that bytecode hash mismatch is detected
+ * @details Verifies that using a proving key generated for one circuit
+ * with a different circuit's bytecode throws an appropriate error
+ */
+TEST_F(StatefulKeygenTest, BytecodeHashMismatch)
+{
+    // Create two different circuits
+    auto [bytecode1, witness1] = acir_bincode_mocks::create_simple_circuit_bytecode(1);
+    auto [bytecode2, witness2] = acir_bincode_mocks::create_simple_circuit_bytecode(2);
+
+    bbapi::ProofSystemSettings settings{ .ipa_accumulation = false,
+                                         .oracle_hash_type = "poseidon2",
+                                         .disable_zk = true };
+
+    // Generate proving key for circuit 1
+    auto pk_response =
+        AcirGetProvingKey{ .circuit = { .name = "test_circuit", .bytecode = bytecode1 }, .settings = settings }
+            .execute();
+
+    // Try to use it with circuit 2's bytecode - should fail
+    // Note: EXPECT_THROW doesn't work with brace-enclosed initializer lists,
+    // so we use a lambda and manual exception checking
+    bool threw_expected_exception = false;
+    try {
+        AcirProveWithPk prove_cmd;
+        prove_cmd.circuit = { .name = "test_circuit", .bytecode = bytecode2 };
+        prove_cmd.witness = witness2;
+        prove_cmd.proving_key = pk_response.proving_key;
+        prove_cmd.settings = settings;
+        std::move(prove_cmd).execute();
+    } catch (const std::runtime_error& e) {
+        threw_expected_exception = true;
+        // Verify the error message mentions bytecode hash mismatch
+        std::string error_msg = e.what();
+        EXPECT_TRUE(error_msg.find("Bytecode hash mismatch") != std::string::npos ||
+                    error_msg.find("bytecode") != std::string::npos)
+            << "Error message should mention bytecode hash mismatch, got: " << error_msg;
+    } catch (...) {
+        FAIL() << "Expected std::runtime_error but got different exception type";
+    }
+    EXPECT_TRUE(threw_expected_exception) << "Using proving key with mismatched bytecode should throw";
+}
+
+} // namespace bb::bbapi

--- a/barretenberg/cpp/src/barretenberg/bbapi/bbapi_ultra_honk.cpp
+++ b/barretenberg/cpp/src/barretenberg/bbapi/bbapi_ultra_honk.cpp
@@ -1,5 +1,7 @@
 #include "barretenberg/bbapi/bbapi_ultra_honk.hpp"
+#include "barretenberg/bbapi/bbapi_flavor_dispatch.hpp"
 #include "barretenberg/bbapi/bbapi_shared.hpp"
+#include "barretenberg/bbapi/bbapi_stateful.hpp"
 #include "barretenberg/circuit_checker/circuit_checker.hpp"
 #include "barretenberg/commitment_schemes/ipa/ipa.hpp"
 #include "barretenberg/common/log.hpp"
@@ -415,108 +417,36 @@ CircuitWriteSolidityVerifier::Response CircuitWriteSolidityVerifier::execute(BB_
     return { std::move(contract) };
 }
 
-/**
- * @brief Serializable polynomial data for proving key export.
- * @details Captures all metadata needed to reconstruct a polynomial:
- *   - coefficients: The actual coefficient data
- *   - start_index: The starting index of the memory-backed range (used for shifts)
- *   - virtual_size: The total logical size of the polynomial
- *
- * This allows proper reconstruction of "shiftable" polynomials that require
- * start_index > 0 for the shifted() operation to work correctly.
- */
-struct PolynomialExport {
-    std::vector<bb::fr> coefficients;
-    uint64_t start_index;
-    uint64_t virtual_size;
-
-    MSGPACK_FIELDS(coefficients, start_index, virtual_size);
-};
-
-/**
- * @brief Serializable proving key data for UltraFlavor.
- * @details Contains circuit-specific precomputed data that can be
- * cached and reused across multiple proofs with different witnesses.
- *
- * Key design decisions for upstream compatibility:
- * 1. PolynomialExport preserves start_index/virtual_size for proper reconstruction
- * 2. Bytecode hash enables cache validation across circuit versions
- * 3. All integer types use uint64_t for cross-platform msgpack compatibility
- */
-struct DeciderProvingKeyExport {
-    std::vector<PolynomialExport> polynomials;
-    std::vector<bb::fr> public_inputs;
-    bb::RelationParameters<bb::fr> relation_parameters;
-    std::vector<bb::fr> gate_challenges;
-    bb::fr target_sum;
-    bool is_structured;
-    uint64_t dyadic_size;
-    uint64_t num_public_inputs;
-    uint64_t pub_inputs_offset;
-    uint64_t overflow_size;
-    uint64_t final_active_wire_idx;
-    // Bytecode hash for cache validation - ensures proving key matches circuit
-    std::vector<uint8_t> bytecode_hash;
-    // Memory records for RAM/ROM lookup arguments (indices into full trace)
-    std::vector<uint32_t> memory_read_records;
-    std::vector<uint32_t> memory_write_records;
-
-    MSGPACK_FIELDS(polynomials,
-                   public_inputs,
-                   relation_parameters,
-                   gate_challenges,
-                   target_sum,
-                   is_structured,
-                   dyadic_size,
-                   num_public_inputs,
-                   pub_inputs_offset,
-                   overflow_size,
-                   final_active_wire_idx,
-                   bytecode_hash,
-                   memory_read_records,
-                   memory_write_records);
-};
-
 AcirGetProvingKey::Response AcirGetProvingKey::execute(BB_UNUSED const BBApiRequest& request) &&
 {
     BB_BENCH_NAME(MSGPACK_SCHEMA_NAME);
-    using ProverInstance = ProverInstance_<UltraFlavor>;
 
-    // Compute bytecode hash BEFORE consuming bytecode (for cache validation)
-    auto bytecode_hash_arr = blake3::blake3s(circuit.bytecode);
-    std::vector<uint8_t> bytecode_hash_vec(bytecode_hash_arr.begin(), bytecode_hash_arr.end());
+    // Select appropriate flavor based on settings
+    auto flavor_type = select_ultra_flavor(settings);
 
-    // Build proving key from circuit
-    auto prover_instance = [&] {
-        const acir_format::ProgramMetadata metadata{};
-        acir_format::AcirProgram program{ acir_format::circuit_buf_to_acir_format(std::move(circuit.bytecode)) };
-        auto builder = acir_format::create_circuit<UltraCircuitBuilder>(program);
-        return std::make_shared<ProverInstance>(builder);
-    }();
-
-    // Extract ONLY precomputed polynomials (selectors, sigmas, ids, tables, lagrange)
-    // WitnessEntities (w_l, w_r, w_o, w_4, z_perm, lookup_inverses, etc.) are witness-dependent
-    // and must be computed fresh for each proof with the new witness
     DeciderProvingKeyExport export_data;
-    for (auto& poly : prover_instance->polynomials.get_precomputed()) {
-        PolynomialExport poly_export;
-        poly_export.coefficients = std::vector<bb::fr>(poly.data(), poly.data() + poly.size());
-        poly_export.start_index = poly.start_index();
-        poly_export.virtual_size = poly.virtual_size();
-        export_data.polynomials.push_back(std::move(poly_export));
-    }
-    export_data.public_inputs = prover_instance->public_inputs;
-    export_data.relation_parameters = prover_instance->relation_parameters;
-    export_data.gate_challenges = prover_instance->gate_challenges;
-    export_data.dyadic_size = prover_instance->dyadic_size();
-    export_data.num_public_inputs = prover_instance->num_public_inputs();
-    export_data.pub_inputs_offset = prover_instance->pub_inputs_offset();
-    export_data.final_active_wire_idx = prover_instance->get_final_active_wire_idx();
-    export_data.bytecode_hash = std::move(bytecode_hash_vec);
-    export_data.memory_read_records = prover_instance->memory_read_records;
-    export_data.memory_write_records = prover_instance->memory_write_records;
 
-    // Serialize to msgpack
+    // Dispatch to the correct flavor
+    switch (flavor_type) {
+    case UltraFlavorType::Ultra:
+        export_data = get_proving_key<UltraFlavor>(circuit, settings);
+        break;
+    case UltraFlavorType::UltraZK:
+        export_data = get_proving_key<UltraZKFlavor>(circuit, settings);
+        break;
+    case UltraFlavorType::UltraKeccak:
+        export_data = get_proving_key<UltraKeccakFlavor>(circuit, settings);
+        break;
+    case UltraFlavorType::UltraKeccakZK:
+        export_data = get_proving_key<UltraKeccakZKFlavor>(circuit, settings);
+        break;
+    case UltraFlavorType::UltraRollup:
+        // UltraRollup uses same proving key structure as Ultra
+        export_data = get_proving_key<UltraRollupFlavor>(circuit, settings);
+        break;
+    }
+
+    // Serialize proving key to msgpack
     msgpack::sbuffer buffer;
     msgpack::pack(buffer, export_data);
 
@@ -525,104 +455,31 @@ AcirGetProvingKey::Response AcirGetProvingKey::execute(BB_UNUSED const BBApiRequ
 
 AcirProveWithPk::Response AcirProveWithPk::execute(BB_UNUSED const BBApiRequest& request) &&
 {
+    BB_BENCH_NAME(MSGPACK_SCHEMA_NAME);
+
+    // Select appropriate flavor based on settings
+    auto flavor_type = select_ultra_flavor(settings);
+
     std::vector<uint8_t> result_vec;
-    {
-        BB_BENCH_NAME(MSGPACK_SCHEMA_NAME);
-        using ProverInstance = ProverInstance_<UltraFlavor>;
-        using VerificationKey = UltraFlavor::VerificationKey;
 
-        // Compute bytecode hash for cache validation
-        auto current_bytecode_hash = blake3::blake3s(circuit.bytecode);
-
-        // Deserialize proving key
-        DeciderProvingKeyExport pk_data;
-        msgpack::object_handle oh = msgpack::unpack((const char*)proving_key.data(), proving_key.size());
-        msgpack::object obj = oh.get();
-        obj.convert(pk_data);
-
-        // Validate bytecode hash matches proving key
-        bool hash_matches =
-            (pk_data.bytecode_hash.size() == current_bytecode_hash.size()) &&
-            std::equal(pk_data.bytecode_hash.begin(), pk_data.bytecode_hash.end(), current_bytecode_hash.begin());
-
-        if (!hash_matches) {
-            throw_or_abort("AcirProveWithPk: Bytecode hash mismatch. "
-                           "The proving key was generated for a different circuit. "
-                           "Please regenerate the proving key with the current bytecode.");
-        }
-
-        // Reconstruct circuit from bytecode and witness
-        acir_format::AcirProgram program{ acir_format::circuit_buf_to_acir_format(std::move(circuit.bytecode)) };
-        program.witness = acir_format::witness_buf_to_witness_vector(std::move(witness));
-        auto builder = acir_format::create_circuit<UltraCircuitBuilder>(program);
-
-        // Reconstruct metadata from proving key
-        MetaData metadata;
-        metadata.dyadic_size = static_cast<size_t>(pk_data.dyadic_size);
-        metadata.num_public_inputs = static_cast<size_t>(pk_data.num_public_inputs);
-        metadata.pub_inputs_offset = static_cast<size_t>(pk_data.pub_inputs_offset);
-
-        // Convert PolynomialExport to ProverInstance::PolynomialData
-        std::vector<ProverInstance::PolynomialData> poly_data_vec;
-        poly_data_vec.reserve(pk_data.polynomials.size());
-        for (auto& poly_export : pk_data.polynomials) {
-            ProverInstance::PolynomialData poly_data;
-            poly_data.coefficients = std::move(poly_export.coefficients);
-            poly_data.start_index = static_cast<size_t>(poly_export.start_index);
-            poly_data.virtual_size = static_cast<size_t>(poly_export.virtual_size);
-            poly_data_vec.push_back(std::move(poly_data));
-        }
-
-        // HYDRATION: Create ProverInstance using precomputed polynomials from proving key
-        // This skips recomputing selectors, permutation polynomials, and lookup tables
-        auto instance = std::make_shared<ProverInstance>(builder,
-                                                         std::move(poly_data_vec),
-                                                         metadata,
-                                                         static_cast<size_t>(pk_data.final_active_wire_idx),
-                                                         std::move(pk_data.memory_read_records),
-                                                         std::move(pk_data.memory_write_records));
-
-        // Construct verification key and prove
-        auto verification_key = std::make_shared<VerificationKey>(instance->get_precomputed());
-        UltraProver prover{ instance, verification_key };
-
-        auto proof = prover.construct_proof();
-
-        // Calculate inner public inputs (excluding pairing point accumulator), consistent with CircuitProve
-        size_t num_inner_public_inputs = [&]() {
-            size_t num_public_inputs = instance->num_public_inputs();
-            // UltraFlavor uses DefaultIO::PUBLIC_INPUTS_SIZE for pairing point accumulator
-            constexpr size_t PAIRING_POINT_SIZE = 16; // DefaultIO::PUBLIC_INPUTS_SIZE
-            BB_ASSERT(num_public_inputs >= PAIRING_POINT_SIZE,
-                      "Public inputs should contain a pairing point accumulator.");
-            return num_public_inputs - PAIRING_POINT_SIZE;
-        }();
-
-        // Create the combined result
-        // Format: [num_public_inputs (4 bytes)] [public_inputs (32 bytes each)] [proof...]
-        size_t total_size = 4 + (num_inner_public_inputs * 32) + (proof.size() * 32);
-        result_vec.resize(total_size);
-
-        uint8_t* ptr = result_vec.data();
-
-        // Pack num_inner_public_inputs (4 bytes, big endian, matches CircuitProve format)
-        uint32_t num_pub_inputs_be = htonl(static_cast<uint32_t>(num_inner_public_inputs));
-        std::memcpy(ptr, &num_pub_inputs_be, 4);
-        ptr += 4;
-
-        // Pack inner public inputs (from proof, excluding pairing point accumulator)
-        // These are the first num_inner_public_inputs elements of the proof
-        for (size_t i = 0; i < num_inner_public_inputs; ++i) {
-            bb::fr::serialize_to_buffer(proof[i], ptr);
-            ptr += 32;
-        }
-
-        // Pack proof (skip public inputs which were already extracted above)
-        for (size_t i = num_inner_public_inputs; i < proof.size(); ++i) {
-            bb::fr::serialize_to_buffer(proof[i], ptr);
-            ptr += 32;
-        }
-    } // Destructors run here
+    // Dispatch to the correct flavor
+    switch (flavor_type) {
+    case UltraFlavorType::Ultra:
+        result_vec = prove_with_pk<UltraFlavor>(circuit, witness, proving_key, settings);
+        break;
+    case UltraFlavorType::UltraZK:
+        result_vec = prove_with_pk<UltraZKFlavor>(circuit, witness, proving_key, settings);
+        break;
+    case UltraFlavorType::UltraKeccak:
+        result_vec = prove_with_pk<UltraKeccakFlavor>(circuit, witness, proving_key, settings);
+        break;
+    case UltraFlavorType::UltraKeccakZK:
+        result_vec = prove_with_pk<UltraKeccakZKFlavor>(circuit, witness, proving_key, settings);
+        break;
+    case UltraFlavorType::UltraRollup:
+        result_vec = prove_with_pk<UltraRollupFlavor>(circuit, witness, proving_key, settings);
+        break;
+    }
 
     return { .combined_result = std::move(result_vec) };
 }

--- a/barretenberg/cpp/src/barretenberg/bbapi/bbapi_ultra_honk.cpp
+++ b/barretenberg/cpp/src/barretenberg/bbapi/bbapi_ultra_honk.cpp
@@ -424,33 +424,28 @@ AcirGetProvingKey::Response AcirGetProvingKey::execute(BB_UNUSED const BBApiRequ
     // Select appropriate flavor based on settings
     auto flavor_type = select_ultra_flavor(settings);
 
-    DeciderProvingKeyExport export_data;
+    std::vector<uint8_t> serialized_pk;
 
-    // Dispatch to the correct flavor
+    // Dispatch to the correct flavor (zero-copy serialization)
     switch (flavor_type) {
     case UltraFlavorType::Ultra:
-        export_data = get_proving_key<UltraFlavor>(circuit, settings);
+        serialized_pk = get_proving_key_serialized<UltraFlavor>(circuit, settings);
         break;
     case UltraFlavorType::UltraZK:
-        export_data = get_proving_key<UltraZKFlavor>(circuit, settings);
+        serialized_pk = get_proving_key_serialized<UltraZKFlavor>(circuit, settings);
         break;
     case UltraFlavorType::UltraKeccak:
-        export_data = get_proving_key<UltraKeccakFlavor>(circuit, settings);
+        serialized_pk = get_proving_key_serialized<UltraKeccakFlavor>(circuit, settings);
         break;
     case UltraFlavorType::UltraKeccakZK:
-        export_data = get_proving_key<UltraKeccakZKFlavor>(circuit, settings);
+        serialized_pk = get_proving_key_serialized<UltraKeccakZKFlavor>(circuit, settings);
         break;
     case UltraFlavorType::UltraRollup:
-        // UltraRollup uses same proving key structure as Ultra
-        export_data = get_proving_key<UltraRollupFlavor>(circuit, settings);
+        serialized_pk = get_proving_key_serialized<UltraRollupFlavor>(circuit, settings);
         break;
     }
 
-    // Serialize proving key to msgpack
-    msgpack::sbuffer buffer;
-    msgpack::pack(buffer, export_data);
-
-    return { .proving_key = std::vector<uint8_t>(buffer.data(), buffer.data() + buffer.size()) };
+    return { .proving_key = std::move(serialized_pk) };
 }
 
 AcirProveWithPk::Response AcirProveWithPk::execute(BB_UNUSED const BBApiRequest& request) &&

--- a/barretenberg/cpp/src/barretenberg/bbapi/bbapi_ultra_honk.cpp
+++ b/barretenberg/cpp/src/barretenberg/bbapi/bbapi_ultra_honk.cpp
@@ -2,6 +2,7 @@
 #include "barretenberg/bbapi/bbapi_shared.hpp"
 #include "barretenberg/circuit_checker/circuit_checker.hpp"
 #include "barretenberg/commitment_schemes/ipa/ipa.hpp"
+#include "barretenberg/common/log.hpp"
 #include "barretenberg/common/serialize.hpp"
 #include "barretenberg/common/throw_or_abort.hpp"
 #include "barretenberg/constants.hpp"
@@ -22,11 +23,16 @@
 #include "barretenberg/ultra_honk/prover_instance.hpp"
 #include "barretenberg/ultra_honk/ultra_prover.hpp"
 #include "barretenberg/ultra_honk/ultra_verifier.hpp"
+#include <iostream>
 #include <type_traits>
 #ifdef STARKNET_GARAGA_FLAVORS
 #include "barretenberg/flavor/ultra_starknet_flavor.hpp"
 #include "barretenberg/flavor/ultra_starknet_zk_flavor.hpp"
 #endif
+#include "barretenberg/common/net.hpp"
+#include "barretenberg/crypto/blake3s/blake3s.hpp"
+#include <cstring>
+#include <exception>
 #include <iomanip>
 #include <sstream>
 
@@ -55,13 +61,8 @@ template <typename Flavor>
 std::shared_ptr<ProverInstance_<Flavor>> _compute_prover_instance(std::vector<uint8_t>&& bytecode,
                                                                   std::vector<uint8_t>&& witness)
 {
-    // Measure function time and debug print
-    auto initial_time = std::chrono::high_resolution_clock::now();
     typename Flavor::CircuitBuilder builder = _compute_circuit<Flavor>(std::move(bytecode), std::move(witness));
     auto prover_instance = std::make_shared<ProverInstance_<Flavor>>(builder);
-    auto final_time = std::chrono::high_resolution_clock::now();
-    auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(final_time - initial_time);
-    info("CircuitProve: Proving key computed in ", duration.count(), " ms");
     return prover_instance;
 }
 template <typename Flavor>
@@ -74,7 +75,9 @@ CircuitProve::Response _prove(std::vector<uint8_t>&& bytecode,
     auto prover_instance = _compute_prover_instance<Flavor>(std::move(bytecode), std::move(witness));
     std::shared_ptr<typename Flavor::VerificationKey> vk;
     if (vk_bytes.empty()) {
-        info("WARNING: computing verification key while proving. Pass in a precomputed vk for better performance.");
+        std::cerr
+            << "WARNING: computing verification key while proving. Pass in a precomputed vk for better performance."
+            << std::endl;
         vk = std::make_shared<typename Flavor::VerificationKey>(prover_instance->get_precomputed());
     } else {
         vk =
@@ -84,6 +87,7 @@ CircuitProve::Response _prove(std::vector<uint8_t>&& bytecode,
     UltraProver_<Flavor> prover{ prover_instance, vk };
 
     Proof concat_pi_and_proof = prover.construct_proof();
+
     // Compute number of inner public inputs. Perform loose checks that the public inputs contain enough data.
     auto num_inner_public_inputs = [&]() {
         size_t num_public_inputs = prover.prover_instance->num_public_inputs();
@@ -115,15 +119,31 @@ CircuitProve::Response _prove(std::vector<uint8_t>&& bytecode,
                         .hash = to_buffer(vk->hash()) };
     }
 
-    // We split the inner public inputs, which are stored at the front of the proof, from the rest of the proof. Now,
-    // the "proof" refers to everything except the inner public inputs.
-    return { .public_inputs = std::vector<uint256_t>{ concat_pi_and_proof.begin(),
-                                                      concat_pi_and_proof.begin() +
-                                                          static_cast<std::ptrdiff_t>(num_inner_public_inputs) },
-             .proof = std::vector<uint256_t>{ concat_pi_and_proof.begin() +
-                                                  static_cast<std::ptrdiff_t>(num_inner_public_inputs),
-                                              concat_pi_and_proof.end() },
-             .vk = std::move(vk_response) };
+    // Format: [num_public_inputs (4 bytes)] [public_inputs (32 bytes each)] [proof...]
+    std::vector<uint8_t> result_vec;
+    size_t total_size =
+        4 + (num_inner_public_inputs * 32) + ((concat_pi_and_proof.size() - num_inner_public_inputs) * 32);
+    result_vec.resize(total_size);
+
+    uint8_t* ptr = result_vec.data();
+
+    // Pack num_public_inputs (4 bytes, big endian)
+    uint32_t num_pub_inputs_be = htonl(static_cast<uint32_t>(num_inner_public_inputs));
+    std::memcpy(ptr, &num_pub_inputs_be, 4);
+    ptr += 4;
+
+    // Pack public inputs
+    for (size_t i = 0; i < num_inner_public_inputs; ++i) {
+        bb::fr::serialize_to_buffer(concat_pi_and_proof[i], ptr);
+        ptr += 32;
+    }
+
+    // Pack proof
+    for (size_t i = num_inner_public_inputs; i < concat_pi_and_proof.size(); ++i) {
+        bb::fr::serialize_to_buffer(concat_pi_and_proof[i], ptr);
+        ptr += 32;
+    }
+    return { .combined_result = std::move(result_vec), .vk = std::move(vk_response) };
 }
 
 template <typename Flavor>
@@ -392,8 +412,219 @@ CircuitWriteSolidityVerifier::Response CircuitWriteSolidityVerifier::execute(BB_
         contract = get_optimized_honk_solidity_verifier(vk);
     }
 #endif
-
     return { std::move(contract) };
+}
+
+/**
+ * @brief Serializable polynomial data for proving key export.
+ * @details Captures all metadata needed to reconstruct a polynomial:
+ *   - coefficients: The actual coefficient data
+ *   - start_index: The starting index of the memory-backed range (used for shifts)
+ *   - virtual_size: The total logical size of the polynomial
+ *
+ * This allows proper reconstruction of "shiftable" polynomials that require
+ * start_index > 0 for the shifted() operation to work correctly.
+ */
+struct PolynomialExport {
+    std::vector<bb::fr> coefficients;
+    uint64_t start_index;
+    uint64_t virtual_size;
+
+    MSGPACK_FIELDS(coefficients, start_index, virtual_size);
+};
+
+/**
+ * @brief Serializable proving key data for UltraFlavor.
+ * @details Contains circuit-specific precomputed data that can be
+ * cached and reused across multiple proofs with different witnesses.
+ *
+ * Key design decisions for upstream compatibility:
+ * 1. PolynomialExport preserves start_index/virtual_size for proper reconstruction
+ * 2. Bytecode hash enables cache validation across circuit versions
+ * 3. All integer types use uint64_t for cross-platform msgpack compatibility
+ */
+struct DeciderProvingKeyExport {
+    std::vector<PolynomialExport> polynomials;
+    std::vector<bb::fr> public_inputs;
+    bb::RelationParameters<bb::fr> relation_parameters;
+    std::vector<bb::fr> gate_challenges;
+    bb::fr target_sum;
+    bool is_structured;
+    uint64_t dyadic_size;
+    uint64_t num_public_inputs;
+    uint64_t pub_inputs_offset;
+    uint64_t overflow_size;
+    uint64_t final_active_wire_idx;
+    // Bytecode hash for cache validation - ensures proving key matches circuit
+    std::vector<uint8_t> bytecode_hash;
+    // Memory records for RAM/ROM lookup arguments (indices into full trace)
+    std::vector<uint32_t> memory_read_records;
+    std::vector<uint32_t> memory_write_records;
+
+    MSGPACK_FIELDS(polynomials,
+                   public_inputs,
+                   relation_parameters,
+                   gate_challenges,
+                   target_sum,
+                   is_structured,
+                   dyadic_size,
+                   num_public_inputs,
+                   pub_inputs_offset,
+                   overflow_size,
+                   final_active_wire_idx,
+                   bytecode_hash,
+                   memory_read_records,
+                   memory_write_records);
+};
+
+AcirGetProvingKey::Response AcirGetProvingKey::execute(BB_UNUSED const BBApiRequest& request) &&
+{
+    BB_BENCH_NAME(MSGPACK_SCHEMA_NAME);
+    using ProverInstance = ProverInstance_<UltraFlavor>;
+
+    // Compute bytecode hash BEFORE consuming bytecode (for cache validation)
+    auto bytecode_hash_arr = blake3::blake3s(circuit.bytecode);
+    std::vector<uint8_t> bytecode_hash_vec(bytecode_hash_arr.begin(), bytecode_hash_arr.end());
+
+    // Build proving key from circuit
+    auto prover_instance = [&] {
+        const acir_format::ProgramMetadata metadata{};
+        acir_format::AcirProgram program{ acir_format::circuit_buf_to_acir_format(std::move(circuit.bytecode)) };
+        auto builder = acir_format::create_circuit<UltraCircuitBuilder>(program);
+        return std::make_shared<ProverInstance>(builder);
+    }();
+
+    // Extract ONLY precomputed polynomials (selectors, sigmas, ids, tables, lagrange)
+    // WitnessEntities (w_l, w_r, w_o, w_4, z_perm, lookup_inverses, etc.) are witness-dependent
+    // and must be computed fresh for each proof with the new witness
+    DeciderProvingKeyExport export_data;
+    for (auto& poly : prover_instance->polynomials.get_precomputed()) {
+        PolynomialExport poly_export;
+        poly_export.coefficients = std::vector<bb::fr>(poly.data(), poly.data() + poly.size());
+        poly_export.start_index = poly.start_index();
+        poly_export.virtual_size = poly.virtual_size();
+        export_data.polynomials.push_back(std::move(poly_export));
+    }
+    export_data.public_inputs = prover_instance->public_inputs;
+    export_data.relation_parameters = prover_instance->relation_parameters;
+    export_data.gate_challenges = prover_instance->gate_challenges;
+    export_data.dyadic_size = prover_instance->dyadic_size();
+    export_data.num_public_inputs = prover_instance->num_public_inputs();
+    export_data.pub_inputs_offset = prover_instance->pub_inputs_offset();
+    export_data.final_active_wire_idx = prover_instance->get_final_active_wire_idx();
+    export_data.bytecode_hash = std::move(bytecode_hash_vec);
+    export_data.memory_read_records = prover_instance->memory_read_records;
+    export_data.memory_write_records = prover_instance->memory_write_records;
+
+    // Serialize to msgpack
+    msgpack::sbuffer buffer;
+    msgpack::pack(buffer, export_data);
+
+    return { .proving_key = std::vector<uint8_t>(buffer.data(), buffer.data() + buffer.size()) };
+}
+
+AcirProveWithPk::Response AcirProveWithPk::execute(BB_UNUSED const BBApiRequest& request) &&
+{
+    std::vector<uint8_t> result_vec;
+    {
+        BB_BENCH_NAME(MSGPACK_SCHEMA_NAME);
+        using ProverInstance = ProverInstance_<UltraFlavor>;
+        using VerificationKey = UltraFlavor::VerificationKey;
+
+        // Compute bytecode hash for cache validation
+        auto current_bytecode_hash = blake3::blake3s(circuit.bytecode);
+
+        // Deserialize proving key
+        DeciderProvingKeyExport pk_data;
+        msgpack::object_handle oh = msgpack::unpack((const char*)proving_key.data(), proving_key.size());
+        msgpack::object obj = oh.get();
+        obj.convert(pk_data);
+
+        // Validate bytecode hash matches proving key
+        bool hash_matches =
+            (pk_data.bytecode_hash.size() == current_bytecode_hash.size()) &&
+            std::equal(pk_data.bytecode_hash.begin(), pk_data.bytecode_hash.end(), current_bytecode_hash.begin());
+
+        if (!hash_matches) {
+            throw_or_abort("AcirProveWithPk: Bytecode hash mismatch. "
+                           "The proving key was generated for a different circuit. "
+                           "Please regenerate the proving key with the current bytecode.");
+        }
+
+        // Reconstruct circuit from bytecode and witness
+        acir_format::AcirProgram program{ acir_format::circuit_buf_to_acir_format(std::move(circuit.bytecode)) };
+        program.witness = acir_format::witness_buf_to_witness_vector(std::move(witness));
+        auto builder = acir_format::create_circuit<UltraCircuitBuilder>(program);
+
+        // Reconstruct metadata from proving key
+        MetaData metadata;
+        metadata.dyadic_size = static_cast<size_t>(pk_data.dyadic_size);
+        metadata.num_public_inputs = static_cast<size_t>(pk_data.num_public_inputs);
+        metadata.pub_inputs_offset = static_cast<size_t>(pk_data.pub_inputs_offset);
+
+        // Convert PolynomialExport to ProverInstance::PolynomialData
+        std::vector<ProverInstance::PolynomialData> poly_data_vec;
+        poly_data_vec.reserve(pk_data.polynomials.size());
+        for (auto& poly_export : pk_data.polynomials) {
+            ProverInstance::PolynomialData poly_data;
+            poly_data.coefficients = std::move(poly_export.coefficients);
+            poly_data.start_index = static_cast<size_t>(poly_export.start_index);
+            poly_data.virtual_size = static_cast<size_t>(poly_export.virtual_size);
+            poly_data_vec.push_back(std::move(poly_data));
+        }
+
+        // HYDRATION: Create ProverInstance using precomputed polynomials from proving key
+        // This skips recomputing selectors, permutation polynomials, and lookup tables
+        auto instance = std::make_shared<ProverInstance>(builder,
+                                                         std::move(poly_data_vec),
+                                                         metadata,
+                                                         static_cast<size_t>(pk_data.final_active_wire_idx),
+                                                         std::move(pk_data.memory_read_records),
+                                                         std::move(pk_data.memory_write_records));
+
+        // Construct verification key and prove
+        auto verification_key = std::make_shared<VerificationKey>(instance->get_precomputed());
+        UltraProver prover{ instance, verification_key };
+
+        auto proof = prover.construct_proof();
+
+        // Calculate inner public inputs (excluding pairing point accumulator), consistent with CircuitProve
+        size_t num_inner_public_inputs = [&]() {
+            size_t num_public_inputs = instance->num_public_inputs();
+            // UltraFlavor uses DefaultIO::PUBLIC_INPUTS_SIZE for pairing point accumulator
+            constexpr size_t PAIRING_POINT_SIZE = 16; // DefaultIO::PUBLIC_INPUTS_SIZE
+            BB_ASSERT(num_public_inputs >= PAIRING_POINT_SIZE,
+                      "Public inputs should contain a pairing point accumulator.");
+            return num_public_inputs - PAIRING_POINT_SIZE;
+        }();
+
+        // Create the combined result
+        // Format: [num_public_inputs (4 bytes)] [public_inputs (32 bytes each)] [proof...]
+        size_t total_size = 4 + (num_inner_public_inputs * 32) + (proof.size() * 32);
+        result_vec.resize(total_size);
+
+        uint8_t* ptr = result_vec.data();
+
+        // Pack num_inner_public_inputs (4 bytes, big endian, matches CircuitProve format)
+        uint32_t num_pub_inputs_be = htonl(static_cast<uint32_t>(num_inner_public_inputs));
+        std::memcpy(ptr, &num_pub_inputs_be, 4);
+        ptr += 4;
+
+        // Pack inner public inputs (from proof, excluding pairing point accumulator)
+        // These are the first num_inner_public_inputs elements of the proof
+        for (size_t i = 0; i < num_inner_public_inputs; ++i) {
+            bb::fr::serialize_to_buffer(proof[i], ptr);
+            ptr += 32;
+        }
+
+        // Pack proof (skip public inputs which were already extracted above)
+        for (size_t i = num_inner_public_inputs; i < proof.size(); ++i) {
+            bb::fr::serialize_to_buffer(proof[i], ptr);
+            ptr += 32;
+        }
+    } // Destructors run here
+
+    return { .combined_result = std::move(result_vec) };
 }
 
 } // namespace bb::bbapi

--- a/barretenberg/cpp/src/barretenberg/bbapi/bbapi_ultra_honk.hpp
+++ b/barretenberg/cpp/src/barretenberg/bbapi/bbapi_ultra_honk.hpp
@@ -17,6 +17,8 @@
 
 namespace bb::bbapi {
 
+using bb::numeric::uint256_t;
+
 struct CircuitComputeVk {
     static constexpr const char MSGPACK_SCHEMA_NAME[] = "CircuitComputeVk";
 
@@ -55,10 +57,9 @@ struct CircuitProve {
     struct Response {
         static constexpr const char MSGPACK_SCHEMA_NAME[] = "CircuitProveResponse";
 
-        std::vector<uint256_t> public_inputs;
-        std::vector<uint256_t> proof;
+        std::vector<uint8_t> combined_result;
         CircuitComputeVk::Response vk;
-        MSGPACK_FIELDS(public_inputs, proof, vk);
+        MSGPACK_FIELDS(combined_result, vk);
         bool operator==(const Response&) const = default;
     };
 
@@ -186,6 +187,52 @@ struct CircuitWriteSolidityVerifier {
     MSGPACK_FIELDS(verification_key, settings);
     Response execute(const BBApiRequest& request = {}) &&;
     bool operator==(const CircuitWriteSolidityVerifier&) const = default;
+};
+
+/**
+ * @struct AcirGetProvingKey
+ * @brief Generate a reusable proving key from circuit bytecode.
+ */
+struct AcirGetProvingKey {
+    static constexpr const char MSGPACK_SCHEMA_NAME[] = "AcirGetProvingKey";
+
+    struct Response {
+        static constexpr const char MSGPACK_SCHEMA_NAME[] = "AcirGetProvingKeyResponse";
+
+        std::vector<uint8_t> proving_key;
+        MSGPACK_FIELDS(proving_key);
+        bool operator==(const Response&) const = default;
+    };
+
+    CircuitInput circuit;
+    ProofSystemSettings settings;
+    MSGPACK_FIELDS(circuit, settings);
+    Response execute(const BBApiRequest& request = {}) &&;
+    bool operator==(const AcirGetProvingKey&) const = default;
+};
+
+/**
+ * @struct AcirProveWithPk
+ * @brief Generate proof using precomputed proving key and fresh witness.
+ */
+struct AcirProveWithPk {
+    static constexpr const char MSGPACK_SCHEMA_NAME[] = "AcirProveWithPk";
+
+    struct Response {
+        static constexpr const char MSGPACK_SCHEMA_NAME[] = "AcirProveWithPkResponse";
+
+        std::vector<uint8_t> combined_result;
+        MSGPACK_FIELDS(combined_result);
+        bool operator==(const Response&) const = default;
+    };
+
+    CircuitInput circuit;
+    std::vector<uint8_t> witness;
+    std::vector<uint8_t> proving_key;
+    ProofSystemSettings settings;
+    MSGPACK_FIELDS(circuit, witness, proving_key, settings);
+    Response execute(const BBApiRequest& request = {}) &&;
+    bool operator==(const AcirProveWithPk&) const = default;
 };
 
 } // namespace bb::bbapi

--- a/barretenberg/cpp/src/barretenberg/bbapi/bbapi_ultra_honk.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/bbapi/bbapi_ultra_honk.test.cpp
@@ -1,10 +1,12 @@
 #include "barretenberg/bbapi/bbapi_ultra_honk.hpp"
 #include "barretenberg/chonk/acir_bincode_mocks.hpp"
+#include "barretenberg/common/net.hpp"
 #include "barretenberg/common/thread.hpp"
 #include "barretenberg/dsl/acir_format/acir_format.hpp"
 #include "barretenberg/dsl/acir_format/acir_to_constraint_buf.hpp"
 #include "barretenberg/flavor/mega_flavor.hpp"
 #include "barretenberg/flavor/ultra_flavor.hpp"
+#include <cstring>
 #include <gtest/gtest.h>
 #include <vector>
 
@@ -57,10 +59,56 @@ TEST_F(BBApiUltraHonkTest, CircuitProve)
                                             .settings = settings }
                                   .execute();
 
+        // Helper to unpack combined result from vector<uint8_t>
+        auto unpack_combined = [](const std::vector<uint8_t>& combined) {
+            if (combined.size() < 4) {
+                throw std::runtime_error("Combined result too small");
+            }
+
+            // Read num_public_inputs (first 4 bytes, big endian)
+            uint32_t num_pub_inputs_be;
+            std::memcpy(&num_pub_inputs_be, combined.data(), 4);
+            uint32_t num_pub_inputs = ntohl(num_pub_inputs_be);
+
+            size_t offset = 4;
+            size_t element_size = 32;
+            size_t pub_inputs_bytes = num_pub_inputs * element_size;
+
+            if (combined.size() < offset + pub_inputs_bytes) {
+                throw std::runtime_error("Combined result too small for public inputs");
+            }
+
+            std::vector<uint256_t> public_inputs;
+            for (size_t i = 0; i < num_pub_inputs; ++i) {
+                uint64_t bin_data[4];
+                std::memcpy(bin_data, &combined[offset + i * element_size], element_size);
+                public_inputs.emplace_back(
+                    ntohll(bin_data[3]), ntohll(bin_data[2]), ntohll(bin_data[1]), ntohll(bin_data[0]));
+            }
+
+            offset += pub_inputs_bytes;
+            size_t remaining_bytes = combined.size() - offset;
+            if (remaining_bytes % element_size != 0) {
+                throw std::runtime_error("Invalid proof size in combined result");
+            }
+            size_t num_proof_elements = remaining_bytes / element_size;
+
+            std::vector<uint256_t> proof;
+            for (size_t i = 0; i < num_proof_elements; ++i) {
+                uint64_t bin_data[4];
+                std::memcpy(bin_data, &combined[offset + i * element_size], element_size);
+                proof.emplace_back(ntohll(bin_data[3]), ntohll(bin_data[2]), ntohll(bin_data[1]), ntohll(bin_data[0]));
+            }
+
+            return std::make_pair(public_inputs, proof);
+        };
+
+        auto [public_inputs, proof] = unpack_combined(prove_response.combined_result);
+
         // Verify the proof
         auto verify_response = CircuitVerify{ .verification_key = vk_response.bytes,
-                                              .public_inputs = prove_response.public_inputs,
-                                              .proof = prove_response.proof,
+                                              .public_inputs = public_inputs,
+                                              .proof = proof,
                                               .settings = settings }
                                    .execute();
 

--- a/barretenberg/cpp/src/barretenberg/chonk/acir_bincode_mocks.hpp
+++ b/barretenberg/cpp/src/barretenberg/chonk/acir_bincode_mocks.hpp
@@ -4,6 +4,8 @@
 #include "barretenberg/dsl/acir_format/serde/witness_stack.hpp"
 #include "barretenberg/dsl/acir_format/utils.hpp"
 #include <cstddef>
+#include <stdexcept>
+#include <string>
 #include <vector>
 
 namespace bb::acir_bincode_mocks {
@@ -117,6 +119,34 @@ inline std::pair<std::vector<uint8_t>, std::vector<uint8_t>> create_simple_circu
     witness_stack.stack.push_back(stack_item);
 
     return { program.bincodeSerialize(), witness_stack.bincodeSerialize() };
+}
+
+/**
+ * @brief Create a witness for a simple circuit with given values
+ * @details Creates witness data for a circuit with num_constraints constraints.
+ *          Each constraint is: a * b = c
+ * @param a First multiplicand for each constraint
+ * @param b Second multiplicand for each constraint
+ * @param num_constraints Number of constraints in the circuit (must match circuit)
+ * @return Serialized witness data
+ */
+inline std::vector<uint8_t> create_witness_for_simple_circuit(bb::fr a, bb::fr b, size_t num_constraints = 1)
+{
+    bb::fr c = a * b;
+
+    Witnesses::WitnessStack witness_stack;
+    Witnesses::StackItem stack_item{};
+
+    // For each constraint, add witnesses: w[i*3]=a, w[i*3+1]=b, w[i*3+2]=c
+    uint32_t witness_idx = 0;
+    for (size_t i = 0; i < num_constraints; ++i) {
+        stack_item.witness.value[Witnesses::Witness{ witness_idx++ }] = a.to_buffer();
+        stack_item.witness.value[Witnesses::Witness{ witness_idx++ }] = b.to_buffer();
+        stack_item.witness.value[Witnesses::Witness{ witness_idx++ }] = c.to_buffer();
+    }
+    witness_stack.stack.push_back(stack_item);
+
+    return witness_stack.bincodeSerialize();
 }
 
 /**

--- a/barretenberg/cpp/src/barretenberg/dsl/CMakeLists.txt
+++ b/barretenberg/cpp/src/barretenberg/dsl/CMakeLists.txt
@@ -8,7 +8,8 @@ set(DSL_DEPENDENCIES
     stdlib_keccak
     stdlib_poseidon2
     stdlib_honk_verifier
-    stdlib_chonk_verifier)
+    stdlib_chonk_verifier
+    circuit_checker)
 
 barretenberg_module(
     dsl

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_proofs/c_bind.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_proofs/c_bind.cpp
@@ -7,6 +7,7 @@
 #include "c_bind.hpp"
 #include "../acir_format/acir_to_constraint_buf.hpp"
 #include "barretenberg/chonk/private_execution_steps.hpp"
+#include "barretenberg/circuit_checker/circuit_checker.hpp"
 #include "barretenberg/common/mem.hpp"
 #include "barretenberg/common/net.hpp"
 #include "barretenberg/common/serialize.hpp"
@@ -15,6 +16,7 @@
 #include "barretenberg/dsl/acir_format/acir_format.hpp"
 #include "barretenberg/dsl/acir_format/hypernova_recursion_constraint.hpp"
 
+#include "barretenberg/commitment_schemes/commitment_key.hpp"
 #include "barretenberg/honk/execution_trace/mega_execution_trace.hpp"
 #include "barretenberg/serialize/msgpack.hpp"
 #include "honk_contract.hpp"

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/prover_instance.hpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/prover_instance.hpp
@@ -35,7 +35,7 @@ template <IsUltraOrMegaHonk Flavor_> class ProverInstance_ {
     using Flavor = Flavor_;
     using FF = typename Flavor::FF;
 
-  private:
+  public:
     using Circuit = typename Flavor::CircuitBuilder;
     using CommitmentKey = typename Flavor::CommitmentKey;
     using ProverPolynomials = typename Flavor::ProverPolynomials;
@@ -198,6 +198,149 @@ template <IsUltraOrMegaHonk Flavor_> class ProverInstance_ {
         auto end = std::chrono::steady_clock::now();
         auto diff = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
         vinfo("time to construct proving key: ", diff.count(), " ms.");
+    }
+
+    /**
+     * @brief Serialized polynomial data for hydration.
+     * @details Contains all metadata needed to reconstruct a polynomial:
+     *   - coefficients: The actual coefficient data
+     *   - start_index: The starting index of the memory-backed range (for shifts)
+     *   - virtual_size: The total logical size of the polynomial
+     */
+    struct PolynomialData {
+        std::vector<FF> coefficients;
+        size_t start_index;
+        size_t virtual_size;
+    };
+
+    /**
+     * @brief Construct ProverInstance by hydrating precomputed polynomials from serialized data.
+     * @details This avoids recomputing selectors, permutation polynomials, and lookup tables.
+     * Only witness-specific data (wires, z_perm, lookup_inverses) is computed fresh from the circuit.
+     *
+     * Key design for upstream compatibility:
+     * - Uses PolynomialData struct that preserves start_index/virtual_size
+     * - Properly reconstructs shiftable polynomials (start_index > 0)
+     * - Validates polynomial count matches expected flavor
+     * - Accepts pre-serialized memory records (avoids trace_offset dependency)
+     *
+     * @param circuit The circuit builder with witness data populated
+     * @param precomputed_polynomials Vector of PolynomialData from DeciderProvingKeyExport
+     * @param precomputed_metadata Metadata (dyadic_size, num_public_inputs, pub_inputs_offset)
+     * @param final_active_wire_idx_in The final active wire index from the proving key
+     * @param precomputed_memory_read_records Memory read records from proving key
+     * @param precomputed_memory_write_records Memory write records from proving key
+     * @param commitment_key Optional commitment key
+     */
+    ProverInstance_(Circuit& circuit,
+                    std::vector<PolynomialData>&& precomputed_polynomials,
+                    const MetaData& precomputed_metadata,
+                    size_t final_active_wire_idx_in,
+                    std::vector<uint32_t>&& precomputed_memory_read_records,
+                    std::vector<uint32_t>&& precomputed_memory_write_records,
+                    const CommitmentKey& commitment_key_in = CommitmentKey())
+        : final_active_wire_idx(final_active_wire_idx_in)
+        , commitment_key(commitment_key_in)
+    {
+        BB_BENCH_NAME("ProverInstance(Circuit&, hydrated)");
+        vinfo("Constructing ProverInstance with hydration (stateful keygen)");
+        auto start = std::chrono::steady_clock::now();
+
+        // Copy metadata from proving key
+        metadata = precomputed_metadata;
+
+        // Validate circuit is finalized
+        if (!circuit.circuit_finalized) {
+            circuit.finalize_circuit(/* ensure_nonzero = */ true);
+        }
+
+        // Compute block offsets - needed for trace population
+        circuit.blocks.compute_offsets();
+
+        // --- STEP 1: Allocate and compute WITNESS-DEPENDENT polynomials from fresh circuit ---
+        // These MUST be computed fresh for each proof since they depend on the witness:
+        // - wires (w_l, w_r, w_o, w_4)
+        // - z_perm (permutation argument)
+        // - lookup_inverses, lookup_read_counts, lookup_read_tags
+        {
+            BB_BENCH_NAME("allocating and populating witness polynomials");
+
+            // Use pre-serialized memory records (already computed with correct trace offsets)
+            memory_read_records = std::move(precomputed_memory_read_records);
+            memory_write_records = std::move(precomputed_memory_write_records);
+
+            // Allocate witness polynomials
+            allocate_wires();
+            allocate_permutation_argument_polynomials();
+            allocate_table_lookup_polynomials(circuit);
+
+            if constexpr (IsMegaFlavor<Flavor>) {
+                allocate_ecc_op_polynomials(circuit);
+            }
+            if constexpr (HasDataBus<Flavor>) {
+                allocate_databus_polynomials(circuit);
+            }
+        }
+
+        // --- STEP 2: Hydrate PRECOMPUTED polynomials from serialized data ---
+        // These are circuit-specific and do NOT change between witnesses:
+        // - selectors (q_m, q_c, q_l, q_r, q_o, q_4, q_arith, etc.)
+        // - sigmas (sigma_1, sigma_2, sigma_3, sigma_4)
+        // - ids (id_1, id_2, id_3, id_4)
+        // - tables (table_1, table_2, table_3, table_4)
+        // - lagrange (lagrange_first, lagrange_last)
+        {
+            BB_BENCH_NAME("hydrating precomputed polynomials from proving key");
+            auto precomputed_polys = polynomials.get_precomputed();
+            BB_ASSERT(precomputed_polynomials.size() == precomputed_polys.size(),
+                      "ProverInstance hydration: precomputed polynomial count mismatch. Expected ",
+                      precomputed_polys.size(),
+                      " but got ",
+                      precomputed_polynomials.size());
+
+            size_t idx = 0;
+            for (auto& poly : precomputed_polys) {
+                auto& poly_data = precomputed_polynomials[idx];
+                size_t actual_size = poly_data.coefficients.size();
+                poly = Polynomial(actual_size, poly_data.virtual_size, poly_data.start_index);
+                std::copy(poly_data.coefficients.begin(), poly_data.coefficients.end(), poly.data());
+                ++idx;
+            }
+        }
+
+        // Set shifted polynomials (views into the to_be_shifted polynomials)
+        polynomials.set_shifted();
+
+        // --- STEP 3: Populate wire polynomials and compute witness-dependent data ---
+        {
+            BB_BENCH_NAME("populating witness trace");
+            // Populate wires from circuit witness - this fills w_l, w_r, w_o, w_4
+            Trace::populate(circuit, polynomials);
+
+            // Construct lookup read counts from circuit
+            construct_lookup_read_counts<Flavor>(polynomials.lookup_read_counts, polynomials.lookup_read_tags, circuit);
+
+            // If Goblin/Mega, construct databus polynomials
+            if constexpr (IsMegaFlavor<Flavor>) {
+                construct_databus_polynomials(circuit);
+            }
+        }
+
+        // --- STEP 4: Extract public inputs from fresh witness wires ---
+        {
+            for (size_t i = 0; i < metadata.num_public_inputs; ++i) {
+                size_t idx = i + metadata.pub_inputs_offset;
+                public_inputs.emplace_back(polynomials.w_r[idx]);
+            }
+
+            if constexpr (HasIPAAccumulator<Flavor>) {
+                ipa_proof = circuit.ipa_proof;
+            }
+        }
+
+        auto end = std::chrono::steady_clock::now();
+        auto diff = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
+        vinfo("time to construct proving key (hydrated): ", diff.count(), " ms.");
     }
 
     ProverInstance_() = default;

--- a/barretenberg/ts/src/barretenberg/index.ts
+++ b/barretenberg/ts/src/barretenberg/index.ts
@@ -1,5 +1,7 @@
 import { Crs, GrumpkinCrs } from '../crs/index.js';
 import { AsyncApi } from '../cbind/generated/async.js';
+
+
 import { SyncApi } from '../cbind/generated/sync.js';
 import { IMsgpackBackendSync, IMsgpackBackendAsync } from '../bb_backends/interface.js';
 import { BackendOptions, BackendType } from '../bb_backends/index.js';
@@ -34,7 +36,7 @@ export class Barretenberg extends AsyncApi {
    *   2. WasmWorker (in browser) or Wasm (in Node.js)
    */
   static async new(options: BackendOptions = {}) {
-    const logger = options.logger ?? (() => {});
+    const logger = options.logger ?? (() => { });
 
     if (options.backend) {
       // Explicit backend required - no fallback
@@ -141,6 +143,7 @@ export class Barretenberg extends AsyncApi {
     }
     return barretenbergSingleton;
   }
+
 }
 
 let barretenbergSingletonPromise: Promise<Barretenberg>;
@@ -166,7 +169,7 @@ export class BarretenbergSync extends SyncApi {
    * Not supported: WasmWorker (no workers in sync), NativeUnixSocket (async only)
    */
   static async new(options: BackendOptions = {}) {
-    const logger = options.logger ?? (() => {});
+    const logger = options.logger ?? (() => { });
 
     if (options.backend) {
       return await createSyncBackend(options.backend, options, logger);


### PR DESCRIPTION
### Problem

The current `bb.js` implementation supports only one-shot proving via `proveAndVerify`. This requires regenerating the proving key for every proof, which is computationally expensive and memory-intensive.

In resource-constrained environments like browsers, holding both the circuit builder and the proving key simultaneously can exceed the WASM 4GB memory limit, resulting in Out-Of-Memory (OOM) errors.

### Solution

This PR implements **stateful proving** by decoupling key generation from proof generation. It introduces two new exports:

1. `acir_get_proving_key_ultra_honk`: Generates and serializes the proving key independently.
2. `acir_prove_ultra_honk_with_pk`: Generates proofs using a pre-computed key and a fresh witness.

This enables a **Generate Once → Cache → Prove Many** workflow, allowing the heavy key generation step to be performed once and the lighter proving step to be repeated efficiently.

### Use Cases

- **Browser Environments:** Avoids OOM errors by allowing builder memory to be freed before loading the key.
- **Caching:** Proving keys can be persisted in `IndexedDB` or `localStorage`.
- **Performance:** Eliminates redundant computation for circuits proven multiple times.

### Security & Design

Reusing proving keys with different witnesses is the standard design for zk-SNARKs. The serialized proving key encodes circuit structure (public parameters) but **no witness data**.

The serialized key contains:
- Fixed polynomials (circuit-specific, reusable)
- Relation parameters (circuit-specific, reusable)
- Gate challenges (circuit-specific, reusable)

Witness data remains ephemeral and is computed fresh for every proof.

### Implementation Changes

**C++ Layer (`bbapi`)**
- Implemented `AcirGetProvingKey` and `AcirProveWithPk` commands in `bbapi_ultra_honk.cpp`
- Defined `DeciderProvingKeyExport` struct for MsgPack serialization
- Registered new commands in `bbapi_execute.hpp`
- Added comprehensive unit tests in `bbapi_stateful_keygen.test.cpp`
- Aligned `AcirProveWithPkResponse` and `combined_result` serialization in C++ to strictly match the snake_case expectations of the auto-generated TypeScript bindings

**TypeScript Layer**
- Auto-generated bindings for new commands
- Updated `Barretenberg` class to use generated `acirGetProvingKeyUltraHonk` and `acirProveUltraHonkWithPk`
