### PR TITLE
fix: publish deployment benchmark stats on test failure

### DIFF
--- a/.github/workflows/test-network-scenarios.yml
+++ b/.github/workflows/test-network-scenarios.yml
@@ -197,7 +197,7 @@ jobs:
       # Benchmarks
       #############
       - name: Download deploy benchmarks
-        if: (env.SEMVER != '' || env.DOCKER_IMAGE != '') && (steps.ci_cache.outputs.cache-hit != 'true' || github.event_name == 'workflow_dispatch')
+        if: always()
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -207,7 +207,7 @@ jobs:
           fi
 
       - name: Upload deploy benchmarks
-        if: env.ENABLE_DEPLOY_BENCH == '1'
+        if: always() && env.ENABLE_DEPLOY_BENCH == '1'
         uses: benchmark-action/github-action-benchmark@4de1bed97a47495fc4c5404952da0499e31f5c29
         with:
           name: CI Benchmarks

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -546,12 +546,14 @@ case "$cmd" in
   "ci-network-deploy")
     export CI=1
     build
-    spartan/bootstrap.sh network_deploy $NETWORK_ENV_FILE
+    deploy_exit_code=0
+    spartan/bootstrap.sh network_deploy $NETWORK_ENV_FILE || deploy_exit_code=$?
     # Merge and upload deploy benchmarks (deploy_network.sh writes to spartan/bench-out/)
     rm -rf bench-out
     mkdir -p bench-out
     bench_merge
     cache_upload deploy-bench-$(git rev-parse HEAD^{tree}).tar.gz bench-out/bench.json
+    exit $deploy_exit_code
     ;;
   "ci-network-tests")
     export CI=1


### PR DESCRIPTION
Ensure that deployment benchmark statistics gathered during test-network-scenarios.yml execution are always published