### PR TITLE
chore: noir-contracts content hash depends on bb cpp+ts so CI reruns on bb changes

### DIFF
--- a/noir-projects/noir-contracts/bootstrap.sh
+++ b/noir-projects/noir-contracts/bootstrap.sh
@@ -112,6 +112,8 @@ function get_contract_hash {
       $NOIR_HASH \
       $(cache_content_hash \
         ../avm-transpiler/.rebuild_patterns \
+        ../barretenberg/cpp/.rebuild_patterns \
+        ../barretenberg/ts/.rebuild_patterns \
         "^docs/examples/$contract_path/" \
         "^noir-projects/aztec-nr/" \
         "^noir-projects/noir-protocol-circuits/crates/types/")
@@ -121,6 +123,8 @@ function get_contract_hash {
       $NOIR_HASH \
       $(cache_content_hash \
         ../../avm-transpiler/.rebuild_patterns \
+        ../../barretenberg/cpp/.rebuild_patterns \
+        ../../barretenberg/ts/.rebuild_patterns \
         "^noir-projects/noir-contracts/contracts/$contract_path/" \
         "^noir-projects/aztec-nr/" \
         "^noir-projects/noir-protocol-circuits/crates/types/")


### PR DESCRIPTION
Without this, PRs with AVM changes weren't running noir-contracts tests, but the TXE runs the C++ simulator.