### PR TITLE
feat: handle encryption (and therefore message delivery) to invalid addresses

### DIFF
--- a/docs/docs/developers/docs/resources/migration_notes.md
+++ b/docs/docs/developers/docs/resources/migration_notes.md
@@ -9,6 +9,15 @@ Aztec is in full-speed development. Literally every version breaks compatibility
 
 ## TBD
 
+### [Aztec.nr] `derive_ecdh_shared_secret_using_aztec_address` removed
+
+This function made it annoying to deal with invalid addresses in circuits. If you were using it, replace it with `derive_ecdh_shared_secret` instead:
+
+```diff
+-let shared_secret = derive_ecdh_shared_secret_using_aztec_address(secret, address).unwrap();
++let shared_secret = derive_ecdh_shared_secret(secret, address.to_address_point().unwrap().inner);
+```
+
 ### [Aztec.nr] Note owner is now enshrined
 
 It turns out that in all the cases a note always have a logical owner.

--- a/noir-projects/aztec-nr/aztec/src/keys/ecdh_shared_secret.nr
+++ b/noir-projects/aztec-nr/aztec/src/keys/ecdh_shared_secret.nr
@@ -3,40 +3,19 @@ use dep::protocol_types::{
 };
 use std::{embedded_curve_ops::multi_scalar_mul, ops::Neg};
 
-/// Computes a standard ecdh shared secret: [secret] * public_key = shared_secret.
-/// The input secret is known only to one party. The output shared secret is derivable
-/// by both parties, through this function.
+/// Computes a standard ECDH shared secret: secret * public_key = shared_secret.
+///
+/// The input secret is known only to one party. The output shared secret can be derived given knowledge of
+/// `public_key`'s key-pair and the public ephemeral secret, using this same function (with reversed inputs).
+///
 /// E.g.:
-/// Epk = esk * G // ephemeral keypair
-/// Pk = sk * G // recipient keypair
-/// Shared secret S = esk * Pk = sk * Epk // see how this function can be called with two different sets of inputs, depending on which secret the caller knows (either esk or sk)?
-// See also: https://en.wikipedia.org/wiki/Elliptic-curve_Diffie%E2%80%93Hellman
+/// Epk = esk * G // ephemeral key-pair
+/// Pk = sk * G // recipient key-pair
+/// Shared secret S = esk * Pk = sk * Epk
+///
+/// See also: https://en.wikipedia.org/wiki/Elliptic-curve_Diffie%E2%80%93Hellman
 pub fn derive_ecdh_shared_secret(secret: Scalar, public_key: Point) -> Point {
-    let shared_secret = multi_scalar_mul([public_key], [secret]);
-    shared_secret
-}
-
-/// Computes a standard ECDH shared secret using the public key corresponding to an AztecAddress:
-///
-/// # Formula
-/// `[ephemeral_secret] * recipient_address_public_key = shared_secret`
-///
-/// # Usage
-/// The intention is that the _creator_ of a shared secret calls this function,
-/// providing the address of their intended recipient.
-///
-/// # Note
-/// The function returns `Option<Point>` because the recipient address might be invalid
-/// (i.e., not correspond to a point on the curve). Callers must handle the `None` case.
-/// This is unlike `derive_ecdh_shared_secret`, which always returns a `Point` because it
-/// operates on guaranteed-valid inputs.
-pub fn derive_ecdh_shared_secret_using_aztec_address(
-    ephemeral_secret: Scalar,
-    recipient_address: AztecAddress,
-) -> Option<Point> {
-    recipient_address.to_address_point().map(|addr_point| {
-        derive_ecdh_shared_secret(ephemeral_secret, addr_point.inner)
-    })
+    multi_scalar_mul([public_key], [secret])
 }
 
 #[test]
@@ -103,8 +82,9 @@ unconstrained fn test_shared_secret_computation_from_address_in_both_directions(
         pk_b.neg()
     };
 
-    let shared_secret = derive_ecdh_shared_secret_using_aztec_address(secret_a, address_b);
+    let shared_secret =
+        derive_ecdh_shared_secret(secret_a, address_b.to_address_point().unwrap().inner);
     let shared_secret_alt = derive_ecdh_shared_secret(secret_b, pk_a);
 
-    assert_eq(shared_secret.unwrap(), shared_secret_alt);
+    assert_eq(shared_secret, shared_secret_alt);
 }

