### PR TITLE
fix(avm): functionSelector with empty calladata

### DIFF
--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/simulator.cpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/simulator.cpp
@@ -140,9 +140,16 @@ SimulatorResult CppSimulator::simulate(const std::vector<uint8_t>& bytecode, con
     TestSimulator simulator;
     TxSimulationResult result = simulator.simulate(bytecode, calldata);
     bool reverted = result.revert_code != RevertCode::OK;
-    auto output = result.call_stack_metadata.back().output;
-    vinfo("C++ Simulator result - reverted: ", reverted, ", output size: ", output.size());
-    return { .reverted = reverted, .output = output };
+    // Just process the top level call's output
+    vinfo(
+        "C++ Simulator result - reverted: ", reverted, ", output size: ", result.call_stack_metadata[0].output.size());
+    std::vector<FF> values = {};
+    if (result.call_stack_metadata.size() != 0) {
+        for (const auto& output : result.call_stack_metadata.at(0).output) {
+            values.push_back(output);
+        }
+    }
+    return { .reverted = reverted, .output = values };
 }
 
 JsSimulator* JsSimulator::instance = nullptr;

--- a/yarn-project/simulator/src/public/public_tx_simulator/public_tx_simulator.ts
+++ b/yarn-project/simulator/src/public/public_tx_simulator/public_tx_simulator.ts
@@ -303,7 +303,7 @@ export class PublicTxSimulator implements PublicTxSimulatorInterface {
     );
 
     if (result.reverted) {
-      const culprit = `${contractAddress}:${callRequest.functionSelector}`;
+      const culprit = `${contractAddress}:${fnName}`;
       context.revert(phase, result.revertReason, culprit);
     }
 


### PR DESCRIPTION
Fixes a crash where the TS simulator reverts AND the calldata is empty. It tries to extract `calldata[0]` when calling `callRequest.functionSelector`.

This just replaces `callRequest.functionSelector` with `fnName`. In the rare case where we revert with empty calldata the log is a bit redundant (since contract address is printed twice) but that's fine for now.