### PR TITLE
feat: Support txs sent via spire proposer

### DIFF
--- a/yarn-project/archiver/src/archiver/l1/README.md
+++ b/yarn-project/archiver/src/archiver/l1/README.md
@@ -39,7 +39,19 @@ Second attempt to decode the transaction as a direct `propose` call to the rollu
 - Return the transaction input as the propose calldata
 
 This handles scenarios where clients submit transactions directly to the rollup contract without
-using multicall3 for bundling. Any validation failure triggers fallback to the last step.
+using multicall3 for bundling. Any validation failure triggers fallback to the next step.
+
+### Spire Proposer Call
+
+Given existing attempts to route the call via the Spire proposer, we also check if the tx is `to` the 
+proposer known address, and if so, we try decoding it as either a multicall3 or a direct call to the
+rollup contract.
+
+Similar as with the multicall3 check, we check that there are no other calls in the Spire proposer, so
+we are absolutely sure that the only call is the successful one to the rollup.
+
+Furthermore, since the Spire proposer is upgradeable, we check if the implementation has not changed in
+order to decode. As usual, any validation failure triggers fallback to the next step.
 
 ### Verifying Multicall3 Arguments
 

--- a/yarn-project/archiver/src/archiver/l1/bin/index.ts
+++ b/yarn-project/archiver/src/archiver/l1/bin/index.ts
@@ -1,0 +1,185 @@
+#!/usr/bin/env node
+import type { ViemPublicClient, ViemPublicDebugClient } from '@aztec/ethereum';
+import { EthAddress } from '@aztec/foundation/eth-address';
+import { createLogger } from '@aztec/foundation/log';
+
+import { type Hex, createPublicClient, http } from 'viem';
+import { mainnet } from 'viem/chains';
+
+import { CalldataRetriever } from '../calldata_retriever.js';
+
+const logger = createLogger('archiver:calldata-test');
+
+interface ScriptArgs {
+  rollupAddress: EthAddress;
+  txHash: Hex;
+  rpcUrl: string;
+  targetCommitteeSize: number;
+}
+
+function parseArgs(): ScriptArgs {
+  const args = process.argv.slice(2);
+
+  if (args.length < 2) {
+    // eslint-disable-next-line no-console
+    console.error('Usage: node index.js <rollup-address> <tx-hash> [target-committee-size]');
+    // eslint-disable-next-line no-console
+    console.error('');
+    // eslint-disable-next-line no-console
+    console.error('Environment variables:');
+    // eslint-disable-next-line no-console
+    console.error('  ETHEREUM_HOST or RPC_URL - Ethereum RPC endpoint');
+    // eslint-disable-next-line no-console
+    console.error('');
+    // eslint-disable-next-line no-console
+    console.error('Example:');
+    // eslint-disable-next-line no-console
+    console.error('  RPC_URL=https://eth-mainnet.g.alchemy.com/v2/YOUR-API-KEY \\');
+    // eslint-disable-next-line no-console
+    console.error('  node index.js 0x1234... 0xabcd... 32');
+    process.exit(1);
+  }
+
+  const rollupAddress = EthAddress.fromString(args[0]);
+  const txHash = args[1] as Hex;
+  const targetCommitteeSize = args[2] ? parseInt(args[2], 10) : 24;
+
+  const rpcUrl = process.env.ETHEREUM_HOST || process.env.RPC_URL;
+  if (!rpcUrl) {
+    // eslint-disable-next-line no-console
+    console.error('Error: ETHEREUM_HOST or RPC_URL environment variable must be set');
+    process.exit(1);
+  }
+
+  if (targetCommitteeSize <= 0 || targetCommitteeSize > 256) {
+    // eslint-disable-next-line no-console
+    console.error('Error: target-committee-size must be between 1 and 256');
+    process.exit(1);
+  }
+
+  return { rollupAddress, txHash, rpcUrl, targetCommitteeSize };
+}
+
+async function main() {
+  const { rollupAddress, txHash, rpcUrl, targetCommitteeSize } = parseArgs();
+
+  logger.info('Calldata Retriever Test Script');
+  logger.info('===============================');
+  logger.info(`Rollup Address: ${rollupAddress.toString()}`);
+  logger.info(`Transaction Hash: ${txHash}`);
+  logger.info(`RPC URL: ${rpcUrl}`);
+  logger.info(`Target Committee Size: ${targetCommitteeSize}`);
+  logger.info('');
+
+  try {
+    // Create viem public client
+    const publicClient = createPublicClient({
+      chain: mainnet,
+      transport: http(rpcUrl),
+    });
+
+    logger.info('Fetching transaction...');
+    const tx = await publicClient.getTransaction({ hash: txHash });
+
+    if (!tx) {
+      throw new Error(`Transaction ${txHash} not found`);
+    }
+
+    logger.info(`Transaction found in block ${tx.blockNumber}`);
+
+    // For simplicity, use zero addresses for optional contract addresses
+    // In production, these would be fetched from the rollup contract or configuration
+    const slashingProposerAddress = EthAddress.ZERO;
+    const governanceProposerAddress = EthAddress.ZERO;
+    const slashFactoryAddress = undefined;
+
+    logger.info('Using zero addresses for governance/slashing (can be configured if needed)');
+
+    // Create CalldataRetriever
+    const retriever = new CalldataRetriever(
+      publicClient as unknown as ViemPublicClient,
+      publicClient as unknown as ViemPublicDebugClient,
+      targetCommitteeSize,
+      logger,
+      {
+        rollupAddress,
+        governanceProposerAddress,
+        slashingProposerAddress,
+        slashFactoryAddress,
+      },
+    );
+
+    // Extract L2 block number from transaction logs
+    logger.info('Decoding transaction to extract L2 block number...');
+    const receipt = await publicClient.getTransactionReceipt({ hash: txHash });
+    const l2BlockProposedEvent = receipt.logs.find(log => {
+      try {
+        // Try to match the L2BlockProposed event
+        return (
+          log.address.toLowerCase() === rollupAddress.toString().toLowerCase() &&
+          log.topics[0] === '0x2f1d0e696fa5186494a2f2f89a0e0bcbb15d607f6c5eac4637e07e1e5e7d3c00' // L2BlockProposed event signature
+        );
+      } catch {
+        return false;
+      }
+    });
+
+    let l2BlockNumber: number;
+    if (l2BlockProposedEvent && l2BlockProposedEvent.topics[1]) {
+      // L2 block number is typically the first indexed parameter
+      l2BlockNumber = Number(BigInt(l2BlockProposedEvent.topics[1]));
+      logger.info(`L2 Block Number (from event): ${l2BlockNumber}`);
+    } else {
+      // Fallback: try to extract from transaction data or use a default
+      logger.warn('Could not extract L2 block number from event, using block number as fallback');
+      l2BlockNumber = Number(tx.blockNumber);
+    }
+
+    logger.info('');
+    logger.info('Retrieving block header from rollup transaction...');
+    logger.info('');
+
+    const result = await retriever.getBlockHeaderFromRollupTx(txHash, l2BlockNumber);
+
+    logger.info(' Successfully retrieved block header!');
+    logger.info('');
+    logger.info('Block Header Details:');
+    logger.info('====================');
+    logger.info(`L2 Block Number: ${result.l2BlockNumber}`);
+    logger.info(`Block Hash: ${result.blockHash}`);
+    logger.info(`Archive Root: ${result.archiveRoot.toString()}`);
+    logger.info('');
+    logger.info('State Reference:');
+    logger.info(`  L1 to L2 Message Tree Root: ${result.stateReference.l1ToL2MessageTree.root.toString()}`);
+    logger.info(
+      `  L1 to L2 Message Tree Next Index: ${result.stateReference.l1ToL2MessageTree.nextAvailableLeafIndex}`,
+    );
+    logger.info('');
+    logger.info('Header:');
+    logger.info(`  Slot Number: ${result.header.slotNumber.toString()}`);
+    logger.info(`  Timestamp: ${result.header.timestamp.toString()}`);
+    logger.info(`  Coinbase: ${result.header.coinbase.toString()}`);
+    logger.info(`  Fee Recipient: ${result.header.feeRecipient.toString()}`);
+    logger.info(`  Total Mana Used: ${result.header.totalManaUsed.toString()}`);
+    logger.info('');
+    logger.info('Attestations:');
+    logger.info(`  Count: ${result.attestations.length}`);
+    logger.info(`  Non-empty attestations: ${result.attestations.filter(a => !a.signature.isEmpty()).length}`);
+
+    process.exit(0);
+  } catch (error) {
+    logger.error('Error retrieving block header:');
+    logger.error(error instanceof Error ? error.message : String(error));
+
+    if (error instanceof Error && error.stack) {
+      logger.debug(error.stack);
+    }
+
+    process.exit(1);
+  }
+}
+
+// Only run if this is the main module
+if (import.meta.url === `file://${process.argv[1]}`) {
+  void main();
+}

