### PR TITLE
chore: use Pippenger for `batch_mul_native` 

### DIFF
--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/ipa/ipa.hpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/ipa/ipa.hpp
@@ -703,7 +703,7 @@ template <typename Curve_, size_t log_poly_length = CONST_ECCVM_LOG_N> class IPA
         if constexpr (Curve::is_stdlib_type) {
             shplonk_output_commitment = GroupElement::batch_mul(commitments, scalars);
         } else {
-            shplonk_output_commitment = batch_mul_native(commitments, scalars);
+            shplonk_output_commitment = batch_mul_native<Curve>(commitments, scalars);
         }
         // Output an opening claim, which in practice will be verified by the IPA opening protocol
         return { { shplonk_eval_challenge, Fr(0) }, shplonk_output_commitment };

--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/kzg/kzg.hpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/kzg/kzg.hpp
@@ -149,7 +149,7 @@ template <typename Curve_> class KZG {
                                           /*with_edgecases=*/true,
                                           /*masking_scalar=*/masking_challenge);
         } else {
-            P_0 = batch_mul_native(batch_opening_claim.commitments, batch_opening_claim.scalars);
+            P_0 = batch_mul_native<Curve>(batch_opening_claim.commitments, batch_opening_claim.scalars);
         }
         auto P_1 = -quotient_commitment;
 

--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/shplonk/shplemini.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/shplonk/shplemini.test.cpp
@@ -136,7 +136,7 @@ TYPED_TEST(ShpleminiTest, CorrectnessOfMultivariateClaimBatching)
         commitments, scalars, verifier_batched_evaluation, rho);
 
     // Final pairing check
-    GroupElement shplemini_result = batch_mul_native(commitments, scalars);
+    GroupElement shplemini_result = batch_mul_native<Curve>(commitments, scalars);
 
     EXPECT_EQ(commitments.size(),
               mock_claims.unshifted.commitments.size() + mock_claims.to_be_shifted.commitments.size());
@@ -250,7 +250,7 @@ TYPED_TEST(ShpleminiTest, CorrectnessOfGeminiClaimBatching)
                                                                 expected_constant_term_accumulator);
 
     // Compute the group element using the output of Shplemini method
-    GroupElement shplemini_result = batch_mul_native(commitments, scalars);
+    GroupElement shplemini_result = batch_mul_native<Curve>(commitments, scalars);
 
     EXPECT_EQ(shplemini_result, expected_result);
 }

--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/utils/batch_mul_native.hpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/utils/batch_mul_native.hpp
@@ -6,59 +6,48 @@
 
 #pragma once
 #include "barretenberg/common/ref_span.hpp"
+#include "barretenberg/ecc/curves/bn254/bn254.hpp"
+#include "barretenberg/ecc/curves/grumpkin/grumpkin.hpp"
+#include "barretenberg/ecc/scalar_multiplication/scalar_multiplication.hpp"
 #include "barretenberg/stdlib/primitives/biggroup/biggroup.hpp"
 #include <vector>
 
 namespace bb {
 
-// TODO(https://github.com/AztecProtocol/barretenberg/issues/1552): Optimize batch_mul_native
 /**
- * @brief Utility for native batch multiplication of group elements
- * @note This is used only for native verification and is not optimized for efficiency
+ * @brief Wrapper around Pippenger MSM for native batch multiplication
+ * @note Uses MSM::msm with handle_edge_cases=true for safe evaluation
  */
-template <typename Commitment, typename FF>
-static Commitment batch_mul_native(std::span<const Commitment> _points, std::span<const FF> _scalars)
+template <typename Curve>
+static typename Curve::AffineElement batch_mul_native(std::span<const typename Curve::AffineElement> _points,
+                                                      std::span<const typename Curve::ScalarField> _scalars)
 {
-    std::vector<Commitment> points;
-    std::vector<FF> scalars;
-    for (size_t i = 0; i < _points.size(); ++i) {
-        auto point = _points[i];
-        auto scalar = _scalars[i];
-
-        // TODO: Special handling of point at infinity here due to incorrect serialization.
-        if (!scalar.is_zero() && !point.is_point_at_infinity() && !point.y.is_zero()) {
-            points.emplace_back(point);
-            scalars.emplace_back(scalar);
-        }
-    }
-
-    if (points.empty()) {
-        return Commitment::infinity();
-    }
-
-    auto result = points[0] * scalars[0];
-    for (size_t idx = 1; idx < scalars.size(); ++idx) {
-        result = result + points[idx] * scalars[idx];
-    }
-    return result;
+    using FF = typename Curve::ScalarField;
+    // Copy scalars since MSM mutates them (converts from Montgomery form)
+    std::vector<FF> scalars(_scalars.begin(), _scalars.end());
+    PolynomialSpan<const FF> scalar_span(0, scalars);
+    return scalar_multiplication::MSM<Curve>::msm(_points, scalar_span, /*handle_edge_cases=*/true);
 }
 
 /**
- * @brief Wrapper for batch_mul_native that accepts vectors for backward compatibility
+ * @brief Wrapper that accepts vectors for backward compatibility
  */
-template <typename Commitment, typename FF>
-static Commitment batch_mul_native(const std::vector<Commitment>& _points, const std::vector<FF>& _scalars)
+template <typename Curve>
+static typename Curve::AffineElement batch_mul_native(const std::vector<typename Curve::AffineElement>& _points,
+                                                      const std::vector<typename Curve::ScalarField>& _scalars)
 {
-    return batch_mul_native<Commitment, FF>(std::span<const Commitment>(_points), std::span<const FF>(_scalars));
+    return batch_mul_native<Curve>(std::span<const typename Curve::AffineElement>(_points),
+                                   std::span<const typename Curve::ScalarField>(_scalars));
 }
 
 /**
- * @brief Wrapper for batch_mul_native that accepts span + vector (common pattern)
+ * @brief Wrapper that accepts span + vector (common pattern)
  */
-template <typename Commitment, typename FF>
-static Commitment batch_mul_native(std::span<const Commitment> _points, const std::vector<FF>& _scalars)
+template <typename Curve>
+static typename Curve::AffineElement batch_mul_native(std::span<const typename Curve::AffineElement> _points,
+                                                      const std::vector<typename Curve::ScalarField>& _scalars)
 {
-    return batch_mul_native<Commitment, FF>(_points, std::span<const FF>(_scalars));
+    return batch_mul_native<Curve>(_points, std::span<const typename Curve::ScalarField>(_scalars));
 }
 
 } // namespace bb

