### PR TITLE
fix: Wipe 3s off startup time with lazy kzg init.

### DIFF
--- a/yarn-project/blob-lib/src/blob.test.ts
+++ b/yarn-project/blob-lib/src/blob.test.ts
@@ -6,12 +6,13 @@ import { updateInlineTestData } from '@aztec/foundation/testing/files';
 
 import { Blob } from './blob.js';
 import { commitmentToFields } from './hash.js';
-import { BYTES_PER_BLOB, kzg } from './kzg_context.js';
+import { BYTES_PER_BLOB, getKzg } from './kzg_context.js';
 import { makeRandomBlob } from './testing.js';
 
 describe('blob', () => {
   it('kzg lib should verify a batch of blobs', () => {
     // This test is taken from the blob-lib repo
+    const kzg = getKzg();
     const BATCH_SIZE = 3;
     const blobs: Uint8Array[] = [];
     const commitments: Uint8Array[] = [];
@@ -31,6 +32,7 @@ describe('blob', () => {
 
   it('should verify a kzg precise proof', () => {
     // This test is taken from the blob-lib repo
+    const kzg = getKzg();
     const zBytes = Buffer.alloc(32);
 
     // blobs[0][31] = x, and z = 0x01 results in y = x.

--- a/yarn-project/blob-lib/src/blob.ts
+++ b/yarn-project/blob-lib/src/blob.ts
@@ -4,7 +4,7 @@ import { BufferReader, serializeToBuffer } from '@aztec/foundation/serialize';
 
 import { computeBlobCommitment, computeChallengeZ, computeEthVersionedBlobHash } from './hash.js';
 import type { BlobJson } from './interface.js';
-import { BYTES_PER_BLOB, BYTES_PER_COMMITMENT, kzg } from './kzg_context.js';
+import { BYTES_PER_BLOB, BYTES_PER_COMMITMENT, getKzg } from './kzg_context.js';
 
 export { FIELDS_PER_BLOB };
 
@@ -136,6 +136,7 @@ export class Blob {
    *  proof: Buffer - KZG opening proof for y = p(z). The commitment to quotient polynomial Q, used in compressed BLS12 point format (48 bytes).
    */
   evaluate(challengeZ: Fr, verifyProof = false) {
+    const kzg = getKzg();
     const res = kzg.computeKzgProof(this.data, challengeZ.toBuffer());
     if (verifyProof && !kzg.verifyKzgProof(this.commitment, challengeZ.toBuffer(), res[1], res[0])) {
       throw new Error(`KZG proof did not verify.`);
@@ -178,6 +179,7 @@ export class Blob {
   }
 
   static getViemKzgInstance() {
+    const kzg = getKzg();
     return {
       blobToKzgCommitment: kzg.blobToKzgCommitment.bind(kzg),
       computeBlobKzgProof: kzg.computeBlobKzgProof.bind(kzg),

--- a/yarn-project/blob-lib/src/blob_batching.ts
+++ b/yarn-project/blob-lib/src/blob_batching.ts
@@ -7,7 +7,7 @@ import { Blob } from './blob.js';
 import { getBlobsPerL1Block } from './blob_utils.js';
 import { BlobAccumulator, FinalBlobAccumulator, FinalBlobBatchingChallenges } from './circuit_types/index.js';
 import { computeBlobFieldsHash, hashNoirBigNumLimbs } from './hash.js';
-import { kzg } from './kzg_context.js';
+import { getKzg } from './kzg_context.js';
 
 /**
  * A class to create, manage, and prove batched EVM blobs.
@@ -248,7 +248,12 @@ export class BatchedBlobAccumulator {
   }
 
   verify() {
-    return kzg.verifyKzgProof(this.cAcc.compress(), this.zAcc.toBuffer(), this.yAcc.toBuffer(), this.qAcc.compress());
+    return getKzg().verifyKzgProof(
+      this.cAcc.compress(),
+      this.zAcc.toBuffer(),
+      this.yAcc.toBuffer(),
+      this.qAcc.compress(),
+    );
   }
 
   isEmptyState() {

--- a/yarn-project/blob-lib/src/hash.ts
+++ b/yarn-project/blob-lib/src/hash.ts
@@ -1,7 +1,7 @@
 import { poseidon2Hash, sha256, sha256ToField } from '@aztec/foundation/crypto';
 import { BLS12Fr, Fr } from '@aztec/foundation/fields';
 
-import { BYTES_PER_BLOB, BYTES_PER_COMMITMENT, kzg } from './kzg_context.js';
+import { BYTES_PER_BLOB, BYTES_PER_COMMITMENT, getKzg } from './kzg_context.js';
 import { SpongeBlob } from './sponge_blob.js';
 
 const VERSIONED_HASH_VERSION_KZG = 0x01;
@@ -47,7 +47,7 @@ export function computeBlobCommitment(data: Uint8Array): Buffer {
     throw new Error(`Expected ${BYTES_PER_BLOB} bytes per blob. Got ${data.length}.`);
   }
 
-  return Buffer.from(kzg.blobToKzgCommitment(data));
+  return Buffer.from(getKzg().blobToKzgCommitment(data));
 }
 
 /**

--- a/yarn-project/blob-lib/src/index.ts
+++ b/yarn-project/blob-lib/src/index.ts
@@ -7,3 +7,4 @@ export * from './encoding/index.js';
 export * from './hash.js';
 export * from './interface.js';
 export * from './sponge_blob.js';
+export * from './kzg_context.js';

--- a/yarn-project/blob-lib/src/kzg_context.ts
+++ b/yarn-project/blob-lib/src/kzg_context.ts
@@ -2,4 +2,15 @@ import { DasContextJs } from '@crate-crypto/node-eth-kzg';
 
 export * from '@crate-crypto/node-eth-kzg';
 
-export const kzg = DasContextJs.create({ usePrecomp: true });
+let kzgInstance: DasContextJs | undefined;
+
+/**
+ * Returns the lazily-initialized KZG context.
+ * The first call takes ~3 seconds to initialize the precomputation tables.
+ */
+export function getKzg(): DasContextJs {
+  if (!kzgInstance) {
+    kzgInstance = DasContextJs.create({ usePrecomp: true });
+  }
+  return kzgInstance;
+}

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.ts
@@ -1,4 +1,5 @@
 import { L2Block } from '@aztec/aztec.js/block';
+import { getKzg } from '@aztec/blob-lib';
 import { BLOBS_PER_CHECKPOINT, FIELDS_PER_BLOB, INITIAL_L2_BLOCK_NUM } from '@aztec/constants';
 import type { EpochCache } from '@aztec/epoch-cache';
 import { FormattedViemError, NoCommitteeError, type RollupContract } from '@aztec/ethereum';
@@ -220,6 +221,8 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
   }
 
   public async init() {
+    // Takes ~3s to precompute some tables.
+    getKzg();
     this.publisher = (await this.publisherFactory.create(undefined)).publisher;
   }
 


### PR DESCRIPTION
Don't compute the kzg table stuff at global level to improve start times.