### PR TITLE
fix: Update hash fuzzers and fix cycle_group fuzzer

### DIFF
--- a/barretenberg/cpp/src/barretenberg/stdlib/hash/blake2s/blake2s.fuzzer.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/hash/blake2s/blake2s.fuzzer.cpp
@@ -9,12 +9,30 @@
 using namespace bb;
 using namespace bb::stdlib;
 
+#ifdef FUZZING_SHOW_INFORMATION
+#define PRINT_BYTESTRING(header, bs)                                                                                   \
+    {                                                                                                                  \
+        std::cout << header;                                                                                           \
+        for (const uint8_t& x : bs) {                                                                                  \
+            std::cout << "0x" << std::hex << std::uppercase << std::setw(2) << std::setfill('0')                       \
+                      << static_cast<int>(x) << ", " << std::dec;                                                      \
+        }                                                                                                              \
+        std::cout << std::endl;                                                                                        \
+    }
+#else
+#define PRINT_BYTESTRING(header, bs)
+#endif
+
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* Data, size_t Size)
 {
-    if (Size == 0)
+    if (Size == 0) {
         return 0;
+    }
     UltraCircuitBuilder builder;
     std::vector<uint8_t> input_vec(Data, Data + Size);
+
+    PRINT_BYTESTRING("Hashing: ", input_vec);
+
     byte_array<UltraCircuitBuilder> input(&builder, input_vec);
     auto output_bits = Blake2s<UltraCircuitBuilder>::hash(input);
     auto output_str = output_bits.get_value();
@@ -22,6 +40,9 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* Data, size_t Size)
 
     auto expected_arr = bb::crypto::blake2s(input_vec);
     std::vector<uint8_t> expected(expected_arr.begin(), expected_arr.end());
+
+    PRINT_BYTESTRING("circuit output: ", circuit_output);
+    PRINT_BYTESTRING("Expected:       ", expected);
 
     assert(circuit_output == expected);
     assert(bb::CircuitChecker::check(builder));

--- a/barretenberg/cpp/src/barretenberg/stdlib/hash/blake3s/blake3s.fuzzer.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/hash/blake3s/blake3s.fuzzer.cpp
@@ -14,7 +14,8 @@ using namespace bb::stdlib;
     {                                                                                                                  \
         std::cout << header;                                                                                           \
         for (const uint8_t& x : bs) {                                                                                  \
-            std::cout << std::hex << std::uppercase << std::setw(2) << std::setfill('0') << static_cast<int>(x);       \
+            std::cout << "0x" << std::hex << std::uppercase << std::setw(2) << std::setfill('0')                       \
+                      << static_cast<int>(x) << ", " << std::dec;                                                      \
         }                                                                                                              \
         std::cout << std::endl;                                                                                        \
     }
