### PR TITLE
feat: world state advances l1-l2 message tree per checkpoint

### DIFF
--- a/yarn-project/archiver/src/archiver/archiver.ts
+++ b/yarn-project/archiver/src/archiver/archiver.ts
@@ -1162,6 +1162,11 @@ export class Archiver extends (EventEmitter as new () => ArchiverEmitter) implem
     return blocks.map(b => b.toPublishedCheckpoint());
   }
 
+  public async getCheckpointByArchive(archive: Fr): Promise<Checkpoint | undefined> {
+    // TODO: Implement this properly. This only works when we have one block per checkpoint.
+    return (await this.getPublishedBlockByArchive(archive))?.block.toCheckpoint();
+  }
+
   public async getCheckpoints(from: CheckpointNumber, limit: number, proven?: boolean): Promise<Checkpoint[]> {
     const published = await this.getPublishedCheckpoints(from, limit, proven);
     return published.map(p => p.checkpoint);

--- a/yarn-project/archiver/src/test/mock_archiver.ts
+++ b/yarn-project/archiver/src/test/mock_archiver.ts
@@ -1,6 +1,7 @@
 import type { CheckpointNumber } from '@aztec/foundation/branded-types';
 import type { Fr } from '@aztec/foundation/fields';
-import type { L2Block, L2BlockSource } from '@aztec/stdlib/block';
+import { L2Block, type L2BlockSource } from '@aztec/stdlib/block';
+import type { Checkpoint } from '@aztec/stdlib/checkpoint';
 import type { L1ToL2MessageSource } from '@aztec/stdlib/messaging';
 
 import { MockL1ToL2MessageSource } from './mock_l1_to_l2_message_source.js';
@@ -34,30 +35,34 @@ export class MockArchiver extends MockL2BlockSource implements L2BlockSource, L1
  * A mocked implementation of the archiver with a set of precomputed blocks and messages.
  */
 export class MockPrefilledArchiver extends MockArchiver {
-  private precomputed: L2Block[];
+  private prefilled: Checkpoint[] = [];
 
-  constructor(precomputed: L2Block[], messages: Fr[][]) {
+  constructor(prefilled: { checkpoint: Checkpoint; messages: Fr[] }[]) {
     super();
-    this.precomputed = precomputed.slice();
-    messages.forEach((msgs, i) => this.setL1ToL2Messages(i + 1, msgs));
+    this.setPrefilled(prefilled);
   }
 
-  public setPrefilledBlocks(blocks: L2Block[], messages: Fr[][]) {
-    for (const block of blocks) {
-      this.precomputed[block.number - 1] = block;
+  public setPrefilled(prefilled: { checkpoint: Checkpoint; messages: Fr[] }[]) {
+    for (const { checkpoint, messages } of prefilled) {
+      this.prefilled[checkpoint.number - 1] = checkpoint;
+      if (checkpoint.blocks.length !== 1) {
+        throw new Error('Prefilled checkpoint must only have 1 block at the moment.');
+      }
+      this.setL1ToL2Messages(checkpoint.blocks[0].number, messages);
     }
-    messages.forEach((msgs, i) => this.setL1ToL2Messages(blocks[i].number, msgs));
   }
 
   public override createBlocks(numBlocks: number) {
-    if (this.l2Blocks.length + numBlocks > this.precomputed.length) {
+    const flattenedBlocks = this.prefilled.flatMap(c => c.blocks);
+    if (this.l2Blocks.length + numBlocks > flattenedBlocks.length) {
       throw new Error(
         `Not enough precomputed blocks to create ${numBlocks} more blocks (already at ${this.l2Blocks.length})`,
       );
     }
 
     const fromBlock = this.l2Blocks.length;
-    this.addBlocks(this.precomputed.slice(fromBlock, fromBlock + numBlocks));
+    // TODO: Add L2 blocks and checkpoints separately once archiver has the apis for that.
+    this.addBlocks(this.prefilled.slice(fromBlock, fromBlock + numBlocks).map(c => L2Block.fromCheckpoint(c)));
     return Promise.resolve();
   }
 }

--- a/yarn-project/archiver/src/test/mock_l2_block_source.ts
+++ b/yarn-project/archiver/src/test/mock_l2_block_source.ts
@@ -1,6 +1,6 @@
 import { GENESIS_ARCHIVE_ROOT } from '@aztec/constants';
 import { DefaultL1ContractsConfig } from '@aztec/ethereum';
-import { BlockNumber, EpochNumber, SlotNumber } from '@aztec/foundation/branded-types';
+import { BlockNumber, CheckpointNumber, EpochNumber, SlotNumber } from '@aztec/foundation/branded-types';
 import { Buffer32 } from '@aztec/foundation/buffer';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { Fr } from '@aztec/foundation/fields';
@@ -114,9 +114,14 @@ export class MockL2BlockSource implements L2BlockSource, ContractDataSource {
     );
   }
 
-  public async getPublishedCheckpoints(from: number, limit: number) {
+  public async getPublishedCheckpoints(from: CheckpointNumber, limit: number) {
     // TODO: Implement this properly. This only works when we have one block per checkpoint.
     return (await this.getPublishedBlocks(from, limit)).map(block => block.toPublishedCheckpoint());
+  }
+
+  public async getCheckpointByArchive(archive: Fr): Promise<Checkpoint | undefined> {
+    // TODO: Implement this properly. This only works when we have one block per checkpoint.
+    return (await this.getPublishedBlockByArchive(archive))?.block.toCheckpoint();
   }
 
   public async getPublishedBlocks(from: number, limit: number, proven?: boolean) {

--- a/yarn-project/end-to-end/src/spartan/gating-passive.test.ts
+++ b/yarn-project/end-to-end/src/spartan/gating-passive.test.ts
@@ -1,6 +1,7 @@
 import { createAztecNodeClient } from '@aztec/aztec.js/node';
 import { RollupCheatCodes } from '@aztec/aztec/testing';
 import { EthCheatCodesWithState } from '@aztec/ethereum/test';
+import { CheckpointNumber } from '@aztec/foundation/branded-types';
 import { createLogger } from '@aztec/foundation/log';
 import { DateProvider } from '@aztec/foundation/timer';
 
@@ -12,7 +13,7 @@ import {
   applyBootNodeFailure,
   applyNetworkShaping,
   applyValidatorKill,
-  awaitL2BlockNumber,
+  awaitCheckpointNumber,
   getGitProjectRoot,
   installTransferBot,
   restartBot,
@@ -131,11 +132,16 @@ describe('a test that passively observes the network in the presence of network 
 
     await restartBot(NAMESPACE, debugLogger);
 
-    // wait for the chain to build at least 1 epoch's worth of blocks
-    // note, don't forget that normally an epoch doesn't need epochDuration worth of blocks,
+    // wait for the chain to build at least 1 epoch's worth of checkpoints
+    // note, don't forget that normally an epoch doesn't need epochDuration worth of checkpoints,
     // but here we do double duty:
-    // we want a handful of blocks, and we want to pass the epoch boundary
-    await awaitL2BlockNumber(rollupCheatCodes, BigInt(epochDuration) * BigInt(slotDuration), 60 * 6, debugLogger);
+    // we want a handful of checkpoints, and we want to pass the epoch boundary
+    await awaitCheckpointNumber(
+      rollupCheatCodes,
+      CheckpointNumber.fromBigInt(epochDuration * BigInt(slotDuration)),
+      60 * 6,
+      debugLogger,
+    );
 
     let deploymentOutput: string = '';
     deploymentOutput = await applyNetworkShaping({
@@ -163,15 +169,20 @@ describe('a test that passively observes the network in the presence of network 
         logger: debugLogger,
       });
       debugLogger.info(deploymentOutput);
-      debugLogger.info(`Waiting for chain to progress by at least 1 block`);
+      debugLogger.info(`Waiting for chain to progress by at least 1 checkpoint`);
       const controlTips = await rollupCheatCodes.getTips();
       const timeoutSeconds = Math.ceil(Number(BigInt(epochDuration) * BigInt(slotDuration)) * 2);
-      await awaitL2BlockNumber(rollupCheatCodes, controlTips.pending + 1n, timeoutSeconds, debugLogger);
+      await awaitCheckpointNumber(
+        rollupCheatCodes,
+        CheckpointNumber(controlTips.pending + 1),
+        timeoutSeconds,
+        debugLogger,
+      );
       const newTips = await rollupCheatCodes.getTips();
 
       // calculate the percentage of slots missed for debugging purposes
-      const perfectPending = controlTips.pending + BigInt(Math.floor(Number(epochDuration)));
-      const missedSlots = Number(perfectPending) - Number(newTips.pending);
+      const perfectPending = CheckpointNumber(controlTips.pending + Math.floor(Number(epochDuration)));
+      const missedSlots = perfectPending - newTips.pending;
       const missedSlotsPercentage = (missedSlots / Number(epochDuration)) * 100;
       debugLogger.info(`Missed ${missedSlots} slots, ${missedSlotsPercentage.toFixed(2)}%`);
 

--- a/yarn-project/end-to-end/src/spartan/utils.ts
+++ b/yarn-project/end-to-end/src/spartan/utils.ts
@@ -1,6 +1,7 @@
 import { createLogger } from '@aztec/aztec.js/log';
 import type { RollupCheatCodes } from '@aztec/aztec/testing';
 import type { L1ContractAddresses, ViemPublicClient } from '@aztec/ethereum';
+import type { CheckpointNumber } from '@aztec/foundation/branded-types';
 import type { Logger } from '@aztec/foundation/log';
 import { promiseWithResolvers } from '@aztec/foundation/promise';
 import { makeBackoff, retry } from '@aztec/foundation/retry';
@@ -531,24 +532,24 @@ export function applyNetworkShaping({
   });
 }
 
-export async function awaitL2BlockNumber(
+export async function awaitCheckpointNumber(
   rollupCheatCodes: RollupCheatCodes,
-  blockNumber: bigint,
+  checkpointNumber: CheckpointNumber,
   timeoutSeconds: number,
   logger: Logger,
 ) {
-  logger.info(`Waiting for L2 Block ${blockNumber}`);
+  logger.info(`Waiting for checkpoint ${checkpointNumber}`);
   let tips = await rollupCheatCodes.getTips();
   const endTime = Date.now() + timeoutSeconds * 1000;
-  while (tips.pending < blockNumber && Date.now() < endTime) {
-    logger.info(`At L2 Block ${tips.pending}`);
+  while (tips.pending < checkpointNumber && Date.now() < endTime) {
+    logger.info(`At checkpoint ${tips.pending}`);
     await sleep(1000);
     tips = await rollupCheatCodes.getTips();
   }
-  if (tips.pending < blockNumber) {
-    throw new Error(`Timeout waiting for L2 Block ${blockNumber}, only reached ${tips.pending}`);
+  if (tips.pending < checkpointNumber) {
+    throw new Error(`Timeout waiting for checkpoint ${checkpointNumber}, only reached ${tips.pending}`);
   } else {
-    logger.info(`Reached L2 Block ${tips.pending}`);
+    logger.info(`Reached checkpoint ${tips.pending}`);
   }
 }
 

--- a/yarn-project/ethereum/src/contracts/rollup.ts
+++ b/yarn-project/ethereum/src/contracts/rollup.ts
@@ -420,8 +420,12 @@ export class RollupContract {
     return this.rollup.read.getCheckpoint([BigInt(checkpointNumber)]);
   }
 
-  getTips() {
-    return this.rollup.read.getTips();
+  async getTips(): Promise<{ pending: CheckpointNumber; proven: CheckpointNumber }> {
+    const { pending, proven } = await this.rollup.read.getTips();
+    return {
+      pending: CheckpointNumber.fromBigInt(pending),
+      proven: CheckpointNumber.fromBigInt(proven),
+    };
   }
 
   getTimestampForSlot(slot: SlotNumber) {

--- a/yarn-project/ethereum/src/test/rollup_cheat_codes.ts
+++ b/yarn-project/ethereum/src/test/rollup_cheat_codes.ts
@@ -1,6 +1,6 @@
 import { RollupContract, type ViemPublicClient } from '@aztec/ethereum';
 import type { L1ContractAddresses } from '@aztec/ethereum/l1-contract-addresses';
-import { EpochNumber, SlotNumber } from '@aztec/foundation/branded-types';
+import { CheckpointNumber, EpochNumber, SlotNumber } from '@aztec/foundation/branded-types';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { createLogger } from '@aztec/foundation/log';
 import type { DateProvider } from '@aztec/foundation/timer';
@@ -66,10 +66,14 @@ export class RollupCheatCodes {
    * @returns The pending and proven chain tips
    */
   public async getTips(): Promise<{
-    /** The pending chain tip */ pending: bigint;
-    /** The proven chain tip */ proven: bigint;
+    /** The pending chain tip */ pending: CheckpointNumber;
+    /** The proven chain tip */ proven: CheckpointNumber;
   }> {
-    return await this.rollup.read.getTips();
+    const { pending, proven } = await this.rollup.read.getTips();
+    return {
+      pending: CheckpointNumber.fromBigInt(pending),
+      proven: CheckpointNumber.fromBigInt(proven),
+    };
   }
 
   /**

--- a/yarn-project/prover-node/src/prover-node-publisher.test.ts
+++ b/yarn-project/prover-node/src/prover-node-publisher.test.ts
@@ -54,30 +54,30 @@ describe('prover-node-publisher', () => {
 
   const testCases = [
     // Usual case of proving full epoch
-    { pending: 65n, proven: 32n, fromCheckpoint: 33, toCheckpoint: 64, expectedPublish: true, message: '' },
+    { pending: 65, proven: 32, fromCheckpoint: 33, toCheckpoint: 64, expectedPublish: true, message: '' },
     // Failure case of proving beyond the pending chain
     {
-      pending: 65n,
-      proven: 32n,
+      pending: 65,
+      proven: 32,
       fromCheckpoint: 33,
       toCheckpoint: 66,
       expectedPublish: false,
       message: 'Cannot submit epoch proof for 33-66 as pending checkpoint is 65',
     },
     // Some successful partial epochs
-    { pending: 33n, proven: 32n, fromCheckpoint: 33, toCheckpoint: 33, expectedPublish: true, message: '' },
-    { pending: 65n, proven: 32n, fromCheckpoint: 33, toCheckpoint: 38, expectedPublish: true, message: '' },
-    { pending: 40n, proven: 32n, fromCheckpoint: 33, toCheckpoint: 33, expectedPublish: true, message: '' },
+    { pending: 33, proven: 32, fromCheckpoint: 33, toCheckpoint: 33, expectedPublish: true, message: '' },
+    { pending: 65, proven: 32, fromCheckpoint: 33, toCheckpoint: 38, expectedPublish: true, message: '' },
+    { pending: 40, proven: 32, fromCheckpoint: 33, toCheckpoint: 33, expectedPublish: true, message: '' },
 
     // Somebody else proved the entire epoch already
 
     // We try and prove the full epoch - succeeds
-    { pending: 65n, proven: 64n, fromCheckpoint: 33, toCheckpoint: 64, expectedPublish: true, message: '' },
+    { pending: 65, proven: 64, fromCheckpoint: 33, toCheckpoint: 64, expectedPublish: true, message: '' },
 
     // We try and prove a partial epoch that falls short of the end - fails as pointless to publish
     {
-      pending: 65n,
-      proven: 64n,
+      pending: 65,
+      proven: 64,
       fromCheckpoint: 33,
       toCheckpoint: 35,
       expectedPublish: false,
@@ -87,24 +87,24 @@ describe('prover-node-publisher', () => {
     // Somebody else partially proved the epoch already
 
     // We try and prove the rest of the epoch - succeeds
-    { pending: 65n, proven: 40n, fromCheckpoint: 41, toCheckpoint: 64, expectedPublish: true, message: '' },
+    { pending: 65, proven: 40, fromCheckpoint: 41, toCheckpoint: 64, expectedPublish: true, message: '' },
 
     // We try and prove all of the epoch - succeeds
-    { pending: 65n, proven: 40n, fromCheckpoint: 33, toCheckpoint: 64, expectedPublish: true, message: '' },
+    { pending: 65, proven: 40, fromCheckpoint: 33, toCheckpoint: 64, expectedPublish: true, message: '' },
 
     // We try and partially prove the epoch after their proof - succeeds again
-    { pending: 65n, proven: 40n, fromCheckpoint: 41, toCheckpoint: 45, expectedPublish: true, message: '' },
+    { pending: 65, proven: 40, fromCheckpoint: 41, toCheckpoint: 45, expectedPublish: true, message: '' },
 
     // We try and partially prove the epoch on top of their proof - succeeds again
-    { pending: 65n, proven: 40n, fromCheckpoint: 33, toCheckpoint: 45, expectedPublish: true, message: '' },
+    { pending: 65, proven: 40, fromCheckpoint: 33, toCheckpoint: 45, expectedPublish: true, message: '' },
 
     // We try and partially prove the epoch and partially on top of their proof - succeeds again
-    { pending: 65n, proven: 40n, fromCheckpoint: 35, toCheckpoint: 45, expectedPublish: true, message: '' },
+    { pending: 65, proven: 40, fromCheckpoint: 35, toCheckpoint: 45, expectedPublish: true, message: '' },
 
     // We try and partially prove the epoch but less than was already proven - fails as pointless
     {
-      pending: 65n,
-      proven: 40n,
+      pending: 65,
+      proven: 40,
       fromCheckpoint: 33,
       toCheckpoint: 39,
       expectedPublish: false,
@@ -113,8 +113,8 @@ describe('prover-node-publisher', () => {
 
     // We try and partially prove the epoch but the same as was already proven - should possibly fail but succeeds for now, quite an edge case
     {
-      pending: 65n,
-      proven: 40n,
+      pending: 65,
+      proven: 40,
       fromCheckpoint: 33,
       toCheckpoint: 40,
       expectedPublish: true,
@@ -131,8 +131,8 @@ describe('prover-node-publisher', () => {
 
       // Return the tips specified by the test
       rollup.getTips.mockResolvedValue({
-        pending: pending,
-        proven: proven,
+        pending: CheckpointNumber(pending),
+        proven: CheckpointNumber(proven),
       });
 
       // Return the requested checkpoint
@@ -200,8 +200,8 @@ describe('prover-node-publisher', () => {
 
     // Return the tips specified by the test
     rollup.getTips.mockResolvedValue({
-      pending: 2n,
-      proven: 1n,
+      pending: CheckpointNumber(2),
+      proven: CheckpointNumber(1),
     });
 
     // Return the requested checkpoint

--- a/yarn-project/prover-node/src/prover-node-publisher.ts
+++ b/yarn-project/prover-node/src/prover-node-publisher.ts
@@ -156,7 +156,7 @@ export class ProverNodePublisher {
     // Check that the checkpoint numbers match the expected epoch to be proven
     const { pending, proven } = await this.rollupContract.getTips();
     // Don't publish if proven is beyond our toCheckpoint, pointless to do so
-    if (proven > BigInt(toCheckpoint)) {
+    if (proven > toCheckpoint) {
       throw new Error(
         `Cannot submit epoch proof for ${fromCheckpoint}-${toCheckpoint} as proven checkpoint is ${proven}`,
       );

--- a/yarn-project/stdlib/src/block/l2_block_new.ts
+++ b/yarn-project/stdlib/src/block/l2_block_new.ts
@@ -103,6 +103,10 @@ export class L2BlockNew {
     };
   }
 
+  static empty() {
+    return new L2BlockNew(AppendOnlyTreeSnapshot.empty(), BlockHeader.empty(), Body.empty());
+  }
+
   /**
    * Creates an L2 block containing random data.
    * @param l2BlockNum - The number of the L2 block.

--- a/yarn-project/stdlib/src/block/l2_block_source.ts
+++ b/yarn-project/stdlib/src/block/l2_block_source.ts
@@ -1,4 +1,10 @@
-import { BlockNumber, BlockNumberSchema, type EpochNumber, type SlotNumber } from '@aztec/foundation/branded-types';
+import {
+  BlockNumber,
+  BlockNumberSchema,
+  type CheckpointNumber,
+  type EpochNumber,
+  type SlotNumber,
+} from '@aztec/foundation/branded-types';
 import type { EthAddress } from '@aztec/foundation/eth-address';
 import type { Fr } from '@aztec/foundation/fields';
 import type { TypedEventEmitter } from '@aztec/foundation/types';
@@ -67,7 +73,15 @@ export interface L2BlockSource {
    */
   getBlocks(from: BlockNumber, limit: number, proven?: boolean): Promise<L2Block[]>;
 
-  getPublishedCheckpoints(from: number, limit: number): Promise<PublishedCheckpoint[]>;
+  getPublishedCheckpoints(from: CheckpointNumber, limit: number): Promise<PublishedCheckpoint[]>;
+
+  /**
+   * Gets a checkpoint by the archive root, which should be the root of the archive tree after the requested checkpoint
+   * is applied.
+   * @param archive - The new archive root of the checkpoint.
+   * @returns The requested checkpoint (or undefined if not found).
+   */
+  getCheckpointByArchive(archive: Fr): Promise<Checkpoint | undefined>;
 
   /** Equivalent to getBlocks but includes publish data. */
   getPublishedBlocks(from: BlockNumber, limit: number, proven?: boolean): Promise<PublishedL2Block[]>;

--- a/yarn-project/stdlib/src/checkpoint/checkpoint.ts
+++ b/yarn-project/stdlib/src/checkpoint/checkpoint.ts
@@ -74,7 +74,7 @@ export class Checkpoint {
       numBlocks = 1,
       startBlockNumber = 1,
       ...options
-    }: { numBlocks?: number; startBlockNumber?: number } & Partial<FieldsOf<CheckpointHeader>> &
+    }: { numBlocks?: number; startBlockNumber?: number } & Partial<Parameters<typeof CheckpointHeader.random>[0]> &
       Partial<Parameters<typeof L2BlockNew.random>[1]> = {},
   ) {
     const header = CheckpointHeader.random(options);

--- a/yarn-project/stdlib/src/interfaces/archiver.test.ts
+++ b/yarn-project/stdlib/src/interfaces/archiver.test.ts
@@ -110,11 +110,16 @@ describe('ArchiverApiSchema', () => {
   });
 
   it('getPublishedCheckpoints', async () => {
-    const response = await context.client.getPublishedCheckpoints(1, BlockNumber(1));
+    const response = await context.client.getPublishedCheckpoints(CheckpointNumber(1), BlockNumber(1));
     expect(response).toHaveLength(1);
     expect(response[0].checkpoint.constructor.name).toEqual('Checkpoint');
     expect(response[0].attestations[0]).toBeInstanceOf(CommitteeAttestation);
     expect(response[0].l1).toBeDefined();
+  });
+
+  it('getCheckpointByArchive', async () => {
+    const result = await context.client.getCheckpointByArchive(Fr.random());
+    expect(result).toBeInstanceOf(Checkpoint);
   });
 
   it('getPublishedBlocks', async () => {
@@ -346,7 +351,7 @@ class MockArchiver implements ArchiverApi {
   async getBlocks(from: BlockNumber, _limit: number, _proven?: boolean): Promise<L2Block[]> {
     return [await L2Block.random(from)];
   }
-  async getPublishedCheckpoints(from: number, _limit: number): Promise<PublishedCheckpoint[]> {
+  async getPublishedCheckpoints(from: CheckpointNumber, _limit: number): Promise<PublishedCheckpoint[]> {
     return [
       PublishedCheckpoint.from({
         checkpoint: await Checkpoint.random(CheckpointNumber(from)),
@@ -354,6 +359,9 @@ class MockArchiver implements ArchiverApi {
         l1: { blockHash: `0x`, blockNumber: 1n, timestamp: 0n },
       }),
     ];
+  }
+  getCheckpointByArchive(_archive: Fr): Promise<Checkpoint | undefined> {
+    return Promise.resolve(Checkpoint.random());
   }
   async getPublishedBlocks(from: BlockNumber, _limit: number, _proven?: boolean): Promise<PublishedL2Block[]> {
     return [

--- a/yarn-project/stdlib/src/interfaces/archiver.ts
+++ b/yarn-project/stdlib/src/interfaces/archiver.ts
@@ -88,8 +88,9 @@ export const ArchiverApiSchema: ApiSchemaFor<ArchiverApi> = {
     .returns(z.array(L2Block.schema)),
   getPublishedCheckpoints: z
     .function()
-    .args(schemas.Integer, schemas.Integer)
+    .args(CheckpointNumberSchema, schemas.Integer)
     .returns(z.array(PublishedCheckpoint.schema)),
+  getCheckpointByArchive: z.function().args(schemas.Fr).returns(Checkpoint.schema.optional()),
   getPublishedBlocks: z
     .function()
     .args(BlockNumberSchema, schemas.Integer, optional(z.boolean()))

--- a/yarn-project/stdlib/src/rollup/checkpoint_header.ts
+++ b/yarn-project/stdlib/src/rollup/checkpoint_header.ts
@@ -137,11 +137,13 @@ export class CheckpointHeader {
     });
   }
 
-  static random(overrides: Partial<FieldsOf<CheckpointHeader>> = {}): CheckpointHeader {
+  static random(
+    overrides: Partial<FieldsOf<CheckpointHeader>> & Partial<FieldsOf<ContentCommitment>> = {},
+  ): CheckpointHeader {
     return CheckpointHeader.from({
       lastArchiveRoot: Fr.random(),
       blockHeadersHash: Fr.random(),
-      contentCommitment: ContentCommitment.random(),
+      contentCommitment: ContentCommitment.random(overrides),
       slotNumber: SlotNumber(Math.floor(Math.random() * 1000) + 1),
       timestamp: BigInt(Math.floor(Date.now() / 1000)),
       coinbase: EthAddress.random(),

--- a/yarn-project/stdlib/src/tx/content_commitment.ts
+++ b/yarn-project/stdlib/src/tx/content_commitment.ts
@@ -28,6 +28,10 @@ export class ContentCommitment {
     return [fields.blobsHash, fields.inHash, fields.outHash] as const;
   }
 
+  static from(fields: FieldsOf<ContentCommitment>) {
+    return new ContentCommitment(...ContentCommitment.getFields(fields));
+  }
+
   getSize() {
     return this.toBuffer().length;
   }
@@ -75,8 +79,13 @@ export class ContentCommitment {
     return new ContentCommitment(reader.readField(), reader.readField(), reader.readField());
   }
 
-  static random(): ContentCommitment {
-    return new ContentCommitment(Fr.random(), Fr.random(), Fr.random());
+  static random(overrides: Partial<FieldsOf<ContentCommitment>> = {}): ContentCommitment {
+    return ContentCommitment.from({
+      blobsHash: Fr.random(),
+      inHash: Fr.random(),
+      outHash: Fr.random(),
+      ...overrides,
+    });
   }
 
   static empty(): ContentCommitment {

--- a/yarn-project/txe/src/state_machine/archiver.ts
+++ b/yarn-project/txe/src/state_machine/archiver.ts
@@ -95,6 +95,10 @@ export class TXEArchiver extends ArchiverStoreHelper implements L2BlockSource {
     throw new Error('TXE Archiver does not implement "getPublishedCheckpoints"');
   }
 
+  public getCheckpointByArchive(_archive: Fr): Promise<Checkpoint | undefined> {
+    throw new Error('TXE Archiver does not implement "getCheckpointByArchive"');
+  }
+
   public getL2SlotNumber(): Promise<SlotNumber | undefined> {
     throw new Error('TXE Archiver does not implement "getL2SlotNumber"');
   }

--- a/yarn-project/txe/src/state_machine/index.ts
+++ b/yarn-project/txe/src/state_machine/index.ts
@@ -59,7 +59,7 @@ export class TXEStateMachine {
 
   public async handleL2Block(block: L2Block) {
     await Promise.all([
-      this.synchronizer.handleL2Block(block),
+      this.synchronizer.handleL2Block(block.toL2Block()),
       this.archiver.addBlocks([
         PublishedL2Block.fromFields({
           block,

--- a/yarn-project/txe/src/state_machine/synchronizer.ts
+++ b/yarn-project/txe/src/state_machine/synchronizer.ts
@@ -1,7 +1,7 @@
 import { NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP } from '@aztec/constants';
 import { BlockNumber } from '@aztec/foundation/branded-types';
 import { Fr } from '@aztec/foundation/fields';
-import type { L2Block } from '@aztec/stdlib/block';
+import type { L2BlockNew } from '@aztec/stdlib/block';
 import type {
   MerkleTreeReadOperations,
   MerkleTreeWriteOperations,
@@ -23,10 +23,11 @@ export class TXESynchronizer implements WorldStateSynchronizer {
     return new this(nativeWorldStateService);
   }
 
-  public async handleL2Block(block: L2Block) {
+  public async handleL2Block(block: L2BlockNew) {
     await this.nativeWorldStateService.handleL2BlockAndMessages(
       block,
       Array(NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP).fill(0).map(Fr.zero),
+      true,
     );
 
     this.blockNumber = block.header.globalVariables.blockNumber;

--- a/yarn-project/world-state/src/native/native_bench.test.ts
+++ b/yarn-project/world-state/src/native/native_bench.test.ts
@@ -74,7 +74,7 @@ describe('Native World State: benchmarks', () => {
     const startTime = performance.now();
 
     for (const { block, messages } of blocks) {
-      await worldState.handleL2BlockAndMessages(block, messages);
+      await worldState.handleL2BlockAndMessages(block, messages, true);
     }
 
     const endTime = performance.now();
@@ -251,7 +251,7 @@ describe('Native World State: benchmarks', () => {
     const treeInfo = await fork.getTreeInfo(MerkleTreeId.NULLIFIER_TREE);
     const startSize = Number(treeInfo.size);
     const { block, messages } = await mockBlock(BlockNumber(1), 32, fork, 64);
-    await worldState.handleL2BlockAndMessages(block, messages);
+    await worldState.handleL2BlockAndMessages(block, messages, true);
     await fork.close();
 
     const values = block.body.txEffects.flatMap(txEffect => txEffect.nullifiers.map(nullifier => nullifier.toBuffer()));
@@ -270,7 +270,7 @@ describe('Native World State: benchmarks', () => {
   it('Retrieves low leaves', async () => {
     const fork = await worldState.fork();
     const { block, messages } = await mockBlock(BlockNumber(1), 32, fork, 64);
-    await worldState.handleL2BlockAndMessages(block, messages);
+    await worldState.handleL2BlockAndMessages(block, messages, true);
 
     const treeInfo = await fork.getTreeInfo(MerkleTreeId.NULLIFIER_TREE);
     const startSize = Number(treeInfo.size);

--- a/yarn-project/world-state/src/native/native_world_state.test.ts
+++ b/yarn-project/world-state/src/native/native_world_state.test.ts
@@ -16,7 +16,7 @@ import { EthAddress } from '@aztec/foundation/eth-address';
 import { Fr } from '@aztec/foundation/fields';
 import type { SiblingPath } from '@aztec/foundation/trees';
 import { PublicDataWrite } from '@aztec/stdlib/avm';
-import { L2Block } from '@aztec/stdlib/block';
+import { L2BlockNew } from '@aztec/stdlib/block';
 import { DatabaseVersion, DatabaseVersionManager } from '@aztec/stdlib/database-version';
 import type { MerkleTreeLeafType, MerkleTreeWriteOperations } from '@aztec/stdlib/interfaces/server';
 import { makeGlobalVariables } from '@aztec/stdlib/testing';
@@ -62,8 +62,103 @@ describe('NativeWorldState', () => {
     }
   });
 
+  describe('Padding', () => {
+    let ws: NativeWorldStateService;
+    let fork: MerkleTreeWriteOperations;
+
+    beforeEach(async () => {
+      ws = await NativeWorldStateService.tmp();
+      fork = await ws.fork();
+    });
+
+    afterEach(async () => {
+      await fork.close();
+      await ws.close();
+    });
+
+    it('pads messages, note hashes, nullifiers correctly for first block', async () => {
+      const isFirstBlock = true;
+      const txsPerBlock = 2;
+      const maxEffects = 1;
+      const numMessages = 2;
+      const { block, messages } = await mockBlock(
+        BlockNumber(1),
+        txsPerBlock,
+        fork,
+        maxEffects,
+        numMessages,
+        isFirstBlock,
+      );
+
+      const status = await ws.handleL2BlockAndMessages(block, messages, isFirstBlock);
+
+      expect(status.meta.messageTreeMeta.size).toBe(BigInt(NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP));
+
+      const expectedNoteHashCount = txsPerBlock * MAX_NOTE_HASHES_PER_TX;
+      expect(status.meta.noteHashTreeMeta.size).toBe(BigInt(expectedNoteHashCount));
+
+      const expectedNullifierCount = txsPerBlock * MAX_NULLIFIERS_PER_TX;
+      expect(status.meta.nullifierTreeMeta.size).toBe(BigInt(INITIAL_NULLIFIER_TREE_SIZE + expectedNullifierCount));
+
+      // Public data writes are never padded.
+      const expectedPublicDataCount = txsPerBlock * maxEffects;
+      expect(status.meta.publicDataTreeMeta.size).toBe(BigInt(INITIAL_PUBLIC_DATA_TREE_SIZE + expectedPublicDataCount));
+    });
+
+    it('pads everything except for l1 to l2 messages for non-first block', async () => {
+      const isFirstBlock = false;
+      const txsPerBlock = 2;
+      const maxEffects = 1;
+      const numMessages = 0;
+      const { block, messages } = await mockBlock(
+        BlockNumber(1),
+        txsPerBlock,
+        fork,
+        maxEffects,
+        numMessages,
+        isFirstBlock,
+      );
+
+      const status = await ws.handleL2BlockAndMessages(block, messages, isFirstBlock);
+
+      // L1 to L2 messages should NOT grow for non-first blocks
+      expect(status.meta.messageTreeMeta.size).toBe(0n);
+
+      // Note hashes should be padded.
+      const expectedNoteHashCount = txsPerBlock * MAX_NOTE_HASHES_PER_TX;
+      expect(status.meta.noteHashTreeMeta.size).toBe(BigInt(expectedNoteHashCount));
+
+      // Nullifiers should be padded.
+      const expectedNullifierCount = txsPerBlock * MAX_NULLIFIERS_PER_TX;
+      expect(status.meta.nullifierTreeMeta.size).toBe(BigInt(INITIAL_NULLIFIER_TREE_SIZE + expectedNullifierCount));
+
+      // Public data writes are never padded.
+      const expectedPublicDataCount = txsPerBlock * maxEffects;
+      expect(status.meta.publicDataTreeMeta.size).toBe(BigInt(INITIAL_PUBLIC_DATA_TREE_SIZE + expectedPublicDataCount));
+    });
+
+    it('pads empty messages array for first block', async () => {
+      const isFirstBlock = true;
+      const numMessages = 0;
+      const { block, messages } = await mockBlock(BlockNumber(1), 1, fork, 1, numMessages, isFirstBlock);
+
+      const status = await ws.handleL2BlockAndMessages(block, messages, isFirstBlock);
+      expect(status.meta.messageTreeMeta.size).toBe(BigInt(NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP));
+    });
+
+    it('throws error if messages are provided for non-first block', async () => {
+      const isFirstBlock = false;
+      const numMessages = 1;
+      const { block, messages } = await mockBlock(BlockNumber(1), 1, fork, 1, numMessages, isFirstBlock);
+
+      await expect(ws.handleL2BlockAndMessages(block, messages, isFirstBlock)).rejects.toThrow(
+        'L1 to L2 messages must be empty for non-first blocks',
+      );
+    });
+  });
+
   describe('Persistence', () => {
-    let block: L2Block;
+    let block: L2BlockNew;
     let messages: Fr[];
     let noteHash: Fr;
 
@@ -88,7 +183,7 @@ describe('NativeWorldState', () => {
       noteHash = block.body.txEffects[0].noteHashes[0];
       await fork.close();
 
-      await ws.handleL2BlockAndMessages(block, messages);
+      await ws.handleL2BlockAndMessages(block, messages, true);
       await ws.close();
     });
 
@@ -124,7 +219,7 @@ describe('NativeWorldState', () => {
       await timesAsync(5, async i => {
         const fork = await ws.fork();
         const { block, messages } = await mockBlock(BlockNumber(i + 1), 2, fork);
-        await ws.handleL2BlockAndMessages(block, messages);
+        await ws.handleL2BlockAndMessages(block, messages, true);
         await fork.close();
       });
 
@@ -168,7 +263,7 @@ describe('NativeWorldState', () => {
       ({ block, messages } = await mockBlock(BlockNumber(1), 2, fork));
       await fork.close();
 
-      const status = await ws.handleL2BlockAndMessages(block, messages);
+      const status = await ws.handleL2BlockAndMessages(block, messages, true);
       expect(status.summary.unfinalizedBlockNumber).toBe(1);
       await ws.close();
       // we open up the version file that was created and modify the version to be older
@@ -207,7 +302,7 @@ describe('NativeWorldState', () => {
       const { block: block3, messages: messages3 } = await mockBlock(BlockNumber(3), 8, initialFork);
 
       // The first block should succeed
-      await expect(ws.handleL2BlockAndMessages(block1, messages1)).resolves.toBeDefined();
+      await expect(ws.handleL2BlockAndMessages(block1, messages1, true)).resolves.toBeDefined();
 
       // The trees should be synched at block 1
       const goodSummary = await ws.getStatusSummary();
@@ -219,7 +314,7 @@ describe('NativeWorldState', () => {
       } as WorldStateStatusSummary);
 
       // The second block should fail
-      await expect(ws.handleL2BlockAndMessages(block2, messages2)).rejects.toThrow();
+      await expect(ws.handleL2BlockAndMessages(block2, messages2, true)).rejects.toThrow();
 
       // The summary should indicate that the unfinalized block number (that of the archive tree) is 2
       // But it should also tell us that the trees are not synched
@@ -232,8 +327,12 @@ describe('NativeWorldState', () => {
       } as WorldStateStatusSummary);
 
       // Commits should always fail now, the trees are in an inconsistent state
-      await expect(ws.handleL2BlockAndMessages(block2, messages2)).rejects.toThrow('World state trees are out of sync');
-      await expect(ws.handleL2BlockAndMessages(block3, messages3)).rejects.toThrow('World state trees are out of sync');
+      await expect(ws.handleL2BlockAndMessages(block2, messages2, true)).rejects.toThrow(
+        'World state trees are out of sync',
+      );
+      await expect(ws.handleL2BlockAndMessages(block3, messages3, true)).rejects.toThrow(
+        'World state trees are out of sync',
+      );
 
       // Creating another world state instance should fail
       await ws.close();
@@ -248,7 +347,7 @@ describe('NativeWorldState', () => {
       const fork = await ws.fork();
       ({ block, messages } = await mockBlock(BlockNumber(1), 2, fork));
       await fork.close();
-      const status = await ws.handleL2BlockAndMessages(block, messages);
+      const status = await ws.handleL2BlockAndMessages(block, messages, true);
       expect(status.summary.unfinalizedBlockNumber).toBe(1);
 
       // Clear it
@@ -302,7 +401,7 @@ describe('NativeWorldState', () => {
       const initialFork = await ws.fork();
       for (let i = 0; i < 5; i++) {
         const { block, messages } = await mockBlock(BlockNumber(i + 1), 2, initialFork);
-        await ws.handleL2BlockAndMessages(block, messages);
+        await ws.handleL2BlockAndMessages(block, messages, true);
       }
 
       const fork = await ws.fork(BlockNumber(3));
@@ -331,7 +430,7 @@ describe('NativeWorldState', () => {
       for (let i = 0; i < 5; i++) {
         const blockNumber = i + 1;
         const { block, messages } = await mockBlock(BlockNumber(blockNumber), 1, fork);
-        const status = await ws.handleL2BlockAndMessages(block, messages);
+        const status = await ws.handleL2BlockAndMessages(block, messages, true);
 
         expect(status.summary.unfinalizedBlockNumber).toBe(blockNumber);
       }
@@ -361,7 +460,7 @@ describe('NativeWorldState', () => {
         const blockNumber = i + 1;
         const provenBlock = blockNumber - 4;
         const { block, messages } = await mockBlock(BlockNumber(blockNumber), 1, fork);
-        const status = await ws.handleL2BlockAndMessages(block, messages);
+        const status = await ws.handleL2BlockAndMessages(block, messages, true);
 
         expect(status.summary.unfinalizedBlockNumber).toBe(blockNumber);
         expect(status.summary.oldestHistoricalBlock).toBe(1);
@@ -383,7 +482,7 @@ describe('NativeWorldState', () => {
       for (let i = 0; i < 16; i++) {
         const blockNumber = i + 1;
         const { block, messages } = await mockBlock(BlockNumber(blockNumber), 1, fork);
-        const status = await ws.handleL2BlockAndMessages(block, messages);
+        const status = await ws.handleL2BlockAndMessages(block, messages, true);
 
         expect(status.summary.unfinalizedBlockNumber).toBe(blockNumber);
         expect(status.summary.oldestHistoricalBlock).toBe(1);
@@ -407,7 +506,7 @@ describe('NativeWorldState', () => {
         const provenBlock = blockNumber - provenBlockLag;
         const prunedBlockNumber = blockNumber - prunedBlockLag;
         const { block, messages } = await mockBlock(BlockNumber(blockNumber), 1, fork);
-        const status = await ws.handleL2BlockAndMessages(block, messages);
+        const status = await ws.handleL2BlockAndMessages(block, messages, true);
 
         expect(status.summary.unfinalizedBlockNumber).toBe(blockNumber);
 
@@ -508,7 +607,7 @@ describe('NativeWorldState', () => {
         const blockNumber = i + 1;
         const provenBlock = blockNumber - provenBlockLag;
         const { block, messages } = await mockBlock(BlockNumber(blockNumber), 1, fork);
-        const status = await ws.handleL2BlockAndMessages(block, messages);
+        const status = await ws.handleL2BlockAndMessages(block, messages, true);
 
         expect(status.summary.unfinalizedBlockNumber).toBe(blockNumber);
 
@@ -545,7 +644,7 @@ describe('NativeWorldState', () => {
         const blockNumber = i + 1;
         const provenBlock = blockNumber - provenBlockLag;
         const { block, messages } = await mockBlock(BlockNumber(blockNumber), 1, fork);
-        const status = await ws.handleL2BlockAndMessages(block, messages);
+        const status = await ws.handleL2BlockAndMessages(block, messages, true);
 
         expect(status.summary.unfinalizedBlockNumber).toBe(blockNumber);
 
@@ -578,7 +677,7 @@ describe('NativeWorldState', () => {
         for (let i = 0; i < 8; i++) {
           const blockNumber = i + 1;
           const { block, messages } = await mockBlock(BlockNumber(blockNumber), 1, fork);
-          await ws.handleL2BlockAndMessages(block, messages);
+          await ws.handleL2BlockAndMessages(block, messages, true);
         }
       }
 
@@ -588,7 +687,7 @@ describe('NativeWorldState', () => {
         for (let i = 8; i < 16; i++) {
           const blockNumber = i + 1;
           const { block, messages } = await mockBlock(BlockNumber(blockNumber), 1, fork);
-          await worldState.handleL2BlockAndMessages(block, messages);
+          await worldState.handleL2BlockAndMessages(block, messages, true);
         }
       });
 
@@ -602,7 +701,7 @@ describe('NativeWorldState', () => {
 
         const blockNumber = 9;
         const { block, messages } = await mockBlock(BlockNumber(blockNumber), 1, fork);
-        const statusFull = await ws.handleL2BlockAndMessages(block, messages);
+        const statusFull = await ws.handleL2BlockAndMessages(block, messages, true);
         expect(statusFull.meta.archiveTreeMeta.unfinalizedBlockHeight).toEqual(9);
         expect(statusFull.meta.messageTreeMeta.unfinalizedBlockHeight).toEqual(9);
         expect(statusFull.meta.noteHashTreeMeta.unfinalizedBlockHeight).toEqual(9);
@@ -620,7 +719,7 @@ describe('NativeWorldState', () => {
         for (let i = 0; i < 16; i++) {
           const blockNumber = i + 1;
           const { block, messages } = await mockBlock(BlockNumber(blockNumber), 1, fork);
-          const status = await ws.handleL2BlockAndMessages(block, messages);
+          const status = await ws.handleL2BlockAndMessages(block, messages, true);
 
           const provenBlock = blockNumber - provenBlockLag;
 
@@ -642,7 +741,7 @@ describe('NativeWorldState', () => {
         for (let i = 16; i < 20; i++) {
           const blockNumber = i + 1;
           const { block, messages } = await mockBlock(BlockNumber(blockNumber), 1, fork);
-          await worldState.handleL2BlockAndMessages(block, messages);
+          await worldState.handleL2BlockAndMessages(block, messages, true);
           const provenBlock = blockNumber - provenBlockLag;
           await worldState.setFinalized(BlockNumber(provenBlock));
         }
@@ -659,7 +758,7 @@ describe('NativeWorldState', () => {
         expect(summary.unfinalizedBlockNumber).toEqual(expectedPendingBlockNumber);
 
         const { block, messages } = await mockBlock(BlockNumber(expectedPendingBlockNumber + 1), 1, fork);
-        const statusFull = await ws.handleL2BlockAndMessages(block, messages);
+        const statusFull = await ws.handleL2BlockAndMessages(block, messages, true);
         expect(statusFull.summary.treesAreSynched).toBeTruthy();
         expect(statusFull.meta.archiveTreeMeta.unfinalizedBlockHeight).toEqual(expectedPendingBlockNumber + 1);
         expect(statusFull.meta.messageTreeMeta.unfinalizedBlockHeight).toEqual(expectedPendingBlockNumber + 1);
@@ -721,7 +820,7 @@ describe('NativeWorldState', () => {
       for (let i = 0; i < 16; i++) {
         const blockNumber = i + 1;
         const { block, messages } = await genBlock(blockNumber, fork);
-        const status = await ws.handleL2BlockAndMessages(block, messages);
+        const status = await ws.handleL2BlockAndMessages(block, messages, true);
         blockStats.push(status);
         const blockFork = await ws.fork();
         blockForks.push(blockFork);
@@ -731,14 +830,14 @@ describe('NativeWorldState', () => {
         siblingPaths.push(siblingPath);
 
         if (blockNumber < 9) {
-          const statusNonReorg = await nonReorgState.handleL2BlockAndMessages(block, messages);
+          const statusNonReorg = await nonReorgState.handleL2BlockAndMessages(block, messages, true);
           expect(status.summary).toEqual(statusNonReorg.summary);
 
           const treeInfoNonReorg = await nonReorgState.getCommitted().getTreeInfo(MerkleTreeId.NULLIFIER_TREE);
           expect(treeInfo).toEqual(treeInfoNonReorg);
         }
 
-        await sequentialReorgState.handleL2BlockAndMessages(block, messages);
+        await sequentialReorgState.handleL2BlockAndMessages(block, messages, true);
       }
 
       // unwind 1 chain by a single block at a time
@@ -785,7 +884,7 @@ describe('NativeWorldState', () => {
       for (let i = 8; i < 16; i++) {
         const blockNumber = i + 1;
         const { block, messages } = await mockBlock(BlockNumber(blockNumber), 1, fork);
-        const status = await ws.handleL2BlockAndMessages(block, messages);
+        const status = await ws.handleL2BlockAndMessages(block, messages, true);
         blockStats[i] = status;
         const blockFork = await ws.fork();
         blockForks[i] = blockFork;
@@ -794,7 +893,7 @@ describe('NativeWorldState', () => {
         const siblingPath = await ws.getCommitted().getSiblingPath(MerkleTreeId.NULLIFIER_TREE, 0n);
         siblingPaths[i] = siblingPath;
 
-        const statusNonReorg = await nonReorgState.handleL2BlockAndMessages(block, messages);
+        const statusNonReorg = await nonReorgState.handleL2BlockAndMessages(block, messages, true);
         expect(status.summary).toEqual(statusNonReorg.summary);
       }
 
@@ -820,7 +919,7 @@ describe('NativeWorldState', () => {
       for (let i = 0; i < 16; i++) {
         const blockNumber = i + 1;
         const { block, messages } = await mockBlock(BlockNumber(blockNumber), 1, fork);
-        const status = await ws.handleL2BlockAndMessages(block, messages);
+        const status = await ws.handleL2BlockAndMessages(block, messages, true);
         blockStats.push(status);
         const blockFork = await ws.fork();
         blockForks.push(blockFork);
@@ -863,7 +962,7 @@ describe('NativeWorldState', () => {
         const blockNumber = i + 1;
         const provenBlock = blockNumber - 2;
         const { block, messages } = await mockBlock(BlockNumber(blockNumber), 1, fork);
-        const status = await ws.handleL2BlockAndMessages(block, messages);
+        const status = await ws.handleL2BlockAndMessages(block, messages, true);
 
         expect(status.summary.unfinalizedBlockNumber).toBe(blockNumber);
         expect(status.summary.oldestHistoricalBlock).toBe(1);
@@ -881,15 +980,15 @@ describe('NativeWorldState', () => {
       // Now build an invalid block, see that it is rejected and that we can then insert the correct block
       {
         const { block: block, messages } = await mockBlock(BlockNumber(5), 1, fork);
-        const invalidBlock = L2Block.fromBuffer(block.toBuffer());
+        const invalidBlock = L2BlockNew.fromBuffer(block.toBuffer());
         invalidBlock.header.state.partial.nullifierTree.root = Fr.random();
 
-        await expect(ws.handleL2BlockAndMessages(invalidBlock, messages)).rejects.toThrow(
+        await expect(ws.handleL2BlockAndMessages(invalidBlock, messages, true)).rejects.toThrow(
           "Can't synch block: block state does not match world state",
         );
 
         // Accepts the correct block
-        await expect(ws.handleL2BlockAndMessages(block, messages)).resolves.toBeDefined();
+        await expect(ws.handleL2BlockAndMessages(block, messages, true)).resolves.toBeDefined();
 
         const summary = await ws.getStatusSummary();
         expect(summary.unfinalizedBlockNumber).toBe(5);
@@ -900,10 +999,10 @@ describe('NativeWorldState', () => {
       // Now we push another invalid block, see that it is rejected and check we can unwind to the last proven block
       {
         const { block: block, messages } = await mockBlock(BlockNumber(6), 1, fork);
-        const invalidBlock = L2Block.fromBuffer(block.toBuffer());
+        const invalidBlock = L2BlockNew.fromBuffer(block.toBuffer());
         invalidBlock.header.state.partial.nullifierTree.root = Fr.random();
 
-        await expect(ws.handleL2BlockAndMessages(invalidBlock, messages)).rejects.toThrow(
+        await expect(ws.handleL2BlockAndMessages(invalidBlock, messages, true)).rejects.toThrow(
           "Can't synch block: block state does not match world state",
         );
 
@@ -917,7 +1016,7 @@ describe('NativeWorldState', () => {
   });
 
   describe('Finding leaves', () => {
-    let block: L2Block;
+    let block: L2BlockNew;
     let messages: Fr[];
 
     it('retrieves leaf indices', async () => {
@@ -937,7 +1036,7 @@ describe('NativeWorldState', () => {
         nullifiers.push(...block.body.txEffects.flatMap(x => x.nullifiers.flatMap(x => x.toBuffer())));
         publicWrites.push(...block.body.txEffects.flatMap(x => x.publicDataWrites.flatMap(x => x.toBuffer())));
         await fork.close();
-        await ws.handleL2BlockAndMessages(block, messages);
+        await ws.handleL2BlockAndMessages(block, messages, true);
       }
 
       const testQuery = async (
@@ -979,7 +1078,7 @@ describe('NativeWorldState', () => {
   });
 
   describe('Finding sibling paths', () => {
-    let block: L2Block;
+    let block: L2BlockNew;
     let messages: Fr[];
 
     it('retrieves leaf sibling paths', async () => {
@@ -996,7 +1095,7 @@ describe('NativeWorldState', () => {
         nullifiers.push(...block.body.txEffects.flatMap(x => x.nullifiers.flatMap(x => x.toBuffer())));
         publicWrites.push(...block.body.txEffects.flatMap(x => x.publicDataWrites.flatMap(x => x.toBuffer())));
         await fork.close();
-        await ws.handleL2BlockAndMessages(block, messages);
+        await ws.handleL2BlockAndMessages(block, messages, true);
       }
 
       const testQuery = async (
@@ -1037,7 +1136,7 @@ describe('NativeWorldState', () => {
   });
 
   describe('Block numbers for indices', () => {
-    let block: L2Block;
+    let block: L2BlockNew;
     let messages: Fr[];
     let noteHashes: number;
     let nullifiers: number;
@@ -1059,7 +1158,7 @@ describe('NativeWorldState', () => {
         nullifiers = block.body.txEffects[0].nullifiers.length;
         publicTree = block.body.txEffects[0].publicDataWrites.length;
         await fork.close();
-        const status = await ws.handleL2BlockAndMessages(block, messages);
+        const status = await ws.handleL2BlockAndMessages(block, messages, true);
         statuses.push(status);
       }
 
@@ -1098,7 +1197,7 @@ describe('NativeWorldState', () => {
   });
 
   describe('Status reporting', () => {
-    let block: L2Block;
+    let block: L2BlockNew;
     let messages: Fr[];
 
     beforeAll(async () => {
@@ -1112,7 +1211,7 @@ describe('NativeWorldState', () => {
         const fork = await ws.fork();
         ({ block, messages } = await mockBlock(BlockNumber(1), 2, fork));
         await fork.close();
-        const status = await ws.handleL2BlockAndMessages(block, messages);
+        const status = await ws.handleL2BlockAndMessages(block, messages, true);
         statuses.push(status);
 
         expect(status.summary).toEqual({
@@ -1273,7 +1372,7 @@ describe('NativeWorldState', () => {
       const { block: block2 } = await mockBlock(BlockNumber(2), 8, setupFork);
       const { block: block3 } = await mockBlock(BlockNumber(3), 8, setupFork);
 
-      await ws.handleL2BlockAndMessages(block1, messages);
+      await ws.handleL2BlockAndMessages(block1, messages, true);
 
       const testFork = await ws.fork();
       const commitmentDb = ws.getCommitted();
@@ -1342,7 +1441,7 @@ describe('NativeWorldState', () => {
       const { block, messages } = await mockBlock(BlockNumber(1), 2, fork);
       await fork.close();
 
-      await ws.handleL2BlockAndMessages(block, messages);
+      await ws.handleL2BlockAndMessages(block, messages, true);
     });
 
     afterEach(async () => {

--- a/yarn-project/world-state/src/native/native_world_state.ts
+++ b/yarn-project/world-state/src/native/native_world_state.ts
@@ -5,7 +5,7 @@ import { EthAddress } from '@aztec/foundation/eth-address';
 import { Fr } from '@aztec/foundation/fields';
 import { tryRmDir } from '@aztec/foundation/fs';
 import { type Logger, createLogger } from '@aztec/foundation/log';
-import type { L2Block, L2BlockNew } from '@aztec/stdlib/block';
+import type { L2BlockNew } from '@aztec/stdlib/block';
 import { DatabaseVersionManager } from '@aztec/stdlib/database-version';
 import type {
   IndexedTreeId,
@@ -181,19 +181,25 @@ export class NativeWorldStateService implements MerkleTreeDatabase {
   }
 
   public async handleL2BlockAndMessages(
-    l2Block: L2Block | L2BlockNew,
+    l2Block: L2BlockNew,
     l1ToL2Messages: Fr[],
-    // TODO(#17027)
-    // Temporary hack to only insert l1 to l2 messages for the first block in a checkpoint.
-    isFirstBlock = true,
+    isFirstBlock: boolean,
   ): Promise<WorldStateStatusFull> {
-    // We have to pad both the values within tx effects because that's how the trees are built by circuits.
-    const paddedNoteHashes = l2Block.body.txEffects.flatMap(txEffect =>
-      padArrayEnd(txEffect.noteHashes, Fr.ZERO, MAX_NOTE_HASHES_PER_TX),
-    );
+    if (!isFirstBlock && l1ToL2Messages.length > 0) {
+      throw new Error(
+        `L1 to L2 messages must be empty for non-first blocks, but got ${l1ToL2Messages.length} messages for block ${l2Block.number}.`,
+      );
+    }
+
+    // We have to pad the given l1 to l2 messages, and the note hashes and nullifiers within tx effects, because that's
+    // how the trees are built by circuits.
     const paddedL1ToL2Messages = isFirstBlock
       ? padArrayEnd<Fr, number>(l1ToL2Messages, Fr.ZERO, NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP)
       : [];
+
+    const paddedNoteHashes = l2Block.body.txEffects.flatMap(txEffect =>
+      padArrayEnd(txEffect.noteHashes, Fr.ZERO, MAX_NOTE_HASHES_PER_TX),
+    );
 
     const paddedNullifiers = l2Block.body.txEffects
       .flatMap(txEffect => padArrayEnd(txEffect.nullifiers, Fr.ZERO, MAX_NULLIFIERS_PER_TX))

--- a/yarn-project/world-state/src/synchronizer/server_world_state_synchronizer.test.ts
+++ b/yarn-project/world-state/src/synchronizer/server_world_state_synchronizer.test.ts
@@ -1,11 +1,15 @@
-import { L1_TO_L2_MSG_SUBTREE_HEIGHT } from '@aztec/constants';
-import { BlockNumber } from '@aztec/foundation/branded-types';
+import { BlockNumber, CheckpointNumber } from '@aztec/foundation/branded-types';
 import { times, timesParallel } from '@aztec/foundation/collection';
-import { SHA256Trunc, randomInt } from '@aztec/foundation/crypto';
 import { Fr } from '@aztec/foundation/fields';
 import { type Logger, createLogger } from '@aztec/foundation/log';
-import { MerkleTreeCalculator } from '@aztec/foundation/trees';
-import { L2Block, type L2BlockSource, type L2BlockStream, type PublishedL2Block } from '@aztec/stdlib/block';
+import {
+  L2Block,
+  L2BlockNew,
+  type L2BlockSource,
+  type L2BlockStream,
+  type PublishedL2Block,
+} from '@aztec/stdlib/block';
+import type { Checkpoint } from '@aztec/stdlib/checkpoint';
 import { type MerkleTreeReadOperations, WorldStateRunningState } from '@aztec/stdlib/interfaces/server';
 import type { L1ToL2MessageSource } from '@aztec/stdlib/messaging';
 import type { BlockHeader } from '@aztec/stdlib/tx';
@@ -15,6 +19,7 @@ import { type MockProxy, mock } from 'jest-mock-extended';
 
 import type { MerkleTreeAdminDatabase, WorldStateConfig } from '../index.js';
 import { type WorldStateStatusSummary, buildEmptyWorldStateStatusFull } from '../native/message.js';
+import { mockCheckpoint } from '../test/utils.js';
 import { ServerWorldStateSynchronizer } from './server_world_state_synchronizer.js';
 
 describe('ServerWorldStateSynchronizer', () => {
@@ -22,8 +27,7 @@ describe('ServerWorldStateSynchronizer', () => {
 
   let log: Logger;
 
-  let l1ToL2Messages: Fr[];
-  let inHash: Fr;
+  let checkpoints: { checkpoint: Checkpoint; messages: Fr[] }[];
 
   let blockAndMessagesSource: MockProxy<L2BlockSource & L1ToL2MessageSource>;
   let merkleTreeDb: MockProxy<MerkleTreeAdminDatabase>;
@@ -38,20 +42,26 @@ describe('ServerWorldStateSynchronizer', () => {
   beforeAll(async () => {
     log = createLogger('world-state:test:server_world_state_synchronizer');
 
-    // Seed l1 to l2 msgs
-    l1ToL2Messages = times(randomInt(2 ** L1_TO_L2_MSG_SUBTREE_HEIGHT), Fr.random);
-
-    // Compute inHash for verification
-    const calculator = await MerkleTreeCalculator.create(L1_TO_L2_MSG_SUBTREE_HEIGHT, Buffer.alloc(32), (lhs, rhs) =>
-      Promise.resolve(new SHA256Trunc().hash(lhs, rhs)),
+    // Generate 10 mock checkpoints, each with 1 block and i + 2 message.
+    checkpoints = await timesParallel(10, i =>
+      mockCheckpoint(CheckpointNumber(i + 1), { startBlockNumber: BlockNumber(i + 1), numL1ToL2Messages: i + 2 }),
     );
-    inHash = new Fr(await calculator.computeTreeRoot(l1ToL2Messages.map(msg => msg.toBuffer())));
   });
 
   beforeEach(() => {
     blockAndMessagesSource = mock<L2BlockSource & L1ToL2MessageSource>();
     blockAndMessagesSource.getBlockNumber.mockResolvedValue(BlockNumber(LATEST_BLOCK_NUMBER));
-    blockAndMessagesSource.getL1ToL2Messages.mockResolvedValue(l1ToL2Messages);
+    blockAndMessagesSource.getBlockHeader.mockImplementation(blockNumber => {
+      return Promise.resolve(checkpoints.flatMap(c => c.checkpoint.blocks).find(b => b.number === blockNumber)?.header);
+    });
+    blockAndMessagesSource.getCheckpointByArchive.mockImplementation(archiveRoot => {
+      return Promise.resolve(
+        checkpoints.find(c => c.checkpoint.blocks.at(-1)!.archive.root.equals(archiveRoot))?.checkpoint,
+      );
+    });
+    blockAndMessagesSource.getL1ToL2Messages.mockImplementation(blockNumber => {
+      return Promise.resolve(checkpoints.find(c => c.checkpoint.blocks[0].number === blockNumber)?.messages ?? []);
+    });
 
     merkleTreeRead = mock<MerkleTreeReadOperations>();
     merkleTreeRead.getInitialHeader.mockReturnValue({
@@ -61,7 +71,7 @@ describe('ServerWorldStateSynchronizer', () => {
 
     merkleTreeDb = mock<MerkleTreeAdminDatabase>();
     merkleTreeDb.getCommitted.mockReturnValue(merkleTreeRead);
-    merkleTreeDb.handleL2BlockAndMessages.mockImplementation((l2Block: L2Block) => {
+    merkleTreeDb.handleL2BlockAndMessages.mockImplementation((l2Block: L2BlockNew) => {
       latestHandledBlockNumber = l2Block.number;
       return Promise.resolve(buildEmptyWorldStateStatusFull());
     });
@@ -95,9 +105,9 @@ describe('ServerWorldStateSynchronizer', () => {
   const pushBlocks = async (from: number, to: number) => {
     await server.handleBlockStreamEvent({
       type: 'blocks-added',
-      blocks: await timesParallel(
+      blocks: times(
         to - from + 1,
-        async i => ({ block: await L2Block.random(BlockNumber(i + from), 4, 3, 1, inHash) }) as PublishedL2Block,
+        i => ({ block: L2Block.fromCheckpoint(checkpoints[from + i - 1].checkpoint) }) as PublishedL2Block,
       ),
     });
     server.latest.number = BlockNumber(to);

--- a/yarn-project/world-state/src/synchronizer/server_world_state_synchronizer.ts
+++ b/yarn-project/world-state/src/synchronizer/server_world_state_synchronizer.ts
@@ -1,14 +1,11 @@
-import { L1_TO_L2_MSG_SUBTREE_HEIGHT } from '@aztec/constants';
 import { BlockNumber } from '@aztec/foundation/branded-types';
-import { SHA256Trunc } from '@aztec/foundation/crypto';
 import type { Fr } from '@aztec/foundation/fields';
 import { type Logger, createLogger } from '@aztec/foundation/log';
 import { promiseWithResolvers } from '@aztec/foundation/promise';
 import { elapsed } from '@aztec/foundation/timer';
-import { MerkleTreeCalculator } from '@aztec/foundation/trees';
 import type {
-  L2Block,
   L2BlockId,
+  L2BlockNew,
   L2BlockSource,
   L2BlockStream,
   L2BlockStreamEvent,
@@ -33,6 +30,7 @@ import type { WorldStateStatusFull } from '../native/message.js';
 import type { MerkleTreeAdminDatabase } from '../world-state-db/merkle_tree_db.js';
 import type { WorldStateConfig } from './config.js';
 import { WorldStateSynchronizerError } from './errors.js';
+import { findFirstBlocksInCheckpoints } from './utils.js';
 
 export type { SnapshotDataKeys };
 
@@ -270,7 +268,7 @@ export class ServerWorldStateSynchronizer
   public async handleBlockStreamEvent(event: L2BlockStreamEvent): Promise<void> {
     switch (event.type) {
       case 'blocks-added':
-        await this.handleL2Blocks(event.blocks.map(b => b.block));
+        await this.handleL2Blocks(event.blocks.map(b => b.block.toL2Block()));
         break;
       case 'chain-pruned':
         await this.handleChainPruned(BlockNumber(event.block.number));
@@ -289,22 +287,23 @@ export class ServerWorldStateSynchronizer
    * @param l2Blocks - The L2 blocks to handle.
    * @returns Whether the block handled was produced by this same node.
    */
-  private async handleL2Blocks(l2Blocks: L2Block[]) {
+  private async handleL2Blocks(l2Blocks: L2BlockNew[]) {
     this.log.trace(`Handling L2 blocks ${l2Blocks[0].number} to ${l2Blocks.at(-1)!.number}`);
 
-    const messagePromises = l2Blocks.map(block => this.l2BlockSource.getL1ToL2Messages(block.number));
-    const l1ToL2Messages: Fr[][] = await Promise.all(messagePromises);
-    let updateStatus: WorldStateStatusFull | undefined = undefined;
+    const firstBlocksInCheckpoints = await findFirstBlocksInCheckpoints(l2Blocks, this.l2BlockSource);
 
-    for (let i = 0; i < l2Blocks.length; i++) {
-      const [duration, result] = await elapsed(() => this.handleL2Block(l2Blocks[i], l1ToL2Messages[i]));
-      this.log.info(`World state updated with L2 block ${l2Blocks[i].number}`, {
+    let updateStatus: WorldStateStatusFull | undefined = undefined;
+    for (const block of l2Blocks) {
+      const l1ToL2Messages = firstBlocksInCheckpoints.get(block.number) ?? [];
+      const isFirstBlock = firstBlocksInCheckpoints.has(block.number);
+      const [duration, result] = await elapsed(() => this.handleL2Block(block, l1ToL2Messages, isFirstBlock));
+      this.log.info(`World state updated with L2 block ${block.number}`, {
         eventName: 'l2-block-handled',
         duration,
         unfinalizedBlockNumber: BigInt(result.summary.unfinalizedBlockNumber),
         finalizedBlockNumber: BigInt(result.summary.finalizedBlockNumber),
         oldestHistoricBlock: BigInt(result.summary.oldestHistoricalBlock),
-        ...l2Blocks[i].getStats(),
+        ...block.getStats(),
       } satisfies L2BlockHandledStats);
       updateStatus = result;
     }
@@ -320,20 +319,18 @@ export class ServerWorldStateSynchronizer
    * @param l1ToL2Messages - The L1 to L2 messages for the block.
    * @returns Whether the block handled was produced by this same node.
    */
-  private async handleL2Block(l2Block: L2Block, l1ToL2Messages: Fr[]): Promise<WorldStateStatusFull> {
-    // First we check that the L1 to L2 messages hash to the block inHash.
-    // Note that we cannot optimize this check by checking the root of the subtree after inserting the messages
-    // to the real L1_TO_L2_MESSAGE_TREE (like we do in merkleTreeDb.handleL2BlockAndMessages(...)) because that
-    // tree uses pedersen and we don't have access to the converted root.
-    await this.verifyMessagesHashToInHash(l1ToL2Messages, l2Block.header.contentCommitment.inHash);
-
+  private async handleL2Block(
+    l2Block: L2BlockNew,
+    l1ToL2Messages: Fr[],
+    isFirstBlock: boolean,
+  ): Promise<WorldStateStatusFull> {
     // If the above check succeeds, we can proceed to handle the block.
     this.log.trace(`Pushing L2 block ${l2Block.number} to merkle tree db `, {
       blockNumber: l2Block.number,
       blockHash: await l2Block.hash().then(h => h.toString()),
       l1ToL2Messages: l1ToL2Messages.map(msg => msg.toString()),
     });
-    const result = await this.merkleTreeDb.handleL2BlockAndMessages(l2Block, l1ToL2Messages);
+    const result = await this.merkleTreeDb.handleL2BlockAndMessages(l2Block, l1ToL2Messages, isFirstBlock);
 
     if (this.currentState === WorldStateRunningState.SYNCHING && l2Block.number >= this.latestBlockNumberAtStart) {
       this.setCurrentState(WorldStateRunningState.RUNNING);
@@ -379,25 +376,5 @@ export class ServerWorldStateSynchronizer
   private setCurrentState(newState: WorldStateRunningState) {
     this.currentState = newState;
     this.log.debug(`Moved to state ${WorldStateRunningState[this.currentState]}`);
-  }
-
-  /**
-   * Verifies that the L1 to L2 messages hash to the block inHash.
-   * @param l1ToL2Messages - The L1 to L2 messages for the block.
-   * @param inHash - The inHash of the block.
-   * @throws If the L1 to L2 messages do not hash to the block inHash.
-   */
-  protected async verifyMessagesHashToInHash(l1ToL2Messages: Fr[], inHash: Fr) {
-    const treeCalculator = await MerkleTreeCalculator.create(
-      L1_TO_L2_MSG_SUBTREE_HEIGHT,
-      Buffer.alloc(32),
-      (lhs, rhs) => Promise.resolve(new SHA256Trunc().hash(lhs, rhs)),
-    );
-
-    const root = await treeCalculator.computeTreeRoot(l1ToL2Messages.map(msg => msg.toBuffer()));
-
-    if (!root.equals(inHash.toBuffer())) {
-      throw new Error('Obtained L1 to L2 messages failed to be hashed to the block inHash');
-    }
   }
 }

--- a/yarn-project/world-state/src/synchronizer/utils.test.ts
+++ b/yarn-project/world-state/src/synchronizer/utils.test.ts
@@ -1,0 +1,151 @@
+import { BlockNumber, CheckpointNumber } from '@aztec/foundation/branded-types';
+import { timesParallel } from '@aztec/foundation/collection';
+import { Fr } from '@aztec/foundation/fields';
+import type { L2BlockSource } from '@aztec/stdlib/block';
+import type { Checkpoint } from '@aztec/stdlib/checkpoint';
+import type { L1ToL2MessageSource } from '@aztec/stdlib/messaging';
+
+import { type MockProxy, mock } from 'jest-mock-extended';
+
+import { mockCheckpoint } from '../test/utils.js';
+import { findFirstBlocksInCheckpoints } from './utils.js';
+
+describe('findFirstBlocksInCheckpoints', () => {
+  let checkpoints: { checkpoint: Checkpoint; messages: Fr[] }[];
+  let blockAndMessagesSource: MockProxy<L2BlockSource & L1ToL2MessageSource>;
+
+  beforeAll(async () => {
+    // Generate 4 mock checkpoints, each with i + 1 blocks and i messages.
+    // The result should be:
+    // Checkpoint 1: [Block 1]
+    // Checkpoint 2: [Block 2, Block 3]
+    // Checkpoint 3: [Block 4, Block 5, Block 6]
+    // Checkpoint 4: [Block 7, Block 8, Block 9, Block 10]
+    checkpoints = await timesParallel(4, i =>
+      mockCheckpoint(CheckpointNumber(i + 1), {
+        numBlocks: i + 1,
+        startBlockNumber: Array(i + 1)
+          .fill(0)
+          .reduce((acc, _, index) => acc + index, 1),
+        numL1ToL2Messages: i,
+      }),
+    );
+  });
+
+  beforeEach(() => {
+    blockAndMessagesSource = mock<L2BlockSource & L1ToL2MessageSource>();
+
+    blockAndMessagesSource.getBlockHeader.mockImplementation(blockNumber => {
+      return Promise.resolve(checkpoints.flatMap(c => c.checkpoint.blocks).find(b => b.number === blockNumber)?.header);
+    });
+
+    blockAndMessagesSource.getCheckpointByArchive.mockImplementation(archiveRoot => {
+      return Promise.resolve(
+        checkpoints.find(c => c.checkpoint.blocks.at(-1)!.archive.root.equals(archiveRoot))?.checkpoint,
+      );
+    });
+
+    blockAndMessagesSource.getL1ToL2MessagesForCheckpoint.mockImplementation(checkpointNumber => {
+      return Promise.resolve(checkpoints.find(c => c.checkpoint.number === checkpointNumber)?.messages ?? []);
+    });
+
+    blockAndMessagesSource.getL1ToL2Messages.mockImplementation(blockNumber => {
+      // The messages of a checkpoint are added for the first block in the checkpoint.
+      return Promise.resolve(checkpoints.find(c => c.checkpoint.blocks[0].number === blockNumber)?.messages ?? []);
+    });
+  });
+
+  it('identifies block 1 as first block in checkpoint', async () => {
+    const blocks = [checkpoints[0].checkpoint.blocks[0]];
+
+    const result = await findFirstBlocksInCheckpoints(blocks, blockAndMessagesSource);
+
+    expect(result.size).toBe(1);
+    expect(result.get(BlockNumber(1))).toEqual(checkpoints[0].messages);
+  });
+
+  it('identifies first block even when not all blocks in the checkpoint are added', async () => {
+    // Only add block 2 for checkpoint 2.
+    const blocks = [checkpoints[1].checkpoint.blocks[0]];
+
+    const result = await findFirstBlocksInCheckpoints(blocks, blockAndMessagesSource);
+
+    expect(result.size).toBe(1);
+    expect(result.get(BlockNumber(2))).toEqual(checkpoints[1].messages);
+  });
+
+  it('does not identify blocks[0] as first block if previous block was in the same slot', async () => {
+    // Add all blocks except the first one from checkpoint 2.
+    const blocks = checkpoints[1].checkpoint.blocks.slice(1);
+
+    const result = await findFirstBlocksInCheckpoints(blocks, blockAndMessagesSource);
+
+    expect(result.size).toBe(0);
+  });
+
+  it('handles blocks in the middle of a checkpoint', async () => {
+    // Add all blocks from checkpoint 4 except the first and the last ones.
+    const blocks = checkpoints[3].checkpoint.blocks.slice(1, -1);
+
+    const result = await findFirstBlocksInCheckpoints(blocks, blockAndMessagesSource);
+
+    expect(result.size).toBe(0);
+  });
+
+  it('identifies a first block at the end of the given blocks', async () => {
+    const blocks = [checkpoints[1].checkpoint.blocks[1], checkpoints[2].checkpoint.blocks[0]];
+
+    const result = await findFirstBlocksInCheckpoints(blocks, blockAndMessagesSource);
+
+    expect(result.size).toBe(1);
+    expect(result.get(BlockNumber(4))).toEqual(checkpoints[2].messages);
+  });
+
+  it('identifies all first blocks in all checkpoints', async () => {
+    // Add all blocks from all checkpoints.
+    const blocks = checkpoints.flatMap(c => c.checkpoint.blocks);
+
+    const result = await findFirstBlocksInCheckpoints(blocks, blockAndMessagesSource);
+
+    expect(result.size).toBe(4);
+    expect(result.get(BlockNumber(1))).toEqual(checkpoints[0].messages);
+    expect(result.get(BlockNumber(2))).toEqual(checkpoints[1].messages);
+    expect(result.get(BlockNumber(4))).toEqual(checkpoints[2].messages);
+    expect(result.get(BlockNumber(7))).toEqual(checkpoints[3].messages);
+  });
+
+  it('identifies multiple first blocks across checkpoints', async () => {
+    // Add all blocks from all checkpoints.
+    const blocks = [
+      checkpoints[1].checkpoint.blocks[1],
+      ...checkpoints[2].checkpoint.blocks,
+      ...checkpoints[3].checkpoint.blocks,
+    ];
+
+    const result = await findFirstBlocksInCheckpoints(blocks, blockAndMessagesSource);
+
+    expect(result.size).toBe(2);
+    expect(result.get(BlockNumber(4))).toEqual(checkpoints[2].messages);
+    expect(result.get(BlockNumber(7))).toEqual(checkpoints[3].messages);
+  });
+
+  it('throws error if previous block header cannot be fetched', async () => {
+    // Return undefined for the previous block header.
+    blockAndMessagesSource.getBlockHeader.mockResolvedValue(undefined);
+
+    const blocks = checkpoints[1].checkpoint.blocks;
+
+    await expect(findFirstBlocksInCheckpoints(blocks, blockAndMessagesSource)).rejects.toThrow(/Failed to get block 1/);
+  });
+
+  it('throws error if L1 to L2 messages do not hash to checkpoint inHash', async () => {
+    // Return random messages for the checkpoint.
+    blockAndMessagesSource.getL1ToL2MessagesForCheckpoint.mockResolvedValue([Fr.random(), Fr.random()]);
+
+    const blocks = checkpoints[1].checkpoint.blocks;
+
+    await expect(findFirstBlocksInCheckpoints(blocks, blockAndMessagesSource)).rejects.toThrow(
+      /Obtained L1 to L2 messages failed to be hashed to the checkpoint inHash/,
+    );
+  });
+});

--- a/yarn-project/world-state/src/synchronizer/utils.ts
+++ b/yarn-project/world-state/src/synchronizer/utils.ts
@@ -1,0 +1,83 @@
+import { BlockNumber, type SlotNumber } from '@aztec/foundation/branded-types';
+import type { Fr } from '@aztec/foundation/fields';
+import type { L2BlockNew, L2BlockSource } from '@aztec/stdlib/block';
+import type { Checkpoint } from '@aztec/stdlib/checkpoint';
+import { type L1ToL2MessageSource, computeInHashFromL1ToL2Messages } from '@aztec/stdlib/messaging';
+
+/**
+ * Determine which blocks in the given array are the first block in a checkpoint.
+ * @param blocks - The candidate blocks, sorted by block number in ascending order.
+ * @param l2BlockSource - The L2 block source to use to fetch the checkpoints, block headers and L1->L2 messages.
+ * @returns A map of block numbers that begin a checkpoint to the L1->L2 messages for that checkpoint.
+ */
+export async function findFirstBlocksInCheckpoints(
+  blocks: L2BlockNew[],
+  l2BlockSource: L2BlockSource & L1ToL2MessageSource,
+): Promise<Map<number, Fr[]>> {
+  // Select the blocks that are the final block within each group of identical slot numbers.
+  let seenSlot: SlotNumber | undefined;
+  const maybeLastBlocks = [...blocks]
+    .reverse()
+    .filter(b => {
+      if (b.header.globalVariables.slotNumber !== seenSlot) {
+        seenSlot = b.header.globalVariables.slotNumber;
+        return true;
+      }
+      return false;
+    })
+    .reverse();
+
+  // Try to fetch the checkpoints for those blocks. If undefined (which should only occur for blocks.at(-1)),
+  // then the block is not the last one in a checkpoint.
+  // If we are not checking the inHashes below, only blocks.at(-1) would need its checkpoint header fetched.
+  const checkpointedBlocks = (
+    await Promise.all(
+      maybeLastBlocks.map(async b => ({
+        blockNumber: b.number,
+        // A checkpoint's archive root is the archive root of its last block.
+        checkpoint: await l2BlockSource.getCheckpointByArchive(b.archive.root),
+      })),
+    )
+  ).filter(b => b.checkpoint !== undefined) as { blockNumber: BlockNumber; checkpoint: Checkpoint }[];
+
+  // Verify that the L1->L2 messages hash to the checkpoint's inHash.
+  const checkpointedL1ToL2Messages: Fr[][] = await Promise.all(
+    checkpointedBlocks.map(b => l2BlockSource.getL1ToL2MessagesForCheckpoint(b.checkpoint!.number)),
+  );
+  checkpointedBlocks.forEach((b, i) => {
+    const computedInHash = computeInHashFromL1ToL2Messages(checkpointedL1ToL2Messages[i]);
+    const inHash = b.checkpoint.header.contentCommitment.inHash;
+    if (!computedInHash.equals(inHash)) {
+      throw new Error('Obtained L1 to L2 messages failed to be hashed to the checkpoint inHash');
+    }
+  });
+
+  // Compute the first block numbers, which should be right after each checkpointed block. Exclude blocks that haven't
+  // been added yet.
+  const firstBlockNumbers = checkpointedBlocks
+    .map(b => BlockNumber(b.blockNumber + 1))
+    .filter(n => n <= blocks.at(-1)!.number);
+  // Check if blocks[0] is the first block in a checkpoint.
+  if (blocks[0].number === 1) {
+    firstBlockNumbers.push(blocks[0].number);
+  } else {
+    const lastBlockHeader = await l2BlockSource.getBlockHeader(BlockNumber(blocks[0].number - 1));
+    if (!lastBlockHeader) {
+      throw new Error(`Failed to get block ${blocks[0].number - 1}`);
+    }
+    if (lastBlockHeader.globalVariables.slotNumber !== blocks[0].header.globalVariables.slotNumber) {
+      firstBlockNumbers.push(blocks[0].number);
+    }
+  }
+
+  // Fetch the L1->L2 messages for the first blocks and assign them to the map.
+  const messagesByBlockNumber = new Map<BlockNumber, Fr[]>();
+  await Promise.all(
+    firstBlockNumbers.map(async blockNumber => {
+      const l1ToL2Messages = await l2BlockSource.getL1ToL2Messages(blockNumber);
+      messagesByBlockNumber.set(blockNumber, l1ToL2Messages);
+    }),
+  );
+
+  return messagesByBlockNumber;
+}

--- a/yarn-project/world-state/src/test/integration.test.ts
+++ b/yarn-project/world-state/src/test/integration.test.ts
@@ -1,20 +1,21 @@
 import { MockPrefilledArchiver } from '@aztec/archiver/test';
-import { BlockNumber } from '@aztec/foundation/branded-types';
+import { BlockNumber, CheckpointNumber } from '@aztec/foundation/branded-types';
+import { timesAsync } from '@aztec/foundation/collection';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import type { Fr } from '@aztec/foundation/fields';
 import { type Logger, createLogger } from '@aztec/foundation/log';
 import { sleep } from '@aztec/foundation/sleep';
 import type { DataStoreConfig } from '@aztec/kv-store/config';
-import type { L2Block } from '@aztec/stdlib/block';
+import type { Checkpoint } from '@aztec/stdlib/checkpoint';
 import { MerkleTreeId } from '@aztec/stdlib/trees';
 
-import { jest } from '@jest/globals';
+import { describe, jest } from '@jest/globals';
 
 import { NativeWorldStateService } from '../native/native_world_state.js';
 import type { WorldStateConfig } from '../synchronizer/config.js';
 import { createWorldState } from '../synchronizer/factory.js';
 import { ServerWorldStateSynchronizer } from '../synchronizer/server_world_state_synchronizer.js';
-import { mockBlocks } from './utils.js';
+import { mockCheckpoint } from './utils.js';
 
 jest.setTimeout(60_000);
 
@@ -26,18 +27,21 @@ describe('world-state integration', () => {
   let config: WorldStateConfig & DataStoreConfig;
   let log: Logger;
 
-  let blocks: L2Block[];
-  let messages: Fr[][];
+  let checkpoints: { checkpoint: Checkpoint; messages: Fr[] }[];
 
-  const MAX_BLOCK_COUNT = 20;
+  const MAX_CHECKPOINT_COUNT = 20;
 
   beforeAll(async () => {
     log = createLogger('world-state:test:integration');
     rollupAddress = EthAddress.random();
     const db = await NativeWorldStateService.tmp(rollupAddress);
-    log.info(`Generating ${MAX_BLOCK_COUNT} mock blocks`);
-    ({ blocks, messages } = await mockBlocks(BlockNumber(1), MAX_BLOCK_COUNT, 1, db));
-    log.info(`Generated ${blocks.length} mock blocks`);
+    const fork = await db.fork(BlockNumber(0));
+    log.info(`Generating ${MAX_CHECKPOINT_COUNT} mock checkpoints`);
+    checkpoints = await timesAsync(MAX_CHECKPOINT_COUNT, i =>
+      mockCheckpoint(CheckpointNumber(i + 1), { startBlockNumber: BlockNumber(i + 1), fork }),
+    );
+    log.info(`Generated ${checkpoints.length} mock checkpoints`);
+    await fork.close();
   });
 
   beforeEach(async () => {
@@ -52,7 +56,7 @@ describe('world-state integration', () => {
       worldStateBlockHistory: 0,
     };
 
-    archiver = new MockPrefilledArchiver(blocks, messages);
+    archiver = new MockPrefilledArchiver(checkpoints);
 
     db = (await createWorldState(config)) as NativeWorldStateService;
     synchronizer = new TestWorldStateSynchronizer(db, archiver, config);
@@ -184,9 +188,13 @@ describe('world-state integration', () => {
       await synchronizer.start();
       await expectSynchedToBlock(5);
 
-      // Create blocks for an alternate chain forking off block 2
-      const { blocks, messages } = await mockBlocks(BlockNumber(3), 5, 1, db);
-      archiver.setPrefilledBlocks(blocks, messages);
+      // Create checkpoints for an alternate chain forking off checkpoint 2
+      const fork = await db.fork(BlockNumber(2));
+      const newCheckpoints = await timesAsync(5, i =>
+        mockCheckpoint(CheckpointNumber(i + 3), { startBlockNumber: BlockNumber(i + 3), fork }),
+      );
+      await fork.close();
+      archiver.setPrefilled(newCheckpoints);
 
       archiver.removeBlocks(3);
       await archiver.createBlocks(2);
@@ -263,11 +271,6 @@ describe('world-state integration', () => {
 });
 
 class TestWorldStateSynchronizer extends ServerWorldStateSynchronizer {
-  // Skip validation for the sake of this test
-  protected override verifyMessagesHashToInHash(_l1ToL2Messages: Fr[], _inHash: Fr): Promise<void> {
-    return Promise.resolve();
-  }
-
   // Stops the block stream but not the db so we can reuse it for another synchronizer
   public async stopBlockStream() {
     await this.blockStream?.stop();

--- a/yarn-project/world-state/src/test/utils.ts
+++ b/yarn-project/world-state/src/test/utils.ts
@@ -4,15 +4,17 @@ import {
   NULLIFIER_SUBTREE_HEIGHT,
   NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP,
 } from '@aztec/constants';
-import { BlockNumber } from '@aztec/foundation/branded-types';
+import { BlockNumber, type CheckpointNumber, SlotNumber } from '@aztec/foundation/branded-types';
 import { padArrayEnd } from '@aztec/foundation/collection';
 import { Fr } from '@aztec/foundation/fields';
-import { L2Block } from '@aztec/stdlib/block';
+import { L2BlockNew } from '@aztec/stdlib/block';
+import { Checkpoint } from '@aztec/stdlib/checkpoint';
 import type {
   IndexedTreeId,
   MerkleTreeReadOperations,
   MerkleTreeWriteOperations,
 } from '@aztec/stdlib/interfaces/server';
+import { computeInHashFromL1ToL2Messages } from '@aztec/stdlib/messaging';
 import { AppendOnlyTreeSnapshot, MerkleTreeId } from '@aztec/stdlib/trees';
 
 import type { NativeWorldStateService } from '../native/native_world_state.js';
@@ -22,17 +24,11 @@ export async function mockBlock(
   size: number,
   fork: MerkleTreeWriteOperations,
   maxEffects: number | undefined = 1000, // Defaults to the maximum tx effects.
+  numL1ToL2Messages: number = NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP,
+  isFirstBlock: boolean = true,
 ) {
-  const l2Block = await L2Block.random(
-    BlockNumber(Number(blockNum)),
-    size,
-    undefined,
-    undefined,
-    undefined,
-    undefined,
-    maxEffects,
-  );
-  const l1ToL2Messages = Array(NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP).fill(0).map(Fr.random);
+  const l2Block = await L2BlockNew.random(blockNum, { txsPerBlock: size, txOptions: { maxEffects } });
+  const l1ToL2Messages = mockL1ToL2Messages(numL1ToL2Messages);
 
   {
     const insertData = async (
@@ -64,7 +60,9 @@ export async function mockBlock(
       padArrayEnd(txEffect.noteHashes, Fr.ZERO, MAX_NOTE_HASHES_PER_TX),
     );
 
-    const l1ToL2MessagesPadded = padArrayEnd<Fr, number>(l1ToL2Messages, Fr.ZERO, NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP);
+    const l1ToL2MessagesPadded = isFirstBlock
+      ? padArrayEnd<Fr, number>(l1ToL2Messages, Fr.ZERO, NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP)
+      : l1ToL2Messages;
 
     const noteHashInsert = fork.appendLeaves(MerkleTreeId.NOTE_HASH_TREE, noteHashesPadded);
     const messageInsert = fork.appendLeaves(MerkleTreeId.L1_TO_L2_MESSAGE_TREE, l1ToL2MessagesPadded);
@@ -73,7 +71,7 @@ export async function mockBlock(
 
   const state = await fork.getStateReference();
   l2Block.header.state = state;
-  await fork.updateArchive(l2Block.getBlockHeader());
+  await fork.updateArchive(l2Block.header);
 
   const archiveState = await fork.getTreeInfo(MerkleTreeId.ARCHIVE);
 
@@ -86,7 +84,7 @@ export async function mockBlock(
 }
 
 export async function mockEmptyBlock(blockNum: BlockNumber, fork: MerkleTreeWriteOperations) {
-  const l2Block = L2Block.empty();
+  const l2Block = L2BlockNew.empty();
   const l1ToL2Messages = Array(16).fill(0).map(Fr.zero);
 
   l2Block.header.globalVariables.blockNumber = blockNum;
@@ -124,7 +122,7 @@ export async function mockEmptyBlock(blockNum: BlockNumber, fork: MerkleTreeWrit
 
   const state = await fork.getStateReference();
   l2Block.header.state = state;
-  await fork.updateArchive(l2Block.getBlockHeader());
+  await fork.updateArchive(l2Block.header);
 
   const archiveState = await fork.getTreeInfo(MerkleTreeId.ARCHIVE);
 
@@ -155,6 +153,47 @@ export async function mockBlocks(
   await tempFork.close();
 
   return { blocks, messages: messagesArray };
+}
+
+export function mockL1ToL2Messages(numL1ToL2Messages: number) {
+  return Array(numL1ToL2Messages).fill(0).map(Fr.random);
+}
+
+export async function mockCheckpoint(
+  checkpointNumber: CheckpointNumber,
+  {
+    startBlockNumber = BlockNumber(1),
+    numBlocks = 1,
+    numTxsPerBlock = 1,
+    numL1ToL2Messages = 1,
+    fork,
+  }: {
+    startBlockNumber?: BlockNumber;
+    numBlocks?: number;
+    numTxsPerBlock?: number;
+    numL1ToL2Messages?: number;
+    fork?: MerkleTreeWriteOperations;
+  } = {},
+) {
+  const slotNumber = SlotNumber(checkpointNumber * 10);
+  const blocksAndMessages = [];
+  for (let i = 0; i < numBlocks; i++) {
+    const blockNumber = BlockNumber(startBlockNumber + i);
+    const { block, messages } = fork
+      ? await mockBlock(blockNumber, numTxsPerBlock, fork, blockNumber === startBlockNumber ? numL1ToL2Messages : 0)
+      : {
+          block: await L2BlockNew.random(blockNumber, { txsPerBlock: numTxsPerBlock, slotNumber }),
+          messages: mockL1ToL2Messages(numL1ToL2Messages),
+        };
+    blocksAndMessages.push({ block, messages });
+  }
+
+  const messages = blocksAndMessages[0].messages;
+  const inHash = computeInHashFromL1ToL2Messages(messages);
+  const checkpoint = await Checkpoint.random(checkpointNumber, { numBlocks: 0, slotNumber, inHash });
+  checkpoint.blocks = blocksAndMessages.map(({ block }) => block);
+
+  return { checkpoint, messages };
 }
 
 export async function assertSameState(forkA: MerkleTreeReadOperations, forkB: MerkleTreeReadOperations) {

--- a/yarn-project/world-state/src/world-state-db/merkle_tree_db.ts
+++ b/yarn-project/world-state/src/world-state-db/merkle_tree_db.ts
@@ -2,7 +2,7 @@ import { MAX_NULLIFIERS_PER_TX, MAX_TOTAL_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX } f
 import { BlockNumber } from '@aztec/foundation/branded-types';
 import type { Fr } from '@aztec/foundation/fields';
 import type { IndexedTreeSnapshot, TreeSnapshot } from '@aztec/merkle-tree';
-import type { L2Block, L2BlockNew } from '@aztec/stdlib/block';
+import type { L2BlockNew } from '@aztec/stdlib/block';
 import type { ForkMerkleTreeOperations, MerkleTreeReadOperations } from '@aztec/stdlib/interfaces/server';
 import type { MerkleTreeId } from '@aztec/stdlib/trees';
 
@@ -40,13 +40,13 @@ export interface MerkleTreeAdminDatabase extends ForkMerkleTreeOperations {
    * Handles a single L2 block (i.e. Inserts the new note hashes into the merkle tree).
    * @param block - The L2 block to handle.
    * @param l1ToL2Messages - The L1 to L2 messages for the block.
-   * @param isFirstBlock - Whether the block is the first block in a checkpoint. Temporary hack to only insert l1 to l2
-   * messages for the first block in a checkpoint. TODO(#17027) Remove this.
+   * @param isFirstBlock - Whether the block is the first block in a checkpoint. The messages are padded and inserted
+   * to the tree for the first block in a checkpoint.
    */
   handleL2BlockAndMessages(
-    block: L2Block | L2BlockNew,
+    block: L2BlockNew,
     l1ToL2Messages: Fr[],
-    isFirstBlock?: boolean,
+    isFirstBlock: boolean,
   ): Promise<WorldStateStatusFull>;
 
   /**


### PR DESCRIPTION
L1->L2 messages should only be padded and inserted to the tree for the first block in a checkpoint.
This pr also removes all references to the to-be-deprecated `L2Block` in the world state package, except for the `blocks-added` event the synchronizer listens to, which is still emitting the `L2Block` struct (as part of the PublishedL2Block). 