### PR TITLE
feat(avm): initial ws in fuzzer

### DIFF
--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/avm.fuzzer.cpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/avm.fuzzer.cpp
@@ -4,6 +4,7 @@
 #include <string>
 #include <vector>
 
+#include "barretenberg/avm_fuzzer/common/interfaces/dbs.hpp"
 #include "barretenberg/avm_fuzzer/fuzz_lib/control_flow.hpp"
 #include "barretenberg/avm_fuzzer/fuzz_lib/fuzz.hpp"
 #include "barretenberg/avm_fuzzer/fuzz_lib/fuzzer_data.hpp"
@@ -12,18 +13,19 @@
 #include "barretenberg/serialize/msgpack_impl.hpp"
 
 using FuzzInstruction = ::FuzzInstruction;
+using namespace bb::avm2::fuzzer;
 
-/// Initializes the typescript simulator process
+/// Initializes the typescript simulator process and the world state manager
 /// See yarn-project/simulator/scripts/fuzzing/
 extern "C" int LLVMFuzzerInitialize(int*, char***)
 {
-
     const char* simulator_path = std::getenv("AVM_SIMULATOR_BIN");
     if (simulator_path == nullptr) {
         throw std::runtime_error("AVM_SIMULATOR_BIN is not set");
     }
     std::string simulator_path_str(simulator_path);
     JsSimulator::initialize(simulator_path_str);
+    FuzzerWorldStateManager::initialize();
     return 0;
 }
 
@@ -35,7 +37,11 @@ SimulatorResult fuzz(const uint8_t* buffer, size_t size)
     } catch (const std::exception& e) {
         deserialized_data = FuzzerData();
     }
+
+    FuzzerWorldStateManager* ws_mgr = FuzzerWorldStateManager::getInstance();
+    ws_mgr->fork();
     auto res = fuzz(deserialized_data);
+    ws_mgr->reset_world_state();
 
     return res;
 }

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/common/interfaces/dbs.cpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/common/interfaces/dbs.cpp
@@ -7,6 +7,7 @@
 
 using namespace bb::avm2::simulation;
 using namespace bb::crypto::merkle_tree;
+using namespace bb::world_state;
 
 // TODO(ilyas): implement other methods as needed
 namespace bb::avm2::fuzzer {
@@ -119,7 +120,7 @@ simulation::IndexedLeaf<NullifierLeafValue> FuzzerLowLevelDB::get_leaf_preimage_
     return simulation::IndexedLeaf<NullifierLeafValue>(leaf_value, next_index, next_value);
 }
 