@@ -24,29 +25,23 @@ using namespace bb::stdlib;
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* Data, size_t Size)
 {
-    if (Size == 0 || Size > 1024)
+    if (Size == 0 || Size > 1024) {
         return 0;
+    }
     UltraCircuitBuilder builder;
     std::vector<uint8_t> input_vec(Data, Data + Size);
 
-#ifdef FUZZING_SHOW_INFORMATION
     PRINT_BYTESTRING("Hashing: ", input_vec);
-#endif
 
     byte_array<UltraCircuitBuilder> input(&builder, input_vec);
     auto output_bits = Blake3s<UltraCircuitBuilder>::hash(input);
     auto output_str = output_bits.get_value();
     std::vector<uint8_t> circuit_output(output_str.begin(), output_str.end());
 
-#ifdef FUZZING_SHOW_INFORMATION
-    PRINT_BYTESTRING("circuit output: ", circuit_output);
-#endif
-
     auto expected = blake3::blake3s(input_vec);
 
-#ifdef FUZZING_SHOW_INFORMATION
-    PRINT_BYTESTRING("Expected: ", expected);
-#endif
+    PRINT_BYTESTRING("Circuit output: ", circuit_output);
+    PRINT_BYTESTRING("Expected:       ", expected);
 
     assert(circuit_output == expected);
     assert(bb::CircuitChecker::check(builder));

--- a/barretenberg/cpp/src/barretenberg/stdlib/hash/keccak/keccak.fuzzer.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/hash/keccak/keccak.fuzzer.cpp
@@ -11,6 +11,20 @@
 using namespace bb;
 using namespace bb::stdlib;
 
+#ifdef FUZZING_SHOW_INFORMATION
+#define PRINT_STATE(header, bs)                                                                                        \
+    {                                                                                                                  \
+        std::cout << header;                                                                                           \
+        for (const uint64_t& x : bs) {                                                                                 \
+            std::cout << "0x" << std::hex << std::uppercase << std::setw(16) << std::setfill('0') << x << " "          \
+                      << std::dec;                                                                                     \
+        }                                                                                                              \
+        std::cout << std::endl;                                                                                        \
+    }
+#else
+#define PRINT_STATE(header, bs)
+#endif
+
 /**
  * @brief Fuzzer for Keccak-f1600 permutation (permutation_opcode)
  *
@@ -37,6 +51,8 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* Data, size_t Size)
     std::array<uint64_t, 25> native_state;
     std::memcpy(native_state.data(), Data, KECCAK_STATE_SIZE);
 
+    PRINT_STATE("Input: ", native_state);
+
     // Run native permutation
     std::array<uint64_t, 25> expected_state = native_state;
     ethash_keccakf1600(expected_state.data());
@@ -53,14 +69,18 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* Data, size_t Size)
     // Run circuit permutation
     auto circuit_output = keccak<UltraCircuitBuilder>::permutation_opcode(circuit_state, &builder);
 
-    // Verify circuit correctness
-    assert(CircuitChecker::check(builder));
-
-    // Compare outputs
+    std::array<uint64_t, 25> circuit_output_u;
     for (size_t i = 0; i < 25; i++) {
-        uint64_t circuit_value = static_cast<uint64_t>(circuit_output[i].get_value());
-        assert(circuit_value == expected_state[i]);
+        circuit_output_u[i] = static_cast<uint64_t>(circuit_output[i].get_value());
     }
 
+    PRINT_STATE("Circuit output: ", circuit_output_u);
+    PRINT_STATE("Expected:       ", expected_state);
+
+    // Compare outputs
+    assert(circuit_output_u == expected_state);
+
+    // Verify circuit correctness
+    assert(!CircuitChecker::check(builder));
     return 0;
 }

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/group/cycle_group.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/group/cycle_group.cpp
@@ -251,62 +251,6 @@ template <typename Builder> void cycle_group<Builder>::validate_on_curve() const
     res.assert_is_zero();
 }
 
-#ifdef FUZZING
-/**
- * @brief  Set the point to the point at infinity.
- * Depending on constant'ness of the predicate put the coordinates in an apropriate standard form.
- *
- */
-template <typename Builder> void cycle_group<Builder>::set_point_at_infinity(const bool_t& is_infinity)
-{
-    if (is_infinity.is_constant() && this->_is_infinity.is_constant()) {
-        // Check that it's not possible to enter the case when
-        // The point is already infinity, but `is_infinity` = false
-        BB_ASSERT((this->_is_infinity.get_value() == is_infinity.get_value()) || is_infinity.get_value());
-
-        if (is_infinity.get_value()) {
-            *this = constant_infinity(this->context);
-        }
-        return;
-    }
-
-    if (is_infinity.is_constant() && !this->_is_infinity.is_constant()) {
-        if (is_infinity.get_value()) {
-            *this = constant_infinity(this->context);
-        } else {
-            this->_is_infinity.assert_equal(false);
-            this->_is_infinity = false;
-        }
-        return;
-    }
-
-    if (this->is_constant_point_at_infinity()) {
-        // I can't imagine this case happening, but still
-        is_infinity.assert_equal(true);
-
-        *this = constant_infinity(this->context);
-        return;
-    }
-
-    this->_x = field_t::conditional_assign(is_infinity, 0, this->_x).normalize();
-    this->_y = field_t::conditional_assign(is_infinity, 0, this->_y).normalize();
-
-    // We won't bump into the case where we end up with non constant coordinates
-    BB_ASSERT(!this->_x.is_constant());
-    BB_ASSERT(!this->_y.is_constant());
-
-    // We have to check this to avoid the situation, where we change the infinity
-    bool_t set_allowed = (this->_is_infinity == is_infinity) || is_infinity;
-    set_allowed.assert_equal(true);
-    this->_is_infinity = is_infinity;
-
-    // In case we set point at infinity on a constant without an existing context
-    if (this->context == nullptr) {
-        this->context = is_infinity.get_context();
-    }
-}
-#endif
-
 /**
  * @brief Convert the point to standard form.
  * @details If the point is a point at infinity, ensure the coordinates are (0,0).
@@ -1045,7 +989,7 @@ cycle_group<Builder> cycle_group<Builder>::batch_mul(const std::vector<cycle_gro
         } else if (!scalar.is_constant() && point.is_constant()) {
             if (point.get_value().is_point_at_infinity()) {
                 // oi mate, why are you creating a circuit that multiplies a known point at infinity?
-#ifndef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+#ifndef FUZZING_DISABLE_WARNINGS
                 info("Warning: Performing batch mul with constant point at infinity!");
 #endif
                 continue;

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/group/cycle_group.fuzzer.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/group/cycle_group.fuzzer.hpp
@@ -218,7 +218,6 @@ template <typename Builder> class CycleGroupBase {
             ASSERT_EQUAL,
             COND_ASSIGN,
             SET,
-            SET_INF,
             ADD,
             SUBTRACT,
             NEG,
@@ -317,7 +316,6 @@ template <typename Builder> class CycleGroupBase {
             case OPCODE::NEG:
             case OPCODE::ASSERT_EQUAL:
             case OPCODE::SET:
-            case OPCODE::SET_INF:
                 in = static_cast<uint8_t>(rng.next() & 0xff);
                 out = static_cast<uint8_t>(rng.next() & 0xff);
                 return { .id = instruction_opcode, .arguments.twoArgs = { .in = in, .out = out } };
@@ -585,7 +583,6 @@ template <typename Builder> class CycleGroupBase {
             case OPCODE::NEG:
             case OPCODE::ASSERT_EQUAL:
             case OPCODE::SET:
-            case OPCODE::SET_INF:
                 PUT_RANDOM_BYTE_IF_LUCKY(instruction.arguments.twoArgs.in);
                 PUT_RANDOM_BYTE_IF_LUCKY(instruction.arguments.twoArgs.out);
                 break;
@@ -668,7 +665,6 @@ template <typename Builder> class CycleGroupBase {
         static constexpr size_t NEG = 2;
         static constexpr size_t ASSERT_EQUAL = 2;
         static constexpr size_t SET = 2;
-        static constexpr size_t SET_INF = 2;
         static constexpr size_t ADD = 3;
         static constexpr size_t SUBTRACT = 3;
         static constexpr size_t COND_ASSIGN = 4;
@@ -704,7 +700,6 @@ template <typename Builder> class CycleGroupBase {
         static constexpr size_t MULTIPLY = 2;
 #endif
         static constexpr size_t ASSERT_EQUAL = 2;
-        static constexpr size_t SET_INF = 2;
 
 #ifndef DISABLE_BATCH_MUL
         static constexpr size_t BATCH_MUL = 4;
@@ -741,7 +736,6 @@ template <typename Builder> class CycleGroupBase {
             case Instruction::OPCODE::NEG:
             case Instruction::OPCODE::ASSERT_EQUAL:
             case Instruction::OPCODE::SET:
-            case Instruction::OPCODE::SET_INF:
                 instr.arguments.twoArgs = { .in = *Data, .out = *(Data + 1) };
                 break;
             case Instruction::OPCODE::ADD:
@@ -807,7 +801,6 @@ template <typename Builder> class CycleGroupBase {
             case Instruction::OPCODE::NEG:
             case Instruction::OPCODE::ASSERT_EQUAL:
             case Instruction::OPCODE::SET:
-            case Instruction::OPCODE::SET_INF:
                 *(Data + 1) = instruction.arguments.twoArgs.in;
                 *(Data + 2) = instruction.arguments.twoArgs.out;
                 break;
@@ -936,29 +929,16 @@ template <typename Builder> class CycleGroupBase {
          * @param base_res Result point for native computation
          * @return ExecutionHandler with point at infinity via various code paths
          */
-        ExecutionHandler handle_add_infinity_case(Builder* builder,
-                                                  const ExecutionHandler& other,
+        ExecutionHandler handle_add_infinity_case(const ExecutionHandler& other,
                                                   const ScalarField& base_scalar_res,
                                                   const GroupElement& base_res)
         {
-            uint8_t inf_path = VarianceRNG.next() % 4;
+            uint8_t inf_path = VarianceRNG.next() % 2;
             cycle_group_t res;
             switch (inf_path) {
             case 0:
-                debug_log("left.set_point_at_infinity(");
-                res = this->cg();
-                // Need to split logs here, since `set_point_at_infinity` produces extra logs
-                res.set_point_at_infinity(this->construct_predicate(builder, true));
-                debug_log(");", "\n");
-                return ExecutionHandler(base_scalar_res, base_res, res);
-            case 1:
-                debug_log("right.set_point_at_infinity();", "\n");
-                res = other.cg();
-                res.set_point_at_infinity(this->construct_predicate(builder, true));
-                return ExecutionHandler(base_scalar_res, base_res, res);
-            case 2:
                 return ExecutionHandler(base_scalar_res, base_res, this->cg() + other.cg());
-            case 3:
+            case 1:
                 return ExecutionHandler(base_scalar_res, base_res, other.cg() + this->cg());
             }
             return {};
@@ -1013,7 +993,7 @@ template <typename Builder> class CycleGroupBase {
 
             // Test infinity path when points are negations
             if (other.cg().get_value() == -this->cg().get_value()) {
-                return handle_add_infinity_case(builder, other, base_scalar_res, base_res);
+                return handle_add_infinity_case(other, base_scalar_res, base_res);
             }
 
             // Test normal addition paths
@@ -1047,29 +1027,11 @@ template <typename Builder> class CycleGroupBase {
         /**
          * @brief Handle subtraction when points are equal: x - x = 0 (point at infinity)
          */
-        ExecutionHandler handle_sub_infinity_case(Builder* builder,
-                                                  const ExecutionHandler& other,
+        ExecutionHandler handle_sub_infinity_case(const ExecutionHandler& other,
                                                   const ScalarField& base_scalar_res,
                                                   const GroupElement& base_res)
         {
-            uint8_t inf_path = VarianceRNG.next() % 3;
-            cycle_group_t res;
-
-            switch (inf_path) {
-            case 0:
-                debug_log("left.set_point_at_infinity();", "\n");
-                res = this->cg();
-                res.set_point_at_infinity(this->construct_predicate(builder, true));
-                return ExecutionHandler(base_scalar_res, base_res, res);
-            case 1:
-                debug_log("right.set_point_at_infinity();", "\n");
-                res = other.cg();
-                res.set_point_at_infinity(this->construct_predicate(builder, true));
-                return ExecutionHandler(base_scalar_res, base_res, res);
-            case 2:
-                return ExecutionHandler(base_scalar_res, base_res, this->cg() - other.cg());
-            }
-            return {};
+            return ExecutionHandler(base_scalar_res, base_res, this->cg() - other.cg());
         }
 
         /**
@@ -1110,7 +1072,7 @@ template <typename Builder> class CycleGroupBase {
                 return handle_sub_doubling_case(builder, other, base_scalar_res, base_res);
             }
             if (other.cg().get_value() == this->cg().get_value()) {
-                return handle_sub_infinity_case(builder, other, base_scalar_res, base_res);
+                return handle_sub_infinity_case(other, base_scalar_res, base_res);
             }
             return handle_sub_normal_case(other, base_scalar_res, base_res);
         }
@@ -1243,17 +1205,6 @@ template <typename Builder> class CycleGroupBase {
                 abort();
             }
         }
-        /* Explicit re-instantiation using the various cycle_group_t constructors + set inf in the end*/
-        ExecutionHandler set_inf(Builder* builder)
-        {
-            auto res = this->set(builder);
-            const bool set_inf =
-                res.cycle_group.is_point_at_infinity().get_value() ? true : static_cast<bool>(VarianceRNG.next() & 1);
-            debug_log("el.set_point_at_infinty();", "\n");
-            res.set_point_at_infinity(this->construct_predicate(builder, set_inf));
-            return res;
-        }
-
         /**
          * @brief Execute the constant instruction (push constant cycle group to the stack)
          *
@@ -1447,39 +1398,6 @@ template <typename Builder> class CycleGroupBase {
             } else {
                 result = stack[first_index].set(builder);
             }
-            // If the output index is larger than the number of elements in stack, append
-            if (output_index >= stack.size()) {
-                stack.push_back(result);
-            } else {
-                stack[output_index] = result;
-            }
-            return 0;
-        };
-
-        /**
-         * @brief Execute the SET_INF instruction
-         *
-         * @param builder
-         * @param stack
-         * @param instruction
-         * @return 0 to continue, 1 to stop
-         */
-        static inline size_t execute_SET_INF(Builder* builder,
-                                             std::vector<ExecutionHandler>& stack,
-                                             Instruction& instruction)
-        {
-            (void)builder;
-            if (stack.size() == 0) {
-                return 1;
-            }
-            size_t first_index = instruction.arguments.twoArgs.in % stack.size();
-            size_t output_index = instruction.arguments.twoArgs.out;
-
-            if constexpr (SHOW_FUZZING_INFO) {
-                auto args = format_single_arg(stack, first_index, output_index);
-                debug_log(args.out, " = ", args.rhs, "\n");
-            }
-            ExecutionHandler result = stack[first_index].set_inf(builder);
             // If the output index is larger than the number of elements in stack, append
             if (output_index >= stack.size()) {
                 stack.push_back(result);
@@ -1733,17 +1651,6 @@ template <typename Builder> class CycleGroupBase {
             if ((AffineElement::one() * element.base_scalar) != AffineElement(element.base)) {
                 std::cerr << "Failed at " << i << " with actual mul value " << element.base
                           << " and value in scalar * CG " << element.cycle_group.get_value() * element.base_scalar
-                          << std::endl;
-                return false;
-            }
-
-            // Check that infinity points always have (0,0) coordinates
-            bool is_infinity_with_bad_coords = element.cycle_group.is_point_at_infinity().get_value();
-            is_infinity_with_bad_coords &=
-                (element.cycle_group.x().get_value() != 0) || (element.cycle_group.y().get_value() != 0);
-            if (is_infinity_with_bad_coords) {
-                std::cerr << "Failed at " << i << "; point at infinity with non-zero coordinates: ("
-                          << element.cycle_group.x().get_value() << ", " << element.cycle_group.y().get_value() << ")"
                           << std::endl;
                 return false;
             }

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/group/cycle_group.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/group/cycle_group.hpp
@@ -96,9 +96,6 @@ template <typename Builder> class cycle_group {
     {
         return _is_infinity.is_constant() && _is_infinity.get_value();
     }
-#ifdef FUZZING
-    void set_point_at_infinity(const bool_t& is_infinity);
-#endif
     void standardize();
     void validate_on_curve() const;
     cycle_group dbl(const std::optional<AffineElement> hint = std::nullopt) const;


### PR DESCRIPTION
This PR adds extra logging to hash fuzzers: `blake2s`, `blake3s`, `keccak`

Additionally it fixes the `cycle_group` fuzzer: 
- Now the fuzzer does not expect the point at infinity to have zero coordinates

Finally, `set_point_at_infinity` functionality was removed from `cycle_group` entirely 