--- a/barretenberg/cpp/src/barretenberg/hypernova/hypernova_prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/hypernova/hypernova_prover.cpp
@@ -36,7 +36,7 @@ HypernovaFoldingProver::Commitment HypernovaFoldingProver::batch_mul(const RefAr
         points[idx++] = point;
     }
 
-    return batch_mul_native(points, scalars);
+    return batch_mul_native<MegaFlavor::Curve>(points, scalars);
 }
 
 HypernovaFoldingProver::Accumulator HypernovaFoldingProver::sumcheck_output_to_accumulator(

--- a/barretenberg/cpp/src/barretenberg/hypernova/hypernova_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/hypernova/hypernova_verifier.cpp
@@ -40,7 +40,7 @@ HypernovaFoldingVerifier<Flavor_>::Commitment HypernovaFoldingVerifier<Flavor_>:
     if constexpr (IsRecursiveFlavor<Flavor>) {
         return Curve::Group::batch_mul(points, scalars);
     } else {
-        return batch_mul_native(points, scalars);
+        return batch_mul_native<Curve>(points, scalars);
     }
 }
 

--- a/barretenberg/cpp/src/barretenberg/multilinear_batching/multilinear_batching_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/multilinear_batching/multilinear_batching_verifier.cpp
@@ -67,7 +67,7 @@ MultilinearBatchingVerifier<Flavor_>::Commitment MultilinearBatchingVerifier<Fla
     if constexpr (IsRecursiveFlavor<Flavor>) {
         return Curve::Group::batch_mul(points, scalars);
     } else {
-        return batch_mul_native(points, scalars);
+        return batch_mul_native<Curve>(points, scalars);
     }
 }
 

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/verifier.cpp
@@ -153,9 +153,9 @@ bool AvmVerifier::verify_proof(const HonkProof& proof, const std::vector<std::ve
 
     // Batch commitments: first commitment has coefficient 1, rest are batched with challenges
     Commitment squashed_unshifted =
-        unshifted_comms[0] + batch_mul_native(unshifted_comms.subspan(1), unshifted_challenges);
+        unshifted_comms[0] + batch_mul_native<Curve>(unshifted_comms.subspan(1), unshifted_challenges);
 
-    Commitment squashed_shifted = batch_mul_native(shifted_comms, shifted_challenges);
+    Commitment squashed_shifted = batch_mul_native<Curve>(shifted_comms, shifted_challenges);
 
     // Batch evaluations: compute inner product with first eval as initial value for unshifted
     FF squashed_unshifted_eval = std::inner_product(


### PR DESCRIPTION
We were using a naive `batch_mul_native` algorithm for native PCS verifications, and now in `MultiLinearBatchingVerifier`. 
This PR switches this method to be just a wrapper around the "safe" `pippenger` impl we already have. 