### PR TITLE
chore: address the addition overflow issue in BLAKE

### DIFF
--- a/barretenberg/cpp/scripts/test_chonk_standalone_vks_havent_changed.sh
+++ b/barretenberg/cpp/scripts/test_chonk_standalone_vks_havent_changed.sh
@@ -13,7 +13,7 @@ cd ..
 # - Generate a hash for versioning: sha256sum bb-chonk-inputs.tar.gz
 # - Upload the compressed results: aws s3 cp bb-chonk-inputs.tar.gz s3://aztec-ci-artifacts/protocol/bb-chonk-inputs-[hash(0:8)].tar.gz
 # Note: In case of the "Test suite failed to run ... Unexpected token 'with' " error, need to run: docker pull aztecprotocol/build:3.0
-pinned_short_hash="9d100e1f"
+pinned_short_hash="069bd3d2"
 pinned_chonk_inputs_url="https://aztec-ci-artifacts.s3.us-east-2.amazonaws.com/protocol/bb-chonk-inputs-${pinned_short_hash}.tar.gz"
 
 function compress_and_upload {

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/block_constraint.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/block_constraint.test.cpp
@@ -475,7 +475,7 @@ class CallDataTestingFunctions {
         case InvalidWitness::Target::ReadValueIncremented:
             // Tamper with a random read value using the recorded witness index
             const size_t random_read_idx = static_cast<size_t>(engine.get_random_uint32() % num_reads);
-            const uint32_t witness_idx = memory_constraint.trace[random_read_idx].index.index;
+            const uint32_t witness_idx = memory_constraint.trace[random_read_idx].value.index;
             witness_values[witness_idx] += bb::fr(1);
             break;
         }

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/gate_count_constants.hpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/gate_count_constants.hpp
@@ -37,8 +37,8 @@ template <typename Builder> inline constexpr size_t ECDSA_SECP256K1 = 41994 + ZE
 template <typename Builder>
 inline constexpr size_t ECDSA_SECP256R1 = 72209 + ZERO_GATE + (IsMegaBuilder<Builder> ? 2 : 0);
 
-template <typename Builder> inline constexpr size_t BLAKE2S = 2864 + ZERO_GATE + MEGA_OFFSET<Builder>;
-template <typename Builder> inline constexpr size_t BLAKE3 = 2100 + ZERO_GATE + MEGA_OFFSET<Builder>;
+template <typename Builder> inline constexpr size_t BLAKE2S = 2959 + ZERO_GATE + MEGA_OFFSET<Builder>;
+template <typename Builder> inline constexpr size_t BLAKE3 = 2165 + ZERO_GATE + MEGA_OFFSET<Builder>;
 template <typename Builder> inline constexpr size_t KECCAK_PERMUTATION = 17387 + ZERO_GATE + MEGA_OFFSET<Builder>;
 template <typename Builder> inline constexpr size_t POSEIDON2_PERMUTATION = 73 + ZERO_GATE + MEGA_OFFSET<Builder>;
 template <typename Builder> inline constexpr size_t MULTI_SCALAR_MUL = 3550 + ZERO_GATE;

--- a/barretenberg/cpp/src/barretenberg/stdlib/hash/blake2s/blake2s.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/hash/blake2s/blake2s.test.cpp
@@ -131,3 +131,29 @@ TEST(stdlib_blake2s, test_multiple_sized_blocks)
         EXPECT_EQ(proof_result, true);
     }
 }