--- a/yarn-project/archiver/src/archiver/l1/calldata_retriever.test.ts
+++ b/yarn-project/archiver/src/archiver/l1/calldata_retriever.test.ts
@@ -23,6 +23,13 @@ import { type MockProxy, mock } from 'jest-mock-extended';
 import { type Hex, type Transaction, encodeFunctionData, multicall3Abi, toFunctionSelector } from 'viem';
 
 import { CalldataRetriever } from './calldata_retriever.js';
+import {
+  EIP1967_IMPLEMENTATION_SLOT,
+  SPIRE_PROPOSER_ADDRESS,
+  SPIRE_PROPOSER_EXPECTED_IMPLEMENTATION,
+  getCallFromSpireProposer,
+  verifyProxyImplementation,
+} from './spire_proposer.js';
 
 /**
  * Test class that exposes protected methods for testing
@@ -40,13 +47,8 @@ class TestCalldataRetriever extends CalldataRetriever {
     return await super.extractCalldataViaTrace(txHash);
   }
 
-  public override decodeAndBuildBlockHeader(
-    proposeCalldata: Hex,
-    blockHash: Hex,
-    blobHashes: Buffer[],
-    l2BlockNumber: number,
-  ) {
-    return super.decodeAndBuildBlockHeader(proposeCalldata, blockHash, blobHashes, l2BlockNumber);
+  public override decodeAndBuildBlockHeader(proposeCalldata: Hex, blockHash: Hex, l2BlockNumber: number) {
+    return super.decodeAndBuildBlockHeader(proposeCalldata, blockHash, l2BlockNumber);
   }
 }
 
@@ -144,7 +146,6 @@ describe('CalldataRetriever', () => {
   }
 
   describe('getBlockHeaderFromRollupTx', () => {
-    const blobHashes = [Buffer.from('blob1'), Buffer.from('blob2')];
     const l2BlockNumber = 42;
 
     it('should successfully decode valid multicall3 transaction', async () => {
@@ -153,7 +154,7 @@ describe('CalldataRetriever', () => {
 
       publicClient.getTransaction.mockResolvedValue(tx);
 
-      const result = await retriever.getBlockHeaderFromRollupTx(txHash, blobHashes, l2BlockNumber);
+      const result = await retriever.getBlockHeaderFromRollupTx(txHash, l2BlockNumber);
 
       expect(result.l2BlockNumber).toBe(l2BlockNumber);
       expect(result.header).toBeInstanceOf(ProposedBlockHeader);
@@ -176,7 +177,7 @@ describe('CalldataRetriever', () => {
 
       publicClient.getTransaction.mockResolvedValue(tx);
 
-      const result = await retriever.getBlockHeaderFromRollupTx(txHash, blobHashes, l2BlockNumber);
+      const result = await retriever.getBlockHeaderFromRollupTx(txHash, l2BlockNumber);
 
       expect(result.l2BlockNumber).toBe(l2BlockNumber);
       expect(result.header).toBeInstanceOf(ProposedBlockHeader);
@@ -217,7 +218,7 @@ describe('CalldataRetriever', () => {
         },
       ]);
 
-      const result = await retriever.getBlockHeaderFromRollupTx(txHash, blobHashes, l2BlockNumber);
+      const result = await retriever.getBlockHeaderFromRollupTx(txHash, l2BlockNumber);
 
       expect(result.l2BlockNumber).toBe(l2BlockNumber);
       expect(debugClient.request).toHaveBeenCalledWith({ method: 'trace_transaction', params: [txHash] });
@@ -240,7 +241,7 @@ describe('CalldataRetriever', () => {
       // Mock both trace methods to fail
       debugClient.request.mockRejectedValue(new Error(`Method not available`));
 
-      await expect(retriever.getBlockHeaderFromRollupTx(txHash, blobHashes, l2BlockNumber)).rejects.toThrow(
+      await expect(retriever.getBlockHeaderFromRollupTx(txHash, l2BlockNumber)).rejects.toThrow(
         'Failed to trace transaction',
       );
     });
@@ -248,7 +249,7 @@ describe('CalldataRetriever', () => {
     it('should throw when transaction retrieval fails', async () => {
       publicClient.getTransaction.mockRejectedValue(new Error('Transaction not found'));
 
-      await expect(retriever.getBlockHeaderFromRollupTx(txHash, blobHashes, l2BlockNumber)).rejects.toThrow(
+      await expect(retriever.getBlockHeaderFromRollupTx(txHash, l2BlockNumber)).rejects.toThrow(
         'Transaction not found',
       );
     });
@@ -495,6 +496,311 @@ describe('CalldataRetriever', () => {
     });
   });
 
+  describe('tryDecodeSpireProposer', () => {
+    function makeSpireProposerMulticallTransaction(call: { target: Hex; data: Hex }): Transaction {
+      const spireMulticallData = encodeFunctionData({
+        abi: [
+          {
+            inputs: [
+              {
+                components: [
+                  { internalType: 'address', name: 'proposer', type: 'address' },
+                  { internalType: 'address', name: 'target', type: 'address' },
+                  { internalType: 'bytes', name: 'data', type: 'bytes' },
+                  { internalType: 'uint256', name: 'value', type: 'uint256' },
+                  { internalType: 'uint256', name: 'gasLimit', type: 'uint256' },
+                ],
+                internalType: 'struct IProposerMulticall.Call[]',
+                name: '_calls',
+                type: 'tuple[]',
+              },
+            ],
+            name: 'multicall',
+            outputs: [],
+            stateMutability: 'nonpayable',
+            type: 'function',
+          },
+        ] as const,
+        functionName: 'multicall',
+        args: [
+          [
+            {
+              proposer: EthAddress.random().toString() as Hex,
+              target: call.target,
+              data: call.data,
+              value: 0n,
+              gasLimit: 1000000n,
+            },
+          ],
+        ],
+      });
+
+      return {
+        input: spireMulticallData,
+        blockHash,
+        to: SPIRE_PROPOSER_ADDRESS as Hex,
+        hash: txHash,
+      } as Transaction;
+    }
+
+    it('should decode Spire Proposer with direct propose call', async () => {
+      const proposeCalldata = await makeProposeCalldata();
+      const tx = makeSpireProposerMulticallTransaction({
+        target: rollupAddress.toString() as Hex,
+        data: proposeCalldata,
+      });
+
+      // Mock the proxy implementation verification
+      publicClient.getStorageAt.mockResolvedValue(
+        ('0x000000000000000000000000' + SPIRE_PROPOSER_EXPECTED_IMPLEMENTATION.slice(2)) as Hex,
+      );
+
+      const result = await getCallFromSpireProposer(tx, publicClient, logger);
+
+      expect(result).toBeDefined();
+      expect(result?.to.toLowerCase()).toBe(rollupAddress.toString().toLowerCase());
+      expect(result?.data).toBe(proposeCalldata);
+      expect(publicClient.getStorageAt).toHaveBeenCalledWith({
+        address: SPIRE_PROPOSER_ADDRESS,
+        slot: EIP1967_IMPLEMENTATION_SLOT,
+      });
+    });
+
+    it('should decode Spire Proposer with multicall3 containing propose', async () => {
+      const proposeCalldata = await makeProposeCalldata();
+      const multicall3Data = encodeFunctionData({
+        abi: multicall3Abi,
+        functionName: 'aggregate3',
+        args: [[{ target: rollupAddress.toString() as Hex, allowFailure: false, callData: proposeCalldata }]],
+      });
+
+      const tx = makeSpireProposerMulticallTransaction({
+        target: MULTI_CALL_3_ADDRESS as Hex,
+        data: multicall3Data,
+      });
+
+      // Mock the proxy implementation verification
+      publicClient.getStorageAt.mockResolvedValue(
+        ('0x000000000000000000000000' + SPIRE_PROPOSER_EXPECTED_IMPLEMENTATION.slice(2)) as Hex,
+      );
+
+      const result = await getCallFromSpireProposer(tx, publicClient, logger);
+
+      expect(result).toBeDefined();
+      expect(result?.to).toBe(MULTI_CALL_3_ADDRESS);
+      expect(result?.data).toBe(multicall3Data);
+    });
+
+    it('should return undefined when not to Spire Proposer address', async () => {
+      const proposeCalldata = await makeProposeCalldata();
+      const tx = {
+        input: proposeCalldata,
+        to: rollupAddress.toString() as Hex,
+        hash: txHash,
+      } as Transaction;
+
+      const result = await getCallFromSpireProposer(tx, publicClient, logger);
+
+      expect(result).toBeUndefined();
+      expect(publicClient.getStorageAt).not.toHaveBeenCalled();
+    });
+
+    it('should return undefined when proxy implementation verification fails', async () => {
+      const proposeCalldata = await makeProposeCalldata();
+      const tx = makeSpireProposerMulticallTransaction({
+        target: rollupAddress.toString() as Hex,
+        data: proposeCalldata,
+      });
+
+      // Mock the proxy pointing to wrong implementation
+      publicClient.getStorageAt.mockResolvedValue('0x000000000000000000000000wrongimplementation0000000000' as Hex);
+
+      const result = await getCallFromSpireProposer(tx, publicClient, logger);
+
+      expect(result).toBeUndefined();
+    });
+
+    it('should return undefined when Spire Proposer contains multiple calls', async () => {
+      const proposeCalldata = await makeProposeCalldata();
+      const spireMulticallData = encodeFunctionData({
+        abi: [
+          {
+            inputs: [
+              {
+                components: [
+                  { internalType: 'address', name: 'proposer', type: 'address' },
+                  { internalType: 'address', name: 'target', type: 'address' },
+                  { internalType: 'bytes', name: 'data', type: 'bytes' },
+                  { internalType: 'uint256', name: 'value', type: 'uint256' },
+                  { internalType: 'uint256', name: 'gasLimit', type: 'uint256' },
+                ],
+                internalType: 'struct IProposerMulticall.Call[]',
+                name: '_calls',
+                type: 'tuple[]',
+              },
+            ],
+            name: 'multicall',
+            outputs: [],
+            stateMutability: 'nonpayable',
+            type: 'function',
+          },
+        ] as const,
+        functionName: 'multicall',
+        args: [
+          [
+            {
+              proposer: EthAddress.random().toString() as Hex,
+              target: rollupAddress.toString() as Hex,
+              data: proposeCalldata,
+              value: 0n,
+              gasLimit: 1000000n,
+            },
+            {
+              proposer: EthAddress.random().toString() as Hex,
+              target: rollupAddress.toString() as Hex,
+              data: proposeCalldata,
+              value: 0n,
+              gasLimit: 1000000n,
+            },
+          ],
+        ],
+      });
+
+      const tx = {
+        input: spireMulticallData,
+        blockHash,
+        to: SPIRE_PROPOSER_ADDRESS as Hex,
+        hash: txHash,
+      } as Transaction;
+
+      // Mock the proxy implementation verification
+      publicClient.getStorageAt.mockResolvedValue(
+        ('0x000000000000000000000000' + SPIRE_PROPOSER_EXPECTED_IMPLEMENTATION.slice(2)) as Hex,
+      );
+
+      const result = await getCallFromSpireProposer(tx, publicClient, logger);
+
+      expect(result).toBeUndefined();
+    });
+
+    it('should extract call even if target is unknown (validation happens in next step)', async () => {
+      const unknownAddress = EthAddress.random();
+      const tx = makeSpireProposerMulticallTransaction({
+        target: unknownAddress.toString() as Hex,
+        data: '0x12345678' as Hex,
+      });
+
+      // Mock the proxy implementation verification
+      publicClient.getStorageAt.mockResolvedValue(
+        ('0x000000000000000000000000' + SPIRE_PROPOSER_EXPECTED_IMPLEMENTATION.slice(2)) as Hex,
+      );
+
+      const result = await getCallFromSpireProposer(tx, publicClient, logger);
+
+      // Spire proposer should successfully extract the call, even if target is unknown
+      // The validation of the target happens in the next step (tryDecodeMulticall3 or tryDecodeDirectPropose)
+      expect(result).toBeDefined();
+      expect(result?.to.toLowerCase()).toBe(unknownAddress.toString().toLowerCase());
+      expect(result?.data).toBe('0x12345678');
+    });
+
+    it('should extract multicall3 call (validation of inner calls happens in next step)', async () => {
+      const proposeCalldata = await makeProposeCalldata();
+      const invalidCalldata = '0x99999999' as Hex; // Unknown selector
+
+      const multicall3Data = encodeFunctionData({
+        abi: multicall3Abi,
+        functionName: 'aggregate3',
+        args: [
+          [
+            { target: rollupAddress.toString() as Hex, allowFailure: false, callData: proposeCalldata },
+            { target: rollupAddress.toString() as Hex, allowFailure: false, callData: invalidCalldata },
+          ],
+        ],
+      });
+
+      const tx = makeSpireProposerMulticallTransaction({
+        target: MULTI_CALL_3_ADDRESS as Hex,
+        data: multicall3Data,
+      });
+
+      // Mock the proxy implementation verification
+      publicClient.getStorageAt.mockResolvedValue(
+        ('0x000000000000000000000000' + SPIRE_PROPOSER_EXPECTED_IMPLEMENTATION.slice(2)) as Hex,
+      );
+
+      const result = await getCallFromSpireProposer(tx, publicClient, logger);
+
+      // Spire proposer should successfully extract the multicall3 call
+      // Validation of the inner calls happens in tryDecodeMulticall3
+      expect(result).toBeDefined();
+      expect(result?.to).toBe(MULTI_CALL_3_ADDRESS);
+      expect(result?.data).toBe(multicall3Data);
+    });
+  });
+
+  describe('verifyProxyImplementation', () => {
+    it('should return true when proxy points to expected implementation', async () => {
+      // Mock storage slot containing the implementation address (padded to 32 bytes)
+      publicClient.getStorageAt.mockResolvedValue(
+        ('0x000000000000000000000000' + SPIRE_PROPOSER_EXPECTED_IMPLEMENTATION.slice(2)) as Hex,
+      );
+
+      const result = await verifyProxyImplementation(
+        publicClient,
+        SPIRE_PROPOSER_ADDRESS as Hex,
+        SPIRE_PROPOSER_EXPECTED_IMPLEMENTATION as Hex,
+        logger,
+      );
+
+      expect(result).toBe(true);
+      expect(publicClient.getStorageAt).toHaveBeenCalledWith({
+        address: SPIRE_PROPOSER_ADDRESS,
+        slot: EIP1967_IMPLEMENTATION_SLOT,
+      });
+    });
+
+    it('should return false when proxy points to different implementation', async () => {
+      // Mock storage slot with wrong implementation
+      publicClient.getStorageAt.mockResolvedValue('0x000000000000000000000000wrongimplementation0000000000' as Hex);
+
+      const result = await verifyProxyImplementation(
+        publicClient,
+        SPIRE_PROPOSER_ADDRESS as Hex,
+        SPIRE_PROPOSER_EXPECTED_IMPLEMENTATION as Hex,
+        logger,
+      );
+
+      expect(result).toBe(false);
+    });
+
+    it('should return false when storage slot is empty', async () => {
+      publicClient.getStorageAt.mockResolvedValue(undefined);
+
+      const result = await verifyProxyImplementation(
+        publicClient,
+        SPIRE_PROPOSER_ADDRESS as Hex,
+        SPIRE_PROPOSER_EXPECTED_IMPLEMENTATION as Hex,
+        logger,
+      );
+
+      expect(result).toBe(false);
+    });
+
+    it('should return false when getStorageAt throws error', async () => {
+      publicClient.getStorageAt.mockRejectedValue(new Error('RPC error'));
+
+      const result = await verifyProxyImplementation(
+        publicClient,
+        SPIRE_PROPOSER_ADDRESS as Hex,
+        SPIRE_PROPOSER_EXPECTED_IMPLEMENTATION as Hex,
+        logger,
+      );
+
+      expect(result).toBe(false);
+    });
+  });
+
   describe('extractCalldataViaTrace', () => {
     it('should successfully extract calldata using trace_transaction', async () => {
       const proposeCalldata = await makeProposeCalldata();
@@ -640,13 +946,12 @@ describe('CalldataRetriever', () => {
 
   describe('decodeAndBuildBlockHeader', () => {
     const blockHash = Fr.random().toString() as Hex;
-    const blobHashes = [Buffer.from('blob1'), Buffer.from('blob2')];
     const l2BlockNumber = 42;
 
     it('should correctly decode propose calldata and build block header', async () => {
       const proposeCalldata = await makeProposeCalldata();
 
-      const result = retriever.decodeAndBuildBlockHeader(proposeCalldata, blockHash, blobHashes, l2BlockNumber);
+      const result = retriever.decodeAndBuildBlockHeader(proposeCalldata, blockHash, l2BlockNumber);
 
       expect(result.l2BlockNumber).toBe(l2BlockNumber);
       expect(result.header).toBeInstanceOf(ProposedBlockHeader);
@@ -660,7 +965,7 @@ describe('CalldataRetriever', () => {
       const attestations = makeViemCommitteeAttestations();
       const proposeCalldata = await makeProposeCalldata(undefined, undefined, attestations);
 
-      const result = retriever.decodeAndBuildBlockHeader(proposeCalldata, blockHash, blobHashes, l2BlockNumber);
+      const result = retriever.decodeAndBuildBlockHeader(proposeCalldata, blockHash, l2BlockNumber);
 
       expect(result.attestations).toHaveLength(TARGET_COMMITTEE_SIZE);
     });
@@ -671,22 +976,17 @@ describe('CalldataRetriever', () => {
       );
       const invalidCalldata = (invalidateBadSelector + '0'.repeat(120)) as Hex;
 
-      expect(() =>
-        retriever.decodeAndBuildBlockHeader(invalidCalldata, blockHash, blobHashes, l2BlockNumber),
-      ).toThrow();
+      expect(() => retriever.decodeAndBuildBlockHeader(invalidCalldata, blockHash, l2BlockNumber)).toThrow();
     });
 
     it('should throw when calldata is malformed', () => {
       const malformedCalldata = '0xinvalid' as Hex;
 
-      expect(() =>
-        retriever.decodeAndBuildBlockHeader(malformedCalldata, blockHash, blobHashes, l2BlockNumber),
-      ).toThrow();
+      expect(() => retriever.decodeAndBuildBlockHeader(malformedCalldata, blockHash, l2BlockNumber)).toThrow();
     });
   });
 
   describe('integration', () => {
-    const blobHashes = [Buffer.from('blob1'), Buffer.from('blob2')];
     const l2BlockNumber = 42;
 
     it('should complete full flow from tx hash to block header via multicall3', async () => {
@@ -695,7 +995,7 @@ describe('CalldataRetriever', () => {
 
       publicClient.getTransaction.mockResolvedValue(tx);
 
-      const result = await retriever.getBlockHeaderFromRollupTx(txHash, blobHashes, l2BlockNumber);
+      const result = await retriever.getBlockHeaderFromRollupTx(txHash, l2BlockNumber);
 
       expect(result).toBeDefined();
       expect(result.l2BlockNumber).toBe(l2BlockNumber);
@@ -710,6 +1010,82 @@ describe('CalldataRetriever', () => {
       expect(result.stateReference.partial).toBeInstanceOf(PartialStateReference);
       expect(result.header.contentCommitment).toBeInstanceOf(ContentCommitment);
       expect(result.header.gasFees).toBeInstanceOf(GasFees);
+    });
+
+    it('should complete full flow from tx hash to block header via Spire Proposer', async () => {
+      const SPIRE_PROPOSER_ADDRESS = '0x9ccc2f3ecde026230e11a5c8799ac7524f2bb294';
+      const SPIRE_PROPOSER_EXPECTED_IMPLEMENTATION = '0x7d38d47e7c82195e6e607d3b0f1c20c615c7bf42';
+
+      const proposeCalldata = await makeProposeCalldata();
+
+      // Create Spire Proposer multicall transaction
+      const spireMulticallData = encodeFunctionData({
+        abi: [
+          {
+            inputs: [
+              {
+                components: [
+                  { internalType: 'address', name: 'proposer', type: 'address' },
+                  { internalType: 'address', name: 'target', type: 'address' },
+                  { internalType: 'bytes', name: 'data', type: 'bytes' },
+                  { internalType: 'uint256', name: 'value', type: 'uint256' },
+                  { internalType: 'uint256', name: 'gasLimit', type: 'uint256' },
+                ],
+                internalType: 'struct IProposerMulticall.Call[]',
+                name: '_calls',
+                type: 'tuple[]',
+              },
+            ],
+            name: 'multicall',
+            outputs: [],
+            stateMutability: 'nonpayable',
+            type: 'function',
+          },
+        ] as const,
+        functionName: 'multicall',
+        args: [
+          [
+            {
+              proposer: EthAddress.random().toString() as Hex,
+              target: rollupAddress.toString() as Hex,
+              data: proposeCalldata,
+              value: 0n,
+              gasLimit: 1000000n,
+            },
+          ],
+        ],
+      });
+
+      const tx = {
+        input: spireMulticallData,
+        blockHash,
+        to: SPIRE_PROPOSER_ADDRESS as Hex,
+        hash: txHash,
+      } as Transaction;
+
+      publicClient.getTransaction.mockResolvedValue(tx);
+      publicClient.getStorageAt.mockResolvedValue(
+        ('0x000000000000000000000000' + SPIRE_PROPOSER_EXPECTED_IMPLEMENTATION.slice(2)) as Hex,
+      );
+
+      const result = await retriever.getBlockHeaderFromRollupTx(txHash, l2BlockNumber);
+
+      expect(result).toBeDefined();
+      expect(result.l2BlockNumber).toBe(l2BlockNumber);
+      expect(result.header).toBeInstanceOf(ProposedBlockHeader);
+      expect(result.stateReference).toBeInstanceOf(StateReference);
+      expect(result.archiveRoot).toBeInstanceOf(Fr);
+      expect(Array.isArray(result.attestations)).toBe(true);
+      expect(result.blockHash).toBe(blockHash);
+
+      // Verify all components are properly decoded
+      expect(result.stateReference.l1ToL2MessageTree).toBeInstanceOf(AppendOnlyTreeSnapshot);
+      expect(result.stateReference.partial).toBeInstanceOf(PartialStateReference);
+      expect(result.header.contentCommitment).toBeInstanceOf(ContentCommitment);
+      expect(result.header.gasFees).toBeInstanceOf(GasFees);
+
+      // Verify proxy implementation was checked
+      expect(publicClient.getStorageAt).toHaveBeenCalled();
     });
   });
 });

--- a/yarn-project/archiver/src/archiver/l1/calldata_retriever.ts
+++ b/yarn-project/archiver/src/archiver/l1/calldata_retriever.ts
@@ -32,6 +32,7 @@ import {
 
 import type { RetrievedL2Block } from './data_retrieval.js';
 import { getSuccessfulCallsFromDebug } from './debug_tx.js';
+import { getCallFromSpireProposer } from './spire_proposer.js';
 import { getSuccessfulCallsFromTrace } from './trace_tx.js';
 import type { CallInfo } from './types.js';
 
@@ -65,19 +66,17 @@ export class CalldataRetriever {
    * Gets block header and metadata from the calldata of an L1 transaction.
    * Tries multicall3 decoding, falls back to trace-based extraction.
    * @param txHash - Hash of the tx that published it.
-   * @param blobHashes - Blob hashes for the block
    * @param l2BlockNumber - L2 block number.
    * @returns L2 block header and metadata from the calldata, deserialized (without body)
    */
   async getBlockHeaderFromRollupTx(
     txHash: `0x${string}`,
-    blobHashes: Buffer[],
     l2BlockNumber: number,
   ): Promise<Omit<RetrievedL2Block, 'l1' | 'chainId' | 'version' | 'body'> & { blockHash: string }> {
     this.logger.trace(`Fetching L2 block ${l2BlockNumber} from rollup tx ${txHash}`);
     const tx = await this.publicClient.getTransaction({ hash: txHash });
     const proposeCalldata = await this.getProposeCallData(tx, l2BlockNumber);
-    return this.decodeAndBuildBlockHeader(proposeCalldata, tx.blockHash!, blobHashes, l2BlockNumber);
+    return this.decodeAndBuildBlockHeader(proposeCalldata, tx.blockHash!, l2BlockNumber);
   }
 
   /** Gets rollup propose calldata from a transaction */
