### PR TITLE
fix(fuzzing_build): fix coverage reports

### DIFF
--- a/container-builds/fuzzing-container/src/Dockerfile
+++ b/container-builds/fuzzing-container/src/Dockerfile
@@ -32,6 +32,9 @@ RUN git clone https://github.com/AztecProtocol/aztec-packages.git --depth 1 && \
         git checkout $COMMIT || exit 1;                                        \
     fi
 
+# Create a clean copy of the source tree for the runtime image
+RUN cp -r ./aztec-packages aztec-packages-src && rm -rf ./aztec-packages-src/.git
+
 # Download crs
 WORKDIR /home/fuzzer/aztec-packages/barretenberg
 RUN ./crs/bootstrap.sh
@@ -71,8 +74,6 @@ RUN apt-get update && \
         libelf1 \
         libdwarf1 \
         llvm-18 \
-        curl \
-        unzip \
         ca-certificates && \
     apt-get -y autoremove && \
     apt-get clean && \
@@ -81,12 +82,21 @@ RUN apt-get update && \
 RUN useradd -m fuzzer -G sudo
 WORKDIR /home/fuzzer
 
+# Reuse source tree from builder for coverage reports
+COPY --from=builder /home/fuzzer/aztec-packages-src /home/fuzzer/aztec-packages
+
+WORKDIR /home/fuzzer/aztec-packages/barretenberg/cpp
+
 # Copy binaries from build stage
 COPY --from=builder /home/fuzzer/aztec-packages/barretenberg/cpp/build-fuzzing/bin ./build-fuzzing/bin
 COPY --from=builder /home/fuzzer/aztec-packages/barretenberg/cpp/build-fuzzing-noasm/bin ./build-fuzzing-noasm/bin
 COPY --from=builder /home/fuzzer/aztec-packages/barretenberg/cpp/build-fuzzing-asan/bin ./build-fuzzing-asan/bin
-COPY --from=builder /home/fuzzer/aztec-packages/barretenberg/cpp/build-fuzzing-cov/bin ./build-fuzzing-cov/bin
 COPY --from=builder /home/fuzzer/aztec-packages/barretenberg/cpp/build-fuzzing-avm/bin ./build-fuzzing-avm/bin
+
+# Copy full cov-build to keep LLVM links and external dependencies for coverage report
+COPY --from=builder /home/fuzzer/aztec-packages/barretenberg/cpp/build-fuzzing-cov/ ./build-fuzzing-cov/
+
+# Copy CRS
 COPY --from=builder /root/.bb-crs /root/.bb-crs
 
 # Copy entrypoint script


### PR DESCRIPTION
https://github.com/AztecProtocol/aztec-packages/pull/18712 introduced build stage for fuzzing, but I forgot about coverage reports, which depends on sources and external dependencies

Right now it works and the coverage report looks like this: 
I just copied coverage/ dir after `./run.sh -f eccvm_eccvm_fuzzer -m coverage`
<img width="1792" height="640" alt="image" src="https://github.com/user-attachments/assets/0f8c2577-2e13-48c4-bc04-adc8f85009c4" />

Tested for eccvm fuzzer only, but i hope there are no differences with other fuzzers