+
+// Edge case that caused addition overflow issues in Blake
+TEST(stdlib_blake2s, test_edge_case_addition_overflow)
+{
+    std::array<uint8_t, 62> v = { 0x0E, 0xF6, 0xF6, 0xF6, 0xF6, 0xF6, 0xF6, 0xF6, 0xF6, 0xF6, 0xF6, 0xF6, 0xF6,
+                                  0xF6, 0xF6, 0xF6, 0xF6, 0xF6, 0xF6, 0xF6, 0xF6, 0xF6, 0xF6, 0xF6, 0xF6, 0xF6,
+                                  0xF6, 0xF6, 0xF6, 0xF6, 0xF6, 0xF6, 0xF6, 0xF6, 0xF6, 0xF6, 0xF6, 0xF6, 0xFF,
+                                  0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x00, 0xF6, 0xF6, 0xF6, 0xF6, 0xF6, 0xF6,
+                                  0xF6, 0xF6, 0xF6, 0xF6, 0xED, 0xC3, 0x00, 0x00, 0x00, 0xED };
+
+    Builder builder;
+
+    std::vector<uint8_t> input_v(v.begin(), v.end());
+
+    byte_array_ct input_arr(&builder, input_v);
+    byte_array_ct output = stdlib::Blake2s<Builder>::hash(input_arr);
+
+    auto expected = crypto::blake2s(input_v);
+
+    EXPECT_EQ(output.get_value(), std::vector<uint8_t>(expected.begin(), expected.end()));
+
+    info(".: builder gates = ", builder.get_num_finalized_gates_inefficient());
+
+    bool proof_result = CircuitChecker::check(builder);
+    EXPECT_EQ(proof_result, true);
+}

--- a/barretenberg/cpp/src/barretenberg/stdlib/hash/blake2s/blake2s.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/hash/blake2s/blake2s.test.cpp
@@ -132,8 +132,11 @@ TEST(stdlib_blake2s, test_multiple_sized_blocks)
     }
 }
 
-// Edge case that caused addition overflow issues in Blake. See https://hackmd.io/@aztec-network/SyTHLkAWZx for a
-// detailed description of the addition overflow issue.
+// Previously, certain inputs were pushing the addition overflows in `g` to beyond 3 bits (where `add_normalize` can
+// tolerate up to 3 bits of overflow), causing failures. This has been addressed by calling `add_normalize` in the
+// second half of every call to `g` to ensure that the overflow doesn't go beyond 3 bits. The edge case that caused
+// addition overflow issues in Blake is tested here. See https://hackmd.io/@aztec-network/SyTHLkAWZx for a detailed
+// description of the addition overflow issue.
 TEST(stdlib_blake2s, test_edge_case_addition_overflow)
 {
     std::array<uint8_t, 62> v = { 0x0E, 0xF6, 0xF6, 0xF6, 0xF6, 0xF6, 0xF6, 0xF6, 0xF6, 0xF6, 0xF6, 0xF6, 0xF6,

--- a/barretenberg/cpp/src/barretenberg/stdlib/hash/blake2s/blake2s.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/hash/blake2s/blake2s.test.cpp
@@ -132,7 +132,8 @@ TEST(stdlib_blake2s, test_multiple_sized_blocks)
     }
 }
 