--- a/noir-projects/aztec-nr/aztec/src/messages/encryption/aes128.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/encryption/aes128.nr
@@ -3,13 +3,11 @@ use dep::protocol_types::{
     constants::{GENERATOR_INDEX__SYMMETRIC_KEY, GENERATOR_INDEX__SYMMETRIC_KEY_2},
     hash::poseidon2_hash_with_separator,
     point::Point,
+    public_keys::AddressPoint,
 };
 
 use crate::{
-    keys::{
-        ecdh_shared_secret::derive_ecdh_shared_secret_using_aztec_address,
-        ephemeral::generate_ephemeral_key_pair,
-    },
+    keys::{ecdh_shared_secret::derive_ecdh_shared_secret, ephemeral::generate_ephemeral_key_pair},
     messages::{
         encoding::{
             EPH_PK_SIGN_BYTE_SIZE_IN_BYTES, EPH_PK_X_SIZE_IN_FIELDS,
@@ -21,7 +19,9 @@ use crate::{
             get_arr_of_size__message_bytes_padding__from_PT,
         },
     },
-    oracle::{aes128_decrypt::aes128_decrypt_oracle, shared_secret::get_shared_secret},
+    oracle::{
+        aes128_decrypt::aes128_decrypt_oracle, random::random, shared_secret::get_shared_secret,
+    },
     utils::{
         array,
         conversion::{
@@ -174,10 +174,28 @@ impl MessageEncryption for AES128 {
         let eph_pk_sign_byte: u8 = get_sign_of_point(eph_pk) as u8;
 
         // (not to be confused with the tagging shared secret)
-        // TODO (#17158): Currently we unwrap the Option returned by derive_ecdh_shared_secret_using_aztec_address.
+        // TODO (#17158): Currently we unwrap the Option returned by derive_ecdh_shared_secret.
         // We need to handle the case where the ephemeral public key is invalid to prevent potential DoS vectors.
-        let ciphertext_shared_secret =
-            derive_ecdh_shared_secret_using_aztec_address(eph_sk, recipient).unwrap();
+        let ciphertext_shared_secret = derive_ecdh_shared_secret(
+            eph_sk,
+            recipient
+                .to_address_point()
+                .unwrap_or(
+                    // Safety: if the recipient is an invalid address, then it is not possible to encrypt a message for
+                    // them because we cannot establish a shared secret. This is never expected to occur during normal
+                    // operation. However, it is technically possible for us to receive an invalid address, and we must
+                    // therefore handle it.
+                    // We could simply fail, but that'd introduce a potential security issue in which an attacker forces
+                    // a contract to encrypt a message for an invalid address, resulting in an impossible transaction -
+                    // this is sometimes called a 'king of the hill' attack.
+                    // We choose instead to not fail and encrypt the plaintext regardless using the shared secret that
+                    // results from a random valid address. The sender is free to choose this address and hence shared
+                    // secret, but this has no security implications as they already know not only the full plaintext
+                    // but also the ephemeral private key anyway.
+                    unsafe { random_address_point() },
+                )
+                .inner,
+        );
         // TODO: also use this shared secret for deriving note randomness.
 
         // *****************************************************************************
@@ -385,15 +403,34 @@ impl MessageEncryption for AES128 {
     }
 }
 
+/// Produces a random valid address point, i.e. one that is on the curve. This is equivalent to calling
+/// [AztecAddress::to_address_point] on a random valid address.
+unconstrained fn random_address_point() -> AddressPoint {
+    let mut result = std::mem::zeroed();
+
+    loop {
+        // We simply produce random x coordinates until we find one that is on the curve. About half of the x
+        // coordinates fulfill this condition, so this should only take a few iterations at most.
+        let x_coord = random();
+        let point = point_from_x_coord_and_sign(x_coord, true);
+        if point.is_some() {
+            result = AddressPoint { inner: point.unwrap() };
+            break;
+        }
+    }
+
+    result
+}
+
 mod test {
     use crate::{
-        keys::ecdh_shared_secret::derive_ecdh_shared_secret_using_aztec_address,
+        keys::ecdh_shared_secret::derive_ecdh_shared_secret,
         messages::{
             encoding::MESSAGE_PLAINTEXT_LEN, encryption::message_encryption::MessageEncryption,
         },
         test::helpers::test_environment::TestEnvironment,
     };
-    use super::AES128;
+    use super::{AES128, random_address_point};
     use protocol_types::{address::AztecAddress, traits::FromField};
     use std::{embedded_curve_ops::EmbeddedCurveScalar, test::OracleMock};
 
@@ -422,12 +459,12 @@ mod test {
             let encrypted_message = BoundedVec::from_array(AES128::encrypt(plaintext, recipient));
 
             // Mock shared secret for deterministic test
-            let shared_secret = derive_ecdh_shared_secret_using_aztec_address(
+            let shared_secret = derive_ecdh_shared_secret(
                 EmbeddedCurveScalar::from_field(eph_sk),
-                recipient,
+                recipient.to_address_point().unwrap().inner,
             );
 
-            let _ = OracleMock::mock("utilityGetSharedSecret").returns(shared_secret.unwrap());
+            let _ = OracleMock::mock("utilityGetSharedSecret").returns(shared_secret);
 
             // Decrypt the message
             let decrypted = AES128::decrypt(encrypted_message, recipient).unwrap();
@@ -466,6 +503,26 @@ mod test {
                 BoundedVec::from_array(plaintext),
             );
         });
+    }
+
+    #[test]
+    unconstrained fn encrypt_to_invalid_address() {
+        // x = 3 is a non-residue for this curve, resulting in an invalid address
+        let invalid_address = AztecAddress { inner: 3 };
+
+        // We just test that we produced some output and did not crash - the result is gibberish as it is encrypted
+        // using a public key for which we do not know the private key.
+        let _ = AES128::encrypt([1, 2, 3, 4], invalid_address);
+    }
+
+    #[test]
+    unconstrained fn random_address_point_produces_valid_points() {
+        // About half of random addresses are invalid, so testing just a couple gives us high confidence that
+        // `random_address_point` is indeed producing valid addresses.
+        for _ in 0..10 {
+            let random_address = AztecAddress { inner: random_address_point().inner.x };
+            assert(random_address.to_address_point().is_some());
+        }
     }
 
     #[test]


### PR DESCRIPTION
Closes https://linear.app/aztec-labs/issue/F-188/handle-invalid-addresses.

Instead of skipping log emission, I decided to encrypt to a random point. This is better as it results in zero additional constraints.