@@ -98,20 +97,63 @@ export class CalldataRetriever {
       return directProposeCalldata;
     }
 
+    // Try to decode as Spire Proposer multicall wrapper
+    const spireProposeCalldata = await this.tryDecodeSpireProposer(tx);
+    if (spireProposeCalldata) {
+      this.logger.trace(`Decoded propose calldata from Spire Proposer for tx ${tx.hash}`);
+      return spireProposeCalldata;
+    }
+
     // Fall back to trace-based extraction
     this.logger.warn(
-      `Failed to decode multicall3 or direct propose for L1 tx ${tx.hash}, falling back to trace for L2 block ${l2BlockNumber}`,
+      `Failed to decode multicall3, direct propose, or Spire Proposer for L1 tx ${tx.hash}, falling back to trace for L2 block ${l2BlockNumber}`,
     );
     return await this.extractCalldataViaTrace(tx.hash);
   }
 
   /**
+   * Attempts to decode a transaction as a Spire Proposer multicall wrapper.
+   * If successful, extracts the wrapped call and validates it as either multicall3 or direct propose.
+   * @param tx - The transaction to decode
+   * @returns The propose calldata if successfully decoded and validated, undefined otherwise
+   */
+  protected async tryDecodeSpireProposer(tx: Transaction): Promise<Hex | undefined> {
+    // Try to decode as Spire Proposer multicall (extracts the wrapped call)
+    const spireWrappedCall = await getCallFromSpireProposer(tx, this.publicClient, this.logger);
+    if (!spireWrappedCall) {
+      return undefined;
+    }
+
+    this.logger.trace(`Decoded Spire Proposer wrapping for tx ${tx.hash}, inner call to ${spireWrappedCall.to}`);
+
+    // Now try to decode the wrapped call as either multicall3 or direct propose
+    const wrappedTx = { to: spireWrappedCall.to, input: spireWrappedCall.data, hash: tx.hash };
+
+    const multicall3Calldata = this.tryDecodeMulticall3(wrappedTx);
+    if (multicall3Calldata) {
+      this.logger.trace(`Decoded propose calldata from Spire Proposer to multicall3 for tx ${tx.hash}`);
+      return multicall3Calldata;
+    }
+
+    const directProposeCalldata = this.tryDecodeDirectPropose(wrappedTx);
+    if (directProposeCalldata) {
+      this.logger.trace(`Decoded propose calldata from Spire Proposer to direct propose for tx ${tx.hash}`);
+      return directProposeCalldata;
+    }
+
+    this.logger.warn(
+      `Spire Proposer wrapped call could not be decoded as multicall3 or direct propose for tx ${tx.hash}`,
+    );
+    return undefined;
+  }
+
+  /**
    * Attempts to decode transaction input as multicall3 and extract propose calldata.
    * Returns undefined if validation fails.
-   * @param tx - The transaction to decode
+   * @param tx - The transaction-like object with to, input, and hash
    * @returns The propose calldata if successfully validated, undefined otherwise
    */