-// Edge case that caused addition overflow issues in Blake
+// Edge case that caused addition overflow issues in Blake. See https://hackmd.io/@aztec-network/SyTHLkAWZx for a
+// detailed description of the addition overflow issue.
 TEST(stdlib_blake2s, test_edge_case_addition_overflow)
 {
     std::array<uint8_t, 62> v = { 0x0E, 0xF6, 0xF6, 0xF6, 0xF6, 0xF6, 0xF6, 0xF6, 0xF6, 0xF6, 0xF6, 0xF6, 0xF6,

--- a/barretenberg/cpp/src/barretenberg/stdlib/hash/blake2s/blake_util.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/hash/blake2s/blake_util.hpp
@@ -71,25 +71,23 @@ template <typename Builder> field_t<Builder> add_normalize(const field_t<Builder
  * Inputs: - A pointer to a 16-word `state`,
  *         - indices a, b, c, d,
  *         - addition messages x and y
- *         - boolean `last_update` to make sure addition is normalised only in
- *           last update of the state
  *
  * Gate costs per call to function G in lookup case:
  *
  * Read sequence from table = 6 gates per read => 6 * 4 = 24
- * Addition gates = 4 gates
+ * Addition gates = 2 gates
  * Range gates = 2 gates
  * Addition gate for correct output of XOR rotate 12 = 1 gate
  * Normalizing scaling factors = 2 gates
  *
- * Subtotal = 33 gates
+ * Subtotal = 31 gates
  * Outside rounds, each of Blake2s and Blake3s needs 20 and 24 lookup reads respectively.
  *
  * +-----------+--------------+-----------------------+---------------------------+--------------+
  * |           |  calls to G  | gate count for rounds | gate count outside rounds |    total     |
  * |-----------|--------------|-----------------------|---------------------------|--------------|
- * |  Blake2s  |      80      |        80 * 33        |          20 * 6           |     2760     |
- * |  Blake3s  |      56      |        56 * 33        |          24 * 6           |     1992     |
+ * |  Blake2s  |      80      |        80 * 31        |          20 * 6           |     2600     |
+ * |  Blake3s  |      56      |        56 * 31        |          24 * 6           |     1880     |
  * +-----------+--------------+-----------------------+---------------------------+--------------+
  *
  * P.S. This doesn't include some more addition gates required after the rounds.
@@ -109,6 +107,7 @@ template <typename Builder> field_t<Builder> add_normalize(const field_t<Builder
  *
  *
  **/
+
 template <typename Builder>
 void g(field_t<Builder> state[BLAKE_STATE_SIZE],
        size_t a,
@@ -116,8 +115,7 @@ void g(field_t<Builder> state[BLAKE_STATE_SIZE],
        size_t c,
        size_t d,
        field_t<Builder> x,
-       field_t<Builder> y,
-       const bool last_update = false)
+       field_t<Builder> y)
 {
     typedef field_t<Builder> field_pt;
 
@@ -161,11 +159,7 @@ void g(field_t<Builder> state[BLAKE_STATE_SIZE],
     state[b] = lookup_output;
 
     // a = a + b + y
-    if (!last_update) {
-        state[a] = state[a].add_two(state[b], y);
-    } else {
-        state[a] = add_normalize(state[a], state[b] + y);
-    }
+    state[a] = add_normalize(state[a], state[b] + y);
 
     // d = (d ^ a).ror(8)
     // Get the lookup accumulator where `lookup_3[ColumnIdx::C3][0]` contains the
@@ -177,11 +171,7 @@ void g(field_t<Builder> state[BLAKE_STATE_SIZE],
     state[d] = lookup_3[ColumnIdx::C3][0] * scaling_factor_3;
 
     // c = c + d
-    if (!last_update) {
-        state[c] = state[c] + state[d];
-    } else {
-        state[c] = add_normalize(state[c], state[d]);
-    }
+    state[c] = add_normalize(state[c], state[d]);
 
     // b = (b ^ c).ror(7)
     // Get the lookup accumulator where `lookup_4[ColumnIdx::C3][0]` contains the
@@ -197,7 +187,7 @@ void g(field_t<Builder> state[BLAKE_STATE_SIZE],
  * This is the round function used in Blake2s and Blake3s for Ultra.
  * Inputs: - 16-word state
  *         - 16-word msg
- *         - round numbe
+ *         - round number
  *         - which_blake to choose Blake2 or Blake3 (false -> Blake2)
  */
 template <typename Builder>
@@ -216,10 +206,10 @@ void round_fn(field_t<Builder> state[BLAKE_STATE_SIZE],
     g<Builder>(state, 3, 7, 11, 15, msg[schedule[6]], msg[schedule[7]]);
 
     // Mix the rows.
-    g<Builder>(state, 0, 5, 10, 15, msg[schedule[8]], msg[schedule[9]], true);
-    g<Builder>(state, 1, 6, 11, 12, msg[schedule[10]], msg[schedule[11]], true);
-    g<Builder>(state, 2, 7, 8, 13, msg[schedule[12]], msg[schedule[13]], true);
-    g<Builder>(state, 3, 4, 9, 14, msg[schedule[14]], msg[schedule[15]], true);
+    g<Builder>(state, 0, 5, 10, 15, msg[schedule[8]], msg[schedule[9]]);
+    g<Builder>(state, 1, 6, 11, 12, msg[schedule[10]], msg[schedule[11]]);
+    g<Builder>(state, 2, 7, 8, 13, msg[schedule[12]], msg[schedule[13]]);
+    g<Builder>(state, 3, 4, 9, 14, msg[schedule[14]], msg[schedule[15]]);
 }
 
 } // namespace bb::stdlib::blake_util

--- a/barretenberg/cpp/src/barretenberg/stdlib/hash/blake3s/blake3s.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/hash/blake3s/blake3s.test.cpp
@@ -135,3 +135,27 @@ TEST(stdlib_blake3s, test_multiple_sized_blocks)
         EXPECT_EQ(proof_result, true);
     }
 }
+
+// Edge case that caused addition overflow issues in Blake
+TEST(stdlib_blake3s, test_edge_case_addition_overflow)
+{
+    std::array<uint8_t, 34> v = { 0xC3, 0x2B, 0xC3, 0x91, 0x23, 0xFF, 0xFF, 0xFF, 0xFF, 0xC3, 0xFF, 0xFF,
+                                  0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+                                  0xFF, 0xFF, 0xFF, 0xFF, 0xC3, 0x03, 0x83, 0x83, 0x83, 0x40 };
+
+    UltraBuilder builder;
+
+    std::vector<uint8_t> input_v(v.begin(), v.end());
+
+    byte_array_ct input_arr(&builder, input_v);
+    byte_array_ct output = stdlib::Blake3s<UltraBuilder>::hash(input_arr);
+
+    auto expected = blake3::blake3s(input_v);
+
+    EXPECT_EQ(output.get_value(), std::vector<uint8_t>(expected.begin(), expected.end()));
+
+    info(".: builder gates = ", builder.get_num_finalized_gates_inefficient());
+
+    bool proof_result = CircuitChecker::check(builder);
+    EXPECT_EQ(proof_result, true);
+}

--- a/barretenberg/cpp/src/barretenberg/stdlib/hash/blake3s/blake3s.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/hash/blake3s/blake3s.test.cpp
@@ -136,7 +136,8 @@ TEST(stdlib_blake3s, test_multiple_sized_blocks)
     }
 }
 
-// Edge case that caused addition overflow issues in Blake
+// Edge case that caused addition overflow issues in Blake. See https://hackmd.io/@aztec-network/SyTHLkAWZx for a
+// detailed description of the addition overflow issue.
 TEST(stdlib_blake3s, test_edge_case_addition_overflow)
 {
     std::array<uint8_t, 34> v = { 0xC3, 0x2B, 0xC3, 0x91, 0x23, 0xFF, 0xFF, 0xFF, 0xFF, 0xC3, 0xFF, 0xFF,

--- a/barretenberg/cpp/src/barretenberg/stdlib/hash/blake3s/blake3s.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/hash/blake3s/blake3s.test.cpp
@@ -136,8 +136,11 @@ TEST(stdlib_blake3s, test_multiple_sized_blocks)
     }
 }
 
-// Edge case that caused addition overflow issues in Blake. See https://hackmd.io/@aztec-network/SyTHLkAWZx for a
-// detailed description of the addition overflow issue.
+// Previously, certain inputs were pushing the addition overflows in `g` to beyond 3 bits (where `add_normalize` can
+// tolerate up to 3 bits of overflow), causing failures. This has been addressed by calling `add_normalize` in the
+// second half of every call to `g` to ensure that the overflow doesn't go beyond 3 bits. The edge case that caused
+// addition overflow issues in Blake is tested here. See https://hackmd.io/@aztec-network/SyTHLkAWZx for a detailed
+// description of the addition overflow issue.
 TEST(stdlib_blake3s, test_edge_case_addition_overflow)
 {
     std::array<uint8_t, 34> v = { 0xC3, 0x2B, 0xC3, 0x91, 0x23, 0xFF, 0xFF, 0xFF, 0xFF, 0xC3, 0xFF, 0xFF,


### PR DESCRIPTION
The addition with normalisation function (`add_normalize`), invoked in BLAKE’s mixing function `g`, is designed to ensure that addition of two 32 bit numbers can have a maximum overflow of 3 bits. However, for few inputs the overflow reaches up to 5 bits. [Here](https://hackmd.io/@aztec-network/SyTHLkAWZx) is an overview of the issue. 

To fix this issue, `g` function is updated to invoke `add_normalize` more frequently to ensure the overflow from addition stays within 3 bits. 
Additional test with overflow-triggering input has been included for correctness. 