### PR TITLE
chore: ACIR audit - part 11

### DIFF
--- a/barretenberg/cpp/src/barretenberg/chonk/chonk.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/chonk/chonk.test.cpp
@@ -227,7 +227,7 @@ TEST_F(ChonkTests, WrongProofComponentFailure)
 
         tampered_proof.goblin_proof.merge_proof = chonk_proof_2.goblin_proof.merge_proof;
 
-        EXPECT_THROW_OR_ABORT(Chonk::verify(tampered_proof, chonk_vk_1), ".*IPA verification fails.*");
+        EXPECT_THROW_WITH_MESSAGE(Chonk::verify(tampered_proof, chonk_vk_1), "IPA verification fails");
     }
 
     {
@@ -236,7 +236,7 @@ TEST_F(ChonkTests, WrongProofComponentFailure)
 
         tampered_proof.mega_proof = chonk_proof_2.mega_proof;
 
-        EXPECT_THROW_OR_ABORT(Chonk::verify(tampered_proof, chonk_vk_1), ".*IPA verification fails.*");
+        EXPECT_THROW_WITH_MESSAGE(Chonk::verify(tampered_proof, chonk_vk_1), "IPA verification fails");
     }
 
     {
@@ -245,7 +245,7 @@ TEST_F(ChonkTests, WrongProofComponentFailure)
 
         tampered_proof.goblin_proof.eccvm_proof = chonk_proof_2.goblin_proof.eccvm_proof;
 
-        EXPECT_THROW_OR_ABORT(Chonk::verify(tampered_proof, chonk_vk_1), ".*IPA verification fails.*");
+        EXPECT_THROW_WITH_MESSAGE(Chonk::verify(tampered_proof, chonk_vk_1), "IPA verification fails");
     }
 
     {

--- a/barretenberg/cpp/src/barretenberg/common/assert.hpp
+++ b/barretenberg/cpp/src/barretenberg/common/assert.hpp
@@ -4,6 +4,7 @@
 #include "barretenberg/common/compiler_hints.hpp"
 #include "barretenberg/common/throw_or_abort.hpp"
 #include <cstdint>
+#include <regex>
 #include <sstream>
 
 // Enable this for (VERY SLOW) stats on which asserts are hit the most. Note that the time measured will be very
@@ -68,9 +69,11 @@ struct AssertGuard {
     do {                                                                                                               \
         BB_BENCH_ASSERT("BB_ASSERT" #expression);                                                                      \
         if (!(BB_LIKELY(expression))) {                                                                                \
-            info("Assertion failed: (" #expression ")");                                                               \
-            __VA_OPT__(info("Reason   : ", __VA_ARGS__);)                                                              \
-            bb::assert_failure("");                                                                                    \
+            std::ostringstream oss;                                                                                    \
+            oss << "Assertion failed: (" #expression ")";                                                              \
+            __VA_OPT__(oss << "\nReason   : " << __VA_ARGS__;)                                                         \
+            info(oss.str());                                                                                           \
+            bb::assert_failure(oss.str());                                                                             \
         }                                                                                                              \
     } while (0)
 
@@ -169,8 +172,17 @@ struct AssertGuard {
 #ifdef BB_NO_EXCEPTIONS
 #define ASSERT_THROW_OR_ABORT(statement, matcher) ASSERT_DEATH(statement, matcher)
 #define EXPECT_THROW_OR_ABORT(statement, matcher) EXPECT_DEATH(statement, matcher)
+#define EXPECT_THROW_WITH_MESSAGE(code, expectedMessage) EXPECT_DEATH(code, expectedMessage)
 #else
 #define ASSERT_THROW_OR_ABORT(statement, matcher) ASSERT_THROW(statement, std::runtime_error)
 #define EXPECT_THROW_OR_ABORT(statement, matcher) EXPECT_THROW(statement, std::runtime_error)
+#define EXPECT_THROW_WITH_MESSAGE(code, expectedMessageRegex)                                                          \
+    try {                                                                                                              \
+        code;                                                                                                          \
+        FAIL() << "Expected exception with message matching: " << expectedMessageRegex;                                \
+    } catch (const std::exception& e) {                                                                                \
+        EXPECT_TRUE(std::regex_search(std::string(e.what()), std::regex(expectedMessageRegex)))                        \
+            << "Exception message: " << e.what() << "\nExpected to match regex: " << expectedMessageRegex;             \
+    }
 #endif // BB_NO_EXCEPTIONS
 // NOLINTEND

--- a/barretenberg/cpp/src/barretenberg/crypto/blake3s/blake3s.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/crypto/blake3s/blake3s.test.cpp
@@ -419,5 +419,5 @@ TEST(MiscBlake3s, TestVectors)
 TEST(MiscBlake3s, TooLargeInputTest)
 {
     std::vector<uint8_t> input(1025, 0);
-    EXPECT_THROW_OR_ABORT(blake3::blake3s(input), "Assertion failed");
+    EXPECT_THROW_WITH_MESSAGE(blake3::blake3s(input), "Assertion failed");
 }

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_format.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_format.test.cpp
@@ -1,0 +1,62 @@
+#include <gtest/gtest.h>
+#include <memory>
+#include <vector>
+
+#include "acir_format.hpp"
+#include "acir_format_mocks.hpp"
+#include "acir_to_constraint_buf.hpp"
+#include "barretenberg/common/streams.hpp"
+#include "barretenberg/dsl/acir_format/gate_count_constants.hpp"
+#include "barretenberg/op_queue/ecc_op_queue.hpp"
+
+#include "barretenberg/serialize/test_helper.hpp"
+
+using namespace bb;
+using namespace bb::crypto;
+using namespace acir_format;
+
+// Gate count pinning test suite
+template <typename Builder> class AcirFormatTests : public ::testing::Test {
+  protected:
+    static void SetUpTestSuite() { bb::srs::init_file_crs_factory(bb::srs::bb_crs_path()); }
+};
+
+using BuilderTypes = testing::Types<UltraCircuitBuilder, MegaCircuitBuilder>;
+TYPED_TEST_SUITE(AcirFormatTests, BuilderTypes);
+
+TYPED_TEST(AcirFormatTests, ExpressionWithOnlyConstantTermFails)
+{
+    // Test that circuit construction fails if we have an expression with only a constant term. This is expected
+    // behavior: an expression with only a constant term represent either:
+    // 1) an unsatisfied constraint if the constant term is non-zero
+    // 2) a zero constraint if the constant term is zero
+    // In both cases, we should not construct a circuit as either the circuit is not satisfiable, or there is zero gate.
+    Acir::Expression expr{ .q_c = bb::fr::one().to_buffer() };
+    Acir::Circuit circuit{
+        .current_witness_index = 0,
+        .opcodes = { Acir::Opcode{ Acir::Opcode::AssertZero{ .value = expr } } },
+        .public_parameters = {},
+        .return_values = {},
+    };
+
+    EXPECT_THROW_WITH_MESSAGE(circuit_serde_to_acir_format(circuit),
+                              "split_into_mul_quad_gates: resulted in zero gates.");
+}
+
+TYPED_TEST(AcirFormatTests, ExpressionWithCancellingCoefficientsFails)
+{
+    // Test that circuit construction fails if we have an expression where all linear terms cancel out. This is expected
+    // behavior as such an expression would result in a zero gate.
+    Acir::Expression expr{ .linear_combinations = { { bb::fr::one().to_buffer(), Acir::Witness{ 0 } },
+                                                    { bb::fr(-1).to_buffer(), Acir::Witness{ 0 } } },
+                           .q_c = bb::fr::zero().to_buffer() };
+    Acir::Circuit circuit{
+        .current_witness_index = 0,
+        .opcodes = { Acir::Opcode{ Acir::Opcode::AssertZero{ .value = expr } } },
+        .public_parameters = {},
+        .return_values = {},
+    };
+
+    EXPECT_THROW_WITH_MESSAGE(circuit_serde_to_acir_format(circuit),
+                              "acir_format::assert_zero_to_quad_constraints: produced an arithmetic zero gate.");
+}

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_format.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_format.test.cpp
@@ -15,7 +15,6 @@ using namespace bb;
 using namespace bb::crypto;
 using namespace acir_format;
 
-// Gate count pinning test suite
 template <typename Builder> class AcirFormatTests : public ::testing::Test {
   protected:
     static void SetUpTestSuite() { bb::srs::init_file_crs_factory(bb::srs::bb_crs_path()); }
@@ -59,4 +58,35 @@ TYPED_TEST(AcirFormatTests, ExpressionWithCancellingCoefficientsFails)
 
     EXPECT_THROW_WITH_MESSAGE(circuit_serde_to_acir_format(circuit),
                               "acir_format::assert_zero_to_quad_constraints: produced an arithmetic zero gate.");
+}
+
+TYPED_TEST(AcirFormatTests, PublicInputs)
+{
+    // Test that public inputs are handled correctly.
+    WitnessVector witnesses = { 2, 4, 6, 8, 10, 12 };
+
+    // 8 - 6 - 2 = 0
+    Acir::Expression expr{ .linear_combinations = { { bb::fr::one().to_buffer(), Acir::Witness{ 3 } },
+                                                    { bb::fr(-1).to_buffer(), Acir::Witness{ 2 } } },
+                           .q_c = bb::fr(-2).to_buffer() };
+
+    Acir::Circuit circuit{
+        .current_witness_index = static_cast<uint32_t>(witnesses.size() - 1),
+        .opcodes = { Acir::Opcode{ Acir::Opcode::AssertZero{ .value = expr } } },
+        .public_parameters =
+            Acir::PublicInputs{ .value = { Acir::Witness{ .value = 0 }, Acir::Witness{ .value = 1 } } },
+        .return_values = Acir::PublicInputs{ .value = { Acir::Witness{ .value = 4 }, Acir::Witness{ .value = 5 } } },
+    };
+
+    AcirFormat acir_format = circuit_serde_to_acir_format(circuit);
+    BB_ASSERT_EQ(acir_format.public_inputs, std::vector<uint32_t>({ 0, 1, 4, 5 }));
+
+    AcirProgram program{ acir_format, witnesses };
+    auto builder = create_circuit<TypeParam>(program, {});
+
+    for (size_t idx = 0; idx < acir_format.public_inputs.size(); ++idx) {
+        uint32_t pub_input_idx = acir_format.public_inputs[idx];
+        EXPECT_EQ(pub_input_idx, builder.public_inputs()[idx]);
+        EXPECT_EQ(witnesses[pub_input_idx], builder.get_variable(pub_input_idx));
+    }
 }

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_format_mocks.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_format_mocks.cpp
@@ -4,9 +4,11 @@
 // external_2:  { status: not started, auditors: [], date: YYYY-MM-DD }
 // =====================
 
-#include "acir_format.hpp"
+#include "acir_format_mocks.hpp"
 
-acir_format::AcirFormatOriginalOpcodeIndices create_empty_original_opcode_indices()
+namespace acir_format {
+
+AcirFormatOriginalOpcodeIndices create_empty_original_opcode_indices()
 {
     return acir_format::AcirFormatOriginalOpcodeIndices{
         .logic_constraints = {},
@@ -99,3 +101,5 @@ void mock_opcode_indices(acir_format::AcirFormat& constraint_system)
 
     constraint_system.num_acir_opcodes = static_cast<uint32_t>(current_opcode);
 }
+
+} // namespace acir_format

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_format_mocks.hpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_format_mocks.hpp
@@ -6,6 +6,18 @@
 
 #include "acir_format.hpp"
 
-acir_format::AcirFormatOriginalOpcodeIndices create_empty_original_opcode_indices();
+namespace acir_format {
 
-void mock_opcode_indices(acir_format::AcirFormat& constraint_system);
+/**
+ * @brief Create a empty instance of the AcirFormatOriginalOpcodeIndices struct. Used for testing purposes.
+ */
+AcirFormatOriginalOpcodeIndices create_empty_original_opcode_indices();
+
+/**
+ * @brief Mock the opcode indices of the constraints in an AcirFormat. Used for testing purposes.
+ *
+ * @param constraint_system
+ */
+void mock_opcode_indices(AcirFormat& constraint_system);
+
+} // namespace acir_format

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_to_constraint_buf.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_to_constraint_buf.cpp
@@ -35,7 +35,7 @@ bb::fr from_buffer_with_bound_checks(const std::vector<uint8_t>& buffer)
     return fr::serialize_from_buffer(buffer.data());
 }
 
-WitnessOrConstant<bb::fr> parse_input(Acir::FunctionInput input)
+WitnessOrConstant<bb::fr> parse_input(const Acir::FunctionInput& input)
 {
     WitnessOrConstant<bb::fr> result = std::visit(
         [&](auto&& e) {
@@ -61,7 +61,7 @@ WitnessOrConstant<bb::fr> parse_input(Acir::FunctionInput input)
     return result;
 }
 
-uint32_t get_witness_from_function_input(Acir::FunctionInput input)
+uint32_t get_witness_from_function_input(const Acir::FunctionInput& input)
 {
     BB_ASSERT(std::holds_alternative<Acir::FunctionInput::Witness>(input.value),
               "acir_format::get_witness_from_function_input: input must be a Witness variant. An error here means "
@@ -70,7 +70,7 @@ uint32_t get_witness_from_function_input(Acir::FunctionInput input)
     return std::get<Acir::FunctionInput::Witness>(input.value).value.value;
 }
 
-void update_max_witness_index(uint32_t witness_idx, AcirFormat& af)
+void update_max_witness_index(const uint32_t witness_idx, AcirFormat& af)
 {
     if (witness_idx != stdlib::IS_CONSTANT) {
         af.max_witness_index = std::max(af.max_witness_index, witness_idx);
@@ -326,12 +326,12 @@ AcirFormat circuit_serde_to_acir_format(Acir::Circuit const& circuit)
     af.num_acir_opcodes = static_cast<uint32_t>(circuit.opcodes.size());
     af.public_inputs = join({
         transform::map(circuit.public_parameters.value,
-                       [&](auto e) {
+                       [&](const Acir::Witness& e) {
                            update_max_witness_index(e.value, af);
                            return e.value;
                        }),
         transform::map(circuit.return_values.value,
-                       [&](auto e) {
+                       [&](const Acir::Witness& e) {
                            update_max_witness_index(e.value, af);
                            return e.value;
                        }),
@@ -597,9 +597,9 @@ void add_blackbox_func_call_to_acir_format(Acir::Opcode::BlackBoxFuncCall const&
                                            AcirFormat& af,
                                            size_t opcode_index)
 {
-    auto to_witness_or_constant = [&](auto& e) { return parse_input(e); };
-    auto to_witness = [&](auto& e) { return e.value; };
-    auto to_witness_from_input = [&](auto& e) { return get_witness_from_function_input(e); };
+    auto to_witness_or_constant = [&](const Acir::FunctionInput& e) { return parse_input(e); };
+    auto to_witness = [&](const Acir::Witness& e) { return e.value; };
+    auto to_witness_from_input = [&](const Acir::FunctionInput& e) { return get_witness_from_function_input(e); };
 
     std::visit(
         [&](auto&& arg) {

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_to_constraint_buf.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_to_constraint_buf.cpp
@@ -553,10 +553,9 @@ std::vector<mul_quad_<fr>> split_into_mul_quad_gates(Acir::Expression const& arg
         result.emplace_back(mul_quad);
     }
 
-    BB_ASSERT_EQ(!result.empty(),
-                 true,
-                 "split_into_mul_quad_gates: resulted in zero gates. This means that there is an expression with no  "
-                 "multiplication terms and no linear terms.");
+    BB_ASSERT(!result.empty(),
+              "split_into_mul_quad_gates: resulted in zero gates. This means that there is an expression with no  "
+              "multiplication terms and no linear terms.");
     result.shrink_to_fit();
 
     return result;
@@ -589,9 +588,8 @@ void assert_zero_to_quad_constraints(Acir::Opcode::AssertZero const& arg, AcirFo
     }
 
     for (auto const& mul_quad : mul_quads) {
-        BB_ASSERT_EQ(!is_zero_gate(mul_quad),
-                     true,
-                     "acir_format::assert_zero_to_quad_constraints: produced an arithmetic zero gate.");
+        BB_ASSERT(!is_zero_gate(mul_quad),
+                  "acir_format::assert_zero_to_quad_constraints: produced an arithmetic zero gate.");
     }
 }
 

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_to_constraint_buf.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_to_constraint_buf.cpp
@@ -1,5 +1,5 @@
 // === AUDIT STATUS ===
-// internal:    { status: not started, auditors: [], date: YYYY-MM-DD }
+// internal:    { status: Completed, auditors: [Federico], date: 2025-12-04 }
 // external_1:  { status: not started, auditors: [], date: YYYY-MM-DD }
 // external_2:  { status: not started, auditors: [], date: YYYY-MM-DD }
 // =====================
@@ -29,6 +29,12 @@ using namespace bb;
 
 /// ========= HELPERS ========= ///
 
+bb::fr from_buffer_with_bound_checks(const std::vector<uint8_t>& buffer)
+{
+    BB_ASSERT_EQ(buffer.size(), 32U, "acir_format::from_buffer_with_bound_checks: buffer size must be 32 bytes.");
+    return fr::serialize_from_buffer(buffer.data());
+}
+
 WitnessOrConstant<bb::fr> parse_input(Acir::FunctionInput input)
 {
     WitnessOrConstant<bb::fr> result = std::visit(
@@ -43,7 +49,7 @@ WitnessOrConstant<bb::fr> parse_input(Acir::FunctionInput input)
             } else if constexpr (std::is_same_v<T, Acir::FunctionInput::Constant>) {
                 return WitnessOrConstant<bb::fr>{
                     .index = bb::stdlib::IS_CONSTANT,
-                    .value = fr::serialize_from_buffer(&e.value[0]),
+                    .value = from_buffer_with_bound_checks(e.value),
                     .is_constant = true,
                 };
             } else {
@@ -313,6 +319,9 @@ T deserialize_any_format(std::vector<uint8_t>&& buf,
 
 AcirFormat circuit_serde_to_acir_format(Acir::Circuit const& circuit)
 {
+    BB_ASSERT_LT(
+        circuit.opcodes.size(), UINT32_MAX, "acir_format::circuit_serde_to_acir_format: too many opcodes in circuit.");
+
     AcirFormat af;
     af.num_acir_opcodes = static_cast<uint32_t>(circuit.opcodes.size());
     af.public_inputs = join({
@@ -436,7 +445,7 @@ WitnessVector witness_map_to_witness_vector(Witnesses::WitnessMap const& witness
             witness_vector.emplace_back(0);
             index++;
         }
-        witness_vector.emplace_back(fr::serialize_from_buffer(&e.second[0]));
+        witness_vector.emplace_back(from_buffer_with_bound_checks(e.second));
         index++;
     }
 
@@ -470,7 +479,7 @@ std::vector<mul_quad_<fr>> split_into_mul_quad_gates(Acir::Expression const& arg
             .b = std::get<2>(mul_term).value,
             .c = bb::stdlib::IS_CONSTANT,
             .d = bb::stdlib::IS_CONSTANT,
-            .mul_scaling = fr::serialize_from_buffer(&(std::get<0>(mul_term)[0])),
+            .mul_scaling = from_buffer_with_bound_checks(std::get<0>(mul_term)),
             .a_scaling = fr::zero(),
             .b_scaling = fr::zero(),
             .c_scaling = fr::zero(),
@@ -500,7 +509,7 @@ std::vector<mul_quad_<fr>> split_into_mul_quad_gates(Acir::Expression const& arg
 
         if (is_first_gate) {
             // First gate contains the constant term and uses all four wires
-            mul_quad.const_scaling = fr::serialize_from_buffer(&arg.q_c[0]);
+            mul_quad.const_scaling = from_buffer_with_bound_checks(arg.q_c);
             if (!linear_terms.empty()) {
                 add_linear_term_and_erase(mul_quad.d, mul_quad.d_scaling, linear_terms);
             }
@@ -534,7 +543,7 @@ std::vector<mul_quad_<fr>> split_into_mul_quad_gates(Acir::Expression const& arg
         }
         if (is_first_gate) {
             // First gate contains the constant term and uses all four wires
-            mul_quad.const_scaling = fr::serialize_from_buffer(&arg.q_c[0]);
+            mul_quad.const_scaling = from_buffer_with_bound_checks(arg.q_c);
             if (!linear_terms.empty()) {
                 add_linear_term_and_erase(mul_quad.d, mul_quad.d_scaling, linear_terms);
             }
@@ -544,7 +553,10 @@ std::vector<mul_quad_<fr>> split_into_mul_quad_gates(Acir::Expression const& arg
         result.emplace_back(mul_quad);
     }
 
-    BB_ASSERT(!result.empty(), "split_into_mul_quad_gates: resulted in zero gates.");
+    BB_ASSERT_EQ(!result.empty(),
+                 true,
+                 "split_into_mul_quad_gates: resulted in zero gates. This means that there is an expression with no  "
+                 "multiplication terms and no linear terms.");
     result.shrink_to_fit();
 
     return result;
@@ -563,19 +575,23 @@ void assert_zero_to_quad_constraints(Acir::Opcode::AssertZero const& arg, AcirFo
     std::vector<mul_quad_<fr>> mul_quads = split_into_mul_quad_gates(arg.value, linear_terms);
 
     if (is_single_gate) {
-        BB_ASSERT_EQ(mul_quads.size(), 1U, "acir_format::handle_arithmetic: expected a single gate.");
+        BB_ASSERT_EQ(mul_quads.size(), 1U, "acir_format::assert_zero_to_quad_constraints: expected a single gate.");
         auto mul_quad = mul_quads[0];
 
         af.quad_constraints.push_back(mul_quad);
         af.original_opcode_indices.quad_constraints.push_back(opcode_index);
     } else {
-        BB_ASSERT_GT(mul_quads.size(), 1U, "acir_format::handle_arithmetic: expected multiple gates but found one.");
+        BB_ASSERT_GT(mul_quads.size(),
+                     1U,
+                     "acir_format::assert_zero_to_quad_constraints: expected multiple gates but found one.");
         af.big_quad_constraints.push_back(mul_quads);
         af.original_opcode_indices.big_quad_constraints.push_back(opcode_index);
     }
 
     for (auto const& mul_quad : mul_quads) {
-        BB_ASSERT(!is_zero_gate(mul_quad), "acir_format::handle_arithmetic: produced an arithmetic zero gate.");
+        BB_ASSERT_EQ(!is_zero_gate(mul_quad),
+                     true,
+                     "acir_format::assert_zero_to_quad_constraints: produced an arithmetic zero gate.");
     }
 }
 
@@ -798,9 +814,9 @@ void add_memory_op_to_block_constraint(Acir::Opcode::MemoryOp const& mem_op, Blo
         BB_ASSERT_LTE(expr.linear_combinations.size(), 1U, "MemoryOp should have at most one linear term");
 
         const fr a_scaling = expr.linear_combinations.size() == 1
-                                 ? fr::serialize_from_buffer(std::get<0>(expr.linear_combinations[0]).data())
+                                 ? from_buffer_with_bound_checks(std::get<0>(expr.linear_combinations[0]))
                                  : fr::zero();
-        const fr constant_term = fr::serialize_from_buffer(expr.q_c.data());
+        const fr constant_term = from_buffer_with_bound_checks(expr.q_c);
 
         bool is_witness = a_scaling == fr::one() && constant_term == fr::zero();
         bool is_constant = a_scaling == fr::zero();
@@ -818,7 +834,7 @@ void add_memory_op_to_block_constraint(Acir::Opcode::MemoryOp const& mem_op, Blo
         BB_ASSERT(expr.mul_terms.empty(), "MemoryOp expression should not have multiplication terms");
         BB_ASSERT(expr.linear_combinations.empty(), "MemoryOp expression should not have linear terms");
 
-        const fr const_term = fr::serialize_from_buffer(&expr.q_c[0]);
+        const fr const_term = from_buffer_with_bound_checks(expr.q_c);
 
         BB_ASSERT((const_term == fr::one()) || (const_term == fr::zero()),
                   "MemoryOp expression should be either zero or one");
@@ -896,7 +912,7 @@ std::map<uint32_t, bb::fr> process_linear_terms(Acir::Expression const& expr)
 {
     std::map<uint32_t, bb::fr> linear_terms;
     for (const auto& linear_term : expr.linear_combinations) {
-        fr selector_value = fr::serialize_from_buffer(&(std::get<0>(linear_term)[0]));
+        fr selector_value = from_buffer_with_bound_checks(std::get<0>(linear_term));
         uint32_t witness_idx = std::get<1>(linear_term).value;
         if (linear_terms.contains(witness_idx)) {
             linear_terms[witness_idx] += selector_value; // Accumulate coefficients for duplicate witnesses

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_to_constraint_buf.hpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_to_constraint_buf.hpp
@@ -26,14 +26,14 @@ bb::fr from_buffer_with_bound_checks(const std::vector<uint8_t>& buffer);
 /**
  * @brief Parse an Acir::FunctionInput (which can either be a witness or a constant) into a WitnessOrConstant.
  */
-WitnessOrConstant<bb::fr> parse_input(Acir::FunctionInput input);
+WitnessOrConstant<bb::fr> parse_input(const Acir::FunctionInput& input);
 
 /**
  * @brief Extract the witness index from an Acir::FunctionInput representing a witness.
  *
  * @note The function asserts that the input is indeed a witness variant.
  */
-uint32_t get_witness_from_function_input(Acir::FunctionInput input);
+uint32_t get_witness_from_function_input(const Acir::FunctionInput& input);
 
 /**
  * @brief Update the max_witness_index.
@@ -43,7 +43,7 @@ uint32_t get_witness_from_function_input(Acir::FunctionInput input);
  * minus one to avoid buffer overrides.
  *
  */
-void update_max_witness_index(uint32_t witness_idx, AcirFormat& af);
+void update_max_witness_index(const uint32_t witness_idx, AcirFormat& af);
 
 /**
  * @brief Update max_witness_index by processing all witnesses in an Acir::Expression.

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_to_constraint_buf.hpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_to_constraint_buf.hpp
@@ -16,6 +16,14 @@ namespace acir_format {
 /// representations.
 
 /**
+ * @brief Deserialize an fr element from buffer. The function checks that the buffer is exactly 32 bytes long.
+ *
+ * @param buffer
+ * @return bb::fr
+ */
+bb::fr from_buffer_with_bound_checks(const std::vector<uint8_t>& buffer);
+
+/**
  * @brief Parse an Acir::FunctionInput (which can either be a witness or a constant) into a WitnessOrConstant.
  */
 WitnessOrConstant<bb::fr> parse_input(Acir::FunctionInput input);
@@ -65,7 +73,12 @@ void update_max_witness_index_from_opcode(Acir::Opcode const& opcode, AcirFormat
 ///   only bincode is supported.
 /// - The Acir::Circuit is transformed into AcirFormat, which is Barretenberg's internal representation of the Acir
 ///   constraints that have to be added to the Builder.
-/// - A buffer of bytes is deserialised into a WitnessVector, which is the list of witness values known at the time of
+/// - A buffer of bytes is deserialized according to either msgpack or bincode into an Acir::Circuit, which is just the
+///   representation of a function in terms of Acir::Opcodes, Acir::Witness, Acir::PublicInputs. Currently only
+///   bincode is supported.
+/// - The Acir::Circuit is transformed into AcirFormat, which is Barretenberg's internal representation of the Acir
+///   constraints that have to be added to the Builder.
+/// - A buffer of bytes is deserialized into a WitnessVector, which is the list of witness values known at the time of
 ///   noir program execution. This conversion takes a WitnessMap (which is a list of couples (witness_index,
 ///   witness_value)) and converts it to a vector of bb::fr elements. ACIR optimizes away some witnesses, so the
 ///   WitnessMap may have holes: witness indices go up, but not necessarily by one. The conversion accounts for these
@@ -79,7 +92,7 @@ void update_max_witness_index_from_opcode(Acir::Opcode const& opcode, AcirFormat
  * falling back to `bincode` if the format cannot be recognized. Currently only `bincode` is expected.
  *
  * @note The function is written so that it can deserialize either `msgpack` or `bincode` depending on the first byte
- * of the buffer. However, at the moment only `bincode` is supported, so we fail in case `msgpack` is encountered. Note
+ * of the buffer. However, currently only `bincode` is supported, so we fail in case `msgpack` is encountered. Note
  * that due to the lack of exception handling available in Wasm, the code cannot be structured to try `bincode` and
  * fall back to `msgpack` if that fails. Therefore, we look at the first byte and commit to a format based on that.
  */

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/block_constraint.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/block_constraint.test.cpp
@@ -177,9 +177,14 @@ using ROMTestConfigs = testing::Types<ROMTestParams<UltraCircuitBuilder, 0, 0, f
                                       ROMTestParams<UltraCircuitBuilder, 10, 0, false>,
                                       ROMTestParams<UltraCircuitBuilder, 10, 0, true>, // Test the case in which there
                                                                                        // are only constant operations
-                                      ROMTestParams<MegaCircuitBuilder, 10, 10, true>,
+                                      ROMTestParams<UltraCircuitBuilder, 10, 20, false>,
+                                      ROMTestParams<UltraCircuitBuilder, 10, 20, true>,
+                                      ROMTestParams<MegaCircuitBuilder, 0, 0, false>,
+                                      ROMTestParams<MegaCircuitBuilder, 10, 0, false>,
+                                      ROMTestParams<MegaCircuitBuilder, 10, 0, true>, // Test the case in which there
+                                                                                      // are only constant operations
+                                      ROMTestParams<MegaCircuitBuilder, 10, 20, false>,
                                       ROMTestParams<MegaCircuitBuilder, 10, 20, true>>;
-
 TYPED_TEST_SUITE(ROMTest, ROMTestConfigs);
 
 TYPED_TEST(ROMTest, GenerateVKFromConstraints)
@@ -417,9 +422,21 @@ class CallDataTestingFunctions {
       public:
         enum class Target : uint8_t { None, ReadValueIncremented };
 
-        static std::vector<Target> get_all() { return { Target::None, Target::ReadValueIncremented }; };
+        static std::vector<Target> get_all()
+        {
+            if constexpr (num_reads > 0) {
+                return { Target::None, Target::ReadValueIncremented };
+            }
+            return { Target::None };
+        }
 
-        static std::vector<std::string> get_labels() { return { "None", "ReadValueIncremented" }; };
+        static std::vector<std::string> get_labels()
+        {
+            if constexpr (num_reads > 0) {
+                return { "None", "ReadValueIncremented" };
+            }
+            return { "None" };
+        }
     };
 
     void generate_constraints(AcirConstraint& memory_constraint, WitnessVector& witness_values)
@@ -442,18 +459,20 @@ class CallDataTestingFunctions {
         std::vector<MemOp> trace;
 
         // Add read operations
-        for (size_t idx = 0; idx < num_reads; ++idx) {
-            MemOp mem_op;
-            const size_t calldata_idx_to_read = static_cast<size_t>(engine.get_random_uint32() % calldata_size);
-            const uint32_t index_for_read =
-                add_to_witness_and_track_indices(witness_values, bb::fr(calldata_idx_to_read));
-            bb::fr read_value = calldata_values[calldata_idx_to_read];
-            const uint32_t value_for_read = add_to_witness_and_track_indices(witness_values, read_value);
+        if constexpr (calldata_size > 0) {
+            for (size_t idx = 0; idx < num_reads; ++idx) {
+                MemOp mem_op;
+                const size_t calldata_idx_to_read = static_cast<size_t>(engine.get_random_uint32() % calldata_size);
+                const uint32_t index_for_read =
+                    add_to_witness_and_track_indices(witness_values, bb::fr(calldata_idx_to_read));
+                bb::fr read_value = calldata_values[calldata_idx_to_read];
+                const uint32_t value_for_read = add_to_witness_and_track_indices(witness_values, read_value);
 
-            mem_op = { .access_type = AccessType::Read,
-                       .index = WitnessOrConstant<bb::fr>::from_index(index_for_read),
-                       .value = WitnessOrConstant<bb::fr>::from_index(value_for_read) };
-            trace.push_back(mem_op);
+                mem_op = { .access_type = AccessType::Read,
+                           .index = WitnessOrConstant<bb::fr>::from_index(index_for_read),
+                           .value = WitnessOrConstant<bb::fr>::from_index(value_for_read) };
+                trace.push_back(mem_op);
+            }
         }
         if constexpr (perform_constant_ops) {
             add_constant_ops<AccessType::Read>(calldata_size, calldata_values, witness_values, trace);
@@ -474,16 +493,22 @@ class CallDataTestingFunctions {
             break;
         case InvalidWitness::Target::ReadValueIncremented:
             // Tamper with a random read value using the recorded witness index
-            const size_t random_read_idx = static_cast<size_t>(engine.get_random_uint32() % num_reads);
-            const uint32_t witness_idx = memory_constraint.trace[random_read_idx].index.index;
-            witness_values[witness_idx] += bb::fr(1);
+            if constexpr (num_reads > 0) {
+                const size_t random_read_idx = static_cast<size_t>(engine.get_random_uint32() % num_reads);
+                const uint32_t witness_idx = memory_constraint.trace[random_read_idx].index.index;
+                witness_values[witness_idx] += bb::fr(1);
+            }
             break;
         }
     }
 };
 
-using CallDataTestConfigs = testing::Types<CallDataTestParams<CallDataType::Primary, 10, 5, false>,
-                                           CallDataTestParams<CallDataType::Primary, 10, 5, true>>;
+using CallDataTestConfigs = testing::Types<CallDataTestParams<CallDataType::Primary, 0, 0, false>,
+                                           CallDataTestParams<CallDataType::Primary, 10, 5, false>,
+                                           CallDataTestParams<CallDataType::Primary, 10, 5, true>,
+                                           CallDataTestParams<CallDataType::Secondary, 0, 0, false>,
+                                           CallDataTestParams<CallDataType::Secondary, 10, 5, false>,
+                                           CallDataTestParams<CallDataType::Secondary, 10, 5, true>>;
 
 template <typename Params>
 class CallDataTests : public ::testing::Test,
@@ -557,61 +582,22 @@ class ReturnDataTestingFunctions {
     }
 };
 
-static constexpr size_t RETURNDATA_SIZE = 10;
-class ReturnDataTests : public ::testing::Test, public TestClass<ReturnDataTestingFunctions<RETURNDATA_SIZE>> {
+template <size_t ReturnDataSize_> class ReturnDataTestsParams {
+  public:
+    static constexpr size_t returndata_size = ReturnDataSize_;
+};
+
+template <typename Params>
+class ReturnDataTests : public ::testing::Test, public TestClass<ReturnDataTestingFunctions<Params::returndata_size>> {
   protected:
     static void SetUpTestSuite() { bb::srs::init_file_crs_factory(bb::srs::bb_crs_path()); }
 };
 
-TEST_F(ReturnDataTests, GenerateVKFromConstraints)
+using ReturnDataTestConfigs = testing::Types<ReturnDataTestsParams<0>, ReturnDataTestsParams<10>>;
+
+TYPED_TEST_SUITE(ReturnDataTests, ReturnDataTestConfigs);
+
+TYPED_TEST(ReturnDataTests, GenerateVKFromConstraints)
 {
-    test_vk_independence<MegaFlavor>();
-}
-
-template <typename Builder> class EmptyBlockConstraintTests : public ::testing::Test {};
-
-using BuilderTypes = testing::Types<UltraCircuitBuilder, MegaCircuitBuilder>;
-TYPED_TEST_SUITE(EmptyBlockConstraintTests, BuilderTypes);
-
-// Test that all block constraint types handle empty initialization gracefully
-TYPED_TEST(EmptyBlockConstraintTests, EmptyBlockConstraints)
-{
-    using Builder = TypeParam;
-
-    std::vector<std::pair<BlockType, CallDataType>> types_to_test;
-
-    // Test each block constraint type
-    if constexpr (IsUltraBuilder<Builder>) {
-        types_to_test = { { BlockType::ROM, CallDataType::None }, { BlockType::RAM, CallDataType::None } };
-    } else {
-        types_to_test = { { BlockType::ROM, CallDataType::None },
-                          { BlockType::RAM, CallDataType::None },
-                          { BlockType::CallData, CallDataType::Primary },
-                          { BlockType::CallData, CallDataType::Secondary },
-                          { BlockType::ReturnData, CallDataType::None } };
-    }
-
-    // Create empty block constraint
-    for (auto type : types_to_test) {
-        BlockConstraint block{
-            .init = {},  // Empty initialization data
-            .trace = {}, // Empty trace
-            .type = type.first,
-            .calldata_id = type.second,
-        };
-
-        AcirProgram program;
-        program.constraints = {
-            .num_acir_opcodes = 1,
-            .public_inputs = {},
-            .block_constraints = { block },
-            .original_opcode_indices = create_empty_original_opcode_indices(),
-        };
-
-        mock_opcode_indices(program.constraints);
-
-        // Circuit construction should succeed without errors
-        auto circuit = create_circuit<Builder>(program);
-        EXPECT_TRUE(CircuitChecker::check(circuit));
-    }
+    TestFixture::template test_vk_independence<MegaFlavor>();
 }

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/logic_constraint.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/logic_constraint.test.cpp
@@ -245,13 +245,12 @@ TYPED_TEST(LogicConstraintTestsBothConstant, Tampering)
     }
 
     {
-        EXPECT_THROW_OR_ABORT(TestFixture::test_constraints(TestFixture::InvalidWitnessTarget::Input1BitSize),
-                              ::testing::HasSubstr("field_t: Left operand in logic gate exceeds specified bit length"));
+        EXPECT_THROW_WITH_MESSAGE(TestFixture::test_constraints(TestFixture::InvalidWitnessTarget::Input1BitSize),
+                                  "field_t: Left operand in logic gate exceeds specified bit length");
     }
 
     {
-        EXPECT_THROW_OR_ABORT(
-            TestFixture::test_constraints(TestFixture::InvalidWitnessTarget::Input2BitSize),
-            ::testing::HasSubstr("field_t: Right operand in logic gate exceeds specified bit length"));
+        EXPECT_THROW_WITH_MESSAGE(TestFixture::test_constraints(TestFixture::InvalidWitnessTarget::Input2BitSize),
+                                  "field_t: Right operand in logic gate exceeds specified bit length");
     }
 }

--- a/barretenberg/cpp/src/barretenberg/ecc/fields/field_declarations.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/fields/field_declarations.hpp
@@ -140,7 +140,9 @@ template <class Params_> struct alignas(32) field {
     constexpr explicit operator bool() const
     {
         field out = from_montgomery_form();
-        BB_ASSERT(out.data[0] == 0 || out.data[0] == 1);
+        if (out.data[0] != 0 && out.data[0] != 1) {
+            bb::assert_failure("Cannot convert field element to bool unless it is 0 or 1");
+        }
         return static_cast<bool>(out.data[0]);
     }
 

--- a/barretenberg/cpp/src/barretenberg/ecc/fields/field_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/fields/field_impl.hpp
@@ -576,7 +576,9 @@ template <class T> constexpr field<T> field<T>::tonelli_shanks_sqrt() const noex
             }
         }
 
-        BB_ASSERT(count != table_size);
+        if (count == table_size) {
+            bb::assert_failure("Tonelli-Shanks: count == table_size");
+        }
         e_slices[table_index] = count;
     }
 

--- a/barretenberg/cpp/src/barretenberg/goblin/merge.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/goblin/merge.test.cpp
@@ -511,9 +511,9 @@ TYPED_TEST(MergeTests, DifferentTranscriptOriginTagFailure)
 
     // Catch the exception and verify it's the expected cross-transcript error
 #ifndef NDEBUG
-    EXPECT_THROW_OR_ABORT([[maybe_unused]] auto result =
-                              verifier_2.verify_proof(proof_2_recursive, input_commitments_1),
-                          "Tags from different transcripts were involved in the same computation");
+    EXPECT_THROW_WITH_MESSAGE([[maybe_unused]] auto result =
+                                  verifier_2.verify_proof(proof_2_recursive, input_commitments_1),
+                              "Tags from different transcripts were involved in the same computation");
 #endif
 }
 

--- a/barretenberg/cpp/src/barretenberg/numeric/general/general.hpp
+++ b/barretenberg/cpp/src/barretenberg/numeric/general/general.hpp
@@ -22,7 +22,10 @@ namespace bb::numeric {
  */
 template <typename T> constexpr T ceil_div(const T& numerator, const T& denominator)
 {
-    BB_ASSERT(denominator > 0, "Denominator must be greater than zero.");
+    if (denominator == 0) {
+        bb::assert_failure("Denominator must be greater than zero.");
+    }
+
     static_assert(std::is_integral_v<T>, "Type must be an integral type.");
     return (numerator + denominator - 1) / denominator;
 }

--- a/barretenberg/cpp/src/barretenberg/numeric/general/general.hpp
+++ b/barretenberg/cpp/src/barretenberg/numeric/general/general.hpp
@@ -22,7 +22,7 @@ namespace bb::numeric {
  */
 template <typename T> constexpr T ceil_div(const T& numerator, const T& denominator)
 {
-    if (denominator == 0) {
+    if (denominator <= 0) {
         bb::assert_failure("Denominator must be greater than zero.");
     }
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/hash/blake3s/blake3s.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/hash/blake3s/blake3s.cpp
@@ -181,8 +181,9 @@ template <typename Builder> void Blake3s<Builder>::hasher_finalize(const blake3_
 
 template <typename Builder> byte_array<Builder> Blake3s<Builder>::hash(const byte_array_ct& input)
 {
-    BB_ASSERT(input.size() <= BLAKE3_CHUNK_LEN,
-              "Barretenberg does not support blake3s with input lengths greater than 1024 bytes.");
+    BB_ASSERT_LTE(input.size(),
+                  BLAKE3_CHUNK_LEN,
+                  "Barretenberg does not support blake3s with input lengths greater than 1024 bytes.");
 
     // Create zero-filled constant buffer for hasher (will be properly initialized by hasher_init)
     Builder* ctx = input.get_context();

--- a/barretenberg/cpp/src/barretenberg/stdlib/hash/blake3s/blake3s.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/hash/blake3s/blake3s.test.cpp
@@ -70,8 +70,8 @@ TEST(stdlib_blake3s, test_too_large_input)
     std::vector<uint8_t> input_v(1025, 0);
 
     byte_array_ct input_arr(&builder, input_v);
-    EXPECT_THROW_OR_ABORT(stdlib::Blake3s<UltraBuilder>::hash(input_arr),
-                          "Barretenberg does not support blake3s with input lengths greater than 1024 bytes.");
+    EXPECT_THROW_WITH_MESSAGE(stdlib::Blake3s<UltraBuilder>::hash(input_arr),
+                              "Barretenberg does not support blake3s with input lengths greater than 1024 bytes.");
 }
 
 TEST(stdlib_blake3s, test_witness_and_constant)

--- a/barretenberg/cpp/src/barretenberg/stdlib/hash/poseidon2/poseidon2.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/hash/poseidon2/poseidon2.test.cpp
@@ -136,7 +136,7 @@ template <typename Builder> class StdlibPoseidon2 : public testing::Test {
         }
 
         native_poseidon2::hash(inputs);
-        EXPECT_THROW_OR_ABORT(poseidon2::hash(witness_inputs), ".*Sponge inputs should not be stdlib constants.*");
+        EXPECT_THROW_WITH_MESSAGE(poseidon2::hash(witness_inputs), "Sponge inputs should not be stdlib constants");
     }
 
     static void test_padding_collisions()

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_edge_cases.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_edge_cases.test.cpp
@@ -578,7 +578,7 @@ template <typename BigField> class stdlib_bigfield_edge_cases : public testing::
 
 #ifndef NDEBUG
             // In debug mode, we should hit an assertion failure
-            EXPECT_THROW_OR_ABORT(a_ct / constant_zero, "bigfield: prime limb diff is zero, but expected non-zero");
+            EXPECT_THROW_WITH_MESSAGE(a_ct / constant_zero, "bigfield: prime limb diff is zero, but expected non-zero");
 #endif
         }
         {
@@ -590,7 +590,7 @@ template <typename BigField> class stdlib_bigfield_edge_cases : public testing::
 
 #ifndef NDEBUG
             fq_ct constant_zero = fq_ct(&builder, uint256_t(0));
-            EXPECT_THROW_OR_ABORT(a_ct / constant_zero, "bigfield: division by zero in constant division");
+            EXPECT_THROW_WITH_MESSAGE(a_ct / constant_zero, "bigfield: division by zero in constant division");
 #endif
         }
         {
@@ -599,8 +599,8 @@ template <typename BigField> class stdlib_bigfield_edge_cases : public testing::
             // numerator is empty, denominator is constant
 #ifndef NDEBUG
             fq_ct constant_zero = fq_ct(&builder, uint256_t(0));
-            EXPECT_THROW_OR_ABORT(fq_ct::div_check_denominator_nonzero({}, constant_zero),
-                                  "bigfield: prime limb diff is zero, but expected non-zero");
+            EXPECT_THROW_WITH_MESSAGE(fq_ct::div_check_denominator_nonzero({}, constant_zero),
+                                      "bigfield: prime limb diff is zero, but expected non-zero");
 #endif
         }
     }

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup.test.cpp
@@ -687,7 +687,7 @@ template <typename TestType> class stdlib_biggroup : public testing::Test {
 
         // With the new assertion, attempting to double a point with y = 0 should throw
         // because for valid curves like bn254, y = 0 cannot occur on the curve
-        EXPECT_THROW_OR_ABORT(a.dbl(), "Attempting to dbl a point with y = 0, not allowed.");
+        EXPECT_THROW_WITH_MESSAGE(a.dbl(), "Attempting to dbl a point with y = 0, not allowed.");
     }
 
     static void test_add_equals_dbl()

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bool/bool.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bool/bool.cpp
@@ -142,7 +142,8 @@ template <typename Builder> bool_t<Builder>& bool_t<Builder>::operator=(bool_t&&
  */
 template <typename Builder> bool_t<Builder>& bool_t<Builder>::operator=(const witness_t<Builder>& other)
 {
-    BB_ASSERT((other.witness == bb::fr::one()) || (other.witness == bb::fr::zero()));
+    BB_ASSERT((other.witness == bb::fr::one()) || (other.witness == bb::fr::zero()),
+              "bool_t: witness value is not 0 or 1");
     context = other.context;
     witness_bool = other.witness == bb::fr::one();
     witness_index = other.witness_index;
@@ -424,7 +425,7 @@ template <typename Builder> void bool_t<Builder>::assert_equal(const bool_t& rhs
     Builder* ctx = validate_context<Builder>(rhs.get_context(), lhs.get_context());
 
     if (lhs.is_constant() && rhs.is_constant()) {
-        BB_ASSERT_EQ(lhs.get_value(), rhs.get_value());
+        BB_ASSERT_EQ(lhs.get_value(), rhs.get_value(), "bool_t::assert_equal: constants are not equal");
     } else if (lhs.is_constant()) {
         BB_ASSERT(!lhs.witness_inverted);
         // if rhs is inverted, flip the value of the lhs constant

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bool/bool.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bool/bool.test.cpp
@@ -124,8 +124,8 @@ template <class Builder_> class BoolTest : public ::testing::Test {
         EXPECT_EQ(builder.get_num_finalized_gates_inefficient() - num_gates_start, 0);
 
         // Out-of-circuit failure when witness points to a non-bool value.
-        EXPECT_THROW_OR_ABORT(bool_witness = bool_ct::from_witness_index_unsafe(&builder, non_bool_witness_idx),
-                              "bool_t: creating a witness bool from a non-boolean value");
+        EXPECT_THROW_WITH_MESSAGE(bool_witness = bool_ct::from_witness_index_unsafe(&builder, non_bool_witness_idx),
+                                  "bool_t: creating a witness bool from a non-boolean value");
     }
     void test_construct_from_witness()
     {
@@ -147,8 +147,8 @@ template <class Builder_> class BoolTest : public ::testing::Test {
         uint256_t random_value(engine.get_random_uint256());
 
         if (random_value * random_value - random_value != 0) {
-            EXPECT_THROW_OR_ABORT(a_incorrect = witness_ct(&builder, random_value),
-                                  "((other.witness == bb::fr::one()) || (other.witness == bb::fr::zero()))");
+            EXPECT_THROW_WITH_MESSAGE(a_incorrect = witness_ct(&builder, random_value),
+                                      "bool_t: witness value is not 0 or 1");
         };
     }
 
@@ -185,8 +185,8 @@ template <class Builder_> class BoolTest : public ::testing::Test {
 
         // Failure test
         Builder builder = Builder();
-        EXPECT_THROW_OR_ABORT(auto new_bool = bool_ct(witness_ct(&builder, 2), use_range_constraint),
-                              "bool_t: witness value is not 0 or 1");
+        EXPECT_THROW_WITH_MESSAGE(auto new_bool = bool_ct(witness_ct(&builder, 2), use_range_constraint),
+                                  "bool_t: witness value is not 0 or 1");
     }
     void test_AND()
     {
@@ -245,7 +245,7 @@ template <class Builder_> class BoolTest : public ::testing::Test {
                 bool_ct b = create_bool_ct(rhs, &builder);
 
                 if (a.is_constant() && b.is_constant() && !(!a.get_value() || b.get_value())) {
-                    EXPECT_THROW_OR_ABORT(a.must_imply(b), R"(\(lhs\.get_value\(\) == rhs\.get_value\(\)\))");
+                    EXPECT_THROW_WITH_MESSAGE(a.must_imply(b), "bool_t::assert_equal: constants are not equal");
                 } else {
                     bool result_is_constant = (!a || b).is_constant();
 
@@ -448,7 +448,7 @@ template <class Builder_> class BoolTest : public ::testing::Test {
                     EXPECT_EQ(CircuitChecker::check(builder), !failed);
                 } else {
                     if (failed) {
-                        EXPECT_THROW_OR_ABORT(a.assert_equal(b), R"(\(lhs\.get_value\(\) == rhs\.get_value\(\)\))");
+                        EXPECT_THROW_WITH_MESSAGE(a.assert_equal(b), "bool_t::assert_equal: constants are not equal");
                     }
                 }
             }

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/byte_array/byte_array.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/byte_array/byte_array.test.cpp
@@ -175,16 +175,16 @@ template <class Builder> class ByteArrayTest : public ::testing::Test {
             uint256_t overflowing_value(fr::modulus + 100);
 
             test_val = field_ct(&builder, bb::fr(overflowing_value));
-            EXPECT_THROW_OR_ABORT(byte_array<Builder> failure_array(test_val, 32, overflowing_value),
-                                  "byte_array: y_hi doesn't fit in 128 bits");
+            EXPECT_THROW_WITH_MESSAGE(byte_array<Builder> failure_array(test_val, 32, overflowing_value),
+                                      "byte_array: y_hi doesn't fit in 128 bits");
         }
 
         {
             // Test the case when (r-1).lo - x.lo + 2^128 is not a 129 bit integer, i.e. is negative.
             uint256_t random_overflowing_value("0xcf9bb18d1ece5fd647afba497e7ea7a3d3bdb158855487614a97cd3d2a1954b2");
             test_val = field_ct(&builder, bb::fr(random_overflowing_value));
-            EXPECT_THROW_OR_ABORT(byte_array<Builder> failure_array(test_val, 32, random_overflowing_value),
-                                  "byte_array: y_hi doesn't fit in 128 bits");
+            EXPECT_THROW_WITH_MESSAGE(byte_array<Builder> failure_array(test_val, 32, random_overflowing_value),
+                                      "byte_array: y_hi doesn't fit in 128 bits");
         }
         // Make sure no gates are added
         EXPECT_TRUE(gates_start == builder.get_num_finalized_gates_inefficient());

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/field/field.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/field/field.cpp
@@ -79,7 +79,8 @@ template <typename Builder> field_t<Builder>::operator bool_t<Builder>() const
     // After ensuring that `additive_constant` \in {0, 1}, we set the `.witness_bool` field of `result` to match the
     // value of `additive_constant`.
     if (is_constant()) {
-        BB_ASSERT(additive_constant == bb::fr::one() || additive_constant == bb::fr::zero());
+        BB_ASSERT(additive_constant == bb::fr::one() || additive_constant == bb::fr::zero(),
+                  "Attempting to create a bool_t from a witness_t not satisfying x^2 - x = 0");
         bool_t<Builder> result(context);
         result.witness_bool = (additive_constant == bb::fr::one());
         result.set_origin_tag(tag);
@@ -106,9 +107,8 @@ template <typename Builder> field_t<Builder>::operator bool_t<Builder>() const
     }
     // Get the normalized value of the witness
     bb::fr witness = context->get_variable(witness_idx);
-    BB_ASSERT_EQ((witness == bb::fr::zero()) || (witness == bb::fr::one()),
-                 true,
-                 "Attempting to create a bool_t from a witness_t not satisfying x^2 - x = 0");
+    BB_ASSERT(witness == bb::fr::zero() || witness == bb::fr::one(),
+              "Attempting to create a bool_t from a witness_t not satisfying x^2 - x = 0");
     bool_t result(context, witness == bb::fr::one());
     result.witness_inverted = result_inverted;
     result.witness_index = witness_idx;
@@ -459,7 +459,7 @@ template <typename Builder> field_t<Builder> field_t<Builder>::pow(const uint32_
 template <typename Builder> field_t<Builder> field_t<Builder>::pow(const field_t& exponent) const
 {
     uint256_t exponent_value = exponent.get_value();
-    BB_ASSERT_LT(exponent_value.get_msb(), 32U);
+    BB_ASSERT_LT(exponent_value.get_msb(), 32U, "Exponent too large in field_t::pow");
 
     if (is_constant() && exponent.is_constant()) {
         return field_t(get_value().pow(exponent_value));

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/field/field.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/field/field.test.cpp
@@ -169,13 +169,12 @@ template <typename Builder> class stdlib_field : public testing::Test {
         // Check that the conversion aborts in the case of random field elements.
         bool_ct invalid_bool;
         // Case 4: Invalid constant conversion
-        EXPECT_THROW_OR_ABORT(
-            invalid_bool = bool_ct(field_ct(input_array.back())),
-            "Assertion failed: (additive_constant == bb::fr::one() || additive_constant == bb::fr::zero())");
+        EXPECT_THROW_WITH_MESSAGE(invalid_bool = bool_ct(field_ct(input_array.back())),
+                                  "Attempting to create a bool_t from a witness_t not satisfying x\\^2 - x = 0");
         // Case 5: Invalid witness conversion
         Builder builder = Builder();
-        EXPECT_THROW_OR_ABORT(invalid_bool = bool_ct(field_ct(witness_ct(&builder, input_array.back()))),
-                              "Assertion failed: ((witness == bb::fr::zero()) || (witness == bb::fr::one()) == true)");
+        EXPECT_THROW_WITH_MESSAGE(invalid_bool = bool_ct(field_ct(witness_ct(&builder, input_array.back()))),
+                                  "Attempting to create a bool_t from a witness_t not satisfying x\\^2 - x = 0");
     }
     /**
      * @brief Test that bool is converted correctly
@@ -364,7 +363,7 @@ template <typename Builder> class stdlib_field : public testing::Test {
         {
             field_ct a(&builder, 3);
             field_ct b(&builder, 7);
-            EXPECT_THROW_OR_ABORT(a.assert_equal(b), "field_t::assert_equal: constants are not equal");
+            EXPECT_THROW_WITH_MESSAGE(a.assert_equal(b), "field_t::assert_equal: constants are not equal");
         }
 
         // Constant == witness
@@ -483,13 +482,13 @@ template <typename Builder> class stdlib_field : public testing::Test {
         {
             // Case 1. Numerator = const, denominator = const 0. Check that the division is aborted
             b = 0;
-            EXPECT_THROW_OR_ABORT(a / b, ".*");
+            EXPECT_THROW(a / b, std::runtime_error);
         }
         { // Case 2. Numerator != const, denominator = const 0. Check that the division is aborted
             Builder builder = Builder();
             field_ct a = witness_ct(&builder, bb::fr::random_element());
             b = 0;
-            EXPECT_THROW_OR_ABORT(a / b, ".*");
+            EXPECT_THROW(a / b, std::runtime_error);
         }
         {
             // Case 3. Numerator != const, denominator = witness 0 . Check that the circuit fails.
@@ -539,7 +538,7 @@ template <typename Builder> class stdlib_field : public testing::Test {
         }
 
         a = 0;
-        EXPECT_THROW_OR_ABORT(a.invert(), "field_t::invert denominator is constant 0");
+        EXPECT_THROW_WITH_MESSAGE(a.invert(), "field_t::invert denominator is constant 0");
     }
     static void test_postfix_increment()
     {
@@ -767,7 +766,7 @@ template <typename Builder> class stdlib_field : public testing::Test {
         }
         { // a is a const 0
             a = field_ct(0);
-            EXPECT_THROW_OR_ABORT(a.assert_is_not_zero(), "assert_is_not_zero");
+            EXPECT_THROW_WITH_MESSAGE(a.assert_is_not_zero(), "assert_is_not_zero");
         }
     }
 
@@ -1105,10 +1104,10 @@ template <typename Builder> class stdlib_field : public testing::Test {
 
         [[maybe_unused]] field_ct base = witness_ct(&builder, base_val);
         field_ct exponent = witness_ct(&builder, exponent_val);
-        EXPECT_THROW_OR_ABORT(base.pow(exponent), "Assertion failed: \\(exponent_value.get_msb\\(\\) < 32\\)");
+        EXPECT_THROW_WITH_MESSAGE(base.pow(exponent), "Exponent too large in field_t::pow");
 
         exponent = field_ct(exponent_val);
-        EXPECT_THROW_OR_ABORT(base.pow(exponent), "Assertion failed: \\(exponent_value.get_msb\\(\\) < 32\\)");
+        EXPECT_THROW_WITH_MESSAGE(base.pow(exponent), "Exponent too large in field_t::pow");
     };
 
     static void test_copy_as_new_witness()
@@ -1142,7 +1141,7 @@ template <typename Builder> class stdlib_field : public testing::Test {
         elt = bb::fr::random_element();
 
         if (elt.get_value() != 0) {
-            EXPECT_THROW_OR_ABORT(elt.assert_is_zero(), "field_t::assert_is_zero");
+            EXPECT_THROW_WITH_MESSAGE(elt.assert_is_zero(), "field_t::assert_is_zero");
         }
         // Create a witness 0
         Builder builder = Builder();
@@ -1489,14 +1488,14 @@ template <typename Builder> class stdlib_field : public testing::Test {
 
         // Case 6: Conflict between two different non-nullptrs
         {
-            EXPECT_THROW_OR_ABORT(validate_context(&builder1, &builder2),
-                                  "Pointers refer to different builder objects!");
+            EXPECT_THROW_WITH_MESSAGE(validate_context(&builder1, &builder2),
+                                      "Pointers refer to different builder objects!");
         }
 
         // Case 7: Conflict between first and last non-null
         {
-            EXPECT_THROW_OR_ABORT(validate_context(&builder1, null, null, &builder2),
-                                  "Pointers refer to different builder objects!");
+            EXPECT_THROW_WITH_MESSAGE(validate_context(&builder1, null, null, &builder2),
+                                      "Pointers refer to different builder objects!");
         }
 
         // Case 8: First null, two same non-null later
@@ -1555,7 +1554,8 @@ template <typename Builder> class stdlib_field : public testing::Test {
                 field_ct(&builder2, 2),
             };
 
-            EXPECT_THROW_OR_ABORT(validate_context<Builder>(fields), "Pointers refer to different builder objects!");
+            EXPECT_THROW_WITH_MESSAGE(validate_context<Builder>(fields),
+                                      "Pointers refer to different builder objects!");
         }
     }
 };

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/field/field_conversion.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/field/field_conversion.test.cpp
@@ -166,8 +166,8 @@ TYPED_TEST(stdlib_field_conversion, FieldConversionBN254AffineElement)
         curve::BN254::AffineElement group_element_val(1, 4);
         bn254_element<Builder> group_element;
         if constexpr (IsAnyOf<Builder, UltraCircuitBuilder>) {
-            EXPECT_THROW_OR_ABORT(group_element = bn254_element<Builder>::from_witness(&builder, group_element_val),
-                                  "");
+            EXPECT_THROW_WITH_MESSAGE(group_element = bn254_element<Builder>::from_witness(&builder, group_element_val),
+                                      "");
         } else {
             group_element = bn254_element<Builder>::from_witness(&builder, group_element_val);
             this->check_conversion(group_element);

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/pairing_points.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/pairing_points.test.cpp
@@ -150,21 +150,19 @@ TYPED_TEST(PairingPointsTests, TaggingMechanismFails)
     EXPECT_FALSE(builder.pairing_points_tagging.has_single_pairing_point_tag());
 
     // Create a ProverInstance, expect failure because pairing points have not been aggregated
-    EXPECT_THROW_OR_ABORT(
+    EXPECT_THROW_WITH_MESSAGE(
         ProverInstance prover_instance(builder),
-        ::testing::HasSubstr(
-            "Pairing points must all be aggregated together. Either no pairing points should be created, or all "
-            "created pairing points must be aggregated into a single pairing point. Found 2 different pairing "
-            "points."));
+        "Pairing points must all be aggregated together. Either no pairing points should be created, or "
+        "all created pairing points must be aggregated into a single pairing point. Found 2 different "
+        "pairing points");
 
     // Aggregate pairing points
     pp_one.aggregate(pp_three);
 
     // Create a ProverInstance, expect failure because pairing points have not been set to public
-    EXPECT_THROW_OR_ABORT(
+    EXPECT_THROW_WITH_MESSAGE(
         ProverInstance prover_instance(builder),
-        ::testing::HasSubstr(
-            "Pairing points must be set to public in the circuit before constructing the ProverInstance."));
+        "Pairing points must be set to public in the circuit before constructing the ProverInstance.");
 
     stdlib::recursion::honk::DefaultIO<Builder> inputs;
     inputs.pairing_inputs = pp_one;

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/prover_instance.hpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/prover_instance.hpp
@@ -102,15 +102,16 @@ template <IsUltraOrMegaHonk Flavor_> class ProverInstance_ {
 
         // Check pairing point tagging: either no pairing points were created,
         // or all pairing points have been aggregated into a single equivalence class
-        BB_ASSERT(circuit.pairing_points_tagging.has_single_pairing_point_tag(),
-                  "Pairing points must all be aggregated together. Either no pairing points should be created, or "
-                  "all created pairing points must be aggregated into a single pairing point. Found ",
-                  circuit.pairing_points_tagging.num_unique_pairing_points(),
-                  " different pairing points.");
+        BB_ASSERT_EQ(circuit.pairing_points_tagging.has_single_pairing_point_tag(),
+                     true,
+                     "Pairing points must all be aggregated together. Either no pairing points should be created, or "
+                     "all created pairing points must be aggregated into a single pairing point. Found "
+                         << circuit.pairing_points_tagging.num_unique_pairing_points() << " different pairing points.");
         // Check pairing point tagging: check that the pairing points have been set to public
-        BB_ASSERT(circuit.pairing_points_tagging.has_public_pairing_points() ||
-                      !circuit.pairing_points_tagging.has_pairing_points(),
-                  "Pairing points must be set to public in the circuit before constructing the ProverInstance.");
+        BB_ASSERT_EQ(circuit.pairing_points_tagging.has_public_pairing_points() ||
+                         !circuit.pairing_points_tagging.has_pairing_points(),
+                     true,
+                     "Pairing points must be set to public in the circuit before constructing the ProverInstance.");
 
         // Decider proving keys can be constructed multiple times, hence, we check whether the circuit has been
         // finalized

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/prover_instance.hpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/prover_instance.hpp
@@ -102,16 +102,14 @@ template <IsUltraOrMegaHonk Flavor_> class ProverInstance_ {
 
         // Check pairing point tagging: either no pairing points were created,
         // or all pairing points have been aggregated into a single equivalence class
-        BB_ASSERT_EQ(circuit.pairing_points_tagging.has_single_pairing_point_tag(),
-                     true,
-                     "Pairing points must all be aggregated together. Either no pairing points should be created, or "
-                     "all created pairing points must be aggregated into a single pairing point. Found "
-                         << circuit.pairing_points_tagging.num_unique_pairing_points() << " different pairing points.");
+        BB_ASSERT(circuit.pairing_points_tagging.has_single_pairing_point_tag(),
+                  "Pairing points must all be aggregated together. Either no pairing points should be created, or "
+                  "all created pairing points must be aggregated into a single pairing point. Found "
+                      << circuit.pairing_points_tagging.num_unique_pairing_points() << " different pairing points.");
         // Check pairing point tagging: check that the pairing points have been set to public
-        BB_ASSERT_EQ(circuit.pairing_points_tagging.has_public_pairing_points() ||
-                         !circuit.pairing_points_tagging.has_pairing_points(),
-                     true,
-                     "Pairing points must be set to public in the circuit before constructing the ProverInstance.");
+        BB_ASSERT(circuit.pairing_points_tagging.has_public_pairing_points() ||
+                      !circuit.pairing_points_tagging.has_pairing_points(),
+                  "Pairing points must be set to public in the circuit before constructing the ProverInstance.");
 
         // Decider proving keys can be constructed multiple times, hence, we check whether the circuit has been
         // finalized

--- a/barretenberg/cpp/src/barretenberg/vm2/testing/macros.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/testing/macros.hpp
@@ -4,13 +4,5 @@
 
 #include "barretenberg/vm2/tracegen/test_trace_container.hpp"
 
-#define EXPECT_THROW_WITH_MESSAGE(code, expectedMessage)                                                               \
-    try {                                                                                                              \
-        code;                                                                                                          \
-        FAIL() << "Expected exception with message: " << expectedMessage;                                              \
-    } catch (const std::exception& e) {                                                                                \
-        EXPECT_THAT(e.what(), ::testing::ContainsRegex(expectedMessage));                                              \
-    }
-
 #define ROW_FIELD_EQ(field_name, expression)                                                                           \
     ::testing::Field(#field_name, &TestTraceContainer::Row::field_name, expression)


### PR DESCRIPTION
### 🧾 Audit Context

This is the eleventh PR in the thread of auditing ACIR. It completes that audit of `acir_to_constraint_buf`.

### 🛠️ Changes Made

- Modified reconstruction of field element from bytes to add boundary checks
- Added check on the number of opcodes in an acir circuit
- Introduced macro for failure testing that checks the error message (we were not checking it before)
- Modified BB_ASSERT to forward the error msg
- Added tests public inputs in ACIR and for expressions resulting in zero gates

### ✅ Checklist

- [ ] Audited all methods of the relevant module/class
- [ ] Audited the interface of the module/class with other (relevant) components
- [ ] Documented existing functionality and any changes made (as per Doxygen requirements)
- [ ] Resolved and/or closed all issues/TODOs pertaining to the audited files
- [ ] Confirmed and documented any security or other issues found (if applicable)
- [ ] Verified that tests cover all critical paths (and added tests if necessary)
- [ ] Updated audit tracking for the files audited (check the start of each file you audited)

### 📌 Notes for Reviewers

(Optional) Call out anything that reviewers should pay close attention to — like logic changes, performance implications, or potential regressions.