-SequentialInsertionResult<PublicDataLeafValue> FuzzerLowLevelDB::insert_indexed_leaves_public_data_tree(
+simulation::SequentialInsertionResult<PublicDataLeafValue> FuzzerLowLevelDB::insert_indexed_leaves_public_data_tree(
     const PublicDataLeafValue& leaf_value)
 {
     // Add to map
@@ -138,7 +139,7 @@ SequentialInsertionResult<PublicDataLeafValue> FuzzerLowLevelDB::insert_indexed_
     return {};
 }
 
-SequentialInsertionResult<NullifierLeafValue> FuzzerLowLevelDB::insert_indexed_leaves_nullifier_tree(
+simulation::SequentialInsertionResult<NullifierLeafValue> FuzzerLowLevelDB::insert_indexed_leaves_nullifier_tree(
     const NullifierLeafValue& leaf_value)
 {
     // Add to map
@@ -235,5 +236,59 @@ void FuzzerContractDB::add_contracts([[maybe_unused]] const ContractDeploymentDa
 void FuzzerContractDB::create_checkpoint() {}
 void FuzzerContractDB::commit_checkpoint() {}
 void FuzzerContractDB::revert_checkpoint() {}
+
+////////////////////////////////////
+/// FuzzerWorldStateManager methods
+////////////////////////////////////
+
+// Static instance definition
+FuzzerWorldStateManager* FuzzerWorldStateManager::instance = nullptr;
+
+void FuzzerWorldStateManager::initialize_world_state()
+{
+    std::unordered_map<simulation::MerkleTreeId, uint32_t> tree_heights{
+        { simulation::MerkleTreeId::NULLIFIER_TREE, NULLIFIER_TREE_HEIGHT },
+        { simulation::MerkleTreeId::NOTE_HASH_TREE, NOTE_HASH_TREE_HEIGHT },
+        { simulation::MerkleTreeId::PUBLIC_DATA_TREE, PUBLIC_DATA_TREE_HEIGHT },
+        { simulation::MerkleTreeId::L1_TO_L2_MESSAGE_TREE, L1_TO_L2_MSG_TREE_HEIGHT },
+        { simulation::MerkleTreeId::ARCHIVE, ARCHIVE_HEIGHT },
+    };
+    std::unordered_map<simulation::MerkleTreeId, index_t> tree_prefill{
+        { simulation::MerkleTreeId::NULLIFIER_TREE, 128 },
+        { simulation::MerkleTreeId::PUBLIC_DATA_TREE, 128 },
+    };
+    uint32_t initial_header_generator_point = 28; // GeneratorIndex.BLOCK_HASH
+    ws = std::make_unique<world_state::WorldState>(
+        /*thread_pool_size=*/4, DATA_DIR, MAP_SIZE_KB, tree_heights, tree_prefill, initial_header_generator_point);
+
+    fork_ids.push(ws->create_fork(std::nullopt));
+}
+
+WorldStateRevision FuzzerWorldStateManager::get_current_revision() const
+{
+    return WorldStateRevision{ .forkId = fork_ids.top(), .blockNumber = 0, .includeUncommitted = true };
+}
+
+WorldStateRevision FuzzerWorldStateManager::fork()
+{
+    auto fork_id = ws->create_fork(std::nullopt);
+    fork_ids.push(fork_id);
+    return WorldStateRevision{ .forkId = fork_id, .blockNumber = 0, .includeUncommitted = true };
+}
+void FuzzerWorldStateManager::reset_world_state()
+{
+    // We keep the initial fork, so pop until only one remains
+    while (fork_ids.size() != 1) {
+        ws->delete_fork(fork_ids.top());
+        fork_ids.pop();
+    }
+}
+void FuzzerWorldStateManager::register_contract_address(const AztecAddress& contract_address)
+{
+    NullifierLeafValue contract_nullifier =
+        unconstrained_silo_nullifier(CONTRACT_INSTANCE_REGISTRY_CONTRACT_ADDRESS, contract_address);
+    auto fork_id = fork_ids.top();
+    ws->insert_indexed_leaves<NullifierLeafValue>(MerkleTreeId::NULLIFIER_TREE, { contract_nullifier }, fork_id);
+}
 
 } // namespace bb::avm2::fuzzer

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/common/interfaces/dbs.hpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/common/interfaces/dbs.hpp
@@ -3,19 +3,23 @@
 #include "barretenberg/vm2/common/aztec_types.hpp"
 #include "barretenberg/vm2/simulation/interfaces/db.hpp"
 #include "barretenberg/vm2/simulation/lib/merkle.hpp"
+#include "barretenberg/world_state/types.hpp"
 #include "barretenberg/world_state/world_state.hpp"
+#include <memory>
+#include <stack>
 
 namespace bb::avm2::fuzzer {
 
+// FIXME(ilyas): This is now unused for the fuzzer, but I have a plan to experiment with this later.
 class FuzzerLowLevelDB : public bb::avm2::simulation::LowLevelMerkleDBInterface {
   public:
     TreeSnapshots get_tree_roots() const override;
 
-    simulation::SiblingPath get_sibling_path(world_state::MerkleTreeId tree_id, index_t leaf_index) const override;
+    simulation::SiblingPath get_sibling_path(simulation::MerkleTreeId tree_id, index_t leaf_index) const override;
 
-    GetLowIndexedLeafResponse get_low_indexed_leaf(world_state::MerkleTreeId tree_id, const FF& value) const override;
+    GetLowIndexedLeafResponse get_low_indexed_leaf(simulation::MerkleTreeId tree_id, const FF& value) const override;
 
-    FF get_leaf_value(world_state::MerkleTreeId tree_id, index_t leaf_index) const override;
+    FF get_leaf_value(simulation::MerkleTreeId tree_id, index_t leaf_index) const override;
 
     simulation::IndexedLeaf<PublicDataLeafValue> get_leaf_preimage_public_data_tree(index_t leaf_index) const override;
 
@@ -27,10 +31,10 @@ class FuzzerLowLevelDB : public bb::avm2::simulation::LowLevelMerkleDBInterface 
     simulation::SequentialInsertionResult<NullifierLeafValue> insert_indexed_leaves_nullifier_tree(
         const NullifierLeafValue& leaf_value) override;
 
-    std::vector<simulation::AppendLeafResult> append_leaves(world_state::MerkleTreeId tree_id,
+    std::vector<simulation::AppendLeafResult> append_leaves(simulation::MerkleTreeId tree_id,
                                                             std::span<const FF> leaves) override;
 
-    void pad_tree(world_state::MerkleTreeId tree_id, size_t num_leaves) override;
+    void pad_tree(simulation::MerkleTreeId tree_id, size_t num_leaves) override;
     void create_checkpoint() override;
     void commit_checkpoint() override;
     void revert_checkpoint() override;
@@ -77,6 +81,62 @@ class FuzzerContractDB : public simulation::ContractDBInterface {
 
   private:
     std::vector<uint8_t> bytecode;
+};
+
+// Set up and manage a world state for the fuzzer, the plan is to use this to set up different world states
+// This is a bit of hack since we need to access the world state in both cpp and ts. Normally, ws is instantiated
+// inside ts and we use napi to access it from cpp, but for the fuzzer we want to instantiate it in cpp and access it
+// from ts. The simplest way is to use the same database files from both cpp and ts, this is fine for now since we know
+// only one thing will be writing to it at a time.
+// FIXME(ilyas): This won't work with multiple concurrent fuzzing processes, but that's ok for now.
+class FuzzerWorldStateManager {
+  public:
+    // Shared constants for C++ and TypeScript to use the same database
+    // Note: TypeScript expects trees in {DATA_DIR}/world_state/, so we include that subdirectory
+    static constexpr const char* DATA_DIR = "/tmp/avm_fuzzer_ws/world_state";
+    static constexpr uint64_t MAP_SIZE_KB = 10240; // 10 MB
+
+    // Static instance management (similar to JsSimulator pattern)
+    static void initialize()
+    {
+        if (instance == nullptr) {
+            instance = new FuzzerWorldStateManager();
+            instance->initialize_world_state();
+        }
+    }
+
+    static FuzzerWorldStateManager* getInstance()
+    {
+        if (instance == nullptr) {
+            throw std::runtime_error("FuzzerWorldStateManager not initialized. Call initialize() first.");
+        }
+        return instance;
+    }
+
+    void reset_world_state();
+    void register_contract_address(const AztecAddress& contract_address);
+
+    world_state::WorldStateRevision get_current_revision() const;
+    world_state::WorldStateRevision fork();
+    world_state::WorldState& get_world_state() { return *ws; }
+
+    void checkpoint() { ws->checkpoint(fork_ids.top()); }
+
+    void commit() { ws->commit_checkpoint(fork_ids.top()); }
+
+    void revert() { ws->revert_checkpoint(fork_ids.top()); }
+
+    static const char* get_data_dir() { return DATA_DIR; }
+
+    static uint64_t get_map_size_kb() { return MAP_SIZE_KB; }
+
+  private:
+    static FuzzerWorldStateManager* instance;
+
+    void initialize_world_state();
+
+    std::unique_ptr<world_state::WorldState> ws;
+    std::stack<uint64_t> fork_ids;
 };
 
 } // namespace bb::avm2::fuzzer

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/fuzz.cpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/fuzz.cpp
@@ -1,8 +1,11 @@
 #include "barretenberg/avm_fuzzer/fuzz_lib/fuzz.hpp"
 
+#include "barretenberg/avm_fuzzer/fuzz_lib/constants.hpp"
 #include "barretenberg/avm_fuzzer/fuzz_lib/control_flow.hpp"
 #include "barretenberg/avm_fuzzer/fuzz_lib/fuzzer_data.hpp"
 #include "barretenberg/common/log.hpp"
+
+using namespace bb::avm2::fuzzer;
 
 void log_result(const SimulatorResult& result)
 {
@@ -28,30 +31,28 @@ SimulatorResult fuzz(FuzzerData& fuzzer_data)
     auto cpp_simulator = CppSimulator();
     JsSimulator* js_simulator = JsSimulator::getInstance();
     SimulatorResult cpp_result;
+
+    FuzzerWorldStateManager* ws_mgr = FuzzerWorldStateManager::getInstance();
+    ws_mgr->register_contract_address(CONTRACT_ADDRESS);
     try {
-        cpp_result = cpp_simulator.simulate(bytecode, fuzzer_data.calldata);
+        ws_mgr->checkpoint();
+        cpp_result = cpp_simulator.simulate(*ws_mgr, bytecode, fuzzer_data.calldata);
+        ws_mgr->revert();
     } catch (const std::exception& e) {
-        std::cout << "Error simulating with CppSimulator: " << e.what() << std::endl;
+        info("CppSimulator failed with error: ", e.what());
         throw std::runtime_error("Error simulating with CppSimulator");
     }
 
-    auto js_result = js_simulator->simulate(bytecode, fuzzer_data.calldata);
+    ws_mgr->checkpoint();
+    auto js_result = js_simulator->simulate(*ws_mgr, bytecode, fuzzer_data.calldata);
 
     // If the results does not match
     if (!compare_simulator_results(cpp_result, js_result)) {
-        // we restart the js simulator, becuase it works on the same worldstate for every run
-        // while cpp simulator works on a new worldstate for every run
-        JsSimulator::restart_simulator();
-        js_simulator = JsSimulator::getInstance();
-        js_result = js_simulator->simulate(bytecode, fuzzer_data.calldata);
-        // if the bug is persistent on "cleared" worldstate, we throw an error
-        if (!compare_simulator_results(cpp_result, js_result)) {
-            info("CppSimulator result: ");
-            log_result(cpp_result);
-            info("JsSimulator result: ");
-            log_result(js_result);
-            throw std::runtime_error("Simulator results are different");
-        }
+        info("CppSimulator result: ");
+        log_result(cpp_result);
+        info("JsSimulator result: ");
+        log_result(js_result);
+        throw std::runtime_error("Simulator results are different");
     }
     if (logging_enabled) {
         info("Simulator results match successfully");

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/fuzz.cpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/fuzz.cpp
@@ -11,6 +11,7 @@ void log_result(const SimulatorResult& result)
 {
     info("Reverted: ", result.reverted);
     info("Output: ", result.output);
+    info("Reason: ", result.revert_reason);
 }
 
 SimulatorResult fuzz(FuzzerData& fuzzer_data)
@@ -34,6 +35,7 @@ SimulatorResult fuzz(FuzzerData& fuzzer_data)
 
     FuzzerWorldStateManager* ws_mgr = FuzzerWorldStateManager::getInstance();
     ws_mgr->register_contract_address(CONTRACT_ADDRESS);
+
     try {
         ws_mgr->checkpoint();
         cpp_result = cpp_simulator.simulate(*ws_mgr, bytecode, fuzzer_data.calldata);

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/simulator.cpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/simulator.cpp
@@ -1,5 +1,6 @@
 #include "barretenberg/avm_fuzzer/fuzz_lib/simulator.hpp"
 
+#include <cstdint>
 #include <iomanip>
 #include <iostream>
 #include <libdeflate.h>
@@ -20,16 +21,24 @@
 #include "barretenberg/vm2/common/memory_types.hpp"
 #include "barretenberg/vm2/common/opcodes.hpp"
 #include "barretenberg/vm2/common/stringify.hpp"
+#include "barretenberg/vm2/simulation/interfaces/db.hpp"
 #include "barretenberg/vm2/simulation/lib/serialization.hpp"
+#include "barretenberg/world_state/types.hpp"
+#include "barretenberg/world_state/world_state.hpp"
 
 using bb::avm2::GlobalVariables;
 using namespace bb::avm2;
 using namespace bb::avm2::simulation;
 using namespace bb::avm2::fuzzer;
+using namespace bb::world_state;
 using json = nlohmann::json;
 
-// Helper function to serialize bytecode and calldata to JSON and print to stdout
-std::string serialize_bytecode_and_calldata(const std::vector<uint8_t>& bytecode, const std::vector<FF>& calldata)
+// Helper function to serialize bytecode, calldata, tx, and globals to JSON
+std::string serialize_simulation_request(fuzzer::FuzzerWorldStateManager& ws,
+                                         const std::vector<uint8_t>& bytecode,
+                                         const std::vector<FF>& calldata,
+                                         const Tx& tx,
+                                         const GlobalVariables& globals)
 {
     json j;
     j["bytecode"] = base64_encode(bytecode.data(), bytecode.size());
@@ -41,6 +50,22 @@ std::string serialize_bytecode_and_calldata(const std::vector<uint8_t>& bytecode
         calldata_strings.push_back(field_to_string(field));
     }
     j["inputs"] = calldata_strings;
+
+    // Pass WorldState database path and configuration for TypeScript to open the same DB
+    // Note: TypeScript expects the parent directory and adds "world_state/" subdirectory itself
+    j["ws_data_dir"] = "/tmp/avm_fuzzer_ws";
+    j["ws_map_size_kb"] = FuzzerWorldStateManager::get_map_size_kb();
+    j["ws_fork_id"] = ws.get_current_revision().forkId;
+
+    // Serialize Tx using msgpack and base64 encode
+    auto [tx_buffer, tx_size] = msgpack_encode_buffer(tx);
+    j["tx"] = base64_encode(tx_buffer, tx_size);
+    delete[] tx_buffer;
+
+    // Serialize GlobalVariables using msgpack and base64 encode
+    auto [globals_buffer, globals_size] = msgpack_encode_buffer(globals);
+    j["globals"] = base64_encode(globals_buffer, globals_size);
+    delete[] globals_buffer;
 
     return j.dump();
 }
@@ -104,41 +129,26 @@ Tx create_default_tx(const AztecAddress& contract_address,
     };
 }
 
-class TestSimulator {
-  protected:
-    FuzzerSimulationHelper helper;
-    AztecAddress contract_address{ CONTRACT_ADDRESS };
-    AztecAddress sender_address{ MSG_SENDER };
-    FF transaction_fee = TRANSACTION_FEE;
-    GlobalVariables globals = create_default_globals();
-    bool is_static_call = IS_STATIC_CALL;
-    Gas gas_limit = GAS_LIMIT; // Large gas limit for tests
-  public:
-    TxSimulationResult simulate(const std::vector<uint8_t>& bytecode, const std::vector<FF>& calldata)
-    {
-        FuzzerContractDB minimal_contract_db(bytecode);
-        FuzzerLowLevelDB minimal_low_level_db;
-
-        const PublicSimulatorConfig config{ .collect_call_metadata = true };
-
-        // This is needed so that the contract existence check passes in simulation
-        minimal_low_level_db.insert_contract_address(contract_address);
-        ProtocolContracts protocol_contracts{};
-
-        return helper.simulate_fast(
-            minimal_contract_db,
-            minimal_low_level_db,
-            config,
-            create_default_tx(contract_address, sender_address, calldata, transaction_fee, is_static_call, gas_limit),
-            globals,
-            protocol_contracts);
-    }
-};
-
-SimulatorResult CppSimulator::simulate(const std::vector<uint8_t>& bytecode, const std::vector<FF>& calldata)
+SimulatorResult CppSimulator::simulate(fuzzer::FuzzerWorldStateManager& ws_mgr,
+                                       const std::vector<uint8_t>& bytecode,
+                                       const std::vector<FF>& calldata)
 {
-    TestSimulator simulator;
-    TxSimulationResult result = simulator.simulate(bytecode, calldata);
+    FuzzerContractDB minimal_contract_db(bytecode);
+
+    const PublicSimulatorConfig config{ .collect_call_metadata = true };
+
+    ProtocolContracts protocol_contracts{};
+
+    auto globals = create_default_globals();
+
+    Tx tx = create_default_tx(CONTRACT_ADDRESS, MSG_SENDER, calldata, TRANSACTION_FEE, IS_STATIC_CALL, GAS_LIMIT);
+
+    WorldState& ws = ws_mgr.get_world_state();
+    WorldStateRevision ws_rev = ws_mgr.get_current_revision();
+
+    AvmSimulationHelper helper;
+    TxSimulationResult result =
+        helper.simulate_fast_with_existing_ws(minimal_contract_db, ws_rev, ws, config, tx, globals, protocol_contracts);
     bool reverted = result.revert_code != RevertCode::OK;
     // Just process the top level call's output
     vinfo(
@@ -149,13 +159,13 @@ SimulatorResult CppSimulator::simulate(const std::vector<uint8_t>& bytecode, con
             values.push_back(output);
         }
     }
-    return { .reverted = reverted, .output = values };
+    return { .reverted = reverted, .output = values, .tree_snapshots = result.public_inputs.end_tree_snapshots };
 }
 
 JsSimulator* JsSimulator::instance = nullptr;
 JsSimulator::JsSimulator(std::string& simulator_path)
     : simulator_path(simulator_path)
-    , process("LOG_LEVEL=silent node " + simulator_path + " 2>/dev/null")
+    , process("LOG_LEVEL=silent node " + simulator_path) // + " 2>/dev/null")
 {}
 
 void JsSimulator::restart_simulator_process()
@@ -239,10 +249,17 @@ void JsSimulator::initialize(std::string& simulator_path)
     instance = new JsSimulator(simulator_path);
 }
 
-SimulatorResult JsSimulator::simulate(const std::vector<uint8_t>& bytecode, const std::vector<FF>& calldata)
+SimulatorResult JsSimulator::simulate(fuzzer::FuzzerWorldStateManager& ws_mgr,
+                                      const std::vector<uint8_t>& bytecode,
+                                      const std::vector<FF>& calldata)
 {
     bool logging_enabled = std::getenv("AVM_FUZZER_LOGGING") != nullptr;
-    std::string serialized = serialize_bytecode_and_calldata(bytecode, calldata);
+
+    // Create tx and globals to match C++ simulator
+    auto globals = create_default_globals();
+    Tx tx = create_default_tx(CONTRACT_ADDRESS, MSG_SENDER, calldata, TRANSACTION_FEE, IS_STATIC_CALL, GAS_LIMIT);
+
+    std::string serialized = serialize_simulation_request(ws_mgr, bytecode, calldata, tx, globals);
     if (logging_enabled) {
         info("Sending request to simulator: ", serialized);
     }
@@ -252,7 +269,7 @@ SimulatorResult JsSimulator::simulate(const std::vector<uint8_t>& bytecode, cons
     std::string response = process.read_line();
     while (response.empty()) {
         std::cout << "Empty response, reading again" << std::endl;
-        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        std::this_thread::sleep_for(std::chrono::milliseconds(1000));
         response = process.read_line();
     }
     // Remove the newline character
@@ -269,7 +286,7 @@ SimulatorResult JsSimulator::simulate(const std::vector<uint8_t>& bytecode, cons
         std::cout << "Response: " << response << std::endl;
         restart_simulator_process();
 
-        return simulate(bytecode, calldata);
+        return simulate(ws_mgr, bytecode, calldata);
     }
 
     std::string response_string(decoded_response.begin(), decoded_response.end());
@@ -290,5 +307,6 @@ SimulatorResult JsSimulator::simulate(const std::vector<uint8_t>& bytecode, cons
 
 bool compare_simulator_results(const SimulatorResult& result1, const SimulatorResult& result2)
 {
+    // add: result1.tree_snapshots == result2.tree_snapshots;
     return result1.reverted == result2.reverted && result1.output == result2.output;
 }

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/simulator.cpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/simulator.cpp
@@ -3,7 +3,6 @@
 #include <cstdint>
 #include <iomanip>
 #include <iostream>
-#include <libdeflate.h>
 #include <nlohmann/json.hpp>
 #include <sys/wait.h>
 #include <unistd.h>
@@ -14,7 +13,6 @@
 #include "barretenberg/avm_fuzzer/fuzz_lib/constants.hpp"
 #include "barretenberg/avm_fuzzer/fuzz_lib/instruction.hpp"
 #include "barretenberg/common/base64.hpp"
-#include "barretenberg/common/get_bytecode.hpp"
 #include "barretenberg/vm2/common/avm_io.hpp"
 #include "barretenberg/vm2/common/aztec_types.hpp"
 #include "barretenberg/vm2/common/field.hpp"
@@ -53,7 +51,7 @@ std::string serialize_simulation_request(fuzzer::FuzzerWorldStateManager& ws,
 
     // Pass WorldState database path and configuration for TypeScript to open the same DB
     // Note: TypeScript expects the parent directory and adds "world_state/" subdirectory itself
-    j["ws_data_dir"] = "/tmp/avm_fuzzer_ws";
+    j["ws_data_dir"] = FuzzerWorldStateManager::get_data_dir();
     j["ws_map_size_kb"] = FuzzerWorldStateManager::get_map_size_kb();
     j["ws_fork_id"] = ws.get_current_revision().forkId;
 
@@ -135,7 +133,7 @@ SimulatorResult CppSimulator::simulate(fuzzer::FuzzerWorldStateManager& ws_mgr,
 {
     FuzzerContractDB minimal_contract_db(bytecode);
 
-    const PublicSimulatorConfig config{ .collect_call_metadata = true };
+    const PublicSimulatorConfig config{ .collect_call_metadata = true, .collect_public_inputs = true };
 
     ProtocolContracts protocol_contracts{};
 
@@ -159,78 +157,18 @@ SimulatorResult CppSimulator::simulate(fuzzer::FuzzerWorldStateManager& ws_mgr,
             values.push_back(output);
         }
     }
-    return { .reverted = reverted, .output = values, .tree_snapshots = result.public_inputs.end_tree_snapshots };
+    if (result.public_inputs.has_value()) {
+        return { .reverted = reverted, .output = values, .tree_snapshots = result.public_inputs->end_tree_snapshots };
+    }
+    return { .reverted = reverted, .output = values };
 }
 
 JsSimulator* JsSimulator::instance = nullptr;
 JsSimulator::JsSimulator(std::string& simulator_path)
     : simulator_path(simulator_path)
-    , process("LOG_LEVEL=silent node " + simulator_path) // + " 2>/dev/null")
+    , process("LOG_LEVEL=silent node " + simulator_path + " 2>/dev/null")
 {}
 
-void JsSimulator::restart_simulator_process()
-{
-    if (instance == nullptr) {
-        throw std::runtime_error("JsSimulator should be initialized before restarting");
-    }
-    std::cout << "Restarting JsSimulator process" << std::endl;
-    std::string simulator_path = instance->simulator_path;
-    delete instance;
-    instance = new JsSimulator(simulator_path);
-}
-
-void JsSimulator::restart_simulator()
-{
-    bool logging_enabled = std::getenv("AVM_FUZZER_LOGGING") != nullptr;
-    if (logging_enabled) {
-        info("Restarting JsSimulator");
-    }
-    if (instance == nullptr) {
-        throw std::runtime_error("JsSimulator should be initialized before restarting");
-    }
-    instance->process.write_line("{\"restart\":1}");
-
-    std::string response = instance->process.read_line();
-    while (response.empty()) {
-        std::cout << "Empty response, reading again" << std::endl;
-        std::this_thread::sleep_for(std::chrono::milliseconds(10));
-        response = instance->process.read_line();
-    }
-    response.erase(response.find_last_not_of('\n') + 1);
-
-    try {
-        std::vector<uint8_t> decoded_response = decode_bytecode(response);
-        std::string response_string(decoded_response.begin(), decoded_response.end());
-        if (logging_enabled) {
-            info("Received restart response: ", response_string);
-        }
-        json response_json = json::parse(response_string);
-
-        // Check if this is actually a restart response (has "restarted" field)
-        if (response_json.contains("reverted")) {
-            if (logging_enabled) {
-                info("Discarding stale simulation response, reading restart response");
-            }
-            response = instance->process.read_line();
-            response.erase(response.find_last_not_of('\n') + 1);
-            decoded_response = decode_bytecode(response);
-            response_string = std::string(decoded_response.begin(), decoded_response.end());
-            if (logging_enabled) {
-                info("Received restart response: ", response_string);
-            }
-            response_json = json::parse(response_string);
-        }
-
-        bool restarted = response_json["restarted"];
-        if (!restarted) {
-            std::string error = response_json.value("error", "Unknown error");
-            throw std::runtime_error("Restart failed: " + error);
-        }
-    } catch (const std::exception& e) {
-        std::cout << "Error processing restart response: " << e.what() << "Response: " << response << std::endl;
-        throw std::runtime_error("Failed to restart simulator: " + std::string(e.what()));
-    }
-}
 JsSimulator* JsSimulator::getInstance()
 {
     if (instance == nullptr) {
@@ -269,39 +207,28 @@ SimulatorResult JsSimulator::simulate(fuzzer::FuzzerWorldStateManager& ws_mgr,
     std::string response = process.read_line();
     while (response.empty()) {
         std::cout << "Empty response, reading again" << std::endl;
-        std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
         response = process.read_line();
     }
     // Remove the newline character
     response.erase(response.find_last_not_of('\n') + 1);
 
-    std::vector<uint8_t> decoded_response;
-    // for some reason, the typescript simulator responds with an empty response (invalid gzip) one time in ~500k runs
-    // restarting the process if this happens
-    try {
-        // HACK: decode_bytecode decodes base64 and ungzips it
-        decoded_response = decode_bytecode(response);
-    } catch (const std::exception& e) {
-        std::cout << "Error decoding response: " << e.what() << std::endl;
-        std::cout << "Response: " << response << std::endl;
-        restart_simulator_process();
-
-        return simulate(ws_mgr, bytecode, calldata);
-    }
-
-    std::string response_string(decoded_response.begin(), decoded_response.end());
+    // Response is plain JSON (no longer gzipped/base64 encoded)
     if (logging_enabled) {
-        info("Received response from simulator: ", response_string);
+        info("Received response from simulator: ", response);
     }
-    json response_json = json::parse(response_string);
+    json response_json = json::parse(response);
     bool reverted = response_json["reverted"];
     std::vector<std::string> output = response_json["output"];
+    std::string revert_reason = response_json.value("revertReason", "");
     std::vector<FF> output_fields;
     output_fields.reserve(output.size());
     for (const auto& field : output) {
         output_fields.push_back(FF(field));
     }
-    SimulatorResult result = { .reverted = reverted, .output = output_fields };
+    SimulatorResult result = {
+        .reverted = reverted, .output = output_fields, .tree_snapshots = {}, .revert_reason = revert_reason
+    };
     return result;
 }
 

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/simulator.hpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/simulator.hpp
@@ -2,7 +2,9 @@
 
 #include <vector>
 
+#include "barretenberg/avm_fuzzer/common/interfaces/dbs.hpp"
 #include "barretenberg/avm_fuzzer/common/process.hpp"
+#include "barretenberg/vm2/common/aztec_types.hpp"
 #include "barretenberg/vm2/common/field.hpp"
 #include "barretenberg/vm2/simulation/interfaces/execution.hpp"
 
@@ -12,6 +14,7 @@ using namespace bb::avm2;
 struct SimulatorResult {
     bool reverted;
     std::vector<FF> output;
+    TreeSnapshots tree_snapshots;
 };
 
 class Simulator {
@@ -22,13 +25,17 @@ class Simulator {
     Simulator(Simulator&&) = delete;
     Simulator& operator=(Simulator&&) = delete;
     Simulator() = default;
-    virtual SimulatorResult simulate(const std::vector<uint8_t>& bytecode, const std::vector<FF>& calldata) = 0;
+    virtual SimulatorResult simulate(fuzzer::FuzzerWorldStateManager& ws_mgr,
+                                     const std::vector<uint8_t>& bytecode,
+                                     const std::vector<FF>& calldata) = 0;
 };
 
 /// @brief uses barretenberg/vm2 to simulate the bytecode
 class CppSimulator : public Simulator {
   public:
-    SimulatorResult simulate(const std::vector<uint8_t>& bytecode, const std::vector<FF>& calldata) override;
+    SimulatorResult simulate(fuzzer::FuzzerWorldStateManager& ws_mgr,
+                             const std::vector<uint8_t>& bytecode,
+                             const std::vector<FF>& calldata) override;
 };
 
 /// @brief uses the yarn-project/simulator to simulate the bytecode
@@ -53,7 +60,9 @@ class JsSimulator : public Simulator {
     static void initialize(std::string& simulator_path);
     static void restart_simulator();
 
-    SimulatorResult simulate(const std::vector<uint8_t>& bytecode, const std::vector<FF>& calldata) override;
+    SimulatorResult simulate(fuzzer::FuzzerWorldStateManager& ws_mgr,
+                             const std::vector<uint8_t>& bytecode,
+                             const std::vector<FF>& calldata) override;
 };
 
 bool compare_simulator_results(const SimulatorResult& result1, const SimulatorResult& result2);

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/simulator.hpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/simulator.hpp
@@ -15,6 +15,7 @@ struct SimulatorResult {
     bool reverted;
     std::vector<FF> output;
     TreeSnapshots tree_snapshots;
+    std::string revert_reason;
 };
 
 class Simulator {
@@ -47,8 +48,6 @@ class JsSimulator : public Simulator {
     JsSimulator(std::string& simulator_path);
     Process process;
 
-    void restart_simulator_process();
-
   public:
     JsSimulator(JsSimulator& other) = delete;
     void operator=(const JsSimulator&) = delete;
@@ -58,7 +57,6 @@ class JsSimulator : public Simulator {
 
     static JsSimulator* getInstance();
     static void initialize(std::string& simulator_path);
-    static void restart_simulator();
 
     SimulatorResult simulate(fuzzer::FuzzerWorldStateManager& ws_mgr,
                              const std::vector<uint8_t>& bytecode,

--- a/yarn-project/simulator/package.json
+++ b/yarn-project/simulator/package.json
@@ -21,7 +21,7 @@
     "build:dev": "../scripts/tsc.sh --watch",
     "clean": "rm -rf ./dest .tsbuildinfo",
     "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --passWithNoTests --maxWorkers=${JEST_MAX_WORKERS:-8}",
-    "build:fuzzer": "tsgo scripts/fuzzing/avm_simulator_bin.ts --outDir dest/scripts/fuzzing --module commonjs --target es2022 --esModuleInterop --allowSyntheticDefaultImports --resolveJsonModule --skipLibCheck"
+    "build:fuzzer": "tsgo scripts/fuzzing/avm_simulator_bin.ts --outDir dest/scripts/fuzzing --module commonjs --target es2022 --esModuleInterop --allowSyntheticDefaultImports --resolveJsonModule --skipLibCheck --ignoreConfig"
   },
   "inherits": [
     "../package.common.json"

--- a/yarn-project/simulator/scripts/fuzzing/avm_simulator_bin.ts
+++ b/yarn-project/simulator/scripts/fuzzing/avm_simulator_bin.ts
@@ -1,4 +1,5 @@
-var { GasFees } = require('@aztec/stdlib/gas');
+var { GasFees, Gas, GasSettings } = require('@aztec/stdlib/gas');
+var { deserializeFromMessagePack, PublicSimulatorConfig, RevertCode } = require('@aztec/stdlib/avm');
 
 var { createInstrumenter } = require('istanbul-lib-instrument');
 var { hookRequire } = require('istanbul-lib-hook');
@@ -16,12 +17,23 @@ hookRequire(
     return newCode;
   },
 );
-var { DEFAULT_DA_GAS_LIMIT, DEFAULT_L2_GAS_LIMIT } = require('@aztec/constants');
 var { Fr } = require('@aztec/foundation/fields');
 var { AztecAddress } = require('@aztec/stdlib/aztec-address');
-var { GlobalVariables } = require('@aztec/stdlib/tx');
-var { UInt64 } = require('@aztec/stdlib/types');
+var { GlobalVariables, Tx, TxHash, HashedValues } = require('@aztec/stdlib/tx');
+var { EthAddress } = require('@aztec/foundation/eth-address');
 var { NativeWorldStateService } = require('@aztec/world-state');
+var { WorldStateRevision } = require('@aztec/stdlib/world-state');
+// Import internal facade for direct fork access
+var { MerkleTreesForkFacade } = require('@aztec/world-state/native/merkle_trees_facade');
+var {
+  PrivateKernelTailCircuitPublicInputs,
+  TxConstantData,
+  TxContext,
+  PrivateToPublicAccumulatedData,
+  PublicCallRequest,
+} = require('@aztec/stdlib/kernel');
+var { PartialPrivateTailPublicInputsForPublic } = require('@aztec/stdlib/kernel');
+var { ChonkProof } = require('@aztec/stdlib/proofs');
 
 var { createInterface } = require('readline');
 var { writeSync } = require('fs');
@@ -31,6 +43,8 @@ var { SimpleContractDataSource } = require('../../public/fixtures/simple_contrac
 var { PublicContractsDB, PublicTreesDB } = require('../../public/public_db_sources.js');
 var { SideEffectTrace } = require('../../public/side_effect_trace.js');
 var { PublicPersistableStateManager } = require('../../public/state_manager/state_manager.js');
+var { PublicTxSimulator } = require('../../public/public_tx_simulator/public_tx_simulator.js');
+var { AvmTxHint } = require('../../public/fuzzer/avm_tx_hint.js');
 
 // Type declaration for Istanbul coverage
 interface CoverageStatement {
@@ -72,7 +86,157 @@ function stringArrayToFields(arr: string[]): (typeof Fr)[] {
   return arr.map(stringToField);
 }
 
-const DEFAULT_TIMESTAMP: typeof UInt64 = 1000000;
+/**
+ * Creates a TypeScript Tx object from a deserialized C++ Tx (AvmTxHint-like structure).
+ * This allows using PublicTxSimulator.simulate() with fuzzer-generated transactions.
+ *
+ * @param cppTx - Deserialized C++ Tx from msgpack (matches AvmTxHint structure)
+ * @returns A TypeScript Tx suitable for PublicTxSimulator
+ */
+function createFuzzerTx(cppTx: typeof AvmTxHint): typeof Tx {
+  // Create TxHash from the C++ tx hash string
+  const txHash = TxHash.fromString(cppTx.hash);
+
+  // Build PrivateToPublicAccumulatedData for non-revertible
+  const nonRevertibleAccumulatedData = new PrivateToPublicAccumulatedData(
+    cppTx.nonRevertibleAccumulatedData.noteHashes || [],
+    cppTx.nonRevertibleAccumulatedData.nullifiers || [],
+    cppTx.nonRevertibleAccumulatedData.l2ToL1Messages || [],
+    [], // privateLogs
+    [], // contractClassLogsHashes
+    cppTx.setupEnqueuedCalls || [], // publicCallRequests - setup calls go here
+  );
+
+  // Build PrivateToPublicAccumulatedData for revertible
+  const revertibleAccumulatedData = new PrivateToPublicAccumulatedData(
+    cppTx.revertibleAccumulatedData.noteHashes || [],
+    cppTx.revertibleAccumulatedData.nullifiers || [],
+    cppTx.revertibleAccumulatedData.l2ToL1Messages || [],
+    [], // privateLogs
+    [], // contractClassLogsHashes
+    cppTx.appLogicEnqueuedCalls || [], // publicCallRequests - app logic calls go here
+  );
+
+  // Build teardown call request (if exists)
+  const teardownCallRequest = cppTx.teardownEnqueuedCall
+    ? new PublicCallRequest(
+        new AztecAddress(cppTx.teardownEnqueuedCall.request.msgSender),
+        new AztecAddress(cppTx.teardownEnqueuedCall.request.contractAddress),
+        cppTx.teardownEnqueuedCall.request.isStaticCall,
+        new Fr(cppTx.teardownEnqueuedCall.request.calldataHash || 0),
+      )
+    : PublicCallRequest.empty();
+
+  // Create forPublic structure
+  const forPublic = new PartialPrivateTailPublicInputsForPublic(
+    nonRevertibleAccumulatedData,
+    revertibleAccumulatedData,
+    teardownCallRequest,
+  );
+
+  // Build GasSettings from C++ tx
+  const gasSettings = new GasSettings(
+    new Gas(Number(cppTx.gasSettings.gasLimits.l2Gas), Number(cppTx.gasSettings.gasLimits.daGas)),
+    new Gas(
+      Number(cppTx.gasSettings.teardownGasLimits?.l2Gas || 0),
+      Number(cppTx.gasSettings.teardownGasLimits?.daGas || 0),
+    ),
+    new GasFees(
+      Number(cppTx.gasSettings.maxFeesPerGas?.feePerDaGas || 0),
+      Number(cppTx.gasSettings.maxFeesPerGas?.feePerL2Gas || 0),
+    ),
+    new GasFees(
+      Number(cppTx.gasSettings.maxPriorityFeesPerGas?.feePerDaGas || 0),
+      Number(cppTx.gasSettings.maxPriorityFeesPerGas?.feePerL2Gas || 0),
+    ),
+  );
+
+  // Build TxContext
+  const txContext = new TxContext(
+    Fr.ZERO, // chainId - will be overridden by globalVariables
+    Fr.ZERO, // version - will be overridden by globalVariables
+    gasSettings,
+  );
+
+  // Build TxConstantData
+  const constants = new TxConstantData(
+    Fr.ZERO, // historicalHeader (unused in simulation)
+    txContext,
+    Fr.ZERO, // vkTreeRoot
+    Fr.ZERO, // protocolContractTreeRoot
+    Fr.ZERO, // globalVariablesHash
+  );
+
+  // Build PrivateKernelTailCircuitPublicInputs
+  const gasUsedByPrivate = new Gas(
+    Number(cppTx.gasUsedByPrivate?.l2Gas || 0),
+    Number(cppTx.gasUsedByPrivate?.daGas || 0),
+  );
+
+  const data = new PrivateKernelTailCircuitPublicInputs(
+    constants,
+    gasUsedByPrivate,
+    new AztecAddress(cppTx.feePayer),
+    0n, // includeByTimestamp
+    forPublic,
+    undefined, // forRollup - not needed for public simulation
+  );
+
+  // Build publicFunctionCalldata from all enqueued calls
+  const publicFunctionCalldata: (typeof HashedValues)[] = [];
+
+  // Add setup calls
+  for (const call of cppTx.setupEnqueuedCalls || []) {
+    publicFunctionCalldata.push(new HashedValues(call.calldata || []));
+  }
+
+  // Add app logic calls
+  for (const call of cppTx.appLogicEnqueuedCalls || []) {
+    publicFunctionCalldata.push(new HashedValues(call.calldata || []));
+  }
+
+  // Add teardown call if present
+  if (cppTx.teardownEnqueuedCall) {
+    publicFunctionCalldata.push(new HashedValues(cppTx.teardownEnqueuedCall.calldata || []));
+  }
+
+  // Create the Tx
+  return new Tx(
+    txHash,
+    data,
+    ChonkProof.empty(), // No real proof needed for simulation
+    [], // contractClassLogFields - empty for fuzzer
+    publicFunctionCalldata,
+  );
+}
+
+const DEFAULT_TIMESTAMP = 1000000;
+
+// Cache for opened world state services by data directory path
+const worldStateCache: Map<string, typeof NativeWorldStateService> = new Map();
+
+// Open an existing WorldState database created by C++
+async function openExistingWorldState(dataDir: string, mapSizeKb: number): Promise<typeof NativeWorldStateService> {
+  // Check cache first
+  let ws = worldStateCache.get(dataDir);
+  if (ws) {
+    return ws;
+  }
+
+  // Open the existing database with matching map sizes
+  const worldStateTreeMapSizes = {
+    archiveTreeMapSizeKb: mapSizeKb,
+    nullifierTreeMapSizeKb: mapSizeKb,
+    noteHashTreeMapSizeKb: mapSizeKb,
+    messageTreeMapSizeKb: mapSizeKb,
+    publicDataTreeMapSizeKb: mapSizeKb,
+  };
+
+  ws = await NativeWorldStateService.new(EthAddress.ZERO, dataDir, worldStateTreeMapSizes);
+
+  worldStateCache.set(dataDir, ws);
+  return ws;
+}
 
 let STATE_MANAGER: typeof PublicPersistableStateManager | undefined;
 
@@ -136,6 +300,14 @@ async function getSimulator(calldata: (typeof Fr)[]) {
   globalVariables.feeRecipient = AztecAddress.ZERO;
   globalVariables.gasFees = new GasFees(1, 1);
 
+  const config = PublicSimulatorConfig.from({
+    skipFeeEnforcement: true,
+    collectDebugLogs: false,
+    collectHints: false,
+    collectStatistics: false,
+    collectCallMetadata: false,
+  });
+
   const simulator = await AvmSimulator.create(
     STATE_MANAGER,
     AztecAddress.fromNumber(42), // address
@@ -145,8 +317,82 @@ async function getSimulator(calldata: (typeof Fr)[]) {
     false, // is static call
     calldata,
     { l2Gas: 1000000, daGas: 1000000 },
+    config,
   );
   return simulator;
+}
+
+/**
+ * Execute a transaction using PublicTxSimulator.
+ * This is the full transaction simulation path that matches the C++ AVM simulator.
+ *
+ * @param dataDir - World state data directory
+ * @param mapSizeKb - World state map size in KB
+ * @param forkId - The fork ID to use (from C++ FuzzerWorldStateManager)
+ * @param bytecode - AVM bytecode to execute
+ * @param cppTx - Deserialized C++ Tx from msgpack
+ * @param cppGlobals - Deserialized C++ GlobalVariables from msgpack
+ * @returns Simulation result with reverted status and output
+ */
+async function simulateWithPublicTxSimulator(
+  dataDir: string,
+  mapSizeKb: number,
+  forkId: number,
+  bytecode: Buffer,
+  cppTx: typeof AvmTxHint,
+  cppGlobals: typeof GlobalVariables,
+): Promise<{ reverted: boolean; output: (typeof Fr)[]; revertReason?: string }> {
+  // Open the existing WorldState database created by C++
+  const worldStateService = await openExistingWorldState(dataDir, mapSizeKb);
+  // Use the same fork as C++ by creating facade directly with the fork ID
+  const revision = new WorldStateRevision(forkId, 0, true);
+  const merkleTrees = new MerkleTreesForkFacade(worldStateService.instance, worldStateService.initialHeader, revision);
+
+  // FIXME: This only works while we have a single app logic call
+  // Get contract address from the app logic call
+  const appLogicCall = cppTx.appLogicEnqueuedCalls[0];
+  const contractAddress = new AztecAddress(appLogicCall.request.contractAddress);
+  // Create contract data source and register bytecode
+  const contractDataSource = new SimpleContractDataSource();
+  // Register the bytecode at the contract address
+  await contractDataSource.addContractWithBytecode(contractAddress, bytecode);
+
+  // Create the contracts DB
+  const contractsDb = new PublicContractsDB(contractDataSource);
+
+  // Build GlobalVariables from deserialized msgpack data
+  const globalVariables = cppGlobals;
+
+  // Create the PublicTxSimulator
+  const config = {
+    skipFeeEnforcement: true,
+    collectDebugLogs: false,
+    collectHints: false,
+    collectStatistics: false,
+    collectCallMetadata: false,
+  };
+  const publicTxSimulator = new PublicTxSimulator(merkleTrees, contractsDb, globalVariables, config);
+
+  // Create a TypeScript Tx from the C++ Tx
+  const tx = createFuzzerTx(cppTx);
+
+  // Simulate the transaction
+  const result = await publicTxSimulator.simulate(tx);
+
+  // Extract output from appLogicReturnValues
+  const output: (typeof Fr)[] = [];
+  for (const returnValues of result.appLogicReturnValues) {
+    if (returnValues.values) {
+      for (const value of returnValues.values) {
+        output.push(value);
+      }
+    }
+  }
+
+  const reverted = !result.revertCode.isOK();
+  const revertReason = result.revertReason?.message;
+
+  return { reverted, output, revertReason };
 }
 
 const FLATTENED_COVERAGE_MAP: Map<string, number> = new Map();
@@ -258,7 +504,30 @@ async function executeFromJson(jsonLine: string): Promise<void> {
     }
     const calldata = stringArrayToFields(input.inputs);
 
-    const result = await executeBytecodeBase64(input.bytecode, calldata);
+    let result;
+    if (input.ws_data_dir && input.ws_map_size_kb && input.ws_fork_id && input.tx && input.globals) {
+      // Use PublicTxSimulator with the existing WorldState database created by C++
+      const bytecode = Buffer.from(input.bytecode, 'base64');
+
+      // Decode base64 and deserialize msgpack for tx and globals
+      const txBuffer = Buffer.from(input.tx, 'base64');
+      const globalsBuffer = Buffer.from(input.globals, 'base64');
+      const tx = deserializeFromMessagePack(txBuffer);
+      const globals = deserializeFromMessagePack(globalsBuffer);
+
+      // Use the new PublicTxSimulator path with the same fork ID as C++
+      result = await simulateWithPublicTxSimulator(
+        input.ws_data_dir,
+        input.ws_map_size_kb,
+        input.ws_fork_id,
+        bytecode,
+        tx,
+        globals,
+      );
+    } else {
+      // Fallback to the default behavior with a temporary WorldState
+      result = await executeBytecodeBase64(input.bytecode, calldata);
+    }
 
     const coverage = Object.fromEntries(report_and_reset_coverage());
 

--- a/yarn-project/simulator/scripts/fuzzing/avm_simulator_bin.ts
+++ b/yarn-project/simulator/scripts/fuzzing/avm_simulator_bin.ts
@@ -1,89 +1,55 @@
-var { GasFees, Gas, GasSettings } = require('@aztec/stdlib/gas');
-var { deserializeFromMessagePack, PublicSimulatorConfig, RevertCode } = require('@aztec/stdlib/avm');
+const { GasFees, Gas, GasSettings } = require('@aztec/stdlib/gas');
+const { deserializeFromMessagePack, AvmTxHint } = require('@aztec/stdlib/avm');
+const { siloNullifier } = require('@aztec/stdlib/hash');
+const { MerkleTreeId } = require('@aztec/stdlib/trees');
 
-var { createInstrumenter } = require('istanbul-lib-instrument');
-var { hookRequire } = require('istanbul-lib-hook');
-var { gzipSync } = require('zlib');
+// Contract Instance Registry address (same as C++ CONTRACT_INSTANCE_REGISTRY_CONTRACT_ADDRESS)
+const CONTRACT_INSTANCE_REGISTRY_CONTRACT_ADDRESS = 2;
 
-const INSTRUMENTER = createInstrumenter({ compact: true });
-
-hookRequire(
-  (filePath: string): boolean => {
-    // Don't instrument node_modules because there's something funky with babel + browserlists dependencies
-    return !filePath.includes('node_modules');
-  },
-  (code: string, { filename }: { filename: string }): string => {
-    const newCode = INSTRUMENTER.instrumentSync(code, filename);
-    return newCode;
-  },
-);
-var { Fr } = require('@aztec/foundation/fields');
-var { AztecAddress } = require('@aztec/stdlib/aztec-address');
-var { GlobalVariables, Tx, TxHash, HashedValues } = require('@aztec/stdlib/tx');
-var { EthAddress } = require('@aztec/foundation/eth-address');
-var { NativeWorldStateService } = require('@aztec/world-state');
-var { WorldStateRevision } = require('@aztec/stdlib/world-state');
-// Import internal facade for direct fork access
-var { MerkleTreesForkFacade } = require('@aztec/world-state/native/merkle_trees_facade');
-var {
+const { Fr } = require('@aztec/foundation/fields');
+const { AztecAddress } = require('@aztec/stdlib/aztec-address');
+const { GlobalVariables, Tx, TxHash, HashedValues, TxContext, TxConstantData } = require('@aztec/stdlib/tx');
+const { EthAddress } = require('@aztec/foundation/eth-address');
+const { NativeWorldStateService } = require('@aztec/world-state');
+const {
   PrivateKernelTailCircuitPublicInputs,
-  TxConstantData,
-  TxContext,
-  PrivateToPublicAccumulatedData,
   PublicCallRequest,
+  PrivateToPublicAccumulatedData,
 } = require('@aztec/stdlib/kernel');
-var { PartialPrivateTailPublicInputsForPublic } = require('@aztec/stdlib/kernel');
-var { ChonkProof } = require('@aztec/stdlib/proofs');
+const { PartialPrivateTailPublicInputsForPublic } = require('@aztec/stdlib/kernel');
+const { padArrayEnd } = require('@aztec/foundation/collection');
+const { MAX_ENQUEUED_CALLS_PER_TX } = require('@aztec/constants');
+const { ChonkProof } = require('@aztec/stdlib/proofs');
 
-var { createInterface } = require('readline');
-var { writeSync } = require('fs');
+const { createInterface } = require('readline');
+const { writeSync } = require('fs');
 
-var { AvmSimulator } = require('../../public/avm/avm_simulator.js');
-var { SimpleContractDataSource } = require('../../public/fixtures/simple_contract_data_source.js');
-var { PublicContractsDB, PublicTreesDB } = require('../../public/public_db_sources.js');
-var { SideEffectTrace } = require('../../public/side_effect_trace.js');
-var { PublicPersistableStateManager } = require('../../public/state_manager/state_manager.js');
-var { PublicTxSimulator } = require('../../public/public_tx_simulator/public_tx_simulator.js');
-var { AvmTxHint } = require('../../public/fuzzer/avm_tx_hint.js');
+const { SimpleContractDataSource } = require('../../public/fixtures/simple_contract_data_source.js');
+const { PublicContractsDB } = require('../../public/public_db_sources.js');
+const { PublicTxSimulator } = require('../../public/public_tx_simulator/public_tx_simulator.js');
 
-// Type declaration for Istanbul coverage
-interface CoverageStatement {
-  [statementId: string]: number;
-}
-
-interface CoverageFunction {
-  [functionId: string]: number;
-}
-
-interface CoverageBranch {
-  [branchId: string]: number[];
-}
-
-interface FileCoverageData {
-  s: CoverageStatement; // statements
-  f: CoverageFunction; // functions
-  b: CoverageBranch; // branches
-}
-
-interface GlobalCoverage {
-  [filePath: string]: FileCoverageData;
-}
-
-// Extend global interface to include __coverage__
-declare global {
-  var __coverage__: GlobalCoverage | undefined;
-}
-
-function stringToField(str: string): typeof Fr {
-  let number = BigInt(str);
-  if (number < 0) {
-    number = Fr.MODULUS + number;
+// Helper to convert msgpack Buffer objects to Fr
+function bufferToFr(value: any): typeof Fr {
+  if (!value) return Fr.ZERO;
+  if (value.type === 'Buffer' && Array.isArray(value.data)) {
+    return Fr.fromBuffer(Buffer.from(value.data));
   }
-  return new Fr(number);
+  if (Buffer.isBuffer(value)) {
+    return Fr.fromBuffer(value);
+  }
+  return new Fr(value);
 }
 
-function stringArrayToFields(arr: string[]): (typeof Fr)[] {
-  return arr.map(stringToField);
+// Helper to convert msgpack Buffer objects to AztecAddress
+function bufferToAddress(value: any): typeof AztecAddress {
+  if (!value) return AztecAddress.ZERO;
+  if (value.type === 'Buffer' && Array.isArray(value.data)) {
+    return AztecAddress.fromBuffer(Buffer.from(value.data));
+  }
+  if (Buffer.isBuffer(value)) {
+    return AztecAddress.fromBuffer(value);
+  }
+  return new AztecAddress(new Fr(value));
 }
 
 /**
@@ -93,37 +59,51 @@ function stringArrayToFields(arr: string[]): (typeof Fr)[] {
  * @param cppTx - Deserialized C++ Tx from msgpack (matches AvmTxHint structure)
  * @returns A TypeScript Tx suitable for PublicTxSimulator
  */
-function createFuzzerTx(cppTx: typeof AvmTxHint): typeof Tx {
+async function createFuzzerTx(cppTx: typeof AvmTxHint): Promise<typeof Tx> {
   // Create TxHash from the C++ tx hash string
+  if (!cppTx.hash) {
+    throw new Error(`cppTx.hash is undefined. Keys: ${Object.keys(cppTx || {}).join(', ')}`);
+  }
   const txHash = TxHash.fromString(cppTx.hash);
 
-  // Build PrivateToPublicAccumulatedData for non-revertible
-  const nonRevertibleAccumulatedData = new PrivateToPublicAccumulatedData(
-    cppTx.nonRevertibleAccumulatedData.noteHashes || [],
-    cppTx.nonRevertibleAccumulatedData.nullifiers || [],
-    cppTx.nonRevertibleAccumulatedData.l2ToL1Messages || [],
-    [], // privateLogs
-    [], // contractClassLogsHashes
-    cppTx.setupEnqueuedCalls || [], // publicCallRequests - setup calls go here
-  );
+  // Build proper PublicCallRequest instances from C++ app logic calls
+  const appLogicCallRequests = (cppTx.appLogicEnqueuedCalls || []).map((call: any, index: number) => {
+    if (!call || !call.request) {
+      throw new Error(`appLogicEnqueuedCalls[${index}] missing request field. call=${JSON.stringify(call)}`);
+    }
+    const req = call.request;
+    return new PublicCallRequest(
+      bufferToAddress(req.msgSender),
+      bufferToAddress(req.contractAddress),
+      req.isStaticCall ?? false,
+      bufferToFr(req.calldataHash),
+    );
+  });
 
-  // Build PrivateToPublicAccumulatedData for revertible
+  // Pad to MAX_ENQUEUED_CALLS_PER_TX with empty requests
+  const paddedAppLogicCalls = padArrayEnd(appLogicCallRequests, PublicCallRequest.empty(), MAX_ENQUEUED_CALLS_PER_TX);
+
+  // Use empty() for non-revertible (setup calls) - fuzzer doesn't use setup phase
+  const nonRevertibleAccumulatedData = PrivateToPublicAccumulatedData.empty();
+
+  // Build revertible accumulated data with proper PublicCallRequest instances
+  const emptyAccumulated = PrivateToPublicAccumulatedData.empty();
   const revertibleAccumulatedData = new PrivateToPublicAccumulatedData(
-    cppTx.revertibleAccumulatedData.noteHashes || [],
-    cppTx.revertibleAccumulatedData.nullifiers || [],
-    cppTx.revertibleAccumulatedData.l2ToL1Messages || [],
-    [], // privateLogs
-    [], // contractClassLogsHashes
-    cppTx.appLogicEnqueuedCalls || [], // publicCallRequests - app logic calls go here
+    emptyAccumulated.noteHashes,
+    emptyAccumulated.nullifiers,
+    emptyAccumulated.l2ToL1Msgs,
+    emptyAccumulated.privateLogs,
+    emptyAccumulated.contractClassLogsHashes,
+    paddedAppLogicCalls,
   );
 
   // Build teardown call request (if exists)
   const teardownCallRequest = cppTx.teardownEnqueuedCall
     ? new PublicCallRequest(
-        new AztecAddress(cppTx.teardownEnqueuedCall.request.msgSender),
-        new AztecAddress(cppTx.teardownEnqueuedCall.request.contractAddress),
-        cppTx.teardownEnqueuedCall.request.isStaticCall,
-        new Fr(cppTx.teardownEnqueuedCall.request.calldataHash || 0),
+        bufferToAddress(cppTx.teardownEnqueuedCall.request.msgSender),
+        bufferToAddress(cppTx.teardownEnqueuedCall.request.contractAddress),
+        cppTx.teardownEnqueuedCall.request.isStaticCall ?? false,
+        bufferToFr(cppTx.teardownEnqueuedCall.request.calldataHash),
       )
     : PublicCallRequest.empty();
 
@@ -135,6 +115,14 @@ function createFuzzerTx(cppTx: typeof AvmTxHint): typeof Tx {
   );
 
   // Build GasSettings from C++ tx
+  // Note: maxFeesPerGas must be >= global gasFees (which is typically 1 for both da and l2)
+  // If C++ provides 0 for maxFeesPerGas, use a default of 1 to match the global fees
+  // Note: values may be Fr objects, so we convert to Number first then check for 0
+  const DEFAULT_MAX_FEE = 1;
+  const toNumberOrDefault = (val: any, defaultVal: number): number => {
+    const num = Number(val);
+    return num > 0 ? num : defaultVal;
+  };
   const gasSettings = new GasSettings(
     new Gas(Number(cppTx.gasSettings.gasLimits.l2Gas), Number(cppTx.gasSettings.gasLimits.daGas)),
     new Gas(
@@ -142,8 +130,8 @@ function createFuzzerTx(cppTx: typeof AvmTxHint): typeof Tx {
       Number(cppTx.gasSettings.teardownGasLimits?.daGas || 0),
     ),
     new GasFees(
-      Number(cppTx.gasSettings.maxFeesPerGas?.feePerDaGas || 0),
-      Number(cppTx.gasSettings.maxFeesPerGas?.feePerL2Gas || 0),
+      toNumberOrDefault(cppTx.gasSettings.maxFeesPerGas?.feePerDaGas, DEFAULT_MAX_FEE),
+      toNumberOrDefault(cppTx.gasSettings.maxFeesPerGas?.feePerL2Gas, DEFAULT_MAX_FEE),
     ),
     new GasFees(
       Number(cppTx.gasSettings.maxPriorityFeesPerGas?.feePerDaGas || 0),
@@ -176,28 +164,31 @@ function createFuzzerTx(cppTx: typeof AvmTxHint): typeof Tx {
   const data = new PrivateKernelTailCircuitPublicInputs(
     constants,
     gasUsedByPrivate,
-    new AztecAddress(cppTx.feePayer),
+    bufferToAddress(cppTx.feePayer),
     0n, // includeByTimestamp
     forPublic,
     undefined, // forRollup - not needed for public simulation
   );
 
   // Build publicFunctionCalldata from all enqueued calls
+  // Convert Buffer objects in calldata to Fr values
+  const convertCalldata = (calldata: any[]): (typeof Fr)[] => (calldata || []).map(bufferToFr);
+
   const publicFunctionCalldata: (typeof HashedValues)[] = [];
 
   // Add setup calls
   for (const call of cppTx.setupEnqueuedCalls || []) {
-    publicFunctionCalldata.push(new HashedValues(call.calldata || []));
+    publicFunctionCalldata.push(await HashedValues.fromCalldata(convertCalldata(call.calldata)));
   }
 
   // Add app logic calls
   for (const call of cppTx.appLogicEnqueuedCalls || []) {
-    publicFunctionCalldata.push(new HashedValues(call.calldata || []));
+    publicFunctionCalldata.push(await HashedValues.fromCalldata(convertCalldata(call.calldata)));
   }
 
   // Add teardown call if present
   if (cppTx.teardownEnqueuedCall) {
-    publicFunctionCalldata.push(new HashedValues(cppTx.teardownEnqueuedCall.calldata || []));
+    publicFunctionCalldata.push(await HashedValues.fromCalldata(convertCalldata(cppTx.teardownEnqueuedCall.calldata)));
   }
 
   // Create the Tx
@@ -209,8 +200,6 @@ function createFuzzerTx(cppTx: typeof AvmTxHint): typeof Tx {
     publicFunctionCalldata,
   );
 }
-
-const DEFAULT_TIMESTAMP = 1000000;
 
 // Cache for opened world state services by data directory path
 const worldStateCache: Map<string, typeof NativeWorldStateService> = new Map();
@@ -238,97 +227,12 @@ async function openExistingWorldState(dataDir: string, mapSizeKb: number): Promi
   return ws;
 }
 
-let STATE_MANAGER: typeof PublicPersistableStateManager | undefined;
-
-async function getStateManager(): Promise<typeof PublicPersistableStateManager> {
-  const contractDataSource = new SimpleContractDataSource();
-  const worldStateService = await NativeWorldStateService.tmp();
-  if (!worldStateService) {
-    throw new Error('NativeWorldStateService.tmp() returned undefined');
-  }
-  const merkleTrees = await worldStateService.fork();
-  if (!merkleTrees) {
-    throw new Error('worldStateService.fork() returned undefined');
-  }
-  const treesDb = new PublicTreesDB(merkleTrees);
-  const contractsDb = new PublicContractsDB(contractDataSource);
-  const trace = new SideEffectTrace();
-  const firstNullifier = new Fr(0xdeadbeef);
-  const stateManager = PublicPersistableStateManager.create(
-    treesDb,
-    contractsDb,
-    trace,
-    firstNullifier,
-    DEFAULT_TIMESTAMP,
-  );
-  if (!stateManager) {
-    throw new Error('PublicPersistableStateManager.create() returned undefined');
-  }
-  return stateManager;
-}
-
-async function initSimulator() {
-  if (STATE_MANAGER) {
-    return;
-  }
-  try {
-    STATE_MANAGER = await getStateManager();
-    if (!STATE_MANAGER) {
-      throw new Error('getStateManager() returned undefined');
-    }
-  } catch (error) {
-    // Reset STATE_MANAGER to undefined on error so we can retry
-    STATE_MANAGER = undefined;
-    throw new Error(`Failed to initialize state manager: ${error.message}`);
-  }
-}
-
-async function getSimulator(calldata: (typeof Fr)[]) {
-  await initSimulator();
-
-  if (!STATE_MANAGER) {
-    throw new Error('State manager not initialized. This may happen if initialization failed after restart.');
-  }
-
-  const globalVariables = GlobalVariables.empty();
-  globalVariables.chainId = new Fr(1);
-  globalVariables.version = new Fr(1);
-  globalVariables.blockNumber = 1;
-  globalVariables.slotNumber = new Fr(1);
-  globalVariables.timestamp = 1000000;
-  globalVariables.coinbase = AztecAddress.ZERO;
-  globalVariables.feeRecipient = AztecAddress.ZERO;
-  globalVariables.gasFees = new GasFees(1, 1);
-
-  const config = PublicSimulatorConfig.from({
-    skipFeeEnforcement: true,
-    collectDebugLogs: false,
-    collectHints: false,
-    collectStatistics: false,
-    collectCallMetadata: false,
-  });
-
-  const simulator = await AvmSimulator.create(
-    STATE_MANAGER,
-    AztecAddress.fromNumber(42), // address
-    AztecAddress.fromNumber(100), // sender
-    new Fr(0), // transaction fee
-    globalVariables,
-    false, // is static call
-    calldata,
-    { l2Gas: 1000000, daGas: 1000000 },
-    config,
-  );
-  return simulator;
-}
-
 /**
  * Execute a transaction using PublicTxSimulator.
  * This is the full transaction simulation path that matches the C++ AVM simulator.
  *
  * @param dataDir - World state data directory
  * @param mapSizeKb - World state map size in KB
- * @param forkId - The fork ID to use (from C++ FuzzerWorldStateManager)
  * @param bytecode - AVM bytecode to execute
  * @param cppTx - Deserialized C++ Tx from msgpack
  * @param cppGlobals - Deserialized C++ GlobalVariables from msgpack
@@ -337,21 +241,27 @@ async function getSimulator(calldata: (typeof Fr)[]) {
 async function simulateWithPublicTxSimulator(
   dataDir: string,
   mapSizeKb: number,
-  forkId: number,
   bytecode: Buffer,
   cppTx: typeof AvmTxHint,
   cppGlobals: typeof GlobalVariables,
 ): Promise<{ reverted: boolean; output: (typeof Fr)[]; revertReason?: string }> {
   // Open the existing WorldState database created by C++
   const worldStateService = await openExistingWorldState(dataDir, mapSizeKb);
-  // Use the same fork as C++ by creating facade directly with the fork ID
-  const revision = new WorldStateRevision(forkId, 0, true);
-  const merkleTrees = new MerkleTreesForkFacade(worldStateService.instance, worldStateService.initialHeader, revision);
+  const merkleTrees = await worldStateService.fork();
 
-  // FIXME: This only works while we have a single app logic call
+  // TODO: This only works while we have a single app logic call
   // Get contract address from the app logic call
   const appLogicCall = cppTx.appLogicEnqueuedCalls[0];
-  const contractAddress = new AztecAddress(appLogicCall.request.contractAddress);
+  const contractAddress = bufferToAddress(appLogicCall.request.contractAddress);
+
+  // Insert contract address nullifier into the nullifier tree
+  // This makes the contract "deployed" from the perspective of the state manager
+  const contractAddressNullifier = await siloNullifier(
+    AztecAddress.fromNumber(CONTRACT_INSTANCE_REGISTRY_CONTRACT_ADDRESS),
+    contractAddress.toField(),
+  );
+  await merkleTrees.sequentialInsert(MerkleTreeId.NULLIFIER_TREE, [contractAddressNullifier.toBuffer()]);
+
   // Create contract data source and register bytecode
   const contractDataSource = new SimpleContractDataSource();
   // Register the bytecode at the contract address
@@ -361,30 +271,34 @@ async function simulateWithPublicTxSimulator(
   const contractsDb = new PublicContractsDB(contractDataSource);
 
   // Build GlobalVariables from deserialized msgpack data
-  const globalVariables = cppGlobals;
+  // Convert gasFees from plain object to proper GasFees instance with BigInt values
+  const globalVariables = {
+    ...cppGlobals,
+    gasFees: new GasFees(Number(cppGlobals.gasFees?.feePerDaGas || 1), Number(cppGlobals.gasFees?.feePerL2Gas || 1)),
+  };
 
   // Create the PublicTxSimulator
   const config = {
     skipFeeEnforcement: true,
-    collectDebugLogs: false,
-    collectHints: false,
-    collectStatistics: false,
-    collectCallMetadata: false,
   };
   const publicTxSimulator = new PublicTxSimulator(merkleTrees, contractsDb, globalVariables, config);
 
   // Create a TypeScript Tx from the C++ Tx
-  const tx = createFuzzerTx(cppTx);
+  const tx = await createFuzzerTx(cppTx);
 
   // Simulate the transaction
   const result = await publicTxSimulator.simulate(tx);
 
   // Extract output from appLogicReturnValues
   const output: (typeof Fr)[] = [];
-  for (const returnValues of result.appLogicReturnValues) {
-    if (returnValues.values) {
-      for (const value of returnValues.values) {
-        output.push(value);
+  if (result.appLogicReturnValues) {
+    for (const returnValues of result.appLogicReturnValues) {
+      if (returnValues && returnValues.values) {
+        for (const value of returnValues.values) {
+          if (value !== undefined && value !== null) {
+            output.push(value);
+          }
+        }
       }
     }
   }
@@ -395,173 +309,56 @@ async function simulateWithPublicTxSimulator(
   return { reverted, output, revertReason };
 }
 
-const FLATTENED_COVERAGE_MAP: Map<string, number> = new Map();
-
-// Report the coverage and reset the global coverage
-// Sets every Program Counter to 0
-// @returns the flattened coverage map
-//
-// The reason why we reset the coverage is because istanbul increment the PCs every time it encountered this counter
-// For instance, executeBytecode executes every time in a loop, so the corresponding PC will be incremented by 1 for each execution
-// We only want to count `new` coverage, so we reset the global coverage after each execution
-function report_and_reset_coverage(): Map<string, number> {
-  if (!global.__coverage__) {
-    return new Map();
-  }
-
-  const coverage = global.__coverage__;
-  const flat: Map<string, number> = FLATTENED_COVERAGE_MAP;
-  const filePaths = Object.keys(coverage);
-  const filePathsLength = filePaths.length;
-
-  for (let i = 0; i < filePathsLength; i++) {
-    const fileData = coverage[filePaths[i]];
-
-    // Flatten and reset statements
-    const statements = fileData.s;
-    const stmtIds = Object.keys(statements);
-    const stmtIdsLength = stmtIds.length;
-    for (let j = 0; j < stmtIdsLength; j++) {
-      const stmtId = stmtIds[j];
-      flat.set('s_' + stmtId, statements[stmtId] ? 1 : 0);
-      global.__coverage__[filePaths[i]].s[stmtId] = 0;
-    }
-
-    // Flatten and reset functions
-    const functions = fileData.f;
-    const funcIds = Object.keys(functions);
-    const funcIdsLength = funcIds.length;
-    for (let j = 0; j < funcIdsLength; j++) {
-      const funcId = funcIds[j];
-      flat.set('f_' + funcId, functions[funcId] ? 1 : 0);
-      global.__coverage__[filePaths[i]].f[funcId] = 0;
-    }
-
-    // Flatten and reset branches
-    const branches = fileData.b;
-    const branchIds = Object.keys(branches);
-    const branchIdsLength = branchIds.length;
-    for (let j = 0; j < branchIdsLength; j++) {
-      const branchId = branchIds[j];
-      const branchHits = branches[branchId];
-      const branchHitsLength = branchHits.length;
-      for (let k = 0; k < branchHitsLength; k++) {
-        flat.set('b_' + branchId + '_' + k, branchHits[k] ? 1 : 0);
-        global.__coverage__[filePaths[i]].b[branchId][k] = 0;
-      }
-    }
-  }
-  return flat;
-}
-
-// After all hooks coverage is filled with dummy functions (exports and so on)
-// We don't want to count these as coverage
-// So we reset the coverage
-const _ = report_and_reset_coverage();
-
-async function executeBytecodeBase64(
-  avmBytecodeBase64: string,
-  calldata: (typeof Fr)[],
-): Promise<{ reverted: boolean; output: (typeof Fr)[]; revertReason?: string }> {
-  const bytecode = Buffer.from(avmBytecodeBase64, 'base64');
-  const simulator = await getSimulator(calldata);
-  const results = await simulator.executeBytecode(bytecode);
-  return { reverted: results.reverted, output: results.output, revertReason: results.revertReason };
-}
-
-// Execute the AVM bytecode and return the result and the coverage
-// @param jsonLine: the JSON line containing the bytecode and the inputs
-// prints gzipped result and the coverage to stdout encoded in base64
-// @returns void
-//
-//
-// The reason why we gzip the result and the coverage is because the coverage is HUGE and low-entropy
-// So printing it to stdout is very slow and we want to avoid that (because we try to maximize the number of executions)
-// It turned out that it is faster to gzip and decode it in the fuzzer than to print it to stdout
+// Execute the AVM bytecode and return the result
+// @param jsonLine: the JSON line containing the bytecode, tx, globals, and world state info
+// prints result to stdout as JSON
 async function executeFromJson(jsonLine: string): Promise<void> {
   try {
     const input = JSON.parse(jsonLine.trim());
-    if ((!input.bytecode || !input.inputs) && !input.restart) {
-      writeSync(process.stdout.fd, 'Error: JSON must contain "bytecode" and "inputs" fields or "restart" field\n');
-      return;
-    }
-    if (input.restart) {
-      STATE_MANAGER = undefined;
-      try {
-        await initSimulator();
-        if (!STATE_MANAGER) {
-          throw new Error('State manager initialization completed but STATE_MANAGER is still undefined');
-        }
-        const response = { restarted: true };
-        const output = gzipSync(JSON.stringify(response, null, 0)).toString('base64') + '\n';
-        writeSync(process.stdout.fd, output);
-      } catch (error: any) {
-        const response = { restarted: false, error: error.message };
-        const output = gzipSync(JSON.stringify(response, null, 0)).toString('base64') + '\n';
-        writeSync(process.stdout.fd, output);
-      }
-      return;
-    }
-    const calldata = stringArrayToFields(input.inputs);
-
-    let result;
-    if (input.ws_data_dir && input.ws_map_size_kb && input.ws_fork_id && input.tx && input.globals) {
-      // Use PublicTxSimulator with the existing WorldState database created by C++
-      const bytecode = Buffer.from(input.bytecode, 'base64');
-
-      // Decode base64 and deserialize msgpack for tx and globals
-      const txBuffer = Buffer.from(input.tx, 'base64');
-      const globalsBuffer = Buffer.from(input.globals, 'base64');
-      const tx = deserializeFromMessagePack(txBuffer);
-      const globals = deserializeFromMessagePack(globalsBuffer);
-
-      // Use the new PublicTxSimulator path with the same fork ID as C++
-      result = await simulateWithPublicTxSimulator(
-        input.ws_data_dir,
-        input.ws_map_size_kb,
-        input.ws_fork_id,
-        bytecode,
-        tx,
-        globals,
+    if (!input.bytecode || !input.ws_data_dir || !input.ws_map_size_kb || !input.tx || !input.globals) {
+      writeSync(
+        process.stdout.fd,
+        'Error: JSON must contain "bytecode", "ws_data_dir", "ws_map_size_kb", "tx", and "globals" fields\n',
       );
-    } else {
-      // Fallback to the default behavior with a temporary WorldState
-      result = await executeBytecodeBase64(input.bytecode, calldata);
+      return;
     }
 
-    const coverage = Object.fromEntries(report_and_reset_coverage());
+    const bytecode = Buffer.from(input.bytecode, 'base64');
 
-    const outputLength = result.output.length;
+    // Decode base64 and deserialize msgpack for tx and globals
+    const txBuffer = Buffer.from(input.tx, 'base64');
+    const globalsBuffer = Buffer.from(input.globals, 'base64');
+    const tx = deserializeFromMessagePack(txBuffer);
+    const globals = deserializeFromMessagePack(globalsBuffer);
+
+    const result = await simulateWithPublicTxSimulator(input.ws_data_dir, input.ws_map_size_kb, bytecode, tx, globals);
+
+    const outputLength = result.output ? result.output.length : 0;
     const outputStrings = new Array(outputLength);
     for (let i = 0; i < outputLength; i++) {
-      outputStrings[i] = result.output[i].toString();
+      const outputValue = result.output[i];
+      outputStrings[i] = outputValue != null ? outputValue.toString() : '0';
     }
     const response = {
       reverted: result.reverted,
       output: outputStrings,
-      coverage: coverage,
       revertReason: result.revertReason,
     };
 
-    const output = gzipSync(JSON.stringify(response, null, 0)).toString('base64') + '\n';
-    writeSync(process.stdout.fd, output);
-  } catch (error) {
-    const coverage = Object.fromEntries(report_and_reset_coverage());
+    writeSync(process.stdout.fd, JSON.stringify(response) + '\n');
+  } catch (error: any) {
     const response = {
       reverted: true,
       output: [],
-      coverage: coverage,
       revertReason: error.message,
     };
-    const output = gzipSync(JSON.stringify(response, null, 0)).toString('base64') + '\n';
-    writeSync(process.stdout.fd, output);
+    writeSync(process.stdout.fd, JSON.stringify(response) + '\n');
   }
 }
 
-// Read json line-by-line from stdin {"bytecode": "...", "inputs": ["1", "2", ...]}
-// Process it and print the result of the execution to stdout {"reverted":false,"output":["0x0..."], "coverage":{"s_0":1,"f_0":1,"b_0_0":1,"b_0_1":1...}
+// Read json line-by-line from stdin
+// Process it and print the result of the execution to stdout
 async function mainLoop() {
-  await initSimulator();
   const rl = createInterface({
     input: process.stdin,
     terminal: false,

--- a/yarn-project/simulator/src/public/fixtures/simple_contract_data_source.ts
+++ b/yarn-project/simulator/src/public/fixtures/simple_contract_data_source.ts
@@ -1,5 +1,5 @@
 import type { BlockNumber } from '@aztec/foundation/branded-types';
-import type { Fr } from '@aztec/foundation/fields';
+import { Fr } from '@aztec/foundation/fields';
 import { createLogger } from '@aztec/foundation/log';
 import type { ContractArtifact, FunctionSelector } from '@aztec/stdlib/abi';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
@@ -16,146 +16,146 @@ import { getFunctionSelector } from '../avm/fixtures/utils.js';
  * This class does not include any real merkle trees & merkle operations.
  */
 export class SimpleContractDataSource implements ContractDataSource {
-    public logger = createLogger('simple-contract-data-source');
+  public logger = createLogger('simple-contract-data-source');
 
-    // maps contract class ID to class
-    private contractClasses: Map<string, ContractClassPublic> = new Map();
-    // maps contract instance address to instance
-    private contractInstances: Map<string, ContractInstanceWithAddress> = new Map();
-    // maps contract instance address to address
-    private contractArtifacts: Map<string, ContractArtifact> = new Map();
-    // maps `${classID}:${fnSelector}` to name
-    private debugFunctionName: Map<string, string> = new Map();
+  // maps contract class ID to class
+  private contractClasses: Map<string, ContractClassPublic> = new Map();
+  // maps contract instance address to instance
+  private contractInstances: Map<string, ContractInstanceWithAddress> = new Map();
+  // maps contract instance address to address
+  private contractArtifacts: Map<string, ContractArtifact> = new Map();
+  // maps `${classID}:${fnSelector}` to name
+  private debugFunctionName: Map<string, string> = new Map();
 
-    /////////////////////////////////////////////////////////////
-    // Helper functions not in the contract data source interface
-    /**
-     * Derive the contract class and instance with some seed.
-     * Add both to the contract data source along with the contract artifact.
-     */
-    async addNewContract(
-        contractArtifact: ContractArtifact,
-        contractClass: ContractClassPublic,
-        contractInstance: ContractInstanceWithAddress,
-    ) {
-        await this.addContractArtifact(contractClass.id, contractArtifact);
-        await this.addContractClass(contractClass);
-        await this.addContractInstance(contractInstance);
+  /////////////////////////////////////////////////////////////
+  // Helper functions not in the contract data source interface
+  /**
+   * Derive the contract class and instance with some seed.
+   * Add both to the contract data source along with the contract artifact.
+   */
+  async addNewContract(
+    contractArtifact: ContractArtifact,
+    contractClass: ContractClassPublic,
+    contractInstance: ContractInstanceWithAddress,
+  ) {
+    await this.addContractArtifact(contractClass.id, contractArtifact);
+    await this.addContractClass(contractClass);
+    await this.addContractInstance(contractInstance);
+  }
+
+  async addContractArtifact(classId: Fr, artifact: ContractArtifact) {
+    this.contractArtifacts.set(classId.toString(), artifact);
+    const classIdStr = classId.toString();
+    const publicFns = artifact.nonDispatchPublicFunctions;
+    if (publicFns.length !== 0) {
+      for (const fn of publicFns) {
+        const actualFnName = `${fn.name}`;
+        const fnSelector = await getFunctionSelector(actualFnName, artifact);
+        const key = `${classIdStr}:${fnSelector.toString()}`;
+
+        const longFnName = `${artifact.name}.${actualFnName}`;
+        this.debugFunctionName.set(key, longFnName);
+      }
     }
+  }
 
-    async addContractArtifact(classId: Fr, artifact: ContractArtifact) {
-        this.contractArtifacts.set(classId.toString(), artifact);
-        const classIdStr = classId.toString();
-        const publicFns = artifact.nonDispatchPublicFunctions;
-        if (publicFns.length !== 0) {
-            for (const fn of publicFns) {
-                const actualFnName = `${fn.name}`;
-                const fnSelector = await getFunctionSelector(actualFnName, artifact);
-                const key = `${classIdStr}:${fnSelector.toString()}`;
+  /////////////////////////////////////////////////////////////
+  // ContractDataSource function implementations
+  getBlockNumber(): Promise<BlockNumber> {
+    throw new Error('Method not implemented.');
+  }
 
-                const longFnName = `${artifact.name}.${actualFnName}`;
-                this.debugFunctionName.set(key, longFnName);
-            }
-        }
+  getContractClass(id: Fr): Promise<ContractClassPublic | undefined> {
+    return Promise.resolve(this.contractClasses.get(id.toString()));
+  }
+
+  getBytecodeCommitment(_id: Fr): Promise<Fr | undefined> {
+    return Promise.resolve(undefined);
+  }
+
+  getContract(address: AztecAddress): Promise<ContractInstanceWithAddress | undefined> {
+    return Promise.resolve(this.contractInstances.get(address.toString()));
+  }
+
+  getContractClassIds(): Promise<Fr[]> {
+    throw new Error('Method not implemented.');
+  }
+
+  async getContractArtifact(address: AztecAddress): Promise<ContractArtifact | undefined> {
+    const contractInstance = await this.getContract(address);
+    if (!contractInstance) {
+      this.logger.warn(`Contract not found at address: ${address}`);
+      return undefined;
     }
+    this.logger.debug(`Retrieved contract artifact for address: ${address}`);
+    this.logger.debug(`Contract class ID: ${contractInstance.currentContractClassId}`);
+    return this.contractArtifacts.get(contractInstance!.currentContractClassId.toString());
+  }
 
-    /////////////////////////////////////////////////////////////
-    // ContractDataSource function implementations
-    getBlockNumber(): Promise<BlockNumber> {
-        throw new Error('Method not implemented.');
+  async getDebugFunctionName(address: AztecAddress, selector: FunctionSelector): Promise<string | undefined> {
+    const contractInstance = await this.getContract(address);
+    if (!contractInstance) {
+      this.logger.warn(`Couldn't get fn name for debugging. Contract not in tester's ContractDataSource.`);
+      return undefined;
     }
-
-    getContractClass(id: Fr): Promise<ContractClassPublic | undefined> {
-        return Promise.resolve(this.contractClasses.get(id.toString()));
+    const key = `${contractInstance.currentContractClassId.toString()}:${selector.toString()}`;
+    const fnName = this.debugFunctionName.get(key);
+    if (!fnName) {
+      this.logger.warn(`Couldn't get fn name for debugging...`);
+      return undefined;
     }
+    return fnName;
+  }
 
-    getBytecodeCommitment(_id: Fr): Promise<Fr | undefined> {
-        return Promise.resolve(undefined);
-    }
+  registerContractFunctionSignatures(_signatures: string[]): Promise<void> {
+    return Promise.resolve();
+  }
 
-    getContract(address: AztecAddress): Promise<ContractInstanceWithAddress | undefined> {
-        return Promise.resolve(this.contractInstances.get(address.toString()));
-    }
+  addContractClass(contractClass: ContractClassPublic): Promise<void> {
+    this.contractClasses.set(contractClass.id.toString(), contractClass);
+    return Promise.resolve();
+  }
 
-    getContractClassIds(): Promise<Fr[]> {
-        throw new Error('Method not implemented.');
-    }
+  addContractInstance(contractInstance: ContractInstanceWithAddress): Promise<void> {
+    this.contractInstances.set(contractInstance.address.toString(), contractInstance);
+    return Promise.resolve();
+  }
 
-    async getContractArtifact(address: AztecAddress): Promise<ContractArtifact | undefined> {
-        const contractInstance = await this.getContract(address);
-        if (!contractInstance) {
-            this.logger.warn(`Contract not found at address: ${address}`);
-            return undefined;
-        }
-        this.logger.debug(`Retrieved contract artifact for address: ${address}`);
-        this.logger.debug(`Contract class ID: ${contractInstance.currentContractClassId}`);
-        return this.contractArtifacts.get(contractInstance!.currentContractClassId.toString());
-    }
+  /**
+   * FIXME: This is temporary
+   * Helper method for fuzzer: registers a contract with raw bytecode at a given address.
+   * Creates a minimal ContractClassPublic and ContractInstanceWithAddress.
+   * @param address - The contract address
+   * @param bytecode - The raw AVM bytecode
+   */
+  async addContractWithBytecode(address: AztecAddress, bytecode: Buffer): Promise<void> {
+    // Generate a deterministic class ID from the bytecode
+    const classId = Fr.fromBufferReduce(bytecode.subarray(0, 32));
 
-    async getDebugFunctionName(address: AztecAddress, selector: FunctionSelector): Promise<string | undefined> {
-        const contractInstance = await this.getContract(address);
-        if (!contractInstance) {
-            this.logger.warn(`Couldn't get fn name for debugging. Contract not in tester's ContractDataSource.`);
-            return undefined;
-        }
-        const key = `${contractInstance.currentContractClassId.toString()}:${selector.toString()}`;
-        const fnName = this.debugFunctionName.get(key);
-        if (!fnName) {
-            this.logger.warn(`Couldn't get fn name for debugging...`);
-            return undefined;
-        }
-        return fnName;
-    }
+    // Create minimal ContractClassPublic
+    const contractClass: ContractClassPublic = {
+      id: classId,
+      version: 1 as const,
+      artifactHash: Fr.ZERO,
+      privateFunctionsRoot: Fr.ZERO,
+      privateFunctions: [],
+      utilityFunctions: [],
+      packedBytecode: bytecode,
+    };
 
-    registerContractFunctionSignatures(_signatures: string[]): Promise<void> {
-        return Promise.resolve();
-    }
+    // Create minimal ContractInstanceWithAddress
+    const contractInstance: ContractInstanceWithAddress = {
+      address,
+      version: 1 as const,
+      salt: Fr.ZERO,
+      deployer: address, // Use the contract address as deployer
+      currentContractClassId: classId,
+      originalContractClassId: classId,
+      initializationHash: Fr.ZERO,
+      publicKeys: PublicKeys.default(),
+    };
 
-    addContractClass(contractClass: ContractClassPublic): Promise<void> {
-        this.contractClasses.set(contractClass.id.toString(), contractClass);
-        return Promise.resolve();
-    }
-
-    addContractInstance(contractInstance: ContractInstanceWithAddress): Promise<void> {
-        this.contractInstances.set(contractInstance.address.toString(), contractInstance);
-        return Promise.resolve();
-    }
-
-    /**
-     * FIXME: This is temporary until we have a proper contract calss / instance mechanism in tests.
-     * Helper method for fuzzer: registers a contract with raw bytecode at a given address.
-     * Creates a minimal ContractClassPublic and ContractInstanceWithAddress.
-     * @param address - The contract address
-     * @param bytecode - The raw AVM bytecode
-     */
-    async addContractWithBytecode(address: AztecAddress, bytecode: Buffer): Promise<void> {
-        // Generate a deterministic class ID from the bytecode
-        const classId = Fr.fromBufferReduce(bytecode.subarray(0, 32));
-
-        // Create minimal ContractClassPublic
-        const contractClass: ContractClassPublic = {
-            id: classId,
-            version: 1 as const,
-            artifactHash: Fr.ZERO,
-            privateFunctionsRoot: Fr.ZERO,
-            privateFunctions: [],
-            utilityFunctions: [],
-            packedBytecode: bytecode,
-        };
-
-        // Create minimal ContractInstanceWithAddress
-        const contractInstance: ContractInstanceWithAddress = {
-            address,
-            version: 1 as const,
-            salt: Fr.ZERO,
-            deployer: address, // Use the contract address as deployer
-            currentContractClassId: classId,
-            originalContractClassId: classId,
-            initializationHash: Fr.ZERO,
-            publicKeys: PublicKeys.default(),
-        };
-
-        await this.addContractClass(contractClass);
-        await this.addContractInstance(contractInstance);
-    }
+    await this.addContractClass(contractClass);
+    await this.addContractInstance(contractInstance);
+  }
 }

--- a/yarn-project/simulator/src/public/fixtures/simple_contract_data_source.ts
+++ b/yarn-project/simulator/src/public/fixtures/simple_contract_data_source.ts
@@ -4,6 +4,7 @@ import { createLogger } from '@aztec/foundation/log';
 import type { ContractArtifact, FunctionSelector } from '@aztec/stdlib/abi';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
 import type { ContractClassPublic, ContractDataSource, ContractInstanceWithAddress } from '@aztec/stdlib/contract';
+import { PublicKeys } from '@aztec/stdlib/keys';
 
 import { getFunctionSelector } from '../avm/fixtures/utils.js';
 
@@ -15,108 +16,146 @@ import { getFunctionSelector } from '../avm/fixtures/utils.js';
  * This class does not include any real merkle trees & merkle operations.
  */
 export class SimpleContractDataSource implements ContractDataSource {
-  public logger = createLogger('simple-contract-data-source');
+    public logger = createLogger('simple-contract-data-source');
 
-  // maps contract class ID to class
-  private contractClasses: Map<string, ContractClassPublic> = new Map();
-  // maps contract instance address to instance
-  private contractInstances: Map<string, ContractInstanceWithAddress> = new Map();
-  // maps contract instance address to address
-  private contractArtifacts: Map<string, ContractArtifact> = new Map();
-  // maps `${classID}:${fnSelector}` to name
-  private debugFunctionName: Map<string, string> = new Map();
+    // maps contract class ID to class
+    private contractClasses: Map<string, ContractClassPublic> = new Map();
+    // maps contract instance address to instance
+    private contractInstances: Map<string, ContractInstanceWithAddress> = new Map();
+    // maps contract instance address to address
+    private contractArtifacts: Map<string, ContractArtifact> = new Map();
+    // maps `${classID}:${fnSelector}` to name
+    private debugFunctionName: Map<string, string> = new Map();
 
-  /////////////////////////////////////////////////////////////
-  // Helper functions not in the contract data source interface
-  /**
-   * Derive the contract class and instance with some seed.
-   * Add both to the contract data source along with the contract artifact.
-   */
-  async addNewContract(
-    contractArtifact: ContractArtifact,
-    contractClass: ContractClassPublic,
-    contractInstance: ContractInstanceWithAddress,
-  ) {
-    await this.addContractArtifact(contractClass.id, contractArtifact);
-    await this.addContractClass(contractClass);
-    await this.addContractInstance(contractInstance);
-  }
-
-  async addContractArtifact(classId: Fr, artifact: ContractArtifact) {
-    this.contractArtifacts.set(classId.toString(), artifact);
-    const classIdStr = classId.toString();
-    const publicFns = artifact.nonDispatchPublicFunctions;
-    if (publicFns.length !== 0) {
-      for (const fn of publicFns) {
-        const actualFnName = `${fn.name}`;
-        const fnSelector = await getFunctionSelector(actualFnName, artifact);
-        const key = `${classIdStr}:${fnSelector.toString()}`;
-
-        const longFnName = `${artifact.name}.${actualFnName}`;
-        this.debugFunctionName.set(key, longFnName);
-      }
+    /////////////////////////////////////////////////////////////
+    // Helper functions not in the contract data source interface
+    /**
+     * Derive the contract class and instance with some seed.
+     * Add both to the contract data source along with the contract artifact.
+     */
+    async addNewContract(
+        contractArtifact: ContractArtifact,
+        contractClass: ContractClassPublic,
+        contractInstance: ContractInstanceWithAddress,
+    ) {
+        await this.addContractArtifact(contractClass.id, contractArtifact);
+        await this.addContractClass(contractClass);
+        await this.addContractInstance(contractInstance);
     }
-  }
 
-  /////////////////////////////////////////////////////////////
-  // ContractDataSource function implementations
-  getBlockNumber(): Promise<BlockNumber> {
-    throw new Error('Method not implemented.');
-  }
+    async addContractArtifact(classId: Fr, artifact: ContractArtifact) {
+        this.contractArtifacts.set(classId.toString(), artifact);
+        const classIdStr = classId.toString();
+        const publicFns = artifact.nonDispatchPublicFunctions;
+        if (publicFns.length !== 0) {
+            for (const fn of publicFns) {
+                const actualFnName = `${fn.name}`;
+                const fnSelector = await getFunctionSelector(actualFnName, artifact);
+                const key = `${classIdStr}:${fnSelector.toString()}`;
 
-  getContractClass(id: Fr): Promise<ContractClassPublic | undefined> {
-    return Promise.resolve(this.contractClasses.get(id.toString()));
-  }
-
-  getBytecodeCommitment(_id: Fr): Promise<Fr | undefined> {
-    return Promise.resolve(undefined);
-  }
-
-  getContract(address: AztecAddress): Promise<ContractInstanceWithAddress | undefined> {
-    return Promise.resolve(this.contractInstances.get(address.toString()));
-  }
-
-  getContractClassIds(): Promise<Fr[]> {
-    throw new Error('Method not implemented.');
-  }
-
-  async getContractArtifact(address: AztecAddress): Promise<ContractArtifact | undefined> {
-    const contractInstance = await this.getContract(address);
-    if (!contractInstance) {
-      this.logger.warn(`Contract not found at address: ${address}`);
-      return undefined;
+                const longFnName = `${artifact.name}.${actualFnName}`;
+                this.debugFunctionName.set(key, longFnName);
+            }
+        }
     }
-    this.logger.debug(`Retrieved contract artifact for address: ${address}`);
-    this.logger.debug(`Contract class ID: ${contractInstance.currentContractClassId}`);
-    return this.contractArtifacts.get(contractInstance!.currentContractClassId.toString());
-  }
 
-  async getDebugFunctionName(address: AztecAddress, selector: FunctionSelector): Promise<string | undefined> {
-    const contractInstance = await this.getContract(address);
-    if (!contractInstance) {
-      this.logger.warn(`Couldn't get fn name for debugging. Contract not in tester's ContractDataSource.`);
-      return undefined;
+    /////////////////////////////////////////////////////////////
+    // ContractDataSource function implementations
+    getBlockNumber(): Promise<BlockNumber> {
+        throw new Error('Method not implemented.');
     }
-    const key = `${contractInstance.currentContractClassId.toString()}:${selector.toString()}`;
-    const fnName = this.debugFunctionName.get(key);
-    if (!fnName) {
-      this.logger.warn(`Couldn't get fn name for debugging...`);
-      return undefined;
+
+    getContractClass(id: Fr): Promise<ContractClassPublic | undefined> {
+        return Promise.resolve(this.contractClasses.get(id.toString()));
     }
-    return fnName;
-  }
 
-  registerContractFunctionSignatures(_signatures: string[]): Promise<void> {
-    return Promise.resolve();
-  }
+    getBytecodeCommitment(_id: Fr): Promise<Fr | undefined> {
+        return Promise.resolve(undefined);
+    }
 
-  addContractClass(contractClass: ContractClassPublic): Promise<void> {
-    this.contractClasses.set(contractClass.id.toString(), contractClass);
-    return Promise.resolve();
-  }
+    getContract(address: AztecAddress): Promise<ContractInstanceWithAddress | undefined> {
+        return Promise.resolve(this.contractInstances.get(address.toString()));
+    }
 
-  addContractInstance(contractInstance: ContractInstanceWithAddress): Promise<void> {
-    this.contractInstances.set(contractInstance.address.toString(), contractInstance);
-    return Promise.resolve();
-  }
+    getContractClassIds(): Promise<Fr[]> {
+        throw new Error('Method not implemented.');
+    }
+
+    async getContractArtifact(address: AztecAddress): Promise<ContractArtifact | undefined> {
+        const contractInstance = await this.getContract(address);
+        if (!contractInstance) {
+            this.logger.warn(`Contract not found at address: ${address}`);
+            return undefined;
+        }
+        this.logger.debug(`Retrieved contract artifact for address: ${address}`);
+        this.logger.debug(`Contract class ID: ${contractInstance.currentContractClassId}`);
+        return this.contractArtifacts.get(contractInstance!.currentContractClassId.toString());
+    }
+
+    async getDebugFunctionName(address: AztecAddress, selector: FunctionSelector): Promise<string | undefined> {
+        const contractInstance = await this.getContract(address);
+        if (!contractInstance) {
+            this.logger.warn(`Couldn't get fn name for debugging. Contract not in tester's ContractDataSource.`);
+            return undefined;
+        }
+        const key = `${contractInstance.currentContractClassId.toString()}:${selector.toString()}`;
+        const fnName = this.debugFunctionName.get(key);
+        if (!fnName) {
+            this.logger.warn(`Couldn't get fn name for debugging...`);
+            return undefined;
+        }
+        return fnName;
+    }
+
+    registerContractFunctionSignatures(_signatures: string[]): Promise<void> {
+        return Promise.resolve();
+    }
+
+    addContractClass(contractClass: ContractClassPublic): Promise<void> {
+        this.contractClasses.set(contractClass.id.toString(), contractClass);
+        return Promise.resolve();
+    }
+
+    addContractInstance(contractInstance: ContractInstanceWithAddress): Promise<void> {
+        this.contractInstances.set(contractInstance.address.toString(), contractInstance);
+        return Promise.resolve();
+    }
+
+    /**
+     * FIXME: This is temporary until we have a proper contract calss / instance mechanism in tests.
+     * Helper method for fuzzer: registers a contract with raw bytecode at a given address.
+     * Creates a minimal ContractClassPublic and ContractInstanceWithAddress.
+     * @param address - The contract address
+     * @param bytecode - The raw AVM bytecode
+     */
+    async addContractWithBytecode(address: AztecAddress, bytecode: Buffer): Promise<void> {
+        // Generate a deterministic class ID from the bytecode
+        const classId = Fr.fromBufferReduce(bytecode.subarray(0, 32));
+
+        // Create minimal ContractClassPublic
+        const contractClass: ContractClassPublic = {
+            id: classId,
+            version: 1 as const,
+            artifactHash: Fr.ZERO,
+            privateFunctionsRoot: Fr.ZERO,
+            privateFunctions: [],
+            utilityFunctions: [],
+            packedBytecode: bytecode,
+        };
+
+        // Create minimal ContractInstanceWithAddress
+        const contractInstance: ContractInstanceWithAddress = {
+            address,
+            version: 1 as const,
+            salt: Fr.ZERO,
+            deployer: address, // Use the contract address as deployer
+            currentContractClassId: classId,
+            originalContractClassId: classId,
+            initializationHash: Fr.ZERO,
+            publicKeys: PublicKeys.default(),
+        };
+
+        await this.addContractClass(contractClass);
+        await this.addContractInstance(contractInstance);
+    }
 }


### PR DESCRIPTION
This is a pretty sizeable PR that does 2 things: (1) Starts using world_state instantiated in cpp fuzzer within the ts simulator and (2) Sends a Tx and GlobalVariables instantiated in cpp fuzzer to ts simulator.

These changes enable the entrypoint for the ts simulator to be changed from `simulator.executeBytecode(bytecode);` to `publicTxSimulator.simulate(tx)`. This is more in-line with the long term vision for the fuzzer.

Finally there are changes to serialization/deserialization between cpp and TS, it now uses msg_pack

### Gotchas
#### World State
Unfortunately the way the WS is communicated is simply through opening the same DB files. Cpp is able to commit an initial (in future a possibly mutated) state which TS can then use. We cannot simply pass the references since these are different processes (unlike how we do it with NAPI for TS -> Cpp). We could possibly clean this up in futture.

#### Contracts DB
Still a wip, since we only have 1 enqueued call and 1 bytecode it's relatively easy for TS to just re-insert dummy contract classses into it's local `SimpleContractDataSource`. In future we need to communicate the instances and classes from Cpp to TS