-  protected tryDecodeMulticall3(tx: Transaction): Hex | undefined {
+  protected tryDecodeMulticall3(tx: { to: Hex | null | undefined; input: Hex; hash: Hex }): Hex | undefined {
     const txHash = tx.hash;
 
     try {
@@ -203,10 +245,10 @@ export class CalldataRetriever {
   /**
    * Attempts to decode transaction as a direct propose call to the rollup contract.
    * Returns undefined if validation fails.
-   * @param tx - The transaction to decode
+   * @param tx - The transaction-like object with to, input, and hash
    * @returns The propose calldata if successfully validated, undefined otherwise
    */
-  protected tryDecodeDirectPropose(tx: Transaction): Hex | undefined {
+  protected tryDecodeDirectPropose(tx: { to: Hex | null | undefined; input: Hex; hash: Hex }): Hex | undefined {
     const txHash = tx.hash;
     try {
       // Check if transaction is to the rollup address
@@ -295,7 +337,6 @@ export class CalldataRetriever {
   protected decodeAndBuildBlockHeader(
     proposeCalldata: Hex,
     blockHash: Hex,
-    blobHashes: Buffer[],
     l2BlockNumber: number,
   ): Omit<RetrievedL2Block, 'l1' | 'chainId' | 'version' | 'body'> & { blockHash: string } {
     const { functionName: rollupFunctionName, args: rollupArgs } = decodeFunctionData({
@@ -329,7 +370,6 @@ export class CalldataRetriever {
       stateReference: decodedArgs.stateReference,
       header: decodedArgs.header,
       l1BlockHash: blockHash,
-      blobHashes,
       attestations,
       packedAttestations,
       targetCommitteeSize: this.targetCommitteeSize,

--- a/yarn-project/archiver/src/archiver/l1/data_retrieval.ts
+++ b/yarn-project/archiver/src/archiver/l1/data_retrieval.ts
@@ -201,11 +201,8 @@ async function processL2BlockProposedLogs(
 
     // The value from the event and contract will match only if the block is in the chain.
     if (archive === archiveFromChain) {
-      const blockHeader = await calldataRetriever.getBlockHeaderFromRollupTx(
-        log.transactionHash!,
-        blobHashes,
-        l2BlockNumber,
-      );
+      const blockHeader = await calldataRetriever.getBlockHeaderFromRollupTx(log.transactionHash!, l2BlockNumber);
+
       const body = await getBlockBodyFromBlobs(
         blobSinkClient,
         blockHeader.blockHash,

--- a/yarn-project/archiver/src/archiver/l1/spire_proposer.test.ts
+++ b/yarn-project/archiver/src/archiver/l1/spire_proposer.test.ts
@@ -1,0 +1,377 @@
+import { EthAddress } from '@aztec/foundation/eth-address';
+import { type Logger, createLogger } from '@aztec/foundation/log';
+
+import { type MockProxy, mock } from 'jest-mock-extended';
+import { type Hex, type Transaction, encodeFunctionData } from 'viem';
+
+import {
+  EIP1967_IMPLEMENTATION_SLOT,
+  SPIRE_PROPOSER_ADDRESS,
+  SPIRE_PROPOSER_EXPECTED_IMPLEMENTATION,
+  SpireProposerAbi,
+  getCallFromSpireProposer,
+  verifyProxyImplementation,
+} from './spire_proposer.js';
+
+describe('Spire Proposer', () => {
+  let publicClient: MockProxy<{ getStorageAt: (params: { address: Hex; slot: Hex }) => Promise<Hex | undefined> }>;
+  let logger: Logger;
+
+  const txHash = '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef' as Hex;
+
+  beforeEach(() => {
+    publicClient = mock<{ getStorageAt: (params: { address: Hex; slot: Hex }) => Promise<Hex | undefined> }>();
+    logger = createLogger('archiver:test:spire_proposer');
+  });
+
+  describe('verifyProxyImplementation', () => {
+    it('should return true when proxy points to expected implementation', async () => {
+      // Mock storage slot containing the implementation address (padded to 32 bytes)
+      publicClient.getStorageAt.mockResolvedValue(
+        ('0x000000000000000000000000' + SPIRE_PROPOSER_EXPECTED_IMPLEMENTATION.slice(2)) as Hex,
+      );
+
+      const result = await verifyProxyImplementation(
+        publicClient,
+        SPIRE_PROPOSER_ADDRESS as Hex,
+        SPIRE_PROPOSER_EXPECTED_IMPLEMENTATION as Hex,
+        logger,
+      );
+
+      expect(result).toBe(true);
+      expect(publicClient.getStorageAt).toHaveBeenCalledWith({
+        address: SPIRE_PROPOSER_ADDRESS,
+        slot: EIP1967_IMPLEMENTATION_SLOT,
+      });
+    });
+
+    it('should return true when proxy points to expected implementation with different casing', async () => {
+      // Mock storage slot with uppercase address
+      const uppercaseImpl = SPIRE_PROPOSER_EXPECTED_IMPLEMENTATION.toUpperCase();
+      publicClient.getStorageAt.mockResolvedValue(('0x000000000000000000000000' + uppercaseImpl.slice(2)) as Hex);
+
+      const result = await verifyProxyImplementation(
+        publicClient,
+        SPIRE_PROPOSER_ADDRESS as Hex,
+        SPIRE_PROPOSER_EXPECTED_IMPLEMENTATION as Hex,
+        logger,
+      );
+
+      expect(result).toBe(true);
+    });
+
+    it('should return false when proxy points to different implementation', async () => {
+      // Mock storage slot with wrong implementation (must be valid address format)
+      const wrongImplementation = EthAddress.random().toString();
+      publicClient.getStorageAt.mockResolvedValue(('0x000000000000000000000000' + wrongImplementation.slice(2)) as Hex);
+
+      const result = await verifyProxyImplementation(
+        publicClient,
+        SPIRE_PROPOSER_ADDRESS as Hex,
+        SPIRE_PROPOSER_EXPECTED_IMPLEMENTATION as Hex,
+        logger,
+      );
+
+      expect(result).toBe(false);
+    });
+
+    it('should return false when storage slot is empty', async () => {
+      publicClient.getStorageAt.mockResolvedValue(undefined);
+
+      const result = await verifyProxyImplementation(
+        publicClient,
+        SPIRE_PROPOSER_ADDRESS as Hex,
+        SPIRE_PROPOSER_EXPECTED_IMPLEMENTATION as Hex,
+        logger,
+      );
+
+      expect(result).toBe(false);
+    });
+
+    it('should return false when getStorageAt throws error', async () => {
+      publicClient.getStorageAt.mockRejectedValue(new Error('RPC error'));
+
+      const result = await verifyProxyImplementation(
+        publicClient,
+        SPIRE_PROPOSER_ADDRESS as Hex,
+        SPIRE_PROPOSER_EXPECTED_IMPLEMENTATION as Hex,
+        logger,
+      );
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('getCallFromSpireProposer', () => {
+    function makeSpireProposerMulticallTransaction(call: { target: Hex; data: Hex }): Transaction {
+      const spireMulticallData = encodeFunctionData({
+        abi: SpireProposerAbi,
+        functionName: 'multicall',
+        args: [
+          [
+            {
+              proposer: EthAddress.random().toString() as Hex,
+              target: call.target,
+              data: call.data,
+              value: 0n,
+              gasLimit: 1000000n,
+            },
+          ],
+        ],
+      });
+
+      return {
+        input: spireMulticallData,
+        to: SPIRE_PROPOSER_ADDRESS as Hex,
+        hash: txHash,
+      } as Transaction;
+    }
+
+    describe('successful decoding', () => {
+      beforeEach(() => {
+        // Mock successful proxy verification
+        publicClient.getStorageAt.mockResolvedValue(
+          ('0x000000000000000000000000' + SPIRE_PROPOSER_EXPECTED_IMPLEMENTATION.slice(2)) as Hex,
+        );
+      });
+
+      it('should decode Spire Proposer with single call', async () => {
+        const targetAddress = EthAddress.random().toString() as Hex;
+        const calldata = '0x12345678' as Hex;
+        const tx = makeSpireProposerMulticallTransaction({
+          target: targetAddress,
+          data: calldata,
+        });
+
+        const result = await getCallFromSpireProposer(tx, publicClient, logger);
+
+        expect(result).toBeDefined();
+        expect(result?.to.toLowerCase()).toBe(targetAddress.toLowerCase());
+        expect(result?.data).toBe(calldata);
+        expect(publicClient.getStorageAt).toHaveBeenCalledWith({
+          address: SPIRE_PROPOSER_ADDRESS,
+          slot: EIP1967_IMPLEMENTATION_SLOT,
+        });
+      });
+
+      it('should extract call with any target address (validation happens later)', async () => {
+        const unknownAddress = EthAddress.random().toString() as Hex;
+        const tx = makeSpireProposerMulticallTransaction({
+          target: unknownAddress,
+          data: '0xabcdef' as Hex,
+        });
+
+        const result = await getCallFromSpireProposer(tx, publicClient, logger);
+
+        expect(result).toBeDefined();
+        expect(result?.to.toLowerCase()).toBe(unknownAddress.toLowerCase());
+        expect(result?.data).toBe('0xabcdef');
+      });
+
+      it('should preserve exact calldata bytes', async () => {
+        const complexCalldata =
+          '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef' as Hex;
+        const tx = makeSpireProposerMulticallTransaction({
+          target: EthAddress.random().toString() as Hex,
+          data: complexCalldata,
+        });
+
+        const result = await getCallFromSpireProposer(tx, publicClient, logger);
+
+        expect(result).toBeDefined();
+        expect(result?.data).toBe(complexCalldata);
+      });
+    });
+
+    describe('validation failures', () => {
+      it('should return undefined when not to Spire Proposer address', async () => {
+        const tx = {
+          input: '0x12345678' as Hex,
+          to: EthAddress.random().toString() as Hex,
+          hash: txHash,
+        } as Transaction;
+
+        const result = await getCallFromSpireProposer(tx, publicClient, logger);
+
+        expect(result).toBeUndefined();
+        expect(publicClient.getStorageAt).not.toHaveBeenCalled();
+      });
+
+      it('should return undefined when to is null', async () => {
+        const tx = {
+          input: '0x12345678' as Hex,
+          to: null,
+          hash: txHash,
+        } as Transaction;
+
+        const result = await getCallFromSpireProposer(tx, publicClient, logger);
+
+        expect(result).toBeUndefined();
+        expect(publicClient.getStorageAt).not.toHaveBeenCalled();
+      });
+
+      it('should return undefined when to is undefined', async () => {
+        const tx = {
+          input: '0x12345678' as Hex,
+          to: undefined,
+          hash: txHash,
+        } as unknown as Transaction;
+
+        const result = await getCallFromSpireProposer(tx, publicClient, logger);
+
+        expect(result).toBeUndefined();
+      });
+
+      it('should return undefined when proxy implementation verification fails', async () => {
+        const tx = makeSpireProposerMulticallTransaction({
+          target: EthAddress.random().toString() as Hex,
+          data: '0x12345678' as Hex,
+        });
+
+        // Mock the proxy pointing to wrong implementation
+        publicClient.getStorageAt.mockResolvedValue('0x00000000000000000000000000000000000000000000000000bad' as Hex);
+
+        const result = await getCallFromSpireProposer(tx, publicClient, logger);
+
+        expect(result).toBeUndefined();
+      });
+
+      it('should return undefined when function is not multicall', async () => {
+        // Create a transaction with a different function
+        const wrongFunctionData = '0x12345678' as Hex; // Not a valid multicall
+
+        const tx = {
+          input: wrongFunctionData,
+          to: SPIRE_PROPOSER_ADDRESS as Hex,
+          hash: txHash,
+        } as Transaction;
+
+        publicClient.getStorageAt.mockResolvedValue(
+          ('0x000000000000000000000000' + SPIRE_PROPOSER_EXPECTED_IMPLEMENTATION.slice(2)) as Hex,
+        );
+
+        const result = await getCallFromSpireProposer(tx, publicClient, logger);
+
+        expect(result).toBeUndefined();
+      });
+
+      it('should return undefined when Spire Proposer contains zero calls', async () => {
+        const spireMulticallData = encodeFunctionData({
+          abi: SpireProposerAbi,
+          functionName: 'multicall',
+          args: [[]],
+        });
+
+        const tx = {
+          input: spireMulticallData,
+          to: SPIRE_PROPOSER_ADDRESS as Hex,
+          hash: txHash,
+        } as Transaction;
+
+        publicClient.getStorageAt.mockResolvedValue(
+          ('0x000000000000000000000000' + SPIRE_PROPOSER_EXPECTED_IMPLEMENTATION.slice(2)) as Hex,
+        );
+
+        const result = await getCallFromSpireProposer(tx, publicClient, logger);
+
+        expect(result).toBeUndefined();
+      });
+
+      it('should return undefined when Spire Proposer contains multiple calls', async () => {
+        const spireMulticallData = encodeFunctionData({
+          abi: SpireProposerAbi,
+          functionName: 'multicall',
+          args: [
+            [
+              {
+                proposer: EthAddress.random().toString() as Hex,
+                target: EthAddress.random().toString() as Hex,
+                data: '0x12345678' as Hex,
+                value: 0n,
+                gasLimit: 1000000n,
+              },
+              {
+                proposer: EthAddress.random().toString() as Hex,
+                target: EthAddress.random().toString() as Hex,
+                data: '0xabcdef' as Hex,
+                value: 0n,
+                gasLimit: 1000000n,
+              },
+            ],
+          ],
+        });
+
+        const tx = {
+          input: spireMulticallData,
+          to: SPIRE_PROPOSER_ADDRESS as Hex,
+          hash: txHash,
+        } as Transaction;
+
+        publicClient.getStorageAt.mockResolvedValue(
+          ('0x000000000000000000000000' + SPIRE_PROPOSER_EXPECTED_IMPLEMENTATION.slice(2)) as Hex,
+        );
+
+        const result = await getCallFromSpireProposer(tx, publicClient, logger);
+
+        expect(result).toBeUndefined();
+      });
+
+      it('should return undefined when decoding throws exception', async () => {
+        const tx = {
+          input: '0xdeadbeef' as Hex, // Invalid calldata that will fail to decode
+          to: SPIRE_PROPOSER_ADDRESS as Hex,
+          hash: txHash,
+        } as Transaction;
+
+        publicClient.getStorageAt.mockResolvedValue(
+          ('0x000000000000000000000000' + SPIRE_PROPOSER_EXPECTED_IMPLEMENTATION.slice(2)) as Hex,
+        );
+
+        const result = await getCallFromSpireProposer(tx, publicClient, logger);
+
+        expect(result).toBeUndefined();
+      });
+    });
+
+    describe('call parameters', () => {
+      beforeEach(() => {
+        publicClient.getStorageAt.mockResolvedValue(
+          ('0x000000000000000000000000' + SPIRE_PROPOSER_EXPECTED_IMPLEMENTATION.slice(2)) as Hex,
+        );
+      });
+
+      it('should ignore proposer field in call', async () => {
+        const calldata = '0x12345678' as Hex;
+        const targetAddress = EthAddress.random().toString() as Hex;
+
+        const spireMulticallData = encodeFunctionData({
+          abi: SpireProposerAbi,
+          functionName: 'multicall',
+          args: [
+            [
+              {
+                proposer: EthAddress.random().toString() as Hex, // Different proposer
+                target: targetAddress,
+                data: calldata,
+                value: 0n,
+                gasLimit: 1000000n,
+              },
+            ],
+          ],
+        });
+
+        const tx = {
+          input: spireMulticallData,
+          to: SPIRE_PROPOSER_ADDRESS as Hex,
+          hash: txHash,
+        } as Transaction;
+
+        const result = await getCallFromSpireProposer(tx, publicClient, logger);
+
+        expect(result).toBeDefined();
+        expect(result?.to.toLowerCase()).toBe(targetAddress.toLowerCase());
+        expect(result?.data).toBe(calldata);
+      });
+    });
+  });
+});

--- a/yarn-project/archiver/src/archiver/l1/spire_proposer.ts
+++ b/yarn-project/archiver/src/archiver/l1/spire_proposer.ts
@@ -1,0 +1,159 @@
+import type { Logger } from '@aztec/foundation/log';
+
+import { type Hex, type Transaction, decodeFunctionData, getAddress, trim } from 'viem';
+
+// Spire Proposer Multicall constants
+export const SPIRE_PROPOSER_ADDRESS = '0x9ccc2f3ecde026230e11a5c8799ac7524f2bb294';
+export const SPIRE_PROPOSER_EXPECTED_IMPLEMENTATION = '0x7d38d47e7c82195e6e607d3b0f1c20c615c7bf42';
+
+// EIP-1967 storage slot for implementation address
+// keccak256("eip1967.proxy.implementation") - 1 = 0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc
+export const EIP1967_IMPLEMENTATION_SLOT =
+  '0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc' as const;
+
+// Spire Proposer Multicall ABI
+export const SpireProposerAbi = [
+  {
+    inputs: [
+      {
+        components: [
+          { internalType: 'address', name: 'proposer', type: 'address' },
+          { internalType: 'address', name: 'target', type: 'address' },
+          { internalType: 'bytes', name: 'data', type: 'bytes' },
+          { internalType: 'uint256', name: 'value', type: 'uint256' },
+          { internalType: 'uint256', name: 'gasLimit', type: 'uint256' },
+        ],
+        internalType: 'struct IProposerMulticall.Call[]',
+        name: '_calls',
+        type: 'tuple[]',
+      },
+    ],
+    name: 'multicall',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+] as const;
+
+/**
+ * Verifies that a proxy contract points to the expected implementation using EIP-1967.
+ * @param publicClient - The viem public client
+ * @param proxyAddress - The proxy contract address
+ * @param expectedImplementation - The expected implementation address
+ * @param logger - Logger instance
+ * @returns True if the proxy points to the expected implementation
+ */
+export async function verifyProxyImplementation(
+  publicClient: { getStorageAt: (params: { address: Hex; slot: Hex }) => Promise<Hex | undefined> },
+  proxyAddress: Hex,
+  expectedImplementation: Hex,
+  logger: Logger,
+): Promise<boolean> {
+  try {
+    // Read the EIP-1967 implementation slot
+    const implementationData = await publicClient.getStorageAt({
+      address: proxyAddress,
+      slot: EIP1967_IMPLEMENTATION_SLOT,
+    });
+
+    if (!implementationData) {
+      logger.warn(`No implementation found in EIP-1967 slot for proxy ${proxyAddress}`);
+      return false;
+    }
+
+    // The implementation address is stored in the last 20 bytes of the slot
+    // We need to extract and normalize it for comparison
+    const implementationAddress = getAddress(trim(implementationData));
+    const expectedAddress = getAddress(expectedImplementation);
+
+    const matches = implementationAddress.toLowerCase() === expectedAddress.toLowerCase();
+
+    if (!matches) {
+      logger.warn(`Proxy implementation mismatch: expected ${expectedAddress}, got ${implementationAddress}`, {
+        proxyAddress,
+        expectedImplementation,
+        actualImplementation: implementationAddress,
+      });
+    }
+
+    return matches;
+  } catch (err) {
+    logger.warn(`Failed to verify proxy implementation for ${proxyAddress}: ${err}`);
+    return false;
+  }
+}
+
+/**
+ * Attempts to decode transaction as a Spire Proposer Multicall.
+ * Spire Proposer is a proxy contract that wraps a single call.
+ * Returns the target address and calldata of the wrapped call if validation succeeds.
+ * @param tx - The transaction to decode
+ * @param publicClient - The viem public client for proxy verification
+ * @param logger - Logger instance
+ * @returns Object with 'to' and 'data' of the wrapped call, or undefined if validation fails
+ */
+export async function getCallFromSpireProposer(
+  tx: Transaction,
+  publicClient: { getStorageAt: (params: { address: Hex; slot: Hex }) => Promise<Hex | undefined> },
+  logger: Logger,
+): Promise<{ to: Hex; data: Hex } | undefined> {
+  const txHash = tx.hash;
+
+  try {
+    // Check if transaction is to the Spire Proposer address
+    if (!tx.to || tx.to.toLowerCase() !== SPIRE_PROPOSER_ADDRESS.toLowerCase()) {
+      logger.trace(`Transaction is not to Spire Proposer address (to: ${tx.to})`, { txHash });
+      return undefined;
+    }
+
+    // Verify the proxy points to the expected implementation
+    const isValidProxy = await verifyProxyImplementation(
+      publicClient,
+      tx.to as Hex,
+      SPIRE_PROPOSER_EXPECTED_IMPLEMENTATION as Hex,
+      logger,
+    );
+
+    if (!isValidProxy) {
+      logger.warn(`Spire Proposer proxy implementation verification failed`, { txHash, to: tx.to });
+      return undefined;
+    }
+
+    // Try to decode as Spire Proposer multicall
+    const { functionName: spireFunctionName, args: spireArgs } = decodeFunctionData({
+      abi: SpireProposerAbi,
+      data: tx.input,
+    });
+
+    // If not multicall, return undefined
+    if (spireFunctionName !== 'multicall') {
+      logger.warn(`Transaction to Spire Proposer is not multicall (got ${spireFunctionName})`, { txHash });
+      return undefined;
+    }
+
+    if (spireArgs.length !== 1) {
+      logger.warn(`Unexpected number of arguments for Spire Proposer multicall (got ${spireArgs.length})`, {
+        txHash,
+      });
+      return undefined;
+    }
+
+    const [calls] = spireArgs;
+
+    // Validate exactly ONE call
+    if (calls.length !== 1) {
+      logger.warn(`Spire Proposer multicall must contain exactly one call (got ${calls.length})`, { txHash });
+      return undefined;
+    }
+
+    const call = calls[0];
+
+    // Successfully extracted the single wrapped call
+    logger.trace(`Decoded Spire Proposer with single call to ${call.target}`, { txHash });
+    return { to: call.target, data: call.data };
+  } catch (err) {
+    // Any decoding error triggers fallback to trace
+    logger.warn(`Failed to decode Spire Proposer: ${err}`, { txHash });
+    return undefined;
+  }
+}


### PR DESCRIPTION
Given we have seen txs sent via the spire proposer, also support txs going through it for decoding calldata before falling back to debug or trace methods.

Also adds a script for manually retrieving calldata given a tx hash and rpc url, useful for testing real-world cases.

Builds on #18758