### PR TITLE
fix: bump UV_THREADPOOL_SIZE for "simple" e2e tests that run multiple nodes in one process

### DIFF
--- a/yarn-project/end-to-end/scripts/test_simple.sh
+++ b/yarn-project/end-to-end/scripts/test_simple.sh
@@ -20,6 +20,7 @@ export TOKIO_WORKER_THREADS=1
 export LOG_LEVEL=${LOG_LEVEL:-verbose}
 export NODE_NO_WARNINGS=1
 export FORCE_COLOR=1
+export UV_THREADPOOL_SIZE=${UV_THREADPOOL_SIZE:-8}
 
 test_file=$1
 test_name=${2:-}


### PR DESCRIPTION
Fixes timeouts (30s+) in TS callbacks from avm C++ sim that only materialized in "simple" e2e tests that run multiple node-like things in one TS process.

<img width="2880" height="558" alt="image" src="https://github.com/user-attachments/assets/81e38161-f087-44f0-a536-b423f25abfa9" />

Pasted from slack:
I still cannot be sure what the issue is, but I _think_ that we are running into a scenario (inconsistently) where we're running out of the default 4 libuv threads for Node. The addition of these new NAPI simulate calls (and especially the fact that TS contracts db callbacks can actually make their way _back_ into C++ to access the underlying LMDB store) likely led to this.

All of the following dispatch work to libuv threads:
1. World state accesses via NAPI
2. Direct LMDB store accesses via NAPI
3. AVM simulate via NAPI

And when AVM makes a callback to TS for contracts, it might fall back to the LMDB store and go _back_ down into C++ and dispatch work to another libuv thread.

The only way I can replicate this locally is to set `UV_THREADPOOL_SIZE=1`. That does replicate the exact issue, but does _not_ give me 100% confidence that this is the problem. Setting it to 4 or even 2, I cannot replicate locally. Only 1 fails in the same way.

I measured these TS callbacks when I run locally with uv threadpool size 2:

| Callback              | Max Time | Avg Time |
  |-----------------------|----------|----------|
  | getContractInstance   | 1.5ms    | 0.3ms    |
  | getContractClass      | 0.3ms    | 0.2ms    |
  | addContracts          | 12.1ms   | 6.3ms    |
  | getBytecodeCommitment | 6.4ms    | 6.4ms    |
  | getDebugFunctionName  | 0.2ms    | 0.1ms    |
  | createCheckpoint      | 0.0ms    | 0.0ms    |
  | commitCheckpoint      | 0.1ms    | 0.0ms    |


This makes me more confident that it's not just some crazy slowdown or bug in the TS callbacks, but is truly a resource issue

**My proposal for now: set `UV_THREADPOOL_SIZE` to 8 in end-to-end `test_simple.sh` and pray that we never see it again**