### PR TITLE
feat: handle invalid ephemeral public keys

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/messages/discovery/process_message.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/discovery/process_message.nr
@@ -31,12 +31,21 @@ pub unconstrained fn process_message_ciphertext<Env>(
     message_ciphertext: BoundedVec<Field, MESSAGE_CIPHERTEXT_LEN>,
     message_context: MessageContext,
 ) {
-    process_message_plaintext(
-        contract_address,
-        compute_note_hash_and_nullifier,
-        AES128::decrypt(message_ciphertext, message_context.recipient),
-        message_context,
-    );
+    let message_plaintext_option = AES128::decrypt(message_ciphertext, message_context.recipient);
+
+    if message_plaintext_option.is_some() {
+        process_message_plaintext(
+            contract_address,
+            compute_note_hash_and_nullifier,
+            message_plaintext_option.unwrap(),
+            message_context,
+        );
+    } else {
+        debug_log_format(
+            "Found invalid message from tx {0}, ignoring",
+            [message_context.tx_hash],
+        );
+    }
 }
 
 pub unconstrained fn process_message_plaintext<Env>(

--- a/noir-projects/aztec-nr/aztec/src/messages/encryption/aes128.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/encryption/aes128.nr
@@ -324,7 +324,7 @@ impl MessageEncryption for AES128 {
     unconstrained fn decrypt(
         ciphertext: BoundedVec<Field, MESSAGE_CIPHERTEXT_LEN>,
         recipient: AztecAddress,
-    ) -> BoundedVec<Field, MESSAGE_PLAINTEXT_LEN> {
+    ) -> Option<BoundedVec<Field, MESSAGE_PLAINTEXT_LEN>> {
         let eph_pk_x = ciphertext.get(0);
 
         let ciphertext_without_eph_pk_x_fields = array::subbvec::<Field, MESSAGE_CIPHERTEXT_LEN, MESSAGE_CIPHERTEXT_LEN - EPH_PK_X_SIZE_IN_FIELDS>(
@@ -337,50 +337,51 @@ impl MessageEncryption for AES128 {
 
         // First byte of the ciphertext represents the ephemeral public key sign
         let eph_pk_sign_bool = ciphertext_without_eph_pk_x.get(0) != 0;
-        // With the sign and the x-coordinate of the ephemeral public key, we can reconstruct the point
-        let eph_pk = point_from_x_coord_and_sign(eph_pk_x, eph_pk_sign_bool);
 
-        // Derive shared secret
-        // TODO(#17158): handle invalid ephemeral keys when decrypting to prevent DoS vectors
-        let ciphertext_shared_secret = get_shared_secret(recipient, eph_pk.unwrap());
+        // With the sign and the x-coordinate of the ephemeral public key, we can reconstruct the point. This may fail
+        // however, as not all x-coordinates are on the curve. In that case, we simply return `Option::none`.
+        point_from_x_coord_and_sign(eph_pk_x, eph_pk_sign_bool).map(|eph_pk| {
+            // Derive shared secret
+            let ciphertext_shared_secret = get_shared_secret(recipient, eph_pk);
 
-        // Derive symmetric keys:
-        let pairs = derive_aes_symmetric_key_and_iv_from_ecdh_shared_secret_using_poseidon2_unsafe::<2>(
-            ciphertext_shared_secret,
-        );
-        let (body_sym_key, body_iv) = pairs[0];
-        let (header_sym_key, header_iv) = pairs[1];
+            // Derive symmetric keys:
+            let pairs = derive_aes_symmetric_key_and_iv_from_ecdh_shared_secret_using_poseidon2_unsafe::<2>(
+                ciphertext_shared_secret,
+            );
+            let (body_sym_key, body_iv) = pairs[0];
+            let (header_sym_key, header_iv) = pairs[1];
 
-        // Extract the header ciphertext
-        let header_start = EPH_PK_SIGN_BYTE_SIZE_IN_BYTES; // Skip eph_pk_sign byte
-        let header_ciphertext: [u8; HEADER_CIPHERTEXT_SIZE_IN_BYTES] =
-            array::subarray(ciphertext_without_eph_pk_x.storage(), header_start);
-        // We need to convert the array to a BoundedVec because the oracle expects a BoundedVec as it's designed to work
-        // with messages with unknown length at compile time. This would not be necessary here as the header ciphertext length
-        // is fixed. But we do it anyway to not have to have duplicate oracles.
-        let header_ciphertext_bvec =
-            BoundedVec::<u8, HEADER_CIPHERTEXT_SIZE_IN_BYTES>::from_array(header_ciphertext);
+            // Extract the header ciphertext
+            let header_start = EPH_PK_SIGN_BYTE_SIZE_IN_BYTES; // Skip eph_pk_sign byte
+            let header_ciphertext: [u8; HEADER_CIPHERTEXT_SIZE_IN_BYTES] =
+                array::subarray(ciphertext_without_eph_pk_x.storage(), header_start);
+            // We need to convert the array to a BoundedVec because the oracle expects a BoundedVec as it's designed to work
+            // with messages with unknown length at compile time. This would not be necessary here as the header ciphertext length
+            // is fixed. But we do it anyway to not have to have duplicate oracles.
+            let header_ciphertext_bvec =
+                BoundedVec::<u8, HEADER_CIPHERTEXT_SIZE_IN_BYTES>::from_array(header_ciphertext);
 
-        // Decrypt header
-        let header_plaintext =
-            aes128_decrypt_oracle(header_ciphertext_bvec, header_iv, header_sym_key);
+            // Decrypt header
+            let header_plaintext =
+                aes128_decrypt_oracle(header_ciphertext_bvec, header_iv, header_sym_key);
 
-        // Extract ciphertext length from header (2 bytes, big-endian)
-        let ciphertext_length =
-            ((header_plaintext.get(0) as u32) << 8) | (header_plaintext.get(1) as u32);
+            // Extract ciphertext length from header (2 bytes, big-endian)
+            let ciphertext_length =
+                ((header_plaintext.get(0) as u32) << 8) | (header_plaintext.get(1) as u32);
 
-        // Extract and decrypt main ciphertext
-        let ciphertext_start = header_start + HEADER_CIPHERTEXT_SIZE_IN_BYTES;
-        let ciphertext_with_padding: [u8; (MESSAGE_CIPHERTEXT_LEN - EPH_PK_X_SIZE_IN_FIELDS) * 31 - HEADER_CIPHERTEXT_SIZE_IN_BYTES - EPH_PK_SIGN_BYTE_SIZE_IN_BYTES] =
-            array::subarray(ciphertext_without_eph_pk_x.storage(), ciphertext_start);
-        let ciphertext: BoundedVec<u8, (MESSAGE_CIPHERTEXT_LEN - EPH_PK_X_SIZE_IN_FIELDS) * 31 - HEADER_CIPHERTEXT_SIZE_IN_BYTES - EPH_PK_SIGN_BYTE_SIZE_IN_BYTES> =
-            BoundedVec::from_parts(ciphertext_with_padding, ciphertext_length);
+            // Extract and decrypt main ciphertext
+            let ciphertext_start = header_start + HEADER_CIPHERTEXT_SIZE_IN_BYTES;
+            let ciphertext_with_padding: [u8; (MESSAGE_CIPHERTEXT_LEN - EPH_PK_X_SIZE_IN_FIELDS) * 31 - HEADER_CIPHERTEXT_SIZE_IN_BYTES - EPH_PK_SIGN_BYTE_SIZE_IN_BYTES] =
+                array::subarray(ciphertext_without_eph_pk_x.storage(), ciphertext_start);
+            let ciphertext: BoundedVec<u8, (MESSAGE_CIPHERTEXT_LEN - EPH_PK_X_SIZE_IN_FIELDS) * 31 - HEADER_CIPHERTEXT_SIZE_IN_BYTES - EPH_PK_SIGN_BYTE_SIZE_IN_BYTES> =
+                BoundedVec::from_parts(ciphertext_with_padding, ciphertext_length);
 
-        // Decrypt main ciphertext and return it
-        let plaintext_bytes = aes128_decrypt_oracle(ciphertext, body_iv, body_sym_key);
+            // Decrypt main ciphertext and return it
+            let plaintext_bytes = aes128_decrypt_oracle(ciphertext, body_iv, body_sym_key);
 
-        // Each field of the original note message was serialized to 32 bytes so we convert the bytes back to fields.
-        fields_from_bytes(plaintext_bytes)
+            // Each field of the original note message was serialized to 32 bytes so we convert the bytes back to fields.
+            fields_from_bytes(plaintext_bytes)
+        })
     }
 }
 
@@ -397,7 +398,7 @@ mod test {
     use std::{embedded_curve_ops::EmbeddedCurveScalar, test::OracleMock};
 
     #[test]
-    unconstrained fn encrypt_decrypt() {
+    unconstrained fn encrypt_decrypt_deterministic() {
         let env = TestEnvironment::new();
 
         // Message decryption requires oracles that are only available during private execution
@@ -429,7 +430,7 @@ mod test {
             let _ = OracleMock::mock("utilityGetSharedSecret").returns(shared_secret.unwrap());
 
             // Decrypt the message
-            let decrypted = AES128::decrypt(encrypted_message, recipient);
+            let decrypted = AES128::decrypt(encrypted_message, recipient).unwrap();
 
             // The decryption function spits out a BoundedVec because it's designed to work with messages with unknown length
             // at compile time. For this reason we need to convert the original input to a BoundedVec.
@@ -445,6 +446,44 @@ mod test {
             // The following is a workaround of "struct is never constructed" Noir compilation error (we only ever use
             // static methods of the struct).
             let _ = AES128 {};
+        });
+    }
+
+    #[test]
+    unconstrained fn encrypt_decrypt_random() {
+        // Same as `encrypt_decrypt_deterministic`, except we don't mock any of the oracles and rely on
+        // `TestEnvironment` instead.
+        let mut env = TestEnvironment::new();
+
+        let recipient = env.create_light_account();
+
+        env.private_context(|_| {
+            let plaintext = [1, 2, 3];
+            let ciphertext = AES128::encrypt(plaintext, recipient);
+
+            assert_eq(
+                AES128::decrypt(BoundedVec::from_array(ciphertext), recipient).unwrap(),
+                BoundedVec::from_array(plaintext),
+            );
+        });
+    }
+
+    #[test]
+    unconstrained fn decrypt_invalid_ephemeral_public_key() {
+        let mut env = TestEnvironment::new();
+
+        let recipient = env.create_light_account();
+
+        env.private_context(|_| {
+            let plaintext = [1, 2, 3, 4];
+            let ciphertext = AES128::encrypt(plaintext, recipient);
+
+            // The first field of the ciphertext is the x-coordinate of the ephemeral public key. We set it to a known
+            // non-residue (3), causing `decrypt` to fail to produce a decryption shared secret.
+            let mut bad_ciphertext = BoundedVec::from_array(ciphertext);
+            bad_ciphertext.set(0, 3);
+
+            assert(AES128::decrypt(bad_ciphertext, recipient).is_none());
         });
     }
 }

--- a/noir-projects/aztec-nr/aztec/src/messages/encryption/message_encryption.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/encryption/message_encryption.nr
@@ -1,10 +1,10 @@
 use crate::messages::encoding::{MESSAGE_CIPHERTEXT_LEN, MESSAGE_PLAINTEXT_LEN};
 use protocol_types::address::AztecAddress;
 
-/// Trait for encrypting and decrypting private logs in the Aztec protocol.
+/// Trait for encrypting and decrypting messages in the Aztec protocol.
 ///
-/// This trait defines the interface for encrypting plaintext data into private logs that can be
-/// emitted onchain or delivered offchain, and decrypting those logs back into their original plaintext.
+/// This trait defines the interface for encrypting plaintext data into messages that are delivered either onchain (via
+/// logs) or offchain, as well as decrypting those messages back into their original plaintext.
 ///
 /// # Type Parameters
 /// - `PLAINTEXT_LEN`: Length of the plaintext array in fields
@@ -12,38 +12,37 @@ use protocol_types::address::AztecAddress;
 /// - `MESSAGE_PLAINTEXT_LEN`: Maximum size of decrypted plaintext (defined globally)
 ///
 /// # Note on privacy sets
-/// To preserve privacy, `encrypt` returns a fixed-length array ensuring all log types are indistinguishable
-/// onchain. Implementations of this trait must handle padding the encrypted log to match this standardized length.
+/// To preserve privacy, [MessageEncryption::encrypt] returns a fixed-length array ensuring all log types are
+/// indistinguishable onchain. Implementations of this trait must handle padding the encrypted log to match this
+/// standardized length.
 pub trait MessageEncryption {
-    /// Encrypts a plaintext field array into a private log that can be emitted onchain.
+    /// Encrypts a plaintext message (a field array) such that only `recipient` can decrypt it.
     ///
-    /// # Arguments
-    /// * `plaintext` - Array of Field elements to encrypt
-    /// * `recipient` - Aztec address of intended recipient who can decrypt the log
+    /// The returned message ciphertext can be passed to [MessageEncryption::decrypt] in order to obtain the original
+    /// `plaintext`.
     ///
-    /// # Returns
-    /// Fixed-size array of encrypted Field elements representing the private log
+    /// # Privacy
+    /// Knowledge of the returned ciphertext provides no information to third parties - `recipients` encryption keys
+    /// (specifically their ivsk and pre-address) are required in order to decrypt. Additionally, [encrypt] adds random
+    /// padding in order to always produce equal length message ciphertexts regardless of the input, hiding its length.
+    ///
+    /// These properties make it secure to distribute the ciphertext publicly, e.g. on blockchain logs (assuming the
+    /// encryption function is itself secure).
     fn encrypt<let PlaintextLen: u32>(
         plaintext: [Field; PlaintextLen],
         recipient: AztecAddress,
     ) -> [Field; MESSAGE_CIPHERTEXT_LEN];
 
-    /// Decrypts a private log back into its original plaintext fields.
-    /// This function is unconstrained since decryption happens when processing logs in an unconstrained context.
+    /// Decrypts a message ciphertext obtained via [MessageEncryption::encrypt] to `recipient` back into its original
+    /// plaintext.
     ///
-    /// # Arguments
-    /// * `ciphertext` - Bounded vector containing the encrypted log fields
-    /// * `recipient` - Aztec address of the recipient who can decrypt
+    /// Note that this function is unconstrained: decryption typically happens when processing messages in utility
+    /// functions.
     ///
-    /// # Returns
-    /// Bounded vector containing the decrypted plaintext fields
-    ///
-    /// # Note on use of BoundedVec
-    /// `BoundedVec` is required since the log length cannot be determined at compile time. This is because
-    /// the `Contract::process_log` function is designed to work with all the private logs, emitted by a given contract
-    /// and not just by 1 log type.
+    /// Not all ciphertexts are valid - among other things, the ephemeral public key included in it may not correspond
+    /// to a point on the curve. In all such cases, [Option::none] is returned instead.
     unconstrained fn decrypt(
         ciphertext: BoundedVec<Field, MESSAGE_CIPHERTEXT_LEN>,
         recipient: AztecAddress,
-    ) -> BoundedVec<Field, MESSAGE_PLAINTEXT_LEN>;
+    ) -> Option<BoundedVec<Field, MESSAGE_PLAINTEXT_LEN>>;
 }


### PR DESCRIPTION
Closes https://github.com/AztecProtocol/aztec-packages/issues/17158.

This prevents a message with a bad public key x-coord from causing message processing to fail and halt. We still need to handle other such instances of this, including the ciphertext being malformed.