### PR TITLE
fix(avm): tag check shifts

### DIFF
--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/simulator.cpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/simulator.cpp
@@ -140,9 +140,16 @@ SimulatorResult CppSimulator::simulate(const std::vector<uint8_t>& bytecode, con
     TestSimulator simulator;
     TxSimulationResult result = simulator.simulate(bytecode, calldata);
     bool reverted = result.revert_code != RevertCode::OK;
-    auto output = result.call_stack_metadata.back().output;
-    vinfo("C++ Simulator result - reverted: ", reverted, ", output size: ", output.size());
-    return { .reverted = reverted, .output = output };
+    // Just process the top level call's output
+    vinfo(
+        "C++ Simulator result - reverted: ", reverted, ", output size: ", result.call_stack_metadata[0].output.size());
+    std::vector<FF> values = {};
+    if (result.call_stack_metadata.size() != 0) {
+        for (const auto& output : result.call_stack_metadata.at(0).output) {
+            values.push_back(output);
+        }
+    }
+    return { .reverted = reverted, .output = values };
 }
 
 JsSimulator* JsSimulator::instance = nullptr;

--- a/yarn-project/simulator/src/public/avm/opcodes/arithmetic.test.ts
+++ b/yarn-project/simulator/src/public/avm/opcodes/arithmetic.test.ts
@@ -479,6 +479,18 @@ describe('Arithmetic Instructions', () => {
       await new Shl(/*indirect=*/ 0, /*aOffset=*/ 20, /*bOffset=*/ 21, /*dstOffset=*/ 22).execute(context);
       expect(context.machineState.memory.get(22)).toEqual(new Uint32(0n));
     });
+
+    it('Should reject Field type for SHL', async () => {
+      const a = new Field(100n);
+      const b = new Field(2n);
+
+      context.machineState.memory.set(0, a);
+      context.machineState.memory.set(1, b);
+
+      await expect(
+        async () => await new Shl(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).execute(context),
+      ).rejects.toThrow(/expected integral/i);
+    });
   });
 
   describe('SHR huge shift amounts', () => {
@@ -566,6 +578,18 @@ describe('Arithmetic Instructions', () => {
       const expected = new Uint32(1n); // Only the MSB remains
       const actual = context.machineState.memory.get(2);
       expect(actual).toEqual(expected);
+    });
+
+    it('Should reject Field type for SHR', async () => {
+      const a = new Field(100n);
+      const b = new Field(2n);
+
+      context.machineState.memory.set(0, a);
+      context.machineState.memory.set(1, b);
+
+      await expect(
+        async () => await new Shr(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).execute(context),
+      ).rejects.toThrow(/expected integral/i);
     });
   });
 });

--- a/yarn-project/simulator/src/public/avm/opcodes/arithmetic.ts
+++ b/yarn-project/simulator/src/public/avm/opcodes/arithmetic.ts
@@ -105,6 +105,11 @@ export class Shl extends ThreeOperandArithmeticInstruction {
   protected override compute(a: IntegralValue, b: IntegralValue): IntegralValue {
     return a.shl(b);
   }
+
+  protected override checkTags(memory: TaggedMemoryInterface, aOffset: number, bOffset: number) {
+    memory.checkTagsAreSame(aOffset, bOffset);
+    TaggedMemory.checkIsIntegralTag(memory.getTag(aOffset)); // Follows that bOffset tag is also of integral type
+  }
 }
 
 export class Shr extends ThreeOperandArithmeticInstruction {
@@ -113,5 +118,10 @@ export class Shr extends ThreeOperandArithmeticInstruction {
 
   protected override compute(a: IntegralValue, b: IntegralValue): IntegralValue {
     return a.shr(b);
+  }
+
+  protected override checkTags(memory: TaggedMemoryInterface, aOffset: number, bOffset: number) {
+    memory.checkTagsAreSame(aOffset, bOffset);
+    TaggedMemory.checkIsIntegralTag(memory.getTag(aOffset)); // Follows that bOffset tag is also of integral type
   }
 }

--- a/yarn-project/simulator/src/public/public_tx_simulator/public_tx_simulator.ts
+++ b/yarn-project/simulator/src/public/public_tx_simulator/public_tx_simulator.ts
@@ -303,7 +303,7 @@ export class PublicTxSimulator implements PublicTxSimulatorInterface {
     );
 
     if (result.reverted) {
-      const culprit = `${contractAddress}:${callRequest.functionSelector}`;
+      const culprit = `${contractAddress}:${fnName}`;
       context.revert(phase, result.revertReason, culprit);
     }
 


### PR DESCRIPTION
We need to have a `checkIsIntegralTag` for shifts as `shl / shr` aren't defined on Field. There's a test also included